### PR TITLE
[libc][bazel] Rephrase list comp for downstream

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdbit/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdbit/BUILD.bazel
@@ -39,7 +39,10 @@ bit_prefix_list = [
     libc_test(
         name = bit_prefix + bit_suffix + "_test",
         srcs = [bit_prefix + bit_suffix + "_test.cpp"],
-        libc_function_deps = ["//libc:" + bit_prefix + bit_suffix],
+        libc_function_deps = ["//libc:func_name".replace(
+            "func_name",
+            bit_prefix + bit_suffix,
+        )],
         deps = ["//libc:__support_cpp_limits"],
     )
     for bit_prefix in bit_prefix_list


### PR DESCRIPTION
The downstream build was having trouble transforming the previous list
comprehension, but it works on this one. I guess it just needs to look
like a proper target.
