### PR TITLE
AMDGPU: Replace undef phi inputs with poison in tests

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/divergent-control-flow.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/divergent-control-flow.ll
@@ -26,7 +26,7 @@ if.true:
   br label %endif
 
 endif:
-  %v = phi i32 [ %val, %if.true ], [ undef, %entry ]
+  %v = phi i32 [ %val, %if.true ], [ poison, %entry ]
   ret i32 %v
 }
 
@@ -49,7 +49,7 @@ entry:
   br i1 %c, label %if.true, label %endif
 
 endif:
-  %v = phi i32 [ %val, %if.true ], [ undef, %entry ]
+  %v = phi i32 [ %val, %if.true ], [ poison, %entry ]
   ret i32 %v
 
 if.true:
@@ -82,7 +82,7 @@ if.true:
   br label %endif
 
 endif:
-  %v = phi i32 [ %val, %if.true ], [ undef, %entry ]
+  %v = phi i32 [ %val, %if.true ], [ poison, %entry ]
   ret i32 %v
 }
 
@@ -114,7 +114,7 @@ if.true:
   br label %endif
 
 endif:
-  %v = phi i32 [ %val, %if.true ], [ undef, %entry ]
+  %v = phi i32 [ %val, %if.true ], [ poison, %entry ]
   ret i32 %v
 }
 

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-codegenprepare-break-large-phis.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-codegenprepare-break-large-phis.ll
@@ -643,11 +643,11 @@ define amdgpu_kernel void @phi_v15i8_random_constant_init(<15 x i8> %in, ptr %ou
 ; OPT-NEXT:    br label [[FINALLY]]
 ; OPT:       finally:
 ; OPT-NEXT:    [[TMP0:%.*]] = phi <4 x i8> [ <i8 poison, i8 1, i8 2, i8 3>, [[THEN]] ], [ [[LARGEPHI_EXTRACTSLICE1]], [[ELSE]] ]
-; OPT-NEXT:    [[TMP1:%.*]] = phi <4 x i8> [ <i8 4, i8 undef, i8 6, i8 7>, [[THEN]] ], [ [[LARGEPHI_EXTRACTSLICE3]], [[ELSE]] ]
+; OPT-NEXT:    [[TMP1:%.*]] = phi <4 x i8> [ <i8 4, i8 poison, i8 6, i8 7>, [[THEN]] ], [ [[LARGEPHI_EXTRACTSLICE3]], [[ELSE]] ]
 ; OPT-NEXT:    [[TMP2:%.*]] = phi <4 x i8> [ <i8 9, i8 10, i8 11, i8 12>, [[THEN]] ], [ [[LARGEPHI_EXTRACTSLICE5]], [[ELSE]] ]
 ; OPT-NEXT:    [[TMP3:%.*]] = phi i8 [ 13, [[THEN]] ], [ [[LARGEPHI_EXTRACTSLICE7]], [[ELSE]] ]
 ; OPT-NEXT:    [[TMP4:%.*]] = phi i8 [ 14, [[THEN]] ], [ [[LARGEPHI_EXTRACTSLICE9]], [[ELSE]] ]
-; OPT-NEXT:    [[TMP5:%.*]] = phi i8 [ undef, [[THEN]] ], [ [[LARGEPHI_EXTRACTSLICE11]], [[ELSE]] ]
+; OPT-NEXT:    [[TMP5:%.*]] = phi i8 [ poison, [[THEN]] ], [ [[LARGEPHI_EXTRACTSLICE11]], [[ELSE]] ]
 ; OPT-NEXT:    [[LARGEPHI_INSERTSLICE0:%.*]] = call <15 x i8> @llvm.vector.insert.v15i8.v4i8(<15 x i8> poison, <4 x i8> [[TMP0]], i64 0)
 ; OPT-NEXT:    [[LARGEPHI_INSERTSLICE1:%.*]] = call <15 x i8> @llvm.vector.insert.v15i8.v4i8(<15 x i8> [[LARGEPHI_INSERTSLICE0]], <4 x i8> [[TMP1]], i64 4)
 ; OPT-NEXT:    [[LARGEPHI_INSERTSLICE2:%.*]] = call <15 x i8> @llvm.vector.insert.v15i8.v4i8(<15 x i8> [[LARGEPHI_INSERTSLICE1]], <4 x i8> [[TMP2]], i64 8)
@@ -666,7 +666,7 @@ define amdgpu_kernel void @phi_v15i8_random_constant_init(<15 x i8> %in, ptr %ou
 ; NOOPT-NEXT:    [[Y:%.*]] = insertelement <15 x i8> [[IN:%.*]], i8 64, i32 6
 ; NOOPT-NEXT:    br label [[FINALLY]]
 ; NOOPT:       finally:
-; NOOPT-NEXT:    [[VAL:%.*]] = phi <15 x i8> [ <i8 poison, i8 1, i8 2, i8 3, i8 4, i8 undef, i8 6, i8 7, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 undef>, [[THEN]] ], [ [[Y]], [[ELSE]] ]
+; NOOPT-NEXT:    [[VAL:%.*]] = phi <15 x i8> [ <i8 poison, i8 1, i8 2, i8 3, i8 4, i8 poison, i8 6, i8 7, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 poison>, [[THEN]] ], [ [[Y]], [[ELSE]] ]
 ; NOOPT-NEXT:    store <15 x i8> [[VAL]], ptr [[OUT:%.*]], align 1
 ; NOOPT-NEXT:    ret void
 ;
@@ -678,7 +678,7 @@ else:
   %y = insertelement <15 x i8> %in, i8 64, i32 6
   br label %finally
 finally:
-  %val = phi <15 x i8> [<i8 poison, i8 1, i8 2, i8 3, i8 4, i8 undef, i8 6, i8 7, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 undef>, %then], [%y, %else]
+  %val = phi <15 x i8> [<i8 poison, i8 1, i8 2, i8 3, i8 4, i8 poison, i8 6, i8 7, i8 9, i8 10, i8 11, i8 12, i8 13, i8 14, i8 poison>, %then], [%y, %else]
   store <15 x i8> %val, ptr %out, align 1
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/amdpal_scratch_mergedshader.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdpal_scratch_mergedshader.ll
@@ -28,7 +28,7 @@ define amdgpu_hs void @_amdgpu_hs_main(i32 inreg %arg, i32 inreg %arg1, i32 inre
   br label %bb
 
 bb:                                               ; preds = %bb, %.endls
-  %lsr.iv182 = phi ptr addrspace(5) [ undef, %bb ], [ %__llpc_global_proxy_7.i, %.endls ]
+  %lsr.iv182 = phi ptr addrspace(5) [ poison, %bb ], [ %__llpc_global_proxy_7.i, %.endls ]
   %scevgep183 = getelementptr [3 x <4 x float>], ptr addrspace(5) %lsr.iv182, i32 0, i32 1
   br label %bb
 }

--- a/llvm/test/CodeGen/AMDGPU/branch-relaxation.ll
+++ b/llvm/test/CodeGen/AMDGPU/branch-relaxation.ll
@@ -1529,7 +1529,7 @@ bb14:                                             ; preds = %bb13, %bb9
   br label %bb19
 
 bb19:                                             ; preds = %bb14, %bb13, %bb9
-  %tmp20 = phi i32 [ undef, %bb9 ], [ undef, %bb13 ], [ %tmp18, %bb14 ]
+  %tmp20 = phi i32 [ poison, %bb9 ], [ poison, %bb13 ], [ %tmp18, %bb14 ]
   %tmp21 = getelementptr inbounds i32, ptr addrspace(1) %arg, i64 %arg5
   store i32 %tmp20, ptr addrspace(1) %tmp21, align 4
   ret void

--- a/llvm/test/CodeGen/AMDGPU/bug-deadlanes.ll
+++ b/llvm/test/CodeGen/AMDGPU/bug-deadlanes.ll
@@ -18,7 +18,7 @@ define dllexport amdgpu_ps void @_amdgpu_ps_main(i32 %descTable2) #0 {
 
 bb1750:                                           ; preds = %bb1897, %.entry
   %__llpc_global_proxy_r3.12.vec.extract2358295 = phi i32 [ 0, %.entry ], [ %__llpc_global_proxy_r3.12.vec.extract2358, %bb1897 ]
-  %__llpc_global_proxy_r13.20293 = phi <4 x i32> [ undef, %.entry ], [ %__llpc_global_proxy_r13.22, %bb1897 ]
+  %__llpc_global_proxy_r13.20293 = phi <4 x i32> [ poison, %.entry ], [ %__llpc_global_proxy_r13.22, %bb1897 ]
   %__llpc_global_proxy_r10.19291 = phi <4 x i32> [ poison, %.entry ], [ %i1914, %bb1897 ]
   %i1751 = call float @llvm.amdgcn.struct.buffer.load.format.f32(<4 x i32> %i1746, i32 poison, i32 0, i32 0, i32 0)
   %i1754 = shufflevector <4 x i32> %__llpc_global_proxy_r10.19291, <4 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 7>

--- a/llvm/test/CodeGen/AMDGPU/coalescer_distribute.ll
+++ b/llvm/test/CodeGen/AMDGPU/coalescer_distribute.ll
@@ -15,7 +15,7 @@ bb6:
   br label %bb8
 
 bb8:
-  %tmp9 = phi i64 [ %tmp7, %bb6 ], [ undef, %bb2 ]
+  %tmp9 = phi i64 [ %tmp7, %bb6 ], [ poison, %bb2 ]
   %tmp10 = icmp eq i32 %tmp, 0
   br i1 %tmp10, label %bb11, label %bb23
 
@@ -26,16 +26,16 @@ bb17:
   br label %bb20
 
 bb20:
-  %tmp21 = phi i64 [ undef, %bb17 ], [ %tmp9, %bb11 ]
+  %tmp21 = phi i64 [ poison, %bb17 ], [ %tmp9, %bb11 ]
   %tmp22 = trunc i64 %tmp21 to i32
   br label %bb23
 
 bb23:
-  %tmp24 = phi i32 [ %tmp22, %bb20 ], [ undef, %bb8 ], [ undef, %bb ]
+  %tmp24 = phi i32 [ %tmp22, %bb20 ], [ poison, %bb8 ], [ poison, %bb ]
   br label %bb25
 
 bb25:
-  %tmp26 = phi i32 [ %tmp24, %bb23 ], [ undef, %bb25 ]
+  %tmp26 = phi i32 [ %tmp24, %bb23 ], [ poison, %bb25 ]
   br i1 %c3, label %bb25, label %bb30
 
 bb30:

--- a/llvm/test/CodeGen/AMDGPU/combine-add-zext-xor.ll
+++ b/llvm/test/CodeGen/AMDGPU/combine-add-zext-xor.ll
@@ -71,7 +71,7 @@ bb:                                               ; preds = %.a
   br label %bb9
 
 bb9:                                              ; preds = %bb, %.a
-  %.2.0.in.in = phi i1 [ %i5, %bb ], [ undef, %.a ]
+  %.2.0.in.in = phi i1 [ %i5, %bb ], [ poison, %.a ]
   %.2.0.in = xor i1 %.2.0.in.in, true
   %.2.0 = zext i1 %.2.0.in to i32
   %i11 = add i32 %.2, %.2.0
@@ -151,7 +151,7 @@ bb:                                               ; preds = %.a
   br label %bb9
 
 bb9:                                              ; preds = %bb, %.a
-  %.2.0.in.in = phi i1 [ %i5, %bb ], [ undef, %.a ]
+  %.2.0.in.in = phi i1 [ %i5, %bb ], [ poison, %.a ]
   %.2.0.in = xor i1 %.2.0.in.in, true
   %.2.0 = zext i1 %.2.0.in to i32
   %i11 = sub i32 %.2, %.2.0
@@ -234,7 +234,7 @@ bb:                                               ; preds = %.a
   br label %bb9
 
 bb9:                                              ; preds = %bb, %.a
-  %.2.0.in.in = phi i1 [ %i5, %bb ], [ undef, %.a ]
+  %.2.0.in.in = phi i1 [ %i5, %bb ], [ poison, %.a ]
   %t = icmp sgt i32 %.2, -1050
   %.2.0.in = or i1 %.2.0.in.in, %t
   %.2.0 = zext i1 %.2.0.in to i32
@@ -318,7 +318,7 @@ bb:                                               ; preds = %.a
   br label %bb9
 
 bb9:                                              ; preds = %bb, %.a
-  %.2.0.in.in = phi i1 [ %i5, %bb ], [ undef, %.a ]
+  %.2.0.in.in = phi i1 [ %i5, %bb ], [ poison, %.a ]
   %t = icmp sgt i32 %.2, -1050
   %.2.0.in = or i1 %.2.0.in.in, %t
   %.2.0 = zext i1 %.2.0.in to i32
@@ -397,7 +397,7 @@ bb:                                               ; preds = %.a
   br label %bb9
 
 bb9:                                              ; preds = %bb, %.a
-  %.2.0.in.in = phi i1 [ %i5, %bb ], [ undef, %.a ]
+  %.2.0.in.in = phi i1 [ %i5, %bb ], [ poison, %.a ]
   %t = icmp sgt i32 %.2, -1050
   %.2.0.in = and i1 %.2.0.in.in, %t
   %.2.0 = zext i1 %.2.0.in to i32
@@ -476,7 +476,7 @@ bb:                                               ; preds = %.a
   br label %bb9
 
 bb9:                                              ; preds = %bb, %.a
-  %.2.0.in.in = phi i1 [ %i5, %bb ], [ undef, %.a ]
+  %.2.0.in.in = phi i1 [ %i5, %bb ], [ poison, %.a ]
   %t = icmp sgt i32 %.2, -1050
   %.2.0.in = and i1 %.2.0.in.in, %t
   %.2.0 = zext i1 %.2.0.in to i32

--- a/llvm/test/CodeGen/AMDGPU/cse-phi-incoming-val.ll
+++ b/llvm/test/CodeGen/AMDGPU/cse-phi-incoming-val.ll
@@ -30,7 +30,7 @@ bb9:                                              ; preds = %bb5
   br label %bb10
 
 bb10:                                             ; preds = %bb9, %bb5, %bb3, %bb
-  %tmp11 = phi float [ 1.000000e+00, %bb3 ], [ 0.000000e+00, %bb9 ], [ 1.000000e+00, %bb ], [ undef, %bb5 ]
+  %tmp11 = phi float [ 1.000000e+00, %bb3 ], [ 0.000000e+00, %bb9 ], [ 1.000000e+00, %bb ], [ poison, %bb5 ]
   call void @llvm.amdgcn.exp.f32(i32 40, i32 15, float %tmp11, float undef, float undef, float undef, i1 false, i1 false) #0
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/dagcomb-shuffle-vecextend-non2.ll
+++ b/llvm/test/CodeGen/AMDGPU/dagcomb-shuffle-vecextend-non2.ll
@@ -25,7 +25,7 @@ bb:
   br label %bb12
 
 bb12:
-  %__llpc_global_proxy_r2.0 = phi <4 x i32> [ %__llpc_global_proxy_r2.0.vec.insert196, %bb ], [ undef, %.entry ]
+  %__llpc_global_proxy_r2.0 = phi <4 x i32> [ %__llpc_global_proxy_r2.0.vec.insert196, %bb ], [ poison, %.entry ]
   %tmp6 = shufflevector <4 x i32> %__llpc_global_proxy_r2.0, <4 x i32> undef, <3 x i32> <i32 1, i32 2, i32 3>
   %tmp7 = bitcast <3 x i32> %tmp6 to <3 x float>
   %a0.i = extractelement <3 x float> %tmp7, i32 0

--- a/llvm/test/CodeGen/AMDGPU/dagcombine-fma-crash.ll
+++ b/llvm/test/CodeGen/AMDGPU/dagcombine-fma-crash.ll
@@ -64,8 +64,8 @@ bb2:
   br label %bb11
 
 bb11:
-  %i12 = phi float [ %i6, %bb2 ], [ undef, %bb ]
-  %i13 = phi float [ %i10, %bb2 ], [ undef, %bb ]
+  %i12 = phi float [ %i6, %bb2 ], [ poison, %bb ]
+  %i13 = phi float [ %i10, %bb2 ], [ poison, %bb ]
   %i14 = phi i1 [ false, %bb2 ], [ true, %bb ]
   br i1 %i14, label %bb15, label %bb17
 

--- a/llvm/test/CodeGen/AMDGPU/divergent-branch-uniform-condition.ll
+++ b/llvm/test/CodeGen/AMDGPU/divergent-branch-uniform-condition.ll
@@ -78,7 +78,7 @@ loop:                                             ; preds = %Flow, %start
   br i1 %2, label %endif1, label %Flow
 
 Flow1:                                            ; preds = %endif2, %endif1
-  %3 = phi i32 [ %v5, %endif2 ], [ undef, %endif1 ]
+  %3 = phi i32 [ %v5, %endif2 ], [ poison, %endif1 ]
   %4 = phi i1 [ false, %endif2 ], [ true, %endif1 ]
   br label %Flow
 
@@ -107,7 +107,7 @@ endif1:                                           ; preds = %loop
   br i1 %5, label %endif2, label %Flow1
 
 Flow:                                             ; preds = %Flow1, %loop
-  %6 = phi i32 [ %3, %Flow1 ], [ undef, %loop ]
+  %6 = phi i32 [ %3, %Flow1 ], [ poison, %loop ]
   %7 = phi i1 [ %4, %Flow1 ], [ true, %loop ]
   %8 = phi i1 [ false, %Flow1 ], [ true, %loop ]
   br i1 %7, label %Flow2, label %loop

--- a/llvm/test/CodeGen/AMDGPU/fold-fabs.ll
+++ b/llvm/test/CodeGen/AMDGPU/fold-fabs.ll
@@ -179,7 +179,7 @@ entry:
   br i1 %4, label %header, label %exit
 
 header:
-  %h.fabs.phi = phi float [ undef, %entry ], [ %l.fabs, %l ]
+  %h.fabs.phi = phi float [ poison, %entry ], [ %l.fabs, %l ]
   %h.fmul = fmul reassoc nnan nsz arcp contract afn float %h.fabs.phi, 2.000000e+00
   %l.1 = fmul reassoc nnan nsz arcp contract afn float %h.fabs.phi, 3.000000e+00
   br label %l

--- a/llvm/test/CodeGen/AMDGPU/i1-copy-phi.ll
+++ b/llvm/test/CodeGen/AMDGPU/i1-copy-phi.ll
@@ -52,7 +52,7 @@ false:
   br label %exit
 
 exit:
-  %c = phi <2 x i1> [ undef, %entry ], [ %cmp, %false ]
+  %c = phi <2 x i1> [ poison, %entry ], [ %cmp, %false ]
   %ret = select <2 x i1> %c, <2 x float> <float 2.0, float 2.0>, <2 x float> <float 4.0, float 4.0>
   ret <2 x float> %ret
 }

--- a/llvm/test/CodeGen/AMDGPU/implicit-def-muse.ll
+++ b/llvm/test/CodeGen/AMDGPU/implicit-def-muse.ll
@@ -18,7 +18,7 @@ false:
   br label %exit
 
 exit:
-  %c = phi <2 x i1> [ undef, %entry ], [ %cmp, %false ]
+  %c = phi <2 x i1> [ poison, %entry ], [ %cmp, %false ]
   %ret = select <2 x i1> %c, <2 x float> <float 2.0, float 2.0>, <2 x float> <float 4.0, float 4.0>
   ret <2 x float> %ret
 }

