### PR TITLE
[libc++] Remove one of the std::signbit overloads

### DIFF
--- a/libcxx/include/__math/traits.h
+++ b/libcxx/include/__math/traits.h
@@ -13,7 +13,6 @@
 #include <__type_traits/enable_if.h>
 #include <__type_traits/is_arithmetic.h>
 #include <__type_traits/is_integral.h>
-#include <__type_traits/is_signed.h>
 #include <__type_traits/promote.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -51,14 +50,9 @@ template <class = void>
   return __builtin_signbit(__x);
 }
 
-template <class _A1, __enable_if_t<is_integral<_A1>::value && is_signed<_A1>::value, int> = 0>
+template <class _A1, __enable_if_t<is_integral<_A1>::value, int> = 0>
 [[__nodiscard__]] inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI bool signbit(_A1 __x) _NOEXCEPT {
   return __x < 0;
-}
-
-template <class _A1, __enable_if_t<is_integral<_A1>::value && !is_signed<_A1>::value, int> = 0>
-[[__nodiscard__]] inline _LIBCPP_SIGNBIT_CONSTEXPR _LIBCPP_HIDE_FROM_ABI bool signbit(_A1) _NOEXCEPT {
-  return false;
 }
 
 // isfinite

--- a/libcxx/test/std/depr/depr.c.headers/math_h.pass.cpp
+++ b/libcxx/test/std/depr/depr.c.headers/math_h.pass.cpp
@@ -12,6 +12,9 @@
 
 // <math.h>
 
+// GCC warns about signbit comparing `bool_v < 0`, which we're testing
+// ADDITIONAL_COMPILE_FLAGS(gcc): -Wno-bool-compare
+
 #include <math.h>
 #include <type_traits>
 #include <cassert>

--- a/libcxx/test/std/numerics/c.math/signbit.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/signbit.pass.cpp
@@ -14,6 +14,9 @@
 // These compilers don't support constexpr `__builtin_signbit` yet.
 // UNSUPPORTED: clang-18, clang-19, apple-clang-15, apple-clang-16, apple-clang-17
 
+// GCC warns about signbit comparing `bool_v < 0`, which we're testing
+// ADDITIONAL_COMPILE_FLAGS(gcc): -Wno-bool-compare
+
 // XFAIL: FROZEN-CXX03-HEADERS-FIXME
 
 #include <cassert>


### PR DESCRIPTION
We'e specialized `std::signbit` for signed and unsigned integral types seperately, even though the optimizer can trivially figure out that `unsigned_value < 0` always false is. This patch removes the specialization, since there is really not much of a benefit to it.

