### PR TITLE
[LLVM][Maintainers] Add llvm-cov / Coverage maintainer

### DIFF
--- a/llvm/Maintainers.md
+++ b/llvm/Maintainers.md
@@ -398,7 +398,9 @@ min.hsu@sifive.com, min@myhsu.dev (email), [mshockwave](https://github.com/mshoc
 #### llvm-cov and Coverage parts of ProfileData
 
 Takumi Nakamura \
-geek4civic@gmail.com (email), [chapuni](https://github.com/chapuni) (GitHub)
+geek4civic@gmail.com (email), [chapuni](https://github.com/chapuni) (GitHub) \
+Alan Philipps \
+a-phipps@ti.com (email), [evodius96](https://github.com/evodius96) (GitHub)
 
 #### Binary Utilities
 

--- a/llvm/Maintainers.md
+++ b/llvm/Maintainers.md
@@ -395,6 +395,11 @@ andrea.dibiagio@sony.com, andrea.dibiagio@gmail.com (email), [adibiagio](https:/
 Min-Yih Hsu \
 min.hsu@sifive.com, min@myhsu.dev (email), [mshockwave](https://github.com/mshockwave) (GitHub)
 
+#### llvm-cov and Coverage parts of ProfileData
+
+Takumi Nakamura \
+geek4civic@gmail.com (email), [chapuni](https://github.com/chapuni) (GitHub)
+
 #### Binary Utilities
 
 James Henderson \


### PR DESCRIPTION
I think @chapuni has been the most active in this area recently (mostly related to MC/DC). Would you be willing to be listed as the maintainer for this component?