### PR TITLE
[readtapi] Condense output when comparing tbd files with mismatched inlined libraries

### DIFF
--- a/llvm/test/tools/llvm-readtapi/compare-left-single-inline.test
+++ b/llvm/test/tools/llvm-readtapi/compare-left-single-inline.test
@@ -38,32 +38,8 @@
 ; CHECK-NEXT:        x86_64-apple-ios-simulator
 ; CHECK-NEXT:                > _symB
 ; CHECK-NEXT:Inlined Reexported Frameworks/Libraries
-; CHECK-NEXT:        Alpine.framework/Alpine
-; CHECK-NEXT:                Current Version
-; CHECK-NEXT:                   > 1.2.3
-; CHECK-NEXT:                Compatibility Version
-; CHECK-NEXT:                   > 0
-; CHECK-NEXT:                Swift ABI Version
-; CHECK-NEXT:                   > 5
-; CHECK-NEXT:                Two Level Namespace
-; CHECK-NEXT:                   > true
-; CHECK-NEXT:                Application Extension Safe
-; CHECK-NEXT:                   > true
-; CHECK-NEXT:                Allowable Clients
-; CHECK-NEXT:                        i386-apple-macos
-; CHECK-NEXT:                               > ClientD
-; CHECK-NEXT:                Parent Umbrellas
-; CHECK-NEXT:                        i386-apple-macos
-; CHECK-NEXT:                               > System
-; CHECK-NEXT:                        x86_64-apple-ios-simulator
-; CHECK-NEXT:                               > System
-; CHECK-NEXT:                Symbols
-; CHECK-NEXT:                        i386-apple-macos
-; CHECK-NEXT:                                > _symA
-; CHECK-NEXT:                                > .objc_class_name_Class1
-; CHECK-NEXT:                                > _symC - Weak-Defined
-; CHECK-NEXT:                        x86_64-apple-ios-simulator
-; CHECK-NEXT:                                > _symB
+; CHECK-NEXT: Install Name
+; CHECK-NEXT:        > Alpine.framework/Alpine
 
 
 

--- a/llvm/test/tools/llvm-readtapi/compare-mismatched-inlines.test
+++ b/llvm/test/tools/llvm-readtapi/compare-mismatched-inlines.test
@@ -10,35 +10,8 @@
 ; CHECK-NEXT:               > Alpine.framework/Alpine
 ; CHECK-NEXT:               > System.framework/System
 ; CHECK-NEXT:Inlined Reexported Frameworks/Libraries
-; CHECK-NEXT:    System.framework/System
-; CHECK-NEXT:        Current Version
-; CHECK-NEXT:                > 1.3.3
-; CHECK-NEXT:        Compatibility Version
-; CHECK-NEXT:                > 1.2
-; CHECK-NEXT:        Swift ABI Version
-; CHECK-NEXT:                > 3
-; CHECK-NEXT:        Two Level Namespace
-; CHECK-NEXT:                > true
-; CHECK-NEXT:        Application Extension Safe
-; CHECK-NEXT:                > true
-; CHECK-NEXT:        Allowable Clients
-; CHECK-NEXT:                i386-apple-macos
-; CHECK-NEXT:                       > ClientA
-; CHECK-NEXT:                x86_64-apple-ios
-; CHECK-NEXT:                       > ClientA
-; CHECK-NEXT:        Parent Umbrellas
-; CHECK-NEXT:                i386-apple-macos
-; CHECK-NEXT:                       > System
-; CHECK-NEXT:                x86_64-apple-ios
-; CHECK-NEXT:                       > System
-; CHECK-NEXT:        Symbols
-; CHECK-NEXT:                i386-apple-macos
-; CHECK-NEXT:                        > _symA
-; CHECK-NEXT:                        > _symC - Reexported
-; CHECK-NEXT:                        > _symD - Undefined
-; CHECK-NEXT:                x86_64-apple-ios
-; CHECK-NEXT:                        > _symB
-; CHECK-NEXT:                        > _symAB
+; CHECK-NEXT: Install Name
+; CHECK-NEXT:    > System.framework/System
 
 ; CHECK-NOT: error:
 ; CHECK-NOT: warning:

