### PR TITLE
[mlir][llvmir] Add SameOperandsAndResultType trait to LLVM_CountZerosIntrOp

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
@@ -86,7 +86,7 @@ class LLVM_TernarySameArgsIntrOpF<string func, list<Trait> traits = []> :
 
 class LLVM_CountZerosIntrOp<string func, list<Trait> traits = []> :
     LLVM_OneResultIntrOp<func, [], [0],
-           !listconcat([Pure], traits),
+           !listconcat([Pure, SameOperandsAndResultType], traits),
             /*requiresFastmath=*/0,
             /*immArgPositions=*/[1], /*immArgAttrNames=*/["is_zero_poison"]> {
   let arguments = (ins LLVM_ScalarOrVectorOf<AnySignlessInteger>:$in,


### PR DESCRIPTION
According to https://llvm.org/docs/LangRef.html#llvm-ctlz-intrinsic and https://llvm.org/docs/LangRef.html#llvm-cttz-intrinsic, The return type of `llvm.intr.ctlz` and `llvm.intr.cttz` must match the first argument type.