--- a/llvm/test/CodeGen/AMDGPU/inline-asm.ll
+++ b/llvm/test/CodeGen/AMDGPU/inline-asm.ll
@@ -307,7 +307,7 @@ false:
   br label %exit
 
 exit:
-  %s1 = phi { i64, i64} [ undef, %entry ], [ %s0, %false]
+  %s1 = phi { i64, i64} [ poison, %entry ], [ %s0, %false]
   %v0 = extractvalue { i64, i64 } %s1, 0
   %v1 = extractvalue { i64, i64 } %s1, 1
   tail call void asm sideeffect "; use $0", "v"(i64 %v0)

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.ds.ordered.swap.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.ds.ordered.swap.ll
@@ -41,7 +41,7 @@ if-true:
   br label %endif
 
 endif:
-  %v = phi i32 [ %val, %if-true ], [ undef, %entry ]
+  %v = phi i32 [ %val, %if-true ], [ poison, %entry ]
   %r = bitcast i32 %v to float
   ret float %r
 }

--- a/llvm/test/CodeGen/AMDGPU/madmk.ll
+++ b/llvm/test/CodeGen/AMDGPU/madmk.ll
@@ -199,7 +199,7 @@ bb1:                                              ; preds = %bb2
   ret void
 
 bb2:                                              ; preds = %bb6, %bb
