### PR TITLE
[clang][lit] mkdir before mkstemp in is_filesystem_case_insensitive()

### DIFF
--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -253,7 +253,7 @@ if platform.system() not in ["Darwin", "Fuchsia"]:
 
 
 def is_filesystem_case_insensitive():
-    os.mkdir(config.test_exec_root)
+    os.makedirs(config.test_exec_root, exist_ok=True)
     handle, path = tempfile.mkstemp(prefix="case-test", dir=config.test_exec_root)
     isInsensitive = os.path.exists(
         os.path.join(os.path.dirname(path), os.path.basename(path).upper())

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -253,6 +253,7 @@ if platform.system() not in ["Darwin", "Fuchsia"]:
 
 
 def is_filesystem_case_insensitive():
+    os.mkdir(config.test_exec_root)
     handle, path = tempfile.mkstemp(prefix="case-test", dir=config.test_exec_root)
     isInsensitive = os.path.exists(
         os.path.join(os.path.dirname(path), os.path.basename(path).upper())


### PR DESCRIPTION
In the CMake build test_exec_root already exists here, but not in the gn build, which causes this to fail.