### PR TITLE
[BOLT] Change Relocation Type to 32-bit NFCI

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -1295,7 +1295,7 @@ public:
   void foldFunction(BinaryFunction &ChildBF, BinaryFunction &ParentBF);
 
   /// Add a Section relocation at a given \p Address.
-  void addRelocation(uint64_t Address, MCSymbol *Symbol, uint64_t Type,
+  void addRelocation(uint64_t Address, MCSymbol *Symbol, uint32_t Type,
                      uint64_t Addend = 0, uint64_t Value = 0);
 
   /// Return a relocation registered at a given \p Address, or nullptr if there
@@ -1308,7 +1308,7 @@ public:
   }
 
   /// Register dynamic relocation at \p Address.
-  void addDynamicRelocation(uint64_t Address, MCSymbol *Symbol, uint64_t Type,
+  void addDynamicRelocation(uint64_t Address, MCSymbol *Symbol, uint32_t Type,
                             uint64_t Addend, uint64_t Value = 0);
 
   /// Return a dynamic relocation registered at a given \p Address, or nullptr

--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -1260,7 +1260,7 @@ public:
   /// Register relocation type \p RelType at a given \p Address in the function
   /// against \p Symbol.
   /// Assert if the \p Address is not inside this function.
-  void addRelocation(uint64_t Address, MCSymbol *Symbol, uint64_t RelType,
+  void addRelocation(uint64_t Address, MCSymbol *Symbol, uint32_t RelType,
                      uint64_t Addend, uint64_t Value);
 
   /// Return the name of the section this function originated from.

--- a/bolt/include/bolt/Core/BinarySection.h
+++ b/bolt/include/bolt/Core/BinarySection.h
@@ -358,14 +358,14 @@ public:
   void clearRelocations();
 
   /// Add a new relocation at the given /p Offset.
-  void addRelocation(uint64_t Offset, MCSymbol *Symbol, uint64_t Type,
+  void addRelocation(uint64_t Offset, MCSymbol *Symbol, uint32_t Type,
                      uint64_t Addend, uint64_t Value = 0) {
     assert(Offset < getSize() && "offset not within section bounds");
     Relocations.emplace(Relocation{Offset, Symbol, Type, Addend, Value});
   }
 
   /// Add a dynamic relocation at the given /p Offset.
-  void addDynamicRelocation(uint64_t Offset, MCSymbol *Symbol, uint64_t Type,
+  void addDynamicRelocation(uint64_t Offset, MCSymbol *Symbol, uint32_t Type,
                             uint64_t Addend, uint64_t Value = 0) {
     addDynamicRelocation(Relocation{Offset, Symbol, Type, Addend, Value});
   }

--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -473,7 +473,7 @@ public:
   ///
   /// For X86, they might be used in scanExternalRefs when we want to skip
   /// a function but still patch references inside it.
-  virtual bool shouldRecordCodeRelocation(uint64_t RelType) const {
+  virtual bool shouldRecordCodeRelocation(uint32_t RelType) const {
     llvm_unreachable("not implemented");
     return false;
   }
@@ -1074,7 +1074,7 @@ public:
   /// MCExpr referencing \p Symbol + \p Addend.
   virtual bool setOperandToSymbolRef(MCInst &Inst, int OpNum,
                                      const MCSymbol *Symbol, int64_t Addend,
-                                     MCContext *Ctx, uint64_t RelType) const;
+                                     MCContext *Ctx, uint32_t RelType) const;
 
   /// Replace an immediate operand in the instruction \p Inst with a reference
   /// of the passed \p Symbol plus \p Addend. If the instruction does not have
@@ -1082,7 +1082,7 @@ public:
   /// return true.
   virtual bool replaceImmWithSymbolRef(MCInst &Inst, const MCSymbol *Symbol,
                                        int64_t Addend, MCContext *Ctx,
-                                       int64_t &Value, uint64_t RelType) const {
+                                       int64_t &Value, uint32_t RelType) const {
     llvm_unreachable("not implemented");
     return false;
   }
@@ -1287,7 +1287,7 @@ public:
   /// Return the MCExpr used for absolute references in this target
   virtual const MCExpr *getTargetExprFor(MCInst &Inst, const MCExpr *Expr,
                                          MCContext &Ctx,
-                                         uint64_t RelType) const {
+                                         uint32_t RelType) const {
     return Expr;
   }
 

--- a/bolt/include/bolt/Core/Relocation.h
+++ b/bolt/include/bolt/Core/Relocation.h
@@ -20,6 +20,11 @@
 
 namespace llvm {
 class MCSymbol;
+
+namespace object {
+class RelocationRef;
+} // namespace object
+
 class raw_ostream;
 
 namespace ELF {
@@ -40,7 +45,7 @@ struct Relocation {
   MCSymbol *Symbol;
 
   /// Relocation type.
-  uint64_t Type;
+  uint32_t Type;
 
   /// The offset from the \p Symbol base used to compute the final
   /// value of this relocation.
@@ -50,72 +55,79 @@ struct Relocation {
   /// Used to validate relocation correctness.
   uint64_t Value;
 
+  /// Relocations added by optimizations can be optional.
+  bool Optional = false;
+
   /// Return size in bytes of the given relocation \p Type.
-  static size_t getSizeForType(uint64_t Type);
+  static size_t getSizeForType(uint32_t Type);
 
   /// Return size of this relocation.
   size_t getSize() const { return getSizeForType(Type); }
 
   /// Skip relocations that we don't want to handle in BOLT
-  static bool skipRelocationType(uint64_t Type);
+  static bool skipRelocationType(uint32_t Type);
 
   /// Handle special cases when relocation should not be processed by BOLT or
   /// change relocation \p Type to proper one before continuing if \p Contents
   /// and \P Type mismatch occurred.
-  static bool skipRelocationProcess(uint64_t &Type, uint64_t Contents);
+  static bool skipRelocationProcess(uint32_t &Type, uint64_t Contents);
 
-  // Adjust value depending on relocation type (make it PC relative or not)
-  static uint64_t encodeValue(uint64_t Type, uint64_t Value, uint64_t PC);
+  /// Adjust value depending on relocation type (make it PC relative or not).
+  static uint64_t encodeValue(uint32_t Type, uint64_t Value, uint64_t PC);
 
   /// Extract current relocated value from binary contents. This is used for
   /// RISC architectures where values are encoded in specific bits depending
   /// on the relocation value. For X86, we limit to sign extending the value
   /// if necessary.
-  static uint64_t extractValue(uint64_t Type, uint64_t Contents, uint64_t PC);
+  static uint64_t extractValue(uint32_t Type, uint64_t Contents, uint64_t PC);
 
   /// Return true if relocation type is PC-relative. Return false otherwise.
-  static bool isPCRelative(uint64_t Type);
+  static bool isPCRelative(uint32_t Type);
 
   /// Check if \p Type is a supported relocation type.
-  static bool isSupported(uint64_t Type);
+  static bool isSupported(uint32_t Type);
 
   /// Return true if relocation type implies the creation of a GOT entry
-  static bool isGOT(uint64_t Type);
+  static bool isGOT(uint32_t Type);
 
   /// Special relocation type that allows the linker to modify the instruction.
-  static bool isX86GOTPCRELX(uint64_t Type);
-  static bool isX86GOTPC64(uint64_t Type);
+  static bool isX86GOTPCRELX(uint32_t Type);
+  static bool isX86GOTPC64(uint32_t Type);
 
   /// Return true if relocation type is NONE
-  static bool isNone(uint64_t Type);
+  static bool isNone(uint32_t Type);
 
   /// Return true if relocation type is RELATIVE
-  static bool isRelative(uint64_t Type);
+  static bool isRelative(uint32_t Type);
 
   /// Return true if relocation type is IRELATIVE
-  static bool isIRelative(uint64_t Type);
+  static bool isIRelative(uint32_t Type);
 
   /// Return true if relocation type is for thread local storage.
-  static bool isTLS(uint64_t Type);
+  static bool isTLS(uint32_t Type);
 
   /// Return true of relocation type is for referencing a specific instruction
   /// (as opposed to a function, basic block, etc).
-  static bool isInstructionReference(uint64_t Type);
+  static bool isInstructionReference(uint32_t Type);
+
+  /// Return the relocation type of \p Rel from llvm::object. It checks for
+  /// overflows as BOLT uses 32 bits for the type.
+  static uint32_t getType(const object::RelocationRef &Rel);
 
   /// Return code for a NONE relocation
-  static uint64_t getNone();
+  static uint32_t getNone();
 
   /// Return code for a PC-relative 4-byte relocation
-  static uint64_t getPC32();
+  static uint32_t getPC32();
 
   /// Return code for a PC-relative 8-byte relocation
-  static uint64_t getPC64();
+  static uint32_t getPC64();
 
   /// Return code for a ABS 8-byte relocation
-  static uint64_t getAbs64();
+  static uint32_t getAbs64();
 
   /// Return code for a RELATIVE relocation
-  static uint64_t getRelative();
+  static uint32_t getRelative();
 
   /// Return true if this relocation is PC-relative. Return false otherwise.
   bool isPCRelative() const { return isPCRelative(Type); }
@@ -161,7 +173,7 @@ private:
   const MCExpr *createExpr(MCStreamer *Streamer) const;
   const MCExpr *createExpr(MCStreamer *Streamer,
                            const MCExpr *RetainedValue) const;
-  static MCBinaryExpr::Opcode getComposeOpcodeFor(uint64_t Type);
+  static MCBinaryExpr::Opcode getComposeOpcodeFor(uint32_t Type);
 };
 
 /// Relocation ordering by offset.

--- a/bolt/include/bolt/Core/Relocation.h
+++ b/bolt/include/bolt/Core/Relocation.h
@@ -55,9 +55,6 @@ struct Relocation {
   /// Used to validate relocation correctness.
   uint64_t Value;
 
-  /// Relocations added by optimizations can be optional.
-  bool Optional = false;
-
   /// Return size in bytes of the given relocation \p Type.
   static size_t getSizeForType(uint32_t Type);
 

--- a/bolt/include/bolt/Rewrite/RewriteInstance.h
+++ b/bolt/include/bolt/Rewrite/RewriteInstance.h
@@ -248,7 +248,7 @@ private:
   /// The \p SymbolName, \p SymbolAddress, \p Addend and \p ExtractedValue
   /// parameters will be set on success. The \p Skip argument indicates
   /// that the relocation was analyzed, but it must not be processed.
-  bool analyzeRelocation(const object::RelocationRef &Rel, uint64_t &RType,
+  bool analyzeRelocation(const object::RelocationRef &Rel, uint32_t &RType,
                          std::string &SymbolName, bool &IsSectionRelocation,
                          uint64_t &SymbolAddress, int64_t &Addend,
                          uint64_t &ExtractedValue, bool &Skip) const;

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -2284,7 +2284,7 @@ ErrorOr<int64_t> BinaryContext::getSignedValueAtAddress(uint64_t Address,
 }
 
 void BinaryContext::addRelocation(uint64_t Address, MCSymbol *Symbol,
-                                  uint64_t Type, uint64_t Addend,
+                                  uint32_t Type, uint64_t Addend,
                                   uint64_t Value) {
   ErrorOr<BinarySection &> Section = getSectionForAddress(Address);
   assert(Section && "cannot find section for address");
@@ -2293,7 +2293,7 @@ void BinaryContext::addRelocation(uint64_t Address, MCSymbol *Symbol,
 }
 
 void BinaryContext::addDynamicRelocation(uint64_t Address, MCSymbol *Symbol,
-                                         uint64_t Type, uint64_t Addend,
+                                         uint32_t Type, uint64_t Addend,
                                          uint64_t Value) {
   ErrorOr<BinarySection &> Section = getSectionForAddress(Address);
   assert(Section && "cannot find section for address");

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -4614,7 +4614,7 @@ bool BinaryFunction::isAArch64Veneer() const {
 }
 
 void BinaryFunction::addRelocation(uint64_t Address, MCSymbol *Symbol,
-                                   uint64_t RelType, uint64_t Addend,
+                                   uint32_t RelType, uint64_t Addend,
                                    uint64_t Value) {
   assert(Address >= getAddress() && Address < getAddress() + getMaxSize() &&
          "address is outside of the function");

--- a/bolt/lib/Core/JumpTable.cpp
+++ b/bolt/lib/Core/JumpTable.cpp
@@ -84,7 +84,7 @@ void bolt::JumpTable::updateOriginal() {
   const uint64_t BaseOffset = getAddress() - getSection().getAddress();
   uint64_t EntryOffset = BaseOffset;
   for (MCSymbol *Entry : Entries) {
-    const uint64_t RelType =
+    const uint32_t RelType =
         Type == JTT_NORMAL ? ELF::R_X86_64_64 : ELF::R_X86_64_PC32;
     const uint64_t RelAddend =
         Type == JTT_NORMAL ? 0 : EntryOffset - BaseOffset;

--- a/bolt/lib/Core/MCPlusBuilder.cpp
+++ b/bolt/lib/Core/MCPlusBuilder.cpp
@@ -551,7 +551,7 @@ void MCPlusBuilder::initSizeMap() {
 bool MCPlusBuilder::setOperandToSymbolRef(MCInst &Inst, int OpNum,
                                           const MCSymbol *Symbol,
                                           int64_t Addend, MCContext *Ctx,
-                                          uint64_t RelType) const {
+                                          uint32_t RelType) const {
   MCOperand Operand;
   if (!Addend) {
     Operand = MCOperand::createExpr(getTargetExprFor(

--- a/bolt/lib/Core/Relocation.cpp
+++ b/bolt/lib/Core/Relocation.cpp
@@ -16,6 +16,7 @@
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSymbol.h"
 #include "llvm/Object/ELF.h"
+#include "llvm/Object/ObjectFile.h"
 
 using namespace llvm;
 using namespace bolt;
@@ -29,7 +30,7 @@ enum {
 
 Triple::ArchType Relocation::Arch;
 
-static bool isSupportedX86(uint64_t Type) {
+static bool isSupportedX86(uint32_t Type) {
   switch (Type) {
   default:
     return false;
@@ -52,7 +53,7 @@ static bool isSupportedX86(uint64_t Type) {
   }
 }
 
-static bool isSupportedAArch64(uint64_t Type) {
+static bool isSupportedAArch64(uint32_t Type) {
   switch (Type) {
   default:
     return false;
@@ -99,7 +100,7 @@ static bool isSupportedAArch64(uint64_t Type) {
   }
 }
 
-static bool isSupportedRISCV(uint64_t Type) {
+static bool isSupportedRISCV(uint32_t Type) {
   switch (Type) {
   default:
     return false;
@@ -131,7 +132,7 @@ static bool isSupportedRISCV(uint64_t Type) {
   }
 }
 
-static size_t getSizeForTypeX86(uint64_t Type) {
+static size_t getSizeForTypeX86(uint32_t Type) {
   switch (Type) {
   default:
     errs() << object::getELFRelocationTypeName(ELF::EM_X86_64, Type) << '\n';
@@ -158,7 +159,7 @@ static size_t getSizeForTypeX86(uint64_t Type) {
   }
 }
 
-static size_t getSizeForTypeAArch64(uint64_t Type) {
+static size_t getSizeForTypeAArch64(uint32_t Type) {
   switch (Type) {
   default:
     errs() << object::getELFRelocationTypeName(ELF::EM_AARCH64, Type) << '\n';
@@ -208,7 +209,7 @@ static size_t getSizeForTypeAArch64(uint64_t Type) {
   }
 }
 
-static size_t getSizeForTypeRISCV(uint64_t Type) {
+static size_t getSizeForTypeRISCV(uint32_t Type) {
   switch (Type) {
   default:
     errs() << object::getELFRelocationTypeName(ELF::EM_RISCV, Type) << '\n';
@@ -238,15 +239,15 @@ static size_t getSizeForTypeRISCV(uint64_t Type) {
   }
 }
 
-static bool skipRelocationTypeX86(uint64_t Type) {
+static bool skipRelocationTypeX86(uint32_t Type) {
   return Type == ELF::R_X86_64_NONE;
 }
 
-static bool skipRelocationTypeAArch64(uint64_t Type) {
+static bool skipRelocationTypeAArch64(uint32_t Type) {
   return Type == ELF::R_AARCH64_NONE || Type == ELF::R_AARCH64_LD_PREL_LO19;
 }
 
-static bool skipRelocationTypeRISCV(uint64_t Type) {
+static bool skipRelocationTypeRISCV(uint32_t Type) {
   switch (Type) {
   default:
     return false;
@@ -256,11 +257,11 @@ static bool skipRelocationTypeRISCV(uint64_t Type) {
   }
 }
 
-static bool skipRelocationProcessX86(uint64_t &Type, uint64_t Contents) {
+static bool skipRelocationProcessX86(uint32_t &Type, uint64_t Contents) {
   return false;
 }
 
-static bool skipRelocationProcessAArch64(uint64_t &Type, uint64_t Contents) {
+static bool skipRelocationProcessAArch64(uint32_t &Type, uint64_t Contents) {
   auto IsMov = [](uint64_t Contents) -> bool {
     // The bits 28-23 are 0b100101
     return (Contents & 0x1f800000) == 0x12800000;
@@ -324,11 +325,11 @@ static bool skipRelocationProcessAArch64(uint64_t &Type, uint64_t Contents) {
   return false;
 }
 
-static bool skipRelocationProcessRISCV(uint64_t &Type, uint64_t Contents) {
+static bool skipRelocationProcessRISCV(uint32_t &Type, uint64_t Contents) {
   return false;
 }
 
-static uint64_t encodeValueX86(uint64_t Type, uint64_t Value, uint64_t PC) {
+static uint64_t encodeValueX86(uint32_t Type, uint64_t Value, uint64_t PC) {
   switch (Type) {
   default:
     llvm_unreachable("unsupported relocation");
@@ -342,7 +343,7 @@ static uint64_t encodeValueX86(uint64_t Type, uint64_t Value, uint64_t PC) {
   return Value;
 }
 
-static uint64_t encodeValueAArch64(uint64_t Type, uint64_t Value, uint64_t PC) {
+static uint64_t encodeValueAArch64(uint32_t Type, uint64_t Value, uint64_t PC) {
   switch (Type) {
   default:
     llvm_unreachable("unsupported relocation");
@@ -374,7 +375,7 @@ static uint64_t encodeValueAArch64(uint64_t Type, uint64_t Value, uint64_t PC) {
   return Value;
 }
 
-static uint64_t encodeValueRISCV(uint64_t Type, uint64_t Value, uint64_t PC) {
+static uint64_t encodeValueRISCV(uint32_t Type, uint64_t Value, uint64_t PC) {
   switch (Type) {
   default:
     llvm_unreachable("unsupported relocation");
@@ -384,7 +385,7 @@ static uint64_t encodeValueRISCV(uint64_t Type, uint64_t Value, uint64_t PC) {
   return Value;
 }
 
-static uint64_t extractValueX86(uint64_t Type, uint64_t Contents, uint64_t PC) {
+static uint64_t extractValueX86(uint32_t Type, uint64_t Contents, uint64_t PC) {
   if (Type == ELF::R_X86_64_32S)
     return SignExtend64<32>(Contents);
   if (Relocation::isPCRelative(Type))
@@ -392,7 +393,7 @@ static uint64_t extractValueX86(uint64_t Type, uint64_t Contents, uint64_t PC) {
   return Contents;
 }
 
-static uint64_t extractValueAArch64(uint64_t Type, uint64_t Contents,
+static uint64_t extractValueAArch64(uint32_t Type, uint64_t Contents,
                                     uint64_t PC) {
   switch (Type) {
   default:
@@ -524,7 +525,7 @@ static uint64_t extractBImmRISCV(uint32_t Contents) {
       (((Contents >> 7) & 0x1) << 11) | (((Contents >> 31) & 0x1) << 12));
 }
 
-static uint64_t extractValueRISCV(uint64_t Type, uint64_t Contents,
+static uint64_t extractValueRISCV(uint32_t Type, uint64_t Contents,
                                   uint64_t PC) {
   switch (Type) {
   default:
@@ -565,7 +566,7 @@ static uint64_t extractValueRISCV(uint64_t Type, uint64_t Contents,
   }
 }
 
-static bool isGOTX86(uint64_t Type) {
+static bool isGOTX86(uint32_t Type) {
   switch (Type) {
   default:
     return false;
@@ -585,7 +586,7 @@ static bool isGOTX86(uint64_t Type) {
   }
 }
 
-static bool isGOTAArch64(uint64_t Type) {
+static bool isGOTAArch64(uint32_t Type) {
   switch (Type) {
   default:
     return false;
@@ -602,7 +603,7 @@ static bool isGOTAArch64(uint64_t Type) {
   }
 }
 
-static bool isGOTRISCV(uint64_t Type) {
+static bool isGOTRISCV(uint32_t Type) {
   switch (Type) {
   default:
     return false;
@@ -612,7 +613,7 @@ static bool isGOTRISCV(uint64_t Type) {
   }
 }
 
-static bool isTLSX86(uint64_t Type) {
+static bool isTLSX86(uint32_t Type) {
   switch (Type) {
   default:
     return false;
@@ -623,7 +624,7 @@ static bool isTLSX86(uint64_t Type) {
   }
 }
 
-static bool isTLSAArch64(uint64_t Type) {
+static bool isTLSAArch64(uint32_t Type) {
   switch (Type) {
   default:
     return false;
@@ -642,7 +643,7 @@ static bool isTLSAArch64(uint64_t Type) {
   }
 }
 
-static bool isTLSRISCV(uint64_t Type) {
+static bool isTLSRISCV(uint32_t Type) {
   switch (Type) {
   default:
     return false;
@@ -657,7 +658,7 @@ static bool isTLSRISCV(uint64_t Type) {
   }
 }
 
-static bool isPCRelativeX86(uint64_t Type) {
+static bool isPCRelativeX86(uint32_t Type) {
   switch (Type) {
   default:
     llvm_unreachable("Unknown relocation type");
@@ -683,7 +684,7 @@ static bool isPCRelativeX86(uint64_t Type) {
   }
 }
 
-static bool isPCRelativeAArch64(uint64_t Type) {
+static bool isPCRelativeAArch64(uint32_t Type) {
   switch (Type) {
   default:
     llvm_unreachable("Unknown relocation type");
@@ -731,7 +732,7 @@ static bool isPCRelativeAArch64(uint64_t Type) {
   }
 }
 
-static bool isPCRelativeRISCV(uint64_t Type) {
+static bool isPCRelativeRISCV(uint32_t Type) {
   switch (Type) {
   default:
     llvm_unreachable("Unknown relocation type");
@@ -758,7 +759,7 @@ static bool isPCRelativeRISCV(uint64_t Type) {
   }
 }
 
-bool Relocation::isSupported(uint64_t Type) {
+bool Relocation::isSupported(uint32_t Type) {
   switch (Arch) {
   default:
     return false;
@@ -771,7 +772,7 @@ bool Relocation::isSupported(uint64_t Type) {
   }
 }
 
-size_t Relocation::getSizeForType(uint64_t Type) {
+size_t Relocation::getSizeForType(uint32_t Type) {
   switch (Arch) {
   default:
     llvm_unreachable("Unsupported architecture");
@@ -784,7 +785,7 @@ size_t Relocation::getSizeForType(uint64_t Type) {
   }
 }
 
-bool Relocation::skipRelocationType(uint64_t Type) {
+bool Relocation::skipRelocationType(uint32_t Type) {
   switch (Arch) {
   default:
     llvm_unreachable("Unsupported architecture");
@@ -797,7 +798,7 @@ bool Relocation::skipRelocationType(uint64_t Type) {
   }
 }
 
-bool Relocation::skipRelocationProcess(uint64_t &Type, uint64_t Contents) {
+bool Relocation::skipRelocationProcess(uint32_t &Type, uint64_t Contents) {
   switch (Arch) {
   default:
     llvm_unreachable("Unsupported architecture");
@@ -810,7 +811,7 @@ bool Relocation::skipRelocationProcess(uint64_t &Type, uint64_t Contents) {
   }
 }
 
-uint64_t Relocation::encodeValue(uint64_t Type, uint64_t Value, uint64_t PC) {
+uint64_t Relocation::encodeValue(uint32_t Type, uint64_t Value, uint64_t PC) {
   switch (Arch) {
   default:
     llvm_unreachable("Unsupported architecture");
@@ -823,7 +824,7 @@ uint64_t Relocation::encodeValue(uint64_t Type, uint64_t Value, uint64_t PC) {
   }
 }
 
-uint64_t Relocation::extractValue(uint64_t Type, uint64_t Contents,
+uint64_t Relocation::extractValue(uint32_t Type, uint64_t Contents,
                                   uint64_t PC) {
   switch (Arch) {
   default:
@@ -837,7 +838,7 @@ uint64_t Relocation::extractValue(uint64_t Type, uint64_t Contents,
   }
 }
 
-bool Relocation::isGOT(uint64_t Type) {
+bool Relocation::isGOT(uint32_t Type) {
   switch (Arch) {
   default:
     llvm_unreachable("Unsupported architecture");
@@ -850,21 +851,21 @@ bool Relocation::isGOT(uint64_t Type) {
   }
 }
 
-bool Relocation::isX86GOTPCRELX(uint64_t Type) {
+bool Relocation::isX86GOTPCRELX(uint32_t Type) {
   if (Arch != Triple::x86_64)
     return false;
   return Type == ELF::R_X86_64_GOTPCRELX || Type == ELF::R_X86_64_REX_GOTPCRELX;
 }
 
-bool Relocation::isX86GOTPC64(uint64_t Type) {
+bool Relocation::isX86GOTPC64(uint32_t Type) {
   if (Arch != Triple::x86_64)
     return false;
   return Type == ELF::R_X86_64_GOTPC64;
 }
 
-bool Relocation::isNone(uint64_t Type) { return Type == getNone(); }
+bool Relocation::isNone(uint32_t Type) { return Type == getNone(); }
 
-bool Relocation::isRelative(uint64_t Type) {
+bool Relocation::isRelative(uint32_t Type) {
   switch (Arch) {
   default:
     llvm_unreachable("Unsupported architecture");
@@ -877,7 +878,7 @@ bool Relocation::isRelative(uint64_t Type) {
   }
 }
 
-bool Relocation::isIRelative(uint64_t Type) {
+bool Relocation::isIRelative(uint32_t Type) {
   switch (Arch) {
   default:
     llvm_unreachable("Unsupported architecture");
@@ -890,7 +891,7 @@ bool Relocation::isIRelative(uint64_t Type) {
   }
 }
 
-bool Relocation::isTLS(uint64_t Type) {
+bool Relocation::isTLS(uint32_t Type) {
   switch (Arch) {
   default:
     llvm_unreachable("Unsupported architecture");
@@ -903,7 +904,7 @@ bool Relocation::isTLS(uint64_t Type) {
   }
 }
 
-bool Relocation::isInstructionReference(uint64_t Type) {
+bool Relocation::isInstructionReference(uint32_t Type) {
   if (Arch != Triple::riscv64)
     return false;
 
@@ -916,7 +917,7 @@ bool Relocation::isInstructionReference(uint64_t Type) {
   }
 }
 
-uint64_t Relocation::getNone() {
+uint32_t Relocation::getNone() {
   switch (Arch) {
   default:
     llvm_unreachable("Unsupported architecture");
@@ -929,7 +930,7 @@ uint64_t Relocation::getNone() {
   }
 }
 
-uint64_t Relocation::getPC32() {
+uint32_t Relocation::getPC32() {
   switch (Arch) {
   default:
     llvm_unreachable("Unsupported architecture");
@@ -942,7 +943,7 @@ uint64_t Relocation::getPC32() {
   }
 }
 
-uint64_t Relocation::getPC64() {
+uint32_t Relocation::getPC64() {
   switch (Arch) {
   default:
     llvm_unreachable("Unsupported architecture");
@@ -955,7 +956,13 @@ uint64_t Relocation::getPC64() {
   }
 }
 
-bool Relocation::isPCRelative(uint64_t Type) {
+uint32_t Relocation::getType(const object::RelocationRef &Rel) {
+  uint64_t RelType = Rel.getType();
+  assert(isUInt<32>(RelType) && "BOLT relocation types are 32 bits");
+  return static_cast<uint32_t>(RelType);
+}
+
+bool Relocation::isPCRelative(uint32_t Type) {
   switch (Arch) {
   default:
     llvm_unreachable("Unsupported architecture");
@@ -968,7 +975,7 @@ bool Relocation::isPCRelative(uint64_t Type) {
   }
 }
 
-uint64_t Relocation::getAbs64() {
+uint32_t Relocation::getAbs64() {
   switch (Arch) {
   default:
     llvm_unreachable("Unsupported architecture");
@@ -981,7 +988,7 @@ uint64_t Relocation::getAbs64() {
   }
 }
 
-uint64_t Relocation::getRelative() {
+uint32_t Relocation::getRelative() {
   switch (Arch) {
   default:
     llvm_unreachable("Unsupported architecture");
@@ -1036,7 +1043,7 @@ const MCExpr *Relocation::createExpr(MCStreamer *Streamer,
   return Value;
 }
 
-MCBinaryExpr::Opcode Relocation::getComposeOpcodeFor(uint64_t Type) {
+MCBinaryExpr::Opcode Relocation::getComposeOpcodeFor(uint32_t Type) {
   assert(Arch == Triple::riscv64 && "only implemented for RISC-V");
 
   switch (Type) {

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -1900,7 +1900,7 @@ void RewriteInstance::relocateEHFrameSection() {
     if (!(DwarfType & dwarf::DW_EH_PE_sdata4))
       return;
 
-    uint64_t RelType;
+    uint32_t RelType;
     switch (DwarfType & 0x0f) {
     default:
       llvm_unreachable("unsupported DWARF encoding type");
@@ -2207,7 +2207,7 @@ uint32_t getRelocationSymbol(const ELFObjectFileBase *Obj,
 } // anonymous namespace
 
 bool RewriteInstance::analyzeRelocation(
-    const RelocationRef &Rel, uint64_t &RType, std::string &SymbolName,
+    const RelocationRef &Rel, uint32_t &RType, std::string &SymbolName,
     bool &IsSectionRelocation, uint64_t &SymbolAddress, int64_t &Addend,
     uint64_t &ExtractedValue, bool &Skip) const {
   Skip = false;
@@ -2426,7 +2426,7 @@ void RewriteInstance::readDynamicRelocations(const SectionRef &Section,
   });
 
   for (const RelocationRef &Rel : Section.relocations()) {
-    const uint64_t RType = Rel.getType();
+    const uint32_t RType = Relocation::getType(Rel);
     if (Relocation::isNone(RType))
       continue;
 
@@ -2473,7 +2473,7 @@ void RewriteInstance::readDynamicRelrRelocations(BinarySection &Section) {
            << ":\n";
   });
 
-  const uint64_t RType = Relocation::getRelative();
+  const uint32_t RType = Relocation::getRelative();
   const uint8_t PSize = BC->AsmInfo->getCodePointerSize();
   const uint64_t MaxDelta = ((CHAR_BIT * DynamicRelrEntrySize) - 1) * PSize;
 
@@ -2586,7 +2586,7 @@ void RewriteInstance::handleRelocation(const SectionRef &RelocatedSection,
 
   SmallString<16> TypeName;
   Rel.getTypeName(TypeName);
-  uint64_t RType = Rel.getType();
+  uint32_t RType = Relocation::getType(Rel);
   if (Relocation::skipRelocationType(RType))
     return;
 
@@ -2688,7 +2688,7 @@ void RewriteInstance::handleRelocation(const SectionRef &RelocatedSection,
       // This might be a relocation for an ABS symbols like __global_pointer$ on
       // RISC-V
       ContainingBF->addRelocation(Rel.getOffset(), ReferencedSymbol,
-                                  Rel.getType(), 0,
+                                  Relocation::getType(Rel), 0,
                                   cantFail(Symbol.getValue()));
       return;
     }

--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -780,7 +780,7 @@ public:
 
   const MCExpr *getTargetExprFor(MCInst &Inst, const MCExpr *Expr,
                                  MCContext &Ctx,
-                                 uint64_t RelType) const override {
+                                 uint32_t RelType) const override {
 
     if (isADR(Inst) || RelType == ELF::R_AARCH64_ADR_PREL_LO21 ||
         RelType == ELF::R_AARCH64_TLSDESC_ADR_PREL21) {
@@ -1885,7 +1885,7 @@ public:
 
   bool replaceImmWithSymbolRef(MCInst &Inst, const MCSymbol *Symbol,
                                int64_t Addend, MCContext *Ctx, int64_t &Value,
-                               uint64_t RelType) const override {
+                               uint32_t RelType) const override {
     unsigned ImmOpNo = -1U;
     for (unsigned Index = 0; Index < MCPlus::getNumPrimeOperands(Inst);
          ++Index) {
@@ -1913,7 +1913,7 @@ public:
         *Ctx, 0)));
   }
 
-  bool shouldRecordCodeRelocation(uint64_t RelType) const override {
+  bool shouldRecordCodeRelocation(uint32_t RelType) const override {
     switch (RelType) {
     case ELF::R_AARCH64_ABS64:
     case ELF::R_AARCH64_ABS32:
@@ -2236,7 +2236,7 @@ public:
     assert(FKI.TargetOffset == 0 && "0-bit relocation offset expected");
     const uint64_t RelOffset = Fixup.getOffset();
 
-    uint64_t RelType;
+    uint32_t RelType;
     if (Fixup.getKind() == MCFixupKind(AArch64::fixup_aarch64_pcrel_call26))
       RelType = ELF::R_AARCH64_CALL26;
     else if (Fixup.getKind() ==

--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -56,7 +56,7 @@ public:
     Regs |= getAliases(RISCV::X27);
   }
 
-  bool shouldRecordCodeRelocation(uint64_t RelType) const override {
+  bool shouldRecordCodeRelocation(uint32_t RelType) const override {
     switch (RelType) {
     case ELF::R_RISCV_JAL:
     case ELF::R_RISCV_CALL:
@@ -405,7 +405,7 @@ public:
 
   bool replaceImmWithSymbolRef(MCInst &Inst, const MCSymbol *Symbol,
                                int64_t Addend, MCContext *Ctx, int64_t &Value,
-                               uint64_t RelType) const override {
+                               uint32_t RelType) const override {
     unsigned ImmOpNo = -1U;
 
     for (unsigned Index = 0; Index < MCPlus::getNumPrimeOperands(Inst);
@@ -426,7 +426,7 @@ public:
 
   const MCExpr *getTargetExprFor(MCInst &Inst, const MCExpr *Expr,
                                  MCContext &Ctx,
-                                 uint64_t RelType) const override {
+                                 uint32_t RelType) const override {
     switch (RelType) {
     default:
       return Expr;

--- a/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
+++ b/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
@@ -387,7 +387,7 @@ public:
     return (Desc.TSFlags & X86II::OpPrefixMask) == X86II::PD;
   }
 
-  bool shouldRecordCodeRelocation(uint64_t RelType) const override {
+  bool shouldRecordCodeRelocation(uint32_t RelType) const override {
     switch (RelType) {
     case ELF::R_X86_64_8:
     case ELF::R_X86_64_16:
@@ -2444,7 +2444,7 @@ public:
     assert(FKI.TargetOffset == 0 && "0-bit relocation offset expected");
     const uint64_t RelOffset = Fixup.getOffset();
 
-    uint64_t RelType;
+    uint32_t RelType;
     if (FKI.Flags & MCFixupKindInfo::FKF_IsPCRel) {
       switch (FKI.TargetSize) {
       default:
@@ -2472,7 +2472,7 @@ public:
 
   bool replaceImmWithSymbolRef(MCInst &Inst, const MCSymbol *Symbol,
                                int64_t Addend, MCContext *Ctx, int64_t &Value,
-                               uint64_t RelType) const override {
+                               uint32_t RelType) const override {
     unsigned ImmOpNo = -1U;
 
     for (unsigned Index = 0; Index < MCPlus::getNumPrimeOperands(Inst);


### PR DESCRIPTION
Change the Relocation Type from uint64_t to uint32_t.

Add an Optional flag to relocations to indicate that they may be skipped.