### PR TITLE
[libc++][NFC] Comment cleanup for `<type_traits>`

### DIFF
--- a/libcxx/include/type_traits
+++ b/libcxx/include/type_traits
@@ -18,13 +18,11 @@ namespace std
 
     // helper class:
     template <class T, T v> struct integral_constant;
-    typedef integral_constant<bool, true>  true_type;   // C++11
-    typedef integral_constant<bool, false> false_type;  // C++11
+    typedef integral_constant<bool, true>  true_type;           // since C++11
+    typedef integral_constant<bool, false> false_type;          // since C++11
 
-    template <bool B>                                   // C++14
-    using bool_constant = integral_constant<bool, B>;   // C++14
-    typedef bool_constant<true> true_type;              // C++14
-    typedef bool_constant<false> false_type;            // C++14
+    template <bool B>
+    using bool_constant = integral_constant<bool, B>;           // since C++17
 
     // helper traits
     template <bool, class T = void> struct enable_if;
@@ -32,7 +30,7 @@ namespace std
 
     // Primary classification traits:
     template <class T> struct is_void;
-    template <class T> struct is_null_pointer;  // C++14
+    template <class T> struct is_null_pointer;                  // since C++14
     template <class T> struct is_integral;
     template <class T> struct is_floating_point;
     template <class T> struct is_array;
@@ -51,7 +49,7 @@ namespace std
     template <class T> struct is_arithmetic;
     template <class T> struct is_fundamental;
     template <class T> struct is_member_pointer;
-    template <class T> struct is_scoped_enum; // C++23
+    template <class T> struct is_scoped_enum;                   // since C++23
     template <class T> struct is_scalar;
     template <class T> struct is_object;
     template <class T> struct is_compound;
@@ -75,9 +73,9 @@ namespace std
     template <class T> struct remove_pointer;
     template <class T> struct add_pointer;
 
-    template<class T> struct type_identity;                     // C++20
+    template<class T> struct type_identity;                     // since C++20
     template<class T>
-      using type_identity_t = typename type_identity<T>::type;  // C++20
+      using type_identity_t = typename type_identity<T>::type;  // since C++20
 
     // Integral properties:
     template <class T> struct is_signed;
@@ -91,20 +89,20 @@ namespace std
     template <class T> struct remove_extent;
     template <class T> struct remove_all_extents;
 
-    template <class T> struct is_bounded_array;                 // C++20
-    template <class T> struct is_unbounded_array;               // C++20
+    template <class T> struct is_bounded_array;                 // since C++20
+    template <class T> struct is_unbounded_array;               // since C++20
 
     // Member introspection:
     template <class T> struct is_trivial;
-    template <class T> struct is_pod;          // Deprecated in C++20
+    template <class T> struct is_pod;                           // deprecated in C++20
     template <class T> struct is_trivially_copyable;
     template <class T> struct is_standard_layout;
-    template <class T> struct is_literal_type; // Deprecated in C++17; removed in C++20
+    template <class T> struct is_literal_type;                  // deprecated in C++17; removed in C++20
     template <class T> struct is_empty;
     template <class T> struct is_polymorphic;
     template <class T> struct is_abstract;
-    template <class T> struct is_final; // C++14
-    template <class T> struct is_aggregate; // C++17
+    template <class T> struct is_final;                         // since C++14
+    template <class T> struct is_aggregate;                     // since C++17
 
     template <class T, class... Args> struct is_constructible;
     template <class T>                struct is_default_constructible;
@@ -113,8 +111,8 @@ namespace std
     template <class T, class U>       struct is_assignable;
     template <class T>                struct is_copy_assignable;
     template <class T>                struct is_move_assignable;
-    template <class T, class U>       struct is_swappable_with;       // C++17
-    template <class T>                struct is_swappable;            // C++17
+    template <class T, class U>       struct is_swappable_with; // since C++17
+    template <class T>                struct is_swappable;      // since C++17
     template <class T>                struct is_destructible;
 
     template <class T, class... Args> struct is_trivially_constructible;
