### PR TITLE
[Clang-repl] Implementation for removeModule for wasm use case

### DIFF
--- a/clang/lib/Interpreter/Wasm.h
+++ b/clang/lib/Interpreter/Wasm.h
@@ -31,6 +31,10 @@ public:
   llvm::Error cleanUp() override;
 
   ~WasmIncrementalExecutor() override;
+
+private:
+  // Tracks loaded modules and their handles
+  std::unordered_map<std::string, void *> LoadedModules;
 };
 
 } // namespace clang


### PR DESCRIPTION
Raising as draft for now. This PR implements the removeModule function that can be put to use while running clang-repl in the browser.

The implementation works as we would like it to. But due to some issues in how the dlopen-dlclose pair works for the wasm case (as compared to the native case) this has some shortcomings. Check the following video to understand why I say so 


https://github.com/user-attachments/assets/a120e767-79c0-4c41-bbb0-f086e6af883b

