### PR TITLE
[libc] init uefi

### DIFF
--- a/libc/cmake/modules/LLVMLibCArchitectures.cmake
+++ b/libc/cmake/modules/LLVMLibCArchitectures.cmake
@@ -191,6 +191,8 @@ elseif(LIBC_TARGET_OS STREQUAL "windows")
   set(LIBC_TARGET_OS_IS_WINDOWS TRUE)
 elseif(LIBC_TARGET_OS STREQUAL "gpu")
   set(LIBC_TARGET_OS_IS_GPU TRUE)
+elseif(LIBC_TARGET_OS STREQUAL "uefi")
+  set(LIBC_TARGET_OS_IS_UEFI TRUE)
 else()
   message(FATAL_ERROR
           "Unsupported libc target operating system ${LIBC_TARGET_OS}")

--- a/libc/config/uefi/config.json
+++ b/libc/config/uefi/config.json
@@ -1,0 +1,7 @@
+{
+  "errno": {
+    "LIBC_CONF_ERRNO_MODE": {
+      "value": "LIBC_ERRNO_MODE_SHARED"
+    }
+  }
+}

--- a/libc/config/uefi/entrypoints.txt
+++ b/libc/config/uefi/entrypoints.txt
@@ -1,0 +1,11 @@
+set(TARGET_LIBC_ENTRYPOINTS
+    # errno.h entrypoints
+    libc.src.errno.errno
+)
+
+set(TARGET_LIBM_ENTRYPOINTS)
+
+set(TARGET_LLVMLIBC_ENTRYPOINTS
+  ${TARGET_LIBC_ENTRYPOINTS}
+  ${TARGET_LIBM_ENTRYPOINTS}
+)

--- a/libc/config/uefi/headers.txt
+++ b/libc/config/uefi/headers.txt
@@ -1,0 +1,4 @@
+set(TARGET_PUBLIC_HEADERS
+    libc.include.errno
+    libc.include.uefi
+)

--- a/libc/include/Uefi.yaml
+++ b/libc/include/Uefi.yaml
@@ -1,5 +1,6 @@
 header: Uefi.h
-standards: UEFI
+standards:
+  - uefi
 macros: []
 types:
   - type_name: EFI_BOOT_SERVICES

--- a/libc/src/__support/OSUtil/io.h
+++ b/libc/src/__support/OSUtil/io.h
@@ -24,6 +24,8 @@
 #elif defined(__ELF__)
 // TODO: Ideally we would have LIBC_TARGET_OS_IS_BAREMETAL.
 #include "baremetal/io.h"
+#elif defined(__UEFI__)
+#include "uefi/io.h"
 #endif
 
 #endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_IO_H

--- a/libc/src/__support/OSUtil/uefi/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/uefi/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_object_library(
+  uefi_util
+  SRCS
+    io.cpp
+    exit.cpp
+  HDRS
+    io.h
+  DEPENDS
+    libc.src.__support.common
+    libc.src.__support.CPP.string_view
+)

--- a/libc/src/__support/OSUtil/uefi/exit.cpp
+++ b/libc/src/__support/OSUtil/uefi/exit.cpp
@@ -1,0 +1,22 @@
+//===-------- UEFI implementation of an exit function ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-----------------------------------------------------------------===//
+
+#include "src/__support/OSUtil/exit.h"
+#include "include/Uefi.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace internal {
+
+[[noreturn]] void exit(int status) {
+  efi_system_table->BootServices->Exit(efi_image_handle, status, 0, nullptr);
+  __builtin_unreachable();
+}
+
+} // namespace internal
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/__support/OSUtil/uefi/io.cpp
+++ b/libc/src/__support/OSUtil/uefi/io.cpp
@@ -1,0 +1,36 @@
+//===---------- UEFI implementation of IO utils ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-----------------------------------------------------------------===//
+
+#include "io.h"
+
+#include "src/__support/CPP/string_view.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+ssize_t read_from_stdin(char *buf, size_t size) { return 0; }
+
+void write_to_stdout(cpp::string_view msg) {
+  // TODO: use mbstowcs once implemented
+  for (size_t i = 0; i < msg.size(); i++) {
+    char16_t e[2] = {msg[i], 0};
+    efi_system_table->ConOut->OutputString(
+        efi_system_table->ConOut, reinterpret_cast<const char16_t *>(&e));
+  }
+}
+
+void write_to_stderr(cpp::string_view msg) {
+  // TODO: use mbstowcs once implemented
+  for (size_t i = 0; i < msg.size(); i++) {
+    char16_t e[2] = {msg[i], 0};
+    efi_system_table->StdErr->OutputString(
+        efi_system_table->StdErr, reinterpret_cast<const char16_t *>(&e));
+  }
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/__support/OSUtil/uefi/io.h
+++ b/libc/src/__support/OSUtil/uefi/io.h
@@ -1,0 +1,25 @@
+//===---------- UEFI implementation of IO utils ------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-----------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_OSUTIL_UEFI_IO_H
+#define LLVM_LIBC_SRC___SUPPORT_OSUTIL_UEFI_IO_H
+
+#include "include/llvm-libc-types/size_t.h"
+#include "include/llvm-libc-types/ssize_t.h"
+#include "src/__support/CPP/string_view.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+ssize_t read_from_stdin(char *buf, size_t size);
+void write_to_stderr(cpp::string_view msg);
+void write_to_stdout(cpp::string_view msg);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_OSUTIL_UEFI_IO_H

--- a/libc/utils/hdrgen/hdrgen/header.py
+++ b/libc/utils/hdrgen/hdrgen/header.py
@@ -43,6 +43,7 @@ LIBRARY_DESCRIPTIONS = {
     "bsd": "BSD",
     "gnu": "GNU",
     "linux": "Linux",
+    "uefi": "UEFI",
 }
 
 HEADER_TEMPLATE = """\


### PR DESCRIPTION
Initial UEFI OS target support after the headers. This just defines enough that stuff might try and compile. Test with:
```
$ cmake -S llvm -B build -G Ninja -DLLVM_RUNTIME_TARGETS=x86_64-unknown-uefi-llvm -DRUNTIMES_x86_64-unknown-uefi-llvm_LLVM_ENABLE_RUNTIMES=libc -DRUNTIMES_x86_64-unknown-uefi-llvm_LLVM_LIBC_FULL_BUILD=true -DCMAKE_C_COMPILER_WORKS=true -DCMAKE_CXX_COMPILER_WORKS=true -DLLVM_ENABLE_PROJECTS="clang;lld" -DCMAKE_BUILD_TYPE=Debug -DLLVM_ENABLE_LIBCXX=true -DLLVM_HOST_TRIPLE=aarch64-unknown-linux-gnu -DLLVM_DEFAULT_TARGET_TRIPLE=x86_64-unknown-uefi-llvm -DCMAKE_INSTALL_LIBDIR=build/target/lib
$ ninja -C build
```