### PR TITLE
[flang] Fix crash in CO_REDUCE semantics

### DIFF
--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -1690,8 +1690,10 @@ static void CheckCoReduce(
           characteristics::FunctionResult::Attr::Allocatable,
           characteristics::FunctionResult::Attr::Pointer,
       };
-  const auto *result{
-      procChars ? procChars->functionResult->GetTypeAndShape() : nullptr};
+  const characteristics::TypeAndShape *result{
+      procChars && procChars->functionResult
+          ? procChars->functionResult->GetTypeAndShape()
+          : nullptr};
   if (!procChars || !procChars->IsPure() ||
       procChars->dummyArguments.size() != 2 || !procChars->functionResult) {
     messages.Say(

--- a/flang/test/Semantics/bug396.f90
+++ b/flang/test/Semantics/bug396.f90
@@ -1,0 +1,6 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+external ext
+integer caf[*]
+!ERROR: OPERATION= argument of CO_REDUCE() must be a pure function of two data arguments
+call co_reduce(caf, ext)
+end


### PR DESCRIPTION
A std::optional<> value was being accessed without first ensuring its presence.