### PR TITLE
[lldb][test] Skip libsanitizers tests for now

### DIFF
--- a/lldb/test/API/functionalities/asan/TestMemoryHistory.py
+++ b/lldb/test/API/functionalities/asan/TestMemoryHistory.py
@@ -19,6 +19,7 @@ class AsanTestCase(TestBase):
         self.asan_tests()
 
     @skipIf(oslist=no_match(["macosx"]))
+    @skipIf(bugnumber="rdar://144997976")
     def test_libsanitizers_asan(self):
         try:
             self.build(make_targets=["libsanitizers"])

--- a/lldb/test/API/functionalities/asan/TestReportData.py
+++ b/lldb/test/API/functionalities/asan/TestReportData.py
@@ -20,6 +20,7 @@ class AsanTestReportDataCase(TestBase):
         self.asan_tests()
 
     @skipIf(oslist=no_match(["macosx"]))
+    @skipIf(bugnumber="rdar://144997976")
     def test_libsanitizers_asan(self):
         try:
             self.build(make_targets=["libsanitizers"])


### PR DESCRIPTION
These are macOS tests only and are currently failing on the x86_64 CI and on arm64 on recent versions of macOS/Xcode.

The tests are failing because we're stopping in:
```
Process 17458 stopped
* thread #1: tid = 0xbda69a, 0x00000002735bd000
  libsystem_malloc.dylib`purgeable_print_self.cold.1, stop reason = EXC_BREAKPOINT (code=1, subcode=0x2735bd000)
```
instead of the libsanitizers library. This seems to be related to `-fsanitize-trivial-abi` support

Skip these for now until we figure out the root cause.