### PR TITLE
Update the libc BUILD.bazel file with selects for Windows builds.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -1373,10 +1373,7 @@ libc_support_library(
 
 libc_support_library(
     name = "__support_osutil_exit",
-    srcs = select({
-        "@platforms//os:linux": ["src/__support/OSUtil/linux/exit.cpp"],
-	"//condition:default": [],
-    }),
+    srcs = ["src/__support/OSUtil/linux/exit.cpp"],
     hdrs = ["src/__support/OSUtil/exit.h"],
     target_compatible_with = select({
         "@platforms//os:linux": [],

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -1,5 +1,5 @@
 # This file is licensed under the Apache License v2.0 with LLVM Exceptions.
-got# See https://llvm.org/LICENSE.txt for license information.
+# See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # LLVM libc project.

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -1,5 +1,5 @@
 # This file is licensed under the Apache License v2.0 with LLVM Exceptions.
-# See https://llvm.org/LICENSE.txt for license information.
+got# See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # LLVM libc project.
@@ -1319,6 +1319,7 @@ libc_support_library(
             "src/__support/OSUtil/linux/aarch64/syscall.h",
             "src/__support/OSUtil/linux/x86_64/syscall.h",
         ],
+	"@platforms//os:windows": [],
     }),
     deps = [
         ":__support_common",
@@ -1360,6 +1361,7 @@ libc_support_library(
     textual_hdrs = select({
         "@platforms//os:macos": ["src/__support/OSUtil/darwin/io.h"],
         "@platforms//os:linux": ["src/__support/OSUtil/linux/io.h"],
+	"@platforms//os:windows": ["src/__support/OSUtil/windows/io.h"],
     }),
     deps = [
         ":__support_common",
@@ -1371,7 +1373,10 @@ libc_support_library(
 
 libc_support_library(
     name = "__support_osutil_exit",
-    srcs = ["src/__support/OSUtil/linux/exit.cpp"],
+    srcs = select({
+        "@platforms//os:linux": ["src/__support/OSUtil/linux/exit.cpp"],
+	"//condition:default": [],
+    }),
     hdrs = ["src/__support/OSUtil/exit.h"],
     target_compatible_with = select({
         "@platforms//os:linux": [],


### PR DESCRIPTION
The Windows toolchain needs to build libc targets in order to support libc++. Currently, some targets fail to resolve, due to non-exhaustive select statements, not accounting for Windows builds.

This change adds clauses to select statements so that Windows builds can proceed.

Additionally, `__support_osutil_exit`, is configured to pass nothing to `srcs` for non-Linux builds. `__support_osutil_exit `is unconditionally included in the transitive dependencies of `extern_libc_shared`. 