### PR TITLE
Optimize std::__tree::__assign_multi to insert the provided range at the end of the tree every time

### DIFF
--- a/libcxx/include/__tree
+++ b/libcxx/include/__tree
@@ -1432,8 +1432,9 @@ void __tree<_Tp, _Compare, _Allocator>::__assign_multi(_InputIterator __first, _
       __cache.__advance();
     }
   }
+  const_iterator __e = end();
   for (; __first != __last; ++__first)
-    __insert_multi(_NodeTypes::__get_value(*__first));
+    __insert_multi(__e, _NodeTypes::__get_value(*__first));
 }
 
 template <class _Tp, class _Compare, class _Allocator>


### PR DESCRIPTION
This improves performance for the copy-assignment operators of associative containers such as `std::map`.

Note that this optimization already exists in other places, e.g.:

https://github.com/llvm/llvm-project/blob/15e6bb6224177805d8b6a8268f08a2b88ae4dd70/libcxx/include/map#L1217-L1218

As an example, this makes the following code 15% faster:
```cc
#include <stddef.h>
#include <chrono>
#include <iostream>
#include <set>

using Clock = std::chrono::high_resolution_clock;

int main() {
  std::set<size_t> a, b;
  for (size_t i = 0; i < 5000000; ++i) {
    b.insert(i);
  }
  Clock::time_point start = Clock::now();
  a = b;
  std::chrono::duration<double> diff = Clock::now() - start;
  std::cout << "Time taken: " << diff.count() << std::endl;
}
```