### PR TITLE
[flang][OpenMP] Translate OpenMP scopes when compiling for target device

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -537,19 +537,12 @@ static llvm::omp::ProcBindKind getProcBindKind(omp::ClauseProcBindKind kind) {
   llvm_unreachable("Unknown ClauseProcBindKind kind");
 }
 
-/// Maps elements of \p blockArgs (which are MLIR values) to the corresponding
-/// LLVM values of \p operands' elements. This is useful when an OpenMP region
-/// with entry block arguments is converted to LLVM. In this case \p blockArgs
-/// are (part of) of the OpenMP region's entry arguments and \p operands are
-/// (part of) of the operands to the OpenMP op containing the region.
-///
-/// This function assumes that \p operands belong to the enclosing op of the
-/// block containing \p blockArgs:
-/// ```
-/// enclosing_op(operands) {
-///   block(blockArgs)
-/// }
-/// ```
+/// Maps block arguments from \p blockArgIface (which are MLIR values) to the
+/// corresponding LLVM values of \p the interface's operands. This is useful
+/// when an OpenMP region with entry block arguments is converted to LLVM. In
+/// this case the block arguments are (part of) of the OpenMP region's entry
+/// arguments and the operands are (part of) of the operands to the OpenMP op
+/// containing the region.
 static void forwardArgs(LLVM::ModuleTranslation &moduleTranslation,
                         omp::BlockArgOpenMPOpInterface blockArgIface) {
   llvm::SmallVector<std::pair<Value, BlockArgument>> blockArgsPairs;

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -29,6 +29,7 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Frontend/OpenMP/OMPConstants.h"
 #include "llvm/Frontend/OpenMP/OMPIRBuilder.h"
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/IRBuilder.h"
@@ -5336,9 +5337,9 @@ convertTargetOpsInNest(Operation *op, llvm::IRBuilderBase &builder,
               assert(builder.GetInsertBlock() &&
                      "No insert block is set for the builder");
               for (auto iv : loopNest.getIVs()) {
-                // Create fake allocas just to maintain IR validity.
+                // Map iv to an undefined value just to keep the IR validity.
                 moduleTranslation.mapValue(
-                    iv, builder.CreateAlloca(
+                    iv, llvm::PoisonValue::get(
                             moduleTranslation.convertType(iv.getType())));
               }
             }

--- a/mlir/test/Target/LLVMIR/openmp-target-nesting-in-host-ops.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-target-nesting-in-host-ops.mlir
@@ -1,0 +1,136 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+module attributes {llvm.target_triple = "amdgcn-amd-amdhsa", omp.is_gpu = true, omp.is_target_device = true} {
+
+  omp.private {type = private} @i32_privatizer : i32
+
+  llvm.func @test_nested_target_in_parallel(%arg0: !llvm.ptr) {
+    omp.parallel {
+    %0 = llvm.mlir.constant(4 : index) : i64
+    %1 = llvm.mlir.constant(1 : index) : i64
+    %4 = omp.map.bounds   lower_bound(%1 : i64) upper_bound(%0 : i64) stride(%1 : i64) start_idx(%1 : i64)
+    %mapv1 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.array<10 x i32>)   map_clauses(tofrom) capture(ByRef) bounds(%4) -> !llvm.ptr {name = ""}
+    omp.target map_entries(%mapv1 -> %map_arg : !llvm.ptr) {
+      omp.terminator
+    }
+      omp.terminator
+    }
+    llvm.return
+  }
+
+// CHECK-LABEL: define void @test_nested_target_in_parallel({{.*}}) {
+// CHECK-NEXT:    br label %omp.parallel.fake.region
+// CHECK:       omp.parallel.fake.region:
+// CHECK-NEXT:    br label %omp.region.cont
+// CHECK:       omp.region.cont:
+// CHECK-NEXT:    ret void
+// CHECK-NEXT:  }
+
+  llvm.func @test_nested_target_in_wsloop(%arg0: !llvm.ptr) {
+    %8 = llvm.mlir.constant(1 : i64) : i64
+    %9 = llvm.alloca %8 x i32 {bindc_name = "i"} : (i64) -> !llvm.ptr
+    %16 = llvm.mlir.constant(10 : i32) : i32
+    %17 = llvm.mlir.constant(1 : i32) : i32
+    omp.wsloop private(@i32_privatizer %9 -> %loop_arg : !llvm.ptr) {
+      omp.loop_nest (%arg1) : i32 = (%17) to (%16) inclusive step (%17) {
+        llvm.store %arg1, %loop_arg : i32, !llvm.ptr
+        %0 = llvm.mlir.constant(4 : index) : i64
+        %1 = llvm.mlir.constant(1 : index) : i64
+        %4 = omp.map.bounds   lower_bound(%1 : i64) upper_bound(%0 : i64) stride(%1 : i64) start_idx(%1 : i64)
+        %mapv1 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.array<10 x i32>)   map_clauses(tofrom) capture(ByRef) bounds(%4) -> !llvm.ptr {name = ""}
+        omp.target map_entries(%mapv1 -> %map_arg : !llvm.ptr) {
+          omp.terminator
+        }
+        omp.yield
+      }
+    }
+    llvm.return
+  }
+
+// CHECK-LABEL: define void @test_nested_target_in_wsloop(ptr %0) {
+// CHECK-NEXT:    %{{.*}} = alloca i32, i64 1, align 4
+// CHECK-NEXT:    br label %omp.wsloop.fake.region
+// CHECK:       omp.wsloop.fake.region:
+// CHECK-NEXT:    %{{.*}} = alloca i32, align 4
+// CHECK-NEXT:    br label %omp.loop_nest.fake.region
+// CHECK:       omp.loop_nest.fake.region:
+// CHECK-NEXT:    store ptr %3, ptr %2, align 8
+// CHECK-NEXT:    br label %omp.region.cont1
+// CHECK:       omp.region.cont1:
+// CHECK-NEXT:    br label %omp.region.cont
+// CHECK:       omp.region.cont:
+// CHECK-NEXT:    ret void
+// CHECK-NEXT:  }
+
+  llvm.func @test_nested_target_in_parallel_with_private(%arg0: !llvm.ptr) {
+    %8 = llvm.mlir.constant(1 : i64) : i64
+    %9 = llvm.alloca %8 x i32 {bindc_name = "i"} : (i64) -> !llvm.ptr
+    omp.parallel private(@i32_privatizer %9 -> %i_priv_arg : !llvm.ptr) {
+        %1 = llvm.mlir.constant(1 : index) : i64
+        // Use the private clause from omp.parallel to make sure block arguments
+        // are handled.
+        %i_val = llvm.load %i_priv_arg : !llvm.ptr -> i64
+        %4 = omp.map.bounds   lower_bound(%1 : i64) upper_bound(%i_val : i64) stride(%1 : i64) start_idx(%1 : i64)
+        %mapv1 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.array<10 x i32>)   map_clauses(tofrom) capture(ByRef) bounds(%4) -> !llvm.ptr {name = ""}
+        omp.target map_entries(%mapv1 -> %map_arg : !llvm.ptr) {
+          omp.terminator
+        }
+        omp.terminator
+    }
+    llvm.return
+  }
+
+  llvm.func @test_nested_target_in_task_with_private(%arg0: !llvm.ptr) {
+    %8 = llvm.mlir.constant(1 : i64) : i64
+    %9 = llvm.alloca %8 x i32 {bindc_name = "i"} : (i64) -> !llvm.ptr
+    omp.task private(@i32_privatizer %9 -> %i_priv_arg : !llvm.ptr) {
+        %1 = llvm.mlir.constant(1 : index) : i64
+        // Use the private clause from omp.task to make sure block arguments
+        // are handled.
+        %i_val = llvm.load %i_priv_arg : !llvm.ptr -> i64
+        %4 = omp.map.bounds   lower_bound(%1 : i64) upper_bound(%i_val : i64) stride(%1 : i64) start_idx(%1 : i64)
+        %mapv1 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.array<10 x i32>)   map_clauses(tofrom) capture(ByRef) bounds(%4) -> !llvm.ptr {name = ""}
+        omp.target map_entries(%mapv1 -> %map_arg : !llvm.ptr) {
+          omp.terminator
+        }
+        omp.terminator
+    }
+    llvm.return
+  }
+
+// CHECK-LABEL: define void @test_nested_target_in_parallel_with_private({{.*}}) {
+// CHECK:        br label %omp.parallel.fake.region
+// CHECK:       omp.parallel.fake.region:
+// CHECK:         br label %omp.region.cont
+// CHECK:       omp.region.cont:
+// CHECK-NEXT:    ret void
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: define {{.*}} amdgpu_kernel void @__omp_offloading_{{.*}}_nested_target_in_parallel_{{.*}} {
+// CHECK:         call i32 @__kmpc_target_init
+// CHECK:       user_code.entry:
+// CHECK:         call void @__kmpc_target_deinit()
+// CHECK:         ret void
+// CHECK:       }
+
+// CHECK-LABEL: define {{.*}} amdgpu_kernel void @__omp_offloading_{{.*}}_test_nested_target_in_wsloop_{{.*}} {
+// CHECK:         call i32 @__kmpc_target_init
+// CHECK:       user_code.entry:
+// CHECK:         call void @__kmpc_target_deinit()
+// CHECK:         ret void
+// CHECK:       }
+
+// CHECK-LABEL: define {{.*}} amdgpu_kernel void @__omp_offloading_{{.*}}_test_nested_target_in_parallel_with_private_{{.*}} {
+// CHECK:         call i32 @__kmpc_target_init
+// CHECK:       user_code.entry:
+// CHECK:         call void @__kmpc_target_deinit()
+// CHECK:         ret void
+// CHECK:       }
+
+// CHECK-LABEL: define {{.*}} amdgpu_kernel void @__omp_offloading_{{.*}}_test_nested_target_in_task_with_private_{{.*}} {
+// CHECK:         call i32 @__kmpc_target_init
+// CHECK:       user_code.entry:
+// CHECK:         call void @__kmpc_target_deinit()
+// CHECK:         ret void
+// CHECK:       }
+}

