### PR TITLE
[AST] Fix printing of large 64-bit unsigned template arguments

### DIFF
--- a/clang/lib/AST/TemplateBase.cpp
+++ b/clang/lib/AST/TemplateBase.cpp
@@ -130,8 +130,14 @@ static void printIntegral(const TemplateArgument &TemplArg, raw_ostream &Out,
     } else
       Out << "(" << T->getCanonicalTypeInternal().getAsString(Policy) << ")"
           << Val;
-  } else
+  } else {
     Out << Val;
+    // Handle cases where the value is too large to fit into the underlying type
+    // i.e. where the unsignedness matters.
+    if (T->isBuiltinType())
+      if (Val.isUnsigned() && Val.getBitWidth() == 64 && Val.countLeadingOnes())
+        Out << "ULL";
+  }
 }
 
 static unsigned getArrayDepth(QualType type) {

--- a/clang/test/AST/ast-print-integral-template-args.cpp
+++ b/clang/test/AST/ast-print-integral-template-args.cpp
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -ast-print -std=c++17 -Wno-implicitly-unsigned-literal %s -o - | FileCheck %s
+
+template <unsigned long long N>
+struct Foo {};
+
+Foo<9223372036854775810> x;
+// CHECK: template<> struct Foo<9223372036854775810ULL> {


### PR DESCRIPTION
Clang omits the `ULL` suffix when printing large unsigned 64-bit template arguments. This patch ensures that values with the high bit set are explicitly printed with `ULL`.

Based on the original patch by Axel Naumann