### PR TITLE
PeepholeOpt: Remove subreg def check for bitcast

### DIFF
--- a/llvm/test/CodeGen/X86/pr41619.ll
+++ b/llvm/test/CodeGen/X86/pr41619.ll
@@ -6,8 +6,6 @@ define void @foo(double %arg) {
 ; CHECK-LABEL: foo:
 ; CHECK:       ## %bb.0: ## %bb
 ; CHECK-NEXT:    vmovq %xmm0, %rax
-; CHECK-NEXT:    vmovd %eax, %xmm0
-; CHECK-NEXT:    vmovq %xmm0, %rax
 ; CHECK-NEXT:    movl %eax, (%rax)
 ; CHECK-NEXT:    movq $0, (%rax)
 ; CHECK-NEXT:    retq


### PR DESCRIPTION
Subregister defs are illegal in SSA. Surprisingly this enables folding
into subregister insert patterns in one test.