### PR TITLE
[libc++][chrono][doc] Use stable names in synopsis.

### DIFF
--- a/libcxx/include/chrono
+++ b/libcxx/include/chrono
@@ -429,7 +429,7 @@ public:
 
 typedef steady_clock high_resolution_clock;
 
-// 25.7.8, local time           // C++20
+// [time.clock.local] local time           // C++20
 struct local_t {};
 template<class Duration>
   using local_time  = time_point<local_t, Duration>;
@@ -440,10 +440,10 @@ template<class charT, class traits, class Duration>     // C++20
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const local_time<Duration>& tp);
 
-// 25.8.2, class last_spec    // C++20
+// [time.cal.last] class last_spec    // C++20
 struct last_spec;
 
-// 25.8.3, class day          // C++20
+// [time.cal.day] class day          // C++20
 
 class day;
 constexpr bool operator==(const day& x, const day& y) noexcept;
@@ -456,7 +456,7 @@ template<class charT, class traits>
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const day& d);
 
-// 25.8.4, class month    // C++20
+// [time.cal.month] class month    // C++20
 class month;
 constexpr bool operator==(const month& x, const month& y) noexcept;
 constexpr strong_ordering operator<=>(const month& x, const month& y) noexcept;
@@ -469,7 +469,7 @@ template<class charT, class traits>
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const month& m);
 
-// 25.8.5, class year    // C++20
+// [time.cal.year] class year    // C++20
 class year;
 constexpr bool operator==(const year& x, const year& y) noexcept;
 constexpr strong_ordering operator<=>(const year& x, const year& y) noexcept;
@@ -482,7 +482,7 @@ template<class charT, class traits>
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const year& y);
 
-// 25.8.6, class weekday    // C++20
+// [time.cal.wd] class weekday    // C++20
 class weekday;
 
 constexpr bool operator==(const weekday& x, const weekday& y) noexcept;
@@ -494,7 +494,7 @@ template<class charT, class traits>
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const weekday& wd);
 
-// 25.8.7, class weekday_indexed    // C++20
+// [time.cal.wdidx] class weekday_indexed    // C++20
 
 class weekday_indexed;
 constexpr bool operator==(const weekday_indexed& x, const weekday_indexed& y) noexcept;
@@ -503,7 +503,7 @@ template<class charT, class traits>
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const weekday_indexed& wdi);
 
-// 25.8.8, class weekday_last    // C++20
+// [time.cal.wdlast] class weekday_last    // C++20
 class weekday_last;
 
 constexpr bool operator==(const weekday_last& x, const weekday_last& y) noexcept;
@@ -512,7 +512,7 @@ template<class charT, class traits>
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const weekday_last& wdl);
 
-// 25.8.9, class month_day    // C++20
+// [time.cal.md] class month_day    // C++20
 class month_day;
 
 constexpr bool operator==(const month_day& x, const month_day& y) noexcept;
@@ -522,7 +522,7 @@ template<class charT, class traits>
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const month_day& md);
 
-// 25.8.10, class month_day_last    // C++20
+// [time.cal.mdlast] class month_day_last    // C++20
 class month_day_last;
 
 constexpr bool operator==(const month_day_last& x, const month_day_last& y) noexcept;
@@ -532,7 +532,7 @@ template<class charT, class traits>
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const month_day_last& mdl);
 
-// 25.8.11, class month_weekday    // C++20
+// [time.cal.mwd] class month_weekday    // C++20
 class month_weekday;
 
 constexpr bool operator==(const month_weekday& x, const month_weekday& y) noexcept;
@@ -541,7 +541,7 @@ template<class charT, class traits>
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const month_weekday& mwd);
 
-// 25.8.12, class month_weekday_last    // C++20
+// [time.cal.mwdlast] class month_weekday_last    // C++20
 class month_weekday_last;
 
 constexpr bool operator==(const month_weekday_last& x, const month_weekday_last& y) noexcept;
@@ -551,7 +551,7 @@ template<class charT, class traits>
     operator<<(basic_ostream<charT, traits>& os, const month_weekday_last& mwdl);
 
 
-// 25.8.13, class year_month    // C++20
+// [time.cal.ym] class year_month    // C++20
 class year_month;
 
 constexpr bool operator==(const year_month& x, const year_month& y) noexcept;
@@ -569,7 +569,7 @@ template<class charT, class traits>
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const year_month& ym);
 
-// 25.8.14, class year_month_day class    // C++20
+// [time.cal.ymd] class year_month_day class    // C++20
 year_month_day;
 
 constexpr bool operator==(const year_month_day& x, const year_month_day& y) noexcept;
@@ -586,7 +586,7 @@ template<class charT, class traits>
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const year_month_day& ymd);
 
-// 25.8.15, class year_month_day_last    // C++20
+// [time.cal.ymdlast] class year_month_day_last    // C++20
 class year_month_day_last;
 
 constexpr bool operator==(const year_month_day_last& x, const year_month_day_last& y) noexcept;
@@ -609,7 +609,7 @@ template<class charT, class traits>
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const year_month_day_last& ymdl);
 
-// 25.8.16, class year_month_weekday    // C++20
+// [time.cal.ymwd] class year_month_weekday    // C++20
 class year_month_weekday;
 
 constexpr bool operator==(const year_month_weekday& x,
@@ -632,7 +632,7 @@ template<class charT, class traits>
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const year_month_weekday& ymwd);
 
-// 25.8.17, class year_month_weekday_last    // C++20
+// [time.cal.ymwdlast] class year_month_weekday_last    // C++20
 class year_month_weekday_last;
 
 constexpr bool operator==(const year_month_weekday_last& x,
@@ -654,7 +654,7 @@ template<class charT, class traits>
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const year_month_weekday_last& ymwdl);
 
-// 25.8.18, civil calendar conventional syntax operators    // C++20
+// [time.cal.operators] civil calendar conventional syntax operators    // C++20
 constexpr year_month
   operator/(const year& y, const month& m) noexcept;
 constexpr year_month
@@ -845,7 +845,7 @@ template<class charT, class traits>                                             
   basic_ostream<charT, traits>&
     operator<<(basic_ostream<charT, traits>& os, const local_info& li);
 
-// 25.10.5, class time_zone                                                      // C++20
+// [time.zone.timezone] class time_zone                                                      // C++20
 enum class choose {earliest, latest};
 class time_zone {
   time_zone(time_zone&&) = default;


### PR DESCRIPTION
Fixes: #80895