### PR TITLE
[lldb][Expression] Allow specifying a preferred ModuleList for lookup during expression evaluation

### DIFF
--- a/lldb/include/lldb/Expression/IRExecutionUnit.h
+++ b/lldb/include/lldb/Expression/IRExecutionUnit.h
@@ -162,10 +162,10 @@ public:
     return m_jitted_global_variables;
   }
 
-  void SetPreferredModules(SymbolContextList const &modules) {
-    for (auto const &m : modules)
-      if (m.module_sp)
-        m_preferred_modules.Append(m.module_sp);
+  void AppendPreferredSymbolContexts(SymbolContextList const &contexts) {
+    for (auto const &ctx : contexts)
+      if (ctx.module_sp)
+        m_preferred_modules.Append(ctx.module_sp);
   }
 
 private:

--- a/lldb/include/lldb/Expression/IRExecutionUnit.h
+++ b/lldb/include/lldb/Expression/IRExecutionUnit.h
@@ -12,7 +12,6 @@
 #include <atomic>
 #include <memory>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 #include "llvm/ExecutionEngine/SectionMemoryManager.h"

--- a/lldb/include/lldb/Expression/IRExecutionUnit.h
+++ b/lldb/include/lldb/Expression/IRExecutionUnit.h
@@ -18,6 +18,7 @@
 #include "llvm/ExecutionEngine/SectionMemoryManager.h"
 #include "llvm/IR/Module.h"
 
+#include "lldb/Core/ModuleList.h"
 #include "lldb/Expression/IRMemoryMap.h"
 #include "lldb/Expression/ObjectFileJIT.h"
 #include "lldb/Symbol/SymbolContext.h"
@@ -162,8 +163,10 @@ public:
     return m_jitted_global_variables;
   }
 
-  void SetPreferredModules(std::unordered_set<lldb::ModuleSP> modules) {
-    m_preferred_modules = std::move(modules);
+  void SetPreferredModules(SymbolContextList const &modules) {
+    for (auto const &m : modules)
+      if (m.module_sp)
+        m_preferred_modules.Append(m.module_sp);
   }
 
 private:
@@ -401,7 +404,11 @@ private:
   ///< defining no functions using that variable, would do this.)  If this
   ///< is true, any allocations need to be committed immediately -- no
   ///< opportunity for relocation.
-  std::unordered_set<lldb::ModuleSP> m_preferred_modules;
+
+  ///< Any Module in this list will be used for symbol/function lookup
+  ///< before any other module (except for the module corresponding to the
+  ///< current frame).
+  ModuleList m_preferred_modules;
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Expression/IRExecutionUnit.h
+++ b/lldb/include/lldb/Expression/IRExecutionUnit.h
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "llvm/ExecutionEngine/SectionMemoryManager.h"
@@ -159,6 +160,10 @@ public:
 
   const std::vector<JittedGlobalVariable> &GetJittedGlobalVariables() {
     return m_jitted_global_variables;
+  }
+
+  void SetPreferredModules(std::unordered_set<lldb::ModuleSP> modules) {
+    m_preferred_modules = std::move(modules);
   }
 
 private:
@@ -396,6 +401,7 @@ private:
   ///< defining no functions using that variable, would do this.)  If this
   ///< is true, any allocations need to be committed immediately -- no
   ///< opportunity for relocation.
+  std::unordered_set<lldb::ModuleSP> m_preferred_modules;
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -510,6 +510,9 @@ private:
   mutable std::string m_pound_line_file;
   mutable uint32_t m_pound_line_line = 0;
 
+  ///< During expression evaluation, any SymbolContext in this list will be
+  ///< used for symbol/function lookup before any other context (except for
+  ///< the module corresponding to the current frame).
   SymbolContextList m_preferred_lookup_contexts;
 };
 

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -333,8 +333,8 @@ public:
     m_language = SourceLanguage(language_type);
   }
 
