### PR TITLE
[z/OS] Add call to shmctl() to release shared memory on z/OS

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/MemoryMapper.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/MemoryMapper.h
@@ -157,6 +157,7 @@ private:
   struct Reservation {
     void *LocalAddr;
     size_t Size;
+    int SharedMemoryId;
   };
 
   ExecutorProcessControl &EPC;

--- a/llvm/lib/ExecutionEngine/Orc/MemoryMapper.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/MemoryMapper.cpp
@@ -220,10 +220,11 @@ void SharedMemoryMapper::reserve(size_t NumBytes,
                                  OnReservedFunction OnReserved) {
 #if (defined(LLVM_ON_UNIX) && !defined(__ANDROID__)) || defined(_WIN32)
 
+  int SharedMemoryId = -1;
   EPC.callSPSWrapperAsync<
       rt::SPSExecutorSharedMemoryMapperServiceReserveSignature>(
       SAs.Reserve,
-      [this, NumBytes, OnReserved = std::move(OnReserved)](
+      [this, NumBytes, OnReserved = std::move(OnReserved), SharedMemoryId](
           Error SerializationErr,
           Expected<std::pair<ExecutorAddr, std::string>> Result) mutable {
         if (SerializationErr) {
@@ -248,7 +249,7 @@ void SharedMemoryMapper::reserve(size_t NumBytes,
             SharedMemoryName.size());
         auto HashedName = BLAKE3::hash<sizeof(key_t)>(Data);
         key_t Key = *reinterpret_cast<key_t *>(HashedName.data());
-        int SharedMemoryId =
+        SharedMemoryId =
             shmget(Key, NumBytes, IPC_CREAT | __IPC_SHAREAS | 0700);
         if (SharedMemoryId < 0) {
           return OnReserved(errorCodeToError(
@@ -298,7 +299,8 @@ void SharedMemoryMapper::reserve(size_t NumBytes,
 #endif
         {
           std::lock_guard<std::mutex> Lock(Mutex);
-          Reservations.insert({RemoteAddr, {LocalAddr, NumBytes}});
+          Reservations.insert(
+              {RemoteAddr, {LocalAddr, NumBytes, SharedMemoryId}});
         }
 
         OnReserved(ExecutorAddrRange(RemoteAddr, NumBytes));
@@ -396,7 +398,8 @@ void SharedMemoryMapper::release(ArrayRef<ExecutorAddr> Bases,
 #if defined(LLVM_ON_UNIX)
 
 #if defined(__MVS__)
-      if (shmdt(Reservations[Base].LocalAddr) < 0)
+      if (shmdt(Reservations[Base].LocalAddr) < 0 ||
+          shmctl(Reservations[Base].SharedMemoryId, IPC_RMID, NULL) < 0)
         Err = joinErrors(std::move(Err), errorCodeToError(errnoAsErrorCode()));
 #else
       if (munmap(Reservations[Base].LocalAddr, Reservations[Base].Size) != 0)


### PR DESCRIPTION
This PR will solve the issue with leaking shared memory we have after running llvm lit test on z/OS.
In particular llvm/unittests/ExecutionEngine/Orc/SharedMemoryMapperTest.cpp was causing the leak.