### PR TITLE
[X86][NFC] Updated POW/EXP*/LOG* functions testcases

### DIFF
--- a/llvm/test/CodeGen/X86/exp10-libcall-names.ll
+++ b/llvm/test/CodeGen/X86/exp10-libcall-names.ll
@@ -10,13 +10,15 @@
 ; RUN: llc -mtriple=x86_64-apple-xros8.0 < %s | FileCheck -check-prefix=APPLE %s
 ; RUN: llc -mtriple=x86_64-apple-driverkit < %s | FileCheck -check-prefix=APPLE %s
 ; RUN: llc -mtriple=x86_64-apple-driverkit24.0 < %s | FileCheck -check-prefix=APPLE %s
+; RUN: llc < %s -mtriple=i686-linux-gnu -global-isel -global-isel-abort=2 | FileCheck %s --check-prefix=GISEL-X86
+; RUN: llc < %s -mtriple=x86_64-linux-gnu -global-isel -global-isel-abort=2 | FileCheck %s --check-prefix=GISEL-X64
 
 ; RUN: not llc -mtriple=x86_64-apple-macos10.8 -filetype=null %s 2>&1 | FileCheck -check-prefix=ERR %s
 ; Check exp10/exp10f is emitted as __exp10/__exp10f on assorted systems.
 
 ; ERR: no libcall available for fexp10
 
