### PR TITLE
[flang] Accept useless label on top-level FUNCTION

### DIFF
--- a/flang/lib/Parser/program-parsers.cpp
+++ b/flang/lib/Parser/program-parsers.cpp
@@ -64,7 +64,7 @@ static constexpr auto programUnit{
     construct<ProgramUnit>(indirect(subroutineSubprogram)) ||
     construct<ProgramUnit>(indirect(Parser<Submodule>{})) ||
     construct<ProgramUnit>(indirect(Parser<BlockData>{})) ||
-    lookAhead(validFunctionStmt) >>
+    lookAhead(maybe(label) >> validFunctionStmt) >>
         construct<ProgramUnit>(indirect(functionSubprogram)) ||
     construct<ProgramUnit>(indirect(Parser<MainProgram>{}))};
 static constexpr auto normalProgramUnit{StartNewSubprogram{} >> programUnit /

--- a/flang/test/Parser/func-label.f
+++ b/flang/test/Parser/func-label.f
@@ -1,0 +1,7 @@
+! RUN: %flang_fc1 -fsyntax-only -pedantic %s 2>&1 | FileCheck --allow-empty %s
+!CHECK-NOT: error:
+ 1    function fun()
+ 2    end function
+ 3    write(6,*) "pass"
+ 4    end
+


### PR DESCRIPTION
The look-ahead parser for function program units didn't allow for a useless label on the statement.

Fixes https://github.com/llvm/llvm-project/issues/129456.