### PR TITLE
[MLIR][LLVMIR] Add module flags support

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -1312,7 +1312,7 @@ def ModuleFlagAttr
   }];
   let parameters = (ins "ModFlagBehaviorAttr":$behavior,
                         "StringAttr":$key,
-                        "IntegerAttr":$value);
+                        "uint32_t":$value);
   let assemblyFormat = "`<` $behavior `,` $key `,` $value `>`";
 }
 

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -1307,7 +1307,7 @@ def ModuleFlagAttr
 
     Example:
     ```mlir
-      #llvm.mlir.module_flag<1 : i64, "wchar_size", 4 : i32>
+      #llvm.mlir.module_flag<error, "wchar_size", 4>
     ```
   }];
   let parameters = (ins "ModFlagBehavior":$behavior,

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -1291,4 +1291,29 @@ def LLVM_DereferenceableAttr : LLVM_Attr<"Dereferenceable", "dereferenceable"> {
   let assemblyFormat = "`<` struct(params) `>`";
 }
 
+//===----------------------------------------------------------------------===//
+// ModuleFlagAttr
+//===----------------------------------------------------------------------===//
+
+def ModuleFlagAttr
+    : LLVM_Attr<"ModuleFlag", "mlir.module_flag"> {
+  let summary = "LLVM module flag metadata";
+  let description = [{
+    Represents a single entry of llvm.module.flags metadata
+    (llvm::Module::ModuleFlagEntry in LLVM). The first element is a behavior
+    flag described by `ModFlagBehaviorAttr`, the second is a string ID
+    and third is the value of the flag (currently only integer constant
+    supported).
+
+    Example:
+    ```mlir
+      #llvm.mlir.module_flag<1 : i64, "wchar_size", 4 : i32>
+    ```
+  }];
+  let parameters = (ins "ModFlagBehaviorAttr":$behavior,
+                        "StringAttr":$key,
+                        "IntegerAttr":$value);
+  let assemblyFormat = "`<` $behavior `,` $key `,` $value `>`";
+}
+
 #endif // LLVMIR_ATTRDEFS

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -1310,7 +1310,7 @@ def ModuleFlagAttr
       #llvm.mlir.module_flag<1 : i64, "wchar_size", 4 : i32>
     ```
   }];
-  let parameters = (ins "ModFlagBehaviorAttr":$behavior,
+  let parameters = (ins "ModFlagBehavior":$behavior,
                         "StringAttr":$key,
                         "uint32_t":$value);
   let assemblyFormat = "`<` $behavior `,` $key `,` $value `>`";

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMAttrDefs.td
@@ -1302,8 +1302,8 @@ def ModuleFlagAttr
     Represents a single entry of llvm.module.flags metadata
     (llvm::Module::ModuleFlagEntry in LLVM). The first element is a behavior
     flag described by `ModFlagBehaviorAttr`, the second is a string ID
-    and third is the value of the flag (currently only integer constant
-    supported).
+    and third is the value of the flag (currently only integer constants
+    are supported).
 
     Example:
     ```mlir

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.td
@@ -33,6 +33,7 @@ def LLVM_Dialect : Dialect {
     static StringRef getAliasScopesAttrName() { return "alias_scopes"; }
     static StringRef getAccessGroupsAttrName() { return "access_groups"; }
     static StringRef getIdentAttrName() { return "llvm.ident"; }
+    static StringRef getModuleFlags() { return "llvm.module.flags"; }
     static StringRef getCommandlineAttrName() { return "llvm.commandline"; }
 
     /// Names of llvm parameter attributes.

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMEnums.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMEnums.td
@@ -818,4 +818,37 @@ def FPExceptionBehaviorAttr : LLVM_EnumAttr<
   let cppNamespace = "::mlir::LLVM";
 }
 
+//===----------------------------------------------------------------------===//
+// Module Flag Behavior
+//===----------------------------------------------------------------------===//
+
+// These values must match llvm::Module::ModFlagBehavior ones.
+// See llvm/include/llvm/IR/Module.h.
+def ModFlagBehaviorError
+    : LLVM_EnumAttrCase<"Error", "error", "Error", 1>;
+def ModFlagBehaviorWarning
+    : LLVM_EnumAttrCase<"Warning", "warning", "Warning", 2>;
+def ModFlagBehaviorRequire
+    : LLVM_EnumAttrCase<"Require", "require", "Require", 3>;
+def ModFlagBehaviorOverride
+    : LLVM_EnumAttrCase<"Override", "override", "Override", 4>;
+def ModFlagBehaviorAppend
+    : LLVM_EnumAttrCase<"Append", "append", "Append", 5>;
+def ModFlagBehaviorAppendUnique
+    : LLVM_EnumAttrCase<"AppendUnique", "append_unique", "AppendUnique", 6>;
+def ModFlagBehaviorMax
+    : LLVM_EnumAttrCase<"Max", "max", "Max", 7>;
+def ModFlagBehaviorMin
+    : LLVM_EnumAttrCase<"Min", "min", "Min", 8>;
+
+def ModFlagBehaviorAttr : LLVM_EnumAttr<
+    "ModFlagBehavior",
+    "::llvm::Module::ModFlagBehavior",
+    "LLVM Module Flag Behavior",
+    [ModFlagBehaviorError, ModFlagBehaviorWarning, ModFlagBehaviorRequire,
+     ModFlagBehaviorOverride, ModFlagBehaviorAppend,
+     ModFlagBehaviorAppendUnique, ModFlagBehaviorMax, ModFlagBehaviorMin]> {
+  let cppNamespace = "::mlir::LLVM";
+}
+
 #endif // LLVMIR_ENUMS

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -2183,4 +2183,36 @@ def LLVM_LinkerOptionsOp
   let hasVerifier = 1;
 }
 
