### PR TITLE
ADT: Switch to a raw pointer for DoubleAPFloat::Floats.

### DIFF
--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -1660,9 +1660,7 @@ const APFloat &DoubleAPFloat::getFirst() const { return Floats[0]; }
 APFloat &DoubleAPFloat::getSecond() { return Floats[1]; }
 const APFloat &DoubleAPFloat::getSecond() const { return Floats[1]; }
 
-inline DoubleAPFloat::~DoubleAPFloat() {
-  delete[] Floats;
-}
+inline DoubleAPFloat::~DoubleAPFloat() { delete[] Floats; }
 
 } // namespace detail
 

--- a/llvm/include/llvm/ADT/APFloat.h
+++ b/llvm/include/llvm/ADT/APFloat.h
@@ -805,7 +805,7 @@ IEEEFloat frexp(const IEEEFloat &Val, int &Exp, roundingMode RM);
 class DoubleAPFloat final {
   // Note: this must be the first data member.
   const fltSemantics *Semantics;
-  std::unique_ptr<APFloat[]> Floats;
+  APFloat *Floats;
 
   opStatus addImpl(const APFloat &a, const APFloat &aa, const APFloat &c,
                    const APFloat &cc, roundingMode RM);
@@ -821,6 +821,7 @@ public:
   DoubleAPFloat(const fltSemantics &S, APFloat &&First, APFloat &&Second);
   DoubleAPFloat(const DoubleAPFloat &RHS);
   DoubleAPFloat(DoubleAPFloat &&RHS);
+  ~DoubleAPFloat();
 
   DoubleAPFloat &operator=(const DoubleAPFloat &RHS);
   inline DoubleAPFloat &operator=(DoubleAPFloat &&RHS);
@@ -1658,6 +1659,10 @@ APFloat &DoubleAPFloat::getFirst() { return Floats[0]; }
 const APFloat &DoubleAPFloat::getFirst() const { return Floats[0]; }
 APFloat &DoubleAPFloat::getSecond() { return Floats[1]; }
 const APFloat &DoubleAPFloat::getSecond() const { return Floats[1]; }
+
+inline DoubleAPFloat::~DoubleAPFloat() {
+  delete[] Floats;
+}
 
 } // namespace detail
 

--- a/llvm/lib/Support/APFloat.cpp
+++ b/llvm/lib/Support/APFloat.cpp
@@ -4876,8 +4876,9 @@ DoubleAPFloat::DoubleAPFloat(const DoubleAPFloat &RHS)
 }
 
 DoubleAPFloat::DoubleAPFloat(DoubleAPFloat &&RHS)
-    : Semantics(RHS.Semantics), Floats(std::move(RHS.Floats)) {
+    : Semantics(RHS.Semantics), Floats(RHS.Floats) {
   RHS.Semantics = &semBogus;
+  RHS.Floats = nullptr;
   assert(Semantics == &semPPCDoubleDouble);
 }
 


### PR DESCRIPTION
In order for the union APFloat::Storage to permit access to the
semantics field when another union member is stored there, all members
of Storage must be standard layout. This is not necessarily the case
for DoubleAPFloat which may be non-standard layout because there is no
requirement that its std::unique_ptr member is standard layout. Fix this
by converting Floats to a raw pointer.
