### PR TITLE
[VectorCombine] scalarizeLoadExtract - don't create scalar loads if any extract is waiting to be erased

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -1579,6 +1579,11 @@ bool VectorCombine::scalarizeLoadExtract(Instruction &I) {
     if (!UI || UI->getParent() != LI->getParent())
       return false;
 
+    // If any extract is waiting to be erased, then bail out as this will
+    // distort the cost calculation and possibly lead to infinite loops.
+    if (isInstructionTriviallyDead(UI))
+      return false;
+
     // Check if any instruction between the load and the extract may modify
     // memory.
     if (LastCheckedInst->comesBefore(UI)) {

--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -1581,7 +1581,7 @@ bool VectorCombine::scalarizeLoadExtract(Instruction &I) {
 
     // If any extract is waiting to be erased, then bail out as this will
     // distort the cost calculation and possibly lead to infinite loops.
-    if (isInstructionTriviallyDead(UI))
+    if (UI->use_empty())
       return false;
 
     // Check if any instruction between the load and the extract may modify

--- a/llvm/test/Transforms/VectorCombine/X86/load-extractelement-scalarization.ll
+++ b/llvm/test/Transforms/VectorCombine/X86/load-extractelement-scalarization.ll
@@ -24,3 +24,15 @@ define void @multiple_extract(ptr %p) {
   store i32 %e1, ptr %p1, align 4
   ret void
 }
+
+; infinite loop if we fold an extract that is waiting to be erased
+define void @unsued_extract(ptr %p) {
+; CHECK-LABEL: @unsued_extract(
+; CHECK-NEXT:    ret void
+;
+  %load = load <4 x float>, ptr %p, align 8
+  %shuffle0 = shufflevector <4 x float> zeroinitializer, <4 x float> %load, <4 x i32> <i32 0, i32 4, i32 1, i32 5>
+  %shuffle1 = shufflevector <4 x float> %shuffle0, <4 x float> zeroinitializer, <4 x i32> <i32 0, i32 4, i32 poison, i32 poison>
+  %extract = extractelement <4 x float> %load, i64 1
+  ret void
+}

--- a/llvm/test/Transforms/VectorCombine/X86/load-extractelement-scalarization.ll
+++ b/llvm/test/Transforms/VectorCombine/X86/load-extractelement-scalarization.ll
@@ -26,8 +26,8 @@ define void @multiple_extract(ptr %p) {
 }
 
 ; infinite loop if we fold an extract that is waiting to be erased
-define void @unsued_extract(ptr %p) {
-; CHECK-LABEL: @unsued_extract(
+define void @unused_extract(ptr %p) {
+; CHECK-LABEL: @unused_extract(
 ; CHECK-NEXT:    ret void
 ;
   %load = load <4 x float>, ptr %p, align 8


### PR DESCRIPTION
If any extract is waiting to be erased, then bail out as this will distort the cost calculation and possibly lead to infinite loops.

Fixes #129373