### PR TITLE
[GSYM] Update gSym unit test with stable / portable path

### DIFF
--- a/llvm/test/tools/llvm-gsymutil/ARM_AArch64/macho-gsym-merged-callsites-dsym.yaml
+++ b/llvm/test/tools/llvm-gsymutil/ARM_AArch64/macho-gsym-merged-callsites-dsym.yaml
@@ -15,7 +15,7 @@
 # CHECK-MERGED-CALLSITES:      FunctionInfo @ 0x[[#%x,FUNC4_1:]]: [0x[[#%x,FUNC4_1_START:]] - 0x[[#%x,FUNC4_1_END:]]) "function4_copy1"
 # CHECK-MERGED-CALLSITES:      ++ Merged FunctionInfos[0]:
 # CHECK-MERGED-CALLSITES-NEXT:     [0x[[#%x,FUNC4_2_START:]] - 0x[[#%x,FUNC4_2_END:]]) "function4_copy2"
- 
+
 # CHECK-MERGED-CALLSITES:      FunctionInfo @ 0x[[#%x,FUNC3_1:]]: [0x[[#%x,FUNC3_1_START:]] - 0x[[#%x,FUNC3_1_END:]]) "function3_copy1"
 # CHECK-MERGED-CALLSITES:      CallSites (by relative return offset):
 # CHECK-MERGED-CALLSITES-NEXT:   0x[[#%.4x,]] Flags[None] MatchRegex[function4_copy1]
@@ -23,7 +23,7 @@
 # CHECK-MERGED-CALLSITES-NEXT:     [0x[[#%x,FUNC3_2_START:]] - 0x[[#%x,FUNC3_2_END:]]) "function3_copy2"
 # CHECK-MERGED-CALLSITES:          CallSites (by relative return offset):
 # CHECK-MERGED-CALLSITES-NEXT:       0x[[#%.4x,]] Flags[None] MatchRegex[function4_copy2]
- 
+
 # CHECK-MERGED-CALLSITES:      FunctionInfo @ 0x[[#%x,FUNC2_1:]]: [0x[[#%x,FUNC2_1_START:]] - 0x[[#%x,FUNC2_1_END:]]) "function2_copy1"
 # CHECK-MERGED-CALLSITES:      CallSites (by relative return offset):
 # CHECK-MERGED-CALLSITES-NEXT:   0x[[#%.4x,]] Flags[None] MatchRegex[function3_copy1]
@@ -31,11 +31,11 @@
 # CHECK-MERGED-CALLSITES-NEXT:     [0x[[#%x,FUNC2_2_START:]] - 0x[[#%x,FUNC2_2_END:]]) "function2_copy2"
 # CHECK-MERGED-CALLSITES:          CallSites (by relative return offset):
 # CHECK-MERGED-CALLSITES-NEXT:       0x[[#%.4x,]] Flags[None] MatchRegex[function3_copy1]
- 
+
 # CHECK-MERGED-CALLSITES:      FunctionInfo @ 0x[[#%x,FUNC1:]]: [0x[[#%x,FUNC1_START:]] - 0x[[#%x,FUNC1_END:]]) "function1"
 # CHECK-MERGED-CALLSITES:      CallSites (by relative return offset):
 # CHECK-MERGED-CALLSITES-NEXT:   0x[[#%.4x,]] Flags[None] MatchRegex[function2_copy1]
- 
+
 # CHECK-MERGED-CALLSITES:      FunctionInfo @ 0x[[#%x,MAIN:]]: [0x[[#%x,MAIN_START:]] - 0x[[#%x,MAIN_END:]]) "main"
 # CHECK-MERGED-CALLSITES:      CallSites (by relative return offset):
 # CHECK-MERGED-CALLSITES-NEXT:   0x[[#%.4x,]] Flags[None] MatchRegex[function1]
@@ -53,39 +53,39 @@
 ###     0x00000001000003e8  =========================>  0x000000010000035c  =>  0x0000000100000340
 
 # RUN: llvm-gsymutil %t/dwarf_call_sites_dSYM.gsym --merged-functions --address=0x00000001000003d0 | FileCheck --check-prefix=CHECK-C1 %s
