### PR TITLE
[flang] Fix Cray pointers in module file output

### DIFF
--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -978,11 +978,9 @@ void ModFileWriter::PutObjectEntity(
         << ") " << symbol.name() << '\n';
   }
   if (symbol.test(Fortran::semantics::Symbol::Flag::CrayPointer)) {
-    if (!symbol.owner().crayPointers().empty()) {
-      for (const auto &[pointee, pointer] : symbol.owner().crayPointers()) {
-        if (pointer == symbol) {
-          os << "pointer(" << symbol.name() << "," << pointee << ")\n";
-        }
+    for (const auto &[pointee, pointer] : symbol.owner().crayPointers()) {
+      if (pointer == symbol) {
+        os << "pointer(" << symbol.name() << "," << pointee << ")\n";
       }
     }
   }
@@ -1724,6 +1722,17 @@ void SubprogramSymbolCollector::DoSymbol(
   }
   if (!scope.IsDerivedType()) {
     need_.push_back(symbol);
+  }
+  if (symbol.test(Fortran::semantics::Symbol::Flag::CrayPointer)) {
+    for (const auto &[pointee, pointer] : symbol.owner().crayPointers()) {
+      if (&*pointer == &symbol) {
+        auto iter{symbol.owner().find(pointee)};
+        CHECK(iter != symbol.owner().end());
+        DoSymbol(*iter->second);
+      }
+    }
+  } else if (symbol.test(Fortran::semantics::Symbol::Flag::CrayPointee)) {
+    DoSymbol(GetCrayPointer(symbol));
   }
 }
 

--- a/flang/test/Semantics/modfile74.f90
+++ b/flang/test/Semantics/modfile74.f90
@@ -1,0 +1,19 @@
+! RUN: %python %S/test_modfile.py %s %flang_fc1
+module m
+ contains
+  function f() result(ptr)
+    character :: str
+    pointer(ptr, str)
+    ptr = 0
+  end
+end
+
+!Expect: m.mod
+!module m
+!contains
+!function f() result(ptr)
+!integer(8)::ptr
+!pointer(ptr,str)
+!character(1_8,1)::str
+!end
+!end


### PR DESCRIPTION
The relationship between a Cray pointee and its pointer is not in the symbol table entry, but instead in a per-scope map.  Use this information to ensure that if a pointee/pointer is needed in the module file, so is its pointer/pointee.

Fixes https://github.com/llvm/llvm-project/issues/130270.