### PR TITLE
[Clang][CodeGen] Fix demangler invariant comment assertion

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2068,9 +2068,10 @@ StringRef CodeGenModule::getMangledName(GlobalDecl GD) {
   // Prior work:
   // https://discourse.llvm.org/t/rfc-clang-diagnostic-for-demangling-failures/82835/8
   // https://github.com/llvm/llvm-project/issues/111345
-  // assert((MangledName.startswith("_Z") || MangledName.startswith("?")) &&
-  //        !GD->hasAttr<AsmLabelAttr>() &&
-  //        llvm::demangle(MangledName) != MangledName &&
+  // assert(!((StringRef(MangledName).starts_with("_Z") ||
+  //           StringRef(MangledName).starts_with("?")) &&
+  //          !GD.getDecl()->hasAttr<AsmLabelAttr>() &&
+  //          llvm::demangle(MangledName) == MangledName) &&
   //        "LLVM demangler must demangle clang-generated names");
 
   auto Result = Manglings.insert(std::make_pair(MangledName, GD));


### PR DESCRIPTION
This patch makes the assertion (that is currently in a comment) that validates that names mangled by clang can be demangled by LLVM actually compile/work. There were some minor issues that needed to be fixed (like starts_with not being available on std::string and needing to call getDecl() on GD), and a logic issue that should be fixed in this patch. This enables just uncommenting the assertion to enable it within the compiler (minus needing to add the header file).