### PR TITLE
[clang][bytecode] Only emit literal_comparison for string literals

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -1065,7 +1065,8 @@ inline bool CmpHelperEQ<Pointer>(InterpState &S, CodePtr OpPC, CompareFn Fn) {
   for (const auto &P : {LHS, RHS}) {
     if (P.isZero())
       continue;
-    if (BothNonNull && P.pointsToLiteral()) {
+    if (BothNonNull && P.pointsToLiteral() &&
+        isa<StringLiteral>(P.getDeclDesc()->asExpr())) {
       const SourceInfo &Loc = S.Current->getSource(OpPC);
       S.FFDiag(Loc, diag::note_constexpr_literal_comparison);
       return false;

--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -1008,9 +1008,9 @@ namespace shufflevector {
 
 namespace FunctionStart {
   void a(void) {}
-  static_assert(__builtin_function_start(a) == a, ""); // both-error {{not an integral constant expression}} \
+  static_assert(__builtin_function_start(a) == a, ""); // ref-error {{not an integral constant expression}} \
                                                        // ref-note {{comparison against opaque constant address '&__builtin_function_start(a)'}} \
-                                                       // expected-note {{comparison of addresses of potentially overlapping literals has unspecified value}}
+                                                       // expected-error {{static assertion failed}}
 }
 
 namespace BuiltinInImplicitCtor {

--- a/clang/test/AST/ByteCode/functions.cpp
+++ b/clang/test/AST/ByteCode/functions.cpp
@@ -484,6 +484,18 @@ namespace AddressOf {
   void testAddressof(int x) {
     static_assert(&x == __builtin_addressof(x), "");
   }
+
+  struct TS {
+    constexpr bool f(TS s) const {
+      /// The addressof call has a CXXConstructExpr as a parameter.
+      return this != __builtin_addressof(s);
+    }
+  };
+  constexpr bool exprAddressOf() {
+    TS s;
+    return s.f(s);
+  }
+  static_assert(exprAddressOf(), "");
 }
 
 namespace std {


### PR DESCRIPTION
This is what the current interpreter does as well.