### PR TITLE
[LLDB][Minidump]Update MinidumpFileBuilder to read and write in chunks

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -1589,10 +1589,19 @@ public:
   size_t ReadMemoryFromInferior(lldb::addr_t vm_addr, void *buf, size_t size,
                                 Status &error);
 
-  typedef lldb::IterationAction(ReadMemoryChunkCallback)(lldb::Status &,
-                                                         DataBufferHeap &, lldb
-                                                         : addr_t,
-                                                           lldb::offset_t);
+  // Callback definition for read Memory in chunks
+  //
+  // Status, the status returned from ReadMemoryFromInferior
+  // uint8_t*, pointer to the bytes read
+  // addr_t, the current_addr, start + bytes read so far.
+  // uint64_t bytes_to_read, the expected bytes read, this
+  // is important if it's a partial read
+  // uint64_t bytes_read_for_chunk, the actual count of bytes read for this
+  // chunk
+  typedef std::function<IterationAction(lldb_private::Status &, const void *,
+    lldb::addr_t, uint64_t, uint64_t)>
+      ReadMemoryChunkCallback;
+
   /// Read of memory from a process in discrete chunks, terminating
   /// either when all bytes are read, or the supplied callback returns
   /// IterationAction::Stop
@@ -1610,9 +1619,6 @@ public:
   ///
   /// \param[in] callback
   ///     The callback to invoke when a chunk is read from memory.
-  /// \param[in] cacheReads
-  ///     Whether to use the ReadMemory instead of ReadMemory inferior, defaults
-  ///     to false.
   ///
   /// \return
   ///     The number of bytes that were actually read into \a buf and
@@ -1622,8 +1628,7 @@ public:
   ///     vm_addr, \a buf, and \a size updated appropriately. Zero is
   ///     returned in the case of an error.
   size_t ReadMemoryInChunks(lldb::addr_t vm_addr, DataBufferHeap &data,
-                            size_t size, ReadMemoryChunkCallback callback,
-                            bool cacheReads = false);
+                            size_t size, ReadMemoryChunkCallback callback);
 
   /// Read a NULL terminated C string from memory
   ///

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -1599,7 +1599,7 @@ public:
   // uint64_t bytes_read_for_chunk, the actual count of bytes read for this
   // chunk
   typedef std::function<IterationAction(lldb_private::Status &, const void *,
-    lldb::addr_t, uint64_t, uint64_t)>
+                                        lldb::addr_t, uint64_t, uint64_t)>
       ReadMemoryChunkCallback;
 
   /// Read of memory from a process in discrete chunks, terminating
@@ -1610,9 +1610,13 @@ public:
   ///     A virtual load address that indicates where to start reading
   ///     memory from.
   ///
-  /// \param[in] data
-  ///     The data buffer heap to use to read the chunk. The chunk size
-  ///     depends upon the byte size of the buffer.
+  /// \param[in] buf
+  ///     A byte buffer that is at least \a chunk_size bytes long that
+  ///     will receive the memory bytes.
+  ///
+  /// \param[in] chunk_size
+  ///     The minimum size of the byte buffer, and the chunk size of memory
+  ///     to read.
   ///
   /// \param[in] size
   ///     The number of bytes to read.
@@ -1627,8 +1631,9 @@ public:
   ///     size, then this function will get called again with \a
   ///     vm_addr, \a buf, and \a size updated appropriately. Zero is
   ///     returned in the case of an error.
-  size_t ReadMemoryInChunks(lldb::addr_t vm_addr, DataBufferHeap &data,
-                            size_t size, ReadMemoryChunkCallback callback);
+  size_t ReadMemoryInChunks(lldb::addr_t vm_addr, void *buf,
+                            lldb::addr_t chunk_size, size_t size,
+                            ReadMemoryChunkCallback callback);
 
   /// Read a NULL terminated C string from memory
   ///

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -1592,14 +1592,12 @@ public:
   // Callback definition for read Memory in chunks
   //
   // Status, the status returned from ReadMemoryFromInferior
