### PR TITLE
[MIPS] Add MIPS i6400 and i6500 processors

### DIFF
--- a/clang/lib/Basic/Targets/Mips.cpp
+++ b/clang/lib/Basic/Targets/Mips.cpp
@@ -47,6 +47,8 @@ bool MipsTargetInfo::processorSupportsGPR64() const {
       .Case("mips64r6", true)
       .Case("octeon", true)
       .Case("octeon+", true)
+      .Case("i6400", true)
+      .Case("i6500", true)
       .Default(false);
 }
 
@@ -54,7 +56,7 @@ static constexpr llvm::StringLiteral ValidCPUNames[] = {
     {"mips1"},  {"mips2"},    {"mips3"},    {"mips4"},    {"mips5"},
     {"mips32"}, {"mips32r2"}, {"mips32r3"}, {"mips32r5"}, {"mips32r6"},
     {"mips64"}, {"mips64r2"}, {"mips64r3"}, {"mips64r5"}, {"mips64r6"},
-    {"octeon"}, {"octeon+"}, {"p5600"}};
+    {"octeon"}, {"octeon+"},  {"p5600"},    {"i6400"},    {"i6500"}};
 
 bool MipsTargetInfo::isValidCPUName(StringRef Name) const {
   return llvm::is_contained(ValidCPUNames, Name);

--- a/clang/lib/Driver/ToolChains/Arch/Mips.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/Mips.cpp
@@ -104,6 +104,8 @@ void mips::getMipsCPUAndABI(const ArgList &Args, const llvm::Triple &Triple,
                   .Case("mips64r6", "n64")
                   .Case("octeon", "n64")
                   .Case("p5600", "o32")
+                  .Case("i6400", "n64")
+                  .Case("i6500", "n64")
                   .Default("");
   }
 
@@ -514,5 +516,7 @@ bool mips::supportsIndirectJumpHazardBarrier(StringRef &CPU) {
       .Case("mips64r6", true)
       .Case("octeon", true)
       .Case("p5600", true)
+      .Case("i6400", true)
+      .Case("i6500", true)
       .Default(false);
 }

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -1501,7 +1501,9 @@ bool clang::driver::findMIPSMultilibs(const Driver &D,
                       CPUName == "mips64r5" || CPUName == "octeon" ||
                       CPUName == "octeon+",
                   "-march=mips64r2", Flags);
-  addMultilibFlag(CPUName == "mips64r6", "-march=mips64r6", Flags);
+  addMultilibFlag(CPUName == "mips64r6" || CPUName == "i6400" ||
+                      CPUName == "i6500",
+                  "-march=mips64r6", Flags);
   addMultilibFlag(isMicroMips(Args), "-mmicromips", Flags);
   addMultilibFlag(tools::mips::isUCLibc(Args), "-muclibc", Flags);
   addMultilibFlag(tools::mips::isNaN2008(D, Args, TargetTriple), "-mnan=2008",

--- a/clang/test/Driver/mips-abi.c
+++ b/clang/test/Driver/mips-abi.c
@@ -121,6 +121,30 @@
 // MIPS-ARCH-P5600-N64: error: ABI 'n64' is not supported on CPU 'p5600'
 //
 // RUN: %clang --target=mips-linux-gnu -### -c %s \
+// RUN:        -march=i6400 2>&1 \
+// RUN:   | FileCheck -check-prefix=MIPS-ARCH-I6400 %s
+// MIPS-ARCH-I6400: "-target-cpu" "i6400"
+// MIPS-ARCH-I6400: "-target-abi" "o32"
+//
+// RUN: %clang --target=mips-linux-gnu -### -c %s \
+// RUN:        -march=i6400 -mabi=64 2>&1 \
+// RUN:   | FileCheck -check-prefix=MIPS-ARCH-I6400-N64 %s
+// MIPS-ARCH-I6400-N64: "-target-cpu" "i6400"
+// MIPS-ARCH-I6400-N64: "-target-abi" "n64"
+//
+// RUN: %clang --target=mips-linux-gnu -### -c %s \
+// RUN:        -march=i6500 2>&1 \
+// RUN:   | FileCheck -check-prefix=MIPS-ARCH-I6500 %s
+// MIPS-ARCH-I6500: "-target-cpu" "i6500"
+// MIPS-ARCH-I6500: "-target-abi" "o32"
+//
+// RUN: %clang --target=mips-linux-gnu -### -c %s \
+// RUN:        -march=i6500 -mabi=64 2>&1 \
+// RUN:   | FileCheck -check-prefix=MIPS-ARCH-I6500-N64 %s
+// MIPS-ARCH-I6500-N64: "-target-cpu" "i6500"
+// MIPS-ARCH-I6500-N64: "-target-abi" "n64"
+//
+// RUN: %clang --target=mips-linux-gnu -### -c %s \
 // RUN:        -march=mips64 2>&1 \
 // RUN:   | FileCheck -check-prefix=MIPS-ARCH-3264 %s
 // MIPS-ARCH-3264: "-target-cpu" "mips64"

--- a/clang/test/Driver/mips-abi.c
+++ b/clang/test/Driver/mips-abi.c
@@ -132,6 +132,18 @@
 // MIPS-ARCH-I6400-N64: "-target-cpu" "i6400"
 // MIPS-ARCH-I6400-N64: "-target-abi" "n64"
 //
+// RUN: %clang --target=mips64-linux-gnu -### -c %s \
+// RUN:        -march=i6400 2>&1 \
+// RUN:   | FileCheck -check-prefix=MIPS64-ARCH-I6400 %s
+// MIPS64-ARCH-I6400: "-target-cpu" "i6400"
+// MIPS64-ARCH-I6400: "-target-abi" "n64"
+//
+// RUN: %clang --target=mips64-linux-gnu -### -c %s \
+// RUN:        -march=i6400 -mabi=32 2>&1 \
+// RUN:   | FileCheck -check-prefix=MIPS64-ARCH-I6400-O32 %s
+// MIPS64-ARCH-I6400-O32: "-target-cpu" "i6400"
+// MIPS64-ARCH-I6400-O32: "-target-abi" "o32"
+//
 // RUN: %clang --target=mips-linux-gnu -### -c %s \
 // RUN:        -march=i6500 2>&1 \
 // RUN:   | FileCheck -check-prefix=MIPS-ARCH-I6500 %s
@@ -143,6 +155,18 @@
 // RUN:   | FileCheck -check-prefix=MIPS-ARCH-I6500-N64 %s
 // MIPS-ARCH-I6500-N64: "-target-cpu" "i6500"
 // MIPS-ARCH-I6500-N64: "-target-abi" "n64"
+//
+// RUN: %clang --target=mips64-linux-gnu -### -c %s \
+// RUN:        -march=i6500 2>&1 \
+// RUN:   | FileCheck -check-prefix=MIPS64-ARCH-I6500 %s
+// MIPS64-ARCH-I6500: "-target-cpu" "i6500"
+// MIPS64-ARCH-I6500: "-target-abi" "n64"
+//
+// RUN: %clang --target=mips64-linux-gnu -### -c %s \
+// RUN:        -march=i6500 -mabi=32 2>&1 \
+// RUN:   | FileCheck -check-prefix=MIPS64-ARCH-I6500-O32 %s
+// MIPS64-ARCH-I6500-O32: "-target-cpu" "i6500"
+// MIPS54-ARCH-I6500-O32: "-target-abi" "o32"
 //
 // RUN: %clang --target=mips-linux-gnu -### -c %s \
 // RUN:        -march=mips64 2>&1 \

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -101,6 +101,8 @@ Changes to the LoongArch Backend
 Changes to the MIPS Backend
 ---------------------------
 
+* `-mcpu=i6400` and `-mcpu=i6500` was added.
+
 Changes to the PowerPC Backend
 ------------------------------
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -101,7 +101,7 @@ Changes to the LoongArch Backend
 Changes to the MIPS Backend
 ---------------------------
 
-* `-mcpu=i6400` and `-mcpu=i6500` was added.
+* `-mcpu=i6400` and `-mcpu=i6500` were added.
 
 Changes to the PowerPC Backend
 ------------------------------

--- a/llvm/lib/Target/Mips/Mips.td
+++ b/llvm/lib/Target/Mips/Mips.td
@@ -238,6 +238,14 @@ def ImplP5600 : SubtargetFeature<"p5600", "ProcImpl",
                                  "MipsSubtarget::CPU::P5600",
                                  "The P5600 Processor", [FeatureMips32r5]>;
 
+def ImplI6400
+    : SubtargetFeature<"i6400", "ProcImpl", "MipsSubtarget::CPU::I6400",
+                       "The I6400 Processor", [FeatureMips64r6]>;
+
+def ImplI6500
+    : SubtargetFeature<"i6500", "ProcImpl", "MipsSubtarget::CPU::I6400",
+                       "The I6500 Processor", [FeatureMips64r6]>;
+
 class Proc<string Name, list<SubtargetFeature> Features>
  : ProcessorModel<Name, MipsGenericModel, Features>;
 
@@ -261,6 +269,8 @@ def : Proc<"mips64r6", [FeatureMips64r6]>;
 def : Proc<"octeon", [FeatureMips64r2, FeatureCnMips]>;
 def : Proc<"octeon+", [FeatureMips64r2, FeatureCnMips, FeatureCnMipsP]>;
 def : ProcessorModel<"p5600", MipsP5600Model, [ImplP5600]>;
+def : ProcessorModel<"i6400", NoSchedModel, [ImplI6400]>;
+def : ProcessorModel<"i6500", NoSchedModel, [ImplI6500]>;
 
 def MipsAsmParser : AsmParser {
   let ShouldEmitMatchRegisterName = 0;

--- a/llvm/lib/Target/Mips/Mips.td
+++ b/llvm/lib/Target/Mips/Mips.td
@@ -238,13 +238,10 @@ def ImplP5600 : SubtargetFeature<"p5600", "ProcImpl",
                                  "MipsSubtarget::CPU::P5600",
                                  "The P5600 Processor", [FeatureMips32r5]>;
 
+// I6500 is multicluster version of I6400. Both are based on same CPU.
 def ImplI6400
     : SubtargetFeature<"i6400", "ProcImpl", "MipsSubtarget::CPU::I6400",
-                       "The I6400 Processor", [FeatureMips64r6]>;
-
-def ImplI6500
-    : SubtargetFeature<"i6500", "ProcImpl", "MipsSubtarget::CPU::I6400",
-                       "The I6500 Processor", [FeatureMips64r6]>;
+                       "MIPS I6400/I6500 Processors", [FeatureMips64r6]>;
 
 class Proc<string Name, list<SubtargetFeature> Features>
  : ProcessorModel<Name, MipsGenericModel, Features>;
@@ -270,7 +267,7 @@ def : Proc<"octeon", [FeatureMips64r2, FeatureCnMips]>;
 def : Proc<"octeon+", [FeatureMips64r2, FeatureCnMips, FeatureCnMipsP]>;
 def : ProcessorModel<"p5600", MipsP5600Model, [ImplP5600]>;
 def : ProcessorModel<"i6400", NoSchedModel, [ImplI6400]>;
-def : ProcessorModel<"i6500", NoSchedModel, [ImplI6500]>;
+def : ProcessorModel<"i6500", NoSchedModel, [ImplI6400]>;
 
 def MipsAsmParser : AsmParser {
   let ShouldEmitMatchRegisterName = 0;

--- a/llvm/lib/Target/Mips/Mips.td
+++ b/llvm/lib/Target/Mips/Mips.td
@@ -238,7 +238,8 @@ def ImplP5600 : SubtargetFeature<"p5600", "ProcImpl",
                                  "MipsSubtarget::CPU::P5600",
                                  "The P5600 Processor", [FeatureMips32r5]>;
 
-// I6500 is multicluster version of I6400. Both are based on same CPU.
+// The I6500 is the multi-cluster version of the I6400. Both are based on the
+// same CPU architecture.
 def ImplI6400
     : SubtargetFeature<"i6400", "ProcImpl", "MipsSubtarget::CPU::I6400",
                        "MIPS I6400/I6500 Processors", [FeatureMips64r6]>;

--- a/llvm/lib/Target/Mips/MipsSubtarget.h
+++ b/llvm/lib/Target/Mips/MipsSubtarget.h
@@ -43,7 +43,7 @@ class MipsSubtarget : public MipsGenSubtargetInfo {
     Mips3, Mips4, Mips5, Mips64, Mips64r2, Mips64r3, Mips64r5, Mips64r6
   };
 
-  enum class CPU { P5600 };
+  enum class CPU { P5600, I6400 };
 
   // Used to avoid printing dsp warnings multiple times.
   static bool DspWarningPrinted;

--- a/llvm/lib/Target/Mips/MipsSubtarget.h
+++ b/llvm/lib/Target/Mips/MipsSubtarget.h
@@ -43,6 +43,8 @@ class MipsSubtarget : public MipsGenSubtargetInfo {
     Mips3, Mips4, Mips5, Mips64, Mips64r2, Mips64r3, Mips64r5, Mips64r6
   };
 
+  // I6400 and I6500 are based on same MIPS64R6 ISA. Hence we define single
+  // subtarget I6400 for subtarget feature use in Mips.td.
   enum class CPU { P5600, I6400 };
 
   // Used to avoid printing dsp warnings multiple times.

--- a/llvm/lib/Target/Mips/MipsSubtarget.h
+++ b/llvm/lib/Target/Mips/MipsSubtarget.h
@@ -43,8 +43,6 @@ class MipsSubtarget : public MipsGenSubtargetInfo {
     Mips3, Mips4, Mips5, Mips64, Mips64r2, Mips64r3, Mips64r5, Mips64r6
   };
 
-  // I6400 and I6500 are based on same MIPS64R6 ISA. Hence we define single
-  // subtarget I6400 for subtarget feature use in Mips.td.
   enum class CPU { P5600, I6400 };
 
   // Used to avoid printing dsp warnings multiple times.


### PR DESCRIPTION
The i6400 and i6500 are high performance multi-core microprocessors from MIPS that provide best in class power efficiency for use in system-on-chip  (SoC) applications. i6400 and i6500 implements Release 6 of the MIPS64 Instruction Set Architecture with full hardware multithreading and hardware virtualization support.

Scheduling model shall be added in separate commit/PR.