### PR TITLE
[C2y] Implement WG14 N3411

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -108,6 +108,9 @@ C Language Changes
 
 C2y Feature Support
 ^^^^^^^^^^^^^^^^^^^
+- Implemented N3411 which allows a source file to not end with a newline
+  character. This is still reported as a conforming extension in earlier
+  language modes.
 
 C23 Feature Support
 ^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Lex/Lexer.cpp
+++ b/clang/lib/Lex/Lexer.cpp
@@ -3192,23 +3192,22 @@ bool Lexer::LexEndOfFile(Token &Result, const char *CurPtr) {
   if (CurPtr != BufferStart && (CurPtr[-1] != '\n' && CurPtr[-1] != '\r')) {
     DiagnosticsEngine &Diags = PP->getDiagnostics();
     SourceLocation EndLoc = getSourceLocation(BufferEnd);
-    unsigned DiagID;
+    unsigned DiagID = diag::warn_no_newline_eof;
 
     if (LangOpts.CPlusPlus11) {
       // C++11 [lex.phases] 2.2 p2
       // Prefer the C++98 pedantic compatibility warning over the generic,
       // non-extension, user-requested "missing newline at EOF" warning.
-      if (!Diags.isIgnored(diag::warn_cxx98_compat_no_newline_eof, EndLoc)) {
+      if (!Diags.isIgnored(diag::warn_cxx98_compat_no_newline_eof, EndLoc))
         DiagID = diag::warn_cxx98_compat_no_newline_eof;
-      } else {
-        DiagID = diag::warn_no_newline_eof;
-      }
     } else {
-      DiagID = diag::ext_no_newline_eof;
+      // This is conforming in C2y, but is an extension in earlier language
+      // modes.
+      if (!LangOpts.C2y)
+        DiagID = diag::ext_no_newline_eof;
     }
 
-    Diag(BufferEnd, DiagID)
-      << FixItHint::CreateInsertion(EndLoc, "\n");
+    Diag(BufferEnd, DiagID) << FixItHint::CreateInsertion(EndLoc, "\n");
   }
 
   BufferPtr = CurPtr;

--- a/clang/test/C/C2y/n3411.c
+++ b/clang/test/C/C2y/n3411.c
@@ -1,6 +1,7 @@
-// RUN: %clang_cc1 -verify=c2y -std=c2y -Wall -pedantic %s
+// RUN: %clang_cc1 -verify=good -std=c2y -Wall -pedantic %s
 // RUN: %clang_cc1 -verify -Wnewline-eof -std=c2y -Wall -pedantic %s
 // RUN: %clang_cc1 -verify -std=c23 -Wall -pedantic %s
+// RUN: %clang_cc1 -verify=good -std=c23 %s
 
 /* WG14 N3411: Yes
  * Slay Some Earthly Demons XII
@@ -8,7 +9,7 @@
  * Allow a non-empty source file to end without a final newline character. Note
  * that this file intentionally does not end with a trailing newline.
  */
-// c2y-no-diagnostics
+// good-no-diagnostics
 
 int x; // Ensure the file contains at least one declaration.
 // expected-warning {{no newline at end of file}}

--- a/clang/test/C/C2y/n3411.c
+++ b/clang/test/C/C2y/n3411.c
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -verify=c2y -std=c2y -Wall -pedantic %s
+// RUN: %clang_cc1 -verify -Wnewline-eof -std=c2y -Wall -pedantic %s
+// RUN: %clang_cc1 -verify -std=c23 -Wall -pedantic %s
+
+/* WG14 N3411: Yes
+ * Slay Some Earthly Demons XII
+ *
+ * Allow a non-empty source file to end without a final newline character. Note
+ * that this file intentionally does not end with a trailing newline.
+ */
+// c2y-no-diagnostics
+
+int x; // Ensure the file contains at least one declaration.
+// expected-warning {{no newline at end of file}}

--- a/clang/www/c_status.html
+++ b/clang/www/c_status.html
@@ -294,7 +294,7 @@ conformance.</p>
     <tr>
       <td>Slay Some Earthly Demons XII</td>
       <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3411.pdf">N3411</a></td>
-      <td class="unknown" align="center">Unknown</td>
+      <td class="unreleased" align="center">Clang 21</td>
 	</tr>
     <tr>
       <td>Slay Some Earthly Demons XIII</td>


### PR DESCRIPTION
This paper (https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3411.pdf) allows a source file to end without a newline. Clang has supported this as a conforming extension for a long time, so this suppresses the diagnotic in C2y mode but continues to diagnose as an extension in earlier language modes. It also continues to diagnose if the user passes -Wnewline-eof explicitly.