### PR TITLE
[lldb-dap] Return a std::optional<bool> from GetBoolean (NFC)

### DIFF
--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -787,7 +787,7 @@ bool DAP::HandleObject(const llvm::json::Object &object) {
       response_handler = std::make_unique<UnknownResponseHandler>("", id);
 
     // Result should be given, use null if not.
-    if (GetBoolean(object, "success", false)) {
+    if (GetBoolean(object, "success").value_or(false)) {
       llvm::json::Value Result = nullptr;
       if (auto *B = object.get("body")) {
         Result = std::move(*B);

--- a/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
@@ -61,7 +61,7 @@ void AttachRequestHandler::operator()(const llvm::json::Object &request) const {
       GetString(arguments, "gdb-remote-hostname", "localhost");
   if (pid != LLDB_INVALID_PROCESS_ID)
     attach_info.SetProcessID(pid);
-  const auto wait_for = GetBoolean(arguments, "waitFor", false);
+  const auto wait_for = GetBoolean(arguments, "waitFor").value_or(false);
   attach_info.SetWaitForLaunch(wait_for, false /*async*/);
   dap.init_commands = GetStrings(arguments, "initCommands");
   dap.pre_run_commands = GetStrings(arguments, "preRunCommands");
@@ -71,16 +71,17 @@ void AttachRequestHandler::operator()(const llvm::json::Object &request) const {
   auto attachCommands = GetStrings(arguments, "attachCommands");
   llvm::StringRef core_file = GetString(arguments, "coreFile");
   const uint64_t timeout_seconds = GetUnsigned(arguments, "timeout", 30);
-  dap.stop_at_entry =
-      core_file.empty() ? GetBoolean(arguments, "stopOnEntry", false) : true;
+  dap.stop_at_entry = core_file.empty()
+                          ? GetBoolean(arguments, "stopOnEntry").value_or(false)
+                          : true;
   dap.post_run_commands = GetStrings(arguments, "postRunCommands");
   const llvm::StringRef debuggerRoot = GetString(arguments, "debuggerRoot");
   dap.enable_auto_variable_summaries =
-      GetBoolean(arguments, "enableAutoVariableSummaries", false);
+      GetBoolean(arguments, "enableAutoVariableSummaries").value_or(false);
   dap.enable_synthetic_child_debugging =
-      GetBoolean(arguments, "enableSyntheticChildDebugging", false);
+      GetBoolean(arguments, "enableSyntheticChildDebugging").value_or(false);
   dap.display_extended_backtrace =
-      GetBoolean(arguments, "displayExtendedBacktrace", false);
+      GetBoolean(arguments, "displayExtendedBacktrace").value_or(false);
   dap.command_escape_prefix = GetString(arguments, "commandEscapePrefix", "`");
   dap.SetFrameFormat(GetString(arguments, "customFrameFormat"));
   dap.SetThreadFormat(GetString(arguments, "customThreadFormat"));

--- a/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
@@ -123,7 +123,8 @@ void DisassembleRequestHandler::operator()(
     return;
   }
 
-  const bool resolveSymbols = GetBoolean(arguments, "resolveSymbols", false);
+  const bool resolveSymbols =
+      GetBoolean(arguments, "resolveSymbols").value_or(false);
   llvm::json::Array instructions;
   const auto num_insts = insts.GetSize();
   for (size_t i = 0; i < num_insts; ++i) {

--- a/lldb/tools/lldb-dap/Handler/DisconnectRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/DisconnectRequestHandler.cpp
@@ -64,8 +64,8 @@ void DisconnectRequestHandler::operator()(
   const auto *arguments = request.getObject("arguments");
 
   bool defaultTerminateDebuggee = dap.is_attach ? false : true;
-  bool terminateDebuggee =
-      GetBoolean(arguments, "terminateDebuggee", defaultTerminateDebuggee);
+  bool terminateDebuggee = GetBoolean(arguments, "terminateDebuggee")
+                               .value_or(defaultTerminateDebuggee);
 
   lldb::SBError error = dap.Disconnect(terminateDebuggee);
   if (error.Fail())

--- a/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
@@ -258,7 +258,8 @@ void InitializeRequestHandler::operator()(
   // sourceInitFile option is not from formal DAP specification. It is only
   // used by unit tests to prevent sourcing .lldbinit files from environment
   // which may affect the outcome of tests.
-  bool source_init_file = GetBoolean(arguments, "sourceInitFile", true);
+  bool source_init_file =
+      GetBoolean(arguments, "sourceInitFile").value_or(true);
 
   // Do not source init files until in/out/err are configured.
   dap.debugger = lldb::SBDebugger::Create(false);
@@ -300,7 +301,7 @@ void InitializeRequestHandler::operator()(
   dap.PopulateExceptionBreakpoints();
   auto cmd = dap.debugger.GetCommandInterpreter().AddMultiwordCommand(
       "lldb-dap", "Commands for managing lldb-dap.");
-  if (GetBoolean(arguments, "supportsStartDebuggingRequest", false)) {
+  if (GetBoolean(arguments, "supportsStartDebuggingRequest").value_or(false)) {
     cmd.AddCommand(
         "start-debugging", new StartDebuggingRequestHandler(dap),
         "Sends a startDebugging request from the debug adapter to the client "

--- a/lldb/tools/lldb-dap/Handler/LaunchRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/LaunchRequestHandler.cpp
@@ -60,14 +60,14 @@ void LaunchRequestHandler::operator()(const llvm::json::Object &request) const {
   dap.exit_commands = GetStrings(arguments, "exitCommands");
   dap.terminate_commands = GetStrings(arguments, "terminateCommands");
   dap.post_run_commands = GetStrings(arguments, "postRunCommands");
-  dap.stop_at_entry = GetBoolean(arguments, "stopOnEntry", false);
+  dap.stop_at_entry = GetBoolean(arguments, "stopOnEntry").value_or(false);
   const llvm::StringRef debuggerRoot = GetString(arguments, "debuggerRoot");
   dap.enable_auto_variable_summaries =
-      GetBoolean(arguments, "enableAutoVariableSummaries", false);
+      GetBoolean(arguments, "enableAutoVariableSummaries").value_or(false);
   dap.enable_synthetic_child_debugging =
-      GetBoolean(arguments, "enableSyntheticChildDebugging", false);
+      GetBoolean(arguments, "enableSyntheticChildDebugging").value_or(false);
   dap.display_extended_backtrace =
-      GetBoolean(arguments, "displayExtendedBacktrace", false);
+      GetBoolean(arguments, "displayExtendedBacktrace").value_or(false);
   dap.command_escape_prefix = GetString(arguments, "commandEscapePrefix", "`");
   dap.SetFrameFormat(GetString(arguments, "customFrameFormat"));
   dap.SetThreadFormat(GetString(arguments, "customThreadFormat"));

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -173,19 +173,20 @@ RequestHandler::LaunchProcess(const llvm::json::Object &request) const {
 
   auto flags = launch_info.GetLaunchFlags();
 
-  if (GetBoolean(arguments, "disableASLR", true))
+  if (GetBoolean(arguments, "disableASLR").value_or(true))
     flags |= lldb::eLaunchFlagDisableASLR;
-  if (GetBoolean(arguments, "disableSTDIO", false))
+  if (GetBoolean(arguments, "disableSTDIO").value_or(false))
     flags |= lldb::eLaunchFlagDisableSTDIO;
-  if (GetBoolean(arguments, "shellExpandArguments", false))
+  if (GetBoolean(arguments, "shellExpandArguments").value_or(false))
     flags |= lldb::eLaunchFlagShellExpandArguments;
-  const bool detachOnError = GetBoolean(arguments, "detachOnError", false);
+  const bool detachOnError =
+      GetBoolean(arguments, "detachOnError").value_or(false);
   launch_info.SetDetachOnError(detachOnError);
   launch_info.SetLaunchFlags(flags | lldb::eLaunchFlagDebug |
                              lldb::eLaunchFlagStopAtEntry);
   const uint64_t timeout_seconds = GetUnsigned(arguments, "timeout", 30);
 
-  if (GetBoolean(arguments, "runInTerminal", false)) {
+  if (GetBoolean(arguments, "runInTerminal").value_or(false)) {
     if (llvm::Error err = RunInTerminal(dap, request, timeout_seconds))
       error.SetErrorString(llvm::toString(std::move(err)).c_str());
   } else if (launchCommands.empty()) {

--- a/lldb/tools/lldb-dap/Handler/StepInRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/StepInRequestHandler.cpp
@@ -74,7 +74,8 @@ void StepInRequestHandler::operator()(const llvm::json::Object &request) const {
   if (it != dap.step_in_targets.end())
     step_in_target = it->second;
 
-  const bool single_thread = GetBoolean(arguments, "singleThread", false);
+  const bool single_thread =
+      GetBoolean(arguments, "singleThread").value_or(false);
   lldb::RunMode run_mode =
       single_thread ? lldb::eOnlyThisThread : lldb::eOnlyDuringStepping;
   lldb::SBThread thread = dap.GetLLDBThread(*arguments);

--- a/lldb/tools/lldb-dap/Handler/VariablesRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/VariablesRequestHandler.cpp
@@ -99,7 +99,7 @@ void VariablesRequestHandler::operator()(
   bool hex = false;
   const auto *format = arguments->getObject("format");
   if (format)
-    hex = GetBoolean(format, "hex", false);
+    hex = GetBoolean(format, "hex").value_or(false);
 
   if (lldb::SBValueList *top_scope =
           dap.variables.GetTopLevelScope(variablesReference)) {

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -100,20 +100,20 @@ uint64_t GetUnsigned(const llvm::json::Object *obj, llvm::StringRef key,
   return GetUnsigned(*obj, key, fail_value);
 }
 
-bool GetBoolean(const llvm::json::Object &obj, llvm::StringRef key,
-                bool fail_value) {
+std::optional<bool> GetBoolean(const llvm::json::Object &obj,
+                               llvm::StringRef key) {
   if (auto value = obj.getBoolean(key))
     return *value;
   if (auto value = obj.getInteger(key))
     return *value != 0;
-  return fail_value;
+  return std::nullopt;
 }
 
-bool GetBoolean(const llvm::json::Object *obj, llvm::StringRef key,
-                bool fail_value) {
-  if (obj == nullptr)
-    return fail_value;
-  return GetBoolean(*obj, key, fail_value);
+std::optional<bool> GetBoolean(const llvm::json::Object *obj,
+                               llvm::StringRef key) {
+  if (obj != nullptr)
+    return GetBoolean(*obj, key);
+  return std::nullopt;
 }
 
 int64_t GetSigned(const llvm::json::Object &obj, llvm::StringRef key,

--- a/lldb/tools/lldb-dap/JSONUtils.h
+++ b/lldb/tools/lldb-dap/JSONUtils.h
@@ -102,13 +102,15 @@ uint64_t GetUnsigned(const llvm::json::Object *obj, llvm::StringRef key,
 ///     The key to use when extracting the value
 ///
 /// \return
-///     The boolean value for the specified \a key, or \a fail_value
+///     The boolean value for the specified \a key, or std::nullopt
 ///     if there is no key that matches or if the value is not a
 ///     boolean value of an integer.
-bool GetBoolean(const llvm::json::Object &obj, llvm::StringRef key,
-                bool fail_value);
-bool GetBoolean(const llvm::json::Object *obj, llvm::StringRef key,
-                bool fail_value);
+/// @{
+std::optional<bool> GetBoolean(const llvm::json::Object &obj,
+                               llvm::StringRef key);
+std::optional<bool> GetBoolean(const llvm::json::Object *obj,
+                               llvm::StringRef key);
+/// @}
 
 /// Extract the signed integer for the specified key from the
 /// specified object.


### PR DESCRIPTION
Return a std::optional<bool> from GetBoolean so you can distinguish between the value not being present and it being explicitly set to true or false. All existing uses are replaced by calling `value_or(fail_value`).

Motivated by #129753 