### PR TITLE
[clang][bytecode] Diagnose member calls on inactive union fields

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1341,6 +1341,9 @@ bool Call(InterpState &S, CodePtr OpPC, const Function *Func,
     } else {
       if (!CheckInvoke(S, OpPC, ThisPtr))
         return cleanup();
+      if (!Func->isConstructor() &&
+          !CheckActive(S, OpPC, ThisPtr, AK_MemberCall))
+        return false;
     }
 
     if (Func->isConstructor() && !checkConstructor(S, OpPC, Func, ThisPtr))

--- a/clang/test/AST/ByteCode/unions.cpp
+++ b/clang/test/AST/ByteCode/unions.cpp
@@ -504,4 +504,22 @@ namespace AnonymousUnion {
   static_assert(return_init_all().a.p == 7); // both-error {{}} \
                                              // both-note {{read of member 'p' of union with no active member}}
 }
+
+namespace MemberCalls {
+  struct S {
+    constexpr bool foo() const { return true; }
+  };
+
+  constexpr bool foo() { // both-error {{never produces a constant expression}}
+    union {
+      int a;
+      S s;
+    } u;
+
+    u.a = 10;
+    return u.s.foo(); // both-note 2{{member call on member 's' of union with active member 'a'}}
+  }
+  static_assert(foo()); // both-error {{not an integral constant expression}} \
+                        // both-note {{in call to}}
+}
 #endif


### PR DESCRIPTION
Unless the function is a constructor, which is allowed to do this since it will activate the member.