### PR TITLE
[Clang] Fix the printout of CXXParenListInitExpr involving default arguments

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -311,6 +311,7 @@ Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 - Fixed type checking when a statement expression ends in an l-value of atomic type. (#GH106576)
 - Fixed uninitialized use check in a lambda within CXXOperatorCallExpr. (#GH129198)
+- Fixed a malformed printout of ``CXXParenListInitExpr`` in certain contexts.
 
 Miscellaneous Bug Fixes
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/StmtPrinter.cpp
+++ b/clang/lib/AST/StmtPrinter.cpp
@@ -2659,10 +2659,8 @@ void StmtPrinter::VisitCXXFoldExpr(CXXFoldExpr *E) {
 }
 
 void StmtPrinter::VisitCXXParenListInitExpr(CXXParenListInitExpr *Node) {
-  OS << "(";
-  llvm::interleaveComma(Node->getInitExprs(), OS,
+  llvm::interleaveComma(Node->getUserSpecifiedInitExprs(), OS,
                         [&](Expr *E) { PrintExpr(E); });
-  OS << ")";
 }
 
 void StmtPrinter::VisitConceptSpecializationExpr(ConceptSpecializationExpr *E) {

--- a/clang/test/CodeGen/p0963r3.cpp
+++ b/clang/test/CodeGen/p0963r3.cpp
@@ -139,9 +139,6 @@ constexpr int bar(auto) {
   }();
   static_assert(value == S(1, 2));
 
-  // FIXME: The diagnostic message adds a trailing comma "static assertion failed due to requirement 'value == Case1::S((0, 1, ))'"
-  // static_assert(value == S(0, 1));
-
   constexpr auto value2 = [] {
     if (auto [a, b] = S(1, 2))
       return S(a, b);

--- a/clang/test/SemaCXX/paren-list-agg-init.cpp
+++ b/clang/test/SemaCXX/paren-list-agg-init.cpp
@@ -357,3 +357,21 @@ ThroughAlias<int, 1> e(42);
 // beforecxx20-warning@-1 {{aggregate initialization of type 'ThroughAlias<int, 1>' (aka 'int[1]') from a parenthesized list of values is a C++20 extension}} 
 
 }
+
+namespace CXXParenListInitExpr {
+
+struct S {
+  int a, b;
+  bool flag = false;
+
+  constexpr bool operator==(S rhs) {
+    return a == rhs.a && b == rhs.b;
+  }
+};
+
+static_assert(S(1, 2) == S(1, 2));
+
+static_assert(S(1, 2) == S(3, 4));
+// expected-error@-1 {{failed due to requirement 'S(1, 2) == S(3, 4)'}}
+
+}

--- a/clang/test/SemaCXX/paren-list-agg-init.cpp
+++ b/clang/test/SemaCXX/paren-list-agg-init.cpp
@@ -369,9 +369,10 @@ struct S {
   }
 };
 
-static_assert(S(1, 2) == S(1, 2));
+static_assert(S(1, 2) == S(1, 2)); // beforecxx20-warning 2{{C++20 extension}}
 
 static_assert(S(1, 2) == S(3, 4));
-// expected-error@-1 {{failed due to requirement 'CXXParenListInitExpr::S(1, 2) == CXXParenListInitExpr::S(3, 4)'}}
+// expected-error@-1 {{failed due to requirement 'CXXParenListInitExpr::S(1, 2) == CXXParenListInitExpr::S(3, 4)'}} \
+// beforecxx20-warning@-1 2{{C++20 extension}}
 
 }

--- a/clang/test/SemaCXX/paren-list-agg-init.cpp
+++ b/clang/test/SemaCXX/paren-list-agg-init.cpp
@@ -372,6 +372,6 @@ struct S {
 static_assert(S(1, 2) == S(1, 2));
 
 static_assert(S(1, 2) == S(3, 4));
-// expected-error@-1 {{failed due to requirement 'S(1, 2) == S(3, 4)'}}
+// expected-error@-1 {{failed due to requirement 'CXXParenListInitExpr::S(1, 2) == CXXParenListInitExpr::S(3, 4)'}}
 
 }


### PR DESCRIPTION
The parantheses are unnecessary IMO because they should have been handled in the parents of such expressions, e.g. in CXXFunctionalCastExpr.

Moreover, we shouldn't join CXXDefaultInitExpr either because they are not printed at all.