### PR TITLE
 [profile] Implement a non-mmap path when reading profile files from a non-local filesystem

### DIFF
--- a/compiler-rt/lib/profile/InstrProfilingFile.c
+++ b/compiler-rt/lib/profile/InstrProfilingFile.c
@@ -431,7 +431,7 @@ static int mmapProfileForMerging(FILE *ProfileFile, uint64_t ProfileFileSize,
                                  ManagedMemory *ProfileBuffer) {
   lprofGetFileContentBuffer(ProfileFile, ProfileFileSize, ProfileBuffer);
 
-  if (ProfileBuffer->Status == MM_INVALID) {
+  if (ProfileBuffer->Status == MS_INVALID) {
     PROF_ERR("Unable to merge profile data: %s\n", "reading file failed");
     return -1;
   }

--- a/compiler-rt/lib/profile/InstrProfilingFile.c
+++ b/compiler-rt/lib/profile/InstrProfilingFile.c
@@ -428,17 +428,18 @@ static int getProfileFileSizeForMerging(FILE *ProfileFile,
  * \p ProfileBuffer. Returns -1 on failure. On success, the caller is
  * responsible for unmapping the mmap'd buffer in \p ProfileBuffer. */
 static int mmapProfileForMerging(FILE *ProfileFile, uint64_t ProfileFileSize,
-                                 char **ProfileBuffer) {
-  *ProfileBuffer = mmap(NULL, ProfileFileSize, PROT_READ, MAP_SHARED | MAP_FILE,
-                        fileno(ProfileFile), 0);
-  if (*ProfileBuffer == MAP_FAILED) {
+                                 ManagedMemory *ProfileBuffer) {
+  lprofGetFileContentBuffer(ProfileFile, ProfileFileSize, ProfileBuffer);
+
+  if (ProfileBuffer->Status == MM_INVALID) {
     PROF_ERR("Unable to merge profile data, mmap failed: %s\n",
              strerror(errno));
     return -1;
   }
 
-  if (__llvm_profile_check_compatibility(*ProfileBuffer, ProfileFileSize)) {
-    (void)munmap(*ProfileBuffer, ProfileFileSize);
+  if (__llvm_profile_check_compatibility(ProfileBuffer->Addr,
+                                         ProfileFileSize)) {
+    (void)lprofReleaseBuffer(ProfileBuffer, ProfileFileSize);
     PROF_WARN("Unable to merge profile data: %s\n",
               "source profile file is not compatible.");
     return -1;
@@ -453,7 +454,7 @@ static int mmapProfileForMerging(FILE *ProfileFile, uint64_t ProfileFileSize,
 */
 static int doProfileMerging(FILE *ProfileFile, int *MergeDone) {
   uint64_t ProfileFileSize;
-  char *ProfileBuffer;
+  ManagedMemory ProfileBuffer;
 
   /* Get the size of the profile on disk. */
   if (getProfileFileSizeForMerging(ProfileFile, &ProfileFileSize) == -1)
@@ -469,9 +470,9 @@ static int doProfileMerging(FILE *ProfileFile, int *MergeDone) {
     return -1;
 
   /* Now start merging */
-  if (__llvm_profile_merge_from_buffer(ProfileBuffer, ProfileFileSize)) {
+  if (__llvm_profile_merge_from_buffer(ProfileBuffer.Addr, ProfileFileSize)) {
     PROF_ERR("%s\n", "Invalid profile data to merge");
-    (void)munmap(ProfileBuffer, ProfileFileSize);
+    (void)lprofReleaseBuffer(&ProfileBuffer, ProfileFileSize);
     return -1;
   }
 
@@ -480,7 +481,7 @@ static int doProfileMerging(FILE *ProfileFile, int *MergeDone) {
   (void)COMPILER_RT_FTRUNCATE(ProfileFile,
                               __llvm_profile_get_size_for_buffer());
 
-  (void)munmap(ProfileBuffer, ProfileFileSize);
+  (void)lprofReleaseBuffer(&ProfileBuffer, ProfileFileSize);
   *MergeDone = 1;
 
   return 0;
@@ -702,13 +703,13 @@ static void initializeProfileForContinuousMode(void) {
     } else {
       /* The merged profile has a non-zero length. Check that it is compatible
        * with the data in this process. */
-      char *ProfileBuffer;
+      ManagedMemory ProfileBuffer;
       if (mmapProfileForMerging(File, ProfileFileSize, &ProfileBuffer) == -1) {
         lprofUnlockFileHandle(File);
         fclose(File);
         return;
       }
-      (void)munmap(ProfileBuffer, ProfileFileSize);
+      (void)lprofReleaseBuffer(&ProfileBuffer, ProfileFileSize);
     }
   } else {
     File = fopen(Filename, FileOpenMode);
@@ -1346,12 +1347,12 @@ COMPILER_RT_VISIBILITY int __llvm_profile_set_file_object(FILE *File,
     } else {
       /* The merged profile has a non-zero length. Check that it is compatible
        * with the data in this process. */
-      char *ProfileBuffer;
+      ManagedMemory ProfileBuffer;
       if (mmapProfileForMerging(File, ProfileFileSize, &ProfileBuffer) == -1) {
         lprofUnlockFileHandle(File);
         return 1;
       }
-      (void)munmap(ProfileBuffer, ProfileFileSize);
+      (void)lprofReleaseBuffer(&ProfileBuffer, ProfileFileSize);
     }
     mmapForContinuousMode(0, File);
     lprofUnlockFileHandle(File);

--- a/compiler-rt/lib/profile/InstrProfilingFile.c
+++ b/compiler-rt/lib/profile/InstrProfilingFile.c
@@ -432,8 +432,7 @@ static int mmapProfileForMerging(FILE *ProfileFile, uint64_t ProfileFileSize,
   lprofGetFileContentBuffer(ProfileFile, ProfileFileSize, ProfileBuffer);
 
   if (ProfileBuffer->Status == MM_INVALID) {
-    PROF_ERR("Unable to merge profile data, mmap failed: %s\n",
-             strerror(errno));
+    PROF_ERR("Unable to merge profile data: %s\n", "reading file failed");
     return -1;
   }
 

--- a/compiler-rt/lib/profile/InstrProfilingPort.h
+++ b/compiler-rt/lib/profile/InstrProfilingPort.h
@@ -23,6 +23,7 @@
 #define COMPILER_RT_FTRUNCATE(f,l) _chsize(_fileno(f),l)
 #define COMPILER_RT_ALWAYS_INLINE __forceinline
 #define COMPILER_RT_CLEANUP(x)
+#define COMPILER_RT_UNUSED
 #define COMPILER_RT_USED
 #elif __GNUC__
 #ifdef _WIN32
@@ -38,6 +39,7 @@
 #define COMPILER_RT_ALLOCA __builtin_alloca
 #define COMPILER_RT_ALWAYS_INLINE inline __attribute((always_inline))
 #define COMPILER_RT_CLEANUP(x) __attribute__((cleanup(x)))
+#define COMPILER_RT_UNUSED __attribute__((unused))
 #define COMPILER_RT_USED __attribute__((used))
 #endif
 

--- a/compiler-rt/lib/profile/InstrProfilingUtil.c
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.c
@@ -267,10 +267,10 @@ COMPILER_RT_VISIBILITY FILE *lprofOpenFileEx(const char *ProfileName) {
   return f;
 }
 
+#if defined(_AIX)
 // Return 1 (true) if the file descriptor Fd represents a file that is on a
 // local filesystem, otherwise return 0.
-COMPILER_RT_UNUSED static int is_local_filesystem(int Fd) {
-#if defined(_AIX)
+static int isLocalFilesystem(int Fd) {
   struct statfs Vfs;
   if (fstatfs(Fd, &Vfs) != 0) {
     PROF_ERR("%s: fstatfs(%d) failed: %s\n", __func__, Fd, strerror(errno));
@@ -310,15 +310,15 @@ COMPILER_RT_UNUSED static int is_local_filesystem(int Fd) {
   free(Buf);
   // There was an error in mntctl or vmount entry not found; "remote" is the
   // conservative answer.
-#endif
   return 0;
 }
+#endif
 
 static int isMmapSafe(int Fd) {
-  if (getenv("LLVM_NO_MMAP")) // For testing purposes.
+  if (getenv("LLVM_PROFILE_NO_MMAP")) // For testing purposes.
     return 0;
 #ifdef _AIX
-  return is_local_filesystem(Fd);
+  return isLocalFilesystem(Fd);
 #else
   return 1;
 #endif

--- a/compiler-rt/lib/profile/InstrProfilingUtil.c
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.c
@@ -372,7 +372,7 @@ void lprofReleaseBuffer(ManagedMemory *Buf, size_t Length) {
     free(Buf->Addr);
     break;
   case MM_MMAP:
-    munmap(Buf->Addr, Length);
+    (void)munmap(Buf->Addr, Length);
     break;
   default:
     PROF_ERR("%s: Buffer has invalid state: %d\n", __func__, Buf->Status);

--- a/compiler-rt/lib/profile/InstrProfilingUtil.c
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.c
@@ -283,6 +283,7 @@ static int is_local_filesystem(int Fd) {
   int Tries = 3;
   while (Tries--) {
     Buf = malloc(BufSize);
+    // mntctl returns -1 if `Buf` is `NULL`.
     Ret = mntctl(MCTL_QUERY, BufSize, Buf);
     if (Ret != 0)
       break;

--- a/compiler-rt/lib/profile/InstrProfilingUtil.c
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.c
@@ -319,8 +319,9 @@ static int isMmapSafe(int Fd) {
   (void)&is_local_filesystem; // a fake reference to satisfy -Wunused-function
 #ifdef _AIX
   return is_local_filesystem(Fd);
-#endif
+#else
   return 1;
+#endif
 }
 
 COMPILER_RT_VISIBILITY void lprofGetFileContentBuffer(FILE *F, uint64_t Length,

--- a/compiler-rt/lib/profile/InstrProfilingUtil.c
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.c
@@ -365,6 +365,7 @@ COMPILER_RT_VISIBILITY void lprofGetFileContentBuffer(FILE *F, uint64_t Length,
   Buf->Status = MM_MALLOC;
 }
 
+COMPILER_RT_VISIBILITY
 void lprofReleaseBuffer(ManagedMemory *Buf, size_t Length) {
   switch (Buf->Status) {
   case MM_MALLOC:

--- a/compiler-rt/lib/profile/InstrProfilingUtil.c
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.c
@@ -373,7 +373,7 @@ void lprofReleaseBuffer(ManagedMemory *Buf, size_t Length) {
   case MM_MMAP:
     munmap(Buf->Addr, Length);
     break;
-  case MM_INVALID:
+  default:
     PROF_ERR("%s: Buffer has invalid state: %d\n", __func__, Buf->Status);
     break;
   }

--- a/compiler-rt/lib/profile/InstrProfilingUtil.c
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.c
@@ -269,7 +269,7 @@ COMPILER_RT_VISIBILITY FILE *lprofOpenFileEx(const char *ProfileName) {
 
 // Return 1 (true) if the file descriptor Fd represents a file that is on a
 // local filesystem, otherwise return 0.
-static int is_local_filesystem(int Fd) {
+COMPILER_RT_UNUSED static int is_local_filesystem(int Fd) {
 #if defined(_AIX)
   struct statfs Vfs;
   if (fstatfs(Fd, &Vfs) != 0) {
@@ -317,7 +317,6 @@ static int is_local_filesystem(int Fd) {
 static int isMmapSafe(int Fd) {
   if (getenv("LLVM_NO_MMAP")) // For testing purposes.
     return 0;
-  (void)&is_local_filesystem; // a fake reference to satisfy -Wunused-function
 #ifdef _AIX
   return is_local_filesystem(Fd);
 #else

--- a/compiler-rt/lib/profile/InstrProfilingUtil.c
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.c
@@ -338,7 +338,7 @@ COMPILER_RT_VISIBILITY void lprofGetFileContentBuffer(FILE *F, uint64_t Length,
   }
 
   if (getenv("LLVM_PROFILE_VERBOSE"))
-    PROF_NOTE("%s\n", "Could not use mmap; using fread instead.");
+    PROF_NOTE("%s\n", "could not use mmap; using fread instead");
 
   void *Buffer = malloc(Length);
   if (!Buffer) {

--- a/compiler-rt/lib/profile/InstrProfilingUtil.c
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.c
@@ -326,14 +326,14 @@ static int isMmapSafe(int Fd) {
 
 COMPILER_RT_VISIBILITY void lprofGetFileContentBuffer(FILE *F, uint64_t Length,
                                                       ManagedMemory *Buf) {
-  Buf->Status = MM_INVALID;
+  Buf->Status = MS_INVALID;
   if (isMmapSafe(fileno(F))) {
     Buf->Addr =
         mmap(NULL, Length, PROT_READ, MAP_SHARED | MAP_FILE, fileno(F), 0);
     if (Buf->Addr == MAP_FAILED)
       PROF_ERR("%s: mmap failed: %s\n", __func__, strerror(errno))
     else
-      Buf->Status = MM_MMAP;
+      Buf->Status = MS_MMAP;
     return;
   }
 
@@ -362,16 +362,16 @@ COMPILER_RT_VISIBILITY void lprofGetFileContentBuffer(FILE *F, uint64_t Length,
 
   // Reading was successful, record the result in the Buf parameter.
   Buf->Addr = Buffer;
-  Buf->Status = MM_MALLOC;
+  Buf->Status = MS_MALLOC;
 }
 
 COMPILER_RT_VISIBILITY
 void lprofReleaseBuffer(ManagedMemory *Buf, size_t Length) {
   switch (Buf->Status) {
-  case MM_MALLOC:
+  case MS_MALLOC:
     free(Buf->Addr);
     break;
-  case MM_MMAP:
+  case MS_MMAP:
     (void)munmap(Buf->Addr, Length);
     break;
   default:
@@ -379,7 +379,7 @@ void lprofReleaseBuffer(ManagedMemory *Buf, size_t Length) {
     break;
   }
   Buf->Addr = NULL;
-  Buf->Status = MM_INVALID;
+  Buf->Status = MS_INVALID;
 }
 
 COMPILER_RT_VISIBILITY const char *lprofGetPathPrefix(int *PrefixStrip,

--- a/compiler-rt/lib/profile/InstrProfilingUtil.c
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.c
@@ -354,7 +354,7 @@ COMPILER_RT_VISIBILITY void lprofGetFileContentBuffer(FILE *F, uint64_t Length,
   size_t BytesRead = fread(Buffer, 1, Length, F);
   if (BytesRead != (size_t)Length) {
     PROF_ERR("%s: fread failed%s\n", __func__,
-             feof(F) ? ", end of file reached" : "");
+             feof(F) ? ": end of file reached" : "");
     free(Buffer);
     return;
   }

--- a/compiler-rt/lib/profile/InstrProfilingUtil.c
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.c
@@ -298,8 +298,9 @@ static int is_local_filesystem(int Fd) {
       _Static_assert(sizeof(Vfs.f_fsid) == sizeof(Vp->vmt_fsid),
                      "fsid length mismatch");
       if (memcmp(&Vfs.f_fsid, &Vp->vmt_fsid, sizeof Vfs.f_fsid) == 0) {
+        int Answer = (Vp->vmt_flags & MNT_REMOTE) == 0;
         free(Buf);
-        return (Vp->vmt_flags & MNT_REMOTE) == 0;
+        return Answer;
       }
       CurObjPtr += Vp->vmt_length;
     }

--- a/compiler-rt/lib/profile/InstrProfilingUtil.c
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.c
@@ -337,7 +337,7 @@ COMPILER_RT_VISIBILITY void lprofGetFileContentBuffer(FILE *F, uint64_t Length,
   }
 
   if (getenv("LLVM_PROFILE_VERBOSE"))
-    PROF_NOTE("Could not use mmap; using fread instead.%s\n", "");
+    PROF_NOTE("%s\n", "Could not use mmap; using fread instead.");
 
   void *Buffer = malloc(Length);
   if (!Buffer) {

--- a/compiler-rt/lib/profile/InstrProfilingUtil.c
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.c
@@ -373,7 +373,7 @@ void lprofReleaseBuffer(ManagedMemory *Buf, size_t Length) {
     munmap(Buf->Addr, Length);
     break;
   case MM_INVALID:
-    PROF_ERR("%s: Buffer has invalid state: %d", __func__, Buf->Status);
+    PROF_ERR("%s: Buffer has invalid state: %d\n", __func__, Buf->Status);
     break;
   }
   Buf->Addr = NULL;

--- a/compiler-rt/lib/profile/InstrProfilingUtil.h
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.h
@@ -33,9 +33,9 @@ int lprofUnlockFileHandle(FILE *F);
 FILE *lprofOpenFileEx(const char *Filename);
 
 enum MemoryStatus {
-  MS_INVALID = 0x1, // Addr is not a valid address
-  MS_MMAP = 0x2,    // Addr was mmap'ed
-  MS_MALLOC = 0x4   // Addr was malloc'ed
+  MS_INVALID, // Addr is not a valid address
+  MS_MMAP,    // Addr was mmap'ed
+  MS_MALLOC   // Addr was malloc'ed
 };
 typedef struct {
   void *Addr;

--- a/compiler-rt/lib/profile/InstrProfilingUtil.h
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.h
@@ -33,9 +33,9 @@ int lprofUnlockFileHandle(FILE *F);
 FILE *lprofOpenFileEx(const char *Filename);
 
 enum MemoryStatus {
-  MM_INVALID = 0x1, // Addr is not a valid address
-  MM_MMAP = 0x2,    // Addr was mmap'ed
-  MM_MALLOC = 0x4   // Addr was malloc'ed
+  MS_INVALID = 0x1, // Addr is not a valid address
+  MS_MMAP = 0x2,    // Addr was mmap'ed
+  MS_MALLOC = 0x4   // Addr was malloc'ed
 };
 typedef struct {
   void *Addr;

--- a/compiler-rt/lib/profile/InstrProfilingUtil.h
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.h
@@ -31,6 +31,25 @@ int lprofUnlockFileHandle(FILE *F);
  * lock for exclusive access. The caller will block
  * if the lock is already held by another process. */
 FILE *lprofOpenFileEx(const char *Filename);
+
+enum MemoryStatus {
+  MM_INVALID = 0x1, // Addr is not a valid address
+  MM_MMAP = 0x2,    // Addr was mmap'ed
+  MM_MALLOC = 0x4   // Addr was malloc'ed
+};
+typedef struct {
+  void *Addr;
+  enum MemoryStatus Status;
+} ManagedMemory;
+
+/* Read the content of a file using mmap or fread into a buffer.
+ * Certain files (e.g. NFS mounted) cannot be opened reliably with mmap,
+ * so we use fread in those cases. The corresponding lprofReleaseBuffer
+ * will free/munmap the buffer.
+ */
+void lprofGetFileContentBuffer(FILE *F, uint64_t FileSize, ManagedMemory *Buf);
+void lprofReleaseBuffer(ManagedMemory *FileBuffer, size_t Length);
+
 /* PS4 doesn't have setenv/getenv/fork. Define a shim. */
 #if __ORBIS__
 #include <sys/types.h>

--- a/compiler-rt/test/profile/Posix/instrprof-fork.c
+++ b/compiler-rt/test/profile/Posix/instrprof-fork.c
@@ -35,8 +35,8 @@ int main(void) {
     }                   //             |
   }                     // ------------+------------
   int status;           //   20     10 |   1     0
-  i = 10;
-  while (i-- > 0)
-    wait(&status);      // (*)  the child inherits counter values prior to fork
-  return 0;             //      from the parent in non-continuous mode.
+  i = 10;               // (*)  the child inherits counter values prior to fork
+  while (i-- > 0)       //      from the parent in non-continuous mode.
+    wait(&status);
+  return 0;
 }

--- a/compiler-rt/test/profile/Posix/instrprof-fork.c
+++ b/compiler-rt/test/profile/Posix/instrprof-fork.c
@@ -4,7 +4,7 @@
 // RUN: %run %t
 // RUN: llvm-profdata show --all-functions --counts %t.profdir/default_*.profraw  | FileCheck %s
 // RUN: rm -fr %t.profdir
-// RUN: env LLVM_NO_MMAP=1 %run %t
+// RUN: env LLVM_PROFILE_NO_MMAP=1 %run %t
 // RUN: llvm-profdata show --all-functions --counts %t.profdir/default_*.profraw  | FileCheck %s
 
 //

--- a/compiler-rt/test/profile/Posix/instrprof-fork.c
+++ b/compiler-rt/test/profile/Posix/instrprof-fork.c
@@ -35,6 +35,8 @@ int main(void) {
     }                   //             |
   }                     // ------------+------------
   int status;           //   20     10 |   1     0
-  wait(&status);        // (*)  the child inherits counter values prior to fork
+  i = 10;
+  while (i-- > 0)
+    wait(&status);      // (*)  the child inherits counter values prior to fork
   return 0;             //      from the parent in non-continuous mode.
 }

--- a/compiler-rt/test/profile/Posix/instrprof-fork.c
+++ b/compiler-rt/test/profile/Posix/instrprof-fork.c
@@ -3,11 +3,15 @@
 // RUN: %clang_pgogen=%t.profdir -o %t -O2 %s
 // RUN: %run %t
 // RUN: llvm-profdata show --all-functions --counts %t.profdir/default_*.profraw  | FileCheck %s
+// RUN: rm -fr %t.profdir
+// RUN: env LLVM_NO_MMAP=1 %run %t
+// RUN: llvm-profdata show --all-functions --counts %t.profdir/default_*.profraw  | FileCheck %s
+
 //
 // CHECK: func1:
-// CHECK: Block counts: [4]
+// CHECK: Block counts: [21]
 // CHECK:  func2:
-// CHECK: Block counts: [1]
+// CHECK: Block counts: [10]
 
 #include <sys/wait.h>
 #include <unistd.h>
@@ -16,17 +20,21 @@ __attribute__((noinline)) void func1() {}
 __attribute__((noinline)) void func2() {}
 
 int main(void) {
-  //                       child     | parent
-  int status;         // func1 func2 | func1 func2
-  func1();            //   +1        |   +1        (*)
-  pid_t pid = fork(); //             |
-  if (pid == -1)      //             |
-    return 1;         //             |
-  if (pid == 0)       //             |
-    func2();          //         +1  |
-  func1();            //   +1        |   +1
-  if (pid)            // ------------+------------
-    wait(&status);    //    2     1  |    2    0
-  return 0;           // (*)  the child inherits counter values prior to fork
-                      //      from the parent in non-continuous mode.
+  //                           child     | parent
+  //                         func1 func2 | func1 func2
+  func1();              //   +10       |   +1        (*)
+  int i = 10;           //             |
+  while (i-- > 0) {     //             |
+    pid_t pid = fork(); //             |
+    if (pid == -1)      //             |
+      return 1;         //             |
+    if (pid == 0) {     //             |
+      func2();          //         +10 |
+      func1();          //   +10       |
+      return 0;         //             |
+    }                   //             |
+  }                     // ------------+------------
+  int status;           //   20     10 |   1     0
+  wait(&status);        // (*)  the child inherits counter values prior to fork
+  return 0;             //      from the parent in non-continuous mode.
 }

--- a/compiler-rt/test/profile/instrprof-no-mmap-during-merging.c
+++ b/compiler-rt/test/profile/instrprof-no-mmap-during-merging.c
@@ -2,7 +2,8 @@
 // RUN: rm -f *.profraw
 // RUN: %clang_pgogen %s -o a.out
 
-// Need to run a.out twice, the second time a merge will occur which will trigger an mmap.
+// Need to run a.out twice. On the second time, a merge will occur, which will
+// trigger an mmap.
 // RUN: ./a.out
 // RUN: llvm-profdata show default_*.profraw --all-functions --counts --memop-sizes 2>&1 | FileCheck %s -check-prefix=PROFDATA
 // RUN: env LLVM_NO_MMAP=1 LLVM_PROFILE_VERBOSE=1 ./a.out 2>&1 | FileCheck %s

--- a/compiler-rt/test/profile/instrprof-no-mmap-during-merging.c
+++ b/compiler-rt/test/profile/instrprof-no-mmap-during-merging.c
@@ -9,7 +9,7 @@
 // RUN: env LLVM_PROFILE_NO_MMAP=1 LLVM_PROFILE_VERBOSE=1 ./a.out 2>&1 | FileCheck %s
 // RUN: llvm-profdata show default_*.profraw --all-functions --counts --memop-sizes 2>&1 | FileCheck %s -check-prefix=PROFDATA2
 
-// CHECK: Could not use mmap; using fread instead.
+// CHECK: could not use mmap; using fread instead
 // PROFDATA: Block counts: [1]
 // PROFDATA: [  0,    0,          1 ]
 // PROFDATA: Maximum function count: 1

--- a/compiler-rt/test/profile/instrprof-no-mmap-during-merging.c
+++ b/compiler-rt/test/profile/instrprof-no-mmap-during-merging.c
@@ -6,7 +6,7 @@
 // trigger an mmap.
 // RUN: ./a.out
 // RUN: llvm-profdata show default_*.profraw --all-functions --counts --memop-sizes 2>&1 | FileCheck %s -check-prefix=PROFDATA
-// RUN: env LLVM_NO_MMAP=1 LLVM_PROFILE_VERBOSE=1 ./a.out 2>&1 | FileCheck %s
+// RUN: env LLVM_PROFILE_NO_MMAP=1 LLVM_PROFILE_VERBOSE=1 ./a.out 2>&1 | FileCheck %s
 // RUN: llvm-profdata show default_*.profraw --all-functions --counts --memop-sizes 2>&1 | FileCheck %s -check-prefix=PROFDATA2
 
 // CHECK: Could not use mmap; using fread instead.

--- a/compiler-rt/test/profile/instrprof-no-mmap-during-merging.c
+++ b/compiler-rt/test/profile/instrprof-no-mmap-during-merging.c
@@ -1,0 +1,25 @@
+// RUN: mkdir -p %t.d && cd %t.d
+// RUN: rm -f *.profraw
+// RUN: %clang_pgogen %s -o a.out
+
+// Need to run a.out twice, the second time a merge will occur which will trigger an mmap.
+// RUN: ./a.out
+// RUN: llvm-profdata show default_*.profraw --all-functions --counts --memop-sizes 2>&1 | FileCheck %s -check-prefix=PROFDATA
+// RUN: env LLVM_NO_MMAP=1 LLVM_PROFILE_VERBOSE=1 ./a.out 2>&1 | FileCheck %s
+// RUN: llvm-profdata show default_*.profraw --all-functions --counts --memop-sizes 2>&1 | FileCheck %s -check-prefix=PROFDATA2
+
+// CHECK: Could not use mmap; using fread instead.
+// PROFDATA: Block counts: [1]
+// PROFDATA: [  0,    0,          1 ]
+// PROFDATA: Maximum function count: 1
+// PROFDATA2: Block counts: [2]
+// PROFDATA2: [  0,    0,          2 ]
+// PROFDATA2: Maximum function count: 2
+
+#include <string.h>
+int ar[8];
+int main() {
+  memcpy(ar, ar + 2, ar[0]);
+  memcpy(ar, ar + 2, ar[2]);
+  return ar[2];
+}


### PR DESCRIPTION
On AIX, when accessing mmap'ed memory associated to a file on NFS, a SIGBUS might be raised at random.
The problem is still in open state with the OS team.

This PR teaches the profile runtime, under certain conditions, to avoid the mmap when reading the profile file during online merging.
This PR has no effect on any platform other than AIX because I'm not aware of this problem on other platforms.
Other platforms can easily opt-in to this functionality in the future.

The logic in function `is_local_filesystem` was copied from [llvm/lib/Support/Unix/Path.inc](https://github.com/llvm/llvm-project/blob/f388ca3d9d9a58e3d189458b590ba68dfd9e5a2d/llvm/lib/Support/Unix/Path.inc#L515) (https://reviews.llvm.org/D58801), because it seems that the compiler-rt/profile cannot reuse code from llvm except through `InstrProfData.inc`.

Thanks to @hubert-reinterpretcast for substantial feedback downstream.