### PR TITLE
[C++20] [Modules] Support generating in-class defined function with try-catch body

### DIFF
--- a/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -632,6 +632,11 @@ void Parser::ParseLexedMethodDef(LexedMethod &LM) {
 
     if (Tok.is(tok::eof) && Tok.getEofData() == LM.D)
       ConsumeAnyToken();
+
+    if (auto *FD = dyn_cast_or_null<FunctionDecl>(LM.D))
+      if (isa<CXXMethodDecl>(FD) ||
+          FD->isInIdentifierNamespace(Decl::IDNS_OrdinaryFriend))
+        Actions.ActOnFinishInlineFunctionDef(FD);
     return;
   }
   if (Tok.is(tok::colon)) {

--- a/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -626,6 +626,12 @@ void Parser::ParseLexedMethodDef(LexedMethod &LM) {
   Actions.ActOnStartOfFunctionDef(getCurScope(), LM.D);
 
   auto _ = llvm::make_scope_exit([&]() {
+    while (Tok.isNot(tok::eof))
+      ConsumeAnyToken();
+
+    if (Tok.is(tok::eof) && Tok.getEofData() == LM.D)
+      ConsumeAnyToken();
+
     if (auto *FD = dyn_cast_or_null<FunctionDecl>(LM.D))
       if (isa<CXXMethodDecl>(FD) ||
           FD->isInIdentifierNamespace(Decl::IDNS_OrdinaryFriend))
@@ -634,12 +640,6 @@ void Parser::ParseLexedMethodDef(LexedMethod &LM) {
 
   if (Tok.is(tok::kw_try)) {
     ParseFunctionTryBlock(LM.D, FnScope);
-
-    while (Tok.isNot(tok::eof))
-      ConsumeAnyToken();
-
-    if (Tok.is(tok::eof) && Tok.getEofData() == LM.D)
-      ConsumeAnyToken();
     return;
   }
   if (Tok.is(tok::colon)) {
@@ -649,12 +649,6 @@ void Parser::ParseLexedMethodDef(LexedMethod &LM) {
     if (!Tok.is(tok::l_brace)) {
       FnScope.Exit();
       Actions.ActOnFinishFunctionBody(LM.D, nullptr);
-
-      while (Tok.isNot(tok::eof))
-        ConsumeAnyToken();
-
-      if (Tok.is(tok::eof) && Tok.getEofData() == LM.D)
-        ConsumeAnyToken();
       return;
     }
   } else
@@ -668,12 +662,6 @@ void Parser::ParseLexedMethodDef(LexedMethod &LM) {
          "current template being instantiated!");
 
   ParseFunctionStatementBody(LM.D, FnScope);
-
-  while (Tok.isNot(tok::eof))
-    ConsumeAnyToken();
-
-  if (Tok.is(tok::eof) && Tok.getEofData() == LM.D)
-    ConsumeAnyToken();
 }
 
 /// ParseLexedMemberInitializers - We finished parsing the member specification

--- a/clang/test/Modules/try-func-body.cppm
+++ b/clang/test/Modules/try-func-body.cppm
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -std=c++20 %s -fexceptions -fcxx-exceptions -emit-llvm -triple %itanium_abi_triple -o - | FileCheck %s
+
+export module func;
+class C {
+public:
+    void member() try {
+
+    } catch (...) {
+
+    }
+};
+
+// CHECK: define {{.*}}@_ZNW4func1C6memberEv


### PR DESCRIPTION

See the example:

```
export module func;
class C {
public:
    void member() try {

    } catch (...) {

    }
};
```

We woudln't generate the definition for `C::member` but we should. Since the function is non-inline in modules.

This turns out to be an oversight in parser to me. Since the try-catch body is relatively rare, so maybe we just forgot it.