### PR TITLE
[flang-rt] Use --as-needed for linking flang-rt libraries.

### DIFF
--- a/flang-rt/CMakeLists.txt
+++ b/flang-rt/CMakeLists.txt
@@ -246,9 +246,9 @@ check_cxx_compiler_flag("-UTESTFLAG" FLANG_RT_SUPPORTS_UNDEFINE_FLAG)
 check_cxx_compiler_flag(-fno-lto FLANG_RT_HAS_FNO_LTO_FLAG)
 
 # Check whether -Wl,--as-needed is supported.
-check_linker_flag(C "-Wl,--as-needed" LINKER_SUPPORTS_AS_NEEDED)
+check_linker_flag(C "LINKER:--as-needed" LINKER_SUPPORTS_AS_NEEDED)
 if (LINKER_SUPPORTS_AS_NEEDED)
-  set(LINKER_AS_NEEDED_OPT "-Wl,--as-needed")
+  set(LINKER_AS_NEEDED_OPT "LINKER:--as-needed")
 endif()
 
 # Different platform may have different name for the POSIX thread library.
@@ -299,6 +299,7 @@ elseif (FLANG_RT_GCC_RESOURCE_DIR)
     set(FLANG_RT_INCLUDE_QUADMATH_H "\"${FLANG_RT_GCC_RESOURCE_DIR}/include/quadmath.h\"")
   endif ()
 endif ()
+
 
 
 #####################

--- a/flang-rt/CMakeLists.txt
+++ b/flang-rt/CMakeLists.txt
@@ -245,6 +245,12 @@ check_cxx_compiler_flag("-UTESTFLAG" FLANG_RT_SUPPORTS_UNDEFINE_FLAG)
 # Check whether -fno-lto is supported.
 check_cxx_compiler_flag(-fno-lto FLANG_RT_HAS_FNO_LTO_FLAG)
 
+# Check whether -Wl,--as-needed is supported.
+check_linker_flag(C "-Wl,--as-needed" LINKER_SUPPORTS_AS_NEEDED)
+if (LINKER_SUPPORTS_AS_NEEDED)
+  set(LINKER_AS_NEEDED_OPT "-Wl,--as-needed")
+endif()
+
 # Different platform may have different name for the POSIX thread library.
 # For example, libpthread.a on AIX. Search for it as it is needed when
 # building the shared flang_rt.runtime.so.
@@ -293,7 +299,6 @@ elseif (FLANG_RT_GCC_RESOURCE_DIR)
     set(FLANG_RT_INCLUDE_QUADMATH_H "\"${FLANG_RT_GCC_RESOURCE_DIR}/include/quadmath.h\"")
   endif ()
 endif ()
-
 
 
 #####################

--- a/flang-rt/cmake/modules/AddFlangRT.cmake
+++ b/flang-rt/cmake/modules/AddFlangRT.cmake
@@ -145,6 +145,20 @@ function (add_flangrt_library name)
     if (Threads_FOUND) 
       target_link_libraries(${name_shared} PUBLIC Threads::Threads)
     endif ()
+
+    # Special dependencies handling for shared libraries only:
+    #
+    # flang-rt libraries must not depend on libc++/libstdc++,
+    # so set the linker language to C to avoid the unnecessary
+    # library dependence. Note that libc++/libstdc++ may still
+    # come through CMAKE_CXX_IMPLICIT_LINK_LIBRARIES.
+    set_target_properties(${name_shared} PROPERTIES LINKER_LANGUAGE C)
+    # Use --as-needed to avoid unnecessary dependencies.
+    if (LINKER_AS_NEEDED_OPT)
+      target_link_options(${name_shared} BEFORE PRIVATE
+        "${LINKER_AS_NEEDED_OPT}"
+        )
+    endif()
   endif ()
 
   if (libtargets)
@@ -186,17 +200,6 @@ function (add_flangrt_library name)
     else ()
       set_target_properties(${tgtname} PROPERTIES FOLDER "Flang-RT/Libraries")
     endif ()
-
-    # flang-rt libraries must not depend on libc++/libstdc++,
-    # so set the linker language to C to avoid the unnecessary
-    # library dependence. Note that libc++/libstdc++ may still
-    # come through CMAKE_CXX_IMPLICIT_LINK_LIBRARIES.
-    set_target_properties(${tgtname} PROPERTIES LINKER_LANGUAGE C)
-    # Use --as-needed to avoid unnecessary dependencies.
-    if (LINKER_AS_NEEDED_OPT)
-      set_property(TARGET ${tgtname} APPEND_STRING PROPERTY
-        LINK_FLAGS "${LINKER_AS_NEEDED_OPT}")
-    endif()
   endforeach ()
 
   # Define how to compile and link the library.

--- a/flang-rt/cmake/modules/AddFlangRT.cmake
+++ b/flang-rt/cmake/modules/AddFlangRT.cmake
@@ -186,6 +186,17 @@ function (add_flangrt_library name)
     else ()
       set_target_properties(${tgtname} PROPERTIES FOLDER "Flang-RT/Libraries")
     endif ()
+
+    # flang-rt libraries must not depend on libc++/libstdc++,
+    # so set the linker language to C to avoid the unnecessary
+    # library dependence. Note that libc++/libstdc++ may still
+    # come through CMAKE_CXX_IMPLICIT_LINK_LIBRARIES.
+    set_target_properties(${tgtname} PROPERTIES LINKER_LANGUAGE C)
+    # Use --as-needed to avoid unnecessary dependencies.
+    if (LINKER_AS_NEEDED_OPT)
+      set_property(TARGET ${tgtname} APPEND_STRING PROPERTY
+        LINK_FLAGS "${LINKER_AS_NEEDED_OPT}")
+    endif()
   endforeach ()
 
   # Define how to compile and link the library.


### PR DESCRIPTION
This change makes sure that there is no unnecessary library
dependencies like libc++/libstdc++.
