### PR TITLE
Make a copy from `getTraversalScope()`

### DIFF
--- a/clang-tools-extra/clangd/refactor/tweaks/AnnotateHighlightings.cpp
+++ b/clang-tools-extra/clangd/refactor/tweaks/AnnotateHighlightings.cpp
@@ -51,7 +51,8 @@ Expected<Tweak::Effect> AnnotateHighlightings::apply(const Selection &Inputs) {
         *Inputs.AST, /*IncludeInactiveRegionTokens=*/true);
   } else {
     // Store the existing scopes.
-    const auto &BackupScopes = Inputs.AST->getASTContext().getTraversalScope();
+    const std::vector<Decl *> BackupScopes =
+        Inputs.AST->getASTContext().getTraversalScope();
     // Narrow the traversal scope to the selected node.
     Inputs.AST->getASTContext().setTraversalScope(
         {const_cast<Decl *>(CommonDecl)});


### PR DESCRIPTION
Fix container-overflow after 9189d84abbfc643db0053200c1c2e16b1e78e8f9.
