### PR TITLE
[mlir][RFC] Bytecode: op fallback path

### DIFF
--- a/mlir/include/mlir/Bytecode/BytecodeImplementation.h
+++ b/mlir/include/mlir/Bytecode/BytecodeImplementation.h
@@ -21,6 +21,7 @@
 #include "mlir/IR/OpImplementation.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Support/ErrorHandling.h"
 
 namespace mlir {
 //===--------------------------------------------------------------------===//
@@ -443,6 +444,14 @@ public:
     reader.emitError() << "dialect " << getDialect()->getNamespace()
                        << " does not support reading types from bytecode";
     return Type();
+  }
+
+  /// Fall back to an operation of this type if parsing an op from bytecode
+  /// fails for any reason. This can be used to handle new ops emitted from a
+  /// different version of the dialect, that cannot be read by an older version
+  /// of the dialect.
+  virtual FailureOr<OperationName> getFallbackOperationName() const {
+    return failure();
   }
 
   //===--------------------------------------------------------------------===//

--- a/mlir/include/mlir/Bytecode/BytecodeOpInterface.td
+++ b/mlir/include/mlir/Bytecode/BytecodeOpInterface.td
@@ -50,16 +50,23 @@ def FallbackBytecodeOpInterface : OpInterface<"FallbackBytecodeOpInterface"> {
 
   let methods = [
     StaticInterfaceMethod<[{
+      Set the original name for this operation from the bytecode.
+      }],
+      "void", "setOriginalOperationName", (ins
+          "::mlir::StringRef":$opName,
+          "::mlir::OperationState &":$state)
+    >,
+    StaticInterfaceMethod<[{
       Read the properties blob for this operation from the bytecode and populate the state.
       }],
-      "LogicalResult", "readPropertiesBlob", (ins
-          "ArrayRef<char>":$blob,
+      "::mlir::LogicalResult", "readPropertiesBlob", (ins
+          "::mlir::ArrayRef<char>":$blob,
           "::mlir::OperationState &":$state)
     >,
     InterfaceMethod<[{
       Get the properties blob for this operation to be emitted into the bytecode.
       }],
-      "ArrayRef<char>", "getPropertiesBlob", (ins)
+      "::mlir::ArrayRef<char>", "getPropertiesBlob", (ins)
     >,
   ];
 }

--- a/mlir/include/mlir/Bytecode/BytecodeOpInterface.td
+++ b/mlir/include/mlir/Bytecode/BytecodeOpInterface.td
@@ -40,4 +40,28 @@ def BytecodeOpInterface : OpInterface<"BytecodeOpInterface"> {
   ];
 }
 
+// `FallbackBytecodeOpInterface`
+def FallbackBytecodeOpInterface : OpInterface<"FallbackBytecodeOpInterface"> {
+  let description = [{
+    This interface allows fallback operations direct access to the bytecode
+    property streams.
+  }];
+  let cppNamespace = "::mlir";
+
+  let methods = [
+    StaticInterfaceMethod<[{
+      Read the properties blob for this operation from the bytecode and populate the state.
+      }],
+      "LogicalResult", "readPropertiesBlob", (ins
+          "ArrayRef<char>":$blob,
+          "::mlir::OperationState &":$state)
+    >,
+    InterfaceMethod<[{
+      Get the properties blob for this operation to be emitted into the bytecode.
+      }],
+      "ArrayRef<char>", "getPropertiesBlob", (ins)
+    >,
+  ];
+}
+
 #endif // MLIR_BYTECODE_BYTECODEOPINTERFACES

--- a/mlir/include/mlir/Bytecode/BytecodeOpInterface.td
+++ b/mlir/include/mlir/Bytecode/BytecodeOpInterface.td
@@ -56,6 +56,11 @@ def FallbackBytecodeOpInterface : OpInterface<"FallbackBytecodeOpInterface"> {
           "::mlir::StringRef":$opName,
           "::mlir::OperationState &":$state)
     >,
+    InterfaceMethod<[{
+      Get the original name for this operation from the bytecode.
+      }],
+      "::mlir::StringRef", "getOriginalOperationName", (ins)
+    >,
     StaticInterfaceMethod<[{
       Read the properties blob for this operation from the bytecode and populate the state.
       }],

