### PR TITLE
[DebugInfo] Preserve line and column number when merging debug info.

### DIFF
--- a/llvm/docs/HowToUpdateDebugInfo.rst
+++ b/llvm/docs/HowToUpdateDebugInfo.rst
@@ -90,14 +90,14 @@ has a location with an accurate scope attached, and b) to prevent misleading
 single-stepping (or breakpoint) behavior. Often, merged instructions are memory
 accesses which can trap: having an accurate scope attached greatly assists in
 crash triage by identifying the (possibly inlined) function where the bad
-memory access occurred. 
+memory access occurred.
 
-For SamplePGO, it is often beneficial to retain an arbitrary but deterministic
-location instead of discarding line and column information as part of merging.
-In particular, loss of location information for calls inhibit optimizations 
-such as indirect call promotion. This behavior can be optionally enabled until
-support for accurately representing merged instructions in the line table is
-implemented. 
+To maintain distinct source locations for SamplePGO, it is often beneficial to
+retain an arbitrary but deterministic location instead of discarding line and
+column information as part of merging. In particular, loss of location
+information for calls inhibit optimizations such as indirect call promotion.
+This behavior can be optionally enabled until support for accurately
+representing merged instructions in the line table is implemented.
 
 Examples of transformations that should follow this rule include:
 

--- a/llvm/docs/HowToUpdateDebugInfo.rst
+++ b/llvm/docs/HowToUpdateDebugInfo.rst
@@ -9,7 +9,8 @@ Introduction
 ============
 
 Certain kinds of code transformations can inadvertently result in a loss of
-debug info, or worse, make debug info misrepresent the state of a program.
+debug info, or worse, make debug info misrepresent the state of a program. Debug
+info availability is also essential for SamplePGO.
 
 This document specifies how to correctly update debug info in various kinds of
 code transformations, and offers suggestions for how to create targeted debug
@@ -89,9 +90,14 @@ has a location with an accurate scope attached, and b) to prevent misleading
 single-stepping (or breakpoint) behavior. Often, merged instructions are memory
 accesses which can trap: having an accurate scope attached greatly assists in
 crash triage by identifying the (possibly inlined) function where the bad
-memory access occurred. This rule is also meant to assist SamplePGO by banning
-scenarios in which a sample of a block containing a merged instruction is
-misattributed to a block containing one of the instructions-to-be-merged.
+memory access occurred. 
+
+For SamplePGO, it is often beneficial to retain an arbitrary but deterministic
+location instead of discarding line and column information as part of merging.
+In particular, loss of location information for calls inhibit optimizations 
+such as indirect call promotion. This behavior can be optionally enabled until
+support for accurately representing merged instructions in the line table is
+implemented. 
 
 Examples of transformations that should follow this rule include:
 

--- a/llvm/docs/SourceLevelDebugging.rst
+++ b/llvm/docs/SourceLevelDebugging.rst
@@ -77,7 +77,12 @@ SamplePGO (also known as `AutoFDO <https://gcc.gnu.org/wiki/AutoFDO>`_)
 is a variant of profile guided optimizations which uses hardware sampling based
 profilers to collect branch frequency data with low overhead in production
 environments. It relies on debug information to associate profile information
-to LLVM IR which is then used to guide optimization heuristics.
+to LLVM IR which is then used to guide optimization heuristics. Maintaining
+deterministic and distinct source locations is necessary to maximize the
+accuracy of mapping hardware sample counts to LLVM IR. For example, DWARF
+`discriminators <https://wiki.dwarfstd.org/Path_Discriminators.md>`_ allow
+SamplePGO to distinguish between multiple paths of execution which map to the
+same source line.
 
 It would also be reasonable to use debug information to feed profiling tools
 for analysis of generated code, or, tools for reconstructing the original

--- a/llvm/docs/SourceLevelDebugging.rst
+++ b/llvm/docs/SourceLevelDebugging.rst
@@ -75,7 +75,7 @@ debug info formats such as STABS.
 
 SamplePGO (also known as `AutoFDO <https://gcc.gnu.org/wiki/AutoFDO>`_)
 is a variant of profile guided optimizations which uses hardware sampling based
-profilers to collect branch frequency data to with low overhead in production
+profilers to collect branch frequency data with low overhead in production
 environments. It relies on debug information to associate profile information
 to LLVM IR which is then used to guide optimization heuristics.
 

