### PR TITLE
[AMDGPU][CodeGen] use vt in VGPRimm pattern

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SIInstructions.td
@@ -2268,7 +2268,7 @@ foreach pred = [NotHasTrue16BitInsts, UseFakeTrue16Insts] in {
 
   foreach vt = [f16, bf16] in {
     def : GCNPat <
-      (VGPRImm<(f16 fpimm)>:$imm),
+      (VGPRImm<(vt fpimm)>:$imm),
       (V_MOV_B32_e32 (vt (bitcast_fpimm_to_i32 $imm)))
     >;
   }


### PR DESCRIPTION
There seems to be a typo error introduced by https://github.com/llvm/llvm-project/commit/2033767d68ed9aabcf1ad5d2bdd7541b272a05fd

Correct this pattern to use vt.