### PR TITLE
[GlobalISel] Preserve original flags of output instructions in matchtable

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/GIMatchTableExecutorImpl.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/GIMatchTableExecutorImpl.h
@@ -80,7 +80,7 @@ bool GIMatchTableExecutor::executeMatchTable(
     for (auto MIB : OutMIs) {
       // Set the NoFPExcept flag when no original matched instruction could
       // raise an FP exception, but the new instruction potentially might.
-      uint16_t MIBFlags = Flags;
+      uint16_t MIBFlags = Flags | MIB.getInstr()->getFlags();
       if (NoFPException && MIB->mayRaiseFPException())
         MIBFlags |= MachineInstr::NoFPExcept;
       if (Observer)


### PR DESCRIPTION
We don't have any combine in trunk that uses output MIFlags when using MIR patterns, but I tried writing one and noticed that the flags were lost.

The reason is that the MatchTableExecutor was overwriting the flags. 