### PR TITLE
[flang] Enforce C955 on DEALLOCATE

### DIFF
--- a/flang/lib/Semantics/check-deallocate.cpp
+++ b/flang/lib/Semantics/check-deallocate.cpp
@@ -89,6 +89,9 @@ void DeallocateChecker::Leave(const parser::DeallocateStmt &deallocateStmt) {
                           "Object in DEALLOCATE statement is not deallocatable"_err_en_US)
                       .Attach(std::move(
                           whyNot->set_severity(parser::Severity::Because)));
+                } else if (evaluate::ExtractCoarrayRef(*expr)) { // F'2023 C955
+                  context_.Say(source,
+                      "Component in DEALLOCATE statement may not be coindexed"_err_en_US);
                 }
               }
             },

--- a/flang/test/Semantics/deallocate05.f90
+++ b/flang/test/Semantics/deallocate05.f90
@@ -27,6 +27,11 @@ Integer :: pi
 Character(256) :: ee
 Procedure(Real) :: prp
 
+type at
+  real, allocatable :: a
+end type
+type(at) :: c[*]
+
 Allocate(rp)
 Deallocate(rp)
 
@@ -66,5 +71,8 @@ Deallocate(x, errmsg=ee, errmsg=ee)
 Deallocate(x, stat=s, errmsg=ee, stat=s)
 !ERROR: ERRMSG may not be duplicated in a DEALLOCATE statement
 Deallocate(x, stat=s, errmsg=ee, errmsg=ee)
+
+!ERROR: Component in DEALLOCATE statement may not be coindexed
+deallocate(c[1]%a)
 
 End Program deallocatetest


### PR DESCRIPTION
Constraint C955 in F'2023 prohibits an allocate-object from being coindexed.  We catch this on ALLOCATE statements but missed it on DEALLOCATE.