### PR TITLE
[MLIR] Refactor to create vectorization convOp precondition check

### DIFF
--- a/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
@@ -2027,6 +2027,7 @@ static LogicalResult vectorizeConvOpPrecondition(linalg::LinalgOp convOp) {
   ShapedType resShapedType = getOperandType(convOp.getDpsInitOperand(0));
   // (LHS has dimension NCW/NWC and RES has dimension NFW/NCW/NWF/NWC) OR
   // (non-channeled convolution -> LHS and RHS both have single dimensions).
+  // Note that this also ensures 2D and 3D convolutions are rejected.
   if ((lhsShapedType.getRank() != 3 || resShapedType.getRank() != 3) &&
       (lhsShapedType.getRank() != 1 || resShapedType.getRank() != 1))
     return failure();

--- a/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp
@@ -1948,7 +1948,10 @@ static bool isCastOfBlockArgument(Operation *op) {
          isa<BlockArgument>(op->getOperand(0));
 }
 
-// Returns true iff it is a valid conv/pooling op.
+// Returns the ConvOperationKind of the op using reduceOp of the generic
+// payload. If it is neither a convolution nor a pooling, it returns
+// std::nullopt.
+//
 // If (region has 2 ops (reduction + yield) or 3 ops (extension + reduction
 // + yield) and rhs is not used) then it is the body of a pooling
 // If conv, check for single `mul` predecessor. The `mul` operands must be


### PR DESCRIPTION
In corner situations, the vectorization pass may face to lower a conv2d op and assert in a completely irrelevant location in vectorizeConvolution() subroutine.

~~This PR rejects the conv2d op early and make the asserted routine to return failure as a defensive workaround.~~

In addressing this, the PR moved all condition check away from the `Conv1dGenerator` into the `convOpPreconditionCheck()` function. This makes the unsupported ops such as conv2d to be rejected early and leave a cleaner `Conv1dGenerator` constructor.