### PR TITLE
[clang-format] Don't sort includes for C#

### DIFF
--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -3547,7 +3547,8 @@ tooling::Replacements sortIncludes(const FormatStyle &Style, StringRef Code,
     return sortJavaScriptImports(Style, Code, Ranges, FileName);
   if (Style.Language == FormatStyle::LanguageKind::LK_Java)
     return sortJavaImports(Style, Code, Ranges, FileName, Replaces);
-  sortCppIncludes(Style, Code, Ranges, FileName, Replaces, Cursor);
+  if (Style.isCpp())
+    sortCppIncludes(Style, Code, Ranges, FileName, Replaces, Cursor);
   return Replaces;
 }
 

--- a/clang/unittests/Format/SortIncludesTest.cpp
+++ b/clang/unittests/Format/SortIncludesTest.cpp
@@ -1085,6 +1085,15 @@ TEST_F(SortIncludesTest, DoNotSortLikelyXml) {
                     "input.h", 0));
 }
 
+TEST_F(SortIncludesTest, DoNotSortCSharp) {
+  constexpr StringRef Code{"const string expectedDataStruct = @\"\n"
+                           "            #include <b.h>\n"
+                           "            #include <a.h>\n"
+                           "        \";"};
+  FmtStyle.Language = FormatStyle::LK_CSharp;
+  EXPECT_TRUE(sortIncludes(FmtStyle, Code, GetCodeRange(Code), "a.cs").empty());
+}
+
 TEST_F(SortIncludesTest, DoNotOutputReplacementsForSortedBlocksWithRegrouping) {
   Style.IncludeBlocks = Style.IBS_Regroup;
   StringRef Code = "#include \"b.h\"\n"


### PR DESCRIPTION
Fixes #106194