### PR TITLE
[clang-format] Add support for absl nullability macros

### DIFF
--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -1508,6 +1508,10 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.AlwaysBreakAfterDefinitionReturnType = FormatStyle::DRTBS_None;
   LLVMStyle.AlwaysBreakBeforeMultilineStrings = false;
   LLVMStyle.AttributeMacros.push_back("__capability");
+  // Abseil aliases to clang's `_Nonnull`, `_Nullable` and `_Null_unspecified`.
+  LLVMStyle.AttributeMacros.push_back("absl_nonnull");
+  LLVMStyle.AttributeMacros.push_back("absl_nullable");
+  LLVMStyle.AttributeMacros.push_back("absl_nullability_unknown");
   LLVMStyle.BinPackArguments = true;
   LLVMStyle.BinPackLongBracedList = true;
   LLVMStyle.BinPackParameters = FormatStyle::BPPS_BinPack;

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -1508,10 +1508,6 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.AlwaysBreakAfterDefinitionReturnType = FormatStyle::DRTBS_None;
   LLVMStyle.AlwaysBreakBeforeMultilineStrings = false;
   LLVMStyle.AttributeMacros.push_back("__capability");
-  // Abseil aliases to clang's `_Nonnull`, `_Nullable` and `_Null_unspecified`.
-  LLVMStyle.AttributeMacros.push_back("absl_nonnull");
-  LLVMStyle.AttributeMacros.push_back("absl_nullable");
-  LLVMStyle.AttributeMacros.push_back("absl_nullability_unknown");
   LLVMStyle.BinPackArguments = true;
   LLVMStyle.BinPackLongBracedList = true;
   LLVMStyle.BinPackParameters = FormatStyle::BPPS_BinPack;
