### PR TITLE
[RISCV] Remove the TODO for fmaximum/fminimum from the tests. (NFC)

### DIFF
--- a/llvm/test/CodeGen/RISCV/double-intrinsics.ll
+++ b/llvm/test/CodeGen/RISCV/double-intrinsics.ll
@@ -818,23 +818,6 @@ define double @maxnum_f64(double %a, double %b) nounwind {
   ret double %1
 }
 
-; TODO: FMINNAN and FMAXNAN aren't handled in
-; SelectionDAGLegalize::ExpandNode.
-
-; declare double @llvm.minimum.f64(double, double)
-
-; define double @fminimum_f64(double %a, double %b) nounwind {
-;   %1 = call double @llvm.minimum.f64(double %a, double %b)
-;   ret double %1
-; }
-
-; declare double @llvm.maximum.f64(double, double)
-
-; define double @fmaximum_f64(double %a, double %b) nounwind {
-;   %1 = call double @llvm.maximum.f64(double %a, double %b)
-;   ret double %1
-; }
-
 declare double @llvm.copysign.f64(double, double)
 
 define double @copysign_f64(double %a, double %b) nounwind {

--- a/llvm/test/CodeGen/RISCV/float-intrinsics.ll
+++ b/llvm/test/CodeGen/RISCV/float-intrinsics.ll
@@ -802,23 +802,6 @@ define float @maxnum_f32(float %a, float %b) nounwind {
   ret float %1
 }
 
-; TODO: FMINNAN and FMAXNAN aren't handled in
-; SelectionDAGLegalize::ExpandNode.
-
-; declare float @llvm.minimum.f32(float, float)
-
-; define float @fminimum_f32(float %a, float %b) nounwind {
-;   %1 = call float @llvm.minimum.f32(float %a, float %b)
-;   ret float %1
-; }
-
-; declare float @llvm.maximum.f32(float, float)
-
-; define float @fmaximum_f32(float %a, float %b) nounwind {
-;   %1 = call float @llvm.maximum.f32(float %a, float %b)
-;   ret float %1
-; }
-
 declare float @llvm.copysign.f32(float, float)
 
 define float @copysign_f32(float %a, float %b) nounwind {

--- a/llvm/test/CodeGen/RISCV/half-intrinsics.ll
+++ b/llvm/test/CodeGen/RISCV/half-intrinsics.ll
@@ -2135,23 +2135,6 @@ define half @maxnum_f16(half %a, half %b) nounwind {
   ret half %1
 }
 
-; TODO: FMINNAN and FMAXNAN aren't handled in
-; SelectionDAGLegalize::ExpandNode.
-
-; declare half @llvm.minimum.f16(half, half)
-
-; define half @fminimum_f16(half %a, half %b) nounwind {
-;   %1 = call half @llvm.minimum.f16(half %a, half %b)
-;   ret half %1
-; }
-
-; declare half @llvm.maximum.f16(half, half)
-
-; define half @fmaximum_f16(half %a, half %b) nounwind {
-;   %1 = call half @llvm.maximum.f16(half %a, half %b)
-;   ret half %1
-; }
-
 declare half @llvm.copysign.f16(half, half)
 
 define half @copysign_f16(half %a, half %b) nounwind {


### PR DESCRIPTION
https://reviews.llvm.org/D156069 has supported it.