### PR TITLE
[Metadata] Change placeholder from `undef` to `poison`

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -640,7 +640,7 @@ void CodeGenFunction::EmitKernelMetadata(const FunctionDecl *FD,
         HintQTy->isSignedIntegerType() ||
         (HintEltQTy && HintEltQTy->getElementType()->isSignedIntegerType());
     llvm::Metadata *AttrMDArgs[] = {
-        llvm::ConstantAsMetadata::get(llvm::UndefValue::get(
+        llvm::ConstantAsMetadata::get(llvm::PoisonValue::get(
             CGM.getTypes().ConvertType(A->getTypeHint()))),
         llvm::ConstantAsMetadata::get(llvm::ConstantInt::get(
             llvm::IntegerType::get(Context, 32),

--- a/clang/test/CodeGenCUDASPIRV/spirv-attrs.cu
+++ b/clang/test/CodeGenCUDASPIRV/spirv-attrs.cu
@@ -24,5 +24,5 @@ __global__ void intel_reqd_sub_group_size_64() {}
 
 // CHECK: ![[WG_SIZE]] = !{i32 128, i32 1, i32 1}
 // CHECK: ![[WG_HINT]] = !{i32 2, i32 2, i32 2}
-// CHECK: ![[VEC_HINT]] = !{i32 undef, i32 1}
+// CHECK: ![[VEC_HINT]] = !{i32 poison, i32 1}
 // CHECK: ![[SUB_GRP]] = !{i32 64}

--- a/clang/test/CodeGenOpenCL/kernel-attributes.cl
+++ b/clang/test/CodeGenOpenCL/kernel-attributes.cl
@@ -11,8 +11,8 @@ kernel __attribute__((vec_type_hint(uint4))) __attribute__((work_group_size_hint
 kernel __attribute__((intel_reqd_sub_group_size(8))) void kernel3(int a) {}
 // CHECK: define {{(dso_local )?}}spir_kernel void @kernel3(i32 {{[^%]*}}%a) {{[^{]+}} !intel_reqd_sub_group_size ![[MD5:[0-9]+]]
 
-// CHECK: [[MD1]] = !{i32 undef, i32 1}
+// CHECK: [[MD1]] = !{i32 poison, i32 1}
 // CHECK: [[MD2]] = !{i32 1, i32 2, i32 4}
-// CHECK: [[MD3]] = !{<4 x i32> undef, i32 0}
+// CHECK: [[MD3]] = !{<4 x i32> poison, i32 0}
 // CHECK: [[MD4]] = !{i32 8, i32 16, i32 32}
 // CHECK: [[MD5]] = !{i32 8}


### PR DESCRIPTION
Replace `undef` constant metadata uses with `poison`.