### PR TITLE
[WebAssembly] Make WASI -threads environment behave as -pthread

### DIFF
--- a/clang/lib/Driver/ToolChains/WebAssembly.cpp
+++ b/clang/lib/Driver/ToolChains/WebAssembly.cpp
@@ -69,6 +69,18 @@ static bool TargetBuildsComponents(const llvm::Triple &TargetTriple) {
          TargetTriple.getOSName() != "wasi";
 }
 
+static bool WantsPthread(const llvm::Triple &Triple, const ArgList &Args) {
+  bool WantsPthread =
+      Args.hasFlag(options::OPT_pthread, options::OPT_no_pthread, false);
+
+  // If the WASI environment is "threads" then enable pthreads support
+  // without requiring -pthread, in order to prevent user error
+  if (Triple.isOSWASI() && Triple.getEnvironmentName() == "threads")
+    WantsPthread = true;
+
+  return WantsPthread;
+}
+
 void wasm::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                                 const InputInfo &Output,
                                 const InputInfoList &Inputs,
@@ -150,14 +162,14 @@ void wasm::Linker::ConstructJob(Compilation &C, const JobAction &JA,
 
   AddLinkerInputs(ToolChain, Inputs, Args, CmdArgs, JA);
 
-  if (Args.hasArg(options::OPT_pthread))
+  if (WantsPthread(ToolChain.getTriple(), Args))
     CmdArgs.push_back("--shared-memory");
 
   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nodefaultlibs)) {
     if (ToolChain.ShouldLinkCXXStdlib(Args))
       ToolChain.AddCXXStdlibLibArgs(Args, CmdArgs);
 
-    if (Args.hasArg(options::OPT_pthread))
+    if (WantsPthread(ToolChain.getTriple(), Args))
       CmdArgs.push_back("-lpthread");
 
     CmdArgs.push_back("-lc");
@@ -292,8 +304,7 @@ void WebAssembly::addClangTargetOptions(const ArgList &DriverArgs,
     CC1Args.push_back("-fno-use-init-array");
 
   // '-pthread' implies atomics, bulk-memory, mutable-globals, and sign-ext
-  if (DriverArgs.hasFlag(options::OPT_pthread, options::OPT_no_pthread,
-                         false)) {
+  if (WantsPthread(getTriple(), DriverArgs)) {
     if (DriverArgs.hasFlag(options::OPT_mno_atomics, options::OPT_matomics,
                            false))
       getDriver().Diag(diag::err_drv_argument_not_allowed_with)

--- a/clang/test/Driver/wasm-toolchain.c
+++ b/clang/test/Driver/wasm-toolchain.c
@@ -110,6 +110,12 @@
 // RUN:   | FileCheck -check-prefix=PTHREAD_NO_SIGN_EXT %s
 // PTHREAD_NO_SIGN_EXT: invalid argument '-pthread' not allowed with '-mno-sign-ext'
 
+// 'wasm32-wasi-threads' does the same thing as '-pthread'
+// RUN: %clang -### --target=wasm32-wasi-threads --sysroot=/foo %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=WASI_THREADS %s
+// WASI_THREADS: "-cc1" {{.*}} "-target-feature" "+atomics" "-target-feature" "+bulk-memory" "-target-feature" "+mutable-globals" "-target-feature" "+sign-ext"
+// WASI_THREADS: wasm-ld{{.*}}" "--shared-memory" "-lpthread"
+
 // '-mllvm -emscripten-cxx-exceptions-allowed=foo,bar' sets
 // '-mllvm --force-attribute=foo:noinline -mllvm --force-attribute=bar:noinline'
 // RUN: %clang -### --target=wasm32-unknown-unknown \


### PR DESCRIPTION
If the user specifies a target triple of wasm32-wasi-threads, then enable all of the same flags as if `-pthread` were passed. This helps prevent user error, as the whole point of selecting this target is to gain pthread support.

The reverse does not happen (passing `-pthread` does not alter the target triple) so as to not interfere with custom environments and/or custom multilib setups.