### PR TITLE
[CIR] Upstream CastOp and scalar conversions

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -81,12 +81,11 @@ public:
   }
 
   mlir::Value createDummyValue(mlir::Location loc, mlir::Type type,
-    clang::CharUnits alignment) {
-auto addr =
-createAlloca(loc, getPointerTo(type), type, {},
-getSizeFromCharUnits(getContext(), alignment));
-return createLoad(loc, addr);
-}
+                               clang::CharUnits alignment) {
+    auto addr = createAlloca(loc, getPointerTo(type), type, {},
+                             getSizeFromCharUnits(getContext(), alignment));
+    return createLoad(loc, addr);
+  }
 
   //===--------------------------------------------------------------------===//
   // Cast/Conversion Operators

--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -126,20 +126,6 @@ public:
     return createCast(loc, cir::CastKind::bitcast, src, newTy);
   }
 
-  mlir::Value createPtrBitcast(mlir::Value src, mlir::Type newPointeeTy) {
-    assert(mlir::isa<cir::PointerType>(src.getType()) && "expected ptr src");
-    return createBitcast(src, getPointerTo(newPointeeTy));
-  }
-
-  mlir::Value createAddrSpaceCast(mlir::Location loc, mlir::Value src,
-                                  mlir::Type newTy) {
-    return createCast(loc, cir::CastKind::address_space, src, newTy);
-  }
-
-  mlir::Value createAddrSpaceCast(mlir::Value src, mlir::Type newTy) {
-    return createAddrSpaceCast(src.getLoc(), src, newTy);
-  }
-
   //
   // Block handling helpers
   // ----------------------

--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -10,6 +10,7 @@
 #define LLVM_CLANG_CIR_DIALECT_BUILDER_CIRBASEBUILDER_H
 
 #include "clang/AST/CharUnits.h"
+#include "clang/AST/Type.h"
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
@@ -78,6 +79,14 @@ public:
                            mlir::Value dst) {
     return create<cir::StoreOp>(loc, val, dst);
   }
+
+  mlir::Value createDummyValue(mlir::Location loc, mlir::Type type,
+    clang::CharUnits alignment) {
+auto addr =
+createAlloca(loc, getPointerTo(type), type, {},
+getSizeFromCharUnits(getContext(), alignment));
+return createLoad(loc, addr);
+}
 
   //===--------------------------------------------------------------------===//
   // Cast/Conversion Operators

