### PR TITLE
[libc++][test] Skip a `is_virtual_base_of` test for apple-clang-17

### DIFF
--- a/libcxx/test/std/utilities/meta/meta.rel/is_virtual_base_of.pass.cpp
+++ b/libcxx/test/std/utilities/meta/meta.rel/is_virtual_base_of.pass.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17, c++20, c++23
 
 // These compilers don't support __builtin_is_virtual_base_of yet.
-// UNSUPPORTED: clang-18, clang-19, gcc-14, apple-clang-16
+// UNSUPPORTED: clang-18, clang-19, gcc-14, apple-clang-16, apple-clang-17
 
 // <type_traits>
 


### PR DESCRIPTION
It seems that Apple Clang 17 starts to be used for CI, while it hasn't supported `__builtin_is_virtual_base_of` yet. And thus we need to skip the test for `is_virtual_base_of`.

Follows up #131302.