### PR TITLE
[win][x64] Unwind v2 3/n: Add support for emitting unwind v2 information (equivalent to MSVC /d2epilogunwind)

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -483,6 +483,9 @@ CODEGENOPT(StaticClosure, 1, 0)
 /// Assume that UAVs/SRVs may alias
 CODEGENOPT(ResMayAlias, 1, 0)
 
+/// Enables unwind v2 (epilog) information for x64 Windows.
+CODEGENOPT(WinX64EHUnwindV2, 1, 0)
+
 /// FIXME: Make DebugOptions its own top-level .def file.
 #include "DebugOptions.def"
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2167,6 +2167,11 @@ defm assume_nothrow_exception_dtor: BoolFOption<"assume-nothrow-exception-dtor",
   LangOpts<"AssumeNothrowExceptionDtor">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption, CC1Option], "Assume that exception objects' destructors are non-throwing">,
   NegFlag<SetFalse>>;
+defm winx64_eh_unwindv2 : BoolFOption<"winx64-eh-unwindv2",
+  CodeGenOpts<"WinX64EHUnwindV2">, DefaultFalse,
+  PosFlag<SetTrue, [], [ClangOption, CC1Option], "Enable">,
+  NegFlag<SetFalse, [], [ClangOption], "Disable">,
+  BothFlags<[], [ClangOption], " unwind v2 (epilog) information for x64 Windows">>;
 def fexcess_precision_EQ : Joined<["-"], "fexcess-precision=">, Group<f_Group>,
   Visibility<[ClangOption, CLOption]>,
   HelpText<"Allows control over excess precision on targets where native "
@@ -8935,6 +8940,8 @@ def _SLASH_M_Group : OptionGroup<"</M group>">, Group<cl_compile_Group>;
 def _SLASH_volatile_Group : OptionGroup<"</volatile group>">,
   Group<cl_compile_Group>;
 
+def _SLASH_d2epilogunwind : CLFlag<"d2epilogunwind">,
+  HelpText<"Enable unwind v2 (epilog) information for x64 Windows">;
 def _SLASH_EH : CLJoined<"EH">, HelpText<"Set exception handling model">;
 def _SLASH_EP : CLFlag<"EP">,
   HelpText<"Disable linemarker output and preprocess to stdout">;

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1307,6 +1307,10 @@ void CodeGenModule::Release() {
     getModule().addModuleFlag(llvm::Module::Warning, "import-call-optimization",
                               1);
 
+  // Enable unwind v2 (epilog).
+  if (CodeGenOpts.WinX64EHUnwindV2)
+    getModule().addModuleFlag(llvm::Module::Warning, "winx64-eh-unwindv2", 1);
+
   // Indicate whether this Module was compiled with -fopenmp
   if (getLangOpts().OpenMP && !getLangOpts().OpenMPSimd)
     getModule().addModuleFlag(llvm::Module::Max, "openmp", LangOpts.OpenMP);

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7503,6 +7503,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     }
   }
 
+  // Unwind v2 (epilog) information for x64 Windows.
+  Args.addOptInFlag(CmdArgs, options::OPT_fwinx64_eh_unwindv2,
+                    options::OPT_fno_winx64_eh_unwindv2);
+
   // C++ "sane" operator new.
   Args.addOptOutFlag(CmdArgs, options::OPT_fassume_sane_operator_new,
                      options::OPT_fno_assume_sane_operator_new);
