### PR TITLE
[lldb] Adapt llgs tests for RISC-V

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
@@ -35,7 +35,7 @@ def check_first_register_readable(test_case):
         test_case.expect("register read r0", substrs=["r0 = 0x"])
     elif arch in ["powerpc64le"]:
         test_case.expect("register read r0", substrs=["r0 = 0x"])
-    elif re.match("^rv(32|64)", arch):
+    elif arch in ["riscv64", "riscv32"]:
         test_case.expect("register read zero", substrs=["zero = 0x"])
     else:
         # TODO: Add check for other architectures

--- a/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
@@ -240,6 +240,10 @@ def getArchitecture():
         arch = "x86_64"
     if arch in ["armv7l", "armv8l"]:
         arch = "arm"
+    if re.match("rv64*", arch):
+        arch = "riscv64"
+    if re.match("rv32*", arch):
+        arch = "riscv32"
     return arch
 
 

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1394,7 +1394,7 @@ class Base(unittest.TestCase):
         return self.isLoongArch() and "lasx" in self.getCPUInfo()
 
     def isRISCV(self):
-        """Returns true if the architecture is RISCV64 or RISCV32.""" 
+        """Returns true if the architecture is RISCV64 or RISCV32."""
         return self.getArchitecture() in ["riscv64", "riscv32"]
 
     def getArchitecture(self):

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1393,6 +1393,10 @@ class Base(unittest.TestCase):
     def isLoongArchLASX(self):
         return self.isLoongArch() and "lasx" in self.getCPUInfo()
 
+    def isRISCV(self):
+        """Returns true if the architecture is RISCV64 or RISCV32.""" 
+        return self.getArchitecture() in ["riscv64", "riscv32"]
+
     def getArchitecture(self):
         """Returns the architecture in effect the test suite is running with."""
         return lldbplatformutil.getArchitecture()

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -682,7 +682,7 @@ class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
         self.assertTrue("name" in reg_info)
         self.assertTrue("bitsize" in reg_info)
 
-        if not self.getArchitecture() == "aarch64":
+        if not (self.getArchitecture() == "aarch64" or self.isRISCV()):
             self.assertTrue("offset" in reg_info)
 
         self.assertTrue("encoding" in reg_info)

--- a/lldb/test/API/tools/lldb-server/TestLldbGdbServer.py
+++ b/lldb/test/API/tools/lldb-server/TestLldbGdbServer.py
@@ -199,6 +199,14 @@ class LldbGdbServerTestCase(
         if not self.isRISCV():
             self.assertIn("flags", generic_regs)
 
+        if self.isRISCV():
+            # Special RISC-V register for a return address
+            self.assertIn("ra", generic_regs)
+
+            # RISC-V's function arguments registers
+            for i in range(1, 9):
+                self.assertIn(f"arg{i}", generic_regs)
+
     def test_qRegisterInfo_contains_at_least_one_register_set(self):
         self.build()
         self.prep_debug_monitor_and_inferior()

--- a/lldb/test/API/tools/lldb-server/TestLldbGdbServer.py
+++ b/lldb/test/API/tools/lldb-server/TestLldbGdbServer.py
@@ -195,8 +195,9 @@ class LldbGdbServerTestCase(
         # Ensure we have a stack pointer register.
         self.assertIn("sp", generic_regs)
 
-        # Ensure we have a flags register.
-        self.assertIn("flags", generic_regs)
+        # Ensure we have a flags register. RISC-V doesn't have a flags register
+        if not self.isRISCV():
+            self.assertIn("flags", generic_regs)
 
     def test_qRegisterInfo_contains_at_least_one_register_set(self):
         self.build()

--- a/lldb/test/API/tools/lldb-server/main.cpp
+++ b/lldb/test/API/tools/lldb-server/main.cpp
@@ -128,6 +128,15 @@ static void swap_chars() {
                :
                : "r"('0'), "r"('1'), "r"(&g_c1), "r"(&g_c2)
                : "memory");
+#elif defined(__riscv)
+  asm volatile("sb %1, (%2)\n\t"
+               "sb %0, (%3)\n\t"
+               "sb %0, (%2)\n\t"
+               "sb %1, (%3)\n\t"
+               :
+               : "r"('0'), "r"('1'), "r"(&g_c1), "r"(&g_c2)
+               : "memory");
+
 #else
 #warning This may generate unpredictible assembly and cause the single-stepping test to fail.
 #warning Please add appropriate assembly for your target.

--- a/lldb/test/API/tools/lldb-server/registers-target-xml-reading/TestGdbRemoteTargetXmlPacket.py
+++ b/lldb/test/API/tools/lldb-server/registers-target-xml-reading/TestGdbRemoteTargetXmlPacket.py
@@ -63,7 +63,7 @@ class TestGdbRemoteTargetXmlPacket(gdbremote_testcase.GdbRemoteTestCaseBase):
             self.assertEqual(q_info_reg["format"], xml_info_reg.get("format"))
             self.assertEqual(q_info_reg["bitsize"], xml_info_reg.get("bitsize"))
 
-            if not self.isAArch64():
+            if not (self.isAArch64() or self.isRISCV()):
                 self.assertEqual(q_info_reg["offset"], xml_info_reg.get("offset"))
 
             self.assertEqual(q_info_reg["encoding"], xml_info_reg.get("encoding"))


### PR DESCRIPTION
Some lldb tests from llgs category fail on RISC-V target due to lack of necessary condition checks. This patch adapts these tests by taking into account the peculiarities of the RISC-V architecture