### PR TITLE
[Flang-RT] Environment introspection for quadmath.h

### DIFF
--- a/flang-rt/CMakeLists.txt
+++ b/flang-rt/CMakeLists.txt
@@ -252,6 +252,49 @@ set(HAVE_BACKTRACE ${Backtrace_FOUND})
 set(BACKTRACE_HEADER ${Backtrace_HEADER})
 
 
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  if (NOT DEFINED FLANG_RT_GCC_RESOURCE_DIR)
+    set(FLANG_RT_GCC_RESOURCE_DIR "FLANG_RT_GCC_RESOURCE_DIR-NOTFOUND")
+    execute_process(
+      COMMAND "${CMAKE_CXX_COMPILER}" -v -c "${FLANG_RT_SOURCE_DIR}/cmake/clang_gcc_root.cpp" ${CMAKE_CXX_FLAGS} -###
+      ERROR_FILE "${CMAKE_CURRENT_BINARY_DIR}/clang_gcc_root_result"
+    )
+    file(STRINGS "${CMAKE_CURRENT_BINARY_DIR}/clang_gcc_root_result" _errorresult)
+    foreach (_line IN LISTS _errorresult)
+      string(REGEX MATCH
+        "^Selected GCC installation: (.+)$"
+        _match
+        "${_line}")
+      if (CMAKE_MATCH_1)
+        set(FLANG_RT_GCC_RESOURCE_DIR "${CMAKE_MATCH_1}")
+        message(STATUS "Found GCC installation selected by Clang: ${FLANG_RT_GCC_RESOURCE_DIR}")
+        break()
+      endif ()
+    endforeach ()
+    set(FLANG_RT_GCC_RESOURCE_DIR "${FLANG_RT_GCC_RESOURCE_DIR}" CACHE INTERNAL "Path to GCC's resource dir selected by Clang" FORCE)
+  endif ()
+endif ()
+
+
+check_include_file("quadmath.h" FOUND_QUADMATH_H)
+if (FOUND_QUADMATH_H)
+  message(STATUS "quadmath.h found without additional include paths")
+  set(FLANG_RT_INCLUDE_QUADMATH_H "<quadmath.h>")
+elseif (FLANG_RT_GCC_RESOURCE_DIR)
+  cmake_push_check_state()
+    list(APPEND CMAKE_REQUIRED_INCLUDES "${FLANG_RT_GCC_RESOURCE_DIR}/include")
+    check_include_file("quadmath.h" FOUND_GCC_QUADMATH_H)
+  cmake_pop_check_state()
+  if (FOUND_GCC_QUADMATH_H)
+    message(STATUS "quadmath.h found in Clang's selected GCC installation")
+    set(FLANG_RT_INCLUDE_QUADMATH_H "\"${FLANG_RT_GCC_RESOURCE_DIR}/include/quadmath.h\"")
+  endif ()
+endif ()
+
+
+
+
 #####################
 # Build Preparation #
 #####################
@@ -273,7 +316,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 
 configure_file(cmake/config.h.cmake.in config.h)
-
+if (FLANG_RT_INCLUDE_QUADMATH_H)
+  configure_file("cmake/quadmath_wrapper.h.in" "${FLANG_RT_BINARY_DIR}/quadmath_wrapper.h")
+endif ()
 
 # The bootstrap build will create a phony target with the same as the top-level
 # directory ("flang-rt") and delegate it to the runtimes build dir.

--- a/flang-rt/CMakeLists.txt
+++ b/flang-rt/CMakeLists.txt
@@ -252,7 +252,6 @@ set(HAVE_BACKTRACE ${Backtrace_FOUND})
 set(BACKTRACE_HEADER ${Backtrace_HEADER})
 
 
-
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   if (NOT DEFINED FLANG_RT_GCC_RESOURCE_DIR)
     set(FLANG_RT_GCC_RESOURCE_DIR "FLANG_RT_GCC_RESOURCE_DIR-NOTFOUND")
@@ -276,7 +275,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   endif ()
 endif ()
 
