### PR TITLE
[compiler-rt][rtsan] copy_file_range interception for Linux.

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
@@ -312,6 +312,18 @@ INTERCEPTOR(int, ftruncate64, int fd, off64_t length) {
 #define RTSAN_MAYBE_INTERCEPT_FTRUNCATE64
 #endif
 
+#if _FILE_OFFSET_BITS == 64 && SANITIZER_LINUX
+INTERCEPTOR(ssize_t, copy_file_range, int fdin, off_t *off_int, int fdout,
+            off_t *off_out, size_t len, unsigned int flags) {
+  __rtsan_notify_intercepted_call("copy_file_range");
+  return REAL(copy_file_range)(fdin, off_int, fdout, off_out, len, flags);
+}
+#define RTSAN_MAYBE_INTERCEPT_COPY_FILE_RANGE                                  \
+  INTERCEPT_FUNCTION(copy_file_range)
+#else
+#define RTSAN_MAYBE_INTERCEPT_COPY_FILE_RANGE
+#endif
+
 // Streams
 
 INTERCEPTOR(FILE *, fopen, const char *path, const char *mode) {
@@ -1468,6 +1480,7 @@ void __rtsan::InitializeInterceptors() {
   INTERCEPT_FUNCTION(ftruncate);
   RTSAN_MAYBE_INTERCEPT_TRUNCATE64;
   RTSAN_MAYBE_INTERCEPT_FTRUNCATE64;
+  RTSAN_MAYBE_INTERCEPT_COPY_FILE_RANGE;
   INTERCEPT_FUNCTION(fopen);
   RTSAN_MAYBE_INTERCEPT_FOPEN64;
   RTSAN_MAYBE_INTERCEPT_FREOPEN64;

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
@@ -887,6 +887,17 @@ TEST_F(RtsanOpenedFileTest, FtruncateDiesWhenRealtime) {
   ExpectNonRealtimeSurvival(Func);
 }
 
+#if _FILE_OFFSET_BITS == 64 && SANITIZER_LINUX
+TEST_F(RtsanOpenedFileTest, CopyfilerangeDiesWhenRealtime) {
+  off_t in = 0, out = 1;
+  auto Func = [this, &in, &out]() {
+    copy_file_range(GetOpenFd(), &in, GetOpenFd(), &out, 1, 0);
+  };
+  ExpectRealtimeDeath(Func, "copy_file_range");
+  ExpectNonRealtimeSurvival(Func);
+}
+#endif
+
 TEST_F(RtsanFileTest, FcloseDiesWhenRealtime) {
   FILE *f = fopen(GetTemporaryFilePath(), "w");
   EXPECT_THAT(f, Ne(nullptr));


### PR DESCRIPTION
glibc had the wrapper for years and musl since 5yrs+, hopefully should not need to address the latter.