### PR TITLE
[AArch64][CodeGen] Add patterns for +lsfe atomic stores

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrAtomics.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrAtomics.td
@@ -548,13 +548,13 @@ defm atomic_load_fmin  : binary_atomic_op_fp<atomic_load_fmin>;
 defm atomic_load_fmax  : binary_atomic_op_fp<atomic_load_fmax>;
 
 let Predicates = [HasLSFE] in {
-  defm : LDFPOPregister_patterns<"LDFADD",   "atomic_load_fadd">;
-  defm : LDFPOPregister_patterns<"LDFMAXNM", "atomic_load_fmax">;
-  defm : LDFPOPregister_patterns<"LDFMINNM", "atomic_load_fmin">;
+  defm : LDFPOPregister_patterns<"FADD",   "atomic_load_fadd">;
+  defm : LDFPOPregister_patterns<"FMAXNM", "atomic_load_fmax">;
+  defm : LDFPOPregister_patterns<"FMINNM", "atomic_load_fmin">;
 
-  defm : LDBFPOPregister_patterns<"LDBFADD",   "atomic_load_fadd">;
-  defm : LDBFPOPregister_patterns<"LDBFMAXNM", "atomic_load_fmax">;
-  defm : LDBFPOPregister_patterns<"LDBFMINNM", "atomic_load_fmin">;
+  defm : LDBFPOPregister_patterns<"BFADD",   "atomic_load_fadd">;
+  defm : LDBFPOPregister_patterns<"BFMAXNM", "atomic_load_fmax">;
+  defm : LDBFPOPregister_patterns<"BFMINNM", "atomic_load_fmin">;
 }
 
 // v8.9a/v9.4a FEAT_LRCPC patterns

