### PR TITLE
[Metadata] Replace `undef` VAMs with `poison` VAMs

### DIFF
--- a/llvm/lib/IR/Metadata.cpp
+++ b/llvm/lib/IR/Metadata.cpp
@@ -339,7 +339,8 @@ void ReplaceableMetadataImpl::SalvageDebugInfo(const Constant &C) {
   ValueAsMetadata *MD = I->second;
   using UseTy =
       std::pair<void *, std::pair<MetadataTracking::OwnerTy, uint64_t>>;
-  // Copy out uses and update value of Constant used by debug info metadata with undef below
+  // Copy out uses and update value of Constant used by debug info metadata with
+  // poison below
   SmallVector<UseTy, 8> Uses(MD->UseMap.begin(), MD->UseMap.end());
 
   for (const auto &Pair : Uses) {
@@ -349,7 +350,7 @@ void ReplaceableMetadataImpl::SalvageDebugInfo(const Constant &C) {
     // Check for MetadataAsValue.
     if (isa<MetadataAsValue *>(Owner)) {
       cast<MetadataAsValue *>(Owner)->handleChangedMetadata(
-          ValueAsMetadata::get(UndefValue::get(C.getType())));
+          ValueAsMetadata::get(PoisonValue::get(C.getType())));
       continue;
     }
     if (!isa<Metadata *>(Owner))
@@ -359,7 +360,7 @@ void ReplaceableMetadataImpl::SalvageDebugInfo(const Constant &C) {
       continue;
     if (isa<DINode>(OwnerMD)) {
       OwnerMD->handleChangedOperand(
-          Pair.first, ValueAsMetadata::get(UndefValue::get(C.getType())));
+          Pair.first, ValueAsMetadata::get(PoisonValue::get(C.getType())));
     }
   }
 }

--- a/llvm/test/DebugInfo/X86/undef-dbg-val.ll
+++ b/llvm/test/DebugInfo/X86/undef-dbg-val.ll
@@ -1,5 +1,5 @@
 ; RUN:  opt -S -passes=globalopt --experimental-debuginfo-iterators=false <%s | FileCheck %s
-; CHECK: #dbg_value(ptr undef, 
+; CHECK: #dbg_value(ptr poison,
 ; CHECK-SAME:    [[VAR:![0-9]+]],
 ; CHECK-SAME:    !DIExpression()
 ; CHECK: [[VAR]] = !DILocalVariable(name: "_format"


### PR DESCRIPTION
`undef` debug info can be replaced with `poison` debug info.