### PR TITLE
[clangd] give project config higher precedence than user config

### DIFF
--- a/clang-tools-extra/clangd/test/config-order.test
+++ b/clang-tools-extra/clangd/test/config-order.test
@@ -1,0 +1,56 @@
+# We specify a custom path in XDG_CONFIG_HOME, which only works on some systems.
+# UNSUPPORTED: system-windows
+# UNSUPPORTED: system-darwin
+
+# RUN: rm -rf %t.config.d %t.project.d
+# RUN: mkdir -p %t.config.d/clangd %t.project.d
+
+# Create a config file that injects a flag we can observe, and has an error.
+# RUN: echo 'CompileFlags: {Remove: -DCONFIG=LOCAL, Add: -DCONFIG=USER}' > %t.config.d/clangd/config.yaml
+# RUN: echo 'CompileFlags: {Remove: -DCONFIG=USER, Add: -DCONFIG=LOCAL}' > %t.project.d/.clangd
+
+# RUN: sed '/^#/!s|PROJECT_DIR|%t.project.d|g' %s | env XDG_CONFIG_HOME=%t.config.d clangd -lit-test -enable-config | FileCheck -strict-whitespace %s
+
+{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":123,"rootPath":"clangd","capabilities":{},"trace":"off"}}
+---
+{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file://PROJECT_DIR/foo.c","languageId":"c","text":"int FOO = CONFIG;"}}}
+# No errors in the config file.
+#      CHECK:  "method": "textDocument/publishDiagnostics",
+# CHECK-NEXT:  "params": {
+# CHECK-NEXT:    "diagnostics": [],
+# CHECK-NEXT:    "uri": "file://{{.*}}/config.yaml"
+# CHECK-NEXT:  }
+# No errors in the config file.
+#      CHECK:  "method": "textDocument/publishDiagnostics",
+# CHECK-NEXT:  "params": {
+# CHECK-NEXT:    "diagnostics": [],
+# CHECK-NEXT:    "uri": "file://{{.*}}/.clangd"
+# CHECK-NEXT:  }
+# LOCAL rather than USER means the local .clangd applied later and overrode the user config.
+#      CHECK:  "method": "textDocument/publishDiagnostics",
+# CHECK-NEXT:  "params": {
+# CHECK-NEXT:    "diagnostics": [
+# CHECK-NEXT:      {
+# CHECK-NEXT:        "code": "undeclared_var_use",
+# CHECK-NEXT:        "message": "Use of undeclared identifier 'LOCAL'",
+# CHECK-NEXT:        "range": {
+# CHECK-NEXT:          "end": {
+# CHECK-NEXT:            "character": 16,
+# CHECK-NEXT:            "line": 0
+# CHECK-NEXT:          },
+# CHECK-NEXT:          "start": {
+# CHECK-NEXT:            "character": 10,
+# CHECK-NEXT:            "line": 0
+# CHECK-NEXT:          }
+# CHECK-NEXT:        },
+# CHECK-NEXT:        "severity": 1,
+# CHECK-NEXT:        "source": "clang"
+# CHECK-NEXT:      }
+# CHECK-NEXT:    ],
+# CHECK-NEXT:    "uri": "file://{{.*}}/foo.c",
+# CHECK-NEXT:    "version": 0
+# CHECK-NEXT:  }
+---
+{"jsonrpc":"2.0","id":4,"method":"shutdown"}
+---
+{"jsonrpc":"2.0","method":"exit"}

--- a/clang-tools-extra/clangd/test/config-order.test
+++ b/clang-tools-extra/clangd/test/config-order.test
@@ -18,7 +18,7 @@
 #      CHECK:  "method": "textDocument/publishDiagnostics",
 # CHECK-NEXT:  "params": {
 # CHECK-NEXT:    "diagnostics": [],
-# CHECK-NEXT:    "uri": [[URI:"file://.*/config\.yaml|\.clangd"]]
+# CHECK-NEXT:    "uri": [[URI:"file://.*/(config\.yaml|\.clangd)"]]
 # CHECK-NEXT:  }
 #      CHECK:  "method": "textDocument/publishDiagnostics",
 # CHECK-NEXT:  "params": {

--- a/clang-tools-extra/clangd/test/config-order.test
+++ b/clang-tools-extra/clangd/test/config-order.test
@@ -14,17 +14,17 @@
 {"jsonrpc":"2.0","id":0,"method":"initialize","params":{"processId":123,"rootPath":"clangd","capabilities":{},"trace":"off"}}
 ---
 {"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file://PROJECT_DIR/foo.c","languageId":"c","text":"int FOO = CONFIG;"}}}
