### PR TITLE
[libc][docs] Fix libc docs build post #129138

### DIFF
--- a/libc/docs/headers/stdfix.rst
+++ b/libc/docs/headers/stdfix.rst
@@ -2,7 +2,7 @@
 StdFix Functions
 ================
 
-.. include:: ../../check.rst
+.. include:: ../check.rst
 
 Standards and Goals
 -------------------


### PR DESCRIPTION
The docs build action was failing with libc due to checks.rst not existing in the expected path. This patch adjusts the path to the actual path which seems to make everything happy. It seems like this did not show up before as stdfix.rst was not included in a place that actually caused it to get picked up by sphinx.