### PR TITLE
[flang-rt] Fixed HAVE_LDBL_MANT_DIG_113 detection.

### DIFF
--- a/flang-rt/CMakeLists.txt
+++ b/flang-rt/CMakeLists.txt
@@ -293,17 +293,6 @@ elseif (FLANG_RT_GCC_RESOURCE_DIR)
   endif ()
 endif ()
 
-# Check if 128-bit float computations can be done via long double.
-check_cxx_source_compiles(
-  "#include <cfloat>
-   #if LDBL_MANT_DIG != 113
-   #error LDBL_MANT_DIG != 113
-   #endif
-   int main() { return 0; }
-  "
-  HAVE_LDBL_MANT_DIG_113)
-
-
 #####################
 # Build Preparation #
 #####################

--- a/flang/cmake/modules/FlangCommon.cmake
+++ b/flang/cmake/modules/FlangCommon.cmake
@@ -25,8 +25,12 @@ if (FLANG_RUNTIME_F128_MATH_LIB)
 endif()
 
 # Check if 128-bit float computations can be done via long double
-check_cxx_source_compiles(
-  "#include <cfloat>
+# Note that '-nostdinc++' might be implied when this code kicks in
+# (see 'runtimes/CMakeLists.txt'), so we cannot use 'cfloat' C++ header
+# file in the test below.
+# Compile it as C.
+check_c_source_compiles(
+  "#include <float.h>
    #if LDBL_MANT_DIG != 113
    #error LDBL_MANT_DIG != 113
    #endif


### PR DESCRIPTION
I thought I guessed a fix in #130836, but I was wrong.
We actually had the same code in `flang/cmake/modules/FlangCommon.cmake`.
The check does not pass in flang-rt bootstrap build, because
`-nostdinc++` is added for all `runtimes` checks.
I decided to make the check with the C header, though, I am still
unsure whether it is reliable with a clang that has not been
installed (it is taken from the build structure during flang-rt
configure step).
I verified that this PR enables REAL(16) math entries on aarch64.
