### PR TITLE
[ORC] skip reoptimization tests on ARM

### DIFF
--- a/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
@@ -59,6 +59,10 @@ protected:
     if (Triple.isRISCV())
       GTEST_SKIP();
 
+    // ARM is not supported yet.
+    if (Triple.isARM())
+      GTEST_SKIP();
+
     auto EPC = SelfExecutorProcessControl::Create();
     if (!EPC) {
       consumeError(EPC.takeError());


### PR DESCRIPTION
It failed on armv7 with "Architecture not supported" which is due to StubTests being not supported on ARM

	/builds/fossdd/aports/main/llvm20/src/llvm-project-20.1.0.src/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp:140: Failure
	Value of: llvm::detail::TakeError(RM.takeError())
	Expected: succeeded
	  Actual: failed  (Architecture not supported) (of type llvm::detail::ErrorHolder)