### PR TITLE
[tsan] Fix false positive on dispatch blocks created with the barrier flag

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_dispatch_defs.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_dispatch_defs.h
@@ -46,6 +46,12 @@ extern const dispatch_block_t _dispatch_data_destructor_free;
 extern const dispatch_block_t _dispatch_data_destructor_munmap;
 } // extern "C"
 
+enum dispatch_block_flags_t : __asan::u64 {
+  DISPATCH_BLOCK_BARRIER = 0x1
+};
+
+#define DISPATCH_BLOCK_PRIVATE_DATA_MAGIC 0xD159B10C // 0xDISPatch_BLOCk
+
 #define DISPATCH_DATA_DESTRUCTOR_DEFAULT nullptr
 #define DISPATCH_DATA_DESTRUCTOR_FREE    _dispatch_data_destructor_free
 #define DISPATCH_DATA_DESTRUCTOR_MUNMAP  _dispatch_data_destructor_munmap


### PR DESCRIPTION
libdispatch allows blocks created with dispatch_block_create to behave as barriers if the DISPATCH_BLOCK_BARRIER flag is applied. However, the TSAN runtime is not aware of this, leading to false positives on barrier blocks. Moreover, swift always uses that flag to create barriers instead of the dispatch_barrier_xxx functions.

To address this issue, it appears that we need to hard code the implementation details in libdispatch. Any suggestions or alternative approaches would be greatly appreciated.
