### PR TITLE
[libc] Use proxy header in the `locale` implementation.

### DIFF
--- a/libc/src/locale/CMakeLists.txt
+++ b/libc/src/locale/CMakeLists.txt
@@ -5,7 +5,7 @@ add_object_library(
   HDRS
     locale.h
   DEPENDS
-    libc.include.locale
+    libc.hdr.types.locale_t
 )
 
 add_entrypoint_object(
@@ -27,7 +27,8 @@ add_entrypoint_object(
   HDRS
     newlocale.h
   DEPENDS
-    libc.include.locale
+    libc.hdr.locale_macros
+    libc.hdr.types.locale_t
     .locale
 )
 
@@ -38,8 +39,7 @@ add_entrypoint_object(
   HDRS
     duplocale.h
   DEPENDS
-    libc.include.locale
-    .locale
+    libc.hdr.types.locale_t
 )
 
 add_entrypoint_object(
@@ -49,8 +49,8 @@ add_entrypoint_object(
   HDRS
     setlocale.h
   DEPENDS
-    libc.include.locale
-    .locale
+    libc.hdr.locale_macros
+    libc.hdr.types.locale_t
 )
 
 add_entrypoint_object(
@@ -60,7 +60,7 @@ add_entrypoint_object(
   HDRS
     uselocale.h
   DEPENDS
-    libc.include.locale
+    libc.hdr.types.locale_t
     .locale
 )
 
@@ -71,6 +71,5 @@ add_entrypoint_object(
   HDRS
     freelocale.h
   DEPENDS
-    libc.include.locale
-    .locale
+    libc.hdr.types.locale_t
 )

--- a/libc/src/locale/duplocale.cpp
+++ b/libc/src/locale/duplocale.cpp
@@ -7,10 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/locale/duplocale.h"
-#include "include/llvm-libc-macros/locale-macros.h"
-#include "src/locale/locale.h"
-
-#include "src/__support/CPP/string_view.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 

--- a/libc/src/locale/freelocale.cpp
+++ b/libc/src/locale/freelocale.cpp
@@ -7,10 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/locale/freelocale.h"
-#include "include/llvm-libc-macros/locale-macros.h"
-#include "src/locale/locale.h"
-
-#include "src/__support/CPP/string_view.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 

--- a/libc/src/locale/locale.cpp
+++ b/libc/src/locale/locale.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/locale/locale.h"
-
-#include "include/llvm-libc-macros/locale-macros.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 

--- a/libc/src/locale/newlocale.cpp
+++ b/libc/src/locale/newlocale.cpp
@@ -7,12 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/locale/newlocale.h"
-#include "include/llvm-libc-macros/locale-macros.h"
-#include "src/locale/locale.h"
-
+#include "hdr/locale_macros.h"
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
+#include "src/locale/locale.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/locale/newlocale.h
+++ b/libc/src/locale/newlocale.h
@@ -9,9 +9,8 @@
 #ifndef LLVM_LIBC_SRC_LOCALE_SETLOCALE_H
 #define LLVM_LIBC_SRC_LOCALE_SETLOCALE_H
 
-#include "src/__support/macros/config.h"
-
 #include "hdr/types/locale_t.h"
+#include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/locale/setlocale.cpp
+++ b/libc/src/locale/setlocale.cpp
@@ -7,9 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/locale/setlocale.h"
-#include "include/llvm-libc-macros/locale-macros.h"
-#include "src/locale/locale.h"
-
+#include "hdr/locale_macros.h"
 #include "src/__support/CPP/string_view.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"

--- a/libc/src/locale/setlocale.h
+++ b/libc/src/locale/setlocale.h
@@ -9,9 +9,8 @@
 #ifndef LLVM_LIBC_SRC_LOCALE_SETLOCALE_H
 #define LLVM_LIBC_SRC_LOCALE_SETLOCALE_H
 
-#include "src/__support/macros/config.h"
-
 #include "hdr/types/locale_t.h"
+#include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {
 


### PR DESCRIPTION
Address review comments in https://github.com/llvm/llvm-project/pull/130621#pullrequestreview-2671843932.

Some unused headers are also removed.