### PR TITLE
Revert "Push down the swig module to avoid an import cycle"

### DIFF
--- a/lldb/bindings/python/CMakeLists.txt
+++ b/lldb/bindings/python/CMakeLists.txt
@@ -59,10 +59,8 @@ endfunction()
 function(finish_swig_python swig_target lldb_python_bindings_dir lldb_python_target_dir)
   # Add a Post-Build Event to copy over Python files and create the symlink to
   # liblldb.so for the Python API(hardlink on Windows).
-  # Note that Swig-generated code is located one level deeper in the `native`
-  # module, in order to avoid cyclic importing.
   add_custom_target(${swig_target} ALL VERBATIM
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${lldb_python_target_dir}/native/
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${lldb_python_target_dir}
     DEPENDS ${lldb_python_bindings_dir}/lldb.py
     COMMENT "Python script sym-linking LLDB Python API")
 
@@ -75,8 +73,6 @@ function(finish_swig_python swig_target lldb_python_bindings_dir lldb_python_tar
     COMMAND ${CMAKE_COMMAND} -E copy
       "${LLDB_SOURCE_DIR}/source/Interpreter/embedded_interpreter.py"
       "${lldb_python_target_dir}")
-
-  create_python_package(${swig_target} ${lldb_python_target_dir} "native" FILES)
 
   # Distribute the examples as python packages.
   create_python_package(
@@ -145,7 +141,7 @@ function(finish_swig_python swig_target lldb_python_bindings_dir lldb_python_tar
   endif()
   set(LIBLLDB_SYMLINK_OUTPUT_FILE "_lldb${LLDB_PYTHON_EXT_SUFFIX}")
   create_relative_symlink(${swig_target} ${LIBLLDB_SYMLINK_DEST}
-                          ${lldb_python_target_dir}/native/ ${LIBLLDB_SYMLINK_OUTPUT_FILE})
+                          ${lldb_python_target_dir} ${LIBLLDB_SYMLINK_OUTPUT_FILE})
 
 
   if (NOT WIN32)

--- a/lldb/bindings/python/python.swig
+++ b/lldb/bindings/python/python.swig
@@ -50,12 +50,7 @@ Older swig versions will simply ignore this setting.
     import $module
 except ImportError:
     # Relative import should work if we are being loaded by Python.
-    # The cpython module built by swig is pushed one level down into
-    # the native submodule, because at this point the interpreter
-    # is still constructing the lldb module itself.
-    # Simply importing anything using `from . import` constitutes
-    # a cyclic importing.
-    from .native import $module"
+    from . import $module"
 %enddef
 
 // The name of the module to be created.


### PR DESCRIPTION
Reverts llvm/llvm-project#129135 due to buildbot test failures.

Definitely caused remote Linux to Windows failures (https://lab.llvm.org/buildbot/#/builders/197/builds/2712), may be the cause of Windows on Arm failures https://lab.llvm.org/buildbot/#/builders/141/builds/6744.