### PR TITLE
[Clang] Make '-Wglobal-constructors` work on the GNU attributes

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -62,6 +62,9 @@ AST Dumping Potentially Breaking Changes
 Clang Frontend Potentially Breaking Changes
 -------------------------------------------
 
+- The ``-Wglobal-constructors`` flag now applies to ``[[gnu::constructor]]`` and
+  ``[[gnu::destructor]]`` attributes.
+
 Clang Python Bindings Potentially Breaking Changes
 --------------------------------------------------
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -7727,6 +7727,17 @@ void Sema::ProcessDeclAttributeList(
     D->setInvalidDecl();
   }
 
+  // Warn on global constructors and destructors created by attributes.
+  if (D->hasAttr<ConstructorAttr>() &&
+      !getDiagnostics().isIgnored(diag::warn_global_constructor,
+                                  D->getLocation()))
+    Diag(D->getLocation(), diag::warn_global_constructor)
+        << D->getSourceRange();
+  if (D->hasAttr<DestructorAttr>() &&
+      !getDiagnostics().isIgnored(diag::warn_global_destructor,
+                                  D->getLocation()))
+    Diag(D->getLocation(), diag::warn_global_destructor) << D->getSourceRange();
+
   // Do this check after processing D's attributes because the attribute
   // objc_method_family can change whether the given method is in the init
   // family, and it can be applied after objc_designated_initializer. This is a

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2138,6 +2138,8 @@ static void handleConstructorAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (AL.getNumArgs() &&
       !S.checkUInt32Argument(AL, AL.getArgAsExpr(0), priority))
     return;
+  S.Diag(D->getLocation(), diag::warn_global_constructor)
+      << D->getSourceRange();
 
   D->addAttr(::new (S.Context) ConstructorAttr(S.Context, AL, priority));
 }
@@ -2147,6 +2149,7 @@ static void handleDestructorAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (AL.getNumArgs() &&
       !S.checkUInt32Argument(AL, AL.getArgAsExpr(0), priority))
     return;
+  S.Diag(D->getLocation(), diag::warn_global_destructor) << D->getSourceRange();
 
   D->addAttr(::new (S.Context) DestructorAttr(S.Context, AL, priority));
 }
@@ -7726,17 +7729,6 @@ void Sema::ProcessDeclAttributeList(
         << (D->hasAttr<ConstructorAttr>() ? "constructors" : "destructors");
     D->setInvalidDecl();
   }
-
-  // Warn on global constructors and destructors created by attributes.
-  if (D->hasAttr<ConstructorAttr>() &&
-      !getDiagnostics().isIgnored(diag::warn_global_constructor,
-                                  D->getLocation()))
-    Diag(D->getLocation(), diag::warn_global_constructor)
-        << D->getSourceRange();
-  if (D->hasAttr<DestructorAttr>() &&
-      !getDiagnostics().isIgnored(diag::warn_global_destructor,
-                                  D->getLocation()))
-    Diag(D->getLocation(), diag::warn_global_destructor) << D->getSourceRange();
 
   // Do this check after processing D's attributes because the attribute
   // objc_method_family can change whether the given method is in the init

--- a/clang/test/SemaCXX/attr-require-constant-initialization.cpp
+++ b/clang/test/SemaCXX/attr-require-constant-initialization.cpp
@@ -337,6 +337,11 @@ constexpr TestCtor<NotC> inval_constexpr(42); // expected-error {{must be initia
 ATTR constexpr TestCtor<NotC> inval_constexpr2(42); // expected-error {{must be initialized by a constant expression}}
 // expected-note@-1 {{in call to 'TestCtor(42)'}}
 
+[[gnu::constructor]] void ctor() {}
+// expected-warning@-1 {{declaration requires a global constructor}}
+[[gnu::destructor]] void dtor() {}
+// expected-warning@-1 {{declaration requires a global destructor}}
+
 #elif defined(TEST_THREE)
 #if defined(__cplusplus)
 #error This test requires C


### PR DESCRIPTION
Summary:
The `-Wglobal-constructors` option is useful for restricting the usage
of global constructors / destructors. However, it currently ignores the
attributes that introduce global constructors, meaning that the module
can still have ctors if `-Werror` is set. If this is intentional by the
user, I believe it would be more correct to push the diagnostic.
