### PR TITLE
[BPF] Remove unnecessary BitCast operations

### DIFF
--- a/llvm/lib/Target/BPF/BPFAbstractMemberAccess.cpp
+++ b/llvm/lib/Target/BPF/BPFAbstractMemberAccess.cpp
@@ -1102,30 +1102,18 @@ bool BPFAbstractMemberAccess::transformGEPChain(CallInst *Call,
   //   %4 = bitcast %struct.net_device** %dev1 to i64*
   // it is transformed to:
   //   %6 = load llvm.sk_buff:0:50$0:0:0:2:0
-  //   %7 = bitcast %struct.sk_buff* %2 to i8*
-  //   %8 = getelementptr i8, i8* %7, %6
-  //   %9 = bitcast i8* %8 to i64*
-  //   using %9 instead of %4
+  //   %8 = getelementptr i8, i8* %2, %6
+  //   using %8 instead of %4
   // The original Call inst is removed.
 
   // Load the global variable.
   auto *LDInst = new LoadInst(Type::getInt64Ty(BB->getContext()), GV, "",
                               Call->getIterator());
 
-  // Generate a BitCast
-  auto *BCInst = new BitCastInst(
-      Base, PointerType::get(BB->getContext(),
-                             Base->getType()->getPointerAddressSpace()));
-  BCInst->insertBefore(Call->getIterator());
-
   // Generate a GetElementPtr
-  auto *GEP = GetElementPtrInst::Create(Type::getInt8Ty(BB->getContext()),
-                                        BCInst, LDInst);
+  auto *GEP = GetElementPtrInst::Create(Type::getInt8Ty(BB->getContext()), Base,
+                                        LDInst);
   GEP->insertBefore(Call->getIterator());
-
-  // Generate a BitCast
-  auto *BCInst2 = new BitCastInst(GEP, Call->getType());
-  BCInst2->insertBefore(Call->getIterator());
 
   // For the following code,
   //    Block0:
@@ -1133,8 +1121,7 @@ bool BPFAbstractMemberAccess::transformGEPChain(CallInst *Call,
   //      if (...) goto Block1 else ...
   //    Block1:
   //      %6 = load llvm.sk_buff:0:50$0:0:0:2:0
-  //      %7 = bitcast %struct.sk_buff* %2 to i8*
-  //      %8 = getelementptr i8, i8* %7, %6
+  //      %8 = getelementptr i8, i8* %2, %6
   //      ...
   //      goto CommonExit
   //    Block2:
@@ -1142,8 +1129,7 @@ bool BPFAbstractMemberAccess::transformGEPChain(CallInst *Call,
   //      if (...) goto Block3 else ...
   //    Block3:
   //      %6 = load llvm.bpf_map:0:40$0:0:0:2:0
-  //      %7 = bitcast %struct.sk_buff* %2 to i8*
-  //      %8 = getelementptr i8, i8* %7, %6
+  //      %8 = getelementptr i8, i8* %2, %6
   //      ...
   //      goto CommonExit
   //    CommonExit
@@ -1157,8 +1143,7 @@ bool BPFAbstractMemberAccess::transformGEPChain(CallInst *Call,
   //    Block_Common:
   //      PHI = [llvm.sk_buff:0:50$0:0:0:2:0, llvm.bpf_map:0:40$0:0:0:2:0]
   //      %6 = load PHI
-  //      %7 = bitcast %struct.sk_buff* %2 to i8*
-  //      %8 = getelementptr i8, i8* %7, %6
+  //      %8 = getelementptr i8, i8* %2, %6
   //      ...
   //      goto CommonExit
   //  For the above code, we cannot perform proper relocation since
@@ -1173,7 +1158,7 @@ bool BPFAbstractMemberAccess::transformGEPChain(CallInst *Call,
   // This approach is also used in other places when global var
   // representing a relocation is used.
   Instruction *PassThroughInst =
-      BPFCoreSharedInfo::insertPassThrough(M, BB, BCInst2, Call);
+      BPFCoreSharedInfo::insertPassThrough(M, BB, GEP, Call);
   Call->replaceAllUsesWith(PassThroughInst);
   Call->eraseFromParent();
 


### PR DESCRIPTION
In [1], Nikita Popov spotted that two BitCast operations are not needed with opaque pointers. So remove these two BitCast operations and adjust corresponding comments as well.

  [1] https://github.com/llvm/llvm-project/pull/130722