-  %tmp = phi float [ undef, %bb ], [ %tmp8, %bb6 ]
+  %tmp = phi float [ poison, %bb ], [ %tmp8, %bb6 ]
   %tid = call i32 @llvm.amdgcn.mbcnt.lo(i32 -1, i32 0) #1
   %f_tid = bitcast i32 %tid to float
   %tmp3 = fsub float %f_tid, %tmp

--- a/llvm/test/CodeGen/AMDGPU/mdt-preserving-crash.ll
+++ b/llvm/test/CodeGen/AMDGPU/mdt-preserving-crash.ll
@@ -48,7 +48,7 @@ if.then3.i:                                       ; preds = %if.end60
   br label %if.end5.i
 
 if.end5.i:                                        ; preds = %if.then3.i, %if.end60
-  %pS.addr.0.i = phi ptr addrspace(5) [ undef, %if.then3.i ], [ %runtimeVersionCopy, %if.end60 ]
+  %pS.addr.0.i = phi ptr addrspace(5) [ poison, %if.then3.i ], [ %runtimeVersionCopy, %if.end60 ]
   %2 = load i8, ptr addrspace(5) %pS.addr.0.i, align 1
   %conv612.i = sext i8 %2 to i32
   %sub13.i = add nsw i32 %conv612.i, -48