-  // uint8_t*, pointer to the bytes read
-  // addr_t, the current_addr, start + bytes read so far.
-  // uint64_t bytes_to_read, the expected bytes read, this
-  // is important if it's a partial read
-  // uint64_t bytes_read_for_chunk, the actual count of bytes read for this
-  // chunk
-  typedef std::function<IterationAction(lldb_private::Status &, const void *,
-                                        lldb::addr_t, uint64_t, uint64_t)>
+  // addr_t, the bytes_addr, start + bytes read so far.
+  // void*, pointer to the bytes read
+  // bytes_size, the count of bytes read for this chunk
+  typedef std::function<IterationAction(
+      lldb_private::Status &error, lldb::addr_t bytes_addr, const void *bytes,
+      lldb::offset_t bytes_size)>
       ReadMemoryChunkCallback;
 
   /// Read of memory from a process in discrete chunks, terminating
@@ -1611,15 +1609,16 @@ public:
   ///     memory from.
   ///
   /// \param[in] buf
-  ///     A byte buffer that is at least \a chunk_size bytes long that
-  ///     will receive the memory bytes.
+  ///    If NULL, a buffer of \a chunk_size will be created and used for the
+  ///    callback. If non NULL, this buffer must be at least \a chunk_size bytes
+  ///    and will be used for storing chunked memory reads.
   ///
   /// \param[in] chunk_size
   ///     The minimum size of the byte buffer, and the chunk size of memory
   ///     to read.
   ///
-  /// \param[in] size
-  ///     The number of bytes to read.
+  /// \param[in] total_size
+  ///     The total number of bytes to read.
   ///
   /// \param[in] callback
   ///     The callback to invoke when a chunk is read from memory.
@@ -1631,9 +1630,10 @@ public:
   ///     size, then this function will get called again with \a
   ///     vm_addr, \a buf, and \a size updated appropriately. Zero is
   ///     returned in the case of an error.
-  size_t ReadMemoryInChunks(lldb::addr_t vm_addr, void *buf,
-                            lldb::addr_t chunk_size, size_t size,
-                            ReadMemoryChunkCallback callback);
+  lldb::offset_t ReadMemoryInChunks(lldb::addr_t vm_addr, void *buf,
+                                    lldb::addr_t chunk_size,
+                                    lldb::offset_t total_size,
+                                    ReadMemoryChunkCallback callback);
 
   /// Read a NULL terminated C string from memory
   ///

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -1589,6 +1589,42 @@ public:
   size_t ReadMemoryFromInferior(lldb::addr_t vm_addr, void *buf, size_t size,
                                 Status &error);
 
+  typedef lldb::IterationAction(ReadMemoryChunkCallback)(lldb::Status &,
+                                                         DataBufferHeap &, lldb
+                                                         : addr_t,
+                                                           lldb::offset_t);
+  /// Read of memory from a process in discrete chunks, terminating
+  /// either when all bytes are read, or the supplied callback returns
+  /// IterationAction::Stop
+  ///
+  /// \param[in] vm_addr
+  ///     A virtual load address that indicates where to start reading
+  ///     memory from.
+  ///
+  /// \param[in] data
+  ///     The data buffer heap to use to read the chunk. The chunk size
+  ///     depends upon the byte size of the buffer.
+  ///
+  /// \param[in] size
+  ///     The number of bytes to read.
+  ///
+  /// \param[in] callback
+  ///     The callback to invoke when a chunk is read from memory.
+  /// \param[in] cacheReads
+  ///     Whether to use the ReadMemory instead of ReadMemory inferior, defaults
+  ///     to false.
+  ///
+  /// \return
+  ///     The number of bytes that were actually read into \a buf and
+  ///     written to the provided callback.
+  ///     If the returned number is greater than zero, yet less than \a
+  ///     size, then this function will get called again with \a
+  ///     vm_addr, \a buf, and \a size updated appropriately. Zero is
+  ///     returned in the case of an error.
+  size_t ReadMemoryInChunks(lldb::addr_t vm_addr, DataBufferHeap &data,
+                            size_t size, ReadMemoryChunkCallback callback,
+                            bool cacheReads = false);
+
   /// Read a NULL terminated C string from memory
   ///
   /// This function will read a cache page at a time until the NULL

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
@@ -998,7 +998,8 @@ Status MinidumpFileBuilder::ReadWriteMemoryInChunks(
                 "Failed to read memory region at: %" PRIx64
                 ". Bytes read: %zu, error: %s",
                 addr, bytes_read_for_chunk, error.AsCString());
