### PR TITLE
[NFC][analyzer] Remove CheckerNameRef::getName()

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/CheckerManager.h
+++ b/clang/include/clang/StaticAnalyzer/Core/CheckerManager.h
@@ -113,7 +113,6 @@ class CheckerNameRef {
 public:
   CheckerNameRef() = default;
 
-  StringRef getName() const { return Name; }
   operator StringRef() const { return Name; }
 };
 

--- a/clang/lib/StaticAnalyzer/Checkers/ExprInspectionChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ExprInspectionChecker.cpp
@@ -431,7 +431,7 @@ void ExprInspectionChecker::analyzerHashDump(const CallExpr *CE,
   const SourceManager &SM = C.getSourceManager();
   FullSourceLoc FL(CE->getArg(0)->getBeginLoc(), SM);
   std::string HashContent =
-      getIssueString(FL, getCheckerName().getName(), "Category",
+      getIssueString(FL, getCheckerName(), "Category",
                      C.getLocationContext()->getDecl(), Opts);
 
   reportBug(HashContent, C);

--- a/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MallocChecker.cpp
@@ -3885,7 +3885,7 @@ void MallocChecker::printState(raw_ostream &Out, ProgramStateRef State,
       Out << " : ";
       Data.dump(Out);
       if (CheckKind)
-        Out << " (" << CheckNames[*CheckKind].getName() << ")";
+        Out << " (" << CheckNames[*CheckKind] << ")";
       Out << NL;
     }
   }

--- a/clang/lib/StaticAnalyzer/Checkers/ValistChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ValistChecker.cpp
@@ -272,12 +272,12 @@ void ValistChecker::reportLeakedVALists(const RegionVector &LeakedVALists,
     if (!BT_leakedvalist) {
       // FIXME: maybe creating a new check name for this type of bug is a better
       // solution.
-      BT_leakedvalist.reset(
-          new BugType(CheckNames[CK_Unterminated].getName().empty()
-                          ? CheckNames[CK_Uninitialized]
-                          : CheckNames[CK_Unterminated],
-                      "Leaked va_list", categories::MemoryError,
-                      /*SuppressOnSink=*/true));
+      BT_leakedvalist.reset(new BugType(
+          static_cast<StringRef>(CheckNames[CK_Unterminated]).empty()
+              ? CheckNames[CK_Uninitialized]
+              : CheckNames[CK_Unterminated],
+          "Leaked va_list", categories::MemoryError,
+          /*SuppressOnSink=*/true));
     }
 
     const ExplodedNode *StartNode = getStartCallSite(N, Reg);

--- a/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
+++ b/clang/lib/StaticAnalyzer/Core/BugReporter.cpp
@@ -3442,8 +3442,8 @@ void BugReporter::EmitBasicReport(const Decl *DeclWithIssue,
 BugType *BugReporter::getBugTypeForName(CheckerNameRef CheckName,
                                         StringRef name, StringRef category) {
   SmallString<136> fullDesc;
-  llvm::raw_svector_ostream(fullDesc) << CheckName.getName() << ":" << name
-                                      << ":" << category;
+  llvm::raw_svector_ostream(fullDesc)
+      << CheckName << ":" << name << ":" << category;
   std::unique_ptr<BugType> &BT = StrBugTypes[fullDesc];
   if (!BT)
     BT = std::make_unique<BugType>(CheckName, name, category);

--- a/clang/lib/StaticAnalyzer/Core/Checker.cpp
+++ b/clang/lib/StaticAnalyzer/Core/Checker.cpp
@@ -18,9 +18,7 @@ using namespace ento;
 
 int ImplicitNullDerefEvent::Tag;
 
-StringRef CheckerBase::getTagDescription() const {
-  return getCheckerName().getName();
-}
+StringRef CheckerBase::getTagDescription() const { return getCheckerName(); }
 
 CheckerNameRef CheckerBase::getCheckerName() const { return Name; }
 
@@ -30,10 +28,10 @@ CheckerProgramPointTag::CheckerProgramPointTag(StringRef CheckerName,
 
 CheckerProgramPointTag::CheckerProgramPointTag(const CheckerBase *Checker,
                                                StringRef Msg)
-    : SimpleProgramPointTag(Checker->getCheckerName().getName(), Msg) {}
+    : SimpleProgramPointTag(Checker->getCheckerName(), Msg) {}
 
 raw_ostream& clang::ento::operator<<(raw_ostream &Out,
                                      const CheckerBase &Checker) {
-  Out << Checker.getCheckerName().getName();
+  Out << Checker.getCheckerName();
   return Out;
 }

--- a/clang/lib/StaticAnalyzer/Core/CheckerManager.cpp
+++ b/clang/lib/StaticAnalyzer/Core/CheckerManager.cpp
@@ -139,7 +139,7 @@ std::string checkerScopeName(StringRef Name, const CheckerBase *Checker) {
   if (!llvm::timeTraceProfilerEnabled())
     return "";
   StringRef CheckerName =
-      Checker ? Checker->getCheckerName().getName() : "<unknown>";
+      Checker ? static_cast<StringRef>(Checker->getCheckerName()) : "<unknown>";
   return (Name + ":" + CheckerName).str();
 }
 
@@ -721,7 +721,7 @@ void CheckerManager::runCheckersForEvalCall(ExplodedNodeSet &Dst,
             "The '{0}' call has been already evaluated by the {1} checker, "
             "while the {2} checker also tried to evaluate the same call. At "
             "most one checker supposed to evaluate a call.",
-            toString(Call), evaluatorChecker->getName(),
+            toString(Call), evaluatorChecker,
             EvalCallChecker.Checker->getCheckerName());
         llvm_unreachable(AssertionMessage.c_str());
       }
@@ -799,7 +799,7 @@ void CheckerManager::runCheckersForPrintStateJson(raw_ostream &Out,
       continue;
 
     Indent(Out, Space, IsDot)
-        << "{ \"checker\": \"" << CT.second->getCheckerName().getName()
+        << "{ \"checker\": \"" << CT.second->getCheckerName()
         << "\", \"messages\": [" << NL;
     Indent(Out, InnerSpace, IsDot)
         << '\"' << TempBuf.str().trim() << '\"' << NL;


### PR DESCRIPTION
`CheckerNameRef` is a trivial wrapper around a `StringRef` which is guaranteed to be owned by the `CheckerRegistry` (the only `friend` of the class) because other code can't call the private constructor.

This class had offered two ways to recover the plain `StringRef`: an an `operator StringRef()` for implicit conversion and a method `StringRef getName()` which could be called explicitly.

However this method name was really confusing, because it implies "get the name of this object" instead of "get this name as a plain `StringRef`"; so I removed it from the codebase and used `static_cast<StringRef>` in the two locations where the cast wasn't performed implicitly.

This commit "prepares the ground" for planned improvements in checker name handling.