### PR TITLE
[Assignment Tracking] Replace `undef` debug info with `poison`

### DIFF
--- a/clang/test/CodeGen/assignment-tracking/assignment-tracking.cpp
+++ b/clang/test/CodeGen/assignment-tracking/assignment-tracking.cpp
@@ -20,16 +20,16 @@ Large L;
 void zeroInit() { int Z[3] = {0, 0, 0}; }
 // CHECK-LABEL: define dso_local void @_Z8zeroInitv
 // CHECK:       %Z = alloca [3 x i32], align 4, !DIAssignID ![[ID_0:[0-9]+]]
-// CHECK-NEXT:  #dbg_assign(i1 undef, ![[VAR_0:[0-9]+]], !DIExpression(), ![[ID_0]], ptr %Z, !DIExpression(),
+// CHECK-NEXT:  #dbg_assign(i1 poison, ![[VAR_0:[0-9]+]], !DIExpression(), ![[ID_0]], ptr %Z, !DIExpression(),
 // CHECK:        @llvm.memset{{.*}}, !DIAssignID ![[ID_1:[0-9]+]]
 // CHECK-NEXT:   #dbg_assign(i8 0, ![[VAR_0]], !DIExpression(), ![[ID_1]], ptr %Z, !DIExpression(),
 
 void memcpyInit() { int A[4] = {0, 1, 2, 3}; }
 // CHECK-LABEL: define dso_local void @_Z10memcpyInitv
 // CHECK:       %A = alloca [4 x i32], align 16, !DIAssignID ![[ID_2:[0-9]+]]
-// CHECK-NEXT:  #dbg_assign(i1 undef, ![[VAR_1:[0-9]+]], !DIExpression(), ![[ID_2]], ptr %A, !DIExpression(),
+// CHECK-NEXT:  #dbg_assign(i1 poison, ![[VAR_1:[0-9]+]], !DIExpression(), ![[ID_2]], ptr %A, !DIExpression(),
 // CHECK:        @llvm.memcpy{{.*}}, !DIAssignID ![[ID_3:[0-9]+]]
