### PR TITLE
[libclc] Skip opt command if opt_flags is empty

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -342,7 +342,7 @@ function(add_libclc_builtin_set)
 
   set( builtins_opt_lib_tgt builtins.opt.${ARG_ARCH_SUFFIX} )
 
-  if( ${ARG_OPT_FLAGS} STREQUAL "" )
+  if( NOT ARG_OPT_FLAGS )
     # Add empty opt target.
     add_custom_target( ${builtins_opt_lib_tgt} ALL )
     add_dependencies( ${builtins_opt_lib_tgt} ${builtins_link_lib_tgt} )

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -340,6 +340,7 @@ function(add_libclc_builtin_set)
     return()
   endif()
 
+  # Add opt target. It is empty if ARG_OPT_FLAGS is empty.
   set( builtins_opt_lib_tgt builtins.opt.${ARG_ARCH_SUFFIX} )
   add_custom_target( ${builtins_opt_lib_tgt} ALL )
   set_target_properties( ${builtins_opt_lib_tgt} PROPERTIES
@@ -347,7 +348,6 @@ function(add_libclc_builtin_set)
   )
   add_dependencies( ${builtins_opt_lib_tgt} ${builtins_link_lib_tgt} )
 
-  # Add opt target
   if( ${ARG_OPT_FLAGS} STREQUAL "" )
     # no-op
     set( builtins_opt_lib ${builtins_link_lib} )

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -345,9 +345,6 @@ function(add_libclc_builtin_set)
   if( ${ARG_OPT_FLAGS} STREQUAL "" )
     # Add empty opt target.
     add_custom_target( ${builtins_opt_lib_tgt} ALL )
-    set_target_properties( ${builtins_opt_lib_tgt} PROPERTIES
-      FOLDER "libclc/Device IR/Opt"
-    )
     add_dependencies( ${builtins_opt_lib_tgt} ${builtins_link_lib_tgt} )
 
     set( builtins_opt_lib ${builtins_link_lib} )
@@ -363,11 +360,13 @@ function(add_libclc_builtin_set)
     )
     set_target_properties( ${builtins_opt_lib_tgt} PROPERTIES
       TARGET_FILE ${CMAKE_CURRENT_BINARY_DIR}/${builtins_opt_lib_tgt}.bc
-      FOLDER "libclc/Device IR/Opt"
     )
 
     set( builtins_opt_lib $<TARGET_PROPERTY:${builtins_opt_lib_tgt},TARGET_FILE> )
   endif()
+  set_target_properties( ${builtins_opt_lib_tgt} PROPERTIES
+    FOLDER "libclc/Device IR/Opt"
+  )
 
   # Add prepare target
   set( obj_suffix ${ARG_ARCH_SUFFIX}.bc )

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -340,27 +340,32 @@ function(add_libclc_builtin_set)
     return()
   endif()
 
-  # Add opt target. It is empty if ARG_OPT_FLAGS is empty.
   set( builtins_opt_lib_tgt builtins.opt.${ARG_ARCH_SUFFIX} )
-  add_custom_target( ${builtins_opt_lib_tgt} ALL )
-  set_target_properties( ${builtins_opt_lib_tgt} PROPERTIES
-    FOLDER "libclc/Device IR/Opt"
-  )
-  add_dependencies( ${builtins_opt_lib_tgt} ${builtins_link_lib_tgt} )
 
   if( ${ARG_OPT_FLAGS} STREQUAL "" )
-    # no-op
+    # Add empty opt target.
+    add_custom_target( ${builtins_opt_lib_tgt} ALL )
+    set_target_properties( ${builtins_opt_lib_tgt} PROPERTIES
+      FOLDER "libclc/Device IR/Opt"
+    )
+    add_dependencies( ${builtins_opt_lib_tgt} ${builtins_link_lib_tgt} )
+
     set( builtins_opt_lib ${builtins_link_lib} )
   else()
+    # Add opt target
     add_custom_command( OUTPUT ${builtins_opt_lib_tgt}.bc
       COMMAND ${opt_exe} ${ARG_OPT_FLAGS} -o ${builtins_opt_lib_tgt}.bc
         ${builtins_link_lib}
       DEPENDS ${opt_target} ${builtins_link_lib} ${builtins_link_lib_tgt}
     )
