### PR TITLE
[lldb][XcodeSDK] Simplify logic that adjusts sysroot during XcodeSDK merging

### DIFF
--- a/lldb/include/lldb/Utility/XcodeSDK.h
+++ b/lldb/include/lldb/Utility/XcodeSDK.h
@@ -65,7 +65,9 @@ public:
   /// parameter. For example, "MacOSX.10.14.sdk".
   XcodeSDK(std::string &&name) : m_name(std::move(name)) {}
   XcodeSDK(std::string name, FileSpec sysroot)
-      : m_name(std::move(name)), m_sysroot(std::move(sysroot)) {}
+      : m_name(std::move(name)), m_sysroot(std::move(sysroot)) {
+    assert(!m_sysroot || m_name == m_sysroot.GetFilename().GetStringRef());
+  }
   static XcodeSDK GetAnyMacOS() { return XcodeSDK("MacOSX.sdk"); }
 
   /// The merge function follows a strict order to maintain monotonicity:

--- a/lldb/unittests/Utility/XcodeSDKTest.cpp
+++ b/lldb/unittests/Utility/XcodeSDKTest.cpp
@@ -66,13 +66,14 @@ TEST(XcodeSDKTest, MergeTest) {
   empty.Merge(XcodeSDK("MacOSX10.14.Internal.sdk"));
   EXPECT_EQ(empty.GetString(), llvm::StringRef("MacOSX10.14.Internal.sdk"));
   EXPECT_FALSE(empty.GetSysroot());
-  empty.Merge(XcodeSDK("MacOSX9.5.Internal.sdk", FileSpec{"/Path/To/9.5.sdk"}));
+  empty.Merge(XcodeSDK("MacOSX9.5.Internal.sdk",
+                       FileSpec{"/Path/To/MacOSX9.5.Internal.sdk"}));
   EXPECT_FALSE(empty.GetSysroot());
-  empty.Merge(XcodeSDK("MacOSX12.5.sdk", FileSpec{"/Path/To/12.5.sdk"}));
-  EXPECT_EQ(empty.GetSysroot(), FileSpec{"/Path/To/12.5.sdk"});
+  empty.Merge(XcodeSDK("MacOSX12.5.sdk", FileSpec{"/Path/To/MacOSX12.5.sdk"}));
+  EXPECT_EQ(empty.GetSysroot(), FileSpec{"/Path/To/MacOSX12.5.sdk"});
   empty.Merge(XcodeSDK("MacOSX11.5.Internal.sdk",
-                       FileSpec{"/Path/To/12.5.Internal.sdk"}));
-  EXPECT_EQ(empty.GetSysroot(), FileSpec{"/Path/To/12.5.Internal.sdk"});
+                       FileSpec{"/Path/To/MacOSX11.5.Internal.sdk"}));
+  EXPECT_EQ(empty.GetSysroot(), FileSpec{"/Path/To/MacOSX12.5.Internal.sdk"});
 }
 
 #ifndef _WIN32


### PR DESCRIPTION
The `DW_AT_APPLE_sdk` should always be equal to the filename of the `DW_AT_LLVM_sysroot`. We can use this property to simplify `XcodeSDK::Merge` to no longer manually adjust the sysroot filename. Instead we simply update the sysroot filename with merged SDK name.

This should be an NFC change.