-      // If we've only read one byte we can just give up and return
+      // If we've read nothing, and get an error or fail to read
+      // we can just give up early.
       if (total_bytes_read == 0)
         return Status();
 

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.h
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.h
@@ -142,6 +142,13 @@ private:
   lldb_private::Status AddDirectory(llvm::minidump::StreamType type,
                                     uint64_t stream_size);
   lldb::offset_t GetCurrentDataEndOffset() const;
+
+  // Read a memory region from the process and write it to the file
+  // in fixed size chunks.
+  lldb_private::Status
+  ReadWriteMemoryInChunks(const lldb_private::CoreFileMemoryRange &range,
+                          uint64_t *bytes_read);
+
   // Stores directories to fill in later
   std::vector<llvm::minidump::Directory> m_directories;
   // When we write off the threads for the first time, we need to clean them up

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.h
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.h
@@ -145,9 +145,9 @@ private:
 
   // Read a memory region from the process and write it to the file
   // in fixed size chunks.
-  lldb_private::Status
-  ReadWriteMemoryInChunks(const lldb_private::CoreFileMemoryRange &range,
-                          uint64_t *bytes_read);
+  lldb_private::Status ReadWriteMemoryInChunks(
+      const std::unique_ptr<lldb_private::DataBufferHeap> &data_up,
+      const lldb_private::CoreFileMemoryRange &range, uint64_t *bytes_read);
 
   // Stores directories to fill in later
   std::vector<llvm::minidump::Directory> m_directories;

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.h
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.h
@@ -145,9 +145,10 @@ private:
 
   // Read a memory region from the process and write it to the file
   // in fixed size chunks.
-  lldb_private::Status ReadWriteMemoryInChunks(
-      const std::unique_ptr<lldb_private::DataBufferHeap> &data_up,
-      const lldb_private::CoreFileMemoryRange &range, uint64_t *bytes_read);
+  lldb_private::Status
+  ReadWriteMemoryInChunks(lldb_private::DataBufferHeap &data_buffer,
+                          const lldb_private::CoreFileMemoryRange &range,
+                          uint64_t &bytes_read);
 
   // Stores directories to fill in later
   std::vector<llvm::minidump::Directory> m_directories;

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -2233,28 +2233,33 @@ size_t Process::ReadMemoryFromInferior(addr_t addr, void *buf, size_t size,
   return bytes_read;
 }
 
