### PR TITLE
[clangd] Explicitly block until async task completes

### DIFF
--- a/clang-tools-extra/clangd/CodeComplete.h
+++ b/clang-tools-extra/clangd/CodeComplete.h
@@ -274,7 +274,6 @@ struct SpeculativeFuzzyFind {
   /// Set by `codeComplete()`. This can be used by callers to update cache.
   std::optional<FuzzyFindRequest> NewReq;
   /// The result is consumed by `codeComplete()` if speculation succeeded.
-  /// NOTE: the destructor will wait for the async call to finish.
   std::future<std::pair<bool /*Incomplete*/, SymbolSlab>> Result;
 };
 


### PR DESCRIPTION
We started seeing some use-after-frees starting with https://github.com/llvm/llvm-project/pull/125433.

This patch ensures we explicitly block for the async task, if there's one,
before destructing `std::future`, independent of the stdlib implementation.
