### PR TITLE
[RTSan][Apple] Disable AccessingALargeAtomicVariableDiesWhenRealtime

### DIFF
--- a/compiler-rt/lib/rtsan/tests/rtsan_test_functional.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_functional.cpp
@@ -171,6 +171,9 @@ TEST(TestRtsan, CopyingALambdaWithLargeCaptureDiesWhenRealtime) {
 }
 
 TEST(TestRtsan, AccessingALargeAtomicVariableDiesWhenRealtime) {
+  #ifdef __APPLE__
+  GTEST_SKIP(); // Test is failing on Apple Devices.
+  #endif
   std::atomic<float> small_atomic{0.0f};
   ASSERT_TRUE(small_atomic.is_lock_free());
   RealtimeInvoke([&small_atomic]() {

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_functional.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_functional.cpp
@@ -171,9 +171,9 @@ TEST(TestRtsan, CopyingALambdaWithLargeCaptureDiesWhenRealtime) {
 }
 
 TEST(TestRtsan, AccessingALargeAtomicVariableDiesWhenRealtime) {
-  #ifdef __APPLE__
+#ifdef __APPLE__
   GTEST_SKIP(); // Test is failing on Apple Devices.
-  #endif
+#endif
   std::atomic<float> small_atomic{0.0f};
   ASSERT_TRUE(small_atomic.is_lock_free());
   RealtimeInvoke([&small_atomic]() {


### PR DESCRIPTION
…on Apple devices

Disabling this test since it is failing Apple CI jobs:
https://green.lab.llvm.org/job/llvm.org/job/clang-stage1-RA/3694/testReport/RealtimeSanitizer-Unit/__Rtsan-x86_64h-Test_TestRtsan/AccessingALargeAtomicVariableDiesWhenRealtime/


rdar://145488759