### PR TITLE
[NFC] Fix formatting for #80963

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -10938,8 +10938,7 @@ void Sema::CheckConstructor(CXXConstructorDecl *Constructor) {
   //   parameters have default arguments.
   if (!Constructor->isInvalidDecl() &&
       Constructor->hasOneParamOrDefaultArgs() &&
-      !Constructor->isFunctionTemplateSpecialization()
-          ) {
+      !Constructor->isFunctionTemplateSpecialization()) {
     QualType ParamType = Constructor->getParamDecl(0)->getType();
     QualType ClassTy = Context.getTagDeclType(ClassDecl);
     if (Context.getCanonicalType(ParamType).getUnqualifiedType() == ClassTy) {


### PR DESCRIPTION
This PR fixes formatting issues in `constructor-template.cpp` introduced in #130866.  

Changes:  
- Ran `clang-format` to adhere to LLVM style guidelines.  
- No functional changes.  

CC: @cor3ntin @shafik 
Thanks