### PR TITLE
[flang][cuda] Allow assumed-size declaration for SHARED variable

### DIFF
--- a/flang/include/flang/Lower/BoxAnalyzer.h
+++ b/flang/include/flang/Lower/BoxAnalyzer.h
@@ -403,8 +403,9 @@ public:
                 continue;
               }
             } else if (subs.ubound().isStar()) {
-              assert(Fortran::semantics::IsNamedConstant(sym) &&
-                     "expect implied shape constant");
+              assert(Fortran::semantics::IsNamedConstant(sym) ||
+                     Fortran::semantics::IsCUDAShared(sym) &&
+                         "expect implied shape constant");
               shapes.push_back(fir::SequenceType::getUnknownExtent());
               continue;
             }

--- a/flang/include/flang/Semantics/tools.h
+++ b/flang/include/flang/Semantics/tools.h
@@ -222,6 +222,16 @@ inline bool HasCUDAAttr(const Symbol &sym) {
   return false;
 }
 
+inline bool IsCUDAShared(const Symbol &sym) {
+  if (const auto *details{sym.GetUltimate().detailsIf<ObjectEntityDetails>()}) {
+    if (details->cudaDataAttr() &&
+        *details->cudaDataAttr() == common::CUDADataAttr::Shared) {
+      return true;
+    }
+  }
+  return false;
+}
+
 inline bool NeedCUDAAlloc(const Symbol &sym) {
   if (IsDummy(sym)) {
     return false;

--- a/flang/test/Lower/CUDA/cuda-shared01.cuf
+++ b/flang/test/Lower/CUDA/cuda-shared01.cuf
@@ -1,0 +1,9 @@
+
+! RUN: bbc -emit-hlfir -fcuda %s -o - | FileCheck %s
+
+attributes(global) subroutine sharedstar()
+  real, shared :: s(*) ! ok. dynamic shared memory.
+end subroutine
+
+! CHECK-LABEL: func.func @_QPsharedstar()
+! CHECK: hlfir.declare %{{.*}}(%{{.*}}) {data_attr = #cuf.cuda<shared>, uniq_name = "_QFsharedstarEs"} : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>) -> (!fir.box<!fir.array<?xf32>>, !fir.ref<!fir.array<?xf32>>)


### PR DESCRIPTION
Avoid triggering an assertion for shared variable using the assumed-size syntax. 

```
attributes(global) subroutine sharedstar()
  real, shared :: s(*) ! ok. dynamic shared memory.
end subroutine
```