-# CHECK-C1:       0x00000001000003d0: main + 32 @ /private/tmp/tst{{[/\\]}}out/merged_funcs_test.cpp:63
+# CHECK-C1:       0x00000001000003d0: main + 32 @ ./merged_funcs_test.cpp:63
 # CHECK-C1-NEXT:      CallSites: function2_copy2
 
 # RUN: llvm-gsymutil %t/dwarf_call_sites_dSYM.gsym --merged-functions --address=0x000000010000037c --merged-functions-filter="function2_copy2" | FileCheck --check-prefix=CHECK-C2 %s
-# CHECK-C2:       0x000000010000037c: function_inlined + 8 @ /private/tmp/tst{{[/\\]}}out/merged_funcs_test.cpp:35 [inlined]
-# CHECK-C2-NEXT:                   function2_copy2 + 16 @ /private/tmp/tst{{[/\\]}}out/merged_funcs_test.cpp:48
+# CHECK-C2:       0x000000010000037c: function_inlined + 8 @ ./merged_funcs_test.cpp:35 [inlined]
+# CHECK-C2-NEXT:                   function2_copy2 + 16 @ ./merged_funcs_test.cpp:48
 # CHECK-C2-NEXT:     CallSites: function3_copy1
 
 # RUN: llvm-gsymutil %t/dwarf_call_sites_dSYM.gsym --merged-functions --address=0x000000010000035c --merged-functions-filter="function3_copy1" | FileCheck --check-prefix=CHECK-C3 %s
 # CHECK-C3:       Found 1 function at address 0x000000010000035c:
-# CHECK-C3-NEXT:     0x000000010000035c: function3_copy1 + 16 @ /private/tmp/tst{{[/\\]}}out/merged_funcs_test.cpp:21
+# CHECK-C3-NEXT:     0x000000010000035c: function3_copy1 + 16 @ ./merged_funcs_test.cpp:21
 # CHECK-C3-NEXT:        CallSites: function4_copy1
 
 # RUN: llvm-gsymutil %t/dwarf_call_sites_dSYM.gsym --merged-functions --address=0x0000000100000340 --merged-functions-filter="function4_copy1" | FileCheck --check-prefix=CHECK-C4 %s
 # CHECK-C4:       Found 1 function at address 0x0000000100000340:
-# CHECK-C4-NEXT:     0x0000000100000340: function4_copy1 + 8 @ /private/tmp/tst{{[/\\]}}out/merged_funcs_test.cpp:7
+# CHECK-C4-NEXT:     0x0000000100000340: function4_copy1 + 8 @ ./merged_funcs_test.cpp:7
 
 ### ----------------------------------------------------------------------------------------------------------------------------------
 ### Resolve the 2nd call stack - the 2nd and 3rd addresses are the same but they resolve to a different function because of the filter
 
 # RUN: llvm-gsymutil %t/dwarf_call_sites_dSYM.gsym --address=0x00000001000003e8 --merged-functions | FileCheck --check-prefix=CHECK-C5 %s
 # CHECK-C5:       Found 1 function at address 0x00000001000003e8:
-# CHECK-C5-NEXT:     0x00000001000003e8: main + 56 @ /private/tmp/tst{{[/\\]}}out/merged_funcs_test.cpp:64
+# CHECK-C5-NEXT:     0x00000001000003e8: main + 56 @ ./merged_funcs_test.cpp:64
 # CHECK-C5-NEXT:        CallSites: function3_copy2
 
 # RUN: llvm-gsymutil %t/dwarf_call_sites_dSYM.gsym --merged-functions --address=0x000000010000035c --merged-functions-filter="function3_copy2" | FileCheck --check-prefix=CHECK-C6 %s
 # CHECK-C6:       Found 1 function at address 0x000000010000035c:
