### PR TITLE
[libc][bazel] Convert "errno" to libc_support_library.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -1598,9 +1598,9 @@ libc_support_library(
     ],
 )
 
-############################### errno targets ################################
+############################### errno ########################################
 
-libc_function(
+libc_support_library(
     name = "errno",
     srcs = ["src/errno/libc_errno.cpp"],
     hdrs = ["src/errno/libc_errno.h"],

--- a/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
@@ -27,14 +27,14 @@ def libc_test(name, srcs, libc_function_deps = [], copts = [], deps = [], local_
       local_defines: The list of target local_defines if any.
       **kwargs: Attributes relevant for a libc_test. For example, name, srcs.
     """
-    all_function_deps = libc_function_deps + ["//libc:errno"]
     native.cc_test(
         name = name,
         srcs = srcs,
         local_defines = local_defines + LIBC_CONFIGURE_OPTIONS,
-        deps = [libc_internal_target(d) for d in all_function_deps] + [
+        deps = [libc_internal_target(d) for d in libc_function_deps] + [
             "//libc/test/UnitTest:LibcUnitTest",
             "//libc:__support_macros_config",
+            "//libc:errno",
             "//libc:func_aligned_alloc",
             "//libc:func_free",
             "//libc:func_malloc",

--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
@@ -186,7 +186,7 @@ libc_test_library(
         "//libc:__support_cpp_type_traits",
         "//libc:__support_ctype_utils",
         "//libc:__support_macros_properties_architectures",
-        "//libc:errno.__internal__",
+        "//libc:errno",
         "//libc/test/UnitTest:LibcUnitTest",
     ],
 )


### PR DESCRIPTION
This shouldn't really be a "libc_function" since it can be used as a dependency of various other support libraries and functions, and doesn't correspond to a well-defined endpoint that the users may want to explicitly depend on (if they depend on it implicitly through a libc_function whose implementation relies on errno, the dependency will be pulled in normally). Remove special handling for "errno" in the Bazel test rules.