@@ -133,301 +131,328 @@ namespace std
     template <class T, class U>       struct is_nothrow_assignable;
     template <class T>                struct is_nothrow_copy_assignable;
     template <class T>                struct is_nothrow_move_assignable;
-    template <class T, class U>       struct is_nothrow_swappable_with; // C++17
-    template <class T>                struct is_nothrow_swappable;      // C++17
+    template <class T, class U>
+      struct is_nothrow_swappable_with;                         // since C++17
+    template <class T>
+      struct is_nothrow_swappable;                              // since C++17
     template <class T>                struct is_nothrow_destructible;
 
-    template<class T> struct is_implicit_lifetime;                     // Since C++23
+    template <class T> struct is_implicit_lifetime;             // since C++23
 
     template <class T> struct has_virtual_destructor;
 
-    template<class T> struct has_unique_object_representations;         // C++17
+    template <class T>
+      struct has_unique_object_representations;                 // since C++17
 
-    template<class T, class U> struct reference_constructs_from_temporary; // Since C++23
-    template<class T, class U> struct reference_converts_from_temporary;   // Since C++23
+    template<class T, class U>
+      struct reference_constructs_from_temporary;               // since C++23
+    template<class T, class U>
+      struct reference_converts_from_temporary;                 // since C++23
 
     // Relationships between types:
     template <class T, class U> struct is_same;
     template <class Base, class Derived> struct is_base_of;
-    template <class Base, class Derived> struct is_virtual_base_of;     // C++26
+    template <class Base, class Derived>
+      struct is_virtual_base_of;                                // since C++26
 
     template <class From, class To> struct is_convertible;
-    template <typename From, typename To> struct is_nothrow_convertible;                  // C++20
-    template <typename From, typename To> inline constexpr bool is_nothrow_convertible_v; // C++20
+    template <class From, class To>
+      struct is_nothrow_convertible;                            // since C++20
 
-    template <class Fn, class... ArgTypes> struct is_invocable;
-    template <class R, class Fn, class... ArgTypes> struct is_invocable_r;
+    template <class Fn, class... ArgTypes> struct is_invocable; // since C++17
+    template <class R, class Fn, class... ArgTypes>
+      struct is_invocable_r;                                    // since C++17
 
-    template <class Fn, class... ArgTypes> struct is_nothrow_invocable;
-    template <class R, class Fn, class... ArgTypes> struct is_nothrow_invocable_r;
+    template <class Fn, class... ArgTypes>
+      struct is_nothrow_invocable;                              // since C++17
+    template <class R, class Fn, class... ArgTypes>
+      struct is_nothrow_invocable_r;                            // since C++17
 
     // Alignment properties and transformations:
     template <class T> struct alignment_of;
     template <size_t Len, size_t Align = most_stringent_alignment_requirement>
-        struct aligned_storage;                                 // deprecated in C++23
+      struct aligned_storage;                                   // deprecated in C++23
     template <size_t Len, class... Types> struct aligned_union; // deprecated in C++23
-    template <class T> struct remove_cvref; // C++20
+    template <class T> struct remove_cvref;                     // since C++20
 
     template <class T> struct decay;
     template <class... T> struct common_type;
     template <class T> struct underlying_type;
-    template <class> class result_of; // undefined; deprecated in C++17; removed in C++20
-    template <class Fn, class... ArgTypes> class result_of<Fn(ArgTypes...)>; // deprecated in C++17; removed in C++20
-    template <class Fn, class... ArgTypes> struct invoke_result;  // C++17
+    template <class> struct result_of;                          // undefined; deprecated in C++17; removed in C++20
+    template <class Fn, class... ArgTypes>
+      struct result_of<Fn(ArgTypes...)>;                        // deprecated in C++17; removed in C++20
+    template <class Fn, class... ArgTypes>
+      struct invoke_result;                                     // since C++17
 
     // const-volatile modifications:
     template <class T>
