### PR TITLE
[compiler-rt][ubsan] Add support for f16

### DIFF
--- a/compiler-rt/lib/ubsan/ubsan_value.cpp
+++ b/compiler-rt/lib/ubsan/ubsan_value.cpp
@@ -120,15 +120,11 @@ FloatMax Value::getFloatValue() const {
   CHECK(getType().isFloatTy());
   if (isInlineFloat()) {
     switch (getType().getFloatBitWidth()) {
-#if 0
-      // FIXME: OpenCL / NEON 'half' type. LLVM can't lower the conversion
-      //        from '__fp16' to 'long double'.
-      case 16: {
-        __fp16 Value;
-        internal_memcpy(&Value, &Val, 4);
-        return Value;
-      }
-#endif
+    case 16: {
+      __fp16 Value;
+      internal_memcpy(&Value, &Val, 2);
+      return Value;
+    }
       case 32: {
         float Value;
 #if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
@@ -146,7 +142,7 @@ FloatMax Value::getFloatValue() const {
         internal_memcpy(&Value, &Val, 8);
         return Value;
       }
-    }
+      }
   } else {
     switch (getType().getFloatBitWidth()) {
     case 64: return *reinterpret_cast<double*>(Val);

--- a/compiler-rt/test/ubsan/TestCases/Float/cast-overflow.cpp
+++ b/compiler-rt/test/ubsan/TestCases/Float/cast-overflow.cpp
@@ -8,6 +8,7 @@
 // RUN: %run %t 5 2>&1 | FileCheck %s --check-prefix=CHECK-5
 // RUN: %run %t 6 2>&1 | FileCheck %s --check-prefix=CHECK-6
 // RUN: %run %t 7 2>&1 | FileCheck %s --check-prefix=CHECK-7
+// RUN: %run %t 8 2>&1 | FileCheck %s --check-prefix=CHECK-8
 
 // Issue #41838
 // XFAIL: sparc-target-arch && target={{.*solaris.*}}
@@ -132,12 +133,17 @@ int main(int argc, char **argv) {
   }
   case '5': {
     // CHECK-5: {{.*}}cast-overflow.cpp:[[@LINE+1]]:27: runtime error: {{.*}} is outside the range of representable values of type 'int'
+    static int test_int = (__fp16)Inf;
+    return 0;
+  }
+  case '6': {
+    // CHECK-6: {{.*}}cast-overflow.cpp:[[@LINE+1]]:27: runtime error: {{.*}} is outside the range of representable values of type 'int'
     static int test_int = NaN;
     return 0;
   }
   // Integer -> floating point overflow.
-  case '6': {
-    // CHECK-6: cast-overflow.cpp:[[@LINE+2]]:{{27: runtime error: 3.40282e\+38 is outside the range of representable values of type 'int'| __int128 not supported}}
+  case '7': {
+    // CHECK-7: cast-overflow.cpp:[[@LINE+2]]:{{27: runtime error: 3.40282e\+38 is outside the range of representable values of type 'int'| __int128 not supported}}
 #if defined(__SIZEOF_INT128__) && !defined(_WIN32)
     static int test_int = (float)(FloatMaxAsUInt128 + 1);
     return 0;
@@ -148,9 +154,9 @@ int main(int argc, char **argv) {
     return 0;
 #endif
   }
-  case '7': {
+  case '8': {
     volatile long double ld = 300.0;
-    // CHECK-7: {{.*}}cast-overflow.cpp:[[@LINE+1]]:14: runtime error: 300 is outside the range of representable values of type 'char'
+    // CHECK-8: {{.*}}cast-overflow.cpp:[[@LINE+1]]:14: runtime error: 300 is outside the range of representable values of type 'char'
     char c = ld;
     // `c` is allowed to contain UNDEF, thus we should not use
     // its value as an exit code.


### PR DESCRIPTION
LLVM  supports long double <-> f16 conversions so we can remove the old FIXME.
