### PR TITLE
[libc++] Guard <codecvt> contents on _LIBCPP_HAS_LOCALIZATION

### DIFF
--- a/libcxx/include/codecvt
+++ b/libcxx/include/codecvt
@@ -58,14 +58,17 @@ class codecvt_utf8_utf16
 #  include <__cxx03/codecvt>
 #else
 #  include <__config>
-#  include <__locale>
-#  include <version>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#  if _LIBCPP_HAS_LOCALIZATION
 
-#  if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_BUILDING_LIBRARY) || defined(_LIBCPP_ENABLE_CXX26_REMOVED_CODECVT)
+#    include <__locale>
+#    include <version>
+
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
+
+#    if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_BUILDING_LIBRARY) || defined(_LIBCPP_ENABLE_CXX26_REMOVED_CODECVT)
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -76,7 +79,7 @@ enum _LIBCPP_DEPRECATED_IN_CXX17 codecvt_mode { consume_header = 4, generate_hea
 template <class _Elem>
 class __codecvt_utf8;
 
-#    if _LIBCPP_HAS_WIDE_CHARACTERS
+#      if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI __codecvt_utf8<wchar_t> : public codecvt<wchar_t, char, mbstate_t> {
   unsigned long __maxcode_;
@@ -115,7 +118,7 @@ protected:
   int do_length(state_type&, const extern_type* __frm, const extern_type* __end, size_t __mx) const override;
   int do_max_length() const _NOEXCEPT override;
 };
-#    endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#      endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <>
@@ -206,7 +209,7 @@ _LIBCPP_SUPPRESS_DEPRECATED_POP
 template <class _Elem, bool _LittleEndian>
 class __codecvt_utf16;
 
-#    if _LIBCPP_HAS_WIDE_CHARACTERS
+#      if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI __codecvt_utf16<wchar_t, false> : public codecvt<wchar_t, char, mbstate_t> {
   unsigned long __maxcode_;
@@ -284,7 +287,7 @@ protected:
   int do_length(state_type&, const extern_type* __frm, const extern_type* __end, size_t __mx) const override;
   int do_max_length() const _NOEXCEPT override;
 };
-#    endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#      endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <>
@@ -451,7 +454,7 @@ _LIBCPP_SUPPRESS_DEPRECATED_POP
 template <class _Elem>
 class __codecvt_utf8_utf16;
 
-#    if _LIBCPP_HAS_WIDE_CHARACTERS
+#      if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI __codecvt_utf8_utf16<wchar_t> : public codecvt<wchar_t, char, mbstate_t> {
   unsigned long __maxcode_;
@@ -490,7 +493,7 @@ protected:
   int do_length(state_type&, const extern_type* __frm, const extern_type* __end, size_t __mx) const override;
   int do_max_length() const _NOEXCEPT override;
 };
-#    endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#      endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <>
@@ -579,7 +582,9 @@ _LIBCPP_SUPPRESS_DEPRECATED_POP
 
 _LIBCPP_END_NAMESPACE_STD
 
-#  endif // _LIBCPP_STD_VER < 26 || defined(_LIBCPP_BUILDING_LIBRARY) || defined(_LIBCPP_ENABLE_CXX26_REMOVED_CODECVT)
+#    endif // _LIBCPP_STD_VER < 26 || defined(_LIBCPP_BUILDING_LIBRARY) || defined(_LIBCPP_ENABLE_CXX26_REMOVED_CODECVT)
+
+#  endif // _LIBCPP_HAS_LOCALIZATION
 
 #  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #    include <atomic>


### PR DESCRIPTION
The codecvt class is defined in <locale> and the contents of the <codecvt> header don't work when localization is disabled. Without this guard, builds with localization disabled that happen to include <codecvt> could be broken because they would try to include <__locale>, which ends up trying to include the locale base API and eventually platform headers like <xlocale.h> that may not exist.