### PR TITLE
[libc] Allow building the GPU targets that don't have CRT

### DIFF
--- a/libc/startup/gpu/CMakeLists.txt
+++ b/libc/startup/gpu/CMakeLists.txt
@@ -40,6 +40,9 @@ endfunction()
 
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_ARCHITECTURE})
   add_subdirectory(${LIBC_TARGET_ARCHITECTURE})
+else()
+  message(WARNING "Cannot build 'crt1.o' for ${LIBC_TARGET_ARCHITECTURE} yet.")
+  return()
 endif()
 
 add_startup_object(


### PR DESCRIPTION
Summary:
If there's no subdirectory we can't make an alias. This allows it to at
least continue.
