### PR TITLE
[AMDGPU][NPM] Support -regalloc-npm options

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -2186,6 +2186,7 @@ AMDGPUCodeGenPassBuilder::getRAOptionsForPhase(RegAllocPhase Phase) const {
     return RA_OPTIONS(onlyAllocateVGPRs, "vgpr", true);
   }
 
+  llvm_unreachable("invalid phase value");
 #undef RA_OPTIONS
 }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -2165,97 +2165,6 @@ static const char NPMRegAllocOptNotSupportedMessage[] =
     "-wwm-regalloc-npm, "
     "and -vgpr-regalloc-npm";
 
-// void AMDGPUCodeGenPassBuilder::addSGPRRegAlloc(AddMachinePass &addPass,
-// RegAllocType RAType, RegAllocFilterFunc FilterFunc, bool Optimized) const {
-//   RegAllocType RAType = RegAllocTypeNPM;
-//   if (RAType == RegAllocType::Default) {
-//     RAType = Optimized ? RegAllocType::Greedy : RegAllocType::Fast;
-//   }
-
-//   if (RAType == RegAllocType::Greedy) {
-//       addPass(RAGreedyPass({onlyAllocateSGPRs, "sgpr"}));
-//       return;
-//   }
-
-//   if (RAType == RegAllocType::Fast) {
-//     addPass(RegAllocFastPass({onlyAllocateSGPRs, "sgpr", false}));
-//     return;
-//   }
-//   report_fatal_error("Unsupported SGPR regalloc type", false);
-// }
-
-// template<typename RegAllocPass>
-// void AMDGPUCodeGenPassBuilder::addRegAllocOfType(AddMachinePass &addPass,
-// RegAllocPass::Options Options) {
-//   addPass(RegAllocPass(Options));
-// }
-
-// this is the final method
-// template<typename RegAllocPass>
-// void AMDGPUCodeGenPassBuilder::addRegAllocOfType(AddMachinePass &addPass,
-// RegAllocPhase Phase) {
-// #define RA_OPTIONS(FilterFunc, Name, ClearVirtRegs) \
-//   [&]() { \
-//     if constexpr (std::is_same_v<RegAllocPass, RegAllocFastPass>) { \
-//       return RegAllocFastPass::Options{FilterFunc, Name, ClearVirtRegs}; \
-//     } else { \
-//       return typename RegAllocPass::Options{FilterFunc, Name}; \
-//     } \
-//   }()
-
-//   typename RegAllocPass::Options Options;
-//   RegAllocType RAType;
-
-//   switch (Phase) {
-//   case RegAllocPhase::SGPR:
-//     Options = RA_OPTIONS(onlyAllocateSGPRs, "sgpr", false);
-//     RAType = SGPRRegAllocTypeNPM;
-//     break;
-//   case RegAllocPhase::WWM:
-//     Options = RA_OPTIONS(onlyAllocateWWMRegs, "wwm", false);
-//     RAType = WWMRegAllocTypeNPM;
-//     break;
-//   case RegAllocPhase::VGPR:
-//     Options = RA_OPTIONS(onlyAllocateVGPRs, "vgpr", true);
-//     RAType = VGPRRegAllocTypeNPM;
-//     break;
-//   };
-
-//   switch(RAType) {
-//     case RegAllocType::Greedy:
-//       addPass(RAGreedyPass(Options));
-//       return;
-//     case RegAllocType::Fast:
-//       addPass(RegAllocFastPass(Options));
-//       return;
-//     case RegAllocType::Unset:
-//       addPass(RegAllocPass(Options));
-//   }
-// #undef RA_OPTIONS
-// }
-
-// template<typename RegAllocPass>
-// void AMDGPUCodeGenPassBuilder::addRegAlloc(AddMachinePass &addPass,
-// RegAllocPhase Phase) {
-//   RegAllocType RAType;
-//   switch(Phase) {
-//     case RegAllocPhase::SGPR:
-//       RAType = SGPRRegAllocTypeNPM;
-//       break;
-//     case RegAllocPhase::WWM:
-//       RAType = WWMRegAllocTypeNPM;
-//       break;
-//     case RegAllocPhase::VGPR:
-//       RAType = VGPRRegAllocTypeNPM;
-//       break;
-//   }
-//   switch (RAType) {
-//     case RegAllocType::Greedy:
-//       addRegAllocOfType(addPass, Phase);
-//   }
-//   addRegAllocOfType<RegAllocPass>(addPass, Phase);
-// }
-
 template <typename RegAllocPassT>
 typename RegAllocPassT::Options
 AMDGPUCodeGenPassBuilder::getRAOptionsForPhase(RegAllocPhase Phase) const {
@@ -2276,18 +2185,6 @@ AMDGPUCodeGenPassBuilder::getRAOptionsForPhase(RegAllocPhase Phase) const {
   case RegAllocPhase::VGPR:
     return RA_OPTIONS(onlyAllocateVGPRs, "vgpr", true);
   }
-  // static_assert(std::is_same_v<PhaseT, SGPRPhase> ||
-  //               std::is_same_v<PhaseT, WWMPhase> ||
-  //               std::is_same_v<PhaseT, VGPRPhase>,
-  //               "Unsupported phase type");
-
-  // if constexpr(std::is_same_v<PhaseT, SGPRPhase>) {
-  //   return RA_OPTIONS(onlyAllocateSGPRs, "sgpr", false);
-  // } else if constexpr(std::is_same_v<PhaseT, WWMPhase>) {
-  //   return RA_OPTIONS(onlyAllocateWWMRegs, "wwm", false);
-  // } else if constexpr(std::is_same_v<PhaseT, VGPRPhase>) {
-  //   return RA_OPTIONS(onlyAllocateVGPRs, "vgpr", true);
-  // }
 
 #undef RA_OPTIONS
 }
