### PR TITLE
[CodeGen][NVPTX] Add a TRI function get the Dwarf register number for a virtual register.

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -1111,6 +1111,10 @@ public:
   prependOffsetExpression(const DIExpression *Expr, unsigned PrependFlags,
                           const StackOffset &Offset) const;
 
+  virtual int64_t getDwarfRegNumForVirtReg(Register RegNum, bool isEH) const {
+    llvm_unreachable("getDwarfRegNumForVirtReg does not exist on this target");
+  }
+
   /// Spill the register so it can be used by the register scavenger.
   /// Return true if the register was spilled, false otherwise.
   /// If this function does not spill the register, the scavenger

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
@@ -106,7 +106,7 @@ bool DwarfExpression::addMachineReg(const TargetRegisterInfo &TRI,
       return true;
     }
     // Try getting dwarf register for virtual register anyway, eg. for NVPTX.
-    int64_t Reg = TRI.getDwarfRegNum(MachineReg, false);
+    int64_t Reg = TRI.getDwarfRegNumForVirtReg(MachineReg, false);
     if (Reg > 0) {
       DwarfRegs.push_back(Register::createRegister(Reg, nullptr));
       return true;

--- a/llvm/lib/Target/NVPTX/NVPTXRegisterInfo.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXRegisterInfo.cpp
@@ -170,15 +170,18 @@ void NVPTXRegisterInfo::addToDebugRegisterMap(
 }
 
 int64_t NVPTXRegisterInfo::getDwarfRegNum(MCRegister RegNum, bool isEH) const {
-  if (RegNum.isPhysical()) {
-    StringRef Name = NVPTXInstPrinter::getRegisterName(RegNum.id());
-    // In NVPTXFrameLowering.cpp, we do arrange for %Depot to be accessible from
-    // %SP. Using the %Depot register doesn't provide any debug info in
-    // cuda-gdb, but switching it to %SP does.
-    if (RegNum.id() == NVPTX::VRDepot)
-      Name = "%SP";
-    return encodeRegisterForDwarf(Name);
-  }
+  StringRef Name = NVPTXInstPrinter::getRegisterName(RegNum.id());
+  // In NVPTXFrameLowering.cpp, we do arrange for %Depot to be accessible from
+  // %SP. Using the %Depot register doesn't provide any debug info in
+  // cuda-gdb, but switching it to %SP does.
+  if (RegNum.id() == NVPTX::VRDepot)
+    Name = "%SP";
+  return encodeRegisterForDwarf(Name);
+}
+
+int64_t NVPTXRegisterInfo::getDwarfRegNumForVirtReg(Register RegNum,
+                                                    bool isEH) const {
+  assert(RegNum.isVirtual());
   uint64_t lookup = debugRegisterMap.lookup(RegNum.id());
   if (lookup)
     return lookup;

--- a/llvm/lib/Target/NVPTX/NVPTXRegisterInfo.h
+++ b/llvm/lib/Target/NVPTX/NVPTXRegisterInfo.h
@@ -72,6 +72,7 @@ public:
                              StringRef RegisterName) const;
   void clearDebugRegisterMap() const;
   int64_t getDwarfRegNum(MCRegister RegNum, bool isEH) const override;
+  int64_t getDwarfRegNumForVirtReg(Register RegNum, bool isEH) const override;
 };
 
 StringRef getNVPTXRegClassName(const TargetRegisterClass *RC);


### PR DESCRIPTION
NVPTX needs to be able to get the Dwarf register number for a virtual register. The interface we have for this today is on MCRegisterInfo and take a MCRegister argument. It shouldn't be legal to convert a Register containing a virtual register to an MCRegister.

This patch adds a getDwarfRegNumForVirtReg function that takes a Register to TRI and splits the NVPTX override of getDwarfRegNum.