### PR TITLE
[mlir][python] Small optimization to mlirApiObjectToCapsule.

### DIFF
--- a/mlir/include/mlir/Bindings/Python/NanobindAdaptors.h
+++ b/mlir/include/mlir/Bindings/Python/NanobindAdaptors.h
@@ -46,14 +46,16 @@ namespace detail {
 static nanobind::object mlirApiObjectToCapsule(nanobind::handle apiObject) {
   if (PyCapsule_CheckExact(apiObject.ptr()))
     return nanobind::borrow<nanobind::object>(apiObject);
-  if (!nanobind::hasattr(apiObject, MLIR_PYTHON_CAPI_PTR_ATTR)) {
+  nanobind::object api =
+      nanobind::getattr(apiObject, MLIR_PYTHON_CAPI_PTR_ATTR, nanobind::none());
+  if (api.is_none()) {
     std::string repr = nanobind::cast<std::string>(nanobind::repr(apiObject));
     throw nanobind::type_error(
         (llvm::Twine("Expected an MLIR object (got ") + repr + ").")
             .str()
             .c_str());
   }
-  return apiObject.attr(MLIR_PYTHON_CAPI_PTR_ATTR);
+  return api;
 }
 
 // Note: Currently all of the following support cast from nanobind::object to


### PR DESCRIPTION
Call nb::getattr(...) rather than using nb::hasattr() and .attr(). Saves a Python string allocation and a dictionary lookup when using a recent nanobind.

Optimization only, no changes in behavior expected.