### PR TITLE
Revert "[clang][dataflow] Fix unsupported types always being equal"

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/Transfer.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Transfer.cpp
@@ -60,9 +60,7 @@ static BoolValue &evaluateBooleanEquality(const Expr &LHS, const Expr &RHS,
   Value *LHSValue = Env.getValue(LHS);
   Value *RHSValue = Env.getValue(RHS);
 
-  // When two unsupported values are compared, both are nullptr. Only supported
-  // values should evaluate to equal.
-  if (LHSValue == RHSValue && LHSValue)
+  if (LHSValue == RHSValue)
     return Env.getBoolLiteralValue(true);
 
   if (auto *LHSBool = dyn_cast_or_null<BoolValue>(LHSValue))
@@ -798,14 +796,6 @@ public:
 
   void VisitIntegerLiteral(const IntegerLiteral *S) {
     Env.setValue(*S, Env.getIntLiteralValue(S->getValue()));
-  }
-
-  // Untyped nullptr's aren't handled by NullToPointer casts, so they need to be
-  // handled separately.
-  void VisitCXXNullPtrLiteralExpr(const CXXNullPtrLiteralExpr *S) {
-    auto &NullPointerVal =
-        Env.getOrCreateNullPointerValue(S->getType()->getPointeeType());
-    Env.setValue(*S, NullPointerVal);
   }
 
   void VisitParenExpr(const ParenExpr *S) {

--- a/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TransferTest.cpp
@@ -4974,41 +4974,6 @@ TEST(TransferTest, IntegerLiteralEquality) {
       });
 }
 
-TEST(TransferTest, UnsupportedValueEquality) {
-  std::string Code = R"(
-    // An explicitly unsupported type by the framework.
-    enum class EC {
-      A,
-      B
-    };
-  
-    void target() {
-      EC ec = EC::A;
-
-      bool unsupported_eq_same = (EC::A == EC::A);
-      bool unsupported_eq_other = (EC::A == EC::B);
-      bool unsupported_eq_var = (ec == EC::B);
-
-      (void)0; // [[p]]
-    }
-  )";
-  runDataflow(
-      Code,
-      [](const llvm::StringMap<DataflowAnalysisState<NoopLattice>> &Results,
-         ASTContext &ASTCtx) {
-        const Environment &Env = getEnvironmentAtAnnotation(Results, "p");
-
-        // We do not model the values of unsupported types, so this
-        // seemingly-trivial case will not be true either.
-        EXPECT_TRUE(isa<AtomicBoolValue>(
-            getValueForDecl<BoolValue>(ASTCtx, Env, "unsupported_eq_same")));
-        EXPECT_TRUE(isa<AtomicBoolValue>(
-            getValueForDecl<BoolValue>(ASTCtx, Env, "unsupported_eq_other")));
-        EXPECT_TRUE(isa<AtomicBoolValue>(
-            getValueForDecl<BoolValue>(ASTCtx, Env, "unsupported_eq_var")));
-      });
-}
-
 TEST(TransferTest, CorrelatedBranches) {
   std::string Code = R"(
     void target(bool B, bool C) {


### PR DESCRIPTION
Reverts llvm/llvm-project#129502

seeing new crashes around https://github.com/google/crubit/blob/859520eca82d60a169fb85cdbf648c57d0a14a99/nullability/test/smart_pointers_diagnosis.cc#L57 

Would like some time to investigate.