### PR TITLE
[MLIR][NFC] Retire let constructor for Bufferization

### DIFF
--- a/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.h
@@ -30,25 +30,6 @@ using DeallocHelperMap = llvm::DenseMap<Operation *, func::FuncOp>;
 #define GEN_PASS_DECL
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h.inc"
 
-/// Creates an instance of the OwnershipBasedBufferDeallocation pass to free all
-/// allocated buffers.
-std::unique_ptr<Pass> createOwnershipBasedBufferDeallocationPass(
-    DeallocationOptions options = DeallocationOptions());
-
-/// Creates a pass that finds all temporary allocations
-/// and attempts to move the deallocation after the last user/dependency
-/// of the allocation, thereby optimizing allocation liveness.
-std::unique_ptr<Pass> createOptimizeAllocationLivenessPass();
-
-/// Creates a pass that optimizes `bufferization.dealloc` operations. For
-/// example, it reduces the number of alias checks needed at runtime using
-/// static alias analysis.
-std::unique_ptr<Pass> createBufferDeallocationSimplificationPass();
-
-/// Creates an instance of the LowerDeallocations pass to lower
-/// `bufferization.dealloc` operations to the `memref` dialect.
-std::unique_ptr<Pass> createLowerDeallocationsPass();
-
 /// Adds the conversion pattern of the `bufferization.dealloc` operation to the
 /// given pattern set for use in other transformation passes.
 void populateBufferizationDeallocLoweringPattern(
@@ -141,14 +122,6 @@ func::FuncOp buildDeallocationLibraryFunction(OpBuilder &builder, Location loc,
 LogicalResult deallocateBuffersOwnershipBased(FunctionOpInterface op,
                                               DeallocationOptions options);
 
-/// Creates a pass that moves allocations upwards to reduce the number of
-/// required copies that are inserted during the BufferDeallocation pass.
-std::unique_ptr<Pass> createBufferHoistingPass();
-
-/// Creates a pass that moves allocations upwards out of loops. This avoids
-/// reallocations inside of loops.
-std::unique_ptr<Pass> createBufferLoopHoistingPass();
-
 // Options struct for BufferResultsToOutParams pass.
 // Note: defined only here, not in tablegen.
 struct BufferResultsToOutParamsOpts {
@@ -192,50 +165,19 @@ struct BufferResultsToOutParamsOpts {
   bool hoistStaticAllocs = false;
 };
 
-/// Creates a pass that converts memref function results to out-params.
-std::unique_ptr<Pass> createBufferResultsToOutParamsPass(
-    const BufferResultsToOutParamsOpts &options = {});
-
 /// Replace buffers that are returned from a function with an out parameter.
 /// Also update all call sites.
 LogicalResult
 promoteBufferResultsToOutParams(ModuleOp module,
                                 const BufferResultsToOutParamsOpts &options);
 
-/// Creates a pass that drops memref function results that are equivalent to a
-/// function argument.
-std::unique_ptr<Pass> createDropEquivalentBufferResultsPass();
-
-/// Create a pass that rewrites tensor.empty to bufferization.alloc_tensor.
-std::unique_ptr<Pass> createEmptyTensorToAllocTensorPass();
-
 /// Drop all memref function results that are equivalent to a function argument.
 LogicalResult dropEquivalentBufferResults(ModuleOp module);
-
-/// Create a pass that bufferizes all ops that implement BufferizableOpInterface
-/// with One-Shot Bufferize.
-std::unique_ptr<Pass> createOneShotBufferizePass();
-
-/// Create a pass that bufferizes all ops that implement BufferizableOpInterface
-/// with One-Shot Bufferize and the specified bufferization options.
-std::unique_ptr<Pass>
-createOneShotBufferizePass(const OneShotBufferizationOptions &options);
-
-/// Creates a pass that promotes heap-based allocations to stack-based ones.
-/// Only buffers smaller than the provided size are promoted.
-/// Dynamic shaped buffers are promoted up to the given rank.
-std::unique_ptr<Pass>
-createPromoteBuffersToStackPass(unsigned maxAllocSizeInBytes = 1024,
-                                unsigned maxRankOfAllocatedMemRef = 1);
 
 /// Creates a pass that promotes heap-based allocations to stack-based ones.
 /// Only buffers smaller with `isSmallAlloc(alloc) == true` are promoted.
 std::unique_ptr<Pass>
 createPromoteBuffersToStackPass(std::function<bool(Value)> isSmallAlloc);
-
-/// Create a pass that tries to eliminate tensor.empty ops that are anchored on
-/// insert_slice ops.
-std::unique_ptr<Pass> createEmptyTensorEliminationPass();
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.td
@@ -11,8 +11,8 @@
 
 include "mlir/Pass/PassBase.td"
 
-def OwnershipBasedBufferDeallocation : Pass<
-    "ownership-based-buffer-deallocation"> {
+def OwnershipBasedBufferDeallocationPass
+    : Pass<"ownership-based-buffer-deallocation"> {
   let summary = "Adds all required dealloc operations for all allocations in "
                 "the input program";
   let description = [{
@@ -137,14 +137,14 @@ def OwnershipBasedBufferDeallocation : Pass<
     argument (which would otherwise be forbidden according to the function
     boundary ABI).
   }];
-  let options = [
-    Option<"privateFuncDynamicOwnership", "private-function-dynamic-ownership",
+  let options =
+      [Option<
+           "privateFuncDynamicOwnership", "private-function-dynamic-ownership",
            "bool", /*default=*/"false",
            "Allows to add additional arguments to private functions to "
            "dynamically pass ownership of memrefs to callees. This can enable "
            "earlier deallocations.">,
   ];
-  let constructor = "mlir::bufferization::createOwnershipBasedBufferDeallocationPass()";
 
   let dependentDialects = [
     "mlir::bufferization::BufferizationDialect", "mlir::arith::ArithDialect",
@@ -152,8 +152,8 @@ def OwnershipBasedBufferDeallocation : Pass<
   ];
 }
 
-def BufferDeallocationSimplification :
-    Pass<"buffer-deallocation-simplification"> {
+def BufferDeallocationSimplificationPass
+    : Pass<"buffer-deallocation-simplification"> {
   let summary = "Optimizes `bufferization.dealloc` operation for more "
                 "efficient codegen";
   let description = [{
@@ -163,32 +163,28 @@ def BufferDeallocationSimplification :
     some memref isn't deallocated twice (double free).
   }];
 
-  let constructor =
-    "mlir::bufferization::createBufferDeallocationSimplificationPass()";
-
   let dependentDialects = [
     "mlir::bufferization::BufferizationDialect", "mlir::arith::ArithDialect",
     "mlir::memref::MemRefDialect"
   ];
 }
 
-def OptimizeAllocationLiveness
+def OptimizeAllocationLivenessPass
     : Pass<"optimize-allocation-liveness", "func::FuncOp"> {
   let summary = "This pass optimizes the liveness of temp allocations in the "
                 "input function";
-  let description =
-       [{This pass will find all operations that have a memory allocation effect.
-       It will search for the corresponding deallocation and move it right after
-       the last user of the allocation.
-       This will optimize the liveness of the allocations.
+  let description = [{
+      This pass will find all operations that have a memory allocation effect.
+      It will search for the corresponding deallocation and move it right after
+      the last user of the allocation.
+      This will optimize the liveness of the allocations.
 
-       The pass is expected to run after the deallocation pipeline.}];
-  let constructor =
-      "mlir::bufferization::createOptimizeAllocationLivenessPass()";
+      The pass is expected to run after the deallocation pipeline.
+  }];
   let dependentDialects = ["mlir::memref::MemRefDialect"];
 }
 
-def LowerDeallocations : Pass<"bufferization-lower-deallocations"> {
+def LowerDeallocationsPass : Pass<"bufferization-lower-deallocations"> {
   let summary = "Lowers `bufferization.dealloc` operations to `memref.dealloc`"
                 "operations";
   let description = [{
@@ -202,36 +198,32 @@ def LowerDeallocations : Pass<"bufferization-lower-deallocations"> {
     library functions to avoid code-size blow-up.
   }];
 
-  let constructor =
-    "mlir::bufferization::createLowerDeallocationsPass()";
-
   let dependentDialects = [
     "arith::ArithDialect", "memref::MemRefDialect", "scf::SCFDialect",
     "func::FuncDialect"
   ];
 }
 
-def BufferHoisting : Pass<"buffer-hoisting", "func::FuncOp"> {
+def BufferHoistingPass : Pass<"buffer-hoisting", "func::FuncOp"> {
   let summary = "Optimizes placement of allocation operations by moving them "
                 "into common dominators and out of nested regions";
   let description = [{
     This pass implements an approach to aggressively move allocations upwards
     into common dominators and out of nested regions.
   }];
-  let constructor = "mlir::bufferization::createBufferHoistingPass()";
 }
 
-def BufferLoopHoisting : Pass<"buffer-loop-hoisting", "func::FuncOp"> {
+def BufferLoopHoistingPass : Pass<"buffer-loop-hoisting", "func::FuncOp"> {
   let summary = "Optimizes placement of allocation operations by moving them "
                 "out of loop nests";
   let description = [{
     This pass implements an approach to aggressively move allocations upwards
     out of loop nests. It does not move allocations into common dominators.
   }];
-  let constructor = "mlir::bufferization::createBufferLoopHoistingPass()";
 }
 
-def BufferResultsToOutParams : Pass<"buffer-results-to-out-params", "ModuleOp">  {
+def BufferResultsToOutParamsPass
+    : Pass<"buffer-results-to-out-params", "ModuleOp"> {
   let summary = "Converts memref-typed function results to out-params";
   let description = [{
     Some calling conventions prefer to pass output memrefs as "out params". The
@@ -258,19 +250,18 @@ def BufferResultsToOutParams : Pass<"buffer-results-to-out-params", "ModuleOp"> 
     is allocated by memref.alloc in the function. It will use the memref given
     in function argument to replace the allocated memref.
   }];
-  let options = [
-    Option<"addResultAttribute", "add-result-attr", "bool",
-       /*default=*/"false",
-       "Add the attribute 'bufferize.result' to all output parameters.">,
-    Option<"hoistStaticAllocs", "hoist-static-allocs",
-       "bool", /*default=*/"false",
-       "Hoist static allocations to call sites.">,
+  let options =
+      [Option<"addResultAttribute", "add-result-attr", "bool",
+              /*default=*/"false",
+              "Add the attribute 'bufferize.result' to all output parameters.">,
+       Option<"hoistStaticAllocs", "hoist-static-allocs", "bool",
+              /*default=*/"false", "Hoist static allocations to call sites.">,
   ];
-  let constructor = "mlir::bufferization::createBufferResultsToOutParamsPass()";
   let dependentDialects = ["memref::MemRefDialect"];
 }
 
-def DropEquivalentBufferResults : Pass<"drop-equivalent-buffer-results", "ModuleOp">  {
+def DropEquivalentBufferResultsPass
+    : Pass<"drop-equivalent-buffer-results", "ModuleOp"> {
   let summary = "Remove MemRef return values that are equivalent to a bbArg";
   let description = [{
     This pass removes MemRef return values from functions if they are equivalent
@@ -280,22 +271,20 @@ def DropEquivalentBufferResults : Pass<"drop-equivalent-buffer-results", "Module
     Note: If a bbArg buffer is not returned directly but casted to beforehand,
     the buffer is still considered equivalent.
   }];
-  let constructor = "mlir::bufferization::createDropEquivalentBufferResultsPass()";
   let dependentDialects = ["memref::MemRefDialect"];
 }
 
-def EmptyTensorToAllocTensor : Pass<"empty-tensor-to-alloc-tensor"> {
+def EmptyTensorToAllocTensorPass : Pass<"empty-tensor-to-alloc-tensor"> {
   let summary = "Replace all empty ops by alloc_tensor ops.";
   let description = [{
     tensor.empty ops return a tensor of unspecified contents who's only purpose
     is to carry the tensor shape. This pass converts such ops to
     bufferization.alloc_tensor ops, which bufferize to buffer allocations.
   }];
-  let constructor = "mlir::bufferization::createEmptyTensorToAllocTensorPass()";
   let dependentDialects = ["tensor::TensorDialect"];
 }
 
-def OneShotBufferize : Pass<"one-shot-bufferize", "ModuleOp"> {
+def OneShotBufferizePass : Pass<"one-shot-bufferize", "ModuleOp"> {
   let summary = "One-Shot Bufferize";
   let description = [{
     This pass bufferizes all ops that implement `BufferizableOpInterface`. It
@@ -403,59 +392,65 @@ def OneShotBufferize : Pass<"one-shot-bufferize", "ModuleOp"> {
       to the beginning of the loop body makes it more likely for the region
       iter_args and yielded values to bufferize to equivalent buffers.
   }];
-  let options = [
-    Option<"allowReturnAllocsFromLoops", "allow-return-allocs-from-loops",
-           "bool", /*default=*/"false",
-           "Allows returning/yielding new allocations from a loop.">,
-    Option<"allowUnknownOps", "allow-unknown-ops", "bool",
-           /*default=*/"false",
-           "Allows unknown (not bufferizable) ops in the input IR.">,
-    Option<"analysisFuzzerSeed", "analysis-fuzzer-seed", "unsigned",
+  let options =
+      [Option<"allowReturnAllocsFromLoops", "allow-return-allocs-from-loops",
+              "bool", /*default=*/"false",
+              "Allows returning/yielding new allocations from a loop.">,
+       Option<"allowUnknownOps", "allow-unknown-ops", "bool",
+              /*default=*/"false",
+              "Allows unknown (not bufferizable) ops in the input IR.">,
+       Option<
+           "analysisFuzzerSeed", "analysis-fuzzer-seed", "unsigned",
            /*default=*/"0",
            "Test only: Analyze ops in random order with a given seed (fuzzer)">,
-    Option<"analysisHeuristic", "analysis-heuristic", "std::string",
-           /*default=*/"\"bottom-up\"",
-           "Heuristic that control the IR traversal during analysis">,
-    Option<"bufferizeFunctionBoundaries", "bufferize-function-boundaries",
-           "bool", /*default=*/"0",
-           "Bufferize function boundaries (experimental).">,
-    Option<"checkParallelRegions", "check-parallel-regions", "bool",
-           /*default=*/"true", "Account for parallel regions in RaW analysis.">,
-    Option<"copyBeforeWrite", "copy-before-write", "bool", /*default=*/"false",
-           "Skip the analysis. Make a buffer copy on every write.">,
-    ListOption<"dialectFilter", "dialect-filter", "std::string",
-               "Restrict bufferization to ops from these dialects.">,
-    Option<"dumpAliasSets", "dump-alias-sets", "bool", /*default=*/"false",
-           "Test only: Annotate tensor IR with alias sets">,
-    ListOption<"noAnalysisFuncFilter", "no-analysis-func-filter", "std::string",
-               "Skip analysis of functions with these symbol names."
-               "Set copyBeforeWrite to true when bufferizing them.">,
-    Option<"functionBoundaryTypeConversion",
-           "function-boundary-type-conversion", "std::string",
-           /*default=*/"\"infer-layout-map\"",
-           "Controls layout maps when bufferizing function signatures.">,
-    Option<"mustInferMemorySpace", "must-infer-memory-space", "bool",
-           /*default=*/"false",
-           "The memory space of an memref types must always be inferred. If "
-           "unset, a default memory space of 0 is used otherwise.">,
-    Option<"useEncodingForMemorySpace", "use-encoding-for-memory-space", "bool",
-            /*default=*/"false",
-            "Use the Tensor encoding attribute for the memory space. Exclusive to"
-            " the 'must-infer-memory-space' option">,
-    Option<"testAnalysisOnly", "test-analysis-only", "bool",
-            /*default=*/"false",
-           "Test only: Only run inplaceability analysis and annotate IR">,
-    Option<"printConflicts", "print-conflicts", "bool",
-            /*default=*/"false",
-           "Test only: Annotate IR with RaW conflicts. Requires "
-           "test-analysis-only.">,
-    Option<"unknownTypeConversion", "unknown-type-conversion", "std::string",
-           /*default=*/"\"fully-dynamic-layout-map\"",
-           "Controls layout maps for non-inferrable memref types.">,
-    Option<"bufferAlignment", "buffer-alignment", "uint64_t", /*default=*/"64",
-           "Sets the alignment of newly allocated buffers.">,
+       Option<"analysisHeuristic", "analysis-heuristic", "std::string",
+              /*default=*/"\"bottom-up\"",
+              "Heuristic that control the IR traversal during analysis">,
+       Option<"bufferizeFunctionBoundaries", "bufferize-function-boundaries",
+              "bool", /*default=*/"0",
+              "Bufferize function boundaries (experimental).">,
+       Option<"checkParallelRegions", "check-parallel-regions", "bool",
+              /*default=*/"true",
+              "Account for parallel regions in RaW analysis.">,
+       Option<"copyBeforeWrite", "copy-before-write", "bool",
+              /*default=*/"false",
+              "Skip the analysis. Make a buffer copy on every write.">,
+       ListOption<"dialectFilter", "dialect-filter", "std::string",
+                  "Restrict bufferization to ops from these dialects.">,
+       Option<"dumpAliasSets", "dump-alias-sets", "bool", /*default=*/"false",
+              "Test only: Annotate tensor IR with alias sets">,
+       ListOption<"noAnalysisFuncFilter", "no-analysis-func-filter",
+                  "std::string",
+                  "Skip analysis of functions with these symbol names."
+                  "Set copyBeforeWrite to true when bufferizing them.">,
+       Option<"functionBoundaryTypeConversion",
+              "function-boundary-type-conversion", "std::string",
+              /*default=*/"\"infer-layout-map\"",
+              "Controls layout maps when bufferizing function signatures.">,
+       Option<"mustInferMemorySpace", "must-infer-memory-space", "bool",
+              /*default=*/"false",
+              "The memory space of an memref types must always be inferred. If "
+              "unset, a default memory space of 0 is used otherwise.">,
+       Option<"useEncodingForMemorySpace", "use-encoding-for-memory-space",
+              "bool",
+              /*default=*/"false",
+              "Use the Tensor encoding attribute for the memory space. "
+              "Exclusive to"
+              " the 'must-infer-memory-space' option">,
+       Option<"testAnalysisOnly", "test-analysis-only", "bool",
+              /*default=*/"false",
+              "Test only: Only run inplaceability analysis and annotate IR">,
+       Option<"printConflicts", "print-conflicts", "bool",
+              /*default=*/"false",
+              "Test only: Annotate IR with RaW conflicts. Requires "
+              "test-analysis-only.">,
+       Option<"unknownTypeConversion", "unknown-type-conversion", "std::string",
+              /*default=*/"\"fully-dynamic-layout-map\"",
+              "Controls layout maps for non-inferrable memref types.">,
+       Option<"bufferAlignment", "buffer-alignment", "uint64_t",
+              /*default=*/"64",
+              "Sets the alignment of newly allocated buffers.">,
   ];
-  let constructor = "mlir::bufferization::createOneShotBufferizePass()";
 
   let statistics = [
     Statistic<"numBufferAlloc", "num-buffer-alloc",
@@ -467,7 +462,8 @@ def OneShotBufferize : Pass<"one-shot-bufferize", "ModuleOp"> {
   ];
 }
 
-def PromoteBuffersToStack : Pass<"promote-buffers-to-stack", "func::FuncOp"> {
+def PromoteBuffersToStackPass
+    : Pass<"promote-buffers-to-stack", "func::FuncOp"> {
   let summary = "Promotes heap-based allocations to automatically managed "
                 "stack-based allocations";
   let description = [{
@@ -477,7 +473,6 @@ def PromoteBuffersToStack : Pass<"promote-buffers-to-stack", "func::FuncOp"> {
     shaped buffers that are limited by the rank of the tensor can be
     converted. They are only transformed if they are considered to be small.
   }];
-  let constructor = "mlir::bufferization::createPromoteBuffersToStackPass()";
   let options = [
     Option<"maxAllocSizeInBytes", "max-alloc-size-in-bytes", "unsigned",
            /*default=*/"1024",
@@ -488,7 +483,7 @@ def PromoteBuffersToStack : Pass<"promote-buffers-to-stack", "func::FuncOp"> {
   ];
 }
 
-def EmptyTensorElimination : Pass<"eliminate-empty-tensors"> {
+def EmptyTensorEliminationPass : Pass<"eliminate-empty-tensors"> {
   let summary = "Try to eliminate all tensor.empty ops.";
   let description = [{
     Try to eliminate "tensor.empty" ops inside `op`. This transformation looks
@@ -508,7 +503,6 @@ def EmptyTensorElimination : Pass<"eliminate-empty-tensors"> {
     "tensor.empty" op. The "tensor.empty" op is replaced with a
     "tensor.extract_slice" op.
   }];
-  let constructor = "mlir::bufferization::createEmptyTensorEliminationPass()";
 }
 
 #endif // MLIR_DIALECT_BUFFERIZATION_TRANSFORMS_PASSES

--- a/mlir/lib/Dialect/Bufferization/Pipelines/BufferizationPipelines.cpp
+++ b/mlir/lib/Dialect/Bufferization/Pipelines/BufferizationPipelines.cpp
@@ -22,7 +22,10 @@ void mlir::bufferization::buildBufferDeallocationPipeline(
     OpPassManager &pm, const BufferDeallocationPipelineOptions &options) {
   pm.addPass(memref::createExpandReallocPass(/*emitDeallocs=*/false));
   pm.addPass(createCanonicalizerPass());
-  pm.addPass(createOwnershipBasedBufferDeallocationPass(options));
+
+  OwnershipBasedBufferDeallocationPassOptions deallocationOptions{
+      options.privateFunctionDynamicOwnership};
+  pm.addPass(createOwnershipBasedBufferDeallocationPass(deallocationOptions));
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createBufferDeallocationSimplificationPass());
   pm.addPass(createLowerDeallocationsPass());

--- a/mlir/lib/Dialect/Bufferization/Transforms/BufferDeallocationSimplification.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/BufferDeallocationSimplification.cpp
@@ -22,7 +22,7 @@
 
 namespace mlir {
 namespace bufferization {
-#define GEN_PASS_DEF_BUFFERDEALLOCATIONSIMPLIFICATION
+#define GEN_PASS_DEF_BUFFERDEALLOCATIONSIMPLIFICATIONPASS
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h.inc"
 } // namespace bufferization
 } // namespace mlir
@@ -453,7 +453,7 @@ namespace {
 /// into the right positions. Furthermore, it inserts additional clones if
 /// necessary. It uses the algorithm described at the top of the file.
 struct BufferDeallocationSimplificationPass
-    : public bufferization::impl::BufferDeallocationSimplificationBase<
+    : public bufferization::impl::BufferDeallocationSimplificationPassBase<
           BufferDeallocationSimplificationPass> {
   void runOnOperation() override {
     BufferOriginAnalysis analysis(getOperation());
@@ -477,8 +477,3 @@ struct BufferDeallocationSimplificationPass
 };
 
 } // namespace
-
-std::unique_ptr<Pass>
-mlir::bufferization::createBufferDeallocationSimplificationPass() {
-  return std::make_unique<BufferDeallocationSimplificationPass>();
-}

--- a/mlir/lib/Dialect/Bufferization/Transforms/BufferResultsToOutParams.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/BufferResultsToOutParams.cpp
@@ -16,7 +16,7 @@
 
 namespace mlir {
 namespace bufferization {
-#define GEN_PASS_DEF_BUFFERRESULTSTOOUTPARAMS
+#define GEN_PASS_DEF_BUFFERRESULTSTOOUTPARAMSPASS
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h.inc"
 } // namespace bufferization
 } // namespace mlir
@@ -233,11 +233,9 @@ LogicalResult mlir::bufferization::promoteBufferResultsToOutParams(
 
 namespace {
 struct BufferResultsToOutParamsPass
-    : bufferization::impl::BufferResultsToOutParamsBase<
+    : bufferization::impl::BufferResultsToOutParamsPassBase<
           BufferResultsToOutParamsPass> {
-  explicit BufferResultsToOutParamsPass(
-      const bufferization::BufferResultsToOutParamsOpts &options)
-      : options(options) {}
+  using Base::Base;
 
   void runOnOperation() override {
     // Convert from pass options in tablegen to BufferResultsToOutParamsOpts.
@@ -255,8 +253,3 @@ private:
   bufferization::BufferResultsToOutParamsOpts options;
 };
 } // namespace
-
-std::unique_ptr<Pass> mlir::bufferization::createBufferResultsToOutParamsPass(
-    const bufferization::BufferResultsToOutParamsOpts &options) {
-  return std::make_unique<BufferResultsToOutParamsPass>(options);
-}

--- a/mlir/lib/Dialect/Bufferization/Transforms/Bufferize.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/Bufferize.cpp
@@ -26,7 +26,7 @@
 
 namespace mlir {
 namespace bufferization {
-#define GEN_PASS_DEF_ONESHOTBUFFERIZE
+#define GEN_PASS_DEF_ONESHOTBUFFERIZEPASS
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h.inc"
 } // namespace bufferization
 } // namespace mlir
@@ -63,11 +63,9 @@ parseHeuristicOption(const std::string &s) {
 }
 
 struct OneShotBufferizePass
-    : public bufferization::impl::OneShotBufferizeBase<OneShotBufferizePass> {
-  OneShotBufferizePass() = default;
-
-  explicit OneShotBufferizePass(const OneShotBufferizationOptions &options)
-      : options(options) {}
+    : public bufferization::impl::OneShotBufferizePassBase<
+          OneShotBufferizePass> {
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry
@@ -210,15 +208,6 @@ private:
   std::optional<OneShotBufferizationOptions> options;
 };
 } // namespace
-
-std::unique_ptr<Pass> mlir::bufferization::createOneShotBufferizePass() {
-  return std::make_unique<OneShotBufferizePass>();
-}
-
-std::unique_ptr<Pass> mlir::bufferization::createOneShotBufferizePass(
-    const OneShotBufferizationOptions &options) {
-  return std::make_unique<OneShotBufferizePass>(options);
-}
 
 //===----------------------------------------------------------------------===//
 // BufferizableOpInterface-based Bufferization

--- a/mlir/lib/Dialect/Bufferization/Transforms/DropEquivalentBufferResults.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/DropEquivalentBufferResults.cpp
@@ -36,7 +36,7 @@
 
 namespace mlir {
 namespace bufferization {
-#define GEN_PASS_DEF_DROPEQUIVALENTBUFFERRESULTS
+#define GEN_PASS_DEF_DROPEQUIVALENTBUFFERRESULTSPASS
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h.inc"
 } // namespace bufferization
 } // namespace mlir
@@ -149,7 +149,7 @@ mlir::bufferization::dropEquivalentBufferResults(ModuleOp module) {
 
 namespace {
 struct DropEquivalentBufferResultsPass
-    : bufferization::impl::DropEquivalentBufferResultsBase<
+    : bufferization::impl::DropEquivalentBufferResultsPassBase<
           DropEquivalentBufferResultsPass> {
   void runOnOperation() override {
     if (failed(bufferization::dropEquivalentBufferResults(getOperation())))
@@ -157,8 +157,3 @@ struct DropEquivalentBufferResultsPass
   }
 };
 } // namespace
-
-std::unique_ptr<Pass>
-mlir::bufferization::createDropEquivalentBufferResultsPass() {
-  return std::make_unique<DropEquivalentBufferResultsPass>();
-}

--- a/mlir/lib/Dialect/Bufferization/Transforms/EmptyTensorElimination.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/EmptyTensorElimination.cpp
@@ -20,7 +20,7 @@
 
 namespace mlir {
 namespace bufferization {
-#define GEN_PASS_DEF_EMPTYTENSORELIMINATION
+#define GEN_PASS_DEF_EMPTYTENSORELIMINATIONPASS
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h.inc"
 } // namespace bufferization
 } // namespace mlir
@@ -187,9 +187,9 @@ LogicalResult mlir::bufferization::eliminateEmptyTensors(
 
 namespace {
 struct EmptyTensorElimination
-    : public bufferization::impl::EmptyTensorEliminationBase<
+    : public bufferization::impl::EmptyTensorEliminationPassBase<
           EmptyTensorElimination> {
-  EmptyTensorElimination() = default;
+  using Base::Base;
 
   void runOnOperation() override;
 
@@ -226,8 +226,4 @@ void EmptyTensorElimination::runOnOperation() {
   IRRewriter rewriter(getOperation()->getContext());
   if (failed(bufferization::eliminateEmptyTensors(rewriter, getOperation())))
     signalPassFailure();
-}
-
-std::unique_ptr<Pass> mlir::bufferization::createEmptyTensorEliminationPass() {
-  return std::make_unique<EmptyTensorElimination>();
 }

--- a/mlir/lib/Dialect/Bufferization/Transforms/EmptyTensorToAllocTensor.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/EmptyTensorToAllocTensor.cpp
@@ -16,7 +16,7 @@
 
 namespace mlir {
 namespace bufferization {
-#define GEN_PASS_DEF_EMPTYTENSORTOALLOCTENSOR
+#define GEN_PASS_DEF_EMPTYTENSORTOALLOCTENSORPASS
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h.inc"
 } // namespace bufferization
 } // namespace mlir
@@ -38,10 +38,8 @@ struct EmptyTensorLoweringPattern : public OpRewritePattern<tensor::EmptyOp> {
 };
 
 struct EmptyTensorToAllocTensor
-    : public bufferization::impl::EmptyTensorToAllocTensorBase<
+    : public bufferization::impl::EmptyTensorToAllocTensorPassBase<
           EmptyTensorToAllocTensor> {
-  EmptyTensorToAllocTensor() = default;
-
   void runOnOperation() override;
 
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -62,9 +60,4 @@ void EmptyTensorToAllocTensor::runOnOperation() {
   populateEmptyTensorToAllocTensorPattern(patterns);
   if (failed(applyPatternsGreedily(op, std::move(patterns))))
     signalPassFailure();
-}
-
-std::unique_ptr<Pass>
-mlir::bufferization::createEmptyTensorToAllocTensorPass() {
-  return std::make_unique<EmptyTensorToAllocTensor>();
 }

--- a/mlir/lib/Dialect/Bufferization/Transforms/LowerDeallocations.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/LowerDeallocations.cpp
@@ -23,7 +23,7 @@
 
 namespace mlir {
 namespace bufferization {
-#define GEN_PASS_DEF_LOWERDEALLOCATIONS
+#define GEN_PASS_DEF_LOWERDEALLOCATIONSPASS
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h.inc"
 } // namespace bufferization
 } // namespace mlir
@@ -379,7 +379,7 @@ private:
 
 namespace {
 struct LowerDeallocationsPass
-    : public bufferization::impl::LowerDeallocationsBase<
+    : public bufferization::impl::LowerDeallocationsPassBase<
           LowerDeallocationsPass> {
   void runOnOperation() override {
     if (!isa<ModuleOp, FunctionOpInterface>(getOperation())) {
@@ -545,8 +545,4 @@ void mlir::bufferization::populateBufferizationDeallocLoweringPattern(
     const bufferization::DeallocHelperMap &deallocHelperFuncMap) {
   patterns.add<DeallocOpConversion>(patterns.getContext(),
                                     deallocHelperFuncMap);
-}
-
-std::unique_ptr<Pass> mlir::bufferization::createLowerDeallocationsPass() {
-  return std::make_unique<LowerDeallocationsPass>();
 }

--- a/mlir/lib/Dialect/Bufferization/Transforms/OptimizeAllocationLiveness.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/OptimizeAllocationLiveness.cpp
@@ -25,7 +25,7 @@
 
 namespace mlir {
 namespace bufferization {
-#define GEN_PASS_DEF_OPTIMIZEALLOCATIONLIVENESS
+#define GEN_PASS_DEF_OPTIMIZEALLOCATIONLIVENESSPASS
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h.inc"
 } // namespace bufferization
 } // namespace mlir
@@ -89,7 +89,7 @@ static bool hasMemoryAllocEffect(MemoryEffectOpInterface memEffectOp) {
 }
 
 struct OptimizeAllocationLiveness
-    : public bufferization::impl::OptimizeAllocationLivenessBase<
+    : public bufferization::impl::OptimizeAllocationLivenessPassBase<
           OptimizeAllocationLiveness> {
 public:
   OptimizeAllocationLiveness() = default;
@@ -150,12 +150,3 @@ public:
 };
 
 } // end anonymous namespace
-
-//===----------------------------------------------------------------------===//
-// OptimizeAllocatinliveness construction
-//===----------------------------------------------------------------------===//
-
-std::unique_ptr<Pass>
-mlir::bufferization::createOptimizeAllocationLivenessPass() {
-  return std::make_unique<OptimizeAllocationLiveness>();
-}

--- a/mlir/lib/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/OwnershipBasedBufferDeallocation.cpp
@@ -30,7 +30,7 @@
 
 namespace mlir {
 namespace bufferization {
-#define GEN_PASS_DEF_OWNERSHIPBASEDBUFFERDEALLOCATION
+#define GEN_PASS_DEF_OWNERSHIPBASEDBUFFERDEALLOCATIONPASS
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h.inc"
 } // namespace bufferization
 } // namespace mlir
@@ -1019,14 +1019,10 @@ namespace {
 /// into the right positions. Furthermore, it inserts additional clones if
 /// necessary. It uses the algorithm described at the top of the file.
 struct OwnershipBasedBufferDeallocationPass
-    : public bufferization::impl::OwnershipBasedBufferDeallocationBase<
+    : public bufferization::impl::OwnershipBasedBufferDeallocationPassBase<
           OwnershipBasedBufferDeallocationPass> {
-  OwnershipBasedBufferDeallocationPass() = default;
-  OwnershipBasedBufferDeallocationPass(DeallocationOptions options)
-      : OwnershipBasedBufferDeallocationPass() {
-    this->privateFuncDynamicOwnership.setValue(
-        options.privateFuncDynamicOwnership);
-  }
+  using Base::Base;
+
   void runOnOperation() override {
     DeallocationOptions options;
     options.privateFuncDynamicOwnership = privateFuncDynamicOwnership;
@@ -1059,14 +1055,4 @@ bufferization::deallocateBuffersOwnershipBased(FunctionOpInterface op,
 
   // Place all required temporary clone and dealloc nodes.
   return deallocation.deallocate(op);
-}
-
-//===----------------------------------------------------------------------===//
-// OwnershipBasedBufferDeallocationPass construction
-//===----------------------------------------------------------------------===//
-
-std::unique_ptr<Pass>
-mlir::bufferization::createOwnershipBasedBufferDeallocationPass(
-    DeallocationOptions options) {
-  return std::make_unique<OwnershipBasedBufferDeallocationPass>(options);
 }


### PR DESCRIPTION
`let constructor` is legacy (do not use in tree!) since the table gen
backend emits most of the glue logic to build a pass.