--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -13,6 +13,7 @@
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
+#include "llvm/Support/ErrorHandling.h"
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -76,6 +77,67 @@ public:
   cir::StoreOp createStore(mlir::Location loc, mlir::Value val,
                            mlir::Value dst) {
     return create<cir::StoreOp>(loc, val, dst);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Cast/Conversion Operators
+  //===--------------------------------------------------------------------===//
+
+  mlir::Value createCast(mlir::Location loc, cir::CastKind kind,
+                         mlir::Value src, mlir::Type newTy) {
+    if (newTy == src.getType())
+      return src;
+    return create<cir::CastOp>(loc, newTy, kind, src);
+  }
+
+  mlir::Value createCast(cir::CastKind kind, mlir::Value src,
+                         mlir::Type newTy) {
+    if (newTy == src.getType())
+      return src;
+    return createCast(src.getLoc(), kind, src, newTy);
+  }
+
+  mlir::Value createIntCast(mlir::Value src, mlir::Type newTy) {
+    return createCast(cir::CastKind::integral, src, newTy);
+  }
+
+  mlir::Value createIntToPtr(mlir::Value src, mlir::Type newTy) {
+    return createCast(cir::CastKind::int_to_ptr, src, newTy);
+  }
+
+  mlir::Value createPtrToInt(mlir::Value src, mlir::Type newTy) {
+    return createCast(cir::CastKind::ptr_to_int, src, newTy);
+  }
+
+  mlir::Value createPtrToBoolCast(mlir::Value v) {
+    return createCast(cir::CastKind::ptr_to_bool, v, getBoolTy());
+  }
+
+  mlir::Value createBoolToInt(mlir::Value src, mlir::Type newTy) {
+    return createCast(cir::CastKind::bool_to_int, src, newTy);
+  }
+
+  mlir::Value createBitcast(mlir::Value src, mlir::Type newTy) {
+    return createCast(cir::CastKind::bitcast, src, newTy);
+  }
+
+  mlir::Value createBitcast(mlir::Location loc, mlir::Value src,
+                            mlir::Type newTy) {
+    return createCast(loc, cir::CastKind::bitcast, src, newTy);
+  }
+
+  mlir::Value createPtrBitcast(mlir::Value src, mlir::Type newPointeeTy) {
+    assert(mlir::isa<cir::PointerType>(src.getType()) && "expected ptr src");
+    return createBitcast(src, getPointerTo(newPointeeTy));
+  }
+
+  mlir::Value createAddrSpaceCast(mlir::Location loc, mlir::Value src,
+                                  mlir::Type newTy) {
+    return createCast(loc, cir::CastKind::address_space, src, newTy);
+  }
+
+  mlir::Value createAddrSpaceCast(mlir::Value src, mlir::Type newTy) {
+    return createAddrSpaceCast(src.getLoc(), src, newTy);
   }
 
   //

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -82,47 +82,92 @@ class CIR_Op<string mnemonic, list<Trait> traits = []> :
 // CastOp
 //===----------------------------------------------------------------------===//
 
-// The enumaration value isn't in sync with clang.
-def CK_IntegralToBoolean : I32EnumAttrCase<"int_to_bool", 1>;
-def CK_ArrayToPointerDecay : I32EnumAttrCase<"array_to_ptrdecay", 2>;
-def CK_IntegralCast : I32EnumAttrCase<"integral", 3>;
-def CK_BitCast : I32EnumAttrCase<"bitcast", 4>;
-def CK_FloatingCast : I32EnumAttrCase<"floating", 5>;
-def CK_PtrToBoolean : I32EnumAttrCase<"ptr_to_bool", 6>;
-def CK_FloatToIntegral : I32EnumAttrCase<"float_to_int", 7>;
-def CK_IntegralToPointer : I32EnumAttrCase<"int_to_ptr", 8>;
-def CK_PointerToIntegral : I32EnumAttrCase<"ptr_to_int", 9>;
-def CK_FloatToBoolean : I32EnumAttrCase<"float_to_bool", 10>;
-def CK_BooleanToIntegral : I32EnumAttrCase<"bool_to_int", 11>;
-def CK_IntegralToFloat : I32EnumAttrCase<"int_to_float", 12>;
-def CK_BooleanToFloat : I32EnumAttrCase<"bool_to_float", 13>;
-def CK_AddressSpaceConversion : I32EnumAttrCase<"address_space", 14>;
-def CK_FloatToComplex : I32EnumAttrCase<"float_to_complex", 15>;
-def CK_IntegralToComplex : I32EnumAttrCase<"int_to_complex", 16>;
-def CK_FloatComplexToReal : I32EnumAttrCase<"float_complex_to_real", 17>;
-def CK_IntegralComplexToReal : I32EnumAttrCase<"int_complex_to_real", 18>;
-def CK_FloatComplexToBoolean : I32EnumAttrCase<"float_complex_to_bool", 19>;
-def CK_IntegralComplexToBoolean : I32EnumAttrCase<"int_complex_to_bool", 20>;
-def CK_FloatComplexCast : I32EnumAttrCase<"float_complex", 21>;
-def CK_FloatComplexToIntegralComplex
-    : I32EnumAttrCase<"float_complex_to_int_complex", 22>;
-def CK_IntegralComplexCast : I32EnumAttrCase<"int_complex", 23>;
-def CK_IntegralComplexToFloatComplex
-    : I32EnumAttrCase<"int_complex_to_float_complex", 24>;
-def CK_MemberPtrToBoolean : I32EnumAttrCase<"member_ptr_to_bool", 25>;
+// CK_Dependent
+def CK_BitCast : I32EnumAttrCase<"bitcast", 1>;
+// CK_LValueBitCast
+// CK_LValueToRValueBitCast
+// CK_LValueToRValue
+// CK_NoOp
+// CK_BaseToDerived
+// CK_DerivedToBase
+// CK_UncheckedDerivedToBase
+// CK_Dynamic
+// CK_ToUnion
+def CK_ArrayToPointerDecay : I32EnumAttrCase<"array_to_ptrdecay", 11>;
+// CK_FunctionToPointerDecay
+// CK_NullToPointer
+// CK_NullToMemberPointer
+// CK_BaseToDerivedMemberPointer
+// CK_DerivedToBaseMemberPointer
+def CK_MemberPointerToBoolean : I32EnumAttrCase<"member_ptr_to_bool", 17>;
+// CK_ReinterpretMemberPointer
+// CK_UserDefinedConversion
+// CK_ConstructorConversion
+def CK_IntegralToPointer : I32EnumAttrCase<"int_to_ptr", 21>;
+def CK_PointerToIntegral : I32EnumAttrCase<"ptr_to_int", 22>;
+def CK_PointerToBoolean : I32EnumAttrCase<"ptr_to_bool", 23>;
+// CK_ToVoid
+// CK_MatrixCast
+// CK_VectorSplat
+def CK_IntegralCast : I32EnumAttrCase<"integral", 27>;
+def CK_IntegralToBoolean : I32EnumAttrCase<"int_to_bool", 28>;
+def CK_IntegralToFloating : I32EnumAttrCase<"int_to_float", 29>;
+// CK_FloatingToFixedPoint
+// CK_FixedPointToFloating
+// CK_FixedPointCast
+// CK_FixedPointToIntegral
+// CK_IntegralToFixedPoint
+// CK_FixedPointToBoolean
+def CK_FloatingToIntegral : I32EnumAttrCase<"float_to_int", 36>;
+def CK_FloatingToBoolean : I32EnumAttrCase<"float_to_bool", 37>;
+def CK_BooleanToSignedIntegral : I32EnumAttrCase<"bool_to_int", 38>;
+def CK_FloatingCast : I32EnumAttrCase<"floating", 39>;
+// CK_CPointerToObjCPointerCast
+// CK_BlockPointerToObjCPointerCast
+// CK_AnyPointerToBlockPointerCast
+// CK_ObjCObjectLValueCast
+// CK_FloatingRealToComplex
+// CK_FloatingComplexToReal
+// CK_FloatingComplexToBoolean
+def CK_FloatingComplexCast : I32EnumAttrCase<"float_complex", 47>;
+// CK_FloatingComplexToIntegralComplex
+// CK_IntegralRealToComplex
+def CK_IntegralComplexToReal : I32EnumAttrCase<"int_complex_to_real", 50>;
+def CK_IntegralComplexToBoolean : I32EnumAttrCase<"int_complex_to_bool", 51>;
+def CK_IntegralComplexCast : I32EnumAttrCase<"int_complex", 52>;
+def CK_IntegralComplexToFloatingComplex
+    : I32EnumAttrCase<"int_complex_to_float_complex", 53>;
+// CK_ARCProduceObject
+// CK_ARCConsumeObject
+// CK_ARCReclaimReturnedObject
+// CK_ARCExtendBlockObject
+// CK_AtomicToNonAtomic
+// CK_NonAtomicToAtomic
+// CK_CopyAndAutoreleaseBlockObject
+// CK_BuiltinFnToFnPtr
+// CK_ZeroToOCLOpaqueType
+def CK_AddressSpaceConversion : I32EnumAttrCase<"address_space", 63>;
+// CK_IntToOCLSampler
+// CK_HLSLVectorTruncation
+// CK_HLSLArrayRValue
+// CK_HLSLElementwiseCast
+// CK_HLSLAggregateSplatCast
+
+// Enums below are specific to CIR and don't have a correspondence to classic
+// codegen:
+def CK_BooleanToFloat : I32EnumAttrCase<"bool_to_float", 1000>;
 
 def CastKind : I32EnumAttr<
     "CastKind",
     "cast kind",
-    [CK_IntegralToBoolean, CK_ArrayToPointerDecay, CK_IntegralCast,
-     CK_BitCast, CK_FloatingCast, CK_PtrToBoolean, CK_FloatToIntegral,
-     CK_IntegralToPointer, CK_PointerToIntegral, CK_FloatToBoolean,
-     CK_BooleanToIntegral, CK_IntegralToFloat, CK_BooleanToFloat,
-     CK_AddressSpaceConversion, CK_FloatToComplex, CK_IntegralToComplex,
-     CK_FloatComplexToReal, CK_IntegralComplexToReal, CK_FloatComplexToBoolean,
-     CK_IntegralComplexToBoolean, CK_FloatComplexCast,
-     CK_FloatComplexToIntegralComplex, CK_IntegralComplexCast,
-     CK_IntegralComplexToFloatComplex, CK_MemberPtrToBoolean]> {
+    [CK_BitCast, CK_ArrayToPointerDecay, CK_MemberPointerToBoolean,
+     CK_IntegralToPointer, CK_PointerToIntegral, CK_PointerToBoolean,
+     CK_IntegralCast, CK_IntegralToBoolean, CK_IntegralToFloating,
+     CK_FloatingToIntegral, CK_FloatingToBoolean, CK_BooleanToSignedIntegral,
+     CK_FloatingCast, CK_FloatingComplexCast, CK_IntegralComplexToReal,
+     CK_IntegralComplexToBoolean, CK_IntegralComplexCast,
+     CK_IntegralComplexToFloatingComplex, CK_AddressSpaceConversion,
+     CK_BooleanToFloat]> {
   let cppNamespace = "::cir";
 }
 

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -79,6 +79,111 @@ class CIR_Op<string mnemonic, list<Trait> traits = []> :
     Op<CIR_Dialect, mnemonic, traits>, LLVMLoweringInfo;
 
 //===----------------------------------------------------------------------===//
+// CastOp
+//===----------------------------------------------------------------------===//
+
+// The enumaration value isn't in sync with clang.
+def CK_IntegralToBoolean : I32EnumAttrCase<"int_to_bool", 1>;
+def CK_ArrayToPointerDecay : I32EnumAttrCase<"array_to_ptrdecay", 2>;
+def CK_IntegralCast : I32EnumAttrCase<"integral", 3>;
+def CK_BitCast : I32EnumAttrCase<"bitcast", 4>;
+def CK_FloatingCast : I32EnumAttrCase<"floating", 5>;
+def CK_PtrToBoolean : I32EnumAttrCase<"ptr_to_bool", 6>;
+def CK_FloatToIntegral : I32EnumAttrCase<"float_to_int", 7>;
+def CK_IntegralToPointer : I32EnumAttrCase<"int_to_ptr", 8>;
+def CK_PointerToIntegral : I32EnumAttrCase<"ptr_to_int", 9>;
+def CK_FloatToBoolean : I32EnumAttrCase<"float_to_bool", 10>;
+def CK_BooleanToIntegral : I32EnumAttrCase<"bool_to_int", 11>;
+def CK_IntegralToFloat : I32EnumAttrCase<"int_to_float", 12>;
+def CK_BooleanToFloat : I32EnumAttrCase<"bool_to_float", 13>;
+def CK_AddressSpaceConversion : I32EnumAttrCase<"address_space", 14>;
+def CK_FloatToComplex : I32EnumAttrCase<"float_to_complex", 15>;
+def CK_IntegralToComplex : I32EnumAttrCase<"int_to_complex", 16>;
+def CK_FloatComplexToReal : I32EnumAttrCase<"float_complex_to_real", 17>;
+def CK_IntegralComplexToReal : I32EnumAttrCase<"int_complex_to_real", 18>;
+def CK_FloatComplexToBoolean : I32EnumAttrCase<"float_complex_to_bool", 19>;
+def CK_IntegralComplexToBoolean : I32EnumAttrCase<"int_complex_to_bool", 20>;
+def CK_FloatComplexCast : I32EnumAttrCase<"float_complex", 21>;
+def CK_FloatComplexToIntegralComplex
+    : I32EnumAttrCase<"float_complex_to_int_complex", 22>;
+def CK_IntegralComplexCast : I32EnumAttrCase<"int_complex", 23>;
+def CK_IntegralComplexToFloatComplex
+    : I32EnumAttrCase<"int_complex_to_float_complex", 24>;
+def CK_MemberPtrToBoolean : I32EnumAttrCase<"member_ptr_to_bool", 25>;
+
+def CastKind : I32EnumAttr<
+    "CastKind",
+    "cast kind",
+    [CK_IntegralToBoolean, CK_ArrayToPointerDecay, CK_IntegralCast,
+     CK_BitCast, CK_FloatingCast, CK_PtrToBoolean, CK_FloatToIntegral,
+     CK_IntegralToPointer, CK_PointerToIntegral, CK_FloatToBoolean,
+     CK_BooleanToIntegral, CK_IntegralToFloat, CK_BooleanToFloat,
+     CK_AddressSpaceConversion, CK_FloatToComplex, CK_IntegralToComplex,
+     CK_FloatComplexToReal, CK_IntegralComplexToReal, CK_FloatComplexToBoolean,
+     CK_IntegralComplexToBoolean, CK_FloatComplexCast,
+     CK_FloatComplexToIntegralComplex, CK_IntegralComplexCast,
+     CK_IntegralComplexToFloatComplex, CK_MemberPtrToBoolean]> {
+  let cppNamespace = "::cir";
+}
+
+def CastOp : CIR_Op<"cast",
+             [Pure,
+              DeclareOpInterfaceMethods<PromotableOpInterface>]> {
+  // FIXME: not all conversions are free of side effects.
+  let summary = "Conversion between values of different types";
+  let description = [{
+    Apply C/C++ usual conversions rules between values. Currently supported kinds:
+
+    - `array_to_ptrdecay`
+    - `bitcast`
+    - `integral`
+    - `int_to_bool`
+    - `int_to_float`
+    - `floating`
+    - `float_to_int`
+    - `float_to_bool`
+    - `ptr_to_int`
+    - `ptr_to_bool`
+    - `bool_to_int`
+    - `bool_to_float`
+    - `address_space`
+    - `float_to_complex`
+    - `int_to_complex`
+    - `float_complex_to_real`
+    - `int_complex_to_real`
+    - `float_complex_to_bool`
+    - `int_complex_to_bool`
+    - `float_complex`
+    - `float_complex_to_int_complex`
+    - `int_complex`
+    - `int_complex_to_float_complex`
+
+    This is effectively a subset of the rules from
+    `llvm-project/clang/include/clang/AST/OperationKinds.def`; but note that some
+    of the conversions aren't implemented in terms of `cir.cast`, `lvalue-to-rvalue`
+    for instance is modeled as a regular `cir.load`.
+
+    ```mlir
+    %4 = cir.cast (int_to_bool, %3 : i32), !cir.bool
+    ...
+    %x = cir.cast(array_to_ptrdecay, %0 : !cir.ptr<!cir.array<i32 x 10>>), !cir.ptr<i32>
+    ```
+  }];
+
+  let arguments = (ins CastKind:$kind, CIR_AnyType:$src);
+  let results = (outs CIR_AnyType:$result);
+
+  let assemblyFormat = [{
+    `(` $kind `,` $src `:` type($src) `)`
+    `,` type($result) attr-dict
+  }];
+
+  // The input and output types should match the cast kind.
+  let hasVerifier = 1;
+  let hasFolder = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // ConstantOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -90,20 +90,19 @@ struct MissingFeatures {
   static bool stackSaveOp() { return false; }
   static bool aggValueSlot() { return false; }
 
-  static bool unsizedTypes() { return false; }
-  static bool scalableVectors() { return false; }
   static bool fpConstraints() { return false; }
   static bool sanitizers() { return false; }
   static bool addHeapAllocSiteMetadata() { return false; }
   static bool targetCodeGenInfoGetNullPointer() { return false; }
+  static bool CGFPOptionsRAII() { return false; }
 
   // Missing types
   static bool dataMemberType() { return false; }
-  static bool methodType() { return false; }
   static bool matrixType() { return false; }
+  static bool methodType() { return false; }
+  static bool scalableVectors() { return false; }
+  static bool unsizedTypes() { return false; }
   static bool vectorType() { return false; }
-  static bool sanitizers() { return false; }
-  static bool CGFPOptionsRAII() { return false; }
 };
 
 } // namespace cir

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -77,12 +77,13 @@ struct MissingFeatures {
   static bool opUnaryPromotionType() { return false; }
 
   // Misc
-  static bool scalarConversionOpts() { return false; }
+  static bool cxxABI() { return false; }
   static bool tryEmitAsConstant() { return false; }
   static bool constructABIArgDirectExtend() { return false; }
   static bool opGlobalViewAttr() { return false; }
   static bool lowerModeOptLevel() { return false; }
   static bool opTBAA() { return false; }
+  static bool opCmp() { return false; }
   static bool objCLifetime() { return false; }
   static bool emitNullabilityCheck() { return false; }
   static bool astVarDeclInterface() { return false; }
@@ -90,11 +91,19 @@ struct MissingFeatures {
   static bool aggValueSlot() { return false; }
 
   static bool unsizedTypes() { return false; }
+  static bool scalableVectors() { return false; }
+  static bool fpConstraints() { return false; }
   static bool sanitizers() { return false; }
-  static bool CGFPOptionsRAII() { return false; }
+  static bool addHeapAllocSiteMetadata() { return false; }
+  static bool targetCodeGenInfoGetNullPointer() { return false; }
 
   // Missing types
+  static bool dataMemberType() { return false; }
+  static bool methodType() { return false; }
+  static bool matrixType() { return false; }
   static bool vectorType() { return false; }
+  static bool sanitizers() { return false; }
+  static bool CGFPOptionsRAII() { return false; }
 };
 
 } // namespace cir

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -10,6 +10,7 @@
 #define LLVM_CLANG_LIB_CIR_CODEGEN_CIRGENBUILDER_H
 
 #include "CIRGenTypeCache.h"
+#include "clang/CIR/MissingFeatures.h"
 
 #include "clang/CIR/Dialect/Builder/CIRBaseBuilder.h"
 #include "clang/CIR/MissingFeatures.h"
@@ -42,6 +43,14 @@ public:
 
     assert(!cir::MissingFeatures::unsizedTypes());
     return false;
+  }
+  
+  bool isInt(mlir::Type i) { return mlir::isa<cir::IntType>(i); }
+
+  // Creates constant nullptr for pointer type ty.
+  cir::ConstantOp getNullPtr(mlir::Type ty, mlir::Location loc) {
+    assert(!cir::MissingFeatures::targetCodeGenInfoGetNullPointer());
+    return create<cir::ConstantOp>(loc, ty, getConstPtrAttr(ty, 0));
   }
 };
 

