### PR TITLE
[Support] Do not remove lock file on failure

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1491,8 +1491,6 @@ static bool compileModuleAndReadASTBehindLock(
       // related errors.
       Diags.Report(ModuleNameLoc, diag::remark_module_lock_failure)
           << Module->Name << toString(std::move(Err));
-      // Clear out any potential leftover.
-      Lock.unsafeRemoveLockFile();
       return compileModuleAndReadASTImpl(ImportingInstance, ImportLoc,
                                          ModuleNameLoc, Module, ModuleFileName);
     }

--- a/llvm/lib/Target/AMDGPU/AMDGPUSplitModule.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSplitModule.cpp
@@ -1552,7 +1552,6 @@ PreservedAnalyses AMDGPUSplitModulePass::run(Module &M,
         LLVM_DEBUG(
             dbgs() << "[amdgpu-split-module] unable to acquire lockfile, debug "
                       "output may be mangled by other processes\n");
-        Lock.unsafeRemoveLockFile();
       } else if (!Owned) {
         switch (Lock.waitForUnlock()) {
         case LockFileManager::Res_Success:


### PR DESCRIPTION
Clients of `LockFileManager` call `unsafeRemoveLockFile()` whenever `tryLock()` fails. However looking at the code, there are no scenarios where this actually does something useful. This PR removes such calls.