### PR TITLE
[NFC][Cloning] Make ClonedModule case more obvious in CollectDebugInfoForCloning

### DIFF
--- a/llvm/lib/Transforms/Utils/CloneFunction.cpp
+++ b/llvm/lib/Transforms/Utils/CloneFunction.cpp
@@ -135,6 +135,10 @@ void llvm::CloneFunctionAttributesInto(Function *NewFunc,
 DISubprogram *llvm::CollectDebugInfoForCloning(const Function &F,
                                                CloneFunctionChangeType Changes,
                                                DebugInfoFinder &DIFinder) {
+  // CloneModule takes care of cloning debug info.
+  if (Changes == CloneFunctionChangeType::ClonedModule)
+    return nullptr;
+
   DISubprogram *SPClonedWithinModule = nullptr;
   if (Changes < CloneFunctionChangeType::DifferentModule) {
     SPClonedWithinModule = F.getSubprogram();
@@ -143,7 +147,7 @@ DISubprogram *llvm::CollectDebugInfoForCloning(const Function &F,
     DIFinder.processSubprogram(SPClonedWithinModule);
 
   const Module *M = F.getParent();
-  if (Changes != CloneFunctionChangeType::ClonedModule && M) {
+  if (M) {
     // Inspect instructions to process e.g. DILexicalBlocks of inlined functions
     for (const auto &I : instructions(F))
       DIFinder.processInstruction(*M, I);


### PR DESCRIPTION
Stacked PRs:
 * #129154
 * #129153
 * #129152
 * #129151
 * #129150
 * #129149
 * #129148
 * #129147
 * #129146
 * #129145
 * #129144
 * __->__#129143


--- --- ---

### [NFC][Cloning] Make ClonedModule case more obvious in CollectDebugInfoForCloning


Summary:
The code's behavior is unchanged, but it's more obvious right now.

Test Plan:
ninja check-llvm-unit check-llvm
