### PR TITLE
[Clang] Fix an incorrect assumption on getTemplatedDecl()

### DIFF
--- a/clang/lib/Sema/SemaAccess.cpp
+++ b/clang/lib/Sema/SemaAccess.cpp
@@ -1518,8 +1518,8 @@ void Sema::HandleDelayedAccessCheck(DelayedDiagnostic &DD, Decl *D) {
   } else if (FunctionDecl *FN = dyn_cast<FunctionDecl>(D)) {
     DC = FN;
   } else if (TemplateDecl *TD = dyn_cast<TemplateDecl>(D)) {
-    if (isa<DeclContext>(TD->getTemplatedDecl()))
-      DC = cast<DeclContext>(TD->getTemplatedDecl());
+    if (auto *D = dyn_cast_if_present<DeclContext>(TD->getTemplatedDecl()))
+      DC = D;
   } else if (auto *RD = dyn_cast<RequiresExprBodyDecl>(D)) {
     DC = RD;
   }

--- a/clang/test/SemaCXX/concept-crash-on-diagnostic.cpp
+++ b/clang/test/SemaCXX/concept-crash-on-diagnostic.cpp
@@ -36,3 +36,15 @@ void function() {
 // expected-note@#4 {{candidate template ignored: constraints not satisfied [with IteratorL = Object *, IteratorR = Object *]}}
 // We don't know exactly the substituted type for `lhs == rhs`, thus a placeholder 'expr-type' is emitted.
 // expected-note@#3 {{because 'convertible_to<expr-type, bool>' would be invalid}}
+
+namespace GH131530 {
+
+class foo {
+  struct bar {}; // expected-note {{implicitly declared private}}
+};
+
+template <typename T>
+concept is_foo_concept = __is_same(foo::bar, T);
+// expected-error@-1 {{'bar' is a private member of 'foo'}}
+
+}

--- a/clang/test/SemaCXX/concept-crash-on-diagnostic.cpp
+++ b/clang/test/SemaCXX/concept-crash-on-diagnostic.cpp
@@ -45,6 +45,6 @@ class foo {
 
 template <typename T>
 concept is_foo_concept = __is_same(foo::bar, T);
-// expected-error@-1 {{'bar' is a private member of 'foo'}}
+// expected-error@-1 {{'bar' is a private member of 'GH131530::foo'}}
 
 }


### PR DESCRIPTION
Since a68d20e98, we've been calling HandleDelayedAccessCheck() for concept declarations when the declaration contains invalid member accesses.

However, a concept declaration is TemplateDecl such that doesn't contain any TemplatedDecl.

(No release note because I think it'd be better to get backported to 20)

Fixes https://github.com/llvm/llvm-project/issues/131530