### PR TITLE
[clang] Remove usage of llvm-spirv in clang LIT tests

### DIFF
--- a/clang/test/Tooling/clang-linker-wrapper-spirv-elf.cpp
+++ b/clang/test/Tooling/clang-linker-wrapper-spirv-elf.cpp
@@ -1,7 +1,7 @@
 // Verify the ELF packaging of OpenMP SPIR-V device images.
 // REQUIRES: system-linux
 // REQUIRES: spirv-tools
-// REQUIRES: llvm-spirv
+// REQUIRES: spirv-registered-target
 // RUN: mkdir -p %t_tmp
 // RUN: cd %t_tmp
 // RUN: %clangxx -fopenmp -fopenmp-targets=spirv64-intel -nogpulib -c -o %t_clang-linker-wrapper-spirv-elf.o %s

--- a/clang/test/Tooling/lit.local.cfg
+++ b/clang/test/Tooling/lit.local.cfg
@@ -9,6 +9,3 @@ if config.spirv_tools_tests:
     config.substitutions.append(("spirv-val", os.path.join(config.llvm_tools_dir, "spirv-val")))
     config.substitutions.append(("spirv-as", os.path.join(config.llvm_tools_dir, "spirv-as")))
     config.substitutions.append(("spirv-link", os.path.join(config.llvm_tools_dir, "spirv-link")))
-
-if lit.util.which("llvm-spirv"):
-    config.available_features.add("llvm-spirv")


### PR DESCRIPTION
We use the backend now, so remove the requirement from the only test that actually executes the translator and remove the LIT requirement variable.