### PR TITLE
[flang][test] fix false positive match in namelist.f90 test

### DIFF
--- a/flang/test/Lower/namelist.f90
+++ b/flang/test/Lower/namelist.f90
@@ -140,5 +140,5 @@ subroutine rename_sub
   write(*,bbb)
 end
 
-! CHECK-NOT:   bbb
+! CHECK-NOT:   fir.global internal @_QQ{{.*}}bbb{{.*}} :
 ! CHECK:       fir.string_lit "aaa\00"(4) : !fir.char<1,4>


### PR DESCRIPTION
Fixes #128855

"bbb" was matching the hashed identifier for the file name on some platforms. I have made this line more specific so that it does not match filename globals. The difference comes in fir.global *internal* vs fir.global *linkonce*.