### PR TITLE
[GOFF] Introduce GOFFWriter class

### DIFF
--- a/llvm/include/llvm/MC/MCGOFFObjectWriter.h
+++ b/llvm/include/llvm/MC/MCGOFFObjectWriter.h
@@ -10,6 +10,7 @@
 #define LLVM_MC_MCGOFFOBJECTWRITER_H
 
 #include "llvm/MC/MCObjectWriter.h"
+#include "llvm/MC/MCValue.h"
 
 namespace llvm {
 class MCObjectWriter;
@@ -27,6 +28,25 @@ public:
   static bool classof(const MCObjectTargetWriter *W) {
     return W->getFormat() == Triple::GOFF;
   }
+};
+
+class GOFFObjectWriter : public MCObjectWriter {
+  // The target specific GOFF writer instance.
+  std::unique_ptr<MCGOFFObjectTargetWriter> TargetObjectWriter;
+
+  // The stream used to write the GOFF records.
+  raw_pwrite_stream &OS;
+
+public:
+  GOFFObjectWriter(std::unique_ptr<MCGOFFObjectTargetWriter> MOTW,
+                   raw_pwrite_stream &OS);
+  ~GOFFObjectWriter() override;
+
+  // Implementation of the MCObjectWriter interface.
+  void recordRelocation(const MCFragment &F, const MCFixup &Fixup,
+                        MCValue Target, uint64_t &FixedValue) override {}
+
+  uint64_t writeObject() override;
 };
 
 /// \brief Construct a new GOFF writer instance.

--- a/llvm/include/llvm/MC/MCGOFFStreamer.h
+++ b/llvm/include/llvm/MC/MCGOFFStreamer.h
@@ -13,6 +13,7 @@
 #include "llvm/MC/MCObjectWriter.h"
 
 namespace llvm {
+class GOFFObjectWriter;
 
 class MCGOFFStreamer : public MCObjectStreamer {
 public:
@@ -23,6 +24,8 @@ public:
                          std::move(Emitter)) {}
 
   ~MCGOFFStreamer() override;
+
+  GOFFObjectWriter &getWriter();
 
   bool emitSymbolAttribute(MCSymbol *Symbol, MCSymbolAttr Attribute) override {
     return false;

--- a/llvm/lib/MC/MCGOFFStreamer.cpp
+++ b/llvm/lib/MC/MCGOFFStreamer.cpp
@@ -15,11 +15,16 @@
 #include "llvm/MC/MCAssembler.h"
 #include "llvm/MC/MCCodeEmitter.h"
 #include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCGOFFObjectWriter.h"
 #include "llvm/MC/TargetRegistry.h"
 
 using namespace llvm;
 
 MCGOFFStreamer::~MCGOFFStreamer() {}
+
+GOFFObjectWriter &MCGOFFStreamer::getWriter() {
+  return static_cast<GOFFObjectWriter &>(getAssembler().getWriter());
+}
 
 MCStreamer *llvm::createGOFFStreamer(MCContext &Context,
                                      std::unique_ptr<MCAsmBackend> &&MAB,


### PR DESCRIPTION
The GOFFWriter has 2 purposes:
- Simplify resource management
- Enable writing of split DWARF files

It follows the design of the other writer classes. No added functionality at this point.