### PR TITLE
clang: Switch linker-wrapper test to unsupported windows

### DIFF
--- a/clang/test/Driver/linker-wrapper.c
+++ b/clang/test/Driver/linker-wrapper.c
@@ -1,8 +1,7 @@
+// UNSUPPORTED: system-windows
 // REQUIRES: x86-registered-target
 // REQUIRES: nvptx-registered-target
 // REQUIRES: amdgpu-registered-target
-
-// REQUIRES: system-linux
 
 // An externally visible variable so static libraries extract.
 __attribute__((visibility("protected"), used)) int x;


### PR DESCRIPTION
Works fine on macos, so expand the tested hosts. This should work
on windows too, but it's been a pain debugging the error on the bot.