### PR TITLE
[mlir] Fix edge case in move operation dependencies utility

### DIFF
--- a/mlir/lib/Transforms/Utils/RegionUtils.cpp
+++ b/mlir/lib/Transforms/Utils/RegionUtils.cpp
@@ -1079,34 +1079,11 @@ LogicalResult mlir::moveOperationDependencies(RewriterBase &rewriter,
                                        "insertion point does not dominate op");
   }
 
-  // Find the backward slice of operation for each `Value` the operation
-  // depends on. Prune the slice to only include operations not already
-  // dominated by the `insertionPoint`
-  BackwardSliceOptions options;
-  options.inclusive = false;
-  options.omitUsesFromAbove = false;
-  // Since current support is to only move within a same basic block,
-  // the slices dont need to look past block arguments.
-  options.omitBlockArguments = true;
-  options.filter = [&](Operation *sliceBoundaryOp) {
-    return !dominance.properlyDominates(sliceBoundaryOp, insertionPoint);
-  };
-  llvm::SetVector<Operation *> slice;
-  getBackwardSlice(op, &slice, options);
-
-  // If the slice contains `insertionPoint` cannot move the dependencies.
-  if (slice.contains(insertionPoint)) {
-    return rewriter.notifyMatchFailure(
-        op,
-        "cannot move dependencies before operation in backward slice of op");
-  }
-
-  // We should move the slice in topological order, but `getBackwardSlice`
-  // already does that. So no need to sort again.
-  for (Operation *op : slice) {
-    rewriter.moveOpBefore(op, insertionPoint);
-  }
-  return success();
+  auto operandRange = op->getOperands();
+  SetVector<Value> defs(operandRange.begin(), operandRange.end());
+  getUsedValuesDefinedAbove(op->getRegions(), defs);
+  return moveValueDefinitions(rewriter, defs.takeVector(), insertionPoint,
+                              dominance);
 }
 
 LogicalResult mlir::moveOperationDependencies(RewriterBase &rewriter,


### PR DESCRIPTION
This change simplifies `moveOperationDependencies` and handles the edge case where if the given op directly uses `insertionPoint`, the op's dependencies can still be moved.



