### PR TITLE
[clang] Fix darwin-related tests' REQUIRES annotation

### DIFF
--- a/clang/test/Driver/apple-arm64-arch.c
+++ b/clang/test/Driver/apple-arm64-arch.c
@@ -1,6 +1,6 @@
 // RUN: env SDKROOT="/" %clang -arch arm64 -c -### %s 2>&1 | \
 // RUN:   FileCheck %s
 //
-// REQUIRES: system-darwin && target={{.*}}-darwin{{.*}}
+// REQUIRES: system-darwin && target={{.*}}-{{darwin|macos}}{{.*}}
 //
 // CHECK: "-triple" "arm64-apple-macosx{{[0-9.]+}}"

--- a/clang/test/Driver/apple-arm64-arch.c
+++ b/clang/test/Driver/apple-arm64-arch.c
@@ -1,6 +1,6 @@
 // RUN: env SDKROOT="/" %clang -arch arm64 -c -### %s 2>&1 | \
 // RUN:   FileCheck %s
 //
-// REQUIRES: system-darwin
+// REQUIRES: system-darwin && target={{.*}}-darwin{{.*}}
 //
 // CHECK: "-triple" "arm64-apple-macosx{{[0-9.]+}}"

--- a/clang/test/Driver/compilation_database_multiarch.c
+++ b/clang/test/Driver/compilation_database_multiarch.c
@@ -1,4 +1,4 @@
-// REQUIRES: system-darwin && target={{.*}}-darwin{{.*}}
+// REQUIRES: system-darwin && target={{.*}}-{{darwin|macos}}{{.*}}
 
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %clang -fdriver-only -o %t/out %s -mtargetos=macos12 -arch arm64 -arch x86_64 -MJ %t/compilation_database.json

--- a/clang/test/Driver/compilation_database_multiarch.c
+++ b/clang/test/Driver/compilation_database_multiarch.c
@@ -1,4 +1,4 @@
-// REQUIRES: system-darwin
+// REQUIRES: system-darwin && target={{.*}}-darwin{{.*}}
 
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %clang -fdriver-only -o %t/out %s -mtargetos=macos12 -arch arm64 -arch x86_64 -MJ %t/compilation_database.json

--- a/clang/test/Driver/darwin-ld-platform-version-macos-requires-darwin.c
+++ b/clang/test/Driver/darwin-ld-platform-version-macos-requires-darwin.c
@@ -7,4 +7,4 @@
 
 // CHECK: "-platform_version" "macos" "{{[0-9]+}}.0.0" "{{[0-9]+}}.{{[0-9]+}}"
 
-// REQUIRES: system-darwin && target={{.*}}-darwin{{.*}}
+// REQUIRES: system-darwin && target={{.*}}-{{darwin|macos}}{{.*}}

--- a/clang/test/Driver/darwin-ld-platform-version-macos-requires-darwin.c
+++ b/clang/test/Driver/darwin-ld-platform-version-macos-requires-darwin.c
@@ -7,4 +7,4 @@
 
 // CHECK: "-platform_version" "macos" "{{[0-9]+}}.0.0" "{{[0-9]+}}.{{[0-9]+}}"
 
-// REQUIRES: system-darwin
+// REQUIRES: system-darwin && target={{.*}}-darwin{{.*}}

--- a/clang/test/Driver/mtargetos-darwin.c
+++ b/clang/test/Driver/mtargetos-darwin.c
@@ -11,7 +11,7 @@
 // RUN: not %clang -mtargetos=darwin20 -arch arm64 -c %s -o %t.o -### 2>&1 | FileCheck --check-prefix=INVALIDOS %s
 // RUN: not %clang -mtargetos=ios -arch arm64 -c %s -o %t.o -### 2>&1 | FileCheck --check-prefix=NOVERSION %s
 
