### PR TITLE
[clang-repl] Fix target creation in Wasm.cpp

### DIFF
--- a/clang/lib/Interpreter/Wasm.cpp
+++ b/clang/lib/Interpreter/Wasm.cpp
@@ -66,7 +66,7 @@ llvm::Error WasmIncrementalExecutor::addModule(PartialTranslationUnit &PTU) {
   std::string ErrorString;
 
   const llvm::Target *Target = llvm::TargetRegistry::lookupTarget(
-      PTU.TheModule->getTargetTriple(), ErrorString);
+      PTU.TheModule->getTargetTriple().str(), ErrorString);
   if (!Target) {
     return llvm::make_error<llvm::StringError>("Failed to create Wasm Target: ",
                                                llvm::inconvertibleErrorCode());
@@ -74,7 +74,7 @@ llvm::Error WasmIncrementalExecutor::addModule(PartialTranslationUnit &PTU) {
 
   llvm::TargetOptions TO = llvm::TargetOptions();
   llvm::TargetMachine *TargetMachine = Target->createTargetMachine(
-      PTU.TheModule->getTargetTriple(), "", "", TO, llvm::Reloc::Model::PIC_);
+      PTU.TheModule->getTargetTriple().str(), "", "", TO, llvm::Reloc::Model::PIC_);
   PTU.TheModule->setDataLayout(TargetMachine->createDataLayout());
   std::string ObjectFileName = PTU.TheModule->getName().str() + ".o";
   std::string BinaryFileName = PTU.TheModule->getName().str() + ".wasm";

--- a/clang/lib/Interpreter/Wasm.cpp
+++ b/clang/lib/Interpreter/Wasm.cpp
@@ -66,7 +66,7 @@ llvm::Error WasmIncrementalExecutor::addModule(PartialTranslationUnit &PTU) {
   std::string ErrorString;
 
   const llvm::Target *Target = llvm::TargetRegistry::lookupTarget(
-      PTU.TheModule->getTargetTriple().str(), ErrorString);
+      PTU.TheModule->getTargetTriple(), ErrorString);
   if (!Target) {
     return llvm::make_error<llvm::StringError>("Failed to create Wasm Target: ",
                                                llvm::inconvertibleErrorCode());

--- a/clang/lib/Interpreter/Wasm.cpp
+++ b/clang/lib/Interpreter/Wasm.cpp
@@ -73,8 +73,9 @@ llvm::Error WasmIncrementalExecutor::addModule(PartialTranslationUnit &PTU) {
   }
 
   llvm::TargetOptions TO = llvm::TargetOptions();
-  llvm::TargetMachine *TargetMachine = Target->createTargetMachine(
-      PTU.TheModule->getTargetTriple().str(), "", "", TO, llvm::Reloc::Model::PIC_);
+  llvm::TargetMachine *TargetMachine =
+      Target->createTargetMachine(PTU.TheModule->getTargetTriple().str(), "",
+                                  "", TO, llvm::Reloc::Model::PIC_);
   PTU.TheModule->setDataLayout(TargetMachine->createDataLayout());
   std::string ObjectFileName = PTU.TheModule->getName().str() + ".o";
   std::string BinaryFileName = PTU.TheModule->getName().str() + ".wasm";


### PR DESCRIPTION
After #129868 went in, I realize some updates have been made to the Triple.

Not sure if @nikic overlooked including this change in his PR (hence I was having build issue when compiling clang against emscripten while building for wasm)

But yeah just like the change was addressed in other files, we need to make the change here too I think

https://github.com/llvm/llvm-project/blob/d921bf233c4fd3840953b1a4b5bb35ad594da773/clang/lib/Interpreter/DeviceOffload.cpp#L79-L86