@@ -65,7 +65,7 @@ if.then3.i308:                                    ; preds = %if.end5.i
   br label %if.end5.i314
 
 if.end5.i314:                                     ; preds = %if.then3.i308, %if.end5.i
-  %pS.addr.0.i309 = phi ptr addrspace(5) [ undef, %if.then3.i308 ], [ %licenseVersionCopy, %if.end5.i ]
+  %pS.addr.0.i309 = phi ptr addrspace(5) [ poison, %if.then3.i308 ], [ %licenseVersionCopy, %if.end5.i ]
   %3 = load i8, ptr addrspace(5) %pS.addr.0.i309, align 1
   %conv612.i311 = sext i8 %3 to i32
   %sub13.i312 = add nsw i32 %conv612.i311, -48
@@ -82,7 +82,7 @@ if.then3.i332:                                    ; preds = %if.end5.i314
   br label %if.end5.i338
 
 if.end5.i338:                                     ; preds = %if.then3.i332, %if.end5.i314
-  %pS.addr.0.i333 = phi ptr addrspace(5) [ undef, %if.then3.i332 ], [ %arrayidx144260.5, %if.end5.i314 ]
+  %pS.addr.0.i333 = phi ptr addrspace(5) [ poison, %if.then3.i332 ], [ %arrayidx144260.5, %if.end5.i314 ]
   %4 = load i8, ptr addrspace(5) %pS.addr.0.i333, align 1
   %conv612.i335 = sext i8 %4 to i32
   %sub13.i336 = add nsw i32 %conv612.i335, -48
@@ -99,7 +99,7 @@ if.then3.i356:                                    ; preds = %if.end5.i338
   br label %if.end5.i362
 
 if.end5.i362:                                     ; preds = %if.then3.i356, %if.end5.i338
-  %pS.addr.0.i357 = phi ptr addrspace(5) [ undef, %if.then3.i356 ], [ %arrayidx156258.5, %if.end5.i338 ]
+  %pS.addr.0.i357 = phi ptr addrspace(5) [ poison, %if.then3.i356 ], [ %arrayidx156258.5, %if.end5.i338 ]
   %5 = load i8, ptr addrspace(5) %pS.addr.0.i357, align 1
   %conv612.i359 = sext i8 %5 to i32
   %sub13.i360 = add nsw i32 %conv612.i359, -48
@@ -120,7 +120,7 @@ if.then3.i394:                                    ; preds = %if.end5.i362
   br label %if.end5.i400
 
 if.end5.i400:                                     ; preds = %if.then3.i394, %if.end5.i362
-  %pS.addr.0.i395 = phi ptr addrspace(5) [ %arrayidx232250.1, %if.then3.i394 ], [ undef, %if.end5.i362 ]
+  %pS.addr.0.i395 = phi ptr addrspace(5) [ %arrayidx232250.1, %if.then3.i394 ], [ poison, %if.end5.i362 ]
   %7 = load i8, ptr addrspace(5) %pS.addr.0.i395, align 1
   %conv612.i397 = sext i8 %7 to i32
   %sub13.i398 = add nsw i32 %conv612.i397, -48

--- a/llvm/test/CodeGen/AMDGPU/move-to-valu-worklist.ll
+++ b/llvm/test/CodeGen/AMDGPU/move-to-valu-worklist.ll
@@ -17,8 +17,8 @@ bb:
 br label %bb1
 
 bb1:                                              ; preds = %bb1, %bb
-	%tmp2 = phi i64 [ undef, %bb ], [ %tmp16, %bb1 ]
-	%tmp3 = phi i64 [ %tmp, %bb ], [ undef, %bb1 ]
+	%tmp2 = phi i64 [ poison, %bb ], [ %tmp16, %bb1 ]
+	%tmp3 = phi i64 [ %tmp, %bb ], [ poison, %bb1 ]
 	%tmp11 = shl i64 %tmp2, 14
 	%tmp13 = xor i64 %tmp11, %tmp2
 	%tmp15 = and i64 %tmp3, %tmp13

--- a/llvm/test/CodeGen/AMDGPU/multilevel-break.ll
+++ b/llvm/test/CodeGen/AMDGPU/multilevel-break.ll
@@ -120,7 +120,7 @@ define amdgpu_kernel void @multi_if_break_loop(i32 %arg) #0 {
 ; OPT-NEXT:    br label [[BB1:%.*]]
 ; OPT:       bb1:
 ; OPT-NEXT:    [[PHI_BROKEN:%.*]] = phi i64 [ [[TMP4:%.*]], [[FLOW4:%.*]] ], [ 0, [[BB:%.*]] ]
