### PR TITLE
[mlir] add StringRef override for FunctionOpInterface::removeResultAttr

### DIFF
--- a/mlir/include/mlir/Interfaces/FunctionInterfaces.td
+++ b/mlir/include/mlir/Interfaces/FunctionInterfaces.td
@@ -539,6 +539,10 @@ def FunctionOpInterface : OpInterface<"FunctionOpInterface", [
     ::mlir::Attribute removeResultAttr(unsigned index, ::mlir::StringAttr name) {
       return ::mlir::function_interface_impl::removeResultAttr($_op, index, name);
     }
+    ::mlir::Attribute removeResultAttr(unsigned index, ::llvm::StringRef name) {
+      return removeResultAttr(
+          index, ::mlir::StringAttr::get(this->getOperation()->getContext(), name));
+    }
 
     /// Returns the dictionary attribute corresponding to the argument at
     /// 'index'. If there are no argument attributes at 'index', a null


### PR DESCRIPTION
A mirror of the corresponding overload for `removeArgAttr(unsigned index, ::llvm::StringRef name)` [here](https://github.com/llvm/llvm-project/blob/41473162fd886d7db548fb288cf3620570f73c17/mlir/include/mlir/Interfaces/FunctionInterfaces.td#L451-L454)