### PR TITLE
[flang] explicitly cast the pointer to void* in std::memcpy calls (NFC)

### DIFF
--- a/flang-rt/lib/runtime/assign.cpp
+++ b/flang-rt/lib/runtime/assign.cpp
@@ -263,7 +263,8 @@ RT_API_ATTRS void Assign(Descriptor &to, const Descriptor &from,
   if (MayAlias(to, from)) {
     if (mustDeallocateLHS) {
       deferDeallocation = &deferredDeallocStatDesc.descriptor();
-      std::memcpy(deferDeallocation, &to, to.SizeInBytes());
+      std::memcpy(
+          reinterpret_cast<void *>(deferDeallocation), &to, to.SizeInBytes());
       to.set_base_addr(nullptr);
     } else if (!isSimpleMemmove()) {
       // Handle LHS/RHS aliasing by copying RHS into a temp, then
@@ -271,7 +272,7 @@ RT_API_ATTRS void Assign(Descriptor &to, const Descriptor &from,
       auto descBytes{from.SizeInBytes()};
       StaticDescriptor<maxRank, true, 16> staticDesc;
       Descriptor &newFrom{staticDesc.descriptor()};
-      std::memcpy(&newFrom, &from, descBytes);
+      std::memcpy(reinterpret_cast<void *>(&newFrom), &from, descBytes);
       // Pretend the temporary descriptor is for an ALLOCATABLE
       // entity, otherwise, the Deallocate() below will not
       // free the descriptor memory.

--- a/flang-rt/lib/runtime/descriptor.cpp
+++ b/flang-rt/lib/runtime/descriptor.cpp
@@ -26,7 +26,7 @@ RT_OFFLOAD_API_GROUP_BEGIN
 RT_API_ATTRS Descriptor::Descriptor(const Descriptor &that) { *this = that; }
 
 RT_API_ATTRS Descriptor &Descriptor::operator=(const Descriptor &that) {
-  std::memcpy(this, &that, that.SizeInBytes());
+  std::memcpy(reinterpret_cast<void *>(this), &that, that.SizeInBytes());
   return *this;
 }
 


### PR DESCRIPTION
The clang 20 compiler gives the following errors in `descriptor.cpp` and `assign.cpp`.

```
/scratch/kli/llvm-project/flang-rt/lib/runtime/assign.cpp:266:19: error: first argument in call to 'memcpy' is a pointer to non-trivially copyable type 'Descriptor' [-Werror,-Wnontrivial-memcall]
  266 |       std::memcpy(deferDeallocation, &to, to.SizeInBytes());
      |                   ^
/scratch/kli/llvm-project/flang-rt/lib/runtime/assign.cpp:266:19: note: explicitly cast the pointer to silence this warning
  266 |       std::memcpy(deferDeallocation, &to, to.SizeInBytes());
      |                   ^
      |                   (void*)
/scratch/kli/llvm-project/flang-rt/lib/runtime/assign.cpp:274:19: error: first argument in call to 'memcpy' is a pointer to non-trivially copyable type 'Descriptor' [-Werror,-Wnontrivial-memcall]
  274 |       std::memcpy(&newFrom, &from, descBytes);
      |                   ^
/scratch/kli/llvm-project/flang-rt/lib/runtime/assign.cpp:274:19: note: explicitly cast the pointer to silence this warning
  274 |       std::memcpy(&newFrom, &from, descBytes);
      |                   ^
      |                   (void*)
2 errors generated.
```

This patch is to add the explicit cast to the first argument of `std::memcpy`.