### PR TITLE
[flang] Catch usage of : and * lengths in array c'tors

### DIFF
--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -78,8 +78,10 @@ static std::optional<DynamicTypeWithLength> AnalyzeTypeSpec(
             const semantics::CharacterTypeSpec &cts{
                 typeSpec->characterTypeSpec()};
             const semantics::ParamValue &len{cts.length()};
-            // N.B. CHARACTER(LEN=*) is allowed in type-specs in ALLOCATE() &
-            // type guards, but not in array constructors.
+            if (len.isAssumed() || len.isDeferred()) {
+              context.messages().Say(
+                  "A length specifier of '*' or ':' may not appear in the type of an array constructor"_err_en_US);
+            }
             DynamicTypeWithLength type{DynamicType{kind, len}};
             if (auto lenExpr{type.LEN()}) {
               type.length = Fold(context,

--- a/flang/test/Semantics/array-constr-len.f90
+++ b/flang/test/Semantics/array-constr-len.f90
@@ -11,4 +11,8 @@ subroutine subr(s,n)
   print *, [(s(1:1),j=1,0)] ! ok
   print *, [character(2)::(s(1:n),j=1,0)] ! ok
   print *, [character(n)::(s(1:n),j=1,0)]
+  !ERROR: A length specifier of '*' or ':' may not appear in the type of an array constructor
+  print *, [ character(:) :: ]
+  !ERROR: A length specifier of '*' or ':' may not appear in the type of an array constructor
+  print *, [ character(*) :: ]
 end


### PR DESCRIPTION
The definition of an array constructor doesn't preclude the use of [character(:)::] or [character(*)::] directly, but there is language elsewhere in the standard that restricts their use to specific contexts, neither of which include explicitly typed array constructors.

Fixes https://github.com/llvm/llvm-project/issues/128755.