--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -12493,19 +12493,39 @@ multiclass LDOPregister_patterns_mod<string inst, string op, string mod> {
                         (i32 (!cast<Instruction>(mod#Wrr) WZR, GPR32:$Rm))>;
 }
 
+class AtomicStoreMonotonicFrag<SDNode atomic_op> : PatFrag<
+  (ops node:$ptr, node:$value),
+  (atomic_op node:$ptr, node:$value),
+  [{ return SDValue(N, 0).use_empty() &&
+     cast<AtomicSDNode>(N)->getMergedOrdering() == AtomicOrdering::Monotonic; }]>;
+
+class AtomicStoreReleaseFrag<SDNode atomic_op> : PatFrag<
+  (ops node:$ptr, node:$value),
+  (atomic_op node:$ptr, node:$value),
+  [{ return SDValue(N, 0).use_empty() &&
+     cast<AtomicSDNode>(N)->getMergedOrdering() == AtomicOrdering::Release; }]>;
+
 let Predicates = [HasLSFE] in
 multiclass LDFPOPregister_patterns_ord_dag<string inst, string suffix, string op,
-                                         ValueType vt, dag data> {
+                                           ValueType vt, dag data> {
   def : Pat<(!cast<PatFrag>(op#"_"#vt#"_monotonic") FPR64:$Rn, data),
-            (!cast<Instruction>(inst # suffix) data, FPR64:$Rn)>;
+            (!cast<Instruction>("LD" # inst # suffix) data, FPR64:$Rn)>;
   def : Pat<(!cast<PatFrag>(op#"_"#vt#"_acquire") FPR64:$Rn, data),
-            (!cast<Instruction>(inst # "A" # suffix) data, FPR64:$Rn)>;
+            (!cast<Instruction>("LD" # inst # "A" # suffix) data, FPR64:$Rn)>;
   def : Pat<(!cast<PatFrag>(op#"_"#vt#"_release") FPR64:$Rn, data),
-            (!cast<Instruction>(inst # "L" # suffix) data, FPR64:$Rn)>;
+            (!cast<Instruction>("LD" # inst # "L" # suffix) data, FPR64:$Rn)>;
   def : Pat<(!cast<PatFrag>(op#"_"#vt#"_acq_rel") FPR64:$Rn, data),
-            (!cast<Instruction>(inst # "AL" # suffix) data, FPR64:$Rn)>;
+            (!cast<Instruction>("LD" # inst # "AL" # suffix) data, FPR64:$Rn)>;
   def : Pat<(!cast<PatFrag>(op#"_"#vt#"_seq_cst") FPR64:$Rn, data),
-            (!cast<Instruction>(inst # "AL" # suffix) data, FPR64:$Rn)>;
+            (!cast<Instruction>("LD" # inst # "AL" # suffix) data, FPR64:$Rn)>;
+
+  let AddedComplexity = 5 in {
+    def : Pat<(AtomicStoreMonotonicFrag<!cast<SDNode>(op)> FPR64:$Rn, data),
+              (!cast<Instruction>("ST" # inst # suffix) data, FPR64:$Rn)>;
+
+    def : Pat<(AtomicStoreReleaseFrag<!cast<SDNode>(op)> FPR64:$Rn, data),
+              (!cast<Instruction>("ST" # inst # "L" # suffix) data, FPR64:$Rn)>;
+  }
 }
 
 multiclass LDFPOPregister_patterns_ord<string inst, string suffix, string op,

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lsfe.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lsfe.ll
@@ -12,7 +12,7 @@ define dso_local half @atomicrmw_fadd_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local void @atomicrmw_fadd_half_aligned_monotonic_to_store(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fadd_half_aligned_monotonic_to_store:
-; CHECK:    ldfadd h0, h0, [x0]
+; CHECK:    stfadd h0, [x0]
     %r = atomicrmw fadd ptr %ptr, half %value monotonic, align 2
     ret void
 }
@@ -33,7 +33,7 @@ define dso_local half @atomicrmw_fadd_half_aligned_release(ptr %ptr, half %value
 
 define dso_local void @atomicrmw_fadd_half_aligned_release_to_store(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fadd_half_aligned_release_to_store:
-; CHECK:    ldfaddl h0, h0, [x0]
+; CHECK:    stfaddl h0, [x0]
     %r = atomicrmw fadd ptr %ptr, half %value release, align 2
     ret void
 }
@@ -61,7 +61,7 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_monotonic(ptr %ptr, bfloa
 
 define dso_local void @atomicrmw_fadd_bfloat_aligned_monotonic_to_store(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fadd_bfloat_aligned_monotonic_to_store:
-; CHECK:    ldbfadd h0, h0, [x0]
+; CHECK:    stbfadd h0, [x0]
     %r = atomicrmw fadd ptr %ptr, bfloat %value monotonic, align 2
     ret void
 }
@@ -82,7 +82,7 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_release(ptr %ptr, bfloat 
 
 define dso_local void @atomicrmw_fadd_bfloat_aligned_release_to_store(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fadd_bfloat_aligned_release_to_store:
-; CHECK:    ldbfaddl h0, h0, [x0]
+; CHECK:    stbfaddl h0, [x0]
     %r = atomicrmw fadd ptr %ptr, bfloat %value release, align 2
     ret void
 }
@@ -110,7 +110,7 @@ define dso_local float @atomicrmw_fadd_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local void @atomicrmw_fadd_float_aligned_monotonic_to_store(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fadd_float_aligned_monotonic_to_store:
-; CHECK:    ldfadd s0, s0, [x0]
+; CHECK:    stfadd s0, [x0]
     %r = atomicrmw fadd ptr %ptr, float %value monotonic, align 4
     ret void
 }
@@ -131,7 +131,7 @@ define dso_local float @atomicrmw_fadd_float_aligned_release(ptr %ptr, float %va
 
 define dso_local void @atomicrmw_fadd_float_aligned_release_to_store(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fadd_float_aligned_release_to_store:
-; CHECK:    ldfaddl s0, s0, [x0]
+; CHECK:    stfaddl s0, [x0]
     %r = atomicrmw fadd ptr %ptr, float %value release, align 4
     ret void
 }
@@ -159,7 +159,7 @@ define dso_local double @atomicrmw_fadd_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local void @atomicrmw_fadd_double_aligned_monotonic_to_store(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fadd_double_aligned_monotonic_to_store:
-; CHECK:    ldfadd d0, d0, [x0]
+; CHECK:    stfadd d0, [x0]
     %r = atomicrmw fadd ptr %ptr, double %value monotonic, align 8
     ret void
 }
@@ -180,7 +180,7 @@ define dso_local double @atomicrmw_fadd_double_aligned_release(ptr %ptr, double 
 
 define dso_local void @atomicrmw_fadd_double_aligned_release_to_store(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fadd_double_aligned_release_to_store:
-; CHECK:    ldfaddl d0, d0, [x0]
+; CHECK:    stfaddl d0, [x0]
     %r = atomicrmw fadd ptr %ptr, double %value release, align 8
     ret void
 }
@@ -863,7 +863,7 @@ define dso_local half @atomicrmw_fmax_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local void @atomicrmw_fmax_half_aligned_monotonic_to_store(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fmax_half_aligned_monotonic_to_store:
-; CHECK:    ldfmaxnm h0, h0, [x0]
+; CHECK:    stfmaxnm h0, [x0]
     %r = atomicrmw fmax ptr %ptr, half %value monotonic, align 2
     ret void
 }
@@ -884,7 +884,7 @@ define dso_local half @atomicrmw_fmax_half_aligned_release(ptr %ptr, half %value
 
 define dso_local void @atomicrmw_fmax_half_aligned_release_to_store(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fmax_half_aligned_release_to_store:
-; CHECK:    ldfmaxnml h0, h0, [x0]
+; CHECK:    stfmaxnml h0, [x0]
     %r = atomicrmw fmax ptr %ptr, half %value release, align 2
     ret void
 }
@@ -912,7 +912,7 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_monotonic(ptr %ptr, bfloa
 
 define dso_local void @atomicrmw_fmax_bfloat_aligned_monotonic_to_store(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fmax_bfloat_aligned_monotonic_to_store:
-; CHECK:    ldbfmaxnm h0, h0, [x0]
+; CHECK:    stbfmaxnm h0, [x0]
     %r = atomicrmw fmax ptr %ptr, bfloat %value monotonic, align 2
     ret void
 }
@@ -933,7 +933,7 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_release(ptr %ptr, bfloat 
 
 define dso_local void @atomicrmw_fmax_bfloat_aligned_release_to_store(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fmax_bfloat_aligned_release_to_store:
-; CHECK:    ldbfmaxnml h0, h0, [x0]
+; CHECK:    stbfmaxnml h0, [x0]
     %r = atomicrmw fmax ptr %ptr, bfloat %value release, align 2
     ret void
 }
@@ -961,7 +961,7 @@ define dso_local float @atomicrmw_fmax_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local void @atomicrmw_fmax_float_aligned_monotonic_to_store(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fmax_float_aligned_monotonic_to_store:
-; CHECK:    ldfmaxnm s0, s0, [x0]
+; CHECK:    stfmaxnm s0, [x0]
     %r = atomicrmw fmax ptr %ptr, float %value monotonic, align 4
     ret void
 }
@@ -982,7 +982,7 @@ define dso_local float @atomicrmw_fmax_float_aligned_release(ptr %ptr, float %va
 
 define dso_local void @atomicrmw_fmax_float_aligned_release_to_store(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fmax_float_aligned_release_to_store:
-; CHECK:    ldfmaxnml s0, s0, [x0]
+; CHECK:    stfmaxnml s0, [x0]
     %r = atomicrmw fmax ptr %ptr, float %value release, align 4
     ret void
 }
@@ -1010,7 +1010,7 @@ define dso_local double @atomicrmw_fmax_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local void @atomicrmw_fmax_double_aligned_monotonic_to_store(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fmax_double_aligned_monotonic_to_store:
-; CHECK:    ldfmaxnm d0, d0, [x0]
+; CHECK:    stfmaxnm d0, [x0]
     %r = atomicrmw fmax ptr %ptr, double %value monotonic, align 8
     ret void
 }
@@ -1031,7 +1031,7 @@ define dso_local double @atomicrmw_fmax_double_aligned_release(ptr %ptr, double 
 
 define dso_local void @atomicrmw_fmax_double_aligned_release_to_store(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fmax_double_aligned_release_to_store:
-; CHECK:    ldfmaxnml d0, d0, [x0]
+; CHECK:    stfmaxnml d0, [x0]
     %r = atomicrmw fmax ptr %ptr, double %value release, align 8
     ret void
 }
@@ -1234,7 +1234,7 @@ define dso_local half @atomicrmw_fmin_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local void @atomicrmw_fmin_half_aligned_monotonic_to_store(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fmin_half_aligned_monotonic_to_store:
-; CHECK:    ldfminnm h0, h0, [x0]
+; CHECK:    stfminnm h0, [x0]
     %r = atomicrmw fmin ptr %ptr, half %value monotonic, align 2
     ret void
 }
@@ -1255,7 +1255,7 @@ define dso_local half @atomicrmw_fmin_half_aligned_release(ptr %ptr, half %value
 
 define dso_local void @atomicrmw_fmin_half_aligned_release_to_store(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fmin_half_aligned_release_to_store:
-; CHECK:    ldfminnml h0, h0, [x0]
+; CHECK:    stfminnml h0, [x0]
     %r = atomicrmw fmin ptr %ptr, half %value release, align 2
     ret void
 }
@@ -1283,7 +1283,7 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_monotonic(ptr %ptr, bfloa
 
 define dso_local void @atomicrmw_fmin_bfloat_aligned_monotonic_to_store(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fmin_bfloat_aligned_monotonic_to_store:
-; CHECK:    ldbfminnm h0, h0, [x0]
+; CHECK:    stbfminnm h0, [x0]
     %r = atomicrmw fmin ptr %ptr, bfloat %value monotonic, align 2
     ret void
 }
@@ -1304,7 +1304,7 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_release(ptr %ptr, bfloat 
 
 define dso_local void @atomicrmw_fmin_bfloat_aligned_release_to_store(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fmin_bfloat_aligned_release_to_store:
-; CHECK:    ldbfminnml h0, h0, [x0]
+; CHECK:    stbfminnml h0, [x0]
     %r = atomicrmw fmin ptr %ptr, bfloat %value release, align 2
     ret void
 }
@@ -1332,7 +1332,7 @@ define dso_local float @atomicrmw_fmin_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local void @atomicrmw_fmin_float_aligned_monotonic_to_store(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fmin_float_aligned_monotonic_to_store:
-; CHECK:    ldfminnm s0, s0, [x0]
+; CHECK:    stfminnm s0, [x0]
     %r = atomicrmw fmin ptr %ptr, float %value monotonic, align 4
     ret void
 }
@@ -1353,7 +1353,7 @@ define dso_local float @atomicrmw_fmin_float_aligned_release(ptr %ptr, float %va
 
 define dso_local void @atomicrmw_fmin_float_aligned_release_to_store(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fmin_float_aligned_release_to_store:
-; CHECK:    ldfminnml s0, s0, [x0]
+; CHECK:    stfminnml s0, [x0]
     %r = atomicrmw fmin ptr %ptr, float %value release, align 4
     ret void
 }
@@ -1381,7 +1381,7 @@ define dso_local double @atomicrmw_fmin_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local void @atomicrmw_fmin_double_aligned_monotonic_to_store(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fmin_double_aligned_monotonic_to_store:
-; CHECK:    ldfminnm d0, d0, [x0]
+; CHECK:    stfminnm d0, [x0]
     %r = atomicrmw fmin ptr %ptr, double %value monotonic, align 8
     ret void
 }
@@ -1402,7 +1402,7 @@ define dso_local double @atomicrmw_fmin_double_aligned_release(ptr %ptr, double 
 
 define dso_local void @atomicrmw_fmin_double_aligned_release_to_store(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fmin_double_aligned_release_to_store:
-; CHECK:    ldfminnml d0, d0, [x0]
+; CHECK:    stfminnml d0, [x0]
     %r = atomicrmw fmin ptr %ptr, double %value release, align 8
     ret void
 }

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lsfe.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64-atomicrmw-lsfe.ll
@@ -10,6 +10,13 @@ define dso_local half @atomicrmw_fadd_half_aligned_monotonic(ptr %ptr, half %val
     ret half %r
 }
 
+define dso_local void @atomicrmw_fadd_half_aligned_monotonic_to_store(ptr %ptr, half %value) {
+; CHECK-LABEL: atomicrmw_fadd_half_aligned_monotonic_to_store:
+; CHECK:    ldfadd h0, h0, [x0]
+    %r = atomicrmw fadd ptr %ptr, half %value monotonic, align 2
+    ret void
+}
+
 define dso_local half @atomicrmw_fadd_half_aligned_acquire(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fadd_half_aligned_acquire:
 ; CHECK:    ldfadda h0, h0, [x0]
@@ -22,6 +29,13 @@ define dso_local half @atomicrmw_fadd_half_aligned_release(ptr %ptr, half %value
 ; CHECK:    ldfaddl h0, h0, [x0]
     %r = atomicrmw fadd ptr %ptr, half %value release, align 2
     ret half %r
+}
+
+define dso_local void @atomicrmw_fadd_half_aligned_release_to_store(ptr %ptr, half %value) {
+; CHECK-LABEL: atomicrmw_fadd_half_aligned_release_to_store:
+; CHECK:    ldfaddl h0, h0, [x0]
+    %r = atomicrmw fadd ptr %ptr, half %value release, align 2
+    ret void
 }
 
 define dso_local half @atomicrmw_fadd_half_aligned_acq_rel(ptr %ptr, half %value) {
@@ -45,6 +59,13 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_monotonic(ptr %ptr, bfloa
     ret bfloat %r
 }
 
+define dso_local void @atomicrmw_fadd_bfloat_aligned_monotonic_to_store(ptr %ptr, bfloat %value) {
+; CHECK-LABEL: atomicrmw_fadd_bfloat_aligned_monotonic_to_store:
+; CHECK:    ldbfadd h0, h0, [x0]
+    %r = atomicrmw fadd ptr %ptr, bfloat %value monotonic, align 2
+    ret void
+}
+
 define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_acquire(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fadd_bfloat_aligned_acquire:
 ; CHECK:    ldbfadda h0, h0, [x0]
@@ -57,6 +78,13 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_release(ptr %ptr, bfloat 
 ; CHECK:    ldbfaddl h0, h0, [x0]
     %r = atomicrmw fadd ptr %ptr, bfloat %value release, align 2
     ret bfloat %r
+}
+
+define dso_local void @atomicrmw_fadd_bfloat_aligned_release_to_store(ptr %ptr, bfloat %value) {
+; CHECK-LABEL: atomicrmw_fadd_bfloat_aligned_release_to_store:
+; CHECK:    ldbfaddl h0, h0, [x0]
+    %r = atomicrmw fadd ptr %ptr, bfloat %value release, align 2
+    ret void
 }
 
 define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_acq_rel(ptr %ptr, bfloat %value) {
@@ -80,6 +108,13 @@ define dso_local float @atomicrmw_fadd_float_aligned_monotonic(ptr %ptr, float %
     ret float %r
 }
 
+define dso_local void @atomicrmw_fadd_float_aligned_monotonic_to_store(ptr %ptr, float %value) {
+; CHECK-LABEL: atomicrmw_fadd_float_aligned_monotonic_to_store:
+; CHECK:    ldfadd s0, s0, [x0]
+    %r = atomicrmw fadd ptr %ptr, float %value monotonic, align 4
+    ret void
+}
+
 define dso_local float @atomicrmw_fadd_float_aligned_acquire(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fadd_float_aligned_acquire:
 ; CHECK:    ldfadda s0, s0, [x0]
@@ -92,6 +127,13 @@ define dso_local float @atomicrmw_fadd_float_aligned_release(ptr %ptr, float %va
 ; CHECK:    ldfaddl s0, s0, [x0]
     %r = atomicrmw fadd ptr %ptr, float %value release, align 4
     ret float %r
+}
+
+define dso_local void @atomicrmw_fadd_float_aligned_release_to_store(ptr %ptr, float %value) {
+; CHECK-LABEL: atomicrmw_fadd_float_aligned_release_to_store:
+; CHECK:    ldfaddl s0, s0, [x0]
+    %r = atomicrmw fadd ptr %ptr, float %value release, align 4
+    ret void
 }
 
 define dso_local float @atomicrmw_fadd_float_aligned_acq_rel(ptr %ptr, float %value) {
@@ -115,6 +157,13 @@ define dso_local double @atomicrmw_fadd_double_aligned_monotonic(ptr %ptr, doubl
     ret double %r
 }
 
+define dso_local void @atomicrmw_fadd_double_aligned_monotonic_to_store(ptr %ptr, double %value) {
+; CHECK-LABEL: atomicrmw_fadd_double_aligned_monotonic_to_store:
+; CHECK:    ldfadd d0, d0, [x0]
+    %r = atomicrmw fadd ptr %ptr, double %value monotonic, align 8
+    ret void
+}
+
 define dso_local double @atomicrmw_fadd_double_aligned_acquire(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fadd_double_aligned_acquire:
 ; CHECK:    ldfadda d0, d0, [x0]
@@ -127,6 +176,13 @@ define dso_local double @atomicrmw_fadd_double_aligned_release(ptr %ptr, double 
 ; CHECK:    ldfaddl d0, d0, [x0]
     %r = atomicrmw fadd ptr %ptr, double %value release, align 8
     ret double %r
+}
+
+define dso_local void @atomicrmw_fadd_double_aligned_release_to_store(ptr %ptr, double %value) {
+; CHECK-LABEL: atomicrmw_fadd_double_aligned_release_to_store:
+; CHECK:    ldfaddl d0, d0, [x0]
+    %r = atomicrmw fadd ptr %ptr, double %value release, align 8
+    ret void
 }
 
 define dso_local double @atomicrmw_fadd_double_aligned_acq_rel(ptr %ptr, double %value) {
@@ -805,6 +861,13 @@ define dso_local half @atomicrmw_fmax_half_aligned_monotonic(ptr %ptr, half %val
     ret half %r
 }
 
+define dso_local void @atomicrmw_fmax_half_aligned_monotonic_to_store(ptr %ptr, half %value) {
+; CHECK-LABEL: atomicrmw_fmax_half_aligned_monotonic_to_store:
+; CHECK:    ldfmaxnm h0, h0, [x0]
+    %r = atomicrmw fmax ptr %ptr, half %value monotonic, align 2
+    ret void
+}
+
 define dso_local half @atomicrmw_fmax_half_aligned_acquire(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fmax_half_aligned_acquire:
 ; CHECK:    ldfmaxnma h0, h0, [x0]
@@ -817,6 +880,13 @@ define dso_local half @atomicrmw_fmax_half_aligned_release(ptr %ptr, half %value
 ; CHECK:    ldfmaxnml h0, h0, [x0]
     %r = atomicrmw fmax ptr %ptr, half %value release, align 2
     ret half %r
+}
+
+define dso_local void @atomicrmw_fmax_half_aligned_release_to_store(ptr %ptr, half %value) {
+; CHECK-LABEL: atomicrmw_fmax_half_aligned_release_to_store:
+; CHECK:    ldfmaxnml h0, h0, [x0]
+    %r = atomicrmw fmax ptr %ptr, half %value release, align 2
+    ret void
 }
 
 define dso_local half @atomicrmw_fmax_half_aligned_acq_rel(ptr %ptr, half %value) {
@@ -840,6 +910,13 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_monotonic(ptr %ptr, bfloa
     ret bfloat %r
 }
 
+define dso_local void @atomicrmw_fmax_bfloat_aligned_monotonic_to_store(ptr %ptr, bfloat %value) {
+; CHECK-LABEL: atomicrmw_fmax_bfloat_aligned_monotonic_to_store:
+; CHECK:    ldbfmaxnm h0, h0, [x0]
+    %r = atomicrmw fmax ptr %ptr, bfloat %value monotonic, align 2
+    ret void
+}
+
 define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_acquire(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fmax_bfloat_aligned_acquire:
 ; CHECK:    ldbfmaxnma h0, h0, [x0]
@@ -852,6 +929,13 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_release(ptr %ptr, bfloat 
 ; CHECK:    ldbfmaxnml h0, h0, [x0]
     %r = atomicrmw fmax ptr %ptr, bfloat %value release, align 2
     ret bfloat %r
+}
+
+define dso_local void @atomicrmw_fmax_bfloat_aligned_release_to_store(ptr %ptr, bfloat %value) {
+; CHECK-LABEL: atomicrmw_fmax_bfloat_aligned_release_to_store:
+; CHECK:    ldbfmaxnml h0, h0, [x0]
+    %r = atomicrmw fmax ptr %ptr, bfloat %value release, align 2
+    ret void
 }
 
 define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_acq_rel(ptr %ptr, bfloat %value) {
@@ -875,6 +959,13 @@ define dso_local float @atomicrmw_fmax_float_aligned_monotonic(ptr %ptr, float %
     ret float %r
 }
 
+define dso_local void @atomicrmw_fmax_float_aligned_monotonic_to_store(ptr %ptr, float %value) {
+; CHECK-LABEL: atomicrmw_fmax_float_aligned_monotonic_to_store:
+; CHECK:    ldfmaxnm s0, s0, [x0]
+    %r = atomicrmw fmax ptr %ptr, float %value monotonic, align 4
+    ret void
+}
+
 define dso_local float @atomicrmw_fmax_float_aligned_acquire(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fmax_float_aligned_acquire:
 ; CHECK:    ldfmaxnma s0, s0, [x0]
@@ -887,6 +978,13 @@ define dso_local float @atomicrmw_fmax_float_aligned_release(ptr %ptr, float %va
 ; CHECK:    ldfmaxnml s0, s0, [x0]
     %r = atomicrmw fmax ptr %ptr, float %value release, align 4
     ret float %r
+}
+
+define dso_local void @atomicrmw_fmax_float_aligned_release_to_store(ptr %ptr, float %value) {
+; CHECK-LABEL: atomicrmw_fmax_float_aligned_release_to_store:
+; CHECK:    ldfmaxnml s0, s0, [x0]
+    %r = atomicrmw fmax ptr %ptr, float %value release, align 4
+    ret void
 }
 
 define dso_local float @atomicrmw_fmax_float_aligned_acq_rel(ptr %ptr, float %value) {
@@ -910,6 +1008,13 @@ define dso_local double @atomicrmw_fmax_double_aligned_monotonic(ptr %ptr, doubl
     ret double %r
 }
 
+define dso_local void @atomicrmw_fmax_double_aligned_monotonic_to_store(ptr %ptr, double %value) {
+; CHECK-LABEL: atomicrmw_fmax_double_aligned_monotonic_to_store:
+; CHECK:    ldfmaxnm d0, d0, [x0]
+    %r = atomicrmw fmax ptr %ptr, double %value monotonic, align 8
+    ret void
+}
+
 define dso_local double @atomicrmw_fmax_double_aligned_acquire(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fmax_double_aligned_acquire:
 ; CHECK:    ldfmaxnma d0, d0, [x0]
@@ -922,6 +1027,13 @@ define dso_local double @atomicrmw_fmax_double_aligned_release(ptr %ptr, double 
 ; CHECK:    ldfmaxnml d0, d0, [x0]
     %r = atomicrmw fmax ptr %ptr, double %value release, align 8
     ret double %r
+}
+
+define dso_local void @atomicrmw_fmax_double_aligned_release_to_store(ptr %ptr, double %value) {
+; CHECK-LABEL: atomicrmw_fmax_double_aligned_release_to_store:
+; CHECK:    ldfmaxnml d0, d0, [x0]
+    %r = atomicrmw fmax ptr %ptr, double %value release, align 8
+    ret void
 }
 
 define dso_local double @atomicrmw_fmax_double_aligned_acq_rel(ptr %ptr, double %value) {
@@ -1120,6 +1232,13 @@ define dso_local half @atomicrmw_fmin_half_aligned_monotonic(ptr %ptr, half %val
     ret half %r
 }
 
+define dso_local void @atomicrmw_fmin_half_aligned_monotonic_to_store(ptr %ptr, half %value) {
+; CHECK-LABEL: atomicrmw_fmin_half_aligned_monotonic_to_store:
+; CHECK:    ldfminnm h0, h0, [x0]
+    %r = atomicrmw fmin ptr %ptr, half %value monotonic, align 2
+    ret void
+}
+
 define dso_local half @atomicrmw_fmin_half_aligned_acquire(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fmin_half_aligned_acquire:
 ; CHECK:    ldfminnma h0, h0, [x0]
@@ -1132,6 +1251,13 @@ define dso_local half @atomicrmw_fmin_half_aligned_release(ptr %ptr, half %value
 ; CHECK:    ldfminnml h0, h0, [x0]
     %r = atomicrmw fmin ptr %ptr, half %value release, align 2
     ret half %r
+}
+
+define dso_local void @atomicrmw_fmin_half_aligned_release_to_store(ptr %ptr, half %value) {
+; CHECK-LABEL: atomicrmw_fmin_half_aligned_release_to_store:
+; CHECK:    ldfminnml h0, h0, [x0]
+    %r = atomicrmw fmin ptr %ptr, half %value release, align 2
+    ret void
 }
 
 define dso_local half @atomicrmw_fmin_half_aligned_acq_rel(ptr %ptr, half %value) {
@@ -1155,6 +1281,13 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_monotonic(ptr %ptr, bfloa
     ret bfloat %r
 }
 
+define dso_local void @atomicrmw_fmin_bfloat_aligned_monotonic_to_store(ptr %ptr, bfloat %value) {
+; CHECK-LABEL: atomicrmw_fmin_bfloat_aligned_monotonic_to_store:
+; CHECK:    ldbfminnm h0, h0, [x0]
+    %r = atomicrmw fmin ptr %ptr, bfloat %value monotonic, align 2
+    ret void
+}
+
 define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_acquire(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fmin_bfloat_aligned_acquire:
 ; CHECK:    ldbfminnma h0, h0, [x0]
@@ -1167,6 +1300,13 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_release(ptr %ptr, bfloat 
 ; CHECK:    ldbfminnml h0, h0, [x0]
     %r = atomicrmw fmin ptr %ptr, bfloat %value release, align 2
     ret bfloat %r
+}
+
+define dso_local void @atomicrmw_fmin_bfloat_aligned_release_to_store(ptr %ptr, bfloat %value) {
+; CHECK-LABEL: atomicrmw_fmin_bfloat_aligned_release_to_store:
+; CHECK:    ldbfminnml h0, h0, [x0]
+    %r = atomicrmw fmin ptr %ptr, bfloat %value release, align 2
+    ret void
 }
 
 define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_acq_rel(ptr %ptr, bfloat %value) {
@@ -1190,6 +1330,13 @@ define dso_local float @atomicrmw_fmin_float_aligned_monotonic(ptr %ptr, float %
     ret float %r
 }
 
+define dso_local void @atomicrmw_fmin_float_aligned_monotonic_to_store(ptr %ptr, float %value) {
+; CHECK-LABEL: atomicrmw_fmin_float_aligned_monotonic_to_store:
+; CHECK:    ldfminnm s0, s0, [x0]
+    %r = atomicrmw fmin ptr %ptr, float %value monotonic, align 4
+    ret void
+}
+
 define dso_local float @atomicrmw_fmin_float_aligned_acquire(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fmin_float_aligned_acquire:
 ; CHECK:    ldfminnma s0, s0, [x0]
@@ -1202,6 +1349,13 @@ define dso_local float @atomicrmw_fmin_float_aligned_release(ptr %ptr, float %va
 ; CHECK:    ldfminnml s0, s0, [x0]
     %r = atomicrmw fmin ptr %ptr, float %value release, align 4
     ret float %r
+}
+
+define dso_local void @atomicrmw_fmin_float_aligned_release_to_store(ptr %ptr, float %value) {
+; CHECK-LABEL: atomicrmw_fmin_float_aligned_release_to_store:
+; CHECK:    ldfminnml s0, s0, [x0]
+    %r = atomicrmw fmin ptr %ptr, float %value release, align 4
+    ret void
 }
 
 define dso_local float @atomicrmw_fmin_float_aligned_acq_rel(ptr %ptr, float %value) {
@@ -1225,6 +1379,13 @@ define dso_local double @atomicrmw_fmin_double_aligned_monotonic(ptr %ptr, doubl
     ret double %r
 }
 
+define dso_local void @atomicrmw_fmin_double_aligned_monotonic_to_store(ptr %ptr, double %value) {
+; CHECK-LABEL: atomicrmw_fmin_double_aligned_monotonic_to_store:
+; CHECK:    ldfminnm d0, d0, [x0]
+    %r = atomicrmw fmin ptr %ptr, double %value monotonic, align 8
+    ret void
+}
+
 define dso_local double @atomicrmw_fmin_double_aligned_acquire(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fmin_double_aligned_acquire:
 ; CHECK:    ldfminnma d0, d0, [x0]
@@ -1237,6 +1398,13 @@ define dso_local double @atomicrmw_fmin_double_aligned_release(ptr %ptr, double 
 ; CHECK:    ldfminnml d0, d0, [x0]
     %r = atomicrmw fmin ptr %ptr, double %value release, align 8
     ret double %r
+}
+
+define dso_local void @atomicrmw_fmin_double_aligned_release_to_store(ptr %ptr, double %value) {
+; CHECK-LABEL: atomicrmw_fmin_double_aligned_release_to_store:
+; CHECK:    ldfminnml d0, d0, [x0]
+    %r = atomicrmw fmin ptr %ptr, double %value release, align 8
+    ret void
 }
 
 define dso_local double @atomicrmw_fmin_double_aligned_acq_rel(ptr %ptr, double %value) {

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-lsfe.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-lsfe.ll
@@ -12,7 +12,7 @@ define dso_local half @atomicrmw_fadd_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local void @atomicrmw_fadd_half_aligned_monotonic_to_store(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fadd_half_aligned_monotonic_to_store:
-; CHECK:    ldfadd h0, h0, [x0]
+; CHECK:    stfadd h0, [x0]
     %r = atomicrmw fadd ptr %ptr, half %value monotonic, align 2
     ret void
 }
@@ -33,7 +33,7 @@ define dso_local half @atomicrmw_fadd_half_aligned_release(ptr %ptr, half %value
 
 define dso_local void @atomicrmw_fadd_half_aligned_release_to_store(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fadd_half_aligned_release_to_store:
-; CHECK:    ldfaddl h0, h0, [x0]
+; CHECK:    stfaddl h0, [x0]
     %r = atomicrmw fadd ptr %ptr, half %value release, align 2
     ret void
 }
@@ -61,7 +61,7 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_monotonic(ptr %ptr, bfloa
 
 define dso_local void @atomicrmw_fadd_bfloat_aligned_monotonic_to_store(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fadd_bfloat_aligned_monotonic_to_store:
-; CHECK:    ldbfadd h0, h0, [x0]
+; CHECK:    stbfadd h0, [x0]
     %r = atomicrmw fadd ptr %ptr, bfloat %value monotonic, align 2
     ret void
 }
@@ -82,7 +82,7 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_release(ptr %ptr, bfloat 
 
 define dso_local void @atomicrmw_fadd_bfloat_aligned_release_to_store(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fadd_bfloat_aligned_release_to_store:
-; CHECK:    ldbfaddl h0, h0, [x0]
+; CHECK:    stbfaddl h0, [x0]
     %r = atomicrmw fadd ptr %ptr, bfloat %value release, align 2
     ret void
 }
@@ -110,7 +110,7 @@ define dso_local float @atomicrmw_fadd_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local void @atomicrmw_fadd_float_aligned_monotonic_to_store(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fadd_float_aligned_monotonic_to_store:
-; CHECK:    ldfadd s0, s0, [x0]
+; CHECK:    stfadd s0, [x0]
     %r = atomicrmw fadd ptr %ptr, float %value monotonic, align 4
     ret void
 }
@@ -131,7 +131,7 @@ define dso_local float @atomicrmw_fadd_float_aligned_release(ptr %ptr, float %va
 
 define dso_local void @atomicrmw_fadd_float_aligned_release_to_store(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fadd_float_aligned_release_to_store:
-; CHECK:    ldfaddl s0, s0, [x0]
+; CHECK:    stfaddl s0, [x0]
     %r = atomicrmw fadd ptr %ptr, float %value release, align 4
     ret void
 }
@@ -159,7 +159,7 @@ define dso_local double @atomicrmw_fadd_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local void @atomicrmw_fadd_double_aligned_monotonic_to_store(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fadd_double_aligned_monotonic_to_store:
-; CHECK:    ldfadd d0, d0, [x0]
+; CHECK:    stfadd d0, [x0]
     %r = atomicrmw fadd ptr %ptr, double %value monotonic, align 8
     ret void
 }
@@ -180,7 +180,7 @@ define dso_local double @atomicrmw_fadd_double_aligned_release(ptr %ptr, double 
 
 define dso_local void @atomicrmw_fadd_double_aligned_release_to_store(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fadd_double_aligned_release_to_store:
-; CHECK:    ldfaddl d0, d0, [x0]
+; CHECK:    stfaddl d0, [x0]
     %r = atomicrmw fadd ptr %ptr, double %value release, align 8
     ret void
 }
@@ -878,7 +878,7 @@ define dso_local half @atomicrmw_fmax_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local void @atomicrmw_fmax_half_aligned_monotonic_to_store(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fmax_half_aligned_monotonic_to_store:
-; CHECK:    ldfmaxnm h0, h0, [x0]
+; CHECK:    stfmaxnm h0, [x0]
     %r = atomicrmw fmax ptr %ptr, half %value monotonic, align 2
     ret void
 }
@@ -899,7 +899,7 @@ define dso_local half @atomicrmw_fmax_half_aligned_release(ptr %ptr, half %value
 
 define dso_local void @atomicrmw_fmax_half_aligned_release_to_store(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fmax_half_aligned_release_to_store:
-; CHECK:    ldfmaxnml h0, h0, [x0]
+; CHECK:    stfmaxnml h0, [x0]
     %r = atomicrmw fmax ptr %ptr, half %value release, align 2
     ret void
 }
@@ -927,7 +927,7 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_monotonic(ptr %ptr, bfloa
 
 define dso_local void @atomicrmw_fmax_bfloat_aligned_monotonic_to_store(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fmax_bfloat_aligned_monotonic_to_store:
-; CHECK:    ldbfmaxnm h0, h0, [x0]
+; CHECK:    stbfmaxnm h0, [x0]
     %r = atomicrmw fmax ptr %ptr, bfloat %value monotonic, align 2
     ret void
 }
@@ -948,7 +948,7 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_release(ptr %ptr, bfloat 
 
 define dso_local void @atomicrmw_fmax_bfloat_aligned_release_to_store(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fmax_bfloat_aligned_release_to_store:
-; CHECK:    ldbfmaxnml h0, h0, [x0]
+; CHECK:    stbfmaxnml h0, [x0]
     %r = atomicrmw fmax ptr %ptr, bfloat %value release, align 2
     ret void
 }
@@ -976,7 +976,7 @@ define dso_local float @atomicrmw_fmax_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local void @atomicrmw_fmax_float_aligned_monotonic_to_store(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fmax_float_aligned_monotonic_to_store:
-; CHECK:    ldfmaxnm s0, s0, [x0]
+; CHECK:    stfmaxnm s0, [x0]
     %r = atomicrmw fmax ptr %ptr, float %value monotonic, align 4
     ret void
 }
@@ -997,7 +997,7 @@ define dso_local float @atomicrmw_fmax_float_aligned_release(ptr %ptr, float %va
 
 define dso_local void @atomicrmw_fmax_float_aligned_release_to_store(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fmax_float_aligned_release_to_store:
-; CHECK:    ldfmaxnml s0, s0, [x0]
+; CHECK:    stfmaxnml s0, [x0]
     %r = atomicrmw fmax ptr %ptr, float %value release, align 4
     ret void
 }
@@ -1025,7 +1025,7 @@ define dso_local double @atomicrmw_fmax_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local void @atomicrmw_fmax_double_aligned_monotonic_to_store(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fmax_double_aligned_monotonic_to_store:
-; CHECK:    ldfmaxnm d0, d0, [x0]
+; CHECK:    stfmaxnm d0, [x0]
     %r = atomicrmw fmax ptr %ptr, double %value monotonic, align 8
     ret void
 }
@@ -1046,7 +1046,7 @@ define dso_local double @atomicrmw_fmax_double_aligned_release(ptr %ptr, double 
 
 define dso_local void @atomicrmw_fmax_double_aligned_release_to_store(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fmax_double_aligned_release_to_store:
-; CHECK:    ldfmaxnml d0, d0, [x0]
+; CHECK:    stfmaxnml d0, [x0]
     %r = atomicrmw fmax ptr %ptr, double %value release, align 8
     ret void
 }
@@ -1249,7 +1249,7 @@ define dso_local half @atomicrmw_fmin_half_aligned_monotonic(ptr %ptr, half %val
 
 define dso_local void @atomicrmw_fmin_half_aligned_monotonic_to_store(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fmin_half_aligned_monotonic_to_store:
-; CHECK:    ldfminnm h0, h0, [x0]
+; CHECK:    stfminnm h0, [x0]
     %r = atomicrmw fmin ptr %ptr, half %value monotonic, align 2
     ret void
 }
@@ -1270,7 +1270,7 @@ define dso_local half @atomicrmw_fmin_half_aligned_release(ptr %ptr, half %value
 
 define dso_local void @atomicrmw_fmin_half_aligned_release_to_store(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fmin_half_aligned_release_to_store:
-; CHECK:    ldfminnml h0, h0, [x0]
+; CHECK:    stfminnml h0, [x0]
     %r = atomicrmw fmin ptr %ptr, half %value release, align 2
     ret void
 }
@@ -1298,7 +1298,7 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_monotonic(ptr %ptr, bfloa
 
 define dso_local void @atomicrmw_fmin_bfloat_aligned_monotonic_to_store(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fmin_bfloat_aligned_monotonic_to_store:
-; CHECK:    ldbfminnm h0, h0, [x0]
+; CHECK:    stbfminnm h0, [x0]
     %r = atomicrmw fmin ptr %ptr, bfloat %value monotonic, align 2
     ret void
 }
@@ -1319,7 +1319,7 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_release(ptr %ptr, bfloat 
 
 define dso_local void @atomicrmw_fmin_bfloat_aligned_release_to_store(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fmin_bfloat_aligned_release_to_store:
-; CHECK:    ldbfminnml h0, h0, [x0]
+; CHECK:    stbfminnml h0, [x0]
     %r = atomicrmw fmin ptr %ptr, bfloat %value release, align 2
     ret void
 }
@@ -1347,7 +1347,7 @@ define dso_local float @atomicrmw_fmin_float_aligned_monotonic(ptr %ptr, float %
 
 define dso_local void @atomicrmw_fmin_float_aligned_monotonic_to_store(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fmin_float_aligned_monotonic_to_store:
-; CHECK:    ldfminnm s0, s0, [x0]
+; CHECK:    stfminnm s0, [x0]
     %r = atomicrmw fmin ptr %ptr, float %value monotonic, align 4
     ret void
 }
@@ -1368,7 +1368,7 @@ define dso_local float @atomicrmw_fmin_float_aligned_release(ptr %ptr, float %va
 
 define dso_local void @atomicrmw_fmin_float_aligned_release_to_store(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fmin_float_aligned_release_to_store:
-; CHECK:    ldfminnml s0, s0, [x0]
+; CHECK:    stfminnml s0, [x0]
     %r = atomicrmw fmin ptr %ptr, float %value release, align 4
     ret void
 }
@@ -1396,7 +1396,7 @@ define dso_local double @atomicrmw_fmin_double_aligned_monotonic(ptr %ptr, doubl
 
 define dso_local void @atomicrmw_fmin_double_aligned_monotonic_to_store(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fmin_double_aligned_monotonic_to_store:
-; CHECK:    ldfminnm d0, d0, [x0]
+; CHECK:    stfminnm d0, [x0]
     %r = atomicrmw fmin ptr %ptr, double %value monotonic, align 8
     ret void
 }
@@ -1417,7 +1417,7 @@ define dso_local double @atomicrmw_fmin_double_aligned_release(ptr %ptr, double 
 
 define dso_local void @atomicrmw_fmin_double_aligned_release_to_store(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fmin_double_aligned_release_to_store:
-; CHECK:    ldfminnml d0, d0, [x0]
+; CHECK:    stfminnml d0, [x0]
     %r = atomicrmw fmin ptr %ptr, double %value release, align 8
     ret void
 }

--- a/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-lsfe.ll
+++ b/llvm/test/CodeGen/AArch64/Atomics/aarch64_be-atomicrmw-lsfe.ll
@@ -10,6 +10,13 @@ define dso_local half @atomicrmw_fadd_half_aligned_monotonic(ptr %ptr, half %val
     ret half %r
 }
 
+define dso_local void @atomicrmw_fadd_half_aligned_monotonic_to_store(ptr %ptr, half %value) {
+; CHECK-LABEL: atomicrmw_fadd_half_aligned_monotonic_to_store:
+; CHECK:    ldfadd h0, h0, [x0]
+    %r = atomicrmw fadd ptr %ptr, half %value monotonic, align 2
+    ret void
+}
+
 define dso_local half @atomicrmw_fadd_half_aligned_acquire(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fadd_half_aligned_acquire:
 ; CHECK:    ldfadda h0, h0, [x0]
@@ -22,6 +29,13 @@ define dso_local half @atomicrmw_fadd_half_aligned_release(ptr %ptr, half %value
 ; CHECK:    ldfaddl h0, h0, [x0]
     %r = atomicrmw fadd ptr %ptr, half %value release, align 2
     ret half %r
+}
+
+define dso_local void @atomicrmw_fadd_half_aligned_release_to_store(ptr %ptr, half %value) {
+; CHECK-LABEL: atomicrmw_fadd_half_aligned_release_to_store:
+; CHECK:    ldfaddl h0, h0, [x0]
+    %r = atomicrmw fadd ptr %ptr, half %value release, align 2
+    ret void
 }
 
 define dso_local half @atomicrmw_fadd_half_aligned_acq_rel(ptr %ptr, half %value) {
@@ -45,6 +59,13 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_monotonic(ptr %ptr, bfloa
     ret bfloat %r
 }
 
+define dso_local void @atomicrmw_fadd_bfloat_aligned_monotonic_to_store(ptr %ptr, bfloat %value) {
+; CHECK-LABEL: atomicrmw_fadd_bfloat_aligned_monotonic_to_store:
+; CHECK:    ldbfadd h0, h0, [x0]
+    %r = atomicrmw fadd ptr %ptr, bfloat %value monotonic, align 2
+    ret void
+}
+
 define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_acquire(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fadd_bfloat_aligned_acquire:
 ; CHECK:    ldbfadda h0, h0, [x0]
@@ -57,6 +78,13 @@ define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_release(ptr %ptr, bfloat 
 ; CHECK:    ldbfaddl h0, h0, [x0]
     %r = atomicrmw fadd ptr %ptr, bfloat %value release, align 2
     ret bfloat %r
+}
+
+define dso_local void @atomicrmw_fadd_bfloat_aligned_release_to_store(ptr %ptr, bfloat %value) {
+; CHECK-LABEL: atomicrmw_fadd_bfloat_aligned_release_to_store:
+; CHECK:    ldbfaddl h0, h0, [x0]
+    %r = atomicrmw fadd ptr %ptr, bfloat %value release, align 2
+    ret void
 }
 
 define dso_local bfloat @atomicrmw_fadd_bfloat_aligned_acq_rel(ptr %ptr, bfloat %value) {
@@ -80,6 +108,13 @@ define dso_local float @atomicrmw_fadd_float_aligned_monotonic(ptr %ptr, float %
     ret float %r
 }
 
+define dso_local void @atomicrmw_fadd_float_aligned_monotonic_to_store(ptr %ptr, float %value) {
+; CHECK-LABEL: atomicrmw_fadd_float_aligned_monotonic_to_store:
+; CHECK:    ldfadd s0, s0, [x0]
+    %r = atomicrmw fadd ptr %ptr, float %value monotonic, align 4
+    ret void
+}
+
 define dso_local float @atomicrmw_fadd_float_aligned_acquire(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fadd_float_aligned_acquire:
 ; CHECK:    ldfadda s0, s0, [x0]
@@ -92,6 +127,13 @@ define dso_local float @atomicrmw_fadd_float_aligned_release(ptr %ptr, float %va
 ; CHECK:    ldfaddl s0, s0, [x0]
     %r = atomicrmw fadd ptr %ptr, float %value release, align 4
     ret float %r
+}
+
+define dso_local void @atomicrmw_fadd_float_aligned_release_to_store(ptr %ptr, float %value) {
+; CHECK-LABEL: atomicrmw_fadd_float_aligned_release_to_store:
+; CHECK:    ldfaddl s0, s0, [x0]
+    %r = atomicrmw fadd ptr %ptr, float %value release, align 4
+    ret void
 }
 
 define dso_local float @atomicrmw_fadd_float_aligned_acq_rel(ptr %ptr, float %value) {
@@ -115,6 +157,13 @@ define dso_local double @atomicrmw_fadd_double_aligned_monotonic(ptr %ptr, doubl
     ret double %r
 }
 
+define dso_local void @atomicrmw_fadd_double_aligned_monotonic_to_store(ptr %ptr, double %value) {
+; CHECK-LABEL: atomicrmw_fadd_double_aligned_monotonic_to_store:
+; CHECK:    ldfadd d0, d0, [x0]
+    %r = atomicrmw fadd ptr %ptr, double %value monotonic, align 8
+    ret void
+}
+
 define dso_local double @atomicrmw_fadd_double_aligned_acquire(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fadd_double_aligned_acquire:
 ; CHECK:    ldfadda d0, d0, [x0]
@@ -127,6 +176,13 @@ define dso_local double @atomicrmw_fadd_double_aligned_release(ptr %ptr, double 
 ; CHECK:    ldfaddl d0, d0, [x0]
     %r = atomicrmw fadd ptr %ptr, double %value release, align 8
     ret double %r
+}
+
+define dso_local void @atomicrmw_fadd_double_aligned_release_to_store(ptr %ptr, double %value) {
+; CHECK-LABEL: atomicrmw_fadd_double_aligned_release_to_store:
+; CHECK:    ldfaddl d0, d0, [x0]
+    %r = atomicrmw fadd ptr %ptr, double %value release, align 8
+    ret void
 }
 
 define dso_local double @atomicrmw_fadd_double_aligned_acq_rel(ptr %ptr, double %value) {
@@ -820,6 +876,13 @@ define dso_local half @atomicrmw_fmax_half_aligned_monotonic(ptr %ptr, half %val
     ret half %r
 }
 
+define dso_local void @atomicrmw_fmax_half_aligned_monotonic_to_store(ptr %ptr, half %value) {
+; CHECK-LABEL: atomicrmw_fmax_half_aligned_monotonic_to_store:
+; CHECK:    ldfmaxnm h0, h0, [x0]
+    %r = atomicrmw fmax ptr %ptr, half %value monotonic, align 2
+    ret void
+}
+
 define dso_local half @atomicrmw_fmax_half_aligned_acquire(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fmax_half_aligned_acquire:
 ; CHECK:    ldfmaxnma h0, h0, [x0]
@@ -832,6 +895,13 @@ define dso_local half @atomicrmw_fmax_half_aligned_release(ptr %ptr, half %value
 ; CHECK:    ldfmaxnml h0, h0, [x0]
     %r = atomicrmw fmax ptr %ptr, half %value release, align 2
     ret half %r
+}
+
+define dso_local void @atomicrmw_fmax_half_aligned_release_to_store(ptr %ptr, half %value) {
+; CHECK-LABEL: atomicrmw_fmax_half_aligned_release_to_store:
+; CHECK:    ldfmaxnml h0, h0, [x0]
+    %r = atomicrmw fmax ptr %ptr, half %value release, align 2
+    ret void
 }
 
 define dso_local half @atomicrmw_fmax_half_aligned_acq_rel(ptr %ptr, half %value) {
@@ -855,6 +925,13 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_monotonic(ptr %ptr, bfloa
     ret bfloat %r
 }
 
+define dso_local void @atomicrmw_fmax_bfloat_aligned_monotonic_to_store(ptr %ptr, bfloat %value) {
+; CHECK-LABEL: atomicrmw_fmax_bfloat_aligned_monotonic_to_store:
+; CHECK:    ldbfmaxnm h0, h0, [x0]
+    %r = atomicrmw fmax ptr %ptr, bfloat %value monotonic, align 2
+    ret void
+}
+
 define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_acquire(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fmax_bfloat_aligned_acquire:
 ; CHECK:    ldbfmaxnma h0, h0, [x0]
@@ -867,6 +944,13 @@ define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_release(ptr %ptr, bfloat 
 ; CHECK:    ldbfmaxnml h0, h0, [x0]
     %r = atomicrmw fmax ptr %ptr, bfloat %value release, align 2
     ret bfloat %r
+}
+
+define dso_local void @atomicrmw_fmax_bfloat_aligned_release_to_store(ptr %ptr, bfloat %value) {
+; CHECK-LABEL: atomicrmw_fmax_bfloat_aligned_release_to_store:
+; CHECK:    ldbfmaxnml h0, h0, [x0]
+    %r = atomicrmw fmax ptr %ptr, bfloat %value release, align 2
+    ret void
 }
 
 define dso_local bfloat @atomicrmw_fmax_bfloat_aligned_acq_rel(ptr %ptr, bfloat %value) {
@@ -890,6 +974,13 @@ define dso_local float @atomicrmw_fmax_float_aligned_monotonic(ptr %ptr, float %
     ret float %r
 }
 
+define dso_local void @atomicrmw_fmax_float_aligned_monotonic_to_store(ptr %ptr, float %value) {
+; CHECK-LABEL: atomicrmw_fmax_float_aligned_monotonic_to_store:
+; CHECK:    ldfmaxnm s0, s0, [x0]
+    %r = atomicrmw fmax ptr %ptr, float %value monotonic, align 4
+    ret void
+}
+
 define dso_local float @atomicrmw_fmax_float_aligned_acquire(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fmax_float_aligned_acquire:
 ; CHECK:    ldfmaxnma s0, s0, [x0]
@@ -902,6 +993,13 @@ define dso_local float @atomicrmw_fmax_float_aligned_release(ptr %ptr, float %va
 ; CHECK:    ldfmaxnml s0, s0, [x0]
     %r = atomicrmw fmax ptr %ptr, float %value release, align 4
     ret float %r
+}
+
+define dso_local void @atomicrmw_fmax_float_aligned_release_to_store(ptr %ptr, float %value) {
+; CHECK-LABEL: atomicrmw_fmax_float_aligned_release_to_store:
+; CHECK:    ldfmaxnml s0, s0, [x0]
+    %r = atomicrmw fmax ptr %ptr, float %value release, align 4
+    ret void
 }
 
 define dso_local float @atomicrmw_fmax_float_aligned_acq_rel(ptr %ptr, float %value) {
@@ -925,6 +1023,13 @@ define dso_local double @atomicrmw_fmax_double_aligned_monotonic(ptr %ptr, doubl
     ret double %r
 }
 
+define dso_local void @atomicrmw_fmax_double_aligned_monotonic_to_store(ptr %ptr, double %value) {
+; CHECK-LABEL: atomicrmw_fmax_double_aligned_monotonic_to_store:
+; CHECK:    ldfmaxnm d0, d0, [x0]
+    %r = atomicrmw fmax ptr %ptr, double %value monotonic, align 8
+    ret void
+}
+
 define dso_local double @atomicrmw_fmax_double_aligned_acquire(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fmax_double_aligned_acquire:
 ; CHECK:    ldfmaxnma d0, d0, [x0]
@@ -937,6 +1042,13 @@ define dso_local double @atomicrmw_fmax_double_aligned_release(ptr %ptr, double 
 ; CHECK:    ldfmaxnml d0, d0, [x0]
     %r = atomicrmw fmax ptr %ptr, double %value release, align 8
     ret double %r
+}
+
+define dso_local void @atomicrmw_fmax_double_aligned_release_to_store(ptr %ptr, double %value) {
+; CHECK-LABEL: atomicrmw_fmax_double_aligned_release_to_store:
+; CHECK:    ldfmaxnml d0, d0, [x0]
+    %r = atomicrmw fmax ptr %ptr, double %value release, align 8
+    ret void
 }
 
 define dso_local double @atomicrmw_fmax_double_aligned_acq_rel(ptr %ptr, double %value) {
@@ -1135,6 +1247,13 @@ define dso_local half @atomicrmw_fmin_half_aligned_monotonic(ptr %ptr, half %val
     ret half %r
 }
 
+define dso_local void @atomicrmw_fmin_half_aligned_monotonic_to_store(ptr %ptr, half %value) {
+; CHECK-LABEL: atomicrmw_fmin_half_aligned_monotonic_to_store:
+; CHECK:    ldfminnm h0, h0, [x0]
+    %r = atomicrmw fmin ptr %ptr, half %value monotonic, align 2
+    ret void
+}
+
 define dso_local half @atomicrmw_fmin_half_aligned_acquire(ptr %ptr, half %value) {
 ; CHECK-LABEL: atomicrmw_fmin_half_aligned_acquire:
 ; CHECK:    ldfminnma h0, h0, [x0]
@@ -1147,6 +1266,13 @@ define dso_local half @atomicrmw_fmin_half_aligned_release(ptr %ptr, half %value
 ; CHECK:    ldfminnml h0, h0, [x0]
     %r = atomicrmw fmin ptr %ptr, half %value release, align 2
     ret half %r
+}
+
+define dso_local void @atomicrmw_fmin_half_aligned_release_to_store(ptr %ptr, half %value) {
+; CHECK-LABEL: atomicrmw_fmin_half_aligned_release_to_store:
+; CHECK:    ldfminnml h0, h0, [x0]
+    %r = atomicrmw fmin ptr %ptr, half %value release, align 2
+    ret void
 }
 
 define dso_local half @atomicrmw_fmin_half_aligned_acq_rel(ptr %ptr, half %value) {
@@ -1170,6 +1296,13 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_monotonic(ptr %ptr, bfloa
     ret bfloat %r
 }
 
+define dso_local void @atomicrmw_fmin_bfloat_aligned_monotonic_to_store(ptr %ptr, bfloat %value) {
+; CHECK-LABEL: atomicrmw_fmin_bfloat_aligned_monotonic_to_store:
+; CHECK:    ldbfminnm h0, h0, [x0]
+    %r = atomicrmw fmin ptr %ptr, bfloat %value monotonic, align 2
+    ret void
+}
+
 define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_acquire(ptr %ptr, bfloat %value) {
 ; CHECK-LABEL: atomicrmw_fmin_bfloat_aligned_acquire:
 ; CHECK:    ldbfminnma h0, h0, [x0]
@@ -1182,6 +1315,13 @@ define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_release(ptr %ptr, bfloat 
 ; CHECK:    ldbfminnml h0, h0, [x0]
     %r = atomicrmw fmin ptr %ptr, bfloat %value release, align 2
     ret bfloat %r
+}
+
+define dso_local void @atomicrmw_fmin_bfloat_aligned_release_to_store(ptr %ptr, bfloat %value) {
+; CHECK-LABEL: atomicrmw_fmin_bfloat_aligned_release_to_store:
+; CHECK:    ldbfminnml h0, h0, [x0]
+    %r = atomicrmw fmin ptr %ptr, bfloat %value release, align 2
+    ret void
 }
 
 define dso_local bfloat @atomicrmw_fmin_bfloat_aligned_acq_rel(ptr %ptr, bfloat %value) {
@@ -1205,6 +1345,13 @@ define dso_local float @atomicrmw_fmin_float_aligned_monotonic(ptr %ptr, float %
     ret float %r
 }
 
+define dso_local void @atomicrmw_fmin_float_aligned_monotonic_to_store(ptr %ptr, float %value) {
+; CHECK-LABEL: atomicrmw_fmin_float_aligned_monotonic_to_store:
+; CHECK:    ldfminnm s0, s0, [x0]
+    %r = atomicrmw fmin ptr %ptr, float %value monotonic, align 4
+    ret void
+}
+
 define dso_local float @atomicrmw_fmin_float_aligned_acquire(ptr %ptr, float %value) {
 ; CHECK-LABEL: atomicrmw_fmin_float_aligned_acquire:
 ; CHECK:    ldfminnma s0, s0, [x0]
@@ -1217,6 +1364,13 @@ define dso_local float @atomicrmw_fmin_float_aligned_release(ptr %ptr, float %va
 ; CHECK:    ldfminnml s0, s0, [x0]
     %r = atomicrmw fmin ptr %ptr, float %value release, align 4
     ret float %r
+}
+
+define dso_local void @atomicrmw_fmin_float_aligned_release_to_store(ptr %ptr, float %value) {
+; CHECK-LABEL: atomicrmw_fmin_float_aligned_release_to_store:
+; CHECK:    ldfminnml s0, s0, [x0]
+    %r = atomicrmw fmin ptr %ptr, float %value release, align 4
+    ret void
 }
 
 define dso_local float @atomicrmw_fmin_float_aligned_acq_rel(ptr %ptr, float %value) {
@@ -1240,6 +1394,13 @@ define dso_local double @atomicrmw_fmin_double_aligned_monotonic(ptr %ptr, doubl
     ret double %r
 }
 
+define dso_local void @atomicrmw_fmin_double_aligned_monotonic_to_store(ptr %ptr, double %value) {
+; CHECK-LABEL: atomicrmw_fmin_double_aligned_monotonic_to_store:
+; CHECK:    ldfminnm d0, d0, [x0]
+    %r = atomicrmw fmin ptr %ptr, double %value monotonic, align 8
+    ret void
+}
+
 define dso_local double @atomicrmw_fmin_double_aligned_acquire(ptr %ptr, double %value) {
 ; CHECK-LABEL: atomicrmw_fmin_double_aligned_acquire:
 ; CHECK:    ldfminnma d0, d0, [x0]
@@ -1252,6 +1413,13 @@ define dso_local double @atomicrmw_fmin_double_aligned_release(ptr %ptr, double 
 ; CHECK:    ldfminnml d0, d0, [x0]
     %r = atomicrmw fmin ptr %ptr, double %value release, align 8
     ret double %r
+}
+
+define dso_local void @atomicrmw_fmin_double_aligned_release_to_store(ptr %ptr, double %value) {
+; CHECK-LABEL: atomicrmw_fmin_double_aligned_release_to_store:
+; CHECK:    ldfminnml d0, d0, [x0]
+    %r = atomicrmw fmin ptr %ptr, double %value release, align 8
+    ret void
 }
 
 define dso_local double @atomicrmw_fmin_double_aligned_acq_rel(ptr %ptr, double %value) {

--- a/llvm/test/CodeGen/AArch64/Atomics/generate-tests.py
+++ b/llvm/test/CodeGen/AArch64/Atomics/generate-tests.py
@@ -190,11 +190,11 @@ def relpath():
 
 
 def generate_store_opt_test(featname, ordering, op, alignval):
-  if featname != 'lsfe' or op == 'fsub' or alignval == 1:
-    return False
-  if ordering not in [AtomicOrder.monotonic, AtomicOrder.release]:
-    return False
-  return True;
+    if featname != "lsfe" or op == "fsub" or alignval == 1:
+        return False
+    if ordering not in [AtomicOrder.monotonic, AtomicOrder.release]:
+        return False
+    return True
 
 
 def align(val, aligned: bool) -> int:
@@ -222,14 +222,14 @@ def all_atomicrmw(f, datatype, atomicrmw_ops, featname):
                     if generate_store_opt_test(featname, ordering, op, alignval):
                         name = f"atomicrmw_{op}_{ty}_{aligned}_{ordering}_to_store"
                         f.write(
-                           textwrap.dedent(
-                               f"""
+                            textwrap.dedent(
+                                f"""
                            define dso_local void @{name}(ptr %ptr, {ty} %value) {{
                                %r = {instr} {op} ptr %ptr, {ty} %value {ordering}, align {alignval}
                                ret void
                            }}
                         """
-                           )
+                            )
                         )
 
 


### PR DESCRIPTION
When FEAT_LSFE is enabled, the ST{B}FADD, ST{B}FMAX and ST{B}FMIN
atomic instructions are available. This patch adds patterns to match an
atomicrmw fadd, fmin or fmax to these instructions when the result is unused.