### PR TITLE
[lldb][test] XcodeSDKModuleTests: remove non-deterministic source mapping checks

### DIFF
--- a/lldb/unittests/SymbolFile/DWARF/XcodeSDKModuleTests.cpp
+++ b/lldb/unittests/SymbolFile/DWARF/XcodeSDKModuleTests.cpp
@@ -116,11 +116,8 @@ DWARF:
   SymbolFileDWARF &sym_file = dwarf_cu->GetSymbolFileDWARF();
   CompUnitSP comp_unit = sym_file.GetCompileUnitAtIndex(0);
   ASSERT_TRUE(static_cast<bool>(comp_unit.get()));
-  ModuleSP module = t.GetModule();
-  ASSERT_EQ(module->GetSourceMappingList().GetSize(), 0u);
   XcodeSDK sdk = sym_file.ParseXcodeSDK(*comp_unit);
   ASSERT_EQ(sdk.GetType(), XcodeSDK::Type::MacOSX);
-  ASSERT_EQ(module->GetSourceMappingList().GetSize(), 1u);
 }
 
 TEST_F(XcodeSDKModuleTests, TestSDKPathFromDebugInfo_InvalidSDKPath) {


### PR DESCRIPTION
This assertion was added to check that `RegisterXcodeSDK` will correctly update the source mappings of the module. However, the source mapping will only get updated if the `Host::RunShellCommand` call to `xcrun` succeeded. Even if `xcrun` failed to find an SDK, the source mappings would get an entry. But if the shell invocation itself failed, then the mappings are not updated (see https://github.com/llvm/llvm-project/blob/f6212c1cd3d8b827c7d7e2f6cf54b135c27eacc6/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm#L424-L444). This means depending on how slow `xcrun` is on a given host, this test may fail. On my machine this happens consistently in debug and release builds.

This patch removes this flakey assertion. We unfortunately lost some test coverage here but I'm not sure there's great alternatives unless we either:
1. Mock the `xcrun` call somehow (we could maybe pass a callable around which defaults to `xcrun` in non-test code?)
2. Make a `xcrun` time-out not an error either?