### PR TITLE
[flang][cuda] Fix descriptor sync in data transfer

### DIFF
--- a/flang-rt/lib/cuda/memory.cpp
+++ b/flang-rt/lib/cuda/memory.cpp
@@ -147,7 +147,7 @@ void RTDECL(CUFDataTransferGlobalDescDesc)(Descriptor *dstDesc,
     void *deviceAddr{
         RTNAME(CUFGetDeviceAddress)((void *)dstDesc, sourceFile, sourceLine)};
     RTNAME(CUFDescriptorSync)
-    ((Descriptor *)deviceAddr, srcDesc, sourceFile, sourceLine);
+    ((Descriptor *)deviceAddr, dstDesc, sourceFile, sourceLine);
   }
 }
 }


### PR DESCRIPTION
The destination descriptor on the device needs to be sync with the destination descriptor on the host, not the src one. 