### PR TITLE
clang/HIP: Use regex for final path separator in hip-partial-link.hip

### DIFF
--- a/clang/test/Driver/hip-partial-link.hip
+++ b/clang/test/Driver/hip-partial-link.hip
@@ -62,11 +62,11 @@
 // STATIC: Found undefined HIP fatbin symbol: __hip_fatbin_[[ID2:[0-9a-f]+]]
 // STATIC: Found undefined HIP gpubin handle symbol: __hip_gpubin_handle_[[ID1]]
 // STATIC: Found undefined HIP gpubin handle symbol: __hip_gpubin_handle_[[ID2]]
-// STATIC: "{{.*}}/clang-offload-bundler" {{.*}}-unbundle
-// STATIC: "{{.*}}/lld" -flavor gnu -m elf64_amdgpu
-// STATIC: "{{.*}}/clang-offload-bundler"
-// STATIC: "{{.*}}/clang{{.*}}" -target x86_64-unknown-linux-gnu
-// STATIC: "{{.*}}/llvm-ar"
+// STATIC: "{{.*[/\\]}}clang-offload-bundler" {{.*}}-unbundle
+// STATIC: "{{.*[/\\]}}lld" -flavor gnu -m elf64_amdgpu
+// STATIC: "{{.*[/\\]}}clang-offload-bundler"
+// STATIC: "{{.*[/\\]}}clang{{.*}}" -target x86_64-unknown-linux-gnu
+// STATIC: "{{.*[/\\]}}llvm-ar"
 
 // RUN: %clang -v --target=x86_64-unknown-linux-gnu --no-offload-new-driver \
 // RUN:   --hip-link -no-hip-rt -fgpu-rdc --offload-arch=gfx906 \


### PR DESCRIPTION
Somehow this passed the precheck test on the windows bot, but is
failing in precheck of unrelated PRs