### PR TITLE
[MergeFunc] Keep comdat on new function, not thunk.

### DIFF
--- a/llvm/lib/Transforms/IPO/MergeFunctions.cpp
+++ b/llvm/lib/Transforms/IPO/MergeFunctions.cpp
@@ -923,6 +923,8 @@ void MergeFunctions::mergeTwoFunctions(Function *F, Function *G) {
                                       F->getAddressSpace(), "", F->getParent());
     NewF->copyAttributesFrom(F);
     NewF->takeName(F);
+    NewF->setComdat(F->getComdat());
+    F->setComdat(nullptr);
     NewF->IsNewDbgInfoFormat = F->IsNewDbgInfoFormat;
     // Ensure CFI type metadata is propagated to the new function.
     copyMetadataIfPresent(F, NewF, "type");

--- a/llvm/test/Transforms/MergeFunc/comdat.ll
+++ b/llvm/test/Transforms/MergeFunc/comdat.ll
@@ -1,9 +1,11 @@
 ; RUN: opt -S -passes=mergefunc %s | FileCheck %s
 
+target triple = "x86_64-unknown-windows-msvc19.42.34436"
+
 @symbols = linkonce_odr global <{ ptr, ptr }> <{ ptr @f, ptr @g }>
 
-$f = comdat any
 $g = comdat any
+$f = comdat any
 
 define linkonce_odr hidden i32 @f(i32 %x, i32 %y) comdat {
   %sum = add i32 %x, %y
@@ -19,14 +21,14 @@ define linkonce_odr hidden i32 @g(i32 %x, i32 %y) comdat {
   ret i32 %sum3
 }
 
-; CHECK: $f = comdat any
 ; CHECK: $g = comdat any
+; CHECK: $f = comdat any
 
 ;.
 ; CHECK: @symbols = linkonce_odr global <{ ptr, ptr }> <{ ptr @f, ptr @g }>
 ;.
 ; CHECK-LABEL: define private i32 @0(
-; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) comdat($f) {
+; CHECK-SAME: i32 [[X:%.*]], i32 [[Y:%.*]]) {
 ; CHECK-NEXT:    [[SUM:%.*]] = add i32 [[X]], [[Y]]
 ; CHECK-NEXT:    [[SUM2:%.*]] = add i32 [[X]], [[SUM]]
 ; CHECK-NEXT:    [[SUM3:%.*]] = add i32 [[X]], [[SUM]]
@@ -40,7 +42,7 @@ define linkonce_odr hidden i32 @g(i32 %x, i32 %y) comdat {
 ;
 ;
 ; CHECK-LABEL: define linkonce_odr hidden i32 @f(
-; CHECK-SAME: i32 [[TMP0:%.*]], i32 [[TMP1:%.*]]) {
+; CHECK-SAME: i32 [[TMP0:%.*]], i32 [[TMP1:%.*]]) comdat {
 ; CHECK-NEXT:    [[TMP3:%.*]] = tail call i32 @[[GLOB0]](i32 [[TMP0]], i32 [[TMP1]])
 ; CHECK-NEXT:    ret i32 [[TMP3]]
 ;


### PR DESCRIPTION
MergeFunc uses the original function F as Thunk and creates a new function NewF for the original function F. Preserve F's comdat info on NewF instead of the thunk.

This fixes a crash when trying to lower comdat on the thunk during codegen.