### PR TITLE
PowerPC: Use REG_SEQUENCE instead of INSERT_SUBREG

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstrMMA.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrMMA.td
@@ -1047,19 +1047,18 @@ let Predicates = [MMA, PrefixInstrs, IsISAFuture] in {
 }
 
 def ConcatsMMA {
-  dag VecsToVecPair0 =
-    (v256i1 (INSERT_SUBREG
-      (INSERT_SUBREG (IMPLICIT_DEF), $vs0, sub_vsx1),
-      $vs1, sub_vsx0));
-  dag VecsToVecPair1 =
-    (v256i1 (INSERT_SUBREG
-      (INSERT_SUBREG (IMPLICIT_DEF), $vs2, sub_vsx1),
-      $vs3, sub_vsx0));
-  dag VecsToVecQuad =
-    (BUILD_UACC (INSERT_SUBREG
-                  (INSERT_SUBREG (v512i1 (IMPLICIT_DEF)),
-                                 (KILL_PAIR VecsToVecPair0), sub_pair0),
-                  (KILL_PAIR VecsToVecPair1), sub_pair1));
+   dag VecsToVecPair0 =
+          (v256i1 (INSERT_SUBREG
+                    (INSERT_SUBREG (IMPLICIT_DEF), $vs0, sub_vsx1),
+                    $vs1, sub_vsx0));
+   dag VecsToVecPair1 =
+          (v256i1 (INSERT_SUBREG
+                    (INSERT_SUBREG (IMPLICIT_DEF), $vs2, sub_vsx1),
+                    $vs3, sub_vsx0));
+  dag VecsToVecQuad = (BUILD_UACC
+          (v512i1 (REG_SEQUENCE UACCRC,
+                                (KILL_PAIR VecsToVecPair0), sub_pair0,
+                                (KILL_PAIR VecsToVecPair1), sub_pair1)));
 }
 
 def Extracts {

--- a/llvm/lib/Target/PowerPC/PPCInstrP10.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrP10.td
@@ -1139,17 +1139,11 @@ class MMIRR_XX3Form_XYP4_XAB6<bits<6> opcode, bits<8> xo, dag OOL, dag IOL,
   let Inst{63} = 0;
 }
 
