### PR TITLE
[CaptureTracking][AA] Only consider provenance captures

### DIFF
--- a/llvm/include/llvm/Support/ModRef.h
+++ b/llvm/include/llvm/Support/ModRef.h
@@ -326,6 +326,10 @@ inline bool capturesFullProvenance(CaptureComponents CC) {
   return (CC & CaptureComponents::Provenance) == CaptureComponents::Provenance;
 }
 
+inline bool capturesAnyProvenance(CaptureComponents CC) {
+  return (CC & CaptureComponents::Provenance) != CaptureComponents::None;
+}
+
 inline bool capturesAll(CaptureComponents CC) {
   return CC == CaptureComponents::All;
 }

--- a/llvm/lib/Analysis/AliasAnalysis.cpp
+++ b/llvm/lib/Analysis/AliasAnalysis.cpp
@@ -622,8 +622,9 @@ ModRefInfo AAResults::callCapturesBefore(const Instruction *I,
   if (!Call || Call == Object)
     return ModRefInfo::ModRef;
 
-  if (PointerMayBeCapturedBefore(Object, /* ReturnCaptures */ true, I, DT,
-                                 /* include Object */ true))
+  if (capturesAnything(PointerMayBeCapturedBefore(
+          Object, /* ReturnCaptures */ true, I, DT,
+          /* include Object */ true, CaptureComponents::Provenance)))
     return ModRefInfo::ModRef;
 
   unsigned ArgNo = 0;
@@ -637,10 +638,11 @@ ModRefInfo AAResults::callCapturesBefore(const Instruction *I,
     if (!(*CI)->getType()->isPointerTy())
       continue;
 
-    // Make sure we still check captures(ret: address, provenance) arguments,
-    // as these wouldn't be treated as a capture at the call-site.
+    // Make sure we still check captures(ret: address, provenance) and
+    // captures(address) arguments, as these wouldn't be treated as a capture
+    // at the call-site.
     CaptureInfo Captures = Call->getCaptureInfo(ArgNo);
-    if (!capturesNothing(Captures.getOtherComponents()))
+    if (capturesAnyProvenance(Captures.getOtherComponents()))
       continue;
 
     AliasResult AR =

--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -220,7 +220,7 @@ bool EarliestEscapeAnalysis::isNotCapturedBefore(const Value *Object,
   if (Iter.second) {
     Instruction *EarliestCapture = FindEarliestCapture(
         Object, *const_cast<Function *>(DT.getRoot()->getParent()),
-        /*ReturnCaptures=*/false, DT);
+        /*ReturnCaptures=*/false, DT, CaptureComponents::Provenance);
     if (EarliestCapture)
       Inst2Obj[EarliestCapture].push_back(Object);
     Iter.first->second = EarliestCapture;

--- a/llvm/test/Analysis/BasicAA/captures.ll
+++ b/llvm/test/Analysis/BasicAA/captures.ll
@@ -1,0 +1,42 @@
+; RUN: opt < %s -passes=aa-eval -print-all-alias-modref-info -disable-output 2>&1 | FileCheck %s
+
+declare void @capture(ptr)
+declare ptr @get_ptr()
+
+; CHECK-LABEL: address_capture
+; CHECK: NoAlias:	i32* %a, i32* %p
+; CHECK: NoModRef:  Ptr: i32* %a	<->  %p = call ptr @get_ptr()
+define void @address_capture() {
+  %a = alloca i32
+  call void @capture(ptr captures(address) %a)
+  %p = call ptr @get_ptr()
+  store i32 0, ptr %p
+  load i32, ptr %a
+  ret void
+}
+
+; CHECK-LABEL: read_only_capture
+; CHECK: MayAlias:	i32* %a, i32* %p
+; CHECK: Both ModRef:  Ptr: i32* %a	<->  %p = call ptr @get_ptr()
+; TODO: The ModRef could be just Ref.
+define void @read_only_capture() {
+  %a = alloca i32
+  call void @capture(ptr captures(address, read_provenance) %a)
+  %p = call ptr @get_ptr()
+  store i32 0, ptr %p
+  load i32, ptr %a
+  ret void
+}
+
+; CHECK-LABEL: address_capture_and_full_capture
+; CHECK: MayAlias:	i32* %a, i32* %p
+; CHECK: Both ModRef:  Ptr: i32* %a	<->  %p = call ptr @get_ptr()
+define void @address_capture_and_full_capture() {
+  %a = alloca i32
+  call void @capture(ptr captures(address) %a)
+  call void @capture(ptr %a)
+  %p = call ptr @get_ptr()
+  store i32 0, ptr %p
+  load i32, ptr %a
+  ret void
+}

--- a/llvm/test/Transforms/DeadStoreElimination/captures.ll
+++ b/llvm/test/Transforms/DeadStoreElimination/captures.ll
@@ -32,3 +32,34 @@ define i16 @ret_has_more_components() {
   %v = load i16, ptr %call, align 1
   ret i16 %v
 }
+
+; Okay to drop the store as only the address of %a is captured, so the load
+; cannot be accessing %a.
+define i16 @address_capture() {
+; CHECK-LABEL: define i16 @address_capture() {
+; CHECK-NEXT:    [[A:%.*]] = alloca i16, align 1
+; CHECK-NEXT:    [[CALL:%.*]] = call ptr @passthrough(ptr readnone captures(address) [[A]])
+; CHECK-NEXT:    [[V:%.*]] = load i16, ptr [[CALL]], align 1
+; CHECK-NEXT:    ret i16 [[V]]
+;
+  %a = alloca i16, align 1
+  store i16 1, ptr %a, align 1
+  %call = call ptr @passthrough(ptr readnone captures(address) %a)
+  %v = load i16, ptr %call, align 1
+  ret i16 %v
+}
+
+define i16 @read_only_capture() {
+; CHECK-LABEL: define i16 @read_only_capture() {
+; CHECK-NEXT:    [[A:%.*]] = alloca i16, align 1
+; CHECK-NEXT:    store i16 1, ptr [[A]], align 1
+; CHECK-NEXT:    [[CALL:%.*]] = call ptr @passthrough(ptr readnone captures(address, read_provenance) [[A]])
+; CHECK-NEXT:    [[V:%.*]] = load i16, ptr [[CALL]], align 1
+; CHECK-NEXT:    ret i16 [[V]]
+;
+  %a = alloca i16, align 1
+  store i16 1, ptr %a, align 1
+  %call = call ptr @passthrough(ptr readnone captures(address, read_provenance) %a)
+  %v = load i16, ptr %call, align 1
+  ret i16 %v
+}


### PR DESCRIPTION
For the purposes of alias analysis, we should only consider provenance captures, not address captures. To support this, change (or add) CaptureTracking APIs to accept a Mask and StopFn argument. The Mask determines which components we are interested in (for AA that would be Provenance).

The StopFn determines when we can abort the walk early. Currently, we want to do this as soon as any of the components in the Mask is captured. The purpose of making this a separate predicate is that in the future we will also want to distinguish between capturing full provenance and read-only provenance. In that case, we can only stop early once full provenance is captured. The earliest escape analysis does not get a StopFn, because it must always inspect all captures.