### PR TITLE
[clang][SPIR-V] Use the SPIR-V backend by default

### DIFF
--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -4681,25 +4681,7 @@ Clang supports generation of SPIR-V conformant to `the OpenCL Environment
 Specification
 <https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Env.html>`_.
 
-To generate SPIR-V binaries, Clang uses the external ``llvm-spirv`` tool from the
-`SPIRV-LLVM-Translator repo
-<https://github.com/KhronosGroup/SPIRV-LLVM-Translator>`_.
-
-Prior to the generation of SPIR-V binary with Clang, ``llvm-spirv``
-should be built or installed. Please refer to `the following instructions
-<https://github.com/KhronosGroup/SPIRV-LLVM-Translator#build-instructions>`_
-for more details. Clang will look for ``llvm-spirv-<LLVM-major-version>`` and
-``llvm-spirv`` executables, in this order, in the ``PATH`` environment variable.
-Clang uses ``llvm-spirv`` with `the widely adopted assembly syntax package
-<https://github.com/KhronosGroup/SPIRV-LLVM-Translator/#build-with-spirv-tools>`_.
-
-`The versioning
-<https://github.com/KhronosGroup/SPIRV-LLVM-Translator/releases>`_ of
-``llvm-spirv`` is aligned with Clang major releases. The same applies to the
-main development branch. It is therefore important to ensure the ``llvm-spirv``
-version is in alignment with the Clang version. For troubleshooting purposes
-``llvm-spirv`` can be `tested in isolation
-<https://github.com/KhronosGroup/SPIRV-LLVM-Translator#test-instructions>`_.
+To generate SPIR-V binaries, Clang uses the in-tree LLVM SPIR-V backend.
 
 Example usage for OpenCL kernel compilation:
 
@@ -4716,18 +4698,6 @@ further by offline SPIR-V consumer tools.
 Converting to SPIR-V produced with the optimization levels other than `-O0` is
 currently available as an experimental feature and it is not guaranteed to work
 in all cases.
-
-Clang also supports integrated generation of SPIR-V without use of ``llvm-spirv``
-tool as an experimental feature when ``-fintegrated-objemitter`` flag is passed in
-the command line.
-
-   .. code-block:: console
-
-     $ clang --target=spirv32 -fintegrated-objemitter -c test.cl
-
-Note that only very basic functionality is supported at this point and therefore
-it is not suitable for arbitrary use cases. This feature is only enabled when clang
-build is configured with ``-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV`` option.
 
 Linking is done using ``spirv-link`` from `the SPIRV-Tools project
 <https://github.com/KhronosGroup/SPIRV-Tools#linker>`_. Similar to other external

--- a/clang/lib/Driver/ToolChains/SPIRV.cpp
+++ b/clang/lib/Driver/ToolChains/SPIRV.cpp
@@ -93,12 +93,6 @@ void SPIRV::Assembler::ConstructJob(Compilation &C, const JobAction &JA,
   constructAssembleCommand(C, *this, JA, Output, Inputs[0], {});
 }
 
