### PR TITLE
[libc][bazel] Add BUILD targets for complex functions and tests.

### DIFF
--- a/libc/utils/MPCWrapper/CMakeLists.txt
+++ b/libc/utils/MPCWrapper/CMakeLists.txt
@@ -2,6 +2,7 @@ if(LIBC_TESTS_CAN_USE_MPC)
   add_library(libcMPCWrapper STATIC
     MPCUtils.cpp
     MPCUtils.h
+    mpc_inc.h
   )
   _get_common_test_compile_options(compile_options "" "")
   list(REMOVE_ITEM compile_options "-ffreestanding")

--- a/libc/utils/MPCWrapper/MPCUtils.cpp
+++ b/libc/utils/MPCWrapper/MPCUtils.cpp
@@ -10,8 +10,8 @@
 
 #include "src/__support/CPP/array.h"
 #include "src/__support/CPP/stringstream.h"
-#include "utils/MPFRWrapper/MPCommon.h"
 #include "utils/MPCWrapper/mpc_inc.h"
+#include "utils/MPFRWrapper/MPCommon.h"
 
 #include <stdint.h>
 

--- a/libc/utils/MPCWrapper/MPCUtils.cpp
+++ b/libc/utils/MPCWrapper/MPCUtils.cpp
@@ -11,10 +11,9 @@
 #include "src/__support/CPP/array.h"
 #include "src/__support/CPP/stringstream.h"
 #include "utils/MPFRWrapper/MPCommon.h"
+#include "utils/MPCWrapper/mpc_inc.h"
 
 #include <stdint.h>
-
-#include "mpc.h"
 
 template <typename T> using FPBits = LIBC_NAMESPACE::fputil::FPBits<T>;
 

--- a/libc/utils/MPCWrapper/mpc_inc.h
+++ b/libc/utils/MPCWrapper/mpc_inc.h
@@ -1,0 +1,23 @@
+//===-- MPCUtils.h ----------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_UTILS_MPCWRAPPER_MPC_INC_H
+#define LLVM_LIBC_UTILS_MPCWRAPPER_MPC_INC_H
+
+#ifdef CUSTOM_MPC_INCLUDER
+// Some downstream repos are monoliths carrying MPC sources in their third
+// party directory. In such repos, including the MPC header as
+// `#include <mpc.h>` is either disallowed or not possible. If that is the
+// case, a file named `CustomMPCIncluder.h` should be added through which the
+// MPC header can be included in manner allowed in that repo.
+#include "CustomMPCIncluder.h"
+#else
+#include <mpc.h>
+#endif
+
+#endif // LLVM_LIBC_UTILS_MPCWRAPPER_MPC_INC_H

