### PR TITLE
[lldb] Add more ARM checks in TestLldbGdbServer.py

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1344,6 +1344,13 @@ class Base(unittest.TestCase):
         arch = self.getArchitecture().lower()
         return arch in ["aarch64", "arm64", "arm64e"]
 
+    def isARM(self):
+        """Returns true if the architecture is ARM, meaning 32-bit ARM. Which could
+        be M profile, A profile Armv7-a, or the AArch32 mode of Armv8-a."""
+        return not self.isAArch64() and (
+            self.getArchitecture().lower().startswith("arm")
+        )
+
     def isAArch64SVE(self):
         return self.isAArch64() and "sve" in self.getCPUInfo()
 

--- a/lldb/test/API/tools/lldb-server/TestLldbGdbServer.py
+++ b/lldb/test/API/tools/lldb-server/TestLldbGdbServer.py
@@ -199,12 +199,12 @@ class LldbGdbServerTestCase(
         if not self.isRISCV():
             self.assertIn("flags", generic_regs)
 
-        if self.isRISCV():
-            # Special RISC-V register for a return address
+        if self.isRISCV() or self.isAArch64() or self.isARM():
+            # Specific register for a return address
             self.assertIn("ra", generic_regs)
 
-            # RISC-V's function arguments registers
-            for i in range(1, 9):
+            # Function arguments registers
+            for i in range(1, 5 if self.isARM() else 9):
                 self.assertIn(f"arg{i}", generic_regs)
 
     def test_qRegisterInfo_contains_at_least_one_register_set(self):


### PR DESCRIPTION
When https://github.com/llvm/llvm-project/pull/130034 enabled RISC-V here I noticed that these should run for ARM as well.

ARM only has 4 argument registers, which matches Arm's ABI for it: https://github.com/ARM-software/abi-aa/blob/main/aapcs32/aapcs32.rst#core-registers

The ABI defines a link register LR, and I assume that's what becomes 'ra' in LLDB.

Tested on ARM and AArch64 Linux.