### PR TITLE
[mlir][emitc][NFC] Eliminate the extra newline printout during emitc.switch emission

### DIFF
--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -484,7 +484,7 @@ static LogicalResult printOperation(CppEmitter &emitter,
                                     emitc::SwitchOp switchOp) {
   raw_indented_ostream &os = emitter.ostream();
 
-  os << "\nswitch (";
+  os << "switch (";
   if (failed(emitter.emitOperand(switchOp.getArg())))
     return failure();
   os << ") {";


### PR DESCRIPTION
Before the output was:
```c++
void emitc_switch_ptrdiff_t() {
  ptrdiff_t v1 = 1;

  switch (v1) {
  ...
  }
  return;
}
```
After:
```c++
void emitc_switch_ptrdiff_t() {
  ptrdiff_t v1 = 1;
  switch (v1) {
  ...
  }
  return;
}
```