### PR TITLE
Simplify Target::RunStopHooks()

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1317,6 +1317,7 @@ public:
     enum class StopHookResult : uint32_t {
       KeepStopped = 0,
       RequestContinue,
+      NoPreference,
       AlreadyContinued
     };
 


### PR DESCRIPTION
Introduce `StopHookResult::NoPreference` and
simplify control flow in `Target::RunStopHooks()`.

The algorithm is (in order):
1. "Auto continue" set on any hook -> continue
2. "Stop demanded" by any hook -> stop
3. "Continue requested" by any hook -> continue
4. No hooks, or "no preference" only (default
   stance) -> stop

The new `NoPreference` lets us keep the default
stance, distinguishing case 3. and 4.