-      using remove_const_t    = typename remove_const<T>::type;  // C++14
+      using remove_const_t = typename remove_const<T>::type;    // since C++14
     template <class T>
-      using remove_volatile_t = typename remove_volatile<T>::type;  // C++14
+      using remove_volatile_t
+        = typename remove_volatile<T>::type;                    // since C++14
     template <class T>
-      using remove_cv_t       = typename remove_cv<T>::type;  // C++14
+      using remove_cv_t    = typename remove_cv<T>::type;       // since C++14
     template <class T>
-      using add_const_t       = typename add_const<T>::type;  // C++14
+      using add_const_t    = typename add_const<T>::type;       // since C++14
     template <class T>
-      using add_volatile_t    = typename add_volatile<T>::type;  // C++14
+      using add_volatile_t = typename add_volatile<T>::type;    // since C++14
     template <class T>
-      using add_cv_t          = typename add_cv<T>::type;  // C++14
+      using add_cv_t       = typename add_cv<T>::type;          // since C++14
 
     // reference modifications:
     template <class T>
-      using remove_reference_t     = typename remove_reference<T>::type;  // C++14
+      using remove_reference_t
+        = typename remove_reference<T>::type;                   // since C++14
     template <class T>
-      using add_lvalue_reference_t = typename add_lvalue_reference<T>::type;  // C++14
+      using add_lvalue_reference_t
+        = typename add_lvalue_reference<T>::type;               // since C++14
     template <class T>
-      using add_rvalue_reference_t = typename add_rvalue_reference<T>::type;  // C++14
+      using add_rvalue_reference_t
+        = typename add_rvalue_reference<T>::type;               // since C++14
 
     // sign modifications:
     template <class T>
-      using make_signed_t   = typename make_signed<T>::type;  // C++14
+      using make_signed_t   = typename make_signed<T>::type;    // since C++14
     template <class T>
-      using make_unsigned_t = typename make_unsigned<T>::type;  // C++14
+      using make_unsigned_t = typename make_unsigned<T>::type;  // since C++14
 
     // array modifications:
     template <class T>
-      using remove_extent_t      = typename remove_extent<T>::type;  // C++14
+      using remove_extent_t
+        = typename remove_extent<T>::type;                      // since C++14
     template <class T>
-      using remove_all_extents_t = typename remove_all_extents<T>::type;  // C++14
+      using remove_all_extents_t
+        = typename remove_all_extents<T>::type;                 // since C++14
 
     template <class T>
       inline constexpr bool is_bounded_array_v
-        = is_bounded_array<T>::value;                                     // C++20
+        = is_bounded_array<T>::value;                           // since C++20
       inline constexpr bool is_unbounded_array_v
-        = is_unbounded_array<T>::value;                                   // C++20
+        = is_unbounded_array<T>::value;                         // since C++20
 
     // pointer modifications:
     template <class T>
-      using remove_pointer_t = typename remove_pointer<T>::type;  // C++14
+      using remove_pointer_t
+        = typename remove_pointer<T>::type;                     // since C++14
     template <class T>
-      using add_pointer_t    = typename add_pointer<T>::type;  // C++14
+      using add_pointer_t = typename add_pointer<T>::type;      // since C++14
 
     // other transformations:
     template <size_t Len, size_t Align=default-alignment>
-      using aligned_storage_t = typename aligned_storage<Len,Align>::type;  // C++14
+      using aligned_storage_t
+        = typename aligned_storage<Len,Align>::type;            // since C++14
     template <size_t Len, class... Types>
-      using aligned_union_t   = typename aligned_union<Len,Types...>::type;  // C++14
+      using aligned_union_t
+        = typename aligned_union<Len,Types...>::type;           // since C++14
     template <class T>
