### PR TITLE
[MLIR] Fix IntegerPolyhedron ctors to avoid copy

### DIFF
--- a/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
+++ b/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
@@ -917,7 +917,7 @@ public:
   /// Constructs a relation with the specified number of dimensions and symbols
   /// and adds the given inequalities.
   explicit IntegerPolyhedron(const PresburgerSpace &space,
-                             IntMatrix inequalities)
+                             const IntMatrix &inequalities)
       : IntegerPolyhedron(space) {
     for (unsigned i = 0, e = inequalities.getNumRows(); i < e; i++)
       addInequality(inequalities.getRow(i));
@@ -927,7 +927,7 @@ public:
   /// and adds the given inequalities, after normalizing row-wise to integer
   /// values.
   explicit IntegerPolyhedron(const PresburgerSpace &space,
-                             FracMatrix inequalities)
+                             const FracMatrix &inequalities)
       : IntegerPolyhedron(space) {
     IntMatrix ineqsNormalized = inequalities.normalizeRows();
     for (unsigned i = 0, e = inequalities.getNumRows(); i < e; i++)


### PR DESCRIPTION
Use const ref. NFC otherwise.
