### PR TITLE
[InstSimplify] Fold `X * C >= X` to `true`

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -3031,7 +3031,9 @@ enum class MonotonicType { GreaterEq, LowerEq };
 
 /// Get values V_i such that V uge V_i (GreaterEq) or V ule V_i (LowerEq).
 static void getUnsignedMonotonicValues(SmallPtrSetImpl<Value *> &Res, Value *V,
-                                       MonotonicType Type, unsigned Depth = 0) {
+                                       MonotonicType Type,
+                                       const SimplifyQuery &Q,
+                                       unsigned Depth = 0) {
   if (!Res.insert(V).second)
     return;
 
@@ -3047,24 +3049,31 @@ static void getUnsignedMonotonicValues(SmallPtrSetImpl<Value *> &Res, Value *V,
   if (Type == MonotonicType::GreaterEq) {
     if (match(I, m_Or(m_Value(X), m_Value(Y))) ||
         match(I, m_Intrinsic<Intrinsic::uadd_sat>(m_Value(X), m_Value(Y)))) {
-      getUnsignedMonotonicValues(Res, X, Type, Depth);
-      getUnsignedMonotonicValues(Res, Y, Type, Depth);
+      getUnsignedMonotonicValues(Res, X, Type, Q, Depth);
+      getUnsignedMonotonicValues(Res, Y, Type, Q, Depth);
+    }
+    // X * Y >= X --> true
+    if (match(I, m_NUWMul(m_Value(X), m_Value(Y)))) {
+      if (isKnownNonZero(X, Q))
+        getUnsignedMonotonicValues(Res, Y, Type, Q, Depth);
+      if (isKnownNonZero(Y, Q))
+        getUnsignedMonotonicValues(Res, X, Type, Q, Depth);
     }
   } else {
     assert(Type == MonotonicType::LowerEq);
     switch (I->getOpcode()) {
     case Instruction::And:
-      getUnsignedMonotonicValues(Res, I->getOperand(0), Type, Depth);
-      getUnsignedMonotonicValues(Res, I->getOperand(1), Type, Depth);
+      getUnsignedMonotonicValues(Res, I->getOperand(0), Type, Q, Depth);
+      getUnsignedMonotonicValues(Res, I->getOperand(1), Type, Q, Depth);
       break;
     case Instruction::URem:
     case Instruction::UDiv:
     case Instruction::LShr:
-      getUnsignedMonotonicValues(Res, I->getOperand(0), Type, Depth);
+      getUnsignedMonotonicValues(Res, I->getOperand(0), Type, Q, Depth);
       break;
     case Instruction::Call:
       if (match(I, m_Intrinsic<Intrinsic::usub_sat>(m_Value(X))))
-        getUnsignedMonotonicValues(Res, X, Type, Depth);
+        getUnsignedMonotonicValues(Res, X, Type, Q, Depth);
       break;
     default:
       break;
@@ -3073,7 +3082,8 @@ static void getUnsignedMonotonicValues(SmallPtrSetImpl<Value *> &Res, Value *V,
 }
 
 static Value *simplifyICmpUsingMonotonicValues(CmpPredicate Pred, Value *LHS,
-                                               Value *RHS) {
+                                               Value *RHS,
+                                               const SimplifyQuery &Q) {
   if (Pred != ICmpInst::ICMP_UGE && Pred != ICmpInst::ICMP_ULT)
     return nullptr;
 
@@ -3081,8 +3091,8 @@ static Value *simplifyICmpUsingMonotonicValues(CmpPredicate Pred, Value *LHS,
   // GreaterValues and LowerValues are the same, it follows that LHS uge RHS.
   SmallPtrSet<Value *, 4> GreaterValues;
   SmallPtrSet<Value *, 4> LowerValues;
-  getUnsignedMonotonicValues(GreaterValues, LHS, MonotonicType::GreaterEq);
-  getUnsignedMonotonicValues(LowerValues, RHS, MonotonicType::LowerEq);
+  getUnsignedMonotonicValues(GreaterValues, LHS, MonotonicType::GreaterEq, Q);
+  getUnsignedMonotonicValues(LowerValues, RHS, MonotonicType::LowerEq, Q);
   for (Value *GV : GreaterValues)
     if (LowerValues.contains(GV))
       return ConstantInt::getBool(getCompareTy(LHS),
@@ -3998,10 +4008,10 @@ static Value *simplifyICmpInst(CmpPredicate Pred, Value *LHS, Value *RHS,
           ICmpInst::getSwappedPredicate(Pred), RHS, LHS))
     return V;
 
-  if (Value *V = simplifyICmpUsingMonotonicValues(Pred, LHS, RHS))
+  if (Value *V = simplifyICmpUsingMonotonicValues(Pred, LHS, RHS, Q))
     return V;
   if (Value *V = simplifyICmpUsingMonotonicValues(
-          ICmpInst::getSwappedPredicate(Pred), RHS, LHS))
+          ICmpInst::getSwappedPredicate(Pred), RHS, LHS, Q))
     return V;
 
   if (Value *V = simplifyICmpWithDominatingAssume(Pred, LHS, RHS, Q))

--- a/llvm/test/Transforms/InstSimplify/icmp-monotonic.ll
+++ b/llvm/test/Transforms/InstSimplify/icmp-monotonic.ll
@@ -216,3 +216,140 @@ define i1 @lshr_add_ule_non_monotonic(i32 %x, i32 %y, i32 %z) {
   %cmp = icmp ule i32 %op1, %op2
   ret i1 %cmp
 }
+
+define i1 @mul_nuw_nonzero_rhs_monotonic(i8 %x, i8 %c) {
+; CHECK-LABEL: define i1 @mul_nuw_nonzero_rhs_monotonic(
+; CHECK-SAME: i8 [[X:%.*]], i8 [[C:%.*]]) {
+; CHECK-NEXT:    [[C_NONZERO:%.*]] = icmp ne i8 [[C]], 0
+; CHECK-NEXT:    call void @llvm.assume(i1 [[C_NONZERO]])
+; CHECK-NEXT:    [[PROD:%.*]] = mul nuw i8 [[X]], [[C]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i8 [[PROD]], [[X]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %c_nonzero = icmp ne i8 %c, 0
+  call void @llvm.assume(i1 %c_nonzero)
+
+  %prod = mul nuw i8 %x, %c
+  %cmp = icmp uge i8 %prod, %x
+  ret i1 %cmp
+}
+
+define i1 @mul_nuw_nonzero_rhs_monotonic_inverse_predicate(i8 %x, i8 %c) {
+; CHECK-LABEL: define i1 @mul_nuw_nonzero_rhs_monotonic_inverse_predicate(
+; CHECK-SAME: i8 [[X:%.*]], i8 [[C:%.*]]) {
+; CHECK-NEXT:    [[C_NONZERO:%.*]] = icmp ne i8 [[C]], 0
+; CHECK-NEXT:    call void @llvm.assume(i1 [[C_NONZERO]])
+; CHECK-NEXT:    [[PROD:%.*]] = mul nuw i8 [[X]], [[C]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i8 [[PROD]], [[X]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %c_nonzero = icmp ne i8 %c, 0
+  call void @llvm.assume(i1 %c_nonzero)
+
+  %prod = mul nuw i8 %x, %c
+  %cmp = icmp ult i8 %prod, %x
+  ret i1 %cmp
+}
+
+define i1 @mul_nuw_nonzero_lhs_monotonic(i8 %x, i8 %c) {
+; CHECK-LABEL: define i1 @mul_nuw_nonzero_lhs_monotonic(
+; CHECK-SAME: i8 [[X:%.*]], i8 [[C:%.*]]) {
+; CHECK-NEXT:    [[C_NONZERO:%.*]] = icmp ne i8 [[X]], 0
+; CHECK-NEXT:    call void @llvm.assume(i1 [[C_NONZERO]])
+; CHECK-NEXT:    [[PROD:%.*]] = mul nuw i8 [[X]], [[C]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i8 [[PROD]], [[C]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %c_nonzero = icmp ne i8 %x, 0
+  call void @llvm.assume(i1 %c_nonzero)
+
+  %prod = mul nuw i8 %x, %c
+  %cmp = icmp uge i8 %prod, %c
+  ret i1 %cmp
+}
+
+define i1 @mul_nuw_nonzero_lhs_rhs_monotonic(i8 %x, i8 %c) {
+; CHECK-LABEL: define i1 @mul_nuw_nonzero_lhs_rhs_monotonic(
+; CHECK-SAME: i8 [[X:%.*]], i8 [[C:%.*]]) {
+; CHECK-NEXT:    [[C_NONZERO:%.*]] = icmp ne i8 [[C]], 0
+; CHECK-NEXT:    call void @llvm.assume(i1 [[C_NONZERO]])
+; CHECK-NEXT:    [[X_NONZERO:%.*]] = icmp ne i8 [[X]], 0
+; CHECK-NEXT:    call void @llvm.assume(i1 [[X_NONZERO]])
+; CHECK-NEXT:    [[PROD:%.*]] = mul nuw i8 [[X]], [[C]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i8 [[PROD]], [[X]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %c_nonzero = icmp ne i8 %c, 0
+  call void @llvm.assume(i1 %c_nonzero)
+
+  %x_nonzero = icmp ne i8 %x, 0
+  call void @llvm.assume(i1 %x_nonzero)
+
+  %prod = mul nuw i8 %x, %c
+  %cmp = icmp uge i8 %prod, %x
+  ret i1 %cmp
+}
+
+
+define i1 @negative_mul_non_nsw(i8 %x, i8 %c) {
+; CHECK-LABEL: define i1 @negative_mul_non_nsw(
+; CHECK-SAME: i8 [[X:%.*]], i8 [[C:%.*]]) {
+; CHECK-NEXT:    [[C_NONZERO:%.*]] = icmp ne i8 [[C]], 0
+; CHECK-NEXT:    call void @llvm.assume(i1 [[C_NONZERO]])
+; CHECK-NEXT:    [[X3:%.*]] = mul i8 [[X]], [[C]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i8 [[X3]], [[X]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %c_nonzero = icmp ne i8 %c, 0
+  call void @llvm.assume(i1 %c_nonzero)
+
+  %prod = mul i8 %x, %c
+  %cmp = icmp uge i8 %prod, %x
+  ret i1 %cmp
+}
+
+define i1 @negative_mul_no_nonzero(i8 %x, i8 %c) {
+; CHECK-LABEL: define i1 @negative_mul_no_nonzero(
+; CHECK-SAME: i8 [[X:%.*]], i8 [[C:%.*]]) {
+; CHECK-NEXT:    [[X3:%.*]] = mul nsw i8 [[X]], [[C]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i8 [[X3]], [[X]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %prod = mul nsw i8 %x, %c
+  %cmp = icmp uge i8 %prod, %x
+  ret i1 %cmp
+}
+
+define i1 @negative_mul_lhs_maybe_zero(i8 %x, i8 %c) {
+; CHECK-LABEL: define i1 @negative_mul_lhs_maybe_zero(
+; CHECK-SAME: i8 [[X:%.*]], i8 [[C:%.*]]) {
+; CHECK-NEXT:    [[C_NONZERO:%.*]] = icmp ne i8 [[C]], 0
+; CHECK-NEXT:    call void @llvm.assume(i1 [[C_NONZERO]])
+; CHECK-NEXT:    [[X3:%.*]] = mul nuw i8 [[X]], [[C]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i8 [[X3]], [[C]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %c_nonzero = icmp ne i8 %c, 0
+  call void @llvm.assume(i1 %c_nonzero)
+
+  %prod = mul nuw i8 %x, %c
+  %cmp = icmp uge i8 %prod, %c
+  ret i1 %cmp
+}
+
+define i1 @negative_mul_rhs_maybe_zero(i8 %x, i8 %c) {
+; CHECK-LABEL: define i1 @negative_mul_rhs_maybe_zero(
+; CHECK-SAME: i8 [[X:%.*]], i8 [[C:%.*]]) {
+; CHECK-NEXT:    [[C_NONZERO:%.*]] = icmp ne i8 [[X]], 0
+; CHECK-NEXT:    call void @llvm.assume(i1 [[C_NONZERO]])
+; CHECK-NEXT:    [[X3:%.*]] = mul nuw i8 [[X]], [[C]]
+; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i8 [[X3]], [[X]]
+; CHECK-NEXT:    ret i1 [[CMP]]
+;
+  %c_nonzero = icmp ne i8 %x, 0
+  call void @llvm.assume(i1 %c_nonzero)
+
+  %prod = mul nuw i8 %x, %c
+  %cmp = icmp uge i8 %prod, %x
+  ret i1 %cmp
+}

--- a/llvm/test/Transforms/InstSimplify/icmp-monotonic.ll
+++ b/llvm/test/Transforms/InstSimplify/icmp-monotonic.ll
@@ -232,6 +232,21 @@ define i1 @mul_nuw_nonzero_rhs_monotonic(i8 %x, i8 %c) {
   ret i1 %cmp
 }
 
+define i1 @mul_nuw_nonzero_rhs_commuted_monotonic(i8 %x, i8 %c) {
+; CHECK-LABEL: define i1 @mul_nuw_nonzero_rhs_commuted_monotonic(
+; CHECK-SAME: i8 [[X:%.*]], i8 [[C:%.*]]) {
+; CHECK-NEXT:    [[C_NONZERO:%.*]] = icmp ne i8 [[C]], 0
+; CHECK-NEXT:    call void @llvm.assume(i1 [[C_NONZERO]])
+; CHECK-NEXT:    ret i1 true
+;
+  %c_nonzero = icmp ne i8 %c, 0
+  call void @llvm.assume(i1 %c_nonzero)
+
+  %prod = mul nuw i8 %c, %x
+  %cmp = icmp uge i8 %prod, %x
+  ret i1 %cmp
+}
+
 define i1 @mul_nuw_nonzero_rhs_monotonic_inverse_predicate(i8 %x, i8 %c) {
 ; CHECK-LABEL: define i1 @mul_nuw_nonzero_rhs_monotonic_inverse_predicate(
 ; CHECK-SAME: i8 [[X:%.*]], i8 [[C:%.*]]) {

--- a/llvm/test/Transforms/InstSimplify/icmp-monotonic.ll
+++ b/llvm/test/Transforms/InstSimplify/icmp-monotonic.ll
@@ -222,9 +222,7 @@ define i1 @mul_nuw_nonzero_rhs_monotonic(i8 %x, i8 %c) {
 ; CHECK-SAME: i8 [[X:%.*]], i8 [[C:%.*]]) {
 ; CHECK-NEXT:    [[C_NONZERO:%.*]] = icmp ne i8 [[C]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[C_NONZERO]])
-; CHECK-NEXT:    [[PROD:%.*]] = mul nuw i8 [[X]], [[C]]
-; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i8 [[PROD]], [[X]]
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 true
 ;
   %c_nonzero = icmp ne i8 %c, 0
   call void @llvm.assume(i1 %c_nonzero)
@@ -239,9 +237,7 @@ define i1 @mul_nuw_nonzero_rhs_monotonic_inverse_predicate(i8 %x, i8 %c) {
 ; CHECK-SAME: i8 [[X:%.*]], i8 [[C:%.*]]) {
 ; CHECK-NEXT:    [[C_NONZERO:%.*]] = icmp ne i8 [[C]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[C_NONZERO]])
-; CHECK-NEXT:    [[PROD:%.*]] = mul nuw i8 [[X]], [[C]]
-; CHECK-NEXT:    [[CMP:%.*]] = icmp ult i8 [[PROD]], [[X]]
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 false
 ;
   %c_nonzero = icmp ne i8 %c, 0
   call void @llvm.assume(i1 %c_nonzero)
@@ -256,9 +252,7 @@ define i1 @mul_nuw_nonzero_lhs_monotonic(i8 %x, i8 %c) {
 ; CHECK-SAME: i8 [[X:%.*]], i8 [[C:%.*]]) {
 ; CHECK-NEXT:    [[C_NONZERO:%.*]] = icmp ne i8 [[X]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[C_NONZERO]])
-; CHECK-NEXT:    [[PROD:%.*]] = mul nuw i8 [[X]], [[C]]
-; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i8 [[PROD]], [[C]]
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 true
 ;
   %c_nonzero = icmp ne i8 %x, 0
   call void @llvm.assume(i1 %c_nonzero)
@@ -275,9 +269,7 @@ define i1 @mul_nuw_nonzero_lhs_rhs_monotonic(i8 %x, i8 %c) {
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[C_NONZERO]])
 ; CHECK-NEXT:    [[X_NONZERO:%.*]] = icmp ne i8 [[X]], 0
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[X_NONZERO]])
-; CHECK-NEXT:    [[PROD:%.*]] = mul nuw i8 [[X]], [[C]]
-; CHECK-NEXT:    [[CMP:%.*]] = icmp uge i8 [[PROD]], [[X]]
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 true
 ;
   %c_nonzero = icmp ne i8 %c, 0
   call void @llvm.assume(i1 %c_nonzero)


### PR DESCRIPTION
Proof: https://alive2.llvm.org/ce/z/T_ocLy

Discovered in: https://github.com/rust-lang/rust/issues/114386

This PR folds `X * C >= X` to `true` when `C` is known to be non-zero and `mul` is `nuw`.

Folds for other math operators exist already: https://llvm-ir.godbolt.org/z/GKcYEf5Kb
