### PR TITLE
[not for merge][RFC] Key Instructions front end demo

### DIFF
--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -1339,6 +1339,7 @@ void CodeGenFunction::EmitCtorPrologue(const CXXConstructorDecl *CD,
     assert(!Member->isBaseInitializer());
     assert(Member->isAnyMemberInitializer() &&
            "Delegating initializer on non-delegating constructor");
+    auto Grp = ApplyAtomGroup(*this);
     CM.addMemberInitializer(Member);
   }
   CM.finish();

--- a/clang/lib/CodeGen/CGCleanup.cpp
+++ b/clang/lib/CodeGen/CGCleanup.cpp
@@ -17,6 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "CGCleanup.h"
+#include "CGDebugInfo.h"
 #include "CodeGenFunction.h"
 #include "llvm/Support/SaveAndRestore.h"
 
@@ -1118,6 +1119,8 @@ void CodeGenFunction::EmitBranchThroughCleanup(JumpDest Dest) {
 
   // Create the branch.
   llvm::BranchInst *BI = Builder.CreateBr(Dest.getBlock());
+  // This is the primary instruction for this atom, acting as a ret.
+  addInstToCurrentSourceAtom(BI, nullptr);
 
   // Calculate the innermost active normal cleanup.
   EHScopeStack::stable_iterator

--- a/clang/lib/CodeGen/CGDeclCXX.cpp
+++ b/clang/lib/CodeGen/CGDeclCXX.cpp
@@ -215,8 +215,10 @@ void CodeGenFunction::EmitCXXGlobalVarDeclInit(const VarDecl &D,
     }
     bool NeedsDtor =
         D.needsDestruction(getContext()) == QualType::DK_cxx_destructor;
-    if (PerformInit)
+    if (PerformInit) {
+      auto Grp = ApplyAtomGroup(*this);
       EmitDeclInit(*this, D, DeclAddr);
+    }
     if (D.getType().isConstantStorage(getContext(), true, !NeedsDtor))
       EmitDeclInvariant(*this, D, DeclPtr);
     else

--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -892,6 +892,7 @@ public:
     return result;                                                             \
   }                                                                            \
   Value *VisitBin##OP##Assign(const CompoundAssignOperator *E) {               \
+    auto Grp = ApplyAtomGroup(CGF);                                            \
     return EmitCompoundAssign(E, &ScalarExprEmitter::Emit##OP);                \
   }
   HANDLEBINOP(Mul)