+//===--------------------------------------------------------------------===//
+// ModuleFlagsOp
+//===--------------------------------------------------------------------===//
+
+def LLVM_ModuleFlagsOp
+    : LLVM_Op<"module_flags"> {
+  let summary = "Information about module properties";
+  let description = [{
+    Represents the equivalent in MLIR for LLVM's `llvm.module.flags` metadata,
+    which requires a list of metadata triplets. Each triplet entry is described
+    by a `ModuleFlagAttr`.
+
+    Example:
+    ```mlir
+    llvm.module.flags [
+      #llvm.mlir.module_flag<1 : i64, "wchar_size", 4 : i32>,
+      #llvm.mlir.module_flag<8 : i64, "PIC Level", 2 : i32>
+    ]
+    ```
+  }];
+  let arguments  = (ins ArrayAttr:$flags);
+  let assemblyFormat = [{
+    $flags attr-dict
+  }];
+
+  let llvmBuilder = [{
+    convertModuleFlagsOp($flags, builder, moduleTranslation);
+  }];
+
+  let hasVerifier = 1;
+}
+
 #endif // LLVMIR_OPS

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -2198,8 +2198,8 @@ def LLVM_ModuleFlagsOp
     Example:
     ```mlir
     llvm.module.flags [
-      #llvm.mlir.module_flag<1 : i64, "wchar_size", 4 : i32>,
-      #llvm.mlir.module_flag<8 : i64, "PIC Level", 2 : i32>
+      #llvm.mlir.module_flag<error, "wchar_size", 4>,
+      #llvm.mlir.module_flag<max, "PIC Level", 2>
     ]
     ```
   }];

--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -218,8 +218,7 @@ public:
   /// LLVM dialect operation.
   LogicalResult convertLinkerOptionsMetadata();
 
-  /// Converts !llvm.module.flags metadata to the XYZ
-  /// LLVM dialect operation.
+  /// Converts !llvm.module.flags metadata.
   LogicalResult convertModuleFlagsMetadata();
 
   /// Converts !llvm.ident metadata to the llvm.ident LLVM ModuleOp attribute.

--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -218,6 +218,10 @@ public:
   /// LLVM dialect operation.
   LogicalResult convertLinkerOptionsMetadata();
 
