### PR TITLE
Fix data race in PyOperation

### DIFF
--- a/mlir/lib/Bindings/Python/IRModule.h
+++ b/mlir/lib/Bindings/Python/IRModule.h
@@ -253,6 +253,9 @@ public:
   struct ErrorCapture;
 
 private:
+  void _clearOperationLocked(MlirOperation op);
+  void _clearOperationAndInsideLocked(PyOperationBase &op);
+
   // Interns the mapping of live MlirContext::ptr to PyMlirContext instances,
   // preserving the relationship that an MlirContext maps to a single
   // PyMlirContext wrapper. This could be replaced in the future with an
@@ -646,8 +649,8 @@ public:
   }
 
   /// Gets the backing operation.
-  operator MlirOperation() const { return get(); }
-  MlirOperation get() const {
+  operator MlirOperation() { return get(); }
+  MlirOperation get() {
     checkValid();
     return operation;
   }
@@ -665,7 +668,7 @@ public:
     assert(attached && "operation already detached");
     attached = false;
   }
-  void checkValid() const;
+  void checkValid();
 
   /// Gets the owning block or raises an exception if the operation has no
   /// owning block.
@@ -700,7 +703,10 @@ public:
   void erase();
 
   /// Invalidate the operation.
-  void setInvalid() { valid = false; }
+  void setInvalid() {
+    nanobind::ft_lock_guard lock(opMutex);
+    valid = false;
+  }
 
   /// Clones this operation.
   nanobind::object clone(const nanobind::object &ip);
@@ -723,6 +729,8 @@ private:
   nanobind::object parentKeepAlive;
   bool attached = true;
   bool valid = true;
+
+  nanobind::ft_mutex opMutex;
 
   friend class PyOperationBase;
   friend class PySymbolTable;

--- a/mlir/test/python/multithreaded_tests.py
+++ b/mlir/test/python/multithreaded_tests.py
@@ -511,6 +511,45 @@ class TestAllMultiThreaded(unittest.TestCase):
             with InsertionPoint(module.body), Location.name("c"):
                 arith.constant(dtype, py_values[2])
 
+    def test_check_pyoperation_race(self):
+        num_workers = 40
+        num_runs = 20
+
+        barrier = threading.Barrier(num_workers)
+
+        def check_op(op):
+            op_name = op.operation.name
+
+        def walk_operations(op):
+            check_op(op)
+            for region in op.operation.regions:
+                for block in region:
+                    for op in block:
+                        walk_operations(op)
+
+        with Context():
+            mlir_module = Module.parse(
+                """
+    module @jit_sin attributes {mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {
+    func.func public @main(%arg0: tensor<f32>) -> (tensor<f32> {jax.result_info = ""}) {
+        return %arg0 : tensor<f32>
+    }
+    }
+                """
+            )
+
+        def closure():
+            barrier.wait()
+
+            for _ in range(num_runs):
+                walk_operations(mlir_module)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
+            futures = []
+            for i in range(num_workers):
+                futures.append(executor.submit(closure))
+            assert len(list(f.result() for f in futures)) == num_workers
+
 
 if __name__ == "__main__":
     # Do not run the tests on CPython with GIL


### PR DESCRIPTION
Description:

In a multi-threaded execution, it can be a situation when one thread creates PyOperation python handle, do some work (e.g. fetch operation name) and finally decreases the reference count of `module.operation` which can lead to the object destruction if the reference was not yet increased. At the same time, another thread can find a PyOperation instance in `liveOperations` and increases its refcount, but it is too late.


- Use liveOperationsMutex in ~PyOperation and lock first liveOperationsMutex and then opMutex

Data race report: https://gist.github.com/vfdev-5/02bb822a0475d782da60815604ef30da
