### PR TITLE
[ctxprof] ProfileWriter abstraction

### DIFF
--- a/compiler-rt/lib/ctx_profile/CtxInstrContextNode.h
+++ b/compiler-rt/lib/ctx_profile/CtxInstrContextNode.h
@@ -112,6 +112,13 @@ public:
 
   uint64_t entrycount() const { return counters()[0]; }
 };
+
+/// Abstraction for the parameter passed to `__llvm_ctx_profile_fetch`.
+class ProfileWriter {
+public:
+  virtual void writeContextual(const ctx_profile::ContextNode &RootNode) = 0;
+  virtual ~ProfileWriter() = default;
+};
 } // namespace ctx_profile
 } // namespace llvm
 #endif

--- a/compiler-rt/lib/ctx_profile/CtxInstrProfiling.cpp
+++ b/compiler-rt/lib/ctx_profile/CtxInstrProfiling.cpp
@@ -294,9 +294,7 @@ void __llvm_ctx_profile_start_collection() {
   __sanitizer::Printf("[ctxprof] Initial NumMemUnits: %zu \n", NumMemUnits);
 }
 
-bool __llvm_ctx_profile_fetch(void *Data,
-                              bool (*Writer)(void *W, const ContextNode &)) {
-  assert(Writer);
+bool __llvm_ctx_profile_fetch(ProfileWriter &Writer) {
   __sanitizer::GenericScopedLock<__sanitizer::SpinMutex> Lock(
       &AllContextsMutex);
 
@@ -308,8 +306,7 @@ bool __llvm_ctx_profile_fetch(void *Data,
       __sanitizer::Printf("[ctxprof] Contextual Profile is %s\n", "invalid");
       return false;
     }
-    if (!Writer(Data, *Root->FirstNode))
-      return false;
+    Writer.writeContextual(*Root->FirstNode);
   }
   return true;
 }

--- a/compiler-rt/lib/ctx_profile/CtxInstrProfiling.h
+++ b/compiler-rt/lib/ctx_profile/CtxInstrProfiling.h
@@ -169,7 +169,6 @@ void __llvm_ctx_profile_free();
 /// The Writer's first parameter plays the role of closure for Writer, and is
 /// what the caller of __llvm_ctx_profile_fetch passes as the Data parameter.
 /// The second parameter is the root of a context tree.
-bool __llvm_ctx_profile_fetch(void *Data,
-                              bool (*Writer)(void *, const ContextNode &));
+bool __llvm_ctx_profile_fetch(ProfileWriter &);
 }
 #endif // CTX_PROFILE_CTXINSTRPROFILING_H_

--- a/llvm/include/llvm/ProfileData/CtxInstrContextNode.h
+++ b/llvm/include/llvm/ProfileData/CtxInstrContextNode.h
@@ -112,6 +112,13 @@ public:
 
   uint64_t entrycount() const { return counters()[0]; }
 };
+
+/// Abstraction for the parameter passed to `__llvm_ctx_profile_fetch`.
+class ProfileWriter {
+public:
+  virtual void writeContextual(const ctx_profile::ContextNode &RootNode) = 0;
+  virtual ~ProfileWriter() = default;
+};
 } // namespace ctx_profile
 } // namespace llvm
 #endif


### PR DESCRIPTION
Introduce a `ProfileWriter` abstraction to replace the callback passed to `__llvm_ctx_profile_fetch`. Subsequent changes will add support for flat profile collection (as in, collection of non-contextual profile for those functions not under a contextual root), which require also a change in the profile format. The abstraction makes it easy to add "write flat" - related capabilities without constantly complicating the signature of `__llvm_ctx_profile_fetch`.