### PR TITLE
[libc] Mark fixed point type generic macros as complete

### DIFF
--- a/libc/docs/headers/stdfix.rst
+++ b/libc/docs/headers/stdfix.rst
@@ -1,6 +1,6 @@
-================
-StdFix Functions
-================
+========
+stdfix.h
+========
 
 .. include:: ../check.rst
 
@@ -89,9 +89,9 @@ The following functions are included in the ISO/IEC TR 18037:2008 standard.
 ================== =========
 Type Generic Macro Available
 ================== =========
-absfx
-countlsfx
-roundfx
+absfx              |check|
+countlsfx          |check|
+roundfx            |check|
 ================== =========
 
 


### PR DESCRIPTION
These were added in https://github.com/llvm/llvm-project/pull/129371.