@@ -2935,6 +2936,7 @@ public:
 llvm::Value *
 ScalarExprEmitter::EmitScalarPrePostIncDec(const UnaryOperator *E, LValue LV,
                                            bool isInc, bool isPre) {
+  auto Grp = ApplyAtomGroup(CGF);
   OMPLastprivateConditionalUpdateRAII OMPRegion(CGF, E);
   QualType type = E->getSubExpr()->getType();
   llvm::PHINode *atomicPHI = nullptr;
@@ -4953,6 +4955,7 @@ llvm::Value *CodeGenFunction::EmitWithOriginalRHSBitfieldAssignment(
 }
 
 Value *ScalarExprEmitter::VisitBinAssign(const BinaryOperator *E) {
+  auto Grp = ApplyAtomGroup(CGF);
   bool Ignore = TestAndClearIgnoreResultAssign();
 
   Value *RHS;
@@ -5720,6 +5723,7 @@ LValue CodeGenFunction::EmitObjCIsaExpr(const ObjCIsaExpr *E) {
 
 LValue CodeGenFunction::EmitCompoundAssignmentLValue(
                                             const CompoundAssignOperator *E) {
+  auto Grp = ApplyAtomGroup(*this);
   ScalarExprEmitter Scalar(*this);
   Value *Result = nullptr;
   switch (E->getOpcode()) {

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -3018,6 +3018,7 @@ public:
   /// Emit an aggregate assignment.
   void EmitAggregateAssign(LValue Dest, LValue Src, QualType EltTy) {
     bool IsVolatile = hasVolatileMember(EltTy);
+    auto Grp = ApplyAtomGroup(*this);
     EmitAggregateCopy(Dest, Src, EltTy, AggValueSlot::MayOverlap, IsVolatile);
   }
 
@@ -5255,7 +5256,7 @@ public:
 
   /// Emit a reached-unreachable diagnostic if \p Loc is valid and runtime
   /// checking is enabled. Otherwise, just emit an unreachable instruction.
-  void EmitUnreachable(SourceLocation Loc);
+  llvm::UnreachableInst *EmitUnreachable(SourceLocation Loc);
 
   /// Create a basic block that will call the trap intrinsic, and emit a
   /// conditional branch to it, for the -ftrapv checks.
@@ -5312,6 +5313,21 @@ public:
   llvm::Value *emitBoolVecConversion(llvm::Value *SrcVec,
                                      unsigned NumElementsDst,
                                      const llvm::Twine &Name = "");
+
+  // Wrapper, see \p DebugInfo::addInstToCurrentSourceAtom.
+  void addInstToCurrentSourceAtom(llvm::Instruction *KeyInstruction,
+                                  llvm::Value *Backup, uint8_t KeyInstRank = 1);
+
+  // Wrapper, see \p DebugInfo::addInstToCurrentSourceAtom.
+  // Adds the instruction to a new source atom rather than the existing
+  // scoped one.
+  void addInstToNewSourceAtom(llvm::Instruction *KeyInstruction,
+                              llvm::Value *Backup, uint8_t KeyInstRank = 1);
+
+  // TODO(OCH): Comment.
+  void addRetToOverrideOrNewSourceAtom(llvm::ReturnInst *Ret,
+                                       llvm::Value *Backup,
+                                       uint8_t KeyInstRank = 1);
 
 private:
   // Emits a convergence_loop instruction for the given |BB|, with |ParentToken|

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -5054,6 +5054,7 @@ void ItaniumCXXABI::emitBeginCatch(CodeGenFunction &CGF,
 
   // Emit the local.
   CodeGenFunction::AutoVarEmission var = CGF.EmitAutoVarAlloca(*CatchParam);
+  auto Grp = ApplyAtomGroup(CGF);
   InitCatchParam(CGF, *CatchParam, var.getObjectAddress(CGF), S->getBeginLoc());
   CGF.EmitAutoVarCleanups(var);
 }

--- a/clang/test/KeyInstructions/agg-cpy.cpp
+++ b/clang/test/KeyInstructions/agg-cpy.cpp
@@ -1,0 +1,13 @@
+
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+struct Struct { int a, b, c; };
+void fun(Struct &a, Struct &b) {
+// CHECK: call void @llvm.memcpy{{.*}}, !dbg  [[G1R1:!.*]]
+  a = b;
+// CHECK: ret void, !dbg [[G2R1:!.*]]
+}
+
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)

--- a/clang/test/KeyInstructions/agg-init-bzero-plus-stores.cpp
+++ b/clang/test/KeyInstructions/agg-init-bzero-plus-stores.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+char g;
+void a() {
+// CHECK: _Z1av()
+// CHECK: call void @llvm.memset{{.*}}, !dbg [[G1R1:!.*]]
+// CHECK: store i8 97{{.*}}, !dbg [[G1R1]]
+// CHECK: store i8 98{{.*}}, !dbg [[G1R1]]
+// CHECK: store i8 99{{.*}}, !dbg [[G1R1]]
+// CHECK: store i8 100{{.*}}, !dbg [[G1R1]]
+  char big[65536] = { 'a', 'b', 'c', 'd' };
+
+// CHECK: call void @llvm.memset{{.*}}, !dbg [[G2R1:!.*]]
+// CHECK: [[l:%.*]] = load i8{{.*}}, !dbg [[G2R2:!.*]]
+// CHECK: store i8 [[l]]{{.*}}, !dbg [[G2R1C22:!.*]]
+  char big2[65536] = { g };
+// CHECK: ret void{{.*}}, !dbg [[G3R1:!.*]]
+}
+
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
+// CHECK: [[G2R1C22]] = !DILocation({{.*}}column: 22{{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)

--- a/clang/test/KeyInstructions/agg-init.cpp
+++ b/clang/test/KeyInstructions/agg-init.cpp
@@ -1,0 +1,24 @@
+
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+// The implicit-check-not is important; we don't want the GEPs created for the
+// store locations to be included in the atom group.
+
+int g;
+void a() {
+// CHECK: _Z1av()
+// CHECK: call void @llvm.memcpy{{.*}}, !dbg [[G1R1:!.*]]
+    int A[] = { 1, 2, 3};
+// CHECK: store i32 1, ptr %{{.*}}, !dbg [[G2R1:!.*]]
+// CHECK: store i32 2, ptr %{{.*}}, !dbg [[G2R1]]
+// CHECK: %0 = load i32, ptr @g{{.*}}, !dbg [[G2R2:!.*]]
+// CHECK: store i32 %0, ptr %{{.*}}, !dbg [[G2R1]]
+    int B[] = { 1, 2, g};
+// CHECK: ret{{.*}}, !dbg [[G3R1:!.*]]
+}
+
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
+// CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)

--- a/clang/test/KeyInstructions/agg-null-init.cpp
+++ b/clang/test/KeyInstructions/agg-null-init.cpp
@@ -1,0 +1,21 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+struct S { void *data[3]; };
+
+// CHECK: _Z1av
+// CHECK-NEXT: entry:
+// CHECK-NEXT: call void @llvm.memset{{.*}}, !dbg [[A_G1R2:!.*]]
+// CHECK-NEXT: ret void, !dbg [[A_G1R1:!.*]]
+S a() { return S(); }
+
+// CHECK: _Z1bv
+// CHECK-NEXT: entry:
+// CHECK-NEXT: call void @llvm.memset{{.*}}, !dbg [[B_G1R2:!.*]]
+// CHECK-NEXT: ret void, !dbg [[B_G1R1:!.*]]
+S b() { return S{}; }
+
+// CHECK: [[A_G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[A_G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[B_G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[B_G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)

--- a/clang/test/KeyInstructions/agg-return-va-arg.cpp
+++ b/clang/test/KeyInstructions/agg-return-va-arg.cpp
@@ -1,0 +1,23 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+typedef struct {
+  struct{} a;
+  double b;
+} s1;
+
+s1 f(int z, ...) {
+  __builtin_va_list list;
+  __builtin_va_start(list, z);
+// CHECK: vaarg.end:
+// CHECK-NEXT: %vaarg.addr = phi ptr
+// CHECK-NEXT: call void @llvm.memcpy{{.*}}, !dbg [[COL10_G1R2:!.*]]
+// CHECK-NEXT: %3 = getelementptr{{.*}}
+// CHECK-NEXT: %4 = load double, ptr %3{{.*}} !dbg [[COL3_G1R2:!.*]]
+// CHECK-NEXT: ret double %4, !dbg [[G1R1:!.*]]
+  return __builtin_va_arg(list, s1);
+}
+
+// CHECK: [[COL10_G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[COL3_G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)

--- a/clang/test/KeyInstructions/assign.c
+++ b/clang/test/KeyInstructions/assign.c
@@ -1,0 +1,11 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+unsigned long long g;
+void fun() { g = 0; }
+
+// CHECK: store i64 0, ptr @g{{.*}}, !dbg [[G1R1:!.*]]
+// CHECK: ret void, !dbg [[G2R1:!.*]]
+
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)

--- a/clang/test/KeyInstructions/binop.c
+++ b/clang/test/KeyInstructions/binop.c
@@ -1,0 +1,17 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+long a;
+void b() {
+  long l;
+  l += a;
+}
+
+// CHECK: %add = add {{.*}}, !dbg [[G1R2:!.*]]
+// CHECK: store {{.*}}, !dbg [[G1R1:!.*]]
+// CHECK: ret void, !dbg [[G2R1:!.*]]
+
+// CHECK: [[G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+

--- a/clang/test/KeyInstructions/bitfield.cpp
+++ b/clang/test/KeyInstructions/bitfield.cpp
@@ -1,0 +1,15 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+struct S { int a:3; };
+
+void foo(int x, S s) {
+// CHECK: %bf.set = or i8 %bf.clear, %bf.value, !dbg [[G1R2:!.*]]
+// CHECK: store i8 %bf.set, ptr %s, align 4, !dbg [[G1R1:!.*]]
+  s.a = x;
+// CHECK: ret void, !dbg [[G2R1:!.*]]
+}
+
+// CHECK: [[G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)

--- a/clang/test/KeyInstructions/cast.cpp
+++ b/clang/test/KeyInstructions/cast.cpp
@@ -1,0 +1,17 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s
+//--implicit-check-not atomGroup --implicit-check-not atomRank
+
+float g;
+void a() {
+// CHECK: %0 = load float, ptr @g{{.*}}, !dbg [[G1R3:!.*]]
+// CHECK: %conv = fptosi float %0 to i32{{.*}}, !dbg [[G1R2:!.*]]
+// CHECK: store i32 %conv, ptr %a{{.*}}, !dbg [[G1R1:!.*]]
+    int a = g;
+// CHECK: ret{{.*}}, !dbg [[G2R1:!.*]]
+}
+
+// CHECK: [[G1R3]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 3)
+// CHECK: [[G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)

--- a/clang/test/KeyInstructions/complex.cpp
+++ b/clang/test/KeyInstructions/complex.cpp
@@ -1,0 +1,28 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+_Complex int ci;
+void test() {
+// CHECK: %ci.real = load i32, ptr @ci{{.*}}, !dbg [[G1R2:!.*]]
+// CHECK: %ci.imag = load i32, ptr getelementptr inbounds ({ i32, i32 }, ptr @ci, i32 0, i32 1){{.*}}, !dbg [[G1R2]]
+// CHECK: store i32 %ci.real, ptr @ci{{.*}}, !dbg [[G1R1:!.*]]
+// CHECK: store i32 %ci.imag, ptr getelementptr inbounds ({ i32, i32 }, ptr @ci, i32 0, i32 1){{.*}}, !dbg [[G1R1]]
+  ci = ci;
+// CHECK: %add.r = add i32 %ci.real3, %ci.real1, !dbg [[G2R2:!.*]]
+// CHECK: %add.i = add i32 %ci.imag4, %ci.imag2, !dbg [[G2R2]]
+// CHECK: store i32 %add.r, ptr @ci{{.*}}, !dbg [[G2R1:!.*]]
+// CHECK: store i32 %add.i, ptr getelementptr inbounds ({ i32, i32 }, ptr @ci, i32 0, i32 1){{.*}}, !dbg [[G2R1]]
+  ci += ci;
+// CHECK: %add = add nsw i32 %0, %1, !dbg [[G3R2:!.*]]
+// CHECK: store i32 %add, ptr getelementptr inbounds ({ i32, i32 }, ptr @ci, i32 0, i32 1){{.*}}, !dbg [[G3R1:!.*]]
+  __imag ci = __imag ci + __imag ci;
+// CHECK: ret void, !dbg [[G4R1:!.*]]
+}
+
+// CHECK: [[G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[G3R2]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 2)
+// CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
+// CHECK: [[G4R1]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 1)

--- a/clang/test/KeyInstructions/compound-assign.cpp
+++ b/clang/test/KeyInstructions/compound-assign.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+unsigned long long g;
+void fun() { g += 60; }
+
+// CHECK: %add = add i64 %0, 60, !dbg [[G1R2:!.*]]
+// CHECK: store i64 %add, ptr @g{{.*}}, !dbg [[G1R1:!.*]]
+// CHECK: ret void, !dbg [[G2R1:!.*]]
+
+// CHECK: [[G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)

--- a/clang/test/KeyInstructions/do.cpp
+++ b/clang/test/KeyInstructions/do.cpp
@@ -1,0 +1,20 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+// FIXME: Perennial quesiton: should the dec be its own source atom or not
+// (currently it is).
+
+void a(int A) {
+// CHECK: %dec = add nsw i32 %0, -1, !dbg [[G1R2:!.*]]
+// CHECK: store i32 %dec, ptr %A.addr{{.*}}, !dbg [[G1R1:!.*]]
+// CHECK: %tobool = icmp ne i32 %dec, 0, !dbg [[G2R2:!.*]]
+// CHECK: br i1 %tobool, label %do.body, label %do.end, !dbg [[G2R1:!.*]], !llvm.loop
+    do { } while (--A);
+// CHECK: ret{{.*}}, !dbg [[G3R1:!.*]]
+}
+
+// CHECK: [[G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)

--- a/clang/test/KeyInstructions/double-assign.cpp
+++ b/clang/test/KeyInstructions/double-assign.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+// FIXME: Question - should these all be in the same atomGroup or not?
+// FIXME: Because of the atomGroup implementation the load can only be
+// associated with one of the two stores, despite being a good backup
+// loction for both.
+
+int g;
+void a() {
+// CHECK: %0 = load i32, ptr @g{{.*}}, !dbg [[G1R2:!.*]]
+// CHECK: store i32 %0, ptr %b{{.*}}, !dbg [[G2R1:!.*]]
+// CHECK: store i32 %0, ptr %a{{.*}}, !dbg [[G1R1:!.*]]
+  int a, b;
+  a = b = g;
+// CHECK: ret{{.*}}, !dbg [[G3R1:!.*]]
+}
+
+// CHECK: [[G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)

--- a/clang/test/KeyInstructions/for.cpp
+++ b/clang/test/KeyInstructions/for.cpp
@@ -1,0 +1,34 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+// FIXME: Perennial quesiton: should the inc be its own source atom or not
+// (currently it is).
+
+void a(int A) {
+// CHECK: entry:
+// CHECK: store i32 0, ptr %i{{.*}}, !dbg [[G1R1:!.*]]
+// CHECK: for.cond:
+// CHECK: %cmp = icmp slt i32 %0, %1, !dbg [[G2R2:!.*]]
+// CHECK: br i1 %cmp, label %for.body, label %for.end, !dbg [[G2R1:!.*]]
+
+// FIXME: Added uncond br group here which is useful for O0, which we're
+// no longer targeting. With optimisations loop rotate puts the condition
+// into for.inc and simplifycfg smooshes that and for.body together, so
+// it's not clear whether it adds any value.
+// CHECK: for.body:
+// CHECK: br label %for.inc, !dbg [[G4R1:!.*]]
+
+// CHECK: for.inc:
+// CHECK: %inc = add{{.*}}, !dbg [[G3R2:!.*]]
+// CHECK: store i32 %inc, ptr %i{{.*}}, !dbg [[G3R1:!.*]]
+    for (int i = 0; i < A; ++i) { }
+// CHECK: ret void, !dbg [[G5R1:!.*]]
+}
+
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[G4R1]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 1)
+// CHECK: [[G3R2]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 2)
+// CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
+// CHECK: [[G5R1]] = !DILocation({{.*}}, atomGroup: 5, atomRank: 1)

--- a/clang/test/KeyInstructions/if.cpp
+++ b/clang/test/KeyInstructions/if.cpp
@@ -1,0 +1,42 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+int g;
+void a(int A) {
+// CHECK: entry:
+// CHECK: %tobool = icmp ne i32 %0, 0{{.*}}, !dbg [[G1R2:!.*]]
+// CHECK: br i1 %tobool, label %if.then, label %if.end{{.*}}, !dbg [[G1R1:!.*]]
+    if (A)
+        ;
+// The assignment in the if currently gets a distinct source atom group.
+// FIXME: Is that the right choice?
+// CHECK: if.end:
+// CHECK: %1 = load i32, ptr %A.addr{{.*}}, !dbg [[G2R2:!.*]]
+// CHECK: store i32 %1, ptr @g{{.*}}, !dbg [[G2R1:!.*]]
+// CHECK: %tobool1 = icmp ne i32 %1, 0{{.*}}, !dbg [[G3R2:!.*]]
+// CHECK: br i1 %tobool1, label %if.then2, label %if.end3{{.*}}, !dbg [[G3R1:!.*]]
+    if ((g = A))
+        ;
+// The assignment in the if currently gets a distinct source atom group.
+// FIXME: Is that the right choice?
+// CHECK: if.end3:
+// CHECK: %2 = load i32, ptr %A.addr{{.*}}, !dbg [[G4R2:!.*]]
+// CHECK: store i32 %2, ptr %B{{.*}}, !dbg [[G4R1:!.*]]
+// CHECK: %tobool4 = icmp ne i32 %3, 0{{.*}}, !dbg [[G5R2:!.*]]
+// CHECK: br i1 %tobool4, label %if.then5, label %if.end6{{.*}}, !dbg [[G5R1:!.*]]
+    if (int B = A; B)
+        ;
+// CHECK: ret{{.*}}, !dbg [[G6R1:!.*]]
+}
+
+// CHECK: [[G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[G3R2]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 2)
+// CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
+// CHECK: [[G4R2]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 2)
+// CHECK: [[G4R1]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 1)
+// CHECK: [[G5R2]] = !DILocation({{.*}}, atomGroup: 5, atomRank: 2)
+// CHECK: [[G5R1]] = !DILocation({{.*}}, atomGroup: 5, atomRank: 1)
+// CHECK: [[G6R1]] = !DILocation({{.*}}, atomGroup: 6, atomRank: 1)

--- a/clang/test/KeyInstructions/inc.cpp
+++ b/clang/test/KeyInstructions/inc.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+int g;
+void fun() { g++; }
+
+// CHECK: %inc = add nsw i32 %0, 1, !dbg [[G1R2:!.*]]
+// CHECK: store i32 %inc, ptr @g{{.*}}, !dbg [[G1R1:!.*]]
+// CHECK: ret void, !dbg [[G2R1:!.*]]
+
+// CHECK: [[G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)

--- a/clang/test/KeyInstructions/member-init.cpp
+++ b/clang/test/KeyInstructions/member-init.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s
+
+class Cls {
+  int x = 1;
+};
+
+void fun() {
+  Cls c;
+}
+
+// CHECK: store i32 1, ptr %x{{.*}}, !dbg [[G1R1:!.*]]
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)

--- a/clang/test/KeyInstructions/memset.c
+++ b/clang/test/KeyInstructions/memset.c
@@ -1,0 +1,10 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - \
+// RUN: | FileCheck %s
+
+void *memset(void *, int, unsigned long);
+void a(int *P) {
+    memset(P, 1, 8);
+}
+
+// CHECK: call void @llvm.memset{{.*}}, !dbg [[G1R1:!.*]]
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)

