### PR TITLE
[mlir][tosa] Add missing controlflow extension comment

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/IR/TosaOpBase.td
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TosaOpBase.td
@@ -233,6 +233,7 @@ class Tosa_I32EnumAttr<string name, string description, string mnemonic,
 // FP8E5M2      : 8-bit floating-point operations E5M2.
 // FFT          : Fast Fourier Transform operations.
 // VARIABLE     : Stateful variable operations.
+// CONTROLFLOW  : Control Flow operations.
 //===----------------------------------------------------------------------===//
 
 def Tosa_NONE : I32EnumAttrCase<"none", 0>;


### PR DESCRIPTION
A previous patch(#128216) that added the support for the control flow extension overlooked adding a comment. This patch adds the comment.
