### PR TITLE
[clang] Add #pragma clang __debug module_lookup

### DIFF
--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -715,6 +715,8 @@ def warn_pragma_debug_unexpected_command : Warning<
   "unexpected debug command '%0'">, InGroup<IgnoredPragmas>;
 def warn_pragma_debug_unknown_module : Warning<
   "unknown module '%0'">, InGroup<IgnoredPragmas>;
+def warn_pragma_debug_unable_to_find_module : Warning<
+  "unable to find module '%0'">, InGroup<IgnoredPragmas>;
 // #pragma module
 def err_pp_expected_module_name : Error<
   "expected %select{identifier after '.' in |}0module name">;

--- a/clang/lib/Lex/Pragma.cpp
+++ b/clang/lib/Lex/Pragma.cpp
@@ -1119,9 +1119,25 @@ struct PragmaDebugHandler : public PragmaHandler {
         M = MM.lookupModuleQualified(IIAndLoc.first->getName(), M);
         if (!M) {
           PP.Diag(IIAndLoc.second, diag::warn_pragma_debug_unknown_module)
-              << IIAndLoc.first;
+              << IIAndLoc.first->getName();
           return;
         }
+      }
+      M->dump();
+    } else if (II->isStr("module_lookup")) {
+      Token MName;
+      PP.LexUnexpandedToken(MName);
+      auto *MNameII = MName.getIdentifierInfo();
+      if (!MNameII) {
+        PP.Diag(MName, diag::warn_pragma_debug_missing_argument)
+            << II->getName();
+        return;
+      }
+      Module *M = PP.getHeaderSearchInfo().lookupModule(MNameII->getName());
+      if (!M) {
+        PP.Diag(MName, diag::warn_pragma_debug_unable_to_find_module)
+            << MNameII->getName();
+        return;
       }
       M->dump();
     } else if (II->isStr("overflow_stack")) {

--- a/clang/test/Modules/clang-pragmas.c
+++ b/clang/test/Modules/clang-pragmas.c
@@ -1,0 +1,22 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -I%t %t/tu.c -fsyntax-only \
+// RUN:   -verify 2>&1 | FileCheck %s
+
+//--- module.modulemap
+
+module A {
+  header "A.h"
+}
+
+//--- A.h
+
+//--- tu.c
+
+#pragma clang __debug module_map A // expected-warning{{unknown module 'A'}}
+#pragma clang __debug module_lookup B // expected-warning{{unable to find module 'B'}}
+#pragma clang __debug module_lookup A // does header search for A
+#pragma clang __debug module_map A // now finds module A
+
+// CHECK: module A
+// CHECK: module A


### PR DESCRIPTION
This can be used to trigger implicit module map lookup without also importing the module. This can be useful for debugging as it avoids loading the module map from the AST file, which has slightly different semantics.