### PR TITLE
Warn about virtual methods in `final` classes

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -247,6 +247,9 @@ Improvements to Clang's diagnostics
 - The ``-Wsign-compare`` warning now treats expressions with bitwise not(~) and minus(-) as signed integers 
   except for the case where the operand is an unsigned integer
   and throws warning if they are compared with unsigned integers (##18878).
+- The ``-Wunnecessary-virtual-specifier`` warning has been added to warn about
+  methods which are marked as virtual inside a ``final`` class, and hence can
+  never be overridden.
 
 - Improve the diagnostics for chained comparisons to report actual expressions and operators (#GH129069).
 

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -380,6 +380,8 @@ cannot be overridden, and hence the ``virtual`` specifier is useless.
 
 The warning also detects virtual methods in classes whose destructor is
 ``final``, for the same reason.
+
+The warning does not fire on virtual methods which are also marked ``override``.
   }];
 }
 

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -372,7 +372,16 @@ def CXX11WarnInconsistentOverrideMethod :
 def CXX11WarnSuggestOverrideDestructor : DiagGroup<"suggest-destructor-override">;
 def CXX11WarnSuggestOverride : DiagGroup<"suggest-override">;
 
-def WarnUnnecessaryVirtualSpecifier : DiagGroup<"unnecessary-virtual-specifier">;
+def WarnUnnecessaryVirtualSpecifier : DiagGroup<"unnecessary-virtual-specifier"> {
+  code Documentation = [{
+Warns when a ``final`` class contains a virtual method (including virtual
+destructors). Since ``final`` classes cannot be subclassed, their methods
+cannot be overridden, and hence the ``virtual`` specifier is useless.
+
+The warning also detects virtual methods in classes whose destructor is
+``final``, for the same reason.
+  }];
+}
 
 // Original name of this warning in Clang
 def : DiagGroup<"c++0x-narrowing", [CXX11Narrowing]>;

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -372,6 +372,8 @@ def CXX11WarnInconsistentOverrideMethod :
 def CXX11WarnSuggestOverrideDestructor : DiagGroup<"suggest-destructor-override">;
 def CXX11WarnSuggestOverride : DiagGroup<"suggest-override">;
 
+def WarnUnnecessaryVirtualSpecifier : DiagGroup<"unnecessary-virtual-specifier">;
+
 // Original name of this warning in Clang
 def : DiagGroup<"c++0x-narrowing", [CXX11Narrowing]>;
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2706,6 +2706,9 @@ def warn_final_dtor_non_final_class : Warning<
   InGroup<FinalDtorNonFinalClass>;
 def note_final_dtor_non_final_class_silence : Note<
   "mark %0 as '%select{final|sealed}1' to silence this warning">;
+def warn_unnecessary_virtual_specifier : Warning<
+  "virtual method %0 is inside a 'final' class and can never be overridden">,
+  InGroup<WarnUnnecessaryVirtualSpecifier>;
 
 // C++11 attributes
 def err_repeat_attribute : Error<"%0 attribute cannot be repeated">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2708,7 +2708,7 @@ def note_final_dtor_non_final_class_silence : Note<
   "mark %0 as '%select{final|sealed}1' to silence this warning">;
 def warn_unnecessary_virtual_specifier : Warning<
   "virtual method %0 is inside a 'final' class and can never be overridden">,
-  InGroup<WarnUnnecessaryVirtualSpecifier>;
+  InGroup<WarnUnnecessaryVirtualSpecifier>, DefaultIgnore;
 
 // C++11 attributes
 def err_repeat_attribute : Error<"%0 attribute cannot be repeated">;

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -7196,15 +7196,14 @@ void Sema::CheckCompletedCXXClass(Scope *S, CXXRecordDecl *Record) {
 
         if (M->hasAttr<OverrideAttr>()) {
           HasMethodWithOverrideControl = true;
+        } else if (M->size_overridden_methods() > 0) {
+          HasOverridingMethodWithoutOverrideControl = true;
         } else {
-          if (M->size_overridden_methods() > 0)
-            HasOverridingMethodWithoutOverrideControl = true;
-
-          // Warn on virtual methods in final classes, unless they're also
-          // marked `override`.
-          if (M->isVirtualAsWritten() && Record->isEffectivelyFinal())
+          // Warn on newly-declared virtual methods in `final` classes
+          if (M->isVirtualAsWritten() && Record->isEffectivelyFinal()) {
             Diag(M->getLocation(), diag::warn_unnecessary_virtual_specifier)
                 << M;
+          }
         }
       }
 

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -7193,10 +7193,15 @@ void Sema::CheckCompletedCXXClass(Scope *S, CXXRecordDecl *Record) {
         // class without overriding any.
         if (!M->isStatic())
           DiagnoseHiddenVirtualMethods(M);
+
         if (M->hasAttr<OverrideAttr>())
           HasMethodWithOverrideControl = true;
         else if (M->size_overridden_methods() > 0)
           HasOverridingMethodWithoutOverrideControl = true;
+
+        // See if a method is marked as virtual inside of a final class.
+        if (M->isVirtualAsWritten() && Record->isEffectivelyFinal())
+          Diag(M->getLocation(), diag::warn_unnecessary_virtual_specifier) << M;
       }
 
       if (!isa<CXXDestructorDecl>(M))

