### PR TITLE
[WASM] wasm-ld: split up __wasm_apply_data_relocs

### DIFF
--- a/lld/wasm/InputChunks.cpp
+++ b/lld/wasm/InputChunks.cpp
@@ -361,12 +361,11 @@ uint64_t InputChunk::getVA(uint64_t offset) const {
 // Generate code to apply relocations to the data section at runtime.
 // This is only called when generating shared libraries (PIC) where address are
 // not known at static link time.
-bool InputChunk::generateRelocationCode(raw_ostream &os) const {
+void InputChunk::generateRelocationCode(std::vector<std::string> &funcs) const {
   LLVM_DEBUG(dbgs() << "generating runtime relocations: " << name
                     << " count=" << relocations.size() << "\n");
 
   bool is64 = ctx.arg.is64.value_or(false);
-  bool generated = false;
   unsigned opcode_ptr_const = is64 ? WASM_OPCODE_I64_CONST
                                    : WASM_OPCODE_I32_CONST;
   unsigned opcode_ptr_add = is64 ? WASM_OPCODE_I64_ADD
@@ -384,6 +383,14 @@ bool InputChunk::generateRelocationCode(raw_ostream &os) const {
     bool requiresRuntimeReloc = ctx.isPic || sym->hasGOTIndex();
     if (!requiresRuntimeReloc)
       continue;
+
+    if (funcs.empty() || funcs.back().size() >= 7654300) {
+      funcs.emplace_back(std::string());
+      raw_string_ostream os(funcs.back());
+      writeUleb128(os, 0, "num locals");
+    }
+
+    raw_string_ostream os(funcs.back());
 
     LLVM_DEBUG(dbgs() << "gen reloc: type=" << relocTypeToString(rel.Type)
                       << " addend=" << rel.Addend << " index=" << rel.Index
@@ -439,9 +446,7 @@ bool InputChunk::generateRelocationCode(raw_ostream &os) const {
     writeU8(os, opcode_reloc_store, "I32_STORE");
     writeUleb128(os, 2, "align");
     writeUleb128(os, 0, "offset");
-    generated = true;
   }
-  return generated;
 }
 
 // Split WASM_SEG_FLAG_STRINGS section. Such a section is a sequence of

--- a/lld/wasm/InputChunks.cpp
+++ b/lld/wasm/InputChunks.cpp
@@ -384,7 +384,9 @@ void InputChunk::generateRelocationCode(std::vector<std::string> &funcs) const {
     if (!requiresRuntimeReloc)
       continue;
 
-    if (funcs.empty() || funcs.back().size() >= 7654300) {
+    // https://www.w3.org/TR/wasm-js-api-2/#limits
+    // The maximum size of a function body, including locals declarations, is 7,654,321 bytes.
+    if (funcs.empty() || funcs.back().size() >= 7654321) {
       funcs.emplace_back(std::string());
       raw_string_ostream os(funcs.back());
       writeUleb128(os, 0, "num locals");

--- a/lld/wasm/InputChunks.h
+++ b/lld/wasm/InputChunks.h
@@ -78,7 +78,7 @@ public:
 
   size_t getNumRelocations() const { return relocations.size(); }
   void writeRelocations(llvm::raw_ostream &os) const;
-  bool generateRelocationCode(raw_ostream &os) const;
+  void generateRelocationCode(std::vector<std::string> &funcs) const;
 
   bool isTLS() const { return flags & llvm::wasm::WASM_SEG_FLAG_TLS; }
   bool isRetained() const { return flags & llvm::wasm::WASM_SEG_FLAG_RETAIN; }

--- a/lld/wasm/SyntheticSections.cpp
+++ b/lld/wasm/SyntheticSections.cpp
@@ -299,6 +299,8 @@ void FunctionSection::writeBody() {
 void FunctionSection::addFunction(InputFunction *func) {
   if (!func->live)
     return;
+  if (func->hasFunctionIndex())
+    return;
   uint32_t functionIndex =
       out.importSec->getNumImportedFunctions() + inputFunctions.size();
   inputFunctions.emplace_back(func);


### PR DESCRIPTION
Addresses the issue of function body size explosion during linking with `wasm-ld`. The specific function in question is `__wasm_apply_data_relocs` which is used to apply relocations to the data section at runtime. Since GHC relies on unknown calls between modules the generated `__wasm_apply_data_relocs` quickly becomes unwieldy. This patch is [currently in use with the WASM backend for GHC](https://gitlab.haskell.org/haskell-wasm/llvm-project/-/commit/b744693b394b2f148d342815e68d2150f814c1c5)

This patch works by taking a chunking strategy and splitting up `__wasm_apply_data_relocs` into smaller functions that do not exceed the body size limit threshold.

As mentioned previously by @sbc100 @k1nder10

- https://github.com/emscripten-core/emscripten/discussions/17374
- https://github.com/llvm/llvm-project/issues/55608#issuecomment-2362818658
- https://github.com/llvm/llvm-project/issues/108599
- https://www.mail-archive.com/llvm-bugs@lists.llvm.org/msg81161.html
- https://gitlab.haskell.org/haskell-wasm/llvm-project/-/commit/b744693b394b2f148d342815e68d2150f814c1c5