### PR TITLE
[bindings] Add OCaml binding to `LLVMGlobalSetMetadata`

### DIFF
--- a/llvm/bindings/ocaml/llvm/llvm.ml
+++ b/llvm/bindings/ocaml/llvm/llvm.ml
@@ -700,7 +700,8 @@ external global_copy_all_metadata : llvalue -> (llmdkind * llmetadata) array
 external is_global_constant : llvalue -> bool = "llvm_is_global_constant"
 external set_global_constant : bool -> llvalue -> unit
                              = "llvm_set_global_constant"
-external global_set_metadata : llvalue -> llmdkind -> llmetadata -> unit = "llvm_global_set_metadata"
+external global_set_metadata : llvalue -> llmdkind -> llmetadata -> unit
+                             = "llvm_global_set_metadata"
 
 (*--... Operations on global variables .....................................--*)
 external declare_global : lltype -> string -> llmodule -> llvalue

--- a/llvm/bindings/ocaml/llvm/llvm.ml
+++ b/llvm/bindings/ocaml/llvm/llvm.ml
@@ -700,6 +700,7 @@ external global_copy_all_metadata : llvalue -> (llmdkind * llmetadata) array
 external is_global_constant : llvalue -> bool = "llvm_is_global_constant"
 external set_global_constant : bool -> llvalue -> unit
                              = "llvm_set_global_constant"
+external global_set_metadata : llvalue -> llmdkind -> llmetadata -> unit = "llvm_global_set_metadata"
 
 (*--... Operations on global variables .....................................--*)
 external declare_global : lltype -> string -> llmodule -> llvalue

--- a/llvm/bindings/ocaml/llvm/llvm.mli
+++ b/llvm/bindings/ocaml/llvm/llvm.mli
@@ -1358,6 +1358,12 @@ val is_global_constant : llvalue -> bool
     See the method [llvm::GlobalVariable::setConstant]. *)
 val set_global_constant : bool -> llvalue -> unit
 
+(** [global_set_metadata g k md] sets the metadata attachment of the global
+    value [g] to the metadata [md] for the given kind [k], erasing the existing
+    metadata attachment if it already exists for the given kind.
+    See the method [llvm::GlobalObject::setMetadata]. *)
+val global_set_metadata : llvalue -> llmdkind -> llmetadata -> unit
+
 (** [global_initializer gv] If global variable [gv] has an initializer it is returned,
     otherwise returns [None]. See the method [llvm::GlobalVariable::getInitializer]. *)
 val global_initializer : llvalue -> llvalue option

--- a/llvm/bindings/ocaml/llvm/llvm_ocaml.c
+++ b/llvm/bindings/ocaml/llvm/llvm_ocaml.c
@@ -1546,6 +1546,13 @@ value llvm_set_global_constant(value Flag, value GlobalVar) {
   return Val_unit;
 }
 
+/* llvalue -> llmdkind -> llmetadata -> unit */
+value llvm_global_set_metadata(value Value, value MetadataKind, value Metadata) {
+  LLVMGlobalSetMetadata(Value_val(Value), (unsigned int)Int_val(MetadataKind),
+                        Metadata_val(Metadata));
+  return Val_unit;
+}
+
 /*--... Operations on aliases ..............................................--*/
 
 /* llmodule -> lltype -> int -> llvalue -> string -> llvalue */

--- a/llvm/bindings/ocaml/llvm/llvm_ocaml.c
+++ b/llvm/bindings/ocaml/llvm/llvm_ocaml.c
@@ -15,16 +15,16 @@
 |*                                                                            *|
 \*===----------------------------------------------------------------------===*/
 
-#include <assert.h>
-#include <stdlib.h>
-#include <string.h>
+#include "llvm_ocaml.h"
+#include "caml/callback.h"
+#include "caml/fail.h"
+#include "caml/memory.h"
 #include "llvm-c/Core.h"
 #include "llvm-c/Support.h"
 #include "llvm/Config/llvm-config.h"
