### PR TITLE
[flang][acc] Use non-boxed value for assumed-size in acc data clause

### DIFF
--- a/flang/test/Lower/OpenACC/acc-bounds.f90
+++ b/flang/test/Lower/OpenACC/acc-bounds.f90
@@ -92,8 +92,7 @@ contains
 ! CHECK: %[[DIMS0:.*]]:3 = fir.box_dims %[[DECL_ARG0]]#0, %c0{{.*}} : (!fir.box<!fir.array<?xf32>>, index) -> (index, index, index)
 ! CHECK: %[[UB:.*]] = arith.subi %[[DIMS0]]#1, %c1{{.*}} : index
 ! CHECK: %[[BOUND:.*]] = acc.bounds lowerbound(%c0{{.*}} : index) upperbound(%[[UB]] : index) extent(%[[DIMS0]]#1 : index) stride(%[[DIMS0]]#2 : index) startIdx(%c1{{.*}} : index) {strideInBytes = true}
-! CHECK: %[[ADDR:.*]] = fir.box_addr %[[DECL_ARG0]]#0 : (!fir.box<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>>
-! CHECK: %[[PRESENT:.*]] = acc.present varPtr(%[[ADDR]] : !fir.ref<!fir.array<?xf32>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.array<?xf32>> {name = "a"}
+! CHECK: %[[PRESENT:.*]] = acc.present varPtr(%[[DECL_ARG0]]#1 : !fir.ref<!fir.array<?xf32>>) bounds(%[[BOUND]]) -> !fir.ref<!fir.array<?xf32>> {name = "a"}
 ! CHECK: acc.kernels dataOperands(%[[PRESENT]] : !fir.ref<!fir.array<?xf32>>)
 
   subroutine acc_multi_strides(a)


### PR DESCRIPTION
Assumed-size arrays end up looking as follows at the HLFIR level:
```
  func.func @_QPsub(%arg0: !fir.ref<!fir.array<?xf64>> {fir.bindc_name =
"arr"}) {
    ...
    %1 = fir.shape %c-1 : (index) -> !fir.shape<1>
    %2:2 = hlfir.declare %arg0(%1) dummy_scope %0 {uniq_name =
"_QFsubEarr"} : (!fir.ref<!fir.array<?xf64>>, !fir.shape<1>,
!fir.dscope) -> (!fir.box<!fir.array<?xf64>>,
!fir.ref<!fir.array<?xf64>>)
```

The declare operation produces an entity with Fortran properties (wrapped via a box) or the raw data pointer. The current acc lowering uses the box value.

During ConvertHLFIRtoFIR, this leads to a forced materialization of descriptor even though the descriptor itself does not hold useful extent information (it holds -1). Other operations such as those that index the array access the raw pointer directly and thus do not force materialization of descriptor.

Since there is nothing useful in descriptor and since at end of the day the acc dialect can accept a pointer to the data, make it consistent. This is useful property because without any acc data clauses, an assumed-size array becomes live-in via raw pointer typically. Thus, the materialization of descriptor is not something acc lowering forces.