### PR TITLE
[stdio][baremetal] Fix templating for print functions

### DIFF
--- a/libc/src/stdio/baremetal/printf.cpp
+++ b/libc/src/stdio/baremetal/printf.cpp
@@ -38,9 +38,9 @@ LLVM_LIBC_FUNCTION(int, printf, (const char *__restrict format, ...)) {
   constexpr size_t BUFF_SIZE = 1024;
   char buffer[BUFF_SIZE];
 
-  printf_core::WriteBuffer<Mode<WriteMode::FLUSH_TO_STREAM>::value> wb(
+  printf_core::WriteBuffer<printf_core::WriteMode::FLUSH_TO_STREAM> wb(
       buffer, BUFF_SIZE, &raw_write_hook, nullptr);
-  printf_core::Writer writer(&wb);
+  printf_core::Writer<printf_core::WriteMode::FLUSH_TO_STREAM> writer(wb);
 
   int retval = printf_core::printf_main(&writer, format, args);
 

--- a/libc/src/stdio/baremetal/vprintf.cpp
+++ b/libc/src/stdio/baremetal/vprintf.cpp
@@ -36,9 +36,9 @@ LLVM_LIBC_FUNCTION(int, vprintf,
   constexpr size_t BUFF_SIZE = 1024;
   char buffer[BUFF_SIZE];
 
-  printf_core::WriteBuffer<Mode<WriteMode::FLUSH_TO_STREAM>::value> wb(
+  printf_core::WriteBuffer<printf_core::WriteMode::FLUSH_TO_STREAM> wb(
       buffer, BUFF_SIZE, &raw_write_hook, nullptr);
-  printf_core::Writer writer(&wb);
+  printf_core::Writer<printf_core::WriteMode::FLUSH_TO_STREAM> writer(wb);
 
   int retval = printf_core::printf_main(&writer, format, args);
 


### PR DESCRIPTION
This addresses build errors from https://github.com/llvm/llvm-project/pull/111559.