### PR TITLE
[libc++] [ci] Update the Windows toolchains to Clang 19

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -255,11 +255,11 @@ jobs:
       - name: Install a current LLVM
         if: ${{ matrix.mingw != true }}
         run: |
-          choco install -y llvm --version=18.1.6 --allow-downgrade
+          choco install -y llvm --version=19.1.7 --allow-downgrade
       - name: Install llvm-mingw
         if: ${{ matrix.mingw == true }}
         run: |
-          curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20240606/llvm-mingw-20240606-ucrt-x86_64.zip
+          curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20250114/llvm-mingw-20250114-ucrt-x86_64.zip
           powershell Expand-Archive llvm-mingw*.zip -DestinationPath .
           del llvm-mingw*.zip
           mv llvm-mingw* c:\llvm-mingw


### PR DESCRIPTION
This also fixes test failures in the clang-cl build configs that started a couple days ago. It seems like the failures were triggered by an update to the base image on the Github provided runners.

There were failures in test/libcxx/system_reserved_names.gen.py, due to an issue in an Clang intrinsics header (avx512fp16intrin.h); this issue was observed and fixed for Clang 19 in
6f04f46927cf54d19cc2a1470f47d5db4b3b96bb. The test does `#define A SYSTEM_RESERVED_NAME`, which clashes with a parameter with the name `A` in that header.

By upgrading the toolchain to Clang 19, we get fixed version of this intrinsics header.

Also update the llvm-mingw toolchains to a version with Clang 19.1.7.