### PR TITLE
[libc][bazel] Create libc_release_library for release configurations.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/BUILD.bazel
@@ -2,6 +2,26 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("//libc:libc_build_rules.bzl", "libc_release_library")
+
 package(default_visibility = ["//visibility:public"])
 
 exports_files(["libc_test_rules.bzl"])
+
+# Sanity check that libc_release_library macro works as intended.
+libc_release_library(
+    name = "libc_release_test",
+    libc_functions = [
+        "//libc:acosf",
+        "//libc:read",
+    ],
+    weak_symbols = [
+        "read",
+    ],
+)
+
+build_test(
+    name = "libc_release_test_build",
+    targets = [":libc_release_test"],
+)

--- a/utils/bazel/llvm-project-overlay/libc/test/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/BUILD.bazel
@@ -9,7 +9,7 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files(["libc_test_rules.bzl"])
 
-# Sanity check that libc_release_library macro works as intended.
+# Smoke test verifying libc_release_library macro functionality.
 libc_release_library(
     name = "libc_release_test",
     libc_functions = [
@@ -22,6 +22,6 @@ libc_release_library(
 )
 
 build_test(
-    name = "libc_release_test_build",
+    name = "libc_release_build_test",
     targets = [":libc_release_test"],
 )


### PR DESCRIPTION
See PR #130327 for background and motivation. This change expands the libc_support_library and libc_function rules to create filegroups that allow building a collection of llvm-libc functions together, from sources, as a part of a single cc_library that can then be used by the downstream clients.

This change also adds an example use of this macro under libc/test/BUILD.bazel to confirm that this macro works as expected.