### PR TITLE
[webkit.NoUncountedMemberChecker] Fix a regression that every class is treated as if it's ref countable.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
@@ -223,7 +223,7 @@ public:
   std::optional<bool>
   isPtrCompatible(const clang::QualType,
                   const clang::CXXRecordDecl *R) const final {
-    return R && isRefCountable(R);
+    return R ? isRefCountable(R) : std::nullopt;
   }
 
   bool isPtrCls(const clang::CXXRecordDecl *R) const final {
@@ -246,7 +246,7 @@ public:
   std::optional<bool>
   isPtrCompatible(const clang::QualType,
                   const clang::CXXRecordDecl *R) const final {
-    return R && isCheckedPtrCapable(R);
+    return R ? isCheckedPtrCapable(R) : std::nullopt;
   }
 
   bool isPtrCls(const clang::CXXRecordDecl *R) const final {

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-members.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-members.cpp
@@ -36,7 +36,6 @@ namespace members {
   };
 }
 
-
 namespace ignore_unions {
   union Foo {
     RefCountable* a;
@@ -60,3 +59,12 @@ void foo(RefCountable* t) {
 }
 
 } // ignore_system_header
+
+namespace ignore_non_ref_countable {
+  struct Foo {
+  };
+
+  struct Bar {
+    Foo* foo;
+  };
+}


### PR DESCRIPTION
This PR fixes a regression that webkit.NoUncountedMemberChecker and alpha.webkit.NoUncheckedMemberChecker emits warnings for every class as if they supported ref counting and checked ptr because we were erroneously coercing the return value of isRefCountable and isCheckedPtrCapable, which is std::optional<bool>, to boolean values.