### PR TITLE
[Format] Do not crash on non-null terminated strings

### DIFF
--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -2031,6 +2031,7 @@ private:
   // The order of these fields are important - they should be in the same order
   // as they are created in `createSourceManagerForFile` so that they can be
   // deleted in the reverse order as they are created.
+  std::string ContentBuffer;
   std::unique_ptr<FileManager> FileMgr;
   std::unique_ptr<DiagnosticsEngine> Diagnostics;
   std::unique_ptr<SourceManager> SourceMgr;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -29097,10 +29097,9 @@ TEST_F(FormatTest, BreakBeforeClassName) {
 }
 
 TEST_F(FormatTest, DoesNotCrashOnNonNullTerminatedStringRefs) {
-  llvm::StringRef TwoLines = "namespace foo {}\n"
-                             "namespace bar {}";
-  llvm::StringRef FirstLine =
-      TwoLines.take_until([](char c) { return c == '\n'; });
+  StringRef TwoLines = "namespace foo {}\n"
+                       "namespace bar {}";
+  StringRef FirstLine = TwoLines.take_until([](char c) { return c == '\n'; });
 
   // The internal API used to crash when passed a non-null-terminated StringRef.
   // Check this does not happen anymore.

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -29104,7 +29104,7 @@ TEST_F(FormatTest, DoesNotCrashOnNonNullTerminatedStringRefs) {
 
   // The internal API used to crash when passed a non-null-terminated StringRef.
   // Check this does not happen anymore.
-  verifyFormat(FirstLine);
+  verifyNoCrash(FirstLine);
 }
 
 } // namespace

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -29096,6 +29096,17 @@ TEST_F(FormatTest, BreakBeforeClassName) {
                "    ArenaSafeUniquePtr {};");
 }
 
+TEST_F(FormatTest, DoesNotCrashOnNonNullTerminatedStringRefs) {
+  llvm::StringRef TwoLines = "namespace foo {}\n"
+                             "namespace bar {}";
+  llvm::StringRef FirstLine =
+      TwoLines.take_until([](char c) { return c == '\n'; });
+
+  // The internal API used to crash when passed a non-null-terminated StringRef.
+  // Check this does not happen anymore.
+  verifyFormat(FirstLine);
+}
+
 } // namespace
 } // namespace test
 } // namespace format


### PR DESCRIPTION
The `format` API receives a StringRef, but crashes whenever it is non-null-terminated with the corresponding assertion:

```
FormatTests: llvm/lib/Support/MemoryBuffer.cpp:53:
void llvm::MemoryBuffer::init(const char *, const char *, bool):
Assertion `(!RequiresNullTerminator || BufEnd[0] == 0) && "Buffer is not null terminated!"' failed.
```

Ensure this does not happen by storing a copy of the inputs in `std::string` that does have a null terminator.

This changes requires an extra copy of the `Content` in the `SourceManagerForFile` APIs, but the costs of that copy should be negligible in practice as the API is designed for convenience rather than performance in the first place. E.g. running clang-format over `Content` is much more expensive than the copy of the Content itself.

This copy could be avoided in most cases if we provide a constructor that accepts `std::string` or null-terminated strings directly, but it does not seem worth the effort.

An alternative fix would be to teach `SourceManager` to work with non-null-terminated buffers, but given how much it is used, this would be very complicated and is likely to incur some performance cost.