### PR TITLE
[RISCV] Move Size and CopyCost overrides for vector register to the VReg class. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -225,9 +225,6 @@ class RISCVRegisterClass<list<ValueType> regTypes, int align, dag regList>
   int VLMul = 1;
   int NF = 1;
 
-  let Size = !if(IsVRegClass, !mul(VLMul, NF, 64), 0);
-  let CopyCost = !if(IsVRegClass, !mul(VLMul, NF), 1);
-
   let TSFlags{0} = IsVRegClass;
   let TSFlags{3-1} = !logtwo(VLMul);
   let TSFlags{6-4} = !sub(NF, 1);
@@ -719,6 +716,9 @@ class VReg<list<ValueType> regTypes, dag regList, int Vlmul>
                          regList> {
   let IsVRegClass = 1;
   let VLMul = Vlmul;
+
+  let Size = !mul(VLMul, NF, 64);
+  let CopyCost = !mul(VLMul, NF);
 }
 
 defvar VMaskVTs = [vbool1_t, vbool2_t, vbool4_t, vbool8_t, vbool16_t,


### PR DESCRIPTION
Instead using the IsVRegClass to calculate in the base class, just override directly.

This will scale better if we need to do different types of overrides for other register types in the future.