### PR TITLE
[clang-tidy][misc-use-internal-linkage] fix false positives for function or variable in header file which contains macro expansion

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/UseInternalLinkageCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UseInternalLinkageCheck.cpp
@@ -52,7 +52,7 @@ AST_MATCHER(FunctionDecl, hasBody) { return Node.hasBody(); }
 static bool isInMainFile(SourceLocation L, SourceManager &SM,
                          const FileExtensionsSet &HeaderFileExtensions) {
   for (;;) {
-    if (utils::isSpellingLocInHeaderFile(L, SM, HeaderFileExtensions))
+    if (utils::isExpansionLocInHeaderFile(L, SM, HeaderFileExtensions))
       return false;
     if (SM.isInMainFile(L))
       return true;

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -129,6 +129,10 @@ Changes in existing checks
   <clang-tidy/checks/misc/redundant-expression>` check by providing additional
   examples and fixing some macro related false positives.
 
+- Improved :doc:`misc-use-internal-linkage
+  <clang-tidy/checks/misc/use-internal-linkage>` check by fix false positives
+  for function or variable in header file which contains macro expansion.
+
 - Improved :doc:`performance/unnecessary-value-param
   <clang-tidy/checks/performance/unnecessary-value-param>` check performance by
   tolerating fix-it breaking compilation when functions is used as pointers 

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-macro.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-macro.hpp
@@ -1,0 +1,5 @@
+// RUN: %check_clang_tidy %s misc-use-internal-linkage %t -- -- -I%S/Inputs/use-internal-linkage
+
+#define B A##C
+
+inline void B() {}


### PR DESCRIPTION
When check whether in main file, spelling loc will lead to `<scratch space>`. instead, expansion loc is close to loc after preprocess. It is suitable to analyze linkage.