+  /// Converts !llvm.module.flags metadata to the XYZ
+  /// LLVM dialect operation.
+  LogicalResult convertModuleFlagsMetadata();
+
   /// Converts !llvm.ident metadata to the llvm.ident LLVM ModuleOp attribute.
   LogicalResult convertIdentMetadata();
 

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3717,7 +3717,7 @@ LogicalResult LinkerOptionsOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ModuleFlagsOp::verify() {
-  if (mlir::Operation *parentOp = (*this)->getParentOp();
+  if (Operation *parentOp = (*this)->getParentOp();
       parentOp && !satisfiesLLVMModule(parentOp))
     return emitOpError("must appear at the module level");
   for (auto &flag : getFlags()) {

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3713,6 +3713,21 @@ LogicalResult LinkerOptionsOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
+// ModuleFlagsOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ModuleFlagsOp::verify() {
+  if (mlir::Operation *parentOp = (*this)->getParentOp();
+      parentOp && !satisfiesLLVMModule(parentOp))
+    return emitOpError("must appear at the module level");
+  for (auto &flag : getFlags()) {
+    if (!isa<ModuleFlagAttr>(flag))
+      return emitOpError("expected a module flag attribute");
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // InlineAsmOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3720,7 +3720,7 @@ LogicalResult ModuleFlagsOp::verify() {
   if (Operation *parentOp = (*this)->getParentOp();
       parentOp && !satisfiesLLVMModule(parentOp))
     return emitOpError("must appear at the module level");
-  for (auto &flag : getFlags()) {
+  for (Attribute flag : getFlags()) {
     if (!isa<ModuleFlagAttr>(flag))
       return emitOpError("expected a module flag attribute");
   }

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3720,10 +3720,9 @@ LogicalResult ModuleFlagsOp::verify() {
   if (Operation *parentOp = (*this)->getParentOp();
       parentOp && !satisfiesLLVMModule(parentOp))
     return emitOpError("must appear at the module level");
-  for (Attribute flag : getFlags()) {
+  for (Attribute flag : getFlags())
     if (!isa<ModuleFlagAttr>(flag))
       return emitOpError("expected a module flag attribute");
-  }
   return success();
 }
 

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -270,6 +270,19 @@ static void convertLinkerOptionsOp(ArrayAttr options,
   linkerMDNode->addOperand(listMDNode);
 }
 
+static void convertModuleFlagsOp(ArrayAttr flags, llvm::IRBuilderBase &builder,
+                                 LLVM::ModuleTranslation &moduleTranslation) {
+  llvm::Module *llvmModule = moduleTranslation.getLLVMModule();
+  for (Attribute attr : flags) {
+    auto flag = cast<ModuleFlagAttr>(attr);
+    auto intVal = dyn_cast<IntegerAttr>(flag.getValue());
+    assert(intVal && "expected integer attribute");
+    llvmModule->addModuleFlag(
+        (llvm::Module::ModFlagBehavior)flag.getBehavior().getValue(),
+        flag.getKey().getValue(), (uint32_t)intVal.getUInt());
+  }
+}
+
 static LogicalResult
 convertOperationImpl(Operation &opInst, llvm::IRBuilderBase &builder,
                      LLVM::ModuleTranslation &moduleTranslation) {

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -273,14 +273,10 @@ static void convertLinkerOptionsOp(ArrayAttr options,
 static void convertModuleFlagsOp(ArrayAttr flags, llvm::IRBuilderBase &builder,
                                  LLVM::ModuleTranslation &moduleTranslation) {
   llvm::Module *llvmModule = moduleTranslation.getLLVMModule();
-  for (auto flagAttr : flags.getAsRange<ModuleFlagAttr>()) {
-    auto flag = cast<ModuleFlagAttr>(attr);
-    auto intVal = dyn_cast<IntegerAttr>(flag.getValue());
-    assert(intVal && "expected integer attribute");
+  for (auto flagAttr : flags.getAsRange<ModuleFlagAttr>())
     llvmModule->addModuleFlag(
-        static_cast<llvm::Module::ModFlagBehavior>(flag.getBehavior().getValue()),
-        flag.getKey().getValue(), (uint32_t)intVal.getUInt());
-  }
+        static_cast<llvm::Module::ModFlagBehavior>(flagAttr.getBehavior()),
+        flagAttr.getKey().getValue(), flagAttr.getValue());
 }
 
 static LogicalResult

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -275,7 +275,7 @@ static void convertModuleFlagsOp(ArrayAttr flags, llvm::IRBuilderBase &builder,
   llvm::Module *llvmModule = moduleTranslation.getLLVMModule();
   for (auto flagAttr : flags.getAsRange<ModuleFlagAttr>())
     llvmModule->addModuleFlag(
-        static_cast<llvm::Module::ModFlagBehavior>(flagAttr.getBehavior()),
+        convertModFlagBehaviorToLLVM(flagAttr.getBehavior()),
         flagAttr.getKey().getValue(), flagAttr.getValue());
 }
 

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -273,7 +273,7 @@ static void convertLinkerOptionsOp(ArrayAttr options,
 static void convertModuleFlagsOp(ArrayAttr flags, llvm::IRBuilderBase &builder,
                                  LLVM::ModuleTranslation &moduleTranslation) {
   llvm::Module *llvmModule = moduleTranslation.getLLVMModule();
-  for (Attribute attr : flags) {
+  for (auto flagAttr : flags.getAsRange<ModuleFlagAttr>()) {
     auto flag = cast<ModuleFlagAttr>(attr);
     auto intVal = dyn_cast<IntegerAttr>(flag.getValue());
     assert(intVal && "expected integer attribute");

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -278,7 +278,7 @@ static void convertModuleFlagsOp(ArrayAttr flags, llvm::IRBuilderBase &builder,
     auto intVal = dyn_cast<IntegerAttr>(flag.getValue());
     assert(intVal && "expected integer attribute");
     llvmModule->addModuleFlag(
-        (llvm::Module::ModFlagBehavior)flag.getBehavior().getValue(),
+        static_cast<llvm::Module::ModFlagBehavior>(flag.getBehavior().getValue()),
         flag.getKey().getValue(), (uint32_t)intVal.getUInt());
   }
 }

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -544,8 +544,8 @@ LogicalResult ModuleImport::convertModuleFlagsMetadata() {
         builder.getContext(), (ModFlagBehavior)behavior);
 
     moduleFlags.push_back(
-        ModuleFlagAttr::get(builder.getContext(), behaviorAttr,
-                            builder.getStringAttr(key->getString()), valAttr));
+        builder.getAttr<ModuleFlagAttr>(behaviorAttr, builder.getStringAttr(key->getString()),
+                                                                valAttr));
   }
 
   if (!moduleFlags.empty()) {

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -530,11 +530,12 @@ LogicalResult ModuleImport::convertModuleFlagsMetadata() {
   for (const auto [behavior, key, val] : llvmModuleFlags) {
     // Currently only supports most common: int constant values.
     auto *constInt = llvm::mdconst::dyn_extract<llvm::ConstantInt>(val);
-    if (!constInt)
-      return emitWarning(mlirModule.getLoc())
-             << "unsupported module flag value: "
-             << diagMD(val, llvmModule.get())
-             << ", only constant integer currently supported";
+    if (!constInt) {
+      emitWarning(mlirModule.getLoc())
+          << "unsupported module flag value: " << diagMD(val, llvmModule.get())
+          << ", only constant integer currently supported";
+      continue;
+    }
 
     moduleFlags.push_back(builder.getAttr<ModuleFlagAttr>(
         convertModFlagBehaviorFromLLVM(behavior),

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -518,15 +518,10 @@ void ModuleImport::addDebugIntrinsic(llvm::CallInst *intrinsic) {
 }
 
 LogicalResult ModuleImport::convertModuleFlagsMetadata() {
-  SmallVector<llvm::Module::ModuleFlagEntry, 4> llvmModuleFlags;
-  for (const llvm::NamedMDNode &named : llvmModule->named_metadata()) {
-    if (named.getName() != LLVMDialect::getModuleFlags())
-      continue;
-    llvmModule->getModuleFlagsMetadata(llvmModuleFlags);
-    break; // there can only be one module flags.
-  }
+  SmallVector<llvm::Module::ModuleFlagEntry> llvmModuleFlags;
+  llvmModule->getModuleFlagsMetadata(llvmModuleFlags);
 
-  SmallVector<Attribute, 4> moduleFlags;
+  SmallVector<Attribute> moduleFlags;
   for (const auto [behavior, key, val] : llvmModuleFlags) {
     // Currently only supports most common: int constant values.
     auto *constInt = llvm::mdconst::dyn_extract<llvm::ConstantInt>(val);

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -536,16 +536,16 @@ LogicalResult ModuleImport::convertModuleFlagsMetadata() {
              << diagMD(val, llvmModule.get())
              << ", only constant integer currently supported";
     }
-    auto valAttr = builder.getIntegerAttr(
-        IntegerType::get(context, constInt->getType()->getIntegerBitWidth()),
-        constInt->getValue());
+    // auto valAttr = builder.getIntegerAttr(
+    //     IntegerType::get(context, constInt->getType()->getIntegerBitWidth()),
+    //     constInt->getValue());
 
-    ModFlagBehaviorAttr behaviorAttr = ModFlagBehaviorAttr::get(
-        builder.getContext(), (ModFlagBehavior)behavior);
+    // ModFlagBehaviorAttr behaviorAttr = ModFlagBehaviorAttr::get(
+    //     builder.getContext(), (ModFlagBehavior)behavior);
 
-    moduleFlags.push_back(
-        builder.getAttr<ModuleFlagAttr>(behaviorAttr, builder.getStringAttr(key->getString()),
-                                                                valAttr));
+    moduleFlags.push_back(builder.getAttr<ModuleFlagAttr>(
+        (ModFlagBehavior)behavior, builder.getStringAttr(key->getString()),
+        constInt->getZExtValue()));
   }
 
   if (!moduleFlags.empty()) {

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -530,28 +530,20 @@ LogicalResult ModuleImport::convertModuleFlagsMetadata() {
   for (const auto [behavior, key, val] : llvmModuleFlags) {
     // Currently only supports most common: int constant values.
     auto *constInt = llvm::mdconst::dyn_extract<llvm::ConstantInt>(val);
-    if (!constInt) {
+    if (!constInt)
       return emitWarning(mlirModule.getLoc())
              << "unsupported module flag value: "
              << diagMD(val, llvmModule.get())
              << ", only constant integer currently supported";
-    }
-    // auto valAttr = builder.getIntegerAttr(
-    //     IntegerType::get(context, constInt->getType()->getIntegerBitWidth()),
-    //     constInt->getValue());
-
-    // ModFlagBehaviorAttr behaviorAttr = ModFlagBehaviorAttr::get(
-    //     builder.getContext(), (ModFlagBehavior)behavior);
 
     moduleFlags.push_back(builder.getAttr<ModuleFlagAttr>(
-        (ModFlagBehavior)behavior, builder.getStringAttr(key->getString()),
-        constInt->getZExtValue()));
+        convertModFlagBehaviorFromLLVM(behavior),
+        builder.getStringAttr(key->getString()), constInt->getZExtValue()));
   }
 
-  if (!moduleFlags.empty()) {
+  if (!moduleFlags.empty())
     builder.create<LLVM::ModuleFlagsOp>(mlirModule.getLoc(),
                                         builder.getArrayAttr(moduleFlags));
-  }
 
   return success();
 }

--- a/mlir/test/Dialect/LLVMIR/invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/invalid.mlir
@@ -1767,7 +1767,7 @@ llvm.mlir.alias external @y5 : i32 {
 // -----
 
 module {
-  // expected-error@+2 {{invalid kind of attribute specified}}
-  // expected-error@+1 {{failed to parse ModuleFlagAttr parameter 'value' which is to be a `IntegerAttr`}}
-  llvm.module_flags [#llvm.mlir.module_flag<1 : i64, "wchar_size", "yolo">]
+  // expected-error@+2 {{expected integer value}}
+  // expected-error@+1 {{failed to parse ModuleFlagAttr parameter 'value' which is to be a `uint32_t`}}
+  llvm.module_flags [#llvm.mlir.module_flag<error, "wchar_size", "yolo">]
 }

--- a/mlir/test/Dialect/LLVMIR/invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/invalid.mlir
@@ -1764,3 +1764,10 @@ llvm.mlir.alias external @y5 : i32 {
   llvm.return %0 : !llvm.ptr<4>
 }
 
+// -----
+
+module {
+  // expected-error@+2 {{invalid kind of attribute specified}}
+  // expected-error@+1 {{failed to parse ModuleFlagAttr parameter 'value' which is to be a `IntegerAttr`}}
+  llvm.module_flags [#llvm.mlir.module_flag<1 : i64, "wchar_size", "yolo">]
+}

--- a/mlir/test/Dialect/LLVMIR/module-roundtrip.mlir
+++ b/mlir/test/Dialect/LLVMIR/module-roundtrip.mlir
@@ -1,16 +1,16 @@
 // RUN: mlir-opt %s | mlir-opt | FileCheck %s
 
 module {
-  llvm.module_flags [#llvm.mlir.module_flag<1 : i64, "wchar_size", 4 : i32>,
-                     #llvm.mlir.module_flag<8 : i64, "PIC Level", 2 : i32>,
-                     #llvm.mlir.module_flag<7 : i64, "PIE Level", 2 : i32>,
-                     #llvm.mlir.module_flag<7 : i64, "uwtable", 2 : i32>,
-                     #llvm.mlir.module_flag<7 : i64, "frame-pointer", 1 : i32>]
+  llvm.module_flags [#llvm.mlir.module_flag<error, "wchar_size", 4>,
+                     #llvm.mlir.module_flag<min, "PIC Level", 2>,
+                     #llvm.mlir.module_flag<max, "PIE Level", 2>,
+                     #llvm.mlir.module_flag<max, "uwtable", 2>,
+                     #llvm.mlir.module_flag<max, "frame-pointer", 1>]
 }
 
 // CHECK: llvm.module_flags [
-// CHECK-SAME: #llvm.mlir.module_flag<1 : i64, "wchar_size", 4 : i32>,
-// CHECK-SAME: #llvm.mlir.module_flag<8 : i64, "PIC Level", 2 : i32>,
-// CHECK-SAME: #llvm.mlir.module_flag<7 : i64, "PIE Level", 2 : i32>,
-// CHECK-SAME: #llvm.mlir.module_flag<7 : i64, "uwtable", 2 : i32>,
-// CHECK-SAME: #llvm.mlir.module_flag<7 : i64, "frame-pointer", 1 : i32>]
+// CHECK-SAME: #llvm.mlir.module_flag<error, "wchar_size", 4>,
+// CHECK-SAME: #llvm.mlir.module_flag<min, "PIC Level", 2>,
+// CHECK-SAME: #llvm.mlir.module_flag<max, "PIE Level", 2>,
+// CHECK-SAME: #llvm.mlir.module_flag<max, "uwtable", 2>,
+// CHECK-SAME: #llvm.mlir.module_flag<max, "frame-pointer", 1>]

--- a/mlir/test/Dialect/LLVMIR/module-roundtrip.mlir
+++ b/mlir/test/Dialect/LLVMIR/module-roundtrip.mlir
@@ -1,0 +1,16 @@
+// RUN: mlir-opt %s | mlir-opt | FileCheck %s
+
+module {
+  llvm.module_flags [#llvm.mlir.module_flag<1 : i64, "wchar_size", 4 : i32>,
+                     #llvm.mlir.module_flag<8 : i64, "PIC Level", 2 : i32>,
+                     #llvm.mlir.module_flag<7 : i64, "PIE Level", 2 : i32>,
+                     #llvm.mlir.module_flag<7 : i64, "uwtable", 2 : i32>,
+                     #llvm.mlir.module_flag<7 : i64, "frame-pointer", 1 : i32>]
+}
+
+// CHECK: llvm.module_flags [
+// CHECK-SAME: #llvm.mlir.module_flag<1 : i64, "wchar_size", 4 : i32>,
+// CHECK-SAME: #llvm.mlir.module_flag<8 : i64, "PIC Level", 2 : i32>,
+// CHECK-SAME: #llvm.mlir.module_flag<7 : i64, "PIE Level", 2 : i32>,
+// CHECK-SAME: #llvm.mlir.module_flag<7 : i64, "uwtable", 2 : i32>,
+// CHECK-SAME: #llvm.mlir.module_flag<7 : i64, "frame-pointer", 1 : i32>]

--- a/mlir/test/Target/LLVMIR/Import/module-flags.ll
+++ b/mlir/test/Target/LLVMIR/Import/module-flags.ll
@@ -10,11 +10,11 @@
 
 ; CHECK-LABEL: module attributes {{.*}} {
 ; CHECK: llvm.module_flags [
-; CHECK-SAME: #llvm.mlir.module_flag<1 : i64, "wchar_size", 4 : i32>,
-; CHECK-SAME: #llvm.mlir.module_flag<8 : i64, "PIC Level", 2 : i32>,
-; CHECK-SAME: #llvm.mlir.module_flag<7 : i64, "PIE Level", 2 : i32>,
-; CHECK-SAME: #llvm.mlir.module_flag<7 : i64, "uwtable", 2 : i32>,
-; CHECK-SAME: #llvm.mlir.module_flag<7 : i64, "frame-pointer", 1 : i32>]
+; CHECK-SAME: #llvm.mlir.module_flag<error, "wchar_size", 4>,
+; CHECK-SAME: #llvm.mlir.module_flag<min, "PIC Level", 2>,
+; CHECK-SAME: #llvm.mlir.module_flag<max, "PIE Level", 2>,
+; CHECK-SAME: #llvm.mlir.module_flag<max, "uwtable", 2>,
+; CHECK-SAME: #llvm.mlir.module_flag<max, "frame-pointer", 1>]
 ; CHECK: }
 
 ; // -----

--- a/mlir/test/Target/LLVMIR/Import/module-flags.ll
+++ b/mlir/test/Target/LLVMIR/Import/module-flags.ll
@@ -1,0 +1,25 @@
+; RUN: mlir-translate -import-llvm -split-input-file -verify-diagnostics %s | FileCheck %s
+
+!llvm.module.flags = !{!0, !1, !2, !3, !4}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 7, !"PIE Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 2}
+!4 = !{i32 7, !"frame-pointer", i32 1}
+
+; CHECK-LABEL: module attributes {{.*}} {
+; CHECK: llvm.module_flags [
+; CHECK-SAME: #llvm.mlir.module_flag<1 : i64, "wchar_size", 4 : i32>,
+; CHECK-SAME: #llvm.mlir.module_flag<8 : i64, "PIC Level", 2 : i32>,
+; CHECK-SAME: #llvm.mlir.module_flag<7 : i64, "PIE Level", 2 : i32>,
+; CHECK-SAME: #llvm.mlir.module_flag<7 : i64, "uwtable", 2 : i32>,
+; CHECK-SAME: #llvm.mlir.module_flag<7 : i64, "frame-pointer", 1 : i32>]
+; CHECK: }
+
+; // -----
+
+!llvm.module.flags = !{!0}
+
+; expected-warning@-5{{unsupported module flag value: !"yolo_more", only constant integer currently supported}}
+!0 = !{i32 1, !"yolo", !"yolo_more"}

--- a/mlir/test/Target/LLVMIR/llvmir-invalid.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-invalid.mlir
@@ -350,7 +350,7 @@ llvm.func @foo() {
 
 llvm.func @foo() {
   // expected-error @below{{must appear at the module level}}
-  llvm.module_flags [#llvm.mlir.module_flag<1 : i64, "wchar_size", 4 : i32>]
+  llvm.module_flags [#llvm.mlir.module_flag<error, "wchar_size", 4>]
 }
 
 // -----

--- a/mlir/test/Target/LLVMIR/llvmir-invalid.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-invalid.mlir
@@ -348,6 +348,20 @@ llvm.func @foo() {
 
 // -----
 
+llvm.func @foo() {
+  // expected-error @below{{must appear at the module level}}
+  llvm.module_flags [#llvm.mlir.module_flag<1 : i64, "wchar_size", 4 : i32>]
+}
+
+// -----
+
+module attributes {} {
+  // expected-error @below{{expected a module flag attribute}}
+  llvm.module_flags [4 : i32]
+}
+
+// -----
+
 module @does_not_exist {
   // expected-error @below{{resource does not exist}}
   llvm.mlir.global internal constant @constant(dense_resource<test0> : tensor<4xf32>) : !llvm.array<4 x f32>

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -2510,6 +2510,25 @@ llvm.linker_options ["/DEFAULTLIB:", "libcmtd"]
 
 // -----
 
+module {
+  llvm.module_flags [#llvm.mlir.module_flag<1 : i64, "wchar_size", 4 : i32>,
+                     #llvm.mlir.module_flag<8 : i64, "PIC Level", 2 : i32>,
+                     #llvm.mlir.module_flag<7 : i64, "PIE Level", 2 : i32>,
+                     #llvm.mlir.module_flag<7 : i64, "uwtable", 2 : i32>,
+                     #llvm.mlir.module_flag<7 : i64, "frame-pointer", 1 : i32>]
+}
+
+// CHECK: !llvm.module.flags = !{![[DBG:.*]], ![[WCHAR:.*]], ![[PIC:.*]], ![[PIE:.*]], ![[UWTABLE:.*]], ![[FP:.*]]}
+
+// CHECK: ![[DBG]] = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK: ![[WCHAR]] = !{i32 1, !"wchar_size", i32 4}
+// CHECK: ![[PIC]] = !{i32 8, !"PIC Level", i32 2}
+// CHECK: ![[PIE]] = !{i32 7, !"PIE Level", i32 2}
+// CHECK: ![[UWTABLE]] = !{i32 7, !"uwtable", i32 2}
+// CHECK: ![[FP]] = !{i32 7, !"frame-pointer", i32 1}
+
+// -----
+
 // CHECK: @big_ = common global [4294967296 x i8] zeroinitializer
 llvm.mlir.global common @big_(dense<0> : vector<4294967296xi8>) {addr_space = 0 : i32} : !llvm.array<4294967296 x i8>
 

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -2518,14 +2518,14 @@ module {
                      #llvm.mlir.module_flag<7 : i64, "frame-pointer", 1 : i32>]
 }
 
-// CHECK: !llvm.module.flags = !{![[DBG:.*]], ![[WCHAR:.*]], ![[PIC:.*]], ![[PIE:.*]], ![[UWTABLE:.*]], ![[FP:.*]]}
+// CHECK: !llvm.module.flags = !{![[#DBG:]], ![[#WCHAR:]], ![[#PIC:]], ![[#PIE:]], ![[#UWTABLE:]], ![[#FP:]]}
 
-// CHECK: ![[DBG]] = !{i32 2, !"Debug Info Version", i32 3}
-// CHECK: ![[WCHAR]] = !{i32 1, !"wchar_size", i32 4}
-// CHECK: ![[PIC]] = !{i32 8, !"PIC Level", i32 2}
-// CHECK: ![[PIE]] = !{i32 7, !"PIE Level", i32 2}
-// CHECK: ![[UWTABLE]] = !{i32 7, !"uwtable", i32 2}
-// CHECK: ![[FP]] = !{i32 7, !"frame-pointer", i32 1}
+// CHECK: ![[#DBG]] = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK: ![[#WCHAR]] = !{i32 1, !"wchar_size", i32 4}
+// CHECK: ![[#PIC]] = !{i32 8, !"PIC Level", i32 2}
+// CHECK: ![[#PIE]] = !{i32 7, !"PIE Level", i32 2}
+// CHECK: ![[#UWTABLE]] = !{i32 7, !"uwtable", i32 2}
+// CHECK: ![[#FP]] = !{i32 7, !"frame-pointer", i32 1}
 
 // -----
 

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -2767,11 +2767,11 @@ llvm.func @call_intrin_with_opbundle(%arg0 : !llvm.ptr) {
 // -----
 
 module {
-  llvm.module_flags [#llvm.mlir.module_flag<1 : i64, "wchar_size", 4 : i32>,
-                     #llvm.mlir.module_flag<8 : i64, "PIC Level", 2 : i32>,
-                     #llvm.mlir.module_flag<7 : i64, "PIE Level", 2 : i32>,
-                     #llvm.mlir.module_flag<7 : i64, "uwtable", 2 : i32>,
-                     #llvm.mlir.module_flag<7 : i64, "frame-pointer", 1 : i32>]
+  llvm.module_flags [#llvm.mlir.module_flag<error, "wchar_size", 4>,
+                     #llvm.mlir.module_flag<min, "PIC Level", 2>,
+                     #llvm.mlir.module_flag<max, "PIE Level", 2>,
+                     #llvm.mlir.module_flag<max, "uwtable", 2>,
+                     #llvm.mlir.module_flag<max, "frame-pointer", 1>]
 }
 
 // CHECK: !llvm.module.flags = !{![[#DBG:]], ![[#WCHAR:]], ![[#PIC:]], ![[#PIE:]], ![[#UWTABLE:]], ![[#FP:]]}

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -2774,11 +2774,11 @@ module {
                      #llvm.mlir.module_flag<max, "frame-pointer", 1>]
 }
 
-// CHECK: !llvm.module.flags = !{![[#DBG:]], ![[#WCHAR:]], ![[#PIC:]], ![[#PIE:]], ![[#UWTABLE:]], ![[#FP:]]}
+// CHECK: !llvm.module.flags = !{![[#DBG:]], ![[#WCHAR:]], ![[#PIC:]], ![[#PIE:]], ![[#UWTABLE:]], ![[#FrameP:]]}
 
 // CHECK: ![[#DBG]] = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK: ![[#WCHAR]] = !{i32 1, !"wchar_size", i32 4}
 // CHECK: ![[#PIC]] = !{i32 8, !"PIC Level", i32 2}
 // CHECK: ![[#PIE]] = !{i32 7, !"PIE Level", i32 2}
 // CHECK: ![[#UWTABLE]] = !{i32 7, !"uwtable", i32 2}
-// CHECK: ![[#FP]] = !{i32 7, !"frame-pointer", i32 1}
+// CHECK: ![[#FrameP]] = !{i32 7, !"frame-pointer", i32 1}

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -2510,25 +2510,6 @@ llvm.linker_options ["/DEFAULTLIB:", "libcmtd"]
 
 // -----
 
-module {
-  llvm.module_flags [#llvm.mlir.module_flag<1 : i64, "wchar_size", 4 : i32>,
-                     #llvm.mlir.module_flag<8 : i64, "PIC Level", 2 : i32>,
-                     #llvm.mlir.module_flag<7 : i64, "PIE Level", 2 : i32>,
-                     #llvm.mlir.module_flag<7 : i64, "uwtable", 2 : i32>,
-                     #llvm.mlir.module_flag<7 : i64, "frame-pointer", 1 : i32>]
-}
-
-// CHECK: !llvm.module.flags = !{![[#DBG:]], ![[#WCHAR:]], ![[#PIC:]], ![[#PIE:]], ![[#UWTABLE:]], ![[#FP:]]}
-
-// CHECK: ![[#DBG]] = !{i32 2, !"Debug Info Version", i32 3}
-// CHECK: ![[#WCHAR]] = !{i32 1, !"wchar_size", i32 4}
-// CHECK: ![[#PIC]] = !{i32 8, !"PIC Level", i32 2}
-// CHECK: ![[#PIE]] = !{i32 7, !"PIE Level", i32 2}
-// CHECK: ![[#UWTABLE]] = !{i32 7, !"uwtable", i32 2}
-// CHECK: ![[#FP]] = !{i32 7, !"frame-pointer", i32 1}
-
-// -----
-
 // CHECK: @big_ = common global [4294967296 x i8] zeroinitializer
 llvm.mlir.global common @big_(dense<0> : vector<4294967296xi8>) {addr_space = 0 : i32} : !llvm.array<4294967296 x i8>
 
@@ -2782,3 +2763,22 @@ llvm.func @call_intrin_with_opbundle(%arg0 : !llvm.ptr) {
 // CHECK-NEXT:   call void @llvm.assume(i1 true) [ "align"(ptr %0, i32 16) ]
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
+
+// -----
+
+module {
+  llvm.module_flags [#llvm.mlir.module_flag<1 : i64, "wchar_size", 4 : i32>,
+                     #llvm.mlir.module_flag<8 : i64, "PIC Level", 2 : i32>,
+                     #llvm.mlir.module_flag<7 : i64, "PIE Level", 2 : i32>,
+                     #llvm.mlir.module_flag<7 : i64, "uwtable", 2 : i32>,
+                     #llvm.mlir.module_flag<7 : i64, "frame-pointer", 1 : i32>]
+}
+
+// CHECK: !llvm.module.flags = !{![[#DBG:]], ![[#WCHAR:]], ![[#PIC:]], ![[#PIE:]], ![[#UWTABLE:]], ![[#FP:]]}
+
+// CHECK: ![[#DBG]] = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK: ![[#WCHAR]] = !{i32 1, !"wchar_size", i32 4}
+// CHECK: ![[#PIC]] = !{i32 8, !"PIC Level", i32 2}
+// CHECK: ![[#PIE]] = !{i32 7, !"PIE Level", i32 2}
+// CHECK: ![[#UWTABLE]] = !{i32 7, !"uwtable", i32 2}
+// CHECK: ![[#FP]] = !{i32 7, !"frame-pointer", i32 1}

--- a/mlir/test/mlir-translate/split-markers.mlir
+++ b/mlir/test/mlir-translate/split-markers.mlir
@@ -21,6 +21,8 @@
 // CHECK-OUTPUT-NEXT: ModuleID
 
 // CHECK-ROUNDTRIP:       module {{.*}} {
+// FIXME: importer forces debug info version even without importing one.
+// CHECK-ROUNDTRIP-NEXT:    llvm.module_flag
 // CHECK-ROUNDTRIP-NEXT:  }
 // CHECK-ROUNDTRIP-EMPTY:
 // CHECK-ROUNDTRIP:       module


### PR DESCRIPTION
Import and translation support.

Note that existing support (prior to this PR) already covers enough in translation specifically to emit "Debug Info Version". Also, the debug info version metadata is being emitted even though the imported IR has no information and is showing up in some tests (will fix that in another PR).