### PR TITLE
[clangd] Disable cppcoreguidelines-macro-to-enum clang-tidy checker

### DIFF
--- a/clang-tools-extra/clangd/TidyProvider.cpp
+++ b/clang-tools-extra/clangd/TidyProvider.cpp
@@ -210,6 +210,7 @@ TidyProvider disableUnusableChecks(llvm::ArrayRef<std::string> ExtraBadChecks) {
       // Check relies on seeing ifndef/define/endif directives,
       // clangd doesn't replay those when using a preamble.
       "-llvm-header-guard", "-modernize-macro-to-enum",
+      "-cppcoreguidelines-macro-to-enum",
 
       // ----- Crashing Checks -----
 

--- a/clang-tools-extra/clangd/unittests/DiagnosticsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/DiagnosticsTests.cpp
@@ -823,6 +823,21 @@ TEST(DiagnosticTest, ClangTidyNoLiteralDataInMacroToken) {
   EXPECT_THAT(TU.build().getDiagnostics(), UnorderedElementsAre()); // no-crash
 }
 
+TEST(DiagnosticTest, ClangTidyMacroToEnumCheck) {
+  Annotations Main(R"cpp(
+    #if 1
+    auto foo();
+    #endif
+  )cpp");
+  TestTU TU = TestTU::withCode(Main.code());
+  std::vector<TidyProvider> Providers;
+  Providers.push_back(
+      addTidyChecks("cppcoreguidelines-macro-to-enum,modernize-macro-to-enum"));
+  Providers.push_back(disableUnusableChecks());
+  TU.ClangTidyProvider = combine(std::move(Providers));
+  EXPECT_THAT(TU.build().getDiagnostics(), UnorderedElementsAre()); // no-crash
+}
+
 TEST(DiagnosticTest, ElseAfterReturnRange) {
   Annotations Main(R"cpp(
     int foo(int cond) {


### PR DESCRIPTION
Clangd does not support its checker because the checker relies on having seen preprocessor conditionals that occur in the preamble, and clangd does not currently replay those.

This checker was already disabled under its main name, modernize-macro-to-enum (https://github.com/clangd/clangd/issues/1464). This commit disables it under the alternative name cppcoreguidelines-macro-to-enum as well.

Fixes https://github.com/llvm/llvm-project/issues/127965