-// CHECK-NEXT:   #dbg_assign(i1 undef, ![[VAR_1]], !DIExpression(), ![[ID_3]], ptr %A, !DIExpression(),
+// CHECK-NEXT:   #dbg_assign(i1 poison, ![[VAR_1]], !DIExpression(), ![[ID_3]], ptr %A, !DIExpression(),
 
 void setField() {
   Outer O;
@@ -37,7 +37,7 @@ void setField() {
 }
 // CHECK-LABEL: define dso_local void @_Z8setFieldv
 // CHECK:       %O = alloca %struct.Outer, align 4, !DIAssignID ![[ID_4:[0-9]+]]
-// CHECK-NEXT:  #dbg_assign(i1 undef, ![[VAR_2:[0-9]+]], !DIExpression(), ![[ID_4]], ptr %O, !DIExpression(),
+// CHECK-NEXT:  #dbg_assign(i1 poison, ![[VAR_2:[0-9]+]], !DIExpression(), ![[ID_4]], ptr %O, !DIExpression(),
 // CHECK:       store i32 %0, ptr %B, align 4,{{.*}}!DIAssignID ![[ID_5:[0-9]+]]
 // CHECK-NEXT:  #dbg_assign(i32 %0, ![[VAR_2]], !DIExpression(DW_OP_LLVM_fragment, 32, 32), ![[ID_5]], ptr %B, !DIExpression(),
 
@@ -47,7 +47,7 @@ void unknownOffset() {
 }
 // CHECK-LABEL: define dso_local void @_Z13unknownOffsetv
 // CHECK:       %A = alloca [2 x i32], align 4, !DIAssignID ![[ID_6:[0-9]+]]
-// CHECK-NEXT:  #dbg_assign(i1 undef, ![[VAR_3:[0-9]+]], !DIExpression(), ![[ID_6]], ptr %A, !DIExpression(),
+// CHECK-NEXT:  #dbg_assign(i1 poison, ![[VAR_3:[0-9]+]], !DIExpression(), ![[ID_6]], ptr %A, !DIExpression(),
 
 Inner sharedAlloca() {
   if (Cond) {
@@ -60,16 +60,16 @@ Inner sharedAlloca() {
 }
 // CHECK-LABEL: define dso_local i64 @_Z12sharedAllocav
 // CHECK:       %retval = alloca %struct.Inner, align 4, !DIAssignID ![[ID_7:[0-9]+]]
-// CHECK-NEXT:  #dbg_assign(i1 undef, ![[VAR_4:[0-9]+]], !DIExpression(), ![[ID_7]], ptr %retval, !DIExpression(),
-// CHECK-NEXT:  #dbg_assign(i1 undef, ![[VAR_5:[0-9]+]], !DIExpression(), ![[ID_7]], ptr %retval, !DIExpression(),
+// CHECK-NEXT:  #dbg_assign(i1 poison, ![[VAR_4:[0-9]+]], !DIExpression(), ![[ID_7]], ptr %retval, !DIExpression(),
+// CHECK-NEXT:  #dbg_assign(i1 poison, ![[VAR_5:[0-9]+]], !DIExpression(), ![[ID_7]], ptr %retval, !DIExpression(),
 // CHECK:     if.then:
 // CHECK:       call void @llvm.memcpy{{.*}}, !DIAssignID ![[ID_8:[0-9]+]]
-// CHECK-NEXT:  #dbg_assign(i1 undef, ![[VAR_4]], !DIExpression(), ![[ID_8]], ptr %retval, !DIExpression(),
-// CHECK-NEXT:  #dbg_assign(i1 undef, ![[VAR_5]], !DIExpression(), ![[ID_8]], ptr %retval, !DIExpression(),
+// CHECK-NEXT:  #dbg_assign(i1 poison, ![[VAR_4]], !DIExpression(), ![[ID_8]], ptr %retval, !DIExpression(),
+// CHECK-NEXT:  #dbg_assign(i1 poison, ![[VAR_5]], !DIExpression(), ![[ID_8]], ptr %retval, !DIExpression(),
 // CHECK:     if.else:
 // CHECK:       call void @llvm.memcpy{{.*}}, !DIAssignID ![[ID_9:[0-9]+]]
-// CHECK-NEXT:  #dbg_assign(i1 undef, ![[VAR_4]], !DIExpression(), ![[ID_9]], ptr %retval, !DIExpression(),
-// CHECK-NEXT:  #dbg_assign(i1 undef, ![[VAR_5]], !DIExpression(), ![[ID_9]], ptr %retval, !DIExpression(),
+// CHECK-NEXT:  #dbg_assign(i1 poison, ![[VAR_4]], !DIExpression(), ![[ID_9]], ptr %retval, !DIExpression(),
+// CHECK-NEXT:  #dbg_assign(i1 poison, ![[VAR_5]], !DIExpression(), ![[ID_9]], ptr %retval, !DIExpression(),
 
 Large sret() {
   Large X = L;

--- a/clang/test/CodeGen/assignment-tracking/memcpy-fragment.cpp
+++ b/clang/test/CodeGen/assignment-tracking/memcpy-fragment.cpp
@@ -23,7 +23,7 @@ void fragmentWhole()
  __builtin_memcpy(&dest.ch, &src, sizeof(char));
 }
 // CHECK: call void @llvm.memcpy{{.+}}, !DIAssignID ![[memberID:[0-9]+]]
-// CHECK-NEXT: #dbg_assign({{.*}}undef, !{{[0-9]+}}, !DIExpression(DW_OP_LLVM_fragment, 32, 8), ![[memberID]], ptr %ch, !DIExpression(),
+// CHECK-NEXT: #dbg_assign({{.*}}poison, !{{[0-9]+}}, !DIExpression(DW_OP_LLVM_fragment, 32, 8), ![[memberID]], ptr %ch, !DIExpression(),
 
 // Write starting at a field and overlapping part of another.
 void fragmentWholeToPartial()
@@ -38,7 +38,7 @@ void fragmentWholeToPartial()
  __builtin_memcpy(&dest.num1, &src, 5);
 }
 // CHECK: call void @llvm.memcpy{{.+}}, !DIAssignID ![[exceed:[0-9]+]]
-// CHECK-NEXT: #dbg_assign({{.*}}undef, !{{[0-9]+}}, !DIExpression(DW_OP_LLVM_fragment, 0, 40), ![[exceed]], ptr %num1, !DIExpression(),
+// CHECK-NEXT: #dbg_assign({{.*}}poison, !{{[0-9]+}}, !DIExpression(DW_OP_LLVM_fragment, 0, 40), ![[exceed]], ptr %num1, !DIExpression(),
 
 // Write starting between fields.
 void fragmentPartialToWhole()
@@ -54,4 +54,4 @@ void fragmentPartialToWhole()
  __builtin_memcpy((char*)&(dest.num2) + 3, &src, 5);
 }
 // CHECK: call void @llvm.memcpy{{.+}}, !DIAssignID ![[addendID:[0-9]+]]
-// CHECK-NEXT: #dbg_assign({{.*}}undef, !{{.*}}, !DIExpression(DW_OP_LLVM_fragment, 56, 40), ![[addendID]], ptr %add.ptr, !DIExpression(),
+// CHECK-NEXT: #dbg_assign({{.*}}poison, !{{.*}}, !DIExpression(DW_OP_LLVM_fragment, 56, 40), ![[addendID]], ptr %add.ptr, !DIExpression(),

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/long-double-x87.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/long-double-x87.ll
@@ -11,7 +11,7 @@
 ;; alloca (80 bits) can be represented with assignment tracking. Create a
 ;; fragment for the dbg.assign for bits 0-80.
 
-; CHECK: #dbg_assign(i1 undef, ![[#]], !DIExpression(DW_OP_LLVM_fragment, 0, 80), ![[#]], ptr %f, !DIExpression(),
+; CHECK: #dbg_assign(i1 poison, ![[#]], !DIExpression(DW_OP_LLVM_fragment, 0, 80), ![[#]], ptr %f, !DIExpression(),
 
 define dso_local void @_Z3funv() #0 !dbg !10 {
 entry:

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/structured-bindings.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/structured-bindings.ll
@@ -13,8 +13,8 @@
 ;; }
 
 ; CHECK: %0 = alloca %struct.two, align 4, !DIAssignID ![[ID1:[0-9]+]]
