### PR TITLE
[libc++] Clean up casts in std::forward_list

### DIFF
--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -282,7 +282,6 @@ struct __forward_node_traits {
   typedef _NodePtr __node_pointer;
   typedef __forward_begin_node<_NodePtr> __begin_node;
   typedef __rebind_pointer_t<_NodePtr, __begin_node> __begin_node_pointer;
-  typedef __rebind_pointer_t<_NodePtr, void> __void_pointer;
 
 // TODO(LLVM 22): Remove this check
 #  ifndef _LIBCPP_ABI_FORWARD_LIST_REMOVE_NODE_POINTER_UB
@@ -294,10 +293,6 @@ struct __forward_node_traits {
                 "is being broken between LLVM 19 and LLVM 20. If you don't care about your ABI being broken, define "
                 "the _LIBCPP_ABI_FORWARD_LIST_REMOVE_NODE_POINTER_UB macro to silence this diagnostic.");
 #  endif
-
-  _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI static __begin_node_pointer __as_iter_node(__node_pointer __p) {
-    return std::__static_fancy_pointer_cast<__begin_node_pointer>(__p);
-  }
 };
 
 template <class _NodePtr>
@@ -309,10 +304,6 @@ struct __forward_begin_node {
 
   _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI __forward_begin_node() : __next_(nullptr) {}
   _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI explicit __forward_begin_node(pointer __n) : __next_(__n) {}
-
-  _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI __begin_node_pointer __next_as_begin() const {
-    return std::__static_fancy_pointer_cast<__begin_node_pointer>(__next_);
-  }
 };
 
 template <class _Tp, class _VoidPtr>
