### PR TITLE
[flang][OpenMP][AMDGPU] Allow REAL(10) to compile on AMDGPU

### DIFF
--- a/flang/include/flang/Tools/TargetSetup.h
+++ b/flang/include/flang/Tools/TargetSetup.h
@@ -42,9 +42,14 @@ namespace Fortran::tools {
     targetCharacteristics.set_hasSubnormalFlushingControl(/*kind=*/8);
   }
 
-  if (targetTriple.getArch() != llvm::Triple::ArchType::x86_64) {
+  switch (targetTriple.getArch()) {
+  case llvm::Triple::ArchType::amdgcn:
+  case llvm::Triple::ArchType::x86_64:
+    break;
+  default:
     targetCharacteristics.DisableType(
         Fortran::common::TypeCategory::Real, /*kind=*/10);
+    break;
   }
 
   // Check for kind=16 support. See flang/runtime/Float128Math/math-entries.h.

--- a/flang/test/Lower/OpenMP/real10.f90
+++ b/flang/test/Lower/OpenMP/real10.f90
@@ -1,0 +1,13 @@
+!REQUIRES: amdgpu-registered-target
+
+!RUN: %flang_fc1 -emit-hlfir -fopenmp -triple amdgcn -fopenmp -fopenmp-is-target-device -o - %s | FileCheck %s
+
+!CHECK: hlfir.declare %0 {uniq_name = "_QFEx"} : (!fir.ref<f80>) -> (!fir.ref<f80>, !fir.ref<f80>)
+
+program p
+  real(10) :: x
+  !$omp target
+    continue
+  !$omp end target
+end
+


### PR DESCRIPTION
This will allow the following code to compile
```
program p
  real(10) :: x
  !$omp target
    continue
  !$omp end target
end
```