### PR TITLE
Filter out configuration file from compile commands

### DIFF
--- a/clang/utils/perf-training/perf-helper.py
+++ b/clang/utils/perf-training/perf-helper.py
@@ -237,6 +237,7 @@ def get_cc1_command_for_args(cmd, env):
             or ln.startswith("InstalledDir:")
             or ln.startswith("LLVM Profile Note")
             or ln.startswith(" (in-process)")
+            or ln.startswith("Configuration file:")
             or " version " in ln
         ):
             continue


### PR DESCRIPTION
The commands to run the compilation when printed with `-###` contain
various irrelevant lines for the perf-training. Most of them are
filtered out already but when configured with
`CLANG_CONFIG_FILE_SYSTEM_DIR` a new line like the following is
added and needs to be filtered out:

`Configuration file: /etc/clang/x86_64-redhat-linux-gnu-clang.cfg`
