### PR TITLE
[flang][debug] Improve handling of cyclic derived types with classes.

### DIFF
--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -210,7 +210,8 @@ mlir::Type getDerivedType(mlir::Type ty) {
           return seq.getEleTy();
         return p.getEleTy();
       })
-      .Case<fir::BoxType>([](auto p) { return getDerivedType(p.getEleTy()); })
+      .Case<fir::BaseBoxType>(
+          [](auto p) { return getDerivedType(p.getEleTy()); })
       .Default([](mlir::Type t) { return t; });
 }
 

--- a/flang/test/Integration/debug-cyclic-derived-type-4.f90
+++ b/flang/test/Integration/debug-cyclic-derived-type-4.f90
@@ -1,0 +1,22 @@
+! RUN: %flang_fc1 -emit-llvm -debug-info-kind=standalone %s -o - | FileCheck  %s
+
+! Same as debug-cyclic-derived-type-2.f90 but using class instead of type.
+module m
+ type t2
+   class(t1), pointer :: p1
+ end type
+ type t1
+   class(t2), pointer :: p2
+   integer abc
+ end type
+ type(t1) :: tee1
+end module
+
+program test
+  use m
+  type(t2) :: lc2
+  print *, lc2%p1%abc
+end program test
+
+! CHECK-DAG: DICompositeType(tag: DW_TAG_structure_type, name: "t1"{{.*}})
+! CHECK-DAG: DICompositeType(tag: DW_TAG_structure_type, name: "t2"{{.*}})


### PR DESCRIPTION
While checking if a type should be cached or not, we use `getDerivedType` to peel outer layers and get to the base type. This function did not peel the `fir.class` which caused the algorithm to fail.

Fixes #128606.