### PR TITLE
[SystemZ] Add header guard macros to vecintrin.h

### DIFF
--- a/clang/lib/Headers/vecintrin.h
+++ b/clang/lib/Headers/vecintrin.h
@@ -7,6 +7,9 @@
  *===-----------------------------------------------------------------------===
  */
 
+#ifndef _VECINTRIN_H
+#define _VECINTRIN_H
+
 #if defined(__s390x__) && defined(__VEC__)
 
 #define __ATTRS_ai __attribute__((__always_inline__))
@@ -12861,3 +12864,5 @@ vec_search_string_until_zero_cc(__vector unsigned int __a,
 #error "Use -fzvector to enable vector extensions"
 
 #endif
+
+#endif /* _VECINTRIN_H */


### PR DESCRIPTION
Add header guard macros to clang/lib/Headers/vecintrin.h. Found while compiling the latest numpy with clang 19 on s390x which ends up including vecintrin.h twice. The gcc version of this file has header guards so numpy compiles fine with gcc.

I'd like if this could also make it into a clang 19 release if possible.

@uweigand, could you have a look at this?