### PR TITLE
[docs] Fix link appearing improperly

### DIFF
--- a/llvm/docs/DeveloperPolicy.rst
+++ b/llvm/docs/DeveloperPolicy.rst
@@ -539,9 +539,9 @@ What are the expectations around a revert?
 Obtaining Commit Access
 -----------------------
 
-Once you have 3 or more merged pull requests, you may use this
-link <https://github.com/llvm/llvm-project/issues/new?title=Request%20Commit%20Access%20For%20%3Cuser%3E&body=%23%23%23%20Why%20Are%20you%20requesting%20commit%20access%20?>`_ to file
-an issue and request commit access. Replace the <user> string in the title
+Once you have 3 or more merged pull requests, you may use `this link
+<https://github.com/llvm/llvm-project/issues/new?title=Request%20Commit%20Access%20For%20%3Cuser%3E&body=%23%23%23%20Why%20Are%20you%20requesting%20commit%20access%20?>`_
+to file an issue and request commit access. Replace the <user> string in the title
 with your github username, and explain why you are requesting commit access in
 the issue description.  Once the issue is created, you will need to get two
 current contributors to support your request before commit access will be granted.


### PR DESCRIPTION
See current live website: https://llvm.org/docs/DeveloperPolicy.html#obtaining-commit-access
![image](https://github.com/user-attachments/assets/f3212ca6-b2a6-4d83-9323-11ba4148d991)

Building locally, it appears correctly:
![image](https://github.com/user-attachments/assets/68f5e932-1abf-48cf-93f0-30dacb0910c6)

Feel free to merge immediately.