### PR TITLE
[clang][dataflow] Add test for crash repro and clean up const accessor handling

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/Models/UncheckedOptionalAccessModel.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Models/UncheckedOptionalAccessModel.cpp
@@ -555,7 +555,8 @@ bool handleConstMemberCall(const CallExpr *CE,
                            dataflow::RecordStorageLocation *RecordLoc,
                            const MatchFinder::MatchResult &Result,
                            LatticeTransferState &State) {
-  if (RecordLoc == nullptr) return false;
+  if (RecordLoc == nullptr)
+    return false;
 
   // If the const method returns an optional or reference to an optional.
   if (isSupportedOptionalType(CE->getType())) {
@@ -582,8 +583,8 @@ bool handleConstMemberCall(const CallExpr *CE,
     return true;
   }
 
-  bool IsBooleanOrPointer = CE->getType()->isBooleanType() ||
-                            CE->getType()->isPointerType();
+  bool IsBooleanOrPointer =
+      CE->getType()->isBooleanType() || CE->getType()->isPointerType();
 
   // Cache if the const method returns a reference
   if (CE->isGLValue()) {

--- a/clang/lib/Analysis/FlowSensitive/Models/UncheckedOptionalAccessModel.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Models/UncheckedOptionalAccessModel.cpp
@@ -582,34 +582,33 @@ bool handleConstMemberCall(const CallExpr *CE,
     State.Env.setStorageLocation(*CE, Loc);
     return true;
   }
-    // PRValue cases:
-    if (CE->getType()->isBooleanType() || CE->getType()->isPointerType()) {
-      // If the const method returns a boolean or pointer type.
-      Value *Val = State.Lattice.getOrCreateConstMethodReturnValue(
-          *RecordLoc, CE, State.Env);
-      if (Val == nullptr)
-        return false;
-      State.Env.setValue(*CE, *Val);
-      return true;
-    }
-    if (isSupportedOptionalType(CE->getType())) {
-      // If the const method returns an optional by value.
-      const FunctionDecl *DirectCallee = CE->getDirectCallee();
-      if (DirectCallee == nullptr)
-        return false;
-      StorageLocation &Loc =
-          State.Lattice.getOrCreateConstMethodReturnStorageLocation(
-              *RecordLoc, DirectCallee, State.Env, [&](StorageLocation &Loc) {
-                setHasValue(cast<RecordStorageLocation>(Loc),
-                            State.Env.makeAtomicBoolValue(), State.Env);
-              });
-      // Use copyRecord to link the optional to the result object of the call
-      // expression.
-      auto &ResultLoc = State.Env.getResultObjectLocation(*CE);
-      copyRecord(cast<RecordStorageLocation>(Loc), ResultLoc, State.Env);
-      return true;
-    }
-
+  // PRValue cases:
+  if (CE->getType()->isBooleanType() || CE->getType()->isPointerType()) {
+    // If the const method returns a boolean or pointer type.
+    Value *Val = State.Lattice.getOrCreateConstMethodReturnValue(*RecordLoc, CE,
+                                                                 State.Env);
+    if (Val == nullptr)
+      return false;
+    State.Env.setValue(*CE, *Val);
+    return true;
+  }
+  if (isSupportedOptionalType(CE->getType())) {
+    // If the const method returns an optional by value.
+    const FunctionDecl *DirectCallee = CE->getDirectCallee();
+    if (DirectCallee == nullptr)
+      return false;
+    StorageLocation &Loc =
+        State.Lattice.getOrCreateConstMethodReturnStorageLocation(
+            *RecordLoc, DirectCallee, State.Env, [&](StorageLocation &Loc) {
+              setHasValue(cast<RecordStorageLocation>(Loc),
+                          State.Env.makeAtomicBoolValue(), State.Env);
+            });
+    // Use copyRecord to link the optional to the result object of the call
+    // expression.
+    auto &ResultLoc = State.Env.getResultObjectLocation(*CE);
+    copyRecord(cast<RecordStorageLocation>(Loc), ResultLoc, State.Env);
+    return true;
+  }
 
   return false;
 }

--- a/clang/lib/Analysis/FlowSensitive/Models/UncheckedOptionalAccessModel.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Models/UncheckedOptionalAccessModel.cpp
@@ -583,9 +583,6 @@ bool handleConstMemberCall(const CallExpr *CE,
     return true;
   }
 
-  bool IsBooleanOrPointer =
-      CE->getType()->isBooleanType() || CE->getType()->isPointerType();
-
   // Cache if the const method returns a reference
   if (CE->isGLValue()) {
     const FunctionDecl *DirectCallee = CE->getDirectCallee();
@@ -595,14 +592,14 @@ bool handleConstMemberCall(const CallExpr *CE,
     StorageLocation &Loc =
         State.Lattice.getOrCreateConstMethodReturnStorageLocation(
             *RecordLoc, DirectCallee, State.Env, [&](StorageLocation &Loc) {
-              if (IsBooleanOrPointer) {
-                State.Env.setValue(Loc, *State.Env.createValue(CE->getType()));
-              }
+              // no-op
+              // NOTE: if we want to support const ref to pointers or bools
+              // we should initialize their values here.
             });
 
     State.Env.setStorageLocation(*CE, Loc);
     return true;
-  } else if (IsBooleanOrPointer) {
+  } else if (CE->getType()->isBooleanType() || CE->getType()->isPointerType()) {
     // Cache if the const method returns a boolean or pointer type.
     Value *Val = State.Lattice.getOrCreateConstMethodReturnValue(*RecordLoc, CE,
                                                                  State.Env);

--- a/clang/lib/Analysis/FlowSensitive/Models/UncheckedOptionalAccessModel.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Models/UncheckedOptionalAccessModel.cpp
@@ -1105,9 +1105,9 @@ auto buildTransferMatchSwitch() {
 
       // const accessor calls
       .CaseOfCFGStmt<CXXMemberCallExpr>(isZeroParamConstMemberCall(),
-                                        transferValue_ConstMemberCall)
+                                        transferConstMemberCall)
       .CaseOfCFGStmt<CXXOperatorCallExpr>(isZeroParamConstMemberOperatorCall(),
-                                          transferValue_ConstMemberOperatorCall)
+                                          transferConstMemberOperatorCall)
       // non-const member calls that may modify the state of an object.
       .CaseOfCFGStmt<CXXMemberCallExpr>(isNonConstMemberCall(),
                                         transferValue_NonConstMemberCall)

--- a/clang/lib/Analysis/FlowSensitive/Models/UncheckedOptionalAccessModel.cpp
+++ b/clang/lib/Analysis/FlowSensitive/Models/UncheckedOptionalAccessModel.cpp
@@ -581,7 +581,7 @@ bool handleConstMemberCall(const CallExpr *CE,
 
     State.Env.setStorageLocation(*CE, Loc);
     return true;
-  } else {
+  }
     // PRValue cases:
     if (CE->getType()->isBooleanType() || CE->getType()->isPointerType()) {
       // If the const method returns a boolean or pointer type.
@@ -591,7 +591,8 @@ bool handleConstMemberCall(const CallExpr *CE,
         return false;
       State.Env.setValue(*CE, *Val);
       return true;
-    } else if (isSupportedOptionalType(CE->getType())) {
+    }
+    if (isSupportedOptionalType(CE->getType())) {
       // If the const method returns an optional by value.
       const FunctionDecl *DirectCallee = CE->getDirectCallee();
       if (DirectCallee == nullptr)
@@ -608,7 +609,7 @@ bool handleConstMemberCall(const CallExpr *CE,
       copyRecord(cast<RecordStorageLocation>(Loc), ResultLoc, State.Env);
       return true;
     }
-  }
+
 
   return false;
 }

--- a/clang/unittests/Analysis/FlowSensitive/UncheckedOptionalAccessModelTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/UncheckedOptionalAccessModelTest.cpp
@@ -3771,30 +3771,6 @@ TEST_P(UncheckedOptionalAccessTest, ConstPointerAccessorWithModInBetween) {
                        /*IgnoreSmartPointerDereference=*/false);
 }
 
-TEST_P(UncheckedOptionalAccessTest, ConstPointerRefAccessor) {
-  ExpectDiagnosticsFor(R"cc(
-    #include "unchecked_optional_access_test.h"
-
-    struct A {
-      $ns::$optional<int> x;
-    };
-
-    struct PtrWrapper {
-      A*& getPtrRef() const;
-      void reset(A*);
-    };
-
-    void target(PtrWrapper p) {
-      if (p.getPtrRef()->x) {
-        *p.getPtrRef()->x;
-        p.reset(nullptr);
-        *p.getPtrRef()->x;  // [[unsafe]]
-      }
-    }
-  )cc",
-                       /*IgnoreSmartPointerDereference=*/false);
-}
-
 TEST_P(UncheckedOptionalAccessTest, SmartPointerAccessorMixed) {
   ExpectDiagnosticsFor(R"cc(
      #include "unchecked_optional_access_test.h"
@@ -3853,7 +3829,7 @@ TEST_P(UncheckedOptionalAccessTest, ConstBoolAccessor) {
     };
 
     void target(A& a) {
-      std::optional<int> opt;
+      $ns::$optional<int> opt;
       if (a.isFoo()) {
         opt = 1;
       }
@@ -3875,7 +3851,7 @@ TEST_P(UncheckedOptionalAccessTest, ConstBoolAccessorWithModInBetween) {
     };
 
     void target(A& a) {
-      std::optional<int> opt;
+      $ns::$optional<int> opt;
       if (a.isFoo()) {
         opt = 1;
       }
@@ -3894,13 +3870,13 @@ TEST_P(UncheckedOptionalAccessTest,
 
     struct A {
       const $ns::$optional<int>& get() const { return x; }
-      
+
       $ns::$optional<int> x;
     };
 
     struct B {
       const A& getA() const { return a; }
-    
+
       A a;
     };
 
@@ -3920,13 +3896,13 @@ TEST_P(
 
     struct A {
       const $ns::$optional<int>& get() const { return x; }
-      
+
       $ns::$optional<int> x;
     };
 
     struct B {
       const A& getA() const { return a; }
-    
+
       A a;
     };
 
@@ -3943,13 +3919,13 @@ TEST_P(UncheckedOptionalAccessTest,
 
     struct A {
       const $ns::$optional<int>& get() const { return x; }
-      
+
       $ns::$optional<int> x;
     };
 
     struct B {
       const A& getA() const { return a; }
-    
+
       A a;
     };
 
@@ -3969,13 +3945,13 @@ TEST_P(UncheckedOptionalAccessTest,
 
     struct A {
       const $ns::$optional<int>& get() const { return x; }
-      
+
       $ns::$optional<int> x;
     };
 
     struct B {
       const A copyA() const { return a; }
-    
+
       A a;
     };
 
@@ -3994,13 +3970,13 @@ TEST_P(UncheckedOptionalAccessTest,
 
     struct A {
       const $ns::$optional<int>& get() const { return x; }
-      
+
       $ns::$optional<int> x;
     };
 
     struct B {
       A& getA() { return a; }
-    
+
       A a;
     };
 
@@ -4055,23 +4031,23 @@ TEST_P(
     ConstRefAccessorToOptionalViaConstRefAccessorToHoldingObjectWithAnotherConstCallAfterCheck) {
   ExpectDiagnosticsFor(R"cc(
       #include "unchecked_optional_access_test.h"
-  
+
       struct A {
         const $ns::$optional<int>& get() const { return x; }
-      
+
         $ns::$optional<int> x;
       };
-  
+
       struct B {
         const A& getA() const { return a; }
-  
+
         void callWithoutChanges() const { 
           // no-op 
         }
-  
+
         A a;
       };
-  
+
       void target(B& b) {  
         if (b.getA().get().has_value()) {
           b.callWithoutChanges(); // calling const method which cannot change A
@@ -4079,6 +4055,34 @@ TEST_P(
         }
       }
     )cc");
+}
+
+TEST_P(UncheckedOptionalAccessTest, ConstPointerRefAccessor) {
+  // A crash reproducer for https://github.com/llvm/llvm-project/issues/125589
+  // NOTE: we currently cache const ref accessors's locations.
+  // If we want to support const ref to pointers or bools, we should initialize
+  // their values.
+  ExpectDiagnosticsFor(R"cc(
+    #include "unchecked_optional_access_test.h"
+
+    struct A {
+      $ns::$optional<int> x;
+    };
+
+    struct PtrWrapper {
+      A*& getPtrRef() const;
+      void reset(A*);
+    };
+
+    void target(PtrWrapper p) {
+      if (p.getPtrRef()->x) {
+        *p.getPtrRef()->x;  // [[unsafe]]
+        p.reset(nullptr);
+        *p.getPtrRef()->x;  // [[unsafe]]
+      }
+    }
+  )cc",
+                       /*IgnoreSmartPointerDereference=*/false);
 }
 
 // FIXME: Add support for:

--- a/clang/unittests/Analysis/FlowSensitive/UncheckedOptionalAccessModelTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/UncheckedOptionalAccessModelTest.cpp
@@ -3771,6 +3771,30 @@ TEST_P(UncheckedOptionalAccessTest, ConstPointerAccessorWithModInBetween) {
                        /*IgnoreSmartPointerDereference=*/false);
 }
 
+TEST_P(UncheckedOptionalAccessTest, ConstPointerRefAccessor) {
+  ExpectDiagnosticsFor(R"cc(
+    #include "unchecked_optional_access_test.h"
+
+    struct A {
+      $ns::$optional<int> x;
+    };
+
+    struct PtrWrapper {
+      A*& getPtrRef() const;
+      void reset(A*);
+    };
+
+    void target(PtrWrapper p) {
+      if (p.getPtrRef()->x) {
+        *p.getPtrRef()->x;
+        p.reset(nullptr);
+        *p.getPtrRef()->x;  // [[unsafe]]
+      }
+    }
+  )cc",
+                       /*IgnoreSmartPointerDereference=*/false);
+}
+
 TEST_P(UncheckedOptionalAccessTest, SmartPointerAccessorMixed) {
   ExpectDiagnosticsFor(R"cc(
      #include "unchecked_optional_access_test.h"


### PR DESCRIPTION
Add test for https://github.com/llvm/llvm-project/issues/125589

The crash is actually incidentally fixed by https://github.com/llvm/llvm-project/pull/128437 since it added a branch for the reference case and would no longer fall through when the return type is a reference to a pointer.

Clean up a bit as well:
- make the fallback for early returns more consistent (check if
  returning optional and call transfer function for that case)
- check RecordLoc == nullptr in one place
- clean up extra spaces in test
- clean up parameterization in test of `std::` vs `$ns::$`