### PR TITLE
[Clang][NFC] Change uses of getAs() to castAs() where the target type is assured.

### DIFF
--- a/clang/lib/CodeGen/Targets/AArch64.cpp
+++ b/clang/lib/CodeGen/Targets/AArch64.cpp
@@ -763,7 +763,7 @@ bool AArch64ABIInfo::passAsPureScalableType(
     return false;
 
   bool isPredicate;
-  switch (Ty->getAs<BuiltinType>()->getKind()) {
+  switch (Ty->castAs<BuiltinType>()->getKind()) {
 #define SVE_VECTOR_TYPE(Name, MangledName, Id, SingletonId)                    \
   case BuiltinType::Id:                                                        \
     isPredicate = false;                                                       \

--- a/clang/lib/Sema/SemaTemplateVariadic.cpp
+++ b/clang/lib/Sema/SemaTemplateVariadic.cpp
@@ -834,7 +834,7 @@ bool Sema::CheckParameterPacksForExpansion(
 
             if (TA.getKind() == TemplateArgument::Type)
               return !TA.getAsType()
-                          ->getAs<PackExpansionType>()
+                          ->castAs<PackExpansionType>()
                           ->getNumExpansions();
 
             if (TA.getKind() == TemplateArgument::Expression)


### PR DESCRIPTION
Static analysis identified two uses of `getAs()` for which the result pointer was unconditionally dereferenced. Source code inspection confirmed that the target type is assured by prior checks. This change replaces these uses of `getAs()` with `castAs()`.

The first case, in `clang/lib/CodeGen/Targets/AArch64.cpp`, performs a cast to `BuiltinType` following a check for `isBuiltinType()`.

The second case, in `clang/lib/Sema/SemaTemplateVariadic.cpp`, performs a cast to `PackExpansionType` on the result of a call to `getAsType()` on an object of type `TemplateArgument` following confirmation that `isPackExpansion()` returned true and that `getKind()` returned `TemplateArgument::Type`. Inspection of `isPackExpansion()` revealed that it only returns true when the template argument kind is `TemplateArgument::Type` if `isa<PackExpansionType>(getAsType())` is true.