### PR TITLE
[lld][WebAssembly] Add RUNTIME_PATH support to wasm-ld

### DIFF
--- a/lld/test/wasm/rpath.s
+++ b/lld/test/wasm/rpath.s
@@ -1,0 +1,14 @@
+# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
+# RUN: wasm-ld -shared -o %t1.wasm %t.o -rpath /a/b/c -rpath /x/y/z
+# RUN: obj2yaml %t1.wasm | FileCheck %s
+
+# CHECK:  - Type:            CUSTOM
+# CHECK-NEXT:    Name:            dylink.0
+# CHECK-NEXT:    MemorySize:      0
+# CHECK-NEXT:    MemoryAlignment: 0
+# CHECK-NEXT:    TableSize:       0
+# CHECK-NEXT:    TableAlignment:  0
+# CHECK-NEXT:    Needed:          []
+# CHECK-NEXT:    RuntimePath:
+# CHECK-NEXT:      - '/a/b/c'
+# CHECK-NEXT:      - '/x/y/z'

--- a/lld/test/wasm/rpath.s
+++ b/lld/test/wasm/rpath.s
@@ -1,5 +1,5 @@
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
-# RUN: wasm-ld -shared -o %t1.wasm %t.o -rpath /a/b/c -rpath /x/y/z
+# RUN: wasm-ld -shared -o %t1.wasm %t.o -rpath /a/b/c -rpath /x/y/z --experimental-pic
 # RUN: obj2yaml %t1.wasm | FileCheck %s
 
 # CHECK:  - Type:            CUSTOM

--- a/lld/wasm/Config.h
+++ b/lld/wasm/Config.h
@@ -120,11 +120,11 @@ struct Config {
   llvm::StringSet<> exportedSymbols;
   std::vector<llvm::StringRef> requiredExports;
   llvm::SmallVector<llvm::StringRef, 0> searchPaths;
+  llvm::SmallVector<llvm::StringRef, 0> rpath;
   llvm::CachePruningPolicy thinLTOCachePolicy;
   std::optional<std::vector<std::string>> features;
   std::optional<std::vector<std::string>> extraFeatures;
   llvm::SmallVector<uint8_t, 0> buildIdVector;
-  llvm::SmallVector<llvm::StringRef, 0> rpath;
 };
 
 // The Ctx object hold all other (non-configuration) global state.

