### PR TITLE
[AA][BasicAA] Move more call logic to BasicAA

### DIFF
--- a/llvm/test/Analysis/BasicAA/call.ll
+++ b/llvm/test/Analysis/BasicAA/call.ll
@@ -3,7 +3,7 @@
 declare void @callee(ptr)
 
 ; CHECK-LABEL: Function: test
-; CHECK: Both ModRef: Ptr: i32* %a.gep <-> call void @callee(ptr %gep)
+; CHECK: NoModRef: Ptr: i32* %a.gep <-> call void @callee(ptr %gep)
 define void @test(i1 %c, ptr %arg) {
   %a = alloca [2 x i32]
   %a.gep = getelementptr i8, ptr %a, i64 4


### PR DESCRIPTION
Currently, the handling for calls is split between AA and BasicAA in an awkward way. BasicAA does argument aliasing analysis for non-escaping objects (but without considering MemoryEffects), while AA handles the generic case using MemoryEffects. However, fundamentally, both of these are really trying to do the same thing.

The new merged logic first tries to remove the OtherMR component of the memory effects, which includes accesses to escaped memory. If a function-local object does not escape, OtherMR can be set to NoModRef.

Then we perform the argument scan in basically the same way as AA previously did. However, we also need to look at the operand bundles. To support that, I've adjusted getArgModRefInfo to accept operand bundle arguments.