### PR TITLE
[gold] Use ld.bfd for tests

### DIFF
--- a/llvm/cmake/config-ix.cmake
+++ b/llvm/cmake/config-ix.cmake
@@ -654,7 +654,8 @@ else( LLVM_ENABLE_THREADS )
   message(STATUS "Threads disabled.")
 endif()
 
-find_program(GOLD_EXECUTABLE NAMES ${LLVM_DEFAULT_TARGET_TRIPLE}-ld.gold ld.gold ${LLVM_DEFAULT_TARGET_TRIPLE}-ld ld DOC "The gold linker")
+find_program(GOLD_EXECUTABLE NAMES ${LLVM_DEFAULT_TARGET_TRIPLE}-ld.gold ld.gold DOC "The gold linker")
+find_program(LD_BFD_EXECUTABLE NAMES ${LLVM_DEFAULT_TARGET_TRIPLE}-ld.bfd ld.bfd ${LLVM_DEFAULT_TARGET_TRIPLE}-ld ld DOC "The bfd linker")
 set(LLVM_BINUTILS_INCDIR "" CACHE PATH
     "PATH to binutils/include containing plugin-api.h for gold plugin.")
 

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -228,6 +228,7 @@ tools = [
     ToolSubst("%lli", FindTool("lli"), post=".", extra_args=lli_args),
     ToolSubst("%llc_dwarf", FindTool("llc"), extra_args=llc_args),
     ToolSubst("%gold", config.gold_executable, unresolved="ignore"),
+    ToolSubst("%ld_bfd", config.ld_bfd_executable, unresolved="ignore"),
     ToolSubst("%ld64", ld64_cmd, unresolved="ignore"),
     ToolSubst("%ocamlc", ocamlc_command, unresolved="ignore"),
     ToolSubst("%ocamlopt", ocamlopt_command, unresolved="ignore"),
@@ -649,14 +650,14 @@ if config.have_llvm_driver:
 import subprocess
 
 
-def have_ld_plugin_support():
+def have_ld_plugin_support(ld_executable, name):
     if not os.path.exists(
         os.path.join(config.llvm_shlib_dir, "LLVMgold" + config.llvm_shlib_ext)
     ):
         return False
 
     ld_cmd = subprocess.Popen(
-        [config.gold_executable, "--help"], stdout=subprocess.PIPE, env={"LANG": "C"}
+        [ld_executable, "--help"], stdout=subprocess.PIPE, env={"LANG": "C"}
     )
     ld_out = ld_cmd.stdout.read().decode()
     ld_cmd.wait()
@@ -679,18 +680,20 @@ def have_ld_plugin_support():
         config.available_features.add("ld_emu_elf32ppc")
 
     ld_version = subprocess.Popen(
-        [config.gold_executable, "--version"], stdout=subprocess.PIPE, env={"LANG": "C"}
+        [ld_executable, "--version"], stdout=subprocess.PIPE, env={"LANG": "C"}
     )
-    if not "GNU gold" in ld_version.stdout.read().decode():
+    if not name in ld_version.stdout.read().decode():
         return False
     ld_version.wait()
 
     return True
 
 
-if have_ld_plugin_support():
+if have_ld_plugin_support(config.ld_bfd_executable, "GNU ld"):
     config.available_features.add("ld_plugin")
 
+if have_ld_plugin_support(config.gold_executable, "GNU gold"):
+    config.available_features.add("gold_linker")
 
 def have_ld64_plugin_support():
     if not os.path.exists(

--- a/llvm/test/lit.site.cfg.py.in
+++ b/llvm/test/lit.site.cfg.py.in
@@ -18,6 +18,7 @@ config.lit_tools_dir = path(r"@LLVM_LIT_TOOLS_DIR@")
 config.errc_messages = "@LLVM_LIT_ERRC_MESSAGES@"
 config.python_executable = "@Python3_EXECUTABLE@"
 config.gold_executable = "@GOLD_EXECUTABLE@"
+config.ld_bfd_executable = "@LD_BFD_EXECUTABLE@"
 config.ld64_executable = "@LD64_EXECUTABLE@"
 config.osx_sysroot = path(r"@CMAKE_OSX_SYSROOT@")
 config.osx_xcrun = path(r"@CMAKE_XCRUN@")

--- a/llvm/test/tools/gold/PowerPC/mtriple.ll
+++ b/llvm/test/tools/gold/PowerPC/mtriple.ll
@@ -1,7 +1,7 @@
 ; REQUIRES: ld_emu_elf32ppc
 
 ; RUN: llvm-as %s -o %t.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext -m elf32ppc \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext -m elf32ppc \
 ; RUN:    -plugin-opt=mtriple=powerpc-linux-gnu \
 ; RUN:    -plugin-opt=obj-path=%t3.o \
 ; RUN:    -shared %t.o -o %t2

--- a/llvm/test/tools/gold/X86/Inputs/linkonce_odr_unnamed_addr.ll
+++ b/llvm/test/tools/gold/X86/Inputs/linkonce_odr_unnamed_addr.ll
@@ -3,3 +3,11 @@ target triple = "x86_64-grtev4-linux-gnu"
 
 @linkonceodrunnamed = linkonce_odr unnamed_addr constant i32 0
 @odrunnamed = weak_odr unnamed_addr constant i32 0
+
+; ld.bfd requires relocations to be present to count as a native code
+; reference.
+define void @refs() {
+  load volatile i32, ptr @linkonceodrunnamed
+  load volatile i32, ptr @odrunnamed
+  ret void
+}

--- a/llvm/test/tools/gold/X86/alias.ll
+++ b/llvm/test/tools/gold/X86/alias.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.o
 ; RUN: llvm-as %p/Inputs/alias-1.ll -o %t2.o
-; RUN: %gold -shared -o %t3.o -plugin %llvmshlibdir/LLVMgold%shlibext %t2.o %t.o \
+; RUN: %ld_bfd -shared -o %t3.o -plugin %llvmshlibdir/LLVMgold%shlibext %t2.o %t.o \
 ; RUN:  -plugin-opt=emit-llvm
 ; RUN: llvm-dis < %t3.o -o - | FileCheck %s
 

--- a/llvm/test/tools/gold/X86/alias2.ll
+++ b/llvm/test/tools/gold/X86/alias2.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t.o
-; RUN: %gold -shared -o %t2.bc -plugin %llvmshlibdir/LLVMgold%shlibext %t.o -plugin-opt=emit-llvm
+; RUN: %ld_bfd -shared -o %t2.bc -plugin %llvmshlibdir/LLVMgold%shlibext %t.o -plugin-opt=emit-llvm
 ; RUN: llvm-dis %t2.bc -o - | FileCheck %s
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"

--- a/llvm/test/tools/gold/X86/asm_undefined.ll
+++ b/llvm/test/tools/gold/X86/asm_undefined.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t.o
-; RUN: %gold -shared -m elf_x86_64 -o %t2 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -shared -m elf_x86_64 -o %t2 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN: %t.o --plugin-opt=save-temps
 ; RUN: llvm-nm %t2 | FileCheck %s --check-prefix=OUTPUT
 

--- a/llvm/test/tools/gold/X86/asm_undefined2.ll
+++ b/llvm/test/tools/gold/X86/asm_undefined2.ll
@@ -1,12 +1,12 @@
 ; RegularLTO testcase
 ; RUN: llvm-as %s -o %t.o
-; RUN: %gold -shared -m elf_x86_64 -o %t2 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -shared -m elf_x86_64 -o %t2 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN: %t.o --plugin-opt=save-temps -upatatino
 ; RUN: llvm-dis < %t2.0.5.precodegen.bc | FileCheck %s
 
 ; ThinLTO testcase
 ; RUN: opt -module-summary %s -o %t.o
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=save-temps \
 ; RUN:     --plugin-opt=thinlto -o %t2 %t.o
 ; RUN: llvm-dis < %t.o.5.precodegen.bc | FileCheck --check-prefix=CHECKTHIN %s

--- a/llvm/test/tools/gold/X86/available-externally.ll
+++ b/llvm/test/tools/gold/X86/available-externally.ll
@@ -1,12 +1,12 @@
 ; RUN: llvm-as %s -o %t.o
 ; RUN: llvm-as %p/Inputs/available-externally.ll -o %t2.o
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t.o %t2.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck %s
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t2.o %t.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck %s

--- a/llvm/test/tools/gold/X86/bad-alias.ll
+++ b/llvm/test/tools/gold/X86/bad-alias.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.o
 
-; RUN: not %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: not %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t.o -o %t2.o 2>&1 | FileCheck %s
 

--- a/llvm/test/tools/gold/X86/bcsection.ll
+++ b/llvm/test/tools/gold/X86/bcsection.ll
@@ -4,7 +4,7 @@
 ; RUN: llvm-mc -I=%t -filetype=obj -triple=x86_64-unknown-unknown -o %t/bcsection.bco %p/Inputs/bcsection.s
 ; RUN: llc -filetype=obj -mtriple=x86_64-unknown-unknown -o %t/bcsection-lib.o %p/Inputs/bcsection-lib.ll
 
-; RUN: %gold -shared --no-undefined -o %t/bcsection.so -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext %t/bcsection.bco %t/bcsection-lib.o
+; RUN: %ld_bfd -shared --no-undefined -o %t/bcsection.so -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext %t/bcsection.bco %t/bcsection-lib.o
 
 ; This test checks that the gold plugin does not attempt to use the bitcode
 ; in the .llvmbc section for LTO.  bcsection-lib.o calls a function that is

--- a/llvm/test/tools/gold/X86/cache.ll
+++ b/llvm/test/tools/gold/X86/cache.ll
@@ -3,7 +3,7 @@
 ; RUN: opt -module-summary %p/Inputs/cache.ll -o %t2.o
 
 ; RUN: rm -Rf %t.cache
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=thinlto \
 ; RUN:     --plugin-opt=cache-dir=%t.cache \
 ; RUN:     -o %t3.o %t2.o %t.o
@@ -18,7 +18,7 @@
 ; RUN: opt -module-hash -module-summary %p/Inputs/cache.ll -o %t2.o
 
 ; RUN: rm -Rf %t.cache
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=thinlto \
 ; RUN:     --plugin-opt=cache-dir=%t.cache \
 ; RUN:     -o %t3.o %t2.o %t.o
@@ -31,7 +31,7 @@
 ; We should only remove files matching the pattern "llvmcache-*".
 
 ; RUN: touch -t 197001011200 %t.cache/llvmcache-foo %t.cache/foo
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=thinlto \
 ; RUN:     --plugin-opt=cache-dir=%t.cache \
 ; RUN:     --plugin-opt=cache-policy=prune_after=1h:prune_interval=0s \
@@ -45,7 +45,7 @@
 ; RUN: %python -c "print(' ' * 65536)" > %t.cache/llvmcache-foo
 
 ; This should leave the file in place.
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=thinlto \
 ; RUN:     --plugin-opt=cache-dir=%t.cache \
 ; RUN:     --plugin-opt=cache-policy=cache_size_bytes=128k:prune_interval=0s \
@@ -57,7 +57,7 @@
 ; RUN: touch -r %t.cache/llvmcache-foo -d '-2 minutes' %t.cache/llvmcache-foo
 
 ; This should remove it.
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=thinlto \
 ; RUN:     --plugin-opt=save-temps \
 ; RUN:     --plugin-opt=cache-dir=%t.cache \

--- a/llvm/test/tools/gold/X86/coff.ll
+++ b/llvm/test/tools/gold/X86/coff.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext -plugin-opt=emit-llvm \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext -plugin-opt=emit-llvm \
 ; RUN:    -shared %t.o -o %t2.o
 ; RUN: llvm-dis %t2.o -o - | FileCheck %s
 

--- a/llvm/test/tools/gold/X86/comdat-nodeduplicate.ll
+++ b/llvm/test/tools/gold/X86/comdat-nodeduplicate.ll
@@ -1,6 +1,9 @@
 ;; Keep __profd_foo in a nodeduplicate comdat, despite a comdat of the same name
 ;; in a previous object file.
 
+; --start-lib is not supported by ld.bfd, use gold instead.
+; REQUIRES: gold_linker
+
 ;; Regular LTO
 
 ; RUN: rm -rf %t && split-file %s %t

--- a/llvm/test/tools/gold/X86/comdat.ll
+++ b/llvm/test/tools/gold/X86/comdat.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t1.o
 ; RUN: llvm-as %p/Inputs/comdat.ll -o %t2.o
-; RUN: %gold -shared -o %t3.o -plugin %llvmshlibdir/LLVMgold%shlibext %t1.o %t2.o \
+; RUN: %ld_bfd -shared -o %t3.o -plugin %llvmshlibdir/LLVMgold%shlibext %t1.o %t2.o \
 ; RUN:  -m elf_x86_64 \
 ; RUN:  -plugin-opt=save-temps
 ; RUN: FileCheck --check-prefix=RES %s < %t3.o.resolution.txt

--- a/llvm/test/tools/gold/X86/comdat2.ll
+++ b/llvm/test/tools/gold/X86/comdat2.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-as %p/Inputs/comdat2.ll -o %t2.bc
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t.bc %t2.bc -o %t3.bc
 ; RUN: llvm-dis %t3.bc -o - | FileCheck %s

--- a/llvm/test/tools/gold/X86/common.ll
+++ b/llvm/test/tools/gold/X86/common.ll
@@ -8,7 +8,7 @@ target triple = "x86_64-unknown-linux-gnu"
 
 @a = common global i16 0, align 8
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t1.o %t2.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck %s --check-prefix=A
@@ -16,7 +16,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ; Shared library case, we merge @a as common and keep it for the symbol table.
 ; A: @a = common global [4 x i8] zeroinitializer, align 8
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t1.o %t2b.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck %s --check-prefix=B
@@ -24,7 +24,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ; (i16 align 8) + (i8 align 16) = i16 align 16
 ; B: @a = common global i16 0, align 16
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t1.o %t2c.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck %s --check-prefix=C
@@ -32,7 +32,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ; (i16 align 8) + (i8 align 1) = i16 align 8.
 ; C: @a = common global i16 0, align 8
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    %t1.o %t2.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck --check-prefix=EXEC %s
@@ -41,7 +41,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ; EXEC: @a = internal global [4 x i8] zeroinitializer, align 8
 
 ; RUN: llc %p/Inputs/common.ll -o %t2native.o -filetype=obj
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    %t1.o %t2native.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck --check-prefix=MIXED %s

--- a/llvm/test/tools/gold/X86/common.ll
+++ b/llvm/test/tools/gold/X86/common.ll
@@ -1,3 +1,7 @@
+; REQUIRES: gold_linker
+; ld.bfd does not handle the mixed case correctly.
+; https://sourceware.org/bugzilla/show_bug.cgi?id=34570
+
 ; RUN: llvm-as %s -o %t1.o
 ; RUN: llvm-as %p/Inputs/common.ll -o %t2.o
 ; RUN: llvm-as %p/Inputs/common2.ll -o %t2b.o
@@ -8,7 +12,7 @@ target triple = "x86_64-unknown-linux-gnu"
 
 @a = common global i16 0, align 8
 
-; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t1.o %t2.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck %s --check-prefix=A
@@ -16,7 +20,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ; Shared library case, we merge @a as common and keep it for the symbol table.
 ; A: @a = common global [4 x i8] zeroinitializer, align 8
 
-; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t1.o %t2b.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck %s --check-prefix=B
@@ -24,7 +28,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ; (i16 align 8) + (i8 align 16) = i16 align 16
 ; B: @a = common global i16 0, align 16
 
-; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t1.o %t2c.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck %s --check-prefix=C
@@ -32,7 +36,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ; (i16 align 8) + (i8 align 1) = i16 align 8.
 ; C: @a = common global i16 0, align 8
 
-; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    %t1.o %t2.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck --check-prefix=EXEC %s
@@ -41,7 +45,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ; EXEC: @a = internal global [4 x i8] zeroinitializer, align 8
 
 ; RUN: llc %p/Inputs/common.ll -o %t2native.o -filetype=obj
-; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    %t1.o %t2native.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck --check-prefix=MIXED %s

--- a/llvm/test/tools/gold/X86/common_thinlto.ll
+++ b/llvm/test/tools/gold/X86/common_thinlto.ll
@@ -1,7 +1,7 @@
 ; RUN: opt -module-summary %s -o %t1.o
 ; RUN: opt -module-summary %p/Inputs/common_thinlto.ll -o %t2.o
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=save-temps \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    -m elf_x86_64 \

--- a/llvm/test/tools/gold/X86/ctors.ll
+++ b/llvm/test/tools/gold/X86/ctors.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t.o -o %t2.o
 ; RUN: llvm-dis %t2.o -o - | FileCheck %s

--- a/llvm/test/tools/gold/X86/ctors2.ll
+++ b/llvm/test/tools/gold/X86/ctors2.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.o
 ; RUN: llvm-as %p/Inputs/ctors2.ll -o %t2.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t.o %t2.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck %s

--- a/llvm/test/tools/gold/X86/devirt_vcall_vis_export_dynamic.ll
+++ b/llvm/test/tools/gold/X86/devirt_vcall_vis_export_dynamic.ll
@@ -8,7 +8,7 @@
 ;; Index based WPD
 ;; Generate unsplit module with summary for ThinLTO index-based WPD.
 ; RUN: opt -thinlto-bc -o %t2.o %s
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=save-temps \
 ; RUN:   --plugin-opt=-pass-remarks=. \
@@ -18,7 +18,7 @@
 ;; Hybrid WPD
 ;; Generate split module with summary for hybrid Thin/Regular LTO WPD.
 ; RUN: opt -thinlto-bc -thinlto-split-lto-unit -o %t.o %s
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=save-temps \
 ; RUN:   --plugin-opt=-pass-remarks=. \
@@ -27,7 +27,7 @@
 
 ;; Regular LTO WPD
 ; RUN: opt -passes=assign-guid -o %t4.o %s
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=save-temps \
 ; RUN:   --plugin-opt=-pass-remarks=. \
@@ -40,7 +40,7 @@
 ;; Check that all WPD fails with --export-dynamic.
 
 ;; Index based WPD
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=save-temps \
 ; RUN:   --plugin-opt=-pass-remarks=. \
@@ -49,7 +49,7 @@
 ; RUN: llvm-dis %t2.o.4.opt.bc -o - | FileCheck %s --check-prefix=CHECK-NODEVIRT-IR
 
 ;; Hybrid WPD
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=save-temps \
 ; RUN:   --plugin-opt=-pass-remarks=. \
@@ -58,7 +58,7 @@
 ; RUN: llvm-dis %t.o.4.opt.bc -o - | FileCheck %s --check-prefix=CHECK-NODEVIRT-IR
 
 ;; Regular LTO WPD
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=save-temps \
 ; RUN:   --plugin-opt=-pass-remarks=. \
@@ -73,9 +73,9 @@
 
 ;; Index based WPD
 ; RUN: opt -relocation-model=pic --thinlto-bc -o %t5.o %s
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN: 	 %t5.o -o %t5.so -shared
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=-pass-remarks=. \
 ; RUN:   %t5.o %t5.so -o %t5 \
@@ -83,9 +83,9 @@
 
 ;; Hybrid WPD
 ; RUN: opt -relocation-model=pic --thinlto-bc --thinlto-split-lto-unit -o %t5.o %s
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN: 	 %t5.o -o %t5.so -shared
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=-pass-remarks=. \
 ; RUN:   %t5.o %t5.so -o %t5 \
@@ -93,9 +93,9 @@
 
 ;; Regular LTO WPD
 ; RUN: opt -passes=assign-guid -relocation-model=pic -o %t5.o %s
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN: 	 %t5.o -o %t5.so -shared
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=-pass-remarks=. \
 ; RUN:   %t5.o %t5.so -o %t5 \

--- a/llvm/test/tools/gold/X86/devirt_vcall_vis_public.ll
+++ b/llvm/test/tools/gold/X86/devirt_vcall_vis_public.ll
@@ -3,7 +3,7 @@
 ;; Index based WPD
 ;; Generate unsplit module with summary for ThinLTO index-based WPD.
 ; RUN: opt -thinlto-bc -o %t2.o %s
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=save-temps \
 ; RUN:   --plugin-opt=-pass-remarks=. \
@@ -13,7 +13,7 @@
 ;; Hybrid WPD
 ;; Generate split module with summary for hybrid Thin/Regular LTO WPD.
 ; RUN: opt -thinlto-bc -thinlto-split-lto-unit -o %t.o %s
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=save-temps \
 ; RUN:   --plugin-opt=-pass-remarks=. \
@@ -22,7 +22,7 @@
 
 ;; Regular LTO WPD
 ; RUN: opt -passes=assign-guid -o %t4.o %s
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=save-temps \
 ; RUN:   --plugin-opt=-pass-remarks=. \
@@ -36,7 +36,7 @@
 ;; WPD fails
 
 ;; Index based WPD
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=save-temps \
 ; RUN:   --plugin-opt=-pass-remarks=. \
 ; RUN:   %t2.o -o %t3 \
@@ -44,7 +44,7 @@
 ; RUN: llvm-dis %t2.o.4.opt.bc -o - | FileCheck %s --check-prefix=CHECK-NODEVIRT-IR
 
 ;; Hybrid WPD
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=save-temps \
 ; RUN:   --plugin-opt=-pass-remarks=. \
 ; RUN:   %t.o -o %t3 \
@@ -52,7 +52,7 @@
 ; RUN: llvm-dis %t.o.4.opt.bc -o - | FileCheck %s --check-prefix=CHECK-NODEVIRT-IR
 
 ;; Regular LTO WPD
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=save-temps \
 ; RUN:   --plugin-opt=-pass-remarks=. \
 ; RUN:   %t4.o -o %t3 \

--- a/llvm/test/tools/gold/X86/devirt_vcall_vis_shared_def.ll
+++ b/llvm/test/tools/gold/X86/devirt_vcall_vis_shared_def.ll
@@ -7,7 +7,7 @@
 ;; Generate unsplit module with summary for ThinLTO index-based WPD.
 ; RUN: opt --thinlto-bc -o %t1a.o %s
 ; RUN: opt --thinlto-bc -o %t2a.o %S/Inputs/devirt_vcall_vis_shared_def.ll
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=save-temps \
 ; RUN:   --plugin-opt=-pass-remarks=. \
@@ -18,7 +18,7 @@
 ;; Generate split module with summary for hybrid Thin/Regular LTO WPD.
 ; RUN: opt --thinlto-bc --thinlto-split-lto-unit -o %t1b.o %s
 ; RUN: opt --thinlto-bc --thinlto-split-lto-unit -o %t2b.o %S/Inputs/devirt_vcall_vis_shared_def.ll
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=save-temps \
 ; RUN:   --plugin-opt=-pass-remarks=. \
@@ -28,7 +28,7 @@
 ;; Regular LTO WPD
 ; RUN: opt -passes=assign-guid -o %t1c.o %s
 ; RUN: opt -passes=assign-guid -o %t2c.o %S/Inputs/devirt_vcall_vis_shared_def.ll
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=save-temps \
 ; RUN:   --plugin-opt=-pass-remarks=. \
@@ -39,11 +39,11 @@
 
 ;; Check that WPD fails with when linking against a shared library
 ;; containing the strong defs of the vtables.
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   %t2c.o -o %t.so -shared
 
 ;; Index based WPD
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=-pass-remarks=. \
 ; RUN:   %t1a.o %t.so -o %t4a \
@@ -51,7 +51,7 @@
 
 ;; Hybrid WPD
 ; RUN: opt --thinlto-bc --thinlto-split-lto-unit -o %t4.o %s
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=-pass-remarks=. \
 ; RUN:   %t1b.o %t.so -o %t4b \
@@ -59,7 +59,7 @@
 
 ;; Regular LTO WPD
 ; RUN: opt -o %t4.o %s
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   --plugin-opt=whole-program-visibility \
 ; RUN:   --plugin-opt=-pass-remarks=. \
 ; RUN:   %t1c.o %t.so -o %t4c \

--- a/llvm/test/tools/gold/X86/disable-verify.ll
+++ b/llvm/test/tools/gold/X86/disable-verify.ll
@@ -1,11 +1,11 @@
 ; RUN: llvm-as %s -o %t.o
 ; REQUIRES: asserts
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=disable-verify --plugin-opt=debug-pass-manager \
 ; RUN:    -shared %t.o -o %t2.o 2>&1 | FileCheck %s
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=debug-pass-manager \
 ; RUN:    -shared %t.o -o %t2.o 2>&1 | FileCheck %s -check-prefix=VERIFY
 

--- a/llvm/test/tools/gold/X86/drop-debug.ll
+++ b/llvm/test/tools/gold/X86/drop-debug.ll
@@ -1,4 +1,4 @@
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm -shared %p/Inputs/drop-debug.bc \
 ; RUN:    -o t2.bc 2>&1 | FileCheck %s
 

--- a/llvm/test/tools/gold/X86/drop-linkage.ll
+++ b/llvm/test/tools/gold/X86/drop-linkage.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-mc %t.s -o %t.o -filetype=obj -triple=x86_64-unknown-linux-gnu
 ; RUN: llvm-as %p/Inputs/drop-linkage.ll -o %t2.o
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t.o %t2.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck %s

--- a/llvm/test/tools/gold/X86/emit-asm.ll
+++ b/llvm/test/tools/gold/X86/emit-asm.ll
@@ -1,11 +1,11 @@
 ; RUN: llvm-as %s -o %t.o
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 --plugin-opt=emit-asm \
 ; RUN:    -shared %t.o -o %t2.s
 ; RUN: FileCheck --input-file %t2.s %s
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 --plugin-opt=emit-asm --plugin-opt=lto-partitions=2\
 ; RUN:    -shared %t.o -o %t2.s
 ; RUN: cat %t2.s %t2.s1 > %t3.s

--- a/llvm/test/tools/gold/X86/emit-llvm.ll
+++ b/llvm/test/tools/gold/X86/emit-llvm.ll
@@ -1,11 +1,11 @@
 ; RUN: llvm-as %s -o %t.o
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t.o -o %t2.o
 ; RUN: llvm-dis %t2.o -o - | FileCheck %s
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     -m elf_x86_64 --plugin-opt=save-temps \
 ; RUN:    -shared %t.o -o %t3.o
 ; RUN: FileCheck --check-prefix=RES %s < %t3.o.resolution.txt
@@ -15,7 +15,7 @@
 ; RUN: llvm-nm %t3.o.lto.o | FileCheck --check-prefix=NM %s
 
 ; RUN: rm -f %t4.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     -m elf_x86_64 --plugin-opt=disable-output \
 ; RUN:    -shared %t.o -o %t4.o
 ; RUN: not test -a %t4.o

--- a/llvm/test/tools/gold/X86/error-unopenable.ll
+++ b/llvm/test/tools/gold/X86/error-unopenable.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as -o %t %s
-; RUN: not %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: not %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=obj-path=%t/nonexistent-dir/foo.o \
 ; RUN:    %t -o %t2 2>&1 | FileCheck %s
 

--- a/llvm/test/tools/gold/X86/fatlto/fatlto.invalid.s
+++ b/llvm/test/tools/gold/X86/fatlto/fatlto.invalid.s
@@ -1,7 +1,7 @@
 # REQUIRES: x86_64-linux
 
 # RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-linux %s -o %t
-# RUN: not %gold -plugin %llvmshlibdir/LLVMgold%shlibext %t -o /dev/null 2>&1 | FileCheck %s
+# RUN: not %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext %t -o /dev/null 2>&1 | FileCheck %s
 
 # CHECK: error:{{.*}} Invalid bitcode signature
 

--- a/llvm/test/tools/gold/X86/fatlto/fatlto.test
+++ b/llvm/test/tools/gold/X86/fatlto/fatlto.test
@@ -1,6 +1,9 @@
 ;; Basic FatLTO tests.
 ; REQUIRES: x86_64-linux
 
+; --start-lib is not supported by ld.bfd, use gold instead.
+; REQUIRES: gold_linker
+
 ; RUN: rm -rf %t && split-file %s %t
 
 ;; Ensure that input files contain .llvm.lto section

--- a/llvm/test/tools/gold/X86/global_with_section.ll
+++ b/llvm/test/tools/gold/X86/global_with_section.ll
@@ -7,7 +7,7 @@
 ; RUN: opt %s -o %t.o
 ; RUN: llvm-lto2 dump-symtab %t.o | FileCheck %s --check-prefix=SYMTAB
 ; RUN: opt %p/Inputs/global_with_section.ll -o %t2.o
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=save-temps \
 ; RUN:     -o %t3.o %t.o %t2.o
 ; Check results of internalization
@@ -17,7 +17,7 @@
 ; RUN: opt -module-summary %s -o %t.o
 ; RUN: llvm-lto2 dump-symtab %t.o | FileCheck %s --check-prefix=SYMTAB
 ; RUN: opt -module-summary %p/Inputs/global_with_section.ll -o %t2.o
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=thinlto \
 ; RUN:     --plugin-opt=save-temps \
 ; RUN:     -o %t3.o %t.o %t2.o

--- a/llvm/test/tools/gold/X86/invalid.ll
+++ b/llvm/test/tools/gold/X86/invalid.ll
@@ -1,4 +1,4 @@
-; RUN: not %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: not %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    %p/Inputs/invalid.bc -o %t2 2>&1 | FileCheck %s
 
 ; test that only one error gets printed

--- a/llvm/test/tools/gold/X86/irmover-error.ll
+++ b/llvm/test/tools/gold/X86/irmover-error.ll
@@ -1,8 +1,8 @@
 ; RUN: llvm-as -o %t1.bc %s
 ; RUN: llvm-as -o %t2.bc %S/Inputs/irmover-error.ll
-; RUN: not %gold -plugin %llvmshlibdir/LLVMgold%shlibext -o %t %t1.bc %t2.bc 2>&1 | FileCheck %s
+; RUN: not %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext -o %t %t1.bc %t2.bc 2>&1 | FileCheck %s
 
-; CHECK: fatal error: Failed to link module {{.*}}2.bc: linking module flags 'foo': IDs have conflicting values
+; CHECK: error: Failed to link module {{.*}}2.bc: linking module flags 'foo': IDs have conflicting values
 
 target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
 

--- a/llvm/test/tools/gold/X86/linker-script.ll
+++ b/llvm/test/tools/gold/X86/linker-script.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.o
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t.o -o %t2.o \
 ; RUN:    -version-script=%p/Inputs/linker-script.export

--- a/llvm/test/tools/gold/X86/linkonce-weak.ll
+++ b/llvm/test/tools/gold/X86/linkonce-weak.ll
@@ -1,12 +1,12 @@
 ; RUN: llvm-as %s -o %t.o
 ; RUN: llvm-as %p/Inputs/linkonce-weak.ll -o %t2.o
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t.o %t2.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck %s
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t2.o %t.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck %s

--- a/llvm/test/tools/gold/X86/linkonce_odr_unnamed_addr.ll
+++ b/llvm/test/tools/gold/X86/linkonce_odr_unnamed_addr.ll
@@ -3,7 +3,7 @@
 
 ; RUN: opt -module-summary %s -o %t.o
 ; RUN: opt -module-summary %p/Inputs/linkonce_odr_unnamed_addr.ll -o %t2.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=save-temps \
 ; RUN:    %t.o %t2.o -o %t3.o
@@ -12,7 +12,7 @@
 ; Now test when one module is a native object. In that case we must be
 ; conservative and not auto hide.
 ; RUN: llc %p/Inputs/linkonce_odr_unnamed_addr.ll -o %t2native.o -filetype=obj
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=save-temps \
 ; RUN:    %t.o %t2native.o -o %t3.o

--- a/llvm/test/tools/gold/X86/merge-functions.ll
+++ b/llvm/test/tools/gold/X86/merge-functions.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-as %p/Inputs/merge-functions-foo.ll -o %t-foo.bc
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    -plugin-opt=merge-functions \
 ; RUN:    -plugin-opt=save-temps \

--- a/llvm/test/tools/gold/X86/mixed_lto.ll
+++ b/llvm/test/tools/gold/X86/mixed_lto.ll
@@ -2,7 +2,7 @@
 ; RUN: opt %s -o %t.o
 ; RUN: opt -module-summary %p/Inputs/mixed_lto.ll -o %t2.o
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     -shared \
 ; RUN:     --plugin-opt=thinlto \
 ; RUN:     --plugin-opt=-import-instr-limit=0 \

--- a/llvm/test/tools/gold/X86/module_asm.ll
+++ b/llvm/test/tools/gold/X86/module_asm.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t.o
-; RUN: %gold -shared -m elf_x86_64 -o %t2 -plugin %llvmshlibdir/LLVMgold%shlibext %t.o
+; RUN: %ld_bfd -shared -m elf_x86_64 -o %t2 -plugin %llvmshlibdir/LLVMgold%shlibext %t.o
 ; RUN: llvm-nm %t2 | FileCheck %s
 ; CHECK: PrepareAndDispatch
 

--- a/llvm/test/tools/gold/X86/multiple-data.s
+++ b/llvm/test/tools/gold/X86/multiple-data.s
@@ -9,6 +9,9 @@
 # RUN:     --section-ordering-file=%t_order_lto.txt
 # RUN: llvm-readelf -s %t.exe | FileCheck %s
 
+# --section-ordering-file is not supported by ld.bfd, use gold instead.
+# REQUIRES: gold_linker
+
 # CHECK-DAG:      00000000004010fc     4 OBJECT  GLOBAL DEFAULT    2 dipsy
 # CHECK-DAG:      00000000004010f8     4 OBJECT  GLOBAL DEFAULT    2 tin
 # CHECK-DAG:      0000000000401100     4 OBJECT  GLOBAL DEFAULT    2 pat

--- a/llvm/test/tools/gold/X86/multiple-sections.ll
+++ b/llvm/test/tools/gold/X86/multiple-sections.ll
@@ -5,6 +5,9 @@
 ; RUN:     --section-ordering-file=%t/order
 ; RUN: llvm-readelf -s %t.exe | FileCheck %s
 
+; --section-ordering-file is not supported by ld.bfd, use gold instead.
+; REQUIRES: gold_linker
+
 ; Check that the order of the sections is tin -> _start -> pat.
 
 ; CHECK:      00000000004000cf     1 FUNC    LOCAL  DEFAULT    1 pat

--- a/llvm/test/tools/gold/X86/new-pm.ll
+++ b/llvm/test/tools/gold/X86/new-pm.ll
@@ -1,7 +1,7 @@
 ; Test plugin options new-pass-manager and debug-pass-manager
 ; RUN: opt -module-summary %s -o %t.o
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=thinlto \
 ; RUN:     --plugin-opt=new-pass-manager \
 ; RUN:     --plugin-opt=debug-pass-manager \

--- a/llvm/test/tools/gold/X86/no-map-whole-file.ll
+++ b/llvm/test/tools/gold/X86/no-map-whole-file.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as -o %t.bc %s
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext -plugin-opt=emit-llvm \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext -plugin-opt=emit-llvm \
 ; RUN:    --no-map-whole-files -r -o %t2.bc %t.bc
 ; RUN: llvm-dis < %t2.bc -o - | FileCheck %s
 

--- a/llvm/test/tools/gold/X86/opt-level.ll
+++ b/llvm/test/tools/gold/X86/opt-level.ll
@@ -1,13 +1,13 @@
 ; RUN: llvm-as -o %t.bc %s
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext -plugin-opt=save-temps \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext -plugin-opt=save-temps \
 ; RUN:    -m elf_x86_64 --plugin-opt=new-pass-manager \
 ; RUN:    -plugin-opt=O0 -r -o %t.o %t.bc
 ; RUN: llvm-dis < %t.o.0.4.opt.bc -o - | FileCheck --check-prefix=CHECK-O0 %s
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext -plugin-opt=save-temps \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext -plugin-opt=save-temps \
 ; RUN:    -m elf_x86_64 --plugin-opt=new-pass-manager \
 ; RUN:    -plugin-opt=O1 -r -o %t.o %t.bc
 ; RUN: llvm-dis < %t.o.0.4.opt.bc -o - | FileCheck --check-prefix=CHECK-O1 %s
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext -plugin-opt=save-temps \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext -plugin-opt=save-temps \
 ; RUN:    -m elf_x86_64 --plugin-opt=new-pass-manager \
 ; RUN:    -plugin-opt=O2 -r -o %t.o %t.bc
 ; RUN: llvm-dis < %t.o.0.4.opt.bc -o - | FileCheck --check-prefix=CHECK-O2 %s

--- a/llvm/test/tools/gold/X86/opt-remarks.ll
+++ b/llvm/test/tools/gold/X86/opt-remarks.ll
@@ -1,23 +1,23 @@
 ; Test plugin options for opt-remarks.
 ; RUN: llvm-as %s -o %t.o
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext -shared \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext -shared \
 ; RUN:	  -plugin-opt=save-temps \
 ; RUN:    -plugin-opt=opt-remarks-passes=inline \
 ; RUN:    -plugin-opt=opt-remarks-format=yaml \
 ; RUN:    -plugin-opt=opt-remarks-filename=%t.yaml %t.o -o %t2.o 2>&1
 ; RUN: llvm-dis %t2.o.0.4.opt.bc -o - | FileCheck %s
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext -shared \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext -shared \
 ; RUN:    -plugin-opt=opt-remarks-passes=inline \
 ; RUN:    -plugin-opt=opt-remarks-format=yaml \
 ; RUN:    -plugin-opt=opt-remarks-with-hotness \
 ; RUN:	  -plugin-opt=opt-remarks-filename=%t.hot.yaml %t.o -o %t2.o 2>&1
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext -shared \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext -shared \
 ; RUN:    -plugin-opt=opt-remarks-passes=inline \
 ; RUN:    -plugin-opt=opt-remarks-format=yaml \
 ; RUN:    -plugin-opt=opt-remarks-with-hotness \
 ; RUN:    -plugin-opt=opt-remarks-hotness-threshold=300 \
 ; RUN:	  -plugin-opt=opt-remarks-filename=%t.t300.yaml %t.o -o %t2.o 2>&1
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext -shared \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext -shared \
 ; RUN:    -plugin-opt=opt-remarks-passes=inline \
 ; RUN:    -plugin-opt=opt-remarks-format=yaml \
 ; RUN:    -plugin-opt=opt-remarks-with-hotness \

--- a/llvm/test/tools/gold/X86/parallel.ll
+++ b/llvm/test/tools/gold/X86/parallel.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as -o %t.bc %s
 ; RUN: rm -f %t.0.5.precodegen.bc %t.1.5.precodegen.bc %t.lto.o %t.lto.o1
-; RUN: env LD_PRELOAD=%llvmshlibdir/LLVMgold%shlibext %gold -plugin %llvmshlibdir/LLVMgold%shlibext -u foo -u bar -plugin-opt lto-partitions=2 -plugin-opt save-temps -m elf_x86_64 -o %t %t.bc
+; RUN: env LD_PRELOAD=%llvmshlibdir/LLVMgold%shlibext %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext -u foo -u bar -plugin-opt lto-partitions=2 -plugin-opt save-temps -m elf_x86_64 -o %t %t.bc
 ; RUN: llvm-dis %t.0.5.precodegen.bc -o - | FileCheck --check-prefix=CHECK-BC0 %s
 ; RUN: llvm-dis %t.1.5.precodegen.bc -o - | FileCheck --check-prefix=CHECK-BC1 %s
 ; RUN: llvm-nm %t.lto.o | FileCheck --check-prefix=CHECK0 %s

--- a/llvm/test/tools/gold/X86/pr19901.ll
+++ b/llvm/test/tools/gold/X86/pr19901.ll
@@ -1,6 +1,6 @@
 ; RUN: llc %s -o %t.o -filetype=obj -relocation-model=pic
 ; RUN: llvm-as %p/Inputs/pr19901-1.ll -o %t2.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     -shared -m elf_x86_64 -o %t.so %t2.o %t.o
 ; RUN: llvm-readobj --symbols %t.so | FileCheck %s
 

--- a/llvm/test/tools/gold/X86/pr19901_thinlto.ll
+++ b/llvm/test/tools/gold/X86/pr19901_thinlto.ll
@@ -1,6 +1,6 @@
 ; RUN: llc %s -o %t.o -filetype=obj -relocation-model=pic
 ; RUN: opt -module-summary %p/Inputs/pr19901-1.ll -o %t2.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=thinlto \
 ; RUN:     -shared -m elf_x86_64 -o %t.so %t2.o %t.o
 ; RUN: llvm-readobj --symbols %t.so | FileCheck %s

--- a/llvm/test/tools/gold/X86/pr25907.ll
+++ b/llvm/test/tools/gold/X86/pr25907.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    -shared %t.o -o %t2
 ; RUN: llvm-nm %t2 | FileCheck %s

--- a/llvm/test/tools/gold/X86/pr25915.ll
+++ b/llvm/test/tools/gold/X86/pr25915.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -plugin-opt=emit-llvm \
 ; RUN:    -shared %t.o -o %t2
 ; RUN: llvm-dis %t2 -o - | FileCheck %s

--- a/llvm/test/tools/gold/X86/relax-relocs.ll
+++ b/llvm/test/tools/gold/X86/relax-relocs.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t.o
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=save-temps \
 ; RUN:    -shared %t.o -o %t.so
 ; RUN: llvm-readobj -r %t.so.lto.o | FileCheck %s

--- a/llvm/test/tools/gold/X86/relocatable.ll
+++ b/llvm/test/tools/gold/X86/relocatable.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t1.o
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -r %t1.o -o %t
 ; RUN: llvm-readobj --symbols %t | FileCheck %s
 

--- a/llvm/test/tools/gold/X86/relocation-model-pic.ll
+++ b/llvm/test/tools/gold/X86/relocation-model-pic.ll
@@ -2,29 +2,29 @@
 
 ;; Non-PIC source.
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --shared \
 ; RUN:    --plugin-opt=save-temps %t.o -o %t-out
 ; RUN: llvm-readobj -r %t-out.lto.o | FileCheck %s --check-prefix=PIC
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --export-dynamic --noinhibit-exec -pie \
 ; RUN:    --plugin-opt=save-temps %t.o -o %t-out
 ; RUN: llvm-readobj -r %t-out.lto.o | FileCheck %s --check-prefix=PIC
 
 ;; PIC source.
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --shared \
 ; RUN:    --plugin-opt=save-temps %t.o -o %t-out
 ; RUN: llvm-readobj -r %t-out.lto.o | FileCheck %s --check-prefix=PIC
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --export-dynamic --noinhibit-exec -pie \
 ; RUN:    --plugin-opt=save-temps %t.o -o %t-out
 ; RUN: llvm-readobj -r %t-out.lto.o | FileCheck %s --check-prefix=PIC
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -r \
 ; RUN:    --plugin-opt=save-temps %t.o -o %t-out
 ; RUN: llvm-readobj -r %t-out.lto.o | FileCheck %s --check-prefix=PIC

--- a/llvm/test/tools/gold/X86/relocation-model-static.ll
+++ b/llvm/test/tools/gold/X86/relocation-model-static.ll
@@ -1,12 +1,12 @@
 ; RUN: llvm-as %s -o %t.o
 
 ;; --noinhibit-exec allows undefined foo.
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --export-dynamic --noinhibit-exec \
 ; RUN:    --plugin-opt=save-temps %t.o -o %t-out
 ; RUN: llvm-readobj -r %t-out.lto.o | FileCheck %s --check-prefix=STATIC
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -r \
 ; RUN:    --plugin-opt=save-temps %t.o -o %t-out
 ; RUN: llvm-readobj -r %t-out.lto.o | FileCheck %s --check-prefix=STATIC

--- a/llvm/test/tools/gold/X86/remarks.ll
+++ b/llvm/test/tools/gold/X86/remarks.ll
@@ -1,9 +1,9 @@
 ; RUN: llvm-as %s -o %t.o
 
-; RUN: not %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: not %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -plugin-opt=-pass-remarks=inline %t.o -o %t2.o 2>&1 | FileCheck %s
 
-; RUN: not %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: not %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:   %t.o -o %t2.o 2>&1 | FileCheck -allow-empty --check-prefix=NO-REMARK %s
 
 

--- a/llvm/test/tools/gold/X86/resolve-to-alias.ll
+++ b/llvm/test/tools/gold/X86/resolve-to-alias.ll
@@ -1,14 +1,14 @@
 ; RUN: llvm-as %s -o %t.o
 ; RUN: llvm-as %p/Inputs/resolve-to-alias.ll -o %t2.o
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t.o %t2.o -o %t.bc
 ; RUN: llvm-dis %t.bc -o %t.ll
 ; RUN: FileCheck --check-prefix=PASS1 %s < %t.ll
 ; RUN: FileCheck --check-prefix=PASS2 %s < %t.ll
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t2.o %t.o -o %t.bc
 ; RUN: llvm-dis %t.bc -o %t.ll

--- a/llvm/test/tools/gold/X86/slp-vectorize-pm.ll
+++ b/llvm/test/tools/gold/X86/slp-vectorize-pm.ll
@@ -1,7 +1,7 @@
 ; RUN: opt -module-summary %s -o %t.o
 
 ; Test SLP and Loop Vectorization are enabled by default at O2 and O3.
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=thinlto \
 ; RUN:     --plugin-opt=new-pass-manager \
 ; RUN:     --plugin-opt=debug-pass-manager \
@@ -12,7 +12,7 @@
 ; RUN:     -o %t2.o %t.o 2>&1 | FileCheck %s --check-prefix=CHECK-O0-SLP
 ; RUN: llvm-dis %t.o.4.opt.bc -o - | FileCheck %s --check-prefix=CHECK-O0-LPV
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=thinlto \
 ; RUN:     --plugin-opt=new-pass-manager \
 ; RUN:     --plugin-opt=debug-pass-manager \
@@ -23,7 +23,7 @@
 ; RUN:     -o %t3.o %t.o 2>&1 | FileCheck %s --check-prefix=CHECK-O1-SLP
 ; RUN: llvm-dis %t.o.4.opt.bc -o - | FileCheck %s --check-prefix=CHECK-O1-LPV
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=thinlto \
 ; RUN:     --plugin-opt=new-pass-manager \
 ; RUN:     --plugin-opt=debug-pass-manager \
@@ -34,7 +34,7 @@
 ; RUN:     -o %t4.o %t.o 2>&1 | FileCheck %s --check-prefix=CHECK-O2-SLP
 ; RUN: llvm-dis %t.o.4.opt.bc -o - | FileCheck %s --check-prefix=CHECK-O2-LPV
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=thinlto \
 ; RUN:     --plugin-opt=new-pass-manager \
 ; RUN:     --plugin-opt=debug-pass-manager \

--- a/llvm/test/tools/gold/X86/slp-vectorize.ll
+++ b/llvm/test/tools/gold/X86/slp-vectorize.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.o
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=save-temps -shared %t.o -o %t2.o
 ; RUN: llvm-dis %t2.o.0.4.opt.bc -o - | FileCheck %s
 

--- a/llvm/test/tools/gold/X86/split-dwarf.ll
+++ b/llvm/test/tools/gold/X86/split-dwarf.ll
@@ -1,6 +1,6 @@
 ; RUN: rm -rf %t && mkdir -p %t
 ; RUN: opt -module-summary %s -o %t/split-dwarf.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext  \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext  \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    --plugin-opt=dwo_dir=%t/dwo_dir \
@@ -16,7 +16,7 @@
 
 ; RUN:rm -rf %t/dwo_dir
 ; RUN: opt  %s -o %t/split-dwarf.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext  \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext  \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    --plugin-opt=dwo_dir=%t/dwo_dir \

--- a/llvm/test/tools/gold/X86/start-lib-common.ll
+++ b/llvm/test/tools/gold/X86/start-lib-common.ll
@@ -1,6 +1,9 @@
 ; Test the case when the preferred (larger / more aligned) version of a common
 ; symbol is located in a module that's not included in the link.
 
+; --start-lib is not supported by ld.bfd, use gold instead.
+; REQUIRES: gold_linker
+
 ; RUN: llvm-as %s -o %t1.o
 ; RUN: llvm-as %p/Inputs/start-lib-common.ll -o %t2.o
 

--- a/llvm/test/tools/gold/X86/stats-file-option.ll
+++ b/llvm/test/tools/gold/X86/stats-file-option.ll
@@ -3,7 +3,7 @@
 ; RUN: llvm-as -o %t.bc %s
 
 ; Try to save statistics to file.
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext -plugin-opt=stats-file=%t2.stats \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext -plugin-opt=stats-file=%t2.stats \
 ; RUN:    -m elf_x86_64 -r -o %t.o %t.bc
 ; RUN: FileCheck --input-file=%t2.stats %s
 
@@ -20,6 +20,6 @@ define i32 @foo() {
 }
 
 ; Try to save statistics to an invalid file.
-; RUN: not %gold -plugin %llvmshlibdir/LLVMgold%shlibext -plugin-opt=stats-file=%t2/foo.stats \
+; RUN: not %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext -plugin-opt=stats-file=%t2/foo.stats \
 ; RUN:    -m elf_x86_64 -r -o %t.o %t.bc 2>&1 | FileCheck -DMSG=%errc_ENOENT --check-prefix=ERROR %s
 ; ERROR: LLVM gold plugin: [[MSG]]

--- a/llvm/test/tools/gold/X86/stats.ll
+++ b/llvm/test/tools/gold/X86/stats.ll
@@ -1,12 +1,12 @@
 ; REQUIRES: asserts
 
 ; RUN: llvm-as %s -o %t.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext  -shared \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext  -shared \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    -plugin-opt=-stats %t.o -o %t2 2>&1 | FileCheck %s
 
 ; RUN: llvm-as %s -o %t.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext  -shared \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext  -shared \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    -plugin-opt=thinlto \
 ; RUN:    -plugin-opt=thinlto-index-only \

--- a/llvm/test/tools/gold/X86/strip_names.ll
+++ b/llvm/test/tools/gold/X86/strip_names.ll
@@ -1,12 +1,12 @@
 ; RUN: llvm-as %s -o %t.o
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=save-temps \
 ; RUN:    -shared %t.o -o %t2.o
 ; RUN: llvm-dis %t2.o.0.2.internalize.bc -o - | FileCheck %s
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t.o -o %t2.o

--- a/llvm/test/tools/gold/X86/thinlto-emit-llvm.ll
+++ b/llvm/test/tools/gold/X86/thinlto-emit-llvm.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %p/Inputs/emit-llvm.foo.ll -o %t.foo.bc
 ; RUN: llvm-as %p/Inputs/emit-llvm.bar.ll -o %t.bar.bc
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext --shared -plugin-opt thinlto -plugin-opt emit-llvm -m elf_x86_64 %t.foo.bc %t.bar.bc -o %t.bc
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext --shared -plugin-opt thinlto -plugin-opt emit-llvm -m elf_x86_64 %t.foo.bc %t.bar.bc -o %t.bc
 ; RUN: llvm-dis %t.bc1 -o - | FileCheck --check-prefix=CHECK-BC1 %s
 ; RUN: llvm-dis %t.bc2 -o - | FileCheck --check-prefix=CHECK-BC2 %s
 

--- a/llvm/test/tools/gold/X86/thinlto.ll
+++ b/llvm/test/tools/gold/X86/thinlto.ll
@@ -7,7 +7,7 @@
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    --plugin-opt=thinlto-index-only \
 ; RUN:    -shared %t.o %t2.o -o %t3
-; RUN: not test -e %t3
+; RUN: not test -s %t3
 ; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=thinlto \
@@ -28,7 +28,7 @@
 ; RUN: llvm-bcanalyzer -dump %t2.o.thinlto.bc | FileCheck %s --check-prefix=BACKEND2
 ; RUN: llvm-dis %t.o.thinlto.bc -o - | FileCheck %s --check-prefix=DIS1
 ; RUN: llvm-dis %t2.o.thinlto.bc -o - | FileCheck %s --check-prefix=DIS2
-; RUN: not test -e %t3
+; RUN: not test -s %t3
 
 ; Ensure gold generates an index as well as a binary with save-temps in ThinLTO mode.
 ; First force single-threaded mode

--- a/llvm/test/tools/gold/X86/thinlto.ll
+++ b/llvm/test/tools/gold/X86/thinlto.ll
@@ -2,13 +2,13 @@
 ; bitcode without summary sections gracefully.
 ; RUN: llvm-as %s -o %t.o
 ; RUN: llvm-as %p/Inputs/thinlto.ll -o %t2.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    --plugin-opt=thinlto-index-only \
 ; RUN:    -shared %t.o %t2.o -o %t3
 ; RUN: not test -e %t3
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    -shared %t.o %t2.o -o %t4
@@ -19,7 +19,7 @@
 ; RUN: opt -module-summary %p/Inputs/thinlto.ll -o %t2.o
 
 ; Ensure gold generates an index and not a binary if requested.
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    --plugin-opt=thinlto-index-only \
@@ -33,7 +33,7 @@
 ; Ensure gold generates an index as well as a binary with save-temps in ThinLTO mode.
 ; First force single-threaded mode
 ; RUN: rm -f %t4*
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=save-temps \
 ; RUN:    --plugin-opt=thinlto \
@@ -45,7 +45,7 @@
 ; RUN: ls %t4.lto.o* | count 2
 
 ; Check with --no-map-whole-files
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=save-temps \
 ; RUN:    --plugin-opt=thinlto \
@@ -56,7 +56,7 @@
 ; RUN: llvm-nm %t4 | FileCheck %s --check-prefix=NM
 
 ; Next force multi-threaded mode
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=save-temps \
 ; RUN:    --plugin-opt=thinlto \
@@ -67,7 +67,7 @@
 
 ; Test --plugin-opt=obj-path to ensure unique object files generated.
 ; RUN: rm -f %t5.o %t5.o1
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    --plugin-opt=jobs=2 \
@@ -80,7 +80,7 @@
 
 ; Test to ensure that thinlto-index-only with obj-path creates the file.
 ; RUN: rm -f %t5.o %t5.o1
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    --plugin-opt=jobs=2 \

--- a/llvm/test/tools/gold/X86/thinlto_afdo.ll
+++ b/llvm/test/tools/gold/X86/thinlto_afdo.ll
@@ -3,7 +3,7 @@
 ; RUN: opt -module-summary %p/Inputs/thinlto.ll -o %t2.o
 
 ; RUN: rm -f %t1.o.4.opt.bc
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    --plugin-opt=save-temps \

--- a/llvm/test/tools/gold/X86/thinlto_alias.ll
+++ b/llvm/test/tools/gold/X86/thinlto_alias.ll
@@ -9,7 +9,7 @@
 ; Note that gold picks the first copy of weakfunc() as the prevailing one,
 ; so listing %t2.o first is sufficient to ensure that this copy is
 ; preempted.
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=thinlto \
 ; RUN:     --plugin-opt=save-temps \
 ; RUN:     -o %t3.o %t2.o %t.o

--- a/llvm/test/tools/gold/X86/thinlto_archive.ll
+++ b/llvm/test/tools/gold/X86/thinlto_archive.ll
@@ -8,7 +8,7 @@
 
 ; Test importing from archive library via gold, using jobs=1 to ensure
 ; output messages are not interleaved.
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    --plugin-opt=-print-imports \

--- a/llvm/test/tools/gold/X86/thinlto_cspgo.ll
+++ b/llvm/test/tools/gold/X86/thinlto_cspgo.ll
@@ -4,7 +4,7 @@
 ; RUN: llvm-profdata merge -o %t.profdata %p/Inputs/cspgo.proftext
 
 ; RUN: rm -f %t1.o.4.opt.bc
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    --plugin-opt=save-temps \

--- a/llvm/test/tools/gold/X86/thinlto_emit_imports.ll
+++ b/llvm/test/tools/gold/X86/thinlto_emit_imports.ll
@@ -7,7 +7,7 @@
 
 ; Ensure gold generates imports files if requested for distributed backends.
 ; RUN: rm -f %t3.o.imports %t3.o.thinlto.bc
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    --plugin-opt=thinlto-index-only \
 ; RUN:    --plugin-opt=thinlto-emit-imports-files \

--- a/llvm/test/tools/gold/X86/thinlto_emit_linked_objects.ll
+++ b/llvm/test/tools/gold/X86/thinlto_emit_linked_objects.ll
@@ -2,6 +2,9 @@
 ; RUN: opt -module-summary %s -o %t.o
 ; RUN: opt -module-summary %p/Inputs/thinlto_emit_linked_objects.ll -o %t2.o
 
+; --start-lib is not supported by ld.bfd, use gold instead.
+; REQUIRES: gold_linker
+
 ; Next do the ThinLink step, specifying thinlto-index-only so that the gold
 ; plugin exits after generating individual indexes. The objects the linker
 ; decided to include in the link should be emitted into the file specified

--- a/llvm/test/tools/gold/X86/thinlto_funcimport.ll
+++ b/llvm/test/tools/gold/X86/thinlto_funcimport.ll
@@ -2,7 +2,7 @@
 ; RUN: opt -module-summary %s -o %t1.bc
 ; RUN: opt -module-summary %p/Inputs/thinlto_funcimport.ll -o %t2.bc
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=save-temps \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    -shared %t1.bc %t2.bc -o %t
@@ -11,7 +11,7 @@
 
 ; We shouldn't do any importing at -O0
 ; rm -f %t2.bc.3.import.bc
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=save-temps \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    --plugin-opt=O0 \

--- a/llvm/test/tools/gold/X86/thinlto_internalize.ll
+++ b/llvm/test/tools/gold/X86/thinlto_internalize.ll
@@ -1,7 +1,7 @@
 ; RUN: opt -module-summary %s -o %t.o
 ; RUN: opt -module-summary %p/Inputs/thinlto_internalize.ll -o %t2.o
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=thinlto \
 ; RUN:     --plugin-opt=-import-instr-limit=0 \
 ; RUN:     --plugin-opt=save-temps \

--- a/llvm/test/tools/gold/X86/thinlto_linkonceresolution.ll
+++ b/llvm/test/tools/gold/X86/thinlto_linkonceresolution.ll
@@ -7,7 +7,7 @@
 ; so listing %t2.o first is sufficient to ensure that this copy is
 ; preempted. Also, set the import-instr-limit to 0 to prevent f() from
 ; being imported from %t2.o which hides the problem.
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=thinlto \
 ; RUN:     --plugin-opt=-import-instr-limit=0 \
 ; RUN:     --plugin-opt=save-temps \

--- a/llvm/test/tools/gold/X86/thinlto_no_objects.ll
+++ b/llvm/test/tools/gold/X86/thinlto_no_objects.ll
@@ -5,7 +5,7 @@
 ; RUN: opt %s -o %t.o
 
 ; RUN: rm -f %t3
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    --plugin-opt=thinlto-index-only=%t3 \
 ; RUN:    -o %t5 \

--- a/llvm/test/tools/gold/X86/thinlto_object_suffix_replace.ll
+++ b/llvm/test/tools/gold/X86/thinlto_object_suffix_replace.ll
@@ -7,7 +7,7 @@
 
 ; First perform the thin link on the normal bitcode file, and save the
 ; resulting index.
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    --plugin-opt=thinlto-index-only \
@@ -19,7 +19,7 @@
 ; RUN: rm -f %t1.o.thinlto.bc
 ; Make sure it isn't inadvertently using the regular bitcode file.
 ; RUN: rm -f %t1.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    --plugin-opt=thinlto-index-only \
@@ -30,7 +30,7 @@
 ; If filename does not end with old suffix, no suffix change should occur,
 ; so ".thinlto.bc" will simply be appended to the input file name.
 ; RUN: rm -f %t1.thinlink.bc.thinlto.bc
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    --plugin-opt=thinlto-index-only \

--- a/llvm/test/tools/gold/X86/thinlto_prefix_replace.ll
+++ b/llvm/test/tools/gold/X86/thinlto_prefix_replace.ll
@@ -4,7 +4,7 @@
 ; Ensure that there is no existing file at the new path, so we properly
 ; test the creation of the new file there.
 ; RUN: rm -f %t/newpath/thinlto_prefix_replace.o.thinlto.bc
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=thinlto \
 ; RUN:    --plugin-opt=thinlto-index-only \
 ; RUN:    --plugin-opt=thinlto-prefix-replace="%t/oldpath/;%t/newpath/" \

--- a/llvm/test/tools/gold/X86/thinlto_weak_library.ll
+++ b/llvm/test/tools/gold/X86/thinlto_weak_library.ll
@@ -2,6 +2,9 @@
 ; final native link based on the linker's determination of which
 ; object within a static library contains the prevailing def of a symbol.
 
+; --start-lib is not supported by ld.bfd, use gold instead.
+; REQUIRES: gold_linker
+
 ; First generate bitcode with a module summary index for each file
 ; RUN: opt -module-summary %s -o %t.o
 ; RUN: opt -module-summary %p/Inputs/thinlto_weak_library1.ll -o %t2.o

--- a/llvm/test/tools/gold/X86/thinlto_weak_resolution.ll
+++ b/llvm/test/tools/gold/X86/thinlto_weak_resolution.ll
@@ -4,7 +4,7 @@
 ; Verify that prevailing weak for linker symbol is kept.
 ; Note that gold picks the first copy of a function as the prevailing one,
 ; so listing %t.o first is sufficient to ensure that its copies are prevailing.
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:     --plugin-opt=thinlto \
 ; RUN:     --plugin-opt=save-temps \
 ; RUN:     -shared \

--- a/llvm/test/tools/gold/X86/time-trace.ll
+++ b/llvm/test/tools/gold/X86/time-trace.ll
@@ -1,17 +1,17 @@
 ; RUN: llvm-as %s -o %t.o
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 --plugin-opt=time-trace=%t2.json \
 ; RUN:    -shared %t.o -o /dev/null
 ; RUN: FileCheck --input-file %t2.json %s
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 --plugin-opt=time-trace=%t2.json \
 ; RUN:    --plugin-opt=time-trace-granularity=250  \
 ; RUN:    -shared %t.o -o /dev/null
 ; RUN: FileCheck --input-file %t2.json %s
 
-; RUN: not %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: not %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 --plugin-opt=time-trace=%t2.json \
 ; RUN:    --plugin-opt=time-trace-granularity=hello  \
 ; RUN:    -shared %t.o -o /dev/null 2> %t4.txt

--- a/llvm/test/tools/gold/X86/type-merge.ll
+++ b/llvm/test/tools/gold/X86/type-merge.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.o
 ; RUN: llvm-as %p/Inputs/type-merge.ll -o %t2.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t.o %t2.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck %s

--- a/llvm/test/tools/gold/X86/type-merge2.ll
+++ b/llvm/test/tools/gold/X86/type-merge2.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.o
 ; RUN: llvm-as %p/Inputs/type-merge2.ll -o %t2.o
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=save-temps \
 ; RUN:    -shared %t.o %t2.o -o %t3.o

--- a/llvm/test/tools/gold/X86/unified-lto.ll
+++ b/llvm/test/tools/gold/X86/unified-lto.ll
@@ -2,7 +2,7 @@
 ; are compiled using unified LTO pipeline
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-as %p/Inputs/unified-lto-foo.ll -o %t-foo.bc
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    -plugin-opt=unifiedlto \
 ; RUN:    -plugin-opt=save-temps \
@@ -12,7 +12,7 @@
 ; RUN: llvm-dis %t-out.0.5.precodegen.bc -o - | FileCheck %s
 
 ; Check thin LTO as well
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    -plugin-opt=unifiedlto \
 ; RUN:    -plugin-opt=thinlto \

--- a/llvm/test/tools/gold/X86/unnamed-addr.ll
+++ b/llvm/test/tools/gold/X86/unnamed-addr.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.o
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t.o -o %t2.o
 ; RUN: llvm-dis %t2.o -o - | FileCheck %s

--- a/llvm/test/tools/gold/X86/vectorize.ll
+++ b/llvm/test/tools/gold/X86/vectorize.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.o
 
-; RUN: %gold -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -m elf_x86_64 -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=save-temps -shared %t.o -o %t2.o
 ; RUN: llvm-dis %t2.o.0.4.opt.bc -o - | FileCheck %s
 

--- a/llvm/test/tools/gold/X86/visibility.ll
+++ b/llvm/test/tools/gold/X86/visibility.ll
@@ -1,7 +1,7 @@
 ; RUN: llvm-as %s -o %t.o
 ; RUN: llvm-as %p/Inputs/visibility.ll -o %t2.o
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    -m elf_x86_64 \
 ; RUN:    --plugin-opt=save-temps \
 ; RUN:    -shared %t.o %t2.o -o %t.so

--- a/llvm/test/tools/gold/X86/weak.ll
+++ b/llvm/test/tools/gold/X86/weak.ll
@@ -1,7 +1,7 @@
 ; RUN: llvm-as %s -o %t.o
 ; RUN: llvm-as %p/Inputs/weak.ll -o %t2.o
 
-; RUN: %gold -plugin %llvmshlibdir/LLVMgold%shlibext \
+; RUN: %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext \
 ; RUN:    --plugin-opt=emit-llvm \
 ; RUN:    -shared %t.o %t2.o -o %t3.o
 ; RUN: llvm-dis %t3.o -o - | FileCheck %s

--- a/llvm/test/tools/gold/invalid-dir.ll
+++ b/llvm/test/tools/gold/invalid-dir.ll
@@ -1,7 +1,7 @@
 ; RUN: rm -rf %t.output
 ; RUN: mkdir %t.output
 ; RUN: llvm-as %s -o %t.o
-; RUN: not %gold -plugin %llvmshlibdir/LLVMgold%shlibext  -shared \
+; RUN: not %ld_bfd -plugin %llvmshlibdir/LLVMgold%shlibext  -shared \
 ; RUN:    %t.o -o %t.output 2>&1 | FileCheck %s -check-prefix=OUTDIR
 
-; OUTDIR: fatal error:
+; OUTDIR: cannot open output file


### PR DESCRIPTION
The gold linker is deprecated and no longer part of the default binutils source distribution. LLVM's gold plugin, despite its name, does not actually require the gold linker, it is compatible with any linker implementing the necessary plugin interface, including the normal ld.bfd linker. However, our tests for the gold plugin currently require the gold linker.

This PR switches the tests to the ld.bfd instead, to the degree that this is possible. A number of tests keep using gold, because they use flags that ld.bfd only supports in very recent versions (`--section-ordering-file` since 2.43 and `--start-lib` since 2.47).

The `thinlto.ll` test is changed to use `test -s` instead of `test -e`, because ld.bfd will always create the (empty) output file, even if `--plugin-opt=thinlto-index-only` is specified.

The `linkonce_odr_unnamed_addr.ll` test adds some uses of the linkonce_odr symbols in the IR that gets compiled to a native object. Unlike ld.gold, ld.bfd will report the IR symbols are PREVAILING_DEF_IRONLY (rather than PREVAILING_DEF) if the native object only has a weak definition, but not references of the symbol in relocations. This seems a bit iffy to me, but probably harmless in practice.

The `common.ll` test keeps using gold, because ld.bfd appears to be incorrectly handling common linkage when linker plugins are involved (https://sourceware.org/bugzilla/show_bug.cgi?id=34570).