### PR TITLE
[RISCV] Shrink the size of the VLMul field in RegisterClass target flags. Use uint8_t for TSFlags. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.h
@@ -22,34 +22,34 @@
 namespace llvm {
 
 namespace RISCVRI {
-enum {
+enum : uint8_t {
   // The IsVRegClass value of this RegisterClass.
   IsVRegClassShift = 0,
   IsVRegClassShiftMask = 0b1 << IsVRegClassShift,
   // The VLMul value of this RegisterClass. This value is valid iff IsVRegClass
   // is true.
   VLMulShift = IsVRegClassShift + 1,
-  VLMulShiftMask = 0b111 << VLMulShift,
+  VLMulShiftMask = 0b11 << VLMulShift,
 
   // The NF value of this RegisterClass. This value is valid iff IsVRegClass is
   // true.
-  NFShift = VLMulShift + 3,
+  NFShift = VLMulShift + 2,
   NFShiftMask = 0b111 << NFShift,
 };
 
 /// \returns the IsVRegClass for the register class.
-static inline bool isVRegClass(uint64_t TSFlags) {
+static inline bool isVRegClass(uint8_t TSFlags) {
   return (TSFlags & IsVRegClassShiftMask) >> IsVRegClassShift;
 }
 
 /// \returns the LMUL for the register class.
-static inline RISCVVType::VLMUL getLMul(uint64_t TSFlags) {
+static inline RISCVVType::VLMUL getLMul(uint8_t TSFlags) {
   return static_cast<RISCVVType::VLMUL>((TSFlags & VLMulShiftMask) >>
                                         VLMulShift);
 }
 
 /// \returns the NF for the register class.
-static inline unsigned getNF(uint64_t TSFlags) {
+static inline unsigned getNF(uint8_t TSFlags) {
   return static_cast<unsigned>((TSFlags & NFShiftMask) >> NFShift) + 1;
 }
 } // namespace RISCVRI

--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -229,8 +229,8 @@ class RISCVRegisterClass<list<ValueType> regTypes, int align, dag regList>
   let CopyCost = !if(IsVRegClass, !mul(VLMul, NF), 1);
 
   let TSFlags{0} = IsVRegClass;
-  let TSFlags{3-1} = !logtwo(VLMul);
-  let TSFlags{6-4} = !sub(NF, 1);
+  let TSFlags{2-1} = !logtwo(VLMul);
+  let TSFlags{5-3} = !sub(NF, 1);
 }
 
 class GPRRegisterClass<dag regList>


### PR DESCRIPTION
There are only 4 possible LMULs corresponding to log2 of 1, 2, 4, and 8. Those fit in 2 bits.

Use uint8_t for the flag bits to match the size in TargetRegisterClass.