### PR TITLE
[AArch64] Don't try to custom lower fp16 selects with nofp

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -505,8 +505,10 @@ AArch64TargetLowering::AArch64TargetLowering(const TargetMachine &TM,
   setOperationAction(ISD::BR_CC, MVT::f64, Custom);
   setOperationAction(ISD::SELECT, MVT::i32, Custom);
   setOperationAction(ISD::SELECT, MVT::i64, Custom);
-  setOperationAction(ISD::SELECT, MVT::f16, Custom);
-  setOperationAction(ISD::SELECT, MVT::bf16, Custom);
+  if (Subtarget->hasFPARMv8()) {
+    setOperationAction(ISD::SELECT, MVT::f16, Custom);
+    setOperationAction(ISD::SELECT, MVT::bf16, Custom);
+  }
   setOperationAction(ISD::SELECT, MVT::f32, Custom);
   setOperationAction(ISD::SELECT, MVT::f64, Custom);
   setOperationAction(ISD::SELECT_CC, MVT::i32, Custom);

--- a/llvm/test/CodeGen/AArch64/16bit-float-promotion-with-nofp.ll
+++ b/llvm/test/CodeGen/AArch64/16bit-float-promotion-with-nofp.ll
@@ -29,3 +29,94 @@ entry:
   ret bfloat %0
 }
 
+define double @select_f64(double %a, double %b, i1 %c) {
+; CHECK-LABEL: select_f64:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    tst w2, #0x1
+; CHECK-NEXT:    csel x0, x0, x1, ne
+; CHECK-NEXT:    ret
+entry:
+  %0 = select i1 %c, double %a, double %b
+  ret double %0
+}
+
+define float @select_f32(float %a, float %b, i1 %c) {
+; CHECK-LABEL: select_f32:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    tst w2, #0x1
+; CHECK-NEXT:    csel w0, w0, w1, ne
+; CHECK-NEXT:    ret
+entry:
+  %0 = select i1 %c, float %a, float %b
+  ret float %0
+}
+
+define half @select_f16(half %a, half %b, i1 %c) {
+; CHECK-LABEL: select_f16:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    tst w2, #0x1
+; CHECK-NEXT:    csel w0, w0, w1, ne
+; CHECK-NEXT:    ret
+entry:
+  %0 = select i1 %c, half %a, half %b
+  ret half %0
+}
+
+define bfloat @select_bf16(bfloat %a, bfloat %b, i1 %c) {
+; CHECK-LABEL: select_bf16:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    tst w2, #0x1
+; CHECK-NEXT:    csel w0, w0, w1, ne
+; CHECK-NEXT:    ret
+entry:
+  %0 = select i1 %c, bfloat %a, bfloat %b
+  ret bfloat %0
+}
+
+define double @selectcc_f64(double %a, double %b, i32 %d) {
+; CHECK-LABEL: selectcc_f64:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    cmp w2, #0
+; CHECK-NEXT:    csel x0, x0, x1, lt
+; CHECK-NEXT:    ret
+entry:
+  %c = icmp slt i32 %d, 0
+  %0 = select i1 %c, double %a, double %b
+  ret double %0
+}
+
+define float @selectcc_f32(float %a, float %b, i32 %d) {
+; CHECK-LABEL: selectcc_f32:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    cmp w2, #0
+; CHECK-NEXT:    csel w0, w0, w1, lt
+; CHECK-NEXT:    ret
+entry:
+  %c = icmp slt i32 %d, 0
+  %0 = select i1 %c, float %a, float %b
+  ret float %0
+}
+
+define half @selectcc_f16(half %a, half %b, i32 %d) {
+; CHECK-LABEL: selectcc_f16:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    cmp w2, #0
+; CHECK-NEXT:    csel w0, w0, w1, lt
+; CHECK-NEXT:    ret
+entry:
+  %c = icmp slt i32 %d, 0
+  %0 = select i1 %c, half %a, half %b
+  ret half %0
+}
+
+define bfloat @selectcc_bf16(bfloat %a, bfloat %b, i32 %d) {
+; CHECK-LABEL: selectcc_bf16:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    cmp w2, #0
+; CHECK-NEXT:    csel w0, w0, w1, lt
+; CHECK-NEXT:    ret
+entry:
+  %c = icmp slt i32 %d, 0
+  %0 = select i1 %c, bfloat %a, bfloat %b
+  ret bfloat %0
+}


### PR DESCRIPTION
If we do not have fp then we do not need to try and custom lower fp16 selects.

Fixes #129394.