### PR TITLE
[Libc] Turn implicit to explicit conversion

### DIFF
--- a/libc/src/__support/high_precision_decimal.h
+++ b/libc/src/__support/high_precision_decimal.h
@@ -401,7 +401,7 @@ public:
         this->right_shift(MAX_SHIFT_AMOUNT);
         shift_amount += MAX_SHIFT_AMOUNT;
       }
-      this->right_shift(-static_cast<uint32_t>(shift_amount));
+      this->right_shift(static_cast<uint32_t>(-shift_amount));
     }
   }
 

--- a/libc/src/__support/high_precision_decimal.h
+++ b/libc/src/__support/high_precision_decimal.h
@@ -401,7 +401,7 @@ public:
         this->right_shift(MAX_SHIFT_AMOUNT);
         shift_amount += MAX_SHIFT_AMOUNT;
       }
-      this->right_shift(-shift_amount);
+      this->right_shift(-static_cast<uint32_t>(shift_amount));
     }
   }
 


### PR DESCRIPTION
This fixes a build issue on the AMDGPU libc bot after https://github.com/llvm/llvm-project/pull/126846 landed that introduced a warning.