### PR TITLE
[NVPTX] Delete `IsSimpleMove` (NFC)

### DIFF
--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXBaseInfo.h
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXBaseInfo.h
@@ -24,12 +24,14 @@ using namespace NVPTXAS;
 namespace NVPTXII {
 enum {
   // These must be kept in sync with TSFlags in NVPTXInstrFormats.td
-  IsTexFlag = 0x80,
-  IsSuldMask = 0x300,
-  IsSuldShift = 8,
-  IsSustFlag = 0x400,
-  IsSurfTexQueryFlag = 0x800,
-  IsTexModeUnifiedFlag = 0x1000
+  // clang-format off
+  IsTexFlag            =  0x40,
+  IsSuldMask           = 0x180,
+  IsSuldShift          =   0x7,
+  IsSustFlag           = 0x200,
+  IsSurfTexQueryFlag   = 0x400,
+  IsTexModeUnifiedFlag = 0x800,
+  // clang-format on
 };
 } // namespace NVPTXII
 

--- a/llvm/lib/Target/NVPTX/NVPTXInstrFormats.td
+++ b/llvm/lib/Target/NVPTX/NVPTXInstrFormats.td
@@ -31,7 +31,6 @@ class NVPTXInst<dag outs, dag ins, string asmstr, list<dag> pattern>
 
   // TSFlagFields
   bits<4> VecInstType = VecNOP.Value;
-  bit IsSimpleMove = false;
   bit IsLoad = false;
   bit IsStore = false;
 
@@ -46,13 +45,12 @@ class NVPTXInst<dag outs, dag ins, string asmstr, list<dag> pattern>
   // 2**(2-1) = 2.
   bits<2> IsSuld = 0;
 
-  let TSFlags{3...0}   = VecInstType;
-  let TSFlags{4...4}   = IsSimpleMove;
-  let TSFlags{5...5}   = IsLoad;
-  let TSFlags{6...6}   = IsStore;
-  let TSFlags{7}       = IsTex;
-  let TSFlags{9...8}   = IsSuld;
-  let TSFlags{10}      = IsSust;
-  let TSFlags{11}      = IsSurfTexQuery;
-  let TSFlags{12}      = IsTexModeUnified;
+  let TSFlags{3...0}  = VecInstType;
+  let TSFlags{4}      = IsLoad;
+  let TSFlags{5}      = IsStore;
+  let TSFlags{6}      = IsTex;
+  let TSFlags{8...7}  = IsSuld;
+  let TSFlags{9}      = IsSust;
+  let TSFlags{10}     = IsSurfTexQuery;
+  let TSFlags{11}     = IsTexModeUnified;
 }

--- a/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
+++ b/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
@@ -1961,7 +1961,7 @@ let hasSideEffects = false in {
 
 
 // copyPhysreg is hard-coded in NVPTXInstrInfo.cpp
-let IsSimpleMove=1, hasSideEffects=0, isAsCheapAsAMove=1 in {
+let hasSideEffects=0, isAsCheapAsAMove=1 in {
   def IMOV1rr :  NVPTXInst<(outs Int1Regs:$dst), (ins Int1Regs:$sss),
                            "mov.pred \t$dst, $sss;", []>;
   def IMOV16rr : NVPTXInst<(outs Int16Regs:$dst), (ins Int16Regs:$sss),


### PR DESCRIPTION
This field is never used, so we should remove it. 