### PR TITLE
Optionally print `!prof` metadata inline

### DIFF
--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -96,6 +96,10 @@ static cl::opt<bool> PrintInstDebugLocs(
     "print-inst-debug-locs", cl::Hidden,
     cl::desc("Pretty print debug locations of instructions when dumping"));
 
+static cl::opt<bool> PrintProfData(
+    "print-prof-data", cl::Hidden,
+    cl::desc("Pretty print perf data (branch weights, etc) when dumping"));
+
 // Make virtual table appear in this compilation unit.
 AssemblyAnnotationWriter::~AssemblyAnnotationWriter() = default;
 
@@ -4161,6 +4165,13 @@ void AssemblyWriter::printFunction(const Function *F) {
     writeOperand(F->getPersonalityFn(), /*PrintType=*/true);
   }
 
+  if (PrintProfData) {
+    if (auto *MDProf = F->getMetadata(LLVMContext::MD_prof)) {
+      Out << " ";
+      MDProf->print(Out, TheModule, /*IsForDebug=*/true);
+    }
+  }
+
   if (F->isDeclaration()) {
     Out << '\n';
   } else {
@@ -4284,6 +4295,14 @@ void AssemblyWriter::printInfoComment(const Value &V) {
       if (I->getDebugLoc()) {
         Out << " ; ";
         I->getDebugLoc().print(Out);
+      }
+    }
+  }
+  if (PrintProfData) {
+    if (auto *I = dyn_cast<Instruction>(&V)) {
+      if (auto *MD = I->getMetadata(LLVMContext::MD_prof)) {
+        Out << " ; ";
+        MD->print(Out, TheModule, /*IsForDebug=*/true);
       }
     }
   }

--- a/llvm/test/Other/print-prof-data.ll
+++ b/llvm/test/Other/print-prof-data.ll
@@ -1,0 +1,24 @@
+; RUN: opt %s -print-prof-data -S | FileCheck %s
+
+define void @foo(ptr %p) !prof !0 {
+  %isnull = icmp eq ptr %p, null
+  br i1 %isnull, label %yes, label %no, !prof !1
+yes:
+  %something = select i1 %isnull, i32 1, i32 2, !prof !2
+  br label %exit
+no:
+  call void %p(), !prof !3
+  br label %exit
+exit:
+  ret void
+}
+
+!0 = !{!"function_entry_count", i64 42}
+!1 = !{!"branch_weights", i64 20, i64 101}
+!2 = !{!"branch_weights", i64 5, i64 70}
+!3 = !{!"VP", i32 0, i64 4, i64 4445083295448962937, i64 2, i64 -2718743882639408571, i64 2}
+
+; CHECK: define void @foo(ptr %p) !0 = !{!"function_entry_count", i64 42} !prof !0 {
+; CHECK: br i1 %isnull, label %yes, label %no, !prof !1 ; !1 = !{!"branch_weights", i64 20, i64 101}
+; CHECK: %something = select i1 %isnull, i32 1, i32 2, !prof !2 ; !2 = !{!"branch_weights", i64 5, i64 70}
+; CHECK: call void %p(), !prof !3 ; !3 = !{!"VP", i32 0, i64 4, i64 4445083295448962937, i64 2, i64 -2718743882639408571, i64 2}


### PR DESCRIPTION
Inspired by PR #127944, this patch adds an option to print profile metadata inline with respect to the instruction (or function) it annotates - this saves one time from having to search up and down large textual modules to find this info.