### PR TITLE
[lld][WebAssembly] Do not emit relocs against dead symbols

### DIFF
--- a/lld/test/wasm/emit-relocs.s
+++ b/lld/test/wasm/emit-relocs.s
@@ -27,6 +27,12 @@ foo:
   .int32  0
   .size   foo, 4
 
+.section .debug_info,"",@
+.p2align 2
+.int32 unused_function
+.int32 _start
+.int32 0
+
 # CHECK:        - Type:            CODE
 # CHECK-NEXT:     Relocations:
 # CHECK-NEXT:       - Type:            R_WASM_FUNCTION_INDEX_LEB
@@ -41,6 +47,15 @@ foo:
 # CHECK-NEXT:           Opcode:          I32_CONST
 # CHECK-NEXT:           Value:           1024
 # CHECK-NEXT:         Content:         '00000000'
+
+# There should be a single relocation in this section (just the live symbol)
+# CHECK-NEXT:  - Type:            CUSTOM
+# CHECK-NEXT:    Relocations:
+# CHECK-NEXT:      - Type:            R_WASM_FUNCTION_OFFSET_I32
+# CHECK-NEXT:        Index:           0
+# CHECK-NEXT:        Offset:          0x4
+# CHECK-NEXT:    Name:            .debug_info
+# CHECK-NEXT:    Payload:         FFFFFFFF0200000000000000
 
 # CHECK:        - Type:            CUSTOM
 # CHECK-NEXT:     Name:            linking

--- a/lld/wasm/InputChunks.cpp
+++ b/lld/wasm/InputChunks.cpp
@@ -167,15 +167,16 @@ void InputChunk::relocate(uint8_t *buf) const {
   }
 }
 
-static bool relocIsLive(const WasmRelocation& rel, ObjFile* file) {
+static bool relocIsLive(const WasmRelocation &rel, ObjFile *file) {
   return rel.Type == R_WASM_TYPE_INDEX_LEB ||
-    file->getSymbol(rel.Index)->isLive();
+         file->getSymbol(rel.Index)->isLive();
 }
 
 size_t InputChunk::getNumLiveRelocations() const {
   size_t result = 0;
-  for (const WasmRelocation& rel : relocations) {
-    if (relocIsLive(rel, file)) result ++;
+  for (const WasmRelocation &rel : relocations) {
+    if (relocIsLive(rel, file))
+      result++;
   }
   return result;
 }

--- a/lld/wasm/InputChunks.cpp
+++ b/lld/wasm/InputChunks.cpp
@@ -14,6 +14,7 @@
 #include "lld/Common/LLVM.h"
 #include "llvm/Support/LEB128.h"
 #include "llvm/Support/xxhash.h"
+#include <algorithm>
 
 #define DEBUG_TYPE "lld"
 
@@ -173,12 +174,10 @@ static bool relocIsLive(const WasmRelocation &rel, ObjFile *file) {
 }
 
 size_t InputChunk::getNumLiveRelocations() const {
-  size_t result = 0;
-  for (const WasmRelocation &rel : relocations) {
-    if (relocIsLive(rel, file))
-      result++;
-  }
-  return result;
+  return std::count_if(relocations.begin(), relocations.end(),
+                       [this](const WasmRelocation &rel) {
+                         return relocIsLive(rel, file);
+                       });
 }
 
 // Copy relocation entries to a given output stream.

--- a/lld/wasm/InputChunks.cpp
+++ b/lld/wasm/InputChunks.cpp
@@ -174,10 +174,9 @@ static bool relocIsLive(const WasmRelocation &rel, ObjFile *file) {
 }
 
 size_t InputChunk::getNumLiveRelocations() const {
-  return std::count_if(relocations.begin(), relocations.end(),
-                       [this](const WasmRelocation &rel) {
-                         return relocIsLive(rel, file);
-                       });
+  return std::count_if(
+      relocations.begin(), relocations.end(),
+      [this](const WasmRelocation &rel) { return relocIsLive(rel, file); });
 }
 
 // Copy relocation entries to a given output stream.

--- a/lld/wasm/InputChunks.h
+++ b/lld/wasm/InputChunks.h
@@ -77,6 +77,7 @@ public:
   uint32_t getInputSectionOffset() const { return inputSectionOffset; }
 
   size_t getNumRelocations() const { return relocations.size(); }
+  size_t getNumLiveRelocations() const;
   void writeRelocations(llvm::raw_ostream &os) const;
   bool generateRelocationCode(raw_ostream &os) const;
 

--- a/lld/wasm/OutputSections.cpp
+++ b/lld/wasm/OutputSections.cpp
@@ -274,7 +274,7 @@ void CustomSection::writeTo(uint8_t *buf) {
 uint32_t CustomSection::getNumRelocations() const {
   uint32_t count = 0;
   for (const InputChunk *inputSect : inputSections)
-    count += inputSect->getNumRelocations();
+    count += inputSect->getNumLiveRelocations();
   return count;
 }
 

--- a/lld/wasm/OutputSections.h
+++ b/lld/wasm/OutputSections.h
@@ -41,6 +41,7 @@ public:
   virtual void writeTo(uint8_t *buf) = 0;
   virtual void finalizeContents() = 0;
   virtual uint32_t getNumRelocations() const { return 0; }
+  virtual uint32_t getNumLiveRelocations() const { return getNumRelocations(); }
   virtual void writeRelocations(raw_ostream &os) const {}
 
   std::string header;

--- a/lld/wasm/Symbols.cpp
+++ b/lld/wasm/Symbols.cpp
@@ -183,7 +183,7 @@ void Symbol::markLive() {
 }
 
 uint32_t Symbol::getOutputSymbolIndex() const {
-  assert(outputSymbolIndex != INVALID_INDEX);
+  assert(outputSymbolIndex != INVALID_INDEX || !isLive());
   return outputSymbolIndex;
 }
 


### PR DESCRIPTION
When emitting relocs with linked output (i.e. --emit-relocs)
skip relocs against dead symbols (which do not appear in the output)
and do not emit them.
