### PR TITLE
[mlir][tosa] Add check for invalid tosa.rescale parameters

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/Utils/QuantUtils.h
+++ b/mlir/include/mlir/Dialect/Tosa/Utils/QuantUtils.h
@@ -28,7 +28,7 @@ namespace tosa {
 
 /// From a scale value, computes multiplier and shift values
 /// for 16 or 32-bit scale widths.
-void computeMultiplierAndShift(double scale, int32_t &multiplier,
+bool computeMultiplierAndShift(double scale, int32_t &multiplier,
                                int32_t &shift, int32_t scaleWidth);
 
 //// Builds ConvOpQuantizationAttr from input and weight.

--- a/mlir/lib/Dialect/Tosa/Utils/QuantUtils.cpp
+++ b/mlir/lib/Dialect/Tosa/Utils/QuantUtils.cpp
@@ -92,18 +92,25 @@ static void computeMultiplierAndShiftTosaScale32(double scale,
 }
 
 /// Generates a quantized multiplier/shift from double.
-void mlir::tosa::computeMultiplierAndShift(double scale, int32_t &multiplier,
+bool mlir::tosa::computeMultiplierAndShift(double scale, int32_t &multiplier,
                                            int32_t &shift, int32_t scaleWidth) {
 
   switch (scaleWidth) {
   case 16:
     computeMultiplierAndShiftTosaScale16(scale, multiplier, shift);
-    return;
+
+    // In some cases computeMultiplierAndShiftTosaScale16 can return
+    // a value less then 2, which is not valid in the TOSA spec.
+    return (!(shift < 2));
   case 32:
     computeMultiplierAndShiftTosaScale32(scale, multiplier, shift);
-    return;
+
+    // In some cases computeMultiplierAndShiftTosaScale32 can return
+    // a value less then 2, which is not valid in the TOSA spec.
+    return (!(shift < 2));
   default:
     assert(0 && "Unsupported Tosa quantized_scale regime specified!");
+    return false;
   }
 }
 

--- a/mlir/test/lib/Dialect/Tosa/TosaTestPasses.cpp
+++ b/mlir/test/lib/Dialect/Tosa/TosaTestPasses.cpp
@@ -163,7 +163,8 @@ ConvertTosaConv2DOp::matchAndRewrite(Operation *op,
   int32_t shift;
 
   // Obtain the quantized scale = multiplier and shift.
-  computeMultiplierAndShift(opTensorScale, multiplier, shift, 32);
+  if (!computeMultiplierAndShift(opTensorScale, multiplier, shift, 32))
+    return failure();
 
   bool input_unsigned =
       newTosaConv2DOp.getResult().getType().isUnsignedInteger();


### PR DESCRIPTION
* mlir::tosa::computeMultiplierAndShift returns a boolean, depending on validity of the shift value