-define float @test_exp10_f32(float %x) {
+define float @test_exp10_f32(float %x) nounwind {
 ; LINUX-LABEL: test_exp10_f32:
 ; LINUX:       # %bb.0:
 ; LINUX-NEXT:    jmp exp10f@PLT # TAILCALL
@@ -25,15 +27,23 @@ define float @test_exp10_f32(float %x) {
 ; APPLE:       ## %bb.0:
 ; APPLE-NEXT:    jmp ___exp10f ## TAILCALL
 ;
-; MISSED-LABEL: test_exp10_f32:
-; MISSED:       ## %bb.0:
-; MISSED-NEXT:    jmp _exp10f ## TAILCALL
-
+; GISEL-X86-LABEL: test_exp10_f32:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    flds {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstps (%esp)
+; GISEL-X86-NEXT:    calll exp10f
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: test_exp10_f32:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    jmp exp10f@PLT # TAILCALL
   %ret = call float @llvm.exp10.f32(float %x)
   ret float %ret
 }
 
-define double @test_exp10_f64(double %x) {
+define double @test_exp10_f64(double %x) nounwind {
 ; LINUX-LABEL: test_exp10_f64:
 ; LINUX:       # %bb.0:
 ; LINUX-NEXT:    jmp exp10@PLT # TAILCALL
@@ -42,10 +52,58 @@ define double @test_exp10_f64(double %x) {
 ; APPLE:       ## %bb.0:
 ; APPLE-NEXT:    jmp ___exp10 ## TAILCALL
 ;
-; MISSED-LABEL: test_exp10_f64:
-; MISSED:       ## %bb.0:
-; MISSED-NEXT:    jmp _exp10 ## TAILCALL
+; GISEL-X86-LABEL: test_exp10_f64:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    fldl {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstpl (%esp)
+; GISEL-X86-NEXT:    calll exp10
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
 ;
+; GISEL-X64-LABEL: test_exp10_f64:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    jmp exp10@PLT # TAILCALL
   %ret = call double @llvm.exp10.f64(double %x)
   ret double %ret
+}
+
+define x86_fp80 @test_exp10_f80(x86_fp80 %x) nounwind {
+; LINUX-LABEL: test_exp10_f80:
+; LINUX:       # %bb.0:
+; LINUX-NEXT:    subq $24, %rsp
+; LINUX-NEXT:    fldt {{[0-9]+}}(%rsp)
+; LINUX-NEXT:    fstpt (%rsp)
+; LINUX-NEXT:    callq exp10l@PLT
+; LINUX-NEXT:    addq $24, %rsp
+; LINUX-NEXT:    retq
+;
+; APPLE-LABEL: test_exp10_f80:
+; APPLE:       ## %bb.0:
+; APPLE-NEXT:    subq $24, %rsp
+; APPLE-NEXT:    fldt {{[0-9]+}}(%rsp)
+; APPLE-NEXT:    fstpt (%rsp)
+; APPLE-NEXT:    callq _exp10l
+; APPLE-NEXT:    addq $24, %rsp
+; APPLE-NEXT:    retq
+;
+; GISEL-X86-LABEL: test_exp10_f80:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstpt (%esp)
+; GISEL-X86-NEXT:    calll exp10l
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: test_exp10_f80:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    subq $24, %rsp
+; GISEL-X64-NEXT:    fldt {{[0-9]+}}(%rsp)
+; GISEL-X64-NEXT:    fstpt (%rsp)
+; GISEL-X64-NEXT:    callq exp10l@PLT
+; GISEL-X64-NEXT:    addq $24, %rsp
+; GISEL-X64-NEXT:    retq
+  %ret = call x86_fp80 @llvm.exp10.f80(x86_fp80 %x)
+  ret x86_fp80 %ret
 }

--- a/llvm/test/CodeGen/X86/finite-libcalls.ll
+++ b/llvm/test/CodeGen/X86/finite-libcalls.ll
@@ -2,6 +2,8 @@
 ; RUN: llc < %s -mtriple=x86_64-pc-linux-gnu     | FileCheck %s --check-prefix=GNU
 ; RUN: llc < %s -mtriple=x86_64-pc-windows-msvc  | FileCheck %s --check-prefix=WIN
 ; RUN: llc < %s -mtriple=x86_64-apple-darwin     | FileCheck %s --check-prefix=MAC
+; RUN: llc < %s -mtriple=i686-linux-gnu -global-isel -global-isel-abort=2 | FileCheck %s --check-prefixes=GISEL-X86
+; RUN: llc < %s -mtriple=x86_64-linux-gnu -global-isel -global-isel-abort=2 | FileCheck %s --check-prefixes=GISEL-X64
 
 ; PR35672 - https://bugs.llvm.org/show_bug.cgi?id=35672
 ; FIXME: We would not need the function-level attributes if FMF were propagated to DAG nodes for this case.
@@ -18,6 +20,19 @@ define float @exp_f32(float %x) #0 {
 ; MAC-LABEL: exp_f32:
 ; MAC:       ## %bb.0:
 ; MAC-NEXT:    jmp _expf ## TAILCALL
+;
+; GISEL-X86-LABEL: exp_f32:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    flds {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstps (%esp)
+; GISEL-X86-NEXT:    calll expf
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: exp_f32:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    jmp expf@PLT # TAILCALL
   %r = tail call nnan ninf float @llvm.exp.f32(float %x)
   ret float %r
 }
@@ -34,6 +49,19 @@ define double @exp_f64(double %x) #0 {
 ; MAC-LABEL: exp_f64:
 ; MAC:       ## %bb.0:
 ; MAC-NEXT:    jmp _exp ## TAILCALL
+;
+; GISEL-X86-LABEL: exp_f64:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    fldl {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstpl (%esp)
+; GISEL-X86-NEXT:    calll exp
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: exp_f64:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    jmp exp@PLT # TAILCALL
   %r = tail call nnan ninf double @llvm.exp.f64(double %x)
   ret double %r
 }
@@ -73,6 +101,24 @@ define x86_fp80 @exp_f80(x86_fp80 %x) #0 {
 ; MAC-NEXT:    callq _expl
 ; MAC-NEXT:    addq $24, %rsp
 ; MAC-NEXT:    retq
+;
+; GISEL-X86-LABEL: exp_f80:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstpt (%esp)
+; GISEL-X86-NEXT:    calll expl
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: exp_f80:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    subq $24, %rsp
+; GISEL-X64-NEXT:    fldt {{[0-9]+}}(%rsp)
+; GISEL-X64-NEXT:    fstpt (%rsp)
+; GISEL-X64-NEXT:    callq expl@PLT
+; GISEL-X64-NEXT:    addq $24, %rsp
+; GISEL-X64-NEXT:    retq
   %r = tail call nnan ninf x86_fp80 @llvm.exp.f80(x86_fp80 %x)
   ret x86_fp80 %r
 }
@@ -89,6 +135,19 @@ define float @exp2_f32(float %x) #0 {
 ; MAC-LABEL: exp2_f32:
 ; MAC:       ## %bb.0:
 ; MAC-NEXT:    jmp _exp2f ## TAILCALL
+;
+; GISEL-X86-LABEL: exp2_f32:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    flds {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstps (%esp)
+; GISEL-X86-NEXT:    calll exp2f
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: exp2_f32:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    jmp exp2f@PLT # TAILCALL
   %r = tail call nnan ninf float @llvm.exp2.f32(float %x)
   ret float %r
 }
@@ -105,6 +164,19 @@ define double @exp2_f64(double %x) #0 {
 ; MAC-LABEL: exp2_f64:
 ; MAC:       ## %bb.0:
 ; MAC-NEXT:    jmp _exp2 ## TAILCALL
+;
+; GISEL-X86-LABEL: exp2_f64:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    fldl {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstpl (%esp)
+; GISEL-X86-NEXT:    calll exp2
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: exp2_f64:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    jmp exp2@PLT # TAILCALL
   %r = tail call nnan ninf double @llvm.exp2.f64(double %x)
   ret double %r
 }
@@ -144,6 +216,24 @@ define x86_fp80 @exp2_f80(x86_fp80 %x) #0 {
 ; MAC-NEXT:    callq _exp2l
 ; MAC-NEXT:    addq $24, %rsp
 ; MAC-NEXT:    retq
+;
+; GISEL-X86-LABEL: exp2_f80:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstpt (%esp)
+; GISEL-X86-NEXT:    calll exp2l
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: exp2_f80:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    subq $24, %rsp
+; GISEL-X64-NEXT:    fldt {{[0-9]+}}(%rsp)
+; GISEL-X64-NEXT:    fstpt (%rsp)
+; GISEL-X64-NEXT:    callq exp2l@PLT
+; GISEL-X64-NEXT:    addq $24, %rsp
+; GISEL-X64-NEXT:    retq
   %r = tail call nnan ninf x86_fp80 @llvm.exp2.f80(x86_fp80 %x)
   ret x86_fp80 %r
 }
@@ -160,6 +250,19 @@ define float @log_f32(float %x) #0 {
 ; MAC-LABEL: log_f32:
 ; MAC:       ## %bb.0:
 ; MAC-NEXT:    jmp _logf ## TAILCALL
+;
+; GISEL-X86-LABEL: log_f32:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    flds {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstps (%esp)
+; GISEL-X86-NEXT:    calll logf
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: log_f32:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    jmp logf@PLT # TAILCALL
   %r = tail call nnan ninf float @llvm.log.f32(float %x)
   ret float %r
 }
@@ -176,6 +279,19 @@ define double @log_f64(double %x) #0 {
 ; MAC-LABEL: log_f64:
 ; MAC:       ## %bb.0:
 ; MAC-NEXT:    jmp _log ## TAILCALL
+;
+; GISEL-X86-LABEL: log_f64:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    fldl {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstpl (%esp)
+; GISEL-X86-NEXT:    calll log
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: log_f64:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    jmp log@PLT # TAILCALL
   %r = tail call nnan ninf double @llvm.log.f64(double %x)
   ret double %r
 }
@@ -215,6 +331,24 @@ define x86_fp80 @log_f80(x86_fp80 %x) #0 {
 ; MAC-NEXT:    callq _logl
 ; MAC-NEXT:    addq $24, %rsp
 ; MAC-NEXT:    retq
+;
+; GISEL-X86-LABEL: log_f80:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstpt (%esp)
+; GISEL-X86-NEXT:    calll logl
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: log_f80:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    subq $24, %rsp
+; GISEL-X64-NEXT:    fldt {{[0-9]+}}(%rsp)
+; GISEL-X64-NEXT:    fstpt (%rsp)
+; GISEL-X64-NEXT:    callq logl@PLT
+; GISEL-X64-NEXT:    addq $24, %rsp
+; GISEL-X64-NEXT:    retq
   %r = tail call nnan ninf x86_fp80 @llvm.log.f80(x86_fp80 %x)
   ret x86_fp80 %r
 }
@@ -231,6 +365,19 @@ define float @log2_f32(float %x) #0 {
 ; MAC-LABEL: log2_f32:
 ; MAC:       ## %bb.0:
 ; MAC-NEXT:    jmp _log2f ## TAILCALL
+;
+; GISEL-X86-LABEL: log2_f32:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    flds {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstps (%esp)
+; GISEL-X86-NEXT:    calll log2f
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: log2_f32:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    jmp log2f@PLT # TAILCALL
   %r = tail call nnan ninf float @llvm.log2.f32(float %x)
   ret float %r
 }
@@ -247,6 +394,19 @@ define double @log2_f64(double %x) #0 {
 ; MAC-LABEL: log2_f64:
 ; MAC:       ## %bb.0:
 ; MAC-NEXT:    jmp _log2 ## TAILCALL
+;
+; GISEL-X86-LABEL: log2_f64:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    fldl {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstpl (%esp)
+; GISEL-X86-NEXT:    calll log2
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: log2_f64:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    jmp log2@PLT # TAILCALL
   %r = tail call nnan ninf double @llvm.log2.f64(double %x)
   ret double %r
 }
@@ -286,6 +446,24 @@ define x86_fp80 @log2_f80(x86_fp80 %x) #0 {
 ; MAC-NEXT:    callq _log2l
 ; MAC-NEXT:    addq $24, %rsp
 ; MAC-NEXT:    retq
+;
+; GISEL-X86-LABEL: log2_f80:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstpt (%esp)
+; GISEL-X86-NEXT:    calll log2l
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: log2_f80:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    subq $24, %rsp
+; GISEL-X64-NEXT:    fldt {{[0-9]+}}(%rsp)
+; GISEL-X64-NEXT:    fstpt (%rsp)
+; GISEL-X64-NEXT:    callq log2l@PLT
+; GISEL-X64-NEXT:    addq $24, %rsp
+; GISEL-X64-NEXT:    retq
   %r = tail call nnan ninf x86_fp80 @llvm.log2.f80(x86_fp80 %x)
   ret x86_fp80 %r
 }
@@ -302,6 +480,19 @@ define float @log10_f32(float %x) #0 {
 ; MAC-LABEL: log10_f32:
 ; MAC:       ## %bb.0:
 ; MAC-NEXT:    jmp _log10f ## TAILCALL
+;
+; GISEL-X86-LABEL: log10_f32:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    flds {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstps (%esp)
+; GISEL-X86-NEXT:    calll log10f
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: log10_f32:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    jmp log10f@PLT # TAILCALL
   %r = tail call nnan ninf float @llvm.log10.f32(float %x)
   ret float %r
 }
@@ -318,6 +509,19 @@ define double @log10_f64(double %x) #0 {
 ; MAC-LABEL: log10_f64:
 ; MAC:       ## %bb.0:
 ; MAC-NEXT:    jmp _log10 ## TAILCALL
+;
+; GISEL-X86-LABEL: log10_f64:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    fldl {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstpl (%esp)
+; GISEL-X86-NEXT:    calll log10
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: log10_f64:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    jmp log10@PLT # TAILCALL
   %r = tail call nnan ninf double @llvm.log10.f64(double %x)
   ret double %r
 }
@@ -357,6 +561,24 @@ define x86_fp80 @log10_f80(x86_fp80 %x) #0 {
 ; MAC-NEXT:    callq _log10l
 ; MAC-NEXT:    addq $24, %rsp
 ; MAC-NEXT:    retq
+;
+; GISEL-X86-LABEL: log10_f80:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstpt (%esp)
+; GISEL-X86-NEXT:    calll log10l
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: log10_f80:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    subq $24, %rsp
+; GISEL-X64-NEXT:    fldt {{[0-9]+}}(%rsp)
+; GISEL-X64-NEXT:    fstpt (%rsp)
+; GISEL-X64-NEXT:    callq log10l@PLT
+; GISEL-X64-NEXT:    addq $24, %rsp
+; GISEL-X64-NEXT:    retq
   %r = tail call nnan ninf x86_fp80 @llvm.log10.f80(x86_fp80 %x)
   ret x86_fp80 %r
 }
@@ -376,6 +598,21 @@ define float @pow_f32(float %x) #0 {
 ; MAC:       ## %bb.0:
 ; MAC-NEXT:    movaps %xmm0, %xmm1
 ; MAC-NEXT:    jmp _powf ## TAILCALL
+;
+; GISEL-X86-LABEL: pow_f32:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    flds {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fsts {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstps (%esp)
+; GISEL-X86-NEXT:    calll powf
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: pow_f32:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    movaps %xmm0, %xmm1
+; GISEL-X64-NEXT:    jmp powf@PLT # TAILCALL
   %r = tail call nnan ninf float @llvm.pow.f32(float %x, float %x)
   ret float %r
 }
@@ -395,6 +632,21 @@ define double @pow_f64(double %x) #0 {
 ; MAC:       ## %bb.0:
 ; MAC-NEXT:    movaps %xmm0, %xmm1
 ; MAC-NEXT:    jmp _pow ## TAILCALL
+;
+; GISEL-X86-LABEL: pow_f64:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $28, %esp
+; GISEL-X86-NEXT:    fldl {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstl {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstpl (%esp)
+; GISEL-X86-NEXT:    calll pow
+; GISEL-X86-NEXT:    addl $28, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: pow_f64:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    movaps %xmm0, %xmm1
+; GISEL-X64-NEXT:    jmp pow@PLT # TAILCALL
   %r = tail call nnan ninf double @llvm.pow.f64(double %x, double %x)
   ret double %r
 }
@@ -441,6 +693,28 @@ define x86_fp80 @pow_f80(x86_fp80 %x) #0 {
 ; MAC-NEXT:    callq _powl
 ; MAC-NEXT:    addq $40, %rsp
 ; MAC-NEXT:    retq
+;
+; GISEL-X86-LABEL: pow_f80:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $28, %esp
+; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fld %st(0)
+; GISEL-X86-NEXT:    fstpt {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstpt (%esp)
+; GISEL-X86-NEXT:    calll powl
+; GISEL-X86-NEXT:    addl $28, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: pow_f80:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    subq $40, %rsp
+; GISEL-X64-NEXT:    fldt {{[0-9]+}}(%rsp)
+; GISEL-X64-NEXT:    fld %st(0)
+; GISEL-X64-NEXT:    fstpt {{[0-9]+}}(%rsp)
+; GISEL-X64-NEXT:    fstpt (%rsp)
+; GISEL-X64-NEXT:    callq powl@PLT
+; GISEL-X64-NEXT:    addq $40, %rsp
+; GISEL-X64-NEXT:    retq
   %r = tail call nnan ninf x86_fp80 @llvm.pow.f80(x86_fp80 %x, x86_fp80 %x)
   ret x86_fp80 %r
 }


### PR DESCRIPTION
- Added global-isel runs as precommit testcase fpr POW/EXP*/LOG*.
- Removed unused tag MISSED.