### PR TITLE
[clang-tidy] `misc-unused-using-decls`: add correct handling of `operator""` with template parametes

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/UnusedUsingDeclsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UnusedUsingDeclsCheck.cpp
@@ -184,8 +184,16 @@ void UnusedUsingDeclsCheck::check(const MatchFinder::MatchResult &Result) {
     return;
   }
   // Check user-defined literals
-  if (const auto *UDL = Result.Nodes.getNodeAs<UserDefinedLiteral>("used"))
-    removeFromFoundDecls(UDL->getCalleeDecl());
+  if (const auto *UDL = Result.Nodes.getNodeAs<UserDefinedLiteral>("used")) {
+    const Decl *CalleeDecl = UDL->getCalleeDecl();
+    if (const auto *FD = dyn_cast<FunctionDecl>(UDL->getCalleeDecl())) {
+      if (const FunctionTemplateDecl *FPT = FD->getPrimaryTemplate()) {
+        removeFromFoundDecls(FPT);
+        return;
+      }
+    }
+    removeFromFoundDecls(CalleeDecl);
+  }
 }
 
 void UnusedUsingDeclsCheck::removeFromFoundDecls(const Decl *D) {

--- a/clang-tools-extra/clang-tidy/misc/UnusedUsingDeclsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UnusedUsingDeclsCheck.cpp
@@ -186,7 +186,7 @@ void UnusedUsingDeclsCheck::check(const MatchFinder::MatchResult &Result) {
   // Check user-defined literals
   if (const auto *UDL = Result.Nodes.getNodeAs<UserDefinedLiteral>("used")) {
     const Decl *CalleeDecl = UDL->getCalleeDecl();
-    if (const auto *FD = dyn_cast<FunctionDecl>(UDL->getCalleeDecl())) {
+    if (const auto *FD = dyn_cast<FunctionDecl>(CalleeDecl)) {
       if (const FunctionTemplateDecl *FPT = FD->getPrimaryTemplate()) {
         removeFromFoundDecls(FPT);
         return;

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -137,6 +137,10 @@ Changes in existing checks
   <clang-tidy/checks/performance/move-const-arg>` check by fixing false negatives
   on ternary operators calling ``std::move``.
 
+- Improved :doc:`misc-unused-using-decls
+  <clang-tidy/checks/misc/unused-using-decls>` check by fixing false positives
+  on ``operator""`` with template parameters.
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-using-decls.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-using-decls.cpp
@@ -222,3 +222,19 @@ using gh69714::StructGH69714_1;
 using gh69714::StructGH69714_2;
 struct StructGH69714_1 a;
 struct StructGH69714_2 *b;
+
+namespace gh53444 {
+namespace my_literals {
+  template <char... Ts>
+  int operator""_r() {
+    return {};
+  }
+}
+
+using my_literals::operator"" _r;
+
+int foo() {
+  auto x2 = 123_r;
+}
+
+}


### PR DESCRIPTION
Fixes false-positives when operator"" has template paremetes, e.g.
```cpp
template <char... Ts>
int operator""_r() {
    return {};
}
```
Closes https://github.com/llvm/llvm-project/issues/53444.

