### PR TITLE
[lldb-dap] Use LLDB_INVALID_LINE_NUMBER & LLDB_INVALID_COLUMN_NUMBER

### DIFF
--- a/lldb/tools/lldb-dap/Handler/BreakpointLocationsHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/BreakpointLocationsHandler.cpp
@@ -131,9 +131,10 @@ void BreakpointLocationsRequestHandler::operator()(
   auto *arguments = request.getObject("arguments");
   auto *source = arguments->getObject("source");
   std::string path = GetString(source, "path").str();
-  const auto start_line = GetInteger<uint64_t>(arguments, "line").value_or(0);
-  const auto start_column =
-      GetInteger<uint64_t>(arguments, "column").value_or(0);
+  const auto start_line = GetInteger<uint64_t>(arguments, "line")
+                              .value_or(LLDB_INVALID_LINE_NUMBER);
+  const auto start_column = GetInteger<uint64_t>(arguments, "column")
+                                .value_or(LLDB_INVALID_COLUMN_NUMBER);
   const auto end_line =
       GetInteger<uint64_t>(arguments, "endLine").value_or(start_line);
   const auto end_column = GetInteger<uint64_t>(arguments, "endColumn")

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -27,8 +27,10 @@ namespace lldb_dap {
 SourceBreakpoint::SourceBreakpoint(DAP &dap, const llvm::json::Object &obj)
     : Breakpoint(dap, obj),
       logMessage(std::string(GetString(obj, "logMessage"))),
-      line(GetInteger<uint64_t>(obj, "line").value_or(0)),
-      column(GetInteger<uint64_t>(obj, "column").value_or(0)) {}
+      line(
+          GetInteger<uint64_t>(obj, "line").value_or(LLDB_INVALID_LINE_NUMBER)),
+      column(GetInteger<uint64_t>(obj, "column")
+                 .value_or(LLDB_INVALID_COLUMN_NUMBER)) {}
 
 void SourceBreakpoint::SetBreakpoint(const llvm::StringRef source_path) {
   lldb::SBFileSpecList module_list;


### PR DESCRIPTION
Consistently use LLDB_INVALID_LINE_NUMBER & LLDB_INVALID_COLUMN_NUMBER when parsing line and column numbers respectively.