### PR TITLE
[Driver][XCore][NFC] Remove redundant setting of IsIntegratedAssemblerDefault

### DIFF
--- a/clang/lib/Driver/ToolChains/XCore.h
+++ b/clang/lib/Driver/ToolChains/XCore.h
@@ -57,7 +57,6 @@ protected:
   Tool *buildLinker() const override;
 
 public:
-  bool IsIntegratedAssemblerDefault() const override { return false; }
   bool isPICDefault() const override;
   bool isPIEDefault(const llvm::opt::ArgList &Args) const override;
   bool isPICDefaultForced() const override;


### PR DESCRIPTION
IsIntegratedAssemblerDefault is already set in
Generic_GCC::IsIntegratedAssemblerDefault