### PR TITLE
[Clang][OpenCL] Wrap image functions with the macro

### DIFF
--- a/clang/lib/Headers/opencl-c-base.h
+++ b/clang/lib/Headers/opencl-c-base.h
@@ -55,6 +55,10 @@
 #endif // defined(__SPIR__) || defined(__SPIRV__)
 #endif // (defined(__OPENCL_CPP_VERSION__) || __OPENCL_C_VERSION__ >= 200)
 
+#if (__OPENCL_C_VERSION__ == 120)
+#define __opencl_c_images 1
+#endif // (__OPENCL_C_VERSION__ == 120)
+
 // Define feature macros for OpenCL C 2.0
 #if (__OPENCL_CPP_VERSION__ == 100 || __OPENCL_C_VERSION__ == 200)
 #define __opencl_c_pipes 1

--- a/clang/lib/Headers/opencl-c.h
+++ b/clang/lib/Headers/opencl-c.h
@@ -15082,6 +15082,7 @@ half16 __ovld __cnfn shuffle2(half16, half16, ushort16);
 #pragma OPENCL EXTENSION cl_khr_gl_msaa_sharing : enable
 #endif //cl_khr_gl_msaa_sharing
 
+#if defined(__opencl_c_images)
 /**
  * Use the coordinate (coord.xy) to do an element lookup in
  * the 2D image object specified by image.
@@ -16142,6 +16143,8 @@ int __ovld __cnfn get_image_num_samples(read_write image2d_array_msaa_t);
 int __ovld __cnfn get_image_num_samples(read_write image2d_array_msaa_depth_t);
 #endif //defined(__opencl_c_read_write_images)
 #endif
+
+#endif // defined(__opencl_c_images)
 
 // OpenCL v2.0 s6.13.15 - Work-group Functions
 


### PR DESCRIPTION
According to the OpenCL C 3.0 spec, the image functions are optional.
If they are supported, the `__opencl_c_images` macro is defined. This
patch wraps the image functions with the macro. Without the wrapping,
the frontend emit errors, when a user tries to disable the images
support.