--- a/clang/test/KeyInstructions/multi-func.cpp
+++ b/clang/test/KeyInstructions/multi-func.cpp
@@ -1,0 +1,28 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+// Check atomGroup is reset to start at 1 in each function.
+
+void a() {
+// CHECK: _Z1av()
+// CHECK: store i32 0, ptr %A{{.*}}, !dbg [[A_G1R1:!.*]]
+    int A = 0;
+// CHECK: store i32 0, ptr %B{{.*}}, !dbg [[A_G2R1:!.*]]
+    int B = 0;
+// CHECK: ret{{.*}}, !dbg [[A_G3R1:!.*]]
+}
+
+void b() {
+// CHECK: _Z1bv()
+// CHECK: store i32 0, ptr %A{{.*}}, !dbg [[B_G1R1:!.*]]
+    int A = 0;
+// CHECK: ret{{.*}}, !dbg [[B_G2R1:!.*]]
+}
+
+// CHECK: [[A:!.*]] = distinct !DISubprogram(name: "a",
+// CHECK: [[A_G1R1]] = !DILocation({{.*}}, scope: [[A]], atomGroup: 1, atomRank: 1)
+// CHECK: [[A_G2R1]] = !DILocation({{.*}}, scope: [[A]], atomGroup: 2, atomRank: 1)
+// CHECK: [[A_G3R1]] = !DILocation({{.*}}, scope: [[A]], atomGroup: 3, atomRank: 1)
+// CHECK: [[B:!.*]] = distinct !DISubprogram(name: "b",
+// CHECK: [[B_G1R1]] = !DILocation({{.*}}, scope: [[B]], atomGroup: 1, atomRank: 1)
+// CHECK: [[B_G2R1]] = !DILocation({{.*}}, scope: [[B]], atomGroup: 2, atomRank: 1)

