### PR TITLE
[MLIR][NFC] Adding a missing option in OneShotBufferizePass

### DIFF
--- a/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Bufferization/Transforms/Passes.td
@@ -450,6 +450,10 @@ def OneShotBufferizePass : Pass<"one-shot-bufferize", "ModuleOp"> {
        Option<"bufferAlignment", "buffer-alignment", "uint64_t",
               /*default=*/"64",
               "Sets the alignment of newly allocated buffers.">,
+       Option<"enforceAliasingInvariants", "enforce-aliasing-invariants", "bool",
+              /*default=*/"true",
+              "Enforce aliasing Op/Operand/OpResult invariants with buffer"
+              " copies.">,
   ];
 
   let statistics = [

--- a/mlir/lib/Dialect/Bufferization/Transforms/Bufferize.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/Bufferize.cpp
@@ -81,6 +81,7 @@ struct OneShotBufferizePass
       opt.allowUnknownOps = allowUnknownOps;
       opt.analysisFuzzerSeed = analysisFuzzerSeed;
       opt.analysisHeuristic = parseHeuristicOption(analysisHeuristic);
+      opt.enforceAliasingInvariants = enforceAliasingInvariants;
       opt.copyBeforeWrite = copyBeforeWrite;
       opt.dumpAliasSets = dumpAliasSets;
       opt.setFunctionBoundaryTypeConversion(


### PR DESCRIPTION
#129850 removed let constructor for `OneShotBufferizePass`, however the list of tablegen options missed one inherited from `BufferizationOptions`.
