### PR TITLE
llvm-rc: Relax error message checked in test

### DIFF
--- a/llvm/test/tools/llvm-rc/windres-preproc.test
+++ b/llvm/test/tools/llvm-rc/windres-preproc.test
@@ -20,7 +20,7 @@
 ;; Test error messages when unable to execute the preprocessor.
 
 ; RUN: not llvm-windres --preprocessor intentionally-missing-executable %p/Inputs/empty.rc %t.res 2>&1 | FileCheck -DMSG=%errc_ENOENT %s --check-prefix=CHECK4
-; CHECK4: llvm-rc: Preprocessing failed: posix_spawn failed: [[MSG]]
+; CHECK4: llvm-rc: Preprocessing failed: {{(posix_spawn failed: )?}}[[MSG]]
 
 ;; Test --preprocessor with an argument with spaces.
 


### PR DESCRIPTION
In the fork path, it does not print the piece about posix_spawn failed

Part of #129208