### PR TITLE
[CIR] Add transform test for cir-flatten-cfg

### DIFF
--- a/clang/test/CIR/Transforms/scope.cir
+++ b/clang/test/CIR/Transforms/scope.cir
@@ -1,0 +1,58 @@
+// RUN: cir-opt %s -cir-flatten-cfg -o - | FileCheck %s
+
+module {
+  cir.func @foo() {
+    cir.scope {
+      %0 = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["a", init] {alignment = 4 : i64}
+      %1 = cir.const #cir.int<4> : !cir.int<u, 32>
+      cir.store %1, %0 : !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>
+    }
+    cir.return
+  }
+// CHECK:  cir.func @foo() {
+// CHECK:    cir.br ^bb1
+// CHECK:  ^bb1:  // pred: ^bb0
+// CHECK:    %0 = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["a", init] {alignment = 4 : i64}
+// CHECK:    %1 = cir.const #cir.int<4> : !cir.int<u, 32>
+// CHECK:    cir.store %1, %0 : !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>
+// CHECK:    cir.br ^bb2
+// CHECK:  ^bb2:  // pred: ^bb1
+// CHECK:    cir.return
+// CHECK:  }
+
+  // Should drop empty scopes.
+  cir.func @empty_scope() {
+    cir.scope {
+    }
+    cir.return
+  }
+// CHECK:  cir.func @empty_scope() {
+// CHECK:    cir.return
+// CHECK:  }
+
+  cir.func @scope_with_return() -> !cir.int<u, 32> {
+    %0 = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["__retval"] {alignment = 4 : i64}
+    cir.scope {
+      %2 = cir.const #cir.int<0> : !cir.int<u, 32>
+      cir.store %2, %0 : !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>
+      %3 = cir.load %0 : !cir.ptr<!cir.int<u, 32>>, !cir.int<u, 32>
+      cir.return %3 : !cir.int<u, 32>
+    }
+    %1 = cir.load %0 : !cir.ptr<!cir.int<u, 32>>, !cir.int<u, 32>
+    cir.return %1 : !cir.int<u, 32>
+  }
+
+// CHECK:  cir.func @scope_with_return() -> !cir.int<u, 32> {
+// CHECK:    %0 = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["__retval"] {alignment = 4 : i64}
+// CHECK:    cir.br ^bb1
+// CHECK:  ^bb1:  // pred: ^bb0
+// CHECK:    %1 = cir.const #cir.int<0> : !cir.int<u, 32>
+// CHECK:    cir.store %1, %0 : !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>
+// CHECK:    %2 = cir.load %0 : !cir.ptr<!cir.int<u, 32>>, !cir.int<u, 32>
+// CHECK:    cir.return %2 : !cir.int<u, 32>
+// CHECK:  ^bb2:  // no predecessors
+// CHECK:    %3 = cir.load %0 : !cir.ptr<!cir.int<u, 32>>, !cir.int<u, 32>
+// CHECK:    cir.return %3 : !cir.int<u, 32>
+// CHECK:  }
+
+}

--- a/clang/tools/cir-opt/CMakeLists.txt
+++ b/clang/tools/cir-opt/CMakeLists.txt
@@ -24,6 +24,7 @@ clang_target_link_libraries(cir-opt
   clangCIR
   clangCIRLoweringDirectToLLVM
   MLIRCIR
+  MLIRCIRTransforms
 )
 
 target_link_libraries(cir-opt

--- a/clang/tools/cir-opt/cir-opt.cpp
+++ b/clang/tools/cir-opt/cir-opt.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/Passes.h"
 #include "clang/CIR/Passes.h"
 
 struct CIRToLLVMPipelineOptions
@@ -38,6 +39,10 @@ int main(int argc, char **argv) {
       [](mlir::OpPassManager &pm, const CIRToLLVMPipelineOptions &options) {
         cir::direct::populateCIRToLLVMPasses(pm);
       });
+
+  ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return mlir::createCIRFlattenCFGPass();
+  });
 
   mlir::registerTransformsPasses();
 


### PR DESCRIPTION
A previous change added the cir-flatten-cfg transform and tested it by lowering a function with nested scopes to LLVM IR. This change adds support for invoking the cir-flatten-cfg pass from the cir-opt tool and adds a new test to verify that functionality in isolation.