### PR TITLE
[clang-tidy] Add check on constexpr & static values in modernize-use-default-member-init

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseDefaultMemberInitCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseDefaultMemberInitCheck.cpp
@@ -194,6 +194,8 @@ void UseDefaultMemberInitCheck::storeOptions(
 }
 
 void UseDefaultMemberInitCheck::registerMatchers(MatchFinder *Finder) {
+  auto ConstExpRef = varDecl(anyOf(isConstexpr(), isStaticStorageClass()));
+
   auto InitBase =
       anyOf(stringLiteral(), characterLiteral(), integerLiteral(),
             unaryOperator(hasAnyOperatorName("+", "-"),
@@ -202,7 +204,7 @@ void UseDefaultMemberInitCheck::registerMatchers(MatchFinder *Finder) {
             unaryOperator(hasAnyOperatorName("+", "-"),
                           hasUnaryOperand(floatLiteral())),
             cxxBoolLiteral(), cxxNullPtrLiteralExpr(), implicitValueInitExpr(),
-            declRefExpr(to(enumConstantDecl())));
+            declRefExpr(to(anyOf(enumConstantDecl(), ConstExpRef))));
 
   auto Init =
       anyOf(initListExpr(anyOf(allOf(initCountIs(1), hasInit(0, InitBase)),

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -136,6 +136,10 @@ Changes in existing checks
   <clang-tidy/checks/misc/use-internal-linkage>` check by fix false positives
   for function or variable in header file which contains macro expansion.
 
+- Improved :doc:`modernize-use-default-member-init
+  <clang-tidy/checks/modernize/use-default-member-init>` check by matching
+  ``constexpr`` and ``static`` values on member initialization.
+
 - Improved :doc:`performance/unnecessary-value-param
   <clang-tidy/checks/performance/unnecessary-value-param>` check performance by
   tolerating fix-it breaking compilation when functions is used as pointers

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-default-member-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-default-member-init.cpp
@@ -518,3 +518,22 @@ class ArrayBraceInitMultipleValues {
 };
 
 } // namespace PR63285
+
+namespace PR122480 {
+
+  static int STATIC_VAL = 23;
+  constexpr const char* CONSTEXPR_REF = "Const";
+
+  class StaticConstExprInit {
+
+    StaticConstExprInit() : a{CONSTEXPR_REF}, b{STATIC_VAL}{}
+    // CHECK-FIXES: StaticConstExprInit()  {}
+    const char* a;
+    // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: use default member initializer for 'a' [modernize-use-default-member-init]
+    // CHECK-FIXES: const char* a{CONSTEXPR_REF};
+    int b;
+    // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: use default member initializer for 'b' [modernize-use-default-member-init]
+    // CHECK-FIXES: int b{STATIC_VAL};
+  };
+
+} //namespace PR122480


### PR DESCRIPTION
This aims to fix a portion of #122480. Simply added a check to look for either compile time initialized variables or static stored variables.
