### PR TITLE
Rename RISCVMCExpr::VK_RISCV_ to VK_. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -510,7 +510,7 @@ public:
     }
 
     if (auto CE = dyn_cast<MCConstantExpr>(Expr)) {
-      VK = RISCVMCExpr::VK_RISCV_None;
+      VK = RISCVMCExpr::VK_None;
       Imm = CE->getValue();
       return true;
     }
@@ -522,7 +522,7 @@ public:
   // modifiers and isShiftedInt<N-1, 1>(Op).
   template <int N> bool isBareSimmNLsb0() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     if (!isImm())
       return false;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
@@ -531,71 +531,70 @@ public:
       IsValid = RISCVAsmParser::classifySymbolRef(getImm(), VK);
     else
       IsValid = isShiftedInt<N - 1, 1>(fixImmediateForRV32(Imm, isRV64Imm()));
-    return IsValid && VK == RISCVMCExpr::VK_RISCV_None;
+    return IsValid && VK == RISCVMCExpr::VK_None;
   }
 
   // Predicate methods for AsmOperands defined in RISCVInstrInfo.td
 
   bool isBareSymbol() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     // Must be of 'immediate' type but not a constant.
     if (!isImm() || evaluateConstantImm(getImm(), Imm, VK))
       return false;
     return RISCVAsmParser::classifySymbolRef(getImm(), VK) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isCallSymbol() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     // Must be of 'immediate' type but not a constant.
     if (!isImm() || evaluateConstantImm(getImm(), Imm, VK))
       return false;
     return RISCVAsmParser::classifySymbolRef(getImm(), VK) &&
-           (VK == RISCVMCExpr::VK_RISCV_CALL ||
-            VK == RISCVMCExpr::VK_RISCV_CALL_PLT);
+           (VK == RISCVMCExpr::VK_CALL || VK == RISCVMCExpr::VK_CALL_PLT);
   }
 
   bool isPseudoJumpSymbol() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     // Must be of 'immediate' type but not a constant.
     if (!isImm() || evaluateConstantImm(getImm(), Imm, VK))
       return false;
     return RISCVAsmParser::classifySymbolRef(getImm(), VK) &&
-           VK == RISCVMCExpr::VK_RISCV_CALL;
+           VK == RISCVMCExpr::VK_CALL;
   }
 
   bool isTPRelAddSymbol() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     // Must be of 'immediate' type but not a constant.
     if (!isImm() || evaluateConstantImm(getImm(), Imm, VK))
       return false;
     return RISCVAsmParser::classifySymbolRef(getImm(), VK) &&
-           VK == RISCVMCExpr::VK_RISCV_TPREL_ADD;
+           VK == RISCVMCExpr::VK_TPREL_ADD;
   }
 
   bool isTLSDESCCallSymbol() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     // Must be of 'immediate' type but not a constant.
     if (!isImm() || evaluateConstantImm(getImm(), Imm, VK))
       return false;
     return RISCVAsmParser::classifySymbolRef(getImm(), VK) &&
-           VK == RISCVMCExpr::VK_RISCV_TLSDESC_CALL;
+           VK == RISCVMCExpr::VK_TLSDESC_CALL;
   }
 
   bool isCSRSystemRegister() const { return isSystemRegister(); }
 
   bool isVTypeImm(unsigned N) const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     if (!isImm())
       return false;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
-    return IsConstantImm && isUIntN(N, Imm) && VK == RISCVMCExpr::VK_RISCV_None;
+    return IsConstantImm && isUIntN(N, Imm) && VK == RISCVMCExpr::VK_None;
   }
 
   // If the last operand of the vsetvli/vsetvli instruction is a constant
@@ -635,19 +634,18 @@ public:
 
   bool isImmXLenLI() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     if (!isImm())
       return false;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
-    if (VK == RISCVMCExpr::VK_RISCV_LO ||
-        VK == RISCVMCExpr::VK_RISCV_PCREL_LO ||
-        VK == RISCVMCExpr::VK_RISCV_TLSDESC_LOAD_LO ||
-        VK == RISCVMCExpr::VK_RISCV_TLSDESC_ADD_LO)
+    if (VK == RISCVMCExpr::VK_LO || VK == RISCVMCExpr::VK_PCREL_LO ||
+        VK == RISCVMCExpr::VK_TLSDESC_LOAD_LO ||
+        VK == RISCVMCExpr::VK_TLSDESC_ADD_LO)
       return true;
     // Given only Imm, ensuring that the actually specified constant is either
     // a signed or unsigned 64-bit number is unfortunately impossible.
     if (IsConstantImm) {
-      return VK == RISCVMCExpr::VK_RISCV_None &&
+      return VK == RISCVMCExpr::VK_None &&
              (isRV64Imm() || (isInt<32>(Imm) || isUInt<32>(Imm)));
     }
 
@@ -656,33 +654,31 @@ public:
 
   bool isImmXLenLI_Restricted() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     if (!isImm())
       return false;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     // 'la imm' supports constant immediates only.
-    return IsConstantImm && (VK == RISCVMCExpr::VK_RISCV_None) &&
+    return IsConstantImm && (VK == RISCVMCExpr::VK_None) &&
            (isRV64Imm() || (isInt<32>(Imm) || isUInt<32>(Imm)));
   }
 
   bool isUImmLog2XLen() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     if (!isImm())
       return false;
-    if (!evaluateConstantImm(getImm(), Imm, VK) ||
-        VK != RISCVMCExpr::VK_RISCV_None)
+    if (!evaluateConstantImm(getImm(), Imm, VK) || VK != RISCVMCExpr::VK_None)
       return false;
     return (isRV64Imm() && isUInt<6>(Imm)) || isUInt<5>(Imm);
   }
 
   bool isUImmLog2XLenNonZero() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     if (!isImm())
       return false;
-    if (!evaluateConstantImm(getImm(), Imm, VK) ||
-        VK != RISCVMCExpr::VK_RISCV_None)
+    if (!evaluateConstantImm(getImm(), Imm, VK) || VK != RISCVMCExpr::VK_None)
       return false;
     if (Imm == 0)
       return false;
@@ -691,22 +687,21 @@ public:
 
   bool isUImmLog2XLenHalf() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     if (!isImm())
       return false;