-// REQUIRES: system-darwin && target={{.*}}-darwin{{.*}}
+// REQUIRES: system-darwin && target={{.*}}-{{darwin|macos}}{{.*}}
 
 // MACOS: "-cc1" "-triple" "arm64-apple-macosx11.0.0"
 // MACOS-NEXT: "-cc1" "-triple" "x86_64-apple-macosx11.0.0"

--- a/clang/test/Driver/mtargetos-darwin.c
+++ b/clang/test/Driver/mtargetos-darwin.c
@@ -11,7 +11,7 @@
 // RUN: not %clang -mtargetos=darwin20 -arch arm64 -c %s -o %t.o -### 2>&1 | FileCheck --check-prefix=INVALIDOS %s
 // RUN: not %clang -mtargetos=ios -arch arm64 -c %s -o %t.o -### 2>&1 | FileCheck --check-prefix=NOVERSION %s
 
-// REQUIRES: system-darwin
+// REQUIRES: system-darwin && target={{.*}}-darwin{{.*}}
 
 // MACOS: "-cc1" "-triple" "arm64-apple-macosx11.0.0"
 // MACOS-NEXT: "-cc1" "-triple" "x86_64-apple-macosx11.0.0"

--- a/clang/test/Driver/xros-driver-requires-darwin-host.c
+++ b/clang/test/Driver/xros-driver-requires-darwin-host.c
@@ -1,4 +1,4 @@
-// REQUIRES: system-darwin && target={{.*}}-darwin{{.*}}
+// REQUIRES: system-darwin && target={{.*}}-{{darwin|macos}}{{.*}}
 
 // RUN: env XROS_DEPLOYMENT_TARGET=1.0 %clang -arch arm64 -c -### %s 2>&1 | FileCheck %s
 

--- a/clang/test/Driver/xros-driver-requires-darwin-host.c
+++ b/clang/test/Driver/xros-driver-requires-darwin-host.c
@@ -1,4 +1,4 @@
-// REQUIRES: system-darwin
+// REQUIRES: system-darwin && target={{.*}}-darwin{{.*}}
 
 // RUN: env XROS_DEPLOYMENT_TARGET=1.0 %clang -arch arm64 -c -### %s 2>&1 | FileCheck %s
 

--- a/clang/test/Index/pch-from-libclang.c
+++ b/clang/test/Index/pch-from-libclang.c
@@ -18,7 +18,7 @@
 // RUN: c-index-test -test-load-source local %s -include %t.clang.h -fmodules -fmodules-cache-path=%t.mcp -Xclang -triple -Xclang x86_64-apple-darwin | FileCheck %s
 
 // FIXME: Still fails on at least some linux boxen.
-// REQUIRES: system-darwin && target={{.*}}-darwin{{.*}}
+// REQUIRES: system-darwin && target={{.*}}-{{darwin|macos}}{{.*}}
 
 #ifndef HEADER
 #define HEADER

--- a/clang/test/Index/pch-from-libclang.c
+++ b/clang/test/Index/pch-from-libclang.c
@@ -18,7 +18,7 @@
 // RUN: c-index-test -test-load-source local %s -include %t.clang.h -fmodules -fmodules-cache-path=%t.mcp -Xclang -triple -Xclang x86_64-apple-darwin | FileCheck %s
 
 // FIXME: Still fails on at least some linux boxen.
-// REQUIRES: system-darwin
+// REQUIRES: system-darwin && target={{.*}}-darwin{{.*}}
 
 #ifndef HEADER
 #define HEADER


### PR DESCRIPTION
The tests updated by this commit were designed to check features in the
clang's driver and index that require clang to be targgeting a darwin
platform while running on a darwin host. For that, their execution is
currently gated by the `REQUIRES: system-darwin` annotation.

This approach becomes a problem when trying to run such tests on a
cross-compiling build of clang on a darwin platform. When no darwin
targets are included in the build, the tests will still run on a darwin
host and fail spuriously because of the missing target.

To fix this issue, this patch introduces an extra condition to the
tests' REQUIRES annotation, `target={{.*}}-darwin{{.*}}`, ensuring they
only run when the relevant target is present.
