### PR TITLE
[clang][driver] Use rva22u64_v as the default march for Fuchsia targets

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/RISCV.cpp
@@ -325,7 +325,8 @@ std::string riscv::getRISCVArch(const llvm::opt::ArgList &Args,
     if (MABI.starts_with_insensitive("lp64")) {
       if (Triple.isAndroid())
         return "rv64imafdcv_zba_zbb_zbs";
-
+      if (Triple.isOSFuchsia())
+        return "rva22u64_v";
       return "rv64imafdc";
     }
   }
@@ -345,6 +346,8 @@ std::string riscv::getRISCVArch(const llvm::opt::ArgList &Args,
     return "rv64imac";
   if (Triple.isAndroid())
     return "rv64imafdcv_zba_zbb_zbs";
+  if (Triple.isOSFuchsia())
+    return "rva22u64_v";
   return "rv64imafdc";
 }
 

--- a/clang/test/Driver/riscv-features.c
+++ b/clang/test/Driver/riscv-features.c
@@ -73,3 +73,15 @@
 
 // ERR-SPLIT-DWARF: error: -gsplit-dwarf{{.*}} is unsupported with RISC-V linker relaxation (-mrelax)
 // SPLIT-DWARF:     "-split-dwarf-file"
+
+// RUN: %clang -mabi=lp64d --target=riscv64-unknown-fuchsia -### %s -fsyntax-only 2>&1 | FileCheck %s -check-prefixes=FUCHSIA
+// FUCHSIA: "-target-feature" "+m"
+// FUCHSIA-SAME: "-target-feature" "+a"
+// FUCHSIA-SAME: "-target-feature" "+f"
+// FUCHSIA-SAME: "-target-feature" "+d"
+// FUCHSIA-SAME: "-target-feature" "+c"
+// FUCHSIA-SAME: "-target-feature" "+v"
+// FUCHSIA-SAME: "-target-feature" "+zba"
+// FUCHSIA-SAME: "-target-feature" "+zbb"
+// FUCHSIA-SAME: "-target-feature" "+zbs"
+


### PR DESCRIPTION
Fuchsia supports RVA22 + Vector as outlined in https://fuchsia.dev/fuchsia-src/contribute/governance/rfcs/0234_riscv_abi_rva22+v?hl=en