-# No errors in the config file.
+# No errors in either config.
 #      CHECK:  "method": "textDocument/publishDiagnostics",
 # CHECK-NEXT:  "params": {
 # CHECK-NEXT:    "diagnostics": [],
-# CHECK-NEXT:    "uri": "file://{{.*}}/config.yaml"
+# CHECK-NEXT:    "uri": [[URI:"file://.*/config\.yaml|\.clangd"]]
 # CHECK-NEXT:  }
-# No errors in the config file.
 #      CHECK:  "method": "textDocument/publishDiagnostics",
 # CHECK-NEXT:  "params": {
 # CHECK-NEXT:    "diagnostics": [],
-# CHECK-NEXT:    "uri": "file://{{.*}}/.clangd"
+#  CHECK-NOT:    "uri": [[URI]]
+# CHECK-NEXT:    "uri": "file://{{.*}}/{{config\.yaml|\.clangd}}"
 # CHECK-NEXT:  }
 # LOCAL rather than USER means the local .clangd applied later and overrode the user config.
 #      CHECK:  "method": "textDocument/publishDiagnostics",

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -956,14 +956,14 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
   std::vector<std::unique_ptr<config::Provider>> ProviderStack;
   std::unique_ptr<config::Provider> Config;
   if (EnableConfig) {
-    ProviderStack.push_back(
-        config::Provider::fromAncestorRelativeYAMLFiles(".clangd", TFS));
     llvm::SmallString<256> UserConfig;
     if (llvm::sys::path::user_config_directory(UserConfig)) {
       llvm::sys::path::append(UserConfig, "clangd", "config.yaml");
       vlog("User config file is {0}", UserConfig);
       ProviderStack.push_back(config::Provider::fromYAMLFile(
           UserConfig, /*Directory=*/"", TFS, /*Trusted=*/true));
+      ProviderStack.push_back(
+          config::Provider::fromAncestorRelativeYAMLFiles(".clangd", TFS));
     } else {
       elog("Couldn't determine user config file, not loading");
     }

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -962,11 +962,11 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
       vlog("User config file is {0}", UserConfig);
       ProviderStack.push_back(config::Provider::fromYAMLFile(
           UserConfig, /*Directory=*/"", TFS, /*Trusted=*/true));
-      ProviderStack.push_back(
-          config::Provider::fromAncestorRelativeYAMLFiles(".clangd", TFS));
     } else {
       elog("Couldn't determine user config file, not loading");
     }
+    ProviderStack.push_back(
+        config::Provider::fromAncestorRelativeYAMLFiles(".clangd", TFS));
   }
   ProviderStack.push_back(std::make_unique<FlagsConfigProvider>());
   std::vector<const config::Provider *> ProviderPointers;


### PR DESCRIPTION
Changing the order of the provider stack to place project config higher lets a project config override elements of the user config rather than the other way around.

Discussed in https://github.com/clangd/clangd/discussions/1193. I've been using a build with this change off and on since asking about it there and haven't had any trouble from it. Any reason to resist this change - some rationale behind the current behavior that I've overlooked, or something that won't work right with just this +2/-2 diff?

created this PR as a draft, going to leave it that way until I have a PR open in [llvm/clangd-www](https://github.com/llvm/clangd-www/) to update the docs accordingly.