### PR TITLE
[lit] Add aarch64 to JIT darwin assertion

### DIFF
--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -588,6 +588,7 @@ def host_unwind_supports_jit():
 
         assert (
             "arm64" in config.host_triple
+            or "aarch64" in config.host_triple
             or "x86_64" in config.host_triple
         )
 


### PR DESCRIPTION
Fix building on aarch64-apple-darwin.

I build LLVM with nix and nixpkgs. See error log here: https://hydra.nixos.org/build/291216049/nixlog/1