### PR TITLE
[llvm-ar] Fix darwin-related tests' XFAIL annotation

### DIFF
--- a/llvm/test/tools/llvm-ar/extract.test
+++ b/llvm/test/tools/llvm-ar/extract.test
@@ -1,5 +1,5 @@
 ## Test extract operation.
-# XFAIL: system-darwin
+# XFAIL: target={{.*}}-darwin{{.*}}
 
 # RUN: rm -rf %t && mkdir -p %t/extracted/
 

--- a/llvm/test/tools/llvm-ar/print.test
+++ b/llvm/test/tools/llvm-ar/print.test
@@ -1,5 +1,5 @@
 ## Test Print output
-# XFAIL: system-darwin
+# XFAIL: target={{.*}}-darwin{{.*}}
 
 # RUN: rm -rf %t && mkdir -p %t
 # RUN: echo file1 > %t/1.txt


### PR DESCRIPTION
The tests updated by this commit are expected to fail when targetting a
darwin platform. As they rely on target detection based on the host,
this is currently checked by using the `XFAIL: system-darwin`
annotation.

This approach becomes a problem when trying to run such tests on a
cross-compiling build of clang on a darwin platform. When no darwin
targets are included in the build, the XFAIL will still apply even
though the target used is not related to the darwin platform, and the
tests will unexpectedly pass.

To fix this issue, this patch updates the condition used by the tests'
XFAIL annotation to `target={{.*}}-darwin{{.*}}`, ensuring they only are
xfailed when the relevant target is used.