@@ -1717,6 +1713,10 @@ FormatStyle getGoogleStyle(FormatStyle::LanguageKind Language) {
       FormatStyle::SIS_WithoutElse;
   GoogleStyle.AllowShortLoopsOnASingleLine = true;
   GoogleStyle.AlwaysBreakBeforeMultilineStrings = true;
+  // Abseil aliases to clang's `_Nonnull`, `_Nullable` and `_Null_unspecified`.
+  GoogleStyle.AttributeMacros.push_back("absl_nonnull");
+  GoogleStyle.AttributeMacros.push_back("absl_nullable");
+  GoogleStyle.AttributeMacros.push_back("absl_nullability_unknown");
   GoogleStyle.BreakTemplateDeclarations = FormatStyle::BTDS_Yes;
   GoogleStyle.DerivePointerAlignment = true;
   GoogleStyle.IncludeStyle.IncludeBlocks = tooling::IncludeStyle::IBS_Regroup;

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -909,6 +909,10 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   Style.AttributeMacros.clear();
   CHECK_PARSE(
       "BasedOnStyle: LLVM", AttributeMacros,
+      std::vector<std::string>({"__capability"}));
+  Style.AttributeMacros.clear();
+  CHECK_PARSE(
+      "BasedOnStyle: Google", AttributeMacros,
       std::vector<std::string>({"__capability", "absl_nonnull", "absl_nullable",
                                 "absl_nullability_unknown"}));
   Style.AttributeMacros.clear();

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -907,9 +907,8 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   CHECK_PARSE("IfMacros: [MYIF]", IfMacros, CustomIfs);
 
   Style.AttributeMacros.clear();
-  CHECK_PARSE(
-      "BasedOnStyle: LLVM", AttributeMacros,
-      std::vector<std::string>({"__capability"}));
+  CHECK_PARSE("BasedOnStyle: LLVM", AttributeMacros,
+              std::vector<std::string>{"__capability"});
   Style.AttributeMacros.clear();
   CHECK_PARSE(
       "BasedOnStyle: Google", AttributeMacros,

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -908,7 +908,9 @@ TEST(ConfigParseTest, ParsesConfiguration) {
 
   Style.AttributeMacros.clear();
   CHECK_PARSE("BasedOnStyle: LLVM", AttributeMacros,
-              std::vector<std::string>{"__capability"});
+      std::vector<std::string>({"__capability", "absl_nonnull", "absl_nullable",
+                                "absl_nullability_unknown"}));
+  Style.AttributeMacros.clear();
   CHECK_PARSE("AttributeMacros: [attr1, attr2]", AttributeMacros,
               std::vector<std::string>({"attr1", "attr2"}));
 

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -907,7 +907,8 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   CHECK_PARSE("IfMacros: [MYIF]", IfMacros, CustomIfs);
 
   Style.AttributeMacros.clear();
-  CHECK_PARSE("BasedOnStyle: LLVM", AttributeMacros,
+  CHECK_PARSE(
+      "BasedOnStyle: LLVM", AttributeMacros,
       std::vector<std::string>({"__capability", "absl_nonnull", "absl_nullable",
                                 "absl_nullability_unknown"}));
   Style.AttributeMacros.clear();

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -909,7 +909,6 @@ TEST(ConfigParseTest, ParsesConfiguration) {
   Style.AttributeMacros.clear();
   CHECK_PARSE("BasedOnStyle: LLVM", AttributeMacros,
               std::vector<std::string>{"__capability"});
-  Style.AttributeMacros.clear();
   CHECK_PARSE(
       "BasedOnStyle: Google", AttributeMacros,
       std::vector<std::string>({"__capability", "absl_nonnull", "absl_nullable",

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -12739,8 +12739,8 @@ TEST_F(FormatTest, UnderstandsPointerQualifiersInCast) {
   FormatStyle LongPointerRightGoogle = getGoogleStyleWithColumns(999);
   FormatStyle LongPointerLeftGoogle = getGoogleStyleWithColumns(999);
   LongPointerLeftGoogle.PointerAlignment = FormatStyle::PAS_Left;
-  Twine AllQualifiersPlusGoogle = AllQualifiers +
-      " absl_nonnull absl_nullable absl_nullability_unknown";
+  Twine AllQualifiersPlusGoogle =
+      AllQualifiers + " absl_nonnull absl_nullable absl_nullability_unknown";
   verifyFormat(("x = (foo *" + AllQualifiersPlusGoogle + ")*v;").str(),
                LongPointerRightGoogle);
   verifyFormat(("x = (foo* " + AllQualifiersPlusGoogle + ")*v;").str(),

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -12375,9 +12375,9 @@ TEST_F(FormatTest, UnderstandsUsesOfStarAndAmp) {
   verifyFormat("vector<a *_Nonnull> v;");
   verifyFormat("vector<a *_Nullable> v;");
   verifyFormat("vector<a *_Null_unspecified> v;");
-  verifyFormat("vector<a *absl_nonnull> v;");
-  verifyFormat("vector<a *absl_nullable> v;");
-  verifyFormat("vector<a *absl_nullability_unknown> v;");
+  verifyGoogleFormat("vector<a *absl_nonnull> v;");
+  verifyGoogleFormat("vector<a *absl_nullable> v;");
+  verifyGoogleFormat("vector<a *absl_nullability_unknown> v;");
   verifyFormat("vector<a *__ptr32> v;");
   verifyFormat("vector<a *__ptr64> v;");
   verifyFormat("vector<a *__capability> v;");
@@ -12521,9 +12521,10 @@ TEST_F(FormatTest, UnderstandsUsesOfStarAndAmp) {
   verifyIndependentOfContext("MACRO(A *_Nonnull a);");
   verifyIndependentOfContext("MACRO(A *_Nullable a);");
   verifyIndependentOfContext("MACRO(A *_Null_unspecified a);");
-  verifyIndependentOfContext("MACRO(A *absl_nonnull a);");
-  verifyIndependentOfContext("MACRO(A *absl_nullable a);");
-  verifyIndependentOfContext("MACRO(A *absl_nullability_unknown a);");
+  verifyIndependentOfContext("MACRO(A *absl_nonnull a);", getGoogleStyle());
+  verifyIndependentOfContext("MACRO(A *absl_nullable a);", getGoogleStyle());
+  verifyIndependentOfContext("MACRO(A *absl_nullability_unknown a);",
+                             getGoogleStyle());
   verifyIndependentOfContext("MACRO(A *__attribute__((foo)) a);");
   verifyIndependentOfContext("MACRO(A *__attribute((foo)) a);");
   verifyIndependentOfContext("MACRO(A *[[clang::attr]] a);");
@@ -12680,14 +12681,14 @@ TEST_F(FormatTest, UnderstandsAttributes) {
   verifyFormat("SomeType *__unused s{InitValue};", CustomAttrs);
   verifyFormat("SomeType s __unused(InitValue);", CustomAttrs);
   verifyFormat("SomeType s __unused{InitValue};", CustomAttrs);
-  verifyFormat("SomeType *absl_nonnull s(InitValue);", CustomAttrs);
-  verifyFormat("SomeType *absl_nonnull s{InitValue};", CustomAttrs);
-  verifyFormat("SomeType *absl_nullable s(InitValue);", CustomAttrs);
-  verifyFormat("SomeType *absl_nullable s{InitValue};", CustomAttrs);
-  verifyFormat("SomeType *absl_nullability_unknown s(InitValue);", CustomAttrs);
-  verifyFormat("SomeType *absl_nullability_unknown s{InitValue};", CustomAttrs);
   verifyFormat("SomeType *__capability s(InitValue);", CustomAttrs);
   verifyFormat("SomeType *__capability s{InitValue};", CustomAttrs);
+  verifyGoogleFormat("SomeType *absl_nonnull s(InitValue);");
+  verifyGoogleFormat("SomeType *absl_nonnull s{InitValue};");
+  verifyGoogleFormat("SomeType *absl_nullable s(InitValue);");
+  verifyGoogleFormat("SomeType *absl_nullable s{InitValue};");
+  verifyGoogleFormat("SomeType *absl_nullability_unknown s(InitValue);");
+  verifyGoogleFormat("SomeType *absl_nullability_unknown s{InitValue};");
 }
 
 TEST_F(FormatTest, UnderstandsPointerQualifiersInCast) {
@@ -12699,9 +12700,9 @@ TEST_F(FormatTest, UnderstandsPointerQualifiersInCast) {
   verifyFormat("x = (foo *_Nonnull)*v;");
   verifyFormat("x = (foo *_Nullable)*v;");
   verifyFormat("x = (foo *_Null_unspecified)*v;");
-  verifyFormat("x = (foo *absl_nonnull)*v;");
-  verifyFormat("x = (foo *absl_nullable)*v;");
-  verifyFormat("x = (foo *absl_nullability_unknown)*v;");
+  verifyGoogleFormat("x = (foo *absl_nonnull)*v;");
+  verifyGoogleFormat("x = (foo *absl_nullable)*v;");
+  verifyGoogleFormat("x = (foo *absl_nullability_unknown)*v;");
   verifyFormat("x = (foo *[[clang::attr]])*v;");
   verifyFormat("x = (foo *[[clang::attr(\"foo\")]])*v;");
   verifyFormat("x = (foo *__ptr32)*v;");
@@ -12715,8 +12716,7 @@ TEST_F(FormatTest, UnderstandsPointerQualifiersInCast) {
   LongPointerLeft.PointerAlignment = FormatStyle::PAS_Left;
   StringRef AllQualifiers =
       "const volatile restrict __attribute__((foo)) _Nonnull _Null_unspecified "
-      "_Nullable absl_nonnull absl_nullable absl_nullability_unknown "
-      "[[clang::attr]] __ptr32 __ptr64 __capability";
+      "_Nullable [[clang::attr]] __ptr32 __ptr64 __capability";
   verifyFormat(("x = (foo *" + AllQualifiers + ")*v;").str(), LongPointerRight);
   verifyFormat(("x = (foo* " + AllQualifiers + ")*v;").str(), LongPointerLeft);
 
@@ -12734,6 +12734,21 @@ TEST_F(FormatTest, UnderstandsPointerQualifiersInCast) {
                CustomQualifier);
   verifyFormat(("x = (foo *" + AllQualifiers + " __my_qualifier)&v;").str(),
                CustomQualifier);
+
+  // Check additional attribute macros in Google style:
+  FormatStyle LongPointerRightGoogle = getGoogleStyleWithColumns(999);
+  FormatStyle LongPointerLeftGoogle = getGoogleStyleWithColumns(999);
+  LongPointerLeftGoogle.PointerAlignment = FormatStyle::PAS_Left;
+  Twine AllQualifiersPlusGoogle = AllQualifiers +
+      " absl_nonnull absl_nullable absl_nullability_unknown";
+  verifyFormat(("x = (foo *" + AllQualifiersPlusGoogle + ")*v;").str(),
+               LongPointerRightGoogle);
+  verifyFormat(("x = (foo* " + AllQualifiersPlusGoogle + ")*v;").str(),
+               LongPointerLeftGoogle);
+  verifyFormat(("x = (foo *" + AllQualifiersPlusGoogle + ")&v;").str(),
+               LongPointerRightGoogle);
+  verifyFormat(("x = (foo* " + AllQualifiersPlusGoogle + ")&v;").str(),
+               LongPointerLeftGoogle);
 
   // Check that unknown identifiers result in binary operator parsing:
   verifyFormat("x = (foo * __unknown_qualifier) * v;");

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -12375,9 +12375,9 @@ TEST_F(FormatTest, UnderstandsUsesOfStarAndAmp) {
   verifyFormat("vector<a *_Nonnull> v;");
   verifyFormat("vector<a *_Nullable> v;");
   verifyFormat("vector<a *_Null_unspecified> v;");
-  verifyGoogleFormat("vector<a *absl_nonnull> v;");
-  verifyGoogleFormat("vector<a *absl_nullable> v;");
-  verifyGoogleFormat("vector<a *absl_nullability_unknown> v;");
+  verifyGoogleFormat("vector<a* absl_nonnull> v;");
+  verifyGoogleFormat("vector<a* absl_nullable> v;");
+  verifyGoogleFormat("vector<a* absl_nullability_unknown> v;");
   verifyFormat("vector<a *__ptr32> v;");
   verifyFormat("vector<a *__ptr64> v;");
   verifyFormat("vector<a *__capability> v;");
@@ -12523,9 +12523,9 @@ TEST_F(FormatTest, UnderstandsUsesOfStarAndAmp) {
   verifyIndependentOfContext("MACRO(A *_Null_unspecified a);");
 
   Style = getGoogleStyle();
-  verifyIndependentOfContext("MACRO(A *absl_nonnull a);", Style);
-  verifyIndependentOfContext("MACRO(A *absl_nullable a);", Style);
-  verifyIndependentOfContext("MACRO(A *absl_nullability_unknown a);", Style);
+  verifyIndependentOfContext("MACRO(A* absl_nonnull a);", Style);
+  verifyIndependentOfContext("MACRO(A* absl_nullable a);", Style);
+  verifyIndependentOfContext("MACRO(A* absl_nullability_unknown a);", Style);
 
   verifyIndependentOfContext("MACRO(A *__attribute__((foo)) a);");
   verifyIndependentOfContext("MACRO(A *__attribute((foo)) a);");
@@ -12685,12 +12685,12 @@ TEST_F(FormatTest, UnderstandsAttributes) {
   verifyFormat("SomeType s __unused{InitValue};", CustomAttrs);
   verifyFormat("SomeType *__capability s(InitValue);", CustomAttrs);
   verifyFormat("SomeType *__capability s{InitValue};", CustomAttrs);
-  verifyGoogleFormat("SomeType *absl_nonnull s(InitValue);");
-  verifyGoogleFormat("SomeType *absl_nonnull s{InitValue};");
-  verifyGoogleFormat("SomeType *absl_nullable s(InitValue);");
-  verifyGoogleFormat("SomeType *absl_nullable s{InitValue};");
-  verifyGoogleFormat("SomeType *absl_nullability_unknown s(InitValue);");
-  verifyGoogleFormat("SomeType *absl_nullability_unknown s{InitValue};");
+  verifyGoogleFormat("SomeType* absl_nonnull s(InitValue);");
+  verifyGoogleFormat("SomeType* absl_nonnull s{InitValue};");
+  verifyGoogleFormat("SomeType* absl_nullable s(InitValue);");
+  verifyGoogleFormat("SomeType* absl_nullable s{InitValue};");
+  verifyGoogleFormat("SomeType* absl_nullability_unknown s(InitValue);");
+  verifyGoogleFormat("SomeType* absl_nullability_unknown s{InitValue};");
 }
 
 TEST_F(FormatTest, UnderstandsPointerQualifiersInCast) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -12525,8 +12525,7 @@ TEST_F(FormatTest, UnderstandsUsesOfStarAndAmp) {
   Style = getGoogleStyle();
   verifyIndependentOfContext("MACRO(A *absl_nonnull a);", Style);
   verifyIndependentOfContext("MACRO(A *absl_nullable a);", Style);
-  verifyIndependentOfContext("MACRO(A *absl_nullability_unknown a);",
-                             Style);
+  verifyIndependentOfContext("MACRO(A *absl_nullability_unknown a);", Style);
 
   verifyIndependentOfContext("MACRO(A *__attribute__((foo)) a);");
   verifyIndependentOfContext("MACRO(A *__attribute((foo)) a);");

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -12375,6 +12375,9 @@ TEST_F(FormatTest, UnderstandsUsesOfStarAndAmp) {
   verifyFormat("vector<a *_Nonnull> v;");
   verifyFormat("vector<a *_Nullable> v;");
   verifyFormat("vector<a *_Null_unspecified> v;");
+  verifyFormat("vector<a *absl_nonnull> v;");
+  verifyFormat("vector<a *absl_nullable> v;");
+  verifyFormat("vector<a *absl_nullability_unknown> v;");
   verifyFormat("vector<a *__ptr32> v;");
   verifyFormat("vector<a *__ptr64> v;");
   verifyFormat("vector<a *__capability> v;");
@@ -12518,6 +12521,9 @@ TEST_F(FormatTest, UnderstandsUsesOfStarAndAmp) {
   verifyIndependentOfContext("MACRO(A *_Nonnull a);");
   verifyIndependentOfContext("MACRO(A *_Nullable a);");
   verifyIndependentOfContext("MACRO(A *_Null_unspecified a);");
+  verifyIndependentOfContext("MACRO(A *absl_nonnull a);");
+  verifyIndependentOfContext("MACRO(A *absl_nullable a);");
+  verifyIndependentOfContext("MACRO(A *absl_nullability_unknown a);");
   verifyIndependentOfContext("MACRO(A *__attribute__((foo)) a);");
   verifyIndependentOfContext("MACRO(A *__attribute((foo)) a);");
   verifyIndependentOfContext("MACRO(A *[[clang::attr]] a);");
@@ -12674,6 +12680,12 @@ TEST_F(FormatTest, UnderstandsAttributes) {
   verifyFormat("SomeType *__unused s{InitValue};", CustomAttrs);
   verifyFormat("SomeType s __unused(InitValue);", CustomAttrs);
   verifyFormat("SomeType s __unused{InitValue};", CustomAttrs);
+  verifyFormat("SomeType *absl_nonnull s(InitValue);", CustomAttrs);
+  verifyFormat("SomeType *absl_nonnull s{InitValue};", CustomAttrs);
+  verifyFormat("SomeType *absl_nullable s(InitValue);", CustomAttrs);
+  verifyFormat("SomeType *absl_nullable s{InitValue};", CustomAttrs);
+  verifyFormat("SomeType *absl_nullability_unknown s(InitValue);", CustomAttrs);
+  verifyFormat("SomeType *absl_nullability_unknown s{InitValue};", CustomAttrs);
   verifyFormat("SomeType *__capability s(InitValue);", CustomAttrs);
   verifyFormat("SomeType *__capability s{InitValue};", CustomAttrs);
 }
@@ -12687,7 +12699,9 @@ TEST_F(FormatTest, UnderstandsPointerQualifiersInCast) {
   verifyFormat("x = (foo *_Nonnull)*v;");
   verifyFormat("x = (foo *_Nullable)*v;");
   verifyFormat("x = (foo *_Null_unspecified)*v;");
-  verifyFormat("x = (foo *_Nonnull)*v;");
+  verifyFormat("x = (foo *absl_nonnull)*v;");
+  verifyFormat("x = (foo *absl_nullable)*v;");
+  verifyFormat("x = (foo *absl_nullability_unknown)*v;");
   verifyFormat("x = (foo *[[clang::attr]])*v;");
   verifyFormat("x = (foo *[[clang::attr(\"foo\")]])*v;");
   verifyFormat("x = (foo *__ptr32)*v;");
@@ -12701,7 +12715,8 @@ TEST_F(FormatTest, UnderstandsPointerQualifiersInCast) {
   LongPointerLeft.PointerAlignment = FormatStyle::PAS_Left;
   StringRef AllQualifiers =
       "const volatile restrict __attribute__((foo)) _Nonnull _Null_unspecified "
-      "_Nonnull [[clang::attr]] __ptr32 __ptr64 __capability";
+      "_Nullable absl_nonnull absl_nullable absl_nullability_unknown "
+      "[[clang::attr]] __ptr32 __ptr64 __capability";
   verifyFormat(("x = (foo *" + AllQualifiers + ")*v;").str(), LongPointerRight);
   verifyFormat(("x = (foo* " + AllQualifiers + ")*v;").str(), LongPointerLeft);
 

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -12521,10 +12521,13 @@ TEST_F(FormatTest, UnderstandsUsesOfStarAndAmp) {
   verifyIndependentOfContext("MACRO(A *_Nonnull a);");
   verifyIndependentOfContext("MACRO(A *_Nullable a);");
   verifyIndependentOfContext("MACRO(A *_Null_unspecified a);");
-  verifyIndependentOfContext("MACRO(A *absl_nonnull a);", getGoogleStyle());
-  verifyIndependentOfContext("MACRO(A *absl_nullable a);", getGoogleStyle());
+
+  Style = getGoogleStyle();
+  verifyIndependentOfContext("MACRO(A *absl_nonnull a);", Style);
+  verifyIndependentOfContext("MACRO(A *absl_nullable a);", Style);
   verifyIndependentOfContext("MACRO(A *absl_nullability_unknown a);",
-                             getGoogleStyle());
+                             Style);
+
   verifyIndependentOfContext("MACRO(A *__attribute__((foo)) a);");
   verifyIndependentOfContext("MACRO(A *__attribute((foo)) a);");
   verifyIndependentOfContext("MACRO(A *[[clang::attr]] a);");
@@ -12734,21 +12737,6 @@ TEST_F(FormatTest, UnderstandsPointerQualifiersInCast) {
                CustomQualifier);
   verifyFormat(("x = (foo *" + AllQualifiers + " __my_qualifier)&v;").str(),
                CustomQualifier);
-
-  // Check additional attribute macros in Google style:
-  FormatStyle LongPointerRightGoogle = getGoogleStyleWithColumns(999);
-  FormatStyle LongPointerLeftGoogle = getGoogleStyleWithColumns(999);
-  LongPointerLeftGoogle.PointerAlignment = FormatStyle::PAS_Left;
-  Twine AllQualifiersPlusGoogle =
-      AllQualifiers + " absl_nonnull absl_nullable absl_nullability_unknown";
-  verifyFormat(("x = (foo *" + AllQualifiersPlusGoogle + ")*v;").str(),
-               LongPointerRightGoogle);
-  verifyFormat(("x = (foo* " + AllQualifiersPlusGoogle + ")*v;").str(),
-               LongPointerLeftGoogle);
-  verifyFormat(("x = (foo *" + AllQualifiersPlusGoogle + ")&v;").str(),
-               LongPointerRightGoogle);
-  verifyFormat(("x = (foo* " + AllQualifiersPlusGoogle + ")&v;").str(),
-               LongPointerLeftGoogle);
 
   // Check that unknown identifiers result in binary operator parsing:
   verifyFormat("x = (foo * __unknown_qualifier) * v;");

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -12702,9 +12702,9 @@ TEST_F(FormatTest, UnderstandsPointerQualifiersInCast) {
   verifyFormat("x = (foo *_Nonnull)*v;");
   verifyFormat("x = (foo *_Nullable)*v;");
   verifyFormat("x = (foo *_Null_unspecified)*v;");
-  verifyGoogleFormat("x = (foo *absl_nonnull)*v;");
-  verifyGoogleFormat("x = (foo *absl_nullable)*v;");
-  verifyGoogleFormat("x = (foo *absl_nullability_unknown)*v;");
+  verifyGoogleFormat("x = (foo* absl_nonnull)*v;");
+  verifyGoogleFormat("x = (foo* absl_nullable)*v;");
+  verifyGoogleFormat("x = (foo* absl_nullability_unknown)*v;");
   verifyFormat("x = (foo *[[clang::attr]])*v;");
   verifyFormat("x = (foo *[[clang::attr(\"foo\")]])*v;");
   verifyFormat("x = (foo *__ptr32)*v;");

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -3186,8 +3186,8 @@ TEST_F(TokenAnnotatorTest, UnderstandsAttributes) {
 }
 
 TEST_F(TokenAnnotatorTest, UnderstandsNullabilityAttributeMacros) {
-  // Under Google style, handles the Abseil macro aliases for the
-  // Clang nullability annotations.
+  // Under Google style, handles the Abseil macro aliases for the Clang
+  // nullability annotations.
   auto Style = getGoogleStyle(FormatStyle::LK_Cpp);
   auto Tokens = annotate("x = (foo* absl_nullable)*v;", Style);
   ASSERT_EQ(Tokens.size(), 11u) << Tokens;

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -3185,48 +3185,24 @@ TEST_F(TokenAnnotatorTest, UnderstandsAttributes) {
   EXPECT_TOKEN(Tokens[5], tok::r_paren, TT_AttributeRParen);
 }
 
-TEST_F(TokenAnnotatorTest, UnderstandsNullabilityAttributes) {
-  auto Tokens = annotate("x = (foo *_Nullable)*v;");
+TEST_F(TokenAnnotatorTest, UnderstandsNullabilityAttributeMacros) {
+  // Under Google style, handles the Abseil macro aliases for the
+  // Clang nullability annotations.
+  auto Style = getGoogleStyle(FormatStyle::LK_Cpp);
+  auto Tokens = annotate("x = (foo* absl_nullable)*v;", Style);
   ASSERT_EQ(Tokens.size(), 11u) << Tokens;
-  EXPECT_TOKEN(Tokens[3], tok::identifier, TT_Unknown);
-  EXPECT_TOKEN(Tokens[4], tok::star, TT_PointerOrReference);
-  EXPECT_TOKEN(Tokens[5], tok::kw__Nullable, TT_Unknown);
-  EXPECT_TOKEN(Tokens[7], tok::star, TT_UnaryOperator);
-
-  Tokens = annotate("x = (foo *_Nonnull)*v;");
-  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
-  EXPECT_TOKEN(Tokens[3], tok::identifier, TT_Unknown);
-  EXPECT_TOKEN(Tokens[4], tok::star, TT_PointerOrReference);
-  EXPECT_TOKEN(Tokens[5], tok::kw__Nonnull, TT_Unknown);
-  EXPECT_TOKEN(Tokens[7], tok::star, TT_UnaryOperator);
-
-  Tokens = annotate("x = (foo *_Null_unspecified)*v;");
-  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
-  EXPECT_TOKEN(Tokens[3], tok::identifier, TT_Unknown);
-  EXPECT_TOKEN(Tokens[4], tok::star, TT_PointerOrReference);
-  EXPECT_TOKEN(Tokens[5], tok::kw__Null_unspecified, TT_Unknown);
-  EXPECT_TOKEN(Tokens[7], tok::star, TT_UnaryOperator);
-
-  // Under Google style, also handles the Abseil macro aliases for the
-  // nullability annotations.
-  FormatStyle Style = getGoogleStyle(FormatStyle::LK_Cpp);
-  Tokens = annotate("x = (foo *absl_nullable)*v;", Style);
-  ASSERT_EQ(Tokens.size(), 11u) << Tokens;
-  EXPECT_TOKEN(Tokens[3], tok::identifier, TT_Unknown);
   EXPECT_TOKEN(Tokens[4], tok::star, TT_PointerOrReference);
   EXPECT_TOKEN(Tokens[5], tok::identifier, TT_AttributeMacro);
   EXPECT_TOKEN(Tokens[7], tok::star, TT_UnaryOperator);
 
-  Tokens = annotate("x = (foo *absl_nonnull)*v;", Style);
+  Tokens = annotate("x = (foo* absl_nonnull)*v;", Style);
   ASSERT_EQ(Tokens.size(), 11u) << Tokens;
-  EXPECT_TOKEN(Tokens[3], tok::identifier, TT_Unknown);
   EXPECT_TOKEN(Tokens[4], tok::star, TT_PointerOrReference);
   EXPECT_TOKEN(Tokens[5], tok::identifier, TT_AttributeMacro);
   EXPECT_TOKEN(Tokens[7], tok::star, TT_UnaryOperator);
 
-  Tokens = annotate("x = (foo *absl_nullability_unknown)*v;", Style);
+  Tokens = annotate("x = (foo* absl_nullability_unknown)*v;", Style);
   ASSERT_EQ(Tokens.size(), 11u) << Tokens;
-  EXPECT_TOKEN(Tokens[3], tok::identifier, TT_Unknown);
   EXPECT_TOKEN(Tokens[4], tok::star, TT_PointerOrReference);
   EXPECT_TOKEN(Tokens[5], tok::identifier, TT_AttributeMacro);
   EXPECT_TOKEN(Tokens[7], tok::star, TT_UnaryOperator);


### PR DESCRIPTION
Add support for formatting w/ absl nullability macros (https://github.com/abseil/abseil-cpp/blob/c52afac4f87ef76e6293b84874e5126a62be1f15/absl/base/nullability.h#L237).
Example at https://godbolt.org/z/PYv19M1Gj
input:
```
std::vector<int* _Nonnull> x;
std::vector<int* absl_nonnull> y;
```

orig output:
```
std::vector<int* _Nonnull> x;
std::vector<int * absl_nonnull> y;
```

new output:
```
std::vector<int* _Nonnull> x;
std::vector<int* absl_nonnull> y;
```
credit to @ymand for the original patch