### PR TITLE
[LLD][COFF] Clarify EC vs. native symbols in diagnostics on ARM64X

### DIFF
--- a/lld/COFF/InputFiles.cpp
+++ b/lld/COFF/InputFiles.cpp
@@ -705,9 +705,9 @@ void ObjFile::handleComdatSelection(
   // seems better though.
   // (This behavior matches ModuleLinker::getComdatResult().)
   if (selection != leaderSelection) {
-    Log(ctx) << "conflicting comdat type for " << leader << ": "
-             << (int)leaderSelection << " in " << leader->getFile() << " and "
-             << (int)selection << " in " << this;
+    Log(ctx) << "conflicting comdat type for " << symtab.printSymbol(leader)
+             << ": " << (int)leaderSelection << " in " << leader->getFile()
+             << " and " << (int)selection << " in " << this;
     symtab.reportDuplicate(leader, this);
     return;
   }

--- a/lld/COFF/SymbolTable.h
+++ b/lld/COFF/SymbolTable.h
@@ -41,6 +41,8 @@ struct WrappedSymbol {
   Symbol *wrap;
 };
 
+struct UndefinedDiag;
+
 // SymbolTable is a bucket of all known symbols, including defined,
 // undefined, or lazy symbols (the last one is symbols in archive
 // files whose archive members are not yet loaded).
@@ -195,6 +197,8 @@ public:
   uint32_t loadConfigSize = 0;
   void initializeLoadConfig();
 
+  std::string printSymbol(Symbol *sym) const;
+
 private:
   /// Given a name without "__imp_" prefix, returns a defined symbol
   /// with the "__imp_" prefix, if it exists.
@@ -216,6 +220,7 @@ private:
   reportProblemSymbols(const llvm::SmallPtrSetImpl<Symbol *> &undefs,
                        const llvm::DenseMap<Symbol *, Symbol *> *localImports,
                        bool needBitcodeFiles);
+  void reportUndefinedSymbol(const UndefinedDiag &undefDiag);
 };
 
 std::vector<std::string> getSymbolLocations(ObjFile *file, uint32_t symIndex);

--- a/lld/COFF/Symbols.cpp
+++ b/lld/COFF/Symbols.cpp
@@ -60,10 +60,6 @@ coff::operator<<(const COFFSyncStream &s,
   return s;
 }
 
