### PR TITLE
[AMDGPU][True16][CodeGen] add omod and clamp to v_mul_f16_fake16 pattern

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SIInstructions.td
@@ -3256,24 +3256,24 @@ def : GCNPat<
 let True16Predicate = UseRealTrue16Insts in {
 def : GCNPat<
   (fcanonicalize (f16 (VOP3Mods f16:$src, i32:$src_mods))),
-  (V_MUL_F16_t16_e64 0, (i16 CONST.FP16_ONE), $src_mods, $src, 0/*Clamp*/, /*omod*/0, /*opsel*/0)
+  (V_MUL_F16_t16_e64 0, (i16 CONST.FP16_ONE), $src_mods, $src, /*Clamp*/0, /*omod*/0, /*opsel*/0)
 >;
 
 def : GCNPat<
   (fcanonicalize (f16 (fneg (VOP3Mods f16:$src, i32:$src_mods)))),
-  (V_MUL_F16_t16_e64 0, (i16 CONST.FP16_NEG_ONE), $src_mods, $src, 0/*Clamp*/, /*omod*/0, /*opsel*/0)
+  (V_MUL_F16_t16_e64 0, (i16 CONST.FP16_NEG_ONE), $src_mods, $src, /*Clamp*/0, /*omod*/0, /*opsel*/0)
 >;
 } // End True16Predicate
 
 let True16Predicate = UseFakeTrue16Insts in {
 def : GCNPat<
   (fcanonicalize (f16 (VOP3Mods f16:$src, i32:$src_mods))),
-  (V_MUL_F16_fake16_e64 0, (i32 CONST.FP16_ONE), $src_mods, $src)
+  (V_MUL_F16_fake16_e64 0, (i32 CONST.FP16_ONE), $src_mods, $src, /*clamp*/0, /*omod*/0)
 >;
 
 def : GCNPat<
   (fcanonicalize (f16 (fneg (VOP3Mods f16:$src, i32:$src_mods)))),
-  (V_MUL_F16_fake16_e64 0, (i32 CONST.FP16_NEG_ONE), $src_mods, $src)
+  (V_MUL_F16_fake16_e64 0, (i32 CONST.FP16_NEG_ONE), $src_mods, $src, /*clamp*/0, /*omod*/0)
 >;
 } // End True16Predicate
 


### PR DESCRIPTION
Fixed an issue in v_mul_f16_fake16 pattern that it missed the opsel/clamp mods.

This is not found before since in GFX11plus we mostly lower fcanonicalize to V_MAX instead of V_MUL and thus we don't have test coverage for this.

This is not important since we will remove fake16 in the end, but mostly just for cleaning up the code