### PR TITLE
[RISCV][MC] Correct the register state update for auipc

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
@@ -195,7 +195,7 @@ public:
     }
     case RISCV::AUIPC:
       setGPRState(Inst.getOperand(0).getReg(),
-                  Addr + (Inst.getOperand(1).getImm() << 12));
+                  Addr + ((int32_t)Inst.getOperand(1).getImm() << 12));
       break;
     }
   }

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
@@ -195,7 +195,7 @@ public:
     }
     case RISCV::AUIPC:
       setGPRState(Inst.getOperand(0).getReg(),
-                  Addr + ((int32_t)Inst.getOperand(1).getImm() << 12));
+                  Addr + SignExtend64<32>(Inst.getOperand(1).getImm() << 12));
       break;
     }
   }

--- a/llvm/test/tools/llvm-objdump/ELF/RISCV/branches.s
+++ b/llvm/test/tools/llvm-objdump/ELF/RISCV/branches.s
@@ -78,3 +78,9 @@ nop
 bar:
 # CHECK: 60: c.nop
 nop
+
+# CHECK-LABEL: 00011000 <far>:
+.org 0x11000
+far:
+# CHECK: jalr ra, 0x0(ra) <foo>
+call foo


### PR DESCRIPTION
AUIPC is a 20-bits value which is used to form 32-bits offset thus it should be a int32 value, then signed-extend to int64.