### PR TITLE
[lldb] Do not bump memory modificator ID when "internal" debugger memory is updated

### DIFF
--- a/lldb/include/lldb/Target/Memory.h
+++ b/lldb/include/lldb/Target/Memory.h
@@ -125,6 +125,8 @@ public:
 
   bool DeallocateMemory(lldb::addr_t ptr);
 
+  bool IsInCache(lldb::addr_t addr) const;
+
 protected:
   typedef std::shared_ptr<AllocatedBlock> AllocatedBlockSP;
 
@@ -133,7 +135,7 @@ protected:
 
   // Classes that inherit from MemoryCache can see and modify these
   Process &m_process;
-  std::recursive_mutex m_mutex;
+  mutable std::recursive_mutex m_mutex;
   typedef std::multimap<uint32_t, AllocatedBlockSP> PermissionsToBlockMap;
   PermissionsToBlockMap m_memory_map;
 

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -111,7 +111,7 @@ public:
   void SetOSPluginReportsAllThreads(bool does_report);
   bool GetSteppingRunsAllThreads() const;
   FollowForkMode GetFollowForkMode() const;
-  bool GetProcessStateTracksMemoryCache() const;
+  bool TrackMemoryCacheChanges() const;
 
 protected:
   Process *m_process; // Can be nullptr for global ProcessProperties

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -313,6 +313,18 @@ public:
     return lldb::EventSP();
   }
 
+  void Dump(Stream &stream) const {
+    stream.Format("ProcessModID:\n"
+                  "  m_stop_id: {0}\n  m_last_natural_stop_id: {1}\n"
+                  "  m_resume_id: {2}\n  m_memory_id: {3}\n"
+                  "  m_last_user_expression_resume: {4}\n"
+                  "  m_running_user_expression: {5}\n"
+                  "  m_running_utility_function: {6}\n",
+                  m_stop_id, m_last_natural_stop_id, m_resume_id, m_memory_id,
+                  m_last_user_expression_resume, m_running_user_expression,
+                  m_running_utility_function);
+  }
+
 private:
   uint32_t m_stop_id = 0;
   uint32_t m_last_natural_stop_id = 0;

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -111,6 +111,7 @@ public:
   void SetOSPluginReportsAllThreads(bool does_report);
   bool GetSteppingRunsAllThreads() const;
   FollowForkMode GetFollowForkMode() const;
+  bool GetProcessStateTracksMemoryCache() const;
 
 protected:
   Process *m_process; // Can be nullptr for global ProcessProperties

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -1377,6 +1377,9 @@ public:
       case 'v':
         m_verbose = true;
         break;
+      case 'd':
+        m_dump = true;
+        break;
       default:
         llvm_unreachable("Unimplemented option");
       }
@@ -1386,6 +1389,7 @@ public:
 
     void OptionParsingStarting(ExecutionContext *execution_context) override {
       m_verbose = false;
+      m_dump = false;
     }
 
     llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
@@ -1394,6 +1398,7 @@ public:
 
     // Instance variables to hold the values for command options.
     bool m_verbose = false;
+    bool m_dump = false;
   };
 
 protected:
@@ -1446,6 +1451,14 @@ protected:
         strm.EOL();
         strm.PutCString("Extended Crash Information:\n");
         crash_info_sp->GetDescription(strm);
+      }
+    }
+
+    if (m_options.m_dump) {
+      StateType state = process->GetState();
+      if (state == eStateStopped) {
+        ProcessModID process_mod_id = process->GetModID();
+        process_mod_id.Dump(result.GetOutputStream());
       }
     }
   }
@@ -1827,33 +1840,6 @@ public:
   ~CommandObjectMultiwordProcessTrace() override = default;
 };
 
-// CommandObjectProcessDumpModificationId
-class CommandObjectProcessDumpModificationId : public CommandObjectParsed {
-public:
-  CommandObjectProcessDumpModificationId(CommandInterpreter &interpreter)
-      : CommandObjectParsed(interpreter, "process dump-modification-id",
-                            "Dump the state of the ProcessModID. Intended to "
-                            "be used for debugging LLDB itself.",
-                            "process dump-modification-id",
-                            eCommandRequiresProcess) {}
-
-  ~CommandObjectProcessDumpModificationId() override = default;
-
-protected:
-  void DoExecute(Args &command, CommandReturnObject &result) override {
-    Process *process = m_exe_ctx.GetProcessPtr();
-    StateType state = process->GetState();
-    if (state != eStateStopped) {
-      result.SetStatus(eReturnStatusFailed);
-      return;
-    }
-
-    ProcessModID process_mod_id = process->GetModID();
-    process_mod_id.Dump(result.GetOutputStream());
-    result.SetStatus(eReturnStatusSuccessFinishResult);
-  }
-};
-
 // CommandObjectMultiwordProcess
 
 CommandObjectMultiwordProcess::CommandObjectMultiwordProcess(
@@ -1893,9 +1879,6 @@ CommandObjectMultiwordProcess::CommandObjectMultiwordProcess(
   LoadSubCommand(
       "trace",
       CommandObjectSP(new CommandObjectMultiwordProcessTrace(interpreter)));
-  LoadSubCommand(
-      "dump-modification-id",
-      CommandObjectSP(new CommandObjectProcessDumpModificationId(interpreter)));
 }
 
 CommandObjectMultiwordProcess::~CommandObjectMultiwordProcess() = default;

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -1827,6 +1827,33 @@ public:
   ~CommandObjectMultiwordProcessTrace() override = default;
 };
 
