### PR TITLE
[scudo] Add `__scudo_get_info` symbol to export stats to a buffer.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/combined.h
+++ b/compiler-rt/lib/scudo/standalone/combined.h
@@ -638,6 +638,7 @@ public:
   // sizing purposes.
   uptr getStats(char *Buffer, uptr Size) {
     ScopedString Str;
+    // TODO: Use Str.copyToBuffer and fail when Buffer is NULL.
     const uptr Length = getStats(&Str) + 1;
     if (Length < Size)
       Size = Length;
@@ -652,6 +653,12 @@ public:
     ScopedString Str;
     getStats(&Str);
     Str.output();
+  }
+
+  uptr getFragmentationInfo(char *Buffer, uptr Size) {
+    ScopedString Str;
+    Primary.getFragmentationInfo(&Str);
+    return Str.copyToBuffer(Buffer, Size);
   }
 
   void printFragmentationInfo() {

--- a/compiler-rt/lib/scudo/standalone/include/scudo/interface.h
+++ b/compiler-rt/lib/scudo/standalone/include/scudo/interface.h
@@ -35,6 +35,23 @@ __attribute__((weak)) void __scudo_realloc_deallocate_hook(void *old_ptr);
 
 void __scudo_print_stats(void);
 
+// Reports all allocators configuration and general statistics as a null
+// terminated text string.
+#ifndef M_INFO_TOPIC_STATS
+#define M_INFO_TOPIC_STATS 1
+#endif
+
+// Reports fragmentation statistics of the primary allocation as a null
+// terminated text string.
+#ifndef M_INFO_TOPIC_FRAGMENTATION
+#define M_INFO_TOPIC_FRAGMENTATION 2
+#endif
+
+// Writes allocator statistics to the buffer, truncating to the specified size
+// if necessary. Returns the full report size (before truncation) for buffer
+// sizing purpose, or zero if the topic is not supported.
+size_t __scudo_get_info(uint32_t topic, void *buffer, size_t size);
+
 typedef void (*iterate_callback)(uintptr_t base, size_t size, void *arg);
 
 // Determine the likely cause of a tag check fault or other memory protection

--- a/compiler-rt/lib/scudo/standalone/string_utils.cpp
+++ b/compiler-rt/lib/scudo/standalone/string_utils.cpp
@@ -229,6 +229,16 @@ void ScopedString::append(const char *Format, ...) {
   va_end(Args);
 }
 
+size_t ScopedString::copyToBuffer(char *OutputBase, size_t OutputLength) {
+  DCHECK(OutputBase);
+  if (OutputLength) {
+    const size_t Written = Min(length(), OutputLength - 1);
+    memcpy(OutputBase, data(), Written);
+    OutputBase[Written] = '\0';
+  }
+  return length() + 1;
+}
+
 void Printf(const char *Format, ...) {
   va_list Args;
   va_start(Args, Format);

--- a/compiler-rt/lib/scudo/standalone/string_utils.h
+++ b/compiler-rt/lib/scudo/standalone/string_utils.h
@@ -19,8 +19,8 @@ namespace scudo {
 class ScopedString {
 public:
   explicit ScopedString() { String.push_back('\0'); }
-  uptr length() { return String.size() - 1; }
-  const char *data() { return String.data(); }
+  uptr length() const { return String.size() - 1; }
+  const char *data() const { return String.data(); }
   void clear() {
     String.clear();
     String.push_back('\0');
@@ -30,6 +30,11 @@ public:
   void output() const { outputRaw(String.data()); }
   void reserve(size_t Size) { String.reserve(Size + 1); }
   uptr capacity() { return String.capacity() - 1; }
+
+  // Copies the string to the buffer, truncating if necessary.
+  // Null-terminates the output if output_length is greater than zero.
+  // Returns the original string's size (including null).
+  size_t copyToBuffer(char *OutputBase, size_t OutputLength);
 
 private:
   void appendNumber(u64 AbsoluteValue, u8 Base, u8 MinNumberLength,

--- a/compiler-rt/lib/scudo/standalone/tests/combined_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/combined_test.cpp
@@ -333,6 +333,12 @@ void ScudoCombinedTest<Config>::BasicTest(scudo::uptr SizeLog) {
 
   Allocator->printStats();
   Allocator->printFragmentationInfo();
+
+  {
+    char buffer[256] = {0};
+    EXPECT_LE(0, Allocator->getStats(buffer, sizeof(buffer)));
+    EXPECT_LE(0, Allocator->getFragmentationInfo(buffer, sizeof(buffer)));
+  }
 }
 
 #define SCUDO_MAKE_BASIC_TEST(SizeLog)                                         \

--- a/compiler-rt/lib/scudo/standalone/wrappers_c.cpp
+++ b/compiler-rt/lib/scudo/standalone/wrappers_c.cpp
@@ -15,6 +15,7 @@
 #include "internal_defs.h"
 #include "platform.h"
 #include "scudo/interface.h"
+#include "string_utils.h"
 #include "wrappers_c.h"
 #include "wrappers_c_checks.h"
 
@@ -36,5 +37,20 @@ scudo::Allocator<scudo::Config, SCUDO_PREFIX(malloc_postinit)> SCUDO_ALLOCATOR;
 #undef SCUDO_PREFIX
 
 extern "C" INTERFACE void __scudo_print_stats(void) { Allocator.printStats(); }
+
+extern "C" INTERFACE size_t __scudo_get_info(uint32_t topic, void *buffer,
+                                             size_t size) {
+  switch (topic) {
+  case M_INFO_TOPIC_STATS:
+    return Allocator.getStats(reinterpret_cast<char *>(buffer), size);
+  case M_INFO_TOPIC_FRAGMENTATION:
+    return Allocator.getFragmentationInfo(reinterpret_cast<char *>(buffer),
+                                          size);
+  default:
+    scudo::Printf("Scudo WARNING: unrecognized __scudo_get_info topic: %d\n",
+                  topic);
+    return 0;
+  }
+}
 
 #endif // !SCUDO_ANDROID || !_BIONIC

--- a/compiler-rt/lib/scudo/standalone/wrappers_c_bionic.cpp
+++ b/compiler-rt/lib/scudo/standalone/wrappers_c_bionic.cpp
@@ -15,6 +15,7 @@
 #include "internal_defs.h"
 #include "platform.h"
 #include "scudo/interface.h"
+#include "string_utils.h"
 #include "wrappers_c.h"
 #include "wrappers_c_checks.h"
 
@@ -37,6 +38,20 @@ static scudo::Allocator<scudo::Config, SCUDO_PREFIX(malloc_postinit)>
 
 // TODO(kostyak): support both allocators.
 INTERFACE void __scudo_print_stats(void) { Allocator.printStats(); }
+
+INTERFACE size_t __scudo_get_info(uint32_t topic, void *buffer, size_t size) {
+  switch (topic) {
+  case M_INFO_TOPIC_STATS:
+    return Allocator.getStats(reinterpret_cast<char *>(buffer), size);
+  case M_INFO_TOPIC_FRAGMENTATION:
+    return Allocator.getFragmentationInfo(reinterpret_cast<char *>(buffer),
+                                          size);
+  default:
+    scudo::Printf("Scudo WARNING: unrecognized __scudo_get_info topic: %d\n",
+                  topic);
+    return 0;
+  }
+}
 
 INTERFACE void __scudo_get_error_info(
     struct scudo_error_info *error_info, uintptr_t fault_addr,


### PR DESCRIPTION
Also make possible to get the fragmentation stats from the primary allocator.

Currenty, `__scudo_print_stats` symbol writes the report to the provided printer, which is not convenient for processing the result.