### PR TITLE
[mlir] To fix a compile time warning.

### DIFF
--- a/mlir/lib/Dialect/Affine/Utils/LoopUtils.cpp
+++ b/mlir/lib/Dialect/Affine/Utils/LoopUtils.cpp
@@ -2062,7 +2062,7 @@ static LogicalResult generateCopy(
 
     // Set copy start location for this dimension in the lower memory space
     // memref.
-    if (auto caf = lbs[d].isSingleConstant()) {
+    if (lbs[d].isSingleConstant()) {
       auto indexVal = lbs[d].getSingleConstantResult();
       if (indexVal == 0) {
         memIndices.push_back(zeroIndex);


### PR DESCRIPTION
Our build on AIX issues warning on unused varaible
```
llvm-project/mlir/lib/Dialect/Affine/Utils/LoopUtils.cpp:2065:14: warning: variable 'caf' set but not used [-Wunused-but-set-variable]
 2065 |     if (auto caf = lbs[d].isSingleConstant()) {
      |              ^
1 warning generated.
```