### PR TITLE
[llvm-diff] Add colorful output to diff

### DIFF
--- a/llvm/tools/llvm-diff/lib/DiffConsumer.cpp
+++ b/llvm/tools/llvm-diff/lib/DiffConsumer.cpp
@@ -14,6 +14,8 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/WithColor.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
 
@@ -199,20 +201,23 @@ void DiffConsumer::logd(const DiffLogBuilder &Log) {
     switch (Log.getLineKind(I)) {
     case DC_match:
       out << "  ";
-      Log.getLeft(I)->print(dbgs()); dbgs() << '\n';
-      //printValue(Log.getLeft(I), true);
+      Log.getLeft(I)->print(dbgs());
+      dbgs() << '\n';
       break;
-    case DC_left:
-      out << "< ";
-      Log.getLeft(I)->print(dbgs()); dbgs() << '\n';
-      //printValue(Log.getLeft(I), true);
-      break;
-    case DC_right:
-      out << "> ";
-      Log.getRight(I)->print(dbgs()); dbgs() << '\n';
-      //printValue(Log.getRight(I), false);
+    case DC_left: {
+      auto LeftColor = llvm::WithColor(out, raw_ostream::RED);
+      LeftColor << "< ";
+      Log.getLeft(I)->print(LeftColor);
+      LeftColor << '\n';
       break;
     }
-    //out << "\n";
+    case DC_right: {
+      auto RightColor = llvm::WithColor(out, raw_ostream::GREEN);
+      RightColor << "> ";
+      Log.getRight(I)->print(RightColor);
+      RightColor << '\n';
+      break;
+    }
+    }
   }
 }


### PR DESCRIPTION
Adds colorful output when when possible to the diff. Adds a use to the `--color` option llvm-diff has. Similar to GNU diff
like this 
![image](https://github.com/user-attachments/assets/8dc4e995-11c4-4060-8c46-60535d8608e3)

First commit formats all files of llvm-diff with clang-format