### PR TITLE
[AArch64][ELF Parser] Fix out-of-scope variable usage

### DIFF
--- a/llvm/lib/Support/ELFAttrParserExtended.cpp
+++ b/llvm/lib/Support/ELFAttrParserExtended.cpp
@@ -53,9 +53,9 @@ ELFExtendedAttrParser::getAttributeString(unsigned Tag) const {
 std::optional<StringRef>
 ELFExtendedAttrParser::getAttributeString(StringRef BuildAttrSubsectionName,
                                           unsigned Tag) const {
-  for (auto SubSection : SubSectionVec) {
+  for (const auto &SubSection : SubSectionVec) {
     if (BuildAttrSubsectionName == SubSection.Name)
-      for (auto BAItem : SubSection.Content) {
+      for (const auto &BAItem : SubSection.Content) {
         if (Tag == BAItem.Tag)
           return std::optional<StringRef>(BAItem.StringValue);
       }


### PR DESCRIPTION
Return a reference to a persistent variable instead of a temporary copy.