-      using remove_cvref_t    = typename remove_cvref<T>::type;  // C++20
+      using remove_cvref_t
+        = typename remove_cvref<T>::type;                       // since C++20
     template <class T>
-      using decay_t           = typename decay<T>::type;  // C++14
+      using decay_t     = typename decay<T>::type;              // since C++14
     template <bool b, class T=void>
-      using enable_if_t       = typename enable_if<b,T>::type;  // C++14
+      using enable_if_t = typename enable_if<b,T>::type;        // since C++14
     template <bool b, class T, class F>
-      using conditional_t     = typename conditional<b,T,F>::type;  // C++14
+      using conditional_t
+        = typename conditional<b,T,F>::type;                    // since C++14
     template <class... T>
-      using common_type_t     = typename common_type<T...>::type;  // C++14
+      using common_type_t
+        = typename common_type<T...>::type;                     // since C++14
     template <class T>
-      using underlying_type_t = typename underlying_type<T>::type;  // C++14
+      using underlying_type_t
+        = typename underlying_type<T>::type;                    // since C++14
     template <class T>
-      using result_of_t       = typename result_of<T>::type;  // C++14; deprecated in C++17; removed in C++20
+      using result_of_t = typename result_of<T>::type;          // since C++14; deprecated in C++17; removed in C++20
     template <class Fn, class... ArgTypes>
-      using invoke_result_t   = typename invoke_result<Fn, ArgTypes...>::type;  // C++17
+      using invoke_result_t
+       = typename invoke_result<Fn, ArgTypes...>::type;         // since C++17
 
     template <class...>
-      using void_t = void;   // C++17
+      using void_t = void;                                      // since C++17
 
       // See C++14 20.10.4.1, primary type categories
       template <class T> inline constexpr bool is_void_v
-        = is_void<T>::value;                                             // C++17
+        = is_void<T>::value;                                    // since C++17
       template <class T> inline constexpr bool is_null_pointer_v
-        = is_null_pointer<T>::value;                                     // C++17
+        = is_null_pointer<T>::value;                            // since C++17
       template <class T> inline constexpr bool is_integral_v
-        = is_integral<T>::value;                                         // C++17
+        = is_integral<T>::value;                                // since C++17
       template <class T> inline constexpr bool is_floating_point_v
-        = is_floating_point<T>::value;                                   // C++17
+        = is_floating_point<T>::value;                          // since C++17
       template <class T> inline constexpr bool is_array_v
-        = is_array<T>::value;                                            // C++17
+        = is_array<T>::value;                                   // since C++17
       template <class T> inline constexpr bool is_pointer_v
-        = is_pointer<T>::value;                                          // C++17
+        = is_pointer<T>::value;                                 // since C++17
       template <class T> inline constexpr bool is_lvalue_reference_v
-        = is_lvalue_reference<T>::value;                                 // C++17
+        = is_lvalue_reference<T>::value;                        // since C++17
       template <class T> inline constexpr bool is_rvalue_reference_v
-        = is_rvalue_reference<T>::value;                                 // C++17
+        = is_rvalue_reference<T>::value;                        // since C++17
       template <class T> inline constexpr bool is_member_object_pointer_v
-        = is_member_object_pointer<T>::value;                            // C++17
+        = is_member_object_pointer<T>::value;                   // since C++17
       template <class T> inline constexpr bool is_member_function_pointer_v
-        = is_member_function_pointer<T>::value;                          // C++17
+        = is_member_function_pointer<T>::value;                 // since C++17
       template <class T> inline constexpr bool is_enum_v
-        = is_enum<T>::value;                                             // C++17
+        = is_enum<T>::value;                                    // since C++17
       template <class T> inline constexpr bool is_union_v
-        = is_union<T>::value;                                            // C++17
+        = is_union<T>::value;                                   // since C++17
       template <class T> inline constexpr bool is_class_v
