### PR TITLE
Reland [flang] In AllocMemOp lowering, convert types for calling malloc on 32-bit

### DIFF
--- a/flang-rt/lib/runtime/extensions.cpp
+++ b/flang-rt/lib/runtime/extensions.cpp
@@ -61,7 +61,7 @@ extern "C" {
 namespace Fortran::runtime {
 
 gid_t RTNAME(GetGID)() {
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__wasi__)
   // Group IDs don't exist on Windows, return 1 to avoid errors
   return 1;
 #else
@@ -70,7 +70,7 @@ gid_t RTNAME(GetGID)() {
 }
 
 uid_t RTNAME(GetUID)() {
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__wasi__)
   // User IDs don't exist on Windows, return 1 to avoid errors
   return 1;
 #else

--- a/flang-rt/lib/runtime/file.cpp
+++ b/flang-rt/lib/runtime/file.cpp
@@ -31,6 +31,10 @@ void OpenFile::set_path(OwningPtr<char> &&path, std::size_t bytes) {
 }
 
 static int openfile_mkstemp(IoErrorHandler &handler) {
+#ifdef __wasi__
+  handler.SignalError("not supported on WASI");
+  return -1;
+#else
 #ifdef _WIN32
   const unsigned int uUnique{0};
   // GetTempFileNameA needs a directory name < MAX_PATH-14 characters in length.
@@ -58,6 +62,7 @@ static int openfile_mkstemp(IoErrorHandler &handler) {
   ::unlink(path);
 #endif
   return fd;
+#endif
 }
 
 void OpenFile::Open(OpenStatus status, Fortran::common::optional<Action> action,

--- a/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
@@ -51,14 +51,14 @@ class DerivedType;
 
 namespace fir::runtime {
 
-using TypeBuilderFunc = mlir::Type (*)(const fir::FirOpBuilder &);
-using FuncTypeBuilderFunc = mlir::FunctionType (*)(const fir::FirOpBuilder &);
+using TypeBuilderFunc = mlir::Type (*)(fir::FirOpBuilder &);
+using FuncTypeBuilderFunc = mlir::FunctionType (*)(fir::FirOpBuilder &);
 
 #define REDUCTION_REF_OPERATION_MODEL(T)                                       \
   template <>                                                                  \
   constexpr TypeBuilderFunc                                                    \
   getModel<Fortran::runtime::ReferenceReductionOperation<T>>() {               \
-    return [](const fir::FirOpBuilder &builder) -> mlir::Type {                \
+    return [](fir::FirOpBuilder &builder) -> mlir::Type {                      \
       TypeBuilderFunc f{getModel<T>()};                                        \
       auto refTy = fir::ReferenceType::get(f(builder));                        \
       return mlir::FunctionType::get(builder.getContext(), {refTy, refTy},     \
@@ -70,7 +70,7 @@ using FuncTypeBuilderFunc = mlir::FunctionType (*)(const fir::FirOpBuilder &);
   template <>                                                                  \
   constexpr TypeBuilderFunc                                                    \
   getModel<Fortran::runtime::ValueReductionOperation<T>>() {                   \
-    return [](const fir::FirOpBuilder &builder) -> mlir::Type {                \
+    return [](fir::FirOpBuilder &builder) -> mlir::Type {                      \
       TypeBuilderFunc f{getModel<T>()};                                        \
       auto refTy = fir::ReferenceType::get(f(builder));                        \
       return mlir::FunctionType::get(builder.getContext(),                     \
@@ -82,7 +82,7 @@ using FuncTypeBuilderFunc = mlir::FunctionType (*)(const fir::FirOpBuilder &);
   template <>                                                                  \
   constexpr TypeBuilderFunc                                                    \
   getModel<Fortran::runtime::ReductionCharOperation<T>>() {                    \
-    return [](const fir::FirOpBuilder &builder) -> mlir::Type {                \
+    return [](fir::FirOpBuilder &builder) -> mlir::Type {                      \
       TypeBuilderFunc f{getModel<T>()};                                        \
       auto voidTy = fir::LLVMPointerType::get(                                 \
           builder.getContext(),                                                \
@@ -115,20 +115,19 @@ static constexpr TypeBuilderFunc getModel();
 
 template <>
 constexpr TypeBuilderFunc getModel<unsigned int>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
-    return mlir::IntegerType::get(builder.getContext(),
-                                  8 * sizeof(unsigned int));
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
+    return builder.getCIntType();
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<short int>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
-    return mlir::IntegerType::get(builder.getContext(), 8 * sizeof(short int));
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
+    return builder.getCShortType();
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<short int *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     TypeBuilderFunc f{getModel<short int>()};
     return fir::ReferenceType::get(f(builder));
   };
@@ -139,13 +138,13 @@ constexpr TypeBuilderFunc getModel<const short int *>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<int>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
-    return mlir::IntegerType::get(builder.getContext(), 8 * sizeof(int));
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
+    return builder.getCIntType();
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<int &>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     TypeBuilderFunc f{getModel<int>()};
     return fir::ReferenceType::get(f(builder));
   };
@@ -156,14 +155,14 @@ constexpr TypeBuilderFunc getModel<int *>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<const int *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     TypeBuilderFunc f{getModel<int>()};
     return fir::ReferenceType::get(f(builder));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<char *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return fir::ReferenceType::get(
         mlir::IntegerType::get(builder.getContext(), 8));
   };
@@ -174,34 +173,34 @@ constexpr TypeBuilderFunc getModel<const char *>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<const char16_t *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return fir::ReferenceType::get(
         mlir::IntegerType::get(builder.getContext(), 16));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<const char32_t *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return fir::ReferenceType::get(
         mlir::IntegerType::get(builder.getContext(), 32));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<char>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::IntegerType::get(builder.getContext(), 8 * sizeof(char));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<signed char>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::IntegerType::get(builder.getContext(),
                                   8 * sizeof(signed char));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<signed char *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     TypeBuilderFunc f{getModel<signed char>()};
     return fir::ReferenceType::get(f(builder));
   };
@@ -212,47 +211,47 @@ constexpr TypeBuilderFunc getModel<const signed char *>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<char16_t>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::IntegerType::get(builder.getContext(), 8 * sizeof(char16_t));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<char16_t *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     TypeBuilderFunc f{getModel<char16_t>()};
     return fir::ReferenceType::get(f(builder));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<char32_t>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::IntegerType::get(builder.getContext(), 8 * sizeof(char32_t));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<char32_t *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     TypeBuilderFunc f{getModel<char32_t>()};
     return fir::ReferenceType::get(f(builder));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<unsigned char>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::IntegerType::get(builder.getContext(),
                                   8 * sizeof(unsigned char));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<void *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return fir::LLVMPointerType::get(
         builder.getContext(), mlir::IntegerType::get(builder.getContext(), 8));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<void (*)(int)>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return fir::LLVMPointerType::get(
         builder.getContext(),
         mlir::FunctionType::get(builder.getContext(), /*inputs=*/{},
@@ -261,20 +260,20 @@ constexpr TypeBuilderFunc getModel<void (*)(int)>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<void **>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return fir::ReferenceType::get(fir::LLVMPointerType::get(
         builder.getContext(), mlir::IntegerType::get(builder.getContext(), 8)));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<long>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::IntegerType::get(builder.getContext(), 8 * 4);
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<long &>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     TypeBuilderFunc f{getModel<long>()};
     return fir::ReferenceType::get(f(builder));
   };
@@ -289,20 +288,20 @@ constexpr TypeBuilderFunc getModel<const long *>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<long long>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::IntegerType::get(builder.getContext(), 8 * sizeof(long long));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<Fortran::common::int128_t>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::IntegerType::get(builder.getContext(),
                                   8 * sizeof(Fortran::common::int128_t));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<long long &>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     TypeBuilderFunc f{getModel<long long>()};
     return fir::ReferenceType::get(f(builder));
   };
@@ -317,26 +316,26 @@ constexpr TypeBuilderFunc getModel<const long long *>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<unsigned long>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::IntegerType::get(builder.getContext(), 8 * 4);
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<unsigned long long>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::IntegerType::get(builder.getContext(),
                                   8 * sizeof(unsigned long long));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<double>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::Float64Type::get(builder.getContext());
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<double &>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     TypeBuilderFunc f{getModel<double>()};
     return fir::ReferenceType::get(f(builder));
   };
@@ -351,7 +350,7 @@ constexpr TypeBuilderFunc getModel<const double *>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<long double>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     // See TODO at the top of the file. This is configuring for the host system
     // - it might be incorrect when cross-compiling!
     constexpr size_t size = sizeof(long double);
@@ -368,7 +367,7 @@ constexpr TypeBuilderFunc getModel<long double>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<long double *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     TypeBuilderFunc f{getModel<long double>()};
     return fir::ReferenceType::get(f(builder));
   };
@@ -379,13 +378,13 @@ constexpr TypeBuilderFunc getModel<const long double *>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<float>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::Float32Type::get(builder.getContext());
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<float &>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     TypeBuilderFunc f{getModel<float>()};
     return fir::ReferenceType::get(f(builder));
   };
@@ -400,27 +399,27 @@ constexpr TypeBuilderFunc getModel<const float *>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<bool>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::IntegerType::get(builder.getContext(), 1);
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<bool &>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     TypeBuilderFunc f{getModel<bool>()};
     return fir::ReferenceType::get(f(builder));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<bool *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     TypeBuilderFunc f{getModel<bool>()};
     return fir::ReferenceType::get(f(builder));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<unsigned short>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::IntegerType::get(
         builder.getContext(), 8 * sizeof(unsigned short),
         mlir::IntegerType::SignednessSemantics::Unsigned);
@@ -428,7 +427,7 @@ constexpr TypeBuilderFunc getModel<unsigned short>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<unsigned char *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return fir::ReferenceType::get(
         mlir::IntegerType::get(builder.getContext(), 8));
   };
@@ -439,7 +438,7 @@ constexpr TypeBuilderFunc getModel<const unsigned char *>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<unsigned short *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return fir::ReferenceType::get(mlir::IntegerType::get(
         builder.getContext(), 8 * sizeof(unsigned short)));
   };
@@ -458,7 +457,7 @@ constexpr TypeBuilderFunc getModel<const unsigned *>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<unsigned long *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return fir::ReferenceType::get(mlir::IntegerType::get(
         builder.getContext(), 8 * sizeof(unsigned long)));
   };
@@ -469,7 +468,7 @@ constexpr TypeBuilderFunc getModel<const unsigned long *>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<unsigned long long *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return fir::ReferenceType::get(mlir::IntegerType::get(
         builder.getContext(), 8 * sizeof(unsigned long long)));
   };
@@ -484,7 +483,7 @@ constexpr TypeBuilderFunc getModel<Fortran::common::uint128_t>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<Fortran::common::int128_t *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     TypeBuilderFunc f{getModel<Fortran::common::int128_t>()};
     return fir::ReferenceType::get(f(builder));
   };
@@ -507,7 +506,7 @@ constexpr TypeBuilderFunc getModel<const Fortran::common::uint128_t *>() {
 
 template <>
 constexpr TypeBuilderFunc getModel<std::complex<float> &>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     mlir::Type floatTy = getModel<float>()(builder);
     return fir::ReferenceType::get(mlir::ComplexType::get(floatTy));
   };
@@ -522,7 +521,7 @@ constexpr TypeBuilderFunc getModel<const std::complex<float> *>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<std::complex<double> &>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     mlir::Type floatTy = getModel<double>()(builder);
     return fir::ReferenceType::get(mlir::ComplexType::get(floatTy));
   };
@@ -537,27 +536,27 @@ constexpr TypeBuilderFunc getModel<const std::complex<double> *>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<c_float_complex_t>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     mlir::Type floatTy = getModel<float>()(builder);
     return mlir::ComplexType::get(floatTy);
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<c_double_complex_t>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     mlir::Type floatTy = getModel<double>()(builder);
     return mlir::ComplexType::get(floatTy);
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<const Fortran::runtime::Descriptor &>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return fir::BoxType::get(mlir::NoneType::get(builder.getContext()));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<Fortran::runtime::Descriptor &>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return fir::ReferenceType::get(
         fir::BoxType::get(mlir::NoneType::get(builder.getContext())));
   };
@@ -572,7 +571,7 @@ constexpr TypeBuilderFunc getModel<Fortran::runtime::Descriptor *>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<Fortran::common::TypeCategory>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::IntegerType::get(builder.getContext(),
                                   sizeof(Fortran::common::TypeCategory) * 8);
   };
@@ -580,20 +579,20 @@ constexpr TypeBuilderFunc getModel<Fortran::common::TypeCategory>() {
 template <>
 constexpr TypeBuilderFunc
 getModel<const Fortran::runtime::typeInfo::DerivedType &>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return fir::ReferenceType::get(mlir::NoneType::get(builder.getContext()));
   };
 }
 template <>
 constexpr TypeBuilderFunc
 getModel<const Fortran::runtime::typeInfo::DerivedType *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return fir::ReferenceType::get(mlir::NoneType::get(builder.getContext()));
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<void>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::NoneType::get(builder.getContext());
   };
 }
