### PR TITLE
[Github][libc++] Prefer ubuntu-24.04 over ubuntu-latest

### DIFF
--- a/.github/workflows/libcxx-build-containers.yml
+++ b/.github/workflows/libcxx-build-containers.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository_owner == 'llvm'
     permissions:
       packages: write

--- a/.github/workflows/libcxx-check-generated-files.yml
+++ b/.github/workflows/libcxx-check-generated-files.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   check_generated_files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4

--- a/.github/workflows/libcxx-restart-preempted-jobs.yaml
+++ b/.github/workflows/libcxx-restart-preempted-jobs.yaml
@@ -26,7 +26,7 @@ jobs:
       statuses: read
       checks: write
       actions: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: "Restart Job"
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1
@@ -161,7 +161,7 @@ jobs:
       statuses: read
       checks: write
       actions: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: "Restart Job (test)"
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea #v7.0.1


### PR DESCRIPTION
This patch replaces all instances of ubuntu-latest with ubuntu-24.04 based on the guidelines in the LLVM CI best practices doc (https://llvm.org/docs/CIBestPractices.html).