### PR TITLE
[flang][runtime] Detect byte order reversal problems

### DIFF
--- a/flang-rt/lib/runtime/unit.h
+++ b/flang-rt/lib/runtime/unit.h
@@ -210,7 +210,7 @@ private:
   RT_API_ATTRS void CommitWrites();
   RT_API_ATTRS bool CheckDirectAccess(IoErrorHandler &);
   RT_API_ATTRS void HitEndOnRead(IoErrorHandler &);
-  RT_API_ATTRS std::int32_t ReadHeaderOrFooter(std::int64_t frameOffset);
+  RT_API_ATTRS std::uint32_t ReadHeaderOrFooter(std::int64_t frameOffset);
 
   Lock lock_;
 


### PR DESCRIPTION
When reading an unformatted sequential file with variable-length records, detect byte order reversal problems with the first record's header and footer words, and emit a more detailed error message.