### PR TITLE
[libc++][CI] Update action runner base image.

### DIFF
--- a/libcxx/utils/ci/docker-compose.yml
+++ b/libcxx/utils/ci/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       dockerfile: Dockerfile
       target: actions-builder
       args:
-        BASE_IMAGE: ghcr.io/actions/actions-runner:2.319.1
+        BASE_IMAGE: ghcr.io/actions/actions-runner:2.322.0
         <<: *compiler_versions
 
   android-buildkite-builder:


### PR DESCRIPTION
Updates to the latest release. The side effect of this change is updating all compilers to the latest upstream version.