### PR TITLE
[WebAssembly] Change placeholder from `undef` to `poison`

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp
@@ -1767,7 +1767,7 @@ void WebAssemblyLowerEmscriptenEHSjLj::handleLongjmpableCallsForWasmSjLj(
     I->eraseFromParent();
 
   // Add entries for new predecessors to phis in unwind destinations. We use
-  // 'undef' as a placeholder value. We should make sure the phis have a valid
+  // 'poison' as a placeholder value. We should make sure the phis have a valid
   // set of predecessors before running SSAUpdater, because SSAUpdater
   // internally can use existing phis to gather predecessor info rather than
   // scanning the actual CFG (See FindPredecessorBlocks in SSAUpdater.cpp for
@@ -1776,7 +1776,7 @@ void WebAssemblyLowerEmscriptenEHSjLj::handleLongjmpableCallsForWasmSjLj(
     for (PHINode &PN : UnwindDest->phis()) {
       for (auto *NewPred : NewPreds) {
         assert(PN.getBasicBlockIndex(NewPred) == -1);
-        PN.addIncoming(UndefValue::get(PN.getType()), NewPred);
+        PN.addIncoming(PoisonValue::get(PN.getType()), NewPred);
       }
     }
   }


### PR DESCRIPTION
Use `poison` instead of `undef` as a placeholder for phi entries of unreachable predecessors.