### PR TITLE
[libc++] Strictly enforce C++ language requirements.

### DIFF
--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -499,7 +499,7 @@ function(cxx_add_basic_build_flags target)
   # Use C++23 for all targets.
   set_target_properties(${target} PROPERTIES
     CXX_STANDARD 23
-    CXX_STANDARD_REQUIRED OFF # TODO: Make this REQUIRED once we don't need to accommodate the LLVM documentation builders using an ancient CMake
+	CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS NO)
 
   # When building the dylib, don't warn for unavailable aligned allocation

--- a/libcxxabi/src/CMakeLists.txt
+++ b/libcxxabi/src/CMakeLists.txt
@@ -181,7 +181,7 @@ set_target_properties(cxxabi_shared_objects
   PROPERTIES
     CXX_EXTENSIONS OFF
     CXX_STANDARD 23
-    CXX_STANDARD_REQUIRED OFF # TODO: Make this REQUIRED once we don't need to accommodate the LLVM documentation builders using an ancient CMake
+	CXX_STANDARD_REQUIRED ON
     COMPILE_FLAGS "${LIBCXXABI_COMPILE_FLAGS}"
     DEFINE_SYMBOL ""
 )
@@ -280,7 +280,7 @@ set_target_properties(cxxabi_static_objects
   PROPERTIES
     CXX_EXTENSIONS OFF
     CXX_STANDARD 23
-    CXX_STANDARD_REQUIRED OFF # TODO: Make this REQUIRED once we don't need to accommodate the LLVM documentation builders using an ancient CMake
+	CXX_STANDARD_REQUIRED ON
     COMPILE_FLAGS "${LIBCXXABI_COMPILE_FLAGS}"
 )
 target_compile_options(cxxabi_static_objects PRIVATE "${LIBCXXABI_ADDITIONAL_COMPILE_FLAGS}")


### PR DESCRIPTION
This was disabled for documentation bots. Testing whether that is still required. Compiling the dylib with a language standard before C++23 does not work, so it would be good when this can be enforced by CMake.