### PR TITLE
[lldb-dap] Adding support for well typed events.

### DIFF
--- a/lldb/tools/lldb-dap/CMakeLists.txt
+++ b/lldb/tools/lldb-dap/CMakeLists.txt
@@ -37,6 +37,9 @@ add_lldb_tool(lldb-dap
   Transport.cpp
   Watchpoint.cpp
 
+  Events/ExitedEventHandler.cpp
+  Events/ProcessEventHandler.cpp
+
   Handler/ResponseHandler.cpp
   Handler/AttachRequestHandler.cpp
   Handler/BreakpointLocationsHandler.cpp
@@ -75,8 +78,9 @@ add_lldb_tool(lldb-dap
   Handler/VariablesRequestHandler.cpp
   
   Protocol/ProtocolBase.cpp
-  Protocol/ProtocolTypes.cpp
+  Protocol/ProtocolEvents.cpp
   Protocol/ProtocolRequests.cpp
+  Protocol/ProtocolTypes.cpp
 
   LINK_LIBS
     liblldb

--- a/lldb/tools/lldb-dap/CMakeLists.txt
+++ b/lldb/tools/lldb-dap/CMakeLists.txt
@@ -39,6 +39,7 @@ add_lldb_tool(lldb-dap
 
   Events/ExitedEventHandler.cpp
   Events/ProcessEventHandler.cpp
+  Events/OutputEventHandler.cpp
 
   Handler/ResponseHandler.cpp
   Handler/AttachRequestHandler.cpp

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -8,6 +8,7 @@
 
 #include "DAP.h"
 #include "DAPLog.h"
+#include "Events/EventHandler.h"
 #include "Handler/RequestHandler.h"
 #include "Handler/ResponseHandler.h"
 #include "JSONUtils.h"
@@ -82,7 +83,9 @@ DAP::DAP(llvm::StringRef path, std::ofstream *log,
       configuration_done_sent(false), waiting_for_run_in_terminal(false),
       progress_event_reporter(
           [&](const ProgressEvent &event) { SendJSON(event.ToJSON()); }),
-      reverse_request_seq(0), repl_mode(default_repl_mode) {}
+      reverse_request_seq(0), repl_mode(default_repl_mode),
+      onExited(ExitedEventHandler(*this)),
+      onProcess(ProcessEventHandler(*this)) {}
 
 DAP::~DAP() = default;
 

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -58,6 +58,9 @@ typedef llvm::StringMap<FunctionBreakpoint> FunctionBreakpointMap;
 typedef llvm::DenseMap<lldb::addr_t, InstructionBreakpoint>
     InstructionBreakpointMap;
 
+/// A debug adapter initiated event.
+template <typename... Args> using OutgoingEvent = std::function<void(Args...)>;
+
 enum class OutputType { Console, Stdout, Stderr, Telemetry };
 
 /// Buffer size for handling output events.
@@ -228,6 +231,17 @@ struct DAP {
   /// @{
   DAP(const DAP &rhs) = delete;
   void operator=(const DAP &rhs) = delete;
+  /// @}
+
+  /// Typed Events Handlers
+  /// @{
+
+  /// onExited sends an event that the debuggee has exited.
+  OutgoingEvent<> onExited;
+  /// onProcess sends an event that indicates that the debugger has begun
+  /// debugging a new process.
+  OutgoingEvent<> onProcess;
+
   /// @}
 
   ExceptionBreakpoint *GetExceptionBreakpoint(const std::string &filter);

--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -8,6 +8,7 @@
 
 #include "EventHelper.h"
 #include "DAP.h"
+#include "Events/EventHandler.h"
 #include "JSONUtils.h"
 #include "LLDBUtils.h"
 #include "lldb/API/SBFileSpec.h"
@@ -128,9 +129,9 @@ void SendStdOutStdErr(DAP &dap, lldb::SBProcess &process) {
   char buffer[OutputBufferSize];
   size_t count;
   while ((count = process.GetSTDOUT(buffer, sizeof(buffer))) > 0)
-    dap.SendOutput(OutputType::Stdout, llvm::StringRef(buffer, count));
+    dap.SendOutput(llvm::StringRef(buffer, count), OutputCategory::Stdout);
   while ((count = process.GetSTDERR(buffer, sizeof(buffer))) > 0)
-    dap.SendOutput(OutputType::Stderr, llvm::StringRef(buffer, count));
+    dap.SendOutput(llvm::StringRef(buffer, count), OutputCategory::Stderr);
 }
 
 // Send a "continued" event to indicate the process is in the running state.

--- a/lldb/tools/lldb-dap/EventHelper.h
+++ b/lldb/tools/lldb-dap/EventHelper.h
@@ -14,10 +14,6 @@
 namespace lldb_dap {
 struct DAP;
 
-enum LaunchMethod { Launch, Attach, AttachForSuspendedLaunch };
-
-void SendProcessEvent(DAP &dap, LaunchMethod launch_method);
-
 void SendThreadStoppedEvent(DAP &dap);
 
 void SendTerminatedEvent(DAP &dap);
@@ -25,8 +21,6 @@ void SendTerminatedEvent(DAP &dap);
 void SendStdOutStdErr(DAP &dap, lldb::SBProcess &process);
 
 void SendContinuedEvent(DAP &dap);
-
-void SendProcessExitedEvent(DAP &dap, lldb::SBProcess &process);
 
 } // namespace lldb_dap
 

--- a/lldb/tools/lldb-dap/Events/EventHandler.h
+++ b/lldb/tools/lldb-dap/Events/EventHandler.h
@@ -1,0 +1,57 @@
+//===-- EventHandler.h ----------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_TOOLS_LLDB_DAP_EVENTS_EVENT_HANDLER
+#define LLDB_TOOLS_LLDB_DAP_EVENTS_EVENT_HANDLER
+
+#include "DAP.h"
+#include "Protocol/ProtocolBase.h"
+#include "Protocol/ProtocolEvents.h"
+#include "lldb/API/SBProcess.h"
+
+namespace lldb_dap {
+
+template <typename Body, typename... Args> class BaseEventHandler {
+public:
+  BaseEventHandler(DAP &dap) : dap(dap) {}
+
+  virtual ~BaseEventHandler() = default;
+
+  virtual llvm::StringLiteral getEvent() const = 0;
+  virtual Body Handler(Args...) const = 0;
+
+  void operator()(Args... args) const {
+    Body body = Handler(args...);
+    protocol::Event event{/*event=*/getEvent().str(), /*body=*/std::move(body)};
+    dap.Send(event);
+  }
+
+protected:
+  DAP &dap;
+};
+
+/// Handler for the event indicates that the debuggee has exited and returns its
+/// exit code.
+class ExitedEventHandler : public BaseEventHandler<protocol::ExitedEventBody> {
+public:
+  using BaseEventHandler::BaseEventHandler;
+  llvm::StringLiteral getEvent() const override { return "exited"; }
+  protocol::ExitedEventBody Handler() const override;
+};
+
+class ProcessEventHandler
+    : public BaseEventHandler<protocol::ProcessEventBody> {
+public:
+  using BaseEventHandler::BaseEventHandler;
+  llvm::StringLiteral getEvent() const override { return "process"; }
+  protocol::ProcessEventBody Handler() const override;
+};
+
+} // end namespace lldb_dap
+
+#endif

--- a/lldb/tools/lldb-dap/Events/ExitedEventHandler.cpp
+++ b/lldb/tools/lldb-dap/Events/ExitedEventHandler.cpp
@@ -6,15 +6,20 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "DAP.h"
 #include "Events/EventHandler.h"
 #include "lldb/API/SBProcess.h"
 
 namespace lldb_dap {
 
-protocol::ExitedEventBody ExitedEventHandler::Handler() const {
+void ExitedEventHandler::operator()(lldb::SBProcess &process) const {
+  if (!process.IsValid())
+    return;
+
   protocol::ExitedEventBody body;
-  body.exitCode = dap.target.GetProcess().GetExitStatus();
-  return body;
+  body.exitCode = process.GetExitStatus();
+  dap.Send(protocol::Event{/*event=*/ExitedEventHandler::event.str(),
+                           /*body=*/std::move(body)});
 }
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Events/ExitedEventHandler.cpp
+++ b/lldb/tools/lldb-dap/Events/ExitedEventHandler.cpp
@@ -1,0 +1,20 @@
+//===-- ExitedEventHandler.cpp --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Events/EventHandler.h"
+#include "lldb/API/SBProcess.h"
+
+namespace lldb_dap {
+
+protocol::ExitedEventBody ExitedEventHandler::Handler() const {
+  protocol::ExitedEventBody body;
+  body.exitCode = dap.target.GetProcess().GetExitStatus();
+  return body;
+}
+
+} // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Events/OutputEventHandler.cpp
+++ b/lldb/tools/lldb-dap/Events/OutputEventHandler.cpp
@@ -1,0 +1,43 @@
+//===-- OutputEventHandler.cpp --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "DAP.h"
+#include "Events/EventHandler.h"
+#include "Protocol/ProtocolEvents.h"
+#include "llvm/ADT/StringRef.h"
+
+using namespace llvm;
+using namespace lldb_dap::protocol;
+
+namespace lldb_dap {
+
+void OutputEventHandler::operator()(llvm::StringRef output,
+                                    OutputCategory category) const {
+  if (output.empty())
+    return;
+
+  // Send each line of output as an individual event, including the newline if
+  // present.
+  size_t idx = 0;
+  do {
+    size_t end = output.find('\n', idx);
+    if (end == llvm::StringRef::npos)
+      end = output.size() - 1;
+
+    OutputEventBody body;
+    body.output = output.slice(idx, end + 1).str();
+    body.category = category;
+
+    dap.Send(protocol::Event{/*event=*/OutputEventHandler::event.str(),
+                             /*body*/ body});
+
+    idx = end + 1;
+  } while (idx < output.size());
+}
+
+} // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Events/ProcessEventHandler.cpp
+++ b/lldb/tools/lldb-dap/Events/ProcessEventHandler.cpp
@@ -1,0 +1,34 @@
+//===-- ProcessEventHandler.cpp -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Events/EventHandler.h"
+#include "Protocol/ProtocolEvents.h"
+#include "lldb/API/SBProcess.h"
+#include "lldb/API/SBTarget.h"
+
+using namespace llvm;
+using namespace lldb_dap::protocol;
+
+namespace lldb_dap {
+
+ProcessEventBody ProcessEventHandler::Handler() const {
+  ProcessEventBody body;
+
+  char path[PATH_MAX] = {0};
+  dap.target.GetExecutable().GetPath(path, sizeof(path));
+  body.name = path;
+  body.systemProcessId = dap.target.GetProcess().GetProcessID();
+  body.isLocalProcess = dap.target.GetPlatform().GetName() ==
+                        lldb::SBPlatform::GetHostPlatform().GetName();
+  body.startMethod = dap.is_attach ? ProcessEventBody::StartMethod::attach
+                                   : ProcessEventBody::StartMethod::launch;
+  body.pointerSize = dap.target.GetAddressByteSize();
+  return body;
+}
+
+} // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
@@ -201,7 +201,7 @@ void AttachRequestHandler::operator()(const llvm::json::Object &request) const {
 
   dap.SendJSON(llvm::json::Value(std::move(response)));
   if (error.Success()) {
-    SendProcessEvent(dap, Attach);
+    dap.onProcess();
     dap.SendJSON(CreateEventObject("initialized"));
   }
 }

--- a/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
@@ -8,6 +8,7 @@
 
 #include "DAP.h"
 #include "EventHelper.h"
+#include "Events/EventHandler.h"
 #include "JSONUtils.h"
 #include "RequestHandler.h"
 #include "lldb/API/SBListener.h"
@@ -131,8 +132,7 @@ void AttachRequestHandler::operator()(const llvm::json::Object &request) const {
     auto attach_msg_len = snprintf(attach_msg, sizeof(attach_msg),
                                    "Waiting to attach to \"%s\"...",
                                    dap.target.GetExecutable().GetFilename());
-    dap.SendOutput(OutputType::Console,
-                   llvm::StringRef(attach_msg, attach_msg_len));
+    dap.SendOutput(llvm::StringRef(attach_msg, attach_msg_len));
   }
   if (attachCommands.empty()) {
     // No "attachCommands", just attach normally.
@@ -201,7 +201,7 @@ void AttachRequestHandler::operator()(const llvm::json::Object &request) const {
 
   dap.SendJSON(llvm::json::Value(std::move(response)));
   if (error.Success()) {
-    dap.onProcess();
+    dap.SendProcess(dap.target, ProcessStartMethod::attach);
     dap.SendJSON(CreateEventObject("initialized"));
   }
 }

--- a/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
@@ -178,7 +178,7 @@ static void EventThreadFunction(DAP &dap) {
               // Run any exit LLDB commands the user specified in the
               // launch.json
               dap.RunExitCommands();
-              SendProcessExitedEvent(dap, process);
+              dap.onExited();
               dap.SendTerminatedEvent();
               done = true;
             }

--- a/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
@@ -166,7 +166,7 @@ static void EventThreadFunction(DAP &dap) {
           case lldb::eStateExited:
             lldb::SBStream stream;
             process.GetStatus(stream);
-            dap.SendOutput(OutputType::Console, stream.GetData());
+            dap.SendOutput(stream.GetData());
 
             // When restarting, we can get an "exited" event for the process we
             // just killed with the old PID, or even with no PID. In that case
@@ -178,7 +178,7 @@ static void EventThreadFunction(DAP &dap) {
               // Run any exit LLDB commands the user specified in the
               // launch.json
               dap.RunExitCommands();
-              dap.onExited();
+              dap.SendExited(process);
               dap.SendTerminatedEvent();
               done = true;
             }

--- a/lldb/tools/lldb-dap/Handler/LaunchRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/LaunchRequestHandler.cpp
@@ -124,10 +124,7 @@ void LaunchRequestHandler::operator()(const llvm::json::Object &request) const {
   dap.SendJSON(llvm::json::Value(std::move(response)));
 
   if (!status.Fail()) {
-    if (dap.is_attach)
-      SendProcessEvent(dap, Attach); // this happens when doing runInTerminal
-    else
-      SendProcessEvent(dap, Launch);
+    dap.onProcess();
   }
   dap.SendJSON(CreateEventObject("initialized"));
 }

--- a/lldb/tools/lldb-dap/Handler/LaunchRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/LaunchRequestHandler.cpp
@@ -8,6 +8,7 @@
 
 #include "DAP.h"
 #include "EventHelper.h"
+#include "Events/EventHandler.h"
 #include "JSONUtils.h"
 #include "RequestHandler.h"
 #include "llvm/Support/FileSystem.h"
@@ -123,9 +124,9 @@ void LaunchRequestHandler::operator()(const llvm::json::Object &request) const {
 
   dap.SendJSON(llvm::json::Value(std::move(response)));
 
-  if (!status.Fail()) {
-    dap.onProcess();
-  }
+  if (!status.Fail())
+    dap.SendProcess(dap.target, ProcessStartMethod::launch);
+
   dap.SendJSON(CreateEventObject("initialized"));
 }
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/RequestHandler.cpp
@@ -66,7 +66,7 @@ void BaseRequestHandler::SetSourceMapFromArguments(
       if (mapping == nullptr || mapping->size() != 2 ||
           (*mapping)[0].kind() != llvm::json::Value::String ||
           (*mapping)[1].kind() != llvm::json::Value::String) {
-        dap.SendOutput(OutputType::Console, llvm::StringRef(sourceMapHelp));
+        dap.SendOutput(llvm::StringRef(sourceMapHelp));
         return;
       }
       const auto mapFrom = GetAsString((*mapping)[0]);
@@ -81,7 +81,7 @@ void BaseRequestHandler::SetSourceMapFromArguments(
     }
   } else {
     if (ObjectContainsKey(arguments, sourceMapKey)) {
-      dap.SendOutput(OutputType::Console, llvm::StringRef(sourceMapHelp));
+      dap.SendOutput(llvm::StringRef(sourceMapHelp));
       return;
     }
     if (sourcePath.empty())

--- a/lldb/tools/lldb-dap/Protocol/ProtocolBase.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolBase.h
@@ -17,8 +17,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLDB_TOOLS_LLDB_DAP_PROTOCOL_H
-#define LLDB_TOOLS_LLDB_DAP_PROTOCOL_H
+#ifndef LLDB_TOOLS_LLDB_DAP_PROTOCOL_PROTOCOL_BASE_H
+#define LLDB_TOOLS_LLDB_DAP_PROTOCOL_PROTOCOL_BASE_H
 
 #include "llvm/Support/JSON.h"
 #include <cstdint>

--- a/lldb/tools/lldb-dap/Protocol/ProtocolEvents.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolEvents.cpp
@@ -1,0 +1,46 @@
+//===-- ProtocolEvents.cpp ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Protocol/ProtocolEvents.h"
+#include "llvm/Support/JSON.h"
+
+using namespace llvm;
+
+namespace lldb_dap::protocol {
+
+json::Value toJSON(const ExitedEventBody &EEB) {
+  return json::Object{{"exitCode", EEB.exitCode}};
+}
+
+json::Value toJSON(const ProcessEventBody::StartMethod &m) {
+  switch (m) {
+  case ProcessEventBody::StartMethod::launch:
+    return "launch";
+  case ProcessEventBody::StartMethod::attach:
+    return "attach";
+  case ProcessEventBody::StartMethod::attachForSuspendedLaunch:
+    return "attachForSuspendedLaunch";
+  }
+}
+
+json::Value toJSON(const ProcessEventBody &PEB) {
+  json::Object result{{"name", PEB.name}};
+
+  if (PEB.systemProcessId)
+    result.insert({"systemProcessId", PEB.systemProcessId});
+  if (PEB.isLocalProcess)
+    result.insert({"isLocalProcess", PEB.isLocalProcess});
+  if (PEB.startMethod)
+    result.insert({"startMethod", PEB.startMethod});
+  if (PEB.pointerSize)
+    result.insert({"pointerSize", PEB.pointerSize});
+
+  return std::move(result);
+}
+
+} // namespace lldb_dap::protocol

--- a/lldb/tools/lldb-dap/Protocol/ProtocolEvents.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolEvents.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Protocol/ProtocolEvents.h"
+#include "Events/EventHandler.h"
 #include "llvm/Support/JSON.h"
 
 using namespace llvm;
@@ -39,6 +40,55 @@ json::Value toJSON(const ProcessEventBody &PEB) {
     result.insert({"startMethod", PEB.startMethod});
   if (PEB.pointerSize)
     result.insert({"pointerSize", PEB.pointerSize});
+
+  return std::move(result);
+}
+
+json::Value toJSON(const OutputEventBody::Category &C) {
+  switch (C) {
+  case OutputEventBody::Category::Console:
+    return "console";
+  case OutputEventBody::Category::Important:
+    return "important";
+  case OutputEventBody::Category::Stdout:
+    return "stdout";
+  case OutputEventBody::Category::Stderr:
+    return "stderr";
+  case OutputEventBody::Category::Telemetry:
+    return "telemetry";
+  }
+}
+
+json::Value toJSON(const OutputEventBody::Group &G) {
+  switch (G) {
+  case OutputEventBody::Group::start:
+    return "start";
+  case OutputEventBody::Group::startCollapsed:
+    return "startCollapsed";
+  case OutputEventBody::Group::end:
+    return "end";
+  }
+}
+
+json::Value toJSON(const OutputEventBody &OEB) {
+  json::Object result{{"output", OEB.output}};
+
+  if (OEB.category)
+    result.insert({"category", *OEB.category});
+  if (OEB.group)
+    result.insert({"group", *OEB.group});
+  if (OEB.variablesReference)
+    result.insert({"variablesReference", *OEB.variablesReference});
+  if (OEB.source)
+    result.insert({"source", *OEB.source});
+  if (OEB.line)
+    result.insert({"line", *OEB.line});
+  if (OEB.column)
+    result.insert({"column", *OEB.column});
+  if (OEB.data)
+    result.insert({"data", *OEB.data});
+  if (OEB.locationReference)
+    result.insert({"locationReference", *OEB.locationReference});
 
   return std::move(result);
 }

--- a/lldb/tools/lldb-dap/Protocol/ProtocolEvents.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolEvents.h
@@ -1,0 +1,76 @@
+//===-- ProtocolEvents.h --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains POD structs based on the DAP specification at
+// https://microsoft.github.io/debug-adapter-protocol/specification
+//
+// This is not meant to be a complete implementation, new interfaces are added
+// when they're needed.
+//
+// Each struct has a toJSON and fromJSON function, that converts between
+// the struct and a JSON representation. (See JSON.h)
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_TOOLS_LLDB_DAP_PROTOCOL_PROTOCOL_EVENTS_H
+#define LLDB_TOOLS_LLDB_DAP_PROTOCOL_PROTOCOL_EVENTS_H
+
+#include "lldb/lldb-types.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/JSON.h"
+
+namespace lldb_dap::protocol {
+
+// MARK: Events
+
+/// The event indicates that the debuggee has exited and returns its exit code.
+struct ExitedEventBody {
+  static llvm::StringLiteral getEvent() { return "exited"; }
+
+  /// The exit code returned from the debuggee.
+  int exitCode;
+};
+llvm::json::Value toJSON(const ExitedEventBody &);
+
+/// The event indicates that the debugger has begun debugging a new process.
+/// Either one that it has launched, or one that it has attached to.
+struct ProcessEventBody {
+  /// The logical name of the process. This is usually the full path to
+  /// process's executable file. Example: /home/example/myproj/program.js.
+  std::string name;
+
+  /// The process ID of the debugged process, as assigned by the operating
+  /// system. This property should be omitted for logical processes that do not
+  /// map to operating system processes on the machine.
+  std::optional<lldb::pid_t> systemProcessId;
+
+  /// If true, the process is running on the same computer as the debug adapter.
+  std::optional<bool> isLocalProcess;
+
+  enum class StartMethod {
+    /// Process was launched under the debugger.
+    launch,
+    /// Debugger attached to an existing process.
+    attach,
+    /// A project launcher component has launched a new process in a suspended
+    /// state and then asked the debugger to attach.
+    attachForSuspendedLaunch
+  };
+
+  /// Describes how the debug engine started debugging this process.
+  std::optional<StartMethod> startMethod;
+
+  /// The size of a pointer or address for this process, in bits. This value may
+  /// be used by clients when formatting addresses for display.
+  std::optional<int> pointerSize;
+};
+llvm::json::Value toJSON(const ProcessEventBody &);
+
+} // namespace lldb_dap::protocol
+
+#endif

--- a/lldb/tools/lldb-dap/Protocol/ProtocolEvents.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolEvents.h
@@ -20,6 +20,7 @@
 #ifndef LLDB_TOOLS_LLDB_DAP_PROTOCOL_PROTOCOL_EVENTS_H
 #define LLDB_TOOLS_LLDB_DAP_PROTOCOL_PROTOCOL_EVENTS_H
 
+#include "Protocol/ProtocolTypes.h"
 #include "lldb/lldb-types.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/JSON.h"
@@ -70,6 +71,105 @@ struct ProcessEventBody {
   std::optional<int> pointerSize;
 };
 llvm::json::Value toJSON(const ProcessEventBody &);
+
+/// The event indicates that the target has produced some output.
+struct OutputEventBody {
+  enum class Category {
+    /// Show the output in the client's default message UI, e.g. a
+    /// 'debug console'. This category should only be used for informational
+    /// output from the debugger (as opposed to the debuggee).
+    Console,
+    /// A hint for the client to show the output in the client's UI
+    /// for important and highly visible information, e.g. as a popup
+    /// notification. This category should only be used for important messages
+    /// from the debugger (as opposed to the debuggee). Since this category
+    /// value
+    /// is a hint, clients might ignore the hint and assume the `console`
+    /// category.
+    Important,
+    /// Show the output as normal program output from the debuggee.
+    Stdout,
+    /// Show the output as error program output from the debuggee.
+    Stderr,
+    /// Send the output to telemetry instead of showing it to the user.
+    Telemetry,
+  };
+
+  /// The output category. If not specified or if the category is not
+  /// understood by the client, `console` is assumed.
+  std::optional<Category> category;
+
+  /// The output to report.
+  ///
+  /// ANSI escape sequences may be used to influence text color and styling if
+  /// `supportsANSIStyling` is present in both the adapter's `Capabilities` and
+  /// the client's `InitializeRequestArguments`. A client may strip any
+  /// unrecognized ANSI sequences.
+  ///
+  /// If the `supportsANSIStyling` capabilities are not both true, then the
+  /// client should display the output literally.
+  std::string output;
+
+  enum class Group {
+    /// Start a new group in expanded mode. Subsequent output events are members
+    /// of the group and should be shown indented.
+    ///
+    /// The `output` attribute becomes the name of the group and is not
+    /// indented.
+    start,
+
+    /// Start a new group in collapsed mode. Subsequent output events are
+    /// members of the group and should be shown indented (as soon as the group
+    /// is expanded).
+    ///
+    /// The `output` attribute becomes the name of the group and is not
+    /// indented.
+    startCollapsed,
+
+    /// End the current group and decrease the indentation of subsequent output
+    /// events.
+    ///
+    /// A non-empty `output` attribute is shown as the unindented end of the
+    /// group.
+    end,
+  };
+
+  /// Support for keeping an output log organized by grouping related messages.
+  std::optional<Group> group;
+
+  /// If an attribute `variablesReference` exists and its value is > 0, the
+  /// output contains objects which can be retrieved by passing
+  /// `variablesReference` to the `variables` request as long as execution
+  /// remains suspended. See 'Lifetime of Object References' in the Overview
+  /// section for details.
+  std::optional<int> variablesReference;
+
+  /// The source location where the output was produced.
+  std::optional<Source> source;
+
+  /// The source location's line where the output was produced.
+  std::optional<int32_t> line;
+  /// The position in `line` where the output was produced. It is measured in
+  /// UTF-16 code units and the client capability `columnsStartAt1` determines
+  /// whether it is 0- or 1-based.
+  std::optional<int32_t> column;
+
+  /// Additional data to report. For the `telemetry` category the data is
+  /// sent to telemetry, for the other categories the data is shown in JSON
+  /// format.
+  std::optional<llvm::json::Value> data;
+
+  /// A reference that allows the client to request the location where the new
+  /// value is declared. For example, if the logged value is function pointer,
+  /// the adapter may be able to look up the function's location. This should
+  /// be present only if the adapter is likely to be able to resolve the
+  /// location.
+  ///
+  /// This reference shares the same lifetime as the `variablesReference`. See
+  /// 'Lifetime of Object References' in the Overview section for details.
+  std::optional<int> locationReference;
+};
+llvm::json::Value toJSON(const OutputEventBody &);
 
 } // namespace lldb_dap::protocol
 

--- a/lldb/tools/lldb-dap/Protocol/ProtocolTypes.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolTypes.cpp
@@ -37,6 +37,32 @@ bool fromJSON(const json::Value &Params, Source::PresentationHint &PH,
   return true;
 }
 
+json::Value toJSON(const Source::PresentationHint &P) {
+  switch (P) {
+  case Source::PresentationHint::normal:
+    return "normal";
+  case Source::PresentationHint::emphasize:
+    return "emphasize";
+  case Source::PresentationHint::deemphasize:
+    return "deemphasize";
+  }
+}
+
+json::Value toJSON(const Source &S) {
+  json::Object result;
+
+  if (S.name)
+    result.insert({"name", *S.name});
+  if (S.path)
+    result.insert({"path", *S.path});
+  if (S.sourceReference)
+    result.insert({"sourceReference", *S.sourceReference});
+  if (S.presentationHint)
+    result.insert({"presentationHint", *S.presentationHint});
+
+  return std::move(result);
+}
+
 bool fromJSON(const json::Value &Params, Source &S, json::Path P) {
   json::ObjectMapper O(Params, P);
   return O && O.mapOptional("name", S.name) && O.mapOptional("path", S.path) &&

--- a/lldb/tools/lldb-dap/Protocol/ProtocolTypes.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolTypes.h
@@ -56,6 +56,7 @@ struct Source {
 
   // unsupported keys: origin, sources, adapterData, checksums
 };
+llvm::json::Value toJSON(const Source &);
 bool fromJSON(const llvm::json::Value &, Source &, llvm::json::Path);
 
 } // namespace lldb_dap::protocol

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -294,7 +294,7 @@ void SourceBreakpoint::SetLogMessage() {
 void SourceBreakpoint::NotifyLogMessageError(llvm::StringRef error) {
   std::string message = "Log message has error: ";
   message += error;
-  dap.SendOutput(OutputType::Console, message);
+  dap.SendOutput(message);
 }
 
 /*static*/
@@ -328,7 +328,7 @@ bool SourceBreakpoint::BreakpointHitCallback(
   }
   if (!output.empty() && output.back() != '\n')
     output.push_back('\n'); // Ensure log message has line break.
-  bp->dap.SendOutput(OutputType::Console, output.c_str());
+  bp->dap.SendOutput(output);
 
   // Do not stop.
   return false;

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -9,6 +9,7 @@
 #include "DAP.h"
 #include "DAPLog.h"
 #include "EventHelper.h"
+#include "Events/EventHandler.h"
 #include "Handler/RequestHandler.h"
 #include "RunInTerminal.h"
 #include "Transport.h"


### PR DESCRIPTION
This adds a mechanism for registering well typed events with the DAP.

For a proof of concept, this updates the 'exited' and the 'process'
event to use the new protocol serialization handlers and updates the
call sites to use the new helper.

