### PR TITLE
[clang][bytecode] Implement __builtin_{memchr,strchr,char_memchr}

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -1960,11 +1960,101 @@ static bool interp__builtin_memcmp(InterpState &S, CodePtr OpPC,
 
   // However, if we read all the available bytes but were instructed to read
   // even more, diagnose this as a "read of dereferenced one-past-the-end
-  // pointer". This is what would happen if we called CheckRead() on every array
+  // pointer". This is what would happen if we called CheckLoad() on every array
   // element.
   S.FFDiag(S.Current->getSource(OpPC), diag::note_constexpr_access_past_end)
       << AK_Read << S.Current->getRange(OpPC);
   return false;
+}
+
+static bool interp__builtin_memchr(InterpState &S, CodePtr OpPC,
+                                   const InterpFrame *Frame,
+                                   const Function *Func, const CallExpr *Call) {
+  unsigned ID = Func->getBuiltinID();
+  if (ID == Builtin::BImemchr || ID == Builtin::BIwcschr ||
+      ID == Builtin::BIstrchr || ID == Builtin::BIwmemchr)
+    diagnoseNonConstexprBuiltin(S, OpPC, ID);
+
+  const Pointer &Ptr = getParam<Pointer>(Frame, 0);
+  APSInt Desired;
+  std::optional<APSInt> MaxLength;
+  if (Call->getNumArgs() == 3) {
+    MaxLength =
+        peekToAPSInt(S.Stk, *S.getContext().classify(Call->getArg(2)), 0);
+    Desired = peekToAPSInt(
+        S.Stk, *S.getContext().classify(Call->getArg(1)),
+        align(primSize(*S.getContext().classify(Call->getArg(2)))) +
+            align(primSize(*S.getContext().classify(Call->getArg(1)))));
+  } else {
+    Desired = peekToAPSInt(S.Stk, *S.getContext().classify(Call->getArg(1)));
+  }
+
+  if (MaxLength && MaxLength->isZero()) {
+    S.Stk.push<Pointer>();
+    return true;
+  }
+
+  if (Ptr.isDummy())
+    return false;
+
+  // Null is only okay if the given size is 0.
+  if (Ptr.isZero()) {
+    S.FFDiag(S.Current->getSource(OpPC), diag::note_constexpr_access_null)
+        << AK_Read;
+    return false;
+  }
+
+  QualType ElemTy = Ptr.getFieldDesc()->isArray()
+                        ? Ptr.getFieldDesc()->getElemQualType()
+                        : Ptr.getFieldDesc()->getType();
+  bool IsRawByte = ID == Builtin::BImemchr || ID == Builtin::BI__builtin_memchr;
+
+  // Give up on byte-oriented matching against multibyte elements.
+  if (IsRawByte && !isOneByteCharacterType(ElemTy)) {
+    S.FFDiag(S.Current->getSource(OpPC),
+             diag::note_constexpr_memchr_unsupported)
+        << S.getASTContext().BuiltinInfo.getQuotedName(ID) << ElemTy;
+    return false;
+  }
+
+  if (ID == Builtin::BIstrchr || ID == Builtin::BI__builtin_strchr) {
+    // strchr compares directly to the passed integer, and therefore
+    // always fails if given an int that is not a char.
+    if (Desired !=
+        Desired.trunc(S.getASTContext().getCharWidth()).getSExtValue()) {
+      S.Stk.push<Pointer>();
+      return true;
+    }
+  }
+
+  uint64_t DesiredVal =
+      Desired.trunc(S.getASTContext().getCharWidth()).getZExtValue();
+  bool StopAtZero =
+      (ID == Builtin::BIstrchr || ID == Builtin::BI__builtin_strchr);
+
+  size_t Index = Ptr.getIndex();
+  for (;;) {
+    const Pointer &ElemPtr = Index > 0 ? Ptr.atIndex(Index) : Ptr;
+
+    if (!CheckLoad(S, OpPC, ElemPtr))
+      return false;
+
+    unsigned char V = static_cast<unsigned char>(ElemPtr.deref<char>());
+    if (V == DesiredVal) {
+      S.Stk.push<Pointer>(ElemPtr);
+      return true;
+    }
+
+    if (StopAtZero && V == 0)
+      break;
+
+    ++Index;
+    if (MaxLength && Index == MaxLength->getZExtValue())
+      break;
+  }
+
+  S.Stk.push<Pointer>();
+  return true;
 }
 
 bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const Function *F,
@@ -2442,6 +2532,21 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const Function *F,
   case Builtin::BI__builtin_wmemcmp:
   case Builtin::BIwmemcmp:
     if (!interp__builtin_memcmp(S, OpPC, Frame, F, Call))
+      return false;
+    break;
+
+  case Builtin::BImemchr:
+  case Builtin::BI__builtin_memchr:
+  case Builtin::BIstrchr:
+  case Builtin::BI__builtin_strchr:
+#if 0
+  case Builtin::BIwcschr:
+  case Builtin::BI__builtin_wcschr:
+  case Builtin::BImemchr:
+  case Builtin::BI__builtin_wmemchr:
+#endif
+  case Builtin::BI__builtin_char_memchr:
+    if (!interp__builtin_memchr(S, OpPC, Frame, F, Call))
       return false;
     break;
 


### PR DESCRIPTION
llvm has recently started to use `__builitn_memchr` at compile time, so implement this. Still needs some work but the basics are done.