--- a/mlir/include/mlir/Bytecode/BytecodeOpInterface.td
+++ b/mlir/include/mlir/Bytecode/BytecodeOpInterface.td
@@ -43,8 +43,8 @@ def BytecodeOpInterface : OpInterface<"BytecodeOpInterface"> {
 // `FallbackBytecodeOpInterface`
 def FallbackBytecodeOpInterface : OpInterface<"FallbackBytecodeOpInterface"> {
   let description = [{
-    This interface allows fallback operations direct access to the bytecode
-    property streams.
+    This interface allows fallback operations sideband access to the 
+    original operation's intrinsic details.
   }];
   let cppNamespace = "::mlir";
 

--- a/mlir/include/mlir/Bytecode/BytecodeOpInterface.td
+++ b/mlir/include/mlir/Bytecode/BytecodeOpInterface.td
@@ -60,19 +60,7 @@ def FallbackBytecodeOpInterface : OpInterface<"FallbackBytecodeOpInterface"> {
       Get the original name for this operation from the bytecode.
       }],
       "::mlir::StringRef", "getOriginalOperationName", (ins)
-    >,
-    StaticInterfaceMethod<[{
-      Read the properties blob for this operation from the bytecode and populate the state.
-      }],
-      "::mlir::LogicalResult", "readPropertiesBlob", (ins
-          "::mlir::ArrayRef<char>":$blob,
-          "::mlir::OperationState &":$state)
-    >,
-    InterfaceMethod<[{
-      Get the properties blob for this operation to be emitted into the bytecode.
-      }],
-      "::mlir::ArrayRef<char>", "getPropertiesBlob", (ins)
-    >,
+    >
   ];
 }
 

