### PR TITLE
[lldb] Add ability to inspect backing threads with `thread info`

### DIFF
--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -1270,6 +1270,7 @@ public:
     void OptionParsingStarting(ExecutionContext *execution_context) override {
       m_json_thread = false;
       m_json_stopinfo = false;
+      m_backing_thread = false;
     }
 
     Status SetOptionValue(uint32_t option_idx, llvm::StringRef option_arg,
@@ -1286,6 +1287,10 @@ public:
         m_json_stopinfo = true;
         break;
 
+      case 'b':
+        m_backing_thread = true;
+        break;
+
       default:
         llvm_unreachable("Unimplemented option");
       }
@@ -1298,6 +1303,7 @@ public:
 
     bool m_json_thread;
     bool m_json_stopinfo;
+    bool m_backing_thread;
   };
 
   CommandObjectThreadInfo(CommandInterpreter &interpreter)
@@ -1334,6 +1340,8 @@ public:
     }
 
     Thread *thread = thread_sp.get();
+    if (m_options.m_backing_thread && thread->GetBackingThread())
+      thread = thread->GetBackingThread().get();
 
     Stream &strm = result.GetOutputStream();
     if (!thread->GetDescription(strm, eDescriptionLevelFull,

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -1108,6 +1108,9 @@ let Command = "thread info" in {
     " JSON format.">;
   def thread_info_stop_info : Option<"stop-info", "s">, Desc<"Display the "
     "extended stop info in JSON format.">;
+  def thread_info_backing_thread : Option<"backing-thread", "b">,
+    Desc<"If this is an OS plugin thread, query the backing thread instead; has"
+    " no effect otherwise.">;
 }
 
 let Command = "thread return" in {

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
@@ -132,6 +132,7 @@ class PluginPythonOSPlugin(TestBase):
         )
 
     tid_regex = re.compile("tid = (0x[0-9a-fA-F]+)")
+
     def get_tid_from_thread_info_command(self, thread, use_backing_thread):
         interp = self.dbg.GetCommandInterpreter()
         result = lldb.SBCommandReturnObject()

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
@@ -131,7 +131,7 @@ class PluginPythonOSPlugin(TestBase):
             "Make sure there is no thread 0x333333333 after we unload the python OS plug-in",
         )
 
-    tid_regex = re.compile("tid = (0x[0-9a-fA-F]+)")
+    tid_regex = re.compile(r"tid = ((0x)?[0-9a-fA-F]+)")
 
     def get_tid_from_thread_info_command(self, thread, use_backing_thread):
         interp = self.dbg.GetCommandInterpreter()

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
@@ -149,7 +149,7 @@ class PluginPythonOSPlugin(TestBase):
         self.assertTrue(result.Succeeded(), "failed to run thread info")
         match = self.tid_regex.search(result.GetOutput())
         self.assertNotEqual(match, None)
-        return match.group(1)
+        return int(match.group(1), 0)
 
     def run_python_os_step(self):
         """Test that the Python operating system plugin works correctly and allows single stepping of a virtual thread that is backed by a real thread"""
@@ -230,7 +230,7 @@ class PluginPythonOSPlugin(TestBase):
         thread.StepOver()
 
         tid_os = self.get_tid_from_thread_info_command(thread, False)
-        self.assertEqual(tid_os, "0x111111111")
+        self.assertEqual(tid_os, 0x111111111)
         tid_real = self.get_tid_from_thread_info_command(thread, True)
         self.assertNotEqual(tid_os, tid_real)
 


### PR DESCRIPTION
When OS plugins are present, it can be helpful to query information about the backing thread behind an OS thread, if it exists. There is no mechanism to do so prior to this commit.

As a first step, this commit enhances `thread info` with a `--backing-thread` flag, causing the command to use the backing thread of the selected thread, if it exists.