-const COFFSyncStream &coff::operator<<(const COFFSyncStream &s, Symbol *sym) {
-  return s << maybeDemangleSymbol(s.ctx, sym->getName());
-}
-
 namespace coff {
 
 void Symbol::computeName() {

--- a/lld/COFF/Symbols.h
+++ b/lld/COFF/Symbols.h
@@ -38,7 +38,6 @@ class SymbolTable;
 
 const COFFSyncStream &operator<<(const COFFSyncStream &,
                                  const llvm::object::Archive::Symbol *);
-const COFFSyncStream &operator<<(const COFFSyncStream &, Symbol *);
 
 // The base class for real symbol classes.
 class Symbol {

--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -1282,12 +1282,13 @@ void Writer::createImportTables() {
       ctx.config.dllOrder[dll] = ctx.config.dllOrder.size();
 
     if (file->impSym && !isa<DefinedImportData>(file->impSym))
-      Fatal(ctx) << file->impSym << " was replaced";
+      Fatal(ctx) << file->symtab.printSymbol(file->impSym) << " was replaced";
     DefinedImportData *impSym = cast_or_null<DefinedImportData>(file->impSym);
     if (ctx.config.delayLoads.count(StringRef(file->dllName).lower())) {
       if (!file->thunkSym)
         Fatal(ctx) << "cannot delay-load " << toString(file)
-                   << " due to import of data: " << impSym;
+                   << " due to import of data: "
+                   << file->symtab.printSymbol(impSym);
       delayIdata.add(impSym);
     } else {
       idata.add(impSym);
@@ -1306,7 +1307,8 @@ void Writer::appendImportThunks() {
 
     if (file->thunkSym) {
       if (!isa<DefinedImportThunk>(file->thunkSym))
-        Fatal(ctx) << file->thunkSym << " was replaced";
+        Fatal(ctx) << file->symtab.printSymbol(file->thunkSym)
+                   << " was replaced";
       auto *chunk = cast<DefinedImportThunk>(file->thunkSym)->getChunk();
       if (chunk->live)
         textSec->addChunk(chunk);
@@ -1314,7 +1316,8 @@ void Writer::appendImportThunks() {
 
     if (file->auxThunkSym) {
       if (!isa<DefinedImportThunk>(file->auxThunkSym))
-        Fatal(ctx) << file->auxThunkSym << " was replaced";
+        Fatal(ctx) << file->symtab.printSymbol(file->auxThunkSym)
+                   << " was replaced";
       auto *chunk = cast<DefinedImportThunk>(file->auxThunkSym)->getChunk();
       if (chunk->live)
         textSec->addChunk(chunk);

--- a/lld/test/COFF/arm64x-altnames.s
+++ b/lld/test/COFF/arm64x-altnames.s
@@ -12,7 +12,7 @@
 // RUN:              2>&1 | FileCheck --check-prefix=ERR-NATIVE %s
 
 // ERR-NATIVE-NOT:  test-arm64ec.obj
-// ERR-NATIVE:      lld-link: error: undefined symbol: sym
+// ERR-NATIVE:      lld-link: error: undefined symbol: sym (native symbol)
 // ERR-NATIVE-NEXT: >>> referenced by test-arm64.obj:(.test)
 // ERR-NATIVE-NOT:  test-arm64ec.obj
 
@@ -25,7 +25,7 @@
 // RUN:              2>&1 | FileCheck --check-prefix=ERR-EC %s
 
 // ERR-EC-NOT:  test-arm64.obj
-// ERR-EC:      lld-link: error: undefined symbol: sym
+// ERR-EC:      lld-link: error: undefined symbol: sym (EC symbol)
 // ERR-EC-NEXT: >>> referenced by test-arm64ec.obj:(.test)
 // ERR-EC-NOT:  test-arm64.obj
 

--- a/lld/test/COFF/arm64x-incl.s
+++ b/lld/test/COFF/arm64x-incl.s
@@ -40,14 +40,15 @@
 // Check that including a missing symbol results in an error.
 
 // RUN: not lld-link -machine:arm64x -out:err.dll -dll -noentry loadconfig-arm64.obj loadconfig-arm64ec.obj -include:sym sym-aarch64.obj \
-// RUN:              2>&1 | FileCheck --check-prefix=ERR %s
-// ERR: lld-link: error: <root>: undefined symbol: sym
+// RUN:              2>&1 | FileCheck --check-prefix=ERR-EC %s
+// ERR-EC: lld-link: error: <root>: undefined symbol: sym (EC symbol)
 
 // RUN: not lld-link -machine:arm64x -out:err.dll -dll -noentry loadconfig-arm64.obj loadconfig-arm64ec.obj drectve-arm64ec.obj sym-aarch64.obj \
-// RUN:              2>&1 | FileCheck --check-prefix=ERR %s
+// RUN:              2>&1 | FileCheck --check-prefix=ERR-EC %s
 
 // RUN: not lld-link -machine:arm64x -out:err.dll -dll -noentry loadconfig-arm64.obj loadconfig-arm64ec.obj drectve-aarch64.obj sym-arm64ec.obj \
-// RUN:              2>&1 | FileCheck --check-prefix=ERR %s
+// RUN:              2>&1 | FileCheck --check-prefix=ERR-NATIVE %s
+// ERR-NATIVE: lld-link: error: <root>: undefined symbol: sym (native symbol)
 
 #--- sym-aarch64.s
         .section ".test","dr"

--- a/lld/test/COFF/arm64x-symtab.s
+++ b/lld/test/COFF/arm64x-symtab.s
@@ -18,19 +18,19 @@
 
 // RUN: not lld-link -machine:arm64x -dll -noentry -out:err1.dll symref-aarch64.obj sym-arm64ec.obj \
 // RUN:              2>&1 | FileCheck --check-prefix=UNDEF %s
-// UNDEF:      lld-link: error: undefined symbol: sym
+// UNDEF:      lld-link: error: undefined symbol: sym (native symbol)
 // UNDEF-NEXT: >>> referenced by symref-aarch64.obj:(.data)
 
 // Check that EC object files can't reference native symbols.
 
 // RUN: not lld-link -machine:arm64x -dll -noentry -out:out.dll symref-arm64ec.obj sym-aarch64.obj \
 // RUN:              2>&1 | FileCheck --check-prefix=UNDEFEC %s
-// UNDEFEC:      lld-link: error: undefined symbol: sym
+// UNDEFEC:      lld-link: error: undefined symbol: sym (EC symbol)
 // UNDEFEC-NEXT: >>> referenced by symref-arm64ec.obj:(.data)
 
 // RUN: not lld-link -machine:arm64x -dll -noentry -out:out.dll symref-x86_64.obj sym-aarch64.obj \
 // RUN:              2>&1 | FileCheck --check-prefix=UNDEFX86 %s
-// UNDEFX86:      lld-link: error: undefined symbol: sym
+// UNDEFX86:      lld-link: error: undefined symbol: sym (EC symbol)
 // UNDEFX86-NEXT: >>> referenced by symref-x86_64.obj:(.data)
 
 // RUN: not lld-link -machine:arm64x -dll -noentry -out:err2.dll symref-aarch64.obj sym-x86_64.obj \

--- a/lld/test/COFF/locally-imported-arm64x.s
+++ b/lld/test/COFF/locally-imported-arm64x.s
@@ -4,8 +4,8 @@
 // RUN: llvm-mc -filetype=obj -triple=arm64ec-windows %s -o %t.arm64ec.obj
 
 // RUN: lld-link -machine:arm64x -dll -noentry %t.arm64.obj %t.arm64ec.obj -out:%t.dll 2>&1 | FileCheck --check-prefix=WARN %s
-// WARN:      lld-link: warning: {{.*}}.arm64.obj: locally defined symbol imported: func
-// WARN-NEXT: lld-link: warning: {{.*}}.arm64ec.obj: locally defined symbol imported: func
+// WARN:      lld-link: warning: {{.*}}.arm64.obj: locally defined symbol imported: func (native symbol)
+// WARN-NEXT: lld-link: warning: {{.*}}.arm64ec.obj: locally defined symbol imported: func (EC symbol)
 
 // RUN: llvm-readobj --hex-dump=.test %t.dll | FileCheck --check-prefix=TEST %s
 // TEST: 0x180005000 00300000 08300000


### PR DESCRIPTION
On ARM64X, symbol names alone are ambiguous as they may refer to either a native or an EC symbol. Append '(EC symbol)' or '(native symbol)' in diagnostic messages to distinguish them.