--- a/clang/test/SemaCXX/unnecessary-virtual-specifier.cpp
+++ b/clang/test/SemaCXX/unnecessary-virtual-specifier.cpp
@@ -2,10 +2,10 @@
 
 struct Foo final {
   Foo() = default;
-	virtual ~Foo() = default;                      // expected-warning {{virtual method}}
-	virtual Foo& operator=(Foo& other) = default;  // expected-warning {{virtual method}}
-	virtual Foo& operator=(Foo&& other) = default; // expected-warning {{virtual method}}
-	void f();
+  virtual ~Foo() = default;                      // expected-warning {{virtual method}}
+  virtual Foo& operator=(Foo& other) = default;  // expected-warning {{virtual method}}
+  virtual Foo& operator=(Foo&& other) = default; // expected-warning {{virtual method}}
+  void f();
   virtual void f(int);                           // expected-warning {{virtual method}}
   int g(int x) { return x; };
   virtual int g(bool);                           // expected-warning {{virtual method}}
@@ -14,14 +14,15 @@ struct Foo final {
 
 struct BarBase {
   virtual ~BarBase() = delete;
-	virtual void virt() {}
-	virtual int virt(int);
+  virtual void virt() {}
+  virtual int virt(int);
   int nonvirt();
 };
 
 struct Bar final : BarBase {
   ~Bar() override = delete;
-	void virt() override {};
-	virtual int virt(int) override;                // expected-warning {{virtual method}}
+  void virt() override {};
+  // `virtual ... override;` is a common pattern, so don't warn
+  virtual int virt(int) override;
   int nonvirt();
 };

--- a/clang/test/SemaCXX/unnecessary-virtual-specifier.cpp
+++ b/clang/test/SemaCXX/unnecessary-virtual-specifier.cpp
@@ -24,5 +24,6 @@ struct Bar final : BarBase {
   void virt() override {};
   // `virtual ... override;` is a common pattern, so don't warn
   virtual int virt(int) override;
+  virtual int virt(bool);                        // expected-warning {{virtual method}}
   int nonvirt();
 };

--- a/clang/test/SemaCXX/unnecessary-virtual-specifier.cpp
+++ b/clang/test/SemaCXX/unnecessary-virtual-specifier.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -verify -Wunnecessary-virtual-specifier %s
+// RUN: %clang_cc1 -fsyntax-only -verify -Wunnecessary-virtual-specifier -Wno-inconsistent-missing-override %s
 
 struct Foo final {
   Foo() = default;
@@ -15,15 +15,17 @@ struct Foo final {
 struct BarBase {
   virtual ~BarBase() = delete;
   virtual void virt() {}
-  virtual int virt(int);
+  virtual int  virt2(int);
+  virtual bool virt3(bool);
   int nonvirt();
 };
 
 struct Bar final : BarBase {
   ~Bar() override = delete;
-  void virt() override {};
-  // `virtual ... override;` is a common pattern, so don't warn
-  virtual int virt(int) override;
-  virtual int virt(bool);                        // expected-warning {{virtual method}}
+          void virt() override {};
+  virtual int  virt2(int) override;               // `virtual ... override;` is a common pattern, so don't warn
+  virtual bool virt3(bool);                       // Already virtual in the base class; triggers
+                                                  // -Winconsistent-missing-override or -Wsuggest-override instead
+  virtual int  new_virt(bool);                    // expected-warning {{virtual method}}
   int nonvirt();
 };

--- a/clang/test/SemaCXX/unnecessary-virtual-specifier.cpp
+++ b/clang/test/SemaCXX/unnecessary-virtual-specifier.cpp
@@ -1,0 +1,27 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -Wunnecessary-virtual-specifier -Wsuggest-override %s
+
+struct Foo final {
+  Foo() = default;
+	virtual ~Foo() = default;                      // expected-warning {{virtual method}}
+	virtual Foo& operator=(Foo& other) = default;  // expected-warning {{virtual method}}
+	virtual Foo& operator=(Foo&& other) = default; // expected-warning {{virtual method}}
+	void f();
+  virtual void f(int);                           // expected-warning {{virtual method}}
+  int g(int x) { return x; };
+  virtual int g(bool);                           // expected-warning {{virtual method}}
+  static int s();
+};
+
+struct BarBase {
+  virtual ~BarBase() = delete;
+	virtual void virt() {}
+	virtual int virt(int);
+  int nonvirt();
+};
+
+struct Bar final : BarBase {
+  ~Bar() override = delete;
+	void virt() override {};
+	virtual int virt(int) override;                // expected-warning {{virtual method}}
+  int nonvirt();
+};

--- a/clang/test/SemaCXX/unnecessary-virtual-specifier.cpp
+++ b/clang/test/SemaCXX/unnecessary-virtual-specifier.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -verify -Wunnecessary-virtual-specifier -Wsuggest-override %s
+// RUN: %clang_cc1 -fsyntax-only -verify -Wunnecessary-virtual-specifier %s
 
 struct Foo final {
   Foo() = default;


### PR DESCRIPTION
There's never any point to adding a `virtual` specifier to methods in a `final` class, since the class can't be subclassed. This adds a warning when we notice this happening, as suggested in #131108.

We don't currently implement the second part of the suggestion, to warn on `virtual` methods which are never overridden anywhere. Although it's feasible to do this for things with internal linkage (so we can check at the end of the TU), it's more complicated to implement and it's not clear it's worth the effort.

I tested the warning by compiling chromium and clang itself. Chromium resulted in [277 warnings across 109 files](https://github.com/user-attachments/files/19234889/warnings-chromium.txt), while clang had [38 warnings across 29 files](https://github.com/user-attachments/files/19234888/warnings-clang.txt). I inspected a subset of the warning sites manually, and they all seemed legitimate.

This warning is very easy to fix (just remove the `virtual` specifier) and I haven't seen any false positives, so it's suitable for on-by-default. However, I've currently made it off-by-default because it fires at several places in the repo. I plan to submit a followup PR fixing those places and enabling the warning by default.