### PR TITLE
Fixes: Can not use C99 function names as variable names in C89 

### DIFF
--- a/clang/lib/Basic/Builtins.cpp
+++ b/clang/lib/Basic/Builtins.cpp
@@ -147,7 +147,8 @@ static bool isSymbolAvailableInC89(const llvm::StringTable &Strings,
   }
 
   // FIXME: add other C89 symbols here
-  if (NameStr == "log") {
+  if (NameStr == "log" || NameStr == "va_start" || NameStr == "va_arg" ||
+      NameStr == "va_end") {
     return true;
   }
 

--- a/clang/lib/Basic/Builtins.cpp
+++ b/clang/lib/Basic/Builtins.cpp
@@ -14,6 +14,7 @@
 #include "BuiltinTargetFeatures.h"
 #include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/LangOptions.h"
+#include "clang/Basic/LangStandard.h"
 #include "clang/Basic/TargetInfo.h"
 #include "llvm/ADT/StringRef.h"
 using namespace clang;
@@ -148,7 +149,7 @@ static bool builtinIsSupported(const llvm::StringTable &Strings,
   if (!LangOpts.Coroutines && (BuiltinInfo.Langs & COR_LANG))
     return false;
   /* MathBuiltins Unsupported */
-  if (LangOpts.NoMathBuiltin && BuiltinInfo.Header.ID == HeaderDesc::MATH_H)
+  if ((LangOpts.NoMathBuiltin || /*C89*/ LangOpts.LangStd == LangStandard::lang_c89)&& BuiltinInfo.Header.ID == HeaderDesc::MATH_H)
     return false;
   /* GnuMode Unsupported */
   if (!LangOpts.GNUMode && (BuiltinInfo.Langs & GNU_LANG))

--- a/clang/lib/Basic/Builtins.cpp
+++ b/clang/lib/Basic/Builtins.cpp
@@ -149,7 +149,9 @@ static bool builtinIsSupported(const llvm::StringTable &Strings,
   if (!LangOpts.Coroutines && (BuiltinInfo.Langs & COR_LANG))
     return false;
   /* MathBuiltins Unsupported */
-  if ((LangOpts.NoMathBuiltin || /*C89*/ LangOpts.LangStd == LangStandard::lang_c89)&& BuiltinInfo.Header.ID == HeaderDesc::MATH_H)
+  if ((LangOpts.NoMathBuiltin ||
+       /*C89*/ LangOpts.LangStd == LangStandard::lang_c89) &&
+      BuiltinInfo.Header.ID == HeaderDesc::MATH_H)
     return false;
   /* GnuMode Unsupported */
   if (!LangOpts.GNUMode && (BuiltinInfo.Langs & GNU_LANG))

--- a/clang/lib/Basic/Builtins.cpp
+++ b/clang/lib/Basic/Builtins.cpp
@@ -142,7 +142,7 @@ static bool isSymbolAvailableInC89(const llvm::StringTable &Strings,
 
   auto NameStr = Strings[BuiltinInfo.Offsets.Name];
 
-  if (NameStr.starts_with("__builtin_") || NameStr.starts_with("__clang")) {
+  if (NameStr.starts_with("__builtin_")) {
     return true;
   }
 

--- a/clang/lib/Basic/Builtins.cpp
+++ b/clang/lib/Basic/Builtins.cpp
@@ -142,6 +142,10 @@ static bool isSymbolAvailableInC89(const llvm::StringTable &Strings,
 
   auto NameStr = Strings[BuiltinInfo.Offsets.Name];
 
+  if(NameStr.starts_with("__builtin_")) {
+    return true;
+  }
+
   // FIXME: add other C89 symbols here
   if (NameStr == "log") {
     return true;

--- a/clang/lib/Basic/Builtins.cpp
+++ b/clang/lib/Basic/Builtins.cpp
@@ -142,7 +142,7 @@ static bool isSymbolAvailableInC89(const llvm::StringTable &Strings,
 
   auto NameStr = Strings[BuiltinInfo.Offsets.Name];
 
-  if (NameStr.starts_with("__builtin_") || NameStr.starts_with("__arm")) {
+  if (NameStr.starts_with("__builtin_")) {
     return true;
   }
 
@@ -167,7 +167,8 @@ static bool builtinIsSupported(const llvm::StringTable &Strings,
   if (!LangOpts.Coroutines && (BuiltinInfo.Langs & COR_LANG))
     return false;
   bool isC89 = /*C89*/ LangOpts.LangStd == LangStandard::lang_c89;
-  if (isC89 && !isSymbolAvailableInC89(Strings, BuiltinInfo)) {
+  if (isC89 && BuiltinInfo.Header.ID != BuiltinInfo.Header.NO_HEADER &&
+      !isSymbolAvailableInC89(Strings, BuiltinInfo)) {
     return false;
   }
   /* MathBuiltins Unsupported */

--- a/clang/lib/Basic/Builtins.cpp
+++ b/clang/lib/Basic/Builtins.cpp
@@ -142,7 +142,7 @@ static bool isSymbolAvailableInC89(const llvm::StringTable &Strings,
 
   auto NameStr = Strings[BuiltinInfo.Offsets.Name];
 
-  if(NameStr.starts_with("__builtin_")) {
+  if (NameStr.starts_with("__builtin_") || NameStr.starts_with("__clang")) {
     return true;
   }
 

--- a/clang/lib/Basic/Builtins.cpp
+++ b/clang/lib/Basic/Builtins.cpp
@@ -142,7 +142,7 @@ static bool isSymbolAvailableInC89(const llvm::StringTable &Strings,
 
   auto NameStr = Strings[BuiltinInfo.Offsets.Name];
 
-  if (NameStr.starts_with("__builtin_")) {
+  if (NameStr.starts_with("__builtin_") || NameStr.starts_with("__arm")) {
     return true;
   }
 

--- a/clang/lib/Basic/Builtins.cpp
+++ b/clang/lib/Basic/Builtins.cpp
@@ -137,12 +137,13 @@ bool Builtin::Context::isBuiltinFunc(llvm::StringRef FuncName) {
   return false;
 }
 
-static bool isSymbolAvailableInC89(const llvm::StringTable& Strings, const Builtin::Info & BuiltinInfo) {
+static bool isSymbolAvailableInC89(const llvm::StringTable &Strings,
+                                   const Builtin::Info &BuiltinInfo) {
 
   auto NameStr = Strings[BuiltinInfo.Offsets.Name];
 
   // FIXME: add other C89 symbols here
-  if(NameStr == "log") {
+  if (NameStr == "log") {
     return true;
   }
 
@@ -166,8 +167,7 @@ static bool builtinIsSupported(const llvm::StringTable &Strings,
     return false;
   }
   /* MathBuiltins Unsupported */
-  if (LangOpts.NoMathBuiltin &&
-      BuiltinInfo.Header.ID == HeaderDesc::MATH_H)
+  if (LangOpts.NoMathBuiltin && BuiltinInfo.Header.ID == HeaderDesc::MATH_H)
     return false;
   /* GnuMode Unsupported */
   if (!LangOpts.GNUMode && (BuiltinInfo.Langs & GNU_LANG))

--- a/clang/lib/Basic/Builtins.cpp
+++ b/clang/lib/Basic/Builtins.cpp
@@ -17,6 +17,7 @@
 #include "clang/Basic/LangStandard.h"
 #include "clang/Basic/TargetInfo.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringTable.h"
 using namespace clang;
 
 const char *HeaderDesc::getName() const {
@@ -136,6 +137,18 @@ bool Builtin::Context::isBuiltinFunc(llvm::StringRef FuncName) {
   return false;
 }
 
+static bool isSymbolAvailableInC89(const llvm::StringTable& Strings, const Builtin::Info & BuiltinInfo) {
+
+  auto NameStr = Strings[BuiltinInfo.Offsets.Name];
+
+  // FIXME: add other C89 symbols here
+  if(NameStr == "log") {
+    return true;
+  }
+
+  return false;
+}
+
 /// Is this builtin supported according to the given language options?
 static bool builtinIsSupported(const llvm::StringTable &Strings,
                                const Builtin::Info &BuiltinInfo,
@@ -148,9 +161,12 @@ static bool builtinIsSupported(const llvm::StringTable &Strings,
   /* CorBuiltins Unsupported */
   if (!LangOpts.Coroutines && (BuiltinInfo.Langs & COR_LANG))
     return false;
+  bool isC89 = /*C89*/ LangOpts.LangStd == LangStandard::lang_c89;
+  if (isC89 && !isSymbolAvailableInC89(Strings, BuiltinInfo)) {
+    return false;
+  }
   /* MathBuiltins Unsupported */
-  if ((LangOpts.NoMathBuiltin ||
-       /*C89*/ LangOpts.LangStd == LangStandard::lang_c89) &&
+  if (LangOpts.NoMathBuiltin &&
       BuiltinInfo.Header.ID == HeaderDesc::MATH_H)
     return false;
   /* GnuMode Unsupported */

--- a/clang/test/C/drs/c89_with_c99_functions.c
+++ b/clang/test/C/drs/c89_with_c99_functions.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -std=c89 -verify %s
+// expected-no-diagnostics
 
 // From: https://github.com/llvm/llvm-project/issues/15522#issue-1071059939
 int logf = 5;

--- a/clang/test/C/drs/c89_with_c99_functions.c
+++ b/clang/test/C/drs/c89_with_c99_functions.c
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 -std=c89 -verify %s
+
+// From: https://github.com/llvm/llvm-project/issues/15522#issue-1071059939
+int logf = 5;
+int main() {
+return logf;
+}

--- a/clang/test/C/drs/c89_with_c99_functions.c
+++ b/clang/test/C/drs/c89_with_c99_functions.c
@@ -1,8 +1,14 @@
-// RUN: %clang_cc1 -std=c89 -verify %s
-// expected-no-diagnostics
+// RUN: %clang_cc1 -std=c89 -verify=c89 %s
 
 // From: https://github.com/llvm/llvm-project/issues/15522#issue-1071059939
-int logf = 5;
+int logf = 5; // this is fine
+
+// redefinition because log as a symbol exists in C89
+int log = 6; // #1
 int main() {
-return logf;
+return 0;
 }
+
+// c89-error@#1 {{redefinition of 'log' as different kind of symbol}}
+// c89-note@#1 {{unguarded header; consider using #ifdef guards or #pragma once}}
+// c89-note@#1 {{previous definition}}


### PR DESCRIPTION
Fixes #15522

~~Essentially all of math.h doesn't exist until `C99`: https://en.cppreference.com/w/c/numeric/math/log~~

Todo: need more granular filtering based on poring the reference 