-    if (!evaluateConstantImm(getImm(), Imm, VK) ||
-        VK != RISCVMCExpr::VK_RISCV_None)
+    if (!evaluateConstantImm(getImm(), Imm, VK) || VK != RISCVMCExpr::VK_None)
       return false;
     return (isRV64Imm() && isUInt<5>(Imm)) || isUInt<4>(Imm);
   }
 
   template <unsigned N> bool IsUImm() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     if (!isImm())
       return false;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
-    return IsConstantImm && isUInt<N>(Imm) && VK == RISCVMCExpr::VK_RISCV_None;
+    return IsConstantImm && isUInt<N>(Imm) && VK == RISCVMCExpr::VK_None;
   }
 
   bool isUImm1() const { return IsUImm<1>(); }
@@ -729,202 +724,202 @@ public:
     if (!isImm())
       return false;
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && isUInt<5>(Imm) && (Imm != 0) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isUImm5GT3() const {
     if (!isImm())
       return false;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     int64_t Imm;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && isUInt<5>(Imm) && (Imm > 3) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isUImm5Plus1() const {
     if (!isImm())
       return false;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     int64_t Imm;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && ((isUInt<5>(Imm) && (Imm != 0)) || (Imm == 32)) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isUImm5GE6Plus1() const {
     if (!isImm())
       return false;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     int64_t Imm;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && ((isUInt<5>(Imm) && (Imm >= 6)) || (Imm == 32)) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isUImm8GE32() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     if (!isImm())
       return false;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && isUInt<8>(Imm) && Imm >= 32 &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isRnumArg() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     if (!isImm())
       return false;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && Imm >= INT64_C(0) && Imm <= INT64_C(10) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isRnumArg_0_7() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     if (!isImm())
       return false;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && Imm >= INT64_C(0) && Imm <= INT64_C(7) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isRnumArg_1_10() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     if (!isImm())
       return false;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && Imm >= INT64_C(1) && Imm <= INT64_C(10) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isRnumArg_2_14() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     if (!isImm())
       return false;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && Imm >= INT64_C(2) && Imm <= INT64_C(14) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isSImm5() const {
     if (!isImm())
       return false;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     int64_t Imm;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && isInt<5>(fixImmediateForRV32(Imm, isRV64Imm())) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isSImm6() const {
     if (!isImm())
       return false;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     int64_t Imm;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && isInt<6>(fixImmediateForRV32(Imm, isRV64Imm())) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isSImm6NonZero() const {
     if (!isImm())
       return false;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     int64_t Imm;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && Imm != 0 &&
            isInt<6>(fixImmediateForRV32(Imm, isRV64Imm())) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isCLUIImm() const {
     if (!isImm())
       return false;
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && (Imm != 0) &&
            (isUInt<5>(Imm) || (Imm >= 0xfffe0 && Imm <= 0xfffff)) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isUImm2Lsb0() const {
     if (!isImm())
       return false;
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && isShiftedUInt<1, 1>(Imm) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isUImm5Lsb0() const {
     if (!isImm())
       return false;
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && isShiftedUInt<4, 1>(Imm) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isUImm6Lsb0() const {
     if (!isImm())
       return false;
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && isShiftedUInt<5, 1>(Imm) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isUImm7Lsb00() const {
     if (!isImm())
       return false;
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && isShiftedUInt<5, 2>(Imm) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isUImm7Lsb000() const {
     if (!isImm())
       return false;
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && isShiftedUInt<4, 3>(Imm) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isUImm8Lsb00() const {
     if (!isImm())
       return false;
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && isShiftedUInt<6, 2>(Imm) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isUImm8Lsb000() const {
     if (!isImm())
       return false;
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && isShiftedUInt<5, 3>(Imm) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isSImm9Lsb0() const { return isBareSimmNLsb0<9>(); }
@@ -933,20 +928,20 @@ public:
     if (!isImm())
       return false;
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && isShiftedUInt<6, 3>(Imm) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isUImm10Lsb00NonZero() const {
     if (!isImm())
       return false;
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && isShiftedUInt<8, 2>(Imm) && (Imm != 0) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   // If this a RV32 and the immediate is a uimm32, sign extend it to 32 bits.
@@ -960,15 +955,15 @@ public:
   bool isSImm11() const {
     if (!isImm())
       return false;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     int64_t Imm;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && isInt<11>(fixImmediateForRV32(Imm, isRV64Imm())) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isSImm12() const {
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     int64_t Imm;
     bool IsValid;
     if (!isImm())
@@ -978,12 +973,12 @@ public:
       IsValid = RISCVAsmParser::classifySymbolRef(getImm(), VK);
     else
       IsValid = isInt<12>(fixImmediateForRV32(Imm, isRV64Imm()));
-    return IsValid && ((IsConstantImm && VK == RISCVMCExpr::VK_RISCV_None) ||
-                       VK == RISCVMCExpr::VK_RISCV_LO ||
-                       VK == RISCVMCExpr::VK_RISCV_PCREL_LO ||
-                       VK == RISCVMCExpr::VK_RISCV_TPREL_LO ||
-                       VK == RISCVMCExpr::VK_RISCV_TLSDESC_LOAD_LO ||
-                       VK == RISCVMCExpr::VK_RISCV_TLSDESC_ADD_LO);
+    return IsValid &&
+           ((IsConstantImm && VK == RISCVMCExpr::VK_None) ||
+            VK == RISCVMCExpr::VK_LO || VK == RISCVMCExpr::VK_PCREL_LO ||
+            VK == RISCVMCExpr::VK_TPREL_LO ||
+            VK == RISCVMCExpr::VK_TLSDESC_LOAD_LO ||
+            VK == RISCVMCExpr::VK_TLSDESC_ADD_LO);
   }
 
   bool isSImm12Lsb0() const { return isBareSimmNLsb0<12>(); }
@@ -991,12 +986,12 @@ public:
   bool isSImm12Lsb00000() const {
     if (!isImm())
       return false;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     int64_t Imm;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm &&
            isShiftedInt<7, 5>(fixImmediateForRV32(Imm, isRV64Imm())) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isSImm13Lsb0() const { return isBareSimmNLsb0<13>(); }
@@ -1005,15 +1000,15 @@ public:
     if (!isImm())
       return false;
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && (Imm != 0) &&
            isShiftedInt<6, 4>(fixImmediateForRV32(Imm, isRV64Imm())) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isUImm20LUI() const {
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     int64_t Imm;
     bool IsValid;
     if (!isImm())
@@ -1021,17 +1016,17 @@ public:
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     if (!IsConstantImm) {
       IsValid = RISCVAsmParser::classifySymbolRef(getImm(), VK);
-      return IsValid && (VK == RISCVMCExpr::VK_RISCV_HI ||
-                         VK == RISCVMCExpr::VK_RISCV_TPREL_HI);
+      return IsValid &&
+             (VK == RISCVMCExpr::VK_HI || VK == RISCVMCExpr::VK_TPREL_HI);
     } else {
-      return isUInt<20>(Imm) && (VK == RISCVMCExpr::VK_RISCV_None ||
-                                 VK == RISCVMCExpr::VK_RISCV_HI ||
-                                 VK == RISCVMCExpr::VK_RISCV_TPREL_HI);
+      return isUInt<20>(Imm) &&
+             (VK == RISCVMCExpr::VK_None || VK == RISCVMCExpr::VK_HI ||
+              VK == RISCVMCExpr::VK_TPREL_HI);
     }
   }
 
   bool isUImm20AUIPC() const {
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     int64_t Imm;
     bool IsValid;
     if (!isImm())
@@ -1039,19 +1034,18 @@ public:
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     if (!IsConstantImm) {
       IsValid = RISCVAsmParser::classifySymbolRef(getImm(), VK);
-      return IsValid && (VK == RISCVMCExpr::VK_RISCV_PCREL_HI ||
-                         VK == RISCVMCExpr::VK_RISCV_GOT_HI ||
-                         VK == RISCVMCExpr::VK_RISCV_TLS_GOT_HI ||
-                         VK == RISCVMCExpr::VK_RISCV_TLS_GD_HI ||
-                         VK == RISCVMCExpr::VK_RISCV_TLSDESC_HI);
+      return IsValid &&
+             (VK == RISCVMCExpr::VK_PCREL_HI || VK == RISCVMCExpr::VK_GOT_HI ||
+              VK == RISCVMCExpr::VK_TLS_GOT_HI ||
+              VK == RISCVMCExpr::VK_TLS_GD_HI ||
+              VK == RISCVMCExpr::VK_TLSDESC_HI);
     }
 
-    return isUInt<20>(Imm) && (VK == RISCVMCExpr::VK_RISCV_None ||
-                               VK == RISCVMCExpr::VK_RISCV_PCREL_HI ||
-                               VK == RISCVMCExpr::VK_RISCV_GOT_HI ||
-                               VK == RISCVMCExpr::VK_RISCV_TLS_GOT_HI ||
-                               VK == RISCVMCExpr::VK_RISCV_TLS_GD_HI ||
-                               VK == RISCVMCExpr::VK_RISCV_TLSDESC_HI);
+    return isUInt<20>(Imm) &&
+           (VK == RISCVMCExpr::VK_None || VK == RISCVMCExpr::VK_PCREL_HI ||
+            VK == RISCVMCExpr::VK_GOT_HI || VK == RISCVMCExpr::VK_TLS_GOT_HI ||
+            VK == RISCVMCExpr::VK_TLS_GD_HI ||
+            VK == RISCVMCExpr::VK_TLSDESC_HI);
   }
 
   bool isSImm21Lsb0JAL() const { return isBareSimmNLsb0<21>(); }
@@ -1060,50 +1054,50 @@ public:
     if (!isImm())
       return false;
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
-    return IsConstantImm && (Imm == 0) && VK == RISCVMCExpr::VK_RISCV_None;
+    return IsConstantImm && (Imm == 0) && VK == RISCVMCExpr::VK_None;
   }
 
   bool isSImm5Plus1() const {
     if (!isImm())
       return false;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     int64_t Imm;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm &&
            isInt<5>(fixImmediateForRV32(Imm, isRV64Imm()) - 1) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   bool isSImm20() const {
     if (!isImm())
       return false;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     int64_t Imm;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
-    return IsConstantImm && (VK == RISCVMCExpr::VK_RISCV_None) &&
+    return IsConstantImm && (VK == RISCVMCExpr::VK_None) &&
            isInt<20>(fixImmediateForRV32(Imm, isRV64Imm()));
   }
 
   bool isSImm26() const {
     if (!isImm())
       return false;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     int64_t Imm;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
-    return IsConstantImm && (VK == RISCVMCExpr::VK_RISCV_None) &&
+    return IsConstantImm && (VK == RISCVMCExpr::VK_None) &&
            isInt<26>(fixImmediateForRV32(Imm, isRV64Imm()));
   }
 
   bool isSImm32() const {
     int64_t Imm;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     if (!isImm())
       return false;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm && isInt<32>(fixImmediateForRV32(Imm, isRV64Imm())) &&
-           VK == RISCVMCExpr::VK_RISCV_None;
+           VK == RISCVMCExpr::VK_None;
   }
 
   /// getStartLoc - Gets location of the first token of this operand
@@ -1314,7 +1308,7 @@ public:
   static void addExpr(MCInst &Inst, const MCExpr *Expr, bool IsRV64Imm) {
     assert(Expr && "Expr shouldn't be null!");
     int64_t Imm = 0;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
     bool IsConstant = evaluateConstantImm(Expr, Imm, VK);
 
     if (IsConstant)
@@ -1364,7 +1358,7 @@ public:
     assert(N == 1 && "Invalid number of operands!");
     int64_t Imm = 0;
     if (Kind == KindTy::Immediate) {
-      RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_RISCV_None;
+      RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
       [[maybe_unused]] bool IsConstantImm =
           evaluateConstantImm(getImm(), Imm, VK);
       assert(IsConstantImm && "Invalid VTypeI Operand!");
@@ -2157,7 +2151,7 @@ ParseStatus RISCVAsmParser::parseOperandWithModifier(OperandVector &Operands) {
     return Error(getLoc(), "expected valid identifier for operand modifier");
   StringRef Identifier = getParser().getTok().getIdentifier();
   RISCVMCExpr::VariantKind VK = RISCVMCExpr::getVariantKindForName(Identifier);
-  if (VK == RISCVMCExpr::VK_RISCV_Invalid)
+  if (VK == RISCVMCExpr::VK_Invalid)
     return Error(getLoc(), "unrecognized operand modifier");
 
   getParser().Lex(); // Eat the identifier
@@ -2243,7 +2237,7 @@ ParseStatus RISCVAsmParser::parseCallSymbol(OperandVector &Operands) {
 
   SMLoc E = SMLoc::getFromPointer(S.getPointer() + Identifier.size());
 
-  RISCVMCExpr::VariantKind Kind = RISCVMCExpr::VK_RISCV_CALL_PLT;
+  RISCVMCExpr::VariantKind Kind = RISCVMCExpr::VK_CALL_PLT;
   (void)Identifier.consume_back("@plt");
 
   MCSymbol *Sym = getContext().getOrCreateSymbol(Identifier);
@@ -2266,7 +2260,7 @@ ParseStatus RISCVAsmParser::parsePseudoJumpSymbol(OperandVector &Operands) {
           MCSymbolRefExpr::VariantKind::VK_PLT)
     return Error(S, "operand must be a valid jump target");
 
-  Res = RISCVMCExpr::create(Res, RISCVMCExpr::VK_RISCV_CALL, getContext());
+  Res = RISCVMCExpr::create(Res, RISCVMCExpr::VK_CALL, getContext());
   Operands.push_back(RISCVOperand::createImm(Res, S, E, isRV64()));
   return ParseStatus::Success;
 }
@@ -2916,7 +2910,7 @@ bool RISCVAsmParser::parseInstruction(ParseInstructionInfo &Info,
 
 bool RISCVAsmParser::classifySymbolRef(const MCExpr *Expr,
                                        RISCVMCExpr::VariantKind &Kind) {
-  Kind = RISCVMCExpr::VK_RISCV_None;
+  Kind = RISCVMCExpr::VK_None;
 
   if (const RISCVMCExpr *RE = dyn_cast<RISCVMCExpr>(Expr)) {
     Kind = RE->getKind();
@@ -2925,14 +2919,14 @@ bool RISCVAsmParser::classifySymbolRef(const MCExpr *Expr,
 
   MCValue Res;
   if (Expr->evaluateAsRelocatable(Res, nullptr))
-    return Res.getRefKind() == RISCVMCExpr::VK_RISCV_None;
+    return Res.getRefKind() == RISCVMCExpr::VK_None;
   return false;
 }
 
 bool RISCVAsmParser::isSymbolDiff(const MCExpr *Expr) {
   MCValue Res;
   if (Expr->evaluateAsRelocatable(Res, nullptr)) {
-    return Res.getRefKind() == RISCVMCExpr::VK_RISCV_None && Res.getSymA() &&
+    return Res.getRefKind() == RISCVMCExpr::VK_None && Res.getSymA() &&
            Res.getSymB();
   }
   return false;
@@ -3419,9 +3413,8 @@ void RISCVAsmParser::emitAuipcInstPair(MCOperand DestReg, MCOperand TmpReg,
   emitToStreamer(
       Out, MCInstBuilder(RISCV::AUIPC).addOperand(TmpReg).addExpr(SymbolHi));
 
-  const MCExpr *RefToLinkTmpLabel =
-      RISCVMCExpr::create(MCSymbolRefExpr::create(TmpLabel, Ctx),
-                          RISCVMCExpr::VK_RISCV_PCREL_LO, Ctx);
+  const MCExpr *RefToLinkTmpLabel = RISCVMCExpr::create(
+      MCSymbolRefExpr::create(TmpLabel, Ctx), RISCVMCExpr::VK_PCREL_LO, Ctx);
 
   emitToStreamer(Out, MCInstBuilder(SecondOpcode)
                           .addOperand(DestReg)
@@ -3439,7 +3432,7 @@ void RISCVAsmParser::emitLoadLocalAddress(MCInst &Inst, SMLoc IDLoc,
   //             ADDI rdest, rdest, %pcrel_lo(TmpLabel)
   MCOperand DestReg = Inst.getOperand(0);
   const MCExpr *Symbol = Inst.getOperand(1).getExpr();
-  emitAuipcInstPair(DestReg, DestReg, Symbol, RISCVMCExpr::VK_RISCV_PCREL_HI,
+  emitAuipcInstPair(DestReg, DestReg, Symbol, RISCVMCExpr::VK_PCREL_HI,
                     RISCV::ADDI, IDLoc, Out);
 }
 
@@ -3454,7 +3447,7 @@ void RISCVAsmParser::emitLoadGlobalAddress(MCInst &Inst, SMLoc IDLoc,
   MCOperand DestReg = Inst.getOperand(0);
   const MCExpr *Symbol = Inst.getOperand(1).getExpr();
   unsigned SecondOpcode = isRV64() ? RISCV::LD : RISCV::LW;
-  emitAuipcInstPair(DestReg, DestReg, Symbol, RISCVMCExpr::VK_RISCV_GOT_HI,
+  emitAuipcInstPair(DestReg, DestReg, Symbol, RISCVMCExpr::VK_GOT_HI,
                     SecondOpcode, IDLoc, Out);
 }
 
@@ -3484,7 +3477,7 @@ void RISCVAsmParser::emitLoadTLSIEAddress(MCInst &Inst, SMLoc IDLoc,
   MCOperand DestReg = Inst.getOperand(0);
   const MCExpr *Symbol = Inst.getOperand(1).getExpr();
   unsigned SecondOpcode = isRV64() ? RISCV::LD : RISCV::LW;
-  emitAuipcInstPair(DestReg, DestReg, Symbol, RISCVMCExpr::VK_RISCV_TLS_GOT_HI,
+  emitAuipcInstPair(DestReg, DestReg, Symbol, RISCVMCExpr::VK_TLS_GOT_HI,
                     SecondOpcode, IDLoc, Out);
 }
 
@@ -3498,7 +3491,7 @@ void RISCVAsmParser::emitLoadTLSGDAddress(MCInst &Inst, SMLoc IDLoc,
   //             ADDI rdest, rdest, %pcrel_lo(TmpLabel)
   MCOperand DestReg = Inst.getOperand(0);
   const MCExpr *Symbol = Inst.getOperand(1).getExpr();
-  emitAuipcInstPair(DestReg, DestReg, Symbol, RISCVMCExpr::VK_RISCV_TLS_GD_HI,
+  emitAuipcInstPair(DestReg, DestReg, Symbol, RISCVMCExpr::VK_TLS_GD_HI,
                     RISCV::ADDI, IDLoc, Out);
 }
 
@@ -3517,8 +3510,8 @@ void RISCVAsmParser::emitLoadStoreSymbol(MCInst &Inst, unsigned Opcode,
   unsigned SymbolOpIdx = HasTmpReg ? 2 : 1;
   MCOperand TmpReg = Inst.getOperand(0);
   const MCExpr *Symbol = Inst.getOperand(SymbolOpIdx).getExpr();
-  emitAuipcInstPair(DestReg, TmpReg, Symbol, RISCVMCExpr::VK_RISCV_PCREL_HI,
-                    Opcode, IDLoc, Out);
+  emitAuipcInstPair(DestReg, TmpReg, Symbol, RISCVMCExpr::VK_PCREL_HI, Opcode,
+                    IDLoc, Out);
 }
 
 void RISCVAsmParser::emitPseudoExtend(MCInst &Inst, bool SignExtend,

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFObjectWriter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFObjectWriter.cpp
@@ -57,10 +57,10 @@ unsigned RISCVELFObjectWriter::getRelocType(MCContext &Ctx,
     return Kind - FirstLiteralRelocationKind;
 
   switch (Target.getRefKind()) {
-  case RISCVMCExpr::VK_RISCV_TPREL_HI:
-  case RISCVMCExpr::VK_RISCV_TLS_GOT_HI:
-  case RISCVMCExpr::VK_RISCV_TLS_GD_HI:
-  case RISCVMCExpr::VK_RISCV_TLSDESC_HI:
+  case RISCVMCExpr::VK_TPREL_HI:
+  case RISCVMCExpr::VK_TLS_GOT_HI:
+  case RISCVMCExpr::VK_TLS_GD_HI:
+  case RISCVMCExpr::VK_TLSDESC_HI:
     if (auto *S = Target.getSymA())
       cast<MCSymbolELF>(S->getSymbol()).setType(ELF::STT_TLS);
     break;
@@ -130,7 +130,7 @@ unsigned RISCVELFObjectWriter::getRelocType(MCContext &Ctx,
     return ELF::R_RISCV_NONE;
   case FK_Data_4:
     if (Expr->getKind() == MCExpr::Target &&
-        cast<RISCVMCExpr>(Expr)->getKind() == RISCVMCExpr::VK_RISCV_32_PCREL)
+        cast<RISCVMCExpr>(Expr)->getKind() == RISCVMCExpr::VK_32_PCREL)
       return ELF::R_RISCV_32_PCREL;
     if (Target.getSymA()->getKind() == MCSymbolRefExpr::VK_GOTPCREL)
       return ELF::R_RISCV_GOT32_PCREL;

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
@@ -50,5 +50,5 @@ const MCExpr *RISCVMCAsmInfo::getExprForFDESymbol(const MCSymbol *Sym,
   MCContext &Ctx = Streamer.getContext();
   const MCExpr *ME = MCSymbolRefExpr::create(Sym, Ctx);
   assert(Encoding & dwarf::DW_EH_PE_sdata4 && "Unexpected encoding");
-  return RISCVMCExpr::create(ME, RISCVMCExpr::VK_RISCV_32_PCREL, Ctx);
+  return RISCVMCExpr::create(ME, RISCVMCExpr::VK_32_PCREL, Ctx);
 }

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp
@@ -197,7 +197,7 @@ void RISCVMCCodeEmitter::expandAddTPRel(const MCInst &MI,
          "Expected expression as third input to TP-relative add");
 
   const RISCVMCExpr *Expr = dyn_cast<RISCVMCExpr>(SrcSymbol.getExpr());
-  assert(Expr && Expr->getKind() == RISCVMCExpr::VK_RISCV_TPREL_ADD &&
+  assert(Expr && Expr->getKind() == RISCVMCExpr::VK_TPREL_ADD &&
          "Expected tprel_add relocation on TP-relative symbol");
 
   // Emit the correct tprel_add relocation for the symbol.
@@ -442,85 +442,83 @@ uint64_t RISCVMCCodeEmitter::getImmOpValue(const MCInst &MI, unsigned OpNo,
     const RISCVMCExpr *RVExpr = cast<RISCVMCExpr>(Expr);
 
     switch (RVExpr->getKind()) {
-    case RISCVMCExpr::VK_RISCV_None:
-    case RISCVMCExpr::VK_RISCV_Invalid:
-    case RISCVMCExpr::VK_RISCV_32_PCREL:
+    case RISCVMCExpr::VK_None:
+    case RISCVMCExpr::VK_Invalid:
+    case RISCVMCExpr::VK_32_PCREL:
       llvm_unreachable("Unhandled fixup kind!");
-    case RISCVMCExpr::VK_RISCV_TPREL_ADD:
+    case RISCVMCExpr::VK_TPREL_ADD:
       // tprel_add is only used to indicate that a relocation should be emitted
       // for an add instruction used in TP-relative addressing. It should not be
       // expanded as if representing an actual instruction operand and so to
       // encounter it here is an error.
       llvm_unreachable(
-          "VK_RISCV_TPREL_ADD should not represent an instruction operand");
-    case RISCVMCExpr::VK_RISCV_LO:
+          "VK_TPREL_ADD should not represent an instruction operand");
+    case RISCVMCExpr::VK_LO:
       if (MIFrm == RISCVII::InstFormatI)
         FixupKind = RISCV::fixup_riscv_lo12_i;
       else if (MIFrm == RISCVII::InstFormatS)
         FixupKind = RISCV::fixup_riscv_lo12_s;
       else
-        llvm_unreachable("VK_RISCV_LO used with unexpected instruction format");
+        llvm_unreachable("VK_LO used with unexpected instruction format");
       RelaxCandidate = true;
       break;
-    case RISCVMCExpr::VK_RISCV_HI:
+    case RISCVMCExpr::VK_HI:
       FixupKind = RISCV::fixup_riscv_hi20;
       RelaxCandidate = true;
       break;
-    case RISCVMCExpr::VK_RISCV_PCREL_LO:
+    case RISCVMCExpr::VK_PCREL_LO:
       if (MIFrm == RISCVII::InstFormatI)
         FixupKind = RISCV::fixup_riscv_pcrel_lo12_i;
       else if (MIFrm == RISCVII::InstFormatS)
         FixupKind = RISCV::fixup_riscv_pcrel_lo12_s;
       else
-        llvm_unreachable(
-            "VK_RISCV_PCREL_LO used with unexpected instruction format");
+        llvm_unreachable("VK_PCREL_LO used with unexpected instruction format");
       RelaxCandidate = true;
       break;
-    case RISCVMCExpr::VK_RISCV_PCREL_HI:
+    case RISCVMCExpr::VK_PCREL_HI:
       FixupKind = RISCV::fixup_riscv_pcrel_hi20;
       RelaxCandidate = true;
       break;
-    case RISCVMCExpr::VK_RISCV_GOT_HI:
+    case RISCVMCExpr::VK_GOT_HI:
       FixupKind = RISCV::fixup_riscv_got_hi20;
       break;
-    case RISCVMCExpr::VK_RISCV_TPREL_LO:
+    case RISCVMCExpr::VK_TPREL_LO:
       if (MIFrm == RISCVII::InstFormatI)
         FixupKind = RISCV::fixup_riscv_tprel_lo12_i;
       else if (MIFrm == RISCVII::InstFormatS)
         FixupKind = RISCV::fixup_riscv_tprel_lo12_s;
       else
-        llvm_unreachable(
-            "VK_RISCV_TPREL_LO used with unexpected instruction format");
+        llvm_unreachable("VK_TPREL_LO used with unexpected instruction format");
       RelaxCandidate = true;
       break;
-    case RISCVMCExpr::VK_RISCV_TPREL_HI:
+    case RISCVMCExpr::VK_TPREL_HI:
       FixupKind = RISCV::fixup_riscv_tprel_hi20;
       RelaxCandidate = true;
       break;
-    case RISCVMCExpr::VK_RISCV_TLS_GOT_HI:
+    case RISCVMCExpr::VK_TLS_GOT_HI:
       FixupKind = RISCV::fixup_riscv_tls_got_hi20;
       break;
-    case RISCVMCExpr::VK_RISCV_TLS_GD_HI:
+    case RISCVMCExpr::VK_TLS_GD_HI:
       FixupKind = RISCV::fixup_riscv_tls_gd_hi20;
       break;
-    case RISCVMCExpr::VK_RISCV_CALL:
+    case RISCVMCExpr::VK_CALL:
       FixupKind = RISCV::fixup_riscv_call;
       RelaxCandidate = true;
       break;
-    case RISCVMCExpr::VK_RISCV_CALL_PLT:
+    case RISCVMCExpr::VK_CALL_PLT:
       FixupKind = RISCV::fixup_riscv_call_plt;
       RelaxCandidate = true;
       break;
-    case RISCVMCExpr::VK_RISCV_TLSDESC_HI:
+    case RISCVMCExpr::VK_TLSDESC_HI:
       FixupKind = RISCV::fixup_riscv_tlsdesc_hi20;
       break;
-    case RISCVMCExpr::VK_RISCV_TLSDESC_LOAD_LO:
+    case RISCVMCExpr::VK_TLSDESC_LOAD_LO:
       FixupKind = RISCV::fixup_riscv_tlsdesc_load_lo12;
       break;
-    case RISCVMCExpr::VK_RISCV_TLSDESC_ADD_LO:
+    case RISCVMCExpr::VK_TLSDESC_ADD_LO:
       FixupKind = RISCV::fixup_riscv_tlsdesc_add_lo12;
       break;
-    case RISCVMCExpr::VK_RISCV_TLSDESC_CALL:
+    case RISCVMCExpr::VK_TLSDESC_CALL:
       FixupKind = RISCV::fixup_riscv_tlsdesc_call;
       break;
     }

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCExpr.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCExpr.cpp
@@ -34,8 +34,8 @@ const RISCVMCExpr *RISCVMCExpr::create(const MCExpr *Expr, VariantKind Kind,
 
 void RISCVMCExpr::printImpl(raw_ostream &OS, const MCAsmInfo *MAI) const {
   VariantKind Kind = getKind();
-  bool HasVariant = ((Kind != VK_RISCV_None) && (Kind != VK_RISCV_CALL) &&
-                     (Kind != VK_RISCV_CALL_PLT));
+  bool HasVariant =
+      ((Kind != VK_None) && (Kind != VK_CALL) && (Kind != VK_CALL_PLT));
 
   if (HasVariant)
     OS << '%' << getVariantKindName(getKind()) << '(';
@@ -96,7 +96,7 @@ bool RISCVMCExpr::evaluateAsRelocatableImpl(MCValue &Res,
   Res =
       MCValue::get(Res.getSymA(), Res.getSymB(), Res.getConstant(), getKind());
   // Custom fixup types are not valid with symbol difference expressions.
-  return Res.getSymB() ? getKind() == VK_RISCV_None : true;
+  return Res.getSymB() ? getKind() == VK_None : true;
 }
 
 void RISCVMCExpr::visitUsedExpr(MCStreamer &Streamer) const {
@@ -105,61 +105,61 @@ void RISCVMCExpr::visitUsedExpr(MCStreamer &Streamer) const {
 
 RISCVMCExpr::VariantKind RISCVMCExpr::getVariantKindForName(StringRef name) {
   return StringSwitch<RISCVMCExpr::VariantKind>(name)
-      .Case("lo", VK_RISCV_LO)
-      .Case("hi", VK_RISCV_HI)
-      .Case("pcrel_lo", VK_RISCV_PCREL_LO)
-      .Case("pcrel_hi", VK_RISCV_PCREL_HI)
-      .Case("got_pcrel_hi", VK_RISCV_GOT_HI)
-      .Case("tprel_lo", VK_RISCV_TPREL_LO)
-      .Case("tprel_hi", VK_RISCV_TPREL_HI)
-      .Case("tprel_add", VK_RISCV_TPREL_ADD)
-      .Case("tls_ie_pcrel_hi", VK_RISCV_TLS_GOT_HI)
-      .Case("tls_gd_pcrel_hi", VK_RISCV_TLS_GD_HI)
-      .Case("tlsdesc_hi", VK_RISCV_TLSDESC_HI)
-      .Case("tlsdesc_load_lo", VK_RISCV_TLSDESC_LOAD_LO)
-      .Case("tlsdesc_add_lo", VK_RISCV_TLSDESC_ADD_LO)
-      .Case("tlsdesc_call", VK_RISCV_TLSDESC_CALL)
-      .Default(VK_RISCV_Invalid);
+      .Case("lo", VK_LO)
+      .Case("hi", VK_HI)
+      .Case("pcrel_lo", VK_PCREL_LO)
+      .Case("pcrel_hi", VK_PCREL_HI)
+      .Case("got_pcrel_hi", VK_GOT_HI)
+      .Case("tprel_lo", VK_TPREL_LO)
+      .Case("tprel_hi", VK_TPREL_HI)
+      .Case("tprel_add", VK_TPREL_ADD)
+      .Case("tls_ie_pcrel_hi", VK_TLS_GOT_HI)
+      .Case("tls_gd_pcrel_hi", VK_TLS_GD_HI)
+      .Case("tlsdesc_hi", VK_TLSDESC_HI)
+      .Case("tlsdesc_load_lo", VK_TLSDESC_LOAD_LO)
+      .Case("tlsdesc_add_lo", VK_TLSDESC_ADD_LO)
+      .Case("tlsdesc_call", VK_TLSDESC_CALL)
+      .Default(VK_Invalid);
 }
 
 StringRef RISCVMCExpr::getVariantKindName(VariantKind Kind) {
   switch (Kind) {
-  case VK_RISCV_Invalid:
-  case VK_RISCV_None:
+  case VK_Invalid:
+  case VK_None:
     llvm_unreachable("Invalid ELF symbol kind");
-  case VK_RISCV_LO:
+  case VK_LO:
     return "lo";
-  case VK_RISCV_HI:
+  case VK_HI:
     return "hi";
-  case VK_RISCV_PCREL_LO:
+  case VK_PCREL_LO:
     return "pcrel_lo";
-  case VK_RISCV_PCREL_HI:
+  case VK_PCREL_HI:
     return "pcrel_hi";
-  case VK_RISCV_GOT_HI:
+  case VK_GOT_HI:
     return "got_pcrel_hi";
-  case VK_RISCV_TPREL_LO:
+  case VK_TPREL_LO:
     return "tprel_lo";
-  case VK_RISCV_TPREL_HI:
+  case VK_TPREL_HI:
     return "tprel_hi";
-  case VK_RISCV_TPREL_ADD:
+  case VK_TPREL_ADD:
     return "tprel_add";
-  case VK_RISCV_TLS_GOT_HI:
+  case VK_TLS_GOT_HI:
     return "tls_ie_pcrel_hi";
-  case VK_RISCV_TLSDESC_HI:
+  case VK_TLSDESC_HI:
     return "tlsdesc_hi";
-  case VK_RISCV_TLSDESC_LOAD_LO:
+  case VK_TLSDESC_LOAD_LO:
     return "tlsdesc_load_lo";
-  case VK_RISCV_TLSDESC_ADD_LO:
+  case VK_TLSDESC_ADD_LO:
     return "tlsdesc_add_lo";
-  case VK_RISCV_TLSDESC_CALL:
+  case VK_TLSDESC_CALL:
     return "tlsdesc_call";
-  case VK_RISCV_TLS_GD_HI:
+  case VK_TLS_GD_HI:
     return "tls_gd_pcrel_hi";
-  case VK_RISCV_CALL:
+  case VK_CALL:
     return "call";
-  case VK_RISCV_CALL_PLT:
+  case VK_CALL_PLT:
     return "call_plt";
-  case VK_RISCV_32_PCREL:
+  case VK_32_PCREL:
     return "32_pcrel";
   }
   llvm_unreachable("Invalid ELF symbol kind");
@@ -167,7 +167,7 @@ StringRef RISCVMCExpr::getVariantKindName(VariantKind Kind) {
 
 bool RISCVMCExpr::evaluateAsConstant(int64_t &Res) const {
   MCValue Value;
-  if (Kind != VK_RISCV_LO && Kind != VK_RISCV_HI)
+  if (Kind != VK_LO && Kind != VK_HI)
     return false;
 
   if (!getSubExpr()->evaluateAsRelocatable(Value, nullptr))
@@ -184,9 +184,9 @@ int64_t RISCVMCExpr::evaluateAsInt64(int64_t Value) const {
   switch (Kind) {
   default:
     llvm_unreachable("Invalid kind");
-  case VK_RISCV_LO:
+  case VK_LO:
     return SignExtend64<12>(Value);
-  case VK_RISCV_HI:
+  case VK_HI:
     // Add 1 if bit 11 is 1, to compensate for low 12 bits being negative.
     return ((Value + 0x800) >> 12) & 0xfffff;
   }

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCExpr.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCExpr.h
@@ -23,25 +23,25 @@ class StringRef;
 class RISCVMCExpr : public MCTargetExpr {
 public:
   enum VariantKind {
-    VK_RISCV_None,
-    VK_RISCV_LO,
-    VK_RISCV_HI,
-    VK_RISCV_PCREL_LO,
-    VK_RISCV_PCREL_HI,
-    VK_RISCV_GOT_HI,
-    VK_RISCV_TPREL_LO,
-    VK_RISCV_TPREL_HI,
-    VK_RISCV_TPREL_ADD,
-    VK_RISCV_TLS_GOT_HI,
-    VK_RISCV_TLS_GD_HI,
-    VK_RISCV_CALL,
-    VK_RISCV_CALL_PLT,
-    VK_RISCV_32_PCREL,
-    VK_RISCV_TLSDESC_HI,
-    VK_RISCV_TLSDESC_LOAD_LO,
-    VK_RISCV_TLSDESC_ADD_LO,
-    VK_RISCV_TLSDESC_CALL,
-    VK_RISCV_Invalid // Must be the last item
+    VK_None,
+    VK_LO,
+    VK_HI,
+    VK_PCREL_LO,
+    VK_PCREL_HI,
+    VK_GOT_HI,
+    VK_TPREL_LO,
+    VK_TPREL_HI,
+    VK_TPREL_ADD,
+    VK_TLS_GOT_HI,
+    VK_TLS_GD_HI,
+    VK_CALL,
+    VK_CALL_PLT,
+    VK_32_PCREL,
+    VK_TLSDESC_HI,
+    VK_TLSDESC_LOAD_LO,
+    VK_TLSDESC_ADD_LO,
+    VK_TLSDESC_CALL,
+    VK_Invalid // Must be the last item
   };
 
 private:
@@ -61,10 +61,10 @@ public:
 
   const MCExpr *getSubExpr() const { return Expr; }
 
-  /// Get the corresponding PC-relative HI fixup that a VK_RISCV_PCREL_LO
+  /// Get the corresponding PC-relative HI fixup that a VK_PCREL_LO
   /// points to, and optionally the fragment containing it.
   ///
-  /// \returns nullptr if this isn't a VK_RISCV_PCREL_LO pointing to a
+  /// \returns nullptr if this isn't a VK_PCREL_LO pointing to a
   /// known PC-relative HI fixup.
   const MCFixup *getPCRelHiFixup(const MCFragment **DFOut) const;
 

--- a/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/RISCVAsmPrinter.cpp
@@ -622,7 +622,7 @@ void RISCVAsmPrinter::LowerHWASAN_CHECK_MEMACCESS(const MachineInstr &MI) {
     Sym = OutContext.getOrCreateSymbol(SymName);
   }
   auto Res = MCSymbolRefExpr::create(Sym, OutContext);
-  auto Expr = RISCVMCExpr::create(Res, RISCVMCExpr::VK_RISCV_CALL, OutContext);
+  auto Expr = RISCVMCExpr::create(Res, RISCVMCExpr::VK_CALL, OutContext);
 
   EmitToStreamer(*OutStreamer, MCInstBuilder(RISCV::PseudoCALL).addExpr(Expr));
 }
@@ -733,8 +733,8 @@ void RISCVAsmPrinter::EmitHwasanMemaccessSymbols(Module &M) {
 
   const MCSymbolRefExpr *HwasanTagMismatchV2Ref =
       MCSymbolRefExpr::create(HwasanTagMismatchV2Sym, OutContext);
-  auto Expr = RISCVMCExpr::create(HwasanTagMismatchV2Ref,
-                                  RISCVMCExpr::VK_RISCV_CALL, OutContext);
+  auto Expr = RISCVMCExpr::create(HwasanTagMismatchV2Ref, RISCVMCExpr::VK_CALL,
+                                  OutContext);
 
   for (auto &P : HwasanMemaccessSymbols) {
     unsigned Reg = std::get<0>(P.first);
@@ -946,52 +946,52 @@ static MCOperand lowerSymbolOperand(const MachineOperand &MO, MCSymbol *Sym,
   default:
     llvm_unreachable("Unknown target flag on GV operand");
   case RISCVII::MO_None:
-    Kind = RISCVMCExpr::VK_RISCV_None;
+    Kind = RISCVMCExpr::VK_None;
     break;
   case RISCVII::MO_CALL:
-    Kind = RISCVMCExpr::VK_RISCV_CALL_PLT;
+    Kind = RISCVMCExpr::VK_CALL_PLT;
     break;
   case RISCVII::MO_LO:
-    Kind = RISCVMCExpr::VK_RISCV_LO;
+    Kind = RISCVMCExpr::VK_LO;
     break;
   case RISCVII::MO_HI:
-    Kind = RISCVMCExpr::VK_RISCV_HI;
+    Kind = RISCVMCExpr::VK_HI;
     break;
   case RISCVII::MO_PCREL_LO:
-    Kind = RISCVMCExpr::VK_RISCV_PCREL_LO;
+    Kind = RISCVMCExpr::VK_PCREL_LO;
     break;
   case RISCVII::MO_PCREL_HI:
-    Kind = RISCVMCExpr::VK_RISCV_PCREL_HI;
+    Kind = RISCVMCExpr::VK_PCREL_HI;
     break;
   case RISCVII::MO_GOT_HI:
-    Kind = RISCVMCExpr::VK_RISCV_GOT_HI;
+    Kind = RISCVMCExpr::VK_GOT_HI;
     break;
   case RISCVII::MO_TPREL_LO:
-    Kind = RISCVMCExpr::VK_RISCV_TPREL_LO;
+    Kind = RISCVMCExpr::VK_TPREL_LO;
     break;
   case RISCVII::MO_TPREL_HI:
-    Kind = RISCVMCExpr::VK_RISCV_TPREL_HI;
+    Kind = RISCVMCExpr::VK_TPREL_HI;
     break;
   case RISCVII::MO_TPREL_ADD:
-    Kind = RISCVMCExpr::VK_RISCV_TPREL_ADD;
+    Kind = RISCVMCExpr::VK_TPREL_ADD;
     break;
   case RISCVII::MO_TLS_GOT_HI:
-    Kind = RISCVMCExpr::VK_RISCV_TLS_GOT_HI;
+    Kind = RISCVMCExpr::VK_TLS_GOT_HI;
     break;
   case RISCVII::MO_TLS_GD_HI:
-    Kind = RISCVMCExpr::VK_RISCV_TLS_GD_HI;
+    Kind = RISCVMCExpr::VK_TLS_GD_HI;
     break;
   case RISCVII::MO_TLSDESC_HI:
-    Kind = RISCVMCExpr::VK_RISCV_TLSDESC_HI;
+    Kind = RISCVMCExpr::VK_TLSDESC_HI;
     break;
   case RISCVII::MO_TLSDESC_LOAD_LO:
-    Kind = RISCVMCExpr::VK_RISCV_TLSDESC_LOAD_LO;
+    Kind = RISCVMCExpr::VK_TLSDESC_LOAD_LO;
     break;
   case RISCVII::MO_TLSDESC_ADD_LO:
-    Kind = RISCVMCExpr::VK_RISCV_TLSDESC_ADD_LO;
+    Kind = RISCVMCExpr::VK_TLSDESC_ADD_LO;
     break;
   case RISCVII::MO_TLSDESC_CALL:
-    Kind = RISCVMCExpr::VK_RISCV_TLSDESC_CALL;
+    Kind = RISCVMCExpr::VK_TLSDESC_CALL;
     break;
   }
 
@@ -1001,7 +1001,7 @@ static MCOperand lowerSymbolOperand(const MachineOperand &MO, MCSymbol *Sym,
     ME = MCBinaryExpr::createAdd(
         ME, MCConstantExpr::create(MO.getOffset(), Ctx), Ctx);
 
-  if (Kind != RISCVMCExpr::VK_RISCV_None)
+  if (Kind != RISCVMCExpr::VK_None)
     ME = RISCVMCExpr::create(ME, Kind, Ctx);
   return MCOperand::createExpr(ME);
 }


### PR DESCRIPTION
They implement relocation operators and are named VK_RISCV_ probably to
avoid confusion with `MCSymbolRefExpr::VariantKind`.
`MCSymbolRefExpr::VariantKind` is discouraged
(https://discourse.llvm.org/t/error-expected-relocatable-expression-with-mctargetexpr/84926/2)
and targets are migrating away from `MCSymbolRefExpr::VariantKind`.

Therefore, there is no need to make the name long in the presence of the
clear `RISCVMCExpr::` prefix.
