### PR TITLE
[libc] Fix non-templated uses of `printf_core::Writer`

### DIFF
--- a/libc/src/stdio/baremetal/printf.cpp
+++ b/libc/src/stdio/baremetal/printf.cpp
@@ -38,7 +38,8 @@ LLVM_LIBC_FUNCTION(int, printf, (const char *__restrict format, ...)) {
   constexpr size_t BUFF_SIZE = 1024;
   char buffer[BUFF_SIZE];
 
-  printf_core::WriteBuffer wb(buffer, BUFF_SIZE, &raw_write_hook, nullptr);
+  printf_core::WriteBuffer<Mode<WriteMode::FLUSH_TO_STREAM>::value> wb(
+      buffer, BUFF_SIZE, &raw_write_hook, nullptr);
   printf_core::Writer writer(&wb);
 
   int retval = printf_core::printf_main(&writer, format, args);

--- a/libc/src/stdio/baremetal/vprintf.cpp
+++ b/libc/src/stdio/baremetal/vprintf.cpp
@@ -36,7 +36,8 @@ LLVM_LIBC_FUNCTION(int, vprintf,
   constexpr size_t BUFF_SIZE = 1024;
   char buffer[BUFF_SIZE];
 
-  printf_core::WriteBuffer wb(buffer, BUFF_SIZE, &raw_write_hook, nullptr);
+  printf_core::WriteBuffer<Mode<WriteMode::FLUSH_TO_STREAM>::value> wb(
+      buffer, BUFF_SIZE, &raw_write_hook, nullptr);
   printf_core::Writer writer(&wb);
 
   int retval = printf_core::printf_main(&writer, format, args);

--- a/libc/src/stdio/printf_core/float_dec_converter_limited.h
+++ b/libc/src/stdio/printf_core/float_dec_converter_limited.h
@@ -375,11 +375,11 @@ DigitsOutput decimal_digits(DigitsInput input, int precision, bool e_mode) {
   return output;
 }
 
-LIBC_INLINE int convert_float_inner(Writer *writer,
-                                    const FormatSection &to_conv,
-                                    int32_t fraction_len, int exponent,
-                                    StorageType mantissa, Sign sign,
-                                    ConversionType ctype) {
+template <WriteMode write_mode>
+LIBC_INLINE int
+convert_float_inner(Writer<write_mode> *writer, const FormatSection &to_conv,
+                    int32_t fraction_len, int exponent, StorageType mantissa,
+                    Sign sign, ConversionType ctype) {
   // If to_conv doesn't specify a precision, the precision defaults to 6.
   unsigned precision = to_conv.precision < 0 ? 6 : to_conv.precision;
 
@@ -617,9 +617,10 @@ LIBC_INLINE int convert_float_inner(Writer *writer,
   return WRITE_OK;
 }
 
-template <typename T, cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
+template <typename T, WriteMode write_mode,
+          cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
 LIBC_INLINE int
-convert_float_typed(Writer *writer, const FormatSection &to_conv,
+convert_float_typed(Writer<write_mode> *writer, const FormatSection &to_conv,
                     fputil::FPBits<T> float_bits, ConversionType ctype) {
   return convert_float_inner(writer, to_conv, float_bits.FRACTION_LEN,
                              float_bits.get_explicit_exponent(),
@@ -627,7 +628,8 @@ convert_float_typed(Writer *writer, const FormatSection &to_conv,
                              float_bits.sign(), ctype);
 }
 
-LIBC_INLINE int convert_float_outer(Writer *writer,
+template <WriteMode write_mode>
+LIBC_INLINE int convert_float_outer(Writer<write_mode> *writer,
                                     const FormatSection &to_conv,
                                     ConversionType ctype) {
   if (to_conv.length_modifier == LengthModifier::L) {
@@ -649,38 +651,44 @@ LIBC_INLINE int convert_float_outer(Writer *writer,
   return convert_inf_nan(writer, to_conv);
 }
 
-template <typename T, cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
-LIBC_INLINE int convert_float_decimal_typed(Writer *writer,
+template <typename T, WriteMode write_mode,
+          cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
+LIBC_INLINE int convert_float_decimal_typed(Writer<write_mode> *writer,
                                             const FormatSection &to_conv,
                                             fputil::FPBits<T> float_bits) {
   return convert_float_typed<T>(writer, to_conv, float_bits, ConversionType::F);
 }
 
-template <typename T, cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
-LIBC_INLINE int convert_float_dec_exp_typed(Writer *writer,
+template <typename T, WriteMode write_mode,
+          cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
+LIBC_INLINE int convert_float_dec_exp_typed(Writer<write_mode> *writer,
                                             const FormatSection &to_conv,
                                             fputil::FPBits<T> float_bits) {
   return convert_float_typed<T>(writer, to_conv, float_bits, ConversionType::E);
 }
 
-template <typename T, cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
-LIBC_INLINE int convert_float_dec_auto_typed(Writer *writer,
+template <typename T, WriteMode write_mode,
+          cpp::enable_if_t<cpp::is_floating_point_v<T>, int> = 0>
+LIBC_INLINE int convert_float_dec_auto_typed(Writer<write_mode> *writer,
                                              const FormatSection &to_conv,
                                              fputil::FPBits<T> float_bits) {
   return convert_float_typed<T>(writer, to_conv, float_bits, ConversionType::G);
 }
 
-LIBC_INLINE int convert_float_decimal(Writer *writer,
+template <WriteMode write_mode>
+LIBC_INLINE int convert_float_decimal(Writer<write_mode> *writer,
                                       const FormatSection &to_conv) {
   return convert_float_outer(writer, to_conv, ConversionType::F);
 }
 
-LIBC_INLINE int convert_float_dec_exp(Writer *writer,
+template <WriteMode write_mode>
+LIBC_INLINE int convert_float_dec_exp(Writer<write_mode> *writer,
                                       const FormatSection &to_conv) {
   return convert_float_outer(writer, to_conv, ConversionType::E);
 }
 
-LIBC_INLINE int convert_float_dec_auto(Writer *writer,
+template <WriteMode write_mode>
+LIBC_INLINE int convert_float_dec_auto(Writer<write_mode> *writer,
                                        const FormatSection &to_conv) {
   return convert_float_outer(writer, to_conv, ConversionType::G);
 }


### PR DESCRIPTION
Commit 598e882ee88a1e3 turned `Writer` into a template, and updated most of the call sites that use it. But not all. The alternative FP printf system in `float_dec_converter_limited.h` wasn't updated, and neither was `baremetal/printf.cpp` or `baremetal/vprintf.cpp`.

This patch updates `float_dec_converter_limited.h` in the same way that the previous commit updated `float_dec_converter.h`: propagate the templatedness through everything in the header, so that anything using a `Writer` at all has a `write_mode` template parameter to pass on to it.

`printf.cpp` and `vprintf.cpp` are updated in the same way that the previous commit updated `printf_core/vfprintf_internal.h`: the `WriteBuffer` has parameter `WriteMode::FLUSH_TO_STREAM`, and `Writer` picks it up implicitly from that.