### PR TITLE
[Github] Prefer ubuntu-24.04 over ubuntu-latest

### DIFF
--- a/.github/workflows/build-metrics-container.yml
+++ b/.github/workflows/build-metrics-container.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   build-metrics-container:
     if: github.repository_owner == 'llvm'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       container-name: ${{ steps.vars.outputs.container-name }}
       container-name-tag: ${{ steps.vars.outputs.container-name-tag }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,7 @@ on:
 jobs:
   check-docs-build:
     name: "Test documentation build"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository == 'llvm/llvm-project'
     steps:
       # Don't fetch before checking for file changes to force the file changes

--- a/.github/workflows/email-check.yaml
+++ b/.github/workflows/email-check.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   validate_email:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository == 'llvm/llvm-project'
     steps:
       - name: Fetch LLVM sources

--- a/.github/workflows/issue-release-workflow.yml
+++ b/.github/workflows/issue-release-workflow.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   backport-commits:
     name: Backport Commits
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/issue-subscriber.yml
+++ b/.github/workflows/issue-subscriber.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   auto-subscribe:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository == 'llvm/llvm-project'
     steps:
       - name: Checkout Automation Script

--- a/.github/workflows/issue-write.yml
+++ b/.github/workflows/issue-write.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   pr-comment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     if: >

--- a/.github/workflows/libclang-abi-tests.yml
+++ b/.github/workflows/libclang-abi-tests.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   abi-dump-setup:
     if: github.repository_owner == 'llvm'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       BASELINE_REF: ${{ steps.vars.outputs.BASELINE_REF }}
       ABI_HEADERS: ${{ steps.vars.outputs.ABI_HEADERS }}
@@ -83,7 +83,7 @@ jobs:
   abi-dump:
     if: github.repository_owner == 'llvm'
     needs: abi-dump-setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         name:
@@ -137,7 +137,7 @@ jobs:
 
   abi-compare:
     if: github.repository_owner == 'llvm'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - abi-dump-setup
       - abi-dump

--- a/.github/workflows/llvm-bugs.yml
+++ b/.github/workflows/llvm-bugs.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   auto-subscribe:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository == 'llvm/llvm-project'
     steps:
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -14,7 +14,7 @@ on:
         required: false
       os_list:
         required: false
-        default: '["ubuntu-latest", "windows-2019", "macOS-13"]'
+        default: '["ubuntu-24.04", "windows-2019", "macOS-13"]'
       python_version:
         required: false
         type: string
@@ -39,7 +39,7 @@ on:
         type: string
         # Use windows-2019 due to:
         # https://developercommunity.visualstudio.com/t/Prev-Issue---with-__assume-isnan-/1597317
-        # Use ubuntu-22.04 rather than ubuntu-latest to match the ubuntu
+        # Use ubuntu-22.04 rather than ubuntu-24.04 to match the ubuntu
         # version in the CI container. Without this, setup-python tries
         # to install a python version linked against a newer version of glibc.
         # TODO(boomanaiden154): Bump the Ubuntu version once the version in the

--- a/.github/workflows/llvm-tests.yml
+++ b/.github/workflows/llvm-tests.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   abi-dump-setup:
     if: github.repository_owner == 'llvm'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       BASELINE_REF: ${{ steps.vars.outputs.BASELINE_REF }}
       ABI_HEADERS: ${{ steps.vars.outputs.ABI_HEADERS }}
@@ -71,7 +71,7 @@ jobs:
   abi-dump:
     if: github.repository_owner == 'llvm'
     needs: abi-dump-setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         name:
@@ -141,7 +141,7 @@ jobs:
 
   abi-compare:
     if: github.repository_owner == 'llvm'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - abi-dump-setup
       - abi-dump

--- a/.github/workflows/merged-prs.yml
+++ b/.github/workflows/merged-prs.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   buildbot_comment:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     if: >-

--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -10,7 +10,7 @@ jobs:
   automate-issues-labels:
     permissions:
       issues: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository == 'llvm/llvm-project'
     steps:
       - uses: llvm/actions/issue-labeler@main

--- a/.github/workflows/new-prs.yml
+++ b/.github/workflows/new-prs.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   greeter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     # Only comment on PRs that have been opened for the first time, by someone
@@ -56,7 +56,7 @@ jobs:
   automate-prs-labels:
     # Greet first so that only the author gets that notification.
     needs: greeter
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # Ignore PRs with more than 10 commits.  Pull requests with a lot of
     # commits tend to be accidents usually when someone made a mistake while trying
     # to rebase.  We want to ignore these pull requests to avoid excessive

--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   code_formatter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-request-release-note.yml
+++ b/.github/workflows/pr-request-release-note.yml
@@ -14,7 +14,7 @@ jobs:
       github.repository_owner == 'llvm' &&
       startsWith(github.ref, 'refs/heads/release')
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # We need to pull the script from the main branch, so that we ensure
       # we get the latest version of this script.

--- a/.github/workflows/pr-subscriber.yml
+++ b/.github/workflows/pr-subscriber.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   auto-subscribe:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository == 'llvm/llvm-project'
     steps:
       - name: Checkout Automation Script

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -29,7 +29,7 @@ on:
 jobs:
   release-documentation:
     name: Build and Upload Release Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       upload: ${{ inputs.upload && !contains(inputs.release-version, 'rc') }}
     steps:

--- a/.github/workflows/release-doxygen.yml
+++ b/.github/workflows/release-doxygen.yml
@@ -33,7 +33,7 @@ on:
 jobs:
   release-doxygen:
     name: Build and Upload Release Doxygen
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     env:

--- a/.github/workflows/release-lit.yml
+++ b/.github/workflows/release-lit.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   release-lit:
     name: Release Lit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout LLVM
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/release-sources.yml
+++ b/.github/workflows/release-sources.yml
@@ -47,7 +47,7 @@ jobs:
     outputs:
       ref: ${{ steps.inputs.outputs.ref }}
       export-args: ${{ steps.inputs.outputs.export-args }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - id: inputs
         run: |
@@ -63,7 +63,7 @@ jobs:
   release-sources:
     name: Package Release Sources
     if: github.repository_owner == 'llvm'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - inputs
     permissions:

--- a/.github/workflows/release-tasks.yml
+++ b/.github/workflows/release-tasks.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   validate-tag:
     name: Validate Tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository == 'llvm/llvm-project'
     outputs:
       release-version: ${{ steps.validate-tag.outputs.release-version }}
@@ -26,7 +26,7 @@ jobs:
 
   release-create:
     name: Create a New Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write # For creating the release.
     needs: validate-tag

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository == 'llvm/llvm-project'
     permissions:
       # Needed to upload the results to code-scanning dashboard.

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   version_check:
     if: github.repository_owner == 'llvm'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Fetch LLVM sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
This patch replaces all instances of ubuntu-latest with ubuntu-24.04 (outside of the entries in libc++) based on the guidelines in the LLVM CI best practices doc (https://llvm.org/docs/CIBestPractices.html).