--- a/llvm/test/tools/llvm-readtapi/compare-multiple-inlines.test
+++ b/llvm/test/tools/llvm-readtapi/compare-multiple-inlines.test
@@ -42,61 +42,10 @@
 ; CHECK-NEXT:        x86_64-apple-ios-simulator
 ; CHECK-NEXT:                > _symB
 ; CHECK-NEXT:Inlined Reexported Frameworks/Libraries
-; CHECK-NEXT:        Alpine.framework/Alpine
-; CHECK-NEXT:                Current Version
-; CHECK-NEXT:                        >  1.2.3
-; CHECK-NEXT:                Compatibility Version
-; CHECK-NEXT:                        >  0
-; CHECK-NEXT:                Swift ABI Version
-; CHECK-NEXT:                        >  5
-; CHECK-NEXT:                Two Level Namespace
-; CHECK-NEXT:                        >  true
-; CHECK-NEXT:                Application Extension Safe
-; CHECK-NEXT:                        >  true
-; CHECK-NEXT:                Allowable Clients
-; CHECK-NEXT:                        i386-apple-macos
-; CHECK-NEXT:                               > ClientD
-; CHECK-NEXT:                Parent Umbrellas
-; CHECK-NEXT:                        i386-apple-macos
-; CHECK-NEXT:                               > System
-; CHECK-NEXT:                        x86_64-apple-ios-simulator
-; CHECK-NEXT:                               > System
-; CHECK-NEXT:                Symbols
-; CHECK-NEXT:                        i386-apple-macos
-; CHECK-NEXT:                                >  _symA
-; CHECK-NEXT:                                >  .objc_class_name_Class1
-; CHECK-NEXT:                                >  _symC - Weak-Defined
-; CHECK-NEXT:                        x86_64-apple-ios-simulator
-; CHECK-NEXT:                                >  _symB
-; CHECK-NEXT:        System.framework/System
-; CHECK-NEXT:                Current Version
-; CHECK-NEXT:                        >  1.3.3
-; CHECK-NEXT:                Compatibility Version
-; CHECK-NEXT:                        >  1.2
-; CHECK-NEXT:                Swift ABI Version
-; CHECK-NEXT:                        >  3
-; CHECK-NEXT:                Two Level Namespace
-; CHECK-NEXT:                        >  true
-; CHECK-NEXT:                Application Extension Safe
-; CHECK-NEXT:                        >  true
-; CHECK-NEXT:                Allowable Clients
-; CHECK-NEXT:                        i386-apple-macos
-; CHECK-NEXT:                               > ClientA
-; CHECK-NEXT:                        x86_64-apple-ios
-; CHECK-NEXT:                               > ClientA
-; CHECK-NEXT:                Parent Umbrellas
-; CHECK-NEXT:                        i386-apple-macos
-; CHECK-NEXT:                               > System
-; CHECK-NEXT:                        x86_64-apple-ios
-; CHECK-NEXT:                               > System
-; CHECK-NEXT:                Symbols
-; CHECK-NEXT:                        i386-apple-macos
-; CHECK-NEXT:                                >  _symA
-; CHECK-NEXT:                                >  _symC - Reexported
-; CHECK-NEXT:                                >  _symD - Undefined
-; CHECK-NEXT:                        x86_64-apple-ios
-; CHECK-NEXT:                                >  _symB
-; CHECK-NEXT:                                >  _symAB
+; CHECK-NEXT: Install Name
+; CHECK-NEXT:        > Alpine.framework/Alpine
+; CHECK-NEXT: Install Name
+; CHECK-NEXT:        > System.framework/System
 
 ; CHECK-NOT: error:
 ; CHECK-NOT: warning:

