### PR TITLE
[mlir][tosa] Rename the result of MATMUL from `c` to `output`

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
@@ -301,7 +301,7 @@ def Tosa_MatMulOp : Tosa_InferShapedTypeOp<"matmul"> {
   );
 
   let results = (outs
-    Tosa_Tensor3D:$c
+    Tosa_Tensor3D:$output
   );
 
   list<Availability> availability = [


### PR DESCRIPTION
This renames the output of TOSA MatMul operator from `c` to `output`
to align to TOSA spec