### PR TITLE
[mlir] Handle large integers (> 64 bits) for the IntegerAttr C-API

### DIFF
--- a/mlir/include/mlir-c/BuiltinAttributes.h
+++ b/mlir/include/mlir-c/BuiltinAttributes.h
@@ -158,6 +158,25 @@ MLIR_CAPI_EXPORTED uint64_t mlirIntegerAttrGetValueUInt(MlirAttribute attr);
 /// Returns the typeID of an Integer attribute.
 MLIR_CAPI_EXPORTED MlirTypeID mlirIntegerAttrGetTypeID(void);
 
+// Used to create large IntegerAttr's (>64 bits) via the CAPI
+// See
+// https://github.com/llvm/llvm-project/issues/128072#issuecomment-2672767777
+typedef struct {
+  size_t numbits;
+  union {
+    uint64_t *pVAL;
+    uint64_t VAL;
+  } data;
+} apint_interop_t;
+
+// Creates an APInt interop from an IntegerAttr
+MLIR_CAPI_EXPORTED int mlirIntegerAttrGetValueInterop(MlirAttribute attr,
+                                                      apint_interop_t *interop);
+
+// Creates an integer attribute of the given type from an APInt interop
+MLIR_CAPI_EXPORTED MlirAttribute
+mlirIntegerAttrFromInterop(MlirType type, apint_interop_t *interop);
+
 //===----------------------------------------------------------------------===//
 // Bool attribute.
 //===----------------------------------------------------------------------===//

--- a/mlir/test/python/ir/attributes.py
+++ b/mlir/test/python/ir/attributes.py
@@ -239,6 +239,51 @@ def testIntegerAttr():
         print("default_get:", IntegerAttr.get(IntegerType.get_signless(32), 42))
 
 
+@run
+def testLargeIntegerAttr():
+    with Context() as ctx:
+        max_positive_64_val = 0x7fffffffffffffff
+        max_positive_64 = IntegerAttr.get(IntegerType.get_signed(64), max_positive_64_val)
+        # CHECK: max_positive_64: 9223372036854775807 : si64
+        print("max_positive_64:", max_positive_64)
+        assert(int(max_positive_64) == max_positive_64_val)
+
+        neg_one_64_val = -1
+        neg_one_64 = IntegerAttr.get(IntegerType.get_signed(64), neg_one_64_val)
+        # CHECK: neg_one_64: -1 : si64
+        print("neg_one_64:", neg_one_64)
+        assert(int(neg_one_64) == neg_one_64_val)
+
+        max_unsigned_64_val = 0xffffffffffffffff
+        max_unsigned_64 = IntegerAttr.get(IntegerType.get_signless(64), max_unsigned_64_val)
+        # CHECK: max_unsigned_64: -1 : i64
+        print("max_unsigned_64:", max_unsigned_64)
+        assert(int(max_unsigned_64) == max_unsigned_64_val)
+
+        random_64_val = 0x0123456789ABCDEF
+        random_64 = IntegerAttr.get(IntegerType.get_signless(64), random_64_val)
+        # CHECK: random_64: 81985529216486895 : i64
+        print("random_64:", random_64)
+        assert(int(random_64) == random_64_val)
+
+        max_unsigned_65_val = 0x1FFFFFFFFFFFFFFFF
+        max_unsigned_65 = IntegerAttr.get(IntegerType.get_unsigned(65), max_unsigned_65_val)
+        # CHECK: max_unsigned_65: 36893488147419103231 : ui65
+        print("max_unsigned_65:", max_unsigned_65)
+        assert(int(max_unsigned_65) == max_unsigned_65_val)
+
+        random_128_val = 0x0123456789ABCDEF0123456789ABCDEF
+        random_128 = IntegerAttr.get(IntegerType.get_signless(128), random_128_val)
+        # CHECK: random_128: 1512366075204170929049582354406559215 : i128
+        print("random_128:", random_128)
+        assert(int(random_128) == random_128_val)
+
+        random_92_val = 0x9ABCDEF0123456789ABCDEF
+        random_92 = IntegerAttr.get(IntegerType.get_signless(92), random_92_val)
+        # CHECK: random_92: -1958696259612506469130580497 : i92
+        print("random_92:", random_92)
+        assert(int(random_92) == random_92_val)
+
 # CHECK-LABEL: TEST: testBoolAttr
 @run
 def testBoolAttr():


### PR DESCRIPTION
Address issue #128072.

@stellaraccident @teqdruid I created/used the `apint_interop_t` struct as suggested. Similar to APInt, I put a union member within the struct so that small values will be stored locally inside the struct.

For testing, expanded `mlir/test/python/ir/attributes.py` to include large integer cases (including the one mentioned in the issue. All `mlir/test` pass when running `llvm-lit` except one, see below.

One issue that needs to be resolved is that there are uses in the dialect tests when a signless IntegerAttr is created with a negative value. Should this be allowed, or should we only permit negative values to be used when creating signed IntegerAttrs?