-; CHECK-NEXT: #dbg_assign(i1 undef, ![[AGGR:[0-9]+]], !DIExpression(), ![[ID1]], ptr %0, !DIExpression(),
-; CHECK-NEXT: #dbg_assign(i1 undef, ![[A:[0-9]+]], !DIExpression(), ![[ID1]], ptr %0, !DIExpression(),
+; CHECK-NEXT: #dbg_assign(i1 poison, ![[AGGR:[0-9]+]], !DIExpression(), ![[ID1]], ptr %0, !DIExpression(),
+; CHECK-NEXT: #dbg_assign(i1 poison, ![[A:[0-9]+]], !DIExpression(), ![[ID1]], ptr %0, !DIExpression(),
 ; CHECK-NEXT: #dbg_declare(ptr %0, ![[B:[0-9]+]], !DIExpression(DW_OP_plus_uconst, 4),
 
 ; CHECK: store i64 %call, ptr %0, align 4,{{.*}}, !DIAssignID ![[ID2:[0-9]+]]

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/var-not-alloca-sized.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/declare-to-assign/var-not-alloca-sized.ll
@@ -17,7 +17,7 @@ entry:
   %0 = alloca [4 x i16], align 4
   call void @llvm.dbg.declare(metadata ptr %0, metadata !15, metadata !DIExpression()), !dbg !16
 ; CHECK: %0 = alloca [4 x i16], align 4, !DIAssignID ![[ID1:[0-9]+]]
