### PR TITLE
[DFSan] Change placeholders from `undef` to `poison`

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/DataFlowSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/DataFlowSanitizer.cpp
@@ -3447,9 +3447,9 @@ void DFSanVisitor::visitPHINode(PHINode &PN) {
                                       PN.getIterator());
 
   // Give the shadow phi node valid predecessors to fool SplitEdge into working.
-  Value *UndefShadow = UndefValue::get(ShadowTy);
+  Value *PoisonShadow = PoisonValue::get(ShadowTy);
   for (BasicBlock *BB : PN.blocks())
-    ShadowPN->addIncoming(UndefShadow, BB);
+    ShadowPN->addIncoming(PoisonShadow, BB);
 
   DFSF.setShadow(&PN, ShadowPN);
 
@@ -3457,9 +3457,9 @@ void DFSanVisitor::visitPHINode(PHINode &PN) {
   if (DFSF.DFS.shouldTrackOrigins()) {
     OriginPN = PHINode::Create(DFSF.DFS.OriginTy, PN.getNumIncomingValues(), "",
                                PN.getIterator());
-    Value *UndefOrigin = UndefValue::get(DFSF.DFS.OriginTy);
+    Value *PoisonOrigin = PoisonValue::get(DFSF.DFS.OriginTy);
     for (BasicBlock *BB : PN.blocks())
-      OriginPN->addIncoming(UndefOrigin, BB);
+      OriginPN->addIncoming(PoisonOrigin, BB);
     DFSF.setOrigin(&PN, OriginPN);
   }
 


### PR DESCRIPTION
Use `poison` to create dummy phi nodes instead of `undef`.