--- a/clang/lib/CIR/CodeGen/CIRGenBuilder.h
+++ b/clang/lib/CIR/CodeGen/CIRGenBuilder.h
@@ -44,7 +44,7 @@ public:
     assert(!cir::MissingFeatures::unsizedTypes());
     return false;
   }
-  
+
   bool isInt(mlir::Type i) { return mlir::isa<cir::IntType>(i); }
 
   // Creates constant nullptr for pointer type ty.

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -264,6 +264,13 @@ mlir::Value CIRGenFunction::emitAlloca(StringRef name, mlir::Type ty,
   return addr;
 }
 
+mlir::Value CIRGenFunction::createDummyValue(mlir::Location loc,
+                                             clang::QualType qt) {
+  mlir::Type t = convertType(qt);
+  CharUnits alignment = getContext().getTypeAlignInChars(qt);
+  return builder.createDummyValue(loc, t, alignment);
+}
+
 /// This creates an alloca and inserts it  at the current insertion point of the
 /// builder.
 Address CIRGenFunction::createTempAlloca(mlir::Type ty, CharUnits align,

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -511,7 +511,7 @@ public:
     // Handle pointer conversions next: pointers can only be converted to/from
     // other pointers and integers. Check for pointer types in terms of LLVM, as
     // some native types (like Obj-C id) may map to a pointer type.
-    if (auto dstPT = dyn_cast<cir::PointerType>(mlirDstType)) {
+    if (isa_cast<cir::PointerType>(mlirDstType)) {
       cgf.getCIRGenModule().errorNYI(loc, "pointer casts");
       CharUnits alignment = cgf.getContext().getTypeAlignInChars(dstType);
       auto addr =

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -502,7 +502,7 @@ public:
     // Handle pointer conversions next: pointers can only be converted to/from
     // other pointers and integers. Check for pointer types in terms of LLVM, as
     // some native types (like Obj-C id) may map to a pointer type.
-    if (isa_cast<cir::PointerType>(mlirDstType)) {
+    if (auto dstPT = dyn_cast<cir::PointerType>(mlirDstType)) {
       cgf.getCIRGenModule().errorNYI(loc, "pointer casts");
       return builder.getNullPtr(dstPT, src.getLoc());
     }
@@ -703,8 +703,7 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
     return builder.createPtrToInt(Visit(subExpr), cgf.convertType(destTy));
   }
   case CK_ToVoid:
-    cgf.getCIRGenModule().errorNYI(subExpr->getSourceRange(),
-                                   "ignored expression on void cast");
+    cgf.emitIgnoredExpr(subExpr);
     return {};
 
   case CK_IntegralToFloating:

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -207,7 +207,7 @@ public:
         castKind = cir::CastKind::float_to_int;
       } else if (mlir::isa<cir::CIRFPTypeInterface>(dstTy)) {
         cgf.getCIRGenModule().errorNYI("floating point casts");
-        return builder.getNullPtr(dstTy, src.getLoc());
+        return cgf.createDummyValue(src.getLoc(), dstType);
       } else {
         llvm_unreachable("Internal error: Cast to unexpected type");
       }

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -141,7 +141,7 @@ public:
     if (srcType->isRealFloatingType())
       return emitFloatToBoolConversion(src, loc);
 
-    if ([[maybe_unused]] auto *mpt = llvm::dyn_cast<MemberPointerType>(srcType))
+    if (llvm::isa<MemberPointerType>(srcType))
       cgf.getCIRGenModule().errorNYI(loc, "member pointer to bool conversion");
 
     if (srcType->isIntegerType())

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -662,9 +662,7 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
 
   case CK_NullToPointer: {
     if (MustVisitNullValue(subExpr))
-      cgf.getCIRGenModule().errorNYI(
-          subExpr->getSourceRange(),
-          "ignored expression on null to pointer cast");
+      cgf.emitIgnoredExpr(subExpr);
 
     // Note that DestTy is used as the MLIR type instead of a custom
     // nullptr type.

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -73,6 +73,9 @@ public:
     return &fn.getRegion().front();
   }
 
+  /// Sanitizers enabled for this function.
+  clang::SanitizerSet sanOpts;
+
   mlir::Type convertTypeForMem(QualType T);
 
   mlir::Type convertType(clang::QualType T);

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -109,6 +109,8 @@ public:
   mlir::Value emitAlloca(llvm::StringRef name, mlir::Type ty,
                          mlir::Location loc, clang::CharUnits alignment);
 
+  mlir::Value createDummyValue(mlir::Location loc, clang::QualType qt);
+
 private:
   // Track current variable initialization (if there's one)
   const clang::VarDecl *currVarDecl = nullptr;

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -183,6 +183,176 @@ OpFoldResult cir::ConstantOp::fold(FoldAdaptor /*adaptor*/) {
 }
 
 //===----------------------------------------------------------------------===//
+// CastOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult cir::CastOp::verify() {
+  auto resType = getResult().getType();
+  auto srcType = getSrc().getType();
+
+  switch (getKind()) {
+  case cir::CastKind::int_to_bool: {
+    if (!mlir::isa<cir::BoolType>(resType))
+      return emitOpError() << "requires !cir.bool type for result";
+    if (!mlir::isa<cir::IntType>(srcType))
+      return emitOpError() << "requires !cir.int type for source";
+    return success();
+  }
+  case cir::CastKind::ptr_to_bool: {
+    if (!mlir::isa<cir::BoolType>(resType))
+      return emitOpError() << "requires !cir.bool type for result";
+    if (!mlir::isa<cir::PointerType>(srcType))
+      return emitOpError() << "requires !cir.ptr type for source";
+    return success();
+  }
+  case cir::CastKind::integral: {
+    if (!mlir::isa<cir::IntType>(resType))
+      return emitOpError() << "requires !cir.int type for result";
+    if (!mlir::isa<cir::IntType>(srcType))
+      return emitOpError() << "requires !cir.int type for source";
+    return success();
+  }
+  case cir::CastKind::bitcast: {
+    // Handle the pointer types first.
+    auto srcPtrTy = mlir::dyn_cast<cir::PointerType>(srcType);
+    auto resPtrTy = mlir::dyn_cast<cir::PointerType>(resType);
+
+    if (srcPtrTy && resPtrTy) {
+      return success();
+    }
+
+    return success();
+  }
+  case cir::CastKind::floating: {
+    if (!mlir::isa<cir::CIRFPTypeInterface>(srcType) ||
+        !mlir::isa<cir::CIRFPTypeInterface>(resType))
+      return emitOpError() << "requires !cir.float type for source and result";
+    return success();
+  }
+  case cir::CastKind::float_to_int: {
+    if (!mlir::isa<cir::CIRFPTypeInterface>(srcType))
+      return emitOpError() << "requires !cir.float type for source";
+    if (!mlir::dyn_cast<cir::IntType>(resType))
+      return emitOpError() << "requires !cir.int type for result";
+    return success();
+  }
+  case cir::CastKind::int_to_ptr: {
+    if (!mlir::dyn_cast<cir::IntType>(srcType))
+      return emitOpError() << "requires !cir.int type for source";
+    if (!mlir::dyn_cast<cir::PointerType>(resType))
+      return emitOpError() << "requires !cir.ptr type for result";
+    return success();
+  }
+  case cir::CastKind::ptr_to_int: {
+    if (!mlir::dyn_cast<cir::PointerType>(srcType))
+      return emitOpError() << "requires !cir.ptr type for source";
+    if (!mlir::dyn_cast<cir::IntType>(resType))
+      return emitOpError() << "requires !cir.int type for result";
+    return success();
+  }
+  case cir::CastKind::float_to_bool: {
+    if (!mlir::isa<cir::CIRFPTypeInterface>(srcType))
+      return emitOpError() << "requires !cir.float type for source";
+    if (!mlir::isa<cir::BoolType>(resType))
+      return emitOpError() << "requires !cir.bool type for result";
+    return success();
+  }
+  case cir::CastKind::bool_to_int: {
+    if (!mlir::isa<cir::BoolType>(srcType))
+      return emitOpError() << "requires !cir.bool type for source";
+    if (!mlir::isa<cir::IntType>(resType))
+      return emitOpError() << "requires !cir.int type for result";
+    return success();
+  }
+  case cir::CastKind::int_to_float: {
+    if (!mlir::isa<cir::IntType>(srcType))
+      return emitOpError() << "requires !cir.int type for source";
+    if (!mlir::isa<cir::CIRFPTypeInterface>(resType))
+      return emitOpError() << "requires !cir.float type for result";
+    return success();
+  }
+  case cir::CastKind::bool_to_float: {
+    if (!mlir::isa<cir::BoolType>(srcType))
+      return emitOpError() << "requires !cir.bool type for source";
+    if (!mlir::isa<cir::CIRFPTypeInterface>(resType))
+      return emitOpError() << "requires !cir.float type for result";
+    return success();
+  }
+  case cir::CastKind::address_space: {
+    auto srcPtrTy = mlir::dyn_cast<cir::PointerType>(srcType);
+    auto resPtrTy = mlir::dyn_cast<cir::PointerType>(resType);
+    if (!srcPtrTy || !resPtrTy)
+      return emitOpError() << "requires !cir.ptr type for source and result";
+    if (srcPtrTy.getPointee() != resPtrTy.getPointee())
+      return emitOpError() << "requires two types differ in addrspace only";
+    return success();
+  }
+  }
+
+  llvm_unreachable("Unknown CastOp kind?");
+}
+
+static bool isIntOrBoolCast(cir::CastOp op) {
+  auto kind = op.getKind();
+  return kind == cir::CastKind::bool_to_int ||
+         kind == cir::CastKind::int_to_bool || kind == cir::CastKind::integral;
+}
+
+static Value tryFoldCastChain(cir::CastOp op) {
+  cir::CastOp head = op, tail = op;
+
+  while (op) {
+    if (!isIntOrBoolCast(op))
+      break;
+    head = op;
+    op = dyn_cast_or_null<cir::CastOp>(head.getSrc().getDefiningOp());
+  }
+
+  if (head == tail)
+    return {};
+
+  // if bool_to_int -> ...  -> int_to_bool: take the bool
+  // as we had it was before all casts
+  if (head.getKind() == cir::CastKind::bool_to_int &&
+      tail.getKind() == cir::CastKind::int_to_bool)
+    return head.getSrc();
+
+  // if int_to_bool -> ...  -> int_to_bool: take the result
+  // of the first one, as no other casts (and ext casts as well)
+  // don't change the first result
+  if (head.getKind() == cir::CastKind::int_to_bool &&
+      tail.getKind() == cir::CastKind::int_to_bool)
+    return head.getResult();
+
+  return {};
+}
+
+OpFoldResult cir::CastOp::fold(FoldAdaptor adaptor) {
+  if (getSrc().getType() == getResult().getType()) {
+    switch (getKind()) {
+    case cir::CastKind::integral: {
+      // TODO: for sign differences, it's possible in certain conditions to
+      // create a new attribute that's capable of representing the source.
+      llvm::SmallVector<mlir::OpFoldResult, 1> foldResults;
+      auto foldOrder = getSrc().getDefiningOp()->fold(foldResults);
+      if (foldOrder.succeeded() && mlir::isa<mlir::Attribute>(foldResults[0]))
+        return mlir::cast<mlir::Attribute>(foldResults[0]);
+      return {};
+    }
+    case cir::CastKind::bitcast:
+    case cir::CastKind::address_space:
+    case cir::CastKind::float_complex:
+    case cir::CastKind::int_complex: {
+      return getSrc();
+    }
+    default:
+      return {};
+    }
+  }
+  return tryFoldCastChain(*this);
+}
+
+//===----------------------------------------------------------------------===//
 // ReturnOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -42,6 +42,21 @@ using namespace llvm;
 namespace cir {
 namespace direct {
 
+//===----------------------------------------------------------------------===//
+// Helper Methods
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// If the given type is a vector type, return the vector's element type.
+/// Otherwise return the given type unchanged.
+// TODO(cir): Return the vector element type once we have support for vectors
+// instead of the identity type.
+mlir::Type elementTypeIfVector(mlir::Type type) {
+  assert(!cir::MissingFeatures::vectorType());
+  return type;
+}
+} // namespace
+
 /// Given a type convertor and a data layout, convert the given type to a type
 /// that is suitable for memory operations. For example, this can be used to
 /// lower cir.bool accesses to i8.
@@ -140,6 +155,24 @@ mlir::LLVM::Linkage convertLinkage(cir::GlobalLinkageKind linkage) {
     return LLVM::WeakODR;
   };
   llvm_unreachable("Unknown CIR linkage type");
+}
+
+static mlir::Value getLLVMIntCast(mlir::ConversionPatternRewriter &rewriter,
+                                  mlir::Value llvmSrc, mlir::Type llvmDstIntTy,
+                                  bool isUnsigned, uint64_t cirSrcWidth,
+                                  uint64_t cirDstIntWidth) {
+  if (cirSrcWidth == cirDstIntWidth)
+    return llvmSrc;
+
+  auto loc = llvmSrc.getLoc();
+  if (cirSrcWidth < cirDstIntWidth) {
+    if (isUnsigned)
+      return rewriter.create<mlir::LLVM::ZExtOp>(loc, llvmDstIntTy, llvmSrc);
+    return rewriter.create<mlir::LLVM::SExtOp>(loc, llvmDstIntTy, llvmSrc);
+  }
+
+  // Otherwise truncate
+  return rewriter.create<mlir::LLVM::TruncOp>(loc, llvmDstIntTy, llvmSrc);
 }
 
 class CIRAttrToValue {
@@ -246,6 +279,179 @@ struct ConvertCIRToLLVMPass
 
   StringRef getArgument() const override { return "cir-flat-to-llvm"; }
 };
+
+mlir::Type CIRToLLVMCastOpLowering::convertTy(mlir::Type ty) const {
+  return getTypeConverter()->convertType(ty);
+}
+
+mlir::LogicalResult CIRToLLVMCastOpLowering::matchAndRewrite(
+    cir::CastOp castOp, OpAdaptor adaptor,
+    mlir::ConversionPatternRewriter &rewriter) const {
+  // For arithmetic conversions, LLVM IR uses the same instruction to convert
+  // both individual scalars and entire vectors. This lowering pass handles
+  // both situations.
+
+  switch (castOp.getKind()) {
+  case cir::CastKind::array_to_ptrdecay: {
+    const auto ptrTy = mlir::cast<cir::PointerType>(castOp.getType());
+    auto sourceValue = adaptor.getOperands().front();
+    auto targetType = convertTy(ptrTy);
+    auto elementTy = convertTypeForMemory(*getTypeConverter(), dataLayout,
+                                          ptrTy.getPointee());
+    auto offset = llvm::SmallVector<mlir::LLVM::GEPArg>{0};
+    rewriter.replaceOpWithNewOp<mlir::LLVM::GEPOp>(
+        castOp, targetType, elementTy, sourceValue, offset);
+    break;
+  }
+  case cir::CastKind::int_to_bool:
+    assert(!cir::MissingFeatures::opCmp());
+    break;
+  case cir::CastKind::integral: {
+    auto srcType = castOp.getSrc().getType();
+    auto dstType = castOp.getResult().getType();
+    auto llvmSrcVal = adaptor.getOperands().front();
+    auto llvmDstType = getTypeConverter()->convertType(dstType);
+    cir::IntType srcIntType =
+        mlir::cast<cir::IntType>(elementTypeIfVector(srcType));
+    cir::IntType dstIntType =
+        mlir::cast<cir::IntType>(elementTypeIfVector(dstType));
+    rewriter.replaceOp(castOp, getLLVMIntCast(rewriter, llvmSrcVal, llvmDstType,
+                                              srcIntType.isUnsigned(),
+                                              srcIntType.getWidth(),
+                                              dstIntType.getWidth()));
+    break;
+  }
+  case cir::CastKind::floating: {
+    auto llvmSrcVal = adaptor.getOperands().front();
+    auto llvmDstTy =
+        getTypeConverter()->convertType(castOp.getResult().getType());
+
+    auto srcTy = elementTypeIfVector(castOp.getSrc().getType());
+    auto dstTy = elementTypeIfVector(castOp.getResult().getType());
+
+    if (!mlir::isa<cir::CIRFPTypeInterface>(dstTy) ||
+        !mlir::isa<cir::CIRFPTypeInterface>(srcTy))
+      return castOp.emitError() << "NYI cast from " << srcTy << " to " << dstTy;
+
+    auto getFloatWidth = [](mlir::Type ty) -> unsigned {
+      return mlir::cast<cir::CIRFPTypeInterface>(ty).getWidth();
+    };
+
+    if (getFloatWidth(srcTy) > getFloatWidth(dstTy))
+      rewriter.replaceOpWithNewOp<mlir::LLVM::FPTruncOp>(castOp, llvmDstTy,
+                                                         llvmSrcVal);
+    else
+      rewriter.replaceOpWithNewOp<mlir::LLVM::FPExtOp>(castOp, llvmDstTy,
+                                                       llvmSrcVal);
+    return mlir::success();
+  }
+  case cir::CastKind::int_to_ptr: {
+    auto dstTy = mlir::cast<cir::PointerType>(castOp.getType());
+    auto llvmSrcVal = adaptor.getOperands().front();
+    auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::IntToPtrOp>(castOp, llvmDstTy,
+                                                        llvmSrcVal);
+    return mlir::success();
+  }
+  case cir::CastKind::ptr_to_int: {
+    auto dstTy = mlir::cast<cir::IntType>(castOp.getType());
+    auto llvmSrcVal = adaptor.getOperands().front();
+    auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::PtrToIntOp>(castOp, llvmDstTy,
+                                                        llvmSrcVal);
+    return mlir::success();
+  }
+  case cir::CastKind::float_to_bool: {
+    auto llvmSrcVal = adaptor.getOperands().front();
+    auto kind = mlir::LLVM::FCmpPredicate::une;
+
+    // Check if float is not equal to zero.
+    auto zeroFloat = rewriter.create<mlir::LLVM::ConstantOp>(
+        castOp.getLoc(), llvmSrcVal.getType(),
+        mlir::FloatAttr::get(llvmSrcVal.getType(), 0.0));
+
+    // Extend comparison result to either bool (C++) or int (C).
+    rewriter.replaceOpWithNewOp<mlir::LLVM::FCmpOp>(castOp, kind, llvmSrcVal,
+                                                    zeroFloat);
+
+    return mlir::success();
+  }
+  case cir::CastKind::bool_to_int: {
+    auto dstTy = mlir::cast<cir::IntType>(castOp.getType());
+    auto llvmSrcVal = adaptor.getOperands().front();
+    auto llvmSrcTy = mlir::cast<mlir::IntegerType>(llvmSrcVal.getType());
+    auto llvmDstTy =
+        mlir::cast<mlir::IntegerType>(getTypeConverter()->convertType(dstTy));
+    if (llvmSrcTy.getWidth() == llvmDstTy.getWidth())
+      rewriter.replaceOpWithNewOp<mlir::LLVM::BitcastOp>(castOp, llvmDstTy,
+                                                         llvmSrcVal);
+    else
+      rewriter.replaceOpWithNewOp<mlir::LLVM::ZExtOp>(castOp, llvmDstTy,
+                                                      llvmSrcVal);
+    return mlir::success();
+  }
+  case cir::CastKind::bool_to_float: {
+    auto dstTy = castOp.getType();
+    auto llvmSrcVal = adaptor.getOperands().front();
+    auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::UIToFPOp>(castOp, llvmDstTy,
+                                                      llvmSrcVal);
+    return mlir::success();
+  }
+  case cir::CastKind::int_to_float: {
+    auto dstTy = castOp.getType();
+    auto llvmSrcVal = adaptor.getOperands().front();
+    auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+    if (mlir::cast<cir::IntType>(elementTypeIfVector(castOp.getSrc().getType()))
+            .isSigned())
+      rewriter.replaceOpWithNewOp<mlir::LLVM::SIToFPOp>(castOp, llvmDstTy,
+                                                        llvmSrcVal);
+    else
+      rewriter.replaceOpWithNewOp<mlir::LLVM::UIToFPOp>(castOp, llvmDstTy,
+                                                        llvmSrcVal);
+    return mlir::success();
+  }
+  case cir::CastKind::float_to_int: {
+    auto dstTy = castOp.getType();
+    auto llvmSrcVal = adaptor.getOperands().front();
+    auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+    if (mlir::cast<cir::IntType>(
+            elementTypeIfVector(castOp.getResult().getType()))
+            .isSigned())
+      rewriter.replaceOpWithNewOp<mlir::LLVM::FPToSIOp>(castOp, llvmDstTy,
+                                                        llvmSrcVal);
+    else
+      rewriter.replaceOpWithNewOp<mlir::LLVM::FPToUIOp>(castOp, llvmDstTy,
+                                                        llvmSrcVal);
+    return mlir::success();
+  }
+  case cir::CastKind::bitcast:
+    assert(!MissingFeatures::cxxABI());
+    assert(!MissingFeatures::dataMemberType());
+    break;
+  case cir::CastKind::ptr_to_bool:
+    assert(!cir::MissingFeatures::opCmp());
+    break;
+  case cir::CastKind::address_space: {
+    auto dstTy = castOp.getType();
+    auto llvmSrcVal = adaptor.getOperands().front();
+    auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+    rewriter.replaceOpWithNewOp<mlir::LLVM::AddrSpaceCastOp>(castOp, llvmDstTy,
+                                                             llvmSrcVal);
+    break;
+  }
+  case cir::CastKind::member_ptr_to_bool:
+    assert(!MissingFeatures::cxxABI());
+    assert(!MissingFeatures::methodType());
+    break;
+  default: {
+    return castOp.emitError("Unhandled cast kind: ")
+           << castOp.getKindAttrName();
+  }
+  }
+
+  return mlir::success();
+}
 
 mlir::LogicalResult CIRToLLVMAllocaOpLowering::matchAndRewrite(
     cir::AllocaOp op, OpAdaptor adaptor,
@@ -833,6 +1039,7 @@ void ConvertCIRToLLVMPass::runOnOperation() {
   patterns.add<CIRToLLVMLoadOpLowering>(converter, patterns.getContext(), dl);
   patterns.add<CIRToLLVMStoreOpLowering>(converter, patterns.getContext(), dl);
   patterns.add<CIRToLLVMGlobalOpLowering>(converter, patterns.getContext(), dl);
+  patterns.add<CIRToLLVMCastOpLowering>(converter, patterns.getContext(), dl);
   patterns.add<CIRToLLVMConstantOpLowering>(converter, patterns.getContext(),
                                             dl);
   patterns.add<

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -298,7 +298,7 @@ mlir::LogicalResult CIRToLLVMCastOpLowering::matchAndRewrite(
     mlir::Type targetType = convertTy(ptrTy);
     mlir::Type elementTy = convertTypeForMemory(*getTypeConverter(), dataLayout,
                                                 ptrTy.getPointee());
-    auto offset = llvm::SmallVector<mlir::LLVM::GEPArg>{0};
+    llvm::SmallVector<mlir::LLVM::GEPArg> offset{0};
     rewriter.replaceOpWithNewOp<mlir::LLVM::GEPOp>(
         castOp, targetType, elementTy, sourceValue, offset);
     break;

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -303,9 +303,15 @@ mlir::LogicalResult CIRToLLVMCastOpLowering::matchAndRewrite(
         castOp, targetType, elementTy, sourceValue, offset);
     break;
   }
-  case cir::CastKind::int_to_bool:
+  case cir::CastKind::int_to_bool: {
     assert(!cir::MissingFeatures::opCmp());
-    break;
+    mlir::Type dstType = castOp.getResult().getType();
+    mlir::Type llvmDstType = getTypeConverter()->convertType(dstType);
+    auto zeroBool = rewriter.create<mlir::LLVM::ConstantOp>(
+        castOp.getLoc(), llvmDstType, mlir::BoolAttr::get(getContext(), false));
+    rewriter.replaceOp(castOp, zeroBool);
+    return castOp.emitError() << "NYI int_to_bool cast";
+  }
   case cir::CastKind::integral: {
     mlir::Type srcType = castOp.getSrc().getType();
     mlir::Type dstType = castOp.getResult().getType();

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -294,10 +294,10 @@ mlir::LogicalResult CIRToLLVMCastOpLowering::matchAndRewrite(
   switch (castOp.getKind()) {
   case cir::CastKind::array_to_ptrdecay: {
     const auto ptrTy = mlir::cast<cir::PointerType>(castOp.getType());
-    auto sourceValue = adaptor.getOperands().front();
-    auto targetType = convertTy(ptrTy);
-    auto elementTy = convertTypeForMemory(*getTypeConverter(), dataLayout,
-                                          ptrTy.getPointee());
+    mlir::Value sourceValue = adaptor.getOperands().front();
+    mlir::Type targetType = convertTy(ptrTy);
+    mlir::Type elementTy = convertTypeForMemory(*getTypeConverter(), dataLayout,
+                                                ptrTy.getPointee());
     auto offset = llvm::SmallVector<mlir::LLVM::GEPArg>{0};
     rewriter.replaceOpWithNewOp<mlir::LLVM::GEPOp>(
         castOp, targetType, elementTy, sourceValue, offset);
@@ -307,10 +307,10 @@ mlir::LogicalResult CIRToLLVMCastOpLowering::matchAndRewrite(
     assert(!cir::MissingFeatures::opCmp());
     break;
   case cir::CastKind::integral: {
-    auto srcType = castOp.getSrc().getType();
-    auto dstType = castOp.getResult().getType();
-    auto llvmSrcVal = adaptor.getOperands().front();
-    auto llvmDstType = getTypeConverter()->convertType(dstType);
+    mlir::Type srcType = castOp.getSrc().getType();
+    mlir::Type dstType = castOp.getResult().getType();
+    mlir::Value llvmSrcVal = adaptor.getOperands().front();
+    mlir::Type llvmDstType = getTypeConverter()->convertType(dstType);
     cir::IntType srcIntType =
         mlir::cast<cir::IntType>(elementTypeIfVector(srcType));
     cir::IntType dstIntType =
@@ -322,12 +322,12 @@ mlir::LogicalResult CIRToLLVMCastOpLowering::matchAndRewrite(
     break;
   }
   case cir::CastKind::floating: {
-    auto llvmSrcVal = adaptor.getOperands().front();
-    auto llvmDstTy =
+    mlir::Value llvmSrcVal = adaptor.getOperands().front();
+    mlir::Type llvmDstTy =
         getTypeConverter()->convertType(castOp.getResult().getType());
 
-    auto srcTy = elementTypeIfVector(castOp.getSrc().getType());
-    auto dstTy = elementTypeIfVector(castOp.getResult().getType());
+    mlir::Type srcTy = elementTypeIfVector(castOp.getSrc().getType());
+    mlir::Type dstTy = elementTypeIfVector(castOp.getResult().getType());
 
     if (!mlir::isa<cir::CIRFPTypeInterface>(dstTy) ||
         !mlir::isa<cir::CIRFPTypeInterface>(srcTy))
@@ -347,22 +347,22 @@ mlir::LogicalResult CIRToLLVMCastOpLowering::matchAndRewrite(
   }
   case cir::CastKind::int_to_ptr: {
     auto dstTy = mlir::cast<cir::PointerType>(castOp.getType());
-    auto llvmSrcVal = adaptor.getOperands().front();
-    auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+    mlir::Value llvmSrcVal = adaptor.getOperands().front();
+    mlir::Type llvmDstTy = getTypeConverter()->convertType(dstTy);
     rewriter.replaceOpWithNewOp<mlir::LLVM::IntToPtrOp>(castOp, llvmDstTy,
                                                         llvmSrcVal);
     return mlir::success();
   }
   case cir::CastKind::ptr_to_int: {
     auto dstTy = mlir::cast<cir::IntType>(castOp.getType());
-    auto llvmSrcVal = adaptor.getOperands().front();
-    auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+    mlir::Value llvmSrcVal = adaptor.getOperands().front();
+    mlir::Type llvmDstTy = getTypeConverter()->convertType(dstTy);
     rewriter.replaceOpWithNewOp<mlir::LLVM::PtrToIntOp>(castOp, llvmDstTy,
                                                         llvmSrcVal);
     return mlir::success();
   }
   case cir::CastKind::float_to_bool: {
-    auto llvmSrcVal = adaptor.getOperands().front();
+    mlir::Value llvmSrcVal = adaptor.getOperands().front();
     auto kind = mlir::LLVM::FCmpPredicate::une;
 
     // Check if float is not equal to zero.
@@ -378,7 +378,7 @@ mlir::LogicalResult CIRToLLVMCastOpLowering::matchAndRewrite(
   }
   case cir::CastKind::bool_to_int: {
     auto dstTy = mlir::cast<cir::IntType>(castOp.getType());
-    auto llvmSrcVal = adaptor.getOperands().front();
+    mlir::Value llvmSrcVal = adaptor.getOperands().front();
     auto llvmSrcTy = mlir::cast<mlir::IntegerType>(llvmSrcVal.getType());
     auto llvmDstTy =
         mlir::cast<mlir::IntegerType>(getTypeConverter()->convertType(dstTy));
@@ -391,17 +391,17 @@ mlir::LogicalResult CIRToLLVMCastOpLowering::matchAndRewrite(
     return mlir::success();
   }
   case cir::CastKind::bool_to_float: {
-    auto dstTy = castOp.getType();
-    auto llvmSrcVal = adaptor.getOperands().front();
-    auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+    mlir::Type dstTy = castOp.getType();
+    mlir::Value llvmSrcVal = adaptor.getOperands().front();
+    mlir::Type llvmDstTy = getTypeConverter()->convertType(dstTy);
     rewriter.replaceOpWithNewOp<mlir::LLVM::UIToFPOp>(castOp, llvmDstTy,
                                                       llvmSrcVal);
     return mlir::success();
   }
   case cir::CastKind::int_to_float: {
-    auto dstTy = castOp.getType();
-    auto llvmSrcVal = adaptor.getOperands().front();
-    auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+    mlir::Type dstTy = castOp.getType();
+    mlir::Value llvmSrcVal = adaptor.getOperands().front();
+    mlir::Type llvmDstTy = getTypeConverter()->convertType(dstTy);
     if (mlir::cast<cir::IntType>(elementTypeIfVector(castOp.getSrc().getType()))
             .isSigned())
       rewriter.replaceOpWithNewOp<mlir::LLVM::SIToFPOp>(castOp, llvmDstTy,
@@ -412,9 +412,9 @@ mlir::LogicalResult CIRToLLVMCastOpLowering::matchAndRewrite(
     return mlir::success();
   }
   case cir::CastKind::float_to_int: {
-    auto dstTy = castOp.getType();
-    auto llvmSrcVal = adaptor.getOperands().front();
-    auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+    mlir::Type dstTy = castOp.getType();
+    mlir::Value llvmSrcVal = adaptor.getOperands().front();
+    mlir::Type llvmDstTy = getTypeConverter()->convertType(dstTy);
     if (mlir::cast<cir::IntType>(
             elementTypeIfVector(castOp.getResult().getType()))
             .isSigned())
@@ -433,9 +433,9 @@ mlir::LogicalResult CIRToLLVMCastOpLowering::matchAndRewrite(
     assert(!cir::MissingFeatures::opCmp());
     break;
   case cir::CastKind::address_space: {
-    auto dstTy = castOp.getType();
-    auto llvmSrcVal = adaptor.getOperands().front();
-    auto llvmDstTy = getTypeConverter()->convertType(dstTy);
+    mlir::Type dstTy = castOp.getType();
+    mlir::Value llvmSrcVal = adaptor.getOperands().front();
+    mlir::Type llvmDstTy = getTypeConverter()->convertType(dstTy);
     rewriter.replaceOpWithNewOp<mlir::LLVM::AddrSpaceCastOp>(castOp, llvmDstTy,
                                                              llvmSrcVal);
     break;

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -22,6 +22,22 @@ namespace direct {
 
 mlir::LLVM::Linkage convertLinkage(cir::GlobalLinkageKind linkage);
 
+class CIRToLLVMCastOpLowering : public mlir::OpConversionPattern<cir::CastOp> {
+  mlir::DataLayout const &dataLayout;
+
+  mlir::Type convertTy(mlir::Type ty) const;
+
+public:
+  CIRToLLVMCastOpLowering(const mlir::TypeConverter &typeConverter,
+                          mlir::MLIRContext *context,
+                          mlir::DataLayout const &dataLayout)
+      : OpConversionPattern(typeConverter, context), dataLayout(dataLayout) {}
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::CastOp op, OpAdaptor,
+                  mlir::ConversionPatternRewriter &) const override;
+};
+
 class CIRToLLVMReturnOpLowering
     : public mlir::OpConversionPattern<cir::ReturnOp> {
 public:

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -8,14 +8,14 @@ unsigned char cxxstaticcast_0(unsigned int x) {
 }
 
 // CIR: cir.func @cxxstaticcast_0
-// CIR:    %0 = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["x", init] {alignment = 4 : i64}
-// CIR:    cir.store %arg0, %0 : !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>
-// CIR:    %1 = cir.load %0 : !cir.ptr<!cir.int<u, 32>>, !cir.int<u, 32>
-// CIR:    %2 = cir.cast(integral, %1 : !cir.int<u, 32>), !cir.int<u, 8>
-// CIR:    cir.return %2 : !cir.int<u, 8>
+// CIR:    %[[XPTR:[0-9]+]] = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["x", init] {alignment = 4 : i64}
+// CIR:    cir.store %arg0, %[[XPTR]] : !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>
+// CIR:    %[[XVAL:[0-9]+]] = cir.load %[[XPTR]] : !cir.ptr<!cir.int<u, 32>>, !cir.int<u, 32>
+// CIR:    %[[CASTED:[0-9]+]] = cir.cast(integral, %[[XVAL]] : !cir.int<u, 32>), !cir.int<u, 8>
+// CIR:    cir.return %[[CASTED]] : !cir.int<u, 8>
 // CIR:  }
 
-// LLVM: define i8 @cxxstaticcast_0(i32 %0)
+// LLVM: define i8 @cxxstaticcast_0(i32 %{{[0-9]+}})
 // LLVM: %[[LOAD:[0-9]+]] = load i32, ptr %{{[0-9]+}}, align 4
 // LLVM: %[[TRUNC:[0-9]+]] = trunc i32 %[[LOAD]] to i8
 // LLVM: ret i8 %[[TRUNC]]
@@ -79,10 +79,10 @@ bool cptr(void *d) {
 }
 
 // CIR: cir.func @cptr(%arg0: !cir.ptr<!cir.void>
-// CIR:   %0 = cir.alloca !cir.ptr<!cir.void>, !cir.ptr<!cir.ptr<!cir.void>>, ["d", init] {alignment = 8 : i64}
+// CIR:   %[[DPTR:[0-9]+]] = cir.alloca !cir.ptr<!cir.void>, !cir.ptr<!cir.ptr<!cir.void>>, ["d", init] {alignment = 8 : i64}
 
-// CIR:   %2 = cir.load %0 : !cir.ptr<!cir.ptr<!cir.void>>, !cir.ptr<!cir.void>
-// CIR:   %3 = cir.cast(ptr_to_bool, %2 : !cir.ptr<!cir.void>), !cir.bool
+// CIR:   %[[DVAL:[0-9]+]] = cir.load %[[DPTR]] : !cir.ptr<!cir.ptr<!cir.void>>, !cir.ptr<!cir.void>
+// CIR:   %{{[0-9]+}} = cir.cast(ptr_to_bool, %[[DVAL]] : !cir.ptr<!cir.void>), !cir.bool
 #endif
 
 void should_not_cast() {

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -58,7 +58,6 @@ void should_not_cast() {
 
   unsigned uu = (unsigned)x1;
   bool ib = (bool)x1;
-  return (void) x1;
 }
 
 // CHECK:     cir.func @should_not_cast

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -35,11 +35,7 @@ int cStyleCasts_0(unsigned x1, int x2, float x3, short x4, double x5) {
   int si = (int)x1; // sign add
   // CHECK: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !cir.int<u, 32>), !cir.int<s, 32>
 
-  unsigned uu = (unsigned)x1; // should not be generated
-  // CHECK-NOT: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !cir.int<u, 32>), !cir.int<u, 32>
-
-  bool ib = (bool)x1; // No checking, because this isn't a regular cast.
-
+  bool ib;
   int bi = (int)ib; // bool to int
   // CHECK: %{{[0-9]+}} = cir.cast(bool_to_int, %{{[0-9]+}} : !cir.bool), !cir.int<s, 32>
 
@@ -56,3 +52,15 @@ bool cptr(void *d) {
 
 // CHECK:   %2 = cir.load %0 : !cir.ptr<!cir.ptr<!cir.void>>, !cir.ptr<!cir.void>
 // CHECK:   %3 = cir.cast(ptr_to_bool, %2 : !cir.ptr<!cir.void>), !cir.bool
+
+void should_not_cast() {
+  unsigned x1;
+
+  unsigned uu = (unsigned)x1;
+  bool ib = (bool)x1;
+  return (void) x1;
+}
+
+// CHECK:     cir.func @should_not_cast
+// CHECK-NOT:   cir.cast
+// CHECK:     }

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -66,13 +66,14 @@ bool cptr(void *d) {
 
 void should_not_cast() {
   unsigned x1;
+  unsigned uu = (unsigned)x1; // identity
 
-  unsigned uu = (unsigned)x1;
-  bool ib = (bool)x1;
+  bool x2;
+  bool ib = (bool)x2; // identity
   
   (void) ib; // void cast
 }
 
 // CHECK:     cir.func @should_not_cast
 // CHECK-NOT:   cir.cast
-// CHECK:     }
+// CHECK:     cir.return

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -1,0 +1,58 @@
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s
+
+unsigned char cxxstaticcast_0(unsigned int x) {
+  return static_cast<unsigned char>(x);
+}
+
+// CHECK: cir.func @cxxstaticcast_0
+// CHECK:    %0 = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["x", init] {alignment = 4 : i64}
+// CHECK:    cir.store %arg0, %0 : !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>
+// CHECK:    %1 = cir.load %0 : !cir.ptr<!cir.int<u, 32>>, !cir.int<u, 32>
+// CHECK:    %2 = cir.cast(integral, %1 : !cir.int<u, 32>), !cir.int<u, 8>
+// CHECK:    cir.return %2 : !cir.int<u, 8>
+// CHECK:  }
+
+
+int cStyleCasts_0(unsigned x1, int x2, float x3, short x4, double x5) {
+// CHECK: cir.func @cStyleCasts_0
+
+  char a = (char)x1; // truncate
+  // CHECK: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !cir.int<u, 32>), !cir.int<s, 8>
+
+  short b = (short)x2; // truncate with sign
+  // CHECK: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !cir.int<s, 32>), !cir.int<s, 16>
+
+  long long c = (long long)x1; // zero extend
+  // CHECK: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !cir.int<u, 32>), !cir.int<s, 64>
+
+  long long d = (long long)x2; // sign extend
+  // CHECK: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !cir.int<s, 32>), !cir.int<s, 64>
+
+  unsigned ui = (unsigned)x2; // sign drop
+  // CHECK: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !cir.int<s, 32>), !cir.int<u, 32>
+
+  int si = (int)x1; // sign add
+  // CHECK: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !cir.int<u, 32>), !cir.int<s, 32>
+
+  unsigned uu = (unsigned)x1; // should not be generated
+  // CHECK-NOT: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !cir.int<u, 32>), !cir.int<u, 32>
+
+  bool ib = (bool)x1; // No checking, because this isn't a regular cast.
+
+  int bi = (int)ib; // bool to int
+  // CHECK: %{{[0-9]+}} = cir.cast(bool_to_int, %{{[0-9]+}} : !cir.bool), !cir.int<s, 32>
+
+  return 0;
+}
+
+bool cptr(void *d) {
+  bool x = d;
+  return x;
+}
+
+// CHECK: cir.func @cptr(%arg0: !cir.ptr<!cir.void>
+// CHECK:   %0 = cir.alloca !cir.ptr<!cir.void>, !cir.ptr<!cir.ptr<!cir.void>>, ["d", init] {alignment = 8 : i64}
+
+// CHECK:   %2 = cir.load %0 : !cir.ptr<!cir.ptr<!cir.void>>, !cir.ptr<!cir.void>
+// CHECK:   %3 = cir.cast(ptr_to_bool, %2 : !cir.ptr<!cir.void>), !cir.bool

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -58,6 +58,7 @@ void should_not_cast() {
 
   unsigned uu = (unsigned)x1;
   bool ib = (bool)x1;
+  (void) ib;
 }
 
 // CHECK:     cir.func @should_not_cast

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -39,6 +39,17 @@ int cStyleCasts_0(unsigned x1, int x2, float x3, short x4, double x5) {
   int bi = (int)ib; // bool to int
   // CHECK: %{{[0-9]+}} = cir.cast(bool_to_int, %{{[0-9]+}} : !cir.bool), !cir.int<s, 32>
 
+  bool b2 = x2; // int to bool
+  // CHECK: %{{[0-9]+}} = cir.cast(int_to_bool, %{{[0-9]+}} : !cir.int<s, 32>), !cir.bool
+  
+  void *p;
+  bool b3 = p; // ptr to bool
+  // CHECK: %{{[0-9]+}} = cir.cast(ptr_to_bool, %{{[0-9]+}} : !cir.ptr<!cir.void>), !cir.bool
+
+  float f;
+  bool b4 = f; // float to bool
+  // CHECK: %{{[0-9]+}} = cir.cast(float_to_bool, %{{[0-9]+}} : !cir.float), !cir.bool
+
   return 0;
 }
 
@@ -58,7 +69,8 @@ void should_not_cast() {
 
   unsigned uu = (unsigned)x1;
   bool ib = (bool)x1;
-  (void) ib;
+  
+  (void) ib; // void cast
 }
 
 // CHECK:     cir.func @should_not_cast

--- a/clang/test/CIR/IR/cast.cir
+++ b/clang/test/CIR/IR/cast.cir
@@ -1,0 +1,23 @@
+// RUN: cir-opt %s | cir-opt | FileCheck %s
+!s32i = !cir.int<s, 32>
+
+module  {
+  cir.func @yolo(%arg0 : !s32i) {
+    %a = cir.cast (int_to_bool, %arg0 : !s32i), !cir.bool
+
+    %0 = cir.const #cir.int<0> : !s32i
+    cir.return
+  }
+
+  cir.func @bitcast(%p: !cir.ptr<!s32i>) {
+    %0 = cir.cast(bitcast, %p : !cir.ptr<!s32i>), !cir.ptr<f32>
+    cir.return
+  }
+}
+
+// CHECK: cir.func @yolo(%arg0: !cir.int<s, 32>)
+// CHECK: %0 = cir.cast(int_to_bool, %arg0 : !cir.int<s, 32>), !cir.bool
+// CHECK: %1 = cir.const #cir.int<0> : !cir.int<s, 32>
+
+// CHECK: cir.func @bitcast
+// CHECK: %0 = cir.cast(bitcast, %arg0 : !cir.ptr<!cir.int<s, 32>>), !cir.ptr<f32>

--- a/clang/test/CIR/Lowering/cast.cir
+++ b/clang/test/CIR/Lowering/cast.cir
@@ -1,0 +1,92 @@
+// RUN: cir-opt %s -cir-to-llvm -o %t.cir
+// RUN: FileCheck %s --input-file=%t.cir
+
+!s16i = !cir.int<s, 16>
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+!s8i = !cir.int<s, 8>
+!u32i = !cir.int<u, 32>
+!u8i = !cir.int<u, 8>
+!u64i = !cir.int<u, 64>
+
+module {
+  cir.func @cStyleCasts(%arg0: !u32i, %arg1: !s32i, %arg2: !cir.float, %arg3: !cir.double) -> !s32i {
+  // CHECK: llvm.func @cStyleCasts
+    %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["x1", init] {alignment = 4 : i64}
+    %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["x2", init] {alignment = 4 : i64}
+    %20 = cir.alloca !s16i, !cir.ptr<!s16i>, ["x4", init] {alignment = 2 : i64}
+    %2 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
+    %3 = cir.alloca !s8i, !cir.ptr<!s8i>, ["a", init] {alignment = 1 : i64}
+    %4 = cir.alloca !s16i, !cir.ptr<!s16i>, ["b", init] {alignment = 2 : i64}
+    %5 = cir.alloca !s64i, !cir.ptr<!s64i>, ["c", init] {alignment = 8 : i64}
+    %6 = cir.alloca !s64i, !cir.ptr<!s64i>, ["d", init] {alignment = 8 : i64}
+    %8 = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["e", init] {alignment = 8 : i64}
+    cir.store %arg0, %0 : !u32i, !cir.ptr<!u32i>
+    cir.store %arg1, %1 : !s32i, !cir.ptr<!s32i>
+
+    // Integer casts.
+    %9 = cir.load %0 : !cir.ptr<!u32i>, !u32i
+    %10 = cir.cast(integral, %9 : !u32i), !s8i
+    // CHECK: %{{[0-9]+}} = llvm.trunc %{{[0-9]+}} : i32 to i8
+    cir.store %10, %3 : !s8i, !cir.ptr<!s8i>
+    %11 = cir.load %1 : !cir.ptr<!s32i>, !s32i
+    %12 = cir.cast(integral, %11 : !s32i), !s16i
+    // CHECK: %{{[0-9]+}} = llvm.trunc %{{[0-9]+}} : i32 to i16
+    cir.store %12, %4 : !s16i, !cir.ptr<!s16i>
+    %13 = cir.load %0 : !cir.ptr<!u32i>, !u32i
+    %14 = cir.cast(integral, %13 : !u32i), !s64i
+    // CHECK: %{{[0-9]+}} = llvm.zext %{{[0-9]+}} : i32 to i64
+    cir.store %14, %5 : !s64i, !cir.ptr<!s64i>
+    %15 = cir.load %1 : !cir.ptr<!s32i>, !s32i
+    %16 = cir.cast(integral, %15 : !s32i), !s64i
+    // CHECK: %{{[0-9]+}} = llvm.sext %{{[0-9]+}} : i32 to i64
+    %30 = cir.cast(integral, %arg1 : !s32i), !u32i
+    // Should not produce a cast.
+    %32 = cir.cast(integral, %arg0 : !u32i), !s32i
+    // Should not produce a cast.
+    %21 = cir.load %20 : !cir.ptr<!s16i>, !s16i
+    %22 = cir.cast(integral, %21 : !s16i), !u64i
+    // CHECK: %[[TMP:[0-9]+]] = llvm.sext %{{[0-9]+}} : i16 to i64
+
+    // Pointer casts.
+    cir.store %16, %6 : !s64i, !cir.ptr<!s64i>
+    %23 = cir.cast(int_to_ptr, %22 : !u64i), !cir.ptr<!u8i>
+    // CHECK: %[[TMP2:[0-9]+]] = llvm.inttoptr %[[TMP]] : i64 to !llvm.ptr
+    %24 = cir.cast(ptr_to_int, %23 : !cir.ptr<!u8i>), !s32i
+    // CHECK: %{{[0-9]+}} = llvm.ptrtoint %[[TMP2]] : !llvm.ptr to i32
+    %29 = cir.cast(ptr_to_bool, %23 : !cir.ptr<!u8i>), !cir.bool
+
+    // Floating point casts.
+    %25 = cir.cast(int_to_float, %arg1 : !s32i), !cir.float
+    // CHECK: %{{.+}} = llvm.sitofp %{{.+}} : i32 to f32
+    %26 = cir.cast(int_to_float, %arg0 : !u32i), !cir.float
+    // CHECK: %{{.+}} = llvm.uitofp %{{.+}} : i32 to f32
+    %27 = cir.cast(float_to_int, %arg2 : !cir.float), !s32i
+    // CHECK: %{{.+}} = llvm.fptosi %{{.+}} : f32 to i32
+    %28 = cir.cast(float_to_int, %arg2 : !cir.float), !u32i
+    // CHECK: %{{.+}} = llvm.fptoui %{{.+}} : f32 to i32
+    %18 = cir.const #cir.int<0> : !s32i
+    // CHECK: %{{.+}} = llvm.fptrunc %{{.+}} : f64 to f32
+    %34 = cir.cast(floating, %arg3 : !cir.double), !cir.float
+
+    cir.store %18, %2 : !s32i, !cir.ptr<!s32i>
+    %19 = cir.load %2 : !cir.ptr<!s32i>, !s32i
+    cir.return %19 : !s32i
+  }
+
+  cir.func @testBoolToIntCast(%arg0: !cir.bool)  {
+  // CHECK: llvm.func @testBoolToIntCast
+    %0 = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["bl", init] {alignment = 1 : i64}
+    %1 = cir.alloca !u8i, !cir.ptr<!u8i>, ["y", init] {alignment = 1 : i64}
+    cir.store %arg0, %0 : !cir.bool, !cir.ptr<!cir.bool>
+
+    %2 = cir.load %0 : !cir.ptr<!cir.bool>, !cir.bool
+    %3 = cir.cast(bool_to_int, %2 : !cir.bool), !u8i
+    // CHECK: %[[LOAD_BOOL:.*]] = llvm.load %{{.*}} : !llvm.ptr -> i8
+    // CHECK: %[[TRUNC:.*]] = llvm.trunc %[[LOAD_BOOL]] : i8 to i1
+    // CHECK: %[[EXT:.*]] = llvm.zext %[[TRUNC]] : i1 to i8
+
+    cir.store %3, %1 : !u8i, !cir.ptr<!u8i>
+    cir.return
+  }
+}


### PR DESCRIPTION
This patch upstreams ClangIR's CastOp with the following exceptions:
- No Fixed/FP conversions
- No casts between value categories
- No complex casts
- No array_to_ptrdecay
- No address_space
- No casts involving record types (member pointers, base/derived casts)
- No casts specific to ObjC or OpenCL