### PR TITLE
[flang-rt] Move unit-map.cpp to host-only sources list.

### DIFF
--- a/flang-rt/lib/runtime/CMakeLists.txt
+++ b/flang-rt/lib/runtime/CMakeLists.txt
@@ -66,7 +66,6 @@ set(supported_sources
   type-code.cpp
   type-info.cpp
   unit.cpp
-  unit-map.cpp
   utf.cpp
 )
 
@@ -86,6 +85,7 @@ set(host_sources
   stop.cpp
   temporary-stack.cpp
   time-intrinsic.cpp
+  unit-map.cpp
 )
 
 file(GLOB_RECURSE public_headers


### PR DESCRIPTION
This file is not enabled for the offload builds.
This patch aligns the list with flang/runtime/CMakeLists.txt
(that is about to be removed).
