### PR TITLE
[TableGen] Add `!match` operator to do regex matching

### DIFF
--- a/llvm/docs/TableGen/ProgRef.rst
+++ b/llvm/docs/TableGen/ProgRef.rst
@@ -225,11 +225,11 @@ TableGen provides "bang operators" that have a wide variety of uses:
                : !getdagname  !getdagop    !gt          !head        !if
                : !initialized !interleave  !isa         !le          !listconcat
                : !listflatten !listremove  !listsplat   !logtwo      !lt
-               : !mul         !ne          !not         !or          !range
-               : !repr        !setdagarg   !setdagname  !setdagop    !shl
-               : !size        !sra         !srl         !strconcat   !sub
-               : !subst       !substr      !tail        !tolower     !toupper
-               : !xor
+               : !match       !mul         !ne          !not         !or
+               : !range       !repr        !setdagarg   !setdagname  !setdagop
+               : !shl         !size        !sra         !srl         !strconcat
+               : !sub         !subst       !substr      !tail        !tolower
+               : !toupper     !xor
 
 The ``!cond`` operator has a slightly different
 syntax compared to other bang operators, so it is defined separately:
@@ -1877,6 +1877,10 @@ and non-0 as true.
 ``!lt(``\ *a*\ `,` *b*\ ``)``
     This operator produces 1 if *a* is less than *b*; 0 otherwise.
     The arguments must be ``bit``, ``bits``, ``int``, or ``string`` values.
+
+``!match(``\ *str*\ `,` *regex*\ ``)``
+    This operator produces 1 if the *str* matches the regular expression
+    *regex*. The format of *regex* is ERE (Extended POSIX Regular Expressions).
 
 ``!mul(``\ *a*\ ``,`` *b*\ ``, ...)``
     This operator multiplies *a*, *b*, etc., and produces the product.

--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -911,6 +911,7 @@ public:
     STRCONCAT,
     INTERLEAVE,
     CONCAT,
+    MATCH,
     EQ,
     NE,
     LE,
@@ -1182,38 +1183,6 @@ public:
   // Fold - If possible, fold this to a simpler init.  Return this if not
   // possible to fold.
   const Init *Fold(const Record *CurRec, bool IsFinal = false) const;
