### PR TITLE
[CI] Extend metrics container to log BuildKite metrics

### DIFF
--- a/.ci/metrics/metrics.py
+++ b/.ci/metrics/metrics.py
@@ -380,7 +380,7 @@ def get_per_workflow_metrics(github_repo: github.Repository, last_workflow_id: s
 
             workflow_metrics.append(
                 JobMetrics(
-                    workflow_key + "-" + job_key,
+                    workflow_key + "_" + job_key,
                     queue_time.seconds,
                     run_time.seconds,
                     job_result,

--- a/.ci/metrics/metrics.py
+++ b/.ci/metrics/metrics.py
@@ -144,9 +144,12 @@ def buildkite_get_builds_up_to(buildkite_token: str, last_cursor: str = None) ->
             return page
 
         # Cursor has been provided, check if present in this page.
-        match_index = next(
-            (i for i, x in enumerate(page) if x["cursor"] == last_cursor), None
-        )
+        match_index = None
+        for index, item in enumerate(page):
+            if item["cursor"] == last_cursor:
+                match_index = index
+                break
+
         # Not present, continue loading more pages.
         if match_index is None:
             output += page

--- a/.ci/metrics/metrics.py
+++ b/.ci/metrics/metrics.py
@@ -65,7 +65,10 @@ class GaugeMetric:
 def buildkite_fetch_page_build_list(
     buildkite_token: str, after_cursor: str = None
 ) -> list[dict[str, str]]:
-    """Fetches a page of the build list using the GraphQL BuildKite API. Returns the BUILDKITE_GRAPHQL_BUILDS_PER_PAGE last **finished** builds by default, or the BUILDKITE_GRAPHQL_BUILDS_PER_PAGE **finished** builds older than the one pointer by |cursor| if provided.
+    """Fetches a page of the build list using the GraphQL BuildKite API.
+    Returns the BUILDKITE_GRAPHQL_BUILDS_PER_PAGE last **finished** builds by
+    default, or the BUILDKITE_GRAPHQL_BUILDS_PER_PAGE **finished** builds
+    older than the one pointer by |cursor| if provided.
     The |cursor| value is taken from the previous page returned by the API.
 
     The returned data had the following format:
@@ -75,7 +78,7 @@ def buildkite_fetch_page_build_list(
       after_cursor: cursor after which to start the page fetch.
 
     Returns:
-      Returns most recents builds after cursor (if set) with the following format:
+      The most recent builds after cursor (if set) with the following format:
       [
         {
             "cursor": <value>,
@@ -127,7 +130,8 @@ def buildkite_fetch_page_build_list(
 
 def buildkite_get_build_info(build_number: str) -> dict:
     """Returns all the info associated with the provided build number.
-    Note: for unknown reasons, graphql returns no jobs for a given build, while this endpoint does, hence why this uses this API instead of graphql.
+    Note: for unknown reasons, graphql returns no jobs for a given build,
+    while this endpoint does, hence why this uses this API instead of graphql.
 
       Args:
         build_number: which build number to fetch info for.
@@ -292,7 +296,8 @@ def get_sampled_workflow_metrics(github_repo: github.Repository):
                 time.time_ns(),
             )
         )
-    # Always send a hearbeat metric so we can monitor is this container is still able to log to Grafana.
+    # Always send a hearbeat metric so we can monitor is this container is
+    # still able to log to Grafana.
     workflow_metrics.append(
         GaugeMetric("metrics_container_heartbeat", 1, time.time_ns())
     )

--- a/.ci/metrics/metrics.py
+++ b/.ci/metrics/metrics.py
@@ -144,7 +144,6 @@ def buildkite_get_builds_up_to(buildkite_token, last_cursor=None):
 #  - the last processed build.
 #  - the last build if no initial cursor was provided.
 def buildkite_get_metrics(buildkite_token, last_cursor=None):
-
     builds = buildkite_get_builds_up_to(buildkite_token, last_cursor)
     # Don't return any metrics if last_cursor is None.
     # This happens when the program starts.


### PR DESCRIPTION
The current container focuses on Github metrics. Before deprecating BuildKite, we want to make sure the new infra quality is better, or at least the same.

Being able to compare buildkite metrics with github metrics on grafana will allow us to easily present the comparison.

This PR requires https://github.com/llvm/llvm-zorg/pull/400 to be merged first.