### PR TITLE
[mlir][MLProgram][NFC] Migrate to OpAsmAttrInterface for ASM alias generation

### DIFF
--- a/mlir/include/mlir/Dialect/MLProgram/IR/MLProgramAttributes.td
+++ b/mlir/include/mlir/Dialect/MLProgram/IR/MLProgramAttributes.td
@@ -40,6 +40,9 @@ def MLProgram_ExternAttr : MLProgram_Attr<"Extern", [TypedAttrInterface]> {
   let parameters = (ins AttributeSelfTypeParameter<"">:$type);
   let mnemonic = "extern";
   let assemblyFormat = "";
+
+  // Generate mnemonic alias for the attribute.
+  let genMnemonicAlias = 1;
 }
 
 #endif // MLPROGRAM_ATTRIBUTES

--- a/mlir/lib/Dialect/MLProgram/IR/MLProgramDialect.cpp
+++ b/mlir/lib/Dialect/MLProgram/IR/MLProgramDialect.cpp
@@ -39,14 +39,6 @@ struct MLProgramInlinerInterface : public DialectInlinerInterface {
 
 struct MLProgramOpAsmDialectInterface : public OpAsmDialectInterface {
   using OpAsmDialectInterface::OpAsmDialectInterface;
-
-  AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
-    if (llvm::isa<ExternAttr>(attr)) {
-      os << "extern";
-      return AliasResult::OverridableAlias;
-    }
-    return AliasResult::NoAlias;
-  }
 };
 } // namespace
 


### PR DESCRIPTION
After the introduction of `OpAsmAttrInterface`, it is favorable to migrate code using `OpAsmDialectInterface` for ASM alias generation, which lives in `Dialect.cpp`, to use `OpAsmAttrInterface`, which lives in `Attrs.td`. In this way, attribute behavior is placed near its tablegen definition and people won't need to go through other files to know what other (unexpected) hooks comes into play.

See #124721 for the interface itself and #128191 and #130479 for prior migrations.

Note that `MLProgramOpAsmInterface` has no content now. However, if we delete it, a failure related to dialect resource handling will occur

```
within split at llvm-project/mlir/test/IR/invalid-file-metadata.mlir:60 offset :7:7: error: unexpected error: unexpected 'resource' section for dialect 'ml_program'
```

To support resource such interface must be registered.