### PR TITLE
[lldb] Support ordered patterns in lldbtest.expect

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2356,8 +2356,9 @@ FileCheck output:
         matches the patterns contained in 'patterns'.
 
         When matching is true and ordered is true, which are both the default,
-        the strings in the substrs array have to appear in the command output
-        in the order in which they appear in the array.
+        the strings in the substrs array, and regex in the patterns array, have
+        to appear in the command output in the order in which they appear in
+        their respective array.
 
         If the keyword argument error is set to True, it signifies that the API
         client is expecting the command to fail.  In this case, the error stream

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2460,9 +2460,9 @@ FileCheck output:
         if substrs and matched == matching:
             start = 0
             for substr in substrs:
-                index = output[start:].find(substr)
-                start = start + index + len(substr) if ordered and matching else 0
+                index = output.find(substr, start)
                 matched = index != -1
+                start = index + len(substr) if ordered and matched else 0
                 log_lines.append(
                     '{} sub string: "{}" ({})'.format(
                         expecting_str, substr, found_str(matched)
@@ -2473,20 +2473,21 @@ FileCheck output:
                     break
 
         if patterns and matched == matching:
+            start = 0
             for pattern in patterns:
-                matched = re.search(pattern, output)
+                pat = re.compile(pattern)
+                match = pat.search(output, start)
+                matched = bool(match)
+                start = match.end() if ordered and matched else 0
 
                 pattern_line = '{} regex pattern: "{}" ({}'.format(
                     expecting_str, pattern, found_str(matched)
                 )
-                if matched:
-                    pattern_line += ', matched "{}"'.format(matched.group(0))
+                if match:
+                    pattern_line += ', matched "{}"'.format(match.group(0))
                 pattern_line += ")"
                 log_lines.append(pattern_line)
 
-                # Convert to bool because match objects
-                # are True-ish but is not True itself
-                matched = bool(matched)
                 if matched != matching:
                     break
 

--- a/lldb/test/API/functionalities/alias/TestBtAliasRepeat.py
+++ b/lldb/test/API/functionalities/alias/TestBtAliasRepeat.py
@@ -9,7 +9,7 @@ class TestCase(TestBase):
         lldbutil.run_to_source_breakpoint(self, "return", lldb.SBFileSpec("main.c"))
 
         # Expect "frame #0" but not "frame #1".
-        self.expect("bt 1", inHistory=True, patterns=["frame #0", "^(?!.*frame #1)"])
+        self.expect("bt 1", inHistory=True, patterns=["frame #0", "(?!.*frame #1)"])
 
         # Run an empty command to run the repeat command for `bt`.
         # The repeat command for `bt N` lists the subsequent N frames.

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSContainer.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSContainer.py
@@ -52,6 +52,7 @@ class ObjCDataFormatterNSContainer(ObjCDataFormatterTestCase):
 
         self.expect(
             "frame variable -d run-target *nscfDictionary",
+            ordered=False,
             patterns=[
                 r"\(__NSCFDictionary\) \*nscfDictionary =",
                 'key = 0x.* @"foo"',
@@ -67,6 +68,7 @@ class ObjCDataFormatterNSContainer(ObjCDataFormatterTestCase):
 
         self.expect(
             "frame variable -d run-target *cfDictionaryRef",
+            ordered=False,
             patterns=[
                 r"\(const __CFDictionary\) \*cfDictionaryRef =",
                 'key = 0x.* @"foo"',

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unordered/TestDataFormatterGenericUnordered.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unordered/TestDataFormatterGenericUnordered.py
@@ -122,8 +122,8 @@ class GenericUnorderedDataFormatterTestCase(TestBase):
         )
 
     def look_for_content_and_continue(self, var_name, patterns):
-        self.expect(("frame variable %s" % var_name), patterns=patterns)
-        self.expect(("frame variable %s" % var_name), patterns=patterns)
+        self.expect(("frame variable %s" % var_name), ordered=False, patterns=patterns)
+        self.expect(("frame variable %s" % var_name), ordered=False, patterns=patterns)
         self.runCmd("continue")
 
     @add_test_categories(["libstdcxx"])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/span/TestDataFormatterLibcxxSpan.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/span/TestDataFormatterLibcxxSpan.py
@@ -172,4 +172,4 @@ class LibcxxSpanDataFormatterTestCase(TestBase):
 
         # The pointer should just show the right number of elements:
 
-        self.expect("frame variable ptr", patterns=["ptr = 0x.*", " size=5"])
+        self.expect("frame variable ptr", patterns=["ptr = 0x[0-9a-f]+ size=5"])

--- a/lldb/test/API/functionalities/data-formatter/root-reference-children/TestRootReferenceChildren.py
+++ b/lldb/test/API/functionalities/data-formatter/root-reference-children/TestRootReferenceChildren.py
@@ -20,8 +20,8 @@ class TestCase(TestBase):
             "v summary_and_children_ref", substrs=["some summary", "child = 30"]
         )
         self.expect(
-            "v summary_only_ref", patterns=["some summary", "(?s)^(?!.*child = )"]
+            "v summary_only_ref", patterns=["some summary", "(?s)(?!.*child = )"]
         )
         self.expect(
-            "v children_only_ref", patterns=["(?s)^(?!.*some summary)", "child = 30"]
+            "v children_only_ref", patterns=["(?s)(?!.*some summary)", "child = 30"]
         )

--- a/lldb/test/API/lang/cpp/signed_types/TestSignedTypes.py
+++ b/lldb/test/API/lang/cpp/signed_types/TestSignedTypes.py
@@ -57,8 +57,8 @@ class SignedTypesTestCase(TestBase):
             "frame variable --show-types --no-args",
             VARIABLES_DISPLAYED_CORRECTLY,
             patterns=[
-                r"\((short int|short)\) the_signed_short = 99",
                 r"\((signed char|char)\) the_signed_char = 'c'",
+                r"\((short int|short)\) the_signed_short = 99",
             ],
             substrs=[
                 "(int) the_signed_int = 99",

--- a/lldb/test/API/lang/objc/foundation/TestObjCMethods.py
+++ b/lldb/test/API/lang/objc/foundation/TestObjCMethods.py
@@ -166,7 +166,7 @@ class FoundationTestCase(TestBase):
             "frame variable --show-types --scope",
             VARIABLES_DISPLAYED_CORRECTLY,
             substrs=["ARG: (MyString *) self"],
-            patterns=[r"ARG: \(.*\) _cmd", "(objc_selector *)|(SEL)"],
+            patterns=[r"ARG: \(SEL|objc_selector \*\) _cmd"],
         )
 
         # rdar://problem/8651752

--- a/lldb/test/API/source-manager/TestSourceManager.py
+++ b/lldb/test/API/source-manager/TestSourceManager.py
@@ -129,6 +129,7 @@ class SourceManagerTestCase(TestBase):
             stream.GetData(),
             "Source code displayed correctly:\n" + stream.GetData(),
             exe=False,
+            ordered=False,
             patterns=["=>", "%d.*Hello world" % self.line, needle_regex],
         )
 


### PR DESCRIPTION
Change `lldbtest.expect` to require the regexes in `patterns` be found in order – when the
`ordered` parameter is true. This matches the behavior of `substrs`.

The `ordered` parameter is true by default, so this change also fixes tests by either
tweaking the patterns to work in order, or by setting `ordered=False`.

I have often wanted to test with `patterns` and also verify the order. This change
allows that.
