### PR TITLE
[MC] Speed up checkFeatures() (NFCI)

### DIFF
--- a/llvm/lib/MC/MCSubtargetInfo.cpp
+++ b/llvm/lib/MC/MCSubtargetInfo.cpp
@@ -322,11 +322,9 @@ bool MCSubtargetInfo::checkFeatures(StringRef FS) const {
            "Feature flags should start with '+' or '-'");
     const SubtargetFeatureKV *FeatureEntry =
         Find(SubtargetFeatures::StripFlag(F), ProcFeatures);
-    if (!FeatureEntry) {
-      errs() << "'" << F << "' is not a recognized feature for this target"
-             << " (ignoring feature)\n";
-      return true;
-    }
+    if (!FeatureEntry)
+      report_fatal_error(Twine("'") + F +
+                         "' is not a recognized feature for this target");
 
     return FeatureBits.test(FeatureEntry->Value) ==
            SubtargetFeatures::isEnabled(F);


### PR DESCRIPTION
checkFeatures() currently goes through ApplyFeatureFlag(), which will also handle implied features. This is very slow -- just querying every feature once takes up 10% of a Rust hello world compile.

However, if we only want to query whether certain features are set/unset, we can do so directly -- implied features have already been handled when the FeatureBitset was constructed.