### PR TITLE
[flang] Disabling REAL kinds must also disable their COMPLEX

### DIFF
--- a/flang/include/flang/Tools/TargetSetup.h
+++ b/flang/include/flang/Tools/TargetSetup.h
@@ -49,6 +49,8 @@ namespace Fortran::tools {
   default:
     targetCharacteristics.DisableType(
         Fortran::common::TypeCategory::Real, /*kind=*/10);
+    targetCharacteristics.DisableType(
+        Fortran::common::TypeCategory::Complex, /*kind=*/10);
     break;
   }
 
@@ -62,11 +64,16 @@ namespace Fortran::tools {
   constexpr bool f128Support = false;
 #endif
 
-  if constexpr (!f128Support)
+  if constexpr (!f128Support) {
     targetCharacteristics.DisableType(Fortran::common::TypeCategory::Real, 16);
+    targetCharacteristics.DisableType(
+        Fortran::common::TypeCategory::Complex, 16);
+  }
 
-  for (auto realKind : targetOptions.disabledRealKinds)
+  for (auto realKind : targetOptions.disabledRealKinds) {
     targetCharacteristics.DisableType(common::TypeCategory::Real, realKind);
+    targetCharacteristics.DisableType(common::TypeCategory::Complex, realKind);
+  }
 
   for (auto intKind : targetOptions.disabledIntegerKinds)
     targetCharacteristics.DisableType(common::TypeCategory::Integer, intKind);

--- a/flang/test/Integration/debug-complex-1.f90
+++ b/flang/test/Integration/debug-complex-1.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: %flang_fc1 -emit-llvm -debug-info-kind=standalone %s -o - | FileCheck  %s
 
 program mn

--- a/flang/test/Lower/Intrinsics/acos_complex16.f90
+++ b/flang/test/Lower/Intrinsics/acos_complex16.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/Intrinsics/acosh_complex16.f90
+++ b/flang/test/Lower/Intrinsics/acosh_complex16.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/Intrinsics/asin_complex16.f90
+++ b/flang/test/Lower/Intrinsics/asin_complex16.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/Intrinsics/asinh_complex16.f90
+++ b/flang/test/Lower/Intrinsics/asinh_complex16.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/Intrinsics/atan_complex16.f90
+++ b/flang/test/Lower/Intrinsics/atan_complex16.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/Intrinsics/atanh_complex16.f90
+++ b/flang/test/Lower/Intrinsics/atanh_complex16.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/Intrinsics/cos_complex16.f90
+++ b/flang/test/Lower/Intrinsics/cos_complex16.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/Intrinsics/cosh_complex16.f90
+++ b/flang/test/Lower/Intrinsics/cosh_complex16.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/Intrinsics/exp_complex16.f90
+++ b/flang/test/Lower/Intrinsics/exp_complex16.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/Intrinsics/log_complex16.f90
+++ b/flang/test/Lower/Intrinsics/log_complex16.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/Intrinsics/pow_complex16.f90
+++ b/flang/test/Lower/Intrinsics/pow_complex16.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/Intrinsics/pow_complex16i.f90
+++ b/flang/test/Lower/Intrinsics/pow_complex16i.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/Intrinsics/pow_complex16k.f90
+++ b/flang/test/Lower/Intrinsics/pow_complex16k.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/Intrinsics/sin_complex16.f90
+++ b/flang/test/Lower/Intrinsics/sin_complex16.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/Intrinsics/sinh_complex16.f90
+++ b/flang/test/Lower/Intrinsics/sinh_complex16.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/Intrinsics/sqrt_complex16.f90
+++ b/flang/test/Lower/Intrinsics/sqrt_complex16.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/Intrinsics/tan_complex16.f90
+++ b/flang/test/Lower/Intrinsics/tan_complex16.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/Intrinsics/tanh_complex16.f90
+++ b/flang/test/Lower/Intrinsics/tanh_complex16.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -emit-fir %s -o - | FileCheck %s
 ! RUN: bbc --math-runtime=precise -emit-fir %s -o - | FileCheck %s
 ! RUN: %flang_fc1 -emit-fir %s -o - | FileCheck %s

--- a/flang/test/Lower/complex-operations.f90
+++ b/flang/test/Lower/complex-operations.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: bbc -hlfir=false %s -o - | FileCheck %s
 
 ! CHECK-LABEL: @_QPadd_test

--- a/flang/test/Semantics/data05.f90
+++ b/flang/test/Semantics/data05.f90
@@ -1,3 +1,4 @@
+!REQUIRES: flang-supports-f128-math
 !RUN: %flang_fc1 -fdebug-dump-symbols %s | FileCheck %s
 module m
   interface

--- a/flang/test/Semantics/intrinsics01.f90
+++ b/flang/test/Semantics/intrinsics01.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: %python %S/test_errors.py %s %flang_fc1
 ! Check for semantic errors for DREAL, DIMAG, DCONJG intrinsics
 

--- a/flang/test/Semantics/modfile12.f90
+++ b/flang/test/Semantics/modfile12.f90
@@ -1,3 +1,4 @@
+! REQUIRES: flang-supports-f128-math
 ! RUN: %python %S/test_modfile.py %s %flang_fc1
 module m
   integer(8), parameter :: a = 1, b = 2_8


### PR DESCRIPTION
When disabling kinds of REAL in the TargetCharacteristics, one must also disable the corresponding kinds of COMPLEX.

Fixes https://github.com/llvm/llvm-project/issues/131088.