+// CommandObjectProcessDumpModId
+class CommandObjectProcessDumpModId : public CommandObjectParsed {
+public:
+  CommandObjectProcessDumpModId(CommandInterpreter &interpreter)
+      : CommandObjectParsed(interpreter, "process dump-mod-id",
+                            "Dump the state of the ProcessModID. Intended to "
+                            "be used for debugging LLDB itself.",
+                            "process dump-mod-id",
+                            eCommandRequiresProcess) {}
+
+  ~CommandObjectProcessDumpModId() override = default;
+
+protected:
+  void DoExecute(Args &command, CommandReturnObject &result) override {
+    Process *process = m_exe_ctx.GetProcessPtr();
+    StateType state = process->GetState();
+    if (state != eStateStopped) {
+      result.SetStatus(eReturnStatusFailed);
+      return;
+    }
+
+    ProcessModID process_mod_id = process->GetModID();
+    process_mod_id.Dump(result.GetOutputStream());
+    result.SetStatus(eReturnStatusSuccessFinishResult);
+  }
+};
+
 // CommandObjectMultiwordProcess
 
 CommandObjectMultiwordProcess::CommandObjectMultiwordProcess(
@@ -1866,6 +1893,8 @@ CommandObjectMultiwordProcess::CommandObjectMultiwordProcess(
   LoadSubCommand(
       "trace",
       CommandObjectSP(new CommandObjectMultiwordProcessTrace(interpreter)));
+  LoadSubCommand("dump-mod-id",
+                 CommandObjectSP(new CommandObjectProcessDumpModId(interpreter)));
 }
 
 CommandObjectMultiwordProcess::~CommandObjectMultiwordProcess() = default;

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -1827,16 +1827,17 @@ public:
   ~CommandObjectMultiwordProcessTrace() override = default;
 };
 
-// CommandObjectProcessDumpModId
-class CommandObjectProcessDumpModId : public CommandObjectParsed {
+// CommandObjectProcessDumpModificationId
+class CommandObjectProcessDumpModificationId : public CommandObjectParsed {
 public:
-  CommandObjectProcessDumpModId(CommandInterpreter &interpreter)
-      : CommandObjectParsed(interpreter, "process dump-mod-id",
+  CommandObjectProcessDumpModificationId(CommandInterpreter &interpreter)
+      : CommandObjectParsed(interpreter, "process dump-modification-id",
                             "Dump the state of the ProcessModID. Intended to "
                             "be used for debugging LLDB itself.",
-                            "process dump-mod-id", eCommandRequiresProcess) {}
+                            "process dump-modification-id",
+                            eCommandRequiresProcess) {}
 
-  ~CommandObjectProcessDumpModId() override = default;
+  ~CommandObjectProcessDumpModificationId() override = default;
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
@@ -1893,8 +1894,8 @@ CommandObjectMultiwordProcess::CommandObjectMultiwordProcess(
       "trace",
       CommandObjectSP(new CommandObjectMultiwordProcessTrace(interpreter)));
   LoadSubCommand(
-      "dump-mod-id",
-      CommandObjectSP(new CommandObjectProcessDumpModId(interpreter)));
+      "dump-modification-id",
+      CommandObjectSP(new CommandObjectProcessDumpModificationId(interpreter)));
 }
 
 CommandObjectMultiwordProcess::~CommandObjectMultiwordProcess() = default;

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -1834,8 +1834,7 @@ public:
       : CommandObjectParsed(interpreter, "process dump-mod-id",
                             "Dump the state of the ProcessModID. Intended to "
                             "be used for debugging LLDB itself.",
-                            "process dump-mod-id",
-                            eCommandRequiresProcess) {}
+                            "process dump-mod-id", eCommandRequiresProcess) {}
 
   ~CommandObjectProcessDumpModId() override = default;
 
