### PR TITLE
[mlir][vector][docs] Document indexed vs. non-indexed arguments

### DIFF
--- a/mlir/docs/Dialects/Vector.md
+++ b/mlir/docs/Dialects/Vector.md
@@ -320,7 +320,12 @@ There is **no consistent way** to identify:
 A more consistent way to classify "to", "from", and "value-to-store" arguments
 is by determining whether an operand is _indexed_ or _non-indexed_.
 
-#### **Example: `vector.transfer_read` and `vector.transfer_write`**
+The distinction is somewhat intuitive, but for clarity:
+- Indexed operands require indices to specify an element/slice (e.g., `%A[0]`).
+- Non-indexed operands do not require indices as they are accessed in their
+  entirety (e.g., `%B`).
+
+Below is an example using: `vector.transfer_read` and `vector.transfer_write`
 ```mlir
                       Indexed Operand
                              |


### PR DESCRIPTION
Adds a section to the Vector dialect documentation introducing the
distinction between **indexed** and **non-indexed** arguments for
"read"/"write"-like operations.

The goal is to provide guidance on improving terminology consistency
within the Vector dialect and to establish a point of reference for
future discussions.

Credits to Diego Caballero <dieg0ca6aller0@gmail.com> for proposing this
terminology in https://github.com/llvm/llvm-project/pull/115824.
