### PR TITLE
[MLIR][Affine] Fix bug in `simplifySemiAffine` utility

### DIFF
--- a/mlir/lib/IR/AffineExpr.cpp
+++ b/mlir/lib/IR/AffineExpr.cpp
@@ -597,7 +597,11 @@ static AffineExpr simplifySemiAffine(AffineExpr expr, unsigned numDims,
       return getAffineBinaryOpExpr(expr.getKind(), sLHS, sRHS);
     if (expr.getKind() == AffineExprKind::Mod)
       return getAffineConstantExpr(0, expr.getContext());
-    return symbolicDivide(sLHS, symbolPos, expr.getKind());
+    AffineExpr simplifiedQuotient =
+        symbolicDivide(sLHS, symbolPos, expr.getKind());
+    return simplifiedQuotient
+               ? simplifiedQuotient
+               : getAffineBinaryOpExpr(expr.getKind(), sLHS, sRHS);
   }
   }
   llvm_unreachable("Unknown AffineExpr");


### PR DESCRIPTION
Whenever `symbolicDivide` returns nullptr when called from inside `simplifySemiAffine` we substitute the result with the original expression (`expr`). nullptr simply indicates that the floordiv expression cannot be simplified further.

Fixes: https://github.com/llvm/llvm-project/issues/122231