### PR TITLE
[SystemZ] Change operand type for CKSM intrstruction.

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.td
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.td
@@ -2183,7 +2183,7 @@ let mayLoad = 1, mayStore = 1, Defs = [CC, R0D, R1D, R2D, R3D, R5D],
 
 // Checksum.
 let mayLoad = 1, Defs = [CC] in
-  def CKSM : SideEffectBinaryMemMemRRE<"cksm", 0xB241, GR64, GR128>;
+  def CKSM : SideEffectBinaryMemMemRRE<"cksm", 0xB241, GR32, GR128>;
 
 // Compression call.
 let mayLoad = 1, mayStore = 1, Defs = [CC, R1D], Uses = [R0L, R1D] in


### PR DESCRIPTION
The current definition of the CKSM instruction uses GR64 for the first operand. However, according to the Principles Of Operation the bits 0-31 of the first operand always remain unchanged. This PR changes the first operand to GR32 to model this.
This has no further implication as this instruction is not used during code generation.