### PR TITLE
[flang][OpenMP] Don't allow namelist variables with threadprivate

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -1516,7 +1516,9 @@ void OmpStructureChecker::CheckThreadprivateOrDeclareTargetVar(
                       "A variable in a %s directive cannot appear in an "
                       "EQUIVALENCE statement"_err_en_US,
                       ContextDirectiveAsFortran());
-                } else if (name->symbol->test(Symbol::Flag::InNamelist)) {
+                } else if (name->symbol->test(Symbol::Flag::InNamelist) &&
+                    GetContext().directive ==
+                        llvm::omp::Directive::OMPD_threadprivate) {
                   context_.Say(name->source,
                       "A variable in a %s directive cannot appear in a NAMELIST"_err_en_US,
                       ContextDirectiveAsFortran());
@@ -1575,7 +1577,9 @@ void OmpStructureChecker::CheckThreadprivateOrDeclareTargetVar(
                           ContextDirectiveAsFortran(), obj->name(),
                           name.symbol->name());
                     }
-                    if (obj->test(Symbol::Flag::InNamelist)) {
+                    if (obj->test(Symbol::Flag::InNamelist) &&
+                        GetContext().directive ==
+                            llvm::omp::OMPD_threadprivate) {
                       context_.Say(name.source,
                           "A variable in a %s directive cannot appear in a NAMELIST"_err_en_US,
                           ContextDirectiveAsFortran());

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -1516,6 +1516,10 @@ void OmpStructureChecker::CheckThreadprivateOrDeclareTargetVar(
                       "A variable in a %s directive cannot appear in an "
                       "EQUIVALENCE statement"_err_en_US,
                       ContextDirectiveAsFortran());
+                } else if (name->symbol->test(Symbol::Flag::InNamelist)) {
+                  context_.Say(name->source,
+                      "A variable in a %s directive cannot appear in a NAMELIST"_err_en_US,
+                      ContextDirectiveAsFortran());
                 } else if (name->symbol->test(Symbol::Flag::OmpThreadprivate) &&
                     GetContext().directive ==
                         llvm::omp::Directive::OMPD_declare_target) {
@@ -1570,6 +1574,11 @@ void OmpStructureChecker::CheckThreadprivateOrDeclareTargetVar(
                           "A variable in a %s directive cannot appear in an EQUIVALENCE statement (variable '%s' from common block '/%s/')"_err_en_US,
                           ContextDirectiveAsFortran(), obj->name(),
                           name.symbol->name());
+                    }
+                    if (obj->test(Symbol::Flag::InNamelist)) {
+                      context_.Say(name.source,
+                          "A variable in a %s directive cannot appear in a NAMELIST"_err_en_US,
+                          ContextDirectiveAsFortran());
                     }
                   }
                 }

--- a/flang/test/Semantics/OpenMP/threadprivate09.f90
+++ b/flang/test/Semantics/OpenMP/threadprivate09.f90
@@ -1,0 +1,12 @@
+! RUN: %python %S/../test_errors.py %s %flang_fc1 %openmp_flags
+
+! Check that namelist variables cannot be used with threadprivate
+
+module m
+  integer :: nam1
+  common /com1/nam1
+  namelist /nam/nam1
+
+  !ERROR: A variable in a THREADPRIVATE directive cannot appear in a NAMELIST
+  !$omp threadprivate(/com1/)
+end


### PR DESCRIPTION
While the standard doesn't explicitly mention namelist variables in this case, it does prohibit privatization of namelist variables. Flang decided to also prohibit namelist variables from appearing in a reduction clause.

Variables that are part of a namelist are linked to I/O mechanisms, and their memory association and initialization are managed by the compiler in a way that conflicts with the requirements of threadprivate variables. I propose we should add this restriction.