### PR TITLE
[llvm-exegesis] Adding  in llvm-exegesis for Aarch64 for handling FPR8/16/32 and FPCR setReg warning  

### DIFF
--- a/llvm/test/tools/llvm-exegesis/AArch64/setReg_init_check.s
+++ b/llvm/test/tools/llvm-exegesis/AArch64/setReg_init_check.s
@@ -60,7 +60,7 @@ RUN: llvm-exegesis -mcpu=neoverse-v2 -mode=latency --dump-object-to-disk=%d --op
 RUN: llvm-objdump -d %d > %t.s
 RUN: FileCheck %s --check-prefix=FPR8-ASM < %t.s
 FPR8-ASM:         <foo>:
-FPR8-ASM:         movi d{{[0-9]+}}, #0000000000000000
+FPR8-ASM:         movi    d{{[0-9]+}}, #0000000000000000
 FPR8-ASM-NEXT:    sqabs   b{{[0-9]+}}, b{{[0-9]+}}
 
 
@@ -69,7 +69,7 @@ RUN: llvm-exegesis -mcpu=neoverse-v2 -mode=latency --dump-object-to-disk=%d --op
 RUN: llvm-objdump -d %d > %t.s
 RUN: FileCheck %s --check-prefix=FPCR-ASM < %t.s
 FPCR-ASM:         <foo>:
-FPCR-ASM:         movi d{{[0-9]+}}, #0000000000000000
+FPCR-ASM:         movi    d{{[0-9]+}}, #0000000000000000
 FPCR-ASM-NEXT:    mov     x8, #0x0
 FPCR-ASM-NEXT:    msr     FPCR, x8
 FPCR-ASM-NEXT:    bfcvt   h{{[0-9]+}}, s{{[0-9]+}}

--- a/llvm/test/tools/llvm-exegesis/AArch64/setReg_init_check.s
+++ b/llvm/test/tools/llvm-exegesis/AArch64/setReg_init_check.s
@@ -37,3 +37,40 @@ RUN: FileCheck %s --check-prefix=FPR64-ASM < %t.s
 FPR64-ASM:          <foo>:
 FPR64-ASM:          movi d{{[0-9]+}}, #0000000000000000
 FPR64-ASM-NEXT:     addv h{{[0-9]+}}, v{{[0-9]+}}.4h
+
+## FPR32 Register Class Initialization Testcase
+RUN: llvm-exegesis -mcpu=neoverse-v2 -mode=latency --dump-object-to-disk=%d --opcode-name=FABSSr --benchmark-phase=assemble-measured-code 2>&1
+RUN: llvm-objdump -d %d > %t.s
+RUN: FileCheck %s --check-prefix=FPR32-ASM < %t.s
+FPR32-ASM:         <foo>:
+FPR32-ASM:         movi d{{[0-9]+}}, #0000000000000000
+FPR32-ASM-NEXT:    fabs s{{[0-9]+}}, s{{[0-9]+}}
+
+
+## FPR16 Register Class Initialization Testcase
+RUN: llvm-exegesis -mcpu=neoverse-v2 -mode=latency --dump-object-to-disk=%d --opcode-name=FABSHr --benchmark-phase=assemble-measured-code 2>&1
+RUN: llvm-objdump -d %d > %t.s
+RUN: FileCheck %s --check-prefix=FPR16-ASM < %t.s
+FPR16-ASM:         <foo>:
+FPR16-ASM:         movi d{{[0-9]+}}, #0000000000000000
+FPR16-ASM-NEXT:    fabs h{{[0-9]+}}, h{{[0-9]+}}
+
+## FPR8 Register Class Initialization Testcase
+RUN: llvm-exegesis -mcpu=neoverse-v2 -mode=latency --dump-object-to-disk=%d --opcode-name=SQABSv1i8 --benchmark-phase=assemble-measured-code 2>&1
+RUN: llvm-objdump -d %d > %t.s
+RUN: FileCheck %s --check-prefix=FPR8-ASM < %t.s
+FPR8-ASM:         <foo>:
+FPR8-ASM:         mov     w{{[0-9]+}}, #0x0
+FPR8-ASM-NEXT:    fmov    h{{[0-9]+}}, w{{[0-9]+}}
+FPR8-ASM-NEXT:    sqabs   b{{[0-9]+}}, b{{[0-9]+}}
+
+
+## FPCR Register Class Initialization Testcase
+RUN: llvm-exegesis -mcpu=neoverse-v2 -mode=latency --dump-object-to-disk=%d --opcode-name=BFCVT --benchmark-phase=assemble-measured-code 2>&1
+RUN: llvm-objdump -d %d > %t.s
+RUN: FileCheck %s --check-prefix=FPCR-ASM < %t.s
+FPCR-ASM:         <foo>:
+FPCR-ASM:         movi d{{[0-9]+}}, #0000000000000000
+FPCR-ASM-NEXT:    mov     x{{[0-9]+}}, #0x0
+FPCR-ASM-NEXT:    msr     FPCR, x{{[0-9]+}}
+FPCR-ASM-NEXT:    bfcvt   h{{[0-9]+}}, s{{[0-9]+}}

