### PR TITLE
[clang-tidy] detect explicit casting within modernize-use-default-member-init

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -156,7 +156,8 @@ Changes in existing checks
 
 - Improved :doc:`modernize-use-default-member-init
   <clang-tidy/checks/modernize/use-default-member-init>` check by matching
-  ``constexpr`` and ``static`` values on member initialization.
+  ``constexpr`` and ``static``` values on member initialization and by detecting
+  explicit casting of built-in types within member list initialization.
 
 - Improved :doc:`performance/unnecessary-value-param
   <clang-tidy/checks/performance/unnecessary-value-param>` check performance by

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-default-member-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-default-member-init.cpp
@@ -536,4 +536,40 @@ namespace PR122480 {
     // CHECK-FIXES: int b{STATIC_VAL};
   };
 
+class CStyleCastInit {
+  CStyleCastInit() : a{(int)1.23}, b{(float)42}, c{(double)'C'} {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:50: warning: member initializer for 'c' is redundant [modernize-use-default-member-init]
+  // CHECK-FIXES: CStyleCastInit()  {}
+
+  int a;
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use default member initializer for 'a' [modernize-use-default-member-init]
+  // CHECK-FIXES: int a{(int)1.23};
+  float b;
+  // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: use default member initializer for 'b' [modernize-use-default-member-init]
+  // CHECK-FIXES: float b{(float)42};
+  double c{(double)'C'};
+};
+
+class StaticCastInit {
+  StaticCastInit() : m(static_cast<int>(9.99)), n(static_cast<char>(65)) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:49: warning: member initializer for 'n' is redundant [modernize-use-default-member-init]
+  // CHECK-FIXES: StaticCastInit()  {}
+  int m;
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use default member initializer for 'm' [modernize-use-default-member-init]
+  // CHECK-FIXES: int m{static_cast<int>(9.99)};
+  char n{static_cast<char>(65)};
+};
+
+class FunctionalCastInit {
+  FunctionalCastInit() : a(int(5.67)), b(float(2)), c(double('C')) {}
+  // CHECK-MESSAGES: :[[@LINE-1]]:40: warning: member initializer for 'b' is redundant [modernize-use-default-member-init]
+  int a;
+  // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use default member initializer for 'a' [modernize-use-default-member-init]
+  // CHECK-FIXES: int a{int(5.67)};
+  float b{float(2)};
+  double c;
+  // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: use default member initializer for 'c' [modernize-use-default-member-init]
+  // CHECK-FIXES: double c{double('C')};
+};
+
 } //namespace PR122480


### PR DESCRIPTION
This aims to fix a portion of #122480. Added some matchers to detect explicit casting which utilize builtin types as its source expression. these are the various forms of casting supported I thought would useful for this check:

- C Style explicit casting
- Static explicit casting
- Functional explicit casting