-; OPT-NEXT:    [[LSR_IV:%.*]] = phi i32 [ undef, [[BB]] ], [ [[TMP2:%.*]], [[FLOW4]] ]
+; OPT-NEXT:    [[LSR_IV:%.*]] = phi i32 [ poison, [[BB]] ], [ [[TMP2:%.*]], [[FLOW4]] ]
 ; OPT-NEXT:    [[LSR_IV_NEXT:%.*]] = add i32 [[LSR_IV]], 1
 ; OPT-NEXT:    [[CMP0:%.*]] = icmp slt i32 [[LSR_IV_NEXT]], 0
 ; OPT-NEXT:    [[LOAD0:%.*]] = load volatile i32, ptr addrspace(1) undef, align 4
@@ -227,7 +227,7 @@ bb:
   br label %bb1
 
 bb1:
-  %lsr.iv = phi i32 [ undef, %bb ], [ %lsr.iv.next, %case0 ], [ %lsr.iv.next, %case1 ]
+  %lsr.iv = phi i32 [ poison, %bb ], [ %lsr.iv.next, %case0 ], [ %lsr.iv.next, %case1 ]
   %lsr.iv.next = add i32 %lsr.iv, 1
   %cmp0 = icmp slt i32 %lsr.iv.next, 0
   %load0 = load volatile i32, ptr addrspace(1) undef, align 4

--- a/llvm/test/CodeGen/AMDGPU/nested-loop-conditions.ll
+++ b/llvm/test/CodeGen/AMDGPU/nested-loop-conditions.ll
@@ -74,7 +74,7 @@ define amdgpu_kernel void @reduced_nested_loop_conditions(ptr addrspace(3) captu
 ; IR-NEXT:    br i1 [[TMP3]], label %[[BB23:.*]], label %[[BB5]]
 ; IR:       [[FLOW]]:
 ; IR-NEXT:    [[TMP4:%.*]] = phi i1 [ [[MY_TMP22:%.*]], %[[BB4]] ], [ true, %[[BB5]] ]
-; IR-NEXT:    [[TMP5]] = phi i32 [ [[MY_TMP21:%.*]], %[[BB4]] ], [ undef, %[[BB5]] ]
+; IR-NEXT:    [[TMP5]] = phi i32 [ [[MY_TMP21:%.*]], %[[BB4]] ], [ poison, %[[BB5]] ]
 ; IR-NEXT:    call void @llvm.amdgcn.end.cf.i64(i64 [[TMP2]])
 ; IR-NEXT:    [[TMP6]] = call i64 @llvm.amdgcn.if.break.i64(i1 [[TMP4]], i64 [[PHI_BROKEN]])
 ; IR-NEXT:    br label %[[BB10]]
@@ -118,7 +118,7 @@ bb9:                                              ; preds = %bb20, %bb9
   br i1 false, label %bb3, label %bb9
 
 bb10:                                             ; preds = %bb5, %bb4
-  %my.tmp11 = phi i32 [ %my.tmp21, %bb4 ], [ undef, %bb5 ]
+  %my.tmp11 = phi i32 [ %my.tmp21, %bb4 ], [ poison, %bb5 ]
   %my.tmp12 = phi i1 [ %my.tmp22, %bb4 ], [ true, %bb5 ]
   br i1 %my.tmp12, label %bb23, label %bb5
 

--- a/llvm/test/CodeGen/AMDGPU/rewrite-undef-for-phi.ll
+++ b/llvm/test/CodeGen/AMDGPU/rewrite-undef-for-phi.ll
@@ -20,7 +20,7 @@ if:
   br label %end
 
 end:
-  %c2 = phi float [ undef, %if ], [ %c, %entry ]
+  %c2 = phi float [ poison, %if ], [ %c, %entry ]
   ret float %c2
 }
 
@@ -61,7 +61,7 @@ bb4:
   br label %end
 
 end:
-  %c2 = phi float [ undef, %bb2 ], [ %c, %bb3 ], [ undef, %bb4 ], [ %c, %entry ]
+  %c2 = phi float [ poison, %bb2 ], [ %c, %bb3 ], [ poison, %bb4 ], [ %c, %entry ]
   ret float %c2
 }
 
@@ -72,7 +72,7 @@ define amdgpu_ps float @exclude_backedge(float inreg %c, i32 %x) #0 {
 ; OPT-NEXT:    br i1 [[CC]], label [[END:%.*]], label [[LOOP:%.*]]
 ; OPT:       loop:
 ; OPT-NEXT:    [[IND:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC:%.*]], [[LOOP]] ]
-; OPT-NEXT:    [[C2:%.*]] = phi float [ [[C:%.*]], [[ENTRY]] ], [ undef, [[LOOP]] ]
+; OPT-NEXT:    [[C2:%.*]] = phi float [ [[C:%.*]], [[ENTRY]] ], [ poison, [[LOOP]] ]
 ; OPT-NEXT:    [[INC]] = add i32 [[IND]], 1
 ; OPT-NEXT:    [[LOOP_CC:%.*]] = icmp slt i32 [[INC]], 5
 ; OPT-NEXT:    br i1 [[LOOP_CC]], label [[LOOP]], label [[LOOP_END:%.*]]
@@ -88,7 +88,7 @@ entry:
 
 loop:
   %ind = phi i32 [ 0, %entry ], [ %inc, %loop ]
-  %c2 = phi float [ %c, %entry ], [ undef, %loop ]
+  %c2 = phi float [ %c, %entry ], [ poison, %loop ]
   %inc = add i32 %ind, 1
   %loop_cc = icmp slt i32 %inc, 5
   br i1 %loop_cc, label %loop, label %loop_end

--- a/llvm/test/CodeGen/AMDGPU/schedule-vs-if-nested-loop-failure.ll
+++ b/llvm/test/CodeGen/AMDGPU/schedule-vs-if-nested-loop-failure.ll
@@ -18,11 +18,11 @@ main_body:
   br i1 %8, label %LOOP, label %ENDIF
 
 Flow1:                                            ; preds = %ENDIF19, %ENDIF16
-  %9 = phi float [ %115, %ENDIF19 ], [ undef, %ENDIF16 ]
-  %10 = phi float [ %114, %ENDIF19 ], [ undef, %ENDIF16 ]
-  %11 = phi float [ %113, %ENDIF19 ], [ undef, %ENDIF16 ]
-  %12 = phi float [ %112, %ENDIF19 ], [ undef, %ENDIF16 ]
-  %13 = phi float [ %111, %ENDIF19 ], [ undef, %ENDIF16 ]
+  %9 = phi float [ %115, %ENDIF19 ], [ poison, %ENDIF16 ]
+  %10 = phi float [ %114, %ENDIF19 ], [ poison, %ENDIF16 ]
+  %11 = phi float [ %113, %ENDIF19 ], [ poison, %ENDIF16 ]
+  %12 = phi float [ %112, %ENDIF19 ], [ poison, %ENDIF16 ]
+  %13 = phi float [ %111, %ENDIF19 ], [ poison, %ENDIF16 ]
   %14 = phi i1 [ false, %ENDIF19 ], [ true, %ENDIF16 ]
   br label %Flow
 
