### PR TITLE
[NFC][DebugInfo] Wrap DILineInfo return type with std::optional to handle missing debug info.

### DIFF
--- a/llvm/include/llvm/DebugInfo/BTF/BTFContext.h
+++ b/llvm/include/llvm/DebugInfo/BTF/BTFContext.h
@@ -30,11 +30,11 @@ public:
     // BTF is no DWARF, so ignore this operation for now.
   }
 
-  DILineInfo getLineInfoForAddress(
+  std::optional<DILineInfo> getLineInfoForAddress(
       object::SectionedAddress Address,
       DILineInfoSpecifier Specifier = DILineInfoSpecifier()) override;
 
-  DILineInfo
+  std::optional<DILineInfo>
   getLineInfoForDataAddress(object::SectionedAddress Address) override;
 
   DILineInfoTable getLineInfoForAddressRange(

--- a/llvm/include/llvm/DebugInfo/DIContext.h
+++ b/llvm/include/llvm/DebugInfo/DIContext.h
@@ -252,10 +252,12 @@ public:
     return true;
   }
 
-  virtual DILineInfo getLineInfoForAddress(
+  // For getLineInfoForAddress and getLineInfoForDataAddress, std::nullopt is
+  // returned when debug info is missing for the given address.
+  virtual std::optional<DILineInfo> getLineInfoForAddress(
       object::SectionedAddress Address,
       DILineInfoSpecifier Specifier = DILineInfoSpecifier()) = 0;
-  virtual DILineInfo
+  virtual std::optional<DILineInfo>
   getLineInfoForDataAddress(object::SectionedAddress Address) = 0;
   virtual DILineInfoTable getLineInfoForAddressRange(
       object::SectionedAddress Address, uint64_t Size,

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFContext.h
@@ -386,10 +386,10 @@ public:
   ///            executable's debug info.
   DIEsForAddress getDIEsForAddress(uint64_t Address, bool CheckDWO = false);
 
-  DILineInfo getLineInfoForAddress(
+  std::optional<DILineInfo> getLineInfoForAddress(
       object::SectionedAddress Address,
       DILineInfoSpecifier Specifier = DILineInfoSpecifier()) override;
-  DILineInfo
+  std::optional<DILineInfo>
   getLineInfoForDataAddress(object::SectionedAddress Address) override;
   DILineInfoTable getLineInfoForAddressRange(
       object::SectionedAddress Address, uint64_t Size,

--- a/llvm/include/llvm/DebugInfo/PDB/PDBContext.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBContext.h
@@ -42,10 +42,10 @@ namespace pdb {
 
     void dump(raw_ostream &OS, DIDumpOptions DIDumpOpts) override;
 
-    DILineInfo getLineInfoForAddress(
+    std::optional<DILineInfo> getLineInfoForAddress(
         object::SectionedAddress Address,
         DILineInfoSpecifier Specifier = DILineInfoSpecifier()) override;
-    DILineInfo
+    std::optional<DILineInfo>
     getLineInfoForDataAddress(object::SectionedAddress Address) override;
     DILineInfoTable getLineInfoForAddressRange(
         object::SectionedAddress Address, uint64_t Size,

--- a/llvm/lib/DebugInfo/BTF/BTFContext.cpp
+++ b/llvm/lib/DebugInfo/BTF/BTFContext.cpp
@@ -20,12 +20,13 @@ using namespace llvm;
 using object::ObjectFile;
 using object::SectionedAddress;
 
-DILineInfo BTFContext::getLineInfoForAddress(SectionedAddress Address,
-                                             DILineInfoSpecifier Specifier) {
+std::optional<DILineInfo>
+BTFContext::getLineInfoForAddress(SectionedAddress Address,
+                                  DILineInfoSpecifier Specifier) {
   const BTF::BPFLineInfo *LineInfo = BTF.findLineInfo(Address);
   DILineInfo Result;
   if (!LineInfo)
-    return Result;
+    return std::nullopt;
 
   Result.LineSource = BTF.findString(LineInfo->LineOff);
   Result.FileName = BTF.findString(LineInfo->FileNameOff);
@@ -34,9 +35,10 @@ DILineInfo BTFContext::getLineInfoForAddress(SectionedAddress Address,
   return Result;
 }
 
-DILineInfo BTFContext::getLineInfoForDataAddress(SectionedAddress Address) {
+std::optional<DILineInfo>
+BTFContext::getLineInfoForDataAddress(SectionedAddress Address) {
   // BTF does not convey such information.
-  return {};
+  return std::nullopt;
 }
 
 DILineInfoTable

--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -1733,41 +1733,38 @@ DWARFContext::getLocalsForAddress(object::SectionedAddress Address) {
 std::optional<DILineInfo>
 DWARFContext::getLineInfoForAddress(object::SectionedAddress Address,
                                     DILineInfoSpecifier Spec) {
+  DILineInfo Result;
   DWARFCompileUnit *CU = getCompileUnitForCodeAddress(Address.Address);
   if (!CU)
-    return std::nullopt;
+    return Result;
 
-  DILineInfo Result;
-  bool HasDebugInfoForAddress = getFunctionNameAndStartLineForAddress(
+  getFunctionNameAndStartLineForAddress(
       CU, Address.Address, Spec.FNKind, Spec.FLIKind, Result.FunctionName,
       Result.StartFileName, Result.StartLine, Result.StartAddress);
   if (Spec.FLIKind != FileLineInfoKind::None) {
     if (const DWARFLineTable *LineTable = getLineTableForUnit(CU)) {
-      HasDebugInfoForAddress |= LineTable->getFileLineInfoForAddress(
+      LineTable->getFileLineInfoForAddress(
           {Address.Address, Address.SectionIndex}, Spec.ApproximateLine,
           CU->getCompilationDir(), Spec.FLIKind, Result);
     }
   }
-  if (!HasDebugInfoForAddress)
-    return std::nullopt;
 
   return Result;
 }
 
 std::optional<DILineInfo>
 DWARFContext::getLineInfoForDataAddress(object::SectionedAddress Address) {
+  DILineInfo Result;
   DWARFCompileUnit *CU = getCompileUnitForDataAddress(Address.Address);
   if (!CU)
-    return std::nullopt;
+    return Result;
 
   if (DWARFDie Die = CU->getVariableForAddress(Address.Address)) {
-    DILineInfo Result;
     Result.FileName = Die.getDeclFile(FileLineInfoKind::AbsoluteFilePath);
     Result.Line = Die.getDeclLine();
-    return Result;
   }
 
-  return std::nullopt;
+  return Result;
 }
 
 DILineInfoTable DWARFContext::getLineInfoForAddressRange(

--- a/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
+++ b/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
@@ -728,8 +728,11 @@ llvm::Error DwarfTransformer::verify(StringRef GsymPath,
           DICtx.getInliningInfoForAddress(SectAddr, DLIS);
       uint32_t NumDwarfInlineInfos = DwarfInlineInfos.getNumberOfFrames();
       if (NumDwarfInlineInfos == 0) {
-        DwarfInlineInfos.addFrame(
-            DICtx.getLineInfoForAddress(SectAddr, DLIS));
+        if (std::optional<DILineInfo> DwarfLineInfo =
+                DICtx.getLineInfoForAddress(SectAddr, DLIS))
+          DwarfInlineInfos.addFrame(*DwarfLineInfo);
+        else
+          DwarfInlineInfos.addFrame(DILineInfo());
       }
 
       // Check for 1 entry that has no file and line info

--- a/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
+++ b/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
@@ -728,11 +728,8 @@ llvm::Error DwarfTransformer::verify(StringRef GsymPath,
           DICtx.getInliningInfoForAddress(SectAddr, DLIS);
       uint32_t NumDwarfInlineInfos = DwarfInlineInfos.getNumberOfFrames();
       if (NumDwarfInlineInfos == 0) {
-        if (std::optional<DILineInfo> DwarfLineInfo =
-                DICtx.getLineInfoForAddress(SectAddr, DLIS))
-          DwarfInlineInfos.addFrame(*DwarfLineInfo);
-        else
-          DwarfInlineInfos.addFrame(DILineInfo());
+        DwarfInlineInfos.addFrame(
+            DICtx.getLineInfoForAddress(SectAddr, DLIS).value_or(DILineInfo()));
       }
 
       // Check for 1 entry that has no file and line info

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/VTuneSupportPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/VTuneSupportPlugin.cpp
@@ -71,10 +71,8 @@ static VTuneMethodBatch getMethodBatch(LinkGraph &G, bool EmitDebugInfo) {
         SAddr, Sym->getSize(),
         DILineInfoSpecifier::FileLineInfoKind::AbsoluteFilePath);
     Method.SourceFileSI = Batch.Strings.size();
-    if (std::optional<DILineInfo> LineInfo = DC->getLineInfoForAddress(SAddr))
-      Batch.Strings.push_back(LineInfo->FileName);
-    else
-      Batch.Strings.push_back(DILineInfo::BadString);
+    Batch.Strings.push_back(
+        DC->getLineInfoForAddress(SAddr).value_or(DILineInfo()).FileName);
     for (auto &LInfo : LinesInfo) {
       Method.LineTable.push_back(
           std::pair<unsigned, unsigned>{/*unsigned*/ Sym->getOffset(),

--- a/llvm/lib/ExecutionEngine/Orc/Debugging/VTuneSupportPlugin.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Debugging/VTuneSupportPlugin.cpp
@@ -71,7 +71,10 @@ static VTuneMethodBatch getMethodBatch(LinkGraph &G, bool EmitDebugInfo) {
         SAddr, Sym->getSize(),
         DILineInfoSpecifier::FileLineInfoKind::AbsoluteFilePath);
     Method.SourceFileSI = Batch.Strings.size();
-    Batch.Strings.push_back(DC->getLineInfoForAddress(SAddr).FileName);
+    if (std::optional<DILineInfo> LineInfo = DC->getLineInfoForAddress(SAddr))
+      Batch.Strings.push_back(LineInfo->FileName);
+    else
+      Batch.Strings.push_back(DILineInfo::BadString);
     for (auto &LInfo : LinesInfo) {
       Method.LineTable.push_back(
           std::pair<unsigned, unsigned>{/*unsigned*/ Sym->getOffset(),

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -565,9 +565,11 @@ static bool lookup(ObjectFile &Obj, DWARFContext &DICtx, uint64_t Address,
 
   // TODO: it is neccessary to set proper SectionIndex here.
   // object::SectionedAddress::UndefSection works for only absolute addresses.
-  if (DILineInfo LineInfo = DICtx.getLineInfoForAddress(
+  DILineInfo LineInfo;
+  if (std::optional<DILineInfo> DBGLineInfo = DICtx.getLineInfoForAddress(
           {Lookup, object::SectionedAddress::UndefSection}))
-    LineInfo.dump(OS);
+    LineInfo = *DBGLineInfo;
+  LineInfo.dump(OS);
 
   return true;
 }

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -565,11 +565,13 @@ static bool lookup(ObjectFile &Obj, DWARFContext &DICtx, uint64_t Address,
 
   // TODO: it is neccessary to set proper SectionIndex here.
   // object::SectionedAddress::UndefSection works for only absolute addresses.
-  DILineInfo LineInfo;
-  if (std::optional<DILineInfo> DBGLineInfo = DICtx.getLineInfoForAddress(
-          {Lookup, object::SectionedAddress::UndefSection}))
-    LineInfo = *DBGLineInfo;
-  LineInfo.dump(OS);
+  if (DILineInfo LineInfo =
+          DICtx
+              .getLineInfoForAddress(
+                  {Lookup, object::SectionedAddress::UndefSection})
+              .value_or(DILineInfo())) {
+    LineInfo.dump(OS);
+  }
 
   return true;
 }

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -7594,7 +7594,7 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
       else
         outs() << SymName << ":\n";
 
-      std::optional<DILineInfo> lastLine;
+      DILineInfo lastLine;
       for (uint64_t Index = Start; Index < End; Index += Size) {
         MCInst Inst;
 
@@ -7646,12 +7646,12 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
 
           // Print debug info.
           if (diContext) {
-            std::optional<DILineInfo> dli =
-                diContext->getLineInfoForAddress({PC, SectIdx});
+            DILineInfo dli = diContext->getLineInfoForAddress({PC, SectIdx})
+                                 .value_or(DILineInfo());
             // Print valid line info if it changed.
-            if (dli && dli != lastLine && dli->Line != 0)
-              outs() << "\t## " << dli->FileName << ':' << dli->Line << ':'
-                     << dli->Column;
+            if (dli != lastLine && dli.Line != 0)
+              outs() << "\t## " << dli.FileName << ':' << dli.Line << ':'
+                     << dli.Column;
             lastLine = dli;
           }
           outs() << "\n";

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -7594,7 +7594,7 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
       else
         outs() << SymName << ":\n";
 
-      DILineInfo lastLine;
+      std::optional<DILineInfo> lastLine;
       for (uint64_t Index = Start; Index < End; Index += Size) {
         MCInst Inst;
 
@@ -7646,11 +7646,12 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
 
           // Print debug info.
           if (diContext) {
-            DILineInfo dli = diContext->getLineInfoForAddress({PC, SectIdx});
+            std::optional<DILineInfo> dli =
+                diContext->getLineInfoForAddress({PC, SectIdx});
             // Print valid line info if it changed.
-            if (dli != lastLine && dli.Line != 0)
-              outs() << "\t## " << dli.FileName << ':' << dli.Line << ':'
-                     << dli.Column;
+            if (dli && dli != lastLine && dli->Line != 0)
+              outs() << "\t## " << dli->FileName << ':' << dli->Line << ':'
+                     << dli->Column;
             lastLine = dli;
           }
           outs() << "\n";

--- a/llvm/unittests/DebugInfo/BTF/BTFParserTest.cpp
+++ b/llvm/unittests/DebugInfo/BTF/BTFParserTest.cpp
@@ -343,17 +343,15 @@ TEST(BTFParserTest, btfContext) {
   BTFParser BTF;
   std::unique_ptr<BTFContext> Ctx = BTFContext::create(Mock.makeObj());
 
-  DILineInfo I1 = Ctx->getLineInfoForAddress({16, 1});
-  EXPECT_EQ(I1.Line, 7u);
-  EXPECT_EQ(I1.Column, 1u);
-  EXPECT_EQ(I1.FileName, "a.c");
-  EXPECT_EQ(I1.LineSource, "first line");
+  std::optional<DILineInfo> I1 = Ctx->getLineInfoForAddress({16, 1});
+  EXPECT_TRUE(I1.has_value());
+  EXPECT_EQ(I1->Line, 7u);
+  EXPECT_EQ(I1->Column, 1u);
+  EXPECT_EQ(I1->FileName, "a.c");
+  EXPECT_EQ(I1->LineSource, "first line");
 
-  DILineInfo I2 = Ctx->getLineInfoForAddress({24, 1});
-  EXPECT_EQ(I2.Line, 0u);
-  EXPECT_EQ(I2.Column, 0u);
-  EXPECT_EQ(I2.FileName, DILineInfo::BadString);
-  EXPECT_EQ(I2.LineSource, std::nullopt);
+  std::optional<DILineInfo> I2 = Ctx->getLineInfoForAddress({24, 1});
+  EXPECT_FALSE(I2.has_value());
 }
 
 static uint32_t mkInfo(uint32_t Kind) { return Kind << 24; }


### PR DESCRIPTION
Currently, `DIContext::getLineInfoForAddress` and `DIContext::getLineInfoForDataAddress` returns empty DILineInfo when the debug info is missing for the given address. This is not differentiable with the case when debug info is found for the given address but the debug info is default value (filename:linenum is <invalid>:0). 

This change wraps the return types of `DIContext::getLineInfoForAddress` and `DIContext::getLineInfoForDataAddress` with `std::optional`.