-# CHECK-C6-NEXT:     0x000000010000035c: function3_copy2 + 16 @ /private/tmp/tst{{[/\\]}}out/merged_funcs_test.cpp:28
+# CHECK-C6-NEXT:     0x000000010000035c: function3_copy2 + 16 @ ./merged_funcs_test.cpp:28
 # CHECK-C6-NEXT:        CallSites: function4_copy2
 
 # RUN: llvm-gsymutil %t/dwarf_call_sites_dSYM.gsym --merged-functions --merged-functions-filter="function4_copy2" --address=0x0000000100000340 | FileCheck --check-prefix=CHECK-C7 %s
 # CHECK-C7:       Found 1 function at address 0x0000000100000340:
-# CHECK-C7-NEXT:     0x0000000100000340: function4_copy2 + 8 @ /private/tmp/tst{{[/\\]}}out/merged_funcs_test.cpp:14
+# CHECK-C7-NEXT:     0x0000000100000340: function4_copy2 + 8 @ ./merged_funcs_test.cpp:14
 
 
 #--- merged_funcs_test.cpp
@@ -197,6 +197,7 @@ functions:
 # Compile merged_funcs_test.cpp to merged_funcs_test.o with flags -g -O3 for MachO / arm64
 clang --target=arm64-apple-macos11 -c  -g -gdwarf-4 -fno-unwind-tables \
     -mllvm -emit-func-debug-line-table-offsets -fno-exceptions -mno-outline \
+    -fdebug-compilation-dir=. \
     -O3 "merged_funcs_test.cpp" -o "merged_funcs_test.o"
 
 # Link using ld64.lld directly with flags "--icf=all --keep-icf-stabs"
@@ -228,7 +229,7 @@ FileHeader:
 LoadCommands:
   - cmd:             LC_UUID
     cmdsize:         24
-    uuid:            4C4C44F6-5555-3144-A1E3-14AF19709811
+    uuid:            4C4C441A-5555-3144-A124-E395C0E7AA96
   - cmd:             LC_BUILD_VERSION
     cmdsize:         24
     platform:        1
@@ -276,7 +277,7 @@ LoadCommands:
         reserved1:       0x0
         reserved2:       0x0
         reserved3:       0x0
-        content:         CFFAEDFE0C000001000000000A00000008000000C005000000000000000000001B000000180000004C4C44F655553144A1E314AF1970981132000000180000000100000000000B0000000B00000000000200000018000000001000000A000000A01000009C00000019000000480000005F5F504147455A45524F00000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000019000000980000005F5F54455854000000000000000000000000000001000000
+        content:         CFFAEDFE0C000001000000000A00000008000000C005000000000000000000001B000000180000004C4C441A55553144A124E395C0E7AA9632000000180000000100000000000B0000000B00000000000200000018000000001000000A000000A01000009C00000019000000480000005F5F504147455A45524F00000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000019000000980000005F5F54455854000000000000000000000000000001000000
   - cmd:             LC_SEGMENT_64
     cmdsize:         152
     segname:         __DATA
@@ -318,7 +319,7 @@ LoadCommands:
     vmaddr:          4295004160
     vmsize:          4096
     fileoff:         8192
-    filesize:        3526
+    filesize:        3507
     maxprot:         7
     initprot:        3
     nsects:          11
@@ -360,7 +361,7 @@ LoadCommands:
         reserved1:       0x0
         reserved2:       0x0
         reserved3:       0x0
