### PR TITLE
[mlir] Introduction of LocalEffectsOpInterface

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.td
@@ -31,6 +31,7 @@ class LinalgStructuredBase_Op<string mnemonic, list<Trait> props>
        DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
        DeclareOpInterfaceMethods<ConditionallySpeculatable>,
        RecursiveMemoryEffects,
+       LocalEffectsOpInterface,
        DestinationStyleOpInterface,
        LinalgStructuredInterface,
        ReifyRankedShapedTypeOpInterface], props)> {

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -547,7 +547,8 @@ def CopyOp : MemRef_Op<"copy", [CopyOpInterface, SameOperandsElementType,
 // DeallocOp
 //===----------------------------------------------------------------------===//
 
-def MemRef_DeallocOp : MemRef_Op<"dealloc", [MemRefsNormalizable]> {
+def MemRef_DeallocOp
+    : MemRef_Op<"dealloc", [MemRefsNormalizable, LocalEffectsOpInterface]> {
   let summary = "memory deallocation operation";
   let description = [{
     The `dealloc` operation frees the region of memory referenced by a memref
@@ -1180,6 +1181,7 @@ def LoadOp : MemRef_Op<"load",
                      "memref", "result",
                      "::llvm::cast<MemRefType>($_self).getElementType()">,
       MemRefsNormalizable,
+      LocalEffectsOpInterface,
       DeclareOpInterfaceMethods<PromotableMemOpInterface>,
       DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>]> {
   let summary = "load operation";
@@ -1813,6 +1815,7 @@ def MemRef_StoreOp : MemRef_Op<"store",
                      "memref", "value",
                      "::llvm::cast<MemRefType>($_self).getElementType()">,
       MemRefsNormalizable,
+      LocalEffectsOpInterface,
       DeclareOpInterfaceMethods<PromotableMemOpInterface>,
       DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>]> {
   let summary = "store operation";

--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.h
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.h
@@ -15,6 +15,7 @@
 #define MLIR_INTERFACES_CONTROLFLOWINTERFACES_H
 
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 
 namespace mlir {
 class BranchOpInterface;

--- a/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
+++ b/mlir/include/mlir/Interfaces/ControlFlowInterfaces.td
@@ -14,6 +14,7 @@
 #ifndef MLIR_INTERFACES_CONTROLFLOWINTERFACES
 #define MLIR_INTERFACES_CONTROLFLOWINTERFACES
 
+include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
 
 //===----------------------------------------------------------------------===//
@@ -115,7 +116,8 @@ def BranchOpInterface : OpInterface<"BranchOpInterface"> {
 // RegionBranchOpInterface
 //===----------------------------------------------------------------------===//
 
-def RegionBranchOpInterface : OpInterface<"RegionBranchOpInterface"> {
+def RegionBranchOpInterface
+    : OpInterface<"RegionBranchOpInterface", [LocalEffectsOpInterface]> {
   let description = [{
     This interface provides information for region operations that exhibit
     branching behavior between held regions. I.e., this interface allows for

--- a/mlir/include/mlir/Interfaces/SideEffectInterfaces.h
+++ b/mlir/include/mlir/Interfaces/SideEffectInterfaces.h
@@ -457,6 +457,15 @@ bool isSpeculatable(Operation *op);
 /// This function is the C++ equivalent of the `Pure` trait.
 bool isPure(Operation *op);
 
+//===----------------------------------------------------------------------===//
+// LocalEffects Utilities
+//===----------------------------------------------------------------------===//
+
+namespace detail {
+/// Default implementation of `hasLocalEffects` method.
+bool hasLocalEffectsDefaultImpl(Operation *op);
+} // namespace detail
+
 } // namespace mlir
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Interfaces/SideEffectInterfaces.td
+++ b/mlir/include/mlir/Interfaces/SideEffectInterfaces.td
@@ -145,4 +145,29 @@ def RecursivelySpeculatable : TraitList<[
 // are always legal to hoist or sink.
 def Pure : TraitList<[AlwaysSpeculatable, NoMemoryEffect]>;
 
+//===----------------------------------------------------------------------===//
+// LocalEffects
+//===----------------------------------------------------------------------===//
+
+// Interface which could be implemented by imperative operators that have no
+// effects on state outside of what’s directly available through their operands
+// (for example, they can’t access a `memref.global`, can’t make a call to
+// another function that can potentially do so, can’t perform a
+// synchronization/wait on other pending memory operations, etc.), including
+// through operators in their regions.
+def LocalEffectsOpInterface : OpInterface<"LocalEffectsOpInterface"> {
+  let description = [{An interface for operators which have no effects on state
+                      outside of what's directly available through their own
+                      operands or operands of the operators inside their regions.
+  }];
+  let cppNamespace = "::mlir";
+
+  let methods =
+      [InterfaceMethod<[{ Returns true if operator has only local effects. }],
+                       "bool", "hasLocalEffects", (ins), [{}], [{
+                         return mlir::detail::hasLocalEffectsDefaultImpl(
+                             $_op.getOperation());
+                       }]>];
+}
+
 #endif // MLIR_INTERFACES_SIDEEFFECTS


### PR DESCRIPTION
Introduce new interface `LocalEffectsOpInterface` to allow querying if the operator does not change state outside its operand or its nested operator's operands. Meant to improve affine loop fusion analysis and potentially other analyses.

Based on discussion: https://discourse.llvm.org/t/linalg-ops-prevent-affine-loop-fusion/84767