### PR TITLE
[lldb-dap] Adaptor -> Adapter (NFC)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/test_categories.py
+++ b/lldb/packages/Python/lldbsuite/test/test_categories.py
@@ -31,7 +31,7 @@ all_categories = {
     "libc++": "Test for libc++ data formatters",
     "libstdcxx": "Test for libstdcxx data formatters",
     "lldb-server": "Tests related to lldb-server",
-    "lldb-dap": "Tests for the Debug Adaptor Protocol with lldb-dap",
+    "lldb-dap": "Tests for the Debug Adapter Protocol with lldb-dap",
     "llgs": "Tests for the gdb-server functionality of lldb-server",
     "pexpect": "Tests requiring the pexpect library to be available",
     "objc": "Tests related to the Objective-C programming language support",

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -76,7 +76,7 @@ def read_packet(f, verbose=False, trace_file=None):
         if verbose:
             print('json: "%s"' % (json_str))
         if trace_file:
-            trace_file.write("from adaptor:\n%s\n" % (json_str))
+            trace_file.write("from adapter:\n%s\n" % (json_str))
         # Decode the JSON bytes into a python dictionary
         return json.loads(json_str)
 
@@ -259,7 +259,7 @@ class DebugCommunication(object):
     def send_packet(self, command_dict, set_sequence=True):
         """Take the "command_dict" python dictionary and encode it as a JSON
         string and send the contents as a packet to the VSCode debug
-        adaptor"""
+        adapter"""
         # Set the sequence ID for this command automatically
         if set_sequence:
             command_dict["seq"] = self.sequence
@@ -267,7 +267,7 @@ class DebugCommunication(object):
         # Encode our command dictionary as a JSON string
         json_str = json.dumps(command_dict, separators=(",", ":"))
         if self.trace_file:
-            self.trace_file.write("to adaptor:\n%s\n" % (json_str))
+            self.trace_file.write("to adapter:\n%s\n" % (json_str))
         length = len(json_str)
         if length > 0:
             # Send the encoded JSON packet and flush the 'send' file
@@ -275,7 +275,7 @@ class DebugCommunication(object):
             self.send.flush()
 
     def recv_packet(self, filter_type=None, filter_event=None, timeout=None):
-        """Get a JSON packet from the VSCode debug adaptor. This function
+        """Get a JSON packet from the VSCode debug adapter. This function
         assumes a thread that reads packets is running and will deliver
         any received packets by calling handle_recv_packet(...). This
         function will wait for the packet to arrive and return it when
@@ -1184,7 +1184,7 @@ class DebugCommunication(object):
         return self.send_recv(command_dict)
 
 
-class DebugAdaptorServer(DebugCommunication):
+class DebugAdapterServer(DebugCommunication):
     def __init__(
         self,
         executable=None,
@@ -1196,7 +1196,7 @@ class DebugAdaptorServer(DebugCommunication):
         self.process = None
         self.connection = None
         if executable is not None:
-            process, connection = DebugAdaptorServer.launch(
+            process, connection = DebugAdapterServer.launch(
                 executable=executable, connection=connection, env=env, log_file=log_file
             )
             self.process = process
@@ -1224,12 +1224,12 @@ class DebugAdaptorServer(DebugCommunication):
 
     @classmethod
     def launch(cls, /, executable, env=None, log_file=None, connection=None):
-        adaptor_env = os.environ.copy()
+        adapter_env = os.environ.copy()
         if env is not None:
-            adaptor_env.update(env)
+            adapter_env.update(env)
 
         if log_file:
-            adaptor_env["LLDBDAP_LOG"] = log_file
+            adapter_env["LLDBDAP_LOG"] = log_file
         args = [executable]
 
         if connection is not None:
@@ -1241,7 +1241,7 @@ class DebugAdaptorServer(DebugCommunication):
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            env=adaptor_env,
+            env=adapter_env,
         )
 
         if connection is None:
@@ -1271,7 +1271,7 @@ class DebugAdaptorServer(DebugCommunication):
         return -1
 
     def terminate(self):
-        super(DebugAdaptorServer, self).terminate()
+        super(DebugAdapterServer, self).terminate()
         if self.process is not None:
             self.process.terminate()
             self.process.wait()
@@ -1347,7 +1347,7 @@ def run_vscode(dbg, args, options):
 def main():
     parser = optparse.OptionParser(
         description=(
-            "A testing framework for the Visual Studio Code Debug Adaptor protocol"
+            "A testing framework for the Visual Studio Code Debug Adapter protocol"
         )
     )
 
@@ -1357,7 +1357,7 @@ def main():
         dest="vscode_path",
         help=(
             "The path to the command line program that implements the "
-            "Visual Studio Code Debug Adaptor protocol."
+            "Visual Studio Code Debug Adapter protocol."
         ),
         default=None,
     )
@@ -1407,7 +1407,7 @@ def main():
         dest="replay",
         help=(
             "Specify a file containing a packet log to replay with the "
-            "current Visual Studio Code Debug Adaptor executable."
+            "current Visual Studio Code Debug Adapter executable."
         ),
         default=None,
     )
@@ -1418,7 +1418,7 @@ def main():
         action="store_true",
         dest="debug",
         default=False,
-        help="Pause waiting for a debugger to attach to the debug adaptor",
+        help="Pause waiting for a debugger to attach to the debug adapter",
     )
 
     parser.add_option(
@@ -1581,11 +1581,11 @@ def main():
     if options.vscode_path is None and options.connection is None:
         print(
             "error: must either specify a path to a Visual Studio Code "
-            "Debug Adaptor vscode executable path using the --vscode "
+            "Debug Adapter vscode executable path using the --vscode "
             "option, or using the --connection option"
         )
         return
-    dbg = DebugAdaptorServer(
+    dbg = DebugAdapterServer(
         executable=options.vscode_path, connection=options.connection
     )
     if options.debug:

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -14,13 +14,13 @@ class DAPTestCaseBase(TestBase):
     timeoutval = 10 * (10 if ("ASAN_OPTIONS" in os.environ) else 1)
     NO_DEBUG_INFO_TESTCASE = True
 
-    def create_debug_adaptor(self, lldbDAPEnv=None, connection=None):
-        """Create the Visual Studio Code debug adaptor"""
+    def create_debug_adapter(self, lldbDAPEnv=None, connection=None):
+        """Create the Visual Studio Code debug adapter"""
         self.assertTrue(
             is_exe(self.lldbDAPExec), "lldb-dap must exist and be executable"
         )
         log_file_path = self.getBuildArtifact("dap.txt")
-        self.dap_server = dap_server.DebugAdaptorServer(
+        self.dap_server = dap_server.DebugAdapterServer(
             executable=self.lldbDAPExec,
             connection=connection,
             init_commands=self.setUpCommands(),
@@ -28,9 +28,9 @@ class DAPTestCaseBase(TestBase):
             env=lldbDAPEnv,
         )
 
-    def build_and_create_debug_adaptor(self, lldbDAPEnv=None):
+    def build_and_create_debug_adapter(self, lldbDAPEnv=None):
         self.build()
-        self.create_debug_adaptor(lldbDAPEnv)
+        self.create_debug_adapter(lldbDAPEnv)
 
     def set_source_breakpoints(self, source_path, lines, data=None):
         """Sets source breakpoints and returns an array of strings containing
@@ -324,11 +324,11 @@ class DAPTestCaseBase(TestBase):
         gdbRemotePort=None,
         gdbRemoteHostname=None,
     ):
