### PR TITLE
[alpha.webkit.UncountedCallArgsChecker] Treat an explicit construction of Ref from a Ref return value safe.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
@@ -70,6 +70,8 @@ bool tryToFindPtrOrigin(
           if (isCtorOfSafePtr(ConversionFunc))
             return callback(E, true);
         }
+        if (isa<CXXFunctionalCastExpr>(E) && isSafePtrType(cast->getType()))
+          return callback(E, true);
       }
       // FIXME: This can give false "origin" that would lead to false negatives
       // in checkers. See https://reviews.llvm.org/D37023 for reference.

--- a/clang/test/Analysis/Checkers/WebKit/call-args.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args.cpp
@@ -414,6 +414,10 @@ namespace call_with_explicit_temporary_obj {
       Ref { ensure() }->method();
     }
   };
+
+  void baz(Ref<RefCountable>&& arg) {
+    Ref { arg }->method();
+  }
 }
 
 namespace call_with_explicit_construct {

--- a/clang/test/Analysis/Checkers/WebKit/call-args.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args.cpp
@@ -407,6 +407,13 @@ namespace call_with_explicit_temporary_obj {
   void baz() {
     bar<int>();
   }
+
+  class Foo {
+    Ref<RefCountable> ensure();
+    void foo() {
+      Ref { ensure() }->method();
+    }
+  };
 }
 
 namespace call_with_explicit_construct {


### PR DESCRIPTION
Fix a bug that an explicit construction of Ref out of a Ref return value would not be treated as safe. It is definitely safe albit redundant.