-        = is_class<T>::value;                                            // C++17
+        = is_class<T>::value;                                   // since C++17
       template <class T> inline constexpr bool is_function_v
-        = is_function<T>::value;                                         // C++17
+        = is_function<T>::value;                                // since C++17
 
       // See C++14 20.10.4.2, composite type categories
       template <class T> inline constexpr bool is_reference_v
-        = is_reference<T>::value;                                        // C++17
+        = is_reference<T>::value;                               // since C++17
       template <class T> inline constexpr bool is_arithmetic_v
-        = is_arithmetic<T>::value;                                       // C++17
+        = is_arithmetic<T>::value;                              // since C++17
       template <class T> inline constexpr bool is_fundamental_v
-        = is_fundamental<T>::value;                                      // C++17
+        = is_fundamental<T>::value;                             // since C++17
       template <class T> inline constexpr bool is_object_v
-        = is_object<T>::value;                                           // C++17
+        = is_object<T>::value;                                  // since C++17
       template <class T> inline constexpr bool is_scalar_v
-        = is_scalar<T>::value;                                           // C++17
+        = is_scalar<T>::value;                                  // since C++17
       template <class T> inline constexpr bool is_compound_v
-        = is_compound<T>::value;                                         // C++17
+        = is_compound<T>::value;                                // since C++17
       template <class T> inline constexpr bool is_member_pointer_v
-        = is_member_pointer<T>::value;                                   // C++17
+        = is_member_pointer<T>::value;                          // since C++17
       template <class T> inline constexpr bool is_scoped_enum_v
-        = is_scoped_enum<T>::value;                                      // C++23
+        = is_scoped_enum<T>::value;                             // since C++23
 
       // See C++14 20.10.4.3, type properties
       template <class T> inline constexpr bool is_const_v
-        = is_const<T>::value;                                            // C++17
+        = is_const<T>::value;                                   // since C++17
       template <class T> inline constexpr bool is_volatile_v
-        = is_volatile<T>::value;                                         // C++17
+        = is_volatile<T>::value;                                // since C++17
       template <class T> inline constexpr bool is_trivial_v
-        = is_trivial<T>::value;                                          // C++17
+        = is_trivial<T>::value;                                 // since C++17
       template <class T> inline constexpr bool is_trivially_copyable_v
-        = is_trivially_copyable<T>::value;                               // C++17
+        = is_trivially_copyable<T>::value;                      // since C++17
       template <class T> inline constexpr bool is_standard_layout_v
-        = is_standard_layout<T>::value;                                  // C++17
+        = is_standard_layout<T>::value;                         // since C++17
       template <class T> inline constexpr bool is_pod_v
-        = is_pod<T>::value;                                              // C++17; deprecated in C++20
+        = is_pod<T>::value;                                     // since C++17; deprecated in C++20
       template <class T> inline constexpr bool is_literal_type_v
-        = is_literal_type<T>::value;                                     // C++17; deprecated in C++17; removed in C++20
+        = is_literal_type<T>::value;                            // since C++17; deprecated in C++17; removed in C++20
       template <class T> inline constexpr bool is_empty_v
-        = is_empty<T>::value;                                            // C++17
+        = is_empty<T>::value;                                   // since C++17
       template <class T> inline constexpr bool is_polymorphic_v
-        = is_polymorphic<T>::value;                                      // C++17
+        = is_polymorphic<T>::value;                             // since C++17
       template <class T> inline constexpr bool is_abstract_v
-        = is_abstract<T>::value;                                         // C++17
+        = is_abstract<T>::value;                                // since C++17
       template <class T> inline constexpr bool is_final_v
-        = is_final<T>::value;                                            // C++17
+        = is_final<T>::value;                                   // since C++17
       template <class T> inline constexpr bool is_aggregate_v
