### PR TITLE
[clang] Fix inaccurate wording of warn_second_arg_of_va_start_not_last_named_param

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10613,8 +10613,8 @@ def err_va_start_used_in_wrong_abi_function : Error<
   "'va_start' used in %select{System V|Win64}0 ABI function">;
 def err_ms_va_start_used_in_sysv_function : Error<
   "'__builtin_ms_va_start' used in System V ABI function">;
-def warn_second_arg_of_va_start_not_last_named_param : Warning<
-  "second argument to 'va_start' is not the last named parameter">,
+def warn_second_arg_of_va_start_not_last_non_variadic_param : Warning<
+  "second argument to 'va_start' is not the last non-variadic parameter">,
   InGroup<Varargs>;
 def warn_c17_compat_ellipsis_only_parameter : Warning<
   "'...' as the only parameter of a function is incompatible with C standards "

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -4893,7 +4893,7 @@ bool Sema::BuiltinVAStart(unsigned BuiltinID, CallExpr *TheCall) {
 
   if (!SecondArgIsLastNamedArgument)
     Diag(TheCall->getArg(1)->getBeginLoc(),
-         diag::warn_second_arg_of_va_start_not_last_named_param);
+         diag::warn_second_arg_of_va_start_not_last_non_variadic_param);
   else if (IsCRegister || Type->isReferenceType() ||
            Type->isSpecificBuiltinType(BuiltinType::Float) || [=] {
              // Promotable integers are UB, but enumerations need a bit of

--- a/clang/test/C/C23/n2975.c
+++ b/clang/test/C/C23/n2975.c
@@ -46,7 +46,7 @@ void diag(int a, int b, ...) {
   va_start(list, a);
   // However, the builtin itself is under no such constraints regarding
   // expanding or evaluating the second argument, so it can still diagnose.
-  __builtin_va_start(list, a); // expected-warning {{second argument to 'va_start' is not the last named parameter}}
+  __builtin_va_start(list, a); // expected-warning {{second argument to 'va_start' is not the last non-variadic parameter}}
   va_end(list);
 }
 

--- a/clang/test/Sema/varargs-x86-64.c
+++ b/clang/test/Sema/varargs-x86-64.c
@@ -20,8 +20,8 @@ void __attribute__((ms_abi)) g1(int a) {
 void __attribute__((ms_abi)) g2(int a, int b, ...) {
   __builtin_ms_va_list ap;
 
-  __builtin_ms_va_start(ap, 10); // expected-warning {{second argument to 'va_start' is not the last named parameter}}
-  __builtin_ms_va_start(ap, a); // expected-warning {{second argument to 'va_start' is not the last named parameter}}
+  __builtin_ms_va_start(ap, 10); // expected-warning {{second argument to 'va_start' is not the last non-variadic parameter}}
+  __builtin_ms_va_start(ap, a); // expected-warning {{second argument to 'va_start' is not the last non-variadic parameter}}
   __builtin_ms_va_start(ap, b);
 }
 

--- a/clang/test/Sema/varargs.c
+++ b/clang/test/Sema/varargs.c
@@ -14,8 +14,8 @@ void f2(int a, int b, ...)
 {
     __builtin_va_list ap;
 
-    __builtin_va_start(ap, 10); // expected-warning {{second argument to 'va_start' is not the last named parameter}}
-    __builtin_va_start(ap, a); // expected-warning {{second argument to 'va_start' is not the last named parameter}}
+    __builtin_va_start(ap, 10); // expected-warning {{second argument to 'va_start' is not the last non-variadic parameter}}
+    __builtin_va_start(ap, a); // expected-warning {{second argument to 'va_start' is not the last non-variadic parameter}}
     __builtin_va_start(ap, b);
 }
 

--- a/clang/test/SemaCXX/vararg-non-pod.cpp
+++ b/clang/test/SemaCXX/vararg-non-pod.cpp
@@ -167,7 +167,7 @@ void t6(Foo somearg, ... ) {
 // it should behave the same
 void t6b(Foo somearg, ... ) {
   __builtin_va_list list;
-  __builtin_stdarg_start(list, somearg); // second argument to 'va_start' is not the last named parameter [-Wvarargs]
+  __builtin_stdarg_start(list, somearg); // second argument to 'va_start' is not the last non-variadic parameter [-Wvarargs]
 }
 
 void t7(int n, ...) {

--- a/clang/test/SemaCXX/varargs.cpp
+++ b/clang/test/SemaCXX/varargs.cpp
@@ -15,7 +15,7 @@ void g(register int i, ...) { // expected-warning 0-1{{deprecated}}
 // Don't crash when there is no last parameter.
 void no_params(...) {
   int a;
-  __builtin_va_start(ap, a); // expected-warning {{second argument to 'va_start' is not the last named parameter}}
+  __builtin_va_start(ap, a); // expected-warning {{second argument to 'va_start' is not the last non-variadic parameter}}
 }
 
 // Reject this. The __builtin_va_start would execute in Foo's non-variadic


### PR DESCRIPTION
Rename and update the wording of `warn_second_arg_of_va_start_not_last_named_param` to best indicate that it's actually the last non-variadic parameter instead.

As per issue:
- https://github.com/llvm/llvm-project/issues/131171