### PR TITLE
[lldb-dap] Restore the override FD used by the output redirect on stop.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/io/TestDAP_io.py
+++ b/lldb/test/API/tools/lldb-dap/io/TestDAP_io.py
@@ -18,18 +18,19 @@ class TestDAP_io(lldbdap_testcase.DAPTestCaseBase):
             # If the process is still alive, terminate it.
             if process.poll() is None:
                 process.terminate()
-                stdout_data = process.stdout.read()
-                stderr_data = process.stderr.read()
-                print("========= STDOUT =========")
-                print(stdout_data)
-                print("========= END =========")
-                print("========= STDERR =========")
-                print(stderr_data)
-                print("========= END =========")
-                print("========= DEBUG ADAPTER PROTOCOL LOGS =========")
-                with open(log_file_path, "r") as file:
-                    print(file.read())
-                print("========= END =========")
+                process.wait()
+            stdout_data = process.stdout.read()
+            stderr_data = process.stderr.read()
+            print("========= STDOUT =========")
+            print(stdout_data)
+            print("========= END =========")
+            print("========= STDERR =========")
+            print(stderr_data)
+            print("========= END =========")
+            print("========= DEBUG ADAPTER PROTOCOL LOGS =========")
+            with open(log_file_path, "r") as file:
+                print(file.read())
+            print("========= END =========")
 
         # Execute the cleanup function during test case tear down.
         self.addTearDownHook(cleanup)

--- a/lldb/tools/lldb-dap/OutputRedirector.cpp
+++ b/lldb/tools/lldb-dap/OutputRedirector.cpp
@@ -38,7 +38,7 @@ Expected<int> OutputRedirector::GetWriteFileDescriptor() {
   return m_fd;
 }
 
-Error OutputRedirector::RedirectTo(std::FILE *override,
+Error OutputRedirector::RedirectTo(std::FILE *file_override,
                                    std::function<void(StringRef)> callback) {
   assert(m_fd == kInvalidDescriptor && "Output readirector already started.");
   int new_fd[2];

--- a/lldb/tools/lldb-dap/OutputRedirector.cpp
+++ b/lldb/tools/lldb-dap/OutputRedirector.cpp
@@ -27,7 +27,9 @@ namespace lldb_dap {
 
 int OutputRedirector::kInvalidDescriptor = -1;
 
-OutputRedirector::OutputRedirector() : m_fd(kInvalidDescriptor) {}
+OutputRedirector::OutputRedirector()
+    : m_fd(kInvalidDescriptor), m_original_fd(kInvalidDescriptor),
+      m_restore_fd(kInvalidDescriptor) {}
 
 Expected<int> OutputRedirector::GetWriteFileDescriptor() {
   if (m_fd == kInvalidDescriptor)
@@ -36,7 +38,8 @@ Expected<int> OutputRedirector::GetWriteFileDescriptor() {
   return m_fd;
 }
 
-Error OutputRedirector::RedirectTo(std::function<void(StringRef)> callback) {
+Error OutputRedirector::RedirectTo(std::FILE *override,
+                                   std::function<void(StringRef)> callback) {
   assert(m_fd == kInvalidDescriptor && "Output readirector already started.");
   int new_fd[2];
 
@@ -52,6 +55,19 @@ Error OutputRedirector::RedirectTo(std::function<void(StringRef)> callback) {
 
   int read_fd = new_fd[0];
   m_fd = new_fd[1];
+
+  if (override) {
+    int override_fd = fileno(override);
+
+    // Backup the FD to restore once redirection is complete.
+    m_original_fd = override_fd;
+    m_restore_fd = dup(override_fd);
+
+    // Override the existing fd the new write end of the pipe.
+    if (::dup2(m_fd, override_fd) == -1)
+      return llvm::errorCodeToError(llvm::errnoAsErrorCode());
+  }
+
   m_forwarder = std::thread([this, callback, read_fd]() {
     char buffer[OutputBufferSize];
     while (!m_stopped) {
@@ -92,6 +108,17 @@ void OutputRedirector::Stop() {
     (void)::write(fd, kCloseSentinel.data(), kCloseSentinel.size());
     ::close(fd);
     m_forwarder.join();
+
+    // Restore the fd back to its original state since we stopped the
+    // redirection.
+    if (m_restore_fd != kInvalidDescriptor &&
+        m_original_fd != kInvalidDescriptor) {
+      int restore_fd = m_restore_fd;
+      m_restore_fd = kInvalidDescriptor;
+      int original_fd = m_original_fd;
+      m_original_fd = kInvalidDescriptor;
+      ::dup2(restore_fd, original_fd);
+    }
   }
 }
 

--- a/lldb/tools/lldb-dap/OutputRedirector.h
+++ b/lldb/tools/lldb-dap/OutputRedirector.h
@@ -27,7 +27,8 @@ public:
   /// \return
   ///     \a Error::success if the redirection was set up correctly, or an error
   ///     otherwise.
-  llvm::Error RedirectTo(std::function<void(llvm::StringRef)> callback);
+  llvm::Error RedirectTo(std::FILE *overrideFile,
+                         std::function<void(llvm::StringRef)> callback);
 
   llvm::Expected<int> GetWriteFileDescriptor();
   void Stop();
@@ -41,6 +42,8 @@ public:
 private:
   std::atomic<bool> m_stopped = false;
   int m_fd;
+  int m_original_fd;
+  int m_restore_fd;
   std::thread m_forwarder;
 };
 


### PR DESCRIPTION
While running lldb-dap over stdin/stdout the `stdout` and `stderr` FD's are replaced with a pipe that is reading the output to forward to the dap client. During shutdown we were not properly restoring those FDs, which means if any component attempted to write to stderr it would trigger a SIGPIPE due to the pipe being closed during the shutdown process. This can happen if we have an error reported from the `DAP::Loop` call that would then log to stderr, such as an error parsing a malformed DAP message or if lldb-dap crashed and it was trying to write the stack trace to stderr.

There is one place we were not handling an `llvm::Error` if there was no logging setup that could trigger this condition.

To address this, I updated the OutputRedirector to restore the FD to the prior state when `Stop` is called.