@@ -361,14 +352,8 @@ class __forward_list_iterator {
   typedef typename __traits::__begin_node __begin_node_type;
   typedef typename __traits::__node_pointer __node_pointer;
   typedef typename __traits::__begin_node_pointer __begin_node_pointer;
-  typedef typename __traits::__void_pointer __void_pointer;
 
   __begin_node_pointer __ptr_;
-
-  _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI __begin_node_pointer __get_begin() const { return __ptr_; }
-  _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI __node_pointer __get_unsafe_node_pointer() const {
-    return std::__static_fancy_pointer_cast<__node_pointer>(__ptr_);
-  }
 
   _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI explicit __forward_list_iterator(nullptr_t) _NOEXCEPT
       : __ptr_(nullptr) {}
@@ -377,7 +362,7 @@ class __forward_list_iterator {
   _LIBCPP_HIDE_FROM_ABI explicit __forward_list_iterator(__begin_node_pointer __p) _NOEXCEPT : __ptr_(__p) {}
 
   _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI explicit __forward_list_iterator(__node_pointer __p) _NOEXCEPT
-      : __ptr_(__traits::__as_iter_node(__p)) {}
+      : __ptr_(std::__static_fancy_pointer_cast<__begin_node_pointer>(__p)) {}
 
   template <class, class>
   friend class forward_list;
@@ -394,14 +379,14 @@ public:
   _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI __forward_list_iterator() _NOEXCEPT : __ptr_(nullptr) {}
 
   _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI reference operator*() const {
-    return __get_unsafe_node_pointer()->__get_value();
+    return std::__static_fancy_pointer_cast<__node_pointer>(__ptr_)->__get_value();
   }
   _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI pointer operator->() const {
-    return pointer_traits<pointer>::pointer_to(__get_unsafe_node_pointer()->__get_value());
+    return pointer_traits<pointer>::pointer_to(std::__static_fancy_pointer_cast<__node_pointer>(__ptr_)->__get_value());
   }
 
   _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI __forward_list_iterator& operator++() {
-    __ptr_ = __traits::__as_iter_node(__ptr_->__next_);
+    __ptr_ = std::__static_fancy_pointer_cast<__begin_node_pointer>(__ptr_->__next_);
     return *this;
   }
   _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI __forward_list_iterator operator++(int) {
@@ -430,14 +415,8 @@ class __forward_list_const_iterator {
   typedef typename __traits::__begin_node __begin_node_type;
   typedef typename __traits::__node_pointer __node_pointer;
   typedef typename __traits::__begin_node_pointer __begin_node_pointer;
-  typedef typename __traits::__void_pointer __void_pointer;
 
   __begin_node_pointer __ptr_;
-
-  _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI __begin_node_pointer __get_begin() const { return __ptr_; }
-  _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI __node_pointer __get_unsafe_node_pointer() const {
-    return std::__static_fancy_pointer_cast<__node_pointer>(__ptr_);
-  }
 
   _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI explicit __forward_list_const_iterator(nullptr_t) _NOEXCEPT
       : __ptr_(nullptr) {}
@@ -447,7 +426,7 @@ class __forward_list_const_iterator {
 
   _LIBCPP_CONSTEXPR_SINCE_CXX26
   _LIBCPP_HIDE_FROM_ABI explicit __forward_list_const_iterator(__node_pointer __p) _NOEXCEPT
-      : __ptr_(__traits::__as_iter_node(__p)) {}
+      : __ptr_(std::__static_fancy_pointer_cast<__begin_node_pointer>(__p)) {}
 
   template <class, class>
   friend class forward_list;
@@ -464,14 +443,14 @@ public:
   __forward_list_const_iterator(__forward_list_iterator<__node_pointer> __p) _NOEXCEPT : __ptr_(__p.__ptr_) {}
 
   _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI reference operator*() const {
-    return __get_unsafe_node_pointer()->__get_value();
+    return std::__static_fancy_pointer_cast<__node_pointer>(__ptr_)->__get_value();
   }
   _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI pointer operator->() const {
-    return pointer_traits<pointer>::pointer_to(__get_unsafe_node_pointer()->__get_value());
+    return pointer_traits<pointer>::pointer_to(std::__static_fancy_pointer_cast<__node_pointer>(__ptr_)->__get_value());
   }
 
   _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI __forward_list_const_iterator& operator++() {
-    __ptr_ = __traits::__as_iter_node(__ptr_->__next_);
+    __ptr_ = std::__static_fancy_pointer_cast<__begin_node_pointer>(__ptr_->__next_);
     return *this;
   }
   _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI __forward_list_const_iterator operator++(int) {
@@ -963,7 +942,8 @@ _LIBCPP_CONSTEXPR_SINCE_CXX26 inline forward_list<_Tp, _Alloc>::forward_list(con
 template <class _Tp, class _Alloc>
 _LIBCPP_CONSTEXPR_SINCE_CXX26 forward_list<_Tp, _Alloc>::forward_list(size_type __n) {
   if (__n > 0) {
-    for (__begin_node_pointer __p = __base::__before_begin(); __n > 0; --__n, __p = __p->__next_as_begin()) {
+    for (__begin_node_pointer __p = __base::__before_begin(); __n > 0;
+         --__n, __p = std::__static_fancy_pointer_cast<__begin_node_pointer>(__p->__next_)) {
       __p->__next_ = this->__create_node(/* next = */ nullptr);
     }
   }
@@ -974,7 +954,8 @@ template <class _Tp, class _Alloc>
 _LIBCPP_CONSTEXPR_SINCE_CXX26 forward_list<_Tp, _Alloc>::forward_list(size_type __n, const allocator_type& __base_alloc)
     : __base(__base_alloc) {
   if (__n > 0) {
-    for (__begin_node_pointer __p = __base::__before_begin(); __n > 0; --__n, __p = __p->__next_as_begin()) {
+    for (__begin_node_pointer __p = __base::__before_begin(); __n > 0;
+         --__n, __p = std::__static_fancy_pointer_cast<__begin_node_pointer>(__p->__next_)) {
       __p->__next_ = this->__create_node(/* next = */ nullptr);
     }
   }
@@ -1167,7 +1148,7 @@ template <class _Tp, class _Alloc>
 template <class... _Args>
 _LIBCPP_CONSTEXPR_SINCE_CXX26 typename forward_list<_Tp, _Alloc>::iterator
 forward_list<_Tp, _Alloc>::emplace_after(const_iterator __p, _Args&&... __args) {
-  __begin_node_pointer const __r = __p.__get_begin();
+  __begin_node_pointer const __r = __p.__ptr_;
   __r->__next_                   = this->__create_node(/* next = */ __r->__next_, std::forward<_Args>(__args)...);
   return iterator(__r->__next_);
 }
@@ -1175,7 +1156,7 @@ forward_list<_Tp, _Alloc>::emplace_after(const_iterator __p, _Args&&... __args) 
 template <class _Tp, class _Alloc>
 _LIBCPP_CONSTEXPR_SINCE_CXX26 typename forward_list<_Tp, _Alloc>::iterator
 forward_list<_Tp, _Alloc>::insert_after(const_iterator __p, value_type&& __v) {
-  __begin_node_pointer const __r = __p.__get_begin();
+  __begin_node_pointer const __r = __p.__ptr_;
   __r->__next_                   = this->__create_node(/* next = */ __r->__next_, std::move(__v));
   return iterator(__r->__next_);
 }
@@ -1185,7 +1166,7 @@ forward_list<_Tp, _Alloc>::insert_after(const_iterator __p, value_type&& __v) {
 template <class _Tp, class _Alloc>
 _LIBCPP_CONSTEXPR_SINCE_CXX26 typename forward_list<_Tp, _Alloc>::iterator
 forward_list<_Tp, _Alloc>::insert_after(const_iterator __p, const value_type& __v) {
-  __begin_node_pointer const __r = __p.__get_begin();
+  __begin_node_pointer const __r = __p.__ptr_;
   __r->__next_                   = this->__create_node(/* next = */ __r->__next_, __v);
   return iterator(__r->__next_);
 }
@@ -1194,7 +1175,7 @@ template <class _Tp, class _Alloc>
 template <class... _Args>
 _LIBCPP_CONSTEXPR_SINCE_CXX26 typename forward_list<_Tp, _Alloc>::iterator
 forward_list<_Tp, _Alloc>::__insert_after(const_iterator __p, size_type __n, _Args&&... __args) {
-  __begin_node_pointer __r = __p.__get_begin();
+  __begin_node_pointer __r = __p.__ptr_;
   if (__n > 0) {
     __node_pointer __first = this->__create_node(/* next = */ nullptr, std::forward<_Args>(__args)...);
     __node_pointer __last  = __first;
@@ -1216,7 +1197,7 @@ forward_list<_Tp, _Alloc>::__insert_after(const_iterator __p, size_type __n, _Ar
 #  endif // _LIBCPP_HAS_EXCEPTIONS
     __last->__next_ = __r->__next_;
     __r->__next_    = __first;
-    __r             = __forward_node_traits<__node_pointer>::__as_iter_node(__last);
+    __r             = std::__static_fancy_pointer_cast<__begin_node_pointer>(__last);
   }
   return iterator(__r);
 }
@@ -1232,7 +1213,7 @@ template <class _Tp, class _Alloc>
 template <class _InputIterator, class _Sentinel>
 _LIBCPP_CONSTEXPR_SINCE_CXX26 _LIBCPP_HIDE_FROM_ABI typename forward_list<_Tp, _Alloc>::iterator
 forward_list<_Tp, _Alloc>::__insert_after_with_sentinel(const_iterator __p, _InputIterator __f, _Sentinel __l) {
-  __begin_node_pointer __r = __p.__get_begin();
+  __begin_node_pointer __r = __p.__ptr_;
 
   if (__f != __l) {
     __node_pointer __first = this->__create_node(/* next = */ nullptr, *__f);
@@ -1257,7 +1238,7 @@ forward_list<_Tp, _Alloc>::__insert_after_with_sentinel(const_iterator __p, _Inp
 
     __last->__next_ = __r->__next_;
     __r->__next_    = __first;
-    __r             = __forward_node_traits<__node_pointer>::__as_iter_node(__last);
+    __r             = std::__static_fancy_pointer_cast<__begin_node_pointer>(__last);
   }
 
   return iterator(__r);
@@ -1266,7 +1247,7 @@ forward_list<_Tp, _Alloc>::__insert_after_with_sentinel(const_iterator __p, _Inp
 template <class _Tp, class _Alloc>
 _LIBCPP_CONSTEXPR_SINCE_CXX26 typename forward_list<_Tp, _Alloc>::iterator
 forward_list<_Tp, _Alloc>::erase_after(const_iterator __f) {
-  __begin_node_pointer __p = __f.__get_begin();
+  __begin_node_pointer __p = __f.__ptr_;
   __node_pointer __n       = __p->__next_;
   __p->__next_             = __n->__next_;
   this->__delete_node(__n);
@@ -1276,9 +1257,9 @@ forward_list<_Tp, _Alloc>::erase_after(const_iterator __f) {
 template <class _Tp, class _Alloc>
 _LIBCPP_CONSTEXPR_SINCE_CXX26 typename forward_list<_Tp, _Alloc>::iterator
 forward_list<_Tp, _Alloc>::erase_after(const_iterator __f, const_iterator __l) {
-  __node_pointer __e = __l.__get_unsafe_node_pointer();
+  __node_pointer __e = std::__static_fancy_pointer_cast<__node_pointer>(__l.__ptr_);
   if (__f != __l) {
-    __begin_node_pointer __bp = __f.__get_begin();
+    __begin_node_pointer __bp = __f.__ptr_;
 
     __node_pointer __n = __bp->__next_;
     if (__n != __e) {
@@ -1324,13 +1305,13 @@ _LIBCPP_CONSTEXPR_SINCE_CXX26 void forward_list<_Tp, _Alloc>::resize(size_type _
 template <class _Tp, class _Alloc>
 _LIBCPP_CONSTEXPR_SINCE_CXX26 void forward_list<_Tp, _Alloc>::splice_after(const_iterator __p, forward_list& __x) {
   if (!__x.empty()) {
-    if (__p.__get_begin()->__next_ != nullptr) {
+    if (__p.__ptr_->__next_ != nullptr) {
       const_iterator __lm1 = __x.before_begin();
-      while (__lm1.__get_begin()->__next_ != nullptr)
+      while (__lm1.__ptr_->__next_ != nullptr)
         ++__lm1;
-      __lm1.__get_begin()->__next_ = __p.__get_begin()->__next_;
+      __lm1.__ptr_->__next_ = __p.__ptr_->__next_;
     }
-    __p.__get_begin()->__next_    = __x.__before_begin()->__next_;
+    __p.__ptr_->__next_           = __x.__before_begin()->__next_;
     __x.__before_begin()->__next_ = nullptr;
   }
 }
@@ -1340,9 +1321,9 @@ _LIBCPP_CONSTEXPR_SINCE_CXX26 void
 forward_list<_Tp, _Alloc>::splice_after(const_iterator __p, forward_list& /*__other*/, const_iterator __i) {
   const_iterator __lm1 = std::next(__i);
   if (__p != __i && __p != __lm1) {
-    __i.__get_begin()->__next_   = __lm1.__get_begin()->__next_;
-    __lm1.__get_begin()->__next_ = __p.__get_begin()->__next_;
-    __p.__get_begin()->__next_   = __lm1.__get_unsafe_node_pointer();
+    __i.__ptr_->__next_   = __lm1.__ptr_->__next_;
+    __lm1.__ptr_->__next_ = __p.__ptr_->__next_;
+    __p.__ptr_->__next_   = std::__static_fancy_pointer_cast<__node_pointer>(__lm1.__ptr_);
   }
 }
 
@@ -1351,12 +1332,12 @@ _LIBCPP_CONSTEXPR_SINCE_CXX26 void forward_list<_Tp, _Alloc>::splice_after(
     const_iterator __p, forward_list& /*__other*/, const_iterator __f, const_iterator __l) {
   if (__f != __l && __p != __f) {
     const_iterator __lm1 = __f;
-    while (__lm1.__get_begin()->__next_ != __l.__get_begin())
+    while (__lm1.__ptr_->__next_ != __l.__ptr_)
       ++__lm1;
     if (__f != __lm1) {
-      __lm1.__get_begin()->__next_ = __p.__get_begin()->__next_;
-      __p.__get_begin()->__next_   = __f.__get_begin()->__next_;
-      __f.__get_begin()->__next_   = __l.__get_unsafe_node_pointer();
+      __lm1.__ptr_->__next_ = __p.__ptr_->__next_;
+      __p.__ptr_->__next_   = __f.__ptr_->__next_;
+      __f.__ptr_->__next_   = std::__static_fancy_pointer_cast<__node_pointer>(__l.__ptr_);
     }
   }
 }
@@ -1385,8 +1366,8 @@ forward_list<_Tp, _Alloc>::remove(const value_type& __v) {
   forward_list<_Tp, _Alloc> __deleted_nodes(get_allocator()); // collect the nodes we're removing
   typename forward_list<_Tp, _Alloc>::size_type __count_removed = 0;
   const iterator __e                                            = end();
-  for (iterator __i = before_begin(); __i.__get_begin()->__next_ != nullptr;) {
-    if (__i.__get_begin()->__next_->__get_value() == __v) {
+  for (iterator __i = before_begin(); __i.__ptr_->__next_ != nullptr;) {
+    if (__i.__ptr_->__next_->__get_value() == __v) {
       ++__count_removed;
       iterator __j = std::next(__i, 2);
       for (; __j != __e && *__j == __v; ++__j)
@@ -1409,8 +1390,8 @@ forward_list<_Tp, _Alloc>::remove_if(_Predicate __pred) {
   forward_list<_Tp, _Alloc> __deleted_nodes(get_allocator()); // collect the nodes we're removing
   typename forward_list<_Tp, _Alloc>::size_type __count_removed = 0;
   const iterator __e                                            = end();
-  for (iterator __i = before_begin(); __i.__get_begin()->__next_ != nullptr;) {
-    if (__pred(__i.__get_begin()->__next_->__get_value())) {
+  for (iterator __i = before_begin(); __i.__ptr_->__next_ != nullptr;) {
+    if (__pred(__i.__ptr_->__next_->__get_value())) {
       ++__count_removed;
       iterator __j = std::next(__i, 2);
       for (; __j != __e && __pred(*__j); ++__j)
@@ -1436,7 +1417,7 @@ forward_list<_Tp, _Alloc>::unique(_BinaryPredicate __binary_pred) {
     iterator __j = std::next(__i);
     for (; __j != __e && __binary_pred(*__i, *__j); ++__j)
       ++__count_removed;
-    if (__i.__get_begin()->__next_ != __j.__get_unsafe_node_pointer())
+    if (__i.__ptr_->__next_ != std::__static_fancy_pointer_cast<__node_pointer>(__j.__ptr_))
       __deleted_nodes.splice_after(__deleted_nodes.before_begin(), *this, __i, __j);
     __i = __j;
   }
@@ -1516,7 +1497,7 @@ forward_list<_Tp, _Alloc>::__sort(__node_pointer __f1, difference_type __sz, _Co
   }
   difference_type __sz1 = __sz / 2;
   difference_type __sz2 = __sz - __sz1;
-  __node_pointer __t    = std::next(iterator(__f1), __sz1 - 1).__get_unsafe_node_pointer();
+  __node_pointer __t    = std::__static_fancy_pointer_cast<__node_pointer>(std::next(iterator(__f1), __sz1 - 1).__ptr_);
   __node_pointer __f2   = __t->__next_;
   __t->__next_          = nullptr;
   return __merge(__sort(__f1, __sz1, __comp), __sort(__f2, __sz2, __comp), __comp);


### PR DESCRIPTION
The patch removes unnecessary casts to `void*` pointers, inline some casts, and eliminates an identity cast.