@@ -1893,8 +1892,9 @@ CommandObjectMultiwordProcess::CommandObjectMultiwordProcess(
   LoadSubCommand(
       "trace",
       CommandObjectSP(new CommandObjectMultiwordProcessTrace(interpreter)));
-  LoadSubCommand("dump-mod-id",
-                 CommandObjectSP(new CommandObjectProcessDumpModId(interpreter)));
+  LoadSubCommand(
+      "dump-mod-id",
+      CommandObjectSP(new CommandObjectProcessDumpModId(interpreter)));
 }
 
 CommandObjectMultiwordProcess::~CommandObjectMultiwordProcess() = default;

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -784,6 +784,8 @@ let Command = "process handle" in {
 let Command = "process status" in {
   def process_status_verbose : Option<"verbose", "v">, Group<1>,
     Desc<"Show verbose process status including extended crash information.">;
+  def process_status_dump : Option<"dump-modification-id", "d">, Group<1>,
+    Desc<"Dump the state of the ProcessModID of the stopped process.">;
 }
 
 let Command = "process save_core" in {

--- a/lldb/source/Target/Memory.cpp
+++ b/lldb/source/Target/Memory.cpp
@@ -433,3 +433,11 @@ bool AllocatedMemoryCache::DeallocateMemory(lldb::addr_t addr) {
             (uint64_t)addr, success);
   return success;
 }
+
+bool AllocatedMemoryCache::IsInCache(lldb::addr_t addr) const {
+  std::lock_guard guard(m_mutex);
+
+  return llvm::any_of(m_memory_map, [addr](const auto &block) {
+    return block.second->Contains(addr);
+  });
+}

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -2287,8 +2287,7 @@ size_t Process::WriteMemory(addr_t addr, const void *buf, size_t size,
     return 0;
 
 #if defined(USE_ALLOCATE_MEMORY_CACHE)
-  if (TrackMemoryCacheChanges() ||
-      !m_allocated_memory_cache.IsInCache(addr))
+  if (TrackMemoryCacheChanges() || !m_allocated_memory_cache.IsInCache(addr))
     m_mod_id.BumpMemoryID();
 #else
   m_mod_id.BumpMemoryID();

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -369,6 +369,12 @@ FollowForkMode ProcessProperties::GetFollowForkMode() const {
                g_process_properties[idx].default_uint_value));
 }
 
+bool ProcessProperties::GetProcessStateTracksMemoryCache() const {
+  const uint32_t idx = ePropertyProcessStateTracksMemoryCache;
+  return GetPropertyAtIndexAs<bool>(
+      idx, g_process_properties[idx].default_uint_value != 0);
+}
+
 ProcessSP Process::FindPlugin(lldb::TargetSP target_sp,
                               llvm::StringRef plugin_name,
                               ListenerSP listener_sp,
@@ -2281,7 +2287,8 @@ size_t Process::WriteMemory(addr_t addr, const void *buf, size_t size,
     return 0;
 
 #if defined(USE_ALLOCATE_MEMORY_CACHE)
-  if (!m_allocated_memory_cache.IsInCache(addr))
+  if (GetProcessStateTracksMemoryCache() ||
+      !m_allocated_memory_cache.IsInCache(addr))
     m_mod_id.BumpMemoryID();
 #else
   m_mod_id.BumpMemoryID();

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -369,8 +369,8 @@ FollowForkMode ProcessProperties::GetFollowForkMode() const {
                g_process_properties[idx].default_uint_value));
 }
 
-bool ProcessProperties::GetProcessStateTracksMemoryCache() const {
-  const uint32_t idx = ePropertyProcessStateTracksMemoryCache;
+bool ProcessProperties::TrackMemoryCacheChanges() const {
+  const uint32_t idx = ePropertyTrackMemoryCacheChanges;
   return GetPropertyAtIndexAs<bool>(
       idx, g_process_properties[idx].default_uint_value != 0);
 }
@@ -2287,7 +2287,7 @@ size_t Process::WriteMemory(addr_t addr, const void *buf, size_t size,
     return 0;
 
 #if defined(USE_ALLOCATE_MEMORY_CACHE)
-  if (GetProcessStateTracksMemoryCache() ||
+  if (TrackMemoryCacheChanges() ||
       !m_allocated_memory_cache.IsInCache(addr))
     m_mod_id.BumpMemoryID();
 #else

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -298,7 +298,7 @@ let Definition = "process" in {
     Desc<"Debugger's behavior upon fork or vfork.">;
   def TrackMemoryCacheChanges: Property<"track-memory-cache-changes", "Boolean">,
     DefaultTrue,
-    Desc<"If true, memory cache modifications (which happen often during expressions evaluation) will bump process state ID (and invalidate all synthetic children). Disabling this option helps to avoid synthetic children reevaluation when pretty printers heavily use expressions, but convenience variables won't reevaluate synthetic children automatically.">;
+    Desc<"If true, memory cache modifications (which happen often during expressions evaluation) will bump process state ID (and invalidate all synthetic children). Disabling this option helps to avoid synthetic children reevaluation when pretty printers heavily use expressions. The downside of disabled setting is that convenience variables won't reevaluate synthetic children automatically.">;
 }
 
 let Definition = "platform" in {

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -296,7 +296,7 @@ let Definition = "process" in {
     DefaultEnumValue<"eFollowParent">,
     EnumValues<"OptionEnumValues(g_follow_fork_mode_values)">,
     Desc<"Debugger's behavior upon fork or vfork.">;
-  def ProcessStateTracksMemoryCache: Property<"process-state-tracks-memory-cache", "Boolean">,
+  def TrackMemoryCacheChanges: Property<"track-memory-cache-changes", "Boolean">,
     DefaultTrue,
     Desc<"If true, memory cache modifications (which happen often during expressions evaluation) will bump process state ID (and invalidate all synthetic children). Disabling this option helps to avoid synthetic children reevaluation when pretty printers heavily use expressions, but convenience variables won't reevaluate synthetic children automatically.">;
 }

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -296,6 +296,9 @@ let Definition = "process" in {
     DefaultEnumValue<"eFollowParent">,
     EnumValues<"OptionEnumValues(g_follow_fork_mode_values)">,
     Desc<"Debugger's behavior upon fork or vfork.">;
+  def ProcessStateTracksMemoryCache: Property<"process-state-tracks-memory-cache", "Boolean">,
+    DefaultTrue,
+    Desc<"If true, memory cache modifications (which happen often during expressions evaluation) will bump process state ID (and invalidate all synthetic children). Disabling this option helps to avoid synthetic children reevaluation when pretty printers heavily use expressions, but convenience variables won't reevaluate synthetic children automatically.">;
 }
 
 let Definition = "platform" in {

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -907,6 +907,7 @@ class SettingsCommandTestCase(TestBase):
                 "target.process.extra-startup-command",
                 "target.process.thread.trace-thread",
                 "target.process.thread.step-avoid-regexp",
+                "target.process.process-state-tracks-memory-cache",
             ],
         )
 

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -905,7 +905,7 @@ class SettingsCommandTestCase(TestBase):
                 "target.use-hex-immediates",
                 "target.process.disable-memory-cache",
                 "target.process.extra-startup-command",
-                "target.process.process-state-tracks-memory-cache",
+                "target.process.track-memory-cache-changes",
                 "target.process.thread.trace-thread",
                 "target.process.thread.step-avoid-regexp",
             ],

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -905,9 +905,9 @@ class SettingsCommandTestCase(TestBase):
                 "target.use-hex-immediates",
                 "target.process.disable-memory-cache",
                 "target.process.extra-startup-command",
+                "target.process.process-state-tracks-memory-cache",
                 "target.process.thread.trace-thread",
                 "target.process.thread.step-avoid-regexp",
-                "target.process.process-state-tracks-memory-cache",
             ],
         )
 

