### PR TITLE
[WIP][CodeGen]  Modifying MBB's liveins representation as into regUnits

### DIFF
--- a/llvm/include/llvm/CodeGen/LivePhysRegs.h
+++ b/llvm/include/llvm/CodeGen/LivePhysRegs.h
@@ -202,14 +202,12 @@ bool isPhysRegUsedAfter(Register Reg, MachineBasicBlock::iterator MBI);
 /// any changes were made.
 static inline bool recomputeLiveIns(MachineBasicBlock &MBB) {
   LivePhysRegs LPR;
-  std::vector<MachineBasicBlock::RegisterMaskPair> OldLiveIns;
+  DenseSet<MCRegister> OldLiveIns;
 
   MBB.clearLiveIns(OldLiveIns);
   computeAndAddLiveIns(LPR, MBB);
-  MBB.sortUniqueLiveIns();
 
-  const std::vector<MachineBasicBlock::RegisterMaskPair> &NewLiveIns =
-      MBB.getLiveIns();
+  const DenseSet<MCRegister> &NewLiveIns = MBB.getLiveIns();
   return OldLiveIns != NewLiveIns;
 }
 

--- a/llvm/include/llvm/CodeGen/LiveRegUnits.h
+++ b/llvm/include/llvm/CodeGen/LiveRegUnits.h
@@ -90,7 +90,7 @@ public:
 
   /// Adds register units covered by physical register \p Reg that are
   /// part of the lanemask \p Mask.
-  void addRegMasked(MCRegister Reg, LaneBitmask Mask) {
+  void addRegMasked(MCRegister Reg, LaneBitmask Mask = LaneBitmask::getAll()) {
     for (MCRegUnitMaskIterator Unit(Reg, TRI); Unit.isValid(); ++Unit) {
       LaneBitmask UnitMask = (*Unit).second;
       if ((UnitMask & Mask).any())

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -159,7 +159,6 @@ private:
 
   MachineFunction *xParent;
   Instructions Insts;
-  const TargetRegisterInfo *TRI;
 
   /// Keep track of the predecessor / successor basic blocks.
   SmallVector<MachineBasicBlock *, 4> Predecessors;

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -15,6 +15,7 @@
 
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/GraphTraits.h"
 #include "llvm/ADT/SparseBitVector.h"
 #include "llvm/ADT/ilist.h"
@@ -175,12 +176,7 @@ private:
   std::optional<uint64_t> IrrLoopHeaderWeight;
 
   /// Keep track of the physical registers that are livein of the basicblock.
-  using LiveInVector = std::vector<RegisterMaskPair>;
-  LiveInVector LiveIns;
-
-  /// Keeps track of live register units for those physical registers which
-  /// are livein of the basicblock.
-  BitVector LiveInRegUnits;
+  DenseSet<MCRegister> LiveIns;
 
   /// Alignment of the basic block. One if the basic block does not need to be
   /// aligned.
@@ -466,34 +462,17 @@ public:
 
   // LiveIn management methods.
 
-  /// Adds the specified register as a live in. Note that it is an error to add
-  /// the same register to the same set more than once unless the intention is
-  /// to call sortUniqueLiveIns after all registers are added.
+  /// Adds the live regUnits(both of its roots registers) as the live in, based
+  /// on the LaneMask.
   void addLiveIn(MCRegister PhysReg,
-                 LaneBitmask LaneMask = LaneBitmask::getAll()) {
-    LiveIns.push_back(RegisterMaskPair(PhysReg, LaneMask));
-    addLiveInRegUnit(PhysReg, LaneMask);
-  }
-  void addLiveIn(const RegisterMaskPair &RegMaskPair) {
-    LiveIns.push_back(RegMaskPair);
-    addLiveInRegUnit(RegMaskPair.PhysReg, RegMaskPair.LaneMask);
-  }
-
-  // Sets the register units for Reg based on the LaneMask in the
-  // LiveInRegUnits.
-  void addLiveInRegUnit(MCRegister Reg, LaneBitmask LaneMask);
-
-  /// Sorts and uniques the LiveIns vector. It can be significantly faster to do
-  /// this than repeatedly calling isLiveIn before calling addLiveIn for every
-  /// LiveIn insertion.
-  void sortUniqueLiveIns();
+                 LaneBitmask LaneMask = LaneBitmask::getAll());
 
   /// Clear live in list.
   void clearLiveIns();
 
   /// Clear the live in list, and return the removed live in's in \p OldLiveIns.
   /// Requires that the vector \p OldLiveIns is empty.
-  void clearLiveIns(std::vector<RegisterMaskPair> &OldLiveIns);
+  void clearLiveIns(DenseSet<MCRegister> &OldLiveIns);
 
   /// Add PhysReg as live in to this block, and ensure that there is a copy of
   /// PhysReg to a virtual register of class RC. Return the virtual register
@@ -504,16 +483,13 @@ public:
   void removeLiveIn(MCRegister Reg,
                     LaneBitmask LaneMask = LaneBitmask::getAll());
 
-  /// Resets the register units from LiveInRegUnits for the specified regsiters.
-  void removeLiveInRegUnit(MCRegister Reg);
-
   /// Return true if the specified register is in the live in set.
   bool isLiveIn(MCRegister Reg,
                 LaneBitmask LaneMask = LaneBitmask::getAll()) const;
 
   // Iteration support for live in sets.  These sets are kept in sorted
   // order by their register number.
-  using livein_iterator = LiveInVector::const_iterator;
+  using livein_iterator = DenseSet<MCRegister>::const_iterator;
 
   /// Unlike livein_begin, this method does not check that the liveness
   /// information is accurate. Still for debug purposes it may be useful
@@ -534,15 +510,15 @@ public:
   /// Remove entry from the livein set and return iterator to the next.
   livein_iterator removeLiveIn(livein_iterator I);
 
-  const std::vector<RegisterMaskPair> &getLiveIns() const { return LiveIns; }
+  const DenseSet<MCRegister> &getLiveIns() const { return LiveIns; }
 
   class liveout_iterator {
   public:
     using iterator_category = std::input_iterator_tag;
     using difference_type = std::ptrdiff_t;
-    using value_type = RegisterMaskPair;
-    using pointer = const RegisterMaskPair *;
-    using reference = const RegisterMaskPair &;
+    using value_type = MCRegister;
+    using pointer = const MCRegister *;
+    using reference = const MCRegister &;
 
     liveout_iterator(const MachineBasicBlock &MBB, MCPhysReg ExceptionPointer,
                      MCPhysReg ExceptionSelector, bool End)
@@ -555,8 +531,7 @@ public:
         LiveRegI = (*BlockI)->livein_begin();
         if (!advanceToValidPosition())
           return;
-        if (LiveRegI->PhysReg == ExceptionPointer ||
-            LiveRegI->PhysReg == ExceptionSelector)
+        if (*LiveRegI == ExceptionPointer || *LiveRegI == ExceptionSelector)
           ++(*this);
       }
     }
@@ -566,9 +541,8 @@ public:
         ++LiveRegI;
         if (!advanceToValidPosition())
           return *this;
-      } while ((*BlockI)->isEHPad() &&
-               (LiveRegI->PhysReg == ExceptionPointer ||
-                LiveRegI->PhysReg == ExceptionSelector));
+      } while ((*BlockI)->isEHPad() && (*LiveRegI == ExceptionPointer ||
+                                        *LiveRegI == ExceptionSelector));
       return *this;
     }
 

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_CODEGEN_MACHINEBASICBLOCK_H
 #define LLVM_CODEGEN_MACHINEBASICBLOCK_H
 