-        = is_aggregate<T>::value;                                        // C++17
+        = is_aggregate<T>::value;                               // since C++17
       template <class T> inline constexpr bool is_signed_v
-        = is_signed<T>::value;                                           // C++17
+        = is_signed<T>::value;                                  // since C++17
       template <class T> inline constexpr bool is_unsigned_v
-        = is_unsigned<T>::value;                                         // C++17
+        = is_unsigned<T>::value;                                // since C++17
       template <class T, class... Args> inline constexpr bool is_constructible_v
-        = is_constructible<T, Args...>::value;                           // C++17
+        = is_constructible<T, Args...>::value;                  // since C++17
       template <class T> inline constexpr bool is_default_constructible_v
-        = is_default_constructible<T>::value;                            // C++17
+        = is_default_constructible<T>::value;                   // since C++17
       template <class T> inline constexpr bool is_copy_constructible_v
-        = is_copy_constructible<T>::value;                               // C++17
+        = is_copy_constructible<T>::value;                      // since C++17
       template <class T> inline constexpr bool is_move_constructible_v
-        = is_move_constructible<T>::value;                               // C++17
+        = is_move_constructible<T>::value;                      // since C++17
       template <class T, class U> inline constexpr bool is_assignable_v
-        = is_assignable<T, U>::value;                                    // C++17
+        = is_assignable<T, U>::value;                           // since C++17
       template <class T> inline constexpr bool is_copy_assignable_v
-        = is_copy_assignable<T>::value;                                  // C++17
+        = is_copy_assignable<T>::value;                         // since C++17
       template <class T> inline constexpr bool is_move_assignable_v
-        = is_move_assignable<T>::value;                                  // C++17
+        = is_move_assignable<T>::value;                         // since C++17
       template <class T, class U> inline constexpr bool is_swappable_with_v
-        = is_swappable_with<T, U>::value;                                // C++17
+        = is_swappable_with<T, U>::value;                       // since C++17
       template <class T> inline constexpr bool is_swappable_v
-        = is_swappable<T>::value;                                        // C++17
+        = is_swappable<T>::value;                               // since C++17
       template <class T> inline constexpr bool is_destructible_v
-        = is_destructible<T>::value;                                     // C++17
+        = is_destructible<T>::value;                            // since C++17
       template <class T, class... Args> inline constexpr bool is_trivially_constructible_v
-        = is_trivially_constructible<T, Args...>::value;                 // C++17
+        = is_trivially_constructible<T, Args...>::value;        // since C++17
       template <class T> inline constexpr bool is_trivially_default_constructible_v
-        = is_trivially_default_constructible<T>::value;                  // C++17
+        = is_trivially_default_constructible<T>::value;         // since C++17
       template <class T> inline constexpr bool is_trivially_copy_constructible_v
-        = is_trivially_copy_constructible<T>::value;                     // C++17
+        = is_trivially_copy_constructible<T>::value;            // since C++17
       template <class T> inline constexpr bool is_trivially_move_constructible_v
-        = is_trivially_move_constructible<T>::value;                     // C++17
+        = is_trivially_move_constructible<T>::value;            // since C++17
       template <class T, class U> inline constexpr bool is_trivially_assignable_v
-        = is_trivially_assignable<T, U>::value;                          // C++17
+        = is_trivially_assignable<T, U>::value;                 // since C++17
       template <class T> inline constexpr bool is_trivially_copy_assignable_v
-        = is_trivially_copy_assignable<T>::value;                        // C++17
+        = is_trivially_copy_assignable<T>::value;               // since C++17
       template <class T> inline constexpr bool is_trivially_move_assignable_v
-        = is_trivially_move_assignable<T>::value;                        // C++17
+        = is_trivially_move_assignable<T>::value;               // since C++17
       template <class T> inline constexpr bool is_trivially_destructible_v
-        = is_trivially_destructible<T>::value;                           // C++17
+        = is_trivially_destructible<T>::value;                  // since C++17
       template <class T, class... Args> inline constexpr bool is_nothrow_constructible_v
