### PR TITLE
[clang] Add diagnostic for unresolved using declaration that shadows template parameters

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -310,6 +310,7 @@ Bug Fixes to C++ Support
 - Clang now correctly parses ``if constexpr`` expressions in immediate function context. (#GH123524)
 - Fixed an assertion failure affecting code that uses C++23 "deducing this". (#GH130272)
 - Clang now properly instantiates destructors for initialized members within non-delegating constructors. (#GH93251)
+- Correctly diagnoses if unresolved using declarations shadows template paramters (#GH129411)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -12895,6 +12895,10 @@ NamedDecl *Sema::BuildUsingDeclaration(
                                                   SS, NameInfo, IdentLoc))
       return nullptr;
 
+    if (Previous.isSingleResult() &&
+        Previous.getFoundDecl()->isTemplateParameter())
+      DiagnoseTemplateParameterShadow(IdentLoc, Previous.getFoundDecl());
+
     if (HasTypenameKeyword) {
       // FIXME: not all declaration name kinds are legal here
       D = UnresolvedUsingTypenameDecl::Create(Context, CurContext,

--- a/clang/test/Parser/cxx-template-decl.cpp
+++ b/clang/test/Parser/cxx-template-decl.cpp
@@ -109,6 +109,14 @@ template<template<typename> class T> struct shadow8 { // expected-note{{template
   template<template<typename> class T> struct inner; // expected-error{{declaration of 'T' shadows template parameter}}
 };
 
+template<class>
+class shadow9_;
+
+template<class T> // expected-note{{template parameter is declared here}}
+class shadow9 : public shadow9_<T> {
+  using typename shadow9_<T>::T; // expected-error{{declaration of 'T' shadows template parameter}}
+};
+
 // Non-type template parameters in scope
 template<int Size>
 void f(int& i) {


### PR DESCRIPTION
Fix #129411 