### PR TITLE
[ADT] Use `adl_begin`/`adl_end` in `make_filter_range`

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -573,11 +573,9 @@ iterator_range<filter_iterator<detail::IterOfRange<RangeT>, PredicateT>>
 make_filter_range(RangeT &&Range, PredicateT Pred) {
   using FilterIteratorT =
       filter_iterator<detail::IterOfRange<RangeT>, PredicateT>;
-  return make_range(
-      FilterIteratorT(std::begin(std::forward<RangeT>(Range)),
-                      std::end(std::forward<RangeT>(Range)), Pred),
-      FilterIteratorT(std::end(std::forward<RangeT>(Range)),
-                      std::end(std::forward<RangeT>(Range)), Pred));
+  auto B = adl_begin(Range);
+  auto E = adl_end(Range);
+  return make_range(FilterIteratorT(B, E, Pred), FilterIteratorT(E, E, Pred));
 }
 
 /// A pseudo-iterator adaptor that is designed to implement "early increment"

--- a/llvm/unittests/ADT/IteratorTest.cpp
+++ b/llvm/unittests/ADT/IteratorTest.cpp
@@ -22,6 +22,22 @@ using testing::ElementsAre;
 
 namespace {
 
+namespace adl_test {
+struct WithFreeBeginEnd {
+  int data[3] = {21, 22, 23};
+};
+
+auto begin(const WithFreeBeginEnd &X) { return std::begin(X.data); }
+auto end(const WithFreeBeginEnd &X) { return std::end(X.data); }
+
+struct WithFreeRBeginREnd {
+  int data[3] = {42, 43, 44};
+};
+
+auto rbegin(const WithFreeRBeginREnd &X) { return std::rbegin(X.data); }
+auto rend(const WithFreeRBeginREnd &X) { return std::rend(X.data); }
+} // namespace adl_test
+
 template <int> struct Shadow;
 
 struct WeirdIter
@@ -364,6 +380,14 @@ TEST(FilterIteratorTest, ReverseFilterRange) {
   EXPECT_EQ((SmallVector<int, 4>{6, 4, 2, 0}), Actual4);
 }
 
+TEST(FilterIteratorTest, ADL) {
+  // Make sure that we use the `begin`/`end` functions
+  // from `adl_test`, using ADL.
+  adl_test::WithFreeBeginEnd R;
+  auto IsOdd = [](int N) { return N % 2 != 0; };
+  EXPECT_THAT(make_filter_range(R, IsOdd), ElementsAre(21, 23));
+}
+
 TEST(PointerIterator, Basic) {
   int A[] = {1, 2, 3, 4};
   pointer_iterator<int *> Begin(std::begin(A)), End(std::end(A));
@@ -395,18 +419,9 @@ TEST(PointerIterator, Range) {
     EXPECT_EQ(A + I++, P);
 }
 
-namespace rbegin_detail {
-struct WithFreeRBegin {
-  int data[3] = {42, 43, 44};
-};
-
-auto rbegin(const WithFreeRBegin &X) { return std::rbegin(X.data); }
-auto rend(const WithFreeRBegin &X) { return std::rend(X.data); }
-} // namespace rbegin_detail
-
 TEST(ReverseTest, ADL) {
   // Check that we can find the rbegin/rend functions via ADL.
-  rbegin_detail::WithFreeRBegin Foo;
+  adl_test::WithFreeRBeginREnd Foo;
   EXPECT_THAT(reverse(Foo), ElementsAre(44, 43, 42));
 }
 


### PR DESCRIPTION
This is to make sure that ADT helpers consistently use argument dependent lookup when dealing with input ranges.

This was a part of https://github.com/llvm/llvm-project/pull/87936 but reverted due to buildbot failures.

Also fix potential issue with double-move on the input range.