### PR TITLE
[clang][analyzer] Add support for C++23 container methods releated to iterator in ContainerModeling

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/ContainerModeling.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ContainerModeling.cpp
@@ -445,10 +445,10 @@ void ContainerModeling::handlePushBack(CheckerContext &C, SVal Cont,
     auto &BVF = SymMgr.getBasicVals();
     auto &SVB = C.getSValBuilder();
     const auto newEndSym =
-      SVB.evalBinOp(State, BO_Add,
-                    nonloc::SymbolVal(EndSym),
+        SVB.evalBinOp(State, BO_Add, nonloc::SymbolVal(EndSym),
                       nonloc::ConcreteInt(BVF.getValue(llvm::APSInt::get(1))),
-                    SymMgr.getType(EndSym)).getAsSymbol();
+                      SymMgr.getType(EndSym))
+            .getAsSymbol();
     const NoteTag *ChangeTag =
         getChangeTag(C, "extended to the back by 1 position", ContReg, ContE);
     State = setContainerData(State, ContReg, CData->newEnd(newEndSym));
@@ -474,10 +474,10 @@ void ContainerModeling::handlePopBack(CheckerContext &C, SVal Cont,
     auto &BVF = SymMgr.getBasicVals();
     auto &SVB = C.getSValBuilder();
     const auto BackSym =
-      SVB.evalBinOp(State, BO_Sub,
-                    nonloc::SymbolVal(EndSym),
+        SVB.evalBinOp(State, BO_Sub, nonloc::SymbolVal(EndSym),
                       nonloc::ConcreteInt(BVF.getValue(llvm::APSInt::get(1))),
-                    SymMgr.getType(EndSym)).getAsSymbol();
+                      SymMgr.getType(EndSym))
+            .getAsSymbol();
     const NoteTag *ChangeTag =
         getChangeTag(C, "shrank from the back by 1 position", ContReg, ContE);
     // For vector-like and deque-like containers invalidate the last and the
@@ -519,10 +519,10 @@ void ContainerModeling::handlePushFront(CheckerContext &C, SVal Cont,
       auto &BVF = SymMgr.getBasicVals();
       auto &SVB = C.getSValBuilder();
       const auto newBeginSym =
-        SVB.evalBinOp(State, BO_Sub,
-                      nonloc::SymbolVal(BeginSym),
+          SVB.evalBinOp(State, BO_Sub, nonloc::SymbolVal(BeginSym),
                         nonloc::ConcreteInt(BVF.getValue(llvm::APSInt::get(1))),
-                      SymMgr.getType(BeginSym)).getAsSymbol();
+                        SymMgr.getType(BeginSym))
+              .getAsSymbol();
       const NoteTag *ChangeTag =
         getChangeTag(C, "extended to the front by 1 position", ContReg, ContE);
       State = setContainerData(State, ContReg, CData->newBegin(newBeginSym));
@@ -556,10 +556,10 @@ void ContainerModeling::handlePopFront(CheckerContext &C, SVal Cont,
     auto &BVF = SymMgr.getBasicVals();
     auto &SVB = C.getSValBuilder();
     const auto newBeginSym =
-      SVB.evalBinOp(State, BO_Add,
-                    nonloc::SymbolVal(BeginSym),
+        SVB.evalBinOp(State, BO_Add, nonloc::SymbolVal(BeginSym),
                       nonloc::ConcreteInt(BVF.getValue(llvm::APSInt::get(1))),
-                    SymMgr.getType(BeginSym)).getAsSymbol();
+                      SymMgr.getType(BeginSym))
+            .getAsSymbol();
     const NoteTag *ChangeTag =
         getChangeTag(C, "shrank from the front by 1 position", ContReg, ContE);
     State = setContainerData(State, ContReg, CData->newBegin(newBeginSym));
@@ -681,10 +681,10 @@ void ContainerModeling::handleEraseAfter(CheckerContext &C, SVal Cont,
   auto &BVF = SymMgr.getBasicVals();
   auto &SVB = C.getSValBuilder();
   const auto NextSym =
-    SVB.evalBinOp(State, BO_Add,
-                  nonloc::SymbolVal(Pos->getOffset()),
+      SVB.evalBinOp(State, BO_Add, nonloc::SymbolVal(Pos->getOffset()),
                     nonloc::ConcreteInt(BVF.getValue(llvm::APSInt::get(1))),
-                  SymMgr.getType(Pos->getOffset())).getAsSymbol();
+                    SymMgr.getType(Pos->getOffset()))
+          .getAsSymbol();
   State = invalidateIteratorPositions(State, NextSym, BO_EQ);
   C.addTransition(State);
 }

--- a/clang/test/Analysis/Inputs/system-header-simulator-cxx.h
+++ b/clang/test/Analysis/Inputs/system-header-simulator-cxx.h
@@ -336,6 +336,15 @@ namespace std {
     iterator erase(const_iterator position);
     iterator erase(const_iterator first, const_iterator last);
 
+    template<typename R>
+    void assign_range(R&& rg);
+
+    template<typename R>
+    iterator insert_range(const_iterator position, R&& rg);
+
+    template<typename R>
+    void append_range(R&& rg);
+
     T &operator[](size_t n) {
       return _start[n];
     }
@@ -414,6 +423,18 @@ namespace std {
     iterator erase(const_iterator position);
     iterator erase(const_iterator first, const_iterator last);
 
+    template<typename R>
+    void assign_range(R&& rg);
+
+    template<typename R>
+    iterator insert_range(const_iterator position, R&& rg);
+
+    template<typename R>
+    void append_range(R&& rg);
+
+    template<typename R>
+    void prepend_range(R&& rg);
+
     iterator begin() { return iterator(_start); }
     const_iterator begin() const { return const_iterator(_start); }
     const_iterator cbegin() const { return const_iterator(_start); }
@@ -488,6 +509,18 @@ namespace std {
     iterator erase(const_iterator position);
     iterator erase(const_iterator first, const_iterator last);
 
+    template<typename R>
+    void assign_range(R&& rg);
+
+    template<typename R>
+    iterator insert_range(const_iterator position, R&& rg);
+
+    template<typename R>
+    void append_range(R&& rg);
+
+    template<typename R>
+    void prepend_range(R&& rg);
+
     T &operator[](size_t n) {
       return _start[n];
     }
@@ -560,6 +593,15 @@ namespace std {
 
     iterator erase_after(const_iterator position);
     iterator erase_after(const_iterator first, const_iterator last);
+
+    template<typename R>
+    void assign_range(R&& rg);
+
+    template<typename R>
+    void prepend_range(R&& rg);
+
+    template<typename R>
+    iterator insert_range_after(const_iterator pos, R&& rg);
 
     iterator begin() { return iterator(_start); }
     const_iterator begin() const { return const_iterator(_start); }


### PR DESCRIPTION
this PR add support for the following container methods introduced by C++23 in ContainerModeling:
1. `assign_range`: range version of `assign`, have the same effect for iterator
2. `append_range`: range version of `push_back`, have the same effect for iterator
3. `prepend_range`: range version of `push_front`, have the same effect for iterator
4. `insert_range`: range version of `insert`, have the same effect for iterator
5. `insert_range_after`: range version of `insert_after`, no effect for iterator