### PR TITLE
draft: [lldb] Upgrade ValueObject::GetData to return llvm::Expected

### DIFF
--- a/lldb/include/lldb/ValueObject/ValueObject.h
+++ b/lldb/include/lldb/ValueObject/ValueObject.h
@@ -757,7 +757,7 @@ public:
   virtual size_t GetPointeeData(DataExtractor &data, uint32_t item_idx = 0,
                                 uint32_t item_count = 1);
 
-  virtual uint64_t GetData(DataExtractor &data, Status &error);
+  virtual llvm::Expected<DataExtractor> GetData();
 
   virtual bool SetData(DataExtractor &data, Status &error);
 

--- a/lldb/source/API/SBValue.cpp
+++ b/lldb/source/API/SBValue.cpp
@@ -1381,11 +1381,14 @@ lldb::SBData SBValue::GetData() {
   ValueLocker locker;
   lldb::ValueObjectSP value_sp(GetSP(locker));
   if (value_sp) {
+    auto data_or_err = value_sp->GetData();
+    if (!data_or_err) {
+
+      LLDB_LOG_ERRORV(GetLog(LLDBLog::API), data_or_err.takeError(),
+                      "SBValue GetData failed to extract info: {0}");
+    }
     DataExtractorSP data_sp(new DataExtractor());
-    Status error;
-    value_sp->GetData(*data_sp, error);
-    if (error.Success())
-      *sb_data = data_sp;
+    *sb_data = data_sp;
   }
 
   return sb_data;

--- a/lldb/source/API/SBValue.cpp
+++ b/lldb/source/API/SBValue.cpp
@@ -1382,11 +1382,10 @@ lldb::SBData SBValue::GetData() {
   lldb::ValueObjectSP value_sp(GetSP(locker));
   if (value_sp) {
     auto data_or_err = value_sp->GetData();
-    if (!data_or_err) {
-
+    if (!data_or_err)
       LLDB_LOG_ERRORV(GetLog(LLDBLog::API), data_or_err.takeError(),
                       "SBValue GetData failed to extract info: {0}");
-    }
+
     DataExtractorSP data_sp(new DataExtractor());
     *sb_data = data_sp;
   }

--- a/lldb/source/DataFormatters/TypeFormat.cpp
+++ b/lldb/source/DataFormatters/TypeFormat.cpp
@@ -200,10 +200,12 @@ bool TypeFormatImpl_EnumType::FormatObject(ValueObject *valobj,
                     "Can't extract data related to enum type info: {0}");
     return false;
   }
+
+  auto data = std::move(*data_or_err);
   ExecutionContext exe_ctx(valobj->GetExecutionContextRef());
   StreamString sstr;
-  valobj_enum_type.DumpTypeValue(&sstr, lldb::eFormatEnum, *data_or_err, 0,
-                                 data_or_err->GetByteSize(), 0, 0,
+  valobj_enum_type.DumpTypeValue(&sstr, lldb::eFormatEnum, data, 0,
+                                 data.GetByteSize(), 0, 0,
                                  exe_ctx.GetBestExecutionContextScope());
   if (!sstr.GetString().empty())
     dest = std::string(sstr.GetString());

--- a/lldb/source/DataFormatters/TypeFormat.cpp
+++ b/lldb/source/DataFormatters/TypeFormat.cpp
@@ -53,6 +53,7 @@ bool TypeFormatImpl_Format::FormatObject(ValueObject *valobj,
                       "Failed to extract data: {0}");
       return false;
     }
+    auto data = std::move(*data_or_err);
     if (context_type == Value::ContextType::RegisterInfo) {
       const RegisterInfo *reg_info = value.GetRegisterInfo();
       if (reg_info) {
@@ -92,7 +93,7 @@ bool TypeFormatImpl_Format::FormatObject(ValueObject *valobj,
               target_sp->ReadCStringFromMemory(
                   address, (char *)buffer_sp->GetBytes(), max_len, error);
               if (error.Success())
-                data_or_err->SetData(buffer_sp);
+                data.SetData(buffer_sp);
             }
           }
         } else {

--- a/lldb/source/DataFormatters/TypeFormat.cpp
+++ b/lldb/source/DataFormatters/TypeFormat.cpp
@@ -98,11 +98,12 @@ bool TypeFormatImpl_Format::FormatObject(ValueObject *valobj,
           }
         } else {
           auto data_or_err = valobj->GetData();
-          if (!data_or_err)
+          if (!data_or_err) {
             LLDB_LOG_ERRORV(
                 GetLog(LLDBLog::DataFormatters), data_or_err.takeError(),
                 "Failed to extract data for CString info to display: {0}:");
-          return false;
+            return false;
+          }
         }
 
         ExecutionContextScope *exe_scope =

--- a/lldb/source/DataFormatters/TypeFormat.cpp
+++ b/lldb/source/DataFormatters/TypeFormat.cpp
@@ -49,21 +49,24 @@ bool TypeFormatImpl_Format::FormatObject(ValueObject *valobj,
 
     auto data_or_err = valobj->GetData();
     if (!data_or_err) {
-          LLDB_LOG_ERRORV(GetLog(LLDBLog::DataFormatters), data_or_err.takeError(), "Failed to extract data: {0}");
-          return false;
-        } 
+      LLDB_LOG_ERRORV(GetLog(LLDBLog::DataFormatters), data_or_err.takeError(),
+                      "Failed to extract data: {0}");
+      return false;
+    }
     if (context_type == Value::ContextType::RegisterInfo) {
       const RegisterInfo *reg_info = value.GetRegisterInfo();
       if (reg_info) {
         auto data_or_err = valobj->GetData();
         if (!data_or_err) {
-          LLDB_LOG_ERRORV(GetLog(LLDBLog::Process), data_or_err.takeError(), "Failed to extract data for register info: {0}");
+          LLDB_LOG_ERRORV(GetLog(LLDBLog::Process), data_or_err.takeError(),
+                          "Failed to extract data for register info: {0}");
           return false;
         }
-          
+
         StreamString reg_sstr;
-        DumpDataExtractor(*data_or_err, &reg_sstr, 0, GetFormat(), reg_info->byte_size,
-                          1, UINT32_MAX, LLDB_INVALID_ADDRESS, 0, 0,
+        DumpDataExtractor(*data_or_err, &reg_sstr, 0, GetFormat(),
+                          reg_info->byte_size, 1, UINT32_MAX,
+                          LLDB_INVALID_ADDRESS, 0, 0,
                           exe_ctx.GetBestExecutionContextScope());
         dest = std::string(reg_sstr.GetString());
       }
@@ -95,9 +98,10 @@ bool TypeFormatImpl_Format::FormatObject(ValueObject *valobj,
         } else {
           auto data_or_err = valobj->GetData();
           if (!data_or_err)
-            LLDB_LOG_ERRORV(GetLog(LLDBLog::DataFormatters), data_or_err.takeError(),
+            LLDB_LOG_ERRORV(
+                GetLog(LLDBLog::DataFormatters), data_or_err.takeError(),
                 "Failed to extract data for CString info to display: {0}:");
-            return false;
+          return false;
         }
 
         ExecutionContextScope *exe_scope =
@@ -193,10 +197,10 @@ bool TypeFormatImpl_EnumType::FormatObject(ValueObject *valobj,
   auto data_or_err = valobj->GetData();
   if (!data_or_err) {
     LLDB_LOG_ERRORV(GetLog(LLDBLog::DataFormatters), data_or_err.takeError(),
-        "Can't extract data related to enum type info: {0}");
+                    "Can't extract data related to enum type info: {0}");
     return false;
   }
-      ExecutionContext exe_ctx(valobj->GetExecutionContextRef());
+  ExecutionContext exe_ctx(valobj->GetExecutionContextRef());
   StreamString sstr;
   valobj_enum_type.DumpTypeValue(&sstr, lldb::eFormatEnum, *data_or_err, 0,
                                  data_or_err->GetByteSize(), 0, 0,

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -525,8 +525,7 @@ public:
         auto data_or_err = valobj_sp->GetData();
         if (auto error = data_or_err.takeError()) {
             err = Status::FromError(
-                llvm::joinErrors(
-                  llvm::createStringError("couldn't get the value of %s: ", 
+                llvm::joinErrors(llvm::createStringError("couldn't get the value of %s: ", 
                     GetName().AsCString()), std::move(error)));
             return;
         }

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -487,11 +487,11 @@ public:
 
       if (auto error = valobj_extractor_or_err.takeError()) {
         err = Status::FromError(llvm::joinErrors(
-            llvm::createStringError("couldn't read contents of reference variable %s: ",
-                                    GetName().AsCString()),
+            llvm::createStringError(
+                "couldn't read contents of reference variable %s: ",
+                GetName().AsCString()),
             std::move(error)));
         return;
-
       }
 
       lldb::offset_t offset = 0;

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -493,7 +493,8 @@ public:
       }
 
       lldb::offset_t offset = 0;
-      lldb::addr_t reference_addr = valobj_extractor_or_err->GetAddress(&offset);
+      lldb::addr_t reference_addr =
+          valobj_extractor_or_err->GetAddress(&offset);
 
       Status write_error;
       map.WritePointerToMemory(load_addr, reference_addr, write_error);
@@ -573,8 +574,8 @@ public:
 
         m_temporary_allocation_size = data_or_err->GetByteSize();
 
-        m_original_data = std::make_shared<DataBufferHeap>(data_or_err->GetDataStart(),
-                                                           data_or_err->GetByteSize());
+        m_original_data = std::make_shared<DataBufferHeap>(
+            data_or_err->GetDataStart(), data_or_err->GetByteSize());
 
         if (!alloc_error.Success()) {
           err = Status::FromErrorStringWithFormat(

--- a/lldb/source/Plugins/ABI/AArch64/ABIMacOSX_arm64.cpp
+++ b/lldb/source/Plugins/ABI/AArch64/ABIMacOSX_arm64.cpp
@@ -256,15 +256,15 @@ ABIMacOSX_arm64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
   RegisterContext *reg_ctx = thread->GetRegisterContext().get();
 
   if (reg_ctx) {
-    DataExtractor data;
-    Status data_error;
-    const uint64_t byte_size = new_value_sp->GetData(data, data_error);
-    if (data_error.Fail()) {
-      error = Status::FromErrorStringWithFormat(
-          "Couldn't convert return value to raw data: %s",
-          data_error.AsCString());
-      return error;
-    }
+    auto data_or_err = new_value_sp->GetData();
+
+    if (auto error = data_or_err.takeError())
+      return Status::FromError(llvm::joinErrors(
+          llvm::createStringError("Couldn't convert return value to raw data"),
+          std::move(error)));
+
+    auto data = std::move(*data_or_err);
+    const uint64_t byte_size = data.GetByteSize();
 
     const uint32_t type_flags = return_value_type.GetTypeInfo(nullptr);
     if (type_flags & eTypeIsScalar || type_flags & eTypeIsPointer) {

--- a/lldb/source/Plugins/ABI/ARM/ABISysV_arm.cpp
+++ b/lldb/source/Plugins/ABI/ARM/ABISysV_arm.cpp
@@ -1849,15 +1849,15 @@ Status ABISysV_arm::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
   bool set_it_simple = false;
   if (compiler_type.IsIntegerOrEnumerationType(is_signed) ||
       compiler_type.IsPointerType()) {
-    DataExtractor data;
-    Status data_error;
-    size_t num_bytes = new_value_sp->GetData(data, data_error);
-    if (data_error.Fail()) {
-      error = Status::FromErrorStringWithFormat(
-          "Couldn't convert return value to raw data: %s",
-          data_error.AsCString());
-      return error;
+    auto data_or_err = new_value_sp->GetData();
+    if (auto error = data_or_err.takeError()) {
+      return Status::FromError(llvm::joinErrors(
+          llvm::createStringError("Couldn't convert return value to raw data"),
+          std::move(error)));
     }
+    auto data = std::move(*data_or_err);
+
+    size_t num_bytes = data.GetByteSize();
     lldb::offset_t offset = 0;
     if (num_bytes <= 8) {
       const RegisterInfo *r0_info = reg_ctx->GetRegisterInfo(

--- a/lldb/source/Plugins/ABI/LoongArch/ABISysV_loongarch.cpp
+++ b/lldb/source/Plugins/ABI/LoongArch/ABISysV_loongarch.cpp
@@ -267,15 +267,16 @@ Status ABISysV_loongarch::SetReturnValueObject(StackFrameSP &frame_sp,
     return result;
   }
 
-  DataExtractor data;
-  size_t num_bytes = new_value_sp->GetData(data, result);
+  auto data_or_err = new_value_sp->GetData();
 
-  if (result.Fail()) {
-    result = Status::FromErrorStringWithFormat(
-        "Couldn't convert return value to raw data: %s", result.AsCString());
-    return result;
-  }
+  if (auto error = data_or_err.takeError())
+    return Status::FromError(llvm::joinErrors(
+        llvm::createStringError("Couldn't convert return value to raw data"),
+        std::move(error)));
 
+  auto data = std::move(*data_or_err);
+
+  size_t num_bytes = data.GetByteSize();
   size_t reg_size = m_is_la64 ? 8 : 4;
   // Currently, we only support sizeof(data) <= 2 * reg_size.
   // 1. If the (`size` <= reg_size), the `data` will be returned through `ARG1`.

--- a/lldb/source/Plugins/ABI/Mips/ABISysV_mips.cpp
+++ b/lldb/source/Plugins/ABI/Mips/ABISysV_mips.cpp
@@ -716,16 +716,15 @@ Status ABISysV_mips::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
   bool set_it_simple = false;
   if (compiler_type.IsIntegerOrEnumerationType(is_signed) ||
       compiler_type.IsPointerType()) {
-    DataExtractor data;
-    Status data_error;
-    size_t num_bytes = new_value_sp->GetData(data, data_error);
-    if (data_error.Fail()) {
-      error = Status::FromErrorStringWithFormat(
-          "Couldn't convert return value to raw data: %s",
-          data_error.AsCString());
-      return error;
-    }
 
+    auto data_or_err = new_value_sp->GetData();
+    if (auto error = data_or_err.takeError())
+      return Status::FromError(llvm::joinErrors(
+          llvm::createStringError("Couldn't convert return value to raw data"),
+          std::move(error)));
+
+    auto data = std::move(*data_or_err);
+    size_t num_bytes = data.GetByteSize();
     lldb::offset_t offset = 0;
     if (num_bytes <= 8) {
       const RegisterInfo *r2_info = reg_ctx->GetRegisterInfoByName("r2", 0);

--- a/lldb/source/Plugins/ABI/Mips/ABISysV_mips64.cpp
+++ b/lldb/source/Plugins/ABI/Mips/ABISysV_mips64.cpp
@@ -675,12 +675,10 @@ Status ABISysV_mips64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     error = Status::FromErrorString("no registers are available");
 
   auto data_or_err = new_value_sp->GetData();
-  if (auto err = data_or_err.takeError()) {
-    error = Status::FromErrorStringWithFormat(
-        "Couldn't convert return value to raw data: %s",
-        llvm::toString(std::move(err)).c_str());
-    return error;
-  }
+  if (auto err = data_or_err.takeError())
+    return Status::FromError(llvm::joinErrors(
+        llvm::createStringError("Couldn't convert return value to raw data"),
+        std::move(error)));
 
   auto data = std::move(*data_or_err);
   size_t num_bytes = data.GetByteSize();

--- a/lldb/source/Plugins/ABI/Mips/ABISysV_mips64.cpp
+++ b/lldb/source/Plugins/ABI/Mips/ABISysV_mips64.cpp
@@ -678,7 +678,7 @@ Status ABISysV_mips64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
   if (auto err = data_or_err.takeError())
     return Status::FromError(llvm::joinErrors(
         llvm::createStringError("Couldn't convert return value to raw data"),
-        std::move(error)));
+        std::move(err)));
 
   auto data = std::move(*data_or_err);
   size_t num_bytes = data.GetByteSize();

--- a/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.cpp
+++ b/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.cpp
@@ -442,7 +442,6 @@ Status ABISysV_ppc::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
           llvm::createStringError("Couldn't convert return value to raw data"),
           std::move(err)));
 
-
     auto data = std::move(*data_or_err);
 
     size_t num_bytes = data.GetByteSize();

--- a/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.cpp
+++ b/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.cpp
@@ -438,9 +438,10 @@ Status ABISysV_ppc::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
 
     auto data_or_err = new_value_sp->GetData();
     if (auto err = data_or_err.takeError())
-      return Status::FromErrorStringWithFormat(
-          "Couldn't convert return value to raw data: %s",
-          llvm::toString(std::move(err)).c_str());
+      return Status::FromError(llvm::joinErrors(
+          llvm::createStringError("Couldn't convert return value to raw data"),
+          std::move(err)));
+
 
     auto data = std::move(*data_or_err);
 

--- a/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.cpp
+++ b/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.cpp
@@ -436,13 +436,15 @@ Status ABISysV_ppc::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
       compiler_type.IsPointerType()) {
     const RegisterInfo *reg_info = reg_ctx->GetRegisterInfoByName("r3", 0);
 
-    DataExtractor data;
-    Status data_error;
-    size_t num_bytes = new_value_sp->GetData(data, data_error);
-    if (data_error.Fail())
+    auto data_or_err = new_value_sp->GetData();
+    if (auto err = data_or_err.takeError())
       return Status::FromErrorStringWithFormat(
           "Couldn't convert return value to raw data: %s",
-          data_error.AsCString());
+          llvm::toString(std::move(err)).c_str());
+
+    auto data = std::move(*data_or_err);
+
+    size_t num_bytes = data.GetByteSize();
     lldb::offset_t offset = 0;
     if (num_bytes <= 8) {
       uint64_t raw_value = data.GetMaxU64(&offset, num_bytes);
@@ -466,16 +468,16 @@ Status ABISysV_ppc::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         return error;
       }
       if (*bit_width <= 64) {
-        DataExtractor data;
-        Status data_error;
-        size_t num_bytes = new_value_sp->GetData(data, data_error);
-        if (data_error.Fail()) {
-          error = Status::FromErrorStringWithFormat(
-              "Couldn't convert return value to raw data: %s",
-              data_error.AsCString());
-          return error;
-        }
+        auto data_or_err = new_value_sp->GetData();
 
+        if (auto error = data_or_err.takeError())
+          return Status::FromError(
+              llvm::joinErrors(llvm::createStringError(
+                                   "Couldn't convert return value to raw data"),
+                               std::move(error)));
+
+        auto data = std::move(*data_or_err);
+        size_t num_bytes = data.GetByteSize();
         unsigned char buffer[16];
         ByteOrder byte_order = data.GetByteOrder();
 

--- a/lldb/source/Plugins/ABI/RISCV/ABISysV_riscv.cpp
+++ b/lldb/source/Plugins/ABI/RISCV/ABISysV_riscv.cpp
@@ -388,14 +388,16 @@ Status ABISysV_riscv::SetReturnValueObject(StackFrameSP &frame_sp,
     return result;
   }
 
-  DataExtractor data;
-  size_t num_bytes = new_value_sp->GetData(data, result);
+  auto data_or_err = new_value_sp->GetData();
 
-  if (result.Fail()) {
-    result = Status::FromErrorStringWithFormat(
-        "Couldn't convert return value to raw data: %s", result.AsCString());
-    return result;
+  if (auto error = data_or_err.takeError()) {
+    return Status::FromError(llvm::joinErrors(
+        llvm::createStringError("Couldn't convert return value to raw data: "),
+        std::move(error)));
   }
+
+  auto data = std::move(*data_or_err);
+  size_t num_bytes = data.GetByteSize();
 
   size_t reg_size = m_is_rv64 ? 8 : 4;
   if (num_bytes <= 2 * reg_size) {

--- a/lldb/source/Plugins/ABI/SystemZ/ABISysV_s390x.cpp
+++ b/lldb/source/Plugins/ABI/SystemZ/ABISysV_s390x.cpp
@@ -404,11 +404,10 @@ Status ABISysV_s390x::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     const RegisterInfo *reg_info = reg_ctx->GetRegisterInfoByName("r2", 0);
 
     auto data_or_err = new_value_sp->GetData();
-    if (auto error = data_or_err.takeError()) {
-      return Status::FromErrorStringWithFormat(
-          "Couldn't convert return value to raw data: %s",
-          llvm::toString(std::move(error)).c_str());
-    }
+    if (auto error = data_or_err.takeError())
+      return Status::FromError(llvm::joinErrors(
+          llvm::createStringError("Couldn't convert return value to raw data"),
+          std::move(error)));
 
     auto data = std::move(*data_or_err);
 

--- a/lldb/source/Plugins/ABI/X86/ABIMacOSX_i386.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABIMacOSX_i386.cpp
@@ -206,30 +206,31 @@ Status ABIMacOSX_i386::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
   bool set_it_simple = false;
   if (compiler_type.IsIntegerOrEnumerationType(is_signed) ||
       compiler_type.IsPointerType()) {
-    DataExtractor data;
-    Status data_error;
-    size_t num_bytes = new_value_sp->GetData(data, data_error);
-    if (data_error.Fail()) {
+    auto data_or_err = new_value_sp->GetData();
+    if (auto err = data_or_err.takeError()) {
       error = Status::FromErrorStringWithFormat(
           "Couldn't convert return value to raw data: %s",
-          data_error.AsCString());
+          llvm::toString(std::move(err)).c_str());
       return error;
     }
+    size_t num_bytes = data_or_err->GetByteSize();
+
     lldb::offset_t offset = 0;
     if (num_bytes <= 8) {
       const RegisterInfo *eax_info = reg_ctx->GetRegisterInfoByName("eax", 0);
       if (num_bytes <= 4) {
-        uint32_t raw_value = data.GetMaxU32(&offset, num_bytes);
+        uint32_t raw_value = data_or_err->GetMaxU32(&offset, num_bytes);
 
         if (reg_ctx->WriteRegisterFromUnsigned(eax_info, raw_value))
           set_it_simple = true;
       } else {
-        uint32_t raw_value = data.GetMaxU32(&offset, 4);
+        uint32_t raw_value = data_or_err->GetMaxU32(&offset, 4);
 
         if (reg_ctx->WriteRegisterFromUnsigned(eax_info, raw_value)) {
           const RegisterInfo *edx_info =
               reg_ctx->GetRegisterInfoByName("edx", 0);
-          uint32_t raw_value = data.GetMaxU32(&offset, num_bytes - offset);
+          uint32_t raw_value =
+              data_or_err->GetMaxU32(&offset, num_bytes - offset);
 
           if (reg_ctx->WriteRegisterFromUnsigned(edx_info, raw_value))
             set_it_simple = true;

--- a/lldb/source/Plugins/ABI/X86/ABISysV_i386.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABISysV_i386.cpp
@@ -218,13 +218,13 @@ Status ABISysV_i386::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
   auto data_or_err = new_value_sp->GetData();
   bool register_write_successful = true;
 
-  if (auto err = data_or_err.takeError()) {
-    error = Status::FromErrorStringWithFormat(
-        "Couldn't convert return value to raw data: %s",
-        llvm::toString(std::move(err)).c_str());
-    return error;
-  }
-  size_t num_bytes = data_or_err->GetByteSize();
+  if (auto error = data_or_err.takeError())
+    return Status::FromError(llvm::joinErrors(
+        llvm::createStringError("Couldn't convert return value to raw data"),
+        std::move(error)));
+
+  auto data = std::move(*data_or_err);
+  size_t num_bytes = data.GetByteSize();
 
   // Following "IF ELSE" block categorizes various 'Fundamental Data Types'.
   // The terminology 'Fundamental Data Types' used here is adopted from Table
@@ -239,7 +239,7 @@ Status ABISysV_i386::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     }
     lldb::offset_t offset = 0;
     const RegisterInfo *eax_info = reg_ctx->GetRegisterInfoByName("eax", 0);
-    uint32_t raw_value = data_or_err->GetMaxU32(&offset, num_bytes);
+    uint32_t raw_value = data.GetMaxU32(&offset, num_bytes);
     register_write_successful =
         reg_ctx->WriteRegisterFromUnsigned(eax_info, raw_value);
   } else if ((type_flags & eTypeIsScalar) ||
@@ -258,10 +258,9 @@ Status ABISysV_i386::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         // handle it
         break;
       case 8: {
-        uint32_t raw_value_low = data_or_err->GetMaxU32(&offset, 4);
+        uint32_t raw_value_low = data.GetMaxU32(&offset, 4);
         const RegisterInfo *edx_info = reg_ctx->GetRegisterInfoByName("edx", 0);
-        uint32_t raw_value_high =
-            data_or_err->GetMaxU32(&offset, num_bytes - offset);
+        uint32_t raw_value_high = data.GetMaxU32(&offset, num_bytes - offset);
         register_write_successful =
             (reg_ctx->WriteRegisterFromUnsigned(eax_info, raw_value_low) &&
              reg_ctx->WriteRegisterFromUnsigned(edx_info, raw_value_high));
@@ -270,7 +269,7 @@ Status ABISysV_i386::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
       case 4:
       case 2:
       case 1: {
-        uint32_t raw_value = data_or_err->GetMaxU32(&offset, num_bytes);
+        uint32_t raw_value = data.GetMaxU32(&offset, num_bytes);
         register_write_successful =
             reg_ctx->WriteRegisterFromUnsigned(eax_info, raw_value);
         break;
@@ -278,7 +277,7 @@ Status ABISysV_i386::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
       }
     } else if (type_flags & eTypeIsEnumeration) // handles enum
     {
-      uint32_t raw_value = data_or_err->GetMaxU32(&offset, num_bytes);
+      uint32_t raw_value = data.GetMaxU32(&offset, num_bytes);
       register_write_successful =
           reg_ctx->WriteRegisterFromUnsigned(eax_info, raw_value);
     } else if (type_flags & eTypeIsFloat) // 'Floating Point'
@@ -314,11 +313,11 @@ Status ABISysV_i386::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
       {
         long double value_long_dbl = 0.0;
         if (num_bytes == 4)
-          value_long_dbl = data_or_err->GetFloat(&offset);
+          value_long_dbl = data.GetFloat(&offset);
         else if (num_bytes == 8)
-          value_long_dbl = data_or_err->GetDouble(&offset);
+          value_long_dbl = data.GetDouble(&offset);
         else if (num_bytes == 12)
-          value_long_dbl = data_or_err->GetLongDouble(&offset);
+          value_long_dbl = data.GetLongDouble(&offset);
         else {
           error = Status::FromErrorString(
               "Invalid number of bytes for this return type");

--- a/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
@@ -318,17 +318,17 @@ Status ABISysV_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
     const RegisterInfo *reg_info = reg_ctx->GetRegisterInfoByName("rax", 0);
 
     auto data_or_err = new_value_sp->GetData();
-    if (auto err = data_or_err.takeError()) {
-      error = Status::FromErrorStringWithFormat(
-          "Couldn't convert return value to raw data: %s",
-          llvm::toString(std::move(err)).c_str());
-      return error;
-    }
+    if (auto error = data_or_err.takeError())
+      return Status::FromError(llvm::joinErrors(
+          llvm::createStringError("Couldn't convert return value to raw data"),
+          std::move(error)));
 
-    size_t num_bytes = data_or_err->GetByteSize();
+    auto data = std::move(*data_or_err);
+
+    size_t num_bytes = data.GetByteSize();
     lldb::offset_t offset = 0;
     if (num_bytes <= 8) {
-      uint64_t raw_value = data_or_err->GetMaxU64(&offset, num_bytes);
+      uint64_t raw_value = data.GetMaxU64(&offset, num_bytes);
 
       if (reg_ctx->WriteRegisterFromUnsigned(reg_info, raw_value))
         set_it_simple = true;
@@ -353,18 +353,19 @@ Status ABISysV_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
             reg_ctx->GetRegisterInfoByName("xmm0", 0);
         RegisterValue xmm0_value;
         auto data_or_err = new_value_sp->GetData();
-        if (auto err = data_or_err.takeError()) {
-          error = Status::FromErrorStringWithFormat(
-              "Couldn't convert return value to raw data: %s",
-              llvm::toString(std::move(err)).c_str());
-          return error;
-        }
+        if (auto err = data_or_err.takeError())
+          return Status::FromError(
+              llvm::joinErrors(llvm::createStringError(
+                                   "Couldn't convert return value to raw data"),
+                               std::move(err)));
 
-        size_t num_bytes = data_or_err->GetByteSize();
+        auto data = std::move(*data_or_err);
+
+        size_t num_bytes = data.GetByteSize();
         unsigned char buffer[16];
-        ByteOrder byte_order = data_or_err->GetByteOrder();
+        ByteOrder byte_order = data.GetByteOrder();
 
-        data_or_err->CopyByteOrderedData(0, num_bytes, buffer, 16, byte_order);
+        data.CopyByteOrderedData(0, num_bytes, buffer, 16, byte_order);
         xmm0_value.SetBytes(buffer, 16, byte_order);
         reg_ctx->WriteRegister(xmm0_info, xmm0_value);
         set_it_simple = true;

--- a/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
@@ -317,18 +317,18 @@ Status ABISysV_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
       compiler_type.IsPointerType()) {
     const RegisterInfo *reg_info = reg_ctx->GetRegisterInfoByName("rax", 0);
 
-    DataExtractor data;
-    Status data_error;
-    size_t num_bytes = new_value_sp->GetData(data, data_error);
-    if (data_error.Fail()) {
+    auto data_or_err = new_value_sp->GetData();
+    if (auto err = data_or_err.takeError()) {
       error = Status::FromErrorStringWithFormat(
           "Couldn't convert return value to raw data: %s",
-          data_error.AsCString());
+          llvm::toString(std::move(err)).c_str());
       return error;
     }
+
+    size_t num_bytes = data_or_err->GetByteSize();
     lldb::offset_t offset = 0;
     if (num_bytes <= 8) {
-      uint64_t raw_value = data.GetMaxU64(&offset, num_bytes);
+      uint64_t raw_value = data_or_err->GetMaxU64(&offset, num_bytes);
 
       if (reg_ctx->WriteRegisterFromUnsigned(reg_info, raw_value))
         set_it_simple = true;
@@ -352,20 +352,19 @@ Status ABISysV_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         const RegisterInfo *xmm0_info =
             reg_ctx->GetRegisterInfoByName("xmm0", 0);
         RegisterValue xmm0_value;
-        DataExtractor data;
-        Status data_error;
-        size_t num_bytes = new_value_sp->GetData(data, data_error);
-        if (data_error.Fail()) {
+        auto data_or_err = new_value_sp->GetData();
+        if (auto err = data_or_err.takeError()) {
           error = Status::FromErrorStringWithFormat(
               "Couldn't convert return value to raw data: %s",
-              data_error.AsCString());
+              llvm::toString(std::move(err)).c_str());
           return error;
         }
 
+        size_t num_bytes = data_or_err->GetByteSize();
         unsigned char buffer[16];
-        ByteOrder byte_order = data.GetByteOrder();
+        ByteOrder byte_order = data_or_err->GetByteOrder();
 
-        data.CopyByteOrderedData(0, num_bytes, buffer, 16, byte_order);
+        data_or_err->CopyByteOrderedData(0, num_bytes, buffer, 16, byte_order);
         xmm0_value.SetBytes(buffer, 16, byte_order);
         reg_ctx->WriteRegister(xmm0_info, xmm0_value);
         set_it_simple = true;

--- a/lldb/source/Plugins/ABI/X86/ABIWindows_x86_64.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABIWindows_x86_64.cpp
@@ -324,18 +324,18 @@ Status ABIWindows_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
 
     auto data_or_err = new_value_sp->GetData();
 
-    if (auto err = data_or_err.takeError()) {
-      error = Status::FromErrorStringWithFormat(
-          "Couldn't convert return value to raw data: %s",
-          llvm::toString(std::move(err)).c_str());
-      return error;
-    }
+    if (auto err = data_or_err.takeError())
+      return Status::FromError(llvm::joinErrors(
+          llvm::createStringError("Couldn't convert return value to raw data"),
+          std::move(err)));
 
-    size_t num_bytes = data_or_err->GetByteSize();
+    auto data = std::move(*data_or_err);
+
+    size_t num_bytes = data.GetByteSize();
 
     lldb::offset_t offset = 0;
     if (num_bytes <= 8) {
-      uint64_t raw_value = data_or_err->GetMaxU64(&offset, num_bytes);
+      uint64_t raw_value = data.GetMaxU64(&offset, num_bytes);
 
       if (reg_ctx->WriteRegisterFromUnsigned(reg_info, raw_value))
         set_it_simple = true;
@@ -361,18 +361,19 @@ Status ABIWindows_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
         RegisterValue xmm0_value;
 
         auto data_or_err = new_value_sp->GetData();
-        if (auto err = data_or_err.takeError()) {
-          error = Status::FromErrorStringWithFormat(
-              "Couldn't convert return value to raw data: %s",
-              llvm::toString(std::move(err)).c_str());
-          return error;
-        }
-        size_t num_bytes = data_or_err->GetByteSize();
+        if (auto err = data_or_err.takeError())
+          return Status::FromError(
+              llvm::joinErrors(llvm::createStringError(
+                                   "Couldn't convert return value to raw data"),
+                               std::move(err)));
+
+        auto data = std::move(*data_or_err);
+        size_t num_bytes = data.GetByteSize();
 
         unsigned char buffer[16];
-        ByteOrder byte_order = data_or_err->GetByteOrder();
+        ByteOrder byte_order = data.GetByteOrder();
 
-        data_or_err->CopyByteOrderedData(0, num_bytes, buffer, 16, byte_order);
+        data.CopyByteOrderedData(0, num_bytes, buffer, 16, byte_order);
         xmm0_value.SetBytes(buffer, 16, byte_order);
         reg_ctx->WriteRegister(xmm0_info, xmm0_value);
         set_it_simple = true;

--- a/lldb/source/Plugins/Language/CPlusPlus/CxxStringTypes.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CxxStringTypes.cpp
@@ -68,11 +68,9 @@ static bool CharStringSummaryProvider(ValueObject &valobj, Stream &stream) {
 
 template <StringElementType ElemType>
 static bool CharSummaryProvider(ValueObject &valobj, Stream &stream) {
-  DataExtractor data;
-  Status error;
-  valobj.GetData(data, error);
+  auto data_or_err = valobj.GetData();
 
-  if (error.Fail())
+  if (!data_or_err)
     return false;
 
   std::string value;
@@ -84,7 +82,7 @@ static bool CharSummaryProvider(ValueObject &valobj, Stream &stream) {
   if (!value.empty())
     stream.Printf("%s ", value.c_str());
 
-  options.SetData(std::move(data));
+  options.SetData(std::move(*data_or_err));
   options.SetStream(&stream);
   options.SetPrefixToken(ElemTraits.first);
   options.SetQuote('\'');
@@ -169,11 +167,9 @@ bool lldb_private::formatters::Char32SummaryProvider(
 
 bool lldb_private::formatters::WCharSummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &) {
-  DataExtractor data;
-  Status error;
-  valobj.GetData(data, error);
+  auto data_or_err = valobj.GetData();
 
-  if (error.Fail())
+  if (!data_or_err)
     return false;
 
   // Get a wchar_t basic type from the current type system
@@ -191,7 +187,7 @@ bool lldb_private::formatters::WCharSummaryProvider(
   const uint32_t wchar_size = *size;
 
   StringPrinter::ReadBufferAndDumpToStreamOptions options(valobj);
-  options.SetData(std::move(data));
+  options.SetData(std::move(*data_or_err));
   options.SetStream(&stream);
   options.SetPrefixToken("L");
   options.SetQuote('\'');

--- a/lldb/source/Plugins/Language/CPlusPlus/CxxStringTypes.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CxxStringTypes.cpp
@@ -174,7 +174,7 @@ bool lldb_private::formatters::WCharSummaryProvider(
 
   if (!data_or_err) {
     LLDB_LOG_ERRORV(GetLog(LLDBLog::DataFormatters), data_or_err.takeError(),
-        "Can't extract data for WChar Summary: {0}")
+                    "Can't extract data for WChar Summary: {0}");
     return false;
   }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/CxxStringTypes.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CxxStringTypes.cpp
@@ -71,7 +71,8 @@ static bool CharSummaryProvider(ValueObject &valobj, Stream &stream) {
   auto data_or_err = valobj.GetData();
 
   if (!data_or_err) {
-    LLDB_LOG_ERRORV(GetLog(LLDBLog::DataFormatters), data_or_err.takeError(), "Cannot extract data: {0}");
+    LLDB_LOG_ERRORV(GetLog(LLDBLog::DataFormatters), data_or_err.takeError(),
+                    "Cannot extract data: {0}");
     return false;
   }
 
@@ -171,8 +172,11 @@ bool lldb_private::formatters::WCharSummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &) {
   auto data_or_err = valobj.GetData();
 
-  if (!data_or_err)
+  if (!data_or_err) {
+    LLDB_LOG_ERRORV(GetLog(LLDBLog::DataFormatters), data_or_err.takeError(),
+        "Can't extract data for WChar Summary: {0}")
     return false;
+  }
 
   // Get a wchar_t basic type from the current type system
   CompilerType wchar_compiler_type =

--- a/lldb/source/Plugins/Language/CPlusPlus/CxxStringTypes.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CxxStringTypes.cpp
@@ -70,8 +70,10 @@ template <StringElementType ElemType>
 static bool CharSummaryProvider(ValueObject &valobj, Stream &stream) {
   auto data_or_err = valobj.GetData();
 
-  if (!data_or_err)
+  if (!data_or_err) {
+    LLDB_LOG_ERRORV(GetLog(LLDBLog::DataFormatters), data_or_err.takeError(), "Cannot extract data: {0}");
     return false;
+  }
 
   std::string value;
   StringPrinter::ReadBufferAndDumpToStreamOptions options(valobj);

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
@@ -273,12 +273,12 @@ ValueObjectSP ForwardListFrontEnd::GetChildAtIndex(uint32_t idx) {
 
   // we need to copy current_sp into a new object otherwise we will end up with
   // all items named __value_
-  auto data_or_err = current_sp->GetData();
-  if (!data_or_err)
+  auto data = llvm::expectedToOptional(current_sp->GetData());
+  if (!data)
     return nullptr;
 
   return CreateValueObjectFromData(
-      llvm::formatv("[{0}]", idx).str(), *data_or_err,
+      llvm::formatv("[{0}]", idx).str(), *data,
       m_backend.GetExecutionContextRef(), m_element_type);
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
@@ -392,13 +392,13 @@ lldb::ValueObjectSP ListFrontEnd::GetChildAtIndex(uint32_t idx) {
 
   // we need to copy current_sp into a new object otherwise we will end up with
   // all items named __value_
-  auto data_or_err = current_sp->GetData();
-  if (!data_or_err)
+  auto data = llvm::expectedToOptional(current_sp->GetData());
+  if (!data)
     return lldb::ValueObjectSP();
 
   StreamString name;
   name.Printf("[%" PRIu64 "]", (uint64_t)idx);
-  return CreateValueObjectFromData(name.GetString(), *data_or_err,
+  return CreateValueObjectFromData(name.GetString(), *data,
                                    m_backend.GetExecutionContextRef(),
                                    m_element_type);
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
@@ -273,13 +273,11 @@ ValueObjectSP ForwardListFrontEnd::GetChildAtIndex(uint32_t idx) {
 
   // we need to copy current_sp into a new object otherwise we will end up with
   // all items named __value_
-  DataExtractor data;
-  Status error;
-  current_sp->GetData(data, error);
-  if (error.Fail())
+  auto data_or_err = current_sp->GetData();
+  if (!data_or_err)
     return nullptr;
 
-  return CreateValueObjectFromData(llvm::formatv("[{0}]", idx).str(), data,
+  return CreateValueObjectFromData(llvm::formatv("[{0}]", idx).str(), *data_or_err,
                                    m_backend.GetExecutionContextRef(),
                                    m_element_type);
 }
@@ -394,15 +392,13 @@ lldb::ValueObjectSP ListFrontEnd::GetChildAtIndex(uint32_t idx) {
 
   // we need to copy current_sp into a new object otherwise we will end up with
   // all items named __value_
-  DataExtractor data;
-  Status error;
-  current_sp->GetData(data, error);
-  if (error.Fail())
+  auto data_or_err = current_sp->GetData();
+  if (!data_or_err)
     return lldb::ValueObjectSP();
 
   StreamString name;
   name.Printf("[%" PRIu64 "]", (uint64_t)idx);
-  return CreateValueObjectFromData(name.GetString(), data,
+  return CreateValueObjectFromData(name.GetString(), *data_or_err,
                                    m_backend.GetExecutionContextRef(),
                                    m_element_type);
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxList.cpp
@@ -277,9 +277,9 @@ ValueObjectSP ForwardListFrontEnd::GetChildAtIndex(uint32_t idx) {
   if (!data_or_err)
     return nullptr;
 
-  return CreateValueObjectFromData(llvm::formatv("[{0}]", idx).str(), *data_or_err,
-                                   m_backend.GetExecutionContextRef(),
-                                   m_element_type);
+  return CreateValueObjectFromData(
+      llvm::formatv("[{0}]", idx).str(), *data_or_err,
+      m_backend.GetExecutionContextRef(), m_element_type);
 }
 
 lldb::ChildCacheState ForwardListFrontEnd::Update() {

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -207,13 +207,13 @@ lldb::ValueObjectSP lldb_private::formatters::
     return lldb::ValueObjectSP();
   StreamString stream;
   stream.Printf("[%" PRIu64 "]", (uint64_t)idx);
-  auto data_or_err = val_hash.first->GetData();
-  if (!data_or_err)
+  auto data = llvm::expectedToOptional(val_hash.first->GetData());
+  if (!data)
     return lldb::ValueObjectSP();
   const bool thread_and_frame_only_if_stopped = true;
   ExecutionContext exe_ctx = val_hash.first->GetExecutionContextRef().Lock(
       thread_and_frame_only_if_stopped);
-  return CreateValueObjectFromData(stream.GetString(), *data_or_err, exe_ctx,
+  return CreateValueObjectFromData(stream.GetString(), *data, exe_ctx,
                                    m_element_type);
 }
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -207,15 +207,13 @@ lldb::ValueObjectSP lldb_private::formatters::
     return lldb::ValueObjectSP();
   StreamString stream;
   stream.Printf("[%" PRIu64 "]", (uint64_t)idx);
-  DataExtractor data;
-  Status error;
-  val_hash.first->GetData(data, error);
-  if (error.Fail())
+  auto data_or_err = val_hash.first->GetData();
+  if (!data_or_err)
     return lldb::ValueObjectSP();
   const bool thread_and_frame_only_if_stopped = true;
   ExecutionContext exe_ctx = val_hash.first->GetExecutionContextRef().Lock(
       thread_and_frame_only_if_stopped);
-  return CreateValueObjectFromData(stream.GetString(), data, exe_ctx,
+  return CreateValueObjectFromData(stream.GetString(), *data_or_err, exe_ctx,
                                    m_element_type);
 }
 

--- a/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -1205,10 +1205,11 @@ bool lldb_private::formatters::ObjCSELSummaryProvider(
     valobj_sp = ValueObject::CreateValueObjectFromAddress("text", data_address,
                                                           exe_ctx, charstar);
   } else {
-    auto data_or_err = valobj.GetData();
-    if (!data_or_err)
+    auto data = llvm::expectedToOptional(valobj.GetData());
+
+    if (!data)
       return false;
-    valobj_sp = ValueObject::CreateValueObjectFromData("text", *data_or_err,
+    valobj_sp = ValueObject::CreateValueObjectFromData("text", *data,
                                                        exe_ctx, charstar);
   }
 

--- a/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -1205,13 +1205,11 @@ bool lldb_private::formatters::ObjCSELSummaryProvider(
     valobj_sp = ValueObject::CreateValueObjectFromAddress("text", data_address,
                                                           exe_ctx, charstar);
   } else {
-    DataExtractor data;
-    Status error;
-    valobj.GetData(data, error);
-    if (error.Fail())
+    auto data_or_err = valobj.GetData();
+    if (!data_or_err)
       return false;
     valobj_sp =
-        ValueObject::CreateValueObjectFromData("text", data, exe_ctx, charstar);
+        ValueObject::CreateValueObjectFromData("text", *data_or_err, exe_ctx, charstar);
   }
 
   if (!valobj_sp)

--- a/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -1208,8 +1208,8 @@ bool lldb_private::formatters::ObjCSELSummaryProvider(
     auto data_or_err = valobj.GetData();
     if (!data_or_err)
       return false;
-    valobj_sp =
-        ValueObject::CreateValueObjectFromData("text", *data_or_err, exe_ctx, charstar);
+    valobj_sp = ValueObject::CreateValueObjectFromData("text", *data_or_err,
+                                                       exe_ctx, charstar);
   }
 
   if (!valobj_sp)

--- a/lldb/source/Plugins/Language/ObjC/NSString.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSString.cpp
@@ -291,11 +291,11 @@ bool lldb_private::formatters::NSAttributedStringSummaryProvider(
       "string_ptr", pointer_value, exe_ctx, type));
   if (!child_ptr_sp)
     return false;
-  auto data_or_err = child_ptr_sp->GetData();
-  if (!data_or_err)
+  auto data = llvm::expectedToOptional(child_ptr_sp->GetData());
+  if (!data)
     return false;
   ValueObjectSP child_sp(child_ptr_sp->CreateValueObjectFromData(
-      "string_data", *data_or_err, exe_ctx, type));
+      "string_data", *data, exe_ctx, type));
   child_sp->GetValueAsUnsigned(0);
   if (child_sp)
     return NSStringSummaryProvider(*child_sp, stream, options);

--- a/lldb/source/Plugins/Language/ObjC/NSString.cpp
+++ b/lldb/source/Plugins/Language/ObjC/NSString.cpp
@@ -291,13 +291,11 @@ bool lldb_private::formatters::NSAttributedStringSummaryProvider(
       "string_ptr", pointer_value, exe_ctx, type));
   if (!child_ptr_sp)
     return false;
-  DataExtractor data;
-  Status error;
-  child_ptr_sp->GetData(data, error);
-  if (error.Fail())
+  auto data_or_err = child_ptr_sp->GetData();
+  if (!data_or_err)
     return false;
   ValueObjectSP child_sp(child_ptr_sp->CreateValueObjectFromData(
-      "string_data", data, exe_ctx, type));
+      "string_data", *data_or_err, exe_ctx, type));
   child_sp->GetValueAsUnsigned(0);
   if (child_sp)
     return NSStringSummaryProvider(*child_sp, stream, options);

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
@@ -552,12 +552,12 @@ ThreadSP AppleObjCRuntime::GetBacktraceThreadFromException(
     auto data_or_err = dict_entry->GetData();
     if (!data_or_err)
       return ThreadSP();
-    data_or_err->SetAddressByteSize(
-        dict_entry->GetProcessSP()->GetAddressByteSize());
+    auto data = std::move(*data_or_err);
+    data.SetAddressByteSize(dict_entry->GetProcessSP()->GetAddressByteSize());
 
     lldb::offset_t data_offset = 0;
-    auto dict_entry_key = data_or_err->GetAddress(&data_offset);
-    auto dict_entry_value = data_or_err->GetAddress(&data_offset);
+    auto dict_entry_key = data.GetAddress(&data_offset);
+    auto dict_entry_value = data.GetAddress(&data_offset);
 
     auto key_nsstring = objc_object_from_address(dict_entry_key, "key");
     StreamString key_summary;

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
@@ -549,7 +549,7 @@ ThreadSP AppleObjCRuntime::GetBacktraceThreadFromException(
        idx++) {
     ValueObjectSP dict_entry = reserved_dict->GetChildAtIndex(idx);
 
-    auto data_or_err = dict_entry->GetData();
+    auto data_or_err = llvm::expectedToOptional(dict_entry->GetData());
     if (!data_or_err)
       return ThreadSP();
     auto data = std::move(*data_or_err);

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
@@ -551,9 +551,8 @@ ThreadSP AppleObjCRuntime::GetBacktraceThreadFromException(
 
     DataExtractor data;
     data.SetAddressByteSize(dict_entry->GetProcessSP()->GetAddressByteSize());
-    Status error;
-    dict_entry->GetData(data, error);
-    if (error.Fail()) return ThreadSP();
+    auto data_or_err = dict_entry->GetData();
+    if (!data_or_err) return ThreadSP();
 
     lldb::offset_t data_offset = 0;
     auto dict_entry_key = data.GetAddress(&data_offset);

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
@@ -549,15 +549,14 @@ ThreadSP AppleObjCRuntime::GetBacktraceThreadFromException(
        idx++) {
     ValueObjectSP dict_entry = reserved_dict->GetChildAtIndex(idx);
 
-    DataExtractor data;
-    data.SetAddressByteSize(dict_entry->GetProcessSP()->GetAddressByteSize());
     auto data_or_err = dict_entry->GetData();
     if (!data_or_err)
       return ThreadSP();
+    data_or_err->SetAddressByteSize(dict_entry->GetProcessSP()->GetAddressByteSize());
 
     lldb::offset_t data_offset = 0;
-    auto dict_entry_key = data.GetAddress(&data_offset);
-    auto dict_entry_value = data.GetAddress(&data_offset);
+    auto dict_entry_key = data_or_err->GetAddress(&data_offset);
+    auto dict_entry_value = data_or_err->GetAddress(&data_offset);
 
     auto key_nsstring = objc_object_from_address(dict_entry_key, "key");
     StreamString key_summary;

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
@@ -552,7 +552,8 @@ ThreadSP AppleObjCRuntime::GetBacktraceThreadFromException(
     DataExtractor data;
     data.SetAddressByteSize(dict_entry->GetProcessSP()->GetAddressByteSize());
     auto data_or_err = dict_entry->GetData();
-    if (!data_or_err) return ThreadSP();
+    if (!data_or_err)
+      return ThreadSP();
 
     lldb::offset_t data_offset = 0;
     auto dict_entry_key = data.GetAddress(&data_offset);

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
@@ -552,7 +552,8 @@ ThreadSP AppleObjCRuntime::GetBacktraceThreadFromException(
     auto data_or_err = dict_entry->GetData();
     if (!data_or_err)
       return ThreadSP();
-    data_or_err->SetAddressByteSize(dict_entry->GetProcessSP()->GetAddressByteSize());
+    data_or_err->SetAddressByteSize(
+        dict_entry->GetProcessSP()->GetAddressByteSize());
 
     lldb::offset_t data_offset = 0;
     auto dict_entry_key = data_or_err->GetAddress(&data_offset);

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -254,11 +254,12 @@ static lldb::addr_t GetVTableAddress(Process &process,
     return LLDB_INVALID_ADDRESS;
   }
 
-  auto size = data_or_err->GetByteSize();
-  if (vbtable_ptr_offset + data_or_err->GetAddressByteSize() > size)
+  auto data = std::move(*data_or_err);
+  auto size = data.GetByteSize();
+  if (vbtable_ptr_offset + data.GetAddressByteSize() > size)
     return LLDB_INVALID_ADDRESS;
 
-  return data_or_err->GetAddress(&vbtable_ptr_offset);
+  return data.GetAddress(&vbtable_ptr_offset);
 }
 
 static int64_t ReadVBaseOffsetFromVTable(Process &process,

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -249,11 +249,10 @@ static lldb::addr_t GetVTableAddress(Process &process,
 
   auto data_or_err = valobj.GetData();
   if (!data_or_err) {
-    LLDB_LOG_ERRORV(GetLog(LLDBLog::Types), data_or_err.takeError(), "Extracted data is an invalid address: {0}");
+    LLDB_LOG_ERRORV(GetLog(LLDBLog::Types), data_or_err.takeError(),
+                    "Extracted data is an invalid address: {0}");
     return LLDB_INVALID_ADDRESS;
   }
-
-
 
   auto size = data_or_err->GetByteSize();
   if (vbtable_ptr_offset + data_or_err->GetAddressByteSize() > size)

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -248,8 +248,12 @@ static lldb::addr_t GetVTableAddress(Process &process,
   // so just extract VTable pointer from it
 
   auto data_or_err = valobj.GetData();
-  if (!data_or_err)
+  if (!data_or_err) {
+    LLDB_LOG_ERRORV(GetLog(LLDBLog::Types), data_or_err.takeError(), "Extracted data is an invalid address: {0}");
     return LLDB_INVALID_ADDRESS;
+  }
+
+
 
   auto size = data_or_err->GetByteSize();
   if (vbtable_ptr_offset + data_or_err->GetAddressByteSize() > size)

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -247,13 +247,15 @@ static lldb::addr_t GetVTableAddress(Process &process,
   // We have an object already read from process memory,
   // so just extract VTable pointer from it
 
-  DataExtractor data;
-  Status err;
-  auto size = valobj.GetData(data, err);
-  if (err.Fail() || vbtable_ptr_offset + data.GetAddressByteSize() > size)
+  auto data_or_err = valobj.GetData();
+  if (!data_or_err)
     return LLDB_INVALID_ADDRESS;
 
-  return data.GetAddress(&vbtable_ptr_offset);
+  auto size = data_or_err->GetByteSize();
+  if (vbtable_ptr_offset + data_or_err->GetAddressByteSize() > size)
+    return LLDB_INVALID_ADDRESS;
+
+  return data_or_err->GetAddress(&vbtable_ptr_offset);
 }
 
 static int64_t ReadVBaseOffsetFromVTable(Process &process,

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -691,7 +691,8 @@ size_t ValueObject::GetPointeeData(DataExtractor &data, uint32_t item_idx,
       ValueObjectSP pointee_sp = Dereference(error);
       if (error.Fail() || pointee_sp.get() == nullptr)
         return 0;
-      auto data_or_err = pointee_sp->GetData();
+      
+      auto data_or_err = llvm::expectedToOptional(pointee_sp->GetData());
       if (!data_or_err)
         return 0;
       data = *data_or_err;
@@ -700,7 +701,7 @@ size_t ValueObject::GetPointeeData(DataExtractor &data, uint32_t item_idx,
       ValueObjectSP child_sp = GetChildAtIndex(0);
       if (child_sp.get() == nullptr)
         return 0;
-      auto data_or_err = child_sp->GetData();
+      auto data_or_err = llvm::expectedToOptional(child_sp->GetData());
       if (!data_or_err)
         return 0;
       data = *data_or_err;

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -691,7 +691,7 @@ size_t ValueObject::GetPointeeData(DataExtractor &data, uint32_t item_idx,
       ValueObjectSP pointee_sp = Dereference(error);
       if (error.Fail() || pointee_sp.get() == nullptr)
         return 0;
-      
+
       auto data_or_err = llvm::expectedToOptional(pointee_sp->GetData());
       if (!data_or_err)
         return 0;

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -691,13 +691,20 @@ size_t ValueObject::GetPointeeData(DataExtractor &data, uint32_t item_idx,
       ValueObjectSP pointee_sp = Dereference(error);
       if (error.Fail() || pointee_sp.get() == nullptr)
         return 0;
-      return pointee_sp->GetData(data, error);
+      auto data_or_err = pointee_sp->GetData();
+      if (!data_or_err)
+        return 0;
+      data = *data_or_err;
+      return data.GetByteSize();
     } else {
       ValueObjectSP child_sp = GetChildAtIndex(0);
       if (child_sp.get() == nullptr)
         return 0;
-      Status error;
-      return child_sp->GetData(data, error);
+      auto data_or_err = child_sp->GetData();
+      if (!data_or_err)
+        return 0;
+      data = *data_or_err;
+      return data.GetByteSize();
     }
     return true;
   } else /* (items > 1) */
@@ -764,22 +771,27 @@ size_t ValueObject::GetPointeeData(DataExtractor &data, uint32_t item_idx,
   return 0;
 }
 
-uint64_t ValueObject::GetData(DataExtractor &data, Status &error) {
+llvm::Expected<DataExtractor> ValueObject::GetData() {
   UpdateValueIfNeeded(false);
   ExecutionContext exe_ctx(GetExecutionContextRef());
-  error = m_value.GetValueAsData(&exe_ctx, data, GetModule().get());
+  DataExtractor data;
+  Status error = m_value.GetValueAsData(&exe_ctx, data, GetModule().get());
   if (error.Fail()) {
     if (m_data.GetByteSize()) {
       data = m_data;
       error.Clear();
-      return data.GetByteSize();
+      data.SetAddressByteSize(m_data.GetAddressByteSize());
+      data.SetByteOrder(m_data.GetByteOrder());
+      return data;
     } else {
-      return 0;
+      return llvm::createStringError(
+          "GetData failed: %s",
+          error.AsCString());
     }
   }
   data.SetAddressByteSize(m_data.GetAddressByteSize());
   data.SetByteOrder(m_data.GetByteOrder());
-  return data.GetByteSize();
+  return data;
 }
 
 bool ValueObject::SetData(DataExtractor &data, Status &error) {

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -784,9 +784,7 @@ llvm::Expected<DataExtractor> ValueObject::GetData() {
       data.SetByteOrder(m_data.GetByteOrder());
       return data;
     } else {
-      return llvm::createStringError(
-          "GetData failed: %s",
-          error.AsCString());
+      return llvm::createStringError("GetData failed: %s", error.AsCString());
     }
   }
   data.SetAddressByteSize(m_data.GetAddressByteSize());

--- a/lldb/unittests/ValueObject/DumpValueObjectOptionsTests.cpp
+++ b/lldb/unittests/ValueObject/DumpValueObjectOptionsTests.cpp
@@ -88,6 +88,7 @@ public:
                                                       var_name, data_extractor);
       if (llvm::Error error = valobj_sp->Dump(strm, options))
         llvm::consumeError(std::move(error));
+      
       ASSERT_STREQ(strm.GetString().str().c_str(), expected);
       strm.Clear();
     }


### PR DESCRIPTION
Original mentioned here: [Discourse](https://discourse.llvm.org/t/rich-disassembler-for-lldb/76952/20?u=wizardengineer)

This patch consist of changing GetData method in the ValueObject to return a llvm::Expected in order to have more meaningful error messages.

cc: @adrian-prantl 