### PR TITLE
[AMDGPU] Fix register class constraints for si-fold-operands pass when folding immediate into copies

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
@@ -1068,18 +1068,14 @@ void SIFoldOperandsImpl::foldOperand(
     if (MovOp == AMDGPU::COPY)
       return;
 
-    // Check for common register subclass between destination (DestRC) and MOV
-    // result (ResRC). If exists, verify this common subclass is a superclass of
-    // (or equal to) the destination register class, otherwise folding is
-    // illegal.
-
+    // Fold if the destination register class of the MOV instruction (ResRC)
+    // is a superclass of (or equal to) the destination register class of the COPY (DestRC).
+    // If this condition fails, folding would be illegal.
     const MCInstrDesc &MovDesc = TII->get(MovOp);
     assert(MovDesc.getNumDefs() > 0 && MovDesc.operands()[0].RegClass != -1);
     const TargetRegisterClass *ResRC =
         TRI->getRegClass(MovDesc.operands()[0].RegClass);
-    const TargetRegisterClass *CommonRC = TRI->getCommonSubClass(DestRC, ResRC);
-
-    if (!CommonRC || !DestRC->hasSuperClassEq(CommonRC))
+    if (!DestRC->hasSuperClassEq(ResRC))
       return;
 
     MachineInstr::mop_iterator ImpOpI = UseMI->implicit_operands().begin();

--- a/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
@@ -1069,8 +1069,8 @@ void SIFoldOperandsImpl::foldOperand(
       return;
 
     // Fold if the destination register class of the MOV instruction (ResRC)
-    // is a superclass of (or equal to) the destination register class of the COPY (DestRC).
-    // If this condition fails, folding would be illegal.
+    // is a superclass of (or equal to) the destination register class of the
+    // COPY (DestRC). If this condition fails, folding would be illegal.
     const MCInstrDesc &MovDesc = TII->get(MovOp);
     assert(MovDesc.getNumDefs() > 0 && MovDesc.operands()[0].RegClass != -1);
     const TargetRegisterClass *ResRC =

--- a/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
@@ -1068,6 +1068,16 @@ void SIFoldOperandsImpl::foldOperand(
     if (MovOp == AMDGPU::COPY)
       return;
 
+    // Fold if the destination register class of the MOV instruction (ResRC)
+    // is a superclass of (or equal to) the destination register class of the COPY (DestRC).
+    // If this condition fails, folding would be illegal.
+    const MCInstrDesc &MovDesc = TII->get(MovOp);
+    if (MovDesc.getNumDefs() > 0 && MovDesc.operands()[0].RegClass != -1) {
+      const TargetRegisterClass *ResRC = 
+          TRI->getRegClass(MovDesc.operands()[0].RegClass);
+      if (!DestRC -> hasSuperClassEq(ResRC)) return;
+    }
+
     MachineInstr::mop_iterator ImpOpI = UseMI->implicit_operands().begin();
     MachineInstr::mop_iterator ImpOpE = UseMI->implicit_operands().end();
     while (ImpOpI != ImpOpE) {

--- a/llvm/test/CodeGen/AMDGPU/fold-imm-copy.mir
+++ b/llvm/test/CodeGen/AMDGPU/fold-imm-copy.mir
@@ -208,52 +208,70 @@ body:             |
 
 ...
 
-# FIXME: Register class restrictions of av register not respected,
-# issue 130020
+---
+name: s_mov_b32_inlineimm_copy_s_to_av_32
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    ; GCN-LABEL: name: s_mov_b32_inlineimm_copy_s_to_av_32
+    ; GCN: [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 32
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:av_32 = COPY [[S_MOV_B32_]]
+    ; GCN-NEXT: $agpr0 = COPY [[COPY]]
+    ; GCN-NEXT: S_ENDPGM 0
+    %0:sreg_32 = S_MOV_B32 32
+    %1:av_32 = COPY %0
+    $agpr0 = COPY %1
+    S_ENDPGM 0
 
-# ---
-# name: s_mov_b32_inlineimm_copy_s_to_av_32
-# tracksRegLiveness: true
-# body:             |
-#   bb.0:
-#     %0:sreg_32 = S_MOV_B32 32
-#     %1:av_32 = COPY %0
-#     $agpr0 = COPY %1
-#     S_ENDPGM 0
+...
 
-# ...
+---
+name: v_mov_b32_inlineimm_copy_v_to_av_32
+tracksRegLiveness: true
+body:             |
+ bb.0:
+    ; GCN-LABEL: name: v_mov_b32_inlineimm_copy_v_to_av_32
+    ; GCN: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 32, implicit $exec
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:av_32 = COPY [[V_MOV_B32_e32_]]
+    ; GCN-NEXT: $agpr0 = COPY [[COPY]]
+    ; GCN-NEXT: S_ENDPGM 0
+   %0:vgpr_32 = V_MOV_B32_e32 32, implicit $exec
+   %1:av_32 = COPY %0
+   $agpr0 = COPY %1
+   S_ENDPGM 0
 
-# ---
-# name: v_mov_b32_inlineimm_copy_v_to_av_32
-# tracksRegLiveness: true
-# body:             |
-#  bb.0:
-#    %0:vgpr_32 = V_MOV_B32_e32 32, implicit $exec
-#    %1:av_32 = COPY %0
-#    $agpr0 = COPY %1
-#    S_ENDPGM 0
-# ...
+...
 
-# ---
-# name: s_mov_b32_imm_literal_copy_s_to_av_32
-# tracksRegLiveness: true
-# body:             |
-#   bb.0:
-#     %0:sreg_32 = S_MOV_B32 999
-#     %1:av_32 = COPY %0
-#     $agpr0 = COPY %1
-#     S_ENDPGM 0
+---
+name: s_mov_b32_imm_literal_copy_s_to_av_32
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    ; GCN-LABEL: name: s_mov_b32_imm_literal_copy_s_to_av_32
+    ; GCN: [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 999
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:av_32 = COPY [[S_MOV_B32_]]
+    ; GCN-NEXT: $agpr0 = COPY [[COPY]]
+    ; GCN-NEXT: S_ENDPGM 0
+    %0:sreg_32 = S_MOV_B32 999
+    %1:av_32 = COPY %0
+    $agpr0 = COPY %1
+    S_ENDPGM 0
 
-# ...
+...
 
-# ---
-# name: v_mov_b32_imm_literal_copy_v_to_av_32
-# tracksRegLiveness: true
-# body:             |
-#   bb.0:
-#     %0:vgpr_32 = V_MOV_B32_e32 999, implicit $exec
-#     %1:av_32 = COPY %0
-#     $agpr0 = COPY %1
-#     S_ENDPGM 0
+---
+name: v_mov_b32_imm_literal_copy_v_to_av_32
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    ; GCN-LABEL: name: v_mov_b32_imm_literal_copy_v_to_av_32
+    ; GCN: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 999, implicit $exec
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:av_32 = COPY [[V_MOV_B32_e32_]]
+    ; GCN-NEXT: $agpr0 = COPY [[COPY]]
+    ; GCN-NEXT: S_ENDPGM 0
+    %0:vgpr_32 = V_MOV_B32_e32 999, implicit $exec
+    %1:av_32 = COPY %0
+    $agpr0 = COPY %1
+    S_ENDPGM 0
 
-# ...
+...

--- a/llvm/test/CodeGen/AMDGPU/fold-imm-copy.mir
+++ b/llvm/test/CodeGen/AMDGPU/fold-imm-copy.mir
@@ -29,6 +29,7 @@ body:             |
     %8:sreg_32_xm0 = S_MOV_B32 65535
     %9:vgpr_32 = COPY %8
     %10:vgpr_32 = V_AND_B32_e32 %7, %9, implicit $exec
+
 ...
 
 ---
@@ -52,6 +53,7 @@ body:             |
     %4:vreg_64 = REG_SEQUENCE killed %0, %subreg.sub0, killed %3, %subreg.sub1
     %5:vgpr_32 = V_XOR_B32_e32 %1, %4.sub1, implicit $exec
     %6:vgpr_32 = V_XOR_B32_e32 %2, %4.sub0, implicit $exec
+
 ...
 
 ---
@@ -59,6 +61,7 @@ body:             |
 # Make sure the subreg index is not reinterpreted when folding
 # immediates
 #
+
 name: clear_subreg_imm_fold
 tracksRegLiveness: true
 body:             |
@@ -128,126 +131,69 @@ body:             |
 ...
 
 ---
-name: av_mov_b32_imm_pseudo_copy_av_32_to_physreg_agpr
+name: s_mov_b32_inlineimm_copy_s_to_av_32
 tracksRegLiveness: true
 body:             |
   bb.0:
-    ; GCN-LABEL: name: av_mov_b32_imm_pseudo_copy_av_32_to_physreg_agpr
-    ; GCN: [[AV_MOV_:%[0-9]+]]:av_32 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
-    ; GCN-NEXT: $agpr0 = COPY [[AV_MOV_]]
-    ; GCN-NEXT: S_ENDPGM 0, implicit $agpr0
-    %0:av_32 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
-    $agpr0 = COPY %0
-    S_ENDPGM 0, implicit $agpr0
-
-...
-
----
-name: av_mov_b32_imm_pseudo_copy_av_32_to_physreg_vgpr
-tracksRegLiveness: true
-body:             |
-  bb.0:
-    ; GCN-LABEL: name: av_mov_b32_imm_pseudo_copy_av_32_to_physreg_vgpr
-    ; GCN: [[AV_MOV_:%[0-9]+]]:av_32 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
-    ; GCN-NEXT: $vgpr0 = COPY [[AV_MOV_]]
-    ; GCN-NEXT: S_ENDPGM 0, implicit $vgpr0
-    %0:av_32 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
-    $vgpr0 = COPY %0
-    S_ENDPGM 0, implicit $vgpr0
-
-...
-
----
-name: av_mov_b32_imm_pseudo_copy_av_32_to_virtreg_agpr
-tracksRegLiveness: true
-body:             |
-  bb.0:
-    ; GCN-LABEL: name: av_mov_b32_imm_pseudo_copy_av_32_to_virtreg_agpr
-    ; GCN: [[V_ACCVGPR_WRITE_B32_e64_:%[0-9]+]]:agpr_32 = V_ACCVGPR_WRITE_B32_e64 0, implicit $exec
-    ; GCN-NEXT: S_ENDPGM 0, implicit [[V_ACCVGPR_WRITE_B32_e64_]]
-    %0:av_32 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
-    %1:agpr_32 = COPY %0
-    S_ENDPGM 0, implicit %1
-
-...
-
----
-name: av_mov_b32_imm_pseudo_copy_av_32_to_virtreg_vgpr
-tracksRegLiveness: true
-body:             |
-  bb.0:
-    ; GCN-LABEL: name: av_mov_b32_imm_pseudo_copy_av_32_to_virtreg_vgpr
-    ; GCN: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-    ; GCN-NEXT: S_ENDPGM 0, implicit [[V_MOV_B32_e32_]]
-    %0:av_32 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
-    %1:vgpr_32 = COPY %0
-    S_ENDPGM 0, implicit %1
-
-...
-
----
-name: v_mov_b32_imm_literal_copy_v_to_agpr_32
-tracksRegLiveness: true
-body:             |
-  bb.0:
-    ; GCN-LABEL: name: v_mov_b32_imm_literal_copy_v_to_agpr_32
-    ; GCN: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 999, implicit $exec
-    ; GCN-NEXT: [[COPY:%[0-9]+]]:agpr_32 = COPY [[V_MOV_B32_e32_]]
-    ; GCN-NEXT: $agpr0 = COPY [[COPY]]
-    ; GCN-NEXT: S_ENDPGM 0
-    %0:vgpr_32 = V_MOV_B32_e32 999, implicit $exec
-    %1:agpr_32 = COPY %0
+    ; CHECK-LABEL: name: s_mov_b32_inlineimm_copy_s_to_av_32
+    ; CHECK: [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 32
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:av_32 = COPY [[S_MOV_B32_]]
+    ; CHECK-NEXT: $agpr0 = COPY [[COPY]]
+    ; CHECK-NEXT: S_ENDPGM 0
+    %0:sreg_32 = S_MOV_B32 32
+    %1:av_32 = COPY %0
     $agpr0 = COPY %1
     S_ENDPGM 0
 
 ...
 
-# FIXME: Register class restrictions of av register not respected,
-# issue 130020
+---
+name: v_mov_b32_inlineimm_copy_v_to_av_32
+tracksRegLiveness: true
+body:             |
+ bb.0:
+    ; CHECK-LABEL: name: v_mov_b32_inlineimm_copy_v_to_av_32
+    ; CHECK: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 32, implicit $exec
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:av_32 = COPY [[V_MOV_B32_e32_]]
+    ; CHECK-NEXT: $agpr0 = COPY [[COPY]]
+    ; CHECK-NEXT: S_ENDPGM 0
+   %0:vgpr_32 = V_MOV_B32_e32 32, implicit $exec
+   %1:av_32 = COPY %0
+   $agpr0 = COPY %1
+   S_ENDPGM 0
 
-# ---
-# name: s_mov_b32_inlineimm_copy_s_to_av_32
-# tracksRegLiveness: true
-# body:             |
-#   bb.0:
-#     %0:sreg_32 = S_MOV_B32 32
-#     %1:av_32 = COPY %0
-#     $agpr0 = COPY %1
-#     S_ENDPGM 0
+...
 
-# ...
+---
+name: s_mov_b32_imm_literal_copy_s_to_av_32
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    ; CHECK-LABEL: name: s_mov_b32_imm_literal_copy_s_to_av_32
+    ; CHECK: [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 999
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:av_32 = COPY [[S_MOV_B32_]]
+    ; CHECK-NEXT: $agpr0 = COPY [[COPY]]
+    ; CHECK-NEXT: S_ENDPGM 0
+    %0:sreg_32 = S_MOV_B32 999
+    %1:av_32 = COPY %0
+    $agpr0 = COPY %1
+    S_ENDPGM 0
 
-# ---
-# name: v_mov_b32_inlineimm_copy_v_to_av_32
-# tracksRegLiveness: true
-# body:             |
-#  bb.0:
-#    %0:vgpr_32 = V_MOV_B32_e32 32, implicit $exec
-#    %1:av_32 = COPY %0
-#    $agpr0 = COPY %1
-#    S_ENDPGM 0
-# ...
+...
 
-# ---
-# name: s_mov_b32_imm_literal_copy_s_to_av_32
-# tracksRegLiveness: true
-# body:             |
-#   bb.0:
-#     %0:sreg_32 = S_MOV_B32 999
-#     %1:av_32 = COPY %0
-#     $agpr0 = COPY %1
-#     S_ENDPGM 0
+---
+name: v_mov_b32_imm_literal_copy_v_to_av_32
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    ; CHECK-LABEL: name: v_mov_b32_imm_literal_copy_v_to_av_32
+    ; CHECK: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 999, implicit $exec
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:av_32 = COPY [[V_MOV_B32_e32_]]
+    ; CHECK-NEXT: $agpr0 = COPY [[COPY]]
+    ; CHECK-NEXT: S_ENDPGM 0
+    %0:vgpr_32 = V_MOV_B32_e32 999, implicit $exec
+    %1:av_32 = COPY %0
+    $agpr0 = COPY %1
+    S_ENDPGM 0
 
-# ...
-
-# ---
-# name: v_mov_b32_imm_literal_copy_v_to_av_32
-# tracksRegLiveness: true
-# body:             |
-#   bb.0:
-#     %0:vgpr_32 = V_MOV_B32_e32 999, implicit $exec
-#     %1:av_32 = COPY %0
-#     $agpr0 = COPY %1
-#     S_ENDPGM 0
-
-# ...
+...

--- a/llvm/test/CodeGen/AMDGPU/fold-imm-copy.mir
+++ b/llvm/test/CodeGen/AMDGPU/fold-imm-copy.mir
@@ -29,7 +29,6 @@ body:             |
     %8:sreg_32_xm0 = S_MOV_B32 65535
     %9:vgpr_32 = COPY %8
     %10:vgpr_32 = V_AND_B32_e32 %7, %9, implicit $exec
-
 ...
 
 ---
@@ -53,7 +52,6 @@ body:             |
     %4:vreg_64 = REG_SEQUENCE killed %0, %subreg.sub0, killed %3, %subreg.sub1
     %5:vgpr_32 = V_XOR_B32_e32 %1, %4.sub1, implicit $exec
     %6:vgpr_32 = V_XOR_B32_e32 %2, %4.sub0, implicit $exec
-
 ...
 
 ---
@@ -61,7 +59,6 @@ body:             |
 # Make sure the subreg index is not reinterpreted when folding
 # immediates
 #
-
 name: clear_subreg_imm_fold
 tracksRegLiveness: true
 body:             |
@@ -76,6 +73,10 @@ body:             |
     S_ENDPGM 0, implicit %1, implicit %2
 
 ...
+
+# GCN-LABEL: name: no_fold_imm_into_m0{{$}}
+# GCN: %0:sreg_32 = S_MOV_B32 -8
+# GCN-NEXT: $m0 = COPY %0
 
 ---
 name: no_fold_imm_into_m0
@@ -92,6 +93,8 @@ body:             |
 
 ...
 
+# GCN-LABEL: name: fold_sgpr_imm_to_vgpr_copy{{$}}
+# GCN: $vgpr0 = V_MOV_B32_e32 -8, implicit $exec
 ---
 name: fold_sgpr_imm_to_vgpr_copy
 tracksRegLiveness: true
@@ -131,69 +134,126 @@ body:             |
 ...
 
 ---
-name: s_mov_b32_inlineimm_copy_s_to_av_32
+name: av_mov_b32_imm_pseudo_copy_av_32_to_physreg_agpr
 tracksRegLiveness: true
 body:             |
   bb.0:
-    ; CHECK-LABEL: name: s_mov_b32_inlineimm_copy_s_to_av_32
-    ; CHECK: [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 32
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:av_32 = COPY [[S_MOV_B32_]]
-    ; CHECK-NEXT: $agpr0 = COPY [[COPY]]
-    ; CHECK-NEXT: S_ENDPGM 0
-    %0:sreg_32 = S_MOV_B32 32
-    %1:av_32 = COPY %0
-    $agpr0 = COPY %1
-    S_ENDPGM 0
+    ; GCN-LABEL: name: av_mov_b32_imm_pseudo_copy_av_32_to_physreg_agpr
+    ; GCN: [[AV_MOV_:%[0-9]+]]:av_32 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
+    ; GCN-NEXT: $agpr0 = COPY [[AV_MOV_]]
+    ; GCN-NEXT: S_ENDPGM 0, implicit $agpr0
+    %0:av_32 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
+    $agpr0 = COPY %0
+    S_ENDPGM 0, implicit $agpr0
 
 ...
 
 ---
-name: v_mov_b32_inlineimm_copy_v_to_av_32
+name: av_mov_b32_imm_pseudo_copy_av_32_to_physreg_vgpr
 tracksRegLiveness: true
 body:             |
- bb.0:
-    ; CHECK-LABEL: name: v_mov_b32_inlineimm_copy_v_to_av_32
-    ; CHECK: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 32, implicit $exec
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:av_32 = COPY [[V_MOV_B32_e32_]]
-    ; CHECK-NEXT: $agpr0 = COPY [[COPY]]
-    ; CHECK-NEXT: S_ENDPGM 0
-   %0:vgpr_32 = V_MOV_B32_e32 32, implicit $exec
-   %1:av_32 = COPY %0
-   $agpr0 = COPY %1
-   S_ENDPGM 0
+  bb.0:
+    ; GCN-LABEL: name: av_mov_b32_imm_pseudo_copy_av_32_to_physreg_vgpr
+    ; GCN: [[AV_MOV_:%[0-9]+]]:av_32 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
+    ; GCN-NEXT: $vgpr0 = COPY [[AV_MOV_]]
+    ; GCN-NEXT: S_ENDPGM 0, implicit $vgpr0
+    %0:av_32 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
+    $vgpr0 = COPY %0
+    S_ENDPGM 0, implicit $vgpr0
 
 ...
 
 ---
-name: s_mov_b32_imm_literal_copy_s_to_av_32
+name: av_mov_b32_imm_pseudo_copy_av_32_to_virtreg_agpr
 tracksRegLiveness: true
 body:             |
   bb.0:
-    ; CHECK-LABEL: name: s_mov_b32_imm_literal_copy_s_to_av_32
-    ; CHECK: [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 999
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:av_32 = COPY [[S_MOV_B32_]]
-    ; CHECK-NEXT: $agpr0 = COPY [[COPY]]
-    ; CHECK-NEXT: S_ENDPGM 0
-    %0:sreg_32 = S_MOV_B32 999
-    %1:av_32 = COPY %0
-    $agpr0 = COPY %1
-    S_ENDPGM 0
+    ; GCN-LABEL: name: av_mov_b32_imm_pseudo_copy_av_32_to_virtreg_agpr
+    ; GCN: [[V_ACCVGPR_WRITE_B32_e64_:%[0-9]+]]:agpr_32 = V_ACCVGPR_WRITE_B32_e64 0, implicit $exec
+    ; GCN-NEXT: S_ENDPGM 0, implicit [[V_ACCVGPR_WRITE_B32_e64_]]
+    %0:av_32 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
+    %1:agpr_32 = COPY %0
+    S_ENDPGM 0, implicit %1
 
 ...
 
 ---
-name: v_mov_b32_imm_literal_copy_v_to_av_32
+name: av_mov_b32_imm_pseudo_copy_av_32_to_virtreg_vgpr
 tracksRegLiveness: true
 body:             |
   bb.0:
-    ; CHECK-LABEL: name: v_mov_b32_imm_literal_copy_v_to_av_32
-    ; CHECK: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 999, implicit $exec
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:av_32 = COPY [[V_MOV_B32_e32_]]
-    ; CHECK-NEXT: $agpr0 = COPY [[COPY]]
-    ; CHECK-NEXT: S_ENDPGM 0
+    ; GCN-LABEL: name: av_mov_b32_imm_pseudo_copy_av_32_to_virtreg_vgpr
+    ; GCN: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
+    ; GCN-NEXT: S_ENDPGM 0, implicit [[V_MOV_B32_e32_]]
+    %0:av_32 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
+    %1:vgpr_32 = COPY %0
+    S_ENDPGM 0, implicit %1
+
+...
+
+---
+name: v_mov_b32_imm_literal_copy_v_to_agpr_32
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    ; GCN-LABEL: name: v_mov_b32_imm_literal_copy_v_to_agpr_32
+    ; GCN: [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 999, implicit $exec
+    ; GCN-NEXT: [[COPY:%[0-9]+]]:agpr_32 = COPY [[V_MOV_B32_e32_]]
+    ; GCN-NEXT: $agpr0 = COPY [[COPY]]
+    ; GCN-NEXT: S_ENDPGM 0
     %0:vgpr_32 = V_MOV_B32_e32 999, implicit $exec
-    %1:av_32 = COPY %0
+    %1:agpr_32 = COPY %0
     $agpr0 = COPY %1
     S_ENDPGM 0
 
 ...
+
+# FIXME: Register class restrictions of av register not respected,
+# issue 130020
+
+# ---
+# name: s_mov_b32_inlineimm_copy_s_to_av_32
+# tracksRegLiveness: true
+# body:             |
+#   bb.0:
+#     %0:sreg_32 = S_MOV_B32 32
+#     %1:av_32 = COPY %0
+#     $agpr0 = COPY %1
+#     S_ENDPGM 0
+
+# ...
+
+# ---
+# name: v_mov_b32_inlineimm_copy_v_to_av_32
+# tracksRegLiveness: true
+# body:             |
+#  bb.0:
+#    %0:vgpr_32 = V_MOV_B32_e32 32, implicit $exec
+#    %1:av_32 = COPY %0
+#    $agpr0 = COPY %1
+#    S_ENDPGM 0
+# ...
+
+# ---
+# name: s_mov_b32_imm_literal_copy_s_to_av_32
+# tracksRegLiveness: true
+# body:             |
+#   bb.0:
+#     %0:sreg_32 = S_MOV_B32 999
+#     %1:av_32 = COPY %0
+#     $agpr0 = COPY %1
+#     S_ENDPGM 0
+
+# ...
+
+# ---
+# name: v_mov_b32_imm_literal_copy_v_to_av_32
+# tracksRegLiveness: true
+# body:             |
+#   bb.0:
+#     %0:vgpr_32 = V_MOV_B32_e32 999, implicit $exec
+#     %1:av_32 = COPY %0
+#     $agpr0 = COPY %1
+#     S_ENDPGM 0
+
+# ...

--- a/llvm/test/CodeGen/AMDGPU/fold-imm-copy.mir
+++ b/llvm/test/CodeGen/AMDGPU/fold-imm-copy.mir
@@ -74,10 +74,6 @@ body:             |
 
 ...
 
-# GCN-LABEL: name: no_fold_imm_into_m0{{$}}
-# GCN: %0:sreg_32 = S_MOV_B32 -8
-# GCN-NEXT: $m0 = COPY %0
-
 ---
 name: no_fold_imm_into_m0
 tracksRegLiveness: true
@@ -93,8 +89,6 @@ body:             |
 
 ...
 
-# GCN-LABEL: name: fold_sgpr_imm_to_vgpr_copy{{$}}
-# GCN: $vgpr0 = V_MOV_B32_e32 -8, implicit $exec
 ---
 name: fold_sgpr_imm_to_vgpr_copy
 tracksRegLiveness: true


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/130020

This fixes an issue where the si-fold-operands pass would incorrectly fold immediate values into COPY instructions targeting av_32 registers.

The pass now checks register class constraints before attempting to fold the immediate.