### PR TITLE
[SPIR-V] Fix an issue with casting types in debug-info extension implementation

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -158,9 +158,9 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
                 // pointed on from other DI types
                 // DerivedType->getBaseType is null when pointer
                 // is representing a void type
-                if (DerivedType->getBaseType())
-                  BasicTypes.insert(
-                      cast<DIBasicType>(DerivedType->getBaseType()));
+                if (auto *BT = dyn_cast_or_null<DIBasicType>(
+                        DerivedType->getBaseType()))
+                  BasicTypes.insert(BT);
               }
             }
           }

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -330,7 +330,7 @@ bool SPIRVEmitNonSemanticDI::emitGlobalDI(MachineFunction &MF) {
         // If the Pointer is representing a void type it's getBaseType
         // is a nullptr
         const auto *MaybeNestedBasicType =
-            cast_or_null<DIBasicType>(PointerDerivedType->getBaseType());
+            dyn_cast_or_null<DIBasicType>(PointerDerivedType->getBaseType());
         if (MaybeNestedBasicType) {
           for (const auto &BasicTypeRegPair : BasicTypeRegPairs) {
             const auto &[DefinedBasicType, BasicTypeReg] = BasicTypeRegPair;

--- a/llvm/test/CodeGen/SPIRV/debug-info/debug-type-pointer.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/debug-type-pointer.ll
@@ -81,6 +81,8 @@
 
 ; CHECK-OPTION-NOT: DebugTypePointer
 
+%struct_wrapper = type { i32 }
+
 @gi0 = dso_local addrspace(1) global ptr addrspace(4) null, align 4, !dbg !0
 @gv0 = dso_local addrspace(1) global ptr addrspace(4) null, align 4, !dbg !5
 
@@ -278,3 +280,4 @@ define spir_func i32 @test1() !dbg !72 {
 !98 = !DILocalVariable(name: "arr1", scope: !72, file: !3, line: 35, type: !67)
 !99 = !DILocation(line: 35, column: 7, scope: !72)
 !100 = !DILocation(line: 36, column: 3, scope: !72)
+!101 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !67, size: 32, dwarfAddressSpace: 4)

--- a/llvm/test/CodeGen/SPIRV/debug-info/debug-type-pointer.ll
+++ b/llvm/test/CodeGen/SPIRV/debug-info/debug-type-pointer.ll
@@ -81,8 +81,6 @@
 
 ; CHECK-OPTION-NOT: DebugTypePointer
 
-%struct_wrapper = type { i32 }
-
 @gi0 = dso_local addrspace(1) global ptr addrspace(4) null, align 4, !dbg !0
 @gv0 = dso_local addrspace(1) global ptr addrspace(4) null, align 4, !dbg !5
 


### PR DESCRIPTION
This PR fixes an issue in debug-info extension implementation (namely, a wrong assumption that all pointee types are basic types). The reproducer is added to an existing test case of "pointers with debug-info".