### PR TITLE
[MLIR][Affine] Fix copy generation for missing memref definition depth check

### DIFF
--- a/mlir/test/Dialect/Affine/affine-data-copy.mlir
+++ b/mlir/test/Dialect/Affine/affine-data-copy.mlir
@@ -419,3 +419,15 @@ func.func @scalar_memref_copy_in_loop(%3:memref<480xi1>) {
   // CHECK: memref.dealloc %[[FAST_MEMREF]] : memref<480xi1>
   return
 }
+
+// CHECK-LABEL: func @memref_def_inside
+func.func @memref_def_inside(%arg0: index) {
+  %0 = llvm.mlir.constant(1.000000e+00 : f32) : f32
+  // No copy generation can happen at this depth given the definition inside.
+  affine.for %arg1 = 0 to 29 {
+    %alloc_7 = memref.alloc() : memref<1xf32>
+    // CHECK: affine.store {{.*}} : memref<1xf32>
+    affine.store %0, %alloc_7[0] : memref<1xf32>
+  }
+  return
+}


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/122210
