### PR TITLE
[CSSPGO] Fix redundant reading of profile metadata

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProfReader.h
+++ b/llvm/include/llvm/ProfileData/SampleProfReader.h
@@ -777,7 +777,7 @@ protected:
   std::error_code readSecHdrTable();
 
   std::error_code readFuncMetadata(bool ProfileHasAttribute,
-                                   SampleProfileMap &Profiles);
+                                   DenseSet<FunctionSamples *> &Profiles);
   std::error_code readFuncMetadata(bool ProfileHasAttribute);
   std::error_code readFuncMetadata(bool ProfileHasAttribute,
                                    FunctionSamples *FProfile);

--- a/llvm/lib/ProfileData/SampleProfReader.cpp
+++ b/llvm/lib/ProfileData/SampleProfReader.cpp
@@ -831,8 +831,15 @@ SampleProfileReaderExtBinaryBase::read(const DenseSet<StringRef> &FuncsToUse,
   if (std::error_code EC = readFuncProfiles(FuncsToUse, Profiles))
     return EC;
   End = Data;
+  DenseSet<FunctionSamples *> ProfilesToReadMetadata;
+  for (auto FName : FuncsToUse) {
+    auto I = Profiles.find(FName);
+    if (I != Profiles.end())
+      ProfilesToReadMetadata.insert(&I->second);
+  }
 
-  if (std::error_code EC = readFuncMetadata(ProfileHasAttribute, Profiles))
+  if (std::error_code EC =
+          readFuncMetadata(ProfileHasAttribute, ProfilesToReadMetadata))
     return EC;
   return sampleprof_error::success;
 }
@@ -1300,14 +1307,12 @@ SampleProfileReaderExtBinaryBase::readFuncMetadata(bool ProfileHasAttribute,
   return sampleprof_error::success;
 }
 
-std::error_code
-SampleProfileReaderExtBinaryBase::readFuncMetadata(bool ProfileHasAttribute,
-                                                   SampleProfileMap &Profiles) {
+std::error_code SampleProfileReaderExtBinaryBase::readFuncMetadata(
+    bool ProfileHasAttribute, DenseSet<FunctionSamples *> &Profiles) {
   if (FuncMetadataIndex.empty())
     return sampleprof_error::success;
 
-  for (auto &I : Profiles) {
-    FunctionSamples *FProfile = &I.second;
+  for (auto *FProfile : Profiles) {
     auto R = FuncMetadataIndex.find(FProfile->getContext().getHashCode());
     if (R == FuncMetadataIndex.end())
       continue;

--- a/llvm/lib/ProfileData/SampleProfReader.cpp
+++ b/llvm/lib/ProfileData/SampleProfReader.cpp
@@ -826,6 +826,9 @@ bool SampleProfileReaderExtBinaryBase::useFuncOffsetList() const {
 std::error_code
 SampleProfileReaderExtBinaryBase::read(const DenseSet<StringRef> &FuncsToUse,
                                        SampleProfileMap &Profiles) {
+  if (FuncsToUse.empty())
+    return sampleprof_error::success;
+
   Data = ProfileSecRange.first;
   End = ProfileSecRange.second;
   if (std::error_code EC = readFuncProfiles(FuncsToUse, Profiles))


### PR DESCRIPTION
Fix a build speed regression due to repeated reading of profile metadata. Before the function `readFuncMetadata(ProfileHasAttribute, Profiles)` reads the metadata for all the functions(`Profiles`), however, it's actually used for on-demand loading, it can be called for multiple times, which leads to redundant reading that causes the build speed regression. Now fix it to read the metadata only for the new loaded functions(functions in the `FuncsToUse`). 