### PR TITLE
[libunwind][RISCV] Make asm statement volatile

### DIFF
--- a/libunwind/src/Registers.hpp
+++ b/libunwind/src/Registers.hpp
@@ -4126,7 +4126,7 @@ inline reg_t Registers_riscv::getRegister(int regNum) const {
     return _registers[regNum];
   if (regNum == UNW_RISCV_VLENB) {
     reg_t vlenb;
-    __asm__("csrr %0, 0xC22" : "=r"(vlenb));
+    __asm__ volatile("csrr %0, 0xC22" : "=r"(vlenb));
     return vlenb;
   }
   _LIBUNWIND_ABORT("unsupported riscv register");


### PR DESCRIPTION
Compiling with `O3`, the `early-machinelicm` pass hoisted the asm statement to a path that has been executed unconditionally during stack unwinding. On hardware without vector extension support, this resulted in reading a nonexistent register.