### PR TITLE
[libc][sched] Implement `CPU_ZERO`, `CPU_ISSET`, `CPU_SET` macros

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -912,6 +912,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.sched.__sched_getcpucount
     libc.src.sched.__sched_setcpuzero
     libc.src.sched.__sched_setcpuset
+    libc.src.sched.__sched_getcpuisset
 
     # strings.h entrypoints
     libc.src.strings.strcasecmp_l

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -910,6 +910,7 @@ if(LLVM_LIBC_FULL_BUILD)
 
     # sched.h entrypoints
     libc.src.sched.__sched_getcpucount
+    libc.src.sched.__sched_setcpuzero
 
     # strings.h entrypoints
     libc.src.strings.strcasecmp_l

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -911,6 +911,7 @@ if(LLVM_LIBC_FULL_BUILD)
     # sched.h entrypoints
     libc.src.sched.__sched_getcpucount
     libc.src.sched.__sched_setcpuzero
+    libc.src.sched.__sched_setcpuset
 
     # strings.h entrypoints
     libc.src.strings.strcasecmp_l

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -858,6 +858,7 @@ if(LLVM_LIBC_FULL_BUILD)
 
     # sched.h entrypoints
     libc.src.sched.__sched_getcpucount
+    libc.src.sched.__sched_setcpuzero
 
     # setjmp.h entrypoints
     libc.src.setjmp.longjmp

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -860,6 +860,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.sched.__sched_getcpucount
     libc.src.sched.__sched_setcpuzero
     libc.src.sched.__sched_setcpuset
+    libc.src.sched.__sched_getcpuisset
 
     # setjmp.h entrypoints
     libc.src.setjmp.longjmp

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -859,6 +859,7 @@ if(LLVM_LIBC_FULL_BUILD)
     # sched.h entrypoints
     libc.src.sched.__sched_getcpucount
     libc.src.sched.__sched_setcpuzero
+    libc.src.sched.__sched_setcpuset
 
     # setjmp.h entrypoints
     libc.src.setjmp.longjmp

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1029,6 +1029,7 @@ if(LLVM_LIBC_FULL_BUILD)
     # sched.h entrypoints
     libc.src.sched.__sched_getcpucount
     libc.src.sched.__sched_setcpuzero
+    libc.src.sched.__sched_setcpuset
 
     # setjmp.h entrypoints
     libc.src.setjmp.longjmp

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1030,6 +1030,7 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.sched.__sched_getcpucount
     libc.src.sched.__sched_setcpuzero
     libc.src.sched.__sched_setcpuset
+    libc.src.sched.__sched_getcpuisset
 
     # setjmp.h entrypoints
     libc.src.setjmp.longjmp

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -1028,6 +1028,7 @@ if(LLVM_LIBC_FULL_BUILD)
 
     # sched.h entrypoints
     libc.src.sched.__sched_getcpucount
+    libc.src.sched.__sched_setcpuzero
 
     # setjmp.h entrypoints
     libc.src.setjmp.longjmp

