### PR TITLE
[mlir][linalg] Fix linalg.pack/unpack docs

### DIFF
--- a/mlir/docs/Dialects/Linalg/_index.md
+++ b/mlir/docs/Dialects/Linalg/_index.md
@@ -695,4 +695,3 @@ the same IR.
 ## Operations
 
 [include "Dialects/LinalgOps.md"]
-[include "Dialects/LinalgRelayoutOps.td"]

--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgDoc.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgDoc.td
@@ -18,6 +18,7 @@
 
 include "mlir/Dialect/Linalg/IR/LinalgBase.td"
 include "mlir/Dialect/Linalg/IR/LinalgOps.td"
+include "mlir/Dialect/Linalg/IR/LinalgRelayoutOps.td"
 include "mlir/Dialect/Linalg/IR/LinalgStructuredOps.td"
 
 #endif // LINALG_DOC


### PR DESCRIPTION
Adds missing relayout ops to Linalg docs tablegen.

Follow-up to #127729