+    add_custom_target( ${builtins_opt_lib_tgt}
+      ALL DEPENDS ${builtins_opt_lib_tgt}.bc
+    )
     set_target_properties( ${builtins_opt_lib_tgt} PROPERTIES
       TARGET_FILE ${CMAKE_CURRENT_BINARY_DIR}/${builtins_opt_lib_tgt}.bc
-      DEPENDS ${builtins_opt_lib_tgt}.bc
+      FOLDER "libclc/Device IR/Opt"
     )
+
     set( builtins_opt_lib $<TARGET_PROPERTY:${builtins_opt_lib_tgt},TARGET_FILE> )
   endif()
 

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -340,29 +340,37 @@ function(add_libclc_builtin_set)
     return()
   endif()
 
-  set( builtins_opt_lib_tgt builtins.opt.${ARG_ARCH_SUFFIX} )
+  if( ${ARG_OPT_FLAGS} )
+    set( builtins_opt_lib_tgt builtins.opt.${ARG_ARCH_SUFFIX} )
 
-  # Add opt target
-  add_custom_command( OUTPUT ${builtins_opt_lib_tgt}.bc
-    COMMAND ${opt_exe} ${ARG_OPT_FLAGS} -o ${builtins_opt_lib_tgt}.bc
-      ${builtins_link_lib}
-    DEPENDS ${opt_target} ${builtins_link_lib} ${builtins_link_lib_tgt}
-  )
-  add_custom_target( ${builtins_opt_lib_tgt}
-    ALL DEPENDS ${builtins_opt_lib_tgt}.bc
-  )
-  set_target_properties( ${builtins_opt_lib_tgt} PROPERTIES
-    TARGET_FILE ${CMAKE_CURRENT_BINARY_DIR}/${builtins_opt_lib_tgt}.bc
-    FOLDER "libclc/Device IR/Opt"
-  )
+    # Add opt target
+    add_custom_command( OUTPUT ${builtins_opt_lib_tgt}.bc
+      COMMAND ${opt_exe} ${ARG_OPT_FLAGS} -o ${builtins_opt_lib_tgt}.bc
+        ${builtins_link_lib}
+      DEPENDS ${opt_target} ${builtins_link_lib} ${builtins_link_lib_tgt}
+    )
+    add_custom_target( ${builtins_opt_lib_tgt}
+      ALL DEPENDS ${builtins_opt_lib_tgt}.bc
+    )
+    set_target_properties( ${builtins_opt_lib_tgt} PROPERTIES
+      TARGET_FILE ${CMAKE_CURRENT_BINARY_DIR}/${builtins_opt_lib_tgt}.bc
+      FOLDER "libclc/Device IR/Opt"
+    )
 
-  set( builtins_opt_lib $<TARGET_PROPERTY:${builtins_opt_lib_tgt},TARGET_FILE> )
+    set( builtins_opt_lib $<TARGET_PROPERTY:${builtins_opt_lib_tgt},TARGET_FILE> )
+
+    set( builtins_link_opt_lib ${builtins_opt_lib} )
+    set( builtins_link_opt_lib_tgt ${builtins_opt_lib_tgt} )
+  else()
+    set( builtins_link_opt_lib ${builtins_link_lib} )
+    set( builtins_link_opt_lib_tgt ${builtins_link_lib_tgt} )
+  endif()
 
   # Add prepare target
   set( obj_suffix ${ARG_ARCH_SUFFIX}.bc )
   add_custom_command( OUTPUT ${obj_suffix}
-    COMMAND ${prepare_builtins_exe} -o ${obj_suffix} ${builtins_opt_lib}
-    DEPENDS ${builtins_opt_lib} ${builtins_opt_lib_tgt} ${prepare_builtins_target} )
+    COMMAND ${prepare_builtins_exe} -o ${obj_suffix} ${builtins_link_opt_lib}
+    DEPENDS ${builtins_link_opt_lib} ${builtins_link_opt_lib_tgt} ${prepare_builtins_target} )
   add_custom_target( prepare-${obj_suffix} ALL DEPENDS ${obj_suffix} )
   set_target_properties( "prepare-${obj_suffix}" PROPERTIES FOLDER "libclc/Device IR/Prepare" )
 


### PR DESCRIPTION
When the flag is empty, the opt command probably won't modify the bitcode; however, the command is slow for large bitcode files in debug mode.