-
 check_include_file("quadmath.h" FOUND_QUADMATH_H)
 if (FOUND_QUADMATH_H)
   message(STATUS "quadmath.h found without additional include paths")
@@ -291,7 +289,6 @@ elseif (FLANG_RT_GCC_RESOURCE_DIR)
     set(FLANG_RT_INCLUDE_QUADMATH_H "\"${FLANG_RT_GCC_RESOURCE_DIR}/include/quadmath.h\"")
   endif ()
 endif ()
-
 
 
 

--- a/flang-rt/cmake/clang_gcc_root.cpp
+++ b/flang-rt/cmake/clang_gcc_root.cpp
@@ -1,3 +1,1 @@
-int main() {
-  return 0;
-}
+int main() { return 0; }

--- a/flang-rt/cmake/clang_gcc_root.cpp
+++ b/flang-rt/cmake/clang_gcc_root.cpp
@@ -1,0 +1,3 @@
+int main() {
+  return 0;
+}

--- a/flang-rt/cmake/quadmath_wrapper.h.in
+++ b/flang-rt/cmake/quadmath_wrapper.h.in
@@ -1,0 +1,9 @@
+/*===-- cmake/quadmath_wrapper.h.in ---------------------=-----------*- C -*-===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===----------------------------------------------------------------------===*/
+
+#include ${FLANG_RT_INCLUDE_QUADMATH_H}

--- a/flang-rt/lib/quadmath/CMakeLists.txt
+++ b/flang-rt/lib/quadmath/CMakeLists.txt
@@ -78,8 +78,7 @@ target_include_directories(FortranFloat128MathILib INTERFACE
 
 if (FLANG_RUNTIME_F128_MATH_LIB)
   if (${FLANG_RUNTIME_F128_MATH_LIB} STREQUAL "libquadmath")
-    check_include_file(quadmath.h FOUND_QUADMATH_HEADER)
-    if(FOUND_QUADMATH_HEADER)
+    if(FLANG_RT_INCLUDE_QUADMATH_H)
       add_compile_definitions(HAS_QUADMATHLIB)
     else()
       message(FATAL_ERROR

--- a/flang-rt/lib/quadmath/complex-math.h
+++ b/flang-rt/lib/quadmath/complex-math.h
@@ -13,7 +13,7 @@
 #include "flang/Runtime/entry-names.h"
 
 #if HAS_QUADMATHLIB
-#include "quadmath.h"
+#include "quadmath_wrapper.h"
 #define CAbs(x) cabsq(x)
 #define CAcos(x) cacosq(x)
 #define CAcosh(x) cacoshq(x)

--- a/flang-rt/lib/quadmath/math-entries.h
+++ b/flang-rt/lib/quadmath/math-entries.h
@@ -112,7 +112,7 @@ DEFINE_FALLBACK_F128(Yn)
 
 #if HAS_QUADMATHLIB
 // Define wrapper callers for libquadmath.
-#include "quadmath.h"
+#include "quadmath_wrapper.h"
 DEFINE_SIMPLE_ALIAS(Abs, fabsq)
 DEFINE_SIMPLE_ALIAS(Acos, acosq)
 DEFINE_SIMPLE_ALIAS(Acosh, acoshq)


### PR DESCRIPTION
When compiling Flang-RT with Clang, query Clang for the GCC installation it uses. If found, create `quadmath_wrapper.h` that points to the `quadmath.h` of that GCC installation.

`quadmath.h` is only available when compiling with gcc, and Clang has no equivalent even though gcc's version compiles fine with Clang (at least up to and including gcc 13). It is still available in gcc's installation resource dir (in constrast to a system-wide directory such as `/usr/include` or `/usr/local/include`) and therefore not available to any compiler other than the gcc of that installation. quadmath may also be a different OS package than gcc itself, so it is not necessarily presesent.
 
Clang actually already appropriates a GCC installation for its libraries such that `libquadmath.a` is already found, but it does not do so for the include paths. Because adding that directory to the header search path may have wide-reaching consquences, we create only a wrapper header that points to the real `quadmath.h` in the same GCC installation that Clang uses.