### PR TITLE
[libc][bazel] Add targets for float16 math

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2294,6 +2294,26 @@ libc_math_function(name = "canonicalizef128")
 
 libc_math_function(name = "canonicalizef16")
 
+libc_math_function(name = "iscanonical")
+
+libc_math_function(name = "iscanonicalf")
+
+libc_math_function(name = "iscanonicall")
+
+libc_math_function(name = "iscanonicalf128")
+
+libc_math_function(name = "iscanonicalf16")
+
+libc_math_function(name = "issignaling")
+
+libc_math_function(name = "issignalingf")
+
+libc_math_function(name = "issignalingl")
+
+libc_math_function(name = "issignalingf128")
+
+libc_math_function(name = "issignalingf16")
+
 libc_math_function(
     name = "cbrt",
     additional_deps = [
@@ -2349,6 +2369,15 @@ libc_math_function(
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
         ":sincosf_utils",
+    ],
+)
+
+libc_math_function(
+    name = "cosf16",
+    additional_deps = [
+        ":__support_fputil_multiply_add",
+        ":__support_macros_optimization",
+        ":sincosf16_utils",
     ],
 )
 
@@ -3446,6 +3475,15 @@ libc_math_function(
 )
 
 libc_math_function(
+    name = "sinf16",
+    additional_deps = [
+        ":__support_fputil_nearest_integer",
+        ":__support_fputil_polyeval",
+        ":sincosf16_utils",
+    ],
+)
+
+libc_math_function(
     name = "sincos",
     additional_deps = [
         ":__support_fputil_multiply_add",
@@ -3566,6 +3604,15 @@ libc_math_function(
 )
 
 libc_math_function(
+    name = "tanf16",
+    additional_deps = [
+        ":__support_fputil_nearest_integer",
+        ":__support_fputil_polyeval",
+        ":sincosf16_utils",
+    ],
+)
+
+libc_math_function(
     name = "tanhf",
     additional_deps = [
         ":__support_fputil_fma",
@@ -3584,6 +3631,17 @@ libc_math_function(
     name = "tanhf16",
     additional_deps = [
         ":expxf16",
+    ],
+)
+
+libc_math_function(
+    name = "tanpif16",
+    additional_deps = [
+        ":sincosf16_utils",
+        ":hdr_errno_macros",
+        ":hdr_fenv_macros",
+        ":__support_fputil_cast",
+        ":__support_fputil_multiply_add",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -58,6 +58,19 @@ math_test(
     ],
 )
 
+math_test(
+    name = "canonicalizef16",
+    hdrs = ["CanonicalizeTest.h"],
+    deps = [
+        "//libc:__support_integer_literals",
+    ],
+)
+
+math_test(
+    name = "iscanonicalf16",
+    hdrs = ["IsCanonicalTest.h"],
+)
+
 math_test(name = "cbrt")
 
 math_test(name = "cbrtf")
@@ -83,6 +96,11 @@ math_test(
 )
 
 math_test(
+    name = "ceilf16",
+    hdrs = ["CeilTest.h"],
+)
+
+math_test(
     name = "copysign",
     hdrs = ["CopySignTest.h"],
 )
@@ -99,6 +117,11 @@ math_test(
 
 math_test(
     name = "copysignf128",
+    hdrs = ["CopySignTest.h"],
+)
+
+math_test(
+    name = "copysignf16",
     hdrs = ["CopySignTest.h"],
 )
 
@@ -126,12 +149,42 @@ math_test(
 )
 
 math_test(
+    name = "f16add",
+    hdrs = ["AddTest.h"],
+)
+
+math_test(
+    name = "f16addf",
+    hdrs = ["AddTest.h"],
+)
+
+math_test(
+    name = "f16addl",
+    hdrs = ["AddTest.h"],
+)
+
+math_test(
     name = "ddivl",
     hdrs = ["DivTest.h"],
 )
 
 math_test(
     name = "ddivf128",
+    hdrs = ["DivTest.h"],
+)
+
+math_test(
+    name = "f16div",
+    hdrs = ["DivTest.h"],
+)
+
+math_test(
+    name = "f16divf",
+    hdrs = ["DivTest.h"],
+)
+
+math_test(
+    name = "f16divl",
     hdrs = ["DivTest.h"],
 )
 
@@ -146,6 +199,21 @@ math_test(
 )
 
 math_test(
+    name = "f16fma",
+    hdrs = ["FmaTest.h"],
+)
+
+math_test(
+    name = "f16fmaf",
+    hdrs = ["FmaTest.h"],
+)
+
+math_test(
+    name = "f16fmal",
+    hdrs = ["FmaTest.h"],
+)
+
+math_test(
     name = "dmull",
     hdrs = ["MulTest.h"],
 )
@@ -153,6 +221,36 @@ math_test(
 math_test(
     name = "dmulf128",
     hdrs = ["MulTest.h"],
+)
+
+math_test(
+    name = "f16mul",
+    hdrs = ["MulTest.h"],
+)
+
+math_test(
+    name = "f16mulf",
+    hdrs = ["MulTest.h"],
+)
+
+math_test(
+    name = "f16mull",
+    hdrs = ["MulTest.h"],
+)
+
+math_test(
+    name = "fsqrt",
+    hdrs = ["SqrtTest.h"],
+)
+
+math_test(
+    name = "fsqrtl",
+    hdrs = ["SqrtTest.h"],
+)
+
+math_test(
+    name = "fsqrtf128",
+    hdrs = ["SqrtTest.h"],
 )
 
 math_test(
@@ -166,12 +264,67 @@ math_test(
 )
 
 math_test(
+    name = "sqrt",
+    hdrs = ["SqrtTest.h"],
+)
+
+math_test(
+    name = "sqrtf",
+    hdrs = ["SqrtTest.h"],
+)
+
+math_test(
+    name = "sqrtl",
+    hdrs = ["SqrtTest.h"],
+)
+
+math_test(
+    name = "sqrtf128",
+    hdrs = ["SqrtTest.h"],
+)
+
+math_test(
+    name = "f16sqrt",
+    hdrs = ["SqrtTest.h"],
+)
+
+math_test(
+    name = "f16sqrtf",
+    hdrs = ["SqrtTest.h"],
+)
+
+math_test(
+    name = "sqrtf16",
+    hdrs = ["SqrtTest.h"],
+)
+
+math_test(
+    name = "f16sqrtl",
+    hdrs = ["SqrtTest.h"],
+)
+
+math_test(
     name = "dsubl",
     hdrs = ["SubTest.h"],
 )
 
 math_test(
     name = "dsubf128",
+    hdrs = ["SubTest.h"],
+)
+
+math_test(
+    name = "f16sub",
+    hdrs = ["SubTest.h"],
+)
+
+math_test(
+    name = "f16subf",
+    hdrs = ["SubTest.h"],
+)
+
+math_test(
+    name = "f16subl",
     hdrs = ["SubTest.h"],
 )
 
@@ -216,6 +369,11 @@ math_test(
 )
 
 math_test(
+    name = "fabsf16",
+    hdrs = ["FAbsTest.h"],
+)
+
+math_test(
     name = "fadd",
     hdrs = ["AddTest.h"],
 )
@@ -247,6 +405,11 @@ math_test(
 
 math_test(
     name = "fdimf128",
+    hdrs = ["FDimTest.h"],
+)
+
+math_test(
+    name = "fdimf16",
     hdrs = ["FDimTest.h"],
 )
 
@@ -300,6 +463,11 @@ math_test(
     hdrs = ["FloorTest.h"],
 )
 
+math_test(
+    name = "floorf16",
+    hdrs = ["FloorTest.h"],
+)
+
 # TODO: Add fma, fmaf, fmal, fmaf128 tests.
 
 math_test(
@@ -319,6 +487,11 @@ math_test(
 
 math_test(
     name = "fmaxf128",
+    hdrs = ["FMaxTest.h"],
+)
+
+math_test(
+    name = "fmaxf16",
     hdrs = ["FMaxTest.h"],
 )
 
@@ -403,6 +576,26 @@ math_test(
 )
 
 math_test(
+    name = "fmaximum_mag_numf16",
+    hdrs = ["FMaximumMagNumTest.h"],
+)
+
+math_test(
+    name = "fmaximum_magf16",
+    hdrs = ["FMaximumMagTest.h"],
+)
+
+math_test(
+    name = "fmaximum_numf16",
+    hdrs = ["FMaximumNumTest.h"],
+)
+
+math_test(
+    name = "fmaximumf16",
+    hdrs = ["FMaximumTest.h"],
+)
+
+math_test(
     name = "fmin",
     hdrs = ["FMinTest.h"],
 )
@@ -419,6 +612,11 @@ math_test(
 
 math_test(
     name = "fminf128",
+    hdrs = ["FMinTest.h"],
+)
+
+math_test(
+    name = "fminf16",
     hdrs = ["FMinTest.h"],
 )
 
@@ -463,6 +661,11 @@ math_test(
 )
 
 math_test(
+    name = "fminimum_magf16",
+    hdrs = ["FMinimumMagTest.h"],
+)
+
+math_test(
     name = "fminimum_mag_num",
     hdrs = ["FMinimumMagNumTest.h"],
 )
@@ -479,6 +682,11 @@ math_test(
 
 math_test(
     name = "fminimum_mag_numf128",
+    hdrs = ["FMinimumMagNumTest.h"],
+)
+
+math_test(
+    name = "fminimum_mag_numf16",
     hdrs = ["FMinimumMagNumTest.h"],
 )
 
@@ -503,6 +711,16 @@ math_test(
 )
 
 math_test(
+    name = "fminimum_numf16",
+    hdrs = ["FMinimumNumTest.h"],
+)
+
+math_test(
+    name = "fminimumf16",
+    hdrs = ["FMinimumTest.h"],
+)
+
+math_test(
     name = "fmod",
     hdrs = ["FModTest.h"],
 )
@@ -519,6 +737,11 @@ math_test(
 
 math_test(
     name = "fmodf128",
+    hdrs = ["FModTest.h"],
+)
+
+math_test(
+    name = "fmodf16",
     hdrs = ["FModTest.h"],
 )
 
@@ -558,6 +781,11 @@ math_test(
 )
 
 math_test(
+    name = "frexpf16",
+    hdrs = ["FrexpTest.h"],
+)
+
+math_test(
     name = "fromfp",
     hdrs = ["FromfpTest.h"],
 )
@@ -574,6 +802,11 @@ math_test(
 
 math_test(
     name = "fromfpf128",
+    hdrs = ["FromfpTest.h"],
+)
+
+math_test(
+    name = "fromfpf16",
     hdrs = ["FromfpTest.h"],
 )
 
@@ -598,18 +831,8 @@ math_test(
 )
 
 math_test(
-    name = "fsqrt",
-    hdrs = ["SqrtTest.h"],
-)
-
-math_test(
-    name = "fsqrtl",
-    hdrs = ["SqrtTest.h"],
-)
-
-math_test(
-    name = "fsqrtf128",
-    hdrs = ["SqrtTest.h"],
+    name = "fromfpxf16",
+    hdrs = ["FromfpxTest.h"],
 )
 
 math_test(
@@ -644,6 +867,11 @@ math_test(
 
 math_test(
     name = "getpayloadf128",
+    hdrs = ["GetPayloadTest.h"],
+)
+
+math_test(
+    name = "getpayloadf16",
     hdrs = ["GetPayloadTest.h"],
 )
 
@@ -698,6 +926,11 @@ math_test(
 )
 
 math_test(
+    name = "ldexpf16",
+    hdrs = ["LdExpTest.h"],
+)
+
+math_test(
     name = "llogb",
     hdrs = ["ILogbTest.h"],
 )
@@ -714,6 +947,16 @@ math_test(
 
 math_test(
     name = "llogbf128",
+    hdrs = ["ILogbTest.h"],
+)
+
+math_test(
+    name = "ilogbf16",
+    hdrs = ["ILogbTest.h"],
+)
+
+math_test(
+    name = "llogbf16",
     hdrs = ["ILogbTest.h"],
 )
 
@@ -738,6 +981,16 @@ math_test(
 )
 
 math_test(
+    name = "llrintf16",
+    hdrs = ["RoundToIntegerTest.h"],
+)
+
+math_test(
+    name = "lrintf16",
+    hdrs = ["RoundToIntegerTest.h"],
+)
+
+math_test(
     name = "llround",
     hdrs = ["RoundToIntegerTest.h"],
 )
@@ -754,6 +1007,16 @@ math_test(
 
 math_test(
     name = "llroundf128",
+    hdrs = ["RoundToIntegerTest.h"],
+)
+
+math_test(
+    name = "llroundf16",
+    hdrs = ["RoundToIntegerTest.h"],
+)
+
+math_test(
+    name = "lroundf16",
     hdrs = ["RoundToIntegerTest.h"],
 )
 
@@ -790,6 +1053,11 @@ math_test(
 
 math_test(
     name = "logbf128",
+    hdrs = ["LogbTest.h"],
+)
+
+math_test(
+    name = "logbf16",
     hdrs = ["LogbTest.h"],
 )
 
@@ -853,6 +1121,11 @@ math_test(
     hdrs = ["ModfTest.h"],
 )
 
+math_test(
+    name = "modff16",
+    hdrs = ["ModfTest.h"],
+)
+
 # TODO: add nan tests.
 
 math_test(
@@ -872,6 +1145,11 @@ math_test(
 
 math_test(
     name = "nearbyintf128",
+    hdrs = ["NearbyIntTest.h"],
+)
+
+math_test(
+    name = "nearbyintf16",
     hdrs = ["NearbyIntTest.h"],
 )
 
@@ -896,6 +1174,11 @@ math_test(
 )
 
 math_test(
+    name = "nextafterf16",
+    hdrs = ["NextAfterTest.h"],
+)
+
+math_test(
     name = "nextdown",
     hdrs = ["NextDownTest.h"],
 )
@@ -916,6 +1199,11 @@ math_test(
 )
 
 math_test(
+    name = "nextdownf16",
+    hdrs = ["NextDownTest.h"],
+)
+
+math_test(
     name = "nexttoward",
     hdrs = ["NextTowardTest.h"],
 )
@@ -927,6 +1215,11 @@ math_test(
 
 math_test(
     name = "nexttowardl",
+    hdrs = ["NextTowardTest.h"],
+)
+
+math_test(
+    name = "nexttowardf16",
     hdrs = ["NextTowardTest.h"],
 )
 
@@ -947,6 +1240,11 @@ math_test(
 
 math_test(
     name = "nextupf128",
+    hdrs = ["NextUpTest.h"],
+)
+
+math_test(
+    name = "nextupf16",
     hdrs = ["NextUpTest.h"],
 )
 
@@ -975,6 +1273,11 @@ math_test(
 )
 
 math_test(
+    name = "remquof16",
+    hdrs = ["RemQuoTest.h"],
+)
+
+math_test(
     name = "rint",
     hdrs = ["RIntTest.h"],
 )
@@ -991,6 +1294,11 @@ math_test(
 
 math_test(
     name = "rintf128",
+    hdrs = ["RIntTest.h"],
+)
+
+math_test(
+    name = "rintf16",
     hdrs = ["RIntTest.h"],
 )
 
@@ -1015,6 +1323,11 @@ math_test(
 )
 
 math_test(
+    name = "roundevenf16",
+    hdrs = ["RoundEvenTest.h"],
+)
+
+math_test(
     name = "round",
     hdrs = ["RoundTest.h"],
 )
@@ -1031,6 +1344,11 @@ math_test(
 
 math_test(
     name = "roundf128",
+    hdrs = ["RoundTest.h"],
+)
+
+math_test(
+    name = "roundf16",
     hdrs = ["RoundTest.h"],
 )
 
@@ -1060,6 +1378,22 @@ math_test(
 
 math_test(
     name = "scalbnf128",
+    hdrs = [
+        "LdExpTest.h",
+        "ScalbnTest.h",
+    ],
+)
+
+math_test(
+    name = "scalblnf16",
+    hdrs = [
+        "LdExpTest.h",
+        "ScalbnTest.h",
+    ],
+)
+
+math_test(
+    name = "scalbnf16",
     hdrs = [
         "LdExpTest.h",
         "ScalbnTest.h",
@@ -1119,6 +1453,11 @@ math_test(
 )
 
 math_test(
+    name = "setpayloadf16",
+    hdrs = ["SetPayloadTest.h"],
+)
+
+math_test(
     name = "setpayloadsig",
     hdrs = ["SetPayloadSigTest.h"],
 )
@@ -1138,6 +1477,11 @@ math_test(
     hdrs = ["SetPayloadSigTest.h"],
 )
 
+math_test(
+    name = "setpayloadsigf16",
+    hdrs = ["SetPayloadSigTest.h"],
+)
+
 math_test(name = "sin")
 
 math_test(name = "sinf")
@@ -1154,26 +1498,6 @@ math_test(
 )
 
 math_test(name = "sinpif")
-
-math_test(
-    name = "sqrt",
-    hdrs = ["SqrtTest.h"],
-)
-
-math_test(
-    name = "sqrtf",
-    hdrs = ["SqrtTest.h"],
-)
-
-math_test(
-    name = "sqrtl",
-    hdrs = ["SqrtTest.h"],
-)
-
-math_test(
-    name = "sqrtf128",
-    hdrs = ["SqrtTest.h"],
-)
 
 math_test(name = "tan")
 
@@ -1202,6 +1526,11 @@ math_test(
 )
 
 math_test(
+    name = "totalorderf16",
+    hdrs = ["TotalOrderTest.h"],
+)
+
+math_test(
     name = "totalordermag",
     hdrs = ["TotalOrderMagTest.h"],
 )
@@ -1218,6 +1547,11 @@ math_test(
 
 math_test(
     name = "totalordermagf128",
+    hdrs = ["TotalOrderMagTest.h"],
+)
+
+math_test(
+    name = "totalordermagf16",
     hdrs = ["TotalOrderMagTest.h"],
 )
 
@@ -1242,6 +1576,11 @@ math_test(
 )
 
 math_test(
+    name = "truncf16",
+    hdrs = ["TruncTest.h"],
+)
+
+math_test(
     name = "ufromfp",
     hdrs = ["UfromfpTest.h"],
 )
@@ -1258,6 +1597,11 @@ math_test(
 
 math_test(
     name = "ufromfpf128",
+    hdrs = ["UfromfpTest.h"],
+)
+
+math_test(
+    name = "ufromfpf16",
     hdrs = ["UfromfpTest.h"],
 )
 
@@ -1280,3 +1624,59 @@ math_test(
     name = "ufromfpxf128",
     hdrs = ["UfromfpxTest.h"],
 )
+
+math_test(
+    name = "ufromfpxf16",
+    hdrs = ["UfromfpxTest.h"],
+)
+
+math_test(name = "cosf16")
+
+math_test(name = "coshf16")
+
+math_test(name = "cospif16")
+
+math_test(name = "exp10f16")
+
+math_test(name = "exp10m1f16")
+
+math_test(name = "exp2f16")
+
+math_test(name = "exp2m1f16")
+
+math_test(name = "expf16")
+
+math_test(name = "expm1f16")
+
+math_test(
+    name = "issignalingf16",
+    hdrs = ["IsSignalingTest.h"],
+)
+
+math_test(name = "log10f16")
+
+math_test(name = "log2f16")
+
+math_test(name = "logf16")
+
+math_test(
+    name = "nanf16",
+    deps = [
+        "//libc:__support_macros_sanitizer",
+        "//libc:hdr_signal_macros",
+    ],
+)
+
+# math_test(name = "remainderf16") #TODO: add remainderf16 tests
+
+math_test(name = "sinf16")
+
+math_test(name = "sinhf16")
+
+math_test(name = "sinpif16")
+
+math_test(name = "tanf16")
+
+math_test(name = "tanhf16")
+
+math_test(name = "tanpif16")


### PR DESCRIPTION
Add targets for some float16 math functions that were missing them, but
mostly add targets for the smoke tests.
