### PR TITLE
[RISCV] Add an error that Xqccmp, Xqciac, and Xqcicm are not compatible with C+D or Zcd.

### DIFF
--- a/llvm/lib/TargetParser/RISCVISAInfo.cpp
+++ b/llvm/lib/TargetParser/RISCVISAInfo.cpp
@@ -748,8 +748,7 @@ Error RISCVISAInfo::checkDependency() {
       {"xqcicm"},  {"xqcics"}, {"xqcicsr"}, {"xqciint"},
       {"xqcilia"}, {"xqcilo"}, {"xqcilsm"}, {"xqcisls"}};
   static constexpr StringLiteral ZcdOverlaps[] = {
-    {"zcmt"}, {"zcmp"}, {"xqciac"}, {"xqcicm"}
-  };
+      {"zcmt"}, {"zcmp"}, {"xqciac"}, {"xqcicm"}};
 
   if (HasI && HasE)
     return getIncompatibleError("i", "e");
@@ -763,10 +762,9 @@ Error RISCVISAInfo::checkDependency() {
   if (HasD && (HasC || Exts.count("zcd")))
     for (auto Ext : ZcdOverlaps)
       if (Exts.count(Ext.str()))
-        return getError(Twine("'") + Ext +
-                        "' extension is incompatible with '" +
-                        (HasC ? "c" : "zcd") +
-                        "' extension when 'd' extension is enabled");
+        return getError(
+            Twine("'") + Ext + "' extension is incompatible with '" +
+            (HasC ? "c" : "zcd") + "' extension when 'd' extension is enabled");
 
   if (XLen != 32 && Exts.count("zcf"))
     return getError("'zcf' is only supported for 'rv32'");

--- a/llvm/lib/TargetParser/RISCVISAInfo.cpp
+++ b/llvm/lib/TargetParser/RISCVISAInfo.cpp
@@ -740,13 +740,16 @@ Error RISCVISAInfo::checkDependency() {
   bool HasZfinx = Exts.count("zfinx") != 0;
   bool HasVector = Exts.count("zve32x") != 0;
   bool HasZvl = MinVLen != 0;
-  bool HasZcmt = Exts.count("zcmt") != 0;
+  bool HasZcmp = Exts.count("zcmp") != 0;
+  bool HasXqccmp = Exts.count("xqccmp") != 0;
+
   static constexpr StringLiteral XqciExts[] = {
       {"xqcia"},   {"xqciac"}, {"xqcibm"},  {"xqcicli"},
       {"xqcicm"},  {"xqcics"}, {"xqcicsr"}, {"xqciint"},
       {"xqcilia"}, {"xqcilo"}, {"xqcilsm"}, {"xqcisls"}};
-  bool HasZcmp = Exts.count("zcmp") != 0;
-  bool HasXqccmp = Exts.count("xqccmp") != 0;
+  static constexpr StringLiteral ZcdOverlaps[] = {
+    {"zcmt"}, {"zcmp"}, {"xqciac"}, {"xqcicm"}
+  };
 
   if (HasI && HasE)
     return getIncompatibleError("i", "e");
@@ -757,11 +760,13 @@ Error RISCVISAInfo::checkDependency() {
   if (HasZvl && !HasVector)
     return getExtensionRequiresError("zvl*b", "v' or 'zve*");
 
-  if ((HasZcmt || Exts.count("zcmp")) && HasD && (HasC || Exts.count("zcd")))
-    return getError(Twine("'") + (HasZcmt ? "zcmt" : "zcmp") +
-                    "' extension is incompatible with '" +
-                    (HasC ? "c" : "zcd") +
-                    "' extension when 'd' extension is enabled");
+  if (HasD && (HasC || Exts.count("zcd")))
+    for (auto Ext : ZcdOverlaps)
+      if (Exts.count(Ext.str()))
+        return getError(Twine("'") + Ext +
+                        "' extension is incompatible with '" +
+                        (HasC ? "c" : "zcd") +
+                        "' extension when 'd' extension is enabled");
 
   if (XLen != 32 && Exts.count("zcf"))
     return getError("'zcf' is only supported for 'rv32'");

--- a/llvm/lib/TargetParser/RISCVISAInfo.cpp
+++ b/llvm/lib/TargetParser/RISCVISAInfo.cpp
@@ -748,7 +748,7 @@ Error RISCVISAInfo::checkDependency() {
       {"xqcicm"},  {"xqcics"}, {"xqcicsr"}, {"xqciint"},
       {"xqcilia"}, {"xqcilo"}, {"xqcilsm"}, {"xqcisls"}};
   static constexpr StringLiteral ZcdOverlaps[] = {
-      {"zcmt"}, {"zcmp"}, {"xqciac"}, {"xqcicm"}};
+      {"zcmt"}, {"zcmp"}, {"xqccmp"}, {"xqciac"}, {"xqcicm"}};
 
   if (HasI && HasE)
     return getIncompatibleError("i", "e");

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -670,9 +670,10 @@ TEST(ParseArchString, RejectsConflictingExtensions) {
   }
 
   for (StringRef Input : {"rv32i_zcd_xqciac0p3"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'xqciac' extension is incompatible with 'zcd' extension when 'd' "
-              "extension is enabled");
+    EXPECT_EQ(
+        toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
+        "'xqciac' extension is incompatible with 'zcd' extension when 'd' "
+        "extension is enabled");
   }
 
   for (StringRef Input : {"rv32idc_xqcicm0p2"}) {
@@ -682,9 +683,10 @@ TEST(ParseArchString, RejectsConflictingExtensions) {
   }
 
   for (StringRef Input : {"rv32i_zcd_xqcicm0p2"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'xqcicm' extension is incompatible with 'zcd' extension when 'd' "
-              "extension is enabled");
+    EXPECT_EQ(
+        toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
+        "'xqcicm' extension is incompatible with 'zcd' extension when 'd' "
+        "extension is enabled");
   }
 
   for (StringRef Input : {"rv32i_zcmp_xqccmp0p1", "rv64i_zcmp_xqccmp0p1"}) {

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -663,6 +663,30 @@ TEST(ParseArchString, RejectsConflictingExtensions) {
         ::testing::EndsWith(" is only supported for 'rv32'"));
   }
 
+  for (StringRef Input : {"rv32idc_xqciac0p3"}) {
+    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
+              "'xqciac' extension is incompatible with 'c' extension when 'd' "
+              "extension is enabled");
+  }
+
+  for (StringRef Input : {"rv32i_zcd_xqciac0p3"}) {
+    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
+              "'xqciac' extension is incompatible with 'zcd' extension when 'd' "
+              "extension is enabled");
+  }
+
+  for (StringRef Input : {"rv32idc_xqcicm0p2"}) {
+    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
+              "'xqcicm' extension is incompatible with 'c' extension when 'd' "
+              "extension is enabled");
+  }
+
+  for (StringRef Input : {"rv32i_zcd_xqcicm0p2"}) {
+    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
+              "'xqcicm' extension is incompatible with 'zcd' extension when 'd' "
+              "extension is enabled");
+  }
+
   for (StringRef Input : {"rv32i_zcmp_xqccmp0p1", "rv64i_zcmp_xqccmp0p1"}) {
     EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
               "'zcmp' and 'xqccmp' extensions are incompatible");

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -663,8 +663,9 @@ TEST(ParseArchString, RejectsConflictingExtensions) {
         ::testing::EndsWith(" is only supported for 'rv32'"));
   }
 
