### PR TITLE
[RISCV] Remove Last Traces of User Interrupts

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2828,8 +2828,8 @@ targets. This attribute may be attached to a function definition and instructs
 the backend to generate appropriate function entry/exit code so that it can be
 used directly as an interrupt service routine.
 
-Permissible values for this parameter are ``user``, ``supervisor``,
-and ``machine``. If there is no parameter, then it defaults to machine.
+Permissible values for this parameter are ``supervisor`` and ``machine``. If
+there is no parameter, then it defaults to ``machine``.
 
 Repeated interrupt attribute on the same declaration will cause a warning
 to be emitted. In case of repeated declarations, the last one prevails.

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -20777,7 +20777,7 @@ SDValue RISCVTargetLowering::LowerFormalArguments(
     StringRef Kind =
       MF.getFunction().getFnAttribute("interrupt").getValueAsString();
 
-    if (!(Kind == "user" || Kind == "supervisor" || Kind == "machine"))
+    if (!(Kind == "supervisor" || Kind == "machine"))
       report_fatal_error(
         "Function interrupt attribute argument not supported!");
   }

--- a/llvm/test/CodeGen/RISCV/lpad.ll
+++ b/llvm/test/CodeGen/RISCV/lpad.ll
@@ -279,7 +279,7 @@ define internal void @internal2() {
 }
 
 ; Check interrupt function does not need landing pad.
-define void @interrupt() "interrupt"="user" {
+define void @interrupt() "interrupt"="machine" {
 ; CHECK-LABEL: interrupt:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    mret

--- a/llvm/test/CodeGen/RISCV/push-pop-popret.ll
+++ b/llvm/test/CodeGen/RISCV/push-pop-popret.ll
@@ -1769,7 +1769,7 @@ define void @alloca(i32 %n) {
 declare i32 @foo_test_irq(...)
 @var_test_irq = global [32 x i32] zeroinitializer
 
-define void @foo_with_irq() "interrupt"="user" {
+define void @foo_with_irq() "interrupt"="machine" {
 ; RV32IZCMP-LABEL: foo_with_irq:
 ; RV32IZCMP:       # %bb.0:
 ; RV32IZCMP-NEXT:    cm.push {ra}, -64
@@ -2273,7 +2273,7 @@ define void @foo_no_irq() {
   ret void
 }
 
-define void @callee_with_irq() "interrupt"="user" {
+define void @callee_with_irq() "interrupt"="machine" {
 ; RV32IZCMP-LABEL: callee_with_irq:
 ; RV32IZCMP:       # %bb.0:
 ; RV32IZCMP-NEXT:    cm.push {ra, s0-s11}, -112


### PR DESCRIPTION
These were left over from when Craig removed `__attribute__((interrupt("user")))` support in 05d0caef6081e1a6cb23a5a5afe43dc82e8ca558.

The tests change "interrupt"="user" into "interrupt"="machine" as they are still intending to be interrupt tests. ISelLowering will now reject "interrupt"="user". The docs no longer mention "user" as a possible interrupt attribute argument.