-
-
 def Concats {
   dag VecsToVecPair0 =
-    (v256i1 (INSERT_SUBREG
-      (INSERT_SUBREG (IMPLICIT_DEF), $vs0, sub_vsx1),
-      $vs1, sub_vsx0));
+    (v256i1 (REG_SEQUENCE VSRpRC, $vs0, sub_vsx1, $vs1, sub_vsx0));
   dag VecsToVecPair1 =
-    (v256i1 (INSERT_SUBREG
-      (INSERT_SUBREG (IMPLICIT_DEF), $vs2, sub_vsx1),
-      $vs3, sub_vsx0));
+    (v256i1 (REG_SEQUENCE VSRpRC, $vs2, sub_vsx1, $vs3, sub_vsx0));
 }
 
 let Predicates = [PairedVectorMemops] in {

--- a/llvm/test/CodeGen/PowerPC/bfloat16-outer-product.ll
+++ b/llvm/test/CodeGen/PowerPC/bfloat16-outer-product.ll
@@ -70,10 +70,10 @@ declare <512 x i1> @llvm.ppc.mma.pmxvbf16ger2(<16 x i8>, <16 x i8>, i32, i32, i3
 define dso_local void @test52(ptr nocapture readonly %vqp, ptr nocapture readnone %vpp, <16 x i8> %vc, ptr nocapture %resp) {
 ; CHECK-LABEL: test52:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvbf16ger2pp acc0, v2, v2
 ; CHECK-NEXT:    xxmfacc acc0
@@ -85,10 +85,10 @@ define dso_local void @test52(ptr nocapture readonly %vqp, ptr nocapture readnon
 ;
 ; CHECK-BE-LABEL: test52:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvbf16ger2pp acc0, v2, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -111,10 +111,10 @@ declare <512 x i1> @llvm.ppc.mma.xvbf16ger2pp(<512 x i1>, <16 x i8>, <16 x i8>)
 define dso_local void @test53(ptr nocapture readonly %vqp, ptr nocapture readnone %vpp, <16 x i8> %vc, ptr nocapture %resp) {
 ; CHECK-LABEL: test53:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvbf16ger2pn acc0, v2, v2
 ; CHECK-NEXT:    xxmfacc acc0
@@ -126,10 +126,10 @@ define dso_local void @test53(ptr nocapture readonly %vqp, ptr nocapture readnon
 ;
 ; CHECK-BE-LABEL: test53:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvbf16ger2pn acc0, v2, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -152,10 +152,10 @@ declare <512 x i1> @llvm.ppc.mma.xvbf16ger2pn(<512 x i1>, <16 x i8>, <16 x i8>)
 define dso_local void @test54(ptr nocapture readonly %vqp, ptr nocapture readnone %vpp, <16 x i8> %vc, ptr nocapture %resp) {
 ; CHECK-LABEL: test54:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvbf16ger2np acc0, v2, v2
 ; CHECK-NEXT:    xxmfacc acc0
@@ -167,10 +167,10 @@ define dso_local void @test54(ptr nocapture readonly %vqp, ptr nocapture readnon
 ;
 ; CHECK-BE-LABEL: test54:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvbf16ger2np acc0, v2, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -193,10 +193,10 @@ declare <512 x i1> @llvm.ppc.mma.xvbf16ger2np(<512 x i1>, <16 x i8>, <16 x i8>)
 define dso_local void @test55(ptr nocapture readonly %vqp, ptr nocapture readnone %vpp, <16 x i8> %vc, ptr nocapture %resp) {
 ; CHECK-LABEL: test55:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvbf16ger2nn acc0, v2, v2
 ; CHECK-NEXT:    xxmfacc acc0
@@ -208,10 +208,10 @@ define dso_local void @test55(ptr nocapture readonly %vqp, ptr nocapture readnon
 ;
 ; CHECK-BE-LABEL: test55:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvbf16ger2nn acc0, v2, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -234,10 +234,10 @@ declare <512 x i1> @llvm.ppc.mma.xvbf16ger2nn(<512 x i1>, <16 x i8>, <16 x i8>)
 define dso_local void @test56(ptr nocapture readonly %vqp, ptr nocapture readnone %vpp, <16 x i8> %vc, ptr nocapture %resp) {
 ; CHECK-LABEL: test56:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvbf16ger2pp acc0, v2, v2, 0, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
@@ -249,10 +249,10 @@ define dso_local void @test56(ptr nocapture readonly %vqp, ptr nocapture readnon
 ;
 ; CHECK-BE-LABEL: test56:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvbf16ger2pp acc0, v2, v2, 0, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -275,10 +275,10 @@ declare <512 x i1> @llvm.ppc.mma.pmxvbf16ger2pp(<512 x i1>, <16 x i8>, <16 x i8>
 define dso_local void @test57(ptr nocapture readonly %vqp, ptr nocapture readnone %vpp, <16 x i8> %vc, ptr nocapture %resp) {
 ; CHECK-LABEL: test57:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvbf16ger2pn acc0, v2, v2, 0, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
@@ -290,10 +290,10 @@ define dso_local void @test57(ptr nocapture readonly %vqp, ptr nocapture readnon
 ;
 ; CHECK-BE-LABEL: test57:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvbf16ger2pn acc0, v2, v2, 0, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -316,10 +316,10 @@ declare <512 x i1> @llvm.ppc.mma.pmxvbf16ger2pn(<512 x i1>, <16 x i8>, <16 x i8>
 define dso_local void @test58(ptr nocapture readonly %vqp, ptr nocapture readnone %vpp, <16 x i8> %vc, ptr nocapture %resp) {
 ; CHECK-LABEL: test58:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvbf16ger2np acc0, v2, v2, 0, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
@@ -331,10 +331,10 @@ define dso_local void @test58(ptr nocapture readonly %vqp, ptr nocapture readnon
 ;
 ; CHECK-BE-LABEL: test58:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvbf16ger2np acc0, v2, v2, 0, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -357,10 +357,10 @@ declare <512 x i1> @llvm.ppc.mma.pmxvbf16ger2np(<512 x i1>, <16 x i8>, <16 x i8>
 define dso_local void @test59(ptr nocapture readonly %vqp, ptr nocapture readnone %vpp, <16 x i8> %vc, ptr nocapture %resp) {
 ; CHECK-LABEL: test59:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvbf16ger2nn acc0, v2, v2, 0, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
@@ -372,10 +372,10 @@ define dso_local void @test59(ptr nocapture readonly %vqp, ptr nocapture readnon
 ;
 ; CHECK-BE-LABEL: test59:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvbf16ger2nn acc0, v2, v2, 0, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0

--- a/llvm/test/CodeGen/PowerPC/dmf-outer-product.ll
+++ b/llvm/test/CodeGen/PowerPC/dmf-outer-product.ll
@@ -11,9 +11,9 @@ declare <1024 x i1> @llvm.ppc.mma.dmxvi8gerx4(<256 x i1>, <16 x i8>)
 define void @test_dmxvi8gerx4(ptr %vpp, ptr %vcp, ptr %resp) {
 ; CHECK-LABEL: test_dmxvi8gerx4:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv v3, 0(r3)
-; CHECK-NEXT:    lxv vs0, 0(r4)
 ; CHECK-NEXT:    lxv v2, 16(r3)
+; CHECK-NEXT:    lxv vs0, 0(r4)
+; CHECK-NEXT:    lxv v3, 0(r3)
 ; CHECK-NEXT:    dmxvi8gerx4 dmr0, vsp34, vs0
 ; CHECK-NEXT:    dmxxextfdmr512 wacc0, vsp34, vsp36, 0
 ; CHECK-NEXT:    stxvp vsp34, 96(r5)
@@ -25,9 +25,9 @@ define void @test_dmxvi8gerx4(ptr %vpp, ptr %vcp, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test_dmxvi8gerx4:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv v3, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r4)
 ; CHECK-BE-NEXT:    lxv v2, 0(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r4)
+; CHECK-BE-NEXT:    lxv v3, 16(r3)
 ; CHECK-BE-NEXT:    dmxvi8gerx4 dmr0, vsp34, vs0
 ; CHECK-BE-NEXT:    dmxxextfdmr512 wacc_hi0, vsp34, vsp36, 1
 ; CHECK-BE-NEXT:    stxvp vsp36, 96(r5)
@@ -55,9 +55,9 @@ define void @test_dmxvi8gerx4pp(ptr %vop, ptr %vpp, ptr %vcp, ptr %resp) {
 ; CHECK-NEXT:    lxvp vsp34, 64(r3)
 ; CHECK-NEXT:    lxvp vsp36, 96(r3)
 ; CHECK-NEXT:    dmxxinstfdmr512 wacc0, vsp36, vsp34, 0
-; CHECK-NEXT:    lxv v3, 0(r4)
-; CHECK-NEXT:    lxv vs0, 0(r5)
 ; CHECK-NEXT:    lxv v2, 16(r4)
+; CHECK-NEXT:    lxv vs0, 0(r5)
+; CHECK-NEXT:    lxv v3, 0(r4)
 ; CHECK-NEXT:    dmxvi8gerx4pp dmr0, vsp34, vs0
 ; CHECK-NEXT:    dmxxextfdmr512 wacc0, vsp34, vsp36, 0
 ; CHECK-NEXT:    stxvp vsp34, 96(r6)
@@ -69,23 +69,23 @@ define void @test_dmxvi8gerx4pp(ptr %vop, ptr %vpp, ptr %vcp, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test_dmxvi8gerx4pp:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:  lxvp vsp34, 96(r3)
-; CHECK-BE-NEXT:  lxvp vsp36, 64(r3)
-; CHECK-BE-NEXT:  dmxxinstfdmr512 wacc_hi0, vsp36, vsp34, 1
-; CHECK-BE-NEXT:  lxvp vsp34, 32(r3)
-; CHECK-BE-NEXT:  lxvp vsp36, 0(r3)
-; CHECK-BE-NEXT:  dmxxinstfdmr512 wacc0, vsp36, vsp34, 0
-; CHECK-BE-NEXT:  lxv v3, 16(r4)
-; CHECK-BE-NEXT:  lxv vs0, 0(r5)
-; CHECK-BE-NEXT:  lxv v2, 0(r4)
-; CHECK-BE-NEXT:  dmxvi8gerx4pp dmr0, vsp34, vs0
-; CHECK-BE-NEXT:  dmxxextfdmr512 wacc_hi0, vsp34, vsp36, 1
-; CHECK-BE-NEXT:  stxvp vsp36, 96(r6)
-; CHECK-BE-NEXT:  stxvp vsp34, 64(r6)
-; CHECK-BE-NEXT:  dmxxextfdmr512 wacc0, vsp34, vsp36, 0
-; CHECK-BE-NEXT:  stxvp vsp36, 32(r6)
-; CHECK-BE-NEXT:  stxvp vsp34, 0(r6)
-; CHECK-BE-NEXT:  blr
+; CHECK-BE-NEXT:    lxvp vsp34, 96(r3)
+; CHECK-BE-NEXT:    lxvp vsp36, 64(r3)
+; CHECK-BE-NEXT:    dmxxinstfdmr512 wacc_hi0, vsp36, vsp34, 1
+; CHECK-BE-NEXT:    lxvp vsp34, 32(r3)
+; CHECK-BE-NEXT:    lxvp vsp36, 0(r3)
+; CHECK-BE-NEXT:    dmxxinstfdmr512 wacc0, vsp36, vsp34, 0
+; CHECK-BE-NEXT:    lxv v2, 0(r4)
+; CHECK-BE-NEXT:    lxv vs0, 0(r5)
+; CHECK-BE-NEXT:    lxv v3, 16(r4)
+; CHECK-BE-NEXT:    dmxvi8gerx4pp dmr0, vsp34, vs0
+; CHECK-BE-NEXT:    dmxxextfdmr512 wacc_hi0, vsp34, vsp36, 1
+; CHECK-BE-NEXT:    stxvp vsp36, 96(r6)
+; CHECK-BE-NEXT:    stxvp vsp34, 64(r6)
+; CHECK-BE-NEXT:    dmxxextfdmr512 wacc0, vsp34, vsp36, 0
+; CHECK-BE-NEXT:    stxvp vsp36, 32(r6)
+; CHECK-BE-NEXT:    stxvp vsp34, 0(r6)
+; CHECK-BE-NEXT:    blr
 entry:
   %v.dmr = load <1024 x i1>, ptr %vop, align 64
   %v1 = load <256 x i1>, ptr %vpp, align 32
@@ -106,9 +106,9 @@ define void @test_dmxvi8gerx4spp(ptr %vop, ptr %vpp, ptr %vcp, ptr %resp) {
 ; CHECK-NEXT:    lxvp vsp34, 64(r3)
 ; CHECK-NEXT:    lxvp vsp36, 96(r3)
 ; CHECK-NEXT:    dmxxinstfdmr512 wacc0, vsp36, vsp34, 0
-; CHECK-NEXT:    lxv v3, 0(r4)
-; CHECK-NEXT:    lxv vs0, 0(r5)
 ; CHECK-NEXT:    lxv v2, 16(r4)
+; CHECK-NEXT:    lxv vs0, 0(r5)
+; CHECK-NEXT:    lxv v3, 0(r4)
 ; CHECK-NEXT:    dmxvi8gerx4spp dmr0, vsp34, vs0
 ; CHECK-NEXT:    dmxxextfdmr512 wacc0, vsp34, vsp36, 0
 ; CHECK-NEXT:    stxvp vsp34, 96(r6)
@@ -120,23 +120,23 @@ define void @test_dmxvi8gerx4spp(ptr %vop, ptr %vpp, ptr %vcp, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test_dmxvi8gerx4spp:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:     lxvp vsp34, 96(r3)
-; CHECK-BE-NEXT:     lxvp vsp36, 64(r3)
-; CHECK-BE-NEXT:     dmxxinstfdmr512 wacc_hi0, vsp36, vsp34, 1
-; CHECK-BE-NEXT:     lxvp vsp34, 32(r3)
-; CHECK-BE-NEXT:     lxvp vsp36, 0(r3)
-; CHECK-BE-NEXT:     dmxxinstfdmr512 wacc0, vsp36, vsp34, 0
-; CHECK-BE-NEXT:     lxv v3, 16(r4)
-; CHECK-BE-NEXT:     lxv vs0, 0(r5)
-; CHECK-BE-NEXT:     lxv v2, 0(r4)
-; CHECK-BE-NEXT:     dmxvi8gerx4spp dmr0, vsp34, vs0
-; CHECK-BE-NEXT:     dmxxextfdmr512 wacc_hi0, vsp34, vsp36, 1
-; CHECK-BE-NEXT:     stxvp vsp36, 96(r6)
-; CHECK-BE-NEXT:     stxvp vsp34, 64(r6)
-; CHECK-BE-NEXT:     dmxxextfdmr512 wacc0, vsp34, vsp36, 0
-; CHECK-BE-NEXT:     stxvp vsp36, 32(r6)
-; CHECK-BE-NEXT:     stxvp vsp34, 0(r6)
-; CHECK-BE-NEXT:     blr
+; CHECK-BE-NEXT:    lxvp vsp34, 96(r3)
+; CHECK-BE-NEXT:    lxvp vsp36, 64(r3)
+; CHECK-BE-NEXT:    dmxxinstfdmr512 wacc_hi0, vsp36, vsp34, 1
+; CHECK-BE-NEXT:    lxvp vsp34, 32(r3)
+; CHECK-BE-NEXT:    lxvp vsp36, 0(r3)
+; CHECK-BE-NEXT:    dmxxinstfdmr512 wacc0, vsp36, vsp34, 0
+; CHECK-BE-NEXT:    lxv v2, 0(r4)
+; CHECK-BE-NEXT:    lxv vs0, 0(r5)
+; CHECK-BE-NEXT:    lxv v3, 16(r4)
+; CHECK-BE-NEXT:    dmxvi8gerx4spp dmr0, vsp34, vs0
+; CHECK-BE-NEXT:    dmxxextfdmr512 wacc_hi0, vsp34, vsp36, 1
+; CHECK-BE-NEXT:    stxvp vsp36, 96(r6)
+; CHECK-BE-NEXT:    stxvp vsp34, 64(r6)
+; CHECK-BE-NEXT:    dmxxextfdmr512 wacc0, vsp34, vsp36, 0
+; CHECK-BE-NEXT:    stxvp vsp36, 32(r6)
+; CHECK-BE-NEXT:    stxvp vsp34, 0(r6)
+; CHECK-BE-NEXT:    blr
 entry:
   %v.dmr = load <1024 x i1>, ptr %vop, align 64
   %v1 = load <256 x i1>, ptr %vpp, align 32
@@ -157,9 +157,9 @@ define void @test_pmdmxvi8gerx4pp(ptr %vop, ptr %vpp, ptr %vcp, ptr %resp) {
 ; CHECK-NEXT:    lxvp vsp34, 64(r3)
 ; CHECK-NEXT:    lxvp vsp36, 96(r3)
 ; CHECK-NEXT:    dmxxinstfdmr512 wacc0, vsp36, vsp34, 0
-; CHECK-NEXT:    lxv v3, 0(r4)
-; CHECK-NEXT:    lxv vs0, 0(r5)
 ; CHECK-NEXT:    lxv v2, 16(r4)
+; CHECK-NEXT:    lxv vs0, 0(r5)
+; CHECK-NEXT:    lxv v3, 0(r4)
 ; CHECK-NEXT:    pmdmxvi8gerx4pp dmr0, vsp34, vs0, 42, 7, 9
 ; CHECK-NEXT:    dmxxextfdmr512 wacc0, vsp34, vsp36, 0
 ; CHECK-NEXT:    stxvp vsp34, 96(r6)
@@ -177,9 +177,9 @@ define void @test_pmdmxvi8gerx4pp(ptr %vop, ptr %vpp, ptr %vcp, ptr %resp) {
 ; CHECK-BE-NEXT:    lxvp vsp34, 32(r3)
 ; CHECK-BE-NEXT:    lxvp vsp36, 0(r3)
 ; CHECK-BE-NEXT:    dmxxinstfdmr512 wacc0, vsp36, vsp34, 0
-; CHECK-BE-NEXT:    lxv v3, 16(r4)
-; CHECK-BE-NEXT:    lxv vs0, 0(r5)
 ; CHECK-BE-NEXT:    lxv v2, 0(r4)
+; CHECK-BE-NEXT:    lxv vs0, 0(r5)
+; CHECK-BE-NEXT:    lxv v3, 16(r4)
 ; CHECK-BE-NEXT:    pmdmxvi8gerx4pp dmr0, vsp34, vs0, 42, 7, 9
 ; CHECK-BE-NEXT:    dmxxextfdmr512 wacc_hi0, vsp34, vsp36, 1
 ; CHECK-BE-NEXT:    stxvp vsp36, 96(r6)
@@ -202,9 +202,9 @@ declare <1024 x i1> @llvm.ppc.mma.pmdmxvi8gerx4(<256 x i1>, <16 x i8>, i32, i32,
 define void @test_pmdmxvi8gerx4(ptr %vpp, ptr %vcp, ptr %resp) {
 ; CHECK-LABEL: test_pmdmxvi8gerx4:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv v3, 0(r3)
-; CHECK-NEXT:    lxv vs0, 0(r4)
 ; CHECK-NEXT:    lxv v2, 16(r3)
+; CHECK-NEXT:    lxv vs0, 0(r4)
+; CHECK-NEXT:    lxv v3, 0(r3)
 ; CHECK-NEXT:    pmdmxvi8gerx4 dmr0, vsp34, vs0, 55, 5, 10
 ; CHECK-NEXT:    dmxxextfdmr512 wacc0, vsp34, vsp36, 0
 ; CHECK-NEXT:    stxvp vsp34, 96(r5)
@@ -216,17 +216,17 @@ define void @test_pmdmxvi8gerx4(ptr %vpp, ptr %vcp, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test_pmdmxvi8gerx4:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:     lxv v3, 16(r3)
-; CHECK-BE-NEXT:     lxv vs0, 0(r4)
-; CHECK-BE-NEXT:     lxv v2, 0(r3)
-; CHECK-BE-NEXT:     pmdmxvi8gerx4 dmr0, vsp34, vs0, 55, 5, 10
-; CHECK-BE-NEXT:     dmxxextfdmr512 wacc_hi0, vsp34, vsp36, 1
-; CHECK-BE-NEXT:     stxvp vsp36, 96(r5)
-; CHECK-BE-NEXT:     stxvp vsp34, 64(r5)
-; CHECK-BE-NEXT:     dmxxextfdmr512 wacc0, vsp34, vsp36, 0
-; CHECK-BE-NEXT:     stxvp vsp36, 32(r5)
-; CHECK-BE-NEXT:     stxvp vsp34, 0(r5)
-; CHECK-BE-NEXT:     blr
+; CHECK-BE-NEXT:    lxv v2, 0(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r4)
+; CHECK-BE-NEXT:    lxv v3, 16(r3)
+; CHECK-BE-NEXT:    pmdmxvi8gerx4 dmr0, vsp34, vs0, 55, 5, 10
+; CHECK-BE-NEXT:    dmxxextfdmr512 wacc_hi0, vsp34, vsp36, 1
+; CHECK-BE-NEXT:    stxvp vsp36, 96(r5)
+; CHECK-BE-NEXT:    stxvp vsp34, 64(r5)
+; CHECK-BE-NEXT:    dmxxextfdmr512 wacc0, vsp34, vsp36, 0
+; CHECK-BE-NEXT:    stxvp vsp36, 32(r5)
+; CHECK-BE-NEXT:    stxvp vsp34, 0(r5)
+; CHECK-BE-NEXT:    blr
 entry:
   %v1 = load <256 x i1>, ptr %vpp, align 32
   %v2 = load <16 x i8>, ptr %vcp, align 32
@@ -246,9 +246,9 @@ define dso_local void @test_pmdmxvi8gerx4spp(ptr %vop, ptr %vpp, ptr %vcp, ptr %
 ; CHECK-NEXT:    lxvp vsp34, 64(r3)
 ; CHECK-NEXT:    lxvp vsp36, 96(r3)
 ; CHECK-NEXT:    dmxxinstfdmr512 wacc0, vsp36, vsp34, 0
-; CHECK-NEXT:    lxv v3, 0(r4)
-; CHECK-NEXT:    lxv vs0, 0(r5)
 ; CHECK-NEXT:    lxv v2, 16(r4)
+; CHECK-NEXT:    lxv vs0, 0(r5)
+; CHECK-NEXT:    lxv v3, 0(r4)
 ; CHECK-NEXT:    pmdmxvi8gerx4spp dmr0, vsp34, vs0, 100, 6, 12
 ; CHECK-NEXT:    dmxxextfdmr512 wacc0, vsp34, vsp36, 0
 ; CHECK-NEXT:    stxvp vsp34, 96(r6)
@@ -266,9 +266,9 @@ define dso_local void @test_pmdmxvi8gerx4spp(ptr %vop, ptr %vpp, ptr %vcp, ptr %
 ; CHECK-BE-NEXT:    lxvp vsp34, 32(r3)
 ; CHECK-BE-NEXT:    lxvp vsp36, 0(r3)
 ; CHECK-BE-NEXT:    dmxxinstfdmr512 wacc0, vsp36, vsp34, 0
-; CHECK-BE-NEXT:    lxv v3, 16(r4)
-; CHECK-BE-NEXT:    lxv vs0, 0(r5)
 ; CHECK-BE-NEXT:    lxv v2, 0(r4)
+; CHECK-BE-NEXT:    lxv vs0, 0(r5)
+; CHECK-BE-NEXT:    lxv v3, 16(r4)
 ; CHECK-BE-NEXT:    pmdmxvi8gerx4spp dmr0, vsp34, vs0, 100, 6, 12
 ; CHECK-BE-NEXT:    dmxxextfdmr512 wacc_hi0, vsp34, vsp36, 1
 ; CHECK-BE-NEXT:    stxvp vsp36, 96(r6)

--- a/llvm/test/CodeGen/PowerPC/mma-acc-copy-hints.ll
+++ b/llvm/test/CodeGen/PowerPC/mma-acc-copy-hints.ll
@@ -28,9 +28,9 @@ define void @testMultiply(ptr nocapture noundef readonly %a, ptr nocapture nound
 ; CHECK-NEXT:    bl _Z15buildVectorPairPu13__vector_pairDv16_hS0_@notoc
 ; CHECK-NEXT:    xxsetaccz acc1
 ; CHECK-NEXT:    xvf32gerpp acc1, v31, v30
-; CHECK-NEXT:    lxv v3, 32(r1)
 ; CHECK-NEXT:    lxv vs0, 48(r1)
-; CHECK-NEXT:    xvf32gerpp acc1, v3, vs0
+; CHECK-NEXT:    lxv vs1, 32(r1)
+; CHECK-NEXT:    xvf32gerpp acc1, vs1, vs0
 ; CHECK-NEXT:    lxv v31, -48(r30) # 16-byte Folded Reload
 ; CHECK-NEXT:    lxv v30, -64(r30) # 16-byte Folded Reload
 ; CHECK-NEXT:    xxmfacc acc1
@@ -71,16 +71,16 @@ define void @testMultiply(ptr nocapture noundef readonly %a, ptr nocapture nound
 ; CHECK-BE-NEXT:    nop
 ; CHECK-BE-NEXT:    xxsetaccz acc1
 ; CHECK-BE-NEXT:    xvf32gerpp acc1, v31, v30
-; CHECK-BE-NEXT:    lxv v3, 144(r1)
 ; CHECK-BE-NEXT:    lxv vs0, 128(r1)
-; CHECK-BE-NEXT:    xvf32gerpp acc1, vs0, v3
+; CHECK-BE-NEXT:    lxv vs1, 144(r1)
+; CHECK-BE-NEXT:    xvf32gerpp acc1, vs0, vs1
 ; CHECK-BE-NEXT:    lxv v31, -48(r30) # 16-byte Folded Reload
 ; CHECK-BE-NEXT:    lxv v30, -64(r30) # 16-byte Folded Reload
 ; CHECK-BE-NEXT:    xxmfacc acc1
-; CHECK-BE-NEXT:    xxlor vs1, vs6, vs6
-; CHECK-BE-NEXT:    xxlor vs0, vs7, vs7
 ; CHECK-BE-NEXT:    xxlor vs3, vs4, vs4
 ; CHECK-BE-NEXT:    xxlor vs2, vs5, vs5
+; CHECK-BE-NEXT:    xxlor vs1, vs6, vs6
+; CHECK-BE-NEXT:    xxlor vs0, vs7, vs7
 ; CHECK-BE-NEXT:    stxv vs0, 0(r29)
 ; CHECK-BE-NEXT:    pstxv vs1, 8(r29), 0
 ; CHECK-BE-NEXT:    stxv vs2, 16(r29)

--- a/llvm/test/CodeGen/PowerPC/mma-acc-memops.ll
+++ b/llvm/test/CodeGen/PowerPC/mma-acc-memops.ll
@@ -26,10 +26,10 @@
 define dso_local void @testLdSt(i64 %SrcIdx, i64 %DstIdx) {
 ; LE-PAIRED-LABEL: testLdSt:
 ; LE-PAIRED:       # %bb.0: # %entry
-; LE-PAIRED-NEXT:    plxv vs1, f@PCREL+96(0), 1
-; LE-PAIRED-NEXT:    plxv vs0, f@PCREL+112(0), 1
 ; LE-PAIRED-NEXT:    plxv vs3, f@PCREL+64(0), 1
 ; LE-PAIRED-NEXT:    plxv vs2, f@PCREL+80(0), 1
+; LE-PAIRED-NEXT:    plxv vs1, f@PCREL+96(0), 1
+; LE-PAIRED-NEXT:    plxv vs0, f@PCREL+112(0), 1
 ; LE-PAIRED-NEXT:    pstxv vs0, f@PCREL+176(0), 1
 ; LE-PAIRED-NEXT:    pstxv vs1, f@PCREL+160(0), 1
 ; LE-PAIRED-NEXT:    pstxv vs2, f@PCREL+144(0), 1
@@ -40,10 +40,10 @@ define dso_local void @testLdSt(i64 %SrcIdx, i64 %DstIdx) {
 ; BE-PAIRED:       # %bb.0: # %entry
 ; BE-PAIRED-NEXT:    addis r3, r2, f@toc@ha
 ; BE-PAIRED-NEXT:    addi r3, r3, f@toc@l
-; BE-PAIRED-NEXT:    lxv vs1, 80(r3)
-; BE-PAIRED-NEXT:    lxv vs0, 64(r3)
 ; BE-PAIRED-NEXT:    lxv vs3, 112(r3)
 ; BE-PAIRED-NEXT:    lxv vs2, 96(r3)
+; BE-PAIRED-NEXT:    lxv vs1, 80(r3)
+; BE-PAIRED-NEXT:    lxv vs0, 64(r3)
 ; BE-PAIRED-NEXT:    stxv vs1, 144(r3)
 ; BE-PAIRED-NEXT:    stxv vs0, 128(r3)
 ; BE-PAIRED-NEXT:    stxv vs3, 176(r3)
@@ -135,12 +135,12 @@ define dso_local void @testXLdSt(i64 %SrcIdx, i64 %DstIdx) {
 ; LE-PAIRED-NEXT:    paddi r5, 0, f@PCREL, 1
 ; LE-PAIRED-NEXT:    sldi r3, r3, 6
 ; LE-PAIRED-NEXT:    add r6, r5, r3
-; LE-PAIRED-NEXT:    lxv vs1, 32(r6)
-; LE-PAIRED-NEXT:    lxv vs0, 48(r6)
 ; LE-PAIRED-NEXT:    lxvx vs3, r5, r3
-; LE-PAIRED-NEXT:    lxv vs2, 16(r6)
 ; LE-PAIRED-NEXT:    sldi r3, r4, 6
 ; LE-PAIRED-NEXT:    add r4, r5, r3
+; LE-PAIRED-NEXT:    lxv vs2, 16(r6)
+; LE-PAIRED-NEXT:    lxv vs1, 32(r6)
+; LE-PAIRED-NEXT:    lxv vs0, 48(r6)
 ; LE-PAIRED-NEXT:    stxvx vs3, r5, r3
 ; LE-PAIRED-NEXT:    stxv vs0, 48(r4)
 ; LE-PAIRED-NEXT:    stxv vs1, 32(r4)
@@ -153,12 +153,12 @@ define dso_local void @testXLdSt(i64 %SrcIdx, i64 %DstIdx) {
 ; BE-PAIRED-NEXT:    addi r5, r5, f@toc@l
 ; BE-PAIRED-NEXT:    sldi r3, r3, 6
 ; BE-PAIRED-NEXT:    add r6, r5, r3
-; BE-PAIRED-NEXT:    lxvx vs0, r5, r3
-; BE-PAIRED-NEXT:    sldi r3, r4, 6
-; BE-PAIRED-NEXT:    add r4, r5, r3
-; BE-PAIRED-NEXT:    lxv vs1, 16(r6)
 ; BE-PAIRED-NEXT:    lxv vs3, 48(r6)
 ; BE-PAIRED-NEXT:    lxv vs2, 32(r6)
+; BE-PAIRED-NEXT:    lxvx vs0, r5, r3
+; BE-PAIRED-NEXT:    lxv vs1, 16(r6)
+; BE-PAIRED-NEXT:    sldi r3, r4, 6
+; BE-PAIRED-NEXT:    add r4, r5, r3
 ; BE-PAIRED-NEXT:    stxvx vs0, r5, r3
 ; BE-PAIRED-NEXT:    stxv vs1, 16(r4)
 ; BE-PAIRED-NEXT:    stxv vs3, 48(r4)
@@ -253,10 +253,10 @@ entry:
 define dso_local void @testUnalignedLdSt() {
 ; LE-PAIRED-LABEL: testUnalignedLdSt:
 ; LE-PAIRED:       # %bb.0: # %entry
-; LE-PAIRED-NEXT:    plxv vs1, f@PCREL+43(0), 1
-; LE-PAIRED-NEXT:    plxv vs0, f@PCREL+59(0), 1
 ; LE-PAIRED-NEXT:    plxv vs3, f@PCREL+11(0), 1
 ; LE-PAIRED-NEXT:    plxv vs2, f@PCREL+27(0), 1
+; LE-PAIRED-NEXT:    plxv vs1, f@PCREL+43(0), 1
+; LE-PAIRED-NEXT:    plxv vs0, f@PCREL+59(0), 1
 ; LE-PAIRED-NEXT:    pstxv vs0, f@PCREL+67(0), 1
 ; LE-PAIRED-NEXT:    pstxv vs1, f@PCREL+51(0), 1
 ; LE-PAIRED-NEXT:    pstxv vs2, f@PCREL+35(0), 1
@@ -267,10 +267,10 @@ define dso_local void @testUnalignedLdSt() {
 ; BE-PAIRED:       # %bb.0: # %entry
 ; BE-PAIRED-NEXT:    addis r3, r2, f@toc@ha
 ; BE-PAIRED-NEXT:    addi r3, r3, f@toc@l
-; BE-PAIRED-NEXT:    plxv vs1, 27(r3), 0
-; BE-PAIRED-NEXT:    plxv vs0, 11(r3), 0
 ; BE-PAIRED-NEXT:    plxv vs3, 59(r3), 0
 ; BE-PAIRED-NEXT:    plxv vs2, 43(r3), 0
+; BE-PAIRED-NEXT:    plxv vs1, 27(r3), 0
+; BE-PAIRED-NEXT:    plxv vs0, 11(r3), 0
 ; BE-PAIRED-NEXT:    pstxv vs1, 35(r3), 0
 ; BE-PAIRED-NEXT:    pstxv vs0, 19(r3), 0
 ; BE-PAIRED-NEXT:    pstxv vs3, 67(r3), 0
@@ -375,19 +375,19 @@ entry:
 define dso_local void @testLdStPair(i64 %SrcIdx, i64 %DstIdx) {
 ; LE-PAIRED-LABEL: testLdStPair:
 ; LE-PAIRED:       # %bb.0: # %entry
-; LE-PAIRED-NEXT:    plxv v3, g@PCREL+32(0), 1
 ; LE-PAIRED-NEXT:    plxv vs0, g@PCREL+48(0), 1
+; LE-PAIRED-NEXT:    plxv vs1, g@PCREL+32(0), 1
 ; LE-PAIRED-NEXT:    pstxv vs0, g@PCREL+80(0), 1
-; LE-PAIRED-NEXT:    pstxv v3, g@PCREL+64(0), 1
+; LE-PAIRED-NEXT:    pstxv vs1, g@PCREL+64(0), 1
 ; LE-PAIRED-NEXT:    blr
 ;
 ; BE-PAIRED-LABEL: testLdStPair:
 ; BE-PAIRED:       # %bb.0: # %entry
 ; BE-PAIRED-NEXT:    addis r3, r2, g@toc@ha
 ; BE-PAIRED-NEXT:    addi r3, r3, g@toc@l
-; BE-PAIRED-NEXT:    lxv v3, 48(r3)
 ; BE-PAIRED-NEXT:    lxv vs0, 32(r3)
-; BE-PAIRED-NEXT:    stxv v3, 80(r3)
+; BE-PAIRED-NEXT:    lxv vs1, 48(r3)
+; BE-PAIRED-NEXT:    stxv vs1, 80(r3)
 ; BE-PAIRED-NEXT:    stxv vs0, 64(r3)
 ; BE-PAIRED-NEXT:    blr
 ;
@@ -452,12 +452,12 @@ define dso_local void @testXLdStPair(i64 %SrcIdx, i64 %DstIdx) {
 ; LE-PAIRED-NEXT:    sldi r3, r3, 5
 ; LE-PAIRED-NEXT:    paddi r5, 0, g@PCREL, 1
 ; LE-PAIRED-NEXT:    add r6, r5, r3
-; LE-PAIRED-NEXT:    lxvx v3, r5, r3
+; LE-PAIRED-NEXT:    lxvx vs0, r5, r3
 ; LE-PAIRED-NEXT:    sldi r3, r4, 5
 ; LE-PAIRED-NEXT:    add r4, r5, r3
-; LE-PAIRED-NEXT:    lxv vs0, 16(r6)
-; LE-PAIRED-NEXT:    stxvx v3, r5, r3
-; LE-PAIRED-NEXT:    stxv vs0, 16(r4)
+; LE-PAIRED-NEXT:    lxv vs1, 16(r6)
+; LE-PAIRED-NEXT:    stxvx vs0, r5, r3
+; LE-PAIRED-NEXT:    stxv vs1, 16(r4)
 ; LE-PAIRED-NEXT:    blr
 ;
 ; BE-PAIRED-LABEL: testXLdStPair:
@@ -469,9 +469,9 @@ define dso_local void @testXLdStPair(i64 %SrcIdx, i64 %DstIdx) {
 ; BE-PAIRED-NEXT:    lxvx vs0, r5, r3
 ; BE-PAIRED-NEXT:    sldi r3, r4, 5
 ; BE-PAIRED-NEXT:    add r4, r5, r3
-; BE-PAIRED-NEXT:    lxv v3, 16(r6)
+; BE-PAIRED-NEXT:    lxv vs1, 16(r6)
 ; BE-PAIRED-NEXT:    stxvx vs0, r5, r3
-; BE-PAIRED-NEXT:    stxv v3, 16(r4)
+; BE-PAIRED-NEXT:    stxv vs1, 16(r4)
 ; BE-PAIRED-NEXT:    blr
 ;
 ; LE-PWR9-LABEL: testXLdStPair:
@@ -542,19 +542,19 @@ entry:
 define dso_local void @testUnalignedLdStPair() {
 ; LE-PAIRED-LABEL: testUnalignedLdStPair:
 ; LE-PAIRED:       # %bb.0: # %entry
-; LE-PAIRED-NEXT:    plxv v3, g@PCREL+11(0), 1
 ; LE-PAIRED-NEXT:    plxv vs0, g@PCREL+27(0), 1
+; LE-PAIRED-NEXT:    plxv vs1, g@PCREL+11(0), 1
 ; LE-PAIRED-NEXT:    pstxv vs0, g@PCREL+35(0), 1
-; LE-PAIRED-NEXT:    pstxv v3, g@PCREL+19(0), 1
+; LE-PAIRED-NEXT:    pstxv vs1, g@PCREL+19(0), 1
 ; LE-PAIRED-NEXT:    blr
 ;
 ; BE-PAIRED-LABEL: testUnalignedLdStPair:
 ; BE-PAIRED:       # %bb.0: # %entry
 ; BE-PAIRED-NEXT:    addis r3, r2, g@toc@ha
 ; BE-PAIRED-NEXT:    addi r3, r3, g@toc@l
-; BE-PAIRED-NEXT:    plxv v3, 27(r3), 0
 ; BE-PAIRED-NEXT:    plxv vs0, 11(r3), 0
-; BE-PAIRED-NEXT:    pstxv v3, 35(r3), 0
+; BE-PAIRED-NEXT:    plxv vs1, 27(r3), 0
+; BE-PAIRED-NEXT:    pstxv vs1, 35(r3), 0
 ; BE-PAIRED-NEXT:    pstxv vs0, 19(r3), 0
 ; BE-PAIRED-NEXT:    blr
 ;

--- a/llvm/test/CodeGen/PowerPC/mma-acc-spill.ll
+++ b/llvm/test/CodeGen/PowerPC/mma-acc-spill.ll
@@ -38,9 +38,9 @@ define void @intrinsics1(<16 x i8> %vc1, <16 x i8> %vc2, <16 x i8> %vc3, <16 x i
 ; CHECK-NEXT:    stxv v31, 144(r1) # 16-byte Folded Spill
 ; CHECK-NEXT:    vmr v31, v5
 ; CHECK-NEXT:    vmr v30, v4
-; CHECK-NEXT:    xxlor vs1, v29, v29
 ; CHECK-NEXT:    xxlor vs2, v30, v30
 ; CHECK-NEXT:    xxlor vs3, v31, v31
+; CHECK-NEXT:    xxlor vs1, v29, v29
 ; CHECK-NEXT:    std r30, 160(r1) # 8-byte Folded Spill
 ; CHECK-NEXT:    ld r30, 272(r1)
 ; CHECK-NEXT:    xxmtacc acc0
@@ -89,9 +89,9 @@ define void @intrinsics1(<16 x i8> %vc1, <16 x i8> %vc2, <16 x i8> %vc3, <16 x i
 ; CHECK-BE-NEXT:    stxv v31, 224(r1) # 16-byte Folded Spill
 ; CHECK-BE-NEXT:    vmr v31, v5
 ; CHECK-BE-NEXT:    vmr v30, v4
-; CHECK-BE-NEXT:    xxlor vs1, v29, v29
 ; CHECK-BE-NEXT:    xxlor vs2, v30, v30
 ; CHECK-BE-NEXT:    xxlor vs3, v31, v31
+; CHECK-BE-NEXT:    xxlor vs1, v29, v29
 ; CHECK-BE-NEXT:    std r30, 240(r1) # 8-byte Folded Spill
 ; CHECK-BE-NEXT:    ld r30, 368(r1)
 ; CHECK-BE-NEXT:    xxmtacc acc0

--- a/llvm/test/CodeGen/PowerPC/mma-integer-based-outer-product.ll
+++ b/llvm/test/CodeGen/PowerPC/mma-integer-based-outer-product.ll
@@ -70,10 +70,10 @@ declare <512 x i1> @llvm.ppc.mma.pmxvi16ger2(<16 x i8>, <16 x i8>, i32, i32, i32
 define dso_local void @test3(ptr nocapture readonly %vqp, ptr nocapture readnone %vpp, <16 x i8> %vc, ptr nocapture %resp) {
 ; CHECK-LABEL: test3:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvi8ger4spp acc0, v2, v2
 ; CHECK-NEXT:    xxmfacc acc0
@@ -85,10 +85,10 @@ define dso_local void @test3(ptr nocapture readonly %vqp, ptr nocapture readnone
 ;
 ; CHECK-BE-LABEL: test3:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvi8ger4spp acc0, v2, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -111,10 +111,10 @@ declare <512 x i1> @llvm.ppc.mma.xvi8ger4spp(<512 x i1>, <16 x i8>, <16 x i8>)
 define dso_local void @test4(ptr nocapture readonly %vqp, ptr nocapture readnone %vpp, <16 x i8> %vc, ptr nocapture %resp) {
 ; CHECK-LABEL: test4:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvi16ger2pp acc0, v2, v2
 ; CHECK-NEXT:    xxmfacc acc0
@@ -126,10 +126,10 @@ define dso_local void @test4(ptr nocapture readonly %vqp, ptr nocapture readnone
 ;
 ; CHECK-BE-LABEL: test4:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvi16ger2pp acc0, v2, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -152,10 +152,10 @@ declare <512 x i1> @llvm.ppc.mma.xvi16ger2pp(<512 x i1>, <16 x i8>, <16 x i8>)
 define dso_local void @test5(ptr nocapture readonly %vqp, ptr nocapture readnone %vpp, <16 x i8> %vc, ptr nocapture %resp) {
 ; CHECK-LABEL: test5:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvi8ger4spp acc0, v2, v2, 0, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
@@ -167,10 +167,10 @@ define dso_local void @test5(ptr nocapture readonly %vqp, ptr nocapture readnone
 ;
 ; CHECK-BE-LABEL: test5:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvi8ger4spp acc0, v2, v2, 0, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -193,10 +193,10 @@ declare <512 x i1> @llvm.ppc.mma.pmxvi8ger4spp(<512 x i1>, <16 x i8>, <16 x i8>,
 define dso_local void @test6(ptr nocapture readonly %vqp, ptr nocapture readnone %vpp, <16 x i8> %vc, ptr nocapture %resp) {
 ; CHECK-LABEL: test6:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvi16ger2pp acc0, v2, v2, 0, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
@@ -208,10 +208,10 @@ define dso_local void @test6(ptr nocapture readonly %vqp, ptr nocapture readnone
 ;
 ; CHECK-BE-LABEL: test6:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvi16ger2pp acc0, v2, v2, 0, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0

--- a/llvm/test/CodeGen/PowerPC/mma-intrinsics.ll
+++ b/llvm/test/CodeGen/PowerPC/mma-intrinsics.ll
@@ -184,10 +184,10 @@ define void @testBranch(ptr %ptr, <16 x i8> %vc, i32 %val) {
 ; CHECK-NEXT:    xxsetaccz acc0
 ; CHECK-NEXT:    b .LBB5_3
 ; CHECK-NEXT:  .LBB5_2: # %if.else
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvi4ger8pp acc0, v2, v2
 ; CHECK-NEXT:  .LBB5_3: # %if.end
@@ -206,10 +206,10 @@ define void @testBranch(ptr %ptr, <16 x i8> %vc, i32 %val) {
 ; CHECK-BE-NEXT:    xxsetaccz acc0
 ; CHECK-BE-NEXT:    b .LBB5_3
 ; CHECK-BE-NEXT:  .LBB5_2: # %if.else
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvi4ger8pp acc0, v2, v2
 ; CHECK-BE-NEXT:  .LBB5_3: # %if.end
@@ -617,10 +617,10 @@ declare void @llvm.ppc.vsx.stxvp(<256 x i1>, ptr)
 define void @test_ldst_1(ptr nocapture readonly %vqp, ptr %vpp, <16 x i8> %vc, ptr nocapture %resp)  {
 ; CHECK-LABEL: test_ldst_1:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    plxvp vsp36, 8(r4), 0
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvf64gernn acc0, vsp36, v2, 0, 0
@@ -633,10 +633,10 @@ define void @test_ldst_1(ptr nocapture readonly %vqp, ptr %vpp, <16 x i8> %vc, p
 ;
 ; CHECK-BE-LABEL: test_ldst_1:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    plxvp vsp36, 8(r4), 0
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvf64gernn acc0, vsp36, v2, 0, 0
@@ -659,10 +659,10 @@ entry:
 define void @test_ldst_2(ptr nocapture readonly %vqp, ptr %vpp, <16 x i8> %vc, ptr nocapture %resp)  {
 ; CHECK-LABEL: test_ldst_2:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    lxvp vsp36, 0(r4)
 ; CHECK-NEXT:    xvf64gernp acc0, vsp36, v2
@@ -675,10 +675,10 @@ define void @test_ldst_2(ptr nocapture readonly %vqp, ptr %vpp, <16 x i8> %vc, p
 ;
 ; CHECK-BE-LABEL: test_ldst_2:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    lxvp vsp36, 0(r4)
 ; CHECK-BE-NEXT:    xvf64gernp acc0, vsp36, v2
@@ -700,10 +700,10 @@ entry:
 define void @test_ldst_3(ptr nocapture readonly %vqp, i64 %offs, ptr %vpp, <16 x i8> %vc, ptr nocapture %resp)  {
 ; CHECK-LABEL: test_ldst_3:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    lxvp vsp36, 0(r5)
 ; CHECK-NEXT:    xvf64gernp acc0, vsp36, v2
@@ -716,10 +716,10 @@ define void @test_ldst_3(ptr nocapture readonly %vqp, i64 %offs, ptr %vpp, <16 x
 ;
 ; CHECK-BE-LABEL: test_ldst_3:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    lxvp vsp36, 0(r5)
 ; CHECK-BE-NEXT:    xvf64gernp acc0, vsp36, v2

--- a/llvm/test/CodeGen/PowerPC/mma-outer-product.ll
+++ b/llvm/test/CodeGen/PowerPC/mma-outer-product.ll
@@ -16,9 +16,9 @@ define void @intrinsics1(<16 x i8> %vc1, <16 x i8> %vc2, <16 x i8> %vc3, <16 x i
 ; CHECK-NEXT:    vmr v0, v2
 ; CHECK-NEXT:    xxlor vs3, v5, v5
 ; CHECK-NEXT:    ld r3, 96(r1)
+; CHECK-NEXT:    xxlor vs2, v4, v4
 ; CHECK-NEXT:    xxlor vs0, v0, v0
 ; CHECK-NEXT:    xxlor vs1, v1, v1
-; CHECK-NEXT:    xxlor vs2, v4, v4
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvi4ger8pp acc0, v2, v3
 ; CHECK-NEXT:    xvf16ger2pp acc0, v2, v1
@@ -40,9 +40,9 @@ define void @intrinsics1(<16 x i8> %vc1, <16 x i8> %vc2, <16 x i8> %vc3, <16 x i
 ; CHECK-BE-NEXT:    vmr v0, v2
 ; CHECK-BE-NEXT:    xxlor vs3, v5, v5
 ; CHECK-BE-NEXT:    ld r3, 112(r1)
+; CHECK-BE-NEXT:    xxlor vs2, v4, v4
 ; CHECK-BE-NEXT:    xxlor vs0, v0, v0
 ; CHECK-BE-NEXT:    xxlor vs1, v1, v1
-; CHECK-BE-NEXT:    xxlor vs2, v4, v4
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvi4ger8pp acc0, v2, v3
 ; CHECK-BE-NEXT:    xvf16ger2pp acc0, v2, v1
@@ -75,9 +75,9 @@ define void @intrinsics2(ptr %ptr1, ptr %ptr2, ptr %ptr3, ptr %ptr4, ptr %ptr) {
 ; CHECK-NEXT:    xxlor vs0, v2, v2
 ; CHECK-NEXT:    lxv v4, 0(r5)
 ; CHECK-NEXT:    lxv v5, 0(r6)
-; CHECK-NEXT:    xxlor vs1, v3, v3
 ; CHECK-NEXT:    xxlor vs2, v4, v4
 ; CHECK-NEXT:    xxlor vs3, v5, v5
+; CHECK-NEXT:    xxlor vs1, v3, v3
 ; CHECK-NEXT:    vmr v1, v2
 ; CHECK-NEXT:    vmr v0, v5
 ; CHECK-NEXT:    xxmtacc acc0
@@ -99,9 +99,9 @@ define void @intrinsics2(ptr %ptr1, ptr %ptr2, ptr %ptr3, ptr %ptr4, ptr %ptr) {
 ; CHECK-BE-NEXT:    xxlor vs0, v2, v2
 ; CHECK-BE-NEXT:    lxv v4, 0(r5)
 ; CHECK-BE-NEXT:    lxv v5, 0(r6)
-; CHECK-BE-NEXT:    xxlor vs1, v3, v3
 ; CHECK-BE-NEXT:    xxlor vs2, v4, v4
 ; CHECK-BE-NEXT:    xxlor vs3, v5, v5
+; CHECK-BE-NEXT:    xxlor vs1, v3, v3
 ; CHECK-BE-NEXT:    vmr v1, v2
 ; CHECK-BE-NEXT:    vmr v0, v5
 ; CHECK-BE-NEXT:    xxmtacc acc0
@@ -169,10 +169,10 @@ declare <512 x i1> @llvm.ppc.mma.xvi4ger8(<16 x i8>, <16 x i8>)
 define void @test2(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test2:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvi4ger8pp acc0, v2, v2
 ; CHECK-NEXT:    xxmfacc acc0
@@ -184,10 +184,10 @@ define void @test2(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test2:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvi4ger8pp acc0, v2, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -238,10 +238,10 @@ declare <512 x i1> @llvm.ppc.mma.pmxvi4ger8(<16 x i8>, <16 x i8>, i32, i32, i32)
 define void @test4(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test4:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvi4ger8pp acc0, v2, v2, 0, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
@@ -253,10 +253,10 @@ define void @test4(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test4:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvi4ger8pp acc0, v2, v2, 0, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -307,10 +307,10 @@ declare <512 x i1> @llvm.ppc.mma.xvi8ger4(<16 x i8>, <16 x i8>)
 define void @test6(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test6:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvi8ger4pp acc0, v2, v2
 ; CHECK-NEXT:    xxmfacc acc0
@@ -322,10 +322,10 @@ define void @test6(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test6:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvi8ger4pp acc0, v2, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -376,10 +376,10 @@ declare <512 x i1> @llvm.ppc.mma.pmxvi8ger4(<16 x i8>, <16 x i8>, i32, i32, i32)
 define void @test8(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test8:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvi8ger4pp acc0, v2, v2, 0, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
@@ -391,10 +391,10 @@ define void @test8(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test8:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvi8ger4pp acc0, v2, v2, 0, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -445,10 +445,10 @@ declare <512 x i1> @llvm.ppc.mma.xvi16ger2s(<16 x i8>, <16 x i8>)
 define void @test10(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test10:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvi16ger2spp acc0, v2, v2
 ; CHECK-NEXT:    xxmfacc acc0
@@ -460,10 +460,10 @@ define void @test10(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test10:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvi16ger2spp acc0, v2, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -514,10 +514,10 @@ declare <512 x i1> @llvm.ppc.mma.pmxvi16ger2s(<16 x i8>, <16 x i8>, i32, i32, i3
 define void @test12(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test12:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvi16ger2spp acc0, v2, v2, 0, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
@@ -529,10 +529,10 @@ define void @test12(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test12:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvi16ger2spp acc0, v2, v2, 0, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -583,10 +583,10 @@ declare <512 x i1> @llvm.ppc.mma.xvf16ger2(<16 x i8>, <16 x i8>)
 define void @test14(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test14:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvf16ger2pp acc0, v2, v2
 ; CHECK-NEXT:    xxmfacc acc0
@@ -598,10 +598,10 @@ define void @test14(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test14:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvf16ger2pp acc0, v2, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -623,10 +623,10 @@ declare <512 x i1> @llvm.ppc.mma.xvf16ger2pp(<512 x i1>, <16 x i8>, <16 x i8>)
 define void @test15(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test15:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvf16ger2pn acc0, v2, v2
 ; CHECK-NEXT:    xxmfacc acc0
@@ -638,10 +638,10 @@ define void @test15(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test15:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvf16ger2pn acc0, v2, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -663,10 +663,10 @@ declare <512 x i1> @llvm.ppc.mma.xvf16ger2pn(<512 x i1>, <16 x i8>, <16 x i8>)
 define void @test16(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test16:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvf16ger2np acc0, v2, v2
 ; CHECK-NEXT:    xxmfacc acc0
@@ -678,10 +678,10 @@ define void @test16(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test16:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvf16ger2np acc0, v2, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -703,10 +703,10 @@ declare <512 x i1> @llvm.ppc.mma.xvf16ger2np(<512 x i1>, <16 x i8>, <16 x i8>)
 define void @test17(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test17:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvf16ger2nn acc0, v2, v2
 ; CHECK-NEXT:    xxmfacc acc0
@@ -718,10 +718,10 @@ define void @test17(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test17:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvf16ger2nn acc0, v2, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -772,10 +772,10 @@ declare <512 x i1> @llvm.ppc.mma.pmxvf16ger2(<16 x i8>, <16 x i8>, i32, i32, i32
 define void @test19(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test19:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvf16ger2pp acc0, v2, v2, 0, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
@@ -787,10 +787,10 @@ define void @test19(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test19:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvf16ger2pp acc0, v2, v2, 0, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -812,10 +812,10 @@ declare <512 x i1> @llvm.ppc.mma.pmxvf16ger2pp(<512 x i1>, <16 x i8>, <16 x i8>,
 define void @test20(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test20:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvf16ger2pn acc0, v2, v2, 0, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
@@ -827,10 +827,10 @@ define void @test20(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test20:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvf16ger2pn acc0, v2, v2, 0, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -852,10 +852,10 @@ declare <512 x i1> @llvm.ppc.mma.pmxvf16ger2pn(<512 x i1>, <16 x i8>, <16 x i8>,
 define void @test21(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test21:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvf16ger2np acc0, v2, v2, 0, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
@@ -867,10 +867,10 @@ define void @test21(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test21:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvf16ger2np acc0, v2, v2, 0, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -892,10 +892,10 @@ declare <512 x i1> @llvm.ppc.mma.pmxvf16ger2np(<512 x i1>, <16 x i8>, <16 x i8>,
 define void @test22(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test22:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvf16ger2nn acc0, v2, v2, 0, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
@@ -907,10 +907,10 @@ define void @test22(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test22:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvf16ger2nn acc0, v2, v2, 0, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -961,10 +961,10 @@ declare <512 x i1> @llvm.ppc.mma.xvf32ger(<16 x i8>, <16 x i8>)
 define void @test24(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test24:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvf32gerpp acc0, v2, v2
 ; CHECK-NEXT:    xxmfacc acc0
@@ -976,10 +976,10 @@ define void @test24(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test24:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvf32gerpp acc0, v2, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -1001,10 +1001,10 @@ declare <512 x i1> @llvm.ppc.mma.xvf32gerpp(<512 x i1>, <16 x i8>, <16 x i8>)
 define void @test25(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test25:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvf32gerpn acc0, v2, v2
 ; CHECK-NEXT:    xxmfacc acc0
@@ -1016,10 +1016,10 @@ define void @test25(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test25:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvf32gerpn acc0, v2, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -1041,10 +1041,10 @@ declare <512 x i1> @llvm.ppc.mma.xvf32gerpn(<512 x i1>, <16 x i8>, <16 x i8>)
 define void @test26(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test26:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvf32gernp acc0, v2, v2
 ; CHECK-NEXT:    xxmfacc acc0
@@ -1056,10 +1056,10 @@ define void @test26(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test26:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvf32gernp acc0, v2, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -1081,10 +1081,10 @@ declare <512 x i1> @llvm.ppc.mma.xvf32gernp(<512 x i1>, <16 x i8>, <16 x i8>)
 define void @test27(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test27:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    xvf32gernn acc0, v2, v2
 ; CHECK-NEXT:    xxmfacc acc0
@@ -1096,10 +1096,10 @@ define void @test27(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test27:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    xvf32gernn acc0, v2, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -1150,10 +1150,10 @@ declare <512 x i1> @llvm.ppc.mma.pmxvf32ger(<16 x i8>, <16 x i8>, i32, i32)
 define void @test29(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test29:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvf32gerpp acc0, v2, v2, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
@@ -1165,10 +1165,10 @@ define void @test29(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test29:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvf32gerpp acc0, v2, v2, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -1190,10 +1190,10 @@ declare <512 x i1> @llvm.ppc.mma.pmxvf32gerpp(<512 x i1>, <16 x i8>, <16 x i8>, 
 define void @test30(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test30:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvf32gerpn acc0, v2, v2, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
@@ -1205,10 +1205,10 @@ define void @test30(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test30:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvf32gerpn acc0, v2, v2, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -1230,10 +1230,10 @@ declare <512 x i1> @llvm.ppc.mma.pmxvf32gerpn(<512 x i1>, <16 x i8>, <16 x i8>, 
 define void @test31(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test31:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvf32gernp acc0, v2, v2, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
@@ -1245,10 +1245,10 @@ define void @test31(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test31:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvf32gernp acc0, v2, v2, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -1270,10 +1270,10 @@ declare <512 x i1> @llvm.ppc.mma.pmxvf32gernp(<512 x i1>, <16 x i8>, <16 x i8>, 
 define void @test32(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test32:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    xxmtacc acc0
 ; CHECK-NEXT:    pmxvf32gernn acc0, v2, v2, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
@@ -1285,10 +1285,10 @@ define void @test32(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test32:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    xxmtacc acc0
 ; CHECK-BE-NEXT:    pmxvf32gernn acc0, v2, v2, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
@@ -1310,8 +1310,8 @@ declare <512 x i1> @llvm.ppc.mma.pmxvf32gernn(<512 x i1>, <16 x i8>, <16 x i8>, 
 define void @test33(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test33:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv v5, 0(r4)
 ; CHECK-NEXT:    lxv v4, 16(r4)
+; CHECK-NEXT:    lxv v5, 0(r4)
 ; CHECK-NEXT:    xvf64ger acc0, vsp36, v2
 ; CHECK-NEXT:    xxmfacc acc0
 ; CHECK-NEXT:    stxv vs0, 48(r7)
@@ -1322,8 +1322,8 @@ define void @test33(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test33:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv v5, 16(r4)
 ; CHECK-BE-NEXT:    lxv v4, 0(r4)
+; CHECK-BE-NEXT:    lxv v5, 16(r4)
 ; CHECK-BE-NEXT:    xvf64ger acc0, vsp36, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
 ; CHECK-BE-NEXT:    stxv vs1, 16(r7)
@@ -1344,13 +1344,13 @@ declare <512 x i1> @llvm.ppc.mma.xvf64ger(<256 x i1>, <16 x i8>)
 define void @test34(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test34:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
-; CHECK-NEXT:    lxv v5, 0(r4)
-; CHECK-NEXT:    xxmtacc acc0
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv v4, 16(r4)
+; CHECK-NEXT:    xxmtacc acc0
+; CHECK-NEXT:    lxv v5, 0(r4)
 ; CHECK-NEXT:    xvf64gerpp acc0, vsp36, v2
 ; CHECK-NEXT:    xxmfacc acc0
 ; CHECK-NEXT:    stxv vs0, 48(r7)
@@ -1361,13 +1361,13 @@ define void @test34(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test34:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
-; CHECK-BE-NEXT:    lxv v5, 16(r4)
-; CHECK-BE-NEXT:    xxmtacc acc0
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv v4, 0(r4)
+; CHECK-BE-NEXT:    xxmtacc acc0
+; CHECK-BE-NEXT:    lxv v5, 16(r4)
 ; CHECK-BE-NEXT:    xvf64gerpp acc0, vsp36, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
 ; CHECK-BE-NEXT:    stxv vs1, 16(r7)
@@ -1389,13 +1389,13 @@ declare <512 x i1> @llvm.ppc.mma.xvf64gerpp(<512 x i1>, <256 x i1>, <16 x i8>)
 define void @test35(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test35:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
-; CHECK-NEXT:    lxv v5, 0(r4)
-; CHECK-NEXT:    xxmtacc acc0
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv v4, 16(r4)
+; CHECK-NEXT:    xxmtacc acc0
+; CHECK-NEXT:    lxv v5, 0(r4)
 ; CHECK-NEXT:    xvf64gerpn acc0, vsp36, v2
 ; CHECK-NEXT:    xxmfacc acc0
 ; CHECK-NEXT:    stxv vs0, 48(r7)
@@ -1406,13 +1406,13 @@ define void @test35(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test35:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
-; CHECK-BE-NEXT:    lxv v5, 16(r4)
-; CHECK-BE-NEXT:    xxmtacc acc0
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv v4, 0(r4)
+; CHECK-BE-NEXT:    xxmtacc acc0
+; CHECK-BE-NEXT:    lxv v5, 16(r4)
 ; CHECK-BE-NEXT:    xvf64gerpn acc0, vsp36, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
 ; CHECK-BE-NEXT:    stxv vs1, 16(r7)
@@ -1434,13 +1434,13 @@ declare <512 x i1> @llvm.ppc.mma.xvf64gerpn(<512 x i1>, <256 x i1>, <16 x i8>)
 define void @test36(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test36:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
-; CHECK-NEXT:    lxv v5, 0(r4)
-; CHECK-NEXT:    xxmtacc acc0
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv v4, 16(r4)
+; CHECK-NEXT:    xxmtacc acc0
+; CHECK-NEXT:    lxv v5, 0(r4)
 ; CHECK-NEXT:    xvf64gernp acc0, vsp36, v2
 ; CHECK-NEXT:    xxmfacc acc0
 ; CHECK-NEXT:    stxv vs0, 48(r7)
@@ -1451,13 +1451,13 @@ define void @test36(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test36:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
-; CHECK-BE-NEXT:    lxv v5, 16(r4)
-; CHECK-BE-NEXT:    xxmtacc acc0
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv v4, 0(r4)
+; CHECK-BE-NEXT:    xxmtacc acc0
+; CHECK-BE-NEXT:    lxv v5, 16(r4)
 ; CHECK-BE-NEXT:    xvf64gernp acc0, vsp36, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
 ; CHECK-BE-NEXT:    stxv vs1, 16(r7)
@@ -1479,13 +1479,13 @@ declare <512 x i1> @llvm.ppc.mma.xvf64gernp(<512 x i1>, <256 x i1>, <16 x i8>)
 define void @test37(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test37:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
-; CHECK-NEXT:    lxv v5, 0(r4)
-; CHECK-NEXT:    xxmtacc acc0
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv v4, 16(r4)
+; CHECK-NEXT:    xxmtacc acc0
+; CHECK-NEXT:    lxv v5, 0(r4)
 ; CHECK-NEXT:    xvf64gernn acc0, vsp36, v2
 ; CHECK-NEXT:    xxmfacc acc0
 ; CHECK-NEXT:    stxv vs0, 48(r7)
@@ -1496,13 +1496,13 @@ define void @test37(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test37:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
-; CHECK-BE-NEXT:    lxv v5, 16(r4)
-; CHECK-BE-NEXT:    xxmtacc acc0
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv v4, 0(r4)
+; CHECK-BE-NEXT:    xxmtacc acc0
+; CHECK-BE-NEXT:    lxv v5, 16(r4)
 ; CHECK-BE-NEXT:    xvf64gernn acc0, vsp36, v2
 ; CHECK-BE-NEXT:    xxmfacc acc0
 ; CHECK-BE-NEXT:    stxv vs1, 16(r7)
@@ -1524,8 +1524,8 @@ declare <512 x i1> @llvm.ppc.mma.xvf64gernn(<512 x i1>, <256 x i1>, <16 x i8>)
 define void @test38(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test38:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv v5, 0(r4)
 ; CHECK-NEXT:    lxv v4, 16(r4)
+; CHECK-NEXT:    lxv v5, 0(r4)
 ; CHECK-NEXT:    pmxvf64ger acc0, vsp36, v2, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
 ; CHECK-NEXT:    stxv vs0, 48(r7)
@@ -1536,8 +1536,8 @@ define void @test38(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test38:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv v5, 16(r4)
 ; CHECK-BE-NEXT:    lxv v4, 0(r4)
+; CHECK-BE-NEXT:    lxv v5, 16(r4)
 ; CHECK-BE-NEXT:    pmxvf64ger acc0, vsp36, v2, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
 ; CHECK-BE-NEXT:    stxv vs1, 16(r7)
@@ -1558,13 +1558,13 @@ declare <512 x i1> @llvm.ppc.mma.pmxvf64ger(<256 x i1>, <16 x i8>, i32, i32)
 define void @test39(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test39:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
-; CHECK-NEXT:    lxv v5, 0(r4)
-; CHECK-NEXT:    xxmtacc acc0
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv v4, 16(r4)
+; CHECK-NEXT:    xxmtacc acc0
+; CHECK-NEXT:    lxv v5, 0(r4)
 ; CHECK-NEXT:    pmxvf64gerpp acc0, vsp36, v2, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
 ; CHECK-NEXT:    stxv vs0, 48(r7)
@@ -1575,13 +1575,13 @@ define void @test39(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test39:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
-; CHECK-BE-NEXT:    lxv v5, 16(r4)
-; CHECK-BE-NEXT:    xxmtacc acc0
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv v4, 0(r4)
+; CHECK-BE-NEXT:    xxmtacc acc0
+; CHECK-BE-NEXT:    lxv v5, 16(r4)
 ; CHECK-BE-NEXT:    pmxvf64gerpp acc0, vsp36, v2, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
 ; CHECK-BE-NEXT:    stxv vs1, 16(r7)
@@ -1603,13 +1603,13 @@ declare <512 x i1> @llvm.ppc.mma.pmxvf64gerpp(<512 x i1>, <256 x i1>, <16 x i8>,
 define void @test40(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test40:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
-; CHECK-NEXT:    lxv v5, 0(r4)
-; CHECK-NEXT:    xxmtacc acc0
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv v4, 16(r4)
+; CHECK-NEXT:    xxmtacc acc0
+; CHECK-NEXT:    lxv v5, 0(r4)
 ; CHECK-NEXT:    pmxvf64gerpn acc0, vsp36, v2, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
 ; CHECK-NEXT:    stxv vs0, 48(r7)
@@ -1620,13 +1620,13 @@ define void @test40(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test40:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
-; CHECK-BE-NEXT:    lxv v5, 16(r4)
-; CHECK-BE-NEXT:    xxmtacc acc0
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv v4, 0(r4)
+; CHECK-BE-NEXT:    xxmtacc acc0
+; CHECK-BE-NEXT:    lxv v5, 16(r4)
 ; CHECK-BE-NEXT:    pmxvf64gerpn acc0, vsp36, v2, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
 ; CHECK-BE-NEXT:    stxv vs1, 16(r7)
@@ -1648,13 +1648,13 @@ declare <512 x i1> @llvm.ppc.mma.pmxvf64gerpn(<512 x i1>, <256 x i1>, <16 x i8>,
 define void @test41(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test41:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
-; CHECK-NEXT:    lxv v5, 0(r4)
-; CHECK-NEXT:    xxmtacc acc0
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv v4, 16(r4)
+; CHECK-NEXT:    xxmtacc acc0
+; CHECK-NEXT:    lxv v5, 0(r4)
 ; CHECK-NEXT:    pmxvf64gernp acc0, vsp36, v2, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
 ; CHECK-NEXT:    stxv vs0, 48(r7)
@@ -1665,13 +1665,13 @@ define void @test41(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test41:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
-; CHECK-BE-NEXT:    lxv v5, 16(r4)
-; CHECK-BE-NEXT:    xxmtacc acc0
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv v4, 0(r4)
+; CHECK-BE-NEXT:    xxmtacc acc0
+; CHECK-BE-NEXT:    lxv v5, 16(r4)
 ; CHECK-BE-NEXT:    pmxvf64gernp acc0, vsp36, v2, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
 ; CHECK-BE-NEXT:    stxv vs1, 16(r7)
@@ -1693,13 +1693,13 @@ declare <512 x i1> @llvm.ppc.mma.pmxvf64gernp(<512 x i1>, <256 x i1>, <16 x i8>,
 define void @test42(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ; CHECK-LABEL: test42:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv vs1, 32(r3)
-; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv vs3, 0(r3)
 ; CHECK-NEXT:    lxv vs2, 16(r3)
-; CHECK-NEXT:    lxv v5, 0(r4)
-; CHECK-NEXT:    xxmtacc acc0
+; CHECK-NEXT:    lxv vs1, 32(r3)
+; CHECK-NEXT:    lxv vs0, 48(r3)
 ; CHECK-NEXT:    lxv v4, 16(r4)
+; CHECK-NEXT:    xxmtacc acc0
+; CHECK-NEXT:    lxv v5, 0(r4)
 ; CHECK-NEXT:    pmxvf64gernn acc0, vsp36, v2, 0, 0
 ; CHECK-NEXT:    xxmfacc acc0
 ; CHECK-NEXT:    stxv vs0, 48(r7)
@@ -1710,13 +1710,13 @@ define void @test42(ptr %vqp, ptr %vpp, <16 x i8> %vc, ptr %resp) {
 ;
 ; CHECK-BE-LABEL: test42:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv vs1, 16(r3)
-; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv vs3, 48(r3)
 ; CHECK-BE-NEXT:    lxv vs2, 32(r3)
-; CHECK-BE-NEXT:    lxv v5, 16(r4)
-; CHECK-BE-NEXT:    xxmtacc acc0
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
+; CHECK-BE-NEXT:    lxv vs0, 0(r3)
 ; CHECK-BE-NEXT:    lxv v4, 0(r4)
+; CHECK-BE-NEXT:    xxmtacc acc0
+; CHECK-BE-NEXT:    lxv v5, 16(r4)
 ; CHECK-BE-NEXT:    pmxvf64gernn acc0, vsp36, v2, 0, 0
 ; CHECK-BE-NEXT:    xxmfacc acc0
 ; CHECK-BE-NEXT:    stxv vs1, 16(r7)

--- a/llvm/test/CodeGen/PowerPC/mmaplus-intrinsics.ll
+++ b/llvm/test/CodeGen/PowerPC/mmaplus-intrinsics.ll
@@ -613,12 +613,10 @@ define void @cmplx_xxmacc(ptr %ptr1, ptr %ptr2, <16 x i8> %vc1, <16 x i8> %vc2) 
 ; CHECK-NEXT:    lxv v0, 16(r3)
 ; CHECK-NEXT:    lxv v6, 48(r3)
 ; CHECK-NEXT:    vmr v4, v3
+; CHECK-NEXT:    vmr v3, v2
 ; CHECK-NEXT:    vmr v5, v2
-; CHECK-NEXT:    xxlor v2, v4, v4
-; CHECK-NEXT:    vmr v2, v5
-; CHECK-NEXT:    xxlor v3, v5, v5
 ; CHECK-NEXT:    dmxxinstfdmr512 wacc0, vsp38, vsp32, 0
-; CHECK-NEXT:    xvf64gerpp wacc0, vsp34, v5
+; CHECK-NEXT:    xvf64gerpp wacc0, vsp34, v2
 ; CHECK-NEXT:    xvf64gerpp wacc0, vsp36, v4
 ; CHECK-NEXT:    dmxxextfdmr512 wacc0, vsp34, vsp36, 0
 ; CHECK-NEXT:    stxv v4, 48(r3)
@@ -634,12 +632,10 @@ define void @cmplx_xxmacc(ptr %ptr1, ptr %ptr2, <16 x i8> %vc1, <16 x i8> %vc2) 
 ; CHECK-BE-NEXT:    lxv v0, 32(r3)
 ; CHECK-BE-NEXT:    lxv v6, 0(r3)
 ; CHECK-BE-NEXT:    vmr v4, v3
+; CHECK-BE-NEXT:    vmr v3, v2
 ; CHECK-BE-NEXT:    vmr v5, v2
-; CHECK-BE-NEXT:    xxlor v2, v4, v4
-; CHECK-BE-NEXT:    vmr v2, v5
-; CHECK-BE-NEXT:    xxlor v3, v5, v5
 ; CHECK-BE-NEXT:    dmxxinstfdmr512 wacc0, vsp38, vsp32, 0
-; CHECK-BE-NEXT:    xvf64gerpp wacc0, vsp34, v5
+; CHECK-BE-NEXT:    xvf64gerpp wacc0, vsp34, v2
 ; CHECK-BE-NEXT:    xvf64gerpp wacc0, vsp36, v4
 ; CHECK-BE-NEXT:    dmxxextfdmr512 wacc0, vsp34, vsp36, 0
 ; CHECK-BE-NEXT:    stxv v5, 48(r3)
@@ -652,11 +648,9 @@ define void @cmplx_xxmacc(ptr %ptr1, ptr %ptr2, <16 x i8> %vc1, <16 x i8> %vc2) 
 ; CHECK-O0:       # %bb.0: # %entry
 ; CHECK-O0-NEXT:    vmr v4, v3
 ; CHECK-O0-NEXT:    vmr v5, v2
-; CHECK-O0-NEXT:    # implicit-def: $vsrp16
-; CHECK-O0-NEXT:    vmr v1, v5
-; CHECK-O0-NEXT:    xxlor v2, v0, v0
-; CHECK-O0-NEXT:    xxlor v3, v1, v1
+; CHECK-O0-NEXT:    vmr v3, v5
 ; CHECK-O0-NEXT:    vmr v2, v4
+; CHECK-O0-NEXT:    vmr v1, v5
 ; CHECK-O0-NEXT:    vmr v0, v5
 ; CHECK-O0-NEXT:    lxv vs0, 0(r3)
 ; CHECK-O0-NEXT:    # implicit-def: $vsrp20
@@ -688,11 +682,9 @@ define void @cmplx_xxmacc(ptr %ptr1, ptr %ptr2, <16 x i8> %vc1, <16 x i8> %vc2) 
 ; CHECK-O0-BE:       # %bb.0: # %entry
 ; CHECK-O0-BE-NEXT:    vmr v4, v3
 ; CHECK-O0-BE-NEXT:    vmr v5, v2
-; CHECK-O0-BE-NEXT:    # implicit-def: $vsrp16
-; CHECK-O0-BE-NEXT:    vmr v1, v5
-; CHECK-O0-BE-NEXT:    xxlor v2, v0, v0
-; CHECK-O0-BE-NEXT:    xxlor v3, v1, v1
+; CHECK-O0-BE-NEXT:    vmr v3, v5
 ; CHECK-O0-BE-NEXT:    vmr v2, v4
+; CHECK-O0-BE-NEXT:    vmr v1, v5
 ; CHECK-O0-BE-NEXT:    vmr v0, v5
 ; CHECK-O0-BE-NEXT:    lxv vs0, 48(r3)
 ; CHECK-O0-BE-NEXT:    # implicit-def: $vsrp20
@@ -727,12 +719,10 @@ define void @cmplx_xxmacc(ptr %ptr1, ptr %ptr2, <16 x i8> %vc1, <16 x i8> %vc2) 
 ; CHECK-AIX64-NEXT:    lxv 0, 32(3)
 ; CHECK-AIX64-NEXT:    lxv 6, 0(3)
 ; CHECK-AIX64-NEXT:    vmr 4, 3
+; CHECK-AIX64-NEXT:    vmr 3, 2
 ; CHECK-AIX64-NEXT:    vmr 5, 2
-; CHECK-AIX64-NEXT:    xxlor 2, 4, 4
-; CHECK-AIX64-NEXT:    vmr 2, 5
-; CHECK-AIX64-NEXT:    xxlor 3, 5, 5
 ; CHECK-AIX64-NEXT:    dmxxinstfdmr512 0, 38, 32, 0
-; CHECK-AIX64-NEXT:    xvf64gerpp 0, 34, 5
+; CHECK-AIX64-NEXT:    xvf64gerpp 0, 34, 2
 ; CHECK-AIX64-NEXT:    xvf64gerpp 0, 36, 4
 ; CHECK-AIX64-NEXT:    dmxxextfdmr512 0, 34, 36, 0
 ; CHECK-AIX64-NEXT:    stxv 5, 48(3)
@@ -748,12 +738,10 @@ define void @cmplx_xxmacc(ptr %ptr1, ptr %ptr2, <16 x i8> %vc1, <16 x i8> %vc2) 
 ; CHECK-AIX32-NEXT:    lxv 0, 32(3)
 ; CHECK-AIX32-NEXT:    lxv 6, 0(3)
 ; CHECK-AIX32-NEXT:    vmr 4, 3
+; CHECK-AIX32-NEXT:    vmr 3, 2
 ; CHECK-AIX32-NEXT:    vmr 5, 2
-; CHECK-AIX32-NEXT:    xxlor 2, 4, 4
-; CHECK-AIX32-NEXT:    vmr 2, 5
-; CHECK-AIX32-NEXT:    xxlor 3, 5, 5
 ; CHECK-AIX32-NEXT:    dmxxinstfdmr512 0, 38, 32, 0
-; CHECK-AIX32-NEXT:    xvf64gerpp 0, 34, 5
+; CHECK-AIX32-NEXT:    xvf64gerpp 0, 34, 2
 ; CHECK-AIX32-NEXT:    xvf64gerpp 0, 36, 4
 ; CHECK-AIX32-NEXT:    dmxxextfdmr512 0, 34, 36, 0
 ; CHECK-AIX32-NEXT:    stxv 5, 48(3)

--- a/llvm/test/CodeGen/PowerPC/paired-vector-intrinsics.ll
+++ b/llvm/test/CodeGen/PowerPC/paired-vector-intrinsics.ll
@@ -52,34 +52,34 @@ declare { <16 x i8>, <16 x i8> } @llvm.ppc.vsx.disassemble.pair(<256 x i1>)
 define void @disass_pair(ptr %ptr1, ptr %ptr2, ptr %ptr3) {
 ; CHECK-LABEL: disass_pair:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    lxv v3, 0(r3)
 ; CHECK-NEXT:    lxv vs0, 16(r3)
-; CHECK-NEXT:    stxv v3, 0(r4)
+; CHECK-NEXT:    lxv vs1, 0(r3)
+; CHECK-NEXT:    stxv vs1, 0(r4)
 ; CHECK-NEXT:    stxv vs0, 0(r5)
 ; CHECK-NEXT:    blr
 ;
 ; CHECK-NOMMA-LABEL: disass_pair:
 ; CHECK-NOMMA:       # %bb.0: # %entry
-; CHECK-NOMMA-NEXT:    lxv v3, 0(r3)
 ; CHECK-NOMMA-NEXT:    lxv vs0, 16(r3)
-; CHECK-NOMMA-NEXT:    stxv v3, 0(r4)
+; CHECK-NOMMA-NEXT:    lxv vs1, 0(r3)
+; CHECK-NOMMA-NEXT:    stxv vs1, 0(r4)
 ; CHECK-NOMMA-NEXT:    stxv vs0, 0(r5)
 ; CHECK-NOMMA-NEXT:    blr
 ;
 ; CHECK-BE-LABEL: disass_pair:
 ; CHECK-BE:       # %bb.0: # %entry
-; CHECK-BE-NEXT:    lxv v3, 16(r3)
 ; CHECK-BE-NEXT:    lxv vs0, 0(r3)
+; CHECK-BE-NEXT:    lxv vs1, 16(r3)
 ; CHECK-BE-NEXT:    stxv vs0, 0(r4)
-; CHECK-BE-NEXT:    stxv v3, 0(r5)
+; CHECK-BE-NEXT:    stxv vs1, 0(r5)
 ; CHECK-BE-NEXT:    blr
 ;
 ; CHECK-BE-NOMMA-LABEL: disass_pair:
 ; CHECK-BE-NOMMA:       # %bb.0: # %entry
-; CHECK-BE-NOMMA-NEXT:    lxv v3, 16(r3)
 ; CHECK-BE-NOMMA-NEXT:    lxv vs0, 0(r3)
+; CHECK-BE-NOMMA-NEXT:    lxv vs1, 16(r3)
 ; CHECK-BE-NOMMA-NEXT:    stxv vs0, 0(r4)
-; CHECK-BE-NOMMA-NEXT:    stxv v3, 0(r5)
+; CHECK-BE-NOMMA-NEXT:    stxv vs1, 0(r5)
 ; CHECK-BE-NOMMA-NEXT:    blr
 entry:
   %0 = load <256 x i1>, ptr %ptr1, align 32

--- a/llvm/test/CodeGen/PowerPC/ppc64-acc-regalloc-bugfix.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc64-acc-regalloc-bugfix.ll
@@ -6,8 +6,8 @@
 define void @copy_novsrp() local_unnamed_addr {
 ; CHECK-LABEL: copy_novsrp:
 ; CHECK:       # %bb.0: # %dmblvi_entry
-; CHECK-NEXT:    xxlxor vs3, vs3, vs3
 ; CHECK-NEXT:    xxlxor vs0, vs0, vs0
+; CHECK-NEXT:    xxlxor vs3, vs3, vs3
 ; CHECK-NEXT:    stxv vs0, 0(0)
 dmblvi_entry:
   %0 = tail call <512 x i1> @llvm.ppc.mma.assemble.acc(<16 x i8> zeroinitializer, <16 x i8> undef, <16 x i8> undef, <16 x i8> zeroinitializer)

--- a/llvm/test/CodeGen/PowerPC/ppc64-acc-regalloc.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc64-acc-regalloc.ll
@@ -13,52 +13,53 @@ define void @acc_regalloc(ptr %arg, ptr %arg1, ptr %arg2) local_unnamed_addr {
 ; CHECK-LABEL: acc_regalloc:
 ; CHECK:       # %bb.0: # %bb
 ; CHECK-NEXT:    lwz r3, 0(r3)
-; CHECK-NEXT:    lxv v4, 0(0)
-; CHECK-NEXT:    xxlxor v0, v0, v0
-; CHECK-NEXT:    xxlxor v1, v1, v1
+; CHECK-NEXT:    lxv v0, 0(0)
+; CHECK-NEXT:    xxlxor v6, v6, v6
+; CHECK-NEXT:    xxlxor v4, v4, v4
 ; CHECK-NEXT:    xxlxor v2, v2, v2
 ; CHECK-NEXT:    li r6, 1
 ; CHECK-NEXT:    li r4, 16
 ; CHECK-NEXT:    stfd f14, -144(r1) # 8-byte Folded Spill
 ; CHECK-NEXT:    stfd f15, -136(r1) # 8-byte Folded Spill
 ; CHECK-NEXT:    extswsli r3, r3, 3
-; CHECK-NEXT:    xvmaddadp v1, v4, v1
-; CHECK-NEXT:    lxvdsx v5, 0, r3
-; CHECK-NEXT:    xvmaddadp v0, v5, v0
+; CHECK-NEXT:    xvmaddadp v4, v0, v4
+; CHECK-NEXT:    lxvdsx v1, 0, r3
+; CHECK-NEXT:    xvmaddadp v6, v1, v6
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  .LBB0_1: # %bb9
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    addi r6, r6, 2
-; CHECK-NEXT:    lxv vs0, 16(0)
 ; CHECK-NEXT:    lxv vs1, -64(r5)
+; CHECK-NEXT:    lxv vs0, 16(0)
 ; CHECK-NEXT:    xxlxor vs7, vs7, vs7
-; CHECK-NEXT:    xxlor vs3, v0, v0
+; CHECK-NEXT:    xxlor vs3, v6, v6
 ; CHECK-NEXT:    xxlxor vs2, vs2, vs2
 ; CHECK-NEXT:    xxlxor vs12, vs12, vs12
+; CHECK-NEXT:    lxv vs4, -16(r5)
+; CHECK-NEXT:    xxlor vs10, v4, v4
+; CHECK-NEXT:    xxlor vs8, v4, v4
+; CHECK-NEXT:    xxlor vs8, v2, v2
 ; CHECK-NEXT:    mulld r6, r6, r3
-; CHECK-NEXT:    xxlor vs10, v2, v2
-; CHECK-NEXT:    xxlor vs4, v2, v2
-; CHECK-NEXT:    xxlor vs8, vs10, vs10
-; CHECK-NEXT:    xxlor vs10, v1, v1
-; CHECK-NEXT:    xvmaddadp vs7, vs0, v5
+; CHECK-NEXT:    xvmaddadp vs7, vs0, v1
 ; CHECK-NEXT:    xvmuldp vs6, vs0, v2
-; CHECK-NEXT:    lxv vs0, -16(r5)
 ; CHECK-NEXT:    xvmaddadp vs3, vs1, v2
 ; CHECK-NEXT:    xvmaddadp vs2, vs1, vs2
-; CHECK-NEXT:    lxvdsx v6, r6, r4
+; CHECK-NEXT:    xvmaddadp vs12, vs4, vs12
+; CHECK-NEXT:    xxlor vs0, v2, v2
+; CHECK-NEXT:    lxvdsx v7, r6, r4
 ; CHECK-NEXT:    li r6, 0
 ; CHECK-NEXT:    xvmaddadp vs7, v2, v2
 ; CHECK-NEXT:    xvmaddadp vs6, v2, v2
-; CHECK-NEXT:    xvmaddadp vs12, vs0, vs12
-; CHECK-NEXT:    xvmuldp v3, vs1, v6
-; CHECK-NEXT:    xvmuldp vs11, v4, v6
-; CHECK-NEXT:    xvmuldp vs13, vs0, v6
-; CHECK-NEXT:    xvmuldp vs5, v6, v2
-; CHECK-NEXT:    xxlor vs0, v2, v2
 ; CHECK-NEXT:    xxlor vs14, vs12, vs12
 ; CHECK-NEXT:    xxlor vs12, v2, v2
+; CHECK-NEXT:    xvmuldp v3, vs1, v7
+; CHECK-NEXT:    xvmuldp v5, v0, v7
+; CHECK-NEXT:    xvmuldp vs13, vs4, v7
+; CHECK-NEXT:    xvmuldp vs5, v7, v2
+; CHECK-NEXT:    xxlor vs4, v2, v2
 ; CHECK-NEXT:    xxlor vs1, v3, v3
-; CHECK-NEXT:    xxlor vs9, vs11, vs11
+; CHECK-NEXT:    xxlor vs11, v5, v5
+; CHECK-NEXT:    xxlor vs9, v5, v5
 ; CHECK-NEXT:    xxlor vs15, vs13, vs13
 ; CHECK-NEXT:    xxmtacc acc1
 ; CHECK-NEXT:    xxmtacc acc0
@@ -93,10 +94,10 @@ define void @acc_regalloc(ptr %arg, ptr %arg1, ptr %arg2) local_unnamed_addr {
 ; CHECK-NEXT:    xvf64gerpp acc2, vsp34, vs0
 ; CHECK-NEXT:    xvf64gerpp acc3, vsp34, vs0
 ; CHECK-NEXT:    xxmfacc acc0
+; CHECK-NEXT:    stxv vs1, 0(r3)
 ; CHECK-NEXT:    xxmfacc acc1
 ; CHECK-NEXT:    xxmfacc acc2
 ; CHECK-NEXT:    xxmfacc acc3
-; CHECK-NEXT:    stxv vs1, 0(r3)
 ; CHECK-NEXT:    stxv vs9, 32(r3)
 ; CHECK-NEXT:    stxv vs4, 16(0)
 ; CHECK-NEXT:    stxv vs12, 48(0)
@@ -105,52 +106,53 @@ define void @acc_regalloc(ptr %arg, ptr %arg1, ptr %arg2) local_unnamed_addr {
 ; TRACKLIVE-LABEL: acc_regalloc:
 ; TRACKLIVE:       # %bb.0: # %bb
 ; TRACKLIVE-NEXT:    lwz r3, 0(r3)
-; TRACKLIVE-NEXT:    lxv v4, 0(0)
-; TRACKLIVE-NEXT:    xxlxor v0, v0, v0
-; TRACKLIVE-NEXT:    xxlxor v1, v1, v1
+; TRACKLIVE-NEXT:    lxv v0, 0(0)
+; TRACKLIVE-NEXT:    xxlxor v6, v6, v6
+; TRACKLIVE-NEXT:    xxlxor v4, v4, v4
 ; TRACKLIVE-NEXT:    xxlxor v2, v2, v2
 ; TRACKLIVE-NEXT:    li r6, 1
 ; TRACKLIVE-NEXT:    li r4, 16
 ; TRACKLIVE-NEXT:    stfd f14, -144(r1) # 8-byte Folded Spill
 ; TRACKLIVE-NEXT:    stfd f15, -136(r1) # 8-byte Folded Spill
 ; TRACKLIVE-NEXT:    extswsli r3, r3, 3
-; TRACKLIVE-NEXT:    xvmaddadp v1, v4, v1
-; TRACKLIVE-NEXT:    lxvdsx v5, 0, r3
-; TRACKLIVE-NEXT:    xvmaddadp v0, v5, v0
+; TRACKLIVE-NEXT:    xvmaddadp v4, v0, v4
+; TRACKLIVE-NEXT:    lxvdsx v1, 0, r3
+; TRACKLIVE-NEXT:    xvmaddadp v6, v1, v6
 ; TRACKLIVE-NEXT:    .p2align 4
 ; TRACKLIVE-NEXT:  .LBB0_1: # %bb9
 ; TRACKLIVE-NEXT:    #
 ; TRACKLIVE-NEXT:    addi r6, r6, 2
-; TRACKLIVE-NEXT:    lxv vs0, 16(0)
 ; TRACKLIVE-NEXT:    lxv vs1, -64(r5)
+; TRACKLIVE-NEXT:    lxv vs0, 16(0)
 ; TRACKLIVE-NEXT:    xxlxor vs7, vs7, vs7
-; TRACKLIVE-NEXT:    xxlor vs3, v0, v0
+; TRACKLIVE-NEXT:    xxlor vs3, v6, v6
 ; TRACKLIVE-NEXT:    xxlxor vs2, vs2, vs2
 ; TRACKLIVE-NEXT:    xxlxor vs12, vs12, vs12
+; TRACKLIVE-NEXT:    lxv vs4, -16(r5)
+; TRACKLIVE-NEXT:    xxlor vs10, v4, v4
+; TRACKLIVE-NEXT:    xxlor vs8, v4, v4
+; TRACKLIVE-NEXT:    xxlor vs8, v2, v2
 ; TRACKLIVE-NEXT:    mulld r6, r6, r3
-; TRACKLIVE-NEXT:    xxlor vs10, v2, v2
-; TRACKLIVE-NEXT:    xxlor vs4, v2, v2
-; TRACKLIVE-NEXT:    xxlor vs8, vs10, vs10
-; TRACKLIVE-NEXT:    xxlor vs10, v1, v1
-; TRACKLIVE-NEXT:    xvmaddadp vs7, vs0, v5
+; TRACKLIVE-NEXT:    xvmaddadp vs7, vs0, v1
 ; TRACKLIVE-NEXT:    xvmuldp vs6, vs0, v2
-; TRACKLIVE-NEXT:    lxv vs0, -16(r5)
 ; TRACKLIVE-NEXT:    xvmaddadp vs3, vs1, v2
 ; TRACKLIVE-NEXT:    xvmaddadp vs2, vs1, vs2
-; TRACKLIVE-NEXT:    lxvdsx v6, r6, r4
+; TRACKLIVE-NEXT:    xvmaddadp vs12, vs4, vs12
+; TRACKLIVE-NEXT:    xxlor vs0, v2, v2
+; TRACKLIVE-NEXT:    lxvdsx v7, r6, r4
 ; TRACKLIVE-NEXT:    li r6, 0
 ; TRACKLIVE-NEXT:    xvmaddadp vs7, v2, v2
 ; TRACKLIVE-NEXT:    xvmaddadp vs6, v2, v2
-; TRACKLIVE-NEXT:    xvmaddadp vs12, vs0, vs12
-; TRACKLIVE-NEXT:    xvmuldp v3, vs1, v6
-; TRACKLIVE-NEXT:    xvmuldp vs11, v4, v6
-; TRACKLIVE-NEXT:    xvmuldp vs13, vs0, v6
-; TRACKLIVE-NEXT:    xvmuldp vs5, v6, v2
-; TRACKLIVE-NEXT:    xxlor vs0, v2, v2
 ; TRACKLIVE-NEXT:    xxlor vs14, vs12, vs12
 ; TRACKLIVE-NEXT:    xxlor vs12, v2, v2
+; TRACKLIVE-NEXT:    xvmuldp v3, vs1, v7
+; TRACKLIVE-NEXT:    xvmuldp v5, v0, v7
+; TRACKLIVE-NEXT:    xvmuldp vs13, vs4, v7
+; TRACKLIVE-NEXT:    xvmuldp vs5, v7, v2
+; TRACKLIVE-NEXT:    xxlor vs4, v2, v2
 ; TRACKLIVE-NEXT:    xxlor vs1, v3, v3
-; TRACKLIVE-NEXT:    xxlor vs9, vs11, vs11
+; TRACKLIVE-NEXT:    xxlor vs11, v5, v5
+; TRACKLIVE-NEXT:    xxlor vs9, v5, v5
 ; TRACKLIVE-NEXT:    xxlor vs15, vs13, vs13
 ; TRACKLIVE-NEXT:    xxmtacc acc1
 ; TRACKLIVE-NEXT:    xxmtacc acc0
@@ -185,10 +187,10 @@ define void @acc_regalloc(ptr %arg, ptr %arg1, ptr %arg2) local_unnamed_addr {
 ; TRACKLIVE-NEXT:    xvf64gerpp acc2, vsp34, vs0
 ; TRACKLIVE-NEXT:    xvf64gerpp acc3, vsp34, vs0
 ; TRACKLIVE-NEXT:    xxmfacc acc0
+; TRACKLIVE-NEXT:    stxv vs1, 0(r3)
 ; TRACKLIVE-NEXT:    xxmfacc acc1
 ; TRACKLIVE-NEXT:    xxmfacc acc2
 ; TRACKLIVE-NEXT:    xxmfacc acc3
-; TRACKLIVE-NEXT:    stxv vs1, 0(r3)
 ; TRACKLIVE-NEXT:    stxv vs9, 32(r3)
 ; TRACKLIVE-NEXT:    stxv vs4, 16(0)
 ; TRACKLIVE-NEXT:    stxv vs12, 48(0)


### PR DESCRIPTION
Update to use REG_SEQUENCE when possible.

This patch only update td pattern to utilize REG_SEQUENCE for INSERT_SUBREG for cases where it does not produce
a nesting  of REG_SEQUENCE.  This seem to show some improvement in code gen for `llvm/test/CodeGen/PowerPC/mmaplus-intrinsics.ll`.   

Fixes part of https://github.com/llvm/llvm-project/issues/125502
