### PR TITLE
[SandboxVec] Add print-region pass

### DIFF
--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PrintRegion.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PrintRegion.h
@@ -1,0 +1,29 @@
+#ifndef LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_PASSES_PRINTREGION_H
+#define LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_PASSES_PRINTREGION_H
+
+#include "llvm/SandboxIR/Pass.h"
+#include "llvm/SandboxIR/Region.h"
+
+namespace llvm::sandboxir {
+
+/// A Region pass that does nothing, for use as a placeholder in tests.
+class PrintRegion final : public RegionPass {
+public:
+  PrintRegion() : RegionPass("print-region") {}
+  bool runOnRegion(Region &R, const Analyses &A) final {
+    raw_ostream &OS = outs();
+#ifndef NDEBUG
+    OS << "-- Region --\n";
+    OS << R << "\n";
+#else
+    // TODO: Make this available in all builds, depends on enabling SandboxIR
+    // dumps in non-debug builds.
+    OS << "Region dump only available in DEBUG build!";
+#endif
+    return false;
+  }
+};
+
+} // namespace llvm::sandboxir
+
+#endif // LLVM_TRANSFORMS_VECTORIZE_SANDBOXVECTORIZER_PASSES_PRINTREGION_H

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/PassRegistry.def
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/Passes/PassRegistry.def
@@ -19,6 +19,7 @@
 
 REGION_PASS("null", ::llvm::sandboxir::NullPass)
 REGION_PASS("print-instruction-count", ::llvm::sandboxir::PrintInstructionCount)
+REGION_PASS("print-region", ::llvm::sandboxir::PrintRegion)
 REGION_PASS("tr-save", ::llvm::sandboxir::TransactionSave)
 REGION_PASS("tr-accept", ::llvm::sandboxir::TransactionAlwaysAccept)
 REGION_PASS("tr-accept-or-revert", ::llvm::sandboxir::TransactionAcceptOrRevert)

--- a/llvm/lib/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizerPassBuilder.cpp
+++ b/llvm/lib/Transforms/Vectorize/SandboxVectorizer/SandboxVectorizerPassBuilder.cpp
@@ -3,6 +3,7 @@
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/Passes/BottomUpVec.h"
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/Passes/NullPass.h"
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PrintInstructionCount.h"
+#include "llvm/Transforms/Vectorize/SandboxVectorizer/Passes/PrintRegion.h"
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/Passes/RegionsFromBBs.h"
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/Passes/RegionsFromMetadata.h"
 #include "llvm/Transforms/Vectorize/SandboxVectorizer/Passes/SeedCollection.h"

--- a/llvm/test/Transforms/SandboxVectorizer/print_region_pass.ll
+++ b/llvm/test/Transforms/SandboxVectorizer/print_region_pass.ll
@@ -1,0 +1,26 @@
+; RUN: opt -disable-output -passes=sandbox-vectorizer -sbvec-passes="regions-from-metadata<print-region>" %s | FileCheck %s
+; REQUIRES: asserts
+
+define void @foo(i8 %v) {
+; CHECK: -- Region --
+; CHECK-NEXT:  %add0 = add i8 %v, 0, !sandboxvec !0 {{.*}}
+; CHECK: -- Region --
+; CHECK-NEXT:  %add1 = add i8 %v, 1, !sandboxvec !1 {{.*}}
+; CHECK-NEXT:  %add2 = add i8 %v, 2, !sandboxvec !1 {{.*}}
+; CHECK-NEXT:  %add3 = add i8 %v, 3, !sandboxvec !1, !sandboxaux !2 {{.*}}
+; CHECK-NEXT:  %add4 = add i8 %v, 4, !sandboxvec !1, !sandboxaux !3 {{.*}}
+; CHECK: Aux:
+; CHECK-NEXT:  %add3 = add i8 %v, 3, !sandboxvec !1, !sandboxaux !2 {{.*}}
+; CHECK-NEXT:  %add4 = add i8 %v, 4, !sandboxvec !1, !sandboxaux !3 {{.*}}
+  %add0 = add i8 %v, 0, !sandboxvec !0
+  %add1 = add i8 %v, 1, !sandboxvec !1
+  %add2 = add i8 %v, 2, !sandboxvec !1
+  %add3 = add i8 %v, 3, !sandboxvec !1, !sandboxaux !2
+  %add4 = add i8 %v, 4, !sandboxvec !1, !sandboxaux !3
+  ret void
+}
+
+!0 = distinct !{!"sandboxregion"}
+!1 = distinct !{!"sandboxregion"}
+!2 = !{i32 0}
+!3 = !{i32 1}


### PR DESCRIPTION
This patch implements a simple printing pass for regions. This is meant to be used in tests and for debugging.