### PR TITLE
[clang][bytecode][NFC] Bail out on non constant evaluated builtins

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -2059,6 +2059,9 @@ static bool interp__builtin_memchr(InterpState &S, CodePtr OpPC,
 
 bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const Function *F,
                       const CallExpr *Call, uint32_t BuiltinID) {
+  if (!S.getASTContext().BuiltinInfo.isConstantEvaluated(BuiltinID))
+    return false;
+
   const InterpFrame *Frame = S.Current;
 
   std::optional<PrimType> ReturnT = S.getContext().classify(Call);


### PR DESCRIPTION
If the ASTContext says so, don't bother trying to constant evaluate the given builtin.