### PR TITLE
[clang][test] Don't require specific alignment in test case

### DIFF
--- a/clang/test/CodeGenCXX/cxx23-p2280r4.cpp
+++ b/clang/test/CodeGenCXX/cxx23-p2280r4.cpp
@@ -15,11 +15,11 @@ int& test() {
 }
 
 // CHECK-LABEL: @_Z1fv(
-// CHECK: [[X1:%.*]] = load ptr, ptr @x, align 8
+// CHECK: [[X1:%.*]] = load ptr, ptr @x, align {{.*}}
 // CHECK-NEXT: store ptr [[X1]]
-// CHECK: [[X2:%.*]] = load ptr, ptr @x, align 8
+// CHECK: [[X2:%.*]] = load ptr, ptr @x, align {{.*}}
 // CHECK-NEXT: store ptr [[X2]]
-// CHECK: [[X3:%.*]] = load ptr, ptr @x, align 8
+// CHECK: [[X3:%.*]] = load ptr, ptr @x, align {{.*}}
 // CHECK-NEXT: store ptr [[X3]]
 int &ff();
 int &x = ff();


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/129952 / 42d49a77241df73a17cb442973702fc460e7fb90 added this test which is failing on 32-bit ARM because the alignment chosen is 4 not 8. Which would make sense if this is a 32/64 bit difference

https://lab.llvm.org/buildbot/#/builders/154/builds/13059
```
<stdin>:34:30: note: scanning from here
define dso_local void @_Z1fv(ptr dead_on_unwind noalias writable sret(%struct.B) align 4 %agg.result) #0 {
                             ^
<stdin>:38:2: note: possible intended match here
 %0 = load ptr, ptr @x, align 4
 ^
```
The other test does not check alignment, so I'm assuming that it is not important here.