--- a/clang/test/KeyInstructions/new.cpp
+++ b/clang/test/KeyInstructions/new.cpp
@@ -1,0 +1,36 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+
+void f(int x) {
+// CHECK: %call = call noalias noundef nonnull ptr @_Znwm{{.*}}, !dbg [[G1R2_C12:!.*]]
+// CHECK: %0 = load i32, ptr %x.addr{{.*}}, !dbg [[G1R2_C20:!.*]]
+// CHECK: store i32 %0, ptr %call{{.*}}, !dbg [[G1R1_C12:!.*]]
+// CHECK: store ptr %call, ptr %{{.*}}, !dbg [[G1R1_C8:!.*]]
+  int *n = new int(x);
+// CHECK: %call1 = call noalias noundef nonnull ptr @_Znwm{{.*}}, !dbg [[G2R2_C7:!.*]]
+// CHECK: %1 = load i32, ptr %x.addr{{.*}}, !dbg [[G2R2_C15:!.*]]
+// CHECK: store i32 %1, ptr %call{{.*}}, !dbg [[G2R1_C7:!.*]]
+// CHECK: store ptr %call1, ptr %{{.*}}, !dbg [[G2R1_C5:!.*]]
+  n = new int(x);
+// CHECK: %2 = load i32, ptr %x.addr{{.*}}, !dbg [[G3R2:!.*]]
+// CHECK: %3 = load ptr, ptr %n
+// CHECK: store i32 %2, ptr %3{{.*}}, !dbg [[G3R1:!.*]]
+  *n = x;
+// CHECK: ret void, !dbg [[G4R1:!.*]]
+}
+
+// CHECK: [[G1R2_C12]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[G1R2_C20]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[G1R1_C12]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G1R1_C8]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+
+// CHECK: [[G2R2_C7]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
+// CHECK: [[G2R2_C15]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
+// CHECK: [[G2R1_C7]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[G2R1_C5]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+
+// CHECK: [[G3R2]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 2)
+// CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
+
+// CHECK: [[G4R1]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 1)