-#include "caml/memory.h"
-#include "caml/fail.h"
-#include "caml/callback.h"
-#include "llvm_ocaml.h"
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
 
 #if OCAML_VERSION < 41200
 value caml_alloc_some(value v) {
@@ -1547,7 +1547,8 @@ value llvm_set_global_constant(value Flag, value GlobalVar) {
 }
 
 /* llvalue -> llmdkind -> llmetadata -> unit */
-value llvm_global_set_metadata(value Value, value MetadataKind, value Metadata) {
+value llvm_global_set_metadata(value Value, value MetadataKind,
+                               value Metadata) {
   LLVMGlobalSetMetadata(Value_val(Value), (unsigned int)Int_val(MetadataKind),
                         Metadata_val(Metadata));
   return Val_unit;

--- a/llvm/test/Bindings/OCaml/core.ml
+++ b/llvm/test/Bindings/OCaml/core.ml
@@ -439,7 +439,7 @@ let test_global_values () =
   (* CHECK: GVal07{{.*}}!test !{{.*}}
    * See metadata check at the end of the file.
    *)
-  group "metdata";
+  group "metadata";
   let g = define_global "GVal07" zero32 m in
   let md_string = mdstring context "global test metadata" in
   let md_node = mdnode context [| zero32; md_string |] |> value_as_metadata in

--- a/llvm/test/Bindings/OCaml/core.ml
+++ b/llvm/test/Bindings/OCaml/core.ml
@@ -1127,6 +1127,7 @@ let test_builder () =
 
   group "metadata"; begin
     (* CHECK: %metadata = add i32 %P1, %P2, !test !2
+     * !2 is metadata emitted at EOF.
      *)
     let i = build_add p1 p2 "metadata" atentry in
     insist ((has_metadata i) = false);

--- a/llvm/test/Bindings/OCaml/core.ml
+++ b/llvm/test/Bindings/OCaml/core.ml
@@ -1443,7 +1443,7 @@ let test_builder () =
   end
 
 (* End-of-file checks for things like metdata and attributes.
- * CHECK: !llvm.module.flags = !1
+ * CHECK: !llvm.module.flags = !{!1}
  * CHECK: !0 = !{i32 0, !"global test metadata"}
  * CHECK: !1 = !{i32 1, !"Debug Info Version", i32 3}
  * CHECK: !2 = !{i32 1, !"metadata test"}

--- a/llvm/test/Bindings/OCaml/core.ml
+++ b/llvm/test/Bindings/OCaml/core.ml
@@ -436,7 +436,7 @@ let test_global_values () =
           set_dll_storage_class DLLStorageClass.DLLExport in
   insist (DLLStorageClass.DLLExport = dll_storage_class g);
 
-  (* CHECK: GVal07{{.*}}!test !{{.*}}
+  (* CHECK: GVal07{{.*}}!test !0
    * See metadata check at the end of the file.
    *)
   group "metadata";
@@ -1126,9 +1126,7 @@ let test_builder () =
   end;
 
   group "metadata"; begin
-    (* CHECK: %metadata = add i32 %P1, %P2, !test !{{[0-9]+}}
-     * Number of metadata nodes is not predictable, so we just check for
-     * the presence of metadata here
+    (* CHECK: %metadata = add i32 %P1, %P2, !test !2
      *)
     let i = build_add p1 p2 "metadata" atentry in
     insist ((has_metadata i) = false);
@@ -1444,10 +1442,10 @@ let test_builder () =
   end
 
 (* End-of-file checks for things like metdata and attributes.
- * CHECK: !llvm.module.flags = !{!{{[0-9]+}}}
- * CHECK: !{{[0-9]+}} = !{i32 0, !"global test metadata"}
- * CHECK: !{{[0-9]+}} = !{i32 1, !"Debug Info Version", i32 3}
- * CHECK: !{{[0-9]+}} = !{i32 1, !"metadata test"}
+ * CHECK: !llvm.module.flags = !1
+ * CHECK: !0 = !{i32 0, !"global test metadata"}
+ * CHECK: !1 = !{i32 1, !"Debug Info Version", i32 3}
+ * CHECK: !2 = !{i32 1, !"metadata test"}
  *)
 
 

--- a/llvm/test/Bindings/OCaml/core.ml
+++ b/llvm/test/Bindings/OCaml/core.ml
@@ -434,8 +434,19 @@ let test_global_values () =
   group "dll_storage_class";
   let g = define_global "GVal06" zero32 m ++
           set_dll_storage_class DLLStorageClass.DLLExport in
-  insist (DLLStorageClass.DLLExport = dll_storage_class g)
+  insist (DLLStorageClass.DLLExport = dll_storage_class g);
 
+  (* CHECK: GVal07{{.*}}!test !{{.*}}
+   * See metadata check at the end of the file.
+   *)
+  group "metdata";
+  let g = define_global "GVal07" zero32 m in
+  let md_string = mdstring context "global test metadata" in
+  let md_node = mdnode context [| zero32; md_string |] |> value_as_metadata in
+  let mdkind_test = mdkind_id context "test" in
+  global_set_metadata g mdkind_test md_node;
+  let md' = global_copy_all_metadata g in
+  insist (md' = [| mdkind_test, md_node |])
 
 (*===-- Global Variables --------------------------------------------------===*)
 
@@ -1115,8 +1126,9 @@ let test_builder () =
   end;
 
   group "metadata"; begin
-    (* CHECK: %metadata = add i32 %P1, %P2, !test !1
-     * !1 is metadata emitted at EOF.
+    (* CHECK: %metadata = add i32 %P1, %P2, !test !{{[0-9]+}}
+     * Number of metadata nodes is not predictable, so we just check for
+     * the presence of metadata here
      *)
     let i = build_add p1 p2 "metadata" atentry in
     insist ((has_metadata i) = false);
@@ -1432,9 +1444,10 @@ let test_builder () =
   end
 
 (* End-of-file checks for things like metdata and attributes.
- * CHECK: !llvm.module.flags = !{!0}
- * CHECK: !0 = !{i32 1, !"Debug Info Version", i32 3}
- * CHECK: !1 = !{i32 1, !"metadata test"}
+ * CHECK: !llvm.module.flags = !{!{{[0-9]+}}}
+ * CHECK: !{{[0-9]+}} = !{i32 0, !"global test metadata"}
+ * CHECK: !{{[0-9]+}} = !{i32 1, !"Debug Info Version", i32 3}
+ * CHECK: !{{[0-9]+}} = !{i32 1, !"metadata test"}
  *)
 
 


### PR DESCRIPTION
This PR adds the OCaml binding to `LLVMGlobalSetMetadata`, so that OCaml users can set metadata on global values like functions. This is useful for e.g. adding debug information to functions.

(Note that the existing [`set_metadata`](https://github.com/moonbitlang/llvm-project/blob/0bf3e74a492894f7fb10227797d5d7df73001b08/llvm/bindings/ocaml/llvm/llvm.ml#L598) function operates on _instructions_, and cannot be used to set metadata on global values.)

---

This is my first PR to LLVM, so please tell me if I have done anything wrong.

~~Although the contribution guide said that contributions should include a unit test, I can't find any unit test in the OCaml bindings, so I guess I can skip that? My fault, I didn't see the test directory. I will add tests soon.~~ Tests are added now.

This binding has been tested in our internal projects and worked. 

The code within this PR came from a branch of version 18.x. As far as I know, related C bindings haven't changed during the times, so this patch should still be relevant.