--- a/utils/bazel/WORKSPACE
+++ b/utils/bazel/WORKSPACE
@@ -128,6 +128,15 @@ maybe(
 
 maybe(
     http_archive,
+    name = "mpc",
+    build_file = "@llvm-raw//utils/bazel/third_party_build:mpc.BUILD",
+    sha256 = "ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8",
+    strip_prefix = "mpc-1.3.1",
+    urls = ["https://ftp.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz"],
+)
+
+maybe(
+    http_archive,
     name = "pfm",
     build_file = "@llvm-raw//utils/bazel/third_party_build:pfm.BUILD",
     sha256 = "d18b97764c755528c1051d376e33545d0eb60c6ebf85680436813fa5b04cc3d1",

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -52,6 +52,34 @@ config_setting(
     flag_values = {":mpfr": "system"},
 )
 
+# A flag to pick which `mpc` to use for math tests.
+# Usage: `--@llvm-project//libc:mpc=<disable|external|system>`.
+# Flag documentation: https://bazel.build/extending/config
+string_flag(
+    name = "mpc",
+    build_setting_default = "external",
+    values = [
+        "disable",  # Skip tests that need mpc
+        "external",  # Build mpc from source
+        "system",  # Use system mpc (non hermetic)
+    ],
+)
+
+config_setting(
+    name = "mpc_disable",
+    flag_values = {":mpc": "disable"},
+)
+
+config_setting(
+    name = "mpc_external",
+    flag_values = {":mpc": "external"},
+)
+
+config_setting(
+    name = "mpc_system",
+    flag_values = {":mpc": "system"},
+)
+
 ########################### Header Generation ##################################
 
 py_binary(
@@ -862,6 +890,26 @@ libc_support_library(
         ":__support_str_to_num_result",
         ":__support_uint128",
         ":errno",
+    ],
+)
+
+libc_support_library(
+    name = "__support_complex_type",
+    hdrs = ["src/__support/complex_type.h"],
+    deps = [
+        ":__support_macros_config",
+        ":__support_macros_properties_complex_types",
+        ":__support_macros_properties_types",
+    ],
+)
+
+libc_support_library(
+    name = "__support_complex_basic_ops",
+    hdrs = ["src/__support/complex_basic_ops.h"],
+    deps = [
+        ":__support_complex_type",
+        ":__support_cpp_bit",
+        ":__support_fputil_fp_bits",
     ],
 )
 
@@ -1887,6 +1935,249 @@ libc_support_library(
         ":__support_fputil_fp_bits",
         ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
+    ],
+)
+
+############################### complex targets ################################
+
+libc_function(
+    name = "cimag",
+    srcs = ["src/complex/generic/cimag.cpp"],
+    hdrs = ["src/complex/cimag.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_type",
+        ":__support_cpp_bit",
+        ":__support_macros_config",
+    ],
+)
+
+libc_function(
+    name = "cimagf",
+    srcs = ["src/complex/generic/cimagf.cpp"],
+    hdrs = ["src/complex/cimagf.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_type",
+        ":__support_cpp_bit",
+        ":__support_macros_config",
+    ],
+)
+
+libc_function(
+    name = "cimagf128",
+    srcs = ["src/complex/generic/cimagf128.cpp"],
+    hdrs = ["src/complex/cimagf128.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_type",
+        ":__support_cpp_bit",
+        ":__support_macros_config",
+        ":__support_macros_properties_complex_types",
+        ":__support_macros_properties_types",
+    ],
+)
+
+libc_function(
+    name = "cimagf16",
+    srcs = ["src/complex/generic/cimagf16.cpp"],
+    hdrs = ["src/complex/cimagf16.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_type",
+        ":__support_cpp_bit",
+        ":__support_macros_config",
+        ":__support_macros_properties_complex_types",
+        ":__support_macros_properties_types",
+    ],
+)
+
+libc_function(
+    name = "cimagl",
+    srcs = ["src/complex/generic/cimagl.cpp"],
+    hdrs = ["src/complex/cimagl.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_type",
+        ":__support_cpp_bit",
+        ":__support_macros_config",
+    ],
+)
+
+libc_function(
+    name = "conj",
+    srcs = ["src/complex/generic/conj.cpp"],
+    hdrs = ["src/complex/conj.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_basic_ops",
+        ":__support_macros_config",
+    ],
+)
+
+libc_function(
+    name = "conjf",
+    srcs = ["src/complex/generic/conjf.cpp"],
+    hdrs = ["src/complex/conjf.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_basic_ops",
+        ":__support_macros_config",
+    ],
+)
+
+libc_function(
+    name = "conjf128",
+    srcs = ["src/complex/generic/conjf128.cpp"],
+    hdrs = ["src/complex/conjf128.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_basic_ops",
+        ":__support_macros_config",
+        ":__support_macros_properties_complex_types",
+    ],
+)
+
+libc_function(
+    name = "conjf16",
+    srcs = ["src/complex/generic/conjf16.cpp"],
+    hdrs = ["src/complex/conjf16.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_basic_ops",
+        ":__support_cpp_bit",
+        ":__support_macros_config",
+        ":__support_macros_properties_complex_types",
+    ],
+)
+
+libc_function(
+    name = "conjl",
+    srcs = ["src/complex/generic/conjl.cpp"],
+    hdrs = ["src/complex/conjl.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_basic_ops",
+        ":__support_macros_config",
+    ],
+)
+
+libc_function(
+    name = "cproj",
+    srcs = ["src/complex/generic/cproj.cpp"],
+    hdrs = ["src/complex/cproj.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_basic_ops",
+        ":__support_macros_config",
+    ],
+)
+
+libc_function(
+    name = "cprojf",
+    srcs = ["src/complex/generic/cprojf.cpp"],
+    hdrs = ["src/complex/cprojf.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_basic_ops",
+        ":__support_macros_config",
+    ],
+)
+
+libc_function(
+    name = "cprojf128",
+    srcs = ["src/complex/generic/cprojf128.cpp"],
+    hdrs = ["src/complex/cprojf128.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_basic_ops",
+        ":__support_macros_config",
+        ":__support_macros_properties_complex_types",
+    ],
+)
+
+libc_function(
+    name = "cprojf16",
+    srcs = ["src/complex/generic/cprojf16.cpp"],
+    hdrs = ["src/complex/cprojf16.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_basic_ops",
+        ":__support_macros_config",
+        ":__support_macros_properties_complex_types",
+    ],
+)
+
+libc_function(
+    name = "cprojl",
+    srcs = ["src/complex/generic/cprojl.cpp"],
+    hdrs = ["src/complex/cprojl.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_basic_ops",
+        ":__support_macros_config",
+    ],
+)
+
+libc_function(
+    name = "creal",
+    srcs = ["src/complex/generic/creal.cpp"],
+    hdrs = ["src/complex/creal.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_type",
+        ":__support_cpp_bit",
+        ":__support_macros_config",
+    ],
+)
+
+libc_function(
+    name = "crealf",
+    srcs = ["src/complex/generic/crealf.cpp"],
+    hdrs = ["src/complex/crealf.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_type",
+        ":__support_cpp_bit",
+        ":__support_macros_config",
+    ],
+)
+
+libc_function(
+    name = "crealf128",
+    srcs = ["src/complex/generic/crealf128.cpp"],
+    hdrs = ["src/complex/crealf128.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_type",
+        ":__support_cpp_bit",
+        ":__support_macros_config",
+        ":__support_macros_properties_complex_types",
+    ],
+)
+
+libc_function(
+    name = "crealf16",
+    srcs = ["src/complex/generic/crealf16.cpp"],
+    hdrs = ["src/complex/crealf16.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_type",
+        ":__support_cpp_bit",
+        ":__support_macros_config",
+        ":__support_macros_properties_complex_types",
+    ],
+)
+
+libc_function(
+    name = "creall",
+    srcs = ["src/complex/generic/creall.cpp"],
+    hdrs = ["src/complex/creall.h"],
+    deps = [
+        ":__support_common",
+        ":__support_complex_type",
+        ":__support_cpp_bit",
+        ":__support_macros_config",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/test/src/complex/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/complex/BUILD.bazel
@@ -1,0 +1,89 @@
+load("//libc/test:libc_test_rules.bzl", "libc_test")
+
+[
+    libc_test(
+        name = func_name + "_test",
+        srcs = [
+            "CImagTest.h",
+            func_name + "_test.cpp",
+        ],
+        libc_function_deps = ["//libc:func_name".replace("func_name", func_name)],
+        deps = [
+            "//libc:hdr_math_macros",
+            "//libc/test/UnitTest:fp_test_helpers",
+        ],
+    )
+    for func_name in [
+        "cimag",
+        "cimagf",
+        "cimagl",
+        "cimagf128",
+        "cimagf16",
+    ]
+]
+
+[
+    libc_test(
+        name = func_name + "_test",
+        srcs = [
+            "ConjTest.h",
+            func_name + "_test.cpp",
+        ],
+        libc_function_deps = ["//libc:func_name".replace("func_name", func_name)],
+        deps = [
+            "//libc:hdr_math_macros",
+            "//libc/test/UnitTest:fp_test_helpers",
+        ],
+    )
+    for func_name in [
+        "conj",
+        "conjf",
+        "conjl",
+        "conjf128",
+        "conjf16",
+    ]
+]
+
+[
+    libc_test(
+        name = func_name + "_test",
+        srcs = [
+            "CprojTest.h",
+            func_name + "_test.cpp",
+        ],
+        libc_function_deps = ["//libc:func_name".replace("func_name", func_name)],
+        deps = [
+            "//libc:hdr_math_macros",
+            "//libc/test/UnitTest:fp_test_helpers",
+        ] + (["//libc/utils/MPCWrapper:mpc_wrapper"] if func_name == "cprojf" else []),
+    )
+    for func_name in [
+        "cproj",
+        "cprojf",
+        "cprojl",
+        "cprojf128",
+        "cprojf16",
+    ]
+]
+
+[
+    libc_test(
+        name = func_name + "_test",
+        srcs = [
+            "CRealTest.h",
+            func_name + "_test.cpp",
+        ],
+        libc_function_deps = ["//libc:func_name".replace("func_name", func_name)],
+        deps = [
+            "//libc:hdr_math_macros",
+            "//libc/test/UnitTest:fp_test_helpers",
+        ],
+    )
+    for func_name in [
+        "creal",
+        "crealf",
+        "creall",
+        "crealf128",
+        "crealf16",
+    ]
+]

--- a/utils/bazel/llvm-project-overlay/libc/utils/MPCWrapper/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/utils/MPCWrapper/BUILD.bazel
@@ -1,0 +1,59 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# A wrapper library over MPC for use with LLVM libc math unittests.
+
+load("//libc:libc_build_rules.bzl", "libc_support_library")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+cc_library(
+    name = "mpc_impl",
+    hdrs = ["mpc_inc.h"],
+    target_compatible_with = select({
+        "//conditions:default": [],
+        "//libc:mpc_disable": ["@platforms//:incompatible"],
+    }),
+    deps = select(
+        {
+            "//conditions:default": [],
+            "//libc:mpc_external": ["@mpc//:mpc_external"],
+            "//libc:mpc_system": ["@mpc//:mpc_system"],
+        },
+    ),
+)
+
+libc_support_library(
+    name = "mpc_wrapper",
+    srcs = ["MPCUtils.cpp"],
+    hdrs = ["MPCUtils.h"],
+    # Disable layering check when using mpc_system.
+    features = select(
+        {
+            "//conditions:default": [],
+            "//libc:mpc_system": ["-layering_check"],
+        },
+    ),
+    target_compatible_with = select({
+        "//conditions:default": [],
+        "//libc:mpc_disable": ["@platforms//:incompatible"],
+    }),
+    deps = [
+        ":mpc_impl",
+        "//libc:__support_complex_type",
+        "//libc:__support_cpp_array",
+        "//libc:__support_cpp_stringstream",
+        "//libc:__support_cpp_type_traits",
+        "//libc:__support_macros_config",
+        "//libc:__support_macros_properties_complex_types",
+        "//libc:__support_macros_properties_types",
+        "//libc:hdr_math_macros",
+        "//libc/test/UnitTest:LibcUnitTest",
+        "//libc/test/UnitTest:fp_test_helpers",
+        "//libc/utils/MPFRWrapper:mp_common",
+        "//libc/utils/MPFRWrapper:mpfr_wrapper",
+    ],
+)

--- a/utils/bazel/third_party_build/mpc.BUILD
+++ b/utils/bazel/third_party_build/mpc.BUILD
@@ -1,0 +1,33 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make_variant")
+
+filegroup(
+    name = "sources",
+    srcs = glob(["**"]),
+)
+
+configure_make_variant(
+    name = "mpc",
+    configure_options = ["--with-pic"],
+    copts = ["-w"],
+    lib_name = "libmpc",
+    lib_source = ":sources",
+    toolchain = "@rules_foreign_cc//toolchains:preinstalled_autoconf_toolchain",
+    visibility = ["//visibility:public"],
+    deps = ["@mpfr//:mpfr_"],
+)
+
+alias(
+    name = "mpc_external",
+    actual = "@mpc//:mpc_",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "mpc_system",
+    linkopts = ["-lmpc"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This involved a little bit of yak shaving because one of the new tests depends on MPC, and we didn't have targets for it yet, so I ended up needing to add a similar setup to what we have for MPFR.