### PR TITLE
[lldb] fix set SBLineEntryColumn

### DIFF
--- a/lldb/source/API/SBLineEntry.cpp
+++ b/lldb/source/API/SBLineEntry.cpp
@@ -137,7 +137,7 @@ void SBLineEntry::SetLine(uint32_t line) {
 void SBLineEntry::SetColumn(uint32_t column) {
   LLDB_INSTRUMENT_VA(this, column);
 
-  ref().line = column;
+  ref().column = column;
 }
 
 bool SBLineEntry::operator==(const SBLineEntry &rhs) const {

--- a/lldb/unittests/API/CMakeLists.txt
+++ b/lldb/unittests/API/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_lldb_unittest(APITests
   SBCommandInterpreterTest.cpp
+        SBLineEntryTest.cpp
 
   LINK_LIBS
     liblldb

--- a/lldb/unittests/API/CMakeLists.txt
+++ b/lldb/unittests/API/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_lldb_unittest(APITests
   SBCommandInterpreterTest.cpp
-        SBLineEntryTest.cpp
+  SBLineEntryTest.cpp
 
   LINK_LIBS
     liblldb

--- a/lldb/unittests/API/SBLineEntryTest.cpp
+++ b/lldb/unittests/API/SBLineEntryTest.cpp
@@ -1,0 +1,26 @@
+//===-- SBLineEntryTest.cpp -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===/
+
+#include "gtest/gtest.h"
+
+#include "lldb/API/LLDB.h"
+
+TEST(SBLineEntryTest, SetLineAndColumn) {
+  constexpr uint32_t expected_line_no = 40;
+  constexpr uint32_t expected_column_no = 20;
+
+  lldb::SBLineEntry line_entry{};
+  line_entry.SetLine(expected_line_no);
+  line_entry.SetColumn(expected_column_no);
+
+  const uint32_t line_no = line_entry.GetLine();
+  const uint32_t column_no = line_entry.GetColumn();
+
+  EXPECT_EQ(line_no, line_no);
+  EXPECT_EQ(column_no, expected_column_no);
+}


### PR DESCRIPTION
Calling the public API `SBLineEntry::SetColumn()` sets the row instead of the column. 

This probably should be backported as it has been since version 3.4. 