--- a/mlir/include/mlir/Bytecode/BytecodeOpInterface.td
+++ b/mlir/include/mlir/Bytecode/BytecodeOpInterface.td
@@ -53,7 +53,7 @@ def FallbackBytecodeOpInterface : OpInterface<"FallbackBytecodeOpInterface"> {
       Set the original name for this operation from the bytecode.
       }],
       "void", "setOriginalOperationName", (ins
-          "::mlir::StringRef":$opName,
+          "const ::mlir::Twine&":$opName,
           "::mlir::OperationState &":$state)
     >,
     InterfaceMethod<[{

--- a/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
+++ b/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
@@ -21,6 +21,7 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include "llvm/Support/SourceMgr.h"
@@ -2257,8 +2258,11 @@ BytecodeReader::Impl::parseOpWithoutRegions(EncodingReader &reader,
   // state.
   OperationState opState(opLoc, *opName);
   // If this is a fallback op, provide the original name of the operation.
-  if (auto *iface = opName->getInterface<FallbackBytecodeOpInterface>())
-    iface->setOriginalOperationName((*bytecodeOp)->name, opState);
+  if (auto *iface = opName->getInterface<FallbackBytecodeOpInterface>()) {
+    const Twine originalName =
+        opName->getDialect()->getNamespace() + "." + (*bytecodeOp)->name;
+    iface->setOriginalOperationName(originalName, opState);
+  }
 
   // Parse the attributes of the operation.
   if (opMask & bytecode::OpEncodingMask::kHasAttrs) {

--- a/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
+++ b/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
@@ -1118,11 +1118,6 @@ public:
         return failure();
     }
 
-    // If the op is a "fallback" op, give it a handle to the raw properties
-    // buffer.
-    if (auto *iface = opName->getInterface<FallbackBytecodeOpInterface>())
-      return iface->readPropertiesBlob(rawProperties, opState);
-
     // Setup a new reader to read from the `rawProperties` sub-buffer.
     EncodingReader reader(
         StringRef(rawProperties.begin(), rawProperties.size()), fileLoc);
@@ -2182,6 +2177,9 @@ BytecodeReader::Impl::parseRegions(std::vector<RegionReadState> &regionStack,
 
         // Parse the bytecode.
         {
+          // If the op is registered (and serialized in a compatible manner), or
+          // unregistered but uses standard properties encoding, parsing without
+          // going through the fallback path should work.
           EncodingReader::Snapshot snapshot(reader);
           op = parseOpWithoutRegions(reader, readState, isIsolatedFromAbove,
                                      /*useDialectFallback=*/false);

--- a/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
+++ b/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
@@ -1883,9 +1883,11 @@ BytecodeReader::Impl::parseOpName(EncodingReader &reader,
       if (failed(opName->dialect->load(dialectReader, getContext())))
         return failure();
 
+      const BytecodeDialectInterface *dialectIface = opName->dialect->interface;
       if (useDialectFallback) {
-        auto fallbackOp =
-            opName->dialect->interface->getFallbackOperationName();
+        FailureOr<OperationName> fallbackOp =
+            dialectIface ? dialectIface->getFallbackOperationName()
+                         : FailureOr<OperationName>{};
 
         // If the dialect doesn't have a fallback operation, we can't parse as
         // instructed.

--- a/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
+++ b/mlir/lib/Bytecode/Reader/BytecodeReader.cpp
@@ -1117,13 +1117,13 @@ public:
               dialectReader.withEncodingReader(reader).readBlob(rawProperties)))
         return failure();
     }
-
     // Setup a new reader to read from the `rawProperties` sub-buffer.
     EncodingReader reader(
         StringRef(rawProperties.begin(), rawProperties.size()), fileLoc);
     DialectReader propReader = dialectReader.withEncodingReader(reader);
 
-    if (auto *iface = opName->getInterface<BytecodeOpInterface>())
+    auto *iface = opName->getInterface<BytecodeOpInterface>();
+    if (iface)
       return iface->readProperties(propReader, opState);
     if (opName->isRegistered())
       return propReader.emitError(

--- a/mlir/lib/Bytecode/Writer/BytecodeWriter.cpp
+++ b/mlir/lib/Bytecode/Writer/BytecodeWriter.cpp
@@ -518,6 +518,13 @@ public:
       return emit(scratch);
     }
 
+    if (auto iface = dyn_cast<FallbackBytecodeOpInterface>(op)) {
+      // Fallback ops should write the properties payload to the bytecode buffer
+      // directly.
+      ArrayRef<char> encodedProperties = iface.getPropertiesBlob();
+      return emit(encodedProperties);
+    }
+
     EncodingEmitter emitter;
     DialectWriter propertiesWriter(config.bytecodeVersion, emitter,
                                    numberingState, stringSection,

--- a/mlir/lib/Bytecode/Writer/BytecodeWriter.cpp
+++ b/mlir/lib/Bytecode/Writer/BytecodeWriter.cpp
@@ -518,13 +518,6 @@ public:
       return emit(scratch);
     }
 
-    if (auto iface = dyn_cast<FallbackBytecodeOpInterface>(op)) {
-      // Fallback ops should write the properties payload to the bytecode buffer
-      // directly.
-      ArrayRef<char> encodedProperties = iface.getPropertiesBlob();
-      return emit(encodedProperties);
-    }
-
     EncodingEmitter emitter;
     DialectWriter propertiesWriter(config.bytecodeVersion, emitter,
                                    numberingState, stringSection,

--- a/mlir/lib/Bytecode/Writer/IRNumbering.h
+++ b/mlir/lib/Bytecode/Writer/IRNumbering.h
@@ -63,14 +63,17 @@ struct TypeNumbering : public AttrTypeNumbering {
 
 /// This class represents the numbering entry of an operation name.
 struct OpNameNumbering {
-  OpNameNumbering(DialectNumbering *dialect, OperationName name)
-      : dialect(dialect), name(name) {}
+  OpNameNumbering(DialectNumbering *dialect, OperationName name, bool isOpaque)
+      : dialect(dialect), name(name), isOpaqueEntry(isOpaque) {}
 
   /// The dialect of this value.
   DialectNumbering *dialect;
 
   /// The concrete name.
   OperationName name;
+
+  /// This entry represents an opaque operation entry.
+  bool isOpaqueEntry = false;
 
   /// The number assigned to this name.
   unsigned number = 0;
@@ -210,7 +213,7 @@ public:
 
   /// Get the set desired bytecode version to emit.
   int64_t getDesiredBytecodeVersion() const;
-  
+
 private:
   /// This class is used to provide a fake dialect writer for numbering nested
   /// attributes and types.
@@ -225,7 +228,7 @@ private:
   DialectNumbering &numberDialect(Dialect *dialect);
   DialectNumbering &numberDialect(StringRef dialect);
   void number(Operation &op);
-  void number(OperationName opName);
+  void number(OperationName opName, bool isOpaque);
   void number(Region &region);
   void number(Type type);
 

--- a/mlir/test/Bytecode/versioning/versioning-fallback.mlir
+++ b/mlir/test/Bytecode/versioning/versioning-fallback.mlir
@@ -1,10 +1,23 @@
 // RUN: mlir-opt %s --emit-bytecode > %T/versioning-fallback.mlirbc
-"test.versionedD"() <{attribute = #test.attr_params<42, 24>}> : () -> ()
+"test.versionedD"() <{
+  attribute = #test.compound_attr_no_reading<
+    noReadingNested = #test.compound_attr_no_reading_nested<
+      value = "foo", 
+      payload = [24, "bar"]
+    >, 
+    supportsReading = #test.attr_params<42, 24>
+  >
+}> : () -> ()
 
 // COM: check that versionedD was parsed as a fallback op.
 // RUN: mlir-opt %T/versioning-fallback.mlirbc | FileCheck %s --check-prefix=CHECK-PARSE
 // CHECK-PARSE: test.bytecode.fallback 
-// CHECK-PARSE-SAME: opname = "test.versionedD"
+// CHECK-PARSE-SAME: encodedReqdAttributes = [#test.bytecode_fallback<attrIndex = 100, 
+// CHECK-PARSE-SAME:  encodedReqdAttributes = [#test.bytecode_fallback<attrIndex = 101, 
+// CHECK-PARSE-SAME:    encodedReqdAttributes = ["foo", [24, "bar"]], 
+// CHECK-PARSE-SAME:  #test.attr_params<42, 24>
+// CHECK-PARSE-SAME: opname = "test.versionedD", 
+// CHECK-PARSE-SAME: opversion = 1
 
 // COM: check that the bytecode roundtrip was successful
 // RUN: mlir-opt %T/versioning-fallback.mlirbc --verify-roundtrip

--- a/mlir/test/Bytecode/versioning/versioning-fallback.mlir
+++ b/mlir/test/Bytecode/versioning/versioning-fallback.mlir
@@ -1,0 +1,13 @@
+// RUN: mlir-opt %s --emit-bytecode > %T/versioning-fallback.mlirbc
+"test.versionedD"() <{attribute = #test.attr_params<42, 24>}> : () -> ()
+
+// COM: check that versionedD was parsed as a fallback op.
+// RUN: mlir-opt %T/versioning-fallback.mlirbc | FileCheck %s --check-prefix=CHECK-PARSE
+// CHECK-PARSE: test.bytecode.fallback 
+// CHECK-PARSE-SAME: opname = "test.versionedD"
+
+// COM: check that the bytecode roundtrip was successful
+// RUN: mlir-opt %T/versioning-fallback.mlirbc --verify-roundtrip
+
+// COM: check that the bytecode roundtrip is bitwise exact
+// RUN: mlir-opt %T/versioning-fallback.mlirbc --emit-bytecode | diff %T/versioning-fallback.mlirbc -

--- a/mlir/test/lib/Dialect/Test/TestAttrDefs.td
+++ b/mlir/test/lib/Dialect/Test/TestAttrDefs.td
@@ -405,4 +405,41 @@ def TestOpAsmAttrInterfaceAttr : Test_Attr<"TestOpAsmAttrInterface",
   }];
 }
 
+// Test fallback attributes.
+def TestBytecodeFallbackAttr : Test_Attr<"TestBytecodeFallback"> {
+  let mnemonic = "bytecode_fallback";
+  let parameters = (ins 
+    "uint64_t":$attrIndex,
+    "::mlir::ArrayAttr":$encodedReqdAttributes,
+    "::mlir::ArrayAttr":$encodedOptAttributes);
+
+  let assemblyFormat = [{
+    `<` struct(params) `>`
+  }];
+}
+
+// New nested CompoundAttr to validate bytecode fallback attr.
+def CompoundAttrNoReadingNested : Test_Attr<"CompoundAttrNoReadingNested"> {
+  let mnemonic = "compound_attr_no_reading_nested";
+  let parameters = (ins
+    "::mlir::StringAttr":$value,
+    "::mlir::ArrayAttr":$payload);
+
+  let assemblyFormat = [{
+    `<` struct(params) `>`
+  }];
+}
+
+// New CompoundAttr to validate bytecode fallback attr.
+def CompoundAttrNoReading : Test_Attr<"CompoundAttrNoReading"> {
+  let mnemonic = "compound_attr_no_reading";
+  let parameters = (ins
+    CompoundAttrNoReadingNested:$noReadingNested,
+    TestAttrParams:$supportsReading);
+  
+  let assemblyFormat = [{
+    `<` struct(params) `>`
+  }];
+}
+
 #endif // TEST_ATTRDEFS

--- a/mlir/test/lib/Dialect/Test/TestDialectInterfaces.cpp
+++ b/mlir/test/lib/Dialect/Test/TestDialectInterfaces.cpp
@@ -8,6 +8,7 @@
 
 #include "TestDialect.h"
 #include "TestOps.h"
+#include "mlir/IR/OperationSupport.h"
 #include "mlir/Interfaces/FoldInterfaces.h"
 #include "mlir/Reducer/ReductionPatternInterface.h"
 #include "mlir/Transforms/InliningUtils.h"
@@ -90,6 +91,11 @@ struct TestBytecodeDialectInterface : public BytecodeDialectInterface {
       return readAttrNewEncoding(reader);
     // Forbid reading future versions by returning nullptr.
     return Attribute();
+  }
+
+  FailureOr<OperationName> getFallbackOperationName() const final {
+    return OperationName(TestBytecodeFallbackOp::getOperationName(),
+                         getContext());
   }
 
   // Emit a specific version of the dialect.

--- a/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
+++ b/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
@@ -1261,7 +1261,7 @@ void TestVersionedOpA::writeProperties(mlir::DialectBytecodeWriter &writer) {
 // TestBytecodeFallbackOp
 //===----------------------------------------------------------------------===//
 
-void TestBytecodeFallbackOp::setOriginalOperationName(StringRef name,
+void TestBytecodeFallbackOp::setOriginalOperationName(const Twine &name,
                                                       OperationState &state) {
   state.getOrAddProperties<Properties>().setOpname(
       StringAttr::get(state.getContext(), name));

--- a/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
+++ b/mlir/test/lib/Dialect/Test/TestOpDefs.cpp
@@ -8,6 +8,7 @@
 
 #include "TestDialect.h"
 #include "TestOps.h"
+#include "mlir/Bytecode/BytecodeImplementation.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Verifier.h"
@@ -1264,6 +1265,10 @@ void TestBytecodeFallbackOp::setOriginalOperationName(StringRef name,
                                                       OperationState &state) {
   state.getOrAddProperties<Properties>().setOpname(
       StringAttr::get(state.getContext(), name));
+}
+
+StringRef TestBytecodeFallbackOp::getOriginalOperationName() {
+  return getProperties().getOpname().getValue();
 }
 
 LogicalResult

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -20,6 +20,7 @@ include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/PatternBase.td"
 include "mlir/IR/RegionKindInterface.td"
 include "mlir/IR/SymbolInterfaces.td"
+include "mlir/Bytecode/BytecodeOpInterface.td"
 include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/CopyOpInterface.td"
@@ -30,7 +31,6 @@ include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/LoopLikeInterface.td"
 include "mlir/Interfaces/MemorySlotInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
-
 
 // Include the attribute definitions.
 include "TestAttrDefs.td"
@@ -3028,6 +3028,25 @@ def TestVersionedOpC : TEST_Op<"versionedC"> {
   let arguments = (ins AnyAttrOf<[TestAttrParams,
                                   I32ElementsAttr]>:$attribute
   );
+}
+
+// def TestVersionedOpD : TEST_Op<"versionedD"> {
+//   let arguments = (ins AnyAttrOf<[TestAttrParams,
+//                                   I32ElementsAttr]>:$attribute
+//   );
+
+//   let useCustomPropertiesEncoding = 1;
+// }
+
+def TestBytecodeFallbackOp : TEST_Op<"bytecode.fallback", [
+  DeclareOpInterfaceMethods<FallbackBytecodeOpInterface, ["setOriginalOperationName", "readPropertiesBlob", "getPropertiesBlob"]>
+]> {
+  let arguments = (ins 
+    StrAttr:$opname,
+    DenseI8ArrayAttr:$bytecodeProperties,
+    Variadic<AnyType>:$operands);
+  let regions = (region VariadicRegion<AnyRegion>:$bodyRegions);
+  let results = (outs Variadic<AnyType>:$results);
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -3040,7 +3040,7 @@ def TestVersionedOpD : TEST_Op<"versionedD"> {
 }
 
 def TestBytecodeFallbackOp : TEST_Op<"bytecode.fallback", [
-  DeclareOpInterfaceMethods<FallbackBytecodeOpInterface, ["setOriginalOperationName", "readPropertiesBlob", "getPropertiesBlob"]>
+  DeclareOpInterfaceMethods<FallbackBytecodeOpInterface, ["setOriginalOperationName"]>
 ]> {
   let arguments = (ins 
     StrAttr:$opname,

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -3030,23 +3030,28 @@ def TestVersionedOpC : TEST_Op<"versionedC"> {
   );
 }
 
-// def TestVersionedOpD : TEST_Op<"versionedD"> {
-//   let arguments = (ins AnyAttrOf<[TestAttrParams,
-//                                   I32ElementsAttr]>:$attribute
-//   );
+// This op is used to generate tests for the bytecode dialect fallback path.
+def TestVersionedOpD : TEST_Op<"versionedD"> {
+  let arguments = (ins AnyAttrOf<[TestAttrParams,
+                                  I32ElementsAttr]>:$attribute
+  );
 
-//   let useCustomPropertiesEncoding = 1;
-// }
+  let useCustomPropertiesEncoding = 1;
+}
 
 def TestBytecodeFallbackOp : TEST_Op<"bytecode.fallback", [
   DeclareOpInterfaceMethods<FallbackBytecodeOpInterface, ["setOriginalOperationName", "readPropertiesBlob", "getPropertiesBlob"]>
 ]> {
   let arguments = (ins 
     StrAttr:$opname,
-    DenseI8ArrayAttr:$bytecodeProperties,
+    IntProp<"int64_t">:$opversion,
+    ArrayAttr:$encodedReqdAttributes,
+    ArrayAttr:$encodedOptAttributes,
     Variadic<AnyType>:$operands);
   let regions = (region VariadicRegion<AnyRegion>:$bodyRegions);
   let results = (outs Variadic<AnyType>:$results);
+
+  let useCustomPropertiesEncoding = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -3032,7 +3032,7 @@ def TestVersionedOpC : TEST_Op<"versionedC"> {
 
 // This op is used to generate tests for the bytecode dialect fallback path.
 def TestVersionedOpD : TEST_Op<"versionedD"> {
-  let arguments = (ins AnyAttrOf<[TestAttrParams,
+  let arguments = (ins AnyAttrOf<[CompoundAttrNoReading,
                                   I32ElementsAttr]>:$attribute
   );
 


### PR DESCRIPTION
Bytecode dialect versioning today is built around the premise that MLIR bytecode is used as a long-term storage format: specifically, that the producing process has knowledge about the version of dialect to target, and is able to downgrade the dialect prior to serialization. If it cannot, this is an error at serialization time.

This poses a problem if bytecode is used as an exchange format between distributed compilers with different versions of the dialect. If a given module references an operation that the receiving process doesn't know about, or utilizes a newer version of the op that the receiving process doesn't have support for, the receiving process will fail to parse the bytecode in its entirety, regardless of whether or not the failing operation is relevant to the receiving process.

This proposal adds a fallback mechanism for dialects to construct an operation that maintains the semantics of the unknown operation, while supporting roundtrip bytecode serialization in a bitwise exact manner. Specifically, the flow changes to the following:
1. Attempt to deserialize bytecode using the standard dialect/op interface mechanisms.
2. If an op cannot be parsed, attempt to parse it again using the dialect fallback mechanism. This uses a sideband path to register the original operation's name with the fallback op, and requires that properties are encoded using a preset dialect-wide properties encoding scheme. The fallback op has flexible semantics to allow it to represent any op in the dialect.
3. When round-tripping back to bytecode, the numbering scheme uses the sideband path to reference the original operation's name, and use that in-place of the fallback op. Properties are serialized according to the dialect's standard encoding scheme.

Existing options considered:
- Unregistered operations: this does not work if the operation is registered on the sending side, but not on the receiving side. Unregistered operations require that properties are serialized as attributes, which breaks down if the sending side uses custom properties encoding for versioning. The registration state is also serialized into the bytecode, so it will be incorrect on the receiving side.
- Passing through the properties section as-is: the original version of this patch envisioned a fallback interface where the properties blob was read directly from the bytecode and then serialized back as-is during the roundtrip, eliminating the need for a standard property encoding scheme between dialect ops. Unfortunately, the numbering scheme in the round tripped bytecode doesn't match up with the numbers encoded in the attribute and type sections, because we're not able to number the attributes and types stored in the opaque properties blob.
- Downgrade on serialization: this adds significant overhead. It requires negotiating the minimum supported dialect version between the receiving processes, which may result in the semantics of the program changing significantly to accommodate. Furthermore, it does not solve the problem if the module cannot be downgraded. Alternatively, the serialization process could convert newer ops to opaque fallback ops at serialization time, but that would still require determining the dialect version of the receiving process.