--- a/clang/test/KeyInstructions/ret-agg.cpp
+++ b/clang/test/KeyInstructions/ret-agg.cpp
@@ -1,0 +1,23 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+struct S {
+  void* a;
+  void* b;
+};
+S get();
+void fun() {
+// CHECK: %0 = getelementptr inbounds { ptr, ptr }, ptr %s, i32 0, i32 0
+// CHECK: %1 = extractvalue { ptr, ptr } %call, 0, !dbg [[G1R2:!.*]]
+// CHECK: store ptr %1, ptr %0{{.*}}, !dbg [[G1R1:!.*]]
+// CHECK: %2 = getelementptr inbounds { ptr, ptr }, ptr %s, i32 0, i32 1
+// CHECK: %3 = extractvalue { ptr, ptr } %call, 1, !dbg [[G1R2]]
+// CHECK: store ptr %3, ptr %2{{.*}}, !dbg [[G1R1:!.*]]
+  S s = get();
+// CHECK: ret void, !dbg [[G2R1:!.*]]
+}
+
+// CHECK: [[G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+

--- a/clang/test/KeyInstructions/return-no-loc.c
+++ b/clang/test/KeyInstructions/return-no-loc.c
@@ -1,0 +1,26 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+// The implicit return here get the line number of the closing brace; make it
+// key to match existing behaviour.
+
+int a() {
+  if (a)
+    return 1;
+}
+
+// CHECK: br i1 true{{.*}}, !dbg [[G1R1:!.*]]
+
+// CHECK: if.then:
+// CHECK-NEXT: store i32 1, ptr %retval{{.*}}, !dbg [[G2R2:!.*]]
+// CHECK-NEXT: br label %if.end, !dbg [[G2R1:!.*]]
+
+// CHECK: if.end:
+// CHECK-NEXT: %0 = load i32, ptr %retval{{.*}}, !dbg [[G3R2:!.*]]
+// CHECK-NEXT: ret i32{{.*}}, !dbg [[G3R1:!.*]]
+
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[G3R2]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 2)
+// CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)

--- a/clang/test/KeyInstructions/return-ref.cpp
+++ b/clang/test/KeyInstructions/return-ref.cpp
@@ -1,0 +1,19 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s
+
+// Include ctrl-flow to stop ret value store being elided.
+
+int g;
+int &f(int &r) {
+  if (r)
+// CHECK: if.then:
+// CHECK-NEXT: %2 = load ptr, ptr %r.addr{{.*}}, !dbg [[G2R3:!.*]]
+// CHECK-NEXT: store ptr %2, ptr %retval{{.*}}, !dbg [[G2R2:!.*]]
+// CHECK-NEXT: br label %return, !dbg [[G2R1:!.*]]
+    return r;
+  return g;
+}
+
+// CHECK: [[G2R3]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 3)
+// CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)