-        = is_nothrow_constructible<T, Args...>::value;                   // C++17
+        = is_nothrow_constructible<T, Args...>::value;          // since C++17
       template <class T> inline constexpr bool is_nothrow_default_constructible_v
-        = is_nothrow_default_constructible<T>::value;                    // C++17
+        = is_nothrow_default_constructible<T>::value;           // since C++17
       template <class T> inline constexpr bool is_nothrow_copy_constructible_v
-        = is_nothrow_copy_constructible<T>::value;                       // C++17
+        = is_nothrow_copy_constructible<T>::value;              // since C++17
       template <class T> inline constexpr bool is_nothrow_move_constructible_v
-        = is_nothrow_move_constructible<T>::value;                       // C++17
+        = is_nothrow_move_constructible<T>::value;              // since C++17
       template <class T, class U> inline constexpr bool is_nothrow_assignable_v
-        = is_nothrow_assignable<T, U>::value;                            // C++17
+        = is_nothrow_assignable<T, U>::value;                   // since C++17
       template <class T> inline constexpr bool is_nothrow_copy_assignable_v
-        = is_nothrow_copy_assignable<T>::value;                          // C++17
+        = is_nothrow_copy_assignable<T>::value;                 // since C++17
       template <class T> inline constexpr bool is_nothrow_move_assignable_v
-        = is_nothrow_move_assignable<T>::value;                          // C++17
+        = is_nothrow_move_assignable<T>::value;                 // since C++17
       template <class T, class U> inline constexpr bool is_nothrow_swappable_with_v
-        = is_nothrow_swappable_with<T, U>::value;                       // C++17
+        = is_nothrow_swappable_with<T, U>::value;               // since C++17
       template <class T> inline constexpr bool is_nothrow_swappable_v
-        = is_nothrow_swappable<T>::value;                               // C++17
+        = is_nothrow_swappable<T>::value;                       // since C++17
       template <class T> inline constexpr bool is_nothrow_destructible_v
-        = is_nothrow_destructible<T>::value;                             // C++17
-      template<class T>
-        constexpr bool is_implicit_lifetime_v = is_implicit_lifetime<T>::value;   // Since C++23
+        = is_nothrow_destructible<T>::value;                    // since C++17
+      template <class T> inline constexpr bool is_implicit_lifetime_v
+        = is_implicit_lifetime<T>::value;                       // since C++23
       template <class T> inline constexpr bool has_virtual_destructor_v
-        = has_virtual_destructor<T>::value;                              // C++17
-      template<class T> inline constexpr bool has_unique_object_representations_v // C++17
-        = has_unique_object_representations<T>::value;
+        = has_virtual_destructor<T>::value;                     // since C++17
+      template<class T> inline constexpr bool has_unique_object_representations_v
+        = has_unique_object_representations<T>::value;          // since C++17
       template<class T, class U>
         constexpr bool reference_constructs_from_temporary_v
-          = reference_constructs_from_temporary<T, U>::value;            // Since C++23
+          = reference_constructs_from_temporary<T, U>::value;   // since C++23
       template<class T, class U>
         constexpr bool reference_converts_from_temporary_v
-          = reference_converts_from_temporary<T, U>::value;              // Since C++23
+          = reference_converts_from_temporary<T, U>::value;     // since C++23
 
       // See C++14 20.10.5, type property queries
       template <class T> inline constexpr size_t alignment_of_v
-        = alignment_of<T>::value;                                        // C++17
+        = alignment_of<T>::value;                               // since C++17
       template <class T> inline constexpr size_t rank_v
-        = rank<T>::value;                                                // C++17
+        = rank<T>::value;                                       // since C++17
       template <class T, unsigned I = 0> inline constexpr size_t extent_v