@@ -8547,6 +8551,10 @@ void Clang::AddClangCLArgs(const ArgList &Args, types::ID InputType,
 
   if (Args.hasArg(options::OPT__SLASH_kernel))
     CmdArgs.push_back("-fms-kernel");
+
+  // Unwind v2 (epilog) information for x64 Windows.
+  if (Args.hasArg(options::OPT__SLASH_d2epilogunwind))
+    CmdArgs.push_back("-fwinx64-eh-unwindv2");
 
   for (const Arg *A : Args.filtered(options::OPT__SLASH_guard)) {
     StringRef GuardArgs = A->getValue();

--- a/clang/test/CodeGen/epilog-unwind.c
+++ b/clang/test/CodeGen/epilog-unwind.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -emit-llvm %s -o - | FileCheck %s -check-prefix=DISABLED
+// RUN: %clang_cc1 -fwinx64-eh-unwindv2 -emit-llvm %s -o - | FileCheck %s -check-prefix=ENABLED
+// RUN: %clang -fwinx64-eh-unwindv2 -S -emit-llvm %s -o - | FileCheck %s -check-prefix=ENABLED
+// RUN: %clang -fno-winx64-eh-unwindv2 -S -emit-llvm %s -o - | FileCheck %s -check-prefix=DISABLED
+
+void f(void) {}
+
+// ENABLED: !"winx64-eh-unwindv2", i32 1}
+// DISABLED-NOT: "winx64-eh-unwindv2"

--- a/clang/test/Driver/cl-options.c
+++ b/clang/test/Driver/cl-options.c
@@ -820,4 +820,7 @@
 // RUN: %clang_cl -vctoolsdir "" /arm64EC /c -target x86_64-pc-windows-msvc  -### -- %s 2>&1 | FileCheck --check-prefix=ARM64EC_OVERRIDE %s
 // ARM64EC_OVERRIDE: warning: /arm64EC has been overridden by specified target: x86_64-pc-windows-msvc; option ignored
 
+// RUN: %clang_cl /d2epilogunwind /c -### -- %s 2>&1 | FileCheck %s --check-prefix=EPILOGUNWIND
+// EPILOGUNWIND: -fwinx64-eh-unwindv2
+
 void f(void) { }

--- a/llvm/include/llvm/MC/MCStreamer.h
+++ b/llvm/include/llvm/MC/MCStreamer.h
@@ -255,11 +255,8 @@ class MCStreamer {
   bool AllowAutoPadding = false;
 
 protected:
-  // True if we are processing SEH directives in an epilogue.
-  bool InEpilogCFI = false;
-
   // Symbol of the current epilog for which we are processing SEH directives.
-  MCSymbol *CurrentEpilog = nullptr;
+  WinEH::FrameInfo::Epilog *CurrentWinEpilog = nullptr;
 
   MCFragment *CurFrag = nullptr;
 
@@ -342,9 +339,11 @@ public:
     return WinFrameInfos;
   }
 
-  MCSymbol *getCurrentEpilog() const { return CurrentEpilog; }
+  WinEH::FrameInfo::Epilog *getCurrentWinEpilog() const {
+    return CurrentWinEpilog;
+  }
 
-  bool isInEpilogCFI() const { return InEpilogCFI; }
+  bool isInEpilogCFI() const { return CurrentWinEpilog; }
 
   void generateCompactUnwindEncodings(MCAsmBackend *MAB);
 
@@ -1026,6 +1025,8 @@ public:
   virtual void emitWinCFIEndProlog(SMLoc Loc = SMLoc());
   virtual void emitWinCFIBeginEpilogue(SMLoc Loc = SMLoc());
   virtual void emitWinCFIEndEpilogue(SMLoc Loc = SMLoc());
+  virtual void emitWinCFIUnwindV2Start(SMLoc Loc = SMLoc());
+  virtual void emitWinCFIUnwindVersion(uint8_t Version, SMLoc Loc = SMLoc());
   virtual void emitWinEHHandler(const MCSymbol *Sym, bool Unwind, bool Except,
                                 SMLoc Loc = SMLoc());
   virtual void emitWinEHHandlerData(SMLoc Loc = SMLoc());

--- a/llvm/include/llvm/MC/MCWinEH.h
+++ b/llvm/include/llvm/MC/MCWinEH.h
@@ -10,6 +10,7 @@
 #define LLVM_MC_MCWINEH_H
 
 #include "llvm/ADT/MapVector.h"
+#include "llvm/Support/SMLoc.h"
 #include <vector>
 
 namespace llvm {
@@ -42,6 +43,7 @@ struct FrameInfo {
   const MCSymbol *FuncletOrFuncEnd = nullptr;
   const MCSymbol *ExceptionHandler = nullptr;
   const MCSymbol *Function = nullptr;
+  SMLoc FunctionLoc;
   const MCSymbol *PrologEnd = nullptr;
   const MCSymbol *Symbol = nullptr;
   MCSection *TextSection = nullptr;
@@ -52,6 +54,8 @@ struct FrameInfo {
   bool HandlesExceptions = false;
   bool EmitAttempted = false;
   bool Fragment = false;
+  constexpr static uint8_t DefaultVersion = 1;
+  uint8_t Version = DefaultVersion;
 
   int LastFrameInst = -1;
   const FrameInfo *ChainedParent = nullptr;
@@ -59,7 +63,10 @@ struct FrameInfo {
   struct Epilog {
     std::vector<Instruction> Instructions;
     unsigned Condition;
-    MCSymbol *End;
+    const MCSymbol *Start = nullptr;
+    const MCSymbol *End = nullptr;
+    const MCSymbol *UnwindV2Start = nullptr;
+    SMLoc Loc;
   };
   MapVector<MCSymbol *, Epilog> EpilogMap;
 

--- a/llvm/lib/MC/MCAsmStreamer.cpp
+++ b/llvm/lib/MC/MCAsmStreamer.cpp
@@ -391,6 +391,8 @@ public:
   void emitWinCFIEndProlog(SMLoc Loc) override;
   void emitWinCFIBeginEpilogue(SMLoc Loc) override;
   void emitWinCFIEndEpilogue(SMLoc Loc) override;
+  void emitWinCFIUnwindV2Start(SMLoc Loc) override;
+  void emitWinCFIUnwindVersion(uint8_t Version, SMLoc Loc) override;
 
   void emitWinEHHandler(const MCSymbol *Sym, bool Unwind, bool Except,
                         SMLoc Loc) override;
@@ -2302,6 +2304,20 @@ void MCAsmStreamer::emitWinCFIEndEpilogue(SMLoc Loc) {
   MCStreamer::emitWinCFIEndEpilogue(Loc);
 
   OS << "\t.seh_endepilogue";
+  EmitEOL();
+}
+
+void MCAsmStreamer::emitWinCFIUnwindV2Start(SMLoc Loc) {
+  MCStreamer::emitWinCFIUnwindV2Start(Loc);
+
+  OS << "\t.seh_unwindv2start";
+  EmitEOL();
+}
+
+void MCAsmStreamer::emitWinCFIUnwindVersion(uint8_t Version, SMLoc Loc) {
+  MCStreamer::emitWinCFIUnwindVersion(Version, Loc);
+
+  OS << "\t.seh_unwindversion " << (unsigned)Version;
   EmitEOL();
 }
 

--- a/llvm/lib/MC/MCWin64EH.cpp
+++ b/llvm/lib/MC/MCWin64EH.cpp
@@ -8,14 +8,57 @@
 
 #include "llvm/MC/MCWin64EH.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/MC/MCAssembler.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCObjectStreamer.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSymbol.h"
+#include "llvm/MC/MCValue.h"
 #include "llvm/Support/Win64EH.h"
+
 namespace llvm {
 class MCSection;
+
+/// MCExpr that represents the epilog unwind code in an unwind table.
+class MCUnwindV2EpilogTargetExpr final : public MCTargetExpr {
+  const MCSymbol *FunctionEnd;
+  const MCSymbol *UnwindV2Start;
+  const MCSymbol *EpilogEnd;
+  uint8_t EpilogSize;
+  SMLoc Loc;
+
+  MCUnwindV2EpilogTargetExpr(const WinEH::FrameInfo &FrameInfo,
+                             const WinEH::FrameInfo::Epilog &Epilog,
+                             uint8_t EpilogSize_)
+      : FunctionEnd(FrameInfo.FuncletOrFuncEnd),
+        UnwindV2Start(Epilog.UnwindV2Start), EpilogEnd(Epilog.End),
+        EpilogSize(EpilogSize_), Loc(Epilog.Loc) {}
+
+public:
+  static MCUnwindV2EpilogTargetExpr *
+  create(const WinEH::FrameInfo &FrameInfo,
+         const WinEH::FrameInfo::Epilog &Epilog, uint8_t EpilogSize_,
+         MCContext &Ctx) {
+    return new (Ctx) MCUnwindV2EpilogTargetExpr(FrameInfo, Epilog, EpilogSize_);
+  }
+
+  void printImpl(raw_ostream &OS, const MCAsmInfo *MAI) const override {
+    OS << ":epilog:";
+    UnwindV2Start->print(OS, MAI);
+  }
+
+  bool evaluateAsRelocatableImpl(MCValue &Res,
+                                 const MCAssembler *Asm) const override;
+
+  void visitUsedExpr(MCStreamer &Streamer) const override {
+    // Contains no sub-expressions.
+  }
+
+  MCFragment *findAssociatedFragment() const override {
+    return UnwindV2Start->getFragment();
+  }
+};
 }
 
 using namespace llvm;
@@ -163,20 +206,91 @@ static void EmitRuntimeFunction(MCStreamer &streamer,
                                              context), 4);
 }
 
+static std::optional<int64_t>
+GetOptionalAbsDifference(const MCAssembler &Assembler, const MCSymbol *LHS,
+                         const MCSymbol *RHS) {
+  MCContext &Context = Assembler.getContext();
+  const MCExpr *Diff =
+      MCBinaryExpr::createSub(MCSymbolRefExpr::create(LHS, Context),
+                              MCSymbolRefExpr::create(RHS, Context), Context);
+  // It should normally be possible to calculate the length of a function
+  // at this point, but it might not be possible in the presence of certain
+  // unusual constructs, like an inline asm with an alignment directive.
+  int64_t value;
+  if (!Diff->evaluateAsAbsolute(value, Assembler))
+    return std::nullopt;
+  return value;
+}
+
 static void EmitUnwindInfo(MCStreamer &streamer, WinEH::FrameInfo *info) {
   // If this UNWIND_INFO already has a symbol, it's already been emitted.
   if (info->Symbol)
     return;
 
   MCContext &context = streamer.getContext();
+  MCObjectStreamer *OS = (MCObjectStreamer *)(&streamer);
   MCSymbol *Label = context.createTempSymbol();
 
   streamer.emitValueToAlignment(Align(4));
   streamer.emitLabel(Label);
   info->Symbol = Label;
 
-  // Upper 3 bits are the version number (currently 1).
-  uint8_t flags = 0x01;
+  uint8_t numCodes = CountOfUnwindCodes(info->Instructions);
+  bool LastEpilogIsAtEnd = false;
+  bool AddPaddingEpilogCode = false;
+  uint8_t EpilogSize = 0;
+  bool EnableUnwindV2 = (info->Version >= 2) && !info->EpilogMap.empty();
+  if (EnableUnwindV2) {
+    auto &LastEpilog = info->EpilogMap.back().second;
+
+    // Calculate the size of the epilogs. Note that we +1 to the size so that
+    // the terminator instruction is also included in the epilog (the Windows
+    // unwinder does a simple range check versus the current instruction pointer
+    // so, although there are terminators that are large than 1 byte, the
+    // starting address of the terminator instruction will always be considered
+    // inside the epilog).
+    auto MaybeSize = GetOptionalAbsDifference(
+        OS->getAssembler(), LastEpilog.End, LastEpilog.UnwindV2Start);
+    if (!MaybeSize) {
+      context.reportError(LastEpilog.Loc,
+                          "Failed to evaluate epilog size for Unwind v2");
+      return;
+    }
+    assert(*MaybeSize >= 0);
+    if (*MaybeSize >= (int64_t)UINT8_MAX) {
+      context.reportError(LastEpilog.Loc,
+                          "Epilog size is too large for Unwind v2");
+      return;
+    }
+    EpilogSize = *MaybeSize + 1;
+
+    // If the last epilog is at the end of the function, we can use a special
+    // encoding for it. Because of our +1 trick for the size, this will only
+    // work where that final terminator instruction is 1 byte long.
+    auto LastEpilogToFuncEnd = GetOptionalAbsDifference(
+        OS->getAssembler(), info->FuncletOrFuncEnd, LastEpilog.UnwindV2Start);
+    LastEpilogIsAtEnd = (LastEpilogToFuncEnd == EpilogSize);
+
+    // If we have an odd number of epilog codes, we need to add a padding code.
+    size_t numEpilogCodes =
+        info->EpilogMap.size() + (LastEpilogIsAtEnd ? 0 : 1);
+    if ((numEpilogCodes % 2) != 0) {
+      AddPaddingEpilogCode = true;
+      numEpilogCodes++;
+    }
+
+    // Too many epilogs to handle.
+    if ((size_t)numCodes + numEpilogCodes > UINT8_MAX) {
+      context.reportError(info->FunctionLoc,
+                          "Too many unwind codes with Unwind v2 enabled");
+      return;
+    }
+
+    numCodes += numEpilogCodes;
+  }
+
+  // Upper 3 bits are the version number.
+  uint8_t flags = info->Version;
   if (info->ChainedParent)
     flags |= Win64EH::UNW_ChainInfo << 3;
   else {
@@ -192,7 +306,6 @@ static void EmitUnwindInfo(MCStreamer &streamer, WinEH::FrameInfo *info) {
   else
     streamer.emitInt8(0);
 
-  uint8_t numCodes = CountOfUnwindCodes(info->Instructions);
   streamer.emitInt8(numCodes);
 
   uint8_t frame = 0;
@@ -202,6 +315,35 @@ static void EmitUnwindInfo(MCStreamer &streamer, WinEH::FrameInfo *info) {
     frame = (frameInst.Register & 0x0F) | (frameInst.Offset & 0xF0);
   }
   streamer.emitInt8(frame);
+
+  // Emit the epilog instructions.
+  if (EnableUnwindV2) {
+    MCDataFragment *DF = OS->getOrCreateDataFragment();
+
+    bool IsLast = true;
+    for (const auto &Epilog : llvm::reverse(info->EpilogMap)) {
+      if (IsLast) {
+        IsLast = false;
+        uint8_t Flags = LastEpilogIsAtEnd ? 0x01 : 0;
+        streamer.emitInt8(EpilogSize);
+        streamer.emitInt8((Flags << 4) | Win64EH::UOP_Epilog);
+
+        if (LastEpilogIsAtEnd)
+          continue;
+      }
+
+      // Each epilog is emitted as a fixup, since we can't measure the distance
+      // between the start of the epilog and the end of the function until
+      // layout has been completed.
+      auto *MCE = MCUnwindV2EpilogTargetExpr::create(*info, Epilog.second,
+                                                     EpilogSize, context);
+      MCFixup Fixup = MCFixup::create(DF->getContents().size(), MCE, FK_Data_2);
+      DF->getFixups().push_back(Fixup);
+      DF->appendContents(2, 0);
+    }
+  }
+  if (AddPaddingEpilogCode)
+    streamer.emitInt16(Win64EH::UOP_Epilog << 8);
 
   // Emit unwind instructions (in reverse order).
   uint8_t numInst = info->Instructions.size();
@@ -232,6 +374,39 @@ static void EmitUnwindInfo(MCStreamer &streamer, WinEH::FrameInfo *info) {
     // than 2 slots used in the unwind code array, we have to pad to 8 bytes.
     streamer.emitInt32(0);
   }
+}
+
+bool MCUnwindV2EpilogTargetExpr::evaluateAsRelocatableImpl(
+    MCValue &Res, const MCAssembler *Asm) const {
+  // Calculate the offset to this epilog, and validate it's within the allowed
+  // range.
+  auto Offset = GetOptionalAbsDifference(*Asm, FunctionEnd, UnwindV2Start);
+  if (!Offset) {
+    Asm->getContext().reportError(
+        Loc, "Failed to evaluate epilog offset for Unwind v2");
+    return false;
+  }
+  assert(*Offset > 0);
+  constexpr uint16_t MaxEpilogOffset = 0x0fff;
+  if (*Offset > MaxEpilogOffset) {
+    Asm->getContext().reportError(Loc,
+                                  "Epilog offset is too large for Unwind v2");
+    return false;
+  }
+
+  // Sanity check that all epilogs are the same size.
+  auto Size = GetOptionalAbsDifference(*Asm, EpilogEnd, UnwindV2Start);
+  if (Size != (EpilogSize - 1)) {
+    Asm->getContext().reportError(
+        Loc,
+        "Size of this epilog does not match size of last epilog in function");
+    return false;
+  }
+
+  auto HighBits = *Offset >> 8;
+  Res = MCValue::get((HighBits << 12) | (Win64EH::UOP_Epilog << 8) |
+                     (*Offset & 0xFF));
+  return true;
 }
 
 void llvm::Win64EH::UnwindEmitter::Emit(MCStreamer &Streamer) const {
@@ -276,18 +451,8 @@ static const MCExpr *GetSubDivExpr(MCStreamer &Streamer, const MCSymbol *LHS,
 static std::optional<int64_t> GetOptionalAbsDifference(MCStreamer &Streamer,
                                                        const MCSymbol *LHS,
                                                        const MCSymbol *RHS) {
-  MCContext &Context = Streamer.getContext();
-  const MCExpr *Diff =
-      MCBinaryExpr::createSub(MCSymbolRefExpr::create(LHS, Context),
-                              MCSymbolRefExpr::create(RHS, Context), Context);
   MCObjectStreamer *OS = (MCObjectStreamer *)(&Streamer);
-  // It should normally be possible to calculate the length of a function
-  // at this point, but it might not be possible in the presence of certain
-  // unusual constructs, like an inline asm with an alignment directive.
-  int64_t value;
-  if (!Diff->evaluateAsAbsolute(value, OS->getAssembler()))
-    return std::nullopt;
-  return value;
+  return GetOptionalAbsDifference(OS->getAssembler(), LHS, RHS);
 }
 
 static int64_t GetAbsDifference(MCStreamer &Streamer, const MCSymbol *LHS,

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64WinCOFFStreamer.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64WinCOFFStreamer.cpp
@@ -74,7 +74,7 @@ void AArch64TargetWinCOFFStreamer::emitARM64WinUnwindCode(unsigned UnwindCode,
     return;
   auto Inst = WinEH::Instruction(UnwindCode, /*Label=*/nullptr, Reg, Offset);
   if (S.isInEpilogCFI())
-    CurFrame->EpilogMap[S.getCurrentEpilog()].Instructions.push_back(Inst);
+    S.getCurrentWinEpilog()->Instructions.push_back(Inst);
   else
     CurFrame->Instructions.push_back(Inst);
 }
@@ -195,7 +195,7 @@ void AArch64TargetWinCOFFStreamer::emitARM64WinCFIEpilogEnd() {
   if (S.isInEpilogCFI()) {
     WinEH::Instruction Inst =
         WinEH::Instruction(Win64EH::UOP_End, /*Label=*/nullptr, -1, 0);
-    CurFrame->EpilogMap[S.getCurrentEpilog()].Instructions.push_back(Inst);
+    S.getCurrentWinEpilog()->Instructions.push_back(Inst);
   }
   S.emitWinCFIEndEpilogue();
 }

--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMWinCOFFStreamer.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMWinCOFFStreamer.cpp
@@ -112,7 +112,7 @@ void ARMTargetWinCOFFStreamer::emitARMWinUnwindCode(unsigned UnwindCode,
   MCSymbol *Label = S.emitCFILabel();
   auto Inst = WinEH::Instruction(UnwindCode, Label, Reg, Offset);
   if (S.isInEpilogCFI())
-    CurFrame->EpilogMap[S.getCurrentEpilog()].Instructions.push_back(Inst);
+    S.getCurrentWinEpilog()->Instructions.push_back(Inst);
   else
     CurFrame->Instructions.push_back(Inst);
 }
@@ -223,7 +223,7 @@ void ARMTargetWinCOFFStreamer::emitARMWinCFIEpilogStart(unsigned Condition) {
 
   S.emitWinCFIBeginEpilogue();
   if (S.isInEpilogCFI()) {
-    CurFrame->EpilogMap[S.getCurrentEpilog()].Condition = Condition;
+    S.getCurrentWinEpilog()->Condition = Condition;
   }
 }
 
@@ -235,7 +235,7 @@ void ARMTargetWinCOFFStreamer::emitARMWinCFIEpilogEnd() {
 
   if (S.isInEpilogCFI()) {
     std::vector<WinEH::Instruction> &Epilog =
-        CurFrame->EpilogMap[S.getCurrentEpilog()].Instructions;
+        S.getCurrentWinEpilog()->Instructions;
 
     unsigned UnwindCode = Win64EH::UOP_End;
     if (!Epilog.empty()) {
@@ -250,7 +250,7 @@ void ARMTargetWinCOFFStreamer::emitARMWinCFIEpilogEnd() {
     }
 
     WinEH::Instruction Inst = WinEH::Instruction(UnwindCode, nullptr, -1, 0);
-    CurFrame->EpilogMap[S.getCurrentEpilog()].Instructions.push_back(Inst);
+    S.getCurrentWinEpilog()->Instructions.push_back(Inst);
   }
   S.emitWinCFIEndEpilogue();
 }

--- a/llvm/lib/Target/X86/CMakeLists.txt
+++ b/llvm/lib/Target/X86/CMakeLists.txt
@@ -84,6 +84,7 @@ set(sources
   X86TargetTransformInfo.cpp
   X86VZeroUpper.cpp
   X86WinEHState.cpp
+  X86WinEHUnwindV2.cpp
   X86WinFixupBufferSecurityCheck.cpp
   X86InsertWait.cpp
   GISel/X86CallLowering.cpp

--- a/llvm/lib/Target/X86/X86.h
+++ b/llvm/lib/Target/X86/X86.h
@@ -160,6 +160,9 @@ FunctionPass *createX86InsertX87waitPass();
 /// ways.
 FunctionPass *createX86PartialReductionPass();
 
+/// // Analyzes and emits pseudos to support Win x64 Unwind V2.
+FunctionPass *createX86WinEHUnwindV2Pass();
+
 InstructionSelector *createX86InstructionSelector(const X86TargetMachine &TM,
                                                   const X86Subtarget &,
                                                   const X86RegisterBankInfo &);
@@ -207,6 +210,7 @@ void initializeX86SpeculativeExecutionSideEffectSuppressionPass(PassRegistry &);
 void initializeX86SpeculativeLoadHardeningPassPass(PassRegistry &);
 void initializeX86TileConfigPass(PassRegistry &);
 void initializeX86SuppressAPXForRelocationPassPass(PassRegistry &);
+void initializeX86WinEHUnwindV2Pass(PassRegistry &);
 
 namespace X86AS {
 enum : unsigned {

--- a/llvm/lib/Target/X86/X86InstrCompiler.td
+++ b/llvm/lib/Target/X86/X86InstrCompiler.td
@@ -258,6 +258,8 @@ let isPseudo = 1, isMeta = 1, isNotDuplicable = 1, SchedRW = [WriteSystem] in {
                             "#SEH_PushFrame $mode", []>;
   def SEH_EndPrologue : I<0, Pseudo, (outs), (ins),
                             "#SEH_EndPrologue", []>;
+  def SEH_UnwindVersion : I<0, Pseudo, (outs), (ins i1imm:$version),
+                            "#SEH_UnwindVersion $version", []>;
 }
 
 // Epilog instructions:
@@ -266,6 +268,8 @@ let isPseudo = 1, isMeta = 1, SchedRW = [WriteSystem] in {
                             "#SEH_BeginEpilogue", []>;
   def SEH_EndEpilogue : I<0, Pseudo, (outs), (ins),
                             "#SEH_EndEpilogue", []>;
+  def SEH_UnwindV2Start : I<0, Pseudo, (outs), (ins),
+                            "#SEH_UnwindV2Start", []>;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/X86/X86MCInstLower.cpp
+++ b/llvm/lib/Target/X86/X86MCInstLower.cpp
@@ -1786,6 +1786,14 @@ void X86AsmPrinter::EmitSEHInstruction(const MachineInstr *MI) {
     OutStreamer->emitWinCFIEndEpilogue();
     break;
 
+  case X86::SEH_UnwindV2Start:
+    OutStreamer->emitWinCFIUnwindV2Start();
+    break;
+
+  case X86::SEH_UnwindVersion:
+    OutStreamer->emitWinCFIUnwindVersion(MI->getOperand(0).getImm());
+    break;
+
   default:
     llvm_unreachable("expected SEH_ instruction");
   }
@@ -2428,6 +2436,8 @@ void X86AsmPrinter::emitInstruction(const MachineInstr *MI) {
   case X86::SEH_PushFrame:
   case X86::SEH_EndPrologue:
   case X86::SEH_EndEpilogue:
+  case X86::SEH_UnwindV2Start:
+  case X86::SEH_UnwindVersion:
     EmitSEHInstruction(MI);
     return;
 

--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -107,6 +107,7 @@ extern "C" LLVM_C_ABI void LLVMInitializeX86Target() {
   initializeX86FixupVectorConstantsPassPass(PR);
   initializeX86DynAllocaExpanderPass(PR);
   initializeX86SuppressAPXForRelocationPassPass(PR);
+  initializeX86WinEHUnwindV2Pass(PR);
 }
 
 static std::unique_ptr<TargetLoweringObjectFile> createTLOF(const Triple &TT) {
@@ -670,6 +671,11 @@ void X86PassConfig::addPreEmitPass2() {
             (M->getFunction("objc_retainAutoreleasedReturnValue") ||
              M->getFunction("objc_unsafeClaimAutoreleasedReturnValue")));
   }));
+
+  // Analyzes and emits pseudos to support Win x64 Unwind V2. This pass must run
+  // after all real instructions have been added to the epilog.
+  if (TT.isOSWindows() && (TT.getArch() == Triple::x86_64))
+    addPass(createX86WinEHUnwindV2Pass());
 }
 
 bool X86PassConfig::addPostFastRegAllocRewrite() {

--- a/llvm/lib/Target/X86/X86WinEHUnwindV2.cpp
+++ b/llvm/lib/Target/X86/X86WinEHUnwindV2.cpp
@@ -1,0 +1,221 @@
+//===-- X86WinEHUnwindV2.cpp - Win x64 Unwind v2 ----------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// Implements the analysis required to detect if a function can use Unwind v2
+/// information, and emits the neccesary pseudo instructions used by MC to
+/// generate the unwind info.
+///
+//===----------------------------------------------------------------------===//
+
+#include "MCTargetDesc/X86BaseInfo.h"
+#include "X86.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/CodeGen/TargetInstrInfo.h"
+#include "llvm/CodeGen/TargetSubtargetInfo.h"
+#include "llvm/IR/Module.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "x86-wineh-unwindv2"
+
+STATISTIC(MeetsUnwindV2Criteria,
+          "Number of functions that meet Unwind v2 criteria");
+STATISTIC(FailsUnwindV2Criteria,
+          "Number of functions that fail Unwind v2 criteria");
+
+namespace {
+
+class X86WinEHUnwindV2 : public MachineFunctionPass {
+public:
+  static char ID;
+
+  X86WinEHUnwindV2() : MachineFunctionPass(ID) {
+    initializeX86WinEHUnwindV2Pass(*PassRegistry::getPassRegistry());
+  }
+
+  StringRef getPassName() const override { return "WinEH Unwind V2"; }
+
+  bool runOnMachineFunction(MachineFunction &MF) override;
+  bool rejectCurrentFunction() const {
+    FailsUnwindV2Criteria++;
+    return false;
+  }
+};
+
+enum class FunctionState {
+  InProlog,
+  HasProlog,
+  InEpilog,
+  FinishedEpilog,
+};
+
+} // end anonymous namespace
+
+char X86WinEHUnwindV2::ID = 0;
+
+INITIALIZE_PASS(X86WinEHUnwindV2, "x86-wineh-unwindv2",
+                "Analyze and emit instructions for Win64 Unwind v2", false,
+                false)
+
+FunctionPass *llvm::createX86WinEHUnwindV2Pass() {
+  return new X86WinEHUnwindV2();
+}
+
+bool X86WinEHUnwindV2::runOnMachineFunction(MachineFunction &MF) {
+  if (!MF.getFunction().getParent()->getModuleFlag("winx64-eh-unwindv2"))
+    return false;
+
+  // Current state of processing the function. We'll assume that all functions
+  // start with a prolog.
+  FunctionState State = FunctionState::InProlog;
+
+  // Prolog information.
+  SmallVector<int64_t> PushedRegs;
+  bool HasStackAlloc = false;
+
+  // Requested changes.
+  SmallVector<MachineInstr *> UnwindV2StartLocations;
+
+  for (MachineBasicBlock &MBB : MF) {
+    // Current epilog information. We assume that epilogs cannot cross basic
+    // block boundaries.
+    unsigned PoppedRegCount = 0;
+    bool HasStackDealloc = false;
+    MachineInstr *UnwindV2StartLocation = nullptr;
+
+    for (MachineInstr &MI : MBB) {
+      switch (MI.getOpcode()) {
+      //
+      // Prolog handling.
+      //
+      case X86::SEH_PushReg:
+        if (State != FunctionState::InProlog)
+          llvm_unreachable("SEH_PushReg outside of prolog");
+        PushedRegs.push_back(MI.getOperand(0).getImm());
+        break;
+
+      case X86::SEH_StackAlloc:
+      case X86::SEH_SetFrame:
+        if (State != FunctionState::InProlog)
+          llvm_unreachable("SEH_StackAlloc or SEH_SetFrame outside of prolog");
+        HasStackAlloc = true;
+        break;
+
+      case X86::SEH_EndPrologue:
+        if (State != FunctionState::InProlog)
+          llvm_unreachable("SEH_EndPrologue outside of prolog");
+        State = FunctionState::HasProlog;
+        break;
+
+      //
+      // Epilog handling.
+      //
+      case X86::SEH_BeginEpilogue:
+        if (State != FunctionState::HasProlog)
+          llvm_unreachable("SEH_BeginEpilogue in prolog or another epilog");
+        State = FunctionState::InEpilog;
+        break;
+
+      case X86::SEH_EndEpilogue:
+        if (State != FunctionState::InEpilog)
+          llvm_unreachable("SEH_EndEpilogue outside of epilog");
+        if ((HasStackAlloc != HasStackDealloc) ||
+            (PoppedRegCount != PushedRegs.size()))
+          // Non-canonical epilog, reject the function.
+          return rejectCurrentFunction();
+
+        // If we didn't find the start location, then use the end of the
+        // epilog.
+        if (!UnwindV2StartLocation)
+          UnwindV2StartLocation = &MI;
+        UnwindV2StartLocations.push_back(UnwindV2StartLocation);
+        State = FunctionState::FinishedEpilog;
+        break;
+
+      case X86::MOV64rr:
+      case X86::ADD64ri32:
+        if (State == FunctionState::InEpilog) {
+          // If the prolog contains a stack allocation, then the first
+          // instruction in the epilog must be to adjust the stack pointer.
+          if (!HasStackAlloc || HasStackDealloc || (PoppedRegCount > 0)) {
+            return rejectCurrentFunction();
+          }
+          HasStackDealloc = true;
+        } else if (State == FunctionState::FinishedEpilog)
+          // Unexpected instruction after the epilog.
+          return rejectCurrentFunction();
+        break;
+
+      case X86::POP64r:
+        if (State == FunctionState::InEpilog) {
+          // After the stack pointer has been adjusted, the epilog must
+          // POP each register in reverse order of the PUSHes in the prolog.
+          PoppedRegCount++;
+          if ((HasStackAlloc != HasStackDealloc) ||
+              (PoppedRegCount > PushedRegs.size()) ||
+              (PushedRegs[PushedRegs.size() - PoppedRegCount] !=
+               MI.getOperand(0).getReg())) {
+            return rejectCurrentFunction();
+          }
+
+          // Unwind v2 records the size of the epilog not from where we place
+          // SEH_BeginEpilogue (as that contains the instruction to adjust the
+          // stack pointer) but from the first POP instruction (if there is
+          // one).
+          if (!UnwindV2StartLocation) {
+            assert(PoppedRegCount == 1);
+            UnwindV2StartLocation = &MI;
+          }
+        } else if (State == FunctionState::FinishedEpilog)
+          // Unexpected instruction after the epilog.
+          return rejectCurrentFunction();
+        break;
+
+      default:
+        if (MI.isTerminator()) {
+          if (State == FunctionState::FinishedEpilog)
+            // Found the terminator after the epilog, we're now ready for
+            // another epilog.
+            State = FunctionState::HasProlog;
+          else if (State == FunctionState::InEpilog)
+            llvm_unreachable("Terminator in the middle of the epilog");
+        } else if (!MI.isDebugOrPseudoInstr()) {
+          if ((State == FunctionState::FinishedEpilog) ||
+              (State == FunctionState::InEpilog))
+            // Unknown instruction in or after the epilog.
+            return rejectCurrentFunction();
+        }
+      }
+    }
+  }
+
+  if (UnwindV2StartLocations.empty()) {
+    assert(State == FunctionState::InProlog &&
+           "If there are no epilogs, then there should be no prolog");
+    return false;
+  }
+
+  MeetsUnwindV2Criteria++;
+
+  // Emit the pseudo instruction that marks the start of each epilog.
+  const TargetInstrInfo *TII = MF.getSubtarget().getInstrInfo();
+  for (MachineInstr *MI : UnwindV2StartLocations) {
+    BuildMI(*MI->getParent(), MI, MI->getDebugLoc(),
+            TII->get(X86::SEH_UnwindV2Start));
+  }
+  // Note that the function is using Unwind v2.
+  MachineBasicBlock &FirstMBB = MF.front();
+  BuildMI(FirstMBB, FirstMBB.front(), FirstMBB.front().getDebugLoc(),
+          TII->get(X86::SEH_UnwindVersion))
+      .addImm(2);
+
+  return true;
+}

--- a/llvm/test/CodeGen/X86/win64-eh-unwindv2.ll
+++ b/llvm/test/CodeGen/X86/win64-eh-unwindv2.ll
@@ -1,0 +1,160 @@
+; RUN: llc -mtriple=x86_64-unknown-windows-msvc -o - %s | FileCheck %s
+
+define dso_local void @no_epilog() local_unnamed_addr {
+entry:
+  ret void
+}
+; CHECK-LABEL:  no_epilog:
+; CHECK-NOT:    .seh_
+; CHECK:        retq
+
+define dso_local void @stack_alloc_no_pushes() local_unnamed_addr {
+entry:
+  call void @a()
+  ret void
+}
+; CHECK-LABEL:  stack_alloc_no_pushes:
+; CHECK:        .seh_unwindversion 2
+; CHECK-NOT:    .seh_pushreg
+; CHECK:        .seh_stackalloc
+; CHECK:        .seh_endprologue
+; CHECK-NOT:    .seh_endproc
+; CHECK:        .seh_startepilogue
+; CHECK-NEXT:   addq
+; CHECK-NEXT:   .seh_unwindv2start
+; CHECK-NEXT:   .seh_endepilogue
+; CHECK-NEXT:   retq
+
+define dso_local i32 @stack_alloc_and_pushes(i32 %x) local_unnamed_addr {
+entry:
+  %call = tail call i32 @c(i32 %x)
+  %call1 = tail call i32 @c(i32 %x)
+  %add = add nsw i32 %call1, %call
+  %call2 = tail call i32 @c(i32 %x)
+  %call3 = tail call i32 @c(i32 %call2)
+  %add4 = add nsw i32 %add, %call3
+  ret i32 %add4
+}
+; CHECK-LABEL:  stack_alloc_and_pushes:
+; CHECK:        .seh_unwindversion 2
+; CHECK:        .seh_pushreg %rsi
+; CHECK:        .seh_pushreg %rdi
+; CHECK:        .seh_pushreg %rbx
+; CHECK:        .seh_stackalloc
+; CHECK:        .seh_endprologue
+; CHECK-NOT:    .seh_endproc
+; CHECK:        .seh_startepilogue
+; CHECK-NEXT:   addq
+; CHECK-NEXT:   .seh_unwindv2start
+; CHECK-NEXT:   popq    %rbx
+; CHECK-NEXT:   popq    %rdi
+; CHECK-NEXT:   popq    %rsi
+; CHECK-NEXT:   .seh_endepilogue
+; CHECK-NEXT:   retq
+
+define dso_local i32 @tail_call(i32 %x) local_unnamed_addr {
+entry:
+  %call = tail call i32 @c(i32 %x)
+  %call1 = tail call i32 @c(i32 %call)
+  ret i32 %call1
+}
+; CHECK-LABEL:  tail_call:
+; CHECK:        .seh_unwindversion 2
+; CHECK-NOT:    .seh_pushreg
+; CHECK:        .seh_stackalloc
+; CHECK:        .seh_endprologue
+; CHECK-NOT:    .seh_endproc
+; CHECK:        .seh_startepilogue
+; CHECK-NEXT:   addq
+; CHECK-NEXT:   .seh_unwindv2start
+; CHECK-NEXT:   .seh_endepilogue
+; CHECK-NEXT:   jmp
+
+define dso_local i32 @multiple_epilogs(i32 %x) local_unnamed_addr {
+entry:
+  %call = tail call i32 @c(i32 noundef %x)
+  %cmp = icmp sgt i32 %call, 0
+  br i1 %cmp, label %if.then, label %if.else
+
+if.then:
+  %call1 = tail call i32 @c(i32 noundef %call)
+  ret i32 %call1
+
+if.else:
+  %call2 = tail call i32 @b()
+  ret i32 %call2
+}
+; CHECK-LABEL:  multiple_epilogs:
+; CHECK:        .seh_unwindversion 2
+; CHECK-NOT:    .seh_pushreg
+; CHECK:        .seh_stackalloc
+; CHECK:        .seh_endprologue
+; CHECK-NOT:    .seh_endproc
+; CHECK:        .seh_startepilogue
+; CHECK-NEXT:   addq
+; CHECK-NEXT:   .seh_unwindv2start
+; CHECK-NEXT:   .seh_endepilogue
+; CHECK-NEXT:   jmp
+; CHECK-NOT:    .seh_endproc
+; CHECK:        .seh_startepilogue
+; CHECK-NEXT:   addq
+; CHECK-NEXT:   .seh_unwindv2start
+; CHECK-NEXT:   .seh_endepilogue
+; CHECK-NEXT:   jmp
+
+define dso_local i32 @mismatched_terminators() local_unnamed_addr {
+entry:
+  %call = tail call i32 @b()
+  %cmp = icmp sgt i32 %call, 0
+  br i1 %cmp, label %if.then, label %if.else
+
+if.then:
+  %call1 = tail call i32 @b()
+  ret i32 %call1
+
+if.else:
+  ret i32 %call
+}
+; CHECK-LABEL:  mismatched_terminators:
+; CHECK:        .seh_unwindversion 2
+; CHECK-NOT:    .seh_pushreg
+; CHECK:        .seh_stackalloc
+; CHECK:        .seh_endprologue
+; CHECK-NOT:    .seh_endproc
+; CHECK:        .seh_startepilogue
+; CHECK-NEXT:   addq
+; CHECK-NEXT:   .seh_unwindv2start
+; CHECK-NEXT:   .seh_endepilogue
+; CHECK-NEXT:   jmp
+; CHECK-NOT:    .seh_endproc
+; CHECK:        .seh_startepilogue
+; CHECK-NEXT:   addq
+; CHECK-NEXT:   .seh_unwindv2start
+; CHECK-NEXT:   .seh_endepilogue
+; CHECK-NEXT:   ret
+
+define dso_local void @dynamic_stack_alloc(i32 %x) local_unnamed_addr {
+entry:
+  %y = alloca i32, i32 %x
+  ret void
+}
+; CHECK-LABEL:  dynamic_stack_alloc:
+; CHECK:        .seh_unwindversion 2
+; CHECK:        .seh_pushreg %rbp
+; CHECK:        .seh_setframe %rbp, 0
+; CHECK:        .seh_endprologue
+; CHECK-NOT:    .seh_endproc
+; CHECK:        .seh_startepilogue
+; CHECK-NEXT:   movq    %rbp, %rsp
+; CHECK-NEXT:   .seh_unwindv2start
+; CHECK-NEXT:   popq    %rbp
+; CHECK-NEXT:   .seh_endepilogue
+; CHECK-NEXT:   retq
+; CHECK-NEXT:   .seh_endproc
+
+declare void @a() local_unnamed_addr
+declare i32 @b() local_unnamed_addr
+declare i32 @c(i32) local_unnamed_addr
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"winx64-eh-unwindv2", i32 1}

--- a/llvm/test/MC/AsmParser/seh-directive-errors.s
+++ b/llvm/test/MC/AsmParser/seh-directive-errors.s
@@ -17,6 +17,9 @@
 	.seh_endepilogue
 	# CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: .seh_ directive must appear within an active frame
 
+	.seh_unwindv2start
+	# CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: .seh_ directive must appear within an active frame
+
 	.def	 f;
 	.scl	2;
 	.type	32;
@@ -130,5 +133,29 @@ i:
 	.seh_setframe %xmm0, 16
 # CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: register is not supported for use with this directive
 	.seh_endprologue
+	ret
+	.seh_endproc
+
+j:
+	.seh_proc j
+	.seh_unwindversion 1
+# CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: Unsupported version specified in .seh_unwindversion in j
+	.seh_unwindversion 2
+	.seh_unwindversion 2
+# CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: Duplicate .seh_unwindversion in j
+	.seh_endprologue
+	.seh_unwindv2start
+# CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: Stray .seh_unwindv2start in j
+
+	.seh_startepilogue
+	.seh_endepilogue
+# CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: Missing .seh_unwindv2start in j
+	ret
+
+	.seh_startepilogue
+	.seh_unwindv2start
+	.seh_unwindv2start
+# CHECK: :[[@LINE-1]]:{{[0-9]+}}: error: Duplicate .seh_unwindv2start in j
+	.seh_endepilogue
 	ret
 	.seh_endproc

--- a/llvm/test/MC/COFF/bad-parse.s
+++ b/llvm/test/MC/COFF/bad-parse.s
@@ -11,3 +11,14 @@
         .secoffset
 // CHECK: [[@LINE+1]]:{{[0-9]+}}: error: unexpected token in directive
         .secoffset section extra
+
+// CHECK: [[@LINE+1]]:{{[0-9]+}}: error: expected unwind version number
+        .seh_unwindversion
+// CHECK: [[@LINE+1]]:{{[0-9]+}}: error: expected unwind version number
+        .seh_unwindversion hello
+// CHECK: [[@LINE+1]]:{{[0-9]+}}: error: invalid unwind version
+        .seh_unwindversion 0
+// CHECK: [[@LINE+1]]:{{[0-9]+}}: error: invalid unwind version
+        .seh_unwindversion 9000
+// CHECK: [[@LINE+1]]:{{[0-9]+}}: error: unexpected token in directive
+        .seh_unwindversion 2 hello

--- a/llvm/test/MC/COFF/seh-unwindv2.s
+++ b/llvm/test/MC/COFF/seh-unwindv2.s
@@ -1,0 +1,154 @@
+// RUN: llvm-mc -triple x86_64-pc-win32 -filetype=obj %s | llvm-readobj -u - | FileCheck %s
+
+// CHECK:       UnwindInformation [
+
+.text
+
+single_epilog_atend:
+    .seh_proc stack_alloc_no_pushes
+    .seh_unwindversion 2
+    subq    $40, %rsp
+    .seh_stackalloc 40
+    .seh_endprologue
+    callq   a
+    nop
+    .seh_startepilogue
+    addq    $40, %rsp
+    .seh_unwindv2start
+    .seh_endepilogue
+    retq
+    .seh_endproc
+// CHECK-LABEL:  StartAddress: single_epilog_atend
+// CHECK-NEXT:   EndAddress: single_epilog_atend +0xF
+// CHECK-NEXT:   UnwindInfoAddress: .xdata
+// CHECK-NEXT:   UnwindInfo {
+// CHECK-NEXT:     Version: 2
+// CHECK-NEXT:     Flags [ (0x0)
+// CHECK-NEXT:     ]
+// CHECK-NEXT:     PrologSize: 4
+// CHECK-NEXT:     FrameRegister: -
+// CHECK-NEXT:     FrameOffset: -
+// CHECK-NEXT:     UnwindCodeCount: 3
+// CHECK-NEXT:     UnwindCodes [
+// CHECK-NEXT:       0x01: EPILOG atend=yes, length=0x1
+// CHECK-NEXT:       0x00: EPILOG padding
+// CHECK-NEXT:       0x04: ALLOC_SMALL size=40
+// CHECK-NEXT:     ]
+// CHECK-NEXT:   }
+
+single_epilog_notatend:
+    .seh_proc stack_alloc_no_pushes
+    .seh_unwindversion 2
+    subq    $40, %rsp
+    .seh_stackalloc 40
+    .seh_endprologue
+    callq   a
+    nop
+    .seh_startepilogue
+    addq    $40, %rsp
+    .seh_unwindv2start
+    .seh_endepilogue
+    retq
+    nop
+    .seh_endproc
+// CHECK-LABEL:  StartAddress: single_epilog_notatend
+// CHECK-NEXT:   EndAddress: single_epilog_notatend +0x10
+// CHECK-NEXT:   UnwindInfoAddress: .xdata +0xC
+// CHECK-NEXT:   UnwindInfo {
+// CHECK-NEXT:     Version: 2
+// CHECK-NEXT:     Flags [ (0x0)
+// CHECK-NEXT:     ]
+// CHECK-NEXT:     PrologSize: 4
+// CHECK-NEXT:     FrameRegister: -
+// CHECK-NEXT:     FrameOffset: -
+// CHECK-NEXT:     UnwindCodeCount: 3
+// CHECK-NEXT:     UnwindCodes [
+// CHECK-NEXT:       0x01: EPILOG atend=no, length=0x1
+// CHECK-NEXT:       0x02: EPILOG offset=0x2
+// CHECK-NEXT:       0x04: ALLOC_SMALL size=40
+// CHECK-NEXT:     ]
+// CHECK-NEXT:   }
+
+multiple_epilogs:
+    .seh_proc multiple_epilogs
+    .seh_unwindversion 2
+    subq    $40, %rsp
+    .seh_stackalloc 40
+    .seh_endprologue
+    callq   c
+    testl   %eax, %eax
+    jle     .L_ELSE_1
+    movl    %eax, %ecx
+    .seh_startepilogue
+    addq    $40, %rsp
+    .seh_unwindv2start
+    .seh_endepilogue
+    jmp     c
+.L_ELSE_1:
+    nop
+    .seh_startepilogue
+    addq    $40, %rsp
+    .seh_unwindv2start
+    .seh_endepilogue
+    jmp     b
+    .seh_endproc
+// CHECK-LABEL:  StartAddress: multiple_epilogs
+// CHECK-NEXT:   EndAddress: multiple_epilogs +0x22
+// CHECK-NEXT:   UnwindInfoAddress: .xdata +0x18
+// CHECK-NEXT:   UnwindInfo {
+// CHECK-NEXT:     Version: 2
+// CHECK-NEXT:     Flags [ (0x0)
+// CHECK-NEXT:     ]
+// CHECK-NEXT:     PrologSize: 4
+// CHECK-NEXT:     FrameRegister: -
+// CHECK-NEXT:     FrameOffset: -
+// CHECK-NEXT:     UnwindCodeCount: 5
+// CHECK-NEXT:     UnwindCodes [
+// CHECK-NEXT:       0x01: EPILOG atend=no, length=0x1
+// CHECK-NEXT:       0x05: EPILOG offset=0x5
+// CHECK-NEXT:       0x0F: EPILOG offset=0xF
+// CHECK-NEXT:       0x00: EPILOG padding
+// CHECK-NEXT:       0x04: ALLOC_SMALL size=40
+// CHECK-NEXT:     ]
+// CHECK-NEXT:   }
+
+mismatched_terminators:
+    .seh_proc mismatched_terminators
+    .seh_unwindversion 2
+    subq    $40, %rsp
+    .seh_stackalloc 40
+    .seh_endprologue
+    callq   b
+    testl   %eax, %eax
+    jle     .L_ELSE_1
+# %bb.2:
+    .seh_startepilogue
+    addq    $40, %rsp
+    .seh_unwindv2start
+    .seh_endepilogue
+    jmp     b
+.L_ELSE_2:
+    nop
+    .seh_startepilogue
+    addq    $40, %rsp
+    .seh_unwindv2start
+    .seh_endepilogue
+    retq
+    .seh_endproc
+// CHECK-LABEL:  StartAddress: mismatched_terminators
+// CHECK-NEXT:   EndAddress: mismatched_terminators +0x1C
+// CHECK-NEXT:   UnwindInfoAddress: .xdata +0x28
+// CHECK-NEXT:   UnwindInfo {
+// CHECK-NEXT:     Version: 2
+// CHECK-NEXT:     Flags [ (0x0)
+// CHECK-NEXT:     ]
+// CHECK-NEXT:     PrologSize: 4
+// CHECK-NEXT:     FrameRegister: -
+// CHECK-NEXT:     FrameOffset: -
+// CHECK-NEXT:     UnwindCodeCount: 3
+// CHECK-NEXT:     UnwindCodes [
+// CHECK-NEXT:       0x01: EPILOG atend=yes, length=0x1
+// CHECK-NEXT:       0x0B: EPILOG offset=0xB
+// CHECK-NEXT:       0x04: ALLOC_SMALL size=40
+// CHECK-NEXT:     ]
+// CHECK-NEXT:   }


### PR DESCRIPTION
Adds support for emitting Windows x64 Unwind V2 information, includes support `/d2epilogunwind` in clang-cl.

Unwind v2 adds information about the epilogs in functions such that the unwinder can unwind even in the middle of an epilog, without having to disassembly the function to see what has or has not been cleaned up.

Unwind v2 requires that all epilogs are in "canonical" form:
* If there was a stack allocation (fixed or dynamic) in the prolog, then the first instruction in the epilog must be a stack deallocation.
* Next, for each `PUSH` in the prolog there must be a corresponding `POP` instruction in exact reverse order.
* Finally, the epilog must end with the terminator.

This change adds a pass to validate epilogs in modules that have Unwind v2 enabled and, if they pass, emits new pseudo instructions to MC that 1) note that the function is using unwind v2 and 2) mark the start of the epilog (this is either the first `POP` if there is one, otherwise the terminator instruction). If a function does not meet these requirements, it is downgraded to Unwind v1 (i.e., these new pseudo instructions are not emitted).

Note that the unwind v2 table only marks the size of the epilog in the "header" unwind code, but it's possible for epilogs to use different terminator instructions thus they are not all the same size. As a work around for this, MC will assume that all terminator instructions are 1-byte long - this still works correctly with the Windows unwinder as it is only using the size to do a range check to see if a thread is in an epilog or not, and since the instruction pointer will never be in the middle of an instruction and the terminator is always at the end of an epilog the range check will function correctly. This does mean, however, that the "at end" optimization (where an epilog unwind code can be elided if the last epilog is at the end of the function) can only be used if the terminator is 1-byte long.

One other complication with the implementation is that the unwind table for a function is emitted during streaming, however we can't calculate the distance between an epilog and the end of the function at that time as layout hasn't been completed yet (thus some instructions may be relaxed). To work around this, epilog unwind codes are emitted via a fixup. This also means that we can't pre-emptively downgrade a function to Unwind v1 if one of these offsets is too large, so instead we raise an error (but I've passed through the location information, so the user will know which of their functions is problematic).