### PR TITLE
[EquivClasses] Fix signature of copy-assignment operator

### DIFF
--- a/llvm/include/llvm/ADT/EquivalenceClasses.h
+++ b/llvm/include/llvm/ADT/EquivalenceClasses.h
@@ -144,7 +144,7 @@ public:
     operator=(RHS);
   }
 
-  const EquivalenceClasses &operator=(const EquivalenceClasses &RHS) {
+  EquivalenceClasses &operator=(const EquivalenceClasses &RHS) {
     TheMapping.clear();
     for (iterator I = RHS.begin(), E = RHS.end(); I != E; ++I)
       if (I->isLeader()) {

--- a/llvm/unittests/ADT/EquivalenceClassesTest.cpp
+++ b/llvm/unittests/ADT/EquivalenceClassesTest.cpp
@@ -13,6 +13,15 @@ using namespace llvm;
 
 namespace llvm {
 
+TEST(EquivalenceClassesTest, CopyAssignemnt) {
+  EquivalenceClasses<int> EC, Copy;
+  EC.insert(1);
+  EC.insert(4);
+  EquivalenceClasses<int> &Ref = Copy = EC;
+  EXPECT_EQ(Copy.getNumClasses(), 2u);
+  EXPECT_EQ(&Ref, &Copy);
+}
+
 TEST(EquivalenceClassesTest, NoMerges) {
   EquivalenceClasses<int> EqClasses;
   // Until we merged any sets, check that every element is only equivalent to


### PR DESCRIPTION
The current signature is unusual, and deviates from the C++ operator overloading spec.

https://en.cppreference.com/w/cpp/language/copy_assignment