### PR TITLE
[hwasan] Don't check code model if there are no globals

### DIFF
--- a/compiler-rt/lib/hwasan/hwasan_globals.cpp
+++ b/compiler-rt/lib/hwasan/hwasan_globals.cpp
@@ -84,7 +84,7 @@ ArrayRef<const hwasan_global> HwasanGlobalsFor(ElfW(Addr) base,
       //
       // There is always a HWASan globals note ("Create the note even if we
       // aren't instrumenting globals." - HWAddressSanitizer.cpp), but we can
-      // elide the code model check if there are no real globals.
+      // elide the code model check if there are no globals.
       if (globals_begin != globals_end)
         CheckCodeModel(base, phdr, phnum);
 

--- a/compiler-rt/lib/hwasan/hwasan_globals.cpp
+++ b/compiler-rt/lib/hwasan/hwasan_globals.cpp
@@ -73,15 +73,20 @@ ArrayRef<const hwasan_global> HwasanGlobalsFor(ElfW(Addr) base,
         continue;
       }
 
-      // Only libraries with instrumented globals need to be checked against the
-      // code model since they use relocations that aren't checked at link time.
-      CheckCodeModel(base, phdr, phnum);
-
       auto *global_note = reinterpret_cast<const hwasan_global_note *>(desc);
       auto *globals_begin = reinterpret_cast<const hwasan_global *>(
           note + global_note->begin_relptr);
       auto *globals_end = reinterpret_cast<const hwasan_global *>(
           note + global_note->end_relptr);
+
+      // Only libraries with instrumented globals need to be checked against the
+      // code model since they use relocations that aren't checked at link time.
+      //
+      // There is always a HWASan globals note ("Create the note even if we
+      // aren't instrumenting globals. - HWAddressSanitizer.cpp), but we can
+      // elide the code model check if there are no real globals.
+      if (globals_begin != globals_end)
+        CheckCodeModel(base, phdr, phnum);
 
       return {globals_begin, globals_end};
     }

--- a/compiler-rt/lib/hwasan/hwasan_globals.cpp
+++ b/compiler-rt/lib/hwasan/hwasan_globals.cpp
@@ -83,7 +83,7 @@ ArrayRef<const hwasan_global> HwasanGlobalsFor(ElfW(Addr) base,
       // code model since they use relocations that aren't checked at link time.
       //
       // There is always a HWASan globals note ("Create the note even if we
-      // aren't instrumenting globals. - HWAddressSanitizer.cpp), but we can
+      // aren't instrumenting globals." - HWAddressSanitizer.cpp), but we can
       // elide the code model check if there are no real globals.
       if (globals_begin != globals_end)
         CheckCodeModel(base, phdr, phnum);


### PR DESCRIPTION
Currently, the code model check is always performed even if there are no globals, because:
1) the HWASan compiler pass always leaves a note
2) the HWASan runtime always performs the check if there is a HWASan globals note.
This unnecessarily adds a 2**32 byte size limit.

This patch elides the check if the globals note doesn't actually contain globals, thus allowing larger libraries to be successfully instrumented without globals.

Sent from my iPhone