### PR TITLE
[SandboxVec][NFC] Add LLVM_DEBUG dumps

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Debug.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Debug.h
@@ -1,0 +1,21 @@
+//===- Debug.h --------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines the DEBUG_TYPE macro for LLVM_DEBUG which is shared across the
+// vectorizer components.
+//
+
+#ifndef LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_DEBUG_H
+#define LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_DEBUG_H
+
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "sandbox-vectorizer"
+#define DEBUG_PREFIX "SBVec: "
+
+#endif // LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_DEBUG_H

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Legality.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Legality.cpp
@@ -17,8 +17,6 @@
 
 namespace llvm::sandboxir {
 
-#define DEBUG_TYPE "SBVec:Legality"
-
 #ifndef NDEBUG
 void ShuffleMask::dump() const {
   print(dbgs());
@@ -191,13 +189,6 @@ LegalityAnalysis::notVectorizableBasedOnOpcodesAndTypes(
   return std::nullopt;
 }
 
-#ifndef NDEBUG
-static void dumpBndl(ArrayRef<Value *> Bndl) {
-  for (auto *V : Bndl)
-    dbgs() << *V << "\n";
-}
-#endif // NDEBUG
-
 CollectDescr
 LegalityAnalysis::getHowToCollectValues(ArrayRef<Value *> Bndl) const {
   SmallVector<CollectDescr::ExtractElementDescr, 4> Vec;
@@ -220,11 +211,8 @@ LegalityAnalysis::getHowToCollectValues(ArrayRef<Value *> Bndl) const {
 const LegalityResult &LegalityAnalysis::canVectorize(ArrayRef<Value *> Bndl,
                                                      bool SkipScheduling) {
   // If Bndl contains values other than instructions, we need to Pack.
-  if (any_of(Bndl, [](auto *V) { return !isa<Instruction>(V); })) {
-    LLVM_DEBUG(dbgs() << "Not vectorizing: Not Instructions:\n";
-               dumpBndl(Bndl););
+  if (any_of(Bndl, [](auto *V) { return !isa<Instruction>(V); }))
     return createLegalityResult<Pack>(ResultReason::NotInstructions);
-  }
   // Pack if not in the same BB.
   auto *BB = cast<Instruction>(Bndl[0])->getParent();
   if (any_of(drop_begin(Bndl),

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionAcceptOrRevert.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionAcceptOrRevert.cpp
@@ -9,6 +9,7 @@
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionAcceptOrRevert.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InstructionCost.h"
+#include "llvm/Transforms/Vectorize/SandboxVectorizer/Debug.h"
 
 namespace llvm {
 
@@ -20,15 +21,22 @@ namespace sandboxir {
 
 bool TransactionAcceptOrRevert::runOnRegion(Region &Rgn, const Analyses &A) {
   const auto &SB = Rgn.getScoreboard();
+  auto CostBefore = SB.getBeforeCost();
+  auto CostAfter = SB.getAfterCost();
   InstructionCost CostAfterMinusBefore = SB.getAfterCost() - SB.getBeforeCost();
+  LLVM_DEBUG(dbgs() << DEBUG_PREFIX << "Cost gain: " << CostAfterMinusBefore
+                    << " (before/after/threshold: " << CostBefore << "/"
+                    << CostAfter << "/" << CostThreshold << ")\n");
   // TODO: Print costs / write to remarks.
   auto &Tracker = Rgn.getContext().getTracker();
   if (CostAfterMinusBefore < -CostThreshold) {
     bool HasChanges = !Tracker.empty();
     Tracker.accept();
+    LLVM_DEBUG(dbgs() << DEBUG_PREFIX << "*** Transaction Accept ***\n");
     return HasChanges;
   }
   // Revert the IR.
+  LLVM_DEBUG(dbgs() << DEBUG_PREFIX << "*** Transaction Revert ***\n");
   Rgn.getContext().getTracker().revert();
   return false;
 }

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionSave.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionSave.cpp
@@ -9,10 +9,12 @@
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/Passes/TransactionSave.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/InstructionCost.h"
+#include "llvm/Transforms/Vectorize/SandboxVectorizer/Debug.h"
 
 namespace llvm::sandboxir {
 
 bool TransactionSave::runOnRegion(Region &Rgn, const Analyses &A) {
+  LLVM_DEBUG(dbgs() << DEBUG_PREFIX << "*** Save Transaction ***\n");
   Rgn.getContext().save();
   return false;
 }

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizer.cpp
@@ -11,13 +11,11 @@
 #include "llvm/IR/Module.h"
 #include "llvm/SandboxIR/Constant.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Transforms/Vectorize/SandboxVectorizer/Debug.h"
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizerPassBuilder.h"
 #include <regex>
 
 using namespace llvm;
-
-#define SV_NAME "sandbox-vectorizer"
-#define DEBUG_TYPE SV_NAME
 
 static cl::opt<bool>
     PrintPassPipeline("sbvec-print-pass-pipeline", cl::init(false), cl::Hidden,
@@ -119,13 +117,16 @@ bool SandboxVectorizerPass::runImpl(Function &LLVMF) {
 
   // If the target claims to have no vector registers early return.
   if (!TTI->getNumberOfRegisters(TTI->getRegisterClassForType(true))) {
-    LLVM_DEBUG(dbgs() << "SBVec: Target has no vector registers, return.\n");
+    LLVM_DEBUG(dbgs() << DEBUG_PREFIX
+                      << "Target has no vector registers, return.\n");
     return false;
   }
-  LLVM_DEBUG(dbgs() << "SBVec: Analyzing " << LLVMF.getName() << ".\n");
+  LLVM_DEBUG(dbgs() << DEBUG_PREFIX << "Analyzing " << LLVMF.getName()
+                    << ".\n");
   // Early return if the attribute NoImplicitFloat is used.
   if (LLVMF.hasFnAttribute(Attribute::NoImplicitFloat)) {
-    LLVM_DEBUG(dbgs() << "SBVec: NoImplicitFloat attribute, return.\n");
+    LLVM_DEBUG(dbgs() << DEBUG_PREFIX
+                      << "NoImplicitFloat attribute, return.\n");
     return false;
   }
 


### PR DESCRIPTION
This patch updates/adds LLVM_DEBUG dumps.
It moves the DEBUG_TYPE into SandboxVectorizer/Debug.h such that it can be shared across all components of the vectorizer.