--- a/mlir/test/Target/LLVMIR/openmp-target-nesting-in-host-ops.mlir
+++ b/mlir/test/Target/LLVMIR/openmp-target-nesting-in-host-ops.mlir
@@ -51,10 +51,9 @@ module attributes {llvm.target_triple = "amdgcn-amd-amdhsa", omp.is_gpu = true, 
 // CHECK-NEXT:    %{{.*}} = alloca i32, i64 1, align 4
 // CHECK-NEXT:    br label %omp.wsloop.fake.region
 // CHECK:       omp.wsloop.fake.region:
-// CHECK-NEXT:    %{{.*}} = alloca i32, align 4
 // CHECK-NEXT:    br label %omp.loop_nest.fake.region
 // CHECK:       omp.loop_nest.fake.region:
-// CHECK-NEXT:    store ptr %3, ptr %2, align 8
+// CHECK-NEXT:    store i32 poison, ptr %{{.*}}
 // CHECK-NEXT:    br label %omp.region.cont1
 // CHECK:       omp.region.cont1:
 // CHECK-NEXT:    br label %omp.region.cont


### PR DESCRIPTION
If a `target` directive is nested in a host OpenMP directive (e.g.
parallel, task, or a worksharing loop), flang currently crashes if the
target directive-related MLIR ops (e.g. `omp.map.bounds` and
`omp.map.info` depends on SSA values defined inside the parent host
OpenMP directives/ops.

This PR tries to solve this problem by treating these parent OpenMP ops
as "SSA scopes". Whenever we are translating for the device, instead of
completely translating host ops, we just tranlate their MLIR ops as pure
SSA values.