-#include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/GraphTraits.h"

--- a/llvm/lib/CodeGen/AggressiveAntiDepBreaker.cpp
+++ b/llvm/lib/CodeGen/AggressiveAntiDepBreaker.cpp
@@ -153,7 +153,7 @@ void AggressiveAntiDepBreaker::StartBlock(MachineBasicBlock *BB) {
   // Examine the live-in regs of all successors.
   for (MachineBasicBlock *Succ : BB->successors())
     for (const auto &LI : Succ->liveins()) {
-      for (MCRegAliasIterator AI(LI.PhysReg, TRI, true); AI.isValid(); ++AI) {
+      for (MCRegAliasIterator AI(LI, TRI, true); AI.isValid(); ++AI) {
         unsigned Reg = *AI;
         State->UnionGroups(Reg, 0);
         KillIndices[Reg] = BB->size();

--- a/llvm/lib/CodeGen/BranchFolding.cpp
+++ b/llvm/lib/CodeGen/BranchFolding.cpp
@@ -401,12 +401,7 @@ void BranchFolder::replaceTailWithBranchTo(MachineBasicBlock::iterator OldInst,
     // Merging the tails may have switched some undef operand to non-undef ones.
     // Add IMPLICIT_DEFS into OldMBB as necessary to have a definition of the
     // register.
-    for (MachineBasicBlock::RegisterMaskPair P : NewDest.liveins()) {
-      // We computed the liveins with computeLiveIn earlier and should only see
-      // full registers:
-      assert(P.LaneMask == LaneBitmask::getAll() &&
-             "Can only handle full register.");
-      MCRegister Reg = P.PhysReg;
+    for (MCRegister Reg : NewDest.liveins()) {
       if (!LiveRegs.available(*MRI, Reg))
         continue;
       DebugLoc DL;

--- a/llvm/lib/CodeGen/BranchRelaxation.cpp
+++ b/llvm/lib/CodeGen/BranchRelaxation.cpp
@@ -581,11 +581,10 @@ bool BranchRelaxation::fixupUnconditionalBranch(MachineInstr &MI) {
 
     // Add live outs.
     for (const MachineBasicBlock *Succ : MBB->successors()) {
-      for (const MachineBasicBlock::RegisterMaskPair &LiveIn : Succ->liveins())
+      for (const MCRegister LiveIn : Succ->liveins())
         BranchBB->addLiveIn(LiveIn);
     }
 
-    BranchBB->sortUniqueLiveIns();
     BranchBB->addSuccessor(DestBB);
     MBB->replaceSuccessor(DestBB, BranchBB);
     if (TrampolineInsertionPoint == MBB)

--- a/llvm/lib/CodeGen/CriticalAntiDepBreaker.cpp
+++ b/llvm/lib/CodeGen/CriticalAntiDepBreaker.cpp
@@ -66,10 +66,10 @@ void CriticalAntiDepBreaker::StartBlock(MachineBasicBlock *BB) {
   // Examine the live-in regs of all successors.
   for (const MachineBasicBlock *Succ : BB->successors())
     for (const auto &LI : Succ->liveins()) {
-      for (MCRegAliasIterator AI(LI.PhysReg, TRI, true); AI.isValid(); ++AI) {
-        MCRegister Reg = *AI;
-        Classes[Reg.id()] = reinterpret_cast<TargetRegisterClass *>(-1);
-        KillIndices[Reg.id()] = BBSize;
+      for (MCRegAliasIterator AI(LI, TRI, true); AI.isValid(); ++AI) {
+        unsigned Reg = (*AI).id();
+        Classes[Reg] = reinterpret_cast<TargetRegisterClass *>(-1);
+        KillIndices[Reg] = BBSize;
         DefIndices[Reg] = ~0u;
       }
     }

--- a/llvm/lib/CodeGen/CriticalAntiDepBreaker.cpp
+++ b/llvm/lib/CodeGen/CriticalAntiDepBreaker.cpp
@@ -67,9 +67,9 @@ void CriticalAntiDepBreaker::StartBlock(MachineBasicBlock *BB) {
   for (const MachineBasicBlock *Succ : BB->successors())
     for (const auto &LI : Succ->liveins()) {
       for (MCRegAliasIterator AI(LI, TRI, true); AI.isValid(); ++AI) {
-        unsigned Reg = (*AI).id();
-        Classes[Reg] = reinterpret_cast<TargetRegisterClass *>(-1);
-        KillIndices[Reg] = BBSize;
+        MCRegister Reg = *AI;
+        Classes[Reg.id()] = reinterpret_cast<TargetRegisterClass *>(-1);
+        KillIndices[Reg.id()] = BBSize;
         DefIndices[Reg] = ~0u;
       }
     }

--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -4192,9 +4192,8 @@ bool IRTranslator::runOnMachineFunction(MachineFunction &CurMF) {
                     EntryBB->end());
 
   // Update the live-in information for the new entry block.
-  for (const MachineBasicBlock::RegisterMaskPair &LiveIn : EntryBB->liveins())
+  for (const MCRegister LiveIn : EntryBB->liveins())
     NewEntryBB.addLiveIn(LiveIn);
-  NewEntryBB.sortUniqueLiveIns();
 
   // Get rid of the now empty basic block.
   EntryBB->removeSuccessor(&NewEntryBB);

--- a/llvm/lib/CodeGen/LiveIntervals.cpp
+++ b/llvm/lib/CodeGen/LiveIntervals.cpp
@@ -370,7 +370,7 @@ void LiveIntervals::computeLiveInRegUnits() {
     SlotIndex Begin = Indexes->getMBBStartIdx(&MBB);
     LLVM_DEBUG(dbgs() << Begin << "\t" << printMBBReference(MBB));
     for (const auto &LI : MBB.liveins()) {
-      for (MCRegUnit Unit : TRI->regunits(LI.PhysReg)) {
+      for (MCRegUnit Unit : TRI->regunits(LI)) {
         LiveRange *LR = RegUnitRanges[Unit];
         if (!LR) {
           // Use segment set to speed-up initial computation of the live range.

--- a/llvm/lib/CodeGen/LivePhysRegs.cpp
+++ b/llvm/lib/CodeGen/LivePhysRegs.cpp
@@ -153,21 +153,8 @@ bool LivePhysRegs::available(const MachineRegisterInfo &MRI,
 
 /// Add live-in registers of basic block \p MBB to \p LiveRegs.
 void LivePhysRegs::addBlockLiveIns(const MachineBasicBlock &MBB) {
-  for (const auto &LI : MBB.liveins()) {
-    MCRegister Reg = LI.PhysReg;
-    LaneBitmask Mask = LI.LaneMask;
-    MCSubRegIndexIterator S(Reg, TRI);
-    assert(Mask.any() && "Invalid livein mask");
-    if (Mask.all() || !S.isValid()) {
-      addReg(Reg);
-      continue;
-    }
-    for (; S.isValid(); ++S) {
-      unsigned SI = S.getSubRegIndex();
-      if ((Mask & TRI->getSubRegIndexLaneMask(SI)).any())
-        addReg(S.getSubReg());
-    }
-  }
+  for (const MCRegister Reg : MBB.liveins())
+    addReg(Reg);
 }
 
 /// Adds all callee saved registers to \p LiveRegs.

--- a/llvm/lib/CodeGen/LiveRegUnits.cpp
+++ b/llvm/lib/CodeGen/LiveRegUnits.cpp
@@ -88,7 +88,7 @@ void LiveRegUnits::accumulate(const MachineInstr &MI) {
 static void addBlockLiveIns(LiveRegUnits &LiveUnits,
                             const MachineBasicBlock &MBB) {
   for (const auto &LI : MBB.liveins())
-    LiveUnits.addRegMasked(LI.PhysReg, LI.LaneMask);
+    LiveUnits.addRegMasked(LI, LaneBitmask::getAll());
 }
 
 /// Adds all callee saved registers to \p LiveUnits.

--- a/llvm/lib/CodeGen/LiveRegUnits.cpp
+++ b/llvm/lib/CodeGen/LiveRegUnits.cpp
@@ -88,7 +88,7 @@ void LiveRegUnits::accumulate(const MachineInstr &MI) {
 static void addBlockLiveIns(LiveRegUnits &LiveUnits,
                             const MachineBasicBlock &MBB) {
   for (const auto &LI : MBB.liveins())
-    LiveUnits.addRegMasked(LI, LaneBitmask::getAll());
+    LiveUnits.addRegMasked(LI);
 }
 
 /// Adds all callee saved registers to \p LiveUnits.

--- a/llvm/lib/CodeGen/LiveVariables.cpp
+++ b/llvm/lib/CodeGen/LiveVariables.cpp
@@ -570,9 +570,8 @@ void LiveVariables::runOnBlock(MachineBasicBlock *MBB, unsigned NumRegs) {
   // Mark live-in registers as live-in.
   SmallVector<Register, 4> Defs;
   for (const auto &LI : MBB->liveins()) {
-    assert(LI.PhysReg.isPhysical() &&
-           "Cannot have a live-in virtual register!");
-    HandlePhysRegDef(LI.PhysReg, nullptr, Defs);
+    assert(LI.isPhysical() && "Cannot have a live-in virtual register!");
+    HandlePhysRegDef(LI, nullptr, Defs);
   }
 
   // Loop over all of the instructions, processing them.
@@ -606,9 +605,9 @@ void LiveVariables::runOnBlock(MachineBasicBlock *MBB, unsigned NumRegs) {
     if (SuccMBB->isEHPad())
       continue;
     for (const auto &LI : SuccMBB->liveins()) {
-      if (!TRI->isInAllocatableClass(LI.PhysReg))
+      if (!TRI->isInAllocatableClass(LI))
         // Ignore other live-ins, e.g. those that are live into landing pads.
-        LiveOuts.insert(LI.PhysReg);
+        LiveOuts.insert(LI);
     }
   }
 

--- a/llvm/lib/CodeGen/MIRPrinter.cpp
+++ b/llvm/lib/CodeGen/MIRPrinter.cpp
@@ -728,12 +728,9 @@ void printMBB(raw_ostream &OS, MFPrintState &State,
   if (!MBB.livein_empty()) {
     const TargetRegisterInfo &TRI = *MRI.getTargetRegisterInfo();
     OS.indent(2) << "liveins: ";
-    bool First = true;
-    for (const Register Reg : MBB.liveins_dbg()) {
-      if (!First)
-        OS << ", ";
-      First = false;
-      OS << printReg(Reg, &TRI);
+    ListSeparator LS;
+    for (const auto &LI : MBB.liveins_dbg()) {
+      OS << LS << printReg(LI, &TRI);
     }
     OS << "\n";
     HasLineAttributes = true;

--- a/llvm/lib/CodeGen/MIRPrinter.cpp
+++ b/llvm/lib/CodeGen/MIRPrinter.cpp
@@ -728,11 +728,12 @@ void printMBB(raw_ostream &OS, MFPrintState &State,
   if (!MBB.livein_empty()) {
     const TargetRegisterInfo &TRI = *MRI.getTargetRegisterInfo();
     OS.indent(2) << "liveins: ";
-    ListSeparator LS;
-    for (const auto &LI : MBB.liveins_dbg()) {
-      OS << LS << printReg(LI.PhysReg, &TRI);
-      if (!LI.LaneMask.all())
-        OS << ":0x" << PrintLaneMask(LI.LaneMask);
+    bool First = true;
+    for (const Register Reg : MBB.liveins_dbg()) {
+      if (!First)
+        OS << ", ";
+      First = false;
+      OS << printReg(Reg, &TRI);
     }
     OS << "\n";
     HasLineAttributes = true;

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -427,7 +427,7 @@ void MachineBasicBlock::print(raw_ostream &OS, ModuleSlotTracker &MST,
     OS.indent(2) << "liveins: ";
 
     ListSeparator LS;
-    for (const MCRegister Reg : liveins()) {
+    for (MCRegister Reg : liveins()) {
       OS << LS << printReg(Reg, TRI);
     }
     HasLineAttributes = true;
@@ -656,7 +656,7 @@ bool MachineBasicBlock::isLiveIn(MCRegister Reg, LaneBitmask LaneMask) const {
 Register
 MachineBasicBlock::addLiveIn(MCRegister PhysReg, const TargetRegisterClass *RC) {
   assert(getParent() && "MBB must be inserted in function");
-  assert(PhysReg && "Expected physreg");
+  assert(PhysReg.isPhysical() && "Expected physreg");
   assert(RC && "Register class is required");
   assert((isEHPad() || this == &getParent()->front()) &&
          "Only the entry block and landing pads can have physreg live ins");

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -35,6 +35,7 @@
 #include "llvm/IR/ModuleSlotTracker.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Target/TargetMachine.h"
@@ -51,10 +52,12 @@ static cl::opt<bool> PrintSlotIndexes(
     cl::init(true), cl::Hidden);
 
 MachineBasicBlock::MachineBasicBlock(MachineFunction &MF, const BasicBlock *B)
-    : BB(B), Number(-1), xParent(&MF) {
+    : BB(B), Number(-1), xParent(&MF),
+      TRI(MF.getSubtarget().getRegisterInfo()) {
   Insts.Parent = this;
   if (B)
     IrrLoopHeaderWeight = B->getIrrLoopHeaderWeight();
+  LiveInRegUnits.resize(TRI->getNumRegUnits());
 }
 
 MachineBasicBlock::~MachineBasicBlock() = default;
@@ -597,6 +600,14 @@ void MachineBasicBlock::printAsOperand(raw_ostream &OS,
   printName(OS, 0);
 }
 
+void MachineBasicBlock::addLiveInRegUnit(MCRegister Reg, LaneBitmask LaneMask) {
+  for (MCRegUnitMaskIterator Unit(Reg, TRI); Unit.isValid(); ++Unit) {
+    LaneBitmask UnitMask = (*Unit).second;
+    if ((UnitMask & LaneMask).any())
+      LiveInRegUnits.set((*Unit).first);
+  }
+}
+
 void MachineBasicBlock::removeLiveIn(MCRegister Reg, LaneBitmask LaneMask) {
   LiveInVector::iterator I = find_if(
       LiveIns, [Reg](const RegisterMaskPair &LI) { return LI.PhysReg == Reg; });
@@ -604,21 +615,32 @@ void MachineBasicBlock::removeLiveIn(MCRegister Reg, LaneBitmask LaneMask) {
     return;
 
   I->LaneMask &= ~LaneMask;
-  if (I->LaneMask.none())
+  if (I->LaneMask.none()) {
     LiveIns.erase(I);
+    removeLiveInRegUnit(I->PhysReg);
+  }
 }
 
 MachineBasicBlock::livein_iterator
 MachineBasicBlock::removeLiveIn(MachineBasicBlock::livein_iterator I) {
   // Get non-const version of iterator.
   LiveInVector::iterator LI = LiveIns.begin() + (I - LiveIns.begin());
+  removeLiveInRegUnit(LI->PhysReg);
   return LiveIns.erase(LI);
 }
 
+void MachineBasicBlock::removeLiveInRegUnit(MCRegister Reg) {
+  for (MCRegUnit Unit : TRI->regunits(Reg))
+    LiveInRegUnits.reset(Unit);
+}
+
 bool MachineBasicBlock::isLiveIn(MCRegister Reg, LaneBitmask LaneMask) const {
-  livein_iterator I = find_if(
-      LiveIns, [Reg](const RegisterMaskPair &LI) { return LI.PhysReg == Reg; });
-  return I != livein_end() && (I->LaneMask & LaneMask).any();
+  for (MCRegUnitMaskIterator Unit(Reg, TRI); Unit.isValid(); ++Unit) {
+    LaneBitmask UnitMask = (*Unit).second;
+    if ((UnitMask & LaneMask).any() && LiveInRegUnits.test((*Unit).first))
+      return true;
+  }
+  return false;
 }
 
 void MachineBasicBlock::sortUniqueLiveIns() {
@@ -1767,12 +1789,14 @@ MachineBasicBlock::getEndClobberMask(const TargetRegisterInfo *TRI) const {
 
 void MachineBasicBlock::clearLiveIns() {
   LiveIns.clear();
+  LiveInRegUnits.reset();
 }
 
 void MachineBasicBlock::clearLiveIns(
     std::vector<RegisterMaskPair> &OldLiveIns) {
   assert(OldLiveIns.empty() && "Vector must be empty");
   std::swap(LiveIns, OldLiveIns);
+  LiveInRegUnits.reset();
 }
 
 MachineBasicBlock::livein_iterator MachineBasicBlock::livein_begin() const {

--- a/llvm/lib/CodeGen/MachineCopyPropagation.cpp
+++ b/llvm/lib/CodeGen/MachineCopyPropagation.cpp
@@ -553,12 +553,9 @@ void MachineCopyPropagation::readSuccessorLiveIns(
   // If a copy result is livein to a successor, it is not dead.
   for (const MachineBasicBlock *Succ : MBB.successors()) {
     for (const auto &LI : Succ->liveins()) {
-      for (MCRegUnitMaskIterator U(LI.PhysReg, TRI); U.isValid(); ++U) {
-        auto [Unit, Mask] = *U;
-        if ((Mask & LI.LaneMask).any()) {
-          if (MachineInstr *Copy = Tracker.findCopyForUnit(Unit, *TRI))
-            MaybeDeadCopies.remove(Copy);
-        }
+      for (MCRegUnitIterator U(LI, TRI); U.isValid(); ++U) {
+        if (MachineInstr *Copy = Tracker.findCopyForUnit(*U, *TRI))
+          MaybeDeadCopies.remove(Copy);
       }
     }
   }

--- a/llvm/lib/CodeGen/MachineLICM.cpp
+++ b/llvm/lib/CodeGen/MachineLICM.cpp
@@ -625,8 +625,8 @@ void MachineLICMImpl::HoistRegionPostRA(MachineLoop *CurLoop) {
     // FIXME: That means a reload that're reused in successor block(s) will not
     // be LICM'ed.
     for (const auto &LI : BB->liveins()) {
-      for (MCRegUnit Unit : TRI->regunits(LI.PhysReg))
-        RUDefs.set(Unit);
+      for (MCRegUnitIterator RUI(LI, TRI); RUI.isValid(); ++RUI)
+        RUDefs.set(*RUI);
     }
 
     // Funclet entry blocks will clobber all registers

--- a/llvm/lib/CodeGen/MachineSink.cpp
+++ b/llvm/lib/CodeGen/MachineSink.cpp
@@ -2189,7 +2189,6 @@ static void updateLiveIn(MachineInstr *MI, MachineBasicBlock *SuccBB,
       SuccBB->removeLiveIn(S);
   for (auto U : UsedOpsInCopy)
     SuccBB->addLiveIn(MI->getOperand(U).getReg());
-  SuccBB->sortUniqueLiveIns();
 }
 
 static bool hasRegisterDependency(MachineInstr *MI,

--- a/llvm/lib/CodeGen/PrologEpilogInserter.cpp
+++ b/llvm/lib/CodeGen/PrologEpilogInserter.cpp
@@ -1250,8 +1250,8 @@ void PEIImpl::insertZeroCallUsedRegs(MachineFunction &MF) {
 
   // Get a list of registers that are used.
   BitVector LiveIns(TRI.getNumRegs());
-  for (const MachineBasicBlock::RegisterMaskPair &LI : MF.front().liveins())
-    LiveIns.set(LI.PhysReg);
+  for (const MCRegister &LI : MF.front().liveins())
+    LiveIns.set(LI);
 
   BitVector RegsToZero(TRI.getNumRegs());
   for (MCRegister Reg : AllocatableSet.set_bits()) {

--- a/llvm/lib/CodeGen/RDFGraph.cpp
+++ b/llvm/lib/CodeGen/RDFGraph.cpp
@@ -915,8 +915,8 @@ void DataFlowGraph::build(const Config &config) {
   for (std::pair<MCRegister, Register> P : MRI.liveins())
     LiveIns.insert(RegisterRef(P.first));
   if (MRI.tracksLiveness()) {
-    for (auto I : EntryB.liveins())
-      LiveIns.insert(RegisterRef(I.PhysReg, I.LaneMask));
+    for (auto Reg : EntryB.liveins())
+      LiveIns.insert(RegisterRef(Reg));
   }
 
   // Add function-entry phi nodes for the live-in registers.

--- a/llvm/lib/CodeGen/ReachingDefAnalysis.cpp
+++ b/llvm/lib/CodeGen/ReachingDefAnalysis.cpp
@@ -81,7 +81,7 @@ void ReachingDefAnalysis::enterBasicBlock(MachineBasicBlock *MBB) {
   // This is the entry block.
   if (MBB->pred_empty()) {
     for (const auto &LI : MBB->liveins()) {
-      for (MCRegUnit Unit : TRI->regunits(LI.PhysReg)) {
+      for (MCRegUnit Unit : TRI->regunits(LI)) {
         // Treat function live-ins as if they were defined just before the first
         // instruction.  Usually, function arguments are set up immediately
         // before the call.

--- a/llvm/lib/CodeGen/RegAllocFast.cpp
+++ b/llvm/lib/CodeGen/RegAllocFast.cpp
@@ -687,8 +687,7 @@ void RegAllocFastImpl::reloadAtBegin(MachineBasicBlock &MBB) {
   if (LiveVirtRegs.empty())
     return;
 
-  for (MachineBasicBlock::RegisterMaskPair P : MBB.liveins()) {
-    MCRegister Reg = P.PhysReg;
+  for (MCRegister Reg : MBB.liveins()) {
     // Set state to live-in. This possibly overrides mappings to virtual
     // registers but we don't care anymore at this point.
     setPhysRegState(Reg, regLiveIn);
@@ -1781,7 +1780,7 @@ void RegAllocFastImpl::allocateBasicBlock(MachineBasicBlock &MBB) {
   assert(LiveVirtRegs.empty() && "Mapping not cleared from last block?");
 
   for (const auto &LiveReg : MBB.liveouts())
-    setPhysRegState(LiveReg.PhysReg, regPreAssigned);
+    setPhysRegState(LiveReg, regPreAssigned);
 
   Coalesced.clear();
 

--- a/llvm/lib/CodeGen/ScheduleDAGInstrs.cpp
+++ b/llvm/lib/CodeGen/ScheduleDAGInstrs.cpp
@@ -244,10 +244,9 @@ void ScheduleDAGInstrs::addSchedBarrierDeps() {
     // uses all the registers that are livein to the successor blocks.
     for (const MachineBasicBlock *Succ : BB->successors()) {
       for (const auto &LI : Succ->liveins()) {
-        for (MCRegUnitMaskIterator U(LI.PhysReg, TRI); U.isValid(); ++U) {
-          auto [Unit, Mask] = *U;
-          if ((Mask & LI.LaneMask).any() && !Uses.contains(Unit))
-            Uses.insert(PhysRegSUOper(&ExitSU, -1, Unit));
+        for (MCRegUnitIterator Unit(LI, TRI); Unit.isValid(); ++Unit) {
+          if (!Uses.contains(*Unit))
+            Uses.insert(PhysRegSUOper(&ExitSU, -1, *Unit));
         }
       }
     }

--- a/llvm/lib/CodeGen/ShrinkWrap.cpp
+++ b/llvm/lib/CodeGen/ShrinkWrap.cpp
@@ -507,8 +507,8 @@ tryToSplitRestore(MachineBasicBlock *MBB,
   // interfere with control flow optimizer decisions.
   MF->insert(MF->end(), NMBB);
 
-  for (const MachineBasicBlock::RegisterMaskPair &LI : MBB->liveins())
-    NMBB->addLiveIn(LI.PhysReg);
+  for (const MCRegister LI : MBB->liveins())
+    NMBB->addLiveIn(LI);
 
   TII->insertUnconditionalBranch(*NMBB, MBB, DebugLoc());
 

--- a/llvm/lib/CodeGen/VirtRegMap.cpp
+++ b/llvm/lib/CodeGen/VirtRegMap.cpp
@@ -440,11 +440,6 @@ void VirtRegRewriter::addMBBLiveIns() {
       }
     }
   }
-
-  // Sort and unique MBB LiveIns as we've not checked if SubReg/PhysReg were in
-  // each MBB's LiveIns set before calling addLiveIn on them.
-  for (MachineBasicBlock &MBB : *MF)
-    MBB.sortUniqueLiveIns();
 }
 
 /// Returns true if the given machine operand \p MO only reads undefined lanes.

--- a/llvm/lib/Target/AArch64/AArch64CollectLOH.cpp
+++ b/llvm/lib/Target/AArch64/AArch64CollectLOH.cpp
@@ -545,7 +545,7 @@ bool AArch64CollectLOH::runOnMachineFunction(MachineFunction &MF) {
     // Live-out registers are used.
     for (const MachineBasicBlock *Succ : MBB.successors()) {
       for (const auto &LI : Succ->liveins()) {
-        int RegIdx = mapRegToGPRIndex(LI.PhysReg);
+        int RegIdx = mapRegToGPRIndex(LI);
         if (RegIdx >= 0)
           LOHInfos[RegIdx].OneUser = true;
       }

--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -3234,12 +3234,10 @@ bool AArch64FrameLowering::spillCalleeSavedRegisters(
         AFI->setVGIdx(RPI.FrameIdx);
       } else {
         const AArch64Subtarget &STI = MF.getSubtarget<AArch64Subtarget>();
-        if (llvm::any_of(
-                MBB.liveins(),
-                [&STI](const MachineBasicBlock::RegisterMaskPair &LiveIn) {
-                  return STI.getRegisterInfo()->isSuperOrSubRegisterEq(
-                      AArch64::X0, LiveIn.PhysReg);
-                }))
+        if (llvm::any_of(MBB.liveins(), [&STI](const MCRegister &LiveIn) {
+              return STI.getRegisterInfo()->isSuperOrSubRegisterEq(AArch64::X0,
+                                                                   LiveIn);
+            }))
           X0Scratch = Reg1;
 
         if (X0Scratch != AArch64::NoRegister)

--- a/llvm/lib/Target/AMDGPU/SIFrameLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFrameLowering.cpp
@@ -1040,8 +1040,6 @@ void SIFrameLowering::emitCSRSpillStores(
     for (MachineBasicBlock &MBB : MF) {
       for (MCPhysReg Reg : ScratchSGPRs)
         MBB.addLiveIn(Reg);
-
-      MBB.sortUniqueLiveIns();
     }
     if (!LiveUnits.empty()) {
       for (MCPhysReg Reg : ScratchSGPRs)
@@ -1444,8 +1442,6 @@ void SIFrameLowering::processFunctionBeforeFrameFinalized(
 
       for (MCPhysReg Reg : FuncInfo->getAGPRSpillVGPRs())
         MBB.addLiveIn(Reg);
-
-      MBB.sortUniqueLiveIns();
 
       if (!SpillFIs.empty() && SeenDbgInstr) {
         // FIXME: The dead frame indices are replaced with a null register from
@@ -1958,7 +1954,6 @@ bool SIFrameLowering::spillCalleeSavedRegisters(
     // skip it.
     MBB.addLiveIn(Reg);
   }
-  MBB.sortUniqueLiveIns();
 
   return true;
 }
@@ -2009,7 +2004,6 @@ bool SIFrameLowering::restoreCalleeSavedRegisters(
     MBB.addLiveIn(Reg);
   }
 
-  MBB.sortUniqueLiveIns();
   return true;
 }
 

--- a/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.cpp
+++ b/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.cpp
@@ -240,7 +240,6 @@ static void updateLiveness(MachineFunction &MF, ArrayRef<CalleeSavedInfo> CSI) {
 
   for (const CalleeSavedInfo &CSIReg : CSI)
     EntryBB.addLiveIn(CSIReg.getReg());
-  EntryBB.sortUniqueLiveIns();
 }
 
 bool SILowerSGPRSpills::spillCalleeSavedRegs(

--- a/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.cpp
@@ -364,7 +364,6 @@ void SIMachineFunctionInfo::shiftWwmVGPRsToLowestRange(
 
     for (MachineBasicBlock &MBB : MF) {
       MBB.removeLiveIn(Reg);
-      MBB.sortUniqueLiveIns();
     }
 
     Reg = NewReg;
@@ -411,7 +410,6 @@ bool SIMachineFunctionInfo::allocatePhysicalVGPRForSGPRSpills(
     reserveWWMRegister(LaneVGPR);
     for (MachineBasicBlock &MBB : MF) {
       MBB.addLiveIn(LaneVGPR);
-      MBB.sortUniqueLiveIns();
     }
     SpillPhysVGPRs.push_back(LaneVGPR);
   } else {

--- a/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
+++ b/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
@@ -2503,8 +2503,8 @@ MachineBasicBlock *ARMConstantIslands::adjustJTTargetBlockForward(
   MF->insert(MBBI, NewBB);
 
   // Copy live-in information to new block.
-  for (const MachineBasicBlock::RegisterMaskPair &RegMaskPair : BB->liveins())
-    NewBB->addLiveIn(RegMaskPair);
+  for (const MCRegister Reg : BB->liveins())
+    NewBB->addLiveIn(Reg);
 
   // Add an unconditional branch from NewBB to BB.
   // There doesn't seem to be meaningful DebugInfo available; this doesn't

--- a/llvm/lib/Target/ARM/ARMFrameLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMFrameLowering.cpp
@@ -3344,8 +3344,6 @@ void ARMFrameLowering::adjustForSegmentedStacks(
   }
 
   for (MachineBasicBlock *MBB : BeforePrologueRegion) {
-    // Make sure the LiveIns are still sorted and unique.
-    MBB->sortUniqueLiveIns();
     // Replace the edges to PrologueMBB by edges to the sequences
     // we are about to add, but only update for immediate predecessors.
     if (MBB->isSuccessor(&PrologueMBB))

--- a/llvm/lib/Target/ARM/ARMLowOverheadLoops.cpp
+++ b/llvm/lib/Target/ARM/ARMLowOverheadLoops.cpp
@@ -1014,17 +1014,17 @@ bool LowOverheadLoop::ValidateLiveOuts() {
   assert(ML.getNumBlocks() == 1 && "Expected single block loop!");
   assert(ExitBlocks.size() == 1 && "Expected a single exit block");
   MachineBasicBlock *ExitBB = ExitBlocks.front();
-  for (const MachineBasicBlock::RegisterMaskPair &RegMask : ExitBB->liveins()) {
+  for (const MCRegister Reg : ExitBB->liveins()) {
     // TODO: Instead of blocking predication, we could move the vctp to the exit
     // block and calculate it's operand there in or the preheader.
-    if (RegMask.PhysReg == ARM::VPR) {
+    if (Reg == ARM::VPR) {
       LLVM_DEBUG(dbgs() << "  VPR is live in to the exit block.");
       return false;
     }
     // Check Q-regs that are live in the exit blocks. We don't collect scalars
     // because they won't be affected by lane predication.
-    if (QPRs->contains(RegMask.PhysReg))
-      if (auto *MI = RDA.getLocalLiveOutMIDef(Header, RegMask.PhysReg))
+    if (QPRs->contains(Reg))
+      if (auto *MI = RDA.getLocalLiveOutMIDef(Header, Reg))
         LiveOutMIs.insert(MI);
   }
 

--- a/llvm/lib/Target/ARM/ThumbRegisterInfo.cpp
+++ b/llvm/lib/Target/ARM/ThumbRegisterInfo.cpp
@@ -196,7 +196,7 @@ static void emitThumbRegPlusImmInReg(
       }
       // If there's no use or def of CPSR then it may be live if it's a
       // live-out value.
-      auto liveOutIsCpsr = [](auto &Out) { return Out.PhysReg == ARM::CPSR; };
+      auto liveOutIsCpsr = [](auto &Out) { return Out == ARM::CPSR; };
       if (!LiveCpsr && !CpsrWrite)
         LiveCpsr = any_of(MBB.liveouts(), liveOutIsCpsr);
 

--- a/llvm/lib/Target/AVR/AVRFrameLowering.cpp
+++ b/llvm/lib/Target/AVR/AVRFrameLowering.cpp
@@ -261,7 +261,7 @@ bool AVRFrameLowering::spillCalleeSavedRegisters(
     // add it to the livein list.
     if (IsNotLiveIn)
       for (const auto &LiveIn : MBB.liveins())
-        if (STI.getRegisterInfo()->isSubRegister(LiveIn.PhysReg, Reg)) {
+        if (STI.getRegisterInfo()->isSubRegister(LiveIn, Reg)) {
           IsNotLiveIn = false;
           MBB.addLiveIn(Reg);
           break;

--- a/llvm/lib/Target/Hexagon/HexagonBlockRanges.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonBlockRanges.cpp
@@ -234,17 +234,8 @@ HexagonBlockRanges::RegisterSet HexagonBlockRanges::getLiveIns(
   RegisterSet LiveIns;
   RegisterSet Tmp;
 
-  for (auto I : B.liveins()) {
-    MCSubRegIndexIterator S(I.PhysReg, &TRI);
-    if (I.LaneMask.all() || (I.LaneMask.any() && !S.isValid())) {
-      Tmp.insert({I.PhysReg, 0});
-      continue;
-    }
-    for (; S.isValid(); ++S) {
-      unsigned SI = S.getSubRegIndex();
-      if ((I.LaneMask & TRI.getSubRegIndexLaneMask(SI)).any())
-        Tmp.insert({S.getSubReg(), 0});
-    }
+  for (auto Reg : B.liveins()) {
+    Tmp.insert({Reg, 0});
   }
 
   for (auto R : Tmp) {

--- a/llvm/lib/Target/Hexagon/HexagonCFGOptimizer.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonCFGOptimizer.cpp
@@ -207,13 +207,12 @@ bool HexagonCFGOptimizer::runOnMachineFunction(MachineFunction &Fn) {
               // Correct live-in information. Is used by post-RA scheduler
               // The live-in to LayoutSucc is now all values live-in to
               // JumpAroundTarget.
-              std::vector<MachineBasicBlock::RegisterMaskPair> OrigLiveIn(
-                  LayoutSucc->livein_begin(), LayoutSucc->livein_end());
-              std::vector<MachineBasicBlock::RegisterMaskPair> NewLiveIn(
-                  JumpAroundTarget->livein_begin(),
-                  JumpAroundTarget->livein_end());
+              DenseSet<MCRegister> OrigLiveIn(LayoutSucc->livein_begin(),
+                                              LayoutSucc->livein_end());
+              DenseSet<MCRegister> NewLiveIn(JumpAroundTarget->livein_begin(),
+                                             JumpAroundTarget->livein_end());
               for (const auto &OrigLI : OrigLiveIn)
-                LayoutSucc->removeLiveIn(OrigLI.PhysReg);
+                LayoutSucc->removeLiveIn(OrigLI);
               for (const auto &NewLI : NewLiveIn)
                 LayoutSucc->addLiveIn(NewLI);
             }

--- a/llvm/lib/Target/M68k/M68kFrameLowering.cpp
+++ b/llvm/lib/Target/M68k/M68kFrameLowering.cpp
@@ -177,9 +177,7 @@ static unsigned findDeadCallerSavedReg(MachineBasicBlock &MBB,
 
 static bool isRegLiveIn(MachineBasicBlock &MBB, unsigned Reg) {
   return llvm::any_of(MBB.liveins(),
-                      [Reg](MachineBasicBlock::RegisterMaskPair RegMask) {
-                        return RegMask.PhysReg == Reg;
-                      });
+                      [Reg](MCRegister RegVal) { return RegVal == Reg; });
 }
 
 uint64_t

--- a/llvm/lib/Target/Mips/MipsDelaySlotFiller.cpp
+++ b/llvm/lib/Target/Mips/MipsDelaySlotFiller.cpp
@@ -399,8 +399,8 @@ void RegDefsUses::addLiveOut(const MachineBasicBlock &MBB,
                              const MachineBasicBlock &SuccBB) {
   for (const MachineBasicBlock *S : MBB.successors())
     if (S != &SuccBB)
-      for (const auto &LI : S->liveins())
-        Uses.set(LI.PhysReg.id());
+      for (const MCRegister LI : S->liveins())
+        Uses.set(LI.id());
 }
 
 bool RegDefsUses::update(const MachineInstr &MI, unsigned Begin, unsigned End) {

--- a/llvm/lib/Target/X86/X86FloatingPoint.cpp
+++ b/llvm/lib/Target/X86/X86FloatingPoint.cpp
@@ -126,7 +126,7 @@ namespace {
       unsigned Mask = 0;
       for (MachineBasicBlock::livein_iterator I = MBB->livein_begin();
            I != MBB->livein_end(); ) {
-        MCPhysReg Reg = I->PhysReg;
+        MCPhysReg Reg = *I;
         static_assert(X86::FP6 - X86::FP0 == 6, "sequential regnums");
         if (Reg >= X86::FP0 && Reg <= X86::FP6) {
           Mask |= 1 << (Reg - X86::FP0);

--- a/llvm/lib/Target/X86/X86FrameLowering.cpp
+++ b/llvm/lib/Target/X86/X86FrameLowering.cpp
@@ -173,8 +173,7 @@ static unsigned getPOP2Opcode(const X86Subtarget &ST) {
 }
 
 static bool isEAXLiveIn(MachineBasicBlock &MBB) {
-  for (MachineBasicBlock::RegisterMaskPair RegMask : MBB.liveins()) {
-    MCRegister Reg = RegMask.PhysReg;
+  for (MCRegister Reg : MBB.liveins()) {
 
     if (Reg == X86::RAX || Reg == X86::EAX || Reg == X86::AX ||
         Reg == X86::AH || Reg == X86::AL)

--- a/llvm/test/CodeGen/ARM/aes-erratum-fix.ll
+++ b/llvm/test/CodeGen/ARM/aes-erratum-fix.ll
@@ -68,8 +68,8 @@ define arm_aapcs_vfpcc void @aese_via_call2(half %0, ptr %1) nounwind {
 ; CHECK-FIX-NEXT:    push {r4, lr}
 ; CHECK-FIX-NEXT:    mov r4, r0
 ; CHECK-FIX-NEXT:    bl get_inputf16
-; CHECK-FIX-NEXT:    vorr q0, q0, q0
 ; CHECK-FIX-NEXT:    vld1.64 {d16, d17}, [r4]
+; CHECK-FIX-NEXT:    vorr q0, q0, q0
 ; CHECK-FIX-NEXT:    aese.8 q8, q0
 ; CHECK-FIX-NEXT:    aesmc.8 q8, q8
 ; CHECK-FIX-NEXT:    vst1.64 {d16, d17}, [r4]
@@ -89,8 +89,8 @@ define arm_aapcs_vfpcc void @aese_via_call3(float %0, ptr %1) nounwind {
 ; CHECK-FIX-NEXT:    push {r4, lr}
 ; CHECK-FIX-NEXT:    mov r4, r0
 ; CHECK-FIX-NEXT:    bl get_inputf32
-; CHECK-FIX-NEXT:    vorr q0, q0, q0
 ; CHECK-FIX-NEXT:    vld1.64 {d16, d17}, [r4]
+; CHECK-FIX-NEXT:    vorr q0, q0, q0
 ; CHECK-FIX-NEXT:    aese.8 q8, q0
 ; CHECK-FIX-NEXT:    aesmc.8 q8, q8
 ; CHECK-FIX-NEXT:    vst1.64 {d16, d17}, [r4]
@@ -2222,8 +2222,8 @@ define arm_aapcs_vfpcc void @aesd_via_call2(half %0, ptr %1) nounwind {
 ; CHECK-FIX-NEXT:    push {r4, lr}
 ; CHECK-FIX-NEXT:    mov r4, r0
 ; CHECK-FIX-NEXT:    bl get_inputf16
-; CHECK-FIX-NEXT:    vorr q0, q0, q0
 ; CHECK-FIX-NEXT:    vld1.64 {d16, d17}, [r4]
+; CHECK-FIX-NEXT:    vorr q0, q0, q0
 ; CHECK-FIX-NEXT:    aesd.8 q8, q0
 ; CHECK-FIX-NEXT:    aesimc.8 q8, q8
 ; CHECK-FIX-NEXT:    vst1.64 {d16, d17}, [r4]
@@ -2243,8 +2243,8 @@ define arm_aapcs_vfpcc void @aesd_via_call3(float %0, ptr %1) nounwind {
 ; CHECK-FIX-NEXT:    push {r4, lr}
 ; CHECK-FIX-NEXT:    mov r4, r0
 ; CHECK-FIX-NEXT:    bl get_inputf32
-; CHECK-FIX-NEXT:    vorr q0, q0, q0
 ; CHECK-FIX-NEXT:    vld1.64 {d16, d17}, [r4]
+; CHECK-FIX-NEXT:    vorr q0, q0, q0
 ; CHECK-FIX-NEXT:    aesd.8 q8, q0
 ; CHECK-FIX-NEXT:    aesimc.8 q8, q8
 ; CHECK-FIX-NEXT:    vst1.64 {d16, d17}, [r4]

--- a/llvm/tools/llvm-exegesis/lib/SnippetRepetitor.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SnippetRepetitor.cpp
@@ -104,7 +104,7 @@ public:
         Loop.MBB->addLiveIn(LoopCounter);
         for (MCRegister Reg : Filler.getRegistersSetUp())
           Loop.MBB->addLiveIn(Reg);
-        for (const auto &LiveIn : Entry.MBB->liveins())
+        for (const MCRegister LiveIn : Entry.MBB->liveins())
           Loop.MBB->addLiveIn(LiveIn);
       }
       for (auto _ : seq(LoopUnrollFactor)) {

--- a/llvm/unittests/tools/llvm-exegesis/X86/SnippetRepetitorTest.cpp
+++ b/llvm/unittests/tools/llvm-exegesis/X86/SnippetRepetitorTest.cpp
@@ -66,10 +66,6 @@ static auto HasOpcode = [](unsigned Opcode) {
   return Property(&MachineInstr::getOpcode, Eq(Opcode));
 };
 
-static auto LiveReg = [](unsigned Reg) {
-  return Field(&MachineBasicBlock::RegisterMaskPair::PhysReg, Eq(Reg));
-};
-
 TEST_F(X86SnippetRepetitorTest, Duplicate) {
   TestCommon(Benchmark::Duplicate);
   // Duplicating creates a single basic block that repeats the instructions.
@@ -101,12 +97,11 @@ TEST_F(X86SnippetRepetitorTest, Loop) {
                           HasOpcode(X86::NOOP), HasOpcode(X86::NOOP),
                           HasOpcode(X86::NOOP), HasOpcode(X86::ADD64ri8),
                           HasOpcode(X86::JCC_1)));
-  EXPECT_THAT(
-      LoopBlock.liveins(),
-      UnorderedElementsAre(
-          LiveReg(X86::EAX),
-          LiveReg(State.getExegesisTarget().getDefaultLoopCounterRegister(
-              State.getTargetMachine().getTargetTriple()))));
+  EXPECT_THAT(LoopBlock.liveins(),
+              UnorderedElementsAre(
+                  MCRegister(X86::EAX),
+                  State.getExegesisTarget().getDefaultLoopCounterRegister(
+                      State.getTargetMachine().getTargetTriple())));
   EXPECT_THAT(MF->getBlockNumbered(2)->instrs(),
               ElementsAre(HasOpcode(X86::RET64)));
 }


### PR DESCRIPTION
Currently, the machine basicblock does not fully utilizes the laneBitmask associated with physReg liveIns to check for the precise liveness. Conservatively, it acts fully correct now, only if all liveIns check for MBB is in form it defines it for itself.

So, now with the use of register units tracking for MBB's liveIns , its possible to track & check liveness for all sorts of physRegs.
