### PR TITLE
[GVN][NFC] Remove unnecessary assembly output from test

### DIFF
--- a/llvm/test/Transforms/GVN/opt-remarks.ll
+++ b/llvm/test/Transforms/GVN/opt-remarks.ll
@@ -1,11 +1,11 @@
-; RUN: opt < %s -passes=gvn -o /dev/null  -S -pass-remarks=gvn -pass-remarks-missed=gvn  \
+; RUN: opt < %s -passes=gvn -disable-output -pass-remarks=gvn -pass-remarks-missed=gvn  \
 ; RUN:     2>&1 | FileCheck %s
-; RUN: opt < %s -passes=gvn -o /dev/null  -pass-remarks-output=%t -S
+; RUN: opt < %s -passes=gvn -disable-output -pass-remarks-output=%t -S
 ; RUN: cat %t | FileCheck -check-prefix=YAML %s
 
-; RUN: opt < %s -aa-pipeline=basic-aa -passes=gvn -o /dev/null -S -pass-remarks=gvn -pass-remarks-missed=gvn \
+; RUN: opt < %s -aa-pipeline=basic-aa -passes=gvn -disable-output -pass-remarks=gvn -pass-remarks-missed=gvn \
 ; RUN:     2>&1 | FileCheck %s
-; RUN: opt < %s -aa-pipeline=basic-aa -passes=gvn -o /dev/null -pass-remarks-output=%t -S
+; RUN: opt < %s -aa-pipeline=basic-aa -passes=gvn -disable-output -pass-remarks-output=%t -S
 ; RUN: cat %t | FileCheck -check-prefix=YAML %s
 
 ; CHECK:      remark: <unknown>:0:0: load of type i32 eliminated{{$}}


### PR DESCRIPTION
This test doesn't check any output from opt, so it can be safely `disable-output` and thus less redirections.