### PR TITLE
[AMDGPU] Change placeholder from `undef` to `poison`

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp
@@ -1620,7 +1620,7 @@ void SplitPtrStructs::killAndReplaceSplitInstructions(
         Dbg->setExpression(*RsrcExpr);
         Dbg->replaceVariableLocationOp(I, Rsrc);
       } else {
-        Dbg->replaceVariableLocationOp(I, UndefValue::get(I->getType()));
+        Dbg->replaceVariableLocationOp(I, PoisonValue::get(I->getType()));
       }
     }
 


### PR DESCRIPTION
Replace `undef` debug info with `poison`.