### PR TITLE
[SPARC][Driver] Set correct IAS mode defaults for Linux and Free/OpenBSD

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2876,6 +2876,17 @@ static void CollectArgsForIntegratedAssembler(Compilation &C,
     CmdArgs.push_back("-target-feature");
     CmdArgs.push_back(MipsTargetFeature);
   }
+
+  // Those OSes default to enabling VIS on 64-bit SPARC.
+  // See also the corresponding code for external assemblers in
+  // sparc::getSparcAsmModeForCPU().
+  bool IsSparcV9ATarget =
+      (C.getDefaultToolChain().getArch() == llvm::Triple::sparcv9) &&
+      (Triple.isOSLinux() || Triple.isOSFreeBSD() || Triple.isOSOpenBSD());
+  if (IsSparcV9ATarget && SparcTargetFeatures.empty()) {
+    CmdArgs.push_back("-target-feature");
+    CmdArgs.push_back("+vis");
+  }
   for (const char *Feature : SparcTargetFeatures) {
     CmdArgs.push_back("-target-feature");
     CmdArgs.push_back(Feature);

--- a/clang/test/Driver/sparc-ias-Wa.s
+++ b/clang/test/Driver/sparc-ias-Wa.s
@@ -58,3 +58,12 @@
 // V9D: "-target-feature" "+vis"
 // V9D: "-target-feature" "+vis2"
 // V9D: "-target-feature" "+vis3"
+
+// RUN: %clang --target=sparc64-linux-gnu -### -fintegrated-as -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=VIS-DEFAULT %s
+// RUN: %clang --target=sparc64-freebsd -### -fintegrated-as -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=VIS-DEFAULT %s
+// RUN: %clang --target=sparc64-openbsd -### -fintegrated-as -c %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=VIS-DEFAULT %s
+// VIS-DEFAULT: -cc1as
+// VIS-DEFAULT: "-target-feature" "+vis"


### PR DESCRIPTION
On those OSes, clang should set the assembler to enable VIS by default. This is already the case when clang calls an external assembler, so make sure clang+IAS use the same defaults.

This should fix [issue #125124](https://github.com/llvm/llvm-project/issues/125124).