### PR TITLE
[lldb] Use UnwindPlan::Row as values

### DIFF
--- a/lldb/include/lldb/Symbol/UnwindPlan.h
+++ b/lldb/include/lldb/Symbol/UnwindPlan.h
@@ -463,8 +463,12 @@ public:
   void Dump(Stream &s, Thread *thread, lldb::addr_t base_addr) const;
 
   void AppendRow(const RowSP &row_sp);
+  void AppendRow(Row row) { AppendRow(std::make_shared<Row>(std::move(row))); }
 
   void InsertRow(const RowSP &row_sp, bool replace_existing = false);
+  void InsertRow(Row row, bool replace_existing = false) {
+    InsertRow(std::make_shared<Row>(std::move(row)), replace_existing);
+  }
 
   // Returns a pointer to the best row for the given offset into the function's
   // instructions. If offset is -1 it indicates that the function start is

--- a/lldb/source/Plugins/Platform/Linux/PlatformLinux.cpp
+++ b/lldb/source/Plugins/Platform/Linux/PlatformLinux.cpp
@@ -210,8 +210,7 @@ static lldb::UnwindPlanSP GetAArch64TrapHandlerUnwindPlan(ConstString name) {
   if (name != "__kernel_rt_sigreturn")
     return unwind_plan_sp;
 
-  UnwindPlan::RowSP row = std::make_shared<UnwindPlan::Row>();
-  row->SetOffset(0);
+  UnwindPlan::Row row;
 
   // In the signal trampoline frame, sp points to an rt_sigframe[1], which is:
   //  - 128-byte siginfo struct
@@ -235,48 +234,48 @@ static lldb::UnwindPlanSP GetAArch64TrapHandlerUnwindPlan(ConstString name) {
 
   // Skip fault address
   offset += 8;
-  row->GetCFAValue().SetIsRegisterPlusOffset(arm64_dwarf::sp, offset);
+  row.GetCFAValue().SetIsRegisterPlusOffset(arm64_dwarf::sp, offset);
 
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x0, 0 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x1, 1 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x2, 2 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x3, 3 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x4, 4 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x5, 5 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x6, 6 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x7, 7 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x8, 8 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x9, 9 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x10, 10 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x11, 11 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x12, 12 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x13, 13 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x14, 14 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x15, 15 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x16, 16 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x17, 17 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x18, 18 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x19, 19 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x20, 20 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x21, 21 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x22, 22 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x23, 23 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x24, 24 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x25, 25 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x26, 26 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x27, 27 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x28, 28 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::fp, 29 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x30, 30 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::sp, 31 * 8, false);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::pc, 32 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x0, 0 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x1, 1 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x2, 2 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x3, 3 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x4, 4 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x5, 5 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x6, 6 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x7, 7 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x8, 8 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x9, 9 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x10, 10 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x11, 11 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x12, 12 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x13, 13 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x14, 14 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x15, 15 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x16, 16 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x17, 17 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x18, 18 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x19, 19 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x20, 20 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x21, 21 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x22, 22 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x23, 23 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x24, 24 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x25, 25 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x26, 26 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x27, 27 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x28, 28 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::fp, 29 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::x30, 30 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::sp, 31 * 8, false);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_dwarf::pc, 32 * 8, false);
 
   // The sigcontext may also contain floating point and SVE registers.
   // However this would require a dynamic unwind plan so they are not included
   // here.
 
   unwind_plan_sp = std::make_shared<UnwindPlan>(eRegisterKindDWARF);
-  unwind_plan_sp->AppendRow(row);
+  unwind_plan_sp->AppendRow(std::move(row));
   unwind_plan_sp->SetSourceName("AArch64 Linux sigcontext");
   unwind_plan_sp->SetSourcedFromCompiler(eLazyBoolYes);
   // Because sp is the same throughout the function

--- a/lldb/source/Plugins/SymbolFile/Breakpad/SymbolFileBreakpad.cpp
+++ b/lldb/source/Plugins/SymbolFile/Breakpad/SymbolFileBreakpad.cpp
@@ -660,11 +660,10 @@ SymbolFileBreakpad::ParseCFIUnwindPlan(const Bookmark &bookmark,
       AddressRange(base + init_record->Address, *init_record->Size,
                    m_objfile_sp->GetModule()->GetSectionList()));
 
-  auto row_sp = std::make_shared<UnwindPlan::Row>();
-  row_sp->SetOffset(0);
-  if (!ParseCFIUnwindRow(init_record->UnwindRules, resolver, *row_sp))
+  UnwindPlan::Row row;
+  if (!ParseCFIUnwindRow(init_record->UnwindRules, resolver, row))
     return nullptr;
-  plan_sp->AppendRow(row_sp);
+  plan_sp->AppendRow(row);
   for (++It; It != End; ++It) {
     std::optional<StackCFIRecord> record = StackCFIRecord::parse(*It);
     if (!record)
@@ -672,11 +671,10 @@ SymbolFileBreakpad::ParseCFIUnwindPlan(const Bookmark &bookmark,
     if (record->Size)
       break;
 
-    row_sp = std::make_shared<UnwindPlan::Row>(*row_sp);
-    row_sp->SetOffset(record->Address - init_record->Address);
-    if (!ParseCFIUnwindRow(record->UnwindRules, resolver, *row_sp))
+    row.SetOffset(record->Address - init_record->Address);
+    if (!ParseCFIUnwindRow(record->UnwindRules, resolver, row))
       return nullptr;
-    plan_sp->AppendRow(row_sp);
+    plan_sp->AppendRow(row);
   }
   return plan_sp;
 }
@@ -702,8 +700,7 @@ SymbolFileBreakpad::ParseWinUnwindPlan(const Bookmark &bookmark,
       AddressRange(base + record->RVA, record->CodeSize,
                    m_objfile_sp->GetModule()->GetSectionList()));
 
-  auto row_sp = std::make_shared<UnwindPlan::Row>();
-  row_sp->SetOffset(0);
+  UnwindPlan::Row row;
 
   llvm::BumpPtrAllocator node_alloc;
   std::vector<std::pair<llvm::StringRef, postfix::Node *>> program =
@@ -732,8 +729,8 @@ SymbolFileBreakpad::ParseWinUnwindPlan(const Bookmark &bookmark,
   // clang will use T1, if it needs to realign the stack.
   auto *symbol = llvm::dyn_cast<postfix::SymbolNode>(it->second);
   if (symbol && symbol->GetName() == ".raSearch") {
-    row_sp->GetCFAValue().SetRaSearch(record->LocalSize +
-                                      record->SavedRegisterSize);
+    row.GetCFAValue().SetRaSearch(record->LocalSize +
+                                  record->SavedRegisterSize);
   } else {
     if (!postfix::ResolveSymbols(it->second, symbol_resolver)) {
       LLDB_LOG(log, "Resolving symbols in `{0}` failed.",
@@ -741,7 +738,7 @@ SymbolFileBreakpad::ParseWinUnwindPlan(const Bookmark &bookmark,
       return nullptr;
     }
     llvm::ArrayRef<uint8_t> saved  = SaveAsDWARF(*it->second);
-    row_sp->GetCFAValue().SetIsDWARFExpression(saved.data(), saved.size());
+    row.GetCFAValue().SetIsDWARFExpression(saved.data(), saved.size());
   }
 
   // Replace the node value with InitialValueNode, so that subsequent
@@ -766,10 +763,10 @@ SymbolFileBreakpad::ParseWinUnwindPlan(const Bookmark &bookmark,
     llvm::ArrayRef<uint8_t> saved = SaveAsDWARF(*it->second);
     UnwindPlan::Row::AbstractRegisterLocation loc;
     loc.SetIsDWARFExpression(saved.data(), saved.size());
-    row_sp->SetRegisterInfo(info->kinds[eRegisterKindLLDB], loc);
+    row.SetRegisterInfo(info->kinds[eRegisterKindLLDB], loc);
   }
 
-  plan_sp->AppendRow(row_sp);
+  plan_sp->AppendRow(std::move(row));
   return plan_sp;
 }
 

--- a/lldb/source/Plugins/UnwindAssembly/InstEmulation/UnwindAssemblyInstEmulation.cpp
+++ b/lldb/source/Plugins/UnwindAssembly/InstEmulation/UnwindAssemblyInstEmulation.cpp
@@ -209,9 +209,8 @@ bool UnwindAssemblyInstEmulation::GetNonCallSiteUnwindPlanFromAssembly(
       }
     }
     for (auto &[_, state] : saved_unwind_states) {
-      unwind_plan.InsertRow(
-          std::make_shared<UnwindPlan::Row>(std::move(state.row)),
-          /*replace_existing=*/true);
+      unwind_plan.InsertRow(std::move(state.row),
+                            /*replace_existing=*/true);
     }
   }
 