-        content:         00000000000000000800000000000000010050080000000000000014000000000000000400A301509F0000000000000000000000000000000004000000000000000C0000000000000001005800000000000000000000000000000000080000000000000014000000000000000100500000000000000000000000000000000000000000000000000800000000000000010050080000000000000014000000000000000400A301509F0000000000000000000000000000000004000000000000000C0000000000000001005800000000000000000000000000000000080000000000000014000000000000000100500000000000000000000000000000000014000000000000002000000000000000010050200000000000000034000000000000000400A301509F00000000000000000000000000000000240000000000000034000000000000000100500000000000000000000000000000000014000000000000002000000000000000010050200000000000000034000000000000000400A301509F00000000000000000000000000000000240000000000000034000000000000000100500000000000000000000000000000000034000000000000004000000000000000010050400000000000000058000000000000000400A301509F000000000000000000000000000000003C0000000000000040000000000000000300707E9F000000000000000000000000000000004400000000000000580000000000000001005000000000000000000000000000000000340000000000000040000000000000000300707E9F00000000000000000000000000000000440000000000000058000000000000000100500000000000000000000000000000000034000000000000004000000000000000010050400000000000000058000000000000000400A301509F000000000000000000000000000000003C0000000000000040000000000000000300707E9F00000000000000000000000000000000440000000000000058000000000000000100500000000000000000000000000000000058000000000000006400000000000000010050640000000000000078000000000000000400A301509F00000000000000000000000000000000680000000000000078000000000000000100500000000000000000000000000000000084000000000000009000000000000000030011009F90000000000000009C000000000000000100639C00000000000000A800000000000000010064B800000000000000C00000000000000001006300000000000000000000000000000000
+        content:         00000000000000000800000000000000010050080000000000000014000000000000000400A301509F0000000000000000000000000000000004000000000000000C0000000000000001005800000000000000000000000000000000080000000000000014000000000000000100500000000000000000000000000000000000000000000000000800000000000000010050080000000000000014000000000000000400A301509F0000000000000000000000000000000004000000000000000C0000000000000001005800000000000000000000000000000000080000000000000014000000000000000100500000000000000000000000000000000014000000000000002000000000000000010050200000000000000034000000000000000400A301509F00000000000000000000000000000000240000000000000034000000000000000100500000000000000000000000000000000014000000000000002000000000000000010050200000000000000034000000000000000400A301509F00000000000000000000000000000000240000000000000034000000000000000100500000000000000000000000000000000034000000000000004000000000000000010050400000000000000058000000000000000400A301509F000000000000000000000000000000003C0000000000000040000000000000000300707E9F000000000000000000000000000000004400000000000000580000000000000001005000000000000000000000000000000000340000000000000040000000000000000300707E9F00000000000000000000000000000000440000000000000058000000000000000100500000000000000000000000000000000034000000000000004000000000000000010050400000000000000058000000000000000400A301509F000000000000000000000000000000003C0000000000000040000000000000000300707E9F000000000000000000000000000000004400000000000000580000000000000001005000000000000000000000000000000000340000000000000040000000000000000300707E9F00000000000000000000000000000000440000000000000058000000000000000100500000000000000000000000000000000058000000000000006400000000000000010050640000000000000078000000000000000400A301509F00000000000000000000000000000000680000000000000078000000000000000100500000000000000000000000000000000084000000000000009000000000000000030011009F90000000000000009C000000000000000100639C00000000000000A800000000000000010064B800000000000000C00000000000000001006300000000000000000000000000000000
       - sectname:        __debug_info
         segname:         __DWARF
         addr:            0x100009575
@@ -401,7 +402,7 @@ LoadCommands:
       - sectname:        __debug_str
         segname:         __DWARF
         addr:            0x100009B24
-        size:            207
+        size:            188
         offset:          0x2B24
         align:           0
         reloff:          0x0
@@ -412,9 +413,9 @@ LoadCommands:
         reserved3:       0x0
       - sectname:        __apple_namespac
         segname:         __DWARF
-        addr:            0x100009BF3
+        addr:            0x100009BE0
         size:            36
-        offset:          0x2BF3
+        offset:          0x2BE0
         align:           0
         reloff:          0x0
         nreloc:          0
@@ -425,9 +426,9 @@ LoadCommands:
         content:         485341480100000001000000000000000C000000000000000100000001000600FFFFFFFF
       - sectname:        __apple_names
         segname:         __DWARF
-        addr:            0x100009C17
+        addr:            0x100009C04
         size:            316
-        offset:          0x2C17
+        offset:          0x2C04
         align:           0
         reloff:          0x0
         nreloc:          0
