### PR TITLE
[Darwin][ASan][Test] Create a noinlined wrapper function for reliable suppression in test.

### DIFF
--- a/compiler-rt/test/asan/TestCases/Darwin/suppressions-sandbox.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/suppressions-sandbox.cpp
@@ -13,7 +13,8 @@
 
 #include <CoreFoundation/CoreFoundation.h>
 
-// Use a noinline + disable_tail_calls wrapper function to suppress to stabilize test.
+// Disable optimizations to ensure that this function appears on the stack trace so our
+// configured suppressions `interceptor_via_fun:createCFString` can take effect.
 __attribute__((noinline, disable_tail_calls)) CFStringRef
 createCFString(const unsigned char *bytes, CFIndex length) {
   return CFStringCreateWithBytes(kCFAllocatorDefault, bytes, length,

--- a/compiler-rt/test/asan/TestCases/Darwin/suppressions-sandbox.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/suppressions-sandbox.cpp
@@ -4,7 +4,7 @@
 
 // Check that suppressing a function name works within a no-fork sandbox
 // RUN: echo "interceptor_via_fun:createCFString" > %t.supp
-// RUN: %env_asan_opts=suppressions='"%t.supp"':verbosity=1:detect_leaks=0 \
+// RUN: %env_asan_opts=suppressions='"%t.supp"' \
 // RUN:   sandbox-exec -p '(version 1)(allow default)(deny process-fork)' \
 // RUN:   %run %t 2>&1 | FileCheck --check-prefix=CHECK-IGNORE %s
 

--- a/compiler-rt/test/asan/TestCases/Darwin/suppressions-sandbox.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/suppressions-sandbox.cpp
@@ -3,8 +3,8 @@
 // RUN: not %run %t 2>&1 | FileCheck --check-prefix=CHECK-CRASH %s
 
 // Check that suppressing a function name works within a no-fork sandbox
-// RUN: echo "interceptor_via_fun:CFStringCreateWithBytes" > %t.supp
-// RUN: %env_asan_opts=suppressions='"%t.supp"' \
+// RUN: echo "interceptor_via_fun:createCFString" > %t.supp
+// RUN: %env_asan_opts=suppressions='"%t.supp"':verbosity=1:detect_leaks=0 \
 // RUN:   sandbox-exec -p '(version 1)(allow default)(deny process-fork)' \
 // RUN:   %run %t 2>&1 | FileCheck --check-prefix=CHECK-IGNORE %s
 
@@ -13,12 +13,17 @@
 
 #include <CoreFoundation/CoreFoundation.h>
 
+// Use a noinline + disable_tail_calls wrapper function to suppress to stabilize test.
+__attribute__((noinline, disable_tail_calls)) CFStringRef
+createCFString(const unsigned char *bytes, CFIndex length) {
+  return CFStringCreateWithBytes(kCFAllocatorDefault, bytes, length,
+                                 kCFStringEncodingUTF8, FALSE);
+}
+
 int main() {
   char *a = (char *)malloc(6);
   strcpy(a, "hello");
-  CFStringRef str =
-      CFStringCreateWithBytes(kCFAllocatorDefault, (unsigned char *)a, 10,
-                              kCFStringEncodingUTF8, FALSE);  // BOOM
+  CFStringRef str = createCFString((unsigned char *)a, 10); // BOOM
   fprintf(stderr, "Ignored.\n");
   free(a);
   CFRelease(str);


### PR DESCRIPTION
CFStringCreateWithBytes may not always appear on stack due to optimizations. Create a wrapper function for the purposes of testing suppression files that will always appear on stack for test stability.

Also necessary to disable leaks to pass on Apple Silicon.

rdar://144800068
