### PR TITLE
Fix a bug copying the stop hooks from the dummy target.

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -211,6 +211,7 @@ Target::~Target() {
 
 void Target::PrimeFromDummyTarget(Target &target) {
   m_stop_hooks = target.m_stop_hooks;
+  m_stop_hook_next_id = target.m_stop_hook_next_id;
 
   for (const auto &breakpoint_sp : target.m_breakpoint_list.Breakpoints()) {
     if (breakpoint_sp->IsInternal())

--- a/lldb/test/API/commands/target/stop-hooks/TestStopHooks.py
+++ b/lldb/test/API/commands/target/stop-hooks/TestStopHooks.py
@@ -31,8 +31,8 @@ class TestStopHooks(TestBase):
         self.after_expr_test()
 
     def test_stop_hooks_before_and_after_creation(self):
-        """Test that if we add a stop hook in the dummy target, we can
-        they don't collide with ones set directly in the target."""
+        """Test that if we add a stop hooks in the dummy target,
+        they aren't overridden by the ones set directly in the target."""
         self.before_and_after_target()
 
     def step_out_test(self):

--- a/lldb/test/API/commands/target/stop-hooks/TestStopHooks.py
+++ b/lldb/test/API/commands/target/stop-hooks/TestStopHooks.py
@@ -26,9 +26,14 @@ class TestStopHooks(TestBase):
         self.step_out_test()
 
     def test_stop_hooks_after_expr(self):
-        """Test that a stop hook fires when hitting a breakpoint
-        that runs an expression"""
+        """Test that a stop hook fires when hitting a breakpoint that
+           runs an expression"""
         self.after_expr_test()
+
+    def test_stop_hooks_before_and_after_creation(self):
+        """Test that if we add a stop hook in the dummy target, we can
+           they don't collide with ones set directly in the target."""
+        self.before_and_after_target()
 
     def step_out_test(self):
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
@@ -85,3 +90,18 @@ class TestStopHooks(TestBase):
         var = target.FindFirstGlobalVariable("g_var")
         self.assertTrue(var.IsValid())
         self.assertEqual(var.GetValueAsUnsigned(), 1, "Updated g_var")
+
+    def before_and_after_target(self):
+        interp = self.dbg.GetCommandInterpreter()
+        result = lldb.SBCommandReturnObject()
+        interp.HandleCommand("target stop-hook add -o 'expr g_var++'", result)
+        self.assertTrue(result.Succeeded(), "Set the target stop hook")
+
+        (target, process, thread, first_bkpt) = lldbutil.run_to_source_breakpoint(
+            self, "Set a breakpoint here", self.main_source_file
+        )
+
+        interp.HandleCommand("target stop-hook add -o 'thread backtrace'", result)
+        self.assertTrue(result.Succeeded(), "Set the target stop hook")
+        self.expect("target stop-hook list", substrs=["expr g_var++", "thread backtrace"])
+

--- a/lldb/test/API/commands/target/stop-hooks/TestStopHooks.py
+++ b/lldb/test/API/commands/target/stop-hooks/TestStopHooks.py
@@ -27,12 +27,12 @@ class TestStopHooks(TestBase):
 
     def test_stop_hooks_after_expr(self):
         """Test that a stop hook fires when hitting a breakpoint that
-           runs an expression"""
+        runs an expression"""
         self.after_expr_test()
 
     def test_stop_hooks_before_and_after_creation(self):
         """Test that if we add a stop hook in the dummy target, we can
-           they don't collide with ones set directly in the target."""
+        they don't collide with ones set directly in the target."""
         self.before_and_after_target()
 
     def step_out_test(self):
@@ -103,5 +103,6 @@ class TestStopHooks(TestBase):
 
         interp.HandleCommand("target stop-hook add -o 'thread backtrace'", result)
         self.assertTrue(result.Succeeded(), "Set the target stop hook")
-        self.expect("target stop-hook list", substrs=["expr g_var++", "thread backtrace"])
-
+        self.expect(
+            "target stop-hook list", substrs=["expr g_var++", "thread backtrace"]
+        )

--- a/lldb/test/API/commands/target/stop-hooks/TestStopHooks.py
+++ b/lldb/test/API/commands/target/stop-hooks/TestStopHooks.py
@@ -31,7 +31,7 @@ class TestStopHooks(TestBase):
         self.after_expr_test()
 
     def test_stop_hooks_before_and_after_creation(self):
-        """Test that if we add a stop hooks in the dummy target,
+        """Test that if we add stop hooks in the dummy target,
         they aren't overridden by the ones set directly in the target."""
         self.before_and_after_target()
 


### PR DESCRIPTION
We didn't also copy over the next stop hook id, which meant we would overwrite the stop hooks from the dummy target with stop hooks set after they are copied over.