### PR TITLE
[libc] Allow using sscanf() and vsscanf() on baremetal targets.

### DIFF
--- a/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
+++ b/libc/cmake/modules/LLVMLibCCompileOptionRules.cmake
@@ -119,6 +119,9 @@ function(_get_common_compile_options output_var flags)
     list(APPEND compile_options "-fpie")
 
     if(LLVM_LIBC_FULL_BUILD)
+      if(LIBC_TARGET_OS_IS_BAREMETAL)
+        list(APPEND compile_options "-DLIBC_TARGET_OS_IS_BAREMETAL")
+      endif()
       # Only add -ffreestanding flag in non-GPU full build mode.
       if(NOT LIBC_TARGET_OS_IS_GPU)
         list(APPEND compile_options "-ffreestanding")

--- a/libc/src/stdio/baremetal/getchar.cpp
+++ b/libc/src/stdio/baremetal/getchar.cpp
@@ -17,7 +17,7 @@ namespace LIBC_NAMESPACE_DECL {
 LLVM_LIBC_FUNCTION(int, getchar, ()) {
   char buf[1];
   auto result = read_from_stdin(buf, sizeof(buf));
-  if (result < 0)
+  if (result <= 0)
     return EOF;
   return buf[0];
 }

--- a/libc/src/stdio/scanf_core/CMakeLists.txt
+++ b/libc/src/stdio/scanf_core/CMakeLists.txt
@@ -16,6 +16,10 @@ if(LIBC_TARGET_OS_IS_GPU)
     libc.src.stdio.ungetc
     libc.src.stdio.ferror
   )
+elseif(LIBC_TARGET_OS_IS_BAREMETAL)
+  list(APPEND file_deps
+    libc.src.stdio.getchar
+  )
 elseif(LLVM_LIBC_FULL_BUILD)
   list(APPEND file_deps
     libc.src.__support.File.file
@@ -53,13 +57,6 @@ add_header_library(
     libc.src.__support.CPP.bitset
     libc.src.__support.CPP.string_view
 )
-
-if(NOT(TARGET libc.src.__support.File.file) AND LLVM_LIBC_FULL_BUILD AND
-  (NOT LIBC_TARGET_OS_IS_GPU))
-  # Not all platforms have a file implementation. If file is unvailable, and a
-  # full build is requested, then we must skip all file based scanf sections.
-  return()
-endif()
 
 add_object_library(
   scanf_main
@@ -116,6 +113,13 @@ add_object_library(
     ${file_deps}
   ${use_system_file}
 )
+
+if(NOT(TARGET libc.src.__support.File.file) AND LLVM_LIBC_FULL_BUILD AND
+  (NOT LIBC_TARGET_OS_IS_GPU))
+  # Not all platforms have a file implementation. If file is unvailable, and a
+  # full build is requested, then we must skip all file based scanf sections.
+  return()
+endif()
 
 #TODO: condense the file-related code as possible.
 add_header_library(

--- a/libc/src/stdio/scanf_core/reader.h
+++ b/libc/src/stdio/scanf_core/reader.h
@@ -11,7 +11,8 @@
 
 #include "hdr/types/FILE.h"
 
-#if !defined(LIBC_COPT_STDIO_USE_SYSTEM_FILE) && !defined(LIBC_TARGET_OS_IS_BAREMETAL)
+#if !defined(LIBC_COPT_STDIO_USE_SYSTEM_FILE) &&                               \
+    !defined(LIBC_TARGET_OS_IS_BAREMETAL)
 #include "src/__support/File/file.h"
 #endif
 
@@ -19,8 +20,8 @@
 #include "src/stdio/getc.h"
 #include "src/stdio/ungetc.h"
 #elif defined(LIBC_TARGET_OS_IS_BAREMETAL)
-#include "src/stdio/getchar.h"
 #include "hdr/stdio_macros.h" // for EOF.
+#include "src/stdio/getchar.h"
 #endif
 
 #include "src/__support/macros/attributes.h" // For LIBC_INLINE


### PR DESCRIPTION
In addition to the normal "cookie" definitions a baremetal user needs to provide to use printf(), a user also needs to add `FILE *stdin;` somewhere in their source. I have not updated the default baremetal entrypoints, so a user will currently need to supply their own to add sscanf() and vsscanf(). This might also work for regular sscanf(), but I have not yet tried it.

This updates LLVMCCompileOptionRules.cmake to add a macro the libc build can use to determine if it is doing a baremetal build. This also updates the baremetal getchar() function because it looked like it would return an uninitialized value if __llvm_libc_stdio_read() returned 0. The baremetal build does not provide ungetc(), so the baremetal Reader class tracks the would-be ungot character itself. From what I could see in the code, tracking only one character is sufficient.