### PR TITLE
[clang] Add builtins for `add` with `nuw` and/or `nsw`

### DIFF
--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -5037,64 +5037,22 @@ def ArithmeticFence : LangBuiltin<"ALL_LANGUAGES"> {
   let Prototype = "void(...)";
 }
 
-class SNUWTemplate :
-  Template<["int",      "long int",  "long long int"],
-           ["_nuw",     "l_nuw",     "ll_nuw"]>;
-
-class SNSWTemplate :
-  Template<["int",      "long int",  "long long int"],
-           ["_nsw",     "l_nsw",     "ll_nsw"]>;
-
-class SNXWTemplate :
-  Template<["int",      "long int",  "long long int"],
-           ["_nuw_nsw", "l_nuw_nsw", "ll_nuw_nsw"]>;
-
-def SAddNUW : Builtin, SNUWTemplate {
-  let Spellings = ["__builtin_sadd"];
-  let Attributes = [NoThrow];
-  let Prototype = "T(T const, T const)";
+def AddNUW : Builtin {
+  let Spellings = ["__builtin_add_nuw"];
+  let Attributes = [CustomTypeChecking, NoThrow];
+  let Prototype = "void(...)";
 }
 
-def SAddNSW : Builtin, SNSWTemplate {
-  let Spellings = ["__builtin_sadd"];
-  let Attributes = [NoThrow];
-  let Prototype = "T(T const, T const)";
+def AddNSW : Builtin {
+  let Spellings = ["__builtin_add_nsw"];
+  let Attributes = [CustomTypeChecking, NoThrow];
+  let Prototype = "void(...)";
 }
 
-def SAddNXW : Builtin, SNXWTemplate {
-  let Spellings = ["__builtin_sadd"];
-  let Attributes = [NoThrow];
-  let Prototype = "T(T const, T const)";
-}
-
-class UNUWTemplate :
-  Template<["unsigned int", "unsigned long int", "unsigned long long int"],
-           ["_nuw",         "l_nuw",             "ll_nuw"]>;
-
-class UNSWTemplate :
-  Template<["unsigned int", "unsigned long int", "unsigned long long int"],
-           ["_nsw",         "l_nsw",             "ll_nsw"]>;
-
-class UNXWTemplate :
-  Template<["unsigned int", "unsigned long int", "unsigned long long int"],
-           ["_nuw_nsw",     "l_nuw_nsw",         "ll_nuw_nsw"]>;
-
-def UAddNUW : Builtin, UNUWTemplate {
-  let Spellings = ["__builtin_uadd"];
-  let Attributes = [NoThrow];
-  let Prototype = "T(T const, T const)";
-}
-
-def UAddNSW : Builtin, UNSWTemplate {
-  let Spellings = ["__builtin_uadd"];
-  let Attributes = [NoThrow];
-  let Prototype = "T(T const, T const)";
-}
-
-def UAddNXW : Builtin, UNXWTemplate {
-  let Spellings = ["__builtin_uadd"];
-  let Attributes = [NoThrow];
-  let Prototype = "T(T const, T const)";
+def AddNW : Builtin {
+  let Spellings = ["__builtin_add_nuw_nsw"];
+  let Attributes = [CustomTypeChecking, NoThrow];
+  let Prototype = "void(...)";
 }
 
 def CountedByRef : Builtin {

--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -5037,6 +5037,66 @@ def ArithmeticFence : LangBuiltin<"ALL_LANGUAGES"> {
   let Prototype = "void(...)";
 }
 
+class SNUWTemplate :
+  Template<["int",      "long int",  "long long int"],
+           ["_nuw",     "l_nuw",     "ll_nuw"]>;
+
+class SNSWTemplate :
+  Template<["int",      "long int",  "long long int"],
+           ["_nsw",     "l_nsw",     "ll_nsw"]>;
+
+class SNXWTemplate :
+  Template<["int",      "long int",  "long long int"],
+           ["_nuw_nsw", "l_nuw_nsw", "ll_nuw_nsw"]>;
+
+def SAddNUW : Builtin, SNUWTemplate {
+  let Spellings = ["__builtin_sadd"];
+  let Attributes = [NoThrow];
+  let Prototype = "T(T const, T const)";
+}
+
+def SAddNSW : Builtin, SNSWTemplate {
+  let Spellings = ["__builtin_sadd"];
+  let Attributes = [NoThrow];
+  let Prototype = "T(T const, T const)";
+}
+
+def SAddNXW : Builtin, SNXWTemplate {
+  let Spellings = ["__builtin_sadd"];
+  let Attributes = [NoThrow];
+  let Prototype = "T(T const, T const)";
+}
+
+class UNUWTemplate :
+  Template<["unsigned int", "unsigned long int", "unsigned long long int"],
+           ["_nuw",         "l_nuw",             "ll_nuw"]>;
+
+class UNSWTemplate :
+  Template<["unsigned int", "unsigned long int", "unsigned long long int"],
+           ["_nsw",         "l_nsw",             "ll_nsw"]>;
+
+class UNXWTemplate :
+  Template<["unsigned int", "unsigned long int", "unsigned long long int"],
+           ["_nuw_nsw",     "l_nuw_nsw",         "ll_nuw_nsw"]>;
+
+def UAddNUW : Builtin, UNUWTemplate {
+  let Spellings = ["__builtin_uadd"];
+  let Attributes = [NoThrow];
+  let Prototype = "T(T const, T const)";
+}
+
+def UAddNSW : Builtin, UNSWTemplate {
+  let Spellings = ["__builtin_uadd"];
+  let Attributes = [NoThrow];
+  let Prototype = "T(T const, T const)";
+}
+
+def UAddNXW : Builtin, UNXWTemplate {
+  let Spellings = ["__builtin_uadd"];
+  let Attributes = [NoThrow];
+  let Prototype = "T(T const, T const)";
+}
+
 def CountedByRef : Builtin {
   let Spellings = ["__builtin_counted_by_ref"];
   let Attributes = [NoThrow, CustomTypeChecking];

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12527,6 +12527,9 @@ def err_builtin_matrix_stride_too_small: Error<
 def err_builtin_matrix_invalid_dimension: Error<
   "%0 dimension is outside the allowed range [1, %1]">;
 
+def err_builtin_add_nxw_invalid_arg : Error<
+  "both arguments must be of integral type but %ordinal0 argument is %1">;
+
 def warn_mismatched_import : Warning<
   "import %select{module|name}0 (%1) does not match the import %select{module|name}0 (%2) of the "
   "previous declaration">,

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -6617,49 +6617,12 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     return RValue::get(Str.getPointer());
   }
 
-  case Builtin::BI__builtin_sadd_nuw:
-  case Builtin::BI__builtin_saddl_nuw:
-  case Builtin::BI__builtin_saddll_nuw:
-  case Builtin::BI__builtin_uadd_nuw:
-  case Builtin::BI__builtin_uaddl_nuw:
-  case Builtin::BI__builtin_uaddll_nuw:
-
-  case Builtin::BI__builtin_sadd_nsw:
-  case Builtin::BI__builtin_saddl_nsw:
-  case Builtin::BI__builtin_saddll_nsw:
-  case Builtin::BI__builtin_uadd_nsw:
-  case Builtin::BI__builtin_uaddl_nsw:
-  case Builtin::BI__builtin_uaddll_nsw:
-
-  case Builtin::BI__builtin_sadd_nuw_nsw:
-  case Builtin::BI__builtin_saddl_nuw_nsw:
-  case Builtin::BI__builtin_saddll_nuw_nsw:
-  case Builtin::BI__builtin_uadd_nuw_nsw:
-  case Builtin::BI__builtin_uaddl_nuw_nsw:
-  case Builtin::BI__builtin_uaddll_nuw_nsw: {
-    bool NUW = false;
-    bool NSW = false;
-    switch (BuiltinIDIfNoAsmLabel) {
-    case Builtin::BI__builtin_sadd_nuw:
-    case Builtin::BI__builtin_saddl_nuw:
-    case Builtin::BI__builtin_saddll_nuw:
-    case Builtin::BI__builtin_uadd_nuw:
-    case Builtin::BI__builtin_uaddl_nuw:
-    case Builtin::BI__builtin_uaddll_nuw:
-      NUW = true;
-      break;
-    case Builtin::BI__builtin_sadd_nsw:
-    case Builtin::BI__builtin_saddl_nsw:
-    case Builtin::BI__builtin_saddll_nsw:
-    case Builtin::BI__builtin_uadd_nsw:
-    case Builtin::BI__builtin_uaddl_nsw:
-    case Builtin::BI__builtin_uaddll_nsw:
-      NSW = true;
-      break;
-    default:
-      NUW = NSW = true;
-      break;
-    }
+  case Builtin::BI__builtin_add_nuw:
+  case Builtin::BI__builtin_add_nsw:
+  case Builtin::BI__builtin_add_nuw_nsw: {
+    bool NXW = BuiltinIDIfNoAsmLabel == Builtin::BI__builtin_add_nuw_nsw;
+    bool NUW = BuiltinIDIfNoAsmLabel == Builtin::BI__builtin_add_nuw || NXW;
+    bool NSW = BuiltinIDIfNoAsmLabel == Builtin::BI__builtin_add_nsw || NXW;
     llvm::Value *X = EmitScalarExpr(E->getArg(0));
     llvm::Value *Y = EmitScalarExpr(E->getArg(1));
     return RValue::get(Builder.CreateAdd(X, Y, "add", NUW, NSW));

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -6616,6 +6616,54 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     auto Str = CGM.GetAddrOfConstantCString(Name, "");
     return RValue::get(Str.getPointer());
   }
+
+  case Builtin::BI__builtin_sadd_nuw:
+  case Builtin::BI__builtin_saddl_nuw:
+  case Builtin::BI__builtin_saddll_nuw:
+  case Builtin::BI__builtin_uadd_nuw:
+  case Builtin::BI__builtin_uaddl_nuw:
+  case Builtin::BI__builtin_uaddll_nuw:
+
+  case Builtin::BI__builtin_sadd_nsw:
+  case Builtin::BI__builtin_saddl_nsw:
+  case Builtin::BI__builtin_saddll_nsw:
+  case Builtin::BI__builtin_uadd_nsw:
+  case Builtin::BI__builtin_uaddl_nsw:
+  case Builtin::BI__builtin_uaddll_nsw:
+
+  case Builtin::BI__builtin_sadd_nuw_nsw:
+  case Builtin::BI__builtin_saddl_nuw_nsw:
+  case Builtin::BI__builtin_saddll_nuw_nsw:
+  case Builtin::BI__builtin_uadd_nuw_nsw:
+  case Builtin::BI__builtin_uaddl_nuw_nsw:
+  case Builtin::BI__builtin_uaddll_nuw_nsw: {
+    bool NUW = false;
+    bool NSW = false;
+    switch (BuiltinIDIfNoAsmLabel) {
+    case Builtin::BI__builtin_sadd_nuw:
+    case Builtin::BI__builtin_saddl_nuw:
+    case Builtin::BI__builtin_saddll_nuw:
+    case Builtin::BI__builtin_uadd_nuw:
+    case Builtin::BI__builtin_uaddl_nuw:
+    case Builtin::BI__builtin_uaddll_nuw:
+      NUW = true;
+      break;
+    case Builtin::BI__builtin_sadd_nsw:
+    case Builtin::BI__builtin_saddl_nsw:
+    case Builtin::BI__builtin_saddll_nsw:
+    case Builtin::BI__builtin_uadd_nsw:
+    case Builtin::BI__builtin_uaddl_nsw:
+    case Builtin::BI__builtin_uaddll_nsw:
+      NSW = true;
+      break;
+    default:
+      NUW = NSW = true;
+      break;
+    }
+    llvm::Value *X = EmitScalarExpr(E->getArg(0));
+    llvm::Value *Y = EmitScalarExpr(E->getArg(1));
+    return RValue::get(Builder.CreateAdd(X, Y, "add", NUW, NSW));
+  }
   }
 
   // If this is an alias for a lib function (e.g. __builtin_sin), emit

--- a/clang/test/CodeGen/builtins-int-wrap.c
+++ b/clang/test/CodeGen/builtins-int-wrap.c
@@ -5,107 +5,107 @@
 //------------------------------------------------------------------------------
 // int
 //------------------------------------------------------------------------------
-int test_sadd_nuw(int x, int y) { return __builtin_sadd_nuw(x, y); }
-// CHECK-LABEL: @test_sadd_nuw
+int test_add_nuw(int x, int y) { return __builtin_add_nuw(x, y); }
+// CHECK-LABEL: @test_add_nuw
 // CHECK: [[RV:%.+]] = add nuw i32
 // CHECK: ret i32 [[RV]]
 
-int test_sadd_nsw(int x, int y) { return __builtin_sadd_nsw(x, y); }
-// CHECK-LABEL: @test_sadd_nsw
+int test_add_nsw(int x, int y) { return __builtin_add_nsw(x, y); }
+// CHECK-LABEL: @test_add_nsw
 // CHECK: [[RV:%.+]] = add nsw i32
 // CHECK: ret i32 [[RV]]
 
-int test_sadd_nuw_nsw(int x, int y) { return __builtin_sadd_nuw_nsw(x, y); }
-// CHECK-LABEL: @test_sadd_nuw_nsw
+int test_add_nuw_nsw(int x, int y) { return __builtin_add_nuw_nsw(x, y); }
+// CHECK-LABEL: @test_add_nuw_nsw
 // CHECK: [[RV:%.+]] = add nuw nsw i32
 // CHECK: ret i32 [[RV]]
 
 //------------------------------------------------------------------------------
 // long int
 //------------------------------------------------------------------------------
-long int test_saddl_nuw(long int x, long int y) { return __builtin_saddl_nuw(x, y); }
-// CHECK-LABEL: @test_saddl_nuw
+long int test_add_nuw_l(long int x, long int y) { return __builtin_add_nuw(x, y); }
+// CHECK-LABEL: @test_add_nuw_l
 // CHECK: [[RV:%.+]] = add nuw i64
 // CHECK: ret i64 [[RV]]
 
-long int test_saddl_nsw(long int x, long int y) { return __builtin_saddl_nsw(x, y); }
-// CHECK-LABEL: @test_saddl_nsw
+long int test_add_nsw_l(long int x, long int y) { return __builtin_add_nsw(x, y); }
+// CHECK-LABEL: @test_add_nsw_l
 // CHECK: [[RV:%.+]] = add nsw i64
 // CHECK: ret i64 [[RV]]
 
-long int test_saddl_nuw_nsw(long int x, long int y) { return __builtin_saddl_nuw_nsw(x, y); }
-// CHECK-LABEL: @test_saddl_nuw_nsw
+long int test_add_nuw_nsw_l(long int x, long int y) { return __builtin_add_nuw_nsw(x, y); }
+// CHECK-LABEL: @test_add_nuw_nsw_l
 // CHECK: [[RV:%.+]] = add nuw nsw i64
 // CHECK: ret i64 [[RV]]
 
 //------------------------------------------------------------------------------
 // long int
 //------------------------------------------------------------------------------
-long long int test_saddll_nuw(long long int x, long long int y) { return __builtin_saddll_nuw(x, y); }
-// CHECK-LABEL: @test_saddll_nuw
+long long int test_add_nuw_ll(long long int x, long long int y) { return __builtin_add_nuw(x, y); }
+// CHECK-LABEL: @test_add_nuw_ll
 // CHECK: [[RV:%.+]] = add nuw i64
 // CHECK: ret i64 [[RV]]
 
-long long int test_saddll_nsw(long long int x, long long int y) { return __builtin_saddll_nsw(x, y); }
-// CHECK-LABEL: @test_saddll_nsw
+long long int test_add_nsw_ll(long long int x, long long int y) { return __builtin_add_nsw(x, y); }
+// CHECK-LABEL: @test_add_nsw_ll
 // CHECK: [[RV:%.+]] = add nsw i64
 // CHECK: ret i64 [[RV]]
 
-long long int test_saddll_nuw_nsw(long long int x, long long int y) { return __builtin_saddll_nuw_nsw(x, y); }
-// CHECK-LABEL: @test_saddll_nuw_nsw
+long long int test_add_nuw_nsw_ll(long long int x, long long int y) { return __builtin_add_nuw_nsw(x, y); }
+// CHECK-LABEL: @test_add_nuw_nsw_ll
 // CHECK: [[RV:%.+]] = add nuw nsw i64
 // CHECK: ret i64 [[RV]]
 
 //------------------------------------------------------------------------------
 // unsigned int
 //------------------------------------------------------------------------------
-unsigned int test_uadd_nuw(unsigned int x, unsigned int y) { return __builtin_uadd_nuw(x, y); }
-// CHECK-LABEL: @test_uadd_nuw
+unsigned int test_add_nuw_u(unsigned int x, unsigned int y) { return __builtin_add_nuw(x, y); }
+// CHECK-LABEL: @test_add_nuw_u
 // CHECK: [[RV:%.+]] = add nuw i32
 // CHECK: ret i32 [[RV]]
 
-unsigned int test_uadd_nsw(unsigned int x, unsigned int y) { return __builtin_uadd_nsw(x, y); }
-// CHECK-LABEL: @test_uadd_nsw
+unsigned int test_add_nsw_u(unsigned int x, unsigned int y) { return __builtin_add_nsw(x, y); }
+// CHECK-LABEL: @test_add_nsw_u
 // CHECK: [[RV:%.+]] = add nsw i32
 // CHECK: ret i32 [[RV]]
 
-unsigned int test_uadd_nuw_nsw(unsigned int x, unsigned int y) { return __builtin_uadd_nuw_nsw(x, y); }
-// CHECK-LABEL: @test_uadd_nuw_nsw
+unsigned int test_add_nuw_nsw_u(unsigned int x, unsigned int y) { return __builtin_add_nuw_nsw(x, y); }
+// CHECK-LABEL: @test_add_nuw_nsw_u
 // CHECK: [[RV:%.+]] = add nuw nsw i32
 // CHECK: ret i32 [[RV]]
 
 //------------------------------------------------------------------------------
 // unsigned long int
 //------------------------------------------------------------------------------
-unsigned long int test_uaddl_nuw(unsigned long int x, unsigned long int y) { return __builtin_uaddl_nuw(x, y); }
-// CHECK-LABEL: @test_uaddl_nuw
+unsigned long int test_add_nuw_ul(unsigned long int x, unsigned long int y) { return __builtin_add_nuw(x, y); }
+// CHECK-LABEL: @test_add_nuw_ul
 // CHECK: [[RV:%.+]] = add nuw i64
 // CHECK: ret i64 [[RV]]
 
-unsigned long int test_uaddl_nsw(unsigned long int x, unsigned long int y) { return __builtin_uaddl_nsw(x, y); }
-// CHECK-LABEL: @test_uaddl_nsw
+unsigned long int test_add_nsw_ul(unsigned long int x, unsigned long int y) { return __builtin_add_nsw(x, y); }
+// CHECK-LABEL: @test_add_nsw_ul
 // CHECK: [[RV:%.+]] = add nsw i64
 // CHECK: ret i64 [[RV]]
 
-unsigned long int test_uaddl_nuw_nsw(unsigned long int x, unsigned long int y) { return __builtin_uaddl_nuw_nsw(x, y); }
-// CHECK-LABEL: @test_uaddl_nuw_nsw
+unsigned long int test_add_nuw_nsw_ul(unsigned long int x, unsigned long int y) { return __builtin_add_nuw_nsw(x, y); }
+// CHECK-LABEL: @test_add_nuw_nsw_ul
 // CHECK: [[RV:%.+]] = add nuw nsw i64
 // CHECK: ret i64 [[RV]]
 
 //------------------------------------------------------------------------------
 // unsigned long long int
 //------------------------------------------------------------------------------
-unsigned long long int test_uaddll_nuw(unsigned long long int x, unsigned long long int y) { return __builtin_uaddll_nuw(x, y); }
-// CHECK-LABEL: @test_uaddll_nuw
+unsigned long long int test_add_nuw_ull(unsigned long long int x, unsigned long long int y) { return __builtin_add_nuw(x, y); }
+// CHECK-LABEL: @test_add_nuw_ull
 // CHECK: [[RV:%.+]] = add nuw i64
 // CHECK: ret i64 [[RV]]
 
-unsigned long long int test_uaddll_nsw(unsigned long long int x, unsigned long long int y) { return __builtin_uaddll_nsw(x, y); }
-// CHECK-LABEL: @test_uaddll_nsw
+unsigned long long int test_add_nsw_ull(unsigned long long int x, unsigned long long int y) { return __builtin_add_nsw(x, y); }
+// CHECK-LABEL: @test_add_nsw_ull
 // CHECK: [[RV:%.+]] = add nsw i64
 // CHECK: ret i64 [[RV]]
 
-unsigned long long int test_uaddll_nuw_nsw(unsigned long long int x, unsigned long long int y) { return __builtin_uaddll_nuw_nsw(x, y); }
-// CHECK-LABEL: @test_uaddll_nuw_nsw
+unsigned long long int test_add_nuw_nsw_ull(unsigned long long int x, unsigned long long int y) { return __builtin_add_nuw_nsw(x, y); }
+// CHECK-LABEL: @test_add_nuw_nsw_ull
 // CHECK: [[RV:%.+]] = add nuw nsw i64
 // CHECK: ret i64 [[RV]]

--- a/clang/test/CodeGen/builtins-int-wrap.c
+++ b/clang/test/CodeGen/builtins-int-wrap.c
@@ -1,0 +1,111 @@
+// Test CodeGen for nuw/nsw builtins.
+
+// RUN: %clang_cc1 -triple "x86_64-unknown-unknown" -emit-llvm -x c %s -o - | FileCheck %s
+
+//------------------------------------------------------------------------------
+// int
+//------------------------------------------------------------------------------
+int test_sadd_nuw(int x, int y) { return __builtin_sadd_nuw(x, y); }
+// CHECK-LABEL: @test_sadd_nuw
+// CHECK: [[RV:%.+]] = add nuw i32
+// CHECK: ret i32 [[RV]]
+
+int test_sadd_nsw(int x, int y) { return __builtin_sadd_nsw(x, y); }
+// CHECK-LABEL: @test_sadd_nsw
+// CHECK: [[RV:%.+]] = add nsw i32
+// CHECK: ret i32 [[RV]]
+
+int test_sadd_nuw_nsw(int x, int y) { return __builtin_sadd_nuw_nsw(x, y); }
+// CHECK-LABEL: @test_sadd_nuw_nsw
+// CHECK: [[RV:%.+]] = add nuw nsw i32
+// CHECK: ret i32 [[RV]]
+
+//------------------------------------------------------------------------------
+// long int
+//------------------------------------------------------------------------------
+long int test_saddl_nuw(long int x, long int y) { return __builtin_saddl_nuw(x, y); }
+// CHECK-LABEL: @test_saddl_nuw
+// CHECK: [[RV:%.+]] = add nuw i64
+// CHECK: ret i64 [[RV]]
+
+long int test_saddl_nsw(long int x, long int y) { return __builtin_saddl_nsw(x, y); }
+// CHECK-LABEL: @test_saddl_nsw
+// CHECK: [[RV:%.+]] = add nsw i64
+// CHECK: ret i64 [[RV]]
+
+long int test_saddl_nuw_nsw(long int x, long int y) { return __builtin_saddl_nuw_nsw(x, y); }
+// CHECK-LABEL: @test_saddl_nuw_nsw
+// CHECK: [[RV:%.+]] = add nuw nsw i64
+// CHECK: ret i64 [[RV]]
+
+//------------------------------------------------------------------------------
+// long int
+//------------------------------------------------------------------------------
+long long int test_saddll_nuw(long long int x, long long int y) { return __builtin_saddll_nuw(x, y); }
+// CHECK-LABEL: @test_saddll_nuw
+// CHECK: [[RV:%.+]] = add nuw i64
+// CHECK: ret i64 [[RV]]
+
+long long int test_saddll_nsw(long long int x, long long int y) { return __builtin_saddll_nsw(x, y); }
+// CHECK-LABEL: @test_saddll_nsw
+// CHECK: [[RV:%.+]] = add nsw i64
+// CHECK: ret i64 [[RV]]
+
+long long int test_saddll_nuw_nsw(long long int x, long long int y) { return __builtin_saddll_nuw_nsw(x, y); }
+// CHECK-LABEL: @test_saddll_nuw_nsw
+// CHECK: [[RV:%.+]] = add nuw nsw i64
+// CHECK: ret i64 [[RV]]
+
+//------------------------------------------------------------------------------
+// unsigned int
+//------------------------------------------------------------------------------
+unsigned int test_uadd_nuw(unsigned int x, unsigned int y) { return __builtin_uadd_nuw(x, y); }
+// CHECK-LABEL: @test_uadd_nuw
+// CHECK: [[RV:%.+]] = add nuw i32
+// CHECK: ret i32 [[RV]]
+
+unsigned int test_uadd_nsw(unsigned int x, unsigned int y) { return __builtin_uadd_nsw(x, y); }
+// CHECK-LABEL: @test_uadd_nsw
+// CHECK: [[RV:%.+]] = add nsw i32
+// CHECK: ret i32 [[RV]]
+
+unsigned int test_uadd_nuw_nsw(unsigned int x, unsigned int y) { return __builtin_uadd_nuw_nsw(x, y); }
+// CHECK-LABEL: @test_uadd_nuw_nsw
+// CHECK: [[RV:%.+]] = add nuw nsw i32
+// CHECK: ret i32 [[RV]]
+
+//------------------------------------------------------------------------------
+// unsigned long int
+//------------------------------------------------------------------------------
+unsigned long int test_uaddl_nuw(unsigned long int x, unsigned long int y) { return __builtin_uaddl_nuw(x, y); }
+// CHECK-LABEL: @test_uaddl_nuw
+// CHECK: [[RV:%.+]] = add nuw i64
+// CHECK: ret i64 [[RV]]
+
+unsigned long int test_uaddl_nsw(unsigned long int x, unsigned long int y) { return __builtin_uaddl_nsw(x, y); }
+// CHECK-LABEL: @test_uaddl_nsw
+// CHECK: [[RV:%.+]] = add nsw i64
+// CHECK: ret i64 [[RV]]
+
+unsigned long int test_uaddl_nuw_nsw(unsigned long int x, unsigned long int y) { return __builtin_uaddl_nuw_nsw(x, y); }
+// CHECK-LABEL: @test_uaddl_nuw_nsw
+// CHECK: [[RV:%.+]] = add nuw nsw i64
+// CHECK: ret i64 [[RV]]
+
+//------------------------------------------------------------------------------
+// unsigned long long int
+//------------------------------------------------------------------------------
+unsigned long long int test_uaddll_nuw(unsigned long long int x, unsigned long long int y) { return __builtin_uaddll_nuw(x, y); }
+// CHECK-LABEL: @test_uaddll_nuw
+// CHECK: [[RV:%.+]] = add nuw i64
+// CHECK: ret i64 [[RV]]
+
+unsigned long long int test_uaddll_nsw(unsigned long long int x, unsigned long long int y) { return __builtin_uaddll_nsw(x, y); }
+// CHECK-LABEL: @test_uaddll_nsw
+// CHECK: [[RV:%.+]] = add nsw i64
+// CHECK: ret i64 [[RV]]
+
+unsigned long long int test_uaddll_nuw_nsw(unsigned long long int x, unsigned long long int y) { return __builtin_uaddll_nuw_nsw(x, y); }
+// CHECK-LABEL: @test_uaddll_nuw_nsw
+// CHECK: [[RV:%.+]] = add nuw nsw i64
+// CHECK: ret i64 [[RV]]

--- a/clang/test/Sema/builtins-int-wrap.c
+++ b/clang/test/Sema/builtins-int-wrap.c
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -triple x86_64-unknown-unknown %s
+
+
+struct Foo { int x; };
+
+int test_add_nuw(int x, double y, struct Foo z) {
+  __builtin_add_nuw(x, y); // expected-error {{both arguments must be of integral type but 2nd argument is 'double'}}
+  __builtin_add_nuw(y, x); // expected-error {{both arguments must be of integral type but 1st argument is 'double'}}
+  __builtin_add_nuw(x, z); // expected-error {{both arguments must be of integral type but 2nd argument is 'struct Foo'}}
+}
+
+int test_add_nsw(int x, double y, struct Foo z) {
+  __builtin_add_nsw(x, y); // expected-error {{both arguments must be of integral type but 2nd argument is 'double'}}
+  __builtin_add_nsw(y, x); // expected-error {{both arguments must be of integral type but 1st argument is 'double'}}
+  __builtin_add_nsw(x, z); // expected-error {{both arguments must be of integral type but 2nd argument is 'struct Foo'}}
+}
+
+int test_add_nuw_nsw(int x, double y, struct Foo z) {
+  __builtin_add_nuw_nsw(x, y); // expected-error {{both arguments must be of integral type but 2nd argument is 'double'}}
+  __builtin_add_nuw_nsw(y, x); // expected-error {{both arguments must be of integral type but 1st argument is 'double'}}
+  __builtin_add_nuw_nsw(x, z); // expected-error {{both arguments must be of integral type but 2nd argument is 'struct Foo'}}
+}


### PR DESCRIPTION
To be used for OpenMP runtime library development where lack of control over nuw/nsw prevents analysis by ScalarEvolution and subsequently loop unrolling.