### PR TITLE
[flang] Check coranks on MOVE_ALLOC

### DIFF
--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -1840,6 +1840,13 @@ static void CheckMove_Alloc(evaluate::ActualArguments &arguments,
   if (arguments.size() >= 2) {
     evaluate::CheckForCoindexedObject(
         messages, arguments[1], "move_alloc", "to");
+    int fromCR{GetCorank(arguments[0])};
+    int toCR{GetCorank(arguments[1])};
+    if (fromCR != toCR) {
+      messages.Say(*arguments[0]->sourceLocation(),
+          "FROM= argument to MOVE_ALLOC has corank %d, but TO= argument has corank %d"_err_en_US,
+          fromCR, toCR);
+    }
   }
   if (arguments.size() >= 3) {
     evaluate::CheckForCoindexedObject(

--- a/flang/test/Semantics/move_alloc.f90
+++ b/flang/test/Semantics/move_alloc.f90
@@ -1,7 +1,7 @@
 ! RUN: %python %S/test_errors.py %s %flang_fc1
 ! Check for semantic errors in move_alloc() subroutine calls
 program main
-  integer, allocatable :: a(:)[:], b(:)[:], f(:), g(:)
+  integer, allocatable :: a(:)[:], b(:)[:], f(:), g(:), h(:)[:,:]
   type alloc_component
     integer, allocatable :: a(:)
   end type
@@ -72,5 +72,8 @@ program main
   call move_alloc(f(::2), g)
   !ERROR: Argument #2 to MOVE_ALLOC must be allocatable
   call move_alloc(f, g(::2))
+
+  !ERROR: FROM= argument to MOVE_ALLOC has corank 1, but TO= argument has corank 2
+  call move_alloc(a, h)
 
 end program main


### PR DESCRIPTION
The FROM= and TO= arguments in a reference to the MOVE_ALLOC intrinsic subroutine must have the same corank.