### PR TITLE
[RISCV][clang] Add address space argument to getNaturalAlignIndirect

### DIFF
--- a/clang/lib/CodeGen/Targets/RISCV.cpp
+++ b/clang/lib/CodeGen/Targets/RISCV.cpp
@@ -578,7 +578,9 @@ ABIArgInfo RISCVABIInfo::coerceVLSVector(QualType Ty, unsigned ABIVLen) const {
   } else {
     // Check registers needed <= 8.
     if ((EltType->getScalarSizeInBits() * NumElts / ABIVLen) > 8)
-      return getNaturalAlignIndirect(Ty, /*ByVal=*/false);
+      return getNaturalAlignIndirect(
+          Ty, /*AddrSpace=*/getDataLayout().getAllocaAddrSpace(),
+          /*ByVal=*/false);
 
     // Generic vector
     // The number of elements needs to be at least 1.


### PR DESCRIPTION
This is introduced in 39ec9de7c23063b87f5c56f4e80c8d0f8b511a4b
