### PR TITLE
[win] Fix EH Cont Guard targets when SEH personality is used

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/WinException.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/WinException.cpp
@@ -290,6 +290,12 @@ void WinException::endFuncletImpl() {
       // functions that need it in the end anyway.
     }
 
+    if (!MF->getEHContTargets().empty()) {
+      // Copy the function's EH Continuation targets to a module-level list.
+      EHContTargets.insert(EHContTargets.end(), MF->getEHContTargets().begin(),
+                           MF->getEHContTargets().end());
+    }
+
     // Switch back to the funclet start .text section now that we are done
     // writing to .xdata, and emit an .seh_endproc directive to mark the end of
     // the function.

--- a/llvm/test/CodeGen/AArch64/arm64ec-eh.ll
+++ b/llvm/test/CodeGen/AArch64/arm64ec-eh.ll
@@ -22,7 +22,6 @@ define dso_local i32 @test() #0 personality ptr @__C_specific_handler {
 ; CHECK-NEXT:    bl      "#ext"
 ; CHECK-NEXT:  .Ltmp1:
 ; CHECK-NEXT:  .LBB0_1:
-; CHECK-NEXT:  $ehgcr_0_1:
 ; CHECK-NEXT:    stur    w0, [x29, #-4]
 ; CHECK-NEXT:    .seh_startepilogue
 ; CHECK-NEXT:    ldp     x29, x30, [sp, #16]             // 16-byte Folded Reload
@@ -32,6 +31,7 @@ define dso_local i32 @test() #0 personality ptr @__C_specific_handler {
 ; CHECK-NEXT:    .seh_endepilogue
 ; CHECK-NEXT:    ret
 ; CHECK-NEXT:  .LBB0_2:
+; CHECK-NEXT:  $ehgcr_0_2:
 ; CHECK-NEXT:    mov     w0, wzr
 ; CHECK-NEXT:    b       .LBB0_1
   %1 = alloca i32, align 4

--- a/llvm/test/CodeGen/AArch64/landingpad-ifcvt.ll
+++ b/llvm/test/CodeGen/AArch64/landingpad-ifcvt.ll
@@ -2,6 +2,7 @@
 
 ; Make sure this doesn't crash (and the output is sane).
 ; CHECK: // %__except.ret
+; CHECK-NEXT: $ehgcr_0_2:
 ; CHECK-NEXT: mov     x0, xzr
 
 target datalayout = "e-m:w-p:64:64-i32:32-i64:64-i128:128-n32:64-S128"

--- a/llvm/test/CodeGen/X86/seh-except-restore.ll
+++ b/llvm/test/CodeGen/X86/seh-except-restore.ll
@@ -48,6 +48,7 @@ return:                                           ; preds = %entry, %__except
 ; CHECK: LBB0_2:                                 # %return
 
 ; CHECK: LBB0_1:                                 # %__except.ret
+; CHECK-NEXT:         $ehgcr_0_1:
 ; CHECK-NEXT:         movl    -24(%ebp), %esp
 ; CHECK-NEXT:         addl    $12, %ebp
 

--- a/llvm/test/CodeGen/X86/win32-seh-catchpad.ll
+++ b/llvm/test/CodeGen/X86/win32-seh-catchpad.ll
@@ -196,6 +196,7 @@ __except:
 
 ; CHECK-LABEL: _code_in_catchpad:
 ; CHECK: # %__except.ret
+; CHECK-NEXT:         $ehgcr_4_1:
 ; CHECK-NEXT:         movl    -24(%ebp), %esp
 ; CHECK-NEXT:         addl    $12, %ebp
 ; CHECK-NEXT:         movl    $-1, -16(%ebp)


### PR DESCRIPTION
There were two issues when `/guard:ehcont` is enabled with the SEH personality on Windows:
1. As @namazso correctly identified, we bail out of `WinException::endFunction` early for `MSVC_TableSEH` with funclets, expecting the exception data to be emitted in `endFunclet`, but `endFunclet` didn't copy the EHCont metadata from the function to the module.
2. The SEH personality requires that the basic block containing the `catchpad` is the target, not the `catchret`.

Fixes #64585 