### PR TITLE
[Support] Prevent leaking unique lock files

### DIFF
--- a/llvm/lib/Support/LockFileManager.cpp
+++ b/llvm/lib/Support/LockFileManager.cpp
@@ -189,6 +189,10 @@ Expected<bool> LockFileManager::tryLock() {
     return createStringError(EC, "failed to create unique file " +
                                      UniqueLockFileName);
 
+  // Clean up the unique file on signal or scope exit. This also releases the
+  // lock if it's held since the .lock symlink will point to a nonexistent file.
+  RemoveUniqueLockFileOnSignal RemoveUniqueFile(UniqueLockFileName);
+
   // Write our process ID to our unique lock file.
   {
     SmallString<256> HostID;
@@ -200,20 +204,14 @@ Expected<bool> LockFileManager::tryLock() {
     Out.close();
 
     if (Out.has_error()) {
-      // We failed to write out PID, so report the error, remove the
-      // unique lock file, and fail.
+      // We failed to write out PID, so report the error and fail.
       Error Err = createStringError(Out.error(),
                                     "failed to write to " + UniqueLockFileName);
-      sys::fs::remove(UniqueLockFileName);
       // Don't call report_fatal_error.
       Out.clear_error();
       return std::move(Err);
     }
   }
-
-  // Clean up the unique file on signal, which also releases the lock if it is
-  // held since the .lock symlink will point to a nonexistent file.
-  RemoveUniqueLockFileOnSignal RemoveUniqueFile(UniqueLockFileName);
 
   while (true) {
     // Create a link from the lock file name. If this succeeds, we're done.
@@ -232,8 +230,6 @@ Expected<bool> LockFileManager::tryLock() {
     // Someone else managed to create the lock file first. Read the process ID
     // from the lock file.
     if (auto LockFileOwner = readLockFile(LockFileName)) {
-      // Wipe out our unique lock file (it's useless now)
-      sys::fs::remove(UniqueLockFileName);
       Owner = std::move(*LockFileOwner);
       return false;
     }

--- a/llvm/lib/Support/LockFileManager.cpp
+++ b/llvm/lib/Support/LockFileManager.cpp
@@ -189,8 +189,7 @@ Expected<bool> LockFileManager::tryLock() {
     return createStringError(EC, "failed to create unique file " +
                                      UniqueLockFileName);
 
-  // Clean up the unique file on signal or scope exit. This also releases the
-  // lock if it's held since the .lock symlink will point to a nonexistent file.
+  // Clean up the unique file on signal or scope exit.
   RemoveUniqueLockFileOnSignal RemoveUniqueFile(UniqueLockFileName);
 
   // Write our process ID to our unique lock file.


### PR DESCRIPTION
Prior to this PR, failing to get the host ID would leave the unique lock file on the file system. This is now fixed by constructing `RemoveUniqueLockFileOnSignal` earlier. This PR also removes one call to `sys::fs::remove()` that is now redundant and another that was redundant even before this patch.