### PR TITLE
[libc] Fix new warning in DyadicFloat::as_mantissa_type_rounded

### DIFF
--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -455,6 +455,10 @@ template <size_t Bits> struct DyadicFloat {
       if (exponent > 0) {
         new_mant <<= exponent;
       } else if (exponent < 0) {
+        // Cast the exponent to size_t before negating it, rather than after,
+        // to avoid undefined behavior negating INT_MIN as an integer (although
+        // exponents coming in to this function _shouldn't_ be that large). The
+        // result should always end up as a positive size_t.
         size_t shift = -static_cast<size_t>(exponent);
         new_mant >>= shift;
         round_dir = rounding_direction(mantissa, shift, sign);

--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -455,7 +455,7 @@ template <size_t Bits> struct DyadicFloat {
       if (exponent > 0) {
         new_mant <<= exponent;
       } else if (exponent < 0) {
-        size_t shift = -exponent;
+        size_t shift = -static_cast<size_t>(exponent);
         new_mant >>= shift;
         round_dir = rounding_direction(mantissa, shift, sign);
         if (round_dir > 0)


### PR DESCRIPTION
The affected line of code converts a float's exponent from `int` to `size_t`, negating it in the process. Following clang commit 773e88f9d61399c, this provokes a warning, presumably because the conversion goes wrong if `size_t` is wider than `int` and the input value is `INT_MIN`: negating it within the `int` type is undefined behavior, with the likely (though not guaranteed) effect of leaving it still at `INT_MIN` and then sign-extending that on promotion to `size_t`.

This fix adds a cast so that the promotion to `size_t` happens _before_ the negation, so that the negative input value will _always_ be sign-extended, and then the negation will make it positive again.

(I don't believe this case will actually come up. `DyadicFloat` is a helper system used in processing ordinary float formats, so nothing is expected to generate an exponent with even a 16-bit absolute value, let alone 31. But it's as easy to fix it to be robust as it is to just suppress the warning!)