-; CHECK-NEXT: #dbg_assign(i1 undef, ![[#]], !DIExpression(), ![[ID1]], ptr %0, !DIExpression(),
+; CHECK-NEXT: #dbg_assign(i1 poison, ![[#]], !DIExpression(), ![[ID1]], ptr %0, !DIExpression(),
   %a = getelementptr inbounds [4 x i16], ptr %0, i32 0, i32 0
   %a.5 = getelementptr inbounds [4 x i16], ptr %0, i32 0, i32 1
   %b = getelementptr inbounds [4 x i16], ptr %0, i32 0, i32 2

--- a/llvm/test/DebugInfo/Generic/assignment-tracking/track-assignments.ll
+++ b/llvm/test/DebugInfo/Generic/assignment-tracking/track-assignments.ll
@@ -92,7 +92,7 @@ define dso_local void @_Z8zeroInitv() #0 !dbg !31 {
 entry:
   %Z = alloca [3 x i32], align 4
 ; CHECK:      %Z = alloca [3 x i32], align 4, !DIAssignID ![[ID_0:[0-9]+]]
-; CHECK-NEXT: #dbg_assign(i1 undef, ![[VAR_0:[0-9]+]], !DIExpression(), ![[ID_0]], ptr %Z, !DIExpression(),
+; CHECK-NEXT: #dbg_assign(i1 poison, ![[VAR_0:[0-9]+]], !DIExpression(), ![[ID_0]], ptr %Z, !DIExpression(),
   %0 = bitcast ptr %Z to ptr, !dbg !39
   call void @llvm.lifetime.start.p0(i64 12, ptr %0) #5, !dbg !39
   call void @llvm.dbg.declare(metadata ptr %Z, metadata !35, metadata !DIExpression()), !dbg !40
@@ -110,21 +110,21 @@ entry:
 ;;    void memcpyInit() { int A[4] = {0, 1, 2, 3}; }
 ;;
 ;; Check that we get two dbg.assign intrinsics. The first linked to the alloca
-;; and the second linked to the initialising memcpy, which should have an Undef
+;; and the second linked to the initialising memcpy, which should have a poison
 ;; value component.
 define dso_local void @_Z10memcpyInitv() #0 !dbg !42 {
 ; CHECK-LABEL: define dso_local void @_Z10memcpyInitv
 entry:
   %A = alloca [4 x i32], align 16
 ; CHECK:      %A = alloca [4 x i32], align 16, !DIAssignID ![[ID_2:[0-9]+]]
-; CHECK-NEXT: #dbg_assign(i1 undef, ![[VAR_1:[0-9]+]], !DIExpression(), ![[ID_2]], ptr %A, !DIExpression(),
+; CHECK-NEXT: #dbg_assign(i1 poison, ![[VAR_1:[0-9]+]], !DIExpression(), ![[ID_2]], ptr %A, !DIExpression(),
   %0 = bitcast ptr %A to ptr, !dbg !48
   call void @llvm.lifetime.start.p0(i64 16, ptr %0) #5, !dbg !48
   call void @llvm.dbg.declare(metadata ptr %A, metadata !44, metadata !DIExpression()), !dbg !49
   %1 = bitcast ptr %A to ptr, !dbg !49
   call void @llvm.memcpy.p0.p0.i64(ptr align 16 %1, ptr align 16 @__const._Z10memcpyInitv.A, i64 16, i1 false), !dbg !49
 ; CHECK:       @llvm.memcpy{{.*}}, !DIAssignID ![[ID_3:[0-9]+]]
