### PR TITLE
[llvm][Timer] Don't print timers in TimerGroup when all Timers are removed

### DIFF
--- a/llvm/lib/Support/Timer.cpp
+++ b/llvm/lib/Support/Timer.cpp
@@ -284,6 +284,11 @@ TimerGroup::~TimerGroup() {
   while (FirstTimer)
     removeTimer(*FirstTimer);
 
+  if (!TimersToPrint.empty()) {
+    std::unique_ptr<raw_ostream> OutStream = CreateInfoOutputFile();
+    PrintQueuedTimers(*OutStream);
+  }
+
   // Remove the group from the TimerGroupList.
   sys::SmartScopedLock<true> L(timerLock());
   *Prev = Next;
@@ -305,14 +310,6 @@ void TimerGroup::removeTimer(Timer &T) {
   *T.Prev = T.Next;
   if (T.Next)
     T.Next->Prev = T.Prev;
-
-  // Print the report when all timers in this group are destroyed if some of
-  // them were started.
-  if (FirstTimer || TimersToPrint.empty())
-    return;
-
-  std::unique_ptr<raw_ostream> OutStream = CreateInfoOutputFile();
-  PrintQueuedTimers(*OutStream);
 }
 
 void TimerGroup::addTimer(Timer &T) {

--- a/llvm/unittests/Support/TimerTest.cpp
+++ b/llvm/unittests/Support/TimerTest.cpp
@@ -66,4 +66,20 @@ TEST(Timer, CheckIfTriggered) {
   EXPECT_FALSE(T1.hasTriggered());
 }
 
-} // end anon namespace
+TEST(Timer, TimerGroupTimerDestructed) {
+  testing::internal::CaptureStderr();
+
+  {
+    TimerGroup TG("tg", "desc");
+    {
+      Timer T1("T1", "T1", TG);
+      T1.startTimer();
+      T1.stopTimer();
+    }
+    EXPECT_TRUE(testing::internal::GetCapturedStderr().empty());
+    testing::internal::CaptureStderr();
+  }
+  EXPECT_FALSE(testing::internal::GetCapturedStderr().empty());
+}
+
+} // namespace


### PR DESCRIPTION
Only print them on TimerGroup destruction (or eagerly when TimerGroup::printAll() is called).

We should be able to destroy all Timers in a TimerGroup while delaying printing the stored TimeRecords.