### PR TITLE
[lldb] Remove an extraneous `printf` statement.

### DIFF
--- a/lldb/source/Host/macosx/objcxx/MemoryMonitorMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/MemoryMonitorMacOSX.mm
@@ -32,7 +32,6 @@ class MemoryMonitorMacOSX : public MemoryMonitor {
       }
     });
     dispatch_activate(m_memory_pressure_source);
-    printf("Started\n");
   }
 
   void Stop() override {


### PR DESCRIPTION
This was missed in review but is showing up in lldb-dap output.