### PR TITLE
[ADT] Use `adl_being`/`adl_end` in `make_early_inc_range`

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -657,8 +657,8 @@ iterator_range<early_inc_iterator_impl<detail::IterOfRange<RangeT>>>
 make_early_inc_range(RangeT &&Range) {
   using EarlyIncIteratorT =
       early_inc_iterator_impl<detail::IterOfRange<RangeT>>;
-  return make_range(EarlyIncIteratorT(std::begin(std::forward<RangeT>(Range))),
-                    EarlyIncIteratorT(std::end(std::forward<RangeT>(Range))));
+  return make_range(EarlyIncIteratorT(adl_begin(Range)),
+                    EarlyIncIteratorT(adl_end(Range)));
 }
 
 // Forward declarations required by zip_shortest/zip_equal/zip_first/zip_longest

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -767,7 +767,7 @@ TEST(STLExtrasTest, EarlyIncrementTest) {
 #endif
 
   // Inserting shouldn't break anything. We should be able to keep dereferencing
-  // the currrent iterator and increment. The increment to go to the "next"
+  // the current iterator and increment. The increment to go to the "next"
   // iterator from before we inserted.
   L.insert(std::next(L.begin(), 2), -1);
   ++I;
@@ -779,6 +779,14 @@ TEST(STLExtrasTest, EarlyIncrementTest) {
   EXPECT_EQ(4, *I);
   ++I;
   EXPECT_EQ(EIR.end(), I);
+}
+
+TEST(STLExtrasTest, EarlyIncADLTest) {
+  // Make sure that we use the `begin`/`end` functions from `some_namespace`,
+  // using ADL.
+  some_namespace::some_struct S;
+  S.data = {1, 2, 3};
+  EXPECT_THAT(make_early_inc_range(S), ElementsAre(1, 2, 3));
 }
 
 // A custom iterator that returns a pointer when dereferenced. This is used to


### PR DESCRIPTION
This is to make sure that ADT helpers consistently use argument dependent lookup when dealing with input ranges.

This was a part of #87936 but reverted due to buildbot failures.

Also fix potential issue with double-move on the input range.