### PR TITLE
[libc][bazel] explicitly use system-provided errno in Bazel builds.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/libc_configure_options.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_configure_options.bzl
@@ -44,6 +44,11 @@ LIBC_CONFIGURE_OPTIONS = [
     # "LIBC_COPT_STRTOFLOAT_DISABLE_EISEL_LEMIRE",
     # "LIBC_COPT_STRTOFLOAT_DISABLE_SIMPLE_DECIMAL_CONVERSION",
 
+    # Documentation in libc/src/errno/...
+    # Since we're only using Bazel for overlay build for now, explicitly
+    # enforce using the system-provided errno in both tests and release build.
+    "LIBC_ERRNO_MODE=LIBC_ERRNO_MODE_SYSTEM",
+
     # Documentation in libc/src/__support/libc_assert.h
     # "LIBC_COPT_USE_C_ASSERT",
 ]


### PR DESCRIPTION
Addressing the comments from PR #130368 review. Since Bazel builds are effectively overlay mode, switch to explicitly setting -DLIBC_ERRNO_MODE=LIBC_ERRNO_MODE_SYSTEM configuration option, so that unit tests and release builds are consistent. Verified that all the unit tests pass with this flag specified.