### PR TITLE
[MLIR][OpenMP] - Fix translation of omp.target when private variables need cleaning up

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -4832,6 +4832,7 @@ convertOmpTarget(Operation &opInst, llvm::IRBuilderBase &builder,
             "failed to inline `dealloc` region of `omp.private` "
             "op in the target region");
       }
+      return builder.saveIP();
     }
 
     return InsertPointTy(exitBlock.get(), exitBlock.get()->end());


### PR DESCRIPTION
This is a simple fix that ensures that the InsertPoint is properly fixed up after we have translated the dealloc region of all privatized variables during translation of omp.target from MLIR to LLVMIR.

Fix for https://github.com/llvm/llvm-project/issues/129202