### PR TITLE
[clang-tidy] Fixed bugprone-non-zero-enum-to-bool-conversion

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -118,6 +118,10 @@ New check aliases
 Changes in existing checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Improved :doc:`bugprone-non-zero-enum-to-bool-conversion
+  <clang-tidy/checks/bugprone/non-zero-enum-to-bool-conversion>` check to
+  ignore enums without enumerators and enums with ``bool`` as underlying type.
+
 - Improved :doc:`bugprone-optional-value-conversion
   <clang-tidy/checks/bugprone/optional-value-conversion>` check to detect
   conversion in argument of ``std::make_optional``.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/non-zero-enum-to-bool-conversion.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/non-zero-enum-to-bool-conversion.rst
@@ -12,7 +12,8 @@ and maintainability and can result in bugs.
 May produce false positives if the ``enum`` is used to store other values
 (used as a bit-mask or zero-initialized on purpose). To deal with them,
 ``// NOLINT`` or casting first to the underlying type before casting to ``bool``
-can be used.
+can be used. Enums without enumerators and enums that use ``bool`` as the
+underlying type are ignored.
 
 It is important to note that this check will not generate warnings if the
 definition of the enumeration type is not available.

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/non-zero-enum-to-bool-conversion-cpp11.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/non-zero-enum-to-bool-conversion-cpp11.cpp
@@ -106,5 +106,18 @@ bool testEnumConversion(const EResult& value) {
 }
 
 }
+}
 
+namespace without::issue {
+namespace enum_bool {
+
+enum EResult : bool {
+  OK = 1
+};
+
+bool testEnumConversion(const EResult& value) {
+  return value;
+}
+
+}
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/non-zero-enum-to-bool-conversion.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/non-zero-enum-to-bool-conversion.cpp
@@ -126,4 +126,10 @@ void testCustomOperator(CustomOperatorEnum e) {
     if (!(e & E1)) {}
 }
 
+enum EmptyEnum {};
+
+bool testCustomOperator(EmptyEnum value) {
+  return value;
+}
+
 }


### PR DESCRIPTION
Improved bugprone-non-zero-enum-to-bool-conversion check to 
ignore enums without enumerators and enums with bool as underlying type.

Fixes #130762