### PR TITLE
Support: Fix program error test failures when using fork

### DIFF
--- a/llvm/lib/Support/Program.cpp
+++ b/llvm/lib/Support/Program.cpp
@@ -45,6 +45,10 @@ int sys::ExecuteAndWait(StringRef Program, ArrayRef<StringRef> Args,
     ProcessInfo Result = Wait(
         PI, SecondsToWait == 0 ? std::nullopt : std::optional(SecondsToWait),
         ErrMsg, ProcStat);
+
+    if (ExecutionFailed && Result.ReturnCode < 0)
+      *ExecutionFailed = true;
+
     return Result.ReturnCode;
   }
 

--- a/llvm/lib/Support/Program.cpp
+++ b/llvm/lib/Support/Program.cpp
@@ -45,10 +45,6 @@ int sys::ExecuteAndWait(StringRef Program, ArrayRef<StringRef> Args,
     ProcessInfo Result = Wait(
         PI, SecondsToWait == 0 ? std::nullopt : std::optional(SecondsToWait),
         ErrMsg, ProcStat);
-
-    if (ExecutionFailed && Result.ReturnCode < 0)
-      *ExecutionFailed = true;
-
     return Result.ReturnCode;
   }
 

--- a/llvm/unittests/Support/ProgramTest.cpp
+++ b/llvm/unittests/Support/ProgramTest.cpp
@@ -433,10 +433,19 @@ TEST(ProgramTest, TestExecuteNegative) {
     bool ExecutionFailed;
     ProcessInfo PI = ExecuteNoWait(Executable, argv, std::nullopt, {}, 0,
                                    &Error, &ExecutionFailed);
-    EXPECT_EQ(PI.Pid, ProcessInfo::InvalidPid)
-        << "On error ExecuteNoWait should return an invalid ProcessInfo";
-    EXPECT_TRUE(ExecutionFailed);
-    EXPECT_FALSE(Error.empty());
+
+    if (ExecutionFailed) {
+      EXPECT_EQ(PI.Pid, ProcessInfo::InvalidPid)
+          << "On error ExecuteNoWait should return an invalid ProcessInfo";
+      EXPECT_FALSE(Error.empty());
+    } else {
+      std::string WaitErrMsg;
+      EXPECT_NE(PI.Pid, ProcessInfo::InvalidPid);
+      ProcessInfo WaitPI = Wait(PI, std::nullopt, &WaitErrMsg);
+      EXPECT_EQ(WaitPI.Pid, PI.Pid);
+      EXPECT_LT(WaitPI.ReturnCode, 0);
+      EXPECT_FALSE(WaitErrMsg.empty());
+    }
   }
 
 }

--- a/llvm/unittests/Support/ProgramTest.cpp
+++ b/llvm/unittests/Support/ProgramTest.cpp
@@ -422,10 +422,13 @@ TEST(ProgramTest, TestExecuteNegative) {
     bool ExecutionFailed;
     int RetCode = ExecuteAndWait(Executable, argv, std::nullopt, {}, 0, 0,
                                  &Error, &ExecutionFailed);
+
     EXPECT_LT(RetCode, 0) << "On error ExecuteAndWait should return 0 or "
                              "positive value indicating the result code";
-    EXPECT_TRUE(ExecutionFailed);
     EXPECT_FALSE(Error.empty());
+
+    // Note ExecutionFailed may or may not be false. When using fork, the error
+    // is produced on the wait for the child, not the execution point.
   }
 
   {


### PR DESCRIPTION
The actual exec error will not be immediate in the parent when
using the fork path. The error will manifest on the wait. The
ExecuteNoWait test was also expecting the immediate wait.

Remove the check in the AndWait test check for ExecutionFailed. 
The execution did succeed in some sense.

Fixes #129208