### PR TITLE
[DAG] Add ShuffleVectorSDNode::getSplatMaskIndex static helper

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -1663,10 +1663,13 @@ public:
 
   bool isSplat() const { return isSplatMask(getMask()); }
 
-  int getSplatIndex() const {
-    assert(isSplat() && "Cannot get splat index for non-splat!");
-    EVT VT = getValueType(0);
-    for (unsigned i = 0, e = VT.getVectorNumElements(); i != e; ++i)
+  int getSplatIndex() const { return getSplatMaskIndex(getMask()); }
+
+  static bool isSplatMask(ArrayRef<int> Mask);
+
+  static int getSplatMaskIndex(ArrayRef<int> Mask) {
+    assert(isSplatMask(Mask) && "Cannot get splat index for non-splat!");
+    for (unsigned i = 0, e = Mask.size(); i != e; ++i)
       if (Mask[i] >= 0)
         return Mask[i];
 
@@ -1674,8 +1677,6 @@ public:
     // are undefined. Return 0 for better potential for callers to simplify.
     return 0;
   }
-
-  static bool isSplatMask(ArrayRef<int> Mask);
 
   /// Change values in a shuffle permute mask assuming
   /// the two vector operands have swapped position.


### PR DESCRIPTION
Move ShuffleVectorSDNode::getSplatIndex implementation into getSplatMaskIndex static helper, and covert getSplatIndex into a wrapper similar to isSplat