### PR TITLE
[clang dependency scanning] Make Current Working Directory Optimization Off by Default

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
@@ -67,7 +67,7 @@ enum class ScanningOptimizations {
   IgnoreCWD = (1 << 4),
 
   DSS_LAST_BITMASK_ENUM(IgnoreCWD),
-  Default = All
+  Default = All & (~IgnoreCWD)
 };
 
 #undef DSS_LAST_BITMASK_ENUM

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
@@ -67,6 +67,10 @@ enum class ScanningOptimizations {
   IgnoreCWD = (1 << 4),
 
   DSS_LAST_BITMASK_ENUM(IgnoreCWD),
+
+  // The build system needs to be aware that the current working
+  // directory is ignored. Without a good way of notifying the build
+  // system, it is less risky to default to off.
   Default = All & (~IgnoreCWD)
 };
 

--- a/clang/test/ClangScanDeps/modules-context-hash-cwd.c
+++ b/clang/test/ClangScanDeps/modules-context-hash-cwd.c
@@ -9,14 +9,14 @@
 // RUN: sed -e "s|DIR|%/t|g" %t/cdb3.json.in > %t/cdb3.json
 // RUN: sed -e "s|DIR|%/t|g" %t/cdb4.json.in > %t/cdb4.json
 // RUN: sed -e "s|DIR|%/t|g" %t/cdb5.json.in > %t/cdb5.json
-// RUN: clang-scan-deps -compilation-database %t/cdb0.json -format experimental-full > %t/result0.json
-// RUN: clang-scan-deps -compilation-database %t/cdb1.json -format experimental-full > %t/result1.json
+// RUN: clang-scan-deps -compilation-database %t/cdb0.json -format experimental-full -optimize-args=all > %t/result0.json
+// RUN: clang-scan-deps -compilation-database %t/cdb1.json -format experimental-full -optimize-args=all > %t/result1.json
 // It is not a typo to use cdb1.json for result2. We intend to use the same
 // compilation database, but different clang-scan-deps optimize-args options.
 // RUN: clang-scan-deps -compilation-database %t/cdb1.json -format experimental-full -optimize-args=header-search,system-warnings,vfs,canonicalize-macros > %t/result2.json
-// RUN: clang-scan-deps -compilation-database %t/cdb3.json -format experimental-full > %t/result3.json
-// RUN: clang-scan-deps -compilation-database %t/cdb4.json -format experimental-full > %t/result4.json
-// RUN: clang-scan-deps -compilation-database %t/cdb5.json -format experimental-full > %t/result5.json
+// RUN: clang-scan-deps -compilation-database %t/cdb3.json -format experimental-full -optimize-args=all > %t/result3.json
+// RUN: clang-scan-deps -compilation-database %t/cdb4.json -format experimental-full -optimize-args=all > %t/result4.json
+// RUN: clang-scan-deps -compilation-database %t/cdb5.json -format experimental-full -optimize-args=all > %t/result5.json
 // RUN: cat %t/result0.json %t/result1.json | FileCheck %s
 // RUN: cat %t/result0.json %t/result2.json | FileCheck %s -check-prefix=SKIPOPT
 // RUN: cat %t/result3.json %t/result4.json | FileCheck %s -check-prefix=RELPATH

--- a/clang/test/ClangScanDeps/modules-debug-dir.c
+++ b/clang/test/ClangScanDeps/modules-debug-dir.c
@@ -4,7 +4,7 @@
 // RUN: split-file %s %t
 // RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.in > %t/cdb.json
 // RUN: clang-scan-deps -compilation-database %t/cdb.json -format \
-// RUN:   experimental-full > %t/result.json
+// RUN:   experimental-full -optimize-args=all > %t/result.json
 // RUN: cat %t/result.json | sed 's:\\\\\?:/:g' | FileCheck %s
 
 //--- cdb.json.in


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/124786 implemented current working directory (CWD) optimization and the optimization was on by default. We have discovered that build system needs to be compatible with the CWD optimization and default off is a better behavior. The build system needs to be aware that the current working directory is ignored. Without a good way of notifying the build system, it is less risky to default to off. This PR implement the change. 

rdar://145860213