### PR TITLE
[flang] Fixes in preprocessing conditional compilation code when preceded by macros

### DIFF
--- a/flang/include/flang/Parser/parsing.h
+++ b/flang/include/flang/Parser/parsing.h
@@ -19,6 +19,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include <optional>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -66,6 +67,7 @@ public:
   void DumpProvenance(llvm::raw_ostream &) const;
   void DumpParsingLog(llvm::raw_ostream &) const;
   void Parse(llvm::raw_ostream &debugOutput);
+  const char *IsCompilerDirectiveSentinel(const char *, std::size_t) const;
   void ClearLog();
 
   void EmitMessage(llvm::raw_ostream &o, const char *at,
@@ -87,6 +89,7 @@ private:
   std::optional<Program> parseTree_;
   ParsingLog log_;
   Preprocessor preprocessor_{allCooked_.allSources()};
+  std::unordered_set<std::string> compilerDirectiveSentinels_;
 };
 } // namespace Fortran::parser
 #endif // FORTRAN_PARSER_PARSING_H_

--- a/flang/lib/Parser/prescan.cpp
+++ b/flang/lib/Parser/prescan.cpp
@@ -511,7 +511,7 @@ bool Prescanner::MustSkipToEndOfLine() const {
   if (inFixedForm_ && column_ > fixedFormColumnLimit_ && !tabInCurrentLine_) {
     return true; // skip over ignored columns in right margin (73:80)
   } else if (*at_ == '!' && !inCharLiteral_) {
-    return !IsCompilerDirectiveSentinel(at_);
+    return !IsCompilerDirectiveSentinel(at_ + 1);
   } else {
     return false;
   }

--- a/flang/lib/Parser/prescan.h
+++ b/flang/lib/Parser/prescan.h
@@ -90,6 +90,9 @@ public:
   template <typename... A> Message &Say(A &&...a) {
     return messages_.Say(std::forward<A>(a)...);
   }
+  std::unordered_set<std::string> getCompilerDirectiveSentinels() {
+    return compilerDirectiveSentinels_;
+  }
 
 private:
   struct LineClassification {

--- a/flang/test/Preprocessing/bug126459.f90
+++ b/flang/test/Preprocessing/bug126459.f90
@@ -1,0 +1,8 @@
+! RUN: %flang -fopenmp -E %s 2>&1 | FileCheck %s
+!CHECK: !$ NDIR=0
+program main
+integer NDIR
+#define BLANKMACRO
+
+BLANKMACRO !$ NDIR=0
+end program main


### PR DESCRIPTION

The compiler directives and  conditional compilation codes are getting ignored in the presence of preprocessor macros. The necessary changes are added to identify the compiler directives and to emit proper preprocessor outputs.

Fixes issue #126459
