### PR TITLE
[clang][dataflow] Fix unsupported types always being equal

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -60,7 +60,9 @@ static BoolValue &evaluateBooleanEquality(const Expr &LHS, const Expr &RHS,
   Value *LHSValue = Env.getValue(LHS);
   Value *RHSValue = Env.getValue(RHS);
 
-  if (LHSValue == RHSValue)
+  // When two unsupported values are compared, both are nullptr. Only supported
+  // values should evaluate to equal.
+  if (LHSValue == RHSValue && LHSValue)
     return Env.getBoolLiteralValue(true);
 
   if (auto *LHSBool = dyn_cast_or_null<BoolValue>(LHSValue))
@@ -796,6 +798,14 @@ public:
 
   void VisitIntegerLiteral(const IntegerLiteral *S) {
     Env.setValue(*S, Env.getIntLiteralValue(S->getValue()));
+  }
+
+  // Untyped nullptr's aren't handled by NullToPointer casts, so they need to be
+  // handled separately.
+  void VisitCXXNullPtrLiteralExpr(const CXXNullPtrLiteralExpr *S) {
+    auto &NullPointerVal =
+        Env.getOrCreateNullPointerValue(S->getType()->getPointeeType());
+    Env.setValue(*S, NullPointerVal);
   }
 
   void VisitParenExpr(const ParenExpr *S) {


### PR DESCRIPTION
Previously when the framework encountered unsupported values (such as enum classes), they were always treated as equal when comparing with `==`, regardless of their actual values being different.
Now the two sides are only equal if there's a Value assigned to them.

Added a Value assignment for `nullptr`, to handle the special case of `nullptr == nullptr`.