### PR TITLE
[lldb] Support discontinuous functions in another Disasembler overload

### DIFF
--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -552,13 +552,23 @@ void Disassembler::PrintInstructions(Debugger &debugger, const ArchSpec &arch,
 
 bool Disassembler::Disassemble(Debugger &debugger, const ArchSpec &arch,
                                StackFrame &frame, Stream &strm) {
+  constexpr const char *plugin_name = nullptr;
+  constexpr const char *flavor = nullptr;
+  constexpr const char *cpu = nullptr;
+  constexpr const char *features = nullptr;
+  constexpr bool mixed_source_and_assembly = false;
+  constexpr uint32_t num_mixed_context_lines = 0;
+  constexpr uint32_t options = 0;
+
   SymbolContext sc(
       frame.GetSymbolContext(eSymbolContextFunction | eSymbolContextSymbol));
   if (sc.function) {
     if (DisassemblerSP disasm_sp = DisassembleRange(
-            arch, nullptr, nullptr, nullptr, nullptr, *frame.CalculateTarget(),
+            arch, plugin_name, flavor, cpu, features, *frame.CalculateTarget(),
             sc.function->GetAddressRanges())) {
-      disasm_sp->PrintInstructions(debugger, arch, frame, false, 0, 0, strm);
+      disasm_sp->PrintInstructions(debugger, arch, frame,
+                                   mixed_source_and_assembly,
+                                   num_mixed_context_lines, options, strm);
       return true;
     }
     return false;
@@ -579,8 +589,9 @@ bool Disassembler::Disassemble(Debugger &debugger, const ArchSpec &arch,
   if (limit.value == 0)
     limit.value = DEFAULT_DISASM_BYTE_SIZE;
 
-  return Disassemble(debugger, arch, nullptr, nullptr, nullptr, nullptr, frame,
-                     range.GetBaseAddress(), limit, false, 0, 0, strm);
+  return Disassemble(debugger, arch, plugin_name, flavor, cpu, features, frame,
+                     range.GetBaseAddress(), limit, mixed_source_and_assembly,
+                     num_mixed_context_lines, options, strm);
 }
 
 Instruction::Instruction(const Address &address, AddressClass addr_class)

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -556,8 +556,8 @@ bool Disassembler::Disassemble(Debugger &debugger, const ArchSpec &arch,
       frame.GetSymbolContext(eSymbolContextFunction | eSymbolContextSymbol));
   if (sc.function) {
     if (DisassemblerSP disasm_sp = DisassembleRange(
-        arch, nullptr, nullptr, nullptr, nullptr, *frame.CalculateTarget(),
-        sc.function->GetAddressRanges())) {
+            arch, nullptr, nullptr, nullptr, nullptr, *frame.CalculateTarget(),
+            sc.function->GetAddressRanges())) {
       disasm_sp->PrintInstructions(debugger, arch, frame, false, 0, 0, strm);
       return true;
     }


### PR DESCRIPTION
This overload is taking a StackFrame, so we just need to change how we obtain the ranges out of it. A slightly fiddly aspect is the code which tries to provide a default dissassembly range for the case where we don't have a real one. I believe this case is only relevant for symbol-based stack frames as debug info always has size/range for the functions (if it didn't we wouldn't even resolve the stack frame to a function), which is why I've split the handling of the two cases.

We already have a test case for disassembly of discontinuous functions (in test/Shell/Commands/command-disassemble.s), so I'm not creating another one as this is just a slightly different entry point into the same code.