--- a/llvm/test/tools/llvm-readtapi/compare-right-single-inline.test
+++ b/llvm/test/tools/llvm-readtapi/compare-right-single-inline.test
@@ -35,32 +35,8 @@
 ; CHECK-NEXT:       x86_64-apple-ios-simulator
 ; CHECK-NEXT:                < _symB
 ; CHECK-NEXT:Inlined Reexported Frameworks/Libraries
-; CHECK-NEXT:        Alpine.framework/Alpine
-; CHECK-NEXT:                Current Version
-; CHECK-NEXT:                        <  1.2.3
-; CHECK-NEXT:                Compatibility Version
-; CHECK-NEXT:                        <  0
-; CHECK-NEXT:                Swift ABI Version
-; CHECK-NEXT:                        <  5
-; CHECK-NEXT:                Two Level Namespace
-; CHECK-NEXT:                        <  true
-; CHECK-NEXT:                Application Extension Safe
-; CHECK-NEXT:                        <  true
-; CHECK-NEXT:                Allowable Clients
-; CHECK-NEXT:                        i386-apple-macos
-; CHECK-NEXT:                               < ClientD
-; CHECK-NEXT:                Parent Umbrellas
-; CHECK-NEXT:                        i386-apple-macos
-; CHECK-NEXT:                               < System
-; CHECK-NEXT:                       x86_64-apple-ios-simulator
-; CHECK-NEXT:                               < System
-; CHECK-NEXT:                Symbols
-; CHECK-NEXT:                        i386-apple-macos
-; CHECK-NEXT:                                <  _symA
-; CHECK-NEXT:                                <  .objc_class_name_Class1
-; CHECK-NEXT:                                <  _symC - Weak-Defined
-; CHECK-NEXT:                       x86_64-apple-ios-simulator
-; CHECK-NEXT:                                <  _symB
+; CHECK-NEXT: Install Name
+; CHECK-NEXT:        < Alpine.framework/Alpine
 
 ; CHECK-NOT: error:
 ; CHECK-NOT: warning:

--- a/llvm/tools/llvm-readtapi/DiffEngine.cpp
+++ b/llvm/tools/llvm-readtapi/DiffEngine.cpp
@@ -203,27 +203,6 @@ std::vector<DiffOutput> getSingleIF(InterfaceFile *Interface,
   diffAttribute("Install Name", Output,
                 DiffScalarVal<StringRef, AD_Diff_Scalar_Str>(
                     Order, Interface->getInstallName()));
-  diffAttribute("Current Version", Output,
-                DiffScalarVal<PackedVersion, AD_Diff_Scalar_PackedVersion>(
-                    Order, Interface->getCurrentVersion()));
-  diffAttribute("Compatibility Version", Output,
-                DiffScalarVal<PackedVersion, AD_Diff_Scalar_PackedVersion>(
-                    Order, Interface->getCompatibilityVersion()));
-  diffAttribute("Swift ABI Version", Output,
-                DiffScalarVal<uint8_t, AD_Diff_Scalar_Unsigned>(
-                    Order, Interface->getSwiftABIVersion()));
-  diffAttribute("Two Level Namespace", Output,
-                DiffScalarVal<bool, AD_Diff_Scalar_Bool>(
-                    Order, Interface->isTwoLevelNamespace()));
-  diffAttribute("Application Extension Safe", Output,
-                DiffScalarVal<bool, AD_Diff_Scalar_Bool>(
-                    Order, Interface->isApplicationExtensionSafe()));
-  diffAttribute("Reexported Libraries", Output,
-                Interface->reexportedLibraries(), Order);
-  diffAttribute("Allowable Clients", Output, Interface->allowableClients(),
-                Order);
-  diffAttribute("Parent Umbrellas", Output, Interface->umbrellas(), Order);
-  diffAttribute("Symbols", Output, Interface->symbols(), Order);
   for (const auto &Doc : Interface->documents()) {
     DiffOutput Documents("Inlined Reexported Frameworks/Libraries");
     Documents.Kind = AD_Inline_Doc;
@@ -419,10 +398,11 @@ DiffEngine::findDifferences(const InterfaceFile *IFLHS,
           Docs.Values.push_back(
               std::make_unique<InlineDoc>(std::move(PairDiff)));
       }
-      // If a match is not found, get attributes from single item.
+      // No matching inlined library was found.
       else
-        Docs.Values.push_back(std::make_unique<InlineDoc>(InlineDoc(
-            DocLHS->getInstallName(), getSingleIF(DocLHS.get(), lhs))));
+        Docs.Values.push_back(std::make_unique<InlineDoc>(
+            InlineDoc(DocLHS->getInstallName(), getSingleIF(DocLHS.get(), lhs),
+                      /*IsMissingDoc=*/true)));
       DocsInserted.push_back(DocLHS->getInstallName());
     }
     for (auto DocRHS : IFRHS->documents()) {
@@ -431,8 +411,9 @@ DiffEngine::findDifferences(const InterfaceFile *IFLHS,
             return (GatheredDoc == DocRHS->getInstallName());
           });
       if (!WasGathered)
-        Docs.Values.push_back(std::make_unique<InlineDoc>(InlineDoc(
-            DocRHS->getInstallName(), getSingleIF(DocRHS.get(), rhs))));
+        Docs.Values.push_back(std::make_unique<InlineDoc>(
+            InlineDoc(DocRHS->getInstallName(), getSingleIF(DocRHS.get(), rhs),
+                      /*IsMissingDoc=*/true)));
     }
     if (!Docs.Values.empty())
       Output.push_back(std::move(Docs));
