### PR TITLE
[clang-tidy] Add IgnoreMacros to readability-function-size

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/FunctionSizeCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/FunctionSizeCheck.h
@@ -47,6 +47,7 @@ private:
   const std::optional<unsigned> ParameterThreshold;
   const std::optional<unsigned> NestingThreshold;
   const std::optional<unsigned> VariableThreshold;
+  const bool IgnoreMacros;
 
   static constexpr std::optional<unsigned> DefaultLineThreshold = std::nullopt;
   static constexpr std::optional<unsigned> DefaultStatementThreshold = 800U;
@@ -58,6 +59,7 @@ private:
       std::nullopt;
   static constexpr std::optional<unsigned> DefaultVariableThreshold =
       std::nullopt;
+  static constexpr bool DefaultIgnoreMacros = false;
 };
 
 } // namespace clang::tidy::readability

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -178,6 +178,10 @@ Changes in existing checks
   tolerating fix-it breaking compilation when functions is used as pointers
   to avoid matching usage of functions within the current compilation unit.
 
+- Improved :doc:`readability-function-size
+  <clang-tidy/checks/readability/function-size>` check by adding the option
+  `IgnoreMacros` to allow ignoring code inside macros.
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/function-size.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/function-size.rst
@@ -43,3 +43,10 @@ Options
    The default is `none` (ignore the number of variables).
    Please note that function parameters and variables declared in lambdas,
    GNU Statement Expressions, and nested class inline functions are not counted.
+
+.. option:: IgnoreMacros
+
+   If set to `true`, the check will ignore code inside macros. Note, that also
+   any macro arguments are ignored, even if they should count to the complexity.
+   As this might change in the future, this option isn't guaranteed to be
+   forward-compatible. Default is `false`.

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/function-size.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/function-size.cpp
@@ -15,7 +15,8 @@
 // RUN:         readability-function-size.BranchThreshold: "5", \
 // RUN:         readability-function-size.ParameterThreshold: "none", \
 // RUN:         readability-function-size.NestingThreshold: "", \
-// RUN:         readability-function-size.VariableThreshold: "" \
+// RUN:         readability-function-size.VariableThreshold: "", \
+// RUN:         readability-function-size.IgnoreMacros: "true" \
 // RUN:     }}'
 
 // Bad formatting is intentional, don't run clang-format over the whole file!
@@ -319,3 +320,15 @@ void variables_16() {
 // CHECK-MESSAGES: :[[@LINE-5]]:6: note: 3 lines including whitespace and comments (threshold 0)
 // CHECK-MESSAGES: :[[@LINE-6]]:6: note: 4 statements (threshold 0)
 // CHECK-MESSAGES: :[[@LINE-7]]:6: note: 2 variables (threshold 1)
+
+#define CONDITION(value) if (value) { return value; }
+
+int macro_test(int v) {
+// CHECK-MESSAGES: :[[@LINE-1]]:5: warning: function 'macro_test' exceeds recommended size/complexity thresholds [readability-function-size]
+// CHECK-MESSAGES: :[[@LINE-2]]:5: note: 8 lines including whitespace and comments (threshold 0)
+// CHECK-MESSAGES: :[[@LINE-3]]:5: note: 31 statements (threshold 0)
+// CHECK-MESSAGES: :[[@LINE-4]]:5: note: 8 branches (threshold 0)
+
+  CONDITION(v);CONDITION(v);CONDITION(v);CONDITION(v);CONDITION(v);CONDITION(v);CONDITION(v);
+  if (v) { return v; }
+}


### PR DESCRIPTION
Extend readability-function-size check by adding
IgnoreMacros option.

Fixes #112835