--- a/llvm/docs/SourceLevelDebugging.rst
+++ b/llvm/docs/SourceLevelDebugging.rst
@@ -55,6 +55,8 @@ the stored debug information into source-language specific information.  As
 such, a debugger must be aware of the source-language, and is thus tied to a
 specific language or family of languages.
 
+.. _intro_consumers:
+
 Debug information consumers
 ---------------------------
 
@@ -70,6 +72,12 @@ the Microsoft debug info format, which is usable with Microsoft debuggers such
 as Visual Studio and WinDBG. LLVM's debug information format is mostly derived
 from and inspired by DWARF, but it is feasible to translate into other target
 debug info formats such as STABS.
+
+SamplePGO (also known as `AutoFDO <https://gcc.gnu.org/wiki/AutoFDO>`_)
+is a variant of profile guided optimizations which uses hardware sampling based
+profilers to collect branch frequency data to with low overhead in production
+environments. It relies on debug information to associate profile information
+to LLVM IR which is then used to guide optimization heuristics.
 
 It would also be reasonable to use debug information to feed profiling tools
 for analysis of generated code, or, tools for reconstructing the original

--- a/llvm/lib/IR/DebugInfoMetadata.cpp
+++ b/llvm/lib/IR/DebugInfoMetadata.cpp
@@ -138,12 +138,10 @@ DILocation *DILocation::getMergedLocation(DILocation *LocA, DILocation *LocB) {
   // not useful for PGO.
   if (PickMergedSourceLocations) {
     auto A = std::make_tuple(LocA->getLine(), LocA->getColumn(),
-                             LocA->getDiscriminator(),
-                             LocA->getFilename(),
+                             LocA->getDiscriminator(), LocA->getFilename(),
                              LocA->getDirectory());
     auto B = std::make_tuple(LocB->getLine(), LocB->getColumn(),
-                             LocB->getDiscriminator(),
-                             LocB->getFilename(),
+                             LocB->getDiscriminator(), LocB->getFilename(),
                              LocB->getDirectory());
     return A < B ? LocA : LocB;
   }

--- a/llvm/test/DebugInfo/pick-merged-source-locations.ll
+++ b/llvm/test/DebugInfo/pick-merged-source-locations.ll
@@ -1,19 +1,19 @@
 ;; This test verifies that we assign a deterministic location for merged
-;; instructions when -preserve-merged-debug-info is enabled. We use the
+;; instructions when -pick-merged-source-locations is enabled. We use the
 ;; simplifycfg pass to test this behaviour since it was a common source of
 ;; merged instructions, however we intend this to apply to all users of the
 ;; getMergedLocation API.
 
 ;; Run simplifycfg and check that only 1 call to bar remains and it's debug
 ;; location has a valid line number (lexicographically smallest).
-; RUN: opt %s -passes=simplifycfg -hoist-common-insts -preserve-merged-debug-info -S | FileCheck %s --check-prefix=ENABLED
+; RUN: opt %s -passes=simplifycfg -hoist-common-insts -pick-merged-source-locations -S | FileCheck %s --check-prefix=ENABLED
 ; ENABLED: call i32 @bar{{.*!dbg !}}[[TAG:[0-9]+]]
 ; ENABLED-NOT: call i32 @bar
 ; ENABLED: ![[TAG]] = !DILocation(line: 9, column: 16, scope: !9)
 
 ;; Run simplifycfg without the pass to ensure that we don't spuriously start
 ;; passing the test if simplifycfg behaviour changes.
-; RUN: opt %s -passes=simplifycfg -hoist-common-insts -preserve-merged-debug-info=false -S | FileCheck %s --check-prefix=DISABLED
+; RUN: opt %s -passes=simplifycfg -hoist-common-insts -pick-merged-source-locations=false -S | FileCheck %s --check-prefix=DISABLED
 ; DISABLED: call i32 @bar{{.*!dbg !}}[[TAG:[0-9]+]]
 ; DISABLED-NOT: call i32 @bar
 ; DISABLED: ![[TAG]] = !DILocation(line: 0, scope: !9)

--- a/llvm/test/DebugInfo/preserve-merged-debug-info.ll
+++ b/llvm/test/DebugInfo/preserve-merged-debug-info.ll
@@ -1,0 +1,65 @@
+; RUN: opt %s -passes=simplifycfg -hoist-common-insts -preserve-merged-debug-info -S | FileCheck %s
+; CHECK: tail call i32 @bar{{.*!dbg !}}[[TAG:[0-9]+]]
+; CHECK: ![[TAG]] = !DILocation(line: 9, column: 16, scope: !9) 
+
+; ModuleID = '../llvm/test/DebugInfo/Inputs/debug-info-merge-call.c'
+source_filename = "../llvm/test/DebugInfo/Inputs/debug-info-merge-call.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
+; Function Attrs: nounwind uwtable
+define dso_local i32 @test(i32 noundef %n) local_unnamed_addr #0 !dbg !9 {
+entry:
+  %call = tail call i32 @foo(i32 noundef %n) #2, !dbg !12
+  %cmp1 = icmp sgt i32 %n, 100, !dbg !13
+  br i1 %cmp1, label %if.then, label %if.else, !dbg !13
+
+if.then:                                          ; preds = %entry
+  %call2 = tail call i32 @bar(i32 noundef %n) #2, !dbg !14
+  %add = add nsw i32 %call2, %call, !dbg !15
+  br label %if.end, !dbg !16
+
+if.else:                                          ; preds = %entry
+  %call4 = tail call i32 @bar(i32 noundef %n) #2, !dbg !17
+  br label %if.end
+
+if.end:                                           ; preds = %if.else, %if.then
+  %r.0 = phi i32 [ %add, %if.then ], [ %call4, %if.else ], !dbg !18
+  ret i32 %r.0, !dbg !19
+}
+
+declare !dbg !20 i32 @foo(i32 noundef) local_unnamed_addr #1
+
+declare !dbg !21 i32 @bar(i32 noundef) local_unnamed_addr #1
+
+attributes #0 = { nounwind uwtable "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #1 = { "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" }
+attributes #2 = { nounwind }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7}
+!llvm.ident = !{!8}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang version 21.0.0git (git@github.com:snehasish/llvm-project.git 6ce41db6b0275d060d6e60f88b96a1657024345c)", isOptimized: true, runtimeVersion: 0, emissionKind: LineTablesOnly, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "../llvm/test/DebugInfo/Inputs/debug-info-merge-call.c", directory: "/usr/local/google/home/snehasishk/working/llvm-project/build-assert", checksumkind: CSK_MD5, checksum: "ac1be6c40dad11691922d600f9d55c55")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 8, !"PIC Level", i32 2}
+!6 = !{i32 7, !"PIE Level", i32 2}
+!7 = !{i32 7, !"uwtable", i32 2}
+!8 = !{!"clang version 21.0.0git (git@github.com:snehasish/llvm-project.git 6ce41db6b0275d060d6e60f88b96a1657024345c)"}
+!9 = distinct !DISubprogram(name: "test", scope: !1, file: !1, line: 5, type: !10, scopeLine: 5, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
+!10 = !DISubroutineType(types: !11)
+!11 = !{}
+!12 = !DILocation(line: 7, column: 13, scope: !9)
+!13 = !DILocation(line: 8, column: 8, scope: !9)
+!14 = !DILocation(line: 9, column: 16, scope: !9)
+!15 = !DILocation(line: 9, column: 14, scope: !9)
+!16 = !DILocation(line: 10, column: 3, scope: !9)
+!17 = !DILocation(line: 11, column: 10, scope: !9)
+!18 = !DILocation(line: 0, scope: !9)
+!19 = !DILocation(line: 13, column: 3, scope: !9)
+!20 = !DISubprogram(name: "foo", scope: !1, file: !1, line: 2, type: !10, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
+!21 = !DISubprogram(name: "bar", scope: !1, file: !1, line: 1, type: !10, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
+


### PR DESCRIPTION
This patch introduces a new option `-preserve-merged-debug-info` to preserve an arbitrary but deterministic version of debug information when DILocations are merged. This is intended to be used in production environments from which sample based profiles are derived such as AutoFDO and MemProf.

With this patch we have see a 0.2% improvement on an internal workload at Google when generating AutoFDO profiles. It also significantly improves the ability for MemProf by preserving debug info for merged call instructions used in the contextual profile.