### PR TITLE
[libc][bazel] Introduce libc_test_library macros.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
@@ -4,13 +4,13 @@
 
 # LLVM libc unittest library.
 
-load("//libc:libc_build_rules.bzl", "libc_support_library")
+load("//libc/test:libc_test_rules.bzl", "libc_test_library")
 
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
-libc_support_library(
+libc_test_library(
     name = "test_logger",
     srcs = ["TestLogger.cpp"],
     hdrs = ["TestLogger.h"],
@@ -29,7 +29,7 @@ libc_support_library(
     ],
 )
 
-libc_support_library(
+libc_test_library(
     name = "LibcUnitTest",
     srcs = [
         "BazelFilePath.cpp",
@@ -73,7 +73,7 @@ libc_support_library(
     ],
 )
 
-libc_support_library(
+libc_test_library(
     name = "fp_test_helpers",
     srcs = [
         "FEnvSafeTest.cpp",
@@ -108,7 +108,7 @@ libc_support_library(
     ],
 )
 
-libc_support_library(
+libc_test_library(
     name = "memory_matcher",
     srcs = [
         "MemoryMatcher.cpp",
@@ -127,7 +127,7 @@ libc_support_library(
     ],
 )
 
-libc_support_library(
+libc_test_library(
     name = "printf_matcher",
     srcs = [
         "PrintfMatcher.cpp",
@@ -144,7 +144,7 @@ libc_support_library(
     ],
 )
 
-libc_support_library(
+libc_test_library(
     name = "string_utils",
     hdrs = [
         "StringUtils.h",

--- a/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
@@ -44,3 +44,21 @@ def libc_test(name, srcs, libc_function_deps = [], copts = [], deps = [], local_
         linkstatic = 1,
         **kwargs
     )
+
+def libc_test_library(name, copts = [], local_defines = [], **kwargs):
+    """Add target for library used in libc tests.
+
+    Args:
+      name: Library target name.
+      copts: See cc_library.copts.
+      local_defines: See cc_library.local_defines.
+      **kwargs: Other attributes relevant to cc_library (e.g. "deps").
+    """
+    native.cc_library(
+        name = name,
+        testonly = True,
+        copts = copts + libc_common_copts(),
+        local_defines = local_defines + LIBC_CONFIGURE_OPTIONS,
+        linkstatic = 1,
+        **kwargs
+    )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
@@ -4,8 +4,7 @@
 
 # Tests for LLVM libc stdlib.h functions.
 
-load("//libc:libc_build_rules.bzl", "libc_support_library")
-load("//libc/test:libc_test_rules.bzl", "libc_test")
+load("//libc/test:libc_test_rules.bzl", "libc_test", "libc_test_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -29,7 +28,7 @@ libc_test(
     libc_function_deps = ["//libc:llabs"],
 )
 
-libc_support_library(
+libc_test_library(
     name = "div_test_helper",
     hdrs = ["DivTest.h"],
     deps = ["//libc/test/UnitTest:LibcUnitTest"],
@@ -65,7 +64,7 @@ libc_test(
     ],
 )
 
-libc_support_library(
+libc_test_library(
     name = "atoi_test_helper",
     hdrs = ["AtoiTest.h"],
     deps = [
@@ -110,7 +109,7 @@ libc_test(
     deps = ["//libc:types_size_t"],
 )
 
-libc_support_library(
+libc_test_library(
     name = "qsort_test_helper",
     hdrs = ["SortingTest.h"],
     deps = [
@@ -148,7 +147,7 @@ libc_test(
     deps = ["//libc:types_size_t"],
 )
 
-libc_support_library(
+libc_test_library(
     name = "strfrom_test_helper",
     hdrs = ["StrfromTest.h"],
     deps = [
@@ -179,7 +178,7 @@ libc_test(
     deps = [":strfrom_test_helper"],
 )
 
-libc_support_library(
+libc_test_library(
     name = "strtol_test_helper",
     hdrs = ["StrtolTest.h"],
     deps = [

--- a/utils/bazel/llvm-project-overlay/libc/test/src/string/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/string/BUILD.bazel
@@ -4,8 +4,7 @@
 
 # Tests for LLVM libc string.h functions.
 
-load("//libc:libc_build_rules.bzl", "libc_support_library")
-load("//libc/test:libc_test_rules.bzl", "libc_test")
+load("//libc/test:libc_test_rules.bzl", "libc_test", "libc_test_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -43,7 +42,7 @@ libc_test(
     ],
 )
 
-libc_support_library(
+libc_test_library(
     name = "strchr_test_helper",
     hdrs = ["StrchrTest.h"],
     deps = ["//libc/test/UnitTest:LibcUnitTest"],
@@ -115,7 +114,7 @@ libc_test(
     ],
 )
 
-libc_support_library(
+libc_test_library(
     name = "memory_check_utils",
     hdrs = ["memory_utils/memory_check_utils.h"],
     deps = [
@@ -127,7 +126,7 @@ libc_support_library(
     ],
 )
 
-libc_support_library(
+libc_test_library(
     name = "protected_pages",
     hdrs = ["memory_utils/protected_pages.h"],
     deps = [

--- a/utils/bazel/llvm-project-overlay/libc/test/src/strings/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/strings/BUILD.bazel
@@ -4,7 +4,6 @@
 
 # Tests for LLVM libc strings.h functions.
 
-load("//libc:libc_build_rules.bzl", "libc_support_library")
 load("//libc/test:libc_test_rules.bzl", "libc_test")
 
 package(default_visibility = ["//visibility:public"])

--- a/utils/bazel/llvm-project-overlay/libc/utils/MPCWrapper/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/utils/MPCWrapper/BUILD.bazel
@@ -4,7 +4,7 @@
 
 # A wrapper library over MPC for use with LLVM libc math unittests.
 
-load("//libc:libc_build_rules.bzl", "libc_support_library")
+load("//libc/test:libc_test_rules.bzl", "libc_test_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -26,7 +26,7 @@ cc_library(
     ),
 )
 
-libc_support_library(
+libc_test_library(
     name = "mpc_wrapper",
     srcs = ["MPCUtils.cpp"],
     hdrs = ["MPCUtils.h"],

--- a/utils/bazel/llvm-project-overlay/libc/utils/MPFRWrapper/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/utils/MPFRWrapper/BUILD.bazel
@@ -4,7 +4,7 @@
 
 # A wrapper library over MPFR for use with LLVM libc math unittests.
 
-load("//libc:libc_build_rules.bzl", "libc_support_library")
+load("//libc/test:libc_test_rules.bzl", "libc_test_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -26,7 +26,7 @@ cc_library(
     ),
 )
 
-libc_support_library(
+libc_test_library(
     name = "mp_common",
     srcs = ["MPCommon.cpp"],
     hdrs = ["MPCommon.h"],
@@ -52,7 +52,7 @@ libc_support_library(
     ],
 )
 
-libc_support_library(
+libc_test_library(
     name = "mpfr_wrapper",
     srcs = ["MPFRUtils.cpp"],
     hdrs = ["MPFRUtils.h"],


### PR DESCRIPTION
Use it instead of libc_support_library macros for all helper libraries that are used for unit tests. See #130327 for the rationale why we want to do this. With this change, we can additionally ensure that no testonly library will end up being a dependency of production libraries.