### PR TITLE
[ctxprof] Profile section for flat profiles

### DIFF
--- a/llvm/include/llvm/ProfileData/PGOCtxProfReader.h
+++ b/llvm/include/llvm/ProfileData/PGOCtxProfReader.h
@@ -174,6 +174,7 @@ using CtxProfContextualProfiles =
     std::map<GlobalValue::GUID, PGOCtxProfContext>;
 struct PGOCtxProfile {
   CtxProfContextualProfiles Contexts;
+  CtxProfFlatProfile FlatProfiles;
 
   PGOCtxProfile() = default;
   PGOCtxProfile(const PGOCtxProfile &) = delete;
@@ -192,10 +193,12 @@ class PGOCtxProfileReader final {
   Expected<std::pair<std::optional<uint32_t>, PGOCtxProfContext>>
   readProfile(PGOCtxProfileBlockIDs Kind);
 
+  bool tryGetNextKnownBlockID(PGOCtxProfileBlockIDs &ID);
   bool canEnterBlockWithID(PGOCtxProfileBlockIDs ID);
   Error enterBlockWithID(PGOCtxProfileBlockIDs ID);
 
   Error loadContexts(CtxProfContextualProfiles &P);
+  Error loadFlatProfiles(CtxProfFlatProfile &P);
 
 public:
   PGOCtxProfileReader(StringRef Buffer)

--- a/llvm/include/llvm/ProfileData/PGOCtxProfWriter.h
+++ b/llvm/include/llvm/ProfileData/PGOCtxProfWriter.h
@@ -22,10 +22,14 @@ namespace llvm {
 enum PGOCtxProfileRecords { Invalid = 0, Version, Guid, CalleeIndex, Counters };
 
 enum PGOCtxProfileBlockIDs {
-  ProfileMetadataBlockID = bitc::FIRST_APPLICATION_BLOCKID,
+  FIRST_VALID = bitc::FIRST_APPLICATION_BLOCKID,
+  ProfileMetadataBlockID = FIRST_VALID,
   ContextsSectionBlockID = ProfileMetadataBlockID + 1,
   ContextRootBlockID = ContextsSectionBlockID + 1,
   ContextNodeBlockID = ContextRootBlockID + 1,
+  FlatProfilesSectionBlockID = ContextNodeBlockID + 1,
+  FlatProfileBlockID = FlatProfilesSectionBlockID + 1,
+  LAST_VALID = FlatProfileBlockID
 };
 
 /// Write one or more ContextNodes to the provided raw_fd_stream.
@@ -82,6 +86,11 @@ public:
   void startContextSection() override;
   void writeContextual(const ctx_profile::ContextNode &RootNode) override;
   void endContextSection() override;
+
+  void startFlatSection();
+  void writeFlatSection(ctx_profile::GUID Guid, const uint64_t *Buffer,
+                        size_t BufferSize);
+  void endFlatSection();
 
   // constants used in writing which a reader may find useful.
   static constexpr unsigned CodeLen = 2;

--- a/llvm/test/tools/llvm-ctxprof-util/Inputs/invalid-flat.yaml
+++ b/llvm/test/tools/llvm-ctxprof-util/Inputs/invalid-flat.yaml
@@ -1,0 +1,2 @@
+FlatProfiles:
+  - Guid: 1

--- a/llvm/test/tools/llvm-ctxprof-util/Inputs/valid-ctx-only.yaml
+++ b/llvm/test/tools/llvm-ctxprof-util/Inputs/valid-ctx-only.yaml
@@ -12,8 +12,3 @@ Contexts:
           Counters:        [ 40, 50 ]
   - Guid:            18446744073709551612
     Counters:        [ 5, 9, 10 ]
-FlatProfiles:
-  - Guid:            1234
-    Counters:        [ 5, 6, 7 ]
-  - Guid:            5555
-    Counters:        [ 1 ]

--- a/llvm/test/tools/llvm-ctxprof-util/Inputs/valid-flat-first.yaml
+++ b/llvm/test/tools/llvm-ctxprof-util/Inputs/valid-flat-first.yaml
@@ -1,4 +1,9 @@
 
+FlatProfiles:
+  - Guid:            1234
+    Counters:        [ 5, 6, 7 ]
+  - Guid:            5555
+    Counters:        [ 1 ]
 Contexts:
   - Guid:            1000
     Counters:        [ 1, 2, 3 ]
@@ -12,8 +17,3 @@ Contexts:
           Counters:        [ 40, 50 ]
   - Guid:            18446744073709551612
     Counters:        [ 5, 9, 10 ]
-FlatProfiles:
-  - Guid:            1234
-    Counters:        [ 5, 6, 7 ]
-  - Guid:            5555
-    Counters:        [ 1 ]

--- a/llvm/test/tools/llvm-ctxprof-util/Inputs/valid-flat-only.yaml
+++ b/llvm/test/tools/llvm-ctxprof-util/Inputs/valid-flat-only.yaml
@@ -1,0 +1,6 @@
+
+FlatProfiles:
+  - Guid:            1234
+    Counters:        [ 5, 6, 7 ]
+  - Guid:            5555
+    Counters:        [ 1 ]

--- a/llvm/test/tools/llvm-ctxprof-util/llvm-ctxprof-util-negative.test
+++ b/llvm/test/tools/llvm-ctxprof-util/llvm-ctxprof-util-negative.test
@@ -9,6 +9,7 @@
 ; RUN: not llvm-ctxprof-util fromYAML --input %S/Inputs/invalid-no-ctx.yaml 2>&1 | FileCheck %s --check-prefix=NO_CTX
 ; RUN: not llvm-ctxprof-util fromYAML --input %S/Inputs/invalid-no-counters.yaml 2>&1 | FileCheck %s --check-prefix=NO_COUNTERS
 ; RUN: not llvm-ctxprof-util fromYAML --input %S/Inputs/invalid-bad-subctx.yaml 2>&1 | FileCheck %s --check-prefix=BAD_SUBCTX
+; RUN: not llvm-ctxprof-util fromYAML --input %S/Inputs/invalid-flat.yaml 2>&1 | FileCheck %s --check-prefix=BAD_FLAT
 ; RUN: rm -rf %t
 ; RUN: not llvm-ctxprof-util fromYAML --input %S/Inputs/valid.yaml --output %t/output.bitstream 2>&1 | FileCheck %s --check-prefix=NO_DIR
 
@@ -21,4 +22,5 @@
 ; NO_CTX: YAML:1:1: error: not a mapping
 ; NO_COUNTERS: YAML:2:5: error: missing required key 'Counters'
 ; BAD_SUBCTX: YAML:4:18: error: not a sequence
+; BAD_FLAT: YAML:2:5: error: missing required key 'Counters'
 ; NO_DIR: failed to open output

--- a/llvm/test/tools/llvm-ctxprof-util/llvm-ctxprof-util.test
+++ b/llvm/test/tools/llvm-ctxprof-util/llvm-ctxprof-util.test
@@ -8,6 +8,21 @@
 ; RUN: llvm-ctxprof-util toYAML -input %t/valid.bitstream -output %t/valid2.yaml
 ; RUN: diff %t/valid2.yaml %S/Inputs/valid.yaml
 
+
+; RUN: llvm-ctxprof-util fromYAML -input %S/Inputs/valid-ctx-only.yaml -output %t/valid-ctx-only.bitstream
+; RUN: llvm-ctxprof-util toYAML -input %t/valid-ctx-only.bitstream -output %t/valid-ctx-only.yaml
+; RUN: diff %t/valid-ctx-only.yaml %S/Inputs/valid-ctx-only.yaml
+
+; RUN: llvm-ctxprof-util fromYAML -input %S/Inputs/valid-flat-only.yaml -output %t/valid-flat-only.bitstream
+; RUN: llvm-ctxprof-util toYAML -input %t/valid-flat-only.bitstream -output %t/valid-flat-only.yaml
+; RUN: diff %t/valid-flat-only.yaml %S/Inputs/valid-flat-only.yaml
+
+; This case is the "valid.yaml" case but with the flat profile first.
+; The output, though, should match valid.yaml
+; RUN: llvm-ctxprof-util fromYAML -input %S/Inputs/valid-flat-first.yaml -output %t/valid-flat-first.bitstream
+; RUN: llvm-ctxprof-util toYAML -input %t/valid-flat-first.bitstream -output %t/valid-flat-first.yaml
+; RUN: diff %t/valid-flat-first.yaml %S/Inputs/valid.yaml
+
 ; For the valid case, check against a reference output.
 ; Note that uint64_t are printed as signed values by llvm-bcanalyzer:
 ;  * 18446744073709551613 in yaml is -3 in the output
@@ -22,7 +37,7 @@
 ; EMPTY-NEXT: </Metadata>
 
 ; VALID:      <BLOCKINFO_BLOCK/>
-; VALID-NEXT: <Metadata NumWords=33 BlockCodeSize=2>
+; VALID-NEXT: <Metadata NumWords=45 BlockCodeSize=2>
 ; VALID-NEXT:   <Version op0=2/>
 ; VALID-NEXT:   <Contexts NumWords=29 BlockCodeSize=2>
 ; VALID-NEXT:     <Root NumWords=20 BlockCodeSize=2>
@@ -49,4 +64,14 @@
 ; VALID-NEXT:       <Counters op0=5 op1=9 op2=10/>
 ; VALID-NEXT:     </Root>
 ; VALID-NEXT:   </Contexts>
+; VALID-NEXT:   <FlatProfiles NumWords=10 BlockCodeSize=2>
+; VALID-NEXT:       <Flat NumWords=3 BlockCodeSize=2>
+; VALID-NEXT:         <GUID op0=1234/>
+; VALID-NEXT:         <Counters op0=5 op1=6 op2=7/>
+; VALID-NEXT:       </Flat>
+; VALID-NEXT:       <Flat NumWords=2 BlockCodeSize=2>
+; VALID-NEXT:         <GUID op0=5555/>
+; VALID-NEXT:         <Counters op0=1/>
+; VALID-NEXT:       </Flat>
+; VALID-NEXT:   </FlatProfiles>
 ; VALID-NEXT: </Metadata>


### PR DESCRIPTION
A section for flat profiles (i.e. non-contextual). This is useful for debugging or for intentional cases where a root isn't identified.

This patch adds the reader/writer support. `compiler-rt` changes follow in a subsequent change.