-  for (StringRef Input : {"rv32idc_xqciac0p3", "rv32i_zcd_xqciac0p3", "rv32idc_xqcicm0p2",
-                          "rv32i_zcd_xqcicm0p2"}) {
+  for (StringRef Input :
+       {"rv32idc_xqciac0p3", "rv32i_zcd_xqciac0p3", "rv32idc_xqcicm0p2",
+        "rv32i_zcd_xqcicm0p2", "rv32idc_xqccmp0p1", "rv32i_zcd_xqccmp0p1"}) {
     EXPECT_THAT(
         toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
         ::testing::EndsWith("extension when 'd' extension is enabled"));

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -663,30 +663,11 @@ TEST(ParseArchString, RejectsConflictingExtensions) {
         ::testing::EndsWith(" is only supported for 'rv32'"));
   }
 
-  for (StringRef Input : {"rv32idc_xqciac0p3"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'xqciac' extension is incompatible with 'c' extension when 'd' "
-              "extension is enabled");
-  }
-
-  for (StringRef Input : {"rv32i_zcd_xqciac0p3"}) {
-    EXPECT_EQ(
+  for (StringRef Input : {"rv32idc_xqciac0p3", "rv32i_zcd_xqciac0p3", "rv32idc_xqcicm0p2",
+                          "rv32i_zcd_xqcicm0p2"}) {
+    EXPECT_THAT(
         toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-        "'xqciac' extension is incompatible with 'zcd' extension when 'd' "
-        "extension is enabled");
-  }
-
-  for (StringRef Input : {"rv32idc_xqcicm0p2"}) {
-    EXPECT_EQ(toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-              "'xqcicm' extension is incompatible with 'c' extension when 'd' "
-              "extension is enabled");
-  }
-
-  for (StringRef Input : {"rv32i_zcd_xqcicm0p2"}) {
-    EXPECT_EQ(
-        toString(RISCVISAInfo::parseArchString(Input, true).takeError()),
-        "'xqcicm' extension is incompatible with 'zcd' extension when 'd' "
-        "extension is enabled");
+        ::testing::EndsWith("extension when 'd' extension is enabled"));
   }
 
   for (StringRef Input : {"rv32i_zcmp_xqccmp0p1", "rv64i_zcmp_xqccmp0p1"}) {


### PR DESCRIPTION
I was reviewing encodings to put the disassembling of vendor instructions after after standard instructions and found that these overlap with c.fldsp and c.fsdsp.