### PR TITLE
[clang] NFCI: Mutate `HeaderSearchOptions` earlier

### DIFF
--- a/clang/include/clang/Lex/HeaderSearchOptions.h
+++ b/clang/include/clang/Lex/HeaderSearchOptions.h
@@ -235,6 +235,7 @@ public:
 
   /// Whether to entirely skip writing diagnostic options.
   /// Primarily used to speed up deserialization during dependency scanning.
+  /// FIXME: Consider moving these into separate `SerializationOptions` class.
   LLVM_PREFERRED_TYPE(bool)
   unsigned ModulesSkipDiagnosticOptions : 1;
 

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4966,7 +4966,9 @@ bool CompilerInvocation::CreateFromArgsImpl(
                         Res.getFileSystemOpts().WorkingDir);
   if (Res.getFrontendOpts().GenReducedBMI ||
       Res.getFrontendOpts().ProgramAction ==
-          frontend::GenerateReducedModuleInterface) {
+          frontend::GenerateReducedModuleInterface ||
+      Res.getFrontendOpts().ProgramAction ==
+          frontend::GenerateModuleInterface) {
     Res.getHeaderSearchOpts().ModulesSkipDiagnosticOptions = true;
     Res.getHeaderSearchOpts().ModulesSkipHeaderSearchPaths = true;
   }

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4964,6 +4964,12 @@ bool CompilerInvocation::CreateFromArgsImpl(
   llvm::Triple T(Res.getTargetOpts().Triple);
   ParseHeaderSearchArgs(Res.getHeaderSearchOpts(), Args, Diags,
                         Res.getFileSystemOpts().WorkingDir);
+  if (Res.getFrontendOpts().GenReducedBMI ||
+      Res.getFrontendOpts().ProgramAction ==
+          frontend::GenerateReducedModuleInterface) {
+    Res.getHeaderSearchOpts().ModulesSkipDiagnosticOptions = true;
+    Res.getHeaderSearchOpts().ModulesSkipHeaderSearchPaths = true;
+  }
   ParseAPINotesArgs(Res.getAPINotesOpts(), Args, Diags);
 
   ParsePointerAuthArgs(LangOpts, Args, Diags);

--- a/clang/lib/Serialization/GeneratePCH.cpp
+++ b/clang/lib/Serialization/GeneratePCH.cpp
@@ -120,13 +120,6 @@ Module *CXX20ModulesGenerator::getEmittingModule(ASTContext &Ctx) {
 }
 
 void CXX20ModulesGenerator::HandleTranslationUnit(ASTContext &Ctx) {
-  // FIMXE: We'd better to wrap such options to a new class ASTWriterOptions
-  // since this is not about searching header really.
-  HeaderSearchOptions &HSOpts =
-      getPreprocessor().getHeaderSearchInfo().getHeaderSearchOpts();
-  HSOpts.ModulesSkipDiagnosticOptions = true;
-  HSOpts.ModulesSkipHeaderSearchPaths = true;
-
   PCHGenerator::HandleTranslationUnit(Ctx);
 
   if (!isComplete())


### PR DESCRIPTION
I would like to ensure that `CompilerInvocation` and its constituents are not mutated late during the compilation. This PR moves adjustment of the `HeaderSearchOptions::ModulesSkip{DiagnosticOptions,HeaderSearchPaths}` bits from somewhere deep in the serialization library into `CompilerInvocation::CreateFromArgs()`.