### PR TITLE
use if with braces to silence Wdanlging-else warning

### DIFF
--- a/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
+++ b/clang-tools-extra/clangd/unittests/SymbolCollectorTests.cpp
@@ -1145,12 +1145,14 @@ o]] f{};
                ImplicitRefs = std::move(ImplicitSlabBuilder).build();
     EXPECT_EQ(SpelledRanges.empty(), SpelledRefs.empty());
     EXPECT_EQ(ImplicitRanges.empty(), ImplicitRefs.empty());
-    if (!SpelledRanges.empty())
+    if (!SpelledRanges.empty()) {
       EXPECT_THAT(SpelledRefs,
                   Contains(Pair(TargetID, haveRanges(SpelledRanges))));
-    if (!ImplicitRanges.empty())
+    }
+    if (!ImplicitRanges.empty()) {
       EXPECT_THAT(ImplicitRefs,
                   Contains(Pair(TargetID, haveRanges(ImplicitRanges))));
+    }
   }
 }
 

--- a/clang-tools-extra/clangd/unittests/TUSchedulerTests.cpp
+++ b/clang-tools-extra/clangd/unittests/TUSchedulerTests.cpp
@@ -1216,9 +1216,10 @@ TEST_F(TUSchedulerTests, PublishWithStalePreamble) {
     void onPreambleAST(
         PathRef Path, llvm::StringRef Version, CapturedASTCtx,
         std::shared_ptr<const include_cleaner::PragmaIncludes>) override {
-      if (BuildBefore)
+      if (BuildBefore) {
         ASSERT_TRUE(UnblockPreamble.wait(timeoutSeconds(60)))
             << "Expected notification";
+      }
       BuildBefore = true;
     }
 


### PR DESCRIPTION
the pull request aims to silence the dangling else warning when compiling the unit tests