@@ -605,7 +604,7 @@ constexpr TypeBuilderFunc getModel<Fortran::runtime::io::IoStatementState *>() {
 }
 template <>
 constexpr TypeBuilderFunc getModel<Fortran::runtime::io::Iostat>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::IntegerType::get(builder.getContext(),
                                   8 * sizeof(Fortran::runtime::io::Iostat));
   };
@@ -613,14 +612,14 @@ constexpr TypeBuilderFunc getModel<Fortran::runtime::io::Iostat>() {
 template <>
 constexpr TypeBuilderFunc
 getModel<const Fortran::runtime::io::NamelistGroup &>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return fir::ReferenceType::get(mlir::TupleType::get(builder.getContext()));
   };
 }
 template <>
 constexpr TypeBuilderFunc
 getModel<const Fortran::runtime::io::NonTbpDefinedIoTable *>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return fir::ReferenceType::get(mlir::TupleType::get(builder.getContext()));
   };
 }
@@ -660,7 +659,7 @@ REDUCTION_VALUE_OPERATION_MODEL(long double)
 template <>
 constexpr TypeBuilderFunc
 getModel<Fortran::runtime::ValueReductionOperation<std::complex<float>>>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     mlir::Type cplx = mlir::ComplexType::get(getModel<float>()(builder));
     auto refTy = fir::ReferenceType::get(cplx);
     return mlir::FunctionType::get(builder.getContext(), {cplx, cplx}, refTy);
