### PR TITLE
[flang][OpenMP] Silence unused-but-set-variable message (NFC)

### DIFF
--- a/flang/lib/Lower/OpenMP/Clauses.cpp
+++ b/flang/lib/Lower/OpenMP/Clauses.cpp
@@ -165,6 +165,7 @@ std::optional<Object> getBaseObject(const Object &object,
       // e.g. A(i) is represented as {Symbol(A), Designator(ArrayRef(A, i))}.
       // Here we have the Symbol(A), which is what we started with.
       assert(&**symRef == object.sym());
+      [[maybe_unused]] auto *unused = symRef;
       return std::nullopt;
     }
   } else {


### PR DESCRIPTION
This patch is to get around the unused-but-set message.
```
llvm-project/flang/lib/Lower/OpenMP/Clauses.cpp:162:22: error: variable 'symRef' set but not used [-Werror,-Wunused-but-set-variable]
  162 |     } else if (auto *symRef = base.UnwrapSymbolRef()) {
      |                      ^
1 error generated.
```