### PR TITLE
[CodeGenPrepare][RISCV] Combine (X ^ Y) and (X == Y) where appropriate

### DIFF
--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -8575,7 +8575,8 @@ static bool optimizeBranch(BranchInst *Branch, const TargetLowering &TLI,
     }
     if (Cmp->isEquality() &&
         (match(UI, m_Add(m_Specific(X), m_SpecificInt(-CmpC))) ||
-         match(UI, m_Sub(m_Specific(X), m_SpecificInt(CmpC))))) {
+         match(UI, m_Sub(m_Specific(X), m_SpecificInt(CmpC))) ||
+         match(UI, m_Xor(m_Specific(X), m_SpecificInt(CmpC))))) {
       IRBuilder<> Builder(Branch);
       if (UI->getParent() != Branch->getParent())
         UI->moveBefore(Branch->getIterator());

--- a/llvm/test/CodeGen/RISCV/select-constant-xor.ll
+++ b/llvm/test/CodeGen/RISCV/select-constant-xor.ll
@@ -239,3 +239,79 @@ define i32 @oneusecmp(i32 %a, i32 %b, i32 %d) {
   %x = add i32 %s, %s2
   ret i32 %x
 }
+
+define i32 @xor_branch_imm_ret(i32 %x) nounwind {
+; RV32-LABEL: xor_branch_imm_ret:
+; RV32:       # %bb.0: # %entry
+; RV32-NEXT:    li a1, -1365
+; RV32-NEXT:    beq a0, a1, .LBB11_2
+; RV32-NEXT:  # %bb.1: # %if.then
+; RV32-NEXT:    xori a0, a0, -1365
+; RV32-NEXT:    ret
+; RV32-NEXT:  .LBB11_2: # %if.end
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
+; RV32-NEXT:    call abort
+;
+; RV64-LABEL: xor_branch_imm_ret:
+; RV64:       # %bb.0: # %entry
+; RV64-NEXT:    sext.w a1, a0
+; RV64-NEXT:    li a2, -1365
+; RV64-NEXT:    beq a1, a2, .LBB11_2
+; RV64-NEXT:  # %bb.1: # %if.then
+; RV64-NEXT:    xori a0, a0, -1365
+; RV64-NEXT:    ret
+; RV64-NEXT:  .LBB11_2: # %if.end
+; RV64-NEXT:    addi sp, sp, -16
+; RV64-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
+; RV64-NEXT:    call abort
+entry:
+  %cmp.not = icmp eq i32 %x, -1365
+  br i1 %cmp.not, label %if.end, label %if.then
+if.then:
+  %xor = xor i32 %x, -1365
+  ret i32 %xor
+if.end:
+    tail call void @abort() #2
+  unreachable
+}
+
+define i32 @xor_branch_ret(i32 %x) nounwind {
+; RV32-LABEL: xor_branch_ret:
+; RV32:       # %bb.0: # %entry
+; RV32-NEXT:    li a1, 1
+; RV32-NEXT:    slli a1, a1, 11
+; RV32-NEXT:    beq a0, a1, .LBB12_2
+; RV32-NEXT:  # %bb.1: # %if.then
+; RV32-NEXT:    xor a0, a0, a1
+; RV32-NEXT:    ret
+; RV32-NEXT:  .LBB12_2: # %if.end
+; RV32-NEXT:    addi sp, sp, -16
+; RV32-NEXT:    sw ra, 12(sp) # 4-byte Folded Spill
+; RV32-NEXT:    call abort
+;
+; RV64-LABEL: xor_branch_ret:
+; RV64:       # %bb.0: # %entry
+; RV64-NEXT:    sext.w a2, a0
+; RV64-NEXT:    li a1, 1
+; RV64-NEXT:    slli a1, a1, 11
+; RV64-NEXT:    beq a2, a1, .LBB12_2
+; RV64-NEXT:  # %bb.1: # %if.then
+; RV64-NEXT:    xor a0, a0, a1
+; RV64-NEXT:    ret
+; RV64-NEXT:  .LBB12_2: # %if.end
+; RV64-NEXT:    addi sp, sp, -16
+; RV64-NEXT:    sd ra, 8(sp) # 8-byte Folded Spill
+; RV64-NEXT:    call abort
+entry:
+  %cmp.not = icmp eq i32 %x, 2048
+  br i1 %cmp.not, label %if.end, label %if.then
+if.then:
+  %xor = xor i32 %x, 2048
+  ret i32 %xor
+if.end:
+    tail call void @abort() #2
+  unreachable
+}
+
+declare void @abort()

--- a/llvm/test/CodeGen/RISCV/select-constant-xor.ll
+++ b/llvm/test/CodeGen/RISCV/select-constant-xor.ll
@@ -243,10 +243,9 @@ define i32 @oneusecmp(i32 %a, i32 %b, i32 %d) {
 define i32 @xor_branch_imm_ret(i32 %x) nounwind {
 ; RV32-LABEL: xor_branch_imm_ret:
 ; RV32:       # %bb.0: # %entry
-; RV32-NEXT:    li a1, -1365
-; RV32-NEXT:    beq a0, a1, .LBB11_2
-; RV32-NEXT:  # %bb.1: # %if.then
 ; RV32-NEXT:    xori a0, a0, -1365
+; RV32-NEXT:    beqz a0, .LBB11_2
+; RV32-NEXT:  # %bb.1: # %if.then
 ; RV32-NEXT:    ret
 ; RV32-NEXT:  .LBB11_2: # %if.end
 ; RV32-NEXT:    addi sp, sp, -16
@@ -255,11 +254,10 @@ define i32 @xor_branch_imm_ret(i32 %x) nounwind {
 ;
 ; RV64-LABEL: xor_branch_imm_ret:
 ; RV64:       # %bb.0: # %entry
-; RV64-NEXT:    sext.w a1, a0
-; RV64-NEXT:    li a2, -1365
-; RV64-NEXT:    beq a1, a2, .LBB11_2
-; RV64-NEXT:  # %bb.1: # %if.then
 ; RV64-NEXT:    xori a0, a0, -1365
+; RV64-NEXT:    sext.w a1, a0
+; RV64-NEXT:    beqz a1, .LBB11_2
+; RV64-NEXT:  # %bb.1: # %if.then
 ; RV64-NEXT:    ret
 ; RV64-NEXT:  .LBB11_2: # %if.end
 ; RV64-NEXT:    addi sp, sp, -16
@@ -292,9 +290,9 @@ define i32 @xor_branch_ret(i32 %x) nounwind {
 ;
 ; RV64-LABEL: xor_branch_ret:
 ; RV64:       # %bb.0: # %entry
-; RV64-NEXT:    sext.w a2, a0
 ; RV64-NEXT:    li a1, 1
 ; RV64-NEXT:    slli a1, a1, 11
+; RV64-NEXT:    sext.w a2, a0
 ; RV64-NEXT:    beq a2, a1, .LBB12_2
 ; RV64-NEXT:  # %bb.1: # %if.then
 ; RV64-NEXT:    xor a0, a0, a1


### PR DESCRIPTION
Fixes #130510.

In RISCV, modify the folding of (X ^ Y == 0) -> (X == Y) to account for cases where the (X ^ Y) will be re-used.

If a constant is being used for the XOR before a branch, ensure that it is small enough to fit within a 12-bit immediate field. Otherwise, the equality check is more efficient than the check against 0, see the following:
```
# %bb.0:
        lui     a1, 5
        addiw   a1, a1, 1365
        xor     a0, a0, a1
        beqz    a0, .LBB0_2
# %bb.1: 
        ret
.LBB0_2: 
```

```
# %bb.0:
        lui     a1, 5
        addiw   a1, a1, 1365
        beq    a0, a1, .LBB0_2
# %bb.1: 
        xor     a0, a0, a1
        ret
.LBB0_2: 
```

Similarly, if the XOR is between 1 and a size one integer, we should still fold away the XOR since that comparison can be optimized as a comparison against 0.
```
# %bb.0:
        slt a0, a0, a1
        xor  a0, a0, 1
        beqz    a0, .LBB0_2
# %bb.1: 
        ret
.LBB0_2: 
```

```
# %bb.0:
        slt a0, a0, a1
        bnez    a0, .LBB0_2
# %bb.1: 
        xor  a0, a0, 1
        ret
.LBB0_2: 
```

One question about my code is that I used a hard-coded value for the width of a RISCV ALU immediate. Do you know of a way that I can gather this from the `context`, I was unable to devise one.