### PR TITLE
[NFC][Cloning] Move DebugInfoFinder decl closer to its place of usage

### DIFF
--- a/llvm/lib/Transforms/Utils/CloneFunction.cpp
+++ b/llvm/lib/Transforms/Utils/CloneFunction.cpp
@@ -266,8 +266,6 @@ void llvm::CloneFunctionInto(Function *NewFunc, const Function *OldFunc,
   if (OldFunc->isDeclaration())
     return;
 
-  DebugInfoFinder DIFinder;
-
   if (Changes < CloneFunctionChangeType::DifferentModule) {
     assert((NewFunc->getParent() == nullptr ||
             NewFunc->getParent() == OldFunc->getParent()) &&
@@ -320,7 +318,8 @@ void llvm::CloneFunctionInto(Function *NewFunc, const Function *OldFunc,
     Visited.insert(Operand);
 
   // Collect and clone all the compile units referenced from the instructions in
-  // the function (e.g. as a scope).
+  // the function (e.g. as instructions' scope).
+  DebugInfoFinder DIFinder;
   collectDebugInfoFromInstructions(*OldFunc, DIFinder);
   for (auto *Unit : DIFinder.compile_units()) {
     MDNode *MappedUnit =


### PR DESCRIPTION
Stacked PRs:
 * __->__#129154
 * #129153
 * #129152
 * #129151
 * #129150
 * #129149


--- --- ---

### [NFC][Cloning] Move DebugInfoFinder decl closer to its place of usage


Summary:
This makes it clear that DIFinder is only really necessary for llvm.dbg.cu update.

Test Plan:
ninja check-llvm-unit
