### PR TITLE
SelectionDAG: neg (and x, 1)  -->  SIGN_EXTEND_INREG x, i1

### DIFF
--- a/llvm/test/CodeGen/AArch64/arm64-bitfield-extract.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-bitfield-extract.ll
@@ -1067,3 +1067,18 @@ if.else:
 end:
   ret void
 }
+
+define i64 @sign_extend_lsb(i64 %arg) nounwind {
+; LLC-LABEL: sign_extend_lsb:
+; LLC:       // %bb.0:
+; LLC-NEXT:    sbfx x0, x0, #0, #1
+; LLC-NEXT:    ret
+; OPT-LABEL: @sign_extend_lsb(
+; OPT-NEXT:    [[AND:%.*]] = and i64 [[ARG:%.*]], 1
+; OPT-NEXT:    [[NEG:%.*]] = sub i64 0, [[AND]]
+; OPT-NEXT:    ret i64 [[NEG]]
+;
+  %and = and i64 %arg, 1
+  %neg = sub i64 0, %and
+  ret i64 %neg
+}

--- a/llvm/test/CodeGen/AArch64/pr61111.ll
+++ b/llvm/test/CodeGen/AArch64/pr61111.ll
@@ -5,9 +5,9 @@ define i62 @f(i1 %0) {
 ; CHECK-LABEL: f:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    // kill: def $w0 killed $w0 def $x0
-; CHECK-NEXT:    and x8, x0, #0x1
-; CHECK-NEXT:    sub x8, x8, #1
-; CHECK-NEXT:    tst x8, #0x3fffffffffffffff
+; CHECK-NEXT:    sbfx x8, x0, #0, #1
+; CHECK-NEXT:    mov x9, #4611686018427387903 // =0x3fffffffffffffff
+; CHECK-NEXT:    bics xzr, x9, x8
 ; CHECK-NEXT:    cset w0, ne
 ; CHECK-NEXT:    ret
   %2 = zext i1 %0 to i59


### PR DESCRIPTION
The pattern
```LLVM
%shl = shl i32 %x, 31
%ashr = ashr i32 %shl, 31
```
would be combined to `SIGN_EXTEND_INREG %x, ValueType:ch:i1` by SelectionDAG.
However InstCombine normalizes this pattern to:
```LLVM
%and = and i32 %x, 1
%neg = sub i32 0, %and
```
This adds matching code to DAGCombiner to catch this variant as well.