### PR TITLE
[RISCV] Order the implicit defs/uses of vl/vtype on MC instructions the same as the pseudo version.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrFormatsV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrFormatsV.td
@@ -120,7 +120,7 @@ class RVInstVV<bits<6> funct6, RISCVVFormat opv, dag outs, dag ins,
   let Inst{11-7} = vd;
   let Inst{6-0} = OPC_OP_V.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let RVVConstraint = VMConstraint;
 }
 
@@ -140,7 +140,7 @@ class RVInstVX<bits<6> funct6, RISCVVFormat opv, dag outs, dag ins,
   let Inst{11-7} = vd;
   let Inst{6-0} = OPC_OP_V.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let RVVConstraint = VMConstraint;
 }
 
@@ -159,7 +159,7 @@ class RVInstV2<bits<6> funct6, bits<5> vs2, RISCVVFormat opv, dag outs, dag ins,
   let Inst{11-7} = vd;
   let Inst{6-0} = OPC_OP_V.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let RVVConstraint = VMConstraint;
 }
 
@@ -179,7 +179,7 @@ class RVInstIVI<bits<6> funct6, dag outs, dag ins, string opcodestr,
   let Inst{11-7} = vd;
   let Inst{6-0} = OPC_OP_V.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let RVVConstraint = VMConstraint;
 }
 
@@ -198,7 +198,7 @@ class RVInstV<bits<6> funct6, bits<5> vs1, RISCVVFormat opv, dag outs,
   let Inst{11-7} = vd;
   let Inst{6-0} = OPC_OP_V.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let RVVConstraint = VMConstraint;
 }
 
@@ -220,7 +220,7 @@ class RVInstVLU<bits<3> nf, bit mew, RISCVLSUMOP lumop,
   let Inst{11-7} = vd;
   let Inst{6-0} = OPC_LOAD_FP.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let RVVConstraint = VMConstraint;
 }
 
@@ -242,7 +242,7 @@ class RVInstVLS<bits<3> nf, bit mew, bits<3> width,
   let Inst{11-7} = vd;
   let Inst{6-0} = OPC_LOAD_FP.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let RVVConstraint = VMConstraint;
 }
 
@@ -264,7 +264,7 @@ class RVInstVLX<bits<3> nf, bit mew, RISCVMOP mop, bits<3> width,
   let Inst{11-7} = vd;
   let Inst{6-0} = OPC_LOAD_FP.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let RVVConstraint = VMConstraint;
 }
 
@@ -286,7 +286,7 @@ class RVInstVSU<bits<3> nf, bit mew, RISCVLSUMOP sumop,
   let Inst{11-7} = vs3;
   let Inst{6-0} = OPC_STORE_FP.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
 }
 
 class RVInstVSS<bits<3> nf, bit mew, bits<3> width,
@@ -307,7 +307,7 @@ class RVInstVSS<bits<3> nf, bit mew, bits<3> width,
   let Inst{11-7} = vs3;
   let Inst{6-0} = OPC_STORE_FP.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
 }
 
 class RVInstVSX<bits<3> nf, bit mew, RISCVMOP mop, bits<3> width,
@@ -328,5 +328,5 @@ class RVInstVSX<bits<3> nf, bit mew, RISCVMOP mop, bits<3> width,
   let Inst{11-7} = vs3;
   let Inst{6-0} = OPC_STORE_FP.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
 }

--- a/llvm/lib/Target/RISCV/RISCVInstrFormatsV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrFormatsV.td
@@ -68,7 +68,7 @@ class RVInstSetiVLi<dag outs, dag ins, string opcodestr, string argstr>
   let Inst{11-7} = rd;
   let Inst{6-0} = OPC_OP_V.Value;
 
-  let Defs = [VTYPE, VL];
+  let Defs = [VL, VTYPE];
 }
 
 class RVInstSetVLi<dag outs, dag ins, string opcodestr, string argstr>
@@ -84,7 +84,7 @@ class RVInstSetVLi<dag outs, dag ins, string opcodestr, string argstr>
   let Inst{11-7} = rd;
   let Inst{6-0} = OPC_OP_V.Value;
 
-  let Defs = [VTYPE, VL];
+  let Defs = [VL, VTYPE];
 }
 
 class RVInstSetVL<dag outs, dag ins, string opcodestr, string argstr>
@@ -101,7 +101,7 @@ class RVInstSetVL<dag outs, dag ins, string opcodestr, string argstr>
   let Inst{11-7} = rd;
   let Inst{6-0} = OPC_OP_V.Value;
 
-  let Defs = [VTYPE, VL];
+  let Defs = [VL, VTYPE];
 }
 
 class RVInstVV<bits<6> funct6, RISCVVFormat opv, dag outs, dag ins,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXRivos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXRivos.td
@@ -26,7 +26,7 @@ class CustomRivosVXI<bits<6> funct6, RISCVVFormat opv, dag outs, dag ins,
   let Inst{11-7} = vd;
   let Inst{6-0} = OPC_CUSTOM_2.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let RVVConstraint = NoConstraint;
   let Constraints = "$vd = $vd_wb";
 }
@@ -47,7 +47,7 @@ class CustomRivosXVI<bits<6> funct6, RISCVVFormat opv, dag outs, dag ins,
   let Inst{11-7} = rd;
   let Inst{6-0} = OPC_CUSTOM_2.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let RVVConstraint = NoConstraint;
 }
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXSf.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXSf.td
@@ -73,7 +73,7 @@ class RVInstVCCustom2<bits<4> funct6_hi4, bits<3> funct3, dag outs, dag ins,
   let Inst{11-7} = rd;
   let Inst{6-0} = OPC_CUSTOM_2.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let RVVConstraint = NoConstraint;
   let ElementsDependOn = EltDepsVLMask;
 }
@@ -97,7 +97,7 @@ class RVInstVCFCustom2<bits<4> funct6_hi4, bits<3> funct3, dag outs, dag ins,
   let Inst{11-7} = rd;
   let Inst{6-0} = OPC_CUSTOM_2.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let RVVConstraint = NoConstraint;
   let ElementsDependOn = EltDepsVLMask;
 }

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZvk.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZvk.td
@@ -46,7 +46,7 @@ class RVInstIVI_VROR<bits<6> funct6, dag outs, dag ins, string opcodestr,
   let Inst{11-7} = vd;
   let Inst{6-0} = OPC_OP_V.Value;
 
-  let Uses = [VTYPE, VL];
+  let Uses = [VL, VTYPE];
   let RVVConstraint = VMConstraint;
 }
 


### PR DESCRIPTION
CodeGen pseudos and the vsetvli insertion pass put VL before VTYPE. Make the MC layer instructions consistent.