### PR TITLE
[lldb-dap] Fix: disableASLR launch argument not working.

### DIFF
--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -31,7 +31,18 @@ MakeArgv(const llvm::ArrayRef<std::string> &strs) {
   return argv;
 }
 
-// Both attach and launch take a either a sourcePath or sourceMap
+static uint32_t SetLaunchFlag(uint32_t flags, const llvm::json::Object *obj,
+                              llvm::StringRef key, lldb::LaunchFlags mask,
+                              bool default_value) {
+  if (GetBoolean(obj, key).value_or(default_value))
+    flags |= mask;
+  else
+    flags &= ~mask;
+
+  return flags;
+}
+
+// Both attach and launch take either a sourcePath or a sourceMap
 // argument (or neither), from which we need to set the target.source-map.
 void RequestHandler::SetSourceMapFromArguments(
     const llvm::json::Object &arguments) const {
@@ -173,12 +184,13 @@ RequestHandler::LaunchProcess(const llvm::json::Object &request) const {
 
   auto flags = launch_info.GetLaunchFlags();
 
-  if (GetBoolean(arguments, "disableASLR").value_or(true))
-    flags |= lldb::eLaunchFlagDisableASLR;
-  if (GetBoolean(arguments, "disableSTDIO").value_or(false))
-    flags |= lldb::eLaunchFlagDisableSTDIO;
-  if (GetBoolean(arguments, "shellExpandArguments").value_or(false))
-    flags |= lldb::eLaunchFlagShellExpandArguments;
+  flags = SetLaunchFlag(flags, arguments, "disableASLR",
+                        lldb::eLaunchFlagDisableASLR, true);
+  flags = SetLaunchFlag(flags, arguments, "disableSTDIO",
+                        lldb::eLaunchFlagDisableSTDIO, false);
+  flags = SetLaunchFlag(flags, arguments, "shellExpandArguments",
+                        lldb::eLaunchFlagShellExpandArguments, false);
+
   const bool detachOnError =
       GetBoolean(arguments, "detachOnError").value_or(false);
   launch_info.SetDetachOnError(detachOnError);

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -33,11 +33,12 @@ MakeArgv(const llvm::ArrayRef<std::string> &strs) {
 
 static uint32_t SetLaunchFlag(uint32_t flags, const llvm::json::Object *obj,
                               llvm::StringRef key, lldb::LaunchFlags mask) {
-  if (const auto opt_value = GetBoolean(obj, key))
-    if (opt_value.value())
+  if (const auto opt_value = GetBoolean(obj, key)) {
+    if (*opt_value)
       flags |= mask;
     else
       flags &= ~mask;
+  }
 
   return flags;
 }

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -32,12 +32,12 @@ MakeArgv(const llvm::ArrayRef<std::string> &strs) {
 }
 
 static uint32_t SetLaunchFlag(uint32_t flags, const llvm::json::Object *obj,
-                              llvm::StringRef key, lldb::LaunchFlags mask,
-                              bool default_value) {
-  if (GetBoolean(obj, key).value_or(default_value))
-    flags |= mask;
-  else
-    flags &= ~mask;
+                              llvm::StringRef key, lldb::LaunchFlags mask) {
+  if (const auto opt_value = GetBoolean(obj, key))
+    if (opt_value.value())
+      flags |= mask;
+    else
+      flags &= ~mask;
 
   return flags;
 }
@@ -185,11 +185,11 @@ RequestHandler::LaunchProcess(const llvm::json::Object &request) const {
   auto flags = launch_info.GetLaunchFlags();
 
   flags = SetLaunchFlag(flags, arguments, "disableASLR",
-                        lldb::eLaunchFlagDisableASLR, true);
+                        lldb::eLaunchFlagDisableASLR);
   flags = SetLaunchFlag(flags, arguments, "disableSTDIO",
-                        lldb::eLaunchFlagDisableSTDIO, false);
+                        lldb::eLaunchFlagDisableSTDIO);
   flags = SetLaunchFlag(flags, arguments, "shellExpandArguments",
-                        lldb::eLaunchFlagShellExpandArguments, false);
+                        lldb::eLaunchFlagShellExpandArguments);
 
   const bool detachOnError =
       GetBoolean(arguments, "detachOnError").value_or(false);


### PR DESCRIPTION
Fixes #94338 


https://github.com/user-attachments/assets/8a8bdd27-e476-4b6a-976d-7b1e4947c692

i used `pidof a.out | xargs pmap` to show the memory map of the binary