--- a/lld/wasm/Config.h
+++ b/lld/wasm/Config.h
@@ -70,7 +70,6 @@ struct Config {
   bool pie;
   bool printGcSections;
   bool relocatable;
-  llvm::SmallVector<llvm::StringRef, 0> rpath;
   bool saveTemps;
   bool shared;
   bool shlibSigCheck;
@@ -125,6 +124,7 @@ struct Config {
   std::optional<std::vector<std::string>> features;
   std::optional<std::vector<std::string>> extraFeatures;
   llvm::SmallVector<uint8_t, 0> buildIdVector;
+  llvm::SmallVector<llvm::StringRef, 0> rpath;
 };
 
 // The Ctx object hold all other (non-configuration) global state.

--- a/lld/wasm/Config.h
+++ b/lld/wasm/Config.h
@@ -70,6 +70,7 @@ struct Config {
   bool pie;
   bool printGcSections;
   bool relocatable;
+  llvm::SmallVector<llvm::StringRef, 0> rpath;
   bool saveTemps;
   bool shared;
   bool shlibSigCheck;

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -583,6 +583,7 @@ static void readConfigs(opt::InputArgList &args) {
   ctx.arg.optimize = args::getInteger(args, OPT_O, 1);
   ctx.arg.outputFile = args.getLastArgValue(OPT_o);
   ctx.arg.relocatable = args.hasArg(OPT_relocatable);
+  ctx.arg.rpath = args::getStrings(args, OPT_rpath);
   ctx.arg.gcSections =
       args.hasFlag(OPT_gc_sections, OPT_no_gc_sections, !ctx.arg.relocatable);
   for (auto *arg : args.filtered(OPT_keep_section))

--- a/lld/wasm/Options.td
+++ b/lld/wasm/Options.td
@@ -291,7 +291,6 @@ def: Flag<["-"], "t">, Alias<trace>, HelpText<"Alias for --trace">;
 def: JoinedOrSeparate<["-"], "y">, Alias<trace_symbol>, HelpText<"Alias for --trace-symbol">;
 def: JoinedOrSeparate<["-"], "u">, Alias<undefined>;
 def: Flag<["-"], "V">, Alias<v>, HelpText<"Alias for -v">;
-def: JoinedOrSeparate<["-"], "R">, Alias<rpath>, HelpText<"Alias for --rpath">;
 
 // LTO-related options.
 def lto_O: JJ<"lto-O">, MetaVarName<"<opt-level>">,

--- a/lld/wasm/Options.td
+++ b/lld/wasm/Options.td
@@ -132,6 +132,8 @@ def relocatable: F<"relocatable">, HelpText<"Create relocatable object file">;
 
 defm reproduce: EEq<"reproduce", "Dump linker invocation and input files for debugging">;
 
+defm rpath: Eq<"rpath", "Add a DT_RUNPATH to the output">;
+
 defm rsp_quoting: Eq<"rsp-quoting", "Quoting style for response files">,
   MetaVarName<"[posix,windows]">;
 
@@ -289,6 +291,7 @@ def: Flag<["-"], "t">, Alias<trace>, HelpText<"Alias for --trace">;
 def: JoinedOrSeparate<["-"], "y">, Alias<trace_symbol>, HelpText<"Alias for --trace-symbol">;
 def: JoinedOrSeparate<["-"], "u">, Alias<undefined>;
 def: Flag<["-"], "V">, Alias<v>, HelpText<"Alias for -v">;
+def: JoinedOrSeparate<["-"], "R">, Alias<rpath>, HelpText<"Alias for --rpath">;
 
 // LTO-related options.
 def lto_O: JJ<"lto-O">, MetaVarName<"<opt-level>">,

--- a/lld/wasm/SyntheticSections.cpp
+++ b/lld/wasm/SyntheticSections.cpp
@@ -16,6 +16,7 @@
 #include "InputElement.h"
 #include "OutputSegment.h"
 #include "SymbolTable.h"
+#include "llvm/BinaryFormat/Wasm.h"
 #include "llvm/Support/Path.h"
 #include <optional>
 
@@ -131,6 +132,14 @@ void DylinkSection::writeBody() {
       writeUleb128(sub.os, sym->flags, "sym flags");
     }
 
+    sub.writeTo(os);
+  }
+  if (!ctx.arg.rpath.empty()) {
+    SubSection sub(WASM_DYLINK_RUNTIME_PATH);
+    writeUleb128(sub.os, ctx.arg.rpath.size(), "num rpath entries");
+    for (const auto ref : ctx.arg.rpath) {
+      writeStr(sub.os, ref, "rpath entry");
+    }
     sub.writeTo(os);
   }
 }

--- a/lld/wasm/SyntheticSections.cpp
+++ b/lld/wasm/SyntheticSections.cpp
@@ -134,12 +134,12 @@ void DylinkSection::writeBody() {
 
     sub.writeTo(os);
   }
+
   if (!ctx.arg.rpath.empty()) {
     SubSection sub(WASM_DYLINK_RUNTIME_PATH);
     writeUleb128(sub.os, ctx.arg.rpath.size(), "num rpath entries");
-    for (const auto ref : ctx.arg.rpath) {
+    for (const auto ref : ctx.arg.rpath)
       writeStr(sub.os, ref, "rpath entry");
-    }
     sub.writeTo(os);
   }
 }


### PR DESCRIPTION
This finishes adding RPATH support for WebAssembly.

See my previous PR which added RPATH support to yaml2obj and obj2yaml: https://github.com/llvm/llvm-project/pull/126080
See corresponding update to the WebAssembly/tool-conventions repo on dynamic linking: https://github.com/WebAssembly/tool-conventions/pull/246

cc @sbc100 @ryanking13