--- a/lldb/source/Plugins/UnwindAssembly/x86/x86AssemblyInspectionEngine.cpp
+++ b/lldb/source/Plugins/UnwindAssembly/x86/x86AssemblyInspectionEngine.cpp
@@ -916,31 +916,26 @@ bool x86AssemblyInspectionEngine::GetNonCallSiteUnwindPlanFromAssembly(
   int current_sp_bytes_offset_from_fa = 0;
   bool is_aligned = false;
   UnwindPlan::Row::AbstractRegisterLocation initial_regloc;
-  UnwindPlan::RowSP row(new UnwindPlan::Row);
+  UnwindPlan::Row row;
 
   unwind_plan.SetPlanValidAddressRange(func_range);
   unwind_plan.SetRegisterKind(eRegisterKindLLDB);
 
   // At the start of the function, find the CFA by adding wordsize to the SP
   // register
-  row->SetOffset(current_func_text_offset);
-  row->GetCFAValue().SetIsRegisterPlusOffset(m_lldb_sp_regnum, m_wordsize);
+  row.SetOffset(current_func_text_offset);
+  row.GetCFAValue().SetIsRegisterPlusOffset(m_lldb_sp_regnum, m_wordsize);
 
   // caller's stack pointer value before the call insn is the CFA address
   initial_regloc.SetIsCFAPlusOffset(0);
-  row->SetRegisterInfo(m_lldb_sp_regnum, initial_regloc);
+  row.SetRegisterInfo(m_lldb_sp_regnum, initial_regloc);
 
   // saved instruction pointer can be found at CFA - wordsize.
   current_sp_bytes_offset_from_fa = m_wordsize;
   initial_regloc.SetAtCFAPlusOffset(-current_sp_bytes_offset_from_fa);
-  row->SetRegisterInfo(m_lldb_ip_regnum, initial_regloc);
+  row.SetRegisterInfo(m_lldb_ip_regnum, initial_regloc);
 
   unwind_plan.AppendRow(row);
-
-  // Allocate a new Row, populate it with the existing Row contents.
-  UnwindPlan::Row *newrow = new UnwindPlan::Row;
-  *newrow = *row.get();
-  row.reset(newrow);
 
   // Track which registers have been saved so far in the prologue. If we see
   // another push of that register, it's not part of the prologue. The register
@@ -953,7 +948,8 @@ bool x86AssemblyInspectionEngine::GetNonCallSiteUnwindPlanFromAssembly(
   // that epilogue we'll reinstate the unwind setup -- we assume that some code
   // path jumps over the mid-function epilogue
 
-  UnwindPlan::RowSP prologue_completed_row; // copy of prologue row of CFI
+  std::optional<UnwindPlan::Row>
+      prologue_completed_row; // copy of prologue row of CFI
   int prologue_completed_sp_bytes_offset_from_cfa = 0; // The sp value before the
                                                    // epilogue started executed
   bool prologue_completed_is_aligned = false;
@@ -978,8 +974,8 @@ bool x86AssemblyInspectionEngine::GetNonCallSiteUnwindPlanFromAssembly(
       break;
     }
 
-    auto &cfa_value = row->GetCFAValue();
-    auto &afa_value = row->GetAFAValue();
+    auto &cfa_value = row.GetCFAValue();
+    auto &afa_value = row.GetAFAValue();
     auto fa_value_ptr = is_aligned ? &afa_value : &cfa_value;
 
     if (mov_rsp_rbp_pattern_p()) {
@@ -1063,7 +1059,7 @@ bool x86AssemblyInspectionEngine::GetNonCallSiteUnwindPlanFromAssembly(
             regloc.SetAtAFAPlusOffset(-current_sp_bytes_offset_from_fa);
         else
             regloc.SetAtCFAPlusOffset(-current_sp_bytes_offset_from_fa);
-        row->SetRegisterInfo(lldb_regno, regloc);
+        row.SetRegisterInfo(lldb_regno, regloc);
         saved_registers[machine_regno] = true;
         row_updated = true;
       }
@@ -1077,7 +1073,7 @@ bool x86AssemblyInspectionEngine::GetNonCallSiteUnwindPlanFromAssembly(
           machine_regno_to_lldb_regno(machine_regno, lldb_regno) &&
           saved_registers[machine_regno]) {
         saved_registers[machine_regno] = false;
-        row->RemoveRegisterInfo(lldb_regno);
+        row.RemoveRegisterInfo(lldb_regno);
 
         if (lldb_regno == fa_value_ptr->GetRegisterNumber()) {
           fa_value_ptr->SetIsRegisterPlusOffset(
@@ -1113,7 +1109,7 @@ bool x86AssemblyInspectionEngine::GetNonCallSiteUnwindPlanFromAssembly(
     else if (leave_pattern_p()) {
       if (saved_registers[m_machine_fp_regnum]) {
         saved_registers[m_machine_fp_regnum] = false;
-        row->RemoveRegisterInfo(m_lldb_fp_regnum);
+        row.RemoveRegisterInfo(m_lldb_fp_regnum);
 
         row_updated = true;
       }
@@ -1164,7 +1160,7 @@ bool x86AssemblyInspectionEngine::GetNonCallSiteUnwindPlanFromAssembly(
       else
           regloc.SetAtCFAPlusOffset(-(stack_offset + fa_value_ptr->GetOffset()));
 
-      row->SetRegisterInfo(lldb_regno, regloc);
+      row.SetRegisterInfo(lldb_regno, regloc);
 
       row_updated = true;
     }
@@ -1238,9 +1234,10 @@ bool x86AssemblyInspectionEngine::GetNonCallSiteUnwindPlanFromAssembly(
       }
     }
 
-    else if (prologue_completed_row.get() && 
+    else if (prologue_completed_row &&
              (ret_pattern_p() ||
-              non_local_branch_p (current_func_text_offset, func_range, insn_len) ||
+              non_local_branch_p(current_func_text_offset, func_range,
+                                 insn_len) ||
               jmp_to_reg_p())) {
       // Check if the current instruction is the end of an epilogue sequence,
       // and if so, re-instate the prologue-completed unwind state.
@@ -1251,8 +1248,8 @@ bool x86AssemblyInspectionEngine::GetNonCallSiteUnwindPlanFromAssembly(
       // has been unwound to the same as it was at function entry to avoid 
       // mis-identifying a JMP instruction as an epilogue.
       UnwindPlan::Row::AbstractRegisterLocation sp, pc;
-      if (row->GetRegisterInfo(m_lldb_sp_regnum, sp) &&
-          row->GetRegisterInfo(m_lldb_ip_regnum, pc)) {
+      if (row.GetRegisterInfo(m_lldb_sp_regnum, sp) &&
+          row.GetRegisterInfo(m_lldb_ip_regnum, pc)) {
         // Any ret instruction variant is definitely indicative of an
         // epilogue; for other insn patterns verify that we're back to
         // the original unwind state.
@@ -1262,20 +1259,13 @@ bool x86AssemblyInspectionEngine::GetNonCallSiteUnwindPlanFromAssembly(
           // Reinstate the saved prologue setup for any instructions that come
           // after the epilogue
 
-          UnwindPlan::Row *newrow = new UnwindPlan::Row;
-          *newrow = *prologue_completed_row.get();
-          row.reset(newrow);
+          row = *prologue_completed_row;
           current_sp_bytes_offset_from_fa =
               prologue_completed_sp_bytes_offset_from_cfa;
           current_sp_offset_updated = true;
           is_aligned = prologue_completed_is_aligned;
 
-          saved_registers.clear();
-          saved_registers.resize(prologue_completed_saved_registers.size(), false);
-          for (size_t i = 0; i < prologue_completed_saved_registers.size(); ++i) {
-            saved_registers[i] = prologue_completed_saved_registers[i];
-          }
-
+          saved_registers = prologue_completed_saved_registers;
           in_epilogue = true;
           row_updated = true;
         }
@@ -1298,26 +1288,15 @@ bool x86AssemblyInspectionEngine::GetNonCallSiteUnwindPlanFromAssembly(
 
     if (row_updated) {
       if (current_func_text_offset + insn_len < size) {
-        row->SetOffset(current_func_text_offset + insn_len);
+        row.SetOffset(current_func_text_offset + insn_len);
         unwind_plan.AppendRow(row);
-        // Allocate a new Row, populate it with the existing Row contents.
-        newrow = new UnwindPlan::Row;
-        *newrow = *row.get();
-        row.reset(newrow);
       }
     }
 
     if (!in_epilogue && row_updated) {
       // If we're not in an epilogue sequence, save the updated Row
-      UnwindPlan::Row *newrow = new UnwindPlan::Row;
-      *newrow = *row.get();
-      prologue_completed_row.reset(newrow);
-
-      prologue_completed_saved_registers.clear();
-      prologue_completed_saved_registers.resize(saved_registers.size(), false);
-      for (size_t i = 0; i < saved_registers.size(); ++i) {
-        prologue_completed_saved_registers[i] = saved_registers[i];
-      }
+      prologue_completed_row = row;
+      prologue_completed_saved_registers = saved_registers;
     }
 
     // We may change the sp value without adding a new Row necessarily -- keep
@@ -1377,7 +1356,7 @@ bool x86AssemblyInspectionEngine::AugmentUnwindPlanFromCallSite(
   size_t offset = 0;
   int row_id = 1;
   bool unwind_plan_updated = false;
-  UnwindPlan::RowSP row(new UnwindPlan::Row(*first_row));
+  UnwindPlan::Row row = *first_row;
 
   // After a mid-function epilogue we will need to re-insert the original
   // unwind rules so unwinds work for the remainder of the function.  These
@@ -1401,12 +1380,9 @@ bool x86AssemblyInspectionEngine::AugmentUnwindPlanFromCallSite(
       continue;
 
     if (reinstate_unwind_state) {
-      UnwindPlan::RowSP new_row(new UnwindPlan::Row());
-      *new_row = *original_last_row;
-      new_row->SetOffset(offset);
-      unwind_plan.AppendRow(new_row);
-      row = std::make_shared<UnwindPlan::Row>();
-      *row = *new_row;
+      row = *original_last_row;
+      row.SetOffset(offset);
+      unwind_plan.AppendRow(row);
       reinstate_unwind_state = false;
       unwind_plan_updated = true;
       continue;
@@ -1419,7 +1395,7 @@ bool x86AssemblyInspectionEngine::AugmentUnwindPlanFromCallSite(
     }
     const UnwindPlan::Row *original_row = unwind_plan.GetRowAtIndex(row_id - 1);
     if (original_row->GetOffset() == offset) {
-      *row = *original_row;
+      row = *original_row;
       continue;
     }
 
@@ -1430,11 +1406,10 @@ bool x86AssemblyInspectionEngine::AugmentUnwindPlanFromCallSite(
     }
 
     // Inspect the instruction to check if we need a new row for it.
-    cfa_reg = row->GetCFAValue().GetRegisterNumber();
+    cfa_reg = row.GetCFAValue().GetRegisterNumber();
     if (unwind_plan.GetRegisterKind() != eRegisterKindLLDB) {
       cfa_reg = reg_ctx->ConvertRegisterKindToRegisterNumber(
-          unwind_plan.GetRegisterKind(),
-          row->GetCFAValue().GetRegisterNumber());
+          unwind_plan.GetRegisterKind(), row.GetCFAValue().GetRegisterNumber());
     }
     if (cfa_reg == m_lldb_sp_regnum) {
       // CFA register is sp.
@@ -1443,11 +1418,10 @@ bool x86AssemblyInspectionEngine::AugmentUnwindPlanFromCallSite(
       //     call 0
       //  => pop  %ebx
       if (call_next_insn_pattern_p()) {
-        row->SetOffset(offset);
-        row->GetCFAValue().IncOffset(m_wordsize);
+        row.SetOffset(offset);
+        row.GetCFAValue().IncOffset(m_wordsize);
 
-        UnwindPlan::RowSP new_row(new UnwindPlan::Row(*row));
-        unwind_plan.InsertRow(new_row);
+        unwind_plan.InsertRow(row);
         unwind_plan_updated = true;
         continue;
       }
@@ -1455,11 +1429,10 @@ bool x86AssemblyInspectionEngine::AugmentUnwindPlanFromCallSite(
       // push/pop register
       int regno;
       if (push_reg_p(regno)) {
-        row->SetOffset(offset);
-        row->GetCFAValue().IncOffset(m_wordsize);
+        row.SetOffset(offset);
+        row.GetCFAValue().IncOffset(m_wordsize);
 
-        UnwindPlan::RowSP new_row(new UnwindPlan::Row(*row));
-        unwind_plan.InsertRow(new_row);
+        unwind_plan.InsertRow(row);
         unwind_plan_updated = true;
         continue;
       }
@@ -1469,41 +1442,37 @@ bool x86AssemblyInspectionEngine::AugmentUnwindPlanFromCallSite(
         // practice, previous rule for the register is still valid... So we
         // ignore this case.
 
-        row->SetOffset(offset);
-        row->GetCFAValue().IncOffset(-m_wordsize);
+        row.SetOffset(offset);
+        row.GetCFAValue().IncOffset(-m_wordsize);
 
-        UnwindPlan::RowSP new_row(new UnwindPlan::Row(*row));
-        unwind_plan.InsertRow(new_row);
+        unwind_plan.InsertRow(row);
         unwind_plan_updated = true;
         continue;
       }
 
       if (pop_misc_reg_p()) {
-        row->SetOffset(offset);
-        row->GetCFAValue().IncOffset(-m_wordsize);
+        row.SetOffset(offset);
+        row.GetCFAValue().IncOffset(-m_wordsize);
 
-        UnwindPlan::RowSP new_row(new UnwindPlan::Row(*row));
-        unwind_plan.InsertRow(new_row);
+        unwind_plan.InsertRow(row);
         unwind_plan_updated = true;
         continue;
       }
 
       // push imm
       if (push_imm_pattern_p()) {
-        row->SetOffset(offset);
-        row->GetCFAValue().IncOffset(m_wordsize);
-        UnwindPlan::RowSP new_row(new UnwindPlan::Row(*row));
-        unwind_plan.InsertRow(new_row);
+        row.SetOffset(offset);
+        row.GetCFAValue().IncOffset(m_wordsize);
+        unwind_plan.InsertRow(row);
         unwind_plan_updated = true;
         continue;
       }
 
       // push extended
       if (push_extended_pattern_p() || push_misc_reg_p()) {
-        row->SetOffset(offset);
-        row->GetCFAValue().IncOffset(m_wordsize);
-        UnwindPlan::RowSP new_row(new UnwindPlan::Row(*row));
-        unwind_plan.InsertRow(new_row);
+        row.SetOffset(offset);
+        row.GetCFAValue().IncOffset(m_wordsize);
+        unwind_plan.InsertRow(row);
         unwind_plan_updated = true;
         continue;
       }
@@ -1511,31 +1480,28 @@ bool x86AssemblyInspectionEngine::AugmentUnwindPlanFromCallSite(
       // add/sub %rsp/%esp
       int amount;
       if (add_rsp_pattern_p(amount)) {
-        row->SetOffset(offset);
-        row->GetCFAValue().IncOffset(-amount);
+        row.SetOffset(offset);
+        row.GetCFAValue().IncOffset(-amount);
 
-        UnwindPlan::RowSP new_row(new UnwindPlan::Row(*row));
-        unwind_plan.InsertRow(new_row);
+        unwind_plan.InsertRow(row);
         unwind_plan_updated = true;
         continue;
       }
       if (sub_rsp_pattern_p(amount)) {
-        row->SetOffset(offset);
-        row->GetCFAValue().IncOffset(amount);
+        row.SetOffset(offset);
+        row.GetCFAValue().IncOffset(amount);
 
-        UnwindPlan::RowSP new_row(new UnwindPlan::Row(*row));
-        unwind_plan.InsertRow(new_row);
+        unwind_plan.InsertRow(row);
         unwind_plan_updated = true;
         continue;
       }
 
       // lea %rsp, [%rsp + $offset]
       if (lea_rsp_pattern_p(amount)) {
-        row->SetOffset(offset);
-        row->GetCFAValue().IncOffset(-amount);
+        row.SetOffset(offset);
+        row.GetCFAValue().IncOffset(-amount);
 
-        UnwindPlan::RowSP new_row(new UnwindPlan::Row(*row));
-        unwind_plan.InsertRow(new_row);
+        unwind_plan.InsertRow(row);
         unwind_plan_updated = true;
         continue;
       }
@@ -1553,12 +1519,11 @@ bool x86AssemblyInspectionEngine::AugmentUnwindPlanFromCallSite(
       if (pop_rbp_pattern_p() || leave_pattern_p()) {
         m_cur_insn++;
         if (ret_pattern_p()) {
-          row->SetOffset(offset);
-          row->GetCFAValue().SetIsRegisterPlusOffset(
+          row.SetOffset(offset);
+          row.GetCFAValue().SetIsRegisterPlusOffset(
               first_row->GetCFAValue().GetRegisterNumber(), m_wordsize);
 
-          UnwindPlan::RowSP new_row(new UnwindPlan::Row(*row));
-          unwind_plan.InsertRow(new_row);
+          unwind_plan.InsertRow(row);
           unwind_plan_updated = true;
           reinstate_unwind_state = true;
           continue;

--- a/lldb/source/Symbol/ArmUnwindInfo.cpp
+++ b/lldb/source/Symbol/ArmUnwindInfo.cpp
@@ -321,23 +321,22 @@ bool ArmUnwindInfo::GetUnwindPlan(Target &target, const Address &addr,
     }
   }
 
-  UnwindPlan::RowSP row = std::make_shared<UnwindPlan::Row>();
-  row->SetOffset(0);
-  row->GetCFAValue().SetIsRegisterPlusOffset(vsp_reg, vsp);
+  UnwindPlan::Row row;
+  row.GetCFAValue().SetIsRegisterPlusOffset(vsp_reg, vsp);
 
   bool have_location_for_pc = false;
   for (const auto &offset : register_offsets) {
     have_location_for_pc |= offset.first == dwarf_pc;
-    row->SetRegisterLocationToAtCFAPlusOffset(offset.first, offset.second - vsp,
-                                              true);
+    row.SetRegisterLocationToAtCFAPlusOffset(offset.first, offset.second - vsp,
+                                             true);
   }
 
   if (!have_location_for_pc) {
     UnwindPlan::Row::AbstractRegisterLocation lr_location;
-    if (row->GetRegisterInfo(dwarf_lr, lr_location))
-      row->SetRegisterInfo(dwarf_pc, lr_location);
+    if (row.GetRegisterInfo(dwarf_lr, lr_location))
+      row.SetRegisterInfo(dwarf_pc, lr_location);
     else
-      row->SetRegisterLocationToRegister(dwarf_pc, dwarf_lr, false);
+      row.SetRegisterLocationToRegister(dwarf_pc, dwarf_lr, false);
   }
 
   unwind_plan.AppendRow(row);

--- a/lldb/source/Symbol/CompactUnwindInfo.cpp
+++ b/lldb/source/Symbol/CompactUnwindInfo.cpp
@@ -744,21 +744,20 @@ bool CompactUnwindInfo::CreateUnwindPlan_x86_64(Target &target,
   unwind_plan.SetLSDAAddress(function_info.lsda_address);
   unwind_plan.SetPersonalityFunctionPtr(function_info.personality_ptr_address);
 
-  UnwindPlan::RowSP row(new UnwindPlan::Row);
+  UnwindPlan::Row row;
 
   const int wordsize = 8;
   int mode = function_info.encoding & UNWIND_X86_64_MODE_MASK;
   switch (mode) {
   case UNWIND_X86_64_MODE_RBP_FRAME: {
-    row->GetCFAValue().SetIsRegisterPlusOffset(
+    row.GetCFAValue().SetIsRegisterPlusOffset(
         translate_to_eh_frame_regnum_x86_64(UNWIND_X86_64_REG_RBP),
         2 * wordsize);
-    row->SetOffset(0);
-    row->SetRegisterLocationToAtCFAPlusOffset(x86_64_eh_regnum::rbp,
-                                              wordsize * -2, true);
-    row->SetRegisterLocationToAtCFAPlusOffset(x86_64_eh_regnum::rip,
-                                              wordsize * -1, true);
-    row->SetRegisterLocationToIsCFAPlusOffset(x86_64_eh_regnum::rsp, 0, true);
+    row.SetRegisterLocationToAtCFAPlusOffset(x86_64_eh_regnum::rbp,
+                                             wordsize * -2, true);
+    row.SetRegisterLocationToAtCFAPlusOffset(x86_64_eh_regnum::rip,
+                                             wordsize * -1, true);
+    row.SetRegisterLocationToIsCFAPlusOffset(x86_64_eh_regnum::rsp, 0, true);
 
     uint32_t saved_registers_offset =
         EXTRACT_BITS(function_info.encoding, UNWIND_X86_64_RBP_FRAME_OFFSET);
@@ -778,7 +777,7 @@ bool CompactUnwindInfo::CreateUnwindPlan_x86_64(Target &target,
       case UNWIND_X86_64_REG_R13:
       case UNWIND_X86_64_REG_R14:
       case UNWIND_X86_64_REG_R15:
-        row->SetRegisterLocationToAtCFAPlusOffset(
+        row.SetRegisterLocationToAtCFAPlusOffset(
             translate_to_eh_frame_regnum_x86_64(regnum),
             wordsize * -saved_registers_offset, true);
         break;
@@ -786,7 +785,7 @@ bool CompactUnwindInfo::CreateUnwindPlan_x86_64(Target &target,
       saved_registers_offset--;
       saved_registers_locations >>= 3;
     }
-    unwind_plan.AppendRow(row);
+    unwind_plan.AppendRow(std::move(row));
     return true;
   } break;
 
@@ -841,12 +840,11 @@ bool CompactUnwindInfo::CreateUnwindPlan_x86_64(Target &target,
     int32_t offset = mode == UNWIND_X86_64_MODE_STACK_IND
                          ? stack_size
                          : stack_size * wordsize;
-    row->GetCFAValue().SetIsRegisterPlusOffset(x86_64_eh_regnum::rsp, offset);
+    row.GetCFAValue().SetIsRegisterPlusOffset(x86_64_eh_regnum::rsp, offset);
 
-    row->SetOffset(0);
-    row->SetRegisterLocationToAtCFAPlusOffset(x86_64_eh_regnum::rip,
-                                              wordsize * -1, true);
-    row->SetRegisterLocationToIsCFAPlusOffset(x86_64_eh_regnum::rsp, 0, true);
+    row.SetRegisterLocationToAtCFAPlusOffset(x86_64_eh_regnum::rip,
+                                             wordsize * -1, true);
+    row.SetRegisterLocationToIsCFAPlusOffset(x86_64_eh_regnum::rsp, 0, true);
 
     if (register_count > 0) {
 
@@ -946,7 +944,7 @@ bool CompactUnwindInfo::CreateUnwindPlan_x86_64(Target &target,
         case UNWIND_X86_64_REG_R14:
         case UNWIND_X86_64_REG_R15:
         case UNWIND_X86_64_REG_RBP:
-          row->SetRegisterLocationToAtCFAPlusOffset(
+          row.SetRegisterLocationToAtCFAPlusOffset(
               translate_to_eh_frame_regnum_x86_64(registers[i]),
               wordsize * -saved_registers_offset, true);
           saved_registers_offset++;
@@ -954,7 +952,7 @@ bool CompactUnwindInfo::CreateUnwindPlan_x86_64(Target &target,
         }
       }
     }
-    unwind_plan.AppendRow(row);
+    unwind_plan.AppendRow(std::move(row));
     return true;
   } break;
 
@@ -1016,20 +1014,19 @@ bool CompactUnwindInfo::CreateUnwindPlan_i386(Target &target,
   unwind_plan.SetLSDAAddress(function_info.lsda_address);
   unwind_plan.SetPersonalityFunctionPtr(function_info.personality_ptr_address);
 
-  UnwindPlan::RowSP row(new UnwindPlan::Row);
+  UnwindPlan::Row row;
 
   const int wordsize = 4;
   int mode = function_info.encoding & UNWIND_X86_MODE_MASK;
   switch (mode) {
   case UNWIND_X86_MODE_EBP_FRAME: {
-    row->GetCFAValue().SetIsRegisterPlusOffset(
+    row.GetCFAValue().SetIsRegisterPlusOffset(
         translate_to_eh_frame_regnum_i386(UNWIND_X86_REG_EBP), 2 * wordsize);
-    row->SetOffset(0);
-    row->SetRegisterLocationToAtCFAPlusOffset(i386_eh_regnum::ebp,
-                                              wordsize * -2, true);
-    row->SetRegisterLocationToAtCFAPlusOffset(i386_eh_regnum::eip,
-                                              wordsize * -1, true);
-    row->SetRegisterLocationToIsCFAPlusOffset(i386_eh_regnum::esp, 0, true);
+    row.SetRegisterLocationToAtCFAPlusOffset(i386_eh_regnum::ebp, wordsize * -2,
+                                             true);
+    row.SetRegisterLocationToAtCFAPlusOffset(i386_eh_regnum::eip, wordsize * -1,
+                                             true);
+    row.SetRegisterLocationToIsCFAPlusOffset(i386_eh_regnum::esp, 0, true);
 
     uint32_t saved_registers_offset =
         EXTRACT_BITS(function_info.encoding, UNWIND_X86_EBP_FRAME_OFFSET);
@@ -1049,7 +1046,7 @@ bool CompactUnwindInfo::CreateUnwindPlan_i386(Target &target,
       case UNWIND_X86_REG_EDX:
       case UNWIND_X86_REG_EDI:
       case UNWIND_X86_REG_ESI:
-        row->SetRegisterLocationToAtCFAPlusOffset(
+        row.SetRegisterLocationToAtCFAPlusOffset(
             translate_to_eh_frame_regnum_i386(regnum),
             wordsize * -saved_registers_offset, true);
         break;
@@ -1057,7 +1054,7 @@ bool CompactUnwindInfo::CreateUnwindPlan_i386(Target &target,
       saved_registers_offset--;
       saved_registers_locations >>= 3;
     }
-    unwind_plan.AppendRow(row);
+    unwind_plan.AppendRow(std::move(row));
     return true;
   } break;
 
@@ -1105,11 +1102,10 @@ bool CompactUnwindInfo::CreateUnwindPlan_i386(Target &target,
 
     int32_t offset =
         mode == UNWIND_X86_MODE_STACK_IND ? stack_size : stack_size * wordsize;
-    row->GetCFAValue().SetIsRegisterPlusOffset(i386_eh_regnum::esp, offset);
-    row->SetOffset(0);
-    row->SetRegisterLocationToAtCFAPlusOffset(i386_eh_regnum::eip,
-                                              wordsize * -1, true);
-    row->SetRegisterLocationToIsCFAPlusOffset(i386_eh_regnum::esp, 0, true);
+    row.GetCFAValue().SetIsRegisterPlusOffset(i386_eh_regnum::esp, offset);
+    row.SetRegisterLocationToAtCFAPlusOffset(i386_eh_regnum::eip, wordsize * -1,
+                                             true);
+    row.SetRegisterLocationToIsCFAPlusOffset(i386_eh_regnum::esp, 0, true);
 
     if (register_count > 0) {
 
@@ -1209,7 +1205,7 @@ bool CompactUnwindInfo::CreateUnwindPlan_i386(Target &target,
         case UNWIND_X86_REG_EDI:
         case UNWIND_X86_REG_ESI:
         case UNWIND_X86_REG_EBP:
-          row->SetRegisterLocationToAtCFAPlusOffset(
+          row.SetRegisterLocationToAtCFAPlusOffset(
               translate_to_eh_frame_regnum_i386(registers[i]),
               wordsize * -saved_registers_offset, true);
           saved_registers_offset++;
@@ -1218,7 +1214,7 @@ bool CompactUnwindInfo::CreateUnwindPlan_i386(Target &target,
       }
     }
 
-    unwind_plan.AppendRow(row);
+    unwind_plan.AppendRow(std::move(row));
     return true;
   } break;
 
@@ -1313,7 +1309,7 @@ bool CompactUnwindInfo::CreateUnwindPlan_arm64(Target &target,
   unwind_plan.SetLSDAAddress(function_info.lsda_address);
   unwind_plan.SetPersonalityFunctionPtr(function_info.personality_ptr_address);
 
-  UnwindPlan::RowSP row(new UnwindPlan::Row);
+  UnwindPlan::Row row;
 
   const int wordsize = 8;
   int mode = function_info.encoding & UNWIND_ARM64_MODE_MASK;
@@ -1322,21 +1318,19 @@ bool CompactUnwindInfo::CreateUnwindPlan_arm64(Target &target,
     return false;
 
   if (mode == UNWIND_ARM64_MODE_FRAMELESS) {
-    row->SetOffset(0);
-
     uint32_t stack_size =
         (EXTRACT_BITS(function_info.encoding,
                       UNWIND_ARM64_FRAMELESS_STACK_SIZE_MASK)) *
         16;
 
     // Our previous Call Frame Address is the stack pointer plus the stack size
-    row->GetCFAValue().SetIsRegisterPlusOffset(arm64_eh_regnum::sp, stack_size);
+    row.GetCFAValue().SetIsRegisterPlusOffset(arm64_eh_regnum::sp, stack_size);
 
     // Our previous PC is in the LR
-    row->SetRegisterLocationToRegister(arm64_eh_regnum::pc, arm64_eh_regnum::ra,
-                                       true);
+    row.SetRegisterLocationToRegister(arm64_eh_regnum::pc, arm64_eh_regnum::ra,
+                                      true);
 
-    unwind_plan.AppendRow(row);
+    unwind_plan.AppendRow(std::move(row));
     return true;
   }
 
@@ -1346,13 +1340,12 @@ bool CompactUnwindInfo::CreateUnwindPlan_arm64(Target &target,
 
   // mode == UNWIND_ARM64_MODE_FRAME
 
-  row->GetCFAValue().SetIsRegisterPlusOffset(arm64_eh_regnum::fp, 2 * wordsize);
-  row->SetOffset(0);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::fp, wordsize * -2,
-                                            true);
-  row->SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::pc, wordsize * -1,
-                                            true);
-  row->SetRegisterLocationToIsCFAPlusOffset(arm64_eh_regnum::sp, 0, true);
+  row.GetCFAValue().SetIsRegisterPlusOffset(arm64_eh_regnum::fp, 2 * wordsize);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::fp, wordsize * -2,
+                                           true);
+  row.SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::pc, wordsize * -1,
+                                           true);
+  row.SetRegisterLocationToIsCFAPlusOffset(arm64_eh_regnum::sp, 0, true);
 
   int reg_pairs_saved_count = 1;
 
@@ -1361,55 +1354,55 @@ bool CompactUnwindInfo::CreateUnwindPlan_arm64(Target &target,
   if (saved_register_bits & UNWIND_ARM64_FRAME_X19_X20_PAIR) {
     int cfa_offset = reg_pairs_saved_count * -2 * wordsize;
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x19, cfa_offset,
-                                              true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x19, cfa_offset,
+                                             true);
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x20, cfa_offset,
-                                              true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x20, cfa_offset,
+                                             true);
     reg_pairs_saved_count++;
   }
 
   if (saved_register_bits & UNWIND_ARM64_FRAME_X21_X22_PAIR) {
     int cfa_offset = reg_pairs_saved_count * -2 * wordsize;
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x21, cfa_offset,
-                                              true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x21, cfa_offset,
+                                             true);
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x22, cfa_offset,
-                                              true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x22, cfa_offset,
+                                             true);
     reg_pairs_saved_count++;
   }
 
   if (saved_register_bits & UNWIND_ARM64_FRAME_X23_X24_PAIR) {
     int cfa_offset = reg_pairs_saved_count * -2 * wordsize;
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x23, cfa_offset,
-                                              true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x23, cfa_offset,
+                                             true);
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x24, cfa_offset,
-                                              true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x24, cfa_offset,
+                                             true);
     reg_pairs_saved_count++;
   }
 
   if (saved_register_bits & UNWIND_ARM64_FRAME_X25_X26_PAIR) {
     int cfa_offset = reg_pairs_saved_count * -2 * wordsize;
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x25, cfa_offset,
-                                              true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x25, cfa_offset,
+                                             true);
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x26, cfa_offset,
-                                              true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x26, cfa_offset,
+                                             true);
     reg_pairs_saved_count++;
   }
 
   if (saved_register_bits & UNWIND_ARM64_FRAME_X27_X28_PAIR) {
     int cfa_offset = reg_pairs_saved_count * -2 * wordsize;
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x27, cfa_offset,
-                                              true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x27, cfa_offset,
+                                             true);
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x28, cfa_offset,
-                                              true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm64_eh_regnum::x28, cfa_offset,
+                                             true);
     reg_pairs_saved_count++;
   }
 
@@ -1430,7 +1423,7 @@ bool CompactUnwindInfo::CreateUnwindPlan_arm64(Target &target,
     reg_pairs_saved_count++;
   }
 
-  unwind_plan.AppendRow(row);
+  unwind_plan.AppendRow(std::move(row));
   return true;
 }
 
@@ -1447,7 +1440,7 @@ bool CompactUnwindInfo::CreateUnwindPlan_armv7(Target &target,
   unwind_plan.SetLSDAAddress(function_info.lsda_address);
   unwind_plan.SetPersonalityFunctionPtr(function_info.personality_ptr_address);
 
-  UnwindPlan::RowSP row(new UnwindPlan::Row);
+  UnwindPlan::Row row;
 
   const int wordsize = 4;
   int mode = function_info.encoding & UNWIND_ARM_MODE_MASK;
@@ -1459,14 +1452,13 @@ bool CompactUnwindInfo::CreateUnwindPlan_armv7(Target &target,
                                         UNWIND_ARM_FRAME_STACK_ADJUST_MASK)) *
                           wordsize;
 
-  row->GetCFAValue().SetIsRegisterPlusOffset(arm_r7,
-                                             (2 * wordsize) + stack_adjust);
-  row->SetOffset(0);
-  row->SetRegisterLocationToAtCFAPlusOffset(
+  row.GetCFAValue().SetIsRegisterPlusOffset(arm_r7,
+                                            (2 * wordsize) + stack_adjust);
+  row.SetRegisterLocationToAtCFAPlusOffset(
       arm_r7, (wordsize * -2) - stack_adjust, true);
-  row->SetRegisterLocationToAtCFAPlusOffset(
+  row.SetRegisterLocationToAtCFAPlusOffset(
       arm_pc, (wordsize * -1) - stack_adjust, true);
-  row->SetRegisterLocationToIsCFAPlusOffset(arm_sp, 0, true);
+  row.SetRegisterLocationToIsCFAPlusOffset(arm_sp, 0, true);
 
   int cfa_offset = -stack_adjust - (2 * wordsize);
 
@@ -1474,42 +1466,42 @@ bool CompactUnwindInfo::CreateUnwindPlan_armv7(Target &target,
 
   if (saved_register_bits & UNWIND_ARM_FRAME_FIRST_PUSH_R6) {
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm_r6, cfa_offset, true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm_r6, cfa_offset, true);
   }
 
   if (saved_register_bits & UNWIND_ARM_FRAME_FIRST_PUSH_R5) {
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm_r5, cfa_offset, true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm_r5, cfa_offset, true);
   }
 
   if (saved_register_bits & UNWIND_ARM_FRAME_FIRST_PUSH_R4) {
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm_r4, cfa_offset, true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm_r4, cfa_offset, true);
   }
 
   if (saved_register_bits & UNWIND_ARM_FRAME_SECOND_PUSH_R12) {
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm_r12, cfa_offset, true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm_r12, cfa_offset, true);
   }
 
   if (saved_register_bits & UNWIND_ARM_FRAME_SECOND_PUSH_R11) {
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm_r11, cfa_offset, true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm_r11, cfa_offset, true);
   }
 
   if (saved_register_bits & UNWIND_ARM_FRAME_SECOND_PUSH_R10) {
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm_r10, cfa_offset, true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm_r10, cfa_offset, true);
   }
 
   if (saved_register_bits & UNWIND_ARM_FRAME_SECOND_PUSH_R9) {
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm_r9, cfa_offset, true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm_r9, cfa_offset, true);
   }
 
   if (saved_register_bits & UNWIND_ARM_FRAME_SECOND_PUSH_R8) {
     cfa_offset -= wordsize;
-    row->SetRegisterLocationToAtCFAPlusOffset(arm_r8, cfa_offset, true);
+    row.SetRegisterLocationToAtCFAPlusOffset(arm_r8, cfa_offset, true);
   }
 
   if (mode == UNWIND_ARM_MODE_FRAME_D) {
@@ -1519,26 +1511,26 @@ bool CompactUnwindInfo::CreateUnwindPlan_armv7(Target &target,
     case 0:
       // vpush {d8}
       cfa_offset -= 8;
-      row->SetRegisterLocationToAtCFAPlusOffset(arm_d8, cfa_offset, true);
+      row.SetRegisterLocationToAtCFAPlusOffset(arm_d8, cfa_offset, true);
       break;
     case 1:
       // vpush {d10}
       // vpush {d8}
       cfa_offset -= 8;
-      row->SetRegisterLocationToAtCFAPlusOffset(arm_d10, cfa_offset, true);
+      row.SetRegisterLocationToAtCFAPlusOffset(arm_d10, cfa_offset, true);
       cfa_offset -= 8;
-      row->SetRegisterLocationToAtCFAPlusOffset(arm_d8, cfa_offset, true);
+      row.SetRegisterLocationToAtCFAPlusOffset(arm_d8, cfa_offset, true);
       break;
     case 2:
       // vpush {d12}
       // vpush {d10}
       // vpush {d8}
       cfa_offset -= 8;
-      row->SetRegisterLocationToAtCFAPlusOffset(arm_d12, cfa_offset, true);
+      row.SetRegisterLocationToAtCFAPlusOffset(arm_d12, cfa_offset, true);
       cfa_offset -= 8;
-      row->SetRegisterLocationToAtCFAPlusOffset(arm_d10, cfa_offset, true);
+      row.SetRegisterLocationToAtCFAPlusOffset(arm_d10, cfa_offset, true);
       cfa_offset -= 8;
-      row->SetRegisterLocationToAtCFAPlusOffset(arm_d8, cfa_offset, true);
+      row.SetRegisterLocationToAtCFAPlusOffset(arm_d8, cfa_offset, true);
       break;
     case 3:
       // vpush {d14}
@@ -1546,13 +1538,13 @@ bool CompactUnwindInfo::CreateUnwindPlan_armv7(Target &target,
       // vpush {d10}
       // vpush {d8}
       cfa_offset -= 8;
-      row->SetRegisterLocationToAtCFAPlusOffset(arm_d14, cfa_offset, true);
+      row.SetRegisterLocationToAtCFAPlusOffset(arm_d14, cfa_offset, true);
       cfa_offset -= 8;
-      row->SetRegisterLocationToAtCFAPlusOffset(arm_d12, cfa_offset, true);
+      row.SetRegisterLocationToAtCFAPlusOffset(arm_d12, cfa_offset, true);
       cfa_offset -= 8;
-      row->SetRegisterLocationToAtCFAPlusOffset(arm_d10, cfa_offset, true);
+      row.SetRegisterLocationToAtCFAPlusOffset(arm_d10, cfa_offset, true);
       cfa_offset -= 8;
-      row->SetRegisterLocationToAtCFAPlusOffset(arm_d8, cfa_offset, true);
+      row.SetRegisterLocationToAtCFAPlusOffset(arm_d8, cfa_offset, true);
       break;
     case 4:
       // vpush {d14}
@@ -1560,9 +1552,9 @@ bool CompactUnwindInfo::CreateUnwindPlan_armv7(Target &target,
       // sp = (sp - 24) & (-16);
       // vst   {d8, d9, d10}
       cfa_offset -= 8;
-      row->SetRegisterLocationToAtCFAPlusOffset(arm_d14, cfa_offset, true);
+      row.SetRegisterLocationToAtCFAPlusOffset(arm_d14, cfa_offset, true);
       cfa_offset -= 8;
-      row->SetRegisterLocationToAtCFAPlusOffset(arm_d12, cfa_offset, true);
+      row.SetRegisterLocationToAtCFAPlusOffset(arm_d12, cfa_offset, true);
 
       // FIXME we don't have a way to represent reg saves at an specific
       // alignment short of
@@ -1576,7 +1568,7 @@ bool CompactUnwindInfo::CreateUnwindPlan_armv7(Target &target,
       // vst   {d12}
 
       cfa_offset -= 8;
-      row->SetRegisterLocationToAtCFAPlusOffset(arm_d14, cfa_offset, true);
+      row.SetRegisterLocationToAtCFAPlusOffset(arm_d14, cfa_offset, true);
 
       // FIXME we don't have a way to represent reg saves at an specific
       // alignment short of
@@ -1606,6 +1598,6 @@ bool CompactUnwindInfo::CreateUnwindPlan_armv7(Target &target,
     }
   }
 
-  unwind_plan.AppendRow(row);
+  unwind_plan.AppendRow(std::move(row));
   return true;
 }

--- a/lldb/unittests/UnwindAssembly/x86/Testx86AssemblyInspectionEngine.cpp
+++ b/lldb/unittests/UnwindAssembly/x86/Testx86AssemblyInspectionEngine.cpp
@@ -2222,7 +2222,6 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSpillRegToStackViaMOVi386) {
 
 TEST_F(Testx86AssemblyInspectionEngine, TestSpArithx86_64Augmented) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine64 = Getx86_64Inspector();
@@ -2251,38 +2250,28 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSpArithx86_64Augmented) {
   unwind_plan.SetPlanValidAddressRange(sample_range);
   unwind_plan.SetRegisterKind(eRegisterKindLLDB);
 
-  row_sp = std::make_shared<UnwindPlan::Row>();
+  {
+    UnwindPlan::Row row;
 
-  // Describe offset 0
-  row_sp->SetOffset(0);
-  row_sp->GetCFAValue().SetIsRegisterPlusOffset(k_rsp, 8);
+    // Describe offset 0
+    row.SetOffset(0);
+    row.GetCFAValue().SetIsRegisterPlusOffset(k_rsp, 8);
+    regloc.SetAtCFAPlusOffset(-8);
+    row.SetRegisterInfo(k_rip, regloc);
+    unwind_plan.AppendRow(row);
 
-  regloc.SetAtCFAPlusOffset(-8);
-  row_sp->SetRegisterInfo(k_rip, regloc);
+    // Describe offset 1
+    row.SetOffset(1);
+    row.GetCFAValue().SetIsRegisterPlusOffset(k_rsp, 16);
+    regloc.SetAtCFAPlusOffset(-16);
+    row.SetRegisterInfo(k_rbp, regloc);
+    unwind_plan.AppendRow(row);
 
-  unwind_plan.AppendRow(row_sp);
-
-  // Allocate a new Row, populate it with the existing Row contents.
-  UnwindPlan::Row *new_row = new UnwindPlan::Row;
-  *new_row = *row_sp.get();
-  row_sp.reset(new_row);
-
-  // Describe offset 1
-  row_sp->SetOffset(1);
-  row_sp->GetCFAValue().SetIsRegisterPlusOffset(k_rsp, 16);
-  regloc.SetAtCFAPlusOffset(-16);
-  row_sp->SetRegisterInfo(k_rbp, regloc);
-  unwind_plan.AppendRow(row_sp);
-
-  // Allocate a new Row, populate it with the existing Row contents.
-  new_row = new UnwindPlan::Row;
-  *new_row = *row_sp.get();
-  row_sp.reset(new_row);
-
-  // Describe offset 4
-  row_sp->SetOffset(4);
-  row_sp->GetCFAValue().SetIsRegisterPlusOffset(k_rsp, 16);
-  unwind_plan.AppendRow(row_sp);
+    // Describe offset 4
+    row.SetOffset(4);
+    row.GetCFAValue().SetIsRegisterPlusOffset(k_rsp, 16);
+    unwind_plan.AppendRow(row);
+  }
 
   RegisterContextSP reg_ctx_sp;
   EXPECT_TRUE(engine64->AugmentUnwindPlanFromCallSite(
@@ -2313,7 +2302,6 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSpArithx86_64Augmented) {
 
 TEST_F(Testx86AssemblyInspectionEngine, TestSimplex86_64Augmented) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine64 = Getx86_64Inspector();
@@ -2338,38 +2326,28 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimplex86_64Augmented) {
   unwind_plan.SetPlanValidAddressRange(sample_range);
   unwind_plan.SetRegisterKind(eRegisterKindLLDB);
 
-  row_sp = std::make_shared<UnwindPlan::Row>();
+  {
+    UnwindPlan::Row row;
 
-  // Describe offset 0
-  row_sp->SetOffset(0);
-  row_sp->GetCFAValue().SetIsRegisterPlusOffset(k_rsp, 8);
+    // Describe offset 0
+    row.SetOffset(0);
+    row.GetCFAValue().SetIsRegisterPlusOffset(k_rsp, 8);
+    regloc.SetAtCFAPlusOffset(-8);
+    row.SetRegisterInfo(k_rip, regloc);
+    unwind_plan.AppendRow(row);
 
-  regloc.SetAtCFAPlusOffset(-8);
-  row_sp->SetRegisterInfo(k_rip, regloc);
+    // Describe offset 1
+    row.SetOffset(1);
+    row.GetCFAValue().SetIsRegisterPlusOffset(k_rsp, 16);
+    regloc.SetAtCFAPlusOffset(-16);
+    row.SetRegisterInfo(k_rbp, regloc);
+    unwind_plan.AppendRow(row);
 
-  unwind_plan.AppendRow(row_sp);
-
-  // Allocate a new Row, populate it with the existing Row contents.
-  UnwindPlan::Row *new_row = new UnwindPlan::Row;
-  *new_row = *row_sp.get();
-  row_sp.reset(new_row);
-
-  // Describe offset 1
-  row_sp->SetOffset(1);
-  row_sp->GetCFAValue().SetIsRegisterPlusOffset(k_rsp, 16);
-  regloc.SetAtCFAPlusOffset(-16);
-  row_sp->SetRegisterInfo(k_rbp, regloc);
-  unwind_plan.AppendRow(row_sp);
-
-  // Allocate a new Row, populate it with the existing Row contents.
-  new_row = new UnwindPlan::Row;
-  *new_row = *row_sp.get();
-  row_sp.reset(new_row);
-
-  // Describe offset 4
-  row_sp->SetOffset(4);
-  row_sp->GetCFAValue().SetIsRegisterPlusOffset(k_rbp, 16);
-  unwind_plan.AppendRow(row_sp);
+    // Describe offset 4
+    row.SetOffset(4);
+    row.GetCFAValue().SetIsRegisterPlusOffset(k_rbp, 16);
+    unwind_plan.AppendRow(row);
+  }
 
   RegisterContextSP reg_ctx_sp;
   EXPECT_TRUE(engine64->AugmentUnwindPlanFromCallSite(
@@ -2391,7 +2369,6 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimplex86_64Augmented) {
 
 TEST_F(Testx86AssemblyInspectionEngine, TestSimplei386ugmented) {
   UnwindPlan::Row::AbstractRegisterLocation regloc;
-  UnwindPlan::RowSP row_sp;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);
   std::unique_ptr<x86AssemblyInspectionEngine> engine32 = Geti386Inspector();
@@ -2416,38 +2393,28 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimplei386ugmented) {
   unwind_plan.SetPlanValidAddressRange(sample_range);
   unwind_plan.SetRegisterKind(eRegisterKindLLDB);
 
-  row_sp = std::make_shared<UnwindPlan::Row>();
+  {
+    UnwindPlan::Row row;
 
-  // Describe offset 0
-  row_sp->SetOffset(0);
-  row_sp->GetCFAValue().SetIsRegisterPlusOffset(k_esp, 4);
+    // Describe offset 0
+    row.SetOffset(0);
+    row.GetCFAValue().SetIsRegisterPlusOffset(k_esp, 4);
+    regloc.SetAtCFAPlusOffset(-4);
+    row.SetRegisterInfo(k_eip, regloc);
+    unwind_plan.AppendRow(row);
 
-  regloc.SetAtCFAPlusOffset(-4);
-  row_sp->SetRegisterInfo(k_eip, regloc);
+    // Describe offset 1
+    row.SetOffset(1);
+    row.GetCFAValue().SetIsRegisterPlusOffset(k_esp, 8);
+    regloc.SetAtCFAPlusOffset(-8);
+    row.SetRegisterInfo(k_ebp, regloc);
+    unwind_plan.AppendRow(row);
 
-  unwind_plan.AppendRow(row_sp);
-
-  // Allocate a new Row, populate it with the existing Row contents.
-  UnwindPlan::Row *new_row = new UnwindPlan::Row;
-  *new_row = *row_sp.get();
-  row_sp.reset(new_row);
-
-  // Describe offset 1
-  row_sp->SetOffset(1);
-  row_sp->GetCFAValue().SetIsRegisterPlusOffset(k_esp, 8);
-  regloc.SetAtCFAPlusOffset(-8);
-  row_sp->SetRegisterInfo(k_ebp, regloc);
-  unwind_plan.AppendRow(row_sp);
-
-  // Allocate a new Row, populate it with the existing Row contents.
-  new_row = new UnwindPlan::Row;
-  *new_row = *row_sp.get();
-  row_sp.reset(new_row);
-
-  // Describe offset 3
-  row_sp->SetOffset(3);
-  row_sp->GetCFAValue().SetIsRegisterPlusOffset(k_ebp, 8);
-  unwind_plan.AppendRow(row_sp);
+    // Describe offset 3
+    row.SetOffset(3);
+    row.GetCFAValue().SetIsRegisterPlusOffset(k_ebp, 8);
+    unwind_plan.AppendRow(row);
+  }
 
   RegisterContextSP reg_ctx_sp;
   EXPECT_TRUE(engine32->AugmentUnwindPlanFromCallSite(


### PR DESCRIPTION
In most places, the rows are copied anyway (because they are generated by cumulating modifications) immediately after adding them to the unwind plans. In others, they can be moved into the unwind plan. This lets us remove some backflip copies and make `const UnwindPlan` actually mean something.

I've split this patch into two (and temporarily left both APIs) as this patch was getting a bit big. This patch covers all the interesting cases. Part two all about converting "architecture default" unwind plans from ABI and InstructionEmulation plugins.