-; CHECK-NEXT:  #dbg_assign(i1 undef, ![[VAR_1]], !DIExpression(), ![[ID_3]], ptr %1, !DIExpression(),
+; CHECK-NEXT:  #dbg_assign(i1 poison, ![[VAR_1]], !DIExpression(), ![[ID_3]], ptr %1, !DIExpression(),
   %2 = bitcast ptr %A to ptr, !dbg !50
   call void @llvm.lifetime.end.p0(i64 16, ptr %2) #5, !dbg !50
   ret void, !dbg !50
@@ -146,7 +146,7 @@ define dso_local void @_Z8setFieldv() #0 !dbg !51 {
 entry:
   %O = alloca %struct.Outer, align 4
 ; CHECK:      %O = alloca %struct.Outer, align 4, !DIAssignID ![[ID_4:[0-9]+]]
-; CHECK-NEXT: #dbg_assign(i1 undef, ![[VAR_2:[0-9]+]], !DIExpression(), ![[ID_4]], ptr %O, !DIExpression(),
+; CHECK-NEXT: #dbg_assign(i1 poison, ![[VAR_2:[0-9]+]], !DIExpression(), ![[ID_4]], ptr %O, !DIExpression(),
   %0 = bitcast ptr %O to ptr, !dbg !58
   call void @llvm.lifetime.start.p0(i64 16, ptr %0) #5, !dbg !58
   call void @llvm.dbg.declare(metadata ptr %O, metadata !53, metadata !DIExpression()), !dbg !59
@@ -178,7 +178,7 @@ define dso_local void @_Z13unknownOffsetv() #0 !dbg !72 {
 entry:
   %A = alloca [2 x i32], align 4
 ; CHECK:      %A = alloca [2 x i32], align 4, !DIAssignID ![[ID_6:[0-9]+]]
-; CHECK-NEXT: #dbg_assign(i1 undef, ![[VAR_3:[0-9]+]], !DIExpression(), ![[ID_6]], ptr %A, !DIExpression(),
+; CHECK-NEXT: #dbg_assign(i1 poison, ![[VAR_3:[0-9]+]], !DIExpression(), ![[ID_6]], ptr %A, !DIExpression(),
   %0 = bitcast ptr %A to ptr, !dbg !78
   call void @llvm.lifetime.start.p0(i64 8, ptr %0) #5, !dbg !78
   call void @llvm.dbg.declare(metadata ptr %A, metadata !74, metadata !DIExpression()), !dbg !79
@@ -209,8 +209,8 @@ define dso_local i64 @_Z12sharedAllocav() #0 !dbg !85 {
 entry:
   %retval = alloca %struct.Inner, align 4
 ; CHECK:      %retval = alloca %struct.Inner, align 4, !DIAssignID ![[ID_7:[0-9]+]]
-; CHECK-NEXT: #dbg_assign(i1 undef, ![[VAR_4:[0-9]+]], !DIExpression(), ![[ID_7]], ptr %retval, !DIExpression(),
-; CHECK-NEXT: #dbg_assign(i1 undef, ![[VAR_5:[0-9]+]], !DIExpression(), ![[ID_7]], ptr %retval, !DIExpression(),
+; CHECK-NEXT: #dbg_assign(i1 poison, ![[VAR_4:[0-9]+]], !DIExpression(), ![[ID_7]], ptr %retval, !DIExpression(),
+; CHECK-NEXT: #dbg_assign(i1 poison, ![[VAR_5:[0-9]+]], !DIExpression(), ![[ID_7]], ptr %retval, !DIExpression(),
   %0 = load i32, ptr @Cond, align 4, !dbg !94, !tbaa !61
   %tobool = icmp ne i32 %0, 0, !dbg !94
   br i1 %tobool, label %if.then, label %if.else, !dbg !95
