### PR TITLE
[PAC][InstCombine] Replace auth+sign with resign

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3383,6 +3383,29 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
         Intrinsic::getOrInsertDeclaration(II->getModule(), NewIntrin);
     return CallInst::Create(NewFn, CallArgs);
   }
+  case Intrinsic::ptrauth_sign: {
+    // auth + sign can be replaced with resign, which prevents unsafe
+    // spills and reloads of intermediate authenticated value.
+    Value *Ptr = II->getArgOperand(0);
+    Value *SignKey = II->getArgOperand(1);
+    Value *SignDisc = II->getArgOperand(2);
+
+    const auto *CI = dyn_cast<CallBase>(Ptr);
+    if (!CI || CI->getIntrinsicID() != Intrinsic::ptrauth_auth)
+      break;
+
+    Value *BasePtr = CI->getOperand(0);
+    Value *AuthKey = CI->getArgOperand(1);
+    Value *AuthDisc = CI->getArgOperand(2);
+
+    // Not replacing auth+sign using the same schema with nop, as auth+sign
+    // pair traps on authentication failure.
+
+    Function *NewFn = Intrinsic::getOrInsertDeclaration(
+        II->getModule(), Intrinsic::ptrauth_resign);
+    return CallInst::Create(NewFn,
+                            {BasePtr, AuthKey, AuthDisc, SignKey, SignDisc});
+  }
   case Intrinsic::arm_neon_vtbl1:
   case Intrinsic::arm_neon_vtbl2:
   case Intrinsic::arm_neon_vtbl3:

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3384,8 +3384,13 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     return CallInst::Create(NewFn, CallArgs);
   }
   case Intrinsic::ptrauth_sign: {
-    // auth + sign can be replaced with resign, which prevents unsafe
-    // spills and reloads of intermediate authenticated value.
+    // Replace auth+sign with a single resign intrinsic.
+    // When auth and sign operations are performed separately, later compiler
+    // passes may spill intermediate result to memory as a raw, unprotected
+    // pointer, which makes it possible for an attacker to replace it under
+    // PAuth threat model. On the other hand, resign intrinsic is not expanded
+    // until AsmPrinter, when it is emitted as a contiguous, non-attackable
+    // sequence of instructions.
     Value *Ptr = II->getArgOperand(0);
     Value *SignKey = II->getArgOperand(1);
     Value *SignDisc = II->getArgOperand(2);

--- a/llvm/test/Transforms/InstCombine/ptrauth-intrinsics.ll
+++ b/llvm/test/Transforms/InstCombine/ptrauth-intrinsics.ll
@@ -200,8 +200,7 @@ define i64 @test_ptrauth_nop_ds_constant() {
 define i64 @test_ptrauth_auth_sign_same_schema(ptr %p) {
 ; CHECK-LABEL: @test_ptrauth_auth_sign_same_schema(
 ; CHECK-NEXT:    [[P_INT:%.*]] = ptrtoint ptr [[P:%.*]] to i64
-; CHECK-NEXT:    [[AUTHED:%.*]] = call i64 @llvm.ptrauth.auth(i64 [[P_INT]], i32 1, i64 1234)
-; CHECK-NEXT:    [[RESIGNED:%.*]] = call i64 @llvm.ptrauth.sign(i64 [[AUTHED]], i32 1, i64 1234)
+; CHECK-NEXT:    [[RESIGNED:%.*]] = call i64 @llvm.ptrauth.resign(i64 [[P_INT]], i32 1, i64 1234, i32 1, i64 1234)
 ; CHECK-NEXT:    ret i64 [[RESIGNED]]
 ;
   %p.int = ptrtoint ptr %p to i64
@@ -213,8 +212,7 @@ define i64 @test_ptrauth_auth_sign_same_schema(ptr %p) {
 define i64 @test_ptrauth_auth_sign_opaque_disc_same_schema(ptr %p, i64 %disc) {
 ; CHECK-LABEL: @test_ptrauth_auth_sign_opaque_disc_same_schema(
 ; CHECK-NEXT:    [[P_INT:%.*]] = ptrtoint ptr [[P:%.*]] to i64
-; CHECK-NEXT:    [[AUTHED:%.*]] = call i64 @llvm.ptrauth.auth(i64 [[P_INT]], i32 1, i64 [[DISC:%.*]])
-; CHECK-NEXT:    [[RESIGNED:%.*]] = call i64 @llvm.ptrauth.sign(i64 [[AUTHED]], i32 1, i64 [[DISC]])
+; CHECK-NEXT:    [[RESIGNED:%.*]] = call i64 @llvm.ptrauth.resign(i64 [[P_INT]], i32 1, i64 [[DISC:%.*]], i32 1, i64 [[DISC]])
 ; CHECK-NEXT:    ret i64 [[RESIGNED]]
 ;
   %p.int = ptrtoint ptr %p to i64
@@ -226,8 +224,7 @@ define i64 @test_ptrauth_auth_sign_opaque_disc_same_schema(ptr %p, i64 %disc) {
 define i64 @test_ptrauth_auth_sign_different_disc(ptr %p, i64 %disc) {
 ; CHECK-LABEL: @test_ptrauth_auth_sign_different_disc(
 ; CHECK-NEXT:    [[P_INT:%.*]] = ptrtoint ptr [[P:%.*]] to i64
-; CHECK-NEXT:    [[AUTHED:%.*]] = call i64 @llvm.ptrauth.auth(i64 [[P_INT]], i32 1, i64 [[DISC:%.*]])
-; CHECK-NEXT:    [[RESIGNED:%.*]] = call i64 @llvm.ptrauth.sign(i64 [[AUTHED]], i32 1, i64 1234)
+; CHECK-NEXT:    [[RESIGNED:%.*]] = call i64 @llvm.ptrauth.resign(i64 [[P_INT]], i32 1, i64 [[DISC:%.*]], i32 1, i64 1234)
 ; CHECK-NEXT:    ret i64 [[RESIGNED]]
 ;
   %p.int = ptrtoint ptr %p to i64
@@ -239,8 +236,7 @@ define i64 @test_ptrauth_auth_sign_different_disc(ptr %p, i64 %disc) {
 define i64 @test_ptrauth_auth_sign_different_key(ptr %p) {
 ; CHECK-LABEL: @test_ptrauth_auth_sign_different_key(
 ; CHECK-NEXT:    [[P_INT:%.*]] = ptrtoint ptr [[P:%.*]] to i64
-; CHECK-NEXT:    [[AUTHED:%.*]] = call i64 @llvm.ptrauth.auth(i64 [[P_INT]], i32 0, i64 1234)
-; CHECK-NEXT:    [[RESIGNED:%.*]] = call i64 @llvm.ptrauth.sign(i64 [[AUTHED]], i32 1, i64 1234)
+; CHECK-NEXT:    [[RESIGNED:%.*]] = call i64 @llvm.ptrauth.resign(i64 [[P_INT]], i32 0, i64 1234, i32 1, i64 1234)
 ; CHECK-NEXT:    ret i64 [[RESIGNED]]
 ;
   %p.int = ptrtoint ptr %p to i64

--- a/llvm/test/Transforms/InstCombine/ptrauth-intrinsics.ll
+++ b/llvm/test/Transforms/InstCombine/ptrauth-intrinsics.ll
@@ -197,6 +197,68 @@ define i64 @test_ptrauth_nop_ds_constant() {
   ret i64 %authed
 }
 
+define i64 @test_ptrauth_auth_sign_same_schema(ptr %p) {
+; CHECK-LABEL: @test_ptrauth_auth_sign_same_schema(
+; CHECK-NEXT:    [[P_INT:%.*]] = ptrtoint ptr [[P:%.*]] to i64
+; CHECK-NEXT:    [[AUTHED:%.*]] = call i64 @llvm.ptrauth.auth(i64 [[P_INT]], i32 1, i64 1234)
+; CHECK-NEXT:    [[RESIGNED:%.*]] = call i64 @llvm.ptrauth.sign(i64 [[AUTHED]], i32 1, i64 1234)
+; CHECK-NEXT:    ret i64 [[RESIGNED]]
+;
+  %p.int = ptrtoint ptr %p to i64
+  %authed = call i64 @llvm.ptrauth.auth(i64 %p.int, i32 1, i64 1234)
+  %resigned = call i64 @llvm.ptrauth.sign(i64 %authed, i32 1, i64 1234)
+  ret i64 %resigned
+}
+
+define i64 @test_ptrauth_auth_sign_opaque_disc_same_schema(ptr %p, i64 %disc) {
+; CHECK-LABEL: @test_ptrauth_auth_sign_opaque_disc_same_schema(
+; CHECK-NEXT:    [[P_INT:%.*]] = ptrtoint ptr [[P:%.*]] to i64
+; CHECK-NEXT:    [[AUTHED:%.*]] = call i64 @llvm.ptrauth.auth(i64 [[P_INT]], i32 1, i64 [[DISC:%.*]])
+; CHECK-NEXT:    [[RESIGNED:%.*]] = call i64 @llvm.ptrauth.sign(i64 [[AUTHED]], i32 1, i64 [[DISC]])
+; CHECK-NEXT:    ret i64 [[RESIGNED]]
+;
+  %p.int = ptrtoint ptr %p to i64
+  %authed = call i64 @llvm.ptrauth.auth(i64 %p.int, i32 1, i64 %disc)
+  %resigned = call i64 @llvm.ptrauth.sign(i64 %authed, i32 1, i64 %disc)
+  ret i64 %resigned
+}
+
+define i64 @test_ptrauth_auth_sign_different_disc(ptr %p, i64 %disc) {
+; CHECK-LABEL: @test_ptrauth_auth_sign_different_disc(
+; CHECK-NEXT:    [[P_INT:%.*]] = ptrtoint ptr [[P:%.*]] to i64
+; CHECK-NEXT:    [[AUTHED:%.*]] = call i64 @llvm.ptrauth.auth(i64 [[P_INT]], i32 1, i64 [[DISC:%.*]])
+; CHECK-NEXT:    [[RESIGNED:%.*]] = call i64 @llvm.ptrauth.sign(i64 [[AUTHED]], i32 1, i64 1234)
+; CHECK-NEXT:    ret i64 [[RESIGNED]]
+;
+  %p.int = ptrtoint ptr %p to i64
+  %authed = call i64 @llvm.ptrauth.auth(i64 %p.int, i32 1, i64 %disc)
+  %resigned = call i64 @llvm.ptrauth.sign(i64 %authed, i32 1, i64 1234)
+  ret i64 %resigned
+}
+
+define i64 @test_ptrauth_auth_sign_different_key(ptr %p) {
+; CHECK-LABEL: @test_ptrauth_auth_sign_different_key(
+; CHECK-NEXT:    [[P_INT:%.*]] = ptrtoint ptr [[P:%.*]] to i64
+; CHECK-NEXT:    [[AUTHED:%.*]] = call i64 @llvm.ptrauth.auth(i64 [[P_INT]], i32 0, i64 1234)
+; CHECK-NEXT:    [[RESIGNED:%.*]] = call i64 @llvm.ptrauth.sign(i64 [[AUTHED]], i32 1, i64 1234)
+; CHECK-NEXT:    ret i64 [[RESIGNED]]
+;
+  %p.int = ptrtoint ptr %p to i64
+  %authed = call i64 @llvm.ptrauth.auth(i64 %p.int, i32 0, i64 1234)
+  %resigned = call i64 @llvm.ptrauth.sign(i64 %authed, i32 1, i64 1234)
+  ret i64 %resigned
+}
+
+define i64 @test_ptrauth_sign_nonauth_nonconst_disc(i64 %disc) {
+; CHECK-LABEL: @test_ptrauth_sign_nonauth_nonconst_disc(
+; CHECK-NEXT:    [[SIGNED:%.*]] = call i64 @llvm.ptrauth.sign(i64 ptrtoint (ptr @foo to i64), i32 1, i64 [[DISC:%.*]])
+; CHECK-NEXT:    ret i64 [[SIGNED]]
+;
+  %foo.int = ptrtoint ptr @foo to i64
+  %signed = call i64 @llvm.ptrauth.sign(i64 %foo.int, i32 1, i64 %disc)
+  ret i64 %signed
+}
+
 declare i64 @llvm.ptrauth.auth(i64, i32, i64)
 declare i64 @llvm.ptrauth.sign(i64, i32, i64)
 declare i64 @llvm.ptrauth.resign(i64, i32, i64, i32, i64)


### PR DESCRIPTION
Prevent introducing signing oracles by increasing the chances that pointer resign pattern is detected and kept as a single operation until it is expanded in AsmPrinter.

With separate auth and sign intrinsics, it is possible that intermediate authenticated pointer is spilled to stack and reloaded before it is signed again, thus making it possible for the attacker to trick the `PAC*` instruction into signing an arbitrary pointer.