### PR TITLE
[LLD][COFF] Implement ECExportThunkChunk::classof

### DIFF
--- a/lld/COFF/Chunks.h
+++ b/lld/COFF/Chunks.h
@@ -59,7 +59,8 @@ public:
     SectionKind,
     SectionECKind,
     OtherKind,
-    ImportThunkKind
+    ImportThunkKind,
+    ECExportThunkKind
   };
   Kind kind() const { return chunkKind; }
 
@@ -827,7 +828,10 @@ static const uint8_t ECExportThunkCode[] = {
 
 class ECExportThunkChunk : public NonSectionCodeChunk {
 public:
-  explicit ECExportThunkChunk(Defined *targetSym) : target(targetSym) {}
+  explicit ECExportThunkChunk(Defined *targetSym)
+      : NonSectionCodeChunk(ECExportThunkKind), target(targetSym) {}
+  static bool classof(const Chunk *c) { return c->kind() == ECExportThunkKind; }
+
   size_t getSize() const override { return sizeof(ECExportThunkCode); };
   void writeTo(uint8_t *buf) const override;
   MachineTypes getMachine() const override { return AMD64; }

--- a/lld/test/COFF/build-id-sym.s
+++ b/lld/test/COFF/build-id-sym.s
@@ -1,6 +1,6 @@
 # REQUIRES: x86
 # RUN: llvm-mc -triple=x86_64-windows-msvc -filetype=obj -o %t.obj %s
-# RUN: lld-link -debug:symtab -entry:main %t.obj -build-id -Brepro -out:%t.exe
+# RUN: lld-link -debug:symtab -entry:main %t.obj -build-id -Brepro -out:%t.exe -guard:cf
 # RUN: llvm-objdump -s -t %t.exe | FileCheck %s
 
 # Check __buildid points to 0x14000203c which is after the signature RSDS.
@@ -21,3 +21,6 @@ main:
 .section .bss,"bw",discard,__buildid
 .global __buildid
 __buildid:
+
+.data
+.quad __buildid


### PR DESCRIPTION
Fixes `dyn_cast_or_null` usage in `maybeAddAddressTakenFunction` (#128440).