### PR TITLE
Change `ASTUnit::getASTContext() const` to return a non-const `ASTContext`

### DIFF
--- a/clang/include/clang/Frontend/ASTUnit.h
+++ b/clang/include/clang/Frontend/ASTUnit.h
@@ -439,8 +439,7 @@ public:
   Preprocessor &getPreprocessor() { return *PP; }
   std::shared_ptr<Preprocessor> getPreprocessorPtr() const { return PP; }
 
-  const ASTContext &getASTContext() const { return *Ctx; }
-  ASTContext &getASTContext() { return *Ctx; }
+  ASTContext &getASTContext() const { return *Ctx; }
 
   void setASTContext(ASTContext *ctx) { Ctx = ctx; }
   void setPreprocessor(std::shared_ptr<Preprocessor> pp);


### PR DESCRIPTION
Also, remove the non-const `ASTUnit::getASTContext()` since it's no longer necessary.
This would make it similar to `Decl::getAstContext() const` for a more consistent and flexible API.