### PR TITLE
[lldb-dap] Updating the logging of lldb-dap to use existing LLDBLog.

### DIFF
--- a/lldb/tools/lldb-dap/CMakeLists.txt
+++ b/lldb/tools/lldb-dap/CMakeLists.txt
@@ -23,6 +23,7 @@ add_lldb_tool(lldb-dap
   Breakpoint.cpp
   BreakpointBase.cpp
   DAP.cpp
+  DAPLog.cpp
   EventHelper.cpp
   ExceptionBreakpoint.cpp
   FifoFiles.cpp

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -248,7 +248,7 @@ void DAP::SendJSON(const std::string &json_str) {
   output.write_full("\r\n\r\n");
   output.write_full(json_str);
 
-  LLDB_LOG(GetLog(DAPLog::Transport), "{0} <-- {1}", name, json_str);
+  LLDB_LOGV(GetLog(DAPLog::Transport), "{0} <-- {1}", name, json_str);
 }
 
 // Serialize the JSON value into a string and send the JSON packet to
@@ -283,7 +283,7 @@ std::string DAP::ReadJSON() {
   if (!input.read_full(length, json_str))
     return json_str;
 
-  LLDB_LOG(GetLog(DAPLog::Transport), "{0} --> {1}", name, json_str);
+  LLDB_LOGV(GetLog(DAPLog::Transport), "{0} --> {1}", name, json_str);
   return json_str;
 }
 

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -125,21 +125,21 @@ struct Variables {
 
 struct StartDebuggingRequestHandler : public lldb::SBCommandPluginInterface {
   DAP &dap;
-  explicit StartDebuggingRequestHandler(DAP &d) : dap(d){};
+  explicit StartDebuggingRequestHandler(DAP &d) : dap(d) {};
   bool DoExecute(lldb::SBDebugger debugger, char **command,
                  lldb::SBCommandReturnObject &result) override;
 };
 
 struct ReplModeRequestHandler : public lldb::SBCommandPluginInterface {
   DAP &dap;
-  explicit ReplModeRequestHandler(DAP &d) : dap(d){};
+  explicit ReplModeRequestHandler(DAP &d) : dap(d) {};
   bool DoExecute(lldb::SBDebugger debugger, char **command,
                  lldb::SBCommandReturnObject &result) override;
 };
 
 struct SendEventRequestHandler : public lldb::SBCommandPluginInterface {
   DAP &dap;
-  explicit SendEventRequestHandler(DAP &d) : dap(d){};
+  explicit SendEventRequestHandler(DAP &d) : dap(d) {};
   bool DoExecute(lldb::SBDebugger debugger, char **command,
                  lldb::SBCommandReturnObject &result) override;
 };

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -125,21 +125,21 @@ struct Variables {
 
 struct StartDebuggingRequestHandler : public lldb::SBCommandPluginInterface {
   DAP &dap;
-  explicit StartDebuggingRequestHandler(DAP &d) : dap(d) {};
+  explicit StartDebuggingRequestHandler(DAP &d) : dap(d){};
   bool DoExecute(lldb::SBDebugger debugger, char **command,
                  lldb::SBCommandReturnObject &result) override;
 };
 
 struct ReplModeRequestHandler : public lldb::SBCommandPluginInterface {
   DAP &dap;
-  explicit ReplModeRequestHandler(DAP &d) : dap(d) {};
+  explicit ReplModeRequestHandler(DAP &d) : dap(d){};
   bool DoExecute(lldb::SBDebugger debugger, char **command,
                  lldb::SBCommandReturnObject &result) override;
 };
 
 struct SendEventRequestHandler : public lldb::SBCommandPluginInterface {
   DAP &dap;
-  explicit SendEventRequestHandler(DAP &d) : dap(d) {};
+  explicit SendEventRequestHandler(DAP &d) : dap(d){};
   bool DoExecute(lldb::SBDebugger debugger, char **command,
                  lldb::SBCommandReturnObject &result) override;
 };
@@ -147,7 +147,6 @@ struct SendEventRequestHandler : public lldb::SBCommandPluginInterface {
 struct DAP {
   std::string name;
   llvm::StringRef debug_adapter_path;
-  std::ofstream *log;
   InputStream input;
   OutputStream output;
   lldb::SBFile in;
@@ -210,8 +209,8 @@ struct DAP {
   // will contain that expression.
   std::string last_nonempty_var_expression;
 
-  DAP(std::string name, llvm::StringRef path, std::ofstream *log,
-      lldb::IOObjectSP input, lldb::IOObjectSP output, ReplMode repl_mode,
+  DAP(std::string name, llvm::StringRef path, lldb::IOObjectSP input,
+      lldb::IOObjectSP output, ReplMode repl_mode,
       std::vector<std::string> pre_init_commands);
   ~DAP();
   DAP(const DAP &rhs) = delete;

--- a/lldb/tools/lldb-dap/DAPLog.cpp
+++ b/lldb/tools/lldb-dap/DAPLog.cpp
@@ -1,3 +1,11 @@
+//===-- DAPLog.cpp --------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #include "DAPLog.h"
 
 using namespace lldb_private;

--- a/lldb/tools/lldb-dap/DAPLog.cpp
+++ b/lldb/tools/lldb-dap/DAPLog.cpp
@@ -1,0 +1,22 @@
+#include "DAPLog.h"
+
+using namespace lldb_private;
+using namespace lldb_dap;
+
+static constexpr Log::Category g_categories[] = {
+    {{"transport"}, {"log DAP transport"}, DAPLog::Transport},
+    {{"protocol"}, {"log protocol handling"}, DAPLog::Protocol},
+    {{"connection"}, {"log connection handling"}, DAPLog::Connection},
+};
+
+static Log::Channel g_log_channel(g_categories, DAPLog::Transport |
+                                                    DAPLog::Protocol |
+                                                    DAPLog::Connection);
+
+template <> Log::Channel &lldb_private::LogChannelFor<DAPLog>() {
+  return g_log_channel;
+}
+
+void lldb_dap::InitializeDAPChannel() {
+  Log::Register("lldb-dap", g_log_channel);
+}

--- a/lldb/tools/lldb-dap/DAPLog.h
+++ b/lldb/tools/lldb-dap/DAPLog.h
@@ -1,4 +1,4 @@
-//===-- DAPLog.h ------------------------------------------------*- C++ -*-===//
+//===-- DAPLog.h ----------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLDB_UTILITY_LLDBLOG_H
-#define LLDB_UTILITY_LLDBLOG_H
+#ifndef LLDB_TOOLS_LLDB_DAP_DAPLOG_H
+#define LLDB_TOOLS_LLDB_DAP_DAPLOG_H
 
 #include "lldb/Utility/Log.h"
 #include "llvm/ADT/BitmaskEnum.h"

--- a/lldb/tools/lldb-dap/DAPLog.h
+++ b/lldb/tools/lldb-dap/DAPLog.h
@@ -1,0 +1,34 @@
+//===-- DAPLog.h ------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_UTILITY_LLDBLOG_H
+#define LLDB_UTILITY_LLDBLOG_H
+
+#include "lldb/Utility/Log.h"
+#include "llvm/ADT/BitmaskEnum.h"
+
+namespace lldb_dap {
+
+enum class DAPLog : lldb_private::Log::MaskType {
+  Transport = lldb_private::Log::ChannelFlag<0>,
+  Protocol = lldb_private::Log::ChannelFlag<1>,
+  Connection = lldb_private::Log::ChannelFlag<2>,
+  LLVM_MARK_AS_BITMASK_ENUM(Connection),
+};
+
+LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();
+
+void InitializeDAPChannel();
+
+} // end namespace lldb_dap
+
+namespace lldb_private {
+template <> lldb_private::Log::Channel &LogChannelFor<lldb_dap::DAPLog>();
+} // namespace lldb_private
+
+#endif

--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -8,6 +8,7 @@
 
 #include "EventHelper.h"
 #include "DAP.h"
+#include "DAPLog.h"
 #include "JSONUtils.h"
 #include "LLDBUtils.h"
 #include "lldb/API/SBFileSpec.h"
@@ -20,6 +21,9 @@
 #define PATH_MAX MAX_PATH
 #endif
 #endif
+
+using namespace lldb_dap;
+using namespace lldb_private;
 
 namespace lldb_dap {
 
@@ -178,15 +182,14 @@ void SendThreadStoppedEvent(DAP &dap) {
           SendThreadExitedEvent(dap, tid);
       }
     } else {
-      if (dap.log)
-        *dap.log << "error: SendThreadStoppedEvent() when process"
-                    " isn't stopped ("
-                 << lldb::SBDebugger::StateAsCString(state) << ')' << std::endl;
+      LLDB_LOG(GetLog(DAPLog::Protocol),
+               "error: SendThreadStoppedEvent() when process"
+               " isn't stopped ({0})",
+               lldb::SBDebugger::StateAsCString(state));
     }
   } else {
-    if (dap.log)
-      *dap.log << "error: SendThreadStoppedEvent() invalid process"
-               << std::endl;
+    LLDB_LOG(GetLog(DAPLog::Protocol),
+             "error: SendThreadStoppedEvent() invalid process");
   }
   dap.RunStopCommands();
 }

--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -121,75 +121,76 @@ void SendProcessEvent(DAP &dap, LaunchMethod launch_method) {
 // is stopped.
 void SendThreadStoppedEvent(DAP &dap) {
   lldb::SBProcess process = dap.target.GetProcess();
-  if (process.IsValid()) {
-    auto state = process.GetState();
-    if (state == lldb::eStateStopped) {
-      llvm::DenseSet<lldb::tid_t> old_thread_ids;
-      old_thread_ids.swap(dap.thread_ids);
-      uint32_t stop_id = process.GetStopID();
-      const uint32_t num_threads = process.GetNumThreads();
-
-      // First make a pass through the threads to see if the focused thread
-      // has a stop reason. In case the focus thread doesn't have a stop
-      // reason, remember the first thread that has a stop reason so we can
-      // set it as the focus thread if below if needed.
-      lldb::tid_t first_tid_with_reason = LLDB_INVALID_THREAD_ID;
-      uint32_t num_threads_with_reason = 0;
-      bool focus_thread_exists = false;
-      for (uint32_t thread_idx = 0; thread_idx < num_threads; ++thread_idx) {
-        lldb::SBThread thread = process.GetThreadAtIndex(thread_idx);
-        const lldb::tid_t tid = thread.GetThreadID();
-        const bool has_reason = ThreadHasStopReason(thread);
-        // If the focus thread doesn't have a stop reason, clear the thread ID
-        if (tid == dap.focus_tid) {
-          focus_thread_exists = true;
-          if (!has_reason)
-            dap.focus_tid = LLDB_INVALID_THREAD_ID;
-        }
-        if (has_reason) {
-          ++num_threads_with_reason;
-          if (first_tid_with_reason == LLDB_INVALID_THREAD_ID)
-            first_tid_with_reason = tid;
-        }
-      }
-
-      // We will have cleared dap.focus_tid if the focus thread doesn't have
-      // a stop reason, so if it was cleared, or wasn't set, or doesn't exist,
-      // then set the focus thread to the first thread with a stop reason.
-      if (!focus_thread_exists || dap.focus_tid == LLDB_INVALID_THREAD_ID)
-        dap.focus_tid = first_tid_with_reason;
-
-      // If no threads stopped with a reason, then report the first one so
-      // we at least let the UI know we stopped.
-      if (num_threads_with_reason == 0) {
-        lldb::SBThread thread = process.GetThreadAtIndex(0);
-        dap.focus_tid = thread.GetThreadID();
-        dap.SendJSON(CreateThreadStopped(dap, thread, stop_id));
-      } else {
-        for (uint32_t thread_idx = 0; thread_idx < num_threads; ++thread_idx) {
-          lldb::SBThread thread = process.GetThreadAtIndex(thread_idx);
-          dap.thread_ids.insert(thread.GetThreadID());
-          if (ThreadHasStopReason(thread)) {
-            dap.SendJSON(CreateThreadStopped(dap, thread, stop_id));
-          }
-        }
-      }
-
-      for (auto tid : old_thread_ids) {
-        auto end = dap.thread_ids.end();
-        auto pos = dap.thread_ids.find(tid);
-        if (pos == end)
-          SendThreadExitedEvent(dap, tid);
-      }
-    } else {
-      LLDB_LOG(GetLog(DAPLog::Protocol),
-               "error: SendThreadStoppedEvent() when process"
-               " isn't stopped ({0})",
-               lldb::SBDebugger::StateAsCString(state));
-    }
-  } else {
+  if (!process.IsValid()) {
     LLDB_LOG(GetLog(DAPLog::Protocol),
              "error: SendThreadStoppedEvent() invalid process");
+    return;
+  }
+
+  auto state = process.GetState();
+  if (state != lldb::eStateStopped) {
+    LLDB_LOG(GetLog(DAPLog::Protocol),
+             "error: SendThreadStoppedEvent() when process isn't stopped ({0})",
+             lldb::SBDebugger::StateAsCString(state));
+    return;
+  }
+
+  llvm::DenseSet<lldb::tid_t> old_thread_ids;
+  old_thread_ids.swap(dap.thread_ids);
+  uint32_t stop_id = process.GetStopID();
+  const uint32_t num_threads = process.GetNumThreads();
+
+  // First make a pass through the threads to see if the focused thread
+  // has a stop reason. In case the focus thread doesn't have a stop
+  // reason, remember the first thread that has a stop reason so we can
+  // set it as the focus thread if below if needed.
+  lldb::tid_t first_tid_with_reason = LLDB_INVALID_THREAD_ID;
+  uint32_t num_threads_with_reason = 0;
+  bool focus_thread_exists = false;
+  for (uint32_t thread_idx = 0; thread_idx < num_threads; ++thread_idx) {
+    lldb::SBThread thread = process.GetThreadAtIndex(thread_idx);
+    const lldb::tid_t tid = thread.GetThreadID();
+    const bool has_reason = ThreadHasStopReason(thread);
+    // If the focus thread doesn't have a stop reason, clear the thread ID
+    if (tid == dap.focus_tid) {
+      focus_thread_exists = true;
+      if (!has_reason)
+        dap.focus_tid = LLDB_INVALID_THREAD_ID;
+    }
+    if (has_reason) {
+      ++num_threads_with_reason;
+      if (first_tid_with_reason == LLDB_INVALID_THREAD_ID)
+        first_tid_with_reason = tid;
+    }
+  }
+
+  // We will have cleared dap.focus_tid if the focus thread doesn't have
+  // a stop reason, so if it was cleared, or wasn't set, or doesn't exist,
+  // then set the focus thread to the first thread with a stop reason.
+  if (!focus_thread_exists || dap.focus_tid == LLDB_INVALID_THREAD_ID)
+    dap.focus_tid = first_tid_with_reason;
+
+  // If no threads stopped with a reason, then report the first one so
+  // we at least let the UI know we stopped.
+  if (num_threads_with_reason == 0) {
+    lldb::SBThread thread = process.GetThreadAtIndex(0);
+    dap.focus_tid = thread.GetThreadID();
+    dap.SendJSON(CreateThreadStopped(dap, thread, stop_id));
+  } else {
+    for (uint32_t thread_idx = 0; thread_idx < num_threads; ++thread_idx) {
+      lldb::SBThread thread = process.GetThreadAtIndex(thread_idx);
+      dap.thread_ids.insert(thread.GetThreadID());
+      if (ThreadHasStopReason(thread)) {
+        dap.SendJSON(CreateThreadStopped(dap, thread, stop_id));
+      }
+    }
+  }
+
+  for (auto tid : old_thread_ids) {
+    auto end = dap.thread_ids.end();
+    auto pos = dap.thread_ids.find(tid);
+    if (pos == end)
+      SendThreadExitedEvent(dap, tid);
   }
   dap.RunStopCommands();
 }

--- a/lldb/tools/lldb-dap/IOStream.cpp
+++ b/lldb/tools/lldb-dap/IOStream.cpp
@@ -7,12 +7,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "IOStream.h"
+#include "DAPLog.h"
 #include "lldb/Utility/IOObject.h"
 #include "lldb/Utility/Status.h"
-#include <fstream>
 #include <string>
 
 using namespace lldb_dap;
+using namespace lldb_private;
 
 bool OutputStream::write_full(llvm::StringRef str) {
   if (!descriptor)
@@ -23,8 +24,7 @@ bool OutputStream::write_full(llvm::StringRef str) {
   return status.Success();
 }
 
-bool InputStream::read_full(std::ofstream *log, size_t length,
-                            std::string &text) {
+bool InputStream::read_full(size_t length, std::string &text) {
   if (!descriptor)
     return false;
 
@@ -39,10 +39,10 @@ bool InputStream::read_full(std::ofstream *log, size_t length,
   return true;
 }
 
-bool InputStream::read_line(std::ofstream *log, std::string &line) {
+bool InputStream::read_line(std::string &line) {
   line.clear();
   while (true) {
-    if (!read_full(log, 1, line))
+    if (!read_full(1, line))
       return false;
 
     if (llvm::StringRef(line).ends_with("\r\n"))
@@ -52,14 +52,13 @@ bool InputStream::read_line(std::ofstream *log, std::string &line) {
   return true;
 }
 
-bool InputStream::read_expected(std::ofstream *log, llvm::StringRef expected) {
+bool InputStream::read_expected(llvm::StringRef expected) {
   std::string result;
-  if (!read_full(log, expected.size(), result))
+  if (!read_full(expected.size(), result))
     return false;
   if (expected != result) {
-    if (log)
-      *log << "Warning: Expected '" << expected.str() << "', got '" << result
-           << "\n";
+    LLDB_LOG(GetLog(DAPLog::Transport), "Warning: Expected '{0}', got '{1}'",
+             expected, result);
   }
   return true;
 }

--- a/lldb/tools/lldb-dap/IOStream.h
+++ b/lldb/tools/lldb-dap/IOStream.h
@@ -11,7 +11,6 @@
 
 #include "lldb/lldb-forward.h"
 #include "llvm/ADT/StringRef.h"
-#include <fstream>
 #include <string>
 
 namespace lldb_dap {
@@ -22,11 +21,11 @@ struct InputStream {
   explicit InputStream(lldb::IOObjectSP descriptor)
       : descriptor(std::move(descriptor)) {}
 
-  bool read_full(std::ofstream *log, size_t length, std::string &text);
+  bool read_full(size_t length, std::string &text);
 
-  bool read_line(std::ofstream *log, std::string &line);
+  bool read_line(std::string &line);
 
-  bool read_expected(std::ofstream *log, llvm::StringRef expected);
+  bool read_expected(llvm::StringRef expected);
 };
 
 struct OutputStream {

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -498,8 +498,8 @@ int main(int argc, char *argv[]) {
 
     if (!lldb_private::Log::EnableLogChannel(
             std::make_shared<DAPLogHandler>(std::move(log)),
-            LLDB_LOG_OPTION_PREPEND_TIMESTAMP, "lldb-dap", {"all"},
-            llvm::errs())) {
+            LLDB_LOG_OPTION_VERBOSE | LLDB_LOG_OPTION_PREPEND_TIMESTAMP,
+            "lldb-dap", {"all"}, llvm::errs())) {
       return EXIT_FAILURE;
     }
   }

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -308,7 +308,7 @@ serveConnection(const Socket::SocketProtocol &protocol, const std::string &name,
                                           &clientCount](
                                              std::unique_ptr<Socket> sock) {
     std::string name = llvm::formatv("client_{0}", clientCount++).str();
-    LLDB_LOG(GetLog(DAPLog::Connection), "client ({0}) connected", name);
+    LLDB_LOG(GetLog(DAPLog::Connection), "{0} connected", name);
 
     lldb::IOObjectSP io(std::move(sock));
 
@@ -338,7 +338,7 @@ serveConnection(const Socket::SocketProtocol &protocol, const std::string &name,
                                     "DAP session error: ");
       }
 
-      LLDB_LOG(GetLog(DAPLog::Connection), "client ({0}) closed", name);
+      LLDB_LOG(GetLog(DAPLog::Connection), "{0} closed", name);
 
       std::unique_lock<std::mutex> lock(dap_sessions_mutex);
       dap_sessions.erase(io.get());


### PR DESCRIPTION
Today, logging is handling by a simple `std::ofstream *` for handling logging.

LLDBLog.h can help improve logging by adding new categories of logs and give us additional formatting support for log messages. We link against the libHost, which includes lldbUtility. This also simplifies logging by not requiring the `std::ofstream *` pointer being passed to every function that includes logging.