### PR TITLE
[SPIRV]support for the extension SPV_INTEL_fp_fast_math_mode

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "SPIRVCommandLine.h"
+#include "MCTargetDesc/SPIRVBaseInfo.h"
 #include "llvm/ADT/StringRef.h"
 #include <algorithm>
 #include <map>
@@ -90,7 +91,9 @@ static const std::map<std::string, SPIRV::Extension::Extension, std::less<>>
         {"SPV_KHR_non_semantic_info",
          SPIRV::Extension::Extension::SPV_KHR_non_semantic_info},
         {"SPV_INTEL_long_composites",
-         SPIRV::Extension::Extension::SPV_INTEL_long_composites}};
+         SPIRV::Extension::Extension::SPV_INTEL_long_composites},
+        {"SPV_INTEL_fp_fast_math_mode",
+            SPIRV::Extension::Extension::SPV_INTEL_fp_fast_math_mode}};
 
 bool SPIRVExtensionsParser::parse(cl::Option &O, llvm::StringRef ArgName,
                                   llvm::StringRef ArgValue,

--- a/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
+++ b/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
@@ -511,6 +511,7 @@ defm FunctionFloatControlINTEL : CapabilityOperand<5821, 0, 0, [SPV_INTEL_float_
 defm LongCompositesINTEL : CapabilityOperand<6089, 0, 0, [SPV_INTEL_long_composites], []>;
 defm BindlessImagesINTEL : CapabilityOperand<6528, 0, 0, [SPV_INTEL_bindless_images], []>;
 defm MemoryAccessAliasingINTEL : CapabilityOperand<5910, 0, 0, [SPV_INTEL_memory_access_aliasing], []>;
+defm FPFastMathModeINTEL : CapabilityOperand<5837, 0, 0, [SPV_INTEL_fp_fast_math_mode], []>;
 
 //===----------------------------------------------------------------------===//
 // Multiclass used to define SourceLanguage enum values and at the same time
@@ -1050,6 +1051,8 @@ defm NotInf : FPFastMathModeOperand<0x2, [Kernel]>;
 defm NSZ : FPFastMathModeOperand<0x4, [Kernel]>;
 defm AllowRecip : FPFastMathModeOperand<0x8, [Kernel]>;
 defm Fast : FPFastMathModeOperand<0x10, [Kernel]>;
+defm AllowContract : FPFastMathModeOperand<0x10000, [FPFastMathModeINTEL]>;
+defm AllowReassoc : FPFastMathModeOperand<0x20000, [FPFastMathModeINTEL]>;
 
 //===----------------------------------------------------------------------===//
 // Multiclass used to define FPRoundingMode enum values and at the same time

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_fp_fast_math_mode/fp_contract_reassoc_fast_mode.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_fp_fast_math_mode/fp_contract_reassoc_fast_mode.ll
@@ -1,0 +1,52 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-EXT-OFF
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown --spirv-ext=+SPV_INTEL_fp_fast_math_mode %s -o - | FileCheck %s --check-prefix=CHECK-EXT-ON
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_fp_fast_math_mode %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-EXT-ON: OpCapability FPFastMathModeINTEL
+; CHECK-EXT-ON: SPV_INTEL_fp_fast_math_mode
+; CHECK-EXT-ON: OpName %[[#mul:]] "mul"
+; CHECK-EXT-ON: OpName %[[#sub:]] "sub"
+; CHECK-EXT-ON: OpDecorate %[[#mu:]] FPFastMathMode AllowContract
+; CHECK-EXT-ON: OpDecorate %[[#su:]] FPFastMathMode AllowReassoc
+
+; CHECK-EXT-OFF-NOT: OpCapability FPFastMathModeINTEL
+; CHECK-EXT-OFF-NOT: SPV_INTEL_fp_fast_math_mode
+; CHECK-EXT-OFF: OpName %[[#mul:]] "mul"
+; CHECK-EXT-OFF: OpName %[[#sub:]] "sub"
+; CHECK-EXT-OFF-NOT: 4 Decorate %[[#mul]] FPFastMathMode AllowContract
+; CHECK-EXT-OFF-NOT: 4 Decorate %[[#sub]] FPFastMathMode AllowReassoc
+
+
+; Function Attrs: convergent noinline norecurse nounwind optnone
+define spir_kernel void @test(float %a, float %b) #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %a.addr = alloca float, align 4
+  %b.addr = alloca float, align 4
+  store float %a, ptr %a.addr, align 4
+  store float %b, ptr %b.addr, align 4
+  %0 = load float, ptr %a.addr, align 4
+  %1 = load float, ptr %a.addr, align 4
+  %mul = fmul contract float %0, %1
+  store float %mul, ptr %b.addr, align 4
+  %2 = load float, ptr %b.addr, align 4
+  %3 = load float, ptr %b.addr, align 4
+  %sub = fsub reassoc float %2, %3
+  store float %sub, ptr %b.addr, align 4
+  ret void
+}
+
+attributes #0 = { convergent noinline norecurse nounwind optnone "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "uniform-work-group-size"="false" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 2, i32 0}
+!2 = !{!"clang version 12.0.0 (https://github.com/intel/llvm.git 5cf8088c994778561c8584d5433d7d32618725b2)"}
+!3 = !{i32 0, i32 0}
+!4 = !{!"none", !"none"}
+!5 = !{!"float", !"float"}
+!6 = !{!"", !""}
+


### PR DESCRIPTION
This is based on the specifications defined in [SPV_INTEL_fp_fast_math_mode](https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/INTEL/SPV_INTEL_fp_fast_math_mode.asciidoc) 

- Ported the test from bidirectional translator
