### PR TITLE
[NVPTX][test] Use 'not' to switch an XFAIL test to PASS

### DIFF
--- a/llvm/test/CodeGen/NVPTX/gvar-init.ll
+++ b/llvm/test/CodeGen/NVPTX/gvar-init.ll
@@ -1,5 +1,5 @@
-; RUN: llc < %s -mtriple=nvptx -mcpu=sm_20 | FileCheck %s
+; RUN: not --crash llc < %s -mtriple=nvptx -mcpu=sm_20 2>&1 | FileCheck %s
 
 ; Error out if initializer is given for address spaces that do not support initializers
-; XFAIL: *
+; CHECK: LLVM ERROR: initial value of 'g0' is not allowed in addrspace(3)
 @g0 = addrspace(3) global i32 42


### PR DESCRIPTION
Use 'not' to confirm the test has the desired behavior and move it to passing.