### PR TITLE
Revert "Use global TimerGroups for both new pass manager and old pass manager timers"

### DIFF
--- a/clang/test/Misc/time-passes.c
+++ b/clang/test/Misc/time-passes.c
@@ -19,5 +19,6 @@
 // NPM:       InstCombinePass{{$}}
 // NPM-NOT:   InstCombinePass #
 // TIME: Total{{$}}
+// NPM: Pass execution timing report
 
 int foo(int x, int y) { return x + y; }

--- a/llvm/include/llvm/IR/PassTimingInfo.h
+++ b/llvm/include/llvm/IR/PassTimingInfo.h
@@ -39,7 +39,8 @@ Timer *getPassTimer(Pass *);
 /// This class implements -time-passes functionality for new pass manager.
 /// It provides the pass-instrumentation callbacks that measure the pass
 /// execution time. They collect timing info into individual timers as
-/// passes are being run.
+/// passes are being run. At the end of its life-time it prints the resulting
+/// timing report.
 class TimePassesHandler {
   /// Value of this type is capable of uniquely identifying pass invocations.
   /// It is a pair of string Pass-Identifier (which for now is common
@@ -47,10 +48,8 @@ class TimePassesHandler {
   using PassInvocationID = std::pair<StringRef, unsigned>;
 
   /// Groups of timers for passes and analyses.
-  TimerGroup &PassTG =
-      NamedRegionTimer::getNamedTimerGroup(PassGroupName, PassGroupDesc);
-  TimerGroup &AnalysisTG = NamedRegionTimer::getNamedTimerGroup(
-      AnalysisGroupName, AnalysisGroupDesc);
+  TimerGroup PassTG;
+  TimerGroup AnalysisTG;
 
   using TimerVector = llvm::SmallVector<std::unique_ptr<Timer>, 4>;
   /// Map of timers for pass invocations
@@ -72,14 +71,11 @@ class TimePassesHandler {
   bool PerRun;
 
 public:
-  static constexpr StringRef PassGroupName = "pass";
-  static constexpr StringRef AnalysisGroupName = "analysis";
-  static constexpr StringRef PassGroupDesc = "Pass execution timing report";
-  static constexpr StringRef AnalysisGroupDesc =
-      "Analysis execution timing report";
-
   TimePassesHandler();
   TimePassesHandler(bool Enabled, bool PerRun = false);
+
+  /// Destructor handles the print action if it has not been handled before.
+  ~TimePassesHandler() { print(); }
 
   /// Prints out timing information and then resets the timers.
   void print();

--- a/llvm/include/llvm/Support/Timer.h
+++ b/llvm/include/llvm/Support/Timer.h
@@ -169,11 +169,6 @@ struct NamedRegionTimer : public TimeRegion {
   explicit NamedRegionTimer(StringRef Name, StringRef Description,
                             StringRef GroupName,
                             StringRef GroupDescription, bool Enabled = true);
-
-  // Create or get a TimerGroup stored in the same global map owned by
-  // NamedRegionTimer.
-  static TimerGroup &getNamedTimerGroup(StringRef GroupName,
-                                        StringRef GroupDescription);
 };
 
 /// The TimerGroup class is used to group together related timers into a single

--- a/llvm/lib/Support/Timer.cpp
+++ b/llvm/lib/Support/Timer.cpp
@@ -222,26 +222,15 @@ public:
              StringRef GroupDescription) {
     sys::SmartScopedLock<true> L(timerLock());
 
-    std::pair<TimerGroup *, Name2TimerMap> &GroupEntry =
-        getGroupEntry(GroupName, GroupDescription);
+    std::pair<TimerGroup*, Name2TimerMap> &GroupEntry = Map[GroupName];
+
+    if (!GroupEntry.first)
+      GroupEntry.first = new TimerGroup(GroupName, GroupDescription);
+
     Timer &T = GroupEntry.second[Name];
     if (!T.isInitialized())
       T.init(Name, Description, *GroupEntry.first);
     return T;
-  }
-
-  TimerGroup &getTimerGroup(StringRef GroupName, StringRef GroupDescription) {
-    return *getGroupEntry(GroupName, GroupDescription).first;
-  }
-
-private:
-  std::pair<TimerGroup *, Name2TimerMap> &
-  getGroupEntry(StringRef GroupName, StringRef GroupDescription) {
-    std::pair<TimerGroup *, Name2TimerMap> &GroupEntry = Map[GroupName];
-    if (!GroupEntry.first)
-      GroupEntry.first = new TimerGroup(GroupName, GroupDescription);
-
-    return GroupEntry;
   }
 };
 
@@ -254,11 +243,6 @@ NamedRegionTimer::NamedRegionTimer(StringRef Name, StringRef Description,
                      ? nullptr
                      : &namedGroupedTimers().get(Name, Description, GroupName,
                                                  GroupDescription)) {}
-
-TimerGroup &NamedRegionTimer::getNamedTimerGroup(StringRef GroupName,
-                                                 StringRef GroupDescription) {
-  return namedGroupedTimers().getTimerGroup(GroupName, GroupDescription);
-}
 
 //===----------------------------------------------------------------------===//
 //   TimerGroup Implementation

--- a/llvm/unittests/IR/TimePassesTest.cpp
+++ b/llvm/unittests/IR/TimePassesTest.cpp
@@ -161,8 +161,8 @@ TEST(TimePassesTest, CustomOut) {
   PI.runBeforePass(Pass2, M);
   PI.runAfterPass(Pass2, M, PreservedAnalyses::all());
 
-  // Clear and generate report again.
-  TimePasses->print();
+  // Generate report by deleting the handler.
+  TimePasses.reset();
 
   // There should be Pass2 in this report and no Pass1.
   EXPECT_FALSE(TimePassesStr.str().empty());


### PR DESCRIPTION
Reverts llvm/llvm-project#130375

Causes breakages, e.g. https://lab.llvm.org/buildbot/#/builders/160/builds/14607