@@ -140,11 +140,11 @@ Flow:                                             ; preds = %Flow1, %LOOP
   %102 = phi float [ %temp2.1, %Flow1 ], [ %temp2.1, %LOOP ]
   %103 = phi float [ %temp1.1, %Flow1 ], [ %temp1.1, %LOOP ]
   %104 = phi float [ %temp.1, %Flow1 ], [ %temp.1, %LOOP ]
-  %105 = phi float [ %9, %Flow1 ], [ undef, %LOOP ]
-  %106 = phi float [ %10, %Flow1 ], [ undef, %LOOP ]
-  %107 = phi float [ %11, %Flow1 ], [ undef, %LOOP ]
-  %108 = phi float [ %12, %Flow1 ], [ undef, %LOOP ]
-  %109 = phi float [ %13, %Flow1 ], [ undef, %LOOP ]
+  %105 = phi float [ %9, %Flow1 ], [ poison, %LOOP ]
+  %106 = phi float [ %10, %Flow1 ], [ poison, %LOOP ]
+  %107 = phi float [ %11, %Flow1 ], [ poison, %LOOP ]
+  %108 = phi float [ %12, %Flow1 ], [ poison, %LOOP ]
+  %109 = phi float [ %13, %Flow1 ], [ poison, %LOOP ]
   %110 = phi i1 [ %14, %Flow1 ], [ true, %LOOP ]
   br i1 %110, label %Flow2, label %LOOP
 

--- a/llvm/test/CodeGen/AMDGPU/sdwa-peephole.ll
+++ b/llvm/test/CodeGen/AMDGPU/sdwa-peephole.ll
@@ -2082,7 +2082,7 @@ bb:
   br label %bb1
 
 bb1:                                              ; preds = %bb11, %bb
-  %tmp = phi <2 x i32> [ %tmp12, %bb11 ], [ undef, %bb ]
+  %tmp = phi <2 x i32> [ %tmp12, %bb11 ], [ poison, %bb ]
   br i1 true, label %bb2, label %bb11
 
 bb2:                                              ; preds = %bb1

--- a/llvm/test/CodeGen/AMDGPU/select-undef.ll
+++ b/llvm/test/CodeGen/AMDGPU/select-undef.ll
@@ -53,7 +53,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi <6 x float> [ undef, %entry ], [ %add, %loop ]
+  %phi = phi <6 x float> [ poison, %entry ], [ %add, %loop ]
   %load = load volatile <6 x float>, ptr addrspace(3) undef
   %add = fadd <6 x float> %load, %phi
   br i1 %cond, label %loop, label %ret
@@ -72,7 +72,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi <6 x i32> [ undef, %entry ], [ %add, %loop ]
+  %phi = phi <6 x i32> [ poison, %entry ], [ %add, %loop ]
   %load = load volatile <6 x i32>, ptr addrspace(3) undef
   %add = add <6 x i32> %load, %phi
   br i1 %cond, label %loop, label %ret
@@ -92,7 +92,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi <5 x float> [ undef, %entry ], [ %add, %loop ]
+  %phi = phi <5 x float> [ poison, %entry ], [ %add, %loop ]
   %load = load volatile <5 x float>, ptr addrspace(3) undef
   %add = fadd <5 x float> %load, %phi
   br i1 %cond, label %loop, label %ret
@@ -111,7 +111,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi <5 x i32> [ undef, %entry ], [ %add, %loop ]
+  %phi = phi <5 x i32> [ poison, %entry ], [ %add, %loop ]
   %load = load volatile <5 x i32>, ptr addrspace(3) undef
   %add = add <5 x i32> %load, %phi
   br i1 %cond, label %loop, label %ret
@@ -131,7 +131,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi <3 x double> [ undef, %entry ], [ %add, %loop ]
+  %phi = phi <3 x double> [ poison, %entry ], [ %add, %loop ]
   %load = load volatile <3 x double>, ptr addrspace(3) %ptr
   %add = fadd <3 x double> %load, %phi
   br i1 %cond, label %loop, label %ret
@@ -150,7 +150,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi <3 x i64> [ undef, %entry ], [ %add, %loop ]
+  %phi = phi <3 x i64> [ poison, %entry ], [ %add, %loop ]
   %load = load volatile <3 x i64>, ptr addrspace(3) %ptr
   %add = add <3 x i64> %load, %phi
   br i1 %cond, label %loop, label %ret
@@ -170,7 +170,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi <4 x half> [ undef, %entry ], [ %add, %loop ]
+  %phi = phi <4 x half> [ poison, %entry ], [ %add, %loop ]
   %load = load volatile <4 x half>, ptr addrspace(3) %ptr
   %add = fadd <4 x half> %load, %phi
   br i1 %cond, label %loop, label %ret
@@ -189,7 +189,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi <4 x i16> [ undef, %entry ], [ %add, %loop ]
+  %phi = phi <4 x i16> [ poison, %entry ], [ %add, %loop ]
   %load = load volatile <4 x i16>, ptr addrspace(3) %ptr
   %add = add <4 x i16> %load, %phi
   br i1 %cond, label %loop, label %ret
@@ -209,7 +209,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi <2 x half> [ undef, %entry ], [ %add, %loop ]
+  %phi = phi <2 x half> [ poison, %entry ], [ %add, %loop ]
   %load = load volatile <2 x half>, ptr addrspace(3) %ptr
   %add = fadd <2 x half> %load, %phi
   br i1 %cond, label %loop, label %ret
@@ -228,7 +228,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi <2 x i16> [ undef, %entry ], [ %add, %loop ]
+  %phi = phi <2 x i16> [ poison, %entry ], [ %add, %loop ]
   %load = load volatile <2 x i16>, ptr addrspace(3) %ptr
   %add = add <2 x i16> %load, %phi
   br i1 %cond, label %loop, label %ret
@@ -268,7 +268,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi bfloat [ undef, %entry ], [ %add, %loop ]
+  %phi = phi bfloat [ poison, %entry ], [ %add, %loop ]
   %load = load volatile bfloat, ptr addrspace(3) undef
   %bc.0 = bitcast bfloat %load to i16
   %bc.1 = bitcast bfloat %phi to i16
@@ -290,7 +290,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi <2 x bfloat> [ undef, %entry ], [ %add, %loop ]
+  %phi = phi <2 x bfloat> [ poison, %entry ], [ %add, %loop ]
   %load = load volatile <2 x bfloat>, ptr addrspace(3) undef
   %bc.0 = bitcast <2 x bfloat> %load to <2 x i16>
   %bc.1 = bitcast <2 x bfloat> %phi to <2 x i16>
