### PR TITLE
[flang-rt] Added FLANG_RT_QUADMATH_INCLUDE_DIR option.

### DIFF
--- a/flang-rt/README.md
+++ b/flang-rt/README.md
@@ -141,6 +141,12 @@ CMake itself provide.
    the compiler for `__float128` or 128-bit `long double` support.
    [More details](docs/Real16MathSupport.md).
 
+ * `FLANG_RT_QUADMATH_INCLUDE_DIR` (default: `""`)
+
+   Allows setting a path to `quadmath.h` directory.
+   It may be required when using non-gcc compiler for building flang-rt.
+   It maye also be required when building flang-rt in bootstrap mode.
+
  * `FLANG_RT_EXPERIMENTAL_OFFLOAD_SUPPORT` (values: `"CUDA"`,`"OpenMP"`, `""` default: `""`)
 
    When set to `CUDA`, builds Flang-RT with experimental support for GPU

--- a/flang-rt/lib/quadmath/CMakeLists.txt
+++ b/flang-rt/lib/quadmath/CMakeLists.txt
@@ -76,8 +76,15 @@ target_include_directories(FortranFloat128MathILib INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
   )
 
+set(FLANG_RT_QUADMATH_INCLUDE_DIR "" CACHE PATH
+  "An optional path to GNU libquadmath header files. \
+   It may be required when building with FLANG_RUNTIME_F128_MATH_LIB \
+   and a non-gcc compiler.")
+
 if (FLANG_RUNTIME_F128_MATH_LIB)
   if (${FLANG_RUNTIME_F128_MATH_LIB} STREQUAL "libquadmath")
+    include_directories(${FLANG_RT_QUADMATH_INCLUDE_DIR})
+    list(APPEND CMAKE_REQUIRED_INCLUDES ${FLANG_RT_QUADMATH_INCLUDE_DIR})
     check_include_file(quadmath.h FOUND_QUADMATH_HEADER)
     if(FOUND_QUADMATH_HEADER)
       add_compile_definitions(HAS_QUADMATHLIB)


### PR DESCRIPTION
It allows specifying path to `quadmath.h` directory,
which is needed when building flang-rt with
FLANG_RUNTIME_F128_MATH_LIB=libquadmath using clang.
