### PR TITLE
[lldb-dap] Test: disable children return test for all arm architectures

### DIFF
--- a/lldb/test/API/tools/lldb-dap/variables/children/TestDAP_variables_children.py
+++ b/lldb/test/API/tools/lldb-dap/variables/children/TestDAP_variables_children.py
@@ -41,7 +41,7 @@ class TestDAP_variables_children(lldbdap_testcase.DAPTestCaseBase):
             )["body"]["result"],
         )
 
-    @skipIf(archs=["arm64"])
+    @skipIf(archs=["arm", "arm64", "aarch64"])
     def test_return_variable_with_children(self):
         """
         Test the stepping out of a function with return value show the children correctly


### PR DESCRIPTION
amd64 and aarch64 are treated differently

Follows up #106907