### PR TITLE
[LLVM] Only enable `-fno-lifetime-dse` in LTO mode

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -688,7 +688,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   append("-Werror=unguarded-availability-new" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND LLVM_ENABLE_LTO)
   # LLVM data structures like llvm::User and llvm::MDNode rely on
   # the value of object storage persisting beyond the lifetime of the
   # object (#24952).  This is not standard compliant and causes a runtime


### PR DESCRIPTION
Summary:
Always passing this option is problematic since it is not supported by
`clang.` this leads to conflicts when using extra CMake tools like
`compile-commands` or `include-what-you-use`. This mainly works around a
bug that showed up during the LTO build. Theoretically this can show up
without LTO, but it's likely to work.

This can be removed once https://github.com/llvm/llvm-project/issues/24952 is resolved.
