### PR TITLE
[LLVM][SVE] Add isel for bfloat based constant splats.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64SVEInstrInfo.td
@@ -931,6 +931,13 @@ let Predicates = [HasSVE_or_SME] in {
               (FDUP_ZI_S fpimm32:$imm8)>;
     def : Pat<(nxv2f64 (splat_vector fpimm64:$imm8)),
               (FDUP_ZI_D fpimm64:$imm8)>;
+    // Some half precision immediates alias with bfloat (e.g. f16(1.875) == bf16(1.0)).
+    def : Pat<(nxv8bf16 (splat_vector fpimmbf16:$imm8)),
+              (FDUP_ZI_H (fpimm16XForm bf16:$imm8))>;
+    def : Pat<(nxv4bf16 (splat_vector fpimmbf16:$imm8)),
+              (FDUP_ZI_H (fpimm16XForm bf16:$imm8))>;
+    def : Pat<(nxv2bf16 (splat_vector fpimmbf16:$imm8)),
+              (FDUP_ZI_H (fpimm16XForm bf16:$imm8))>;
   }
 
   // Select elements from either vector (predicated)

--- a/llvm/test/CodeGen/AArch64/sve-vector-splat.ll
+++ b/llvm/test/CodeGen/AArch64/sve-vector-splat.ll
@@ -486,8 +486,7 @@ define <vscale x 2 x double> @splat_nxv2f64_imm() {
 define <vscale x 8 x bfloat> @splat_nxv8bf16_imm() {
 ; CHECK-LABEL: splat_nxv8bf16_imm:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    fmov h0, #1.87500000
-; CHECK-NEXT:    mov z0.h, h0
+; CHECK-NEXT:    fmov z0.h, #1.87500000
 ; CHECK-NEXT:    ret
   ret <vscale x 8 x bfloat> splat(bfloat 1.0)
 }
@@ -496,8 +495,7 @@ define <vscale x 8 x bfloat> @splat_nxv8bf16_imm() {
 define <vscale x 4 x bfloat> @splat_nxv4bf16_imm() {
 ; CHECK-LABEL: splat_nxv4bf16_imm:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    fmov h0, #-1.87500000
-; CHECK-NEXT:    mov z0.h, h0
+; CHECK-NEXT:    fmov z0.h, #-1.87500000
 ; CHECK-NEXT:    ret
   ret <vscale x 4 x bfloat> splat(bfloat -1.0)
 }
@@ -506,8 +504,7 @@ define <vscale x 4 x bfloat> @splat_nxv4bf16_imm() {
 define <vscale x 2 x bfloat> @splat_nxv2bf16_imm() {
 ; CHECK-LABEL: splat_nxv2bf16_imm:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    fmov h0, #1.87500000
-; CHECK-NEXT:    mov z0.h, h0
+; CHECK-NEXT:    fmov z0.h, #1.87500000
 ; CHECK-NEXT:    ret
   ret <vscale x 2 x bfloat> splat(bfloat 1.0)
 }

--- a/llvm/test/CodeGen/AArch64/sve-vector-splat.ll
+++ b/llvm/test/CodeGen/AArch64/sve-vector-splat.ll
@@ -482,6 +482,36 @@ define <vscale x 2 x double> @splat_nxv2f64_imm() {
   ret <vscale x 2 x double> splat(double 1.0)
 }
 
+; NOTE: f16(1.875) == bf16(1.0)
+define <vscale x 8 x bfloat> @splat_nxv8bf16_imm() {
+; CHECK-LABEL: splat_nxv8bf16_imm:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fmov h0, #1.87500000
+; CHECK-NEXT:    mov z0.h, h0
+; CHECK-NEXT:    ret
+  ret <vscale x 8 x bfloat> splat(bfloat 1.0)
+}
+
+; NOTE: f16(-1.875) == bf16(-1.0)
+define <vscale x 4 x bfloat> @splat_nxv4bf16_imm() {
+; CHECK-LABEL: splat_nxv4bf16_imm:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fmov h0, #-1.87500000
+; CHECK-NEXT:    mov z0.h, h0
+; CHECK-NEXT:    ret
+  ret <vscale x 4 x bfloat> splat(bfloat -1.0)
+}
+
+; NOTE: f16(1.875) == bf16(1.0)
+define <vscale x 2 x bfloat> @splat_nxv2bf16_imm() {
+; CHECK-LABEL: splat_nxv2bf16_imm:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    fmov h0, #1.87500000
+; CHECK-NEXT:    mov z0.h, h0
+; CHECK-NEXT:    ret
+  ret <vscale x 2 x bfloat> splat(bfloat 1.0)
+}
+
 define <vscale x 4 x i32> @splat_nxv4i32_fold(<vscale x 4 x i32> %x) {
 ; CHECK-LABEL: splat_nxv4i32_fold:
 ; CHECK:       // %bb.0:
@@ -554,8 +584,8 @@ define <vscale x 2 x double> @splat_nxv2f64_imm_out_of_range() {
 ; CHECK-LABEL: splat_nxv2f64_imm_out_of_range:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    ptrue p0.d
-; CHECK-NEXT:    adrp x8, .LCPI57_0
-; CHECK-NEXT:    add x8, x8, :lo12:.LCPI57_0
+; CHECK-NEXT:    adrp x8, .LCPI60_0
+; CHECK-NEXT:    add x8, x8, :lo12:.LCPI60_0
 ; CHECK-NEXT:    ld1rd { z0.d }, p0/z, [x8]
 ; CHECK-NEXT:    ret
   ret <vscale x 2 x double> splat(double 3.33)


### PR DESCRIPTION
There are no dedicated bfloat MOV instructions but we can use the half variants when the encoing allows (e.g. f16(1.875) == bf16(1.0)).