@@ -435,12 +436,12 @@ LoadCommands:
         reserved1:       0x0
         reserved2:       0x0
         reserved3:       0x0
-        content:         48534148010000000A0000000A0000000C0000000000000001000000010006000000000002000000030000000400000006000000FFFFFFFF0800000009000000FFFFFFFFFFFFFFFF88CB36CFF4B03BD389CB36CF0A452B694908311C0B452B694A08311CDC41AB586A7F9A7CAD7ED75898000000A8000000B8000000C8000000D8000000E8000000F80000000801000018010000280100009C00000001000000BB010000000000002E000000010000002E00000000000000AC000000010000003A0200000000000040000000010000004F000000000000006B00000001000000E5000000000000005B000000010000009A000000000000007B000000010000003901000000000000BC00000001000000B902000000000000C6000000010000000D030000000000008B00000002000000050200008402000000000000
+        content:         48534148010000000A0000000A0000000C0000000000000001000000010006000000000002000000030000000400000006000000FFFFFFFF0800000009000000FFFFFFFFFFFFFFFF88CB36CFF4B03BD389CB36CF0A452B694908311C0B452B694A08311CDC41AB586A7F9A7CAD7ED75898000000A8000000B8000000C8000000D8000000E8000000F80000000801000018010000280100008900000001000000BB010000000000001B000000010000002E0000000000000099000000010000003A020000000000002D000000010000004F000000000000005800000001000000E50000000000000048000000010000009A0000000000000068000000010000003901000000000000A900000001000000B902000000000000B3000000010000000D030000000000007800000002000000050200008402000000000000
       - sectname:        __apple_types
         segname:         __DWARF
-        addr:            0x100009D53
+        addr:            0x100009D40
         size:            79
-        offset:          0x2D53
+        offset:          0x2D40
         align:           0
         reloff:          0x0
         nreloc:          0
@@ -448,12 +449,12 @@ LoadCommands:
         reserved1:       0x0
         reserved2:       0x0
         reserved3:       0x0
-        content:         48534148010000000100000001000000180000000000000004000000010006000300050005000B0006000600000000003080880B380000003C0000000100000048000000240000A4283A0C00000000
+        content:         48534148010000000100000001000000180000000000000004000000010006000300050005000B0006000600000000003080880B38000000290000000100000048000000240000A4283A0C00000000
       - sectname:        __apple_objc
         segname:         __DWARF
-        addr:            0x100009DA2
+        addr:            0x100009D8F
         size:            36
-        offset:          0x2DA2
+        offset:          0x2D8F
         align:           0
         reloff:          0x0
         nreloc:          0
@@ -532,7 +533,7 @@ DWARF:
     - ''
     - merged_funcs_test.cpp
     - '/'
-    - '/private/tmp/tst/out'
+    - .
     - global_result
     - int
     - function4_copy1
@@ -813,7 +814,7 @@ DWARF:
             - Value:           0xD0
         - AbbrCode:        0x2
           Values:
-            - Value:           0x2E
+            - Value:           0x1B
             - Value:           0x43
             - Value:           0x1
             - Value:           0x1
@@ -826,7 +827,7 @@ DWARF:
             - Value:           0x48
         - AbbrCode:        0x4
           Values:
-            - Value:           0x3C
+            - Value:           0x29
             - Value:           0x5
             - Value:           0x4
         - AbbrCode:        0x5
@@ -838,7 +839,7 @@ DWARF:
             - Value:           0x1
               BlockData:       [ 0x6F ]
             - Value:           0x1
-            - Value:           0x40
+            - Value:           0x2D
             - Value:           0x1
             - Value:           0x4
             - Value:           0x48
@@ -847,21 +848,21 @@ DWARF:
         - AbbrCode:        0x6
           Values:
             - Value:           0x0
-            - Value:           0x50
+            - Value:           0x3D
             - Value:           0x1
             - Value:           0x4
             - Value:           0x48
         - AbbrCode:        0x7
           Values:
             - Value:           0x39
