### PR TITLE
[EquivClasses] Strip testing member_end

### DIFF
--- a/llvm/unittests/ADT/EquivalenceClassesTest.cpp
+++ b/llvm/unittests/ADT/EquivalenceClassesTest.cpp
@@ -77,7 +77,6 @@ TEST(EquivalenceClassesTest, MembersIterator) {
 
   EquivalenceClasses<int>::iterator I = EC.findValue(EC.getLeaderValue(1));
   EXPECT_THAT(EC.members(I), testing::ElementsAre(5, 1, 2));
-  EXPECT_EQ(EC.members(EC.end()).begin(), EC.member_end());
 }
 
 // Type-parameterized tests: Run the same test cases with different element


### PR DESCRIPTION
It is causing test failures. See https://lab.llvm.org/buildbot/#/builders/65/builds/13399.

-- 8< --
There seems to be no end to issues. I think this is a reasonable compromise. Kindly merge on my behalf, or put up an alternate PR fixing the issue, and merge that: it's bed time for me.