### PR TITLE
[webkit.UncountedLambdaCapturesChecker] Recognize std::move(protectedThis)

### DIFF
--- a/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
@@ -2,6 +2,15 @@
 
 #include "mock-types.h"
 
+namespace std {
+
+template <typename T>
+T&& move(T& t) {
+  return static_cast<T&&>(t);
+}
+
+}
+
 namespace WTF {
 
 namespace Detail {
@@ -321,7 +330,7 @@ struct RefCountableWithLambdaCapturingThis {
 
   void method_nested_lambda2() {
     callAsync([this, protectedThis = RefPtr { this }] {
-      callAsync([this, protectedThis = static_cast<const Ref<RefCountableWithLambdaCapturingThis>&&>(*protectedThis)] {
+      callAsync([this, protectedThis = std::move(*protectedThis)] {
         nonTrivial();
       });
     });


### PR DESCRIPTION
In WebKit, it's a common pattern for a lambda to capture "this" along with "protectedThis" of Ref/RefPtr type, and re-capture "this" and "std::move(protectedThis)" for a nested inner lambda. Recognize this pattern and treat it as safe.