### PR TITLE
[AArch64] Fall back to SDAG for instructions with emulated TLS variables

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
@@ -2838,8 +2838,12 @@ bool AArch64InstructionSelector::select(MachineInstr &I) {
       assert(OpFlags == AArch64II::MO_GOT);
     } else {
       GV = I.getOperand(1).getGlobal();
-      if (GV->isThreadLocal())
+      if (GV->isThreadLocal()) {
+        // We don't support instructions with emulated TLS variables yet
+        if (TM.useEmulatedTLS())
+          return false;
         return selectTLSGlobalValue(I, MRI);
+      }
       OpFlags = STI.ClassifyGlobalReference(GV, TM);
     }
 


### PR DESCRIPTION
Fixes #126200.
At the moment, GlobalISel is missing an implementation for emulated TLS variables.
I fixed the issue by falling back to SDAG in this case, as I currently don't have the knowledge to implement it myself.