@@ -221,8 +221,8 @@ if.then:                                          ; preds = %entry
   %1 = bitcast ptr %retval to ptr, !dbg !97
   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %1, ptr align 4 @InnerA, i64 8, i1 false), !dbg !97, !tbaa.struct !98
 ; CHECK:      call void @llvm.memcpy{{.*}}, !DIAssignID ![[ID_8:[0-9]+]]
-; CHECK-NEXT: #dbg_assign(i1 undef, ![[VAR_4]], !DIExpression(), ![[ID_8]], ptr %1, !DIExpression(),
-; CHECK-NEXT: #dbg_assign(i1 undef, ![[VAR_5]], !DIExpression(), ![[ID_8]], ptr %1, !DIExpression(),
+; CHECK-NEXT: #dbg_assign(i1 poison, ![[VAR_4]], !DIExpression(), ![[ID_8]], ptr %1, !DIExpression(),
+; CHECK-NEXT: #dbg_assign(i1 poison, ![[VAR_5]], !DIExpression(), ![[ID_8]], ptr %1, !DIExpression(),
   br label %return, !dbg !99
 
 if.else:                                          ; preds = %entry
@@ -231,8 +231,8 @@ if.else:                                          ; preds = %entry
   %2 = bitcast ptr %retval to ptr, !dbg !101
   call void @llvm.memcpy.p0.p0.i64(ptr align 4 %2, ptr align 4 @InnerB, i64 8, i1 false), !dbg !101, !tbaa.struct !98
 ; CHECK:      call void @llvm.memcpy{{.*}}, !DIAssignID ![[ID_9:[0-9]+]]
-; CHECK-NEXT: #dbg_assign(i1 undef, ![[VAR_4]], !DIExpression(), ![[ID_9]], ptr %2, !DIExpression(),
-; CHECK-NEXT: #dbg_assign(i1 undef, ![[VAR_5]], !DIExpression(), ![[ID_9]], ptr %2, !DIExpression(),
+; CHECK-NEXT: #dbg_assign(i1 poison, ![[VAR_4]], !DIExpression(), ![[ID_9]], ptr %2, !DIExpression(),
+; CHECK-NEXT: #dbg_assign(i1 poison, ![[VAR_5]], !DIExpression(), ![[ID_9]], ptr %2, !DIExpression(),
   br label %return, !dbg !102
 
 return:                                           ; preds = %if.else, %if.then
