### PR TITLE
Make breakpoint stop reason more accurate for function breakpoints

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -86,6 +86,7 @@ class DAPTestCaseBase(TestBase):
                 if (
                     body["reason"] != "breakpoint"
                     and body["reason"] != "instruction breakpoint"
+                    and body["reason"] != "function breakpoint"
                 ):
                     continue
                 if "description" not in body:
@@ -100,7 +101,7 @@ class DAPTestCaseBase(TestBase):
                 # location.
                 description = body["description"]
                 for breakpoint_id in breakpoint_ids:
-                    match_desc = "breakpoint %s." % (breakpoint_id)
+                    match_desc = "%s %s." % (body["reason"], breakpoint_id)
                     if match_desc in description:
                         return
         self.assertTrue(False, "breakpoint not hit")

--- a/lldb/test/API/tools/lldb-dap/databreakpoint/TestDAP_setDataBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/databreakpoint/TestDAP_setDataBreakpoints.py
@@ -174,7 +174,9 @@ class TestDAP_setDataBreakpoints(lldbdap_testcase.DAPTestCaseBase):
 
     @skipIfWindows
     def test_breakpoint_reason(self):
-        """Tests setting data breakpoints on variable. Verify that the breakpoint has the correct reason and description in the stopped event."""
+        """Tests setting data breakpoints on variable.
+        Verify that the breakpoint has the correct reason
+        and description in the stopped event."""
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)
         source = "main.cpp"
@@ -182,9 +184,9 @@ class TestDAP_setDataBreakpoints(lldbdap_testcase.DAPTestCaseBase):
         self.set_source_breakpoints(source, [first_loop_break_line])
         self.continue_to_next_stop()
         self.dap_server.get_local_variables()
-         # Test write watchpoints on x, arr[2]
+        # Test write watchpoints on x
         response_x = self.dap_server.request_dataBreakpointInfo(1, "x")
-                # Test response from dataBreakpointInfo request.
+        # Test response from dataBreakpointInfo request.
         self.assertEqual(response_x["body"]["dataId"].split("/")[1], "4")
         self.assertEqual(response_x["body"]["accessTypes"], self.accessTypes)
         dataBreakpoints = [

--- a/lldb/test/API/tools/lldb-dap/databreakpoint/TestDAP_setDataBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/databreakpoint/TestDAP_setDataBreakpoints.py
@@ -171,3 +171,35 @@ class TestDAP_setDataBreakpoints(lldbdap_testcase.DAPTestCaseBase):
         self.continue_to_next_stop()
         x_val = self.dap_server.get_local_variable_value("x")
         self.assertEqual(x_val, "10")
+
+    @skipIfWindows
+    def test_breakpoint_reason(self):
+        """Tests setting data breakpoints on variable. Verify that the breakpoint has the correct reason and description in the stopped event."""
+        program = self.getBuildArtifact("a.out")
+        self.build_and_launch(program)
+        source = "main.cpp"
+        first_loop_break_line = line_number(source, "// first loop breakpoint")
+        self.set_source_breakpoints(source, [first_loop_break_line])
+        self.continue_to_next_stop()
+        self.dap_server.get_local_variables()
+         # Test write watchpoints on x, arr[2]
+        response_x = self.dap_server.request_dataBreakpointInfo(1, "x")
+                # Test response from dataBreakpointInfo request.
+        self.assertEqual(response_x["body"]["dataId"].split("/")[1], "4")
+        self.assertEqual(response_x["body"]["accessTypes"], self.accessTypes)
+        dataBreakpoints = [
+            {"dataId": response_x["body"]["dataId"], "accessType": "write"},
+        ]
+        set_response = self.dap_server.request_setDataBreakpoint(dataBreakpoints)
+        self.assertEqual(
+            set_response["body"]["breakpoints"],
+            [{"verified": True}],
+        )
+
+        stopped_events = self.continue_to_next_stop()
+        self.assertEqual(len(stopped_events), 1)
+        stopped_event = stopped_events[0]
+        self.assertEqual(stopped_event["body"]["reason"], "data breakpoint")
+        self.assertEqual(stopped_event["body"]["description"], "data breakpoint 1.1")
+        x_val = self.dap_server.get_local_variable_value("x")
+        self.assertEqual(x_val, "2")

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -1014,34 +1014,6 @@ void DAP::SetThreadFormat(llvm::StringRef format) {
   }
 }
 
