### PR TITLE
[ctxprof] Track unhandled call targets

### DIFF
--- a/compiler-rt/lib/ctx_profile/CtxInstrContextNode.h
+++ b/compiler-rt/lib/ctx_profile/CtxInstrContextNode.h
@@ -121,6 +121,7 @@ class ProfileWriter {
 public:
   virtual void startContextSection() = 0;
   virtual void writeContextual(const ctx_profile::ContextNode &RootNode,
+                               const ctx_profile::ContextNode *Unhandled,
                                uint64_t TotalRootEntryCount) = 0;
   virtual void endContextSection() = 0;
 

--- a/compiler-rt/lib/ctx_profile/tests/CtxInstrProfilingTest.cpp
+++ b/compiler-rt/lib/ctx_profile/tests/CtxInstrProfilingTest.cpp
@@ -240,7 +240,7 @@ TEST_F(ContextTest, Dump) {
     TestProfileWriter(ContextRoot *Root, size_t Entries)
         : Root(Root), Entries(Entries) {}
 
-    void writeContextual(const ContextNode &Node,
+    void writeContextual(const ContextNode &Node, const ContextNode *Unhandled,
                          uint64_t TotalRootEntryCount) override {
       EXPECT_EQ(TotalRootEntryCount, Entries);
       EXPECT_EQ(EnteredSectionCount, 1);

--- a/compiler-rt/test/ctx_profile/TestCases/generate-context.cpp
+++ b/compiler-rt/test/ctx_profile/TestCases/generate-context.cpp
@@ -5,7 +5,8 @@
 // RUN: cp %llvm_src/include/llvm/ProfileData/CtxInstrContextNode.h %t_include/
 //
 // Compile with ctx instrumentation "on". We treat "theRoot" as callgraph root.
-// RUN: %clangxx %s %ctxprofilelib -I%t_include -O2 -o %t.bin -mllvm -profile-context-root=theRoot
+// RUN: %clangxx %s %ctxprofilelib -I%t_include -O2 -o %t.bin -mllvm -profile-context-root=theRoot \
+// RUN:   -mllvm -ctx-prof-skip-callsite-instr=skip_me
 //
 // Run the binary, and observe the profile fetch handler's output.
 // RUN: %t.bin | FileCheck %s
@@ -20,11 +21,14 @@ extern "C" bool __llvm_ctx_profile_fetch(ProfileWriter &);
 
 // avoid name mangling
 extern "C" {
+__attribute__((noinline)) void skip_me() {}
+
 __attribute__((noinline)) void someFunction(int I) {
   if (I % 2)
     printf("check odd\n");
   else
     printf("check even\n");
+  skip_me();
 }
 
 // block inlining because the pre-inliner otherwise will inline this - it's
@@ -36,6 +40,7 @@ __attribute__((noinline)) void theRoot() {
   for (auto I = 0; I < 2; ++I) {
     someFunction(I);
   }
+  skip_me();
 }
 
 __attribute__((noinline)) void flatFct() {
@@ -85,9 +90,13 @@ class TestProfileWriter : public ProfileWriter {
   }
 
   void writeContextual(const ContextNode &RootNode,
+                       const ContextNode *Unhandled,
                        uint64_t EntryCount) override {
     std::cout << "Entering Root " << RootNode.guid()
               << " with total entry count " << EntryCount << std::endl;
+    for (const auto *P = Unhandled; P; P = P->next())
+      std::cout << "Unhandled GUID: " << P->guid() << " entered "
+                << P->entrycount() << " times" << std::endl;
     printProfile(RootNode, "", "");
   }
 
@@ -119,6 +128,8 @@ class TestProfileWriter : public ProfileWriter {
 // branches would be taken once, so the second counter is 1.
 // CHECK-NEXT: Entered Context Section
 // CHECK-NEXT: Entering Root 8657661246551306189 with total entry count 1
+// skip_me is entered 4 times: 3 via `someFunction`, and once from `theRoot`
+// CHECK-NEXT: Unhandled GUID: 17928815489886282963 entered 4 times
 // CHECK-NEXT: Guid: 8657661246551306189
 // CHECK-NEXT: Entries: 1
 // CHECK-NEXT: 2 counters and 3 callsites
@@ -135,6 +146,8 @@ class TestProfileWriter : public ProfileWriter {
 // CHECK-NEXT:   Counter values: 2 1
 // CHECK-NEXT: Exited Context Section
 // CHECK-NEXT: Entered Flat Section
+// This is `skip_me`. Entered 3 times via `someFunction`
+// CHECK-NEXT: Flat: 17928815489886282963 3
 // CHECK-NEXT: Flat: 6759619411192316602 3,1
 // This is flatFct (guid: 14569438697463215220)
 // CHECK-NEXT: Flat: 14569438697463215220 1,2

--- a/llvm/include/llvm/ProfileData/CtxInstrContextNode.h
+++ b/llvm/include/llvm/ProfileData/CtxInstrContextNode.h
@@ -121,6 +121,7 @@ class ProfileWriter {
 public:
   virtual void startContextSection() = 0;
   virtual void writeContextual(const ctx_profile::ContextNode &RootNode,
+                               const ctx_profile::ContextNode *Unhandled,
                                uint64_t TotalRootEntryCount) = 0;
   virtual void endContextSection() = 0;
 

--- a/llvm/include/llvm/ProfileData/PGOCtxProfWriter.h
+++ b/llvm/include/llvm/ProfileData/PGOCtxProfWriter.h
@@ -36,7 +36,8 @@ enum PGOCtxProfileBlockIDs {
   ContextNodeBlockID = ContextRootBlockID + 1,
   FlatProfilesSectionBlockID = ContextNodeBlockID + 1,
   FlatProfileBlockID = FlatProfilesSectionBlockID + 1,
-  LAST_VALID = FlatProfileBlockID
+  UnhandledBlockID = FlatProfileBlockID + 1,
+  LAST_VALID = UnhandledBlockID
 };
 
 /// Write one or more ContextNodes to the provided raw_fd_stream.
@@ -94,6 +95,7 @@ public:
 
   void startContextSection() override;
   void writeContextual(const ctx_profile::ContextNode &RootNode,
+                       const ctx_profile::ContextNode *Unhandled,
                        uint64_t TotalRootEntryCount) override;
   void endContextSection() override;
 
@@ -104,7 +106,7 @@ public:
 
   // constants used in writing which a reader may find useful.
   static constexpr unsigned CodeLen = 2;
-  static constexpr uint32_t CurrentVersion = 3;
+  static constexpr uint32_t CurrentVersion = 4;
   static constexpr unsigned VBREncodingBits = 6;
   static constexpr StringRef ContainerMagic = "CTXP";
 };

--- a/llvm/lib/ProfileData/PGOCtxProfWriter.cpp
+++ b/llvm/lib/ProfileData/PGOCtxProfWriter.cpp
@@ -58,6 +58,7 @@ PGOCtxProfileWriter::PGOCtxProfileWriter(
     DescribeRecord(PGOCtxProfileRecords::TotalRootEntryCount,
                    "TotalRootEntryCount");
     DescribeRecord(PGOCtxProfileRecords::Counters, "Counters");
+    DescribeBlock(PGOCtxProfileBlockIDs::UnhandledBlockID, "Unhandled");
     DescribeBlock(PGOCtxProfileBlockIDs::ContextNodeBlockID, "Context");
     DescribeRecord(PGOCtxProfileRecords::Guid, "GUID");
     DescribeRecord(PGOCtxProfileRecords::CallsiteIndex, "CalleeIndex");
@@ -135,6 +136,7 @@ void PGOCtxProfileWriter::endContextSection() { Writer.ExitBlock(); }
 void PGOCtxProfileWriter::endFlatSection() { Writer.ExitBlock(); }
 
 void PGOCtxProfileWriter::writeContextual(const ContextNode &RootNode,
+                                          const ContextNode *Unhandled,
                                           uint64_t TotalRootEntryCount) {
   if (!IncludeEmpty && (!TotalRootEntryCount || (RootNode.counters_size() > 0 &&
                                                  RootNode.entrycount() == 0)))
@@ -143,6 +145,12 @@ void PGOCtxProfileWriter::writeContextual(const ContextNode &RootNode,
   writeGuid(RootNode.guid());
   writeRootEntryCount(TotalRootEntryCount);
   writeCounters({RootNode.counters(), RootNode.counters_size()});
+
+  Writer.EnterSubblock(PGOCtxProfileBlockIDs::UnhandledBlockID, CodeLen);
+  for (const auto *P = Unhandled; P; P = P->next())
+    writeFlat(P->guid(), P->counters(), P->counters_size());
+  Writer.ExitBlock();
+
   writeSubcontexts(RootNode);
   Writer.ExitBlock();
 }
@@ -159,6 +167,9 @@ namespace {
 
 /// Representation of the context node suitable for yaml serialization /
 /// deserialization.
+using SerializableFlatProfileRepresentation =
+    std::pair<ctx_profile::GUID, std::vector<uint64_t>>;
+
 struct SerializableCtxRepresentation {
   ctx_profile::GUID Guid = 0;
   std::vector<uint64_t> Counters;
@@ -167,10 +178,8 @@ struct SerializableCtxRepresentation {
 
 struct SerializableRootRepresentation : public SerializableCtxRepresentation {
   uint64_t TotalRootEntryCount = 0;
+  std::vector<SerializableFlatProfileRepresentation> Unhandled;
 };
-
-using SerializableFlatProfileRepresentation =
-    std::pair<ctx_profile::GUID, std::vector<uint64_t>>;
 
 struct SerializableProfileRepresentation {
   std::vector<SerializableRootRepresentation> Contexts;
@@ -228,6 +237,7 @@ template <> struct yaml::MappingTraits<SerializableRootRepresentation> {
   static void mapping(yaml::IO &IO, SerializableRootRepresentation &R) {
     yaml::MappingTraits<SerializableCtxRepresentation>::mapping(IO, R);
     IO.mapRequired("TotalRootEntryCount", R.TotalRootEntryCount);
+    IO.mapOptional("Unhandled", R.Unhandled);
   }
 };
 
@@ -265,7 +275,15 @@ Error llvm::createCtxProfFromYAML(StringRef Profile, raw_ostream &Out) {
       if (!TopList)
         return createStringError(
             "Unexpected error converting internal structure to ctx profile");
-      Writer.writeContextual(*TopList, DC.TotalRootEntryCount);
+
+      ctx_profile::ContextNode *FirstUnhandled = nullptr;
+      for (const auto &U : DC.Unhandled) {
+        SerializableCtxRepresentation Unhandled;
+        Unhandled.Guid = U.first;
+        Unhandled.Counters = U.second;
+        FirstUnhandled = createNode(Nodes, Unhandled, FirstUnhandled);
+      }
+      Writer.writeContextual(*TopList, FirstUnhandled, DC.TotalRootEntryCount);
     }
     Writer.endContextSection();
   }

--- a/llvm/test/tools/llvm-ctxprof-util/Inputs/valid-with-unhandled.yaml
+++ b/llvm/test/tools/llvm-ctxprof-util/Inputs/valid-with-unhandled.yaml
@@ -1,0 +1,26 @@
+
+Contexts:
+  - Guid:            1000
+    TotalRootEntryCount: 5
+    Counters:        [ 1, 2, 3 ]
+    Callsites:
+      - [  ]
+      - - Guid:            2000
+          Counters:        [ 4, 5 ]
+        - Guid:            18446744073709551613
+          Counters:        [ 6, 7, 8 ]
+      - - Guid:            3000
+          Counters:        [ 40, 50 ]
+  - Guid:            18446744073709551612
+    TotalRootEntryCount: 45
+    Counters:        [ 5, 9, 10 ]
+    Unhandled:
+      - Guid:            555
+        Counters:        [ 1, 2, 3 ]
+      - Guid:            2000
+        Counters:        [ 1, 2 ]
+FlatProfiles:
+  - Guid:            1234
+    Counters:        [ 5, 6, 7 ]
+  - Guid:            5555
+    Counters:        [ 1 ]

--- a/llvm/test/tools/llvm-ctxprof-util/llvm-ctxprof-util.test
+++ b/llvm/test/tools/llvm-ctxprof-util/llvm-ctxprof-util.test
@@ -23,6 +23,11 @@
 ; RUN: llvm-ctxprof-util toYAML -input %t/valid-flat-first.bitstream -output %t/valid-flat-first.yaml
 ; RUN: diff %t/valid-flat-first.yaml %S/Inputs/valid.yaml
 
+; A variant with unhandled contexts:
+; RUN: llvm-ctxprof-util fromYAML -input %S/Inputs/valid-with-unhandled.yaml -output %t/valid-with-unhandled.bitstream
+; RUN: llvm-ctxprof-util toYAML -input %t/valid-with-unhandled.bitstream -output %t/valid-with-unhandled.yaml
+; RUN: diff %t/valid-with-unhandled.yaml %S/Inputs/valid-with-unhandled.yaml
+
 ; For the valid case, check against a reference output.
 ; Note that uint64_t are printed as signed values by llvm-bcanalyzer:
 ;  * 18446744073709551613 in yaml is -3 in the output
@@ -33,17 +38,19 @@
 
 ; EMPTY: <BLOCKINFO_BLOCK/>
 ; EMPTY-NEXT: <Metadata NumWords=1 BlockCodeSize=2>
-; EMPTY-NEXT:   <Version op0=3/>
+; EMPTY-NEXT:   <Version op0=4/>
 ; EMPTY-NEXT: </Metadata>
 
 ; VALID:      <BLOCKINFO_BLOCK/>
-; VALID-NEXT: <Metadata NumWords=46 BlockCodeSize=2>
-; VALID-NEXT:   <Version op0=3/>
-; VALID-NEXT:   <Contexts NumWords=30 BlockCodeSize=2>
-; VALID-NEXT:     <Root NumWords=20 BlockCodeSize=2>
+; VALID-NEXT: <Metadata NumWords=53 BlockCodeSize=2>
+; VALID-NEXT:   <Version op0=4/>
+; VALID-NEXT:   <Contexts NumWords=37 BlockCodeSize=2>
+; VALID-NEXT:     <Root NumWords=23 BlockCodeSize=2>
 ; VALID-NEXT:       <GUID op0=1000/>
 ; VALID-NEXT:       <TotalRootEntryCount op0=5/>
 ; VALID-NEXT:       <Counters op0=1 op1=2 op2=3/>
+; VALID-NEXT:       <Unhandled NumWords=1 BlockCodeSize=2>
+; VALID-NEXT:       </Unhandled>
 ; VALID-NEXT:       <Context NumWords=5 BlockCodeSize=2>
 ; VALID-NEXT:         <GUID op0=-3/>
 ; VALID-NEXT:         <CalleeIndex op0=1/>
@@ -60,10 +67,12 @@
 ; VALID-NEXT:         <Counters op0=40 op1=50/>
 ; VALID-NEXT:       </Context>
 ; VALID-NEXT:     </Root>
-; VALID-NEXT:     <Root NumWords=5 BlockCodeSize=2>
+; VALID-NEXT:     <Root NumWords=9 BlockCodeSize=2>
 ; VALID-NEXT:       <GUID op0=-4/>
 ; VALID-NEXT:       <TotalRootEntryCount op0=45/>
 ; VALID-NEXT:       <Counters op0=5 op1=9 op2=10/>
+; VALID-NEXT:       <Unhandled NumWords=1 BlockCodeSize=2>
+; VALID-NEXT:       </Unhandled>
 ; VALID-NEXT:     </Root>
 ; VALID-NEXT:   </Contexts>
 ; VALID-NEXT:   <FlatProfiles NumWords=10 BlockCodeSize=2>

--- a/llvm/unittests/ProfileData/PGOCtxProfReaderWriterTest.cpp
+++ b/llvm/unittests/ProfileData/PGOCtxProfReaderWriterTest.cpp
@@ -103,7 +103,7 @@ TEST_F(PGOCtxProfRWTest, RoundTrip) {
       PGOCtxProfileWriter Writer(Out);
       Writer.startContextSection();
       for (auto &[_, R] : roots())
-        Writer.writeContextual(*R, 1);
+        Writer.writeContextual(*R, nullptr, 1);
       Writer.endContextSection();
     }
   }
@@ -155,7 +155,7 @@ TEST_F(PGOCtxProfRWTest, InvalidCounters) {
     {
       PGOCtxProfileWriter Writer(Out);
       Writer.startContextSection();
-      Writer.writeContextual(*R, 2);
+      Writer.writeContextual(*R, nullptr, 2);
       Writer.endContextSection();
     }
   }
@@ -181,7 +181,7 @@ TEST_F(PGOCtxProfRWTest, CountersAllZero) {
     {
       PGOCtxProfileWriter Writer(Out);
       Writer.startContextSection();
-      Writer.writeContextual(*R, 42);
+      Writer.writeContextual(*R, nullptr, 42);
       Writer.endContextSection();
     }
   }
@@ -208,7 +208,7 @@ TEST_F(PGOCtxProfRWTest, CountersAllZeroWithOverride) {
       PGOCtxProfileWriter Writer(Out, /*VersionOverride=*/std::nullopt,
                                  /*IncludeEmpty=*/true);
       Writer.startContextSection();
-      Writer.writeContextual(*R, 8);
+      Writer.writeContextual(*R, nullptr, 8);
       Writer.endContextSection();
     }
   }
@@ -293,8 +293,8 @@ TEST_F(PGOCtxProfRWTest, DuplicateRoots) {
       PGOCtxProfileWriter Writer(Out, /*VersionOverride=*/std::nullopt,
                                  /*IncludeEmpty=*/true);
       Writer.startContextSection();
-      Writer.writeContextual(*createNode(1, 1, 1), 1);
-      Writer.writeContextual(*createNode(1, 1, 1), 1);
+      Writer.writeContextual(*createNode(1, 1, 1), nullptr, 1);
+      Writer.writeContextual(*createNode(1, 1, 1), nullptr, 1);
       Writer.endContextSection();
     }
   }
@@ -322,7 +322,7 @@ TEST_F(PGOCtxProfRWTest, DuplicateTargets) {
       R->subContexts()[0] = L2;
       PGOCtxProfileWriter Writer(Out);
       Writer.startContextSection();
-      Writer.writeContextual(*R, 1);
+      Writer.writeContextual(*R, nullptr, 1);
       Writer.endContextSection();
     }
   }


### PR DESCRIPTION
Collect profiles for functions we encounter when collecting a contextual profile, that are not associated with a call site. This is expected to happen for signal handlers, but it also - problematically - currently happens for mem{memset|copy|move|set}, which are currently inserted after profile instrumentation.

Collecting a "regular" flat profile in these cases would hide the problem - that we loose better profile opportunities.