### PR TITLE
[libc++] Add __assertion_handler to the modulemap

### DIFF
--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -2286,9 +2286,8 @@ module std [system] {
     export *
   }
   module assertion_handler {
-    // This header is generated via CMake. It must be textual because it may be vendor-provided,
-    // which means that we can't know what to re-export (if anything) in advance.
-    textual header "__assertion_handler"
+    header "__assertion_handler" // generated via CMake
+    export *
   }
 
   module undef_macros {

--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -2286,7 +2286,9 @@ module std [system] {
     export *
   }
   module assertion_handler {
-    header "__assertion_handler" // Generated via CMake
+    // This header is generated via CMake. It must be textual because it may be vendor-provided,
+    // which means that we can't know what to re-export (if anything) in advance.
+    textual header "__assertion_handler"
   }
 
   module undef_macros {

--- a/libcxx/include/module.modulemap
+++ b/libcxx/include/module.modulemap
@@ -2285,6 +2285,9 @@ module std [system] {
     header "__assert"
     export *
   }
+  module assertion_handler {
+    header "__assertion_handler" // Generated via CMake
+  }
 
   module undef_macros {
     textual header "__undef_macros"


### PR DESCRIPTION
That header is generated via CMake, but it is nonetheless present in the final installation, so it should be covered by the modulemap.

rdar://131418726