### PR TITLE
[LLDB][Telemetry]Init field to nullptr.

### DIFF
--- a/lldb/include/lldb/Core/Telemetry.h
+++ b/lldb/include/lldb/Core/Telemetry.h
@@ -65,7 +65,7 @@ struct LLDBBaseTelemetryInfo : public llvm::telemetry::TelemetryInfo {
   // TBD: could add some memory stats here too?
 
   lldb::user_id_t debugger_id = LLDB_INVALID_UID;
-  Debugger *debugger;
+  Debugger *debugger = nullptr;
 
   // For dyn_cast, isa, etc operations.
   llvm::telemetry::KindType getKind() const override {


### PR DESCRIPTION
The field is currently un-initialised and can cause a crash in some build configs (where it got random values)