--- a/clang/test/KeyInstructions/return.c
+++ b/clang/test/KeyInstructions/return.c
@@ -1,0 +1,36 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+int g;
+float a() {
+  if (a)
+    return g;
+  return 1;
+}
+
+// CHECK: entry:
+// CHECK: br i1 true{{.*}}, !dbg [[G1R1:!.*]]
+
+// CHECK: if.then:
+// CHECK-NEXT: %0 = load i32, ptr @g{{.*}}, !dbg [[G2R4:!.*]]
+// CHECK-NEXT: %conv = sitofp i32 %0 to float{{.*}}, !dbg [[G2R3:!.*]]
+// CHECK-NEXT: store float %conv, ptr %retval{{.*}}, !dbg [[G2R2:!.*]]
+// CHECK-NEXT: br label %return{{.*}}, !dbg [[G2R1:!.*]]
+
+// CHECK: if.end:
+// CHECK-NEXT: store float 1.000000e+00, ptr %retval{{.*}}, !dbg [[G3R2:!.*]]
+// CHECK-NEXT: br label %return, !dbg [[G3R1:!.*]]
+
+// CHECK: return:
+// CHECK-NEXT:  %1 = load float, ptr %retval{{.*}}, !dbg [[G4R2:!.*]]
+// CHECK-NEXT:  ret float %1{{.*}}, !dbg [[G4R1:!.*]]
+
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R4]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 4)
+// CHECK: [[G2R3]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 3)
+// CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[G3R2]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 2)
+// CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
+// CHECK: [[G4R2]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 2)
+// CHECK: [[G4R1]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 1)

--- a/clang/test/KeyInstructions/return.cpp
+++ b/clang/test/KeyInstructions/return.cpp
@@ -1,0 +1,26 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+// NOTE: (return) (g = 1) are two separate atoms. FIXME: is that best?
+
+int g;
+
+// CHECK: _Z1av()
+// CHECK: ret void{{.*}}, !dbg [[A_G1R1:!.*]]
+void a() { return; }
+
+// CHECK: _Z1bv()
+// CHECK: %add = add{{.*}}, !dbg [[B_G1R2:!.*]]
+// CHECK: ret i32 %add{{.*}}, !dbg [[B_G1R1:!.*]]
+int  b() { return g + 1; }
+
+// CHECK: _Z1cv()
+// CHECK: store{{.*}}, !dbg [[C_G2R1:!.*]]
+// CHECK: ret i32 1{{.*}}, !dbg [[C_G1R1:!.*]]
+int  c() { return g = 1; }
+
+// CHECK: [[A_G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[B_G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[B_G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[C_G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[C_G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)

--- a/clang/test/KeyInstructions/scalar-init.cpp
+++ b/clang/test/KeyInstructions/scalar-init.cpp
@@ -1,0 +1,17 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+void a() {
+// CHECK: _Z1av()
+// CHECK: store i32 0, ptr %A{{.*}}, !dbg [[G1R1:!.*]]
+    int A = 0;
+// CHECK: %add = add {{.*}}, !dbg [[G2R2:!.*]]
+// CHECK: store i32 %add, ptr %B, align 4, !dbg [[G2R1:!.*]]
+    int B = 2 * A + 1;
+// CHECK: ret{{.*}}, !dbg [[G3R1:!.*]]
+}
+
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)

--- a/clang/test/KeyInstructions/static-init.cpp
+++ b/clang/test/KeyInstructions/static-init.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+void g(int *a) {
+// CHECK: %2 = load ptr, ptr %a.addr{{.*}}, !dbg [[G1R2:!.*]]
+// CHECK: store ptr %2, ptr @_ZZ1gPiE1b{{.*}}, !dbg [[G1R1:!.*]]
+  static int &b = *a;
+// CHECK: ret void, !dbg [[G2R2:!.*]]
+}
+
+// CHECK: [[G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)

--- a/clang/test/KeyInstructions/try-catch.cpp
+++ b/clang/test/KeyInstructions/try-catch.cpp
@@ -1,0 +1,20 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -fexceptions -fcxx-exceptions \
+// RUN: | FileCheck %s
+
+void except() {
+  // FIXME(OCH): Should `store i32 32, ptr %exception` be key?
+  throw 32;
+}
+
+void attempt() {
+  try { except(); }
+// CHECK: catch:
+// CHECK: %4 = call ptr @__cxa_begin_catch(ptr %exn)
+// CHECK: %5 = load i32{{.*}}, !dbg [[G1R2:!.*]]
+// CHECK: store i32 %5, ptr %e{{.*}}, !dbg [[G1R1:!.*]]
+// CHECK: call void @__cxa_end_catch()
+  catch (int e) { }
+}
+
+// CHECK: [[G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)

--- a/clang/test/KeyInstructions/while.cpp
+++ b/clang/test/KeyInstructions/while.cpp
@@ -1,0 +1,20 @@
+// RUN: %clang %s -gmlt -gcolumn-info -S -emit-llvm -o - -Wno-unused-variable \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+// FIXME: Perennial quesiton: should the `dec` be in its own source atom or not
+// (currently it is).
+
+void a(int A) {
+// CHECK: %dec = add nsw i32 %0, -1, !dbg [[G1R2:!.*]]
+// CHECK: store i32 %dec, ptr %A.addr{{.*}}, !dbg [[G1R1:!.*]]
+// CHECK: %tobool = icmp ne i32 %dec, 0, !dbg [[G2R2:!.*]]
+// CHECK: br i1 %tobool, label %while.body, label %while.end, !dbg [[G2R1:!.*]]
+    while (--A) { };
+// CHECK: ret{{.*}}, !dbg [[G3R1:!.*]]
+}
+
+// CHECK: [[G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)

--- a/llvm/include/llvm/IR/LLVMContext.h
+++ b/llvm/include/llvm/IR/LLVMContext.h
@@ -335,6 +335,10 @@ public:
   StringRef getDefaultTargetFeatures();
   void setDefaultTargetFeatures(StringRef Features);
 
+  /// Key Instructions: update the highest number Atom Group emitted for any
+  /// function.
+  void updateAtomGroupWaterline(uint64_t V);
+
 private:
   // Module needs access to the add/removeModule methods.
   friend class Module;

