### PR TITLE
[clang][test] Fix -DBUILD_SHARED_LIBS build by adding depency on Targ…

### DIFF
--- a/clang/lib/Testing/CMakeLists.txt
+++ b/clang/lib/Testing/CMakeLists.txt
@@ -13,6 +13,7 @@ add_llvm_library(clangTesting
   LINK_COMPONENTS
   MC
   Support
+  TargetParser
   )
 
 clang_target_link_libraries(clangTesting


### PR DESCRIPTION
…etParser from clangTesting

Commit 979c275097a642e9b96c6b0a12f013c831af3a6e (#129868) introduced a dependency on the llvm::Triple::Triple in `lookupTarget`. This is part of TargetParser, which wasn't listed in clang/lib/Testing/CMakeLists.txt. This broke the -DBUILD_SHARED_LIBS=True builds.

Fixes #130112