-size_t Process::ReadMemoryInChunks(lldb::addr_t vm_addr, void *buf,
-                                   lldb::addr_t chunk_size, size_t size,
-                                   ReadMemoryChunkCallback callback) {
+lldb::offset_t Process::ReadMemoryInChunks(lldb::addr_t vm_addr, void *buf,
+                                           lldb::addr_t chunk_size,
+                                           lldb::offset_t size,
+                                           ReadMemoryChunkCallback callback) {
   // Safety check to prevent an infinite loop.
   if (chunk_size == 0)
     return 0;
 
-  // Create a data buffer heap of the specified size, initialized to 0.
+  // Buffer for when a NULL buf is provided, initialized
+  // to 0 bytes, we set it to chunk_size and then replace buf
+  // with the new buffer.
+  DataBufferHeap data_buffer;
+  if (!buf) {
+    data_buffer.SetByteSize(chunk_size);
+    buf = data_buffer.GetBytes();
+  }
+
   uint64_t bytes_remaining = size;
   uint64_t bytes_read = 0;
   Status error;
   while (bytes_remaining > 0) {
     // Get the next read chunk size as the minimum of the remaining bytes and
     // the write chunk max size.
-    const size_t bytes_to_read = std::min(bytes_remaining, chunk_size);
+    const lldb::addr_t bytes_to_read = std::min(bytes_remaining, chunk_size);
     const lldb::addr_t current_addr = vm_addr + bytes_read;
-    const size_t bytes_read_for_chunk =
+    const lldb::addr_t bytes_read_for_chunk =
         ReadMemoryFromInferior(current_addr, buf, bytes_to_read, error);
-
-    if (callback(error, buf, current_addr, bytes_to_read,
-                 bytes_read_for_chunk) == IterationAction::Stop)
-      break;
 
     bytes_read += bytes_read_for_chunk;
     // If the bytes read in this chunk would cause us to overflow, something
@@ -2263,6 +2268,10 @@ size_t Process::ReadMemoryInChunks(lldb::addr_t vm_addr, void *buf,
       return 0;
     else
       bytes_remaining -= bytes_read_for_chunk;
+
+    if (callback(error, current_addr, buf, bytes_read_for_chunk) ==
+        IterationAction::Stop)
+      break;
   }
 
   return bytes_read;

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -2234,27 +2234,27 @@ size_t Process::ReadMemoryFromInferior(addr_t addr, void *buf, size_t size,
 }
 
 size_t Process::ReadMemoryInChunks(lldb::addr_t vm_addr, void *buf,
-  lldb::addr_t chunk_size, size_t size,
-  ReadMemoryChunkCallback callback) {
-// Safety check to prevent an infinite loop.
-if (chunk_size == 0)
-return 0;
+                                   lldb::addr_t chunk_size, size_t size,
+                                   ReadMemoryChunkCallback callback) {
+  // Safety check to prevent an infinite loop.
+  if (chunk_size == 0)
+    return 0;
 
-// Create a data buffer heap of the specified size, initialized to 0.
-uint64_t bytes_remaining = size;
-uint64_t bytes_read = 0;
-Status error;
-while (bytes_remaining > 0) {
-// Get the next read chunk size as the minimum of the remaining bytes and
-// the write chunk max size.
-const size_t bytes_to_read = std::min(bytes_remaining, chunk_size);
-const lldb::addr_t current_addr = vm_addr + bytes_read;
-const size_t bytes_read_for_chunk =
-ReadMemoryFromInferior(current_addr, buf, bytes_to_read, error);
+  // Create a data buffer heap of the specified size, initialized to 0.
+  uint64_t bytes_remaining = size;
+  uint64_t bytes_read = 0;
+  Status error;
+  while (bytes_remaining > 0) {
+    // Get the next read chunk size as the minimum of the remaining bytes and
+    // the write chunk max size.
+    const size_t bytes_to_read = std::min(bytes_remaining, chunk_size);
+    const lldb::addr_t current_addr = vm_addr + bytes_read;
+    const size_t bytes_read_for_chunk =
+        ReadMemoryFromInferior(current_addr, buf, bytes_to_read, error);
 
-if (callback(error, buf, current_addr, bytes_to_read,
-bytes_read_for_chunk) == IterationAction::Stop)
-break;
+    if (callback(error, buf, current_addr, bytes_to_read,
+                 bytes_read_for_chunk) == IterationAction::Stop)
+      break;
 
     bytes_read += bytes_read_for_chunk;
     // If the bytes read in this chunk would cause us to overflow, something


### PR DESCRIPTION
I recently received an internal error report that LLDB was OOM'ing when creating a Minidump. In my 64b refactor we made a decision to acquire buffers the size of the largest memory region so we could read all of the contents in one call. This made error handling very simple (and simpler coding for me!) but had the trade off of large allocations if huge pages were enabled.

This patch is one I've had on the back burner for awhile, but we can read and write the Minidump memory sections in discrete chunks which we already do for writing to disk.

I had to refactor the error handling a bit, but it remains the same. We make a best effort attempt to read as much of the memory region as possible, but fail immediately if we receive an error writing to disk. I did not add new tests for this because our existing test suite is quite good, but I did manually verify a few Minidumps couldn't read beyond the red_zone.

```
(lldb) reg read $sp
     rsp = 0x00007fffffffc3b0
(lldb) p/x 0x00007fffffffc3b0 - 128
(long) 0x00007fffffffc330
(lldb) memory read 0x00007fffffffc330
0x7fffffffc330: 60 c3 ff ff ff 7f 00 00 60 cd ff ff ff 7f 00 00  `.......`.......
0x7fffffffc340: 60 c3 ff ff ff 7f 00 00 65 e6 26 00 00 00 00 00  `.......e.&.....
(lldb) memory read 0x00007fffffffc329
error: could not parse memory info (Success!)
```

I'm not sure how to quantify the memory improvement other than we would allocate the largest size regardless of the size. So a 2gb unreadable region would cause a 2gb allocation even if we were reading 4096 kb. Now we will take the range size or the max chunk size of 128 mb.