### PR TITLE
[Flang] Change sizeof argument name to "x"

### DIFF
--- a/flang/lib/Evaluate/intrinsics.cpp
+++ b/flang/lib/Evaluate/intrinsics.cpp
@@ -940,7 +940,7 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
             OptionalDIM, // unless array is assumed-size
             SizeDefaultKIND},
         KINDInt, Rank::scalar, IntrinsicClass::inquiryFunction},
-    {"sizeof", {{"a", AnyData, Rank::anyOrAssumedRank}}, SubscriptInt,
+    {"sizeof", {{"x", AnyData, Rank::anyOrAssumedRank}}, SubscriptInt,
         Rank::scalar, IntrinsicClass::inquiryFunction},
     {"spacing", {{"x", SameReal}}, SameReal},
     {"spread",

--- a/flang/test/Semantics/sizeof.f90
+++ b/flang/test/Semantics/sizeof.f90
@@ -1,0 +1,10 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+  character(len=20) :: a, b
+  if (sizeof(a) == sizeof(x=b)) then
+    print *, "pass"
+  else
+    print *, "fail"
+  end if
+  !ERROR: unknown keyword argument to intrinsic 'sizeof'
+  print *, sizeof(a=a)
+end


### PR DESCRIPTION
This closes #128610 by fixing the name of the argument to the sizeof function to be "x" and adds a test.