### PR TITLE
[VPlan] Add VPSymbolicValueSC for typed VPValues w/o underlying IR value

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -4478,7 +4478,7 @@ void LoopVectorizationPlanner::emitInvalidCostRemarks(
 static bool willGenerateVectors(VPlan &Plan, ElementCount VF,
                                 const TargetTransformInfo &TTI) {
   assert(VF.isVector() && "Checking a scalar VF?");
-  VPTypeAnalysis TypeInfo(Plan.getCanonicalIV()->getScalarType());
+  VPTypeAnalysis TypeInfo(Plan.getCanonicalIV()->getScalarType()->getContext());
   DenseSet<VPRecipeBase *> EphemeralRecipes;
   collectEphemeralRecipesForVPlan(Plan, EphemeralRecipes);
   // Set of already visited types.
@@ -9083,7 +9083,7 @@ static VPInstruction *addResumePhiRecipeForInduction(
 /// \p IVEndValues.
 static void addScalarResumePhis(VPRecipeBuilder &Builder, VPlan &Plan,
                                 DenseMap<VPValue *, VPValue *> &IVEndValues) {
-  VPTypeAnalysis TypeInfo(Plan.getCanonicalIV()->getScalarType());
+  VPTypeAnalysis TypeInfo(Plan.getCanonicalIV()->getScalarType()->getContext());
   auto *ScalarPH = Plan.getScalarPreheader();
   auto *MiddleVPBB = cast<VPBasicBlock>(ScalarPH->getSinglePredecessor());
   VPRegionBlock *VectorRegion = Plan.getVectorLoopRegion();
@@ -9326,7 +9326,8 @@ LoopVectorizationPlanner::tryToBuildVPlanWithVPRecipes(VFRange &Range) {
             return !CM.requiresScalarEpilogue(VF.isVector());
           },
           Range);
-  auto Plan = std::make_unique<VPlan>(OrigLoop);
+  auto Plan =
+      std::make_unique<VPlan>(OrigLoop, Legal->getWidestInductionType());
   // Build hierarchical CFG.
   // Convert to VPlan-transform and consoliate all transforms for VPlan
   // creation.
@@ -9632,7 +9633,8 @@ VPlanPtr LoopVectorizationPlanner::tryToBuildVPlan(VFRange &Range) {
   assert(EnableVPlanNativePath && "VPlan-native path is not enabled.");
 
   // Create new empty VPlan
-  auto Plan = std::make_unique<VPlan>(OrigLoop);
+  auto Plan =
+      std::make_unique<VPlan>(OrigLoop, Legal->getWidestInductionType());
   // Build hierarchical CFG
   VPlanHCFGBuilder HCFGBuilder(OrigLoop, LI, *Plan);
   HCFGBuilder.buildHierarchicalCFG();

--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -1375,7 +1375,7 @@ static bool isDefinedInsideLoopRegions(const VPValue *VPV) {
 }
 
 Type *VPValue::getType() const {
-  assert(isLiveIn());
+  assert(isLiveIn() && "can only return the type for a live-in");
   return SubclassID == VPSymbolicValueSC ? Ty : getUnderlyingValue()->getType();
 }
 

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -3454,7 +3454,7 @@ public:
   VPlan(Loop *L, Type *InductionTy);
 
   /// Construct a VPlan with a new VPBasicBlock as entry, a VPIRBasicBlock
-  /// wrapping \p ScalarHeaderBB and a trip count of \p TC.
+  /// wrapping \p ScalarHeaderBB and a trip count of \p TC. Also creates symbolic VectorTripCount, VF and VFxUF VPValues using \p InductionTy.
   VPlan(BasicBlock *ScalarHeaderBB, VPValue *TC, Type *InductionTy)
       : VectorTripCount(InductionTy), VF(InductionTy), VFxUF(InductionTy) {
     setEntry(createVPBasicBlock("preheader"));

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -3454,7 +3454,8 @@ public:
   VPlan(Loop *L, Type *InductionTy);
 
   /// Construct a VPlan with a new VPBasicBlock as entry, a VPIRBasicBlock
-  /// wrapping \p ScalarHeaderBB and a trip count of \p TC. Also creates symbolic VectorTripCount, VF and VFxUF VPValues using \p InductionTy.
+  /// wrapping \p ScalarHeaderBB and a trip count of \p TC. Also creates
+  /// symbolic VectorTripCount, VF and VFxUF VPValues using \p InductionTy.
   VPlan(BasicBlock *ScalarHeaderBB, VPValue *TC, Type *InductionTy)
       : VectorTripCount(InductionTy), VF(InductionTy), VFxUF(InductionTy) {
     setEntry(createVPBasicBlock("preheader"));

--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.cpp
@@ -231,13 +231,8 @@ Type *VPTypeAnalysis::inferScalarType(const VPValue *V) {
   if (Type *CachedTy = CachedTypes.lookup(V))
     return CachedTy;
 
-  if (V->isLiveIn()) {
-    if (auto *IRValue = V->getLiveInIRValue())
-      return IRValue->getType();
-    // All VPValues without any underlying IR value (like the vector trip count
-    // or the backedge-taken count) have the same type as the canonical IV.
-    return CanonicalIVTy;
-  }
+  if (V->isLiveIn())
+    return V->getType();
 
   Type *ResultTy =
       TypeSwitch<const VPRecipeBase *, Type *>(V->getDefiningRecipe())

--- a/llvm/lib/Transforms/Vectorize/VPlanAnalysis.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanAnalysis.h
@@ -39,10 +39,6 @@ class Type;
 /// of the previously inferred types.
 class VPTypeAnalysis {
   DenseMap<const VPValue *, Type *> CachedTypes;
-  /// Type of the canonical induction variable. Used for all VPValues without
-  /// any underlying IR value (like the vector trip count or the backedge-taken
-  /// count).
-  Type *CanonicalIVTy;
   LLVMContext &Ctx;
 
   Type *inferScalarTypeForRecipe(const VPBlendRecipe *R);
@@ -55,8 +51,7 @@ class VPTypeAnalysis {
   Type *inferScalarTypeForRecipe(const VPReplicateRecipe *R);
 
 public:
-  VPTypeAnalysis(Type *CanonicalIVTy)
-      : CanonicalIVTy(CanonicalIVTy), Ctx(CanonicalIVTy->getContext()) {}
+  VPTypeAnalysis(LLVMContext &Ctx) : Ctx(Ctx) {}
 
   /// Infer the type of \p V. Returns the scalar type of \p V.
   Type *inferScalarType(const VPValue *V);

--- a/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
@@ -379,8 +379,8 @@ struct VPCostContext {
   VPCostContext(const TargetTransformInfo &TTI, const TargetLibraryInfo &TLI,
                 Type *CanIVTy, LoopVectorizationCostModel &CM,
                 TargetTransformInfo::TargetCostKind CostKind)
-      : TTI(TTI), TLI(TLI), Types(CanIVTy), LLVMCtx(CanIVTy->getContext()),
-        CM(CM), CostKind(CostKind) {}
+      : TTI(TTI), TLI(TLI), Types(CanIVTy->getContext()),
+        LLVMCtx(CanIVTy->getContext()), CM(CM), CostKind(CostKind) {}
 
   /// Return the cost for \p UI with \p VF using the legacy cost model as
   /// fallback until computing the cost of all recipes migrates to VPlan.

--- a/llvm/lib/Transforms/Vectorize/VPlanUnroll.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUnroll.cpp
@@ -73,7 +73,7 @@ class UnrollState {
 
 public:
   UnrollState(VPlan &Plan, unsigned UF, LLVMContext &Ctx)
-      : Plan(Plan), UF(UF), TypeInfo(Plan.getCanonicalIV()->getScalarType()) {}
+      : Plan(Plan), UF(UF), TypeInfo(Ctx) {}
 
   void unrollBlock(VPBlockBase *VPB);
 

--- a/llvm/lib/Transforms/Vectorize/VPlanValue.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanValue.h
@@ -181,7 +181,8 @@ public:
   /// Returns true if this VPValue is a live-in, i.e. defined outside the VPlan.
   bool isLiveIn() const { return !hasDefiningRecipe(); }
 
-  /// Returns true if the VPValue is symbolic, that is a live-in without underlying value.
+  /// Returns true if the VPValue is symbolic, that is a live-in without
+  /// underlying value.
   bool isSymbolic() const { return SubclassID == VPSymbolicValueSC; }
 
   /// If the VPValue is a live-in, return its scalar type.

--- a/llvm/lib/Transforms/Vectorize/VPlanValue.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanValue.h
@@ -92,7 +92,7 @@ protected:
 public:
   /// Return the underlying Value attached to this VPValue.
   Value *getUnderlyingValue() const {
-    return SubclassID == VPSymbolicValueSC ? nullptr : UnderlyingVal;
+    return isSymbolic() ? nullptr : UnderlyingVal;
   }
 
   /// An enumeration for keeping track of the concrete subclass of VPValue that
@@ -181,9 +181,11 @@ public:
   /// Returns true if this VPValue is a live-in, i.e. defined outside the VPlan.
   bool isLiveIn() const { return !hasDefiningRecipe(); }
 
+  /// Returns true if the VPValue is symbolic, that is a live-in without underlying value.
   bool isSymbolic() const { return SubclassID == VPSymbolicValueSC; }
 
-  Type *getType() const;
+  /// If the VPValue is a live-in, return its scalar type.
+  Type *getScalarType() const;
 
   /// Returns the underlying IR value, if this VPValue is defined outside the
   /// scope of VPlan. Returns nullptr if the VPValue is defined by a VPDef

--- a/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
@@ -420,8 +420,10 @@ bool VPlanVerifier::verify(const VPlan &Plan) {
 bool llvm::verifyVPlanIsValid(const VPlan &Plan) {
   VPDominatorTree VPDT;
   VPDT.recalculate(const_cast<VPlan &>(Plan));
-  VPTypeAnalysis TypeInfo(
-      const_cast<VPlan &>(Plan).getCanonicalIV()->getScalarType());
+  VPTypeAnalysis TypeInfo(const_cast<VPlan &>(Plan)
+                              .getCanonicalIV()
+                              ->getScalarType()
+                              ->getContext());
   VPlanVerifier Verifier(VPDT, TypeInfo);
   return Verifier.verify(Plan);
 }

--- a/llvm/unittests/Transforms/Vectorize/VPlanTestBase.h
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTestBase.h
@@ -71,7 +71,7 @@ protected:
 
     Loop *L = LI->getLoopFor(LoopHeader);
     PredicatedScalarEvolution PSE(*SE, *L);
-    auto Plan = std::make_unique<VPlan>(L);
+    auto Plan = std::make_unique<VPlan>(L, IntegerType::get(*Ctx, 64));
     VPlanHCFGBuilder HCFGBuilder(L, LI.get(), *Plan);
     HCFGBuilder.buildHierarchicalCFG();
     VPlanTransforms::introduceTopLevelVectorLoopRegion(
@@ -91,7 +91,8 @@ protected:
   }
 
   VPlan &getPlan(VPValue *TC = nullptr) {
-    Plans.push_back(std::make_unique<VPlan>(&*ScalarHeader, TC));
+    Plans.push_back(
+        std::make_unique<VPlan>(&*ScalarHeader, TC, IntegerType::get(C, 64)));
     return *Plans.back();
   }
 };


### PR DESCRIPTION
This introduces a new VPSymbolicValueSC to be used for typed live-in VPValues without underlying IR. VPValue is updated to store either the type or an underlying value in an union. This allows keeping the size of VPValue unchanged.

The main motivation for adding the type is to not require passing the canonical IV type to VPTypeAnalysis.

While with this patch, we still need to pass the LLVMContext, this can also be removed in a future patch (see
9493c38891d7041b86fdcfa1149c7f3ca16773c7)