### PR TITLE
[TargetRegistry] Accept Triple in createTargetMachine() (NFC)

### DIFF
--- a/bolt/lib/Passes/AsmDump.cpp
+++ b/bolt/lib/Passes/AsmDump.cpp
@@ -143,7 +143,7 @@ void dumpFunction(const BinaryFunction &BF) {
                         std::move(MCEInstance.MCE), std::move(MAB)));
   AsmStreamer->initSections(true, *BC.STI);
   std::unique_ptr<TargetMachine> TM(BC.TheTarget->createTargetMachine(
-      BC.TripleName, "", "", TargetOptions(), std::nullopt));
+      *BC.TheTriple, "", "", TargetOptions(), std::nullopt));
   std::unique_ptr<AsmPrinter> MAP(
       BC.TheTarget->createAsmPrinter(*TM, std::move(AsmStreamer)));
 

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -595,7 +595,7 @@ static void setCommandLineOpts(const CodeGenOptions &CodeGenOpts) {
 void EmitAssemblyHelper::CreateTargetMachine(bool MustCreateTM) {
   // Create the TargetMachine for generating code.
   std::string Error;
-  std::string Triple = TheModule->getTargetTriple().str();
+  const llvm::Triple &Triple = TheModule->getTargetTriple();
   const llvm::Target *TheTarget = TargetRegistry::lookupTarget(Triple, Error);
   if (!TheTarget) {
     if (MustCreateTM)

--- a/clang/lib/Interpreter/DeviceOffload.cpp
+++ b/clang/lib/Interpreter/DeviceOffload.cpp
@@ -83,7 +83,7 @@ llvm::Expected<llvm::StringRef> IncrementalCUDADeviceParser::GeneratePTX() {
                                                std::error_code());
   llvm::TargetOptions TO = llvm::TargetOptions();
   llvm::TargetMachine *TargetMachine = Target->createTargetMachine(
-      PTU.TheModule->getTargetTriple().str(), TargetOpts.CPU, "", TO,
+      PTU.TheModule->getTargetTriple(), TargetOpts.CPU, "", TO,
       llvm::Reloc::Model::PIC_);
   PTU.TheModule->setDataLayout(TargetMachine->createDataLayout());
 

--- a/clang/lib/Interpreter/Wasm.cpp
+++ b/clang/lib/Interpreter/Wasm.cpp
@@ -73,9 +73,8 @@ llvm::Error WasmIncrementalExecutor::addModule(PartialTranslationUnit &PTU) {
   }
 
   llvm::TargetOptions TO = llvm::TargetOptions();
-  llvm::TargetMachine *TargetMachine =
-      Target->createTargetMachine(PTU.TheModule->getTargetTriple().str(), "",
-                                  "", TO, llvm::Reloc::Model::PIC_);
+  llvm::TargetMachine *TargetMachine = Target->createTargetMachine(
+      PTU.TheModule->getTargetTriple(), "", "", TO, llvm::Reloc::Model::PIC_);
   PTU.TheModule->setDataLayout(TargetMachine->createDataLayout());
   std::string ObjectFileName = PTU.TheModule->getName().str() + ".o";
   std::string BinaryFileName = PTU.TheModule->getName().str() + ".wasm";

--- a/clang/tools/clang-fuzzer/handle-llvm/handle_llvm.cpp
+++ b/clang/tools/clang-fuzzer/handle-llvm/handle_llvm.cpp
@@ -127,8 +127,8 @@ static std::string OptLLVM(const std::string &IR, CodeGenOptLevel OLvl) {
     ErrorAndExit(E);
 
   std::unique_ptr<TargetMachine> TM(TheTarget->createTargetMachine(
-      M->getTargetTriple().str(), codegen::getCPUStr(),
-      codegen::getFeaturesStr(), Options, codegen::getExplicitRelocModel(),
+      M->getTargetTriple(), codegen::getCPUStr(), codegen::getFeaturesStr(),
+      Options, codegen::getExplicitRelocModel(),
       codegen::getExplicitCodeModel(), OLvl));
   if (!TM)
     ErrorAndExit("Could not create target machine");

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -637,7 +637,7 @@ Expected<StringRef> compileModule(Module &M, OffloadKind Kind) {
   StringRef CPU = "";
   StringRef Features = "";
   std::unique_ptr<TargetMachine> TM(
-      T->createTargetMachine(M.getTargetTriple().str(), CPU, Features, Options,
+      T->createTargetMachine(M.getTargetTriple(), CPU, Features, Options,
                              Reloc::PIC_, M.getCodeModel()));
 
   if (M.getDataLayout().isDefault())

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -111,9 +111,10 @@ static void ensureSufficientStack() {}
 
 /// Print supported cpus of the given target.
 static int PrintSupportedCPUs(std::string TargetStr) {
+  llvm::Triple Triple(TargetStr);
   std::string Error;
   const llvm::Target *TheTarget =
-      llvm::TargetRegistry::lookupTarget(TargetStr, Error);
+      llvm::TargetRegistry::lookupTarget(Triple, Error);
   if (!TheTarget) {
     llvm::errs() << Error;
     return 1;
@@ -122,15 +123,16 @@ static int PrintSupportedCPUs(std::string TargetStr) {
   // the target machine will handle the mcpu printing
   llvm::TargetOptions Options;
   std::unique_ptr<llvm::TargetMachine> TheTargetMachine(
-      TheTarget->createTargetMachine(TargetStr, "", "+cpuhelp", Options,
+      TheTarget->createTargetMachine(Triple, "", "+cpuhelp", Options,
                                      std::nullopt));
   return 0;
 }
 
 static int PrintSupportedExtensions(std::string TargetStr) {
+  llvm::Triple Triple(TargetStr);
   std::string Error;
   const llvm::Target *TheTarget =
-      llvm::TargetRegistry::lookupTarget(TargetStr, Error);
+      llvm::TargetRegistry::lookupTarget(Triple, Error);
   if (!TheTarget) {
     llvm::errs() << Error;
     return 1;
@@ -138,7 +140,7 @@ static int PrintSupportedExtensions(std::string TargetStr) {
 
   llvm::TargetOptions Options;
   std::unique_ptr<llvm::TargetMachine> TheTargetMachine(
-      TheTarget->createTargetMachine(TargetStr, "", "", Options, std::nullopt));
+      TheTarget->createTargetMachine(Triple, "", "", Options, std::nullopt));
   const llvm::Triple &MachineTriple = TheTargetMachine->getTargetTriple();
   const llvm::MCSubtargetInfo *MCInfo = TheTargetMachine->getMCSubtargetInfo();
   const llvm::ArrayRef<llvm::SubtargetFeatureKV> Features =
@@ -165,9 +167,10 @@ static int PrintSupportedExtensions(std::string TargetStr) {
 }
 
 static int PrintEnabledExtensions(const TargetOptions& TargetOpts) {
+  llvm::Triple Triple(TargetOpts.Triple);
   std::string Error;
   const llvm::Target *TheTarget =
-      llvm::TargetRegistry::lookupTarget(TargetOpts.Triple, Error);
+      llvm::TargetRegistry::lookupTarget(Triple, Error);
   if (!TheTarget) {
     llvm::errs() << Error;
     return 1;
@@ -179,7 +182,8 @@ static int PrintEnabledExtensions(const TargetOptions& TargetOpts) {
   llvm::TargetOptions BackendOptions;
   std::string FeaturesStr = llvm::join(TargetOpts.FeaturesAsWritten, ",");
   std::unique_ptr<llvm::TargetMachine> TheTargetMachine(
-      TheTarget->createTargetMachine(TargetOpts.Triple, TargetOpts.CPU, FeaturesStr, BackendOptions, std::nullopt));
+      TheTarget->createTargetMachine(Triple, TargetOpts.CPU, FeaturesStr,
+                                     BackendOptions, std::nullopt));
   const llvm::Triple &MachineTriple = TheTargetMachine->getTargetTriple();
   const llvm::MCSubtargetInfo *MCInfo = TheTargetMachine->getMCSubtargetInfo();
 

--- a/flang/tools/bbc/bbc.cpp
+++ b/flang/tools/bbc/bbc.cpp
@@ -280,7 +280,7 @@ createTargetMachine(llvm::StringRef targetTriple, std::string &error) {
   if (!theTarget)
     return nullptr;
   return std::unique_ptr<llvm::TargetMachine>{
-      theTarget->createTargetMachine(triple, /*CPU=*/"",
+      theTarget->createTargetMachine(llvm::Triple(triple), /*CPU=*/"",
                                      /*Features=*/"", llvm::TargetOptions(),
                                      /*Reloc::Model=*/std::nullopt)};
 }

--- a/flang/tools/flang-driver/fc1_main.cpp
+++ b/flang/tools/flang-driver/fc1_main.cpp
@@ -45,8 +45,8 @@ static int printSupportedCPUs(llvm::StringRef triple) {
   // the target machine will handle the mcpu printing
   llvm::TargetOptions targetOpts;
   std::unique_ptr<llvm::TargetMachine> targetMachine(
-      target->createTargetMachine(triple, "", "+cpuhelp", targetOpts,
-                                  std::nullopt));
+      target->createTargetMachine(llvm::Triple(triple), "", "+cpuhelp",
+                                  targetOpts, std::nullopt));
   return 0;
 }
 

--- a/llvm/examples/Kaleidoscope/Chapter8/toy.cpp
+++ b/llvm/examples/Kaleidoscope/Chapter8/toy.cpp
@@ -1243,7 +1243,7 @@ int main() {
 
   TargetOptions opt;
   auto TheTargetMachine = Target->createTargetMachine(
-      TargetTriple, CPU, Features, opt, Reloc::PIC_);
+      Triple(TargetTriple), CPU, Features, opt, Reloc::PIC_);
 
   TheModule->setDataLayout(TheTargetMachine->createDataLayout());
 

--- a/llvm/include/llvm/MC/TargetRegistry.h
+++ b/llvm/include/llvm/MC/TargetRegistry.h
@@ -463,6 +463,16 @@ public:
                                JIT);
   }
 
+  [[deprecated("Use overload accepting Triple instead")]]
+  TargetMachine *createTargetMachine(
+      StringRef TT, StringRef CPU, StringRef Features,
+      const TargetOptions &Options, std::optional<Reloc::Model> RM,
+      std::optional<CodeModel::Model> CM = std::nullopt,
+      CodeGenOptLevel OL = CodeGenOptLevel::Default, bool JIT = false) const {
+    return createTargetMachine(Triple(TT), CPU, Features, Options, RM, CM, OL,
+                               JIT);
+  }
+
   /// createMCAsmBackend - Create a target specific assembly parser.
   MCAsmBackend *createMCAsmBackend(const MCSubtargetInfo &STI,
                                    const MCRegisterInfo &MRI,

--- a/llvm/include/llvm/MC/TargetRegistry.h
+++ b/llvm/include/llvm/MC/TargetRegistry.h
@@ -453,14 +453,14 @@ public:
   /// either the target triple from the module, or the target triple of the
   /// host if that does not exist.
   TargetMachine *createTargetMachine(
-      StringRef TT, StringRef CPU, StringRef Features,
+      const Triple &TT, StringRef CPU, StringRef Features,
       const TargetOptions &Options, std::optional<Reloc::Model> RM,
       std::optional<CodeModel::Model> CM = std::nullopt,
       CodeGenOptLevel OL = CodeGenOptLevel::Default, bool JIT = false) const {
     if (!TargetMachineCtorFn)
       return nullptr;
-    return TargetMachineCtorFn(*this, Triple(TT), CPU, Features, Options, RM,
-                               CM, OL, JIT);
+    return TargetMachineCtorFn(*this, TT, CPU, Features, Options, RM, CM, OL,
+                               JIT);
   }
 
   /// createMCAsmBackend - Create a target specific assembly parser.

--- a/llvm/lib/CodeGen/CommandFlags.cpp
+++ b/llvm/lib/CodeGen/CommandFlags.cpp
@@ -764,7 +764,7 @@ codegen::createTargetMachineForTriple(StringRef TargetTriple,
   if (!TheTarget)
     return createStringError(inconvertibleErrorCode(), Error);
   auto *Target = TheTarget->createTargetMachine(
-      TheTriple.getTriple(), codegen::getCPUStr(), codegen::getFeaturesStr(),
+      TheTriple, codegen::getCPUStr(), codegen::getFeaturesStr(),
       codegen::InitTargetOptionsFromCodeGenFlags(TheTriple),
       codegen::getExplicitRelocModel(), codegen::getExplicitCodeModel(),
       OptLevel);

--- a/llvm/lib/DWARFLinker/Classic/DWARFStreamer.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFStreamer.cpp
@@ -123,7 +123,7 @@ Error DwarfStreamer::init(Triple TheTriple,
                              TripleName.c_str());
 
   // Finally create the AsmPrinter we'll use to emit the DIEs.
-  TM.reset(TheTarget->createTargetMachine(TripleName, "", "", TargetOptions(),
+  TM.reset(TheTarget->createTargetMachine(TheTriple, "", "", TargetOptions(),
                                           std::nullopt));
   if (!TM)
     return createStringError(std::errc::invalid_argument,

--- a/llvm/lib/DWARFLinker/Parallel/DWARFEmitterImpl.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFEmitterImpl.cpp
@@ -102,7 +102,7 @@ Error DwarfEmitterImpl::init(Triple TheTriple,
                              TripleName.c_str());
 
   // Finally create the AsmPrinter we'll use to emit the DIEs.
-  TM.reset(TheTarget->createTargetMachine(TripleName, "", "", TargetOptions(),
+  TM.reset(TheTarget->createTargetMachine(TheTriple, "", "", TargetOptions(),
                                           std::nullopt));
   if (!TM)
     return createStringError(std::errc::invalid_argument,

--- a/llvm/lib/ExecutionEngine/Orc/JITTargetMachineBuilder.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/JITTargetMachineBuilder.cpp
@@ -47,9 +47,8 @@ JITTargetMachineBuilder::createTargetMachine() {
     return make_error<StringError>("Target has no JIT support",
                                    inconvertibleErrorCode());
 
-  auto *TM =
-      TheTarget->createTargetMachine(TT.getTriple(), CPU, Features.getString(),
-                                     Options, RM, CM, OptLevel, /*JIT*/ true);
+  auto *TM = TheTarget->createTargetMachine(
+      TT, CPU, Features.getString(), Options, RM, CM, OptLevel, /*JIT*/ true);
   if (!TM)
     return make_error<StringError>("Could not allocate target machine",
                                    inconvertibleErrorCode());

--- a/llvm/lib/ExecutionEngine/Orc/JITTargetMachineBuilder.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/JITTargetMachineBuilder.cpp
@@ -48,7 +48,7 @@ JITTargetMachineBuilder::createTargetMachine() {
                                    inconvertibleErrorCode());
 
   auto *TM = TheTarget->createTargetMachine(
-      TT, CPU, Features.getString(), Options, RM, CM, OptLevel, /*JIT*/ true);
+      TT, CPU, Features.getString(), Options, RM, CM, OptLevel, /*JIT=*/true);
   if (!TM)
     return make_error<StringError>("Could not allocate target machine",
                                    inconvertibleErrorCode());

--- a/llvm/lib/ExecutionEngine/TargetSelect.cpp
+++ b/llvm/lib/ExecutionEngine/TargetSelect.cpp
@@ -86,7 +86,7 @@ TargetMachine *EngineBuilder::selectTarget(const Triple &TargetTriple,
   // Allocate a target...
   TargetMachine *Target = TheTarget->createTargetMachine(
       TheTriple, MCPU, FeaturesStr, Options, RelocModel, CMModel, OptLevel,
-      /*JIT*/ true);
+      /*JIT=*/true);
   Target->Options.EmulatedTLS = EmulatedTLS;
 
   assert(Target && "Could not allocate target machine!");

--- a/llvm/lib/ExecutionEngine/TargetSelect.cpp
+++ b/llvm/lib/ExecutionEngine/TargetSelect.cpp
@@ -84,10 +84,9 @@ TargetMachine *EngineBuilder::selectTarget(const Triple &TargetTriple,
   }
 
   // Allocate a target...
-  TargetMachine *Target =
-      TheTarget->createTargetMachine(TheTriple.getTriple(), MCPU, FeaturesStr,
-                                     Options, RelocModel, CMModel, OptLevel,
-				     /*JIT*/ true);
+  TargetMachine *Target = TheTarget->createTargetMachine(
+      TheTriple, MCPU, FeaturesStr, Options, RelocModel, CMModel, OptLevel,
+      /*JIT*/ true);
   Target->Options.EmulatedTLS = EmulatedTLS;
 
   assert(Target && "Could not allocate target machine!");

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -5505,7 +5505,7 @@ createTargetMachine(Function *F, CodeGenOptLevel OptLevel) {
 
   StringRef CPU = F->getFnAttribute("target-cpu").getValueAsString();
   StringRef Features = F->getFnAttribute("target-features").getValueAsString();
-  const std::string &Triple = M->getTargetTriple().str();
+  const llvm::Triple &Triple = M->getTargetTriple();
 
   std::string Error;
   const llvm::Target *TheTarget = TargetRegistry::lookupTarget(Triple, Error);

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -227,7 +227,7 @@ createTargetMachine(const Config &Conf, const Target *TheTarget, Module &M) {
   }
 
   std::unique_ptr<TargetMachine> TM(TheTarget->createTargetMachine(
-      TheTriple.str(), Conf.CPU, Features.getString(), TargetOpts, RelocModel,
+      TheTriple, Conf.CPU, Features.getString(), TargetOpts, RelocModel,
       CodeModel, Conf.CGOptLevel));
 
   assert(TM && "Failed to create target machine");

--- a/llvm/lib/LTO/LTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/LTOCodeGenerator.cpp
@@ -420,8 +420,8 @@ bool LTOCodeGenerator::determineTarget() {
 std::unique_ptr<TargetMachine> LTOCodeGenerator::createTargetMachine() {
   assert(MArch && "MArch is not set!");
   return std::unique_ptr<TargetMachine>(MArch->createTargetMachine(
-      TripleStr, Config.CPU, FeatureStr, Config.Options, Config.RelocModel,
-      std::nullopt, Config.CGOptLevel));
+      Triple(TripleStr), Config.CPU, FeatureStr, Config.Options,
+      Config.RelocModel, std::nullopt, Config.CGOptLevel));
 }
 
 // If a linkonce global is present in the MustPreserveSymbols, we need to make

--- a/llvm/lib/LTO/LTOModule.cpp
+++ b/llvm/lib/LTO/LTOModule.cpp
@@ -228,8 +228,8 @@ LTOModule::makeLTOModule(MemoryBufferRef Buffer, const TargetOptions &options,
       CPU = "cyclone";
   }
 
-  TargetMachine *target = march->createTargetMachine(
-      Triple.str(), CPU, FeatureStr, options, std::nullopt);
+  TargetMachine *target = march->createTargetMachine(Triple, CPU, FeatureStr,
+                                                     options, std::nullopt);
 
   std::unique_ptr<LTOModule> Ret(new LTOModule(std::move(M), Buffer, target));
   Ret->parseSymbols();

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -588,7 +588,7 @@ std::unique_ptr<TargetMachine> TargetMachineBuilder::create() const {
   std::string FeatureStr = Features.getString();
 
   std::unique_ptr<TargetMachine> TM(
-      TheTarget->createTargetMachine(TheTriple.str(), MCpu, FeatureStr, Options,
+      TheTarget->createTargetMachine(TheTriple, MCpu, FeatureStr, Options,
                                      RelocModel, std::nullopt, CGOptLevel));
   assert(TM && "Cannot create target machine");
 

--- a/llvm/lib/Target/SPIRV/SPIRVAPI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAPI.cpp
@@ -94,7 +94,7 @@ SPIRVTranslate(Module *M, std::string &SpirvObj, std::string &ErrMsg,
   std::optional<Reloc::Model> RM;
   std::optional<CodeModel::Model> CM;
   std::unique_ptr<TargetMachine> Target(TheTarget->createTargetMachine(
-      TargetTriple.getTriple(), "", "", Options, RM, CM, OLevel));
+      TargetTriple, "", "", Options, RM, CM, OLevel));
   if (!Target) {
     ErrMsg = "Could not allocate target machine!";
     return false;

--- a/llvm/lib/Target/TargetMachineC.cpp
+++ b/llvm/lib/Target/TargetMachineC.cpp
@@ -197,14 +197,14 @@ void LLVMTargetMachineOptionsSetCodeModel(LLVMTargetMachineOptionsRef Options,
 }
 
 LLVMTargetMachineRef
-LLVMCreateTargetMachineWithOptions(LLVMTargetRef T, const char *Triple,
+LLVMCreateTargetMachineWithOptions(LLVMTargetRef T, const char *TripleStr,
                                    LLVMTargetMachineOptionsRef Options) {
   auto *Opt = unwrap(Options);
   TargetOptions TO;
   TO.MCOptions.ABIName = Opt->ABI;
-  return wrap(unwrap(T)->createTargetMachine(Triple, Opt->CPU, Opt->Features,
-                                             TO, Opt->RM, Opt->CM, Opt->OL,
-                                             Opt->JIT));
+  return wrap(unwrap(T)->createTargetMachine(Triple(TripleStr), Opt->CPU,
+                                             Opt->Features, TO, Opt->RM,
+                                             Opt->CM, Opt->OL, Opt->JIT));
 }
 
 LLVMTargetMachineRef

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -555,7 +555,7 @@ static int compileModule(char **argv, LLVMContext &Context) {
 
       InitializeOptions(TheTriple);
       Target = std::unique_ptr<TargetMachine>(TheTarget->createTargetMachine(
-          TheTriple.getTriple(), CPUStr, FeaturesStr, Options, RM, CM, OLvl));
+          TheTriple, CPUStr, FeaturesStr, Options, RM, CM, OLvl));
       assert(Target && "Could not allocate target machine!");
 
       return Target->createDataLayout().getStringRepresentation();
@@ -598,7 +598,7 @@ static int compileModule(char **argv, LLVMContext &Context) {
 
     InitializeOptions(TheTriple);
     Target = std::unique_ptr<TargetMachine>(TheTarget->createTargetMachine(
-        TheTriple.getTriple(), CPUStr, FeaturesStr, Options, RM, CM, OLvl));
+        TheTriple, CPUStr, FeaturesStr, Options, RM, CM, OLvl));
     assert(Target && "Could not allocate target machine!");
 
     // If we don't have a module then just exit now. We do this down

--- a/llvm/tools/llvm-exegesis/lib/LlvmState.cpp
+++ b/llvm/tools/llvm-exegesis/lib/LlvmState.cpp
@@ -57,7 +57,7 @@ Expected<LLVMState> LLVMState::Create(std::string TripleName,
   }
   const TargetOptions Options;
   std::unique_ptr<const TargetMachine> TM(TheTarget->createTargetMachine(
-      TripleName, CpuName, Features, Options, Reloc::Model::Static));
+      TheTriple, CpuName, Features, Options, Reloc::Model::Static));
   if (!TM) {
     return make_error<StringError>("unable to create target machine",
                                    inconvertibleErrorCode());
@@ -93,7 +93,7 @@ LLVMState::LLVMState(std::unique_ptr<const TargetMachine> TM,
 std::unique_ptr<TargetMachine> LLVMState::createTargetMachine() const {
   return std::unique_ptr<TargetMachine>(
       TheTargetMachine->getTarget().createTargetMachine(
-          TheTargetMachine->getTargetTriple().normalize(),
+          Triple(TheTargetMachine->getTargetTriple().normalize()),
           TheTargetMachine->getTargetCPU(),
           TheTargetMachine->getTargetFeatureString(), TheTargetMachine->Options,
           Reloc::Model::Static));

--- a/llvm/tools/llvm-split/llvm-split.cpp
+++ b/llvm/tools/llvm-split/llvm-split.cpp
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
 
     TargetOptions Options;
     TM = std::unique_ptr<TargetMachine>(T->createTargetMachine(
-        MTriple, MCPU, /*FS*/ "", Options, std::nullopt, std::nullopt));
+        Triple(MTriple), MCPU, /*FS*/ "", Options, std::nullopt, std::nullopt));
   }
 
   std::unique_ptr<Module> M = parseIRFile(InputFilename, Err, Context);

--- a/llvm/unittests/CodeGen/AArch64SelectionDAGTest.cpp
+++ b/llvm/unittests/CodeGen/AArch64SelectionDAGTest.cpp
@@ -45,7 +45,7 @@ protected:
 
     TargetOptions Options;
     TM = std::unique_ptr<TargetMachine>(
-        T->createTargetMachine("AArch64", "", "+sve", Options, std::nullopt,
+        T->createTargetMachine(TargetTriple, "", "+sve", Options, std::nullopt,
                                std::nullopt, CodeGenOptLevel::Aggressive));
     if (!TM)
       GTEST_SKIP();

--- a/llvm/unittests/CodeGen/AMDGPUMetadataTest.cpp
+++ b/llvm/unittests/CodeGen/AMDGPUMetadataTest.cpp
@@ -52,13 +52,14 @@ protected:
 
   void SetUp() override {
     std::string Error;
-    const Target *T = TargetRegistry::lookupTarget("amdgcn--amdpal", Error);
+    Triple TargetTriple("amdgcn--amdpal");
+    const Target *T = TargetRegistry::lookupTarget(TargetTriple, Error);
     if (!T)
       GTEST_SKIP();
 
     TargetOptions Options;
     TM = std::unique_ptr<TargetMachine>(T->createTargetMachine(
-        "amdgcn--amdpal", "gfx1010", "", Options, std::nullopt));
+        TargetTriple, "gfx1010", "", Options, std::nullopt));
     if (!TM)
       GTEST_SKIP();
 

--- a/llvm/unittests/CodeGen/DroppedVariableStatsMIRTest.cpp
+++ b/llvm/unittests/CodeGen/DroppedVariableStatsMIRTest.cpp
@@ -33,8 +33,9 @@ using namespace llvm;
 namespace {
 
 std::unique_ptr<TargetMachine>
-createTargetMachine(std::string TT, StringRef CPU, StringRef FS) {
+createTargetMachine(std::string TargetStr, StringRef CPU, StringRef FS) {
   std::string Error;
+  Triple TT(TargetStr);
   const Target *T = TargetRegistry::lookupTarget(TT, Error);
   if (!T)
     return nullptr;

--- a/llvm/unittests/CodeGen/GlobalISel/GISelMITest.cpp
+++ b/llvm/unittests/CodeGen/GlobalISel/GISelMITest.cpp
@@ -38,7 +38,7 @@ std::unique_ptr<TargetMachine> AArch64GISelMITest::createTargetMachine() const {
 
   TargetOptions Options;
   return std::unique_ptr<TargetMachine>(
-      T->createTargetMachine("AArch64", "", "", Options, std::nullopt,
+      T->createTargetMachine(TargetTriple, "", "", Options, std::nullopt,
                              std::nullopt, CodeGenOptLevel::Aggressive));
 }
 
@@ -74,9 +74,9 @@ std::unique_ptr<TargetMachine> AMDGPUGISelMITest::createTargetMachine() const {
     return nullptr;
 
   TargetOptions Options;
-  return std::unique_ptr<TargetMachine>(T->createTargetMachine(
-      "amdgcn-amd-amdhsa", "gfx900", "", Options, std::nullopt, std::nullopt,
-      CodeGenOptLevel::Aggressive));
+  return std::unique_ptr<TargetMachine>(
+      T->createTargetMachine(TargetTriple, "gfx900", "", Options, std::nullopt,
+                             std::nullopt, CodeGenOptLevel::Aggressive));
 }
 
 void AMDGPUGISelMITest::getTargetTestModuleString(

--- a/llvm/unittests/CodeGen/InstrRefLDVTest.cpp
+++ b/llvm/unittests/CodeGen/InstrRefLDVTest.cpp
@@ -81,9 +81,9 @@ public:
       GTEST_SKIP();
 
     TargetOptions Options;
-    Machine = std::unique_ptr<TargetMachine>(T->createTargetMachine(
-        Triple::normalize("x86_64--"), "", "", Options, std::nullopt,
-        std::nullopt, CodeGenOptLevel::Aggressive));
+    Machine = std::unique_ptr<TargetMachine>(
+        T->createTargetMachine(TargetTriple, "", "", Options, std::nullopt,
+                               std::nullopt, CodeGenOptLevel::Aggressive));
 
     auto Type = FunctionType::get(Type::getVoidTy(Ctx), false);
     auto F =

--- a/llvm/unittests/CodeGen/MachineDomTreeUpdaterTest.cpp
+++ b/llvm/unittests/CodeGen/MachineDomTreeUpdaterTest.cpp
@@ -57,7 +57,7 @@ public:
       GTEST_SKIP();
     TargetOptions Options;
     TM = std::unique_ptr<TargetMachine>(
-        T->createTargetMachine("X86", "", "", Options, std::nullopt));
+        T->createTargetMachine(TargetTriple, "", "", Options, std::nullopt));
     if (!TM)
       GTEST_SKIP();
     MMI = std::make_unique<MachineModuleInfo>(TM.get());
@@ -116,7 +116,7 @@ body:             |
     successors: %bb.2, %bb.4
     liveins: $rdi, $rsi
 
-    %1:gr32 = COPY $rsi
+    %1:gr64 = COPY $rsi
     %0:gr64 = COPY $rdi
     MOV64mr %1, 1, $noreg, 0, $noreg, %0 :: (store (s64) into %ir.p)
     %2:gr64 = SUB64ri32 %0, 1, implicit-def $eflags
@@ -206,7 +206,7 @@ body:             |
     successors: %bb.2, %bb.4
     liveins: $rdi, $rsi
 
-    %1:gr32 = COPY $rsi
+    %1:gr64 = COPY $rsi
     %0:gr64 = COPY $rdi
     MOV64mr %1, 1, $noreg, 0, $noreg, %0 :: (store (s64) into %ir.p)
     %2:gr64 = SUB64ri32 %0, 1, implicit-def $eflags

--- a/llvm/unittests/CodeGen/PassManagerTest.cpp
+++ b/llvm/unittests/CodeGen/PassManagerTest.cpp
@@ -162,16 +162,14 @@ public:
     // MachineModuleAnalysis needs a TargetMachine instance.
     llvm::InitializeAllTargets();
 
-    std::string TripleName = Triple::normalize(sys::getDefaultTargetTriple());
+    Triple TT(sys::getDefaultTargetTriple());
     std::string Error;
-    const Target *TheTarget =
-        TargetRegistry::lookupTarget(TripleName, Error);
+    const Target *TheTarget = TargetRegistry::lookupTarget(TT, Error);
     if (!TheTarget)
       return;
 
     TargetOptions Options;
-    TM.reset(TheTarget->createTargetMachine(TripleName, "", "", Options,
-                                            std::nullopt));
+    TM.reset(TheTarget->createTargetMachine(TT, "", "", Options, std::nullopt));
   }
 };
 

--- a/llvm/unittests/CodeGen/SelectionDAGAddressAnalysisTest.cpp
+++ b/llvm/unittests/CodeGen/SelectionDAGAddressAnalysisTest.cpp
@@ -48,7 +48,7 @@ protected:
 
     TargetOptions Options;
     TM = std::unique_ptr<TargetMachine>(
-        T->createTargetMachine("AArch64", "", "+sve", Options, std::nullopt,
+        T->createTargetMachine(TargetTriple, "", "+sve", Options, std::nullopt,
                                std::nullopt, CodeGenOptLevel::Aggressive));
     if (!TM)
       GTEST_SKIP();

--- a/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
+++ b/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
@@ -46,7 +46,7 @@ protected:
 
     TargetOptions Options;
     TM = std::unique_ptr<TargetMachine>(T->createTargetMachine(
-        "riscv64", "", "+m,+f,+d,+v", Options, std::nullopt, std::nullopt,
+        TargetTriple, "", "+m,+f,+d,+v", Options, std::nullopt, std::nullopt,
         CodeGenOptLevel::Aggressive));
     if (!TM)
       GTEST_SKIP();

--- a/llvm/unittests/CodeGen/TargetOptionsTest.cpp
+++ b/llvm/unittests/CodeGen/TargetOptionsTest.cpp
@@ -39,8 +39,8 @@ std::unique_ptr<TargetMachine> createTargetMachine(bool EnableIPRA) {
   TargetOptions Options;
   Options.EnableIPRA = EnableIPRA;
   return std::unique_ptr<TargetMachine>(
-      T->createTargetMachine("X86", "", "", Options, std::nullopt, std::nullopt,
-                             CodeGenOptLevel::Aggressive));
+      T->createTargetMachine(TargetTriple, "", "", Options, std::nullopt,
+                             std::nullopt, CodeGenOptLevel::Aggressive));
 }
 
 typedef std::function<void(bool)> TargetOptionsTest;

--- a/llvm/unittests/CodeGen/TestAsmPrinter.cpp
+++ b/llvm/unittests/CodeGen/TestAsmPrinter.cpp
@@ -49,13 +49,13 @@ TestAsmPrinter::create(const std::string &TripleStr, uint16_t DwarfVersion,
 llvm::Error TestAsmPrinter::init(const Target *TheTarget, StringRef TripleName,
                                  uint16_t DwarfVersion,
                                  dwarf::DwarfFormat DwarfFormat) {
-  TM.reset(TheTarget->createTargetMachine(TripleName, "", "", TargetOptions(),
+  Triple TheTriple(TripleName);
+  TM.reset(TheTarget->createTargetMachine(TheTriple, "", "", TargetOptions(),
                                           std::nullopt));
   if (!TM)
     return make_error<StringError>("no target machine for target " + TripleName,
                                    inconvertibleErrorCode());
 
-  Triple TheTriple(TripleName);
   MC.reset(new MCContext(TheTriple, TM->getMCAsmInfo(), TM->getMCRegisterInfo(),
                          TM->getMCSubtargetInfo()));
   TM->getObjFileLowering()->Initialize(*MC, *TM);

--- a/llvm/unittests/DebugInfo/DWARF/DwarfGenerator.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DwarfGenerator.cpp
@@ -482,7 +482,7 @@ llvm::Error dwarfgen::Generator::init(Triple TheTriple, uint16_t V) {
                                        TripleName,
                                    inconvertibleErrorCode());
 
-  TM.reset(TheTarget->createTargetMachine(TripleName, "", "", TargetOptions(),
+  TM.reset(TheTarget->createTargetMachine(TheTriple, "", "", TargetOptions(),
                                           std::nullopt));
   if (!TM)
     return make_error<StringError>("no target machine for target " + TripleName,

--- a/llvm/unittests/MC/AMDGPU/DwarfRegMappings.cpp
+++ b/llvm/unittests/MC/AMDGPU/DwarfRegMappings.cpp
@@ -32,13 +32,14 @@ createTargetMachine(std::string TStr, StringRef CPU, StringRef FS) {
   InitializeAMDGPUTarget();
 
   std::string Error;
-  const Target *T = TargetRegistry::lookupTarget(TStr, Error);
+  Triple TT(TStr);
+  const Target *T = TargetRegistry::lookupTarget(TT, Error);
   if (!T)
     return nullptr;
 
   TargetOptions Options;
-  return std::unique_ptr<TargetMachine>(T->createTargetMachine(
-      TStr, CPU, FS, Options, std::nullopt, std::nullopt));
+  return std::unique_ptr<TargetMachine>(
+      T->createTargetMachine(TT, CPU, FS, Options, std::nullopt, std::nullopt));
 }
 
 TEST(AMDGPUDwarfRegMappingTests, TestWave64DwarfRegMapping) {

--- a/llvm/unittests/MI/LiveIntervalTest.cpp
+++ b/llvm/unittests/MI/LiveIntervalTest.cpp
@@ -50,7 +50,7 @@ std::unique_ptr<TargetMachine> createTargetMachine() {
 
   TargetOptions Options;
   return std::unique_ptr<TargetMachine>(
-      T->createTargetMachine("AMDGPU", "gfx900", "", Options, std::nullopt,
+      T->createTargetMachine(TargetTriple, "gfx900", "", Options, std::nullopt,
                              std::nullopt, CodeGenOptLevel::Aggressive));
 }
 

--- a/llvm/unittests/MIR/MachineMetadata.cpp
+++ b/llvm/unittests/MIR/MachineMetadata.cpp
@@ -67,7 +67,8 @@ protected:
   }
 
   std::unique_ptr<TargetMachine>
-  createTargetMachine(std::string TT, StringRef CPU, StringRef FS) {
+  createTargetMachine(std::string TargetStr, StringRef CPU, StringRef FS) {
+    Triple TT(TargetStr);
     std::string Error;
     const Target *T = TargetRegistry::lookupTarget(TT, Error);
     if (!T)

--- a/llvm/unittests/MIR/MachineStableHashTest.cpp
+++ b/llvm/unittests/MIR/MachineStableHashTest.cpp
@@ -38,8 +38,9 @@ protected:
   void SetUp() override { M = std::make_unique<Module>("Dummy", Context); }
 
   std::unique_ptr<TargetMachine>
-  createTargetMachine(std::string TT, StringRef CPU, StringRef FS) {
+  createTargetMachine(std::string TStr, StringRef CPU, StringRef FS) {
     std::string Error;
+    Triple TT(TStr);
     const Target *T = TargetRegistry::lookupTarget(TT, Error);
     if (!T)
       return nullptr;

--- a/llvm/unittests/Target/AArch64/AArch64RegisterInfoTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64RegisterInfoTest.cpp
@@ -19,7 +19,7 @@ using namespace llvm;
 namespace {
 
 std::unique_ptr<TargetMachine> createTargetMachine(const std::string &CPU) {
-  auto TT(Triple::normalize("aarch64--"));
+  Triple TT("aarch64--");
 
   LLVMInitializeAArch64TargetInfo();
   LLVMInitializeAArch64Target();

--- a/llvm/unittests/Target/AArch64/AArch64SVESchedPseudoTest.cpp
+++ b/llvm/unittests/Target/AArch64/AArch64SVESchedPseudoTest.cpp
@@ -16,7 +16,7 @@
 using namespace llvm;
 namespace {
 std::unique_ptr<TargetMachine> createTargetMachine(const std::string &CPU) {
-  auto TT(Triple::normalize("aarch64--"));
+  Triple TT("aarch64--");
 
   LLVMInitializeAArch64TargetInfo();
   LLVMInitializeAArch64Target();

--- a/llvm/unittests/Target/AArch64/AddressingModes.cpp
+++ b/llvm/unittests/Target/AArch64/AddressingModes.cpp
@@ -202,7 +202,7 @@ TEST(AddressingModes, AddressingModes) {
   LLVMInitializeAArch64TargetMC();
 
   std::string Error;
-  auto TT = Triple::normalize("aarch64");
+  Triple TT("aarch64");
   const Target *T = TargetRegistry::lookupTarget(TT, Error);
 
   std::unique_ptr<TargetMachine> TM(

--- a/llvm/unittests/Target/AArch64/Immediates.cpp
+++ b/llvm/unittests/Target/AArch64/Immediates.cpp
@@ -88,7 +88,7 @@ TEST(Immediates, Immediates) {
   LLVMInitializeAArch64TargetMC();
 
   std::string Error;
-  auto TT = Triple::normalize("aarch64");
+  Triple TT("aarch64");
   const Target *T = TargetRegistry::lookupTarget(TT, Error);
 
   std::unique_ptr<TargetMachine> TM(T->createTargetMachine(

--- a/llvm/unittests/Target/AArch64/InstSizes.cpp
+++ b/llvm/unittests/Target/AArch64/InstSizes.cpp
@@ -13,7 +13,7 @@ using namespace llvm;
 
 namespace {
 std::unique_ptr<TargetMachine> createTargetMachine() {
-  auto TT(Triple::normalize("aarch64--"));
+  Triple TT("aarch64--");
   std::string CPU("generic");
   std::string FS("+pauth,+mops,+mte");
 

--- a/llvm/unittests/Target/AArch64/MatrixRegisterAliasing.cpp
+++ b/llvm/unittests/Target/AArch64/MatrixRegisterAliasing.cpp
@@ -8,7 +8,7 @@ using namespace llvm;
 
 namespace {
 std::unique_ptr<TargetMachine> createTargetMachine() {
-  auto TT(Triple::normalize("aarch64--"));
+  Triple TT("aarch64--");
   std::string CPU("generic");
   std::string FS("+sme");
 

--- a/llvm/unittests/Target/AMDGPU/AMDGPUUnitTests.cpp
+++ b/llvm/unittests/Target/AMDGPU/AMDGPUUnitTests.cpp
@@ -32,15 +32,16 @@ std::unique_ptr<const GCNTargetMachine>
 llvm::createAMDGPUTargetMachine(std::string TStr, StringRef CPU, StringRef FS) {
   InitializeAMDGPUTarget();
 
+  Triple TT(TStr);
   std::string Error;
-  const Target *T = TargetRegistry::lookupTarget(TStr, Error);
+  const Target *T = TargetRegistry::lookupTarget(TT, Error);
   if (!T)
     return nullptr;
 
   TargetOptions Options;
   return std::unique_ptr<GCNTargetMachine>(
       static_cast<GCNTargetMachine *>(T->createTargetMachine(
-          TStr, CPU, FS, Options, std::nullopt, std::nullopt)));
+          TT, CPU, FS, Options, std::nullopt, std::nullopt)));
 }
 
 static cl::opt<bool> PrintCpuRegLimits(

--- a/llvm/unittests/Target/AMDGPU/PALMetadata.cpp
+++ b/llvm/unittests/Target/AMDGPU/PALMetadata.cpp
@@ -40,16 +40,16 @@ protected:
   }
 
   PALMetadata() {
-    StringRef Triple = "amdgcn--amdpal";
+    Triple TT("amdgcn--amdpal");
     StringRef CPU = "gfx1010";
     StringRef FS = "";
 
     std::string Error;
-    const Target *TheTarget = TargetRegistry::lookupTarget(Triple, Error);
+    const Target *TheTarget = TargetRegistry::lookupTarget(TT, Error);
     TargetOptions Options;
 
     TM.reset(static_cast<GCNTargetMachine *>(TheTarget->createTargetMachine(
-        Triple, CPU, FS, Options, std::nullopt, std::nullopt)));
+        TT, CPU, FS, Options, std::nullopt, std::nullopt)));
 
     Ctx = std::make_unique<LLVMContext>();
     M = std::make_unique<Module>("Module", *Ctx);

--- a/llvm/unittests/Target/ARM/InstSizes.cpp
+++ b/llvm/unittests/Target/ARM/InstSizes.cpp
@@ -73,7 +73,7 @@ TEST(InstSizes, PseudoInst) {
   LLVMInitializeARMTarget();
   LLVMInitializeARMTargetMC();
 
-  auto TT(Triple::normalize("thumbv8.1m.main-none-none-eabi"));
+  Triple TT("thumbv8.1m.main-none-none-eabi");
   std::string Error;
   const Target *T = TargetRegistry::lookupTarget(TT, Error);
   if (!T) {

--- a/llvm/unittests/Target/ARM/MachineInstrTest.cpp
+++ b/llvm/unittests/Target/ARM/MachineInstrTest.cpp
@@ -74,7 +74,7 @@ TEST(MachineInstructionDoubleWidthResult, IsCorrect) {
   LLVMInitializeARMTarget();
   LLVMInitializeARMTargetMC();
 
-  auto TT(Triple::normalize("thumbv8.1m.main-none-none-eabi"));
+  Triple TT("thumbv8.1m.main-none-none-eabi");
   std::string Error;
   const Target *T = TargetRegistry::lookupTarget(TT, Error);
   if (!T) {
@@ -230,7 +230,7 @@ TEST(MachineInstructionHorizontalReduction, IsCorrect) {
   LLVMInitializeARMTarget();
   LLVMInitializeARMTargetMC();
 
-  auto TT(Triple::normalize("thumbv8.1m.main-none-none-eabi"));
+  Triple TT("thumbv8.1m.main-none-none-eabi");
   std::string Error;
   const Target *T = TargetRegistry::lookupTarget(TT, Error);
   if (!T) {
@@ -329,7 +329,7 @@ TEST(MachineInstructionRetainsPreviousHalfElement, IsCorrect) {
   LLVMInitializeARMTarget();
   LLVMInitializeARMTargetMC();
 
-  auto TT(Triple::normalize("thumbv8.1m.main-none-none-eabi"));
+  Triple TT("thumbv8.1m.main-none-none-eabi");
   std::string Error;
   const Target *T = TargetRegistry::lookupTarget(TT, Error);
   if (!T) {
@@ -1035,7 +1035,7 @@ TEST(MachineInstrValidTailPredication, IsCorrect) {
   LLVMInitializeARMTarget();
   LLVMInitializeARMTargetMC();
 
-  auto TT(Triple::normalize("thumbv8.1m.main-none-none-eabi"));
+  Triple TT("thumbv8.1m.main-none-none-eabi");
   std::string Error;
   const Target *T = TargetRegistry::lookupTarget(TT, Error);
   if (!T) {
@@ -1178,7 +1178,7 @@ TEST(MachineInstr, HasSideEffects) {
   LLVMInitializeARMTarget();
   LLVMInitializeARMTargetMC();
 
-  auto TT(Triple::normalize("thumbv8.1m.main-none-none-eabi"));
+  Triple TT("thumbv8.1m.main-none-none-eabi");
   std::string Error;
   const Target *T = TargetRegistry::lookupTarget(TT, Error);
   if (!T) {
@@ -2058,7 +2058,7 @@ TEST(MachineInstr, MVEVecSize) {
   LLVMInitializeARMTarget();
   LLVMInitializeARMTargetMC();
 
-  auto TT(Triple::normalize("thumbv8.1m.main-none-none-eabi"));
+  Triple TT("thumbv8.1m.main-none-none-eabi");
   std::string Error;
   const Target *T = TargetRegistry::lookupTarget(TT, Error);
   if (!T) {

--- a/llvm/unittests/Target/LoongArch/InstSizes.cpp
+++ b/llvm/unittests/Target/LoongArch/InstSizes.cpp
@@ -14,7 +14,7 @@ using namespace llvm;
 
 namespace {
 std::unique_ptr<TargetMachine> createTargetMachine() {
-  auto TT(Triple::normalize("loongarch64--"));
+  Triple TT("loongarch64--");
   std::string CPU("generic-la64");
   std::string FS("+64bit");
 

--- a/llvm/unittests/Target/PowerPC/AIXRelocModelTest.cpp
+++ b/llvm/unittests/Target/PowerPC/AIXRelocModelTest.cpp
@@ -27,7 +27,7 @@ TEST_F(AIXRelocModelTest, DefalutToPIC) {
   // Create a TargetMachine for powerpc--aix target, and deliberately leave its
   // relocation model unset.
   std::unique_ptr<TargetMachine> Target(TheTarget->createTargetMachine(
-      /*TT*/ TheTriple.getTriple(), /*CPU*/ "", /*Features*/ "",
+      /*TT*/ TheTriple, /*CPU*/ "", /*Features*/ "",
       /*Options*/ Options, /*RM*/ std::nullopt, /*CM*/ std::nullopt,
       /*OL*/ CodeGenOptLevel::Default));
   ASSERT_TRUE(Target) << "Could not allocate target machine!";

--- a/llvm/unittests/Target/RISCV/RISCVInstrInfoTest.cpp
+++ b/llvm/unittests/Target/RISCV/RISCVInstrInfoTest.cpp
@@ -43,7 +43,7 @@ protected:
 
   RISCVInstrInfoTest() {
     std::string Error;
-    auto TT(Triple::normalize(GetParam()));
+    Triple TT(GetParam());
     const Target *TheTarget = TargetRegistry::lookupTarget(TT, Error);
     TargetOptions Options;
 

--- a/llvm/unittests/Target/VE/MachineInstrTest.cpp
+++ b/llvm/unittests/Target/VE/MachineInstrTest.cpp
@@ -281,7 +281,7 @@ TEST(VETest, VLIndex) {
   LLVMInitializeVETarget();
   LLVMInitializeVETargetMC();
 
-  auto TT(Triple::normalize("ve-unknown-linux-gnu"));
+  Triple TT("ve-unknown-linux-gnu");
   std::string Error;
   const Target *T = TargetRegistry::lookupTarget(TT, Error);
   if (!T) {

--- a/llvm/unittests/Target/WebAssembly/WebAssemblyExceptionInfoTest.cpp
+++ b/llvm/unittests/Target/WebAssembly/WebAssemblyExceptionInfoTest.cpp
@@ -23,7 +23,7 @@ using namespace llvm;
 namespace {
 
 std::unique_ptr<TargetMachine> createTargetMachine() {
-  auto TT(Triple::normalize("wasm32-unknown-unknown"));
+  Triple TT("wasm32-unknown-unknown");
   std::string CPU;
   std::string FS;
 

--- a/llvm/unittests/Target/X86/MachineSizeOptsTest.cpp
+++ b/llvm/unittests/Target/X86/MachineSizeOptsTest.cpp
@@ -29,7 +29,7 @@ using namespace llvm;
 namespace {
 
 std::unique_ptr<TargetMachine> createTargetMachine() {
-  auto TT(Triple::normalize("x86_64--"));
+  Triple TT("x86_64--");
   std::string Error;
   const Target *TheTarget = TargetRegistry::lookupTarget(TT, Error);
   return std::unique_ptr<TargetMachine>(

--- a/llvm/unittests/Target/X86/TernlogTest.cpp
+++ b/llvm/unittests/Target/X86/TernlogTest.cpp
@@ -25,7 +25,7 @@ static std::unique_ptr<TargetMachine> initTM() {
   LLVMInitializeX86Target();
   LLVMInitializeX86TargetMC();
 
-  auto TT(Triple::normalize("x86_64--"));
+  Triple TT("x86_64--");
   std::string Error;
   const Target *TheTarget = TargetRegistry::lookupTarget(TT, Error);
   return std::unique_ptr<TargetMachine>(

--- a/llvm/unittests/tools/llvm-exegesis/Common/AssemblerUtils.h
+++ b/llvm/unittests/tools/llvm-exegesis/Common/AssemblerUtils.h
@@ -29,16 +29,15 @@ namespace exegesis {
 
 class MachineFunctionGeneratorBaseTest : public ::testing::Test {
 protected:
-  MachineFunctionGeneratorBaseTest(const std::string &TT,
+  MachineFunctionGeneratorBaseTest(const std::string &TargetStr,
                                    const std::string &CpuName)
-      : TT(TT), CpuName(CpuName),
-        CanExecute(Triple(TT).getArch() ==
-                   Triple(sys::getProcessTriple()).getArch()),
-        ET(ExegesisTarget::lookup(Triple(TT))) {
+      : TT(TargetStr), CpuName(CpuName),
+        CanExecute(TT.getArch() == Triple(sys::getProcessTriple()).getArch()),
+        ET(ExegesisTarget::lookup(TT)) {
     assert(ET);
     if (!CanExecute) {
       outs() << "Skipping execution, host:" << sys::getProcessTriple()
-             << ", target:" << TT << "\n";
+             << ", target:" << TT.str() << "\n";
     }
   }
 
@@ -64,11 +63,11 @@ private:
   std::unique_ptr<TargetMachine> createTargetMachine() {
     std::string Error;
     const Target *TheTarget = TargetRegistry::lookupTarget(TT, Error);
-    EXPECT_TRUE(TheTarget) << Error << " " << TT;
+    EXPECT_TRUE(TheTarget) << Error << " " << TT.str();
     const TargetOptions Options;
     TargetMachine *TM = TheTarget->createTargetMachine(TT, CpuName, "", Options,
                                                        Reloc::Model::Static);
-    EXPECT_TRUE(TM) << TT << " " << CpuName;
+    EXPECT_TRUE(TM) << TT.str() << " " << CpuName;
     return std::unique_ptr<TargetMachine>(TM);
   }
 
@@ -90,7 +89,7 @@ private:
     return std::move(*ExecFunc);
   }
 
-  const std::string TT;
+  const Triple TT;
   const std::string CpuName;
   const bool CanExecute;
   const ExegesisTarget *const ET;

--- a/mlir/lib/Target/LLVM/ModuleToObject.cpp
+++ b/mlir/lib/Target/LLVM/ModuleToObject.cpp
@@ -68,8 +68,8 @@ ModuleToObject::getOrCreateTargetMachine() {
   }
 
   // Create the target machine using the target.
-  targetMachine.reset(
-      target->createTargetMachine(triple, chip, features, {}, {}));
+  targetMachine.reset(target->createTargetMachine(llvm::Triple(triple), chip,
+                                                  features, {}, {}));
   if (!targetMachine)
     return std::nullopt;
   return targetMachine.get();

--- a/offload/plugins-nextgen/common/src/JIT.cpp
+++ b/offload/plugins-nextgen/common/src/JIT.cpp
@@ -115,7 +115,7 @@ createTargetMachine(Module &M, std::string CPU, unsigned OptLevel) {
   TargetOptions Options = codegen::InitTargetOptionsFromCodeGenFlags(TT);
 
   std::unique_ptr<TargetMachine> TM(T->createTargetMachine(
-      M.getTargetTriple().str(), CPU, Features.getString(), Options, RelocModel,
+      M.getTargetTriple(), CPU, Features.getString(), Options, RelocModel,
       CodeModel, CGOptLevel));
   if (!TM)
     return make_error<StringError>("Failed to create target machine",

--- a/offload/plugins-nextgen/common/src/JIT.cpp
+++ b/offload/plugins-nextgen/common/src/JIT.cpp
@@ -114,9 +114,9 @@ createTargetMachine(Module &M, std::string CPU, unsigned OptLevel) {
 
   TargetOptions Options = codegen::InitTargetOptionsFromCodeGenFlags(TT);
 
-  std::unique_ptr<TargetMachine> TM(T->createTargetMachine(
-      M.getTargetTriple(), CPU, Features.getString(), Options, RelocModel,
-      CodeModel, CGOptLevel));
+  std::unique_ptr<TargetMachine> TM(
+      T->createTargetMachine(M.getTargetTriple(), CPU, Features.getString(),
+                             Options, RelocModel, CodeModel, CGOptLevel));
   if (!TM)
     return make_error<StringError>("Failed to create target machine",
                                    inconvertibleErrorCode());


### PR DESCRIPTION
This avoids doing a Triple -> std::string -> Triple round trip in lots of places, now that the Module stores a Triple.