### PR TITLE
[mlir][IR] Deprecate `match` and `rewrite` functions

### DIFF
--- a/mlir/docs/DialectConversion.md
+++ b/mlir/docs/DialectConversion.md
@@ -179,13 +179,13 @@ updated/remapped operands of an operation, such as when the types of results
 defined by an operation have changed. The general Rewrite Patterns can no longer
 be used in these situations, as the types of the operands of the operation being
 matched will not correspond with those expected by the user. This pattern
-provides, as an additional argument to the `matchAndRewrite` and `rewrite`
-methods, the list of operands that the operation should use after conversion. If
-an operand was the result of a non-converted operation, for example if it was
-already legal, the original operand is used. This means that the operands
-provided always have a 1-1 non-null correspondence with the operands on the
-operation. The original operands of the operation are still intact and may be
-inspected as normal. These patterns also utilize a special `PatternRewriter`,
+provides, as an additional argument to the `matchAndRewrite` method, the list
+of operands that the operation should use after conversion. If an operand was
+the result of a non-converted operation, for example if it was already legal,
+the original operand is used. This means that the operands provided always have
+a 1-1 non-null correspondence with the operands on the operation. The original
+operands of the operation are still intact and may be inspected as normal.
+These patterns also utilize a special `PatternRewriter`,
 `ConversionPatternRewriter`, that provides special hooks for use with the
 conversion infrastructure.
 

--- a/mlir/docs/PatternRewriter.md
+++ b/mlir/docs/PatternRewriter.md
@@ -48,13 +48,9 @@ operation type, a special tag must be provided to make the intent explicit:
 ### `matchAndRewrite` implementation
 
 This is the chunk of code that matches a given root `Operation` and performs a
-rewrite of the IR. A `RewritePattern` can specify this implementation either via
-the `matchAndRewrite` method or via separate `match` and `rewrite` methods when
-deriving from `RewritePattern::SplitMatchAndRewrite`. When using the combined
-`matchAndRewrite` method, no IR mutation should take place before the match is
-deemed successful. The combined `matchAndRewrite` is useful when non-trivially
-recomputable information is required by the matching and rewriting phase. See
-below for examples:
+rewrite of the IR. A `RewritePattern` can specify this implementation via the
+`matchAndRewrite` method. No IR mutation should take place before the match is
+deemed successful. See below for examples:
 
 ```c++
 class MyPattern : public RewritePattern {
@@ -67,21 +63,6 @@ public:
   MyPattern(PatternBenefit benefit)
       : RewritePattern(benefit, MatchAnyOpTypeTag()) {}
 
-  /// In this section, the `match` and `rewrite` implementation is specified
-  /// using the separate hooks.
-  LogicalResult match(Operation *op) const override {
-    // The `match` method returns `success()` if the pattern is a match, failure
-    // otherwise.
-    // ...
-  }
-  void rewrite(Operation *op, PatternRewriter &rewriter) const override {
-    // The `rewrite` method performs mutations on the IR rooted at `op` using
-    // the provided rewriter. All mutations must go through the provided
-    // rewriter.
-  }
-
-  /// In this section, the `match` and `rewrite` implementation is specified
-  /// using a single hook.
   LogicalResult matchAndRewrite(Operation *op, PatternRewriter &rewriter) const override {
     // The `matchAndRewrite` method performs both the matching and the mutation.
     // Note that the match must reach a successful point before IR mutation may
@@ -92,12 +73,6 @@ public:
 
 #### Restrictions
 
-Within the `match` section of a pattern, the following constraints apply:
-
-*   No mutation of the IR is allowed.
-
-Within the `rewrite` section of a pattern, the following constraints apply:
-
 *   All IR mutations, including creation, *must* be performed by the given
     `PatternRewriter`. This class provides hooks for performing all of the
     possible mutations that may take place within a pattern. For example, this
@@ -107,8 +82,6 @@ Within the `rewrite` section of a pattern, the following constraints apply:
 *   The root operation is required to either be: updated in-place, replaced, or
     erased.
 *   `matchAndRewrite` must return "success" if and only if the IR was modified.
-    `match` must return "success" if and only if the IR is going to be modified
-    during `rewrite`.
 
 
 ### Application Recursion

--- a/mlir/docs/Tutorials/QuickstartRewrites.md
+++ b/mlir/docs/Tutorials/QuickstartRewrites.md
@@ -216,25 +216,6 @@ In case ODS patterns and `matchAndRewrite`-style functions are not sufficient
 you can also specify rewrites as a general set of `RewritePattern`s:
 
 ```c++
