### PR TITLE
[OpenMP] Mark Failing OpenMP Tests as XFAIL on Windows

### DIFF
--- a/openmp/runtime/test/lit.cfg
+++ b/openmp/runtime/test/lit.cfg
@@ -137,6 +137,9 @@ if config.operating_system in ['Windows', 'Linux', 'FreeBSD', 'NetBSD', 'DragonF
 if config.operating_system in ['Linux']:
     config.available_features.add('hidden-helper')
 
+if config.operating_system == 'Windows':
+    config.available_features.add("windows")
+
 target_arch = getattr(config, 'target_arch', None)
 if target_arch:
   config.available_features.add(target_arch + '-target-arch')

--- a/openmp/runtime/test/lit.cfg
+++ b/openmp/runtime/test/lit.cfg
@@ -137,8 +137,8 @@ if config.operating_system in ['Windows', 'Linux', 'FreeBSD', 'NetBSD', 'DragonF
 if config.operating_system in ['Linux']:
     config.available_features.add('hidden-helper')
 
-if config.operating_system == 'Windows':
-    config.available_features.add("windows")
+if config.compiler_frontend_variant == 'MSVC':
+    config.available_features.add("msvc")
 
 target_arch = getattr(config, 'target_arch', None)
 if target_arch:

--- a/openmp/runtime/test/lit.cfg
+++ b/openmp/runtime/test/lit.cfg
@@ -137,7 +137,7 @@ if config.operating_system in ['Windows', 'Linux', 'FreeBSD', 'NetBSD', 'DragonF
 if config.operating_system in ['Linux']:
     config.available_features.add('hidden-helper')
 
-if config.compiler_frontend_variant == 'MSVC':
+if config.compiler_frontend_variant == 'MSVC' or config.compiler_simulate_id == 'MSVC':
     config.available_features.add("msvc")
 
 target_arch = getattr(config, 'target_arch', None)

--- a/openmp/runtime/test/lit.site.cfg.in
+++ b/openmp/runtime/test/lit.site.cfg.in
@@ -21,6 +21,7 @@ config.has_libatomic = @LIBOMP_HAVE_LIBATOMIC@
 config.is_standalone_build = @OPENMP_STANDALONE_BUILD@
 config.has_omit_frame_pointer_flag = @OPENMP_TEST_COMPILER_HAS_OMIT_FRAME_POINTER_FLAGS@
 config.target_arch = "@LIBOMP_ARCH@"
+config.compiler_frontend_variant="@CMAKE_C_COMPILER_FRONTEND_VARIANT@"
 
 # Let the main config do the real work.
 lit_config.load_config(config, "@LIBOMP_BASE_DIR@/test/lit.cfg")

--- a/openmp/runtime/test/lit.site.cfg.in
+++ b/openmp/runtime/test/lit.site.cfg.in
@@ -21,7 +21,8 @@ config.has_libatomic = @LIBOMP_HAVE_LIBATOMIC@
 config.is_standalone_build = @OPENMP_STANDALONE_BUILD@
 config.has_omit_frame_pointer_flag = @OPENMP_TEST_COMPILER_HAS_OMIT_FRAME_POINTER_FLAGS@
 config.target_arch = "@LIBOMP_ARCH@"
-config.compiler_frontend_variant="@CMAKE_C_COMPILER_FRONTEND_VARIANT@"
+config.compiler_frontend_variant = "@CMAKE_C_COMPILER_FRONTEND_VARIANT@"
+config.compiler_simulate_id = "@CMAKE_C_SIMULATE_ID@"
 
 # Let the main config do the real work.
 lit_config.load_config(config, "@LIBOMP_BASE_DIR@/test/lit.cfg")

--- a/openmp/runtime/test/transform/interchange/iterfor.cpp
+++ b/openmp/runtime/test/transform/interchange/iterfor.cpp
@@ -1,3 +1,4 @@
+// XFAIL: windows
 // RUN: %libomp-cxx20-compile-and-run | FileCheck %s --match-full-lines
 
 #ifndef HEADER

--- a/openmp/runtime/test/transform/interchange/iterfor.cpp
+++ b/openmp/runtime/test/transform/interchange/iterfor.cpp
@@ -1,4 +1,5 @@
 // XFAIL: windows
+// Fails on windows due to issue #129023
 // RUN: %libomp-cxx20-compile-and-run | FileCheck %s --match-full-lines
 
 #ifndef HEADER

--- a/openmp/runtime/test/transform/interchange/iterfor.cpp
+++ b/openmp/runtime/test/transform/interchange/iterfor.cpp
@@ -1,4 +1,4 @@
-// XFAIL: windows
+// XFAIL: msvc
 // Fails on windows due to issue #129023
 // RUN: %libomp-cxx20-compile-and-run | FileCheck %s --match-full-lines
 

--- a/openmp/runtime/test/transform/tile/iterfor.cpp
+++ b/openmp/runtime/test/transform/tile/iterfor.cpp
@@ -1,3 +1,4 @@
+// XFAIL: windows
 // RUN: %libomp-cxx20-compile-and-run | FileCheck %s --match-full-lines
 
 #ifndef HEADER

--- a/openmp/runtime/test/transform/tile/iterfor.cpp
+++ b/openmp/runtime/test/transform/tile/iterfor.cpp
@@ -1,4 +1,5 @@
 // XFAIL: windows
+// Fails on windows due to issue #129023
 // RUN: %libomp-cxx20-compile-and-run | FileCheck %s --match-full-lines
 
 #ifndef HEADER

--- a/openmp/runtime/test/transform/tile/iterfor.cpp
+++ b/openmp/runtime/test/transform/tile/iterfor.cpp
@@ -1,4 +1,4 @@
-// XFAIL: windows
+// XFAIL: msvc
 // Fails on windows due to issue #129023
 // RUN: %libomp-cxx20-compile-and-run | FileCheck %s --match-full-lines
 

--- a/openmp/runtime/test/worksharing/for/omp_for_collapse_LowerTriangularLess.c
+++ b/openmp/runtime/test/worksharing/for/omp_for_collapse_LowerTriangularLess.c
@@ -1,3 +1,4 @@
+// XFAIL: windows
 // RUN: %libomp-compile-and-run
 #include <stdio.h>
 #include <stdlib.h>

--- a/openmp/runtime/test/worksharing/for/omp_for_collapse_LowerTriangularLess.c
+++ b/openmp/runtime/test/worksharing/for/omp_for_collapse_LowerTriangularLess.c
@@ -1,4 +1,5 @@
 // XFAIL: windows
+// Fails on windows due to issue #129023
 // RUN: %libomp-compile-and-run
 #include <stdio.h>
 #include <stdlib.h>

--- a/openmp/runtime/test/worksharing/for/omp_for_collapse_LowerTriangularLess.c
+++ b/openmp/runtime/test/worksharing/for/omp_for_collapse_LowerTriangularLess.c
@@ -1,4 +1,4 @@
-// XFAIL: windows
+// XFAIL: msvc
 // Fails on windows due to issue #129023
 // RUN: %libomp-compile-and-run
 #include <stdio.h>

--- a/openmp/runtime/test/worksharing/for/omp_for_collapse_LowerTriangularLessEqual.c
+++ b/openmp/runtime/test/worksharing/for/omp_for_collapse_LowerTriangularLessEqual.c
@@ -1,3 +1,4 @@
+// XFAIL: windows
 // RUN: %libomp-compile-and-run
 #include <stdio.h>
 #include <stdlib.h>

--- a/openmp/runtime/test/worksharing/for/omp_for_collapse_LowerTriangularLessEqual.c
+++ b/openmp/runtime/test/worksharing/for/omp_for_collapse_LowerTriangularLessEqual.c
@@ -1,4 +1,5 @@
 // XFAIL: windows
+// Fails on windows due to issue #129023
 // RUN: %libomp-compile-and-run
 #include <stdio.h>
 #include <stdlib.h>

--- a/openmp/runtime/test/worksharing/for/omp_for_collapse_LowerTriangularLessEqual.c
+++ b/openmp/runtime/test/worksharing/for/omp_for_collapse_LowerTriangularLessEqual.c
@@ -1,4 +1,4 @@
-// XFAIL: windows
+// XFAIL: msvc
 // Fails on windows due to issue #129023
 // RUN: %libomp-compile-and-run
 #include <stdio.h>

--- a/openmp/runtime/test/worksharing/for/omp_for_collapse_UpperTriangular.c
+++ b/openmp/runtime/test/worksharing/for/omp_for_collapse_UpperTriangular.c
@@ -1,3 +1,4 @@
+// XFAIL: windows
 // RUN: %libomp-compile-and-run
 #include <stdio.h>
 #include <stdlib.h>

--- a/openmp/runtime/test/worksharing/for/omp_for_collapse_UpperTriangular.c
+++ b/openmp/runtime/test/worksharing/for/omp_for_collapse_UpperTriangular.c
@@ -1,4 +1,5 @@
 // XFAIL: windows
+// Fails on windows due to issue #129023
 // RUN: %libomp-compile-and-run
 #include <stdio.h>
 #include <stdlib.h>

--- a/openmp/runtime/test/worksharing/for/omp_for_collapse_UpperTriangular.c
+++ b/openmp/runtime/test/worksharing/for/omp_for_collapse_UpperTriangular.c
@@ -1,4 +1,4 @@
-// XFAIL: windows
+// XFAIL: msvc
 // Fails on windows due to issue #129023
 // RUN: %libomp-compile-and-run
 #include <stdio.h>


### PR DESCRIPTION
This patch marks specific OpenMP runtime tests as XFAIL on Windows due to failures reported in #129023