### PR TITLE
[DXIL] Remove definition and any uses of DXIL `Property`

### DIFF
--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -288,17 +288,6 @@ def ReadOnly : DXILAttribute;
 def NoDuplicate : DXILAttribute;
 def NoReturn : DXILAttribute;
 
-// A property is simply used to mark that a DXIL op belongs to a sub-group of
-// DXIL ops, and it is used to query if a particular op holds this property.
-// This is used for the static analysis of DXIL ops.
-class DXILProperty;
-
-def IsBarrier : DXILProperty;
-def IsGradient : DXILProperty;
-def IsFeedback : DXILProperty;
-def IsWave : DXILProperty;
-def RequiresUniformInputs : DXILProperty;
-
 class Overloads<Version ver, list<DXILOpParamType> ols> {
   Version dxil_version = ver;
   list<DXILOpParamType> overload_types = ols;
@@ -406,9 +395,6 @@ class DXILOp<int opcode, DXILOpClass opclass> {
 
   // Versioned attributes of operation
   list<Attributes> attributes = [];
-
-  // List of properties. Default to no properties.
-  list<DXILProperty> properties = [];
 }
 
 // Concrete definitions of DXIL Operations
@@ -898,7 +884,6 @@ def Barrier : DXILOp<80, barrier> {
   let result = VoidTy;
   let stages = [Stages<DXIL1_0, [compute, library]>];
   let attributes = [Attributes<DXIL1_0, []>];
-  let properties = [IsBarrier];
 }
 
 def Discard : DXILOp<82, discard> {
@@ -974,7 +959,6 @@ def WaveIsFirstLane : DXILOp<110, waveIsFirstLane> {
   let arguments = [];
   let result = Int1Ty;
   let stages = [Stages<DXIL1_0, [all_stages]>];
-  let properties = [IsWave];
 }
 
 def WaveGetLaneIndex : DXILOp<111, waveGetLaneIndex> {
@@ -984,7 +968,6 @@ def WaveGetLaneIndex : DXILOp<111, waveGetLaneIndex> {
   let result = Int32Ty;
   let stages = [Stages<DXIL1_0, [all_stages]>];
   let attributes = [Attributes<DXIL1_0, [ReadOnly]>];
-  let properties = [IsWave];
 }
 
 def WaveActiveAnyTrue : DXILOp<113, waveAnyTrue> {
@@ -994,7 +977,6 @@ def WaveActiveAnyTrue : DXILOp<113, waveAnyTrue> {
   let arguments = [Int1Ty];
   let result = Int1Ty;
   let stages = [Stages<DXIL1_0, [all_stages]>];
-  let properties = [IsWave];
 }
 
 def WaveActiveAllTrue : DXILOp<114, waveAllTrue> {
@@ -1004,7 +986,6 @@ def WaveActiveAllTrue : DXILOp<114, waveAllTrue> {
   let arguments = [Int1Ty];
   let result = Int1Ty;
   let stages = [Stages<DXIL1_0, [all_stages]>];
-  let properties = [IsWave];
 }
 
 def WaveReadLaneAt : DXILOp<117, waveReadLaneAt> {
@@ -1015,7 +996,6 @@ def WaveReadLaneAt : DXILOp<117, waveReadLaneAt> {
   let overloads = [Overloads<
       DXIL1_0, [HalfTy, FloatTy, DoubleTy, Int1Ty, Int16Ty, Int32Ty, Int64Ty]>];
   let stages = [Stages<DXIL1_0, [all_stages]>];
-  let properties = [IsWave];
 }
 
 def WaveActiveOp : DXILOp<119, waveActiveOp> {
@@ -1058,7 +1038,6 @@ def WaveAllBitCount : DXILOp<135, waveAllOp> {
   let arguments = [Int1Ty];
   let result = Int32Ty;
   let stages = [Stages<DXIL1_0, [all_stages]>];
-  let properties = [IsWave];
 }
 
 def RawBufferLoad : DXILOp<139, rawBufferLoad> {

--- a/llvm/lib/Target/DirectX/DXILConstants.h
+++ b/llvm/lib/Target/DirectX/DXILConstants.h
@@ -47,11 +47,6 @@ inline Attributes &operator|=(Attributes &a, Attributes &b) {
   return a;
 }
 
-struct Properties {
-#define DXIL_PROPERTY(Name) bool Name = false;
-#include "DXILOperation.inc"
-};
-
 } // namespace dxil
 } // namespace llvm
 

--- a/llvm/utils/TableGen/DXILEmitter.cpp
+++ b/llvm/utils/TableGen/DXILEmitter.cpp
@@ -56,7 +56,6 @@ struct DXILOperationDesc {
   SmallVector<const Record *> OverloadRecs;
   SmallVector<const Record *> StageRecs;
   SmallVector<const Record *> AttrRecs;
-  SmallVector<const Record *> PropRecs;
   SmallVector<DXILIntrinsicSelect> IntrinsicSelects;
   SmallVector<StringRef, 4>
       ShaderStages; // shader stages to which this applies, empty for all.
@@ -177,12 +176,6 @@ DXILOperationDesc::DXILOperationDesc(const Record *R) {
   for (const Record *CR : Recs) {
     AttrRecs.push_back(CR);
   }
-
-  Recs = R->getValueAsListOfDefs("properties");
-
-  // Get property records
-  for (const Record *CR : Recs)
-    PropRecs.push_back(CR);
 
   // Get the operation class
   OpClass = R->getValueAsDef("OpClass")->getName();
@@ -427,15 +420,6 @@ static void emitDXILOpAttributes(const RecordKeeper &Records,
   OS << "#endif\n\n";
 }
 
-/// Emit a list of DXIL op properties
-static void emitDXILProperties(const RecordKeeper &Records, raw_ostream &OS) {
-  OS << "#ifdef DXIL_PROPERTY\n";
-  for (const Record *Prop : Records.getAllDerivedDefinitions("DXILProperty"))
-    OS << "DXIL_PROPERTY(" << Prop->getName() << ")\n";
-  OS << "#undef DXIL_PROPERTY\n";
-  OS << "#endif\n\n";
-}
-
 /// Emit a list of DXIL op function types
 static void emitDXILOpFunctionTypes(ArrayRef<DXILOperationDesc> Ops,
                                     raw_ostream &OS) {
@@ -639,7 +623,6 @@ static void emitDxilOperation(const RecordKeeper &Records, raw_ostream &OS) {
   emitDXILOpParamTypes(Records, OS);
   emitDXILAttributes(Records, OS);
   emitDXILOpAttributes(Records, DXILOps, OS);
-  emitDXILProperties(Records, OS);
   emitDXILOpFunctionTypes(DXILOps, OS);
   emitDXILIntrinsicArgSelectTypes(Records, OS);
   emitDXILIntrinsicMap(DXILOps, OS);


### PR DESCRIPTION
- Remove definitions from DXIL.td and any emissions/definitions that were previously planned to be used

See resolved issue for motivations of deletion

Resolves #126298