### PR TITLE
[RISCV] Move vendor extensions after standard extensions in RISCVDisassembler::getInstruction16.

### DIFF
--- a/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
+++ b/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
@@ -736,14 +736,7 @@ DecodeStatus RISCVDisassembler::getInstruction16(MCInst &MI, uint64_t &Size,
 
   uint32_t Insn = support::endian::read16le(Bytes.data());
 
-  TRY_TO_DECODE_FEATURE_ANY(XqciFeatureGroup, DecoderTableXqci16,
-                            "Qualcomm uC 16bit");
-  TRY_TO_DECODE_FEATURE(
-      RISCV::FeatureVendorXqccmp, DecoderTableXqccmp16,
-      "Xqccmp (Qualcomm 16-bit Push/Pop & Double Move Instructions)");
-  TRY_TO_DECODE_AND_ADD_SP(STI.hasFeature(RISCV::FeatureVendorXwchc),
-                           DecoderTableXwchc16, "WCH QingKe XW");
-
+  // Standard Extensions
   // DecoderTableZicfiss16 must be checked before DecoderTable16.
   TRY_TO_DECODE(true, DecoderTableZicfiss16, "RVZicfiss (Shadow Stack)");
   TRY_TO_DECODE_AND_ADD_SP(true, DecoderTable16,
@@ -753,6 +746,15 @@ DecodeStatus RISCVDisassembler::getInstruction16(MCInst &MI, uint64_t &Size,
   // Zc* instructions incompatible with Zcf or Zcd.
   TRY_TO_DECODE(true, DecoderTableZcOverlap16,
                 "ZcOverlap (16-bit Instructions overlapping with Zcf/Zcd)");
+
+  // Vendor Extensions
+  TRY_TO_DECODE_FEATURE_ANY(XqciFeatureGroup, DecoderTableXqci16,
+                            "Qualcomm uC 16bit");
+  TRY_TO_DECODE_FEATURE(
+      RISCV::FeatureVendorXqccmp, DecoderTableXqccmp16,
+      "Xqccmp (Qualcomm 16-bit Push/Pop & Double Move Instructions)");
+  TRY_TO_DECODE_AND_ADD_SP(STI.hasFeature(RISCV::FeatureVendorXwchc),
+                           DecoderTableXwchc16, "WCH QingKe XW");
 
   return MCDisassembler::Fail;
 }


### PR DESCRIPTION
All of the vendor extensions should be mutex with the standard extensions based on the incompatible extension checks in RISCVISAInfo.cpp. There is one missing check that will be fixed by #130816.

I'll make a similar patch for the 32-bit table, but I need to do more auditing first.