### PR TITLE
[DirectX] Match DXC's resource order in DX container

### DIFF
--- a/llvm/include/llvm/BinaryFormat/DXContainer.h
+++ b/llvm/include/llvm/BinaryFormat/DXContainer.h
@@ -320,7 +320,7 @@ ArrayRef<EnumEntry<ResourceKind>> getResourceKinds();
 
 #define RESOURCE_FLAG(Index, Enum) bool Enum = false;
 struct ResourceFlags {
-  ResourceFlags() {};
+  ResourceFlags() : Flags(0U) {};
   struct FlagsBits {
 #include "llvm/BinaryFormat/DXContainerConstants.def"
   };

--- a/llvm/test/CodeGen/DirectX/ContainerData/PSVResources-order.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/PSVResources-order.ll
@@ -1,0 +1,26 @@
+; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s
+
+; Check that resources are emitted to the object in the order that matches what
+; the DXIL validator expects: CBuffers, Samplers, SRVs, and then UAVs.
+
+; CHECK: Resources:
+; CHECK: - Type: CBV
+; TODO:  - Type: Sampler
+; CHECK: - Type: SRVRaw
+; CHECK: - Type: UAVTyped
+
+target triple = "dxil-unknown-shadermodel6.0-compute"
+
+define void @main() #0 {
+  %uav0 = call target("dx.TypedBuffer", i32, 1, 0, 1)
+      @llvm.dx.resource.handlefrombinding.tdx.TypedBuffer_i32_1_0t(
+          i32 2, i32 7, i32 1, i32 0, i1 false)
+  %srv0 = call target("dx.RawBuffer", i8, 0, 0)
+      @llvm.dx.resource.handlefrombinding.tdx.RawBuffer_i8_0_0t(
+          i32 1, i32 8, i32 1, i32 0, i1 false)
+  %cbuf = call target("dx.CBuffer", target("dx.Layout", {float}, 4, 0))
+      @llvm.dx.resource.handlefrombinding(i32 3, i32 2, i32 1, i32 0, i1 false)
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }

--- a/llvm/test/CodeGen/DirectX/ContainerData/PSVResources.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/PSVResources.ll
@@ -6,6 +6,17 @@ target triple = "dxil-unknown-shadermodel6.0-compute"
 
 define void @main() #0 {
 
+  ; cbuffer : register(b2, space3) { float x; }
+; CHECK:        - Type:            CBV
+; CHECK:          Space:           3
+; CHECK:          LowerBound:      2
+; CHECK:          UpperBound:      2
+; CHECK:          Kind:            CBuffer
+; CHECK:          Flags:
+; CHECK:            UsedByAtomic64:  false
+  %cbuf = call target("dx.CBuffer", target("dx.Layout", {float}, 4, 0))
+      @llvm.dx.resource.handlefrombinding(i32 3, i32 2, i32 1, i32 0, i1 false)
+
   ; ByteAddressBuffer Buf : register(t8, space1)
 ; CHECK:        - Type:            SRVRaw
 ; CHECK:          Space:           1


### PR DESCRIPTION
DXC and the DXIL validator expect resources in a DX container to be specifically ordered CBuffers, Samplers, SRVs, and then UAVs. Match this behaviour so that we can pass the validator.

Fixes #130232.