### PR TITLE
[Clang] Remove use of 'temporary' toolchains for offload deduction

### DIFF
--- a/clang/test/Driver/offload-Xarch.c
+++ b/clang/test/Driver/offload-Xarch.c
@@ -1,5 +1,3 @@
-// UNSUPPORTED: target={{.*darwin.*}}
-
 // RUN: %clang --target=x86_64-unknown-linux-gnu -x cuda %s -Xarch_nvptx64 -O3 -S -nogpulib -nogpuinc -### 2>&1 | FileCheck -check-prefix=O3ONCE %s
 // RUN: %clang -x cuda %s -Xarch_device -O3 -S -nogpulib -nogpuinc -### 2>&1 | FileCheck -check-prefix=O3ONCE %s
 // RUN: %clang -x hip %s -Xarch_amdgcn -O3 -S -nogpulib -nogpuinc -### 2>&1 | FileCheck -check-prefix=O3ONCE %s


### PR DESCRIPTION
Summary:
We need a toolchain to get the GPU architectures when compiling with
OpenMP. This kind of breaks the toolchain model because these are cached
all over the place. Instead of making a new one, just create both of
them unconditionally. It's not like this is saving any work since we
still needed to create both toolchains in the earlier case.

Fixes: https://github.com/llvm/llvm-project/issues/131325
