### PR TITLE
[clang][bytecode] Fix diagnostic difference with opaque call cmps

### DIFF
--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -1008,9 +1008,8 @@ namespace shufflevector {
 
 namespace FunctionStart {
   void a(void) {}
-  static_assert(__builtin_function_start(a) == a, ""); // ref-error {{not an integral constant expression}} \
-                                                       // ref-note {{comparison against opaque constant address '&__builtin_function_start(a)'}} \
-                                                       // expected-error {{static assertion failed}}
+  static_assert(__builtin_function_start(a) == a, ""); // both-error {{not an integral constant expression}} \
+                                                       // both-note {{comparison against opaque constant address '&__builtin_function_start(a)'}}
 }
 
 namespace BuiltinInImplicitCtor {


### PR DESCRIPTION
Try to dig out the call expression and diagnose this as an opaque call.