-            - Value:           0x52
+            - Value:           0x3F
             - Value:           0x1
             - Value:           0x5
             - Value:           0x48
         - AbbrCode:        0x7
           Values:
             - Value:           0x5C
-            - Value:           0x54
+            - Value:           0x41
             - Value:           0x1
             - Value:           0x6
             - Value:           0x48
@@ -875,7 +876,7 @@ DWARF:
             - Value:           0x1
               BlockData:       [ 0x6F ]
             - Value:           0x1
-            - Value:           0x5B
+            - Value:           0x48
             - Value:           0x1
             - Value:           0xB
             - Value:           0x48
@@ -884,21 +885,21 @@ DWARF:
         - AbbrCode:        0x6
           Values:
             - Value:           0x7F
-            - Value:           0x50
+            - Value:           0x3D
             - Value:           0x1
             - Value:           0xB
             - Value:           0x48
         - AbbrCode:        0x7
           Values:
             - Value:           0xB8
-            - Value:           0x52
+            - Value:           0x3F
             - Value:           0x1
             - Value:           0xC
             - Value:           0x48
         - AbbrCode:        0x7
           Values:
             - Value:           0xDB
-            - Value:           0x54
+            - Value:           0x41
             - Value:           0x1
             - Value:           0xD
             - Value:           0x48
@@ -911,7 +912,7 @@ DWARF:
             - Value:           0x1
               BlockData:       [ 0x6D ]
             - Value:           0x1
-            - Value:           0x6B
+            - Value:           0x58
             - Value:           0x1
             - Value:           0x12
             - Value:           0x48
@@ -920,20 +921,20 @@ DWARF:
         - AbbrCode:        0x6
           Values:
             - Value:           0xFE
-            - Value:           0x50
+            - Value:           0x3D
             - Value:           0x1
             - Value:           0x12
             - Value:           0x48
         - AbbrCode:        0x7
           Values:
             - Value:           0x137
-            - Value:           0x54
+            - Value:           0x41
             - Value:           0x1
             - Value:           0x14
             - Value:           0x48
         - AbbrCode:        0x9
           Values:
-            - Value:           0x52
+            - Value:           0x3F
             - Value:           0x1
             - Value:           0x13
             - Value:           0x48
@@ -950,7 +951,7 @@ DWARF:
             - Value:           0x1
               BlockData:       [ 0x6D ]
             - Value:           0x1
-            - Value:           0x7B
+            - Value:           0x68
             - Value:           0x1
             - Value:           0x19
             - Value:           0x48
@@ -959,20 +960,20 @@ DWARF:
         - AbbrCode:        0x6
           Values:
             - Value:           0x15A
-            - Value:           0x50
+            - Value:           0x3D
             - Value:           0x1
             - Value:           0x19
             - Value:           0x48
         - AbbrCode:        0x7
           Values:
             - Value:           0x193
-            - Value:           0x54
+            - Value:           0x41
             - Value:           0x1
             - Value:           0x1B
             - Value:           0x48
         - AbbrCode:        0x9
           Values:
-            - Value:           0x52
+            - Value:           0x3F
             - Value:           0x1
             - Value:           0x1A
             - Value:           0x48
@@ -983,7 +984,7 @@ DWARF:
         - AbbrCode:        0x0
         - AbbrCode:        0xB
           Values:
-            - Value:           0x8B
+            - Value:           0x78
             - Value:           0x1
             - Value:           0x20
             - Value:           0x48
@@ -992,19 +993,19 @@ DWARF:
             - Value:           0x1
         - AbbrCode:        0xC
           Values:
-            - Value:           0x50
+            - Value:           0x3D
             - Value:           0x1
             - Value:           0x20
             - Value:           0x48
         - AbbrCode:        0x9
           Values:
-            - Value:           0x54
+            - Value:           0x41
             - Value:           0x1
             - Value:           0x22
             - Value:           0x48
         - AbbrCode:        0x9
           Values:
-            - Value:           0x52
+            - Value:           0x3F
             - Value:           0x1
             - Value:           0x21
             - Value:           0x48
