### PR TITLE
[clang][bytecode] Fix a crash in CheckConstantExpression

### DIFF
--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -210,7 +210,8 @@ APValue Pointer::toAPValue(const ASTContext &ASTCtx) const {
   };
 
   bool UsePath = true;
-  if (getType()->isLValueReferenceType())
+  if (const ValueDecl *VD = getDeclDesc()->asValueDecl();
+      VD && VD->getType()->isLValueReferenceType())
     UsePath = false;
 
   // Build the path into the object.


### PR DESCRIPTION
The APValue we generated for a pointer with a LValueReferenceType base had an incorrect lvalue path attached.

The attached test case is extracted from libc++'s regex.cpp.