### PR TITLE
[lldb] Make ELF files able to load section headers from memory.

### DIFF
--- a/lldb/source/Plugins/ObjectFile/ELF/ELFHeader.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ELFHeader.h
@@ -100,6 +100,12 @@ struct ELFHeader {
   ///    The byte order of this ELF file as described by the header.
   lldb::ByteOrder GetByteOrder() const;
 
+  /// Get the size in bytes of the section header data.
+  ///
+  /// \return
+  ///   The byte size of the section header data.
+  uint64_t GetSectionHeaderByteSize() const { return e_shnum * e_shentsize; }
+
   /// The jump slot relocation type of this ELF.
   unsigned GetRelocationJumpSlotType() const;
 

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -303,7 +303,7 @@ private:
   /// \return True if the section has a size and all bytes can be read,
   ///         False otherwise.
   using ReadSectionDataCallback =
-  std::function<bool(const elf::ELFSectionHeader &sh,
+  llvm::function_ref<bool(const elf::ELFSectionHeader &sh,
                      lldb_private::DataExtractor &data)>;
 
   /// Parses the elf section headers and returns the uuid, debug link name,

--- a/lldb/test/Shell/ObjectFile/ELF/elf-memory.test
+++ b/lldb/test/Shell/ObjectFile/ELF/elf-memory.test
@@ -19,9 +19,14 @@
 // RUN:   -o "script real_module = lldb.target.module[0]" \
 // RUN:   -o "script base_addr = real_module.GetObjectFileHeaderAddress().GetLoadAddress(lldb.target)" \
 // RUN:   -o "script mem_module = lldb.SBModule(lldb.process, base_addr)" \
+// RUN:   -o 'script vsdo_module = [m for m in lldb.target.modules if m.GetFileSpec().fullpath == "[vdso]"][0]' \
 // RUN:   -o "script target2 = lldb.debugger.CreateTarget('')" \
 // RUN:   -o "script target2.AddModule(mem_module)" \
 // RUN:   -o "target select 1" \
+// RUN:   -o "image dump objfile" \
+// RUN:   -o "script target3 = lldb.debugger.CreateTarget('')" \
+// RUN:   -o "script target3.AddModule(vsdo_module)" \
+// RUN:   -o "target select 2" \
 // RUN:   -o "image dump objfile" \
 // RUN:   | FileCheck %s --check-prefix=MAIN --dump-input=always
 // MAIN: (lldb) image dump objfile
@@ -32,6 +37,9 @@
 // Make sure we find the program headers and see a PT_DYNAMIC entry.
 // MAIN: Program Headers
 // MAIN: ] PT_DYNAMIC
+
+// Make sure there are no section headers for when they aren't loaded
+// MAIN-NOT: Section Headers
 
 // Make sure we see some sections created from the program headers
 // MAIN: SectID
@@ -52,4 +60,36 @@
 // MAIN-DAG: STRSZ {{0x[0-9a-f]+}}
 // MAIN-DAG: SYMENT {{0x[0-9a-f]+}}
 // MAIN-DAG: DEBUG {{0x[0-9a-f]+}}
+// MAIN:     NULL {{0x[0-9a-f]+}}
+
+// Watch for the dump of the VSDO image. This should have section headers
+// MAIN: ObjectFileELF, file = '', arch = {{.*, addr = 0x[0-9a-f]+}}
+// MAIN: ELF Header
+
+// Make sure we find the program headers and see a PT_DYNAMIC entry.
+// MAIN: Program Headers
+// MAIN: ] PT_DYNAMIC
+
+// Make sure we find the section headers with at least a .text section to
+// ensure we found the sections and their names.
+// MAIN: Section Headers
+// MAIN: .text
+
+// Make sure we see some sections created from the program headers
+// MAIN: SectID
+// MAIN: PT_LOAD[0]
+
+// Ensure we find some dependent modules as won't find these if we aren't able
+// to load the .dynamic section from the PT_DYNAMIC program header.
+// MAIN-NOT: Dependent Modules:
+
+// Check for the .dynamic dump and ensure we find all dynamic entries that are
+// required to be there and needed to get the .dynstr section and the symbol
+// table, and the DT_DEBUG entry to find the list of shared libraries.
+// MAIN: .dynamic:
+// Make sure we found the .dynstr section by checking for valid strings after NEEDED
+// MAIN-DAG: STRTAB {{0x[0-9a-f]+}}
+// MAIN-DAG: SYMTAB {{0x[0-9a-f]+}}
+// MAIN-DAG: STRSZ {{0x[0-9a-f]+}}
+// MAIN-DAG: SYMENT {{0x[0-9a-f]+}}
 // MAIN:     NULL {{0x[0-9a-f]+}}


### PR DESCRIPTION
When we don't specify the size of an ELF image when loading from memory, our data for the ELF file might end up being truncated to only include the ELF header and the program headers. The ObjectFileELF class was able to load program header contents, this patch modifies the class so the section headers can still be loaded even if they are not included in the data buffer.