### PR TITLE
[clang][bytecode] Ignore function calls with depth > 0...

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -714,6 +714,9 @@ bool CheckCallable(InterpState &S, CodePtr OpPC, const Function *F) {
     return false;
   }
 
+  if (S.checkingPotentialConstantExpression() && S.Current->getDepth() != 0)
+    return false;
+
   if (F->isConstexpr() && F->hasBody() &&
       (F->getDecl()->isConstexpr() || F->getDecl()->hasAttr<MSConstexprAttr>()))
     return true;

--- a/clang/test/AST/ByteCode/functions.cpp
+++ b/clang/test/AST/ByteCode/functions.cpp
@@ -681,3 +681,16 @@ namespace StableAddress {
   static_assert(sum<str{"$hello $world."}>() == 1234, "");
 }
 #endif
+
+namespace NoDiags {
+  void huh();
+  template <unsigned>
+  constexpr void hd_fun() {
+    huh();
+  }
+
+  constexpr bool foo() {
+    hd_fun<1>();
+    return true;
+  }
+}


### PR DESCRIPTION
... when checking for a potential constant expression. This is also what the current interpreter does.