### PR TITLE
[mlir][NVMM] Add `globaltimer_wait` op

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -2583,6 +2583,10 @@ def NVVM_MapaOp: NVVM_Op<"mapa",
   let assemblyFormat = "$a`,` $b attr-dict `:` type($a) `->` type($res)";
 }
 
+//===----------------------------------------------------------------------===//
+// Special control flow ops
+//===----------------------------------------------------------------------===//
+
 def NVVM_Exit : NVVM_Op<"exit"> {
   let summary = "Exit Op";
   let description = [{
@@ -2596,11 +2600,6 @@ def NVVM_Exit : NVVM_Op<"exit"> {
   let assemblyFormat = "attr-dict";
 }
 
-
-//===----------------------------------------------------------------------===//
-// NVVM breakpoint Op
-//===----------------------------------------------------------------------===//
-
 def NVVM_Breakpoint : NVVM_Op<"breakpoint"> {
   let summary = "Breakpoint Op";
   let description = [{
@@ -2612,6 +2611,31 @@ def NVVM_Breakpoint : NVVM_Op<"breakpoint"> {
   }];
 
   let assemblyFormat = "attr-dict";
+}
+
+def NVVM_GlobalTimerWaitOp : NVVM_PTXBuilder_Op<"globaltimer_wait">,  
+    Arguments<(ins I64:$time)> {
+  let summary = "globaltimer busy loop";
+  let description = [{
+    Wait in busy loop for certain number of nanoseconds.
+    [For more information, see PTX ISA.](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#special-registers-globaltimer)
+  }];
+  let assemblyFormat = "$time attr-dict";
+
+  let extraClassDefinition = [{
+    std::string $cppClass::getPtx() {
+      return R"({
+  .reg .pred continueloop;
+  .reg .u64 rd<3>;
+  mov.u64 rd0, %globaltimer;
+  add.s64 rd1, rd0, %0;
+  L_busy:
+  mov.u64 rd2, %globaltimer;
+  setp.lt.s64 continueloop, rd2, rd1;
+  @continueloop bra L_busy;
+})";
+    }
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/LLVMIR/IR/BasicPtxBuilderInterface.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/BasicPtxBuilderInterface.cpp
@@ -13,6 +13,8 @@
 
 #include "mlir/Dialect/LLVMIR/BasicPtxBuilderInterface.h"
 
+#include <regex>
+
 #define DEBUG_TYPE "ptx-builder"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define DBGSNL() (llvm::dbgs() << "\n")
@@ -129,9 +131,9 @@ LLVM::InlineAsmOp PtxBuilder::build() {
   }
 
   // Tablegen doesn't accept $, so we use %, but inline assembly uses $.
-  // Replace all % with $
-  std::replace(ptxInstruction.begin(), ptxInstruction.end(), '%', '$');
-
+  // Replace all % with $, but only if they are followed by a digit.
+  ptxInstruction = std::regex_replace(ptxInstruction, std::regex("(%)(\\d+)"),
+                                      "$\\2", std::regex_constants::format_sed);
   return rewriter.create<LLVM::InlineAsmOp>(
       interfaceOp->getLoc(),
       /*result types=*/resultTypes,


### PR DESCRIPTION
A helper op to wait for a certain number of nanoseconds in a busy loop according to `%globaltimer`. This operation can be used for debugging.