@@ -2318,10 +2215,11 @@ void AMDGPUCodeGenPassBuilder::addRegAlloc(AddMachinePass &addPass,
     addPass(RegAllocFastPass(getRAOptionsForPhase<RegAllocFastPass>(Phase)));
     return;
   case RegAllocType::Unset:
+  case RegAllocType::Default:
     addPass(RegAllocPassT(getRAOptionsForPhase<RegAllocPassT>(Phase)));
     return;
   default:
-    report_fatal_error("Unsupported regalloc type", false);
+    report_fatal_error("Unsupported regalloc type for AMDGPU", false);
   }
 }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.h
@@ -194,10 +194,6 @@ public:
   void addStraightLineScalarOptimizationPasses(AddIRPass &) const;
 
 private:
-  // /// Dummy structs to represent different phases of register allocation.
-  // struct SGPRPhase{};
-  // struct VGPRPhase{};
-  // struct WWMPhase{};
   enum class RegAllocPhase { SGPR, VGPR, WWM };
 
   template <typename RegAllocPassT>

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.h
@@ -209,17 +209,6 @@ private:
   /// \param Phase The phase of register allocation to add.
   template <typename PreferredRegAllocPassT>
   void addRegAlloc(AddMachinePass &, RegAllocPhase Phase) const;
-
-  // instantiate the template for each phase
-  /// Add the register allocation pass for given filter func and type
-  /// (greedy/fast).
-  /// @param Type If RegAllocType::Default, add according to the optimization
-  /// level.
-  // void addRegAllocPass(AddMachinePass &, RegAllocType Type,
-  // RegAllocFilterFunc FilterFunc) const;
-  void addSGPRRegAlloc(AddMachinePass &, bool Optimized) const;
-  void addWWMRegAlloc(AddMachinePass &, bool Optimized) const;
-  void addVGPRRegAlloc(AddMachinePass &, bool Optimized) const;
 };
 
 } // end namespace llvm

--- a/llvm/test/tools/llc/new-pm/regalloc-amdgpu.mir
+++ b/llvm/test/tools/llc/new-pm/regalloc-amdgpu.mir
@@ -2,7 +2,7 @@
 # RUN: llc -mtriple=amdgcn --passes='regallocfast<filter=sgpr>,regallocfast<filter=wwm>,regallocfast<filter=vgpr>' --print-pipeline-passes --filetype=null %s | FileCheck %s --check-prefix=PASS
 # RUN: not llc -mtriple=amdgcn --passes='regallocfast<filter=bad-filter>' --print-pipeline-passes --filetype=null %s 2>&1 | FileCheck %s --check-prefix=BAD-FILTER
 
-# RUN: llc -mtriple=amdgcn -enable-new-pm -sgpr-regalloc-npm=greedy -vgpr-regalloc-npm=fast -print-pipeline-passes %s | FileCheck %s --check-prefix=NPM-PASS
+# RUN: llc -mtriple=amdgcn -enable-new-pm -sgpr-regalloc-npm=greedy -wwm-regalloc-npm=fast -vgpr-regalloc-npm=fast -print-pipeline-passes %s | FileCheck %s --check-prefix=NPM-PASS
 
 
 # PASS: regallocfast<filter=sgpr>
@@ -11,6 +11,7 @@
 # BAD-FILTER: invalid regallocfast register filter 'bad-filter'
 
 # NPM-PASS: greedy<sgpr>
+# NPM-PASS: regallocfast<filter=wwm;no-clear-vregs>
 # NPM-PASS: regallocfast<filter=vgpr>
 ---
 name: f

--- a/llvm/test/tools/llc/new-pm/regalloc-amdgpu.mir
+++ b/llvm/test/tools/llc/new-pm/regalloc-amdgpu.mir
@@ -2,11 +2,16 @@
 # RUN: llc -mtriple=amdgcn --passes='regallocfast<filter=sgpr>,regallocfast<filter=wwm>,regallocfast<filter=vgpr>' --print-pipeline-passes --filetype=null %s | FileCheck %s --check-prefix=PASS
 # RUN: not llc -mtriple=amdgcn --passes='regallocfast<filter=bad-filter>' --print-pipeline-passes --filetype=null %s 2>&1 | FileCheck %s --check-prefix=BAD-FILTER
 
+# RUN: llc -mtriple=amdgcn -enable-new-pm -sgpr-regalloc-npm=greedy -vgpr-regalloc-npm=fast -print-pipeline-passes %s | FileCheck %s --check-prefix=NPM-PASS
+
+
 # PASS: regallocfast<filter=sgpr>
 # PASS: regallocfast<filter=wwm>
 # PASS: regallocfast<filter=vgpr>
 # BAD-FILTER: invalid regallocfast register filter 'bad-filter'
 
+# NPM-PASS: greedy<sgpr>
+# NPM-PASS: regallocfast<filter=vgpr>
 ---
 name: f
 ...


### PR DESCRIPTION
Regalloc options for AMDGPU are `-{phase}-regalloc-npm={type}` where `phase=sgpr|vgpr|wwm` and `type=greedy|fast...` (common regalloc pass types)