### PR TITLE
[SystemZ, ArgExt verification] Cache results of isFullyInternal().

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZISelLowering.cpp
@@ -10237,6 +10237,11 @@ static void printFunctionArgExts(const Function *F, raw_fd_ostream &OS) {
 void SystemZTargetLowering::
 verifyNarrowIntegerArgs_Call(const SmallVectorImpl<ISD::OutputArg> &Outs,
                              const Function *F, SDValue Callee) const {
+  // Temporarily only do the check when explicitly requested, until it can be
+  // enabled by default.
+  if (!EnableIntArgExtCheck)
+    return;
+
   bool IsInternal = false;
   const Function *CalleeFn = nullptr;
   if (auto *G = dyn_cast<GlobalAddressSDNode>(Callee))
@@ -10258,6 +10263,11 @@ verifyNarrowIntegerArgs_Call(const SmallVectorImpl<ISD::OutputArg> &Outs,
 void SystemZTargetLowering::
 verifyNarrowIntegerArgs_Ret(const SmallVectorImpl<ISD::OutputArg> &Outs,
                             const Function *F) const {
+  // Temporarily only do the check when explicitly requested, until it can be
+  // enabled by default.
+  if (!EnableIntArgExtCheck)
+    return;
+
   if (!verifyNarrowIntegerArgs(Outs, isFullyInternal(F))) {
     errs() << "ERROR: Missing extension attribute of returned "
            << "value from function:\n";
@@ -10272,11 +10282,6 @@ bool SystemZTargetLowering::
 verifyNarrowIntegerArgs(const SmallVectorImpl<ISD::OutputArg> &Outs,
                         bool IsInternal) const {
   if (IsInternal || !Subtarget.isTargetELF())
-    return true;
-
-  // Temporarily only do the check when explicitly requested, until it can be
-  // enabled by default.
-  if (!EnableIntArgExtCheck)
     return true;
 
   if (EnableIntArgExtCheck.getNumOccurrences()) {


### PR DESCRIPTION
It has found to be quite a slowdown to traverse the users of a function from each call site when it is called many (~70k) times.
Make sure to only do this once per function by using a new Function flag for this purpose.

This is my first attempt that works as expected, but not sure if it's desired to introduce the new Function member. As this is at the I/R level, it is not strictly of SystemZ interest only, although at the moment it is. isFullyInternal() could be moved into Function perhaps if some other target decides to do a similar check, so in a sense it belongs here.

There is the IsNewDbgInfoFormat which is also kind of a flag without being a proper attribute, which would be overkill in this case.

Maybe an alternative might be to have a set of Function pointers in SystemZIselLowering that should hopefully live throughout the compilation of the module, which is what is needed. It seems safer though to avoid the potential reuse of pointers entirely.

Not sure if MachineModuleInfo could be used - do not see other similar usages.

It is probably also a good idea to avoid calling isFullyInternal() unless the actual check is enabled. Waiting with that until the test case is confirmed to be resolved.