--- a/llvm/test/tools/llvm-exegesis/AArch64/setReg_init_check.s
+++ b/llvm/test/tools/llvm-exegesis/AArch64/setReg_init_check.s
@@ -60,8 +60,7 @@ RUN: llvm-exegesis -mcpu=neoverse-v2 -mode=latency --dump-object-to-disk=%d --op
 RUN: llvm-objdump -d %d > %t.s
 RUN: FileCheck %s --check-prefix=FPR8-ASM < %t.s
 FPR8-ASM:         <foo>:
-FPR8-ASM:         mov     w{{[0-9]+}}, #0x0
-FPR8-ASM-NEXT:    fmov    h{{[0-9]+}}, w{{[0-9]+}}
+FPR8-ASM:         movi d{{[0-9]+}}, #0000000000000000
 FPR8-ASM-NEXT:    sqabs   b{{[0-9]+}}, b{{[0-9]+}}
 
 
@@ -71,6 +70,6 @@ RUN: llvm-objdump -d %d > %t.s
 RUN: FileCheck %s --check-prefix=FPCR-ASM < %t.s
 FPCR-ASM:         <foo>:
 FPCR-ASM:         movi d{{[0-9]+}}, #0000000000000000
-FPCR-ASM-NEXT:    mov     x{{[0-9]+}}, #0x0
-FPCR-ASM-NEXT:    msr     FPCR, x{{[0-9]+}}
+FPCR-ASM-NEXT:    mov     x8, #0x0
+FPCR-ASM-NEXT:    msr     FPCR, x8
 FPCR-ASM-NEXT:    bfcvt   h{{[0-9]+}}, s{{[0-9]+}}

--- a/llvm/tools/llvm-exegesis/lib/AArch64/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/AArch64/Target.cpp
@@ -88,11 +88,11 @@ loadFP8Immediate(MCRegister Reg, unsigned RegBitWidth, const APInt &Value) {
 static unsigned getLoadFPImmediateOpcode(unsigned RegBitWidth) {
   switch (RegBitWidth) {
   case 16:
-    return AArch64::FMOVH0; //FMOVHi;
+    return AArch64::FMOVH0; // FMOVHi;
   case 32:
-    return AArch64::FMOVS0; //FMOVSi;
+    return AArch64::FMOVS0; // FMOVSi;
   case 64:
-    return AArch64::MOVID; //FMOVDi;
+    return AArch64::MOVID; // FMOVDi;
   case 128:
     return AArch64::MOVIv2d_ns;
   }


### PR DESCRIPTION
[llvm-exegesis] Adding in llvm-exegesis for Aarch64 for handling FPR8/16/32 and FPCR setReg warning

Current implementation (for Aarch64) in llvm-exegesis only supports GRP32, GPR64, FPR64/128, PPR16 and ZPR128 register class, thus for opcodes variants which used llvm-exegesis throws warning "setReg is not implemented". This code will handle the all rest floating point register classes and initialize the registers using appropriate base instruction. And appropriate testcases for the four register classes.