### PR TITLE
[Dependency Scanning] Teach `DependencyScanningTool::getModuleDependencies` to Process a List of Module Names

### DIFF
--- a/clang/include/clang/Frontend/FrontendActions.h
+++ b/clang/include/clang/Frontend/FrontendActions.h
@@ -320,12 +320,12 @@ protected:
 };
 
 class GetDependenciesByModuleNameAction : public PreprocessOnlyAction {
-  StringRef ModuleName;
+  ArrayRef<StringRef> ModuleNames;
   void ExecuteAction() override;
 
 public:
-  GetDependenciesByModuleNameAction(StringRef ModuleName)
-      : ModuleName(ModuleName) {}
+  GetDependenciesByModuleNameAction(ArrayRef<StringRef> ModuleNames)
+      : ModuleNames(ModuleNames) {}
 };
 
 }  // end namespace clang

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -146,7 +146,7 @@ public:
   /// Given a compilation context specified via the Clang driver command-line,
   /// gather modular dependencies of modules specified by the the given list of
   /// names, and return the information needed for explicit build.
-  llvm::Expected<ModuleDepsGraph>
+  std::pair<llvm::Error, ModuleDepsGraph>
   getModuleDependencies(ArrayRef<StringRef> ModuleNames,
                         const std::vector<std::string> &CommandLine,
                         StringRef CWD,

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -144,12 +144,14 @@ public:
       std::optional<llvm::MemoryBufferRef> TUBuffer = std::nullopt);
 
   /// Given a compilation context specified via the Clang driver command-line,
-  /// gather modular dependencies of module with the given name, and return the
-  /// information needed for explicit build.
-  llvm::Expected<ModuleDepsGraph> getModuleDependencies(
-      StringRef ModuleName, const std::vector<std::string> &CommandLine,
-      StringRef CWD, const llvm::DenseSet<ModuleID> &AlreadySeen,
-      LookupModuleOutputCallback LookupModuleOutput);
+  /// gather modular dependencies of modules specified by the the given list of
+  /// names, and return the information needed for explicit build.
+  llvm::Expected<ModuleDepsGraph>
+  getModuleDependencies(ArrayRef<StringRef> ModuleNames,
+                        const std::vector<std::string> &CommandLine,
+                        StringRef CWD,
+                        const llvm::DenseSet<ModuleID> &AlreadySeen,
+                        LookupModuleOutputCallback LookupModuleOutput);
 
   llvm::vfs::FileSystem &getWorkerVFS() const { return Worker.getVFS(); }
 

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -111,7 +111,7 @@ public:
                            DependencyConsumer &DepConsumer,
                            DependencyActionController &Controller,
                            DiagnosticConsumer &DiagConsumer,
-                           StringRef ModuleName);
+                           ArrayRef<StringRef> ModuleNames);
 
   /// Run the dependency scanning tool for a given clang driver command-line
   /// for a specific translation unit via file system or memory buffer.
@@ -132,7 +132,7 @@ public:
                                   const std::vector<std::string> &CommandLine,
                                   DependencyConsumer &Consumer,
                                   DependencyActionController &Controller,
-                                  StringRef ModuleName);
+                                  ArrayRef<StringRef> ModuleNames);
 
   llvm::vfs::FileSystem &getVFS() const { return *BaseFS; }
 
@@ -156,7 +156,7 @@ private:
                         DependencyActionController &Controller,
                         DiagnosticConsumer &DC,
                         llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS,
-                        std::optional<StringRef> ModuleName);
+                        std::optional<ArrayRef<StringRef>> ModuleNames);
 };
 
 } // end namespace dependencies

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -154,7 +154,8 @@ DependencyScanningTool::getTranslationUnitDependencies(
   return Consumer.takeTranslationUnitDeps();
 }
 
