### PR TITLE
[Clang][OpenCL] Fix Missing `-fdeclare-opencl-builtins` When Using `--save-temps`

### DIFF
--- a/clang/lib/Driver/Types.cpp
+++ b/clang/lib/Driver/Types.cpp
@@ -226,7 +226,17 @@ bool types::isObjC(ID Id) {
   }
 }
 
-bool types::isOpenCL(ID Id) { return Id == TY_CL || Id == TY_CLCXX; }
+bool types::isOpenCL(ID Id) {
+  switch (Id) {
+  default:
+    return false;
+  case TY_PP_CL:
+  case TY_PP_CLCXX:
+  case TY_CL:
+  case TY_CLCXX:
+    return true;
+  }
+}
 
 bool types::isCXX(ID Id) {
   switch (Id) {

--- a/clang/test/Driver/opencl-aot-compilation.cl
+++ b/clang/test/Driver/opencl-aot-compilation.cl
@@ -1,0 +1,4 @@
+// RUN: %clang -x cl %s --save-temps -### 2>&1 | FileCheck %s
+
+// CHECK: "-fdeclare-opencl-builtins" {{.*}} "[[SRC:.+]].cli" "-x" "cl" "{{.*}}[[SRC]].cl"
+// CHECK-NEXT: "-fdeclare-opencl-builtins" {{.*}} "-x" "cl-cpp-output" "[[SRC]].cli"


### PR DESCRIPTION
When compiling an OpenCL program directly with `clang` using `--save-temps`, an
error may occur if the program contains OpenCL builtins:

```
test.cl:3:21: error: use of undeclared identifier 'get_global_id'
    3 |   unsigned int id = get_global_id(0);
      |                     ^
```

This happens because the driver does not add `-fdeclare-opencl-builtins` when
the input type is `TY_PP_CL`. This PR fixes the issue.