### PR TITLE
[alpha.webkit.UncountedCallArgsChecker] os_log functions should be treated as safe.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -425,7 +425,7 @@ bool isPtrConversion(const FunctionDecl *F) {
 }
 
 bool isTrivialBuiltinFunction(const FunctionDecl *F) {
-  if (!F)
+  if (!F || !F->getDeclName().isIdentifier())
     return false;
   auto Name = F->getName();
   return Name.starts_with("__builtin") || Name == "__libcpp_verbose_abort" ||

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -424,6 +424,14 @@ bool isPtrConversion(const FunctionDecl *F) {
   return false;
 }
 
+bool isTrivialBuiltinFunction(const FunctionDecl *F) {
+  if (!F)
+    return false;
+  auto Name = F->getName();
+  return Name.starts_with("__builtin") || Name == "__libcpp_verbose_abort" ||
+         Name.starts_with("os_log") || Name.starts_with("_os_log");
+}
+
 bool isSingleton(const FunctionDecl *F) {
   assert(F);
   // FIXME: check # of params == 1
@@ -601,8 +609,7 @@ public:
         Name == "isMainThreadOrGCThread" || Name == "isMainRunLoop" ||
         Name == "isWebThread" || Name == "isUIThread" ||
         Name == "mayBeGCThread" || Name == "compilerFenceForCrash" ||
-        Name == "bitwise_cast" || Name.find("__builtin") == 0 ||
-        Name == "__libcpp_verbose_abort")
+        Name == "bitwise_cast" || isTrivialBuiltinFunction(Callee))
       return true;
 
     return IsFunctionTrivial(Callee);

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.h
@@ -142,6 +142,9 @@ std::optional<bool> isGetterOfSafePtr(const clang::CXXMethodDecl *Method);
 /// pointer types.
 bool isPtrConversion(const FunctionDecl *F);
 
+/// \returns true if \p F is a builtin function which is considered trivial.
+bool isTrivialBuiltinFunction(const FunctionDecl *F);
+
 /// \returns true if \p F is a static singleton function.
 bool isSingleton(const FunctionDecl *F);
 

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
@@ -246,6 +246,9 @@ public:
     if (Callee && TFA.isTrivial(Callee) && !Callee->isVirtualAsWritten())
       return true;
 
+    if (isTrivialBuiltinFunction(Callee))
+      return true;
+
     if (CE->getNumArgs() == 0)
       return false;
 

--- a/clang/test/Analysis/Checkers/WebKit/mock-system-header.h
+++ b/clang/test/Analysis/Checkers/WebKit/mock-system-header.h
@@ -28,4 +28,4 @@ enum os_log_type_t : uint8_t {
 
 typedef struct os_log_s *os_log_t;
 os_log_t os_log_create(const char *subsystem, const char *category);
-void os_log_msg(os_log_t oslog, os_log_type_t type, const char *msg);
+void os_log_msg(os_log_t oslog, os_log_type_t type, const char *msg, ...);

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.cpp
@@ -695,9 +695,13 @@ RefPtr<RefCounted> object();
 void someFunction(const RefCounted&);
 
 void test2() {
-    someFunction(*object());
+  someFunction(*object());
 }
 
 void system_header() {
   callMethod<RefCountable>(object);
+}
+
+void log(RefCountable* obj) {
+  os_log_msg(os_log_create("WebKit", "DOM"), OS_LOG_TYPE_INFO, "obj: %p next: %p", obj, obj->next());
 }

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.mm
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-obj-arg.mm
@@ -50,3 +50,7 @@ public:
 static void foo(WrapperObj *configuration) {
   configuration._protectedWebExtensionControllerConfiguration->copy();
 }
+
+void log(RefCountable* obj) {
+  os_log_msg(os_log_create("WebKit", "DOM"), OS_LOG_TYPE_INFO, "obj: %p next: %p", obj, obj->next());
+}


### PR DESCRIPTION
…os_log functions should be treated as safe in call arguments checkers.

Also treat __builtin_* functions and __libcpp_verbose_abort functions as "trivial" for the purpose in call argument checkers.