@@ -312,7 +312,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi <3 x bfloat> [ undef, %entry ], [ %add, %loop ]
+  %phi = phi <3 x bfloat> [ poison, %entry ], [ %add, %loop ]
   %load = load volatile <3 x bfloat>, ptr addrspace(3) undef
   %bc.0 = bitcast <3 x bfloat> %load to <3 x i16>
   %bc.1 = bitcast <3 x bfloat> %phi to <3 x i16>
@@ -334,7 +334,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi <4 x bfloat> [ undef, %entry ], [ %add, %loop ]
+  %phi = phi <4 x bfloat> [ poison, %entry ], [ %add, %loop ]
   %load = load volatile <4 x bfloat>, ptr addrspace(3) undef
   %bc.0 = bitcast <4 x bfloat> %load to <4 x i16>
   %bc.1 = bitcast <4 x bfloat> %phi to <4 x i16>
@@ -356,7 +356,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi <6 x bfloat> [ undef, %entry ], [ %add, %loop ]
+  %phi = phi <6 x bfloat> [ poison, %entry ], [ %add, %loop ]
   %load = load volatile <6 x bfloat>, ptr addrspace(3) undef
   %bc.0 = bitcast <6 x bfloat> %load to <6 x i16>
   %bc.1 = bitcast <6 x bfloat> %phi to <6 x i16>
@@ -378,7 +378,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi <8 x bfloat> [ undef, %entry ], [ %add, %loop ]
+  %phi = phi <8 x bfloat> [ poison, %entry ], [ %add, %loop ]
   %load = load volatile <8 x bfloat>, ptr addrspace(3) undef
   %bc.0 = bitcast <8 x bfloat> %load to <8 x i16>
   %bc.1 = bitcast <8 x bfloat> %phi to <8 x i16>
@@ -400,7 +400,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi <16 x bfloat> [ undef, %entry ], [ %add, %loop ]
+  %phi = phi <16 x bfloat> [ poison, %entry ], [ %add, %loop ]
   %load = load volatile <16 x bfloat>, ptr addrspace(3) undef
   %bc.0 = bitcast <16 x bfloat> %load to <16 x i16>
   %bc.1 = bitcast <16 x bfloat> %phi to <16 x i16>
@@ -422,7 +422,7 @@ entry:
   br label %loop
 
 loop:
-  %phi = phi <32 x bfloat> [ undef, %entry ], [ %add, %loop ]
+  %phi = phi <32 x bfloat> [ poison, %entry ], [ %add, %loop ]
   %load = load volatile <32 x bfloat>, ptr addrspace(3) undef
   %bc.0 = bitcast <32 x bfloat> %load to <32 x i16>
   %bc.1 = bitcast <32 x bfloat> %phi to <32 x i16>

--- a/llvm/test/CodeGen/AMDGPU/si-spill-cf.ll
+++ b/llvm/test/CodeGen/AMDGPU/si-spill-cf.ll
@@ -80,7 +80,7 @@ main_body:
 
 LOOP:                                             ; preds = %ENDIF2795, %main_body
   %temp894.0 = phi float [ 0.000000e+00, %main_body ], [ %temp894.1, %ENDIF2795 ]
-  %temp18.0 = phi float [ undef, %main_body ], [ %temp18.1, %ENDIF2795 ]
+  %temp18.0 = phi float [ poison, %main_body ], [ %temp18.1, %ENDIF2795 ]
   %tid = call i32 @llvm.amdgcn.mbcnt.lo(i32 -1, i32 0)
   %tmp67 = icmp sgt i32 %tid, 4
   br i1 %tmp67, label %ENDLOOP, label %ENDIF
@@ -247,8 +247,8 @@ ELSE2566:                                         ; preds = %ENDIF
   br i1 %tmp201, label %ENDLOOP, label %ELSE2593
 
 ENDIF2564:                                        ; preds = %ENDIF2594, %ENDIF2588
-  %temp894.1 = phi float [ undef, %ENDIF2588 ], [ %temp894.2, %ENDIF2594 ]
-  %temp18.1 = phi float [ %tmp218, %ENDIF2588 ], [ undef, %ENDIF2594 ]
+  %temp894.1 = phi float [ poison, %ENDIF2588 ], [ %temp894.2, %ENDIF2594 ]
+  %temp18.1 = phi float [ %tmp218, %ENDIF2588 ], [ poison, %ENDIF2594 ]
   %tmp202 = fsub float %tmp5, undef
   %tmp203 = fmul float %tmp202, undef
   %tmp204 = call float @llvm.maxnum.f32(float undef, float %tmp203)

--- a/llvm/test/CodeGen/AMDGPU/simplifydemandedbits-recursion.ll
+++ b/llvm/test/CodeGen/AMDGPU/simplifydemandedbits-recursion.ll
@@ -66,7 +66,7 @@ bb26:                                             ; preds = %.loopexit
   br label %bb31
 
 .preheader:                                       ; preds = %.preheader, %bb12
-  %tmp27 = phi i32 [ %tmp28, %.preheader ], [ undef, %bb12 ]
+  %tmp27 = phi i32 [ %tmp28, %.preheader ], [ poison, %bb12 ]
   %tmp28 = add nuw i32 %tmp27, 128
   %tmp29 = icmp ult i32 %tmp28, 1568
   br i1 %tmp29, label %.preheader, label %.loopexit145
@@ -75,7 +75,7 @@ bb30:                                             ; preds = %bb31
   br i1 %c4, label %bb11, label %bb12
 
 bb31:                                             ; preds = %bb31, %bb26
-  %tmp32 = phi i32 [ %tmp9, %bb26 ], [ undef, %bb31 ]
+  %tmp32 = phi i32 [ %tmp9, %bb26 ], [ poison, %bb31 ]
   %tmp33 = getelementptr inbounds [462 x float], ptr addrspace(3) @0, i32 0, i32 %tmp32
   %tmp34 = load float, ptr addrspace(3) %tmp33, align 4
   %tmp35 = tail call float @llvm.fmuladd.f32(float %tmp34, float undef, float undef)

--- a/llvm/test/CodeGen/AMDGPU/skip-if-dead.ll
+++ b/llvm/test/CodeGen/AMDGPU/skip-if-dead.ll
@@ -1690,7 +1690,7 @@ live:
   br label %export
 
 export:
-  %proxy = phi float [ undef, %kill ], [ %scale, %live ]
+  %proxy = phi float [ poison, %kill ], [ %scale, %live ]
   call void @llvm.amdgcn.exp.f32(i32 0, i32 15, float %proxy, float %proxy, float %proxy, float %proxy, i1 true, i1 true) #3
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/subreg-coalescer-crash.ll
+++ b/llvm/test/CodeGen/AMDGPU/subreg-coalescer-crash.ll
@@ -54,7 +54,7 @@ bb2:                                              ; preds = %bb4, %bb
   br i1 undef, label %bb9, label %bb13
 
 bb4:                                              ; preds = %bb7, %bb6, %bb1
