### PR TITLE
[cmake] Move FindLibcCommonUtils to shared cmake, to fix standalone builds

### DIFF
--- a/cmake/Modules/FindLibcCommonUtils.cmake
+++ b/cmake/Modules/FindLibcCommonUtils.cmake
@@ -7,7 +7,7 @@
 #===--------------------------------------------------------------------===//
 
 if(NOT TARGET llvm-libc-common-utilities)
-  set(libc_path ${CMAKE_CURRENT_LIST_DIR}/../../../libc)
+  set(libc_path ${CMAKE_CURRENT_LIST_DIR}/../../libc)
   if (EXISTS ${libc_path} AND IS_DIRECTORY ${libc_path})
     add_library(llvm-libc-common-utilities INTERFACE)
     # TODO: Reorganize the libc shared section so that it can be included without


### PR DESCRIPTION
Move `FindLibcCommonUtils` from LLVM's CMake module directory to the shared top-level CMake directory, as the module is intended to be used from within the source tree rather than the installed LLVM version. This fixes standalone offload builds after #131205.