-/// Multi-step rewrite using "match" and "rewrite". This allows for separating
-/// the concerns of matching and rewriting.
-struct ConvertTFLeakyRelu : public RewritePattern {
-  ConvertTFLeakyRelu(MLIRContext *context)
-      : RewritePattern("tf.LeakyRelu", 1, context) {}
-
-  LogicalResult match(Operation *op) const override {
-    return success();
-  }
-
-  void rewrite(Operation *op, PatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<TFL::LeakyReluOp>(
-        op, op->getResult(0).getType(), op->getOperand(0),
-        /*alpha=*/op->getAttrOfType<FloatAttr>("alpha"));
-  }
-};
-
-/// Single-step rewrite with "matchAndRewrite". This allows for performing the
-/// rewrite immediately upon a successful match.
 struct ConvertTFLeakyRelu : public RewritePattern {
   ConvertTFLeakyRelu(MLIRContext *context)
       : RewritePattern("tf.LeakyRelu", 1, context) {}

--- a/mlir/include/mlir/Conversion/LLVMCommon/Pattern.h
+++ b/mlir/include/mlir/Conversion/LLVMCommon/Pattern.h
@@ -40,6 +40,8 @@ LogicalResult oneToOneRewrite(
 /// during the entire pattern lifetime.
 class ConvertToLLVMPattern : public ConversionPattern {
 public:
+  /// `SplitMatchAndRewrite` is deprecated. Use `matchAndRewrite` instead of
+  /// separate `match` and `rewrite`.
   using SplitMatchAndRewrite =
       detail::ConversionSplitMatchAndRewriteImpl<ConvertToLLVMPattern>;
 
@@ -149,6 +151,9 @@ public:
   using OpAdaptor = typename SourceOp::Adaptor;
   using OneToNOpAdaptor =
       typename SourceOp::template GenericAdaptor<ArrayRef<ValueRange>>;
+
+  /// `SplitMatchAndRewrite` is deprecated. Use `matchAndRewrite` instead of
+  /// separate `match` and `rewrite`.
   using SplitMatchAndRewrite = detail::ConversionSplitMatchAndRewriteImpl<
       ConvertOpToLLVMPattern<SourceOp>>;
 

--- a/mlir/include/mlir/IR/PatternMatch.h
+++ b/mlir/include/mlir/IR/PatternMatch.h
@@ -237,6 +237,9 @@ private:
 namespace detail {
 /// Helper class that derives from a RewritePattern class and provides separate
 /// `match` and `rewrite` entry points instead of a combined `matchAndRewrite`.
+///
+/// This class is deprecated. Use `matchAndRewrite` instead of separate `match`
+/// and `rewrite`.
 template <typename PatternT>
 class SplitMatchAndRewriteImpl : public PatternT {
   using PatternT::PatternT;
@@ -268,6 +271,9 @@ class SplitMatchAndRewriteImpl : public PatternT {
 class RewritePattern : public Pattern {
 public:
   using OperationT = Operation *;
+
+  /// `SplitMatchAndRewrite` is deprecated. Use `matchAndRewrite` instead of
+  /// separate `match` and `rewrite`.
   using SplitMatchAndRewrite = detail::SplitMatchAndRewriteImpl<RewritePattern>;
 
   virtual ~RewritePattern() = default;
@@ -350,6 +356,9 @@ struct OpOrInterfaceRewritePatternBase : public RewritePattern {
 template <typename SourceOp>
 struct OpRewritePattern
     : public detail::OpOrInterfaceRewritePatternBase<SourceOp> {
+
+  /// `SplitMatchAndRewrite` is deprecated. Use `matchAndRewrite` instead of
+  /// separate `match` and `rewrite`.
   using SplitMatchAndRewrite =
       detail::SplitMatchAndRewriteImpl<OpRewritePattern<SourceOp>>;
 
@@ -368,6 +377,9 @@ struct OpRewritePattern
 template <typename SourceOp>
 struct OpInterfaceRewritePattern
     : public detail::OpOrInterfaceRewritePatternBase<SourceOp> {
+
+  /// `SplitMatchAndRewrite` is deprecated. Use `matchAndRewrite` instead of
+  /// separate `match` and `rewrite`.
   using SplitMatchAndRewrite =
       detail::SplitMatchAndRewriteImpl<OpInterfaceRewritePattern<SourceOp>>;
 

--- a/mlir/include/mlir/Transforms/DialectConversion.h
+++ b/mlir/include/mlir/Transforms/DialectConversion.h
@@ -598,6 +598,9 @@ public:
   using OperationT = Operation *;
   using OpAdaptor = ArrayRef<Value>;
   using OneToNOpAdaptor = ArrayRef<ValueRange>;
+
+  /// `SplitMatchAndRewrite` is deprecated. Use `matchAndRewrite` instead of
+  /// separate `match` and `rewrite`.
   using SplitMatchAndRewrite =
       detail::ConversionSplitMatchAndRewriteImpl<ConversionPattern>;
 
@@ -669,6 +672,9 @@ public:
   using OpAdaptor = typename SourceOp::Adaptor;
   using OneToNOpAdaptor =
       typename SourceOp::template GenericAdaptor<ArrayRef<ValueRange>>;
+
+  /// `SplitMatchAndRewrite` is deprecated. Use `matchAndRewrite` instead of
+  /// separate `match` and `rewrite`.
   using SplitMatchAndRewrite =
       detail::ConversionSplitMatchAndRewriteImpl<OpConversionPattern<SourceOp>>;
 

--- a/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
+++ b/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
@@ -657,11 +657,12 @@ struct RankOpLowering : public ConvertOpToLLVMPattern<memref::RankOp> {
   }
 };
 
-struct MemRefCastOpLowering
-    : public ConvertOpToLLVMPattern<memref::CastOp>::SplitMatchAndRewrite {
-  using SplitMatchAndRewrite::SplitMatchAndRewrite;
+struct MemRefCastOpLowering : public ConvertOpToLLVMPattern<memref::CastOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
 
-  LogicalResult match(memref::CastOp memRefCastOp) const override {
+  LogicalResult
+  matchAndRewrite(memref::CastOp memRefCastOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
     Type srcType = memRefCastOp.getOperand().getType();
     Type dstType = memRefCastOp.getType();
 
@@ -671,30 +672,22 @@ struct MemRefCastOpLowering
     // perform a sanity check that the underlying structs are the same. Once op
     // semantics are relaxed we can revisit.
     if (isa<MemRefType>(srcType) && isa<MemRefType>(dstType))
-      return success(typeConverter->convertType(srcType) ==
-                     typeConverter->convertType(dstType));
-
-    // At least one of the operands is unranked type
-    assert(isa<UnrankedMemRefType>(srcType) ||
-           isa<UnrankedMemRefType>(dstType));
+      if (typeConverter->convertType(srcType) !=
+          typeConverter->convertType(dstType))
+        return failure();
 
     // Unranked to unranked cast is disallowed
-    return !(isa<UnrankedMemRefType>(srcType) &&
-             isa<UnrankedMemRefType>(dstType))
-               ? success()
-               : failure();
-  }
+    if (isa<UnrankedMemRefType>(srcType) && isa<UnrankedMemRefType>(dstType))
+      return failure();
 
-  void rewrite(memref::CastOp memRefCastOp, OpAdaptor adaptor,
-               ConversionPatternRewriter &rewriter) const override {
-    auto srcType = memRefCastOp.getOperand().getType();
-    auto dstType = memRefCastOp.getType();
     auto targetStructType = typeConverter->convertType(memRefCastOp.getType());
     auto loc = memRefCastOp.getLoc();
 
     // For ranked/ranked case, just keep the original descriptor.
-    if (isa<MemRefType>(srcType) && isa<MemRefType>(dstType))
-      return rewriter.replaceOp(memRefCastOp, {adaptor.getSource()});
+    if (isa<MemRefType>(srcType) && isa<MemRefType>(dstType)) {
+      rewriter.replaceOp(memRefCastOp, {adaptor.getSource()});
+      return success();
+    }
 
     if (isa<MemRefType>(srcType) && isa<UnrankedMemRefType>(dstType)) {
       // Casting ranked to unranked memref type
@@ -733,6 +726,8 @@ struct MemRefCastOpLowering
     } else {
       llvm_unreachable("Unsupported unranked memref to unranked memref cast");
     }
+
+    return success();
   }
 };
 

--- a/mlir/lib/Dialect/Arith/Transforms/EmulateUnsupportedFloats.cpp
+++ b/mlir/lib/Dialect/Arith/Transforms/EmulateUnsupportedFloats.cpp
@@ -40,36 +40,33 @@ struct EmulateUnsupportedFloatsPass
   void runOnOperation() override;
 };
 
-struct EmulateFloatPattern final : ConversionPattern::SplitMatchAndRewrite {
+struct EmulateFloatPattern final : ConversionPattern {
   EmulateFloatPattern(const TypeConverter &converter, MLIRContext *ctx)
-      : ConversionPattern::SplitMatchAndRewrite(
+      : ConversionPattern::ConversionPattern(
             converter, Pattern::MatchAnyOpTypeTag(), 1, ctx) {}
 
-  LogicalResult match(Operation *op) const override;
-  void rewrite(Operation *op, ArrayRef<Value> operands,
-               ConversionPatternRewriter &rewriter) const override;
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override;
 };
 } // end namespace
 
-LogicalResult EmulateFloatPattern::match(Operation *op) const {
+LogicalResult EmulateFloatPattern::matchAndRewrite(
+    Operation *op, ArrayRef<Value> operands,
+    ConversionPatternRewriter &rewriter) const {
   if (getTypeConverter()->isLegal(op))
     return failure();
   // The rewrite doesn't handle cloning regions.
   if (op->getNumRegions() != 0)
     return failure();
-  return success();
-}
 
-void EmulateFloatPattern::rewrite(Operation *op, ArrayRef<Value> operands,
-                                  ConversionPatternRewriter &rewriter) const {
   Location loc = op->getLoc();
   const TypeConverter *converter = getTypeConverter();
   SmallVector<Type> resultTypes;
   if (failed(converter->convertTypes(op->getResultTypes(), resultTypes))) {
     // Note to anyone looking for this error message: this is a "can't happen".
     // If you're seeing it, there's a bug.
-    op->emitOpError("type conversion failed in float emulation");
-    return;
+    return op->emitOpError("type conversion failed in float emulation");
   }
   Operation *expandedOp =
       rewriter.create(loc, op->getName().getIdentifier(), operands, resultTypes,
@@ -84,6 +81,7 @@ void EmulateFloatPattern::rewrite(Operation *op, ArrayRef<Value> operands,
     }
   }
   rewriter.replaceOp(op, newResults);
+  return success();
 }
 
 void mlir::arith::populateEmulateUnsupportedFloatsConversions(

--- a/mlir/lib/Dialect/Arith/Transforms/IntRangeOptimizations.cpp
+++ b/mlir/lib/Dialect/Arith/Transforms/IntRangeOptimizations.cpp
@@ -140,7 +140,7 @@ struct MaterializeKnownConstantValues : public RewritePattern {
             llvm::any_of(block.getArguments(), needsReplacing);
       }
     }
-    if (!(hasConstantResults || hasConstantRegionArgs))
+    if (!hasConstantResults && !hasConstantRegionArgs)
       return failure();
 
     bool replacedAll = (op->getNumResults() != 0);

--- a/mlir/lib/Dialect/Arith/Transforms/IntRangeOptimizations.cpp
+++ b/mlir/lib/Dialect/Arith/Transforms/IntRangeOptimizations.cpp
@@ -115,14 +115,14 @@ protected:
 /// and replace their uses with that constant. Return success() if all results
 /// where thus replaced and the operation is erased. Also replace any block
 /// arguments with their constant values.
-struct MaterializeKnownConstantValues
-    : public RewritePattern::SplitMatchAndRewrite {
+struct MaterializeKnownConstantValues : public RewritePattern {
   MaterializeKnownConstantValues(MLIRContext *context, DataFlowSolver &s)
-      : RewritePattern::SplitMatchAndRewrite(Pattern::MatchAnyOpTypeTag(),
-                                             /*benefit=*/1, context),
+      : RewritePattern::RewritePattern(Pattern::MatchAnyOpTypeTag(),
+                                       /*benefit=*/1, context),
         solver(s) {}
 
-  LogicalResult match(Operation *op) const override {
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
     if (matchPattern(op, m_Constant()))
       return failure();
 
@@ -131,7 +131,8 @@ struct MaterializeKnownConstantValues
     };
     bool hasConstantResults = llvm::any_of(op->getResults(), needsReplacing);
     if (op->getNumRegions() == 0)
-      return success(hasConstantResults);
+      if (!hasConstantResults)
+        return failure();
     bool hasConstantRegionArgs = false;
     for (Region &region : op->getRegions()) {
       for (Block &block : region.getBlocks()) {
@@ -139,10 +140,9 @@ struct MaterializeKnownConstantValues
             llvm::any_of(block.getArguments(), needsReplacing);
       }
     }
-    return success(hasConstantResults || hasConstantRegionArgs);
-  }
+    if (!(hasConstantResults || hasConstantRegionArgs))
+      return failure();
 
-  void rewrite(Operation *op, PatternRewriter &rewriter) const override {
     bool replacedAll = (op->getNumResults() != 0);
     for (Value v : op->getResults())
       replacedAll &=
@@ -150,7 +150,7 @@ struct MaterializeKnownConstantValues
            v.use_empty());
     if (replacedAll && isOpTriviallyDead(op)) {
       rewriter.eraseOp(op);
-      return;
+      return success();
     }
 
     PatternRewriter::InsertionGuard guard(rewriter);
@@ -162,6 +162,8 @@ struct MaterializeKnownConstantValues
         }
       }
     }
+
+    return success();
   }
 
 private:


### PR DESCRIPTION
Deprecate the `match` and `rewrite` functions. They mainly exist for historic reasons. This PR also updates all remaining uses of in the MLIR codebase.

This is addressing a [comment](https://github.com/llvm/llvm-project/pull/129861#pullrequestreview-2662696084) on an earlier PR.

Note for LLVM integration: `SplitMatchAndRewrite` will be deleted soon, update your patterns to use `matchAndRewrite` instead of separate `match` / `rewrite`.
