### PR TITLE
[mlir][ODS] Fix default inferReturnTypes generation for variadic operands

### DIFF
--- a/mlir/test/mlir-tblgen/op-result.td
+++ b/mlir/test/mlir-tblgen/op-result.td
@@ -136,9 +136,8 @@ def OpL1 : NS_Op<"op_with_all_types_constraint",
 
 // CHECK-LABEL: LogicalResult OpL1::inferReturnTypes
 // CHECK-NOT: }
-// CHECK: if (operands.size() <= 0)
-// CHECK-NEXT: return ::mlir::failure();
-// CHECK: ::mlir::Type odsInferredType0 = operands[0].getType();
+// CHECK: OpL1::Adaptor adaptor
+// CHECK: ::mlir::Type odsInferredType0 = adaptor.getA().getType();
 // CHECK: inferredReturnTypes[0] = odsInferredType0;
 
 def OpL2 : NS_Op<"op_with_all_types_constraint",
@@ -149,11 +148,9 @@ def OpL2 : NS_Op<"op_with_all_types_constraint",
 
 // CHECK-LABEL: LogicalResult OpL2::inferReturnTypes
 // CHECK-NOT: }
-// CHECK: if (operands.size() <= 2)
-// CHECK-NEXT: return ::mlir::failure();
-// CHECK-NOT: if (operands.size() <= 0)
-// CHECK: ::mlir::Type odsInferredType0 = operands[2].getType();
-// CHECK: ::mlir::Type odsInferredType1 = operands[0].getType();
+// CHECK: OpL2::Adaptor adaptor
+// CHECK: ::mlir::Type odsInferredType0 = adaptor.getC().getType();
+// CHECK: ::mlir::Type odsInferredType1 = adaptor.getA().getType();
 // CHECK: inferredReturnTypes[0] = odsInferredType0;
 // CHECK: inferredReturnTypes[1] = odsInferredType1;
 
@@ -177,9 +174,8 @@ def OpL4 : NS_Op<"two_inference_edges", [
 }
 
 // CHECK-LABEL: LogicalResult OpL4::inferReturnTypes
-// CHECK: if (operands.size() <= 0)
-// CHECK-NEXT: return ::mlir::failure();
-// CHECK: odsInferredType0 = fromInput(operands[0].getType())
+// CHECK: OpL4::Adaptor adaptor
+// CHECK: odsInferredType0 = fromInput(adaptor.getInput().getType())
 // CHECK: odsInferredType1 = infer0(odsInferredType0)
 // CHECK: odsInferredType2 = infer1(odsInferredType1)
 // CHECK: inferredReturnTypes[0] = odsInferredType0

--- a/mlir/test/mlir-tblgen/op-result.td
+++ b/mlir/test/mlir-tblgen/op-result.td
@@ -203,6 +203,18 @@ def OpL6 : NS_Op<"op_with_same_and_constraint_results",
 // CHECK: inferredReturnTypes[1] = odsInferredType1;
 // CHECK: inferredReturnTypes[2] = odsInferredType2;
 
+def OpL7 : NS_Op<"one_variadic_and_one_normal_operand_with_infer_result_op",
+    [TypesMatchWith<"", "input2", "output1", "infer0($_self)">]> {
+  let arguments = (ins Variadic<AnyTensor>:$input1, AnyTensor:$input2);
+  let results = (outs AnyTensor:$output1);
+}
+
+// CHECK-LABEL: LogicalResult OpL7::inferReturnTypes
+// CHECK-NOT: }
+// CHECK: OpL7::Adaptor adaptor
+// CHECK: odsInferredType0 = infer0(adaptor.getInput2().getType())
+// CHECK: inferredReturnTypes[0] = odsInferredType0
+
 def OpM : NS_Op<"mix_diff_size_variadic_and_normal_results_op", [AttrSizedResultSegments]> {
   let results = (outs Variadic<AnyTensor>:$output1, AnyTensor:$output2, Optional<AnyTensor>:$output3);
 }

--- a/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
@@ -3754,15 +3754,6 @@ void OpEmitter::genTypeInterfaceMethods() {
   body << "  " << op.getCppClassName()
        << "::Adaptor adaptor(operands, attributes, properties, regions);\n";
 
-  // TODO: Ideally, we should be doing some sort of verification here. This
-  // is however problemetic due to 2 reasons:
-  //
-  // 1. Adaptor::verify only verifies attributes. It really should verify
-  //    if the number of given attributes is right too.
-  // 2. PDL passes empty properties to inferReturnTypes, which does not verify.
-  //    Without properties, it's not really possible to verify the number of
-  //    operands as we do not know the variadic operand segment sizes.
-
   // Process the type inference graph in topological order, starting from
   // types that are always fully-inferred: operands and results with
   // constructible types. The type inference graph here will always be a


### PR DESCRIPTION
For variadic operands, `operands[odsOperandIndex]` is incorrect, because the operand can be variadic. Instead, create an adaptor and use it to get the correct operand.