### PR TITLE
[flang] Improve two coarray error messages

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -731,7 +731,8 @@ void CheckHelper::CheckObjectEntity(
           symbol.name(), commonBlock->name());
     } else if (isLocalVariable && !IsAllocatableOrPointer(symbol) &&
         !IsSaved(symbol)) {
-      messages_.Say("Local coarray must have the SAVE attribute"_err_en_US);
+      messages_.Say(
+          "Local coarray must have the SAVE or ALLOCATABLE attribute"_err_en_US);
     }
     for (int j{0}; j < corank; ++j) {
       if (auto lcbv{evaluate::ToInt64(evaluate::Fold(
@@ -980,7 +981,7 @@ void CheckHelper::CheckObjectEntity(
               symbol.name(), badPotential.BuildResultDesignatorName());
         } else if (isUnsavedLocal) { // F'2023 C826
           SayWithDeclaration(*badPotential,
-              "Local variable '%s' without the SAVE attribute may not have a coarray potential subobject component '%s'"_err_en_US,
+              "Local variable '%s' without the SAVE or ALLOCATABLE attribute may not have a coarray potential subobject component '%s'"_err_en_US,
               symbol.name(), badPotential.BuildResultDesignatorName());
         } else {
           DIE("caught unexpected bad coarray potential component");

--- a/flang/test/Semantics/coarrays02.f90
+++ b/flang/test/Semantics/coarrays02.f90
@@ -6,7 +6,7 @@ end
 program main
   use iso_fortran_env
   !ERROR: Coarray 'namedconst' may not be a named constant
-  !ERROR: Local coarray must have the SAVE attribute
+  !ERROR: Local coarray must have the SAVE or ALLOCATABLE attribute
   integer, parameter :: namedConst = 123
   codimension namedConst[*]
   !ERROR: Coarray 'coarr1' may not be in COMMON block '//'
@@ -22,7 +22,7 @@ end
 function func1()
   !ERROR: Function result may not be a coarray
   integer :: func1[*]
-  !ERROR: Local coarray must have the SAVE attribute
+  !ERROR: Local coarray must have the SAVE or ALLOCATABLE attribute
   integer :: local[*]
   integer, save :: saved[*] ! ok
   integer :: inited[*] = 1 ! ok
@@ -45,6 +45,6 @@ function func2()
   type(t), pointer :: ptr
   !ERROR: Coarray 'coarr' may not have a coarray potential component '%comp'
   type(t), save :: coarr[*]
-  !ERROR: Local variable 'local' without the SAVE attribute may not have a coarray potential subobject component '%comp'
+  !ERROR: Local variable 'local' without the SAVE or ALLOCATABLE attribute may not have a coarray potential subobject component '%comp'
   type(t) :: local
 end

--- a/flang/test/Semantics/init01.f90
+++ b/flang/test/Semantics/init01.f90
@@ -18,7 +18,7 @@ subroutine objectpointers(j)
   end type
   type(t1), target, save :: o1
   type(t1), save :: o2
-!ERROR: Local variable 'o3' without the SAVE attribute may not have a coarray potential subobject component '%c2'
+!ERROR: Local variable 'o3' without the SAVE or ALLOCATABLE attribute may not have a coarray potential subobject component '%c2'
   type(t1), target :: o3
 !ERROR: An initial data target may not be a reference to an ALLOCATABLE 'x1'
   real, pointer :: p1 => x1


### PR DESCRIPTION
Two messages that complain about local variables mention that they don't have the SAVE attribute; in both cases, it would be okay if they were ALLOCATABLE instead.  Clarify the messages.