-  %tmp5 = phi float [ undef, %bb1 ], [ undef, %bb6 ], [ %tmp8, %bb7 ]
+  %tmp5 = phi float [ poison, %bb1 ], [ poison, %bb6 ], [ %tmp8, %bb7 ]
   br label %bb2
 
 bb6:                                              ; preds = %bb1
@@ -74,8 +74,8 @@ bb13:                                             ; preds = %bb2
   br i1 undef, label %bb23, label %bb24
 
 bb14:                                             ; preds = %bb27, %bb24, %bb9
-  %tmp15 = phi float [ %tmp12, %bb9 ], [ undef, %bb27 ], [ 0.000000e+00, %bb24 ]
-  %tmp16 = phi float [ %tmp11, %bb9 ], [ undef, %bb27 ], [ %tmp25, %bb24 ]
+  %tmp15 = phi float [ %tmp12, %bb9 ], [ poison, %bb27 ], [ 0.000000e+00, %bb24 ]
+  %tmp16 = phi float [ %tmp11, %bb9 ], [ poison, %bb27 ], [ %tmp25, %bb24 ]
   %tmp17 = fmul float 1.050000e+01, %tmp16
   %tmp18 = fmul float 1.150000e+01, %tmp15
   call void @llvm.amdgcn.exp.f32(i32 0, i32 15, float %tmp18, float %tmp17, float %tmp17, float %tmp17, i1 true, i1 true) #0

--- a/llvm/test/CodeGen/AMDGPU/switch-default-block-unreachable.ll
+++ b/llvm/test/CodeGen/AMDGPU/switch-default-block-unreachable.ll
@@ -47,7 +47,7 @@ define void @test(i1 %c0) #1 {
     br label %unreach.blk
 
   unreach.blk:                                      ; preds = %preheader.blk, %pre.false.blk
-    %phi.val = phi i32 [ %call.pre.false, %pre.false.blk ], [ undef, %preheader.blk ]
+    %phi.val = phi i32 [ %call.pre.false, %pre.false.blk ], [ poison, %preheader.blk ]
     store i32 %phi.val, ptr undef
     unreachable
 

--- a/llvm/test/CodeGen/AMDGPU/tuple-allocation-failure.ll
+++ b/llvm/test/CodeGen/AMDGPU/tuple-allocation-failure.ll
@@ -604,7 +604,7 @@ bb:
   br label %bb5
 
 bb5:                                              ; preds = %bb5.backedge, %bb
-  %tmp4.i.sroa.0.0 = phi <9 x double> [ undef, %bb ], [ %tmp4.i.sroa.0.1, %bb5.backedge ]
+  %tmp4.i.sroa.0.0 = phi <9 x double> [ poison, %bb ], [ %tmp4.i.sroa.0.1, %bb5.backedge ]
   %tmp14.1.i = load i32, ptr inttoptr (i64 128 to ptr), align 128
   store i32 0, ptr addrspace(5) null, align 4
   %tmp14.2.i = load i32, ptr inttoptr (i64 128 to ptr), align 128

--- a/llvm/test/CodeGen/AMDGPU/uniform-phi-with-undef.ll
+++ b/llvm/test/CodeGen/AMDGPU/uniform-phi-with-undef.ll
@@ -44,7 +44,7 @@ if:
 
 end:
   %v2 = phi float [ %v.if, %if ], [ %v, %entry ]
-  %c2 = phi float [ undef, %if ], [ %c, %entry ]
+  %c2 = phi float [ poison, %if ], [ %c, %entry ]
   %r = fadd float %v2, %c2
   ret float %r
 }

--- a/llvm/test/CodeGen/AMDGPU/unigine-liveness-crash.ll
+++ b/llvm/test/CodeGen/AMDGPU/unigine-liveness-crash.ll
@@ -83,7 +83,7 @@ ENDIF25:                                          ; preds = %IF29, %main_body
   ret <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, float, float, float, float, float, float, float, float, float, float, float, float, float, float }> %tmp83
 
 LOOP:                                             ; preds = %ENDIF28, %IF26
-  %.5 = phi float [ undef, %IF26 ], [ %tmp89, %ENDIF28 ]
+  %.5 = phi float [ poison, %IF26 ], [ %tmp89, %ENDIF28 ]
   br i1 false, label %IF29, label %ENDIF28
 
 IF29:                                             ; preds = %LOOP

--- a/llvm/test/CodeGen/AMDGPU/vgpr-liverange-ir.ll
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-liverange-ir.ll
@@ -548,7 +548,7 @@ sw.bb:                                            ; preds = %if.then9
   br label %sw.bb18
 
 sw.bb18:                                          ; preds = %sw.bb, %if.then9
-  %a.sroa.0.0 = phi <4 x i8> [ %a.sroa.0.0.vecblend, %sw.bb ], [ undef, %if.then9 ]
+  %a.sroa.0.0 = phi <4 x i8> [ %a.sroa.0.0.vecblend, %sw.bb ], [ poison, %if.then9 ]
   %a.sroa.0.0.vec.extract61 = shufflevector <4 x i8> %a.sroa.0.0, <4 x i8> zeroinitializer, <3 x i32> <i32 undef, i32 1, i32 undef>
   %i19 = insertelement <3 x i8> %a.sroa.0.0.vec.extract61, i8 0, i64 0
   %i20 = select <3 x i1> zeroinitializer, <3 x i8> zeroinitializer, <3 x i8> %i19

--- a/llvm/test/CodeGen/AMDGPU/wave32.ll
+++ b/llvm/test/CodeGen/AMDGPU/wave32.ll
@@ -1610,7 +1610,7 @@ bb:
   br label %bb1
 
 bb1:                                              ; preds = %Flow, %bb
-  %lsr.iv = phi i32 [ undef, %bb ], [ %tmp2, %Flow ]
+  %lsr.iv = phi i32 [ poison, %bb ], [ %tmp2, %Flow ]
   %lsr.iv.next = add i32 %lsr.iv, 1
   %cmp0 = icmp slt i32 %lsr.iv.next, 0
   br i1 %cmp0, label %bb4, label %Flow
@@ -1621,7 +1621,7 @@ bb4:                                              ; preds = %bb1
   br label %Flow
 
 Flow:                                             ; preds = %bb4, %bb1
-  %tmp2 = phi i32 [ %lsr.iv.next, %bb4 ], [ undef, %bb1 ]
+  %tmp2 = phi i32 [ %lsr.iv.next, %bb4 ], [ poison, %bb1 ]
   %tmp3 = phi i1 [ %cmp1, %bb4 ], [ true, %bb1 ]
   br i1 %tmp3, label %bb1, label %bb9
 


### PR DESCRIPTION
I think the chance of this changing the tests in meaningful ways
is very low. This was perl with a few minor adjustments to a few
tests that produce new undefs. Only one test had a minor codegen
change with the switch, which I dropped from the change.