### PR TITLE
[PAC] Make ValueMapper handle ConstantPtrAuth values

### DIFF
--- a/llvm/lib/Transforms/Utils/ValueMapper.cpp
+++ b/llvm/lib/Transforms/Utils/ValueMapper.cpp
@@ -525,6 +525,9 @@ Value *Mapper::mapValue(const Value *V) {
     return getVM()[V] = ConstantStruct::get(cast<StructType>(NewTy), Ops);
   if (isa<ConstantVector>(C))
     return getVM()[V] = ConstantVector::get(Ops);
+  if (isa<ConstantPtrAuth>(C))
+    return getVM()[V] = ConstantPtrAuth::get(Ops[0], cast<ConstantInt>(Ops[1]),
+                                             cast<ConstantInt>(Ops[2]), Ops[3]);
   // If this is a no-operand constant, it must be because the type was remapped.
   if (isa<PoisonValue>(C))
     return getVM()[V] = PoisonValue::get(NewTy);

--- a/llvm/unittests/Transforms/Utils/ValueMapperTest.cpp
+++ b/llvm/unittests/Transforms/Utils/ValueMapperTest.cpp
@@ -436,4 +436,34 @@ TEST(ValueMapperTest, mapValueConstantTargetNoneToLayoutTypeNullValue) {
   EXPECT_EQ(NewConstant, Mapper.mapValue(*OldConstant));
 }
 
+TEST(ValueMapperTest, mapValuePtrAuth) {
+  LLVMContext C;
+  Type *PtrTy = PointerType::get(C, 0);
+  IntegerType *Int32Ty = Type::getInt32Ty(C);
+  IntegerType *Int64Ty = Type::getInt64Ty(C);
+
+  std::unique_ptr<GlobalVariable> Var0 = std::make_unique<GlobalVariable>(
+      PtrTy, false, GlobalValue::ExternalLinkage, nullptr, "Var0");
+  std::unique_ptr<GlobalVariable> Var1 = std::make_unique<GlobalVariable>(
+      PtrTy, false, GlobalValue::ExternalLinkage, nullptr, "Var1");
+  std::unique_ptr<GlobalVariable> Storage0 = std::make_unique<GlobalVariable>(
+      PtrTy, false, GlobalValue::ExternalLinkage, nullptr, "Storage0");
+  std::unique_ptr<GlobalVariable> Storage1 = std::make_unique<GlobalVariable>(
+      PtrTy, false, GlobalValue::ExternalLinkage, nullptr, "Storage1");
+
+  ConstantInt *ConstKey = ConstantInt::get(Int32Ty, 1);
+  ConstantInt *ConstDisc = ConstantInt::get(Int64Ty, 1234);
+
+  ValueToValueMapTy VM;
+  VM[Var0.get()] = Var1.get();
+  VM[Storage0.get()] = Storage1.get();
+
+  ConstantPtrAuth *Value =
+      ConstantPtrAuth::get(Var0.get(), ConstKey, ConstDisc, Storage0.get());
+  ConstantPtrAuth *MappedValue =
+      ConstantPtrAuth::get(Var1.get(), ConstKey, ConstDisc, Storage1.get());
+
+  EXPECT_EQ(ValueMapper(VM).mapValue(*Value), MappedValue);
+}
+
 } // end namespace


### PR DESCRIPTION
Fix assertion failure when building PAuth-hardened code with LTO.