### PR TITLE
[RISCV][lld] Guarding lld relaxation for RISCV

### DIFF
--- a/lld/ELF/Arch/RISCV.cpp
+++ b/lld/ELF/Arch/RISCV.cpp
@@ -902,6 +902,9 @@ bool RISCV::relaxOnce(int pass) const {
   if (ctx.arg.relocatable)
     return false;
 
+  if (pass == 29)
+    return false;
+
   if (pass == 0)
     initSymbolAnchors(ctx);
 


### PR DESCRIPTION
Based on https://github.com/llvm/llvm-project/issues/123248#issuecomment-2675911618, the relaxation algorithm assumes relaxing a call will shift the later function forward by the same bytes we removed. As some sections are between call and its call target are 32-byte aligned, the call and call target sections might not be the same distance apart anymore. We guard band the relaxation so it stops the relaxation loop and take the last state.