@@ -312,10 +312,10 @@ define dso_local noundef i32 @_Z3funi(i32 noundef %X) !dbg !139 {
 entry:
   %Y.addr.i = alloca i32, align 4
 ; CHECK:      %Y.addr.i = alloca i32, align 4, !DIAssignID ![[ID_10:[0-9]+]]
-; CHECK-NEXT: #dbg_assign(i1 undef, ![[VAR_6:[0-9]+]], !DIExpression(), ![[ID_10]], ptr %Y.addr.i, !DIExpression(), ![[DBG_0:[0-9]+]]
+; CHECK-NEXT: #dbg_assign(i1 poison, ![[VAR_6:[0-9]+]], !DIExpression(), ![[ID_10]], ptr %Y.addr.i, !DIExpression(), ![[DBG_0:[0-9]+]]
   %X.addr = alloca i32, align 4
 ; CHECK-NEXT: %X.addr = alloca i32, align 4, !DIAssignID ![[ID_11:[0-9]+]]
-; CHECK-NEXT: #dbg_assign(i1 undef, ![[VAR_7:[0-9]+]], !DIExpression(), ![[ID_11]], ptr %X.addr, !DIExpression(), ![[DBG_1:[0-9]+]]
+; CHECK-NEXT: #dbg_assign(i1 poison, ![[VAR_7:[0-9]+]], !DIExpression(), ![[ID_11]], ptr %X.addr, !DIExpression(), ![[DBG_1:[0-9]+]]
   store i32 %X, ptr %X.addr, align 4
 ; CHECK-NEXT: store i32 %X, ptr %X.addr, align 4, !DIAssignID ![[ID_12:[0-9]+]]
 ; CHECK-NEXT: #dbg_assign(i32 %X, ![[VAR_7]], !DIExpression(), ![[ID_12]], ptr %X.addr, !DIExpression(), ![[DBG_1]]

--- a/llvm/test/DebugInfo/Generic/sroa-alloca-offset.ll
+++ b/llvm/test/DebugInfo/Generic/sroa-alloca-offset.ll
@@ -98,15 +98,15 @@ entry:
 ; OLD-NEXT: #dbg_value(i32 %[[bb_reg]], ![[y1]], !DIExpression(DW_OP_LLVM_fragment, 32, 32),
 ; OLD-NEXT: #dbg_value(i32 %[[bb_reg]], ![[A1]], !DIExpression(DW_OP_LLVM_fragment, 96, 32),
 
-; NEW-NEXT: #dbg_assign(i1 undef, ![[x1:[0-9]+]], !DIExpression(DW_OP_LLVM_fragment, 32, 32), ![[#]], ptr %[[ab_ba_addr]], !DIExpression(),
-; NEW-NEXT: #dbg_assign(i1 undef, ![[A1:[0-9]+]], !DIExpression(DW_OP_LLVM_fragment, 32, 64), ![[#]], ptr %[[ab_ba_addr]], !DIExpression(),
+; NEW-NEXT: #dbg_assign(i1 poison, ![[x1:[0-9]+]], !DIExpression(DW_OP_LLVM_fragment, 32, 32), ![[#]], ptr %[[ab_ba_addr]], !DIExpression(),
+; NEW-NEXT: #dbg_assign(i1 poison, ![[A1:[0-9]+]], !DIExpression(DW_OP_LLVM_fragment, 32, 64), ![[#]], ptr %[[ab_ba_addr]], !DIExpression(),
 ; NEW-NEXT: #dbg_declare(ptr %[[ab_ba_addr]], ![[y1:[0-9]+]], !DIExpression(DW_OP_plus_uconst, 4, DW_OP_LLVM_fragment, 0, 32),
 ; NEW-NEXT: %[[aa_reg:.*]] = load i32, ptr @gf, align 4
 ; NEW-NEXT: llvm.memcpy{{.*}}(ptr align 4 %[[ab_ba_addr]], ptr align 4 getelementptr inbounds (i8, ptr @gf, i64 4), i64 8, i1 false){{.*}}, !DIAssignID ![[ID:[0-9]+]]
 ; NEW-NEXT: %[[bb_reg:.*]] = load i32, ptr getelementptr inbounds (i8, ptr @gf, i64 12), align 4
 ; NEW-NEXT: #dbg_value(i32 %[[bb_reg]], ![[y1:[0-9]+]], !DIExpression(DW_OP_LLVM_fragment, 32, 32),
 ; NEW-NEXT: #dbg_value(i32 %[[aa_reg]], ![[A1]], !DIExpression(DW_OP_LLVM_fragment, 0, 32),
-; NEW-NEXT: #dbg_assign(i1 undef, ![[A1]], !DIExpression(DW_OP_LLVM_fragment, 32, 64), ![[ID]], ptr %[[ab_ba_addr]], !DIExpression(),
+; NEW-NEXT: #dbg_assign(i1 poison, ![[A1]], !DIExpression(DW_OP_LLVM_fragment, 32, 64), ![[ID]], ptr %[[ab_ba_addr]], !DIExpression(),
 ; NEW-NEXT: #dbg_value(i32 %[[bb_reg]], ![[A1]], !DIExpression(DW_OP_LLVM_fragment, 96, 32),
 ; NEW-NEXT: #dbg_value(i32 %[[aa_reg]], ![[x1]], !DIExpression(DW_OP_LLVM_fragment, 0, 32),
 define dso_local noundef i32 @_Z4fun2v() #0 !dbg !48 {


### PR DESCRIPTION
`undef` debug info can be replaced with `poison` debug info.