### PR TITLE
[ADT] Add DenseSet::insert_range

### DIFF
--- a/llvm/include/llvm/ADT/DenseSet.h
+++ b/llvm/include/llvm/ADT/DenseSet.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_ADT_DENSESET_H
 #define LLVM_ADT_DENSESET_H
 
+#include "llvm/ADT/ADL.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/Support/MathExtras.h"
@@ -236,6 +237,10 @@ public:
   template <typename InputIt> void insert(InputIt I, InputIt E) {
     for (; I != E; ++I)
       insert(*I);
+  }
+
+  template <typename Range> void insert_range(Range &&R) {
+    insert(adl_begin(R), adl_end(R));
   }
 };
 

--- a/llvm/unittests/ADT/DenseSetTest.cpp
+++ b/llvm/unittests/ADT/DenseSetTest.cpp
@@ -32,6 +32,17 @@ TEST(DenseSetTest, DoubleEntrySetTest) {
   EXPECT_EQ(0u, set.count(2));
 }
 
+TEST(DenseSetTest, InsertRange) {
+  llvm::DenseSet<unsigned> set1;
+  llvm::DenseSet<unsigned> set2;
+  set1.insert(1);
+  set1.insert(2);
+  set1.insert(3);
+  constexpr unsigned Args[] = {3, 1, 2};
+  set2.insert_range(Args);
+  EXPECT_EQ(set1, set2);
+}
+
 struct TestDenseSetInfo {
   static inline unsigned getEmptyKey() { return ~0; }
   static inline unsigned getTombstoneKey() { return ~0U - 1; }

--- a/llvm/unittests/ADT/DenseSetTest.cpp
+++ b/llvm/unittests/ADT/DenseSetTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ADT/DenseSet.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <type_traits>
 
@@ -33,14 +34,10 @@ TEST(DenseSetTest, DoubleEntrySetTest) {
 }
 
 TEST(DenseSetTest, InsertRange) {
-  llvm::DenseSet<unsigned> set1;
-  llvm::DenseSet<unsigned> set2;
-  set1.insert(1);
-  set1.insert(2);
-  set1.insert(3);
+  llvm::DenseSet<unsigned> set;
   constexpr unsigned Args[] = {3, 1, 2};
-  set2.insert_range(Args);
-  EXPECT_EQ(set1, set2);
+  set.insert_range(Args);
+  EXPECT_THAT(set, ::testing::UnorderedElementsAre(1, 2, 3));
 }
 
 struct TestDenseSetInfo {


### PR DESCRIPTION
This pach adds DenseSet::insert_range, named after
std::map::insert_range from C++23.  The intent is to allow a heavy
operation as the argument like:

  Set.insert_range(Map[Key]);

Without insert_range, we would have to do:

  Set.insert(Map[Key].begin(), Map[Key].end());

or:

  auto &M = Map[Key];
  Set.insert(M.begin(), M.end());

Neither is elegant.
