### PR TITLE
[llvm][lit] fix writing results to --time-trace-output file

### DIFF
--- a/llvm/utils/lit/lit/reports.py
+++ b/llvm/utils/lit/lit/reports.py
@@ -286,8 +286,7 @@ class TimeTraceReport(Report):
 
         json_data = {"traceEvents": events}
 
-        with open(self.output_file, "w") as time_trace_file:
-            json.dump(json_data, time_trace_file, indent=2, sort_keys=True)
+        json.dump(json_data, file, indent=2, sort_keys=True)
 
     def _get_test_event(self, test, first_start_time):
         test_name = test.getFullName()

--- a/llvm/utils/lit/lit/reports.py
+++ b/llvm/utils/lit/lit/reports.py
@@ -286,7 +286,8 @@ class TimeTraceReport(Report):
 
         json_data = {"traceEvents": events}
 
-        json.dump(json_data, time_trace_file, indent=2, sort_keys=True)
+        with open(self.output_file, "w") as time_trace_file:
+            json.dump(json_data, time_trace_file, indent=2, sort_keys=True)
 
     def _get_test_event(self, test, first_start_time):
         test_name = test.getFullName()


### PR DESCRIPTION
This patch fixes an issue introduced with commit:  https://github.com/llvm/llvm-project/commit/8507dbaec3f644b8a0c6291f097800d82a4f4b16
