### PR TITLE
[AMDGPU] Extend ComputePGMRSrc3 to gfx10+. NFCI.

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIProgramInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIProgramInfo.cpp
@@ -57,7 +57,7 @@ void SIProgramInfo::reset(const MachineFunction &MF) {
   LdsSize = 0;
   EXCPEnable = 0;
 
-  ComputePGMRSrc3GFX90A = ZeroExpr;
+  ComputePGMRSrc3 = ZeroExpr;
 
   NumVGPR = ZeroExpr;
   NumArchVGPR = ZeroExpr;

--- a/llvm/lib/Target/AMDGPU/SIProgramInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIProgramInfo.h
@@ -63,7 +63,7 @@ struct LLVM_EXTERNAL_VISIBILITY SIProgramInfo {
   uint32_t LdsSize = 0;
   uint32_t EXCPEnable = 0;
 
-  const MCExpr *ComputePGMRSrc3GFX90A = nullptr;
+  const MCExpr *ComputePGMRSrc3 = nullptr;
 
   const MCExpr *NumVGPR = nullptr;
   const MCExpr *NumArchVGPR = nullptr;


### PR DESCRIPTION
ComputePGMRSrc3 exists since gfx90a and gfx10+. Current code
only expects gfx90a. This is NFCI since we do not fill it on
gfx10+ yet.