### PR TITLE
 [AMDGPU] Improve StructurizeCFG pass performance by using SSAUpdaterBulk.

### DIFF
--- a/llvm/lib/Transforms/Scalar/StructurizeCFG.cpp
+++ b/llvm/lib/Transforms/Scalar/StructurizeCFG.cpp
@@ -47,6 +47,7 @@
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Transforms/Utils/Local.h"
 #include "llvm/Transforms/Utils/SSAUpdater.h"
+#include "llvm/Transforms/Utils/SSAUpdaterBulk.h"
 #include <cassert>
 #include <utility>
 
@@ -317,7 +318,7 @@ class StructurizeCFG {
 
   void collectInfos();
 
-  void insertConditions(bool Loops);
+  void insertConditions(bool Loops, SSAUpdaterBulk &PhiInserter);
 
   void simplifyConditions();
 
@@ -600,10 +601,9 @@ void StructurizeCFG::collectInfos() {
 }
 
 /// Insert the missing branch conditions
-void StructurizeCFG::insertConditions(bool Loops) {
+void StructurizeCFG::insertConditions(bool Loops, SSAUpdaterBulk &PhiInserter) {
   BranchVector &Conds = Loops ? LoopConds : Conditions;
   Value *Default = Loops ? BoolTrue : BoolFalse;
-  SSAUpdater PhiInserter;
 
   for (BranchInst *Term : Conds) {
     assert(Term->isConditional());
@@ -619,22 +619,23 @@ void StructurizeCFG::insertConditions(bool Loops) {
       Term->setCondition(PI.Pred);
       CondBranchWeights::setMetadata(*Term, PI.Weights);
     } else {
-      PhiInserter.Initialize(Boolean, "");
-      PhiInserter.AddAvailableValue(Loops ? SuccFalse : Parent, Default);
+      unsigned Variable = PhiInserter.AddVariable("", Boolean);
+      PhiInserter.AddAvailableValue(Variable, Loops ? SuccFalse : Parent,
+                                    Default);
 
       NearestCommonDominator Dominator(DT);
       Dominator.addBlock(Parent);
 
       for (auto [BB, PI] : Preds) {
         assert(BB != Parent);
-        PhiInserter.AddAvailableValue(BB, PI.Pred);
+        PhiInserter.AddAvailableValue(Variable, BB, PI.Pred);
         Dominator.addAndRememberBlock(BB);
       }
 
       if (!Dominator.resultIsRememberedBlock())
-        PhiInserter.AddAvailableValue(Dominator.result(), Default);
+        PhiInserter.AddAvailableValue(Variable, Dominator.result(), Default);
 
-      Term->setCondition(PhiInserter.GetValueInMiddleOfBlock(Parent));
+      PhiInserter.AddUse(Variable, &Term->getOperandUse(0));
     }
   }
 }
@@ -1321,8 +1322,12 @@ bool StructurizeCFG::run(Region *R, DominatorTree *DT) {
   orderNodes();
   collectInfos();
   createFlow();
-  insertConditions(false);
-  insertConditions(true);
+
+  SSAUpdaterBulk PhiInserter;
+  insertConditions(false, PhiInserter);
+  insertConditions(true, PhiInserter);
+  PhiInserter.RewriteAllUses(DT);
+
   setPhiValues();
   simplifyConditions();
   simplifyAffectedPhis();


### PR DESCRIPTION
This is almost the rebased patch from @arsenm. This speedups the StructurizeCFG by 42x on a large testcase.

I haven't fully reviewed test changes, I'm not sure why they happened. One of the idea is to compare IRs after the pass to get a clue what is going on there.