--- a/libc/hdr/CMakeLists.txt
+++ b/libc/hdr/CMakeLists.txt
@@ -73,6 +73,15 @@ add_proxy_header_library(
 )
 
 add_proxy_header_library(
+  sched_macros
+  HDRS
+    sched_macros.h
+  FULL_BUILD_DEPENDS
+    libc.include.sched
+    libc.include.llvm-libc-macros.sched_macros
+)
+
+add_proxy_header_library(
   signal_macros
   HDRS
     signal_macros.h

--- a/libc/hdr/sched_macros.h
+++ b/libc/hdr/sched_macros.h
@@ -1,0 +1,22 @@
+//===-- Definition of macros from sched.h ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_SCHED_MACROS_H
+#define LLVM_LIBC_HDR_SCHED_MACROS_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-macros/sched-macros.h"
+
+#else // Overlay mode
+
+#include <sched.h>
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_SCHED_MACROS_H

--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -349,3 +349,11 @@ add_proxy_header_library(
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-types.struct_pollfd
 )
+
+add_proxy_header_library(
+  cpu_set_t
+  HDRS
+    cpu_set_t.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.cpu_set_t
+)

--- a/libc/hdr/types/cpu_set_t.h
+++ b/libc/hdr/types/cpu_set_t.h
@@ -1,0 +1,22 @@
+//===-- Proxy for cpu_set_t -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_CPU_SET_T_H
+#define LLVM_LIBC_HDR_TYPES_CPU_SET_T_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/cpu_set_t.h"
+
+#else // Overlay mode
+
+#include <sched.h>
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_CPU_SET_T_H

--- a/libc/include/llvm-libc-macros/linux/sched-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sched-macros.h
@@ -25,5 +25,7 @@
 
 #define CPU_COUNT_S(setsize, set) __sched_getcpucount(setsize, set)
 #define CPU_COUNT(set) CPU_COUNT_S(sizeof(cpu_set_t), set)
+#define CPU_ZERO_S(setsize, set) __sched_setcpuzero(setsize, set)
+#define CPU_ZERO(set) CPU_ZERO_S(sizeof(cpu_set_t), set)
 
 #endif // LLVM_LIBC_MACROS_LINUX_SCHED_MACROS_H

--- a/libc/include/llvm-libc-macros/linux/sched-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sched-macros.h
@@ -29,5 +29,7 @@
 #define CPU_COUNT(set) CPU_COUNT_S(sizeof(cpu_set_t), set)
 #define CPU_ZERO_S(setsize, set) __sched_setcpuzero(setsize, set)
 #define CPU_ZERO(set) CPU_ZERO_S(sizeof(cpu_set_t), set)
+#define CPU_SET_S(setsize, set) __sched_setcpuset(setsize, set)
+#define CPU_SET(setsize, set) CPU_SET_S(sizeof(cpt_set_t), set)
 
 #endif // LLVM_LIBC_MACROS_LINUX_SCHED_MACROS_H

--- a/libc/include/llvm-libc-macros/linux/sched-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sched-macros.h
@@ -29,7 +29,9 @@
 #define CPU_COUNT(set) CPU_COUNT_S(sizeof(cpu_set_t), set)
 #define CPU_ZERO_S(setsize, set) __sched_setcpuzero(setsize, set)
 #define CPU_ZERO(set) CPU_ZERO_S(sizeof(cpu_set_t), set)
-#define CPU_SET_S(setsize, set) __sched_setcpuset(setsize, set)
-#define CPU_SET(setsize, set) CPU_SET_S(sizeof(cpt_set_t), set)
+#define CPU_SET_S(cpu, setsize, set) __sched_setcpuset(cpu, setsize, set)
+#define CPU_SET(cpu, setsize, set) CPU_SET_S(cpu, sizeof(cpt_set_t), set)
+#define CPU_ISSET_S(cpu, setsize, set) __sched_getcpuisset(cpu, setsize, set)
+#define CPU_ISSET(cpu, setsize, set) CPU_ISSET_S(cpu, sizeof(cpt_set_t), set)
 
 #endif // LLVM_LIBC_MACROS_LINUX_SCHED_MACROS_H

--- a/libc/include/llvm-libc-macros/linux/sched-macros.h
+++ b/libc/include/llvm-libc-macros/linux/sched-macros.h
@@ -23,6 +23,8 @@
 #define SCHED_IDLE 5
 #define SCHED_DEADLINE 6
 
+#define CPU_SETSIZE __CPU_SETSIZE
+#define NCPUBITS __NCPUBITS
 #define CPU_COUNT_S(setsize, set) __sched_getcpucount(setsize, set)
 #define CPU_COUNT(set) CPU_COUNT_S(sizeof(cpu_set_t), set)
 #define CPU_ZERO_S(setsize, set) __sched_setcpuzero(setsize, set)

--- a/libc/include/llvm-libc-types/cpu_set_t.h
+++ b/libc/include/llvm-libc-types/cpu_set_t.h
@@ -10,7 +10,7 @@
 #define LLVM_LIBC_TYPES_CPU_SET_T_H
 
 #define __CPU_SETSIZE 1024
-#define __NCPUBITS 8 * sizeof(unsigned long)
+#define __NCPUBITS (8 * sizeof(unsigned long))
 
 typedef struct {
   // If a processor with more than 1024 CPUs is to be supported in future,

--- a/libc/include/llvm-libc-types/cpu_set_t.h
+++ b/libc/include/llvm-libc-types/cpu_set_t.h
@@ -10,7 +10,7 @@
 #define LLVM_LIBC_TYPES_CPU_SET_T_H
 
 #define __CPU_SETSIZE 1024
-#define __NCPUBITS8 8 * sizeof(unsigned long)
+#define __NCPUBITS 8 * sizeof(unsigned long)
 
 typedef struct {
   // If a processor with more than 1024 CPUs is to be supported in future,

--- a/libc/include/llvm-libc-types/cpu_set_t.h
+++ b/libc/include/llvm-libc-types/cpu_set_t.h
@@ -9,6 +9,9 @@
 #ifndef LLVM_LIBC_TYPES_CPU_SET_T_H
 #define LLVM_LIBC_TYPES_CPU_SET_T_H
 
+#define __CPU_SETSIZE 1024
+#define __NCPUBITS8 8 * sizeof(unsigned long)
+
 typedef struct {
   // If a processor with more than 1024 CPUs is to be supported in future,
   // we need to adjust the size of this array.

--- a/libc/src/sched/CMakeLists.txt
+++ b/libc/src/sched/CMakeLists.txt
@@ -85,3 +85,10 @@ add_entrypoint_object(
   DEPENDS
     .${LIBC_TARGET_OS}.__sched_setcpuzero
 )
+
+add_entrypoint_object(
+  __sched_setcpuset
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.__sched_setcpuset
+)

--- a/libc/src/sched/CMakeLists.txt
+++ b/libc/src/sched/CMakeLists.txt
@@ -78,3 +78,10 @@ add_entrypoint_object(
   DEPENDS
     .${LIBC_TARGET_OS}.__sched_getcpucount
 )
+
+add_entrypoint_object(
+  __sched_setcpuzero
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.__sched_setcpuzero
+)

--- a/libc/src/sched/CMakeLists.txt
+++ b/libc/src/sched/CMakeLists.txt
@@ -92,3 +92,10 @@ add_entrypoint_object(
   DEPENDS
     .${LIBC_TARGET_OS}.__sched_setcpuset
 )
+
+add_entrypoint_object(
+  __sched_getcpuisset
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.__sched_getcpuisset
+)

--- a/libc/src/sched/linux/CMakeLists.txt
+++ b/libc/src/sched/linux/CMakeLists.txt
@@ -143,6 +143,9 @@ add_entrypoint_object(
   HDRS
     ../sched_setcpuzero.h
   DEPENDS
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.src.__support.macros.null_check
     libc.hdr.types.cpu_set_t
     libc.hdr.types.size_t
 )
@@ -154,6 +157,9 @@ add_entrypoint_object(
   HDRS
     ../sched_setcpuset.h
   DEPENDS
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.src.__support.macros.null_check
     libc.hdr.sched_macros
     libc.hdr.types.cpu_set_t
     libc.hdr.types.size_t
@@ -166,6 +172,9 @@ add_entrypoint_object(
   HDRS
     ../sched_getcpuisset.h
   DEPENDS
+    libc.src.__support.common
+    libc.src.__support.macros.config
+    libc.src.__support.macros.null_check
     libc.hdr.sched_macros
     libc.hdr.types.cpu_set_t
     libc.hdr.types.size_t

--- a/libc/src/sched/linux/CMakeLists.txt
+++ b/libc/src/sched/linux/CMakeLists.txt
@@ -146,3 +146,14 @@ add_entrypoint_object(
     libc.hdr.types.cpu_set_t
     libc.hdr.types.size_t
 )
+
+add_entrypoint_object(
+  __sched_setcpuset
+  SRCS
+    sched_setcpuset.cpp
+  HDRS
+    ../sched_setcpuset.h
+  DEPENDS
+    libc.hdr.types.cpu_set_t
+    libc.hdr.types.size_t
+)

--- a/libc/src/sched/linux/CMakeLists.txt
+++ b/libc/src/sched/linux/CMakeLists.txt
@@ -30,7 +30,7 @@ add_entrypoint_object(
     ../sched_getcpucount.h
   DEPENDS
     libc.include.sched
-  )
+)
 
 add_entrypoint_object(
   sched_yield
@@ -134,4 +134,15 @@ add_entrypoint_object(
     libc.include.sched
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
+)
+
+add_entrypoint_object(
+  __sched_setcpuzero
+  SRCS
+    sched_setcpuzero.cpp
+  HDRS
+    ../sched_setcpuzero.h
+  DEPENDS
+    libc.hdr.types.cpu_set_t
+    libc.hdr.types.size_t
 )

--- a/libc/src/sched/linux/CMakeLists.txt
+++ b/libc/src/sched/linux/CMakeLists.txt
@@ -154,6 +154,19 @@ add_entrypoint_object(
   HDRS
     ../sched_setcpuset.h
   DEPENDS
+    libc.hdr.sched_macros
+    libc.hdr.types.cpu_set_t
+    libc.hdr.types.size_t
+)
+
+add_entrypoint_object(
+  __sched_getcpuisset
+  SRCS
+    sched_getcpuisset.cpp
+  HDRS
+    ../sched_getcpuisset.h
+  DEPENDS
+    libc.hdr.sched_macros
     libc.hdr.types.cpu_set_t
     libc.hdr.types.size_t
 )

--- a/libc/src/sched/linux/sched_getcpuisset.cpp
+++ b/libc/src/sched/linux/sched_getcpuisset.cpp
@@ -8,8 +8,9 @@
 
 #include "src/sched/sched_getcpuisset.h"
 
-#include "src/__support/common.h"        // LLVM_LIBC_FUNCTION
-#include "src/__support/macros/config.h" // LIBC_NAMESPACE_DECL
+#include "src/__support/common.h"            // LLVM_LIBC_FUNCTION
+#include "src/__support/macros/config.h"     // LIBC_NAMESPACE_DECL
+#include "src/__support/macros/null_check.h" // LIBC_CRASH_ON_NULLPTR
 
 #include "hdr/sched_macros.h" // NCPUBITS
 #include "hdr/types/cpu_set_t.h"
@@ -19,6 +20,8 @@ namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, __sched_getcpuisset,
                    (int cpu, const size_t cpuset_size, cpu_set_t *set)) {
+  LIBC_CRASH_ON_NULLPTR(set);
+
   if (static_cast<size_t>(cpu) / 8 < cpuset_size) {
     const size_t element_index = static_cast<size_t>(cpu) / NCPUBITS;
     const size_t bit_position = static_cast<size_t>(cpu) % NCPUBITS;

--- a/libc/src/sched/linux/sched_getcpuisset.cpp
+++ b/libc/src/sched/linux/sched_getcpuisset.cpp
@@ -1,4 +1,4 @@
-//===-- Implementation of sched_setcpuset ---------------------------------===//
+//===-- Implementation of sched_getcpuisset -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/sched/sched_setcpuset.h"
+#include "src/sched/sched_getcpuisset.h"
 
 #include "src/__support/common.h"        // LLVM_LIBC_FUNCTION
 #include "src/__support/macros/config.h" // LIBC_NAMESPACE_DECL
@@ -17,15 +17,17 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(void, __sched_setcpuset,
+LLVM_LIBC_FUNCTION(int, __sched_getcpuisset,
                    (int cpu, const size_t cpuset_size, cpu_set_t *set)) {
   if (static_cast<size_t>(cpu) / 8 < cpuset_size) {
     const size_t element_index = static_cast<size_t>(cpu) / NCPUBITS;
     const size_t bit_position = static_cast<size_t>(cpu) % NCPUBITS;
 
     const unsigned long mask = 1UL << bit_position;
-    set->__mask[element_index] |= mask;
+    return set->__mask[element_index] & mask;
   }
+
+  return 0;
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/sched/linux/sched_getcpuisset.cpp
+++ b/libc/src/sched/linux/sched_getcpuisset.cpp
@@ -24,7 +24,7 @@ LLVM_LIBC_FUNCTION(int, __sched_getcpuisset,
     const size_t bit_position = static_cast<size_t>(cpu) % NCPUBITS;
 
     const unsigned long mask = 1UL << bit_position;
-    return set->__mask[element_index] & mask;
+    return (set->__mask[element_index] & mask) != 0;
   }
 
   return 0;

--- a/libc/src/sched/linux/sched_setcpuset.cpp
+++ b/libc/src/sched/linux/sched_setcpuset.cpp
@@ -16,7 +16,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-LLVM_LIBC_FUNCTION(int, __sched_setcpuset,
+LLVM_LIBC_FUNCTION(void, __sched_setcpuset,
                    (int cpu, const size_t cpuset_size, cpu_set_t *set)) {
   if (cpu / 8 < cpuset_size) {
     const size_t element_index = cpu / NCPUBITS;

--- a/libc/src/sched/linux/sched_setcpuset.cpp
+++ b/libc/src/sched/linux/sched_setcpuset.cpp
@@ -1,0 +1,30 @@
+//===-- Implementation of sched_setcpuset ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/sched/sched_setcpuset.h"
+
+#include "src/__support/common.h"        // LLVM_LIBC_FUNCTION
+#include "src/__support/macros/config.h" // LIBC_NAMESPACE_DECL
+
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/size_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, __sched_setcpuset,
+                   (int cpu, const size_t cpuset_size, cpu_set_t *set)) {
+  if (cpu / 8 < cpuset_size) {
+    const size_t element_index = cpu / NCPUBITS;
+    const size_t bit_position = cpu % NCPUBITS;
+
+    const unsigned long mask = 1UL << bit_position;
+    set->__bits[element_index] |= mask;
+  }
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/sched/linux/sched_setcpuset.cpp
+++ b/libc/src/sched/linux/sched_setcpuset.cpp
@@ -8,8 +8,9 @@
 
 #include "src/sched/sched_setcpuset.h"
 
-#include "src/__support/common.h"        // LLVM_LIBC_FUNCTION
-#include "src/__support/macros/config.h" // LIBC_NAMESPACE_DECL
+#include "src/__support/common.h"            // LLVM_LIBC_FUNCTION
+#include "src/__support/macros/config.h"     // LIBC_NAMESPACE_DECL
+#include "src/__support/macros/null_check.h" // LIBC_CRASH_ON_NULLPTR
 
 #include "hdr/sched_macros.h" // NCPUBITS
 #include "hdr/types/cpu_set_t.h"
@@ -19,6 +20,7 @@ namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(void, __sched_setcpuset,
                    (int cpu, const size_t cpuset_size, cpu_set_t *set)) {
+  LIBC_CRASH_ON_NULLPTR(set);
   if (static_cast<size_t>(cpu) / 8 < cpuset_size) {
     const size_t element_index = static_cast<size_t>(cpu) / NCPUBITS;
     const size_t bit_position = static_cast<size_t>(cpu) % NCPUBITS;

--- a/libc/src/sched/linux/sched_setcpuset.cpp
+++ b/libc/src/sched/linux/sched_setcpuset.cpp
@@ -11,6 +11,7 @@
 #include "src/__support/common.h"        // LLVM_LIBC_FUNCTION
 #include "src/__support/macros/config.h" // LIBC_NAMESPACE_DECL
 
+#include "hdr/sched_macros.h" // NCPUBITS
 #include "hdr/types/cpu_set_t.h"
 #include "hdr/types/size_t.h"
 
@@ -18,9 +19,9 @@ namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(void, __sched_setcpuset,
                    (int cpu, const size_t cpuset_size, cpu_set_t *set)) {
-  if (cpu / 8 < cpuset_size) {
-    const size_t element_index = cpu / NCPUBITS;
-    const size_t bit_position = cpu % NCPUBITS;
+  if (static_cast<size_t>(cpu) / 8 < cpuset_size) {
+    const size_t element_index = static_cast<size_t>(cpu) / NCPUBITS;
+    const size_t bit_position = static_cast<size_t>(cpu) % NCPUBITS;
 
     const unsigned long mask = 1UL << bit_position;
     set->__bits[element_index] |= mask;

--- a/libc/src/sched/linux/sched_setcpuzero.cpp
+++ b/libc/src/sched/linux/sched_setcpuzero.cpp
@@ -9,7 +9,7 @@
 #include "src/sched/sched_setcpuzero.h"
 
 #include "src/__support/common.h"        // LLVM_LIBC_FUNCTION
-#include "src/__support/macros/config.h" // LLVM_LIBC_FUNCTION
+#include "src/__support/macros/config.h" // LIBC_NAMESPACE_DECL
 
 #include "hdr/types/cpu_set_t.h"
 #include "hdr/types/size_t.h"

--- a/libc/src/sched/linux/sched_setcpuzero.cpp
+++ b/libc/src/sched/linux/sched_setcpuzero.cpp
@@ -8,8 +8,9 @@
 
 #include "src/sched/sched_setcpuzero.h"
 
-#include "src/__support/common.h"        // LLVM_LIBC_FUNCTION
-#include "src/__support/macros/config.h" // LIBC_NAMESPACE_DECL
+#include "src/__support/common.h"            // LLVM_LIBC_FUNCTION
+#include "src/__support/macros/config.h"     // LIBC_NAMESPACE_DECL
+#include "src/__support/macros/null_check.h" // LIBC_CRASH_ON_NULLPTR
 
 #include "hdr/types/cpu_set_t.h"
 #include "hdr/types/size_t.h"
@@ -18,6 +19,7 @@ namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(void, __sched_setcpuzero,
                    (const size_t cpuset_size, cpu_set_t *set)) {
+  LIBC_CRASH_ON_NULLPTR(set);
   __builtin_memset(set, 0, cpuset_size);
 }
 

--- a/libc/src/sched/linux/sched_setcpuzero.cpp
+++ b/libc/src/sched/linux/sched_setcpuzero.cpp
@@ -1,0 +1,24 @@
+//===-- Implementation of sched_setcpuzero --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/sched/sched_setcpuzero.h"
+
+#include "src/__support/common.h"        // LLVM_LIBC_FUNCTION
+#include "src/__support/macros/config.h" // LLVM_LIBC_FUNCTION
+
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/size_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(void, __sched_setcpuzero,
+                   (const size_t cpuset_size, cpu_set_t *set)) {
+  __builtin_memset(set, 0, cpuset_size);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/sched/sched_getcpuisset.h
+++ b/libc/src/sched/sched_getcpuisset.h
@@ -1,0 +1,24 @@
+//===-- Implementation header for sched_getcpuisset -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SCHED_SCHED_GETCPUISSET_H
+#define LLVM_LIBC_SRC_SCHED_SCHED_GETCPUISSET_H
+
+#include "src/__support/macros/config.h" // LIBC_NAMESPACE_DECL
+
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/size_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// for internal use in the CPU_ISSET macro
+int __sched_getcpuisset(int cpu, const size_t cpuset_size, cpu_set_t *set);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SCHED_SCHED_GETCPUISSET_H

--- a/libc/src/sched/sched_setcpuset.h
+++ b/libc/src/sched/sched_setcpuset.h
@@ -1,0 +1,24 @@
+//===-- Implementation header for sched_setcpuset ---------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SCHED_SCHED_SETCPUSET_H
+#define LLVM_LIBC_SRC_SCHED_SCHED_SETCPUSET_H
+
+#include "src/__support/macros/config.h"
+
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/size_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// for internal use in the CPU_SET macro
+void __sched_setcpuset(int cpu, const size_t cpuset_size, cpu_set_t *set);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SCHED_SCHED_SETCPUSET_H

--- a/libc/src/sched/sched_setcpuzero.h
+++ b/libc/src/sched/sched_setcpuzero.h
@@ -1,0 +1,24 @@
+//===-- Implementation header for sched_setcpuzero --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SCHED_SCHED_SETCPUZERO_H
+#define LLVM_LIBC_SRC_SCHED_SCHED_SETCPUZERO_H
+
+#include "src/__support/macros/config.h"
+
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/size_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+// for internal use in the CPU_ZERO macro
+void __sched_setcpuzero(const size_t cpuset_size, cpu_set_t *set);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SCHED_SCHED_SETCPUZERO_H


### PR DESCRIPTION
This PR implements the following macros for `sched.h`:
- `CPU_ZERO`
- `CPU_ISSET`
- `CPU_SET`

Fixes #124642 