### PR TITLE
[RISCV] Use hasFeature instead of checkFeature in llvm-exegesis. NFC

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
@@ -156,15 +156,33 @@ public:
     // FIXME: We could have obtained these two constants from RISCVSubtarget
     // but in order to get that from TargetMachine, we need a Function.
     const MCSubtargetInfo &STI = State.getSubtargetInfo();
-    ELEN = STI.checkFeatures("+zve64x") ? 64 : 32;
+    ELEN = STI.hasFeature(RISCV::FeatureStdExtZve64x) ? 64 : 32;
 
-    std::string ZvlQuery;
-    for (unsigned Size = 32; Size <= 65536; Size *= 2) {
-      ZvlQuery = "+zvl";
-      raw_string_ostream SS(ZvlQuery);
-      SS << Size << "b";
-      if (STI.checkFeatures(SS.str()) && ZvlVLen < Size)
-        ZvlVLen = Size;
+    static_assert(RISCV::FeatureStdExtZvl64b == RISCV::FeatureStdExtZvl32b + 1);
+    static_assert(RISCV::FeatureStdExtZvl128b ==
+                  RISCV::FeatureStdExtZvl32b + 2);
+    static_assert(RISCV::FeatureStdExtZvl256b ==
+                  RISCV::FeatureStdExtZvl32b + 3);
+    static_assert(RISCV::FeatureStdExtZvl512b ==
+                  RISCV::FeatureStdExtZvl32b + 4);
+    static_assert(RISCV::FeatureStdExtZvl1024b ==
+                  RISCV::FeatureStdExtZvl32b + 5);
+    static_assert(RISCV::FeatureStdExtZvl2048b ==
+                  RISCV::FeatureStdExtZvl32b + 6);
+    static_assert(RISCV::FeatureStdExtZvl4096b ==
+                  RISCV::FeatureStdExtZvl32b + 7);
+    static_assert(RISCV::FeatureStdExtZvl8192b ==
+                  RISCV::FeatureStdExtZvl32b + 8);
+    static_assert(RISCV::FeatureStdExtZvl16384b ==
+                  RISCV::FeatureStdExtZvl32b + 9);
+    static_assert(RISCV::FeatureStdExtZvl32768b ==
+                  RISCV::FeatureStdExtZvl32b + 10);
+    static_assert(RISCV::FeatureStdExtZvl65536b ==
+                  RISCV::FeatureStdExtZvl32b + 11);
+    for (unsigned Feature = RISCV::FeatureStdExtZvl32b, Size = 32;
+         Size <= 65536; ++Feature, Size *= 2) {
+      if (STI.hasFeature(Feature))
+        ZvlVLen = std::max(ZvlVLen, Size);
     }
   }
 

--- a/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
@@ -158,31 +158,16 @@ public:
     const MCSubtargetInfo &STI = State.getSubtargetInfo();
     ELEN = STI.hasFeature(RISCV::FeatureStdExtZve64x) ? 64 : 32;
 
-    static_assert(RISCV::FeatureStdExtZvl64b == RISCV::FeatureStdExtZvl32b + 1);
-    static_assert(RISCV::FeatureStdExtZvl128b ==
-                  RISCV::FeatureStdExtZvl32b + 2);
-    static_assert(RISCV::FeatureStdExtZvl256b ==
-                  RISCV::FeatureStdExtZvl32b + 3);
-    static_assert(RISCV::FeatureStdExtZvl512b ==
-                  RISCV::FeatureStdExtZvl32b + 4);
-    static_assert(RISCV::FeatureStdExtZvl1024b ==
-                  RISCV::FeatureStdExtZvl32b + 5);
-    static_assert(RISCV::FeatureStdExtZvl2048b ==
-                  RISCV::FeatureStdExtZvl32b + 6);
-    static_assert(RISCV::FeatureStdExtZvl4096b ==
-                  RISCV::FeatureStdExtZvl32b + 7);
-    static_assert(RISCV::FeatureStdExtZvl8192b ==
-                  RISCV::FeatureStdExtZvl32b + 8);
-    static_assert(RISCV::FeatureStdExtZvl16384b ==
-                  RISCV::FeatureStdExtZvl32b + 9);
-    static_assert(RISCV::FeatureStdExtZvl32768b ==
-                  RISCV::FeatureStdExtZvl32b + 10);
-    static_assert(RISCV::FeatureStdExtZvl65536b ==
-                  RISCV::FeatureStdExtZvl32b + 11);
-    for (unsigned Feature = RISCV::FeatureStdExtZvl32b, Size = 32;
-         Size <= 65536; ++Feature, Size *= 2) {
+    const unsigned ZvlFeatures[] = {
+        RISCV::FeatureStdExtZvl32b,    RISCV::FeatureStdExtZvl64b,
+        RISCV::FeatureStdExtZvl128b,   RISCV::FeatureStdExtZvl256b,
+        RISCV::FeatureStdExtZvl512b,   RISCV::FeatureStdExtZvl1024b,
+        RISCV::FeatureStdExtZvl2048b,  RISCV::FeatureStdExtZvl4096b,
+        RISCV::FeatureStdExtZvl8192b,  RISCV::FeatureStdExtZvl16384b,
+        RISCV::FeatureStdExtZvl32768b, RISCV::FeatureStdExtZvl65536b};
+    for (auto [Idx, Feature] : enumerate(ZvlFeatures)) {
       if (STI.hasFeature(Feature))
-        ZvlVLen = std::max(ZvlVLen, Size);
+        ZvlVLen = std::max(ZvlVLen, 1u << (Idx + 5));
     }
   }
 


### PR DESCRIPTION
Until recently checkFeature was quite slow. #130936

I was curious where we use checkFeature and noticed these. I thought we could use hasFeature instead of going through strings.