### PR TITLE
[libc][bazel] Remove unneeded deps.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/utils/MPFRWrapper/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/utils/MPFRWrapper/BUILD.bazel
@@ -48,7 +48,6 @@ libc_test_library(
         "//libc:__support_macros_properties_types",
         "//libc/test/UnitTest:fp_test_helpers",
         "//libc/utils/MPFRWrapper:mpfr_impl",
-        "@gmp//:gmp_",
     ],
 )
 
@@ -82,6 +81,5 @@ libc_test_library(
         "//libc/test/UnitTest:LibcUnitTest",
         "//libc/test/UnitTest:fp_test_helpers",
         "//libc/utils/MPFRWrapper:mpfr_impl",
-        "@gmp//:gmp_",
     ],
 )


### PR DESCRIPTION
The MPFRWrapper BUILD targets don't depend directly on gmp. MPFR itself does depend on gmp, but not the wrapper.