### PR TITLE
[Clang] Implement Wpointer-bool-conversion-strict

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -136,6 +136,8 @@ New Compiler Flags
   The feature has `existed <https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#running-the-instrumented-program>`_)
   for a while and this is just a user facing option.
 
+- New Option ``-Wpointer-bool-conversion-strict`` has been added to warn about all implicit pointer-to-bool conversions (#GH9500). This option is ignored by default.
+
 Deprecated Compiler Flags
 -------------------------
 

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -74,6 +74,7 @@ def LiteralConversion : DiagGroup<"literal-conversion">;
 def StringConversion : DiagGroup<"string-conversion">;
 def SignConversion : DiagGroup<"sign-conversion">;
 def PointerBoolConversion : DiagGroup<"pointer-bool-conversion">;
+def PointerBoolConversionStrict : DiagGroup<"pointer-bool-conversion-strict">;
 def UndefinedBoolConversion : DiagGroup<"undefined-bool-conversion">;
 def BitwiseInsteadOfLogical : DiagGroup<"bitwise-instead-of-logical">;
 def BoolOperation : DiagGroup<"bool-operation", [BitwiseInsteadOfLogical]>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -4337,6 +4337,10 @@ def warn_impcast_pointer_to_bool : Warning<
     "address of %select{'%1'|function '%1'|array '%1'|lambda function pointer "
     "conversion operator}0 will always evaluate to 'true'">,
     InGroup<PointerBoolConversion>;
+def warn_impcast_pointer_to_bool_strict: Warning<
+    "implicit conversion of pointer to bool">,
+    InGroup<PointerBoolConversionStrict>,
+    DefaultIgnore;
 def warn_cast_nonnull_to_bool : Warning<
     "nonnull %select{function call|parameter}0 '%1' will evaluate to "
     "'true' on first encounter">,

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -11699,6 +11699,9 @@ void Sema::CheckImplicitConversion(Expr *E, QualType T, SourceLocation CC,
       DiagnoseAlwaysNonNullPointer(E, Expr::NPCK_NotNull, /*IsEqual*/ false,
                                    SourceRange(CC));
     }
+    if (Source->isPointerType()) {
+      Diag(E->getExprLoc(), diag::warn_impcast_pointer_to_bool_strict);
+    }
   }
 
   // If the we're converting a constant to an ObjC BOOL on a platform where BOOL

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -11695,12 +11695,10 @@ void Sema::CheckImplicitConversion(Expr *E, QualType T, SourceLocation CC,
                              diag::warn_impcast_objective_c_literal_to_bool);
     }
     if (Source->isPointerType() || Source->canDecayToPointerType()) {
+      Diag(E->getExprLoc(), diag::warn_impcast_pointer_to_bool_strict);
       // Warn on pointer to bool conversion that is always true.
       DiagnoseAlwaysNonNullPointer(E, Expr::NPCK_NotNull, /*IsEqual*/ false,
                                    SourceRange(CC));
-    }
-    if (Source->isPointerType()) {
-      Diag(E->getExprLoc(), diag::warn_impcast_pointer_to_bool_strict);
     }
   }
 

--- a/clang/test/Sema/warn-pointer-bool-conversion-strict.c
+++ b/clang/test/Sema/warn-pointer-bool-conversion-strict.c
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -fsyntax-only -Wpointer-bool-conversion %s
+#include <stddef.h>
+_Bool f() {
+  int *p;
+  if (p) {} // expected-warning {{implicit conversion of pointer to bool}}
+  return (void *)0; // expected-warning {{implicit conversion of pointer to bool}}
+}
+
+_Bool g() {
+  int *p = (void *)0;
+  if (p == NULL) {} // no-warning
+  return (void *)0 == NULL; // no-warning
+}

--- a/clang/test/Sema/warn-pointer-bool-conversion-strict.cpp
+++ b/clang/test/Sema/warn-pointer-bool-conversion-strict.cpp
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -fsyntax-only -Wpointer-bool-conversion %s
+bool f() {
+    int *p;
+    if (p) {} // expected-warning {{implicit conversion of pointer to bool}}
+    return (void *)0; // expected-warning {{implicit conversion of pointer to bool}}
+}
+
+bool g() {
+    int *p = nullptr;
+    if (p == nullptr) {} // no-warning
+    return (void *)0 == nullptr; // no-warning
+}


### PR DESCRIPTION
This PR implements the feature request from issue #9500. From the original issue:

```c
_Bool foo(void) {
  _Bool x = (void *)0; // warn on this
  return (void *)0; // warn on this
}
```

However, I believe that using null checks like if ``(!p) return;`` is a common practice in C/C++ code. Because of this, I made the option ignored by default.

Additionally, the issue creator appears to be requesting more than just pointer-to-bool conversion checks. Please let me know your thoughts on this.