### PR TITLE
[clang-tidy] detect arithmetic operations within member list initialization in modernize-use-default-member-init check

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseDefaultMemberInitCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseDefaultMemberInitCheck.cpp
@@ -159,6 +159,13 @@ static bool sameValue(const Expr *E1, const Expr *E2) {
   case Stmt::UnaryOperatorClass:
     return sameValue(cast<UnaryOperator>(E1)->getSubExpr(),
                      cast<UnaryOperator>(E2)->getSubExpr());
+  case Stmt::BinaryOperatorClass: {
+    const auto *BinOp1 = cast<BinaryOperator>(E1);
+    const auto *BinOp2 = cast<BinaryOperator>(E2);
+    return BinOp1->getOpcode() == BinOp2->getOpcode() &&
+           sameValue(BinOp1->getLHS(), BinOp2->getLHS()) &&
+           sameValue(BinOp1->getRHS(), BinOp2->getRHS());
+  }
   case Stmt::CharacterLiteralClass:
     return cast<CharacterLiteral>(E1)->getValue() ==
            cast<CharacterLiteral>(E2)->getValue();
@@ -199,17 +206,22 @@ void UseDefaultMemberInitCheck::storeOptions(
 }
 
 void UseDefaultMemberInitCheck::registerMatchers(MatchFinder *Finder) {
-  auto ConstExpRef = varDecl(anyOf(isConstexpr(), isStaticStorageClass()));
+  auto NumericLiteral = anyOf(integerLiteral(), floatLiteral());
+  auto UnaryNumericLiteral = unaryOperator(hasAnyOperatorName("+", "-"),
+                                           hasUnaryOperand(NumericLiteral));
+
+  auto ConstExprRef = varDecl(anyOf(isConstexpr(), isStaticStorageClass()));
+  auto ImmutableRef =
+      declRefExpr(to(decl(anyOf(enumConstantDecl(), ConstExprRef))));
+
+  auto BinaryNumericExpr = binaryOperator(
+      hasOperands(anyOf(NumericLiteral, ImmutableRef, binaryOperator()),
+                  anyOf(NumericLiteral, ImmutableRef, binaryOperator())));
 
   auto InitBase =
-      anyOf(stringLiteral(), characterLiteral(), integerLiteral(),
-            unaryOperator(hasAnyOperatorName("+", "-"),
-                          hasUnaryOperand(integerLiteral())),
-            floatLiteral(),
-            unaryOperator(hasAnyOperatorName("+", "-"),
-                          hasUnaryOperand(floatLiteral())),
-            cxxBoolLiteral(), cxxNullPtrLiteralExpr(), implicitValueInitExpr(),
-            declRefExpr(to(anyOf(enumConstantDecl(), ConstExpRef))));
+      anyOf(stringLiteral(), characterLiteral(), NumericLiteral,
+            UnaryNumericLiteral, cxxBoolLiteral(), cxxNullPtrLiteralExpr(),
+            implicitValueInitExpr(), ImmutableRef, BinaryNumericExpr);
 
   auto ExplicitCastExpr = castExpr(hasSourceExpression(InitBase));
   auto InitMatcher = anyOf(InitBase, ExplicitCastExpr);

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -190,7 +190,7 @@ Changes in existing checks
 
 - Improved :doc:`modernize-use-default-member-init
   <clang-tidy/checks/modernize/use-default-member-init>` check by matching
-  ``constexpr`` and ``static``` values on member initialization and by detecting
+  arithmetic operations, ``constexpr`` and ``static`` values, and detecting
   explicit casting of built-in types within member list initialization.
 
 - Improved :doc:`modernize-use-designated-initializers

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-default-member-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-default-member-init.cpp
@@ -572,4 +572,27 @@ class FunctionalCastInit {
   // CHECK-FIXES: double c{double('C')};
 };
 
+#define ARITHMETIC_MACRO (44 - 2)
+
+class DefaultMemberInitWithArithmetic {
+  DefaultMemberInitWithArithmetic() : a{1 + 1},  b{1 + 11 + 123 + 1234},  c{2 + (4 / 2) + 3 + (7 / 11)},  d{ARITHMETIC_MACRO * 2}, e{1.2 + 3.4} {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:39: warning: member initializer for 'a' is redundant [modernize-use-default-member-init]
+  // CHECK-FIXES: DefaultMemberInitWithArithmetic()  {}
+
+  int a{1 + 1};
+  int b;
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use default member initializer for 'b' [modernize-use-default-member-init]
+  // CHECK-FIXES:  int b{1 + 11 + 123 + 1234};
+  int c;
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use default member initializer for 'c' [modernize-use-default-member-init]
+  // CHECK-FIXES: int c{2 + (4 / 2) + 3 + (7 / 11)};
+  int d;
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use default member initializer for 'd' [modernize-use-default-member-init]
+  // CHECK-FIXES: int d{ARITHMETIC_MACRO * 2};
+  double e;
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: use default member initializer for 'e' [modernize-use-default-member-init]
+  // CHECK-FIXES: double e{1.2 + 3.4};
+
+};
+
 } //namespace PR122480


### PR DESCRIPTION
This aims to address a portion of #122480 by adding matchers on binary operators. **This allows the detection of explicit arithmetic operations within initializers.**

### Note
I'm aware of the other false-negatives presented in the issue above, specifically not matching explicit castings & constexpr values. These will be addressed separately on a different PR's which are in the process and shouldn't take long (let me know if that's the right approach).

Feedback is much appreciated. 
