### PR TITLE
[lld-macho] Improve ICF thunk folding logic

### DIFF
--- a/lld/MachO/ICF.cpp
+++ b/lld/MachO/ICF.cpp
@@ -297,15 +297,24 @@ static Symbol *getThunkTargetSymbol(ConcatInputSection *isec) {
 // direct branch thunk rather than containing a full copy of the actual function
 // body.
 void ICF::applySafeThunksToRange(size_t begin, size_t end) {
-  // If the functions we're dealing with are smaller than the thunk size, then
-  // just leave them all as-is - creating thunks would be a net loss.
-  uint32_t thunkSize = target->getICFSafeThunkSize();
-  if (icfInputs[begin]->data.size() <= thunkSize)
-    return;
-
   // When creating a unique ICF thunk, use the first section as the section that
   // all thunks will branch to.
   ConcatInputSection *masterIsec = icfInputs[begin];
+
+  // If the first section is not address significant, sorting guarantees that
+  // there are no address significant functions. So we can skip this range.
+  if (!masterIsec->keepUnique)
+    return;
+
+  // Skip anything that is not a code section.
+  if (!isCodeSection(masterIsec))
+    return;
+
+  // If the functions we're dealing with are smaller than the thunk size, then
+  // just leave them all as-is - creating thunks would be a net loss.
+  uint32_t thunkSize = target->getICFSafeThunkSize();
+  if (masterIsec->data.size() <= thunkSize)
+    return;
 
   // Get the symbol that all thunks will branch to.
   Symbol *masterSym = getThunkTargetSymbol(masterIsec);


### PR DESCRIPTION
Refactor to add some early return logic to `applySafeThunksToRange` so that we completely skip irrelevant ranges. 

Also add a check for `isCodeSection` to ensure we only apply branch thunks to code section (they don't make sense for anything else). Currently this isn't an issue since there are no `keepUnique` non-code sections - but this is not a hard restriction and may be implemented in the future, so we should be able to handle (i.e. avoid) this scenario. 