### PR TITLE
[RISCV][clang] Fix wrong VLS CC detection

### DIFF
--- a/clang/lib/CodeGen/Targets/RISCV.cpp
+++ b/clang/lib/CodeGen/Targets/RISCV.cpp
@@ -389,7 +389,7 @@ ABIArgInfo RISCVABIInfo::coerceAndExpandFPCCEligibleStruct(
 bool RISCVABIInfo::detectVLSCCEligibleStruct(QualType Ty, unsigned ABIVLen,
                                              llvm::Type *&VLSType) const {
   // No riscv_vls_cc attribute.
-  if (ABIVLen == 1)
+  if (ABIVLen == 0)
     return false;
 
   // Legal struct for VLS calling convention should fulfill following rules:

--- a/clang/test/CodeGen/RISCV/pr129995.cc
+++ b/clang/test/CodeGen/RISCV/pr129995.cc
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 triple riscv64 -emit-llvm -target-feature +m -target-feature +v -target-abi lp64d -o /dev/null %s
+
+struct a {
+  using b = char __attribute__((vector_size(sizeof(char))));
+};
+class c {
+  using d = a::b;
+  d e;
+
+public:
+  static c f();
+};
+class g {
+public:
+  template <class h> g(h);
+  friend g operator^(g, g) { c::f; }
+  friend g operator^=(g i, g j) { i ^ j; }
+};
+template <typename, int> using k = g;
+template <typename l> using m = k<l, sizeof(l)>;
+void n() {
+  void o();
+  m<char> p = o ^= p;
+}


### PR DESCRIPTION
RISCVABIInfo::detectVLSCCEligibleStruct should early exit if VLS calling convention is not used, however the sentinel value was not set to correctly, it should be zero instead of one.