### PR TITLE
[libc++] Add tests for gcd that result in something other than zero or one

### DIFF
--- a/libcxx/test/std/numerics/numeric.ops/numeric.ops.gcd/gcd.pass.cpp
+++ b/libcxx/test/std/numerics/numeric.ops/numeric.ops.gcd/gcd.pass.cpp
@@ -27,7 +27,19 @@ constexpr struct {
   int x;
   int y;
   int expect;
-} Cases[] = {{0, 0, 0}, {1, 0, 1}, {0, 1, 1}, {1, 1, 1}, {2, 3, 1}, {2, 4, 2}, {11, 9, 1}, {36, 17, 1}, {36, 18, 18}};
+} Cases[] = {
+    {0, 0, 0},
+    {1, 0, 1},
+    {0, 1, 1},
+    {1, 1, 1},
+    {2, 3, 1},
+    {2, 4, 2},
+    {11, 9, 1},
+    {36, 17, 1},
+    {36, 18, 18},
+    {25, 30, 5},
+    {24, 16, 8},
+    {128, 100, 4}};
 
 template <typename Input1, typename Input2, typename Output>
 constexpr bool test0(int in1, int in2, int out)


### PR DESCRIPTION
@colincross identified gcd does not have a single case whose answer is not 0, 1, or the smaller of the two inputs.