### PR TITLE
[llvm-strip] Let llvm-strip continue on encountering an error

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -152,6 +152,7 @@ Changes to the LLVM tools
 ---------------------------------
 
 * llvm-objcopy now supports the `--update-section` flag for intermediate Mach-O object files.
+* llvm-strip now supports continuing to process files on encountering an error.
 
 Changes to LLDB
 ---------------------------------

--- a/llvm/test/tools/llvm-objcopy/strip-error-handling.test
+++ b/llvm/test/tools/llvm-objcopy/strip-error-handling.test
@@ -1,0 +1,25 @@
+## Checks that llvm-strip continues to strip objects after encountering a bad
+## one while emitting an error for each bad one.
+
+# RUN: echo "bad" > %t1
+# RUN: yaml2obj %s -o %t2
+# RUN: cp %t1 %t3
+# RUN: not llvm-strip --strip-sections %t1 %t2 %t3 2>&1 | FileCheck %s --check-prefix=ERROR -DFILE1=%t1 -DFILE3=%t3 --implicit-check-not=error:
+
+# ERROR: error: '[[FILE1]]': The file was not recognized as a valid object file
+# ERROR-NEXT: error: '[[FILE3]]': The file was not recognized as a valid object file
+
+# RUN: llvm-readobj --file-header %t2 | FileCheck %s --check-prefix=NUMSECTIONS
+
+# NUMSECTIONS: SectionHeaderCount: 0
+
+!ELF
+FileHeader:
+  Class: ELFCLASS64
+  Data:  ELFDATA2LSB
+  Type:  ET_EXEC
+  Machine: EM_X86_64
+Sections:
+  - Name:    .debugGlobal
+    Type:    SHT_PROGBITS
+    Content: "00000000"

--- a/llvm/tools/llvm-objcopy/llvm-objcopy.cpp
+++ b/llvm/tools/llvm-objcopy/llvm-objcopy.cpp
@@ -247,14 +247,16 @@ int llvm_objcopy_main(int argc, char **argv, const llvm::ToolContext &) {
                           WithColor::error(errs(), ToolName));
     return 1;
   }
+
+  int ret = 0;
   for (ConfigManager &ConfigMgr : DriverConfig->CopyConfigs) {
     assert(!ConfigMgr.Common.ErrorCallback);
     ConfigMgr.Common.ErrorCallback = reportWarning;
     if (Error E = executeObjcopy(ConfigMgr)) {
       logAllUnhandledErrors(std::move(E), WithColor::error(errs(), ToolName));
-      return 1;
+      ret = 1;
     }
   }
 
-  return 0;
+  return ret;
 }


### PR DESCRIPTION
This change means that llvm-strip no longer exits immediately upon encountering an error when modifying a file and will instead continue modifying the other inputs. Fixes #129412 