### PR TITLE
[lldb] Fix TestGdbRemoteForkNonStop.py test

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2022,7 +2022,7 @@ class TestBase(Base, metaclass=LLDBTestCaseFactory):
         """Get the working directory that should be used when launching processes for local or remote processes."""
         if lldb.remote_platform:
             # Remote tests set the platform working directory up in
-            # TestBase.setUp()
+            # Base.setUp()
             return lldb.remote_platform.GetWorkingDirectory()
         else:
             # local tests change directory into each test subdirectory

--- a/lldb/test/API/tools/lldb-server/TestGdbRemoteForkNonStop.py
+++ b/lldb/test/API/tools/lldb-server/TestGdbRemoteForkNonStop.py
@@ -1,6 +1,6 @@
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
-
+from lldbsuite.test.lldbutil import append_to_process_working_directory
 from fork_testbase import GdbRemoteForkTestBase
 
 
@@ -156,8 +156,8 @@ class TestGdbRemoteForkNonStop(GdbRemoteForkTestBase):
 
     @add_test_categories(["fork"])
     def test_c_both_nonstop(self):
-        lock1 = self.getBuildArtifact("lock1")
-        lock2 = self.getBuildArtifact("lock2")
+        lock1 = lldbutil.append_to_process_working_directory(self, "lock1")
+        lock2 = lldbutil.append_to_process_working_directory(self, "lock2")
         parent_pid, parent_tid, child_pid, child_tid = self.start_fork_test(
             [
                 "fork",
@@ -194,8 +194,8 @@ class TestGdbRemoteForkNonStop(GdbRemoteForkTestBase):
 
     @add_test_categories(["fork"])
     def test_vCont_both_nonstop(self):
-        lock1 = self.getBuildArtifact("lock1")
-        lock2 = self.getBuildArtifact("lock2")
+        lock1 = lldbutil.append_to_process_working_directory(self, "lock1")
+        lock2 = lldbutil.append_to_process_working_directory(self, "lock2")
         parent_pid, parent_tid, child_pid, child_tid = self.start_fork_test(
             [
                 "fork",
@@ -227,8 +227,8 @@ class TestGdbRemoteForkNonStop(GdbRemoteForkTestBase):
         self.assertIn("PID: {}".format(int(child_pid, 16)).encode(), output)
 
     def vCont_both_nonstop_test(self, vCont_packet):
-        lock1 = self.getBuildArtifact("lock1")
-        lock2 = self.getBuildArtifact("lock2")
+        lock1 = lldbutil.append_to_process_working_directory(self, "lock1")
+        lock2 = lldbutil.append_to_process_working_directory(self, "lock2")
         parent_pid, parent_tid, child_pid, child_tid = self.start_fork_test(
             [
                 "fork",


### PR DESCRIPTION
During lldb testing on remote targets TestGdbRemoteForkNonStop.py freezes because in this test we try to create file on remote machine using absolute file path from local machine. This patch fixes this error