### PR TITLE
[clang] Fix a segfault when M is a nullptr

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -520,12 +520,12 @@ Improvements to Clang's diagnostics
 - Several compatibility diagnostics that were incorrectly being grouped under
   ``-Wpre-c++20-compat`` are now part of ``-Wc++20-compat``. (#GH138775)
 
-- Improved the ``-Wtautological-overlap-compare`` diagnostics to warn about overlapping and non-overlapping ranges involving character literals and floating-point literals. 
+- Improved the ``-Wtautological-overlap-compare`` diagnostics to warn about overlapping and non-overlapping ranges involving character literals and floating-point literals.
   The warning message for non-overlapping cases has also been improved (#GH13473).
 
 - Fixed a duplicate diagnostic when performing typo correction on function template
   calls with explicit template arguments. (#GH139226)
-  
+
 - Explanatory note is printed when ``assert`` fails during evaluation of a
   constant expression. Prior to this, the error inaccurately implied that assert
   could not be used at all in a constant expression (#GH130458)
@@ -709,6 +709,7 @@ Bug Fixes to C++ Support
 - Fixed the handling of pack indexing types in the constraints of a member function redeclaration. (#GH138255)
 - Clang now correctly parses arbitrary order of ``[[]]``, ``__attribute__`` and ``alignas`` attributes for declarations (#GH133107)
 - Fixed a crash when forming an invalid function type in a dependent context. (#GH138657) (#GH115725) (#GH68852)
+- Clang no longer segfaults when there is a configuration mismatch between modules and their users (http://crbug.com/400353616).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/Basic/Module.h
+++ b/clang/include/clang/Basic/Module.h
@@ -888,7 +888,7 @@ public:
 
   /// Get the location at which the import of a module was triggered.
   SourceLocation getImportLoc(const Module *M) const {
-    return M->getVisibilityID() < ImportLocs.size()
+    return M && M->getVisibilityID() < ImportLocs.size()
                ? ImportLocs[M->getVisibilityID()]
                : SourceLocation();
   }

--- a/clang/test/Modules/pr130712.cppm
+++ b/clang/test/Modules/pr130712.cppm
@@ -1,0 +1,33 @@
+// RUN: split-file %s %t
+
+// There are two requirements here to result in the owner of a macro being null.
+// 1) There must be a configuration mismatch between a header and a file it depends on
+// 2) -fmodules-local-submodule-visibility must be enabled.
+
+// In the following example, when compiling module C, A_H has no owning module.
+
+// RUN: %clang_cc1 -I%t -emit-module -o %t/a.pcm -fmodules %t/module.modulemap -fmodule-name=a -fmodules-local-submodule-visibility 
+// RUN: %clang_cc1 -fexceptions -Wno-module-file-config-mismatch -I%t -emit-module -o %t/b.pcm -fmodules %t/module.modulemap -fmodule-name=b -fmodules-local-submodule-visibility -fmodule-file=%t/a.pcm
+// RUN: %clang_cc1 -fexceptions -Wno-module-file-config-mismatch -I%t -emit-module -o %t/c.pcm -fmodules %t/module.modulemap -fmodule-name=c -fmodules-local-submodule-visibility -fmodule-file=%t/a.pcm -fmodule-file=%t/b.pcm
+
+//--- module.modulemap
+module a { header "a.h" }
+module b { header "b.h" }
+module c { header "c.h" }
+
+//--- a.h
+#ifndef A_H
+#define A_H
+#endif
+
+//--- b.h
+#ifndef B_H
+#define B_H
+
+#include <a.h>
+
+#endif
+
+//--- c.h
+#include <a.h>
+#include <b.h>


### PR DESCRIPTION
If `MM->getOwningModule` returns nullptr, then `isVisible` is called with nullptr, which then calls `getImportLoc(nullptr)`

https://github.com/llvm/llvm-project/blob/077e0c134a31cc16c432ce685458b1de80bfbf84/clang/lib/Lex/PPMacroExpansion.cpp#L208
