### PR TITLE
[compiler-rt] allow building with uefi

### DIFF
--- a/compiler-rt/lib/builtins/int_lib.h
+++ b/compiler-rt/lib/builtins/int_lib.h
@@ -49,7 +49,7 @@
 #define SYMBOL_NAME(name) XSTR(__USER_LABEL_PREFIX__) #name
 
 #if defined(__ELF__) || defined(__MINGW32__) || defined(__wasm__) ||           \
-    defined(_AIX)    || defined(__CYGWIN__)
+    defined(_AIX) || defined(__CYGWIN__)
 #define COMPILER_RT_ALIAS(name, aliasname) \
   COMPILER_RT_ABI __typeof(name) aliasname __attribute__((__alias__(#name)));
 #elif defined(__APPLE__)
@@ -64,7 +64,7 @@
   COMPILER_RT_ALIAS_VISIBILITY(aliasname) \
   __asm__(SYMBOL_NAME(aliasname) " = " SYMBOL_NAME(name)); \
   COMPILER_RT_ABI __typeof(name) aliasname;
-#elif defined(_WIN32)
+#elif defined(_WIN32) || defined(__UEFI__)
 #define COMPILER_RT_ALIAS(name, aliasname)
 #else
 #error Unsupported target


### PR DESCRIPTION
I'm trying to put together an LLVM built toolchain (including LLVM libc) targeting UEFI, currently I get an error saying "Unknown target". This PR enables compiling compiler-rt for UEFI.