### PR TITLE
[SPIR-V] Stop using Register to represent target specific virtual registers.

### DIFF
--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
@@ -14,7 +14,6 @@
 #include "SPIRV.h"
 #include "SPIRVBaseInfo.h"
 #include "llvm/ADT/APFloat.h"
-#include "llvm/CodeGen/Register.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCInst.h"
@@ -97,7 +96,7 @@ void SPIRVInstPrinter::printOpConstantVarOps(const MCInst *MI,
 }
 
 void SPIRVInstPrinter::recordOpExtInstImport(const MCInst *MI) {
-  Register Reg = MI->getOperand(0).getReg();
+  MCRegister Reg = MI->getOperand(0).getReg();
   auto Name = getSPIRVStringOperand(*MI, 1);
   auto Set = getExtInstSetFromString(Name);
   ExtInstSetIDs.insert({Reg, Set});
@@ -335,7 +334,7 @@ void SPIRVInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
   if (OpNo < MI->getNumOperands()) {
     const MCOperand &Op = MI->getOperand(OpNo);
     if (Op.isReg())
-      O << '%' << (Register(Op.getReg()).virtRegIndex() + 1);
+      O << '%' << (getIDFromRegister(Op.getReg().id()) + 1);
     else if (Op.isImm())
       O << formatImm((int64_t)Op.getImm());
     else if (Op.isDFPImm())

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCCodeEmitter.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCCodeEmitter.cpp
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "MCTargetDesc/SPIRVMCTargetDesc.h"
-#include "llvm/CodeGen/Register.h"
 #include "llvm/MC/MCCodeEmitter.h"
 #include "llvm/MC/MCFixup.h"
 #include "llvm/MC/MCInst.h"
@@ -77,7 +76,8 @@ static void emitOperand(const MCOperand &Op, SmallVectorImpl<char> &CB) {
   if (Op.isReg()) {
     // Emit the id index starting at 1 (0 is an invalid index).
     support::endian::write<uint32_t>(
-        CB, Register(Op.getReg()).virtRegIndex() + 1, llvm::endianness::little);
+        CB, SPIRV::getIDFromRegister(Op.getReg().id()) + 1,
+        llvm::endianness::little);
   } else if (Op.isImm()) {
     support::endian::write(CB, static_cast<uint32_t>(Op.getImm()),
                            llvm::endianness::little);

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCTargetDesc.h
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCTargetDesc.h
@@ -14,6 +14,7 @@
 #define LLVM_LIB_TARGET_SPIRV_MCTARGETDESC_SPIRVMCTARGETDESC_H
 
 #include "llvm/Support/DataTypes.h"
+#include <cassert>
 #include <memory>
 
 namespace llvm {
@@ -49,5 +50,12 @@ std::unique_ptr<MCObjectTargetWriter> createSPIRVObjectTargetWriter();
 
 #define GET_SUBTARGETINFO_ENUM
 #include "SPIRVGenSubtargetInfo.inc"
+
+namespace llvm::SPIRV {
+inline unsigned getIDFromRegister(unsigned Reg) {
+  assert(Reg & (1U << 31));
+  return Reg & ~(1U << 31);
+}
+} // namespace llvm::SPIRV
 
 #endif // LLVM_LIB_TARGET_SPIRV_MCTARGETDESC_SPIRVMCTARGETDESC_H

--- a/llvm/lib/Target/SPIRV/SPIRVMCInstLower.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVMCInstLower.cpp
@@ -34,7 +34,7 @@ void SPIRVMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI,
     default:
       llvm_unreachable("unknown operand type");
     case MachineOperand::MO_GlobalAddress: {
-      Register FuncReg = MAI->getFuncReg(dyn_cast<Function>(MO.getGlobal()));
+      MCRegister FuncReg = MAI->getFuncReg(dyn_cast<Function>(MO.getGlobal()));
       if (!FuncReg.isValid()) {
         std::string DiagMsg;
         raw_string_ostream OS(DiagMsg);
@@ -49,13 +49,14 @@ void SPIRVMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI,
       MCOp = MCOperand::createReg(MAI->getOrCreateMBBRegister(*MO.getMBB()));
       break;
     case MachineOperand::MO_Register: {
-      Register NewReg = MAI->getRegisterAlias(MF, MO.getReg());
-      MCOp = MCOperand::createReg(NewReg.isValid() ? NewReg : MO.getReg());
+      MCRegister NewReg = MAI->getRegisterAlias(MF, MO.getReg());
+      MCOp = MCOperand::createReg(NewReg.isValid() ? NewReg
+                                                   : MO.getReg().asMCReg());
       break;
     }
     case MachineOperand::MO_Immediate:
       if (MI->getOpcode() == SPIRV::OpExtInst && i == 2) {
-        Register Reg = MAI->getExtInstSetReg(MO.getImm());
+        MCRegister Reg = MAI->getExtInstSetReg(MO.getImm());
         MCOp = MCOperand::createReg(Reg);
       } else {
         MCOp = MCOperand::createImm(MO.getImm());

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
@@ -126,7 +126,7 @@ public:
 
 using InstrList = SmallVector<const MachineInstr *>;
 // Maps a local register to the corresponding global alias.
-using LocalToGlobalRegTable = std::map<Register, Register>;
+using LocalToGlobalRegTable = std::map<Register, MCRegister>;
 using RegisterAliasMapTy =
     std::map<const MachineFunction *, LocalToGlobalRegTable>;
 
@@ -140,11 +140,11 @@ struct ModuleAnalysisInfo {
   unsigned SrcLangVersion;
   StringSet<> SrcExt;
   // Maps ExtInstSet to corresponding ID register.
-  DenseMap<unsigned, Register> ExtInstSetMap;
+  DenseMap<unsigned, MCRegister> ExtInstSetMap;
   // Contains the list of all global OpVariables in the module.
   SmallVector<const MachineInstr *, 4> GlobalVarList;
   // Maps functions to corresponding function ID registers.
-  DenseMap<const Function *, Register> FuncMap;
+  DenseMap<const Function *, MCRegister> FuncMap;
   // The set contains machine instructions which are necessary
   // for correct MIR but will not be emitted in function bodies.
   DenseSet<const MachineInstr *> InstrsToDelete;
@@ -157,29 +157,29 @@ struct ModuleAnalysisInfo {
   // The array contains lists of MIs for each module section.
   InstrList MS[NUM_MODULE_SECTIONS];
   // The table maps MBB number to SPIR-V unique ID register.
-  DenseMap<std::pair<const MachineFunction *, int>, Register> BBNumToRegMap;
+  DenseMap<std::pair<const MachineFunction *, int>, MCRegister> BBNumToRegMap;
 
-  Register getFuncReg(const Function *F) {
+  MCRegister getFuncReg(const Function *F) {
     assert(F && "Function is null");
     auto FuncPtrRegPair = FuncMap.find(F);
-    return FuncPtrRegPair == FuncMap.end() ? Register(0)
+    return FuncPtrRegPair == FuncMap.end() ? MCRegister()
                                            : FuncPtrRegPair->second;
   }
-  Register getExtInstSetReg(unsigned SetNum) { return ExtInstSetMap[SetNum]; }
+  MCRegister getExtInstSetReg(unsigned SetNum) { return ExtInstSetMap[SetNum]; }
   InstrList &getMSInstrs(unsigned MSType) { return MS[MSType]; }
   void setSkipEmission(const MachineInstr *MI) { InstrsToDelete.insert(MI); }
   bool getSkipEmission(const MachineInstr *MI) {
     return InstrsToDelete.contains(MI);
   }
   void setRegisterAlias(const MachineFunction *MF, Register Reg,
-                        Register AliasReg) {
+                        MCRegister AliasReg) {
     RegisterAliasTable[MF][Reg] = AliasReg;
   }
-  Register getRegisterAlias(const MachineFunction *MF, Register Reg) {
+  MCRegister getRegisterAlias(const MachineFunction *MF, Register Reg) {
     auto &RegTable = RegisterAliasTable[MF];
     auto RI = RegTable.find(Reg);
     if (RI == RegTable.end()) {
-      return Register(0);
+      return MCRegister();
     }
     return RI->second;
   }
@@ -190,16 +190,19 @@ struct ModuleAnalysisInfo {
     return RI->second.find(Reg) != RI->second.end();
   }
   unsigned getNextID() { return MaxID++; }
+  MCRegister getNextIDRegister() {
+    return MCRegister((1U << 31) | getNextID());
+  }
   bool hasMBBRegister(const MachineBasicBlock &MBB) {
     auto Key = std::make_pair(MBB.getParent(), MBB.getNumber());
     return BBNumToRegMap.contains(Key);
   }
   // Convert MBB's number to corresponding ID register.
-  Register getOrCreateMBBRegister(const MachineBasicBlock &MBB) {
+  MCRegister getOrCreateMBBRegister(const MachineBasicBlock &MBB) {
     auto Key = std::make_pair(MBB.getParent(), MBB.getNumber());
     auto [It, Inserted] = BBNumToRegMap.try_emplace(Key);
     if (Inserted)
-      It->second = Register::index2VirtReg(getNextID());
+      It->second = getNextIDRegister();
     return It->second;
   }
 };
@@ -230,11 +233,11 @@ private:
   void visitDecl(const MachineRegisterInfo &MRI, InstrGRegsMap &SignatureToGReg,
                  std::map<const Value *, unsigned> &GlobalToGReg,
                  const MachineFunction *MF, const MachineInstr &MI);
-  Register handleVariable(const MachineFunction *MF, const MachineInstr &MI,
-                          std::map<const Value *, unsigned> &GlobalToGReg);
-  Register handleTypeDeclOrConstant(const MachineInstr &MI,
-                                    InstrGRegsMap &SignatureToGReg);
-  Register
+  MCRegister handleVariable(const MachineFunction *MF, const MachineInstr &MI,
+                            std::map<const Value *, unsigned> &GlobalToGReg);
+  MCRegister handleTypeDeclOrConstant(const MachineInstr &MI,
+                                      InstrGRegsMap &SignatureToGReg);
+  MCRegister
   handleFunctionOrParameter(const MachineFunction *MF, const MachineInstr &MI,
                             std::map<const Value *, unsigned> &GlobalToGReg,
                             bool &IsFunDef);


### PR DESCRIPTION
These were using the virtual register encoding in Register which required including Register.h in MC layer code which is a layering violation.

This also required converting Register with bit 31 set to MCRegister which should be an error. Register with bit 31 set should only be used for codegen virtual register. I'd like to add assertions to enforce this.

Migrate to MCRegister and manually create an encoding with bit 31 set. WebAssembly also does this.

We could consider adding interfaces to MCRegister for target specific virtual registers.