### PR TITLE
[Clang][diagnostics] Fix structured binding shadows template param loc

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -214,6 +214,8 @@ Improvements to Clang's diagnostics
   :doc:`ThreadSafetyAnalysis` still does not perform alias analysis. The
   feature will be default-enabled with ``-Wthread-safety`` in a future release.
 
+- Improve the diagnostics for shadows template parameter.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -214,7 +214,7 @@ Improvements to Clang's diagnostics
   :doc:`ThreadSafetyAnalysis` still does not perform alias analysis. The
   feature will be default-enabled with ``-Wthread-safety`` in a future release.
 
-- Improve the diagnostics for shadows template parameter.
+- Improve the diagnostics for shadows template parameter to report correct location (#GH129060).
 
 Improvements to Clang's time-trace
 ----------------------------------

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -883,8 +883,7 @@ Sema::ActOnDecompositionDeclarator(Scope *S, Declarator &D,
     // It's not permitted to shadow a template parameter name.
     if (Previous.isSingleResult() &&
         Previous.getFoundDecl()->isTemplateParameter()) {
-      DiagnoseTemplateParameterShadow(D.getIdentifierLoc(),
-                                      Previous.getFoundDecl());
+      DiagnoseTemplateParameterShadow(B.NameLoc, Previous.getFoundDecl());
       Previous.clear();
     }
 

--- a/clang/test/CXX/temp/temp.res/temp.local/p6.cpp
+++ b/clang/test/CXX/temp/temp.res/temp.local/p6.cpp
@@ -163,7 +163,9 @@ struct A {
 A<0>::B a;
 }
 
-template <typename T> void shadow9() {  // expected-note{{template parameter is declared here}}
+template <typename T> void shadow() {  // expected-note{{template parameter is declared here}}
   using arr = int[1]; // expected-warning@+1 {{decomposition declarations are a C++17 extension}}
-  auto [T] = arr{}; // expected-error {{declaration of 'T' shadows template parameter}}
+  auto [
+    T // expected-error {{declaration of 'T' shadows template parameter}}
+    ] = arr{};
 }

--- a/clang/test/CXX/temp/temp.res/temp.local/p6.cpp
+++ b/clang/test/CXX/temp/temp.res/temp.local/p6.cpp
@@ -162,3 +162,8 @@ struct A {
 };
 A<0>::B a;
 }
+
+template <typename T> void shadow9() {  // expected-note{{template parameter is declared here}}
+  using arr = int[1]; // expected-warning@+1 {{decomposition declarations are a C++17 extension}}
+  auto [T] = arr{}; // expected-error {{declaration of 'T' shadows template parameter}}
+}

--- a/clang/test/CXX/temp/temp.res/temp.local/p6.cpp
+++ b/clang/test/CXX/temp/temp.res/temp.local/p6.cpp
@@ -163,10 +163,13 @@ struct A {
 A<0>::B a;
 }
 
-template <typename T> void shadow() {  // expected-note{{template parameter is declared here}}
+template <typename T> int shadow() {  // expected-note{{template parameter is declared here}}
   using arr = int[1];
   // expected-warning@+1 {{decomposition declarations are a C++17 extension}}
   auto [
     T // expected-error {{declaration of 'T' shadows template parameter}}
     ] = arr{};
+  return 0;
 }
+
+auto Use = shadow<int>();

--- a/clang/test/CXX/temp/temp.res/temp.local/p6.cpp
+++ b/clang/test/CXX/temp/temp.res/temp.local/p6.cpp
@@ -164,7 +164,8 @@ A<0>::B a;
 }
 
 template <typename T> void shadow() {  // expected-note{{template parameter is declared here}}
-  using arr = int[1]; // expected-warning@+1 {{decomposition declarations are a C++17 extension}}
+  using arr = int[1];
+  // expected-warning@+1 {{decomposition declarations are a C++17 extension}}
   auto [
     T // expected-error {{declaration of 'T' shadows template parameter}}
     ] = arr{};


### PR DESCRIPTION
Fix structured binding shadows template parameter location

Fixes: #129060