### PR TITLE
[NFC][Coro] Use CloneFunctionInto for coroutine cloning instead of CloneFunction<Part>

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -921,14 +921,8 @@ void coro::BaseCloner::create() {
   auto savedLinkage = NewF->getLinkage();
   NewF->setLinkage(llvm::GlobalValue::ExternalLinkage);
 
-  MetadataPredicate IdentityMD = [&](const Metadata *MD) {
-    return CommonDebugInfo.contains(MD);
-  };
-  CloneFunctionAttributesInto(NewF, &OrigF, VMap, false);
-  CloneFunctionMetadataInto(*NewF, OrigF, VMap, RF_None, nullptr, nullptr,
-                            &IdentityMD);
-  CloneFunctionBodyInto(*NewF, OrigF, VMap, RF_None, Returns, "", nullptr,
-                        nullptr, nullptr, &IdentityMD);
+  CloneFunctionInto(NewF, &OrigF, VMap,
+                    CloneFunctionChangeType::LocalChangesOnly, Returns);
 
   auto &Context = NewF->getContext();
 


### PR DESCRIPTION
Stacked PRs:
 * #129154
 * #129153
 * #129152
 * #129151
 * #129150
 * __->__#129149


--- --- ---

### [NFC][Coro] Use CloneFunctionInto for coroutine cloning instead of CloneFunction<Part>


Summary:
CloneFunctionInto now is fast on its own and we don't need to use
CloneFunctionAttributes/Metadata/Body separately.

CommonDebugInfo in CoroClone is now unused and is cleaned up separately
in the next diff in the stack.

Test Plan:
ninja check-all
