### PR TITLE
[CIR] Clean up warnings

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -62,7 +62,7 @@ void CIRGenFunction::emitAutoVarInit(const clang::VarDecl &d) {
 
 void CIRGenFunction::emitAutoVarCleanups(const clang::VarDecl &d) {
   // Check the type for a cleanup.
-  if (QualType::DestructionKind dtorKind = d.needsDestruction(getContext()))
+  if (d.needsDestruction(getContext()))
     cgm.errorNYI(d.getSourceRange(), "emitAutoVarCleanups: type cleanup");
 
   assert(!cir::MissingFeatures::opAllocaPreciseLifetime());

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -98,6 +98,7 @@ public:
 
     cgf.getCIRGenModule().errorNYI(loc,
                                    "emitScalarConversion for unequal types");
+    return {};
   }
 };
 

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -13,6 +13,7 @@
 #include "CIRGenFunction.h"
 
 #include "CIRGenCall.h"
+#include "CIRGenValue.h"
 #include "mlir/IR/Location.h"
 #include "clang/AST/GlobalDecl.h"
 #include "clang/CIR/MissingFeatures.h"
@@ -134,10 +135,9 @@ mlir::Location CIRGenFunction::getLoc(mlir::Location lhs, mlir::Location rhs) {
   return mlir::FusedLoc::get(locs, metadata, &getMLIRContext());
 }
 
-mlir::LogicalResult CIRGenFunction::declare(mlir::Value addrVal,
-                                            const Decl *var, QualType ty,
-                                            mlir::Location loc,
-                                            CharUnits alignment, bool isParam) {
+void CIRGenFunction::declare(mlir::Value addrVal, const Decl *var, QualType ty,
+                             mlir::Location loc, CharUnits alignment,
+                             bool isParam) {
   const auto *namedVar = dyn_cast_or_null<NamedDecl>(var);
   assert(namedVar && "Needs a named decl");
   assert(!cir::MissingFeatures::cgfSymbolTable());
@@ -147,8 +147,6 @@ mlir::LogicalResult CIRGenFunction::declare(mlir::Value addrVal,
     allocaOp.setInitAttr(mlir::UnitAttr::get(&getMLIRContext()));
   if (ty->isReferenceType() || ty.isConstQualified())
     allocaOp.setConstantAttr(mlir::UnitAttr::get(&getMLIRContext()));
-
-  return mlir::success();
 }
 
 void CIRGenFunction::startFunction(GlobalDecl gd, QualType returnType,
@@ -306,6 +304,7 @@ LValue CIRGenFunction::emitLValue(const Expr *e) {
     getCIRGenModule().errorNYI(e->getSourceRange(),
                                std::string("l-value not implemented for '") +
                                    e->getStmtClassName() + "'");
+    return LValue();
     break;
   case Expr::DeclRefExprClass:
     return emitDeclRefLValue(cast<DeclRefExpr>(e));

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -305,7 +305,6 @@ LValue CIRGenFunction::emitLValue(const Expr *e) {
                                std::string("l-value not implemented for '") +
                                    e->getStmtClassName() + "'");
     return LValue();
-    break;
   case Expr::DeclRefExprClass:
     return emitDeclRefLValue(cast<DeclRefExpr>(e));
   }

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -97,9 +97,9 @@ public:
 private:
   /// Declare a variable in the current scope, return success if the variable
   /// wasn't declared yet.
-  mlir::LogicalResult declare(mlir::Value addrVal, const clang::Decl *var,
-                              clang::QualType ty, mlir::Location loc,
-                              clang::CharUnits alignment, bool isParam = false);
+  void declare(mlir::Value addrVal, const clang::Decl *var, clang::QualType ty,
+               mlir::Location loc, clang::CharUnits alignment,
+               bool isParam = false);
 
 public:
   mlir::Value emitAlloca(llvm::StringRef name, mlir::Type ty,


### PR DESCRIPTION
Previous CIR commits have introduced a few warnings. This change fixes those.

There are still warnings present when building with GCC because GCC warns about virtual functions being hidden in the mlir::OpConversion classes. A separate discussion will be required to decide what should be done about those.