### PR TITLE
[ctxprof] Fix initializer in PGOCtxProfLowering

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/PGOCtxProfLowering.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOCtxProfLowering.cpp
@@ -124,6 +124,7 @@ CtxInstrumentationLowerer::CtxInstrumentationLowerer(Module &M,
                                       });
   FunctionDataTy =
       StructType::get(M.getContext(), {
+                                          PointerTy,          /*Next*/
                                           PointerTy,          /*FlatCtx*/
                                           SanitizerMutexType, /*Mutex*/
                                       });


### PR DESCRIPTION
It needs to match the structure of `FunctionData` in compiler-rt, but missed a field in PR #130655.