### PR TITLE
c-index-test: fix buffer overflow

### DIFF
--- a/clang/tools/c-index-test/c-index-test.c
+++ b/clang/tools/c-index-test/c-index-test.c
@@ -3555,11 +3555,11 @@ static CXIdxClientContainer makeClientContainer(CXClientData *client_data,
   clang_indexLoc_getFileLocation(loc, &file, 0, &line, &column, 0);
 
   len = sizeof(IndexDataStringList) + strlen(name) + digitCount(line) +
-        digitCount(column) + 2;
+        digitCount(column) + 3;
   node = (IndexDataStringList *)malloc(len);
   assert(node);
   newStr = node->data;
-  snprintf(newStr, len, "%s:%d:%d", name, line, column);
+  snprintf(newStr, len - sizeof(IndexDataStringList) , "%s:%d:%d", name, line, column);
 
   /* Remember string so it can be freed later. */
   index_data = (IndexData *)client_data;

--- a/clang/tools/c-index-test/c-index-test.c
+++ b/clang/tools/c-index-test/c-index-test.c
@@ -3559,7 +3559,8 @@ static CXIdxClientContainer makeClientContainer(CXClientData *client_data,
   node = (IndexDataStringList *)malloc(len);
   assert(node);
   newStr = node->data;
-  snprintf(newStr, len - sizeof(IndexDataStringList) , "%s:%d:%d", name, line, column);
+  snprintf(newStr, len - sizeof(IndexDataStringList), "%s:%d:%d", name, line,
+           column);
 
   /* Remember string so it can be freed later. */
   index_data = (IndexData *)client_data;


### PR DESCRIPTION
We should not try to overwrite the pointer of struct, also need to add 1 for end of line.