### PR TITLE
[flang] Use precompiled headers in Frontend, Lower, Parser, Semantics and Evaluate

### DIFF
--- a/flang/lib/Evaluate/CMakeLists.txt
+++ b/flang/lib/Evaluate/CMakeLists.txt
@@ -73,3 +73,17 @@ add_flang_library(FortranEvaluate
   acc_gen
   omp_gen
 )
+
+target_precompile_headers(FortranEvaluate PRIVATE
+  [["flang/Evaluate/common.h"]]
+  [["flang/Evaluate/call.h"]]
+  [["flang/Evaluate/traverse.h"]]
+  [["flang/Evaluate/shape.h"]]
+  [["flang/Evaluate/characteristics.h"]]
+  [["flang/Evaluate/variable.h"]]
+  [["flang/Evaluate/real.h"]]
+  [["flang/Evaluate/type.h"]]
+  [["flang/Evaluate/integer.h"]]
+  [["flang/Evaluate/expression.h"]]
+  [["flang/Evaluate/tools.h"]]
+)

--- a/flang/lib/Frontend/CMakeLists.txt
+++ b/flang/lib/Frontend/CMakeLists.txt
@@ -74,3 +74,11 @@ add_flang_library(flangFrontend
   clangBasic
   clangDriver
 )
+
+target_precompile_headers(flangFrontend PRIVATE
+  [["flang/Parser/parsing.h"]]
+  [["flang/Parser/parse-tree.h"]]
+  [["flang/Parser/dump-parse-tree.h"]]
+  [["flang/Lower/PFTBuilder.h"]]
+  [["flang/Lower/Bridge.h"]]
+)

--- a/flang/lib/Lower/CMakeLists.txt
+++ b/flang/lib/Lower/CMakeLists.txt
@@ -73,3 +73,14 @@ add_flang_library(FortranLower
   MLIRLLVMDialect
   MLIRSCFToControlFlow
 )
+
+target_precompile_headers(FortranLower PRIVATE
+  [["flang/Lower/ConvertExpr.h"]]
+  [["flang/Lower/SymbolMap.h"]]
+  [["flang/Lower/AbstractConverter.h"]]
+  [["flang/Lower/IterationSpace.h"]]
+  [["flang/Lower/CallInterface.h"]]
+  [["flang/Lower/BoxAnalyzer.h"]]
+  [["flang/Lower/PFTBuilder.h"]]
+  [["flang/Lower/DirectivesCommon.h"]]
+)

--- a/flang/lib/Parser/CMakeLists.txt
+++ b/flang/lib/Parser/CMakeLists.txt
@@ -36,3 +36,11 @@ add_flang_library(FortranParser
   omp_gen
   acc_gen
 )
+
+target_precompile_headers(FortranParser PRIVATE
+  [["flang/Parser/parsing.h"]]
+  [["flang/Parser/parse-tree.h"]]
+  [["flang/Parser/provenance.h"]]
+  [["flang/Parser/message.h"]]
+  [["flang/Parser/parse-tree-visitor.h"]]
+)

--- a/flang/lib/Semantics/CMakeLists.txt
+++ b/flang/lib/Semantics/CMakeLists.txt
@@ -64,3 +64,12 @@ add_flang_library(FortranSemantics
   FrontendOpenACC
   TargetParser
 )
+
+target_precompile_headers(FortranSemantics PRIVATE
+  [["flang/Semantics/semantics.h"]]
+  [["flang/Semantics/type.h"]]
+  [["flang/Semantics/openmp-modifiers.h"]]
+  [["flang/Semantics/expression.h"]]
+  [["flang/Semantics/tools.h"]]
+  [["flang/Semantics/symbol.h"]]
+)

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -288,7 +288,11 @@ if(LLVM_CCACHE_BUILD)
     else()
       # Until a way to reliably configure ccache on Windows is found,
       # disable precompiled headers for Windows + ccache builds
-      set(CMAKE_DISABLE_PRECOMPILE_HEADERS "ON")
+      if(NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
+        message(WARNING "Using ccache with precompiled headers on Windows is currently not supported.
+          CMAKE_DISABLE_PRECOMPILE_HEADERS will be set to ON.")
+        set(CMAKE_DISABLE_PRECOMPILE_HEADERS "ON")
+      endif()
       if(LLVM_CCACHE_MAXSIZE OR LLVM_CCACHE_DIR OR
          NOT LLVM_CCACHE_PARAMS MATCHES "CCACHE_CPP2=yes CCACHE_HASHDIR=yes CCACHE_SLOPPINESS=pch_defines,time_macros")
         message(FATAL_ERROR "Ccache configuration through CMake is not supported on Windows. Please use environment variables.")

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -286,6 +286,9 @@ if(LLVM_CCACHE_BUILD)
       endif()
       set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_PROGRAM})
     else()
+      # Until a way to reliably configure ccache on Windows is found,
+      # disable precompiled headers for Windows + ccache builds
+      set(CMAKE_DISABLE_PRECOMPILE_HEADERS "ON")
       if(LLVM_CCACHE_MAXSIZE OR LLVM_CCACHE_DIR OR
          NOT LLVM_CCACHE_PARAMS MATCHES "CCACHE_CPP2=yes CCACHE_HASHDIR=yes CCACHE_SLOPPINESS=pch_defines,time_macros")
         message(FATAL_ERROR "Ccache configuration through CMake is not supported on Windows. Please use environment variables.")


### PR DESCRIPTION
Precompiling larger headers can save a lot of compile time across various compilation units.

Selected compile time & memory improvements are as follows:

flang/lib/Parser/Fortran-parsers.cpp:
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:47.31 -> 0:41.68
Maximum resident set size (kbytes): 2062140 -> 1745584

flang/lib/Lower/Bridge.cpp:
Elapsed (wall clock) time (h:mm:ss or m:ss): 1:19.16 -> 0:45.86
Maximum resident set size (kbytes): 3849144 -> 2443476

flang/lib/Lower/PFTBuilder.cpp
Elapsed (wall clock) time (h:mm:ss or m:ss): 1:29.24 -> 1:00.99
Maximum resident set size (kbytes): 4218368 -> 2923128

flang/lib/Lower/Allocatable.cpp
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:53.03 -> 0:22.50
Maximum resident set size (kbytes): 3092840 -> 2116908

flang/lib/Semantics/Semantics.cpp
Elapsed (wall clock) time (h:mm:ss or m:ss): 1:18.75 -> 1:00.20
Maximum resident set size (kbytes): 3527744 -> 2545308

While the newly added precompiled headers are as follows:

Parser:
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:09.62
Maximum resident set size (kbytes): 1034608

Lower:
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:41.33
Maximum resident set size (kbytes): 3615240

Semantics:
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:26.69
Maximum resident set size (kbytes): 2403776