-        """Build the default Makefile target, create the DAP debug adaptor,
+        """Build the default Makefile target, create the DAP debug adapter,
         and attach to the process.
         """
 
-        # Make sure we disconnect and terminate the DAP debug adaptor even
+        # Make sure we disconnect and terminate the DAP debug adapter even
         # if we throw an exception during the test case.
         def cleanup():
             if disconnectAutomatically:
@@ -479,10 +479,10 @@ class DAPTestCaseBase(TestBase):
         launchCommands=None,
         expectFailure=False,
     ):
-        """Build the default Makefile target, create the DAP debug adaptor,
+        """Build the default Makefile target, create the DAP debug adapter,
         and launch the process.
         """
-        self.build_and_create_debug_adaptor(lldbDAPEnv)
+        self.build_and_create_debug_adapter(lldbDAPEnv)
         self.assertTrue(os.path.exists(program), "executable must exist")
 
         return self.launch(

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -44,7 +44,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         """
         Tests attaching to a process by process ID.
         """
-        self.build_and_create_debug_adaptor()
+        self.build_and_create_debug_adapter()
         program = self.getBuildArtifact("a.out")
         self.process = subprocess.Popen(
             [program],
@@ -60,7 +60,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         """
         Tests attaching to a process by process name.
         """
-        self.build_and_create_debug_adaptor()
+        self.build_and_create_debug_adapter()
         orig_program = self.getBuildArtifact("a.out")
         # Since we are going to attach by process name, we need a unique
         # process name that has minimal chance to match a process that is
@@ -101,7 +101,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         next instance of a process to be launched, ingoring all current
         ones.
         """
-        self.build_and_create_debug_adaptor()
+        self.build_and_create_debug_adapter()
         program = self.getBuildArtifact("a.out")
         self.spawn_thread = threading.Thread(
             target=spawn_and_wait,
@@ -137,7 +137,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         "terminateCommands" are a list of LLDB commands that get executed when
         the debugger session terminates.
         """
-        self.build_and_create_debug_adaptor()
+        self.build_and_create_debug_adapter()
         program = self.getBuildArtifact("a.out")
         # Here we just create a target and launch the process as a way to test
         # if we are able to use attach commands to create any kind of a target
@@ -211,7 +211,7 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         Tests that the "terminateCommands", that can be passed during
         attach, are run when the debugger is disconnected.
         """
-        self.build_and_create_debug_adaptor()
+        self.build_and_create_debug_adapter()
         program = self.getBuildArtifact("a.out")
         # Here we just create a target and launch the process as a way to test
         # if we are able to use attach commands to create any kind of a target

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attachByPortNum.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attachByPortNum.py
@@ -60,7 +60,7 @@ class TestDAP_attachByPortNum(lldbdap_testcase.DAPTestCaseBase):
         """
         Tests attaching to a process by port.
         """
-        self.build_and_create_debug_adaptor()
+        self.build_and_create_debug_adapter()
         program = self.getBuildArtifact("a.out")
 
         debug_server_tool = self.getBuiltinDebugServerTool()
@@ -92,7 +92,7 @@ class TestDAP_attachByPortNum(lldbdap_testcase.DAPTestCaseBase):
         """
         Tests attaching to a process by process ID and port number.
         """
-        self.build_and_create_debug_adaptor()
+        self.build_and_create_debug_adapter()
         program = self.getBuildArtifact("a.out")
 
         # It is not necessary to launch "lldb-server" to obtain the actual port and pid for attaching.
@@ -120,7 +120,7 @@ class TestDAP_attachByPortNum(lldbdap_testcase.DAPTestCaseBase):
         """
         Tests attaching to a process by invalid port number 0.
         """
-        self.build_and_create_debug_adaptor()
+        self.build_and_create_debug_adapter()
         program = self.getBuildArtifact("a.out")
 
         port = 0
@@ -139,7 +139,7 @@ class TestDAP_attachByPortNum(lldbdap_testcase.DAPTestCaseBase):
         """
         Tests attaching to a process by illegal/greater port number 65536
         """
-        self.build_and_create_debug_adaptor()
+        self.build_and_create_debug_adapter()
         program = self.getBuildArtifact("a.out")
 
         port = 65536

--- a/lldb/test/API/tools/lldb-dap/breakpoint-events/TestDAP_breakpointEvents.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint-events/TestDAP_breakpointEvents.py
@@ -41,7 +41,7 @@ class TestDAP_breakpointEvents(lldbdap_testcase.DAPTestCaseBase):
         foo_bp1_line = line_number("foo.cpp", "foo breakpoint 1")
         foo_bp2_line = line_number("foo.cpp", "foo breakpoint 2")
 
-        # Visual Studio Code Debug Adaptors have no way to specify the file
+        # Visual Studio Code Debug Adapters have no way to specify the file
         # without launching or attaching to a process, so we must start a
         # process in order to be able to set breakpoints.
         program = self.getBuildArtifact("a.out")

--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setBreakpoints.py
@@ -27,7 +27,7 @@ class TestDAP_setBreakpoints(lldbdap_testcase.DAPTestCaseBase):
         with the corresponding source maps to have breakpoints and frames
         working.
         """
-        self.build_and_create_debug_adaptor()
+        self.build_and_create_debug_adapter()
 
         other_basename = "other-copy.c"
         other_path = self.getBuildArtifact(other_basename)
@@ -100,7 +100,7 @@ class TestDAP_setBreakpoints(lldbdap_testcase.DAPTestCaseBase):
     @skipIfWindows
     def test_set_and_clear(self):
         """Tests setting and clearing source file and line breakpoints.
-        This packet is a bit tricky on the debug adaptor side since there
+        This packet is a bit tricky on the debug adapter side since there
         is no "clearBreakpoints" packet. Source file and line breakpoints
         are set by sending a "setBreakpoints" packet with a source file
         specified and zero or more source lines. If breakpoints have been
@@ -116,7 +116,7 @@ class TestDAP_setBreakpoints(lldbdap_testcase.DAPTestCaseBase):
         third_line = line_number("main.cpp", "break 14")
         lines = [first_line, third_line, second_line]
 
-        # Visual Studio Code Debug Adaptors have no way to specify the file
+        # Visual Studio Code Debug Adapters have no way to specify the file
         # without launching or attaching to a process, so we must start a
         # process in order to be able to set breakpoints.
         program = self.getBuildArtifact("a.out")
@@ -257,7 +257,7 @@ class TestDAP_setBreakpoints(lldbdap_testcase.DAPTestCaseBase):
             line_number("main.cpp", "break 13"),
         ]
 
-        # Visual Studio Code Debug Adaptors have no way to specify the file
+        # Visual Studio Code Debug Adapters have no way to specify the file
         # without launching or attaching to a process, so we must start a
         # process in order to be able to set breakpoints.
         program = self.getBuildArtifact("a.out")

--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setExceptionBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setExceptionBreakpoints.py
@@ -14,7 +14,7 @@ class TestDAP_setExceptionBreakpoints(lldbdap_testcase.DAPTestCaseBase):
     @skipIfWindows
     def test_functionality(self):
         """Tests setting and clearing exception breakpoints.
-        This packet is a bit tricky on the debug adaptor side since there
+        This packet is a bit tricky on the debug adapter side since there
         is no "clear exception breakpoints" packet. Exception breakpoints
         are set by sending a "setExceptionBreakpoints" packet with zero or
         more exception filters. If exception breakpoints have been set
@@ -26,7 +26,7 @@ class TestDAP_setExceptionBreakpoints(lldbdap_testcase.DAPTestCaseBase):
         and the functionality of each breakpoint, like 'conditions' and
         x'hitCondition' settings.
         """
-        # Visual Studio Code Debug Adaptors have no way to specify the file
+        # Visual Studio Code Debug Adapters have no way to specify the file
         # without launching or attaching to a process, so we must start a
         # process in order to be able to set breakpoints.
         program = self.getBuildArtifact("a.out")

--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setFunctionBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setFunctionBreakpoints.py
@@ -14,7 +14,7 @@ class TestDAP_setFunctionBreakpoints(lldbdap_testcase.DAPTestCaseBase):
     @skipIfWindows
     def test_set_and_clear(self):
         """Tests setting and clearing function breakpoints.
-        This packet is a bit tricky on the debug adaptor side since there
+        This packet is a bit tricky on the debug adapter side since there
         is no "clearFunction Breakpoints" packet. Function breakpoints
         are set by sending a "setFunctionBreakpoints" packet with zero or
         more function names. If function breakpoints have been set before,
@@ -25,7 +25,7 @@ class TestDAP_setFunctionBreakpoints(lldbdap_testcase.DAPTestCaseBase):
         correctly. It doesn't test hitting breakpoints and the functionality
         of each breakpoint, like 'conditions' and 'hitCondition' settings.
         """
-        # Visual Studio Code Debug Adaptors have no way to specify the file
+        # Visual Studio Code Debug Adapters have no way to specify the file
         # without launching or attaching to a process, so we must start a
         # process in order to be able to set breakpoints.
         program = self.getBuildArtifact("a.out")

--- a/lldb/test/API/tools/lldb-dap/commands/TestDAP_commands.py
+++ b/lldb/test/API/tools/lldb-dap/commands/TestDAP_commands.py
@@ -75,7 +75,7 @@ class TestDAP_commands(lldbdap_testcase.DAPTestCaseBase):
             "settings set target.show-hex-variable-values-with-leading-zeroes false"
         )
         command_abort_on_error = "settings set foo bar"
-        self.build_and_create_debug_adaptor()
+        self.build_and_create_debug_adapter()
         self.attach(
             program,
             attachCommands=["?!" + command_quiet, "!" + command_abort_on_error],

--- a/lldb/test/API/tools/lldb-dap/coreFile/TestDAP_coreFile.py
+++ b/lldb/test/API/tools/lldb-dap/coreFile/TestDAP_coreFile.py
@@ -18,7 +18,7 @@ class TestDAP_coreFile(lldbdap_testcase.DAPTestCaseBase):
         exe_file = os.path.join(current_dir, "linux-x86_64.out")
         core_file = os.path.join(current_dir, "linux-x86_64.core")
 
-        self.create_debug_adaptor()
+        self.create_debug_adapter()
         self.attach(exe_file, coreFile=core_file)
 
         expected_frames = [
@@ -64,7 +64,7 @@ class TestDAP_coreFile(lldbdap_testcase.DAPTestCaseBase):
         exe_file = os.path.join(current_dir, "linux-x86_64.out")
         core_file = os.path.join(current_dir, "linux-x86_64.core")
 
-        self.create_debug_adaptor()
+        self.create_debug_adapter()
 
         source_map = [["/home/labath/test", current_dir]]
         self.attach(exe_file, coreFile=core_file, sourceMap=source_map)
@@ -78,7 +78,7 @@ class TestDAP_coreFile(lldbdap_testcase.DAPTestCaseBase):
         exe_file = os.path.join(current_dir, "linux-x86_64.out")
         core_file = os.path.join(current_dir, "linux-x86_64.core")
 
-        self.create_debug_adaptor()
+        self.create_debug_adapter()
 
         source_map = {"/home/labath/test": current_dir}
         self.attach(exe_file, coreFile=core_file, sourceMap=source_map)

--- a/lldb/test/API/tools/lldb-dap/disconnect/TestDAP_disconnect.py
+++ b/lldb/test/API/tools/lldb-dap/disconnect/TestDAP_disconnect.py
@@ -52,7 +52,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         before the file is created, and as the process is not terminated upon disconnection,
         the file is created anyway.
         """
-        self.build_and_create_debug_adaptor()
+        self.build_and_create_debug_adapter()
         program = self.getBuildArtifact("a.out")
 
         # Use a file as a synchronization point between test and inferior.

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -32,7 +32,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         Tests the correct termination of lldb-dap upon a 'disconnect'
         request.
         """
-        self.create_debug_adaptor()
+        self.create_debug_adapter()
         # The underlying lldb-dap process must be alive
         self.assertEqual(self.dap_server.process.poll(), None)
 
@@ -92,7 +92,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
     def test_debuggerRoot(self):
         """
         Tests the "debuggerRoot" will change the working directory of
-        the lldb-dap debug adaptor.
+        the lldb-dap debug adapter.
         """
         program = self.getBuildArtifact("a.out")
         program_parent_dir = os.path.realpath(os.path.dirname(os.path.dirname(program)))
@@ -376,7 +376,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         """
         Tests the "launchCommands" with extra launching settings
         """
-        self.build_and_create_debug_adaptor()
+        self.build_and_create_debug_adapter()
         program = self.getBuildArtifact("a.out")
 
         source = "main.c"
@@ -440,7 +440,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         """
         Tests "launchCommands" failures prevents a launch.
         """
-        self.build_and_create_debug_adaptor()
+        self.build_and_create_debug_adapter()
         program = self.getBuildArtifact("a.out")
 
         # Run an invalid launch command, in this case a bad path.
@@ -483,7 +483,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         Tests that the "terminateCommands", that can be passed during
         launch, are run when the debugger is disconnected.
         """
-        self.build_and_create_debug_adaptor()
+        self.build_and_create_debug_adapter()
         program = self.getBuildArtifact("a.out")
 
         terminateCommands = ["expr 4+2"]

--- a/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
+++ b/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
@@ -118,7 +118,7 @@ class TestDAP_runInTerminal(lldbdap_testcase.DAPTestCaseBase):
     def test_runInTerminalInvalidTarget(self):
         if not self.isTestSupported():
             return
-        self.build_and_create_debug_adaptor()
+        self.build_and_create_debug_adapter()
         response = self.launch(
             "INVALIDPROGRAM",
             runInTerminal=True,
@@ -247,4 +247,4 @@ class TestDAP_runInTerminal(lldbdap_testcase.DAPTestCaseBase):
         self.readPidMessage(comm_file)
 
         _, stderr = proc.communicate()
-        self.assertIn("Timed out trying to get messages from the debug adaptor", stderr)
+        self.assertIn("Timed out trying to get messages from the debug adapter", stderr)

--- a/lldb/test/API/tools/lldb-dap/server/TestDAP_server.py
+++ b/lldb/test/API/tools/lldb-dap/server/TestDAP_server.py
@@ -15,7 +15,7 @@ import lldbdap_testcase
 class TestDAP_server(lldbdap_testcase.DAPTestCaseBase):
     def start_server(self, connection):
         log_file_path = self.getBuildArtifact("dap.txt")
-        (process, connection) = dap_server.DebugAdaptorServer.launch(
+        (process, connection) = dap_server.DebugAdapterServer.launch(
             executable=self.lldbDAPExec,
             connection=connection,
             log_file=log_file_path,
@@ -29,7 +29,7 @@ class TestDAP_server(lldbdap_testcase.DAPTestCaseBase):
         return (process, connection)
 
     def run_debug_session(self, connection, name):
-        self.dap_server = dap_server.DebugAdaptorServer(
+        self.dap_server = dap_server.DebugAdapterServer(
             connection=connection,
         )
         program = self.getBuildArtifact("a.out")
@@ -83,7 +83,7 @@ class TestDAP_server(lldbdap_testcase.DAPTestCaseBase):
         """
         self.build()
         (process, connection) = self.start_server(connection="tcp://localhost:0")
-        self.dap_server = dap_server.DebugAdaptorServer(
+        self.dap_server = dap_server.DebugAdapterServer(
             connection=connection,
         )
         program = self.getBuildArtifact("a.out")

--- a/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
+++ b/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
@@ -113,7 +113,7 @@ class TestDAP_variables(lldbdap_testcase.DAPTestCaseBase):
         # error when we run to main and try to get variables
         os.unlink(main_obj)
 
-        self.create_debug_adaptor()
+        self.create_debug_adapter()
         self.assertTrue(os.path.exists(program), "executable must exist")
 
         self.launch(program=program, initCommands=initCommands)

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -64,7 +64,7 @@ namespace lldb_dap {
 DAP::DAP(std::string name, llvm::StringRef path, std::ofstream *log,
          lldb::IOObjectSP input, lldb::IOObjectSP output, ReplMode repl_mode,
          std::vector<std::string> pre_init_commands)
-    : name(std::move(name)), debug_adaptor_path(path), log(log),
+    : name(std::move(name)), debug_adapter_path(path), log(log),
       input(std::move(input)), output(std::move(output)),
       broadcaster("lldb-dap"), exception_breakpoints(),
       pre_init_commands(std::move(pre_init_commands)),

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -146,7 +146,7 @@ struct SendEventRequestHandler : public lldb::SBCommandPluginInterface {
 
 struct DAP {
   std::string name;
-  llvm::StringRef debug_adaptor_path;
+  llvm::StringRef debug_adapter_path;
   std::ofstream *log;
   InputStream input;
   OutputStream output;

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -100,7 +100,7 @@ static llvm::Error RunInTerminal(DAP &dap,
   debugger_pid = getpid();
 #endif
   llvm::json::Object reverse_request = CreateRunInTerminalReverseRequest(
-      launch_request, dap.debug_adaptor_path, comm_file.m_path, debugger_pid);
+      launch_request, dap.debug_adapter_path, comm_file.m_path, debugger_pid);
   dap.SendReverseRequest<LogFailureResponseHandler>("runInTerminal",
                                                     std::move(reverse_request));
 

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -1436,7 +1436,7 @@ llvm::json::Value CreateCompileUnit(lldb::SBCompileUnit &unit) {
 /// https://microsoft.github.io/debug-adapter-protocol/specification#Reverse_Requests_RunInTerminal
 llvm::json::Object
 CreateRunInTerminalReverseRequest(const llvm::json::Object &launch_request,
-                                  llvm::StringRef debug_adaptor_path,
+                                  llvm::StringRef debug_adapter_path,
                                   llvm::StringRef comm_file,
                                   lldb::pid_t debugger_pid) {
   llvm::json::Object run_in_terminal_args;
@@ -1446,7 +1446,7 @@ CreateRunInTerminalReverseRequest(const llvm::json::Object &launch_request,
 
   const auto *launch_request_arguments = launch_request.getObject("arguments");
   // The program path must be the first entry in the "args" field
-  std::vector<std::string> args = {debug_adaptor_path.str(), "--comm-file",
+  std::vector<std::string> args = {debug_adapter_path.str(), "--comm-file",
                                    comm_file.str()};
   if (debugger_pid != LLDB_INVALID_PROCESS_ID) {
     args.push_back("--debugger-pid");

--- a/lldb/tools/lldb-dap/JSONUtils.h
+++ b/lldb/tools/lldb-dap/JSONUtils.h
@@ -233,7 +233,7 @@ void AppendBreakpoint(
     std::optional<llvm::StringRef> request_path = std::nullopt,
     std::optional<uint32_t> request_line = std::nullopt);
 
-/// Converts breakpoint location to a debug adaptor protocol "Breakpoint".
+/// Converts breakpoint location to a debug adapter protocol "Breakpoint".
 ///
 /// \param[in] bp
 ///     A LLDB breakpoint object to convert into a JSON value
@@ -290,7 +290,7 @@ llvm::json::Value CreateModule(lldb::SBTarget &target, lldb::SBModule &module);
 llvm::json::Object CreateEventObject(const llvm::StringRef event_name);
 
 /// Create a "ExceptionBreakpointsFilter" JSON object as described in
-/// the debug adaptor definition.
+/// the debug adapter definition.
 ///
 /// \param[in] bp
 ///     The exception breakpoint object to use
@@ -301,7 +301,7 @@ llvm::json::Object CreateEventObject(const llvm::StringRef event_name);
 llvm::json::Value
 CreateExceptionBreakpointFilter(const ExceptionBreakpoint &bp);
 
-/// Create a "Scope" JSON object as described in the debug adaptor definition.
+/// Create a "Scope" JSON object as described in the debug adapter definition.
 ///
 /// \param[in] name
 ///     The value to place into the "name" key
@@ -322,7 +322,7 @@ llvm::json::Value CreateScope(const llvm::StringRef name,
                               int64_t variablesReference,
                               int64_t namedVariables, bool expensive);
 
-/// Create a "Source" JSON object as described in the debug adaptor definition.
+/// Create a "Source" JSON object as described in the debug adapter definition.
 ///
 /// \param[in] file
 ///     The SBFileSpec to use when populating out the "Source" object
@@ -332,7 +332,7 @@ llvm::json::Value CreateScope(const llvm::StringRef name,
 ///     definition outlined by Microsoft.
 llvm::json::Value CreateSource(const lldb::SBFileSpec &file);
 
-/// Create a "Source" JSON object as described in the debug adaptor definition.
+/// Create a "Source" JSON object as described in the debug adapter definition.
 ///
 /// \param[in] line_entry
 ///     The LLDB line table to use when populating out the "Source"
@@ -573,8 +573,8 @@ llvm::json::Value CreateCompileUnit(lldb::SBCompileUnit &unit);
 ///     The original launch_request object whose fields are used to construct
 ///     the reverse request object.
 ///
-/// \param[in] debug_adaptor_path
-///     Path to the current debug adaptor. It will be used to delegate the
+/// \param[in] debug_adapter_path
+///     Path to the current debug adapter. It will be used to delegate the
 ///     launch of the target.
 ///
 /// \param[in] comm_file
@@ -590,7 +590,7 @@ llvm::json::Value CreateCompileUnit(lldb::SBCompileUnit &unit);
 ///     Microsoft.
 llvm::json::Object
 CreateRunInTerminalReverseRequest(const llvm::json::Object &launch_request,
-                                  llvm::StringRef debug_adaptor_path,
+                                  llvm::StringRef debug_adapter_path,
                                   llvm::StringRef comm_file,
                                   lldb::pid_t debugger_pid);
 

--- a/lldb/tools/lldb-dap/Options.td
+++ b/lldb/tools/lldb-dap/Options.td
@@ -33,7 +33,7 @@ def launch_target: S<"launch-target">,
 
 def comm_file: S<"comm-file">,
   MetaVarName<"<file>">,
-  HelpText<"The fifo file used to communicate the with the debug adaptor "
+  HelpText<"The fifo file used to communicate the with the debug adapter "
     "when using --launch-target.">;
 
 def debugger_pid: S<"debugger-pid">,

--- a/lldb/tools/lldb-dap/RunInTerminal.cpp
+++ b/lldb/tools/lldb-dap/RunInTerminal.cpp
@@ -97,9 +97,9 @@ static Error ToError(const RunInTerminalMessage &message) {
 
 RunInTerminalLauncherCommChannel::RunInTerminalLauncherCommChannel(
     StringRef comm_file)
-    : m_io(comm_file, "debug adaptor") {}
+    : m_io(comm_file, "debug adapter") {}
 
-Error RunInTerminalLauncherCommChannel::WaitUntilDebugAdaptorAttaches(
+Error RunInTerminalLauncherCommChannel::WaitUntilDebugAdapterAttaches(
     std::chrono::milliseconds timeout) {
   if (Expected<RunInTerminalMessageUP> message =
           GetNextMessage(m_io, timeout)) {

--- a/lldb/tools/lldb-dap/RunInTerminal.h
+++ b/lldb/tools/lldb-dap/RunInTerminal.h
@@ -72,7 +72,7 @@ class RunInTerminalLauncherCommChannel {
 public:
   RunInTerminalLauncherCommChannel(llvm::StringRef comm_file);
 
-  /// Wait until the debug adaptor attaches.
+  /// Wait until the debug adapter attaches.
   ///
   /// \param[in] timeout
   ///     How long to wait to be attached.
@@ -80,16 +80,16 @@ public:
   /// \return
   ///     An \a llvm::Error object in case of errors or if this operation times
   ///     out.
-  llvm::Error WaitUntilDebugAdaptorAttaches(std::chrono::milliseconds timeout);
+  llvm::Error WaitUntilDebugAdapterAttaches(std::chrono::milliseconds timeout);
 
-  /// Notify the debug adaptor this process' pid.
+  /// Notify the debug adapter this process' pid.
   ///
   /// \return
   ///     An \a llvm::Error object in case of errors or if this operation times
   ///     out.
   llvm::Error NotifyPid();
 
-  /// Notify the debug adaptor that there's been an error.
+  /// Notify the debug adapter that there's been an error.
   void NotifyError(llvm::StringRef error);
 
 private:
@@ -122,7 +122,7 @@ private:
   FifoFileIO m_io;
 };
 
-/// Create a fifo file used to communicate the debug adaptor with
+/// Create a fifo file used to communicate the debug adapter with
 /// the runInTerminal launcher.
 llvm::Expected<std::shared_ptr<FifoFile>> CreateRunInTerminalCommFile();
 

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -175,22 +175,22 @@ EXAMPLES:
 // If --launch-target is provided, this instance of lldb-dap becomes a
 // runInTerminal launcher. It will ultimately launch the program specified in
 // the --launch-target argument, which is the original program the user wanted
-// to debug. This is done in such a way that the actual debug adaptor can
+// to debug. This is done in such a way that the actual debug adapter can
 // place breakpoints at the beginning of the program.
 //
-// The launcher will communicate with the debug adaptor using a fifo file in the
+// The launcher will communicate with the debug adapter using a fifo file in the
 // directory specified in the --comm-file argument.
 //
-// Regarding the actual flow, this launcher will first notify the debug adaptor
+// Regarding the actual flow, this launcher will first notify the debug adapter
 // of its pid. Then, the launcher will be in a pending state waiting to be
-// attached by the adaptor.
+// attached by the adapter.
 //
 // Once attached and resumed, the launcher will exec and become the program
 // specified by --launch-target, which is the original target the
 // user wanted to run.
 //
 // In case of errors launching the target, a suitable error message will be
-// emitted to the debug adaptor.
+// emitted to the debug adapter.
 static llvm::Error LaunchRunInTerminalTarget(llvm::opt::Arg &target_arg,
                                              llvm::StringRef comm_file,
                                              lldb::pid_t debugger_pid,
@@ -219,7 +219,7 @@ static llvm::Error LaunchRunInTerminalTarget(llvm::opt::Arg &target_arg,
   const char *timeout_env_var = getenv("LLDB_DAP_RIT_TIMEOUT_IN_MS");
   int timeout_in_ms =
       timeout_env_var != nullptr ? atoi(timeout_env_var) : 20000;
-  if (llvm::Error err = comm_channel.WaitUntilDebugAdaptorAttaches(
+  if (llvm::Error err = comm_channel.WaitUntilDebugAdapterAttaches(
           std::chrono::milliseconds(timeout_in_ms))) {
     return err;
   }


### PR DESCRIPTION
Both spellings are considered correct and acceptable, with adapter being more common in American English. Given that DAP stands for Debug Adapter Protocol (with an e) let's go with that as the canonical spelling.