### PR TITLE
Revert "[libc++][test] extend -linux-gnu XFAIL to cover all of the -linux targets (#129140)"

### DIFF
--- a/libcxx/test/std/input.output/iostream.format/std.manip/setfill_wchar_max.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/std.manip/setfill_wchar_max.pass.cpp
@@ -16,7 +16,7 @@
 
 // XFAIL: target={{.*}}-windows{{.*}} && libcpp-abi-version=1
 // XFAIL: target=armv{{7|8}}{{l?}}{{.*}}-linux-gnueabihf && libcpp-abi-version=1
-// XFAIL: target=aarch64{{.*}}-linux{{.*}} && libcpp-abi-version=1
+// XFAIL: target=aarch64{{.*}}-linux-gnu && libcpp-abi-version=1
 
 #include <iomanip>
 #include <ostream>

--- a/libcxx/test/std/re/re.alg/re.alg.match/awk.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.match/awk.locale.pass.cpp
@@ -18,7 +18,7 @@
 
 // TODO: investigation needed
 // TODO(netbsd): incomplete support for locales
-// XFAIL: target={{.*}}-linux{{.*}}, netbsd, freebsd
+// XFAIL: target={{.*}}-linux-gnu{{.*}}, netbsd, freebsd
 // REQUIRES: locale.cs_CZ.ISO8859-2
 
 #include <regex>

--- a/libcxx/test/std/re/re.alg/re.alg.match/basic.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.match/basic.locale.pass.cpp
@@ -22,7 +22,7 @@
 //                  regex_constants::match_flag_type flags = regex_constants::match_default);
 
 // TODO: investigation needed
-// XFAIL: target={{.*}}-linux{{.*}}, freebsd
+// XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.match/ecma.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.match/ecma.locale.pass.cpp
@@ -22,7 +22,7 @@
 //                  regex_constants::match_flag_type flags = regex_constants::match_default);
 
 // TODO: investigation needed
-// XFAIL: target={{.*}}-linux{{.*}}, freebsd
+// XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.match/extended.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.match/extended.locale.pass.cpp
@@ -22,7 +22,7 @@
 //                  regex_constants::match_flag_type flags = regex_constants::match_default);
 
 // TODO: investigation needed
-// XFAIL: target={{.*}}-linux{{.*}}, freebsd
+// XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.search/awk.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.search/awk.locale.pass.cpp
@@ -22,7 +22,7 @@
 //                  regex_constants::match_flag_type flags = regex_constants::match_default);
 
 // TODO: investigation needed
-// XFAIL: target={{.*}}-linux{{.*}}, freebsd
+// XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.search/basic.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.search/basic.locale.pass.cpp
@@ -22,7 +22,7 @@
 //                  regex_constants::match_flag_type flags = regex_constants::match_default);
 
 // TODO: investigation needed
-// XFAIL: target={{.*}}-linux{{.*}}, freebsd
+// XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.search/ecma.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.search/ecma.locale.pass.cpp
@@ -22,7 +22,7 @@
 //                  regex_constants::match_flag_type flags = regex_constants::match_default);
 
 // TODO: investigation needed
-// XFAIL: target={{.*}}-linux{{.*}}, freebsd
+// XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.search/extended.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.search/extended.locale.pass.cpp
@@ -22,7 +22,7 @@
 //                  regex_constants::match_flag_type flags = regex_constants::match_default);
 
 // TODO: investigation needed
-// XFAIL: target={{.*}}-linux{{.*}}, freebsd
+// XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.traits/lookup_collatename.pass.cpp
+++ b/libcxx/test/std/re/re.traits/lookup_collatename.pass.cpp
@@ -23,7 +23,7 @@
 //   lookup_collatename(ForwardIterator first, ForwardIterator last) const;
 
 // TODO: investigation needed
-// XFAIL: target={{.*}}-linux{{.*}}
+// XFAIL: target={{.*}}-linux-gnu{{.*}}
 
 #include <regex>
 #include <iterator>


### PR DESCRIPTION
The effect of this commit is too broad and may affect also those variants of Linux systems on which the affected test cases are known to pass.

An alternative version of this commit will be prepared afresh.

This reverts commit c93dc581d979eb20ded470d2c16e51b3e775f6e7.