### PR TITLE
[libc] Fix warning in libc/utils/MPCWrapper/MPCUtils.h

### DIFF
--- a/libc/utils/MPCWrapper/MPCUtils.h
+++ b/libc/utils/MPCWrapper/MPCUtils.h
@@ -174,11 +174,11 @@ template <Operation op, typename InputType, typename OutputType>
 constexpr bool is_valid_operation() {
   return (Operation::BeginBinaryOperationsSingleOutput < op &&
           op < Operation::EndBinaryOperationsSingleOutput &&
-          cpp::is_complex_type_same<InputType, OutputType> &&
+          cpp::is_complex_type_same<InputType, OutputType>() &&
           cpp::is_complex_v<InputType>) ||
          (Operation::BeginUnaryOperationsSingleOutputSameOutputType < op &&
           op < Operation::EndUnaryOperationsSingleOutputSameOutputType &&
-          cpp::is_complex_type_same<InputType, OutputType> &&
+          cpp::is_complex_type_same<InputType, OutputType>() &&
           cpp::is_complex_v<InputType>) ||
          (Operation::BeginUnaryOperationsSingleOutputDifferentOutputType < op &&
           op < Operation::EndUnaryOperationsSingleOutputDifferentOutputType &&


### PR DESCRIPTION
`cpp::is_complex_type_same<T1, T2>` is a function, so we need parentheses in order to call it. Otherwise the expression is treated like a function pointer which is always true in this boolean context.