### PR TITLE
[clang][bytecode] Fix CallPtr return type check

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1512,7 +1512,7 @@ bool CallPtr(InterpState &S, CodePtr OpPC, uint32_t ArgSize,
   // This happens when the call expression has been cast to
   // something else, but we don't support that.
   if (S.Ctx.classify(F->getDecl()->getReturnType()) !=
-      S.Ctx.classify(CE->getType()))
+      S.Ctx.classify(CE->getCallReturnType(S.getASTContext())))
     return false;
 
   // Check argument nullability state.

--- a/clang/test/AST/ByteCode/memberpointers.cpp
+++ b/clang/test/AST/ByteCode/memberpointers.cpp
@@ -226,3 +226,26 @@ namespace IndirectFields {
   constexpr I i{12};
   static_assert(ReadField<I, &I::a>(i) == 12, "");
 }
+
+namespace CallExprTypeMismatch {
+  /// The call expression's getType() returns just S, not S&.
+  struct S {
+    constexpr S(int i_) : i(i_) {}
+    constexpr const S& identity() const { return *this; }
+    int i;
+  };
+
+  template<typename T, typename U>
+  constexpr void Call(T t, U u) {
+    ((&u)->*t)();
+  }
+
+  constexpr bool test() {
+    const S s{12};
+
+    Call(&S::identity, s);
+
+    return true;
+  }
+  static_assert(test(), "");
+}


### PR DESCRIPTION
CallExpr::getType() isn't enough here in some cases, we need to use CallExpr::getCallReturnType().