### PR TITLE
[Github][Docs] Add best practice for top level read permissions

### DIFF
--- a/llvm/docs/CIBestPractices.rst
+++ b/llvm/docs/CIBestPractices.rst
@@ -92,3 +92,19 @@ image to a new version with potentially breaking changes, instead allowing us
 to explicitly opt-in to using the new image when we have done sufficient
 testing to ensure that our existing workflows work as expected in the new
 environment.
+
+Top Level Read Permissions
+--------------------------
+
+The top of every workflow should specify that the job only has read
+permissions:
+
+.. code-block:: yaml
+
+  permissions:
+    contents: read
+
+If specific jobs within the workflow need additional permissions, those
+permissions should be added within the specific job. This practice locks down
+all permissions by default and only enables them when needed, better enforcing
+the principal of least privilege.

--- a/llvm/docs/CIBestPractices.rst
+++ b/llvm/docs/CIBestPractices.rst
@@ -107,4 +107,4 @@ permissions:
 If specific jobs within the workflow need additional permissions, those
 permissions should be added within the specific job. This practice locks down
 all permissions by default and only enables them when needed, better enforcing
-the principal of least privilege.
+the principle of least privilege.


### PR DESCRIPTION
This patch adds a section pointing out how permissions should be done within Github workflows. I believe all of our workflows are currently compliant with this, but it helps to have something to point to documenting the practice and especially the motivation.