### PR TITLE
[libclc] Reduce bithacking for INF/NAN values

### DIFF
--- a/libclc/clc/include/clc/float/definitions.h
+++ b/libclc/clc/include/clc/float/definitions.h
@@ -13,6 +13,8 @@
 #define FLT_MIN 0x1.0p-126f
 #define FLT_EPSILON 0x1.0p-23f
 #define FLT_NAN __builtin_nanf("")
+#define FLT_PINF (__builtin_inff())
+#define FLT_NINF (-__builtin_inff())
 
 #define FP_ILOGB0 (-2147483647 - 1)
 #define FP_ILOGBNAN 2147483647
@@ -47,6 +49,8 @@
 #define DBL_MIN 0x1.0p-1022
 #define DBL_EPSILON 0x1.0p-52
 #define DBL_NAN __builtin_nan("")
+#define DBL_PINF (__builtin_inf())
+#define DBL_NINF (-__builtin_inf())
 
 #define M_E 0x1.5bf0a8b145769p+1
 #define M_LOG2E 0x1.71547652b82fep+0
@@ -82,6 +86,8 @@
 #define HALF_MIN 0x1.0p-14h
 #define HALF_EPSILON 0x1.0p-10h
 #define HALF_NAN __builtin_nanf16("")
+#define HALF_PINF (__builtin_inff16())
+#define HALF_NINF (-__builtin_inff16())
 
 #define M_LOG2E_H 0x1.714p+0h
 

--- a/libclc/clc/include/clc/math/gentype.inc
+++ b/libclc/clc/include/clc/math/gentype.inc
@@ -1,7 +1,7 @@
 #include <clc/clcfunc.h>
 #include <clc/clctypes.h>
-#include <clc/utils.h>
 #include <clc/float/definitions.h>
+#include <clc/utils.h>
 
 // Define some useful macros for type conversions.
 #define __CLC_AS_GENTYPE __CLC_XCONCAT(__clc_as_, __CLC_GENTYPE)

--- a/libclc/clc/include/clc/math/gentype.inc
+++ b/libclc/clc/include/clc/math/gentype.inc
@@ -1,6 +1,7 @@
 #include <clc/clcfunc.h>
 #include <clc/clctypes.h>
 #include <clc/utils.h>
+#include <clc/float/definitions.h>
 
 // Define some useful macros for type conversions.
 #define __CLC_AS_GENTYPE __CLC_XCONCAT(__clc_as_, __CLC_GENTYPE)
@@ -45,6 +46,8 @@
 #define __CLC_CONVERT_UINTN __CLC_XCONCAT(__clc_convert_, __CLC_UINTN)
 #define __CLC_CONVERT_ULONGN __CLC_XCONCAT(__clc_convert_, __CLC_ULONGN)
 
+#define __CLC_GENTYPE_INF __CLC_GENTYPE_PINF
+
 // See definitions of __CLC_S_GENTYPE/__CLC_U_GENTYPE below, which depend on the
 // specific size of floating-point type. These are the signed and unsigned
 // integers of the same bitwidth and element count as the GENTYPE. They match
@@ -59,6 +62,9 @@
 #define __CLC_SCALAR_GENTYPE float
 #define __CLC_FPSIZE 32
 #define __CLC_FP_LIT(x) x##F
+#define __CLC_GENTYPE_PINF ((__CLC_GENTYPE)FLT_PINF)
+#define __CLC_GENTYPE_NINF ((__CLC_GENTYPE)FLT_NINF)
+#define __CLC_GENTYPE_NAN ((__CLC_GENTYPE)FLT_NAN)
 
 #define __CLC_S_GENTYPE __CLC_XCONCAT(int, __CLC_VECSIZE)
 #define __CLC_U_GENTYPE __CLC_XCONCAT(uint, __CLC_VECSIZE)
@@ -115,6 +121,9 @@
 
 #undef __CLC_U_GENTYPE
 #undef __CLC_S_GENTYPE
+#undef __CLC_GENTYPE_NINF
+#undef __CLC_GENTYPE_PINF
+#undef __CLC_GENTYPE_NAN
 #undef __CLC_FP_LIT
 #undef __CLC_FPSIZE
 #undef __CLC_SCALAR_GENTYPE
@@ -126,6 +135,9 @@
 #define __CLC_SCALAR_GENTYPE double
 #define __CLC_FPSIZE 64
 #define __CLC_FP_LIT(x) (x)
+#define __CLC_GENTYPE_PINF ((__CLC_GENTYPE)DBL_PINF)
+#define __CLC_GENTYPE_NINF ((__CLC_GENTYPE)DBL_NINF)
+#define __CLC_GENTYPE_NAN ((__CLC_GENTYPE)DBL_NAN)
 
 #define __CLC_S_GENTYPE __CLC_XCONCAT(long, __CLC_VECSIZE)
 #define __CLC_U_GENTYPE __CLC_XCONCAT(ulong, __CLC_VECSIZE)
@@ -182,6 +194,9 @@
 
 #undef __CLC_U_GENTYPE
 #undef __CLC_S_GENTYPE
+#undef __CLC_GENTYPE_NINF
+#undef __CLC_GENTYPE_PINF
+#undef __CLC_GENTYPE_NAN
 #undef __CLC_FP_LIT
 #undef __CLC_FPSIZE
 #undef __CLC_SCALAR_GENTYPE
@@ -195,6 +210,9 @@
 #define __CLC_SCALAR_GENTYPE half
 #define __CLC_FPSIZE 16
 #define __CLC_FP_LIT(x) x##H