-clang::driver::Tool *SPIRVToolChain::getTranslator() const {
-  if (!Translator)
-    Translator = std::make_unique<SPIRV::Translator>(*this);
-  return Translator.get();
-}
-
 clang::driver::Tool *SPIRVToolChain::getAssembler() const {
   if (!Assembler)
     Assembler = std::make_unique<SPIRV::Assembler>(*this);
@@ -114,8 +108,6 @@ clang::driver::Tool *SPIRVToolChain::getTool(Action::ActionClass AC) const {
   switch (AC) {
   default:
     break;
-  case Action::BackendJobClass:
-    return SPIRVToolChain::getTranslator();
   case Action::AssembleJobClass:
     return SPIRVToolChain::getAssembler();
   }

--- a/clang/lib/Driver/ToolChains/SPIRV.h
+++ b/clang/lib/Driver/ToolChains/SPIRV.h
@@ -78,7 +78,7 @@ public:
 
   bool useIntegratedAs() const override { return true; }
 
-  bool IsIntegratedBackendDefault() const override { return false; }
+  bool IsIntegratedBackendDefault() const override { return true; }
   bool IsNonIntegratedBackendSupported() const override { return true; }
   bool IsMathErrnoDefault() const override { return false; }
   bool isCrossCompiling() const override { return true; }
@@ -97,7 +97,6 @@ protected:
   Tool *buildLinker() const override;
 
 private:
-  clang::driver::Tool *getTranslator() const;
   clang::driver::Tool *getAssembler() const;
 
   bool NativeLLVMSupport;

--- a/clang/lib/Driver/ToolChains/SPIRV.h
+++ b/clang/lib/Driver/ToolChains/SPIRV.h
@@ -69,7 +69,6 @@ public:
 namespace toolchains {
 
 class LLVM_LIBRARY_VISIBILITY SPIRVToolChain : public ToolChain {
-  mutable std::unique_ptr<Tool> Translator;
   mutable std::unique_ptr<Tool> Assembler;
 
 public:

--- a/clang/test/Driver/spirv-openmp-toolchain.c
+++ b/clang/test/Driver/spirv-openmp-toolchain.c
@@ -4,8 +4,7 @@
 
 // verify the tools invocations
 // CHECK: "-cc1" "-triple" "x86_64-unknown-linux-gnu"{{.*}}"-emit-llvm-bc"{{.*}}"-x" "c"
-// CHECK: "-cc1" "-triple" "spirv64-intel" "-aux-triple" "x86_64-unknown-linux-gnu"
-// CHECK: llvm-spirv{{.*}}
+// CHECK: "-cc1" "-triple" "spirv64-intel" "-aux-triple" "x86_64-unknown-linux-gnu"{{.*}} "-o" "{{.*}}.o"
 // CHECK: "-cc1" "-triple" "x86_64-unknown-linux-gnu"{{.*}}"-emit-obj"
 // CHECK: clang-linker-wrapper{{.*}} "-o" "a.out"
 
@@ -32,8 +31,7 @@
 // RUN: %clang -### --target=x86_64-unknown-linux-gnu -ccc-print-bindings -fopenmp=libomp -fopenmp-targets=spirv64-intel -nogpulib %s 2>&1 | FileCheck %s --check-prefix=CHECK-BINDINGS
 
 // CHECK-BINDINGS: "x86_64-unknown-linux-gnu" - "clang", inputs: ["[[INPUT:.+]]"], output: "[[HOST_BC:.+]]"
-// CHECK-BINDINGS: "spirv64-intel" - "clang", inputs: ["[[INPUT]]", "[[HOST_BC]]"], output: "[[DEVICE_TEMP_BC:.+]]"
-// CHECK-BINDINGS: "spirv64-intel" - "SPIR-V::Translator", inputs: ["[[DEVICE_TEMP_BC]]"], output: "[[DEVICE_SPV:.+]]"
+// CHECK-BINDINGS: "spirv64-intel" - "clang", inputs: ["[[INPUT]]", "[[HOST_BC]]"], output: "[[DEVICE_SPV:.+]]"
 // CHECK-BINDINGS: "x86_64-unknown-linux-gnu" - "Offload::Packager", inputs: ["[[DEVICE_SPV]]"], output: "[[DEVICE_IMAGE:.+]]"
 // CHECK-BINDINGS: "x86_64-unknown-linux-gnu" - "clang", inputs: ["[[HOST_BC]]", "[[DEVICE_IMAGE]]"], output: "[[HOST_OBJ:.+]]"
 // CHECK-BINDINGS: "x86_64-unknown-linux-gnu" - "Offload::Linker", inputs: ["[[HOST_OBJ]]"], output: "a.out"
@@ -43,8 +41,8 @@
 // CHECK-BINDINGS-TEMPS: "x86_64-unknown-linux-gnu" - "clang", inputs: ["[[INPUT:.+]]"], output: "[[HOST_PP:.+]]"
 // CHECK-BINDINGS-TEMPS: "x86_64-unknown-linux-gnu" - "clang", inputs: ["[[HOST_PP]]"], output: "[[HOST_BC:.+]]"
 // CHECK-BINDINGS-TEMPS: "spirv64-intel" - "clang", inputs: ["[[INPUT]]"], output: "[[DEVICE_PP:.+]]"
-// CHECK-BINDINGS-TEMPS: "spirv64-intel" - "clang", inputs: ["[[DEVICE_PP]]", "[[HOST_BC]]"], output: "[[DEVICE_TEMP_BC:.+]]"
-// CHECK-BINDINGS-TEMPS: "spirv64-intel" - "SPIR-V::Translator", inputs: ["[[DEVICE_TEMP_BC]]"], output: "[[DEVICE_ASM:.+]]"
+// CHECK-BINDINGS-TEMPS: "spirv64-intel" - "clang", inputs: ["[[DEVICE_PP]]", "[[HOST_BC]]"], output: "[[DEVICE_BC:.+]]"
+// CHECK-BINDINGS-TEMPS: "spirv64-intel" - "clang", inputs: ["[[DEVICE_BC]]"], output: "[[DEVICE_ASM:.+]]"
 // CHECK-BINDINGS-TEMPS: "spirv64-intel" - "SPIR-V::Assembler", inputs: ["[[DEVICE_ASM]]"], output: "[[DEVICE_SPV:.+]]"
 // CHECK-BINDINGS-TEMPS: "x86_64-unknown-linux-gnu" - "Offload::Packager", inputs: ["[[DEVICE_SPV]]"], output: "[[DEVICE_IMAGE:.+]]"
 // CHECK-BINDINGS-TEMPS: "x86_64-unknown-linux-gnu" - "clang", inputs: ["[[HOST_BC]]", "[[DEVICE_IMAGE]]"], output: "[[HOST_ASM:.+]]"

--- a/clang/test/Driver/spirv-toolchain.cl
+++ b/clang/test/Driver/spirv-toolchain.cl
@@ -6,8 +6,7 @@
 // RUN: %clang -### --target=spirv64 -x c -c %s 2>&1 | FileCheck --check-prefix=SPV64 %s
 
 // SPV64: "-cc1" "-triple" "spirv64"
-// SPV64-SAME: "-o" [[BC:".*bc"]]
-// SPV64: {{llvm-spirv.*"}} [[BC]] "-o" {{".*o"}}
+// SPV64-SAME: "-o" {{".*o"}}
 
 // RUN: %clang -### --target=spirv32 -x cl -c %s 2>&1 | FileCheck --check-prefix=SPV32 %s
 // RUN: %clang -### --target=spirv32 %s 2>&1 | FileCheck --check-prefix=SPV32 %s
@@ -16,8 +15,7 @@
 // RUN: %clang -### --target=spirv32 -x c -c %s 2>&1 | FileCheck --check-prefix=SPV32 %s
 
 // SPV32: "-cc1" "-triple" "spirv32"
-// SPV32-SAME: "-o" [[BC:".*bc"]]
-// SPV32: {{llvm-spirv.*"}} [[BC]] "-o" {{".*o"}}
+// SPV32-SAME: "-o" {{".*o"}}
 
 //-----------------------------------------------------------------------------
 // Check Assembly emission.
@@ -27,8 +25,7 @@
 // RUN: %clang -### --target=spirv64 -x c -S %s 2>&1 | FileCheck --check-prefix=SPT64 %s
 
 // SPT64: "-cc1" "-triple" "spirv64"
-// SPT64-SAME: "-o" [[BC:".*bc"]]
-// SPT64: {{llvm-spirv.*"}} [[BC]] "--spirv-tools-dis" "-o" {{".*s"}}
+// SPT64-SAME: "-o" {{".*s"}}
 
 // RUN: %clang -### --target=spirv32 -x cl -S %s 2>&1 | FileCheck --check-prefix=SPT32 %s
 // RUN: %clang -### --target=spirv32 -x ir -S %s 2>&1 | FileCheck --check-prefix=SPT32 %s
@@ -36,8 +33,7 @@
 // RUN: %clang -### --target=spirv32 -x c -S %s 2>&1 | FileCheck --check-prefix=SPT32 %s
 
 // SPT32: "-cc1" "-triple" "spirv32"
-// SPT32-SAME: "-o" [[BC:".*bc"]]
-// SPT32: {{llvm-spirv.*"}} [[BC]] "--spirv-tools-dis" "-o" {{".*s"}}
+// SPT32-SAME: "-o" {{".*s"}}
 
 //-----------------------------------------------------------------------------
 // Check assembly input -> object output
@@ -55,7 +51,9 @@
 // TMP: "-cc1" "-triple" "spirv64"
 // TMP-SAME: "-o" [[BC:".*bc"]]
 // TMP-SAME: [[I]]
-// TMP: {{llvm-spirv.*"}} [[BC]] "--spirv-tools-dis" "-o" [[S:".*s"]]
+// TMP: "-cc1"
+// TMP-SAME: "-o" [[S:".*s"]]
+// TMP-SAME: [[BC]]
 // TMP: {{spirv-as.*"}} [[S]] "-o" {{".*o"}}
 
 //-----------------------------------------------------------------------------
@@ -63,21 +61,17 @@
 // RUN: %clang -### -target spirv64 %s %s 2>&1 | FileCheck --check-prefix=SPLINK %s
 
 // SPLINK: "-cc1" "-triple" "spirv64"
-// SPLINK-SAME: "-o" [[BC:".*bc"]]
-// SPLINK: {{llvm-spirv.*"}} [[BC]] "-o" [[SPV1:".*o"]]
+// SPLINK-SAME: "-o" [[SPV1:".*o"]]
 // SPLINK: "-cc1" "-triple" "spirv64"
-// SPLINK-SAME: "-o" [[BC:".*bc"]]
-// SPLINK: {{llvm-spirv.*"}} [[BC]] "-o" [[SPV2:".*o"]]
+// SPLINK-SAME: "-o" [[SPV2:".*o"]]
 // SPLINK: {{spirv-link.*"}} [[SPV1]] [[SPV2]] "-o" "a.out"
 
 //-----------------------------------------------------------------------------
 // Check bindings when linking when multiple input files are passed.
 // RUN: %clang -### -target spirv64 -ccc-print-bindings %s %s 2>&1 | FileCheck --check-prefix=SPLINK-BINDINGS %s
 
-// SPLINK-BINDINGS: "clang", inputs: [[[CL:".*cl"]]], output: [[BC1:".*bc"]]
-// SPLINK-BINDINGS: "SPIR-V::Translator", inputs: [[[BC1]]], output: [[OBJ1:".*o"]]
-// SPLINK-BINDINGS: "clang", inputs: [[[CL]]], output: [[BC2:".*bc"]]
-// SPLINK-BINDINGS: "SPIR-V::Translator", inputs: [[[BC2]]], output: [[OBJ2:".*o"]]
+// SPLINK-BINDINGS: "clang", inputs: [[[CL:".*cl"]]], output: [[OBJ1:".*o"]]
+// SPLINK-BINDINGS: "clang", inputs: [[[CL]]], output: [[OBJ2:".*o"]]
 // SPLINK-BINDINGS: "SPIR-V::Linker", inputs: [[[OBJ1]], [[OBJ2]]], output: "a.out"
 
 //-----------------------------------------------------------------------------
@@ -85,20 +79,20 @@
 // RUN: %clang -### --target=spirv64 -fno-integrated-objemitter %s 2>&1 | FileCheck --check-prefix=XTOR %s
 // RUN: %clang -### --target=spirv64 -fintegrated-objemitter %s 2>&1 | FileCheck --check-prefix=BACKEND %s
 
-// XTOR: {{llvm-spirv.*"}}
-// BACKEND-NOT: {{llvm-spirv.*"}}
+// XTOR-NOT: "llvm-spirv.*"
+// BACKEND-NOT: "llvm-spirv.*"
 
 //-----------------------------------------------------------------------------
-// Check llvm-spirv-<LLVM_VERSION_MAJOR> is used if it is found in PATH.
+// Check spirv-as-<LLVM_VERSION_MAJOR> is used if it is found in PATH.
 //
 // This test uses the PATH environment variable; on Windows, we may need to retain
 // the original path for the built Clang binary to be able to execute (as it is
 // used for locating dependent DLLs). Therefore, skip this test on system-windows.
 //
 // RUN: mkdir -p %t/versioned
-// RUN: touch %t/versioned/llvm-spirv-%llvm-version-major \
-// RUN:   && chmod +x %t/versioned/llvm-spirv-%llvm-version-major
-// RUN: %if !system-windows %{ env "PATH=%t/versioned" %clang -### --target=spirv64 -x cl -c %s 2>&1 \
+// RUN: touch %t/versioned/spirv-as-%llvm-version-major \
+// RUN:   && chmod +x %t/versioned/spirv-as-%llvm-version-major
+// RUN: %if !system-windows %{ env "PATH=%t/versioned" %clang -### --target=spirv64 -x cl -c --save-temps %s 2>&1 \
 // RUN:   | FileCheck -DVERSION=%llvm-version-major --check-prefix=VERSIONED %s %}
 
-// VERSIONED: {{.*}}llvm-spirv-[[VERSION]]
+// VERSIONED: {{.*}}spirv-as-[[VERSION]]


### PR DESCRIPTION
The SPIR-V backend is now a supported backend, and we believe it is ready to be used by default in Clang over the SPIR-V translator. 

Some IR generated by Clang today, such as those requiring SPIR-V target address spaces, cannot be compiled by the translator for reasons in this [RFC](https://discourse.llvm.org/t/rfc-the-spir-v-backend-should-change-its-address-space-mappings/82640), so we expect even more programs to work as well.

Enable it by default, but keep some of the code as it is still called by the HIP toolchain directly.