@@ -1017,7 +1018,7 @@ DWARF:
             - Value:           0x1
               BlockData:       [ 0x6D ]
             - Value:           0x1
-            - Value:           0x9C
+            - Value:           0x89
             - Value:           0x1
             - Value:           0x27
             - Value:           0x48
@@ -1026,21 +1027,21 @@ DWARF:
         - AbbrCode:        0x6
           Values:
             - Value:           0x1B6
-            - Value:           0x50
+            - Value:           0x3D
             - Value:           0x1
             - Value:           0x27
             - Value:           0x48
         - AbbrCode:        0x7
           Values:
             - Value:           0x1EF
-            - Value:           0x52
+            - Value:           0x3F
             - Value:           0x1
             - Value:           0x28
             - Value:           0x48
         - AbbrCode:        0x7
           Values:
             - Value:           0x214
-            - Value:           0x54
+            - Value:           0x41
             - Value:           0x1
             - Value:           0x29
             - Value:           0x48
@@ -1074,7 +1075,7 @@ DWARF:
             - Value:           0x1
               BlockData:       [ 0x6D ]
             - Value:           0x1
-            - Value:           0xAC
+            - Value:           0x99
             - Value:           0x1
             - Value:           0x2E
             - Value:           0x48
@@ -1083,21 +1084,21 @@ DWARF:
         - AbbrCode:        0x6
           Values:
             - Value:           0x27F
-            - Value:           0x50
+            - Value:           0x3D
             - Value:           0x1
             - Value:           0x2E
             - Value:           0x48
         - AbbrCode:        0x7
           Values:
             - Value:           0x2B8
-            - Value:           0x52
+            - Value:           0x3F
             - Value:           0x1
             - Value:           0x2F
             - Value:           0x48
         - AbbrCode:        0x7
           Values:
             - Value:           0x2DD
-            - Value:           0x54
+            - Value:           0x41
             - Value:           0x1
             - Value:           0x30
             - Value:           0x48
@@ -1131,7 +1132,7 @@ DWARF:
             - Value:           0x1
               BlockData:       [ 0x6D ]
             - Value:           0x1
-            - Value:           0xBC
+            - Value:           0xA9
             - Value:           0x1
             - Value:           0x35
             - Value:           0x48
@@ -1140,20 +1141,20 @@ DWARF:
         - AbbrCode:        0x6
           Values:
             - Value:           0x348
-            - Value:           0x50
+            - Value:           0x3D
             - Value:           0x1
             - Value:           0x35
             - Value:           0x48
         - AbbrCode:        0x7
           Values:
             - Value:           0x381
-            - Value:           0x54
+            - Value:           0x41
             - Value:           0x1
             - Value:           0x37
             - Value:           0x48
         - AbbrCode:        0x9
           Values:
-            - Value:           0x52
+            - Value:           0x3F
             - Value:           0x1
             - Value:           0x36
             - Value:           0x48
@@ -1170,7 +1171,7 @@ DWARF:
             - Value:           0x1
               BlockData:       [ 0x6D ]
             - Value:           0x1
-            - Value:           0xC6
+            - Value:           0xB3
             - Value:           0x1
             - Value:           0x3C
             - Value:           0x48
@@ -1179,7 +1180,7 @@ DWARF:
         - AbbrCode:        0x7
           Values:
             - Value:           0x3A4
-            - Value:           0xCB
+            - Value:           0xB8
             - Value:           0x1
             - Value:           0x3D
             - Value:           0x48


### PR DESCRIPTION
This patch adds `-fdebug-compilation-dir=.` to the clang invocation in `llvm/test/tools/llvm-gsymutil/ARM_AArch64/macho-gsym-merged-callsites-dsym.yaml` and updates the rest of the test accordingly.

Previously, without the newly added argument, the test would significantly change every time it was regenerated due to the generation script using a temporary directory as the compilation directory. See discussion in https://github.com/llvm/llvm-project/pull/129562 for additional context. 

This patch ensures determinism across test update runs - if the test hasn't been updated and we try to regenerate the contents, nothing will change. 