### PR TITLE
[clang-tidy] Contributing.rst update snippet and docs

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/Contributing.rst
+++ b/clang-tools-extra/docs/clang-tidy/Contributing.rst
@@ -149,6 +149,9 @@ After choosing the module and the name for the check, run the
 ``clang-tidy/add_new_check.py`` script to create the skeleton of the check and
 plug it to :program:`clang-tidy`. It's the recommended way of adding new checks.
 
+By default, the new check will apply only to C++ code. If it should apply under
+different language options, use the ``--language`` script's parameter.
+
 If we want to create a `readability-awesome-function-names`, we would run:
 
 .. code-block:: console
@@ -171,9 +174,7 @@ Let's see in more detail at the check class definition:
 
   #include "../ClangTidyCheck.h"
 
-  namespace clang {
-  namespace tidy {
-  namespace readability {
+  namespace clang::tidy::readability {
 
   ...
   class AwesomeFunctionNamesCheck : public ClangTidyCheck {
@@ -182,11 +183,12 @@ Let's see in more detail at the check class definition:
         : ClangTidyCheck(Name, Context) {}
     void registerMatchers(ast_matchers::MatchFinder *Finder) override;
     void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+    bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
+      return LangOpts.CPlusPlus;
+    }
   };
 
-  } // namespace readability
-  } // namespace tidy
-  } // namespace clang
+  } // namespace clang::tidy::readability
 
   ...
 
@@ -230,9 +232,6 @@ If you need to interact with macros or preprocessor directives, you will want to
 override the method ``registerPPCallbacks``.  The ``add_new_check.py`` script
 does not generate an override for this method in the starting point for your
 new check.
-
-If your check applies only under a specific set of language options, be sure
-to override the method ``isLanguageVersionSupported`` to reflect that.
 
 Check development tips
 ----------------------


### PR DESCRIPTION
This reflects the add_new_check.py changes: isLanguageVersionSupported is now overridden by default by the script

The changes were instroduced in https://github.com/llvm/llvm-project/pull/100129

Thanks