-llvm::Expected<ModuleDepsGraph> DependencyScanningTool::getModuleDependencies(
+std::pair<llvm::Error, ModuleDepsGraph>
+DependencyScanningTool::getModuleDependencies(
     ArrayRef<StringRef> ModuleNames,
     const std::vector<std::string> &CommandLine, StringRef CWD,
     const llvm::DenseSet<ModuleID> &AlreadySeen,
@@ -165,9 +166,8 @@ llvm::Expected<ModuleDepsGraph> DependencyScanningTool::getModuleDependencies(
   assert(ModuleNames.size() && "GettingModuleDependencies for an empty list!");
   llvm::Error Result = Worker.computeDependencies(CWD, CommandLine, Consumer,
                                                   Controller, ModuleNames);
-  if (Result)
-    return std::move(Result);
-  return Consumer.takeModuleGraphDeps();
+
+  return std::make_pair(std::move(Result), Consumer.takeModuleGraphDeps());
 }
 
 TranslationUnitDeps FullDependencyConsumer::takeTranslationUnitDeps() {

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -155,13 +155,16 @@ DependencyScanningTool::getTranslationUnitDependencies(
 }
 
 llvm::Expected<ModuleDepsGraph> DependencyScanningTool::getModuleDependencies(
-    StringRef ModuleName, const std::vector<std::string> &CommandLine,
-    StringRef CWD, const llvm::DenseSet<ModuleID> &AlreadySeen,
+    ArrayRef<StringRef> ModuleNames,
+    const std::vector<std::string> &CommandLine, StringRef CWD,
+    const llvm::DenseSet<ModuleID> &AlreadySeen,
     LookupModuleOutputCallback LookupModuleOutput) {
   FullDependencyConsumer Consumer(AlreadySeen);
   CallbackActionController Controller(LookupModuleOutput);
+
+  assert(ModuleNames.size() && "GettingModuleDependencies for an empty list!");
   llvm::Error Result = Worker.computeDependencies(CWD, CommandLine, Consumer,
-                                                  Controller, ModuleName);
+                                                  Controller, ModuleNames);
   if (Result)
     return std::move(Result);
   return Consumer.takeModuleGraphDeps();

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -432,10 +432,11 @@ public:
 
     if (Service.getFormat() == ScanningOutputFormat::P1689)
       Action = std::make_unique<PreprocessOnlyAction>();
-    else if (ModuleNames)
+    else if (ModuleNames) {
+      ScanInstance.getDiagnostics().setFatalsAsError(true);
       Action =
           std::make_unique<GetDependenciesByModuleNameAction>(*ModuleNames);
-    else
+    } else
       Action = std::make_unique<ReadPCHAndPreprocessAction>();
 
     if (ScanInstance.getDiagnostics().hasErrorOccurred())

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -751,10 +751,19 @@ bool DependencyScanningWorker::computeDependencies(
   InMemoryFS->setCurrentWorkingDirectory(WorkingDirectory);
   SmallString<128> FakeInputPath;
   // TODO: We should retry the creation if the path already exists.
-  // FIXME: should we create files for multiple modules? I think so?
+  // FIXME: Using ModuleNames[0] should be sufficient to create a unique
+  // input file name. The diagnostic information is specifc enough about
+  // in which exact module an error occurs. That said any error reporting
+  // that relies on the path below could be confusing.We may want to
+  // find better ways (e.g. by concatenating the module names) to make
+  // the temporary file name more precise.
   llvm::sys::fs::createUniquePath(ModuleNames[0] + "-%%%%%%%%.input",
                                   FakeInputPath,
                                   /*MakeAbsolute=*/false);
+
+  // The fake file must contain at least ModuleNames.size() characters,
+  // since we are simulating lexing it, and we are assuming each module name
+  // takes the space of one character.
   std::string FakeString(ModuleNames.size(), ' ');
   InMemoryFS->addFile(FakeInputPath, 0,
                       llvm::MemoryBuffer::getMemBuffer(FakeString));

--- a/clang/test/ClangScanDeps/link-libraries.c
+++ b/clang/test/ClangScanDeps/link-libraries.c
@@ -32,7 +32,7 @@ module transitive {
 }]
 
 // RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
-// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-full -module-name=root > %t/result.json
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-full -module-names=root > %t/result.json
 // RUN: cat %t/result.json | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
 
 // CHECK:      {

--- a/clang/test/ClangScanDeps/modules-full-by-mod-name.c
+++ b/clang/test/ClangScanDeps/modules-full-by-mod-name.c
@@ -25,7 +25,7 @@ module transitive { header "transitive.h" }
 }]
 
 // RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
-// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-full -module-name=root > %t/result.json
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-full -module-names=root > %t/result.json
 // RUN: cat %t/result.json | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
 
 // CHECK:      {

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -1025,8 +1025,8 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
         }
       } else if (ModuleName) {
         auto MaybeModuleDepsGraph = WorkerTool.getModuleDependencies(
-            *ModuleName, Input->CommandLine, CWD, AlreadySeenModules,
-            LookupOutput);
+            ArrayRef<StringRef>({*ModuleName}), Input->CommandLine, CWD,
+            AlreadySeenModules, LookupOutput);
         if (handleModuleResult(*ModuleName, MaybeModuleDepsGraph, *FD,
                                LocalIndex, DependencyOS, Errs))
           HadErrors = true;

--- a/clang/tools/clang-scan-deps/Opts.td
+++ b/clang/tools/clang-scan-deps/Opts.td
@@ -26,7 +26,7 @@ def eager_load_pcm : F<"eager-load-pcm", "Load PCM files eagerly (instead of laz
 def j : Arg<"j", "Number of worker threads to use (default: use all concurrent threads)">;
 
 defm compilation_database : Eq<"compilation-database", "Compilation database">;
-defm module_name : Eq<"module-name", "the module of which the dependencies are to be computed">;
+defm module_names : Eq<"module-names", "the module of which the dependencies are to be computed">;
 defm dependency_target : Eq<"dependency-target", "The names of dependency targets for the dependency file">;
 
 defm tu_buffer_path: Eq<"tu-buffer-path", "The path to the translation unit for depscan. Not compatible with -module-name">;


### PR DESCRIPTION
Currently `DependencyScanningTool::getModuleDependencies` takes a single `ModuleName` and if we have a list of module names to process for the same compilation, we invoke `getModuleDependencies` multiple times and sets up the identical `CompilerInvocation` multiple times (in `DependencyScanningAction::runInvocation`). 

This PR revises `getModuleDependencies` so it can take a list of module names. Then the module dependencies can be computed and aggregated without recreating identical `CompilerInvocation` instances.

rdar://136303612