### PR TITLE
AMDGPU: Replace ptr addrspace(1) undefs with poison

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/amdgpu-irtranslator.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/amdgpu-irtranslator.ll
@@ -8,6 +8,6 @@
 ; CHECK: {{%[0-9]+}}:_(s32) = G_ADD
 define amdgpu_kernel void @addi32(i32 %arg1, i32 %arg2) {
   %res = add i32 %arg1, %arg2
-  store i32 %res, ptr addrspace(1) undef
+  store i32 %res, ptr addrspace(1) poison
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/bool-legalization.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/bool-legalization.ll
@@ -102,11 +102,11 @@ entry:
   br i1 %trunc, label %bb0, label %bb1
 
 bb0:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   unreachable
 
 bb1:
-  store volatile i32 1, ptr addrspace(1) undef
+  store volatile i32 1, ptr addrspace(1) poison
   unreachable
 }
 
@@ -153,10 +153,10 @@ entry:
   br i1 %and, label %bb0, label %bb1
 
 bb0:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   unreachable
 
 bb1:
-  store volatile i32 1, ptr addrspace(1) undef
+  store volatile i32 1, ptr addrspace(1) poison
   unreachable
 }

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/cvt_f32_ubyte.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/cvt_f32_ubyte.ll
@@ -96,7 +96,7 @@ define float @v_uitofp_to_f32_multi_use_lshr8_mask255(i32 %arg0) nounwind {
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    s_setpc_b64 s[30:31]
   %lshr.8 = lshr i32 %arg0, 8
-  store i32 %lshr.8, ptr addrspace(1) undef
+  store i32 %lshr.8, ptr addrspace(1) poison
   %masked = and i32 %lshr.8, 255
   %cvt = uitofp i32 %masked to float
   ret float %cvt

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/divergent-control-flow.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/divergent-control-flow.ll
@@ -22,7 +22,7 @@ entry:
   br i1 %c, label %if.true, label %endif
 
 if.true:
-  %val = load volatile i32, ptr addrspace(1) undef
+  %val = load volatile i32, ptr addrspace(1) poison
   br label %endif
 
 endif:
@@ -53,7 +53,7 @@ endif:
   ret i32 %v
 
 if.true:
-  %val = load volatile i32, ptr addrspace(1) undef
+  %val = load volatile i32, ptr addrspace(1) poison
   br label %endif
 }
 
@@ -78,7 +78,7 @@ entry:
   br i1 %c, label %if.true, label %endif
 
 if.true:
-  %val = load volatile i32, ptr addrspace(1) undef
+  %val = load volatile i32, ptr addrspace(1) poison
   br label %endif
 
 endif:
@@ -110,7 +110,7 @@ entry:
   br i1 %c, label %if.true, label %endif
 
 if.true:
-  %val = load volatile i32, ptr addrspace(1) undef
+  %val = load volatile i32, ptr addrspace(1) poison
   br label %endif
 
 endif:
@@ -237,7 +237,7 @@ bb1:
   br i1 %cmp0, label %bb4, label %bb9
 
 bb4:
-  %load = load volatile i32, ptr addrspace(1) undef, align 4
+  %load = load volatile i32, ptr addrspace(1) poison, align 4
   %cmp1 = icmp slt i32 %tmp, %load
   br i1 %cmp1, label %bb1, label %bb9
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/extractelement.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/extractelement.ll
@@ -483,7 +483,7 @@ define amdgpu_ps void @dyn_extract_v8i64_const_s_s(i32 inreg %sel) {
 ; GFX11-NEXT:    s_endpgm
 entry:
   %ext = extractelement <8 x i64> <i64 1, i64 2, i64 3, i64 4, i64 5, i64 6, i64 7, i64 8>, i32 %sel
-  store i64 %ext, ptr addrspace(1) undef
+  store i64 %ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -628,7 +628,7 @@ define amdgpu_ps void @dyn_extract_v8i64_s_v(<8 x i64> inreg %vec, i32 %sel) {
 ; GFX11-NEXT:    s_endpgm
 entry:
   %ext = extractelement <8 x i64> %vec, i32 %sel
-  store i64 %ext, ptr addrspace(1) undef
+  store i64 %ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -744,7 +744,7 @@ define amdgpu_ps void @dyn_extract_v8i64_v_s(<8 x i64> %vec, i32 inreg %sel) {
 ; GFX11-NEXT:    s_endpgm
 entry:
   %ext = extractelement <8 x i64> %vec, i32 %sel
-  store i64 %ext, ptr addrspace(1) undef
+  store i64 %ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -849,7 +849,7 @@ define amdgpu_ps void @dyn_extract_v8i64_s_s(<8 x i64> inreg %vec, i32 inreg %se
 ; GFX11-NEXT:    s_endpgm
 entry:
   %ext = extractelement <8 x i64> %vec, i32 %sel
-  store i64 %ext, ptr addrspace(1) undef
+  store i64 %ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -1800,7 +1800,7 @@ define amdgpu_ps void @dyn_extract_v8p1_s_s(<8 x ptr addrspace(1)> inreg %vec, i
 ; GFX11-NEXT:    s_endpgm
 entry:
   %ext = extractelement <8 x ptr addrspace(1)> %vec, i32 %idx
-  store ptr addrspace(1) %ext, ptr addrspace(1) undef
+  store ptr addrspace(1) %ext, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/function-returns.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/function-returns.ll
@@ -7,11 +7,11 @@ define i1 @i1_func_void() #0 {
   ; CHECK-LABEL: name: i1_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s1) = G_LOAD [[DEF]](p1) :: (load (s1) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s1) = G_LOAD [[DEF]](p1) :: (load (s1) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[LOAD]](s1)
   ; CHECK-NEXT:   $vgpr0 = COPY [[ANYEXT]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load i1, ptr addrspace(1) undef
+  %val = load i1, ptr addrspace(1) poison
   ret i1 %val
 }
 
@@ -19,11 +19,11 @@ define zeroext i1 @i1_zeroext_func_void() #0 {
   ; CHECK-LABEL: name: i1_zeroext_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s1) = G_LOAD [[DEF]](p1) :: (load (s1) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s1) = G_LOAD [[DEF]](p1) :: (load (s1) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[ZEXT:%[0-9]+]]:_(s32) = G_ZEXT [[LOAD]](s1)
   ; CHECK-NEXT:   $vgpr0 = COPY [[ZEXT]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load i1, ptr addrspace(1) undef
+  %val = load i1, ptr addrspace(1) poison
   ret i1 %val
 }
 
@@ -31,11 +31,11 @@ define signext i1 @i1_signext_func_void() #0 {
   ; CHECK-LABEL: name: i1_signext_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s1) = G_LOAD [[DEF]](p1) :: (load (s1) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s1) = G_LOAD [[DEF]](p1) :: (load (s1) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[SEXT:%[0-9]+]]:_(s32) = G_SEXT [[LOAD]](s1)
   ; CHECK-NEXT:   $vgpr0 = COPY [[SEXT]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load i1, ptr addrspace(1) undef
+  %val = load i1, ptr addrspace(1) poison
   ret i1 %val
 }
 
@@ -43,11 +43,11 @@ define i7 @i7_func_void() #0 {
   ; CHECK-LABEL: name: i7_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s7) = G_LOAD [[DEF]](p1) :: (load (s7) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s7) = G_LOAD [[DEF]](p1) :: (load (s7) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[LOAD]](s7)
   ; CHECK-NEXT:   $vgpr0 = COPY [[ANYEXT]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load i7, ptr addrspace(1) undef
+  %val = load i7, ptr addrspace(1) poison
   ret i7 %val
 }
 
@@ -55,11 +55,11 @@ define zeroext i7 @i7_zeroext_func_void() #0 {
   ; CHECK-LABEL: name: i7_zeroext_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s7) = G_LOAD [[DEF]](p1) :: (load (s7) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s7) = G_LOAD [[DEF]](p1) :: (load (s7) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[ZEXT:%[0-9]+]]:_(s32) = G_ZEXT [[LOAD]](s7)
   ; CHECK-NEXT:   $vgpr0 = COPY [[ZEXT]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load i7, ptr addrspace(1) undef
+  %val = load i7, ptr addrspace(1) poison
   ret i7 %val
 }
 
@@ -67,11 +67,11 @@ define signext i7 @i7_signext_func_void() #0 {
   ; CHECK-LABEL: name: i7_signext_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s7) = G_LOAD [[DEF]](p1) :: (load (s7) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s7) = G_LOAD [[DEF]](p1) :: (load (s7) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[SEXT:%[0-9]+]]:_(s32) = G_SEXT [[LOAD]](s7)
   ; CHECK-NEXT:   $vgpr0 = COPY [[SEXT]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load i7, ptr addrspace(1) undef
+  %val = load i7, ptr addrspace(1) poison
   ret i7 %val
 }
 
@@ -79,11 +79,11 @@ define i8 @i8_func_void() #0 {
   ; CHECK-LABEL: name: i8_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[DEF]](p1) :: (load (s8) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[DEF]](p1) :: (load (s8) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[LOAD]](s8)
   ; CHECK-NEXT:   $vgpr0 = COPY [[ANYEXT]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load i8, ptr addrspace(1) undef
+  %val = load i8, ptr addrspace(1) poison
   ret i8 %val
 }
 
@@ -91,11 +91,11 @@ define zeroext i8 @i8_zeroext_func_void() #0 {
   ; CHECK-LABEL: name: i8_zeroext_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[DEF]](p1) :: (load (s8) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[DEF]](p1) :: (load (s8) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[ZEXT:%[0-9]+]]:_(s32) = G_ZEXT [[LOAD]](s8)
   ; CHECK-NEXT:   $vgpr0 = COPY [[ZEXT]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load i8, ptr addrspace(1) undef
+  %val = load i8, ptr addrspace(1) poison
   ret i8 %val
 }
 
@@ -103,11 +103,11 @@ define signext i8 @i8_signext_func_void() #0 {
   ; CHECK-LABEL: name: i8_signext_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[DEF]](p1) :: (load (s8) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[DEF]](p1) :: (load (s8) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[SEXT:%[0-9]+]]:_(s32) = G_SEXT [[LOAD]](s8)
   ; CHECK-NEXT:   $vgpr0 = COPY [[SEXT]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load i8, ptr addrspace(1) undef
+  %val = load i8, ptr addrspace(1) poison
   ret i8 %val
 }
 
@@ -115,11 +115,11 @@ define i16 @i16_func_void() #0 {
   ; CHECK-LABEL: name: i16_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s16) = G_LOAD [[DEF]](p1) :: (load (s16) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s16) = G_LOAD [[DEF]](p1) :: (load (s16) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[LOAD]](s16)
   ; CHECK-NEXT:   $vgpr0 = COPY [[ANYEXT]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load i16, ptr addrspace(1) undef
+  %val = load i16, ptr addrspace(1) poison
   ret i16 %val
 }
 
@@ -127,11 +127,11 @@ define zeroext i16 @i16_zeroext_func_void() #0 {
   ; CHECK-LABEL: name: i16_zeroext_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s16) = G_LOAD [[DEF]](p1) :: (load (s16) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s16) = G_LOAD [[DEF]](p1) :: (load (s16) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[ZEXT:%[0-9]+]]:_(s32) = G_ZEXT [[LOAD]](s16)
   ; CHECK-NEXT:   $vgpr0 = COPY [[ZEXT]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load i16, ptr addrspace(1) undef
+  %val = load i16, ptr addrspace(1) poison
   ret i16 %val
 }
 
@@ -139,11 +139,11 @@ define signext i16 @i16_signext_func_void() #0 {
   ; CHECK-LABEL: name: i16_signext_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s16) = G_LOAD [[DEF]](p1) :: (load (s16) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s16) = G_LOAD [[DEF]](p1) :: (load (s16) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[SEXT:%[0-9]+]]:_(s32) = G_SEXT [[LOAD]](s16)
   ; CHECK-NEXT:   $vgpr0 = COPY [[SEXT]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load i16, ptr addrspace(1) undef
+  %val = load i16, ptr addrspace(1) poison
   ret i16 %val
 }
 
@@ -151,11 +151,11 @@ define half @f16_func_void() #0 {
   ; CHECK-LABEL: name: f16_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s16) = G_LOAD [[DEF]](p1) :: (load (s16) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s16) = G_LOAD [[DEF]](p1) :: (load (s16) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[LOAD]](s16)
   ; CHECK-NEXT:   $vgpr0 = COPY [[ANYEXT]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load half, ptr addrspace(1) undef
+  %val = load half, ptr addrspace(1) poison
   ret half %val
 }
 
@@ -163,11 +163,11 @@ define i24 @i24_func_void() #0 {
   ; CHECK-LABEL: name: i24_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s24) = G_LOAD [[DEF]](p1) :: (load (s24) from `ptr addrspace(1) undef`, align 4, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s24) = G_LOAD [[DEF]](p1) :: (load (s24) from `ptr addrspace(1) poison`, align 4, addrspace 1)
   ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[LOAD]](s24)
   ; CHECK-NEXT:   $vgpr0 = COPY [[ANYEXT]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load i24, ptr addrspace(1) undef
+  %val = load i24, ptr addrspace(1) poison
   ret i24 %val
 }
 
@@ -175,11 +175,11 @@ define zeroext i24 @i24_zeroext_func_void() #0 {
   ; CHECK-LABEL: name: i24_zeroext_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s24) = G_LOAD [[DEF]](p1) :: (load (s24) from `ptr addrspace(1) undef`, align 4, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s24) = G_LOAD [[DEF]](p1) :: (load (s24) from `ptr addrspace(1) poison`, align 4, addrspace 1)
   ; CHECK-NEXT:   [[ZEXT:%[0-9]+]]:_(s32) = G_ZEXT [[LOAD]](s24)
   ; CHECK-NEXT:   $vgpr0 = COPY [[ZEXT]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load i24, ptr addrspace(1) undef
+  %val = load i24, ptr addrspace(1) poison
   ret i24 %val
 }
 
@@ -187,11 +187,11 @@ define signext i24 @i24_signext_func_void() #0 {
   ; CHECK-LABEL: name: i24_signext_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s24) = G_LOAD [[DEF]](p1) :: (load (s24) from `ptr addrspace(1) undef`, align 4, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s24) = G_LOAD [[DEF]](p1) :: (load (s24) from `ptr addrspace(1) poison`, align 4, addrspace 1)
   ; CHECK-NEXT:   [[SEXT:%[0-9]+]]:_(s32) = G_SEXT [[LOAD]](s24)
   ; CHECK-NEXT:   $vgpr0 = COPY [[SEXT]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load i24, ptr addrspace(1) undef
+  %val = load i24, ptr addrspace(1) poison
   ret i24 %val
 }
 
@@ -199,14 +199,14 @@ define <2 x i24> @v2i24_func_void() #0 {
   ; CHECK-LABEL: name: v2i24_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s24>) = G_LOAD [[DEF]](p1) :: (load (<2 x s24>) from `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s24>) = G_LOAD [[DEF]](p1) :: (load (<2 x s24>) from `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s24), [[UV1:%[0-9]+]]:_(s24) = G_UNMERGE_VALUES [[LOAD]](<2 x s24>)
   ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[UV]](s24)
   ; CHECK-NEXT:   [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[UV1]](s24)
   ; CHECK-NEXT:   $vgpr0 = COPY [[ANYEXT]](s32)
   ; CHECK-NEXT:   $vgpr1 = COPY [[ANYEXT1]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1
-  %val = load <2 x i24>, ptr addrspace(1) undef
+  %val = load <2 x i24>, ptr addrspace(1) poison
   ret <2 x i24> %val
 }
 
@@ -214,7 +214,7 @@ define <3 x i24> @v3i24_func_void() #0 {
   ; CHECK-LABEL: name: v3i24_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<3 x s24>) = G_LOAD [[DEF]](p1) :: (load (<3 x s24>) from `ptr addrspace(1) undef`, align 16, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<3 x s24>) = G_LOAD [[DEF]](p1) :: (load (<3 x s24>) from `ptr addrspace(1) poison`, align 16, addrspace 1)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s24), [[UV1:%[0-9]+]]:_(s24), [[UV2:%[0-9]+]]:_(s24) = G_UNMERGE_VALUES [[LOAD]](<3 x s24>)
   ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[UV]](s24)
   ; CHECK-NEXT:   [[ANYEXT1:%[0-9]+]]:_(s32) = G_ANYEXT [[UV1]](s24)
@@ -223,7 +223,7 @@ define <3 x i24> @v3i24_func_void() #0 {
   ; CHECK-NEXT:   $vgpr1 = COPY [[ANYEXT1]](s32)
   ; CHECK-NEXT:   $vgpr2 = COPY [[ANYEXT2]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1, implicit $vgpr2
-  %val = load <3 x i24>, ptr addrspace(1) undef
+  %val = load <3 x i24>, ptr addrspace(1) poison
   ret <3 x i24> %val
 }
 
@@ -231,10 +231,10 @@ define i32 @i32_func_void() #0 {
   ; CHECK-LABEL: name: i32_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[DEF]](p1) :: (load (s32) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[DEF]](p1) :: (load (s32) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   $vgpr0 = COPY [[LOAD]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load i32, ptr addrspace(1) undef
+  %val = load i32, ptr addrspace(1) poison
   ret i32 %val
 }
 
@@ -242,13 +242,13 @@ define i48 @i48_func_void() #0 {
   ; CHECK-LABEL: name: i48_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s48) = G_LOAD [[DEF]](p1) :: (load (s48) from `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s48) = G_LOAD [[DEF]](p1) :: (load (s48) from `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(s64) = G_ANYEXT [[LOAD]](s48)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[ANYEXT]](s64)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; CHECK-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1
-  %val = load i48, ptr addrspace(1) undef, align 8
+  %val = load i48, ptr addrspace(1) poison, align 8
   ret i48 %val
 }
 
@@ -256,13 +256,13 @@ define signext i48 @i48_signext_func_void() #0 {
   ; CHECK-LABEL: name: i48_signext_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s48) = G_LOAD [[DEF]](p1) :: (load (s48) from `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s48) = G_LOAD [[DEF]](p1) :: (load (s48) from `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   [[SEXT:%[0-9]+]]:_(s64) = G_SEXT [[LOAD]](s48)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[SEXT]](s64)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; CHECK-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1
-  %val = load i48, ptr addrspace(1) undef, align 8
+  %val = load i48, ptr addrspace(1) poison, align 8
   ret i48 %val
 }
 
@@ -270,13 +270,13 @@ define zeroext i48 @i48_zeroext_func_void() #0 {
   ; CHECK-LABEL: name: i48_zeroext_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s48) = G_LOAD [[DEF]](p1) :: (load (s48) from `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s48) = G_LOAD [[DEF]](p1) :: (load (s48) from `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   [[ZEXT:%[0-9]+]]:_(s64) = G_ZEXT [[LOAD]](s48)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[ZEXT]](s64)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; CHECK-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1
-  %val = load i48, ptr addrspace(1) undef, align 8
+  %val = load i48, ptr addrspace(1) poison, align 8
   ret i48 %val
 }
 
@@ -284,12 +284,12 @@ define i64 @i64_func_void() #0 {
   ; CHECK-LABEL: name: i64_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s64) = G_LOAD [[DEF]](p1) :: (load (s64) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s64) = G_LOAD [[DEF]](p1) :: (load (s64) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[LOAD]](s64)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; CHECK-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1
-  %val = load i64, ptr addrspace(1) undef
+  %val = load i64, ptr addrspace(1) poison
   ret i64 %val
 }
 
@@ -297,14 +297,14 @@ define i65 @i65_func_void() #0 {
   ; CHECK-LABEL: name: i65_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s65) = G_LOAD [[DEF]](p1) :: (load (s65) from `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s65) = G_LOAD [[DEF]](p1) :: (load (s65) from `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(s96) = G_ANYEXT [[LOAD]](s65)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[ANYEXT]](s96)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; CHECK-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; CHECK-NEXT:   $vgpr2 = COPY [[UV2]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1, implicit $vgpr2
-  %val = load i65, ptr addrspace(1) undef
+  %val = load i65, ptr addrspace(1) poison
   ret i65 %val
 }
 
@@ -312,14 +312,14 @@ define signext i65 @i65_signext_func_void() #0 {
   ; CHECK-LABEL: name: i65_signext_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s65) = G_LOAD [[DEF]](p1) :: (load (s65) from `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s65) = G_LOAD [[DEF]](p1) :: (load (s65) from `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   [[SEXT:%[0-9]+]]:_(s96) = G_SEXT [[LOAD]](s65)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[SEXT]](s96)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; CHECK-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; CHECK-NEXT:   $vgpr2 = COPY [[UV2]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1, implicit $vgpr2
-  %val = load i65, ptr addrspace(1) undef
+  %val = load i65, ptr addrspace(1) poison
   ret i65 %val
 }
 
@@ -327,14 +327,14 @@ define zeroext i65 @i65_zeroext_func_void() #0 {
   ; CHECK-LABEL: name: i65_zeroext_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s65) = G_LOAD [[DEF]](p1) :: (load (s65) from `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s65) = G_LOAD [[DEF]](p1) :: (load (s65) from `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   [[ZEXT:%[0-9]+]]:_(s96) = G_ZEXT [[LOAD]](s65)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[ZEXT]](s96)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; CHECK-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; CHECK-NEXT:   $vgpr2 = COPY [[UV2]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1, implicit $vgpr2
-  %val = load i65, ptr addrspace(1) undef
+  %val = load i65, ptr addrspace(1) poison
   ret i65 %val
 }
 
@@ -342,10 +342,10 @@ define float @f32_func_void() #0 {
   ; CHECK-LABEL: name: f32_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[DEF]](p1) :: (load (s32) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[DEF]](p1) :: (load (s32) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   $vgpr0 = COPY [[LOAD]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load float, ptr addrspace(1) undef
+  %val = load float, ptr addrspace(1) poison
   ret float %val
 }
 
@@ -353,12 +353,12 @@ define double @f64_func_void() #0 {
   ; CHECK-LABEL: name: f64_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s64) = G_LOAD [[DEF]](p1) :: (load (s64) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s64) = G_LOAD [[DEF]](p1) :: (load (s64) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[LOAD]](s64)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; CHECK-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1
-  %val = load double, ptr addrspace(1) undef
+  %val = load double, ptr addrspace(1) poison
   ret double %val
 }
 
@@ -366,14 +366,14 @@ define <2 x double> @v2f64_func_void() #0 {
   ; CHECK-LABEL: name: v2f64_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s64>) = G_LOAD [[DEF]](p1) :: (load (<2 x s64>) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s64>) = G_LOAD [[DEF]](p1) :: (load (<2 x s64>) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[LOAD]](<2 x s64>)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; CHECK-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; CHECK-NEXT:   $vgpr2 = COPY [[UV2]](s32)
   ; CHECK-NEXT:   $vgpr3 = COPY [[UV3]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1, implicit $vgpr2, implicit $vgpr3
-  %val = load <2 x double>, ptr addrspace(1) undef
+  %val = load <2 x double>, ptr addrspace(1) poison
   ret <2 x double> %val
 }
 
@@ -381,12 +381,12 @@ define <2 x i32> @v2i32_func_void() #0 {
   ; CHECK-LABEL: name: v2i32_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s32>) = G_LOAD [[DEF]](p1) :: (load (<2 x s32>) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s32>) = G_LOAD [[DEF]](p1) :: (load (<2 x s32>) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[LOAD]](<2 x s32>)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; CHECK-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1
-  %val = load <2 x i32>, ptr addrspace(1) undef
+  %val = load <2 x i32>, ptr addrspace(1) poison
   ret <2 x i32> %val
 }
 
@@ -394,13 +394,13 @@ define <3 x i32> @v3i32_func_void() #0 {
   ; CHECK-LABEL: name: v3i32_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<3 x s32>) = G_LOAD [[DEF]](p1) :: (load (<3 x s32>) from `ptr addrspace(1) undef`, align 16, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<3 x s32>) = G_LOAD [[DEF]](p1) :: (load (<3 x s32>) from `ptr addrspace(1) poison`, align 16, addrspace 1)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[LOAD]](<3 x s32>)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; CHECK-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; CHECK-NEXT:   $vgpr2 = COPY [[UV2]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1, implicit $vgpr2
-  %val = load <3 x i32>, ptr addrspace(1) undef
+  %val = load <3 x i32>, ptr addrspace(1) poison
   ret <3 x i32> %val
 }
 
@@ -408,14 +408,14 @@ define <4 x i32> @v4i32_func_void() #0 {
   ; CHECK-LABEL: name: v4i32_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<4 x s32>) = G_LOAD [[DEF]](p1) :: (load (<4 x s32>) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<4 x s32>) = G_LOAD [[DEF]](p1) :: (load (<4 x s32>) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[LOAD]](<4 x s32>)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; CHECK-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; CHECK-NEXT:   $vgpr2 = COPY [[UV2]](s32)
   ; CHECK-NEXT:   $vgpr3 = COPY [[UV3]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1, implicit $vgpr2, implicit $vgpr3
-  %val = load <4 x i32>, ptr addrspace(1) undef
+  %val = load <4 x i32>, ptr addrspace(1) poison
   ret <4 x i32> %val
 }
 
@@ -423,7 +423,7 @@ define <5 x i32> @v5i32_func_void() #0 {
   ; CHECK-LABEL: name: v5i32_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<5 x s32>) = G_LOAD [[DEF]](p1) :: (volatile load (<5 x s32>) from `ptr addrspace(1) undef`, align 32, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<5 x s32>) = G_LOAD [[DEF]](p1) :: (volatile load (<5 x s32>) from `ptr addrspace(1) poison`, align 32, addrspace 1)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[LOAD]](<5 x s32>)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; CHECK-NEXT:   $vgpr1 = COPY [[UV1]](s32)
@@ -431,7 +431,7 @@ define <5 x i32> @v5i32_func_void() #0 {
   ; CHECK-NEXT:   $vgpr3 = COPY [[UV3]](s32)
   ; CHECK-NEXT:   $vgpr4 = COPY [[UV4]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1, implicit $vgpr2, implicit $vgpr3, implicit $vgpr4
-  %val = load volatile <5 x i32>, ptr addrspace(1) undef
+  %val = load volatile <5 x i32>, ptr addrspace(1) poison
   ret <5 x i32> %val
 }
 
@@ -534,14 +534,14 @@ define <2 x i64> @v2i64_func_void() #0 {
   ; CHECK-LABEL: name: v2i64_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s64>) = G_LOAD [[DEF]](p1) :: (load (<2 x s64>) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s64>) = G_LOAD [[DEF]](p1) :: (load (<2 x s64>) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[LOAD]](<2 x s64>)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; CHECK-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; CHECK-NEXT:   $vgpr2 = COPY [[UV2]](s32)
   ; CHECK-NEXT:   $vgpr3 = COPY [[UV3]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1, implicit $vgpr2, implicit $vgpr3
-  %val = load <2 x i64>, ptr addrspace(1) undef
+  %val = load <2 x i64>, ptr addrspace(1) poison
   ret <2 x i64> %val
 }
 
@@ -686,10 +686,10 @@ define <2 x i16> @v2i16_func_void() #0 {
   ; CHECK-LABEL: name: v2i16_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s16>) = G_LOAD [[DEF]](p1) :: (load (<2 x s16>) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s16>) = G_LOAD [[DEF]](p1) :: (load (<2 x s16>) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   $vgpr0 = COPY [[LOAD]](<2 x s16>)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load <2 x i16>, ptr addrspace(1) undef
+  %val = load <2 x i16>, ptr addrspace(1) poison
   ret <2 x i16> %val
 }
 
@@ -697,10 +697,10 @@ define <2 x half> @v2f16_func_void() #0 {
   ; CHECK-LABEL: name: v2f16_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s16>) = G_LOAD [[DEF]](p1) :: (load (<2 x s16>) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s16>) = G_LOAD [[DEF]](p1) :: (load (<2 x s16>) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   $vgpr0 = COPY [[LOAD]](<2 x s16>)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0
-  %val = load <2 x half>, ptr addrspace(1) undef
+  %val = load <2 x half>, ptr addrspace(1) poison
   ret <2 x half> %val
 }
 
@@ -708,7 +708,7 @@ define <3 x i16> @v3i16_func_void() #0 {
   ; CHECK-LABEL: name: v3i16_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<3 x s16>) = G_LOAD [[DEF]](p1) :: (load (<3 x s16>) from `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<3 x s16>) = G_LOAD [[DEF]](p1) :: (load (<3 x s16>) from `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16), [[UV2:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[LOAD]](<3 x s16>)
   ; CHECK-NEXT:   [[DEF1:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s16>) = G_BUILD_VECTOR [[UV]](s16), [[UV1]](s16), [[UV2]](s16), [[DEF1]](s16)
@@ -716,7 +716,7 @@ define <3 x i16> @v3i16_func_void() #0 {
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV3]](<2 x s16>)
   ; CHECK-NEXT:   $vgpr1 = COPY [[UV4]](<2 x s16>)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1
-  %val = load <3 x i16>, ptr addrspace(1) undef
+  %val = load <3 x i16>, ptr addrspace(1) poison
   ret <3 x i16> %val
 }
 
@@ -724,12 +724,12 @@ define <4 x i16> @v4i16_func_void() #0 {
   ; CHECK-LABEL: name: v4i16_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<4 x s16>) = G_LOAD [[DEF]](p1) :: (load (<4 x s16>) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<4 x s16>) = G_LOAD [[DEF]](p1) :: (load (<4 x s16>) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(<2 x s16>), [[UV1:%[0-9]+]]:_(<2 x s16>) = G_UNMERGE_VALUES [[LOAD]](<4 x s16>)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](<2 x s16>)
   ; CHECK-NEXT:   $vgpr1 = COPY [[UV1]](<2 x s16>)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1
-  %val = load <4 x i16>, ptr addrspace(1) undef
+  %val = load <4 x i16>, ptr addrspace(1) poison
   ret <4 x i16> %val
 }
 
@@ -737,12 +737,12 @@ define <4 x half> @v4f16_func_void() #0 {
   ; CHECK-LABEL: name: v4f16_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<4 x s16>) = G_LOAD [[DEF]](p1) :: (load (<4 x s16>) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<4 x s16>) = G_LOAD [[DEF]](p1) :: (load (<4 x s16>) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(<2 x s16>), [[UV1:%[0-9]+]]:_(<2 x s16>) = G_UNMERGE_VALUES [[LOAD]](<4 x s16>)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](<2 x s16>)
   ; CHECK-NEXT:   $vgpr1 = COPY [[UV1]](<2 x s16>)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1
-  %val = load <4 x half>, ptr addrspace(1) undef
+  %val = load <4 x half>, ptr addrspace(1) poison
   ret <4 x half> %val
 }
 
@@ -868,7 +868,7 @@ define <2 x i8> @v2i8_func_void() #0 {
   ; CHECK-LABEL: name: v2i8_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s8>) = G_LOAD [[DEF]](p1) :: (load (<2 x s8>) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s8>) = G_LOAD [[DEF]](p1) :: (load (<2 x s8>) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s8), [[UV1:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[LOAD]](<2 x s8>)
   ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(s16) = G_ANYEXT [[UV]](s8)
   ; CHECK-NEXT:   [[ANYEXT1:%[0-9]+]]:_(s16) = G_ANYEXT [[UV1]](s8)
@@ -877,7 +877,7 @@ define <2 x i8> @v2i8_func_void() #0 {
   ; CHECK-NEXT:   [[ANYEXT3:%[0-9]+]]:_(s32) = G_ANYEXT [[ANYEXT1]](s16)
   ; CHECK-NEXT:   $vgpr1 = COPY [[ANYEXT3]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1
-  %val = load <2 x i8>, ptr addrspace(1) undef
+  %val = load <2 x i8>, ptr addrspace(1) poison
   ret <2 x i8> %val
 }
 
@@ -885,7 +885,7 @@ define <3 x i8> @v3i8_func_void() #0 {
   ; CHECK-LABEL: name: v3i8_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<3 x s8>) = G_LOAD [[DEF]](p1) :: (load (<3 x s8>) from `ptr addrspace(1) undef`, align 4, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<3 x s8>) = G_LOAD [[DEF]](p1) :: (load (<3 x s8>) from `ptr addrspace(1) poison`, align 4, addrspace 1)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s8), [[UV1:%[0-9]+]]:_(s8), [[UV2:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[LOAD]](<3 x s8>)
   ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(s16) = G_ANYEXT [[UV]](s8)
   ; CHECK-NEXT:   [[ANYEXT1:%[0-9]+]]:_(s16) = G_ANYEXT [[UV1]](s8)
@@ -897,7 +897,7 @@ define <3 x i8> @v3i8_func_void() #0 {
   ; CHECK-NEXT:   [[ANYEXT5:%[0-9]+]]:_(s32) = G_ANYEXT [[ANYEXT2]](s16)
   ; CHECK-NEXT:   $vgpr2 = COPY [[ANYEXT5]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1, implicit $vgpr2
-  %val = load <3 x i8>, ptr addrspace(1) undef
+  %val = load <3 x i8>, ptr addrspace(1) poison
   ret <3 x i8> %val
 }
 
@@ -930,15 +930,15 @@ define {i8, i32} @struct_i8_i32_func_void() #0 {
   ; CHECK-LABEL: name: struct_i8_i32_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[DEF]](p1) :: (load (s8) from `ptr addrspace(1) undef`, align 4, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[DEF]](p1) :: (load (s8) from `ptr addrspace(1) poison`, align 4, addrspace 1)
   ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
   ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p1) = G_PTR_ADD [[DEF]], [[C]](s64)
-  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD]](p1) :: (load (s32) from `ptr addrspace(1) undef` + 4, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD]](p1) :: (load (s32) from `ptr addrspace(1) poison` + 4, addrspace 1)
   ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(s32) = G_ANYEXT [[LOAD]](s8)
   ; CHECK-NEXT:   $vgpr0 = COPY [[ANYEXT]](s32)
   ; CHECK-NEXT:   $vgpr1 = COPY [[LOAD1]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1
-  %val = load { i8, i32 }, ptr addrspace(1) undef
+  %val = load { i8, i32 }, ptr addrspace(1) poison
   ret { i8, i32 } %val
 }
 
@@ -949,15 +949,15 @@ define void @void_func_sret_struct_i8_i32(ptr addrspace(5) sret({ i8, i32 }) %ar
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(p5) = COPY $vgpr0
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[DEF]](p1) :: (volatile load (s8) from `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[DEF]](p1) :: (volatile load (s32) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[DEF]](p1) :: (volatile load (s8) from `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[DEF]](p1) :: (volatile load (s32) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 4
   ; CHECK-NEXT:   %13:_(p5) = nuw nusw G_PTR_ADD [[COPY]], [[C]](s32)
   ; CHECK-NEXT:   G_STORE [[LOAD]](s8), [[COPY]](p5) :: (store (s8) into %ir.arg0, addrspace 5)
   ; CHECK-NEXT:   G_STORE [[LOAD1]](s32), %13(p5) :: (store (s32) into %ir.gep1, addrspace 5)
   ; CHECK-NEXT:   SI_RETURN
-  %val0 = load volatile i8, ptr addrspace(1) undef
-  %val1 = load volatile i32, ptr addrspace(1) undef
+  %val0 = load volatile i8, ptr addrspace(1) poison
+  %val1 = load volatile i32, ptr addrspace(1) poison
   %gep0 = getelementptr inbounds { i8, i32 }, ptr addrspace(5) %arg0, i32 0, i32 0
   %gep1 = getelementptr inbounds { i8, i32 }, ptr addrspace(5) %arg0, i32 0, i32 1
   store i8 %val0, ptr addrspace(5) %gep0
@@ -1157,7 +1157,7 @@ define i1022 @i1022_func_void() #0 {
   ; CHECK-LABEL: name: i1022_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s1022) = G_LOAD [[DEF]](p1) :: (load (s1022) from `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s1022) = G_LOAD [[DEF]](p1) :: (load (s1022) from `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(s1024) = G_ANYEXT [[LOAD]](s1022)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32), [[UV5:%[0-9]+]]:_(s32), [[UV6:%[0-9]+]]:_(s32), [[UV7:%[0-9]+]]:_(s32), [[UV8:%[0-9]+]]:_(s32), [[UV9:%[0-9]+]]:_(s32), [[UV10:%[0-9]+]]:_(s32), [[UV11:%[0-9]+]]:_(s32), [[UV12:%[0-9]+]]:_(s32), [[UV13:%[0-9]+]]:_(s32), [[UV14:%[0-9]+]]:_(s32), [[UV15:%[0-9]+]]:_(s32), [[UV16:%[0-9]+]]:_(s32), [[UV17:%[0-9]+]]:_(s32), [[UV18:%[0-9]+]]:_(s32), [[UV19:%[0-9]+]]:_(s32), [[UV20:%[0-9]+]]:_(s32), [[UV21:%[0-9]+]]:_(s32), [[UV22:%[0-9]+]]:_(s32), [[UV23:%[0-9]+]]:_(s32), [[UV24:%[0-9]+]]:_(s32), [[UV25:%[0-9]+]]:_(s32), [[UV26:%[0-9]+]]:_(s32), [[UV27:%[0-9]+]]:_(s32), [[UV28:%[0-9]+]]:_(s32), [[UV29:%[0-9]+]]:_(s32), [[UV30:%[0-9]+]]:_(s32), [[UV31:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[ANYEXT]](s1024)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
@@ -1193,7 +1193,7 @@ define i1022 @i1022_func_void() #0 {
   ; CHECK-NEXT:   $vgpr30 = COPY [[UV30]](s32)
   ; CHECK-NEXT:   $vgpr31 = COPY [[UV31]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1, implicit $vgpr2, implicit $vgpr3, implicit $vgpr4, implicit $vgpr5, implicit $vgpr6, implicit $vgpr7, implicit $vgpr8, implicit $vgpr9, implicit $vgpr10, implicit $vgpr11, implicit $vgpr12, implicit $vgpr13, implicit $vgpr14, implicit $vgpr15, implicit $vgpr16, implicit $vgpr17, implicit $vgpr18, implicit $vgpr19, implicit $vgpr20, implicit $vgpr21, implicit $vgpr22, implicit $vgpr23, implicit $vgpr24, implicit $vgpr25, implicit $vgpr26, implicit $vgpr27, implicit $vgpr28, implicit $vgpr29, implicit $vgpr30, implicit $vgpr31
-  %val = load i1022, ptr addrspace(1) undef
+  %val = load i1022, ptr addrspace(1) poison
   ret i1022 %val
 }
 
@@ -1201,7 +1201,7 @@ define signext i1022 @i1022_signext_func_void() #0 {
   ; CHECK-LABEL: name: i1022_signext_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s1022) = G_LOAD [[DEF]](p1) :: (load (s1022) from `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s1022) = G_LOAD [[DEF]](p1) :: (load (s1022) from `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   [[SEXT:%[0-9]+]]:_(s1024) = G_SEXT [[LOAD]](s1022)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32), [[UV5:%[0-9]+]]:_(s32), [[UV6:%[0-9]+]]:_(s32), [[UV7:%[0-9]+]]:_(s32), [[UV8:%[0-9]+]]:_(s32), [[UV9:%[0-9]+]]:_(s32), [[UV10:%[0-9]+]]:_(s32), [[UV11:%[0-9]+]]:_(s32), [[UV12:%[0-9]+]]:_(s32), [[UV13:%[0-9]+]]:_(s32), [[UV14:%[0-9]+]]:_(s32), [[UV15:%[0-9]+]]:_(s32), [[UV16:%[0-9]+]]:_(s32), [[UV17:%[0-9]+]]:_(s32), [[UV18:%[0-9]+]]:_(s32), [[UV19:%[0-9]+]]:_(s32), [[UV20:%[0-9]+]]:_(s32), [[UV21:%[0-9]+]]:_(s32), [[UV22:%[0-9]+]]:_(s32), [[UV23:%[0-9]+]]:_(s32), [[UV24:%[0-9]+]]:_(s32), [[UV25:%[0-9]+]]:_(s32), [[UV26:%[0-9]+]]:_(s32), [[UV27:%[0-9]+]]:_(s32), [[UV28:%[0-9]+]]:_(s32), [[UV29:%[0-9]+]]:_(s32), [[UV30:%[0-9]+]]:_(s32), [[UV31:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[SEXT]](s1024)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
@@ -1237,7 +1237,7 @@ define signext i1022 @i1022_signext_func_void() #0 {
   ; CHECK-NEXT:   $vgpr30 = COPY [[UV30]](s32)
   ; CHECK-NEXT:   $vgpr31 = COPY [[UV31]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1, implicit $vgpr2, implicit $vgpr3, implicit $vgpr4, implicit $vgpr5, implicit $vgpr6, implicit $vgpr7, implicit $vgpr8, implicit $vgpr9, implicit $vgpr10, implicit $vgpr11, implicit $vgpr12, implicit $vgpr13, implicit $vgpr14, implicit $vgpr15, implicit $vgpr16, implicit $vgpr17, implicit $vgpr18, implicit $vgpr19, implicit $vgpr20, implicit $vgpr21, implicit $vgpr22, implicit $vgpr23, implicit $vgpr24, implicit $vgpr25, implicit $vgpr26, implicit $vgpr27, implicit $vgpr28, implicit $vgpr29, implicit $vgpr30, implicit $vgpr31
-  %val = load i1022, ptr addrspace(1) undef
+  %val = load i1022, ptr addrspace(1) poison
   ret i1022 %val
 }
 
@@ -1245,7 +1245,7 @@ define zeroext i1022 @i1022_zeroext_func_void() #0 {
   ; CHECK-LABEL: name: i1022_zeroext_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s1022) = G_LOAD [[DEF]](p1) :: (load (s1022) from `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s1022) = G_LOAD [[DEF]](p1) :: (load (s1022) from `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   [[ZEXT:%[0-9]+]]:_(s1024) = G_ZEXT [[LOAD]](s1022)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32), [[UV5:%[0-9]+]]:_(s32), [[UV6:%[0-9]+]]:_(s32), [[UV7:%[0-9]+]]:_(s32), [[UV8:%[0-9]+]]:_(s32), [[UV9:%[0-9]+]]:_(s32), [[UV10:%[0-9]+]]:_(s32), [[UV11:%[0-9]+]]:_(s32), [[UV12:%[0-9]+]]:_(s32), [[UV13:%[0-9]+]]:_(s32), [[UV14:%[0-9]+]]:_(s32), [[UV15:%[0-9]+]]:_(s32), [[UV16:%[0-9]+]]:_(s32), [[UV17:%[0-9]+]]:_(s32), [[UV18:%[0-9]+]]:_(s32), [[UV19:%[0-9]+]]:_(s32), [[UV20:%[0-9]+]]:_(s32), [[UV21:%[0-9]+]]:_(s32), [[UV22:%[0-9]+]]:_(s32), [[UV23:%[0-9]+]]:_(s32), [[UV24:%[0-9]+]]:_(s32), [[UV25:%[0-9]+]]:_(s32), [[UV26:%[0-9]+]]:_(s32), [[UV27:%[0-9]+]]:_(s32), [[UV28:%[0-9]+]]:_(s32), [[UV29:%[0-9]+]]:_(s32), [[UV30:%[0-9]+]]:_(s32), [[UV31:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[ZEXT]](s1024)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
@@ -1281,7 +1281,7 @@ define zeroext i1022 @i1022_zeroext_func_void() #0 {
   ; CHECK-NEXT:   $vgpr30 = COPY [[UV30]](s32)
   ; CHECK-NEXT:   $vgpr31 = COPY [[UV31]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1, implicit $vgpr2, implicit $vgpr3, implicit $vgpr4, implicit $vgpr5, implicit $vgpr6, implicit $vgpr7, implicit $vgpr8, implicit $vgpr9, implicit $vgpr10, implicit $vgpr11, implicit $vgpr12, implicit $vgpr13, implicit $vgpr14, implicit $vgpr15, implicit $vgpr16, implicit $vgpr17, implicit $vgpr18, implicit $vgpr19, implicit $vgpr20, implicit $vgpr21, implicit $vgpr22, implicit $vgpr23, implicit $vgpr24, implicit $vgpr25, implicit $vgpr26, implicit $vgpr27, implicit $vgpr28, implicit $vgpr29, implicit $vgpr30, implicit $vgpr31
-  %val = load i1022, ptr addrspace(1) undef
+  %val = load i1022, ptr addrspace(1) poison
   ret i1022 %val
 }
 
@@ -1294,16 +1294,16 @@ define %struct.with.ptrs @ptr_in_struct_func_void() #0 {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(p5) = COPY $vgpr0
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<32 x s32>) = G_LOAD [[DEF]](p1) :: (volatile load (<32 x s32>) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<32 x s32>) = G_LOAD [[DEF]](p1) :: (volatile load (<32 x s32>) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 128
   ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p1) = G_PTR_ADD [[DEF]], [[C]](s64)
-  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(p3) = G_LOAD [[PTR_ADD]](p1) :: (volatile load (p3) from `ptr addrspace(1) undef` + 128, align 128, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(p3) = G_LOAD [[PTR_ADD]](p1) :: (volatile load (p3) from `ptr addrspace(1) poison` + 128, align 128, addrspace 1)
   ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 136
   ; CHECK-NEXT:   [[PTR_ADD1:%[0-9]+]]:_(p1) = G_PTR_ADD [[DEF]], [[C1]](s64)
-  ; CHECK-NEXT:   [[LOAD2:%[0-9]+]]:_(p1) = G_LOAD [[PTR_ADD1]](p1) :: (volatile load (p1) from `ptr addrspace(1) undef` + 136, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD2:%[0-9]+]]:_(p1) = G_LOAD [[PTR_ADD1]](p1) :: (volatile load (p1) from `ptr addrspace(1) poison` + 136, addrspace 1)
   ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(s64) = G_CONSTANT i64 144
   ; CHECK-NEXT:   [[PTR_ADD2:%[0-9]+]]:_(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
-  ; CHECK-NEXT:   [[LOAD3:%[0-9]+]]:_(<2 x p1>) = G_LOAD [[PTR_ADD2]](p1) :: (volatile load (<2 x p1>) from `ptr addrspace(1) undef` + 144, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD3:%[0-9]+]]:_(<2 x p1>) = G_LOAD [[PTR_ADD2]](p1) :: (volatile load (<2 x p1>) from `ptr addrspace(1) poison` + 144, addrspace 1)
   ; CHECK-NEXT:   G_STORE [[LOAD]](<32 x s32>), [[COPY]](p5) :: (store (<32 x s32>), addrspace 5)
   ; CHECK-NEXT:   [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 128
   ; CHECK-NEXT:   [[PTR_ADD3:%[0-9]+]]:_(p5) = G_PTR_ADD [[COPY]], [[C3]](s32)
@@ -1315,7 +1315,7 @@ define %struct.with.ptrs @ptr_in_struct_func_void() #0 {
   ; CHECK-NEXT:   [[PTR_ADD5:%[0-9]+]]:_(p5) = G_PTR_ADD [[COPY]], [[C5]](s32)
   ; CHECK-NEXT:   G_STORE [[LOAD3]](<2 x p1>), [[PTR_ADD5]](p5) :: (store (<2 x p1>), addrspace 5)
   ; CHECK-NEXT:   SI_RETURN
-  %val = load volatile %struct.with.ptrs, ptr addrspace(1) undef
+  %val = load volatile %struct.with.ptrs, ptr addrspace(1) poison
   ret %struct.with.ptrs %val
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/function-returns.v2i65.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/function-returns.v2i65.ll
@@ -5,7 +5,7 @@ define <2 x i65> @v2i65_func_void() #0 {
   ; CHECK-LABEL: name: v2i65_func_void
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s65>) = G_LOAD [[DEF]](p1) :: (load (<2 x s65>) from `ptr addrspace(1) undef`, align 32, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s65>) = G_LOAD [[DEF]](p1) :: (load (<2 x s65>) from `ptr addrspace(1) poison`, align 32, addrspace 1)
   ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(<2 x s96>) = G_ANYEXT [[LOAD]](<2 x s65>)
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32), [[UV5:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[ANYEXT]](<2 x s96>)
   ; CHECK-NEXT:   $vgpr0 = COPY [[UV]](s32)
@@ -15,6 +15,6 @@ define <2 x i65> @v2i65_func_void() #0 {
   ; CHECK-NEXT:   $vgpr4 = COPY [[UV4]](s32)
   ; CHECK-NEXT:   $vgpr5 = COPY [[UV5]](s32)
   ; CHECK-NEXT:   SI_RETURN implicit $vgpr0, implicit $vgpr1, implicit $vgpr2, implicit $vgpr3, implicit $vgpr4, implicit $vgpr5
-  %val = load <2 x i65>, ptr addrspace(1) undef
+  %val = load <2 x i65>, ptr addrspace(1) poison
   ret <2 x i65> %val
 }

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/implicit-kernarg-backend-usage-global-isel.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/implicit-kernarg-backend-usage-global-isel.ll
@@ -163,7 +163,7 @@ define amdgpu_kernel void @llvm_amdgcn_is_shared(ptr %ptr) {
 ; GFX9V5-NEXT:    s_endpgm
   %is.shared = call i1 @llvm.amdgcn.is.shared(ptr %ptr)
   %zext = zext i1 %is.shared to i32
-  store volatile i32 %zext, ptr addrspace(1) undef
+  store volatile i32 %zext, ptr addrspace(1) poison
   ret void
 }
 
@@ -219,7 +219,7 @@ define amdgpu_kernel void @llvm_amdgcn_is_private(ptr %ptr) {
 ; GFX9V5-NEXT:    s_endpgm
   %is.private = call i1 @llvm.amdgcn.is.private(ptr %ptr)
   %zext = zext i1 %is.private to i32
-  store volatile i32 %zext, ptr addrspace(1) undef
+  store volatile i32 %zext, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/insertelement.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/insertelement.ll
@@ -874,10 +874,10 @@ entry:
   %vec.1 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 2, i32 3>
   %vec.2 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 4, i32 5>
   %vec.3 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 6, i32 7>
-  store volatile <2 x double> %vec.0, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.1, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.2, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.3, ptr addrspace(1) undef
+  store volatile <2 x double> %vec.0, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.1, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.2, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.3, ptr addrspace(1) poison
   ret void
 }
 
@@ -1085,10 +1085,10 @@ entry:
   %vec.1 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 2, i32 3>
   %vec.2 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 4, i32 5>
   %vec.3 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 6, i32 7>
-  store volatile <2 x double> %vec.0, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.1, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.2, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.3, ptr addrspace(1) undef
+  store volatile <2 x double> %vec.0, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.1, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.2, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.3, ptr addrspace(1) poison
   ret void
 }
 
@@ -1233,10 +1233,10 @@ entry:
   %vec.1 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 2, i32 3>
   %vec.2 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 4, i32 5>
   %vec.3 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 6, i32 7>
-  store volatile <2 x double> %vec.0, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.1, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.2, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.3, ptr addrspace(1) undef
+  store volatile <2 x double> %vec.0, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.1, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.2, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.3, ptr addrspace(1) poison
   ret void
 }
 
@@ -1293,10 +1293,10 @@ entry:
   %vec.1 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 2, i32 3>
   %vec.2 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 4, i32 5>
   %vec.3 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 6, i32 7>
-  store volatile <2 x double> %vec.0, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.1, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.2, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.3, ptr addrspace(1) undef
+  store volatile <2 x double> %vec.0, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.1, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.2, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.3, ptr addrspace(1) poison
   ret void
 }
 
@@ -1498,10 +1498,10 @@ entry:
   %vec.1 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 2, i32 3>
   %vec.2 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 4, i32 5>
   %vec.3 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 6, i32 7>
-  store volatile <2 x double> %vec.0, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.1, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.2, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.3, ptr addrspace(1) undef
+  store volatile <2 x double> %vec.0, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.1, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.2, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.3, ptr addrspace(1) poison
   ret void
 }
 
@@ -1621,10 +1621,10 @@ entry:
   %vec.1 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 2, i32 3>
   %vec.2 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 4, i32 5>
   %vec.3 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 6, i32 7>
-  store volatile <2 x double> %vec.0, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.1, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.2, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.3, ptr addrspace(1) undef
+  store volatile <2 x double> %vec.0, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.1, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.2, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.3, ptr addrspace(1) poison
   ret void
 }
 
@@ -1681,10 +1681,10 @@ entry:
   %vec.1 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 2, i32 3>
   %vec.2 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 4, i32 5>
   %vec.3 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 6, i32 7>
-  store volatile <2 x double> %vec.0, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.1, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.2, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.3, ptr addrspace(1) undef
+  store volatile <2 x double> %vec.0, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.1, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.2, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.3, ptr addrspace(1) poison
   ret void
 }
 
@@ -1798,10 +1798,10 @@ entry:
   %vec.1 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 2, i32 3>
   %vec.2 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 4, i32 5>
   %vec.3 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 6, i32 7>
-  store volatile <2 x double> %vec.0, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.1, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.2, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.3, ptr addrspace(1) undef
+  store volatile <2 x double> %vec.0, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.1, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.2, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.3, ptr addrspace(1) poison
   ret void
 }
 
@@ -2405,10 +2405,10 @@ entry:
   %vec.1 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 2, i32 3>
   %vec.2 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 4, i32 5>
   %vec.3 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 6, i32 7>
-  store volatile <2 x double> %vec.0, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.1, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.2, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.3, ptr addrspace(1) undef
+  store volatile <2 x double> %vec.0, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.1, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.2, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.3, ptr addrspace(1) poison
   ret void
 }
 
@@ -2529,10 +2529,10 @@ entry:
   %vec.1 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 2, i32 3>
   %vec.2 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 4, i32 5>
   %vec.3 = shufflevector <8 x double> %insert, <8 x double> poison, <2 x i32> <i32 6, i32 7>
-  store volatile <2 x double> %vec.0, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.1, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.2, ptr addrspace(1) undef
-  store volatile <2 x double> %vec.3, ptr addrspace(1) undef
+  store volatile <2 x double> %vec.0, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.1, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.2, ptr addrspace(1) poison
+  store volatile <2 x double> %vec.3, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-amdgpu_kernel-system-sgprs.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-amdgpu_kernel-system-sgprs.ll
@@ -21,7 +21,7 @@ define amdgpu_kernel void @default_kernel() {
 ; HSA-NEXT: frameInfo:
 define amdgpu_kernel void @workgroup_id_x() {
   %id = call i32 @llvm.amdgcn.workgroup.id.x()
-  store volatile i32 %id, ptr addrspace(1) undef
+  store volatile i32 %id, ptr addrspace(1) poison
   ret void
 }
 
@@ -35,7 +35,7 @@ define amdgpu_kernel void @workgroup_id_x() {
 ; HSA-NEXT: frameInfo:
 define amdgpu_kernel void @workgroup_id_y() {
   %id = call i32 @llvm.amdgcn.workgroup.id.y()
-  store volatile i32 %id, ptr addrspace(1) undef
+  store volatile i32 %id, ptr addrspace(1) poison
   ret void
 }
 
@@ -49,7 +49,7 @@ define amdgpu_kernel void @workgroup_id_y() {
 ; HSA-NEXT: frameInfo:
 define amdgpu_kernel void @workgroup_id_z() {
   %id = call i32 @llvm.amdgcn.workgroup.id.z()
-  store volatile i32 %id, ptr addrspace(1) undef
+  store volatile i32 %id, ptr addrspace(1) poison
   ret void
 }
 
@@ -63,9 +63,9 @@ define amdgpu_kernel void @workgroup_id_z() {
 ; HSA-NEXT: frameInfo:
 define amdgpu_kernel void @workgroup_id_xy() {
   %id0 = call i32 @llvm.amdgcn.workgroup.id.x()
-  store volatile i32 %id0, ptr addrspace(1) undef
+  store volatile i32 %id0, ptr addrspace(1) poison
   %id1 = call i32 @llvm.amdgcn.workgroup.id.y()
-  store volatile i32 %id1, ptr addrspace(1) undef
+  store volatile i32 %id1, ptr addrspace(1) poison
   ret void
 }
 
@@ -79,11 +79,11 @@ define amdgpu_kernel void @workgroup_id_xy() {
 ; HSA-NEXT: frameInfo:
 define amdgpu_kernel void @workgroup_id_xyz() {
   %id0 = call i32 @llvm.amdgcn.workgroup.id.x()
-  store volatile i32 %id0, ptr addrspace(1) undef
+  store volatile i32 %id0, ptr addrspace(1) poison
   %id1 = call i32 @llvm.amdgcn.workgroup.id.y()
-  store volatile i32 %id1, ptr addrspace(1) undef
+  store volatile i32 %id1, ptr addrspace(1) poison
   %id2 = call i32 @llvm.amdgcn.workgroup.id.y()
-  store volatile i32 %id2, ptr addrspace(1) undef
+  store volatile i32 %id2, ptr addrspace(1) poison
   ret void
 }
 
@@ -97,9 +97,9 @@ define amdgpu_kernel void @workgroup_id_xyz() {
 ; HSA-NEXT: frameInfo:
 define amdgpu_kernel void @workgroup_id_yz() {
   %id0 = call i32 @llvm.amdgcn.workgroup.id.x()
-  store volatile i32 %id0, ptr addrspace(1) undef
+  store volatile i32 %id0, ptr addrspace(1) poison
   %id1 = call i32 @llvm.amdgcn.workgroup.id.y()
-  store volatile i32 %id1, ptr addrspace(1) undef
+  store volatile i32 %id1, ptr addrspace(1) poison
   ret void
 }
 
@@ -113,9 +113,9 @@ define amdgpu_kernel void @workgroup_id_yz() {
 ; HSA-NEXT: frameInfo:
 define amdgpu_kernel void @workgroup_id_xz() {
   %id0 = call i32 @llvm.amdgcn.workgroup.id.x()
-  store volatile i32 %id0, ptr addrspace(1) undef
+  store volatile i32 %id0, ptr addrspace(1) poison
   %id1 = call i32 @llvm.amdgcn.workgroup.id.z()
-  store volatile i32 %id1, ptr addrspace(1) undef
+  store volatile i32 %id1, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-amdgpu_kernel.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-amdgpu_kernel.ll
@@ -1187,7 +1187,7 @@ define amdgpu_kernel void @empty_struct_arg({} %arg0, i32 %arg1) nounwind {
   ; HSA-VI-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p4) = G_PTR_ADD [[COPY]], [[C]](s64)
   ; HSA-VI-NEXT:   [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD]](p4) :: (dereferenceable invariant load (s32), align 16, addrspace 4)
   ; HSA-VI-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; HSA-VI-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; HSA-VI-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; HSA-VI-NEXT:   S_ENDPGM 0
   ;
   ; LEGACY-MESA-VI-LABEL: name: empty_struct_arg
@@ -1199,9 +1199,9 @@ define amdgpu_kernel void @empty_struct_arg({} %arg0, i32 %arg1) nounwind {
   ; LEGACY-MESA-VI-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p4) = G_PTR_ADD [[COPY]], [[C]](s64)
   ; LEGACY-MESA-VI-NEXT:   [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD]](p4) :: (dereferenceable invariant load (s32), addrspace 4)
   ; LEGACY-MESA-VI-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; LEGACY-MESA-VI-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; LEGACY-MESA-VI-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; LEGACY-MESA-VI-NEXT:   S_ENDPGM 0
-  store i32 %arg1, ptr addrspace(1) undef
+  store i32 %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1215,7 +1215,7 @@ define amdgpu_kernel void @empty_array_arg([0 x i8] %arg0, i32 %arg1) nounwind {
   ; HSA-VI-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p4) = G_PTR_ADD [[COPY]], [[C]](s64)
   ; HSA-VI-NEXT:   [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD]](p4) :: (dereferenceable invariant load (s32), align 16, addrspace 4)
   ; HSA-VI-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; HSA-VI-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; HSA-VI-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; HSA-VI-NEXT:   S_ENDPGM 0
   ;
   ; LEGACY-MESA-VI-LABEL: name: empty_array_arg
@@ -1227,9 +1227,9 @@ define amdgpu_kernel void @empty_array_arg([0 x i8] %arg0, i32 %arg1) nounwind {
   ; LEGACY-MESA-VI-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p4) = G_PTR_ADD [[COPY]], [[C]](s64)
   ; LEGACY-MESA-VI-NEXT:   [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD]](p4) :: (dereferenceable invariant load (s32), addrspace 4)
   ; LEGACY-MESA-VI-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; LEGACY-MESA-VI-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; LEGACY-MESA-VI-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; LEGACY-MESA-VI-NEXT:   S_ENDPGM 0
-  store i32 %arg1, ptr addrspace(1) undef
+  store i32 %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1936,7 +1936,7 @@ define amdgpu_kernel void @byref_constant_i32_arg_offset0(ptr addrspace(4) byref
   ; HSA-VI-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p4) = G_PTR_ADD [[COPY]], [[C]](s64)
   ; HSA-VI-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; HSA-VI-NEXT:   [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD]](p4) :: (dereferenceable invariant load (s32) from %ir.in.byref, addrspace 4)
-  ; HSA-VI-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; HSA-VI-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; HSA-VI-NEXT:   S_ENDPGM 0
   ;
   ; LEGACY-MESA-VI-LABEL: name: byref_constant_i32_arg_offset0
@@ -1948,10 +1948,10 @@ define amdgpu_kernel void @byref_constant_i32_arg_offset0(ptr addrspace(4) byref
   ; LEGACY-MESA-VI-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p4) = G_PTR_ADD [[COPY]], [[C]](s64)
   ; LEGACY-MESA-VI-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; LEGACY-MESA-VI-NEXT:   [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD]](p4) :: (dereferenceable invariant load (s32) from %ir.in.byref, addrspace 4)
-  ; LEGACY-MESA-VI-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; LEGACY-MESA-VI-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; LEGACY-MESA-VI-NEXT:   S_ENDPGM 0
   %in = load i32, ptr addrspace(4) %in.byref
-  store i32 %in, ptr addrspace(1) undef, align 4
+  store i32 %in, ptr addrspace(1) poison, align 4
   ret void
 }
 
@@ -2017,7 +2017,7 @@ define amdgpu_kernel void @v2p1i8_arg(<2 x ptr addrspace(1)> %arg) nounwind {
   ; HSA-VI-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p4) = G_PTR_ADD [[COPY]], [[C]](s64)
   ; HSA-VI-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x p1>) = G_LOAD [[PTR_ADD]](p4) :: (dereferenceable invariant load (<2 x p1>), addrspace 4)
   ; HSA-VI-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; HSA-VI-NEXT:   G_STORE [[LOAD]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; HSA-VI-NEXT:   G_STORE [[LOAD]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison`, addrspace 1)
   ; HSA-VI-NEXT:   S_ENDPGM 0
   ;
   ; LEGACY-MESA-VI-LABEL: name: v2p1i8_arg
@@ -2029,9 +2029,9 @@ define amdgpu_kernel void @v2p1i8_arg(<2 x ptr addrspace(1)> %arg) nounwind {
   ; LEGACY-MESA-VI-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p4) = G_PTR_ADD [[COPY]], [[C]](s64)
   ; LEGACY-MESA-VI-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x p1>) = G_LOAD [[PTR_ADD]](p4) :: (dereferenceable invariant load (<2 x p1>), align 4, addrspace 4)
   ; LEGACY-MESA-VI-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; LEGACY-MESA-VI-NEXT:   G_STORE [[LOAD]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; LEGACY-MESA-VI-NEXT:   G_STORE [[LOAD]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison`, addrspace 1)
   ; LEGACY-MESA-VI-NEXT:   S_ENDPGM 0
-  store <2 x ptr addrspace(1)> %arg, ptr addrspace(1) undef
+  store <2 x ptr addrspace(1)> %arg, ptr addrspace(1) poison
   ret void
 }
 
@@ -2045,7 +2045,7 @@ define amdgpu_kernel void @v2p3i8_arg(<2 x ptr addrspace(3)> %arg) nounwind {
   ; HSA-VI-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p4) = G_PTR_ADD [[COPY]], [[C]](s64)
   ; HSA-VI-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x p3>) = G_LOAD [[PTR_ADD]](p4) :: (dereferenceable invariant load (<2 x p3>), align 16, addrspace 4)
   ; HSA-VI-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; HSA-VI-NEXT:   G_STORE [[LOAD]](<2 x p3>), [[DEF]](p1) :: (store (<2 x p3>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; HSA-VI-NEXT:   G_STORE [[LOAD]](<2 x p3>), [[DEF]](p1) :: (store (<2 x p3>) into `ptr addrspace(1) poison`, addrspace 1)
   ; HSA-VI-NEXT:   S_ENDPGM 0
   ;
   ; LEGACY-MESA-VI-LABEL: name: v2p3i8_arg
@@ -2057,9 +2057,9 @@ define amdgpu_kernel void @v2p3i8_arg(<2 x ptr addrspace(3)> %arg) nounwind {
   ; LEGACY-MESA-VI-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p4) = G_PTR_ADD [[COPY]], [[C]](s64)
   ; LEGACY-MESA-VI-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x p3>) = G_LOAD [[PTR_ADD]](p4) :: (dereferenceable invariant load (<2 x p3>), align 4, addrspace 4)
   ; LEGACY-MESA-VI-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; LEGACY-MESA-VI-NEXT:   G_STORE [[LOAD]](<2 x p3>), [[DEF]](p1) :: (store (<2 x p3>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; LEGACY-MESA-VI-NEXT:   G_STORE [[LOAD]](<2 x p3>), [[DEF]](p1) :: (store (<2 x p3>) into `ptr addrspace(1) poison`, addrspace 1)
   ; LEGACY-MESA-VI-NEXT:   S_ENDPGM 0
-  store <2 x ptr addrspace(3)> %arg, ptr addrspace(1) undef
+  store <2 x ptr addrspace(3)> %arg, ptr addrspace(1) poison
   ret void
 }
 
@@ -2076,10 +2076,10 @@ define amdgpu_kernel void @v2p1i8_in_struct_arg({ <2 x ptr addrspace(1)>, <2 x p
   ; HSA-VI-NEXT:   [[PTR_ADD1:%[0-9]+]]:_(p4) = G_PTR_ADD [[COPY]], [[C1]](s64)
   ; HSA-VI-NEXT:   [[LOAD1:%[0-9]+]]:_(<2 x p3>) = G_LOAD [[PTR_ADD1]](p4) :: (dereferenceable invariant load (<2 x s32>), align 16, addrspace 4)
   ; HSA-VI-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; HSA-VI-NEXT:   G_STORE [[LOAD]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; HSA-VI-NEXT:   G_STORE [[LOAD]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison`, addrspace 1)
   ; HSA-VI-NEXT:   [[C2:%[0-9]+]]:_(s64) = G_CONSTANT i64 16
   ; HSA-VI-NEXT:   [[PTR_ADD2:%[0-9]+]]:_(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
-  ; HSA-VI-NEXT:   G_STORE [[LOAD1]](<2 x p3>), [[PTR_ADD2]](p1) :: (store (<2 x p3>) into `ptr addrspace(1) undef` + 16, align 16, addrspace 1)
+  ; HSA-VI-NEXT:   G_STORE [[LOAD1]](<2 x p3>), [[PTR_ADD2]](p1) :: (store (<2 x p3>) into `ptr addrspace(1) poison` + 16, align 16, addrspace 1)
   ; HSA-VI-NEXT:   S_ENDPGM 0
   ;
   ; LEGACY-MESA-VI-LABEL: name: v2p1i8_in_struct_arg
@@ -2094,11 +2094,11 @@ define amdgpu_kernel void @v2p1i8_in_struct_arg({ <2 x ptr addrspace(1)>, <2 x p
   ; LEGACY-MESA-VI-NEXT:   [[PTR_ADD1:%[0-9]+]]:_(p4) = G_PTR_ADD [[COPY]], [[C1]](s64)
   ; LEGACY-MESA-VI-NEXT:   [[LOAD1:%[0-9]+]]:_(<2 x p3>) = G_LOAD [[PTR_ADD1]](p4) :: (dereferenceable invariant load (<2 x s32>), align 4, addrspace 4)
   ; LEGACY-MESA-VI-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; LEGACY-MESA-VI-NEXT:   G_STORE [[LOAD]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; LEGACY-MESA-VI-NEXT:   G_STORE [[LOAD]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison`, addrspace 1)
   ; LEGACY-MESA-VI-NEXT:   [[C2:%[0-9]+]]:_(s64) = G_CONSTANT i64 16
   ; LEGACY-MESA-VI-NEXT:   [[PTR_ADD2:%[0-9]+]]:_(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
-  ; LEGACY-MESA-VI-NEXT:   G_STORE [[LOAD1]](<2 x p3>), [[PTR_ADD2]](p1) :: (store (<2 x p3>) into `ptr addrspace(1) undef` + 16, align 16, addrspace 1)
+  ; LEGACY-MESA-VI-NEXT:   G_STORE [[LOAD1]](<2 x p3>), [[PTR_ADD2]](p1) :: (store (<2 x p3>) into `ptr addrspace(1) poison` + 16, align 16, addrspace 1)
   ; LEGACY-MESA-VI-NEXT:   S_ENDPGM 0
-  store { <2 x ptr addrspace(1)>, <2 x ptr addrspace(3)> } %arg, ptr addrspace(1) undef
+  store { <2 x ptr addrspace(1)>, <2 x ptr addrspace(3)> } %arg, ptr addrspace(1) poison
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-call-return-values.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-call-return-values.ll
@@ -204,10 +204,10 @@ define amdgpu_kernel void @test_call_external_i1_func_void() #0 {
   ; GCN-NEXT:   [[COPY21:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; GCN-NEXT:   [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[COPY21]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[TRUNC]](s1), [[DEF]](p1) :: (volatile store (s1) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[TRUNC]](s1), [[DEF]](p1) :: (volatile store (s1) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call i1 @external_i1_func_void()
-  store volatile i1 %val, ptr addrspace(1) undef
+  store volatile i1 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -223,10 +223,10 @@ define amdgpu_gfx void @test_gfx_call_external_i1_func_void() #0 {
   ; GCN-NEXT:   [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; GCN-NEXT:   [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[COPY1]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[TRUNC]](s1), [[DEF]](p1) :: (volatile store (s1) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[TRUNC]](s1), [[DEF]](p1) :: (volatile store (s1) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   SI_RETURN
   %val = call amdgpu_gfx i1 @external_gfx_i1_func_void()
-  store volatile i1 %val, ptr addrspace(1) undef
+  store volatile i1 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -284,11 +284,11 @@ define amdgpu_kernel void @test_call_external_i1_zeroext_func_void() #0 {
   ; GCN-NEXT:   [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[ASSERT_ZEXT]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; GCN-NEXT:   [[ZEXT:%[0-9]+]]:_(s32) = G_ZEXT [[TRUNC]](s1)
-  ; GCN-NEXT:   G_STORE [[ZEXT]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[ZEXT]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call i1 @external_i1_zeroext_func_void()
   %val.ext = zext i1 %val to i32
-  store volatile i32 %val.ext, ptr addrspace(1) undef
+  store volatile i32 %val.ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -346,11 +346,11 @@ define amdgpu_kernel void @test_call_external_i1_signext_func_void() #0 {
   ; GCN-NEXT:   [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[ASSERT_SEXT]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; GCN-NEXT:   [[SEXT:%[0-9]+]]:_(s32) = G_SEXT [[TRUNC]](s1)
-  ; GCN-NEXT:   G_STORE [[SEXT]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[SEXT]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call i1 @external_i1_signext_func_void()
   %val.ext = sext i1 %val to i32
-  store volatile i32 %val.ext, ptr addrspace(1) undef
+  store volatile i32 %val.ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -407,10 +407,10 @@ define amdgpu_kernel void @test_call_external_i8_func_void() #0 {
   ; GCN-NEXT:   [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY21]](s32)
   ; GCN-NEXT:   [[TRUNC1:%[0-9]+]]:_(s8) = G_TRUNC [[TRUNC]](s16)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[TRUNC1]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[TRUNC1]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call i8 @external_i8_func_void()
-  store volatile i8 %val, ptr addrspace(1) undef
+  store volatile i8 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -427,10 +427,10 @@ define amdgpu_gfx void @test_gfx_call_external_i8_func_void() #0 {
   ; GCN-NEXT:   [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY1]](s32)
   ; GCN-NEXT:   [[TRUNC1:%[0-9]+]]:_(s8) = G_TRUNC [[TRUNC]](s16)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[TRUNC1]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[TRUNC1]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   SI_RETURN
   %val = call amdgpu_gfx i8 @external_gfx_i8_func_void()
-  store volatile i8 %val, ptr addrspace(1) undef
+  store volatile i8 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -488,11 +488,11 @@ define amdgpu_kernel void @test_call_external_i8_zeroext_func_void() #0 {
   ; GCN-NEXT:   [[TRUNC:%[0-9]+]]:_(s8) = G_TRUNC [[ASSERT_ZEXT]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; GCN-NEXT:   [[ZEXT:%[0-9]+]]:_(s32) = G_ZEXT [[TRUNC]](s8)
-  ; GCN-NEXT:   G_STORE [[ZEXT]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[ZEXT]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call i8 @external_i8_zeroext_func_void()
   %val.ext = zext i8 %val to i32
-  store volatile i32 %val.ext, ptr addrspace(1) undef
+  store volatile i32 %val.ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -550,11 +550,11 @@ define amdgpu_kernel void @test_call_external_i8_signext_func_void() #0 {
   ; GCN-NEXT:   [[TRUNC:%[0-9]+]]:_(s8) = G_TRUNC [[ASSERT_SEXT]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; GCN-NEXT:   [[SEXT:%[0-9]+]]:_(s32) = G_SEXT [[TRUNC]](s8)
-  ; GCN-NEXT:   G_STORE [[SEXT]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[SEXT]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call i8 @external_i8_signext_func_void()
   %val.ext = sext i8 %val to i32
-  store volatile i32 %val.ext, ptr addrspace(1) undef
+  store volatile i32 %val.ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -610,10 +610,10 @@ define amdgpu_kernel void @test_call_external_i16_func_void() #0 {
   ; GCN-NEXT:   [[COPY21:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; GCN-NEXT:   [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY21]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[TRUNC]](s16), [[DEF]](p1) :: (volatile store (s16) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[TRUNC]](s16), [[DEF]](p1) :: (volatile store (s16) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call i16 @external_i16_func_void()
-  store volatile i16 %val, ptr addrspace(1) undef
+  store volatile i16 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -671,11 +671,11 @@ define amdgpu_kernel void @test_call_external_i16_zeroext_func_void() #0 {
   ; GCN-NEXT:   [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[ASSERT_ZEXT]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; GCN-NEXT:   [[ZEXT:%[0-9]+]]:_(s32) = G_ZEXT [[TRUNC]](s16)
-  ; GCN-NEXT:   G_STORE [[ZEXT]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[ZEXT]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call i16 @external_i16_zeroext_func_void()
   %val.ext = zext i16 %val to i32
-  store volatile i32 %val.ext, ptr addrspace(1) undef
+  store volatile i32 %val.ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -733,11 +733,11 @@ define amdgpu_kernel void @test_call_external_i16_signext_func_void() #0 {
   ; GCN-NEXT:   [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[ASSERT_SEXT]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; GCN-NEXT:   [[SEXT:%[0-9]+]]:_(s32) = G_SEXT [[TRUNC]](s16)
-  ; GCN-NEXT:   G_STORE [[SEXT]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[SEXT]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call i16 @external_i16_signext_func_void()
   %val.ext = sext i16 %val to i32
-  store volatile i32 %val.ext, ptr addrspace(1) undef
+  store volatile i32 %val.ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -792,10 +792,10 @@ define amdgpu_kernel void @test_call_external_i32_func_void() #0 {
   ; GCN-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_i32_func_void, csr_amdgpu, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31, implicit-def $vgpr0
   ; GCN-NEXT:   [[COPY21:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[COPY21]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[COPY21]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call i32 @external_i32_func_void()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -810,10 +810,10 @@ define amdgpu_gfx void @test_gfx_call_external_i32_func_void() #0 {
   ; GCN-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_gfx_i32_func_void, csr_amdgpu_si_gfx, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit-def $vgpr0
   ; GCN-NEXT:   [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[COPY1]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[COPY1]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   SI_RETURN
   %val = call amdgpu_gfx i32 @external_gfx_i32_func_void()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -871,10 +871,10 @@ define amdgpu_kernel void @test_call_external_i48_func_void() #0 {
   ; GCN-NEXT:   [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY21]](s32), [[COPY22]](s32)
   ; GCN-NEXT:   [[TRUNC:%[0-9]+]]:_(s48) = G_TRUNC [[MV]](s64)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[TRUNC]](s48), [[DEF]](p1) :: (volatile store (s48) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[TRUNC]](s48), [[DEF]](p1) :: (volatile store (s48) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call i48 @external_i48_func_void()
-  store volatile i48 %val, ptr addrspace(1) undef
+  store volatile i48 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -933,11 +933,11 @@ define amdgpu_kernel void @test_call_external_i48_zeroext_func_void() #0 {
   ; GCN-NEXT:   [[TRUNC:%[0-9]+]]:_(s48) = G_TRUNC [[MV]](s64)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; GCN-NEXT:   [[ZEXT:%[0-9]+]]:_(s64) = G_ZEXT [[TRUNC]](s48)
-  ; GCN-NEXT:   G_STORE [[ZEXT]](s64), [[DEF]](p1) :: (volatile store (s64) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[ZEXT]](s64), [[DEF]](p1) :: (volatile store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call i48 @external_i48_zeroext_func_void()
   %ext = zext i48 %val to i64
-  store volatile i64 %ext, ptr addrspace(1) undef
+  store volatile i64 %ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -996,11 +996,11 @@ define amdgpu_kernel void @test_call_external_i48_signext_func_void() #0 {
   ; GCN-NEXT:   [[TRUNC:%[0-9]+]]:_(s48) = G_TRUNC [[MV]](s64)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; GCN-NEXT:   [[SEXT:%[0-9]+]]:_(s64) = G_SEXT [[TRUNC]](s48)
-  ; GCN-NEXT:   G_STORE [[SEXT]](s64), [[DEF]](p1) :: (volatile store (s64) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[SEXT]](s64), [[DEF]](p1) :: (volatile store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call i48 @external_i48_signext_func_void()
   %ext = sext i48 %val to i64
-  store volatile i64 %ext, ptr addrspace(1) undef
+  store volatile i64 %ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -1057,10 +1057,10 @@ define amdgpu_kernel void @test_call_external_i64_func_void() #0 {
   ; GCN-NEXT:   [[COPY22:%[0-9]+]]:_(s32) = COPY $vgpr1
   ; GCN-NEXT:   [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY21]](s32), [[COPY22]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (volatile store (s64) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (volatile store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call i64 @external_i64_func_void()
-  store volatile i64 %val, ptr addrspace(1) undef
+  store volatile i64 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -1117,10 +1117,10 @@ define amdgpu_kernel void @test_call_external_p1_func_void() #0 {
   ; GCN-NEXT:   [[COPY22:%[0-9]+]]:_(s32) = COPY $vgpr1
   ; GCN-NEXT:   [[MV:%[0-9]+]]:_(p1) = G_MERGE_VALUES [[COPY21]](s32), [[COPY22]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[MV]](p1), [[DEF]](p1) :: (volatile store (p1) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[MV]](p1), [[DEF]](p1) :: (volatile store (p1) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call ptr addrspace(1) @external_p1_func_void()
-  store volatile ptr addrspace(1) %val, ptr addrspace(1) undef
+  store volatile ptr addrspace(1) %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -1181,10 +1181,10 @@ define amdgpu_kernel void @test_call_external_v2p1_func_void() #0 {
   ; GCN-NEXT:   [[MV1:%[0-9]+]]:_(p1) = G_MERGE_VALUES [[COPY23]](s32), [[COPY24]](s32)
   ; GCN-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x p1>) = G_BUILD_VECTOR [[MV]](p1), [[MV1]](p1)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x p1>), [[DEF]](p1) :: (volatile store (<2 x p1>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x p1>), [[DEF]](p1) :: (volatile store (<2 x p1>) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <2 x ptr addrspace(1)> @external_v2p1_func_void()
-  store volatile <2 x ptr addrspace(1)> %val, ptr addrspace(1) undef
+  store volatile <2 x ptr addrspace(1)> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -1358,10 +1358,10 @@ define amdgpu_kernel void @test_call_external_f16_func_void() #0 {
   ; GCN-NEXT:   [[COPY21:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; GCN-NEXT:   [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY21]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[TRUNC]](s16), [[DEF]](p1) :: (volatile store (s16) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[TRUNC]](s16), [[DEF]](p1) :: (volatile store (s16) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call half @external_f16_func_void()
-  store volatile half %val, ptr addrspace(1) undef
+  store volatile half %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -1416,10 +1416,10 @@ define amdgpu_kernel void @test_call_external_f32_func_void() #0 {
   ; GCN-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_f32_func_void, csr_amdgpu, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31, implicit-def $vgpr0
   ; GCN-NEXT:   [[COPY21:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[COPY21]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[COPY21]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call float @external_f32_func_void()
-  store volatile float %val, ptr addrspace(1) undef
+  store volatile float %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -1476,10 +1476,10 @@ define amdgpu_kernel void @test_call_external_f64_func_void() #0 {
   ; GCN-NEXT:   [[COPY22:%[0-9]+]]:_(s32) = COPY $vgpr1
   ; GCN-NEXT:   [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY21]](s32), [[COPY22]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (volatile store (s64) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (volatile store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call double @external_f64_func_void()
-  store volatile double %val, ptr addrspace(1) undef
+  store volatile double %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -1540,10 +1540,10 @@ define amdgpu_kernel void @test_call_external_v2f64_func_void() #0 {
   ; GCN-NEXT:   [[MV1:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY23]](s32), [[COPY24]](s32)
   ; GCN-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s64>), [[DEF]](p1) :: (volatile store (<2 x s64>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s64>), [[DEF]](p1) :: (volatile store (<2 x s64>) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <2 x double> @external_v2f64_func_void()
-  store volatile <2 x double> %val, ptr addrspace(1) undef
+  store volatile <2 x double> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -1600,10 +1600,10 @@ define amdgpu_kernel void @test_call_external_v2i32_func_void() #0 {
   ; GCN-NEXT:   [[COPY22:%[0-9]+]]:_(s32) = COPY $vgpr1
   ; GCN-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY21]](s32), [[COPY22]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s32>), [[DEF]](p1) :: (volatile store (<2 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s32>), [[DEF]](p1) :: (volatile store (<2 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <2 x i32> @external_v2i32_func_void()
-  store volatile <2 x i32> %val, ptr addrspace(1) undef
+  store volatile <2 x i32> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -1661,10 +1661,10 @@ define amdgpu_kernel void @test_call_external_v3i32_func_void() #0 {
   ; GCN-NEXT:   [[COPY23:%[0-9]+]]:_(s32) = COPY $vgpr2
   ; GCN-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[COPY21]](s32), [[COPY22]](s32), [[COPY23]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s32>), [[DEF]](p1) :: (volatile store (<3 x s32>) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s32>), [[DEF]](p1) :: (volatile store (<3 x s32>) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <3 x i32> @external_v3i32_func_void()
-  store volatile <3 x i32> %val, ptr addrspace(1) undef, align 8
+  store volatile <3 x i32> %val, ptr addrspace(1) poison, align 8
   ret void
 }
 
@@ -1723,10 +1723,10 @@ define amdgpu_kernel void @test_call_external_v4i32_func_void() #0 {
   ; GCN-NEXT:   [[COPY24:%[0-9]+]]:_(s32) = COPY $vgpr3
   ; GCN-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_BUILD_VECTOR [[COPY21]](s32), [[COPY22]](s32), [[COPY23]](s32), [[COPY24]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<4 x s32>), [[DEF]](p1) :: (volatile store (<4 x s32>) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<4 x s32>), [[DEF]](p1) :: (volatile store (<4 x s32>) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <4 x i32> @external_v4i32_func_void()
-  store volatile <4 x i32> %val, ptr addrspace(1) undef, align 8
+  store volatile <4 x i32> %val, ptr addrspace(1) poison, align 8
   ret void
 }
 
@@ -1786,10 +1786,10 @@ define amdgpu_kernel void @test_call_external_v5i32_func_void() #0 {
   ; GCN-NEXT:   [[COPY25:%[0-9]+]]:_(s32) = COPY $vgpr4
   ; GCN-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<5 x s32>) = G_BUILD_VECTOR [[COPY21]](s32), [[COPY22]](s32), [[COPY23]](s32), [[COPY24]](s32), [[COPY25]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<5 x s32>), [[DEF]](p1) :: (volatile store (<5 x s32>) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<5 x s32>), [[DEF]](p1) :: (volatile store (<5 x s32>) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <5 x i32> @external_v5i32_func_void()
-  store volatile <5 x i32> %val, ptr addrspace(1) undef, align 8
+  store volatile <5 x i32> %val, ptr addrspace(1) poison, align 8
   ret void
 }
 
@@ -1852,10 +1852,10 @@ define amdgpu_kernel void @test_call_external_v8i32_func_void() #0 {
   ; GCN-NEXT:   [[COPY28:%[0-9]+]]:_(s32) = COPY $vgpr7
   ; GCN-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<8 x s32>) = G_BUILD_VECTOR [[COPY21]](s32), [[COPY22]](s32), [[COPY23]](s32), [[COPY24]](s32), [[COPY25]](s32), [[COPY26]](s32), [[COPY27]](s32), [[COPY28]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<8 x s32>), [[DEF]](p1) :: (volatile store (<8 x s32>) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<8 x s32>), [[DEF]](p1) :: (volatile store (<8 x s32>) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <8 x i32> @external_v8i32_func_void()
-  store volatile <8 x i32> %val, ptr addrspace(1) undef, align 8
+  store volatile <8 x i32> %val, ptr addrspace(1) poison, align 8
   ret void
 }
 
@@ -1926,10 +1926,10 @@ define amdgpu_kernel void @test_call_external_v16i32_func_void() #0 {
   ; GCN-NEXT:   [[COPY36:%[0-9]+]]:_(s32) = COPY $vgpr15
   ; GCN-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_BUILD_VECTOR [[COPY21]](s32), [[COPY22]](s32), [[COPY23]](s32), [[COPY24]](s32), [[COPY25]](s32), [[COPY26]](s32), [[COPY27]](s32), [[COPY28]](s32), [[COPY29]](s32), [[COPY30]](s32), [[COPY31]](s32), [[COPY32]](s32), [[COPY33]](s32), [[COPY34]](s32), [[COPY35]](s32), [[COPY36]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<16 x s32>), [[DEF]](p1) :: (volatile store (<16 x s32>) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<16 x s32>), [[DEF]](p1) :: (volatile store (<16 x s32>) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <16 x i32> @external_v16i32_func_void()
-  store volatile <16 x i32> %val, ptr addrspace(1) undef, align 8
+  store volatile <16 x i32> %val, ptr addrspace(1) poison, align 8
   ret void
 }
 
@@ -2016,10 +2016,10 @@ define amdgpu_kernel void @test_call_external_v32i32_func_void() #0 {
   ; GCN-NEXT:   [[COPY52:%[0-9]+]]:_(s32) = COPY $vgpr31
   ; GCN-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<32 x s32>) = G_BUILD_VECTOR [[COPY21]](s32), [[COPY22]](s32), [[COPY23]](s32), [[COPY24]](s32), [[COPY25]](s32), [[COPY26]](s32), [[COPY27]](s32), [[COPY28]](s32), [[COPY29]](s32), [[COPY30]](s32), [[COPY31]](s32), [[COPY32]](s32), [[COPY33]](s32), [[COPY34]](s32), [[COPY35]](s32), [[COPY36]](s32), [[COPY37]](s32), [[COPY38]](s32), [[COPY39]](s32), [[COPY40]](s32), [[COPY41]](s32), [[COPY42]](s32), [[COPY43]](s32), [[COPY44]](s32), [[COPY45]](s32), [[COPY46]](s32), [[COPY47]](s32), [[COPY48]](s32), [[COPY49]](s32), [[COPY50]](s32), [[COPY51]](s32), [[COPY52]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <32 x i32> @external_v32i32_func_void()
-  store volatile <32 x i32> %val, ptr addrspace(1) undef, align 8
+  store volatile <32 x i32> %val, ptr addrspace(1) poison, align 8
   ret void
 }
 
@@ -2074,10 +2074,10 @@ define amdgpu_kernel void @test_call_external_v2i16_func_void() #0 {
   ; GCN-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_v2i16_func_void, csr_amdgpu, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31, implicit-def $vgpr0
   ; GCN-NEXT:   [[COPY21:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[COPY21]](<2 x s16>), [[DEF]](p1) :: (volatile store (<2 x s16>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[COPY21]](<2 x s16>), [[DEF]](p1) :: (volatile store (<2 x s16>) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <2 x i16> @external_v2i16_func_void()
-  store volatile <2 x i16> %val, ptr addrspace(1) undef
+  store volatile <2 x i16> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -2136,10 +2136,10 @@ define amdgpu_kernel void @test_call_external_v3i16_func_void() #0 {
   ; GCN-NEXT:   [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16), [[UV2:%[0-9]+]]:_(s16), [[UV3:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<4 x s16>)
   ; GCN-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s16>) = G_BUILD_VECTOR [[UV]](s16), [[UV1]](s16), [[UV2]](s16)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s16>), [[DEF]](p1) :: (volatile store (<3 x s16>) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s16>), [[DEF]](p1) :: (volatile store (<3 x s16>) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <3 x i16> @external_v3i16_func_void()
-  store volatile <3 x i16> %val, ptr addrspace(1) undef
+  store volatile <3 x i16> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -2196,10 +2196,10 @@ define amdgpu_kernel void @test_call_external_v4i16_func_void() #0 {
   ; GCN-NEXT:   [[COPY22:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
   ; GCN-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[COPY21]](<2 x s16>), [[COPY22]](<2 x s16>)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[CONCAT_VECTORS]](<4 x s16>), [[DEF]](p1) :: (volatile store (<4 x s16>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[CONCAT_VECTORS]](<4 x s16>), [[DEF]](p1) :: (volatile store (<4 x s16>) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <4 x i16> @external_v4i16_func_void()
-  store volatile <4 x i16> %val, ptr addrspace(1) undef
+  store volatile <4 x i16> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -2254,10 +2254,10 @@ define amdgpu_kernel void @test_call_external_v2f16_func_void() #0 {
   ; GCN-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_v2f16_func_void, csr_amdgpu, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31, implicit-def $vgpr0
   ; GCN-NEXT:   [[COPY21:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[COPY21]](<2 x s16>), [[DEF]](p1) :: (volatile store (<2 x s16>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[COPY21]](<2 x s16>), [[DEF]](p1) :: (volatile store (<2 x s16>) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <2 x half> @external_v2f16_func_void()
-  store volatile <2 x half> %val, ptr addrspace(1) undef
+  store volatile <2 x half> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -2316,10 +2316,10 @@ define amdgpu_kernel void @test_call_external_v3f16_func_void() #0 {
   ; GCN-NEXT:   [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16), [[UV2:%[0-9]+]]:_(s16), [[UV3:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<4 x s16>)
   ; GCN-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s16>) = G_BUILD_VECTOR [[UV]](s16), [[UV1]](s16), [[UV2]](s16)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s16>), [[DEF]](p1) :: (volatile store (<3 x s16>) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s16>), [[DEF]](p1) :: (volatile store (<3 x s16>) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <3 x half> @external_v3f16_func_void()
-  store volatile <3 x half> %val, ptr addrspace(1) undef
+  store volatile <3 x half> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -2376,10 +2376,10 @@ define amdgpu_kernel void @test_call_external_v4f16_func_void() #0 {
   ; GCN-NEXT:   [[COPY22:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
   ; GCN-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[COPY21]](<2 x s16>), [[COPY22]](<2 x s16>)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[CONCAT_VECTORS]](<4 x s16>), [[DEF]](p1) :: (volatile store (<4 x s16>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[CONCAT_VECTORS]](<4 x s16>), [[DEF]](p1) :: (volatile store (<4 x s16>) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <4 x half> @external_v4f16_func_void()
-  store volatile <4 x half> %val, ptr addrspace(1) undef
+  store volatile <4 x half> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -2437,10 +2437,10 @@ define amdgpu_kernel void @test_call_external_v3f32_func_void() #0 {
   ; GCN-NEXT:   [[COPY23:%[0-9]+]]:_(s32) = COPY $vgpr2
   ; GCN-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[COPY21]](s32), [[COPY22]](s32), [[COPY23]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s32>), [[DEF]](p1) :: (volatile store (<3 x s32>) into `ptr addrspace(1) undef`, align 16, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s32>), [[DEF]](p1) :: (volatile store (<3 x s32>) into `ptr addrspace(1) poison`, align 16, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <3 x float> @external_v3f32_func_void()
-  store volatile <3 x float> %val, ptr addrspace(1) undef
+  store volatile <3 x float> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -2500,10 +2500,10 @@ define amdgpu_kernel void @test_call_external_v5f32_func_void() #0 {
   ; GCN-NEXT:   [[COPY25:%[0-9]+]]:_(s32) = COPY $vgpr4
   ; GCN-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<5 x s32>) = G_BUILD_VECTOR [[COPY21]](s32), [[COPY22]](s32), [[COPY23]](s32), [[COPY24]](s32), [[COPY25]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<5 x s32>), [[DEF]](p1) :: (volatile store (<5 x s32>) into `ptr addrspace(1) undef`, align 32, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[BUILD_VECTOR]](<5 x s32>), [[DEF]](p1) :: (volatile store (<5 x s32>) into `ptr addrspace(1) poison`, align 32, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <5 x float> @external_v5f32_func_void()
-  store volatile <5 x float> %val, ptr addrspace(1) undef
+  store volatile <5 x float> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -2562,14 +2562,14 @@ define amdgpu_kernel void @test_call_external_i32_i64_func_void() #0 {
   ; GCN-NEXT:   [[COPY23:%[0-9]+]]:_(s32) = COPY $vgpr2
   ; GCN-NEXT:   [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY22]](s32), [[COPY23]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[COPY21]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
-  ; GCN-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (volatile store (s64) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[COPY21]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (volatile store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call { i32, i64 } @external_i32_i64_func_void()
   %val.0 = extractvalue { i32, i64 } %val, 0
   %val.1 = extractvalue { i32, i64 } %val, 1
-  store volatile i32 %val.0, ptr addrspace(1) undef
-  store volatile i64 %val.1, ptr addrspace(1) undef
+  store volatile i32 %val.0, ptr addrspace(1) poison
+  store volatile i64 %val.1, ptr addrspace(1) poison
   ret void
 }
 
@@ -2587,14 +2587,14 @@ define amdgpu_gfx void @test_gfx_call_external_i32_i64_func_void() #0 {
   ; GCN-NEXT:   [[COPY3:%[0-9]+]]:_(s32) = COPY $vgpr2
   ; GCN-NEXT:   [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY2]](s32), [[COPY3]](s32)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[COPY1]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
-  ; GCN-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (volatile store (s64) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[COPY1]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (volatile store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   SI_RETURN
   %val = call amdgpu_gfx { i32, i64 } @external_gfx_i32_i64_func_void()
   %val.0 = extractvalue { i32, i64 } %val, 0
   %val.1 = extractvalue { i32, i64 } %val, 1
-  store volatile i32 %val.0, ptr addrspace(1) undef
-  store volatile i64 %val.1, ptr addrspace(1) undef
+  store volatile i32 %val.0, ptr addrspace(1) poison
+  store volatile i64 %val.1, ptr addrspace(1) poison
   ret void
 }
 
@@ -2650,14 +2650,14 @@ define amdgpu_kernel void @test_call_external_a2i32_func_void() #0 {
   ; GCN-NEXT:   [[COPY21:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; GCN-NEXT:   [[COPY22:%[0-9]+]]:_(s32) = COPY $vgpr1
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[COPY21]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
-  ; GCN-NEXT:   G_STORE [[COPY22]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[COPY21]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[COPY22]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call [2 x i32] @external_a2i32_func_void()
   %val.0 = extractvalue [2 x i32] %val, 0
   %val.1 = extractvalue [2 x i32] %val, 1
-  store volatile i32 %val.0, ptr addrspace(1) undef
-  store volatile i32 %val.1, ptr addrspace(1) undef
+  store volatile i32 %val.0, ptr addrspace(1) poison
+  store volatile i32 %val.1, ptr addrspace(1) poison
   ret void
 }
 
@@ -2726,11 +2726,11 @@ define amdgpu_kernel void @test_call_external_a5i8_func_void() #0 {
   ; GCN-NEXT:   [[TRUNC8:%[0-9]+]]:_(s16) = G_TRUNC [[COPY25]](s32)
   ; GCN-NEXT:   [[TRUNC9:%[0-9]+]]:_(s8) = G_TRUNC [[TRUNC8]](s16)
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
-  ; GCN-NEXT:   G_STORE [[TRUNC1]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) undef`, addrspace 1)
-  ; GCN-NEXT:   G_STORE [[TRUNC3]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) undef`, addrspace 1)
-  ; GCN-NEXT:   G_STORE [[TRUNC5]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) undef`, addrspace 1)
-  ; GCN-NEXT:   G_STORE [[TRUNC7]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) undef`, addrspace 1)
-  ; GCN-NEXT:   G_STORE [[TRUNC9]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[TRUNC1]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) poison`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[TRUNC3]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) poison`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[TRUNC5]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) poison`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[TRUNC7]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) poison`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[TRUNC9]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call [5 x i8] @external_a5i8_func_void()
   %val.0 = extractvalue [5 x i8] %val, 0
@@ -2738,11 +2738,11 @@ define amdgpu_kernel void @test_call_external_a5i8_func_void() #0 {
   %val.2 = extractvalue [5 x i8] %val, 2
   %val.3 = extractvalue [5 x i8] %val, 3
   %val.4 = extractvalue [5 x i8] %val, 4
-  store volatile i8 %val.0, ptr addrspace(1) undef
-  store volatile i8 %val.1, ptr addrspace(1) undef
-  store volatile i8 %val.2, ptr addrspace(1) undef
-  store volatile i8 %val.3, ptr addrspace(1) undef
-  store volatile i8 %val.4, ptr addrspace(1) undef
+  store volatile i8 %val.0, ptr addrspace(1) poison
+  store volatile i8 %val.1, ptr addrspace(1) poison
+  store volatile i8 %val.2, ptr addrspace(1) poison
+  store volatile i8 %val.3, ptr addrspace(1) poison
+  store volatile i8 %val.4, ptr addrspace(1) poison
   ret void
 }
 
@@ -2802,14 +2802,14 @@ define amdgpu_kernel void @test_call_external_v32i32_i32_func_void() #0 {
   ; GCN-NEXT:   [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 128
   ; GCN-NEXT:   [[PTR_ADD1:%[0-9]+]]:_(p5) = G_PTR_ADD [[FRAME_INDEX]], [[C3]](s32)
   ; GCN-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD1]](p5) :: (load (s32) from %stack.0, align 128, addrspace 5)
-  ; GCN-NEXT:   G_STORE [[LOAD]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) undef`, align 8, addrspace 1)
-  ; GCN-NEXT:   G_STORE [[LOAD1]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[LOAD]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) poison`, align 8, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[LOAD1]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call { <32 x i32>, i32 } @external_v32i32_i32_func_void()
   %val0 = extractvalue { <32 x i32>, i32 } %val, 0
   %val1 = extractvalue { <32 x i32>, i32 } %val, 1
-  store volatile <32 x i32> %val0, ptr addrspace(1) undef, align 8
-  store volatile i32 %val1, ptr addrspace(1) undef
+  store volatile <32 x i32> %val0, ptr addrspace(1) poison, align 8
+  store volatile i32 %val1, ptr addrspace(1) poison
   ret void
 }
 
@@ -2869,14 +2869,14 @@ define amdgpu_kernel void @test_call_external_i32_v32i32_func_void() #0 {
   ; GCN-NEXT:   [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 128
   ; GCN-NEXT:   [[PTR_ADD1:%[0-9]+]]:_(p5) = G_PTR_ADD [[FRAME_INDEX]], [[C3]](s32)
   ; GCN-NEXT:   [[LOAD1:%[0-9]+]]:_(<32 x s32>) = G_LOAD [[PTR_ADD1]](p5) :: (load (<32 x s32>) from %stack.0, addrspace 5)
-  ; GCN-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
-  ; GCN-NEXT:   G_STORE [[LOAD1]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[LOAD1]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call { i32, <32 x i32> } @external_i32_v32i32_func_void()
   %val0 = extractvalue { i32, <32 x i32> } %val, 0
   %val1 = extractvalue { i32, <32 x i32> } %val, 1
-  store volatile i32 %val0, ptr addrspace(1) undef
-  store volatile <32 x i32> %val1, ptr addrspace(1) undef, align 8
+  store volatile i32 %val0, ptr addrspace(1) poison
+  store volatile <32 x i32> %val1, ptr addrspace(1) poison, align 8
   ret void
 }
 
@@ -2933,10 +2933,10 @@ define amdgpu_kernel void @test_call_external_v33i32_func_void() #0 {
   ; GCN-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_v33i32_func_void, csr_amdgpu, implicit $vgpr0, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; GCN-NEXT:   [[LOAD:%[0-9]+]]:_(<33 x s32>) = G_LOAD [[FRAME_INDEX]](p5) :: (load (<33 x s32>) from %stack.0, align 256, addrspace 5)
-  ; GCN-NEXT:   G_STORE [[LOAD]](<33 x s32>), [[DEF]](p1) :: (volatile store (<33 x s32>) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[LOAD]](<33 x s32>), [[DEF]](p1) :: (volatile store (<33 x s32>) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <33 x i32> @external_v33i32_func_void()
-  store volatile <33 x i32> %val, ptr addrspace(1) undef, align 8
+  store volatile <33 x i32> %val, ptr addrspace(1) poison, align 8
   ret void
 }
 
@@ -3002,10 +3002,10 @@ define amdgpu_kernel void @test_call_external_v33i32_func_v33i32_i32(ptr addrspa
   ; GCN-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_v33i32_func_v33i32_i32, csr_amdgpu, implicit $vgpr0, implicit $vgpr1, implicit $vgpr2, implicit $vgpr3, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; GCN-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; GCN-NEXT:   [[LOAD2:%[0-9]+]]:_(<33 x s32>) = G_LOAD [[FRAME_INDEX]](p5) :: (load (<33 x s32>) from %stack.0, align 256, addrspace 5)
-  ; GCN-NEXT:   G_STORE [[LOAD2]](<33 x s32>), [[DEF]](p1) :: (volatile store (<33 x s32>) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[LOAD2]](<33 x s32>), [[DEF]](p1) :: (volatile store (<33 x s32>) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %val = call <33 x i32> @external_v33i32_func_v33i32_i32(ptr addrspace(1) %p, i32 %idx)
-  store volatile <33 x i32> %val, ptr addrspace(1) undef, align 8
+  store volatile <33 x i32> %val, ptr addrspace(1) poison, align 8
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-call-sret.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-call-sret.ll
@@ -71,8 +71,8 @@ define amdgpu_kernel void @test_call_external_void_func_sret_struct_i8_i32_byval
   ; GCN-NEXT:   %46:_(p5) = nuw nusw G_PTR_ADD [[FRAME_INDEX1]], [[C2]](s32)
   ; GCN-NEXT:   [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[FRAME_INDEX1]](p5) :: (dereferenceable load (s8) from %ir.out.val, addrspace 5)
   ; GCN-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD %46(p5) :: (dereferenceable load (s32) from %ir.out.gep1, addrspace 5)
-  ; GCN-NEXT:   G_STORE [[LOAD]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) undef`, addrspace 1)
-  ; GCN-NEXT:   G_STORE [[LOAD1]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[LOAD]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) poison`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[LOAD1]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_ENDPGM 0
   %in.val = alloca { i8, i32 }, align 4, addrspace(5)
   %out.val = alloca { i8, i32 }, align 4, addrspace(5)
@@ -85,8 +85,8 @@ define amdgpu_kernel void @test_call_external_void_func_sret_struct_i8_i32_byval
   %out.gep1 = getelementptr inbounds { i8, i32 }, ptr addrspace(5) %out.val, i32 0, i32 1
   %out.val0 = load i8, ptr addrspace(5) %out.gep0
   %out.val1 = load i32, ptr addrspace(5) %out.gep1
-  store volatile i8 %out.val0, ptr addrspace(1) undef
-  store volatile i32 %out.val1, ptr addrspace(1) undef
+  store volatile i8 %out.val0, ptr addrspace(1) poison
+  store volatile i32 %out.val1, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-call.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-call.ll
@@ -409,7 +409,7 @@ define amdgpu_kernel void @test_call_external_void_func_i1_signext(i32) #0 {
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[INT:%[0-9]+]]:_(p4) = G_INTRINSIC intrinsic(@llvm.amdgcn.kernarg.segment.ptr)
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s1) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s1) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s1) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s1) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_i1_signext
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -447,7 +447,7 @@ define amdgpu_kernel void @test_call_external_void_func_i1_signext(i32) #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_i1_signext, csr_amdgpu, implicit $vgpr0, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %var = load volatile i1, ptr addrspace(1) undef
+  %var = load volatile i1, ptr addrspace(1) poison
   call void @external_void_func_i1_signext(i1 signext %var)
   ret void
 }
@@ -469,7 +469,7 @@ define amdgpu_kernel void @test_call_external_void_func_i1_zeroext(i32) #0 {
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[INT:%[0-9]+]]:_(p4) = G_INTRINSIC intrinsic(@llvm.amdgcn.kernarg.segment.ptr)
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s1) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s1) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s1) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s1) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_i1_zeroext
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -507,7 +507,7 @@ define amdgpu_kernel void @test_call_external_void_func_i1_zeroext(i32) #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_i1_zeroext, csr_amdgpu, implicit $vgpr0, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %var = load volatile i1, ptr addrspace(1) undef
+  %var = load volatile i1, ptr addrspace(1) poison
   call void @external_void_func_i1_zeroext(i1 zeroext %var)
   ret void
 }
@@ -588,7 +588,7 @@ define amdgpu_kernel void @test_call_external_void_func_i8_signext(i32) #0 {
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[INT:%[0-9]+]]:_(p4) = G_INTRINSIC intrinsic(@llvm.amdgcn.kernarg.segment.ptr)
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s8) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s8) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_i8_signext
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -627,7 +627,7 @@ define amdgpu_kernel void @test_call_external_void_func_i8_signext(i32) #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_i8_signext, csr_amdgpu, implicit $vgpr0, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %var = load volatile i8, ptr addrspace(1) undef
+  %var = load volatile i8, ptr addrspace(1) poison
   call void @external_void_func_i8_signext(i8 signext %var)
   ret void
 }
@@ -649,7 +649,7 @@ define amdgpu_kernel void @test_call_external_void_func_i8_zeroext(i32) #0 {
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[INT:%[0-9]+]]:_(p4) = G_INTRINSIC intrinsic(@llvm.amdgcn.kernarg.segment.ptr)
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s8) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s8) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_i8_zeroext
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -688,7 +688,7 @@ define amdgpu_kernel void @test_call_external_void_func_i8_zeroext(i32) #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_i8_zeroext, csr_amdgpu, implicit $vgpr0, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %var = load volatile i8, ptr addrspace(1) undef
+  %var = load volatile i8, ptr addrspace(1) poison
   call void @external_void_func_i8_zeroext(i8 zeroext %var)
   ret void
 }
@@ -767,7 +767,7 @@ define amdgpu_kernel void @test_call_external_void_func_i16_signext(i32) #0 {
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[INT:%[0-9]+]]:_(p4) = G_INTRINSIC intrinsic(@llvm.amdgcn.kernarg.segment.ptr)
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s16) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s16) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s16) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s16) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_i16_signext
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -805,7 +805,7 @@ define amdgpu_kernel void @test_call_external_void_func_i16_signext(i32) #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_i16_signext, csr_amdgpu, implicit $vgpr0, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %var = load volatile i16, ptr addrspace(1) undef
+  %var = load volatile i16, ptr addrspace(1) poison
   call void @external_void_func_i16_signext(i16 signext %var)
   ret void
 }
@@ -827,7 +827,7 @@ define amdgpu_kernel void @test_call_external_void_func_i16_zeroext(i32) #0 {
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[INT:%[0-9]+]]:_(p4) = G_INTRINSIC intrinsic(@llvm.amdgcn.kernarg.segment.ptr)
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s16) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s16) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s16) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s16) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_i16_zeroext
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -865,7 +865,7 @@ define amdgpu_kernel void @test_call_external_void_func_i16_zeroext(i32) #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_i16_zeroext, csr_amdgpu, implicit $vgpr0, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %var = load volatile i16, ptr addrspace(1) undef
+  %var = load volatile i16, ptr addrspace(1) poison
   call void @external_void_func_i16_zeroext(i16 zeroext %var)
   ret void
 }
@@ -1165,7 +1165,7 @@ define amdgpu_kernel void @test_call_external_void_func_i48(i32) #0 {
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[INT:%[0-9]+]]:_(p4) = G_INTRINSIC intrinsic(@llvm.amdgcn.kernarg.segment.ptr)
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s48) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s48) from `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s48) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s48) from `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_i48
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -1205,7 +1205,7 @@ define amdgpu_kernel void @test_call_external_void_func_i48(i32) #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_i48, csr_amdgpu, implicit $vgpr0, implicit $vgpr1, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %var = load volatile i48, ptr addrspace(1) undef
+  %var = load volatile i48, ptr addrspace(1) poison
   call void @external_void_func_i48(i48 %var)
   ret void
 }
@@ -1227,7 +1227,7 @@ define amdgpu_kernel void @test_call_external_void_func_i48_signext(i32) #0 {
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[INT:%[0-9]+]]:_(p4) = G_INTRINSIC intrinsic(@llvm.amdgcn.kernarg.segment.ptr)
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s48) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s48) from `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s48) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s48) from `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_i48_signext
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -1267,7 +1267,7 @@ define amdgpu_kernel void @test_call_external_void_func_i48_signext(i32) #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_i48_signext, csr_amdgpu, implicit $vgpr0, implicit $vgpr1, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %var = load volatile i48, ptr addrspace(1) undef
+  %var = load volatile i48, ptr addrspace(1) poison
   call void @external_void_func_i48_signext(i48 signext %var)
   ret void
 }
@@ -1289,7 +1289,7 @@ define amdgpu_kernel void @test_call_external_void_func_i48_zeroext(i32) #0 {
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[INT:%[0-9]+]]:_(p4) = G_INTRINSIC intrinsic(@llvm.amdgcn.kernarg.segment.ptr)
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s48) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s48) from `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s48) = G_LOAD [[DEF]](p1) :: (volatile "amdgpu-noclobber" load (s48) from `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_i48_zeroext
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -1329,7 +1329,7 @@ define amdgpu_kernel void @test_call_external_void_func_i48_zeroext(i32) #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_i48_zeroext, csr_amdgpu, implicit $vgpr0, implicit $vgpr1, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %var = load volatile i48, ptr addrspace(1) undef
+  %var = load volatile i48, ptr addrspace(1) poison
   call void @external_void_func_i48_zeroext(i48 zeroext %var)
   ret void
 }
@@ -2098,7 +2098,7 @@ define amdgpu_kernel void @test_call_external_void_func_v2i16() #0 {
   ; CHECK-NEXT:   [[COPY8:%[0-9]+]]:sgpr_64 = COPY $sgpr4_sgpr5
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<2 x s16>) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<2 x s16>) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_v2i16
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -2135,7 +2135,7 @@ define amdgpu_kernel void @test_call_external_void_func_v2i16() #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_v2i16, csr_amdgpu, implicit $vgpr0, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %val = load <2 x i16>, ptr addrspace(1) undef
+  %val = load <2 x i16>, ptr addrspace(1) poison
   call void @external_void_func_v2i16(<2 x i16> %val)
   ret void
 }
@@ -2156,7 +2156,7 @@ define amdgpu_kernel void @test_call_external_void_func_v3i16() #0 {
   ; CHECK-NEXT:   [[COPY8:%[0-9]+]]:sgpr_64 = COPY $sgpr4_sgpr5
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<3 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<3 x s16>) from `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<3 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<3 x s16>) from `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_v3i16
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -2198,7 +2198,7 @@ define amdgpu_kernel void @test_call_external_void_func_v3i16() #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_v3i16, csr_amdgpu, implicit $vgpr0, implicit $vgpr1, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %val = load <3 x i16>, ptr addrspace(1) undef
+  %val = load <3 x i16>, ptr addrspace(1) poison
   call void @external_void_func_v3i16(<3 x i16> %val)
   ret void
 }
@@ -2219,7 +2219,7 @@ define amdgpu_kernel void @test_call_external_void_func_v3f16() #0 {
   ; CHECK-NEXT:   [[COPY8:%[0-9]+]]:sgpr_64 = COPY $sgpr4_sgpr5
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<3 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<3 x s16>) from `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<3 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<3 x s16>) from `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_v3f16
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -2261,7 +2261,7 @@ define amdgpu_kernel void @test_call_external_void_func_v3f16() #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_v3f16, csr_amdgpu, implicit $vgpr0, implicit $vgpr1, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %val = load <3 x half>, ptr addrspace(1) undef
+  %val = load <3 x half>, ptr addrspace(1) poison
   call void @external_void_func_v3f16(<3 x half> %val)
   ret void
 }
@@ -2282,7 +2282,7 @@ define amdgpu_kernel void @test_call_external_void_func_v4i16() #0 {
   ; CHECK-NEXT:   [[COPY8:%[0-9]+]]:sgpr_64 = COPY $sgpr4_sgpr5
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<4 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<4 x s16>) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<4 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<4 x s16>) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_v4i16
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -2321,7 +2321,7 @@ define amdgpu_kernel void @test_call_external_void_func_v4i16() #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_v4i16, csr_amdgpu, implicit $vgpr0, implicit $vgpr1, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %val = load <4 x i16>, ptr addrspace(1) undef
+  %val = load <4 x i16>, ptr addrspace(1) poison
   call void @external_void_func_v4i16(<4 x i16> %val)
   ret void
 }
@@ -2404,7 +2404,7 @@ define amdgpu_kernel void @test_call_external_void_func_v5i16() #0 {
   ; CHECK-NEXT:   [[COPY8:%[0-9]+]]:sgpr_64 = COPY $sgpr4_sgpr5
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<5 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<5 x s16>) from `ptr addrspace(1) undef`, align 16, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<5 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<5 x s16>) from `ptr addrspace(1) poison`, align 16, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_v5i16
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -2447,7 +2447,7 @@ define amdgpu_kernel void @test_call_external_void_func_v5i16() #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_v5i16, csr_amdgpu, implicit $vgpr0, implicit $vgpr1, implicit $vgpr2, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %val = load <5 x i16>, ptr addrspace(1) undef
+  %val = load <5 x i16>, ptr addrspace(1) poison
   call void @external_void_func_v5i16(<5 x i16> %val)
   ret void
 }
@@ -2468,7 +2468,7 @@ define amdgpu_kernel void @test_call_external_void_func_v7i16() #0 {
   ; CHECK-NEXT:   [[COPY8:%[0-9]+]]:sgpr_64 = COPY $sgpr4_sgpr5
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<7 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<7 x s16>) from `ptr addrspace(1) undef`, align 16, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<7 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<7 x s16>) from `ptr addrspace(1) poison`, align 16, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_v7i16
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -2512,7 +2512,7 @@ define amdgpu_kernel void @test_call_external_void_func_v7i16() #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_v7i16, csr_amdgpu, implicit $vgpr0, implicit $vgpr1, implicit $vgpr2, implicit $vgpr3, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %val = load <7 x i16>, ptr addrspace(1) undef
+  %val = load <7 x i16>, ptr addrspace(1) poison
   call void @external_void_func_v7i16(<7 x i16> %val)
   ret void
 }
@@ -2533,7 +2533,7 @@ define amdgpu_kernel void @test_call_external_void_func_v63i16() #0 {
   ; CHECK-NEXT:   [[COPY8:%[0-9]+]]:sgpr_64 = COPY $sgpr4_sgpr5
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<63 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<63 x s16>) from `ptr addrspace(1) undef`, align 128, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<63 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<63 x s16>) from `ptr addrspace(1) poison`, align 128, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_v63i16
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -2608,7 +2608,7 @@ define amdgpu_kernel void @test_call_external_void_func_v63i16() #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_v63i16, csr_amdgpu, implicit $vgpr0, implicit $vgpr1, implicit $vgpr2, implicit $vgpr3, implicit $vgpr4, implicit $vgpr5, implicit $vgpr6, implicit $vgpr7, implicit $vgpr8, implicit $vgpr9, implicit $vgpr10, implicit $vgpr11, implicit $vgpr12, implicit $vgpr13, implicit $vgpr14, implicit $vgpr15, implicit $vgpr16, implicit $vgpr17, implicit $vgpr18, implicit $vgpr19, implicit $vgpr20, implicit $vgpr21, implicit $vgpr22, implicit $vgpr23, implicit $vgpr24, implicit $vgpr25, implicit $vgpr26, implicit $vgpr27, implicit $vgpr28, implicit $vgpr29, implicit $vgpr30, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 4, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %val = load <63 x i16>, ptr addrspace(1) undef
+  %val = load <63 x i16>, ptr addrspace(1) poison
   call void @external_void_func_v63i16(<63 x i16> %val)
   ret void
 }
@@ -2629,7 +2629,7 @@ define amdgpu_kernel void @test_call_external_void_func_v65i16() #0 {
   ; CHECK-NEXT:   [[COPY8:%[0-9]+]]:sgpr_64 = COPY $sgpr4_sgpr5
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<65 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<65 x s16>) from `ptr addrspace(1) undef`, align 256, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<65 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<65 x s16>) from `ptr addrspace(1) poison`, align 256, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_v65i16
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -2707,7 +2707,7 @@ define amdgpu_kernel void @test_call_external_void_func_v65i16() #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_v65i16, csr_amdgpu, implicit $vgpr0, implicit $vgpr1, implicit $vgpr2, implicit $vgpr3, implicit $vgpr4, implicit $vgpr5, implicit $vgpr6, implicit $vgpr7, implicit $vgpr8, implicit $vgpr9, implicit $vgpr10, implicit $vgpr11, implicit $vgpr12, implicit $vgpr13, implicit $vgpr14, implicit $vgpr15, implicit $vgpr16, implicit $vgpr17, implicit $vgpr18, implicit $vgpr19, implicit $vgpr20, implicit $vgpr21, implicit $vgpr22, implicit $vgpr23, implicit $vgpr24, implicit $vgpr25, implicit $vgpr26, implicit $vgpr27, implicit $vgpr28, implicit $vgpr29, implicit $vgpr30, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 8, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %val = load <65 x i16>, ptr addrspace(1) undef
+  %val = load <65 x i16>, ptr addrspace(1) poison
   call void @external_void_func_v65i16(<65 x i16> %val)
   ret void
 }
@@ -2728,7 +2728,7 @@ define amdgpu_kernel void @test_call_external_void_func_v66i16() #0 {
   ; CHECK-NEXT:   [[COPY8:%[0-9]+]]:sgpr_64 = COPY $sgpr4_sgpr5
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<66 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<66 x s16>) from `ptr addrspace(1) undef`, align 256, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<66 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<66 x s16>) from `ptr addrspace(1) poison`, align 256, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_v66i16
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -2803,7 +2803,7 @@ define amdgpu_kernel void @test_call_external_void_func_v66i16() #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_v66i16, csr_amdgpu, implicit $vgpr0, implicit $vgpr1, implicit $vgpr2, implicit $vgpr3, implicit $vgpr4, implicit $vgpr5, implicit $vgpr6, implicit $vgpr7, implicit $vgpr8, implicit $vgpr9, implicit $vgpr10, implicit $vgpr11, implicit $vgpr12, implicit $vgpr13, implicit $vgpr14, implicit $vgpr15, implicit $vgpr16, implicit $vgpr17, implicit $vgpr18, implicit $vgpr19, implicit $vgpr20, implicit $vgpr21, implicit $vgpr22, implicit $vgpr23, implicit $vgpr24, implicit $vgpr25, implicit $vgpr26, implicit $vgpr27, implicit $vgpr28, implicit $vgpr29, implicit $vgpr30, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 8, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %val = load <66 x i16>, ptr addrspace(1) undef
+  %val = load <66 x i16>, ptr addrspace(1) poison
   call void @external_void_func_v66i16(<66 x i16> %val)
   ret void
 }
@@ -2824,7 +2824,7 @@ define amdgpu_kernel void @test_call_external_void_func_v2f16() #0 {
   ; CHECK-NEXT:   [[COPY8:%[0-9]+]]:sgpr_64 = COPY $sgpr4_sgpr5
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<2 x s16>) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s16>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<2 x s16>) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_v2f16
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -2861,7 +2861,7 @@ define amdgpu_kernel void @test_call_external_void_func_v2f16() #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_v2f16, csr_amdgpu, implicit $vgpr0, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %val = load <2 x half>, ptr addrspace(1) undef
+  %val = load <2 x half>, ptr addrspace(1) poison
   call void @external_void_func_v2f16(<2 x half> %val)
   ret void
 }
@@ -2882,7 +2882,7 @@ define amdgpu_kernel void @test_call_external_void_func_v2i32() #0 {
   ; CHECK-NEXT:   [[COPY8:%[0-9]+]]:sgpr_64 = COPY $sgpr4_sgpr5
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s32>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<2 x s32>) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<2 x s32>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<2 x s32>) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_v2i32
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -2921,7 +2921,7 @@ define amdgpu_kernel void @test_call_external_void_func_v2i32() #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_v2i32, csr_amdgpu, implicit $vgpr0, implicit $vgpr1, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %val = load <2 x i32>, ptr addrspace(1) undef
+  %val = load <2 x i32>, ptr addrspace(1) poison
   call void @external_void_func_v2i32(<2 x i32> %val)
   ret void
 }
@@ -3130,7 +3130,7 @@ define amdgpu_kernel void @test_call_external_void_func_v4i32() #0 {
   ; CHECK-NEXT:   [[COPY8:%[0-9]+]]:sgpr_64 = COPY $sgpr4_sgpr5
   ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(p4) = COPY $sgpr8_sgpr9
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<4 x s32>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<4 x s32>) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<4 x s32>) = G_LOAD [[DEF]](p1) :: ("amdgpu-noclobber" load (<4 x s32>) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_v4i32
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -3171,7 +3171,7 @@ define amdgpu_kernel void @test_call_external_void_func_v4i32() #0 {
   ; CHECK-NEXT:   $sgpr30_sgpr31 = noconvergent G_SI_CALL [[GV]](p0), @external_void_func_v4i32, csr_amdgpu, implicit $vgpr0, implicit $vgpr1, implicit $vgpr2, implicit $vgpr3, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $scc
   ; CHECK-NEXT:   S_ENDPGM 0
-  %val = load <4 x i32>, ptr addrspace(1) undef
+  %val = load <4 x i32>, ptr addrspace(1) poison
   call void @external_void_func_v4i32(<4 x i32> %val)
   ret void
 }
@@ -3637,7 +3637,7 @@ define amdgpu_kernel void @test_call_external_void_func_v32i32_i32(i32) #0 {
   ; CHECK-NEXT:   [[INT:%[0-9]+]]:_(p4) = G_INTRINSIC intrinsic(@llvm.amdgcn.kernarg.segment.ptr)
   ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(p1) = G_LOAD [[DEF]](p4) :: (invariant load (p1) from `ptr addrspace(4) undef`, addrspace 4)
   ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(<32 x s32>) = G_LOAD [[LOAD]](p1) :: ("amdgpu-noclobber" load (<32 x s32>) from %ir.ptr0, addrspace 1)
-  ; CHECK-NEXT:   [[LOAD2:%[0-9]+]]:_(s32) = G_LOAD [[DEF1]](p1) :: ("amdgpu-noclobber" load (s32) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD2:%[0-9]+]]:_(s32) = G_LOAD [[DEF1]](p1) :: ("amdgpu-noclobber" load (s32) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_v32i32_i32
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -3714,7 +3714,7 @@ define amdgpu_kernel void @test_call_external_void_func_v32i32_i32(i32) #0 {
   ; CHECK-NEXT:   S_ENDPGM 0
   %ptr0 = load ptr addrspace(1), ptr addrspace(4) undef
   %val0 = load <32 x i32>, ptr addrspace(1) %ptr0
-  %val1 = load i32, ptr addrspace(1) undef
+  %val1 = load i32, ptr addrspace(1) poison
   call void @external_void_func_v32i32_i32(<32 x i32> %val0, i32 %val1)
   ret void
 }
@@ -3738,8 +3738,8 @@ define amdgpu_kernel void @test_call_external_void_func_v32i32_i8_i8_i16() #0 {
   ; CHECK-NEXT:   [[DEF1:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(p1) = G_LOAD [[DEF]](p4) :: (invariant load (p1) from `ptr addrspace(4) undef`, addrspace 4)
   ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(<32 x s32>) = G_LOAD [[LOAD]](p1) :: ("amdgpu-noclobber" load (<32 x s32>) from %ir.ptr0, addrspace 1)
-  ; CHECK-NEXT:   [[LOAD2:%[0-9]+]]:_(s8) = G_LOAD [[DEF1]](p1) :: ("amdgpu-noclobber" load (s8) from `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   [[LOAD3:%[0-9]+]]:_(s16) = G_LOAD [[DEF1]](p1) :: ("amdgpu-noclobber" load (s16) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD2:%[0-9]+]]:_(s8) = G_LOAD [[DEF1]](p1) :: ("amdgpu-noclobber" load (s8) from `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD3:%[0-9]+]]:_(s16) = G_LOAD [[DEF1]](p1) :: ("amdgpu-noclobber" load (s16) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_v32i32_i8_i8_i16
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -3824,9 +3824,9 @@ define amdgpu_kernel void @test_call_external_void_func_v32i32_i8_i8_i16() #0 {
   ; CHECK-NEXT:   S_ENDPGM 0
   %ptr0 = load ptr addrspace(1), ptr addrspace(4) undef
   %val0 = load <32 x i32>, ptr addrspace(1) %ptr0
-  %val1 = load i8, ptr addrspace(1) undef
-  %val2 = load i8, ptr addrspace(1) undef
-  %val3 = load i16, ptr addrspace(1) undef
+  %val1 = load i8, ptr addrspace(1) poison
+  %val2 = load i8, ptr addrspace(1) poison
+  %val3 = load i16, ptr addrspace(1) poison
   call void @external_void_func_v32i32_i8_i8_i16(<32 x i32> %val0, i8 %val1, i8 %val2, i16 %val3)
   ret void
 }
@@ -3850,8 +3850,8 @@ define amdgpu_kernel void @test_call_external_void_func_v32i32_p3_p5() #0 {
   ; CHECK-NEXT:   [[DEF1:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(p1) = G_LOAD [[DEF]](p4) :: (invariant load (p1) from `ptr addrspace(4) undef`, addrspace 4)
   ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(<32 x s32>) = G_LOAD [[LOAD]](p1) :: ("amdgpu-noclobber" load (<32 x s32>) from %ir.ptr0, addrspace 1)
-  ; CHECK-NEXT:   [[LOAD2:%[0-9]+]]:_(p3) = G_LOAD [[DEF1]](p1) :: ("amdgpu-noclobber" load (p3) from `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   [[LOAD3:%[0-9]+]]:_(p5) = G_LOAD [[DEF1]](p1) :: ("amdgpu-noclobber" load (p5) from `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD2:%[0-9]+]]:_(p3) = G_LOAD [[DEF1]](p1) :: ("amdgpu-noclobber" load (p3) from `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   [[LOAD3:%[0-9]+]]:_(p5) = G_LOAD [[DEF1]](p1) :: ("amdgpu-noclobber" load (p5) from `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $scc
   ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @external_void_func_v32i32_p3_p5
   ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(p4) = COPY [[COPY8]]
@@ -3931,8 +3931,8 @@ define amdgpu_kernel void @test_call_external_void_func_v32i32_p3_p5() #0 {
   ; CHECK-NEXT:   S_ENDPGM 0
   %ptr0 = load ptr addrspace(1), ptr addrspace(4) undef
   %val0 = load <32 x i32>, ptr addrspace(1) %ptr0
-  %val1 = load ptr addrspace(3), ptr addrspace(1) undef
-  %val2 = load ptr addrspace(5), ptr addrspace(1) undef
+  %val1 = load ptr addrspace(3), ptr addrspace(1) poison
+  %val2 = load ptr addrspace(5), ptr addrspace(1) poison
   call void @external_void_func_v32i32_p3_p5(<32 x i32> %val0, ptr addrspace(3) %val1, ptr addrspace(5) %val2)
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-fast-math-flags.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-fast-math-flags.ll
@@ -5,7 +5,7 @@
 ; CHECK: nnan G_FADD
 define amdgpu_kernel void @fadd_nnan(float %arg0, float %arg1) {
   %res = fadd nnan float %arg0, %arg1
-  store float %res, ptr addrspace(1) undef
+  store float %res, ptr addrspace(1) poison
   ret void
 }
 
@@ -14,7 +14,7 @@ define amdgpu_kernel void @fadd_nnan(float %arg0, float %arg1) {
 ; CHECK: nnan ninf nsz arcp contract afn reassoc G_FMA
 define amdgpu_kernel void @fma_fast(float %arg0, float %arg1, float %arg2) {
   %res = call fast float @llvm.fma.f32(float %arg0, float %arg1, float %arg2)
-  store float %res, ptr addrspace(1) undef
+  store float %res, ptr addrspace(1) poison
   ret void
 }
 
@@ -23,7 +23,7 @@ define amdgpu_kernel void @fma_fast(float %arg0, float %arg1, float %arg2) {
 ; CHECK: = nsz G_INTRINSIC intrinsic(@llvm.amdgcn.rcp), %{{[0-9]+}}(s32)
 define amdgpu_kernel void @rcp_nsz(float %arg0) {
   %res = call nsz float @llvm.amdgcn.rcp.f32 (float %arg0)
-  store float %res, ptr addrspace(1) undef
+  store float %res, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-fixed-function-abi-vgpr-args.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-fixed-function-abi-vgpr-args.ll
@@ -43,8 +43,8 @@ define void @void_a31i32_i32([31 x i32] %arg0, i32 %arg1) {
   ; FIXED-NEXT:   [[FRAME_INDEX:%[0-9]+]]:_(p5) = G_FRAME_INDEX %fixed-stack.0
   ; FIXED-NEXT:   [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[FRAME_INDEX]](p5) :: (invariant load (s32) from %fixed-stack.0, align 16, addrspace 5)
   ; FIXED-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; FIXED-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; FIXED-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; FIXED-NEXT:   SI_RETURN
-  store i32 %arg1, ptr addrspace(1) undef
+  store i32 %arg1, ptr addrspace(1) poison
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-function-args.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-function-args.ll
@@ -12,9 +12,9 @@ define void @void_func_empty_arg({} %arg0, i32 %arg1) #0 {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i32 %arg1, ptr addrspace(1) undef
+  store i32 %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -25,9 +25,9 @@ define void @void_func_empty_array([0 x i8] %arg0, i32 %arg1) #0 {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i32 %arg1, ptr addrspace(1) undef
+  store i32 %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -39,9 +39,9 @@ define void @void_func_i1(i1 %arg0) #0 {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[COPY]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC]](s1), [[DEF]](p1) :: (store (s1) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC]](s1), [[DEF]](p1) :: (store (s1) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i1 %arg0, ptr addrspace(1) undef
+  store i1 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -57,11 +57,11 @@ define void @void_func_i1_zeroext(i1 zeroext %arg0) #0 {
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[ZEXT:%[0-9]+]]:_(s32) = G_ZEXT [[TRUNC]](s1)
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(s32) = G_ADD [[ZEXT]], [[C]]
-  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
   %ext = zext i1 %arg0 to i32
   %add = add i32 %ext, 12
-  store i32 %add, ptr addrspace(1) undef
+  store i32 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -77,11 +77,11 @@ define void @void_func_i1_signext(i1 signext %arg0) #0 {
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[SEXT:%[0-9]+]]:_(s32) = G_SEXT [[TRUNC]](s1)
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(s32) = G_ADD [[SEXT]], [[C]]
-  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
   %ext = sext i1 %arg0 to i32
   %add = add i32 %ext, 12
-  store i32 %add, ptr addrspace(1) undef
+  store i32 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -104,7 +104,7 @@ define void @i1_arg_i1_use(i1 %arg) #0 {
   ; CHECK-NEXT: bb.2.bb1:
   ; CHECK-NEXT:   successors: %bb.3(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   G_STORE [[C1]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[C1]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   G_BR %bb.3
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.3.bb2:
@@ -114,7 +114,7 @@ bb:
   br i1 %arg, label %bb2, label %bb1
 
 bb1:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %bb2
 
 bb2:
@@ -130,9 +130,9 @@ define void @void_func_i8(i8 %arg0) #0 {
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
   ; CHECK-NEXT:   [[TRUNC1:%[0-9]+]]:_(s8) = G_TRUNC [[TRUNC]](s16)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC1]](s8), [[DEF]](p1) :: (store (s8) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC1]](s8), [[DEF]](p1) :: (store (s8) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i8 %arg0, ptr addrspace(1) undef
+  store i8 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -148,11 +148,11 @@ define void @void_func_i8_zeroext(i8 zeroext %arg0) #0 {
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[ZEXT:%[0-9]+]]:_(s32) = G_ZEXT [[TRUNC]](s8)
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(s32) = G_ADD [[ZEXT]], [[C]]
-  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
   %ext = zext i8 %arg0 to i32
   %add = add i32 %ext, 12
-  store i32 %add, ptr addrspace(1) undef
+  store i32 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -168,11 +168,11 @@ define void @void_func_i8_signext(i8 signext %arg0) #0 {
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[SEXT:%[0-9]+]]:_(s32) = G_SEXT [[TRUNC]](s8)
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(s32) = G_ADD [[SEXT]], [[C]]
-  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
   %ext = sext i8 %arg0 to i32
   %add = add i32 %ext, 12
-  store i32 %add, ptr addrspace(1) undef
+  store i32 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -184,9 +184,9 @@ define void @void_func_i16(i16 %arg0) #0 {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC]](s16), [[DEF]](p1) :: (store (s16) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC]](s16), [[DEF]](p1) :: (store (s16) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i16 %arg0, ptr addrspace(1) undef
+  store i16 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -202,11 +202,11 @@ define void @void_func_i16_zeroext(i16 zeroext %arg0) #0 {
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[ZEXT:%[0-9]+]]:_(s32) = G_ZEXT [[TRUNC]](s16)
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(s32) = G_ADD [[ZEXT]], [[C]]
-  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
   %ext = zext i16 %arg0 to i32
   %add = add i32 %ext, 12
-  store i32 %add, ptr addrspace(1) undef
+  store i32 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -222,11 +222,11 @@ define void @void_func_i16_signext(i16 signext %arg0) #0 {
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[SEXT:%[0-9]+]]:_(s32) = G_SEXT [[TRUNC]](s16)
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(s32) = G_ADD [[SEXT]], [[C]]
-  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
   %ext = sext i16 %arg0 to i32
   %add = add i32 %ext, 12
-  store i32 %add, ptr addrspace(1) undef
+  store i32 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -238,9 +238,9 @@ define void @void_func_i24(i24 %arg0) #0 {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(s24) = G_TRUNC [[COPY]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC]](s24), [[DEF]](p1) :: (store (s24) into `ptr addrspace(1) undef`, align 4, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC]](s24), [[DEF]](p1) :: (store (s24) into `ptr addrspace(1) poison`, align 4, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i24 %arg0, ptr addrspace(1) undef
+  store i24 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -253,9 +253,9 @@ define void @void_func_i24_zeroext(i24 zeroext %arg0) #0 {
   ; CHECK-NEXT:   [[ASSERT_ZEXT:%[0-9]+]]:_(s32) = G_ASSERT_ZEXT [[COPY]], 24
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(s24) = G_TRUNC [[ASSERT_ZEXT]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC]](s24), [[DEF]](p1) :: (store (s24) into `ptr addrspace(1) undef`, align 4, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC]](s24), [[DEF]](p1) :: (store (s24) into `ptr addrspace(1) poison`, align 4, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i24 %arg0, ptr addrspace(1) undef
+  store i24 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -268,9 +268,9 @@ define void @void_func_i24_signext(i24 signext %arg0) #0 {
   ; CHECK-NEXT:   [[ASSERT_SEXT:%[0-9]+]]:_(s32) = G_ASSERT_SEXT [[COPY]], 24
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(s24) = G_TRUNC [[ASSERT_SEXT]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC]](s24), [[DEF]](p1) :: (store (s24) into `ptr addrspace(1) undef`, align 4, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC]](s24), [[DEF]](p1) :: (store (s24) into `ptr addrspace(1) poison`, align 4, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i24 %arg0, ptr addrspace(1) undef
+  store i24 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -281,9 +281,9 @@ define void @void_func_i32(i32 %arg0) #0 {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i32 %arg0, ptr addrspace(1) undef
+  store i32 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -295,9 +295,9 @@ define void @void_func_i32_signext(i32 signext %arg0) #0 {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i32 %arg0, ptr addrspace(1) undef
+  store i32 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -309,9 +309,9 @@ define void @void_func_i32_zeroext(i32 zeroext %arg0) #0 {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i32 %arg0, ptr addrspace(1) undef
+  store i32 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -322,9 +322,9 @@ define void @void_func_p3i8(ptr addrspace(3) %arg0) #0 {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(p3) = COPY $vgpr0
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[COPY]](p3), [[DEF]](p1) :: (store (p3) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY]](p3), [[DEF]](p1) :: (store (p3) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store ptr addrspace(3) %arg0, ptr addrspace(1) undef
+  store ptr addrspace(3) %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -338,9 +338,9 @@ define void @void_func_i48(i48 %arg0) #0 {
   ; CHECK-NEXT:   [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY]](s32), [[COPY1]](s32)
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(s48) = G_TRUNC [[MV]](s64)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC]](s48), [[DEF]](p1) :: (store (s48) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC]](s48), [[DEF]](p1) :: (store (s48) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i48 %arg0, ptr addrspace(1) undef
+  store i48 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -357,11 +357,11 @@ define void @void_func_i48_zeroext(i48 zeroext %arg0) #0 {
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[ZEXT:%[0-9]+]]:_(s64) = G_ZEXT [[TRUNC]](s48)
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(s64) = G_ADD [[ZEXT]], [[C]]
-  ; CHECK-NEXT:   G_STORE [[ADD]](s64), [[DEF]](p1) :: (store (s64) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[ADD]](s64), [[DEF]](p1) :: (store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
   %ext = zext i48 %arg0 to i64
   %add = add i64 %ext, 12
-  store i64 %add, ptr addrspace(1) undef
+  store i64 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -378,11 +378,11 @@ define void @void_func_i48_signext(i48 signext %arg0) #0 {
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[SEXT:%[0-9]+]]:_(s64) = G_SEXT [[TRUNC]](s48)
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(s64) = G_ADD [[SEXT]], [[C]]
-  ; CHECK-NEXT:   G_STORE [[ADD]](s64), [[DEF]](p1) :: (store (s64) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[ADD]](s64), [[DEF]](p1) :: (store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
   %ext = sext i48 %arg0 to i64
   %add = add i64 %ext, 12
-  store i64 %add, ptr addrspace(1) undef
+  store i64 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -395,9 +395,9 @@ define void @void_func_i64(i64 %arg0) #0 {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
   ; CHECK-NEXT:   [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY]](s32), [[COPY1]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (store (s64) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i64 %arg0, ptr addrspace(1) undef
+  store i64 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -412,9 +412,9 @@ define void @void_func_i95(i95 %arg0) #0 {
   ; CHECK-NEXT:   [[MV:%[0-9]+]]:_(s96) = G_MERGE_VALUES [[COPY]](s32), [[COPY1]](s32), [[COPY2]](s32)
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(s95) = G_TRUNC [[MV]](s96)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC]](s95), [[DEF]](p1) :: (store (s95) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC]](s95), [[DEF]](p1) :: (store (s95) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i95 %arg0, ptr addrspace(1) undef
+  store i95 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -432,11 +432,11 @@ define void @void_func_i95_zeroext(i95 zeroext %arg0) #0 {
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[ZEXT:%[0-9]+]]:_(s96) = G_ZEXT [[TRUNC]](s95)
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(s96) = G_ADD [[ZEXT]], [[C]]
-  ; CHECK-NEXT:   G_STORE [[ADD]](s96), [[DEF]](p1) :: (store (s96) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[ADD]](s96), [[DEF]](p1) :: (store (s96) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
   %ext = zext i95 %arg0 to i96
   %add = add i96 %ext, 12
-  store i96 %add, ptr addrspace(1) undef
+  store i96 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -454,11 +454,11 @@ define void @void_func_i95_signext(i95 signext %arg0) #0 {
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[SEXT:%[0-9]+]]:_(s96) = G_SEXT [[TRUNC]](s95)
   ; CHECK-NEXT:   [[ADD:%[0-9]+]]:_(s96) = G_ADD [[SEXT]], [[C]]
-  ; CHECK-NEXT:   G_STORE [[ADD]](s96), [[DEF]](p1) :: (store (s96) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[ADD]](s96), [[DEF]](p1) :: (store (s96) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
   %ext = sext i95 %arg0 to i96
   %add = add i96 %ext, 12
-  store i96 %add, ptr addrspace(1) undef
+  store i96 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -472,9 +472,9 @@ define void @void_func_i96(i96 %arg0) #0 {
   ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:_(s32) = COPY $vgpr2
   ; CHECK-NEXT:   [[MV:%[0-9]+]]:_(s96) = G_MERGE_VALUES [[COPY]](s32), [[COPY1]](s32), [[COPY2]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[MV]](s96), [[DEF]](p1) :: (store (s96) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[MV]](s96), [[DEF]](p1) :: (store (s96) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i96 %arg0, ptr addrspace(1) undef
+  store i96 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -487,9 +487,9 @@ define void @void_func_p0i8(ptr %arg0) #0 {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
   ; CHECK-NEXT:   [[MV:%[0-9]+]]:_(p0) = G_MERGE_VALUES [[COPY]](s32), [[COPY1]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[MV]](p0), [[DEF]](p1) :: (store (p0) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[MV]](p0), [[DEF]](p1) :: (store (p0) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store ptr %arg0, ptr addrspace(1) undef
+  store ptr %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -502,9 +502,9 @@ define void @void_func_p1i8(ptr addrspace(1) %arg0) #0 {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
   ; CHECK-NEXT:   [[MV:%[0-9]+]]:_(p1) = G_MERGE_VALUES [[COPY]](s32), [[COPY1]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[MV]](p1), [[DEF]](p1) :: (store (p1) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[MV]](p1), [[DEF]](p1) :: (store (p1) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store ptr addrspace(1) %arg0, ptr addrspace(1) undef
+  store ptr addrspace(1) %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -516,9 +516,9 @@ define void @void_func_f16(half %arg0) #0 {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC]](s16), [[DEF]](p1) :: (store (s16) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC]](s16), [[DEF]](p1) :: (store (s16) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store half %arg0, ptr addrspace(1) undef
+  store half %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -529,9 +529,9 @@ define void @void_func_f32(float %arg0) #0 {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store float %arg0, ptr addrspace(1) undef
+  store float %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -544,9 +544,9 @@ define void @void_func_f64(double %arg0) #0 {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
   ; CHECK-NEXT:   [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY]](s32), [[COPY1]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (store (s64) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store double %arg0, ptr addrspace(1) undef
+  store double %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -559,9 +559,9 @@ define void @void_func_v2i32(<2 x i32> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY1]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s32>), [[DEF]](p1) :: (store (<2 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s32>), [[DEF]](p1) :: (store (<2 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x i32> %arg0, ptr addrspace(1) undef
+  store <2 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -575,9 +575,9 @@ define void @void_func_v2i24(<2 x i24> %arg0) #0 {
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY1]](s32)
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(<2 x s24>) = G_TRUNC [[BUILD_VECTOR]](<2 x s32>)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC]](<2 x s24>), [[DEF]](p1) :: (store (<2 x s24>) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC]](<2 x s24>), [[DEF]](p1) :: (store (<2 x s24>) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x i24> %arg0, ptr addrspace(1) undef
+  store <2 x i24> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -592,9 +592,9 @@ define void @void_func_v3i24(<3 x i24> %arg0) #0 {
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY1]](s32), [[COPY2]](s32)
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(<3 x s24>) = G_TRUNC [[BUILD_VECTOR]](<3 x s32>)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC]](<3 x s24>), [[DEF]](p1) :: (store (<3 x s24>) into `ptr addrspace(1) undef`, align 16, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC]](<3 x s24>), [[DEF]](p1) :: (store (<3 x s24>) into `ptr addrspace(1) poison`, align 16, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <3 x i24> %arg0, ptr addrspace(1) undef
+  store <3 x i24> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -610,9 +610,9 @@ define void @void_func_v2i8(<2 x i8> %arg0) #0 {
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[TRUNC]](s16), [[TRUNC1]](s16)
   ; CHECK-NEXT:   [[TRUNC2:%[0-9]+]]:_(<2 x s8>) = G_TRUNC [[BUILD_VECTOR]](<2 x s16>)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC2]](<2 x s8>), [[DEF]](p1) :: (store (<2 x s8>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC2]](<2 x s8>), [[DEF]](p1) :: (store (<2 x s8>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x i8> %arg0, ptr addrspace(1) undef
+  store <2 x i8> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -630,9 +630,9 @@ define void @void_func_v3i8(<3 x i8> %arg0) #0 {
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s16>) = G_BUILD_VECTOR [[TRUNC]](s16), [[TRUNC1]](s16), [[TRUNC2]](s16)
   ; CHECK-NEXT:   [[TRUNC3:%[0-9]+]]:_(<3 x s8>) = G_TRUNC [[BUILD_VECTOR]](<3 x s16>)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC3]](<3 x s8>), [[DEF]](p1) :: (store (<3 x s8>) into `ptr addrspace(1) undef`, align 4, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC3]](<3 x s8>), [[DEF]](p1) :: (store (<3 x s8>) into `ptr addrspace(1) poison`, align 4, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <3 x i8> %arg0, ptr addrspace(1) undef
+  store <3 x i8> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -652,9 +652,9 @@ define void @void_func_v4i8(<4 x i8> %arg0) #0 {
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s16>) = G_BUILD_VECTOR [[TRUNC]](s16), [[TRUNC1]](s16), [[TRUNC2]](s16), [[TRUNC3]](s16)
   ; CHECK-NEXT:   [[TRUNC4:%[0-9]+]]:_(<4 x s8>) = G_TRUNC [[BUILD_VECTOR]](<4 x s16>)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC4]](<4 x s8>), [[DEF]](p1) :: (store (<4 x s8>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC4]](<4 x s8>), [[DEF]](p1) :: (store (<4 x s8>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <4 x i8> %arg0, ptr addrspace(1) undef
+  store <4 x i8> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -667,9 +667,9 @@ define void @void_func_v2p3i8(<2 x ptr addrspace(3)> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(p3) = COPY $vgpr1
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x p3>) = G_BUILD_VECTOR [[COPY]](p3), [[COPY1]](p3)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x p3>), [[DEF]](p1) :: (store (<2 x p3>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x p3>), [[DEF]](p1) :: (store (<2 x p3>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x ptr addrspace(3)> %arg0, ptr addrspace(1) undef
+  store <2 x ptr addrspace(3)> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -683,9 +683,9 @@ define void @void_func_v3i32(<3 x i32> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:_(s32) = COPY $vgpr2
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY1]](s32), [[COPY2]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s32>), [[DEF]](p1) :: (store (<3 x s32>) into `ptr addrspace(1) undef`, align 16, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s32>), [[DEF]](p1) :: (store (<3 x s32>) into `ptr addrspace(1) poison`, align 16, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <3 x i32> %arg0, ptr addrspace(1) undef
+  store <3 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -700,9 +700,9 @@ define void @void_func_v4i32(<4 x i32> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:_(s32) = COPY $vgpr3
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY1]](s32), [[COPY2]](s32), [[COPY3]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <4 x i32> %arg0, ptr addrspace(1) undef
+  store <4 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -718,9 +718,9 @@ define void @void_func_v5i32(<5 x i32> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY4:%[0-9]+]]:_(s32) = COPY $vgpr4
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<5 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY1]](s32), [[COPY2]](s32), [[COPY3]](s32), [[COPY4]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<5 x s32>), [[DEF]](p1) :: (store (<5 x s32>) into `ptr addrspace(1) undef`, align 32, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<5 x s32>), [[DEF]](p1) :: (store (<5 x s32>) into `ptr addrspace(1) poison`, align 32, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <5 x i32> %arg0, ptr addrspace(1) undef
+  store <5 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -739,9 +739,9 @@ define void @void_func_v8i32(<8 x i32> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY7:%[0-9]+]]:_(s32) = COPY $vgpr7
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<8 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY1]](s32), [[COPY2]](s32), [[COPY3]](s32), [[COPY4]](s32), [[COPY5]](s32), [[COPY6]](s32), [[COPY7]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<8 x s32>), [[DEF]](p1) :: (store (<8 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<8 x s32>), [[DEF]](p1) :: (store (<8 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <8 x i32> %arg0, ptr addrspace(1) undef
+  store <8 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -768,9 +768,9 @@ define void @void_func_v16i32(<16 x i32> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY15:%[0-9]+]]:_(s32) = COPY $vgpr15
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY1]](s32), [[COPY2]](s32), [[COPY3]](s32), [[COPY4]](s32), [[COPY5]](s32), [[COPY6]](s32), [[COPY7]](s32), [[COPY8]](s32), [[COPY9]](s32), [[COPY10]](s32), [[COPY11]](s32), [[COPY12]](s32), [[COPY13]](s32), [[COPY14]](s32), [[COPY15]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<16 x s32>), [[DEF]](p1) :: (store (<16 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<16 x s32>), [[DEF]](p1) :: (store (<16 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <16 x i32> %arg0, ptr addrspace(1) undef
+  store <16 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -814,9 +814,9 @@ define void @void_func_v32i32(<32 x i32> %arg0) #0 {
   ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[FRAME_INDEX]](p5) :: (invariant load (s32) from %fixed-stack.0, align 16, addrspace 5)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<32 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY1]](s32), [[COPY2]](s32), [[COPY3]](s32), [[COPY4]](s32), [[COPY5]](s32), [[COPY6]](s32), [[COPY7]](s32), [[COPY8]](s32), [[COPY9]](s32), [[COPY10]](s32), [[COPY11]](s32), [[COPY12]](s32), [[COPY13]](s32), [[COPY14]](s32), [[COPY15]](s32), [[COPY16]](s32), [[COPY17]](s32), [[COPY18]](s32), [[COPY19]](s32), [[COPY20]](s32), [[COPY21]](s32), [[COPY22]](s32), [[COPY23]](s32), [[COPY24]](s32), [[COPY25]](s32), [[COPY26]](s32), [[COPY27]](s32), [[COPY28]](s32), [[COPY29]](s32), [[COPY30]](s32), [[LOAD]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (store (<32 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (store (<32 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <32 x i32> %arg0, ptr addrspace(1) undef
+  store <32 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -863,9 +863,9 @@ define void @void_func_v33i32(<33 x i32> %arg0) #0 {
   ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[FRAME_INDEX1]](p5) :: (invariant load (s32) from %fixed-stack.0, addrspace 5)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<33 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY1]](s32), [[COPY2]](s32), [[COPY3]](s32), [[COPY4]](s32), [[COPY5]](s32), [[COPY6]](s32), [[COPY7]](s32), [[COPY8]](s32), [[COPY9]](s32), [[COPY10]](s32), [[COPY11]](s32), [[COPY12]](s32), [[COPY13]](s32), [[COPY14]](s32), [[COPY15]](s32), [[COPY16]](s32), [[COPY17]](s32), [[COPY18]](s32), [[COPY19]](s32), [[COPY20]](s32), [[COPY21]](s32), [[COPY22]](s32), [[COPY23]](s32), [[COPY24]](s32), [[COPY25]](s32), [[COPY26]](s32), [[COPY27]](s32), [[COPY28]](s32), [[COPY29]](s32), [[COPY30]](s32), [[LOAD]](s32), [[LOAD1]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<33 x s32>), [[DEF]](p1) :: (store (<33 x s32>) into `ptr addrspace(1) undef`, align 256, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<33 x s32>), [[DEF]](p1) :: (store (<33 x s32>) into `ptr addrspace(1) poison`, align 256, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <33 x i32> %arg0, ptr addrspace(1) undef
+  store <33 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -882,9 +882,9 @@ define void @void_func_v2i64(<2 x i64> %arg0) #0 {
   ; CHECK-NEXT:   [[MV1:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY2]](s32), [[COPY3]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s64>), [[DEF]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s64>), [[DEF]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x i64> %arg0, ptr addrspace(1) undef
+  store <2 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -901,9 +901,9 @@ define void @void_func_v2p0i8(<2 x ptr> %arg0) #0 {
   ; CHECK-NEXT:   [[MV1:%[0-9]+]]:_(p0) = G_MERGE_VALUES [[COPY2]](s32), [[COPY3]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x p0>) = G_BUILD_VECTOR [[MV]](p0), [[MV1]](p0)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x p0>), [[DEF]](p1) :: (store (<2 x p0>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x p0>), [[DEF]](p1) :: (store (<2 x p0>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x ptr> %arg0, ptr addrspace(1) undef
+  store <2 x ptr> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -920,9 +920,9 @@ define void @void_func_v2p1i8(<2 x ptr addrspace(1)> %arg0) #0 {
   ; CHECK-NEXT:   [[MV1:%[0-9]+]]:_(p1) = G_MERGE_VALUES [[COPY2]](s32), [[COPY3]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x p1>) = G_BUILD_VECTOR [[MV]](p1), [[MV1]](p1)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x ptr addrspace(1)> %arg0, ptr addrspace(1) undef
+  store <2 x ptr addrspace(1)> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -942,9 +942,9 @@ define void @void_func_v3i64(<3 x i64> %arg0) #0 {
   ; CHECK-NEXT:   [[MV2:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY4]](s32), [[COPY5]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64), [[MV2]](s64)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s64>), [[DEF]](p1) :: (store (<3 x s64>) into `ptr addrspace(1) undef`, align 32, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s64>), [[DEF]](p1) :: (store (<3 x s64>) into `ptr addrspace(1) poison`, align 32, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <3 x i64> %arg0, ptr addrspace(1) undef
+  store <3 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -967,9 +967,9 @@ define void @void_func_v4i64(<4 x i64> %arg0) #0 {
   ; CHECK-NEXT:   [[MV3:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY6]](s32), [[COPY7]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64), [[MV2]](s64), [[MV3]](s64)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<4 x s64>), [[DEF]](p1) :: (store (<4 x s64>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<4 x s64>), [[DEF]](p1) :: (store (<4 x s64>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <4 x i64> %arg0, ptr addrspace(1) undef
+  store <4 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -995,9 +995,9 @@ define void @void_func_v5i64(<5 x i64> %arg0) #0 {
   ; CHECK-NEXT:   [[MV4:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY8]](s32), [[COPY9]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<5 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64), [[MV2]](s64), [[MV3]](s64), [[MV4]](s64)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<5 x s64>), [[DEF]](p1) :: (store (<5 x s64>) into `ptr addrspace(1) undef`, align 64, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<5 x s64>), [[DEF]](p1) :: (store (<5 x s64>) into `ptr addrspace(1) poison`, align 64, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <5 x i64> %arg0, ptr addrspace(1) undef
+  store <5 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1032,9 +1032,9 @@ define void @void_func_v8i64(<8 x i64> %arg0) #0 {
   ; CHECK-NEXT:   [[MV7:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY14]](s32), [[COPY15]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<8 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64), [[MV2]](s64), [[MV3]](s64), [[MV4]](s64), [[MV5]](s64), [[MV6]](s64), [[MV7]](s64)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<8 x s64>), [[DEF]](p1) :: (store (<8 x s64>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<8 x s64>), [[DEF]](p1) :: (store (<8 x s64>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <8 x i64> %arg0, ptr addrspace(1) undef
+  store <8 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1094,9 +1094,9 @@ define void @void_func_v16i64(<16 x i64> %arg0) #0 {
   ; CHECK-NEXT:   [[MV15:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY30]](s32), [[LOAD]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<16 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64), [[MV2]](s64), [[MV3]](s64), [[MV4]](s64), [[MV5]](s64), [[MV6]](s64), [[MV7]](s64), [[MV8]](s64), [[MV9]](s64), [[MV10]](s64), [[MV11]](s64), [[MV12]](s64), [[MV13]](s64), [[MV14]](s64), [[MV15]](s64)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<16 x s64>), [[DEF]](p1) :: (store (<16 x s64>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<16 x s64>), [[DEF]](p1) :: (store (<16 x s64>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <16 x i64> %arg0, ptr addrspace(1) undef
+  store <16 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1107,9 +1107,9 @@ define void @void_func_v2i16(<2 x i16> %arg0) #0 {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[COPY]](<2 x s16>), [[DEF]](p1) :: (store (<2 x s16>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY]](<2 x s16>), [[DEF]](p1) :: (store (<2 x s16>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x i16> %arg0, ptr addrspace(1) undef
+  store <2 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1124,9 +1124,9 @@ define void @void_func_v3i16(<3 x i16> %arg0) #0 {
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16), [[UV2:%[0-9]+]]:_(s16), [[UV3:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<4 x s16>)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s16>) = G_BUILD_VECTOR [[UV]](s16), [[UV1]](s16), [[UV2]](s16)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s16>), [[DEF]](p1) :: (store (<3 x s16>) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s16>), [[DEF]](p1) :: (store (<3 x s16>) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <3 x i16> %arg0, ptr addrspace(1) undef
+  store <3 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1139,9 +1139,9 @@ define void @void_func_v4i16(<4 x i16> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
   ; CHECK-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[COPY]](<2 x s16>), [[COPY1]](<2 x s16>)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[CONCAT_VECTORS]](<4 x s16>), [[DEF]](p1) :: (store (<4 x s16>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[CONCAT_VECTORS]](<4 x s16>), [[DEF]](p1) :: (store (<4 x s16>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <4 x i16> %arg0, ptr addrspace(1) undef
+  store <4 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1157,9 +1157,9 @@ define void @void_func_v5i16(<5 x i16> %arg0) #0 {
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16), [[UV2:%[0-9]+]]:_(s16), [[UV3:%[0-9]+]]:_(s16), [[UV4:%[0-9]+]]:_(s16), [[UV5:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<6 x s16>)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<5 x s16>) = G_BUILD_VECTOR [[UV]](s16), [[UV1]](s16), [[UV2]](s16), [[UV3]](s16), [[UV4]](s16)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<5 x s16>), [[DEF]](p1) :: (store (<5 x s16>) into `ptr addrspace(1) undef`, align 16, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<5 x s16>), [[DEF]](p1) :: (store (<5 x s16>) into `ptr addrspace(1) poison`, align 16, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <5 x i16> %arg0, ptr addrspace(1) undef
+  store <5 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1174,9 +1174,9 @@ define void @void_func_v8i16(<8 x i16> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr3
   ; CHECK-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x s16>) = G_CONCAT_VECTORS [[COPY]](<2 x s16>), [[COPY1]](<2 x s16>), [[COPY2]](<2 x s16>), [[COPY3]](<2 x s16>)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[CONCAT_VECTORS]](<8 x s16>), [[DEF]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[CONCAT_VECTORS]](<8 x s16>), [[DEF]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <8 x i16> %arg0, ptr addrspace(1) undef
+  store <8 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1195,9 +1195,9 @@ define void @void_func_v16i16(<16 x i16> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY7:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr7
   ; CHECK-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:_(<16 x s16>) = G_CONCAT_VECTORS [[COPY]](<2 x s16>), [[COPY1]](<2 x s16>), [[COPY2]](<2 x s16>), [[COPY3]](<2 x s16>), [[COPY4]](<2 x s16>), [[COPY5]](<2 x s16>), [[COPY6]](<2 x s16>), [[COPY7]](<2 x s16>)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[CONCAT_VECTORS]](<16 x s16>), [[DEF]](p1) :: (store (<16 x s16>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[CONCAT_VECTORS]](<16 x s16>), [[DEF]](p1) :: (store (<16 x s16>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <16 x i16> %arg0, ptr addrspace(1) undef
+  store <16 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1247,9 +1247,9 @@ define void @void_func_v65i16(<65 x i16> %arg0) #0 {
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16), [[UV2:%[0-9]+]]:_(s16), [[UV3:%[0-9]+]]:_(s16), [[UV4:%[0-9]+]]:_(s16), [[UV5:%[0-9]+]]:_(s16), [[UV6:%[0-9]+]]:_(s16), [[UV7:%[0-9]+]]:_(s16), [[UV8:%[0-9]+]]:_(s16), [[UV9:%[0-9]+]]:_(s16), [[UV10:%[0-9]+]]:_(s16), [[UV11:%[0-9]+]]:_(s16), [[UV12:%[0-9]+]]:_(s16), [[UV13:%[0-9]+]]:_(s16), [[UV14:%[0-9]+]]:_(s16), [[UV15:%[0-9]+]]:_(s16), [[UV16:%[0-9]+]]:_(s16), [[UV17:%[0-9]+]]:_(s16), [[UV18:%[0-9]+]]:_(s16), [[UV19:%[0-9]+]]:_(s16), [[UV20:%[0-9]+]]:_(s16), [[UV21:%[0-9]+]]:_(s16), [[UV22:%[0-9]+]]:_(s16), [[UV23:%[0-9]+]]:_(s16), [[UV24:%[0-9]+]]:_(s16), [[UV25:%[0-9]+]]:_(s16), [[UV26:%[0-9]+]]:_(s16), [[UV27:%[0-9]+]]:_(s16), [[UV28:%[0-9]+]]:_(s16), [[UV29:%[0-9]+]]:_(s16), [[UV30:%[0-9]+]]:_(s16), [[UV31:%[0-9]+]]:_(s16), [[UV32:%[0-9]+]]:_(s16), [[UV33:%[0-9]+]]:_(s16), [[UV34:%[0-9]+]]:_(s16), [[UV35:%[0-9]+]]:_(s16), [[UV36:%[0-9]+]]:_(s16), [[UV37:%[0-9]+]]:_(s16), [[UV38:%[0-9]+]]:_(s16), [[UV39:%[0-9]+]]:_(s16), [[UV40:%[0-9]+]]:_(s16), [[UV41:%[0-9]+]]:_(s16), [[UV42:%[0-9]+]]:_(s16), [[UV43:%[0-9]+]]:_(s16), [[UV44:%[0-9]+]]:_(s16), [[UV45:%[0-9]+]]:_(s16), [[UV46:%[0-9]+]]:_(s16), [[UV47:%[0-9]+]]:_(s16), [[UV48:%[0-9]+]]:_(s16), [[UV49:%[0-9]+]]:_(s16), [[UV50:%[0-9]+]]:_(s16), [[UV51:%[0-9]+]]:_(s16), [[UV52:%[0-9]+]]:_(s16), [[UV53:%[0-9]+]]:_(s16), [[UV54:%[0-9]+]]:_(s16), [[UV55:%[0-9]+]]:_(s16), [[UV56:%[0-9]+]]:_(s16), [[UV57:%[0-9]+]]:_(s16), [[UV58:%[0-9]+]]:_(s16), [[UV59:%[0-9]+]]:_(s16), [[UV60:%[0-9]+]]:_(s16), [[UV61:%[0-9]+]]:_(s16), [[UV62:%[0-9]+]]:_(s16), [[UV63:%[0-9]+]]:_(s16), [[UV64:%[0-9]+]]:_(s16), [[UV65:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<66 x s16>)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<65 x s16>) = G_BUILD_VECTOR [[UV]](s16), [[UV1]](s16), [[UV2]](s16), [[UV3]](s16), [[UV4]](s16), [[UV5]](s16), [[UV6]](s16), [[UV7]](s16), [[UV8]](s16), [[UV9]](s16), [[UV10]](s16), [[UV11]](s16), [[UV12]](s16), [[UV13]](s16), [[UV14]](s16), [[UV15]](s16), [[UV16]](s16), [[UV17]](s16), [[UV18]](s16), [[UV19]](s16), [[UV20]](s16), [[UV21]](s16), [[UV22]](s16), [[UV23]](s16), [[UV24]](s16), [[UV25]](s16), [[UV26]](s16), [[UV27]](s16), [[UV28]](s16), [[UV29]](s16), [[UV30]](s16), [[UV31]](s16), [[UV32]](s16), [[UV33]](s16), [[UV34]](s16), [[UV35]](s16), [[UV36]](s16), [[UV37]](s16), [[UV38]](s16), [[UV39]](s16), [[UV40]](s16), [[UV41]](s16), [[UV42]](s16), [[UV43]](s16), [[UV44]](s16), [[UV45]](s16), [[UV46]](s16), [[UV47]](s16), [[UV48]](s16), [[UV49]](s16), [[UV50]](s16), [[UV51]](s16), [[UV52]](s16), [[UV53]](s16), [[UV54]](s16), [[UV55]](s16), [[UV56]](s16), [[UV57]](s16), [[UV58]](s16), [[UV59]](s16), [[UV60]](s16), [[UV61]](s16), [[UV62]](s16), [[UV63]](s16), [[UV64]](s16)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<65 x s16>), [[DEF]](p1) :: (store (<65 x s16>) into `ptr addrspace(1) undef`, align 256, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<65 x s16>), [[DEF]](p1) :: (store (<65 x s16>) into `ptr addrspace(1) poison`, align 256, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <65 x i16> %arg0, ptr addrspace(1) undef
+  store <65 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1262,9 +1262,9 @@ define void @void_func_v2f32(<2 x float> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY1]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s32>), [[DEF]](p1) :: (store (<2 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s32>), [[DEF]](p1) :: (store (<2 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x float> %arg0, ptr addrspace(1) undef
+  store <2 x float> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1278,9 +1278,9 @@ define void @void_func_v3f32(<3 x float> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:_(s32) = COPY $vgpr2
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY1]](s32), [[COPY2]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s32>), [[DEF]](p1) :: (store (<3 x s32>) into `ptr addrspace(1) undef`, align 16, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s32>), [[DEF]](p1) :: (store (<3 x s32>) into `ptr addrspace(1) poison`, align 16, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <3 x float> %arg0, ptr addrspace(1) undef
+  store <3 x float> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1295,9 +1295,9 @@ define void @void_func_v4f32(<4 x float> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:_(s32) = COPY $vgpr3
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY1]](s32), [[COPY2]](s32), [[COPY3]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <4 x float> %arg0, ptr addrspace(1) undef
+  store <4 x float> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1316,9 +1316,9 @@ define void @void_func_v8f32(<8 x float> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY7:%[0-9]+]]:_(s32) = COPY $vgpr7
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<8 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY1]](s32), [[COPY2]](s32), [[COPY3]](s32), [[COPY4]](s32), [[COPY5]](s32), [[COPY6]](s32), [[COPY7]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<8 x s32>), [[DEF]](p1) :: (store (<8 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<8 x s32>), [[DEF]](p1) :: (store (<8 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <8 x float> %arg0, ptr addrspace(1) undef
+  store <8 x float> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1345,9 +1345,9 @@ define void @void_func_v16f32(<16 x float> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY15:%[0-9]+]]:_(s32) = COPY $vgpr15
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY1]](s32), [[COPY2]](s32), [[COPY3]](s32), [[COPY4]](s32), [[COPY5]](s32), [[COPY6]](s32), [[COPY7]](s32), [[COPY8]](s32), [[COPY9]](s32), [[COPY10]](s32), [[COPY11]](s32), [[COPY12]](s32), [[COPY13]](s32), [[COPY14]](s32), [[COPY15]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<16 x s32>), [[DEF]](p1) :: (store (<16 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<16 x s32>), [[DEF]](p1) :: (store (<16 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <16 x float> %arg0, ptr addrspace(1) undef
+  store <16 x float> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1364,9 +1364,9 @@ define void @void_func_v2f64(<2 x double> %arg0) #0 {
   ; CHECK-NEXT:   [[MV1:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY2]](s32), [[COPY3]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s64>), [[DEF]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s64>), [[DEF]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x double> %arg0, ptr addrspace(1) undef
+  store <2 x double> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1386,9 +1386,9 @@ define void @void_func_v3f64(<3 x double> %arg0) #0 {
   ; CHECK-NEXT:   [[MV2:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY4]](s32), [[COPY5]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64), [[MV2]](s64)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s64>), [[DEF]](p1) :: (store (<3 x s64>) into `ptr addrspace(1) undef`, align 32, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s64>), [[DEF]](p1) :: (store (<3 x s64>) into `ptr addrspace(1) poison`, align 32, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <3 x double> %arg0, ptr addrspace(1) undef
+  store <3 x double> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1411,9 +1411,9 @@ define void @void_func_v4f64(<4 x double> %arg0) #0 {
   ; CHECK-NEXT:   [[MV3:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY6]](s32), [[COPY7]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64), [[MV2]](s64), [[MV3]](s64)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<4 x s64>), [[DEF]](p1) :: (store (<4 x s64>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<4 x s64>), [[DEF]](p1) :: (store (<4 x s64>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <4 x double> %arg0, ptr addrspace(1) undef
+  store <4 x double> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1448,9 +1448,9 @@ define void @void_func_v8f64(<8 x double> %arg0) #0 {
   ; CHECK-NEXT:   [[MV7:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY14]](s32), [[COPY15]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<8 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64), [[MV2]](s64), [[MV3]](s64), [[MV4]](s64), [[MV5]](s64), [[MV6]](s64), [[MV7]](s64)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<8 x s64>), [[DEF]](p1) :: (store (<8 x s64>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<8 x s64>), [[DEF]](p1) :: (store (<8 x s64>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <8 x double> %arg0, ptr addrspace(1) undef
+  store <8 x double> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1510,9 +1510,9 @@ define void @void_func_v16f64(<16 x double> %arg0) #0 {
   ; CHECK-NEXT:   [[MV15:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY30]](s32), [[LOAD]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<16 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64), [[MV2]](s64), [[MV3]](s64), [[MV4]](s64), [[MV5]](s64), [[MV6]](s64), [[MV7]](s64), [[MV8]](s64), [[MV9]](s64), [[MV10]](s64), [[MV11]](s64), [[MV12]](s64), [[MV13]](s64), [[MV14]](s64), [[MV15]](s64)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<16 x s64>), [[DEF]](p1) :: (store (<16 x s64>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<16 x s64>), [[DEF]](p1) :: (store (<16 x s64>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <16 x double> %arg0, ptr addrspace(1) undef
+  store <16 x double> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1523,9 +1523,9 @@ define void @void_func_v2f16(<2 x half> %arg0) #0 {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr0
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[COPY]](<2 x s16>), [[DEF]](p1) :: (store (<2 x s16>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY]](<2 x s16>), [[DEF]](p1) :: (store (<2 x s16>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x half> %arg0, ptr addrspace(1) undef
+  store <2 x half> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1540,9 +1540,9 @@ define void @void_func_v3f16(<3 x half> %arg0) #0 {
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16), [[UV2:%[0-9]+]]:_(s16), [[UV3:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<4 x s16>)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<3 x s16>) = G_BUILD_VECTOR [[UV]](s16), [[UV1]](s16), [[UV2]](s16)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s16>), [[DEF]](p1) :: (store (<3 x s16>) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<3 x s16>), [[DEF]](p1) :: (store (<3 x s16>) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <3 x half> %arg0, ptr addrspace(1) undef
+  store <3 x half> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1555,9 +1555,9 @@ define void @void_func_v4f16(<4 x half> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr1
   ; CHECK-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[COPY]](<2 x s16>), [[COPY1]](<2 x s16>)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[CONCAT_VECTORS]](<4 x s16>), [[DEF]](p1) :: (store (<4 x s16>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[CONCAT_VECTORS]](<4 x s16>), [[DEF]](p1) :: (store (<4 x s16>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <4 x half> %arg0, ptr addrspace(1) undef
+  store <4 x half> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1572,9 +1572,9 @@ define void @void_func_v8f16(<8 x half> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr3
   ; CHECK-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x s16>) = G_CONCAT_VECTORS [[COPY]](<2 x s16>), [[COPY1]](<2 x s16>), [[COPY2]](<2 x s16>), [[COPY3]](<2 x s16>)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[CONCAT_VECTORS]](<8 x s16>), [[DEF]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[CONCAT_VECTORS]](<8 x s16>), [[DEF]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <8 x half> %arg0, ptr addrspace(1) undef
+  store <8 x half> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1593,9 +1593,9 @@ define void @void_func_v16f16(<16 x half> %arg0) #0 {
   ; CHECK-NEXT:   [[COPY7:%[0-9]+]]:_(<2 x s16>) = COPY $vgpr7
   ; CHECK-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:_(<16 x s16>) = G_CONCAT_VECTORS [[COPY]](<2 x s16>), [[COPY1]](<2 x s16>), [[COPY2]](<2 x s16>), [[COPY3]](<2 x s16>), [[COPY4]](<2 x s16>), [[COPY5]](<2 x s16>), [[COPY6]](<2 x s16>), [[COPY7]](<2 x s16>)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[CONCAT_VECTORS]](<16 x s16>), [[DEF]](p1) :: (store (<16 x s16>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[CONCAT_VECTORS]](<16 x s16>), [[DEF]](p1) :: (store (<16 x s16>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <16 x half> %arg0, ptr addrspace(1) undef
+  store <16 x half> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1611,13 +1611,13 @@ define void @void_func_i32_i64_i32(i32 %arg0, i64 %arg1, i32 %arg2) #0 {
   ; CHECK-NEXT:   [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY1]](s32), [[COPY2]](s32)
   ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:_(s32) = COPY $vgpr3
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (volatile store (s64) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[COPY3]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (volatile store (s64) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY3]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store volatile i32 %arg0, ptr addrspace(1) undef
-  store volatile i64 %arg1, ptr addrspace(1) undef
-  store volatile i32 %arg2, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
+  store volatile i64 %arg1, ptr addrspace(1) poison
+  store volatile i32 %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -1628,9 +1628,9 @@ define void @void_func_struct_i32({ i32 } %arg0) #0 {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $vgpr0
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store { i32 } %arg0, ptr addrspace(1) undef
+  store { i32 } %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1644,12 +1644,12 @@ define void @void_func_struct_i8_i32({ i8, i32 } %arg0) #0 {
   ; CHECK-NEXT:   [[TRUNC1:%[0-9]+]]:_(s8) = G_TRUNC [[TRUNC]](s16)
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s32) = COPY $vgpr1
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC1]](s8), [[DEF]](p1) :: (store (s8) into `ptr addrspace(1) undef`, align 4, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC1]](s8), [[DEF]](p1) :: (store (s8) into `ptr addrspace(1) poison`, align 4, addrspace 1)
   ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
   ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p1) = G_PTR_ADD [[DEF]], [[C]](s64)
-  ; CHECK-NEXT:   G_STORE [[COPY1]](s32), [[PTR_ADD]](p1) :: (store (s32) into `ptr addrspace(1) undef` + 4, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY1]](s32), [[PTR_ADD]](p1) :: (store (s32) into `ptr addrspace(1) poison` + 4, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store { i8, i32 } %arg0, ptr addrspace(1) undef
+  store { i8, i32 } %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1663,13 +1663,13 @@ define void @void_func_byval_struct_i8_i32(ptr addrspace(5) byval({ i8, i32 }) %
   ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 4
   ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p5) = G_PTR_ADD [[COPY]], [[C]](s32)
   ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD]](p5) :: (load (s32) from %ir.arg0 + 4, addrspace 5)
-  ; CHECK-NEXT:   G_STORE [[LOAD]](s8), [[DEF]](p1) :: (store (s8) into `ptr addrspace(1) undef`, align 4, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[LOAD]](s8), [[DEF]](p1) :: (store (s8) into `ptr addrspace(1) poison`, align 4, addrspace 1)
   ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
   ; CHECK-NEXT:   [[PTR_ADD1:%[0-9]+]]:_(p1) = G_PTR_ADD [[DEF]], [[C1]](s64)
-  ; CHECK-NEXT:   G_STORE [[LOAD1]](s32), [[PTR_ADD1]](p1) :: (store (s32) into `ptr addrspace(1) undef` + 4, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[LOAD1]](s32), [[PTR_ADD1]](p1) :: (store (s32) into `ptr addrspace(1) poison` + 4, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
   %arg0.load = load { i8, i32 }, ptr addrspace(5) %arg0
-  store { i8, i32 } %arg0.load, ptr addrspace(1) undef
+  store { i8, i32 } %arg0.load, ptr addrspace(1) poison
   ret void
 }
 
@@ -1692,19 +1692,19 @@ define void @void_func_byval_struct_i8_i32_x2(ptr addrspace(5) byval({ i8, i32 }
   ; CHECK-NEXT:   [[LOAD2:%[0-9]+]]:_(s8) = G_LOAD [[COPY1]](p5) :: (volatile load (s8) from %ir.arg1, align 4, addrspace 5)
   ; CHECK-NEXT:   [[PTR_ADD1:%[0-9]+]]:_(p5) = G_PTR_ADD [[COPY1]], [[C]](s32)
   ; CHECK-NEXT:   [[LOAD3:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD1]](p5) :: (volatile load (s32) from %ir.arg1 + 4, addrspace 5)
-  ; CHECK-NEXT:   G_STORE [[LOAD]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) undef`, align 4, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[LOAD]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) poison`, align 4, addrspace 1)
   ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(s64) = G_CONSTANT i64 4
   ; CHECK-NEXT:   [[PTR_ADD2:%[0-9]+]]:_(p1) = G_PTR_ADD [[DEF]], [[C1]](s64)
-  ; CHECK-NEXT:   G_STORE [[LOAD1]](s32), [[PTR_ADD2]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef` + 4, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[LOAD2]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) undef`, align 4, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[LOAD1]](s32), [[PTR_ADD2]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison` + 4, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[LOAD2]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) poison`, align 4, addrspace 1)
   ; CHECK-NEXT:   [[PTR_ADD3:%[0-9]+]]:_(p1) = G_PTR_ADD [[DEF]], [[C1]](s64)
-  ; CHECK-NEXT:   G_STORE [[LOAD3]](s32), [[PTR_ADD3]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef` + 4, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[LOAD3]](s32), [[PTR_ADD3]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison` + 4, addrspace 1)
   ; CHECK-NEXT:   G_STORE [[COPY2]](s32), [[DEF1]](p3) :: (volatile store (s32) into `ptr addrspace(3) undef`, addrspace 3)
   ; CHECK-NEXT:   SI_RETURN
   %arg0.load = load volatile { i8, i32 }, ptr addrspace(5) %arg0
   %arg1.load = load volatile { i8, i32 }, ptr addrspace(5) %arg1
-  store volatile { i8, i32 } %arg0.load, ptr addrspace(1) undef
-  store volatile { i8, i32 } %arg1.load, ptr addrspace(1) undef
+  store volatile { i8, i32 } %arg0.load, ptr addrspace(1) poison
+  store volatile { i8, i32 } %arg1.load, ptr addrspace(1) poison
   store volatile i32 %arg2, ptr addrspace(3) undef
   ret void
 }
@@ -1719,13 +1719,13 @@ define void @void_func_byval_i32_byval_i64(ptr addrspace(5) byval(i32) %arg0, pt
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[COPY]](p5) :: (load (s32) from %ir.arg0, addrspace 5)
   ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s64) = G_LOAD [[COPY1]](p5) :: (load (s64) from %ir.arg1, addrspace 5)
-  ; CHECK-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[LOAD1]](s64), [[DEF]](p1) :: (store (s64) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[LOAD]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[LOAD1]](s64), [[DEF]](p1) :: (store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
   %arg0.load = load i32, ptr addrspace(5) %arg0
   %arg1.load = load i64, ptr addrspace(5) %arg1
-  store i32 %arg0.load, ptr addrspace(1) undef
-  store i64 %arg1.load, ptr addrspace(1) undef
+  store i32 %arg0.load, ptr addrspace(1) poison
+  store i64 %arg1.load, ptr addrspace(1) poison
   ret void
 }
 
@@ -1939,13 +1939,13 @@ define void @void_func_v32i32_i32_i64(<32 x i32> %arg0, i32 %arg1, i64 %arg2) #0
   ; CHECK-NEXT:   [[LOAD3:%[0-9]+]]:_(s32) = G_LOAD [[FRAME_INDEX3]](p5) :: (invariant load (s32) from %fixed-stack.0, addrspace 5)
   ; CHECK-NEXT:   [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[LOAD2]](s32), [[LOAD3]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[LOAD1]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (volatile store (s64) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[LOAD1]](s32), [[DEF]](p1) :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (volatile store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile i32 %arg1, ptr addrspace(1) undef
-  store volatile i64 %arg2, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile i32 %arg1, ptr addrspace(1) poison
+  store volatile i64 %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -2000,17 +2000,17 @@ define void @void_func_v32i32_i1_i8_i16(<32 x i32> %arg0, i1 %arg1, i8 %arg2, i1
   ; CHECK-NEXT:   [[FRAME_INDEX4:%[0-9]+]]:_(p5) = G_FRAME_INDEX %fixed-stack.0
   ; CHECK-NEXT:   [[LOAD4:%[0-9]+]]:_(s16) = G_LOAD [[FRAME_INDEX4]](p5) :: (invariant load (s16) from %fixed-stack.0, align 16, addrspace 5)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[TRUNC]](s1), [[DEF]](p1) :: (volatile store (s1) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[TRUNC1]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[LOAD3]](s16), [[DEF]](p1) :: (volatile store (s16) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[LOAD4]](s16), [[DEF]](p1) :: (volatile store (s16) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC]](s1), [[DEF]](p1) :: (volatile store (s1) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC1]](s8), [[DEF]](p1) :: (volatile store (s8) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[LOAD3]](s16), [[DEF]](p1) :: (volatile store (s16) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[LOAD4]](s16), [[DEF]](p1) :: (volatile store (s16) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile i1 %arg1, ptr addrspace(1) undef
-  store volatile i8 %arg2, ptr addrspace(1) undef
-  store volatile i16 %arg3, ptr addrspace(1) undef
-  store volatile half %arg4, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile i1 %arg1, ptr addrspace(1) poison
+  store volatile i8 %arg2, ptr addrspace(1) poison
+  store volatile i16 %arg3, ptr addrspace(1) poison
+  store volatile half %arg4, ptr addrspace(1) poison
   ret void
 }
 
@@ -2058,13 +2058,13 @@ define void @void_func_v32i32_p3_p5_i16(<32 x i32> %arg0, ptr addrspace(3) %arg1
   ; CHECK-NEXT:   [[FRAME_INDEX2:%[0-9]+]]:_(p5) = G_FRAME_INDEX %fixed-stack.0
   ; CHECK-NEXT:   [[LOAD2:%[0-9]+]]:_(p5) = G_LOAD [[FRAME_INDEX2]](p5) :: (invariant load (p5) from %fixed-stack.0, align 8, addrspace 5)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[LOAD1]](p3), [[DEF]](p1) :: (volatile store (p3) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[LOAD2]](p5), [[DEF]](p1) :: (volatile store (p5) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[LOAD1]](p3), [[DEF]](p1) :: (volatile store (p3) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[LOAD2]](p5), [[DEF]](p1) :: (volatile store (p5) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile ptr addrspace(3) %arg1, ptr addrspace(1) undef
-  store volatile ptr addrspace(5) %arg2, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile ptr addrspace(3) %arg1, ptr addrspace(1) poison
+  store volatile ptr addrspace(5) %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -2118,13 +2118,13 @@ define void @void_func_v32i32_v2i32_v2f32(<32 x i32> %arg0, <2 x i32> %arg1, <2 
   ; CHECK-NEXT:   [[LOAD4:%[0-9]+]]:_(s32) = G_LOAD [[FRAME_INDEX4]](p5) :: (invariant load (s32) from %fixed-stack.0, align 16, addrspace 5)
   ; CHECK-NEXT:   [[BUILD_VECTOR2:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[LOAD3]](s32), [[LOAD4]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR1]](<2 x s32>), [[DEF]](p1) :: (volatile store (<2 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR2]](<2 x s32>), [[DEF]](p1) :: (volatile store (<2 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR1]](<2 x s32>), [[DEF]](p1) :: (volatile store (<2 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR2]](<2 x s32>), [[DEF]](p1) :: (volatile store (<2 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile <2 x i32> %arg1, ptr addrspace(1) undef
-  store volatile <2 x float> %arg2, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile <2 x i32> %arg1, ptr addrspace(1) poison
+  store volatile <2 x float> %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -2172,13 +2172,13 @@ define void @void_func_v32i32_v2i16_v2f16(<32 x i32> %arg0, <2 x i16> %arg1, <2 
   ; CHECK-NEXT:   [[FRAME_INDEX2:%[0-9]+]]:_(p5) = G_FRAME_INDEX %fixed-stack.0
   ; CHECK-NEXT:   [[LOAD2:%[0-9]+]]:_(<2 x s16>) = G_LOAD [[FRAME_INDEX2]](p5) :: (invariant load (<2 x s16>) from %fixed-stack.0, align 8, addrspace 5)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[LOAD1]](<2 x s16>), [[DEF]](p1) :: (volatile store (<2 x s16>) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[LOAD2]](<2 x s16>), [[DEF]](p1) :: (volatile store (<2 x s16>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[LOAD1]](<2 x s16>), [[DEF]](p1) :: (volatile store (<2 x s16>) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[LOAD2]](<2 x s16>), [[DEF]](p1) :: (volatile store (<2 x s16>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile <2 x i16> %arg1, ptr addrspace(1) undef
-  store volatile <2 x half> %arg2, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile <2 x i16> %arg1, ptr addrspace(1) poison
+  store volatile <2 x half> %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -2244,13 +2244,13 @@ define void @void_func_v32i32_v2i64_v2f64(<32 x i32> %arg0, <2 x i64> %arg1, <2 
   ; CHECK-NEXT:   [[MV3:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[LOAD7]](s32), [[LOAD8]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR2:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[MV2]](s64), [[MV3]](s64)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR1]](<2 x s64>), [[DEF]](p1) :: (volatile store (<2 x s64>) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR2]](<2 x s64>), [[DEF]](p1) :: (volatile store (<2 x s64>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR1]](<2 x s64>), [[DEF]](p1) :: (volatile store (<2 x s64>) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR2]](<2 x s64>), [[DEF]](p1) :: (volatile store (<2 x s64>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile <2 x i64> %arg1, ptr addrspace(1) undef
-  store volatile <2 x double> %arg2, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile <2 x i64> %arg1, ptr addrspace(1) poison
+  store volatile <2 x double> %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -2312,13 +2312,13 @@ define void @void_func_v32i32_v4i32_v4f32(<32 x i32> %arg0, <4 x i32> %arg1, <4 
   ; CHECK-NEXT:   [[LOAD8:%[0-9]+]]:_(s32) = G_LOAD [[FRAME_INDEX8]](p5) :: (invariant load (s32) from %fixed-stack.0, align 16, addrspace 5)
   ; CHECK-NEXT:   [[BUILD_VECTOR2:%[0-9]+]]:_(<4 x s32>) = G_BUILD_VECTOR [[LOAD5]](s32), [[LOAD6]](s32), [[LOAD7]](s32), [[LOAD8]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR1]](<4 x s32>), [[DEF]](p1) :: (volatile store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR2]](<4 x s32>), [[DEF]](p1) :: (volatile store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR1]](<4 x s32>), [[DEF]](p1) :: (volatile store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR2]](<4 x s32>), [[DEF]](p1) :: (volatile store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile <4 x i32> %arg1, ptr addrspace(1) undef
-  store volatile <4 x float> %arg2, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile <4 x i32> %arg1, ptr addrspace(1) poison
+  store volatile <4 x float> %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -2396,13 +2396,13 @@ define void @void_func_v32i32_v8i32_v8f32(<32 x i32> %arg0, <8 x i32> %arg1, <8 
   ; CHECK-NEXT:   [[LOAD16:%[0-9]+]]:_(s32) = G_LOAD [[FRAME_INDEX16]](p5) :: (invariant load (s32) from %fixed-stack.0, align 16, addrspace 5)
   ; CHECK-NEXT:   [[BUILD_VECTOR2:%[0-9]+]]:_(<8 x s32>) = G_BUILD_VECTOR [[LOAD9]](s32), [[LOAD10]](s32), [[LOAD11]](s32), [[LOAD12]](s32), [[LOAD13]](s32), [[LOAD14]](s32), [[LOAD15]](s32), [[LOAD16]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR1]](<8 x s32>), [[DEF]](p1) :: (volatile store (<8 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR2]](<8 x s32>), [[DEF]](p1) :: (volatile store (<8 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR1]](<8 x s32>), [[DEF]](p1) :: (volatile store (<8 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR2]](<8 x s32>), [[DEF]](p1) :: (volatile store (<8 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile <8 x i32> %arg1, ptr addrspace(1) undef
-  store volatile <8 x float> %arg2, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile <8 x i32> %arg1, ptr addrspace(1) poison
+  store volatile <8 x float> %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -2512,13 +2512,13 @@ define void @void_func_v32i32_v16i32_v16f32(<32 x i32> %arg0, <16 x i32> %arg1, 
   ; CHECK-NEXT:   [[LOAD32:%[0-9]+]]:_(s32) = G_LOAD [[FRAME_INDEX32]](p5) :: (invariant load (s32) from %fixed-stack.0, align 16, addrspace 5)
   ; CHECK-NEXT:   [[BUILD_VECTOR2:%[0-9]+]]:_(<16 x s32>) = G_BUILD_VECTOR [[LOAD17]](s32), [[LOAD18]](s32), [[LOAD19]](s32), [[LOAD20]](s32), [[LOAD21]](s32), [[LOAD22]](s32), [[LOAD23]](s32), [[LOAD24]](s32), [[LOAD25]](s32), [[LOAD26]](s32), [[LOAD27]](s32), [[LOAD28]](s32), [[LOAD29]](s32), [[LOAD30]](s32), [[LOAD31]](s32), [[LOAD32]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR1]](<16 x s32>), [[DEF]](p1) :: (volatile store (<16 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR2]](<16 x s32>), [[DEF]](p1) :: (volatile store (<16 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR1]](<16 x s32>), [[DEF]](p1) :: (volatile store (<16 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR2]](<16 x s32>), [[DEF]](p1) :: (volatile store (<16 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile <16 x i32> %arg1, ptr addrspace(1) undef
-  store volatile <16 x float> %arg2, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile <16 x i32> %arg1, ptr addrspace(1) poison
+  store volatile <16 x float> %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -2628,9 +2628,9 @@ define void @void_func_v16i8(<16 x i8> %arg0) #0 {
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[TRUNC]](s16), [[TRUNC1]](s16), [[TRUNC2]](s16), [[TRUNC3]](s16), [[TRUNC4]](s16), [[TRUNC5]](s16), [[TRUNC6]](s16), [[TRUNC7]](s16), [[TRUNC8]](s16), [[TRUNC9]](s16), [[TRUNC10]](s16), [[TRUNC11]](s16), [[TRUNC12]](s16), [[TRUNC13]](s16), [[TRUNC14]](s16), [[TRUNC15]](s16)
   ; CHECK-NEXT:   [[TRUNC16:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[BUILD_VECTOR]](<16 x s16>)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC16]](<16 x s8>), [[DEF]](p1) :: (volatile store (<16 x s8>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC16]](<16 x s8>), [[DEF]](p1) :: (volatile store (<16 x s8>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store volatile <16 x i8> %arg0, ptr addrspace(1) undef
+  store volatile <16 x i8> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2709,11 +2709,11 @@ define void @void_func_v32i32_v16i8(<32 x i32> %arg0, <16 x i8> %arg1) #0 {
   ; CHECK-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[LOAD1]](s16), [[LOAD2]](s16), [[LOAD3]](s16), [[LOAD4]](s16), [[LOAD5]](s16), [[LOAD6]](s16), [[LOAD7]](s16), [[LOAD8]](s16), [[LOAD9]](s16), [[LOAD10]](s16), [[LOAD11]](s16), [[LOAD12]](s16), [[LOAD13]](s16), [[LOAD14]](s16), [[LOAD15]](s16), [[LOAD16]](s16)
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[BUILD_VECTOR1]](<16 x s16>)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[TRUNC]](<16 x s8>), [[DEF]](p1) :: (volatile store (<16 x s8>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<32 x s32>), [[DEF]](p1) :: (volatile store (<32 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC]](<16 x s8>), [[DEF]](p1) :: (volatile store (<16 x s8>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile <16 x i8> %arg1, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile <16 x i8> %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -2768,12 +2768,12 @@ define void @vector_ptr_in_struct_arg({ <2 x ptr addrspace(1)>, <2 x ptr addrspa
   ; CHECK-NEXT:   [[COPY5:%[0-9]+]]:_(p3) = COPY $vgpr5
   ; CHECK-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x p3>) = G_BUILD_VECTOR [[COPY4]](p3), [[COPY5]](p3)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 16
   ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p1) = G_PTR_ADD [[DEF]], [[C]](s64)
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR1]](<2 x p3>), [[PTR_ADD]](p1) :: (store (<2 x p3>) into `ptr addrspace(1) undef` + 16, align 16, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR1]](<2 x p3>), [[PTR_ADD]](p1) :: (store (<2 x p3>) into `ptr addrspace(1) poison` + 16, align 16, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store { <2 x ptr addrspace(1)>, <2 x ptr addrspace(3)> } %arg, ptr addrspace(1) undef
+  store { <2 x ptr addrspace(1)>, <2 x ptr addrspace(3)> } %arg, ptr addrspace(1) poison
   ret void
 }
 
@@ -2785,9 +2785,9 @@ define void @void_func_i1_inreg(i1 inreg %arg0) #0 {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $sgpr16
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(s1) = G_TRUNC [[COPY]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC]](s1), [[DEF]](p1) :: (store (s1) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC]](s1), [[DEF]](p1) :: (store (s1) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i1 %arg0, ptr addrspace(1) undef
+  store i1 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2800,9 +2800,9 @@ define void @void_func_i8_inreg(i8 inreg %arg0) #0 {
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
   ; CHECK-NEXT:   [[TRUNC1:%[0-9]+]]:_(s8) = G_TRUNC [[TRUNC]](s16)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC1]](s8), [[DEF]](p1) :: (store (s8) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC1]](s8), [[DEF]](p1) :: (store (s8) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i8 %arg0, ptr addrspace(1) undef
+  store i8 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2814,9 +2814,9 @@ define void @void_func_i16_inreg(i16 inreg %arg0) #0 {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $sgpr16
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC]](s16), [[DEF]](p1) :: (store (s16) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC]](s16), [[DEF]](p1) :: (store (s16) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i16 %arg0, ptr addrspace(1) undef
+  store i16 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2827,9 +2827,9 @@ define void @void_func_i32_inreg(i32 inreg %arg0) #0 {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $sgpr16
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i32 %arg0, ptr addrspace(1) undef
+  store i32 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2843,9 +2843,9 @@ define void @void_func_i48_inreg(i48 inreg %arg0) #0 {
   ; CHECK-NEXT:   [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY]](s32), [[COPY1]](s32)
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(s48) = G_TRUNC [[MV]](s64)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC]](s48), [[DEF]](p1) :: (store (s48) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC]](s48), [[DEF]](p1) :: (store (s48) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i48 %arg0, ptr addrspace(1) undef
+  store i48 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2858,9 +2858,9 @@ define void @void_func_i64_inreg(i64 inreg %arg0) #0 {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s32) = COPY $sgpr17
   ; CHECK-NEXT:   [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY]](s32), [[COPY1]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (store (s64) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i64 %arg0, ptr addrspace(1) undef
+  store i64 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2874,9 +2874,9 @@ define void @void_func_i96_inreg(i96 inreg %arg0) #0 {
   ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:_(s32) = COPY $sgpr18
   ; CHECK-NEXT:   [[MV:%[0-9]+]]:_(s96) = G_MERGE_VALUES [[COPY]](s32), [[COPY1]](s32), [[COPY2]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[MV]](s96), [[DEF]](p1) :: (store (s96) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[MV]](s96), [[DEF]](p1) :: (store (s96) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i96 %arg0, ptr addrspace(1) undef
+  store i96 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2891,9 +2891,9 @@ define void @void_func_i128_inreg(i128 inreg %arg0) #0 {
   ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:_(s32) = COPY $sgpr19
   ; CHECK-NEXT:   [[MV:%[0-9]+]]:_(s128) = G_MERGE_VALUES [[COPY]](s32), [[COPY1]](s32), [[COPY2]](s32), [[COPY3]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[MV]](s128), [[DEF]](p1) :: (store (s128) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[MV]](s128), [[DEF]](p1) :: (store (s128) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store i128 %arg0, ptr addrspace(1) undef
+  store i128 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2905,9 +2905,9 @@ define void @void_func_f16_inreg(half inreg %arg0) #0 {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $sgpr16
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC]](s16), [[DEF]](p1) :: (store (s16) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC]](s16), [[DEF]](p1) :: (store (s16) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store half %arg0, ptr addrspace(1) undef
+  store half %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2919,9 +2919,9 @@ define void @void_func_bf16_inreg(bfloat inreg %arg0) #0 {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $sgpr16
   ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(s16) = G_TRUNC [[COPY]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC]](s16), [[DEF]](p1) :: (store (s16) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC]](s16), [[DEF]](p1) :: (store (s16) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store bfloat %arg0, ptr addrspace(1) undef
+  store bfloat %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2932,9 +2932,9 @@ define void @void_func_f32_inreg(float inreg %arg0) #0 {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $sgpr16
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store float %arg0, ptr addrspace(1) undef
+  store float %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2947,9 +2947,9 @@ define void @void_func_f64_inreg(double inreg %arg0) #0 {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s32) = COPY $sgpr17
   ; CHECK-NEXT:   [[MV:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY]](s32), [[COPY1]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (store (s64) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[MV]](s64), [[DEF]](p1) :: (store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store double %arg0, ptr addrspace(1) undef
+  store double %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2965,9 +2965,9 @@ define void @void_func_v2i1_inreg(<2 x i1> inreg %arg0) #0 {
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[TRUNC]](s16), [[TRUNC1]](s16)
   ; CHECK-NEXT:   [[TRUNC2:%[0-9]+]]:_(<2 x s1>) = G_TRUNC [[BUILD_VECTOR]](<2 x s16>)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC2]](<2 x s1>), [[DEF]](p1) :: (store (<2 x s1>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC2]](<2 x s1>), [[DEF]](p1) :: (store (<2 x s1>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x i1> %arg0, ptr addrspace(1) undef
+  store <2 x i1> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2984,9 +2984,9 @@ define void @void_func_v2i8_inreg(<2 x i8> inreg %arg0) #0 {
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[TRUNC]](s16), [[TRUNC1]](s16)
   ; CHECK-NEXT:   [[TRUNC2:%[0-9]+]]:_(<2 x s8>) = G_TRUNC [[BUILD_VECTOR]](<2 x s16>)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[TRUNC2]](<2 x s8>), [[DEF]](p1) :: (store (<2 x s8>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[TRUNC2]](<2 x s8>), [[DEF]](p1) :: (store (<2 x s8>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x i8> %arg0, ptr addrspace(1) undef
+  store <2 x i8> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2997,9 +2997,9 @@ define void @void_func_v2i16_inreg(<2 x i16> inreg %arg0) #0 {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $sgpr16
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[COPY]](<2 x s16>), [[DEF]](p1) :: (store (<2 x s16>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY]](<2 x s16>), [[DEF]](p1) :: (store (<2 x s16>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x i16> %arg0, ptr addrspace(1) undef
+  store <2 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -3010,9 +3010,9 @@ define void @void_func_v2f16_inreg(<2 x half> inreg %arg0) #0 {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $sgpr16
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[COPY]](<2 x s16>), [[DEF]](p1) :: (store (<2 x s16>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY]](<2 x s16>), [[DEF]](p1) :: (store (<2 x s16>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x half> %arg0, ptr addrspace(1) undef
+  store <2 x half> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -3024,9 +3024,9 @@ define void @void_func_v2bf16_inreg(<2 x bfloat> inreg %arg0) #0 {
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s32) = COPY $sgpr16
   ; CHECK-NEXT:   [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[COPY]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BITCAST]](<2 x s16>), [[DEF]](p1) :: (store (<2 x s16>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BITCAST]](<2 x s16>), [[DEF]](p1) :: (store (<2 x s16>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x bfloat> %arg0, ptr addrspace(1) undef
+  store <2 x bfloat> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -3039,9 +3039,9 @@ define void @void_func_v2i32_inreg(<2 x i32> inreg %arg0) #0 {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s32) = COPY $sgpr17
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY1]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s32>), [[DEF]](p1) :: (store (<2 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s32>), [[DEF]](p1) :: (store (<2 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x i32> %arg0, ptr addrspace(1) undef
+  store <2 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -3054,9 +3054,9 @@ define void @void_func_v2f32_inreg(<2 x float> inreg %arg0) #0 {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s32) = COPY $sgpr17
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY1]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s32>), [[DEF]](p1) :: (store (<2 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s32>), [[DEF]](p1) :: (store (<2 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x float> %arg0, ptr addrspace(1) undef
+  store <2 x float> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -3073,9 +3073,9 @@ define void @void_func_v2i64_inreg(<2 x i64> inreg %arg0) #0 {
   ; CHECK-NEXT:   [[MV1:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY2]](s32), [[COPY3]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s64>), [[DEF]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s64>), [[DEF]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x i64> %arg0, ptr addrspace(1) undef
+  store <2 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -3092,20 +3092,20 @@ define void @void_func_v2f64_inreg(<2 x double> inreg %arg0) #0 {
   ; CHECK-NEXT:   [[MV1:%[0-9]+]]:_(s64) = G_MERGE_VALUES [[COPY2]](s32), [[COPY3]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s64>) = G_BUILD_VECTOR [[MV]](s64), [[MV1]](s64)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s64>), [[DEF]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s64>), [[DEF]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x double> %arg0, ptr addrspace(1) undef
+  store <2 x double> %arg0, ptr addrspace(1) poison
   ret void
 }
 
 ; FIXME: Broken, see issue #78121
 ; define void @void_func_v2i128_inreg(<2 x i128> inreg %arg0) #0 {
-;   store <2 x i128> %arg0, ptr addrspace(1) undef
+;   store <2 x i128> %arg0, ptr addrspace(1) poison
 ;   ret void
 ; }
 
 ; define void @void_func_v2f128_inreg(<2 x fp128> inreg %arg0) #0 {
-;   store <2 x fp128> %arg0, ptr addrspace(1) undef
+;   store <2 x fp128> %arg0, ptr addrspace(1) poison
 ;   ret void
 ; }
 
@@ -3118,9 +3118,9 @@ define void @void_func_p0_inreg(ptr inreg %arg0) #0 {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s32) = COPY $sgpr17
   ; CHECK-NEXT:   [[MV:%[0-9]+]]:_(p0) = G_MERGE_VALUES [[COPY]](s32), [[COPY1]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[MV]](p0), [[DEF]](p1) :: (store (p0) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[MV]](p0), [[DEF]](p1) :: (store (p0) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store ptr %arg0, ptr addrspace(1) undef
+  store ptr %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -3133,9 +3133,9 @@ define void @void_func_p1_inreg(ptr addrspace(1) inreg %arg0) #0 {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s32) = COPY $sgpr17
   ; CHECK-NEXT:   [[MV:%[0-9]+]]:_(p1) = G_MERGE_VALUES [[COPY]](s32), [[COPY1]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[MV]](p1), [[DEF]](p1) :: (store (p1) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[MV]](p1), [[DEF]](p1) :: (store (p1) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store ptr addrspace(1) %arg0, ptr addrspace(1) undef
+  store ptr addrspace(1) %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -3146,9 +3146,9 @@ define void @void_func_p3_inreg(ptr addrspace(3) inreg %arg0) #0 {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(p3) = COPY $sgpr16
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[COPY]](p3), [[DEF]](p1) :: (store (p3) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY]](p3), [[DEF]](p1) :: (store (p3) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store ptr addrspace(3) %arg0, ptr addrspace(1) undef
+  store ptr addrspace(3) %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -3159,9 +3159,9 @@ define void @void_func_p5_inreg(ptr addrspace(5) inreg %arg0) #0 {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(p5) = COPY $sgpr16
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[COPY]](p5), [[DEF]](p1) :: (store (p5) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY]](p5), [[DEF]](p1) :: (store (p5) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store ptr addrspace(5) %arg0, ptr addrspace(1) undef
+  store ptr addrspace(5) %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -3174,9 +3174,9 @@ define void @void_func_p999_inreg(ptr addrspace(999) inreg %arg0) #0 {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s32) = COPY $sgpr17
   ; CHECK-NEXT:   [[MV:%[0-9]+]]:_(p999) = G_MERGE_VALUES [[COPY]](s32), [[COPY1]](s32)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[MV]](p999), [[DEF]](p1) :: (store (p999) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[MV]](p999), [[DEF]](p1) :: (store (p999) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store ptr addrspace(999) %arg0, ptr addrspace(1) undef
+  store ptr addrspace(999) %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -3193,9 +3193,9 @@ define void @void_func_v2p0_inreg(<2 x ptr> inreg %arg0) #0 {
   ; CHECK-NEXT:   [[MV1:%[0-9]+]]:_(p0) = G_MERGE_VALUES [[COPY2]](s32), [[COPY3]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x p0>) = G_BUILD_VECTOR [[MV]](p0), [[MV1]](p0)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x p0>), [[DEF]](p1) :: (store (<2 x p0>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x p0>), [[DEF]](p1) :: (store (<2 x p0>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x ptr> %arg0, ptr addrspace(1) undef
+  store <2 x ptr> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -3212,9 +3212,9 @@ define void @void_func_v2p1_inreg(<2 x ptr addrspace(1)> inreg %arg0) #0 {
   ; CHECK-NEXT:   [[MV1:%[0-9]+]]:_(p1) = G_MERGE_VALUES [[COPY2]](s32), [[COPY3]](s32)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x p1>) = G_BUILD_VECTOR [[MV]](p1), [[MV1]](p1)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x ptr addrspace(1)> %arg0, ptr addrspace(1) undef
+  store <2 x ptr addrspace(1)> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -3227,9 +3227,9 @@ define void @void_func_v2p3_inreg(<2 x ptr addrspace(3)> inreg %arg0) #0 {
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(p3) = COPY $sgpr17
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x p3>) = G_BUILD_VECTOR [[COPY]](p3), [[COPY1]](p3)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x p3>), [[DEF]](p1) :: (store (<2 x p3>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x p3>), [[DEF]](p1) :: (store (<2 x p3>) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x ptr addrspace(3)> %arg0, ptr addrspace(1) undef
+  store <2 x ptr addrspace(3)> %arg0, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-function-args.v2i65.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-function-args.v2i65.ll
@@ -18,8 +18,8 @@ define void @void_func_v2i65(<2 x i65> %arg0) #0 {
   ; CHECK-NEXT:   [[TRUNC1:%[0-9]+]]:_(s65) = G_TRUNC [[MV1]](s96)
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<2 x s65>) = G_BUILD_VECTOR [[TRUNC]](s65), [[TRUNC1]](s65)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s65>), [[DEF]](p1) :: (store (<2 x s65>) into `ptr addrspace(1) undef`, align 32, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<2 x s65>), [[DEF]](p1) :: (store (<2 x s65>) into `ptr addrspace(1) poison`, align 32, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
-  store <2 x i65> %arg0, ptr addrspace(1) undef
+  store <2 x i65> %arg0, ptr addrspace(1) poison
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-inline-asm.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-inline-asm.ll
@@ -289,17 +289,17 @@ define void @test_many_matching_constraints(i32 %a, i32 %b, i32 %c) nounwind {
   ; CHECK-NEXT:   [[COPY6:%[0-9]+]]:_(s32) = COPY %11
   ; CHECK-NEXT:   [[COPY7:%[0-9]+]]:_(s32) = COPY %12
   ; CHECK-NEXT:   [[COPY8:%[0-9]+]]:_(s32) = COPY %13
-  ; CHECK-NEXT:   G_STORE [[COPY6]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[COPY7]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[COPY8]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY6]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY7]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[COPY8]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   SI_RETURN
   %asm = call {i32, i32, i32} asm sideeffect "; ", "=v,=v,=v,0,2,1"(i32 %c, i32 %a, i32 %b)
   %asmresult0 = extractvalue  {i32, i32, i32} %asm, 0
-  store i32 %asmresult0, ptr addrspace(1) undef
+  store i32 %asmresult0, ptr addrspace(1) poison
   %asmresult1 = extractvalue  {i32, i32, i32} %asm, 1
-  store i32 %asmresult1, ptr addrspace(1) undef
+  store i32 %asmresult1, ptr addrspace(1) poison
   %asmresult2 = extractvalue  {i32, i32, i32} %asm, 2
-  store i32 %asmresult2, ptr addrspace(1) undef
+  store i32 %asmresult2, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-readnone-intrinsic-callsite.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-readnone-intrinsic-callsite.ll
@@ -9,9 +9,9 @@
 ; CHECK: G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.amdgcn.s.getreg)
 define amdgpu_kernel void @getreg_callsite_attributes() {
   %reg0 = call i32 @llvm.amdgcn.s.getreg(i32 0)
-  store volatile i32 %reg0, ptr addrspace(1) undef
+  store volatile i32 %reg0, ptr addrspace(1) poison
   %reg1 = call i32 @llvm.amdgcn.s.getreg(i32 0) #1
-  store volatile i32 %reg1, ptr addrspace(1) undef
+  store volatile i32 %reg1, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-struct-return-intrinsics.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/irtranslator-struct-return-intrinsics.ll
@@ -13,14 +13,14 @@ define amdgpu_ps void @test_div_scale(float %arg0, float %arg1) {
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[INT:%[0-9]+]]:_(s32), [[INT1:%[0-9]+]]:_(s1) = G_INTRINSIC intrinsic(@llvm.amdgcn.div.scale), [[COPY]](s32), [[COPY1]](s32), -1
   ; CHECK-NEXT:   [[SEXT:%[0-9]+]]:_(s32) = G_SEXT [[INT1]](s1)
-  ; CHECK-NEXT:   G_STORE [[INT]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
-  ; CHECK-NEXT:   G_STORE [[SEXT]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[INT]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
+  ; CHECK-NEXT:   G_STORE [[SEXT]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; CHECK-NEXT:   S_ENDPGM 0
   %call = call { float, i1 } @llvm.amdgcn.div.scale.f32(float %arg0, float %arg1, i1 true)
   %extract0 = extractvalue { float, i1 } %call, 0
   %extract1 = extractvalue { float, i1 } %call, 1
   %ext = sext i1 %extract1 to i32
-  store float %extract0, ptr addrspace(1) undef
-  store i32 %ext, ptr addrspace(1) undef
+  store float %extract0, ptr addrspace(1) poison
+  store i32 %ext, ptr addrspace(1) poison
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-llvm.amdgcn.image.dim.a16.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-llvm.amdgcn.image.dim.a16.ll
@@ -4890,7 +4890,7 @@ define amdgpu_ps <4 x float> @load_1d_tfe(<8 x i32> inreg %rsrc, <2 x i16> %coor
   ; GFX9-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[TRUNC]](s16), [[DEF1]](s16)
   ; GFX9-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<5 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.1d), 15, [[BUILD_VECTOR1]](<2 x s16>), [[BUILD_VECTOR]](<8 x s32>), 1, 0, 3 :: (dereferenceable load (<4 x s32>), addrspace 8)
   ; GFX9-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<5 x s32>)
-  ; GFX9-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GFX9-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GFX9-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GFX9-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; GFX9-NEXT:   $vgpr2 = COPY [[UV2]](s32)
@@ -4920,7 +4920,7 @@ define amdgpu_ps <4 x float> @load_1d_tfe(<8 x i32> inreg %rsrc, <2 x i16> %coor
   ; GFX10NSA-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[TRUNC]](s16), [[DEF1]](s16)
   ; GFX10NSA-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<5 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.1d), 15, [[BUILD_VECTOR1]](<2 x s16>), [[BUILD_VECTOR]](<8 x s32>), 1, 0, 1 :: (dereferenceable load (<4 x s32>), addrspace 8)
   ; GFX10NSA-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<5 x s32>)
-  ; GFX10NSA-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GFX10NSA-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GFX10NSA-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GFX10NSA-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; GFX10NSA-NEXT:   $vgpr2 = COPY [[UV2]](s32)
@@ -4950,7 +4950,7 @@ define amdgpu_ps <4 x float> @load_1d_tfe(<8 x i32> inreg %rsrc, <2 x i16> %coor
   ; GFX12-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[TRUNC]](s16), [[DEF1]](s16)
   ; GFX12-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<5 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.1d), 15, [[BUILD_VECTOR1]](<2 x s16>), [[BUILD_VECTOR]](<8 x s32>), 1, 0, 1 :: (dereferenceable load (<4 x s32>), addrspace 8)
   ; GFX12-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<5 x s32>)
-  ; GFX12-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GFX12-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GFX12-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; GFX12-NEXT:   $vgpr2 = COPY [[UV2]](s32)
@@ -4961,7 +4961,7 @@ main_body:
   %v = call { <4 x float>, i32 } @llvm.amdgcn.image.load.1d.sl_v4f32i32s.i16(i32 15, i16 %s, <8 x i32> %rsrc, i32 1, i32 0)
   %data = extractvalue { <4 x float>, i32 } %v, 0
   %tfe = extractvalue { <4 x float>, i32 } %v, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <4 x float> %data
 }
 
@@ -4992,7 +4992,7 @@ define amdgpu_ps <4 x float> @load_2d_tfe(<8 x i32> inreg %rsrc, <2 x i16> %coor
   ; GFX9-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[TRUNC]](s16), [[TRUNC1]](s16)
   ; GFX9-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<5 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2d), 15, [[BUILD_VECTOR1]](<2 x s16>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 3 :: (dereferenceable load (<4 x s32>), addrspace 8)
   ; GFX9-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<5 x s32>)
-  ; GFX9-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GFX9-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GFX9-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GFX9-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; GFX9-NEXT:   $vgpr2 = COPY [[UV2]](s32)
@@ -5025,7 +5025,7 @@ define amdgpu_ps <4 x float> @load_2d_tfe(<8 x i32> inreg %rsrc, <2 x i16> %coor
   ; GFX10NSA-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[TRUNC]](s16), [[TRUNC1]](s16)
   ; GFX10NSA-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<5 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2d), 15, [[BUILD_VECTOR1]](<2 x s16>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 1 :: (dereferenceable load (<4 x s32>), addrspace 8)
   ; GFX10NSA-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<5 x s32>)
-  ; GFX10NSA-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GFX10NSA-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GFX10NSA-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GFX10NSA-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; GFX10NSA-NEXT:   $vgpr2 = COPY [[UV2]](s32)
@@ -5058,7 +5058,7 @@ define amdgpu_ps <4 x float> @load_2d_tfe(<8 x i32> inreg %rsrc, <2 x i16> %coor
   ; GFX12-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[TRUNC]](s16), [[TRUNC1]](s16)
   ; GFX12-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<5 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2d), 15, [[BUILD_VECTOR1]](<2 x s16>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 1 :: (dereferenceable load (<4 x s32>), addrspace 8)
   ; GFX12-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<5 x s32>)
-  ; GFX12-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GFX12-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GFX12-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; GFX12-NEXT:   $vgpr2 = COPY [[UV2]](s32)
@@ -5070,7 +5070,7 @@ main_body:
   %v = call { <4 x float>, i32 } @llvm.amdgcn.image.load.2d.sl_v4f32i32s.i16(i32 15, i16 %s, i16 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %data = extractvalue { <4 x float>, i32 } %v, 0
   %tfe = extractvalue { <4 x float>, i32 } %v, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <4 x float> %data
 }
 
@@ -5108,7 +5108,7 @@ define amdgpu_ps <4 x float> @load_3d_tfe(<8 x i32> inreg %rsrc, <2 x i16> %coor
   ; GFX9-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[BUILD_VECTOR1]](<2 x s16>), [[BUILD_VECTOR2]](<2 x s16>)
   ; GFX9-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<5 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.3d), 15, [[CONCAT_VECTORS]](<4 x s16>), $noreg, $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 3 :: (dereferenceable load (<4 x s32>), addrspace 8)
   ; GFX9-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<5 x s32>)
-  ; GFX9-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GFX9-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GFX9-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GFX9-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; GFX9-NEXT:   $vgpr2 = COPY [[UV2]](s32)
@@ -5147,7 +5147,7 @@ define amdgpu_ps <4 x float> @load_3d_tfe(<8 x i32> inreg %rsrc, <2 x i16> %coor
   ; GFX10NSA-NEXT:   [[BUILD_VECTOR2:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[TRUNC2]](s16), [[DEF1]](s16)
   ; GFX10NSA-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<5 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.3d), 15, [[BUILD_VECTOR1]](<2 x s16>), [[BUILD_VECTOR2]](<2 x s16>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 1 :: (dereferenceable load (<4 x s32>), addrspace 8)
   ; GFX10NSA-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<5 x s32>)
-  ; GFX10NSA-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GFX10NSA-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GFX10NSA-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GFX10NSA-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; GFX10NSA-NEXT:   $vgpr2 = COPY [[UV2]](s32)
@@ -5186,7 +5186,7 @@ define amdgpu_ps <4 x float> @load_3d_tfe(<8 x i32> inreg %rsrc, <2 x i16> %coor
   ; GFX12-NEXT:   [[BUILD_VECTOR2:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[TRUNC2]](s16), [[DEF1]](s16)
   ; GFX12-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<5 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.3d), 15, [[BUILD_VECTOR1]](<2 x s16>), [[BUILD_VECTOR2]](<2 x s16>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 1 :: (dereferenceable load (<4 x s32>), addrspace 8)
   ; GFX12-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<5 x s32>)
-  ; GFX12-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GFX12-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GFX12-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; GFX12-NEXT:   $vgpr2 = COPY [[UV2]](s32)
@@ -5199,7 +5199,7 @@ main_body:
   %v = call { <4 x float>, i32 } @llvm.amdgcn.image.load.3d.sl_v4f32i32s.i16(i32 15, i16 %s, i16 %t, i16 %r, <8 x i32> %rsrc, i32 1, i32 0)
   %data = extractvalue { <4 x float>, i32 } %v, 0
   %tfe = extractvalue { <4 x float>, i32 } %v, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <4 x float> %data
 }
 
@@ -5239,7 +5239,7 @@ define amdgpu_ps <4 x float> @load_2darraymsaa_tfe(<8 x i32> inreg %rsrc, <2 x i
   ; GFX9-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:_(<4 x s16>) = G_CONCAT_VECTORS [[BUILD_VECTOR1]](<2 x s16>), [[BUILD_VECTOR2]](<2 x s16>)
   ; GFX9-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<5 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2darraymsaa), 15, [[CONCAT_VECTORS]](<4 x s16>), $noreg, $noreg, $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 3 :: (dereferenceable load (<4 x s32>), addrspace 8)
   ; GFX9-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<5 x s32>)
-  ; GFX9-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GFX9-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GFX9-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GFX9-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; GFX9-NEXT:   $vgpr2 = COPY [[UV2]](s32)
@@ -5280,7 +5280,7 @@ define amdgpu_ps <4 x float> @load_2darraymsaa_tfe(<8 x i32> inreg %rsrc, <2 x i
   ; GFX10NSA-NEXT:   [[BUILD_VECTOR2:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[TRUNC2]](s16), [[TRUNC3]](s16)
   ; GFX10NSA-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<5 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2darraymsaa), 15, [[BUILD_VECTOR1]](<2 x s16>), [[BUILD_VECTOR2]](<2 x s16>), $noreg, $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 1 :: (dereferenceable load (<4 x s32>), addrspace 8)
   ; GFX10NSA-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<5 x s32>)
-  ; GFX10NSA-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GFX10NSA-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GFX10NSA-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GFX10NSA-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; GFX10NSA-NEXT:   $vgpr2 = COPY [[UV2]](s32)
@@ -5321,7 +5321,7 @@ define amdgpu_ps <4 x float> @load_2darraymsaa_tfe(<8 x i32> inreg %rsrc, <2 x i
   ; GFX12-NEXT:   [[BUILD_VECTOR2:%[0-9]+]]:_(<2 x s16>) = G_BUILD_VECTOR [[TRUNC2]](s16), [[TRUNC3]](s16)
   ; GFX12-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<5 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2darraymsaa), 15, [[BUILD_VECTOR1]](<2 x s16>), [[BUILD_VECTOR2]](<2 x s16>), $noreg, $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 1 :: (dereferenceable load (<4 x s32>), addrspace 8)
   ; GFX12-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<5 x s32>)
-  ; GFX12-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GFX12-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GFX12-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; GFX12-NEXT:   $vgpr2 = COPY [[UV2]](s32)
@@ -5335,7 +5335,7 @@ main_body:
   %v = call { <4 x float>, i32 } @llvm.amdgcn.image.load.2darraymsaa.sl_v4f32i32s.i16(i32 15, i16 %s, i16 %t, i16 %slice, i16 %fragid, <8 x i32> %rsrc, i32 1, i32 0)
   %data = extractvalue { <4 x float>, i32 } %v, 0
   %tfe = extractvalue { <4 x float>, i32 } %v, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <4 x float> %data
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-llvm.amdgcn.image.load.2d.d16.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-llvm.amdgcn.image.load.2d.d16.ll
@@ -248,7 +248,7 @@ define amdgpu_ps half @image_load_tfe_f16(<8 x i32> inreg %rsrc, i32 %s, i32 %t)
   ; UNPACKED-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; UNPACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s16), addrspace 8)
   ; UNPACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<2 x s32>)
-  ; UNPACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; UNPACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; UNPACKED-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; UNPACKED-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0
   ;
@@ -271,13 +271,13 @@ define amdgpu_ps half @image_load_tfe_f16(<8 x i32> inreg %rsrc, i32 %s, i32 %t)
   ; PACKED-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; PACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s16), addrspace 8)
   ; PACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<2 x s32>)
-  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; PACKED-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; PACKED-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0
   %res = call { half, i32 } @llvm.amdgcn.image.load.2d.sl_f16i32s.i32(i32 1, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { half, i32 } %res, 0
   %tfe = extractvalue { half, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret half %tex
 }
 
@@ -308,7 +308,7 @@ define amdgpu_ps <2 x half> @image_load_tfe_v2f16(<8 x i32> inreg %rsrc, i32 %s,
   ; UNPACKED-NEXT:   [[SHL:%[0-9]+]]:_(s32) = G_SHL [[AND1]], [[C1]](s32)
   ; UNPACKED-NEXT:   [[OR:%[0-9]+]]:_(s32) = G_OR [[AND]], [[SHL]]
   ; UNPACKED-NEXT:   [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR]](s32)
-  ; UNPACKED-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; UNPACKED-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; UNPACKED-NEXT:   $vgpr0 = COPY [[BITCAST]](<2 x s16>)
   ; UNPACKED-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0
   ;
@@ -332,13 +332,13 @@ define amdgpu_ps <2 x half> @image_load_tfe_v2f16(<8 x i32> inreg %rsrc, i32 %s,
   ; PACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 3, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (<2 x s16>), addrspace 8)
   ; PACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<2 x s32>)
   ; PACKED-NEXT:   [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[UV]](s32)
-  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; PACKED-NEXT:   $vgpr0 = COPY [[BITCAST]](<2 x s16>)
   ; PACKED-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0
   %res = call { <2 x half>, i32 } @llvm.amdgcn.image.load.2d.sl_v2f16i32s.i32(i32 3, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <2 x half>, i32 } %res, 0
   %tfe = extractvalue { <2 x half>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <2 x half> %tex
 }
 
@@ -362,7 +362,7 @@ define amdgpu_ps <3 x half> @image_load_tfe_v3f16(<8 x i32> inreg %rsrc, i32 %s,
   ; UNPACKED-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; UNPACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<4 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 7, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (<3 x s16>), align 8, addrspace 8)
   ; UNPACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<4 x s32>)
-  ; UNPACKED-NEXT:   G_STORE [[UV3]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; UNPACKED-NEXT:   G_STORE [[UV3]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; UNPACKED-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
   ; UNPACKED-NEXT:   [[AND:%[0-9]+]]:_(s32) = G_AND [[UV]], [[C]]
   ; UNPACKED-NEXT:   [[AND1:%[0-9]+]]:_(s32) = G_AND [[UV1]], [[C]]
@@ -400,14 +400,14 @@ define amdgpu_ps <3 x half> @image_load_tfe_v3f16(<8 x i32> inreg %rsrc, i32 %s,
   ; PACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<3 x s32>)
   ; PACKED-NEXT:   [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[UV]](s32)
   ; PACKED-NEXT:   [[BITCAST1:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[UV1]](s32)
-  ; PACKED-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PACKED-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; PACKED-NEXT:   $vgpr0 = COPY [[BITCAST]](<2 x s16>)
   ; PACKED-NEXT:   $vgpr1 = COPY [[BITCAST1]](<2 x s16>)
   ; PACKED-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0, implicit $vgpr1
   %res = call { <3 x half>, i32 } @llvm.amdgcn.image.load.2d.sl_v3f16i32s.i32(i32 7, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <3 x half>, i32 } %res, 0
   %tfe = extractvalue { <3 x half>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <3 x half> %tex
 }
 
@@ -431,7 +431,7 @@ define amdgpu_ps <4 x half> @image_load_tfe_v4f16(<8 x i32> inreg %rsrc, i32 %s,
   ; UNPACKED-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; UNPACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<5 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 15, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (<4 x s16>), addrspace 8)
   ; UNPACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<5 x s32>)
-  ; UNPACKED-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; UNPACKED-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; UNPACKED-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
   ; UNPACKED-NEXT:   [[AND:%[0-9]+]]:_(s32) = G_AND [[UV]], [[C]]
   ; UNPACKED-NEXT:   [[AND1:%[0-9]+]]:_(s32) = G_AND [[UV1]], [[C]]
@@ -469,14 +469,14 @@ define amdgpu_ps <4 x half> @image_load_tfe_v4f16(<8 x i32> inreg %rsrc, i32 %s,
   ; PACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<3 x s32>)
   ; PACKED-NEXT:   [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[UV]](s32)
   ; PACKED-NEXT:   [[BITCAST1:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[UV1]](s32)
-  ; PACKED-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PACKED-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; PACKED-NEXT:   $vgpr0 = COPY [[BITCAST]](<2 x s16>)
   ; PACKED-NEXT:   $vgpr1 = COPY [[BITCAST1]](<2 x s16>)
   ; PACKED-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0, implicit $vgpr1
   %res = call { <4 x half>, i32 } @llvm.amdgcn.image.load.2d.sl_v4f16i32s.i32(i32 15, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <4 x half>, i32 } %res, 0
   %tfe = extractvalue { <4 x half>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <4 x half> %tex
 }
 
@@ -969,7 +969,7 @@ define amdgpu_ps half @image_load_tfe_f16_dmask_0000(<8 x i32> inreg %rsrc, i32 
   ; UNPACKED-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; UNPACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s16), addrspace 8)
   ; UNPACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<2 x s32>)
-  ; UNPACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; UNPACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; UNPACKED-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; UNPACKED-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0
   ;
@@ -992,13 +992,13 @@ define amdgpu_ps half @image_load_tfe_f16_dmask_0000(<8 x i32> inreg %rsrc, i32 
   ; PACKED-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; PACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s16), addrspace 8)
   ; PACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<2 x s32>)
-  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; PACKED-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; PACKED-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0
   %res = call { half, i32 } @llvm.amdgcn.image.load.2d.sl_f16i32s.i32(i32 0, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { half, i32 } %res, 0
   %tfe = extractvalue { half, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret half %tex
 }
 
@@ -1029,7 +1029,7 @@ define amdgpu_ps <2 x half> @image_load_tfe_v2f16_dmask_1000(<8 x i32> inreg %rs
   ; UNPACKED-NEXT:   [[SHL:%[0-9]+]]:_(s32) = G_SHL [[C1]], [[C2]](s32)
   ; UNPACKED-NEXT:   [[OR:%[0-9]+]]:_(s32) = G_OR [[AND]], [[SHL]]
   ; UNPACKED-NEXT:   [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR]](s32)
-  ; UNPACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; UNPACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; UNPACKED-NEXT:   $vgpr0 = COPY [[BITCAST]](<2 x s16>)
   ; UNPACKED-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0
   ;
@@ -1053,13 +1053,13 @@ define amdgpu_ps <2 x half> @image_load_tfe_v2f16_dmask_1000(<8 x i32> inreg %rs
   ; PACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s16), addrspace 8)
   ; PACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<2 x s32>)
   ; PACKED-NEXT:   [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[UV]](s32)
-  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; PACKED-NEXT:   $vgpr0 = COPY [[BITCAST]](<2 x s16>)
   ; PACKED-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0
   %res = call { <2 x half>, i32 } @llvm.amdgcn.image.load.2d.sl_v2f16i32s.i32(i32 1, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <2 x half>, i32 } %res, 0
   %tfe = extractvalue { <2 x half>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <2 x half> %tex
 }
 
@@ -1090,7 +1090,7 @@ define amdgpu_ps <2 x half> @image_load_tfe_v2f16_dmask_0000(<8 x i32> inreg %rs
   ; UNPACKED-NEXT:   [[SHL:%[0-9]+]]:_(s32) = G_SHL [[C1]], [[C2]](s32)
   ; UNPACKED-NEXT:   [[OR:%[0-9]+]]:_(s32) = G_OR [[AND]], [[SHL]]
   ; UNPACKED-NEXT:   [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR]](s32)
-  ; UNPACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; UNPACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; UNPACKED-NEXT:   $vgpr0 = COPY [[BITCAST]](<2 x s16>)
   ; UNPACKED-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0
   ;
@@ -1114,13 +1114,13 @@ define amdgpu_ps <2 x half> @image_load_tfe_v2f16_dmask_0000(<8 x i32> inreg %rs
   ; PACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s16), addrspace 8)
   ; PACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<2 x s32>)
   ; PACKED-NEXT:   [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[UV]](s32)
-  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; PACKED-NEXT:   $vgpr0 = COPY [[BITCAST]](<2 x s16>)
   ; PACKED-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0
   %res = call { <2 x half>, i32 } @llvm.amdgcn.image.load.2d.sl_v2f16i32s.i32(i32 0, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <2 x half>, i32 } %res, 0
   %tfe = extractvalue { <2 x half>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <2 x half> %tex
 }
 
@@ -1144,7 +1144,7 @@ define amdgpu_ps <3 x half> @image_load_tfe_v3f16_dmask_1100(<8 x i32> inreg %rs
   ; UNPACKED-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; UNPACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<3 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 3, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (<2 x s16>), addrspace 8)
   ; UNPACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<3 x s32>)
-  ; UNPACKED-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; UNPACKED-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; UNPACKED-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
   ; UNPACKED-NEXT:   [[AND:%[0-9]+]]:_(s32) = G_AND [[UV]], [[C]]
   ; UNPACKED-NEXT:   [[AND1:%[0-9]+]]:_(s32) = G_AND [[UV1]], [[C]]
@@ -1180,7 +1180,7 @@ define amdgpu_ps <3 x half> @image_load_tfe_v3f16_dmask_1100(<8 x i32> inreg %rs
   ; PACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 3, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (<2 x s16>), addrspace 8)
   ; PACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<2 x s32>)
   ; PACKED-NEXT:   [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[UV]](s32)
-  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; PACKED-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
   ; PACKED-NEXT:   [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
   ; PACKED-NEXT:   [[SHL:%[0-9]+]]:_(s32) = G_SHL [[C]], [[C1]](s32)
@@ -1192,7 +1192,7 @@ define amdgpu_ps <3 x half> @image_load_tfe_v3f16_dmask_1100(<8 x i32> inreg %rs
   %res = call { <3 x half>, i32 } @llvm.amdgcn.image.load.2d.sl_v3f16i32s.i32(i32 3, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <3 x half>, i32 } %res, 0
   %tfe = extractvalue { <3 x half>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <3 x half> %tex
 }
 
@@ -1216,7 +1216,7 @@ define amdgpu_ps <3 x half> @image_load_tfe_v3f16_dmask_1000(<8 x i32> inreg %rs
   ; UNPACKED-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; UNPACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s16), addrspace 8)
   ; UNPACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<2 x s32>)
-  ; UNPACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; UNPACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; UNPACKED-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
   ; UNPACKED-NEXT:   [[AND:%[0-9]+]]:_(s32) = G_AND [[UV]], [[C]]
   ; UNPACKED-NEXT:   [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
@@ -1250,7 +1250,7 @@ define amdgpu_ps <3 x half> @image_load_tfe_v3f16_dmask_1000(<8 x i32> inreg %rs
   ; PACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s16), addrspace 8)
   ; PACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<2 x s32>)
   ; PACKED-NEXT:   [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[UV]](s32)
-  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; PACKED-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
   ; PACKED-NEXT:   [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
   ; PACKED-NEXT:   [[SHL:%[0-9]+]]:_(s32) = G_SHL [[C]], [[C1]](s32)
@@ -1262,7 +1262,7 @@ define amdgpu_ps <3 x half> @image_load_tfe_v3f16_dmask_1000(<8 x i32> inreg %rs
   %res = call { <3 x half>, i32 } @llvm.amdgcn.image.load.2d.sl_v3f16i32s.i32(i32 1, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <3 x half>, i32 } %res, 0
   %tfe = extractvalue { <3 x half>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <3 x half> %tex
 }
 
@@ -1286,7 +1286,7 @@ define amdgpu_ps <3 x half> @image_load_tfe_v3f16_dmask_0000(<8 x i32> inreg %rs
   ; UNPACKED-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; UNPACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s16), addrspace 8)
   ; UNPACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<2 x s32>)
-  ; UNPACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; UNPACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; UNPACKED-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
   ; UNPACKED-NEXT:   [[AND:%[0-9]+]]:_(s32) = G_AND [[UV]], [[C]]
   ; UNPACKED-NEXT:   [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
@@ -1320,7 +1320,7 @@ define amdgpu_ps <3 x half> @image_load_tfe_v3f16_dmask_0000(<8 x i32> inreg %rs
   ; PACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s16), addrspace 8)
   ; PACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<2 x s32>)
   ; PACKED-NEXT:   [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[UV]](s32)
-  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; PACKED-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
   ; PACKED-NEXT:   [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
   ; PACKED-NEXT:   [[SHL:%[0-9]+]]:_(s32) = G_SHL [[C]], [[C1]](s32)
@@ -1332,7 +1332,7 @@ define amdgpu_ps <3 x half> @image_load_tfe_v3f16_dmask_0000(<8 x i32> inreg %rs
   %res = call { <3 x half>, i32 } @llvm.amdgcn.image.load.2d.sl_v3f16i32s.i32(i32 0, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <3 x half>, i32 } %res, 0
   %tfe = extractvalue { <3 x half>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <3 x half> %tex
 }
 
@@ -1356,7 +1356,7 @@ define amdgpu_ps <4 x half> @image_load_tfe_v4f16_dmask_1110(<8 x i32> inreg %rs
   ; UNPACKED-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; UNPACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<4 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 7, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (<3 x s16>), align 8, addrspace 8)
   ; UNPACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<4 x s32>)
-  ; UNPACKED-NEXT:   G_STORE [[UV3]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; UNPACKED-NEXT:   G_STORE [[UV3]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; UNPACKED-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
   ; UNPACKED-NEXT:   [[AND:%[0-9]+]]:_(s32) = G_AND [[UV]], [[C]]
   ; UNPACKED-NEXT:   [[AND1:%[0-9]+]]:_(s32) = G_AND [[UV1]], [[C]]
@@ -1394,14 +1394,14 @@ define amdgpu_ps <4 x half> @image_load_tfe_v4f16_dmask_1110(<8 x i32> inreg %rs
   ; PACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<3 x s32>)
   ; PACKED-NEXT:   [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[UV]](s32)
   ; PACKED-NEXT:   [[BITCAST1:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[UV1]](s32)
-  ; PACKED-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PACKED-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; PACKED-NEXT:   $vgpr0 = COPY [[BITCAST]](<2 x s16>)
   ; PACKED-NEXT:   $vgpr1 = COPY [[BITCAST1]](<2 x s16>)
   ; PACKED-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0, implicit $vgpr1
   %res = call { <4 x half>, i32 } @llvm.amdgcn.image.load.2d.sl_v4f16i32s.i32(i32 7, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <4 x half>, i32 } %res, 0
   %tfe = extractvalue { <4 x half>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <4 x half> %tex
 }
 
@@ -1425,7 +1425,7 @@ define amdgpu_ps <4 x half> @image_load_tfe_v4f16_dmask_1100(<8 x i32> inreg %rs
   ; UNPACKED-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; UNPACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<3 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 3, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (<2 x s16>), addrspace 8)
   ; UNPACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<3 x s32>)
-  ; UNPACKED-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; UNPACKED-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; UNPACKED-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
   ; UNPACKED-NEXT:   [[AND:%[0-9]+]]:_(s32) = G_AND [[UV]], [[C]]
   ; UNPACKED-NEXT:   [[AND1:%[0-9]+]]:_(s32) = G_AND [[UV1]], [[C]]
@@ -1462,14 +1462,14 @@ define amdgpu_ps <4 x half> @image_load_tfe_v4f16_dmask_1100(<8 x i32> inreg %rs
   ; PACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<2 x s32>)
   ; PACKED-NEXT:   [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[UV]](s32)
   ; PACKED-NEXT:   [[DEF1:%[0-9]+]]:_(<2 x s16>) = G_IMPLICIT_DEF
-  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; PACKED-NEXT:   $vgpr0 = COPY [[BITCAST]](<2 x s16>)
   ; PACKED-NEXT:   $vgpr1 = COPY [[DEF1]](<2 x s16>)
   ; PACKED-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0, implicit $vgpr1
   %res = call { <4 x half>, i32 } @llvm.amdgcn.image.load.2d.sl_v4f16i32s.i32(i32 3, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <4 x half>, i32 } %res, 0
   %tfe = extractvalue { <4 x half>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <4 x half> %tex
 }
 
@@ -1493,7 +1493,7 @@ define amdgpu_ps <4 x half> @image_load_tfe_v4f16_dmask_1000(<8 x i32> inreg %rs
   ; UNPACKED-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; UNPACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s16), addrspace 8)
   ; UNPACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<2 x s32>)
-  ; UNPACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; UNPACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; UNPACKED-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
   ; UNPACKED-NEXT:   [[AND:%[0-9]+]]:_(s32) = G_AND [[UV]], [[C]]
   ; UNPACKED-NEXT:   [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
@@ -1528,14 +1528,14 @@ define amdgpu_ps <4 x half> @image_load_tfe_v4f16_dmask_1000(<8 x i32> inreg %rs
   ; PACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<2 x s32>)
   ; PACKED-NEXT:   [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[UV]](s32)
   ; PACKED-NEXT:   [[DEF1:%[0-9]+]]:_(<2 x s16>) = G_IMPLICIT_DEF
-  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; PACKED-NEXT:   $vgpr0 = COPY [[BITCAST]](<2 x s16>)
   ; PACKED-NEXT:   $vgpr1 = COPY [[DEF1]](<2 x s16>)
   ; PACKED-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0, implicit $vgpr1
   %res = call { <4 x half>, i32 } @llvm.amdgcn.image.load.2d.sl_v4f16i32s.i32(i32 1, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <4 x half>, i32 } %res, 0
   %tfe = extractvalue { <4 x half>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <4 x half> %tex
 }
 
@@ -1559,7 +1559,7 @@ define amdgpu_ps <4 x half> @image_load_tfe_v4f16_dmask_0000(<8 x i32> inreg %rs
   ; UNPACKED-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; UNPACKED-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD_D16_:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD_D16 intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s16), addrspace 8)
   ; UNPACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<2 x s32>)
-  ; UNPACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; UNPACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; UNPACKED-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
   ; UNPACKED-NEXT:   [[AND:%[0-9]+]]:_(s32) = G_AND [[UV]], [[C]]
   ; UNPACKED-NEXT:   [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
@@ -1594,14 +1594,14 @@ define amdgpu_ps <4 x half> @image_load_tfe_v4f16_dmask_0000(<8 x i32> inreg %rs
   ; PACKED-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD_D16_]](<2 x s32>)
   ; PACKED-NEXT:   [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[UV]](s32)
   ; PACKED-NEXT:   [[DEF1:%[0-9]+]]:_(<2 x s16>) = G_IMPLICIT_DEF
-  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PACKED-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; PACKED-NEXT:   $vgpr0 = COPY [[BITCAST]](<2 x s16>)
   ; PACKED-NEXT:   $vgpr1 = COPY [[DEF1]](<2 x s16>)
   ; PACKED-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0, implicit $vgpr1
   %res = call { <4 x half>, i32 } @llvm.amdgcn.image.load.2d.sl_v4f16i32s.i32(i32 0, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <4 x half>, i32 } %res, 0
   %tfe = extractvalue { <4 x half>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <4 x half> %tex
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-llvm.amdgcn.image.load.2d.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-llvm.amdgcn.image.load.2d.ll
@@ -126,13 +126,13 @@ define amdgpu_ps float @image_load_tfe_f32(<8 x i32> inreg %rsrc, i32 %s, i32 %t
   ; GCN-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; GCN-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s32), addrspace 8)
   ; GCN-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<2 x s32>)
-  ; GCN-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GCN-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0
   %res = call { float, i32 } @llvm.amdgcn.image.load.2d.sl_f32i32s.i32(i32 1, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { float, i32 } %res, 0
   %tfe = extractvalue { float, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret float %tex
 }
 
@@ -156,14 +156,14 @@ define amdgpu_ps <2 x float> @image_load_tfe_v2f32(<8 x i32> inreg %rsrc, i32 %s
   ; GCN-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; GCN-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<3 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2d), 3, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (<2 x s32>), addrspace 8)
   ; GCN-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<3 x s32>)
-  ; GCN-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GCN-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; GCN-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0, implicit $vgpr1
   %res = call { <2 x float>, i32 } @llvm.amdgcn.image.load.2d.sl_v2f32i32s.i32(i32 3, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <2 x float>, i32 } %res, 0
   %tfe = extractvalue { <2 x float>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <2 x float> %tex
 }
 
@@ -187,7 +187,7 @@ define amdgpu_ps <3 x float> @image_load_tfe_v3f32(<8 x i32> inreg %rsrc, i32 %s
   ; GCN-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; GCN-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<4 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2d), 7, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (<3 x s32>), align 16, addrspace 8)
   ; GCN-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>)
-  ; GCN-NEXT:   G_STORE [[UV3]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[UV3]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GCN-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; GCN-NEXT:   $vgpr2 = COPY [[UV2]](s32)
@@ -195,7 +195,7 @@ define amdgpu_ps <3 x float> @image_load_tfe_v3f32(<8 x i32> inreg %rsrc, i32 %s
   %res = call { <3 x float>, i32 } @llvm.amdgcn.image.load.2d.sl_v3f32i32s.i32(i32 7, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <3 x float>, i32 } %res, 0
   %tfe = extractvalue { <3 x float>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <3 x float> %tex
 }
 
@@ -219,7 +219,7 @@ define amdgpu_ps <4 x float> @image_load_tfe_v4f32(<8 x i32> inreg %rsrc, i32 %s
   ; GCN-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; GCN-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<5 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2d), 15, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (<4 x s32>), addrspace 8)
   ; GCN-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<5 x s32>)
-  ; GCN-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[UV4]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GCN-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; GCN-NEXT:   $vgpr2 = COPY [[UV2]](s32)
@@ -228,7 +228,7 @@ define amdgpu_ps <4 x float> @image_load_tfe_v4f32(<8 x i32> inreg %rsrc, i32 %s
   %res = call { <4 x float>, i32 } @llvm.amdgcn.image.load.2d.sl_v4f32i32s.i32(i32 15, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <4 x float>, i32 } %res, 0
   %tfe = extractvalue { <4 x float>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <4 x float> %tex
 }
 
@@ -484,13 +484,13 @@ define amdgpu_ps float @image_load_tfe_f32_dmask_0000(<8 x i32> inreg %rsrc, i32
   ; GCN-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; GCN-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s32), addrspace 8)
   ; GCN-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<2 x s32>)
-  ; GCN-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GCN-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0
   %res = call { float, i32 } @llvm.amdgcn.image.load.2d.sl_f32i32s.i32(i32 0, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { float, i32 } %res, 0
   %tfe = extractvalue { float, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret float %tex
 }
 
@@ -514,7 +514,7 @@ define amdgpu_ps <2 x float> @image_load_tfe_v2f32_dmask_1000(<8 x i32> inreg %r
   ; GCN-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; GCN-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s32), addrspace 8)
   ; GCN-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<2 x s32>)
-  ; GCN-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<2 x s32>)
   ; GCN-NEXT:   $vgpr0 = COPY [[UV2]](s32)
   ; GCN-NEXT:   $vgpr1 = COPY [[UV3]](s32)
@@ -522,7 +522,7 @@ define amdgpu_ps <2 x float> @image_load_tfe_v2f32_dmask_1000(<8 x i32> inreg %r
   %res = call { <2 x float>, i32 } @llvm.amdgcn.image.load.2d.sl_v2f32i32s.i32(i32 1, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <2 x float>, i32 } %res, 0
   %tfe = extractvalue { <2 x float>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <2 x float> %tex
 }
 
@@ -546,7 +546,7 @@ define amdgpu_ps <2 x float> @image_load_tfe_v2f32_dmask_0000(<8 x i32> inreg %r
   ; GCN-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; GCN-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s32), addrspace 8)
   ; GCN-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<2 x s32>)
-  ; GCN-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<2 x s32>)
   ; GCN-NEXT:   $vgpr0 = COPY [[UV2]](s32)
   ; GCN-NEXT:   $vgpr1 = COPY [[UV3]](s32)
@@ -554,7 +554,7 @@ define amdgpu_ps <2 x float> @image_load_tfe_v2f32_dmask_0000(<8 x i32> inreg %r
   %res = call { <2 x float>, i32 } @llvm.amdgcn.image.load.2d.sl_v2f32i32s.i32(i32 0, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <2 x float>, i32 } %res, 0
   %tfe = extractvalue { <2 x float>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <2 x float> %tex
 }
 
@@ -578,7 +578,7 @@ define amdgpu_ps <3 x float> @image_load_tfe_v3f32_dmask_1100(<8 x i32> inreg %r
   ; GCN-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; GCN-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<3 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2d), 3, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (<2 x s32>), addrspace 8)
   ; GCN-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<3 x s32>)
-  ; GCN-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   [[UV3:%[0-9]+]]:_(s32), [[UV4:%[0-9]+]]:_(s32), [[UV5:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<3 x s32>)
   ; GCN-NEXT:   $vgpr0 = COPY [[UV3]](s32)
   ; GCN-NEXT:   $vgpr1 = COPY [[UV4]](s32)
@@ -587,7 +587,7 @@ define amdgpu_ps <3 x float> @image_load_tfe_v3f32_dmask_1100(<8 x i32> inreg %r
   %res = call { <3 x float>, i32 } @llvm.amdgcn.image.load.2d.sl_v3f32i32s.i32(i32 3, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <3 x float>, i32 } %res, 0
   %tfe = extractvalue { <3 x float>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <3 x float> %tex
 }
 
@@ -612,7 +612,7 @@ define amdgpu_ps <3 x float> @image_load_tfe_v3f32_dmask_1000(<8 x i32> inreg %r
   ; GCN-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s32), addrspace 8)
   ; GCN-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<2 x s32>)
   ; GCN-NEXT:   [[DEF1:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-  ; GCN-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GCN-NEXT:   $vgpr1 = COPY [[DEF1]](s32)
   ; GCN-NEXT:   $vgpr2 = COPY [[DEF1]](s32)
@@ -620,7 +620,7 @@ define amdgpu_ps <3 x float> @image_load_tfe_v3f32_dmask_1000(<8 x i32> inreg %r
   %res = call { <3 x float>, i32 } @llvm.amdgcn.image.load.2d.sl_v3f32i32s.i32(i32 1, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <3 x float>, i32 } %res, 0
   %tfe = extractvalue { <3 x float>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <3 x float> %tex
 }
 
@@ -645,7 +645,7 @@ define amdgpu_ps <3 x float> @image_load_tfe_v3f32_dmask_0000(<8 x i32> inreg %r
   ; GCN-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s32), addrspace 8)
   ; GCN-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<2 x s32>)
   ; GCN-NEXT:   [[DEF1:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-  ; GCN-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GCN-NEXT:   $vgpr1 = COPY [[DEF1]](s32)
   ; GCN-NEXT:   $vgpr2 = COPY [[DEF1]](s32)
@@ -653,7 +653,7 @@ define amdgpu_ps <3 x float> @image_load_tfe_v3f32_dmask_0000(<8 x i32> inreg %r
   %res = call { <3 x float>, i32 } @llvm.amdgcn.image.load.2d.sl_v3f32i32s.i32(i32 0, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <3 x float>, i32 } %res, 0
   %tfe = extractvalue { <3 x float>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <3 x float> %tex
 }
 
@@ -677,7 +677,7 @@ define amdgpu_ps <4 x float> @image_load_tfe_v4f32_dmask_1110(<8 x i32> inreg %r
   ; GCN-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<2 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32)
   ; GCN-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<4 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2d), 7, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (<3 x s32>), align 16, addrspace 8)
   ; GCN-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>)
-  ; GCN-NEXT:   G_STORE [[UV3]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[UV3]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   [[UV4:%[0-9]+]]:_(s32), [[UV5:%[0-9]+]]:_(s32), [[UV6:%[0-9]+]]:_(s32), [[UV7:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>)
   ; GCN-NEXT:   $vgpr0 = COPY [[UV4]](s32)
   ; GCN-NEXT:   $vgpr1 = COPY [[UV5]](s32)
@@ -687,7 +687,7 @@ define amdgpu_ps <4 x float> @image_load_tfe_v4f32_dmask_1110(<8 x i32> inreg %r
   %res = call { <4 x float>, i32 } @llvm.amdgcn.image.load.2d.sl_v4f32i32s.i32(i32 7, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <4 x float>, i32 } %res, 0
   %tfe = extractvalue { <4 x float>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <4 x float> %tex
 }
 
@@ -712,7 +712,7 @@ define amdgpu_ps <4 x float> @image_load_tfe_v4f32_dmask_1100(<8 x i32> inreg %r
   ; GCN-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<3 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2d), 3, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (<2 x s32>), addrspace 8)
   ; GCN-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<3 x s32>)
   ; GCN-NEXT:   [[DEF1:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-  ; GCN-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[UV2]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GCN-NEXT:   $vgpr1 = COPY [[UV1]](s32)
   ; GCN-NEXT:   $vgpr2 = COPY [[DEF1]](s32)
@@ -721,7 +721,7 @@ define amdgpu_ps <4 x float> @image_load_tfe_v4f32_dmask_1100(<8 x i32> inreg %r
   %res = call { <4 x float>, i32 } @llvm.amdgcn.image.load.2d.sl_v4f32i32s.i32(i32 3, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <4 x float>, i32 } %res, 0
   %tfe = extractvalue { <4 x float>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <4 x float> %tex
 }
 
@@ -746,7 +746,7 @@ define amdgpu_ps <4 x float> @image_load_tfe_v4f32_dmask_1000(<8 x i32> inreg %r
   ; GCN-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s32), addrspace 8)
   ; GCN-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<2 x s32>)
   ; GCN-NEXT:   [[DEF1:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-  ; GCN-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GCN-NEXT:   $vgpr1 = COPY [[DEF1]](s32)
   ; GCN-NEXT:   $vgpr2 = COPY [[DEF1]](s32)
@@ -755,7 +755,7 @@ define amdgpu_ps <4 x float> @image_load_tfe_v4f32_dmask_1000(<8 x i32> inreg %r
   %res = call { <4 x float>, i32 } @llvm.amdgcn.image.load.2d.sl_v4f32i32s.i32(i32 1, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <4 x float>, i32 } %res, 0
   %tfe = extractvalue { <4 x float>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <4 x float> %tex
 }
 
@@ -780,7 +780,7 @@ define amdgpu_ps <4 x float> @image_load_tfe_v4f32_dmask_0000(<8 x i32> inreg %r
   ; GCN-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.2d), 1, [[BUILD_VECTOR1]](<2 x s32>), $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s32), addrspace 8)
   ; GCN-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<2 x s32>)
   ; GCN-NEXT:   [[DEF1:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-  ; GCN-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GCN-NEXT:   $vgpr1 = COPY [[DEF1]](s32)
   ; GCN-NEXT:   $vgpr2 = COPY [[DEF1]](s32)
@@ -789,7 +789,7 @@ define amdgpu_ps <4 x float> @image_load_tfe_v4f32_dmask_0000(<8 x i32> inreg %r
   %res = call { <4 x float>, i32 } @llvm.amdgcn.image.load.2d.sl_v4f32i32s.i32(i32 0, i32 %s, i32 %t, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { <4 x float>, i32 } %res, 0
   %tfe = extractvalue { <4 x float>, i32 } %res, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret <4 x float> %tex
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-llvm.amdgcn.image.load.3d.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/legalize-llvm.amdgcn.image.load.3d.ll
@@ -70,7 +70,7 @@ define amdgpu_ps float @image_load_3d_tfe_f32(<8 x i32> inreg %rsrc, i32 %s, i32
   ; GFX6-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<3 x s32>) = G_BUILD_VECTOR [[COPY8]](s32), [[COPY9]](s32), [[COPY10]](s32)
   ; GFX6-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.3d), 1, [[BUILD_VECTOR1]](<3 x s32>), $noreg, $noreg, [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s32), addrspace 8)
   ; GFX6-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<2 x s32>)
-  ; GFX6-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GFX6-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GFX6-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GFX6-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0
   ;
@@ -93,13 +93,13 @@ define amdgpu_ps float @image_load_3d_tfe_f32(<8 x i32> inreg %rsrc, i32 %s, i32
   ; GFX10NSA-NEXT:   [[DEF:%[0-9]+]]:_(p1) = G_IMPLICIT_DEF
   ; GFX10NSA-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:_(<2 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.3d), 1, [[COPY8]](s32), [[COPY9]](s32), [[COPY10]](s32), [[BUILD_VECTOR]](<8 x s32>), 1, 0, 0 :: (dereferenceable load (s32), addrspace 8)
   ; GFX10NSA-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[AMDGPU_INTRIN_IMAGE_LOAD]](<2 x s32>)
-  ; GFX10NSA-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GFX10NSA-NEXT:   G_STORE [[UV1]](s32), [[DEF]](p1) :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GFX10NSA-NEXT:   $vgpr0 = COPY [[UV]](s32)
   ; GFX10NSA-NEXT:   SI_RETURN_TO_EPILOG implicit $vgpr0
   %val = call { float, i32 } @llvm.amdgcn.image.load.3d.sl_f32i32s.i32(i32 1, i32 %s, i32 %t, i32 %r, <8 x i32> %rsrc, i32 1, i32 0)
   %tex = extractvalue { float, i32 } %val, 0
   %tfe = extractvalue { float, i32 } %val, 1
-  store i32 %tfe, ptr addrspace(1) undef
+  store i32 %tfe, ptr addrspace(1) poison
   ret float %tex
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.end.cf.i32.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.end.cf.i32.ll
@@ -46,12 +46,12 @@ entry:
   br i1 %cond, label %mid, label %bb
 
 mid:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %bb
 
 bb:
   call void @llvm.amdgcn.end.cf.i32(i32 %saved)
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.end.cf.i64.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.end.cf.i64.ll
@@ -25,12 +25,12 @@ entry:
   br i1 %cond, label %mid, label %bb
 
 mid:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %bb
 
 bb:
   call void @llvm.amdgcn.end.cf.i64(i64 %saved)
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.global.atomic.csub.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.global.atomic.csub.ll
@@ -167,7 +167,7 @@ define amdgpu_kernel void @global_atomic_csub_sgpr_base_offset(ptr addrspace(1) 
 ; GFX12-NEXT:    s_endpgm
   %gep = getelementptr i32, ptr addrspace(1) %ptr, i64 1024
   %ret = call i32 @llvm.amdgcn.global.atomic.csub.p1(ptr addrspace(1) %gep, i32 %data)
-  store i32 %ret, ptr addrspace(1) undef
+  store i32 %ret, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.if.break.i32.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.if.break.i32.ll
@@ -37,7 +37,7 @@ define amdgpu_kernel void @test_wave32(i32 %arg0, [8 x i32], i32 %saved) {
 entry:
   %cond = icmp eq i32 %arg0, 0
   %break = call i32 @llvm.amdgcn.if.break.i32(i1 %cond, i32 %saved)
-  store volatile i32 %break, ptr addrspace(1) undef
+  store volatile i32 %break, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.if.break.i64.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.if.break.i64.ll
@@ -20,7 +20,7 @@ define amdgpu_kernel void @test_wave64(i32 %arg0, [8 x i32], i64 %saved) {
 entry:
   %cond = icmp eq i32 %arg0, 0
   %break = call i64 @llvm.amdgcn.if.break.i64(i1 %cond, i64 %saved)
-  store volatile i64 %break, ptr addrspace(1) undef
+  store volatile i64 %break, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.kernarg.segment.ptr.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/llvm.amdgcn.kernarg.segment.ptr.ll
@@ -85,7 +85,7 @@ define amdgpu_kernel void @test_no_kernargs() #4 {
   %kernarg.segment.ptr = call noalias ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
   %gep = getelementptr i32, ptr addrspace(4) %kernarg.segment.ptr, i64 10
   %value = load i32, ptr addrspace(4) %gep
-  store volatile i32 %value, ptr addrspace(1) undef
+  store volatile i32 %value, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/localizer.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/localizer.ll
@@ -64,21 +64,21 @@ entry:
   br i1 %cond, label %bb0, label %bb1
 
 bb0:
-  store volatile i32 123, ptr addrspace(1) undef
-  store volatile i32 456, ptr addrspace(1) undef
-  store volatile i32 999, ptr addrspace(1) undef
-  store volatile i32 1000, ptr addrspace(1) undef
-  store volatile i32 455, ptr addrspace(1) undef
-  store volatile i32 23526, ptr addrspace(1) undef
+  store volatile i32 123, ptr addrspace(1) poison
+  store volatile i32 456, ptr addrspace(1) poison
+  store volatile i32 999, ptr addrspace(1) poison
+  store volatile i32 1000, ptr addrspace(1) poison
+  store volatile i32 455, ptr addrspace(1) poison
+  store volatile i32 23526, ptr addrspace(1) poison
   br label %bb2
 
 bb1:
-  store volatile i32 23526, ptr addrspace(1) undef
-  store volatile i32 455, ptr addrspace(1) undef
-  store volatile i32 1000, ptr addrspace(1) undef
-  store volatile i32 456, ptr addrspace(1) undef
-  store volatile i32 999, ptr addrspace(1) undef
-  store volatile i32 123, ptr addrspace(1) undef
+  store volatile i32 23526, ptr addrspace(1) poison
+  store volatile i32 455, ptr addrspace(1) poison
+  store volatile i32 1000, ptr addrspace(1) poison
+  store volatile i32 456, ptr addrspace(1) poison
+  store volatile i32 999, ptr addrspace(1) poison
+  store volatile i32 123, ptr addrspace(1) poison
   br label %bb2
 
 bb2:

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/non-entry-alloca.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/non-entry-alloca.ll
@@ -73,7 +73,7 @@ bb.1:
   br label %bb.2
 
 bb.2:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   ret void
 }
 ; DEFAULTSIZE: .amdhsa_private_segment_fixed_size 16
@@ -135,7 +135,7 @@ bb.0:
   br label %bb.1
 
 bb.1:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   ret void
 }
 
@@ -206,7 +206,7 @@ bb.1:
   br label %bb.2
 
 bb.2:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   ret void
 }
 
@@ -265,7 +265,7 @@ bb.0:
   br label %bb.1
 
 bb.1:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/regbankselect-amdgcn.image.load.1d.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/regbankselect-amdgcn.image.load.1d.ll
@@ -21,7 +21,7 @@ define amdgpu_ps void @load_1d_vgpr_vaddr__sgpr_srsrc(<8 x i32> inreg %rsrc, i32
   ; FAST-NEXT:   [[DEF:%[0-9]+]]:sgpr(p1) = G_IMPLICIT_DEF
   ; FAST-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:vgpr(<4 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.1d), 15, [[COPY8]](s32), [[BUILD_VECTOR]](<8 x s32>), 0, 0, 0 :: (dereferenceable load (<4 x s32>), addrspace 8)
   ; FAST-NEXT:   [[COPY9:%[0-9]+]]:vgpr(p1) = COPY [[DEF]](p1)
-  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[COPY9]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[COPY9]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; FAST-NEXT:   S_ENDPGM 0
   ;
   ; GREEDY-LABEL: name: load_1d_vgpr_vaddr__sgpr_srsrc
@@ -41,10 +41,10 @@ define amdgpu_ps void @load_1d_vgpr_vaddr__sgpr_srsrc(<8 x i32> inreg %rsrc, i32
   ; GREEDY-NEXT:   [[DEF:%[0-9]+]]:sgpr(p1) = G_IMPLICIT_DEF
   ; GREEDY-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:vgpr(<4 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.1d), 15, [[COPY8]](s32), [[BUILD_VECTOR]](<8 x s32>), 0, 0, 0 :: (dereferenceable load (<4 x s32>), addrspace 8)
   ; GREEDY-NEXT:   [[COPY9:%[0-9]+]]:vgpr(p1) = COPY [[DEF]](p1)
-  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[COPY9]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[COPY9]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; GREEDY-NEXT:   S_ENDPGM 0
   %v = call <4 x float> @llvm.amdgcn.image.load.1d.v4f32.i32(i32 15, i32 %s, <8 x i32> %rsrc, i32 0, i32 0)
-  store <4 x float> %v, ptr addrspace(1) undef
+  store <4 x float> %v, ptr addrspace(1) poison
   ret void
 }
 
@@ -68,7 +68,7 @@ define amdgpu_ps void @load_1d_sgpr_vaddr__sgpr_srsrc(<8 x i32> inreg %rsrc, i32
   ; FAST-NEXT:   [[COPY9:%[0-9]+]]:vgpr(s32) = COPY [[COPY8]](s32)
   ; FAST-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:vgpr(<4 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.1d), 15, [[COPY9]](s32), [[BUILD_VECTOR]](<8 x s32>), 0, 0, 0 :: (dereferenceable load (<4 x s32>), addrspace 8)
   ; FAST-NEXT:   [[COPY10:%[0-9]+]]:vgpr(p1) = COPY [[DEF]](p1)
-  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[COPY10]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[COPY10]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; FAST-NEXT:   S_ENDPGM 0
   ;
   ; GREEDY-LABEL: name: load_1d_sgpr_vaddr__sgpr_srsrc
@@ -89,10 +89,10 @@ define amdgpu_ps void @load_1d_sgpr_vaddr__sgpr_srsrc(<8 x i32> inreg %rsrc, i32
   ; GREEDY-NEXT:   [[COPY9:%[0-9]+]]:vgpr(s32) = COPY [[COPY8]](s32)
   ; GREEDY-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:vgpr(<4 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.load.1d), 15, [[COPY9]](s32), [[BUILD_VECTOR]](<8 x s32>), 0, 0, 0 :: (dereferenceable load (<4 x s32>), addrspace 8)
   ; GREEDY-NEXT:   [[COPY10:%[0-9]+]]:vgpr(p1) = COPY [[DEF]](p1)
-  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[COPY10]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[COPY10]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; GREEDY-NEXT:   S_ENDPGM 0
   %v = call <4 x float> @llvm.amdgcn.image.load.1d.v4f32.i32(i32 15, i32 %s, <8 x i32> %rsrc, i32 0, i32 0)
-  store <4 x float> %v, ptr addrspace(1) undef
+  store <4 x float> %v, ptr addrspace(1) poison
   ret void
 }
 
@@ -157,7 +157,7 @@ define amdgpu_ps void @load_1d_vgpr_vaddr__vgpr_srsrc(<8 x i32> %rsrc, i32 %s) {
   ; FAST-NEXT: {{  $}}
   ; FAST-NEXT: bb.5:
   ; FAST-NEXT:   [[COPY9:%[0-9]+]]:vgpr(p1) = COPY [[DEF]](p1)
-  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[COPY9]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[COPY9]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; FAST-NEXT:   S_ENDPGM 0
   ;
   ; GREEDY-LABEL: name: load_1d_vgpr_vaddr__vgpr_srsrc
@@ -219,10 +219,10 @@ define amdgpu_ps void @load_1d_vgpr_vaddr__vgpr_srsrc(<8 x i32> %rsrc, i32 %s) {
   ; GREEDY-NEXT: {{  $}}
   ; GREEDY-NEXT: bb.5:
   ; GREEDY-NEXT:   [[COPY9:%[0-9]+]]:vgpr(p1) = COPY [[DEF]](p1)
-  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[COPY9]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[COPY9]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; GREEDY-NEXT:   S_ENDPGM 0
   %v = call <4 x float> @llvm.amdgcn.image.load.1d.v4f32.i32(i32 15, i32 %s, <8 x i32> %rsrc, i32 0, i32 0)
-  store <4 x float> %v, ptr addrspace(1) undef
+  store <4 x float> %v, ptr addrspace(1) poison
   ret void
 }
 
@@ -288,7 +288,7 @@ define amdgpu_ps void @load_1d_sgpr_vaddr__vgpr_srsrc(<8 x i32> %rsrc, i32 inreg
   ; FAST-NEXT: {{  $}}
   ; FAST-NEXT: bb.5:
   ; FAST-NEXT:   [[COPY10:%[0-9]+]]:vgpr(p1) = COPY [[DEF]](p1)
-  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[COPY10]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[COPY10]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; FAST-NEXT:   S_ENDPGM 0
   ;
   ; GREEDY-LABEL: name: load_1d_sgpr_vaddr__vgpr_srsrc
@@ -351,10 +351,10 @@ define amdgpu_ps void @load_1d_sgpr_vaddr__vgpr_srsrc(<8 x i32> %rsrc, i32 inreg
   ; GREEDY-NEXT: {{  $}}
   ; GREEDY-NEXT: bb.5:
   ; GREEDY-NEXT:   [[COPY10:%[0-9]+]]:vgpr(p1) = COPY [[DEF]](p1)
-  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[COPY10]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[COPY10]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; GREEDY-NEXT:   S_ENDPGM 0
   %v = call <4 x float> @llvm.amdgcn.image.load.1d.v4f32.i32(i32 15, i32 %s, <8 x i32> %rsrc, i32 0, i32 0)
-  store <4 x float> %v, ptr addrspace(1) undef
+  store <4 x float> %v, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/regbankselect-amdgcn.image.sample.1d.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/regbankselect-amdgcn.image.sample.1d.ll
@@ -25,7 +25,7 @@ define amdgpu_ps void @sample_1d_vgpr_vaddr__sgpr_rsrc__sgpr_samp(<8 x i32> inre
   ; FAST-NEXT:   [[COPY12:%[0-9]+]]:vgpr(s32) = COPY $vgpr0
   ; FAST-NEXT:   [[DEF:%[0-9]+]]:sgpr(p1) = G_IMPLICIT_DEF
   ; FAST-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:vgpr(<4 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.sample.1d), 15, [[COPY12]](s32), [[BUILD_VECTOR]](<8 x s32>), [[BUILD_VECTOR1]](<4 x s32>), 0, 0, 0, 0 :: (dereferenceable load (<4 x s32>), addrspace 8)
-  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; FAST-NEXT:   S_ENDPGM 0
   ;
   ; GREEDY-LABEL: name: sample_1d_vgpr_vaddr__sgpr_rsrc__sgpr_samp
@@ -49,10 +49,10 @@ define amdgpu_ps void @sample_1d_vgpr_vaddr__sgpr_rsrc__sgpr_samp(<8 x i32> inre
   ; GREEDY-NEXT:   [[COPY12:%[0-9]+]]:vgpr(s32) = COPY $vgpr0
   ; GREEDY-NEXT:   [[DEF:%[0-9]+]]:sgpr(p1) = G_IMPLICIT_DEF
   ; GREEDY-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:vgpr(<4 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.sample.1d), 15, [[COPY12]](s32), [[BUILD_VECTOR]](<8 x s32>), [[BUILD_VECTOR1]](<4 x s32>), 0, 0, 0, 0 :: (dereferenceable load (<4 x s32>), addrspace 8)
-  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; GREEDY-NEXT:   S_ENDPGM 0
   %v = call <4 x float> @llvm.amdgcn.image.sample.1d.v4f32.f32(i32 15, float %s, <8 x i32> %rsrc, <4 x i32> %samp, i1 false, i32 0, i32 0)
-  store <4 x float> %v, ptr addrspace(1) undef
+  store <4 x float> %v, ptr addrspace(1) poison
   ret void
 }
 
@@ -80,7 +80,7 @@ define amdgpu_ps void @sample_1d_sgpr_vaddr__sgpr_rsrc__sgpr_samp(<8 x i32> inre
   ; FAST-NEXT:   [[DEF:%[0-9]+]]:sgpr(p1) = G_IMPLICIT_DEF
   ; FAST-NEXT:   [[COPY13:%[0-9]+]]:vgpr(s32) = COPY [[COPY12]](s32)
   ; FAST-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:vgpr(<4 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.sample.1d), 15, [[COPY13]](s32), [[BUILD_VECTOR]](<8 x s32>), [[BUILD_VECTOR1]](<4 x s32>), 0, 0, 0, 0 :: (dereferenceable load (<4 x s32>), addrspace 8)
-  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; FAST-NEXT:   S_ENDPGM 0
   ;
   ; GREEDY-LABEL: name: sample_1d_sgpr_vaddr__sgpr_rsrc__sgpr_samp
@@ -105,10 +105,10 @@ define amdgpu_ps void @sample_1d_sgpr_vaddr__sgpr_rsrc__sgpr_samp(<8 x i32> inre
   ; GREEDY-NEXT:   [[DEF:%[0-9]+]]:sgpr(p1) = G_IMPLICIT_DEF
   ; GREEDY-NEXT:   [[COPY13:%[0-9]+]]:vgpr(s32) = COPY [[COPY12]](s32)
   ; GREEDY-NEXT:   [[AMDGPU_INTRIN_IMAGE_LOAD:%[0-9]+]]:vgpr(<4 x s32>) = G_AMDGPU_INTRIN_IMAGE_LOAD intrinsic(@llvm.amdgcn.image.sample.1d), 15, [[COPY13]](s32), [[BUILD_VECTOR]](<8 x s32>), [[BUILD_VECTOR1]](<4 x s32>), 0, 0, 0, 0 :: (dereferenceable load (<4 x s32>), addrspace 8)
-  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; GREEDY-NEXT:   S_ENDPGM 0
   %v = call <4 x float> @llvm.amdgcn.image.sample.1d.v4f32.f32(i32 15, float %s, <8 x i32> %rsrc, <4 x i32> %samp, i1 false, i32 0, i32 0)
-  store <4 x float> %v, ptr addrspace(1) undef
+  store <4 x float> %v, ptr addrspace(1) poison
   ret void
 }
 
@@ -177,7 +177,7 @@ define amdgpu_ps void @sample_1d_vgpr_vaddr__vgpr_rsrc__sgpr_samp(<8 x i32> %rsr
   ; FAST-NEXT:   $exec = S_MOV_B64_term [[S_MOV_B64_]]
   ; FAST-NEXT: {{  $}}
   ; FAST-NEXT: bb.5:
-  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; FAST-NEXT:   S_ENDPGM 0
   ;
   ; GREEDY-LABEL: name: sample_1d_vgpr_vaddr__vgpr_rsrc__sgpr_samp
@@ -243,10 +243,10 @@ define amdgpu_ps void @sample_1d_vgpr_vaddr__vgpr_rsrc__sgpr_samp(<8 x i32> %rsr
   ; GREEDY-NEXT:   $exec = S_MOV_B64_term [[S_MOV_B64_]]
   ; GREEDY-NEXT: {{  $}}
   ; GREEDY-NEXT: bb.5:
-  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; GREEDY-NEXT:   S_ENDPGM 0
   %v = call <4 x float> @llvm.amdgcn.image.sample.1d.v4f32.f32(i32 15, float %s, <8 x i32> %rsrc, <4 x i32> %samp, i1 false, i32 0, i32 0)
-  store <4 x float> %v, ptr addrspace(1) undef
+  store <4 x float> %v, ptr addrspace(1) poison
   ret void
 }
 
@@ -307,7 +307,7 @@ define amdgpu_ps void @sample_1d_vgpr_vaddr__sgpr_rsrc__vgpr_samp(<8 x i32> inre
   ; FAST-NEXT:   $exec = S_MOV_B64_term [[S_MOV_B64_]]
   ; FAST-NEXT: {{  $}}
   ; FAST-NEXT: bb.5:
-  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; FAST-NEXT:   S_ENDPGM 0
   ;
   ; GREEDY-LABEL: name: sample_1d_vgpr_vaddr__sgpr_rsrc__vgpr_samp
@@ -365,10 +365,10 @@ define amdgpu_ps void @sample_1d_vgpr_vaddr__sgpr_rsrc__vgpr_samp(<8 x i32> inre
   ; GREEDY-NEXT:   $exec = S_MOV_B64_term [[S_MOV_B64_]]
   ; GREEDY-NEXT: {{  $}}
   ; GREEDY-NEXT: bb.5:
-  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; GREEDY-NEXT:   S_ENDPGM 0
   %v = call <4 x float> @llvm.amdgcn.image.sample.1d.v4f32.f32(i32 15, float %s, <8 x i32> %rsrc, <4 x i32> %samp, i1 false, i32 0, i32 0)
-  store <4 x float> %v, ptr addrspace(1) undef
+  store <4 x float> %v, ptr addrspace(1) poison
   ret void
 }
 
@@ -449,7 +449,7 @@ define amdgpu_ps void @sample_1d_vgpr_vaddr__vgpr_rsrc__vgpr_samp(<8 x i32> %rsr
   ; FAST-NEXT:   $exec = S_MOV_B64_term [[S_MOV_B64_]]
   ; FAST-NEXT: {{  $}}
   ; FAST-NEXT: bb.5:
-  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; FAST-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; FAST-NEXT:   S_ENDPGM 0
   ;
   ; GREEDY-LABEL: name: sample_1d_vgpr_vaddr__vgpr_rsrc__vgpr_samp
@@ -527,10 +527,10 @@ define amdgpu_ps void @sample_1d_vgpr_vaddr__vgpr_rsrc__vgpr_samp(<8 x i32> %rsr
   ; GREEDY-NEXT:   $exec = S_MOV_B64_term [[S_MOV_B64_]]
   ; GREEDY-NEXT: {{  $}}
   ; GREEDY-NEXT: bb.5:
-  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GREEDY-NEXT:   G_STORE [[AMDGPU_INTRIN_IMAGE_LOAD]](<4 x s32>), [[DEF]](p1) :: (store (<4 x s32>) into `ptr addrspace(1) poison`, addrspace 1)
   ; GREEDY-NEXT:   S_ENDPGM 0
   %v = call <4 x float> @llvm.amdgcn.image.sample.1d.v4f32.f32(i32 15, float %s, <8 x i32> %rsrc, <4 x i32> %samp, i1 false, i32 0, i32 0)
-  store <4 x float> %v, ptr addrspace(1) undef
+  store <4 x float> %v, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/regbankselect-amdgcn.s.buffer.load.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/regbankselect-amdgcn.s.buffer.load.ll
@@ -653,7 +653,7 @@ define amdgpu_ps void @s_buffer_load_i96_vgpr_offset(<4 x i32> inreg %rsrc, i32 
   ; GFX7-NEXT:   [[C1:%[0-9]+]]:vgpr(s32) = G_CONSTANT i32 0
   ; GFX7-NEXT:   [[AMDGPU_BUFFER_LOAD:%[0-9]+]]:vgpr(s128) = G_AMDGPU_BUFFER_LOAD [[BUILD_VECTOR]](<4 x s32>), [[C1]](s32), [[COPY4]], [[C]], 0, 0, 0 :: (dereferenceable invariant load (s128), align 4)
   ; GFX7-NEXT:   [[TRUNC:%[0-9]+]]:vgpr(s96) = G_TRUNC [[AMDGPU_BUFFER_LOAD]](s128)
-  ; GFX7-NEXT:   G_STORE [[TRUNC]](s96), [[DEF]](p1) :: (store (s96) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[TRUNC]](s96), [[DEF]](p1) :: (store (s96) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GFX7-NEXT:   S_ENDPGM 0
   ;
   ; GFX12-LABEL: name: s_buffer_load_i96_vgpr_offset
@@ -671,10 +671,10 @@ define amdgpu_ps void @s_buffer_load_i96_vgpr_offset(<4 x i32> inreg %rsrc, i32 
   ; GFX12-NEXT:   [[C1:%[0-9]+]]:vgpr(s32) = G_CONSTANT i32 0
   ; GFX12-NEXT:   [[AMDGPU_BUFFER_LOAD:%[0-9]+]]:vgpr(s96) = G_AMDGPU_BUFFER_LOAD [[BUILD_VECTOR]](<4 x s32>), [[C1]](s32), [[COPY4]], [[C]], 0, 0, 0 :: (dereferenceable invariant load (s96), align 4)
   ; GFX12-NEXT:   [[COPY5:%[0-9]+]]:vgpr(p1) = COPY [[DEF]](p1)
-  ; GFX12-NEXT:   G_STORE [[AMDGPU_BUFFER_LOAD]](s96), [[COPY5]](p1) :: (store (s96) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[AMDGPU_BUFFER_LOAD]](s96), [[COPY5]](p1) :: (store (s96) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GFX12-NEXT:   S_ENDPGM 0
   %val = call i96 @llvm.amdgcn.s.buffer.load.i96(<4 x i32> %rsrc, i32 %soffset, i32 0)
-  store i96 %val, ptr addrspace(1) undef
+  store i96 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -697,10 +697,10 @@ define amdgpu_ps void @s_buffer_load_i256_vgpr_offset(<4 x i32> inreg %rsrc, i32
   ; GFX7-NEXT:   [[AMDGPU_BUFFER_LOAD1:%[0-9]+]]:vgpr(s128) = G_AMDGPU_BUFFER_LOAD [[BUILD_VECTOR]](<4 x s32>), [[C1]](s32), [[COPY4]], [[C]], 16, 0, 0 :: (dereferenceable invariant load (s128), align 4)
   ; GFX7-NEXT:   [[MV:%[0-9]+]]:vgpr(s256) = G_MERGE_VALUES [[AMDGPU_BUFFER_LOAD]](s128), [[AMDGPU_BUFFER_LOAD1]](s128)
   ; GFX7-NEXT:   [[UV:%[0-9]+]]:vgpr(s128), [[UV1:%[0-9]+]]:vgpr(s128) = G_UNMERGE_VALUES [[MV]](s256)
-  ; GFX7-NEXT:   G_STORE [[UV]](s128), [[DEF]](p1) :: (store (s128) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV]](s128), [[DEF]](p1) :: (store (s128) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GFX7-NEXT:   [[C2:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 16
   ; GFX7-NEXT:   [[PTR_ADD:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
-  ; GFX7-NEXT:   G_STORE [[UV1]](s128), [[PTR_ADD]](p1) :: (store (s128) into `ptr addrspace(1) undef` + 16, align 8, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV1]](s128), [[PTR_ADD]](p1) :: (store (s128) into `ptr addrspace(1) poison` + 16, align 8, addrspace 1)
   ; GFX7-NEXT:   S_ENDPGM 0
   ;
   ; GFX12-LABEL: name: s_buffer_load_i256_vgpr_offset
@@ -721,14 +721,14 @@ define amdgpu_ps void @s_buffer_load_i256_vgpr_offset(<4 x i32> inreg %rsrc, i32
   ; GFX12-NEXT:   [[MV:%[0-9]+]]:vgpr(s256) = G_MERGE_VALUES [[AMDGPU_BUFFER_LOAD]](s128), [[AMDGPU_BUFFER_LOAD1]](s128)
   ; GFX12-NEXT:   [[UV:%[0-9]+]]:vgpr(s128), [[UV1:%[0-9]+]]:vgpr(s128) = G_UNMERGE_VALUES [[MV]](s256)
   ; GFX12-NEXT:   [[COPY5:%[0-9]+]]:vgpr(p1) = COPY [[DEF]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV]](s128), [[COPY5]](p1) :: (store (s128) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV]](s128), [[COPY5]](p1) :: (store (s128) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GFX12-NEXT:   [[C2:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 16
   ; GFX12-NEXT:   [[PTR_ADD:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
   ; GFX12-NEXT:   [[COPY6:%[0-9]+]]:vgpr(p1) = COPY [[PTR_ADD]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV1]](s128), [[COPY6]](p1) :: (store (s128) into `ptr addrspace(1) undef` + 16, align 8, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV1]](s128), [[COPY6]](p1) :: (store (s128) into `ptr addrspace(1) poison` + 16, align 8, addrspace 1)
   ; GFX12-NEXT:   S_ENDPGM 0
   %val = call i256 @llvm.amdgcn.s.buffer.load.i256(<4 x i32> %rsrc, i32 %soffset, i32 0)
-  store i256 %val, ptr addrspace(1) undef
+  store i256 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -753,16 +753,16 @@ define amdgpu_ps void @s_buffer_load_i512_vgpr_offset(<4 x i32> inreg %rsrc, i32
   ; GFX7-NEXT:   [[AMDGPU_BUFFER_LOAD3:%[0-9]+]]:vgpr(s128) = G_AMDGPU_BUFFER_LOAD [[BUILD_VECTOR]](<4 x s32>), [[C1]](s32), [[COPY4]], [[C]], 48, 0, 0 :: (dereferenceable invariant load (s128) from unknown-address + 48, align 4)
   ; GFX7-NEXT:   [[MV:%[0-9]+]]:vgpr(s512) = G_MERGE_VALUES [[AMDGPU_BUFFER_LOAD]](s128), [[AMDGPU_BUFFER_LOAD1]](s128), [[AMDGPU_BUFFER_LOAD2]](s128), [[AMDGPU_BUFFER_LOAD3]](s128)
   ; GFX7-NEXT:   [[UV:%[0-9]+]]:vgpr(s128), [[UV1:%[0-9]+]]:vgpr(s128), [[UV2:%[0-9]+]]:vgpr(s128), [[UV3:%[0-9]+]]:vgpr(s128) = G_UNMERGE_VALUES [[MV]](s512)
-  ; GFX7-NEXT:   G_STORE [[UV]](s128), [[DEF]](p1) :: (store (s128) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV]](s128), [[DEF]](p1) :: (store (s128) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GFX7-NEXT:   [[C2:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 16
   ; GFX7-NEXT:   [[PTR_ADD:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
-  ; GFX7-NEXT:   G_STORE [[UV1]](s128), [[PTR_ADD]](p1) :: (store (s128) into `ptr addrspace(1) undef` + 16, align 8, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV1]](s128), [[PTR_ADD]](p1) :: (store (s128) into `ptr addrspace(1) poison` + 16, align 8, addrspace 1)
   ; GFX7-NEXT:   [[C3:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 32
   ; GFX7-NEXT:   [[PTR_ADD1:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C3]](s64)
-  ; GFX7-NEXT:   G_STORE [[UV2]](s128), [[PTR_ADD1]](p1) :: (store (s128) into `ptr addrspace(1) undef` + 32, align 8, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV2]](s128), [[PTR_ADD1]](p1) :: (store (s128) into `ptr addrspace(1) poison` + 32, align 8, addrspace 1)
   ; GFX7-NEXT:   [[C4:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 48
   ; GFX7-NEXT:   [[PTR_ADD2:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C4]](s64)
-  ; GFX7-NEXT:   G_STORE [[UV3]](s128), [[PTR_ADD2]](p1) :: (store (s128) into `ptr addrspace(1) undef` + 48, align 8, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV3]](s128), [[PTR_ADD2]](p1) :: (store (s128) into `ptr addrspace(1) poison` + 48, align 8, addrspace 1)
   ; GFX7-NEXT:   S_ENDPGM 0
   ;
   ; GFX12-LABEL: name: s_buffer_load_i512_vgpr_offset
@@ -785,22 +785,22 @@ define amdgpu_ps void @s_buffer_load_i512_vgpr_offset(<4 x i32> inreg %rsrc, i32
   ; GFX12-NEXT:   [[MV:%[0-9]+]]:vgpr(s512) = G_MERGE_VALUES [[AMDGPU_BUFFER_LOAD]](s128), [[AMDGPU_BUFFER_LOAD1]](s128), [[AMDGPU_BUFFER_LOAD2]](s128), [[AMDGPU_BUFFER_LOAD3]](s128)
   ; GFX12-NEXT:   [[UV:%[0-9]+]]:vgpr(s128), [[UV1:%[0-9]+]]:vgpr(s128), [[UV2:%[0-9]+]]:vgpr(s128), [[UV3:%[0-9]+]]:vgpr(s128) = G_UNMERGE_VALUES [[MV]](s512)
   ; GFX12-NEXT:   [[COPY5:%[0-9]+]]:vgpr(p1) = COPY [[DEF]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV]](s128), [[COPY5]](p1) :: (store (s128) into `ptr addrspace(1) undef`, align 8, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV]](s128), [[COPY5]](p1) :: (store (s128) into `ptr addrspace(1) poison`, align 8, addrspace 1)
   ; GFX12-NEXT:   [[C2:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 16
   ; GFX12-NEXT:   [[PTR_ADD:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
   ; GFX12-NEXT:   [[COPY6:%[0-9]+]]:vgpr(p1) = COPY [[PTR_ADD]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV1]](s128), [[COPY6]](p1) :: (store (s128) into `ptr addrspace(1) undef` + 16, align 8, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV1]](s128), [[COPY6]](p1) :: (store (s128) into `ptr addrspace(1) poison` + 16, align 8, addrspace 1)
   ; GFX12-NEXT:   [[C3:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 32
   ; GFX12-NEXT:   [[PTR_ADD1:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C3]](s64)
   ; GFX12-NEXT:   [[COPY7:%[0-9]+]]:vgpr(p1) = COPY [[PTR_ADD1]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV2]](s128), [[COPY7]](p1) :: (store (s128) into `ptr addrspace(1) undef` + 32, align 8, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV2]](s128), [[COPY7]](p1) :: (store (s128) into `ptr addrspace(1) poison` + 32, align 8, addrspace 1)
   ; GFX12-NEXT:   [[C4:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 48
   ; GFX12-NEXT:   [[PTR_ADD2:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C4]](s64)
   ; GFX12-NEXT:   [[COPY8:%[0-9]+]]:vgpr(p1) = COPY [[PTR_ADD2]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV3]](s128), [[COPY8]](p1) :: (store (s128) into `ptr addrspace(1) undef` + 48, align 8, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV3]](s128), [[COPY8]](p1) :: (store (s128) into `ptr addrspace(1) poison` + 48, align 8, addrspace 1)
   ; GFX12-NEXT:   S_ENDPGM 0
   %val = call i512 @llvm.amdgcn.s.buffer.load.i512(<4 x i32> %rsrc, i32 %soffset, i32 0)
-  store i512 %val, ptr addrspace(1) undef
+  store i512 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -823,10 +823,10 @@ define amdgpu_ps void @s_buffer_load_v16i16_vgpr_offset(<4 x i32> inreg %rsrc, i
   ; GFX7-NEXT:   [[AMDGPU_BUFFER_LOAD1:%[0-9]+]]:vgpr(<8 x s16>) = G_AMDGPU_BUFFER_LOAD [[BUILD_VECTOR]](<4 x s32>), [[C1]](s32), [[COPY4]], [[C]], 16, 0, 0 :: (dereferenceable invariant load (s128), align 4)
   ; GFX7-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:vgpr(<16 x s16>) = G_CONCAT_VECTORS [[AMDGPU_BUFFER_LOAD]](<8 x s16>), [[AMDGPU_BUFFER_LOAD1]](<8 x s16>)
   ; GFX7-NEXT:   [[UV:%[0-9]+]]:vgpr(<8 x s16>), [[UV1:%[0-9]+]]:vgpr(<8 x s16>) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<16 x s16>)
-  ; GFX7-NEXT:   G_STORE [[UV]](<8 x s16>), [[DEF]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) undef`, align 32, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV]](<8 x s16>), [[DEF]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) poison`, align 32, addrspace 1)
   ; GFX7-NEXT:   [[C2:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 16
   ; GFX7-NEXT:   [[PTR_ADD:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
-  ; GFX7-NEXT:   G_STORE [[UV1]](<8 x s16>), [[PTR_ADD]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) undef` + 16, basealign 32, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV1]](<8 x s16>), [[PTR_ADD]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) poison` + 16, basealign 32, addrspace 1)
   ; GFX7-NEXT:   S_ENDPGM 0
   ;
   ; GFX12-LABEL: name: s_buffer_load_v16i16_vgpr_offset
@@ -847,14 +847,14 @@ define amdgpu_ps void @s_buffer_load_v16i16_vgpr_offset(<4 x i32> inreg %rsrc, i
   ; GFX12-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:vgpr(<16 x s16>) = G_CONCAT_VECTORS [[AMDGPU_BUFFER_LOAD]](<8 x s16>), [[AMDGPU_BUFFER_LOAD1]](<8 x s16>)
   ; GFX12-NEXT:   [[UV:%[0-9]+]]:vgpr(<8 x s16>), [[UV1:%[0-9]+]]:vgpr(<8 x s16>) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<16 x s16>)
   ; GFX12-NEXT:   [[COPY5:%[0-9]+]]:vgpr(p1) = COPY [[DEF]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV]](<8 x s16>), [[COPY5]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) undef`, align 32, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV]](<8 x s16>), [[COPY5]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) poison`, align 32, addrspace 1)
   ; GFX12-NEXT:   [[C2:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 16
   ; GFX12-NEXT:   [[PTR_ADD:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
   ; GFX12-NEXT:   [[COPY6:%[0-9]+]]:vgpr(p1) = COPY [[PTR_ADD]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV1]](<8 x s16>), [[COPY6]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) undef` + 16, basealign 32, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV1]](<8 x s16>), [[COPY6]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) poison` + 16, basealign 32, addrspace 1)
   ; GFX12-NEXT:   S_ENDPGM 0
   %val = call <16 x i16> @llvm.amdgcn.s.buffer.load.v16i16(<4 x i32> %rsrc, i32 %soffset, i32 0)
-  store <16 x i16> %val, ptr addrspace(1) undef
+  store <16 x i16> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -879,16 +879,16 @@ define amdgpu_ps void @s_buffer_load_v32i16_vgpr_offset(<4 x i32> inreg %rsrc, i
   ; GFX7-NEXT:   [[AMDGPU_BUFFER_LOAD3:%[0-9]+]]:vgpr(<8 x s16>) = G_AMDGPU_BUFFER_LOAD [[BUILD_VECTOR]](<4 x s32>), [[C1]](s32), [[COPY4]], [[C]], 48, 0, 0 :: (dereferenceable invariant load (s128) from unknown-address + 48, align 4)
   ; GFX7-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:vgpr(<32 x s16>) = G_CONCAT_VECTORS [[AMDGPU_BUFFER_LOAD]](<8 x s16>), [[AMDGPU_BUFFER_LOAD1]](<8 x s16>), [[AMDGPU_BUFFER_LOAD2]](<8 x s16>), [[AMDGPU_BUFFER_LOAD3]](<8 x s16>)
   ; GFX7-NEXT:   [[UV:%[0-9]+]]:vgpr(<8 x s16>), [[UV1:%[0-9]+]]:vgpr(<8 x s16>), [[UV2:%[0-9]+]]:vgpr(<8 x s16>), [[UV3:%[0-9]+]]:vgpr(<8 x s16>) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<32 x s16>)
-  ; GFX7-NEXT:   G_STORE [[UV]](<8 x s16>), [[DEF]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) undef`, align 64, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV]](<8 x s16>), [[DEF]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) poison`, align 64, addrspace 1)
   ; GFX7-NEXT:   [[C2:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 16
   ; GFX7-NEXT:   [[PTR_ADD:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
-  ; GFX7-NEXT:   G_STORE [[UV1]](<8 x s16>), [[PTR_ADD]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) undef` + 16, basealign 64, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV1]](<8 x s16>), [[PTR_ADD]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) poison` + 16, basealign 64, addrspace 1)
   ; GFX7-NEXT:   [[C3:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 32
   ; GFX7-NEXT:   [[PTR_ADD1:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C3]](s64)
-  ; GFX7-NEXT:   G_STORE [[UV2]](<8 x s16>), [[PTR_ADD1]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) undef` + 32, align 32, basealign 64, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV2]](<8 x s16>), [[PTR_ADD1]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) poison` + 32, align 32, basealign 64, addrspace 1)
   ; GFX7-NEXT:   [[C4:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 48
   ; GFX7-NEXT:   [[PTR_ADD2:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C4]](s64)
-  ; GFX7-NEXT:   G_STORE [[UV3]](<8 x s16>), [[PTR_ADD2]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) undef` + 48, basealign 64, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV3]](<8 x s16>), [[PTR_ADD2]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) poison` + 48, basealign 64, addrspace 1)
   ; GFX7-NEXT:   S_ENDPGM 0
   ;
   ; GFX12-LABEL: name: s_buffer_load_v32i16_vgpr_offset
@@ -911,22 +911,22 @@ define amdgpu_ps void @s_buffer_load_v32i16_vgpr_offset(<4 x i32> inreg %rsrc, i
   ; GFX12-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:vgpr(<32 x s16>) = G_CONCAT_VECTORS [[AMDGPU_BUFFER_LOAD]](<8 x s16>), [[AMDGPU_BUFFER_LOAD1]](<8 x s16>), [[AMDGPU_BUFFER_LOAD2]](<8 x s16>), [[AMDGPU_BUFFER_LOAD3]](<8 x s16>)
   ; GFX12-NEXT:   [[UV:%[0-9]+]]:vgpr(<8 x s16>), [[UV1:%[0-9]+]]:vgpr(<8 x s16>), [[UV2:%[0-9]+]]:vgpr(<8 x s16>), [[UV3:%[0-9]+]]:vgpr(<8 x s16>) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<32 x s16>)
   ; GFX12-NEXT:   [[COPY5:%[0-9]+]]:vgpr(p1) = COPY [[DEF]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV]](<8 x s16>), [[COPY5]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) undef`, align 64, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV]](<8 x s16>), [[COPY5]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) poison`, align 64, addrspace 1)
   ; GFX12-NEXT:   [[C2:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 16
   ; GFX12-NEXT:   [[PTR_ADD:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
   ; GFX12-NEXT:   [[COPY6:%[0-9]+]]:vgpr(p1) = COPY [[PTR_ADD]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV1]](<8 x s16>), [[COPY6]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) undef` + 16, basealign 64, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV1]](<8 x s16>), [[COPY6]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) poison` + 16, basealign 64, addrspace 1)
   ; GFX12-NEXT:   [[C3:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 32
   ; GFX12-NEXT:   [[PTR_ADD1:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C3]](s64)
   ; GFX12-NEXT:   [[COPY7:%[0-9]+]]:vgpr(p1) = COPY [[PTR_ADD1]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV2]](<8 x s16>), [[COPY7]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) undef` + 32, align 32, basealign 64, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV2]](<8 x s16>), [[COPY7]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) poison` + 32, align 32, basealign 64, addrspace 1)
   ; GFX12-NEXT:   [[C4:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 48
   ; GFX12-NEXT:   [[PTR_ADD2:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C4]](s64)
   ; GFX12-NEXT:   [[COPY8:%[0-9]+]]:vgpr(p1) = COPY [[PTR_ADD2]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV3]](<8 x s16>), [[COPY8]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) undef` + 48, basealign 64, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV3]](<8 x s16>), [[COPY8]](p1) :: (store (<8 x s16>) into `ptr addrspace(1) poison` + 48, basealign 64, addrspace 1)
   ; GFX12-NEXT:   S_ENDPGM 0
   %val = call <32 x i16> @llvm.amdgcn.s.buffer.load.v32i16(<4 x i32> %rsrc, i32 %soffset, i32 0)
-  store <32 x i16> %val, ptr addrspace(1) undef
+  store <32 x i16> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -949,10 +949,10 @@ define amdgpu_ps void @s_buffer_load_v4i64_vgpr_offset(<4 x i32> inreg %rsrc, i3
   ; GFX7-NEXT:   [[AMDGPU_BUFFER_LOAD1:%[0-9]+]]:vgpr(<2 x s64>) = G_AMDGPU_BUFFER_LOAD [[BUILD_VECTOR]](<4 x s32>), [[C1]](s32), [[COPY4]], [[C]], 16, 0, 0 :: (dereferenceable invariant load (s128), align 4)
   ; GFX7-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:vgpr(<4 x s64>) = G_CONCAT_VECTORS [[AMDGPU_BUFFER_LOAD]](<2 x s64>), [[AMDGPU_BUFFER_LOAD1]](<2 x s64>)
   ; GFX7-NEXT:   [[UV:%[0-9]+]]:vgpr(<2 x s64>), [[UV1:%[0-9]+]]:vgpr(<2 x s64>) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<4 x s64>)
-  ; GFX7-NEXT:   G_STORE [[UV]](<2 x s64>), [[DEF]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) undef`, align 32, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV]](<2 x s64>), [[DEF]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) poison`, align 32, addrspace 1)
   ; GFX7-NEXT:   [[C2:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 16
   ; GFX7-NEXT:   [[PTR_ADD:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
-  ; GFX7-NEXT:   G_STORE [[UV1]](<2 x s64>), [[PTR_ADD]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) undef` + 16, basealign 32, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV1]](<2 x s64>), [[PTR_ADD]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) poison` + 16, basealign 32, addrspace 1)
   ; GFX7-NEXT:   S_ENDPGM 0
   ;
   ; GFX12-LABEL: name: s_buffer_load_v4i64_vgpr_offset
@@ -973,14 +973,14 @@ define amdgpu_ps void @s_buffer_load_v4i64_vgpr_offset(<4 x i32> inreg %rsrc, i3
   ; GFX12-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:vgpr(<4 x s64>) = G_CONCAT_VECTORS [[AMDGPU_BUFFER_LOAD]](<2 x s64>), [[AMDGPU_BUFFER_LOAD1]](<2 x s64>)
   ; GFX12-NEXT:   [[UV:%[0-9]+]]:vgpr(<2 x s64>), [[UV1:%[0-9]+]]:vgpr(<2 x s64>) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<4 x s64>)
   ; GFX12-NEXT:   [[COPY5:%[0-9]+]]:vgpr(p1) = COPY [[DEF]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV]](<2 x s64>), [[COPY5]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) undef`, align 32, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV]](<2 x s64>), [[COPY5]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) poison`, align 32, addrspace 1)
   ; GFX12-NEXT:   [[C2:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 16
   ; GFX12-NEXT:   [[PTR_ADD:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
   ; GFX12-NEXT:   [[COPY6:%[0-9]+]]:vgpr(p1) = COPY [[PTR_ADD]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV1]](<2 x s64>), [[COPY6]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) undef` + 16, basealign 32, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV1]](<2 x s64>), [[COPY6]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) poison` + 16, basealign 32, addrspace 1)
   ; GFX12-NEXT:   S_ENDPGM 0
   %val = call <4 x i64> @llvm.amdgcn.s.buffer.load.v4i64(<4 x i32> %rsrc, i32 %soffset, i32 0)
-  store <4 x i64> %val, ptr addrspace(1) undef
+  store <4 x i64> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -1005,16 +1005,16 @@ define amdgpu_ps void @s_buffer_load_v8i64_vgpr_offset(<4 x i32> inreg %rsrc, i3
   ; GFX7-NEXT:   [[AMDGPU_BUFFER_LOAD3:%[0-9]+]]:vgpr(<2 x s64>) = G_AMDGPU_BUFFER_LOAD [[BUILD_VECTOR]](<4 x s32>), [[C1]](s32), [[COPY4]], [[C]], 48, 0, 0 :: (dereferenceable invariant load (s128) from unknown-address + 48, align 4)
   ; GFX7-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:vgpr(<8 x s64>) = G_CONCAT_VECTORS [[AMDGPU_BUFFER_LOAD]](<2 x s64>), [[AMDGPU_BUFFER_LOAD1]](<2 x s64>), [[AMDGPU_BUFFER_LOAD2]](<2 x s64>), [[AMDGPU_BUFFER_LOAD3]](<2 x s64>)
   ; GFX7-NEXT:   [[UV:%[0-9]+]]:vgpr(<2 x s64>), [[UV1:%[0-9]+]]:vgpr(<2 x s64>), [[UV2:%[0-9]+]]:vgpr(<2 x s64>), [[UV3:%[0-9]+]]:vgpr(<2 x s64>) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<8 x s64>)
-  ; GFX7-NEXT:   G_STORE [[UV]](<2 x s64>), [[DEF]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) undef`, align 64, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV]](<2 x s64>), [[DEF]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) poison`, align 64, addrspace 1)
   ; GFX7-NEXT:   [[C2:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 16
   ; GFX7-NEXT:   [[PTR_ADD:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
-  ; GFX7-NEXT:   G_STORE [[UV1]](<2 x s64>), [[PTR_ADD]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) undef` + 16, basealign 64, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV1]](<2 x s64>), [[PTR_ADD]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) poison` + 16, basealign 64, addrspace 1)
   ; GFX7-NEXT:   [[C3:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 32
   ; GFX7-NEXT:   [[PTR_ADD1:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C3]](s64)
-  ; GFX7-NEXT:   G_STORE [[UV2]](<2 x s64>), [[PTR_ADD1]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) undef` + 32, align 32, basealign 64, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV2]](<2 x s64>), [[PTR_ADD1]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) poison` + 32, align 32, basealign 64, addrspace 1)
   ; GFX7-NEXT:   [[C4:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 48
   ; GFX7-NEXT:   [[PTR_ADD2:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C4]](s64)
-  ; GFX7-NEXT:   G_STORE [[UV3]](<2 x s64>), [[PTR_ADD2]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) undef` + 48, basealign 64, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV3]](<2 x s64>), [[PTR_ADD2]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) poison` + 48, basealign 64, addrspace 1)
   ; GFX7-NEXT:   S_ENDPGM 0
   ;
   ; GFX12-LABEL: name: s_buffer_load_v8i64_vgpr_offset
@@ -1037,22 +1037,22 @@ define amdgpu_ps void @s_buffer_load_v8i64_vgpr_offset(<4 x i32> inreg %rsrc, i3
   ; GFX12-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:vgpr(<8 x s64>) = G_CONCAT_VECTORS [[AMDGPU_BUFFER_LOAD]](<2 x s64>), [[AMDGPU_BUFFER_LOAD1]](<2 x s64>), [[AMDGPU_BUFFER_LOAD2]](<2 x s64>), [[AMDGPU_BUFFER_LOAD3]](<2 x s64>)
   ; GFX12-NEXT:   [[UV:%[0-9]+]]:vgpr(<2 x s64>), [[UV1:%[0-9]+]]:vgpr(<2 x s64>), [[UV2:%[0-9]+]]:vgpr(<2 x s64>), [[UV3:%[0-9]+]]:vgpr(<2 x s64>) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<8 x s64>)
   ; GFX12-NEXT:   [[COPY5:%[0-9]+]]:vgpr(p1) = COPY [[DEF]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV]](<2 x s64>), [[COPY5]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) undef`, align 64, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV]](<2 x s64>), [[COPY5]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) poison`, align 64, addrspace 1)
   ; GFX12-NEXT:   [[C2:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 16
   ; GFX12-NEXT:   [[PTR_ADD:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
   ; GFX12-NEXT:   [[COPY6:%[0-9]+]]:vgpr(p1) = COPY [[PTR_ADD]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV1]](<2 x s64>), [[COPY6]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) undef` + 16, basealign 64, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV1]](<2 x s64>), [[COPY6]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) poison` + 16, basealign 64, addrspace 1)
   ; GFX12-NEXT:   [[C3:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 32
   ; GFX12-NEXT:   [[PTR_ADD1:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C3]](s64)
   ; GFX12-NEXT:   [[COPY7:%[0-9]+]]:vgpr(p1) = COPY [[PTR_ADD1]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV2]](<2 x s64>), [[COPY7]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) undef` + 32, align 32, basealign 64, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV2]](<2 x s64>), [[COPY7]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) poison` + 32, align 32, basealign 64, addrspace 1)
   ; GFX12-NEXT:   [[C4:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 48
   ; GFX12-NEXT:   [[PTR_ADD2:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C4]](s64)
   ; GFX12-NEXT:   [[COPY8:%[0-9]+]]:vgpr(p1) = COPY [[PTR_ADD2]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV3]](<2 x s64>), [[COPY8]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) undef` + 48, basealign 64, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV3]](<2 x s64>), [[COPY8]](p1) :: (store (<2 x s64>) into `ptr addrspace(1) poison` + 48, basealign 64, addrspace 1)
   ; GFX12-NEXT:   S_ENDPGM 0
   %val = call <8 x i64> @llvm.amdgcn.s.buffer.load.v8i64(<4 x i32> %rsrc, i32 %soffset, i32 0)
-  store <8 x i64> %val, ptr addrspace(1) undef
+  store <8 x i64> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -1075,10 +1075,10 @@ define amdgpu_ps void @s_buffer_load_v4p1_vgpr_offset(<4 x i32> inreg %rsrc, i32
   ; GFX7-NEXT:   [[AMDGPU_BUFFER_LOAD1:%[0-9]+]]:vgpr(<2 x p1>) = G_AMDGPU_BUFFER_LOAD [[BUILD_VECTOR]](<4 x s32>), [[C1]](s32), [[COPY4]], [[C]], 16, 0, 0 :: (dereferenceable invariant load (s128), align 4)
   ; GFX7-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:vgpr(<4 x p1>) = G_CONCAT_VECTORS [[AMDGPU_BUFFER_LOAD]](<2 x p1>), [[AMDGPU_BUFFER_LOAD1]](<2 x p1>)
   ; GFX7-NEXT:   [[UV:%[0-9]+]]:vgpr(<2 x p1>), [[UV1:%[0-9]+]]:vgpr(<2 x p1>) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<4 x p1>)
-  ; GFX7-NEXT:   G_STORE [[UV]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef`, align 32, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison`, align 32, addrspace 1)
   ; GFX7-NEXT:   [[C2:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 16
   ; GFX7-NEXT:   [[PTR_ADD:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
-  ; GFX7-NEXT:   G_STORE [[UV1]](<2 x p1>), [[PTR_ADD]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef` + 16, basealign 32, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV1]](<2 x p1>), [[PTR_ADD]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison` + 16, basealign 32, addrspace 1)
   ; GFX7-NEXT:   S_ENDPGM 0
   ;
   ; GFX12-LABEL: name: s_buffer_load_v4p1_vgpr_offset
@@ -1099,14 +1099,14 @@ define amdgpu_ps void @s_buffer_load_v4p1_vgpr_offset(<4 x i32> inreg %rsrc, i32
   ; GFX12-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:vgpr(<4 x p1>) = G_CONCAT_VECTORS [[AMDGPU_BUFFER_LOAD]](<2 x p1>), [[AMDGPU_BUFFER_LOAD1]](<2 x p1>)
   ; GFX12-NEXT:   [[UV:%[0-9]+]]:vgpr(<2 x p1>), [[UV1:%[0-9]+]]:vgpr(<2 x p1>) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<4 x p1>)
   ; GFX12-NEXT:   [[COPY5:%[0-9]+]]:vgpr(p1) = COPY [[DEF]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV]](<2 x p1>), [[COPY5]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef`, align 32, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV]](<2 x p1>), [[COPY5]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison`, align 32, addrspace 1)
   ; GFX12-NEXT:   [[C2:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 16
   ; GFX12-NEXT:   [[PTR_ADD:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
   ; GFX12-NEXT:   [[COPY6:%[0-9]+]]:vgpr(p1) = COPY [[PTR_ADD]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV1]](<2 x p1>), [[COPY6]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef` + 16, basealign 32, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV1]](<2 x p1>), [[COPY6]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison` + 16, basealign 32, addrspace 1)
   ; GFX12-NEXT:   S_ENDPGM 0
   %val = call <4 x ptr addrspace(1)> @llvm.amdgcn.s.buffer.load.v4p1(<4 x i32> %rsrc, i32 %soffset, i32 0)
-  store <4 x ptr addrspace(1)> %val, ptr addrspace(1) undef
+  store <4 x ptr addrspace(1)> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -1131,16 +1131,16 @@ define amdgpu_ps void @s_buffer_load_v8p1_vgpr_offset(<4 x i32> inreg %rsrc, i32
   ; GFX7-NEXT:   [[AMDGPU_BUFFER_LOAD3:%[0-9]+]]:vgpr(<2 x p1>) = G_AMDGPU_BUFFER_LOAD [[BUILD_VECTOR]](<4 x s32>), [[C1]](s32), [[COPY4]], [[C]], 48, 0, 0 :: (dereferenceable invariant load (s128) from unknown-address + 48, align 4)
   ; GFX7-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:vgpr(<8 x p1>) = G_CONCAT_VECTORS [[AMDGPU_BUFFER_LOAD]](<2 x p1>), [[AMDGPU_BUFFER_LOAD1]](<2 x p1>), [[AMDGPU_BUFFER_LOAD2]](<2 x p1>), [[AMDGPU_BUFFER_LOAD3]](<2 x p1>)
   ; GFX7-NEXT:   [[UV:%[0-9]+]]:vgpr(<2 x p1>), [[UV1:%[0-9]+]]:vgpr(<2 x p1>), [[UV2:%[0-9]+]]:vgpr(<2 x p1>), [[UV3:%[0-9]+]]:vgpr(<2 x p1>) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<8 x p1>)
-  ; GFX7-NEXT:   G_STORE [[UV]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef`, align 64, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV]](<2 x p1>), [[DEF]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison`, align 64, addrspace 1)
   ; GFX7-NEXT:   [[C2:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 16
   ; GFX7-NEXT:   [[PTR_ADD:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
-  ; GFX7-NEXT:   G_STORE [[UV1]](<2 x p1>), [[PTR_ADD]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef` + 16, basealign 64, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV1]](<2 x p1>), [[PTR_ADD]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison` + 16, basealign 64, addrspace 1)
   ; GFX7-NEXT:   [[C3:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 32
   ; GFX7-NEXT:   [[PTR_ADD1:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C3]](s64)
-  ; GFX7-NEXT:   G_STORE [[UV2]](<2 x p1>), [[PTR_ADD1]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef` + 32, align 32, basealign 64, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV2]](<2 x p1>), [[PTR_ADD1]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison` + 32, align 32, basealign 64, addrspace 1)
   ; GFX7-NEXT:   [[C4:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 48
   ; GFX7-NEXT:   [[PTR_ADD2:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C4]](s64)
-  ; GFX7-NEXT:   G_STORE [[UV3]](<2 x p1>), [[PTR_ADD2]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef` + 48, basealign 64, addrspace 1)
+  ; GFX7-NEXT:   G_STORE [[UV3]](<2 x p1>), [[PTR_ADD2]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison` + 48, basealign 64, addrspace 1)
   ; GFX7-NEXT:   S_ENDPGM 0
   ;
   ; GFX12-LABEL: name: s_buffer_load_v8p1_vgpr_offset
@@ -1163,22 +1163,22 @@ define amdgpu_ps void @s_buffer_load_v8p1_vgpr_offset(<4 x i32> inreg %rsrc, i32
   ; GFX12-NEXT:   [[CONCAT_VECTORS:%[0-9]+]]:vgpr(<8 x p1>) = G_CONCAT_VECTORS [[AMDGPU_BUFFER_LOAD]](<2 x p1>), [[AMDGPU_BUFFER_LOAD1]](<2 x p1>), [[AMDGPU_BUFFER_LOAD2]](<2 x p1>), [[AMDGPU_BUFFER_LOAD3]](<2 x p1>)
   ; GFX12-NEXT:   [[UV:%[0-9]+]]:vgpr(<2 x p1>), [[UV1:%[0-9]+]]:vgpr(<2 x p1>), [[UV2:%[0-9]+]]:vgpr(<2 x p1>), [[UV3:%[0-9]+]]:vgpr(<2 x p1>) = G_UNMERGE_VALUES [[CONCAT_VECTORS]](<8 x p1>)
   ; GFX12-NEXT:   [[COPY5:%[0-9]+]]:vgpr(p1) = COPY [[DEF]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV]](<2 x p1>), [[COPY5]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef`, align 64, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV]](<2 x p1>), [[COPY5]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison`, align 64, addrspace 1)
   ; GFX12-NEXT:   [[C2:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 16
   ; GFX12-NEXT:   [[PTR_ADD:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C2]](s64)
   ; GFX12-NEXT:   [[COPY6:%[0-9]+]]:vgpr(p1) = COPY [[PTR_ADD]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV1]](<2 x p1>), [[COPY6]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef` + 16, basealign 64, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV1]](<2 x p1>), [[COPY6]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison` + 16, basealign 64, addrspace 1)
   ; GFX12-NEXT:   [[C3:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 32
   ; GFX12-NEXT:   [[PTR_ADD1:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C3]](s64)
   ; GFX12-NEXT:   [[COPY7:%[0-9]+]]:vgpr(p1) = COPY [[PTR_ADD1]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV2]](<2 x p1>), [[COPY7]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef` + 32, align 32, basealign 64, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV2]](<2 x p1>), [[COPY7]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison` + 32, align 32, basealign 64, addrspace 1)
   ; GFX12-NEXT:   [[C4:%[0-9]+]]:sgpr(s64) = G_CONSTANT i64 48
   ; GFX12-NEXT:   [[PTR_ADD2:%[0-9]+]]:sgpr(p1) = G_PTR_ADD [[DEF]], [[C4]](s64)
   ; GFX12-NEXT:   [[COPY8:%[0-9]+]]:vgpr(p1) = COPY [[PTR_ADD2]](p1)
-  ; GFX12-NEXT:   G_STORE [[UV3]](<2 x p1>), [[COPY8]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) undef` + 48, basealign 64, addrspace 1)
+  ; GFX12-NEXT:   G_STORE [[UV3]](<2 x p1>), [[COPY8]](p1) :: (store (<2 x p1>) into `ptr addrspace(1) poison` + 48, basealign 64, addrspace 1)
   ; GFX12-NEXT:   S_ENDPGM 0
   %val = call <8 x ptr addrspace(1)> @llvm.amdgcn.s.buffer.load.v8p1(<4 x i32> %rsrc, i32 %soffset, i32 0)
-  store <8 x ptr addrspace(1)> %val, ptr addrspace(1) undef
+  store <8 x ptr addrspace(1)> %val, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/smrd.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/smrd.ll
@@ -12,7 +12,7 @@ define amdgpu_kernel void @smrd0(ptr addrspace(4) %ptr) {
 entry:
   %0 = getelementptr i32, ptr addrspace(4) %ptr, i64 1
   %1 = load i32, ptr addrspace(4) %0
-  store i32 %1, ptr addrspace(1) undef
+  store i32 %1, ptr addrspace(1) poison
   ret void
 }
 
@@ -24,7 +24,7 @@ define amdgpu_kernel void @smrd1(ptr addrspace(4) %ptr) {
 entry:
   %0 = getelementptr i32, ptr addrspace(4) %ptr, i64 255
   %1 = load i32, ptr addrspace(4) %0
-  store i32 %1, ptr addrspace(1) undef
+  store i32 %1, ptr addrspace(1) poison
   ret void
 }
 
@@ -39,7 +39,7 @@ define amdgpu_kernel void @smrd2(ptr addrspace(4) %ptr) {
 entry:
   %0 = getelementptr i32, ptr addrspace(4) %ptr, i64 256
   %1 = load i32, ptr addrspace(4) %0
-  store i32 %1, ptr addrspace(1) undef
+  store i32 %1, ptr addrspace(1) poison
   ret void
 }
 
@@ -54,7 +54,7 @@ define amdgpu_kernel void @smrd3(ptr addrspace(4) %ptr) {
 entry:
   %0 = getelementptr i32, ptr addrspace(4) %ptr, i64 4294967296 ; 2 ^ 32
   %1 = load i32, ptr addrspace(4) %0
-  store i32 %1, ptr addrspace(1) undef
+  store i32 %1, ptr addrspace(1) poison
   ret void
 }
 
@@ -70,7 +70,7 @@ define amdgpu_kernel void @smrd4(ptr addrspace(4) %ptr) {
 entry:
   %0 = getelementptr i32, ptr addrspace(4) %ptr, i64 262143
   %1 = load i32, ptr addrspace(4) %0
-  store i32 %1, ptr addrspace(1) undef
+  store i32 %1, ptr addrspace(1) poison
   ret void
 }
 
@@ -84,7 +84,7 @@ define amdgpu_kernel void @smrd5(ptr addrspace(4) %ptr) {
 entry:
   %0 = getelementptr i32, ptr addrspace(4) %ptr, i64 262144
   %1 = load i32, ptr addrspace(4) %0
-  store i32 %1, ptr addrspace(1) undef
+  store i32 %1, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/abi-attribute-hints-undefined-behavior.ll
+++ b/llvm/test/CodeGen/AMDGPU/abi-attribute-hints-undefined-behavior.ll
@@ -340,7 +340,7 @@ define void @is_shared_requires_queue_ptr(ptr %ptr) #0 {
 ; FIXEDABI-NEXT:    s_setpc_b64 s[30:31]
   %is.shared = call i1 @llvm.amdgcn.is.shared(ptr %ptr)
   %zext = zext i1 %is.shared to i32
-  store volatile i32 %zext, ptr addrspace(1) undef
+  store volatile i32 %zext, ptr addrspace(1) poison
   ret void
 }
 
@@ -358,7 +358,7 @@ define void @is_private_requires_queue_ptr(ptr %ptr) #0 {
 ; FIXEDABI-NEXT:    s_setpc_b64 s[30:31]
   %is.private = call i1 @llvm.amdgcn.is.private(ptr %ptr)
   %zext = zext i1 %is.private to i32
-  store volatile i32 %zext, ptr addrspace(1) undef
+  store volatile i32 %zext, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/adjust-writemask-invalid-copy.ll
+++ b/llvm/test/CodeGen/AMDGPU/adjust-writemask-invalid-copy.ll
@@ -12,7 +12,7 @@ main_body:
   %tmp2 = shufflevector <2 x i32> %tmp1, <2 x i32> poison, <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>
   %tmp3 = bitcast <4 x i32> %tmp2 to <4 x float>
   %tmp4 = extractelement <4 x float> %tmp3, i32 0
-  store volatile float %tmp4, ptr addrspace(1) undef
+  store volatile float %tmp4, ptr addrspace(1) poison
   ret void
 }
 
@@ -28,7 +28,7 @@ main_body:
   %tmp2 = shufflevector <2 x i32> %tmp1, <2 x i32> poison, <4 x i32> <i32 1, i32 0, i32 poison, i32 poison>
   %tmp3 = bitcast <4 x i32> %tmp2 to <4 x float>
   %tmp4 = extractelement <4 x float> %tmp3, i32 1
-  store volatile float %tmp4, ptr addrspace(1) undef
+  store volatile float %tmp4, ptr addrspace(1) poison
   ret void
 }
 
@@ -44,7 +44,7 @@ main_body:
   %tmp2 = shufflevector <2 x i32> %tmp1, <2 x i32> poison, <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>
   %tmp3 = bitcast <4 x i32> %tmp2 to <4 x float>
   %tmp4 = extractelement <4 x float> %tmp3, i32 0
-  store volatile float %tmp4, ptr addrspace(1) undef
+  store volatile float %tmp4, ptr addrspace(1) poison
   ret void
 }
 
@@ -60,7 +60,7 @@ main_body:
   %tmp2 = shufflevector <2 x i32> %tmp1, <2 x i32> poison, <4 x i32> <i32 1, i32 0, i32 poison, i32 poison>
   %tmp3 = bitcast <4 x i32> %tmp2 to <4 x float>
   %tmp4 = extractelement <4 x float> %tmp3, i32 1
-  store volatile float %tmp4, ptr addrspace(1) undef
+  store volatile float %tmp4, ptr addrspace(1) poison
   ret void
 }
 
@@ -71,7 +71,7 @@ main_body:
   %tmp2 = shufflevector <4 x i32> %tmp1, <4 x i32> poison, <4 x i32> <i32 1, i32 poison, i32 poison, i32 poison>
   %tmp3 = bitcast <4 x i32> %tmp2 to <4 x float>
   %tmp4 = extractelement <4 x float> %tmp3, i32 0
-  store volatile float %tmp4, ptr addrspace(1) undef
+  store volatile float %tmp4, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/agpr-csr.ll
+++ b/llvm/test/CodeGen/AMDGPU/agpr-csr.ll
@@ -94,7 +94,7 @@ define amdgpu_kernel void @test_call_empty() #0 {
 bb:
   %reg = call <32 x float> asm sideeffect "; def $0", "=a"()
   call void @func_empty()
-  store volatile <32 x float> %reg, ptr addrspace(1) undef
+  store volatile <32 x float> %reg, ptr addrspace(1) poison
   ret void
 }
 
@@ -116,7 +116,7 @@ define amdgpu_kernel void @test_call_areg4() #0 {
 bb:
   %reg = call <32 x float> asm sideeffect "; def $0", "=a"()
   call void @func_areg_4()
-  store volatile <32 x float> %reg, ptr addrspace(1) undef
+  store volatile <32 x float> %reg, ptr addrspace(1) poison
   ret void
 }
 
@@ -138,7 +138,7 @@ define amdgpu_kernel void @test_call_areg32() #0 {
 bb:
   %reg = call <32 x float> asm sideeffect "; def $0", "=a"()
   call void @func_areg_32()
-  store volatile <32 x float> %reg, ptr addrspace(1) undef
+  store volatile <32 x float> %reg, ptr addrspace(1) poison
   ret void
 }
 
@@ -159,7 +159,7 @@ define amdgpu_kernel void @test_call_areg64() #0 {
 bb:
   %reg = call <32 x float> asm sideeffect "; def $0", "=a"()
   call void @func_areg_64()
-  store volatile <32 x float> %reg, ptr addrspace(1) undef
+  store volatile <32 x float> %reg, ptr addrspace(1) poison
   ret void
 }
 
@@ -181,7 +181,7 @@ define amdgpu_kernel void @test_call_areg31_63() #0 {
 bb:
   %reg = call <32 x float> asm sideeffect "; def $0", "=a"()
   call void @func_areg_31_63()
-  store volatile <32 x float> %reg, ptr addrspace(1) undef
+  store volatile <32 x float> %reg, ptr addrspace(1) poison
   ret void
 }
 
@@ -203,7 +203,7 @@ define amdgpu_kernel void @test_call_unknown() #0 {
 bb:
   %reg = call <32 x float> asm sideeffect "; def $0", "=a"()
   call void @func_unknown()
-  store volatile <32 x float> %reg, ptr addrspace(1) undef
+  store volatile <32 x float> %reg, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/amdgcn-ieee.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn-ieee.ll
@@ -8,10 +8,10 @@
 ; GCN: v_min_f32_e32 [[MIN:v[0-9]+]], [[QUIET0]], [[QUIET1]]
 ; GCN-NOT: v_mul_f32
 define amdgpu_kernel void @kernel_ieee_mode_default() #0 {
-  %val0 = load volatile float, ptr addrspace(1) undef
-  %val1 = load volatile float, ptr addrspace(1) undef
+  %val0 = load volatile float, ptr addrspace(1) poison
+  %val1 = load volatile float, ptr addrspace(1) poison
   %min = call float @llvm.minnum.f32(float %val0, float %val1)
-  store volatile float %min, ptr addrspace(1) undef
+  store volatile float %min, ptr addrspace(1) poison
   ret void
 }
 
@@ -23,10 +23,10 @@ define amdgpu_kernel void @kernel_ieee_mode_default() #0 {
 ; GCN: v_min_f32_e32 [[MIN:v[0-9]+]], [[QUIET0]], [[QUIET1]]
 ; GCN-NOT: v_mul_f32
 define amdgpu_kernel void @kernel_ieee_mode_on() #1 {
-  %val0 = load volatile float, ptr addrspace(1) undef
-  %val1 = load volatile float, ptr addrspace(1) undef
+  %val0 = load volatile float, ptr addrspace(1) poison
+  %val1 = load volatile float, ptr addrspace(1) poison
   %min = call float @llvm.minnum.f32(float %val0, float %val1)
-  store volatile float %min, ptr addrspace(1) undef
+  store volatile float %min, ptr addrspace(1) poison
   ret void
 }
 
@@ -38,10 +38,10 @@ define amdgpu_kernel void @kernel_ieee_mode_on() #1 {
 ; GCN: v_min_f32_e32 [[MIN:v[0-9]+]], [[VAL0]], [[VAL1]]
 ; GCN-NOT: v_mul_f32
 define amdgpu_kernel void @kernel_ieee_mode_off() #2 {
-  %val0 = load volatile float, ptr addrspace(1) undef
-  %val1 = load volatile float, ptr addrspace(1) undef
+  %val0 = load volatile float, ptr addrspace(1) poison
+  %val1 = load volatile float, ptr addrspace(1) poison
   %min = call float @llvm.minnum.f32(float %val0, float %val1)
-  store volatile float %min, ptr addrspace(1) undef
+  store volatile float %min, ptr addrspace(1) poison
   ret void
 }
 
@@ -53,10 +53,10 @@ define amdgpu_kernel void @kernel_ieee_mode_off() #2 {
 ; GCN: v_min_f32_e32 [[MIN:v[0-9]+]], [[QUIET0]], [[QUIET1]]
 ; GCN-NOT: v_mul_f32
 define void @func_ieee_mode_default() #0 {
-  %val0 = load volatile float, ptr addrspace(1) undef
-  %val1 = load volatile float, ptr addrspace(1) undef
+  %val0 = load volatile float, ptr addrspace(1) poison
+  %val1 = load volatile float, ptr addrspace(1) poison
   %min = call float @llvm.minnum.f32(float %val0, float %val1)
-  store volatile float %min, ptr addrspace(1) undef
+  store volatile float %min, ptr addrspace(1) poison
   ret void
 }
 
@@ -68,10 +68,10 @@ define void @func_ieee_mode_default() #0 {
 ; GCN: v_min_f32_e32 [[MIN:v[0-9]+]], [[QUIET0]], [[QUIET1]]
 ; GCN-NOT: v_mul_f32
 define void @func_ieee_mode_on() #1 {
-  %val0 = load volatile float, ptr addrspace(1) undef
-  %val1 = load volatile float, ptr addrspace(1) undef
+  %val0 = load volatile float, ptr addrspace(1) poison
+  %val1 = load volatile float, ptr addrspace(1) poison
   %min = call float @llvm.minnum.f32(float %val0, float %val1)
-  store volatile float %min, ptr addrspace(1) undef
+  store volatile float %min, ptr addrspace(1) poison
   ret void
 }
 
@@ -83,10 +83,10 @@ define void @func_ieee_mode_on() #1 {
 ; GCN: v_min_f32_e32 [[MIN:v[0-9]+]], [[VAL0]], [[VAL1]]
 ; GCN-NOT: v_mul_f32
 define void @func_ieee_mode_off() #2 {
-  %val0 = load volatile float, ptr addrspace(1) undef
-  %val1 = load volatile float, ptr addrspace(1) undef
+  %val0 = load volatile float, ptr addrspace(1) poison
+  %val1 = load volatile float, ptr addrspace(1) poison
   %min = call float @llvm.minnum.f32(float %val0, float %val1)
-  store volatile float %min, ptr addrspace(1) undef
+  store volatile float %min, ptr addrspace(1) poison
   ret void
 }
 
@@ -98,10 +98,10 @@ define void @func_ieee_mode_off() #2 {
 ; GCN: v_min_f32_e32 [[MIN:v[0-9]+]], [[QUIET0]], [[QUIET1]]
 ; GCN-NOT: v_mul_f32
 define amdgpu_cs void @cs_ieee_mode_default() #0 {
-  %val0 = load volatile float, ptr addrspace(1) undef
-  %val1 = load volatile float, ptr addrspace(1) undef
+  %val0 = load volatile float, ptr addrspace(1) poison
+  %val1 = load volatile float, ptr addrspace(1) poison
   %min = call float @llvm.minnum.f32(float %val0, float %val1)
-  store volatile float %min, ptr addrspace(1) undef
+  store volatile float %min, ptr addrspace(1) poison
   ret void
 }
 
@@ -113,10 +113,10 @@ define amdgpu_cs void @cs_ieee_mode_default() #0 {
 ; GCN: v_min_f32_e32 [[MIN:v[0-9]+]], [[QUIET0]], [[QUIET1]]
 ; GCN-NOT: v_mul_f32
 define amdgpu_cs void @cs_ieee_mode_on() #1 {
-  %val0 = load volatile float, ptr addrspace(1) undef
-  %val1 = load volatile float, ptr addrspace(1) undef
+  %val0 = load volatile float, ptr addrspace(1) poison
+  %val1 = load volatile float, ptr addrspace(1) poison
   %min = call float @llvm.minnum.f32(float %val0, float %val1)
-  store volatile float %min, ptr addrspace(1) undef
+  store volatile float %min, ptr addrspace(1) poison
   ret void
 }
 
@@ -128,10 +128,10 @@ define amdgpu_cs void @cs_ieee_mode_on() #1 {
 ; GCN: v_min_f32_e32 [[MIN:v[0-9]+]], [[VAL0]], [[VAL1]]
 ; GCN-NOT: v_mul_f32
 define amdgpu_cs void @cs_ieee_mode_off() #2 {
-  %val0 = load volatile float, ptr addrspace(1) undef
-  %val1 = load volatile float, ptr addrspace(1) undef
+  %val0 = load volatile float, ptr addrspace(1) poison
+  %val1 = load volatile float, ptr addrspace(1) poison
   %min = call float @llvm.minnum.f32(float %val0, float %val1)
-  store volatile float %min, ptr addrspace(1) undef
+  store volatile float %min, ptr addrspace(1) poison
   ret void
 }
 
@@ -143,10 +143,10 @@ define amdgpu_cs void @cs_ieee_mode_off() #2 {
 ; GCN: v_min_f32_e32 [[MIN:v[0-9]+]], [[VAL0]], [[VAL1]]
 ; GCN-NOT: v_mul_f32
 define amdgpu_ps void @ps_ieee_mode_default() #0 {
-  %val0 = load volatile float, ptr addrspace(1) undef
-  %val1 = load volatile float, ptr addrspace(1) undef
+  %val0 = load volatile float, ptr addrspace(1) poison
+  %val1 = load volatile float, ptr addrspace(1) poison
   %min = call float @llvm.minnum.f32(float %val0, float %val1)
-  store volatile float %min, ptr addrspace(1) undef
+  store volatile float %min, ptr addrspace(1) poison
   ret void
 }
 
@@ -158,10 +158,10 @@ define amdgpu_ps void @ps_ieee_mode_default() #0 {
 ; GCN: v_min_f32_e32 [[MIN:v[0-9]+]], [[QUIET0]], [[QUIET1]]
 ; GCN-NOT: v_mul_f32
 define amdgpu_ps void @ps_ieee_mode_on() #1 {
-  %val0 = load volatile float, ptr addrspace(1) undef
-  %val1 = load volatile float, ptr addrspace(1) undef
+  %val0 = load volatile float, ptr addrspace(1) poison
+  %val1 = load volatile float, ptr addrspace(1) poison
   %min = call float @llvm.minnum.f32(float %val0, float %val1)
-  store volatile float %min, ptr addrspace(1) undef
+  store volatile float %min, ptr addrspace(1) poison
   ret void
 }
 
@@ -173,10 +173,10 @@ define amdgpu_ps void @ps_ieee_mode_on() #1 {
 ; GCN: v_min_f32_e32 [[MIN:v[0-9]+]], [[VAL0]], [[VAL1]]
 ; GCN-NOT: v_mul_f32
 define amdgpu_ps void @ps_ieee_mode_off() #2 {
-  %val0 = load volatile float, ptr addrspace(1) undef
-  %val1 = load volatile float, ptr addrspace(1) undef
+  %val0 = load volatile float, ptr addrspace(1) poison
+  %val1 = load volatile float, ptr addrspace(1) poison
   %min = call float @llvm.minnum.f32(float %val0, float %val1)
-  store volatile float %min, ptr addrspace(1) undef
+  store volatile float %min, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-codegenprepare-fold-binop-select.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-codegenprepare-fold-binop-select.ll
@@ -387,7 +387,7 @@ define i32 @select_mul_rhs_const_i32(i1 %cond) {
 define amdgpu_kernel void @select_add_lhs_const_i16(i1 %cond) {
 ; IR-LABEL: @select_add_lhs_const_i16(
 ; IR-NEXT:    [[OP:%.*]] = select i1 [[COND:%.*]], i16 128, i16 131
-; IR-NEXT:    store i16 [[OP]], ptr addrspace(1) undef, align 2
+; IR-NEXT:    store i16 [[OP]], ptr addrspace(1) poison, align 2
 ; IR-NEXT:    ret void
 ;
 ; GCN-LABEL: select_add_lhs_const_i16:
@@ -402,7 +402,7 @@ define amdgpu_kernel void @select_add_lhs_const_i16(i1 %cond) {
 ; GCN-NEXT:    s_endpgm
   %select = select i1 %cond, i16 5, i16 8
   %op = add i16 %select, 123
-  store i16 %op, ptr addrspace(1) undef
+  store i16 %op, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-codegenprepare-i16-to-i32.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-codegenprepare-i16-to-i32.ll
@@ -5,7 +5,7 @@
 define amdgpu_kernel void @add_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @add_i3(
 ; SI-NEXT:    [[R:%.*]] = add i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @add_i3(
@@ -13,18 +13,18 @@ define amdgpu_kernel void @add_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = add nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = add i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @add_nsw_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @add_nsw_i3(
 ; SI-NEXT:    [[R:%.*]] = add nsw i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @add_nsw_i3(
@@ -32,18 +32,18 @@ define amdgpu_kernel void @add_nsw_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = add nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = add nsw i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @add_nuw_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @add_nuw_i3(
 ; SI-NEXT:    [[R:%.*]] = add nuw i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @add_nuw_i3(
@@ -51,18 +51,18 @@ define amdgpu_kernel void @add_nuw_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = add nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = add nuw i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @add_nuw_nsw_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @add_nuw_nsw_i3(
 ; SI-NEXT:    [[R:%.*]] = add nuw nsw i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @add_nuw_nsw_i3(
@@ -70,18 +70,18 @@ define amdgpu_kernel void @add_nuw_nsw_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = add nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = add nuw nsw i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @sub_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @sub_i3(
 ; SI-NEXT:    [[R:%.*]] = sub i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @sub_i3(
@@ -89,18 +89,18 @@ define amdgpu_kernel void @sub_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = sub nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = sub i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @sub_nsw_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @sub_nsw_i3(
 ; SI-NEXT:    [[R:%.*]] = sub nsw i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @sub_nsw_i3(
@@ -108,18 +108,18 @@ define amdgpu_kernel void @sub_nsw_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = sub nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = sub nsw i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @sub_nuw_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @sub_nuw_i3(
 ; SI-NEXT:    [[R:%.*]] = sub nuw i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @sub_nuw_i3(
@@ -127,18 +127,18 @@ define amdgpu_kernel void @sub_nuw_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = sub nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = sub nuw i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @sub_nuw_nsw_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @sub_nuw_nsw_i3(
 ; SI-NEXT:    [[R:%.*]] = sub nuw nsw i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @sub_nuw_nsw_i3(
@@ -146,18 +146,18 @@ define amdgpu_kernel void @sub_nuw_nsw_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = sub nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = sub nuw nsw i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @mul_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @mul_i3(
 ; SI-NEXT:    [[R:%.*]] = mul i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @mul_i3(
@@ -165,18 +165,18 @@ define amdgpu_kernel void @mul_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = mul nuw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = mul i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @mul_nsw_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @mul_nsw_i3(
 ; SI-NEXT:    [[R:%.*]] = mul nsw i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @mul_nsw_i3(
@@ -184,18 +184,18 @@ define amdgpu_kernel void @mul_nsw_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = mul nuw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = mul nsw i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @mul_nuw_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @mul_nuw_i3(
 ; SI-NEXT:    [[R:%.*]] = mul nuw i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @mul_nuw_i3(
@@ -203,18 +203,18 @@ define amdgpu_kernel void @mul_nuw_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = mul nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = mul nuw i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @mul_nuw_nsw_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @mul_nuw_nsw_i3(
 ; SI-NEXT:    [[R:%.*]] = mul nuw nsw i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @mul_nuw_nsw_i3(
@@ -222,18 +222,18 @@ define amdgpu_kernel void @mul_nuw_nsw_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = mul nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = mul nuw nsw i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @shl_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @shl_i3(
 ; SI-NEXT:    [[R:%.*]] = shl i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @shl_i3(
@@ -241,18 +241,18 @@ define amdgpu_kernel void @shl_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = shl nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = shl i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @shl_nsw_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @shl_nsw_i3(
 ; SI-NEXT:    [[R:%.*]] = shl nsw i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @shl_nsw_i3(
@@ -260,18 +260,18 @@ define amdgpu_kernel void @shl_nsw_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = shl nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = shl nsw i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @shl_nuw_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @shl_nuw_i3(
 ; SI-NEXT:    [[R:%.*]] = shl nuw i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @shl_nuw_i3(
@@ -279,18 +279,18 @@ define amdgpu_kernel void @shl_nuw_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = shl nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = shl nuw i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @shl_nuw_nsw_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @shl_nuw_nsw_i3(
 ; SI-NEXT:    [[R:%.*]] = shl nuw nsw i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @shl_nuw_nsw_i3(
@@ -298,18 +298,18 @@ define amdgpu_kernel void @shl_nuw_nsw_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = shl nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = shl nuw nsw i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @lshr_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @lshr_i3(
 ; SI-NEXT:    [[R:%.*]] = lshr i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @lshr_i3(
@@ -317,18 +317,18 @@ define amdgpu_kernel void @lshr_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = lshr i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = lshr i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @lshr_exact_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @lshr_exact_i3(
 ; SI-NEXT:    [[R:%.*]] = lshr exact i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @lshr_exact_i3(
@@ -336,18 +336,18 @@ define amdgpu_kernel void @lshr_exact_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = lshr exact i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = lshr exact i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @ashr_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @ashr_i3(
 ; SI-NEXT:    [[R:%.*]] = ashr i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @ashr_i3(
@@ -355,18 +355,18 @@ define amdgpu_kernel void @ashr_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = sext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = ashr i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = ashr i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @ashr_exact_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @ashr_exact_i3(
 ; SI-NEXT:    [[R:%.*]] = ashr exact i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @ashr_exact_i3(
@@ -374,18 +374,18 @@ define amdgpu_kernel void @ashr_exact_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = sext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = ashr exact i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = ashr exact i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @and_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @and_i3(
 ; SI-NEXT:    [[R:%.*]] = and i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @and_i3(
@@ -393,18 +393,18 @@ define amdgpu_kernel void @and_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = and i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = and i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @or_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @or_i3(
 ; SI-NEXT:    [[R:%.*]] = or i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @or_i3(
@@ -412,18 +412,18 @@ define amdgpu_kernel void @or_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = or i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = or i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @xor_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @xor_i3(
 ; SI-NEXT:    [[R:%.*]] = xor i3 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[R]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @xor_i3(
@@ -431,11 +431,11 @@ define amdgpu_kernel void @xor_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i3 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %r = xor i3 %a, %b
-  store volatile i3 %r, ptr addrspace(1) undef
+  store volatile i3 %r, ptr addrspace(1) poison
   ret void
 }
 
@@ -443,7 +443,7 @@ define amdgpu_kernel void @select_eq_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @select_eq_i3(
 ; SI-NEXT:    [[CMP:%.*]] = icmp eq i3 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i3 [[A]], i3 [[B]]
-; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_eq_i3(
@@ -454,12 +454,12 @@ define amdgpu_kernel void @select_eq_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext i3 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i3
-; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp eq i3 %a, %b
   %sel = select i1 %cmp, i3 %a, i3 %b
-  store volatile i3 %sel, ptr addrspace(1) undef
+  store volatile i3 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -467,7 +467,7 @@ define amdgpu_kernel void @select_ne_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @select_ne_i3(
 ; SI-NEXT:    [[CMP:%.*]] = icmp ne i3 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i3 [[A]], i3 [[B]]
-; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_ne_i3(
@@ -478,12 +478,12 @@ define amdgpu_kernel void @select_ne_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext i3 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i3
-; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp ne i3 %a, %b
   %sel = select i1 %cmp, i3 %a, i3 %b
-  store volatile i3 %sel, ptr addrspace(1) undef
+  store volatile i3 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -491,7 +491,7 @@ define amdgpu_kernel void @select_ugt_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @select_ugt_i3(
 ; SI-NEXT:    [[CMP:%.*]] = icmp ugt i3 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i3 [[A]], i3 [[B]]
-; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_ugt_i3(
@@ -502,12 +502,12 @@ define amdgpu_kernel void @select_ugt_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext i3 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i3
-; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp ugt i3 %a, %b
   %sel = select i1 %cmp, i3 %a, i3 %b
-  store volatile i3 %sel, ptr addrspace(1) undef
+  store volatile i3 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -515,7 +515,7 @@ define amdgpu_kernel void @select_uge_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @select_uge_i3(
 ; SI-NEXT:    [[CMP:%.*]] = icmp uge i3 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i3 [[A]], i3 [[B]]
-; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_uge_i3(
@@ -526,12 +526,12 @@ define amdgpu_kernel void @select_uge_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext i3 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i3
-; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp uge i3 %a, %b
   %sel = select i1 %cmp, i3 %a, i3 %b
-  store volatile i3 %sel, ptr addrspace(1) undef
+  store volatile i3 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -539,7 +539,7 @@ define amdgpu_kernel void @select_ult_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @select_ult_i3(
 ; SI-NEXT:    [[CMP:%.*]] = icmp ult i3 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i3 [[A]], i3 [[B]]
-; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_ult_i3(
@@ -550,12 +550,12 @@ define amdgpu_kernel void @select_ult_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext i3 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i3
-; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp ult i3 %a, %b
   %sel = select i1 %cmp, i3 %a, i3 %b
-  store volatile i3 %sel, ptr addrspace(1) undef
+  store volatile i3 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -563,7 +563,7 @@ define amdgpu_kernel void @select_ule_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @select_ule_i3(
 ; SI-NEXT:    [[CMP:%.*]] = icmp ule i3 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i3 [[A]], i3 [[B]]
-; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_ule_i3(
@@ -574,12 +574,12 @@ define amdgpu_kernel void @select_ule_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext i3 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i3
-; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp ule i3 %a, %b
   %sel = select i1 %cmp, i3 %a, i3 %b
-  store volatile i3 %sel, ptr addrspace(1) undef
+  store volatile i3 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -587,7 +587,7 @@ define amdgpu_kernel void @select_sgt_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @select_sgt_i3(
 ; SI-NEXT:    [[CMP:%.*]] = icmp sgt i3 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i3 [[A]], i3 [[B]]
-; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_sgt_i3(
@@ -598,12 +598,12 @@ define amdgpu_kernel void @select_sgt_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = sext i3 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i3
-; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp sgt i3 %a, %b
   %sel = select i1 %cmp, i3 %a, i3 %b
-  store volatile i3 %sel, ptr addrspace(1) undef
+  store volatile i3 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -611,7 +611,7 @@ define amdgpu_kernel void @select_sge_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @select_sge_i3(
 ; SI-NEXT:    [[CMP:%.*]] = icmp sge i3 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i3 [[A]], i3 [[B]]
-; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_sge_i3(
@@ -622,12 +622,12 @@ define amdgpu_kernel void @select_sge_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = sext i3 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i3
-; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp sge i3 %a, %b
   %sel = select i1 %cmp, i3 %a, i3 %b
-  store volatile i3 %sel, ptr addrspace(1) undef
+  store volatile i3 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -635,7 +635,7 @@ define amdgpu_kernel void @select_slt_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @select_slt_i3(
 ; SI-NEXT:    [[CMP:%.*]] = icmp slt i3 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i3 [[A]], i3 [[B]]
-; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_slt_i3(
@@ -646,12 +646,12 @@ define amdgpu_kernel void @select_slt_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = sext i3 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i3
-; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp slt i3 %a, %b
   %sel = select i1 %cmp, i3 %a, i3 %b
-  store volatile i3 %sel, ptr addrspace(1) undef
+  store volatile i3 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -659,7 +659,7 @@ define amdgpu_kernel void @select_sle_i3(i3 %a, i3 %b) {
 ; SI-LABEL: @select_sle_i3(
 ; SI-NEXT:    [[CMP:%.*]] = icmp sle i3 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i3 [[A]], i3 [[B]]
-; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[SEL]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_sle_i3(
@@ -670,12 +670,12 @@ define amdgpu_kernel void @select_sle_i3(i3 %a, i3 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = sext i3 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i3
-; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP7]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp sle i3 %a, %b
   %sel = select i1 %cmp, i3 %a, i3 %b
-  store volatile i3 %sel, ptr addrspace(1) undef
+  store volatile i3 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -683,7 +683,7 @@ declare i3 @llvm.bitreverse.i3(i3)
 define amdgpu_kernel void @bitreverse_i3(i3 %a) {
 ; SI-LABEL: @bitreverse_i3(
 ; SI-NEXT:    [[BREV:%.*]] = call i3 @llvm.bitreverse.i3(i3 [[A:%.*]])
-; SI-NEXT:    store volatile i3 [[BREV]], ptr addrspace(1) undef, align 1
+; SI-NEXT:    store volatile i3 [[BREV]], ptr addrspace(1) poison, align 1
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @bitreverse_i3(
@@ -691,18 +691,18 @@ define amdgpu_kernel void @bitreverse_i3(i3 %a) {
 ; VI-NEXT:    [[TMP2:%.*]] = call i32 @llvm.bitreverse.i32(i32 [[TMP1]])
 ; VI-NEXT:    [[TMP3:%.*]] = lshr i32 [[TMP2]], 29
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i3
-; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) undef, align 1
+; VI-NEXT:    store volatile i3 [[TMP4]], ptr addrspace(1) poison, align 1
 ; VI-NEXT:    ret void
 ;
   %brev = call i3 @llvm.bitreverse.i3(i3 %a)
-  store volatile i3 %brev, ptr addrspace(1) undef
+  store volatile i3 %brev, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @add_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @add_i16(
 ; SI-NEXT:    [[R:%.*]] = add i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @add_i16(
@@ -710,63 +710,63 @@ define amdgpu_kernel void @add_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = add nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = add i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @constant_add_i16() {
 ; SI-LABEL: @constant_add_i16(
 ; SI-NEXT:    [[R:%.*]] = add i16 1, 2
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @constant_add_i16(
-; VI-NEXT:    store volatile i16 3, ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 3, ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = add i16 1, 2
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @constant_add_nsw_i16() {
 ; SI-LABEL: @constant_add_nsw_i16(
 ; SI-NEXT:    [[R:%.*]] = add nsw i16 1, 2
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @constant_add_nsw_i16(
-; VI-NEXT:    store volatile i16 3, ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 3, ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = add nsw i16 1, 2
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @constant_add_nuw_i16() {
 ; SI-LABEL: @constant_add_nuw_i16(
 ; SI-NEXT:    [[R:%.*]] = add nsw i16 1, 2
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @constant_add_nuw_i16(
-; VI-NEXT:    store volatile i16 3, ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 3, ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = add nsw i16 1, 2
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @add_nsw_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @add_nsw_i16(
 ; SI-NEXT:    [[R:%.*]] = add nsw i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @add_nsw_i16(
@@ -774,18 +774,18 @@ define amdgpu_kernel void @add_nsw_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = add nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = add nsw i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @add_nuw_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @add_nuw_i16(
 ; SI-NEXT:    [[R:%.*]] = add nuw i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @add_nuw_i16(
@@ -793,18 +793,18 @@ define amdgpu_kernel void @add_nuw_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = add nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = add nuw i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @add_nuw_nsw_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @add_nuw_nsw_i16(
 ; SI-NEXT:    [[R:%.*]] = add nuw nsw i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @add_nuw_nsw_i16(
@@ -812,18 +812,18 @@ define amdgpu_kernel void @add_nuw_nsw_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = add nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = add nuw nsw i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @sub_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @sub_i16(
 ; SI-NEXT:    [[R:%.*]] = sub i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @sub_i16(
@@ -831,18 +831,18 @@ define amdgpu_kernel void @sub_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = sub nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = sub i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @sub_nsw_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @sub_nsw_i16(
 ; SI-NEXT:    [[R:%.*]] = sub nsw i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @sub_nsw_i16(
@@ -850,18 +850,18 @@ define amdgpu_kernel void @sub_nsw_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = sub nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = sub nsw i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @sub_nuw_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @sub_nuw_i16(
 ; SI-NEXT:    [[R:%.*]] = sub nuw i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @sub_nuw_i16(
@@ -869,18 +869,18 @@ define amdgpu_kernel void @sub_nuw_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = sub nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = sub nuw i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @sub_nuw_nsw_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @sub_nuw_nsw_i16(
 ; SI-NEXT:    [[R:%.*]] = sub nuw nsw i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @sub_nuw_nsw_i16(
@@ -888,18 +888,18 @@ define amdgpu_kernel void @sub_nuw_nsw_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = sub nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = sub nuw nsw i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @mul_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @mul_i16(
 ; SI-NEXT:    [[R:%.*]] = mul i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @mul_i16(
@@ -907,18 +907,18 @@ define amdgpu_kernel void @mul_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = mul nuw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = mul i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @mul_nsw_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @mul_nsw_i16(
 ; SI-NEXT:    [[R:%.*]] = mul nsw i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @mul_nsw_i16(
@@ -926,18 +926,18 @@ define amdgpu_kernel void @mul_nsw_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = mul nuw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = mul nsw i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @mul_nuw_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @mul_nuw_i16(
 ; SI-NEXT:    [[R:%.*]] = mul nuw i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @mul_nuw_i16(
@@ -945,18 +945,18 @@ define amdgpu_kernel void @mul_nuw_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = mul nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = mul nuw i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @mul_nuw_nsw_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @mul_nuw_nsw_i16(
 ; SI-NEXT:    [[R:%.*]] = mul nuw nsw i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @mul_nuw_nsw_i16(
@@ -964,18 +964,18 @@ define amdgpu_kernel void @mul_nuw_nsw_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = mul nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = mul nuw nsw i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @shl_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @shl_i16(
 ; SI-NEXT:    [[R:%.*]] = shl i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @shl_i16(
@@ -983,18 +983,18 @@ define amdgpu_kernel void @shl_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = shl nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = shl i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @shl_nsw_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @shl_nsw_i16(
 ; SI-NEXT:    [[R:%.*]] = shl nsw i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @shl_nsw_i16(
@@ -1002,18 +1002,18 @@ define amdgpu_kernel void @shl_nsw_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = shl nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = shl nsw i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @shl_nuw_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @shl_nuw_i16(
 ; SI-NEXT:    [[R:%.*]] = shl nuw i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @shl_nuw_i16(
@@ -1021,18 +1021,18 @@ define amdgpu_kernel void @shl_nuw_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = shl nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = shl nuw i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @shl_nuw_nsw_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @shl_nuw_nsw_i16(
 ; SI-NEXT:    [[R:%.*]] = shl nuw nsw i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @shl_nuw_nsw_i16(
@@ -1040,18 +1040,18 @@ define amdgpu_kernel void @shl_nuw_nsw_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = shl nuw nsw i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = shl nuw nsw i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @lshr_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @lshr_i16(
 ; SI-NEXT:    [[R:%.*]] = lshr i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @lshr_i16(
@@ -1059,18 +1059,18 @@ define amdgpu_kernel void @lshr_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = lshr i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = lshr i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @lshr_exact_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @lshr_exact_i16(
 ; SI-NEXT:    [[R:%.*]] = lshr exact i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @lshr_exact_i16(
@@ -1078,18 +1078,18 @@ define amdgpu_kernel void @lshr_exact_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = lshr exact i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = lshr exact i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @ashr_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @ashr_i16(
 ; SI-NEXT:    [[R:%.*]] = ashr i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @ashr_i16(
@@ -1097,18 +1097,18 @@ define amdgpu_kernel void @ashr_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = sext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = ashr i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = ashr i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @ashr_exact_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @ashr_exact_i16(
 ; SI-NEXT:    [[R:%.*]] = ashr exact i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @ashr_exact_i16(
@@ -1116,33 +1116,33 @@ define amdgpu_kernel void @ashr_exact_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = sext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = ashr exact i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = ashr exact i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @constant_lshr_exact_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @constant_lshr_exact_i16(
 ; SI-NEXT:    [[R:%.*]] = lshr exact i16 4, 1
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @constant_lshr_exact_i16(
-; VI-NEXT:    store volatile i16 2, ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 2, ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = lshr exact i16 4, 1
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @and_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @and_i16(
 ; SI-NEXT:    [[R:%.*]] = and i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @and_i16(
@@ -1150,18 +1150,18 @@ define amdgpu_kernel void @and_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = and i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = and i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @or_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @or_i16(
 ; SI-NEXT:    [[R:%.*]] = or i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @or_i16(
@@ -1169,18 +1169,18 @@ define amdgpu_kernel void @or_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = or i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = or i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @xor_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @xor_i16(
 ; SI-NEXT:    [[R:%.*]] = xor i16 [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[R]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @xor_i16(
@@ -1188,11 +1188,11 @@ define amdgpu_kernel void @xor_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext i16 [[B:%.*]] to i32
 ; VI-NEXT:    [[TMP3:%.*]] = xor i32 [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %r = xor i16 %a, %b
-  store volatile i16 %r, ptr addrspace(1) undef
+  store volatile i16 %r, ptr addrspace(1) poison
   ret void
 }
 
@@ -1200,7 +1200,7 @@ define amdgpu_kernel void @select_eq_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @select_eq_i16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp eq i16 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i16 [[A]], i16 [[B]]
-; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_eq_i16(
@@ -1211,12 +1211,12 @@ define amdgpu_kernel void @select_eq_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext i16 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i16
-; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp eq i16 %a, %b
   %sel = select i1 %cmp, i16 %a, i16 %b
-  store volatile i16 %sel, ptr addrspace(1) undef
+  store volatile i16 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -1224,7 +1224,7 @@ define amdgpu_kernel void @select_ne_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @select_ne_i16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp ne i16 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i16 [[A]], i16 [[B]]
-; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_ne_i16(
@@ -1235,12 +1235,12 @@ define amdgpu_kernel void @select_ne_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext i16 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i16
-; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp ne i16 %a, %b
   %sel = select i1 %cmp, i16 %a, i16 %b
-  store volatile i16 %sel, ptr addrspace(1) undef
+  store volatile i16 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -1248,7 +1248,7 @@ define amdgpu_kernel void @select_ugt_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @select_ugt_i16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp ugt i16 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i16 [[A]], i16 [[B]]
-; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_ugt_i16(
@@ -1259,12 +1259,12 @@ define amdgpu_kernel void @select_ugt_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext i16 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i16
-; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp ugt i16 %a, %b
   %sel = select i1 %cmp, i16 %a, i16 %b
-  store volatile i16 %sel, ptr addrspace(1) undef
+  store volatile i16 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -1272,7 +1272,7 @@ define amdgpu_kernel void @select_uge_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @select_uge_i16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp uge i16 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i16 [[A]], i16 [[B]]
-; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_uge_i16(
@@ -1283,12 +1283,12 @@ define amdgpu_kernel void @select_uge_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext i16 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i16
-; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp uge i16 %a, %b
   %sel = select i1 %cmp, i16 %a, i16 %b
-  store volatile i16 %sel, ptr addrspace(1) undef
+  store volatile i16 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -1296,7 +1296,7 @@ define amdgpu_kernel void @select_ult_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @select_ult_i16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp ult i16 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i16 [[A]], i16 [[B]]
-; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_ult_i16(
@@ -1307,12 +1307,12 @@ define amdgpu_kernel void @select_ult_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext i16 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i16
-; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp ult i16 %a, %b
   %sel = select i1 %cmp, i16 %a, i16 %b
-  store volatile i16 %sel, ptr addrspace(1) undef
+  store volatile i16 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -1320,7 +1320,7 @@ define amdgpu_kernel void @select_ule_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @select_ule_i16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp ule i16 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i16 [[A]], i16 [[B]]
-; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_ule_i16(
@@ -1331,12 +1331,12 @@ define amdgpu_kernel void @select_ule_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext i16 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i16
-; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp ule i16 %a, %b
   %sel = select i1 %cmp, i16 %a, i16 %b
-  store volatile i16 %sel, ptr addrspace(1) undef
+  store volatile i16 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -1344,7 +1344,7 @@ define amdgpu_kernel void @select_sgt_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @select_sgt_i16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp sgt i16 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i16 [[A]], i16 [[B]]
-; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_sgt_i16(
@@ -1355,12 +1355,12 @@ define amdgpu_kernel void @select_sgt_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = sext i16 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i16
-; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp sgt i16 %a, %b
   %sel = select i1 %cmp, i16 %a, i16 %b
-  store volatile i16 %sel, ptr addrspace(1) undef
+  store volatile i16 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -1368,7 +1368,7 @@ define amdgpu_kernel void @select_sge_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @select_sge_i16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp sge i16 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i16 [[A]], i16 [[B]]
-; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_sge_i16(
@@ -1379,12 +1379,12 @@ define amdgpu_kernel void @select_sge_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = sext i16 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i16
-; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp sge i16 %a, %b
   %sel = select i1 %cmp, i16 %a, i16 %b
-  store volatile i16 %sel, ptr addrspace(1) undef
+  store volatile i16 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -1392,7 +1392,7 @@ define amdgpu_kernel void @select_slt_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @select_slt_i16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp slt i16 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i16 [[A]], i16 [[B]]
-; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_slt_i16(
@@ -1403,12 +1403,12 @@ define amdgpu_kernel void @select_slt_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = sext i16 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i16
-; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp slt i16 %a, %b
   %sel = select i1 %cmp, i16 %a, i16 %b
-  store volatile i16 %sel, ptr addrspace(1) undef
+  store volatile i16 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -1416,7 +1416,7 @@ define amdgpu_kernel void @select_sle_i16(i16 %a, i16 %b) {
 ; SI-LABEL: @select_sle_i16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp sle i16 [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select i1 [[CMP]], i16 [[A]], i16 [[B]]
-; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[SEL]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_sle_i16(
@@ -1427,12 +1427,12 @@ define amdgpu_kernel void @select_sle_i16(i16 %a, i16 %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = sext i16 [[B]] to i32
 ; VI-NEXT:    [[TMP6:%.*]] = select i1 [[TMP3]], i32 [[TMP4]], i32 [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc i32 [[TMP6]] to i16
-; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP7]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp sle i16 %a, %b
   %sel = select i1 %cmp, i16 %a, i16 %b
-  store volatile i16 %sel, ptr addrspace(1) undef
+  store volatile i16 %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -1441,7 +1441,7 @@ declare i16 @llvm.bitreverse.i16(i16)
 define amdgpu_kernel void @bitreverse_i16(i16 %a) {
 ; SI-LABEL: @bitreverse_i16(
 ; SI-NEXT:    [[BREV:%.*]] = call i16 @llvm.bitreverse.i16(i16 [[A:%.*]])
-; SI-NEXT:    store volatile i16 [[BREV]], ptr addrspace(1) undef, align 2
+; SI-NEXT:    store volatile i16 [[BREV]], ptr addrspace(1) poison, align 2
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @bitreverse_i16(
@@ -1449,18 +1449,18 @@ define amdgpu_kernel void @bitreverse_i16(i16 %a) {
 ; VI-NEXT:    [[TMP2:%.*]] = call i32 @llvm.bitreverse.i32(i32 [[TMP1]])
 ; VI-NEXT:    [[TMP3:%.*]] = lshr i32 [[TMP2]], 16
 ; VI-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i16
-; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) undef, align 2
+; VI-NEXT:    store volatile i16 [[TMP4]], ptr addrspace(1) poison, align 2
 ; VI-NEXT:    ret void
 ;
   %brev = call i16 @llvm.bitreverse.i16(i16 %a)
-  store volatile i16 %brev, ptr addrspace(1) undef
+  store volatile i16 %brev, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @add_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @add_3xi15(
 ; SI-NEXT:    [[R:%.*]] = add <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @add_3xi15(
@@ -1468,18 +1468,18 @@ define amdgpu_kernel void @add_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = add nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = add <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @add_nsw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @add_nsw_3xi15(
 ; SI-NEXT:    [[R:%.*]] = add nsw <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @add_nsw_3xi15(
@@ -1487,18 +1487,18 @@ define amdgpu_kernel void @add_nsw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = add nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = add nsw <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @add_nuw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @add_nuw_3xi15(
 ; SI-NEXT:    [[R:%.*]] = add nuw <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @add_nuw_3xi15(
@@ -1506,18 +1506,18 @@ define amdgpu_kernel void @add_nuw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = add nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = add nuw <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @add_nuw_nsw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @add_nuw_nsw_3xi15(
 ; SI-NEXT:    [[R:%.*]] = add nuw nsw <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @add_nuw_nsw_3xi15(
@@ -1525,18 +1525,18 @@ define amdgpu_kernel void @add_nuw_nsw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = add nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = add nuw nsw <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @sub_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @sub_3xi15(
 ; SI-NEXT:    [[R:%.*]] = sub <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @sub_3xi15(
@@ -1544,18 +1544,18 @@ define amdgpu_kernel void @sub_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = sub nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = sub <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @sub_nsw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @sub_nsw_3xi15(
 ; SI-NEXT:    [[R:%.*]] = sub nsw <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @sub_nsw_3xi15(
@@ -1563,18 +1563,18 @@ define amdgpu_kernel void @sub_nsw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = sub nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = sub nsw <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @sub_nuw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @sub_nuw_3xi15(
 ; SI-NEXT:    [[R:%.*]] = sub nuw <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @sub_nuw_3xi15(
@@ -1582,18 +1582,18 @@ define amdgpu_kernel void @sub_nuw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = sub nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = sub nuw <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @sub_nuw_nsw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @sub_nuw_nsw_3xi15(
 ; SI-NEXT:    [[R:%.*]] = sub nuw nsw <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @sub_nuw_nsw_3xi15(
@@ -1601,18 +1601,18 @@ define amdgpu_kernel void @sub_nuw_nsw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = sub nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = sub nuw nsw <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @mul_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @mul_3xi15(
 ; SI-NEXT:    [[R:%.*]] = mul <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @mul_3xi15(
@@ -1620,18 +1620,18 @@ define amdgpu_kernel void @mul_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = mul nuw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = mul <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @mul_nsw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @mul_nsw_3xi15(
 ; SI-NEXT:    [[R:%.*]] = mul nsw <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @mul_nsw_3xi15(
@@ -1639,18 +1639,18 @@ define amdgpu_kernel void @mul_nsw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = mul nuw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = mul nsw <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @mul_nuw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @mul_nuw_3xi15(
 ; SI-NEXT:    [[R:%.*]] = mul nuw <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @mul_nuw_3xi15(
@@ -1658,18 +1658,18 @@ define amdgpu_kernel void @mul_nuw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = mul nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = mul nuw <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @mul_nuw_nsw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @mul_nuw_nsw_3xi15(
 ; SI-NEXT:    [[R:%.*]] = mul nuw nsw <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @mul_nuw_nsw_3xi15(
@@ -1677,18 +1677,18 @@ define amdgpu_kernel void @mul_nuw_nsw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = mul nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = mul nuw nsw <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @shl_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @shl_3xi15(
 ; SI-NEXT:    [[R:%.*]] = shl <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @shl_3xi15(
@@ -1696,18 +1696,18 @@ define amdgpu_kernel void @shl_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = shl nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = shl <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @shl_nsw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @shl_nsw_3xi15(
 ; SI-NEXT:    [[R:%.*]] = shl nsw <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @shl_nsw_3xi15(
@@ -1715,18 +1715,18 @@ define amdgpu_kernel void @shl_nsw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = shl nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = shl nsw <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @shl_nuw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @shl_nuw_3xi15(
 ; SI-NEXT:    [[R:%.*]] = shl nuw <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @shl_nuw_3xi15(
@@ -1734,18 +1734,18 @@ define amdgpu_kernel void @shl_nuw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = shl nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = shl nuw <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @shl_nuw_nsw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @shl_nuw_nsw_3xi15(
 ; SI-NEXT:    [[R:%.*]] = shl nuw nsw <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @shl_nuw_nsw_3xi15(
@@ -1753,18 +1753,18 @@ define amdgpu_kernel void @shl_nuw_nsw_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = shl nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = shl nuw nsw <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @lshr_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @lshr_3xi15(
 ; SI-NEXT:    [[R:%.*]] = lshr <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @lshr_3xi15(
@@ -1772,18 +1772,18 @@ define amdgpu_kernel void @lshr_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = lshr <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = lshr <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @lshr_exact_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @lshr_exact_3xi15(
 ; SI-NEXT:    [[R:%.*]] = lshr exact <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @lshr_exact_3xi15(
@@ -1791,18 +1791,18 @@ define amdgpu_kernel void @lshr_exact_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = lshr exact <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = lshr exact <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @ashr_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @ashr_3xi15(
 ; SI-NEXT:    [[R:%.*]] = ashr <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @ashr_3xi15(
@@ -1810,18 +1810,18 @@ define amdgpu_kernel void @ashr_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = sext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = ashr <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = ashr <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @ashr_exact_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @ashr_exact_3xi15(
 ; SI-NEXT:    [[R:%.*]] = ashr exact <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @ashr_exact_3xi15(
@@ -1829,18 +1829,18 @@ define amdgpu_kernel void @ashr_exact_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = sext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = ashr exact <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = ashr exact <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @and_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @and_3xi15(
 ; SI-NEXT:    [[R:%.*]] = and <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @and_3xi15(
@@ -1848,18 +1848,18 @@ define amdgpu_kernel void @and_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = and <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = and <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @or_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @or_3xi15(
 ; SI-NEXT:    [[R:%.*]] = or <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @or_3xi15(
@@ -1867,18 +1867,18 @@ define amdgpu_kernel void @or_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = or <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = or <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @xor_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @xor_3xi15(
 ; SI-NEXT:    [[R:%.*]] = xor <3 x i15> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @xor_3xi15(
@@ -1886,11 +1886,11 @@ define amdgpu_kernel void @xor_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i15> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = xor <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = xor <3 x i15> %a, %b
-  store volatile <3 x i15> %r, ptr addrspace(1) undef
+  store volatile <3 x i15> %r, ptr addrspace(1) poison
   ret void
 }
 
@@ -1898,7 +1898,7 @@ define amdgpu_kernel void @select_eq_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @select_eq_3xi15(
 ; SI-NEXT:    [[CMP:%.*]] = icmp eq <3 x i15> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i15> [[A]], <3 x i15> [[B]]
-; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_eq_3xi15(
@@ -1909,12 +1909,12 @@ define amdgpu_kernel void @select_eq_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext <3 x i15> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp eq <3 x i15> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i15> %a, <3 x i15> %b
-  store volatile <3 x i15> %sel, ptr addrspace(1) undef
+  store volatile <3 x i15> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -1922,7 +1922,7 @@ define amdgpu_kernel void @select_ne_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @select_ne_3xi15(
 ; SI-NEXT:    [[CMP:%.*]] = icmp ne <3 x i15> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i15> [[A]], <3 x i15> [[B]]
-; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_ne_3xi15(
@@ -1933,12 +1933,12 @@ define amdgpu_kernel void @select_ne_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext <3 x i15> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp ne <3 x i15> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i15> %a, <3 x i15> %b
-  store volatile <3 x i15> %sel, ptr addrspace(1) undef
+  store volatile <3 x i15> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -1946,7 +1946,7 @@ define amdgpu_kernel void @select_ugt_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @select_ugt_3xi15(
 ; SI-NEXT:    [[CMP:%.*]] = icmp ugt <3 x i15> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i15> [[A]], <3 x i15> [[B]]
-; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_ugt_3xi15(
@@ -1957,12 +1957,12 @@ define amdgpu_kernel void @select_ugt_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext <3 x i15> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp ugt <3 x i15> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i15> %a, <3 x i15> %b
-  store volatile <3 x i15> %sel, ptr addrspace(1) undef
+  store volatile <3 x i15> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -1970,7 +1970,7 @@ define amdgpu_kernel void @select_uge_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @select_uge_3xi15(
 ; SI-NEXT:    [[CMP:%.*]] = icmp uge <3 x i15> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i15> [[A]], <3 x i15> [[B]]
-; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_uge_3xi15(
@@ -1981,12 +1981,12 @@ define amdgpu_kernel void @select_uge_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext <3 x i15> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp uge <3 x i15> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i15> %a, <3 x i15> %b
-  store volatile <3 x i15> %sel, ptr addrspace(1) undef
+  store volatile <3 x i15> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -1994,7 +1994,7 @@ define amdgpu_kernel void @select_ult_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @select_ult_3xi15(
 ; SI-NEXT:    [[CMP:%.*]] = icmp ult <3 x i15> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i15> [[A]], <3 x i15> [[B]]
-; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_ult_3xi15(
@@ -2005,12 +2005,12 @@ define amdgpu_kernel void @select_ult_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext <3 x i15> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp ult <3 x i15> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i15> %a, <3 x i15> %b
-  store volatile <3 x i15> %sel, ptr addrspace(1) undef
+  store volatile <3 x i15> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -2018,7 +2018,7 @@ define amdgpu_kernel void @select_ule_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @select_ule_3xi15(
 ; SI-NEXT:    [[CMP:%.*]] = icmp ule <3 x i15> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i15> [[A]], <3 x i15> [[B]]
-; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_ule_3xi15(
@@ -2029,12 +2029,12 @@ define amdgpu_kernel void @select_ule_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext <3 x i15> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp ule <3 x i15> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i15> %a, <3 x i15> %b
-  store volatile <3 x i15> %sel, ptr addrspace(1) undef
+  store volatile <3 x i15> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -2042,7 +2042,7 @@ define amdgpu_kernel void @select_sgt_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @select_sgt_3xi15(
 ; SI-NEXT:    [[CMP:%.*]] = icmp sgt <3 x i15> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i15> [[A]], <3 x i15> [[B]]
-; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_sgt_3xi15(
@@ -2053,12 +2053,12 @@ define amdgpu_kernel void @select_sgt_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = sext <3 x i15> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp sgt <3 x i15> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i15> %a, <3 x i15> %b
-  store volatile <3 x i15> %sel, ptr addrspace(1) undef
+  store volatile <3 x i15> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -2066,7 +2066,7 @@ define amdgpu_kernel void @select_sge_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @select_sge_3xi15(
 ; SI-NEXT:    [[CMP:%.*]] = icmp sge <3 x i15> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i15> [[A]], <3 x i15> [[B]]
-; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_sge_3xi15(
@@ -2077,12 +2077,12 @@ define amdgpu_kernel void @select_sge_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = sext <3 x i15> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp sge <3 x i15> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i15> %a, <3 x i15> %b
-  store volatile <3 x i15> %sel, ptr addrspace(1) undef
+  store volatile <3 x i15> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -2090,7 +2090,7 @@ define amdgpu_kernel void @select_slt_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @select_slt_3xi15(
 ; SI-NEXT:    [[CMP:%.*]] = icmp slt <3 x i15> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i15> [[A]], <3 x i15> [[B]]
-; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_slt_3xi15(
@@ -2101,12 +2101,12 @@ define amdgpu_kernel void @select_slt_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = sext <3 x i15> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp slt <3 x i15> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i15> %a, <3 x i15> %b
-  store volatile <3 x i15> %sel, ptr addrspace(1) undef
+  store volatile <3 x i15> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -2114,7 +2114,7 @@ define amdgpu_kernel void @select_sle_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; SI-LABEL: @select_sle_3xi15(
 ; SI-NEXT:    [[CMP:%.*]] = icmp sle <3 x i15> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i15> [[A]], <3 x i15> [[B]]
-; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_sle_3xi15(
@@ -2125,12 +2125,12 @@ define amdgpu_kernel void @select_sle_3xi15(<3 x i15> %a, <3 x i15> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = sext <3 x i15> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp sle <3 x i15> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i15> %a, <3 x i15> %b
-  store volatile <3 x i15> %sel, ptr addrspace(1) undef
+  store volatile <3 x i15> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -2138,7 +2138,7 @@ declare <3 x i15> @llvm.bitreverse.v3i15(<3 x i15>)
 define amdgpu_kernel void @bitreverse_3xi15(<3 x i15> %a) {
 ; SI-LABEL: @bitreverse_3xi15(
 ; SI-NEXT:    [[BREV:%.*]] = call <3 x i15> @llvm.bitreverse.v3i15(<3 x i15> [[A:%.*]])
-; SI-NEXT:    store volatile <3 x i15> [[BREV]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i15> [[BREV]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @bitreverse_3xi15(
@@ -2146,18 +2146,18 @@ define amdgpu_kernel void @bitreverse_3xi15(<3 x i15> %a) {
 ; VI-NEXT:    [[TMP2:%.*]] = call <3 x i32> @llvm.bitreverse.v3i32(<3 x i32> [[TMP1]])
 ; VI-NEXT:    [[TMP3:%.*]] = lshr <3 x i32> [[TMP2]], splat (i32 17)
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i15>
-; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i15> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %brev = call <3 x i15> @llvm.bitreverse.v3i15(<3 x i15> %a)
-  store volatile <3 x i15> %brev, ptr addrspace(1) undef
+  store volatile <3 x i15> %brev, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @add_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @add_3xi16(
 ; SI-NEXT:    [[R:%.*]] = add <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @add_3xi16(
@@ -2165,18 +2165,18 @@ define amdgpu_kernel void @add_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = add nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = add <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @add_nsw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @add_nsw_3xi16(
 ; SI-NEXT:    [[R:%.*]] = add nsw <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @add_nsw_3xi16(
@@ -2184,18 +2184,18 @@ define amdgpu_kernel void @add_nsw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = add nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = add nsw <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @add_nuw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @add_nuw_3xi16(
 ; SI-NEXT:    [[R:%.*]] = add nuw <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @add_nuw_3xi16(
@@ -2203,18 +2203,18 @@ define amdgpu_kernel void @add_nuw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = add nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = add nuw <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @add_nuw_nsw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @add_nuw_nsw_3xi16(
 ; SI-NEXT:    [[R:%.*]] = add nuw nsw <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @add_nuw_nsw_3xi16(
@@ -2222,18 +2222,18 @@ define amdgpu_kernel void @add_nuw_nsw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = add nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = add nuw nsw <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @sub_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @sub_3xi16(
 ; SI-NEXT:    [[R:%.*]] = sub <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @sub_3xi16(
@@ -2241,18 +2241,18 @@ define amdgpu_kernel void @sub_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = sub nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = sub <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @sub_nsw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @sub_nsw_3xi16(
 ; SI-NEXT:    [[R:%.*]] = sub nsw <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @sub_nsw_3xi16(
@@ -2260,18 +2260,18 @@ define amdgpu_kernel void @sub_nsw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = sub nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = sub nsw <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @sub_nuw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @sub_nuw_3xi16(
 ; SI-NEXT:    [[R:%.*]] = sub nuw <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @sub_nuw_3xi16(
@@ -2279,18 +2279,18 @@ define amdgpu_kernel void @sub_nuw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = sub nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = sub nuw <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @sub_nuw_nsw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @sub_nuw_nsw_3xi16(
 ; SI-NEXT:    [[R:%.*]] = sub nuw nsw <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @sub_nuw_nsw_3xi16(
@@ -2298,18 +2298,18 @@ define amdgpu_kernel void @sub_nuw_nsw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = sub nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = sub nuw nsw <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @mul_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @mul_3xi16(
 ; SI-NEXT:    [[R:%.*]] = mul <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @mul_3xi16(
@@ -2317,18 +2317,18 @@ define amdgpu_kernel void @mul_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = mul nuw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = mul <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @mul_nsw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @mul_nsw_3xi16(
 ; SI-NEXT:    [[R:%.*]] = mul nsw <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @mul_nsw_3xi16(
@@ -2336,18 +2336,18 @@ define amdgpu_kernel void @mul_nsw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = mul nuw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = mul nsw <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @mul_nuw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @mul_nuw_3xi16(
 ; SI-NEXT:    [[R:%.*]] = mul nuw <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @mul_nuw_3xi16(
@@ -2355,18 +2355,18 @@ define amdgpu_kernel void @mul_nuw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = mul nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = mul nuw <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @mul_nuw_nsw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @mul_nuw_nsw_3xi16(
 ; SI-NEXT:    [[R:%.*]] = mul nuw nsw <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @mul_nuw_nsw_3xi16(
@@ -2374,18 +2374,18 @@ define amdgpu_kernel void @mul_nuw_nsw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = mul nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = mul nuw nsw <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @shl_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @shl_3xi16(
 ; SI-NEXT:    [[R:%.*]] = shl <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @shl_3xi16(
@@ -2393,18 +2393,18 @@ define amdgpu_kernel void @shl_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = shl nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = shl <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @shl_nsw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @shl_nsw_3xi16(
 ; SI-NEXT:    [[R:%.*]] = shl nsw <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @shl_nsw_3xi16(
@@ -2412,18 +2412,18 @@ define amdgpu_kernel void @shl_nsw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = shl nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = shl nsw <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @shl_nuw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @shl_nuw_3xi16(
 ; SI-NEXT:    [[R:%.*]] = shl nuw <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @shl_nuw_3xi16(
@@ -2431,18 +2431,18 @@ define amdgpu_kernel void @shl_nuw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = shl nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = shl nuw <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @shl_nuw_nsw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @shl_nuw_nsw_3xi16(
 ; SI-NEXT:    [[R:%.*]] = shl nuw nsw <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @shl_nuw_nsw_3xi16(
@@ -2450,18 +2450,18 @@ define amdgpu_kernel void @shl_nuw_nsw_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = shl nuw nsw <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = shl nuw nsw <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @lshr_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @lshr_3xi16(
 ; SI-NEXT:    [[R:%.*]] = lshr <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @lshr_3xi16(
@@ -2469,18 +2469,18 @@ define amdgpu_kernel void @lshr_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = lshr <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = lshr <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @lshr_exact_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @lshr_exact_3xi16(
 ; SI-NEXT:    [[R:%.*]] = lshr exact <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @lshr_exact_3xi16(
@@ -2488,18 +2488,18 @@ define amdgpu_kernel void @lshr_exact_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = lshr exact <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = lshr exact <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @ashr_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @ashr_3xi16(
 ; SI-NEXT:    [[R:%.*]] = ashr <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @ashr_3xi16(
@@ -2507,18 +2507,18 @@ define amdgpu_kernel void @ashr_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = sext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = ashr <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = ashr <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @ashr_exact_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @ashr_exact_3xi16(
 ; SI-NEXT:    [[R:%.*]] = ashr exact <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @ashr_exact_3xi16(
@@ -2526,18 +2526,18 @@ define amdgpu_kernel void @ashr_exact_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = sext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = ashr exact <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = ashr exact <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @and_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @and_3xi16(
 ; SI-NEXT:    [[R:%.*]] = and <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @and_3xi16(
@@ -2545,18 +2545,18 @@ define amdgpu_kernel void @and_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = and <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = and <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @or_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @or_3xi16(
 ; SI-NEXT:    [[R:%.*]] = or <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @or_3xi16(
@@ -2564,18 +2564,18 @@ define amdgpu_kernel void @or_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = or <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = or <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @xor_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @xor_3xi16(
 ; SI-NEXT:    [[R:%.*]] = xor <3 x i16> [[A:%.*]], [[B:%.*]]
-; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[R]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @xor_3xi16(
@@ -2583,11 +2583,11 @@ define amdgpu_kernel void @xor_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP2:%.*]] = zext <3 x i16> [[B:%.*]] to <3 x i32>
 ; VI-NEXT:    [[TMP3:%.*]] = xor <3 x i32> [[TMP1]], [[TMP2]]
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %r = xor <3 x i16> %a, %b
-  store volatile <3 x i16> %r, ptr addrspace(1) undef
+  store volatile <3 x i16> %r, ptr addrspace(1) poison
   ret void
 }
 
@@ -2595,7 +2595,7 @@ define amdgpu_kernel void @select_eq_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @select_eq_3xi16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp eq <3 x i16> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i16> [[A]], <3 x i16> [[B]]
-; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_eq_3xi16(
@@ -2606,12 +2606,12 @@ define amdgpu_kernel void @select_eq_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext <3 x i16> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp eq <3 x i16> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i16> %a, <3 x i16> %b
-  store volatile <3 x i16> %sel, ptr addrspace(1) undef
+  store volatile <3 x i16> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -2619,7 +2619,7 @@ define amdgpu_kernel void @select_ne_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @select_ne_3xi16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp ne <3 x i16> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i16> [[A]], <3 x i16> [[B]]
-; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_ne_3xi16(
@@ -2630,12 +2630,12 @@ define amdgpu_kernel void @select_ne_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext <3 x i16> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp ne <3 x i16> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i16> %a, <3 x i16> %b
-  store volatile <3 x i16> %sel, ptr addrspace(1) undef
+  store volatile <3 x i16> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -2643,7 +2643,7 @@ define amdgpu_kernel void @select_ugt_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @select_ugt_3xi16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp ugt <3 x i16> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i16> [[A]], <3 x i16> [[B]]
-; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_ugt_3xi16(
@@ -2654,12 +2654,12 @@ define amdgpu_kernel void @select_ugt_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext <3 x i16> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp ugt <3 x i16> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i16> %a, <3 x i16> %b
-  store volatile <3 x i16> %sel, ptr addrspace(1) undef
+  store volatile <3 x i16> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -2667,7 +2667,7 @@ define amdgpu_kernel void @select_uge_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @select_uge_3xi16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp uge <3 x i16> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i16> [[A]], <3 x i16> [[B]]
-; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_uge_3xi16(
@@ -2678,12 +2678,12 @@ define amdgpu_kernel void @select_uge_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext <3 x i16> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp uge <3 x i16> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i16> %a, <3 x i16> %b
-  store volatile <3 x i16> %sel, ptr addrspace(1) undef
+  store volatile <3 x i16> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -2691,7 +2691,7 @@ define amdgpu_kernel void @select_ult_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @select_ult_3xi16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp ult <3 x i16> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i16> [[A]], <3 x i16> [[B]]
-; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_ult_3xi16(
@@ -2702,12 +2702,12 @@ define amdgpu_kernel void @select_ult_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext <3 x i16> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp ult <3 x i16> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i16> %a, <3 x i16> %b
-  store volatile <3 x i16> %sel, ptr addrspace(1) undef
+  store volatile <3 x i16> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -2715,7 +2715,7 @@ define amdgpu_kernel void @select_ule_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @select_ule_3xi16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp ule <3 x i16> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i16> [[A]], <3 x i16> [[B]]
-; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_ule_3xi16(
@@ -2726,12 +2726,12 @@ define amdgpu_kernel void @select_ule_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = zext <3 x i16> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp ule <3 x i16> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i16> %a, <3 x i16> %b
-  store volatile <3 x i16> %sel, ptr addrspace(1) undef
+  store volatile <3 x i16> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -2739,7 +2739,7 @@ define amdgpu_kernel void @select_sgt_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @select_sgt_3xi16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp sgt <3 x i16> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i16> [[A]], <3 x i16> [[B]]
-; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_sgt_3xi16(
@@ -2750,12 +2750,12 @@ define amdgpu_kernel void @select_sgt_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = sext <3 x i16> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp sgt <3 x i16> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i16> %a, <3 x i16> %b
-  store volatile <3 x i16> %sel, ptr addrspace(1) undef
+  store volatile <3 x i16> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -2763,7 +2763,7 @@ define amdgpu_kernel void @select_sge_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @select_sge_3xi16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp sge <3 x i16> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i16> [[A]], <3 x i16> [[B]]
-; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_sge_3xi16(
@@ -2774,12 +2774,12 @@ define amdgpu_kernel void @select_sge_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = sext <3 x i16> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp sge <3 x i16> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i16> %a, <3 x i16> %b
-  store volatile <3 x i16> %sel, ptr addrspace(1) undef
+  store volatile <3 x i16> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -2787,7 +2787,7 @@ define amdgpu_kernel void @select_slt_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @select_slt_3xi16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp slt <3 x i16> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i16> [[A]], <3 x i16> [[B]]
-; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_slt_3xi16(
@@ -2798,12 +2798,12 @@ define amdgpu_kernel void @select_slt_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = sext <3 x i16> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp slt <3 x i16> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i16> %a, <3 x i16> %b
-  store volatile <3 x i16> %sel, ptr addrspace(1) undef
+  store volatile <3 x i16> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -2811,7 +2811,7 @@ define amdgpu_kernel void @select_sle_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; SI-LABEL: @select_sle_3xi16(
 ; SI-NEXT:    [[CMP:%.*]] = icmp sle <3 x i16> [[A:%.*]], [[B:%.*]]
 ; SI-NEXT:    [[SEL:%.*]] = select <3 x i1> [[CMP]], <3 x i16> [[A]], <3 x i16> [[B]]
-; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[SEL]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @select_sle_3xi16(
@@ -2822,12 +2822,12 @@ define amdgpu_kernel void @select_sle_3xi16(<3 x i16> %a, <3 x i16> %b) {
 ; VI-NEXT:    [[TMP5:%.*]] = sext <3 x i16> [[B]] to <3 x i32>
 ; VI-NEXT:    [[TMP6:%.*]] = select <3 x i1> [[TMP3]], <3 x i32> [[TMP4]], <3 x i32> [[TMP5]]
 ; VI-NEXT:    [[TMP7:%.*]] = trunc <3 x i32> [[TMP6]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP7]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %cmp = icmp sle <3 x i16> %a, %b
   %sel = select <3 x i1> %cmp, <3 x i16> %a, <3 x i16> %b
-  store volatile <3 x i16> %sel, ptr addrspace(1) undef
+  store volatile <3 x i16> %sel, ptr addrspace(1) poison
   ret void
 }
 
@@ -2836,7 +2836,7 @@ declare <3 x i16> @llvm.bitreverse.v3i16(<3 x i16>)
 define amdgpu_kernel void @bitreverse_3xi16(<3 x i16> %a) {
 ; SI-LABEL: @bitreverse_3xi16(
 ; SI-NEXT:    [[BREV:%.*]] = call <3 x i16> @llvm.bitreverse.v3i16(<3 x i16> [[A:%.*]])
-; SI-NEXT:    store volatile <3 x i16> [[BREV]], ptr addrspace(1) undef, align 8
+; SI-NEXT:    store volatile <3 x i16> [[BREV]], ptr addrspace(1) poison, align 8
 ; SI-NEXT:    ret void
 ;
 ; VI-LABEL: @bitreverse_3xi16(
@@ -2844,10 +2844,10 @@ define amdgpu_kernel void @bitreverse_3xi16(<3 x i16> %a) {
 ; VI-NEXT:    [[TMP2:%.*]] = call <3 x i32> @llvm.bitreverse.v3i32(<3 x i32> [[TMP1]])
 ; VI-NEXT:    [[TMP3:%.*]] = lshr <3 x i32> [[TMP2]], splat (i32 16)
 ; VI-NEXT:    [[TMP4:%.*]] = trunc <3 x i32> [[TMP3]] to <3 x i16>
-; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) undef, align 8
+; VI-NEXT:    store volatile <3 x i16> [[TMP4]], ptr addrspace(1) poison, align 8
 ; VI-NEXT:    ret void
 ;
   %brev = call <3 x i16> @llvm.bitreverse.v3i16(<3 x i16> %a)
-  store volatile <3 x i16> %brev, ptr addrspace(1) undef
+  store volatile <3 x i16> %brev, ptr addrspace(1) poison
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-late-codegenprepare.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-late-codegenprepare.ll
@@ -10,16 +10,16 @@ define amdgpu_kernel void @constant_from_offset_cast_generic_null() {
 ; GFX9-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) getelementptr (i8, ptr addrspace(4) addrspacecast (ptr null to ptr addrspace(4)), i64 4), align 4
 ; GFX9-NEXT:    [[TMP2:%.*]] = lshr i32 [[TMP1]], 16
 ; GFX9-NEXT:    [[TMP3:%.*]] = trunc i32 [[TMP2]] to i8
-; GFX9-NEXT:    store i8 [[TMP3]], ptr addrspace(1) undef, align 1
+; GFX9-NEXT:    store i8 [[TMP3]], ptr addrspace(1) poison, align 1
 ; GFX9-NEXT:    ret void
 ;
 ; GFX12-LABEL: @constant_from_offset_cast_generic_null(
 ; GFX12-NEXT:    [[LOAD:%.*]] = load i8, ptr addrspace(4) getelementptr inbounds (i8, ptr addrspace(4) addrspacecast (ptr null to ptr addrspace(4)), i64 6), align 1
-; GFX12-NEXT:    store i8 [[LOAD]], ptr addrspace(1) undef, align 1
+; GFX12-NEXT:    store i8 [[LOAD]], ptr addrspace(1) poison, align 1
 ; GFX12-NEXT:    ret void
 ;
   %load = load i8, ptr addrspace(4) getelementptr inbounds (i8, ptr addrspace(4) addrspacecast (ptr null to ptr addrspace(4)), i64 6), align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -28,16 +28,16 @@ define amdgpu_kernel void @constant_from_offset_cast_global_null() {
 ; GFX9-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) getelementptr (i8, ptr addrspace(4) addrspacecast (ptr addrspace(1) null to ptr addrspace(4)), i64 4), align 4
 ; GFX9-NEXT:    [[TMP2:%.*]] = lshr i32 [[TMP1]], 16
 ; GFX9-NEXT:    [[TMP3:%.*]] = trunc i32 [[TMP2]] to i8
-; GFX9-NEXT:    store i8 [[TMP3]], ptr addrspace(1) undef, align 1
+; GFX9-NEXT:    store i8 [[TMP3]], ptr addrspace(1) poison, align 1
 ; GFX9-NEXT:    ret void
 ;
 ; GFX12-LABEL: @constant_from_offset_cast_global_null(
 ; GFX12-NEXT:    [[LOAD:%.*]] = load i8, ptr addrspace(4) getelementptr inbounds (i8, ptr addrspace(4) addrspacecast (ptr addrspace(1) null to ptr addrspace(4)), i64 6), align 1
-; GFX12-NEXT:    store i8 [[LOAD]], ptr addrspace(1) undef, align 1
+; GFX12-NEXT:    store i8 [[LOAD]], ptr addrspace(1) poison, align 1
 ; GFX12-NEXT:    ret void
 ;
   %load = load i8, ptr addrspace(4) getelementptr inbounds (i8, ptr addrspace(4) addrspacecast (ptr addrspace(1) null to ptr addrspace(4)), i64 6), align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -48,16 +48,16 @@ define amdgpu_kernel void @constant_from_offset_cast_global_gv() {
 ; GFX9-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) getelementptr (i8, ptr addrspace(4) addrspacecast (ptr addrspace(1) @gv to ptr addrspace(4)), i64 4), align 4
 ; GFX9-NEXT:    [[TMP2:%.*]] = lshr i32 [[TMP1]], 16
 ; GFX9-NEXT:    [[TMP3:%.*]] = trunc i32 [[TMP2]] to i8
-; GFX9-NEXT:    store i8 [[TMP3]], ptr addrspace(1) undef, align 1
+; GFX9-NEXT:    store i8 [[TMP3]], ptr addrspace(1) poison, align 1
 ; GFX9-NEXT:    ret void
 ;
 ; GFX12-LABEL: @constant_from_offset_cast_global_gv(
 ; GFX12-NEXT:    [[LOAD:%.*]] = load i8, ptr addrspace(4) getelementptr inbounds (i8, ptr addrspace(4) addrspacecast (ptr addrspace(1) @gv to ptr addrspace(4)), i64 6), align 1
-; GFX12-NEXT:    store i8 [[LOAD]], ptr addrspace(1) undef, align 1
+; GFX12-NEXT:    store i8 [[LOAD]], ptr addrspace(1) poison, align 1
 ; GFX12-NEXT:    ret void
 ;
   %load = load i8, ptr addrspace(4) getelementptr inbounds (i8, ptr addrspace(4) addrspacecast (ptr addrspace(1) @gv to ptr addrspace(4)), i64 6), align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -66,32 +66,32 @@ define amdgpu_kernel void @constant_from_offset_cast_generic_inttoptr() {
 ; GFX9-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) getelementptr (i8, ptr addrspace(4) addrspacecast (ptr inttoptr (i64 128 to ptr) to ptr addrspace(4)), i64 4), align 4
 ; GFX9-NEXT:    [[TMP2:%.*]] = lshr i32 [[TMP1]], 16
 ; GFX9-NEXT:    [[TMP3:%.*]] = trunc i32 [[TMP2]] to i8
-; GFX9-NEXT:    store i8 [[TMP3]], ptr addrspace(1) undef, align 1
+; GFX9-NEXT:    store i8 [[TMP3]], ptr addrspace(1) poison, align 1
 ; GFX9-NEXT:    ret void
 ;
 ; GFX12-LABEL: @constant_from_offset_cast_generic_inttoptr(
 ; GFX12-NEXT:    [[LOAD:%.*]] = load i8, ptr addrspace(4) getelementptr inbounds (i8, ptr addrspace(4) addrspacecast (ptr inttoptr (i64 128 to ptr) to ptr addrspace(4)), i64 6), align 1
-; GFX12-NEXT:    store i8 [[LOAD]], ptr addrspace(1) undef, align 1
+; GFX12-NEXT:    store i8 [[LOAD]], ptr addrspace(1) poison, align 1
 ; GFX12-NEXT:    ret void
 ;
   %load = load i8, ptr addrspace(4) getelementptr inbounds (i8, ptr addrspace(4) addrspacecast (ptr inttoptr (i64 128 to ptr) to ptr addrspace(4)), i64 6), align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @constant_from_inttoptr() {
 ; GFX9-LABEL: @constant_from_inttoptr(
 ; GFX9-NEXT:    [[LOAD:%.*]] = load i8, ptr addrspace(4) inttoptr (i64 128 to ptr addrspace(4)), align 4
-; GFX9-NEXT:    store i8 [[LOAD]], ptr addrspace(1) undef, align 1
+; GFX9-NEXT:    store i8 [[LOAD]], ptr addrspace(1) poison, align 1
 ; GFX9-NEXT:    ret void
 ;
 ; GFX12-LABEL: @constant_from_inttoptr(
 ; GFX12-NEXT:    [[LOAD:%.*]] = load i8, ptr addrspace(4) inttoptr (i64 128 to ptr addrspace(4)), align 1
-; GFX12-NEXT:    store i8 [[LOAD]], ptr addrspace(1) undef, align 1
+; GFX12-NEXT:    store i8 [[LOAD]], ptr addrspace(1) poison, align 1
 ; GFX12-NEXT:    ret void
 ;
   %load = load i8, ptr addrspace(4) inttoptr (i64 128 to ptr addrspace(4)), align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-shader-calling-convention.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-shader-calling-convention.ll
@@ -17,6 +17,6 @@ define amdgpu_kernel void @kernel_cc(<4 x i32> inreg, <4 x i32> inreg, i32 inreg
   %vi = bitcast float %v to i32
   %x = add i32 %vi, %w
   %xf = bitcast i32 %x to float
-  store float %xf, ptr addrspace(1) undef
+  store float %xf, ptr addrspace(1) poison
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/annotate-kernel-features-hsa-call.ll
+++ b/llvm/test/CodeGen/AMDGPU/annotate-kernel-features-hsa-call.ll
@@ -22,17 +22,17 @@ define void @use_workitem_id_x() #1 {
 ; AKF_HSA-LABEL: define {{[^@]+}}@use_workitem_id_x
 ; AKF_HSA-SAME: () #[[ATTR1:[0-9]+]] {
 ; AKF_HSA-NEXT:    [[VAL:%.*]] = call i32 @llvm.amdgcn.workitem.id.x()
-; AKF_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) undef, align 4
+; AKF_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) poison, align 4
 ; AKF_HSA-NEXT:    ret void
 ;
 ; ATTRIBUTOR_HSA-LABEL: define {{[^@]+}}@use_workitem_id_x
 ; ATTRIBUTOR_HSA-SAME: () #[[ATTR1:[0-9]+]] {
 ; ATTRIBUTOR_HSA-NEXT:    [[VAL:%.*]] = call i32 @llvm.amdgcn.workitem.id.x()
-; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) undef, align 4
+; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) poison, align 4
 ; ATTRIBUTOR_HSA-NEXT:    ret void
 ;
   %val = call i32 @llvm.amdgcn.workitem.id.x()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -40,17 +40,17 @@ define void @use_workitem_id_y() #1 {
 ; AKF_HSA-LABEL: define {{[^@]+}}@use_workitem_id_y
 ; AKF_HSA-SAME: () #[[ATTR1]] {
 ; AKF_HSA-NEXT:    [[VAL:%.*]] = call i32 @llvm.amdgcn.workitem.id.y()
-; AKF_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) undef, align 4
+; AKF_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) poison, align 4
 ; AKF_HSA-NEXT:    ret void
 ;
 ; ATTRIBUTOR_HSA-LABEL: define {{[^@]+}}@use_workitem_id_y
 ; ATTRIBUTOR_HSA-SAME: () #[[ATTR2:[0-9]+]] {
 ; ATTRIBUTOR_HSA-NEXT:    [[VAL:%.*]] = call i32 @llvm.amdgcn.workitem.id.y()
-; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) undef, align 4
+; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) poison, align 4
 ; ATTRIBUTOR_HSA-NEXT:    ret void
 ;
   %val = call i32 @llvm.amdgcn.workitem.id.y()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -58,17 +58,17 @@ define void @use_workitem_id_z() #1 {
 ; AKF_HSA-LABEL: define {{[^@]+}}@use_workitem_id_z
 ; AKF_HSA-SAME: () #[[ATTR1]] {
 ; AKF_HSA-NEXT:    [[VAL:%.*]] = call i32 @llvm.amdgcn.workitem.id.z()
-; AKF_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) undef, align 4
+; AKF_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) poison, align 4
 ; AKF_HSA-NEXT:    ret void
 ;
 ; ATTRIBUTOR_HSA-LABEL: define {{[^@]+}}@use_workitem_id_z
 ; ATTRIBUTOR_HSA-SAME: () #[[ATTR3:[0-9]+]] {
 ; ATTRIBUTOR_HSA-NEXT:    [[VAL:%.*]] = call i32 @llvm.amdgcn.workitem.id.z()
-; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) undef, align 4
+; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) poison, align 4
 ; ATTRIBUTOR_HSA-NEXT:    ret void
 ;
   %val = call i32 @llvm.amdgcn.workitem.id.z()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -76,17 +76,17 @@ define void @use_workgroup_id_x() #1 {
 ; AKF_HSA-LABEL: define {{[^@]+}}@use_workgroup_id_x
 ; AKF_HSA-SAME: () #[[ATTR1]] {
 ; AKF_HSA-NEXT:    [[VAL:%.*]] = call i32 @llvm.amdgcn.workgroup.id.x()
-; AKF_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) undef, align 4
+; AKF_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) poison, align 4
 ; AKF_HSA-NEXT:    ret void
 ;
 ; ATTRIBUTOR_HSA-LABEL: define {{[^@]+}}@use_workgroup_id_x
 ; ATTRIBUTOR_HSA-SAME: () #[[ATTR4:[0-9]+]] {
 ; ATTRIBUTOR_HSA-NEXT:    [[VAL:%.*]] = call i32 @llvm.amdgcn.workgroup.id.x()
-; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) undef, align 4
+; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) poison, align 4
 ; ATTRIBUTOR_HSA-NEXT:    ret void
 ;
   %val = call i32 @llvm.amdgcn.workgroup.id.x()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -94,17 +94,17 @@ define void @use_workgroup_id_y() #1 {
 ; AKF_HSA-LABEL: define {{[^@]+}}@use_workgroup_id_y
 ; AKF_HSA-SAME: () #[[ATTR1]] {
 ; AKF_HSA-NEXT:    [[VAL:%.*]] = call i32 @llvm.amdgcn.workgroup.id.y()
-; AKF_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) undef, align 4
+; AKF_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) poison, align 4
 ; AKF_HSA-NEXT:    ret void
 ;
 ; ATTRIBUTOR_HSA-LABEL: define {{[^@]+}}@use_workgroup_id_y
 ; ATTRIBUTOR_HSA-SAME: () #[[ATTR5:[0-9]+]] {
 ; ATTRIBUTOR_HSA-NEXT:    [[VAL:%.*]] = call i32 @llvm.amdgcn.workgroup.id.y()
-; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) undef, align 4
+; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) poison, align 4
 ; ATTRIBUTOR_HSA-NEXT:    ret void
 ;
   %val = call i32 @llvm.amdgcn.workgroup.id.y()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -112,17 +112,17 @@ define void @use_workgroup_id_z() #1 {
 ; AKF_HSA-LABEL: define {{[^@]+}}@use_workgroup_id_z
 ; AKF_HSA-SAME: () #[[ATTR1]] {
 ; AKF_HSA-NEXT:    [[VAL:%.*]] = call i32 @llvm.amdgcn.workgroup.id.z()
-; AKF_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) undef, align 4
+; AKF_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) poison, align 4
 ; AKF_HSA-NEXT:    ret void
 ;
 ; ATTRIBUTOR_HSA-LABEL: define {{[^@]+}}@use_workgroup_id_z
 ; ATTRIBUTOR_HSA-SAME: () #[[ATTR6:[0-9]+]] {
 ; ATTRIBUTOR_HSA-NEXT:    [[VAL:%.*]] = call i32 @llvm.amdgcn.workgroup.id.z()
-; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) undef, align 4
+; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) poison, align 4
 ; ATTRIBUTOR_HSA-NEXT:    ret void
 ;
   %val = call i32 @llvm.amdgcn.workgroup.id.z()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -130,17 +130,17 @@ define void @use_dispatch_ptr() #1 {
 ; AKF_HSA-LABEL: define {{[^@]+}}@use_dispatch_ptr
 ; AKF_HSA-SAME: () #[[ATTR1]] {
 ; AKF_HSA-NEXT:    [[DISPATCH_PTR:%.*]] = call ptr addrspace(4) @llvm.amdgcn.dispatch.ptr()
-; AKF_HSA-NEXT:    store volatile ptr addrspace(4) [[DISPATCH_PTR]], ptr addrspace(1) undef, align 8
+; AKF_HSA-NEXT:    store volatile ptr addrspace(4) [[DISPATCH_PTR]], ptr addrspace(1) poison, align 8
 ; AKF_HSA-NEXT:    ret void
 ;
 ; ATTRIBUTOR_HSA-LABEL: define {{[^@]+}}@use_dispatch_ptr
 ; ATTRIBUTOR_HSA-SAME: () #[[ATTR7:[0-9]+]] {
 ; ATTRIBUTOR_HSA-NEXT:    [[DISPATCH_PTR:%.*]] = call ptr addrspace(4) @llvm.amdgcn.dispatch.ptr()
-; ATTRIBUTOR_HSA-NEXT:    store volatile ptr addrspace(4) [[DISPATCH_PTR]], ptr addrspace(1) undef, align 8
+; ATTRIBUTOR_HSA-NEXT:    store volatile ptr addrspace(4) [[DISPATCH_PTR]], ptr addrspace(1) poison, align 8
 ; ATTRIBUTOR_HSA-NEXT:    ret void
 ;
   %dispatch.ptr = call ptr addrspace(4) @llvm.amdgcn.dispatch.ptr()
-  store volatile ptr addrspace(4) %dispatch.ptr, ptr addrspace(1) undef
+  store volatile ptr addrspace(4) %dispatch.ptr, ptr addrspace(1) poison
   ret void
 }
 
@@ -148,17 +148,17 @@ define void @use_queue_ptr() #1 {
 ; AKF_HSA-LABEL: define {{[^@]+}}@use_queue_ptr
 ; AKF_HSA-SAME: () #[[ATTR1]] {
 ; AKF_HSA-NEXT:    [[QUEUE_PTR:%.*]] = call ptr addrspace(4) @llvm.amdgcn.queue.ptr()
-; AKF_HSA-NEXT:    store volatile ptr addrspace(4) [[QUEUE_PTR]], ptr addrspace(1) undef, align 8
+; AKF_HSA-NEXT:    store volatile ptr addrspace(4) [[QUEUE_PTR]], ptr addrspace(1) poison, align 8
 ; AKF_HSA-NEXT:    ret void
 ;
 ; ATTRIBUTOR_HSA-LABEL: define {{[^@]+}}@use_queue_ptr
 ; ATTRIBUTOR_HSA-SAME: () #[[ATTR8:[0-9]+]] {
 ; ATTRIBUTOR_HSA-NEXT:    [[QUEUE_PTR:%.*]] = call ptr addrspace(4) @llvm.amdgcn.queue.ptr()
-; ATTRIBUTOR_HSA-NEXT:    store volatile ptr addrspace(4) [[QUEUE_PTR]], ptr addrspace(1) undef, align 8
+; ATTRIBUTOR_HSA-NEXT:    store volatile ptr addrspace(4) [[QUEUE_PTR]], ptr addrspace(1) poison, align 8
 ; ATTRIBUTOR_HSA-NEXT:    ret void
 ;
   %queue.ptr = call ptr addrspace(4) @llvm.amdgcn.queue.ptr()
-  store volatile ptr addrspace(4) %queue.ptr, ptr addrspace(1) undef
+  store volatile ptr addrspace(4) %queue.ptr, ptr addrspace(1) poison
   ret void
 }
 
@@ -166,17 +166,17 @@ define void @use_dispatch_id() #1 {
 ; AKF_HSA-LABEL: define {{[^@]+}}@use_dispatch_id
 ; AKF_HSA-SAME: () #[[ATTR1]] {
 ; AKF_HSA-NEXT:    [[VAL:%.*]] = call i64 @llvm.amdgcn.dispatch.id()
-; AKF_HSA-NEXT:    store volatile i64 [[VAL]], ptr addrspace(1) undef, align 8
+; AKF_HSA-NEXT:    store volatile i64 [[VAL]], ptr addrspace(1) poison, align 8
 ; AKF_HSA-NEXT:    ret void
 ;
 ; ATTRIBUTOR_HSA-LABEL: define {{[^@]+}}@use_dispatch_id
 ; ATTRIBUTOR_HSA-SAME: () #[[ATTR9:[0-9]+]] {
 ; ATTRIBUTOR_HSA-NEXT:    [[VAL:%.*]] = call i64 @llvm.amdgcn.dispatch.id()
-; ATTRIBUTOR_HSA-NEXT:    store volatile i64 [[VAL]], ptr addrspace(1) undef, align 8
+; ATTRIBUTOR_HSA-NEXT:    store volatile i64 [[VAL]], ptr addrspace(1) poison, align 8
 ; ATTRIBUTOR_HSA-NEXT:    ret void
 ;
   %val = call i64 @llvm.amdgcn.dispatch.id()
-  store volatile i64 %val, ptr addrspace(1) undef
+  store volatile i64 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -185,22 +185,22 @@ define void @use_workgroup_id_y_workgroup_id_z() #1 {
 ; AKF_HSA-SAME: () #[[ATTR1]] {
 ; AKF_HSA-NEXT:    [[VAL0:%.*]] = call i32 @llvm.amdgcn.workgroup.id.y()
 ; AKF_HSA-NEXT:    [[VAL1:%.*]] = call i32 @llvm.amdgcn.workgroup.id.z()
-; AKF_HSA-NEXT:    store volatile i32 [[VAL0]], ptr addrspace(1) undef, align 4
-; AKF_HSA-NEXT:    store volatile i32 [[VAL1]], ptr addrspace(1) undef, align 4
+; AKF_HSA-NEXT:    store volatile i32 [[VAL0]], ptr addrspace(1) poison, align 4
+; AKF_HSA-NEXT:    store volatile i32 [[VAL1]], ptr addrspace(1) poison, align 4
 ; AKF_HSA-NEXT:    ret void
 ;
 ; ATTRIBUTOR_HSA-LABEL: define {{[^@]+}}@use_workgroup_id_y_workgroup_id_z
 ; ATTRIBUTOR_HSA-SAME: () #[[ATTR10:[0-9]+]] {
 ; ATTRIBUTOR_HSA-NEXT:    [[VAL0:%.*]] = call i32 @llvm.amdgcn.workgroup.id.y()
 ; ATTRIBUTOR_HSA-NEXT:    [[VAL1:%.*]] = call i32 @llvm.amdgcn.workgroup.id.z()
-; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL0]], ptr addrspace(1) undef, align 4
-; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL1]], ptr addrspace(1) undef, align 4
+; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL0]], ptr addrspace(1) poison, align 4
+; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL1]], ptr addrspace(1) poison, align 4
 ; ATTRIBUTOR_HSA-NEXT:    ret void
 ;
   %val0 = call i32 @llvm.amdgcn.workgroup.id.y()
   %val1 = call i32 @llvm.amdgcn.workgroup.id.z()
-  store volatile i32 %val0, ptr addrspace(1) undef
-  store volatile i32 %val1, ptr addrspace(1) undef
+  store volatile i32 %val0, ptr addrspace(1) poison
+  store volatile i32 %val1, ptr addrspace(1) poison
   ret void
 }
 
@@ -418,19 +418,19 @@ define void @recursive_use_workitem_id_y() #1 {
 ; AKF_HSA-LABEL: define {{[^@]+}}@recursive_use_workitem_id_y
 ; AKF_HSA-SAME: () #[[ATTR1]] {
 ; AKF_HSA-NEXT:    [[VAL:%.*]] = call i32 @llvm.amdgcn.workitem.id.y()
-; AKF_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) undef, align 4
+; AKF_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) poison, align 4
 ; AKF_HSA-NEXT:    call void @recursive_use_workitem_id_y()
 ; AKF_HSA-NEXT:    ret void
 ;
 ; ATTRIBUTOR_HSA-LABEL: define {{[^@]+}}@recursive_use_workitem_id_y
 ; ATTRIBUTOR_HSA-SAME: () #[[ATTR2]] {
 ; ATTRIBUTOR_HSA-NEXT:    [[VAL:%.*]] = call i32 @llvm.amdgcn.workitem.id.y()
-; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) undef, align 4
+; ATTRIBUTOR_HSA-NEXT:    store volatile i32 [[VAL]], ptr addrspace(1) poison, align 4
 ; ATTRIBUTOR_HSA-NEXT:    call void @recursive_use_workitem_id_y()
 ; ATTRIBUTOR_HSA-NEXT:    ret void
 ;
   %val = call i32 @llvm.amdgcn.workitem.id.y()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   call void @recursive_use_workitem_id_y()
   ret void
 }
@@ -557,17 +557,17 @@ define void @use_kernarg_segment_ptr() #1 {
 ; AKF_HSA-LABEL: define {{[^@]+}}@use_kernarg_segment_ptr
 ; AKF_HSA-SAME: () #[[ATTR1]] {
 ; AKF_HSA-NEXT:    [[KERNARG_SEGMENT_PTR:%.*]] = call ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
-; AKF_HSA-NEXT:    store volatile ptr addrspace(4) [[KERNARG_SEGMENT_PTR]], ptr addrspace(1) undef, align 8
+; AKF_HSA-NEXT:    store volatile ptr addrspace(4) [[KERNARG_SEGMENT_PTR]], ptr addrspace(1) poison, align 8
 ; AKF_HSA-NEXT:    ret void
 ;
 ; ATTRIBUTOR_HSA-LABEL: define {{[^@]+}}@use_kernarg_segment_ptr
 ; ATTRIBUTOR_HSA-SAME: () #[[ATTR11]] {
 ; ATTRIBUTOR_HSA-NEXT:    [[KERNARG_SEGMENT_PTR:%.*]] = call ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
-; ATTRIBUTOR_HSA-NEXT:    store volatile ptr addrspace(4) [[KERNARG_SEGMENT_PTR]], ptr addrspace(1) undef, align 8
+; ATTRIBUTOR_HSA-NEXT:    store volatile ptr addrspace(4) [[KERNARG_SEGMENT_PTR]], ptr addrspace(1) poison, align 8
 ; ATTRIBUTOR_HSA-NEXT:    ret void
 ;
   %kernarg.segment.ptr = call ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
-  store volatile ptr addrspace(4) %kernarg.segment.ptr, ptr addrspace(1) undef
+  store volatile ptr addrspace(4) %kernarg.segment.ptr, ptr addrspace(1) poison
   ret void
 }
 define void @func_indirect_use_kernarg_segment_ptr() #1 {
@@ -589,17 +589,17 @@ define amdgpu_kernel void @kern_use_implicitarg_ptr() #1 {
 ; AKF_HSA-LABEL: define {{[^@]+}}@kern_use_implicitarg_ptr
 ; AKF_HSA-SAME: () #[[ATTR1]] {
 ; AKF_HSA-NEXT:    [[IMPLICITARG_PTR:%.*]] = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
-; AKF_HSA-NEXT:    store volatile ptr addrspace(4) [[IMPLICITARG_PTR]], ptr addrspace(1) undef, align 8
+; AKF_HSA-NEXT:    store volatile ptr addrspace(4) [[IMPLICITARG_PTR]], ptr addrspace(1) poison, align 8
 ; AKF_HSA-NEXT:    ret void
 ;
 ; ATTRIBUTOR_HSA-LABEL: define {{[^@]+}}@kern_use_implicitarg_ptr
 ; ATTRIBUTOR_HSA-SAME: () #[[ATTR12]] {
 ; ATTRIBUTOR_HSA-NEXT:    [[IMPLICITARG_PTR:%.*]] = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
-; ATTRIBUTOR_HSA-NEXT:    store volatile ptr addrspace(4) [[IMPLICITARG_PTR]], ptr addrspace(1) undef, align 8
+; ATTRIBUTOR_HSA-NEXT:    store volatile ptr addrspace(4) [[IMPLICITARG_PTR]], ptr addrspace(1) poison, align 8
 ; ATTRIBUTOR_HSA-NEXT:    ret void
 ;
   %implicitarg.ptr = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
-  store volatile ptr addrspace(4) %implicitarg.ptr, ptr addrspace(1) undef
+  store volatile ptr addrspace(4) %implicitarg.ptr, ptr addrspace(1) poison
   ret void
 }
 
@@ -607,17 +607,17 @@ define void @use_implicitarg_ptr() #1 {
 ; AKF_HSA-LABEL: define {{[^@]+}}@use_implicitarg_ptr
 ; AKF_HSA-SAME: () #[[ATTR1]] {
 ; AKF_HSA-NEXT:    [[IMPLICITARG_PTR:%.*]] = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
-; AKF_HSA-NEXT:    store volatile ptr addrspace(4) [[IMPLICITARG_PTR]], ptr addrspace(1) undef, align 8
+; AKF_HSA-NEXT:    store volatile ptr addrspace(4) [[IMPLICITARG_PTR]], ptr addrspace(1) poison, align 8
 ; AKF_HSA-NEXT:    ret void
 ;
 ; ATTRIBUTOR_HSA-LABEL: define {{[^@]+}}@use_implicitarg_ptr
 ; ATTRIBUTOR_HSA-SAME: () #[[ATTR12]] {
 ; ATTRIBUTOR_HSA-NEXT:    [[IMPLICITARG_PTR:%.*]] = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
-; ATTRIBUTOR_HSA-NEXT:    store volatile ptr addrspace(4) [[IMPLICITARG_PTR]], ptr addrspace(1) undef, align 8
+; ATTRIBUTOR_HSA-NEXT:    store volatile ptr addrspace(4) [[IMPLICITARG_PTR]], ptr addrspace(1) poison, align 8
 ; ATTRIBUTOR_HSA-NEXT:    ret void
 ;
   %implicitarg.ptr = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
-  store volatile ptr addrspace(4) %implicitarg.ptr, ptr addrspace(1) undef
+  store volatile ptr addrspace(4) %implicitarg.ptr, ptr addrspace(1) poison
   ret void
 }
 
@@ -729,17 +729,17 @@ define i32 @use_dispatch_ptr_ret_type() #1 {
 ; AKF_HSA-LABEL: define {{[^@]+}}@use_dispatch_ptr_ret_type
 ; AKF_HSA-SAME: () #[[ATTR1]] {
 ; AKF_HSA-NEXT:    [[DISPATCH_PTR:%.*]] = call ptr addrspace(4) @llvm.amdgcn.dispatch.ptr()
-; AKF_HSA-NEXT:    store volatile ptr addrspace(4) [[DISPATCH_PTR]], ptr addrspace(1) undef, align 8
+; AKF_HSA-NEXT:    store volatile ptr addrspace(4) [[DISPATCH_PTR]], ptr addrspace(1) poison, align 8
 ; AKF_HSA-NEXT:    ret i32 0
 ;
 ; ATTRIBUTOR_HSA-LABEL: define {{[^@]+}}@use_dispatch_ptr_ret_type
 ; ATTRIBUTOR_HSA-SAME: () #[[ATTR7]] {
 ; ATTRIBUTOR_HSA-NEXT:    [[DISPATCH_PTR:%.*]] = call ptr addrspace(4) @llvm.amdgcn.dispatch.ptr()
-; ATTRIBUTOR_HSA-NEXT:    store volatile ptr addrspace(4) [[DISPATCH_PTR]], ptr addrspace(1) undef, align 8
+; ATTRIBUTOR_HSA-NEXT:    store volatile ptr addrspace(4) [[DISPATCH_PTR]], ptr addrspace(1) poison, align 8
 ; ATTRIBUTOR_HSA-NEXT:    ret i32 0
 ;
   %dispatch.ptr = call ptr addrspace(4) @llvm.amdgcn.dispatch.ptr()
-  store volatile ptr addrspace(4) %dispatch.ptr, ptr addrspace(1) undef
+  store volatile ptr addrspace(4) %dispatch.ptr, ptr addrspace(1) poison
   ret i32 0
 }
 

--- a/llvm/test/CodeGen/AMDGPU/annotate-kernel-features-hsa.ll
+++ b/llvm/test/CodeGen/AMDGPU/annotate-kernel-features-hsa.ll
@@ -530,19 +530,19 @@ define amdgpu_kernel void @use_is_shared(ptr %ptr) #1 {
 ; AKF_HSA-SAME: (ptr [[PTR:%.*]]) #[[ATTR1]] {
 ; AKF_HSA-NEXT:    [[IS_SHARED:%.*]] = call i1 @llvm.amdgcn.is.shared(ptr [[PTR]])
 ; AKF_HSA-NEXT:    [[EXT:%.*]] = zext i1 [[IS_SHARED]] to i32
-; AKF_HSA-NEXT:    store i32 [[EXT]], ptr addrspace(1) undef, align 4
+; AKF_HSA-NEXT:    store i32 [[EXT]], ptr addrspace(1) poison, align 4
 ; AKF_HSA-NEXT:    ret void
 ;
 ; ATTRIBUTOR_HSA-LABEL: define {{[^@]+}}@use_is_shared
 ; ATTRIBUTOR_HSA-SAME: (ptr [[PTR:%.*]]) #[[ATTR12]] {
 ; ATTRIBUTOR_HSA-NEXT:    [[IS_SHARED:%.*]] = call i1 @llvm.amdgcn.is.shared(ptr [[PTR]])
 ; ATTRIBUTOR_HSA-NEXT:    [[EXT:%.*]] = zext i1 [[IS_SHARED]] to i32
-; ATTRIBUTOR_HSA-NEXT:    store i32 [[EXT]], ptr addrspace(1) undef, align 4
+; ATTRIBUTOR_HSA-NEXT:    store i32 [[EXT]], ptr addrspace(1) poison, align 4
 ; ATTRIBUTOR_HSA-NEXT:    ret void
 ;
   %is.shared = call i1 @llvm.amdgcn.is.shared(ptr %ptr)
   %ext = zext i1 %is.shared to i32
-  store i32 %ext, ptr addrspace(1) undef
+  store i32 %ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -551,19 +551,19 @@ define amdgpu_kernel void @use_is_private(ptr %ptr) #1 {
 ; AKF_HSA-SAME: (ptr [[PTR:%.*]]) #[[ATTR1]] {
 ; AKF_HSA-NEXT:    [[IS_PRIVATE:%.*]] = call i1 @llvm.amdgcn.is.private(ptr [[PTR]])
 ; AKF_HSA-NEXT:    [[EXT:%.*]] = zext i1 [[IS_PRIVATE]] to i32
-; AKF_HSA-NEXT:    store i32 [[EXT]], ptr addrspace(1) undef, align 4
+; AKF_HSA-NEXT:    store i32 [[EXT]], ptr addrspace(1) poison, align 4
 ; AKF_HSA-NEXT:    ret void
 ;
 ; ATTRIBUTOR_HSA-LABEL: define {{[^@]+}}@use_is_private
 ; ATTRIBUTOR_HSA-SAME: (ptr [[PTR:%.*]]) #[[ATTR12]] {
 ; ATTRIBUTOR_HSA-NEXT:    [[IS_PRIVATE:%.*]] = call i1 @llvm.amdgcn.is.private(ptr [[PTR]])
 ; ATTRIBUTOR_HSA-NEXT:    [[EXT:%.*]] = zext i1 [[IS_PRIVATE]] to i32
-; ATTRIBUTOR_HSA-NEXT:    store i32 [[EXT]], ptr addrspace(1) undef, align 4
+; ATTRIBUTOR_HSA-NEXT:    store i32 [[EXT]], ptr addrspace(1) poison, align 4
 ; ATTRIBUTOR_HSA-NEXT:    ret void
 ;
   %is.private = call i1 @llvm.amdgcn.is.private(ptr %ptr)
   %ext = zext i1 %is.private to i32
-  store i32 %ext, ptr addrspace(1) undef
+  store i32 %ext, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/anyext.ll
+++ b/llvm/test/CodeGen/AMDGPU/anyext.ll
@@ -186,7 +186,7 @@ define amdgpu_kernel void @anyext_v2i16_to_v2i32() #0 {
 ; GFX9-NEXT:    buffer_store_byte v0, off, s[0:3], 0
 ; GFX9-NEXT:    s_endpgm
 bb:
-  %tmp = load i16, ptr addrspace(1) undef, align 2
+  %tmp = load i16, ptr addrspace(1) poison, align 2
   %tmp2 = insertelement <2 x i16> poison, i16 %tmp, i32 1
   %tmp4 = and <2 x i16> %tmp2, <i16 -32767, i16 -32767>
   %tmp5 = zext <2 x i16> %tmp4 to <2 x i32>
@@ -196,7 +196,7 @@ bb:
   %tmp10 = fcmp oeq <2 x float> %tmp8, zeroinitializer
   %tmp11 = zext <2 x i1> %tmp10 to <2 x i8>
   %tmp12 = extractelement <2 x i8> %tmp11, i32 1
-  store i8 %tmp12, ptr addrspace(1) undef, align 1
+  store i8 %tmp12, ptr addrspace(1) poison, align 1
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/attr-amdgpu-num-sgpr.ll
+++ b/llvm/test/CodeGen/AMDGPU/attr-amdgpu-num-sgpr.ll
@@ -19,17 +19,17 @@ define amdgpu_kernel void @max_10_sgprs() #0 {
   %ten = load volatile i32, ptr addrspace(4) undef
   %eleven = load volatile i32, ptr addrspace(4) undef
   call void asm sideeffect "", "s,s,s,s,s,s,s,s,s,s"(i32 %one, i32 %two, i32 %three, i32 %four, i32 %five, i32 %six, i32 %seven, i32 %eight, i32 %nine, i32 %ten)
-  store volatile i32 %one, ptr addrspace(1) undef
-  store volatile i32 %two, ptr addrspace(1) undef
-  store volatile i32 %three, ptr addrspace(1) undef
-  store volatile i32 %four, ptr addrspace(1) undef
-  store volatile i32 %five, ptr addrspace(1) undef
-  store volatile i32 %six, ptr addrspace(1) undef
-  store volatile i32 %seven, ptr addrspace(1) undef
-  store volatile i32 %eight, ptr addrspace(1) undef
-  store volatile i32 %nine, ptr addrspace(1) undef
-  store volatile i32 %ten, ptr addrspace(1) undef
-  store volatile i32 %eleven, ptr addrspace(1) undef
+  store volatile i32 %one, ptr addrspace(1) poison
+  store volatile i32 %two, ptr addrspace(1) poison
+  store volatile i32 %three, ptr addrspace(1) poison
+  store volatile i32 %four, ptr addrspace(1) poison
+  store volatile i32 %five, ptr addrspace(1) poison
+  store volatile i32 %six, ptr addrspace(1) poison
+  store volatile i32 %seven, ptr addrspace(1) poison
+  store volatile i32 %eight, ptr addrspace(1) poison
+  store volatile i32 %nine, ptr addrspace(1) poison
+  store volatile i32 %ten, ptr addrspace(1) poison
+  store volatile i32 %eleven, ptr addrspace(1) poison
   ret void
 }
 
@@ -72,12 +72,12 @@ define amdgpu_kernel void @max_10_sgprs() #0 {
 ;  br label %stores
 ;
 ;stores:
-;  store volatile i32 %x.0, ptr addrspace(1) undef
-;  store volatile i32 %x.0, ptr addrspace(1) undef
-;  store volatile i32 %x.0, ptr addrspace(1) undef
-;  store volatile i64 %x.3, ptr addrspace(1) undef
-;  store volatile ptr addrspace(4) %x.4, ptr addrspace(1) undef
-;  store volatile ptr addrspace(4) %x.5, ptr addrspace(1) undef
+;  store volatile i32 %x.0, ptr addrspace(1) poison
+;  store volatile i32 %x.0, ptr addrspace(1) poison
+;  store volatile i32 %x.0, ptr addrspace(1) poison
+;  store volatile i64 %x.3, ptr addrspace(1) poison
+;  store volatile ptr addrspace(4) %x.4, ptr addrspace(1) poison
+;  store volatile ptr addrspace(4) %x.5, ptr addrspace(1) poison
 ;
 ;  store i32 %one, ptr addrspace(1) %out1
 ;  store i32 %two, ptr addrspace(1) %out2
@@ -101,15 +101,15 @@ define amdgpu_kernel void @max_10_sgprs() #0 {
 ;                                        i32 %one, i32 %two, i32 %three, i32 %four) #2 {
 ;  store volatile i32 0, ptr undef
 ;  %x.0 = call i32 @llvm.amdgcn.workgroup.id.x()
-;  store volatile i32 %x.0, ptr addrspace(1) undef
+;  store volatile i32 %x.0, ptr addrspace(1) poison
 ;  %x.1 = call i32 @llvm.amdgcn.workgroup.id.y()
-;  store volatile i32 %x.0, ptr addrspace(1) undef
+;  store volatile i32 %x.0, ptr addrspace(1) poison
 ;  %x.2 = call i32 @llvm.amdgcn.workgroup.id.z()
-;  store volatile i32 %x.0, ptr addrspace(1) undef
+;  store volatile i32 %x.0, ptr addrspace(1) poison
 ;  %x.3 = call i64 @llvm.amdgcn.dispatch.id()
-;  store volatile i64 %x.3, ptr addrspace(1) undef
+;  store volatile i64 %x.3, ptr addrspace(1) poison
 ;  %x.4 = call ptr addrspace(4) @llvm.amdgcn.dispatch.ptr()
-;  store volatile ptr addrspace(4) %x.4, ptr addrspace(1) undef
+;  store volatile ptr addrspace(4) %x.4, ptr addrspace(1) poison
 ;
 ;  store i32 %one, ptr addrspace(1) %out1
 ;  store i32 %two, ptr addrspace(1) %out2

--- a/llvm/test/CodeGen/AMDGPU/bfe-patterns.ll
+++ b/llvm/test/CodeGen/AMDGPU/bfe-patterns.ll
@@ -112,7 +112,7 @@ define amdgpu_kernel void @v_ubfe_sub_multi_use_shl_i32(ptr addrspace(1) %out, p
   %shl = shl i32 %src, %sub
   %bfe = lshr i32 %shl, %sub
   store i32 %bfe, ptr addrspace(1) %out.gep
-  store volatile i32 %shl, ptr addrspace(1) undef
+  store volatile i32 %shl, ptr addrspace(1) poison
   ret void
 }
 
@@ -200,7 +200,7 @@ define amdgpu_kernel void @s_ubfe_sub_multi_use_shl_i32(ptr addrspace(1) %out, i
   %shl = shl i32 %src, %sub
   %bfe = lshr i32 %shl, %sub
   store i32 %bfe, ptr addrspace(1) %out.gep
-  store volatile i32 %shl, ptr addrspace(1) undef
+  store volatile i32 %shl, ptr addrspace(1) poison
   ret void
 }
 
@@ -314,7 +314,7 @@ define amdgpu_kernel void @v_sbfe_sub_multi_use_shl_i32(ptr addrspace(1) %out, p
   %shl = shl i32 %src, %sub
   %bfe = ashr i32 %shl, %sub
   store i32 %bfe, ptr addrspace(1) %out.gep
-  store volatile i32 %shl, ptr addrspace(1) undef
+  store volatile i32 %shl, ptr addrspace(1) poison
   ret void
 }
 
@@ -402,7 +402,7 @@ define amdgpu_kernel void @s_sbfe_sub_multi_use_shl_i32(ptr addrspace(1) %out, i
   %shl = shl i32 %src, %sub
   %bfe = ashr i32 %shl, %sub
   store i32 %bfe, ptr addrspace(1) %out.gep
-  store volatile i32 %shl, ptr addrspace(1) undef
+  store volatile i32 %shl, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/bfi_int.ll
+++ b/llvm/test/CodeGen/AMDGPU/bfi_int.ll
@@ -1483,7 +1483,7 @@ define amdgpu_kernel void @s_bitselect_i64_pat_0(i64 %a, i64 %b, i64 %mask) {
   %and1 = and i64 %not.a, %mask
   %bitselect = or i64 %and0, %and1
   %scalar.use = add i64 %bitselect, 10
-  store i64 %scalar.use, ptr addrspace(1) undef
+  store i64 %scalar.use, ptr addrspace(1) poison
   ret void
 }
 
@@ -1571,7 +1571,7 @@ define amdgpu_kernel void @s_bitselect_i64_pat_1(i64 %a, i64 %b, i64 %mask) {
   %bitselect = xor i64 %and, %mask
 
   %scalar.use = add i64 %bitselect, 10
-  store i64 %scalar.use, ptr addrspace(1) undef
+  store i64 %scalar.use, ptr addrspace(1) poison
   ret void
 }
 
@@ -1659,7 +1659,7 @@ define amdgpu_kernel void @s_bitselect_i64_pat_2(i64 %a, i64 %b, i64 %mask) {
   %bitselect = xor i64 %and, %mask
 
   %scalar.use = add i64 %bitselect, 10
-  store i64 %scalar.use, ptr addrspace(1) undef
+  store i64 %scalar.use, ptr addrspace(1) poison
   ret void
 }
 
@@ -1754,6 +1754,6 @@ entry:
   %or1 = or i64 %and0, %and1
 
   %scalar.use = add i64 %or1, 10
-  store i64 %scalar.use, ptr addrspace(1) undef
+  store i64 %scalar.use, ptr addrspace(1) poison
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/bfi_int.r600.ll
+++ b/llvm/test/CodeGen/AMDGPU/bfi_int.r600.ll
@@ -149,7 +149,7 @@ define amdgpu_kernel void @s_bitselect_i64_pat_0(i64 %a, i64 %b, i64 %mask) {
   %and1 = and i64 %not.a, %mask
   %bitselect = or i64 %and0, %and1
   %scalar.use = add i64 %bitselect, 10
-  store i64 %scalar.use, ptr addrspace(1) undef
+  store i64 %scalar.use, ptr addrspace(1) poison
   ret void
 }
 
@@ -176,7 +176,7 @@ define amdgpu_kernel void @s_bitselect_i64_pat_1(i64 %a, i64 %b, i64 %mask) {
   %bitselect = xor i64 %and, %mask
 
   %scalar.use = add i64 %bitselect, 10
-  store i64 %scalar.use, ptr addrspace(1) undef
+  store i64 %scalar.use, ptr addrspace(1) poison
   ret void
 }
 
@@ -203,7 +203,7 @@ define amdgpu_kernel void @s_bitselect_i64_pat_2(i64 %a, i64 %b, i64 %mask) {
   %bitselect = xor i64 %and, %mask
 
   %scalar.use = add i64 %bitselect, 10
-  store i64 %scalar.use, ptr addrspace(1) undef
+  store i64 %scalar.use, ptr addrspace(1) poison
   ret void
 }
 
@@ -232,6 +232,6 @@ entry:
   %or1 = or i64 %and0, %and1
 
   %scalar.use = add i64 %or1, 10
-  store i64 %scalar.use, ptr addrspace(1) undef
+  store i64 %scalar.use, ptr addrspace(1) poison
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/branch-relaxation.ll
+++ b/llvm/test/CodeGen/AMDGPU/branch-relaxation.ll
@@ -727,7 +727,7 @@ bb0:
   br i1 %tmp, label %bb2, label %bb3
 
 bb2:
-  store volatile i32 17, ptr addrspace(1) undef
+  store volatile i32 17, ptr addrspace(1) poison
   br label %bb4
 
 bb3:
@@ -1258,7 +1258,7 @@ loop_body:
   br label %loop
 
 ret:
-  store volatile i32 7, ptr addrspace(1) undef
+  store volatile i32 7, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/bug-v4f64-subvector.ll
+++ b/llvm/test/CodeGen/AMDGPU/bug-v4f64-subvector.ll
@@ -17,14 +17,14 @@ entry:
   %tmp5 = extractelement <3 x double> %tmp4, i32 1
   %tmp6 = insertelement <3 x double> poison, double %tmp5, i32 1
   %tmp7 = insertelement <3 x double> %tmp6, double poison, i32 2
-  %tmp8 = load <3 x double>, ptr addrspace(1) undef, align 8, !tbaa !6
+  %tmp8 = load <3 x double>, ptr addrspace(1) poison, align 8, !tbaa !6
   %tmp9 = extractelement <3 x double> %tmp8, i32 2
   %tmp10 = insertelement <3 x double> poison, double %tmp9, i32 2
   %tmp11 = fcmp olt <3 x double> %tmp10, %tmp7
   %tmp12 = select <3 x i1> %tmp11, <3 x double> zeroinitializer, <3 x double> <double 1.000000e+00, double 1.000000e+00, double 1.000000e+00>
   %tmp13 = extractelement <3 x double> %tmp12, i64 1
   %tmp14 = insertelement <2 x double> poison, double %tmp13, i32 1
-  store <2 x double> %tmp14, ptr addrspace(1) undef, align 8, !tbaa !6
+  store <2 x double> %tmp14, ptr addrspace(1) poison, align 8, !tbaa !6
   ret void
 }
 
@@ -44,14 +44,14 @@ entry:
   %tmp5 = extractelement <3 x double> %tmp4, i32 1
   %tmp6 = insertelement <3 x double> poison, double %tmp5, i32 1
   %tmp7 = insertelement <3 x double> %tmp6, double poison, i32 2
-  %tmp8 = load <3 x double>, ptr addrspace(1) undef, align 8, !tbaa !6
+  %tmp8 = load <3 x double>, ptr addrspace(1) poison, align 8, !tbaa !6
   %tmp9 = extractelement <3 x double> %tmp8, i32 1
   %tmp10 = insertelement <3 x double> poison, double %tmp9, i32 1
   %tmp11 = insertelement <3 x double> %tmp10, double poison, i32 2
   %tmp12 = fcmp olt <3 x double> %tmp11, %tmp7
   %tmp13 = select <3 x i1> %tmp12, <3 x double> zeroinitializer, <3 x double> <double 1.000000e+00, double 1.000000e+00, double 1.000000e+00>
   %tmp14 = extractelement <3 x double> %tmp13, i64 2
-  store double %tmp14, ptr addrspace(1) undef, align 8, !tbaa !6
+  store double %tmp14, ptr addrspace(1) poison, align 8, !tbaa !6
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/call-argument-types.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-argument-types.ll
@@ -252,7 +252,7 @@ define amdgpu_kernel void @test_call_external_void_func_i1_signext(i32) #0 {
 ; HSA-NEXT:    v_bfe_i32 v0, v0, 0, 1
 ; HSA-NEXT:    s_swappc_b64 s[30:31], s[8:9]
 ; HSA-NEXT:    s_endpgm
-  %var = load volatile i1, ptr addrspace(1) undef
+  %var = load volatile i1, ptr addrspace(1) poison
   call void @external_void_func_i1_signext(i1 signext %var)
   ret void
 }
@@ -362,7 +362,7 @@ define amdgpu_kernel void @test_call_external_void_func_i1_zeroext(i32) #0 {
 ; HSA-NEXT:    v_and_b32_e32 v0, 1, v0
 ; HSA-NEXT:    s_swappc_b64 s[30:31], s[8:9]
 ; HSA-NEXT:    s_endpgm
-  %var = load volatile i1, ptr addrspace(1) undef
+  %var = load volatile i1, ptr addrspace(1) poison
   call void @external_void_func_i1_zeroext(i1 zeroext %var)
   ret void
 }
@@ -555,7 +555,7 @@ define amdgpu_kernel void @test_call_external_void_func_i8_signext(i32) #0 {
 ; HSA-NEXT:    s_mov_b32 s32, 0
 ; HSA-NEXT:    s_swappc_b64 s[30:31], s[8:9]
 ; HSA-NEXT:    s_endpgm
-  %var = load volatile i8, ptr addrspace(1) undef
+  %var = load volatile i8, ptr addrspace(1) poison
   call void @external_void_func_i8_signext(i8 signext %var)
   ret void
 }
@@ -659,7 +659,7 @@ define amdgpu_kernel void @test_call_external_void_func_i8_zeroext(i32) #0 {
 ; HSA-NEXT:    s_mov_b32 s32, 0
 ; HSA-NEXT:    s_swappc_b64 s[30:31], s[8:9]
 ; HSA-NEXT:    s_endpgm
-  %var = load volatile i8, ptr addrspace(1) undef
+  %var = load volatile i8, ptr addrspace(1) poison
   call void @external_void_func_i8_zeroext(i8 zeroext %var)
   ret void
 }
@@ -851,7 +851,7 @@ define amdgpu_kernel void @test_call_external_void_func_i16_signext(i32) #0 {
 ; HSA-NEXT:    s_mov_b32 s32, 0
 ; HSA-NEXT:    s_swappc_b64 s[30:31], s[8:9]
 ; HSA-NEXT:    s_endpgm
-  %var = load volatile i16, ptr addrspace(1) undef
+  %var = load volatile i16, ptr addrspace(1) poison
   call void @external_void_func_i16_signext(i16 signext %var)
   ret void
 }
@@ -955,7 +955,7 @@ define amdgpu_kernel void @test_call_external_void_func_i16_zeroext(i32) #0 {
 ; HSA-NEXT:    s_mov_b32 s32, 0
 ; HSA-NEXT:    s_swappc_b64 s[30:31], s[8:9]
 ; HSA-NEXT:    s_endpgm
-  %var = load volatile i16, ptr addrspace(1) undef
+  %var = load volatile i16, ptr addrspace(1) poison
   call void @external_void_func_i16_zeroext(i16 zeroext %var)
   ret void
 }
@@ -2453,7 +2453,7 @@ define amdgpu_kernel void @test_call_external_void_func_v2i16() #0 {
 ; HSA-NEXT:    s_mov_b32 s32, 0
 ; HSA-NEXT:    s_swappc_b64 s[30:31], s[8:9]
 ; HSA-NEXT:    s_endpgm
-  %val = load <2 x i16>, ptr addrspace(1) undef
+  %val = load <2 x i16>, ptr addrspace(1) poison
   call void @external_void_func_v2i16(<2 x i16> %val)
   ret void
 }
@@ -2556,7 +2556,7 @@ define amdgpu_kernel void @test_call_external_void_func_v3i16() #0 {
 ; HSA-NEXT:    s_mov_b32 s32, 0
 ; HSA-NEXT:    s_swappc_b64 s[30:31], s[8:9]
 ; HSA-NEXT:    s_endpgm
-  %val = load <3 x i16>, ptr addrspace(1) undef
+  %val = load <3 x i16>, ptr addrspace(1) poison
   call void @external_void_func_v3i16(<3 x i16> %val)
   ret void
 }
@@ -2660,7 +2660,7 @@ define amdgpu_kernel void @test_call_external_void_func_v3f16() #0 {
 ; HSA-NEXT:    s_mov_b32 s32, 0
 ; HSA-NEXT:    s_swappc_b64 s[30:31], s[8:9]
 ; HSA-NEXT:    s_endpgm
-  %val = load <3 x half>, ptr addrspace(1) undef
+  %val = load <3 x half>, ptr addrspace(1) poison
   call void @external_void_func_v3f16(<3 x half> %val)
   ret void
 }
@@ -2951,7 +2951,7 @@ define amdgpu_kernel void @test_call_external_void_func_v4i16() #0 {
 ; HSA-NEXT:    s_mov_b32 s32, 0
 ; HSA-NEXT:    s_swappc_b64 s[30:31], s[8:9]
 ; HSA-NEXT:    s_endpgm
-  %val = load <4 x i16>, ptr addrspace(1) undef
+  %val = load <4 x i16>, ptr addrspace(1) poison
   call void @external_void_func_v4i16(<4 x i16> %val)
   ret void
 }
@@ -3149,7 +3149,7 @@ define amdgpu_kernel void @test_call_external_void_func_v2f16() #0 {
 ; HSA-NEXT:    s_mov_b32 s32, 0
 ; HSA-NEXT:    s_swappc_b64 s[30:31], s[8:9]
 ; HSA-NEXT:    s_endpgm
-  %val = load <2 x half>, ptr addrspace(1) undef
+  %val = load <2 x half>, ptr addrspace(1) poison
   call void @external_void_func_v2f16(<2 x half> %val)
   ret void
 }
@@ -3248,7 +3248,7 @@ define amdgpu_kernel void @test_call_external_void_func_v2i32() #0 {
 ; HSA-NEXT:    s_mov_b32 s32, 0
 ; HSA-NEXT:    s_swappc_b64 s[30:31], s[8:9]
 ; HSA-NEXT:    s_endpgm
-  %val = load <2 x i32>, ptr addrspace(1) undef
+  %val = load <2 x i32>, ptr addrspace(1) poison
   call void @external_void_func_v2i32(<2 x i32> %val)
   ret void
 }
@@ -3637,7 +3637,7 @@ define amdgpu_kernel void @test_call_external_void_func_v4i32() #0 {
 ; HSA-NEXT:    s_mov_b32 s32, 0
 ; HSA-NEXT:    s_swappc_b64 s[30:31], s[8:9]
 ; HSA-NEXT:    s_endpgm
-  %val = load <4 x i32>, ptr addrspace(1) undef
+  %val = load <4 x i32>, ptr addrspace(1) poison
   call void @external_void_func_v4i32(<4 x i32> %val)
   ret void
 }
@@ -4534,7 +4534,7 @@ define amdgpu_kernel void @test_call_external_void_func_v32i32_i32(i32) #0 {
 ; HSA-NEXT:    s_endpgm
   %ptr0 = load ptr addrspace(1), ptr addrspace(4) undef
   %val0 = load <32 x i32>, ptr addrspace(1) %ptr0
-  %val1 = load i32, ptr addrspace(1) undef
+  %val1 = load i32, ptr addrspace(1) poison
   call void @external_void_func_v32i32_i32(<32 x i32> %val0, i32 %val1)
   ret void
 }
@@ -5098,8 +5098,8 @@ define amdgpu_kernel void @test_call_external_void_func_sret_struct_i8_i32_byval
   %out.val0 = load i8, ptr addrspace(5) %out.gep0
   %out.val1 = load i32, ptr addrspace(5) %out.gep1
 
-  store volatile i8 %out.val0, ptr addrspace(1) undef
-  store volatile i32 %out.val1, ptr addrspace(1) undef
+  store volatile i8 %out.val0, ptr addrspace(1) poison
+  store volatile i32 %out.val1, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/call-constant.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-constant.ll
@@ -6,7 +6,7 @@
 define amdgpu_kernel void @test_call_undef() #0 {
   %val = call i32 undef(i32 1)
   %op = add i32 %val, 1
-  store volatile i32 %op, ptr addrspace(1) undef
+  store volatile i32 %op, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/call-constexpr.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-constexpr.ll
@@ -8,7 +8,7 @@
 define amdgpu_kernel void @test_bitcast_return_type_noinline() #0 {
   %val = call float @ret_i32_noinline()
   %op = fadd float %val, 1.0
-  store volatile float %op, ptr addrspace(1) undef
+  store volatile float %op, ptr addrspace(1) poison
   ret void
 }
 
@@ -17,7 +17,7 @@ define amdgpu_kernel void @test_bitcast_return_type_noinline() #0 {
 define amdgpu_kernel void @test_bitcast_return_type_alwaysinline() #0 {
   %val = call float @ret_i32_alwaysinline()
   %op = fadd float %val, 1.0
-  store volatile float %op, ptr addrspace(1) undef
+  store volatile float %op, ptr addrspace(1) poison
   ret void
 }
 
@@ -29,7 +29,7 @@ define amdgpu_kernel void @test_bitcast_return_type_alwaysinline() #0 {
 define amdgpu_kernel void @test_bitcast_argument_type() #0 {
   %val = call i32 @ident_i32(float 2.0)
   %op = add i32 %val, 1
-  store volatile i32 %op, ptr addrspace(1) undef
+  store volatile i32 %op, ptr addrspace(1) poison
   ret void
 }
 
@@ -41,7 +41,7 @@ define amdgpu_kernel void @test_bitcast_argument_type() #0 {
 define amdgpu_kernel void @test_bitcast_argument_and_return_types() #0 {
   %val = call float @ident_i32(float 2.0)
   %op = fadd float %val, 1.0
-  store volatile float %op, ptr addrspace(1) undef
+  store volatile float %op, ptr addrspace(1) poison
   ret void
 }
 
@@ -67,7 +67,7 @@ define hidden i32 @use_workitem_id_x(i32 %arg0) #3 {
 define amdgpu_kernel void @test_bitcast_use_workitem_id_x() #3 {
   %val = call float @use_workitem_id_x(i32 9)
   %op = fadd float %val, 1.0
-  store volatile float %op, ptr addrspace(1) undef
+  store volatile float %op, ptr addrspace(1) poison
   ret void
 }
 
@@ -88,7 +88,7 @@ broken:
 
 continue:
   %op = fadd float %val, 1.0
-  store volatile float %op, ptr addrspace(1) undef
+  store volatile float %op, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/call-preserved-registers.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-preserved-registers.ll
@@ -260,8 +260,8 @@ define amdgpu_kernel void @test_call_void_func_void_clobber_vcc(ptr addrspace(1)
 ; FLATSCR-NEXT:    s_endpgm
   %vcc = call i64 asm sideeffect "; def $0", "={vcc}"()
   call void @void_func_void_clobber_vcc()
-  %val0 = load volatile i32, ptr addrspace(1) undef
-  %val1 = load volatile i32, ptr addrspace(1) undef
+  %val0 = load volatile i32, ptr addrspace(1) poison
+  %val1 = load volatile i32, ptr addrspace(1) poison
   call void asm sideeffect "; use $0", "{vcc}"(i64 %vcc)
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/call-return-types.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-return-types.ll
@@ -60,7 +60,7 @@ define amdgpu_kernel void @test_call_external_void_func_void_x2() #0 {
 ; GCN-LABEL: {{^}}test_call_external_i1_func_void:
 define amdgpu_kernel void @test_call_external_i1_func_void() #0 {
   %val = call i1 @external_i1_func_void()
-  store volatile i1 %val, ptr addrspace(1) undef
+  store volatile i1 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -68,7 +68,7 @@ define amdgpu_kernel void @test_call_external_i1_func_void() #0 {
 define amdgpu_kernel void @test_call_external_i1_zeroext_func_void() #0 {
   %val = call i1 @external_i1_zeroext_func_void()
   %val.ext = zext i1 %val to i32
-  store volatile i32 %val.ext, ptr addrspace(1) undef
+  store volatile i32 %val.ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -76,14 +76,14 @@ define amdgpu_kernel void @test_call_external_i1_zeroext_func_void() #0 {
 define amdgpu_kernel void @test_call_external_i1_signext_func_void() #0 {
   %val = call i1 @external_i1_signext_func_void()
   %val.ext = zext i1 %val to i32
-  store volatile i32 %val.ext, ptr addrspace(1) undef
+  store volatile i32 %val.ext, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_call_external_i8_func_void:
 define amdgpu_kernel void @test_call_external_i8_func_void() #0 {
   %val = call i8 @external_i8_func_void()
-  store volatile i8 %val, ptr addrspace(1) undef
+  store volatile i8 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -91,7 +91,7 @@ define amdgpu_kernel void @test_call_external_i8_func_void() #0 {
 define amdgpu_kernel void @test_call_external_i8_zeroext_func_void() #0 {
   %val = call i8 @external_i8_zeroext_func_void()
   %val.ext = zext i8 %val to i32
-  store volatile i32 %val.ext, ptr addrspace(1) undef
+  store volatile i32 %val.ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -99,14 +99,14 @@ define amdgpu_kernel void @test_call_external_i8_zeroext_func_void() #0 {
 define amdgpu_kernel void @test_call_external_i8_signext_func_void() #0 {
   %val = call i8 @external_i8_signext_func_void()
   %val.ext = zext i8 %val to i32
-  store volatile i32 %val.ext, ptr addrspace(1) undef
+  store volatile i32 %val.ext, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_call_external_i16_func_void:
 define amdgpu_kernel void @test_call_external_i16_func_void() #0 {
   %val = call i16 @external_i16_func_void()
-  store volatile i16 %val, ptr addrspace(1) undef
+  store volatile i16 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -114,7 +114,7 @@ define amdgpu_kernel void @test_call_external_i16_func_void() #0 {
 define amdgpu_kernel void @test_call_external_i16_zeroext_func_void() #0 {
   %val = call i16 @external_i16_zeroext_func_void()
   %val.ext = zext i16 %val to i32
-  store volatile i32 %val.ext, ptr addrspace(1) undef
+  store volatile i32 %val.ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -122,56 +122,56 @@ define amdgpu_kernel void @test_call_external_i16_zeroext_func_void() #0 {
 define amdgpu_kernel void @test_call_external_i16_signext_func_void() #0 {
   %val = call i16 @external_i16_signext_func_void()
   %val.ext = zext i16 %val to i32
-  store volatile i32 %val.ext, ptr addrspace(1) undef
+  store volatile i32 %val.ext, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_call_external_i32_func_void:
 define amdgpu_kernel void @test_call_external_i32_func_void() #0 {
   %val = call i32 @external_i32_func_void()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_call_external_i64_func_void:
 define amdgpu_kernel void @test_call_external_i64_func_void() #0 {
   %val = call i64 @external_i64_func_void()
-  store volatile i64 %val, ptr addrspace(1) undef
+  store volatile i64 %val, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_call_external_f16_func_void:
 define amdgpu_kernel void @test_call_external_f16_func_void() #0 {
   %val = call half @external_f16_func_void()
-  store volatile half %val, ptr addrspace(1) undef
+  store volatile half %val, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_call_external_f32_func_void:
 define amdgpu_kernel void @test_call_external_f32_func_void() #0 {
   %val = call float @external_f32_func_void()
-  store volatile float %val, ptr addrspace(1) undef
+  store volatile float %val, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_call_external_f64_func_void:
 define amdgpu_kernel void @test_call_external_f64_func_void() #0 {
   %val = call double @external_f64_func_void()
-  store volatile double %val, ptr addrspace(1) undef
+  store volatile double %val, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_call_external_v2f64_func_void:
 define amdgpu_kernel void @test_call_external_v2f64_func_void() #0 {
   %val = call <2 x double> @external_v2f64_func_void()
-  store volatile <2 x double> %val, ptr addrspace(1) undef
+  store volatile <2 x double> %val, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_call_external_v2i32_func_void:
 define amdgpu_kernel void @test_call_external_v2i32_func_void() #0 {
   %val = call <2 x i32> @external_v2i32_func_void()
-  store volatile <2 x i32> %val, ptr addrspace(1) undef
+  store volatile <2 x i32> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -182,14 +182,14 @@ define amdgpu_kernel void @test_call_external_v2i32_func_void() #0 {
 ; GFX11-DAG: buffer_store_b96 v[0:2]
 define amdgpu_kernel void @test_call_external_v3i32_func_void() #0 {
   %val = call <3 x i32> @external_v3i32_func_void()
-  store volatile <3 x i32> %val, ptr addrspace(1) undef, align 8
+  store volatile <3 x i32> %val, ptr addrspace(1) poison, align 8
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_call_external_v4i32_func_void:
 define amdgpu_kernel void @test_call_external_v4i32_func_void() #0 {
   %val = call <4 x i32> @external_v4i32_func_void()
-  store volatile <4 x i32> %val, ptr addrspace(1) undef, align 8
+  store volatile <4 x i32> %val, ptr addrspace(1) poison, align 8
   ret void
 }
 
@@ -203,56 +203,56 @@ define amdgpu_kernel void @test_call_external_v4i32_func_void() #0 {
 ; GFX11-DAG: buffer_store_b32 v4
 define amdgpu_kernel void @test_call_external_v5i32_func_void() #0 {
   %val = call <5 x i32> @external_v5i32_func_void()
-  store volatile <5 x i32> %val, ptr addrspace(1) undef, align 8
+  store volatile <5 x i32> %val, ptr addrspace(1) poison, align 8
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_call_external_v8i32_func_void:
 define amdgpu_kernel void @test_call_external_v8i32_func_void() #0 {
   %val = call <8 x i32> @external_v8i32_func_void()
-  store volatile <8 x i32> %val, ptr addrspace(1) undef, align 8
+  store volatile <8 x i32> %val, ptr addrspace(1) poison, align 8
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_call_external_v16i32_func_void:
 define amdgpu_kernel void @test_call_external_v16i32_func_void() #0 {
   %val = call <16 x i32> @external_v16i32_func_void()
-  store volatile <16 x i32> %val, ptr addrspace(1) undef, align 8
+  store volatile <16 x i32> %val, ptr addrspace(1) poison, align 8
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_call_external_v32i32_func_void:
 define amdgpu_kernel void @test_call_external_v32i32_func_void() #0 {
   %val = call <32 x i32> @external_v32i32_func_void()
-  store volatile <32 x i32> %val, ptr addrspace(1) undef, align 8
+  store volatile <32 x i32> %val, ptr addrspace(1) poison, align 8
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_call_external_v2i16_func_void:
 define amdgpu_kernel void @test_call_external_v2i16_func_void() #0 {
   %val = call <2 x i16> @external_v2i16_func_void()
-  store volatile <2 x i16> %val, ptr addrspace(1) undef
+  store volatile <2 x i16> %val, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_call_external_v4i16_func_void:
 define amdgpu_kernel void @test_call_external_v4i16_func_void() #0 {
   %val = call <4 x i16> @external_v4i16_func_void()
-  store volatile <4 x i16> %val, ptr addrspace(1) undef
+  store volatile <4 x i16> %val, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_call_external_v2f16_func_void:
 define amdgpu_kernel void @test_call_external_v2f16_func_void() #0 {
   %val = call <2 x half> @external_v2f16_func_void()
-  store volatile <2 x half> %val, ptr addrspace(1) undef
+  store volatile <2 x half> %val, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_call_external_v4f16_func_void:
 define amdgpu_kernel void @test_call_external_v4f16_func_void() #0 {
   %val = call <4 x half> @external_v4f16_func_void()
-  store volatile <4 x half> %val, ptr addrspace(1) undef
+  store volatile <4 x half> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -264,7 +264,7 @@ define amdgpu_kernel void @test_call_external_v2i24_func_void() #0 {
   %elt0 = extractelement <2 x i24> %val, i32 0
   %elt1 = extractelement <2 x i24> %val, i32 1
   %add = add i24 %elt0, %elt1
-  store volatile i24 %add, ptr addrspace(1) undef
+  store volatile i24 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -275,7 +275,7 @@ define amdgpu_kernel void @test_call_external_v2i24_func_void() #0 {
 ; GFX11-DAG: buffer_store_b96 v[0:2]
 define amdgpu_kernel void @test_call_external_v3f32_func_void() #0 {
   %val = call <3 x float> @external_v3f32_func_void()
-  store volatile <3 x float> %val, ptr addrspace(1) undef
+  store volatile <3 x float> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -289,7 +289,7 @@ define amdgpu_kernel void @test_call_external_v3f32_func_void() #0 {
 ; GFX11-DAG: buffer_store_b32 v4
 define amdgpu_kernel void @test_call_external_v5f32_func_void() #0 {
   %val = call <5 x float> @external_v5f32_func_void()
-  store volatile <5 x float> %val, ptr addrspace(1) undef
+  store volatile <5 x float> %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -298,8 +298,8 @@ define amdgpu_kernel void @test_call_external_i32_i64_func_void() #0 {
   %val = call { i32, i64 } @external_i32_i64_func_void()
   %val.0 = extractvalue { i32, i64 } %val, 0
   %val.1 = extractvalue { i32, i64 } %val, 1
-  store volatile i32 %val.0, ptr addrspace(1) undef
-  store volatile i64 %val.1, ptr addrspace(1) undef
+  store volatile i32 %val.0, ptr addrspace(1) poison
+  store volatile i64 %val.1, ptr addrspace(1) poison
   ret void
 }
 
@@ -309,8 +309,8 @@ define amdgpu_kernel void @test_call_external_v32i32_i32_func_void() #0 {
   %val = call { <32 x i32>, i32 } @external_v32i32_i32_func_void()
   %val0 = extractvalue { <32 x i32>, i32 } %val, 0
   %val1 = extractvalue { <32 x i32>, i32 } %val, 1
-  store volatile <32 x i32> %val0, ptr addrspace(1) undef, align 8
-  store volatile i32 %val1, ptr addrspace(1) undef
+  store volatile <32 x i32> %val0, ptr addrspace(1) poison, align 8
+  store volatile i32 %val1, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/callee-special-input-sgprs-fixed-abi.ll
+++ b/llvm/test/CodeGen/AMDGPU/callee-special-input-sgprs-fixed-abi.ll
@@ -351,7 +351,7 @@ define hidden void @func_indirect_use_workgroup_id_z() #1 {
 ; GCN: ; use s12
 define hidden void @other_arg_use_workgroup_id_x(i32 %arg0) #1 {
   %val = call i32 @llvm.amdgcn.workgroup.id.x()
-  store volatile i32 %arg0, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
   call void asm sideeffect "; use $0", "s"(i32 %val)
   ret void
 }
@@ -362,7 +362,7 @@ define hidden void @other_arg_use_workgroup_id_x(i32 %arg0) #1 {
 ; GCN: ; use s13
 define hidden void @other_arg_use_workgroup_id_y(i32 %arg0) #1 {
   %val = call i32 @llvm.amdgcn.workgroup.id.y()
-  store volatile i32 %arg0, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
   call void asm sideeffect "; use $0", "s"(i32 %val)
   ret void
 }
@@ -373,7 +373,7 @@ define hidden void @other_arg_use_workgroup_id_y(i32 %arg0) #1 {
 ; GCN: ; use s14
 define hidden void @other_arg_use_workgroup_id_z(i32 %arg0) #1 {
   %val = call i32 @llvm.amdgcn.workgroup.id.z()
-  store volatile i32 %arg0, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
   call void asm sideeffect "; use $0", "s"(i32 %val)
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/callee-special-input-vgprs-packed.ll
+++ b/llvm/test/CodeGen/AMDGPU/callee-special-input-vgprs-packed.ll
@@ -11,7 +11,7 @@ target triple = "amdgcn-amd-amdhsa"
 ; GCN-NEXT: s_setpc_b64
 define void @use_workitem_id_x() #1 {
   %val = call i32 @llvm.amdgcn.workitem.id.x()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -23,7 +23,7 @@ define void @use_workitem_id_x() #1 {
 ; GCN-NEXT: s_setpc_b64
 define void @use_workitem_id_y() #1 {
   %val = call i32 @llvm.amdgcn.workitem.id.y()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -35,7 +35,7 @@ define void @use_workitem_id_y() #1 {
 ; GCN-NEXT: s_setpc_b64
 define void @use_workitem_id_z() #1 {
   %val = call i32 @llvm.amdgcn.workitem.id.z()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -50,8 +50,8 @@ define void @use_workitem_id_z() #1 {
 define void @use_workitem_id_xy() #1 {
   %val0 = call i32 @llvm.amdgcn.workitem.id.x()
   %val1 = call i32 @llvm.amdgcn.workitem.id.y()
-  store volatile i32 %val0, ptr addrspace(1) undef
-  store volatile i32 %val1, ptr addrspace(1) undef
+  store volatile i32 %val0, ptr addrspace(1) poison
+  store volatile i32 %val1, ptr addrspace(1) poison
   ret void
 }
 
@@ -69,9 +69,9 @@ define void @use_workitem_id_xyz() #1 {
   %val0 = call i32 @llvm.amdgcn.workitem.id.x()
   %val1 = call i32 @llvm.amdgcn.workitem.id.y()
   %val2 = call i32 @llvm.amdgcn.workitem.id.z()
-  store volatile i32 %val0, ptr addrspace(1) undef
-  store volatile i32 %val1, ptr addrspace(1) undef
-  store volatile i32 %val2, ptr addrspace(1) undef
+  store volatile i32 %val0, ptr addrspace(1) poison
+  store volatile i32 %val1, ptr addrspace(1) poison
+  store volatile i32 %val2, ptr addrspace(1) poison
   ret void
 }
 
@@ -86,8 +86,8 @@ define void @use_workitem_id_xyz() #1 {
 define void @use_workitem_id_xz() #1 {
   %val0 = call i32 @llvm.amdgcn.workitem.id.x()
   %val1 = call i32 @llvm.amdgcn.workitem.id.z()
-  store volatile i32 %val0, ptr addrspace(1) undef
-  store volatile i32 %val1, ptr addrspace(1) undef
+  store volatile i32 %val0, ptr addrspace(1) poison
+  store volatile i32 %val1, ptr addrspace(1) poison
   ret void
 }
 
@@ -102,8 +102,8 @@ define void @use_workitem_id_xz() #1 {
 define void @use_workitem_id_yz() #1 {
   %val0 = call i32 @llvm.amdgcn.workitem.id.y()
   %val1 = call i32 @llvm.amdgcn.workitem.id.z()
-  store volatile i32 %val0, ptr addrspace(1) undef
-  store volatile i32 %val1, ptr addrspace(1) undef
+  store volatile i32 %val0, ptr addrspace(1) poison
+  store volatile i32 %val1, ptr addrspace(1) poison
   ret void
 }
 
@@ -250,8 +250,8 @@ define void @func_indirect_use_workitem_id_z() #1 {
 ; GCN-DAG: {{flat|global}}_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[ID]]
 define void @other_arg_use_workitem_id_x(i32 %arg0) #1 {
   %val = call i32 @llvm.amdgcn.workitem.id.x()
-  store volatile i32 %arg0, ptr addrspace(1) undef
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -262,8 +262,8 @@ define void @other_arg_use_workitem_id_x(i32 %arg0) #1 {
 ; GCN-DAG: {{flat|global}}_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[ID]]
 define void @other_arg_use_workitem_id_y(i32 %arg0) #1 {
   %val = call i32 @llvm.amdgcn.workitem.id.y()
-  store volatile i32 %arg0, ptr addrspace(1) undef
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -274,8 +274,8 @@ define void @other_arg_use_workitem_id_y(i32 %arg0) #1 {
 ; GCN-DAG: {{flat|global}}_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[ID]]
 define void @other_arg_use_workitem_id_z(i32 %arg0) #1 {
   %val = call i32 @llvm.amdgcn.workitem.id.z()
-  store volatile i32 %arg0, ptr addrspace(1) undef
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -335,43 +335,43 @@ define void @too_many_args_use_workitem_id_x(
   i32 %arg16, i32 %arg17, i32 %arg18, i32 %arg19, i32 %arg20, i32 %arg21, i32 %arg22, i32 %arg23,
   i32 %arg24, i32 %arg25, i32 %arg26, i32 %arg27, i32 %arg28, i32 %arg29, i32 %arg30, i32 %arg31) #1 {
   %val = call i32 @llvm.amdgcn.workitem.id.x()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
 
-  store volatile i32 %arg0, ptr addrspace(1) undef
-  store volatile i32 %arg1, ptr addrspace(1) undef
-  store volatile i32 %arg2, ptr addrspace(1) undef
-  store volatile i32 %arg3, ptr addrspace(1) undef
-  store volatile i32 %arg4, ptr addrspace(1) undef
-  store volatile i32 %arg5, ptr addrspace(1) undef
-  store volatile i32 %arg6, ptr addrspace(1) undef
-  store volatile i32 %arg7, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
+  store volatile i32 %arg1, ptr addrspace(1) poison
+  store volatile i32 %arg2, ptr addrspace(1) poison
+  store volatile i32 %arg3, ptr addrspace(1) poison
+  store volatile i32 %arg4, ptr addrspace(1) poison
+  store volatile i32 %arg5, ptr addrspace(1) poison
+  store volatile i32 %arg6, ptr addrspace(1) poison
+  store volatile i32 %arg7, ptr addrspace(1) poison
 
-  store volatile i32 %arg8, ptr addrspace(1) undef
-  store volatile i32 %arg9, ptr addrspace(1) undef
-  store volatile i32 %arg10, ptr addrspace(1) undef
-  store volatile i32 %arg11, ptr addrspace(1) undef
-  store volatile i32 %arg12, ptr addrspace(1) undef
-  store volatile i32 %arg13, ptr addrspace(1) undef
-  store volatile i32 %arg14, ptr addrspace(1) undef
-  store volatile i32 %arg15, ptr addrspace(1) undef
+  store volatile i32 %arg8, ptr addrspace(1) poison
+  store volatile i32 %arg9, ptr addrspace(1) poison
+  store volatile i32 %arg10, ptr addrspace(1) poison
+  store volatile i32 %arg11, ptr addrspace(1) poison
+  store volatile i32 %arg12, ptr addrspace(1) poison
+  store volatile i32 %arg13, ptr addrspace(1) poison
+  store volatile i32 %arg14, ptr addrspace(1) poison
+  store volatile i32 %arg15, ptr addrspace(1) poison
 
-  store volatile i32 %arg16, ptr addrspace(1) undef
-  store volatile i32 %arg17, ptr addrspace(1) undef
-  store volatile i32 %arg18, ptr addrspace(1) undef
-  store volatile i32 %arg19, ptr addrspace(1) undef
-  store volatile i32 %arg20, ptr addrspace(1) undef
-  store volatile i32 %arg21, ptr addrspace(1) undef
-  store volatile i32 %arg22, ptr addrspace(1) undef
-  store volatile i32 %arg23, ptr addrspace(1) undef
+  store volatile i32 %arg16, ptr addrspace(1) poison
+  store volatile i32 %arg17, ptr addrspace(1) poison
+  store volatile i32 %arg18, ptr addrspace(1) poison
+  store volatile i32 %arg19, ptr addrspace(1) poison
+  store volatile i32 %arg20, ptr addrspace(1) poison
+  store volatile i32 %arg21, ptr addrspace(1) poison
+  store volatile i32 %arg22, ptr addrspace(1) poison
+  store volatile i32 %arg23, ptr addrspace(1) poison
 
-  store volatile i32 %arg24, ptr addrspace(1) undef
-  store volatile i32 %arg25, ptr addrspace(1) undef
-  store volatile i32 %arg26, ptr addrspace(1) undef
-  store volatile i32 %arg27, ptr addrspace(1) undef
-  store volatile i32 %arg28, ptr addrspace(1) undef
-  store volatile i32 %arg29, ptr addrspace(1) undef
-  store volatile i32 %arg30, ptr addrspace(1) undef
-  store volatile i32 %arg31, ptr addrspace(1) undef
+  store volatile i32 %arg24, ptr addrspace(1) poison
+  store volatile i32 %arg25, ptr addrspace(1) poison
+  store volatile i32 %arg26, ptr addrspace(1) poison
+  store volatile i32 %arg27, ptr addrspace(1) poison
+  store volatile i32 %arg28, ptr addrspace(1) poison
+  store volatile i32 %arg29, ptr addrspace(1) poison
+  store volatile i32 %arg30, ptr addrspace(1) poison
+  store volatile i32 %arg31, ptr addrspace(1) poison
 
   ret void
 }
@@ -405,7 +405,7 @@ define amdgpu_kernel void @kern_call_too_many_args_use_workitem_id_x() #1 {
 ; GCN: s_swappc_b64
 ; GCN-NOT: v31
 define void @func_call_too_many_args_use_workitem_id_x(i32 %arg0) #1 {
-  store volatile i32 %arg0, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
   call void @too_many_args_use_workitem_id_x(
     i32 10, i32 20, i32 30, i32 40,
     i32 50, i32 60, i32 70, i32 80,
@@ -462,43 +462,43 @@ define void @too_many_args_use_workitem_id_x_byval(
   i32 %arg16, i32 %arg17, i32 %arg18, i32 %arg19, i32 %arg20, i32 %arg21, i32 %arg22, i32 %arg23,
   i32 %arg24, i32 %arg25, i32 %arg26, i32 %arg27, i32 %arg28, i32 %arg29, i32 %arg30, i32 %arg31, ptr addrspace(5) byval(i32) %arg32) #1 {
   %val = call i32 @llvm.amdgcn.workitem.id.x()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
 
-  store volatile i32 %arg0, ptr addrspace(1) undef
-  store volatile i32 %arg1, ptr addrspace(1) undef
-  store volatile i32 %arg2, ptr addrspace(1) undef
-  store volatile i32 %arg3, ptr addrspace(1) undef
-  store volatile i32 %arg4, ptr addrspace(1) undef
-  store volatile i32 %arg5, ptr addrspace(1) undef
-  store volatile i32 %arg6, ptr addrspace(1) undef
-  store volatile i32 %arg7, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
+  store volatile i32 %arg1, ptr addrspace(1) poison
+  store volatile i32 %arg2, ptr addrspace(1) poison
+  store volatile i32 %arg3, ptr addrspace(1) poison
+  store volatile i32 %arg4, ptr addrspace(1) poison
+  store volatile i32 %arg5, ptr addrspace(1) poison
+  store volatile i32 %arg6, ptr addrspace(1) poison
+  store volatile i32 %arg7, ptr addrspace(1) poison
 
-  store volatile i32 %arg8, ptr addrspace(1) undef
-  store volatile i32 %arg9, ptr addrspace(1) undef
-  store volatile i32 %arg10, ptr addrspace(1) undef
-  store volatile i32 %arg11, ptr addrspace(1) undef
-  store volatile i32 %arg12, ptr addrspace(1) undef
-  store volatile i32 %arg13, ptr addrspace(1) undef
-  store volatile i32 %arg14, ptr addrspace(1) undef
-  store volatile i32 %arg15, ptr addrspace(1) undef
+  store volatile i32 %arg8, ptr addrspace(1) poison
+  store volatile i32 %arg9, ptr addrspace(1) poison
+  store volatile i32 %arg10, ptr addrspace(1) poison
+  store volatile i32 %arg11, ptr addrspace(1) poison
+  store volatile i32 %arg12, ptr addrspace(1) poison
+  store volatile i32 %arg13, ptr addrspace(1) poison
+  store volatile i32 %arg14, ptr addrspace(1) poison
+  store volatile i32 %arg15, ptr addrspace(1) poison
 
-  store volatile i32 %arg16, ptr addrspace(1) undef
-  store volatile i32 %arg17, ptr addrspace(1) undef
-  store volatile i32 %arg18, ptr addrspace(1) undef
-  store volatile i32 %arg19, ptr addrspace(1) undef
-  store volatile i32 %arg20, ptr addrspace(1) undef
-  store volatile i32 %arg21, ptr addrspace(1) undef
-  store volatile i32 %arg22, ptr addrspace(1) undef
-  store volatile i32 %arg23, ptr addrspace(1) undef
+  store volatile i32 %arg16, ptr addrspace(1) poison
+  store volatile i32 %arg17, ptr addrspace(1) poison
+  store volatile i32 %arg18, ptr addrspace(1) poison
+  store volatile i32 %arg19, ptr addrspace(1) poison
+  store volatile i32 %arg20, ptr addrspace(1) poison
+  store volatile i32 %arg21, ptr addrspace(1) poison
+  store volatile i32 %arg22, ptr addrspace(1) poison
+  store volatile i32 %arg23, ptr addrspace(1) poison
 
-  store volatile i32 %arg24, ptr addrspace(1) undef
-  store volatile i32 %arg25, ptr addrspace(1) undef
-  store volatile i32 %arg26, ptr addrspace(1) undef
-  store volatile i32 %arg27, ptr addrspace(1) undef
-  store volatile i32 %arg28, ptr addrspace(1) undef
-  store volatile i32 %arg29, ptr addrspace(1) undef
-  store volatile i32 %arg30, ptr addrspace(1) undef
-  store volatile i32 %arg31, ptr addrspace(1) undef
+  store volatile i32 %arg24, ptr addrspace(1) poison
+  store volatile i32 %arg25, ptr addrspace(1) poison
+  store volatile i32 %arg26, ptr addrspace(1) poison
+  store volatile i32 %arg27, ptr addrspace(1) poison
+  store volatile i32 %arg28, ptr addrspace(1) poison
+  store volatile i32 %arg29, ptr addrspace(1) poison
+  store volatile i32 %arg30, ptr addrspace(1) poison
+  store volatile i32 %arg31, ptr addrspace(1) poison
   %private = load volatile i32, ptr addrspace(5) %arg32
   ret void
 }
@@ -590,47 +590,47 @@ define void @too_many_args_use_workitem_id_xyz(
   i32 %arg16, i32 %arg17, i32 %arg18, i32 %arg19, i32 %arg20, i32 %arg21, i32 %arg22, i32 %arg23,
   i32 %arg24, i32 %arg25, i32 %arg26, i32 %arg27, i32 %arg28, i32 %arg29, i32 %arg30, i32 %arg31) #1 {
   %val0 = call i32 @llvm.amdgcn.workitem.id.x()
-  store volatile i32 %val0, ptr addrspace(1) undef
+  store volatile i32 %val0, ptr addrspace(1) poison
   %val1 = call i32 @llvm.amdgcn.workitem.id.y()
-  store volatile i32 %val1, ptr addrspace(1) undef
+  store volatile i32 %val1, ptr addrspace(1) poison
   %val2 = call i32 @llvm.amdgcn.workitem.id.z()
-  store volatile i32 %val2, ptr addrspace(1) undef
+  store volatile i32 %val2, ptr addrspace(1) poison
 
-  store volatile i32 %arg0, ptr addrspace(1) undef
-  store volatile i32 %arg1, ptr addrspace(1) undef
-  store volatile i32 %arg2, ptr addrspace(1) undef
-  store volatile i32 %arg3, ptr addrspace(1) undef
-  store volatile i32 %arg4, ptr addrspace(1) undef
-  store volatile i32 %arg5, ptr addrspace(1) undef
-  store volatile i32 %arg6, ptr addrspace(1) undef
-  store volatile i32 %arg7, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
+  store volatile i32 %arg1, ptr addrspace(1) poison
+  store volatile i32 %arg2, ptr addrspace(1) poison
+  store volatile i32 %arg3, ptr addrspace(1) poison
+  store volatile i32 %arg4, ptr addrspace(1) poison
+  store volatile i32 %arg5, ptr addrspace(1) poison
+  store volatile i32 %arg6, ptr addrspace(1) poison
+  store volatile i32 %arg7, ptr addrspace(1) poison
 
-  store volatile i32 %arg8, ptr addrspace(1) undef
-  store volatile i32 %arg9, ptr addrspace(1) undef
-  store volatile i32 %arg10, ptr addrspace(1) undef
-  store volatile i32 %arg11, ptr addrspace(1) undef
-  store volatile i32 %arg12, ptr addrspace(1) undef
-  store volatile i32 %arg13, ptr addrspace(1) undef
-  store volatile i32 %arg14, ptr addrspace(1) undef
-  store volatile i32 %arg15, ptr addrspace(1) undef
+  store volatile i32 %arg8, ptr addrspace(1) poison
+  store volatile i32 %arg9, ptr addrspace(1) poison
+  store volatile i32 %arg10, ptr addrspace(1) poison
+  store volatile i32 %arg11, ptr addrspace(1) poison
+  store volatile i32 %arg12, ptr addrspace(1) poison
+  store volatile i32 %arg13, ptr addrspace(1) poison
+  store volatile i32 %arg14, ptr addrspace(1) poison
+  store volatile i32 %arg15, ptr addrspace(1) poison
 
-  store volatile i32 %arg16, ptr addrspace(1) undef
-  store volatile i32 %arg17, ptr addrspace(1) undef
-  store volatile i32 %arg18, ptr addrspace(1) undef
-  store volatile i32 %arg19, ptr addrspace(1) undef
-  store volatile i32 %arg20, ptr addrspace(1) undef
-  store volatile i32 %arg21, ptr addrspace(1) undef
-  store volatile i32 %arg22, ptr addrspace(1) undef
-  store volatile i32 %arg23, ptr addrspace(1) undef
+  store volatile i32 %arg16, ptr addrspace(1) poison
+  store volatile i32 %arg17, ptr addrspace(1) poison
+  store volatile i32 %arg18, ptr addrspace(1) poison
+  store volatile i32 %arg19, ptr addrspace(1) poison
+  store volatile i32 %arg20, ptr addrspace(1) poison
+  store volatile i32 %arg21, ptr addrspace(1) poison
+  store volatile i32 %arg22, ptr addrspace(1) poison
+  store volatile i32 %arg23, ptr addrspace(1) poison
 
-  store volatile i32 %arg24, ptr addrspace(1) undef
-  store volatile i32 %arg25, ptr addrspace(1) undef
-  store volatile i32 %arg26, ptr addrspace(1) undef
-  store volatile i32 %arg27, ptr addrspace(1) undef
-  store volatile i32 %arg28, ptr addrspace(1) undef
-  store volatile i32 %arg29, ptr addrspace(1) undef
-  store volatile i32 %arg30, ptr addrspace(1) undef
-  store volatile i32 %arg31, ptr addrspace(1) undef
+  store volatile i32 %arg24, ptr addrspace(1) poison
+  store volatile i32 %arg25, ptr addrspace(1) poison
+  store volatile i32 %arg26, ptr addrspace(1) poison
+  store volatile i32 %arg27, ptr addrspace(1) poison
+  store volatile i32 %arg28, ptr addrspace(1) poison
+  store volatile i32 %arg29, ptr addrspace(1) poison
+  store volatile i32 %arg30, ptr addrspace(1) poison
+  store volatile i32 %arg31, ptr addrspace(1) poison
 
   ret void
 }
@@ -688,46 +688,46 @@ define void @too_many_args_use_workitem_id_x_stack_yz(
   i32 %arg16, i32 %arg17, i32 %arg18, i32 %arg19, i32 %arg20, i32 %arg21, i32 %arg22, i32 %arg23,
   i32 %arg24, i32 %arg25, i32 %arg26, i32 %arg27, i32 %arg28, i32 %arg29, i32 %arg30) #1 {
   %val0 = call i32 @llvm.amdgcn.workitem.id.x()
-  store volatile i32 %val0, ptr addrspace(1) undef
+  store volatile i32 %val0, ptr addrspace(1) poison
   %val1 = call i32 @llvm.amdgcn.workitem.id.y()
-  store volatile i32 %val1, ptr addrspace(1) undef
+  store volatile i32 %val1, ptr addrspace(1) poison
   %val2 = call i32 @llvm.amdgcn.workitem.id.z()
-  store volatile i32 %val2, ptr addrspace(1) undef
+  store volatile i32 %val2, ptr addrspace(1) poison
 
-  store volatile i32 %arg0, ptr addrspace(1) undef
-  store volatile i32 %arg1, ptr addrspace(1) undef
-  store volatile i32 %arg2, ptr addrspace(1) undef
-  store volatile i32 %arg3, ptr addrspace(1) undef
-  store volatile i32 %arg4, ptr addrspace(1) undef
-  store volatile i32 %arg5, ptr addrspace(1) undef
-  store volatile i32 %arg6, ptr addrspace(1) undef
-  store volatile i32 %arg7, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
+  store volatile i32 %arg1, ptr addrspace(1) poison
+  store volatile i32 %arg2, ptr addrspace(1) poison
+  store volatile i32 %arg3, ptr addrspace(1) poison
+  store volatile i32 %arg4, ptr addrspace(1) poison
+  store volatile i32 %arg5, ptr addrspace(1) poison
+  store volatile i32 %arg6, ptr addrspace(1) poison
+  store volatile i32 %arg7, ptr addrspace(1) poison
 
-  store volatile i32 %arg8, ptr addrspace(1) undef
-  store volatile i32 %arg9, ptr addrspace(1) undef
-  store volatile i32 %arg10, ptr addrspace(1) undef
-  store volatile i32 %arg11, ptr addrspace(1) undef
-  store volatile i32 %arg12, ptr addrspace(1) undef
-  store volatile i32 %arg13, ptr addrspace(1) undef
-  store volatile i32 %arg14, ptr addrspace(1) undef
-  store volatile i32 %arg15, ptr addrspace(1) undef
+  store volatile i32 %arg8, ptr addrspace(1) poison
+  store volatile i32 %arg9, ptr addrspace(1) poison
+  store volatile i32 %arg10, ptr addrspace(1) poison
+  store volatile i32 %arg11, ptr addrspace(1) poison
+  store volatile i32 %arg12, ptr addrspace(1) poison
+  store volatile i32 %arg13, ptr addrspace(1) poison
+  store volatile i32 %arg14, ptr addrspace(1) poison
+  store volatile i32 %arg15, ptr addrspace(1) poison
 
-  store volatile i32 %arg16, ptr addrspace(1) undef
-  store volatile i32 %arg17, ptr addrspace(1) undef
-  store volatile i32 %arg18, ptr addrspace(1) undef
-  store volatile i32 %arg19, ptr addrspace(1) undef
-  store volatile i32 %arg20, ptr addrspace(1) undef
-  store volatile i32 %arg21, ptr addrspace(1) undef
-  store volatile i32 %arg22, ptr addrspace(1) undef
-  store volatile i32 %arg23, ptr addrspace(1) undef
+  store volatile i32 %arg16, ptr addrspace(1) poison
+  store volatile i32 %arg17, ptr addrspace(1) poison
+  store volatile i32 %arg18, ptr addrspace(1) poison
+  store volatile i32 %arg19, ptr addrspace(1) poison
+  store volatile i32 %arg20, ptr addrspace(1) poison
+  store volatile i32 %arg21, ptr addrspace(1) poison
+  store volatile i32 %arg22, ptr addrspace(1) poison
+  store volatile i32 %arg23, ptr addrspace(1) poison
 
-  store volatile i32 %arg24, ptr addrspace(1) undef
-  store volatile i32 %arg25, ptr addrspace(1) undef
-  store volatile i32 %arg26, ptr addrspace(1) undef
-  store volatile i32 %arg27, ptr addrspace(1) undef
-  store volatile i32 %arg28, ptr addrspace(1) undef
-  store volatile i32 %arg29, ptr addrspace(1) undef
-  store volatile i32 %arg30, ptr addrspace(1) undef
+  store volatile i32 %arg24, ptr addrspace(1) poison
+  store volatile i32 %arg25, ptr addrspace(1) poison
+  store volatile i32 %arg26, ptr addrspace(1) poison
+  store volatile i32 %arg27, ptr addrspace(1) poison
+  store volatile i32 %arg28, ptr addrspace(1) poison
+  store volatile i32 %arg29, ptr addrspace(1) poison
+  store volatile i32 %arg30, ptr addrspace(1) poison
 
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/callee-special-input-vgprs.ll
+++ b/llvm/test/CodeGen/AMDGPU/callee-special-input-vgprs.ll
@@ -10,7 +10,7 @@ target triple = "amdgcn-amd-amdhsa"
 ; GCN-NEXT: s_setpc_b64
 define void @use_workitem_id_x() #1 {
   %val = call i32 @llvm.amdgcn.workitem.id.x()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -22,7 +22,7 @@ define void @use_workitem_id_x() #1 {
 ; GCN-NEXT: s_setpc_b64
 define void @use_workitem_id_y() #1 {
   %val = call i32 @llvm.amdgcn.workitem.id.y()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -34,7 +34,7 @@ define void @use_workitem_id_y() #1 {
 ; GCN-NEXT: s_setpc_b64
 define void @use_workitem_id_z() #1 {
   %val = call i32 @llvm.amdgcn.workitem.id.z()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -50,8 +50,8 @@ define void @use_workitem_id_z() #1 {
 define void @use_workitem_id_xy() #1 {
   %val0 = call i32 @llvm.amdgcn.workitem.id.x()
   %val1 = call i32 @llvm.amdgcn.workitem.id.y()
-  store volatile i32 %val0, ptr addrspace(1) undef
-  store volatile i32 %val1, ptr addrspace(1) undef
+  store volatile i32 %val0, ptr addrspace(1) poison
+  store volatile i32 %val1, ptr addrspace(1) poison
   ret void
 }
 
@@ -72,9 +72,9 @@ define void @use_workitem_id_xyz() #1 {
   %val0 = call i32 @llvm.amdgcn.workitem.id.x()
   %val1 = call i32 @llvm.amdgcn.workitem.id.y()
   %val2 = call i32 @llvm.amdgcn.workitem.id.z()
-  store volatile i32 %val0, ptr addrspace(1) undef
-  store volatile i32 %val1, ptr addrspace(1) undef
-  store volatile i32 %val2, ptr addrspace(1) undef
+  store volatile i32 %val0, ptr addrspace(1) poison
+  store volatile i32 %val1, ptr addrspace(1) poison
+  store volatile i32 %val2, ptr addrspace(1) poison
   ret void
 }
 
@@ -90,8 +90,8 @@ define void @use_workitem_id_xyz() #1 {
 define void @use_workitem_id_xz() #1 {
   %val0 = call i32 @llvm.amdgcn.workitem.id.x()
   %val1 = call i32 @llvm.amdgcn.workitem.id.z()
-  store volatile i32 %val0, ptr addrspace(1) undef
-  store volatile i32 %val1, ptr addrspace(1) undef
+  store volatile i32 %val0, ptr addrspace(1) poison
+  store volatile i32 %val1, ptr addrspace(1) poison
   ret void
 }
 
@@ -107,8 +107,8 @@ define void @use_workitem_id_xz() #1 {
 define void @use_workitem_id_yz() #1 {
   %val0 = call i32 @llvm.amdgcn.workitem.id.y()
   %val1 = call i32 @llvm.amdgcn.workitem.id.z()
-  store volatile i32 %val0, ptr addrspace(1) undef
-  store volatile i32 %val1, ptr addrspace(1) undef
+  store volatile i32 %val0, ptr addrspace(1) poison
+  store volatile i32 %val1, ptr addrspace(1) poison
   ret void
 }
 
@@ -258,8 +258,8 @@ define void @func_indirect_use_workitem_id_z() #1 {
 ; GCN-DAG: {{flat|global}}_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[ID]]
 define void @other_arg_use_workitem_id_x(i32 %arg0) #1 {
   %val = call i32 @llvm.amdgcn.workitem.id.x()
-  store volatile i32 %arg0, ptr addrspace(1) undef
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -270,8 +270,8 @@ define void @other_arg_use_workitem_id_x(i32 %arg0) #1 {
 ; GCN-DAG: {{flat|global}}_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[ID]]
 define void @other_arg_use_workitem_id_y(i32 %arg0) #1 {
   %val = call i32 @llvm.amdgcn.workitem.id.y()
-  store volatile i32 %arg0, ptr addrspace(1) undef
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -282,8 +282,8 @@ define void @other_arg_use_workitem_id_y(i32 %arg0) #1 {
 ; GCN-DAG: {{flat|global}}_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[ID]]
 define void @other_arg_use_workitem_id_z(i32 %arg0) #1 {
   %val = call i32 @llvm.amdgcn.workitem.id.z()
-  store volatile i32 %arg0, ptr addrspace(1) undef
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -340,43 +340,43 @@ define void @too_many_args_use_workitem_id_x(
   i32 %arg16, i32 %arg17, i32 %arg18, i32 %arg19, i32 %arg20, i32 %arg21, i32 %arg22, i32 %arg23,
   i32 %arg24, i32 %arg25, i32 %arg26, i32 %arg27, i32 %arg28, i32 %arg29, i32 %arg30, i32 %arg31) #1 {
   %val = call i32 @llvm.amdgcn.workitem.id.x()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
 
-  store volatile i32 %arg0, ptr addrspace(1) undef
-  store volatile i32 %arg1, ptr addrspace(1) undef
-  store volatile i32 %arg2, ptr addrspace(1) undef
-  store volatile i32 %arg3, ptr addrspace(1) undef
-  store volatile i32 %arg4, ptr addrspace(1) undef
-  store volatile i32 %arg5, ptr addrspace(1) undef
-  store volatile i32 %arg6, ptr addrspace(1) undef
-  store volatile i32 %arg7, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
+  store volatile i32 %arg1, ptr addrspace(1) poison
+  store volatile i32 %arg2, ptr addrspace(1) poison
+  store volatile i32 %arg3, ptr addrspace(1) poison
+  store volatile i32 %arg4, ptr addrspace(1) poison
+  store volatile i32 %arg5, ptr addrspace(1) poison
+  store volatile i32 %arg6, ptr addrspace(1) poison
+  store volatile i32 %arg7, ptr addrspace(1) poison
 
-  store volatile i32 %arg8, ptr addrspace(1) undef
-  store volatile i32 %arg9, ptr addrspace(1) undef
-  store volatile i32 %arg10, ptr addrspace(1) undef
-  store volatile i32 %arg11, ptr addrspace(1) undef
-  store volatile i32 %arg12, ptr addrspace(1) undef
-  store volatile i32 %arg13, ptr addrspace(1) undef
-  store volatile i32 %arg14, ptr addrspace(1) undef
-  store volatile i32 %arg15, ptr addrspace(1) undef
+  store volatile i32 %arg8, ptr addrspace(1) poison
+  store volatile i32 %arg9, ptr addrspace(1) poison
+  store volatile i32 %arg10, ptr addrspace(1) poison
+  store volatile i32 %arg11, ptr addrspace(1) poison
+  store volatile i32 %arg12, ptr addrspace(1) poison
+  store volatile i32 %arg13, ptr addrspace(1) poison
+  store volatile i32 %arg14, ptr addrspace(1) poison
+  store volatile i32 %arg15, ptr addrspace(1) poison
 
-  store volatile i32 %arg16, ptr addrspace(1) undef
-  store volatile i32 %arg17, ptr addrspace(1) undef
-  store volatile i32 %arg18, ptr addrspace(1) undef
-  store volatile i32 %arg19, ptr addrspace(1) undef
-  store volatile i32 %arg20, ptr addrspace(1) undef
-  store volatile i32 %arg21, ptr addrspace(1) undef
-  store volatile i32 %arg22, ptr addrspace(1) undef
-  store volatile i32 %arg23, ptr addrspace(1) undef
+  store volatile i32 %arg16, ptr addrspace(1) poison
+  store volatile i32 %arg17, ptr addrspace(1) poison
+  store volatile i32 %arg18, ptr addrspace(1) poison
+  store volatile i32 %arg19, ptr addrspace(1) poison
+  store volatile i32 %arg20, ptr addrspace(1) poison
+  store volatile i32 %arg21, ptr addrspace(1) poison
+  store volatile i32 %arg22, ptr addrspace(1) poison
+  store volatile i32 %arg23, ptr addrspace(1) poison
 
-  store volatile i32 %arg24, ptr addrspace(1) undef
-  store volatile i32 %arg25, ptr addrspace(1) undef
-  store volatile i32 %arg26, ptr addrspace(1) undef
-  store volatile i32 %arg27, ptr addrspace(1) undef
-  store volatile i32 %arg28, ptr addrspace(1) undef
-  store volatile i32 %arg29, ptr addrspace(1) undef
-  store volatile i32 %arg30, ptr addrspace(1) undef
-  store volatile i32 %arg31, ptr addrspace(1) undef
+  store volatile i32 %arg24, ptr addrspace(1) poison
+  store volatile i32 %arg25, ptr addrspace(1) poison
+  store volatile i32 %arg26, ptr addrspace(1) poison
+  store volatile i32 %arg27, ptr addrspace(1) poison
+  store volatile i32 %arg28, ptr addrspace(1) poison
+  store volatile i32 %arg29, ptr addrspace(1) poison
+  store volatile i32 %arg30, ptr addrspace(1) poison
+  store volatile i32 %arg31, ptr addrspace(1) poison
 
   ret void
 }
@@ -418,7 +418,7 @@ define amdgpu_kernel void @kern_call_too_many_args_use_workitem_id_x() #1 {
 
 ; GCN: s_swappc_b64
 define void @func_call_too_many_args_use_workitem_id_x(i32 %arg0) #1 {
-  store volatile i32 %arg0, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
   call void @too_many_args_use_workitem_id_x(
     i32 10, i32 20, i32 30, i32 40,
     i32 50, i32 60, i32 70, i32 80,
@@ -477,43 +477,43 @@ define void @too_many_args_use_workitem_id_x_byval(
   i32 %arg16, i32 %arg17, i32 %arg18, i32 %arg19, i32 %arg20, i32 %arg21, i32 %arg22, i32 %arg23,
   i32 %arg24, i32 %arg25, i32 %arg26, i32 %arg27, i32 %arg28, i32 %arg29, i32 %arg30, i32 %arg31, ptr addrspace(5) byval(i32) %arg32) #1 {
   %val = call i32 @llvm.amdgcn.workitem.id.x()
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
 
-  store volatile i32 %arg0, ptr addrspace(1) undef
-  store volatile i32 %arg1, ptr addrspace(1) undef
-  store volatile i32 %arg2, ptr addrspace(1) undef
-  store volatile i32 %arg3, ptr addrspace(1) undef
-  store volatile i32 %arg4, ptr addrspace(1) undef
-  store volatile i32 %arg5, ptr addrspace(1) undef
-  store volatile i32 %arg6, ptr addrspace(1) undef
-  store volatile i32 %arg7, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
+  store volatile i32 %arg1, ptr addrspace(1) poison
+  store volatile i32 %arg2, ptr addrspace(1) poison
+  store volatile i32 %arg3, ptr addrspace(1) poison
+  store volatile i32 %arg4, ptr addrspace(1) poison
+  store volatile i32 %arg5, ptr addrspace(1) poison
+  store volatile i32 %arg6, ptr addrspace(1) poison
+  store volatile i32 %arg7, ptr addrspace(1) poison
 
-  store volatile i32 %arg8, ptr addrspace(1) undef
-  store volatile i32 %arg9, ptr addrspace(1) undef
-  store volatile i32 %arg10, ptr addrspace(1) undef
-  store volatile i32 %arg11, ptr addrspace(1) undef
-  store volatile i32 %arg12, ptr addrspace(1) undef
-  store volatile i32 %arg13, ptr addrspace(1) undef
-  store volatile i32 %arg14, ptr addrspace(1) undef
-  store volatile i32 %arg15, ptr addrspace(1) undef
+  store volatile i32 %arg8, ptr addrspace(1) poison
+  store volatile i32 %arg9, ptr addrspace(1) poison
+  store volatile i32 %arg10, ptr addrspace(1) poison
+  store volatile i32 %arg11, ptr addrspace(1) poison
+  store volatile i32 %arg12, ptr addrspace(1) poison
+  store volatile i32 %arg13, ptr addrspace(1) poison
+  store volatile i32 %arg14, ptr addrspace(1) poison
+  store volatile i32 %arg15, ptr addrspace(1) poison
 
-  store volatile i32 %arg16, ptr addrspace(1) undef
-  store volatile i32 %arg17, ptr addrspace(1) undef
-  store volatile i32 %arg18, ptr addrspace(1) undef
-  store volatile i32 %arg19, ptr addrspace(1) undef
-  store volatile i32 %arg20, ptr addrspace(1) undef
-  store volatile i32 %arg21, ptr addrspace(1) undef
-  store volatile i32 %arg22, ptr addrspace(1) undef
-  store volatile i32 %arg23, ptr addrspace(1) undef
+  store volatile i32 %arg16, ptr addrspace(1) poison
+  store volatile i32 %arg17, ptr addrspace(1) poison
+  store volatile i32 %arg18, ptr addrspace(1) poison
+  store volatile i32 %arg19, ptr addrspace(1) poison
+  store volatile i32 %arg20, ptr addrspace(1) poison
+  store volatile i32 %arg21, ptr addrspace(1) poison
+  store volatile i32 %arg22, ptr addrspace(1) poison
+  store volatile i32 %arg23, ptr addrspace(1) poison
 
-  store volatile i32 %arg24, ptr addrspace(1) undef
-  store volatile i32 %arg25, ptr addrspace(1) undef
-  store volatile i32 %arg26, ptr addrspace(1) undef
-  store volatile i32 %arg27, ptr addrspace(1) undef
-  store volatile i32 %arg28, ptr addrspace(1) undef
-  store volatile i32 %arg29, ptr addrspace(1) undef
-  store volatile i32 %arg30, ptr addrspace(1) undef
-  store volatile i32 %arg31, ptr addrspace(1) undef
+  store volatile i32 %arg24, ptr addrspace(1) poison
+  store volatile i32 %arg25, ptr addrspace(1) poison
+  store volatile i32 %arg26, ptr addrspace(1) poison
+  store volatile i32 %arg27, ptr addrspace(1) poison
+  store volatile i32 %arg28, ptr addrspace(1) poison
+  store volatile i32 %arg29, ptr addrspace(1) poison
+  store volatile i32 %arg30, ptr addrspace(1) poison
+  store volatile i32 %arg31, ptr addrspace(1) poison
   %private = load volatile i32, ptr addrspace(5) %arg32
   ret void
 }
@@ -602,47 +602,47 @@ define void @too_many_args_use_workitem_id_xyz(
   i32 %arg16, i32 %arg17, i32 %arg18, i32 %arg19, i32 %arg20, i32 %arg21, i32 %arg22, i32 %arg23,
   i32 %arg24, i32 %arg25, i32 %arg26, i32 %arg27, i32 %arg28, i32 %arg29, i32 %arg30, i32 %arg31) #1 {
   %val0 = call i32 @llvm.amdgcn.workitem.id.x()
-  store volatile i32 %val0, ptr addrspace(1) undef
+  store volatile i32 %val0, ptr addrspace(1) poison
   %val1 = call i32 @llvm.amdgcn.workitem.id.y()
-  store volatile i32 %val1, ptr addrspace(1) undef
+  store volatile i32 %val1, ptr addrspace(1) poison
   %val2 = call i32 @llvm.amdgcn.workitem.id.z()
-  store volatile i32 %val2, ptr addrspace(1) undef
+  store volatile i32 %val2, ptr addrspace(1) poison
 
-  store volatile i32 %arg0, ptr addrspace(1) undef
-  store volatile i32 %arg1, ptr addrspace(1) undef
-  store volatile i32 %arg2, ptr addrspace(1) undef
-  store volatile i32 %arg3, ptr addrspace(1) undef
-  store volatile i32 %arg4, ptr addrspace(1) undef
-  store volatile i32 %arg5, ptr addrspace(1) undef
-  store volatile i32 %arg6, ptr addrspace(1) undef
-  store volatile i32 %arg7, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
+  store volatile i32 %arg1, ptr addrspace(1) poison
+  store volatile i32 %arg2, ptr addrspace(1) poison
+  store volatile i32 %arg3, ptr addrspace(1) poison
+  store volatile i32 %arg4, ptr addrspace(1) poison
+  store volatile i32 %arg5, ptr addrspace(1) poison
+  store volatile i32 %arg6, ptr addrspace(1) poison
+  store volatile i32 %arg7, ptr addrspace(1) poison
 
-  store volatile i32 %arg8, ptr addrspace(1) undef
-  store volatile i32 %arg9, ptr addrspace(1) undef
-  store volatile i32 %arg10, ptr addrspace(1) undef
-  store volatile i32 %arg11, ptr addrspace(1) undef
-  store volatile i32 %arg12, ptr addrspace(1) undef
-  store volatile i32 %arg13, ptr addrspace(1) undef
-  store volatile i32 %arg14, ptr addrspace(1) undef
-  store volatile i32 %arg15, ptr addrspace(1) undef
+  store volatile i32 %arg8, ptr addrspace(1) poison
+  store volatile i32 %arg9, ptr addrspace(1) poison
+  store volatile i32 %arg10, ptr addrspace(1) poison
+  store volatile i32 %arg11, ptr addrspace(1) poison
+  store volatile i32 %arg12, ptr addrspace(1) poison
+  store volatile i32 %arg13, ptr addrspace(1) poison
+  store volatile i32 %arg14, ptr addrspace(1) poison
+  store volatile i32 %arg15, ptr addrspace(1) poison
 
-  store volatile i32 %arg16, ptr addrspace(1) undef
-  store volatile i32 %arg17, ptr addrspace(1) undef
-  store volatile i32 %arg18, ptr addrspace(1) undef
-  store volatile i32 %arg19, ptr addrspace(1) undef
-  store volatile i32 %arg20, ptr addrspace(1) undef
-  store volatile i32 %arg21, ptr addrspace(1) undef
-  store volatile i32 %arg22, ptr addrspace(1) undef
-  store volatile i32 %arg23, ptr addrspace(1) undef
+  store volatile i32 %arg16, ptr addrspace(1) poison
+  store volatile i32 %arg17, ptr addrspace(1) poison
+  store volatile i32 %arg18, ptr addrspace(1) poison
+  store volatile i32 %arg19, ptr addrspace(1) poison
+  store volatile i32 %arg20, ptr addrspace(1) poison
+  store volatile i32 %arg21, ptr addrspace(1) poison
+  store volatile i32 %arg22, ptr addrspace(1) poison
+  store volatile i32 %arg23, ptr addrspace(1) poison
 
-  store volatile i32 %arg24, ptr addrspace(1) undef
-  store volatile i32 %arg25, ptr addrspace(1) undef
-  store volatile i32 %arg26, ptr addrspace(1) undef
-  store volatile i32 %arg27, ptr addrspace(1) undef
-  store volatile i32 %arg28, ptr addrspace(1) undef
-  store volatile i32 %arg29, ptr addrspace(1) undef
-  store volatile i32 %arg30, ptr addrspace(1) undef
-  store volatile i32 %arg31, ptr addrspace(1) undef
+  store volatile i32 %arg24, ptr addrspace(1) poison
+  store volatile i32 %arg25, ptr addrspace(1) poison
+  store volatile i32 %arg26, ptr addrspace(1) poison
+  store volatile i32 %arg27, ptr addrspace(1) poison
+  store volatile i32 %arg28, ptr addrspace(1) poison
+  store volatile i32 %arg29, ptr addrspace(1) poison
+  store volatile i32 %arg30, ptr addrspace(1) poison
+  store volatile i32 %arg31, ptr addrspace(1) poison
 
   ret void
 }
@@ -694,46 +694,46 @@ define void @too_many_args_use_workitem_id_x_stack_yz(
   i32 %arg16, i32 %arg17, i32 %arg18, i32 %arg19, i32 %arg20, i32 %arg21, i32 %arg22, i32 %arg23,
   i32 %arg24, i32 %arg25, i32 %arg26, i32 %arg27, i32 %arg28, i32 %arg29, i32 %arg30) #1 {
   %val0 = call i32 @llvm.amdgcn.workitem.id.x()
-  store volatile i32 %val0, ptr addrspace(1) undef
+  store volatile i32 %val0, ptr addrspace(1) poison
   %val1 = call i32 @llvm.amdgcn.workitem.id.y()
-  store volatile i32 %val1, ptr addrspace(1) undef
+  store volatile i32 %val1, ptr addrspace(1) poison
   %val2 = call i32 @llvm.amdgcn.workitem.id.z()
-  store volatile i32 %val2, ptr addrspace(1) undef
+  store volatile i32 %val2, ptr addrspace(1) poison
 
-  store volatile i32 %arg0, ptr addrspace(1) undef
-  store volatile i32 %arg1, ptr addrspace(1) undef
-  store volatile i32 %arg2, ptr addrspace(1) undef
-  store volatile i32 %arg3, ptr addrspace(1) undef
-  store volatile i32 %arg4, ptr addrspace(1) undef
-  store volatile i32 %arg5, ptr addrspace(1) undef
-  store volatile i32 %arg6, ptr addrspace(1) undef
-  store volatile i32 %arg7, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
+  store volatile i32 %arg1, ptr addrspace(1) poison
+  store volatile i32 %arg2, ptr addrspace(1) poison
+  store volatile i32 %arg3, ptr addrspace(1) poison
+  store volatile i32 %arg4, ptr addrspace(1) poison
+  store volatile i32 %arg5, ptr addrspace(1) poison
+  store volatile i32 %arg6, ptr addrspace(1) poison
+  store volatile i32 %arg7, ptr addrspace(1) poison
 
-  store volatile i32 %arg8, ptr addrspace(1) undef
-  store volatile i32 %arg9, ptr addrspace(1) undef
-  store volatile i32 %arg10, ptr addrspace(1) undef
-  store volatile i32 %arg11, ptr addrspace(1) undef
-  store volatile i32 %arg12, ptr addrspace(1) undef
-  store volatile i32 %arg13, ptr addrspace(1) undef
-  store volatile i32 %arg14, ptr addrspace(1) undef
-  store volatile i32 %arg15, ptr addrspace(1) undef
+  store volatile i32 %arg8, ptr addrspace(1) poison
+  store volatile i32 %arg9, ptr addrspace(1) poison
+  store volatile i32 %arg10, ptr addrspace(1) poison
+  store volatile i32 %arg11, ptr addrspace(1) poison
+  store volatile i32 %arg12, ptr addrspace(1) poison
+  store volatile i32 %arg13, ptr addrspace(1) poison
+  store volatile i32 %arg14, ptr addrspace(1) poison
+  store volatile i32 %arg15, ptr addrspace(1) poison
 
-  store volatile i32 %arg16, ptr addrspace(1) undef
-  store volatile i32 %arg17, ptr addrspace(1) undef
-  store volatile i32 %arg18, ptr addrspace(1) undef
-  store volatile i32 %arg19, ptr addrspace(1) undef
-  store volatile i32 %arg20, ptr addrspace(1) undef
-  store volatile i32 %arg21, ptr addrspace(1) undef
-  store volatile i32 %arg22, ptr addrspace(1) undef
-  store volatile i32 %arg23, ptr addrspace(1) undef
+  store volatile i32 %arg16, ptr addrspace(1) poison
+  store volatile i32 %arg17, ptr addrspace(1) poison
+  store volatile i32 %arg18, ptr addrspace(1) poison
+  store volatile i32 %arg19, ptr addrspace(1) poison
+  store volatile i32 %arg20, ptr addrspace(1) poison
+  store volatile i32 %arg21, ptr addrspace(1) poison
+  store volatile i32 %arg22, ptr addrspace(1) poison
+  store volatile i32 %arg23, ptr addrspace(1) poison
 
-  store volatile i32 %arg24, ptr addrspace(1) undef
-  store volatile i32 %arg25, ptr addrspace(1) undef
-  store volatile i32 %arg26, ptr addrspace(1) undef
-  store volatile i32 %arg27, ptr addrspace(1) undef
-  store volatile i32 %arg28, ptr addrspace(1) undef
-  store volatile i32 %arg29, ptr addrspace(1) undef
-  store volatile i32 %arg30, ptr addrspace(1) undef
+  store volatile i32 %arg24, ptr addrspace(1) poison
+  store volatile i32 %arg25, ptr addrspace(1) poison
+  store volatile i32 %arg26, ptr addrspace(1) poison
+  store volatile i32 %arg27, ptr addrspace(1) poison
+  store volatile i32 %arg28, ptr addrspace(1) poison
+  store volatile i32 %arg29, ptr addrspace(1) poison
+  store volatile i32 %arg30, ptr addrspace(1) poison
 
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/calling-conventions.ll
+++ b/llvm/test/CodeGen/AMDGPU/calling-conventions.ll
@@ -199,7 +199,7 @@ define amdgpu_kernel void @call_coldcc() #0 {
 ; GFX11-NEXT:    global_store_b32 v[0:1], v0, off
 ; GFX11-NEXT:    s_endpgm
   %val = call float @coldcc(float 1.0)
-  store float %val, ptr addrspace(1) undef
+  store float %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -293,7 +293,7 @@ define amdgpu_kernel void @call_fastcc() #0 {
 ; GFX11-NEXT:    global_store_b32 v[0:1], v0, off
 ; GFX11-NEXT:    s_endpgm
   %val = call float @fastcc(float 1.0)
-  store float %val, ptr addrspace(1) undef
+  store float %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -493,7 +493,7 @@ define amdgpu_ps void @ps_mesa_v2i16(<2 x i16> %arg0) {
 ; GFX11-NEXT:    global_store_b32 v[0:1], v0, off
 ; GFX11-NEXT:    s_endpgm
   %add = add <2 x i16> %arg0, <i16 1, i16 1>
-  store <2 x i16> %add, ptr addrspace(1) undef
+  store <2 x i16> %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -528,7 +528,7 @@ define amdgpu_ps void @ps_mesa_inreg_v2i16(<2 x i16> inreg %arg0) {
 ; GFX11-NEXT:    global_store_b32 v[0:1], v0, off
 ; GFX11-NEXT:    s_endpgm
   %add = add <2 x i16> %arg0, <i16 1, i16 1>
-  store <2 x i16> %add, ptr addrspace(1) undef
+  store <2 x i16> %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -650,7 +650,7 @@ define amdgpu_ps void @ps_mesa_inreg_v3i32(<3 x i32> inreg %arg0) {
 ; GFX11-NEXT:    global_store_b96 v[0:1], v[0:2], off
 ; GFX11-NEXT:    s_endpgm
   %add = add <3 x i32> %arg0, <i32 1, i32 2, i32 3>
-  store <3 x i32> %add, ptr addrspace(1) undef
+  store <3 x i32> %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -682,7 +682,7 @@ define amdgpu_ps void @ps_mesa_inreg_v3f32(<3 x float> inreg %arg0) {
 ; GFX11-NEXT:    global_store_b96 v[0:1], v[0:2], off
 ; GFX11-NEXT:    s_endpgm
   %add = fadd <3 x float> %arg0, <float 1.0, float 2.0, float 4.0>
-  store <3 x float> %add, ptr addrspace(1) undef
+  store <3 x float> %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -737,7 +737,7 @@ define amdgpu_ps void @ps_mesa_inreg_v5i32(<5 x i32> inreg %arg0) {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    s_endpgm
   %add = add <5 x i32> %arg0, <i32 1, i32 2, i32 3, i32 4, i32 5>
-  store <5 x i32> %add, ptr addrspace(1) undef
+  store <5 x i32> %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -778,7 +778,7 @@ define amdgpu_ps void @ps_mesa_inreg_v5f32(<5 x float> inreg %arg0) {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    s_endpgm
   %add = fadd <5 x float> %arg0, <float 1.0, float 2.0, float 4.0, float -1.0, float 0.5>
-  store <5 x float> %add, ptr addrspace(1) undef
+  store <5 x float> %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -810,7 +810,7 @@ define amdgpu_ps void @ps_mesa_v3i32(<3 x i32> %arg0) {
 ; GFX11-NEXT:    global_store_b96 v[0:1], v[0:2], off
 ; GFX11-NEXT:    s_endpgm
   %add = add <3 x i32> %arg0, <i32 1, i32 2, i32 3>
-  store <3 x i32> %add, ptr addrspace(1) undef
+  store <3 x i32> %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -841,7 +841,7 @@ define amdgpu_ps void @ps_mesa_v3f32(<3 x float> %arg0) {
 ; GFX11-NEXT:    global_store_b96 v[0:1], v[0:2], off
 ; GFX11-NEXT:    s_endpgm
   %add = fadd <3 x float> %arg0, <float 1.0, float 2.0, float 4.0>
-  store <3 x float> %add, ptr addrspace(1) undef
+  store <3 x float> %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -882,7 +882,7 @@ define amdgpu_ps void @ps_mesa_v5i32(<5 x i32> %arg0) {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    s_endpgm
   %add = add <5 x i32> %arg0, <i32 1, i32 2, i32 3, i32 4, i32 5>
-  store <5 x i32> %add, ptr addrspace(1) undef
+  store <5 x i32> %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -921,7 +921,7 @@ define amdgpu_ps void @ps_mesa_v5f32(<5 x float> %arg0) {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    s_endpgm
   %add = fadd <5 x float> %arg0, <float 1.0, float 2.0, float 4.0, float -1.0, float 0.5>
-  store <5 x float> %add, ptr addrspace(1) undef
+  store <5 x float> %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -946,7 +946,7 @@ define amdgpu_ps void @ps_mesa_i16(i16 %arg0) {
 ; GFX11-NEXT:    global_store_b16 v[0:1], v0, off
 ; GFX11-NEXT:    s_endpgm
   %add = add i16 %arg0, %arg0
-  store i16 %add, ptr addrspace(1) undef
+  store i16 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -977,7 +977,7 @@ define amdgpu_ps void @ps_mesa_inreg_i16(i16 inreg %arg0) {
 ; GFX11-NEXT:    global_store_b16 v[0:1], v0, off
 ; GFX11-NEXT:    s_endpgm
   %add = add i16 %arg0, %arg0
-  store i16 %add, ptr addrspace(1) undef
+  store i16 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -1021,7 +1021,7 @@ define amdgpu_kernel void @amd_kernel_i8(i8 %arg0) {
 ; GFX11-NEXT:    s_endpgm
 entry:
   %add = add i8 %arg0, %arg0
-  store i8 %add, ptr addrspace(1) undef
+  store i8 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -2173,7 +2173,7 @@ define amdgpu_cs void @amdgpu_cs_i1(i1 %arg0) {
 ; GFX11-NEXT:    v_and_b32_e32 v0, 1, v0
 ; GFX11-NEXT:    global_store_b8 v[0:1], v0, off
 ; GFX11-NEXT:    s_endpgm
-  store i1 %arg0, ptr addrspace(1) undef
+  store i1 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2261,7 +2261,7 @@ define amdgpu_cs void @amdgpu_cs_v8i1(<8 x i1> %arg0) {
 ; GFX11-NEXT:    v_or_b32_e32 v0, v0, v1
 ; GFX11-NEXT:    global_store_b8 v[0:1], v0, off
 ; GFX11-NEXT:    s_endpgm
-  store <8 x i1> %arg0, ptr addrspace(1) undef
+  store <8 x i1> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2421,7 +2421,7 @@ define amdgpu_cs void @amdgpu_cs_v16i1(<16 x i1> %arg0) {
 ; GFX11-NEXT:    v_or_b32_e32 v0, v0, v1
 ; GFX11-NEXT:    global_store_b16 v[0:1], v0, off
 ; GFX11-NEXT:    s_endpgm
-  store <16 x i1> %arg0, ptr addrspace(1) undef
+  store <16 x i1> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2720,7 +2720,7 @@ define amdgpu_cs void @amdgpu_cs_v32i1(<32 x i1> %arg0) {
 ; GFX11-NEXT:    v_or_b32_e32 v0, v0, v1
 ; GFX11-NEXT:    global_store_b32 v[0:1], v0, off
 ; GFX11-NEXT:    s_endpgm
-  store <32 x i1> %arg0, ptr addrspace(1) undef
+  store <32 x i1> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2748,7 +2748,7 @@ define amdgpu_cs void @amdgpu_cs_inreg_i1(i1 inreg %arg0) {
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX11-NEXT:    global_store_b8 v[0:1], v0, off
 ; GFX11-NEXT:    s_endpgm
-  store i1 %arg0, ptr addrspace(1) undef
+  store i1 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2836,7 +2836,7 @@ define amdgpu_cs void @amdgpu_cs_inreg_v8i1(<8 x i1> inreg %arg0) {
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX11-NEXT:    global_store_b8 v[0:1], v0, off
 ; GFX11-NEXT:    s_endpgm
-  store <8 x i1> %arg0, ptr addrspace(1) undef
+  store <8 x i1> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2996,7 +2996,7 @@ define amdgpu_cs void @amdgpu_cs_inreg_v16i1(<16 x i1> inreg %arg0) {
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX11-NEXT:    global_store_b16 v[0:1], v0, off
 ; GFX11-NEXT:    s_endpgm
-  store <16 x i1> %arg0, ptr addrspace(1) undef
+  store <16 x i1> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -3300,7 +3300,7 @@ define amdgpu_cs void @amdgpu_cs_inreg_v32i1(<32 x i1> inreg %arg0) {
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX11-NEXT:    global_store_b32 v[0:1], v0, off
 ; GFX11-NEXT:    s_endpgm
-  store <32 x i1> %arg0, ptr addrspace(1) undef
+  store <32 x i1> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -3324,7 +3324,7 @@ define amdgpu_cs void @amdgpu_cs_i1_sext(i1 signext %arg0) {
 ; GFX11-NEXT:    v_and_b32_e32 v0, 1, v0
 ; GFX11-NEXT:    global_store_b8 v[0:1], v0, off
 ; GFX11-NEXT:    s_endpgm
-  store i1 %arg0, ptr addrspace(1) undef
+  store i1 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -3345,7 +3345,7 @@ define amdgpu_cs void @amdgpu_cs_i1_zext(i1 zeroext %arg0) {
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    global_store_b8 v[0:1], v0, off
 ; GFX11-NEXT:    s_endpgm
-  store i1 %arg0, ptr addrspace(1) undef
+  store i1 %arg0, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/captured-frame-index.ll
+++ b/llvm/test/CodeGen/AMDGPU/captured-frame-index.ll
@@ -9,7 +9,7 @@ define amdgpu_kernel void @store_fi_lifetime(ptr addrspace(1) %out, i32 %in) #0 
 entry:
   %b = alloca i8, addrspace(5)
   call void @llvm.lifetime.start.p5(i64 1, ptr addrspace(5) %b)
-  store volatile ptr addrspace(5) %b, ptr addrspace(1) undef
+  store volatile ptr addrspace(5) %b, ptr addrspace(1) poison
   call void @llvm.lifetime.end.p5(i64 1, ptr addrspace(5) %b)
   ret void
 }
@@ -208,7 +208,7 @@ entry:
   %tmp1 = load volatile ptr addrspace(5), ptr addrspace(1) @g1, align 4
   %arrayidx = getelementptr inbounds i32, ptr addrspace(5) %tmp1, i32 %idx
   %tmp2 = load i32, ptr addrspace(5) %arrayidx, align 4
-  store volatile ptr addrspace(5) %b, ptr addrspace(1) undef
+  store volatile ptr addrspace(5) %b, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/cayman-loop-bug.ll
+++ b/llvm/test/CodeGen/AMDGPU/cayman-loop-bug.ll
@@ -23,7 +23,7 @@ outer_loop_body:
 
 inner_loop:
   %cnt2 = phi i32 [0, %outer_loop_body], [%cnt2_incr, %inner_loop_body]
-  %n = load volatile i32, ptr addrspace(1) undef
+  %n = load volatile i32, ptr addrspace(1) poison
   %cond2 = icmp slt i32 %cnt2, %n
   br i1 %cond2, label %inner_loop_body, label %outer_loop
 

--- a/llvm/test/CodeGen/AMDGPU/cgp-addressing-modes-gfx908.ll
+++ b/llvm/test/CodeGen/AMDGPU/cgp-addressing-modes-gfx908.ll
@@ -14,7 +14,7 @@ define amdgpu_kernel void @test_sink_small_offset_global_atomic_fadd_f32(ptr add
 ; OPT:       [[IF]]:
 ; OPT-NEXT:    [[IN_GEP:%.*]] = getelementptr float, ptr addrspace(1) [[IN]], i32 7
 ; OPT-NEXT:    [[FADD2:%.*]] = atomicrmw fadd ptr addrspace(1) [[IN_GEP]], float 2.000000e+00 syncscope("agent") seq_cst, align 4, !amdgpu.no.fine.grained.memory [[META0:![0-9]+]], !amdgpu.ignore.denormal.mode [[META0]]
-; OPT-NEXT:    [[VAL:%.*]] = load volatile float, ptr addrspace(1) undef, align 4
+; OPT-NEXT:    [[VAL:%.*]] = load volatile float, ptr addrspace(1) poison, align 4
 ; OPT-NEXT:    br label %[[ENDIF]]
 ; OPT:       [[ENDIF]]:
 ; OPT-NEXT:    [[X:%.*]] = phi float [ [[VAL]], %[[IF]] ], [ 0.000000e+00, %[[ENTRY]] ]
@@ -55,7 +55,7 @@ entry:
 if:
   %in.gep = getelementptr float, ptr addrspace(1) %in, i32 7
   %fadd2 = atomicrmw fadd ptr addrspace(1) %in.gep, float 2.000000e+00 syncscope("agent") seq_cst, align 4, !amdgpu.no.fine.grained.memory !0, !amdgpu.ignore.denormal.mode !0
-  %val = load volatile float, ptr addrspace(1) undef
+  %val = load volatile float, ptr addrspace(1) poison
   br label %endif
 
 endif:

--- a/llvm/test/CodeGen/AMDGPU/cgp-bitfield-extract.ll
+++ b/llvm/test/CodeGen/AMDGPU/cgp-bitfield-extract.ll
@@ -42,12 +42,12 @@ entry:
 
 bb0:
   %val0 = and i32 %shr, 255
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %ret
 
 bb1:
   %val1 = and i32 %shr, 127
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %ret
 
 ret:
@@ -82,12 +82,12 @@ entry:
 
 bb0:
   %val0 = and i32 %shr, 255
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %ret
 
 bb1:
   %val1 = and i32 %shr, 127
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %ret
 
 ret:
@@ -139,12 +139,12 @@ entry:
 
 bb0:
   %val0 = and i16 %shr, 255
-  store volatile i16 0, ptr addrspace(1) undef
+  store volatile i16 0, ptr addrspace(1) poison
   br label %ret
 
 bb1:
   %val1 = and i16 %shr, 127
-  store volatile i16 0, ptr addrspace(1) undef
+  store volatile i16 0, ptr addrspace(1) poison
   br label %ret
 
 ret:
@@ -190,12 +190,12 @@ entry:
 
 bb0:
   %val0 = and i64 %shr, 255
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %ret
 
 bb1:
   %val1 = and i64 %shr, 127
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %ret
 
 ret:
@@ -238,12 +238,12 @@ entry:
 
 bb0:
   %val0 = and i64 %shr, 255
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %ret
 
 bb1:
   %val1 = and i64 %shr, 127
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %ret
 
 ret:
@@ -284,12 +284,12 @@ entry:
 
 bb0:
   %val0 = and i64 %shr, 255
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %ret
 
 bb1:
   %val1 = and i64 %shr, 127
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %ret
 
 ret:

--- a/llvm/test/CodeGen/AMDGPU/clamp-modifier.ll
+++ b/llvm/test/CodeGen/AMDGPU/clamp-modifier.ll
@@ -150,7 +150,7 @@ define amdgpu_kernel void @v_clamp_multi_use_src_f32(ptr addrspace(1) %out, ptr 
   %max = call float @llvm.maxnum.f32(float %add, float 0.0)
   %clamp = call float @llvm.minnum.f32(float %max, float 1.0)
   store float %clamp, ptr addrspace(1) %out.gep
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/clamp.ll
+++ b/llvm/test/CodeGen/AMDGPU/clamp.ll
@@ -535,7 +535,7 @@ define amdgpu_kernel void @v_clamp_multi_use_max_f32(ptr addrspace(1) %out, ptr 
   %med = call float @llvm.minnum.f32(float %max, float 1.0)
 
   store float %med, ptr addrspace(1) %out.gep
-  store volatile float %max, ptr addrspace(1) undef
+  store volatile float %max, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/cndmask-no-def-vcc.ll
+++ b/llvm/test/CodeGen/AMDGPU/cndmask-no-def-vcc.ll
@@ -21,7 +21,7 @@ bb0:
   br i1 %tmp9, label %bb1, label %bb2
 
 bb1:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %bb2
 
 bb2:
@@ -47,7 +47,7 @@ bb0:
   br i1 %tmp9, label %bb1, label %bb2
 
 bb1:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %bb2
 
 bb2:

--- a/llvm/test/CodeGen/AMDGPU/coalesce-vgpr-alignment.ll
+++ b/llvm/test/CodeGen/AMDGPU/coalesce-vgpr-alignment.ll
@@ -26,11 +26,11 @@ bb:
 ; GCN:     global_store_dwordx4 v[{{[0-9]*[02468]:[0-9]*[13579]}}], v[{{[0-9]*[02468]:[0-9]*[13579]}}]
 define amdgpu_kernel void @test_vector_creation() #0 {
 entry:
-  %tmp231 = load <4 x i16>, ptr addrspace(1) undef, align 2
+  %tmp231 = load <4 x i16>, ptr addrspace(1) poison, align 2
   %vext466 = shufflevector <4 x i16> %tmp231, <4 x i16> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison>
   %vecinit467 = shufflevector <8 x i16> poison, <8 x i16> %vext466, <8 x i32> <i32 0, i32 1, i32 8, i32 9, i32 10, i32 11, i32 poison, i32 poison>
   %vecinit471 = shufflevector <8 x i16> %vecinit467, <8 x i16> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 8, i32 9>
-  store <8 x i16> %vecinit471, ptr addrspace(1) undef, align 16
+  store <8 x i16> %vecinit471, ptr addrspace(1) poison, align 16
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/commute-compares.ll
+++ b/llvm/test/CodeGen/AMDGPU/commute-compares.ll
@@ -704,7 +704,7 @@ define amdgpu_kernel void @commute_uno_2.0_f64(ptr addrspace(1) %out, ptr addrsp
 define amdgpu_kernel void @commute_frameindex(ptr addrspace(1) nocapture %out) #0 {
 entry:
   %stack0 = alloca i32, addrspace(5)
-  %ptr0 = load volatile ptr addrspace(5), ptr addrspace(1) undef
+  %ptr0 = load volatile ptr addrspace(5), ptr addrspace(1) poison
   %eq = icmp eq ptr addrspace(5) %ptr0, %stack0
   %ext = zext i1 %eq to i32
   store volatile i32 %ext, ptr addrspace(1) %out

--- a/llvm/test/CodeGen/AMDGPU/constant-fold-mi-operands.ll
+++ b/llvm/test/CodeGen/AMDGPU/constant-fold-mi-operands.ll
@@ -92,7 +92,7 @@ define amdgpu_kernel void @fold_mi_s_not_0(ptr addrspace(1) %out, i32 %x) #0 {
 ; GCN-NEXT: v_mov_b32_e32 v[[RESULT_HI:[0-9]+]], -1{{$}}
 ; GCN-NEXT: buffer_store_dwordx2 v[[[RESULT_LO]]:[[RESULT_HI]]]
 define amdgpu_kernel void @fold_mi_v_not_0(ptr addrspace(1) %out) {
-  %vreg = load volatile i64, ptr addrspace(1) undef
+  %vreg = load volatile i64, ptr addrspace(1) poison
   %ctpop = call i64 @llvm.ctpop.i64(i64 %vreg)
   %xor = xor i64 %ctpop, -1
   store i64 %xor, ptr addrspace(1) %out
@@ -111,8 +111,8 @@ define amdgpu_kernel void @fold_mi_v_not_0(ptr addrspace(1) %out) {
 ; GCN-DAG: v_mov_b32_e32 v[[RESULT_HI:[0-9]+]], v[[VREG1_HI]]
 ; GCN: buffer_store_dwordx2 v[[[RESULT_LO]]:[[RESULT_HI]]]
 define amdgpu_kernel void @fold_mi_or_neg1(ptr addrspace(1) %out) {
-  %vreg0 = load volatile i64, ptr addrspace(1) undef
-  %vreg1 = load volatile i64, ptr addrspace(1) undef
+  %vreg0 = load volatile i64, ptr addrspace(1) poison
+  %vreg1 = load volatile i64, ptr addrspace(1) poison
   %ctpop = call i64 @llvm.ctpop.i64(i64 %vreg0)
   %xor = xor i64 %ctpop, -1
   %or = or i64 %xor, %vreg1
@@ -127,8 +127,8 @@ define amdgpu_kernel void @fold_mi_or_neg1(ptr addrspace(1) %out) {
 ; GCN: v_and_b32
 ; GCN-NOT: v_and_b32
 define amdgpu_kernel void @fold_mi_and_neg1(ptr addrspace(1) %out) {
-  %vreg0 = load volatile i64, ptr addrspace(1) undef
-  %vreg1 = load volatile i64, ptr addrspace(1) undef
+  %vreg0 = load volatile i64, ptr addrspace(1) poison
+  %vreg1 = load volatile i64, ptr addrspace(1) poison
   %ctpop = call i64 @llvm.ctpop.i64(i64 %vreg0)
   %xor = xor i64 %ctpop, -1
   %and = and i64 %xor, %vreg1

--- a/llvm/test/CodeGen/AMDGPU/control-flow-optnone.ll
+++ b/llvm/test/CodeGen/AMDGPU/control-flow-optnone.ll
@@ -41,7 +41,7 @@ bb9:                                              ; preds = %bb14, %bb8
   br i1 %tmp12, label %bb13, label %bb14
 
 bb13:                                             ; preds = %bb9
-  store volatile i32 0, ptr addrspace(1) undef, align 4
+  store volatile i32 0, ptr addrspace(1) poison, align 4
   br label %bb14
 
 bb14:                                             ; preds = %bb13, %bb9

--- a/llvm/test/CodeGen/AMDGPU/cross-block-use-is-not-abi-copy.ll
+++ b/llvm/test/CodeGen/AMDGPU/cross-block-use-is-not-abi-copy.ll
@@ -220,7 +220,7 @@ if.else:                                          ; preds = %entry
 
 if.end:                                           ; preds = %if.else, %if.then
   %call6.sink = phi <3 x i16> [ %call6, %if.else ], [ zeroinitializer, %if.then ]
-  store <3 x i16> %call6.sink, ptr addrspace(1) undef
+  store <3 x i16> %call6.sink, ptr addrspace(1) poison
   ret void
 }
 
@@ -271,7 +271,7 @@ if.else:                                          ; preds = %entry
 
 if.end:                                           ; preds = %if.else, %if.then
   %call6.sink = phi <3 x half> [ %call6, %if.else ], [ zeroinitializer, %if.then ]
-  store <3 x half> %call6.sink, ptr addrspace(1) undef
+  store <3 x half> %call6.sink, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/ctlz_zero_undef.ll
+++ b/llvm/test/CodeGen/AMDGPU/ctlz_zero_undef.ll
@@ -1827,7 +1827,7 @@ define amdgpu_kernel void @v_ctlz_zero_undef_i32_sel_eq_neg1_two_use(ptr addrspa
   %cmp = icmp eq i32 %val, 0
   %sel = select i1 %cmp, i32 -1, i32 %ctlz
   store volatile i32 %sel, ptr addrspace(1) %out
-  store volatile i1 %cmp, ptr addrspace(1) undef
+  store volatile i1 %cmp, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/cvt_f32_ubyte.ll
+++ b/llvm/test/CodeGen/AMDGPU/cvt_f32_ubyte.ll
@@ -179,7 +179,7 @@ define float @v_uitofp_to_f32_multi_use_lshr8_mask255(i32 %arg0) nounwind {
 ; GFX11-NEXT:    global_store_b32 v[0:1], v1, off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %lshr.8 = lshr i32 %arg0, 8
-  store i32 %lshr.8, ptr addrspace(1) undef
+  store i32 %lshr.8, ptr addrspace(1) poison
   %masked = and i32 %lshr.8, 255
   %cvt = uitofp i32 %masked to float
   ret float %cvt
@@ -2992,14 +2992,14 @@ entry:
   br label %for.body.i
 
 for.body.i:                                       ; preds = %for.body.i, %entry
-  %retval.sroa.0.0.copyload = load ptr, ptr addrspace(1) undef, align 8
+  %retval.sroa.0.0.copyload = load ptr, ptr addrspace(1) poison, align 8
   %add.ptr = getelementptr inbounds %Vec, ptr %retval.sroa.0.0.copyload, i64 undef
   %retval.sroa.0.0..sroa_cast_adr = addrspacecast ptr %add.ptr to ptr addrspace(1)
   %retval.sroa.0.0.copyload.i = load i32, ptr addrspace(1) %retval.sroa.0.0..sroa_cast_adr, align 1
   %p1.sroa.6.0.extract.shift = lshr i32 %retval.sroa.0.0.copyload.i, 24
   %p1.sroa.6.0.extract.trunc = trunc i32 %p1.sroa.6.0.extract.shift to i8
   %conv12 = uitofp i8 %p1.sroa.6.0.extract.trunc to float
-  %0 = load float, ptr addrspace(1) undef, align 8
+  %0 = load float, ptr addrspace(1) poison, align 8
   %mul = fmul contract float %0, %conv12
   %add = fadd contract float %mul, 5.000000e-01
   %conv13 = fptoui float %add to i8
@@ -3011,7 +3011,7 @@ for.body.i:                                       ; preds = %for.body.i, %entry
   %retval.sroa.2.0.insert.insert = or i32 %retval.sroa.3.0.insert.insert, %retval.sroa.2.0.insert.ext
   %retval.sroa.0.0.insert.ext = and i32 %retval.sroa.0.0.copyload.i, 255
   %retval.sroa.0.0.insert.insert = or i32 %retval.sroa.2.0.insert.insert, %retval.sroa.0.0.insert.ext
-  store i32 %retval.sroa.0.0.insert.insert, ptr addrspace(1) undef, align 1
+  store i32 %retval.sroa.0.0.insert.insert, ptr addrspace(1) poison, align 1
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/dag-divergence.ll
+++ b/llvm/test/CodeGen/AMDGPU/dag-divergence.ll
@@ -9,7 +9,7 @@ define amdgpu_kernel void @private_load_maybe_divergent(ptr addrspace(4) %k, ptr
   %load = load volatile i32, ptr addrspace(5) undef, align 4
   %gep = getelementptr inbounds i32, ptr addrspace(4) %k, i32 %load
   %maybe.not.uniform.load = load i32, ptr addrspace(4) %gep, align 4
-  store i32 %maybe.not.uniform.load, ptr addrspace(1) undef
+  store i32 %maybe.not.uniform.load, ptr addrspace(1) poison
   ret void
 }
 
@@ -25,7 +25,7 @@ define amdgpu_kernel void @flat_load_maybe_divergent(ptr addrspace(4) %k, ptr %f
   %load = load i32, ptr %flat, align 4
   %gep = getelementptr inbounds i32, ptr addrspace(4) %k, i32 %load
   %maybe.not.uniform.load = load i32, ptr addrspace(4) %gep, align 4
-  store i32 %maybe.not.uniform.load, ptr addrspace(1) undef
+  store i32 %maybe.not.uniform.load, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/dead-machine-elim-after-dead-lane.ll
+++ b/llvm/test/CodeGen/AMDGPU/dead-machine-elim-after-dead-lane.ll
@@ -12,7 +12,7 @@ entry:
   ]
 
 sw.bb4:
-  %x = load i64, ptr addrspace(1) undef, align 8
+  %x = load i64, ptr addrspace(1) poison, align 8
   %c = sitofp i64 %x to float
   %v = insertelement <2 x float> <float poison, float 0.000000e+00>, float %c, i32 0
   br label %foo.exit
@@ -23,6 +23,6 @@ sw.bb10:
 foo.exit:
   %agg = phi <2 x float> [ %v, %sw.bb4 ], [ zeroinitializer, %entry ]
   %s = extractelement <2 x float> %agg, i32 1
-  store float %s, ptr addrspace(1) undef, align 4
+  store float %s, ptr addrspace(1) poison, align 4
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/debug-value.ll
+++ b/llvm/test/CodeGen/AMDGPU/debug-value.ll
@@ -4,8 +4,8 @@
 
 define amdgpu_kernel void @wobble(ptr addrspace(1) nocapture readonly %arg) #0 !dbg !4 {
 bb:
-  %tmp = load i32, ptr addrspace(1) undef, align 4
-  %tmp1 = load <4 x float>, ptr addrspace(1) undef, align 16
+  %tmp = load i32, ptr addrspace(1) poison, align 4
+  %tmp1 = load <4 x float>, ptr addrspace(1) poison, align 16
   %tmp2 = sext i32 %tmp to i64
   %tmp3 = shufflevector <4 x float> poison, <4 x float> %tmp1, <2 x i32> <i32 3, i32 7>
   %tmp4 = call float @barney() #2
@@ -41,11 +41,11 @@ bb28:                                             ; preds = %bb25, %bb21
   %tmp32 = sext i32 %tmp31 to i64
   %tmp33 = getelementptr inbounds <2 x float>, ptr addrspace(1) %arg, i64 %tmp32
   %tmp35 = load i64, ptr addrspace(1) %tmp33, align 8
-  %tmp36 = load i32, ptr addrspace(1) undef, align 4
+  %tmp36 = load i32, ptr addrspace(1) poison, align 4
   %tmp37 = sext i32 %tmp36 to i64
   %tmp38 = getelementptr inbounds <4 x float>, ptr addrspace(1) null, i64 %tmp37
   %tmp39 = load <4 x float>, ptr addrspace(1) %tmp38, align 16
-  %tmp40 = load <4 x float>, ptr addrspace(1) undef, align 16
+  %tmp40 = load <4 x float>, ptr addrspace(1) poison, align 16
   %tmp41 = fsub <4 x float> zeroinitializer, %tmp40
   %tmp42 = fsub <4 x float> %tmp39, %tmp40
   %tmp43 = extractelement <4 x float> %tmp40, i32 1
@@ -76,8 +76,8 @@ bb28:                                             ; preds = %bb25, %bb21
   %tmp63 = fsub <2 x float> %tmp62, %tmp59
   %tmp64 = extractelement <2 x float> %tmp63, i64 0
   call void @eggs(float %tmp64) #2
-  store <2 x float> %tmp3, ptr addrspace(1) undef, align 8
-  store float 0.000000e+00, ptr addrspace(1) undef, align 4
+  store <2 x float> %tmp3, ptr addrspace(1) poison, align 8
+  store float 0.000000e+00, ptr addrspace(1) poison, align 4
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/early-inline.ll
+++ b/llvm/test/CodeGen/AMDGPU/early-inline.ll
@@ -19,7 +19,7 @@ entry:
 define amdgpu_kernel void @caller(i32 %x) {
 entry:
   %res = call i32 @callee(i32 %x)
-  store volatile i32 %res, ptr addrspace(1) undef
+  store volatile i32 %res, ptr addrspace(1) poison
   ret void
 }
 
@@ -29,6 +29,6 @@ entry:
 define amdgpu_kernel void @alias_caller(i32 %x) {
 entry:
   %res = call i32 @c_alias(i32 %x)
-  store volatile i32 %res, ptr addrspace(1) undef
+  store volatile i32 %res, ptr addrspace(1) poison
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/extract_vector_elt-f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/extract_vector_elt-f16.ll
@@ -414,7 +414,7 @@ define amdgpu_kernel void @v_insertelement_v4f16_dynamic_vgpr(ptr addrspace(1) %
   %tid.ext = sext i32 %tid to i64
   %in.gep = getelementptr inbounds <4 x half>, ptr addrspace(1) %in, i64 %tid.ext
   %out.gep = getelementptr inbounds half, ptr addrspace(1) %out, i64 %tid.ext
-  %idx.val = load volatile i32, ptr addrspace(1) undef
+  %idx.val = load volatile i32, ptr addrspace(1) poison
   %vec = load <4 x half>, ptr addrspace(1) %in.gep
   %vec.extract = extractelement <4 x half> %vec, i32 %idx.val
   store half %vec.extract, ptr addrspace(1) %out.gep
@@ -475,8 +475,8 @@ define amdgpu_kernel void @reduce_load_vector_v8f16_extract_01(ptr addrspace(4) 
   %load = load <16 x half>, ptr addrspace(4) %ptr
   %elt0 = extractelement <16 x half> %load, i32 0
   %elt1 = extractelement <16 x half> %load, i32 1
-  store volatile half %elt0, ptr addrspace(1) undef, align 2
-  store volatile half %elt1, ptr addrspace(1) undef, align 2
+  store volatile half %elt0, ptr addrspace(1) poison, align 2
+  store volatile half %elt1, ptr addrspace(1) poison, align 2
   ret void
 }
 
@@ -534,8 +534,8 @@ define amdgpu_kernel void @reduce_load_vector_v8f16_extract_23(ptr addrspace(4) 
   %load = load <16 x half>, ptr addrspace(4) %ptr
   %elt2 = extractelement <16 x half> %load, i32 2
   %elt3 = extractelement <16 x half> %load, i32 3
-  store volatile half %elt2, ptr addrspace(1) undef, align 2
-  store volatile half %elt3, ptr addrspace(1) undef, align 2
+  store volatile half %elt2, ptr addrspace(1) poison, align 2
+  store volatile half %elt3, ptr addrspace(1) poison, align 2
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/extract_vector_elt-i16.ll
+++ b/llvm/test/CodeGen/AMDGPU/extract_vector_elt-i16.ll
@@ -145,8 +145,8 @@ define amdgpu_kernel void @reduce_load_vector_v8i16_extract_01(ptr addrspace(4) 
   %load = load <16 x i16>, ptr addrspace(4) %ptr
   %elt0 = extractelement <16 x i16> %load, i32 0
   %elt1 = extractelement <16 x i16> %load, i32 1
-  store volatile i16 %elt0, ptr addrspace(1) undef, align 2
-  store volatile i16 %elt1, ptr addrspace(1) undef, align 2
+  store volatile i16 %elt0, ptr addrspace(1) poison, align 2
+  store volatile i16 %elt1, ptr addrspace(1) poison, align 2
   ret void
 }
 
@@ -160,8 +160,8 @@ define amdgpu_kernel void @reduce_load_vector_v8i16_extract_23(ptr addrspace(4) 
   %load = load <16 x i16>, ptr addrspace(4) %ptr
   %elt2 = extractelement <16 x i16> %load, i32 2
   %elt3 = extractelement <16 x i16> %load, i32 3
-  store volatile i16 %elt2, ptr addrspace(1) undef, align 2
-  store volatile i16 %elt3, ptr addrspace(1) undef, align 2
+  store volatile i16 %elt2, ptr addrspace(1) poison, align 2
+  store volatile i16 %elt3, ptr addrspace(1) poison, align 2
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/extract_vector_elt-i8.ll
+++ b/llvm/test/CodeGen/AMDGPU/extract_vector_elt-i8.ll
@@ -548,10 +548,10 @@ define amdgpu_kernel void @reduce_load_vector_v8i8_extract_0123() #0 {
   %elt1 = extractelement <8 x i8> %load, i32 1
   %elt2 = extractelement <8 x i8> %load, i32 2
   %elt3 = extractelement <8 x i8> %load, i32 3
-  store volatile i8 %elt0, ptr addrspace(1) undef, align 1
-  store volatile i8 %elt1, ptr addrspace(1) undef, align 1
-  store volatile i8 %elt2, ptr addrspace(1) undef, align 1
-  store volatile i8 %elt3, ptr addrspace(1) undef, align 1
+  store volatile i8 %elt0, ptr addrspace(1) poison, align 1
+  store volatile i8 %elt1, ptr addrspace(1) poison, align 1
+  store volatile i8 %elt2, ptr addrspace(1) poison, align 1
+  store volatile i8 %elt3, ptr addrspace(1) poison, align 1
   ret void
 }
 
@@ -602,10 +602,10 @@ define amdgpu_kernel void @reduce_load_vector_v8i8_extract_0145() #0 {
   %elt1 = extractelement <8 x i8> %load, i32 1
   %elt4 = extractelement <8 x i8> %load, i32 4
   %elt5 = extractelement <8 x i8> %load, i32 5
-  store volatile i8 %elt0, ptr addrspace(1) undef, align 1
-  store volatile i8 %elt1, ptr addrspace(1) undef, align 1
-  store volatile i8 %elt4, ptr addrspace(1) undef, align 1
-  store volatile i8 %elt5, ptr addrspace(1) undef, align 1
+  store volatile i8 %elt0, ptr addrspace(1) poison, align 1
+  store volatile i8 %elt1, ptr addrspace(1) poison, align 1
+  store volatile i8 %elt4, ptr addrspace(1) poison, align 1
+  store volatile i8 %elt5, ptr addrspace(1) poison, align 1
   ret void
 }
 
@@ -640,8 +640,8 @@ define amdgpu_kernel void @reduce_load_vector_v8i8_extract_45() #0 {
   %load = load <8 x i8>, ptr addrspace(4) null
   %elt4 = extractelement <8 x i8> %load, i32 4
   %elt5 = extractelement <8 x i8> %load, i32 5
-  store volatile i8 %elt4, ptr addrspace(1) undef, align 1
-  store volatile i8 %elt5, ptr addrspace(1) undef, align 1
+  store volatile i8 %elt4, ptr addrspace(1) poison, align 1
+  store volatile i8 %elt5, ptr addrspace(1) poison, align 1
   ret void
 }
 
@@ -693,10 +693,10 @@ define amdgpu_kernel void @reduce_load_vector_v16i8_extract_0145() #0 {
   %elt1 = extractelement <16 x i8> %load, i32 1
   %elt4 = extractelement <16 x i8> %load, i32 4
   %elt5 = extractelement <16 x i8> %load, i32 5
-  store volatile i8 %elt0, ptr addrspace(1) undef, align 1
-  store volatile i8 %elt1, ptr addrspace(1) undef, align 1
-  store volatile i8 %elt4, ptr addrspace(1) undef, align 1
-  store volatile i8 %elt5, ptr addrspace(1) undef, align 1
+  store volatile i8 %elt0, ptr addrspace(1) poison, align 1
+  store volatile i8 %elt1, ptr addrspace(1) poison, align 1
+  store volatile i8 %elt4, ptr addrspace(1) poison, align 1
+  store volatile i8 %elt5, ptr addrspace(1) poison, align 1
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/fabs.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/fabs.f16.ll
@@ -651,8 +651,8 @@ define amdgpu_kernel void @v_extract_fabs_fold_v2f16(ptr addrspace(1) %in) #0 {
 
   %fmul0 = fmul half %elt0, 4.0
   %fadd1 = fadd half %elt1, 2.0
-  store volatile half %fmul0, ptr addrspace(1) undef
-  store volatile half %fadd1, ptr addrspace(1) undef
+  store volatile half %fmul0, ptr addrspace(1) poison
+  store volatile half %fadd1, ptr addrspace(1) poison
   ret void
 }
 
@@ -728,8 +728,8 @@ define amdgpu_kernel void @v_extract_fabs_no_fold_v2f16(ptr addrspace(1) %in) #0
   %fabs = call <2 x half> @llvm.fabs.v2f16(<2 x half> %val)
   %elt0 = extractelement <2 x half> %fabs, i32 0
   %elt1 = extractelement <2 x half> %fabs, i32 1
-  store volatile half %elt0, ptr addrspace(1) undef
-  store volatile half %elt1, ptr addrspace(1) undef
+  store volatile half %elt0, ptr addrspace(1) poison
+  store volatile half %elt1, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/fadd-fma-fmul-combine.ll
+++ b/llvm/test/CodeGen/AMDGPU/fadd-fma-fmul-combine.ll
@@ -71,15 +71,15 @@ define amdgpu_kernel void @fast_add_fmuladd_fmul() #0 {
 ; GCN-SLOWFMA-NEXT:    buffer_store_dword v0, off, s[0:3], 0
 ; GCN-SLOWFMA-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-SLOWFMA-NEXT:    s_endpgm
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
-  %u = load volatile float, ptr addrspace(1) undef
-  %v = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
+  %u = load volatile float, ptr addrspace(1) poison
+  %v = load volatile float, ptr addrspace(1) poison
   %mul.u.v = fmul fast float %u, %v
   %fma = call fast float @llvm.fmuladd.f32(float %x, float %y, float %mul.u.v)
   %add = fadd fast float %fma, %z
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -145,15 +145,15 @@ define amdgpu_kernel void @fast_sub_fmuladd_fmul() #0 {
 ; GCN-SLOWFMA-NEXT:    buffer_store_dword v0, off, s[0:3], 0
 ; GCN-SLOWFMA-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-SLOWFMA-NEXT:    s_endpgm
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
-  %u = load volatile float, ptr addrspace(1) undef
-  %v = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
+  %u = load volatile float, ptr addrspace(1) poison
+  %v = load volatile float, ptr addrspace(1) poison
   %mul.u.v = fmul fast float %u, %v
   %fma = call fast float @llvm.fmuladd.f32(float %x, float %y, float %mul.u.v)
   %add = fsub fast float %fma, %z
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -227,16 +227,16 @@ define amdgpu_kernel void @fast_add_fmuladd_fmul_multi_use_mul() #0 {
 ; GCN-SLOWFMA-NEXT:    buffer_store_dword v0, off, s[0:3], 0
 ; GCN-SLOWFMA-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-SLOWFMA-NEXT:    s_endpgm
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
-  %u = load volatile float, ptr addrspace(1) undef
-  %v = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
+  %u = load volatile float, ptr addrspace(1) poison
+  %v = load volatile float, ptr addrspace(1) poison
   %mul.u.v = fmul fast float %u, %v
-  store volatile float %mul.u.v, ptr addrspace(1) undef
+  store volatile float %mul.u.v, ptr addrspace(1) poison
   %fma = call fast float @llvm.fmuladd.f32(float %x, float %y, float %mul.u.v)
   %add = fadd fast float %fma, %z
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -310,16 +310,16 @@ define amdgpu_kernel void @fast_add_fmuladd_fmul_multi_use_mul_commute() #0 {
 ; GCN-SLOWFMA-NEXT:    buffer_store_dword v0, off, s[0:3], 0
 ; GCN-SLOWFMA-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-SLOWFMA-NEXT:    s_endpgm
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
-  %u = load volatile float, ptr addrspace(1) undef
-  %v = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
+  %u = load volatile float, ptr addrspace(1) poison
+  %v = load volatile float, ptr addrspace(1) poison
   %mul.u.v = fmul fast float %u, %v
-  store volatile float %mul.u.v, ptr addrspace(1) undef
+  store volatile float %mul.u.v, ptr addrspace(1) poison
   %fma = call fast float @llvm.fmuladd.f32(float %x, float %y, float %mul.u.v)
   %add = fadd fast float %z, %fma
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -393,16 +393,16 @@ define amdgpu_kernel void @fast_add_fmuladd_fmul_multi_use_fmuladd() #0 {
 ; GCN-SLOWFMA-NEXT:    buffer_store_dword v0, off, s[0:3], 0
 ; GCN-SLOWFMA-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-SLOWFMA-NEXT:    s_endpgm
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
-  %u = load volatile float, ptr addrspace(1) undef
-  %v = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
+  %u = load volatile float, ptr addrspace(1) poison
+  %v = load volatile float, ptr addrspace(1) poison
   %mul.u.v = fmul fast float %u, %v
   %fma = call fast float @llvm.fmuladd.f32(float %x, float %y, float %mul.u.v)
-  store volatile float %fma, ptr addrspace(1) undef
+  store volatile float %fma, ptr addrspace(1) poison
   %add = fadd fast float %fma, %z
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -476,16 +476,16 @@ define amdgpu_kernel void @fast_add_fmuladd_fmul_multi_use_fmuladd_commute() #0 
 ; GCN-SLOWFMA-NEXT:    buffer_store_dword v0, off, s[0:3], 0
 ; GCN-SLOWFMA-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-SLOWFMA-NEXT:    s_endpgm
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
-  %u = load volatile float, ptr addrspace(1) undef
-  %v = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
+  %u = load volatile float, ptr addrspace(1) poison
+  %v = load volatile float, ptr addrspace(1) poison
   %mul.u.v = fmul fast float %u, %v
   %fma = call fast float @llvm.fmuladd.f32(float %x, float %y, float %mul.u.v)
-  store volatile float %fma, ptr addrspace(1) undef
+  store volatile float %fma, ptr addrspace(1) poison
   %add = fadd fast float %z, %fma
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -559,16 +559,16 @@ define amdgpu_kernel void @fast_sub_fmuladd_fmul_multi_use_mul() #0 {
 ; GCN-SLOWFMA-NEXT:    buffer_store_dword v0, off, s[0:3], 0
 ; GCN-SLOWFMA-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-SLOWFMA-NEXT:    s_endpgm
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
-  %u = load volatile float, ptr addrspace(1) undef
-  %v = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
+  %u = load volatile float, ptr addrspace(1) poison
+  %v = load volatile float, ptr addrspace(1) poison
   %mul.u.v = fmul fast float %u, %v
   %fma = call fast float @llvm.fmuladd.f32(float %x, float %y, float %mul.u.v)
   %sub = fsub fast float %fma, %z
-  store volatile float %mul.u.v, ptr addrspace(1) undef
-  store volatile float %sub, ptr addrspace(1) undef
+  store volatile float %mul.u.v, ptr addrspace(1) poison
+  store volatile float %sub, ptr addrspace(1) poison
   ret void
 }
 
@@ -642,16 +642,16 @@ define amdgpu_kernel void @fast_sub_fmuladd_fmul_multi_use_fmuladd_lhs() #0 {
 ; GCN-SLOWFMA-NEXT:    buffer_store_dword v1, off, s[0:3], 0
 ; GCN-SLOWFMA-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-SLOWFMA-NEXT:    s_endpgm
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
-  %u = load volatile float, ptr addrspace(1) undef
-  %v = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
+  %u = load volatile float, ptr addrspace(1) poison
+  %v = load volatile float, ptr addrspace(1) poison
   %mul.u.v = fmul fast float %u, %v
   %fma = call fast float @llvm.fmuladd.f32(float %x, float %y, float %mul.u.v)
   %add = fsub fast float %fma, %z
-  store volatile float %fma, ptr addrspace(1) undef
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %fma, ptr addrspace(1) poison
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -725,16 +725,16 @@ define amdgpu_kernel void @fast_sub_fmuladd_fmul_multi_use_fmuladd_rhs() #0 {
 ; GCN-SLOWFMA-NEXT:    buffer_store_dword v1, off, s[0:3], 0
 ; GCN-SLOWFMA-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-SLOWFMA-NEXT:    s_endpgm
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
-  %u = load volatile float, ptr addrspace(1) undef
-  %v = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
+  %u = load volatile float, ptr addrspace(1) poison
+  %v = load volatile float, ptr addrspace(1) poison
   %mul.u.v = fmul fast float %u, %v
   %fma = call fast float @llvm.fmuladd.f32(float %x, float %y, float %mul.u.v)
   %add = fsub fast float %z, %fma
-  store volatile float %fma, ptr addrspace(1) undef
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %fma, ptr addrspace(1) poison
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -814,17 +814,17 @@ define amdgpu_kernel void @fast_sub_fmuladd_fpext_fmul_multi_use_fmuladd_lhs() #
 ; GCN-SLOWFMA-NEXT:    buffer_store_dword v1, off, s[0:3], 0
 ; GCN-SLOWFMA-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-SLOWFMA-NEXT:    s_endpgm
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
-  %u = load volatile half, ptr addrspace(1) undef
-  %v = load volatile half, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
+  %u = load volatile half, ptr addrspace(1) poison
+  %v = load volatile half, ptr addrspace(1) poison
   %mul.u.v.half = fmul fast half %u, %v
   %mul.u.v = fpext half %mul.u.v.half to float
   %fma = call fast float @llvm.fmuladd.f32(float %x, float %y, float %mul.u.v)
   %add = fsub fast float %fma, %z
-  store volatile float %fma, ptr addrspace(1) undef
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %fma, ptr addrspace(1) poison
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -904,17 +904,17 @@ define amdgpu_kernel void @fast_sub_fmuladd_fpext_fmul_multi_use_fmuladd_rhs() #
 ; GCN-SLOWFMA-NEXT:    buffer_store_dword v1, off, s[0:3], 0
 ; GCN-SLOWFMA-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-SLOWFMA-NEXT:    s_endpgm
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
-  %u = load volatile half, ptr addrspace(1) undef
-  %v = load volatile half, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
+  %u = load volatile half, ptr addrspace(1) poison
+  %v = load volatile half, ptr addrspace(1) poison
   %mul.u.v.half = fmul fast half %u, %v
   %mul.u.v = fpext half %mul.u.v.half to float
   %fma = call fast float @llvm.fmuladd.f32(float %x, float %y, float %mul.u.v)
   %add = fsub fast float %z, %fma
-  store volatile float %fma, ptr addrspace(1) undef
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %fma, ptr addrspace(1) poison
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/fcanonicalize-elimination.ll
+++ b/llvm/test/CodeGen/AMDGPU/fcanonicalize-elimination.ll
@@ -671,7 +671,7 @@ define amdgpu_kernel void @test_fold_canonicalize_select_value_f32(ptr addrspace
   %gep = getelementptr inbounds float, ptr addrspace(1) %arg, i32 %id
   %load0 = load volatile float, ptr addrspace(1) %gep, align 4
   %load1 = load volatile float, ptr addrspace(1) %gep, align 4
-  %load2 = load volatile i32, ptr addrspace(1) undef, align 4
+  %load2 = load volatile i32, ptr addrspace(1) poison, align 4
   %v0 = fadd float %load0, 15.0
   %v1 = fadd float %load1, 32.0
   %cond = icmp eq i32 %load2, 0

--- a/llvm/test/CodeGen/AMDGPU/fcanonicalize.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/fcanonicalize.f16.ll
@@ -129,7 +129,7 @@ define amdgpu_kernel void @v_test_canonicalize_var_f16(ptr addrspace(1) %out) #1
 ; GFX11-FAKE16-NEXT:    s_endpgm
   %val = load half, ptr addrspace(1) %out
   %canonicalized = call half @llvm.canonicalize.f16(half %val)
-  store half %canonicalized, ptr addrspace(1) undef
+  store half %canonicalized, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/fdiv.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/fdiv.f16.ll
@@ -1538,7 +1538,7 @@ define amdgpu_kernel void @div_afn_2_x_pat_f16(ptr addrspace(1) %out) #0 {
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX11-NEXT:    s_endpgm
-  %x = load half, ptr addrspace(1) undef
+  %x = load half, ptr addrspace(1) poison
   %rcp = fdiv afn half %x, 2.0
   store half %rcp, ptr addrspace(1) %out, align 4
   ret void
@@ -1603,7 +1603,7 @@ define amdgpu_kernel void @div_afn_k_x_pat_f16(ptr addrspace(1) %out) #0 {
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX11-NEXT:    s_endpgm
-  %x = load half, ptr addrspace(1) undef
+  %x = load half, ptr addrspace(1) poison
   %rcp = fdiv afn half %x, 10.0
   store half %rcp, ptr addrspace(1) %out, align 4
   ret void
@@ -1668,7 +1668,7 @@ define amdgpu_kernel void @div_afn_neg_k_x_pat_f16(ptr addrspace(1) %out) #0 {
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    global_store_b16 v1, v0, s[0:1]
 ; GFX11-NEXT:    s_endpgm
-  %x = load half, ptr addrspace(1) undef
+  %x = load half, ptr addrspace(1) poison
   %rcp = fdiv afn half %x, -10.0
   store half %rcp, ptr addrspace(1) %out, align 4
   ret void

--- a/llvm/test/CodeGen/AMDGPU/fdiv.f64.ll
+++ b/llvm/test/CodeGen/AMDGPU/fdiv.f64.ll
@@ -128,7 +128,7 @@ define amdgpu_kernel void @s_fdiv_v4f64(ptr addrspace(1) %out, <4 x double> %num
 ; GCN: v_mul_f64 [[MUL:v\[[0-9]+:[0-9]+\]]], s{{\[[0-9]+:[0-9]+\]}}, 0.5
 ; GCN: buffer_store_dwordx2 [[MUL]]
 define amdgpu_kernel void @div_fast_2_x_pat_f64(ptr addrspace(1) %out) #1 {
-  %x = load double, ptr addrspace(1) undef
+  %x = load double, ptr addrspace(1) poison
   %rcp = fdiv fast double %x, 2.0
   store double %rcp, ptr addrspace(1) %out, align 4
   ret void
@@ -140,7 +140,7 @@ define amdgpu_kernel void @div_fast_2_x_pat_f64(ptr addrspace(1) %out) #1 {
 ; GCN: v_mul_f64 [[MUL:v\[[0-9]+:[0-9]+\]]], s{{\[[0-9]+:[0-9]+\]}}, v[[[K_LO]]:[[K_HI]]]
 ; GCN: buffer_store_dwordx2 [[MUL]]
 define amdgpu_kernel void @div_fast_k_x_pat_f64(ptr addrspace(1) %out) #1 {
-  %x = load double, ptr addrspace(1) undef
+  %x = load double, ptr addrspace(1) poison
   %rcp = fdiv fast double %x, 10.0
   store double %rcp, ptr addrspace(1) %out, align 4
   ret void
@@ -152,7 +152,7 @@ define amdgpu_kernel void @div_fast_k_x_pat_f64(ptr addrspace(1) %out) #1 {
 ; GCN: v_mul_f64 [[MUL:v\[[0-9]+:[0-9]+\]]], s{{\[[0-9]+:[0-9]+\]}}, v[[[K_LO]]:[[K_HI]]]
 ; GCN: buffer_store_dwordx2 [[MUL]]
 define amdgpu_kernel void @div_fast_neg_k_x_pat_f64(ptr addrspace(1) %out) #1 {
-  %x = load double, ptr addrspace(1) undef
+  %x = load double, ptr addrspace(1) poison
   %rcp = fdiv fast double %x, -10.0
   store double %rcp, ptr addrspace(1) %out, align 4
   ret void

--- a/llvm/test/CodeGen/AMDGPU/fmed3.ll
+++ b/llvm/test/CodeGen/AMDGPU/fmed3.ll
@@ -5709,7 +5709,7 @@ define amdgpu_kernel void @v_test_safe_med3_f32_pat0_multi_use0(ptr addrspace(1)
   %b = load volatile float, ptr addrspace(1) %gep1
   %c = load volatile float, ptr addrspace(1) %gep2
   %tmp0 = call float @llvm.minnum.f32(float %a, float %b)
-  store volatile float %tmp0, ptr addrspace(1) undef
+  store volatile float %tmp0, ptr addrspace(1) poison
   %tmp1 = call float @llvm.maxnum.f32(float %a, float %b)
   %tmp2 = call float @llvm.minnum.f32(float %tmp1, float %c)
   %med3 = call float @llvm.maxnum.f32(float %tmp0, float %tmp2)
@@ -5937,7 +5937,7 @@ define amdgpu_kernel void @v_test_safe_med3_f32_pat0_multi_use1(ptr addrspace(1)
   %c = load volatile float, ptr addrspace(1) %gep2
   %tmp0 = call float @llvm.minnum.f32(float %a, float %b)
   %tmp1 = call float @llvm.maxnum.f32(float %a, float %b)
-  store volatile float %tmp1, ptr addrspace(1) undef
+  store volatile float %tmp1, ptr addrspace(1) poison
   %tmp2 = call float @llvm.minnum.f32(float %tmp1, float %c)
   %med3 = call float @llvm.maxnum.f32(float %tmp0, float %tmp2)
   store float %med3, ptr addrspace(1) %outgep
@@ -6140,7 +6140,7 @@ define amdgpu_kernel void @v_test_safe_med3_f32_pat0_multi_use2(ptr addrspace(1)
   %tmp0 = call float @llvm.minnum.f32(float %a, float %b)
   %tmp1 = call float @llvm.maxnum.f32(float %a, float %b)
   %tmp2 = call float @llvm.minnum.f32(float %tmp1, float %c)
-  store volatile float %tmp2, ptr addrspace(1) undef
+  store volatile float %tmp2, ptr addrspace(1) poison
   %med3 = call float @llvm.maxnum.f32(float %tmp0, float %tmp2)
   store float %med3, ptr addrspace(1) %outgep
   ret void
@@ -8139,7 +8139,7 @@ define amdgpu_kernel void @one_non_inline_constant(ptr addrspace(1) %out, ptr ad
   store float %med, ptr addrspace(1) %out.gep
 
   %extra.use = fadd float %a, 16.0
-  store volatile float %extra.use, ptr addrspace(1) undef
+  store volatile float %extra.use, ptr addrspace(1) poison
   ret void
 }
 
@@ -8343,9 +8343,9 @@ define amdgpu_kernel void @two_non_inline_constant_multi_use(ptr addrspace(1) %o
   store float %med, ptr addrspace(1) %out.gep
 
   %extra.use0 = fadd float %a, 16.0
-  store volatile float %extra.use0, ptr addrspace(1) undef
+  store volatile float %extra.use0, ptr addrspace(1) poison
   %extra.use1 = fadd float %a, 8.0
-  store volatile float %extra.use1, ptr addrspace(1) undef
+  store volatile float %extra.use1, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/fminnum.f64.ll
+++ b/llvm/test/CodeGen/AMDGPU/fminnum.f64.ll
@@ -18,7 +18,7 @@ declare <16 x double> @llvm.minnum.v16f64(<16 x double>, <16 x double>) #0
 ; GCN: v_min_f64 [[RESULT:v\[[0-9]+:[0-9]+\]]], [[QUIETB]], [[QUIETA]]
 define amdgpu_kernel void @test_fmin_f64_ieee_noflush([8 x i32], double %a, [8 x i32], double %b) #1 {
   %val = call double @llvm.minnum.f64(double %a, double %b) #0
-  store double %val, ptr addrspace(1) undef, align 8
+  store double %val, ptr addrspace(1) poison, align 8
   ret void
 }
 
@@ -34,7 +34,7 @@ define amdgpu_kernel void @test_fmin_f64_ieee_noflush([8 x i32], double %a, [8 x
 ; GCN: v_min_f64 [[RESULT:v\[[0-9]+:[0-9]+\]]], [[QUIETB]], [[QUIETA]]
 define amdgpu_kernel void @test_fmin_f64_ieee_flush([8 x i32], double %a, [8 x i32], double %b) #2 {
   %val = call double @llvm.minnum.f64(double %a, double %b) #0
-  store double %val, ptr addrspace(1) undef, align 8
+  store double %val, ptr addrspace(1) poison, align 8
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/fneg-combines.ll
+++ b/llvm/test/CodeGen/AMDGPU/fneg-combines.ll
@@ -1538,7 +1538,7 @@ define amdgpu_kernel void @v_fneg_fp_extend_store_use_fneg_f32_to_f64(ptr addrsp
   %fpext = fpext float %fneg.a to double
   %fneg = fsub double -0.000000e+00, %fpext
   store volatile double %fneg, ptr addrspace(1) %out.gep
-  store volatile float %fneg.a, ptr addrspace(1) undef
+  store volatile float %fneg.a, ptr addrspace(1) poison
   ret void
 }
 
@@ -1557,7 +1557,7 @@ define amdgpu_kernel void @v_fneg_multi_use_fp_extend_fneg_f32_to_f64(ptr addrsp
   %fpext = fpext float %a to double
   %fneg = fsub double -0.000000e+00, %fpext
   store volatile double %fneg, ptr addrspace(1) %out.gep
-  store volatile double %fpext, ptr addrspace(1) undef
+  store volatile double %fpext, ptr addrspace(1) poison
   ret void
 }
 
@@ -1665,7 +1665,7 @@ define amdgpu_kernel void @v_fneg_fp_round_store_use_fneg_f64_to_f32(ptr addrspa
   %fpround = fptrunc double %fneg.a to float
   %fneg = fneg float %fpround
   store volatile float %fneg, ptr addrspace(1) %out.gep
-  store volatile double %fneg.a, ptr addrspace(1) undef
+  store volatile double %fneg.a, ptr addrspace(1) poison
   ret void
 }
 
@@ -1687,7 +1687,7 @@ define amdgpu_kernel void @v_fneg_fp_round_multi_use_fneg_f64_to_f32(ptr addrspa
   %fneg = fneg float %fpround
   %use1 = fmul double %fneg.a, %c
   store volatile float %fneg, ptr addrspace(1) %out.gep
-  store volatile double %use1, ptr addrspace(1) undef
+  store volatile double %use1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1759,7 +1759,7 @@ define amdgpu_kernel void @v_fneg_fp_round_store_use_fneg_f32_to_f16(ptr addrspa
   %fpround = fptrunc float %fneg.a to half
   %fneg = fsub half -0.000000e+00, %fpround
   store volatile half %fneg, ptr addrspace(1) %out.gep
-  store volatile float %fneg.a, ptr addrspace(1) undef
+  store volatile float %fneg.a, ptr addrspace(1) poison
   ret void
 }
 
@@ -1780,7 +1780,7 @@ define amdgpu_kernel void @v_fneg_fp_round_multi_use_fneg_f32_to_f16(ptr addrspa
   %fneg = fsub half -0.000000e+00, %fpround
   %use1 = fmul float %fneg.a, %c
   store volatile half %fneg, ptr addrspace(1) %out.gep
-  store volatile float %use1, ptr addrspace(1) undef
+  store volatile float %use1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1837,7 +1837,7 @@ define amdgpu_kernel void @v_fneg_rcp_store_use_fneg_f32(ptr addrspace(1) %out, 
   %rcp = call float @llvm.amdgcn.rcp.f32(float %fneg.a)
   %fneg = fneg float %rcp
   store volatile float %fneg, ptr addrspace(1) %out.gep
-  store volatile float %fneg.a, ptr addrspace(1) undef
+  store volatile float %fneg.a, ptr addrspace(1) poison
   ret void
 }
 
@@ -1858,7 +1858,7 @@ define amdgpu_kernel void @v_fneg_rcp_multi_use_fneg_f32(ptr addrspace(1) %out, 
   %fneg = fneg float %rcp
   %use1 = fmul float %fneg.a, %c
   store volatile float %fneg, ptr addrspace(1) %out.gep
-  store volatile float %use1, ptr addrspace(1) undef
+  store volatile float %use1, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/fneg.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/fneg.f16.ll
@@ -595,8 +595,8 @@ define amdgpu_kernel void @v_extract_fneg_fold_v2f16(ptr addrspace(1) %in) #0 {
 
   %fmul0 = fmul half %elt0, 4.0
   %fadd1 = fadd half %elt1, 2.0
-  store volatile half %fmul0, ptr addrspace(1) undef
-  store volatile half %fadd1, ptr addrspace(1) undef
+  store volatile half %fmul0, ptr addrspace(1) poison
+  store volatile half %fadd1, ptr addrspace(1) poison
   ret void
 }
 
@@ -648,8 +648,8 @@ define amdgpu_kernel void @v_extract_fneg_no_fold_v2f16(ptr addrspace(1) %in) #0
   %fneg = fsub <2 x half> <half -0.0, half -0.0>, %val
   %elt0 = extractelement <2 x half> %fneg, i32 0
   %elt1 = extractelement <2 x half> %fneg, i32 1
-  store volatile half %elt0, ptr addrspace(1) undef
-  store volatile half %elt1, ptr addrspace(1) undef
+  store volatile half %elt0, ptr addrspace(1) poison
+  store volatile half %elt1, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/fp-min-max-buffer-atomics.ll
+++ b/llvm/test/CodeGen/AMDGPU/fp-min-max-buffer-atomics.ll
@@ -223,7 +223,7 @@ define amdgpu_ps void @raw_buffer_atomic_min_rtn_f32(<4 x i32> inreg %rsrc, floa
 ; G_GFX1100-NEXT:    s_endpgm
 main_body:
   %ret = call float @llvm.amdgcn.raw.buffer.atomic.fmin.f32(float %data, <4 x i32> %rsrc, i32 %vindex, i32 0, i32 0)
-  store float %ret, ptr addrspace(1) undef
+  store float %ret, ptr addrspace(1) poison
   ret void
 }
 
@@ -597,7 +597,7 @@ define amdgpu_ps void @raw_buffer_atomic_max_rtn_f32(<4 x i32> inreg %rsrc, floa
 ; G_GFX1100-NEXT:    s_endpgm
 main_body:
   %ret = call float @llvm.amdgcn.raw.buffer.atomic.fmax.f32(float %data, <4 x i32> %rsrc, i32 %vindex, i32 0, i32 0)
-  store float %ret, ptr addrspace(1) undef
+  store float %ret, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/fp-min-max-buffer-ptr-atomics.ll
+++ b/llvm/test/CodeGen/AMDGPU/fp-min-max-buffer-ptr-atomics.ll
@@ -204,7 +204,7 @@ define amdgpu_ps void @raw_ptr_buffer_atomic_min_rtn_f32(ptr addrspace(8) inreg 
 ; G_GFX1100-NEXT:    s_endpgm
 main_body:
   %ret = call float @llvm.amdgcn.raw.ptr.buffer.atomic.fmin.f32(float %data, ptr addrspace(8) %rsrc, i32 %vindex, i32 0, i32 0)
-  store float %ret, ptr addrspace(1) undef
+  store float %ret, ptr addrspace(1) poison
   ret void
 }
 
@@ -548,7 +548,7 @@ define amdgpu_ps void @raw_ptr_buffer_atomic_max_rtn_f32(ptr addrspace(8) inreg 
 ; G_GFX1100-NEXT:    s_endpgm
 main_body:
   %ret = call float @llvm.amdgcn.raw.ptr.buffer.atomic.fmax.f32(float %data, ptr addrspace(8) %rsrc, i32 %vindex, i32 0, i32 0)
-  store float %ret, ptr addrspace(1) undef
+  store float %ret, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/fpext.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/fpext.f16.ll
@@ -765,7 +765,7 @@ entry:
   %a.neg = fsub half -0.0, %a.val
   %r.val = fpext half %a.neg to float
   store volatile float %r.val, ptr addrspace(1) %r
-  store volatile half %a.neg, ptr addrspace(1) undef
+  store volatile half %a.neg, ptr addrspace(1) poison
   ret void
 }
 
@@ -867,7 +867,7 @@ entry:
   %r.val = fpext half %a.neg to float
   %mul = fmul half %a.neg, %a.val
   store volatile float %r.val, ptr addrspace(1) %r
-  store volatile half %mul, ptr addrspace(1) undef
+  store volatile half %mul, ptr addrspace(1) poison
   ret void
 }
 
@@ -968,7 +968,7 @@ entry:
   %a.fabs = call half @llvm.fabs.f16(half %a.val)
   %r.val = fpext half %a.fabs to float
   store volatile float %r.val, ptr addrspace(1) %r
-  store volatile half %a.fabs, ptr addrspace(1) undef
+  store volatile half %a.fabs, ptr addrspace(1) poison
   ret void
 }
 
@@ -1070,7 +1070,7 @@ entry:
   %r.val = fpext half %a.fabs to float
   %mul = fmul half %a.fabs, %a.val
   store volatile float %r.val, ptr addrspace(1) %r
-  store volatile half %mul, ptr addrspace(1) undef
+  store volatile half %mul, ptr addrspace(1) poison
   ret void
 }
 
@@ -1172,7 +1172,7 @@ entry:
   %a.fneg.fabs = fsub half -0.0, %a.fabs
   %r.val = fpext half %a.fneg.fabs to float
   store volatile float %r.val, ptr addrspace(1) %r
-  store volatile half %a.fneg.fabs, ptr addrspace(1) undef
+  store volatile half %a.fneg.fabs, ptr addrspace(1) poison
   ret void
 }
 
@@ -1275,7 +1275,7 @@ entry:
   %r.val = fpext half %a.fneg.fabs to float
   %mul = fmul half %a.fneg.fabs, %a.val
   store volatile float %r.val, ptr addrspace(1) %r
-  store volatile half %mul, ptr addrspace(1) undef
+  store volatile half %mul, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/function-args-inreg.ll
+++ b/llvm/test/CodeGen/AMDGPU/function-args-inreg.ll
@@ -20,7 +20,7 @@ define void @void_func_i1_inreg(i1 inreg %arg0) #0 {
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX11-NEXT:    global_store_b8 v[0:1], v0, off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store i1 %arg0, ptr addrspace(1) undef
+  store i1 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -39,7 +39,7 @@ define void @void_func_i8_inreg(i8 inreg %arg0) #0 {
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX11-NEXT:    global_store_b8 v[0:1], v0, off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store i8 %arg0, ptr addrspace(1) undef
+  store i8 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -58,7 +58,7 @@ define void @void_func_i16_inreg(i16 inreg %arg0) #0 {
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX11-NEXT:    global_store_b16 v[0:1], v0, off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store i16 %arg0, ptr addrspace(1) undef
+  store i16 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -77,7 +77,7 @@ define void @void_func_i32_inreg(i32 inreg %arg0) #0 {
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX11-NEXT:    global_store_b32 v[0:1], v0, off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store i32 %arg0, ptr addrspace(1) undef
+  store i32 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -97,7 +97,7 @@ define void @void_func_i64_inreg(i64 inreg %arg0) #0 {
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    global_store_b64 v[0:1], v[0:1], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store i64 %arg0, ptr addrspace(1) undef
+  store i64 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -116,7 +116,7 @@ define void @void_func_f16_inreg(half inreg %arg0) #0 {
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX11-NEXT:    global_store_b16 v[0:1], v0, off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store half %arg0, ptr addrspace(1) undef
+  store half %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -135,7 +135,7 @@ define void @void_func_f32_inreg(float inreg %arg0) #0 {
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX11-NEXT:    global_store_b32 v[0:1], v0, off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store float %arg0, ptr addrspace(1) undef
+  store float %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -155,7 +155,7 @@ define void @void_func_f64_inreg(double inreg %arg0) #0 {
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    global_store_b64 v[0:1], v[0:1], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store double %arg0, ptr addrspace(1) undef
+  store double %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -174,7 +174,7 @@ define void @void_func_v2i16_inreg(<2 x i16> inreg %arg0) #0 {
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX11-NEXT:    global_store_b32 v[0:1], v0, off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <2 x i16> %arg0, ptr addrspace(1) undef
+  store <2 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -197,7 +197,7 @@ define void @void_func_v3i16_inreg(<3 x i16> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b16 v[0:1], v0, off
 ; GFX11-NEXT:    global_store_b32 v[0:1], v1, off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <3 x i16> %arg0, ptr addrspace(1) undef
+  store <3 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -226,7 +226,7 @@ define void @void_func_v4i16_inreg(<4 x i16> inreg %arg0) #0 {
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    global_store_b64 v[0:1], v[0:1], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <4 x i16> %arg0, ptr addrspace(1) undef
+  store <4 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -251,7 +251,7 @@ define void @void_func_v5i16_inreg(<5 x i16> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b16 v[0:1], v2, off
 ; GFX11-NEXT:    global_store_b64 v[0:1], v[0:1], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <5 x i16> %arg0, ptr addrspace(1) undef
+  store <5 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -274,7 +274,7 @@ define void @void_func_v8i16_inreg(<8 x i16> inreg %arg0) #0 {
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <8 x i16> %arg0, ptr addrspace(1) undef
+  store <8 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -294,7 +294,7 @@ define void @void_func_v2i32_inreg(<2 x i32> inreg %arg0) #0 {
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    global_store_b64 v[0:1], v[0:1], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <2 x i32> %arg0, ptr addrspace(1) undef
+  store <2 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -316,7 +316,7 @@ define void @void_func_v3i32_inreg(<3 x i32> inreg %arg0) #0 {
 ; GFX11-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX11-NEXT:    global_store_b96 v[0:1], v[0:2], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <3 x i32> %arg0, ptr addrspace(1) undef
+  store <3 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -339,7 +339,7 @@ define void @void_func_v4i32_inreg(<4 x i32> inreg %arg0) #0 {
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <4 x i32> %arg0, ptr addrspace(1) undef
+  store <4 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -367,7 +367,7 @@ define void @void_func_v5i32_inreg(<5 x i32> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b32 v[0:1], v4, off
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <5 x i32> %arg0, ptr addrspace(1) undef
+  store <5 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -400,7 +400,7 @@ define void @void_func_v8i32_inreg(<8 x i32> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[4:7], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <8 x i32> %arg0, ptr addrspace(1) undef
+  store <8 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -480,7 +480,7 @@ define void @void_func_v16i32_inreg(<16 x i32> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[8:11], off
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[12:15], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <16 x i32> %arg0, ptr addrspace(1) undef
+  store <16 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -541,7 +541,7 @@ define void @void_func_v32i32_inreg(<32 x i32> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[8:11], off
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[16:19], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <32 x i32> %arg0, ptr addrspace(1) undef
+  store <32 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -564,7 +564,7 @@ define void @void_func_v2i64_inreg(<2 x i64> inreg %arg0) #0 {
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <2 x i64> %arg0, ptr addrspace(1) undef
+  store <2 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -593,7 +593,7 @@ define void @void_func_v3i64_inreg(<3 x i64> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b64 v[0:1], v[4:5], off
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <3 x i64> %arg0, ptr addrspace(1) undef
+  store <3 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -626,7 +626,7 @@ define void @void_func_v4i64_inreg(<4 x i64> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[4:7], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <4 x i64> %arg0, ptr addrspace(1) undef
+  store <4 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -665,7 +665,7 @@ define void @void_func_v5i64_inreg(<5 x i64> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[4:7], off
 ; GFX11-NEXT:    global_store_b64 v[0:1], v[8:9], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <5 x i64> %arg0, ptr addrspace(1) undef
+  store <5 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -716,7 +716,7 @@ define void @void_func_v8i64_inreg(<8 x i64> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[8:11], off
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[12:15], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <8 x i64> %arg0, ptr addrspace(1) undef
+  store <8 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -777,7 +777,7 @@ define void @void_func_v16i64_inreg(<16 x i64> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[8:11], off
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[16:19], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <16 x i64> %arg0, ptr addrspace(1) undef
+  store <16 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -796,7 +796,7 @@ define void @void_func_v2f16_inreg(<2 x half> inreg %arg0) #0 {
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX11-NEXT:    global_store_b32 v[0:1], v0, off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <2 x half> %arg0, ptr addrspace(1) undef
+  store <2 x half> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -819,7 +819,7 @@ define void @void_func_v3f16_inreg(<3 x half> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b16 v[0:1], v0, off
 ; GFX11-NEXT:    global_store_b32 v[0:1], v1, off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <3 x half> %arg0, ptr addrspace(1) undef
+  store <3 x half> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -839,7 +839,7 @@ define void @void_func_v4f16_inreg(<4 x half> inreg %arg0) #0 {
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    global_store_b64 v[0:1], v[0:1], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <4 x half> %arg0, ptr addrspace(1) undef
+  store <4 x half> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -862,7 +862,7 @@ define void @void_func_v8f16_inreg(<8 x half> inreg %arg0) #0 {
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <8 x half> %arg0, ptr addrspace(1) undef
+  store <8 x half> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -895,7 +895,7 @@ define void @void_func_v16f16_inreg(<16 x half> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[4:7], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <16 x half> %arg0, ptr addrspace(1) undef
+  store <16 x half> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -915,7 +915,7 @@ define void @void_func_v2f32_inreg(<2 x float> inreg %arg0) #0 {
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    global_store_b64 v[0:1], v[0:1], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <2 x float> %arg0, ptr addrspace(1) undef
+  store <2 x float> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -937,7 +937,7 @@ define void @void_func_v3f32_inreg(<3 x float> inreg %arg0) #0 {
 ; GFX11-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX11-NEXT:    global_store_b96 v[0:1], v[0:2], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <3 x float> %arg0, ptr addrspace(1) undef
+  store <3 x float> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -960,7 +960,7 @@ define void @void_func_v4f32_inreg(<4 x float> inreg %arg0) #0 {
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <4 x float> %arg0, ptr addrspace(1) undef
+  store <4 x float> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -993,7 +993,7 @@ define void @void_func_v8f32_inreg(<8 x float> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[4:7], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <8 x float> %arg0, ptr addrspace(1) undef
+  store <8 x float> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1044,7 +1044,7 @@ define void @void_func_v16f32_inreg(<16 x float> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[8:11], off
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[12:15], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <16 x float> %arg0, ptr addrspace(1) undef
+  store <16 x float> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1067,7 +1067,7 @@ define void @void_func_v2f64_inreg(<2 x double> inreg %arg0) #0 {
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <2 x double> %arg0, ptr addrspace(1) undef
+  store <2 x double> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1096,7 +1096,7 @@ define void @void_func_v3f64_inreg(<3 x double> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b64 v[0:1], v[4:5], off
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <3 x double> %arg0, ptr addrspace(1) undef
+  store <3 x double> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1129,7 +1129,7 @@ define void @void_func_v4f64_inreg(<4 x double> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[4:7], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <4 x double> %arg0, ptr addrspace(1) undef
+  store <4 x double> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1180,7 +1180,7 @@ define void @void_func_v8f64_inreg(<8 x double> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[8:11], off
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[12:15], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <8 x double> %arg0, ptr addrspace(1) undef
+  store <8 x double> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1241,7 +1241,7 @@ define void @void_func_v16f64_inreg(<16 x double> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[8:11], off
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[16:19], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <16 x double> %arg0, ptr addrspace(1) undef
+  store <16 x double> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1331,11 +1331,11 @@ define void @void_func_v32i32_i1_i8_i16_f32_inreg(<32 x i32> inreg %arg0, i1 inr
 ; GFX11-NEXT:    global_store_b16 v[0:1], v17, off dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile i1 %arg1, ptr addrspace(1) undef
-  store volatile i8 %arg2, ptr addrspace(1) undef
-  store volatile i16 %arg3, ptr addrspace(1) undef
-  store volatile half %arg4, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile i1 %arg1, ptr addrspace(1) poison
+  store volatile i8 %arg2, ptr addrspace(1) poison
+  store volatile i16 %arg3, ptr addrspace(1) poison
+  store volatile half %arg4, ptr addrspace(1) poison
   ret void
 }
 
@@ -1415,9 +1415,9 @@ define void @void_func_v32i32_v2i32_v2f32_inreg(<32 x i32> inreg %arg0, <2 x i32
 ; GFX11-NEXT:    global_store_b64 v[0:1], v[16:17], off dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile <2 x i32> %arg1, ptr addrspace(1) undef
-  store volatile <2 x float> %arg2, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile <2 x i32> %arg1, ptr addrspace(1) poison
+  store volatile <2 x float> %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -1589,43 +1589,43 @@ define void @too_many_args_use_workitem_id_x_inreg(
   i32 inreg %arg16, i32 inreg %arg17, i32 inreg %arg18, i32 inreg %arg19, i32 inreg %arg20, i32 inreg %arg21, i32 inreg %arg22, i32 inreg %arg23,
   i32 inreg %arg24, i32 inreg %arg25, i32 inreg %arg26, i32 inreg %arg27, i32 inreg %arg28, i32 inreg %arg29, i32 inreg %arg30, i32 inreg %arg31) {
   ;%val = call i32 @llvm.amdgcn.workitem.id.x()
-  ;store volatile i32 %val, ptr addrspace(1) undef
+  ;store volatile i32 %val, ptr addrspace(1) poison
 
-  store volatile i32 %arg0, ptr addrspace(1) undef
-  store volatile i32 %arg1, ptr addrspace(1) undef
-  store volatile i32 %arg2, ptr addrspace(1) undef
-  store volatile i32 %arg3, ptr addrspace(1) undef
-  store volatile i32 %arg4, ptr addrspace(1) undef
-  store volatile i32 %arg5, ptr addrspace(1) undef
-  store volatile i32 %arg6, ptr addrspace(1) undef
-  store volatile i32 %arg7, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
+  store volatile i32 %arg1, ptr addrspace(1) poison
+  store volatile i32 %arg2, ptr addrspace(1) poison
+  store volatile i32 %arg3, ptr addrspace(1) poison
+  store volatile i32 %arg4, ptr addrspace(1) poison
+  store volatile i32 %arg5, ptr addrspace(1) poison
+  store volatile i32 %arg6, ptr addrspace(1) poison
+  store volatile i32 %arg7, ptr addrspace(1) poison
 
-  store volatile i32 %arg8, ptr addrspace(1) undef
-  store volatile i32 %arg9, ptr addrspace(1) undef
-  store volatile i32 %arg10, ptr addrspace(1) undef
-  store volatile i32 %arg11, ptr addrspace(1) undef
-  store volatile i32 %arg12, ptr addrspace(1) undef
-  store volatile i32 %arg13, ptr addrspace(1) undef
-  store volatile i32 %arg14, ptr addrspace(1) undef
-  store volatile i32 %arg15, ptr addrspace(1) undef
+  store volatile i32 %arg8, ptr addrspace(1) poison
+  store volatile i32 %arg9, ptr addrspace(1) poison
+  store volatile i32 %arg10, ptr addrspace(1) poison
+  store volatile i32 %arg11, ptr addrspace(1) poison
+  store volatile i32 %arg12, ptr addrspace(1) poison
+  store volatile i32 %arg13, ptr addrspace(1) poison
+  store volatile i32 %arg14, ptr addrspace(1) poison
+  store volatile i32 %arg15, ptr addrspace(1) poison
 
-  store volatile i32 %arg16, ptr addrspace(1) undef
-  store volatile i32 %arg17, ptr addrspace(1) undef
-  store volatile i32 %arg18, ptr addrspace(1) undef
-  store volatile i32 %arg19, ptr addrspace(1) undef
-  store volatile i32 %arg20, ptr addrspace(1) undef
-  store volatile i32 %arg21, ptr addrspace(1) undef
-  store volatile i32 %arg22, ptr addrspace(1) undef
-  store volatile i32 %arg23, ptr addrspace(1) undef
+  store volatile i32 %arg16, ptr addrspace(1) poison
+  store volatile i32 %arg17, ptr addrspace(1) poison
+  store volatile i32 %arg18, ptr addrspace(1) poison
+  store volatile i32 %arg19, ptr addrspace(1) poison
+  store volatile i32 %arg20, ptr addrspace(1) poison
+  store volatile i32 %arg21, ptr addrspace(1) poison
+  store volatile i32 %arg22, ptr addrspace(1) poison
+  store volatile i32 %arg23, ptr addrspace(1) poison
 
-  store volatile i32 %arg24, ptr addrspace(1) undef
-  store volatile i32 %arg25, ptr addrspace(1) undef
-  store volatile i32 %arg26, ptr addrspace(1) undef
-  store volatile i32 %arg27, ptr addrspace(1) undef
-  store volatile i32 %arg28, ptr addrspace(1) undef
-  store volatile i32 %arg29, ptr addrspace(1) undef
-  store volatile i32 %arg30, ptr addrspace(1) undef
-  store volatile i32 %arg31, ptr addrspace(1) undef
+  store volatile i32 %arg24, ptr addrspace(1) poison
+  store volatile i32 %arg25, ptr addrspace(1) poison
+  store volatile i32 %arg26, ptr addrspace(1) poison
+  store volatile i32 %arg27, ptr addrspace(1) poison
+  store volatile i32 %arg28, ptr addrspace(1) poison
+  store volatile i32 %arg29, ptr addrspace(1) poison
+  store volatile i32 %arg30, ptr addrspace(1) poison
+  store volatile i32 %arg31, ptr addrspace(1) poison
 
   ret void
 }
@@ -1651,8 +1651,8 @@ define void @void_func_i32_v2float_inreg(i32 inreg %arg0, <2 x float> inreg %arg
 ; GFX11-NEXT:    global_store_b32 v[0:1], v2, off
 ; GFX11-NEXT:    global_store_b64 v[0:1], v[0:1], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store i32 %arg0, ptr addrspace(1) undef
-  store <2 x float> %arg1, ptr addrspace(1) undef
+  store i32 %arg0, ptr addrspace(1) poison
+  store <2 x float> %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1764,7 +1764,7 @@ define void @void_func_bf16_inreg(bfloat inreg %arg0) #0 {
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX11-NEXT:    global_store_b16 v[0:1], v0, off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store bfloat %arg0, ptr addrspace(1) undef
+  store bfloat %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1783,7 +1783,7 @@ define void @void_func_v2bf16_inreg(<2 x bfloat> inreg %arg0) #0 {
 ; GFX11-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX11-NEXT:    global_store_b32 v[0:1], v0, off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <2 x bfloat> %arg0, ptr addrspace(1) undef
+  store <2 x bfloat> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1806,7 +1806,7 @@ define void @void_func_v3bf16_inreg(<3 x bfloat> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b16 v[0:1], v0, off
 ; GFX11-NEXT:    global_store_b32 v[0:1], v1, off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <3 x bfloat> %arg0, ptr addrspace(1) undef
+  store <3 x bfloat> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1826,7 +1826,7 @@ define void @void_func_v4bf16_inreg(<4 x bfloat> inreg %arg0) #0 {
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    global_store_b64 v[0:1], v[0:1], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <4 x bfloat> %arg0, ptr addrspace(1) undef
+  store <4 x bfloat> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1849,7 +1849,7 @@ define void @void_func_v8bf16_inreg(<8 x bfloat> inreg %arg0) #0 {
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <8 x bfloat> %arg0, ptr addrspace(1) undef
+  store <8 x bfloat> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1882,7 +1882,7 @@ define void @void_func_v16bf16_inreg(<16 x bfloat> inreg %arg0) #0 {
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[0:3], off
 ; GFX11-NEXT:    global_store_b128 v[0:1], v[4:7], off
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <16 x bfloat> %arg0, ptr addrspace(1) undef
+  store <16 x bfloat> %arg0, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/function-args.ll
+++ b/llvm/test/CodeGen/AMDGPU/function-args.ll
@@ -23,7 +23,7 @@ define void @void_func_i1(i1 %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b8 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store i1 %arg0, ptr addrspace(1) undef
+  store i1 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -48,7 +48,7 @@ define void @void_func_i1_zeroext(i1 zeroext %arg0) #0 {
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %ext = zext i1 %arg0 to i32
   %add = add i32 %ext, 12
-  store i32 %add, ptr addrspace(1) undef
+  store i32 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -93,7 +93,7 @@ define void @void_func_i1_signext(i1 signext %arg0) #0 {
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %ext = sext i1 %arg0 to i32
   %add = add i32 %ext, 12
-  store i32 %add, ptr addrspace(1) undef
+  store i32 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -138,7 +138,7 @@ bb:
   br i1 %arg, label %bb2, label %bb1
 
 bb1:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %bb2
 
 bb2:
@@ -162,7 +162,7 @@ define void @void_func_i8(i8 %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b8 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store i8 %arg0, ptr addrspace(1) undef
+  store i8 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -207,7 +207,7 @@ define void @void_func_i8_zeroext(i8 zeroext %arg0) #0 {
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %ext = zext i8 %arg0 to i32
   %add = add i32 %ext, 12
-  store i32 %add, ptr addrspace(1) undef
+  store i32 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -252,7 +252,7 @@ define void @void_func_i8_signext(i8 signext %arg0) #0 {
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %ext = sext i8 %arg0 to i32
   %add = add i32 %ext, 12
-  store i32 %add, ptr addrspace(1) undef
+  store i32 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -273,7 +273,7 @@ define void @void_func_i16(i16 %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b16 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store i16 %arg0, ptr addrspace(1) undef
+  store i16 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -318,7 +318,7 @@ define void @void_func_i16_zeroext(i16 zeroext %arg0) #0 {
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %ext = zext i16 %arg0 to i32
   %add = add i32 %ext, 12
-  store i32 %add, ptr addrspace(1) undef
+  store i32 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -363,7 +363,7 @@ define void @void_func_i16_signext(i16 signext %arg0) #0 {
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %ext = sext i16 %arg0 to i32
   %add = add i32 %ext, 12
-  store i32 %add, ptr addrspace(1) undef
+  store i32 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -384,7 +384,7 @@ define void @void_func_i32(i32 %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b32 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store i32 %arg0, ptr addrspace(1) undef
+  store i32 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -405,7 +405,7 @@ define void @void_func_i64(i64 %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b64 v[0:1], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store i64 %arg0, ptr addrspace(1) undef
+  store i64 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -436,7 +436,7 @@ define void @void_func_f16(half %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b16 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store half %arg0, ptr addrspace(1) undef
+  store half %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -457,7 +457,7 @@ define void @void_func_f32(float %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b32 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store float %arg0, ptr addrspace(1) undef
+  store float %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -478,7 +478,7 @@ define void @void_func_f64(double %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b64 v[0:1], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store double %arg0, ptr addrspace(1) undef
+  store double %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -499,7 +499,7 @@ define void @void_func_v2i32(<2 x i32> %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b64 v[0:1], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <2 x i32> %arg0, ptr addrspace(1) undef
+  store <2 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -520,7 +520,7 @@ define void @void_func_v3i32(<3 x i32> %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b96 v[0:2], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <3 x i32> %arg0, ptr addrspace(1) undef
+  store <3 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -541,7 +541,7 @@ define void @void_func_v4i32(<4 x i32> %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <4 x i32> %arg0, ptr addrspace(1) undef
+  store <4 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -565,7 +565,7 @@ define void @void_func_v5i32(<5 x i32> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b32 v4, off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <5 x i32> %arg0, ptr addrspace(1) undef
+  store <5 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -589,7 +589,7 @@ define void @void_func_v8i32(<8 x i32> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b128 v[4:7], off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <8 x i32> %arg0, ptr addrspace(1) undef
+  store <8 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -617,7 +617,7 @@ define void @void_func_v16i32(<16 x i32> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b128 v[4:7], off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <16 x i32> %arg0, ptr addrspace(1) undef
+  store <16 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -658,7 +658,7 @@ define void @void_func_v32i32(<32 x i32> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b128 v[4:7], off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <32 x i32> %arg0, ptr addrspace(1) undef
+  store <32 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -751,7 +751,7 @@ define void @void_func_v33i32(<33 x i32> %arg0) #0 {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    buffer_store_b32 v32, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <33 x i32> %arg0, ptr addrspace(1) undef
+  store <33 x i32> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -772,7 +772,7 @@ define void @void_func_v2i64(<2 x i64> %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <2 x i64> %arg0, ptr addrspace(1) undef
+  store <2 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -796,7 +796,7 @@ define void @void_func_v3i64(<3 x i64> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b64 v[4:5], off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <3 x i64> %arg0, ptr addrspace(1) undef
+  store <3 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -820,7 +820,7 @@ define void @void_func_v4i64(<4 x i64> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b128 v[4:7], off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <4 x i64> %arg0, ptr addrspace(1) undef
+  store <4 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -846,7 +846,7 @@ define void @void_func_v5i64(<5 x i64> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b64 v[8:9], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <5 x i64> %arg0, ptr addrspace(1) undef
+  store <5 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -874,7 +874,7 @@ define void @void_func_v8i64(<8 x i64> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b128 v[4:7], off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <8 x i64> %arg0, ptr addrspace(1) undef
+  store <8 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -915,7 +915,7 @@ define void @void_func_v16i64(<16 x i64> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b128 v[4:7], off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <16 x i64> %arg0, ptr addrspace(1) undef
+  store <16 x i64> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -990,7 +990,7 @@ define void @void_func_v2i16(<2 x i16> %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b32 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <2 x i16> %arg0, ptr addrspace(1) undef
+  store <2 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1632,7 +1632,7 @@ define void @void_func_v3i16(<3 x i16> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b16 v1, off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b32 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <3 x i16> %arg0, ptr addrspace(1) undef
+  store <3 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1668,7 +1668,7 @@ define void @void_func_v4i16(<4 x i16> %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b64 v[0:1], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <4 x i16> %arg0, ptr addrspace(1) undef
+  store <4 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1708,7 +1708,7 @@ define void @void_func_v5i16(<5 x i16> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b16 v2, off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b64 v[0:1], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <5 x i16> %arg0, ptr addrspace(1) undef
+  store <5 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1750,7 +1750,7 @@ define void @void_func_v8i16(<8 x i16> %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <8 x i16> %arg0, ptr addrspace(1) undef
+  store <8 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1808,7 +1808,7 @@ define void @void_func_v16i16(<16 x i16> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b128 v[4:7], off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <16 x i16> %arg0, ptr addrspace(1) undef
+  store <16 x i16> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1864,7 +1864,7 @@ define void @void_func_v2i24(<2 x i24> %arg0) #0 {
   %elt0 = extractelement <2 x i24> %arg0, i32 0
   %elt1 = extractelement <2 x i24> %arg0, i32 1
   %add = add i24 %elt0, %elt1
-  store i24 %add, ptr addrspace(1) undef
+  store i24 %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -1885,7 +1885,7 @@ define void @void_func_v2f32(<2 x float> %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b64 v[0:1], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <2 x float> %arg0, ptr addrspace(1) undef
+  store <2 x float> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1906,7 +1906,7 @@ define void @void_func_v3f32(<3 x float> %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b96 v[0:2], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <3 x float> %arg0, ptr addrspace(1) undef
+  store <3 x float> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1927,7 +1927,7 @@ define void @void_func_v4f32(<4 x float> %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <4 x float> %arg0, ptr addrspace(1) undef
+  store <4 x float> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1951,7 +1951,7 @@ define void @void_func_v8f32(<8 x float> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b128 v[4:7], off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <8 x float> %arg0, ptr addrspace(1) undef
+  store <8 x float> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -1979,7 +1979,7 @@ define void @void_func_v16f32(<16 x float> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b128 v[4:7], off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <16 x float> %arg0, ptr addrspace(1) undef
+  store <16 x float> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2000,7 +2000,7 @@ define void @void_func_v2f64(<2 x double> %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <2 x double> %arg0, ptr addrspace(1) undef
+  store <2 x double> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2024,7 +2024,7 @@ define void @void_func_v3f64(<3 x double> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b64 v[4:5], off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <3 x double> %arg0, ptr addrspace(1) undef
+  store <3 x double> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2048,7 +2048,7 @@ define void @void_func_v4f64(<4 x double> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b128 v[4:7], off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <4 x double> %arg0, ptr addrspace(1) undef
+  store <4 x double> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2076,7 +2076,7 @@ define void @void_func_v8f64(<8 x double> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b128 v[4:7], off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <8 x double> %arg0, ptr addrspace(1) undef
+  store <8 x double> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2117,7 +2117,7 @@ define void @void_func_v16f64(<16 x double> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b128 v[4:7], off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <16 x double> %arg0, ptr addrspace(1) undef
+  store <16 x double> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2151,7 +2151,7 @@ define void @void_func_v2f16(<2 x half> %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b32 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <2 x half> %arg0, ptr addrspace(1) undef
+  store <2 x half> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2191,7 +2191,7 @@ define void @void_func_v3f16(<3 x half> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b16 v1, off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b32 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <3 x half> %arg0, ptr addrspace(1) undef
+  store <3 x half> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2229,7 +2229,7 @@ define void @void_func_v4f16(<4 x half> %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b64 v[0:1], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <4 x half> %arg0, ptr addrspace(1) undef
+  store <4 x half> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2275,7 +2275,7 @@ define void @void_func_v8f16(<8 x half> %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <8 x half> %arg0, ptr addrspace(1) undef
+  store <8 x half> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2341,7 +2341,7 @@ define void @void_func_v16f16(<16 x half> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b128 v[4:7], off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <16 x half> %arg0, ptr addrspace(1) undef
+  store <16 x half> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2372,9 +2372,9 @@ define void @void_func_i32_i64_i32(i32 %arg0, i64 %arg1, i32 %arg2) #0 {
 ; GFX11-NEXT:    buffer_store_b32 v3, off, s[0:3], 0 dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store volatile i32 %arg0, ptr addrspace(1) undef
-  store volatile i64 %arg1, ptr addrspace(1) undef
-  store volatile i32 %arg2, ptr addrspace(1) undef
+  store volatile i32 %arg0, ptr addrspace(1) poison
+  store volatile i64 %arg1, ptr addrspace(1) poison
+  store volatile i32 %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -2395,7 +2395,7 @@ define void @void_func_struct_i32({ i32 } %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b32 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store { i32 } %arg0, ptr addrspace(1) undef
+  store { i32 } %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2419,7 +2419,7 @@ define void @void_func_struct_i8_i32({ i8, i32 } %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b32 v1, off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b8 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store { i8, i32 } %arg0, ptr addrspace(1) undef
+  store { i8, i32 } %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -2452,7 +2452,7 @@ define void @void_func_byval_struct_i8_i32(ptr addrspace(5) byval({ i8, i32 }) %
 ; GFX11-NEXT:    buffer_store_b8 v1, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %arg0.load = load { i8, i32 }, ptr addrspace(5) %arg0
-  store { i8, i32 } %arg0.load, ptr addrspace(1) undef
+  store { i8, i32 } %arg0.load, ptr addrspace(1) poison
   ret void
 }
 
@@ -2560,8 +2560,8 @@ define void @void_func_byval_struct_i8_i32_x2(ptr addrspace(5) byval({ i8, i32 }
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %arg0.load = load volatile { i8, i32 }, ptr addrspace(5) %arg0
   %arg1.load = load volatile { i8, i32 }, ptr addrspace(5) %arg1
-  store volatile { i8, i32 } %arg0.load, ptr addrspace(1) undef
-  store volatile { i8, i32 } %arg1.load, ptr addrspace(1) undef
+  store volatile { i8, i32 } %arg0.load, ptr addrspace(1) poison
+  store volatile { i8, i32 } %arg1.load, ptr addrspace(1) poison
   store volatile i32 %arg2, ptr addrspace(3) undef
   ret void
 }
@@ -2597,8 +2597,8 @@ define void @void_func_byval_i32_byval_i64(ptr addrspace(5) byval(i32) %arg0, pt
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
   %arg0.load = load i32, ptr addrspace(5) %arg0
   %arg1.load = load i64, ptr addrspace(5) %arg1
-  store i32 %arg0.load, ptr addrspace(1) undef
-  store i64 %arg1.load, ptr addrspace(1) undef
+  store i32 %arg0.load, ptr addrspace(1) poison
+  store i64 %arg1.load, ptr addrspace(1) poison
   ret void
 }
 
@@ -2669,9 +2669,9 @@ define void @void_func_v32i32_i32_i64(<32 x i32> %arg0, i32 %arg1, i64 %arg2) #0
 ; GFX11-NEXT:    buffer_store_b64 v[32:33], off, s[0:3], 0 dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile i32 %arg1, ptr addrspace(1) undef
-  store volatile i64 %arg2, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile i32 %arg1, ptr addrspace(1) poison
+  store volatile i64 %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -2808,12 +2808,12 @@ define void @void_func_v32i32_i1_i8_i16_bf16(<32 x i32> %arg0, i1 %arg1, i8 %arg
 ; GFX11-NEXT:    buffer_store_b16 v36, off, s[0:3], 0 dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile i1 %arg1, ptr addrspace(1) undef
-  store volatile i8 %arg2, ptr addrspace(1) undef
-  store volatile i16 %arg3, ptr addrspace(1) undef
-  store volatile half %arg4, ptr addrspace(1) undef
-  store volatile bfloat %arg5, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile i1 %arg1, ptr addrspace(1) poison
+  store volatile i8 %arg2, ptr addrspace(1) poison
+  store volatile i16 %arg3, ptr addrspace(1) poison
+  store volatile half %arg4, ptr addrspace(1) poison
+  store volatile bfloat %arg5, ptr addrspace(1) poison
   ret void
 }
 
@@ -2886,9 +2886,9 @@ define void @void_func_v32i32_v2i32_v2f32(<32 x i32> %arg0, <2 x i32> %arg1, <2 
 ; GFX11-NEXT:    buffer_store_b64 v[34:35], off, s[0:3], 0 dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile <2 x i32> %arg1, ptr addrspace(1) undef
-  store volatile <2 x float> %arg2, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile <2 x i32> %arg1, ptr addrspace(1) poison
+  store volatile <2 x float> %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -3042,11 +3042,11 @@ define void @void_func_v32i32_v2i16_v2f16_v2bf16_v4bf16(<32 x i32> %arg0, <2 x i
 ; GFX11-NEXT:    buffer_store_b64 v[32:33], off, s[0:3], 0 dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile <2 x i16> %arg1, ptr addrspace(1) undef
-  store volatile <2 x half> %arg2, ptr addrspace(1) undef
-  store volatile <2 x bfloat> %arg3, ptr addrspace(1) undef
-  store volatile <4 x bfloat> %arg4, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile <2 x i16> %arg1, ptr addrspace(1) poison
+  store volatile <2 x half> %arg2, ptr addrspace(1) poison
+  store volatile <2 x bfloat> %arg3, ptr addrspace(1) poison
+  store volatile <4 x bfloat> %arg4, ptr addrspace(1) poison
   ret void
 }
 
@@ -3127,9 +3127,9 @@ define void @void_func_v32i32_v2i64_v2f64(<32 x i32> %arg0, <2 x i64> %arg1, <2 
 ; GFX11-NEXT:    buffer_store_b128 v[32:35], off, s[0:3], 0 dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile <2 x i64> %arg1, ptr addrspace(1) undef
-  store volatile <2 x double> %arg2, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile <2 x i64> %arg1, ptr addrspace(1) poison
+  store volatile <2 x double> %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -3210,9 +3210,9 @@ define void @void_func_v32i32_v4i32_v4f32(<32 x i32> %arg0, <4 x i32> %arg1, <4 
 ; GFX11-NEXT:    buffer_store_b128 v[36:39], off, s[0:3], 0 dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile <4 x i32> %arg1, ptr addrspace(1) undef
-  store volatile <4 x float> %arg2, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile <4 x i32> %arg1, ptr addrspace(1) poison
+  store volatile <4 x float> %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -3418,9 +3418,9 @@ define void @void_func_v32i32_v8i32_v8f32(<32 x i32> %arg0, <8 x i32> %arg1, <8 
 ; GFX11-NEXT:    buffer_store_b128 v[32:35], off, s[0:3], 0 dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile <8 x i32> %arg1, ptr addrspace(1) undef
-  store volatile <8 x float> %arg2, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile <8 x i32> %arg1, ptr addrspace(1) poison
+  store volatile <8 x float> %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -3728,9 +3728,9 @@ define void @void_func_v32i32_v16i32_v16f32(<32 x i32> %arg0, <16 x i32> %arg1, 
 ; GFX11-NEXT:    buffer_store_b128 v[32:35], off, s[0:3], 0 dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile <16 x i32> %arg1, ptr addrspace(1) undef
-  store volatile <16 x float> %arg2, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile <16 x i32> %arg1, ptr addrspace(1) poison
+  store volatile <16 x float> %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -3918,7 +3918,7 @@ define void @void_func_volatile_v16i8(<16 x i8> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b8 v0, off, s[0:3], 0 dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store volatile <16 x i8> %arg0, ptr addrspace(1) undef
+  store volatile <16 x i8> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -4234,8 +4234,8 @@ define void @void_func_v32i32_v16i8(<32 x i32> %arg0, <16 x i8> %arg1) #0 {
 ; GFX11-NEXT:    buffer_store_b8 v55, off, s[0:3], 0 dlc
 ; GFX11-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store volatile <32 x i32> %arg0, ptr addrspace(1) undef
-  store volatile <16 x i8> %arg1, ptr addrspace(1) undef
+  store volatile <32 x i32> %arg0, ptr addrspace(1) poison
+  store volatile <16 x i8> %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -4268,7 +4268,7 @@ define void @void_func_bf16(bfloat %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b16 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store bfloat %arg0, ptr addrspace(1) undef
+  store bfloat %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -4302,7 +4302,7 @@ define void @void_func_v2bf16(<2 x bfloat> %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b32 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <2 x bfloat> %arg0, ptr addrspace(1) undef
+  store <2 x bfloat> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -4342,7 +4342,7 @@ define void @void_func_v3bf16(<3 x bfloat> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b16 v1, off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b32 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <3 x bfloat> %arg0, ptr addrspace(1) undef
+  store <3 x bfloat> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -4380,7 +4380,7 @@ define void @void_func_v4bf16(<4 x bfloat> %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b64 v[0:1], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <4 x bfloat> %arg0, ptr addrspace(1) undef
+  store <4 x bfloat> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -4426,7 +4426,7 @@ define void @void_func_v8bf16(<8 x bfloat> %arg0) #0 {
 ; GFX11-NEXT:    s_mov_b32 s2, -1
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <8 x bfloat> %arg0, ptr addrspace(1) undef
+  store <8 x bfloat> %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -4492,7 +4492,7 @@ define void @void_func_v16bf16(<16 x bfloat> %arg0) #0 {
 ; GFX11-NEXT:    buffer_store_b128 v[4:7], off, s[0:3], 0
 ; GFX11-NEXT:    buffer_store_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  store <16 x bfloat> %arg0, ptr addrspace(1) undef
+  store <16 x bfloat> %arg0, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/function-returns.ll
+++ b/llvm/test/CodeGen/AMDGPU/function-returns.ll
@@ -22,7 +22,7 @@ define i1 @i1_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_u8 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load i1, ptr addrspace(1) undef
+  %val = load i1, ptr addrspace(1) poison
   ret i1 %val
 }
 
@@ -45,7 +45,7 @@ define zeroext i1 @i1_zeroext_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_u8 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load i1, ptr addrspace(1) undef
+  %val = load i1, ptr addrspace(1) poison
   ret i1 %val
 }
 
@@ -69,7 +69,7 @@ define signext i1 @i1_signext_func_void() #0 {
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    v_bfe_i32 v0, v0, 0, 1
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load i1, ptr addrspace(1) undef
+  %val = load i1, ptr addrspace(1) poison
   ret i1 %val
 }
 
@@ -91,7 +91,7 @@ define i8 @i8_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_u8 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load i8, ptr addrspace(1) undef
+  %val = load i8, ptr addrspace(1) poison
   ret i8 %val
 }
 
@@ -113,7 +113,7 @@ define zeroext i8 @i8_zeroext_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_u8 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load i8, ptr addrspace(1) undef
+  %val = load i8, ptr addrspace(1) poison
   ret i8 %val
 }
 
@@ -135,7 +135,7 @@ define signext i8 @i8_signext_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_i8 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load i8, ptr addrspace(1) undef
+  %val = load i8, ptr addrspace(1) poison
   ret i8 %val
 }
 
@@ -157,7 +157,7 @@ define i16 @i16_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_u16 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load i16, ptr addrspace(1) undef
+  %val = load i16, ptr addrspace(1) poison
   ret i16 %val
 }
 
@@ -179,7 +179,7 @@ define zeroext i16 @i16_zeroext_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_u16 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load i16, ptr addrspace(1) undef
+  %val = load i16, ptr addrspace(1) poison
   ret i16 %val
 }
 
@@ -201,7 +201,7 @@ define signext i16 @i16_signext_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_i16 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load i16, ptr addrspace(1) undef
+  %val = load i16, ptr addrspace(1) poison
   ret i16 %val
 }
 
@@ -223,7 +223,7 @@ define i32 @i32_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b32 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load i32, ptr addrspace(1) undef
+  %val = load i32, ptr addrspace(1) poison
   ret i32 %val
 }
 
@@ -248,7 +248,7 @@ define i48 @i48_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_u16 v1, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load i48, ptr addrspace(1) undef, align 8
+  %val = load i48, ptr addrspace(1) poison, align 8
   ret i48 %val
 }
 
@@ -273,7 +273,7 @@ define zeroext i48 @i48_zeroext_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_u16 v1, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load i48, ptr addrspace(1) undef, align 8
+  %val = load i48, ptr addrspace(1) poison, align 8
   ret i48 %val
 }
 
@@ -298,7 +298,7 @@ define signext i48 @i48_signext_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_i16 v1, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load i48, ptr addrspace(1) undef, align 8
+  %val = load i48, ptr addrspace(1) poison, align 8
   ret i48 %val
 }
 
@@ -373,7 +373,7 @@ define i64 @i64_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b64 v[0:1], off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load i64, ptr addrspace(1) undef
+  %val = load i64, ptr addrspace(1) poison
   ret i64 %val
 }
 
@@ -398,7 +398,7 @@ define i65 @i65_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_u8 v2, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load i65, ptr addrspace(1) undef
+  %val = load i65, ptr addrspace(1) poison
   ret i65 %val
 }
 
@@ -420,7 +420,7 @@ define float @f32_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b32 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load float, ptr addrspace(1) undef
+  %val = load float, ptr addrspace(1) poison
   ret float %val
 }
 
@@ -442,7 +442,7 @@ define double @f64_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b64 v[0:1], off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load double, ptr addrspace(1) undef
+  %val = load double, ptr addrspace(1) poison
   ret double %val
 }
 
@@ -464,7 +464,7 @@ define <2 x double> @v2f64_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <2 x double>, ptr addrspace(1) undef
+  %val = load <2 x double>, ptr addrspace(1) poison
   ret <2 x double> %val
 }
 
@@ -486,7 +486,7 @@ define <2 x i32> @v2i32_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b64 v[0:1], off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <2 x i32>, ptr addrspace(1) undef
+  %val = load <2 x i32>, ptr addrspace(1) poison
   ret <2 x i32> %val
 }
 
@@ -508,7 +508,7 @@ define <3 x i32> @v3i32_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b96 v[0:2], off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <3 x i32>, ptr addrspace(1) undef
+  %val = load <3 x i32>, ptr addrspace(1) poison
   ret <3 x i32> %val
 }
 
@@ -530,7 +530,7 @@ define <4 x i32> @v4i32_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <4 x i32>, ptr addrspace(1) undef
+  %val = load <4 x i32>, ptr addrspace(1) poison
   ret <4 x i32> %val
 }
 
@@ -556,7 +556,7 @@ define <5 x i32> @v5i32_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b128 v[0:3], off, s[0:3], 0 glc dlc
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load volatile <5 x i32>, ptr addrspace(1) undef
+  %val = load volatile <5 x i32>, ptr addrspace(1) poison
   ret <5 x i32> %val
 }
 
@@ -684,7 +684,7 @@ define <2 x i64> @v2i64_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <2 x i64>, ptr addrspace(1) undef
+  %val = load <2 x i64>, ptr addrspace(1) poison
   ret <2 x i64> %val
 }
 
@@ -884,7 +884,7 @@ define <2 x i16> @v2i16_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b32 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <2 x i16>, ptr addrspace(1) undef
+  %val = load <2 x i16>, ptr addrspace(1) poison
   ret <2 x i16> %val
 }
 
@@ -918,7 +918,7 @@ define <3 x i16> @v3i16_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b64 v[0:1], off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <3 x i16>, ptr addrspace(1) undef
+  %val = load <3 x i16>, ptr addrspace(1) poison
   ret <3 x i16> %val
 }
 
@@ -953,7 +953,7 @@ define <4 x i16> @v4i16_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b64 v[0:1], off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <4 x i16>, ptr addrspace(1) undef
+  %val = load <4 x i16>, ptr addrspace(1) poison
   ret <4 x i16> %val
 }
 
@@ -990,7 +990,7 @@ define <4 x half> @v4f16_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b64 v[0:1], off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <4 x half>, ptr addrspace(1) undef
+  %val = load <4 x half>, ptr addrspace(1) poison
   ret <4 x half> %val
 }
 
@@ -1262,7 +1262,7 @@ define {i8, i32} @struct_i8_i32_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b32 v1, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load { i8, i32 }, ptr addrspace(1) undef
+  %val = load { i8, i32 }, ptr addrspace(1) poison
   ret { i8, i32 } %val
 }
 
@@ -1294,8 +1294,8 @@ define void @void_func_sret_struct_i8_i32(ptr addrspace(5) sret({ i8, i32 }) %ar
 ; GFX11-NEXT:    scratch_store_b8 v0, v1, off
 ; GFX11-NEXT:    scratch_store_b32 v0, v2, off offset:4
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val0 = load volatile i8, ptr addrspace(1) undef
-  %val1 = load volatile i32, ptr addrspace(1) undef
+  %val0 = load volatile i8, ptr addrspace(1) poison
+  %val1 = load volatile i32, ptr addrspace(1) poison
   %gep0 = getelementptr inbounds { i8, i32 }, ptr addrspace(5) %arg0, i32 0, i32 0
   %gep1 = getelementptr inbounds { i8, i32 }, ptr addrspace(5) %arg0, i32 0, i32 1
   store i8 %val0, ptr addrspace(5) %gep0
@@ -2361,7 +2361,7 @@ define bfloat @bf16_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_u16 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load bfloat, ptr addrspace(1) undef
+  %val = load bfloat, ptr addrspace(1) poison
   ret bfloat %val
 }
 
@@ -2394,7 +2394,7 @@ define <2 x bfloat> @v2bf16_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b32 v0, off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <2 x bfloat>, ptr addrspace(1) undef
+  %val = load <2 x bfloat>, ptr addrspace(1) poison
   ret <2 x bfloat> %val
 }
 
@@ -2428,7 +2428,7 @@ define <3 x bfloat> @v3bf16_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b64 v[0:1], off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <3 x bfloat>, ptr addrspace(1) undef
+  %val = load <3 x bfloat>, ptr addrspace(1) poison
   ret <3 x bfloat> %val
 }
 
@@ -2463,7 +2463,7 @@ define <4 x bfloat> @v4bf16_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b64 v[0:1], off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <4 x bfloat>, ptr addrspace(1) undef
+  %val = load <4 x bfloat>, ptr addrspace(1) poison
   ret <4 x bfloat> %val
 }
 
@@ -2500,7 +2500,7 @@ define <6 x bfloat> @v6bf16_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b96 v[0:2], off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <6 x bfloat>, ptr addrspace(1) undef
+  %val = load <6 x bfloat>, ptr addrspace(1) poison
   ret <6 x bfloat> %val
 }
 
@@ -2539,7 +2539,7 @@ define <8 x bfloat> @v8bf16_func_void() #0 {
 ; GFX11-NEXT:    buffer_load_b128 v[0:3], off, s[0:3], 0
 ; GFX11-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <8 x bfloat>, ptr addrspace(1) undef
+  %val = load <8 x bfloat>, ptr addrspace(1) poison
   ret <8 x bfloat> %val
 }
 
@@ -2592,7 +2592,7 @@ define <16 x bfloat> @v16bf16_func_void() #0 {
 ; GFX11-NEXT:    v_dual_mov_b32 v4, v0 :: v_dual_mov_b32 v5, v1
 ; GFX11-NEXT:    v_dual_mov_b32 v6, v2 :: v_dual_mov_b32 v7, v3
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <16 x bfloat>, ptr addrspace(1) undef
+  %val = load <16 x bfloat>, ptr addrspace(1) poison
   ret <16 x bfloat> %val
 }
 
@@ -2673,7 +2673,7 @@ define <32 x bfloat> @v32bf16_func_void() #0 {
 ; GFX11-NEXT:    v_dual_mov_b32 v12, v0 :: v_dual_mov_b32 v13, v1
 ; GFX11-NEXT:    v_dual_mov_b32 v14, v2 :: v_dual_mov_b32 v15, v3
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <32 x bfloat>, ptr addrspace(1) undef
+  %val = load <32 x bfloat>, ptr addrspace(1) poison
   ret <32 x bfloat> %val
 }
 

--- a/llvm/test/CodeGen/AMDGPU/gfx-callable-argument-types.ll
+++ b/llvm/test/CodeGen/AMDGPU/gfx-callable-argument-types.ll
@@ -367,7 +367,7 @@ define amdgpu_gfx void @test_call_external_void_func_i1_signext(i32) #0 {
 ; GFX10-SCRATCH-NEXT:    s_mov_b32 s33, s0
 ; GFX10-SCRATCH-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-SCRATCH-NEXT:    s_setpc_b64 s[30:31]
-  %var = load volatile i1, ptr addrspace(1) undef
+  %var = load volatile i1, ptr addrspace(1) poison
   call amdgpu_gfx void @external_void_func_i1_signext(i1 signext%var)
   ret void
 }
@@ -496,7 +496,7 @@ define amdgpu_gfx void @test_call_external_void_func_i1_zeroext(i32) #0 {
 ; GFX10-SCRATCH-NEXT:    s_mov_b32 s33, s0
 ; GFX10-SCRATCH-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-SCRATCH-NEXT:    s_setpc_b64 s[30:31]
-  %var = load volatile i1, ptr addrspace(1) undef
+  %var = load volatile i1, ptr addrspace(1) poison
   call amdgpu_gfx void @external_void_func_i1_zeroext(i1 zeroext %var)
   ret void
 }
@@ -735,7 +735,7 @@ define amdgpu_gfx void @test_call_external_void_func_i8_signext(i32) #0 {
 ; GFX10-SCRATCH-NEXT:    s_mov_b32 s33, s0
 ; GFX10-SCRATCH-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-SCRATCH-NEXT:    s_setpc_b64 s[30:31]
-  %var = load volatile i8, ptr addrspace(1) undef
+  %var = load volatile i8, ptr addrspace(1) poison
   call amdgpu_gfx void @external_void_func_i8_signext(i8 signext %var)
   ret void
 }
@@ -857,7 +857,7 @@ define amdgpu_gfx void @test_call_external_void_func_i8_zeroext(i32) #0 {
 ; GFX10-SCRATCH-NEXT:    s_mov_b32 s33, s0
 ; GFX10-SCRATCH-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-SCRATCH-NEXT:    s_setpc_b64 s[30:31]
-  %var = load volatile i8, ptr addrspace(1) undef
+  %var = load volatile i8, ptr addrspace(1) poison
   call amdgpu_gfx void @external_void_func_i8_zeroext(i8 zeroext %var)
   ret void
 }
@@ -1096,7 +1096,7 @@ define amdgpu_gfx void @test_call_external_void_func_i16_signext(i32) #0 {
 ; GFX10-SCRATCH-NEXT:    s_mov_b32 s33, s0
 ; GFX10-SCRATCH-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-SCRATCH-NEXT:    s_setpc_b64 s[30:31]
-  %var = load volatile i16, ptr addrspace(1) undef
+  %var = load volatile i16, ptr addrspace(1) poison
   call amdgpu_gfx void @external_void_func_i16_signext(i16 signext %var)
   ret void
 }
@@ -1218,7 +1218,7 @@ define amdgpu_gfx void @test_call_external_void_func_i16_zeroext(i32) #0 {
 ; GFX10-SCRATCH-NEXT:    s_mov_b32 s33, s0
 ; GFX10-SCRATCH-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-SCRATCH-NEXT:    s_setpc_b64 s[30:31]
-  %var = load volatile i16, ptr addrspace(1) undef
+  %var = load volatile i16, ptr addrspace(1) poison
   call amdgpu_gfx void @external_void_func_i16_zeroext(i16 zeroext %var)
   ret void
 }
@@ -5789,7 +5789,7 @@ define amdgpu_gfx void @test_call_external_void_func_v2i16() #0 {
 ; GFX10-SCRATCH-NEXT:    s_mov_b32 s33, s0
 ; GFX10-SCRATCH-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-SCRATCH-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <2 x i16>, ptr addrspace(1) undef
+  %val = load <2 x i16>, ptr addrspace(1) poison
   call amdgpu_gfx void @external_void_func_v2i16(<2 x i16> %val)
   ret void
 }
@@ -5907,7 +5907,7 @@ define amdgpu_gfx void @test_call_external_void_func_v3i16() #0 {
 ; GFX10-SCRATCH-NEXT:    s_mov_b32 s33, s0
 ; GFX10-SCRATCH-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-SCRATCH-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <3 x i16>, ptr addrspace(1) undef
+  %val = load <3 x i16>, ptr addrspace(1) poison
   call amdgpu_gfx void @external_void_func_v3i16(<3 x i16> %val)
   ret void
 }
@@ -6025,7 +6025,7 @@ define amdgpu_gfx void @test_call_external_void_func_v3f16() #0 {
 ; GFX10-SCRATCH-NEXT:    s_mov_b32 s33, s0
 ; GFX10-SCRATCH-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-SCRATCH-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <3 x half>, ptr addrspace(1) undef
+  %val = load <3 x half>, ptr addrspace(1) poison
   call amdgpu_gfx void @external_void_func_v3f16(<3 x half> %val)
   ret void
 }
@@ -6384,7 +6384,7 @@ define amdgpu_gfx void @test_call_external_void_func_v4i16() #0 {
 ; GFX10-SCRATCH-NEXT:    s_mov_b32 s33, s0
 ; GFX10-SCRATCH-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-SCRATCH-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <4 x i16>, ptr addrspace(1) undef
+  %val = load <4 x i16>, ptr addrspace(1) poison
   call amdgpu_gfx void @external_void_func_v4i16(<4 x i16> %val)
   ret void
 }
@@ -6623,7 +6623,7 @@ define amdgpu_gfx void @test_call_external_void_func_v2f16() #0 {
 ; GFX10-SCRATCH-NEXT:    s_mov_b32 s33, s0
 ; GFX10-SCRATCH-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-SCRATCH-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <2 x half>, ptr addrspace(1) undef
+  %val = load <2 x half>, ptr addrspace(1) poison
   call amdgpu_gfx void @external_void_func_v2f16(<2 x half> %val)
   ret void
 }
@@ -6741,7 +6741,7 @@ define amdgpu_gfx void @test_call_external_void_func_v2i32() #0 {
 ; GFX10-SCRATCH-NEXT:    s_mov_b32 s33, s0
 ; GFX10-SCRATCH-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-SCRATCH-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <2 x i32>, ptr addrspace(1) undef
+  %val = load <2 x i32>, ptr addrspace(1) poison
   call amdgpu_gfx void @external_void_func_v2i32(<2 x i32> %val)
   ret void
 }
@@ -7230,7 +7230,7 @@ define amdgpu_gfx void @test_call_external_void_func_v4i32() #0 {
 ; GFX10-SCRATCH-NEXT:    s_mov_b32 s33, s0
 ; GFX10-SCRATCH-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-SCRATCH-NEXT:    s_setpc_b64 s[30:31]
-  %val = load <4 x i32>, ptr addrspace(1) undef
+  %val = load <4 x i32>, ptr addrspace(1) poison
   call amdgpu_gfx void @external_void_func_v4i32(<4 x i32> %val)
   ret void
 }
@@ -8251,7 +8251,7 @@ define amdgpu_gfx void @test_call_external_void_func_v32i32_i32(i32) #0 {
 ; GFX10-SCRATCH-NEXT:    s_setpc_b64 s[30:31]
   %ptr0 = load ptr addrspace(1), ptr addrspace(4) undef
   %val0 = load <32 x i32>, ptr addrspace(1) %ptr0
-  %val1 = load i32, ptr addrspace(1) undef
+  %val1 = load i32, ptr addrspace(1) poison
   call amdgpu_gfx void @external_void_func_v32i32_i32(<32 x i32> %val0, i32 %val1)
   ret void
 }
@@ -8862,8 +8862,8 @@ define amdgpu_gfx void @test_call_external_void_func_sret_struct_i8_i32_byval_st
   %out.val0 = load i8, ptr addrspace(5) %out.gep0
   %out.val1 = load i32, ptr addrspace(5) %out.gep1
 
-  store volatile i8 %out.val0, ptr addrspace(1) undef
-  store volatile i32 %out.val1, ptr addrspace(1) undef
+  store volatile i8 %out.val0, ptr addrspace(1) poison
+  store volatile i32 %out.val1, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/gfx11-user-sgpr-init16-bug.ll
+++ b/llvm/test/CodeGen/AMDGPU/gfx11-user-sgpr-init16-bug.ll
@@ -47,7 +47,7 @@
 ; NOWORKAROUND: ; COMPUTE_PGM_RSRC2:USER_SGPR: 0
 define amdgpu_kernel void @minimal_kernel_inputs() #0 {
   %id = call i32 @llvm.amdgcn.workgroup.id.x()
-  store volatile i32 %id, ptr addrspace(1) undef
+  store volatile i32 %id, ptr addrspace(1) poison
   ret void
 }
 
@@ -77,7 +77,7 @@ define amdgpu_kernel void @minimal_kernel_inputs() #0 {
 define amdgpu_kernel void @minimal_kernel_inputs_with_stack() #0 {
   %alloca = alloca i32, addrspace(5)
   %id = call i32 @llvm.amdgcn.workgroup.id.x()
-  store volatile i32 %id, ptr addrspace(1) undef
+  store volatile i32 %id, ptr addrspace(1) poison
   store volatile i32 0, ptr addrspace(5) %alloca
   ret void
 }
@@ -111,7 +111,7 @@ define amdgpu_kernel void @queue_ptr() #1 {
   %queue.ptr = call noalias ptr addrspace(4) @llvm.amdgcn.queue.ptr() #0
   %load = load volatile i8, ptr addrspace(4) %queue.ptr
   %id = call i32 @llvm.amdgcn.workgroup.id.x()
-  store volatile i32 %id, ptr addrspace(1) undef
+  store volatile i32 %id, ptr addrspace(1) poison
   ret void
 }
 
@@ -168,16 +168,16 @@ define amdgpu_kernel void @all_inputs() #2 {
   %load.implicitarg = load volatile i8, ptr addrspace(4) %implicitarg.ptr
 
   %id.x = call i32 @llvm.amdgcn.workgroup.id.x()
-  store volatile i32 %id.x, ptr addrspace(1) undef
+  store volatile i32 %id.x, ptr addrspace(1) poison
 
   %id.y = call i32 @llvm.amdgcn.workgroup.id.y()
-  store volatile i32 %id.y, ptr addrspace(1) undef
+  store volatile i32 %id.y, ptr addrspace(1) poison
 
   %id.z = call i32 @llvm.amdgcn.workgroup.id.z()
-  store volatile i32 %id.z, ptr addrspace(1) undef
+  store volatile i32 %id.z, ptr addrspace(1) poison
 
   %dispatch.id = call i64 @llvm.amdgcn.dispatch.id()
-  store volatile i64 %dispatch.id, ptr addrspace(1) undef
+  store volatile i64 %dispatch.id, ptr addrspace(1) poison
 
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/global-atomicrmw-fadd-wrong-subtarget.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-atomicrmw-fadd-wrong-subtarget.ll
@@ -45,7 +45,7 @@ define amdgpu_kernel void @global_atomic_fadd_ret_f32_wrong_subtarget(ptr addrsp
 ; GCN-NEXT:    global_store_dword v[0:1], v0, off
 ; GCN-NEXT:    s_endpgm
   %result = atomicrmw fadd ptr addrspace(1) %ptr, float 4.0 syncscope("agent") seq_cst, !amdgpu.no.fine.grained.memory !0, !amdgpu.ignore.denormal.mode !0
-  store float %result, ptr addrspace(1) undef
+  store float %result, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/global-saddr-atomics.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-saddr-atomics.ll
@@ -239,7 +239,7 @@ define amdgpu_ps float @global_xchg_saddr_i32_rtn_neg2048(ptr addrspace(1) inreg
 ; Uniformity edge cases
 ; --------------------------------------------------------------------------------
 
-@ptr.in.lds = internal addrspace(3) global ptr addrspace(1) undef
+@ptr.in.lds = internal addrspace(3) global ptr addrspace(1) poison
 
 ; Base pointer is uniform, but also in VGPRs
 define amdgpu_ps float @global_xchg_saddr_uniform_ptr_in_vgprs_rtn(i32 %voffset, i32 %data) {

--- a/llvm/test/CodeGen/AMDGPU/global-saddr-load.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-saddr-load.ll
@@ -1618,7 +1618,7 @@ define amdgpu_ps float @global_load_saddr_i8_zext_vgpr_ptrtoint_commute_add_imm_
 ; Uniformity edge cases
 ; --------------------------------------------------------------------------------
 
-@ptr.in.lds = internal addrspace(3) global ptr addrspace(1) undef
+@ptr.in.lds = internal addrspace(3) global ptr addrspace(1) poison
 
 ; Base pointer is uniform, but also in VGPRs
 define amdgpu_ps float @global_load_saddr_uniform_ptr_in_vgprs(i32 %voffset) {

--- a/llvm/test/CodeGen/AMDGPU/global-saddr-store.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-saddr-store.ll
@@ -98,7 +98,7 @@ define amdgpu_ps void @global_store_saddr_i8_zext_vgpr_offset_neg2048(ptr addrsp
 ; Uniformity edge cases
 ; --------------------------------------------------------------------------------
 
-@ptr.in.lds = internal addrspace(3) global ptr addrspace(1) undef
+@ptr.in.lds = internal addrspace(3) global ptr addrspace(1) poison
 
 ; Base pointer is uniform, but also in VGPRs
 define amdgpu_ps void @global_store_saddr_uniform_ptr_in_vgprs(i32 %voffset, i8 %data) {

--- a/llvm/test/CodeGen/AMDGPU/global-smrd-unknown.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-smrd-unknown.ll
@@ -6,11 +6,11 @@
 ; GCN: flat_store_dword
 define void @unknown_memdep_analysis(ptr addrspace(1) nocapture readonly %arg, float %arg1) #0 {
 bb:
-  %tmp53 = load float, ptr addrspace(1) undef, align 4
+  %tmp53 = load float, ptr addrspace(1) poison, align 4
   %tmp54 = getelementptr inbounds float, ptr addrspace(1) %arg, i32 31
   %tmp55 = load float, ptr addrspace(1) %tmp54, align 4
   %tmp56 = tail call float @llvm.fmuladd.f32(float %arg1, float %tmp53, float %tmp55)
-  store float %tmp56, ptr addrspace(1) undef, align 4
+  store float %tmp56, ptr addrspace(1) poison, align 4
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/hsa-metadata-heap-v5.ll
+++ b/llvm/test/CodeGen/AMDGPU/hsa-metadata-heap-v5.ll
@@ -286,7 +286,7 @@ define amdgpu_kernel void @test_kernel71(ptr addrspace(1) %sink) #2 {
 define amdgpu_kernel void @test_kernel72() #2 {
   %ptr = tail call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
   %gep = getelementptr inbounds i8, ptr addrspace(4) %ptr, i32 42
-  store ptr addrspace(4) %gep, ptr addrspace(1) undef, align 8
+  store ptr addrspace(4) %gep, ptr addrspace(1) poison, align 8
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/hsa-metadata-hostcall-v4.ll
+++ b/llvm/test/CodeGen/AMDGPU/hsa-metadata-hostcall-v4.ll
@@ -286,7 +286,7 @@ define amdgpu_kernel void @test_kernel71(ptr addrspace(1) %sink) #2 {
 define amdgpu_kernel void @test_kernel72() #2 {
   %ptr = tail call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
   %gep = getelementptr inbounds i8, ptr addrspace(4) %ptr, i32 42
-  store ptr addrspace(4) %gep, ptr addrspace(1) undef, align 8
+  store ptr addrspace(4) %gep, ptr addrspace(1) poison, align 8
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/hsa-metadata-hostcall-v5.ll
+++ b/llvm/test/CodeGen/AMDGPU/hsa-metadata-hostcall-v5.ll
@@ -286,7 +286,7 @@ define amdgpu_kernel void @test_kernel71(ptr addrspace(1) %sink) #2 {
 define amdgpu_kernel void @test_kernel72() #2 {
   %ptr = tail call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
   %gep = getelementptr inbounds i8, ptr addrspace(4) %ptr, i32 42
-  store ptr addrspace(4) %gep, ptr addrspace(1) undef, align 8
+  store ptr addrspace(4) %gep, ptr addrspace(1) poison, align 8
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/hsa-metadata-multigrid-sync-arg-v5.ll
+++ b/llvm/test/CodeGen/AMDGPU/hsa-metadata-multigrid-sync-arg-v5.ll
@@ -286,7 +286,7 @@ define amdgpu_kernel void @test_kernel71(ptr addrspace(1) %sink) #2 {
 define amdgpu_kernel void @test_kernel72() #2 {
   %ptr = tail call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
   %gep = getelementptr inbounds i8, ptr addrspace(4) %ptr, i32 42
-  store ptr addrspace(4) %gep, ptr addrspace(1) undef, align 8
+  store ptr addrspace(4) %gep, ptr addrspace(1) poison, align 8
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/hsa-metadata-queue-ptr-v5.ll
+++ b/llvm/test/CodeGen/AMDGPU/hsa-metadata-queue-ptr-v5.ll
@@ -29,7 +29,7 @@ define amdgpu_kernel void @addrspacecast_requires_queue_ptr(ptr addrspace(5) %pt
 define amdgpu_kernel void @is_shared_requires_queue_ptr(ptr %ptr) {
   %is.shared = call i1 @llvm.amdgcn.is.shared(ptr %ptr)
   %zext = zext i1 %is.shared to i32
-  store volatile i32 %zext, ptr addrspace(1) undef
+  store volatile i32 %zext, ptr addrspace(1) poison
   ret void
 }
 
@@ -40,7 +40,7 @@ define amdgpu_kernel void @is_shared_requires_queue_ptr(ptr %ptr) {
 define amdgpu_kernel void @is_private_requires_queue_ptr(ptr %ptr) {
   %is.private = call i1 @llvm.amdgcn.is.private(ptr %ptr)
   %zext = zext i1 %is.private to i32
-  store volatile i32 %zext, ptr addrspace(1) undef
+  store volatile i32 %zext, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/hsa-metadata-queueptr-v5.ll
+++ b/llvm/test/CodeGen/AMDGPU/hsa-metadata-queueptr-v5.ll
@@ -286,7 +286,7 @@ define amdgpu_kernel void @test_kernel71(ptr addrspace(1) %sink) #2 {
 define amdgpu_kernel void @test_kernel72() #2 {
   %ptr = tail call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
   %gep = getelementptr inbounds i8, ptr addrspace(4) %ptr, i32 42
-  store ptr addrspace(4) %gep, ptr addrspace(1) undef, align 8
+  store ptr addrspace(4) %gep, ptr addrspace(1) poison, align 8
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/hsa.ll
+++ b/llvm/test/CodeGen/AMDGPU/hsa.ll
@@ -116,7 +116,7 @@ entry:
 ; HSA: .amdhsa_user_sgpr_kernarg_segment_ptr 0
 define amdgpu_kernel void @simple_no_kernargs() #0 {
 entry:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/huge-private-buffer.ll
+++ b/llvm/test/CodeGen/AMDGPU/huge-private-buffer.ll
@@ -16,7 +16,7 @@ define amdgpu_kernel void @scratch_buffer_known_high_masklo16() {
   store volatile i32 15, ptr addrspace(5) %alloca
   %toint = ptrtoint ptr addrspace(5) %alloca to i32
   %masked = and i32 %toint, 65535
-  store volatile i32 %masked, ptr addrspace(1) undef
+  store volatile i32 %masked, ptr addrspace(1) poison
   ret void
 }
 
@@ -36,7 +36,7 @@ define amdgpu_kernel void @scratch_buffer_known_high_masklo17() {
   store volatile i32 15, ptr addrspace(5) %alloca
   %toint = ptrtoint ptr addrspace(5) %alloca to i32
   %masked = and i32 %toint, 131071
-  store volatile i32 %masked, ptr addrspace(1) undef
+  store volatile i32 %masked, ptr addrspace(1) poison
   ret void
 }
 
@@ -58,7 +58,7 @@ define amdgpu_kernel void @scratch_buffer_known_high_masklo18() {
   store volatile i32 15, ptr addrspace(5) %alloca
   %toint = ptrtoint ptr addrspace(5) %alloca to i32
   %masked = and i32 %toint, 262143
-  store volatile i32 %masked, ptr addrspace(1) undef
+  store volatile i32 %masked, ptr addrspace(1) poison
   ret void
 }
 
@@ -79,7 +79,7 @@ define amdgpu_kernel void @scratch_buffer_known_high_masklo20() {
   store volatile i32 15, ptr addrspace(5) %alloca
   %toint = ptrtoint ptr addrspace(5) %alloca to i32
   %masked = and i32 %toint, 1048575
-  store volatile i32 %masked, ptr addrspace(1) undef
+  store volatile i32 %masked, ptr addrspace(1) poison
   ret void
 }
 
@@ -92,6 +92,6 @@ define amdgpu_kernel void @scratch_buffer_known_high_masklo21() {
   store volatile i32 15, ptr addrspace(5) %alloca
   %toint = ptrtoint ptr addrspace(5) %alloca to i32
   %masked = and i32 %toint, 2097151
-  store volatile i32 %masked, ptr addrspace(1) undef
+  store volatile i32 %masked, ptr addrspace(1) poison
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/i1-copy-phi.ll
+++ b/llvm/test/CodeGen/AMDGPU/i1-copy-phi.ll
@@ -26,7 +26,7 @@ bb3:                                              ; preds = %bb2, %bb
   br i1 %tmp, label %bb4, label %bb6
 
 bb4:                                              ; preds = %bb3
-  %val = load volatile i32, ptr addrspace(1) undef
+  %val = load volatile i32, ptr addrspace(1) poison
   %tmp5 = mul i32 %val, %arg
   br label %bb6
 

--- a/llvm/test/CodeGen/AMDGPU/image-load-d16-tfe.ll
+++ b/llvm/test/CodeGen/AMDGPU/image-load-d16-tfe.ll
@@ -87,8 +87,8 @@ define amdgpu_ps void @load_1d_f16_tfe_dmask0(<8 x i32> inreg %rsrc, i32 %s) {
   %v = call { half, i32 } @llvm.amdgcn.image.load.1d.sl_f16i32s.i32(i32 0, i32 %s, <8 x i32> %rsrc, i32 1, i32 0)
   %v.data = extractvalue { half, i32 } %v, 0
   %v.err = extractvalue { half, i32 } %v, 1
-  store volatile half %v.data, ptr addrspace(1) undef
-  store volatile i32 %v.err, ptr addrspace(1) undef
+  store volatile half %v.data, ptr addrspace(1) poison
+  store volatile i32 %v.err, ptr addrspace(1) poison
   ret void
 }
 
@@ -175,8 +175,8 @@ define amdgpu_ps void @load_1d_f16_tfe_dmask1(<8 x i32> inreg %rsrc, i32 %s) {
   %v = call { half, i32 } @llvm.amdgcn.image.load.1d.sl_f16i32s.i32(i32 1, i32 %s, <8 x i32> %rsrc, i32 1, i32 0)
   %v.data = extractvalue { half, i32 } %v, 0
   %v.err = extractvalue { half, i32 } %v, 1
-  store volatile half %v.data, ptr addrspace(1) undef
-  store volatile i32 %v.err, ptr addrspace(1) undef
+  store volatile half %v.data, ptr addrspace(1) poison
+  store volatile i32 %v.err, ptr addrspace(1) poison
   ret void
 }
 
@@ -263,8 +263,8 @@ define amdgpu_ps void @load_1d_v2f16_tfe_dmask0(<8 x i32> inreg %rsrc, i32 %s) {
   %v = call { <2 x half>, i32 } @llvm.amdgcn.image.load.1d.sl_v2f16i32s.i32(i32 0, i32 %s, <8 x i32> %rsrc, i32 1, i32 0)
   %v.data = extractvalue { <2 x half>, i32 } %v, 0
   %v.err = extractvalue { <2 x half>, i32 } %v, 1
-  store volatile <2 x half> %v.data, ptr addrspace(1) undef
-  store volatile i32 %v.err, ptr addrspace(1) undef
+  store volatile <2 x half> %v.data, ptr addrspace(1) poison
+  store volatile i32 %v.err, ptr addrspace(1) poison
   ret void
 }
 
@@ -351,8 +351,8 @@ define amdgpu_ps void @load_1d_v2f16_tfe_dmask1(<8 x i32> inreg %rsrc, i32 %s) {
   %v = call { <2 x half>, i32 } @llvm.amdgcn.image.load.1d.sl_v2f16i32s.i32(i32 1, i32 %s, <8 x i32> %rsrc, i32 1, i32 0)
   %v.data = extractvalue { <2 x half>, i32 } %v, 0
   %v.err = extractvalue { <2 x half>, i32 } %v, 1
-  store volatile <2 x half> %v.data, ptr addrspace(1) undef
-  store volatile i32 %v.err, ptr addrspace(1) undef
+  store volatile <2 x half> %v.data, ptr addrspace(1) poison
+  store volatile i32 %v.err, ptr addrspace(1) poison
   ret void
 }
 
@@ -442,8 +442,8 @@ define amdgpu_ps void @load_1d_v2f16_tfe_dmask3(<8 x i32> inreg %rsrc, i32 %s) {
   %v = call { <2 x half>, i32 } @llvm.amdgcn.image.load.1d.sl_v2f16i32s.i32(i32 3, i32 %s, <8 x i32> %rsrc, i32 1, i32 0)
   %v.data = extractvalue { <2 x half>, i32 } %v, 0
   %v.err = extractvalue { <2 x half>, i32 } %v, 1
-  store volatile <2 x half> %v.data, ptr addrspace(1) undef
-  store volatile i32 %v.err, ptr addrspace(1) undef
+  store volatile <2 x half> %v.data, ptr addrspace(1) poison
+  store volatile i32 %v.err, ptr addrspace(1) poison
   ret void
 }
 
@@ -545,8 +545,8 @@ define amdgpu_ps void @load_1d_v3f16_tfe_dmask7(<8 x i32> inreg %rsrc, i32 %s) {
   %v = call { <3 x half>, i32 } @llvm.amdgcn.image.load.1d.sl_v3f16i32s.i32(i32 7, i32 %s, <8 x i32> %rsrc, i32 1, i32 0)
   %v.data = extractvalue { <3 x half>, i32 } %v, 0
   %v.err = extractvalue { <3 x half>, i32 } %v, 1
-  store volatile <3 x half> %v.data, ptr addrspace(1) undef
-  store volatile i32 %v.err, ptr addrspace(1) undef
+  store volatile <3 x half> %v.data, ptr addrspace(1) poison
+  store volatile i32 %v.err, ptr addrspace(1) poison
   ret void
 }
 
@@ -642,8 +642,8 @@ define amdgpu_ps void @load_1d_v4f16_tfe_dmask15(<8 x i32> inreg %rsrc, i32 %s) 
   %v = call { <4 x half>, i32 } @llvm.amdgcn.image.load.1d.sl_v4f16i32s.i32(i32 15, i32 %s, <8 x i32> %rsrc, i32 1, i32 0)
   %v.data = extractvalue { <4 x half>, i32 } %v, 0
   %v.err = extractvalue { <4 x half>, i32 } %v, 1
-  store volatile <4 x half> %v.data, ptr addrspace(1) undef
-  store volatile i32 %v.err, ptr addrspace(1) undef
+  store volatile <4 x half> %v.data, ptr addrspace(1) poison
+  store volatile i32 %v.err, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/implicit-kernarg-backend-usage.ll
+++ b/llvm/test/CodeGen/AMDGPU/implicit-kernarg-backend-usage.ll
@@ -159,7 +159,7 @@ define amdgpu_kernel void @llvm_amdgcn_is_shared(ptr %ptr) {
 ; GFX9V5-NEXT:    s_endpgm
   %is.shared = call i1 @llvm.amdgcn.is.shared(ptr %ptr)
   %zext = zext i1 %is.shared to i32
-  store volatile i32 %zext, ptr addrspace(1) undef
+  store volatile i32 %zext, ptr addrspace(1) poison
   ret void
 }
 
@@ -213,7 +213,7 @@ define amdgpu_kernel void @llvm_amdgcn_is_private(ptr %ptr) {
 ; GFX9V5-NEXT:    s_endpgm
   %is.private = call i1 @llvm.amdgcn.is.private(ptr %ptr)
   %zext = zext i1 %is.private to i32
-  store volatile i32 %zext, ptr addrspace(1) undef
+  store volatile i32 %zext, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/implicit-kernel-argument-alignment.ll
+++ b/llvm/test/CodeGen/AMDGPU/implicit-kernel-argument-alignment.ll
@@ -5,7 +5,7 @@
 ; CHECK: .amdhsa_kernarg_size 264
 define amdgpu_kernel void @test_unaligned_to_eight(i32 %four)  {
   %implicitarg.ptr = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
-  store volatile ptr addrspace(4) %implicitarg.ptr, ptr addrspace(1) undef
+  store volatile ptr addrspace(4) %implicitarg.ptr, ptr addrspace(1) poison
   ret void
 }
 
@@ -14,7 +14,7 @@ define amdgpu_kernel void @test_unaligned_to_eight(i32 %four)  {
 ; CHECK: .amdhsa_kernarg_size 264
 define amdgpu_kernel void @test_aligned_to_eight(i64 %eight)  {
   %implicitarg.ptr = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
-  store volatile ptr addrspace(4) %implicitarg.ptr, ptr addrspace(1) undef
+  store volatile ptr addrspace(4) %implicitarg.ptr, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/indirect-addressing-si.ll
+++ b/llvm/test/CodeGen/AMDGPU/indirect-addressing-si.ll
@@ -5679,7 +5679,7 @@ entry:
   br i1 %cmp, label %bb1, label %bb2
 
 bb1:
-  store volatile i32 %live.out.reg, ptr addrspace(1) undef
+  store volatile i32 %live.out.reg, ptr addrspace(1) poison
   br label %bb2
 
 bb2:
@@ -6616,7 +6616,7 @@ entry:
   br i1 %cmp, label %bb1, label %bb2
 
 bb1:
-  store volatile i32 %live.out.val, ptr addrspace(1) undef
+  store volatile i32 %live.out.val, ptr addrspace(1) poison
   br label %bb2
 
 bb2:
@@ -7450,20 +7450,20 @@ bb:
   br i1 %tmp, label %bb1, label %bb4
 
 bb1:
-  %tmp2 = load volatile <4 x float>, ptr addrspace(1) undef
+  %tmp2 = load volatile <4 x float>, ptr addrspace(1) poison
   %tmp3 = extractelement <4 x float> %tmp2, i32 undef
   call void asm sideeffect "; reg use $0", "v"(<4 x float> %tmp2) ; Prevent block optimize out
   br label %bb7
 
 bb4:
-  %tmp5 = load volatile <4 x float>, ptr addrspace(1) undef
+  %tmp5 = load volatile <4 x float>, ptr addrspace(1) poison
   %tmp6 = extractelement <4 x float> %tmp5, i32 undef
   call void asm sideeffect "; reg use $0", "v"(<4 x float> %tmp5) ; Prevent block optimize out
   br label %bb7
 
 bb7:
   %tmp8 = phi float [ %tmp3, %bb1 ], [ %tmp6, %bb4 ]
-  store volatile float %tmp8, ptr addrspace(1) undef
+  store volatile float %tmp8, ptr addrspace(1) poison
   ret void
 }
 
@@ -7698,20 +7698,20 @@ bb:
   br i1 %tmp, label %bb1, label %bb4
 
 bb1:
-  %tmp2 = load volatile <4 x float>, ptr addrspace(1) undef
+  %tmp2 = load volatile <4 x float>, ptr addrspace(1) poison
   %tmp3 = insertelement <4 x float> %tmp2, float %val0, i32 poison
   call void asm sideeffect "; reg use $0", "v"(<4 x float> %tmp3) ; Prevent block optimize out
   br label %bb7
 
 bb4:
-  %tmp5 = load volatile <4 x float>, ptr addrspace(1) undef
+  %tmp5 = load volatile <4 x float>, ptr addrspace(1) poison
   %tmp6 = insertelement <4 x float> %tmp5, float %val0, i32 poison
   call void asm sideeffect "; reg use $0", "v"(<4 x float> %tmp6) ; Prevent block optimize out
   br label %bb7
 
 bb7:
   %tmp8 = phi <4 x float> [ %tmp3, %bb1 ], [ %tmp6, %bb4 ]
-  store volatile <4 x float> %tmp8, ptr addrspace(1) undef
+  store volatile <4 x float> %tmp8, ptr addrspace(1) poison
   ret void
 }
 
@@ -9458,7 +9458,7 @@ bb2:
   br i1 %tmp3, label %bb4, label %bb8
 
 bb4:
-  %vgpr = load volatile i32, ptr addrspace(1) undef
+  %vgpr = load volatile i32, ptr addrspace(1) poison
   %tmp5 = insertelement <16 x i32> poison, i32 poison, i32 %vgpr
   %tmp6 = insertelement <16 x i32> %tmp5, i32 %arg1, i32 %vgpr
   %tmp7 = extractelement <16 x i32> %tmp6, i32 0

--- a/llvm/test/CodeGen/AMDGPU/inline-asm.ll
+++ b/llvm/test/CodeGen/AMDGPU/inline-asm.ll
@@ -234,9 +234,9 @@ entry:
 ; CHECK: {{buffer|flat}}_store_byte [[STORE]],
 define amdgpu_kernel void @i1_input_phys_vgpr() {
 entry:
-  %val = load i1, ptr addrspace(1) undef
+  %val = load i1, ptr addrspace(1) poison
   %cc = call i1 asm sideeffect "; use $1, def $0 ", "={v1}, {v0}"(i1 %val)
-  store i1 %cc, ptr addrspace(1) undef
+  store i1 %cc, ptr addrspace(1) poison
   ret void
 }
 
@@ -249,8 +249,8 @@ entry:
 ; CHECK-NEXT: ASMSTART
 define amdgpu_kernel void @i1_input_phys_vgpr_x2() {
 entry:
-  %val0 = load volatile i1, ptr addrspace(1) undef
-  %val1 = load volatile i1, ptr addrspace(1) undef
+  %val0 = load volatile i1, ptr addrspace(1) poison
+  %val1 = load volatile i1, ptr addrspace(1) poison
   call void asm sideeffect "; use $0 $1 ", "{v0}, {v1}"(i1 %val0, i1 %val1)
   ret void
 }
@@ -265,7 +265,7 @@ entry:
   %def0 = call i32 asm sideeffect "; def $0 ", "={v0}"()
   %def1 = call i32 asm sideeffect "; def $0 ", "={v0}"()
   %add = shl i32 %def0, %def1
-  store i32 %add, ptr addrspace(1) undef
+  store i32 %add, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/inline-maxbb.ll
+++ b/llvm/test/CodeGen/AMDGPU/inline-maxbb.ll
@@ -30,7 +30,7 @@ ret_res:
 
 define amdgpu_kernel void @caller(i32 %x) {
   %res = call i32 @callee(i32 %x)
-  store volatile i32 %res, ptr addrspace(1) undef
+  store volatile i32 %res, ptr addrspace(1) poison
   ret void
 }
 
@@ -63,7 +63,7 @@ ret_res:
 
 define amdgpu_kernel void @caller_hint(i32 %x) {
   %res = call i32 @callee_hint(i32 %x)
-  store volatile i32 %res, ptr addrspace(1) undef
+  store volatile i32 %res, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/insert_vector_elt.v2i16.ll
+++ b/llvm/test/CodeGen/AMDGPU/insert_vector_elt.v2i16.ll
@@ -2063,7 +2063,7 @@ define amdgpu_kernel void @v_insertelement_v4i16_dynamic_vgpr(ptr addrspace(1) %
   %tid.ext = sext i32 %tid to i64
   %in.gep = getelementptr inbounds <4 x i16>, ptr addrspace(1) %in, i64 %tid.ext
   %out.gep = getelementptr inbounds <4 x i16>, ptr addrspace(1) %out, i64 %tid.ext
-  %idx.val = load volatile i32, ptr addrspace(1) undef
+  %idx.val = load volatile i32, ptr addrspace(1) poison
   %vec = load <4 x i16>, ptr addrspace(1) %in.gep
   %val.trunc = trunc i32 %val to i16
   %val.cvt = bitcast i16 %val.trunc to i16

--- a/llvm/test/CodeGen/AMDGPU/ipra-return-address-save-restore.ll
+++ b/llvm/test/CodeGen/AMDGPU/ipra-return-address-save-restore.ll
@@ -185,7 +185,7 @@ sw.bb10:
 ; GCN-DAG: v_readlane_b32 s30, [[CSR_VGPR]],
 ; GCN: s_waitcnt vmcnt(0)
 ; GCN: s_setpc_b64 s[30:31]
-  call fastcc void @svm_node_closure_bsdf(ptr addrspace(1) null, ptr null, <4 x i32> zeroinitializer, ptr null, i32 undef, i8 undef, float undef, float undef, float undef, i1 undef, <4 x i32> undef, float undef, i32 undef, i1 undef, i1 undef, i1 undef, float undef, ptr addrspace(1) undef, ptr addrspace(1) undef, ptr addrspace(1) undef, i1 undef, ptr addrspace(1) undef, i32 undef, i1 undef, i32 undef, i64 undef, i32 undef)
+  call fastcc void @svm_node_closure_bsdf(ptr addrspace(1) null, ptr null, <4 x i32> zeroinitializer, ptr null, i32 undef, i8 undef, float undef, float undef, float undef, i1 undef, <4 x i32> undef, float undef, i32 undef, i1 undef, i1 undef, i1 undef, float undef, ptr addrspace(1) poison, ptr addrspace(1) poison, ptr addrspace(1) poison, i1 undef, ptr addrspace(1) poison, i32 undef, i1 undef, i32 undef, i64 undef, i32 undef)
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/ipra.ll
+++ b/llvm/test/CodeGen/AMDGPU/ipra.ll
@@ -33,9 +33,9 @@ define hidden void @func() #1 {
 ; GCN: ; TotalNumSgprs: 37
 ; GCN: ; NumVgprs: 9
 define amdgpu_kernel void @kernel_call() #0 {
-  %vgpr = load volatile i32, ptr addrspace(1) undef
+  %vgpr = load volatile i32, ptr addrspace(1) poison
   tail call void @func()
-  store volatile i32 %vgpr, ptr addrspace(1) undef
+  store volatile i32 %vgpr, ptr addrspace(1) poison
   ret void
 }
 
@@ -51,9 +51,9 @@ define amdgpu_kernel void @kernel_call() #0 {
 ; GCN: ; TotalNumSgprs: 34
 ; GCN: ; NumVgprs: 10
 define void @func_regular_call() #1 {
-  %vgpr = load volatile i32, ptr addrspace(1) undef
+  %vgpr = load volatile i32, ptr addrspace(1) poison
   tail call void @func()
-  store volatile i32 %vgpr, ptr addrspace(1) undef
+  store volatile i32 %vgpr, ptr addrspace(1) poison
   ret void
 }
 
@@ -80,9 +80,9 @@ define void @func_tail_call() #1 {
 ; GCN: ; TotalNumSgprs: 34
 ; GCN: ; NumVgprs: 10
 define void @func_call_tail_call() #1 {
-  %vgpr = load volatile i32, ptr addrspace(1) undef
+  %vgpr = load volatile i32, ptr addrspace(1) poison
   tail call void @func()
-  store volatile i32 %vgpr, ptr addrspace(1) undef
+  store volatile i32 %vgpr, ptr addrspace(1) poison
   tail call void @func()
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/kernel-args.ll
+++ b/llvm/test/CodeGen/AMDGPU/kernel-args.ll
@@ -5158,8 +5158,8 @@ define amdgpu_kernel void @array_3xi32(i16 %arg0, [3 x i32] %arg1) {
 ; CM-NEXT:     MOV * T3.X, KC0[3].X,
 ; CM-NEXT:     MOV * T4.X, literal.x,
 ; CM-NEXT:    0(0.000000e+00), 0(0.000000e+00)
-  store volatile i16 %arg0, ptr addrspace(1) undef
-  store volatile [3 x i32] %arg1, ptr addrspace(1) undef
+  store volatile i16 %arg0, ptr addrspace(1) poison
+  store volatile [3 x i32] %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -5329,8 +5329,8 @@ define amdgpu_kernel void @array_3xi16(i8 %arg0, [3 x i16] %arg1) {
 ; CM-NEXT:     MOV T2.Y, 0.0,
 ; CM-NEXT:     MOV * T2.Z, 0.0,
 ; CM-NEXT:    65535(9.183409e-41), 0(0.000000e+00)
-  store volatile i8 %arg0, ptr addrspace(1) undef
-  store volatile [3 x i16] %arg1, ptr addrspace(1) undef
+  store volatile i8 %arg0, ptr addrspace(1) poison
+  store volatile [3 x i16] %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -5387,7 +5387,7 @@ define amdgpu_kernel void @small_array_round_down_offset(i8, [1 x i8] %arg) {
 ; EGCM-NEXT:     MOV * T1.X, literal.x,
 ; EGCM-NEXT:    0(0.000000e+00), 0(0.000000e+00)
   %val = extractvalue [1 x i8] %arg, 0
-  store volatile i8 %val, ptr addrspace(1) undef
+  store volatile i8 %val, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/kernel-argument-dag-lowering.ll
+++ b/llvm/test/CodeGen/AMDGPU/kernel-argument-dag-lowering.ll
@@ -160,16 +160,16 @@ define amdgpu_kernel void @struct_argument_alignment_after({i32, i64} %arg0, i8,
 ; GCN-LABEL: {{^}}array_3xi32:
 ; HSA-VI: s_load_dwordx4 s{{\[[0-9]+:[0-9]+\]}}, s[8:9], 0x0
 define amdgpu_kernel void @array_3xi32(i16 %arg0, [3 x i32] %arg1) {
-  store volatile i16 %arg0, ptr addrspace(1) undef
-  store volatile [3 x i32] %arg1, ptr addrspace(1) undef
+  store volatile i16 %arg0, ptr addrspace(1) poison
+  store volatile [3 x i32] %arg1, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}array_3xi16:
 ; HSA-VI: s_load_dwordx2 s{{\[[0-9]+:[0-9]+\]}}, s[8:9], 0x0
 define amdgpu_kernel void @array_3xi16(i8 %arg0, [3 x i16] %arg1) {
-  store volatile i8 %arg0, ptr addrspace(1) undef
-  store volatile [3 x i16] %arg1, ptr addrspace(1) undef
+  store volatile i8 %arg0, ptr addrspace(1) poison
+  store volatile [3 x i16] %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -317,7 +317,7 @@ define amdgpu_kernel void @multi_byref_constant_i32_arg(ptr addrspace(1) nocaptu
 ; GCN: .amdhsa_kernarg_size 4
 define amdgpu_kernel void @byref_constant_i32_arg_offset0(ptr addrspace(4) byref(i32) %in.byref) #0 {
   %in = load i32, ptr addrspace(4) %in.byref
-  store i32 %in, ptr addrspace(1) undef, align 4
+  store i32 %in, ptr addrspace(1) poison, align 4
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/large-alloca-compute.ll
+++ b/llvm/test/CodeGen/AMDGPU/large-alloca-compute.ll
@@ -63,7 +63,7 @@ define amdgpu_kernel void @large_alloca_compute_shader(i32 %x, i32 %y) #0 {
   store volatile i32 %x, ptr addrspace(5) %gep
   %gep1 = getelementptr [8192 x i32], ptr addrspace(5) %large, i32 0, i32 %y
   %val = load volatile i32, ptr addrspace(5) %gep1
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/large-alloca-graphics.ll
+++ b/llvm/test/CodeGen/AMDGPU/large-alloca-graphics.ll
@@ -24,7 +24,7 @@ define amdgpu_ps void @large_alloca_pixel_shader(i32 %x, i32 %y) #0 {
   store volatile i32 %x, ptr addrspace(5) %gep
   %gep1 = getelementptr [8192 x i32], ptr addrspace(5) %large, i32 0, i32 %y
   %val = load volatile i32, ptr addrspace(5) %gep1
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 
@@ -50,7 +50,7 @@ define amdgpu_ps void @large_alloca_pixel_shader_inreg(i32 inreg %x, i32 inreg %
   store volatile i32 %x, ptr addrspace(5) %gep
   %gep1 = getelementptr [8192 x i32], ptr addrspace(5) %large, i32 0, i32 %y
   %val = load volatile i32, ptr addrspace(5) %gep1
-  store volatile i32 %val, ptr addrspace(1) undef
+  store volatile i32 %val, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.class.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.class.ll
@@ -538,7 +538,7 @@ define i1 @test_fold_and_unord(float %a) {
 ; SI: s_and_b64
 define i1 @test_fold_and_ord_multi_use(float %a) {
   %class = call i1 @llvm.amdgcn.class.f32(float %a, i32 35) #1
-  store volatile i1 %class, ptr addrspace(1) undef
+  store volatile i1 %class, ptr addrspace(1) poison
   %ord = fcmp ord float %a, %a
   %and = and i1 %ord, %class
   ret i1 %and

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.interp.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.interp.ll
@@ -54,18 +54,18 @@ bb:
   %p0_10 = call float @llvm.amdgcn.interp.p1(float %i, i32 3, i32 64, i32 256)
   %p0_11 = call float @llvm.amdgcn.interp.p1(float %i, i32 4, i32 64, i32 256)
 
-  store volatile float %p0_0, ptr addrspace(1) undef
-  store volatile float %p0_1, ptr addrspace(1) undef
-  store volatile float %p0_2, ptr addrspace(1) undef
-  store volatile float %p0_3, ptr addrspace(1) undef
-  store volatile float %p0_4, ptr addrspace(1) undef
-  store volatile float %p0_5, ptr addrspace(1) undef
-  store volatile float %p0_6, ptr addrspace(1) undef
-  store volatile float %p0_7, ptr addrspace(1) undef
-  store volatile float %p0_8, ptr addrspace(1) undef
-  store volatile float %p0_9, ptr addrspace(1) undef
-  store volatile float %p0_10, ptr addrspace(1) undef
-  store volatile float %p0_11, ptr addrspace(1) undef
+  store volatile float %p0_0, ptr addrspace(1) poison
+  store volatile float %p0_1, ptr addrspace(1) poison
+  store volatile float %p0_2, ptr addrspace(1) poison
+  store volatile float %p0_3, ptr addrspace(1) poison
+  store volatile float %p0_4, ptr addrspace(1) poison
+  store volatile float %p0_5, ptr addrspace(1) poison
+  store volatile float %p0_6, ptr addrspace(1) poison
+  store volatile float %p0_7, ptr addrspace(1) poison
+  store volatile float %p0_8, ptr addrspace(1) poison
+  store volatile float %p0_9, ptr addrspace(1) poison
+  store volatile float %p0_10, ptr addrspace(1) poison
+  store volatile float %p0_11, ptr addrspace(1) poison
   ret void
 }
 
@@ -93,15 +93,15 @@ bb:
   %p2_7 = call float @llvm.amdgcn.interp.p2(float %x, float %j, i32 0, i32 64, i32 256)
   %p2_8 = call float @llvm.amdgcn.interp.p2(float %x, float %j, i32 4, i32 64, i32 256)
 
-  store volatile float %p2_0, ptr addrspace(1) undef
-  store volatile float %p2_1, ptr addrspace(1) undef
-  store volatile float %p2_2, ptr addrspace(1) undef
-  store volatile float %p2_3, ptr addrspace(1) undef
-  store volatile float %p2_4, ptr addrspace(1) undef
-  store volatile float %p2_5, ptr addrspace(1) undef
-  store volatile float %p2_6, ptr addrspace(1) undef
-  store volatile float %p2_7, ptr addrspace(1) undef
-  store volatile float %p2_8, ptr addrspace(1) undef
+  store volatile float %p2_0, ptr addrspace(1) poison
+  store volatile float %p2_1, ptr addrspace(1) poison
+  store volatile float %p2_2, ptr addrspace(1) poison
+  store volatile float %p2_3, ptr addrspace(1) poison
+  store volatile float %p2_4, ptr addrspace(1) poison
+  store volatile float %p2_5, ptr addrspace(1) poison
+  store volatile float %p2_6, ptr addrspace(1) poison
+  store volatile float %p2_7, ptr addrspace(1) poison
+  store volatile float %p2_8, ptr addrspace(1) poison
   ret void
 }
 
@@ -140,21 +140,21 @@ bb:
   %mov_11 = call float @llvm.amdgcn.interp.mov(i32 3, i32 1, i32 64, i32 256)
   %mov_12 = call float @llvm.amdgcn.interp.mov(i32 10, i32 4, i32 64, i32 256)
 
-  store volatile float %mov_0, ptr addrspace(1) undef
-  store volatile float %mov_1, ptr addrspace(1) undef
-  store volatile float %mov_2, ptr addrspace(1) undef
-  store volatile float %mov_3, ptr addrspace(1) undef
+  store volatile float %mov_0, ptr addrspace(1) poison
+  store volatile float %mov_1, ptr addrspace(1) poison
+  store volatile float %mov_2, ptr addrspace(1) poison
+  store volatile float %mov_3, ptr addrspace(1) poison
 
-  store volatile float %mov_4, ptr addrspace(1) undef
-  store volatile float %mov_5, ptr addrspace(1) undef
-  store volatile float %mov_6, ptr addrspace(1) undef
-  store volatile float %mov_7, ptr addrspace(1) undef
-  store volatile float %mov_8, ptr addrspace(1) undef
+  store volatile float %mov_4, ptr addrspace(1) poison
+  store volatile float %mov_5, ptr addrspace(1) poison
+  store volatile float %mov_6, ptr addrspace(1) poison
+  store volatile float %mov_7, ptr addrspace(1) poison
+  store volatile float %mov_8, ptr addrspace(1) poison
 
-  store volatile float %mov_9, ptr addrspace(1) undef
-  store volatile float %mov_10, ptr addrspace(1) undef
-  store volatile float %mov_11, ptr addrspace(1) undef
-  store volatile float %mov_12, ptr addrspace(1) undef
+  store volatile float %mov_9, ptr addrspace(1) poison
+  store volatile float %mov_10, ptr addrspace(1) poison
+  store volatile float %mov_11, ptr addrspace(1) poison
+  store volatile float %mov_12, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.is.private.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.is.private.ll
@@ -104,7 +104,7 @@ define amdgpu_kernel void @is_private_vgpr(ptr addrspace(1) %ptr.ptr) {
   %ptr = load volatile ptr, ptr addrspace(1) %gep
   %val = call i1 @llvm.amdgcn.is.private(ptr %ptr)
   %ext = zext i1 %val to i32
-  store i32 %ext, ptr addrspace(1) undef
+  store i32 %ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -221,7 +221,7 @@ define amdgpu_kernel void @is_private_sgpr(ptr %ptr) {
   br i1 %val, label %bb0, label %bb1
 
 bb0:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %bb1
 
 bb1:

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.is.shared.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.is.shared.ll
@@ -137,7 +137,7 @@ define amdgpu_kernel void @is_local_vgpr(ptr addrspace(1) %ptr.ptr) {
   %ptr = load volatile ptr, ptr addrspace(1) %gep
   %val = call i1 @llvm.amdgcn.is.shared(ptr %ptr)
   %ext = zext i1 %val to i32
-  store i32 %ext, ptr addrspace(1) undef
+  store i32 %ext, ptr addrspace(1) poison
   ret void
 }
 
@@ -288,7 +288,7 @@ define amdgpu_kernel void @is_local_sgpr(ptr %ptr) {
   br i1 %val, label %bb0, label %bb1
 
 bb0:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %bb1
 
 bb1:

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.kernarg.segment.ptr.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.kernarg.segment.ptr.ll
@@ -82,7 +82,7 @@ define amdgpu_kernel void @test_no_kernargs() #4 {
   %kernarg.segment.ptr = call noalias ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
   %gep = getelementptr i32, ptr addrspace(4) %kernarg.segment.ptr, i64 10
   %value = load i32, ptr addrspace(4) %gep
-  store volatile i32 %value, ptr addrspace(1) undef
+  store volatile i32 %value, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.dcache.inv.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.dcache.inv.ll
@@ -24,7 +24,7 @@ define amdgpu_kernel void @test_s_dcache_inv_insert_wait() #0 {
   br label %end
 
 end:
-  store volatile i32 3, ptr addrspace(1) undef
+  store volatile i32 3, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.dcache.inv.vol.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.dcache.inv.vol.ll
@@ -24,7 +24,7 @@ define amdgpu_kernel void @test_s_dcache_inv_vol_insert_wait() #0 {
   br label %end
 
 end:
-  store volatile i32 3, ptr addrspace(1) undef
+  store volatile i32 3, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.dcache.wb.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.dcache.wb.ll
@@ -22,7 +22,7 @@ define amdgpu_kernel void @test_s_dcache_wb_insert_wait() #0 {
   br label %end
 
 end:
-  store volatile i32 3, ptr addrspace(1) undef
+  store volatile i32 3, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.dcache.wb.vol.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.s.dcache.wb.vol.ll
@@ -22,7 +22,7 @@ define amdgpu_kernel void @test_s_dcache_wb_vol_insert_wait() #0 {
   br label %end
 
 end:
-  store volatile i32 3, ptr addrspace(1) undef
+  store volatile i32 3, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/llvm.mulo.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.mulo.ll
@@ -482,7 +482,7 @@ bb:
   %mul = extractvalue { i64, i1 } %umulo, 0
   %overflow = extractvalue { i64, i1 } %umulo, 1
   %res = select i1 %overflow, i64 0, i64 %mul
-  store i64 %res, ptr addrspace(1) undef
+  store i64 %res, ptr addrspace(1) poison
   ret void
 }
 
@@ -705,7 +705,7 @@ bb:
   %mul = extractvalue { i64, i1 } %umulo, 0
   %overflow = extractvalue { i64, i1 } %umulo, 1
   %res = select i1 %overflow, i64 0, i64 %mul
-  store i64 %res, ptr addrspace(1) undef
+  store i64 %res, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/load-constant-i16.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-constant-i16.ll
@@ -759,7 +759,7 @@ define amdgpu_kernel void @constant_load_v16i16_align2(ptr addrspace(4) %ptr0) #
 ; GFX12-NEXT:    s_endpgm
 entry:
   %ld =  load <16 x i16>, ptr addrspace(4) %ptr0, align 2
-  store <16 x i16> %ld, ptr addrspace(1) undef, align 32
+  store <16 x i16> %ld, ptr addrspace(1) poison, align 32
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/load-hi16.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-hi16.ll
@@ -330,7 +330,7 @@ entry:
   %load = load i16, ptr addrspace(3) %in
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %load, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -461,7 +461,7 @@ entry:
   %load = load half, ptr addrspace(3) %in
   %build0 = insertelement <2 x half> poison, half %reg, i32 0
   %build1 = insertelement <2 x half> %build0, half %load, i32 1
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -511,7 +511,7 @@ entry:
   %ext = zext i8 %load to i16
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %ext, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -561,7 +561,7 @@ entry:
   %ext = sext i8 %load to i16
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %ext, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -613,7 +613,7 @@ entry:
 
   %build0 = insertelement <2 x half> poison, half %reg, i32 0
   %build1 = insertelement <2 x half> %build0, half %bitcast, i32 1
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -665,7 +665,7 @@ entry:
 
   %build0 = insertelement <2 x half> poison, half %reg, i32 0
   %build1 = insertelement <2 x half> %build0, half %bitcast, i32 1
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -716,7 +716,7 @@ entry:
   %load = load i16, ptr addrspace(1) %gep
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %load, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -767,7 +767,7 @@ entry:
   %load = load half, ptr addrspace(1) %gep
   %build0 = insertelement <2 x half> poison, half %reg, i32 0
   %build1 = insertelement <2 x half> %build0, half %load, i32 1
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -819,7 +819,7 @@ entry:
   %ext = zext i8 %load to i16
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %ext, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -871,7 +871,7 @@ entry:
   %ext = sext i8 %load to i16
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %ext, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -924,7 +924,7 @@ entry:
   %bitcast = bitcast i16 %ext to half
   %build0 = insertelement <2 x half> poison, half %reg, i32 0
   %build1 = insertelement <2 x half> %build0, half %bitcast, i32 1
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -977,7 +977,7 @@ entry:
   %bitcast = bitcast i16 %ext to half
   %build0 = insertelement <2 x half> poison, half %reg, i32 0
   %build1 = insertelement <2 x half> %build0, half %bitcast, i32 1
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1025,7 +1025,7 @@ entry:
   %load = load i16, ptr %in
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %load, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1073,7 +1073,7 @@ entry:
   %load = load half, ptr %in
   %build0 = insertelement <2 x half> poison, half %reg, i32 0
   %build1 = insertelement <2 x half> %build0, half %load, i32 1
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1122,7 +1122,7 @@ entry:
   %ext = zext i8 %load to i16
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %ext, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1171,7 +1171,7 @@ entry:
   %ext = sext i8 %load to i16
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %ext, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1221,7 +1221,7 @@ entry:
   %bitcast = bitcast i16 %ext to half
   %build0 = insertelement <2 x half> poison, half %reg, i32 0
   %build1 = insertelement <2 x half> %build0, half %bitcast, i32 1
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1271,7 +1271,7 @@ entry:
   %bitcast = bitcast i16 %ext to half
   %build0 = insertelement <2 x half> poison, half %reg, i32 0
   %build1 = insertelement <2 x half> %build0, half %bitcast, i32 1
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1320,7 +1320,7 @@ entry:
   %load = load i16, ptr addrspace(5) %gep
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %load, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1369,7 +1369,7 @@ entry:
   %load = load half, ptr addrspace(5) %gep
   %build0 = insertelement <2 x half> poison, half %reg, i32 0
   %build1 = insertelement <2 x half> %build0, half %load, i32 1
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1418,7 +1418,7 @@ entry:
   %load = load volatile i16, ptr addrspace(5) inttoptr (i32 4094 to ptr addrspace(5))
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %load, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1467,7 +1467,7 @@ entry:
   %load = load volatile half, ptr addrspace(5) inttoptr (i32 4094 to ptr addrspace(5))
   %build0 = insertelement <2 x half> poison, half %reg, i32 0
   %build1 = insertelement <2 x half> %build0, half %load, i32 1
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1517,7 +1517,7 @@ entry:
   %ext = zext i8 %load to i16
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %ext, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1568,7 +1568,7 @@ entry:
   %bitcast = bitcast i16 %ext to half
   %build0 = insertelement <2 x half> poison, half %reg, i32 0
   %build1 = insertelement <2 x half> %build0, half %bitcast, i32 1
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1619,7 +1619,7 @@ entry:
   %bitcast = bitcast i16 %ext to half
   %build0 = insertelement <2 x half> poison, half %reg, i32 0
   %build1 = insertelement <2 x half> %build0, half %bitcast, i32 1
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1669,7 +1669,7 @@ entry:
   %ext = sext i8 %load to i16
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %ext, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1719,7 +1719,7 @@ entry:
   %ext = zext i8 %load to i16
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %ext, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1769,7 +1769,7 @@ entry:
   %ext = sext i8 %load to i16
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %ext, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1820,7 +1820,7 @@ entry:
   %bc.ext = bitcast i16 %ext to half
   %build0 = insertelement <2 x half> poison, half %reg, i32 0
   %build1 = insertelement <2 x half> %build0, half %bc.ext, i32 1
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1871,7 +1871,7 @@ entry:
   %load = load i16, ptr addrspace(4) %gep
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %load, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1922,7 +1922,7 @@ entry:
   %load = load half, ptr addrspace(4) %gep
   %build0 = insertelement <2 x half> poison, half %reg, i32 0
   %build1 = insertelement <2 x half> %build0, half %load, i32 1
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1975,7 +1975,7 @@ entry:
   %bitcast = bitcast i16 %ext to half
   %build0 = insertelement <2 x half> poison, half %reg, i32 0
   %build1 = insertelement <2 x half> %build0, half %bitcast, i32 1
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -2028,7 +2028,7 @@ entry:
   %bitcast = bitcast i16 %ext to half
   %build0 = insertelement <2 x half> poison, half %reg, i32 0
   %build1 = insertelement <2 x half> %build0, half %bitcast, i32 1
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -2094,7 +2094,7 @@ entry:
   %load = load i16, ptr addrspace(5) %gep
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %load, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -2158,7 +2158,7 @@ entry:
   %ext = sext i8 %load to i16
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %ext, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -2222,7 +2222,7 @@ entry:
   %ext = zext i8 %load to i16
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %ext, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/load-lo16.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-lo16.ll
@@ -126,7 +126,7 @@ entry:
   %load = load i16, ptr addrspace(3) %in
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 1
   %build1 = insertelement <2 x i16> %build0, i16 %load, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -231,7 +231,7 @@ entry:
   %reg.bc = bitcast i32 %reg to <2 x half>
   %load = load half, ptr addrspace(3) %in
   %build1 = insertelement <2 x half> %reg.bc, half %load, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -284,7 +284,7 @@ entry:
   %load = load half, ptr addrspace(3) %in
   %build0 = insertelement <2 x half> poison, half %reg, i32 1
   %build1 = insertelement <2 x half> %build0, half %load, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -325,7 +325,7 @@ entry:
   %load = load i8, ptr addrspace(3) %in
   %ext = zext i8 %load to i16
   %build1 = insertelement <2 x i16> %reg.bc, i16 %ext, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -379,7 +379,7 @@ entry:
   %ext = zext i8 %load to i16
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 1
   %build1 = insertelement <2 x i16> %build0, i16 %ext, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -420,7 +420,7 @@ entry:
   %load = load i8, ptr addrspace(3) %in
   %ext = sext i8 %load to i16
   %build1 = insertelement <2 x i16> %reg.bc, i16 %ext, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -474,7 +474,7 @@ entry:
   %ext = sext i8 %load to i16
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 1
   %build1 = insertelement <2 x i16> %build0, i16 %ext, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -529,7 +529,7 @@ entry:
   %bitcast = bitcast i16 %ext to half
   %build0 = insertelement <2 x half> poison, half %reg, i32 1
   %build1 = insertelement <2 x half> %build0, half %bitcast, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -584,7 +584,7 @@ entry:
   %bitcast = bitcast i16 %ext to half
   %build0 = insertelement <2 x half> poison, half %reg, i32 1
   %build1 = insertelement <2 x half> %build0, half %bitcast, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -646,7 +646,7 @@ entry:
   %elt1 = extractelement <2 x i16> %reg, i32 1
   store i16 %load, ptr addrspace(3) null
   %build1 = insertelement <2 x i16> %reg, i16 %load, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -696,7 +696,7 @@ entry:
   %elt1 = extractelement <2 x i16> %reg, i32 1
   store i16 %elt1, ptr addrspace(3) null
   %build1 = insertelement <2 x i16> %reg, i16 %load, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -763,7 +763,7 @@ entry:
   store i16 %load, ptr addrspace(3) %out0
   store i16 %elt1, ptr addrspace(3) %out1
   %build1 = insertelement <2 x i16> %reg, i16 %load, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -805,7 +805,7 @@ entry:
   %gep = getelementptr inbounds i16, ptr addrspace(1) %in, i64 -2047
   %load = load i16, ptr addrspace(1) %gep
   %build1 = insertelement <2 x i16> %reg.bc, i16 %load, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -847,7 +847,7 @@ entry:
   %gep = getelementptr inbounds half, ptr addrspace(1) %in, i64 -2047
   %load = load half, ptr addrspace(1) %gep
   %build1 = insertelement <2 x half> %reg.bc, half %load, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -890,7 +890,7 @@ entry:
   %load = load i8, ptr addrspace(1) %gep
   %ext = zext i8 %load to i16
   %build1 = insertelement <2 x i16> %reg.bc, i16 %ext, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -933,7 +933,7 @@ entry:
   %load = load i8, ptr addrspace(1) %gep
   %ext = sext i8 %load to i16
   %build1 = insertelement <2 x i16> %reg.bc, i16 %ext, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -977,7 +977,7 @@ entry:
   %ext = zext i8 %load to i16
   %bitcast = bitcast i16 %ext to half
   %build1 = insertelement <2 x half> %reg.bc, half %bitcast, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1021,7 +1021,7 @@ entry:
   %ext = sext i8 %load to i16
   %bitcast = bitcast i16 %ext to half
   %build1 = insertelement <2 x half> %reg.bc, half %bitcast, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1060,7 +1060,7 @@ entry:
   %reg.bc = bitcast i32 %reg to <2 x i16>
   %load = load i16, ptr %in
   %build1 = insertelement <2 x i16> %reg.bc, i16 %load, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1101,7 +1101,7 @@ entry:
   %reg.bc = bitcast i32 %reg to <2 x half>
   %load = load half, ptr %in
   %build1 = insertelement <2 x half> %reg.bc, half %load, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1141,7 +1141,7 @@ entry:
   %load = load i8, ptr %in
   %ext = zext i8 %load to i16
   %build1 = insertelement <2 x i16> %reg.bc, i16 %ext, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1181,7 +1181,7 @@ entry:
   %load = load i8, ptr %in
   %ext = sext i8 %load to i16
   %build1 = insertelement <2 x i16> %reg.bc, i16 %ext, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1222,7 +1222,7 @@ entry:
   %ext = zext i8 %load to i16
   %bitcast = bitcast i16 %ext to half
   %build1 = insertelement <2 x half> %reg.bc, half %bitcast, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1263,7 +1263,7 @@ entry:
   %ext = sext i8 %load to i16
   %bitcast = bitcast i16 %ext to half
   %build1 = insertelement <2 x half> %reg.bc, half %bitcast, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1312,7 +1312,7 @@ entry:
   %gep = getelementptr inbounds i16, ptr addrspace(5) %in, i64 2047
   %load = load i16, ptr addrspace(5) %gep
   %build1 = insertelement <2 x i16> %reg.bc, i16 %load, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1365,7 +1365,7 @@ entry:
   %load = load i16, ptr addrspace(5) %gep
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 1
   %build1 = insertelement <2 x i16> %build0, i16 %load, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1414,7 +1414,7 @@ entry:
   %gep = getelementptr inbounds half, ptr addrspace(5) %in, i64 2047
   %load = load half, ptr addrspace(5) %gep
   %build1 = insertelement <2 x half> %reg.bc, half %load, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1463,7 +1463,7 @@ entry:
   %reg.bc = bitcast i32 %reg to <2 x i16>
   %load = load volatile i16, ptr addrspace(5) inttoptr (i32 4094 to ptr addrspace(5))
   %build1 = insertelement <2 x i16> %reg.bc, i16 %load, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1512,7 +1512,7 @@ entry:
   %reg.bc = bitcast i32 %reg to <2 x i16>
   %load = load volatile i16, ptr addrspace(5) inttoptr (i32 4094 to ptr addrspace(5))
   %build1 = insertelement <2 x i16> %reg.bc, i16 %load, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1561,7 +1561,7 @@ entry:
   %reg.bc = bitcast i32 %reg to <2 x half>
   %load = load volatile half, ptr addrspace(5) inttoptr (i32 4094 to ptr addrspace(5))
   %build1 = insertelement <2 x half> %reg.bc, half %load, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1611,7 +1611,7 @@ entry:
   %load = load i8, ptr addrspace(5) %gep
   %ext = zext i8 %load to i16
   %build1 = insertelement <2 x i16> %reg.bc, i16 %ext, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1661,7 +1661,7 @@ entry:
   %load = load i8, ptr addrspace(5) %gep
   %ext = sext i8 %load to i16
   %build1 = insertelement <2 x i16> %reg.bc, i16 %ext, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1711,7 +1711,7 @@ entry:
   %load = load volatile i8, ptr addrspace(5) inttoptr (i32 4094 to ptr addrspace(5))
   %ext = zext i8 %load to i16
   %build1 = insertelement <2 x i16> %reg.bc, i16 %ext, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1761,7 +1761,7 @@ entry:
   %load = load volatile i8, ptr addrspace(5) inttoptr (i32 4094 to ptr addrspace(5))
   %ext = sext i8 %load to i16
   %build1 = insertelement <2 x i16> %reg.bc, i16 %ext, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1812,7 +1812,7 @@ entry:
   %ext = zext i8 %load to i16
   %bc.ext = bitcast i16 %ext to half
   %build1 = insertelement <2 x half> %reg.bc, half %bc.ext, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1854,7 +1854,7 @@ entry:
   %gep = getelementptr inbounds i16, ptr addrspace(4) %in, i64 -2047
   %load = load i16, ptr addrspace(4) %gep
   %build1 = insertelement <2 x i16> %reg.bc, i16 %load, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1896,7 +1896,7 @@ entry:
   %gep = getelementptr inbounds half, ptr addrspace(4) %in, i64 -2047
   %load = load half, ptr addrspace(4) %gep
   %build1 = insertelement <2 x half> %reg.bc, half %load, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1940,7 +1940,7 @@ entry:
   %ext = zext i8 %load to i16
   %bitcast = bitcast i16 %ext to half
   %build1 = insertelement <2 x half> %reg.bc, half %bitcast, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1984,7 +1984,7 @@ entry:
   %ext = sext i8 %load to i16
   %bitcast = bitcast i16 %ext to half
   %build1 = insertelement <2 x half> %reg.bc, half %bitcast, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -2052,7 +2052,7 @@ entry:
   %gep = getelementptr inbounds [4096 x i16], ptr addrspace(5) %obj1, i32 0, i32 2027
   %load = load volatile i16, ptr addrspace(5) %gep
   %build1 = insertelement <2 x i16> %reg.bc, i16 %load, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -2121,7 +2121,7 @@ entry:
   %load = load volatile i8, ptr addrspace(5) %gep
   %load.ext = sext i8 %load to i16
   %build1 = insertelement <2 x i16> %reg.bc, i16 %load.ext, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -2190,7 +2190,7 @@ entry:
   %load = load volatile i8, ptr addrspace(5) %gep
   %load.ext = zext i8 %load to i16
   %build1 = insertelement <2 x i16> %reg.bc, i16 %load.ext, i32 0
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -2260,7 +2260,7 @@ entry:
   %load.ext = sext i8 %load to i16
   %bitcast = bitcast i16 %load.ext to half
   %build1 = insertelement <2 x half> %reg.bc, half %bitcast, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 
@@ -2330,7 +2330,7 @@ entry:
   %load.ext = zext i8 %load to i16
   %bitcast = bitcast i16 %load.ext to half
   %build1 = insertelement <2 x half> %reg.bc, half %bitcast, i32 0
-  store <2 x half> %build1, ptr addrspace(1) undef
+  store <2 x half> %build1, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/long-branch-reserve-register.ll
+++ b/llvm/test/CodeGen/AMDGPU/long-branch-reserve-register.ll
@@ -310,7 +310,7 @@ bb0:
   br i1 %tmp, label %bb2, label %bb3
 
 bb2:
-  store volatile i32 17, ptr addrspace(1) undef
+  store volatile i32 17, ptr addrspace(1) poison
   br label %bb4
 
 bb3:

--- a/llvm/test/CodeGen/AMDGPU/loop-on-function-argument.ll
+++ b/llvm/test/CodeGen/AMDGPU/loop-on-function-argument.ll
@@ -9,7 +9,7 @@ define void @loop_on_argument(i1 %arg) {
 ; IR:       loop:
 ; IR-NEXT:    [[PHI_BROKEN:%.*]] = phi i64 [ [[TMP0:%.*]], [[LOOP]] ], [ 0, [[ENTRY:%.*]] ]
 ; IR-NEXT:    [[TMP0]] = call i64 @llvm.amdgcn.if.break.i64(i1 [[ARG:%.*]], i64 [[PHI_BROKEN]])
-; IR-NEXT:    store volatile i32 0, ptr addrspace(1) undef, align 4
+; IR-NEXT:    store volatile i32 0, ptr addrspace(1) poison, align 4
 ; IR-NEXT:    [[TMP1:%.*]] = call i1 @llvm.amdgcn.loop.i64(i64 [[TMP0]])
 ; IR-NEXT:    br i1 [[TMP1]], label [[EXIT:%.*]], label [[LOOP]]
 ; IR:       exit:
@@ -38,7 +38,7 @@ entry:
   br label %loop
 
 loop:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br i1 %arg, label %exit, label %loop
 
 exit:

--- a/llvm/test/CodeGen/AMDGPU/loop_break.ll
+++ b/llvm/test/CodeGen/AMDGPU/loop_break.ll
@@ -18,7 +18,7 @@ define amdgpu_kernel void @break_loop(i32 %arg) #0 {
 ; OPT-NEXT:    [[CMP0:%.*]] = icmp slt i32 [[TMP0]], 0
 ; OPT-NEXT:    br i1 [[CMP0]], label %[[BB4:.*]], label %[[FLOW]]
 ; OPT:       [[BB4]]:
-; OPT-NEXT:    [[LOAD:%.*]] = load volatile i32, ptr addrspace(1) undef, align 4
+; OPT-NEXT:    [[LOAD:%.*]] = load volatile i32, ptr addrspace(1) poison, align 4
 ; OPT-NEXT:    [[CMP1:%.*]] = icmp sge i32 [[MY_TMP]], [[LOAD]]
 ; OPT-NEXT:    br label %[[FLOW]]
 ; OPT:       [[FLOW]]:
@@ -74,7 +74,7 @@ bb1:
   br i1 %cmp0, label %bb4, label %bb9
 
 bb4:
-  %load = load volatile i32, ptr addrspace(1) undef, align 4
+  %load = load volatile i32, ptr addrspace(1) poison, align 4
   %cmp1 = icmp slt i32 %my.tmp, %load
   br i1 %cmp1, label %bb1, label %bb9
 
@@ -96,7 +96,7 @@ define amdgpu_kernel void @undef_phi_cond_break_loop(i32 %arg) #0 {
 ; OPT-NEXT:    [[CMP0:%.*]] = icmp slt i32 [[LSR_IV_NEXT]], 0
 ; OPT-NEXT:    br i1 [[CMP0]], label %[[BB4:.*]], label %[[FLOW]]
 ; OPT:       [[BB4]]:
-; OPT-NEXT:    [[LOAD:%.*]] = load volatile i32, ptr addrspace(1) undef, align 4
+; OPT-NEXT:    [[LOAD:%.*]] = load volatile i32, ptr addrspace(1) poison, align 4
 ; OPT-NEXT:    [[CMP1:%.*]] = icmp sge i32 [[MY_TMP]], [[LOAD]]
 ; OPT-NEXT:    br label %[[FLOW]]
 ; OPT:       [[FLOW]]:
@@ -154,7 +154,7 @@ bb1:                                              ; preds = %Flow, %bb
   br i1 %cmp0, label %bb4, label %Flow
 
 bb4:                                              ; preds = %bb1
-  %load = load volatile i32, ptr addrspace(1) undef, align 4
+  %load = load volatile i32, ptr addrspace(1) poison, align 4
   %cmp1 = icmp sge i32 %my.tmp, %load
   br label %Flow
 
@@ -186,7 +186,7 @@ define amdgpu_kernel void @constexpr_phi_cond_break_loop(i32 %arg) #0 {
 ; OPT-NEXT:    [[CMP2:%.*]] = icmp ne ptr addrspace(3) inttoptr (i32 4 to ptr addrspace(3)), @lds
 ; OPT-NEXT:    br i1 [[CMP0]], label %[[BB4:.*]], label %[[FLOW]]
 ; OPT:       [[BB4]]:
-; OPT-NEXT:    [[LOAD:%.*]] = load volatile i32, ptr addrspace(1) undef, align 4
+; OPT-NEXT:    [[LOAD:%.*]] = load volatile i32, ptr addrspace(1) poison, align 4
 ; OPT-NEXT:    [[CMP1:%.*]] = icmp sge i32 [[MY_TMP]], [[LOAD]]
 ; OPT-NEXT:    br label %[[FLOW]]
 ; OPT:       [[FLOW]]:
@@ -249,7 +249,7 @@ bb1:                                              ; preds = %Flow, %bb
   br i1 %cmp0, label %bb4, label %Flow
 
 bb4:                                              ; preds = %bb1
-  %load = load volatile i32, ptr addrspace(1) undef, align 4
+  %load = load volatile i32, ptr addrspace(1) poison, align 4
   %cmp1 = icmp sge i32 %my.tmp, %load
   br label %Flow
 
@@ -277,7 +277,7 @@ define amdgpu_kernel void @true_phi_cond_break_loop(i32 %arg) #0 {
 ; OPT-NEXT:    [[CMP0:%.*]] = icmp slt i32 [[LSR_IV_NEXT]], 0
 ; OPT-NEXT:    br i1 [[CMP0]], label %[[BB4:.*]], label %[[FLOW]]
 ; OPT:       [[BB4]]:
-; OPT-NEXT:    [[LOAD:%.*]] = load volatile i32, ptr addrspace(1) undef, align 4
+; OPT-NEXT:    [[LOAD:%.*]] = load volatile i32, ptr addrspace(1) poison, align 4
 ; OPT-NEXT:    [[CMP1:%.*]] = icmp sge i32 [[MY_TMP]], [[LOAD]]
 ; OPT-NEXT:    br label %[[FLOW]]
 ; OPT:       [[FLOW]]:
@@ -339,7 +339,7 @@ bb1:                                              ; preds = %Flow, %bb
   br i1 %cmp0, label %bb4, label %Flow
 
 bb4:                                              ; preds = %bb1
-  %load = load volatile i32, ptr addrspace(1) undef, align 4
+  %load = load volatile i32, ptr addrspace(1) poison, align 4
   %cmp1 = icmp sge i32 %my.tmp, %load
   br label %Flow
 
@@ -367,7 +367,7 @@ define amdgpu_kernel void @false_phi_cond_break_loop(i32 %arg) #0 {
 ; OPT-NEXT:    [[CMP0:%.*]] = icmp slt i32 [[LSR_IV_NEXT]], 0
 ; OPT-NEXT:    br i1 [[CMP0]], label %[[BB4:.*]], label %[[FLOW]]
 ; OPT:       [[BB4]]:
-; OPT-NEXT:    [[LOAD:%.*]] = load volatile i32, ptr addrspace(1) undef, align 4
+; OPT-NEXT:    [[LOAD:%.*]] = load volatile i32, ptr addrspace(1) poison, align 4
 ; OPT-NEXT:    [[CMP1:%.*]] = icmp sge i32 [[MY_TMP]], [[LOAD]]
 ; OPT-NEXT:    br label %[[FLOW]]
 ; OPT:       [[FLOW]]:
@@ -429,7 +429,7 @@ bb1:                                              ; preds = %Flow, %bb
   br i1 %cmp0, label %bb4, label %Flow
 
 bb4:                                              ; preds = %bb1
-  %load = load volatile i32, ptr addrspace(1) undef, align 4
+  %load = load volatile i32, ptr addrspace(1) poison, align 4
   %cmp1 = icmp sge i32 %my.tmp, %load
   br label %Flow
 
@@ -460,7 +460,7 @@ define amdgpu_kernel void @invert_true_phi_cond_break_loop(i32 %arg) #0 {
 ; OPT-NEXT:    [[CMP0:%.*]] = icmp slt i32 [[LSR_IV_NEXT]], 0
 ; OPT-NEXT:    br i1 [[CMP0]], label %[[BB4:.*]], label %[[FLOW]]
 ; OPT:       [[BB4]]:
-; OPT-NEXT:    [[LOAD:%.*]] = load volatile i32, ptr addrspace(1) undef, align 4
+; OPT-NEXT:    [[LOAD:%.*]] = load volatile i32, ptr addrspace(1) poison, align 4
 ; OPT-NEXT:    [[CMP1:%.*]] = icmp sge i32 [[MY_TMP]], [[LOAD]]
 ; OPT-NEXT:    br label %[[FLOW]]
 ; OPT:       [[FLOW]]:
@@ -524,7 +524,7 @@ bb1:                                              ; preds = %Flow, %bb
   br i1 %cmp0, label %bb4, label %Flow
 
 bb4:                                              ; preds = %bb1
-  %load = load volatile i32, ptr addrspace(1) undef, align 4
+  %load = load volatile i32, ptr addrspace(1) poison, align 4
   %cmp1 = icmp sge i32 %my.tmp, %load
   br label %Flow
 

--- a/llvm/test/CodeGen/AMDGPU/lower-kernargs.ll
+++ b/llvm/test/CodeGen/AMDGPU/lower-kernargs.ll
@@ -19,7 +19,7 @@ define amdgpu_kernel void @kern_i8(i8 %arg) #0 {
 ; HSA-NEXT:    [[ARG_KERNARG_OFFSET_ALIGN_DOWN:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_I8_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1:![0-9]+]]
 ; HSA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i8
-; HSA-NEXT:    store i8 [[TMP2]], ptr addrspace(1) undef, align 1
+; HSA-NEXT:    store i8 [[TMP2]], ptr addrspace(1) poison, align 1
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_i8(
@@ -27,10 +27,10 @@ define amdgpu_kernel void @kern_i8(i8 %arg) #0 {
 ; MESA-NEXT:    [[ARG_KERNARG_OFFSET_ALIGN_DOWN:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_I8_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1:![0-9]+]]
 ; MESA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i8
-; MESA-NEXT:    store i8 [[TMP2]], ptr addrspace(1) undef, align 1
+; MESA-NEXT:    store i8 [[TMP2]], ptr addrspace(1) poison, align 1
 ; MESA-NEXT:    ret void
 ;
-  store i8 %arg, ptr addrspace(1) undef, align 1
+  store i8 %arg, ptr addrspace(1) poison, align 1
   ret void
 }
 
@@ -40,7 +40,7 @@ define amdgpu_kernel void @kern_i16(i16 %arg) #0 {
 ; HSA-NEXT:    [[ARG_KERNARG_OFFSET_ALIGN_DOWN:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_I16_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i16
-; HSA-NEXT:    store i16 [[TMP2]], ptr addrspace(1) undef, align 1
+; HSA-NEXT:    store i16 [[TMP2]], ptr addrspace(1) poison, align 1
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_i16(
@@ -48,10 +48,10 @@ define amdgpu_kernel void @kern_i16(i16 %arg) #0 {
 ; MESA-NEXT:    [[ARG_KERNARG_OFFSET_ALIGN_DOWN:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_I16_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i16
-; MESA-NEXT:    store i16 [[TMP2]], ptr addrspace(1) undef, align 1
+; MESA-NEXT:    store i16 [[TMP2]], ptr addrspace(1) poison, align 1
 ; MESA-NEXT:    ret void
 ;
-  store i16 %arg, ptr addrspace(1) undef, align 1
+  store i16 %arg, ptr addrspace(1) poison, align 1
   ret void
 }
 
@@ -62,7 +62,7 @@ define amdgpu_kernel void @kern_f16(half %arg) #0 {
 ; HSA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i16
 ; HSA-NEXT:    [[ARG_LOAD:%.*]] = bitcast i16 [[TMP2]] to half
-; HSA-NEXT:    store half [[ARG_LOAD]], ptr addrspace(1) undef, align 1
+; HSA-NEXT:    store half [[ARG_LOAD]], ptr addrspace(1) poison, align 1
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_f16(
@@ -71,10 +71,10 @@ define amdgpu_kernel void @kern_f16(half %arg) #0 {
 ; MESA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i16
 ; MESA-NEXT:    [[ARG_LOAD:%.*]] = bitcast i16 [[TMP2]] to half
-; MESA-NEXT:    store half [[ARG_LOAD]], ptr addrspace(1) undef, align 1
+; MESA-NEXT:    store half [[ARG_LOAD]], ptr addrspace(1) poison, align 1
 ; MESA-NEXT:    ret void
 ;
-  store half %arg, ptr addrspace(1) undef, align 1
+  store half %arg, ptr addrspace(1) poison, align 1
   ret void
 }
 
@@ -84,7 +84,7 @@ define amdgpu_kernel void @kern_zeroext_i8(i8 zeroext %arg) #0 {
 ; HSA-NEXT:    [[ARG_KERNARG_OFFSET_ALIGN_DOWN:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_ZEROEXT_I8_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i8
-; HSA-NEXT:    store i8 [[TMP2]], ptr addrspace(1) undef, align 1
+; HSA-NEXT:    store i8 [[TMP2]], ptr addrspace(1) poison, align 1
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_zeroext_i8(
@@ -92,10 +92,10 @@ define amdgpu_kernel void @kern_zeroext_i8(i8 zeroext %arg) #0 {
 ; MESA-NEXT:    [[ARG_KERNARG_OFFSET_ALIGN_DOWN:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_ZEROEXT_I8_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i8
-; MESA-NEXT:    store i8 [[TMP2]], ptr addrspace(1) undef, align 1
+; MESA-NEXT:    store i8 [[TMP2]], ptr addrspace(1) poison, align 1
 ; MESA-NEXT:    ret void
 ;
-  store i8 %arg, ptr addrspace(1) undef, align 1
+  store i8 %arg, ptr addrspace(1) poison, align 1
   ret void
 }
 
@@ -105,7 +105,7 @@ define amdgpu_kernel void @kern_zeroext_i16(i16 zeroext %arg) #0 {
 ; HSA-NEXT:    [[ARG_KERNARG_OFFSET_ALIGN_DOWN:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_ZEROEXT_I16_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i16
-; HSA-NEXT:    store i16 [[TMP2]], ptr addrspace(1) undef, align 1
+; HSA-NEXT:    store i16 [[TMP2]], ptr addrspace(1) poison, align 1
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_zeroext_i16(
@@ -113,10 +113,10 @@ define amdgpu_kernel void @kern_zeroext_i16(i16 zeroext %arg) #0 {
 ; MESA-NEXT:    [[ARG_KERNARG_OFFSET_ALIGN_DOWN:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_ZEROEXT_I16_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i16
-; MESA-NEXT:    store i16 [[TMP2]], ptr addrspace(1) undef, align 1
+; MESA-NEXT:    store i16 [[TMP2]], ptr addrspace(1) poison, align 1
 ; MESA-NEXT:    ret void
 ;
-  store i16 %arg, ptr addrspace(1) undef, align 1
+  store i16 %arg, ptr addrspace(1) poison, align 1
   ret void
 }
 
@@ -126,7 +126,7 @@ define amdgpu_kernel void @kern_signext_i8(i8 signext %arg) #0 {
 ; HSA-NEXT:    [[ARG_KERNARG_OFFSET_ALIGN_DOWN:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_SIGNEXT_I8_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i8
-; HSA-NEXT:    store i8 [[TMP2]], ptr addrspace(1) undef, align 1
+; HSA-NEXT:    store i8 [[TMP2]], ptr addrspace(1) poison, align 1
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_signext_i8(
@@ -134,10 +134,10 @@ define amdgpu_kernel void @kern_signext_i8(i8 signext %arg) #0 {
 ; MESA-NEXT:    [[ARG_KERNARG_OFFSET_ALIGN_DOWN:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_SIGNEXT_I8_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i8
-; MESA-NEXT:    store i8 [[TMP2]], ptr addrspace(1) undef, align 1
+; MESA-NEXT:    store i8 [[TMP2]], ptr addrspace(1) poison, align 1
 ; MESA-NEXT:    ret void
 ;
-  store i8 %arg, ptr addrspace(1) undef, align 1
+  store i8 %arg, ptr addrspace(1) poison, align 1
   ret void
 }
 
@@ -147,7 +147,7 @@ define amdgpu_kernel void @kern_signext_i16(i16 signext %arg) #0 {
 ; HSA-NEXT:    [[ARG_KERNARG_OFFSET_ALIGN_DOWN:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_SIGNEXT_I16_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i16
-; HSA-NEXT:    store i16 [[TMP2]], ptr addrspace(1) undef, align 1
+; HSA-NEXT:    store i16 [[TMP2]], ptr addrspace(1) poison, align 1
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_signext_i16(
@@ -155,10 +155,10 @@ define amdgpu_kernel void @kern_signext_i16(i16 signext %arg) #0 {
 ; MESA-NEXT:    [[ARG_KERNARG_OFFSET_ALIGN_DOWN:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_SIGNEXT_I16_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i16
-; MESA-NEXT:    store i16 [[TMP2]], ptr addrspace(1) undef, align 1
+; MESA-NEXT:    store i16 [[TMP2]], ptr addrspace(1) poison, align 1
 ; MESA-NEXT:    ret void
 ;
-  store i16 %arg, ptr addrspace(1) undef, align 1
+  store i16 %arg, ptr addrspace(1) poison, align 1
   ret void
 }
 
@@ -172,8 +172,8 @@ define amdgpu_kernel void @kern_i8_i8(i8 %arg0, i8 %arg1) {
 ; HSA-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(4) [[ARG1_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP4:%.*]] = lshr i32 [[TMP3]], 8
 ; HSA-NEXT:    [[TMP5:%.*]] = trunc i32 [[TMP4]] to i8
-; HSA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) undef, align 1
+; HSA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) poison, align 1
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_i8_i8(
@@ -185,12 +185,12 @@ define amdgpu_kernel void @kern_i8_i8(i8 %arg0, i8 %arg1) {
 ; MESA-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(4) [[ARG1_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP4:%.*]] = lshr i32 [[TMP3]], 8
 ; MESA-NEXT:    [[TMP5:%.*]] = trunc i32 [[TMP4]] to i8
-; MESA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) undef, align 1
+; MESA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) poison, align 1
 ; MESA-NEXT:    ret void
 ;
-  store volatile i8 %arg0, ptr addrspace(1) undef, align 1
-  store volatile i8 %arg1, ptr addrspace(1) undef, align 1
+  store volatile i8 %arg0, ptr addrspace(1) poison, align 1
+  store volatile i8 %arg1, ptr addrspace(1) poison, align 1
   ret void
 }
 
@@ -201,7 +201,7 @@ define amdgpu_kernel void @kern_v3i8(<3 x i8> %arg) {
 ; HSA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i24
 ; HSA-NEXT:    [[ARG_LOAD:%.*]] = bitcast i24 [[TMP2]] to <3 x i8>
-; HSA-NEXT:    store <3 x i8> [[ARG_LOAD]], ptr addrspace(1) undef, align 4
+; HSA-NEXT:    store <3 x i8> [[ARG_LOAD]], ptr addrspace(1) poison, align 4
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_v3i8(
@@ -210,10 +210,10 @@ define amdgpu_kernel void @kern_v3i8(<3 x i8> %arg) {
 ; MESA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i24
 ; MESA-NEXT:    [[ARG_LOAD:%.*]] = bitcast i24 [[TMP2]] to <3 x i8>
-; MESA-NEXT:    store <3 x i8> [[ARG_LOAD]], ptr addrspace(1) undef, align 4
+; MESA-NEXT:    store <3 x i8> [[ARG_LOAD]], ptr addrspace(1) poison, align 4
 ; MESA-NEXT:    ret void
 ;
-  store <3 x i8> %arg, ptr addrspace(1) undef, align 4
+  store <3 x i8> %arg, ptr addrspace(1) poison, align 4
   ret void
 }
 
@@ -223,7 +223,7 @@ define amdgpu_kernel void @kern_i24(i24 %arg0) {
 ; HSA-NEXT:    [[ARG0_KERNARG_OFFSET_ALIGN_DOWN:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_I24_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG0_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i24
-; HSA-NEXT:    store i24 [[TMP2]], ptr addrspace(1) undef, align 4
+; HSA-NEXT:    store i24 [[TMP2]], ptr addrspace(1) poison, align 4
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_i24(
@@ -231,10 +231,10 @@ define amdgpu_kernel void @kern_i24(i24 %arg0) {
 ; MESA-NEXT:    [[ARG0_KERNARG_OFFSET_ALIGN_DOWN:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_I24_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[TMP1:%.*]] = load i32, ptr addrspace(4) [[ARG0_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP2:%.*]] = trunc i32 [[TMP1]] to i24
-; MESA-NEXT:    store i24 [[TMP2]], ptr addrspace(1) undef, align 4
+; MESA-NEXT:    store i24 [[TMP2]], ptr addrspace(1) poison, align 4
 ; MESA-NEXT:    ret void
 ;
-  store i24 %arg0, ptr addrspace(1) undef
+  store i24 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -243,17 +243,17 @@ define amdgpu_kernel void @kern_i32(i32 %arg0) {
 ; HSA-NEXT:    [[KERN_I32_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(264) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; HSA-NEXT:    [[ARG0_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_I32_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[ARG0_LOAD:%.*]] = load i32, ptr addrspace(4) [[ARG0_KERNARG_OFFSET]], align 16, !invariant.load [[META1]]
-; HSA-NEXT:    store i32 [[ARG0_LOAD]], ptr addrspace(1) undef, align 4
+; HSA-NEXT:    store i32 [[ARG0_LOAD]], ptr addrspace(1) poison, align 4
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_i32(
 ; MESA-NEXT:    [[KERN_I32_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(260) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; MESA-NEXT:    [[ARG0_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_I32_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[ARG0_LOAD:%.*]] = load i32, ptr addrspace(4) [[ARG0_KERNARG_OFFSET]], align 4, !invariant.load [[META1]]
-; MESA-NEXT:    store i32 [[ARG0_LOAD]], ptr addrspace(1) undef, align 4
+; MESA-NEXT:    store i32 [[ARG0_LOAD]], ptr addrspace(1) poison, align 4
 ; MESA-NEXT:    ret void
 ;
-  store i32 %arg0, ptr addrspace(1) undef
+  store i32 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -281,17 +281,17 @@ define amdgpu_kernel void @kern_f32(float %arg0) {
 ; HSA-NEXT:    [[KERN_F32_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(264) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; HSA-NEXT:    [[ARG0_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_F32_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[ARG0_LOAD:%.*]] = load float, ptr addrspace(4) [[ARG0_KERNARG_OFFSET]], align 16, !invariant.load [[META1]]
-; HSA-NEXT:    store float [[ARG0_LOAD]], ptr addrspace(1) undef, align 4
+; HSA-NEXT:    store float [[ARG0_LOAD]], ptr addrspace(1) poison, align 4
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_f32(
 ; MESA-NEXT:    [[KERN_F32_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(260) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; MESA-NEXT:    [[ARG0_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_F32_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[ARG0_LOAD:%.*]] = load float, ptr addrspace(4) [[ARG0_KERNARG_OFFSET]], align 4, !invariant.load [[META1]]
-; MESA-NEXT:    store float [[ARG0_LOAD]], ptr addrspace(1) undef, align 4
+; MESA-NEXT:    store float [[ARG0_LOAD]], ptr addrspace(1) poison, align 4
 ; MESA-NEXT:    ret void
 ;
-  store float %arg0, ptr addrspace(1) undef
+  store float %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -301,7 +301,7 @@ define amdgpu_kernel void @kern_v3i32(<3 x i32> %arg0) {
 ; HSA-NEXT:    [[ARG0_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_V3I32_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[TMP1:%.*]] = load <4 x i32>, ptr addrspace(4) [[ARG0_KERNARG_OFFSET]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[ARG0_LOAD:%.*]] = shufflevector <4 x i32> [[TMP1]], <4 x i32> poison, <3 x i32> <i32 0, i32 1, i32 2>
-; HSA-NEXT:    store <3 x i32> [[ARG0_LOAD]], ptr addrspace(1) undef, align 4
+; HSA-NEXT:    store <3 x i32> [[ARG0_LOAD]], ptr addrspace(1) poison, align 4
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_v3i32(
@@ -309,10 +309,10 @@ define amdgpu_kernel void @kern_v3i32(<3 x i32> %arg0) {
 ; MESA-NEXT:    [[ARG0_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_V3I32_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[TMP1:%.*]] = load <4 x i32>, ptr addrspace(4) [[ARG0_KERNARG_OFFSET]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[ARG0_LOAD:%.*]] = shufflevector <4 x i32> [[TMP1]], <4 x i32> poison, <3 x i32> <i32 0, i32 1, i32 2>
-; MESA-NEXT:    store <3 x i32> [[ARG0_LOAD]], ptr addrspace(1) undef, align 4
+; MESA-NEXT:    store <3 x i32> [[ARG0_LOAD]], ptr addrspace(1) poison, align 4
 ; MESA-NEXT:    ret void
 ;
-  store <3 x i32> %arg0, ptr addrspace(1) undef, align 4
+  store <3 x i32> %arg0, ptr addrspace(1) poison, align 4
   ret void
 }
 
@@ -321,17 +321,17 @@ define amdgpu_kernel void @kern_v8i32(<8 x i32> %arg) #0 {
 ; HSA-NEXT:    [[KERN_V8I32_KERNARG_SEGMENT:%.*]] = call nonnull align 32 dereferenceable(288) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; HSA-NEXT:    [[ARG_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_V8I32_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[ARG_LOAD:%.*]] = load <8 x i32>, ptr addrspace(4) [[ARG_KERNARG_OFFSET]], align 16, !invariant.load [[META1]]
-; HSA-NEXT:    store <8 x i32> [[ARG_LOAD]], ptr addrspace(1) undef, align 32
+; HSA-NEXT:    store <8 x i32> [[ARG_LOAD]], ptr addrspace(1) poison, align 32
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_v8i32(
 ; MESA-NEXT:    [[KERN_V8I32_KERNARG_SEGMENT:%.*]] = call nonnull align 32 dereferenceable(288) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; MESA-NEXT:    [[ARG_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_V8I32_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[ARG_LOAD:%.*]] = load <8 x i32>, ptr addrspace(4) [[ARG_KERNARG_OFFSET]], align 4, !invariant.load [[META1]]
-; MESA-NEXT:    store <8 x i32> [[ARG_LOAD]], ptr addrspace(1) undef, align 32
+; MESA-NEXT:    store <8 x i32> [[ARG_LOAD]], ptr addrspace(1) poison, align 32
 ; MESA-NEXT:    ret void
 ;
-  store <8 x i32> %arg, ptr addrspace(1) undef
+  store <8 x i32> %arg, ptr addrspace(1) poison
   ret void
 }
 
@@ -340,17 +340,17 @@ define amdgpu_kernel void @kern_v8i64(<8 x i64> %arg) #0 {
 ; HSA-NEXT:    [[KERN_V8I64_KERNARG_SEGMENT:%.*]] = call nonnull align 64 dereferenceable(320) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; HSA-NEXT:    [[ARG_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_V8I64_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[ARG_LOAD:%.*]] = load <8 x i64>, ptr addrspace(4) [[ARG_KERNARG_OFFSET]], align 16, !invariant.load [[META1]]
-; HSA-NEXT:    store <8 x i64> [[ARG_LOAD]], ptr addrspace(1) undef, align 64
+; HSA-NEXT:    store <8 x i64> [[ARG_LOAD]], ptr addrspace(1) poison, align 64
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_v8i64(
 ; MESA-NEXT:    [[KERN_V8I64_KERNARG_SEGMENT:%.*]] = call nonnull align 64 dereferenceable(320) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; MESA-NEXT:    [[ARG_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_V8I64_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[ARG_LOAD:%.*]] = load <8 x i64>, ptr addrspace(4) [[ARG_KERNARG_OFFSET]], align 4, !invariant.load [[META1]]
-; MESA-NEXT:    store <8 x i64> [[ARG_LOAD]], ptr addrspace(1) undef, align 64
+; MESA-NEXT:    store <8 x i64> [[ARG_LOAD]], ptr addrspace(1) poison, align 64
 ; MESA-NEXT:    ret void
 ;
-  store <8 x i64> %arg, ptr addrspace(1) undef
+  store <8 x i64> %arg, ptr addrspace(1) poison
   ret void
 }
 
@@ -359,17 +359,17 @@ define amdgpu_kernel void @kern_v16i64(<16 x i64> %arg) #0 {
 ; HSA-NEXT:    [[KERN_V16I64_KERNARG_SEGMENT:%.*]] = call nonnull align 128 dereferenceable(384) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; HSA-NEXT:    [[ARG_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_V16I64_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[ARG_LOAD:%.*]] = load <16 x i64>, ptr addrspace(4) [[ARG_KERNARG_OFFSET]], align 16, !invariant.load [[META1]]
-; HSA-NEXT:    store <16 x i64> [[ARG_LOAD]], ptr addrspace(1) undef, align 128
+; HSA-NEXT:    store <16 x i64> [[ARG_LOAD]], ptr addrspace(1) poison, align 128
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_v16i64(
 ; MESA-NEXT:    [[KERN_V16I64_KERNARG_SEGMENT:%.*]] = call nonnull align 128 dereferenceable(384) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; MESA-NEXT:    [[ARG_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_V16I64_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[ARG_LOAD:%.*]] = load <16 x i64>, ptr addrspace(4) [[ARG_KERNARG_OFFSET]], align 4, !invariant.load [[META1]]
-; MESA-NEXT:    store <16 x i64> [[ARG_LOAD]], ptr addrspace(1) undef, align 128
+; MESA-NEXT:    store <16 x i64> [[ARG_LOAD]], ptr addrspace(1) poison, align 128
 ; MESA-NEXT:    ret void
 ;
-  store <16 x i64> %arg, ptr addrspace(1) undef
+  store <16 x i64> %arg, ptr addrspace(1) poison
   ret void
 }
 
@@ -381,8 +381,8 @@ define amdgpu_kernel void @kern_i32_v3i32(i32 %arg0, <3 x i32> %arg1) {
 ; HSA-NEXT:    [[ARG1_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_I32_V3I32_KERNARG_SEGMENT]], i64 16
 ; HSA-NEXT:    [[TMP1:%.*]] = load <4 x i32>, ptr addrspace(4) [[ARG1_KERNARG_OFFSET]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[ARG1_LOAD:%.*]] = shufflevector <4 x i32> [[TMP1]], <4 x i32> poison, <3 x i32> <i32 0, i32 1, i32 2>
-; HSA-NEXT:    store i32 [[ARG0_LOAD]], ptr addrspace(1) undef, align 4
-; HSA-NEXT:    store <3 x i32> [[ARG1_LOAD]], ptr addrspace(1) undef, align 4
+; HSA-NEXT:    store i32 [[ARG0_LOAD]], ptr addrspace(1) poison, align 4
+; HSA-NEXT:    store <3 x i32> [[ARG1_LOAD]], ptr addrspace(1) poison, align 4
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_i32_v3i32(
@@ -392,12 +392,12 @@ define amdgpu_kernel void @kern_i32_v3i32(i32 %arg0, <3 x i32> %arg1) {
 ; MESA-NEXT:    [[ARG1_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_I32_V3I32_KERNARG_SEGMENT]], i64 52
 ; MESA-NEXT:    [[TMP1:%.*]] = load <4 x i32>, ptr addrspace(4) [[ARG1_KERNARG_OFFSET]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[ARG1_LOAD:%.*]] = shufflevector <4 x i32> [[TMP1]], <4 x i32> poison, <3 x i32> <i32 0, i32 1, i32 2>
-; MESA-NEXT:    store i32 [[ARG0_LOAD]], ptr addrspace(1) undef, align 4
-; MESA-NEXT:    store <3 x i32> [[ARG1_LOAD]], ptr addrspace(1) undef, align 4
+; MESA-NEXT:    store i32 [[ARG0_LOAD]], ptr addrspace(1) poison, align 4
+; MESA-NEXT:    store <3 x i32> [[ARG1_LOAD]], ptr addrspace(1) poison, align 4
 ; MESA-NEXT:    ret void
 ;
-  store i32 %arg0, ptr addrspace(1) undef
-  store <3 x i32> %arg1, ptr addrspace(1) undef, align 4
+  store i32 %arg0, ptr addrspace(1) poison
+  store <3 x i32> %arg1, ptr addrspace(1) poison, align 4
   ret void
 }
 
@@ -409,17 +409,17 @@ define amdgpu_kernel void @kern_struct_a(%struct.a %arg0) {
 ; HSA-NEXT:    [[KERN_STRUCT_A_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(272) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; HSA-NEXT:    [[ARG0_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_STRUCT_A_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[ARG0_LOAD:%.*]] = load [[STRUCT_A:%.*]], ptr addrspace(4) [[ARG0_KERNARG_OFFSET]], align 16, !invariant.load [[META1]]
-; HSA-NEXT:    store [[STRUCT_A]] [[ARG0_LOAD]], ptr addrspace(1) undef, align 4
+; HSA-NEXT:    store [[STRUCT_A]] [[ARG0_LOAD]], ptr addrspace(1) poison, align 4
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_struct_a(
 ; MESA-NEXT:    [[KERN_STRUCT_A_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(268) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; MESA-NEXT:    [[ARG0_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_STRUCT_A_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[ARG0_LOAD:%.*]] = load [[STRUCT_A:%.*]], ptr addrspace(4) [[ARG0_KERNARG_OFFSET]], align 4, !invariant.load [[META1]]
-; MESA-NEXT:    store [[STRUCT_A]] [[ARG0_LOAD]], ptr addrspace(1) undef, align 4
+; MESA-NEXT:    store [[STRUCT_A]] [[ARG0_LOAD]], ptr addrspace(1) poison, align 4
 ; MESA-NEXT:    ret void
 ;
-  store %struct.a %arg0, ptr addrspace(1) undef
+  store %struct.a %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -428,17 +428,17 @@ define amdgpu_kernel void @kern_struct_b_packed(%struct.b.packed %arg0) #0 {
 ; HSA-NEXT:    [[KERN_STRUCT_B_PACKED_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(288) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; HSA-NEXT:    [[ARG0_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_STRUCT_B_PACKED_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[ARG0_LOAD:%.*]] = load [[STRUCT_B_PACKED:%.*]], ptr addrspace(4) [[ARG0_KERNARG_OFFSET]], align 16, !invariant.load [[META1]]
-; HSA-NEXT:    store [[STRUCT_B_PACKED]] [[ARG0_LOAD]], ptr addrspace(1) undef, align 16
+; HSA-NEXT:    store [[STRUCT_B_PACKED]] [[ARG0_LOAD]], ptr addrspace(1) poison, align 16
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_struct_b_packed(
 ; MESA-NEXT:    [[KERN_STRUCT_B_PACKED_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(288) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; MESA-NEXT:    [[ARG0_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_STRUCT_B_PACKED_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[ARG0_LOAD:%.*]] = load [[STRUCT_B_PACKED:%.*]], ptr addrspace(4) [[ARG0_KERNARG_OFFSET]], align 4, !invariant.load [[META1]]
-; MESA-NEXT:    store [[STRUCT_B_PACKED]] [[ARG0_LOAD]], ptr addrspace(1) undef, align 16
+; MESA-NEXT:    store [[STRUCT_B_PACKED]] [[ARG0_LOAD]], ptr addrspace(1) poison, align 16
 ; MESA-NEXT:    ret void
 ;
-  store %struct.b.packed %arg0, ptr addrspace(1) undef
+  store %struct.b.packed %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -447,17 +447,17 @@ define amdgpu_kernel void @kern_implicit_arg_num_bytes(i32 %arg0) #1 {
 ; HSA-NEXT:    [[KERN_IMPLICIT_ARG_NUM_BYTES_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(48) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; HSA-NEXT:    [[ARG0_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_IMPLICIT_ARG_NUM_BYTES_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[ARG0_LOAD:%.*]] = load i32, ptr addrspace(4) [[ARG0_KERNARG_OFFSET]], align 16, !invariant.load [[META1]]
-; HSA-NEXT:    store i32 [[ARG0_LOAD]], ptr addrspace(1) undef, align 4
+; HSA-NEXT:    store i32 [[ARG0_LOAD]], ptr addrspace(1) poison, align 4
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_implicit_arg_num_bytes(
 ; MESA-NEXT:    [[KERN_IMPLICIT_ARG_NUM_BYTES_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(44) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; MESA-NEXT:    [[ARG0_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_IMPLICIT_ARG_NUM_BYTES_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[ARG0_LOAD:%.*]] = load i32, ptr addrspace(4) [[ARG0_KERNARG_OFFSET]], align 4, !invariant.load [[META1]]
-; MESA-NEXT:    store i32 [[ARG0_LOAD]], ptr addrspace(1) undef, align 4
+; MESA-NEXT:    store i32 [[ARG0_LOAD]], ptr addrspace(1) poison, align 4
 ; MESA-NEXT:    ret void
 ;
-  store i32 %arg0, ptr addrspace(1) undef
+  store i32 %arg0, ptr addrspace(1) poison
   ret void
 }
 
@@ -466,17 +466,17 @@ define amdgpu_kernel void @kernel_implicitarg_no_struct_align(<16 x i32>, i32 %a
 ; HSA-NEXT:    [[KERNEL_IMPLICITARG_NO_STRUCT_ALIGN_KERNARG_SEGMENT:%.*]] = call nonnull align 64 dereferenceable(112) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; HSA-NEXT:    [[ARG1_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERNEL_IMPLICITARG_NO_STRUCT_ALIGN_KERNARG_SEGMENT]], i64 64
 ; HSA-NEXT:    [[ARG1_LOAD:%.*]] = load i32, ptr addrspace(4) [[ARG1_KERNARG_OFFSET]], align 16, !invariant.load [[META1]]
-; HSA-NEXT:    store i32 [[ARG1_LOAD]], ptr addrspace(1) undef, align 4
+; HSA-NEXT:    store i32 [[ARG1_LOAD]], ptr addrspace(1) poison, align 4
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kernel_implicitarg_no_struct_align(
 ; MESA-NEXT:    [[KERNEL_IMPLICITARG_NO_STRUCT_ALIGN_KERNARG_SEGMENT:%.*]] = call nonnull align 64 dereferenceable(108) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; MESA-NEXT:    [[ARG1_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERNEL_IMPLICITARG_NO_STRUCT_ALIGN_KERNARG_SEGMENT]], i64 100
 ; MESA-NEXT:    [[ARG1_LOAD:%.*]] = load i32, ptr addrspace(4) [[ARG1_KERNARG_OFFSET]], align 4, !invariant.load [[META1]]
-; MESA-NEXT:    store i32 [[ARG1_LOAD]], ptr addrspace(1) undef, align 4
+; MESA-NEXT:    store i32 [[ARG1_LOAD]], ptr addrspace(1) poison, align 4
 ; MESA-NEXT:    ret void
 ;
-  store i32 %arg1, ptr addrspace(1) undef
+  store i32 %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -519,8 +519,8 @@ define amdgpu_kernel void @kern_realign_i8_i8(i8 %arg0, i8 %arg1) #0 {
 ; HSA-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(4) [[ARG1_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP4:%.*]] = lshr i32 [[TMP3]], 8
 ; HSA-NEXT:    [[TMP5:%.*]] = trunc i32 [[TMP4]] to i8
-; HSA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) undef, align 1
+; HSA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) poison, align 1
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_realign_i8_i8(
@@ -532,12 +532,12 @@ define amdgpu_kernel void @kern_realign_i8_i8(i8 %arg0, i8 %arg1) #0 {
 ; MESA-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(4) [[ARG1_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP4:%.*]] = lshr i32 [[TMP3]], 8
 ; MESA-NEXT:    [[TMP5:%.*]] = trunc i32 [[TMP4]] to i8
-; MESA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) undef, align 1
+; MESA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) poison, align 1
 ; MESA-NEXT:    ret void
 ;
-  store volatile i8 %arg0, ptr addrspace(1) undef
-  store volatile i8 %arg1, ptr addrspace(1) undef
+  store volatile i8 %arg0, ptr addrspace(1) poison
+  store volatile i8 %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -555,9 +555,9 @@ define amdgpu_kernel void @kern_realign_i8_i8_i8(i8 %arg0, i8 %arg1, i8 %arg2) #
 ; HSA-NEXT:    [[TMP6:%.*]] = load i32, ptr addrspace(4) [[ARG2_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP6]], 16
 ; HSA-NEXT:    [[TMP8:%.*]] = trunc i32 [[TMP7]] to i8
-; HSA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i8 [[TMP8]], ptr addrspace(1) undef, align 1
+; HSA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i8 [[TMP8]], ptr addrspace(1) poison, align 1
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_realign_i8_i8_i8(
@@ -573,14 +573,14 @@ define amdgpu_kernel void @kern_realign_i8_i8_i8(i8 %arg0, i8 %arg1, i8 %arg2) #
 ; MESA-NEXT:    [[TMP6:%.*]] = load i32, ptr addrspace(4) [[ARG2_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP6]], 16
 ; MESA-NEXT:    [[TMP8:%.*]] = trunc i32 [[TMP7]] to i8
-; MESA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i8 [[TMP8]], ptr addrspace(1) undef, align 1
+; MESA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i8 [[TMP8]], ptr addrspace(1) poison, align 1
 ; MESA-NEXT:    ret void
 ;
-  store volatile i8 %arg0, ptr addrspace(1) undef
-  store volatile i8 %arg1, ptr addrspace(1) undef
-  store volatile i8 %arg2, ptr addrspace(1) undef
+  store volatile i8 %arg0, ptr addrspace(1) poison
+  store volatile i8 %arg1, ptr addrspace(1) poison
+  store volatile i8 %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -602,10 +602,10 @@ define amdgpu_kernel void @kern_realign_i8_i8_i8_i8(i8 %arg0, i8 %arg1, i8 %arg2
 ; HSA-NEXT:    [[TMP9:%.*]] = load i32, ptr addrspace(4) [[ARG3_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP10:%.*]] = lshr i32 [[TMP9]], 24
 ; HSA-NEXT:    [[TMP11:%.*]] = trunc i32 [[TMP10]] to i8
-; HSA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i8 [[TMP8]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i8 [[TMP11]], ptr addrspace(1) undef, align 1
+; HSA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i8 [[TMP8]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i8 [[TMP11]], ptr addrspace(1) poison, align 1
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_realign_i8_i8_i8_i8(
@@ -625,16 +625,16 @@ define amdgpu_kernel void @kern_realign_i8_i8_i8_i8(i8 %arg0, i8 %arg1, i8 %arg2
 ; MESA-NEXT:    [[TMP9:%.*]] = load i32, ptr addrspace(4) [[ARG3_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP10:%.*]] = lshr i32 [[TMP9]], 24
 ; MESA-NEXT:    [[TMP11:%.*]] = trunc i32 [[TMP10]] to i8
-; MESA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i8 [[TMP8]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i8 [[TMP11]], ptr addrspace(1) undef, align 1
+; MESA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i8 [[TMP8]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i8 [[TMP11]], ptr addrspace(1) poison, align 1
 ; MESA-NEXT:    ret void
 ;
-  store volatile i8 %arg0, ptr addrspace(1) undef
-  store volatile i8 %arg1, ptr addrspace(1) undef
-  store volatile i8 %arg2, ptr addrspace(1) undef
-  store volatile i8 %arg3, ptr addrspace(1) undef
+  store volatile i8 %arg0, ptr addrspace(1) poison
+  store volatile i8 %arg1, ptr addrspace(1) poison
+  store volatile i8 %arg2, ptr addrspace(1) poison
+  store volatile i8 %arg3, ptr addrspace(1) poison
   ret void
 }
 
@@ -648,8 +648,8 @@ define amdgpu_kernel void @kern_realign_i8_v3i8(i8 %arg0, <3 x i8> %arg1) #0 {
 ; HSA-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(4) [[ARG1_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i24
 ; HSA-NEXT:    [[ARG1_LOAD:%.*]] = bitcast i24 [[TMP4]] to <3 x i8>
-; HSA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile <3 x i8> [[ARG1_LOAD]], ptr addrspace(1) undef, align 4
+; HSA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile <3 x i8> [[ARG1_LOAD]], ptr addrspace(1) poison, align 4
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_realign_i8_v3i8(
@@ -661,12 +661,12 @@ define amdgpu_kernel void @kern_realign_i8_v3i8(i8 %arg0, <3 x i8> %arg1) #0 {
 ; MESA-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(4) [[ARG1_KERNARG_OFFSET_ALIGN_DOWN]], align 8, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP4:%.*]] = trunc i32 [[TMP3]] to i24
 ; MESA-NEXT:    [[ARG1_LOAD:%.*]] = bitcast i24 [[TMP4]] to <3 x i8>
-; MESA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile <3 x i8> [[ARG1_LOAD]], ptr addrspace(1) undef, align 4
+; MESA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile <3 x i8> [[ARG1_LOAD]], ptr addrspace(1) poison, align 4
 ; MESA-NEXT:    ret void
 ;
-  store volatile i8 %arg0, ptr addrspace(1) undef
-  store volatile <3 x i8> %arg1, ptr addrspace(1) undef
+  store volatile i8 %arg0, ptr addrspace(1) poison
+  store volatile <3 x i8> %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -680,8 +680,8 @@ define amdgpu_kernel void @kern_realign_i8_i16(i8 %arg0, i16 %arg1) #0 {
 ; HSA-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(4) [[ARG1_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP4:%.*]] = lshr i32 [[TMP3]], 16
 ; HSA-NEXT:    [[TMP5:%.*]] = trunc i32 [[TMP4]] to i16
-; HSA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i16 [[TMP5]], ptr addrspace(1) undef, align 2
+; HSA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i16 [[TMP5]], ptr addrspace(1) poison, align 2
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_realign_i8_i16(
@@ -693,12 +693,12 @@ define amdgpu_kernel void @kern_realign_i8_i16(i8 %arg0, i16 %arg1) #0 {
 ; MESA-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(4) [[ARG1_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP4:%.*]] = lshr i32 [[TMP3]], 16
 ; MESA-NEXT:    [[TMP5:%.*]] = trunc i32 [[TMP4]] to i16
-; MESA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i16 [[TMP5]], ptr addrspace(1) undef, align 2
+; MESA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i16 [[TMP5]], ptr addrspace(1) poison, align 2
 ; MESA-NEXT:    ret void
 ;
-  store volatile i8 %arg0, ptr addrspace(1) undef
-  store volatile i16 %arg1, ptr addrspace(1) undef
+  store volatile i8 %arg0, ptr addrspace(1) poison
+  store volatile i16 %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -712,8 +712,8 @@ define amdgpu_kernel void @kern_realign_i1_i1(i1 %arg0, i1 %arg1) #0 {
 ; HSA-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(4) [[ARG1_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP4:%.*]] = lshr i32 [[TMP3]], 8
 ; HSA-NEXT:    [[TMP5:%.*]] = trunc i32 [[TMP4]] to i1
-; HSA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i1 [[TMP5]], ptr addrspace(1) undef, align 1
+; HSA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i1 [[TMP5]], ptr addrspace(1) poison, align 1
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_realign_i1_i1(
@@ -725,12 +725,12 @@ define amdgpu_kernel void @kern_realign_i1_i1(i1 %arg0, i1 %arg1) #0 {
 ; MESA-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(4) [[ARG1_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP4:%.*]] = lshr i32 [[TMP3]], 8
 ; MESA-NEXT:    [[TMP5:%.*]] = trunc i32 [[TMP4]] to i1
-; MESA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i1 [[TMP5]], ptr addrspace(1) undef, align 1
+; MESA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i1 [[TMP5]], ptr addrspace(1) poison, align 1
 ; MESA-NEXT:    ret void
 ;
-  store volatile i1 %arg0, ptr addrspace(1) undef
-  store volatile i1 %arg1, ptr addrspace(1) undef
+  store volatile i1 %arg0, ptr addrspace(1) poison
+  store volatile i1 %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -748,9 +748,9 @@ define amdgpu_kernel void @kern_realign_i1_i1_i1(i1 %arg0, i1 %arg1, i1 %arg2) #
 ; HSA-NEXT:    [[TMP6:%.*]] = load i32, ptr addrspace(4) [[ARG2_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP6]], 16
 ; HSA-NEXT:    [[TMP8:%.*]] = trunc i32 [[TMP7]] to i1
-; HSA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i1 [[TMP5]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i1 [[TMP8]], ptr addrspace(1) undef, align 1
+; HSA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i1 [[TMP5]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i1 [[TMP8]], ptr addrspace(1) poison, align 1
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_realign_i1_i1_i1(
@@ -766,14 +766,14 @@ define amdgpu_kernel void @kern_realign_i1_i1_i1(i1 %arg0, i1 %arg1, i1 %arg2) #
 ; MESA-NEXT:    [[TMP6:%.*]] = load i32, ptr addrspace(4) [[ARG2_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP7:%.*]] = lshr i32 [[TMP6]], 16
 ; MESA-NEXT:    [[TMP8:%.*]] = trunc i32 [[TMP7]] to i1
-; MESA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i1 [[TMP5]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i1 [[TMP8]], ptr addrspace(1) undef, align 1
+; MESA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i1 [[TMP5]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i1 [[TMP8]], ptr addrspace(1) poison, align 1
 ; MESA-NEXT:    ret void
 ;
-  store volatile i1 %arg0, ptr addrspace(1) undef
-  store volatile i1 %arg1, ptr addrspace(1) undef
-  store volatile i1 %arg2, ptr addrspace(1) undef
+  store volatile i1 %arg0, ptr addrspace(1) poison
+  store volatile i1 %arg1, ptr addrspace(1) poison
+  store volatile i1 %arg2, ptr addrspace(1) poison
   ret void
 }
 
@@ -795,10 +795,10 @@ define amdgpu_kernel void @kern_realign_i1_i1_i1_i1(i1 %arg0, i1 %arg1, i1 %arg2
 ; HSA-NEXT:    [[TMP9:%.*]] = load i32, ptr addrspace(4) [[ARG3_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP10:%.*]] = lshr i32 [[TMP9]], 24
 ; HSA-NEXT:    [[TMP11:%.*]] = trunc i32 [[TMP10]] to i1
-; HSA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i1 [[TMP5]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i1 [[TMP8]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i1 [[TMP11]], ptr addrspace(1) undef, align 1
+; HSA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i1 [[TMP5]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i1 [[TMP8]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i1 [[TMP11]], ptr addrspace(1) poison, align 1
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_realign_i1_i1_i1_i1(
@@ -818,16 +818,16 @@ define amdgpu_kernel void @kern_realign_i1_i1_i1_i1(i1 %arg0, i1 %arg1, i1 %arg2
 ; MESA-NEXT:    [[TMP9:%.*]] = load i32, ptr addrspace(4) [[ARG3_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP10:%.*]] = lshr i32 [[TMP9]], 24
 ; MESA-NEXT:    [[TMP11:%.*]] = trunc i32 [[TMP10]] to i1
-; MESA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i1 [[TMP5]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i1 [[TMP8]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i1 [[TMP11]], ptr addrspace(1) undef, align 1
+; MESA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i1 [[TMP5]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i1 [[TMP8]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i1 [[TMP11]], ptr addrspace(1) poison, align 1
 ; MESA-NEXT:    ret void
 ;
-  store volatile i1 %arg0, ptr addrspace(1) undef
-  store volatile i1 %arg1, ptr addrspace(1) undef
-  store volatile i1 %arg2, ptr addrspace(1) undef
-  store volatile i1 %arg3, ptr addrspace(1) undef
+  store volatile i1 %arg0, ptr addrspace(1) poison
+  store volatile i1 %arg1, ptr addrspace(1) poison
+  store volatile i1 %arg2, ptr addrspace(1) poison
+  store volatile i1 %arg3, ptr addrspace(1) poison
   ret void
 }
 
@@ -842,8 +842,8 @@ define amdgpu_kernel void @kern_realign_i1_v3i1(i1 %arg0, <3 x i1> %arg1) #0 {
 ; HSA-NEXT:    [[TMP4:%.*]] = lshr i32 [[TMP3]], 8
 ; HSA-NEXT:    [[TMP5:%.*]] = trunc i32 [[TMP4]] to i3
 ; HSA-NEXT:    [[ARG1_LOAD:%.*]] = bitcast i3 [[TMP5]] to <3 x i1>
-; HSA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile <3 x i1> [[ARG1_LOAD]], ptr addrspace(1) undef, align 1
+; HSA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile <3 x i1> [[ARG1_LOAD]], ptr addrspace(1) poison, align 1
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_realign_i1_v3i1(
@@ -856,12 +856,12 @@ define amdgpu_kernel void @kern_realign_i1_v3i1(i1 %arg0, <3 x i1> %arg1) #0 {
 ; MESA-NEXT:    [[TMP4:%.*]] = lshr i32 [[TMP3]], 8
 ; MESA-NEXT:    [[TMP5:%.*]] = trunc i32 [[TMP4]] to i3
 ; MESA-NEXT:    [[ARG1_LOAD:%.*]] = bitcast i3 [[TMP5]] to <3 x i1>
-; MESA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile <3 x i1> [[ARG1_LOAD]], ptr addrspace(1) undef, align 1
+; MESA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile <3 x i1> [[ARG1_LOAD]], ptr addrspace(1) poison, align 1
 ; MESA-NEXT:    ret void
 ;
-  store volatile i1 %arg0, ptr addrspace(1) undef
-  store volatile <3 x i1> %arg1, ptr addrspace(1) undef
+  store volatile i1 %arg0, ptr addrspace(1) poison
+  store volatile <3 x i1> %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -875,8 +875,8 @@ define amdgpu_kernel void @kern_realign_i1_i16(i1 %arg0, i16 %arg1) #0 {
 ; HSA-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(4) [[ARG1_KERNARG_OFFSET_ALIGN_DOWN]], align 16, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP4:%.*]] = lshr i32 [[TMP3]], 16
 ; HSA-NEXT:    [[TMP5:%.*]] = trunc i32 [[TMP4]] to i16
-; HSA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i16 [[TMP5]], ptr addrspace(1) undef, align 2
+; HSA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i16 [[TMP5]], ptr addrspace(1) poison, align 2
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_realign_i1_i16(
@@ -888,12 +888,12 @@ define amdgpu_kernel void @kern_realign_i1_i16(i1 %arg0, i16 %arg1) #0 {
 ; MESA-NEXT:    [[TMP3:%.*]] = load i32, ptr addrspace(4) [[ARG1_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP4:%.*]] = lshr i32 [[TMP3]], 16
 ; MESA-NEXT:    [[TMP5:%.*]] = trunc i32 [[TMP4]] to i16
-; MESA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i16 [[TMP5]], ptr addrspace(1) undef, align 2
+; MESA-NEXT:    store volatile i1 [[TMP2]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i16 [[TMP5]], ptr addrspace(1) poison, align 2
 ; MESA-NEXT:    ret void
 ;
-  store volatile i1 %arg0, ptr addrspace(1) undef
-  store volatile i16 %arg1, ptr addrspace(1) undef
+  store volatile i1 %arg0, ptr addrspace(1) poison
+  store volatile i16 %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -927,13 +927,13 @@ define amdgpu_kernel void @kern_realign_i8_i8_i8_i8_i8_i8_i8_i8(i8 %arg0, i8 %ar
 ; HSA-NEXT:    [[TMP18:%.*]] = load i32, ptr addrspace(4) [[ARG7_KERNARG_OFFSET_ALIGN_DOWN]], align 4, !invariant.load [[META1]]
 ; HSA-NEXT:    [[TMP19:%.*]] = lshr i32 [[TMP18]], 24
 ; HSA-NEXT:    [[TMP20:%.*]] = trunc i32 [[TMP19]] to i8
-; HSA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i8 [[TMP8]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i8 [[TMP11]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i8 [[TMP14]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i8 [[TMP17]], ptr addrspace(1) undef, align 1
-; HSA-NEXT:    store volatile i8 [[TMP20]], ptr addrspace(1) undef, align 1
+; HSA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i8 [[TMP8]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i8 [[TMP11]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i8 [[TMP14]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i8 [[TMP17]], ptr addrspace(1) poison, align 1
+; HSA-NEXT:    store volatile i8 [[TMP20]], ptr addrspace(1) poison, align 1
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_realign_i8_i8_i8_i8_i8_i8_i8_i8(
@@ -965,22 +965,22 @@ define amdgpu_kernel void @kern_realign_i8_i8_i8_i8_i8_i8_i8_i8(i8 %arg0, i8 %ar
 ; MESA-NEXT:    [[TMP18:%.*]] = load i32, ptr addrspace(4) [[ARG7_KERNARG_OFFSET_ALIGN_DOWN]], align 8, !invariant.load [[META1]]
 ; MESA-NEXT:    [[TMP19:%.*]] = lshr i32 [[TMP18]], 24
 ; MESA-NEXT:    [[TMP20:%.*]] = trunc i32 [[TMP19]] to i8
-; MESA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i8 [[TMP8]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i8 [[TMP11]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i8 [[TMP14]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i8 [[TMP17]], ptr addrspace(1) undef, align 1
-; MESA-NEXT:    store volatile i8 [[TMP20]], ptr addrspace(1) undef, align 1
+; MESA-NEXT:    store volatile i8 [[TMP2]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i8 [[TMP5]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i8 [[TMP8]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i8 [[TMP11]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i8 [[TMP14]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i8 [[TMP17]], ptr addrspace(1) poison, align 1
+; MESA-NEXT:    store volatile i8 [[TMP20]], ptr addrspace(1) poison, align 1
 ; MESA-NEXT:    ret void
 ;
-  store volatile i8 %arg0, ptr addrspace(1) undef
-  store volatile i8 %arg1, ptr addrspace(1) undef
-  store volatile i8 %arg2, ptr addrspace(1) undef
-  store volatile i8 %arg3, ptr addrspace(1) undef
-  store volatile i8 %arg5, ptr addrspace(1) undef
-  store volatile i8 %arg6, ptr addrspace(1) undef
-  store volatile i8 %arg7, ptr addrspace(1) undef
+  store volatile i8 %arg0, ptr addrspace(1) poison
+  store volatile i8 %arg1, ptr addrspace(1) poison
+  store volatile i8 %arg2, ptr addrspace(1) poison
+  store volatile i8 %arg3, ptr addrspace(1) poison
+  store volatile i8 %arg5, ptr addrspace(1) poison
+  store volatile i8 %arg6, ptr addrspace(1) poison
+  store volatile i8 %arg7, ptr addrspace(1) poison
   ret void
 }
 
@@ -996,8 +996,8 @@ define amdgpu_kernel void @kern_realign_f16_f16(half %arg0, half %arg1) #0 {
 ; HSA-NEXT:    [[TMP4:%.*]] = lshr i32 [[TMP3]], 16
 ; HSA-NEXT:    [[TMP5:%.*]] = trunc i32 [[TMP4]] to i16
 ; HSA-NEXT:    [[ARG1_LOAD:%.*]] = bitcast i16 [[TMP5]] to half
-; HSA-NEXT:    store volatile half [[ARG0_LOAD]], ptr addrspace(1) undef, align 2
-; HSA-NEXT:    store volatile half [[ARG1_LOAD]], ptr addrspace(1) undef, align 2
+; HSA-NEXT:    store volatile half [[ARG0_LOAD]], ptr addrspace(1) poison, align 2
+; HSA-NEXT:    store volatile half [[ARG1_LOAD]], ptr addrspace(1) poison, align 2
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_realign_f16_f16(
@@ -1011,12 +1011,12 @@ define amdgpu_kernel void @kern_realign_f16_f16(half %arg0, half %arg1) #0 {
 ; MESA-NEXT:    [[TMP4:%.*]] = lshr i32 [[TMP3]], 16
 ; MESA-NEXT:    [[TMP5:%.*]] = trunc i32 [[TMP4]] to i16
 ; MESA-NEXT:    [[ARG1_LOAD:%.*]] = bitcast i16 [[TMP5]] to half
-; MESA-NEXT:    store volatile half [[ARG0_LOAD]], ptr addrspace(1) undef, align 2
-; MESA-NEXT:    store volatile half [[ARG1_LOAD]], ptr addrspace(1) undef, align 2
+; MESA-NEXT:    store volatile half [[ARG0_LOAD]], ptr addrspace(1) poison, align 2
+; MESA-NEXT:    store volatile half [[ARG1_LOAD]], ptr addrspace(1) poison, align 2
 ; MESA-NEXT:    ret void
 ;
-  store volatile half %arg0, ptr addrspace(1) undef
-  store volatile half %arg1, ptr addrspace(1) undef
+  store volatile half %arg0, ptr addrspace(1) poison
+  store volatile half %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1025,17 +1025,17 @@ define amdgpu_kernel void @kern_global_ptr(ptr addrspace(1) %ptr) #0 {
 ; HSA-NEXT:    [[KERN_GLOBAL_PTR_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(264) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; HSA-NEXT:    [[PTR_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_GLOBAL_PTR_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[PTR_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[PTR_KERNARG_OFFSET]], align 16, !invariant.load [[META1]]
-; HSA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) undef, align 8
+; HSA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) poison, align 8
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_global_ptr(
 ; MESA-NEXT:    [[KERN_GLOBAL_PTR_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(264) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; MESA-NEXT:    [[PTR_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_GLOBAL_PTR_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[PTR_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[PTR_KERNARG_OFFSET]], align 4, !invariant.load [[META1]]
-; MESA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) undef, align 8
+; MESA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) poison, align 8
 ; MESA-NEXT:    ret void
 ;
-  store volatile ptr addrspace(1) %ptr, ptr addrspace(1) undef
+  store volatile ptr addrspace(1) %ptr, ptr addrspace(1) poison
   ret void
 }
 
@@ -1044,17 +1044,17 @@ define amdgpu_kernel void @kern_global_ptr_dereferencable(ptr addrspace(1) deref
 ; HSA-NEXT:    [[KERN_GLOBAL_PTR_DEREFERENCABLE_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(264) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; HSA-NEXT:    [[PTR_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_GLOBAL_PTR_DEREFERENCABLE_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[PTR_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[PTR_KERNARG_OFFSET]], align 16, !invariant.load [[META1]], !dereferenceable [[META3:![0-9]+]]
-; HSA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) undef, align 8
+; HSA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) poison, align 8
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_global_ptr_dereferencable(
 ; MESA-NEXT:    [[KERN_GLOBAL_PTR_DEREFERENCABLE_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(264) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; MESA-NEXT:    [[PTR_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_GLOBAL_PTR_DEREFERENCABLE_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[PTR_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[PTR_KERNARG_OFFSET]], align 4, !invariant.load [[META1]], !dereferenceable [[META3:![0-9]+]]
-; MESA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) undef, align 8
+; MESA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) poison, align 8
 ; MESA-NEXT:    ret void
 ;
-  store volatile ptr addrspace(1) %ptr, ptr addrspace(1) undef
+  store volatile ptr addrspace(1) %ptr, ptr addrspace(1) poison
   ret void
 }
 
@@ -1063,17 +1063,17 @@ define amdgpu_kernel void @kern_global_ptr_dereferencable_or_null(ptr addrspace(
 ; HSA-NEXT:    [[KERN_GLOBAL_PTR_DEREFERENCABLE_OR_NULL_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(264) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; HSA-NEXT:    [[PTR_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_GLOBAL_PTR_DEREFERENCABLE_OR_NULL_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[PTR_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[PTR_KERNARG_OFFSET]], align 16, !invariant.load [[META1]], !dereferenceable_or_null [[META4:![0-9]+]]
-; HSA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) undef, align 8
+; HSA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) poison, align 8
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_global_ptr_dereferencable_or_null(
 ; MESA-NEXT:    [[KERN_GLOBAL_PTR_DEREFERENCABLE_OR_NULL_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(264) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; MESA-NEXT:    [[PTR_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_GLOBAL_PTR_DEREFERENCABLE_OR_NULL_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[PTR_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[PTR_KERNARG_OFFSET]], align 4, !invariant.load [[META1]], !dereferenceable_or_null [[META4:![0-9]+]]
-; MESA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) undef, align 8
+; MESA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) poison, align 8
 ; MESA-NEXT:    ret void
 ;
-  store volatile ptr addrspace(1) %ptr, ptr addrspace(1) undef
+  store volatile ptr addrspace(1) %ptr, ptr addrspace(1) poison
   ret void
 }
 
@@ -1082,17 +1082,17 @@ define amdgpu_kernel void @kern_nonnull_global_ptr(ptr addrspace(1) nonnull %ptr
 ; HSA-NEXT:    [[KERN_NONNULL_GLOBAL_PTR_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(264) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; HSA-NEXT:    [[PTR_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_NONNULL_GLOBAL_PTR_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[PTR_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[PTR_KERNARG_OFFSET]], align 16, !invariant.load [[META1]], !nonnull [[META1]]
-; HSA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) undef, align 8
+; HSA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) poison, align 8
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_nonnull_global_ptr(
 ; MESA-NEXT:    [[KERN_NONNULL_GLOBAL_PTR_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(264) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; MESA-NEXT:    [[PTR_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_NONNULL_GLOBAL_PTR_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[PTR_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[PTR_KERNARG_OFFSET]], align 4, !invariant.load [[META1]], !nonnull [[META1]]
-; MESA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) undef, align 8
+; MESA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) poison, align 8
 ; MESA-NEXT:    ret void
 ;
-  store volatile ptr addrspace(1) %ptr, ptr addrspace(1) undef
+  store volatile ptr addrspace(1) %ptr, ptr addrspace(1) poison
   ret void
 }
 
@@ -1101,39 +1101,39 @@ define amdgpu_kernel void @kern_align32_global_ptr(ptr addrspace(1) align 1024 %
 ; HSA-NEXT:    [[KERN_ALIGN32_GLOBAL_PTR_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(264) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; HSA-NEXT:    [[PTR_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_ALIGN32_GLOBAL_PTR_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[PTR_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[PTR_KERNARG_OFFSET]], align 16, !invariant.load [[META1]], !align [[META5:![0-9]+]]
-; HSA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) undef, align 8
+; HSA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) poison, align 8
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @kern_align32_global_ptr(
 ; MESA-NEXT:    [[KERN_ALIGN32_GLOBAL_PTR_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(264) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; MESA-NEXT:    [[PTR_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[KERN_ALIGN32_GLOBAL_PTR_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[PTR_LOAD:%.*]] = load ptr addrspace(1), ptr addrspace(4) [[PTR_KERNARG_OFFSET]], align 4, !invariant.load [[META1]], !align [[META5:![0-9]+]]
-; MESA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) undef, align 8
+; MESA-NEXT:    store volatile ptr addrspace(1) [[PTR_LOAD]], ptr addrspace(1) poison, align 8
 ; MESA-NEXT:    ret void
 ;
-  store volatile ptr addrspace(1) %ptr, ptr addrspace(1) undef
+  store volatile ptr addrspace(1) %ptr, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @kern_noalias_global_ptr(ptr addrspace(1) noalias %ptr) #0 {
 ; GCN-LABEL: @kern_noalias_global_ptr(
 ; GCN-NEXT:    [[KERN_NOALIAS_GLOBAL_PTR_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(264) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
-; GCN-NEXT:    store volatile ptr addrspace(1) [[PTR:%.*]], ptr addrspace(1) undef, align 8
+; GCN-NEXT:    store volatile ptr addrspace(1) [[PTR:%.*]], ptr addrspace(1) poison, align 8
 ; GCN-NEXT:    ret void
 ;
-  store volatile ptr addrspace(1) %ptr, ptr addrspace(1) undef
+  store volatile ptr addrspace(1) %ptr, ptr addrspace(1) poison
   ret void
 }
 
 define amdgpu_kernel void @kern_noalias_global_ptr_x2(ptr addrspace(1) noalias %ptr0, ptr addrspace(1) noalias %ptr1) #0 {
 ; GCN-LABEL: @kern_noalias_global_ptr_x2(
 ; GCN-NEXT:    [[KERN_NOALIAS_GLOBAL_PTR_X2_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(272) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
-; GCN-NEXT:    store volatile ptr addrspace(1) [[PTR0:%.*]], ptr addrspace(1) undef, align 8
-; GCN-NEXT:    store volatile ptr addrspace(1) [[PTR1:%.*]], ptr addrspace(1) undef, align 8
+; GCN-NEXT:    store volatile ptr addrspace(1) [[PTR0:%.*]], ptr addrspace(1) poison, align 8
+; GCN-NEXT:    store volatile ptr addrspace(1) [[PTR1:%.*]], ptr addrspace(1) poison, align 8
 ; GCN-NEXT:    ret void
 ;
-  store volatile ptr addrspace(1) %ptr0, ptr addrspace(1) undef
-  store volatile ptr addrspace(1) %ptr1, ptr addrspace(1) undef
+  store volatile ptr addrspace(1) %ptr0, ptr addrspace(1) poison
+  store volatile ptr addrspace(1) %ptr1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1293,17 +1293,17 @@ define amdgpu_kernel void @empty_struct_with_other({} %empty, i32 %arg1) #0 {
 ; HSA-NEXT:    [[EMPTY_STRUCT_WITH_OTHER_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(264) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; HSA-NEXT:    [[ARG1_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[EMPTY_STRUCT_WITH_OTHER_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[ARG1_LOAD:%.*]] = load i32, ptr addrspace(4) [[ARG1_KERNARG_OFFSET]], align 16, !invariant.load [[META1]]
-; HSA-NEXT:    store i32 [[ARG1_LOAD]], ptr addrspace(1) undef, align 4
+; HSA-NEXT:    store i32 [[ARG1_LOAD]], ptr addrspace(1) poison, align 4
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @empty_struct_with_other(
 ; MESA-NEXT:    [[EMPTY_STRUCT_WITH_OTHER_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(260) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; MESA-NEXT:    [[ARG1_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[EMPTY_STRUCT_WITH_OTHER_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[ARG1_LOAD:%.*]] = load i32, ptr addrspace(4) [[ARG1_KERNARG_OFFSET]], align 4, !invariant.load [[META1]]
-; MESA-NEXT:    store i32 [[ARG1_LOAD]], ptr addrspace(1) undef, align 4
+; MESA-NEXT:    store i32 [[ARG1_LOAD]], ptr addrspace(1) poison, align 4
 ; MESA-NEXT:    ret void
 ;
-  store i32 %arg1, ptr addrspace(1) undef
+  store i32 %arg1, ptr addrspace(1) poison
   ret void
 }
 
@@ -1715,18 +1715,18 @@ define amdgpu_kernel void @byref_constant_i32_arg_offset0(ptr addrspace(4) byref
 ; HSA-NEXT:    [[BYREF_CONSTANT_I32_ARG_OFFSET0_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(264) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; HSA-NEXT:    [[IN_BYREF_BYVAL_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[BYREF_CONSTANT_I32_ARG_OFFSET0_KERNARG_SEGMENT]], i64 0
 ; HSA-NEXT:    [[IN:%.*]] = load i32, ptr addrspace(4) [[IN_BYREF_BYVAL_KERNARG_OFFSET]], align 4
-; HSA-NEXT:    store i32 [[IN]], ptr addrspace(1) undef, align 4
+; HSA-NEXT:    store i32 [[IN]], ptr addrspace(1) poison, align 4
 ; HSA-NEXT:    ret void
 ;
 ; MESA-LABEL: @byref_constant_i32_arg_offset0(
 ; MESA-NEXT:    [[BYREF_CONSTANT_I32_ARG_OFFSET0_KERNARG_SEGMENT:%.*]] = call nonnull align 16 dereferenceable(260) ptr addrspace(4) @llvm.amdgcn.kernarg.segment.ptr()
 ; MESA-NEXT:    [[IN_BYREF_BYVAL_KERNARG_OFFSET:%.*]] = getelementptr inbounds i8, ptr addrspace(4) [[BYREF_CONSTANT_I32_ARG_OFFSET0_KERNARG_SEGMENT]], i64 36
 ; MESA-NEXT:    [[IN:%.*]] = load i32, ptr addrspace(4) [[IN_BYREF_BYVAL_KERNARG_OFFSET]], align 4
-; MESA-NEXT:    store i32 [[IN]], ptr addrspace(1) undef, align 4
+; MESA-NEXT:    store i32 [[IN]], ptr addrspace(1) poison, align 4
 ; MESA-NEXT:    ret void
 ;
   %in = load i32, ptr addrspace(4) %in.byref
-  store i32 %in, ptr addrspace(1) undef, align 4
+  store i32 %in, ptr addrspace(1) poison, align 4
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/mad-mix-hi.ll
+++ b/llvm/test/CodeGen/AMDGPU/mad-mix-hi.ll
@@ -531,7 +531,7 @@ define <2 x half> @v_mad_mixhi_f16_f16lo_f16lo_f16lo_undeflo_clamp_postcvt_multi
   %src2.ext = fpext half %src2 to float
   %result = tail call float @llvm.fmuladd.f32(float %src0.ext, float %src1.ext, float %src2.ext)
   %cvt.result = fptrunc float %result to half
-  store volatile half %cvt.result, ptr addrspace(1) undef
+  store volatile half %cvt.result, ptr addrspace(1) poison
   %max = call half @llvm.maxnum.f16(half %cvt.result, half 0.0)
   %clamp = call half @llvm.minnum.f16(half %max, half 1.0)
   %vec.result = insertelement <2 x half> poison, half %clamp, i32 1

--- a/llvm/test/CodeGen/AMDGPU/madak.ll
+++ b/llvm/test/CodeGen/AMDGPU/madak.ll
@@ -1498,15 +1498,15 @@ bb:
   br i1 %tmp, label %bb3, label %bb4
 
 bb3:
-  store volatile float 0.0, ptr addrspace(1) undef
+  store volatile float 0.0, ptr addrspace(1) poison
   br label %bb4
 
 bb4:
-  %vgpr = load volatile float, ptr addrspace(1) undef
+  %vgpr = load volatile float, ptr addrspace(1) poison
   %tmp0 = fmul float %sgpr0, 0.5
   %tmp1 = fadd float %tmp0, 42.0
   %tmp2 = fmul float %tmp1, %vgpr
-  store volatile float %tmp2, ptr addrspace(1) undef, align 4
+  store volatile float %tmp2, ptr addrspace(1) poison, align 4
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/mmo-target-flags-folding.ll
+++ b/llvm/test/CodeGen/AMDGPU/mmo-target-flags-folding.ll
@@ -13,9 +13,9 @@ entry:
   %idx = getelementptr inbounds <2 x float>, ptr addrspace(1) %arrayidx, i64 0, i32 1
   %i4 = load float, ptr addrspace(1) %idx, align 4
   %i5 = load i64, ptr addrspace(1) %arrayidx, align 4, !amdgpu.noclobber !0
-  store i64 %i5, ptr addrspace(1) undef, align 4
+  store i64 %i5, ptr addrspace(1) poison, align 4
   %mul = fmul float %i3, %i4
-  store float %mul, ptr addrspace(1) undef, align 4
+  store float %mul, ptr addrspace(1) poison, align 4
   unreachable
 }
 

--- a/llvm/test/CodeGen/AMDGPU/mubuf-offset-private.ll
+++ b/llvm/test/CodeGen/AMDGPU/mubuf-offset-private.ll
@@ -51,7 +51,7 @@ define amdgpu_kernel void @load_private_offset_i8() #0 {
 define amdgpu_kernel void @sextload_private_offset_i8(ptr addrspace(1) %out) #0 {
   %load = load volatile i8, ptr addrspace(5) inttoptr (i32 8 to ptr addrspace(5))
   %sextload = sext i8 %load to i32
-  store i32 %sextload, ptr addrspace(1) undef
+  store i32 %sextload, ptr addrspace(1) poison
   ret void
 }
 
@@ -60,7 +60,7 @@ define amdgpu_kernel void @sextload_private_offset_i8(ptr addrspace(1) %out) #0 
 define amdgpu_kernel void @zextload_private_offset_i8(ptr addrspace(1) %out) #0 {
   %load = load volatile i8, ptr addrspace(5) inttoptr (i32 8 to ptr addrspace(5))
   %zextload = zext i8 %load to i32
-  store i32 %zextload, ptr addrspace(1) undef
+  store i32 %zextload, ptr addrspace(1) poison
   ret void
 }
 
@@ -76,7 +76,7 @@ define amdgpu_kernel void @load_private_offset_i16() #0 {
 define amdgpu_kernel void @sextload_private_offset_i16(ptr addrspace(1) %out) #0 {
   %load = load volatile i16, ptr addrspace(5) inttoptr (i32 8 to ptr addrspace(5))
   %sextload = sext i16 %load to i32
-  store i32 %sextload, ptr addrspace(1) undef
+  store i32 %sextload, ptr addrspace(1) poison
   ret void
 }
 
@@ -85,7 +85,7 @@ define amdgpu_kernel void @sextload_private_offset_i16(ptr addrspace(1) %out) #0
 define amdgpu_kernel void @zextload_private_offset_i16(ptr addrspace(1) %out) #0 {
   %load = load volatile i16, ptr addrspace(5) inttoptr (i32 8 to ptr addrspace(5))
   %zextload = zext i16 %load to i32
-  store i32 %zextload, ptr addrspace(1) undef
+  store i32 %zextload, ptr addrspace(1) poison
   ret void
 }
 
@@ -149,7 +149,7 @@ define amdgpu_kernel void @store_private_offset_i8_max_offset_plus2() #0 {
 ; GFX9: buffer_store_dword v{{[0-9]+}}, [[ADDR]], s{{\[[0-9]+:[0-9]+\]}}, 0 offen offset:32
 define amdgpu_kernel void @store_private_unknown_bits_vaddr() #0 {
   %alloca = alloca [16 x i32], align 4, addrspace(5)
-  %vaddr = load volatile i32, ptr addrspace(1) undef
+  %vaddr = load volatile i32, ptr addrspace(1) poison
   %vaddr.off = add i32 %vaddr, 8
   %gep = getelementptr inbounds [16 x i32], ptr addrspace(5) %alloca, i32 0, i32 %vaddr.off
   store volatile i32 9, ptr addrspace(5) %gep

--- a/llvm/test/CodeGen/AMDGPU/mul24-pass-ordering.ll
+++ b/llvm/test/CodeGen/AMDGPU/mul24-pass-ordering.ll
@@ -44,7 +44,7 @@ bb23:                                             ; preds = %bb23, %bb
   %tmp30 = sub i32 %tmp24, %tmp29
   %tmp31 = add i32 %tmp30, %arg16
   %tmp37 = icmp ult i32 %tmp31, %arg13
-  %tmp44 = load float, ptr addrspace(1) undef, align 4
+  %tmp44 = load float, ptr addrspace(1) poison, align 4
   store float %tmp44, ptr addrspace(3) undef, align 4
   %tmp47 = add i32 %tmp24, %arg2
   br i1 %tmp37, label %bb23, label %.loopexit
@@ -170,17 +170,17 @@ define void @slsr1_0(i32 %b.arg, i32 %s.arg) #0 {
   %mul0 = mul i32 %b, %s
 ; CHECK: mul i32
 ; CHECK-NOT: mul i32
-  store volatile i32 %mul0, ptr addrspace(1) undef
+  store volatile i32 %mul0, ptr addrspace(1) poison
 
   ; foo((b + 1) * s);
   %b1 = add i32 %b, 1
   %mul1 = mul i32 %b1, %s
-  store volatile i32 %mul1, ptr addrspace(1) undef
+  store volatile i32 %mul1, ptr addrspace(1) poison
 
   ; foo((b + 2) * s);
   %b2 = add i32 %b, 2
   %mul2 = mul i32 %b2, %s
-  store volatile i32 %mul2, ptr addrspace(1) undef
+  store volatile i32 %mul2, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/multi-divergent-exit-region.ll
+++ b/llvm/test/CodeGen/AMDGPU/multi-divergent-exit-region.ll
@@ -38,7 +38,7 @@
 ; IR: br i1 %10, label %exit0, label %UnifiedReturnBlock
 
 ; IR: exit0:
-; IR: store volatile i32 9, ptr addrspace(1) undef
+; IR: store volatile i32 9, ptr addrspace(1) poison
 ; IR: br label %UnifiedReturnBlock
 
 ; IR: Flow1:
@@ -131,7 +131,7 @@ LeafBlock1:                                       ; preds = %entry
   br i1 %SwitchLeaf2, label %exit0, label %exit1
 
 exit0:                                     ; preds = %LeafBlock, %LeafBlock1
-  store volatile i32 9, ptr addrspace(1) undef
+  store volatile i32 9, ptr addrspace(1) poison
   ret void
 
 exit1:                                     ; preds = %LeafBlock, %LeafBlock1
@@ -186,7 +186,7 @@ LeafBlock1:                                       ; preds = %entry
   br i1 %SwitchLeaf2, label %exit0, label %exit1
 
 exit0:                                     ; preds = %LeafBlock, %LeafBlock1
-  store volatile i32 9, ptr addrspace(1) undef
+  store volatile i32 9, ptr addrspace(1) poison
   unreachable
 
 exit1:                                     ; preds = %LeafBlock, %LeafBlock1
@@ -220,7 +220,7 @@ exit1:                                     ; preds = %LeafBlock, %LeafBlock1
 ; IR: br i1 %10, label %exit0, label %UnifiedReturnBlock
 
 ; IR: exit0:
-; IR: store volatile i32 9, ptr addrspace(1) undef
+; IR: store volatile i32 9, ptr addrspace(1) poison
 ; IR: br label %UnifiedReturnBlock
 
 ; IR: {{^}}Flow1:
@@ -267,7 +267,7 @@ LeafBlock1:                                       ; preds = %entry
   br i1 %uniform.cond0, label %exit0, label %exit1
 
 exit0:                                     ; preds = %LeafBlock, %LeafBlock1
-  store volatile i32 9, ptr addrspace(1) undef
+  store volatile i32 9, ptr addrspace(1) poison
   ret void
 
 exit1:                                     ; preds = %LeafBlock, %LeafBlock1
@@ -316,7 +316,7 @@ LeafBlock1:                                       ; preds = %entry
   br i1 %SwitchLeaf2, label %exit0, label %exit1
 
 exit0:                                     ; preds = %LeafBlock, %LeafBlock1
-  store volatile i32 9, ptr addrspace(1) undef
+  store volatile i32 9, ptr addrspace(1) poison
   ret void
 
 exit1:                                     ; preds = %LeafBlock, %LeafBlock1
@@ -347,7 +347,7 @@ LeafBlock1:                                       ; preds = %entry
   br i1 %SwitchLeaf2, label %exit0, label %exit1
 
 exit0:                                     ; preds = %LeafBlock, %LeafBlock1
-  store i32 9, ptr addrspace(1) undef
+  store i32 9, ptr addrspace(1) poison
   ret float 1.0
 
 exit1:                                     ; preds = %LeafBlock, %LeafBlock1
@@ -389,7 +389,7 @@ LeafBlock1:                                       ; preds = %entry
   br i1 %divergent.cond1, label %exit0, label %exit1
 
 exit0:                                     ; preds = %LeafBlock, %LeafBlock1
-  store i32 9, ptr addrspace(1) undef
+  store i32 9, ptr addrspace(1) poison
   ret float 1.0
 
 exit1:                                     ; preds = %LeafBlock, %LeafBlock1
@@ -425,7 +425,7 @@ exit1:                                     ; preds = %LeafBlock, %LeafBlock1
 ; IR: br i1 %15, label %exit1, label %Flow2
 
 ; IR: exit1:
-; IR-NEXT: store volatile i32 9, ptr addrspace(1) undef
+; IR-NEXT: store volatile i32 9, ptr addrspace(1) poison
 ; IR-NEXT: call void @llvm.amdgcn.unreachable()
 ; IR-NEXT: br label %Flow2
 
@@ -464,7 +464,7 @@ exit0:                                     ; preds = %LeafBlock, %LeafBlock1
   ret void
 
 exit1:                                     ; preds = %LeafBlock, %LeafBlock1
-  store volatile i32 9, ptr addrspace(1) undef
+  store volatile i32 9, ptr addrspace(1) poison
   unreachable
 }
 
@@ -479,9 +479,9 @@ exit1:                                     ; preds = %LeafBlock, %LeafBlock1
 
 
 ; IR: indirect.exit1:
-; IR: %load = load volatile i32, ptr addrspace(1) undef
-; IR: store volatile i32 %load, ptr addrspace(1) undef
-; IR: store volatile i32 9, ptr addrspace(1) undef
+; IR: %load = load volatile i32, ptr addrspace(1) poison
+; IR: store volatile i32 %load, ptr addrspace(1) poison
+; IR: store volatile i32 9, ptr addrspace(1) poison
 ; IR: call void @llvm.amdgcn.unreachable()
 ; IR-NEXT: br label %Flow2
 
@@ -520,12 +520,12 @@ exit0:                                     ; preds = %LeafBlock, %LeafBlock1
   ret void
 
 indirect.exit1:
-  %load = load volatile i32, ptr addrspace(1) undef
-  store volatile i32 %load, ptr addrspace(1) undef
+  %load = load volatile i32, ptr addrspace(1) poison
+  store volatile i32 %load, ptr addrspace(1) poison
   br label %exit1
 
 exit1:                                     ; preds = %LeafBlock, %LeafBlock1
-  store volatile i32 9, ptr addrspace(1) undef
+  store volatile i32 9, ptr addrspace(1) poison
   unreachable
 }
 
@@ -564,7 +564,7 @@ exit0:                                     ; preds = %LeafBlock, %LeafBlock1
   ret void
 
 exit1:                                     ; preds = %LeafBlock, %LeafBlock1
-  store volatile i32 9, ptr addrspace(1) undef
+  store volatile i32 9, ptr addrspace(1) poison
   unreachable
 }
 
@@ -588,7 +588,7 @@ divergent.ret1:
   ret void
 
 uniform.ret:
-  store volatile i32 9, ptr addrspace(1) undef
+  store volatile i32 9, ptr addrspace(1) poison
   ret void
 }
 
@@ -604,18 +604,18 @@ divergent.multi.exit.region:
   br i1 %divergent.cond0, label %divergent.if, label %divergent.ret1
 
 divergent.if:
-  %vgpr0 = load volatile float, ptr addrspace(1) undef
+  %vgpr0 = load volatile float, ptr addrspace(1) poison
   %divergent.cond1 = fcmp ogt float %vgpr0, 1.0
   br i1 %divergent.cond1, label %divergent.then, label %divergent.endif
 
 divergent.then:
-  %vgpr1 = load volatile float, ptr addrspace(1) undef
+  %vgpr1 = load volatile float, ptr addrspace(1) poison
   %divergent.cond2 = fcmp olt float %vgpr1, 4.0
-  store volatile i32 33, ptr addrspace(1) undef
+  store volatile i32 33, ptr addrspace(1) poison
   br i1 %divergent.cond2, label %divergent.ret0, label %divergent.endif
 
 divergent.endif:
-  store volatile i32 38, ptr addrspace(1) undef
+  store volatile i32 38, ptr addrspace(1) poison
   br label %divergent.ret0
 
 divergent.ret0:
@@ -627,7 +627,7 @@ divergent.ret1:
   ret void
 
 uniform.ret:
-  store volatile i32 9, ptr addrspace(1) undef
+  store volatile i32 9, ptr addrspace(1) poison
   ret void
 }
 
@@ -661,11 +661,11 @@ uniform.if:
 uniform.then:
   %sgpr1 = load volatile i32, ptr addrspace(4) undef
   %uniform.cond2 = icmp sge i32 %sgpr1, 4
-  store volatile i32 33, ptr addrspace(1) undef
+  store volatile i32 33, ptr addrspace(1) poison
   br i1 %uniform.cond2, label %uniform.ret0, label %uniform.endif
 
 uniform.endif:
-  store volatile i32 38, ptr addrspace(1) undef
+  store volatile i32 38, ptr addrspace(1) poison
   br label %uniform.ret0
 
 uniform.ret0:
@@ -677,7 +677,7 @@ uniform.ret1:
   ret void
 
 divergent.ret:
-  store volatile i32 9, ptr addrspace(1) undef
+  store volatile i32 9, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/multilevel-break.ll
+++ b/llvm/test/CodeGen/AMDGPU/multilevel-break.ll
@@ -125,7 +125,7 @@ define amdgpu_kernel void @multi_if_break_loop(i32 %arg) #0 {
 ; OPT-NEXT:    [[LSR_IV:%.*]] = phi i32 [ poison, %[[BB]] ], [ [[TMP2:%.*]], %[[FLOW4]] ]
 ; OPT-NEXT:    [[TMP2]] = add i32 [[LSR_IV]], 1
 ; OPT-NEXT:    [[CMP0:%.*]] = icmp slt i32 [[TMP2]], 0
-; OPT-NEXT:    [[LOAD0:%.*]] = load volatile i32, ptr addrspace(1) undef, align 4
+; OPT-NEXT:    [[LOAD0:%.*]] = load volatile i32, ptr addrspace(1) poison, align 4
 ; OPT-NEXT:    br label %[[NODEBLOCK:.*]]
 ; OPT:       [[NODEBLOCK]]:
 ; OPT-NEXT:    [[PIVOT:%.*]] = icmp sge i32 [[LOAD0]], 1
@@ -145,7 +145,7 @@ define amdgpu_kernel void @multi_if_break_loop(i32 %arg) #0 {
 ; OPT-NEXT:    [[TMP5:%.*]] = call i1 @llvm.amdgcn.loop.i64(i64 [[TMP4]])
 ; OPT-NEXT:    br i1 [[TMP5]], label %[[BB9:.*]], label %[[BB1]]
 ; OPT:       [[CASE0]]:
-; OPT-NEXT:    [[LOAD1:%.*]] = load volatile i32, ptr addrspace(1) undef, align 4
+; OPT-NEXT:    [[LOAD1:%.*]] = load volatile i32, ptr addrspace(1) poison, align 4
 ; OPT-NEXT:    [[CMP1:%.*]] = icmp sge i32 [[TMP]], [[LOAD1]]
 ; OPT-NEXT:    br label %[[FLOW5]]
 ; OPT:       [[FLOW]]:
@@ -153,7 +153,7 @@ define amdgpu_kernel void @multi_if_break_loop(i32 %arg) #0 {
 ; OPT-NEXT:    [[TMP8:%.*]] = phi i1 [ false, %[[FLOW3]] ], [ true, %[[NODEBLOCK]] ]
 ; OPT-NEXT:    br i1 [[TMP8]], label %[[LEAFBLOCK]], label %[[FLOW4]]
 ; OPT:       [[CASE1]]:
-; OPT-NEXT:    [[LOAD2:%.*]] = load volatile i32, ptr addrspace(1) undef, align 4
+; OPT-NEXT:    [[LOAD2:%.*]] = load volatile i32, ptr addrspace(1) poison, align 4
 ; OPT-NEXT:    [[CMP2]] = icmp sge i32 [[TMP]], [[LOAD2]]
 ; OPT-NEXT:    br label %[[FLOW3]]
 ; OPT:       [[FLOW5]]:
@@ -228,19 +228,19 @@ bb1:
   %lsr.iv = phi i32 [ poison, %bb ], [ %lsr.iv.next, %case0 ], [ %lsr.iv.next, %case1 ]
   %lsr.iv.next = add i32 %lsr.iv, 1
   %cmp0 = icmp slt i32 %lsr.iv.next, 0
-  %load0 = load volatile i32, ptr addrspace(1) undef, align 4
+  %load0 = load volatile i32, ptr addrspace(1) poison, align 4
   switch i32 %load0, label %bb9 [
   i32 0, label %case0
   i32 1, label %case1
   ]
 
 case0:
-  %load1 = load volatile i32, ptr addrspace(1) undef, align 4
+  %load1 = load volatile i32, ptr addrspace(1) poison, align 4
   %cmp1 = icmp slt i32 %tmp, %load1
   br i1 %cmp1, label %bb1, label %bb9
 
 case1:
-  %load2 = load volatile i32, ptr addrspace(1) undef, align 4
+  %load2 = load volatile i32, ptr addrspace(1) poison, align 4
   %cmp2 = icmp slt i32 %tmp, %load2
   br i1 %cmp2, label %bb1, label %bb9
 

--- a/llvm/test/CodeGen/AMDGPU/nested-loop-conditions.ll
+++ b/llvm/test/CodeGen/AMDGPU/nested-loop-conditions.ll
@@ -192,7 +192,7 @@ define amdgpu_kernel void @nested_loop_conditions(ptr addrspace(1) captures(none
 ; IR-LABEL: define amdgpu_kernel void @nested_loop_conditions(
 ; IR-SAME: ptr addrspace(1) captures(none) [[ARG:%.*]]) #[[ATTR0]] {
 ; IR-NEXT:  [[BB:.*]]:
-; IR-NEXT:    [[MY_TMP1134:%.*]] = load volatile i32, ptr addrspace(1) undef, align 4
+; IR-NEXT:    [[MY_TMP1134:%.*]] = load volatile i32, ptr addrspace(1) poison, align 4
 ; IR-NEXT:    [[MY_TMP1235:%.*]] = icmp slt i32 [[MY_TMP1134]], 9
 ; IR-NEXT:    br i1 [[MY_TMP1235]], label %[[BB14_LR_PH:.*]], label %[[FLOW:.*]]
 ; IR:       [[BB14_LR_PH]]:
@@ -200,7 +200,7 @@ define amdgpu_kernel void @nested_loop_conditions(ptr addrspace(1) captures(none
 ; IR-NEXT:    [[MY_TMP1:%.*]] = zext i32 [[MY_TMP]] to i64
 ; IR-NEXT:    [[MY_TMP2:%.*]] = getelementptr inbounds i64, ptr addrspace(1) [[ARG]], i64 [[MY_TMP1]]
 ; IR-NEXT:    [[MY_TMP3:%.*]] = load i64, ptr addrspace(1) [[MY_TMP2]], align 16
-; IR-NEXT:    [[MY_TMP932:%.*]] = load <4 x i32>, ptr addrspace(1) undef, align 16
+; IR-NEXT:    [[MY_TMP932:%.*]] = load <4 x i32>, ptr addrspace(1) poison, align 16
 ; IR-NEXT:    [[MY_TMP1033:%.*]] = extractelement <4 x i32> [[MY_TMP932]], i64 0
 ; IR-NEXT:    br label %[[BB14:.*]]
 ; IR:       [[FLOW3:.*]]:
@@ -246,7 +246,7 @@ define amdgpu_kernel void @nested_loop_conditions(ptr addrspace(1) captures(none
 ; IR-NEXT:    [[TMP17:%.*]] = call i1 @llvm.amdgcn.loop.i64(i64 [[TMP16]])
 ; IR-NEXT:    br i1 [[TMP17]], label %[[FLOW2:.*]], label %[[BB14]]
 ; IR:       [[BB18]]:
-; IR-NEXT:    [[MY_TMP19:%.*]] = load volatile i32, ptr addrspace(1) undef, align 4
+; IR-NEXT:    [[MY_TMP19:%.*]] = load volatile i32, ptr addrspace(1) poison, align 4
 ; IR-NEXT:    [[MY_TMP20:%.*]] = icmp slt i32 [[MY_TMP19]], 9
 ; IR-NEXT:    br i1 [[MY_TMP20]], label %[[BB21]], label %[[BB18]]
 ; IR:       [[BB21]]:
@@ -260,10 +260,10 @@ define amdgpu_kernel void @nested_loop_conditions(ptr addrspace(1) captures(none
 ; IR-NEXT:    [[MY_TMP29:%.*]] = select i1 [[MY_TMP28]], i64 1, i64 2
 ; IR-NEXT:    [[MY_TMP30:%.*]] = extractelement <4 x i32> [[MY_TMP936]], i64 [[MY_TMP29]]
 ; IR-NEXT:    [[MY_TMP7:%.*]] = zext i32 [[MY_TMP30]] to i64
-; IR-NEXT:    [[MY_TMP8:%.*]] = getelementptr inbounds <4 x i32>, ptr addrspace(1) undef, i64 [[MY_TMP7]]
+; IR-NEXT:    [[MY_TMP8:%.*]] = getelementptr inbounds <4 x i32>, ptr addrspace(1) poison, i64 [[MY_TMP7]]
 ; IR-NEXT:    [[MY_TMP9]] = load <4 x i32>, ptr addrspace(1) [[MY_TMP8]], align 16
 ; IR-NEXT:    [[MY_TMP10]] = extractelement <4 x i32> [[MY_TMP9]], i64 0
-; IR-NEXT:    [[MY_TMP11:%.*]] = load volatile i32, ptr addrspace(1) undef, align 4
+; IR-NEXT:    [[MY_TMP11:%.*]] = load volatile i32, ptr addrspace(1) poison, align 4
 ; IR-NEXT:    [[MY_TMP12]] = icmp sge i32 [[MY_TMP11]], 9
 ; IR-NEXT:    br label %[[FLOW1]]
 ; IR:       [[FLOW2]]:
@@ -276,11 +276,11 @@ define amdgpu_kernel void @nested_loop_conditions(ptr addrspace(1) captures(none
 ; IR-NEXT:    br label %[[FLOW3]]
 ; IR:       [[BB31]]:
 ; IR-NEXT:    call void @llvm.amdgcn.end.cf.i64(i64 [[TMP7]])
-; IR-NEXT:    store volatile i32 0, ptr addrspace(1) undef, align 4
+; IR-NEXT:    store volatile i32 0, ptr addrspace(1) poison, align 4
 ; IR-NEXT:    ret void
 ;
 bb:
-  %my.tmp1134 = load volatile i32, ptr addrspace(1) undef
+  %my.tmp1134 = load volatile i32, ptr addrspace(1) poison
   %my.tmp1235 = icmp slt i32 %my.tmp1134, 9
   br i1 %my.tmp1235, label %bb14.lr.ph, label %bb13
 
@@ -289,7 +289,7 @@ bb14.lr.ph:                                       ; preds = %bb
   %my.tmp1 = zext i32 %my.tmp to i64
   %my.tmp2 = getelementptr inbounds i64, ptr addrspace(1) %arg, i64 %my.tmp1
   %my.tmp3 = load i64, ptr addrspace(1) %my.tmp2, align 16
-  %my.tmp932 = load <4 x i32>, ptr addrspace(1) undef, align 16
+  %my.tmp932 = load <4 x i32>, ptr addrspace(1) poison, align 16
   %my.tmp1033 = extractelement <4 x i32> %my.tmp932, i64 0
   br label %bb14
 
@@ -310,7 +310,7 @@ bb16:                                             ; preds = %bb14
   br label %bb18
 
 bb18:                                             ; preds = %bb18, %bb16
-  %my.tmp19 = load volatile i32, ptr addrspace(1) undef
+  %my.tmp19 = load volatile i32, ptr addrspace(1) poison
   %my.tmp20 = icmp slt i32 %my.tmp19, 9
   br i1 %my.tmp20, label %bb21, label %bb18
 
@@ -325,10 +325,10 @@ bb21:                                             ; preds = %bb18
   %my.tmp29 = select i1 %my.tmp28, i64 1, i64 2
   %my.tmp30 = extractelement <4 x i32> %my.tmp936, i64 %my.tmp29
   %my.tmp7 = zext i32 %my.tmp30 to i64
-  %my.tmp8 = getelementptr inbounds <4 x i32>, ptr addrspace(1) undef, i64 %my.tmp7
+  %my.tmp8 = getelementptr inbounds <4 x i32>, ptr addrspace(1) poison, i64 %my.tmp7
   %my.tmp9 = load <4 x i32>, ptr addrspace(1) %my.tmp8, align 16
   %my.tmp10 = extractelement <4 x i32> %my.tmp9, i64 0
-  %my.tmp11 = load volatile i32, ptr addrspace(1) undef
+  %my.tmp11 = load volatile i32, ptr addrspace(1) poison
   %my.tmp12 = icmp slt i32 %my.tmp11, 9
   br i1 %my.tmp12, label %bb14, label %bb4.bb13_crit_edge
 
@@ -336,7 +336,7 @@ bb31.loopexit:                                    ; preds = %bb14
   br label %bb31
 
 bb31:                                             ; preds = %bb31.loopexit, %bb13
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/non-entry-alloca.ll
+++ b/llvm/test/CodeGen/AMDGPU/non-entry-alloca.ll
@@ -106,7 +106,7 @@ bb.1:
   br label %bb.2
 
 bb.2:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   ret void
 }
 ; DEFAULTSIZE: .amdhsa_private_segment_fixed_size 4112
@@ -200,7 +200,7 @@ bb.0:
   br label %bb.1
 
 bb.1:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   ret void
 }
 
@@ -306,7 +306,7 @@ bb.1:
   br label %bb.2
 
 bb.2:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   ret void
 }
 
@@ -399,7 +399,7 @@ bb.0:
   br label %bb.1
 
 bb.1:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/offset-split-global.ll
+++ b/llvm/test/CodeGen/AMDGPU/offset-split-global.ll
@@ -1953,7 +1953,7 @@ define amdgpu_kernel void @global_inst_salu_offset_1(ptr addrspace(1) %p) {
 ; GFX12-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 1
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -1999,7 +1999,7 @@ define amdgpu_kernel void @global_inst_salu_offset_11bit_max(ptr addrspace(1) %p
 ; GFX12-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 2047
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -2045,7 +2045,7 @@ define amdgpu_kernel void @global_inst_salu_offset_12bit_max(ptr addrspace(1) %p
 ; GFX12-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 4095
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -2091,7 +2091,7 @@ define amdgpu_kernel void @global_inst_salu_offset_13bit_max(ptr addrspace(1) %p
 ; GFX12-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 8191
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -2137,7 +2137,7 @@ define amdgpu_kernel void @global_inst_salu_offset_neg_11bit_max(ptr addrspace(1
 ; GFX12-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 -2048
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -2197,7 +2197,7 @@ define amdgpu_kernel void @global_inst_salu_offset_neg_12bit_max(ptr addrspace(1
 ; GFX10-SDAG-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 -4096
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -2274,7 +2274,7 @@ define amdgpu_kernel void @global_inst_salu_offset_neg_13bit_max(ptr addrspace(1
 ; GFX11-SDAG-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 -8192
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -2320,7 +2320,7 @@ define amdgpu_kernel void @global_inst_salu_offset_2x_11bit_max(ptr addrspace(1)
 ; GFX12-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 4095
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -2366,7 +2366,7 @@ define amdgpu_kernel void @global_inst_salu_offset_2x_12bit_max(ptr addrspace(1)
 ; GFX12-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 8191
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -2412,7 +2412,7 @@ define amdgpu_kernel void @global_inst_salu_offset_2x_13bit_max(ptr addrspace(1)
 ; GFX12-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 16383
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -2472,7 +2472,7 @@ define amdgpu_kernel void @global_inst_salu_offset_2x_neg_11bit_max(ptr addrspac
 ; GFX10-SDAG-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 -4096
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -2549,7 +2549,7 @@ define amdgpu_kernel void @global_inst_salu_offset_2x_neg_12bit_max(ptr addrspac
 ; GFX11-SDAG-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 -8192
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -2626,7 +2626,7 @@ define amdgpu_kernel void @global_inst_salu_offset_2x_neg_13bit_max(ptr addrspac
 ; GFX11-SDAG-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 -16384
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -2719,7 +2719,7 @@ define amdgpu_kernel void @global_inst_salu_offset_64bit_11bit_split0(ptr addrsp
 ; GFX12-SDAG-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 8589936639
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -2812,7 +2812,7 @@ define amdgpu_kernel void @global_inst_salu_offset_64bit_11bit_split1(ptr addrsp
 ; GFX12-SDAG-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 8589936640
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -2905,7 +2905,7 @@ define amdgpu_kernel void @global_inst_salu_offset_64bit_12bit_split0(ptr addrsp
 ; GFX12-SDAG-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 8589938687
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -2998,7 +2998,7 @@ define amdgpu_kernel void @global_inst_salu_offset_64bit_12bit_split1(ptr addrsp
 ; GFX12-SDAG-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 8589938688
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -3091,7 +3091,7 @@ define amdgpu_kernel void @global_inst_salu_offset_64bit_13bit_split0(ptr addrsp
 ; GFX12-SDAG-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 8589942783
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -3184,7 +3184,7 @@ define amdgpu_kernel void @global_inst_salu_offset_64bit_13bit_split1(ptr addrsp
 ; GFX12-SDAG-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 8589942784
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -3252,7 +3252,7 @@ define amdgpu_kernel void @global_inst_salu_offset_64bit_11bit_neg_high_split0(p
 ; GFX12-SDAG-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 -9223372036854773761
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -3320,7 +3320,7 @@ define amdgpu_kernel void @global_inst_salu_offset_64bit_11bit_neg_high_split1(p
 ; GFX12-SDAG-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 -9223372036854773760
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -3388,7 +3388,7 @@ define amdgpu_kernel void @global_inst_salu_offset_64bit_12bit_neg_high_split0(p
 ; GFX12-SDAG-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 -9223372036854771713
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -3456,7 +3456,7 @@ define amdgpu_kernel void @global_inst_salu_offset_64bit_12bit_neg_high_split1(p
 ; GFX12-SDAG-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 -9223372036854771712
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -3524,7 +3524,7 @@ define amdgpu_kernel void @global_inst_salu_offset_64bit_13bit_neg_high_split0(p
 ; GFX12-SDAG-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 -9223372036854767617
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }
 
@@ -3592,6 +3592,6 @@ define amdgpu_kernel void @global_inst_salu_offset_64bit_13bit_neg_high_split1(p
 ; GFX12-SDAG-NEXT:    s_endpgm
   %gep = getelementptr i8, ptr addrspace(1) %p, i64 -9223372036854767616
   %load = load volatile i8, ptr addrspace(1) %gep, align 1
-  store i8 %load, ptr addrspace(1) undef
+  store i8 %load, ptr addrspace(1) poison
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/omod.ll
+++ b/llvm/test/CodeGen/AMDGPU/omod.ll
@@ -327,7 +327,7 @@ define amdgpu_ps void @v_omod_div2_f32_signed_zeros(float %a) #4 {
 ; GFX11PLUS-NEXT:    s_endpgm
   %add = fadd float %a, 1.0
   %div2 = fmul float %add, 0.5
-  store float %div2, ptr addrspace(1) undef
+  store float %div2, ptr addrspace(1) poison
   ret void
 }
 
@@ -366,7 +366,7 @@ define amdgpu_ps void @v_omod_div2_f64_signed_zeros(double %a) #4 {
 ; GFX12-NEXT:    s_endpgm
   %add = fadd double %a, 1.0
   %div2 = fmul double %add, 0.5
-  store double %div2, ptr addrspace(1) undef
+  store double %div2, ptr addrspace(1) poison
   ret void
 }
 
@@ -392,7 +392,7 @@ define amdgpu_ps void @v_omod_div2_f32(float %a) #0 {
 ; GFX11PLUS-NEXT:    s_endpgm
   %add = fadd float %a, 1.0
   %div2 = fmul float %add, 0.5
-  store float %div2, ptr addrspace(1) undef
+  store float %div2, ptr addrspace(1) poison
   ret void
 }
 
@@ -424,7 +424,7 @@ define amdgpu_ps void @v_omod_div2_f64(double %a) #5 {
 ; GFX12-NEXT:    s_endpgm
   %add = fadd nsz double %a, 1.0
   %div2 = fmul nsz double %add, 0.5
-  store double %div2, ptr addrspace(1) undef
+  store double %div2, ptr addrspace(1) poison
   ret void
 }
 
@@ -450,7 +450,7 @@ define amdgpu_ps void @v_omod_mul2_f32(float %a) #0 {
 ; GFX11PLUS-NEXT:    s_endpgm
   %add = fadd float %a, 1.0
   %div2 = fmul float %add, 2.0
-  store float %div2, ptr addrspace(1) undef
+  store float %div2, ptr addrspace(1) poison
   ret void
 }
 
@@ -482,7 +482,7 @@ define amdgpu_ps void @v_omod_mul2_med3(float %x, float %y, float %z) #0 {
 ; GFX12-NEXT:    s_endpgm
   %fmed3 = call float @llvm.amdgcn.fmed3.f32(float %x, float %y, float %z)
   %div2 = fmul float %fmed3, 2.0
-  store float %div2, ptr addrspace(1) undef
+  store float %div2, ptr addrspace(1) poison
   ret void
 }
 
@@ -514,7 +514,7 @@ define amdgpu_ps void @v_omod_mul2_f64(double %a) #5 {
 ; GFX12-NEXT:    s_endpgm
   %add = fadd nsz double %a, 1.0
   %div2 = fmul nsz double %add, 2.0
-  store double %div2, ptr addrspace(1) undef
+  store double %div2, ptr addrspace(1) poison
   ret void
 }
 
@@ -540,7 +540,7 @@ define amdgpu_ps void @v_omod_mul4_f32(float %a) #0 {
 ; GFX11PLUS-NEXT:    s_endpgm
   %add = fadd float %a, 1.0
   %div2 = fmul float %add, 4.0
-  store float %div2, ptr addrspace(1) undef
+  store float %div2, ptr addrspace(1) poison
   ret void
 }
 
@@ -572,7 +572,7 @@ define amdgpu_ps void @v_omod_mul4_f64(double %a) #5 {
 ; GFX12-NEXT:    s_endpgm
   %add = fadd nsz double %a, 1.0
   %div2 = fmul nsz double %add, 4.0
-  store double %div2, ptr addrspace(1) undef
+  store double %div2, ptr addrspace(1) poison
   ret void
 }
 
@@ -620,8 +620,8 @@ define amdgpu_ps void @v_omod_mul4_multi_use_f32(float %a) #0 {
 ; GFX12-NEXT:    s_endpgm
   %add = fadd float %a, 1.0
   %div2 = fmul float %add, 4.0
-  store float %div2, ptr addrspace(1) undef
-  store volatile float %add, ptr addrspace(1) undef
+  store float %div2, ptr addrspace(1) poison
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -648,7 +648,7 @@ define amdgpu_ps void @v_omod_mul4_dbg_use_f32(float %a) #0 {
   %add = fadd float %a, 1.0
   call void @llvm.dbg.value(metadata float %add, i64 0, metadata !4, metadata !9), !dbg !10
   %div2 = fmul float %add, 4.0
-  store float %div2, ptr addrspace(1) undef
+  store float %div2, ptr addrspace(1) poison
   ret void
 }
 
@@ -678,7 +678,7 @@ define amdgpu_ps void @v_clamp_omod_div2_f32(float %a) #0 {
 
   %max = call float @llvm.maxnum.f32(float %div2, float 0.0)
   %clamp = call float @llvm.minnum.f32(float %max, float 1.0)
-  store float %clamp, ptr addrspace(1) undef
+  store float %clamp, ptr addrspace(1) poison
   ret void
 }
 
@@ -711,7 +711,7 @@ define amdgpu_ps void @v_omod_div2_clamp_f32(float %a) #0 {
   %max = call float @llvm.maxnum.f32(float %add, float 0.0)
   %clamp = call float @llvm.minnum.f32(float %max, float 1.0)
   %div2 = fmul float %clamp, 0.5
-  store float %div2, ptr addrspace(1) undef
+  store float %div2, ptr addrspace(1) poison
   ret void
 }
 
@@ -742,7 +742,7 @@ define amdgpu_ps void @v_omod_div2_abs_src_f32(float %a) #0 {
   %add = fadd float %a, 1.0
   %abs.add = call float @llvm.fabs.f32(float %add)
   %div2 = fmul float %abs.add, 0.5
-  store float %div2, ptr addrspace(1) undef
+  store float %div2, ptr addrspace(1) poison
   ret void
 }
 
@@ -769,7 +769,7 @@ define amdgpu_ps void @v_omod_add_self_clamp_f32(float %a) #0 {
   %add = fadd float %a, %a
   %max = call float @llvm.maxnum.f32(float %add, float 0.0)
   %clamp = call float @llvm.minnum.f32(float %max, float 1.0)
-  store float %clamp, ptr addrspace(1) undef
+  store float %clamp, ptr addrspace(1) poison
   ret void
 }
 
@@ -808,7 +808,7 @@ define amdgpu_ps void @v_omod_add_clamp_self_f32(float %a) #0 {
   %max = call float @llvm.maxnum.f32(float %a, float 0.0)
   %clamp = call float @llvm.minnum.f32(float %max, float 1.0)
   %add = fadd float %clamp, %clamp
-  store float %add, ptr addrspace(1) undef
+  store float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -839,7 +839,7 @@ define amdgpu_ps void @v_omod_add_abs_self_f32(float %a) #0 {
   %x = fadd float %a, 1.0
   %abs.x = call float @llvm.fabs.f32(float %x)
   %add = fadd float %abs.x, %abs.x
-  store float %add, ptr addrspace(1) undef
+  store float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -870,7 +870,7 @@ define amdgpu_ps void @v_omod_add_abs_x_x_f32(float %a) #0 {
   %x = fadd float %a, 1.0
   %abs.x = call float @llvm.fabs.f32(float %x)
   %add = fadd float %abs.x, %x
-  store float %add, ptr addrspace(1) undef
+  store float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -901,7 +901,7 @@ define amdgpu_ps void @v_omod_add_x_abs_x_f32(float %a) #0 {
   %x = fadd float %a, 1.0
   %abs.x = call float @llvm.fabs.f32(float %x)
   %add = fadd float %x, %abs.x
-  store float %add, ptr addrspace(1) undef
+  store float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -933,7 +933,7 @@ define amdgpu_ps void @v_omod_div2_omod_div2_f32(float %a) #0 {
   %add = fadd float %a, 1.0
   %div2.0 = fmul float %add, 0.5
   %div2.1 = fmul float %div2.0, 0.5
-  store float %div2.1, ptr addrspace(1) undef
+  store float %div2.1, ptr addrspace(1) poison
   ret void
 }
 
@@ -964,7 +964,7 @@ define amdgpu_ps void @v_omod_div2_f32_denormals(float %a) #2 {
 ; GFX11PLUS-NEXT:    s_endpgm
   %add = fadd float %a, 1.0
   %div2 = fmul float %add, 0.5
-  store float %div2, ptr addrspace(1) undef
+  store float %div2, ptr addrspace(1) poison
   ret void
 }
 
@@ -1003,7 +1003,7 @@ define amdgpu_ps void @v_omod_div2_f64_denormals(double %a) #6 {
 ; GFX12-NEXT:    s_endpgm
   %add = fadd double %a, 1.0
   %div2 = fmul double %add, 0.5
-  store double %div2, ptr addrspace(1) undef
+  store double %div2, ptr addrspace(1) poison
   ret void
 }
 
@@ -1034,7 +1034,7 @@ define amdgpu_ps void @v_omod_mul2_f32_denormals(float %a) #2 {
 ; GFX11PLUS-NEXT:    s_endpgm
   %add = fadd float %a, 1.0
   %mul2 = fadd float %add, %add
-  store float %mul2, ptr addrspace(1) undef
+  store float %mul2, ptr addrspace(1) poison
   ret void
 }
 
@@ -1073,7 +1073,7 @@ define amdgpu_ps void @v_omod_mul2_f64_denormals(double %a) #2 {
 ; GFX12-NEXT:    s_endpgm
   %add = fadd double %a, 1.0
   %mul2 = fadd double %add, %add
-  store double %mul2, ptr addrspace(1) undef
+  store double %mul2, ptr addrspace(1) poison
   ret void
 }
 
@@ -1106,7 +1106,7 @@ define amdgpu_ps void @v_omod_div2_f16_denormals(half %a) #0 {
 ; GFX11PLUS-NEXT:    s_endpgm
   %add = fadd half %a, 1.0
   %div2 = fmul half %add, 0.5
-  store half %div2, ptr addrspace(1) undef
+  store half %div2, ptr addrspace(1) poison
   ret void
 }
 
@@ -1139,7 +1139,7 @@ define amdgpu_ps void @v_omod_mul2_f16_denormals(half %a) #0 {
 ; GFX11PLUS-NEXT:    s_endpgm
   %add = fadd half %a, 1.0
   %mul2 = fadd half %add, %add
-  store half %mul2, ptr addrspace(1) undef
+  store half %mul2, ptr addrspace(1) poison
   ret void
 }
 
@@ -1168,7 +1168,7 @@ define amdgpu_ps void @v_omod_div2_f16_no_denormals(half %a) #3 {
 ; GFX11PLUS-NEXT:    s_endpgm
   %add = fadd half %a, 1.0
   %div2 = fmul half %add, 0.5
-  store half %div2, ptr addrspace(1) undef
+  store half %div2, ptr addrspace(1) poison
   ret void
 }
 
@@ -1201,7 +1201,7 @@ define amdgpu_ps void @v_omod_mac_to_mad(float %b, float %a) #0 {
   %add = fadd float %mul, %b
   %mad = fmul float %add, 2.0
   %res = fmul float %mad, %b
-  store float %res, ptr addrspace(1) undef
+  store float %res, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/operand-folding.ll
+++ b/llvm/test/CodeGen/AMDGPU/operand-folding.ll
@@ -115,12 +115,12 @@ entry:
 ; CHECK: v_madmk_f32 v[[RES:[0-9]+]], v[[HI]], 0x41200000, v[[LO]]
 ; CHECK: buffer_store_dword v[[RES]]
 define amdgpu_kernel void @no_fold_tied_subregister() #1 {
-  %tmp1 = load volatile <2 x float>, ptr addrspace(1) undef
+  %tmp1 = load volatile <2 x float>, ptr addrspace(1) poison
   %tmp2 = extractelement <2 x float> %tmp1, i32 0
   %tmp3 = extractelement <2 x float> %tmp1, i32 1
   %tmp4 = fmul float %tmp3, 10.0
   %tmp5 = fadd float %tmp4, %tmp2
-  store volatile float %tmp5, ptr addrspace(1) undef
+  store volatile float %tmp5, ptr addrspace(1) poison
   ret void
 }
 
@@ -135,7 +135,7 @@ entry:
   br label %for.body.i.i
 
 for.body.i.i:
-  %s1 = load i32, ptr addrspace(1) undef, align 8
+  %s1 = load i32, ptr addrspace(1) poison, align 8
   %s1.i64 = sext i32 %s1 to i64
   %xor = xor i64 %s1.i64, %s0.i64
   %flag = icmp ult i64 %xor, 8

--- a/llvm/test/CodeGen/AMDGPU/or.ll
+++ b/llvm/test/CodeGen/AMDGPU/or.ll
@@ -401,7 +401,7 @@ define amdgpu_kernel void @scalar_or_literal_multi_use_i64(ptr addrspace(1) %out
   store i64 %or, ptr addrspace(1) %out
 
   %foo = add i64 %b, 4261135838621753
-  store volatile i64 %foo, ptr addrspace(1) undef
+  store volatile i64 %foo, ptr addrspace(1) poison
   ret void
 }
 
@@ -514,7 +514,7 @@ define amdgpu_kernel void @scalar_or_inline_imm_multi_use_i64(ptr addrspace(1) %
   %or = or i64 %a, 63
   store i64 %or, ptr addrspace(1) %out
   %foo = add i64 %b, 63
-  store volatile i64 %foo, ptr addrspace(1) undef
+  store volatile i64 %foo, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/pack.v2f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/pack.v2f16.ll
@@ -317,7 +317,7 @@ define amdgpu_kernel void @v_pack_v2f16_user(ptr addrspace(1) %in0, ptr addrspac
   %vec.1 = insertelement <2 x half> %vec.0, half %hi, i32 1
   %vec.i32 = bitcast <2 x half> %vec.1 to i32
   %foo = add i32 %vec.i32, 9
-  store volatile i32 %foo, ptr addrspace(1) undef
+  store volatile i32 %foo, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/pack.v2i16.ll
+++ b/llvm/test/CodeGen/AMDGPU/pack.v2i16.ll
@@ -309,7 +309,7 @@ define amdgpu_kernel void @v_pack_v2i16_user(ptr addrspace(1) %in0, ptr addrspac
   %vec.1 = insertelement <2 x i16> %vec.0, i16 %hi, i32 1
   %vec.i32 = bitcast <2 x i16> %vec.1 to i32
   %foo = add i32 %vec.i32, 9
-  store volatile i32 %foo, ptr addrspace(1) undef
+  store volatile i32 %foo, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/packed-op-sel.ll
+++ b/llvm/test/CodeGen/AMDGPU/packed-op-sel.ll
@@ -704,7 +704,7 @@ define amdgpu_kernel void @extract_from_i64(ptr addrspace(1) %out, ptr addrspace
 ; GCN-NEXT:    s_endpgm
 bb:
   %vec0 = load volatile <2 x i16>, ptr addrspace(3) %lds, align 4
-  %i64 = load volatile i64, ptr addrspace(1) undef
+  %i64 = load volatile i64, ptr addrspace(1) poison
 
   %elt0 = trunc i64 %i64 to i16
   %hi = lshr i64 %i64, 16
@@ -743,7 +743,7 @@ bb:
   %vec1 = load volatile <2 x half>, ptr addrspace(3) %lds.gep1, align 4
   %vec2 = load volatile <2 x half>, ptr addrspace(3) %lds.gep2, align 4
 
-  %scalar0 = load volatile i16, ptr addrspace(1) undef
+  %scalar0 = load volatile i16, ptr addrspace(1) poison
   %shl = shl i16 %scalar0, 1
   %shl.bc = bitcast i16 %shl to half
 
@@ -786,8 +786,8 @@ bb:
   %vec1 = load volatile <2 x half>, ptr addrspace(3) %lds.gep1, align 4
   %vec2 = load volatile <2 x half>, ptr addrspace(3) %lds.gep2, align 4
 
-  %scalar0 = load volatile i16, ptr addrspace(1) undef
-  %scalar1 = load volatile half, ptr addrspace(1) undef
+  %scalar0 = load volatile i16, ptr addrspace(1) poison
+  %scalar1 = load volatile half, ptr addrspace(1) poison
   %shl = shl i16 %scalar0, 1
   %shl.bc = bitcast i16 %shl to half
 

--- a/llvm/test/CodeGen/AMDGPU/partial-regcopy-and-spill-missed-at-regalloc.ll
+++ b/llvm/test/CodeGen/AMDGPU/partial-regcopy-and-spill-missed-at-regalloc.ll
@@ -13,15 +13,15 @@ define amdgpu_kernel void @partial_copy(<4 x i32> %arg) #0 {
   ; REGALLOC-GFX908-NEXT:   INLINEASM &"; use $0", 1 /* sideeffect attdialect */, 2162697 /* reguse:AGPR_32 */, undef %5:agpr_32
   ; REGALLOC-GFX908-NEXT:   INLINEASM &"; def $0", 1 /* sideeffect attdialect */, 6291466 /* regdef:VReg_128 */, def %6
   ; REGALLOC-GFX908-NEXT:   INLINEASM &"; def $0", 1 /* sideeffect attdialect */, 3538954 /* regdef:VReg_64 */, def %7
-  ; REGALLOC-GFX908-NEXT:   GLOBAL_STORE_DWORDX4 undef %14:vreg_64, %6, 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) undef`, addrspace 1)
+  ; REGALLOC-GFX908-NEXT:   GLOBAL_STORE_DWORDX4 undef %14:vreg_64, %6, 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) poison`, addrspace 1)
   ; REGALLOC-GFX908-NEXT:   renamable $sgpr0_sgpr1_sgpr2_sgpr3 = S_LOAD_DWORDX4_IMM killed renamable $sgpr4_sgpr5, 0, 0 :: (dereferenceable invariant load (s128) from %ir.arg.kernarg.offset1, addrspace 4)
   ; REGALLOC-GFX908-NEXT:   [[COPY:%[0-9]+]]:areg_128 = COPY killed renamable $sgpr0_sgpr1_sgpr2_sgpr3
   ; REGALLOC-GFX908-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 1, implicit $exec
   ; REGALLOC-GFX908-NEXT:   [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 2, implicit $exec
   ; REGALLOC-GFX908-NEXT:   [[V_MFMA_I32_4X4X4I8_e64_:%[0-9]+]]:areg_128 = V_MFMA_I32_4X4X4I8_e64 [[V_MOV_B32_e32_]], [[V_MOV_B32_e32_1]], [[COPY]], 0, 0, 0, implicit $mode, implicit $exec
-  ; REGALLOC-GFX908-NEXT:   GLOBAL_STORE_DWORDX2 undef %16:vreg_64, %7, 0, 0, implicit $exec :: (volatile store (s64) into `ptr addrspace(1) undef`, addrspace 1)
+  ; REGALLOC-GFX908-NEXT:   GLOBAL_STORE_DWORDX2 undef %16:vreg_64, %7, 0, 0, implicit $exec :: (volatile store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; REGALLOC-GFX908-NEXT:   [[COPY3:%[0-9]+]]:vreg_128 = COPY [[V_MFMA_I32_4X4X4I8_e64_]]
-  ; REGALLOC-GFX908-NEXT:   GLOBAL_STORE_DWORDX4 undef %18:vreg_64, [[COPY3]], 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) undef`, addrspace 1)
+  ; REGALLOC-GFX908-NEXT:   GLOBAL_STORE_DWORDX4 undef %18:vreg_64, [[COPY3]], 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) poison`, addrspace 1)
   ; REGALLOC-GFX908-NEXT:   S_ENDPGM 0
   ;
   ; PEI-GFX908-LABEL: name: partial_copy
@@ -38,7 +38,7 @@ define amdgpu_kernel void @partial_copy(<4 x i32> %arg) #0 {
   ; PEI-GFX908-NEXT:   BUFFER_STORE_DWORD_OFFSET killed $vgpr0, $sgpr8_sgpr9_sgpr10_sgpr11, 0, 0, 0, 0, implicit $exec, implicit-def $vgpr0_vgpr1, implicit $vgpr0_vgpr1 :: (store (s32) into %stack.0, addrspace 5)
   ; PEI-GFX908-NEXT:   $agpr4 = V_ACCVGPR_WRITE_B32_e64 killed $vgpr1, implicit $exec, implicit killed $vgpr0_vgpr1
   ; PEI-GFX908-NEXT:   renamable $vgpr0_vgpr1_vgpr2_vgpr3 = COPY killed renamable $agpr0_agpr1_agpr2_agpr3, implicit $exec
-  ; PEI-GFX908-NEXT:   GLOBAL_STORE_DWORDX4 undef renamable $vgpr0_vgpr1, killed renamable $vgpr0_vgpr1_vgpr2_vgpr3, 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PEI-GFX908-NEXT:   GLOBAL_STORE_DWORDX4 undef renamable $vgpr0_vgpr1, killed renamable $vgpr0_vgpr1_vgpr2_vgpr3, 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) poison`, addrspace 1)
   ; PEI-GFX908-NEXT:   renamable $sgpr0_sgpr1_sgpr2_sgpr3 = S_LOAD_DWORDX4_IMM killed renamable $sgpr4_sgpr5, 0, 0 :: (dereferenceable invariant load (s128) from %ir.arg.kernarg.offset1, addrspace 4)
   ; PEI-GFX908-NEXT:   renamable $agpr0_agpr1_agpr2_agpr3 = COPY killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, implicit $exec
   ; PEI-GFX908-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 1, implicit $exec
@@ -46,9 +46,9 @@ define amdgpu_kernel void @partial_copy(<4 x i32> %arg) #0 {
   ; PEI-GFX908-NEXT:   renamable $agpr0_agpr1_agpr2_agpr3 = V_MFMA_I32_4X4X4I8_e64 killed $vgpr0, killed $vgpr1, killed $agpr0_agpr1_agpr2_agpr3, 0, 0, 0, implicit $mode, implicit $exec
   ; PEI-GFX908-NEXT:   $vgpr0 = BUFFER_LOAD_DWORD_OFFSET $sgpr8_sgpr9_sgpr10_sgpr11, 0, 0, 0, 0, implicit $exec, implicit-def $vgpr0_vgpr1 :: (load (s32) from %stack.0, addrspace 5)
   ; PEI-GFX908-NEXT:   $vgpr1 = V_ACCVGPR_READ_B32_e64 $agpr4, implicit $exec, implicit $vgpr0_vgpr1
-  ; PEI-GFX908-NEXT:   GLOBAL_STORE_DWORDX2 undef renamable $vgpr0_vgpr1, killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec :: (volatile store (s64) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PEI-GFX908-NEXT:   GLOBAL_STORE_DWORDX2 undef renamable $vgpr0_vgpr1, killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec :: (volatile store (s64) into `ptr addrspace(1) poison`, addrspace 1)
   ; PEI-GFX908-NEXT:   renamable $vgpr0_vgpr1_vgpr2_vgpr3 = COPY killed renamable $agpr0_agpr1_agpr2_agpr3, implicit $exec
-  ; PEI-GFX908-NEXT:   GLOBAL_STORE_DWORDX4 undef renamable $vgpr0_vgpr1, killed renamable $vgpr0_vgpr1_vgpr2_vgpr3, 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PEI-GFX908-NEXT:   GLOBAL_STORE_DWORDX4 undef renamable $vgpr0_vgpr1, killed renamable $vgpr0_vgpr1_vgpr2_vgpr3, 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) poison`, addrspace 1)
   ; PEI-GFX908-NEXT:   S_ENDPGM 0
   ;
   ; REGALLOC-GFX90A-LABEL: name: partial_copy
@@ -58,14 +58,14 @@ define amdgpu_kernel void @partial_copy(<4 x i32> %arg) #0 {
   ; REGALLOC-GFX90A-NEXT:   INLINEASM &"; use $0", 1 /* sideeffect attdialect */, 2162697 /* reguse:AGPR_32 */, undef %5:agpr_32
   ; REGALLOC-GFX90A-NEXT:   INLINEASM &"; def $0", 1 /* sideeffect attdialect */, 6619146 /* regdef:VReg_128_Align2 */, def %6
   ; REGALLOC-GFX90A-NEXT:   INLINEASM &"; def $0", 1 /* sideeffect attdialect */, 3866634 /* regdef:VReg_64_Align2 */, def %7
-  ; REGALLOC-GFX90A-NEXT:   GLOBAL_STORE_DWORDX4 undef %14:vreg_64_align2, %6, 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) undef`, addrspace 1)
+  ; REGALLOC-GFX90A-NEXT:   GLOBAL_STORE_DWORDX4 undef %14:vreg_64_align2, %6, 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) poison`, addrspace 1)
   ; REGALLOC-GFX90A-NEXT:   renamable $sgpr0_sgpr1_sgpr2_sgpr3 = S_LOAD_DWORDX4_IMM killed renamable $sgpr4_sgpr5, 0, 0 :: (dereferenceable invariant load (s128) from %ir.arg.kernarg.offset1, addrspace 4)
   ; REGALLOC-GFX90A-NEXT:   [[COPY:%[0-9]+]]:areg_128_align2 = COPY killed renamable $sgpr0_sgpr1_sgpr2_sgpr3
   ; REGALLOC-GFX90A-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 1, implicit $exec
   ; REGALLOC-GFX90A-NEXT:   [[V_MOV_B32_e32_1:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 2, implicit $exec
   ; REGALLOC-GFX90A-NEXT:   [[V_MFMA_I32_4X4X4I8_e64_:%[0-9]+]]:areg_128_align2 = V_MFMA_I32_4X4X4I8_e64 [[V_MOV_B32_e32_]], [[V_MOV_B32_e32_1]], [[COPY]], 0, 0, 0, implicit $mode, implicit $exec
-  ; REGALLOC-GFX90A-NEXT:   GLOBAL_STORE_DWORDX2 undef %16:vreg_64_align2, %7, 0, 0, implicit $exec :: (volatile store (s64) into `ptr addrspace(1) undef`, addrspace 1)
-  ; REGALLOC-GFX90A-NEXT:   GLOBAL_STORE_DWORDX4 undef %18:vreg_64_align2, [[V_MFMA_I32_4X4X4I8_e64_]], 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) undef`, addrspace 1)
+  ; REGALLOC-GFX90A-NEXT:   GLOBAL_STORE_DWORDX2 undef %16:vreg_64_align2, %7, 0, 0, implicit $exec :: (volatile store (s64) into `ptr addrspace(1) poison`, addrspace 1)
+  ; REGALLOC-GFX90A-NEXT:   GLOBAL_STORE_DWORDX4 undef %18:vreg_64_align2, [[V_MFMA_I32_4X4X4I8_e64_]], 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) poison`, addrspace 1)
   ; REGALLOC-GFX90A-NEXT:   S_ENDPGM 0
   ;
   ; PEI-GFX90A-LABEL: name: partial_copy
@@ -81,7 +81,7 @@ define amdgpu_kernel void @partial_copy(<4 x i32> %arg) #0 {
   ; PEI-GFX90A-NEXT:   INLINEASM &"; def $0", 1 /* sideeffect attdialect */, 3866634 /* regdef:VReg_64_Align2 */, def renamable $vgpr0_vgpr1
   ; PEI-GFX90A-NEXT:   BUFFER_STORE_DWORD_OFFSET killed $vgpr0, $sgpr8_sgpr9_sgpr10_sgpr11, 0, 0, 0, 0, implicit $exec, implicit-def $vgpr0_vgpr1, implicit $vgpr0_vgpr1 :: (store (s32) into %stack.0, addrspace 5)
   ; PEI-GFX90A-NEXT:   $agpr4 = V_ACCVGPR_WRITE_B32_e64 killed $vgpr1, implicit $exec, implicit killed $vgpr0_vgpr1
-  ; PEI-GFX90A-NEXT:   GLOBAL_STORE_DWORDX4 undef renamable $vgpr0_vgpr1, killed renamable $agpr0_agpr1_agpr2_agpr3, 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PEI-GFX90A-NEXT:   GLOBAL_STORE_DWORDX4 undef renamable $vgpr0_vgpr1, killed renamable $agpr0_agpr1_agpr2_agpr3, 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) poison`, addrspace 1)
   ; PEI-GFX90A-NEXT:   renamable $sgpr0_sgpr1_sgpr2_sgpr3 = S_LOAD_DWORDX4_IMM killed renamable $sgpr4_sgpr5, 0, 0 :: (dereferenceable invariant load (s128) from %ir.arg.kernarg.offset1, addrspace 4)
   ; PEI-GFX90A-NEXT:   renamable $agpr0_agpr1_agpr2_agpr3 = COPY killed renamable $sgpr0_sgpr1_sgpr2_sgpr3, implicit $exec
   ; PEI-GFX90A-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 1, implicit $exec
@@ -89,16 +89,16 @@ define amdgpu_kernel void @partial_copy(<4 x i32> %arg) #0 {
   ; PEI-GFX90A-NEXT:   renamable $agpr0_agpr1_agpr2_agpr3 = V_MFMA_I32_4X4X4I8_e64 killed $vgpr0, killed $vgpr1, killed $agpr0_agpr1_agpr2_agpr3, 0, 0, 0, implicit $mode, implicit $exec
   ; PEI-GFX90A-NEXT:   $vgpr0 = BUFFER_LOAD_DWORD_OFFSET $sgpr8_sgpr9_sgpr10_sgpr11, 0, 0, 0, 0, implicit $exec, implicit-def $vgpr0_vgpr1 :: (load (s32) from %stack.0, addrspace 5)
   ; PEI-GFX90A-NEXT:   $vgpr1 = V_ACCVGPR_READ_B32_e64 $agpr4, implicit $exec, implicit $vgpr0_vgpr1
-  ; PEI-GFX90A-NEXT:   GLOBAL_STORE_DWORDX2 undef renamable $vgpr0_vgpr1, killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec :: (volatile store (s64) into `ptr addrspace(1) undef`, addrspace 1)
-  ; PEI-GFX90A-NEXT:   GLOBAL_STORE_DWORDX4 undef renamable $vgpr0_vgpr1, killed renamable $agpr0_agpr1_agpr2_agpr3, 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) undef`, addrspace 1)
+  ; PEI-GFX90A-NEXT:   GLOBAL_STORE_DWORDX2 undef renamable $vgpr0_vgpr1, killed renamable $vgpr0_vgpr1, 0, 0, implicit $exec :: (volatile store (s64) into `ptr addrspace(1) poison`, addrspace 1)
+  ; PEI-GFX90A-NEXT:   GLOBAL_STORE_DWORDX4 undef renamable $vgpr0_vgpr1, killed renamable $agpr0_agpr1_agpr2_agpr3, 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) poison`, addrspace 1)
   ; PEI-GFX90A-NEXT:   S_ENDPGM 0
   call void asm sideeffect "; use $0", "a" (i32 undef)
   %v0 = call <4 x i32> asm sideeffect "; def $0", "=v" ()
   %v1 = call <2 x i32> asm sideeffect "; def $0", "=v" ()
   %mai = tail call <4 x i32> @llvm.amdgcn.mfma.i32.4x4x4i8(i32 1, i32 2, <4 x i32> %arg, i32 0, i32 0, i32 0)
-  store volatile <4 x i32> %v0, ptr addrspace(1) undef
-  store volatile <2 x i32> %v1, ptr addrspace(1) undef
-  store volatile <4 x i32> %mai, ptr addrspace(1) undef
+  store volatile <4 x i32> %v0, ptr addrspace(1) poison
+  store volatile <2 x i32> %v1, ptr addrspace(1) poison
+  store volatile <4 x i32> %mai, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/partial-shift-shrink.ll
+++ b/llvm/test/CodeGen/AMDGPU/partial-shift-shrink.ll
@@ -107,7 +107,7 @@ define amdgpu_kernel void @s_trunc_srl_i64_16_to_i16(i64 %x) {
   %shift = lshr i64 %x, 16
   %trunc = trunc i64 %shift to i16
   %add = or i16 %trunc, 4
-  store i16 %add, ptr addrspace(1) undef
+  store i16 %add, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/permute_i8.ll
+++ b/llvm/test/CodeGen/AMDGPU/permute_i8.ll
@@ -2724,7 +2724,7 @@ entry:
   %ext1 = zext i16 %byte1 to i32
   %shifted = shl i32 %ext1, 16
   %result = or i32 %shifted, %ext0
-  store i32 %result, ptr addrspace(1) undef
+  store i32 %result, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-calling-conv.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-calling-conv.ll
@@ -40,7 +40,7 @@ entry:
   store i32 1, ptr addrspace(5) %tmp2
   %tmp3 = getelementptr [2 x i32], ptr addrspace(5) %tmp, i32 0, i32 %in
   %tmp4 = load i32, ptr addrspace(5) %tmp3
-  %tmp5 = load volatile i32, ptr addrspace(1) undef
+  %tmp5 = load volatile i32, ptr addrspace(1) poison
   %tmp6 = add i32 %tmp4, %tmp5
   store i32 %tmp6, ptr addrspace(1) %out
   ret void

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-strip-abi-opt-attributes.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-strip-abi-opt-attributes.ll
@@ -16,7 +16,7 @@ entry:
   store i32 1, ptr addrspace(5) %tmp2
   %tmp3 = getelementptr inbounds [2 x i32], ptr addrspace(5) %tmp, i32 0, i32 %in
   %tmp4 = load i32, ptr addrspace(5) %tmp3
-  %tmp5 = load volatile i32, ptr addrspace(1) undef
+  %tmp5 = load volatile i32, ptr addrspace(1) poison
   %tmp6 = add i32 %tmp4, %tmp5
   store i32 %tmp6, ptr addrspace(1) %out
   ret void

--- a/llvm/test/CodeGen/AMDGPU/promote-alloca-to-lds-constantexpr-use.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-alloca-to-lds-constantexpr-use.ll
@@ -32,7 +32,7 @@ entry:
   %load = load i32, ptr addrspace(5) %arrayidx, align 4
   store i32 %load, ptr addrspace(1) %out
 
-  store volatile i32 ptrtoint (ptr addrspace(3) @all_lds to i32), ptr addrspace(1) undef
+  store volatile i32 ptrtoint (ptr addrspace(3) @all_lds to i32), ptr addrspace(1) poison
   ret void
 }
 
@@ -57,7 +57,7 @@ entry:
   %arrayidx = getelementptr inbounds [4 x i32], ptr addrspace(5) %stack, i32 0, i32 %idx
   %load = load i32, ptr addrspace(5) %arrayidx, align 4
   store i32 %load, ptr addrspace(1) %out
-  store volatile i32 ptrtoint (ptr addrspace(3) @some_lds to i32), ptr addrspace(1) undef
+  store volatile i32 ptrtoint (ptr addrspace(3) @some_lds to i32), ptr addrspace(1) poison
   ret void
 }
 
@@ -175,7 +175,7 @@ entry:
   %load = load i32, ptr addrspace(5) %arrayidx, align 4
   store i32 %load, ptr addrspace(1) %out
 
-  store volatile i32 ptrtoint (ptr addrspace(1) @initializer_user_some to i32), ptr addrspace(1) undef
+  store volatile i32 ptrtoint (ptr addrspace(1) @initializer_user_some to i32), ptr addrspace(1) poison
   ret void
 }
 
@@ -200,7 +200,7 @@ entry:
   %arrayidx = getelementptr inbounds [4 x i32], ptr addrspace(5) %stack, i32 0, i32 %idx
   %load = load i32, ptr addrspace(5) %arrayidx, align 4
   store i32 %load, ptr addrspace(1) %out
-  store volatile i32 ptrtoint (ptr addrspace(1) @initializer_user_all to i32), ptr addrspace(1) undef
+  store volatile i32 ptrtoint (ptr addrspace(1) @initializer_user_all to i32), ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/promote-vect3-load.ll
+++ b/llvm/test/CodeGen/AMDGPU/promote-vect3-load.ll
@@ -13,7 +13,7 @@ define protected amdgpu_kernel void @load_v3i32_align4(ptr addrspace(1) %arg) #0
 ; GCN-NEXT:    s_load_dwordx2 s{{\[[0-9]:[0-9]+\]}}, s[0:1], 0x0
 ; GCN-NEXT:    s_load_dword s{{[0-9]+}}, s[0:1], 0x8
   %vec = load <3 x i32>, ptr addrspace(1) %arg, align 4
-  store <3 x i32> %vec, ptr addrspace(1) undef, align 4
+  store <3 x i32> %vec, ptr addrspace(1) poison, align 4
   ret void
 }
 
@@ -23,7 +23,7 @@ define protected amdgpu_kernel void @load_v3i32_align8(ptr addrspace(1) %arg) #0
 ; GCN:         s_waitcnt lgkmcnt(0)
 ; GCN-NEXT:    s_load_dwordx4 s{{\[[0-9]:[0-9]+\]}}, s[4:5], 0x0
   %vec = load <3 x i32>, ptr addrspace(1) %arg, align 8
-  store <3 x i32> %vec, ptr addrspace(1) undef, align 8
+  store <3 x i32> %vec, ptr addrspace(1) poison, align 8
   ret void
 }
 
@@ -33,7 +33,7 @@ define protected amdgpu_kernel void @load_v3i32_align16(ptr addrspace(1) %arg) #
 ; GCN:         s_waitcnt lgkmcnt(0)
 ; GCN-NEXT:    s_load_dwordx4 s{{\[[0-9]:[0-9]+\]}}, s[0:1], 0x0
   %vec = load <3 x i32>, ptr addrspace(1) %arg, align 16
-  store <3 x i32> %vec, ptr addrspace(1) undef, align 16
+  store <3 x i32> %vec, ptr addrspace(1) poison, align 16
   ret void
 }
 
@@ -44,7 +44,7 @@ define protected amdgpu_kernel void @load_v3f32_align4(ptr addrspace(1) %arg) #0
 ; GCN-NEXT:    s_load_dwordx2 s{{\[[0-9]:[0-9]+\]}}, s[0:1], 0x0
 ; GCN-NEXT:    s_load_dword s{{[0-9]+}}, s[0:1], 0x8
   %vec = load <3 x float>, ptr addrspace(1) %arg, align 4
-  store <3 x float> %vec, ptr addrspace(1) undef, align 4
+  store <3 x float> %vec, ptr addrspace(1) poison, align 4
   ret void
 }
 
@@ -54,7 +54,7 @@ define protected amdgpu_kernel void @load_v3f32_align8(ptr addrspace(1) %arg) #0
 ; GCN:         s_waitcnt lgkmcnt(0)
 ; GCN-NEXT:    s_load_dwordx4 s{{\[[0-9]:[0-9]+\]}}, s[4:5], 0x0
   %vec = load <3 x float>, ptr addrspace(1) %arg, align 8
-  store <3 x float> %vec, ptr addrspace(1) undef, align 8
+  store <3 x float> %vec, ptr addrspace(1) poison, align 8
   ret void
 }
 
@@ -64,7 +64,7 @@ define protected amdgpu_kernel void @load_v3f32_align16(ptr addrspace(1) %arg) #
 ; GCN:         s_waitcnt lgkmcnt(0)
 ; GCN-NEXT:    s_load_dwordx4 s{{\[[0-9]:[0-9]+\]}}, s[0:1], 0x0
   %vec = load <3 x float>, ptr addrspace(1) %arg, align 16
-  store <3 x float> %vec, ptr addrspace(1) undef, align 16
+  store <3 x float> %vec, ptr addrspace(1) poison, align 16
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/rcp-pattern.ll
+++ b/llvm/test/CodeGen/AMDGPU/rcp-pattern.ll
@@ -1288,7 +1288,7 @@ define amdgpu_kernel void @s_div_arcp_2_x_pat_f32_daz(ptr addrspace(1) %out) #0 
 ; CM-NEXT:     MUL_IEEE * T0.X, T0.X, 0.5,
 ; CM-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-  %x = load float, ptr addrspace(1) undef
+  %x = load float, ptr addrspace(1) poison
   %rcp = fdiv arcp float %x, 2.0
   store float %rcp, ptr addrspace(1) %out, align 4
   ret void
@@ -1345,7 +1345,7 @@ define amdgpu_kernel void @s_div_arcp_k_x_pat_f32_daz(ptr addrspace(1) %out) #0 
 ; CM-NEXT:    1036831949(1.000000e-01), 0(0.000000e+00)
 ; CM-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-  %x = load float, ptr addrspace(1) undef
+  %x = load float, ptr addrspace(1) poison
   %rcp = fdiv arcp float %x, 10.0
   store float %rcp, ptr addrspace(1) %out, align 4
   ret void
@@ -1402,7 +1402,7 @@ define amdgpu_kernel void @s_div_arcp_neg_k_x_pat_f32_daz(ptr addrspace(1) %out)
 ; CM-NEXT:    -1110651699(-1.000000e-01), 0(0.000000e+00)
 ; CM-NEXT:     LSHR * T1.X, KC0[2].Y, literal.x,
 ; CM-NEXT:    2(2.802597e-45), 0(0.000000e+00)
-  %x = load float, ptr addrspace(1) undef
+  %x = load float, ptr addrspace(1) poison
   %rcp = fdiv arcp float %x, -10.0
   store float %rcp, ptr addrspace(1) %out, align 4
   ret void

--- a/llvm/test/CodeGen/AMDGPU/recursion.ll
+++ b/llvm/test/CodeGen/AMDGPU/recursion.ll
@@ -10,7 +10,7 @@
 ; V5: .set recursive.has_recursion, 1
 define void @recursive() {
   call void @recursive()
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/ret_jump.ll
+++ b/llvm/test/CodeGen/AMDGPU/ret_jump.ll
@@ -102,7 +102,7 @@ unreachable.bb:                                           ; preds = %else
   unreachable
 
 ret.bb:                                          ; preds = %else, %main_body
-  store volatile i32 11, ptr addrspace(1) undef
+  store volatile i32 11, ptr addrspace(1) poison
   ret <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, float, float, float, float, float, float, float, float, float, float, float, float, float, float }> undef
 }
 

--- a/llvm/test/CodeGen/AMDGPU/returnaddress.ll
+++ b/llvm/test/CodeGen/AMDGPU/returnaddress.ll
@@ -73,10 +73,10 @@ declare void @callee()
 define void @multi_use() nounwind {
 entry:
   %ret0 = tail call ptr @llvm.returnaddress(i32 0)
-  store volatile ptr %ret0, ptr addrspace(1) undef
+  store volatile ptr %ret0, ptr addrspace(1) poison
   call void @callee()
   %ret1 = tail call ptr @llvm.returnaddress(i32 0)
-  store volatile ptr %ret1, ptr addrspace(1) undef
+  store volatile ptr %ret1, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/s-getpc-b64-remat.ll
+++ b/llvm/test/CodeGen/AMDGPU/s-getpc-b64-remat.ll
@@ -92,7 +92,7 @@ entry:
   %0 = tail call i64 @llvm.amdgcn.s.getpc()
   tail call void asm sideeffect "", "s"(i64 %0)
   tail call void asm sideeffect "", "~{s0},~{s1},~{s2},~{s3},~{s4},~{s5},~{s6},~{s7},~{s8},~{s9},~{s10},~{s11},~{s12},~{s13},~{s14},~{s15},~{s16},~{s17},~{s18},~{s19},~{s20},~{s21},~{s22},~{s23},~{s24},~{s25},~{s26},~{s27},~{s28},~{s29},~{s30},~{s31}"()
-  store i64 %0, ptr addrspace(1) undef
+  store i64 %0, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/sad.ll
+++ b/llvm/test/CodeGen/AMDGPU/sad.ll
@@ -397,9 +397,9 @@ define amdgpu_kernel void @v_sad_u32_i16_pat2(ptr addrspace(1) %out) {
 ; GCN-NEXT:    v_mov_b32_e32 v1, s1
 ; GCN-NEXT:    flat_store_short v[0:1], v2
 ; GCN-NEXT:    s_endpgm
-  %a = load volatile i16, ptr addrspace(1) undef
-  %b = load volatile i16, ptr addrspace(1) undef
-  %c = load volatile i16, ptr addrspace(1) undef
+  %a = load volatile i16, ptr addrspace(1) poison
+  %b = load volatile i16, ptr addrspace(1) poison
+  %c = load volatile i16, ptr addrspace(1) poison
   %icmp0 = icmp ugt i16 %a, %b
   %sub0 = sub i16 %a, %b
   %sub1 = sub i16 %b, %a
@@ -456,9 +456,9 @@ define amdgpu_kernel void @v_sad_u32_i8_pat2(ptr addrspace(1) %out) {
 ; GCN-NEXT:    v_mov_b32_e32 v1, s1
 ; GCN-NEXT:    flat_store_byte v[0:1], v2
 ; GCN-NEXT:    s_endpgm
-  %a = load volatile i8, ptr addrspace(1) undef
-  %b = load volatile i8, ptr addrspace(1) undef
-  %c = load volatile i8, ptr addrspace(1) undef
+  %a = load volatile i8, ptr addrspace(1) poison
+  %b = load volatile i8, ptr addrspace(1) poison
+  %c = load volatile i8, ptr addrspace(1) poison
   %icmp0 = icmp ugt i8 %a, %b
   %sub0 = sub i8 %a, %b
   %sub1 = sub i8 %b, %a

--- a/llvm/test/CodeGen/AMDGPU/salu-to-valu.ll
+++ b/llvm/test/CodeGen/AMDGPU/salu-to-valu.ll
@@ -474,7 +474,7 @@ bb2:
 
 bb4:
   %tmp5 = phi i32 [ %tmp3, %bb2 ], [ %tmp, %bb1 ]
-  store volatile i32 %tmp5, ptr addrspace(1) undef
+  store volatile i32 %tmp5, ptr addrspace(1) poison
   br label %bb1
 }
 

--- a/llvm/test/CodeGen/AMDGPU/scalar-branch-missing-and-exec.ll
+++ b/llvm/test/CodeGen/AMDGPU/scalar-branch-missing-and-exec.ll
@@ -22,10 +22,10 @@
 
 define amdgpu_cs void @main(i32 inreg %arg) {
 .entry:
-  %tmp44 = load volatile <2 x float>, ptr addrspace(1) undef
-  %tmp16 = load volatile float, ptr addrspace(1) undef
-  %tmp22 = load volatile float, ptr addrspace(1) undef
-  %tmp25 = load volatile float, ptr addrspace(1) undef
+  %tmp44 = load volatile <2 x float>, ptr addrspace(1) poison
+  %tmp16 = load volatile float, ptr addrspace(1) poison
+  %tmp22 = load volatile float, ptr addrspace(1) poison
+  %tmp25 = load volatile float, ptr addrspace(1) poison
   %tmp31 = fcmp olt float %tmp16, 0x3FA99999A0000000
   br i1 %tmp31, label %bb, label %.exit.thread
 
@@ -45,7 +45,7 @@ bb50:
   br i1 %tmp53, label %.exit3.i, label %.exit.thread
 
 .exit3.i:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %.exit.thread
 
 .exit.thread:

--- a/llvm/test/CodeGen/AMDGPU/scalar_to_vector.ll
+++ b/llvm/test/CodeGen/AMDGPU/scalar_to_vector.ll
@@ -191,10 +191,10 @@ define amdgpu_kernel void @scalar_to_vector_v4i16() {
 ; GFX9-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0
 ; GFX9-NEXT:    s_endpgm
 bb:
-  %tmp = load <2 x i8>, ptr addrspace(1) undef, align 1
+  %tmp = load <2 x i8>, ptr addrspace(1) poison, align 1
   %tmp1 = shufflevector <2 x i8> %tmp, <2 x i8> zeroinitializer, <8 x i32> <i32 0, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
   %tmp2 = shufflevector <8 x i8> %tmp1, <8 x i8> poison, <8 x i32> <i32 0, i32 9, i32 9, i32 9, i32 9, i32 9, i32 9, i32 9>
-  store <8 x i8> %tmp2, ptr addrspace(1) undef, align 8
+  store <8 x i8> %tmp2, ptr addrspace(1) poison, align 8
   ret void
 }
 
@@ -259,11 +259,11 @@ define amdgpu_kernel void @scalar_to_vector_v4f16() {
 ; GFX9-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0
 ; GFX9-NEXT:    s_endpgm
 bb:
-  %load = load half, ptr addrspace(1) undef, align 1
+  %load = load half, ptr addrspace(1) poison, align 1
   %tmp = bitcast half %load to <2 x i8>
   %tmp1 = shufflevector <2 x i8> %tmp, <2 x i8> zeroinitializer, <8 x i32> <i32 0, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>
   %tmp2 = shufflevector <8 x i8> %tmp1, <8 x i8> poison, <8 x i32> <i32 0, i32 9, i32 9, i32 9, i32 9, i32 9, i32 9, i32 9>
-  store <8 x i8> %tmp2, ptr addrspace(1) undef, align 8
+  store <8 x i8> %tmp2, ptr addrspace(1) poison, align 8
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/sdwa-peephole.ll
+++ b/llvm/test/CodeGen/AMDGPU/sdwa-peephole.ll
@@ -2093,7 +2093,7 @@ bb2:                                              ; preds = %bb1
 
 bb11:                                             ; preds = %bb10, %bb2
   %tmp12 = phi <2 x i32> [ %tmp6, %bb2 ], [ %tmp, %bb1 ]
-  store volatile <2 x i32> %tmp12, ptr addrspace(1) undef
+  store volatile <2 x i32> %tmp12, ptr addrspace(1) poison
   br label %bb1
 }
 

--- a/llvm/test/CodeGen/AMDGPU/select-fabs-fneg-extract-legacy.ll
+++ b/llvm/test/CodeGen/AMDGPU/select-fabs-fneg-extract-legacy.ll
@@ -11,13 +11,13 @@
 ; GCN: v_cndmask_b32_e32 [[SELECT:v[0-9]+]], 2.0, [[RCP]], vcc
 ; GCN-NEXT: buffer_store_dword [[SELECT]]
 define amdgpu_kernel void @select_fneg_posk_src_rcp_legacy_f32(i32 %c) #2 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %rcp = call float @llvm.amdgcn.rcp.legacy(float %x)
   %fneg = fsub float -0.0, %rcp
   %select = select i1 %cmp, float %fneg, float 2.0
-  store volatile float %select, ptr addrspace(1) undef
+  store volatile float %select, ptr addrspace(1) poison
   ret void
 }
 
@@ -28,12 +28,12 @@ define amdgpu_kernel void @select_fneg_posk_src_rcp_legacy_f32(i32 %c) #2 {
 ; GCN: v_cndmask_b32_e32 [[SELECT:v[0-9]+]], 2.0, [[MUL]], vcc
 ; GCN-NEXT: buffer_store_dword [[SELECT]]
 define amdgpu_kernel void @select_fneg_posk_src_mul_legacy_f32(i32 %c) #2 {
-  %x = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %mul = call float @llvm.amdgcn.fmul.legacy(float %x, float 4.0)
   %fneg = fsub float -0.0, %mul
   %select = select i1 %cmp, float %fneg, float 2.0
-  store volatile float %select, ptr addrspace(1) undef
+  store volatile float %select, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/select-fabs-fneg-extract.ll
+++ b/llvm/test/CodeGen/AMDGPU/select-fabs-fneg-extract.ll
@@ -9,15 +9,15 @@
 ; GCN: v_cndmask_b32_e32 [[SELECT:v[0-9]+]], [[Y]], [[X]], vcc
 ; GCN: v_add_f32_e64 v{{[0-9]+}}, |[[SELECT]]|, [[Z]]
 define amdgpu_kernel void @add_select_fabs_fabs_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fabs.y = call float @llvm.fabs.f32(float %y)
   %select = select i1 %cmp, float %fabs.x, float %fabs.y
   %add = fadd float %select, %z
-  store float %add, ptr addrspace(1) undef
+  store float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -31,18 +31,18 @@ define amdgpu_kernel void @add_select_fabs_fabs_f32(i32 %c) #0 {
 ; GCN-DAG: v_add_f32_e64 v{{[0-9]+}}, |[[SELECT]]|, [[Z]]
 ; GCN-DAG: v_add_f32_e64 v{{[0-9]+}}, |[[X]]|, [[W]]
 define amdgpu_kernel void @add_select_multi_use_lhs_fabs_fabs_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
-  %w = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
+  %w = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fabs.y = call float @llvm.fabs.f32(float %y)
   %select = select i1 %cmp, float %fabs.x, float %fabs.y
   %add0 = fadd float %select, %z
   %add1 = fadd float %fabs.x, %w
-  store volatile float %add0, ptr addrspace(1) undef
-  store volatile float %add1, ptr addrspace(1) undef
+  store volatile float %add0, ptr addrspace(1) poison
+  store volatile float %add1, ptr addrspace(1) poison
   ret void
 }
 
@@ -58,16 +58,16 @@ define amdgpu_kernel void @add_select_multi_use_lhs_fabs_fabs_f32(i32 %c) #0 {
 ; GCN: buffer_store_dword [[ADD]]
 ; GCN: buffer_store_dword [[X_ABS]]
 define amdgpu_kernel void @add_select_multi_store_use_lhs_fabs_fabs_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fabs.y = call float @llvm.fabs.f32(float %y)
   %select = select i1 %cmp, float %fabs.x, float %fabs.y
   %add0 = fadd float %select, %z
-  store volatile float %add0, ptr addrspace(1) undef
-  store volatile float %fabs.x, ptr addrspace(1) undef
+  store volatile float %add0, ptr addrspace(1) poison
+  store volatile float %fabs.x, ptr addrspace(1) poison
   ret void
 }
 
@@ -81,18 +81,18 @@ define amdgpu_kernel void @add_select_multi_store_use_lhs_fabs_fabs_f32(i32 %c) 
 ; GCN-DAG: v_add_f32_e64 v{{[0-9]+}}, |[[SELECT]]|, [[Z]]
 ; GCN-DAG: v_add_f32_e64 v{{[0-9]+}}, |[[Y]]|, [[W]]
 define amdgpu_kernel void @add_select_multi_use_rhs_fabs_fabs_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
-  %w = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
+  %w = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fabs.y = call float @llvm.fabs.f32(float %y)
   %select = select i1 %cmp, float %fabs.x, float %fabs.y
   %add0 = fadd float %select, %z
   %add1 = fadd float %fabs.y, %w
-  store volatile float %add0, ptr addrspace(1) undef
-  store volatile float %add1, ptr addrspace(1) undef
+  store volatile float %add0, ptr addrspace(1) poison
+  store volatile float %add1, ptr addrspace(1) poison
   ret void
 }
 
@@ -104,14 +104,14 @@ define amdgpu_kernel void @add_select_multi_use_rhs_fabs_fabs_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], [[Y]], |[[X]]|,
 ; GCN: v_add_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Z]]
 define amdgpu_kernel void @add_select_fabs_var_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %select = select i1 %cmp, float %fabs.x, float %y
   %add = fadd float %select, %z
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -122,13 +122,13 @@ define amdgpu_kernel void @add_select_fabs_var_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], -1.0, |[[X]]|,
 ; GCN: v_add_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Y]]
 define amdgpu_kernel void @add_select_fabs_negk_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs = call float @llvm.fabs.f32(float %x)
   %select = select i1 %cmp, float %fabs, float -1.0
   %add = fadd float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -139,12 +139,12 @@ define amdgpu_kernel void @add_select_fabs_negk_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], -1.0, -2.0, s
 ; GCN: v_add_f32_e64 v{{[0-9]+}}, |[[SELECT]]|, [[X]]
 define amdgpu_kernel void @add_select_fabs_negk_negk_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %select = select i1 %cmp, float -2.0, float -1.0
   %fabs = call float @llvm.fabs.f32(float %select)
   %add = fadd float %fabs, %x
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -154,11 +154,11 @@ define amdgpu_kernel void @add_select_fabs_negk_negk_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], 1.0, 2.0, s
 ; GCN: v_add_f32_e32 v{{[0-9]+}}, [[SELECT]], [[X]]
 define amdgpu_kernel void @add_select_posk_posk_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %select = select i1 %cmp, float 2.0, float 1.0
   %add = fadd float %select, %x
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -171,13 +171,13 @@ define amdgpu_kernel void @add_select_posk_posk_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], -1.0, |[[X]]|, [[VCC]]
 ; GCN: v_add_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Y]]
 define amdgpu_kernel void @add_select_negk_fabs_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs = call float @llvm.fabs.f32(float %x)
   %select = select i1 %cmp, float -1.0, float %fabs
   %add = fadd float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -191,13 +191,13 @@ define amdgpu_kernel void @add_select_negk_fabs_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], [[K]], |[[X]]|, [[VCC]]
 ; GCN: v_add_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Y]]
 define amdgpu_kernel void @add_select_negliteralk_fabs_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs = call float @llvm.fabs.f32(float %x)
   %select = select i1 %cmp, float -1024.0, float %fabs
   %add = fadd float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -208,14 +208,14 @@ define amdgpu_kernel void @add_select_negliteralk_fabs_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], 1.0, |[[X]]|, s{{\[[0-9]+:[0-9]+\]}}
 ; GCN: v_add_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Y]]
 define amdgpu_kernel void @add_select_fabs_posk_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
 
   %cmp = icmp eq i32 %c, 0
   %fabs = call float @llvm.fabs.f32(float %x)
   %select = select i1 %cmp, float %fabs, float 1.0
   %add = fadd float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -228,13 +228,13 @@ define amdgpu_kernel void @add_select_fabs_posk_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], 1.0, |[[X]]|, s{{\[[0-9]+:[0-9]+\]}}
 ; GCN: v_add_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Y]]
 define amdgpu_kernel void @add_select_posk_fabs_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs = call float @llvm.fabs.f32(float %x)
   %select = select i1 %cmp, float 1.0, float %fabs
   %add = fadd float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -246,15 +246,15 @@ define amdgpu_kernel void @add_select_posk_fabs_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e32 [[SELECT:v[0-9]+]], [[Y]], [[X]], vcc
 ; GCN: v_sub_f32_e32 v{{[0-9]+}}, [[Z]], [[SELECT]]
 define amdgpu_kernel void @add_select_fneg_fneg_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fneg.x = fsub float -0.0, %x
   %fneg.y = fsub float -0.0, %y
   %select = select i1 %cmp, float %fneg.x, float %fneg.y
   %add = fadd float %select, %z
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -268,18 +268,18 @@ define amdgpu_kernel void @add_select_fneg_fneg_f32(i32 %c) #0 {
 ; GCN-DAG: v_sub_f32_e32 v{{[0-9]+}}, [[Z]], [[SELECT]]
 ; GCN-DAG: v_sub_f32_e32 v{{[0-9]+}}, [[W]], [[X]]
 define amdgpu_kernel void @add_select_multi_use_lhs_fneg_fneg_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
-  %w = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
+  %w = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fneg.x = fsub float -0.0, %x
   %fneg.y = fsub float -0.0, %y
   %select = select i1 %cmp, float %fneg.x, float %fneg.y
   %add0 = fadd float %select, %z
   %add1 = fadd float %fneg.x, %w
-  store volatile float %add0, ptr addrspace(1) undef
-  store volatile float %add1, ptr addrspace(1) undef
+  store volatile float %add0, ptr addrspace(1) poison
+  store volatile float %add1, ptr addrspace(1) poison
   ret void
 }
 
@@ -295,16 +295,16 @@ define amdgpu_kernel void @add_select_multi_use_lhs_fneg_fneg_f32(i32 %c) #0 {
 ; GCN: buffer_store_dword [[ADD]]
 ; GCN: buffer_store_dword [[NEG_X]]
 define amdgpu_kernel void @add_select_multi_store_use_lhs_fneg_fneg_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fneg.x = fsub float -0.0, %x
   %fneg.y = fsub float -0.0, %y
   %select = select i1 %cmp, float %fneg.x, float %fneg.y
   %add0 = fadd float %select, %z
-  store volatile float %add0, ptr addrspace(1) undef
-  store volatile float %fneg.x, ptr addrspace(1) undef
+  store volatile float %add0, ptr addrspace(1) poison
+  store volatile float %fneg.x, ptr addrspace(1) poison
   ret void
 }
 
@@ -318,18 +318,18 @@ define amdgpu_kernel void @add_select_multi_store_use_lhs_fneg_fneg_f32(i32 %c) 
 ; GCN-DAG: v_sub_f32_e32 v{{[0-9]+}}, [[Z]], [[SELECT]]
 ; GCN-DAG: v_sub_f32_e32 v{{[0-9]+}}, [[W]], [[Y]]
 define amdgpu_kernel void @add_select_multi_use_rhs_fneg_fneg_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
-  %w = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
+  %w = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fneg.x = fsub float -0.0, %x
   %fneg.y = fsub float -0.0, %y
   %select = select i1 %cmp, float %fneg.x, float %fneg.y
   %add0 = fadd float %select, %z
   %add1 = fadd float %fneg.y, %w
-  store volatile float %add0, ptr addrspace(1) undef
-  store volatile float %add1, ptr addrspace(1) undef
+  store volatile float %add0, ptr addrspace(1) poison
+  store volatile float %add1, ptr addrspace(1) poison
   ret void
 }
 
@@ -341,14 +341,14 @@ define amdgpu_kernel void @add_select_multi_use_rhs_fneg_fneg_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], [[Y]], -[[X]],
 ; GCN: v_add_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Z]]
 define amdgpu_kernel void @add_select_fneg_var_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fneg.x = fsub float -0.0, %x
   %select = select i1 %cmp, float %fneg.x, float %y
   %add = fadd float %select, %z
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -359,13 +359,13 @@ define amdgpu_kernel void @add_select_fneg_var_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e32 [[SELECT:v[0-9]+]], 1.0, [[X]], vcc
 ; GCN: v_sub_f32_e32 v{{[0-9]+}}, [[Y]], [[SELECT]]
 define amdgpu_kernel void @add_select_fneg_negk_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fneg.x = fsub float -0.0, %x
   %select = select i1 %cmp, float %fneg.x, float -1.0
   %add = fadd float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -377,13 +377,13 @@ define amdgpu_kernel void @add_select_fneg_negk_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e32 [[SELECT:v[0-9]+]], [[K]], [[X]], vcc
 ; GCN: v_sub_f32_e32 v{{[0-9]+}}, [[Y]], [[SELECT]]
 define amdgpu_kernel void @add_select_fneg_inv2pi_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fneg.x = fneg float %x
   %select = select i1 %cmp, float %fneg.x, float 0x3FC45F3060000000
   %add = fadd float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -397,13 +397,13 @@ define amdgpu_kernel void @add_select_fneg_inv2pi_f32(i32 %c) #0 {
 
 ; GCN: v_sub_f32_e32 v{{[0-9]+}},  [[Y]], [[SELECT]]
 define amdgpu_kernel void @add_select_fneg_neginv2pi_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fneg.x = fneg float %x
   %select = select i1 %cmp, float %fneg.x, float 0xBFC45F3060000000
   %add = fadd float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -414,11 +414,11 @@ define amdgpu_kernel void @add_select_fneg_neginv2pi_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], -1.0, -2.0, s
 ; GCN: v_add_f32_e32 v{{[0-9]+}}, [[SELECT]], [[X]]
 define amdgpu_kernel void @add_select_negk_negk_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %select = select i1 %cmp, float -2.0, float -1.0
   %add = fadd float %select, %x
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -431,11 +431,11 @@ define amdgpu_kernel void @add_select_negk_negk_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e32 [[SELECT:v[0-9]+]], [[K1]], [[K0]], vcc
 ; GCN: v_add_f32_e32 v{{[0-9]+}}, [[SELECT]], [[X]]
 define amdgpu_kernel void @add_select_negliteralk_negliteralk_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %select = select i1 %cmp, float -2048.0, float -4096.0
   %add = fadd float %select, %x
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -445,12 +445,12 @@ define amdgpu_kernel void @add_select_negliteralk_negliteralk_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], 1.0, 2.0, s
 ; GCN: v_add_f32_e32 v{{[0-9]+}}, [[SELECT]], [[X]]
 define amdgpu_kernel void @add_select_fneg_negk_negk_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %select = select i1 %cmp, float -2.0, float -1.0
   %fneg.x = fsub float -0.0, %select
   %add = fadd float %fneg.x, %x
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -463,13 +463,13 @@ define amdgpu_kernel void @add_select_fneg_negk_negk_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e32 [[SELECT:v[0-9]+]], 1.0, [[X]], vcc
 ; GCN: v_sub_f32_e32 v{{[0-9]+}}, [[Y]], [[SELECT]]
 define amdgpu_kernel void @add_select_negk_fneg_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fneg.x = fsub float -0.0, %x
   %select = select i1 %cmp, float -1.0, float %fneg.x
   %add = fadd float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -480,13 +480,13 @@ define amdgpu_kernel void @add_select_negk_fneg_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e32 [[SELECT:v[0-9]+]], -1.0, [[X]], vcc
 ; GCN: v_sub_f32_e32 v{{[0-9]+}}, [[Y]], [[SELECT]]
 define amdgpu_kernel void @add_select_fneg_posk_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fneg.x = fsub float -0.0, %x
   %select = select i1 %cmp, float %fneg.x, float 1.0
   %add = fadd float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -499,13 +499,13 @@ define amdgpu_kernel void @add_select_fneg_posk_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e32 [[SELECT:v[0-9]+]], -1.0, [[X]], vcc
 ; GCN: v_sub_f32_e32 v{{[0-9]+}}, [[Y]], [[SELECT]]
 define amdgpu_kernel void @add_select_posk_fneg_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fneg.x = fsub float -0.0, %x
   %select = select i1 %cmp, float 1.0, float %fneg.x
   %add = fadd float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -517,16 +517,16 @@ define amdgpu_kernel void @add_select_posk_fneg_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], |[[Y]]|, -|[[X]]|,
 ; GCN: v_add_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Z]]
 define amdgpu_kernel void @add_select_negfabs_fabs_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fneg.fabs.x = fsub float -0.000000e+00, %fabs.x
   %fabs.y = call float @llvm.fabs.f32(float %y)
   %select = select i1 %cmp, float %fneg.fabs.x, float %fabs.y
   %add = fadd float %select, %z
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -538,16 +538,16 @@ define amdgpu_kernel void @add_select_negfabs_fabs_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], -|[[Y]]|, |[[X]]|,
 ; GCN: v_add_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Z]]
 define amdgpu_kernel void @add_select_fabs_negfabs_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fabs.y = call float @llvm.fabs.f32(float %y)
   %fneg.fabs.y = fsub float -0.000000e+00, %fabs.y
   %select = select i1 %cmp, float %fabs.x, float %fneg.fabs.y
   %add = fadd float %select, %z
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -559,15 +559,15 @@ define amdgpu_kernel void @add_select_fabs_negfabs_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], |[[Y]]|, -[[X]],
 ; GCN: v_add_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Z]]
 define amdgpu_kernel void @add_select_neg_fabs_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fneg.x = fsub float -0.000000e+00, %x
   %fabs.y = call float @llvm.fabs.f32(float %y)
   %select = select i1 %cmp, float %fneg.x, float %fabs.y
   %add = fadd float %select, %z
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -579,15 +579,15 @@ define amdgpu_kernel void @add_select_neg_fabs_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], -[[Y]], |[[X]]|,
 ; GCN: v_add_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Z]]
 define amdgpu_kernel void @add_select_fabs_neg_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fneg.y = fsub float -0.000000e+00, %y
   %select = select i1 %cmp, float %fabs.x, float %fneg.y
   %add = fadd float %select, %z
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -599,16 +599,16 @@ define amdgpu_kernel void @add_select_fabs_neg_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], |[[Y]]|, [[X]],
 ; GCN: v_sub_f32_e32 v{{[0-9]+}}, [[Z]], [[SELECT]]
 define amdgpu_kernel void @add_select_neg_negfabs_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fneg.x = fsub float -0.000000e+00, %x
   %fabs.y = call float @llvm.fabs.f32(float %y)
   %fneg.fabs.y = fsub float -0.000000e+00, %fabs.y
   %select = select i1 %cmp, float %fneg.x, float %fneg.fabs.y
   %add = fadd float %select, %z
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -620,16 +620,16 @@ define amdgpu_kernel void @add_select_neg_negfabs_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], |[[X]]|, [[Y]],
 ; GCN: v_sub_f32_e32 v{{[0-9]+}}, [[Z]], [[SELECT]]
 define amdgpu_kernel void @add_select_negfabs_neg_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fneg.fabs.x = fsub float -0.000000e+00, %fabs.x
   %fneg.y = fsub float -0.000000e+00, %y
   %select = select i1 %cmp, float %fneg.y, float %fneg.fabs.x
   %add = fadd float %select, %z
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -642,14 +642,14 @@ define amdgpu_kernel void @add_select_negfabs_neg_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], 4.0, -|[[X]]|, [[VCC]]
 ; GCN: v_mul_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Y]]
 define amdgpu_kernel void @mul_select_negfabs_posk_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fneg.fabs.x = fsub float -0.000000e+00, %fabs.x
   %select = select i1 %cmp, float %fneg.fabs.x, float 4.0
   %add = fmul float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -662,14 +662,14 @@ define amdgpu_kernel void @mul_select_negfabs_posk_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], 4.0, -|[[X]]|, [[VCC]]
 ; GCN: v_mul_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Y]]
 define amdgpu_kernel void @mul_select_posk_negfabs_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fneg.fabs.x = fsub float -0.000000e+00, %fabs.x
   %select = select i1 %cmp, float 4.0, float %fneg.fabs.x
   %add = fmul float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -680,14 +680,14 @@ define amdgpu_kernel void @mul_select_posk_negfabs_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], -4.0, -|[[X]]|, s{{\[[0-9]+:[0-9]+\]}}
 ; GCN: v_mul_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Y]]
 define amdgpu_kernel void @mul_select_negfabs_negk_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fneg.fabs.x = fsub float -0.000000e+00, %fabs.x
   %select = select i1 %cmp, float %fneg.fabs.x, float -4.0
   %add = fmul float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -700,14 +700,14 @@ define amdgpu_kernel void @mul_select_negfabs_negk_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], -4.0, -|[[X]]|, [[VCC]]
 ; GCN: v_mul_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Y]]
 define amdgpu_kernel void @mul_select_negk_negfabs_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fneg.fabs.x = fsub float -0.000000e+00, %fabs.x
   %select = select i1 %cmp, float -4.0, float %fneg.fabs.x
   %add = fmul float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -723,13 +723,13 @@ define amdgpu_kernel void @mul_select_negk_negfabs_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e32 [[SELECT:v[0-9]+]], 2.0, [[ADD]], vcc
 ; GCN-NEXT: buffer_store_dword [[SELECT]]
 define amdgpu_kernel void @select_fneg_posk_src_add_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %add = fadd float %x, 4.0
   %fneg = fsub float -0.0, %add
   %select = select i1 %cmp, float %fneg, float 2.0
-  store volatile float %select, ptr addrspace(1) undef
+  store volatile float %select, ptr addrspace(1) poison
   ret void
 }
 
@@ -740,12 +740,12 @@ define amdgpu_kernel void @select_fneg_posk_src_add_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e32 [[SELECT:v[0-9]+]], 2.0, [[ADD]], vcc
 ; GCN-NEXT: buffer_store_dword [[SELECT]]
 define amdgpu_kernel void @select_fneg_posk_src_sub_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %add = fsub float %x, 4.0
   %fneg = fsub float -0.0, %add
   %select = select i1 %cmp, float %fneg, float 2.0
-  store volatile float %select, ptr addrspace(1) undef
+  store volatile float %select, ptr addrspace(1) poison
   ret void
 }
 
@@ -756,12 +756,12 @@ define amdgpu_kernel void @select_fneg_posk_src_sub_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e32 [[SELECT:v[0-9]+]], 2.0, [[MUL]], vcc
 ; GCN-NEXT: buffer_store_dword [[SELECT]]
 define amdgpu_kernel void @select_fneg_posk_src_mul_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %mul = fmul float %x, 4.0
   %fneg = fsub float -0.0, %mul
   %select = select i1 %cmp, float %fneg, float 2.0
-  store volatile float %select, ptr addrspace(1) undef
+  store volatile float %select, ptr addrspace(1) poison
   ret void
 }
 
@@ -773,13 +773,13 @@ define amdgpu_kernel void @select_fneg_posk_src_mul_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e32 [[SELECT:v[0-9]+]], 2.0, [[FMA]], vcc
 ; GCN-NEXT: buffer_store_dword [[SELECT]]
 define amdgpu_kernel void @select_fneg_posk_src_fma_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fma = call float @llvm.fma.f32(float %x, float 4.0, float %z)
   %fneg = fsub float -0.0, %fma
   %select = select i1 %cmp, float %fneg, float 2.0
-  store volatile float %select, ptr addrspace(1) undef
+  store volatile float %select, ptr addrspace(1) poison
   ret void
 }
 
@@ -790,13 +790,13 @@ define amdgpu_kernel void @select_fneg_posk_src_fma_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e32 [[SELECT:v[0-9]+]], 2.0, [[X]], vcc
 ; GCN-NEXT: buffer_store_dword [[SELECT]]
 define amdgpu_kernel void @select_fneg_posk_src_fmad_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %z = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %z = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fmad = call float @llvm.fmuladd.f32(float %x, float 4.0, float %z)
   %fneg = fsub float -0.0, %fmad
   %select = select i1 %cmp, float %fneg, float 2.0
-  store volatile float %select, ptr addrspace(1) undef
+  store volatile float %select, ptr addrspace(1) poison
   ret void
 }
 
@@ -808,13 +808,13 @@ define amdgpu_kernel void @select_fneg_posk_src_fmad_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e32 [[SELECT:v[0-9]+]], 2.0, [[RCP]], vcc
 ; GCN-NEXT: buffer_store_dword [[SELECT]]
 define amdgpu_kernel void @select_fneg_posk_src_rcp_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %rcp = call float @llvm.amdgcn.rcp.f32(float %x)
   %fneg = fsub float -0.0, %rcp
   %select = select i1 %cmp, float %fneg, float 2.0
-  store volatile float %select, ptr addrspace(1) undef
+  store volatile float %select, ptr addrspace(1) poison
   ret void
 }
 
@@ -832,14 +832,14 @@ define amdgpu_kernel void @select_fneg_posk_src_rcp_f32(i32 %c) #0 {
 ; VI: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], 0.15915494, -|[[X]]|, [[VCC]]
 ; VI: v_mul_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Y]]
 define amdgpu_kernel void @mul_select_negfabs_posk_inv2pi_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fneg.fabs.x = fneg float %fabs.x
   %select = select i1 %cmp, float %fneg.fabs.x, float 0x3FC45F3060000000
   %add = fmul float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -859,14 +859,14 @@ define amdgpu_kernel void @mul_select_negfabs_posk_inv2pi_f32(i32 %c) #0 {
 ; VI: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], 0.15915494, -|[[X]]|, [[VCC]]
 ; VI: v_mul_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Y]]
 define amdgpu_kernel void @mul_select_posk_inv2pi_negfabs_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fneg.fabs.x = fneg float %fabs.x
   %select = select i1 %cmp, float 0x3FC45F3060000000, float %fneg.fabs.x
   %add = fmul float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -877,14 +877,14 @@ define amdgpu_kernel void @mul_select_posk_inv2pi_negfabs_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], [[K]], -|[[X]]|, s
 ; GCN: v_mul_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Y]]
 define amdgpu_kernel void @mul_select_negfabs_negk_inv2pi_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fneg.fabs.x = fneg float %fabs.x
   %select = select i1 %cmp, float %fneg.fabs.x, float 0xBFC45F3060000000
   %add = fmul float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -898,14 +898,14 @@ define amdgpu_kernel void @mul_select_negfabs_negk_inv2pi_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], [[K]], -|[[X]]|, s[0:1]
 ; GCN: v_mul_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Y]]
 define amdgpu_kernel void @mul_select_negk_inv2pi_negfabs_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fneg.fabs.x = fneg float %fabs.x
   %select = select i1 %cmp, float 0xBFC45F3060000000, float %fneg.fabs.x
   %add = fmul float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -917,14 +917,14 @@ define amdgpu_kernel void @mul_select_negk_inv2pi_negfabs_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], 0, -|[[X]]|, [[VCC]]
 ; GCN: v_mul_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Y]]
 define amdgpu_kernel void @mul_select_negfabs_posk_0_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fneg.fabs.x = fneg float %fabs.x
   %select = select i1 %cmp, float %fneg.fabs.x, float 0.0
   %add = fmul float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -938,14 +938,14 @@ define amdgpu_kernel void @mul_select_negfabs_posk_0_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], 0, -|[[X]]|, [[VCC]]
 ; GCN: v_mul_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Y]]
 define amdgpu_kernel void @mul_select_posk_0_negfabs_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fneg.fabs.x = fneg float %fabs.x
   %select = select i1 %cmp, float 0.0, float %fneg.fabs.x
   %add = fmul float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -957,14 +957,14 @@ define amdgpu_kernel void @mul_select_posk_0_negfabs_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], [[NEG0]], -|[[X]]|, s{{\[[0-9]+:[0-9]+\]}}
 ; GCN: v_mul_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Y]]
 define amdgpu_kernel void @mul_select_negfabs_negk_0_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fneg.fabs.x = fneg float %fabs.x
   %select = select i1 %cmp, float %fneg.fabs.x, float -0.0
   %add = fmul float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 
@@ -978,14 +978,14 @@ define amdgpu_kernel void @mul_select_negfabs_negk_0_f32(i32 %c) #0 {
 ; GCN: v_cndmask_b32_e64 [[SELECT:v[0-9]+]], [[NEG0]], -|[[X]]|, s[0:1]
 ; GCN: v_mul_f32_e32 v{{[0-9]+}}, [[SELECT]], [[Y]]
 define amdgpu_kernel void @mul_select_negk_0_negfabs_f32(i32 %c) #0 {
-  %x = load volatile float, ptr addrspace(1) undef
-  %y = load volatile float, ptr addrspace(1) undef
+  %x = load volatile float, ptr addrspace(1) poison
+  %y = load volatile float, ptr addrspace(1) poison
   %cmp = icmp eq i32 %c, 0
   %fabs.x = call float @llvm.fabs.f32(float %x)
   %fneg.fabs.x = fneg float %fabs.x
   %select = select i1 %cmp, float -0.0, float %fneg.fabs.x
   %add = fmul float %select, %y
-  store volatile float %add, ptr addrspace(1) undef
+  store volatile float %add, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/select-undef.ll
+++ b/llvm/test/CodeGen/AMDGPU/select-undef.ll
@@ -255,7 +255,7 @@ define void @inf_loop_undef_vector(<6 x float> %arg, float %arg1, i64 %arg2) {
   %i5 = extractelement <3 x i64> %i3, i64 1
   %i6 = mul i64 %i5, %arg2
   %i7 = add i64 %i6, %i4
-  store volatile i64 %i7, ptr addrspace(1) undef, align 4
+  store volatile i64 %i7, ptr addrspace(1) poison, align 4
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/setcc-fneg-constant.ll
+++ b/llvm/test/CodeGen/AMDGPU/setcc-fneg-constant.ll
@@ -11,17 +11,17 @@
 ; GCN: v_cmp_eq_f32_e32 vcc, -4.0, [[MUL]]
 ; GCN: buffer_store_dword [[MUL]]
 define amdgpu_kernel void @multi_use_fneg_src() #0 {
-  %a = load volatile float, ptr addrspace(1) undef
-  %b = load volatile float, ptr addrspace(1) undef
-  %x = load volatile i32, ptr addrspace(1) undef
-  %y = load volatile i32, ptr addrspace(1) undef
+  %a = load volatile float, ptr addrspace(1) poison
+  %b = load volatile float, ptr addrspace(1) poison
+  %x = load volatile i32, ptr addrspace(1) poison
+  %y = load volatile i32, ptr addrspace(1) poison
 
   %mul = fmul float %a, %b
   %neg.mul = fsub float -0.0, %mul
   %cmp = fcmp oeq float %neg.mul, 4.0
   %select = select i1 %cmp, i32 %x, i32 %y
-  store volatile i32 %select, ptr addrspace(1) undef
-  store volatile float %mul, ptr addrspace(1) undef
+  store volatile i32 %select, ptr addrspace(1) poison
+  store volatile float %mul, ptr addrspace(1) poison
   ret void
 }
 
@@ -34,10 +34,10 @@ define amdgpu_kernel void @multi_use_fneg_src() #0 {
 ; GCN: v_cmp_eq_f32_e32 vcc, -4.0, [[A]]
 ; GCN: v_mul_f32_e64 [[USE1:v[0-9]+]], [[MUL]], -[[MUL]]
 define amdgpu_kernel void @multi_foldable_use_fneg_src() #0 {
-  %a = load volatile float, ptr addrspace(1) undef
-  %b = load volatile float, ptr addrspace(1) undef
-  %x = load volatile i32, ptr addrspace(1) undef
-  %y = load volatile i32, ptr addrspace(1) undef
+  %a = load volatile float, ptr addrspace(1) poison
+  %b = load volatile float, ptr addrspace(1) poison
+  %x = load volatile i32, ptr addrspace(1) poison
+  %y = load volatile i32, ptr addrspace(1) poison
 
   %mul = fmul float %a, %b
   %neg.mul = fsub float -0.0, %mul
@@ -45,8 +45,8 @@ define amdgpu_kernel void @multi_foldable_use_fneg_src() #0 {
   %cmp = fcmp oeq float %neg.mul, 4.0
   %select = select i1 %cmp, i32 %x, i32 %y
 
-  store volatile i32 %select, ptr addrspace(1) undef
-  store volatile float %use1, ptr addrspace(1) undef
+  store volatile i32 %select, ptr addrspace(1) poison
+  store volatile float %use1, ptr addrspace(1) poison
   ret void
 }
 
@@ -60,17 +60,17 @@ define amdgpu_kernel void @multi_foldable_use_fneg_src() #0 {
 ; GCN-NOT: xor
 ; GCN: buffer_store_dword [[MUL]]
 define amdgpu_kernel void @multi_use_fneg() #0 {
-  %a = load volatile float, ptr addrspace(1) undef
-  %b = load volatile float, ptr addrspace(1) undef
-  %x = load volatile i32, ptr addrspace(1) undef
-  %y = load volatile i32, ptr addrspace(1) undef
+  %a = load volatile float, ptr addrspace(1) poison
+  %b = load volatile float, ptr addrspace(1) poison
+  %x = load volatile i32, ptr addrspace(1) poison
+  %y = load volatile i32, ptr addrspace(1) poison
 
   %mul = fmul float %a, %b
   %neg.mul = fsub float -0.0, %mul
   %cmp = fcmp oeq float %neg.mul, 4.0
   %select = select i1 %cmp, i32 %x, i32 %y
-  store volatile i32 %select, ptr addrspace(1) undef
-  store volatile float %neg.mul, ptr addrspace(1) undef
+  store volatile i32 %select, ptr addrspace(1) poison
+  store volatile float %neg.mul, ptr addrspace(1) poison
   ret void
 }
 
@@ -83,175 +83,175 @@ define amdgpu_kernel void @multi_use_fneg() #0 {
 ; GCN: v_mul_f32_e64 [[MUL1:v[0-9]+]], -[[MUL0]], [[MUL0]]
 ; GCN: buffer_store_dword [[MUL1]]
 define amdgpu_kernel void @multi_foldable_use_fneg() #0 {
-  %a = load volatile float, ptr addrspace(1) undef
-  %b = load volatile float, ptr addrspace(1) undef
-  %x = load volatile i32, ptr addrspace(1) undef
-  %y = load volatile i32, ptr addrspace(1) undef
-  %z = load volatile i32, ptr addrspace(1) undef
+  %a = load volatile float, ptr addrspace(1) poison
+  %b = load volatile float, ptr addrspace(1) poison
+  %x = load volatile i32, ptr addrspace(1) poison
+  %y = load volatile i32, ptr addrspace(1) poison
+  %z = load volatile i32, ptr addrspace(1) poison
 
   %mul = fmul float %a, %b
   %neg.mul = fsub float -0.0, %mul
   %cmp = fcmp oeq float %neg.mul, 4.0
   %select = select i1 %cmp, i32 %x, i32 %y
   %use1 = fmul float %neg.mul, %mul
-  store volatile i32 %select, ptr addrspace(1) undef
-  store volatile float %use1, ptr addrspace(1) undef
+  store volatile i32 %select, ptr addrspace(1) poison
+  store volatile float %use1, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_setcc_fneg_oeq_posk_f32:
 ; GCN: v_cmp_eq_f32_e32 vcc, -4.0, v{{[0-9]+}}
 define amdgpu_kernel void @test_setcc_fneg_oeq_posk_f32() #0 {
-  %a = load volatile float, ptr addrspace(1) undef
-  %x = load volatile i32, ptr addrspace(1) undef
-  %y = load volatile i32, ptr addrspace(1) undef
+  %a = load volatile float, ptr addrspace(1) poison
+  %x = load volatile i32, ptr addrspace(1) poison
+  %y = load volatile i32, ptr addrspace(1) poison
   %neg.a = fsub float -0.0, %a
   %cmp = fcmp oeq float %neg.a, 4.0
   %select = select i1 %cmp, i32 %x, i32 %y
-  store volatile i32 %select, ptr addrspace(1) undef
+  store volatile i32 %select, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_setcc_fneg_ogt_posk_f32:
 ; GCN: v_cmp_gt_f32_e32 vcc, -4.0, v{{[0-9]+}}
 define amdgpu_kernel void @test_setcc_fneg_ogt_posk_f32() #0 {
-  %a = load volatile float, ptr addrspace(1) undef
-  %x = load volatile i32, ptr addrspace(1) undef
-  %y = load volatile i32, ptr addrspace(1) undef
+  %a = load volatile float, ptr addrspace(1) poison
+  %x = load volatile i32, ptr addrspace(1) poison
+  %y = load volatile i32, ptr addrspace(1) poison
   %neg.a = fsub float -0.0, %a
   %cmp = fcmp ogt float %neg.a, 4.0
   %select = select i1 %cmp, i32 %x, i32 %y
-  store volatile i32 %select, ptr addrspace(1) undef
+  store volatile i32 %select, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_setcc_fneg_oge_posk_f32:
 ; GCN: v_cmp_ge_f32_e32 vcc, -4.0, v{{[0-9]+}}
 define amdgpu_kernel void @test_setcc_fneg_oge_posk_f32() #0 {
-  %a = load volatile float, ptr addrspace(1) undef
-  %x = load volatile i32, ptr addrspace(1) undef
-  %y = load volatile i32, ptr addrspace(1) undef
+  %a = load volatile float, ptr addrspace(1) poison
+  %x = load volatile i32, ptr addrspace(1) poison
+  %y = load volatile i32, ptr addrspace(1) poison
   %neg.a = fsub float -0.0, %a
   %cmp = fcmp oge float %neg.a, 4.0
   %select = select i1 %cmp, i32 %x, i32 %y
-  store volatile i32 %select, ptr addrspace(1) undef
+  store volatile i32 %select, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_setcc_fneg_olt_posk_f32:
 ; GCN: v_cmp_lt_f32_e32 vcc, -4.0, v{{[0-9]+}}
 define amdgpu_kernel void @test_setcc_fneg_olt_posk_f32() #0 {
-  %a = load volatile float, ptr addrspace(1) undef
-  %x = load volatile i32, ptr addrspace(1) undef
-  %y = load volatile i32, ptr addrspace(1) undef
+  %a = load volatile float, ptr addrspace(1) poison
+  %x = load volatile i32, ptr addrspace(1) poison
+  %y = load volatile i32, ptr addrspace(1) poison
   %neg.a = fsub float -0.0, %a
   %cmp = fcmp olt float %neg.a, 4.0
   %select = select i1 %cmp, i32 %x, i32 %y
-  store volatile i32 %select, ptr addrspace(1) undef
+  store volatile i32 %select, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_setcc_fneg_ole_posk_f32:
 ; GCN: v_cmp_le_f32_e32 vcc, -4.0, v{{[0-9]+}}
 define amdgpu_kernel void @test_setcc_fneg_ole_posk_f32() #0 {
-  %a = load volatile float, ptr addrspace(1) undef
-  %x = load volatile i32, ptr addrspace(1) undef
-  %y = load volatile i32, ptr addrspace(1) undef
+  %a = load volatile float, ptr addrspace(1) poison
+  %x = load volatile i32, ptr addrspace(1) poison
+  %y = load volatile i32, ptr addrspace(1) poison
   %neg.a = fsub float -0.0, %a
   %cmp = fcmp ole float %neg.a, 4.0
   %select = select i1 %cmp, i32 %x, i32 %y
-  store volatile i32 %select, ptr addrspace(1) undef
+  store volatile i32 %select, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_setcc_fneg_one_posk_f32:
 ; GCN: v_cmp_lg_f32_e32 vcc, -4.0, v{{[0-9]+}}
 define amdgpu_kernel void @test_setcc_fneg_one_posk_f32() #0 {
-  %a = load volatile float, ptr addrspace(1) undef
-  %x = load volatile i32, ptr addrspace(1) undef
-  %y = load volatile i32, ptr addrspace(1) undef
+  %a = load volatile float, ptr addrspace(1) poison
+  %x = load volatile i32, ptr addrspace(1) poison
+  %y = load volatile i32, ptr addrspace(1) poison
   %neg.a = fsub float -0.0, %a
   %cmp = fcmp one float %neg.a, 4.0
   %select = select i1 %cmp, i32 %x, i32 %y
-  store volatile i32 %select, ptr addrspace(1) undef
+  store volatile i32 %select, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_setcc_fneg_ueq_posk_f32:
 ; GCN: v_cmp_nlg_f32_e32 vcc, -4.0, v{{[0-9]+}}
 define amdgpu_kernel void @test_setcc_fneg_ueq_posk_f32() #0 {
-  %a = load volatile float, ptr addrspace(1) undef
-  %x = load volatile i32, ptr addrspace(1) undef
-  %y = load volatile i32, ptr addrspace(1) undef
+  %a = load volatile float, ptr addrspace(1) poison
+  %x = load volatile i32, ptr addrspace(1) poison
+  %y = load volatile i32, ptr addrspace(1) poison
   %neg.a = fsub float -0.0, %a
   %cmp = fcmp ueq float %neg.a, 4.0
   %select = select i1 %cmp, i32 %x, i32 %y
-  store volatile i32 %select, ptr addrspace(1) undef
+  store volatile i32 %select, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_setcc_fneg_ugt_posk_f32:
 ; GCN: v_cmp_nle_f32_e32 vcc, -4.0, v{{[0-9]+}}
 define amdgpu_kernel void @test_setcc_fneg_ugt_posk_f32() #0 {
-  %a = load volatile float, ptr addrspace(1) undef
-  %x = load volatile i32, ptr addrspace(1) undef
-  %y = load volatile i32, ptr addrspace(1) undef
+  %a = load volatile float, ptr addrspace(1) poison
+  %x = load volatile i32, ptr addrspace(1) poison
+  %y = load volatile i32, ptr addrspace(1) poison
   %neg.a = fsub float -0.0, %a
   %cmp = fcmp ugt float %neg.a, 4.0
   %select = select i1 %cmp, i32 %x, i32 %y
-  store volatile i32 %select, ptr addrspace(1) undef
+  store volatile i32 %select, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_setcc_fneg_uge_posk_f32:
 ; GCN: v_cmp_nlt_f32_e32 vcc, -4.0, v{{[0-9]+}}
 define amdgpu_kernel void @test_setcc_fneg_uge_posk_f32() #0 {
-  %a = load volatile float, ptr addrspace(1) undef
-  %x = load volatile i32, ptr addrspace(1) undef
-  %y = load volatile i32, ptr addrspace(1) undef
+  %a = load volatile float, ptr addrspace(1) poison
+  %x = load volatile i32, ptr addrspace(1) poison
+  %y = load volatile i32, ptr addrspace(1) poison
   %neg.a = fsub float -0.0, %a
   %cmp = fcmp uge float %neg.a, 4.0
   %select = select i1 %cmp, i32 %x, i32 %y
-  store volatile i32 %select, ptr addrspace(1) undef
+  store volatile i32 %select, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_setcc_fneg_ult_posk_f32:
 ; GCN: v_cmp_nge_f32_e32 vcc, -4.0, v{{[0-9]+}}
 define amdgpu_kernel void @test_setcc_fneg_ult_posk_f32() #0 {
-  %a = load volatile float, ptr addrspace(1) undef
-  %x = load volatile i32, ptr addrspace(1) undef
-  %y = load volatile i32, ptr addrspace(1) undef
+  %a = load volatile float, ptr addrspace(1) poison
+  %x = load volatile i32, ptr addrspace(1) poison
+  %y = load volatile i32, ptr addrspace(1) poison
   %neg.a = fsub float -0.0, %a
   %cmp = fcmp ult float %neg.a, 4.0
   %select = select i1 %cmp, i32 %x, i32 %y
-  store volatile i32 %select, ptr addrspace(1) undef
+  store volatile i32 %select, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_setcc_fneg_ule_posk_f32:
 ; GCN: v_cmp_ngt_f32_e32 vcc, -4.0, v{{[0-9]+}}
 define amdgpu_kernel void @test_setcc_fneg_ule_posk_f32() #0 {
-  %a = load volatile float, ptr addrspace(1) undef
-  %x = load volatile i32, ptr addrspace(1) undef
-  %y = load volatile i32, ptr addrspace(1) undef
+  %a = load volatile float, ptr addrspace(1) poison
+  %x = load volatile i32, ptr addrspace(1) poison
+  %y = load volatile i32, ptr addrspace(1) poison
   %neg.a = fsub float -0.0, %a
   %cmp = fcmp ule float %neg.a, 4.0
   %select = select i1 %cmp, i32 %x, i32 %y
-  store volatile i32 %select, ptr addrspace(1) undef
+  store volatile i32 %select, ptr addrspace(1) poison
   ret void
 }
 
 ; GCN-LABEL: {{^}}test_setcc_fneg_une_posk_f32:
 ; GCN: v_cmp_neq_f32_e32 vcc, -4.0, v{{[0-9]+}}
 define amdgpu_kernel void @test_setcc_fneg_une_posk_f32() #0 {
-  %a = load volatile float, ptr addrspace(1) undef
-  %x = load volatile i32, ptr addrspace(1) undef
-  %y = load volatile i32, ptr addrspace(1) undef
+  %a = load volatile float, ptr addrspace(1) poison
+  %x = load volatile i32, ptr addrspace(1) poison
+  %y = load volatile i32, ptr addrspace(1) poison
   %neg.a = fsub float -0.0, %a
   %cmp = fcmp une float %neg.a, 4.0
   %select = select i1 %cmp, i32 %x, i32 %y
-  store volatile i32 %select, ptr addrspace(1) undef
+  store volatile i32 %select, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/setcc-opt.ll
+++ b/llvm/test/CodeGen/AMDGPU/setcc-opt.ll
@@ -190,7 +190,7 @@ define amdgpu_kernel void @cmp_sext_k_neg1(ptr addrspace(1) %out, ptr addrspace(
 define void @v_cmp_sext_k_neg1_i8_sext_arg(i8 signext %b) nounwind {
   %b.ext = sext i8 %b to i32
   %icmp0 = icmp ne i32 %b.ext, -1
-  store i1 %icmp0, ptr addrspace(1) undef
+  store i1 %icmp0, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/shl.ll
+++ b/llvm/test/CodeGen/AMDGPU/shl.ll
@@ -2084,7 +2084,7 @@ define amdgpu_kernel void @test_mul2(i32 %p) {
 ; EG-NEXT:     LSHL * T1.X, KC0[2].Y, 1,
 ; EG-NEXT:    0(0.000000e+00), 0(0.000000e+00)
    %i = mul i32 %p, 2
-   store volatile i32 %i, ptr addrspace(1) undef
+   store volatile i32 %i, ptr addrspace(1) poison
    ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/si-annotate-cf-noloop.ll
+++ b/llvm/test/CodeGen/AMDGPU/si-annotate-cf-noloop.ll
@@ -53,7 +53,7 @@ bb1:                                              ; preds = %bb
   %tmp3 = getelementptr inbounds <4 x float>, ptr addrspace(1) %arg, i64 %tmp2
   %tmp4 = load <4 x float>, ptr addrspace(1) %tmp3, align 16
   %tmp5 = extractelement <4 x float> %tmp4, i32 1
-  store volatile <4 x float> %tmp4, ptr addrspace(1) undef
+  store volatile <4 x float> %tmp4, ptr addrspace(1) poison
   %cmp = fcmp ogt float %tmp5, 1.0
   br i1 %cmp, label %bb5, label %bb3
 

--- a/llvm/test/CodeGen/AMDGPU/si-annotate-cf.ll
+++ b/llvm/test/CodeGen/AMDGPU/si-annotate-cf.ll
@@ -208,7 +208,7 @@ entry:
   br label %while.cond.outer
 
 while.cond.outer:
-  %tmp = load float, ptr addrspace(1) undef
+  %tmp = load float, ptr addrspace(1) poison
   br label %while.cond
 
 while.cond:
@@ -225,7 +225,7 @@ if.end:
   br i1 %cmp2, label %if.else, label %while.cond.outer
 
 if.else:
-  store volatile i32 3, ptr addrspace(1) undef, align 4
+  store volatile i32 3, ptr addrspace(1) poison, align 4
   br label %while.cond
 
 for.cond:

--- a/llvm/test/CodeGen/AMDGPU/si-triv-disjoint-mem-access.ll
+++ b/llvm/test/CodeGen/AMDGPU/si-triv-disjoint-mem-access.ll
@@ -5,7 +5,7 @@
 @stored_lds_struct = addrspace(3) global %struct.lds undef, align 16
 @stored_lds_ptr = addrspace(3) global ptr addrspace(3) undef, align 4
 @stored_constant_ptr = addrspace(3) global ptr addrspace(4) undef, align 8
-@stored_global_ptr = addrspace(3) global ptr addrspace(1) undef, align 8
+@stored_global_ptr = addrspace(3) global ptr addrspace(1) poison, align 8
 
 ; GCN-LABEL: {{^}}no_reorder_flat_load_local_store_local_load:
 ; GCN: flat_load_dwordx4

--- a/llvm/test/CodeGen/AMDGPU/skip-if-dead.ll
+++ b/llvm/test/CodeGen/AMDGPU/skip-if-dead.ll
@@ -745,13 +745,13 @@ bb:
   %cmp.var = fcmp olt float %var, 0.0
   ; TODO: We could do an early-exit here (the branch above is uniform!)
   call void @llvm.amdgcn.kill(i1 %cmp.var)
-  store volatile float %live.across, ptr addrspace(1) undef
+  store volatile float %live.across, ptr addrspace(1) poison
   %live.out = call float asm sideeffect "v_mov_b32_e64 v9, -2", "={v9}"()
   br label %exit
 
 exit:
   %phi = phi float [ 0.0, %entry ], [ %live.out, %bb ]
-  store float %phi, ptr addrspace(1) undef
+  store float %phi, ptr addrspace(1) poison
   ret void
 }
 
@@ -1124,12 +1124,12 @@ bb:
     v_nop_e64", "={v7}"()
   %cmp.var = fcmp olt float %var, 0.0
   call void @llvm.amdgcn.kill(i1 %cmp.var)
-  %vgpr = load volatile i32, ptr addrspace(1) undef
+  %vgpr = load volatile i32, ptr addrspace(1) poison
   %loop.cond = icmp eq i32 %vgpr, 0
   br i1 %loop.cond, label %bb, label %exit
 
 exit:
-  store volatile i32 8, ptr addrspace(1) undef
+  store volatile i32 8, ptr addrspace(1) poison
   ret void
 }
 
@@ -1273,11 +1273,11 @@ phibb:
   br i1 %tmp6, label %bb10, label %end
 
 bb8:
-  store volatile i32 8, ptr addrspace(1) undef
+  store volatile i32 8, ptr addrspace(1) poison
   br label %phibb
 
 bb10:
-  store volatile i32 9, ptr addrspace(1) undef
+  store volatile i32 9, ptr addrspace(1) poison
   br label %end
 
 end:
@@ -1538,7 +1538,7 @@ bb4:                                              ; preds = %bb3, %bb
   br i1 %tmp7, label %bb8, label %bb9
 
 bb8:                                              ; preds = %bb9, %bb4
-  store volatile i32 9, ptr addrspace(1) undef
+  store volatile i32 9, ptr addrspace(1) poison
   ret void
 
 bb9:                                              ; preds = %bb4

--- a/llvm/test/CodeGen/AMDGPU/sminmax.ll
+++ b/llvm/test/CodeGen/AMDGPU/sminmax.ll
@@ -264,7 +264,7 @@ define amdgpu_kernel void @v_min_max_i32_user(ptr addrspace(1) %out0, ptr addrsp
 
   store volatile i32 %sel0, ptr addrspace(1) %out0, align 4
   store volatile i32 %sel1, ptr addrspace(1) %out1, align 4
-  store volatile i1 %cond0, ptr addrspace(1) undef
+  store volatile i1 %cond0, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/sminmax.v2i16.ll
+++ b/llvm/test/CodeGen/AMDGPU/sminmax.v2i16.ll
@@ -995,7 +995,7 @@ define amdgpu_kernel void @v_min_max_v2i16_user(ptr addrspace(1) %out0, ptr addr
 
   store volatile <2 x i16> %sel0, ptr addrspace(1) %out0, align 4
   store volatile <2 x i16> %sel1, ptr addrspace(1) %out1, align 4
-  store volatile <2 x i1> %cond0, ptr addrspace(1) undef
+  store volatile <2 x i1> %cond0, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/smrd.ll
+++ b/llvm/test/CodeGen/AMDGPU/smrd.ll
@@ -487,7 +487,7 @@ ret_block:                                       ; preds = %.outer, %.label22, %
 .inner_loop_body:
   %descriptor = load <4 x i32>, ptr addrspace(4) %0, align 16, !invariant.load !0
   %load1result = call float @llvm.amdgcn.s.buffer.load.f32(<4 x i32> %descriptor, i32 0, i32 0)
-  store float %load1result, ptr addrspace(1) undef
+  store float %load1result, ptr addrspace(1) poison
   %inner_br2 = icmp uge i32 %1, 10
   br i1 %inner_br2, label %.inner_loop_header, label %.outer_loop_body
 

--- a/llvm/test/CodeGen/AMDGPU/spill-agpr.ll
+++ b/llvm/test/CodeGen/AMDGPU/spill-agpr.ll
@@ -111,7 +111,7 @@ define amdgpu_kernel void @max_6regs_used_8a(ptr addrspace(1) %arg) #4 {
   %mai.in = load <4 x float>, ptr addrspace(1) %gep
   %mai.out = tail call <4 x float> @llvm.amdgcn.mfma.f32.4x4x1f32(float 1.0, float 1.0, <4 x float> %mai.in, i32 0, i32 0, i32 0)
   store <4 x float> %mai.out, ptr addrspace(1) %gep
-  store volatile <4 x float> %a4, ptr addrspace(1) undef
+  store volatile <4 x float> %a4, ptr addrspace(1) poison
   call void asm sideeffect "; use $0", "v"(float %v0);
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/spill-m0.ll
+++ b/llvm/test/CodeGen/AMDGPU/spill-m0.ll
@@ -114,11 +114,11 @@ main_body:
    br i1 %cmp, label %if, label %else
 
 if:                                               ; preds = %main_body
-  store volatile i32 8, ptr addrspace(1) undef
+  store volatile i32 8, ptr addrspace(1) poison
   br label %endif
 
 else:                                             ; preds = %main_body
-  store volatile i32 11, ptr addrspace(1) undef
+  store volatile i32 11, ptr addrspace(1) poison
   br label %endif
 
 endif:

--- a/llvm/test/CodeGen/AMDGPU/spill-vector-superclass.ll
+++ b/llvm/test/CodeGen/AMDGPU/spill-vector-superclass.ll
@@ -14,13 +14,13 @@ define amdgpu_kernel void @test_spill_av_class(<4 x i32> %arg) #0 {
   ; GCN-NEXT:   [[V_MFMA_I32_4X4X4I8_e64_:%[0-9]+]]:areg_128 = V_MFMA_I32_4X4X4I8_e64 [[V_MOV_B32_e32_]], [[V_MOV_B32_e32_1]], [[COPY]], 0, 0, 0, implicit $mode, implicit $exec
   ; GCN-NEXT:   INLINEASM &"; def $0", 1 /* sideeffect attdialect */, 2228234 /* regdef:VGPR_32 */, def undef %13.sub0
   ; GCN-NEXT:   [[COPY1:%[0-9]+]]:vreg_128 = COPY [[V_MFMA_I32_4X4X4I8_e64_]]
-  ; GCN-NEXT:   GLOBAL_STORE_DWORDX4 undef %23:vreg_64, [[COPY1]], 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   GLOBAL_STORE_DWORDX4 undef %23:vreg_64, [[COPY1]], 0, 0, implicit $exec :: (volatile store (s128) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   INLINEASM &"; use $0", 1 /* sideeffect attdialect */, 3538953 /* reguse:VReg_64 */, %13
   ; GCN-NEXT:   S_ENDPGM 0
   %v0 = call i32 asm sideeffect "; def $0", "=v"()
   %tmp = insertelement <2 x i32> poison, i32 %v0, i32 0
   %mai = tail call <4 x i32> @llvm.amdgcn.mfma.i32.4x4x4i8(i32 1, i32 2, <4 x i32> %arg, i32 0, i32 0, i32 0)
-  store volatile <4 x i32> %mai, ptr addrspace(1) undef
+  store volatile <4 x i32> %mai, ptr addrspace(1) poison
   call void asm sideeffect "; use $0", "v"(<2 x i32> %tmp);
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/spill-vgpr-to-agpr.ll
+++ b/llvm/test/CodeGen/AMDGPU/spill-vgpr-to-agpr.ll
@@ -15,7 +15,7 @@
 ; GFX908: VGPRBlocks: 2
 ; GFX908: NumVGPRsForWavesPerEU: 10
 define amdgpu_kernel void @max_11_vgprs_used_9a(ptr addrspace(1) %p) #0 {
-  %tid = load volatile i32, ptr addrspace(1) undef
+  %tid = load volatile i32, ptr addrspace(1) poison
   call void asm sideeffect "", "a,a,a,a,a,a,a,a,a"(i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9)
   %p1 = getelementptr inbounds i32, ptr addrspace(1) %p, i32 %tid
   %p2 = getelementptr inbounds i32, ptr addrspace(1) %p1, i32 4
@@ -38,16 +38,16 @@ define amdgpu_kernel void @max_11_vgprs_used_9a(ptr addrspace(1) %p) #0 {
   %v9 = load volatile i32, ptr addrspace(1) %p9
   %v10 = load volatile i32, ptr addrspace(1) %p10
   call void asm sideeffect "", "v,v,v,v,v,v,v,v,v,v"(i32 %v1, i32 %v2, i32 %v3, i32 %v4, i32 %v5, i32 %v6, i32 %v7, i32 %v8, i32 %v9, i32 %v10)
-  store volatile i32 %v1, ptr addrspace(1) undef
-  store volatile i32 %v2, ptr addrspace(1) undef
-  store volatile i32 %v3, ptr addrspace(1) undef
-  store volatile i32 %v4, ptr addrspace(1) undef
-  store volatile i32 %v5, ptr addrspace(1) undef
-  store volatile i32 %v6, ptr addrspace(1) undef
-  store volatile i32 %v7, ptr addrspace(1) undef
-  store volatile i32 %v8, ptr addrspace(1) undef
-  store volatile i32 %v9, ptr addrspace(1) undef
-  store volatile i32 %v10, ptr addrspace(1) undef
+  store volatile i32 %v1, ptr addrspace(1) poison
+  store volatile i32 %v2, ptr addrspace(1) poison
+  store volatile i32 %v3, ptr addrspace(1) poison
+  store volatile i32 %v4, ptr addrspace(1) poison
+  store volatile i32 %v5, ptr addrspace(1) poison
+  store volatile i32 %v6, ptr addrspace(1) poison
+  store volatile i32 %v7, ptr addrspace(1) poison
+  store volatile i32 %v8, ptr addrspace(1) poison
+  store volatile i32 %v9, ptr addrspace(1) poison
+  store volatile i32 %v10, ptr addrspace(1) poison
   ret void
 }
 
@@ -84,7 +84,7 @@ define amdgpu_kernel void @max_11_vgprs_used_9a(ptr addrspace(1) %p) #0 {
 ; GFX908: VGPRBlocks: 2
 ; GFX908: NumVGPRsForWavesPerEU: 11
 define amdgpu_kernel void @max_11_vgprs_used_1a_partial_spill(ptr addrspace(1) %p) #0 {
-  %tid = load volatile i32, ptr addrspace(1) undef
+  %tid = load volatile i32, ptr addrspace(1) poison
   call void asm sideeffect "", "a"(i32 1)
   %p1 = getelementptr inbounds i64, ptr addrspace(1) %p, i32 %tid
   %p2 = getelementptr inbounds i64, ptr addrspace(1) %p1, i32 8

--- a/llvm/test/CodeGen/AMDGPU/spill-vgpr.ll
+++ b/llvm/test/CodeGen/AMDGPU/spill-vgpr.ll
@@ -18,7 +18,7 @@
 ; GFX900: NumVGPRsForWavesPerEU: 11
 ; GFX908: NumVGPRsForWavesPerEU: 10
 define amdgpu_kernel void @max_11_vgprs(ptr addrspace(1) %p) #2 {
-  %tid = load volatile i32, ptr addrspace(1) undef
+  %tid = load volatile i32, ptr addrspace(1) poison
   %p1 = getelementptr inbounds i32, ptr addrspace(1) %p, i32 %tid
   %p2 = getelementptr inbounds i32, ptr addrspace(1) %p1, i32 4
   %p3 = getelementptr inbounds i32, ptr addrspace(1) %p2, i32 8
@@ -40,16 +40,16 @@ define amdgpu_kernel void @max_11_vgprs(ptr addrspace(1) %p) #2 {
   %v9 = load volatile i32, ptr addrspace(1) %p9
   %v10 = load volatile i32, ptr addrspace(1) %p10
   call void asm sideeffect "", "v,v,v,v,v,v,v,v,v,v"(i32 %v1, i32 %v2, i32 %v3, i32 %v4, i32 %v5, i32 %v6, i32 %v7, i32 %v8, i32 %v9, i32 %v10)
-  store volatile i32 %v1, ptr addrspace(1) undef
-  store volatile i32 %v2, ptr addrspace(1) undef
-  store volatile i32 %v3, ptr addrspace(1) undef
-  store volatile i32 %v4, ptr addrspace(1) undef
-  store volatile i32 %v5, ptr addrspace(1) undef
-  store volatile i32 %v6, ptr addrspace(1) undef
-  store volatile i32 %v7, ptr addrspace(1) undef
-  store volatile i32 %v8, ptr addrspace(1) undef
-  store volatile i32 %v9, ptr addrspace(1) undef
-  store volatile i32 %v10, ptr addrspace(1) undef
+  store volatile i32 %v1, ptr addrspace(1) poison
+  store volatile i32 %v2, ptr addrspace(1) poison
+  store volatile i32 %v3, ptr addrspace(1) poison
+  store volatile i32 %v4, ptr addrspace(1) poison
+  store volatile i32 %v5, ptr addrspace(1) poison
+  store volatile i32 %v6, ptr addrspace(1) poison
+  store volatile i32 %v7, ptr addrspace(1) poison
+  store volatile i32 %v8, ptr addrspace(1) poison
+  store volatile i32 %v9, ptr addrspace(1) poison
+  store volatile i32 %v10, ptr addrspace(1) poison
   ret void
 }
 
@@ -70,7 +70,7 @@ define amdgpu_kernel void @max_10_vgprs_spill_v32(ptr addrspace(1) %p) #0 {
   %tid = call i32 @llvm.amdgcn.workitem.id.x()
   %gep = getelementptr inbounds <32 x float>, ptr addrspace(1) %p, i32 %tid
   %v = load volatile <32 x float>, ptr addrspace(1) %gep
-  store volatile <32 x float> %v, ptr addrspace(1) undef
+  store volatile <32 x float> %v, ptr addrspace(1) poison
   ret void
 }
 
@@ -112,15 +112,15 @@ define amdgpu_kernel void @max_256_vgprs_spill_9x32(ptr addrspace(1) %p) #1 {
   %v7 = load volatile <32 x float>, ptr addrspace(1) %p7
   %v8 = load volatile <32 x float>, ptr addrspace(1) %p8
   %v9 = load volatile <32 x float>, ptr addrspace(1) %p9
-  store volatile <32 x float> %v1, ptr addrspace(1) undef
-  store volatile <32 x float> %v2, ptr addrspace(1) undef
-  store volatile <32 x float> %v3, ptr addrspace(1) undef
-  store volatile <32 x float> %v4, ptr addrspace(1) undef
-  store volatile <32 x float> %v5, ptr addrspace(1) undef
-  store volatile <32 x float> %v6, ptr addrspace(1) undef
-  store volatile <32 x float> %v7, ptr addrspace(1) undef
-  store volatile <32 x float> %v8, ptr addrspace(1) undef
-  store volatile <32 x float> %v9, ptr addrspace(1) undef
+  store volatile <32 x float> %v1, ptr addrspace(1) poison
+  store volatile <32 x float> %v2, ptr addrspace(1) poison
+  store volatile <32 x float> %v3, ptr addrspace(1) poison
+  store volatile <32 x float> %v4, ptr addrspace(1) poison
+  store volatile <32 x float> %v5, ptr addrspace(1) poison
+  store volatile <32 x float> %v6, ptr addrspace(1) poison
+  store volatile <32 x float> %v7, ptr addrspace(1) poison
+  store volatile <32 x float> %v8, ptr addrspace(1) poison
+  store volatile <32 x float> %v9, ptr addrspace(1) poison
   ret void
 }
 
@@ -166,15 +166,15 @@ define amdgpu_kernel void @max_256_vgprs_spill_9x32_2bb(ptr addrspace(1) %p) #1 
   br label %st
 
 st:
-  store volatile <32 x float> %v1, ptr addrspace(1) undef
-  store volatile <32 x float> %v2, ptr addrspace(1) undef
-  store volatile <32 x float> %v3, ptr addrspace(1) undef
-  store volatile <32 x float> %v4, ptr addrspace(1) undef
-  store volatile <32 x float> %v5, ptr addrspace(1) undef
-  store volatile <32 x float> %v6, ptr addrspace(1) undef
-  store volatile <32 x float> %v7, ptr addrspace(1) undef
-  store volatile <32 x float> %v8, ptr addrspace(1) undef
-  store volatile <32 x float> %v9, ptr addrspace(1) undef
+  store volatile <32 x float> %v1, ptr addrspace(1) poison
+  store volatile <32 x float> %v2, ptr addrspace(1) poison
+  store volatile <32 x float> %v3, ptr addrspace(1) poison
+  store volatile <32 x float> %v4, ptr addrspace(1) poison
+  store volatile <32 x float> %v5, ptr addrspace(1) poison
+  store volatile <32 x float> %v6, ptr addrspace(1) poison
+  store volatile <32 x float> %v7, ptr addrspace(1) poison
+  store volatile <32 x float> %v8, ptr addrspace(1) poison
+  store volatile <32 x float> %v9, ptr addrspace(1) poison
   ret void
 }
 
@@ -204,15 +204,15 @@ define void @stack_args_vgpr_spill(<32 x float> %arg0, <32 x float> %arg1, ptr a
   br label %st
 
 st:
-  store volatile <32 x float> %arg0, ptr addrspace(1) undef
-  store volatile <32 x float> %arg1, ptr addrspace(1) undef
-  store volatile <32 x float> %v1, ptr addrspace(1) undef
-  store volatile <32 x float> %v2, ptr addrspace(1) undef
-  store volatile <32 x float> %v3, ptr addrspace(1) undef
-  store volatile <32 x float> %v4, ptr addrspace(1) undef
-  store volatile <32 x float> %v5, ptr addrspace(1) undef
-  store volatile <32 x float> %v6, ptr addrspace(1) undef
-  store volatile <32 x float> %v7, ptr addrspace(1) undef
+  store volatile <32 x float> %arg0, ptr addrspace(1) poison
+  store volatile <32 x float> %arg1, ptr addrspace(1) poison
+  store volatile <32 x float> %v1, ptr addrspace(1) poison
+  store volatile <32 x float> %v2, ptr addrspace(1) poison
+  store volatile <32 x float> %v3, ptr addrspace(1) poison
+  store volatile <32 x float> %v4, ptr addrspace(1) poison
+  store volatile <32 x float> %v5, ptr addrspace(1) poison
+  store volatile <32 x float> %v6, ptr addrspace(1) poison
+  store volatile <32 x float> %v7, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/sram-ecc-default.ll
+++ b/llvm/test/CodeGen/AMDGPU/sram-ecc-default.ll
@@ -19,6 +19,6 @@ entry:
   %load = load i16, ptr addrspace(1) %gep
   %build0 = insertelement <2 x i16> poison, i16 %reg, i32 0
   %build1 = insertelement <2 x i16> %build0, i16 %load, i32 1
-  store <2 x i16> %build1, ptr addrspace(1) undef
+  store <2 x i16> %build1, ptr addrspace(1) poison
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/subreg-eliminate-dead.ll
+++ b/llvm/test/CodeGen/AMDGPU/subreg-eliminate-dead.ll
@@ -12,7 +12,7 @@ define amdgpu_kernel void @foobar() {
   %v5 = icmp ne i32 %v4, 0
   %v6 = select i1 %v5, i32 undef, i32 0
   %v15 = insertelement <2 x i32> poison, i32 %v6, i32 1
-  store <2 x i32> %v15, ptr addrspace(1) undef, align 8
+  store <2 x i32> %v15, ptr addrspace(1) poison, align 8
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/transform-block-with-return-to-epilog.ll
+++ b/llvm/test/CodeGen/AMDGPU/transform-block-with-return-to-epilog.ll
@@ -31,7 +31,7 @@ define amdgpu_ps float @test_return_to_epilog_into_end_block(i32 inreg %a, float
   ; GCN-NEXT:   successors:
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
-  ; GCN-NEXT:   GLOBAL_STORE_DWORD undef renamable $vgpr0_vgpr1, killed renamable $vgpr0, 0, 0, implicit $exec :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   GLOBAL_STORE_DWORD undef renamable $vgpr0_vgpr1, killed renamable $vgpr0, 0, 0, implicit $exec :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_WAITCNT 3952
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT: bb.3:
@@ -41,7 +41,7 @@ entry:
 if:                                               ; preds = %entry
   ret float %b
 else:                                             ; preds = %entry
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   unreachable
 }
 
@@ -78,7 +78,7 @@ define amdgpu_ps float @test_unify_return_to_epilog_into_end_block(i32 inreg %a,
   ; GCN-NEXT:   successors:
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT:   renamable $vgpr0 = V_MOV_B32_e32 0, implicit $exec
-  ; GCN-NEXT:   GLOBAL_STORE_DWORD undef renamable $vgpr0_vgpr1, killed renamable $vgpr0, 0, 0, implicit $exec :: (volatile store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; GCN-NEXT:   GLOBAL_STORE_DWORD undef renamable $vgpr0_vgpr1, killed renamable $vgpr0, 0, 0, implicit $exec :: (volatile store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; GCN-NEXT:   S_WAITCNT 3952
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT: bb.5:
@@ -93,7 +93,7 @@ else.if.cond:                                     ; preds = %entry
 else.if:                                          ; preds = %else.if.cond
   ret float %d
 else:                                             ; preds = %else.if.cond
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   unreachable
 }
 

--- a/llvm/test/CodeGen/AMDGPU/trunc-combine.ll
+++ b/llvm/test/CodeGen/AMDGPU/trunc-combine.ll
@@ -43,7 +43,7 @@ define i16 @trunc_bitcast_v2i32_to_i16(<2 x i32> %bar) {
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    v_add_u32_e32 v0, vcc, 4, v0
 ; VI-NEXT:    s_setpc_b64 s[30:31]
-  %load0 = load i32, ptr addrspace(1) undef
+  %load0 = load i32, ptr addrspace(1) poison
   %load1 = load i32, ptr addrspace(1) null
   %insert.0 = insertelement <2 x i32> poison, i32 %load0, i32 0
   %insert.1 = insertelement <2 x i32> %insert.0, i32 99, i32 1
@@ -72,7 +72,7 @@ define i16 @trunc_bitcast_v2f32_to_i16(<2 x float> %bar) {
 ; VI-NEXT:    s_waitcnt vmcnt(0)
 ; VI-NEXT:    v_add_u32_e32 v0, vcc, 4, v0
 ; VI-NEXT:    s_setpc_b64 s[30:31]
-  %load0 = load float, ptr addrspace(1) undef
+  %load0 = load float, ptr addrspace(1) poison
   %load1 = load float, ptr addrspace(1) null
   %insert.0 = insertelement <2 x float> poison, float %load0, i32 0
   %insert.1 = insertelement <2 x float> %insert.0, float 4.0, i32 1

--- a/llvm/test/CodeGen/AMDGPU/trunc-store-vec-i16-to-i8.ll
+++ b/llvm/test/CodeGen/AMDGPU/trunc-store-vec-i16-to-i8.ll
@@ -4,7 +4,7 @@
 ; GCN: global_store_byte v
 define protected amdgpu_kernel void @short_char(ptr addrspace(1) %out) {
 entry:
-  %tmp = load i16, ptr addrspace(1) undef
+  %tmp = load i16, ptr addrspace(1) poison
   %tmp1 = trunc i16 %tmp to i8
   store i8 %tmp1, ptr addrspace(1) %out
   ret void
@@ -14,7 +14,7 @@ entry:
 ; GCN: global_store_dword v
 define protected amdgpu_kernel void @short2_char4(ptr addrspace(1) %out) {
 entry:
-  %tmp = load <2 x i16>, ptr addrspace(1) undef, align 4
+  %tmp = load <2 x i16>, ptr addrspace(1) poison, align 4
   %vecinit = shufflevector <2 x i16> %tmp, <2 x i16> poison, <4 x i32> <i32 0, i32 1, i32 poison, i32 poison>
   %vecinit2 = shufflevector <4 x i16> %vecinit, <4 x i16> <i16 poison, i16 poison, i16 0, i16 0>, <4 x i32> <i32 0, i32 1, i32 6, i32 7>
   %tmp1 = trunc <4 x i16> %vecinit2 to <4 x i8>
@@ -26,7 +26,7 @@ entry:
 ; GCN: global_store_dwordx2 v
 define protected amdgpu_kernel void @short4_char8(ptr addrspace(1) %out) {
 entry:
-  %tmp = load <4 x i16>, ptr addrspace(1) undef, align 8
+  %tmp = load <4 x i16>, ptr addrspace(1) poison, align 8
   %vecinit = shufflevector <4 x i16> %tmp, <4 x i16> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 poison, i32 poison, i32 poison, i32 poison>
   %vecinit2 = shufflevector <8 x i16> %vecinit, <8 x i16> <i16 poison, i16 poison, i16 poison, i16 poison, i16 0, i16 0, i16 0, i16 0>, <8 x i32> <i32 0, i32 1, i32 6, i32 7, i32 0, i32 1, i32 6, i32 7>
   %tmp1 = trunc <8 x i16> %vecinit2 to <8 x i8>
@@ -38,7 +38,7 @@ entry:
 ; GCN: global_store_dwordx4 v
 define protected amdgpu_kernel void @short8_char16(ptr addrspace(1) %out) {
 entry:
-  %tmp = load <8 x i16>, ptr addrspace(1) undef, align 16
+  %tmp = load <8 x i16>, ptr addrspace(1) poison, align 16
   %vecinit = shufflevector <8 x i16> %tmp, <8 x i16> poison, <16 x i32> <i32 0, i32 1, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   %vecinit2 = shufflevector <16 x i16> %vecinit, <16 x i16> <i16 poison, i16 poison, i16 poison, i16 poison, i16 poison, i16 poison, i16 poison, i16 poison, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0>, <16 x i32> <i32 0, i32 1, i32 6, i32 7, i32 0, i32 1, i32 6, i32 7, i32 0, i32 1, i32 6, i32 7, i32 0, i32 1, i32 6, i32 7>
   %tmp1 = trunc <16 x i16> %vecinit2 to <16 x i8>
@@ -51,7 +51,7 @@ entry:
 ; GCN: global_store_dwordx4 v
 define protected amdgpu_kernel void @short16_char32(ptr addrspace(1) %out) {
 entry:
-  %tmp = load <16 x i16>, ptr addrspace(1) undef, align 32
+  %tmp = load <16 x i16>, ptr addrspace(1) poison, align 32
   %vecinit = shufflevector <16 x i16> %tmp, <16 x i16> poison, <32 x i32> <i32 0, i32 1, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 0, i32 1, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 0, i32 1, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
   %vecinit2 = shufflevector <32 x i16> %vecinit, <32 x i16> <i16 poison, i16 poison, i16 poison, i16 poison, i16 poison, i16 poison, i16 poison, i16 poison, i16 poison, i16 poison, i16 poison, i16 poison, i16 poison, i16 poison, i16 poison, i16 poison, i16 0, i16 1, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0, i16 poison, i16 poison, i16 0, i16 0, i16 0, i16 0, i16 0, i16 0>, <32 x i32> <i32 0, i32 1, i32 6, i32 7, i32 0, i32 1, i32 6, i32 7, i32 0, i32 1, i32 6, i32 7, i32 0, i32 1, i32 6, i32 7, i32 0, i32 1, i32 6, i32 7, i32 0, i32 1, i32 6, i32 7, i32 0, i32 1, i32 6, i32 7, i32 0, i32 1, i32 6, i32 7>
   %tmp1 = trunc <32 x i16> %vecinit2 to <32 x i8>

--- a/llvm/test/CodeGen/AMDGPU/udiv.ll
+++ b/llvm/test/CodeGen/AMDGPU/udiv.ll
@@ -2246,7 +2246,7 @@ define amdgpu_kernel void @test_udiv2(i32 %p) {
 ; EG-NEXT:     LSHR * T1.X, KC0[2].Y, 1,
 ; EG-NEXT:    0(0.000000e+00), 0(0.000000e+00)
   %i = udiv i32 %p, 2
-  store volatile i32 %i, ptr addrspace(1) undef
+  store volatile i32 %i, ptr addrspace(1) poison
   ret void
 }
 
@@ -2312,7 +2312,7 @@ define amdgpu_kernel void @test_udiv_3_mulhu(i32 %p) {
 ; EG-NEXT:     MOV * T1.X, literal.x,
 ; EG-NEXT:    0(0.000000e+00), 0(0.000000e+00)
    %i = udiv i32 %p, 3
-   store volatile i32 %i, ptr addrspace(1) undef
+   store volatile i32 %i, ptr addrspace(1) poison
    ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/undefined-subreg-liverange.ll
+++ b/llvm/test/CodeGen/AMDGPU/undefined-subreg-liverange.ll
@@ -67,8 +67,8 @@ define amdgpu_ps float @valley_partially_undef_copy() #0 {
 ; CHECK-NEXT:    s_waitcnt vmcnt(0) expcnt(0)
 ; CHECK-NEXT:    ; return to shader part epilog
 bb:
-  %tmp = load volatile i32, ptr addrspace(1) undef, align 4
-  %tmp1 = load volatile i32, ptr addrspace(1) undef, align 4
+  %tmp = load volatile i32, ptr addrspace(1) poison, align 4
+  %tmp1 = load volatile i32, ptr addrspace(1) poison, align 4
   %tmp2 = insertelement <4 x i32> poison, i32 %tmp1, i32 0
   %tmp3 = bitcast i32 %tmp1 to float
   %tmp4 = call <4 x float> @llvm.amdgcn.image.sample.2d.v4f32.f32(i32 15, float %tmp3, float %tmp3, <8 x i32> undef, <4 x i32> undef, i1 0, i32 0, i32 0)
@@ -76,8 +76,8 @@ bb:
   %tmp6 = fmul float %tmp5, undef
   %tmp7 = fadd float %tmp6, %tmp6
   %tmp8 = insertelement <4 x i32> %tmp2, i32 %tmp, i32 1
-  store <4 x i32> %tmp8, ptr addrspace(1) undef, align 16
-  store float %tmp7, ptr addrspace(1) undef, align 4
+  store <4 x i32> %tmp8, ptr addrspace(1) poison, align 16
+  store float %tmp7, ptr addrspace(1) poison, align 4
   br label %bb9
 
 bb9:                                              ; preds = %bb9, %bb
@@ -85,7 +85,7 @@ bb9:                                              ; preds = %bb9, %bb
   br i1 %tmp10, label %bb9, label %bb11
 
 bb11:                                             ; preds = %bb9
-  store <4 x i32> %tmp2, ptr addrspace(1) undef, align 16
+  store <4 x i32> %tmp2, ptr addrspace(1) poison, align 16
   ret float undef
 }
 
@@ -118,7 +118,7 @@ define amdgpu_kernel void @partially_undef_copy() #0 {
   %partially.undef.0 = insertelement <4 x i32> poison, i32 %tmp0, i32 0
   %partially.undef.1 = insertelement <4 x i32> %partially.undef.0, i32 %tmp1, i32 0
 
-  store volatile <4 x i32> %partially.undef.1, ptr addrspace(1) undef, align 16
+  store volatile <4 x i32> %partially.undef.1, ptr addrspace(1) poison, align 16
   tail call void asm sideeffect "v_nop", "v={v[5:8]}"(<4 x i32> %partially.undef.0)
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/uniform-cfg.ll
+++ b/llvm/test/CodeGen/AMDGPU/uniform-cfg.ll
@@ -852,8 +852,8 @@ bb:
   br i1 %tmp1, label %bb2, label %bb9
 
 bb2:                                              ; preds = %bb
-  %tmp3 = load volatile i32, ptr addrspace(1) undef
-  store volatile i32 0, ptr addrspace(1) undef
+  %tmp3 = load volatile i32, ptr addrspace(1) poison
+  store volatile i32 0, ptr addrspace(1) poison
   %tmp9 = icmp sle i32 %cond, 0
   br i1 %tmp9, label %bb9, label %bb7
 

--- a/llvm/test/CodeGen/AMDGPU/unpack-half.ll
+++ b/llvm/test/CodeGen/AMDGPU/unpack-half.ll
@@ -10,7 +10,7 @@
 
 define amdgpu_gs void @main(i32 inreg %arg) local_unnamed_addr #0 {
 .entry:
-  %tmp = load volatile float, ptr addrspace(1) undef
+  %tmp = load volatile float, ptr addrspace(1) poison
   %tmp1 = bitcast float %tmp to i32
   %im0.i = lshr i32 %tmp1, 16
   %tmp2 = insertelement <2 x i32> poison, i32 %im0.i, i32 1
@@ -19,7 +19,7 @@ define amdgpu_gs void @main(i32 inreg %arg) local_unnamed_addr #0 {
   %tmp5 = fpext <2 x half> %tmp4 to <2 x float>
   %bc = bitcast <2 x float> %tmp5 to <2 x i32>
   %tmp6 = extractelement <2 x i32> %bc, i32 1
-  store volatile i32 %tmp6, ptr addrspace(1) undef
+  store volatile i32 %tmp6, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/v_add_u64_pseudo_sdwa.ll
+++ b/llvm/test/CodeGen/AMDGPU/v_add_u64_pseudo_sdwa.ll
@@ -17,7 +17,7 @@ bb:
   %v3 = zext i32 %v1 to i64
   %v.t = and i64 %v3, 255
   %v4 = add i64 %v2, %v.t
-  store i64 %v4, ptr addrspace(1) undef
+  store i64 %v4, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/v_sub_u64_pseudo_sdwa.ll
+++ b/llvm/test/CodeGen/AMDGPU/v_sub_u64_pseudo_sdwa.ll
@@ -17,7 +17,7 @@ bb:
   %v3 = zext i32 %v1 to i64
   %v.t = and i64 %v3, 255
   %v4 = sub i64 %v2, %v.t
-  store i64 %v4, ptr addrspace(1) undef
+  store i64 %v4, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/vgpr-liverange-ir.ll
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-liverange-ir.ll
@@ -639,7 +639,7 @@ define protected amdgpu_kernel void @nested_waterfalls(ptr addrspace(1) %tex.coe
   ; SI-NEXT: {{  $}}
   ; SI-NEXT: bb.7:
   ; SI-NEXT:   $exec_lo = S_MOV_B32 killed [[S_MOV_B32_]]
-  ; SI-NEXT:   GLOBAL_STORE_DWORD undef %34:vreg_64, killed [[IMAGE_SAMPLE_V1_V2_nsa_gfx10_]], 0, 0, implicit $exec :: (store (s32) into `ptr addrspace(1) undef`, addrspace 1)
+  ; SI-NEXT:   GLOBAL_STORE_DWORD undef %34:vreg_64, killed [[IMAGE_SAMPLE_V1_V2_nsa_gfx10_]], 0, 0, implicit $exec :: (store (s32) into `ptr addrspace(1) poison`, addrspace 1)
   ; SI-NEXT:   S_ENDPGM 0
 entry:
   %0 = tail call i32 @llvm.amdgcn.workitem.id.x()
@@ -655,7 +655,7 @@ if.then:                                          ; preds = %entry
   %5 = load <8 x i32>, ptr addrspace(4) %4, align 32
   %6 = load <4 x i32>, ptr addrspace(4) %add.ptr.i, align 16
   %7 = tail call float @llvm.amdgcn.image.sample.2d.f32.f32(i32 1, float undef, float undef, <8 x i32> %5, <4 x i32> %6, i1 false, i32 0, i32 0)
-  store float %7, ptr addrspace(1) undef, align 4
+  store float %7, ptr addrspace(1) poison, align 4
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/vgpr-mark-last-scratch-load.ll
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-mark-last-scratch-load.ll
@@ -48,7 +48,7 @@ define amdgpu_cs void @max_6_vgprs(ptr addrspace(1) %p) "amdgpu-num-vgpr"="6" {
 ; CHECK-NEXT:    global_store_b32 v[0:1], v0, off scope:SCOPE_SYS
 ; CHECK-NEXT:    s_wait_storecnt 0x0
 ; CHECK-NEXT:    s_endpgm
-  %tid = load volatile i32, ptr addrspace(1) undef
+  %tid = load volatile i32, ptr addrspace(1) poison
   %p1 = getelementptr inbounds i32, ptr addrspace(1) %p, i32 %tid
   %p2 = getelementptr inbounds i32, ptr addrspace(1) %p1, i32 4
   %p3 = getelementptr inbounds i32, ptr addrspace(1) %p2, i32 8
@@ -60,11 +60,11 @@ define amdgpu_cs void @max_6_vgprs(ptr addrspace(1) %p) "amdgpu-num-vgpr"="6" {
   %v4 = load volatile i32, ptr addrspace(1) %p4
   %v5 = load volatile i32, ptr addrspace(1) %p5
   call void asm sideeffect "", "~{v[0:4]}" ()
-  store volatile i32 %v1, ptr addrspace(1) undef
-  store volatile i32 %v2, ptr addrspace(1) undef
-  store volatile i32 %v3, ptr addrspace(1) undef
-  store volatile i32 %v4, ptr addrspace(1) undef
-  store volatile i32 %v5, ptr addrspace(1) undef
+  store volatile i32 %v1, ptr addrspace(1) poison
+  store volatile i32 %v2, ptr addrspace(1) poison
+  store volatile i32 %v3, ptr addrspace(1) poison
+  store volatile i32 %v4, ptr addrspace(1) poison
+  store volatile i32 %v5, ptr addrspace(1) poison
   ret void
 }
 
@@ -218,7 +218,7 @@ define amdgpu_cs void @max_11_vgprs_branch(ptr addrspace(1) %p, i32 %tmp) "amdgp
 ; CHECK-NEXT:    s_wait_storecnt 0x0
 ; CHECK-NEXT:    s_endpgm
 .entry:
-  %tid = load volatile i32, ptr addrspace(1) undef
+  %tid = load volatile i32, ptr addrspace(1) poison
   %p1 = getelementptr inbounds i32, ptr addrspace(1) %p, i32 %tid
   %p2 = getelementptr inbounds i32, ptr addrspace(1) %p1, i32 4
   %p3 = getelementptr inbounds i32, ptr addrspace(1) %p2, i32 8
@@ -244,14 +244,14 @@ define amdgpu_cs void @max_11_vgprs_branch(ptr addrspace(1) %p, i32 %tmp) "amdgp
   %v5_t = load volatile i32, ptr addrspace(1) %p5
   %v6_t = load volatile i32, ptr addrspace(1) %p6
   call void asm sideeffect "", "~{v[0:9]}" ()
-  store volatile i32 %v1_t, ptr addrspace(1) undef
-  store volatile i32 %v2_t, ptr addrspace(1) undef
-  store volatile i32 %v3_t, ptr addrspace(1) undef
-  store volatile i32 %v4_t, ptr addrspace(1) undef
-  store volatile i32 %v5_t, ptr addrspace(1) undef
-  store volatile i32 %v6_t, ptr addrspace(1) undef
-  store volatile i32 %v7, ptr addrspace(1) undef
-  store volatile i32 %v8, ptr addrspace(1) undef
+  store volatile i32 %v1_t, ptr addrspace(1) poison
+  store volatile i32 %v2_t, ptr addrspace(1) poison
+  store volatile i32 %v3_t, ptr addrspace(1) poison
+  store volatile i32 %v4_t, ptr addrspace(1) poison
+  store volatile i32 %v5_t, ptr addrspace(1) poison
+  store volatile i32 %v6_t, ptr addrspace(1) poison
+  store volatile i32 %v7, ptr addrspace(1) poison
+  store volatile i32 %v8, ptr addrspace(1) poison
 
   br label %.exit
 
@@ -263,19 +263,19 @@ define amdgpu_cs void @max_11_vgprs_branch(ptr addrspace(1) %p, i32 %tmp) "amdgp
   %v5_f = load volatile i32, ptr addrspace(1) %p5
   %v6_f = load volatile i32, ptr addrspace(1) %p6
   call void asm sideeffect "", "~{v[0:9]}" ()
-  store volatile i32 %v1_f, ptr addrspace(1) undef
-  store volatile i32 %v2_f, ptr addrspace(1) undef
-  store volatile i32 %v3_f, ptr addrspace(1) undef
-  store volatile i32 %v4_f, ptr addrspace(1) undef
-  store volatile i32 %v5_f, ptr addrspace(1) undef
-  store volatile i32 %v6_f, ptr addrspace(1) undef
-  store volatile i32 %v7, ptr addrspace(1) undef
-  store volatile i32 %v8, ptr addrspace(1) undef
+  store volatile i32 %v1_f, ptr addrspace(1) poison
+  store volatile i32 %v2_f, ptr addrspace(1) poison
+  store volatile i32 %v3_f, ptr addrspace(1) poison
+  store volatile i32 %v4_f, ptr addrspace(1) poison
+  store volatile i32 %v5_f, ptr addrspace(1) poison
+  store volatile i32 %v6_f, ptr addrspace(1) poison
+  store volatile i32 %v7, ptr addrspace(1) poison
+  store volatile i32 %v8, ptr addrspace(1) poison
 
   br label %.exit
 
 .exit:
-  store volatile i32 %v9, ptr addrspace(1) undef
-  store volatile i32 %v10, ptr addrspace(1) undef
+  store volatile i32 %v9, ptr addrspace(1) poison
+  store volatile i32 %v10, ptr addrspace(1) poison
   ret void
 }

--- a/llvm/test/CodeGen/AMDGPU/vgpr-tuple-allocation.ll
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-tuple-allocation.ll
@@ -354,7 +354,7 @@ define <4 x float> @call_preserved_vgpr_tuple8(<8 x i32> %rsrc, <4 x i32> %samp,
 
 main_body:
   %v = call <4 x float> @llvm.amdgcn.image.gather4.c.b.cl.2d.v4f32.f32.f32(i32 1, float %bias, float %zcompare, float %s, float %t, float %clamp, <8 x i32> undef, <4 x i32> undef, i1 false, i32 0, i32 0)
-  store <4 x float> %v, ptr addrspace(1) undef
+  store <4 x float> %v, ptr addrspace(1) poison
   call void @extern_func()
   %v1 = call <4 x float> @llvm.amdgcn.image.gather4.c.b.cl.2d.v4f32.f32.f32(i32 1, float %bias, float %zcompare, float %s, float %t, float %clamp, <8 x i32> undef, <4 x i32> undef, i1 false, i32 0, i32 0)
   ret <4 x float> %v1

--- a/llvm/test/CodeGen/AMDGPU/visit-physreg-vgpr-imm-folding-bug.ll
+++ b/llvm/test/CodeGen/AMDGPU/visit-physreg-vgpr-imm-folding-bug.ll
@@ -11,7 +11,7 @@
 ; CHECK:    s_swappc_b64
 define amdgpu_kernel void @vgpr_multi_use_imm_fold() {
 entry:
-  store double 0.0, ptr addrspace(1) undef, align 8
+  store double 0.0, ptr addrspace(1) poison, align 8
   %call0 = tail call fastcc double @__ocml_log_f64(double 2.0)
   %op = fadd double %call0, 0.0
   %call1 = tail call fastcc double @__ocml_sqrt_f64(double %op)

--- a/llvm/test/CodeGen/AMDGPU/wave32.ll
+++ b/llvm/test/CodeGen/AMDGPU/wave32.ll
@@ -1521,7 +1521,7 @@ bb0:
   br i1 %tmp9, label %bb1, label %bb2
 
 bb1:
-  store volatile i32 0, ptr addrspace(1) undef
+  store volatile i32 0, ptr addrspace(1) poison
   br label %bb2
 
 bb2:
@@ -1616,7 +1616,7 @@ bb1:                                              ; preds = %Flow, %bb
   br i1 %cmp0, label %bb4, label %Flow
 
 bb4:                                              ; preds = %bb1
-  %load = load volatile i32, ptr addrspace(1) undef, align 4
+  %load = load volatile i32, ptr addrspace(1) poison, align 4
   %cmp1 = icmp sge i32 %tmp, %load
   br label %Flow
 

--- a/llvm/test/CodeGen/AMDGPU/whole-wave-register-spill.ll
+++ b/llvm/test/CodeGen/AMDGPU/whole-wave-register-spill.ll
@@ -127,7 +127,7 @@ define void @test() #0 {
 ; GCN-O0-NEXT:    s_setpc_b64 s[30:31]
   %sgpr = call i32 asm sideeffect "; def $0", "=s" () #0
   call void @ext_func()
-  store volatile i32 %sgpr, ptr addrspace(1) undef
+  store volatile i32 %sgpr, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/wqm.ll
+++ b/llvm/test/CodeGen/AMDGPU/wqm.ll
@@ -729,7 +729,7 @@ define amdgpu_ps float @test_wwm6_then() {
 ; GFX10-W32-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX10-W32-NEXT:    ; return to shader part epilog
 main_body:
-  %src0 = load volatile float, ptr addrspace(1) undef
+  %src0 = load volatile float, ptr addrspace(1) poison
   ; use mbcnt to make sure the branch is divergent
   %lo = call i32 @llvm.amdgcn.mbcnt.lo(i32 -1, i32 0)
   %hi = call i32 @llvm.amdgcn.mbcnt.hi(i32 -1, i32 %lo)
@@ -737,7 +737,7 @@ main_body:
   br i1 %cc, label %endif, label %if
 
 if:
-  %src1 = load volatile float, ptr addrspace(1) undef
+  %src1 = load volatile float, ptr addrspace(1) poison
   %out = fadd float %src0, %src1
   %out.0 = call float @llvm.amdgcn.wwm.f32(float %out)
   br label %endif
@@ -810,7 +810,7 @@ define amdgpu_ps float @test_wwm6_loop() {
 ; GFX10-W32-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX10-W32-NEXT:    ; return to shader part epilog
 main_body:
-  %src0 = load volatile float, ptr addrspace(1) undef
+  %src0 = load volatile float, ptr addrspace(1) poison
   ; use mbcnt to make sure the branch is divergent
   %lo = call i32 @llvm.amdgcn.mbcnt.lo(i32 -1, i32 0)
   %hi = call i32 @llvm.amdgcn.mbcnt.hi(i32 -1, i32 %lo)
@@ -818,7 +818,7 @@ main_body:
 
 loop:
   %counter = phi i32 [ %hi, %main_body ], [ %counter.1, %loop ]
-  %src1 = load volatile float, ptr addrspace(1) undef
+  %src1 = load volatile float, ptr addrspace(1) poison
   %out = fadd float %src0, %src1
   %out.0 = call float @llvm.amdgcn.wwm.f32(float %out)
   %counter.1 = sub i32 %counter, 1
@@ -1194,7 +1194,7 @@ define amdgpu_ps float @test_strict_wqm6_then() {
 ; GFX10-W32-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX10-W32-NEXT:    ; return to shader part epilog
 main_body:
-  %src0 = load volatile float, ptr addrspace(1) undef
+  %src0 = load volatile float, ptr addrspace(1) poison
   ; use mbcnt to make sure the branch is divergent
   %lo = call i32 @llvm.amdgcn.mbcnt.lo(i32 -1, i32 0)
   %hi = call i32 @llvm.amdgcn.mbcnt.hi(i32 -1, i32 %lo)
@@ -1202,7 +1202,7 @@ main_body:
   br i1 %cc, label %endif, label %if
 
 if:
-  %src1 = load volatile float, ptr addrspace(1) undef
+  %src1 = load volatile float, ptr addrspace(1) poison
   %out = fadd float %src0, %src1
   %out.0 = call float @llvm.amdgcn.strict.wqm.f32(float %out)
   br label %endif
@@ -1281,7 +1281,7 @@ define amdgpu_ps float @test_strict_wqm6_loop() {
 ; GFX10-W32-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX10-W32-NEXT:    ; return to shader part epilog
 main_body:
-  %src0 = load volatile float, ptr addrspace(1) undef
+  %src0 = load volatile float, ptr addrspace(1) poison
   ; use mbcnt to make sure the branch is divergent
   %lo = call i32 @llvm.amdgcn.mbcnt.lo(i32 -1, i32 0)
   %hi = call i32 @llvm.amdgcn.mbcnt.hi(i32 -1, i32 %lo)
@@ -1289,7 +1289,7 @@ main_body:
 
 loop:
   %counter = phi i32 [ %hi, %main_body ], [ %counter.1, %loop ]
-  %src1 = load volatile float, ptr addrspace(1) undef
+  %src1 = load volatile float, ptr addrspace(1) poison
   %out = fadd float %src0, %src1
   %out.0 = call float @llvm.amdgcn.strict.wqm.f32(float %out)
   %counter.1 = sub i32 %counter, 1
@@ -2162,7 +2162,7 @@ entry:
   br i1 %cc, label %if, label %else
 
 if:
-  store volatile <4 x float> %dtex, ptr addrspace(1) undef
+  store volatile <4 x float> %dtex, ptr addrspace(1) poison
   unreachable
 
 else:
@@ -2630,7 +2630,7 @@ define amdgpu_ps float @test_strict_wwm6_then() {
 ; GFX10-W32-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX10-W32-NEXT:    ; return to shader part epilog
 main_body:
-  %src0 = load volatile float, ptr addrspace(1) undef
+  %src0 = load volatile float, ptr addrspace(1) poison
   ; use mbcnt to make sure the branch is divergent
   %lo = call i32 @llvm.amdgcn.mbcnt.lo(i32 -1, i32 0)
   %hi = call i32 @llvm.amdgcn.mbcnt.hi(i32 -1, i32 %lo)
@@ -2638,7 +2638,7 @@ main_body:
   br i1 %cc, label %endif, label %if
 
 if:
-  %src1 = load volatile float, ptr addrspace(1) undef
+  %src1 = load volatile float, ptr addrspace(1) poison
   %out = fadd float %src0, %src1
   %out.0 = call float @llvm.amdgcn.strict.wwm.f32(float %out)
   br label %endif
@@ -2707,7 +2707,7 @@ define amdgpu_ps float @test_strict_wwm6_loop() {
 ; GFX10-W32-NEXT:    s_or_b32 exec_lo, exec_lo, s0
 ; GFX10-W32-NEXT:    ; return to shader part epilog
 main_body:
-  %src0 = load volatile float, ptr addrspace(1) undef
+  %src0 = load volatile float, ptr addrspace(1) poison
   ; use mbcnt to make sure the branch is divergent
   %lo = call i32 @llvm.amdgcn.mbcnt.lo(i32 -1, i32 0)
   %hi = call i32 @llvm.amdgcn.mbcnt.hi(i32 -1, i32 %lo)
@@ -2715,7 +2715,7 @@ main_body:
 
 loop:
   %counter = phi i32 [ %hi, %main_body ], [ %counter.1, %loop ]
-  %src1 = load volatile float, ptr addrspace(1) undef
+  %src1 = load volatile float, ptr addrspace(1) poison
   %out = fadd float %src0, %src1
   %out.0 = call float @llvm.amdgcn.strict.wwm.f32(float %out)
   %counter.1 = sub i32 %counter, 1

--- a/llvm/test/CodeGen/AMDGPU/xor-r600.ll
+++ b/llvm/test/CodeGen/AMDGPU/xor-r600.ll
@@ -390,7 +390,7 @@ define amdgpu_kernel void @scalar_xor_literal_multi_use_i64(ptr addrspace(1) %ou
   store i64 %or, ptr addrspace(1) %out
 
   %foo = add i64 %b, 4261135838621753
-  store volatile i64 %foo, ptr addrspace(1) undef
+  store volatile i64 %foo, ptr addrspace(1) poison
   ret void
 }
 

--- a/llvm/test/CodeGen/AMDGPU/xor.ll
+++ b/llvm/test/CodeGen/AMDGPU/xor.ll
@@ -668,7 +668,7 @@ define amdgpu_kernel void @scalar_xor_literal_multi_use_i64(ptr addrspace(1) %ou
   store i64 %or, ptr addrspace(1) %out
 
   %foo = add i64 %b, 4261135838621753
-  store volatile i64 %foo, ptr addrspace(1) undef
+  store volatile i64 %foo, ptr addrspace(1) poison
   ret void
 }
 


### PR DESCRIPTION
Many tests use store to undef as a placeholder use, so just replace
all of these with poison.