-  void SetPreferredSymbolContexts(SymbolContextList modules) {
-    m_preferred_lookup_contexts = std::move(modules);
+  void SetPreferredSymbolContexts(SymbolContextList contexts) {
+    m_preferred_lookup_contexts = std::move(contexts);
   }
 
   const SymbolContextList &GetPreferredSymbolContexts() const {

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -25,6 +25,7 @@
 #include "lldb/Core/UserSettingsController.h"
 #include "lldb/Expression/Expression.h"
 #include "lldb/Host/ProcessLaunchInfo.h"
+#include "lldb/Symbol/SymbolContext.h"
 #include "lldb/Symbol/TypeSystem.h"
 #include "lldb/Target/ExecutionContextScope.h"
 #include "lldb/Target/PathMappingList.h"
@@ -332,12 +333,12 @@ public:
     m_language = SourceLanguage(language_type);
   }
 
-  void SetPreferredModules(std::unordered_set<lldb::ModuleSP> modules) {
-    m_preferred_modules = std::move(modules);
+  void SetPreferredSymbolContexts(SymbolContextList modules) {
+    m_preferred_lookup_contexts = std::move(modules);
   }
 
-  const std::unordered_set<lldb::ModuleSP> &GetPreferredModules() const {
-    return m_preferred_modules;
+  const SymbolContextList &GetPreferredSymbolContexts() const {
+    return m_preferred_lookup_contexts;
   }
 
   /// Set the language using a pair of language code and version as
@@ -509,7 +510,7 @@ private:
   mutable std::string m_pound_line_file;
   mutable uint32_t m_pound_line_line = 0;
 
-  std::unordered_set<lldb::ModuleSP> m_preferred_modules;
+  SymbolContextList m_preferred_lookup_contexts;
 };
 
 // Target

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -332,6 +332,14 @@ public:
     m_language = SourceLanguage(language_type);
   }
 
+  void SetPreferredModules(std::unordered_set<lldb::ModuleSP> modules) {
+    m_preferred_modules = std::move(modules);
+  }
+
+  const std::unordered_set<lldb::ModuleSP> &GetPreferredModules() const {
+    return m_preferred_modules;
+  }
+
   /// Set the language using a pair of language code and version as
   /// defined by the DWARF 6 specification.
   /// WARNING: These codes may change until DWARF 6 is finalized.
@@ -500,6 +508,8 @@ private:
   // originates
   mutable std::string m_pound_line_file;
   mutable uint32_t m_pound_line_line = 0;
+
+  std::unordered_set<lldb::ModuleSP> m_preferred_modules;
 };
 
 // Target

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -1540,7 +1540,8 @@ lldb_private::Status ClangExpressionParser::DoPrepareForExecution(
       m_compiler->getTargetOpts().Features);
 
   if (auto *options = m_expr.GetOptions())
-    execution_unit_sp->SetPreferredModules(options->GetPreferredModules());
+    execution_unit_sp->SetPreferredModules(
+        options->GetPreferredSymbolContexts());
 
   ClangExpressionHelper *type_system_helper =
       dyn_cast<ClangExpressionHelper>(m_expr.GetTypeSystemHelper());

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -1540,7 +1540,7 @@ lldb_private::Status ClangExpressionParser::DoPrepareForExecution(
       m_compiler->getTargetOpts().Features);
 
   if (auto *options = m_expr.GetOptions())