--- a/llvm/lib/IR/LLVMContext.cpp
+++ b/llvm/lib/IR/LLVMContext.cpp
@@ -377,3 +377,7 @@ StringRef LLVMContext::getDefaultTargetFeatures() {
 void LLVMContext::setDefaultTargetFeatures(StringRef Features) {
   pImpl->DefaultTargetFeatures = Features;
 }
+
+void LLVMContext::updateAtomGroupWaterline(uint64_t V) {
+  pImpl->NextAtomGroup = std::max(pImpl->NextAtomGroup, V);
+}


### PR DESCRIPTION
This draft pull request demonstrates our proposed approach to annotating instructions with Key Instructions metadata. It's not fully complete but works as a proof of concept and I welcome and encourage feedback on the approach, as I'm not particularly familiar with Clang.

The Key Instructions project is introduced here https://discourse.llvm.org/t/rfc-improving-is-stmt-placement-for-better-interactive-debugging/82668, which includes a "quick summary" section at the top which adds context for this PR.

I'll walk through the changes first, followed by some questions at the end.

Note: this PR doesn't include the LLVM parts, so you won't be able to try it out locally.

## Overview

We'd like Clang to annotate instructions with additional metadata (bundled inside DILocations) so that LLVM can make better `is_stmt` placement decisions. Specifically we'll add two new fields to DILocations: An "atom group" number for instructions that perform key functionality ("interesting" behaviour from a debugger-user perspective, see _Key Instructions: Solving the Code Location Problem for Optimized Code (C. Tice, . S. L. Graham, 2000)_); and an "atom rank" number which indicates precedence within a set of instructions that have the same atom group number.

In the project prototype we interpreted IR in a pre-optimisation pass to decide the metadata placement. Having Clang perform the annotation comes with several benefits: it allows the front end to be opinionated about stepping locations, it's more performant for the front end to do it, and it hopefully improves the chance that it can be adopted into other front ends in which the prototype approach isn't approprite.

First, here's an example to highlight the new metadata we'll be producing:

`$ cat -n test.cpp`
```
1.  void f(int a) {
2.    int x[256] = {a};
3.  }
```
`clang++ test.cpp -gmlt -emit-llvm -S`
```
define hidden void @_Z1fi(i32 noundef %a) #0 !dbg !11 {
entry:
  %a.addr = alloca i32, align 4
  %x = alloca [256 x i32], align 16
  store i32 %a, ptr %a.addr, align 4
  call void @llvm.memset.p0.i64(ptr align 16 %x, i8 0, i64 1024, i1 false), !dbg !14      ; atom 1, rank 1
  %arrayinit.begin = getelementptr inbounds [256 x i32], ptr %x, i64 0, i64 0, !dbg !15
  %0 = load i32, ptr %a.addr, align 4, !dbg !16                                           ; atom 1, rank 2
  store i32 %0, ptr %arrayinit.begin, align 4, !dbg !17                                   ; atom 1, rank 1
  ret void, !dbg !18                                                                      ; atom 2, rank 1
}

...
!14 = !DILocation(line: 2, column: 7, scope: !11, atomGroup: 1, atomRank: 1)
!15 = !DILocation(line: 2, column: 16, scope: !11)
!16 = !DILocation(line: 2, column: 17, scope: !11, atomGroup: 1, atomRank: 2)
!17 = !DILocation(line: 2, column: 16, scope: !11, atomGroup: 1, atomRank: 1)
!18 = !DILocation(line: 3, column: 1, scope: !11, atomGroup: 2, atomRank: 1)
```
Atom 1 represents the aggregate initialization of `x`. The store and memset have rank 1. That gives them precedence the load of `a` with rank 2, which is essentially a "backup instruction" for the purposes of assigning `is_stmt`. If all rank 1 instructions are optimized away, we'll use that instead. Atom 2 represents the implicit return (given the source location of the closing brace).

<details>
<summary>
DWARF emission info for additional context (feel free to ignore).
</summary>

Not shown in this patch - During dwarf emission, for each atom group, the last instruction in a block that shares the lowest rank will be candidates for `is_stmt`. The wording is tricky, but essentially if any rank 1 instructions exist, higher rank (lower precedence) instructions won't be candidates for `is_stmt` even if they're in different blocks, but all the final rank 1 instructions in the group in different blocks will be.

As an optimisation for convinience (mostly to minimise unecessary difference when the feature is enabled, but also to improve variable availability in some cases), we apply a heuristc that "floats" the `is_stmt` up to the first instruction in a contiguous block of instructions with the same line number.

In the example above the `store` in atom 1 is the candidate for `is_stmt` (the `memset` comes before the `store` and the `load` is lower precedence as well as before the `store`). Because of the heuristic described above, the `is_stmt` flag floats up to the memset, as all the preceeding instructions have the same line number.
</details>

## Implementation

We need to annotate assignments, conditional branches, some unconditional branches, and calls as these are instructions implementing "key functionality". The GEP used to compute the offset at which to store a value for an assignment is not interesting, but the store itself is. We also want to annotate "backup instructions". E.g., the instruction computing the value being stored, or the `cmp` used for a conditional branch.

`ApplyAtomGroup` works similarly to and alongside `ApplyDebugLocation` as an RAII wrapper around a "current atom group" number during CodeGen. The current atom number is applied to certain instructions as they're emitted (stores, branches, etc) using `addInstToCurrentSourceAtom`.

Here's how it looks with the aggregate initialisation example from the overview section:

<details>
<summary>
`EmitAutoVarInit` creates a new atom group with `ApplyAtomGroup`.
</summary>

```
> clang::CodeGen::ApplyAtomGroup::ApplyAtomGroup(clang::CodeGen::CodeGenFunction & CGF) Line 184
  clang::CodeGen::CodeGenFunction::EmitAutoVarInit(const clang::CodeGen::CodeGenFunction::AutoVarEmission & emission) Line 1958 ++
  clang::CodeGen::CodeGenFunction::EmitAutoVarDecl(const clang::VarDecl & D) Line 1358
  clang::CodeGen::CodeGenFunction::EmitVarDecl(const clang::VarDecl & D) Line 219
  ...
```
</details>

<details>
<summary>
`CheckAggExprForMemSetUse` calls `addInstToCurrentSourceAtom` to add the memset to the current atom group.
</summary>

```
> clang::CodeGen::CodeGenFunction::addInstToCurrentSourceAtom(llvm::Instruction * KeyInstruction, llvm::Value * Backup, unsigned   char KeyInstRank) Line 2551
  CheckAggExprForMemSetUse(clang::CodeGen::AggValueSlot & Slot, const clang::Expr * E, clang::CodeGen::CodeGenFunction & CGF) Line   2026
  clang::CodeGen::CodeGenFunction::EmitAggExpr(const clang::Expr * E, clang::CodeGen::AggValueSlot Slot) Line 2043
  clang::CodeGen::CodeGenFunction::EmitExprAsInit(const clang::Expr * init, const clang::ValueDecl * D, clang::CodeGen::LValue   lvalue, bool capturedByInit) Line 2104
  clang::CodeGen::CodeGenFunction::EmitAutoVarInit(const clang::CodeGen::CodeGenFunction::AutoVarEmission & emission) Line 2047
  clang::CodeGen::CodeGenFunction::EmitAutoVarDecl(const clang::VarDecl & D) Line 1358
  clang::CodeGen::CodeGenFunction::EmitVarDecl(const clang::VarDecl & D) Line 219
  ...
```
</details>

<details>
<summary>
`EmitStoreOfScalar` does the same for the store (note - this is the same atom group number as the memset).
</summary>

```
> clang::CodeGen::CodeGenFunction::addInstToCurrentSourceAtom(llvm::Instruction * KeyInstruction, llvm::Value * Backup, unsigned char KeyInstRank) Line 2551
  clang::CodeGen::CodeGenFunction::EmitStoreOfScalar(llvm::Value * Value, clang::CodeGen::Address Addr, bool Volatile, clang::QualType Ty, clang::CodeGen::LValueBaseInfo BaseInfo, clang::CodeGen::TBAAAccessInfo TBAAInfo, bool isInit, bool isNontemporal) Line 2133
  clang::CodeGen::CodeGenFunction::EmitStoreOfScalar(llvm::Value * value, clang::CodeGen::LValue lvalue, bool isInit) Line 2152
  clang::CodeGen::CodeGenFunction::EmitStoreThroughLValue(clang::CodeGen::RValue Src, clang::CodeGen::LValue Dst, bool isInit) Line 2466
  clang::CodeGen::CodeGenFunction::EmitScalarInit(const clang::Expr * init, const clang::ValueDecl * D, clang::CodeGen::LValue lvalue, bool capturedByInit) Line 803
  `anonymous namespace'::AggExprEmitter::EmitInitializationToLValue(clang::Expr * E, clang::CodeGen::LValue LV) Line 1592
  `anonymous namespace'::AggExprEmitter::EmitArrayInit(clang::CodeGen::Address DestPtr, llvm::ArrayType * AType, clang::QualType rrayQTy, clang::Expr * ExprToVisit, llvm::ArrayRef<clang::Expr *> Args, clang::Expr * ArrayFiller) Line 614
  `anonymous namespace'::AggExprEmitter::VisitCXXParenListOrInitListExpr(clang::Expr * ExprToVisit, llvm::ArrayRef<clang::Expr *> nitExprs, clang::FieldDecl * InitializedFieldInUnion, clang::Expr * ArrayFiller) Line 1672
  `anonymous namespace'::AggExprEmitter::VisitInitListExpr(clang::InitListExpr * E) Line 1641
  clang::StmtVisitorBase<std::add_pointer,`anonymous namespace'::AggExprEmitter,void>::Visit(clang::Stmt * S) Line 352
  `anonymous namespace'::AggExprEmitter::Visit(clang::Expr * E) Line 114
  clang::CodeGen::CodeGenFunction::EmitAggExpr(const clang::Expr * E, clang::CodeGen::AggValueSlot Slot) Line 2045
  clang::CodeGen::CodeGenFunction::EmitExprAsInit(const clang::Expr * init, const clang::ValueDecl * D, clang::CodeGen::LValue value, bool capturedByInit) Line 2104
  clang::CodeGen::CodeGenFunction::EmitAutoVarInit(const clang::CodeGen::CodeGenFunction::AutoVarEmission & emission) Line 2047	C+
  clang::CodeGen::CodeGenFunction::EmitAutoVarDecl(const clang::VarDecl & D) Line 1358
  clang::CodeGen::CodeGenFunction::EmitVarDecl(const clang::VarDecl & D) Line 219
  ...
```

</details>

`addInstToCurrentSourceAtom` annotates the instruction that produces the stored value too, with a higher rank than the store (lower precedence).


## Rough edges and questions

* The single-block return statement handling (see changes in `EmitReturnBlock` in clang/lib/CodeGen/CGStmt.cpp and `addRetToOverrideOrNewSourceAtom` usage in `EmitFunctionEpilog`) doesn't fit the RAII model (I've not found any other cases yet though).
* There's some inefficiency: DILocations are attached to instructions then immediately replaced with a new version with Key Instructions metadata.
* It doesn't fail gracefully: if we accidentally fail to annotate instructions that should be key, those instructions won't be candidate for `is_stmt` and therefore will likely be stepped-over while debugging.
    * Is there a way to implement this that errs on over-application of annotations?
        * Perhaps every statement (in `EmitStmt`) could be assumed to be in an atom group by default, with particular statements opting out, rather than interesting ones opting in?
        * I think we could add all stores (and memsets etc) to a "new" atom group by default, unless there's an "active" RAII group already or they've opted-out. That would offer a graceful fallback for stores. It doesn't help so much with control flow (as I think only some branches are interesting, compared to most stores being interesting).

Finally, does this direction look reasonable overall?