-InstructionBreakpoint *
-DAP::GetInstructionBreakpoint(const lldb::break_id_t bp_id) {
-  for (auto &bp : instruction_breakpoints) {
-    if (bp.second.bp.GetID() == bp_id)
-      return &bp.second;
-  }
-  return nullptr;
-}
-
-InstructionBreakpoint *
-DAP::GetInstructionBPFromStopReason(lldb::SBThread &thread) {
-  const auto num = thread.GetStopReasonDataCount();
-  InstructionBreakpoint *inst_bp = nullptr;
-  for (size_t i = 0; i < num; i += 2) {
-    // thread.GetStopReasonDataAtIndex(i) will return the bp ID and
-    // thread.GetStopReasonDataAtIndex(i+1) will return the location
-    // within that breakpoint. We only care about the bp ID so we can
-    // see if this is an instruction breakpoint that is getting hit.
-    lldb::break_id_t bp_id = thread.GetStopReasonDataAtIndex(i);
-    inst_bp = GetInstructionBreakpoint(bp_id);
-    // If any breakpoint is not an instruction breakpoint, then stop and
-    // report this as a normal breakpoint
-    if (inst_bp == nullptr)
-      return nullptr;
-  }
-  return inst_bp;
-}
-
 lldb::SBValueList *Variables::GetTopLevelScope(int64_t variablesReference) {
   switch (variablesReference) {
   case VARREF_LOCALS:

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -125,21 +125,21 @@ struct Variables {
 
 struct StartDebuggingRequestHandler : public lldb::SBCommandPluginInterface {
   DAP &dap;
-  explicit StartDebuggingRequestHandler(DAP &d) : dap(d){};
+  explicit StartDebuggingRequestHandler(DAP &d) : dap(d) {};
   bool DoExecute(lldb::SBDebugger debugger, char **command,
                  lldb::SBCommandReturnObject &result) override;
 };
 
 struct ReplModeRequestHandler : public lldb::SBCommandPluginInterface {
   DAP &dap;
-  explicit ReplModeRequestHandler(DAP &d) : dap(d){};
+  explicit ReplModeRequestHandler(DAP &d) : dap(d) {};
   bool DoExecute(lldb::SBDebugger debugger, char **command,
                  lldb::SBCommandReturnObject &result) override;
 };
 
 struct SendEventRequestHandler : public lldb::SBCommandPluginInterface {
   DAP &dap;
-  explicit SendEventRequestHandler(DAP &d) : dap(d){};
+  explicit SendEventRequestHandler(DAP &d) : dap(d) {};
   bool DoExecute(lldb::SBDebugger debugger, char **command,
                  lldb::SBCommandReturnObject &result) override;
 };

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -125,21 +125,21 @@ struct Variables {
 
 struct StartDebuggingRequestHandler : public lldb::SBCommandPluginInterface {
   DAP &dap;
-  explicit StartDebuggingRequestHandler(DAP &d) : dap(d) {};
+  explicit StartDebuggingRequestHandler(DAP &d) : dap(d){};
   bool DoExecute(lldb::SBDebugger debugger, char **command,
                  lldb::SBCommandReturnObject &result) override;
 };
 
 struct ReplModeRequestHandler : public lldb::SBCommandPluginInterface {
   DAP &dap;
-  explicit ReplModeRequestHandler(DAP &d) : dap(d) {};
+  explicit ReplModeRequestHandler(DAP &d) : dap(d){};
   bool DoExecute(lldb::SBDebugger debugger, char **command,
                  lldb::SBCommandReturnObject &result) override;
 };
 
 struct SendEventRequestHandler : public lldb::SBCommandPluginInterface {
   DAP &dap;
-  explicit SendEventRequestHandler(DAP &d) : dap(d) {};
+  explicit SendEventRequestHandler(DAP &d) : dap(d){};
   bool DoExecute(lldb::SBDebugger debugger, char **command,
                  lldb::SBCommandReturnObject &result) override;
 };
@@ -392,9 +392,11 @@ struct DAP {
 
   void SetThreadFormat(llvm::StringRef format);
 
-  InstructionBreakpoint *GetInstructionBreakpoint(const lldb::break_id_t bp_id);
-
-  InstructionBreakpoint *GetInstructionBPFromStopReason(lldb::SBThread &thread);
+private:
+  // Send the JSON in "json_str" to the "out" stream. Correctly send the
+  // "Content-Length:" field followed by the length, followed by the raw
+  // JSON bytes.
+  void SendJSON(const std::string &json_str);
 };
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Handler/ExceptionInfoRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/ExceptionInfoRequestHandler.cpp
@@ -123,7 +123,8 @@ void ExceptionInfoRequestHandler::operator()(
     if (stopReason == lldb::eStopReasonSignal)
       body.try_emplace("exceptionId", "signal");
     else if (stopReason == lldb::eStopReasonBreakpoint) {
-      ExceptionBreakpoint *exc_bp = dap.GetExceptionBPFromStopReason(thread);
+      ExceptionBreakpoint *exc_bp =
+          dap.GetBreakpointFromStopReason<ExceptionBreakpoint>(thread);
       if (exc_bp) {
         EmplaceSafeString(body, "exceptionId", exc_bp->filter);
         EmplaceSafeString(body, "description", exc_bp->label);


### PR DESCRIPTION
VSCode uses DAP protocol (https://microsoft.github.io/debug-adapter-protocol/specification) to lldb-dap for native debugging. For breakpoint, current lldb-dap implementation simply returns "breakpoint" stop reason for most breakpoints. 

However, DAP Stopped event (https://microsoft.github.io/debug-adapter-protocol/specification#Events_Stopped) actually supports more accurate breakpoint types such as '`function breakpoint`' | '`data breakpoint` which we did not leverage. 

This task aims to support showing function breakpoint and data breakpoint stop reason in VSCode.
 

Test Plan:
following tests already test the functionality for function and instruction breakpoints, 
- tools/lldb-dap/attach/TestDAP_attach.py : creates function breakpoints tests that they are hit.
- tools/lldb-dap/breakpoint/TestDAP_setFunctionBreakpoints.py also creates breakpoints tests that they are hit.
They test the reason and description in DAPTestCaseBase.`verify_breakpoint_hit` 

- For Data Break points (watch points) added a new testcase








