### PR TITLE
[MLIR][LLVMIR] Add elementtype attribute

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.td
@@ -44,7 +44,7 @@ def LLVM_Dialect : Dialect {
     static StringRef getNoUndefAttrName() { return "llvm.noundef"; }
     static StringRef getDereferenceableAttrName() { return "llvm.dereferenceable"; }
     static StringRef getDereferenceableOrNullAttrName() { return "llvm.dereferenceable_or_null"; }
-    static StringRef getElementTypeAttrName() { return "llvm.element_type"; }
+    static StringRef getElementTypeAttrName() { return "llvm.elementtype"; }
     static StringRef getInAllocaAttrName() { return "llvm.inalloca"; }
     static StringRef getInRegAttrName() { return "llvm.inreg"; }
     static StringRef getNestAttrName() { return "llvm.nest"; }

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.td
@@ -44,6 +44,7 @@ def LLVM_Dialect : Dialect {
     static StringRef getNoUndefAttrName() { return "llvm.noundef"; }
     static StringRef getDereferenceableAttrName() { return "llvm.dereferenceable"; }
     static StringRef getDereferenceableOrNullAttrName() { return "llvm.dereferenceable_or_null"; }
+    static StringRef getElementTypeAttrName() { return "llvm.element_type"; }
     static StringRef getInAllocaAttrName() { return "llvm.inalloca"; }
     static StringRef getInRegAttrName() { return "llvm.inreg"; }
     static StringRef getNestAttrName() { return "llvm.nest"; }

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3942,6 +3942,7 @@ LogicalResult LLVMDialect::verifyParameterAttribute(Operation *op,
   if (name == LLVMDialect::getStructRetAttrName() ||
       name == LLVMDialect::getByValAttrName() ||
       name == LLVMDialect::getByRefAttrName() ||
+      name == LLVMDialect::getElementTypeAttrName() ||
       name == LLVMDialect::getInAllocaAttrName() ||
       name == LLVMDialect::getPreallocatedAttrName()) {
     if (failed(checkTypeAttrType()))

--- a/mlir/lib/Target/LLVMIR/AttrKindDetail.h
+++ b/mlir/lib/Target/LLVMIR/AttrKindDetail.h
@@ -35,6 +35,8 @@ getAttrKindToNameMapping() {
        LLVMDialect::getDereferenceableAttrName()},
       {llvm::Attribute::AttrKind::DereferenceableOrNull,
        LLVMDialect::getDereferenceableOrNullAttrName()},
+      {llvm::Attribute::AttrKind::ElementType,
+       LLVMDialect::getElementTypeAttrName()},
       {llvm::Attribute::AttrKind::InAlloca, LLVMDialect::getInAllocaAttrName()},
       {llvm::Attribute::AttrKind::InReg, LLVMDialect::getInRegAttrName()},
       {llvm::Attribute::AttrKind::Nest, LLVMDialect::getNestAttrName()},

--- a/mlir/test/Dialect/LLVMIR/call-intrin.mlir
+++ b/mlir/test/Dialect/LLVMIR/call-intrin.mlir
@@ -120,6 +120,6 @@ llvm.func @intrinsic_call_arg_attrs(%arg0: i32) -> i32 {
 // CHECK-LABEL: intrinsic_element_type
 llvm.func @intrinsic_element_type(%arg0: !llvm.ptr) {
   // CHECK: call i64 @llvm.aarch64.ldxr.p0(ptr elementtype(i8) %{{.*}})
-  %0 = llvm.call_intrinsic "llvm.aarch64.ldxr.p0"(%arg0) : (!llvm.ptr {llvm.element_type = i8}) -> i64
+  %0 = llvm.call_intrinsic "llvm.aarch64.ldxr.p0"(%arg0) : (!llvm.ptr {llvm.elementtype = i8}) -> i64
   llvm.return
 }

--- a/mlir/test/Dialect/LLVMIR/call-intrin.mlir
+++ b/mlir/test/Dialect/LLVMIR/call-intrin.mlir
@@ -114,3 +114,12 @@ llvm.func @intrinsic_call_arg_attrs(%arg0: i32) -> i32 {
   %0 = llvm.call_intrinsic "llvm.riscv.sha256sig0"(%arg0) : (i32 {llvm.signext}) -> (i32)
   llvm.return %0 : i32
 }
+
+// -----
+
+// CHECK-LABEL: intrinsic_element_type
+llvm.func @intrinsic_element_type(%arg0: !llvm.ptr) {
+  // CHECK: call i64 @llvm.aarch64.ldxr.p0(ptr elementtype(i8) %{{.*}})
+  %0 = llvm.call_intrinsic "llvm.aarch64.ldxr.p0"(%arg0) : (!llvm.ptr {llvm.element_type = i8}) -> i64
+  llvm.return
+}

--- a/mlir/test/Target/LLVMIR/Import/intrinsic-unregistered.ll
+++ b/mlir/test/Target/LLVMIR/Import/intrinsic-unregistered.ll
@@ -9,7 +9,7 @@ define dso_local void @t0(ptr %a) {
 
 ; CHECK-LABEL: llvm.func @llvm.aarch64.ldxr.p0(!llvm.ptr)
 ; CHECK-LABEL: llvm.func @t0
-; CHECK:   llvm.call_intrinsic "llvm.aarch64.ldxr.p0"({{.*}}) : (!llvm.ptr {llvm.element_type = i8}) -> i64
+; CHECK:   llvm.call_intrinsic "llvm.aarch64.ldxr.p0"({{.*}}) : (!llvm.ptr {llvm.elementtype = i8}) -> i64
 ; CHECK:   llvm.return
 ; CHECK: }
 

--- a/mlir/test/Target/LLVMIR/Import/intrinsic-unregistered.ll
+++ b/mlir/test/Target/LLVMIR/Import/intrinsic-unregistered.ll
@@ -9,7 +9,7 @@ define dso_local void @t0(ptr %a) {
 
 ; CHECK-LABEL: llvm.func @llvm.aarch64.ldxr.p0(!llvm.ptr)
 ; CHECK-LABEL: llvm.func @t0
-; CHECK:   llvm.call_intrinsic "llvm.aarch64.ldxr.p0"({{.*}}) : (!llvm.ptr) -> i64
+; CHECK:   llvm.call_intrinsic "llvm.aarch64.ldxr.p0"({{.*}}) : (!llvm.ptr {llvm.element_type = i8}) -> i64
 ; CHECK:   llvm.return
 ; CHECK: }
 


### PR DESCRIPTION
These are very common when using intrinsics (e.g. ARM NEON).

For more context: ClangIR has currently been blocked on such intrinsics emission because of this lacking capability.