### PR TITLE
[LLDB][SBProgress] Fix bad optional in sbprogress

### DIFF
--- a/lldb/source/API/SBProgress.cpp
+++ b/lldb/source/API/SBProgress.cpp
@@ -43,7 +43,7 @@ void SBProgress::Increment(uint64_t amount, const char *description) {
   std::optional<std::string> description_opt;
   if (description && description[0])
     description_opt = description;
-  m_opaque_up->Increment(amount, description_opt);
+  m_opaque_up->Increment(amount, std::move(description_opt));
 }
 
 lldb_private::Progress &SBProgress::ref() const { return *m_opaque_up; }

--- a/lldb/source/API/SBProgress.cpp
+++ b/lldb/source/API/SBProgress.cpp
@@ -40,7 +40,10 @@ SBProgress::~SBProgress() = default;
 void SBProgress::Increment(uint64_t amount, const char *description) {
   LLDB_INSTRUMENT_VA(amount, description);
 
-  m_opaque_up->Increment(amount, description);
+  std::optional<std::string> description_opt;
+  if (description && description[0])
+    description_opt = description;
+  m_opaque_up->Increment(amount, description_opt);
 }
 
 lldb_private::Progress &SBProgress::ref() const { return *m_opaque_up; }

--- a/lldb/test/API/python_api/sbprogress/TestSBProgress.py
+++ b/lldb/test/API/python_api/sbprogress/TestSBProgress.py
@@ -42,11 +42,24 @@ class SBProgressTestCase(TestBase):
         broadcaster = self.dbg.GetBroadcaster()
         broadcaster.AddListener(listener, lldb.eBroadcastBitExternalProgress)
         event = lldb.SBEvent()
-
+        # Sample JSON we're expecting:
+        # { id = 2, title = "Test SBProgress", details = "Test progress", type = update, progress = 1 of 3}
+        # details remains the same as specified in the constructor of the progress
+        # until we update it in the increment function, so we check for the Null and empty string case
+        # that details hasn't changed, but progress x of 3 has.
         progress.Increment(1, None)
         self.assertTrue(listener.GetNextEvent(event))
+        stream = lldb.SBStream()
+        event.GetDescription(stream)
+        self.assertIn("Test progress", stream.GetData())
+        self.assertIn("1 of 3", stream.GetData())
+
         progress.Increment(1, "")
         self.assertTrue(listener.GetNextEvent(event))
+        event.GetDescription(stream)
+        self.assertIn("Test progress", stream.GetData())
+        self.assertIn("2 of 3", stream.GetData())
+
         progress.Increment(1, "Step 3")
         self.assertTrue(listener.GetNextEvent(event))
         stream = lldb.SBStream()

--- a/lldb/test/API/python_api/sbprogress/TestSBProgress.py
+++ b/lldb/test/API/python_api/sbprogress/TestSBProgress.py
@@ -37,11 +37,18 @@ class SBProgressTestCase(TestBase):
     def test_with_external_bit_set(self):
         """Test SBProgress can handle null events."""
 
-        progress = lldb.SBProgress("Test SBProgress", "Test progress", self.dbg)
+        progress = lldb.SBProgress("Test SBProgress", "Test progress", 3, self.dbg)
         listener = lldb.SBListener("Test listener")
         broadcaster = self.dbg.GetBroadcaster()
         broadcaster.AddListener(listener, lldb.eBroadcastBitExternalProgress)
         event = lldb.SBEvent()
 
         progress.Increment(1, None)
-        self.assertTrue(listener.PeekAtNextEvent(event))
+        self.assertTrue(listener.GetNextEvent(event))
+        progress.Increment(1, "")
+        self.assertTrue(listener.GetNextEvent(event))
+        progress.Increment(1, "Step 3")
+        self.assertTrue(listener.GetNextEvent(event))
+        stream = lldb.SBStream()
+        event.GetDescription(stream)
+        self.assertIn("Step 3", stream.GetData())

--- a/lldb/test/API/python_api/sbprogress/TestSBProgress.py
+++ b/lldb/test/API/python_api/sbprogress/TestSBProgress.py
@@ -33,3 +33,15 @@ class SBProgressTestCase(TestBase):
         expected_string = "Test progress first increment"
         progress.Increment(1, expected_string)
         self.assertFalse(listener.PeekAtNextEvent(event))
+
+    def test_with_external_bit_set(self):
+        """Test SBProgress can handle null events."""
+
+        progress = lldb.SBProgress("Test SBProgress", "Test progress", self.dbg)
+        listener = lldb.SBListener("Test listener")
+        broadcaster = self.dbg.GetBroadcaster()
+        broadcaster.AddListener(listener, lldb.eBroadcastBitExternalProgress)
+        event = lldb.SBEvent()
+
+        progress.Increment(1, None)
+        self.assertTrue(listener.PeekAtNextEvent(event))


### PR DESCRIPTION
This fixes the obvious, but untested case of sending None/Null to SBProgress. This was an oversight on my part.