### PR TITLE
[libcxx][clang-modules] Fix headers being marked as textual

### DIFF
--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -1,13 +1,36 @@
 // This module contains headers related to the configuration of the library. These headers
 // are free of any dependency on the rest of libc++.
 module std_config [system] {
-  textual header "__config"
-  textual header "__configuration/abi.h"
-  textual header "__configuration/availability.h"
-  textual header "__configuration/compiler.h"
-  textual header "__configuration/language.h"
-  textual header "__configuration/platform.h"
-  textual header "version"
+  // Each of these submodules has "export *" to preserve compatibility by ensuring that
+  // when you include the module, you get the transitive deps.
+  module config {
+    header "__config"
+    export *
+  }
+  module abi {
+    header "__configuration/abi.h"
+    export *
+  }
+  module availability {
+    header "__configuration/availability.h"
+    export *
+  }
+  module compiler {
+    header "__configuration/compiler.h"
+    export *
+  }
+  module language {
+    header "__configuration/language.h"
+    export *
+  }
+  module platform {
+    header "__configuration/platform.h"
+    export *
+  }
+  module version {
+    header "version"
+    export *
+  }
 }
 
 module std_core [system] {


### PR DESCRIPTION
When building libcxx as a module, it fails to build because it's missing various definitions.

Consider the following code for module A:
```
#include <module B that includes config_site>
#include <config>
#include <module C that includes config>
```

With the module map file:
```
module std {
   module A { header "a.h" }
   module B { header "b.h" }
   module C { header "c.h" }
}
```

Macro visibility rules state that "[macros] are visible if they are from the current submodule or translation unit, or if they were exported from a submodule that has been imported."
* Module A has visibility of all macros exported by modules B and C (because they were exported from an imported submodule)
* Module B and C have visibility over all macros exported by module A (because they are from the current submodule)

1) When we #include the first line, module B successfully includes config_site.

Module B exports: config_site contents, config_site header guard

2) Module A now includes <config> directly

Because it can see module B's exports, it stops at the header guard for config_site and does not include config_site. This is not an issue, however, because it has visibility onto everything exported from config_site thanks to module B.

Module A exports: config  contents, config header guard, config's includes' content and header guard (*except config_site*)

3) Module C now includes config. Based on the above visibility rules, it can see everything exported from module A.

Because of that, we see the header guard for config and do not import it at all. This is mostly OK, as we can see the config that module A exported. However, if we ever try and access config_site, it will fail, as A did not export config_site.