--- a/lldb/test/Shell/Expr/TestExprWithSideEffect.cpp
+++ b/lldb/test/Shell/Expr/TestExprWithSideEffect.cpp
@@ -1,0 +1,82 @@
+// Tests evaluating expressions with side effects.
+// Applied side effect should be visible to the debugger.
+
+// RUN: %build %s -o %t
+// RUN: %lldb %t -o run \
+// RUN:   -o "frame variable x" \
+// RUN:   -o "expr x.inc()" \
+// RUN:   -o "frame variable x" \
+// RUN:   -o "continue" \
+// RUN:   -o "frame variable x" \
+// RUN:   -o "expr x.i = 10" \
+// RUN:   -o "frame variable x" \
+// RUN:   -o "continue" \
+// RUN:   -o "frame variable x" \
+// RUN:   -o "expr int $y = 11" \
+// RUN:   -o "expr $y" \
+// RUN:   -o "expr $y = 100" \
+// RUN:   -o "expr $y" \
+// RUN:   -o "continue" \
+// RUN:   -o "expr $y" \
+// RUN:   -o exit | FileCheck %s -dump-input=fail
+
+class X
+{
+  int i = 0;
+public:
+  void inc()
+  {
+    ++i;
+  }
+};
+
+int main()
+{
+  X x;
+  x.inc();
+
+  __builtin_debugtrap();
+  __builtin_debugtrap();
+  __builtin_debugtrap();
+  __builtin_debugtrap();
+  return 0;
+}
+
+// CHECK-LABEL: frame variable x
+// CHECK: (X) x = (i = 1)
+
+// CHECK-LABEL: expr x.inc()
+// CHECK-LABEL: frame variable x
+// CHECK: (X) x = (i = 2)
+
+// CHECK-LABEL: continue
+// CHECK-LABEL: frame variable x
+// CHECK: (X) x = (i = 2)
+
+
+
+// CHECK-LABEL: expr x.i = 10
+// CHECK: (int) $0 = 10
+
+// CHECK-LABEL: frame variable x
+// CHECK: (X) x = (i = 10)
+
+// CHECK-LABEL: continue
+// CHECK-LABEL: frame variable x
+// CHECK: (X) x = (i = 10)
+
+
+
+// CHECK-LABEL: expr int $y = 11
+// CHECK-LABEL: expr $y
+// CHECK: (int) $y = 11
+
+// CHECK-LABEL: expr $y = 100
+// CHECK: (int) $1 = 100
+
+// CHECK-LABEL: expr $y
+// CHECK: (int) $y = 100
+
+// CHECK-LABEL: continue
+// CHECK-LABEL: expr $y
+// CHECK: (int) $y = 100

--- a/lldb/test/Shell/Expr/TestExprWithSideEffect.cpp
+++ b/lldb/test/Shell/Expr/TestExprWithSideEffect.cpp
@@ -12,30 +12,19 @@
 // RUN:   -o "frame variable x" \
 // RUN:   -o "continue" \
 // RUN:   -o "frame variable x" \