-    execution_unit_sp->SetPreferredModules(
+    execution_unit_sp->AppendPreferredSymbolContexts(
         options->GetPreferredSymbolContexts());
 
   ClangExpressionHelper *type_system_helper =

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -1539,6 +1539,9 @@ lldb_private::Status ClangExpressionParser::DoPrepareForExecution(
       function_name, exe_ctx.GetTargetSP(), sc,
       m_compiler->getTargetOpts().Features);
 
+  if (auto *options = m_expr.GetOptions())
+    execution_unit_sp->SetPreferredModules(options->GetPreferredModules());
+
   ClangExpressionHelper *type_system_helper =
       dyn_cast<ClangExpressionHelper>(m_expr.GetTypeSystemHelper());
   ClangExpressionDeclMap *decl_map =

--- a/lldb/source/Plugins/InstrumentationRuntime/Utility/CMakeLists.txt
+++ b/lldb/source/Plugins/InstrumentationRuntime/Utility/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_lldb_library(lldbPluginInstrumentationRuntimeUtility
   ReportRetriever.cpp
+  Utility.cpp
 
   LINK_LIBS
     lldbBreakpoint

--- a/lldb/source/Plugins/InstrumentationRuntime/Utility/ReportRetriever.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/Utility/ReportRetriever.cpp
@@ -83,7 +83,7 @@ ReportRetriever::RetrieveReportData(const ProcessSP process_sp) {
   options.SetAutoApplyFixIts(false);
   options.SetLanguage(eLanguageTypeObjC_plus_plus);
 
-  if (auto m = GetPreferredSanitizerModule(process_sp->GetTarget())) {
+  if (auto m = GetPreferredAsanModule(process_sp->GetTarget())) {
     SymbolContextList sc_list;
     sc_list.Append(SymbolContext(std::move(m)));
     options.SetPreferredSymbolContexts(std::move(sc_list));

--- a/lldb/source/Plugins/InstrumentationRuntime/Utility/ReportRetriever.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/Utility/ReportRetriever.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ReportRetriever.h"
+#include "Utility.h"
 
 #include "lldb/Breakpoint/StoppointCallbackContext.h"
 #include "lldb/Core/Debugger.h"
@@ -81,6 +82,12 @@ ReportRetriever::RetrieveReportData(const ProcessSP process_sp) {
   options.SetPrefix(address_sanitizer_retrieve_report_data_prefix);
   options.SetAutoApplyFixIts(false);
   options.SetLanguage(eLanguageTypeObjC_plus_plus);
+
+  if (auto m = GetPreferredSanitizerModule(process_sp->GetTarget())) {
+    SymbolContextList sc_list;
+    sc_list.Append(SymbolContext(std::move(m)));
+    options.SetPreferredSymbolContexts(std::move(sc_list));
+  }
 
   ValueObjectSP return_value_sp;
   ExecutionContext exe_ctx;

--- a/lldb/source/Plugins/InstrumentationRuntime/Utility/Utility.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/Utility/Utility.cpp
@@ -17,9 +17,9 @@ namespace lldb_private {
 ///< compiler-rt, and we should prefer it in favour of the system sanitizers.
 ///< This helper searches the target for such a dylib. Returns nullptr if no
 ///< such dylib was found.
-lldb::ModuleSP GetPreferredSanitizerModule(const Target &target) {
+lldb::ModuleSP GetPreferredAsanModule(const Target &target) {
   lldb::ModuleSP module;
-  llvm::Regex pattern(R"(libclang_rt\.(asan|tsan|ubsan)_.*_dynamic\.dylib)");
+  llvm::Regex pattern(R"(libclang_rt\.asan_.*_dynamic\.dylib)");
   target.GetImages().ForEach([&](const lldb::ModuleSP &m) {
     if (pattern.match(m->GetFileSpec().GetFilename().GetStringRef())) {
       module = m;

--- a/lldb/source/Plugins/InstrumentationRuntime/Utility/Utility.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/Utility/Utility.cpp
@@ -1,0 +1,35 @@
+//===-- Utility.cpp -------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Utility.h"
+
+#include "lldb/Core/Module.h"
+#include "lldb/Target/Target.h"
+
+namespace lldb_private {
+
+///< On Darwin, if LLDB loaded libclang_rt, it's coming from a locally built
+///< compiler-rt, and we should prefer it in favour of the system sanitizers.
+///< This helper searches the target for such a dylib. Returns nullptr if no
+///< such dylib was found.
+lldb::ModuleSP GetPreferredSanitizerModule(const Target &target) {
+  lldb::ModuleSP module;
+  llvm::Regex pattern(R"(libclang_rt\.(asan|tsan|ubsan)_.*_dynamic\.dylib)");
+  target.GetImages().ForEach([&](const lldb::ModuleSP &m) {
+    if (pattern.match(m->GetFileSpec().GetFilename().GetStringRef())) {
+      module = m;
+      return false;
+    }
+
+    return true;
+  });
+
+  return module;
+}
+
+} // namespace lldb_private

--- a/lldb/source/Plugins/InstrumentationRuntime/Utility/Utility.h
+++ b/lldb/source/Plugins/InstrumentationRuntime/Utility/Utility.h
@@ -1,0 +1,27 @@
+//===-- Utility.h -----------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_INSTRUMENTATIONRUNTIME_UTILITY_UTILITY_H
+#define LLDB_SOURCE_PLUGINS_INSTRUMENTATIONRUNTIME_UTILITY_UTILITY_H
+
+#include "lldb/lldb-forward.h"
+
+namespace lldb_private {
+
+class Target;
+
+///< On Darwin, if LLDB loaded libclang_rt, it's coming from a locally built
+///< compiler-rt, and we should prefer it in favour of the system sanitizers
+///< when running InstrumentationRuntime utility expressions that use symbols
+///< from the sanitizer libraries. This helper searches the target for such a
+///< dylib. Returns nullptr if no such dylib was found.
+lldb::ModuleSP GetPreferredSanitizerModule(const Target &target);
+
+} // namespace lldb_private
+
+#endif // LLDB_SOURCE_PLUGINS_INSTRUMENTATIONRUNTIME_UTILITY_UTILITY_H

--- a/lldb/source/Plugins/InstrumentationRuntime/Utility/Utility.h
+++ b/lldb/source/Plugins/InstrumentationRuntime/Utility/Utility.h
@@ -20,7 +20,7 @@ class Target;
 ///< when running InstrumentationRuntime utility expressions that use symbols
 ///< from the sanitizer libraries. This helper searches the target for such a
 ///< dylib. Returns nullptr if no such dylib was found.
-lldb::ModuleSP GetPreferredSanitizerModule(const Target &target);
+lldb::ModuleSP GetPreferredAsanModule(const Target &target);
 
 } // namespace lldb_private
 

--- a/lldb/source/Plugins/MemoryHistory/asan/MemoryHistoryASan.cpp
+++ b/lldb/source/Plugins/MemoryHistory/asan/MemoryHistoryASan.cpp
@@ -176,7 +176,7 @@ HistoryThreads MemoryHistoryASan::GetHistoryThreads(lldb::addr_t address) {
   options.SetAutoApplyFixIts(false);
   options.SetLanguage(eLanguageTypeObjC_plus_plus);
 
-  if (auto m = GetPreferredSanitizerModule(process_sp->GetTarget())) {
+  if (auto m = GetPreferredAsanModule(process_sp->GetTarget())) {
     SymbolContextList sc_list;
     sc_list.Append(SymbolContext(std::move(m)));
     options.SetPreferredSymbolContexts(std::move(sc_list));


### PR DESCRIPTION
The `TestMemoryHistory.py`/`TestReportData.py` are currently failing on the x86 macOS CI (started after we upgraded the Xcode SDK on that machien). The LLDB ASAN utility expression is failing to run with following error:
```
(lldb) image lookup -n __asan_get_alloc_stack
1 match found in /usr/lib/system/libsystem_sanitizers.dylib:
        Address: libsystem_sanitizers.dylib[0x00007ffd11e673f7] (libsystem_sanitizers.dylib.__TEXT.__text + 11287)
        Summary: libsystem_sanitizers.dylib`__asan_get_alloc_stack
1 match found in /Users/michaelbuch/Git/lldb-build-main-no-modules/lib/clang/21/lib/darwin/libclang_rt.asan_osx_dynamic.dylib:
        Address: libclang_rt.asan_osx_dynamic.dylib[0x0000000000009ec0] (libclang_rt.asan_osx_dynamic.dylib.__TEXT.__text + 34352)
        Summary: libclang_rt.asan_osx_dynamic.dylib`::__asan_get_alloc_stack(__sanitizer::uptr, __sanitizer::uptr *, __sanitizer::uptr, __sanitizer::u32 *) at asan_debugging.cpp:132
(lldb) memory history 'pointer'
Assertion failed: ((uintptr_t)addr == report.access.address), function __asan_get_alloc_stack, file debugger_abi.cpp, line 62.
warning: cannot evaluate AddressSanitizer expression:
error: Expression execution was interrupted: signal SIGABRT.
The process has been returned to the state before expression evaluation.
```

The reason for this is that the system sanitizer dylib and the locally built libclang_rt contain the same symbol `__asan_get_alloc_stack`, and depending on the order in which they're loaded, we may pick the one from the wrong dylib (this probably changed during the buildbot upgrade and is why it only now started failing). Based on discussion with @wrotki we always want to pick the one that's in the libclang_rt dylib if it was loaded, and libsystem_sanitizers otherwise.

This patch addresses this by adding a "preferred lookup context list" to the expression evaluator. Currently this is only exposed in the `EvaluateExpressionOptions`. We make it a `SymbolContextList` in case we want the lookup contexts to be contexts other than modules (e.g., source files, etc.). In `IRExecutionUnit` we make it a `ModuleList` because it makes the symbol lookup implementation simpler and we only do module lookups here anyway. If we ever need it to be a `SymbolContext`, that transformation shouldn't be too difficult.