### PR TITLE
[GSYM] Fix incorrect comparison in gSYM creation

### DIFF
--- a/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
+++ b/llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp
@@ -324,8 +324,8 @@ static void convertFunctionLineTable(OutputAggregator &Out, CUInfo &CUI,
     // when it refers to an empty line sequence. In such cases, the DWARF linker
     // will exclude the empty sequence from the final output and assign
     // `UINT64_MAX` to the `DW_AT_LLVM_stmt_sequence` attribute.
-    auto StmtSeqVal = dwarf::toSectionOffset(StmtSeqAttr, UINT64_MAX);
-    if (StmtSeqVal != UINT32_MAX)
+    uint64_t StmtSeqVal = dwarf::toSectionOffset(StmtSeqAttr, UINT64_MAX);
+    if (StmtSeqVal != UINT64_MAX)
       StmtSeqOffset = StmtSeqVal;
   }
 


### PR DESCRIPTION
There is a bug in `llvm/lib/DebugInfo/GSYM/DwarfTransformer.cpp` where `StmtSeqVal` was being compared against `UINT32_MAX` rather than the correct `UINT64_MAX` - thanks @nocchijiang for [pointing this out](https://github.com/llvm/llvm-project/pull/129196#discussion_r1986203058).

We correct the issue with this patch. For testing - the issue would show when we have a correct offset of value `UINT32_MAX` - but constructing such a test is impractical. 