### PR TITLE
[mlir][tosa] Update ConstOp to use Tosa_Tensor

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TosaOps.td
@@ -2359,7 +2359,7 @@ def Tosa_ConstOp : Tosa_Op<"const", [ConstantLike, Pure,
   );
 
   let results = (outs
-    TosaTensorOf<[AnyTypeOf<[Tosa_AnyNumber]>]>:$output
+    Tosa_Tensor:$output
   );
 
   list<Availability> availability = [


### PR DESCRIPTION
Since we already defined Tosa_Tensor in TosaTypesBase.td, updated ConstOp to use that.
