### PR TITLE
[Clang] Make `MangleContext::mangleMSGuidDecl()`, `MangleContext::mangleObjCMethodName()` and `MangleContext::mangleObjCMethodNameAsSourceName()` const methods

### DIFF
--- a/clang/include/clang/AST/Mangle.h
+++ b/clang/include/clang/AST/Mangle.h
@@ -140,7 +140,7 @@ public:
   virtual void mangleCXXRTTIName(QualType T, raw_ostream &,
                                  bool NormalizeIntegers = false) = 0;
   virtual void mangleStringLiteral(const StringLiteral *SL, raw_ostream &) = 0;
-  virtual void mangleMSGuidDecl(const MSGuidDecl *GD, raw_ostream &);
+  virtual void mangleMSGuidDecl(const MSGuidDecl *GD, raw_ostream &) const;
 
   void mangleGlobalBlock(const BlockDecl *BD, const NamedDecl *ID,
                          raw_ostream &Out);
@@ -153,9 +153,9 @@ public:
 
   void mangleObjCMethodName(const ObjCMethodDecl *MD, raw_ostream &OS,
                             bool includePrefixByte = true,
-                            bool includeCategoryNamespace = true);
+                            bool includeCategoryNamespace = true) const;
   void mangleObjCMethodNameAsSourceName(const ObjCMethodDecl *MD,
-                                        raw_ostream &);
+                                        raw_ostream &) const;
 
   virtual void mangleStaticGuardVariable(const VarDecl *D, raw_ostream &) = 0;
 

--- a/clang/lib/AST/Mangle.cpp
+++ b/clang/lib/AST/Mangle.cpp
@@ -240,7 +240,8 @@ void MangleContext::mangleName(GlobalDecl GD, raw_ostream &Out) {
   Out << ((DefaultPtrWidth / 8) * ArgWords);
 }
 
-void MangleContext::mangleMSGuidDecl(const MSGuidDecl *GD, raw_ostream &Out) {
+void MangleContext::mangleMSGuidDecl(const MSGuidDecl *GD,
+                                     raw_ostream &Out) const {
   // For now, follow the MSVC naming convention for GUID objects on all
   // targets.
   MSGuidDecl::Parts P = GD->getParts();
@@ -327,7 +328,7 @@ void MangleContext::mangleBlock(const DeclContext *DC, const BlockDecl *BD,
 void MangleContext::mangleObjCMethodName(const ObjCMethodDecl *MD,
                                          raw_ostream &OS,
                                          bool includePrefixByte,
-                                         bool includeCategoryNamespace) {
+                                         bool includeCategoryNamespace) const {
   if (getASTContext().getLangOpts().ObjCRuntime.isGNUFamily()) {
     // This is the mangling we've always used on the GNU runtimes, but it
     // has obvious collisions in the face of underscores within class
@@ -382,7 +383,7 @@ void MangleContext::mangleObjCMethodName(const ObjCMethodDecl *MD,
 }
 
 void MangleContext::mangleObjCMethodNameAsSourceName(const ObjCMethodDecl *MD,
-                                                     raw_ostream &Out) {
+                                                     raw_ostream &Out) const {
   SmallString<64> Name;
   llvm::raw_svector_ostream OS(Name);
 


### PR DESCRIPTION
Unfortunately, making `MangleContext::mangleName()` would require a lot of const escapes due to lazy initialization and id creations:

`Mangle.h`:
* https://github.com/llvm/llvm-project/blob/dffbc030e75b758e7512518abd499a0f680addbf/clang/include/clang/AST/Mangle.h#L82-L85
* https://github.com/llvm/llvm-project/blob/dffbc030e75b758e7512518abd499a0f680addbf/clang/include/clang/AST/Mangle.h#L97-L99

`ItaniumMangle.cpp`:
* https://github.com/llvm/llvm-project/blob/dffbc030e75b758e7512518abd499a0f680addbf/clang/lib/AST/ItaniumMangle.cpp#L158-L161
* https://github.com/llvm/llvm-project/blob/4508d6aa72b0f31056ae01aff0e8009a252e4683/clang/lib/AST/ItaniumMangle.cpp#L641

`MicrosoftMangle.cpp`:
* https://github.com/llvm/llvm-project/blob/dffbc030e75b758e7512518abd499a0f680addbf/clang/lib/AST/MicrosoftMangle.cpp#L243-L245
* https://github.com/llvm/llvm-project/blob/dffbc030e75b758e7512518abd499a0f680addbf/clang/lib/AST/MicrosoftMangle.cpp#L284