-        = extent<T, I>::value;                                           // C++17
+        = extent<T, I>::value;                                  // since C++17
 
       // See C++14 20.10.6, type relations
       template <class T, class U> inline constexpr bool is_same_v
-        = is_same<T, U>::value;                                          // C++17
+        = is_same<T, U>::value;                                 // since C++17
       template <class Base, class Derived> inline constexpr bool is_base_of_v
-        = is_base_of<Base, Derived>::value;                              // C++17
+        = is_base_of<Base, Derived>::value;                     // since C++17
       template <class Base, class Derived> inline constexpr bool is_virtual_base_of_v
-        = is_virtual_base_of<Base, Derived>::value;                      // C++26
+        = is_virtual_base_of<Base, Derived>::value;             // since C++26
       template <class From, class To> inline constexpr bool is_convertible_v
-        = is_convertible<From, To>::value;                               // C++17
+        = is_convertible<From, To>::value;                      // since C++17
+      template <class From, class To> inline constexpr bool is_nothrow_convertible_v
+        = is_nothrow_convertible<From, To>::value;              // since C++20
       template <class Fn, class... ArgTypes> inline constexpr bool is_invocable_v
-        = is_invocable<Fn, ArgTypes...>::value;                          // C++17
+        = is_invocable<Fn, ArgTypes...>::value;                 // since C++17
       template <class R, class Fn, class... ArgTypes> inline constexpr bool is_invocable_r_v
-        = is_invocable_r<R, Fn, ArgTypes...>::value;                     // C++17
+        = is_invocable_r<R, Fn, ArgTypes...>::value;            // since C++17
       template <class Fn, class... ArgTypes> inline constexpr bool is_nothrow_invocable_v
-        = is_nothrow_invocable<Fn, ArgTypes...>::value;                  // C++17
+        = is_nothrow_invocable<Fn, ArgTypes...>::value;         // since C++17
       template <class R, class Fn, class... ArgTypes> inline constexpr bool is_nothrow_invocable_r_v
-        = is_nothrow_invocable_r<R, Fn, ArgTypes...>::value;             // C++17
+        = is_nothrow_invocable_r<R, Fn, ArgTypes...>::value;    // since C++17
 
       // [meta.logical], logical operator traits:
-      template<class... B> struct conjunction;                           // C++17
-      template<class... B>
-        inline constexpr bool conjunction_v = conjunction<B...>::value;  // C++17
-      template<class... B> struct disjunction;                           // C++17
-      template<class... B>
-        inline constexpr bool disjunction_v = disjunction<B...>::value;  // C++17
-      template<class B> struct negation;                                 // C++17
-      template<class B>
-        inline constexpr bool negation_v = negation<B>::value;           // C++17
+      template<class... B> struct conjunction;                  // since C++17
+      template<class... B> inline constexpr bool conjunction_v
+        = conjunction<B...>::value;                             // since C++17
+      template<class... B> struct disjunction;                  // since C++17
+      template<class... B> inline constexpr bool disjunction_v
+        = disjunction<B...>::value;                             // since C++17
+      template<class B> struct negation;                        // since C++17
+      template<class B> inline constexpr bool negation_v
+        = negation<B>::value;                                   // since C++17
 
 }
 


### PR DESCRIPTION
- Aligns all version comments to line 65.
- Consistently uses `// since C++` instead of `// C++`, in lowercase as used in most version comments.
- Consistently uses `class` to introduce type template parameters.
- Consistently uses `inline constexpr` for variable templates.
- Corrects the comment for `bool_constant` to `// since C++17` as it's a C++17 feature.
- Changes the class-key of `result_of` to `struct`, which follows N4659 [depr.meta.types] and the actual usage in libc++.
- Adds missed `// since C++17` for `is_(nothrow_)invocable(_r)`.
- Moves the comments for `is_nothrow_convertible_v` to the part for variable templates.
- Removes duplicated comments for `true_type` and `false_type`.