-// RUN:   -o "expr int $y = 11" \
-// RUN:   -o "expr $y" \
-// RUN:   -o "expr $y = 100" \
-// RUN:   -o "expr $y" \
-// RUN:   -o "continue" \
-// RUN:   -o "expr $y" \
 // RUN:   -o exit | FileCheck %s -dump-input=fail
 
-class X
-{
+class X {
   int i = 0;
+
 public:
-  void inc()
-  {
-    ++i;
-  }
+  void inc() { ++i; }
 };
 
-int main()
-{
+int main() {
   X x;
   x.inc();
 
-  __builtin_debugtrap();
   __builtin_debugtrap();
   __builtin_debugtrap();
   __builtin_debugtrap();
@@ -53,8 +42,6 @@ int main()
 // CHECK-LABEL: frame variable x
 // CHECK: (X) x = (i = 2)
 
-
-
 // CHECK-LABEL: expr x.i = 10
 // CHECK: (int) $0 = 10
 
@@ -64,19 +51,3 @@ int main()
 // CHECK-LABEL: continue
 // CHECK-LABEL: frame variable x
 // CHECK: (X) x = (i = 10)
-
-
-
-// CHECK-LABEL: expr int $y = 11
-// CHECK-LABEL: expr $y
-// CHECK: (int) $y = 11
-
-// CHECK-LABEL: expr $y = 100
-// CHECK: (int) $1 = 100
-
-// CHECK-LABEL: expr $y
-// CHECK: (int) $y = 100
-
-// CHECK-LABEL: continue
-// CHECK-LABEL: expr $y
-// CHECK: (int) $y = 100

--- a/lldb/test/Shell/Expr/TestExprWithSideEffect.cpp
+++ b/lldb/test/Shell/Expr/TestExprWithSideEffect.cpp
@@ -2,7 +2,9 @@
 // Applied side effect should be visible to the debugger.
 
 // RUN: %build %s -o %t
-// RUN: %lldb %t -o run \
+// RUN: %lldb %t \
+// RUN:   -o "settings set target.process.process-state-tracks-memory-cache false" \
+// RUN:   -o "run" \
 // RUN:   -o "frame variable x" \
 // RUN:   -o "expr x.inc()" \
 // RUN:   -o "frame variable x" \
@@ -12,7 +14,7 @@
 // RUN:   -o "frame variable x" \
 // RUN:   -o "continue" \
 // RUN:   -o "frame variable x" \
-// RUN:   -o exit | FileCheck %s -dump-input=fail
+// RUN:   -o "exit" | FileCheck %s -dump-input=fail
 
 class X {
   int i = 0;

--- a/lldb/test/Shell/Expr/TestExprWithSideEffect.cpp
+++ b/lldb/test/Shell/Expr/TestExprWithSideEffect.cpp
@@ -3,7 +3,7 @@
 
 // RUN: %build %s -o %t
 // RUN: %lldb %t \
-// RUN:   -o "settings set target.process.process-state-tracks-memory-cache false" \
+// RUN:   -o "settings set target.process.track-memory-cache-changes false" \
 // RUN:   -o "run" \
 // RUN:   -o "frame variable x" \
 // RUN:   -o "expr x.inc()" \

--- a/lldb/test/Shell/Expr/TestExprWithSideEffectOnConvenienceVar.cpp
+++ b/lldb/test/Shell/Expr/TestExprWithSideEffectOnConvenienceVar.cpp
@@ -1,0 +1,48 @@
+// Tests evaluating expressions with side effects on convenience variable.
+// Applied side effect should be visible to the debugger.
+
+// RUN: %build %s -o %t
+// RUN: %lldb %t -o run \
+// RUN:   -o "expr int $y = 11" \
+// RUN:   -o "expr $y" \
+// RUN:   -o "expr $y = 100" \
+// RUN:   -o "expr $y" \
+// RUN:   -o "continue" \
+// RUN:   -o "expr $y" \
+// RUN:   -o "expr X $mine = {100, 200}" \
+// RUN:   -o "expr $mine.a = 300" \
+// RUN:   -o "expr $mine" \
+// RUN:   -o exit | FileCheck %s -dump-input=fail
+
+struct X {
+  int a;
+  int b;
+};
+
+int main() {
+  X x;
+
+  __builtin_debugtrap();
+  __builtin_debugtrap();
+  return 0;
+}
+
+// CHECK-LABEL: expr int $y = 11
+// CHECK-LABEL: expr $y
+// CHECK: (int) $y = 11
+
+// CHECK-LABEL: expr $y = 100
+// CHECK: (int) $0 = 100
+
+// CHECK-LABEL: expr $y
+// CHECK: (int) $y = 100
+
+// CHECK-LABEL: continue
+// CHECK-LABEL: expr $y
+// CHECK: (int) $y = 100
+
+// CHECK-LABEL: expr X $mine = {100, 200}
+// CHECK-LABEL: expr $mine.a = 300
+// CHECK: (int) $1 = 300
+// CHECK-LABEL: expr $mine
+// CHECK: (X) $mine = (a = 300, b = 200)

--- a/lldb/test/Shell/Expr/TestExprWithSideEffectOnConvenienceVar.cpp
+++ b/lldb/test/Shell/Expr/TestExprWithSideEffectOnConvenienceVar.cpp
@@ -5,7 +5,7 @@
 
 // RUN: %build %s -o %t
 // RUN: %lldb %t \
-// RUN:   -o "settings set target.process.process-state-tracks-memory-cache false" \
+// RUN:   -o "settings set target.process.track-memory-cache-changes false" \
 // RUN:   -o "run" \
 // RUN:   -o "expr int \$y = 11" \
 // RUN:   -o "expr \$y" \

--- a/lldb/test/Shell/Expr/TestExprWithSideEffectOnConvenienceVar.cpp
+++ b/lldb/test/Shell/Expr/TestExprWithSideEffectOnConvenienceVar.cpp
@@ -4,7 +4,9 @@
 // UNSUPPORTED: system-windows
 
 // RUN: %build %s -o %t
-// RUN: %lldb %t -o run \
+// RUN: %lldb %t \
+// RUN:   -o "settings set target.process.process-state-tracks-memory-cache false" \
+// RUN:   -o "run" \
 // RUN:   -o "expr int \$y = 11" \
 // RUN:   -o "expr \$y" \
 // RUN:   -o "expr \$y = 100" \
@@ -14,7 +16,7 @@
 // RUN:   -o "expr X \$mine = {100, 200}" \
 // RUN:   -o "expr \$mine.a = 300" \
 // RUN:   -o "expr \$mine" \
-// RUN:   -o exit | FileCheck %s -dump-input=fail
+// RUN:   -o "exit" | FileCheck %s -dump-input=fail
 
 struct X {
   int a;

--- a/lldb/test/Shell/Expr/TestExprWithSideEffectOnConvenienceVarWindows.cpp
+++ b/lldb/test/Shell/Expr/TestExprWithSideEffectOnConvenienceVarWindows.cpp
@@ -4,7 +4,7 @@
 
 // RUN: %build %s -o %t
 // RUN: %lldb %t \
-// RUN:   -o "settings set target.process.process-state-tracks-memory-cache false" \
+// RUN:   -o "settings set target.process.track-memory-cache-changes false" \
 // RUN:   -o "run" \
 // RUN:   -o "expr int $y = 11" \
 // RUN:   -o "expr $y" \

--- a/lldb/test/Shell/Expr/TestExprWithSideEffectOnConvenienceVarWindows.cpp
+++ b/lldb/test/Shell/Expr/TestExprWithSideEffectOnConvenienceVarWindows.cpp
@@ -3,7 +3,9 @@
 // REQUIRES: target-windows
 
 // RUN: %build %s -o %t
-// RUN: %lldb %t -o run \
+// RUN: %lldb %t \
+// RUN:   -o "settings set target.process.process-state-tracks-memory-cache false" \
+// RUN:   -o "run" \
 // RUN:   -o "expr int $y = 11" \
 // RUN:   -o "expr $y" \
 // RUN:   -o "expr $y = 100" \
@@ -13,7 +15,7 @@
 // RUN:   -o "expr X $mine = {100, 200}" \
 // RUN:   -o "expr $mine.a = 300" \
 // RUN:   -o "expr $mine" \
-// RUN:   -o exit | FileCheck %s -dump-input=fail
+// RUN:   -o "exit" | FileCheck %s -dump-input=fail
 
 struct X {
   int a;

--- a/lldb/test/Shell/Expr/TestExprWithSideEffectOnConvenienceVarWindows.cpp
+++ b/lldb/test/Shell/Expr/TestExprWithSideEffectOnConvenienceVarWindows.cpp
@@ -1,19 +1,18 @@
-// Tests evaluating expressions with side effects on convenience variable.
-// Applied side effect should be visible to the debugger.
+// Same as TestExprWithSideEffectOnConvenienceVar.cpp but without $ escaping
 
-// UNSUPPORTED: system-windows
+// REQUIRES: target-windows
 
 // RUN: %build %s -o %t
 // RUN: %lldb %t -o run \
-// RUN:   -o "expr int \$y = 11" \
-// RUN:   -o "expr \$y" \
-// RUN:   -o "expr \$y = 100" \
-// RUN:   -o "expr \$y" \
+// RUN:   -o "expr int $y = 11" \
+// RUN:   -o "expr $y" \
+// RUN:   -o "expr $y = 100" \
+// RUN:   -o "expr $y" \
 // RUN:   -o "continue" \
-// RUN:   -o "expr \$y" \
-// RUN:   -o "expr X \$mine = {100, 200}" \
-// RUN:   -o "expr \$mine.a = 300" \
-// RUN:   -o "expr \$mine" \
+// RUN:   -o "expr $y" \
+// RUN:   -o "expr X $mine = {100, 200}" \
+// RUN:   -o "expr $mine.a = 300" \
+// RUN:   -o "expr $mine" \
 // RUN:   -o exit | FileCheck %s -dump-input=fail
 
 struct X {

--- a/lldb/test/Shell/Expr/TestProcessModIdOnExpr.cpp
+++ b/lldb/test/Shell/Expr/TestProcessModIdOnExpr.cpp
@@ -1,0 +1,64 @@
+// Tests that ProcessModID.m_memory_id is not bumped when evaluating expressions without side effects.
+
+// RUN: %build %s -o %t
+// RUN: %lldb %t \
+// RUN:   -o "settings set target.process.process-state-tracks-memory-cache false" \
+// RUN:   -o "run" \
+// RUN:   -o "process dump-mod-id" \
+// RUN:   -o "expr x.i != 42" \
+// RUN:   -o "process dump-mod-id" \
+// RUN:   -o "expr x.get()" \
+// RUN:   -o "process dump-mod-id" \
+// RUN:   -o "expr x.i = 10" \
+// RUN:   -o "process dump-mod-id" \
+// RUN:   -o "continue" \
+// RUN:   -o "process dump-mod-id" \
+// RUN:   -o "exit" | FileCheck %s -dump-input=fail
+
+class X {
+  int i = 0;
+
+public:
+  int get() { return i; }
+};
+
+int main() {
+  X x;
+  x.get();
+
+  __builtin_debugtrap();
+  __builtin_debugtrap();
+  return 0;
+}
+
+// CHECK-LABEL: process dump-mod-id
+// CHECK: m_stop_id: 2
+// CHECK: m_memory_id: 0
+
+// CHECK-LABEL: expr x.i != 42
+// IDs are not changed when executing simple expressions
+
+// CHECK-LABEL: process dump-mod-id
+// CHECK: m_stop_id: 2
+// CHECK: m_memory_id: 0
+
+// CHECK-LABEL: expr x.get()
+// Expression causes ID to be bumped because LLDB has to execute function
+
+// CHECK-LABEL: process dump-mod-id
+// CHECK: m_stop_id: 3
+// CHECK: m_memory_id: 1
+
+// CHECK-LABEL: expr x.i = 10
+// Expression causes MemoryID to be bumped because LLDB writes to non-cache memory
+
+// CHECK-LABEL: process dump-mod-id
+// CHECK: m_stop_id: 3
+// CHECK: m_memory_id: 2
+
+// CHECK-LABEL: continue
+// Continue causes StopID to be bumped because process is resumed
+
+// CHECK-LABEL: process dump-mod-id
+// CHECK: m_stop_id: 4
+// CHECK: m_memory_id: 2

--- a/lldb/test/Shell/Expr/TestProcessModIdOnExpr.cpp
+++ b/lldb/test/Shell/Expr/TestProcessModIdOnExpr.cpp
@@ -1,5 +1,8 @@
 // Tests that ProcessModID.m_memory_id is not bumped when evaluating expressions without side effects.
 
+// REQUIRES: target-windows
+// Due to different implementations exact numbers (m_stop_id) are different on different OSs. So we lock this test to specific platform.
+
 // RUN: %build %s -o %t
 // RUN: %lldb %t \
 // RUN:   -o "settings set target.process.track-memory-cache-changes false" \

--- a/lldb/test/Shell/Expr/TestProcessModIdOnExpr.cpp
+++ b/lldb/test/Shell/Expr/TestProcessModIdOnExpr.cpp
@@ -2,7 +2,7 @@
 
 // RUN: %build %s -o %t
 // RUN: %lldb %t \
-// RUN:   -o "settings set target.process.process-state-tracks-memory-cache false" \
+// RUN:   -o "settings set target.process.track-memory-cache-changes false" \
 // RUN:   -o "run" \
 // RUN:   -o "process dump-mod-id" \
 // RUN:   -o "expr x.i != 42" \

--- a/lldb/test/Shell/Expr/TestProcessModificationIdOnExpr.cpp
+++ b/lldb/test/Shell/Expr/TestProcessModificationIdOnExpr.cpp
@@ -7,15 +7,15 @@
 // RUN: %lldb %t \
 // RUN:   -o "settings set target.process.track-memory-cache-changes false" \
 // RUN:   -o "run" \
-// RUN:   -o "process dump-modification-id" \
+// RUN:   -o "process status -d" \
 // RUN:   -o "expr x.i != 42" \
-// RUN:   -o "process dump-modification-id" \
+// RUN:   -o "process status -d" \
 // RUN:   -o "expr x.get()" \
-// RUN:   -o "process dump-modification-id" \
+// RUN:   -o "process status -d" \
 // RUN:   -o "expr x.i = 10" \
-// RUN:   -o "process dump-modification-id" \
+// RUN:   -o "process status -d" \
 // RUN:   -o "continue" \
-// RUN:   -o "process dump-modification-id" \
+// RUN:   -o "process status -d" \
 // RUN:   -o "exit" | FileCheck %s -dump-input=fail
 
 class X {
@@ -34,34 +34,34 @@ int main() {
   return 0;
 }
 
-// CHECK-LABEL: process dump-modification-id
+// CHECK-LABEL: process status -d
 // CHECK: m_stop_id: 2
 // CHECK: m_memory_id: 0
 
 // CHECK-LABEL: expr x.i != 42
 // IDs are not changed when executing simple expressions
 
-// CHECK-LABEL: process dump-modification-id
+// CHECK-LABEL: process status -d
 // CHECK: m_stop_id: 2
 // CHECK: m_memory_id: 0
 
 // CHECK-LABEL: expr x.get()
 // Expression causes ID to be bumped because LLDB has to execute function
 
-// CHECK-LABEL: process dump-modification-id
+// CHECK-LABEL: process status -d
 // CHECK: m_stop_id: 3
 // CHECK: m_memory_id: 1
 
 // CHECK-LABEL: expr x.i = 10
 // Expression causes MemoryID to be bumped because LLDB writes to non-cache memory
 
-// CHECK-LABEL: process dump-modification-id
+// CHECK-LABEL: process status -d
 // CHECK: m_stop_id: 3
 // CHECK: m_memory_id: 2
 
 // CHECK-LABEL: continue
 // Continue causes StopID to be bumped because process is resumed
 
-// CHECK-LABEL: process dump-modification-id
+// CHECK-LABEL: process status -d
 // CHECK: m_stop_id: 4
 // CHECK: m_memory_id: 2

--- a/lldb/test/Shell/Expr/TestProcessModificationIdOnExpr.cpp
+++ b/lldb/test/Shell/Expr/TestProcessModificationIdOnExpr.cpp
@@ -7,15 +7,15 @@
 // RUN: %lldb %t \
 // RUN:   -o "settings set target.process.track-memory-cache-changes false" \
 // RUN:   -o "run" \
-// RUN:   -o "process dump-mod-id" \
+// RUN:   -o "process dump-modification-id" \
 // RUN:   -o "expr x.i != 42" \
-// RUN:   -o "process dump-mod-id" \
+// RUN:   -o "process dump-modification-id" \
 // RUN:   -o "expr x.get()" \
-// RUN:   -o "process dump-mod-id" \
+// RUN:   -o "process dump-modification-id" \
 // RUN:   -o "expr x.i = 10" \
-// RUN:   -o "process dump-mod-id" \
+// RUN:   -o "process dump-modification-id" \
 // RUN:   -o "continue" \
-// RUN:   -o "process dump-mod-id" \
+// RUN:   -o "process dump-modification-id" \
 // RUN:   -o "exit" | FileCheck %s -dump-input=fail
 
 class X {
@@ -34,34 +34,34 @@ int main() {
   return 0;
 }
 
-// CHECK-LABEL: process dump-mod-id
+// CHECK-LABEL: process dump-modification-id
 // CHECK: m_stop_id: 2
 // CHECK: m_memory_id: 0
 
 // CHECK-LABEL: expr x.i != 42
 // IDs are not changed when executing simple expressions
 
-// CHECK-LABEL: process dump-mod-id
+// CHECK-LABEL: process dump-modification-id
 // CHECK: m_stop_id: 2
 // CHECK: m_memory_id: 0
 
 // CHECK-LABEL: expr x.get()
 // Expression causes ID to be bumped because LLDB has to execute function
 
-// CHECK-LABEL: process dump-mod-id
+// CHECK-LABEL: process dump-modification-id
 // CHECK: m_stop_id: 3
 // CHECK: m_memory_id: 1
 
 // CHECK-LABEL: expr x.i = 10
 // Expression causes MemoryID to be bumped because LLDB writes to non-cache memory
 
-// CHECK-LABEL: process dump-mod-id
+// CHECK-LABEL: process dump-modification-id
 // CHECK: m_stop_id: 3
 // CHECK: m_memory_id: 2
 
 // CHECK-LABEL: continue
 // Continue causes StopID to be bumped because process is resumed
 
-// CHECK-LABEL: process dump-mod-id
+// CHECK-LABEL: process dump-modification-id
 // CHECK: m_stop_id: 4
 // CHECK: m_memory_id: 2


### PR DESCRIPTION
This change adds a setting `target.process.track-memory-cache-changes`.
Disabling this setting prevents invalidating and updating values in `ValueObject::UpdateValueIfNeeded` when only "internal" debugger memory is updated. Writing to "internal" debugger memory happens when, for instance, expressions are evaluated by visualizers (pretty printers).
One of the examples when cache invalidation has a particularly heavy impact is visualizations of some collections: in some collections getting collection size is an expensive operation (it requires traversal of the collection).
At the same time evaluating user expression with side effects (visible to target, not only to debugger) will still bump memory ID because:

- If expression is evaluated via interpreter: it will cause write to "non-internal" memory
- If expression is JIT-compiled: then to call the function LLDB will write to "non-internal" stack memory

The downside of disabled `target.process.track-memory-cache-changes` setting is that convenience variables won't reevaluate synthetic children automatically.