### PR TITLE
[clang][bytecode] Fix getting pointer element type in __builtin_memcmp

### DIFF
--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -1352,6 +1352,21 @@ namespace Memcmp {
   static_assert(__builtin_wmemcmp(L"abab\0banana", L"abab\0canada", 7) == -1);
   static_assert(__builtin_wmemcmp(L"abab\0banana", L"abab\0canada", 6) == -1);
   static_assert(__builtin_wmemcmp(L"abab\0banana", L"abab\0canada", 5) == 0);
+
+#if __cplusplus >= 202002L
+  constexpr bool f() {
+    char *c = new char[12];
+    c[0] = 'b';
+
+    char n = 'a';
+    bool b = __builtin_memcmp(c, &n, 1) == 0;
+
+    delete[] c;
+    return !b;
+  }
+  static_assert(f());
+#endif
+
 }
 
 namespace Memchr {


### PR DESCRIPTION
When such a pointer is heap allocated, the type we get is a pointer type. Take the pointee type in that case.