@@ -547,12 +528,23 @@ void DiffEngine::printDifferences(raw_ostream &OS,
     case AD_Inline_Doc:
       if (!Attr.Values.empty()) {
         OS << Indent << Attr.Name << "\n";
-        for (auto &Item : Attr.Values)
-          if (InlineDoc *Doc = dyn_cast<InlineDoc>(Item.get()))
-            if (!Doc->DocValues.empty()) {
+        for (auto &Item : Attr.Values) {
+          if (InlineDoc *Doc = dyn_cast<InlineDoc>(Item.get())) {
+            if (Doc->DocValues.empty())
+              continue;
+            IndentCounter = 2;
+            // When only one input file contains an inlined library, print out
+            // the install name for it. Otherwise print out the different values
+            // by the install name.
+            if (Doc->IsMissingDoc) {
+              printSingleVal<DiffScalarVal<StringRef, AD_Diff_Scalar_Str>>(
+                  std::string(IndentCounter, '\t'), Doc->DocValues.front(), OS);
+            } else {
               OS << Indent << "\t" << Doc->InstallName << "\n";
-              printDifferences(OS, std::move(Doc->DocValues), 2);
+              printDifferences(OS, std::move(Doc->DocValues), IndentCounter);
             }
+          }
+        }
       }
       break;
     }

--- a/llvm/tools/llvm-readtapi/DiffEngine.h
+++ b/llvm/tools/llvm-readtapi/DiffEngine.h
@@ -128,9 +128,12 @@ public:
   std::string InstallName;
   /// Differences found from each file.
   std::vector<DiffOutput> DocValues;
-  InlineDoc(StringRef InstName, std::vector<DiffOutput> Diff)
+  /// Whether document only exists for one input.
+  bool IsMissingDoc;
+  InlineDoc(StringRef InstName, std::vector<DiffOutput> Diff,
+            bool IsMissingDoc = false)
       : AttributeDiff(AD_Inline_Doc), InstallName(InstName),
-        DocValues(std::move(Diff)){};
+        DocValues(std::move(Diff)), IsMissingDoc(IsMissingDoc) {};
 
   static bool classof(const AttributeDiff *A) {
     return A->getKind() == AD_Inline_Doc;


### PR DESCRIPTION
Previously, when an inlined library existed in TBD file A but not in file B, all of the inlined library's attributes were printed. This is noisy since the important detail is the complete contents are missing. Instead, only print the install name of the inlined library and the marker for which the input file exists in.