+#define __CLC_GENTYPE_NAN ((__CLC_GENTYPE)HALF_NAN)
+#define __CLC_GENTYPE_PINF ((__CLC_GENTYPE)HALF_PINF)
+#define __CLC_GENTYPE_NINF ((__CLC_GENTYPE)HALF_NINF)
 
 #define __CLC_S_GENTYPE __CLC_XCONCAT(short, __CLC_VECSIZE)
 #define __CLC_U_GENTYPE __CLC_XCONCAT(ushort, __CLC_VECSIZE)
@@ -251,6 +269,9 @@
 
 #undef __CLC_U_GENTYPE
 #undef __CLC_S_GENTYPE
+#undef __CLC_GENTYPE_NINF
+#undef __CLC_GENTYPE_PINF
+#undef __CLC_GENTYPE_NAN
 #undef __CLC_FP_LIT
 #undef __CLC_FPSIZE
 #undef __CLC_SCALAR_GENTYPE
@@ -288,6 +309,8 @@
 #undef __CLC_CONVERT_USHORTN
 #undef __CLC_CONVERT_UINTN
 #undef __CLC_CONVERT_ULONGN
+
+#undef __CLC_GENTYPE_INF
 
 #undef __CLC_ULONGN
 #undef __CLC_UINTN

--- a/libclc/clc/lib/generic/math/clc_hypot.cl
+++ b/libclc/clc/lib/generic/math/clc_hypot.cl
@@ -29,6 +29,7 @@
 #include <clc/math/clc_sqrt.h>
 #include <clc/math/clc_subnormal_config.h>
 #include <clc/math/math.h>
+#include <clc/relational/clc_isinf.h>
 #include <clc/relational/clc_isnan.h>
 #include <clc/shared/clc_clamp.h>
 

--- a/libclc/clc/lib/generic/math/clc_hypot.inc
+++ b/libclc/clc/lib/generic/math/clc_hypot.inc
@@ -46,9 +46,7 @@ _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_hypot(__CLC_GENTYPE x,
   __CLC_GENTYPE retval = __clc_sqrt(__clc_mad(fx, fx, fy * fy)) * fx_exp;
 
   retval = (ux > PINFBITPATT_SP32 || uy == 0) ? __CLC_AS_GENTYPE(ux) : retval;
-  retval = (ux == PINFBITPATT_SP32 || uy == PINFBITPATT_SP32)
-               ? __CLC_AS_GENTYPE((__CLC_UINTN)PINFBITPATT_SP32)
-               : retval;
+  retval = __clc_isinf(x) || __clc_isinf(y) ? __CLC_GENTYPE_INF : retval;
   return retval;
 }
 
@@ -86,13 +84,10 @@ _CLC_DEF _CLC_OVERLOAD __CLC_GENTYPE __clc_hypot(__CLC_GENTYPE x,
   r = c ? s : r;
 
   // Check for NaN
-  c = __clc_isnan(x) || __clc_isnan(y);
-  r = c ? __CLC_AS_GENTYPE((__CLC_ULONGN)QNANBITPATT_DP64) : r;
+  r = __clc_isnan(x) || __clc_isnan(y) ? __CLC_GENTYPE_NAN : r;
 
   // If either is Inf, we must return Inf
-  c = x == __CLC_AS_GENTYPE((__CLC_ULONGN)PINFBITPATT_DP64) ||
-      y == __CLC_AS_GENTYPE((__CLC_ULONGN)PINFBITPATT_DP64);
-  r = c ? __CLC_AS_GENTYPE((__CLC_ULONGN)PINFBITPATT_DP64) : r;
+  r = __clc_isinf(x) || __clc_isinf(y) ? __CLC_GENTYPE_INF : r;
 
   return r;
 }

--- a/libclc/clc/lib/generic/math/clc_log_base.h
+++ b/libclc/clc/lib/generic/math/clc_log_base.h
@@ -108,7 +108,6 @@ __clc_log(float x)
 #endif
 
   uint xi = __clc_as_uint(x);
-  uint ax = xi & EXSIGNBIT_SP32;
 
   // Calculations for |x-1| < 2^-4
   float r = x - 1.0f;
@@ -179,9 +178,9 @@ __clc_log(float x)
   z = near1 ? znear1 : z;
 
   // Corner cases
-  z = ax >= PINFBITPATT_SP32 ? x : z;
-  z = xi != ax ? __clc_as_float(QNANBITPATT_SP32) : z;
-  z = ax == 0 ? __clc_as_float(NINFBITPATT_SP32) : z;
+  z = __clc_isinf(x) ? FLT_PINF : z;
+  z = (__clc_isnan(x) || x < 0.0f) ? FLT_NAN : z;
+  z = x == 0.0f ? FLT_NINF : z;
 
   return z;
 }
@@ -311,9 +310,9 @@ __clc_log(double x)
 
   double ret = is_near ? ret_near : ret_far;
 
-  ret = __clc_isinf(x) ? __clc_as_double(PINFBITPATT_DP64) : ret;
-  ret = (__clc_isnan(x) | (x < 0.0)) ? __clc_as_double(QNANBITPATT_DP64) : ret;
-  ret = x == 0.0 ? __clc_as_double(NINFBITPATT_DP64) : ret;
+  ret = __clc_isinf(x) ? DBL_PINF : ret;
+  ret = (__clc_isnan(x) || x < 0.0) ? DBL_NAN : ret;
+  ret = x == 0.0 ? DBL_NINF : ret;
   return ret;
 }
 


### PR DESCRIPTION
This commit makes use of 'native' floating-point INF and NAN operations to implement certain patterns previously reliant on bithacking.

To aid in this, a 'gentype' version of INF and NAN were introduced to be used with users of clc/math/gentype.inc.