### PR TITLE
[alpha.webkit.UncountedCallArgsChecker] Recognize CXXUnresolvedConstructExpr as a safe origin.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
@@ -43,6 +43,10 @@ bool tryToFindPtrOrigin(
         break;
       }
     }
+    if (auto *TempExpr = dyn_cast<CXXUnresolvedConstructExpr>(E)) {
+      if (isSafePtrType(TempExpr->getTypeAsWritten()))
+        return callback(TempExpr, true);
+    }
     if (auto *POE = dyn_cast<PseudoObjectExpr>(E)) {
       if (auto *RF = POE->getResultExpr()) {
         E = RF;

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -162,13 +162,14 @@ static bool isPtrOfType(const clang::QualType T, Predicate Pred) {
       type = elaboratedT->desugar();
       continue;
     }
-    auto *SpecialT = type->getAs<TemplateSpecializationType>();
-    if (!SpecialT)
-      return false;
-    auto *Decl = SpecialT->getTemplateName().getAsTemplateDecl();
-    if (!Decl)
-      return false;
-    return Pred(Decl->getNameAsString());
+    if (auto *SpecialT = type->getAs<TemplateSpecializationType>()) {
+      auto *Decl = SpecialT->getTemplateName().getAsTemplateDecl();
+      return Decl && Pred(Decl->getNameAsString());
+    } else if (auto *DTS = type->getAs<DeducedTemplateSpecializationType>()) {
+      auto *Decl = DTS->getTemplateName().getAsTemplateDecl();
+      return Decl && Pred(Decl->getNameAsString());
+    } else
+      break;
   }
   return false;
 }

--- a/clang/test/Analysis/Checkers/WebKit/call-args.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args.cpp
@@ -359,6 +359,41 @@ namespace call_with_ptr_on_ref {
   }
 }
 
+namespace call_with_explicit_construct_from_auto {
+
+  struct Impl {
+    void ref() const;
+    void deref() const;
+
+    static Ref<Impl> create();
+  };
+
+  template <typename T>
+  struct ArgObj {
+    T* t;
+  };
+
+  struct Object {
+    Object();
+    Object(Ref<Impl>&&);
+
+    Impl* impl() const { return m_impl.get(); }
+
+    static Object create(ArgObj<char>&) { return Impl::create(); }
+    static void bar(Impl&);
+
+  private:
+    RefPtr<Impl> m_impl;
+  };
+
+  template<typename CharacterType> void foo()
+  {
+      auto result = Object::create(ArgObj<CharacterType> { });
+      Object::bar(Ref { *result.impl() });
+  }
+
+}
+
 namespace call_with_explicit_temporary_obj {
   void foo() {
     Ref { *provide() }->method();


### PR DESCRIPTION
Handle CXXUnresolvedConstructExpr in tryToFindPtrOrigin so that constructing Ref, RefPtr, CheckedRef, CheckedPtr, ... constructed in such a way that its type is unresolved at AST level will be still treated as a safe pointer origin.

Also fix a bug in isPtrOfType that it was not recognizing DeducedTemplateSpecializationType.