### PR TITLE
[LLDB]Fix test crash

### DIFF
--- a/lldb/unittests/Core/TelemetryTest.cpp
+++ b/lldb/unittests/Core/TelemetryTest.cpp
@@ -80,7 +80,7 @@ using namespace lldb_private::telemetry;
 
 class TelemetryTest : public testing::Test {
 public:
-  SubsystemRAII<lldb_private::FakePlugin> subsystems;
+  lldb_private::SubsystemRAII<lldb_private::FakePlugin> subsystems;
 };
 
 #if LLVM_ENABLE_TELEMETRY

--- a/lldb/unittests/Core/TelemetryTest.cpp
+++ b/lldb/unittests/Core/TelemetryTest.cpp
@@ -11,6 +11,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Telemetry/Telemetry.h"
+#include "TestingSupport/SubsystemRAII.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
 #include <memory>
@@ -77,8 +78,13 @@ public:
 
 using namespace lldb_private::telemetry;
 
+class TelemetryTest : public testing::Test {
+ public:
+  SubsystemRAII<FakePlugin> subsystems;
+};
+
 #if LLVM_ENABLE_TELEMETRY
-#define TELEMETRY_TEST(suite, test) TEST(suite, test)
+#define TELEMETRY_TEST(suite, test) TEST_F(suite, test)
 #else
 #define TELEMETRY_TEST(suite, test) TEST(DISABLED_##suite, test)
 #endif

--- a/lldb/unittests/Core/TelemetryTest.cpp
+++ b/lldb/unittests/Core/TelemetryTest.cpp
@@ -80,7 +80,7 @@ using namespace lldb_private::telemetry;
 
 class TelemetryTest : public testing::Test {
 public:
-  SubsystemRAII<FakePlugin> subsystems;
+  SubsystemRAII<lldb_private::FakePlugin> subsystems;
 };
 
 #if LLVM_ENABLE_TELEMETRY

--- a/lldb/unittests/Core/TelemetryTest.cpp
+++ b/lldb/unittests/Core/TelemetryTest.cpp
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include "lldb/Core/Telemetry.h"
+#include "TestingSupport/SubsystemRAII.h"
 #include "lldb/Core/PluginInterface.h"
 #include "lldb/Core/PluginManager.h"
-#include "lldb/Core/Telemetry.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Telemetry/Telemetry.h"
-#include "TestingSupport/SubsystemRAII.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
 #include <memory>
@@ -79,7 +79,7 @@ public:
 using namespace lldb_private::telemetry;
 
 class TelemetryTest : public testing::Test {
- public:
+public:
   SubsystemRAII<FakePlugin> subsystems;
 };
 


### PR DESCRIPTION
Use the `SubsystemRAII` to unregister the fake manager at end of tests
(Should fix https://github.com/llvm/llvm-project/issues/129910)