@@ -669,7 +668,7 @@ getModel<Fortran::runtime::ValueReductionOperation<std::complex<float>>>() {
 template <>
 constexpr TypeBuilderFunc
 getModel<Fortran::runtime::ValueReductionOperation<std::complex<double>>>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     mlir::Type cplx = mlir::ComplexType::get(getModel<double>()(builder));
     auto refTy = fir::ReferenceType::get(cplx);
     return mlir::FunctionType::get(builder.getContext(), {cplx, cplx}, refTy);
@@ -678,7 +677,7 @@ getModel<Fortran::runtime::ValueReductionOperation<std::complex<double>>>() {
 template <>
 constexpr TypeBuilderFunc
 getModel<Fortran::runtime::ReferenceReductionOperation<std::complex<float>>>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     mlir::Type cplx = mlir::ComplexType::get(getModel<float>()(builder));
     auto refTy = fir::ReferenceType::get(cplx);
     return mlir::FunctionType::get(builder.getContext(), {refTy, refTy}, refTy);
@@ -687,7 +686,7 @@ getModel<Fortran::runtime::ReferenceReductionOperation<std::complex<float>>>() {
 template <>
 constexpr TypeBuilderFunc getModel<
     Fortran::runtime::ReferenceReductionOperation<std::complex<double>>>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     mlir::Type cplx = mlir::ComplexType::get(getModel<double>()(builder));
     auto refTy = fir::ReferenceType::get(cplx);
     return mlir::FunctionType::get(builder.getContext(), {refTy, refTy}, refTy);
@@ -701,7 +700,7 @@ REDUCTION_CHAR_OPERATION_MODEL(char32_t)
 template <>
 constexpr TypeBuilderFunc
 getModel<Fortran::runtime::ReductionDerivedTypeOperation>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     auto voidTy = fir::LLVMPointerType::get(
         builder.getContext(), mlir::IntegerType::get(builder.getContext(), 8));
     return mlir::FunctionType::get(builder.getContext(),
@@ -714,7 +713,7 @@ struct RuntimeTableKey;
 template <typename RT, typename... ATs>
 struct RuntimeTableKey<RT(ATs...)> {
   static constexpr FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       TypeBuilderFunc ret = getModel<RT>();
       std::array<TypeBuilderFunc, sizeof...(ATs)> args = {getModel<ATs>()...};
       mlir::Type retTy = ret(builder);

--- a/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
@@ -87,8 +87,7 @@ using FuncTypeBuilderFunc = mlir::FunctionType (*)(fir::FirOpBuilder &);
       auto voidTy = fir::LLVMPointerType::get(                                 \
           builder.getContext(),                                                \
           mlir::IntegerType::get(builder.getContext(), 8));                    \
-      auto size_tTy = mlir::IntegerType::get(builder.getContext(),             \
-                                             8 * sizeof(std::size_t));         \
+      auto size_tTy = builder.getIntPtrType();                                 \
       auto refTy = fir::ReferenceType::get(f(builder));                        \
       return mlir::FunctionType::get(                                          \
           builder.getContext(),                                                \
@@ -188,14 +187,13 @@ constexpr TypeBuilderFunc getModel<const char32_t *>() {
 template <>
 constexpr TypeBuilderFunc getModel<char>() {
   return [](fir::FirOpBuilder &builder) -> mlir::Type {
-    return mlir::IntegerType::get(builder.getContext(), 8 * sizeof(char));
+    return builder.getCCharType();
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<signed char>() {
   return [](fir::FirOpBuilder &builder) -> mlir::Type {
-    return mlir::IntegerType::get(builder.getContext(),
-                                  8 * sizeof(signed char));
+    return builder.getCCharType();
   };
 }
 template <>
@@ -212,7 +210,7 @@ constexpr TypeBuilderFunc getModel<const signed char *>() {
 template <>
 constexpr TypeBuilderFunc getModel<char16_t>() {
   return [](fir::FirOpBuilder &builder) -> mlir::Type {
-    return mlir::IntegerType::get(builder.getContext(), 8 * sizeof(char16_t));
+    return mlir::IntegerType::get(builder.getContext(), 16);
   };
 }
 template <>
@@ -225,7 +223,7 @@ constexpr TypeBuilderFunc getModel<char16_t *>() {
 template <>
 constexpr TypeBuilderFunc getModel<char32_t>() {
   return [](fir::FirOpBuilder &builder) -> mlir::Type {
-    return mlir::IntegerType::get(builder.getContext(), 8 * sizeof(char32_t));
+    return mlir::IntegerType::get(builder.getContext(), 32);
   };
 }
 template <>
@@ -238,8 +236,7 @@ constexpr TypeBuilderFunc getModel<char32_t *>() {
 template <>
 constexpr TypeBuilderFunc getModel<unsigned char>() {
   return [](fir::FirOpBuilder &builder) -> mlir::Type {
-    return mlir::IntegerType::get(builder.getContext(),
-                                  8 * sizeof(unsigned char));
+    return builder.getCCharType();
   };
 }
 template <>
@@ -268,7 +265,7 @@ constexpr TypeBuilderFunc getModel<void **>() {
 template <>
 constexpr TypeBuilderFunc getModel<long>() {
   return [](fir::FirOpBuilder &builder) -> mlir::Type {
-    return mlir::IntegerType::get(builder.getContext(), 8 * 4);
+    return builder.getCLongType();
   };
 }
 template <>
@@ -289,7 +286,7 @@ constexpr TypeBuilderFunc getModel<const long *>() {
 template <>
 constexpr TypeBuilderFunc getModel<long long>() {
   return [](fir::FirOpBuilder &builder) -> mlir::Type {
-    return mlir::IntegerType::get(builder.getContext(), 8 * sizeof(long long));
+    return builder.getCLongLongType();
   };
 }
 template <>
@@ -317,14 +314,13 @@ constexpr TypeBuilderFunc getModel<const long long *>() {
 template <>
 constexpr TypeBuilderFunc getModel<unsigned long>() {
   return [](fir::FirOpBuilder &builder) -> mlir::Type {
-    return mlir::IntegerType::get(builder.getContext(), 8 * 4);
+    return builder.getCLongType();
   };
 }
 template <>
 constexpr TypeBuilderFunc getModel<unsigned long long>() {
   return [](fir::FirOpBuilder &builder) -> mlir::Type {
-    return mlir::IntegerType::get(builder.getContext(),
-                                  8 * sizeof(unsigned long long));
+    return builder.getCLongLongType();
   };
 }
 template <>
@@ -420,6 +416,7 @@ constexpr TypeBuilderFunc getModel<bool *>() {
 template <>
 constexpr TypeBuilderFunc getModel<unsigned short>() {
   return [](fir::FirOpBuilder &builder) -> mlir::Type {
+    // TODO: This has special signedness semantics?
     return mlir::IntegerType::get(
         builder.getContext(), 8 * sizeof(unsigned short),
         mlir::IntegerType::SignednessSemantics::Unsigned);
@@ -428,8 +425,8 @@ constexpr TypeBuilderFunc getModel<unsigned short>() {
 template <>
 constexpr TypeBuilderFunc getModel<unsigned char *>() {
   return [](fir::FirOpBuilder &builder) -> mlir::Type {
-    return fir::ReferenceType::get(
-        mlir::IntegerType::get(builder.getContext(), 8));
+    TypeBuilderFunc f{getModel<unsigned char>()};
+    return fir::ReferenceType::get(f(builder));
   };
 }
 template <>
@@ -439,8 +436,8 @@ constexpr TypeBuilderFunc getModel<const unsigned char *>() {
 template <>
 constexpr TypeBuilderFunc getModel<unsigned short *>() {
   return [](fir::FirOpBuilder &builder) -> mlir::Type {
-    return fir::ReferenceType::get(mlir::IntegerType::get(
-        builder.getContext(), 8 * sizeof(unsigned short)));
+    TypeBuilderFunc f{getModel<unsigned short>()};
+    return fir::ReferenceType::get(f(builder));
   };
 }
 template <>
@@ -458,8 +455,8 @@ constexpr TypeBuilderFunc getModel<const unsigned *>() {
 template <>
 constexpr TypeBuilderFunc getModel<unsigned long *>() {
   return [](fir::FirOpBuilder &builder) -> mlir::Type {
-    return fir::ReferenceType::get(mlir::IntegerType::get(
-        builder.getContext(), 8 * sizeof(unsigned long)));
+    TypeBuilderFunc f{getModel<unsigned long>()};
+    return fir::ReferenceType::get(f(builder));
   };
 }
 template <>
@@ -469,8 +466,8 @@ constexpr TypeBuilderFunc getModel<const unsigned long *>() {
 template <>
 constexpr TypeBuilderFunc getModel<unsigned long long *>() {
   return [](fir::FirOpBuilder &builder) -> mlir::Type {
-    return fir::ReferenceType::get(mlir::IntegerType::get(
-        builder.getContext(), 8 * sizeof(unsigned long long)));
+    TypeBuilderFunc f{getModel<unsigned long long>()};
+    return fir::ReferenceType::get(f(builder));
   };
 }
 template <>
@@ -572,8 +569,7 @@ constexpr TypeBuilderFunc getModel<Fortran::runtime::Descriptor *>() {
 template <>
 constexpr TypeBuilderFunc getModel<Fortran::common::TypeCategory>() {
   return [](fir::FirOpBuilder &builder) -> mlir::Type {
-    return mlir::IntegerType::get(builder.getContext(),
-                                  sizeof(Fortran::common::TypeCategory) * 8);
+    return builder.getCEnumType();
   };
 }
 template <>
@@ -605,8 +601,7 @@ constexpr TypeBuilderFunc getModel<Fortran::runtime::io::IoStatementState *>() {
 template <>
 constexpr TypeBuilderFunc getModel<Fortran::runtime::io::Iostat>() {
   return [](fir::FirOpBuilder &builder) -> mlir::Type {
-    return mlir::IntegerType::get(builder.getContext(),
-                                  8 * sizeof(Fortran::runtime::io::Iostat));
+    return builder.getCEnumType();
   };
 }
 template <>

--- a/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
+++ b/flang/include/flang/Optimizer/Builder/Runtime/RTBuilder.h
@@ -260,7 +260,7 @@ constexpr TypeBuilderFunc getModel<void **>() {
 template <>
 constexpr TypeBuilderFunc getModel<long>() {
   return [](mlir::MLIRContext *context) -> mlir::Type {
-    return mlir::IntegerType::get(context, 8 * sizeof(long));
+    return mlir::IntegerType::get(context, 8 * 4);
   };
 }
 template <>
@@ -309,7 +309,7 @@ constexpr TypeBuilderFunc getModel<const long long *>() {
 template <>
 constexpr TypeBuilderFunc getModel<unsigned long>() {
   return [](mlir::MLIRContext *context) -> mlir::Type {
-    return mlir::IntegerType::get(context, 8 * sizeof(unsigned long));
+    return mlir::IntegerType::get(context, 8 * 4);
   };
 }
 template <>

--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -777,7 +777,7 @@ private:
     mlir::Value source = sourceExpr ? fir::getBase(sourceExv) : nullptr;
 
     // Keep return type the same as a standard AllocatableAllocate call.
-    mlir::Type retTy = fir::runtime::getModel<int>()(builder.getContext());
+    mlir::Type retTy = fir::runtime::getModel<int>()(builder);
     return builder
         .create<cuf::AllocateOp>(
             loc, retTy, box.getAddr(), errmsg, stream, pinned, source, cudaAttr,
@@ -846,7 +846,7 @@ static mlir::Value genCudaDeallocate(fir::FirOpBuilder &builder,
           : errorManager.errMsgAddr;
 
   // Keep return type the same as a standard AllocatableAllocate call.
-  mlir::Type retTy = fir::runtime::getModel<int>()(builder.getContext());
+  mlir::Type retTy = fir::runtime::getModel<int>()(builder);
   return builder
       .create<cuf::DeallocateOp>(
           loc, retTy, box.getAddr(), errmsg, cudaAttr,

--- a/flang/lib/Lower/IO.cpp
+++ b/flang/lib/Lower/IO.cpp
@@ -267,9 +267,9 @@ getNonTbpDefinedIoTableAddr(Fortran::lower::AbstractConverter &converter,
   mlir::StringAttr linkOnce = builder.createLinkOnceLinkage();
   mlir::Type idxTy = builder.getIndexType();
   mlir::Type sizeTy =
-      fir::runtime::getModel<std::size_t>()(builder.getContext());
-  mlir::Type intTy = fir::runtime::getModel<int>()(builder.getContext());
-  mlir::Type boolTy = fir::runtime::getModel<bool>()(builder.getContext());
+      fir::runtime::getModel<std::size_t>()(builder);
+  mlir::Type intTy = fir::runtime::getModel<int>()(builder);
+  mlir::Type boolTy = fir::runtime::getModel<bool>()(builder);
   mlir::Type listTy = fir::SequenceType::get(
       definedIoProcMap.size(),
       mlir::TupleType::get(context, {refTy, refTy, intTy, boolTy}));
@@ -427,7 +427,7 @@ getNamelistGroup(Fortran::lower::AbstractConverter &converter,
   mlir::StringAttr linkOnce = builder.createLinkOnceLinkage();
   mlir::Type idxTy = builder.getIndexType();
   mlir::Type sizeTy =
-      fir::runtime::getModel<std::size_t>()(builder.getContext());
+      fir::runtime::getModel<std::size_t>()(builder);
   mlir::Type charRefTy = fir::ReferenceType::get(builder.getIntegerType(8));
   mlir::Type descRefTy =
       fir::ReferenceType::get(fir::BoxType::get(mlir::NoneType::get(context)));

--- a/flang/lib/Optimizer/Builder/FIRBuilder.cpp
+++ b/flang/lib/Optimizer/Builder/FIRBuilder.cpp
@@ -33,6 +33,25 @@
 #include "llvm/Support/MD5.h"
 #include <optional>
 
+fir::MinimalCTargetInfo::MinimalCTargetInfo(const llvm::Triple &T) {
+  CharWidth = 8;
+  ShortWidth = 16;
+  DataPointerWidth = T.getArchPointerBitWidth();
+  // TODO: This will need to be changed for targets such as AVR and MSP430
+  IntWidth = 32;
+  // TODO: flags such as -fshort-enums can change ABI
+  EnumWidth = IntWidth;
+  LongLongWidth = 64;
+  if (T.isArch64Bit() && T.isOSWindows()) {
+    // Windows uses sizeof(long) = 32 bits
+    LongWidth = 32;
+  } else {
+    // Assumes sizeof(long) == sizeof(ptr)
+    // (typical for Unix-likes: ILP32 and LP64)
+    LongWidth = DataPointerWidth;
+  }
+}
+
 static llvm::cl::opt<std::size_t>
     nameLengthHashSize("length-to-hash-string-literal",
                        llvm::cl::desc("string literals that exceed this length"

--- a/flang/lib/Optimizer/Builder/Runtime/Intrinsics.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Intrinsics.cpp
@@ -32,7 +32,7 @@ namespace {
 struct ForcedRandomNumberReal16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(RandomNumber16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto boxTy =
           fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
               builder);

--- a/flang/lib/Optimizer/Builder/Runtime/Intrinsics.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Intrinsics.cpp
@@ -32,13 +32,15 @@ namespace {
 struct ForcedRandomNumberReal16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(RandomNumber16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
-      auto strTy = fir::runtime::getModel<const char *>()(ctx);
-      auto intTy = fir::runtime::getModel<int>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
+      auto strTy = fir::runtime::getModel<const char *>()(builder);
+      auto intTy = fir::runtime::getModel<int>()(builder);
       ;
-      return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy}, {});
+      return mlir::FunctionType::get(builder.getContext(),
+                                     {boxTy, strTy, intTy}, {});
     };
   }
 };

--- a/flang/lib/Optimizer/Builder/Runtime/Numeric.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Numeric.cpp
@@ -26,7 +26,7 @@ using namespace Fortran::runtime;
 struct ForcedErfcScaled10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(ErfcScaled10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       return mlir::FunctionType::get(ctx, {ty}, {ty});
@@ -38,7 +38,7 @@ struct ForcedErfcScaled10 {
 struct ForcedErfcScaled16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(ErfcScaled16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       return mlir::FunctionType::get(ctx, {ty}, {ty});
@@ -50,7 +50,7 @@ struct ForcedErfcScaled16 {
 struct ForcedExponent10_4 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Exponent10_4));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto fltTy = mlir::Float80Type::get(ctx);
       auto intTy = mlir::IntegerType::get(ctx, 32);
@@ -62,7 +62,7 @@ struct ForcedExponent10_4 {
 struct ForcedExponent10_8 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Exponent10_8));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto fltTy = mlir::Float80Type::get(ctx);
       auto intTy = mlir::IntegerType::get(ctx, 64);
@@ -75,7 +75,7 @@ struct ForcedExponent10_8 {
 struct ForcedExponent16_4 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Exponent16_4));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto fltTy = mlir::Float128Type::get(ctx);
       auto intTy = mlir::IntegerType::get(ctx, 32);
@@ -87,7 +87,7 @@ struct ForcedExponent16_4 {
 struct ForcedExponent16_8 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Exponent16_8));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto fltTy = mlir::Float128Type::get(ctx);
       auto intTy = mlir::IntegerType::get(ctx, 64);
@@ -100,7 +100,7 @@ struct ForcedExponent16_8 {
 struct ForcedFraction10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Fraction10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       return mlir::FunctionType::get(ctx, {ty}, {ty});
@@ -112,7 +112,7 @@ struct ForcedFraction10 {
 struct ForcedFraction16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Fraction16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       return mlir::FunctionType::get(ctx, {ty}, {ty});
@@ -124,7 +124,7 @@ struct ForcedFraction16 {
 struct ForcedMod10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(ModReal10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto fltTy = mlir::Float80Type::get(ctx);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -139,7 +139,7 @@ struct ForcedMod10 {
 struct ForcedMod16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(ModReal16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto fltTy = mlir::Float128Type::get(ctx);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -154,7 +154,7 @@ struct ForcedMod16 {
 struct ForcedModulo10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(ModuloReal10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto fltTy = mlir::Float80Type::get(ctx);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -169,7 +169,7 @@ struct ForcedModulo10 {
 struct ForcedModulo16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(ModuloReal16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto fltTy = mlir::Float128Type::get(ctx);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -184,7 +184,7 @@ struct ForcedModulo16 {
 struct ForcedNearest10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Nearest10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto fltTy = mlir::Float80Type::get(ctx);
       auto boolTy = mlir::IntegerType::get(ctx, 1);
@@ -197,7 +197,7 @@ struct ForcedNearest10 {
 struct ForcedNearest16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Nearest16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto fltTy = mlir::Float128Type::get(ctx);
       auto boolTy = mlir::IntegerType::get(ctx, 1);
@@ -210,7 +210,7 @@ struct ForcedNearest16 {
 struct ForcedRRSpacing10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(RRSpacing10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       return mlir::FunctionType::get(ctx, {ty}, {ty});
@@ -222,7 +222,7 @@ struct ForcedRRSpacing10 {
 struct ForcedRRSpacing16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(RRSpacing16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       return mlir::FunctionType::get(ctx, {ty}, {ty});
@@ -234,7 +234,7 @@ struct ForcedRRSpacing16 {
 struct ForcedScale10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Scale10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto fltTy = mlir::Float80Type::get(ctx);
       auto intTy = mlir::IntegerType::get(ctx, 64);
@@ -247,7 +247,7 @@ struct ForcedScale10 {
 struct ForcedScale16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Scale16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto fltTy = mlir::Float128Type::get(ctx);
       auto intTy = mlir::IntegerType::get(ctx, 64);
@@ -260,7 +260,7 @@ struct ForcedScale16 {
 struct ForcedSetExponent10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(SetExponent10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto fltTy = mlir::Float80Type::get(ctx);
       auto intTy = mlir::IntegerType::get(ctx, 64);
@@ -273,7 +273,7 @@ struct ForcedSetExponent10 {
 struct ForcedSetExponent16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(SetExponent16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto fltTy = mlir::Float128Type::get(ctx);
       auto intTy = mlir::IntegerType::get(ctx, 64);
@@ -286,7 +286,7 @@ struct ForcedSetExponent16 {
 struct ForcedSpacing10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Spacing10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       return mlir::FunctionType::get(ctx, {ty}, {ty});
@@ -298,7 +298,7 @@ struct ForcedSpacing10 {
 struct ForcedSpacing16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Spacing16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       return mlir::FunctionType::get(ctx, {ty}, {ty});

--- a/flang/lib/Optimizer/Builder/Runtime/Numeric.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Numeric.cpp
@@ -26,7 +26,8 @@ using namespace Fortran::runtime;
 struct ForcedErfcScaled10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(ErfcScaled10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       return mlir::FunctionType::get(ctx, {ty}, {ty});
     };
@@ -37,7 +38,8 @@ struct ForcedErfcScaled10 {
 struct ForcedErfcScaled16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(ErfcScaled16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       return mlir::FunctionType::get(ctx, {ty}, {ty});
     };
@@ -48,7 +50,8 @@ struct ForcedErfcScaled16 {
 struct ForcedExponent10_4 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Exponent10_4));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto fltTy = mlir::Float80Type::get(ctx);
       auto intTy = mlir::IntegerType::get(ctx, 32);
       return mlir::FunctionType::get(ctx, fltTy, intTy);
@@ -59,7 +62,8 @@ struct ForcedExponent10_4 {
 struct ForcedExponent10_8 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Exponent10_8));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto fltTy = mlir::Float80Type::get(ctx);
       auto intTy = mlir::IntegerType::get(ctx, 64);
       return mlir::FunctionType::get(ctx, fltTy, intTy);
@@ -71,7 +75,8 @@ struct ForcedExponent10_8 {
 struct ForcedExponent16_4 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Exponent16_4));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto fltTy = mlir::Float128Type::get(ctx);
       auto intTy = mlir::IntegerType::get(ctx, 32);
       return mlir::FunctionType::get(ctx, fltTy, intTy);
@@ -82,7 +87,8 @@ struct ForcedExponent16_4 {
 struct ForcedExponent16_8 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Exponent16_8));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto fltTy = mlir::Float128Type::get(ctx);
       auto intTy = mlir::IntegerType::get(ctx, 64);
       return mlir::FunctionType::get(ctx, fltTy, intTy);
@@ -94,7 +100,8 @@ struct ForcedExponent16_8 {
 struct ForcedFraction10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Fraction10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       return mlir::FunctionType::get(ctx, {ty}, {ty});
     };
@@ -105,7 +112,8 @@ struct ForcedFraction10 {
 struct ForcedFraction16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Fraction16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       return mlir::FunctionType::get(ctx, {ty}, {ty});
     };
@@ -116,7 +124,8 @@ struct ForcedFraction16 {
 struct ForcedMod10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(ModReal10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto fltTy = mlir::Float80Type::get(ctx);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
@@ -130,7 +139,8 @@ struct ForcedMod10 {
 struct ForcedMod16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(ModReal16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto fltTy = mlir::Float128Type::get(ctx);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
@@ -144,7 +154,8 @@ struct ForcedMod16 {
 struct ForcedModulo10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(ModuloReal10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto fltTy = mlir::Float80Type::get(ctx);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
@@ -158,7 +169,8 @@ struct ForcedModulo10 {
 struct ForcedModulo16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(ModuloReal16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto fltTy = mlir::Float128Type::get(ctx);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
@@ -172,7 +184,8 @@ struct ForcedModulo16 {
 struct ForcedNearest10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Nearest10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto fltTy = mlir::Float80Type::get(ctx);
       auto boolTy = mlir::IntegerType::get(ctx, 1);
       return mlir::FunctionType::get(ctx, {fltTy, boolTy}, {fltTy});
@@ -184,7 +197,8 @@ struct ForcedNearest10 {
 struct ForcedNearest16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Nearest16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto fltTy = mlir::Float128Type::get(ctx);
       auto boolTy = mlir::IntegerType::get(ctx, 1);
       return mlir::FunctionType::get(ctx, {fltTy, boolTy}, {fltTy});
@@ -196,7 +210,8 @@ struct ForcedNearest16 {
 struct ForcedRRSpacing10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(RRSpacing10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       return mlir::FunctionType::get(ctx, {ty}, {ty});
     };
@@ -207,7 +222,8 @@ struct ForcedRRSpacing10 {
 struct ForcedRRSpacing16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(RRSpacing16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       return mlir::FunctionType::get(ctx, {ty}, {ty});
     };
@@ -218,7 +234,8 @@ struct ForcedRRSpacing16 {
 struct ForcedScale10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Scale10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto fltTy = mlir::Float80Type::get(ctx);
       auto intTy = mlir::IntegerType::get(ctx, 64);
       return mlir::FunctionType::get(ctx, {fltTy, intTy}, {fltTy});
@@ -230,7 +247,8 @@ struct ForcedScale10 {
 struct ForcedScale16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Scale16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto fltTy = mlir::Float128Type::get(ctx);
       auto intTy = mlir::IntegerType::get(ctx, 64);
       return mlir::FunctionType::get(ctx, {fltTy, intTy}, {fltTy});
@@ -242,7 +260,8 @@ struct ForcedScale16 {
 struct ForcedSetExponent10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(SetExponent10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto fltTy = mlir::Float80Type::get(ctx);
       auto intTy = mlir::IntegerType::get(ctx, 64);
       return mlir::FunctionType::get(ctx, {fltTy, intTy}, {fltTy});
@@ -254,7 +273,8 @@ struct ForcedSetExponent10 {
 struct ForcedSetExponent16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(SetExponent16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto fltTy = mlir::Float128Type::get(ctx);
       auto intTy = mlir::IntegerType::get(ctx, 64);
       return mlir::FunctionType::get(ctx, {fltTy, intTy}, {fltTy});
@@ -266,7 +286,8 @@ struct ForcedSetExponent16 {
 struct ForcedSpacing10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Spacing10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       return mlir::FunctionType::get(ctx, {ty}, {ty});
     };
@@ -277,7 +298,8 @@ struct ForcedSpacing10 {
 struct ForcedSpacing16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Spacing16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       return mlir::FunctionType::get(ctx, {ty}, {ty});
     };

--- a/flang/lib/Optimizer/Builder/Runtime/Reduction.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Reduction.cpp
@@ -26,7 +26,7 @@ using namespace Fortran::runtime;
 struct ForcedMaxvalReal10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(MaxvalReal10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
@@ -44,7 +44,7 @@ struct ForcedMaxvalReal10 {
 struct ForcedMaxvalReal16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(MaxvalReal16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
@@ -63,7 +63,7 @@ struct ForcedMaxvalInteger16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(MaxvalInteger16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
@@ -82,7 +82,7 @@ struct ForcedMaxvalUnsigned16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(MaxvalUnsigned16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(
           ctx, 128, mlir::IntegerType::SignednessSemantics::Unsigned);
@@ -101,7 +101,7 @@ struct ForcedMaxvalUnsigned16 {
 struct ForcedMinvalReal10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(MinvalReal10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
@@ -119,7 +119,7 @@ struct ForcedMinvalReal10 {
 struct ForcedMinvalReal16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(MinvalReal16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
@@ -138,7 +138,7 @@ struct ForcedMinvalInteger16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(MinvalInteger16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
@@ -157,7 +157,7 @@ struct ForcedMinvalUnsigned16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(MinvalUnsigned16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(
           ctx, 128, mlir::IntegerType::SignednessSemantics::Unsigned);
@@ -188,7 +188,7 @@ using ForcedMinlocUnsigned16 = mkRTKey(MinlocUnsigned16);
 struct ForcedNorm2Real10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Norm2_10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
@@ -205,7 +205,7 @@ struct ForcedNorm2Real10 {
 struct ForcedNorm2Real16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Norm2_16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
@@ -222,7 +222,7 @@ struct ForcedNorm2Real16 {
 struct ForcedNorm2DimReal16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Norm2DimReal16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto boxTy =
           fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
@@ -240,7 +240,7 @@ struct ForcedNorm2DimReal16 {
 struct ForcedProductReal10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(ProductReal10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
@@ -258,7 +258,7 @@ struct ForcedProductReal10 {
 struct ForcedProductReal16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(ProductReal16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
@@ -277,7 +277,7 @@ struct ForcedProductInteger16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ProductInteger16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
@@ -296,7 +296,7 @@ struct ForcedProductUnsigned16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ProductUnsigned16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(
           ctx, 128, mlir::IntegerType::SignednessSemantics::Unsigned);
@@ -316,7 +316,7 @@ struct ForcedProductComplex10 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppProductComplex10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float80Type::get(ctx));
       auto boxTy =
@@ -336,7 +336,7 @@ struct ForcedProductComplex16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppProductComplex16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float128Type::get(ctx));
       auto boxTy =
@@ -356,7 +356,7 @@ struct ForcedDotProductReal10 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(DotProductReal10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
@@ -374,7 +374,7 @@ struct ForcedDotProductReal16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(DotProductReal16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
@@ -392,7 +392,7 @@ struct ForcedDotProductComplex10 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppDotProductComplex10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float80Type::get(ctx));
       auto boxTy =
@@ -412,7 +412,7 @@ struct ForcedDotProductComplex16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppDotProductComplex16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float128Type::get(ctx));
       auto boxTy =
@@ -432,7 +432,7 @@ struct ForcedDotProductInteger16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(DotProductInteger16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
@@ -450,7 +450,7 @@ struct ForcedDotProductUnsigned16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(DotProductUnsigned16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(
           ctx, 128, mlir::IntegerType::SignednessSemantics::Unsigned);
@@ -468,7 +468,7 @@ struct ForcedDotProductUnsigned16 {
 struct ForcedSumReal10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(SumReal10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
@@ -486,7 +486,7 @@ struct ForcedSumReal10 {
 struct ForcedSumReal16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(SumReal16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
@@ -504,7 +504,7 @@ struct ForcedSumReal16 {
 struct ForcedSumInteger16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(SumInteger16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
@@ -522,7 +522,7 @@ struct ForcedSumInteger16 {
 struct ForcedSumUnsigned16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(SumUnsigned16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(
           ctx, 128, mlir::IntegerType::SignednessSemantics::Unsigned);
@@ -542,7 +542,7 @@ struct ForcedSumComplex10 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppSumComplex10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float80Type::get(ctx));
       auto boxTy =
@@ -562,7 +562,7 @@ struct ForcedSumComplex16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppSumComplex16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float128Type::get(ctx));
       auto boxTy =
@@ -581,7 +581,7 @@ struct ForcedSumComplex16 {
 struct ForcedIAll16 {
   static constexpr const char *name = EXPAND_AND_QUOTE_KEY(IAll16);
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
@@ -599,7 +599,7 @@ struct ForcedIAll16 {
 struct ForcedIAny16 {
   static constexpr const char *name = EXPAND_AND_QUOTE_KEY(IAny16);
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
@@ -617,7 +617,7 @@ struct ForcedIAny16 {
 struct ForcedIParity16 {
   static constexpr const char *name = EXPAND_AND_QUOTE_KEY(IParity16);
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
@@ -636,7 +636,7 @@ struct ForcedReduceReal10Ref {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceReal10Ref));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
@@ -658,7 +658,7 @@ struct ForcedReduceReal10Value {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceReal10Value));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
@@ -680,7 +680,7 @@ struct ForcedReduceReal16Ref {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceReal16Ref));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
@@ -702,7 +702,7 @@ struct ForcedReduceReal16Value {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceReal16Value));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
@@ -724,7 +724,7 @@ struct ForcedReduceReal10DimRef {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceReal10DimRef));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
@@ -748,7 +748,7 @@ struct ForcedReduceReal10DimValue {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceReal10DimValue));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
@@ -772,7 +772,7 @@ struct ForcedReduceReal16DimRef {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceReal16DimRef));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
@@ -796,7 +796,7 @@ struct ForcedReduceReal16DimValue {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceReal16DimValue));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
@@ -820,7 +820,7 @@ struct ForcedReduceInteger16Ref {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceInteger16Ref));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
@@ -842,7 +842,7 @@ struct ForcedReduceUnsigned16Ref {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceUnsigned16Ref));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
@@ -864,7 +864,7 @@ struct ForcedReduceInteger16Value {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceInteger16Value));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
@@ -886,7 +886,7 @@ struct ForcedReduceUnsigned16Value {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceUnsigned16Value));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
@@ -908,7 +908,7 @@ struct ForcedReduceInteger16DimRef {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceInteger16DimRef));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
@@ -932,7 +932,7 @@ struct ForcedReduceUnsigned16DimRef {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceUnsigned16DimRef));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(
           ctx, 128, mlir::IntegerType::SignednessSemantics::Unsigned);
@@ -957,7 +957,7 @@ struct ForcedReduceInteger16DimValue {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceInteger16DimValue));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
@@ -981,7 +981,7 @@ struct ForcedReduceUnsigned16DimValue {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceUnsigned16DimValue));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(
           ctx, 128, mlir::IntegerType::SignednessSemantics::Unsigned);
@@ -1006,7 +1006,7 @@ struct ForcedReduceComplex10Ref {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppReduceComplex10Ref));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float80Type::get(ctx));
       auto boxTy =
@@ -1029,7 +1029,7 @@ struct ForcedReduceComplex10Value {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppReduceComplex10Value));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float80Type::get(ctx));
       auto boxTy =
@@ -1052,7 +1052,7 @@ struct ForcedReduceComplex10DimRef {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppReduceComplex10DimRef));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float80Type::get(ctx));
       auto boxTy =
@@ -1076,7 +1076,7 @@ struct ForcedReduceComplex10DimValue {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppReduceComplex10DimValue));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float80Type::get(ctx));
       auto boxTy =
@@ -1100,7 +1100,7 @@ struct ForcedReduceComplex16Ref {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppReduceComplex16Ref));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float128Type::get(ctx));
       auto boxTy =
@@ -1123,7 +1123,7 @@ struct ForcedReduceComplex16Value {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppReduceComplex16Value));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float128Type::get(ctx));
       auto boxTy =
@@ -1146,7 +1146,7 @@ struct ForcedReduceComplex16DimRef {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppReduceComplex16DimRef));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float128Type::get(ctx));
       auto boxTy =
@@ -1170,7 +1170,7 @@ struct ForcedReduceComplex16DimValue {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppReduceComplex16DimValue));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float128Type::get(ctx));
       auto boxTy =

--- a/flang/lib/Optimizer/Builder/Runtime/Reduction.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Reduction.cpp
@@ -26,10 +26,12 @@ using namespace Fortran::runtime;
 struct ForcedMaxvalReal10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(MaxvalReal10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -42,10 +44,12 @@ struct ForcedMaxvalReal10 {
 struct ForcedMaxvalReal16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(MaxvalReal16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -59,10 +63,12 @@ struct ForcedMaxvalInteger16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(MaxvalInteger16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -76,11 +82,13 @@ struct ForcedMaxvalUnsigned16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(MaxvalUnsigned16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(
           ctx, 128, mlir::IntegerType::SignednessSemantics::Unsigned);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -93,10 +101,12 @@ struct ForcedMaxvalUnsigned16 {
 struct ForcedMinvalReal10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(MinvalReal10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -109,10 +119,12 @@ struct ForcedMinvalReal10 {
 struct ForcedMinvalReal16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(MinvalReal16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -126,10 +138,12 @@ struct ForcedMinvalInteger16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(MinvalInteger16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -143,11 +157,13 @@ struct ForcedMinvalUnsigned16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(MinvalUnsigned16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(
           ctx, 128, mlir::IntegerType::SignednessSemantics::Unsigned);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -172,10 +188,12 @@ using ForcedMinlocUnsigned16 = mkRTKey(MinlocUnsigned16);
 struct ForcedNorm2Real10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Norm2_10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy}, {ty});
@@ -187,10 +205,12 @@ struct ForcedNorm2Real10 {
 struct ForcedNorm2Real16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Norm2_16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy}, {ty});
@@ -202,9 +222,11 @@ struct ForcedNorm2Real16 {
 struct ForcedNorm2DimReal16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(Norm2DimReal16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(
@@ -218,10 +240,12 @@ struct ForcedNorm2DimReal16 {
 struct ForcedProductReal10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(ProductReal10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -234,10 +258,12 @@ struct ForcedProductReal10 {
 struct ForcedProductReal16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(ProductReal16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -251,10 +277,12 @@ struct ForcedProductInteger16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ProductInteger16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -268,11 +296,13 @@ struct ForcedProductUnsigned16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ProductUnsigned16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(
           ctx, 128, mlir::IntegerType::SignednessSemantics::Unsigned);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -286,10 +316,12 @@ struct ForcedProductComplex10 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppProductComplex10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float80Type::get(ctx));
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       auto resTy = fir::ReferenceType::get(ty);
@@ -304,10 +336,12 @@ struct ForcedProductComplex16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppProductComplex16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float128Type::get(ctx));
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       auto resTy = fir::ReferenceType::get(ty);
@@ -322,10 +356,12 @@ struct ForcedDotProductReal10 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(DotProductReal10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, boxTy, strTy, intTy}, {ty});
@@ -338,10 +374,12 @@ struct ForcedDotProductReal16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(DotProductReal16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, boxTy, strTy, intTy}, {ty});
@@ -354,10 +392,12 @@ struct ForcedDotProductComplex10 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppDotProductComplex10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float80Type::get(ctx));
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       auto resTy = fir::ReferenceType::get(ty);
@@ -372,10 +412,12 @@ struct ForcedDotProductComplex16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppDotProductComplex16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float128Type::get(ctx));
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       auto resTy = fir::ReferenceType::get(ty);
@@ -390,10 +432,12 @@ struct ForcedDotProductInteger16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(DotProductInteger16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, boxTy, strTy, intTy}, {ty});
@@ -406,11 +450,13 @@ struct ForcedDotProductUnsigned16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(DotProductUnsigned16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(
           ctx, 128, mlir::IntegerType::SignednessSemantics::Unsigned);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, boxTy, strTy, intTy}, {ty});
@@ -422,10 +468,12 @@ struct ForcedDotProductUnsigned16 {
 struct ForcedSumReal10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(SumReal10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -438,10 +486,12 @@ struct ForcedSumReal10 {
 struct ForcedSumReal16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(SumReal16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -454,10 +504,12 @@ struct ForcedSumReal16 {
 struct ForcedSumInteger16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(SumInteger16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -470,11 +522,13 @@ struct ForcedSumInteger16 {
 struct ForcedSumUnsigned16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(SumUnsigned16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(
           ctx, 128, mlir::IntegerType::SignednessSemantics::Unsigned);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -488,10 +542,12 @@ struct ForcedSumComplex10 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppSumComplex10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float80Type::get(ctx));
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       auto resTy = fir::ReferenceType::get(ty);
@@ -506,10 +562,12 @@ struct ForcedSumComplex16 {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppSumComplex16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float128Type::get(ctx));
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       auto resTy = fir::ReferenceType::get(ty);
@@ -523,10 +581,12 @@ struct ForcedSumComplex16 {
 struct ForcedIAll16 {
   static constexpr const char *name = EXPAND_AND_QUOTE_KEY(IAll16);
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -539,10 +599,12 @@ struct ForcedIAll16 {
 struct ForcedIAny16 {
   static constexpr const char *name = EXPAND_AND_QUOTE_KEY(IAny16);
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -555,10 +617,12 @@ struct ForcedIAny16 {
 struct ForcedIParity16 {
   static constexpr const char *name = EXPAND_AND_QUOTE_KEY(IParity16);
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 8 * sizeof(int));
       return mlir::FunctionType::get(ctx, {boxTy, strTy, intTy, intTy, boxTy},
@@ -572,10 +636,12 @@ struct ForcedReduceReal10Ref {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceReal10Ref));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {refTy, refTy}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -592,10 +658,12 @@ struct ForcedReduceReal10Value {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceReal10Value));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {ty, ty}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -612,10 +680,12 @@ struct ForcedReduceReal16Ref {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceReal16Ref));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {refTy, refTy}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -632,10 +702,12 @@ struct ForcedReduceReal16Value {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceReal16Value));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {ty, ty}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -652,10 +724,12 @@ struct ForcedReduceReal10DimRef {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceReal10DimRef));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {refTy, refTy}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -674,10 +748,12 @@ struct ForcedReduceReal10DimValue {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceReal10DimValue));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {ty, ty}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -696,10 +772,12 @@ struct ForcedReduceReal16DimRef {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceReal16DimRef));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {refTy, refTy}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -718,10 +796,12 @@ struct ForcedReduceReal16DimValue {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceReal16DimValue));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {ty, ty}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -740,10 +820,12 @@ struct ForcedReduceInteger16Ref {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceInteger16Ref));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {refTy, refTy}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -760,10 +842,12 @@ struct ForcedReduceUnsigned16Ref {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceUnsigned16Ref));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {refTy, refTy}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -780,10 +864,12 @@ struct ForcedReduceInteger16Value {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceInteger16Value));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {ty, ty}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -800,10 +886,12 @@ struct ForcedReduceUnsigned16Value {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceUnsigned16Value));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {ty, ty}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -820,10 +908,12 @@ struct ForcedReduceInteger16DimRef {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceInteger16DimRef));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {refTy, refTy}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -842,11 +932,13 @@ struct ForcedReduceUnsigned16DimRef {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceUnsigned16DimRef));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(
           ctx, 128, mlir::IntegerType::SignednessSemantics::Unsigned);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {refTy, refTy}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -865,10 +957,12 @@ struct ForcedReduceInteger16DimValue {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceInteger16DimValue));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(ctx, 128);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {ty, ty}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -887,11 +981,13 @@ struct ForcedReduceUnsigned16DimValue {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(ReduceUnsigned16DimValue));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::IntegerType::get(
           ctx, 128, mlir::IntegerType::SignednessSemantics::Unsigned);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {ty, ty}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -910,10 +1006,12 @@ struct ForcedReduceComplex10Ref {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppReduceComplex10Ref));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float80Type::get(ctx));
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {refTy, refTy}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -931,10 +1029,12 @@ struct ForcedReduceComplex10Value {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppReduceComplex10Value));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float80Type::get(ctx));
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {ty, ty}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -952,10 +1052,12 @@ struct ForcedReduceComplex10DimRef {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppReduceComplex10DimRef));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float80Type::get(ctx));
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {refTy, refTy}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -974,10 +1076,12 @@ struct ForcedReduceComplex10DimValue {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppReduceComplex10DimValue));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float80Type::get(ctx));
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {ty, ty}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -996,10 +1100,12 @@ struct ForcedReduceComplex16Ref {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppReduceComplex16Ref));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float128Type::get(ctx));
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {refTy, refTy}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -1017,10 +1123,12 @@ struct ForcedReduceComplex16Value {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppReduceComplex16Value));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float128Type::get(ctx));
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {ty, ty}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -1038,10 +1146,12 @@ struct ForcedReduceComplex16DimRef {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppReduceComplex16DimRef));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float128Type::get(ctx));
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {refTy, refTy}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
@@ -1060,10 +1170,12 @@ struct ForcedReduceComplex16DimValue {
   static constexpr const char *name =
       ExpandAndQuoteKey(RTNAME(CppReduceComplex16DimValue));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::ComplexType::get(mlir::Float128Type::get(ctx));
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
       auto refTy = fir::ReferenceType::get(ty);
       auto opTy = mlir::FunctionType::get(ctx, {ty, ty}, refTy);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));

--- a/flang/lib/Optimizer/Builder/Runtime/Support.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Support.cpp
@@ -17,9 +17,9 @@ using namespace Fortran::runtime;
 template <>
 constexpr fir::runtime::TypeBuilderFunc
 fir::runtime::getModel<Fortran::runtime::LowerBoundModifier>() {
-  return [](mlir::MLIRContext *context) -> mlir::Type {
+  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::IntegerType::get(
-        context, sizeof(Fortran::runtime::LowerBoundModifier) * 8);
+        builder.getContext(), sizeof(Fortran::runtime::LowerBoundModifier) * 8);
   };
 }
 

--- a/flang/lib/Optimizer/Builder/Runtime/Support.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Support.cpp
@@ -17,7 +17,7 @@ using namespace Fortran::runtime;
 template <>
 constexpr fir::runtime::TypeBuilderFunc
 fir::runtime::getModel<Fortran::runtime::LowerBoundModifier>() {
-  return [](const fir::FirOpBuilder &builder) -> mlir::Type {
+  return [](fir::FirOpBuilder &builder) -> mlir::Type {
     return mlir::IntegerType::get(
         builder.getContext(), sizeof(Fortran::runtime::LowerBoundModifier) * 8);
   };

--- a/flang/lib/Optimizer/Builder/Runtime/Transformational.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Transformational.cpp
@@ -24,7 +24,7 @@ using namespace Fortran::runtime;
 struct ForcedBesselJn_10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(BesselJn_10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
@@ -41,7 +41,7 @@ struct ForcedBesselJn_10 {
 struct ForcedBesselJn_16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(BesselJn_16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
@@ -58,7 +58,7 @@ struct ForcedBesselJn_16 {
 struct ForcedBesselJnX0_10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(BesselJnX0_10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto boxTy =
           fir::runtime::getModel<Fortran::runtime::Descriptor &>()(builder);
@@ -74,7 +74,7 @@ struct ForcedBesselJnX0_10 {
 struct ForcedBesselJnX0_16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(BesselJnX0_16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto boxTy =
           fir::runtime::getModel<Fortran::runtime::Descriptor &>()(builder);
@@ -90,7 +90,7 @@ struct ForcedBesselJnX0_16 {
 struct ForcedBesselYn_10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(BesselYn_10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
@@ -107,7 +107,7 @@ struct ForcedBesselYn_10 {
 struct ForcedBesselYn_16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(BesselYn_16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
@@ -124,7 +124,7 @@ struct ForcedBesselYn_16 {
 struct ForcedBesselYnX0_10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(BesselYnX0_10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto boxTy =
           fir::runtime::getModel<Fortran::runtime::Descriptor &>()(builder);
@@ -140,7 +140,7 @@ struct ForcedBesselYnX0_10 {
 struct ForcedBesselYnX0_16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(BesselYnX0_16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto boxTy =
           fir::runtime::getModel<Fortran::runtime::Descriptor &>()(builder);
@@ -332,7 +332,7 @@ void fir::runtime::genEoshiftVector(fir::FirOpBuilder &builder,
 /// Define ForcedMatmul<ACAT><AKIND><BCAT><BKIND> models.
 struct ForcedMatmulTypeModel {
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](const fir::FirOpBuilder &builder) {
+    return [](fir::FirOpBuilder &builder) {
       auto ctx = builder.getContext();
       auto boxRefTy =
           fir::runtime::getModel<Fortran::runtime::Descriptor &>()(builder);

--- a/flang/lib/Optimizer/Builder/Runtime/Transformational.cpp
+++ b/flang/lib/Optimizer/Builder/Runtime/Transformational.cpp
@@ -24,10 +24,11 @@ using namespace Fortran::runtime;
 struct ForcedBesselJn_10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(BesselJn_10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 32);
       return mlir::FunctionType::get(
@@ -40,10 +41,11 @@ struct ForcedBesselJn_10 {
 struct ForcedBesselJn_16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(BesselJn_16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 32);
       return mlir::FunctionType::get(
@@ -56,9 +58,10 @@ struct ForcedBesselJn_16 {
 struct ForcedBesselJnX0_10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(BesselJnX0_10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto boxTy =
-          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 32);
       return mlir::FunctionType::get(ctx, {boxTy, intTy, intTy, strTy, intTy},
@@ -71,9 +74,10 @@ struct ForcedBesselJnX0_10 {
 struct ForcedBesselJnX0_16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(BesselJnX0_16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto boxTy =
-          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 32);
       return mlir::FunctionType::get(ctx, {boxTy, intTy, intTy, strTy, intTy},
@@ -86,10 +90,11 @@ struct ForcedBesselJnX0_16 {
 struct ForcedBesselYn_10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(BesselYn_10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float80Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 32);
       return mlir::FunctionType::get(
@@ -102,10 +107,11 @@ struct ForcedBesselYn_10 {
 struct ForcedBesselYn_16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(BesselYn_16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto ty = mlir::Float128Type::get(ctx);
       auto boxTy =
-          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 32);
       return mlir::FunctionType::get(
@@ -118,9 +124,10 @@ struct ForcedBesselYn_16 {
 struct ForcedBesselYnX0_10 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(BesselYnX0_10));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto boxTy =
-          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 32);
       return mlir::FunctionType::get(ctx, {boxTy, intTy, intTy, strTy, intTy},
@@ -133,9 +140,10 @@ struct ForcedBesselYnX0_10 {
 struct ForcedBesselYnX0_16 {
   static constexpr const char *name = ExpandAndQuoteKey(RTNAME(BesselYnX0_16));
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto boxTy =
-          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(builder);
       auto strTy = fir::ReferenceType::get(mlir::IntegerType::get(ctx, 8));
       auto intTy = mlir::IntegerType::get(ctx, 32);
       return mlir::FunctionType::get(ctx, {boxTy, intTy, intTy, strTy, intTy},
@@ -324,13 +332,15 @@ void fir::runtime::genEoshiftVector(fir::FirOpBuilder &builder,
 /// Define ForcedMatmul<ACAT><AKIND><BCAT><BKIND> models.
 struct ForcedMatmulTypeModel {
   static constexpr fir::runtime::FuncTypeBuilderFunc getTypeModel() {
-    return [](mlir::MLIRContext *ctx) {
+    return [](const fir::FirOpBuilder &builder) {
+      auto ctx = builder.getContext();
       auto boxRefTy =
-          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(ctx);
+          fir::runtime::getModel<Fortran::runtime::Descriptor &>()(builder);
       auto boxTy =
-          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(ctx);
-      auto strTy = fir::runtime::getModel<const char *>()(ctx);
-      auto intTy = fir::runtime::getModel<int>()(ctx);
+          fir::runtime::getModel<const Fortran::runtime::Descriptor &>()(
+              builder);
+      auto strTy = fir::runtime::getModel<const char *>()(builder);
+      auto intTy = fir::runtime::getModel<int>()(builder);
       return mlir::FunctionType::get(
           ctx, {boxRefTy, boxTy, boxTy, strTy, intTy}, {});
     };

--- a/flang/lib/Optimizer/CodeGen/Target.cpp
+++ b/flang/lib/Optimizer/CodeGen/Target.cpp
@@ -1816,6 +1816,44 @@ struct TargetLoongArch64 : public GenericTarget<TargetLoongArch64> {
 };
 } // namespace
 
+//===----------------------------------------------------------------------===//
+// WebAssembly (wasm32) target specifics.
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct TargetWasm32 : public GenericTarget<TargetWasm32> {
+  using GenericTarget::GenericTarget;
+
+  static constexpr int defaultWidth = 32;
+
+  CodeGenSpecifics::Marshalling
+  complexArgumentType(mlir::Location, mlir::Type eleTy) const override {
+    assert(fir::isa_real(eleTy));
+    CodeGenSpecifics::Marshalling marshal;
+    // Use a type that will be translated into LLVM as:
+    // { t, t }   struct of 2 eleTy, byval, align 4
+    auto structTy =
+        mlir::TupleType::get(eleTy.getContext(), mlir::TypeRange{eleTy, eleTy});
+    marshal.emplace_back(fir::ReferenceType::get(structTy),
+                         AT{/*alignment=*/4, /*byval=*/true});
+    return marshal;
+  }
+
+  CodeGenSpecifics::Marshalling
+  complexReturnType(mlir::Location loc, mlir::Type eleTy) const override {
+    assert(fir::isa_real(eleTy));
+    CodeGenSpecifics::Marshalling marshal;
+    // Use a type that will be translated into LLVM as:
+    // { t, t }   struct of 2 eleTy, sret, align 4
+    auto structTy = mlir::TupleType::get(eleTy.getContext(),
+                                          mlir::TypeRange{eleTy, eleTy});
+    marshal.emplace_back(fir::ReferenceType::get(structTy),
+                          AT{/*alignment=*/4, /*byval=*/false, /*sret=*/true});
+    return marshal;
+  }
+};
+} // namespace
+
 // Instantiate the overloaded target instance based on the triple value.
 // TODO: Add other targets to this file as needed.
 std::unique_ptr<fir::CodeGenSpecifics>
@@ -1870,6 +1908,9 @@ fir::CodeGenSpecifics::get(mlir::MLIRContext *ctx, llvm::Triple &&trp,
         ctx, std::move(trp), std::move(kindMap), targetCPU, targetFeatures, dl);
   case llvm::Triple::ArchType::loongarch64:
     return std::make_unique<TargetLoongArch64>(
+        ctx, std::move(trp), std::move(kindMap), targetCPU, targetFeatures, dl);
+  case llvm::Triple::ArchType::wasm32:
+    return std::make_unique<TargetWasm32>(
         ctx, std::move(trp), std::move(kindMap), targetCPU, targetFeatures, dl);
   }
   TODO(mlir::UnknownLoc::get(ctx), "target not implemented");


### PR DESCRIPTION
Previous PR: #129308

Changes: I added `REQUIRES: x86-registered-target` to the newly-added test so that it won't break the other buildbots.