-
-  bool isComplete() const override { return false; }
-
-  const Init *resolveReferences(Resolver &R) const override;
-
-  const Init *getBit(unsigned Bit) const override;
-
-  std::string getAsString() const override;
-};
-
-/// !match(str, regex) - This operator produces 1 if the `str` matches the
-/// regular expression `regex`.
-class MatchOpInit final : public TypedInit, public FoldingSetNode {
-private:
-  const Init *Str;
-  const Init *Regex;
-
-  MatchOpInit(const Init *Str, const Init *Regex)
-      : TypedInit(IK_MatchOpInit, BitRecTy::get(Str->getRecordKeeper())),
-        Str(Str), Regex(Regex) {}
-
-public:
-  MatchOpInit(const MatchOpInit &) = delete;
-  MatchOpInit &operator=(const MatchOpInit &) = delete;
-
-  static bool classof(const Init *I) { return I->getKind() == IK_MatchOpInit; }
-
-  static const MatchOpInit *get(const Init *Str, const Init *Regex);
-
-  void Profile(FoldingSetNodeID &ID) const;
-
-  const Init *Fold() const;
 
   bool isComplete() const override { return false; }
 

--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -316,6 +316,7 @@ protected:
     IK_FoldOpInit,
     IK_IsAOpInit,
     IK_ExistsOpInit,
+    IK_MatchOpInit,
     IK_AnonymousNameInit,
     IK_StringInit,
     IK_VarInit,
@@ -1181,6 +1182,38 @@ public:
   // Fold - If possible, fold this to a simpler init.  Return this if not
   // possible to fold.
   const Init *Fold(const Record *CurRec, bool IsFinal = false) const;
+
+  bool isComplete() const override { return false; }
+
+  const Init *resolveReferences(Resolver &R) const override;
+
+  const Init *getBit(unsigned Bit) const override;
+
+  std::string getAsString() const override;
+};
+
+/// !match(str, regex) - This operator produces 1 if the `str` matches the
+/// regular expression `regex`.
+class MatchOpInit final : public TypedInit, public FoldingSetNode {
+private:
+  const Init *Str;
+  const Init *Regex;
+
+  MatchOpInit(const Init *Str, const Init *Regex)
+      : TypedInit(IK_MatchOpInit, BitRecTy::get(Str->getRecordKeeper())),
+        Str(Str), Regex(Regex) {}
+
+public:
+  MatchOpInit(const MatchOpInit &) = delete;
+  MatchOpInit &operator=(const MatchOpInit &) = delete;
+
+  static bool classof(const Init *I) { return I->getKind() == IK_MatchOpInit; }
+
+  static const MatchOpInit *get(const Init *Str, const Init *Regex);
+
+  void Profile(FoldingSetNodeID &ID) const;
+
+  const Init *Fold() const;
 
   bool isComplete() const override { return false; }
 

--- a/llvm/include/llvm/TableGen/Record.h
+++ b/llvm/include/llvm/TableGen/Record.h
@@ -316,7 +316,6 @@ protected:
     IK_FoldOpInit,
     IK_IsAOpInit,
     IK_ExistsOpInit,
-    IK_MatchOpInit,
     IK_AnonymousNameInit,
     IK_StringInit,
     IK_VarInit,

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -25,6 +25,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/MathExtras.h"
+#include "llvm/Support/Regex.h"
 #include "llvm/Support/SMLoc.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TableGen/Error.h"
@@ -83,6 +84,7 @@ struct RecordKeeperImpl {
   FoldingSet<FoldOpInit> TheFoldOpInitPool;
   FoldingSet<IsAOpInit> TheIsAOpInitPool;
   FoldingSet<ExistsOpInit> TheExistsOpInitPool;
+  FoldingSet<MatchOpInit> TheMatchOpInitPool;
   DenseMap<std::pair<const RecTy *, const Init *>, VarInit *> TheVarInitPool;
   DenseMap<std::pair<const TypedInit *, unsigned>, VarBitInit *>
       TheVarBitInitPool;
@@ -2197,6 +2199,61 @@ std::string ExistsOpInit::getAsString() const {
   return (Twine("!exists<") + CheckType->getAsString() + ">(" +
           Expr->getAsString() + ")")
       .str();
+}
+
+static void ProfileMatchOpInit(FoldingSetNodeID &ID, const Init *Str,
+                               const Init *Regex) {
+  ID.AddPointer(Str);
+  ID.AddPointer(Regex);
+}
+
+const MatchOpInit *MatchOpInit::get(const Init *Str, const Init *Regex) {
+  FoldingSetNodeID ID;
+  ProfileMatchOpInit(ID, Str, Regex);
+
+  detail::RecordKeeperImpl &RK = Regex->getRecordKeeper().getImpl();
+  void *IP = nullptr;
+  if (const MatchOpInit *I = RK.TheMatchOpInitPool.FindNodeOrInsertPos(ID, IP))
+    return I;
+
+  MatchOpInit *I = new (RK.Allocator) MatchOpInit(Str, Regex);
+  RK.TheMatchOpInitPool.InsertNode(I, IP);
+  return I;
+}
+
+void MatchOpInit::Profile(FoldingSetNodeID &ID) const {
+  ProfileMatchOpInit(ID, Str, Regex);
+}
+
+const Init *MatchOpInit::Fold() const {
+  const auto *StrInit = dyn_cast<StringInit>(Str);
+  const auto *RegexInit = dyn_cast<StringInit>(Regex);
+  if (!(StrInit && RegexInit))
+    return this;
+
+  StringRef RegexStr = RegexInit->getValue();
+  llvm::Regex Matcher(RegexStr);
+  if (!Matcher.isValid())
+    PrintFatalError(Twine("invalid regex '") + RegexStr + Twine("'"));
+
+  return BitInit::get(Str->getRecordKeeper(),
+                      Matcher.match(StrInit->getValue()));
+}
+
+const Init *MatchOpInit::resolveReferences(Resolver &R) const {
+  const Init *NewStr = Str->resolveReferences(R);
+  const Init *NewRegex = Regex->resolveReferences(R);
+  if (Str != NewStr || Regex != NewRegex)
+    return get(NewStr, NewRegex)->Fold();
+  return this;
+}
+
+const Init *MatchOpInit::getBit(unsigned Bit) const {
+  return VarBitInit::get(this, Bit);
+}
+
+std::string MatchOpInit::getAsString() const {
+  return "!match(" + Str->getAsString() + ", " + Regex->getAsString() + ")";
 }
 
 const RecTy *TypedInit::getFieldType(const StringInit *FieldName) const {

--- a/llvm/lib/TableGen/Record.cpp
+++ b/llvm/lib/TableGen/Record.cpp
@@ -1321,8 +1321,11 @@ const Init *BinOpInit::Fold(const Record *CurRec) const {
   }
   case MATCH: {
     const auto *StrInit = dyn_cast<StringInit>(LHS);
+    if (!StrInit)
+      return this;
+
     const auto *RegexInit = dyn_cast<StringInit>(RHS);
-    if (!(StrInit && RegexInit))
+    if (!RegexInit)
       return this;
 
     StringRef RegexStr = RegexInit->getValue();

--- a/llvm/lib/TableGen/TGLexer.cpp
+++ b/llvm/lib/TableGen/TGLexer.cpp
@@ -644,6 +644,7 @@ tgtok::TokKind TGLexer::LexExclaim() {
           .Case("tolower", tgtok::XToLower)
           .Case("toupper", tgtok::XToUpper)
           .Case("repr", tgtok::XRepr)
+          .Case("match", tgtok::XMatch)
           .Default(tgtok::Error);
 
   return Kind != tgtok::Error ? Kind

--- a/llvm/lib/TableGen/TGLexer.h
+++ b/llvm/lib/TableGen/TGLexer.h
@@ -126,6 +126,7 @@ enum TokKind {
   XInterleave,
   XSubstr,
   XFind,
+  XMatch,
   XCast,
   XSubst,
   XForEach,

--- a/llvm/test/TableGen/match.td
+++ b/llvm/test/TableGen/match.td
@@ -2,6 +2,7 @@
 // RUN: not llvm-tblgen -DERROR1 %s 2>&1 | FileCheck --check-prefix=ERROR1 %s
 // RUN: not llvm-tblgen -DERROR2 %s 2>&1 | FileCheck --check-prefix=ERROR2 %s
 // RUN: not llvm-tblgen -DERROR3 %s 2>&1 | FileCheck --check-prefix=ERROR3 %s
+// RUN: not llvm-tblgen -DERROR4 %s 2>&1 | FileCheck --check-prefix=ERROR4 %s
 // XFAIL: vg_leak
 
 def test {
@@ -16,15 +17,20 @@ def test {
 
 #ifdef ERROR1
 defvar error1 = !match(123, ".*");
-// ERROR1: error: expected string type argument in !match operator
+// ERROR1: error: expected value of type 'string', got 'int'
 #endif
 
 #ifdef ERROR2
 defvar error2 = !match("abc", 123);
-// ERROR2: error: expected string type argument in !match operator
+// ERROR2: error: expected value of type 'string', got 'int'
 #endif
 
 #ifdef ERROR3
-defvar error3 = !match("abc", "([)]");
-// ERROR3: error: invalid regex '([)]'
+defvar error3 = !match("abc", "abc", "abc");
+// ERROR3: error: expected two operands to operator
+#endif
+
+#ifdef ERROR4
+defvar error4 = !match("abc", "([)]");
+// ERROR4: error: invalid regex '([)]'
 #endif

--- a/llvm/test/TableGen/match.td
+++ b/llvm/test/TableGen/match.td
@@ -1,0 +1,30 @@
+// RUN: llvm-tblgen %s | FileCheck %s
+// RUN: not llvm-tblgen -DERROR1 %s 2>&1 | FileCheck --check-prefix=ERROR1 %s
+// RUN: not llvm-tblgen -DERROR2 %s 2>&1 | FileCheck --check-prefix=ERROR2 %s
+// RUN: not llvm-tblgen -DERROR3 %s 2>&1 | FileCheck --check-prefix=ERROR3 %s
+// XFAIL: vg_leak
+
+def test {
+  bit test0 = !match("123 abc ABC", "[0-9 a-z A-Z]+");
+  bit test1 = !match("abc", "[0-9]+");
+}
+
+// CHECK-LABEL: def test {
+// CHECK-NEXT:    bit test0 = 1;
+// CHECK-NEXT:    bit test1 = 0;
+// CHECK-NEXT:  }
+
+#ifdef ERROR1
+defvar error1 = !match(123, ".*");
+// ERROR1: error: expected string type argument in !match operator
+#endif
+
+#ifdef ERROR2
+defvar error2 = !match("abc", 123);
+// ERROR2: error: expected string type argument in !match operator
+#endif
+
+#ifdef ERROR3
+defvar error3 = !match("abc", "([)]");
+// ERROR3: error: invalid regex '([)]'
+#endif


### PR DESCRIPTION
The grammar is `!match(str, regex)` and this operator produces 1
if the `str` matches the regular expression `regex`.

The format of `regex` is ERE (Extended POSIX Regular Expressions).
