### PR TITLE
[clang] Reject constexpr-unknown values as constant expressions more consistently

### DIFF
--- a/clang/test/CodeGenCXX/cxx23-p2280r4.cpp
+++ b/clang/test/CodeGenCXX/cxx23-p2280r4.cpp
@@ -4,7 +4,7 @@
 
 extern int& s;
 
-// CHECK: @_Z4testv()
+// CHECK-LABEL: @_Z4testv()
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[I:%.*]] = alloca ptr, align {{.*}}
 // CHECK-NEXT: [[X:%.*]] = load ptr, ptr @s, align {{.*}}
@@ -14,12 +14,13 @@ int& test() {
   return i;
 }
 
-// CHECK: @_Z1fv(
-// CHECK-NEXT: entry:
-// CHECK-NEXT: getelementptr inbounds nuw %struct.B
-// CHECK-NEXT: getelementptr inbounds nuw %struct.A
-// CHECK-NEXT: [[X:%.*]] = load ptr, ptr @x, align 8
-// CHECK-NEXT: store ptr [[X]]
+// CHECK-LABEL: @_Z1fv(
+// CHECK: [[X1:%.*]] = load ptr, ptr @x, align 8
+// CHECK-NEXT: store ptr [[X1]]
+// CHECK: [[X2:%.*]] = load ptr, ptr @x, align 8
+// CHECK-NEXT: store ptr [[X2]]
+// CHECK: [[X3:%.*]] = load ptr, ptr @x, align 8
+// CHECK-NEXT: store ptr [[X3]]
 int &ff();
 int &x = ff();
 struct A { int& x; };

--- a/clang/test/CodeGenCXX/cxx23-p2280r4.cpp
+++ b/clang/test/CodeGenCXX/cxx23-p2280r4.cpp
@@ -13,3 +13,15 @@ int& test() {
   auto &i = s;
   return i;
 }
+
+// CHECK: @_Z1fv(
+// CHECK-NEXT: entry:
+// CHECK-NEXT: getelementptr inbounds nuw %struct.B
+// CHECK-NEXT: getelementptr inbounds nuw %struct.A
+// CHECK-NEXT: [[X:%.*]] = load ptr, ptr @x, align 8
+// CHECK-NEXT: store ptr [[X]]
+int &ff();
+int &x = ff();
+struct A { int& x; };
+struct B { A x[20]; };
+B f() { return {x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x}; }

--- a/clang/test/SemaCXX/constant-expression-cxx11.cpp
+++ b/clang/test/SemaCXX/constant-expression-cxx11.cpp
@@ -1472,8 +1472,8 @@ namespace ConvertedConstantExpr {
   enum class E {
     em = m,
     en = n, // expected-error {{enumerator value is not a constant expression}} cxx11_20-note {{initializer of 'n' is unknown}}
-    eo = (m + // pre-cxx23-error {{not a constant expression}}
-          n // cxx11_20-note {{initializer of 'n' is unknown}} cxx23-error {{not a constant expression}}
+    eo = (m + // expected-error {{not a constant expression}}
+          n // cxx11_20-note {{initializer of 'n' is unknown}}
           ),
     eq = reinterpret_cast<long>((int*)0) // expected-error {{not a constant expression}} expected-note {{reinterpret_cast}}
   };

--- a/clang/test/SemaCXX/constant-expression-p2280r4.cpp
+++ b/clang/test/SemaCXX/constant-expression-p2280r4.cpp
@@ -39,8 +39,8 @@ void splash(Swim& swam) {
   static_assert(swam.phelps() == 28);     // ok
   static_assert((&swam)->phelps() == 28); // ok
   Swim* pswam = &swam;                    // expected-note {{declared here}}
-  static_assert(pswam->phelps() == 28);   // expected-error {{static assertion expression is not an integral constant expression}}
-                                          // expected-note@-1 {{read of non-constexpr variable 'pswam' is not allowed in a constant expression}}
+  static_assert(pswam->phelps() == 28);   // expected-error {{static assertion expression is not an integral constant expression}} \
+                                          // expected-note {{read of non-constexpr variable 'pswam' is not allowed in a constant expression}}
   static_assert(how_many(swam) == 28);    // ok
   static_assert(Swim().lochte() == 12);   // ok
   static_assert(swam.lochte() == 12);     // expected-error {{static assertion expression is not an integral constant expression}}
@@ -158,17 +158,17 @@ int g() {
 namespace GH128409 {
   int &ff();
   int &x = ff(); // nointerpreter-note {{declared here}}
-  constinit int &z = x; // expected-error {{variable does not have a constant initializer}}
-                        // expected-note@-1 {{required by 'constinit' specifier here}}
-                        // nointerpreter-note@-2 {{initializer of 'x' is not a constant expression}}
+  constinit int &z = x; // expected-error {{variable does not have a constant initializer}} \
+                        // expected-note {{required by 'constinit' specifier here}} \
+                        // nointerpreter-note {{initializer of 'x' is not a constant expression}}
 }
 
 namespace GH129845 {
   int &ff();
   int &x = ff(); // nointerpreter-note {{declared here}}
   struct A { int& x; };
-  constexpr A g = {x}; // expected-error {{constexpr variable 'g' must be initialized by a constant expression}}
-                       // nointerpreter-note@-1 {{initializer of 'x' is not a constant expression}}
+  constexpr A g = {x}; // expected-error {{constexpr variable 'g' must be initialized by a constant expression}} \
+                       // nointerpreter-note {{initializer of 'x' is not a constant expression}}
   const A* gg = &g;
 }
 


### PR DESCRIPTION
Perform the check for constexpr-unknown values in the same place we perform checks for other values which don't count as constant expressions.

While I'm here, also fix a rejects-valid with a reference that doesn't have an initializer.  This diagnostic was also covering up some of the bugs here.

The existing behavior with -fexperimental-new-constant-interpreter seems to be correct, but the diagnostics are slightly different; it would be helpful if someone could check on that as a followup.

Followup to #128409.

Fixes #129844. Fixes #129845.