### PR TITLE
[MemCpyOpt] Optimization of memopt for implicit local variable assignment.

### DIFF
--- a/llvm/include/llvm/Transforms/Scalar/MemCpyOptimizer.h
+++ b/llvm/include/llvm/Transforms/Scalar/MemCpyOptimizer.h
@@ -81,6 +81,7 @@ private:
                                   BatchAAResults &BAA);
   bool processByValArgument(CallBase &CB, unsigned ArgNo);
   bool processImmutArgument(CallBase &CB, unsigned ArgNo);
+  bool mergeOnmemsetcpy(Function &F);
   Instruction *tryMergingIntoMemset(Instruction *I, Value *StartPtr,
                                     Value *ByteVal);
   bool moveUp(StoreInst *SI, Instruction *P, const LoadInst *LI);

--- a/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
+++ b/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp
@@ -1989,6 +1989,45 @@ bool MemCpyOptPass::processByValArgument(CallBase &CB, unsigned ArgNo) {
   return true;
 }
 
+/// Transform memcpy to memset when its source was just memset and temporary.
+/// In other words, turn:
+/// \code
+///   memset(dst1, c, size);
+///   memcpy(dst2, dst1, size);
+/// \endcode
+/// into:
+/// \code
+///   memset(dst2, c, size);
+/// \endcode
+/// When dst1 is temporary
+
+bool MemCpyOptPass::mergeOnmemsetcpy(Function &F) {
+  bool MadeChange = false;
+  for (BasicBlock &BB : F) {
+    for (BasicBlock::iterator BI = BB.begin(), BE = BB.end(); BI != BE;) {
+      Instruction *I = &*BI;
+      if(!I){
+        break;
+      }
+      Instruction *I1 = &*(++BI);
+      if (auto *M = dyn_cast<MemSetInst>(I))
+        if (auto *M1 = dyn_cast<MemCpyInst>(I1)){
+          auto Op = I->getOperand(0);
+          auto Op2 = I1->getOperand(1);
+          auto *CMemSetSize = dyn_cast<ConstantInt>(M->getLength());
+          auto *CMemCpySize = dyn_cast<ConstantInt>(M1->getLength());
+          if (Op == Op2 && Op->getNumUses() == 2 && CMemSetSize && CMemCpySize &&
+            CMemSetSize->getZExtValue() == CMemCpySize->getZExtValue() ) {
+            I->setOperand(0, I1->getOperand(0));
+            eraseInstruction(I1);
+            MadeChange |= true;
+          }
+        }
+     }
+  }
+  return MadeChange;
+}
+
 /// This is called on memcpy dest pointer arguments attributed as immutable
 /// during call. Try to use memcpy source directly if all of the following
 /// conditions are satisfied.
@@ -2137,7 +2176,7 @@ bool MemCpyOptPass::iterateOnFunction(Function &F) {
       }
     }
   }
-
+  MadeChange |= mergeOnmemsetcpy(F);
   return MadeChange;
 }
 

--- a/llvm/test/Transforms/MemCpyOpt/memcpy-merges-memset.ll
+++ b/llvm/test/Transforms/MemCpyOpt/memcpy-merges-memset.ll
@@ -1,0 +1,22 @@
+; RUN: opt -opaque-pointers -memcpyopt -S < %s -verify-memoryssa | FileCheck %s
+
+target datalayout = "e-i64:64-f80:128-n8:16:32:64-S128"
+
+%struct.deliver_proc_ctx_t = type { i32, [1024 x i32] }
+define dso_local void @test(ptr noundef writeonly %ctx) local_unnamed_addr {
+; CHECK-LABEL: @test(
+; CHECK-LABEL: entry
+; CHECK-NEXT:    %.compoundliteral = alloca %struct.deliver_proc_ctx_t, align 4
+; CHECK-NEXT:    call void @llvm.memset.p0.i64(ptr noundef nonnull align 4 dereferenceable(4100) %ctx, i8 0, i64 4100, i1 false)
+; CHECK-NEXT:    ret void
+;
+entry:
+  %.compoundliteral = alloca %struct.deliver_proc_ctx_t, align 4
+  call void @llvm.memset.p0.i64(ptr noundef nonnull align 4 dereferenceable(4100) %.compoundliteral, i8 0, i64 4100, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 4 %ctx, ptr nonnull align 4 %.compoundliteral, i64 4100, i1 true)
+  ret void
+}
+
+declare void @llvm.memset.p0.i64(ptr writeonly, i8, i64, i1 immarg)
+
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly, ptr noalias readonly, i64, i1 immarg)


### PR DESCRIPTION
Fix the scenario where over-sized local variable initialization is optimized to memset and memcpy, using only memset. Fixes #118149