### PR TITLE
[RISCV] Check subtarget feature in getBrCond

### DIFF
--- a/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
@@ -789,8 +789,7 @@ bool RISCVInstructionSelector::select(MachineInstr &MI) {
     RISCVCC::CondCode CC;
     getOperandsForBranch(MI.getOperand(0).getReg(), CC, LHS, RHS, *MRI);
 
-    auto Bcc = MIB.buildInstr(RISCVCC::getBrCond(CC, STI.getFeatureBits()), {},
-                              {LHS, RHS})
+    auto Bcc = MIB.buildInstr(RISCVCC::getBrCond(STI, CC), {}, {LHS, RHS})
                    .addMBB(MI.getOperand(1).getMBB());
     MI.eraseFromParent();
     return constrainSelectedInstRegOperands(*Bcc, TII, TRI, RBI);

--- a/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVInstructionSelector.cpp
@@ -789,7 +789,8 @@ bool RISCVInstructionSelector::select(MachineInstr &MI) {
     RISCVCC::CondCode CC;
     getOperandsForBranch(MI.getOperand(0).getReg(), CC, LHS, RHS, *MRI);
 
-    auto Bcc = MIB.buildInstr(RISCVCC::getBrCond(CC), {}, {LHS, RHS})
+    auto Bcc = MIB.buildInstr(RISCVCC::getBrCond(CC, STI.getFeatureBits()), {},
+                              {LHS, RHS})
                    .addMBB(MI.getOperand(1).getMBB());
     MI.eraseFromParent();
     return constrainSelectedInstRegOperands(*Bcc, TII, TRI, RBI);

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -953,21 +953,21 @@ static void parseCondBranch(MachineInstr &LastInst, MachineBasicBlock *&Target,
   Cond.push_back(LastInst.getOperand(1));
 }
 
-unsigned RISCVCC::getBrCond(RISCVCC::CondCode CC,
-                            const FeatureBitset &FeatureBits, bool Imm) {
+unsigned RISCVCC::getBrCond(const RISCVSubtarget &STI, RISCVCC::CondCode CC,
+                            bool Imm) {
   switch (CC) {
   default:
     llvm_unreachable("Unknown condition code!");
   case RISCVCC::COND_EQ:
     if (!Imm)
       return RISCV::BEQ;
-    if (FeatureBits[RISCV::FeatureVendorXCVbi])
+    if (STI.hasVendorXCVbi())
       return RISCV::CV_BEQIMM;
     llvm_unreachable("Unknown branch immediate!");
   case RISCVCC::COND_NE:
     if (!Imm)
       return RISCV::BNE;
-    if (FeatureBits[RISCV::FeatureVendorXCVbi])
+    if (STI.hasVendorXCVbi())
       return RISCV::CV_BNEIMM;
     llvm_unreachable("Unknown branch immediate!");
   case RISCVCC::COND_LT:
@@ -983,7 +983,7 @@ unsigned RISCVCC::getBrCond(RISCVCC::CondCode CC,
 
 const MCInstrDesc &RISCVInstrInfo::getBrCond(RISCVCC::CondCode CC,
                                              bool Imm) const {
-  return get(RISCVCC::getBrCond(CC, STI.getFeatureBits(), Imm));
+  return get(RISCVCC::getBrCond(STI, CC, Imm));
 }
 
 RISCVCC::CondCode RISCVCC::getOppositeBranchCondition(RISCVCC::CondCode CC) {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -959,17 +959,17 @@ unsigned RISCVCC::getBrCond(RISCVCC::CondCode CC,
   default:
     llvm_unreachable("Unknown condition code!");
   case RISCVCC::COND_EQ:
-    if (Imm && FeatureBits[RISCV::FeatureVendorXCVbi])
+    if (!Imm)
+      return RISCV::BEQ;
+    if (FeatureBits[RISCV::FeatureVendorXCVbi])
       return RISCV::CV_BEQIMM;
-    else
-      llvm_unreachable("Unknown branch immediate!");
-    return RISCV::BEQ;
+    llvm_unreachable("Unknown branch immediate!");
   case RISCVCC::COND_NE:
-    if (Imm && FeatureBits[RISCV::FeatureVendorXCVbi])
+    if (!Imm)
+      return RISCV::BNE;
+    if (FeatureBits[RISCV::FeatureVendorXCVbi])
       return RISCV::CV_BNEIMM;
-    else
-      llvm_unreachable("Unknown branch immediate!");
-    return RISCV::BNE;
+    llvm_unreachable("Unknown branch immediate!");
   case RISCVCC::COND_LT:
     return RISCV::BLT;
   case RISCVCC::COND_GE:

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.h
@@ -45,7 +45,8 @@ enum CondCode {
 };
 
 CondCode getOppositeBranchCondition(CondCode);
-unsigned getBrCond(CondCode CC, bool Imm = false);
+unsigned getBrCond(CondCode CC, const FeatureBitset &FeatureBits,
+                   bool Imm = false);
 
 } // end of namespace RISCVCC
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.h
@@ -45,8 +45,7 @@ enum CondCode {
 };
 
 CondCode getOppositeBranchCondition(CondCode);
-unsigned getBrCond(CondCode CC, const FeatureBitset &FeatureBits,
-                   bool Imm = false);
+unsigned getBrCond(const RISCVSubtarget &STI, CondCode CC, bool Imm = false);
 
 } // end of namespace RISCVCC
 


### PR DESCRIPTION
The function currently only checks to see if we compare against an immediate before selecting the two branch immediate instructions that are a part of the XCVbi vendor extension. This works at the moment since there are no other extensions that have a branch immediate instruction, but it would be better if we explicitly check to see if the XCVbi extension is enabled before we return the appropriate instruction. 

This is also done in preparation for the branch immediate instructions that are a part of the Xqcibi vendor extension from Qualcomm.