### PR TITLE
[win] NFC: Rename `EHCatchret` to `EHCont` to allow for EH Continuation targets that aren't `catchret` instructions

### DIFF
--- a/llvm/include/llvm/CodeGen/MIRYamlMapping.h
+++ b/llvm/include/llvm/CodeGen/MIRYamlMapping.h
@@ -762,7 +762,7 @@ struct MachineFunction {
 
   bool CallsEHReturn = false;
   bool CallsUnwindInit = false;
-  bool HasEHCatchret = false;
+  bool HasEHContTarget = false;
   bool HasEHScopes = false;
   bool HasEHFunclets = false;
   bool IsOutlined = false;
@@ -810,7 +810,7 @@ template <> struct MappingTraits<MachineFunction> {
 
     YamlIO.mapOptional("callsEHReturn", MF.CallsEHReturn, false);
     YamlIO.mapOptional("callsUnwindInit", MF.CallsUnwindInit, false);
-    YamlIO.mapOptional("hasEHCatchret", MF.HasEHCatchret, false);
+    YamlIO.mapOptional("hasEHContTarget", MF.HasEHContTarget, false);
     YamlIO.mapOptional("hasEHScopes", MF.HasEHScopes, false);
     YamlIO.mapOptional("hasEHFunclets", MF.HasEHFunclets, false);
     YamlIO.mapOptional("isOutlined", MF.IsOutlined, false);

--- a/llvm/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/llvm/include/llvm/CodeGen/MachineBasicBlock.h
@@ -205,8 +205,8 @@ private:
   /// LLVM IR.
   bool IsEHScopeEntry = false;
 
-  /// Indicates if this is a target block of a catchret.
-  bool IsEHCatchretTarget = false;
+  /// Indicates if this is a target of Windows EH Continuation Guard.
+  bool IsEHContTarget = false;
 
   /// Indicate that this basic block is the entry block of an EH funclet.
   bool IsEHFuncletEntry = false;
@@ -234,8 +234,8 @@ private:
   /// is only computed once and is cached.
   mutable MCSymbol *CachedMCSymbol = nullptr;
 
-  /// Cached MCSymbol for this block (used if IsEHCatchRetTarget).
-  mutable MCSymbol *CachedEHCatchretMCSymbol = nullptr;
+  /// Cached MCSymbol for this block (used if IsEHContTarget).
+  mutable MCSymbol *CachedEHContMCSymbol = nullptr;
 
   /// Marks the end of the basic block. Used during basic block sections to
   /// calculate the size of the basic block, or the BB section ending with it.
@@ -652,11 +652,11 @@ public:
   /// that used to have a catchpad or cleanuppad instruction in the LLVM IR.
   void setIsEHScopeEntry(bool V = true) { IsEHScopeEntry = V; }
 
-  /// Returns true if this is a target block of a catchret.
-  bool isEHCatchretTarget() const { return IsEHCatchretTarget; }
+  /// Returns true if this is a target of Windows EH Continuation Guard.
+  bool isEHContTarget() const { return IsEHContTarget; }
 
-  /// Indicates if this is a target block of a catchret.
-  void setIsEHCatchretTarget(bool V = true) { IsEHCatchretTarget = V; }
+  /// Indicates if this is a target of Windows EH Continuation Guard.
+  void setIsEHContTarget(bool V = true) { IsEHContTarget = V; }
 
   /// Returns true if this is the entry block of an EH funclet.
   bool isEHFuncletEntry() const { return IsEHFuncletEntry; }
@@ -1238,8 +1238,8 @@ public:
   /// Return the MCSymbol for this basic block.
   MCSymbol *getSymbol() const;
 
-  /// Return the EHCatchret Symbol for this basic block.
-  MCSymbol *getEHCatchretSymbol() const;
+  /// Return the Windows EH Continuation Symbol for this basic block.
+  MCSymbol *getEHContSymbol() const;
 
   std::optional<uint64_t> getIrrLoopHeaderWeight() const {
     return IrrLoopHeaderWeight;

--- a/llvm/include/llvm/CodeGen/MachineFunction.h
+++ b/llvm/include/llvm/CodeGen/MachineFunction.h
@@ -359,9 +359,9 @@ class LLVM_ABI MachineFunction {
   /// construct a table of valid longjmp targets for Windows Control Flow Guard.
   std::vector<MCSymbol *> LongjmpTargets;
 
-  /// List of basic blocks that are the target of catchrets. Used to construct
-  /// a table of valid targets for Windows EHCont Guard.
-  std::vector<MCSymbol *> CatchretTargets;
+  /// List of basic blocks that are the targets for Windows EH Continuation
+  /// Guard.
+  std::vector<MCSymbol *> EHContTargets;
 
   /// \name Exception Handling
   /// \{
@@ -383,7 +383,7 @@ class LLVM_ABI MachineFunction {
 
   bool CallsEHReturn = false;
   bool CallsUnwindInit = false;
-  bool HasEHCatchret = false;
+  bool HasEHContTarget = false;
   bool HasEHScopes = false;
   bool HasEHFunclets = false;
   bool HasFakeUses = false;
@@ -1197,17 +1197,15 @@ public:
   /// Control Flow Guard.
   void addLongjmpTarget(MCSymbol *Target) { LongjmpTargets.push_back(Target); }
 
-  /// Returns a reference to a list of symbols that we have catchrets.
-  /// Used to construct the catchret target table used by Windows EHCont Guard.
-  const std::vector<MCSymbol *> &getCatchretTargets() const {
-    return CatchretTargets;
+  /// Returns a reference to a list of symbols that are targets for Windows
+  /// EH Continuation Guard.
+  const std::vector<MCSymbol *> &getEHContTargets() const {
+    return EHContTargets;
   }
 
-  /// Add the specified symbol to the list of valid catchret targets for Windows
-  /// EHCont Guard.
-  void addCatchretTarget(MCSymbol *Target) {
-    CatchretTargets.push_back(Target);
-  }
+  /// Add the specified symbol to the list of targets for Windows EH
+  /// Continuation Guard.
+  void addEHContTarget(MCSymbol *Target) { EHContTargets.push_back(Target); }
 
   /// Tries to get the global and target flags for a call site, if the
   /// instruction is a call to a global.
@@ -1236,8 +1234,8 @@ public:
   bool callsUnwindInit() const { return CallsUnwindInit; }
   void setCallsUnwindInit(bool b) { CallsUnwindInit = b; }
 
-  bool hasEHCatchret() const { return HasEHCatchret; }
-  void setHasEHCatchret(bool V) { HasEHCatchret = V; }
+  bool hasEHContTarget() const { return HasEHContTarget; }
+  void setHasEHContTarget(bool V) { HasEHContTarget = V; }
 
   bool hasEHScopes() const { return HasEHScopes; }
   void setHasEHScopes(bool V) { HasEHScopes = V; }

--- a/llvm/include/llvm/CodeGen/Passes.h
+++ b/llvm/include/llvm/CodeGen/Passes.h
@@ -550,9 +550,9 @@ namespace llvm {
   /// \see CFGuardLongjmp.cpp
   FunctionPass *createCFGuardLongjmpPass();
 
-  /// Creates EHContGuard catchret target identification pass.
-  /// \see EHContGuardCatchret.cpp
-  FunctionPass *createEHContGuardCatchretPass();
+  /// Creates Windows EH Continuation Guard target identification pass.
+  /// \see EHContGuardTargets.cpp
+  FunctionPass *createEHContGuardTargetsPass();
 
   /// Create Hardware Loop pass. \see HardwareLoops.cpp
   FunctionPass *createHardwareLoopsLegacyPass();

--- a/llvm/include/llvm/InitializePasses.h
+++ b/llvm/include/llvm/InitializePasses.h
@@ -104,7 +104,7 @@ void initializeEarlyIfPredicatorPass(PassRegistry &);
 void initializeEarlyMachineLICMPass(PassRegistry &);
 void initializeEarlyTailDuplicateLegacyPass(PassRegistry &);
 void initializeEdgeBundlesWrapperLegacyPass(PassRegistry &);
-void initializeEHContGuardCatchretPass(PassRegistry &);
+void initializeEHContGuardTargetsPass(PassRegistry &);
 void initializeExpandLargeFpConvertLegacyPassPass(PassRegistry &);
 void initializeExpandLargeDivRemLegacyPassPass(PassRegistry &);
 void initializeExpandMemCmpLegacyPassPass(PassRegistry &);

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -4288,9 +4288,9 @@ void AsmPrinter::emitBasicBlockStart(const MachineBasicBlock &MBB) {
     }
   }
 
-  if (MBB.isEHCatchretTarget() &&
+  if (MBB.isEHContTarget() &&
       MAI->getExceptionHandlingType() == ExceptionHandling::WinEH) {
-    OutStreamer->emitLabel(MBB.getEHCatchretSymbol());
+    OutStreamer->emitLabel(MBB.getEHContSymbol());
   }
 
   // With BB sections, each basic block must handle CFI information on its own

--- a/llvm/lib/CodeGen/AsmPrinter/WinException.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/WinException.cpp
@@ -160,10 +160,10 @@ void WinException::endFunction(const MachineFunction *MF) {
     Asm->OutStreamer->popSection();
   }
 
-  if (!MF->getCatchretTargets().empty()) {
-    // Copy the function's catchret targets to a module-level list.
-    EHContTargets.insert(EHContTargets.end(), MF->getCatchretTargets().begin(),
-                         MF->getCatchretTargets().end());
+  if (!MF->getEHContTargets().empty()) {
+    // Copy the function's EH Continuation targets to a module-level list.
+    EHContTargets.insert(EHContTargets.end(), MF->getEHContTargets().begin(),
+                         MF->getEHContTargets().end());
   }
 }
 

--- a/llvm/lib/CodeGen/CMakeLists.txt
+++ b/llvm/lib/CodeGen/CMakeLists.txt
@@ -54,7 +54,7 @@ add_llvm_component_library(LLVMCodeGen
   DwarfEHPrepare.cpp
   EarlyIfConversion.cpp
   EdgeBundles.cpp
-  EHContGuardCatchret.cpp
+  EHContGuardTargets.cpp
   ExecutionDomainFix.cpp
   ExpandLargeDivRem.cpp
   ExpandLargeFpConvert.cpp

--- a/llvm/lib/CodeGen/EHContGuardTargets.cpp
+++ b/llvm/lib/CodeGen/EHContGuardTargets.cpp
@@ -1,4 +1,4 @@
-//===-- EHContGuardCatchret.cpp - Catchret target symbols -------*- C++ -*-===//
+//===-- EHContGuardTargets.cpp - EH continuation target symbols -*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -8,9 +8,10 @@
 ///
 /// \file
 /// This file contains a machine function pass to insert a symbol before each
-/// valid catchret target and store this in the MachineFunction's
-/// CatchRetTargets vector. This will be used to emit the table of valid targets
-/// used by EHCont Guard.
+/// valid target where the unwinder in Windows may continue exectution after an
+/// exception is thrown and store this in the MachineFunction's EHContTargets
+/// vector. This will be used to emit the table of valid targets used by Windows
+/// EH Continuation Guard.
 ///
 //===----------------------------------------------------------------------===//
 
@@ -26,19 +27,18 @@ using namespace llvm;
 
 #define DEBUG_TYPE "ehcontguard-catchret"
 
-STATISTIC(EHContGuardCatchretTargets,
-          "Number of EHCont Guard catchret targets");
+STATISTIC(EHContGuardTargetsFound, "Number of EHCont Guard targets");
 
 namespace {
 
 /// MachineFunction pass to insert a symbol before each valid catchret target
 /// and store these in the MachineFunction's CatchRetTargets vector.
-class EHContGuardCatchret : public MachineFunctionPass {
+class EHContGuardTargets : public MachineFunctionPass {
 public:
   static char ID;
 
-  EHContGuardCatchret() : MachineFunctionPass(ID) {
-    initializeEHContGuardCatchretPass(*PassRegistry::getPassRegistry());
+  EHContGuardTargets() : MachineFunctionPass(ID) {
+    initializeEHContGuardTargetsPass(*PassRegistry::getPassRegistry());
   }
 
   StringRef getPassName() const override {
@@ -50,31 +50,31 @@ public:
 
 } // end anonymous namespace
 
-char EHContGuardCatchret::ID = 0;
+char EHContGuardTargets::ID = 0;
 
-INITIALIZE_PASS(EHContGuardCatchret, "EHContGuardCatchret",
-                "Insert symbols at valid catchret targets for /guard:ehcont",
-                false, false)
-FunctionPass *llvm::createEHContGuardCatchretPass() {
-  return new EHContGuardCatchret();
+INITIALIZE_PASS(EHContGuardTargets, "EHContGuardTargets",
+                "Insert symbols at valid targets for /guard:ehcont", false,
+                false)
+FunctionPass *llvm::createEHContGuardTargetsPass() {
+  return new EHContGuardTargets();
 }
 
-bool EHContGuardCatchret::runOnMachineFunction(MachineFunction &MF) {
+bool EHContGuardTargets::runOnMachineFunction(MachineFunction &MF) {
 
   // Skip modules for which the ehcontguard flag is not set.
   if (!MF.getFunction().getParent()->getModuleFlag("ehcontguard"))
     return false;
 
-  // Skip functions that do not have catchret
-  if (!MF.hasEHCatchret())
+  // Skip functions that do not have targets
+  if (!MF.hasEHContTarget())
     return false;
 
   bool Result = false;
 
   for (MachineBasicBlock &MBB : MF) {
-    if (MBB.isEHCatchretTarget()) {
-      MF.addCatchretTarget(MBB.getEHCatchretSymbol());
-      EHContGuardCatchretTargets++;
+    if (MBB.isEHContTarget()) {
+      MF.addEHContTarget(MBB.getEHContSymbol());
+      EHContGuardTargetsFound++;
       Result = true;
     }
   }

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -551,7 +551,7 @@ MIRParserImpl::initializeMachineFunction(const yaml::MachineFunction &YamlMF,
 
   MF.setCallsEHReturn(YamlMF.CallsEHReturn);
   MF.setCallsUnwindInit(YamlMF.CallsUnwindInit);
-  MF.setHasEHCatchret(YamlMF.HasEHCatchret);
+  MF.setHasEHContTarget(YamlMF.HasEHContTarget);
   MF.setHasEHScopes(YamlMF.HasEHScopes);
   MF.setHasEHFunclets(YamlMF.HasEHFunclets);
   MF.setIsOutlined(YamlMF.IsOutlined);

--- a/llvm/lib/CodeGen/MIRPrinter.cpp
+++ b/llvm/lib/CodeGen/MIRPrinter.cpp
@@ -208,7 +208,7 @@ void MIRPrinter::print(const MachineFunction &MF) {
 
   YamlMF.CallsEHReturn = MF.callsEHReturn();
   YamlMF.CallsUnwindInit = MF.callsUnwindInit();
-  YamlMF.HasEHCatchret = MF.hasEHCatchret();
+  YamlMF.HasEHContTarget = MF.hasEHContTarget();
   YamlMF.HasEHScopes = MF.hasEHScopes();
   YamlMF.HasEHFunclets = MF.hasEHFunclets();
   YamlMF.HasFakeUses = MF.hasFakeUses();

--- a/llvm/lib/CodeGen/MachineBasicBlock.cpp
+++ b/llvm/lib/CodeGen/MachineBasicBlock.cpp
@@ -92,15 +92,15 @@ MCSymbol *MachineBasicBlock::getSymbol() const {
   return CachedMCSymbol;
 }
 
-MCSymbol *MachineBasicBlock::getEHCatchretSymbol() const {
-  if (!CachedEHCatchretMCSymbol) {
+MCSymbol *MachineBasicBlock::getEHContSymbol() const {
+  if (!CachedEHContMCSymbol) {
     const MachineFunction *MF = getParent();
     SmallString<128> SymbolName;
     raw_svector_ostream(SymbolName)
         << "$ehgcr_" << MF->getFunctionNumber() << '_' << getNumber();
-    CachedEHCatchretMCSymbol = MF->getContext().getOrCreateSymbol(SymbolName);
+    CachedEHContMCSymbol = MF->getContext().getOrCreateSymbol(SymbolName);
   }
-  return CachedEHCatchretMCSymbol;
+  return CachedEHContMCSymbol;
 }
 
 MCSymbol *MachineBasicBlock::getEndSymbol() const {

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -1981,8 +1981,8 @@ void SelectionDAGBuilder::visitCatchRet(const CatchReturnInst &I) {
   // Update machine-CFG edge.
   MachineBasicBlock *TargetMBB = FuncInfo.getMBB(I.getSuccessor());
   FuncInfo.MBB->addSuccessor(TargetMBB);
-  TargetMBB->setIsEHCatchretTarget(true);
-  DAG.getMachineFunction().setHasEHCatchret(true);
+  TargetMBB->setIsEHContTarget(true);
+  DAG.getMachineFunction().setHasEHContTarget(true);
 
   auto Pers = classifyEHPersonality(FuncInfo.Fn->getPersonalityFn());
   bool IsSEH = isAsynchronousEHPersonality(Pers);

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -869,7 +869,7 @@ void AArch64PassConfig::addPreEmitPass() {
     // Identify valid longjmp targets for Windows Control Flow Guard.
     addPass(createCFGuardLongjmpPass());
     // Identify valid eh continuation targets for Windows EHCont Guard.
-    addPass(createEHContGuardCatchretPass());
+    addPass(createEHContGuardTargetsPass());
   }
 
   if (TM->getOptLevel() != CodeGenOptLevel::None && EnableCollectLOH &&

--- a/llvm/lib/Target/ARM/ARMTargetMachine.cpp
+++ b/llvm/lib/Target/ARM/ARMTargetMachine.cpp
@@ -620,7 +620,7 @@ void ARMPassConfig::addPreEmitPass2() {
     // Identify valid longjmp targets for Windows Control Flow Guard.
     addPass(createCFGuardLongjmpPass());
     // Identify valid eh continuation targets for Windows EHCont Guard.
-    addPass(createEHContGuardCatchretPass());
+    addPass(createEHContGuardTargetsPass());
   }
 }
 

--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -647,7 +647,7 @@ void X86PassConfig::addPreEmitPass2() {
     // Identify valid longjmp targets for Windows Control Flow Guard.
     addPass(createCFGuardLongjmpPass());
     // Identify valid eh continuation targets for Windows EHCont Guard.
-    addPass(createEHContGuardCatchretPass());
+    addPass(createEHContGuardTargetsPass());
   }
   addPass(createX86LoadValueInjectionRetHardeningPass());
 

--- a/llvm/test/CodeGen/AArch64/GlobalISel/store-merging-debug.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/store-merging-debug.mir
@@ -48,7 +48,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/CodeGen/AArch64/cfi-fixup-multi-block-prologue.mir
+++ b/llvm/test/CodeGen/AArch64/cfi-fixup-multi-block-prologue.mir
@@ -51,7 +51,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/AArch64/emit_fneg_with_non_register_operand.mir
+++ b/llvm/test/CodeGen/AArch64/emit_fneg_with_non_register_operand.mir
@@ -39,7 +39,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/AArch64/machine-latecleanup-inlineasm.mir
+++ b/llvm/test/CodeGen/AArch64/machine-latecleanup-inlineasm.mir
@@ -56,7 +56,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/AArch64/nested-iv-regalloc.mir
+++ b/llvm/test/CodeGen/AArch64/nested-iv-regalloc.mir
@@ -97,7 +97,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/AArch64/regalloc-last-chance-recolor-with-split.mir
+++ b/llvm/test/CodeGen/AArch64/regalloc-last-chance-recolor-with-split.mir
@@ -84,7 +84,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/CodeGen/AArch64/sink-and-fold-drop-dbg.mir
+++ b/llvm/test/CodeGen/AArch64/sink-and-fold-drop-dbg.mir
@@ -67,7 +67,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/AArch64/sink-and-fold-illegal-shift.mir
+++ b/llvm/test/CodeGen/AArch64/sink-and-fold-illegal-shift.mir
@@ -27,7 +27,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/AArch64/sink-and-fold-preserve-debugloc.mir
+++ b/llvm/test/CodeGen/AArch64/sink-and-fold-preserve-debugloc.mir
@@ -83,7 +83,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false
@@ -156,7 +156,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/AArch64/split-deadloop.mir
+++ b/llvm/test/CodeGen/AArch64/split-deadloop.mir
@@ -31,7 +31,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/AArch64/stack-probing-last-in-block.mir
+++ b/llvm/test/CodeGen/AArch64/stack-probing-last-in-block.mir
@@ -37,7 +37,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/AArch64/tail-dup-redundant-phi.mir
+++ b/llvm/test/CodeGen/AArch64/tail-dup-redundant-phi.mir
@@ -109,7 +109,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/CodeGen/AArch64/wineh9.mir
+++ b/llvm/test/CodeGen/AArch64/wineh9.mir
@@ -29,7 +29,7 @@ tracksRegLiveness: true
 hasWinCFI:       true
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/CodeGen/ARM/execute-only-save-cpsr.mir
+++ b/llvm/test/CodeGen/ARM/execute-only-save-cpsr.mir
@@ -89,7 +89,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false
@@ -175,7 +175,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false
@@ -267,7 +267,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false
@@ -359,7 +359,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/ARM/inlineasmbr-if-cvt.mir
+++ b/llvm/test/CodeGen/ARM/inlineasmbr-if-cvt.mir
@@ -41,7 +41,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 debugInstrRef:   false

--- a/llvm/test/CodeGen/ARM/jump-table-dbg-value.mir
+++ b/llvm/test/CodeGen/ARM/jump-table-dbg-value.mir
@@ -70,7 +70,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 debugInstrRef:   false

--- a/llvm/test/CodeGen/Hexagon/cext-opt-block-addr.mir
+++ b/llvm/test/CodeGen/Hexagon/cext-opt-block-addr.mir
@@ -46,7 +46,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false
@@ -107,7 +107,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/Hexagon/rdf-copy-clobber.mir
+++ b/llvm/test/CodeGen/Hexagon/rdf-copy-clobber.mir
@@ -36,7 +36,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/Hexagon/rdf-phi-clobber.mir
+++ b/llvm/test/CodeGen/Hexagon/rdf-phi-clobber.mir
@@ -31,7 +31,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/MIR/Hexagon/addrmode-opt-nonreaching.mir
+++ b/llvm/test/CodeGen/MIR/Hexagon/addrmode-opt-nonreaching.mir
@@ -95,7 +95,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/MIR/X86/exception-function-state.mir
+++ b/llvm/test/CodeGen/MIR/X86/exception-function-state.mir
@@ -7,7 +7,7 @@
 # ALL: name: func0
 # ALL: callsEHReturn:   true
 # ALL: callsUnwindInit: true
-# ALL: hasEHCatchret:   true
+# ALL: hasEHContTarget: true
 # ALL: hasEHScopes:     true
 # ALL: hasEHFunclets:   true
 
@@ -15,7 +15,7 @@
 name: func0
 callsEHReturn: true
 callsUnwindInit: true
-hasEHCatchret: true
+hasEHContTarget: true
 hasEHScopes: true
 hasEHFunclets: true
 body: |
@@ -25,13 +25,13 @@ body: |
 # ALL: name: func1
 # FULL: callsEHReturn: false
 # FULL: callsUnwindInit: true
-# FULL: hasEHCatchret: false
+# FULL: hasEHContTarget: false
 # FULL: hasEHScopes: true
 # FULL: hasEHFunclets: false
 
 # SIMPLE-NOT: callsEHReturn
 # SIMPLE: callsUnwindInit: true
-# SIMPLE-NOT: hasEHCatchret
+# SIMPLE-NOT: hasEHContTarget
 # SIMPLE: hasEHScopes: true
 # SIMPLE-NOT: hasEHFunclets
 ---
@@ -39,7 +39,7 @@ name: func1
 tracksRegLiveness: true
 callsEHReturn: false
 callsUnwindInit: true
-hasEHCatchret: false
+hasEHContTarget: false
 hasEHScopes: true
 hasEHFunclets: false
 body: |
@@ -49,13 +49,13 @@ body: |
 # ALL: name: func2
 # FULL: callsEHReturn: true
 # FULL: callsUnwindInit: false
-# FULL: hasEHCatchret: true
+# FULL: hasEHContTarget: true
 # FULL: hasEHScopes: false
 # FULL: hasEHFunclets: false
 
 # SIMPLE: callsEHReturn: true
 # SIMPLE-NOT: callsUnwindInit
-# SIMPLE: hasEHCatchret: true
+# SIMPLE: hasEHContTarget: true
 # SIMPLE-NOT hasEHScopes
 # SIMPLE-NOT: hasEHFunclets
 ---
@@ -63,7 +63,7 @@ name: func2
 tracksRegLiveness: true
 callsEHReturn: true
 callsUnwindInit: false
-hasEHCatchret: true
+hasEHContTarget: true
 hasEHScopes: false
 hasEHFunclets: false
 body: |

--- a/llvm/test/CodeGen/MIR/X86/inline-asm-rm-exhaustion.mir
+++ b/llvm/test/CodeGen/MIR/X86/inline-asm-rm-exhaustion.mir
@@ -40,7 +40,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false
@@ -103,7 +103,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false
@@ -170,7 +170,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/NVPTX/proxy-reg-erasure.mir
+++ b/llvm/test/CodeGen/NVPTX/proxy-reg-erasure.mir
@@ -25,7 +25,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/PowerPC/ctrloop-do-not-duplicate-mi.mir
+++ b/llvm/test/CodeGen/PowerPC/ctrloop-do-not-duplicate-mi.mir
@@ -75,7 +75,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/CodeGen/PowerPC/peephole-replaceInstr-after-eliminate-extsw.mir
+++ b/llvm/test/CodeGen/PowerPC/peephole-replaceInstr-after-eliminate-extsw.mir
@@ -260,7 +260,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/RISCV/rvv/undef-earlyclobber-chain.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/undef-earlyclobber-chain.mir
@@ -30,7 +30,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/RISCV/stack-slot-coloring.mir
+++ b/llvm/test/CodeGen/RISCV/stack-slot-coloring.mir
@@ -21,7 +21,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/CodeGen/Thumb2/LowOverheadLoops/mve-reduct-livein-arg.mir
+++ b/llvm/test/CodeGen/Thumb2/LowOverheadLoops/mve-reduct-livein-arg.mir
@@ -67,7 +67,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/CodeGen/Thumb2/constant-islands-no-split.mir
+++ b/llvm/test/CodeGen/Thumb2/constant-islands-no-split.mir
@@ -47,7 +47,7 @@ noVRegs:         true
 hasFakeUses:     false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/Thumb2/pipeliner-preserve-ties.mir
+++ b/llvm/test/CodeGen/Thumb2/pipeliner-preserve-ties.mir
@@ -101,7 +101,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/CodeGen/WebAssembly/multivalue-dont-move-def-past-use.mir
+++ b/llvm/test/CodeGen/WebAssembly/multivalue-dont-move-def-past-use.mir
@@ -40,7 +40,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/CodeGen/X86/align-basic-block-sections.mir
+++ b/llvm/test/CodeGen/X86/align-basic-block-sections.mir
@@ -56,7 +56,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/CodeGen/X86/amx_tile_pair_configure_O0.mir
+++ b/llvm/test/CodeGen/X86/amx_tile_pair_configure_O0.mir
@@ -14,7 +14,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/CodeGen/X86/amx_tile_pair_configure_O2.mir
+++ b/llvm/test/CodeGen/X86/amx_tile_pair_configure_O2.mir
@@ -49,7 +49,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/CodeGen/X86/amx_tile_pair_copy.mir
+++ b/llvm/test/CodeGen/X86/amx_tile_pair_copy.mir
@@ -14,7 +14,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/CodeGen/X86/amx_tile_pair_preconfigure_O0.mir
+++ b/llvm/test/CodeGen/X86/amx_tile_pair_preconfigure_O0.mir
@@ -14,7 +14,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/CodeGen/X86/amx_tile_pair_preconfigure_O2.mir
+++ b/llvm/test/CodeGen/X86/amx_tile_pair_preconfigure_O2.mir
@@ -14,7 +14,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/CodeGen/X86/apx/domain-reassignment.mir
+++ b/llvm/test/CodeGen/X86/apx/domain-reassignment.mir
@@ -878,7 +878,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/X86/apx/memfold-nd2rmw.mir
+++ b/llvm/test/CodeGen/X86/apx/memfold-nd2rmw.mir
@@ -67,7 +67,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/X86/basic-block-address-map-mir-parse.mir
+++ b/llvm/test/CodeGen/X86/basic-block-address-map-mir-parse.mir
@@ -66,7 +66,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/CodeGen/X86/break-false-dep-crash.mir
+++ b/llvm/test/CodeGen/X86/break-false-dep-crash.mir
@@ -64,7 +64,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/X86/callbr-asm-outputs-regallocfast.mir
+++ b/llvm/test/CodeGen/X86/callbr-asm-outputs-regallocfast.mir
@@ -62,7 +62,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 debugInstrRef:   false

--- a/llvm/test/CodeGen/X86/cse-two-preds.mir
+++ b/llvm/test/CodeGen/X86/cse-two-preds.mir
@@ -50,7 +50,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/X86/domain-reassignment.mir
+++ b/llvm/test/CodeGen/X86/domain-reassignment.mir
@@ -878,7 +878,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/X86/machine-licm-vs-wineh.mir
+++ b/llvm/test/CodeGen/X86/machine-licm-vs-wineh.mir
@@ -66,7 +66,7 @@
 name:            test
 alignment:       16
 tracksRegLiveness: true
-hasEHCatchret:   true
+hasEHContTarget: true
 hasEHScopes:     true
 hasEHFunclets:   true
 debugInstrRef:   true

--- a/llvm/test/CodeGen/X86/peephole-test-after-add.mir
+++ b/llvm/test/CodeGen/X86/peephole-test-after-add.mir
@@ -254,7 +254,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false
@@ -379,7 +379,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false
@@ -505,7 +505,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/CodeGen/X86/zero-call-used-regs-debug-info.mir
+++ b/llvm/test/CodeGen/X86/zero-call-used-regs-debug-info.mir
@@ -90,7 +90,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 debugInstrRef:   true

--- a/llvm/test/DebugInfo/ARM/move-dbg-values-imm-test.mir
+++ b/llvm/test/DebugInfo/ARM/move-dbg-values-imm-test.mir
@@ -63,7 +63,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/test/DebugInfo/MIR/X86/instr-ref-join-def-vphi.mir
+++ b/llvm/test/DebugInfo/MIR/X86/instr-ref-join-def-vphi.mir
@@ -124,7 +124,7 @@ tracksRegLiveness: true
 hasWinCFI:       true
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/DebugInfo/X86/instr-ref-track-clobbers.mir
+++ b/llvm/test/DebugInfo/X86/instr-ref-track-clobbers.mir
@@ -85,7 +85,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/MachineVerifier/verify-inlineasmbr.mir
+++ b/llvm/test/MachineVerifier/verify-inlineasmbr.mir
@@ -68,7 +68,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/tools/UpdateTestChecks/update_mir_test_checks/Inputs/x86-MIFlags.mir
+++ b/llvm/test/tools/UpdateTestChecks/update_mir_test_checks/Inputs/x86-MIFlags.mir
@@ -21,7 +21,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/tools/UpdateTestChecks/update_mir_test_checks/Inputs/x86-MIFlags.mir.expected
+++ b/llvm/test/tools/UpdateTestChecks/update_mir_test_checks/Inputs/x86-MIFlags.mir.expected
@@ -22,7 +22,7 @@ tracksRegLiveness: true
 hasWinCFI:       false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 failsVerification: false

--- a/llvm/test/tools/llvm-reduce/mir/preserve-func-info.mir
+++ b/llvm/test/tools/llvm-reduce/mir/preserve-func-info.mir
@@ -20,7 +20,7 @@
 # RESULT-NEXT: hasFakeUses: true
 # RESULT-NEXT: callsEHReturn: true
 # RESULT-NEXT: callsUnwindInit: true
-# RESULT-NEXT: hasEHCatchret: true
+# RESULT-NEXT: hasEHContTarget: true
 # RESULT-NEXT: hasEHScopes: true
 # RESULT-NEXT: hasEHFunclets: true
 # RESULT-NEXT: failsVerification: true
@@ -53,7 +53,7 @@ failsVerification: true
 tracksDebugUserValues: true
 callsEHReturn: true
 callsUnwindInit: true
-hasEHCatchret: true
+hasEHContTarget: true
 hasEHScopes: true
 hasEHFunclets: true
 

--- a/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
+++ b/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
@@ -267,7 +267,7 @@ static std::unique_ptr<MachineFunction> cloneMF(MachineFunction *SrcMF,
 
     DstMBB->setIsEHPad(SrcMBB.isEHPad());
     DstMBB->setIsEHScopeEntry(SrcMBB.isEHScopeEntry());
-    DstMBB->setIsEHCatchretTarget(SrcMBB.isEHCatchretTarget());
+    DstMBB->setIsEHContTarget(SrcMBB.isEHContTarget());
     DstMBB->setIsEHFuncletEntry(SrcMBB.isEHFuncletEntry());
 
     // FIXME: These are not serialized
@@ -394,13 +394,12 @@ static std::unique_ptr<MachineFunction> cloneMF(MachineFunction *SrcMF,
   DstMF->getProperties().reset().set(SrcMF->getProperties());
 
   if (!SrcMF->getFrameInstructions().empty() ||
-      !SrcMF->getLongjmpTargets().empty() ||
-      !SrcMF->getCatchretTargets().empty())
+      !SrcMF->getLongjmpTargets().empty() || !SrcMF->getEHContTargets().empty())
     report_fatal_error("cloning not implemented for machine function property");
 
   DstMF->setCallsEHReturn(SrcMF->callsEHReturn());
   DstMF->setCallsUnwindInit(SrcMF->callsUnwindInit());
-  DstMF->setHasEHCatchret(SrcMF->hasEHCatchret());
+  DstMF->setHasEHContTarget(SrcMF->hasEHContTarget());
   DstMF->setHasEHScopes(SrcMF->hasEHScopes());
   DstMF->setHasEHFunclets(SrcMF->hasEHFunclets());
   DstMF->setHasFakeUses(SrcMF->hasFakeUses());

--- a/llvm/unittests/CodeGen/DroppedVariableStatsMIRTest.cpp
+++ b/llvm/unittests/CodeGen/DroppedVariableStatsMIRTest.cpp
@@ -126,7 +126,7 @@ noVRegs:         false
 hasFakeUses:     false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false
@@ -275,7 +275,7 @@ noVRegs:         false
 hasFakeUses:     false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false
@@ -418,7 +418,7 @@ noVRegs:         false
 hasFakeUses:     false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false
@@ -561,7 +561,7 @@ noVRegs:         false
 hasFakeUses:     false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false
@@ -706,7 +706,7 @@ noVRegs:         false
 hasFakeUses:     false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false
@@ -851,7 +851,7 @@ noVRegs:         false
 hasFakeUses:     false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false
@@ -997,7 +997,7 @@ noVRegs:         false
 hasFakeUses:     false
 callsEHReturn:   false
 callsUnwindInit: false
-hasEHCatchret:   false
+hasEHContTarget: false
 hasEHScopes:     false
 hasEHFunclets:   false
 isOutlined:      false

--- a/llvm/utils/gn/secondary/llvm/lib/CodeGen/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/lib/CodeGen/BUILD.gn
@@ -52,7 +52,7 @@ static_library("CodeGen") {
     "DetectDeadLanes.cpp",
     "DroppedVariableStatsMIR.cpp",
     "DwarfEHPrepare.cpp",
-    "EHContGuardCatchret.cpp",
+    "EHContGuardTargets.cpp",
     "EarlyIfConversion.cpp",
     "EdgeBundles.cpp",
     "ExecutionDomainFix.cpp",


### PR DESCRIPTION
This change splits out the renaming and comment updates from #129612 as a non-functional change.