### PR TITLE
[AIX] Add -pthread to build on AIX

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1182,6 +1182,7 @@ endif()
 if (UNIX AND ${CMAKE_SYSTEM_NAME} MATCHES "AIX")
           add_compile_definitions(_XOPEN_SOURCE=700)
           add_compile_definitions(_LARGE_FILE_API)
+          add_compile_options(-pthread)
 
   # Modules should be built with -shared -Wl,-G, so we can use runtime linking
   # with plugins.


### PR DESCRIPTION
When building in tree clang without having `-pthread`  we get a bunch of `Assertion failed: FD != kInvalidFile && "Invalid or inactive file descriptor"` when testing check-clang. 