### PR TITLE
Convert unreachable return statement into llvm_unreachable

### DIFF
--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -5329,7 +5329,7 @@ llvm::Error ASTReader::ReadExtensionBlock(ModuleFile &F) {
     }
   }
 
-  return llvm::Error::success();
+  llvm_unreachable("ReadExtensionBlock should return from while loop");
 }
 
 void ASTReader::InitializeContext() {


### PR DESCRIPTION
Static analysis flags the final return statement in `ReadExtensionBlock` as unreachable and indeed it is since there is no way to exit the `while(true)` loop besides a *return statement*.

So I am converting it into a `llvm_unreachable` to explicitly document this.
