### PR TITLE
[X86][AVX10.2] Use 's_' for saturate-convert intrinsics

### DIFF
--- a/clang/lib/Headers/avx10_2_512convertintrin.h
+++ b/clang/lib/Headers/avx10_2_512convertintrin.h
@@ -78,20 +78,20 @@ _mm512_maskz_cvtbiasph_bf8(__mmask32 __U, __m512i __A, __m512h __B) {
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS512
-_mm512_cvtbiassph_bf8(__m512i __A, __m512h __B) {
+_mm512_cvts_biasph_bf8(__m512i __A, __m512h __B) {
   return (__m256i)__builtin_ia32_vcvtbiasph2bf8s_512_mask(
       (__v64qi)__A, (__v32hf)__B, (__v32qi)_mm256_undefined_si256(),
       (__mmask32)-1);
 }
 
-static __inline__ __m256i __DEFAULT_FN_ATTRS512 _mm512_mask_cvtbiassph_bf8(
+static __inline__ __m256i __DEFAULT_FN_ATTRS512 _mm512_mask_cvts_biasph_bf8(
     __m256i __W, __mmask32 __U, __m512i __A, __m512h __B) {
   return (__m256i)__builtin_ia32_vcvtbiasph2bf8s_512_mask(
       (__v64qi)__A, (__v32hf)__B, (__v32qi)(__m256i)__W, (__mmask32)__U);
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS512
-_mm512_maskz_cvtbiassph_bf8(__mmask32 __U, __m512i __A, __m512h __B) {
+_mm512_maskz_cvts_biasph_bf8(__mmask32 __U, __m512i __A, __m512h __B) {
   return (__m256i)__builtin_ia32_vcvtbiasph2bf8s_512_mask(
       (__v64qi)__A, (__v32hf)__B, (__v32qi)(__m256i)_mm256_setzero_si256(),
       (__mmask32)__U);
@@ -118,20 +118,20 @@ _mm512_maskz_cvtbiasph_hf8(__mmask32 __U, __m512i __A, __m512h __B) {
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS512
-_mm512_cvtbiassph_hf8(__m512i __A, __m512h __B) {
+_mm512_cvts_biasph_hf8(__m512i __A, __m512h __B) {
   return (__m256i)__builtin_ia32_vcvtbiasph2hf8s_512_mask(
       (__v64qi)__A, (__v32hf)__B, (__v32qi)_mm256_undefined_si256(),
       (__mmask32)-1);
 }
 
-static __inline__ __m256i __DEFAULT_FN_ATTRS512 _mm512_mask_cvtbiassph_hf8(
+static __inline__ __m256i __DEFAULT_FN_ATTRS512 _mm512_mask_cvts_biasph_hf8(
     __m256i __W, __mmask32 __U, __m512i __A, __m512h __B) {
   return (__m256i)__builtin_ia32_vcvtbiasph2hf8s_512_mask(
       (__v64qi)__A, (__v32hf)__B, (__v32qi)(__m256i)__W, (__mmask32)__U);
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS512
-_mm512_maskz_cvtbiassph_hf8(__mmask32 __U, __m512i __A, __m512h __B) {
+_mm512_maskz_cvts_biasph_hf8(__mmask32 __U, __m512i __A, __m512h __B) {
   return (__m256i)__builtin_ia32_vcvtbiasph2hf8s_512_mask(
       (__v64qi)__A, (__v32hf)__B, (__v32qi)(__m256i)_mm256_setzero_si256(),
       (__mmask32)__U);

--- a/clang/lib/Headers/avx10_2_512convertintrin.h
+++ b/clang/lib/Headers/avx10_2_512convertintrin.h
@@ -157,21 +157,21 @@ _mm512_maskz_cvt2ph_bf8(__mmask64 __U, __m512h __A, __m512h __B) {
 }
 
 static __inline__ __m512i __DEFAULT_FN_ATTRS512
-_mm512_cvts2ph_bf8(__m512h __A, __m512h __B) {
+_mm512_cvts_2ph_bf8(__m512h __A, __m512h __B) {
   return (__m512i)__builtin_ia32_vcvt2ph2bf8s_512((__v32hf)(__A),
                                                   (__v32hf)(__B));
 }
 
 static __inline__ __m512i __DEFAULT_FN_ATTRS512
-_mm512_mask_cvts2ph_bf8(__m512i __W, __mmask64 __U, __m512h __A, __m512h __B) {
+_mm512_mask_cvts_2ph_bf8(__m512i __W, __mmask64 __U, __m512h __A, __m512h __B) {
   return (__m512i)__builtin_ia32_selectb_512(
-      (__mmask64)__U, (__v64qi)_mm512_cvts2ph_bf8(__A, __B), (__v64qi)__W);
+      (__mmask64)__U, (__v64qi)_mm512_cvts_2ph_bf8(__A, __B), (__v64qi)__W);
 }
 
 static __inline__ __m512i __DEFAULT_FN_ATTRS512
-_mm512_maskz_cvts2ph_bf8(__mmask64 __U, __m512h __A, __m512h __B) {
+_mm512_maskz_cvts_2ph_bf8(__mmask64 __U, __m512h __A, __m512h __B) {
   return (__m512i)__builtin_ia32_selectb_512(
-      (__mmask64)__U, (__v64qi)_mm512_cvts2ph_bf8(__A, __B),
+      (__mmask64)__U, (__v64qi)_mm512_cvts_2ph_bf8(__A, __B),
       (__v64qi)(__m512i)_mm512_setzero_si512());
 }
 
@@ -195,21 +195,21 @@ _mm512_maskz_cvt2ph_hf8(__mmask64 __U, __m512h __A, __m512h __B) {
 }
 
 static __inline__ __m512i __DEFAULT_FN_ATTRS512
-_mm512_cvts2ph_hf8(__m512h __A, __m512h __B) {
+_mm512_cvts_2ph_hf8(__m512h __A, __m512h __B) {
   return (__m512i)__builtin_ia32_vcvt2ph2hf8s_512((__v32hf)(__A),
                                                   (__v32hf)(__B));
 }
 
 static __inline__ __m512i __DEFAULT_FN_ATTRS512
-_mm512_mask_cvts2ph_hf8(__m512i __W, __mmask64 __U, __m512h __A, __m512h __B) {
+_mm512_mask_cvts_2ph_hf8(__m512i __W, __mmask64 __U, __m512h __A, __m512h __B) {
   return (__m512i)__builtin_ia32_selectb_512(
-      (__mmask64)__U, (__v64qi)_mm512_cvts2ph_hf8(__A, __B), (__v64qi)__W);
+      (__mmask64)__U, (__v64qi)_mm512_cvts_2ph_hf8(__A, __B), (__v64qi)__W);
 }
 
 static __inline__ __m512i __DEFAULT_FN_ATTRS512
-_mm512_maskz_cvts2ph_hf8(__mmask64 __U, __m512h __A, __m512h __B) {
+_mm512_maskz_cvts_2ph_hf8(__mmask64 __U, __m512h __A, __m512h __B) {
   return (__m512i)__builtin_ia32_selectb_512(
-      (__mmask64)__U, (__v64qi)_mm512_cvts2ph_hf8(__A, __B),
+      (__mmask64)__U, (__v64qi)_mm512_cvts_2ph_hf8(__A, __B),
       (__v64qi)(__m512i)_mm512_setzero_si512());
 }
 
@@ -247,19 +247,20 @@ _mm512_maskz_cvtph_bf8(__mmask32 __U, __m512h __A) {
       (__v32hf)__A, (__v32qi)(__m256i)_mm256_setzero_si256(), (__mmask32)__U);
 }
 
-static __inline__ __m256i __DEFAULT_FN_ATTRS512 _mm512_cvtsph_bf8(__m512h __A) {
+static __inline__ __m256i __DEFAULT_FN_ATTRS512
+_mm512_cvts_ph_bf8(__m512h __A) {
   return (__m256i)__builtin_ia32_vcvtph2bf8s_512_mask(
       (__v32hf)__A, (__v32qi)(__m256i)_mm256_undefined_si256(), (__mmask32)-1);
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS512
-_mm512_mask_cvtsph_bf8(__m256i __W, __mmask32 __U, __m512h __A) {
+_mm512_mask_cvts_ph_bf8(__m256i __W, __mmask32 __U, __m512h __A) {
   return (__m256i)__builtin_ia32_vcvtph2bf8s_512_mask(
       (__v32hf)__A, (__v32qi)(__m256i)__W, (__mmask32)__U);
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS512
-_mm512_maskz_cvtsph_bf8(__mmask32 __U, __m512h __A) {
+_mm512_maskz_cvts_ph_bf8(__mmask32 __U, __m512h __A) {
   return (__m256i)__builtin_ia32_vcvtph2bf8s_512_mask(
       (__v32hf)__A, (__v32qi)(__m256i)_mm256_setzero_si256(), (__mmask32)__U);
 }
@@ -281,19 +282,20 @@ _mm512_maskz_cvtph_hf8(__mmask32 __U, __m512h __A) {
       (__v32hf)__A, (__v32qi)(__m256i)_mm256_setzero_si256(), (__mmask32)__U);
 }
 
-static __inline__ __m256i __DEFAULT_FN_ATTRS512 _mm512_cvtsph_hf8(__m512h __A) {
+static __inline__ __m256i __DEFAULT_FN_ATTRS512
+_mm512_cvts_ph_hf8(__m512h __A) {
   return (__m256i)__builtin_ia32_vcvtph2hf8s_512_mask(
       (__v32hf)__A, (__v32qi)(__m256i)_mm256_undefined_si256(), (__mmask32)-1);
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS512
-_mm512_mask_cvtsph_hf8(__m256i __W, __mmask32 __U, __m512h __A) {
+_mm512_mask_cvts_ph_hf8(__m256i __W, __mmask32 __U, __m512h __A) {
   return (__m256i)__builtin_ia32_vcvtph2hf8s_512_mask(
       (__v32hf)__A, (__v32qi)(__m256i)__W, (__mmask32)__U);
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS512
-_mm512_maskz_cvtsph_hf8(__mmask32 __U, __m512h __A) {
+_mm512_maskz_cvts_ph_hf8(__mmask32 __U, __m512h __A) {
   return (__m256i)__builtin_ia32_vcvtph2hf8s_512_mask(
       (__v32hf)__A, (__v32qi)(__m256i)_mm256_setzero_si256(), (__mmask32)__U);
 }

--- a/clang/lib/Headers/avx10_2_512satcvtdsintrin.h
+++ b/clang/lib/Headers/avx10_2_512satcvtdsintrin.h
@@ -20,20 +20,21 @@
                  __min_vector_width__(512)))
 
 // 512 bit : Double -> Int
-static __inline__ __m256i __DEFAULT_FN_ATTRS _mm512_cvttspd_epi32(__m512d __A) {
+static __inline__ __m256i __DEFAULT_FN_ATTRS
+_mm512_cvtts_pd_epi32(__m512d __A) {
   return ((__m256i)__builtin_ia32_vcvttpd2dqs512_round_mask(
       (__v8df)__A, (__v8si)_mm256_undefined_si256(), (__mmask8)-1,
       _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS
-_mm512_mask_cvttspd_epi32(__m256i __W, __mmask8 __U, __m512d __A) {
+_mm512_mask_cvtts_pd_epi32(__m256i __W, __mmask8 __U, __m512d __A) {
   return ((__m256i)__builtin_ia32_vcvttpd2dqs512_round_mask(
       (__v8df)__A, (__v8si)__W, __U, _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS
-_mm512_maskz_cvttspd_epi32(__mmask8 __U, __m512d __A) {
+_mm512_maskz_cvtts_pd_epi32(__mmask8 __U, __m512d __A) {
   return ((__m256i)__builtin_ia32_vcvttpd2dqs512_round_mask(
       (__v8df)__A, (__v8si)_mm256_setzero_si256(), __U,
       _MM_FROUND_CUR_DIRECTION));
@@ -55,20 +56,21 @@ _mm512_maskz_cvttspd_epi32(__mmask8 __U, __m512d __A) {
       (const int)(__R)))
 
 // 512 bit : Double -> uInt
-static __inline__ __m256i __DEFAULT_FN_ATTRS _mm512_cvttspd_epu32(__m512d __A) {
+static __inline__ __m256i __DEFAULT_FN_ATTRS
+_mm512_cvtts_pd_epu32(__m512d __A) {
   return ((__m256i)__builtin_ia32_vcvttpd2udqs512_round_mask(
       (__v8df)__A, (__v8si)_mm256_undefined_si256(), (__mmask8)-1,
       _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS
-_mm512_mask_cvttspd_epu32(__m256i __W, __mmask8 __U, __m512d __A) {
+_mm512_mask_cvtts_pd_epu32(__m256i __W, __mmask8 __U, __m512d __A) {
   return ((__m256i)__builtin_ia32_vcvttpd2udqs512_round_mask(
       (__v8df)__A, (__v8si)__W, __U, _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS
-_mm512_maskz_cvttspd_epu32(__mmask8 __U, __m512d __A) {
+_mm512_maskz_cvtts_pd_epu32(__mmask8 __U, __m512d __A) {
   return ((__m256i)__builtin_ia32_vcvttpd2udqs512_round_mask(
       (__v8df)__A, (__v8si)_mm256_setzero_si256(), __U,
       _MM_FROUND_CUR_DIRECTION));
@@ -91,18 +93,19 @@ _mm512_maskz_cvttspd_epu32(__mmask8 __U, __m512d __A) {
 
 //  512 bit : Double -> Long
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS _mm512_cvttspd_epi64(__m512d __A) {
+static __inline__ __m512i __DEFAULT_FN_ATTRS
+_mm512_cvtts_pd_epi64(__m512d __A) {
   return ((__m512i)__builtin_ia32_vcvttpd2qqs512_round_mask(
       (__v8df)__A, (__v8di)_mm512_undefined_epi32(), (__mmask8)-1,
       _MM_FROUND_CUR_DIRECTION));
 }
 static __inline__ __m512i __DEFAULT_FN_ATTRS
-_mm512_mask_cvttspd_epi64(__m512i __W, __mmask8 __U, __m512d __A) {
+_mm512_mask_cvtts_pd_epi64(__m512i __W, __mmask8 __U, __m512d __A) {
   return ((__m512i)__builtin_ia32_vcvttpd2qqs512_round_mask(
       (__v8df)__A, (__v8di)__W, __U, _MM_FROUND_CUR_DIRECTION));
 }
 static __inline__ __m512i __DEFAULT_FN_ATTRS
-_mm512_maskz_cvttspd_epi64(__mmask8 __U, __m512d __A) {
+_mm512_maskz_cvtts_pd_epi64(__mmask8 __U, __m512d __A) {
   return ((__m512i)__builtin_ia32_vcvttpd2qqs512_round_mask(
       (__v8df)__A, (__v8di)_mm512_setzero_si512(), __U,
       _MM_FROUND_CUR_DIRECTION));
@@ -125,20 +128,21 @@ _mm512_maskz_cvttspd_epi64(__mmask8 __U, __m512d __A) {
 
 // 512 bit : Double -> ULong
 
-static __inline__ __m512i __DEFAULT_FN_ATTRS _mm512_cvttspd_epu64(__m512d __A) {
+static __inline__ __m512i __DEFAULT_FN_ATTRS
+_mm512_cvtts_pd_epu64(__m512d __A) {
   return ((__m512i)__builtin_ia32_vcvttpd2uqqs512_round_mask(
       (__v8df)__A, (__v8di)_mm512_undefined_epi32(), (__mmask8)-1,
       _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m512i __DEFAULT_FN_ATTRS
-_mm512_mask_cvttspd_epu64(__m512i __W, __mmask8 __U, __m512d __A) {
+_mm512_mask_cvtts_pd_epu64(__m512i __W, __mmask8 __U, __m512d __A) {
   return ((__m512i)__builtin_ia32_vcvttpd2uqqs512_round_mask(
       (__v8df)__A, (__v8di)__W, __U, _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m512i __DEFAULT_FN_ATTRS
-_mm512_maskz_cvttspd_epu64(__mmask8 __U, __m512d __A) {
+_mm512_maskz_cvtts_pd_epu64(__mmask8 __U, __m512d __A) {
   return ((__m512i)__builtin_ia32_vcvttpd2uqqs512_round_mask(
       (__v8df)__A, (__v8di)_mm512_setzero_si512(), __U,
       _MM_FROUND_CUR_DIRECTION));
@@ -160,20 +164,20 @@ _mm512_maskz_cvttspd_epu64(__mmask8 __U, __m512d __A) {
       (const int)(__R)))
 
 // 512 bit: Float -> int
-static __inline__ __m512i __DEFAULT_FN_ATTRS _mm512_cvttsps_epi32(__m512 __A) {
+static __inline__ __m512i __DEFAULT_FN_ATTRS _mm512_cvtts_ps_epi32(__m512 __A) {
   return ((__m512i)__builtin_ia32_vcvttps2dqs512_round_mask(
       (__v16sf)(__A), (__v16si)_mm512_undefined_epi32(), (__mmask16)-1,
       _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m512i __DEFAULT_FN_ATTRS
-_mm512_mask_cvttsps_epi32(__m512i __W, __mmask16 __U, __m512 __A) {
+_mm512_mask_cvtts_ps_epi32(__m512i __W, __mmask16 __U, __m512 __A) {
   return ((__m512i)__builtin_ia32_vcvttps2dqs512_round_mask(
       (__v16sf)(__A), (__v16si)(__W), __U, _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m512i __DEFAULT_FN_ATTRS
-_mm512_maskz_cvttsps_epi32(__mmask16 __U, __m512 __A) {
+_mm512_maskz_cvtts_ps_epi32(__mmask16 __U, __m512 __A) {
   return ((__m512i)__builtin_ia32_vcvttps2dqs512_round_mask(
       (__v16sf)(__A), (__v16si)_mm512_setzero_si512(), __U,
       _MM_FROUND_CUR_DIRECTION));
@@ -195,20 +199,20 @@ _mm512_maskz_cvttsps_epi32(__mmask16 __U, __m512 __A) {
       (__mmask16)(__U), (const int)(__R)))
 
 // 512 bit: Float -> uint
-static __inline__ __m512i __DEFAULT_FN_ATTRS _mm512_cvttsps_epu32(__m512 __A) {
+static __inline__ __m512i __DEFAULT_FN_ATTRS _mm512_cvtts_ps_epu32(__m512 __A) {
   return ((__m512i)__builtin_ia32_vcvttps2udqs512_round_mask(
       (__v16sf)(__A), (__v16si)_mm512_undefined_epi32(), (__mmask16)-1,
       _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m512i __DEFAULT_FN_ATTRS
-_mm512_mask_cvttsps_epu32(__m512i __W, __mmask16 __U, __m512 __A) {
+_mm512_mask_cvtts_ps_epu32(__m512i __W, __mmask16 __U, __m512 __A) {
   return ((__m512i)__builtin_ia32_vcvttps2udqs512_round_mask(
       (__v16sf)(__A), (__v16si)(__W), __U, _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m512i __DEFAULT_FN_ATTRS
-_mm512_maskz_cvttsps_epu32(__mmask16 __U, __m512 __A) {
+_mm512_maskz_cvtts_ps_epu32(__mmask16 __U, __m512 __A) {
   return ((__m512i)__builtin_ia32_vcvttps2udqs512_round_mask(
       (__v16sf)(__A), (__v16si)_mm512_setzero_si512(), __U,
       _MM_FROUND_CUR_DIRECTION));
@@ -230,20 +234,20 @@ _mm512_maskz_cvttsps_epu32(__mmask16 __U, __m512 __A) {
       (__mmask16)(__U), (const int)(__R)))
 
 // 512 bit : float -> long
-static __inline__ __m512i __DEFAULT_FN_ATTRS _mm512_cvttsps_epi64(__m256 __A) {
+static __inline__ __m512i __DEFAULT_FN_ATTRS _mm512_cvtts_ps_epi64(__m256 __A) {
   return ((__m512i)__builtin_ia32_vcvttps2qqs512_round_mask(
       (__v8sf)__A, (__v8di)_mm512_undefined_epi32(), (__mmask8)-1,
       _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m512i __DEFAULT_FN_ATTRS
-_mm512_mask_cvttsps_epi64(__m512i __W, __mmask8 __U, __m256 __A) {
+_mm512_mask_cvtts_ps_epi64(__m512i __W, __mmask8 __U, __m256 __A) {
   return ((__m512i)__builtin_ia32_vcvttps2qqs512_round_mask(
       (__v8sf)__A, (__v8di)__W, __U, _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m512i __DEFAULT_FN_ATTRS
-_mm512_maskz_cvttsps_epi64(__mmask8 __U, __m256 __A) {
+_mm512_maskz_cvtts_ps_epi64(__mmask8 __U, __m256 __A) {
   return ((__m512i)__builtin_ia32_vcvttps2qqs512_round_mask(
       (__v8sf)__A, (__v8di)_mm512_setzero_si512(), __U,
       _MM_FROUND_CUR_DIRECTION));
@@ -265,20 +269,20 @@ _mm512_maskz_cvttsps_epi64(__mmask8 __U, __m256 __A) {
       (const int)(__R)))
 
 // 512 bit : float -> ulong
-static __inline__ __m512i __DEFAULT_FN_ATTRS _mm512_cvttsps_epu64(__m256 __A) {
+static __inline__ __m512i __DEFAULT_FN_ATTRS _mm512_cvtts_ps_epu64(__m256 __A) {
   return ((__m512i)__builtin_ia32_vcvttps2uqqs512_round_mask(
       (__v8sf)__A, (__v8di)_mm512_undefined_epi32(), (__mmask8)-1,
       _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m512i __DEFAULT_FN_ATTRS
-_mm512_mask_cvttsps_epu64(__m512i __W, __mmask8 __U, __m256 __A) {
+_mm512_mask_cvtts_ps_epu64(__m512i __W, __mmask8 __U, __m256 __A) {
   return ((__m512i)__builtin_ia32_vcvttps2uqqs512_round_mask(
       (__v8sf)__A, (__v8di)__W, __U, _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m512i __DEFAULT_FN_ATTRS
-_mm512_maskz_cvttsps_epu64(__mmask8 __U, __m256 __A) {
+_mm512_maskz_cvtts_ps_epu64(__mmask8 __U, __m256 __A) {
   return ((__m512i)__builtin_ia32_vcvttps2uqqs512_round_mask(
       (__v8sf)__A, (__v8di)_mm512_setzero_si512(), __U,
       _MM_FROUND_CUR_DIRECTION));

--- a/clang/lib/Headers/avx10_2_512satcvtintrin.h
+++ b/clang/lib/Headers/avx10_2_512satcvtintrin.h
@@ -14,286 +14,286 @@
 #ifndef __AVX10_2_512SATCVTINTRIN_H
 #define __AVX10_2_512SATCVTINTRIN_H
 
-#define _mm512_ipcvtbf16_epi8(A)                                               \
+#define _mm512_ipcvts_bf16_epi8(A)                                             \
   ((__m512i)__builtin_ia32_vcvtbf162ibs512((__v32bf)(__m512bh)(A)))
 
-#define _mm512_mask_ipcvtbf16_epi8(W, U, A)                                    \
+#define _mm512_mask_ipcvts_bf16_epi8(W, U, A)                                  \
   ((__m512i)__builtin_ia32_selectw_512((__mmask32)(U),                         \
-                                       (__v32hi)_mm512_ipcvtbf16_epi8(A),      \
+                                       (__v32hi)_mm512_ipcvts_bf16_epi8(A),    \
                                        (__v32hi)(__m512i)(W)))
 
-#define _mm512_maskz_ipcvtbf16_epi8(U, A)                                      \
+#define _mm512_maskz_ipcvts_bf16_epi8(U, A)                                    \
   ((__m512i)__builtin_ia32_selectw_512((__mmask32)(U),                         \
-                                       (__v32hi)_mm512_ipcvtbf16_epi8(A),      \
+                                       (__v32hi)_mm512_ipcvts_bf16_epi8(A),    \
                                        (__v32hi)_mm512_setzero_si512()))
 
-#define _mm512_ipcvtbf16_epu8(A)                                               \
+#define _mm512_ipcvts_bf16_epu8(A)                                             \
   ((__m512i)__builtin_ia32_vcvtbf162iubs512((__v32bf)(__m512bh)(A)))
 
-#define _mm512_mask_ipcvtbf16_epu8(W, U, A)                                    \
+#define _mm512_mask_ipcvts_bf16_epu8(W, U, A)                                  \
   ((__m512i)__builtin_ia32_selectw_512((__mmask32)(U),                         \
-                                       (__v32hi)_mm512_ipcvtbf16_epu8(A),      \
+                                       (__v32hi)_mm512_ipcvts_bf16_epu8(A),    \
                                        (__v32hi)(__m512i)(W)))
 
-#define _mm512_maskz_ipcvtbf16_epu8(U, A)                                      \
+#define _mm512_maskz_ipcvts_bf16_epu8(U, A)                                    \
   ((__m512i)__builtin_ia32_selectw_512((__mmask32)(U),                         \
-                                       (__v32hi)_mm512_ipcvtbf16_epu8(A),      \
+                                       (__v32hi)_mm512_ipcvts_bf16_epu8(A),    \
                                        (__v32hi)_mm512_setzero_si512()))
 
-#define _mm512_ipcvttbf16_epi8(A)                                              \
+#define _mm512_ipcvtts_bf16_epi8(A)                                            \
   ((__m512i)__builtin_ia32_vcvttbf162ibs512((__v32bf)(__m512bh)(A)))
 
-#define _mm512_mask_ipcvttbf16_epi8(W, U, A)                                   \
+#define _mm512_mask_ipcvtts_bf16_epi8(W, U, A)                                 \
   ((__m512i)__builtin_ia32_selectw_512((__mmask32)(U),                         \
-                                       (__v32hi)_mm512_ipcvttbf16_epi8(A),     \
+                                       (__v32hi)_mm512_ipcvtts_bf16_epi8(A),   \
                                        (__v32hi)(__m512i)(W)))
 
-#define _mm512_maskz_ipcvttbf16_epi8(U, A)                                     \
+#define _mm512_maskz_ipcvtts_bf16_epi8(U, A)                                   \
   ((__m512i)__builtin_ia32_selectw_512((__mmask32)(U),                         \
-                                       (__v32hi)_mm512_ipcvttbf16_epi8(A),     \
+                                       (__v32hi)_mm512_ipcvtts_bf16_epi8(A),   \
                                        (__v32hi)_mm512_setzero_si512()))
 
-#define _mm512_ipcvttbf16_epu8(A)                                              \
+#define _mm512_ipcvtts_bf16_epu8(A)                                            \
   ((__m512i)__builtin_ia32_vcvttbf162iubs512((__v32bf)(__m512bh)(A)))
 
-#define _mm512_mask_ipcvttbf16_epu8(W, U, A)                                   \
+#define _mm512_mask_ipcvtts_bf16_epu8(W, U, A)                                 \
   ((__m512i)__builtin_ia32_selectw_512((__mmask32)(U),                         \
-                                       (__v32hi)_mm512_ipcvttbf16_epu8(A),     \
+                                       (__v32hi)_mm512_ipcvtts_bf16_epu8(A),   \
                                        (__v32hi)(__m512i)(W)))
 
-#define _mm512_maskz_ipcvttbf16_epu8(U, A)                                     \
+#define _mm512_maskz_ipcvtts_bf16_epu8(U, A)                                   \
   ((__m512i)__builtin_ia32_selectw_512((__mmask32)(U),                         \
-                                       (__v32hi)_mm512_ipcvttbf16_epu8(A),     \
+                                       (__v32hi)_mm512_ipcvtts_bf16_epu8(A),   \
                                        (__v32hi)_mm512_setzero_si512()))
 
-#define _mm512_ipcvtph_epi8(A)                                                 \
+#define _mm512_ipcvts_ph_epi8(A)                                               \
   ((__m512i)__builtin_ia32_vcvtph2ibs512_mask(                                 \
-      (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32)-1,   \
+      (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32) - 1, \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_mask_ipcvtph_epi8(W, U, A)                                      \
+#define _mm512_mask_ipcvts_ph_epi8(W, U, A)                                    \
   ((__m512i)__builtin_ia32_vcvtph2ibs512_mask((__v32hf)(__m512h)(A),           \
                                               (__v32hu)(W), (__mmask32)(U),    \
                                               _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_maskz_ipcvtph_epi8(U, A)                                        \
+#define _mm512_maskz_ipcvts_ph_epi8(U, A)                                      \
   ((__m512i)__builtin_ia32_vcvtph2ibs512_mask(                                 \
       (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32)(U),  \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_ipcvt_roundph_epi8(A, R)                                        \
+#define _mm512_ipcvts_roundph_epi8(A, R)                                       \
   ((__m512i)__builtin_ia32_vcvtph2ibs512_mask((__v32hf)(__m512h)(A),           \
                                               (__v32hu)_mm512_setzero_si512(), \
-                                              (__mmask32)-1, (const int)R))
+                                              (__mmask32) - 1, (const int)R))
 
-#define _mm512_mask_ipcvt_roundph_epi8(W, U, A, R)                             \
+#define _mm512_mask_ipcvts_roundph_epi8(W, U, A, R)                            \
   ((__m512i)__builtin_ia32_vcvtph2ibs512_mask(                                 \
       (__v32hf)(__m512h)(A), (__v32hu)(W), (__mmask32)(U), (const int)R))
 
-#define _mm512_maskz_ipcvt_roundph_epi8(U, A, R)                               \
+#define _mm512_maskz_ipcvts_roundph_epi8(U, A, R)                              \
   ((__m512i)__builtin_ia32_vcvtph2ibs512_mask((__v32hf)(__m512h)(A),           \
                                               (__v32hu)_mm512_setzero_si512(), \
                                               (__mmask32)(U), (const int)R))
 
-#define _mm512_ipcvtph_epu8(A)                                                 \
+#define _mm512_ipcvts_ph_epu8(A)                                               \
   ((__m512i)__builtin_ia32_vcvtph2iubs512_mask(                                \
-      (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32)-1,   \
+      (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32) - 1, \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_mask_ipcvtph_epu8(W, U, A)                                      \
+#define _mm512_mask_ipcvts_ph_epu8(W, U, A)                                    \
   ((__m512i)__builtin_ia32_vcvtph2iubs512_mask((__v32hf)(__m512h)(A),          \
                                                (__v32hu)(W), (__mmask32)(U),   \
                                                _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_maskz_ipcvtph_epu8(U, A)                                        \
+#define _mm512_maskz_ipcvts_ph_epu8(U, A)                                      \
   ((__m512i)__builtin_ia32_vcvtph2iubs512_mask(                                \
       (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32)(U),  \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_ipcvt_roundph_epu8(A, R)                                        \
+#define _mm512_ipcvts_roundph_epu8(A, R)                                       \
   ((__m512i)__builtin_ia32_vcvtph2iubs512_mask(                                \
-      (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32)-1,   \
+      (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32) - 1, \
       (const int)R))
 
-#define _mm512_mask_ipcvt_roundph_epu8(W, U, A, R)                             \
+#define _mm512_mask_ipcvts_roundph_epu8(W, U, A, R)                            \
   ((__m512i)__builtin_ia32_vcvtph2iubs512_mask(                                \
       (__v32hf)(__m512h)(A), (__v32hu)(W), (__mmask32)(U), (const int)R))
 
-#define _mm512_maskz_ipcvt_roundph_epu8(U, A, R)                               \
+#define _mm512_maskz_ipcvts_roundph_epu8(U, A, R)                              \
   ((__m512i)__builtin_ia32_vcvtph2iubs512_mask(                                \
       (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32)(U),  \
       (const int)R))
 
-#define _mm512_ipcvtps_epi8(A)                                                 \
+#define _mm512_ipcvts_ps_epi8(A)                                               \
   ((__m512i)__builtin_ia32_vcvtps2ibs512_mask(                                 \
-      (__v16sf)(__m512)(A), (__v16su)_mm512_setzero_si512(), (__mmask16)-1,    \
+      (__v16sf)(__m512)(A), (__v16su)_mm512_setzero_si512(), (__mmask16) - 1,  \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_mask_ipcvtps_epi8(W, U, A)                                      \
+#define _mm512_mask_ipcvts_ps_epi8(W, U, A)                                    \
   ((__m512i)__builtin_ia32_vcvtps2ibs512_mask((__v16sf)(__m512)(A),            \
                                               (__v16su)(W), (__mmask16)(U),    \
                                               _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_maskz_ipcvtps_epi8(U, A)                                        \
+#define _mm512_maskz_ipcvts_ps_epi8(U, A)                                      \
   ((__m512i)__builtin_ia32_vcvtps2ibs512_mask(                                 \
       (__v16sf)(__m512)(A), (__v16su)_mm512_setzero_si512(), (__mmask16)(U),   \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_ipcvt_roundps_epi8(A, R)                                        \
+#define _mm512_ipcvts_roundps_epi8(A, R)                                       \
   ((__m512i)__builtin_ia32_vcvtps2ibs512_mask((__v16sf)(__m512)(A),            \
                                               (__v16su)_mm512_setzero_si512(), \
-                                              (__mmask16)-1, (const int)R))
+                                              (__mmask16) - 1, (const int)R))
 
-#define _mm512_mask_ipcvt_roundps_epi8(W, U, A, R)                             \
+#define _mm512_mask_ipcvts_roundps_epi8(W, U, A, R)                            \
   ((__m512i)__builtin_ia32_vcvtps2ibs512_mask(                                 \
       (__v16sf)(__m512)(A), (__v16su)(W), (__mmask16)(U), (const int)R))
 
-#define _mm512_maskz_ipcvt_roundps_epi8(U, A, R)                               \
+#define _mm512_maskz_ipcvts_roundps_epi8(U, A, R)                              \
   ((__m512i)__builtin_ia32_vcvtps2ibs512_mask((__v16sf)(__m512)(A),            \
                                               (__v16su)_mm512_setzero_si512(), \
                                               (__mmask16)(U), (const int)R))
 
-#define _mm512_ipcvtps_epu8(A)                                                 \
+#define _mm512_ipcvts_ps_epu8(A)                                               \
   ((__m512i)__builtin_ia32_vcvtps2iubs512_mask(                                \
-      (__v16sf)(__m512)(A), (__v16su)_mm512_setzero_si512(), (__mmask16)-1,    \
+      (__v16sf)(__m512)(A), (__v16su)_mm512_setzero_si512(), (__mmask16) - 1,  \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_mask_ipcvtps_epu8(W, U, A)                                      \
+#define _mm512_mask_ipcvts_ps_epu8(W, U, A)                                    \
   ((__m512i)__builtin_ia32_vcvtps2iubs512_mask((__v16sf)(__m512)(A),           \
                                                (__v16su)(W), (__mmask16)(U),   \
                                                _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_maskz_ipcvtps_epu8(U, A)                                        \
+#define _mm512_maskz_ipcvts_ps_epu8(U, A)                                      \
   ((__m512i)__builtin_ia32_vcvtps2iubs512_mask(                                \
       (__v16sf)(__m512)(A), (__v16su)_mm512_setzero_si512(), (__mmask16)(U),   \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_ipcvt_roundps_epu8(A, R)                                        \
+#define _mm512_ipcvts_roundps_epu8(A, R)                                       \
   ((__m512i)__builtin_ia32_vcvtps2iubs512_mask(                                \
-      (__v16sf)(__m512)(A), (__v16su)_mm512_setzero_si512(), (__mmask16)-1,    \
+      (__v16sf)(__m512)(A), (__v16su)_mm512_setzero_si512(), (__mmask16) - 1,  \
       (const int)R))
 
-#define _mm512_mask_ipcvt_roundps_epu8(W, U, A, R)                             \
+#define _mm512_mask_ipcvts_roundps_epu8(W, U, A, R)                            \
   ((__m512i)__builtin_ia32_vcvtps2iubs512_mask(                                \
       (__v16sf)(__m512)(A), (__v16su)(W), (__mmask16)(U), (const int)R))
 
-#define _mm512_maskz_ipcvt_roundps_epu8(U, A, R)                               \
+#define _mm512_maskz_ipcvts_roundps_epu8(U, A, R)                              \
   ((__m512i)__builtin_ia32_vcvtps2iubs512_mask(                                \
       (__v16sf)(__m512)(A), (__v16su)_mm512_setzero_si512(), (__mmask16)(U),   \
       (const int)R))
 
-#define _mm512_ipcvttph_epi8(A)                                                \
+#define _mm512_ipcvtts_ph_epi8(A)                                              \
   ((__m512i)__builtin_ia32_vcvttph2ibs512_mask(                                \
-      (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32)-1,   \
+      (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32) - 1, \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_mask_ipcvttph_epi8(W, U, A)                                     \
+#define _mm512_mask_ipcvtts_ph_epi8(W, U, A)                                   \
   ((__m512i)__builtin_ia32_vcvttph2ibs512_mask((__v32hf)(__m512h)(A),          \
                                                (__v32hu)(W), (__mmask32)(U),   \
                                                _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_maskz_ipcvttph_epi8(U, A)                                       \
+#define _mm512_maskz_ipcvtts_ph_epi8(U, A)                                     \
   ((__m512i)__builtin_ia32_vcvttph2ibs512_mask(                                \
       (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32)(U),  \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_ipcvtt_roundph_epi8(A, S)                                       \
+#define _mm512_ipcvtts_roundph_epi8(A, S)                                      \
   ((__m512i)__builtin_ia32_vcvttph2ibs512_mask(                                \
-      (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32)-1,   \
+      (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32) - 1, \
       S))
 
-#define _mm512_mask_ipcvtt_roundph_epi8(W, U, A, S)                            \
+#define _mm512_mask_ipcvtts_roundph_epi8(W, U, A, S)                           \
   ((__m512i)__builtin_ia32_vcvttph2ibs512_mask(                                \
       (__v32hf)(__m512h)(A), (__v32hu)(W), (__mmask32)(U), S))
 
-#define _mm512_maskz_ipcvtt_roundph_epi8(U, A, S)                              \
+#define _mm512_maskz_ipcvtts_roundph_epi8(U, A, S)                             \
   ((__m512i)__builtin_ia32_vcvttph2ibs512_mask(                                \
       (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32)(U),  \
       S))
 
-#define _mm512_ipcvttph_epu8(A)                                                \
+#define _mm512_ipcvtts_ph_epu8(A)                                              \
   ((__m512i)__builtin_ia32_vcvttph2iubs512_mask(                               \
-      (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32)-1,   \
+      (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32) - 1, \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_mask_ipcvttph_epu8(W, U, A)                                     \
+#define _mm512_mask_ipcvtts_ph_epu8(W, U, A)                                   \
   ((__m512i)__builtin_ia32_vcvttph2iubs512_mask((__v32hf)(__m512h)(A),         \
                                                 (__v32hu)(W), (__mmask32)(U),  \
                                                 _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_maskz_ipcvttph_epu8(U, A)                                       \
+#define _mm512_maskz_ipcvtts_ph_epu8(U, A)                                     \
   ((__m512i)__builtin_ia32_vcvttph2iubs512_mask(                               \
       (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32)(U),  \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_ipcvtt_roundph_epu8(A, S)                                       \
+#define _mm512_ipcvtts_roundph_epu8(A, S)                                      \
   ((__m512i)__builtin_ia32_vcvttph2iubs512_mask(                               \
-      (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32)-1,   \
+      (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32) - 1, \
       S))
 
-#define _mm512_mask_ipcvtt_roundph_epu8(W, U, A, S)                            \
+#define _mm512_mask_ipcvtts_roundph_epu8(W, U, A, S)                           \
   ((__m512i)__builtin_ia32_vcvttph2iubs512_mask(                               \
       (__v32hf)(__m512h)(A), (__v32hu)(W), (__mmask32)(U), S))
 
-#define _mm512_maskz_ipcvtt_roundph_epu8(U, A, S)                              \
+#define _mm512_maskz_ipcvtts_roundph_epu8(U, A, S)                             \
   ((__m512i)__builtin_ia32_vcvttph2iubs512_mask(                               \
       (__v32hf)(__m512h)(A), (__v32hu)_mm512_setzero_si512(), (__mmask32)(U),  \
       S))
 
-#define _mm512_ipcvttps_epi8(A)                                                \
+#define _mm512_ipcvtts_ps_epi8(A)                                              \
   ((__m512i)__builtin_ia32_vcvttps2ibs512_mask(                                \
-      (__v16sf)(__m512h)(A), (__v16su)_mm512_setzero_si512(), (__mmask16)-1,   \
+      (__v16sf)(__m512h)(A), (__v16su)_mm512_setzero_si512(), (__mmask16) - 1, \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_mask_ipcvttps_epi8(W, U, A)                                     \
+#define _mm512_mask_ipcvtts_ps_epi8(W, U, A)                                   \
   ((__m512i)__builtin_ia32_vcvttps2ibs512_mask((__v16sf)(__m512h)(A),          \
                                                (__v16su)(W), (__mmask16)(U),   \
                                                _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_maskz_ipcvttps_epi8(U, A)                                       \
+#define _mm512_maskz_ipcvtts_ps_epi8(U, A)                                     \
   ((__m512i)__builtin_ia32_vcvttps2ibs512_mask(                                \
       (__v16sf)(__m512h)(A), (__v16su)_mm512_setzero_si512(), (__mmask16)(U),  \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_ipcvtt_roundps_epi8(A, S)                                       \
+#define _mm512_ipcvtts_roundps_epi8(A, S)                                      \
   ((__m512i)__builtin_ia32_vcvttps2ibs512_mask(                                \
-      (__v16sf)(__m512h)(A), (__v16su)_mm512_setzero_si512(), (__mmask16)-1,   \
+      (__v16sf)(__m512h)(A), (__v16su)_mm512_setzero_si512(), (__mmask16) - 1, \
       S))
 
-#define _mm512_mask_ipcvtt_roundps_epi8(W, U, A, S)                            \
+#define _mm512_mask_ipcvtts_roundps_epi8(W, U, A, S)                           \
   ((__m512i)__builtin_ia32_vcvttps2ibs512_mask(                                \
       (__v16sf)(__m512h)(A), (__v16su)(W), (__mmask16)(U), S))
 
-#define _mm512_maskz_ipcvtt_roundps_epi8(U, A, S)                              \
+#define _mm512_maskz_ipcvtts_roundps_epi8(U, A, S)                             \
   ((__m512i)__builtin_ia32_vcvttps2ibs512_mask(                                \
       (__v16sf)(__m512h)(A), (__v16su)_mm512_setzero_si512(), (__mmask16)(U),  \
       S))
 
-#define _mm512_ipcvttps_epu8(A)                                                \
+#define _mm512_ipcvtts_ps_epu8(A)                                              \
   ((__m512i)__builtin_ia32_vcvttps2iubs512_mask(                               \
-      (__v16sf)(__m512h)(A), (__v16su)_mm512_setzero_si512(), (__mmask16)-1,   \
+      (__v16sf)(__m512h)(A), (__v16su)_mm512_setzero_si512(), (__mmask16) - 1, \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_mask_ipcvttps_epu8(W, U, A)                                     \
+#define _mm512_mask_ipcvtts_ps_epu8(W, U, A)                                   \
   ((__m512i)__builtin_ia32_vcvttps2iubs512_mask((__v16sf)(__m512h)(A),         \
                                                 (__v16su)(W), (__mmask16)(U),  \
                                                 _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_maskz_ipcvttps_epu8(U, A)                                       \
+#define _mm512_maskz_ipcvtts_ps_epu8(U, A)                                     \
   ((__m512i)__builtin_ia32_vcvttps2iubs512_mask(                               \
       (__v16sf)(__m512h)(A), (__v16su)_mm512_setzero_si512(), (__mmask16)(U),  \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm512_ipcvtt_roundps_epu8(A, S)                                       \
+#define _mm512_ipcvtts_roundps_epu8(A, S)                                      \
   ((__m512i)__builtin_ia32_vcvttps2iubs512_mask(                               \
-      (__v16sf)(__m512h)(A), (__v16su)_mm512_setzero_si512(), (__mmask16)-1,   \
+      (__v16sf)(__m512h)(A), (__v16su)_mm512_setzero_si512(), (__mmask16) - 1, \
       S))
 
-#define _mm512_mask_ipcvtt_roundps_epu8(W, U, A, S)                            \
+#define _mm512_mask_ipcvtts_roundps_epu8(W, U, A, S)                           \
   ((__m512i)__builtin_ia32_vcvttps2iubs512_mask(                               \
       (__v16sf)(__m512h)(A), (__v16su)(W), (__mmask16)(U), S))
 
-#define _mm512_maskz_ipcvtt_roundps_epu8(U, A, S)                              \
+#define _mm512_maskz_ipcvtts_roundps_epu8(U, A, S)                             \
   ((__m512i)__builtin_ia32_vcvttps2iubs512_mask(                               \
       (__v16sf)(__m512h)(A), (__v16su)_mm512_setzero_si512(), (__mmask16)(U),  \
       S))

--- a/clang/lib/Headers/avx10_2convertintrin.h
+++ b/clang/lib/Headers/avx10_2convertintrin.h
@@ -643,7 +643,7 @@ _mm256_maskz_cvtbiasph_bf8(__mmask16 __U, __m256i __A, __m256h __B) {
 ///    converted elements from \a __B using biases from \a __A; higher order
 ///    elements are zeroed.
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_cvtbiassph_bf8(__m128i __A, __m128h __B) {
+_mm_cvts_biasph_bf8(__m128i __A, __m128h __B) {
   return (__m128i)__builtin_ia32_vcvtbiasph2bf8s_128_mask(
       (__v16qi)__A, (__v8hf)__B, (__v16qi)_mm_undefined_si128(), (__mmask8)-1);
 }
@@ -682,7 +682,7 @@ _mm_cvtbiassph_bf8(__m128i __A, __m128h __B) {
 ///    converted elements from \a __B, using biases from \a __A; higher order
 ///    elements are zeroed. If corresponding mask bit is not set, then element
 ///    from \a __W is taken instead.
-static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_mask_cvtbiassph_bf8(__m128i
+static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_mask_cvts_biasph_bf8(__m128i
 		__W, __mmask8 __U, __m128i __A, __m128h __B) { return
 	(__m128i)__builtin_ia32_vcvtbiasph2bf8s_128_mask( (__v16qi)__A,
 			(__v8hf)__B, (__v16qi)(__m128i)__W, (__mmask8)__U); }
@@ -720,7 +720,7 @@ static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_mask_cvtbiassph_bf8(__m128i
 ///    elements are zeroed. If corresponding mask bit is not set, then element
 ///    is zeroed.
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_maskz_cvtbiassph_bf8(__mmask8 __U, __m128i __A, __m128h __B) {
+_mm_maskz_cvts_biasph_bf8(__mmask8 __U, __m128i __A, __m128h __B) {
   return (__m128i)__builtin_ia32_vcvtbiasph2bf8s_128_mask(
       (__v16qi)__A, (__v8hf)__B, (__v16qi)(__m128i)_mm_setzero_si128(),
       (__mmask8)__U);
@@ -751,7 +751,7 @@ _mm_maskz_cvtbiassph_bf8(__mmask8 __U, __m128i __A, __m128h __B) {
 ///    A 128-bit vector of [16 x bf8]. Elements correspond to the
 ///    converted elements from \a __B using biases from \a __A.
 static __inline__ __m128i __DEFAULT_FN_ATTRS256
-_mm256_cvtbiassph_bf8(__m256i __A, __m256h __B) {
+_mm256_cvts_biasph_bf8(__m256i __A, __m256h __B) {
   return (__m128i)__builtin_ia32_vcvtbiasph2bf8s_256_mask(
       (__v32qi)__A, (__v16hf)__B, (__v16qi)(__m128i)_mm_undefined_si128(),
       (__mmask16)-1);
@@ -790,7 +790,7 @@ _mm256_cvtbiassph_bf8(__m256i __A, __m256h __B) {
 ///    A 128-bit vector of [16 x bf8]. Elements correspond to the converted
 ///    elements from \a __B, using biases from \a __A. If corresponding mask bit
 ///    is not set, then element from \a __W is taken instead.
-static __inline__ __m128i __DEFAULT_FN_ATTRS256 _mm256_mask_cvtbiassph_bf8(
+static __inline__ __m128i __DEFAULT_FN_ATTRS256 _mm256_mask_cvts_biasph_bf8(
     __m128i __W, __mmask16 __U, __m256i __A, __m256h __B) {
   return (__m128i)__builtin_ia32_vcvtbiasph2bf8s_256_mask(
       (__v32qi)__A, (__v16hf)__B, (__v16qi)(__m128i)__W, (__mmask16)__U);
@@ -828,7 +828,7 @@ static __inline__ __m128i __DEFAULT_FN_ATTRS256 _mm256_mask_cvtbiassph_bf8(
 ///    elements from \a __B, using biases from \a __A. If corresponding mask bit
 ///    is not set, then element is zeroed.
 static __inline__ __m128i __DEFAULT_FN_ATTRS256
-_mm256_maskz_cvtbiassph_bf8(__mmask16 __U, __m256i __A, __m256h __B) {
+_mm256_maskz_cvts_biasph_bf8(__mmask16 __U, __m256i __A, __m256h __B) {
   return (__m128i)__builtin_ia32_vcvtbiasph2bf8s_256_mask(
       (__v32qi)__A, (__v16hf)__B, (__v16qi)(__m128i)_mm_setzero_si128(),
       (__mmask16)__U);
@@ -1075,7 +1075,7 @@ _mm256_maskz_cvtbiasph_hf8(__mmask16 __U, __m256i __A, __m256h __B) {
 ///    converted elements from \a __B using biases from \a __A; higher order
 ///    elements are zeroed.
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_cvtbiassph_hf8(__m128i __A, __m128h __B) {
+_mm_cvts_biasph_hf8(__m128i __A, __m128h __B) {
   return (__m128i)__builtin_ia32_vcvtbiasph2hf8s_128_mask(
       (__v16qi)__A, (__v8hf)__B, (__v16qi)_mm_undefined_si128(), (__mmask8)-1);
 }
@@ -1115,7 +1115,7 @@ _mm_cvtbiassph_hf8(__m128i __A, __m128h __B) {
 ///    elements are zeroed. If corresponding mask bit is not set, then element
 ///    from \a __W is taken instead.
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_mask_cvtbiassph_hf8(__m128i __W, __mmask8 __U, __m128i __A, __m128h __B) {
+_mm_mask_cvts_biasph_hf8(__m128i __W, __mmask8 __U, __m128i __A, __m128h __B) {
   return (__m128i)__builtin_ia32_vcvtbiasph2hf8s_128_mask(
       (__v16qi)__A, (__v8hf)__B, (__v16qi)(__m128i)__W, (__mmask8)__U);
 }
@@ -1153,7 +1153,7 @@ _mm_mask_cvtbiassph_hf8(__m128i __W, __mmask8 __U, __m128i __A, __m128h __B) {
 ///    elements are zeroed. If corresponding mask bit is not set, then element
 ///    is zeroed.
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_maskz_cvtbiassph_hf8(__mmask8 __U, __m128i __A, __m128h __B) {
+_mm_maskz_cvts_biasph_hf8(__mmask8 __U, __m128i __A, __m128h __B) {
   return (__m128i)__builtin_ia32_vcvtbiasph2hf8s_128_mask(
       (__v16qi)__A, (__v8hf)__B, (__v16qi)(__m128i)_mm_setzero_si128(),
       (__mmask8)__U);
@@ -1183,7 +1183,7 @@ _mm_maskz_cvtbiassph_hf8(__mmask8 __U, __m128i __A, __m128h __B) {
 ///    A 128-bit vector of [16 x hf8]. Elements correspond to the
 ///    converted elements from \a __B using biases from \a __A.
 static __inline__ __m128i __DEFAULT_FN_ATTRS256
-_mm256_cvtbiassph_hf8(__m256i __A, __m256h __B) {
+_mm256_cvts_biasph_hf8(__m256i __A, __m256h __B) {
   return (__m128i)__builtin_ia32_vcvtbiasph2hf8s_256_mask(
       (__v32qi)__A, (__v16hf)__B, (__v16qi)(__m128i)_mm_undefined_si128(),
       (__mmask16)-1);
@@ -1222,7 +1222,7 @@ _mm256_cvtbiassph_hf8(__m256i __A, __m256h __B) {
 ///    A 128-bit vector of [16 x hf8]. Elements correspond to the converted
 ///    elements from \a __B, using biases from \a __A. If corresponding mask bit
 ///    is not set, then element from \a __W is taken instead.
-static __inline__ __m128i __DEFAULT_FN_ATTRS256 _mm256_mask_cvtbiassph_hf8(
+static __inline__ __m128i __DEFAULT_FN_ATTRS256 _mm256_mask_cvts_biasph_hf8(
     __m128i __W, __mmask16 __U, __m256i __A, __m256h __B) {
   return (__m128i)__builtin_ia32_vcvtbiasph2hf8s_256_mask(
       (__v32qi)__A, (__v16hf)__B, (__v16qi)(__m128i)__W, (__mmask16)__U);
@@ -1260,7 +1260,7 @@ static __inline__ __m128i __DEFAULT_FN_ATTRS256 _mm256_mask_cvtbiassph_hf8(
 ///    elements from \a __B, using biases from \a __A. If corresponding mask bit
 ///    is not set, then element is zeroed.
 static __inline__ __m128i __DEFAULT_FN_ATTRS256
-_mm256_maskz_cvtbiassph_hf8(__mmask16 __U, __m256i __A, __m256h __B) {
+_mm256_maskz_cvts_biasph_hf8(__mmask16 __U, __m256i __A, __m256h __B) {
   return (__m128i)__builtin_ia32_vcvtbiasph2hf8s_256_mask(
       (__v32qi)__A, (__v16hf)__B, (__v16qi)(__m128i)_mm_setzero_si128(),
       (__mmask16)__U);

--- a/clang/lib/Headers/avx10_2convertintrin.h
+++ b/clang/lib/Headers/avx10_2convertintrin.h
@@ -1535,7 +1535,7 @@ _mm256_maskz_cvt2ph_bf8(__mmask32 __U, __m256h __A, __m256h __B) {
 ///    (converted) elements from \a __B; higher order elements correspond to the
 ///    (converted) elements from \a __A.
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_cvts2ph_bf8(__m128h __A, __m128h __B) {
+_mm_cvts_2ph_bf8(__m128h __A, __m128h __B) {
   return (__m128i)__builtin_ia32_vcvt2ph2bf8s_128((__v8hf)(__A),
                                                     (__v8hf)(__B));
 }
@@ -1579,9 +1579,9 @@ _mm_cvts2ph_bf8(__m128h __A, __m128h __B) {
 ///    (converted) elements from \a __A. If corresponding mask bit is not set, then
 ///    element from \a __W is taken instead.
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_mask_cvts2ph_bf8(__m128i __W, __mmask16 __U, __m128h __A, __m128h __B) {
+_mm_mask_cvts_2ph_bf8(__m128i __W, __mmask16 __U, __m128h __A, __m128h __B) {
   return (__m128i)__builtin_ia32_selectb_128(
-      (__mmask16)__U, (__v16qi)_mm_cvts2ph_bf8(__A, __B), (__v16qi)__W);
+      (__mmask16)__U, (__v16qi)_mm_cvts_2ph_bf8(__A, __B), (__v16qi)__W);
 }
 
 /// Convert two 128-bit vectors, \a __A and \a __B, containing packed FP16
@@ -1621,9 +1621,9 @@ _mm_mask_cvts2ph_bf8(__m128i __W, __mmask16 __U, __m128h __A, __m128h __B) {
 ///    (converted) elements from \a __A. If corresponding mask bit is not set, then
 ///    zero is taken instead.
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_maskz_cvts2ph_bf8(__mmask16 __U, __m128h __A, __m128h __B) {
+_mm_maskz_cvts_2ph_bf8(__mmask16 __U, __m128h __A, __m128h __B) {
   return (__m128i)__builtin_ia32_selectb_128(
-      (__mmask16)__U, (__v16qi)_mm_cvts2ph_bf8(__A, __B),
+      (__mmask16)__U, (__v16qi)_mm_cvts_2ph_bf8(__A, __B),
       (__v16qi)(__m128i)_mm_setzero_si128());
 }
 
@@ -1656,7 +1656,7 @@ _mm_maskz_cvts2ph_bf8(__mmask16 __U, __m128h __A, __m128h __B) {
 ///    (converted) elements from \a __B; higher order elements correspond to the
 ///    (converted) elements from \a __A.
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_cvts2ph_bf8(__m256h __A, __m256h __B) {
+_mm256_cvts_2ph_bf8(__m256h __A, __m256h __B) {
   return (__m256i)__builtin_ia32_vcvt2ph2bf8s_256((__v16hf)(__A),
                                                     (__v16hf)(__B));
 }
@@ -1699,10 +1699,10 @@ _mm256_cvts2ph_bf8(__m256h __A, __m256h __B) {
 ///    (converted) elements from \a __B; higher order elements correspond to the
 ///    (converted) elements from \a __A. If corresponding mask bit is not set, then
 ///    element from \a __W is taken instead.
-static __inline__ __m256i __DEFAULT_FN_ATTRS256 _mm256_mask_cvts2ph_bf8(
+static __inline__ __m256i __DEFAULT_FN_ATTRS256 _mm256_mask_cvts_2ph_bf8(
     __m256i __W, __mmask32 __U, __m256h __A, __m256h __B) {
   return (__m256i)__builtin_ia32_selectb_256(
-      (__mmask32)__U, (__v32qi)_mm256_cvts2ph_bf8(__A, __B), (__v32qi)__W);
+      (__mmask32)__U, (__v32qi)_mm256_cvts_2ph_bf8(__A, __B), (__v32qi)__W);
 }
 
 /// Convert two 256-bit vectors, \a __A and \a __B, containing packed FP16
@@ -1742,9 +1742,9 @@ static __inline__ __m256i __DEFAULT_FN_ATTRS256 _mm256_mask_cvts2ph_bf8(
 ///    (converted) elements from \a __A. If corresponding mask bit is not set,
 ///    zero is taken instead.
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_maskz_cvts2ph_bf8(__mmask32 __U, __m256h __A, __m256h __B) {
+_mm256_maskz_cvts_2ph_bf8(__mmask32 __U, __m256h __A, __m256h __B) {
   return (__m256i)__builtin_ia32_selectb_256(
-      (__mmask32)__U, (__v32qi)_mm256_cvts2ph_bf8(__A, __B),
+      (__mmask32)__U, (__v32qi)_mm256_cvts_2ph_bf8(__A, __B),
       (__v32qi)(__m256i)_mm256_setzero_si256());
 }
 
@@ -2017,7 +2017,7 @@ _mm256_maskz_cvt2ph_hf8(__mmask32 __U, __m256h __A, __m256h __B) {
 ///    (converted) elements from \a __B; higher order elements correspond to the
 ///    (converted) elements from \a __A.
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_cvts2ph_hf8(__m128h __A, __m128h __B) {
+_mm_cvts_2ph_hf8(__m128h __A, __m128h __B) {
   return (__m128i)__builtin_ia32_vcvt2ph2hf8s_128((__v8hf)(__A),
                                                     (__v8hf)(__B));
 }
@@ -2061,9 +2061,9 @@ _mm_cvts2ph_hf8(__m128h __A, __m128h __B) {
 ///    (converted) elements from \a __A. If corresponding mask bit is not set, then
 ///    element from \a __W is taken instead.
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_mask_cvts2ph_hf8(__m128i __W, __mmask16 __U, __m128h __A, __m128h __B) {
+_mm_mask_cvts_2ph_hf8(__m128i __W, __mmask16 __U, __m128h __A, __m128h __B) {
   return (__m128i)__builtin_ia32_selectb_128(
-      (__mmask16)__U, (__v16qi)_mm_cvts2ph_hf8(__A, __B), (__v16qi)__W);
+      (__mmask16)__U, (__v16qi)_mm_cvts_2ph_hf8(__A, __B), (__v16qi)__W);
 }
 
 /// Convert two 128-bit vectors, \a __A and \a __B, containing packed FP16
@@ -2103,9 +2103,9 @@ _mm_mask_cvts2ph_hf8(__m128i __W, __mmask16 __U, __m128h __A, __m128h __B) {
 ///    (converted) elements from \a __A. If corresponding mask bit is not set, then
 ///    zero is taken instead.
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_maskz_cvts2ph_hf8(__mmask16 __U, __m128h __A, __m128h __B) {
+_mm_maskz_cvts_2ph_hf8(__mmask16 __U, __m128h __A, __m128h __B) {
   return (__m128i)__builtin_ia32_selectb_128(
-      (__mmask16)__U, (__v16qi)_mm_cvts2ph_hf8(__A, __B),
+      (__mmask16)__U, (__v16qi)_mm_cvts_2ph_hf8(__A, __B),
       (__v16qi)(__m128i)_mm_setzero_si128());
 }
 
@@ -2138,7 +2138,7 @@ _mm_maskz_cvts2ph_hf8(__mmask16 __U, __m128h __A, __m128h __B) {
 ///    (converted) elements from \a __B; higher order elements correspond to the
 ///    (converted) elements from \a __A.
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_cvts2ph_hf8(__m256h __A, __m256h __B) {
+_mm256_cvts_2ph_hf8(__m256h __A, __m256h __B) {
   return (__m256i)__builtin_ia32_vcvt2ph2hf8s_256((__v16hf)(__A),
                                                     (__v16hf)(__B));
 }
@@ -2181,10 +2181,10 @@ _mm256_cvts2ph_hf8(__m256h __A, __m256h __B) {
 ///    (converted) elements from \a __B; higher order elements correspond to the
 ///    (converted) elements from \a __A. If corresponding mask bit is not set, then
 ///    element from \a __W is taken instead.
-static __inline__ __m256i __DEFAULT_FN_ATTRS256 _mm256_mask_cvts2ph_hf8(
+static __inline__ __m256i __DEFAULT_FN_ATTRS256 _mm256_mask_cvts_2ph_hf8(
     __m256i __W, __mmask32 __U, __m256h __A, __m256h __B) {
   return (__m256i)__builtin_ia32_selectb_256(
-      (__mmask32)__U, (__v32qi)_mm256_cvts2ph_hf8(__A, __B), (__v32qi)__W);
+      (__mmask32)__U, (__v32qi)_mm256_cvts_2ph_hf8(__A, __B), (__v32qi)__W);
 }
 
 /// Convert two 256-bit vectors, \a __A and \a __B, containing packed FP16
@@ -2224,9 +2224,9 @@ static __inline__ __m256i __DEFAULT_FN_ATTRS256 _mm256_mask_cvts2ph_hf8(
 ///    (converted) elements from \a __A. If corresponding mask bit is not set,
 ///    zero is taken instead.
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_maskz_cvts2ph_hf8(__mmask32 __U, __m256h __A, __m256h __B) {
+_mm256_maskz_cvts_2ph_hf8(__mmask32 __U, __m256h __A, __m256h __B) {
   return (__m256i)__builtin_ia32_selectb_256(
-      (__mmask32)__U, (__v32qi)_mm256_cvts2ph_hf8(__A, __B),
+      (__mmask32)__U, (__v32qi)_mm256_cvts_2ph_hf8(__A, __B),
       (__v32qi)(__m256i)_mm256_setzero_si256());
 }
 
@@ -2639,7 +2639,7 @@ _mm256_maskz_cvtph_bf8(__mmask16 __U, __m256h __A) {
 /// \returns
 ///    A 128-bit vector of [16 x bf8]. Lower elements correspond to the (converted)
 ///    elements from \a __A; upper elements are zeroed. 
-static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvtsph_bf8(__m128h __A) {
+static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvts_ph_bf8(__m128h __A) {
   return (__m128i)__builtin_ia32_vcvtph2bf8s_128_mask(
       (__v8hf)__A, (__v16qi)(__m128i)_mm_undefined_si128(), (__mmask8)-1);
 }
@@ -2676,7 +2676,7 @@ static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvtsph_bf8(__m128h __A) {
 ///    (converted) elements from \a __A; upper elements are zeroed. If
 ///    corresponding mask bit is not set, then element from \a __W is taken instead.
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_mask_cvtsph_bf8(__m128i __W, __mmask8 __U, __m128h __A) {
+_mm_mask_cvts_ph_bf8(__m128i __W, __mmask8 __U, __m128h __A) {
   return (__m128i)__builtin_ia32_vcvtph2bf8s_128_mask(
       (__v8hf)__A, (__v16qi)(__m128i)__W, (__mmask8)__U);
 }
@@ -2711,7 +2711,7 @@ _mm_mask_cvtsph_bf8(__m128i __W, __mmask8 __U, __m128h __A) {
 ///    (converted) elements from \a __A; upper elements are zeroed. If
 ///    corresponding mask bit is not set, then element is zeroed.
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_maskz_cvtsph_bf8(__mmask8 __U, __m128h __A) {
+_mm_maskz_cvts_ph_bf8(__mmask8 __U, __m128h __A) {
   return (__m128i)__builtin_ia32_vcvtph2bf8s_128_mask(
       (__v8hf)__A, (__v16qi)(__m128i)_mm_setzero_si128(), (__mmask8)__U);
 }
@@ -2737,7 +2737,7 @@ _mm_maskz_cvtsph_bf8(__mmask8 __U, __m128h __A) {
 ///    A 128-bit vector of [16 x bf8]. Resulting elements correspond to the (converted)
 ///    elements from \a __A.
 static __inline__ __m128i __DEFAULT_FN_ATTRS256
-_mm256_cvtsph_bf8(__m256h __A) {
+_mm256_cvts_ph_bf8(__m256h __A) {
   return (__m128i)__builtin_ia32_vcvtph2bf8s_256_mask(
       (__v16hf)__A, (__v16qi)(__m128i)_mm_undefined_si128(), (__mmask16)-1);
 }
@@ -2774,7 +2774,7 @@ _mm256_cvtsph_bf8(__m256h __A) {
 ///    (converted) elements from \a __A. If
 ///    corresponding mask bit is not set, then element from \a __W is taken instead.
 static __inline__ __m128i __DEFAULT_FN_ATTRS256
-_mm256_mask_cvtsph_bf8(__m128i __W, __mmask16 __U, __m256h __A) {
+_mm256_mask_cvts_ph_bf8(__m128i __W, __mmask16 __U, __m256h __A) {
   return (__m128i)__builtin_ia32_vcvtph2bf8s_256_mask(
       (__v16hf)__A, (__v16qi)(__m128i)__W, (__mmask16)__U);
 }
@@ -2809,7 +2809,7 @@ _mm256_mask_cvtsph_bf8(__m128i __W, __mmask16 __U, __m256h __A) {
 ///    (converted) elements from \a __A. If corresponding mask bit is not set,
 ///    then element is zeroed instead.
 static __inline__ __m128i __DEFAULT_FN_ATTRS256
-_mm256_maskz_cvtsph_bf8(__mmask16 __U, __m256h __A) {
+_mm256_maskz_cvts_ph_bf8(__mmask16 __U, __m256h __A) {
   return (__m128i)__builtin_ia32_vcvtph2bf8s_256_mask(
       (__v16hf)__A, (__v16qi)(__m128i)_mm_setzero_si128(), (__mmask16)__U);
 }
@@ -3029,7 +3029,7 @@ _mm256_maskz_cvtph_hf8(__mmask16 __U, __m256h __A) {
 /// \returns
 ///    A 128-bit vector of [16 x hf8]. Lower elements correspond to the (converted)
 ///    elements from \a __A; upper elements are zeroed. 
-static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvtsph_hf8(__m128h __A) {
+static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvts_ph_hf8(__m128h __A) {
   return (__m128i)__builtin_ia32_vcvtph2hf8s_128_mask(
       (__v8hf)__A, (__v16qi)(__m128i)_mm_undefined_si128(), (__mmask8)-1);
 }
@@ -3066,7 +3066,7 @@ static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvtsph_hf8(__m128h __A) {
 ///    (converted) elements from \a __A; upper elements are zeroed. If
 ///    corresponding mask bit is not set, then element from \a __W is taken instead.
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_mask_cvtsph_hf8(__m128i __W, __mmask8 __U, __m128h __A) {
+_mm_mask_cvts_ph_hf8(__m128i __W, __mmask8 __U, __m128h __A) {
   return (__m128i)__builtin_ia32_vcvtph2hf8s_128_mask(
       (__v8hf)__A, (__v16qi)(__m128i)__W, (__mmask8)__U);
 }
@@ -3101,7 +3101,7 @@ _mm_mask_cvtsph_hf8(__m128i __W, __mmask8 __U, __m128h __A) {
 ///    (converted) elements from \a __A; upper elements are zeroed. If
 ///    corresponding mask bit is not set, then element is zeroed.
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_maskz_cvtsph_hf8(__mmask8 __U, __m128h __A) {
+_mm_maskz_cvts_ph_hf8(__mmask8 __U, __m128h __A) {
   return (__m128i)__builtin_ia32_vcvtph2hf8s_128_mask(
       (__v8hf)__A, (__v16qi)(__m128i)_mm_setzero_si128(), (__mmask8)__U);
 }
@@ -3127,7 +3127,7 @@ _mm_maskz_cvtsph_hf8(__mmask8 __U, __m128h __A) {
 ///    A 128-bit vector of [16 x hf8]. Resulting elements correspond to the (converted)
 ///    elements from \a __A.
 static __inline__ __m128i __DEFAULT_FN_ATTRS256
-_mm256_cvtsph_hf8(__m256h __A) {
+_mm256_cvts_ph_hf8(__m256h __A) {
   return (__m128i)__builtin_ia32_vcvtph2hf8s_256_mask(
       (__v16hf)__A, (__v16qi)(__m128i)_mm_undefined_si128(), (__mmask16)-1);
 }
@@ -3164,7 +3164,7 @@ _mm256_cvtsph_hf8(__m256h __A) {
 ///    (converted) elements from \a __A. If
 ///    corresponding mask bit is not set, then element from \a __W is taken instead.
 static __inline__ __m128i __DEFAULT_FN_ATTRS256
-_mm256_mask_cvtsph_hf8(__m128i __W, __mmask16 __U, __m256h __A) {
+_mm256_mask_cvts_ph_hf8(__m128i __W, __mmask16 __U, __m256h __A) {
   return (__m128i)__builtin_ia32_vcvtph2hf8s_256_mask(
       (__v16hf)__A, (__v16qi)(__m128i)__W, (__mmask16)__U);
 }
@@ -3199,7 +3199,7 @@ _mm256_mask_cvtsph_hf8(__m128i __W, __mmask16 __U, __m256h __A) {
 ///    (converted) elements from \a __A. If corresponding mask bit is not set,
 ///    then element is zeroed instead.
 static __inline__ __m128i __DEFAULT_FN_ATTRS256
-_mm256_maskz_cvtsph_hf8(__mmask16 __U, __m256h __A) {
+_mm256_maskz_cvts_ph_hf8(__mmask16 __U, __m256h __A) {
   return (__m128i)__builtin_ia32_vcvtph2hf8s_256_mask(
       (__v16hf)__A, (__v16qi)(__m128i)_mm_setzero_si128(), (__mmask16)__U);
 }

--- a/clang/lib/Headers/avx10_2satcvtdsintrin.h
+++ b/clang/lib/Headers/avx10_2satcvtdsintrin.h
@@ -71,39 +71,40 @@
 #endif /* __x86_64__ */
 
 // 128 Bit : Double -> int
-static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvttspd_epi32(__m128d __A) {
+static __inline__ __m128i __DEFAULT_FN_ATTRS128
+_mm_cvtts_pd_epi32(__m128d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2dqs128_mask(
       (__v2df)__A, (__v4si)(__m128i)_mm_undefined_si128(), (__mmask8)(-1)));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_mask_cvttspd_epi32(__m128i __W, __mmask8 __U, __m128d __A) {
+_mm_mask_cvtts_pd_epi32(__m128i __W, __mmask8 __U, __m128d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2dqs128_mask((__v2df)__A, (__v4si)__W,
                                                       __U));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_maskz_cvttspd_epi32(__mmask16 __U, __m128d __A) {
+_mm_maskz_cvtts_pd_epi32(__mmask16 __U, __m128d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2dqs128_mask(
       (__v2df)__A, (__v4si)(__m128i)_mm_setzero_si128(), __U));
 }
 
 // 256 Bit : Double -> int
 static __inline__ __m128i __DEFAULT_FN_ATTRS256
-_mm256_cvttspd_epi32(__m256d __A) {
+_mm256_cvtts_pd_epi32(__m256d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2dqs256_round_mask(
       (__v4df)__A, (__v4si)_mm_undefined_si128(), (__mmask8)-1,
       _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS256
-_mm256_mask_cvttspd_epi32(__m128i __W, __mmask8 __U, __m256d __A) {
+_mm256_mask_cvtts_pd_epi32(__m128i __W, __mmask8 __U, __m256d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2dqs256_round_mask(
       (__v4df)__A, (__v4si)__W, __U, _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS256
-_mm256_maskz_cvttspd_epi32(__mmask8 __U, __m256d __A) {
+_mm256_maskz_cvtts_pd_epi32(__mmask8 __U, __m256d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2dqs256_round_mask(
       (__v4df)__A, (__v4si)_mm_setzero_si128(), __U, _MM_FROUND_CUR_DIRECTION));
 }
@@ -123,39 +124,40 @@ _mm256_maskz_cvttspd_epi32(__mmask8 __U, __m256d __A) {
       (__mmask8)__U, (int)(__R)))
 
 // 128 Bit : Double -> uint
-static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvttspd_epu32(__m128d __A) {
+static __inline__ __m128i __DEFAULT_FN_ATTRS128
+_mm_cvtts_pd_epu32(__m128d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2udqs128_mask(
       (__v2df)__A, (__v4si)(__m128i)_mm_undefined_si128(), (__mmask8)(-1)));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_mask_cvttspd_epu32(__m128i __W, __mmask8 __U, __m128d __A) {
+_mm_mask_cvtts_pd_epu32(__m128i __W, __mmask8 __U, __m128d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2udqs128_mask(
       (__v2df)__A, (__v4si)(__m128i)__W, (__mmask8)__U));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_maskz_cvttspd_epu32(__mmask8 __U, __m128d __A) {
+_mm_maskz_cvtts_pd_epu32(__mmask8 __U, __m128d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2udqs128_mask(
       (__v2df)__A, (__v4si)(__m128i)_mm_setzero_si128(), __U));
 }
 
 // 256 Bit : Double -> uint
 static __inline__ __m128i __DEFAULT_FN_ATTRS256
-_mm256_cvttspd_epu32(__m256d __A) {
+_mm256_cvtts_pd_epu32(__m256d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2udqs256_round_mask(
       (__v4df)__A, (__v4si)_mm_undefined_si128(), (__mmask8)-1,
       _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS256
-_mm256_mask_cvttspd_epu32(__m128i __W, __mmask8 __U, __m256d __A) {
+_mm256_mask_cvtts_pd_epu32(__m128i __W, __mmask8 __U, __m256d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2udqs256_round_mask(
       (__v4df)__A, (__v4si)__W, __U, _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS256
-_mm256_maskz_cvttspd_epu32(__mmask8 __U, __m256d __A) {
+_mm256_maskz_cvtts_pd_epu32(__mmask8 __U, __m256d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2udqs256_round_mask(
       (__v4df)__A, (__v4si)_mm_setzero_si128(), __U, _MM_FROUND_CUR_DIRECTION));
 }
@@ -175,39 +177,40 @@ _mm256_maskz_cvttspd_epu32(__mmask8 __U, __m256d __A) {
       (__mmask8)__U, (int)(__R)))
 
 // 128 Bit : Double -> long
-static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvttspd_epi64(__m128d __A) {
+static __inline__ __m128i __DEFAULT_FN_ATTRS128
+_mm_cvtts_pd_epi64(__m128d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2qqs128_mask(
       (__v2df)__A, (__v2di)_mm_undefined_si128(), (__mmask8)-1));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_mask_cvttspd_epi64(__m128i __W, __mmask8 __U, __m128d __A) {
+_mm_mask_cvtts_pd_epi64(__m128i __W, __mmask8 __U, __m128d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2qqs128_mask((__v2df)__A, (__v2di)__W,
                                                       (__mmask8)__U));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_maskz_cvttspd_epi64(__mmask8 __U, __m128d __A) {
+_mm_maskz_cvtts_pd_epi64(__mmask8 __U, __m128d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2qqs128_mask(
       (__v2df)__A, (__v2di)_mm_setzero_si128(), (__mmask8)__U));
 }
 
 // 256 Bit : Double -> long
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_cvttspd_epi64(__m256d __A) {
+_mm256_cvtts_pd_epi64(__m256d __A) {
   return ((__m256i)__builtin_ia32_vcvttpd2qqs256_round_mask(
       (__v4df)__A, (__v4di)_mm256_undefined_si256(), (__mmask8)-1,
       _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_mask_cvttspd_epi64(__m256i __W, __mmask8 __U, __m256d __A) {
+_mm256_mask_cvtts_pd_epi64(__m256i __W, __mmask8 __U, __m256d __A) {
   return ((__m256i)__builtin_ia32_vcvttpd2qqs256_round_mask(
       (__v4df)__A, (__v4di)__W, __U, _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_maskz_cvttspd_epi64(__mmask8 __U, __m256d __A) {
+_mm256_maskz_cvtts_pd_epi64(__mmask8 __U, __m256d __A) {
   return ((__m256i)__builtin_ia32_vcvttpd2qqs256_round_mask(
       (__v4df)__A, (__v4di)_mm256_setzero_si256(), __U,
       _MM_FROUND_CUR_DIRECTION));
@@ -227,19 +230,20 @@ _mm256_maskz_cvttspd_epi64(__mmask8 __U, __m256d __A) {
       (__v4df)__A, (__v4di)_mm256_setzero_si256(), (__mmask8)__U, (int)__R))
 
 // 128 Bit : Double -> ulong
-static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvttspd_epu64(__m128d __A) {
+static __inline__ __m128i __DEFAULT_FN_ATTRS128
+_mm_cvtts_pd_epu64(__m128d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2uqqs128_mask(
       (__v2df)__A, (__v2di)_mm_undefined_si128(), (__mmask8)-1));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_mask_cvttspd_epu64(__m128i __W, __mmask8 __U, __m128d __A) {
+_mm_mask_cvtts_pd_epu64(__m128i __W, __mmask8 __U, __m128d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2uqqs128_mask((__v2df)__A, (__v2di)__W,
                                                        (__mmask8)__U));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_maskz_cvttspd_epu64(__mmask8 __U, __m128d __A) {
+_mm_maskz_cvtts_pd_epu64(__mmask8 __U, __m128d __A) {
   return ((__m128i)__builtin_ia32_vcvttpd2uqqs128_mask(
       (__v2df)__A, (__v2di)_mm_setzero_si128(), (__mmask8)__U));
 }
@@ -247,20 +251,20 @@ _mm_maskz_cvttspd_epu64(__mmask8 __U, __m128d __A) {
 // 256 Bit : Double -> ulong
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_cvttspd_epu64(__m256d __A) {
+_mm256_cvtts_pd_epu64(__m256d __A) {
   return ((__m256i)__builtin_ia32_vcvttpd2uqqs256_round_mask(
       (__v4df)__A, (__v4di)_mm256_undefined_si256(), (__mmask8)-1,
       _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_mask_cvttspd_epu64(__m256i __W, __mmask8 __U, __m256d __A) {
+_mm256_mask_cvtts_pd_epu64(__m256i __W, __mmask8 __U, __m256d __A) {
   return ((__m256i)__builtin_ia32_vcvttpd2uqqs256_round_mask(
       (__v4df)__A, (__v4di)__W, __U, _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_maskz_cvttspd_epu64(__mmask8 __U, __m256d __A) {
+_mm256_maskz_cvtts_pd_epu64(__mmask8 __U, __m256d __A) {
   return ((__m256i)__builtin_ia32_vcvttpd2uqqs256_round_mask(
       (__v4df)__A, (__v4di)_mm256_setzero_si256(), __U,
       _MM_FROUND_CUR_DIRECTION));
@@ -280,39 +284,39 @@ _mm256_maskz_cvttspd_epu64(__mmask8 __U, __m256d __A) {
       (__v4df)__A, (__v4di)_mm256_setzero_si256(), (__mmask8)__U, (int)__R))
 
 // 128 Bit : float -> int
-static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvttsps_epi32(__m128 __A) {
+static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvtts_ps_epi32(__m128 __A) {
   return ((__m128i)__builtin_ia32_vcvttps2dqs128_mask(
       (__v4sf)__A, (__v4si)(__m128i)_mm_undefined_si128(), (__mmask8)(-1)));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_mask_cvttsps_epi32(__m128i __W, __mmask8 __U, __m128 __A) {
+_mm_mask_cvtts_ps_epi32(__m128i __W, __mmask8 __U, __m128 __A) {
   return ((__m128i)__builtin_ia32_vcvttps2dqs128_mask((__v4sf)__A, (__v4si)__W,
                                                       (__mmask8)__U));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_maskz_cvttsps_epi32(__mmask8 __U, __m128 __A) {
+_mm_maskz_cvtts_ps_epi32(__mmask8 __U, __m128 __A) {
   return ((__m128i)__builtin_ia32_vcvttps2dqs128_mask(
       (__v4sf)__A, (__v4si)(__m128i)_mm_setzero_si128(), (__mmask8)__U));
 }
 
 // 256 Bit : float -> int
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_cvttsps_epi32(__m256 __A) {
+_mm256_cvtts_ps_epi32(__m256 __A) {
   return ((__m256i)__builtin_ia32_vcvttps2dqs256_round_mask(
       (__v8sf)__A, (__v8si)_mm256_undefined_si256(), (__mmask8)-1,
       _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_mask_cvttsps_epi32(__m256i __W, __mmask8 __U, __m256 __A) {
+_mm256_mask_cvtts_ps_epi32(__m256i __W, __mmask8 __U, __m256 __A) {
   return ((__m256i)__builtin_ia32_vcvttps2dqs256_round_mask(
       (__v8sf)__A, (__v8si)__W, __U, _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_maskz_cvttsps_epi32(__mmask8 __U, __m256 __A) {
+_mm256_maskz_cvtts_ps_epi32(__mmask8 __U, __m256 __A) {
   return ((__m256i)__builtin_ia32_vcvttps2dqs256_round_mask(
       (__v8sf)__A, (__v8si)_mm256_setzero_si256(), __U,
       _MM_FROUND_CUR_DIRECTION));
@@ -333,19 +337,19 @@ _mm256_maskz_cvttsps_epi32(__mmask8 __U, __m256 __A) {
       (__mmask8)__U, (int)(__R)))
 
 // 128 Bit : float -> uint
-static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvttsps_epu32(__m128 __A) {
+static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvtts_ps_epu32(__m128 __A) {
   return ((__m128i)__builtin_ia32_vcvttps2udqs128_mask(
       (__v4sf)__A, (__v4si)(__m128i)_mm_undefined_si128(), (__mmask8)(-1)));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_mask_cvttsps_epu32(__m128i __W, __mmask8 __U, __m128 __A) {
+_mm_mask_cvtts_ps_epu32(__m128i __W, __mmask8 __U, __m128 __A) {
   return ((__m128i)__builtin_ia32_vcvttps2udqs128_mask((__v4sf)__A, (__v4si)__W,
                                                        (__mmask8)__U));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_maskz_cvttsps_epu32(__mmask8 __U, __m128 __A) {
+_mm_maskz_cvtts_ps_epu32(__mmask8 __U, __m128 __A) {
   return ((__m128i)__builtin_ia32_vcvttps2udqs128_mask(
       (__v4sf)__A, (__v4si)_mm_setzero_si128(), (__mmask8)__U));
 }
@@ -353,20 +357,20 @@ _mm_maskz_cvttsps_epu32(__mmask8 __U, __m128 __A) {
 // 256 Bit : float -> uint
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_cvttsps_epu32(__m256 __A) {
+_mm256_cvtts_ps_epu32(__m256 __A) {
   return ((__m256i)__builtin_ia32_vcvttps2udqs256_round_mask(
       (__v8sf)__A, (__v8si)_mm256_undefined_si256(), (__mmask8)-1,
       _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_mask_cvttsps_epu32(__m256i __W, __mmask8 __U, __m256 __A) {
+_mm256_mask_cvtts_ps_epu32(__m256i __W, __mmask8 __U, __m256 __A) {
   return ((__m256i)__builtin_ia32_vcvttps2udqs256_round_mask(
       (__v8sf)__A, (__v8si)__W, __U, _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_maskz_cvttsps_epu32(__mmask8 __U, __m256 __A) {
+_mm256_maskz_cvtts_ps_epu32(__mmask8 __U, __m256 __A) {
   return ((__m256i)__builtin_ia32_vcvttps2udqs256_round_mask(
       (__v8sf)__A, (__v8si)_mm256_setzero_si256(), __U,
       _MM_FROUND_CUR_DIRECTION));
@@ -387,38 +391,38 @@ _mm256_maskz_cvttsps_epu32(__mmask8 __U, __m256 __A) {
       (__mmask8)__U, (int)(__R)))
 
 // 128 bit : float -> long
-static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvttsps_epi64(__m128 __A) {
+static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvtts_ps_epi64(__m128 __A) {
   return ((__m128i)__builtin_ia32_vcvttps2qqs128_mask(
       (__v4sf)__A, (__v2di)_mm_undefined_si128(), (__mmask8)-1));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_mask_cvttsps_epi64(__m128i __W, __mmask8 __U, __m128 __A) {
+_mm_mask_cvtts_ps_epi64(__m128i __W, __mmask8 __U, __m128 __A) {
   return ((__m128i)__builtin_ia32_vcvttps2qqs128_mask(
       (__v4sf)__A, (__v2di)(__m128i)__W, (__mmask8)__U));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_maskz_cvttsps_epi64(__mmask8 __U, __m128 __A) {
+_mm_maskz_cvtts_ps_epi64(__mmask8 __U, __m128 __A) {
   return ((__m128i)__builtin_ia32_vcvttps2qqs128_mask(
       (__v4sf)__A, (__v2di)_mm_setzero_si128(), (__mmask8)__U));
 }
 // 256 bit : float -> long
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_cvttsps_epi64(__m128 __A) {
+_mm256_cvtts_ps_epi64(__m128 __A) {
   return ((__m256i)__builtin_ia32_vcvttps2qqs256_round_mask(
       (__v4sf)__A, (__v4di)_mm256_undefined_si256(), (__mmask8)-1,
       _MM_FROUND_CUR_DIRECTION));
 }
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_mask_cvttsps_epi64(__m256i __W, __mmask8 __U, __m128 __A) {
+_mm256_mask_cvtts_ps_epi64(__m256i __W, __mmask8 __U, __m128 __A) {
   return ((__m256i)__builtin_ia32_vcvttps2qqs256_round_mask(
       (__v4sf)__A, (__v4di)__W, __U, _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_maskz_cvttsps_epi64(__mmask8 __U, __m128 __A) {
+_mm256_maskz_cvtts_ps_epi64(__mmask8 __U, __m128 __A) {
   return ((__m256i)__builtin_ia32_vcvttps2qqs256_round_mask(
       (__v4sf)__A, (__v4di)_mm256_setzero_si256(), __U,
       _MM_FROUND_CUR_DIRECTION));
@@ -439,39 +443,39 @@ _mm256_maskz_cvttsps_epi64(__mmask8 __U, __m128 __A) {
       (int)__R))
 
 // 128 bit : float -> ulong
-static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvttsps_epu64(__m128 __A) {
+static __inline__ __m128i __DEFAULT_FN_ATTRS128 _mm_cvtts_ps_epu64(__m128 __A) {
   return ((__m128i)__builtin_ia32_vcvttps2uqqs128_mask(
       (__v4sf)__A, (__v2di)_mm_undefined_si128(), (__mmask8)-1));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_mask_cvttsps_epu64(__m128i __W, __mmask8 __U, __m128 __A) {
+_mm_mask_cvtts_ps_epu64(__m128i __W, __mmask8 __U, __m128 __A) {
   return ((__m128i)__builtin_ia32_vcvttps2uqqs128_mask(
       (__v4sf)__A, (__v2di)(__m128i)__W, (__mmask8)__U));
 }
 
 static __inline__ __m128i __DEFAULT_FN_ATTRS128
-_mm_maskz_cvttsps_epu64(__mmask8 __U, __m128 __A) {
+_mm_maskz_cvtts_ps_epu64(__mmask8 __U, __m128 __A) {
   return ((__m128i)__builtin_ia32_vcvttps2uqqs128_mask(
       (__v4sf)__A, (__v2di)_mm_setzero_si128(), (__mmask8)__U));
 }
 // 256 bit : float -> ulong
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_cvttsps_epu64(__m128 __A) {
+_mm256_cvtts_ps_epu64(__m128 __A) {
   return ((__m256i)__builtin_ia32_vcvttps2uqqs256_round_mask(
       (__v4sf)__A, (__v4di)_mm256_undefined_si256(), (__mmask8)-1,
       _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_mask_cvttsps_epu64(__m256i __W, __mmask8 __U, __m128 __A) {
+_mm256_mask_cvtts_ps_epu64(__m256i __W, __mmask8 __U, __m128 __A) {
   return ((__m256i)__builtin_ia32_vcvttps2uqqs256_round_mask(
       (__v4sf)__A, (__v4di)__W, __U, _MM_FROUND_CUR_DIRECTION));
 }
 
 static __inline__ __m256i __DEFAULT_FN_ATTRS256
-_mm256_maskz_cvttsps_epu64(__mmask8 __U, __m128 __A) {
+_mm256_maskz_cvtts_ps_epu64(__mmask8 __U, __m128 __A) {
   return ((__m256i)__builtin_ia32_vcvttps2uqqs256_round_mask(
       (__v4sf)__A, (__v4di)_mm256_setzero_si256(), __U,
       _MM_FROUND_CUR_DIRECTION));

--- a/clang/lib/Headers/avx10_2satcvtintrin.h
+++ b/clang/lib/Headers/avx10_2satcvtintrin.h
@@ -14,430 +14,430 @@
 #ifndef __AVX10_2SATCVTINTRIN_H
 #define __AVX10_2SATCVTINTRIN_H
 
-#define _mm_ipcvtbf16_epi8(A)                                                  \
+#define _mm_ipcvts_bf16_epi8(A)                                                \
   ((__m128i)__builtin_ia32_vcvtbf162ibs128((__v8bf)(__m128bh)(A)))
 
-#define _mm_mask_ipcvtbf16_epi8(W, U, A)                                       \
+#define _mm_mask_ipcvts_bf16_epi8(W, U, A)                                     \
   ((__m128i)__builtin_ia32_selectw_128(                                        \
-      (__mmask8)(U), (__v8hi)_mm_ipcvtbf16_epi8(A), (__v8hi)(__m128i)(W)))
+      (__mmask8)(U), (__v8hi)_mm_ipcvts_bf16_epi8(A), (__v8hi)(__m128i)(W)))
 
-#define _mm_maskz_ipcvtbf16_epi8(U, A)                                         \
+#define _mm_maskz_ipcvts_bf16_epi8(U, A)                                       \
   ((__m128i)__builtin_ia32_selectw_128((__mmask8)(U),                          \
-                                       (__v8hi)_mm_ipcvtbf16_epi8(A),          \
+                                       (__v8hi)_mm_ipcvts_bf16_epi8(A),        \
                                        (__v8hi)_mm_setzero_si128()))
 
-#define _mm256_ipcvtbf16_epi8(A)                                               \
+#define _mm256_ipcvts_bf16_epi8(A)                                             \
   ((__m256i)__builtin_ia32_vcvtbf162ibs256((__v16bf)(__m256bh)(A)))
 
-#define _mm256_mask_ipcvtbf16_epi8(W, U, A)                                    \
+#define _mm256_mask_ipcvts_bf16_epi8(W, U, A)                                  \
   ((__m256i)__builtin_ia32_selectw_256((__mmask16)(U),                         \
-                                       (__v16hi)_mm256_ipcvtbf16_epi8(A),      \
+                                       (__v16hi)_mm256_ipcvts_bf16_epi8(A),    \
                                        (__v16hi)(__m256i)(W)))
 
-#define _mm256_maskz_ipcvtbf16_epi8(U, A)                                      \
+#define _mm256_maskz_ipcvts_bf16_epi8(U, A)                                    \
   ((__m256i)__builtin_ia32_selectw_256((__mmask16)(U),                         \
-                                       (__v16hi)_mm256_ipcvtbf16_epi8(A),      \
+                                       (__v16hi)_mm256_ipcvts_bf16_epi8(A),    \
                                        (__v16hi)_mm256_setzero_si256()))
 
-#define _mm_ipcvtbf16_epu8(A)                                                  \
+#define _mm_ipcvts_bf16_epu8(A)                                                \
   ((__m128i)__builtin_ia32_vcvtbf162iubs128((__v8bf)(__m128bh)(A)))
 
-#define _mm_mask_ipcvtbf16_epu8(W, U, A)                                       \
+#define _mm_mask_ipcvts_bf16_epu8(W, U, A)                                     \
   ((__m128i)__builtin_ia32_selectw_128(                                        \
-      (__mmask8)(U), (__v8hi)_mm_ipcvtbf16_epu8(A), (__v8hi)(__m128i)(W)))
+      (__mmask8)(U), (__v8hi)_mm_ipcvts_bf16_epu8(A), (__v8hi)(__m128i)(W)))
 
-#define _mm_maskz_ipcvtbf16_epu8(U, A)                                         \
+#define _mm_maskz_ipcvts_bf16_epu8(U, A)                                       \
   ((__m128i)__builtin_ia32_selectw_128((__mmask8)(U),                          \
-                                       (__v8hi)_mm_ipcvtbf16_epu8(A),          \
+                                       (__v8hi)_mm_ipcvts_bf16_epu8(A),        \
                                        (__v8hi)_mm_setzero_si128()))
 
-#define _mm256_ipcvtbf16_epu8(A)                                               \
+#define _mm256_ipcvts_bf16_epu8(A)                                             \
   ((__m256i)__builtin_ia32_vcvtbf162iubs256((__v16bf)(__m256bh)(A)))
 
-#define _mm256_mask_ipcvtbf16_epu8(W, U, A)                                    \
+#define _mm256_mask_ipcvts_bf16_epu8(W, U, A)                                  \
   ((__m256i)__builtin_ia32_selectw_256((__mmask16)(U),                         \
-                                       (__v16hi)_mm256_ipcvtbf16_epu8(A),      \
+                                       (__v16hi)_mm256_ipcvts_bf16_epu8(A),    \
                                        (__v16hi)(__m256i)(W)))
 
-#define _mm256_maskz_ipcvtbf16_epu8(U, A)                                      \
+#define _mm256_maskz_ipcvts_bf16_epu8(U, A)                                    \
   ((__m256i)__builtin_ia32_selectw_256((__mmask16)(U),                         \
-                                       (__v16hi)_mm256_ipcvtbf16_epu8(A),      \
+                                       (__v16hi)_mm256_ipcvts_bf16_epu8(A),    \
                                        (__v16hi)_mm256_setzero_si256()))
 
-#define _mm_ipcvtph_epi8(A)                                                    \
+#define _mm_ipcvts_ph_epi8(A)                                                  \
   ((__m128i)__builtin_ia32_vcvtph2ibs128_mask(                                 \
-      (__v8hf)(__m128h)(A), (__v8hu)_mm_setzero_si128(), (__mmask8)-1))
+      (__v8hf)(__m128h)(A), (__v8hu)_mm_setzero_si128(), (__mmask8) - 1))
 
-#define _mm_mask_ipcvtph_epi8(W, U, A)                                         \
+#define _mm_mask_ipcvts_ph_epi8(W, U, A)                                       \
   ((__m128i)__builtin_ia32_vcvtph2ibs128_mask((__v8hf)(__m128h)(A),            \
                                               (__v8hu)(W), (__mmask8)(U)))
 
-#define _mm_maskz_ipcvtph_epi8(U, A)                                           \
+#define _mm_maskz_ipcvts_ph_epi8(U, A)                                         \
   ((__m128i)__builtin_ia32_vcvtph2ibs128_mask(                                 \
       (__v8hf)(__m128h)(A), (__v8hu)(_mm_setzero_si128()), (__mmask8)(U)))
 
-#define _mm256_ipcvtph_epi8(A)                                                 \
+#define _mm256_ipcvts_ph_epi8(A)                                               \
   ((__m256i)__builtin_ia32_vcvtph2ibs256_mask(                                 \
-      (__v16hf)(__m256h)(A), (__v16hu)_mm256_setzero_si256(), (__mmask16)-1,   \
+      (__v16hf)(__m256h)(A), (__v16hu)_mm256_setzero_si256(), (__mmask16) - 1, \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_mask_ipcvtph_epi8(W, U, A)                                      \
+#define _mm256_mask_ipcvts_ph_epi8(W, U, A)                                    \
   ((__m256i)__builtin_ia32_vcvtph2ibs256_mask((__v16hf)(__m256h)(A),           \
                                               (__v16hu)(W), (__mmask16)(U),    \
                                               _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_maskz_ipcvtph_epi8(U, A)                                        \
+#define _mm256_maskz_ipcvts_ph_epi8(U, A)                                      \
   ((__m256i)__builtin_ia32_vcvtph2ibs256_mask(                                 \
       (__v16hf)(__m256h)(A), (__v16hu)(_mm256_setzero_si256()),                \
       (__mmask16)(U), _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_ipcvt_roundph_epi8(A, R)                                        \
+#define _mm256_ipcvts_roundph_epi8(A, R)                                       \
   ((__m256i)__builtin_ia32_vcvtph2ibs256_mask((__v16hf)(__m256h)(A),           \
                                               (__v16hu)_mm256_setzero_si256(), \
-                                              (__mmask16)-1, (const int)R))
+                                              (__mmask16) - 1, (const int)R))
 
-#define _mm256_mask_ipcvt_roundph_epi8(W, U, A, R)                             \
+#define _mm256_mask_ipcvts_roundph_epi8(W, U, A, R)                            \
   ((__m256i)__builtin_ia32_vcvtph2ibs256_mask(                                 \
       (__v16hf)(__m256h)(A), (__v16hu)(W), (__mmask16)(U), (const int)R))
 
-#define _mm256_maskz_ipcvt_roundph_epi8(U, A, R)                               \
+#define _mm256_maskz_ipcvts_roundph_epi8(U, A, R)                              \
   ((__m256i)__builtin_ia32_vcvtph2ibs256_mask((__v16hf)(__m256h)(A),           \
                                               (__v16hu)_mm256_setzero_si256(), \
                                               (__mmask16)(U), (const int)R))
 
-#define _mm_ipcvtph_epu8(A)                                                    \
+#define _mm_ipcvts_ph_epu8(A)                                                  \
   ((__m128i)__builtin_ia32_vcvtph2iubs128_mask(                                \
-      (__v8hf)(__m128h)(A), (__v8hu)_mm_setzero_si128(), (__mmask8)-1))
+      (__v8hf)(__m128h)(A), (__v8hu)_mm_setzero_si128(), (__mmask8) - 1))
 
-#define _mm_mask_ipcvtph_epu8(W, U, A)                                         \
+#define _mm_mask_ipcvts_ph_epu8(W, U, A)                                       \
   ((__m128i)__builtin_ia32_vcvtph2iubs128_mask((__v8hf)(__m128h)(A),           \
                                                (__v8hu)(W), (__mmask8)(U)))
 
-#define _mm_maskz_ipcvtph_epu8(U, A)                                           \
+#define _mm_maskz_ipcvts_ph_epu8(U, A)                                         \
   ((__m128i)__builtin_ia32_vcvtph2iubs128_mask(                                \
       (__v8hf)(__m128h)(A), (__v8hu)(_mm_setzero_si128()), (__mmask8)(U)))
 
-#define _mm256_ipcvtph_epu8(A)                                                 \
+#define _mm256_ipcvts_ph_epu8(A)                                               \
   ((__m256i)__builtin_ia32_vcvtph2iubs256_mask(                                \
-      (__v16hf)(__m256h)(A), (__v16hu)_mm256_setzero_si256(), (__mmask16)-1,   \
+      (__v16hf)(__m256h)(A), (__v16hu)_mm256_setzero_si256(), (__mmask16) - 1, \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_mask_ipcvtph_epu8(W, U, A)                                      \
+#define _mm256_mask_ipcvts_ph_epu8(W, U, A)                                    \
   ((__m256i)__builtin_ia32_vcvtph2iubs256_mask((__v16hf)(__m256h)(A),          \
                                                (__v16hu)(W), (__mmask16)(U),   \
                                                _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_maskz_ipcvtph_epu8(U, A)                                        \
+#define _mm256_maskz_ipcvts_ph_epu8(U, A)                                      \
   ((__m256i)__builtin_ia32_vcvtph2iubs256_mask(                                \
       (__v16hf)(__m256h)(A), (__v16hu)(_mm256_setzero_si256()),                \
       (__mmask16)(U), _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_ipcvt_roundph_epu8(A, R)                                        \
+#define _mm256_ipcvts_roundph_epu8(A, R)                                       \
   ((__m256i)__builtin_ia32_vcvtph2iubs256_mask(                                \
-      (__v16hf)(__m256h)(A), (__v16hu)_mm256_setzero_si256(), (__mmask16)-1,   \
+      (__v16hf)(__m256h)(A), (__v16hu)_mm256_setzero_si256(), (__mmask16) - 1, \
       (const int)R))
 
-#define _mm256_mask_ipcvt_roundph_epu8(W, U, A, R)                             \
+#define _mm256_mask_ipcvts_roundph_epu8(W, U, A, R)                            \
   ((__m256i)__builtin_ia32_vcvtph2iubs256_mask(                                \
       (__v16hf)(__m256h)(A), (__v16hu)(W), (__mmask16)(U), (const int)R))
 
-#define _mm256_maskz_ipcvt_roundph_epu8(U, A, R)                               \
+#define _mm256_maskz_ipcvts_roundph_epu8(U, A, R)                              \
   ((__m256i)__builtin_ia32_vcvtph2iubs256_mask(                                \
       (__v16hf)(__m256h)(A), (__v16hu)_mm256_setzero_si256(), (__mmask16)(U),  \
       (const int)R))
 
-#define _mm_ipcvtps_epi8(A)                                                    \
+#define _mm_ipcvts_ps_epi8(A)                                                  \
   ((__m128i)__builtin_ia32_vcvtps2ibs128_mask(                                 \
-      (__v4sf)(__m128)(A), (__v4su)_mm_setzero_si128(), (__mmask8)-1))
+      (__v4sf)(__m128)(A), (__v4su)_mm_setzero_si128(), (__mmask8) - 1))
 
-#define _mm_mask_ipcvtps_epi8(W, U, A)                                         \
+#define _mm_mask_ipcvts_ps_epi8(W, U, A)                                       \
   ((__m128i)__builtin_ia32_vcvtps2ibs128_mask((__v4sf)(__m128)(A),             \
                                               (__v4su)(W), (__mmask8)(U)))
 
-#define _mm_maskz_ipcvtps_epi8(U, A)                                           \
+#define _mm_maskz_ipcvts_ps_epi8(U, A)                                         \
   ((__m128i)__builtin_ia32_vcvtps2ibs128_mask(                                 \
       (__v4sf)(__m128)(A), (__v4su)(_mm_setzero_si128()), (__mmask8)(U)))
 
-#define _mm256_ipcvtps_epi8(A)                                                 \
+#define _mm256_ipcvts_ps_epi8(A)                                               \
   ((__m256i)__builtin_ia32_vcvtps2ibs256_mask(                                 \
-      (__v8sf)(__m256)(A), (__v8su)_mm256_setzero_si256(), (__mmask8)-1,       \
+      (__v8sf)(__m256)(A), (__v8su)_mm256_setzero_si256(), (__mmask8) - 1,     \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_mask_ipcvtps_epi8(W, U, A)                                      \
+#define _mm256_mask_ipcvts_ps_epi8(W, U, A)                                    \
   ((__m256i)__builtin_ia32_vcvtps2ibs256_mask((__v8sf)(__m256)(A),             \
                                               (__v8su)(W), (__mmask8)(U),      \
                                               _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_maskz_ipcvtps_epi8(U, A)                                        \
+#define _mm256_maskz_ipcvts_ps_epi8(U, A)                                      \
   ((__m256i)__builtin_ia32_vcvtps2ibs256_mask(                                 \
       (__v8sf)(__m256)(A), (__v8su)(_mm256_setzero_si256()), (__mmask8)(U),    \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_ipcvt_roundps_epi8(A, R)                                        \
+#define _mm256_ipcvts_roundps_epi8(A, R)                                       \
   ((__m256i)__builtin_ia32_vcvtps2ibs256_mask((__v8sf)(__m256)(A),             \
                                               (__v8su)_mm256_setzero_si256(),  \
-                                              (__mmask8)-1, (const int)R))
+                                              (__mmask8) - 1, (const int)R))
 
-#define _mm256_mask_ipcvt_roundps_epi8(W, U, A, R)                             \
+#define _mm256_mask_ipcvts_roundps_epi8(W, U, A, R)                            \
   ((__m256i)__builtin_ia32_vcvtps2ibs256_mask(                                 \
       (__v8sf)(__m256)(A), (__v8su)(W), (__mmask8)(U), (const int)R))
 
-#define _mm256_maskz_ipcvt_roundps_epi8(U, A, R)                               \
+#define _mm256_maskz_ipcvts_roundps_epi8(U, A, R)                              \
   ((__m256i)__builtin_ia32_vcvtps2ibs256_mask((__v8sf)(__m256)(A),             \
                                               (__v8su)_mm256_setzero_si256(),  \
                                               (__mmask8)(U), (const int)R))
 
-#define _mm_ipcvtps_epu8(A)                                                    \
+#define _mm_ipcvts_ps_epu8(A)                                                  \
   ((__m128i)__builtin_ia32_vcvtps2iubs128_mask(                                \
-      (__v4sf)(__m128)(A), (__v4su)_mm_setzero_si128(), (__mmask8)-1))
+      (__v4sf)(__m128)(A), (__v4su)_mm_setzero_si128(), (__mmask8) - 1))
 
-#define _mm_mask_ipcvtps_epu8(W, U, A)                                         \
+#define _mm_mask_ipcvts_ps_epu8(W, U, A)                                       \
   ((__m128i)__builtin_ia32_vcvtps2iubs128_mask((__v4sf)(__m128)(A),            \
                                                (__v4su)(W), (__mmask8)(U)))
 
-#define _mm_maskz_ipcvtps_epu8(U, A)                                           \
+#define _mm_maskz_ipcvts_ps_epu8(U, A)                                         \
   ((__m128i)__builtin_ia32_vcvtps2iubs128_mask(                                \
       (__v4sf)(__m128)(A), (__v4su)(_mm_setzero_si128()), (__mmask8)(U)))
 
-#define _mm256_ipcvtps_epu8(A)                                                 \
+#define _mm256_ipcvts_ps_epu8(A)                                               \
   ((__m256i)__builtin_ia32_vcvtps2iubs256_mask(                                \
-      (__v8sf)(__m256)(A), (__v8su)_mm256_setzero_si256(), (__mmask8)-1,       \
+      (__v8sf)(__m256)(A), (__v8su)_mm256_setzero_si256(), (__mmask8) - 1,     \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_mask_ipcvtps_epu8(W, U, A)                                      \
+#define _mm256_mask_ipcvts_ps_epu8(W, U, A)                                    \
   ((__m256i)__builtin_ia32_vcvtps2iubs256_mask((__v8sf)(__m256)(A),            \
                                                (__v8su)(W), (__mmask8)(U),     \
                                                _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_maskz_ipcvtps_epu8(U, A)                                        \
+#define _mm256_maskz_ipcvts_ps_epu8(U, A)                                      \
   ((__m256i)__builtin_ia32_vcvtps2iubs256_mask(                                \
       (__v8sf)(__m256)(A), (__v8su)(_mm256_setzero_si256()), (__mmask8)(U),    \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_ipcvt_roundps_epu8(A, R)                                        \
+#define _mm256_ipcvts_roundps_epu8(A, R)                                       \
   ((__m256i)__builtin_ia32_vcvtps2iubs256_mask((__v8sf)(__m256)(A),            \
                                                (__v8su)_mm256_setzero_si256(), \
-                                               (__mmask8)-1, (const int)R))
+                                               (__mmask8) - 1, (const int)R))
 
-#define _mm256_mask_ipcvt_roundps_epu8(W, U, A, R)                             \
+#define _mm256_mask_ipcvts_roundps_epu8(W, U, A, R)                            \
   ((__m256i)__builtin_ia32_vcvtps2iubs256_mask(                                \
       (__v8sf)(__m256)(A), (__v8su)(W), (__mmask8)(U), (const int)R))
 
-#define _mm256_maskz_ipcvt_roundps_epu8(U, A, R)                               \
+#define _mm256_maskz_ipcvts_roundps_epu8(U, A, R)                              \
   ((__m256i)__builtin_ia32_vcvtps2iubs256_mask((__v8sf)(__m256)(A),            \
                                                (__v8su)_mm256_setzero_si256(), \
                                                (__mmask8)(U), (const int)R))
 
-#define _mm_ipcvttbf16_epi8(A)                                                 \
+#define _mm_ipcvtts_bf16_epi8(A)                                               \
   ((__m128i)__builtin_ia32_vcvttbf162ibs128((__v8bf)(__m128bh)(A)))
 
-#define _mm_mask_ipcvttbf16_epi8(W, U, A)                                      \
+#define _mm_mask_ipcvtts_bf16_epi8(W, U, A)                                    \
   ((__m128i)__builtin_ia32_selectw_128(                                        \
-      (__mmask8)(U), (__v8hi)_mm_ipcvttbf16_epi8(A), (__v8hi)(__m128i)(W)))
+      (__mmask8)(U), (__v8hi)_mm_ipcvtts_bf16_epi8(A), (__v8hi)(__m128i)(W)))
 
-#define _mm_maskz_ipcvttbf16_epi8(U, A)                                        \
+#define _mm_maskz_ipcvtts_bf16_epi8(U, A)                                      \
   ((__m128i)__builtin_ia32_selectw_128((__mmask8)(U),                          \
-                                       (__v8hi)_mm_ipcvttbf16_epi8(A),         \
+                                       (__v8hi)_mm_ipcvtts_bf16_epi8(A),       \
                                        (__v8hi)_mm_setzero_si128()))
 
-#define _mm256_ipcvttbf16_epi8(A)                                              \
+#define _mm256_ipcvtts_bf16_epi8(A)                                            \
   ((__m256i)__builtin_ia32_vcvttbf162ibs256((__v16bf)(__m256bh)(A)))
 
-#define _mm256_mask_ipcvttbf16_epi8(W, U, A)                                   \
+#define _mm256_mask_ipcvtts_bf16_epi8(W, U, A)                                 \
   ((__m256i)__builtin_ia32_selectw_256((__mmask16)(U),                         \
-                                       (__v16hi)_mm256_ipcvttbf16_epi8(A),     \
+                                       (__v16hi)_mm256_ipcvtts_bf16_epi8(A),   \
                                        (__v16hi)(__m256i)(W)))
 
-#define _mm256_maskz_ipcvttbf16_epi8(U, A)                                     \
+#define _mm256_maskz_ipcvtts_bf16_epi8(U, A)                                   \
   ((__m256i)__builtin_ia32_selectw_256((__mmask16)(U),                         \
-                                       (__v16hi)_mm256_ipcvttbf16_epi8(A),     \
+                                       (__v16hi)_mm256_ipcvtts_bf16_epi8(A),   \
                                        (__v16hi)_mm256_setzero_si256()))
 
-#define _mm_ipcvttbf16_epu8(A)                                                 \
+#define _mm_ipcvtts_bf16_epu8(A)                                               \
   ((__m128i)__builtin_ia32_vcvttbf162iubs128((__v8bf)(__m128bh)(A)))
 
-#define _mm_mask_ipcvttbf16_epu8(W, U, A)                                      \
+#define _mm_mask_ipcvtts_bf16_epu8(W, U, A)                                    \
   ((__m128i)__builtin_ia32_selectw_128(                                        \
-      (__mmask8)(U), (__v8hi)_mm_ipcvttbf16_epu8(A), (__v8hi)(__m128i)(W)))
+      (__mmask8)(U), (__v8hi)_mm_ipcvtts_bf16_epu8(A), (__v8hi)(__m128i)(W)))
 
-#define _mm_maskz_ipcvttbf16_epu8(U, A)                                        \
+#define _mm_maskz_ipcvtts_bf16_epu8(U, A)                                      \
   ((__m128i)__builtin_ia32_selectw_128((__mmask8)(U),                          \
-                                       (__v8hi)_mm_ipcvttbf16_epu8(A),         \
+                                       (__v8hi)_mm_ipcvtts_bf16_epu8(A),       \
                                        (__v8hi)_mm_setzero_si128()))
 
-#define _mm256_ipcvttbf16_epu8(A)                                              \
+#define _mm256_ipcvtts_bf16_epu8(A)                                            \
   ((__m256i)__builtin_ia32_vcvttbf162iubs256((__v16bf)(__m256bh)(A)))
 
-#define _mm256_mask_ipcvttbf16_epu8(W, U, A)                                   \
+#define _mm256_mask_ipcvtts_bf16_epu8(W, U, A)                                 \
   ((__m256i)__builtin_ia32_selectw_256((__mmask16)(U),                         \
-                                       (__v16hi)_mm256_ipcvttbf16_epu8(A),     \
+                                       (__v16hi)_mm256_ipcvtts_bf16_epu8(A),   \
                                        (__v16hi)(__m256i)(W)))
 
-#define _mm256_maskz_ipcvttbf16_epu8(U, A)                                     \
+#define _mm256_maskz_ipcvtts_bf16_epu8(U, A)                                   \
   ((__m256i)__builtin_ia32_selectw_256((__mmask16)(U),                         \
-                                       (__v16hi)_mm256_ipcvttbf16_epu8(A),     \
+                                       (__v16hi)_mm256_ipcvtts_bf16_epu8(A),   \
                                        (__v16hi)_mm256_setzero_si256()))
 
-#define _mm_ipcvttph_epi8(A)                                                   \
+#define _mm_ipcvtts_ph_epi8(A)                                                 \
   ((__m128i)__builtin_ia32_vcvttph2ibs128_mask(                                \
-      (__v8hf)(__m128h)(A), (__v8hu)_mm_setzero_si128(), (__mmask8)-1))
+      (__v8hf)(__m128h)(A), (__v8hu)_mm_setzero_si128(), (__mmask8) - 1))
 
-#define _mm_mask_ipcvttph_epi8(W, U, A)                                        \
+#define _mm_mask_ipcvtts_ph_epi8(W, U, A)                                      \
   ((__m128i)__builtin_ia32_vcvttph2ibs128_mask((__v8hf)(__m128h)(A),           \
                                                (__v8hu)(W), (__mmask8)(U)))
 
-#define _mm_maskz_ipcvttph_epi8(U, A)                                          \
+#define _mm_maskz_ipcvtts_ph_epi8(U, A)                                        \
   ((__m128i)__builtin_ia32_vcvttph2ibs128_mask(                                \
       (__v8hf)(__m128h)(A), (__v8hu)(_mm_setzero_si128()), (__mmask8)(U)))
 
-#define _mm256_ipcvttph_epi8(A)                                                \
+#define _mm256_ipcvtts_ph_epi8(A)                                              \
   ((__m256i)__builtin_ia32_vcvttph2ibs256_mask(                                \
-      (__v16hf)(__m256h)(A), (__v16hu)_mm256_setzero_si256(), (__mmask16)-1,   \
+      (__v16hf)(__m256h)(A), (__v16hu)_mm256_setzero_si256(), (__mmask16) - 1, \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_mask_ipcvttph_epi8(W, U, A)                                     \
+#define _mm256_mask_ipcvtts_ph_epi8(W, U, A)                                   \
   ((__m256i)__builtin_ia32_vcvttph2ibs256_mask((__v16hf)(__m256h)(A),          \
                                                (__v16hu)(W), (__mmask16)(U),   \
                                                _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_maskz_ipcvttph_epi8(U, A)                                       \
+#define _mm256_maskz_ipcvtts_ph_epi8(U, A)                                     \
   ((__m256i)__builtin_ia32_vcvttph2ibs256_mask(                                \
       (__v16hf)(__m256h)(A), (__v16hu)(_mm256_setzero_si256()),                \
       (__mmask16)(U), _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_ipcvtt_roundph_epi8(A, R)                                       \
+#define _mm256_ipcvtts_roundph_epi8(A, R)                                      \
   ((__m256i)__builtin_ia32_vcvttph2ibs256_mask(                                \
-      (__v16hf)(__m256h)(A), (__v16hu)_mm256_setzero_si256(), (__mmask16)-1,   \
+      (__v16hf)(__m256h)(A), (__v16hu)_mm256_setzero_si256(), (__mmask16) - 1, \
       (const int)R))
 
-#define _mm256_mask_ipcvtt_roundph_epi8(W, U, A, R)                            \
+#define _mm256_mask_ipcvtts_roundph_epi8(W, U, A, R)                           \
   ((__m256i)__builtin_ia32_vcvttph2ibs256_mask(                                \
       (__v16hf)(__m256h)(A), (__v16hu)(W), (__mmask16)(U), (const int)R))
 
-#define _mm256_maskz_ipcvtt_roundph_epi8(U, A, R)                              \
+#define _mm256_maskz_ipcvtts_roundph_epi8(U, A, R)                             \
   ((__m256i)__builtin_ia32_vcvttph2ibs256_mask(                                \
       (__v16hf)(__m256h)(A), (__v16hu)_mm256_setzero_si256(), (__mmask16)(U),  \
       (const int)R))
 
-#define _mm_ipcvttph_epu8(A)                                                   \
+#define _mm_ipcvtts_ph_epu8(A)                                                 \
   ((__m128i)__builtin_ia32_vcvttph2iubs128_mask(                               \
-      (__v8hf)(__m128h)(A), (__v8hu)_mm_setzero_si128(), (__mmask8)-1))
+      (__v8hf)(__m128h)(A), (__v8hu)_mm_setzero_si128(), (__mmask8) - 1))
 
-#define _mm_mask_ipcvttph_epu8(W, U, A)                                        \
+#define _mm_mask_ipcvtts_ph_epu8(W, U, A)                                      \
   ((__m128i)__builtin_ia32_vcvttph2iubs128_mask((__v8hf)(__m128h)(A),          \
                                                 (__v8hu)(W), (__mmask8)(U)))
 
-#define _mm_maskz_ipcvttph_epu8(U, A)                                          \
+#define _mm_maskz_ipcvtts_ph_epu8(U, A)                                        \
   ((__m128i)__builtin_ia32_vcvttph2iubs128_mask(                               \
       (__v8hf)(__m128h)(A), (__v8hu)(_mm_setzero_si128()), (__mmask8)(U)))
 
-#define _mm256_ipcvttph_epu8(A)                                                \
+#define _mm256_ipcvtts_ph_epu8(A)                                              \
   ((__m256i)__builtin_ia32_vcvttph2iubs256_mask(                               \
-      (__v16hf)(__m256h)(A), (__v16hu)_mm256_setzero_si256(), (__mmask16)-1,   \
+      (__v16hf)(__m256h)(A), (__v16hu)_mm256_setzero_si256(), (__mmask16) - 1, \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_mask_ipcvttph_epu8(W, U, A)                                     \
+#define _mm256_mask_ipcvtts_ph_epu8(W, U, A)                                   \
   ((__m256i)__builtin_ia32_vcvttph2iubs256_mask((__v16hf)(__m256h)(A),         \
                                                 (__v16hu)(W), (__mmask16)(U),  \
                                                 _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_maskz_ipcvttph_epu8(U, A)                                       \
+#define _mm256_maskz_ipcvtts_ph_epu8(U, A)                                     \
   ((__m256i)__builtin_ia32_vcvttph2iubs256_mask(                               \
       (__v16hf)(__m256h)(A), (__v16hu)(_mm256_setzero_si256()),                \
       (__mmask16)(U), _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_ipcvtt_roundph_epu8(A, R)                                       \
+#define _mm256_ipcvtts_roundph_epu8(A, R)                                      \
   ((__m256i)__builtin_ia32_vcvttph2iubs256_mask(                               \
-      (__v16hf)(__m256h)(A), (__v16hu)_mm256_setzero_si256(), (__mmask16)-1,   \
+      (__v16hf)(__m256h)(A), (__v16hu)_mm256_setzero_si256(), (__mmask16) - 1, \
       (const int)R))
 
-#define _mm256_mask_ipcvtt_roundph_epu8(W, U, A, R)                            \
+#define _mm256_mask_ipcvtts_roundph_epu8(W, U, A, R)                           \
   ((__m256i)__builtin_ia32_vcvttph2iubs256_mask(                               \
       (__v16hf)(__m256h)(A), (__v16hu)(W), (__mmask16)(U), (const int)R))
 
-#define _mm256_maskz_ipcvtt_roundph_epu8(U, A, R)                              \
+#define _mm256_maskz_ipcvtts_roundph_epu8(U, A, R)                             \
   ((__m256i)__builtin_ia32_vcvttph2iubs256_mask(                               \
       (__v16hf)(__m256h)(A), (__v16hu)_mm256_setzero_si256(), (__mmask16)(U),  \
       (const int)R))
 
-#define _mm_ipcvttps_epi8(A)                                                   \
+#define _mm_ipcvtts_ps_epi8(A)                                                 \
   ((__m128i)__builtin_ia32_vcvttps2ibs128_mask(                                \
-      (__v4sf)(__m128)(A), (__v4su)_mm_setzero_si128(), (__mmask8)-1))
+      (__v4sf)(__m128)(A), (__v4su)_mm_setzero_si128(), (__mmask8) - 1))
 
-#define _mm_mask_ipcvttps_epi8(W, U, A)                                        \
+#define _mm_mask_ipcvtts_ps_epi8(W, U, A)                                      \
   ((__m128i)__builtin_ia32_vcvttps2ibs128_mask((__v4sf)(__m128)(A),            \
                                                (__v4su)(W), (__mmask8)(U)))
 
-#define _mm_maskz_ipcvttps_epi8(U, A)                                          \
+#define _mm_maskz_ipcvtts_ps_epi8(U, A)                                        \
   ((__m128i)__builtin_ia32_vcvttps2ibs128_mask(                                \
       (__v4sf)(__m128)(A), (__v4su)(_mm_setzero_si128()), (__mmask8)(U)))
 
-#define _mm256_ipcvttps_epi8(A)                                                \
+#define _mm256_ipcvtts_ps_epi8(A)                                              \
   ((__m256i)__builtin_ia32_vcvttps2ibs256_mask(                                \
-      (__v8sf)(__m256)(A), (__v8su)_mm256_setzero_si256(), (__mmask8)-1,       \
+      (__v8sf)(__m256)(A), (__v8su)_mm256_setzero_si256(), (__mmask8) - 1,     \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_mask_ipcvttps_epi8(W, U, A)                                     \
+#define _mm256_mask_ipcvtts_ps_epi8(W, U, A)                                   \
   ((__m256i)__builtin_ia32_vcvttps2ibs256_mask((__v8sf)(__m256)(A),            \
                                                (__v8su)(W), (__mmask8)(U),     \
                                                _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_maskz_ipcvttps_epi8(U, A)                                       \
+#define _mm256_maskz_ipcvtts_ps_epi8(U, A)                                     \
   ((__m256i)__builtin_ia32_vcvttps2ibs256_mask(                                \
       (__v8sf)(__m256)(A), (__v8su)(_mm256_setzero_si256()), (__mmask8)(U),    \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_ipcvtt_roundps_epi8(A, R)                                       \
+#define _mm256_ipcvtts_roundps_epi8(A, R)                                      \
   ((__m256i)__builtin_ia32_vcvttps2ibs256_mask((__v8sf)(__m256)(A),            \
                                                (__v8su)_mm256_setzero_si256(), \
-                                               (__mmask8)-1, (const int)R))
+                                               (__mmask8) - 1, (const int)R))
 
-#define _mm256_mask_ipcvtt_roundps_epi8(W, U, A, R)                            \
+#define _mm256_mask_ipcvtts_roundps_epi8(W, U, A, R)                           \
   ((__m256i)__builtin_ia32_vcvttps2ibs256_mask(                                \
       (__v8sf)(__m256)(A), (__v8su)(W), (__mmask8)(U), (const int)R))
 
-#define _mm256_maskz_ipcvtt_roundps_epi8(U, A, R)                              \
+#define _mm256_maskz_ipcvtts_roundps_epi8(U, A, R)                             \
   ((__m256i)__builtin_ia32_vcvttps2ibs256_mask((__v8sf)(__m256)(A),            \
                                                (__v8su)_mm256_setzero_si256(), \
                                                (__mmask8)(U), (const int)R))
 
-#define _mm_ipcvttps_epu8(A)                                                   \
+#define _mm_ipcvtts_ps_epu8(A)                                                 \
   ((__m128i)__builtin_ia32_vcvttps2iubs128_mask(                               \
-      (__v4sf)(__m128)(A), (__v4su)_mm_setzero_si128(), (__mmask8)-1))
+      (__v4sf)(__m128)(A), (__v4su)_mm_setzero_si128(), (__mmask8) - 1))
 
-#define _mm_mask_ipcvttps_epu8(W, U, A)                                        \
+#define _mm_mask_ipcvtts_ps_epu8(W, U, A)                                      \
   ((__m128i)__builtin_ia32_vcvttps2iubs128_mask((__v4sf)(__m128)(A),           \
                                                 (__v4su)(W), (__mmask8)(U)))
 
-#define _mm_maskz_ipcvttps_epu8(U, A)                                          \
+#define _mm_maskz_ipcvtts_ps_epu8(U, A)                                        \
   ((__m128i)__builtin_ia32_vcvttps2iubs128_mask(                               \
       (__v4sf)(__m128)(A), (__v4su)(_mm_setzero_si128()), (__mmask8)(U)))
 
-#define _mm256_ipcvttps_epu8(A)                                                \
+#define _mm256_ipcvtts_ps_epu8(A)                                              \
   ((__m256i)__builtin_ia32_vcvttps2iubs256_mask(                               \
-      (__v8sf)(__m256)(A), (__v8su)_mm256_setzero_si256(), (__mmask8)-1,       \
+      (__v8sf)(__m256)(A), (__v8su)_mm256_setzero_si256(), (__mmask8) - 1,     \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_mask_ipcvttps_epu8(W, U, A)                                     \
+#define _mm256_mask_ipcvtts_ps_epu8(W, U, A)                                   \
   ((__m256i)__builtin_ia32_vcvttps2iubs256_mask((__v8sf)(__m256)(A),           \
                                                 (__v8su)(W), (__mmask8)(U),    \
                                                 _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_maskz_ipcvttps_epu8(U, A)                                       \
+#define _mm256_maskz_ipcvtts_ps_epu8(U, A)                                     \
   ((__m256i)__builtin_ia32_vcvttps2iubs256_mask(                               \
       (__v8sf)(__m256)(A), (__v8su)(_mm256_setzero_si256()), (__mmask8)(U),    \
       _MM_FROUND_CUR_DIRECTION))
 
-#define _mm256_ipcvtt_roundps_epu8(A, R)                                       \
+#define _mm256_ipcvtts_roundps_epu8(A, R)                                      \
   ((__m256i)__builtin_ia32_vcvttps2iubs256_mask(                               \
-      (__v8sf)(__m256)(A), (__v8su)_mm256_setzero_si256(), (__mmask8)-1,       \
+      (__v8sf)(__m256)(A), (__v8su)_mm256_setzero_si256(), (__mmask8) - 1,     \
       (const int)R))
 
-#define _mm256_mask_ipcvtt_roundps_epu8(W, U, A, R)                            \
+#define _mm256_mask_ipcvtts_roundps_epu8(W, U, A, R)                           \
   ((__m256i)__builtin_ia32_vcvttps2iubs256_mask(                               \
       (__v8sf)(__m256)(A), (__v8su)(W), (__mmask8)(U), (const int)R))
 
-#define _mm256_maskz_ipcvtt_roundps_epu8(U, A, R)                              \
+#define _mm256_maskz_ipcvtts_roundps_epu8(U, A, R)                             \
   ((__m256i)__builtin_ia32_vcvttps2iubs256_mask(                               \
       (__v8sf)(__m256)(A), (__v8su)_mm256_setzero_si256(), (__mmask8)(U),      \
       (const int)R))

--- a/clang/test/CodeGen/X86/avx10_2_512convert-builtins.c
+++ b/clang/test/CodeGen/X86/avx10_2_512convert-builtins.c
@@ -59,22 +59,22 @@ __m256i test_mm512_maskz_cvtbiasph_bf8(__mmask32 __U, __m512i __A, __m512h __B) 
   return _mm512_maskz_cvtbiasph_bf8(__U, __A, __B);
 }
 
-__m256i test_mm512_cvtbiassph_bf8(__m512i __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_cvtbiassph_bf8(
+__m256i test_mm512_cvts_biasph_bf8(__m512i __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_cvts_biasph_bf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.mask.vcvtbiasph2bf8s512(
-  return _mm512_cvtbiassph_bf8(__A, __B);
+  return _mm512_cvts_biasph_bf8(__A, __B);
 }
 
-__m256i test_mm512_mask_cvtbiassph_bf8(__m256i __W, __mmask32 __U, __m512i __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_mask_cvtbiassph_bf8(
+__m256i test_mm512_mask_cvts_biasph_bf8(__m256i __W, __mmask32 __U, __m512i __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_mask_cvts_biasph_bf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.mask.vcvtbiasph2bf8s512(
-  return _mm512_mask_cvtbiassph_bf8(__W, __U, __A, __B);
+  return _mm512_mask_cvts_biasph_bf8(__W, __U, __A, __B);
 }
 
-__m256i test_mm512_maskz_cvtbiassph_bf8(__mmask32 __U, __m512i __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_maskz_cvtbiassph_bf8(
+__m256i test_mm512_maskz_cvts_biasph_bf8(__mmask32 __U, __m512i __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_maskz_cvts_biasph_bf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.mask.vcvtbiasph2bf8s512(
-  return _mm512_maskz_cvtbiassph_bf8(__U, __A, __B);
+  return _mm512_maskz_cvts_biasph_bf8(__U, __A, __B);
 }
 
 __m256i test_mm512_cvtbiasph_hf8(__m512i __A, __m512h __B) {
@@ -95,22 +95,22 @@ __m256i test_mm512_maskz_cvtbiasph_hf8(__mmask32 __U, __m512i __A, __m512h __B) 
   return _mm512_maskz_cvtbiasph_hf8(__U, __A, __B);
 }
 
-__m256i test_mm512_cvtbiassph_hf8(__m512i __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_cvtbiassph_hf8(
+__m256i test_mm512_cvts_biasph_hf8(__m512i __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_cvts_biasph_hf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.mask.vcvtbiasph2hf8s512(
-  return _mm512_cvtbiassph_hf8(__A, __B);
+  return _mm512_cvts_biasph_hf8(__A, __B);
 }
 
-__m256i test_mm512_mask_cvtbiassph_hf8(__m256i __W, __mmask32 __U, __m512i __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_mask_cvtbiassph_hf8(
+__m256i test_mm512_mask_cvts_biasph_hf8(__m256i __W, __mmask32 __U, __m512i __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_mask_cvts_biasph_hf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.mask.vcvtbiasph2hf8s512(
-  return _mm512_mask_cvtbiassph_hf8(__W, __U, __A, __B);
+  return _mm512_mask_cvts_biasph_hf8(__W, __U, __A, __B);
 }
 
-__m256i test_mm512_maskz_cvtbiassph_hf8(__mmask32 __U, __m512i __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_maskz_cvtbiassph_hf8(
+__m256i test_mm512_maskz_cvts_biasph_hf8(__mmask32 __U, __m512i __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_maskz_cvts_biasph_hf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.mask.vcvtbiasph2hf8s512(
-  return _mm512_maskz_cvtbiassph_hf8(__U, __A, __B);
+  return _mm512_maskz_cvts_biasph_hf8(__U, __A, __B);
 }
 
 __m512i test_mm512_cvt2ph_bf8(__m512h __A, __m512h __B) {

--- a/clang/test/CodeGen/X86/avx10_2_512convert-builtins.c
+++ b/clang/test/CodeGen/X86/avx10_2_512convert-builtins.c
@@ -135,26 +135,26 @@ __m512i test_mm512_maskz_cvt2ph_bf8(__mmask32 __U, __m512h __A, __m512h __B) {
   return _mm512_maskz_cvt2ph_bf8(__U, __A, __B);
 }
 
-__m512i test_mm512_cvts2ph_bf8(__m512h __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_cvts2ph_bf8(
+__m512i test_mm512_cvts_2ph_bf8(__m512h __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_cvts_2ph_bf8(
   // CHECK: call <64 x i8> @llvm.x86.avx10.vcvt2ph2bf8s512(
-  return _mm512_cvts2ph_bf8(__A, __B);
+  return _mm512_cvts_2ph_bf8(__A, __B);
 }
 
-__m512i test_mm512_mask_cvts2ph_bf8(__m512i __W, __mmask64 __U, __m512h __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_mask_cvts2ph_bf8(
+__m512i test_mm512_mask_cvts_2ph_bf8(__m512i __W, __mmask64 __U, __m512h __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_mask_cvts_2ph_bf8(
   // CHECK: call <64 x i8> @llvm.x86.avx10.vcvt2ph2bf8s512(
   // CHECK: select <64 x i1> %{{.*}}, <64 x i8> %{{.*}}, <64 x i8> %{{.*}}
   // CHECK: ret <8 x i64> %{{.*}}
-  return _mm512_mask_cvts2ph_bf8(__W, __U, __A, __B);
+  return _mm512_mask_cvts_2ph_bf8(__W, __U, __A, __B);
 }
 
-__m512i test_mm512_maskz_cvts2ph_bf8(__mmask64 __U, __m512h __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_maskz_cvts2ph_bf8(
+__m512i test_mm512_maskz_cvts_2ph_bf8(__mmask64 __U, __m512h __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_maskz_cvts_2ph_bf8(
   // CHECK: call <64 x i8> @llvm.x86.avx10.vcvt2ph2bf8s512(
   // CHECK: zeroinitializer
   // CHECK: select <64 x i1> %{{.*}}, <64 x i8> %{{.*}}, <64 x i8> %{{.*}}
-  return _mm512_maskz_cvts2ph_bf8(__U, __A, __B);
+  return _mm512_maskz_cvts_2ph_bf8(__U, __A, __B);
 }
 
 __m512i test_mm512_cvt2ph_hf8(__m512h __A, __m512h __B) {
@@ -179,26 +179,26 @@ __m512i test_mm512_maskz_cvt2ph_hf8(__mmask64 __U, __m512h __A, __m512h __B) {
   return _mm512_maskz_cvt2ph_hf8(__U, __A, __B);
 }
 
-__m512i test_mm512_cvts2ph_hf8(__m512h __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_cvts2ph_hf8(
+__m512i test_mm512_cvts_2ph_hf8(__m512h __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_cvts_2ph_hf8(
   // CHECK: call <64 x i8> @llvm.x86.avx10.vcvt2ph2hf8s512(
-  return _mm512_cvts2ph_hf8(__A, __B);
+  return _mm512_cvts_2ph_hf8(__A, __B);
 }
 
-__m512i test_mm512_mask_cvts2ph_hf8(__m512i __W, __mmask64 __U, __m512h __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_mask_cvts2ph_hf8(
+__m512i test_mm512_mask_cvts_2ph_hf8(__m512i __W, __mmask64 __U, __m512h __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_mask_cvts_2ph_hf8(
   // CHECK: call <64 x i8> @llvm.x86.avx10.vcvt2ph2hf8s512(
   // CHECK: select <64 x i1> %{{.*}}, <64 x i8> %{{.*}}, <64 x i8> %{{.*}}
   // CHECK: ret <8 x i64> %{{.*}}
-  return _mm512_mask_cvts2ph_hf8(__W, __U, __A, __B);
+  return _mm512_mask_cvts_2ph_hf8(__W, __U, __A, __B);
 }
 
-__m512i test_mm512_maskz_cvts2ph_hf8(__mmask64 __U, __m512h __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_maskz_cvts2ph_hf8(
+__m512i test_mm512_maskz_cvts_2ph_hf8(__mmask64 __U, __m512h __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_maskz_cvts_2ph_hf8(
   // CHECK: call <64 x i8> @llvm.x86.avx10.vcvt2ph2hf8s512(
   // CHECK: zeroinitializer
   // CHECK: select <64 x i1> %{{.*}}, <64 x i8> %{{.*}}, <64 x i8> %{{.*}}
-  return _mm512_maskz_cvts2ph_hf8(__U, __A, __B);
+  return _mm512_maskz_cvts_2ph_hf8(__U, __A, __B);
 }
 
 __m512h test_mm512_cvthf8_ph(__m256i __A) {
@@ -237,22 +237,22 @@ __m256i test_mm512_maskz_cvtph_bf8(__mmask32 __A, __m512h __B) {
   return _mm512_maskz_cvtph_bf8(__A, __B);
 }
 
-__m256i test_mm512_cvtsph_bf8(__m512h __A) {
-  // CHECK-LABEL: @test_mm512_cvtsph_bf8(
+__m256i test_mm512_cvts_ph_bf8(__m512h __A) {
+  // CHECK-LABEL: @test_mm512_cvts_ph_bf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.mask.vcvtph2bf8s512(
-  return _mm512_cvtsph_bf8(__A);
+  return _mm512_cvts_ph_bf8(__A);
 }
 
-__m256i test_mm512_mask_cvtsph_bf8(__m256i __A, __mmask32 __B, __m512h __C) {
-  // CHECK-LABEL: @test_mm512_mask_cvtsph_bf8(
+__m256i test_mm512_mask_cvts_ph_bf8(__m256i __A, __mmask32 __B, __m512h __C) {
+  // CHECK-LABEL: @test_mm512_mask_cvts_ph_bf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.mask.vcvtph2bf8s512(
-  return _mm512_mask_cvtsph_bf8(__A, __B, __C);
+  return _mm512_mask_cvts_ph_bf8(__A, __B, __C);
 }
 
-__m256i test_mm512_maskz_cvtsph_bf8(__mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_maskz_cvtsph_bf8(
+__m256i test_mm512_maskz_cvts_ph_bf8(__mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_maskz_cvts_ph_bf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.mask.vcvtph2bf8s512(
-  return _mm512_maskz_cvtsph_bf8(__A, __B);
+  return _mm512_maskz_cvts_ph_bf8(__A, __B);
 }
 
 __m256i test_mm512_cvtph_hf8(__m512h __A) {
@@ -273,22 +273,22 @@ __m256i test_mm512_maskz_cvtph_hf8(__mmask32 __A, __m512h __B) {
   return _mm512_maskz_cvtph_hf8(__A, __B);
 }
 
-__m256i test_mm512_cvtsph_hf8(__m512h __A) {
-  // CHECK-LABEL: @test_mm512_cvtsph_hf8(
+__m256i test_mm512_cvts_ph_hf8(__m512h __A) {
+  // CHECK-LABEL: @test_mm512_cvts_ph_hf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.mask.vcvtph2hf8s512(
-  return _mm512_cvtsph_hf8(__A);
+  return _mm512_cvts_ph_hf8(__A);
 }
 
-__m256i test_mm512_mask_cvtsph_hf8(__m256i __A, __mmask32 __B, __m512h __C) {
-  // CHECK-LABEL: @test_mm512_mask_cvtsph_hf8(
+__m256i test_mm512_mask_cvts_ph_hf8(__m256i __A, __mmask32 __B, __m512h __C) {
+  // CHECK-LABEL: @test_mm512_mask_cvts_ph_hf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.mask.vcvtph2hf8s512(
-  return _mm512_mask_cvtsph_hf8(__A, __B, __C);
+  return _mm512_mask_cvts_ph_hf8(__A, __B, __C);
 }
 
-__m256i test_mm512_maskz_cvtsph_hf8(__mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_maskz_cvtsph_hf8(
+__m256i test_mm512_maskz_cvts_ph_hf8(__mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_maskz_cvts_ph_hf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.mask.vcvtph2hf8s512(
-  return _mm512_maskz_cvtsph_hf8(__A, __B);
+  return _mm512_maskz_cvts_ph_hf8(__A, __B);
 }
 
 __m512h test_mm512_cvtbf8_ph(__m256i A) {

--- a/clang/test/CodeGen/X86/avx10_2_512satcvt-builtins-error.c
+++ b/clang/test/CodeGen/X86/avx10_2_512satcvt-builtins-error.c
@@ -5,194 +5,194 @@
 
 #include <immintrin.h>
 
-__m512i test_mm512_ipcvt_roundph_epi8(__m512h __A) {
-  return _mm512_ipcvt_roundph_epi8(__A, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_ipcvts_roundph_epi8(__m512h __A) {
+  return _mm512_ipcvts_roundph_epi8(__A, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_mask_ipcvt_roundph_epi8(__m512i __S, __mmask32 __A, __m512h __B) {
-  return _mm512_mask_ipcvt_roundph_epi8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_mask_ipcvts_roundph_epi8(__m512i __S, __mmask32 __A, __m512h __B) {
+  return _mm512_mask_ipcvts_roundph_epi8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_maskz_ipcvt_roundph_epi8(__mmask32 __A, __m512h __B) {
-  return _mm512_maskz_ipcvt_roundph_epi8(__A, __B, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_maskz_ipcvts_roundph_epi8(__mmask32 __A, __m512h __B) {
+  return _mm512_maskz_ipcvts_roundph_epi8(__A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_ipcvt_roundph_epu8(__m512h __A) {
-  return _mm512_ipcvt_roundph_epu8(__A, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_ipcvts_roundph_epu8(__m512h __A) {
+  return _mm512_ipcvts_roundph_epu8(__A, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_mask_ipcvt_roundph_epu8(__m512i __S, __mmask32 __A, __m512h __B) {
-  return _mm512_mask_ipcvt_roundph_epu8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_mask_ipcvts_roundph_epu8(__m512i __S, __mmask32 __A, __m512h __B) {
+  return _mm512_mask_ipcvts_roundph_epu8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_maskz_ipcvt_roundph_epu8(__mmask32 __A, __m512h __B) {
-  return _mm512_maskz_ipcvt_roundph_epu8(__A, __B, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_maskz_ipcvts_roundph_epu8(__mmask32 __A, __m512h __B) {
+  return _mm512_maskz_ipcvts_roundph_epu8(__A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_ipcvt_roundps_epi8(__m512 __A) {
-  return _mm512_ipcvt_roundps_epi8(__A, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_ipcvts_roundps_epi8(__m512 __A) {
+  return _mm512_ipcvts_roundps_epi8(__A, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_mask_ipcvt_roundps_epi8(__m512i __S, __mmask16 __A, __m512 __B) {
-  return _mm512_mask_ipcvt_roundps_epi8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_mask_ipcvts_roundps_epi8(__m512i __S, __mmask16 __A, __m512 __B) {
+  return _mm512_mask_ipcvts_roundps_epi8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_maskz_ipcvt_roundps_epi8(__mmask16 __A, __m512 __B) {
-  return _mm512_maskz_ipcvt_roundps_epi8(__A, __B, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_maskz_ipcvts_roundps_epi8(__mmask16 __A, __m512 __B) {
+  return _mm512_maskz_ipcvts_roundps_epi8(__A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_ipcvt_roundps_epu8(__m512 __A) {
-  return _mm512_ipcvt_roundps_epu8(__A, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_ipcvts_roundps_epu8(__m512 __A) {
+  return _mm512_ipcvts_roundps_epu8(__A, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_mask_ipcvt_roundps_epu8(__m512i __S, __mmask16 __A, __m512 __B) {
-  return _mm512_mask_ipcvt_roundps_epu8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_mask_ipcvts_roundps_epu8(__m512i __S, __mmask16 __A, __m512 __B) {
+  return _mm512_mask_ipcvts_roundps_epu8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_maskz_ipcvt_roundps_epu8(__mmask16 __A, __m512 __B) {
-  return _mm512_maskz_ipcvt_roundps_epu8(__A, __B, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_maskz_ipcvts_roundps_epu8(__mmask16 __A, __m512 __B) {
+  return _mm512_maskz_ipcvts_roundps_epu8(__A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_ipcvtt_roundph_epi8(__m512h __A) {
-  return _mm512_ipcvtt_roundph_epi8(__A, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_ipcvtts_roundph_epi8(__m512h __A) {
+  return _mm512_ipcvtts_roundph_epi8(__A, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_mask_ipcvtt_roundph_epi8(__m512i __S, __mmask32 __A, __m512h __B) {
-  return _mm512_mask_ipcvtt_roundph_epi8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_mask_ipcvtts_roundph_epi8(__m512i __S, __mmask32 __A, __m512h __B) {
+  return _mm512_mask_ipcvtts_roundph_epi8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_maskz_ipcvtt_roundph_epi8(__mmask32 __A, __m512h __B) {
-  return _mm512_maskz_ipcvtt_roundph_epi8(__A, __B, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_maskz_ipcvtts_roundph_epi8(__mmask32 __A, __m512h __B) {
+  return _mm512_maskz_ipcvtts_roundph_epi8(__A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_ipcvtt_roundph_epu8(__m512h __A) {
-  return _mm512_ipcvtt_roundph_epu8(__A, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_ipcvtts_roundph_epu8(__m512h __A) {
+  return _mm512_ipcvtts_roundph_epu8(__A, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_mask_ipcvtt_roundph_epu8(__m512i __S, __mmask32 __A, __m512h __B) {
-  return _mm512_mask_ipcvtt_roundph_epu8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_mask_ipcvtts_roundph_epu8(__m512i __S, __mmask32 __A, __m512h __B) {
+  return _mm512_mask_ipcvtts_roundph_epu8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_maskz_ipcvtt_roundph_epu8(__mmask32 __A, __m512h __B) {
-  return _mm512_maskz_ipcvtt_roundph_epu8(__A, __B, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_maskz_ipcvtts_roundph_epu8(__mmask32 __A, __m512h __B) {
+  return _mm512_maskz_ipcvtts_roundph_epu8(__A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_ipcvtt_roundps_epi8(__m512 __A) {
-  return _mm512_ipcvtt_roundps_epi8(__A, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_ipcvtts_roundps_epi8(__m512 __A) {
+  return _mm512_ipcvtts_roundps_epi8(__A, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_mask_ipcvtt_roundps_epi8(__m512i __S, __mmask16 __A, __m512 __B) {
-  return _mm512_mask_ipcvtt_roundps_epi8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_mask_ipcvtts_roundps_epi8(__m512i __S, __mmask16 __A, __m512 __B) {
+  return _mm512_mask_ipcvtts_roundps_epi8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_maskz_ipcvtt_roundps_epi8(__mmask16 __A, __m512 __B) {
-  return _mm512_maskz_ipcvtt_roundps_epi8(__A, __B, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_maskz_ipcvtts_roundps_epi8(__mmask16 __A, __m512 __B) {
+  return _mm512_maskz_ipcvtts_roundps_epi8(__A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_ipcvtt_roundps_epu8(__m512 __A) {
-  return _mm512_ipcvtt_roundps_epu8(__A, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_ipcvtts_roundps_epu8(__m512 __A) {
+  return _mm512_ipcvtts_roundps_epu8(__A, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_mask_ipcvtt_roundps_epu8(__m512i __S, __mmask16 __A, __m512 __B) {
-  return _mm512_mask_ipcvtt_roundps_epu8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_mask_ipcvtts_roundps_epu8(__m512i __S, __mmask16 __A, __m512 __B) {
+  return _mm512_mask_ipcvtts_roundps_epu8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m512i test_mm512_maskz_ipcvtt_roundps_epu8(__mmask16 __A, __m512 __B) {
-  return _mm512_maskz_ipcvtt_roundps_epu8(__A, __B, 22); // expected-error {{invalid rounding argument}}
+__m512i test_mm512_maskz_ipcvtts_roundps_epu8(__mmask16 __A, __m512 __B) {
+  return _mm512_maskz_ipcvtts_roundps_epu8(__A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_ipcvt_roundph_epi8(__m256h __A) {
-  return _mm256_ipcvt_roundph_epi8(__A, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_ipcvts_roundph_epi8(__m256h __A) {
+  return _mm256_ipcvts_roundph_epi8(__A, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_mask_ipcvt_roundph_epi8(__m256i __S, __mmask16 __A, __m256h __B) {
-  return _mm256_mask_ipcvt_roundph_epi8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_mask_ipcvts_roundph_epi8(__m256i __S, __mmask16 __A, __m256h __B) {
+  return _mm256_mask_ipcvts_roundph_epi8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_maskz_ipcvt_roundph_epi8(__mmask16 __A, __m256h __B) {
-  return _mm256_maskz_ipcvt_roundph_epi8(__A, __B, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_maskz_ipcvts_roundph_epi8(__mmask16 __A, __m256h __B) {
+  return _mm256_maskz_ipcvts_roundph_epi8(__A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_ipcvt_roundph_epu8(__m256h __A) {
-  return _mm256_ipcvt_roundph_epu8(__A, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_ipcvts_roundph_epu8(__m256h __A) {
+  return _mm256_ipcvts_roundph_epu8(__A, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_mask_ipcvt_roundph_epu8(__m256i __S, __mmask16 __A, __m256h __B) {
-  return _mm256_mask_ipcvt_roundph_epu8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_mask_ipcvts_roundph_epu8(__m256i __S, __mmask16 __A, __m256h __B) {
+  return _mm256_mask_ipcvts_roundph_epu8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_maskz_ipcvt_roundph_epu8(__mmask16 __A, __m256h __B) {
-  return _mm256_maskz_ipcvt_roundph_epu8(__A, __B, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_maskz_ipcvts_roundph_epu8(__mmask16 __A, __m256h __B) {
+  return _mm256_maskz_ipcvts_roundph_epu8(__A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_ipcvt_roundps_epi8(__m256 __A) {
-  return _mm256_ipcvt_roundps_epi8(__A, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_ipcvts_roundps_epi8(__m256 __A) {
+  return _mm256_ipcvts_roundps_epi8(__A, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_mask_ipcvt_roundps_epi8(__m256i __S, __mmask8 __A, __m256 __B) {
-  return _mm256_mask_ipcvt_roundps_epi8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_mask_ipcvts_roundps_epi8(__m256i __S, __mmask8 __A, __m256 __B) {
+  return _mm256_mask_ipcvts_roundps_epi8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_maskz_ipcvt_roundps_epi8(__mmask8 __A, __m256 __B) {
-  return _mm256_maskz_ipcvt_roundps_epi8(__A, __B, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_maskz_ipcvts_roundps_epi8(__mmask8 __A, __m256 __B) {
+  return _mm256_maskz_ipcvts_roundps_epi8(__A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_ipcvt_roundps_epu8(__m256 __A) {
-  return _mm256_ipcvt_roundps_epu8(__A, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_ipcvts_roundps_epu8(__m256 __A) {
+  return _mm256_ipcvts_roundps_epu8(__A, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_mask_ipcvt_roundps_epu8(__m256i __S, __mmask8 __A, __m256 __B) {
-  return _mm256_mask_ipcvt_roundps_epu8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_mask_ipcvts_roundps_epu8(__m256i __S, __mmask8 __A, __m256 __B) {
+  return _mm256_mask_ipcvts_roundps_epu8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_maskz_ipcvt_roundps_epu8(__mmask8 __A, __m256 __B) {
-  return _mm256_maskz_ipcvt_roundps_epu8(__A, __B, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_maskz_ipcvts_roundps_epu8(__mmask8 __A, __m256 __B) {
+  return _mm256_maskz_ipcvts_roundps_epu8(__A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_ipcvtt_roundph_epi8(__m256h __A) {
-  return _mm256_ipcvtt_roundph_epi8(__A, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_ipcvtts_roundph_epi8(__m256h __A) {
+  return _mm256_ipcvtts_roundph_epi8(__A, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_mask_ipcvtt_roundph_epi8(__m256i __S, __mmask16 __A, __m256h __B) {
-  return _mm256_mask_ipcvtt_roundph_epi8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_mask_ipcvtts_roundph_epi8(__m256i __S, __mmask16 __A, __m256h __B) {
+  return _mm256_mask_ipcvtts_roundph_epi8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_maskz_ipcvtt_roundph_epi8(__mmask16 __A, __m256h __B) {
-  return _mm256_maskz_ipcvtt_roundph_epi8(__A, __B, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_maskz_ipcvtts_roundph_epi8(__mmask16 __A, __m256h __B) {
+  return _mm256_maskz_ipcvtts_roundph_epi8(__A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_ipcvtt_roundph_epu8(__m256h __A) {
-  return _mm256_ipcvtt_roundph_epu8(__A, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_ipcvtts_roundph_epu8(__m256h __A) {
+  return _mm256_ipcvtts_roundph_epu8(__A, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_mask_ipcvtt_roundph_epu8(__m256i __S, __mmask16 __A, __m256h __B) {
-  return _mm256_mask_ipcvtt_roundph_epu8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_mask_ipcvtts_roundph_epu8(__m256i __S, __mmask16 __A, __m256h __B) {
+  return _mm256_mask_ipcvtts_roundph_epu8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_maskz_ipcvtt_roundph_epu8(__mmask16 __A, __m256h __B) {
-  return _mm256_maskz_ipcvtt_roundph_epu8(__A, __B, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_maskz_ipcvtts_roundph_epu8(__mmask16 __A, __m256h __B) {
+  return _mm256_maskz_ipcvtts_roundph_epu8(__A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_ipcvtt_roundps_epi8(__m256 __A) {
-  return _mm256_ipcvtt_roundps_epi8(__A, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_ipcvtts_roundps_epi8(__m256 __A) {
+  return _mm256_ipcvtts_roundps_epi8(__A, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_mask_ipcvtt_roundps_epi8(__m256i __S, __mmask8 __A, __m256 __B) {
-  return _mm256_mask_ipcvtt_roundps_epi8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_mask_ipcvtts_roundps_epi8(__m256i __S, __mmask8 __A, __m256 __B) {
+  return _mm256_mask_ipcvtts_roundps_epi8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_maskz_ipcvtt_roundps_epi8(__mmask8 __A, __m256 __B) {
-  return _mm256_maskz_ipcvtt_roundps_epi8(__A, __B, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_maskz_ipcvtts_roundps_epi8(__mmask8 __A, __m256 __B) {
+  return _mm256_maskz_ipcvtts_roundps_epi8(__A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_ipcvtt_roundps_epu8(__m256 __A) {
-  return _mm256_ipcvtt_roundps_epu8(__A, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_ipcvtts_roundps_epu8(__m256 __A) {
+  return _mm256_ipcvtts_roundps_epu8(__A, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_mask_ipcvtt_roundps_epu8(__m256i __S, __mmask8 __A, __m256 __B) {
-  return _mm256_mask_ipcvtt_roundps_epu8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_mask_ipcvtts_roundps_epu8(__m256i __S, __mmask8 __A, __m256 __B) {
+  return _mm256_mask_ipcvtts_roundps_epu8(__S, __A, __B, 22); // expected-error {{invalid rounding argument}}
 }
 
-__m256i test_mm256_maskz_ipcvtt_roundps_epu8(__mmask8 __A, __m256 __B) {
-  return _mm256_maskz_ipcvtt_roundps_epu8(__A, __B, 22); // expected-error {{invalid rounding argument}}
+__m256i test_mm256_maskz_ipcvtts_roundps_epu8(__mmask8 __A, __m256 __B) {
+  return _mm256_maskz_ipcvtts_roundps_epu8(__A, __B, 22); // expected-error {{invalid rounding argument}}
 }

--- a/clang/test/CodeGen/X86/avx10_2_512satcvt-builtins.c
+++ b/clang/test/CodeGen/X86/avx10_2_512satcvt-builtins.c
@@ -5,375 +5,375 @@
 
 #include <immintrin.h>
 
-__m512i test_mm512_ipcvtbf16_epi8(__m512bh __A) {
-  // CHECK-LABEL: @test_mm512_ipcvtbf16_epi8(
+__m512i test_mm512_ipcvts_bf16_epi8(__m512bh __A) {
+  // CHECK-LABEL: @test_mm512_ipcvts_bf16_epi8(
   // CHECK: @llvm.x86.avx10.vcvtbf162ibs512
-  return _mm512_ipcvtbf16_epi8(__A);
+  return _mm512_ipcvts_bf16_epi8(__A);
 }
 
-__m512i test_mm512_mask_ipcvtbf16_epi8(__m512i __S, __mmask32 __A, __m512bh __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvtbf16_epi8(
+__m512i test_mm512_mask_ipcvts_bf16_epi8(__m512i __S, __mmask32 __A, __m512bh __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvts_bf16_epi8(
   // CHECK: @llvm.x86.avx10.vcvtbf162ibs512
   // CHECK: select <32 x i1> %{{.*}}, <32 x i16> %{{.*}}, <32 x i16> %{{.*}}
-  return _mm512_mask_ipcvtbf16_epi8(__S, __A, __B);
+  return _mm512_mask_ipcvts_bf16_epi8(__S, __A, __B);
 }
 
-__m512i test_mm512_maskz_ipcvtbf16_epi8(__mmask32 __A, __m512bh __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvtbf16_epi8
+__m512i test_mm512_maskz_ipcvts_bf16_epi8(__mmask32 __A, __m512bh __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvts_bf16_epi8
   // CHECK: @llvm.x86.avx10.vcvtbf162ibs512
   // CHECK: zeroinitializer
   // CHECK: select <32 x i1> %{{.*}}, <32 x i16> %{{.*}}, <32 x i16> %{{.*}}
-  return _mm512_maskz_ipcvtbf16_epi8(__A, __B);
+  return _mm512_maskz_ipcvts_bf16_epi8(__A, __B);
 }
 
-__m512i test_mm512_ipcvtbf16_epu8(__m512bh __A) {
-  // CHECK-LABEL: @test_mm512_ipcvtbf16_epu8(
+__m512i test_mm512_ipcvts_bf16_epu8(__m512bh __A) {
+  // CHECK-LABEL: @test_mm512_ipcvts_bf16_epu8(
   // CHECK: @llvm.x86.avx10.vcvtbf162iubs512
-  return _mm512_ipcvtbf16_epu8(__A);
+  return _mm512_ipcvts_bf16_epu8(__A);
 }
 
-__m512i test_mm512_mask_ipcvtbf16_epu8(__m512i __S, __mmask32 __A, __m512bh __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvtbf16_epu8(
+__m512i test_mm512_mask_ipcvts_bf16_epu8(__m512i __S, __mmask32 __A, __m512bh __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvts_bf16_epu8(
   // CHECK: @llvm.x86.avx10.vcvtbf162iubs512
   // CHECK: select <32 x i1> %{{.*}}, <32 x i16> %{{.*}}, <32 x i16> %{{.*}}
-  return _mm512_mask_ipcvtbf16_epu8(__S, __A, __B);
+  return _mm512_mask_ipcvts_bf16_epu8(__S, __A, __B);
 }
 
-__m512i test_mm512_maskz_ipcvtbf16_epu8(__mmask32 __A, __m512bh __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvtbf16_epu8
+__m512i test_mm512_maskz_ipcvts_bf16_epu8(__mmask32 __A, __m512bh __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvts_bf16_epu8
   // CHECK: @llvm.x86.avx10.vcvtbf162iubs512
   // CHECK: zeroinitializer
   // CHECK: select <32 x i1> %{{.*}}, <32 x i16> %{{.*}}, <32 x i16> %{{.*}}
-  return _mm512_maskz_ipcvtbf16_epu8(__A, __B);
+  return _mm512_maskz_ipcvts_bf16_epu8(__A, __B);
 }
 
-__m512i test_mm512_ipcvtph_epi8(__m512h __A) {
-  // CHECK-LABEL: @test_mm512_ipcvtph_epi8(
+__m512i test_mm512_ipcvts_ph_epi8(__m512h __A) {
+  // CHECK-LABEL: @test_mm512_ipcvts_ph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2ibs512
-  return _mm512_ipcvtph_epi8(__A);
+  return _mm512_ipcvts_ph_epi8(__A);
 }
 
-__m512i test_mm512_mask_ipcvtph_epi8(__m512i __S, __mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvtph_epi8(
+__m512i test_mm512_mask_ipcvts_ph_epi8(__m512i __S, __mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvts_ph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2ibs512
-  return _mm512_mask_ipcvtph_epi8(__S, __A, __B);
+  return _mm512_mask_ipcvts_ph_epi8(__S, __A, __B);
 }
 
-__m512i test_mm512_maskz_ipcvtph_epi8(__mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvtph_epi8(
+__m512i test_mm512_maskz_ipcvts_ph_epi8(__mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvts_ph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2ibs512
-  return _mm512_maskz_ipcvtph_epi8(__A, __B);
+  return _mm512_maskz_ipcvts_ph_epi8(__A, __B);
 }
 
-__m512i test_mm512_ipcvt_roundph_epi8(__m512h __A) {
-  // CHECK-LABEL: @test_mm512_ipcvt_roundph_epi8(
+__m512i test_mm512_ipcvts_roundph_epi8(__m512h __A) {
+  // CHECK-LABEL: @test_mm512_ipcvts_roundph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2ibs512
-  return _mm512_ipcvt_roundph_epi8(__A, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm512_ipcvts_roundph_epi8(__A, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_mask_ipcvt_roundph_epi8(__m512i __S, __mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvt_roundph_epi8
+__m512i test_mm512_mask_ipcvts_roundph_epi8(__m512i __S, __mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvts_roundph_epi8
   // CHECK: @llvm.x86.avx10.mask.vcvtph2ibs512
-  return _mm512_mask_ipcvt_roundph_epi8(__S, __A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm512_mask_ipcvts_roundph_epi8(__S, __A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_maskz_ipcvt_roundph_epi8(__mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvt_roundph_epi8
+__m512i test_mm512_maskz_ipcvts_roundph_epi8(__mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvts_roundph_epi8
   // CHECK: @llvm.x86.avx10.mask.vcvtph2ibs512
-  return _mm512_maskz_ipcvt_roundph_epi8(__A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm512_maskz_ipcvts_roundph_epi8(__A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_ipcvtph_epu8(__m512h __A) {
-  // CHECK-LABEL: @test_mm512_ipcvtph_epu8(
+__m512i test_mm512_ipcvts_ph_epu8(__m512h __A) {
+  // CHECK-LABEL: @test_mm512_ipcvts_ph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2iubs512
-  return _mm512_ipcvtph_epu8(__A);
+  return _mm512_ipcvts_ph_epu8(__A);
 }
 
-__m512i test_mm512_mask_ipcvtph_epu8(__m512i __S, __mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvtph_epu8(
+__m512i test_mm512_mask_ipcvts_ph_epu8(__m512i __S, __mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvts_ph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2iubs512
-  return _mm512_mask_ipcvtph_epu8(__S, __A, __B);
+  return _mm512_mask_ipcvts_ph_epu8(__S, __A, __B);
 }
 
-__m512i test_mm512_maskz_ipcvtph_epu8(__mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvtph_epu8(
+__m512i test_mm512_maskz_ipcvts_ph_epu8(__mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvts_ph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2iubs512
-  return _mm512_maskz_ipcvtph_epu8(__A, __B);
+  return _mm512_maskz_ipcvts_ph_epu8(__A, __B);
 }
 
-__m512i test_mm512_ipcvt_roundph_epu8(__m512h __A) {
-  // CHECK-LABEL: @test_mm512_ipcvt_roundph_epu8(
+__m512i test_mm512_ipcvts_roundph_epu8(__m512h __A) {
+  // CHECK-LABEL: @test_mm512_ipcvts_roundph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2iubs512
-  return _mm512_ipcvt_roundph_epu8(__A, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm512_ipcvts_roundph_epu8(__A, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_mask_ipcvt_roundph_epu8(__m512i __S, __mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvt_roundph_epu8
+__m512i test_mm512_mask_ipcvts_roundph_epu8(__m512i __S, __mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvts_roundph_epu8
   // CHECK: @llvm.x86.avx10.mask.vcvtph2iubs512
-  return _mm512_mask_ipcvt_roundph_epu8(__S, __A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm512_mask_ipcvts_roundph_epu8(__S, __A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_maskz_ipcvt_roundph_epu8(__mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvt_roundph_epu8
+__m512i test_mm512_maskz_ipcvts_roundph_epu8(__mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvts_roundph_epu8
   // CHECK: @llvm.x86.avx10.mask.vcvtph2iubs512
-  return _mm512_maskz_ipcvt_roundph_epu8(__A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm512_maskz_ipcvts_roundph_epu8(__A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_ipcvtps_epi8(__m512 __A) {
-  // CHECK-LABEL: @test_mm512_ipcvtps_epi8(
+__m512i test_mm512_ipcvts_ps_epi8(__m512 __A) {
+  // CHECK-LABEL: @test_mm512_ipcvts_ps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2ibs512
-  return _mm512_ipcvtps_epi8(__A);
+  return _mm512_ipcvts_ps_epi8(__A);
 }
 
-__m512i test_mm512_mask_ipcvtps_epi8(__m512i __S, __mmask16 __A, __m512 __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvtps_epi8(
+__m512i test_mm512_mask_ipcvts_ps_epi8(__m512i __S, __mmask16 __A, __m512 __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvts_ps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2ibs512
-  return _mm512_mask_ipcvtps_epi8(__S, __A, __B);
+  return _mm512_mask_ipcvts_ps_epi8(__S, __A, __B);
 }
 
-__m512i test_mm512_maskz_ipcvtps_epi8(__mmask16 __A, __m512 __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvtps_epi8(
+__m512i test_mm512_maskz_ipcvts_ps_epi8(__mmask16 __A, __m512 __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvts_ps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2ibs512
-  return _mm512_maskz_ipcvtps_epi8(__A, __B);
+  return _mm512_maskz_ipcvts_ps_epi8(__A, __B);
 }
 
-__m512i test_mm512_ipcvt_roundps_epi8(__m512 __A) {
-  // CHECK-LABEL: @test_mm512_ipcvt_roundps_epi8(
+__m512i test_mm512_ipcvts_roundps_epi8(__m512 __A) {
+  // CHECK-LABEL: @test_mm512_ipcvts_roundps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2ibs512
-  return _mm512_ipcvt_roundps_epi8(__A, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm512_ipcvts_roundps_epi8(__A, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_mask_ipcvt_roundps_epi8(__m512i __S, __mmask16 __A, __m512 __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvt_roundps_epi8
+__m512i test_mm512_mask_ipcvts_roundps_epi8(__m512i __S, __mmask16 __A, __m512 __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvts_roundps_epi8
   // CHECK: @llvm.x86.avx10.mask.vcvtps2ibs512
-  return _mm512_mask_ipcvt_roundps_epi8(__S, __A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm512_mask_ipcvts_roundps_epi8(__S, __A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_maskz_ipcvt_roundps_epi8(__mmask16 __A, __m512 __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvt_roundps_epi8
+__m512i test_mm512_maskz_ipcvts_roundps_epi8(__mmask16 __A, __m512 __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvts_roundps_epi8
   // CHECK: @llvm.x86.avx10.mask.vcvtps2ibs512
-  return _mm512_maskz_ipcvt_roundps_epi8(__A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm512_maskz_ipcvts_roundps_epi8(__A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_ipcvtps_epu8(__m512 __A) {
-  // CHECK-LABEL: @test_mm512_ipcvtps_epu8(
+__m512i test_mm512_ipcvts_ps_epu8(__m512 __A) {
+  // CHECK-LABEL: @test_mm512_ipcvts_ps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2iubs512
-  return _mm512_ipcvtps_epu8(__A);
+  return _mm512_ipcvts_ps_epu8(__A);
 }
 
-__m512i test_mm512_mask_ipcvtps_epu8(__m512i __S, __mmask16 __A, __m512 __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvtps_epu8(
+__m512i test_mm512_mask_ipcvts_ps_epu8(__m512i __S, __mmask16 __A, __m512 __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvts_ps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2iubs512
-  return _mm512_mask_ipcvtps_epu8(__S, __A, __B);
+  return _mm512_mask_ipcvts_ps_epu8(__S, __A, __B);
 }
 
-__m512i test_mm512_maskz_ipcvtps_epu8(__mmask16 __A, __m512 __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvtps_epu8(
+__m512i test_mm512_maskz_ipcvts_ps_epu8(__mmask16 __A, __m512 __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvts_ps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2iubs512
-  return _mm512_maskz_ipcvtps_epu8(__A, __B);
+  return _mm512_maskz_ipcvts_ps_epu8(__A, __B);
 }
 
-__m512i test_mm512_ipcvt_roundps_epu8(__m512 __A) {
-  // CHECK-LABEL: @test_mm512_ipcvt_roundps_epu8(
+__m512i test_mm512_ipcvts_roundps_epu8(__m512 __A) {
+  // CHECK-LABEL: @test_mm512_ipcvts_roundps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2iubs512
-  return _mm512_ipcvt_roundps_epu8(__A, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm512_ipcvts_roundps_epu8(__A, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_mask_ipcvt_roundps_epu8(__m512i __S, __mmask16 __A, __m512 __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvt_roundps_epu8
+__m512i test_mm512_mask_ipcvts_roundps_epu8(__m512i __S, __mmask16 __A, __m512 __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvts_roundps_epu8
   // CHECK: @llvm.x86.avx10.mask.vcvtps2iubs512
-  return _mm512_mask_ipcvt_roundps_epu8(__S, __A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm512_mask_ipcvts_roundps_epu8(__S, __A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_maskz_ipcvt_roundps_epu8(__mmask16 __A, __m512 __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvt_roundps_epu8
+__m512i test_mm512_maskz_ipcvts_roundps_epu8(__mmask16 __A, __m512 __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvts_roundps_epu8
   // CHECK: @llvm.x86.avx10.mask.vcvtps2iubs512
-  return _mm512_maskz_ipcvt_roundps_epu8(__A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm512_maskz_ipcvts_roundps_epu8(__A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_ipcvttbf16_epi8(__m512bh __A) {
-  // CHECK-LABEL: @test_mm512_ipcvttbf16_epi8(
+__m512i test_mm512_ipcvtts_bf16_epi8(__m512bh __A) {
+  // CHECK-LABEL: @test_mm512_ipcvtts_bf16_epi8(
   // CHECK: @llvm.x86.avx10.vcvttbf162ibs512(
-  return _mm512_ipcvttbf16_epi8(__A);
+  return _mm512_ipcvtts_bf16_epi8(__A);
 }
 
-__m512i test_mm512_mask_ipcvttbf16_epi8(__m512i __S, __mmask32 __A, __m512bh __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvttbf16_epi8(
+__m512i test_mm512_mask_ipcvtts_bf16_epi8(__m512i __S, __mmask32 __A, __m512bh __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvtts_bf16_epi8(
   // CHECK: @llvm.x86.avx10.vcvttbf162ibs512(
   // CHECK: select <32 x i1> %{{.*}}, <32 x i16> %{{.*}}, <32 x i16> %{{.*}}
-  return _mm512_mask_ipcvttbf16_epi8(__S, __A, __B);
+  return _mm512_mask_ipcvtts_bf16_epi8(__S, __A, __B);
 }
 
-__m512i test_mm512_maskz_ipcvttbf16_epi8(__mmask32 __A, __m512bh __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvttbf16_epi8
+__m512i test_mm512_maskz_ipcvtts_bf16_epi8(__mmask32 __A, __m512bh __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvtts_bf16_epi8
   // CHECK: @llvm.x86.avx10.vcvttbf162ibs512(
   // CHECK: zeroinitializer
   // CHECK: select <32 x i1> %{{.*}}, <32 x i16> %{{.*}}, <32 x i16> %{{.*}}
-  return _mm512_maskz_ipcvttbf16_epi8(__A, __B);
+  return _mm512_maskz_ipcvtts_bf16_epi8(__A, __B);
 }
 
-__m512i test_mm512_ipcvttbf16_epu8(__m512bh __A) {
-  // CHECK-LABEL: @test_mm512_ipcvttbf16_epu8(
+__m512i test_mm512_ipcvtts_bf16_epu8(__m512bh __A) {
+  // CHECK-LABEL: @test_mm512_ipcvtts_bf16_epu8(
   // CHECK: @llvm.x86.avx10.vcvttbf162iubs512(
-  return _mm512_ipcvttbf16_epu8(__A);
+  return _mm512_ipcvtts_bf16_epu8(__A);
 }
 
-__m512i test_mm512_mask_ipcvttbf16_epu8(__m512i __S, __mmask32 __A, __m512bh __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvttbf16_epu8(
+__m512i test_mm512_mask_ipcvtts_bf16_epu8(__m512i __S, __mmask32 __A, __m512bh __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvtts_bf16_epu8(
   // CHECK: @llvm.x86.avx10.vcvttbf162iubs512(
   // CHECK: select <32 x i1> %{{.*}}, <32 x i16> %{{.*}}, <32 x i16> %{{.*}}
-  return _mm512_mask_ipcvttbf16_epu8(__S, __A, __B);
+  return _mm512_mask_ipcvtts_bf16_epu8(__S, __A, __B);
 }
 
-__m512i test_mm512_maskz_ipcvttbf16_epu8(__mmask32 __A, __m512bh __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvttbf16_epu8
+__m512i test_mm512_maskz_ipcvtts_bf16_epu8(__mmask32 __A, __m512bh __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvtts_bf16_epu8
   // CHECK: @llvm.x86.avx10.vcvttbf162iubs512(
   // CHECK: zeroinitializer
   // CHECK: select <32 x i1> %{{.*}}, <32 x i16> %{{.*}}, <32 x i16> %{{.*}}
-  return _mm512_maskz_ipcvttbf16_epu8(__A, __B);
+  return _mm512_maskz_ipcvtts_bf16_epu8(__A, __B);
 }
 
-__m512i test_mm512_ipcvttph_epi8(__m512h __A) {
-  // CHECK-LABEL: @test_mm512_ipcvttph_epi8(
+__m512i test_mm512_ipcvtts_ph_epi8(__m512h __A) {
+  // CHECK-LABEL: @test_mm512_ipcvtts_ph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2ibs512
-  return _mm512_ipcvttph_epi8(__A);
+  return _mm512_ipcvtts_ph_epi8(__A);
 }
 
-__m512i test_mm512_mask_ipcvttph_epi8(__m512i __S, __mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvttph_epi8(
+__m512i test_mm512_mask_ipcvtts_ph_epi8(__m512i __S, __mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvtts_ph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2ibs512
-  return _mm512_mask_ipcvttph_epi8(__S, __A, __B);
+  return _mm512_mask_ipcvtts_ph_epi8(__S, __A, __B);
 }
 
-__m512i test_mm512_maskz_ipcvttph_epi8(__mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvttph_epi8
+__m512i test_mm512_maskz_ipcvtts_ph_epi8(__mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvtts_ph_epi8
   // CHECK: @llvm.x86.avx10.mask.vcvttph2ibs512
-  return _mm512_maskz_ipcvttph_epi8(__A, __B);
+  return _mm512_maskz_ipcvtts_ph_epi8(__A, __B);
 }
 
-__m512i test_mm512_ipcvtt_roundph_epi8(__m512h __A) {
-  // CHECK-LABEL: @test_mm512_ipcvtt_roundph_epi8
+__m512i test_mm512_ipcvtts_roundph_epi8(__m512h __A) {
+  // CHECK-LABEL: @test_mm512_ipcvtts_roundph_epi8
   // CHECK: @llvm.x86.avx10.mask.vcvttph2ibs512
-  return _mm512_ipcvtt_roundph_epi8(__A, _MM_FROUND_NO_EXC);
+  return _mm512_ipcvtts_roundph_epi8(__A, _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_mask_ipcvtt_roundph_epi8(__m512i __S, __mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvtt_roundph_epi8
+__m512i test_mm512_mask_ipcvtts_roundph_epi8(__m512i __S, __mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvtts_roundph_epi8
   // CHECK: @llvm.x86.avx10.mask.vcvttph2ibs512
-  return _mm512_mask_ipcvtt_roundph_epi8(__S, __A, __B, _MM_FROUND_NO_EXC);
+  return _mm512_mask_ipcvtts_roundph_epi8(__S, __A, __B, _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_maskz_ipcvtt_roundph_epi8(__mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvtt_roundph_epi8
+__m512i test_mm512_maskz_ipcvtts_roundph_epi8(__mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvtts_roundph_epi8
   // CHECK: @llvm.x86.avx10.mask.vcvttph2ibs512
-  return _mm512_maskz_ipcvtt_roundph_epi8(__A, __B, _MM_FROUND_NO_EXC);
+  return _mm512_maskz_ipcvtts_roundph_epi8(__A, __B, _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_ipcvttph_epu8(__m512h __A) {
-  // CHECK-LABEL: @test_mm512_ipcvttph_epu8(
+__m512i test_mm512_ipcvtts_ph_epu8(__m512h __A) {
+  // CHECK-LABEL: @test_mm512_ipcvtts_ph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2iubs512
-  return _mm512_ipcvttph_epu8(__A);
+  return _mm512_ipcvtts_ph_epu8(__A);
 }
 
-__m512i test_mm512_mask_ipcvttph_epu8(__m512i __S, __mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvttph_epu8(
+__m512i test_mm512_mask_ipcvtts_ph_epu8(__m512i __S, __mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvtts_ph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2iubs512
-  return _mm512_mask_ipcvttph_epu8(__S, __A, __B);
+  return _mm512_mask_ipcvtts_ph_epu8(__S, __A, __B);
 }
 
-__m512i test_mm512_maskz_ipcvttph_epu8(__mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvttph_epu8
+__m512i test_mm512_maskz_ipcvtts_ph_epu8(__mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvtts_ph_epu8
   // CHECK: @llvm.x86.avx10.mask.vcvttph2iubs512
-  return _mm512_maskz_ipcvttph_epu8(__A, __B);
+  return _mm512_maskz_ipcvtts_ph_epu8(__A, __B);
 }
 
-__m512i test_mm512_ipcvtt_roundph_epu8(__m512h __A) {
-  // CHECK-LABEL: @test_mm512_ipcvtt_roundph_epu8
+__m512i test_mm512_ipcvtts_roundph_epu8(__m512h __A) {
+  // CHECK-LABEL: @test_mm512_ipcvtts_roundph_epu8
   // CHECK: @llvm.x86.avx10.mask.vcvttph2iubs512
-  return _mm512_ipcvtt_roundph_epu8(__A, _MM_FROUND_NO_EXC);
+  return _mm512_ipcvtts_roundph_epu8(__A, _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_mask_ipcvtt_roundph_epu8(__m512i __S, __mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvtt_roundph_epu8
+__m512i test_mm512_mask_ipcvtts_roundph_epu8(__m512i __S, __mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvtts_roundph_epu8
   // CHECK: @llvm.x86.avx10.mask.vcvttph2iubs512
-  return _mm512_mask_ipcvtt_roundph_epu8(__S, __A, __B, _MM_FROUND_NO_EXC);
+  return _mm512_mask_ipcvtts_roundph_epu8(__S, __A, __B, _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_maskz_ipcvtt_roundph_epu8(__mmask32 __A, __m512h __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvtt_roundph_epu8
+__m512i test_mm512_maskz_ipcvtts_roundph_epu8(__mmask32 __A, __m512h __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvtts_roundph_epu8
   // CHECK: @llvm.x86.avx10.mask.vcvttph2iubs512
-  return _mm512_maskz_ipcvtt_roundph_epu8(__A, __B, _MM_FROUND_NO_EXC);
+  return _mm512_maskz_ipcvtts_roundph_epu8(__A, __B, _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_ipcvttps_epi8(__m512 __A) {
-  // CHECK-LABEL: @test_mm512_ipcvttps_epi8(
+__m512i test_mm512_ipcvtts_ps_epi8(__m512 __A) {
+  // CHECK-LABEL: @test_mm512_ipcvtts_ps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2ibs512
-  return _mm512_ipcvttps_epi8(__A);
+  return _mm512_ipcvtts_ps_epi8(__A);
 }
 
-__m512i test_mm512_mask_ipcvttps_epi8(__m512i __S, __mmask16 __A, __m512 __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvttps_epi8(
+__m512i test_mm512_mask_ipcvtts_ps_epi8(__m512i __S, __mmask16 __A, __m512 __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvtts_ps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2ibs512
-  return _mm512_mask_ipcvttps_epi8(__S, __A, __B);
+  return _mm512_mask_ipcvtts_ps_epi8(__S, __A, __B);
 }
 
-__m512i test_mm512_maskz_ipcvttps_epi8(__mmask16 __A, __m512 __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvttps_epi8
+__m512i test_mm512_maskz_ipcvtts_ps_epi8(__mmask16 __A, __m512 __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvtts_ps_epi8
   // CHECK: @llvm.x86.avx10.mask.vcvttps2ibs512
-  return _mm512_maskz_ipcvttps_epi8(__A, __B);
+  return _mm512_maskz_ipcvtts_ps_epi8(__A, __B);
 }
 
-__m512i test_mm512_ipcvtt_roundps_epi8(__m512 __A) {
-  // CHECK-LABEL: @test_mm512_ipcvtt_roundps_epi8
+__m512i test_mm512_ipcvtts_roundps_epi8(__m512 __A) {
+  // CHECK-LABEL: @test_mm512_ipcvtts_roundps_epi8
   // CHECK: @llvm.x86.avx10.mask.vcvttps2ibs512
-  return _mm512_ipcvtt_roundps_epi8(__A, _MM_FROUND_NO_EXC);
+  return _mm512_ipcvtts_roundps_epi8(__A, _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_mask_ipcvtt_roundps_epi8(__m512i __S, __mmask16 __A, __m512 __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvtt_roundps_epi8
+__m512i test_mm512_mask_ipcvtts_roundps_epi8(__m512i __S, __mmask16 __A, __m512 __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvtts_roundps_epi8
   // CHECK: @llvm.x86.avx10.mask.vcvttps2ibs512
-  return _mm512_mask_ipcvtt_roundps_epi8(__S, __A, __B, _MM_FROUND_NO_EXC);
+  return _mm512_mask_ipcvtts_roundps_epi8(__S, __A, __B, _MM_FROUND_NO_EXC);
 }
 
 
-__m512i test_mm512_maskz_ipcvtt_roundps_epi8(__mmask16 __A, __m512 __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvtt_roundps_epi8
+__m512i test_mm512_maskz_ipcvtts_roundps_epi8(__mmask16 __A, __m512 __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvtts_roundps_epi8
   // CHECK: @llvm.x86.avx10.mask.vcvttps2ibs512
-  return _mm512_maskz_ipcvtt_roundps_epi8(__A, __B, _MM_FROUND_NO_EXC);
+  return _mm512_maskz_ipcvtts_roundps_epi8(__A, __B, _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_ipcvttps_epu8(__m512 __A) {
-  // CHECK-LABEL: @test_mm512_ipcvttps_epu8(
+__m512i test_mm512_ipcvtts_ps_epu8(__m512 __A) {
+  // CHECK-LABEL: @test_mm512_ipcvtts_ps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2iubs512
-  return _mm512_ipcvttps_epu8(__A);
+  return _mm512_ipcvtts_ps_epu8(__A);
 }
 
-__m512i test_mm512_mask_ipcvttps_epu8(__m512i __S, __mmask16 __A, __m512 __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvttps_epu8(
+__m512i test_mm512_mask_ipcvtts_ps_epu8(__m512i __S, __mmask16 __A, __m512 __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvtts_ps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2iubs512
-  return _mm512_mask_ipcvttps_epu8(__S, __A, __B);
+  return _mm512_mask_ipcvtts_ps_epu8(__S, __A, __B);
 }
 
-__m512i test_mm512_maskz_ipcvttps_epu8(__mmask16 __A, __m512 __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvttps_epu8
+__m512i test_mm512_maskz_ipcvtts_ps_epu8(__mmask16 __A, __m512 __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvtts_ps_epu8
   // CHECK: @llvm.x86.avx10.mask.vcvttps2iubs512
-  return _mm512_maskz_ipcvttps_epu8(__A, __B);
+  return _mm512_maskz_ipcvtts_ps_epu8(__A, __B);
 }
 
-__m512i test_mm512_ipcvtt_roundps_epu8(__m512 __A) {
-  // CHECK-LABEL: @test_mm512_ipcvtt_roundps_epu8
+__m512i test_mm512_ipcvtts_roundps_epu8(__m512 __A) {
+  // CHECK-LABEL: @test_mm512_ipcvtts_roundps_epu8
   // CHECK: @llvm.x86.avx10.mask.vcvttps2iubs512
-  return _mm512_ipcvtt_roundps_epu8(__A, _MM_FROUND_NO_EXC);
+  return _mm512_ipcvtts_roundps_epu8(__A, _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_mask_ipcvtt_roundps_epu8(__m512i __S, __mmask16 __A, __m512 __B) {
-  // CHECK-LABEL: @test_mm512_mask_ipcvtt_roundps_epu8
+__m512i test_mm512_mask_ipcvtts_roundps_epu8(__m512i __S, __mmask16 __A, __m512 __B) {
+  // CHECK-LABEL: @test_mm512_mask_ipcvtts_roundps_epu8
   // CHECK: @llvm.x86.avx10.mask.vcvttps2iubs512
-  return _mm512_mask_ipcvtt_roundps_epu8(__S, __A, __B, _MM_FROUND_NO_EXC);
+  return _mm512_mask_ipcvtts_roundps_epu8(__S, __A, __B, _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_maskz_ipcvtt_roundps_epu8(__mmask16 __A, __m512 __B) {
-  // CHECK-LABEL: @test_mm512_maskz_ipcvtt_roundps_epu8
+__m512i test_mm512_maskz_ipcvtts_roundps_epu8(__mmask16 __A, __m512 __B) {
+  // CHECK-LABEL: @test_mm512_maskz_ipcvtts_roundps_epu8
   // CHECK: @llvm.x86.avx10.mask.vcvttps2iubs512
-  return _mm512_maskz_ipcvtt_roundps_epu8(__A, __B, _MM_FROUND_NO_EXC);
+  return _mm512_maskz_ipcvtts_roundps_epu8(__A, __B, _MM_FROUND_NO_EXC);
 }

--- a/clang/test/CodeGen/X86/avx10_2_512satcvtds-builtins-x64.c
+++ b/clang/test/CodeGen/X86/avx10_2_512satcvtds-builtins-x64.c
@@ -3,58 +3,58 @@
 #include <immintrin.h>
 #include <stddef.h>
 
-long long test_mm_cvttssd_si64(__m128d __A) {
-  // CHECK-LABEL: @test_mm_cvttssd_si64(
+long long test_mm_cvtts_sd_si64(__m128d __A) {
+  // CHECK-LABEL: @test_mm_cvtts_sd_si64(
   // CHECK: @llvm.x86.avx10.vcvttsd2sis64(<2 x double>
   return _mm_cvtts_roundsd_si64(__A, _MM_FROUND_NO_EXC);
 }
 
-long long test_mm_cvttssd_i64(__m128d __A) {
-  // CHECK-LABEL: @test_mm_cvttssd_i64(
+long long test_mm_cvtts_sd_i64(__m128d __A) {
+  // CHECK-LABEL: @test_mm_cvtts_sd_i64(
   // CHECK: @llvm.x86.avx10.vcvttsd2sis64(<2 x double>
   return _mm_cvtts_roundsd_i64(__A, _MM_FROUND_NO_EXC);
 }
 
-unsigned long long test_mm_cvttssd_u64(__m128d __A) {
-  // CHECK-LABEL: @test_mm_cvttssd_u64(
+unsigned long long test_mm_cvtts_sd_u64(__m128d __A) {
+  // CHECK-LABEL: @test_mm_cvtts_sd_u64(
   // CHECK: @llvm.x86.avx10.vcvttsd2usis64(<2 x double>
   return _mm_cvtts_roundsd_u64(__A, _MM_FROUND_NO_EXC);
 }
 
-float test_mm_cvttsss_i64(__m128 __A) {
-  // CHECK-LABEL: @test_mm_cvttsss_i64(
+float test_mm_cvtts_ss_i64(__m128 __A) {
+  // CHECK-LABEL: @test_mm_cvtts_ss_i64(
   // CHECK: @llvm.x86.avx10.vcvttss2sis64(<4 x float>
   return _mm_cvtts_roundss_i64(__A, _MM_FROUND_NO_EXC);
 }
 
-long long test_mm_cvttsss_si64(__m128 __A) {
-  // CHECK-LABEL: @test_mm_cvttsss_si64(
+long long test_mm_cvtts_ss_si64(__m128 __A) {
+  // CHECK-LABEL: @test_mm_cvtts_ss_si64(
   // CHECK: @llvm.x86.avx10.vcvttss2sis64(<4 x float>
   return _mm_cvtts_roundss_si64(__A, _MM_FROUND_NO_EXC);
 }
 
-unsigned long long test_mm_cvttsss_u64(__m128 __A) {
-  // CHECK-LABEL: @test_mm_cvttsss_u64(
+unsigned long long test_mm_cvtts_ss_u64(__m128 __A) {
+  // CHECK-LABEL: @test_mm_cvtts_ss_u64(
   // CHECK: @llvm.x86.avx10.vcvttss2usis64(<4 x float>
   return _mm_cvtts_roundss_u64(__A, _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_cvttspd_epi64(__m512d A) {
-  // CHECK-LABEL: test_mm512_cvttspd_epi64
+__m512i test_mm512_cvtts_pd_epi64(__m512d A) {
+  // CHECK-LABEL: test_mm512_cvtts_pd_epi64
   // CHECK: @llvm.x86.avx10.mask.vcvttpd2qqs.round.512(<8 x double>
-  return _mm512_cvttspd_epi64(A);
+  return _mm512_cvtts_pd_epi64(A);
 }
 
-__m512i test_mm512_mask_cvttspd_epi64(__m512i W, __mmask8 U, __m512d A) {
-  // CHECK-LABEL: test_mm512_mask_cvttspd_epi64
+__m512i test_mm512_mask_cvtts_pd_epi64(__m512i W, __mmask8 U, __m512d A) {
+  // CHECK-LABEL: test_mm512_mask_cvtts_pd_epi64
   // CHECK: @llvm.x86.avx10.mask.vcvttpd2qqs.round.512(<8 x double>
-  return _mm512_mask_cvttspd_epi64(W, U, A);
+  return _mm512_mask_cvtts_pd_epi64(W, U, A);
 }
 
-__m512i test_mm512_maskz_cvttspd_epi64(__mmask8 U, __m512d A) {
-  // CHECK-LABEL: test_mm512_maskz_cvttspd_epi64
+__m512i test_mm512_maskz_cvtts_pd_epi64(__mmask8 U, __m512d A) {
+  // CHECK-LABEL: test_mm512_maskz_cvtts_pd_epi64
   // CHECK: @llvm.x86.avx10.mask.vcvttpd2qqs.round.512(<8 x double>
-  return _mm512_maskz_cvttspd_epi64(U, A);
+  return _mm512_maskz_cvtts_pd_epi64(U, A);
 }
 
 __m512i test_mm512_cvtts_roundpd_epi64(__m512d A) {
@@ -75,22 +75,22 @@ __m512i test_mm512_maskz_cvtts_roundpd_epi64(__mmask8 U, __m512d A) {
   return _mm512_maskz_cvtts_roundpd_epi64(U, A, _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_cvttspd_epu64(__m512d A) {
-  // CHECK-LABEL: test_mm512_cvttspd_epu64
+__m512i test_mm512_cvtts_pd_epu64(__m512d A) {
+  // CHECK-LABEL: test_mm512_cvtts_pd_epu64
   // CHECK: @llvm.x86.avx10.mask.vcvttpd2uqqs.round.512(<8 x double>
-  return _mm512_cvttspd_epu64(A);
+  return _mm512_cvtts_pd_epu64(A);
 }
 
-__m512i test_mm512_mask_cvttspd_epu64(__m512i W, __mmask8 U, __m512d A) {
-  // CHECK-LABEL: test_mm512_mask_cvttspd_epu64
+__m512i test_mm512_mask_cvtts_pd_epu64(__m512i W, __mmask8 U, __m512d A) {
+  // CHECK-LABEL: test_mm512_mask_cvtts_pd_epu64
   // CHECK: @llvm.x86.avx10.mask.vcvttpd2uqqs.round.512(<8 x double>
-  return _mm512_mask_cvttspd_epu64(W, U, A);
+  return _mm512_mask_cvtts_pd_epu64(W, U, A);
 }
 
-__m512i test_mm512_maskz_cvttspd_epu64(__mmask8 U, __m512d A) {
-  // CHECK-LABEL: test_mm512_maskz_cvttspd_epu64
+__m512i test_mm512_maskz_cvtts_pd_epu64(__mmask8 U, __m512d A) {
+  // CHECK-LABEL: test_mm512_maskz_cvtts_pd_epu64
   // CHECK: @llvm.x86.avx10.mask.vcvttpd2uqqs.round.512(<8 x double>
-  return _mm512_maskz_cvttspd_epu64(U, A);
+  return _mm512_maskz_cvtts_pd_epu64(U, A);
 }
 
 __m512i test_mm512_cvtts_roundpd_epu64(__m512d A) {
@@ -111,22 +111,22 @@ __m512i test_mm512_maskz_cvtts_roundpd_epu64(__mmask8 U, __m512d A) {
   return _mm512_maskz_cvtts_roundpd_epu64(U, A, _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_cvttsps_epi64(__m256 A) {
-  // CHECK-LABEL: test_mm512_cvttsps_epi64
+__m512i test_mm512_cvtts_ps_epi64(__m256 A) {
+  // CHECK-LABEL: test_mm512_cvtts_ps_epi64
   // CHECK: @llvm.x86.avx10.mask.vcvttps2qqs.round.512(<8 x float>
-  return _mm512_cvttsps_epi64(A);
+  return _mm512_cvtts_ps_epi64(A);
 }
 
-__m512i test_mm512_mask_cvttsps_epi64(__m512i W, __mmask8 U, __m256 A) {
-  // CHECK-LABEL: test_mm512_mask_cvttsps_epi64
+__m512i test_mm512_mask_cvtts_ps_epi64(__m512i W, __mmask8 U, __m256 A) {
+  // CHECK-LABEL: test_mm512_mask_cvtts_ps_epi64
   // CHECK: @llvm.x86.avx10.mask.vcvttps2qqs.round.512(<8 x float>
-  return _mm512_mask_cvttsps_epi64(W, U, A);
+  return _mm512_mask_cvtts_ps_epi64(W, U, A);
 }
 
-__m512i test_mm512_maskz_cvttsps_epi64(__mmask8 U, __m256 A) {
-  // CHECK-LABEL: test_mm512_maskz_cvttsps_epi64
+__m512i test_mm512_maskz_cvtts_ps_epi64(__mmask8 U, __m256 A) {
+  // CHECK-LABEL: test_mm512_maskz_cvtts_ps_epi64
   // CHECK: @llvm.x86.avx10.mask.vcvttps2qqs.round.512(<8 x float>
-  return _mm512_maskz_cvttsps_epi64(U, A);
+  return _mm512_maskz_cvtts_ps_epi64(U, A);
 }
 
 __m512i test_mm512_cvtts_roundps_epi64(__m256 A) {
@@ -147,22 +147,22 @@ __m512i test_mm512_maskz_cvtts_roundps_epi64(__mmask8 U, __m256 A) {
   return _mm512_maskz_cvtts_roundps_epi64(U, A, _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_cvttsps_epu64(__m256 A) {
-  // CHECK-LABEL: test_mm512_cvttsps_epu64
+__m512i test_mm512_cvtts_ps_epu64(__m256 A) {
+  // CHECK-LABEL: test_mm512_cvtts_ps_epu64
   // CHECK: @llvm.x86.avx10.mask.vcvttps2uqqs.round.512(<8 x float>
-  return _mm512_cvttsps_epu64(A);
+  return _mm512_cvtts_ps_epu64(A);
 }
 
-__m512i test_mm512_mask_cvttsps_epu64(__m512i W, __mmask8 U, __m256 A) {
-  // CHECK-LABEL: test_mm512_mask_cvttsps_epu64
+__m512i test_mm512_mask_cvtts_ps_epu64(__m512i W, __mmask8 U, __m256 A) {
+  // CHECK-LABEL: test_mm512_mask_cvtts_ps_epu64
   // CHECK: @llvm.x86.avx10.mask.vcvttps2uqqs.round.512(<8 x float>
-  return _mm512_mask_cvttsps_epu64(W, U, A);
+  return _mm512_mask_cvtts_ps_epu64(W, U, A);
 }
 
-__m512i test_mm512_maskz_cvttsps_epu64(__mmask8 U, __m256 A) {
-  // CHECK-LABEL: test_mm512_maskz_cvttsps_epu64
+__m512i test_mm512_maskz_cvtts_ps_epu64(__mmask8 U, __m256 A) {
+  // CHECK-LABEL: test_mm512_maskz_cvtts_ps_epu64
   // CHECK: @llvm.x86.avx10.mask.vcvttps2uqqs.round.512(<8 x float>
-  return _mm512_maskz_cvttsps_epu64(U, A);
+  return _mm512_maskz_cvtts_ps_epu64(U, A);
 }
 
 __m512i test_mm512_cvtts_roundps_epu64(__m256 A) {

--- a/clang/test/CodeGen/X86/avx10_2_512satcvtds-builtins.c
+++ b/clang/test/CodeGen/X86/avx10_2_512satcvtds-builtins.c
@@ -4,22 +4,22 @@
 #include <immintrin.h>
 #include <stddef.h>
 
-__m256i test_mm512_cvttspd_epi32(__m512d A) {
-  // CHECK-LABEL: test_mm512_cvttspd_epi32
+__m256i test_mm512_cvtts_pd_epi32(__m512d A) {
+  // CHECK-LABEL: test_mm512_cvtts_pd_epi32
   // CHECK: @llvm.x86.avx10.mask.vcvttpd2dqs.round.512(<8 x double>
-  return _mm512_cvttspd_epi32(A);
+  return _mm512_cvtts_pd_epi32(A);
 }
 
-__m256i test_mm512_mask_cvttspd_epi32(__m256i W, __mmask8 U, __m512d A) {
-  // CHECK-LABEL: test_mm512_mask_cvttspd_epi32
+__m256i test_mm512_mask_cvtts_pd_epi32(__m256i W, __mmask8 U, __m512d A) {
+  // CHECK-LABEL: test_mm512_mask_cvtts_pd_epi32
   // CHECK: @llvm.x86.avx10.mask.vcvttpd2dqs.round.512(<8 x double>
-  return _mm512_mask_cvttspd_epi32(W, U, A);
+  return _mm512_mask_cvtts_pd_epi32(W, U, A);
 }
 
-__m256i test_mm512_maskz_cvttspd_epi32(__mmask8 U, __m512d A) {
-  // CHECK-LABEL: test_mm512_maskz_cvttspd_epi32
+__m256i test_mm512_maskz_cvtts_pd_epi32(__mmask8 U, __m512d A) {
+  // CHECK-LABEL: test_mm512_maskz_cvtts_pd_epi32
   // CHECK: @llvm.x86.avx10.mask.vcvttpd2dqs.round.512(<8 x double>
-  return _mm512_maskz_cvttspd_epi32(U, A);
+  return _mm512_maskz_cvtts_pd_epi32(U, A);
 }
 
 __m256i test_mm512_cvtts_roundpd_epi32(__m512d A) {
@@ -40,22 +40,22 @@ __m256i test_mm512_maskz_cvtts_roundpd_epi32(__mmask8 U, __m512d A) {
   return _mm512_maskz_cvtts_roundpd_epi32(U, A, _MM_FROUND_NO_EXC);
 }
 
-__m256i test_mm512_cvttspd_epu32(__m512d A) {
-  // CHECK-LABEL: test_mm512_cvttspd_epu32
+__m256i test_mm512_cvtts_pd_epu32(__m512d A) {
+  // CHECK-LABEL: test_mm512_cvtts_pd_epu32
   // CHECK: @llvm.x86.avx10.mask.vcvttpd2udqs.round.512(<8 x double>
-  return _mm512_cvttspd_epu32(A);
+  return _mm512_cvtts_pd_epu32(A);
 }
 
-__m256i test_mm512_mask_cvttspd_epu32(__m256i W, __mmask8 U, __m512d A) {
-  // CHECK-LABEL: test_mm512_mask_cvttspd_epu32
+__m256i test_mm512_mask_cvtts_pd_epu32(__m256i W, __mmask8 U, __m512d A) {
+  // CHECK-LABEL: test_mm512_mask_cvtts_pd_epu32
   // CHECK: @llvm.x86.avx10.mask.vcvttpd2udqs.round.512(<8 x double>
-  return _mm512_mask_cvttspd_epu32(W, U, A);
+  return _mm512_mask_cvtts_pd_epu32(W, U, A);
 }
 
-__m256i test_mm512_maskz_cvttspd_epu32(__mmask8 U, __m512d A) {
-  // CHECK-LABEL: test_mm512_maskz_cvttspd_epu32
+__m256i test_mm512_maskz_cvtts_pd_epu32(__mmask8 U, __m512d A) {
+  // CHECK-LABEL: test_mm512_maskz_cvtts_pd_epu32
   // CHECK: @llvm.x86.avx10.mask.vcvttpd2udqs.round.512(<8 x double>
-  return _mm512_maskz_cvttspd_epu32(U, A);
+  return _mm512_maskz_cvtts_pd_epu32(U, A);
 }
 
 __m256i test_mm512_cvtts_roundpd_epu32(__m512d A) {
@@ -76,22 +76,22 @@ __m256i test_mm512_maskz_cvtts_roundpd_epu32(__mmask8 U, __m512d A) {
   return _mm512_maskz_cvtts_roundpd_epu32(U, A, _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_cvttsps_epi32(__m512 A) {
-  // CHECK-LABEL: test_mm512_cvttsps_epi32
+__m512i test_mm512_cvtts_ps_epi32(__m512 A) {
+  // CHECK-LABEL: test_mm512_cvtts_ps_epi32
   // CHECK: @llvm.x86.avx10.mask.vcvttps2dqs.round.512(<16 x float>
-  return _mm512_cvttsps_epi32(A);
+  return _mm512_cvtts_ps_epi32(A);
 }
 
-__m512i test_mm512_mask_cvttsps_epi32(__m512i W, __mmask8 U, __m512 A) {
-  // CHECK-LABEL: test_mm512_mask_cvttsps_epi32
+__m512i test_mm512_mask_cvtts_ps_epi32(__m512i W, __mmask8 U, __m512 A) {
+  // CHECK-LABEL: test_mm512_mask_cvtts_ps_epi32
   // CHECK: @llvm.x86.avx10.mask.vcvttps2dqs.round.512(<16 x float>
-  return _mm512_mask_cvttsps_epi32(W, U, A);
+  return _mm512_mask_cvtts_ps_epi32(W, U, A);
 }
 
-__m512i test_mm512_maskz_cvttsps_epi32(__mmask8 U, __m512 A) {
-  // CHECK-LABEL: test_mm512_maskz_cvttsps_epi32
+__m512i test_mm512_maskz_cvtts_ps_epi32(__mmask8 U, __m512 A) {
+  // CHECK-LABEL: test_mm512_maskz_cvtts_ps_epi32
   // CHECK: @llvm.x86.avx10.mask.vcvttps2dqs.round.512(<16 x float>
-  return _mm512_maskz_cvttsps_epi32(U, A);
+  return _mm512_maskz_cvtts_ps_epi32(U, A);
 }
 
 __m512i test_mm512_cvtts_roundps_epi32(__m512 A) {
@@ -112,22 +112,22 @@ __m512i test_mm512_maskz_cvtts_roundps_epi32(__mmask8 U, __m512 A) {
   return _mm512_maskz_cvtts_roundps_epi32(U, A, _MM_FROUND_NO_EXC);
 }
 
-__m512i test_mm512_cvttsps_epu32(__m512 A) {
-  // CHECK-LABEL: test_mm512_cvttsps_epu32
+__m512i test_mm512_cvtts_ps_epu32(__m512 A) {
+  // CHECK-LABEL: test_mm512_cvtts_ps_epu32
   // CHECK: @llvm.x86.avx10.mask.vcvttps2udqs.round.512(<16 x float>
-  return _mm512_cvttsps_epu32(A);
+  return _mm512_cvtts_ps_epu32(A);
 }
 
-__m512i test_mm512_mask_cvttsps_epu32(__m512i W, __mmask8 U, __m512 A) {
-  // CHECK-LABEL: test_mm512_mask_cvttsps_epu32
+__m512i test_mm512_mask_cvtts_ps_epu32(__m512i W, __mmask8 U, __m512 A) {
+  // CHECK-LABEL: test_mm512_mask_cvtts_ps_epu32
   // CHECK: @llvm.x86.avx10.mask.vcvttps2udqs.round.512(<16 x float>
-  return _mm512_mask_cvttsps_epu32(W, U, A);
+  return _mm512_mask_cvtts_ps_epu32(W, U, A);
 }
 
-__m512i test_mm512_maskz_cvttsps_epu32(__mmask8 U, __m512 A) {
-  // CHECK-LABEL: test_mm512_maskz_cvttsps_epu32
+__m512i test_mm512_maskz_cvtts_ps_epu32(__mmask8 U, __m512 A) {
+  // CHECK-LABEL: test_mm512_maskz_cvtts_ps_epu32
   // CHECK: @llvm.x86.avx10.mask.vcvttps2udqs.round.512(<16 x float>
-  return _mm512_maskz_cvttsps_epu32(U, A);
+  return _mm512_maskz_cvtts_ps_epu32(U, A);
 }
 
 __m512i test_mm512_cvtts_roundps_epu32(__m512 A) {

--- a/clang/test/CodeGen/X86/avx10_2convert-builtins.c
+++ b/clang/test/CodeGen/X86/avx10_2convert-builtins.c
@@ -95,40 +95,40 @@ __m128i test_mm256_maskz_cvtbiasph_bf8(__mmask16 __U, __m256i __A, __m256h __B) 
   return _mm256_maskz_cvtbiasph_bf8(__U, __A, __B);
 }
 
-__m128i test_mm_cvtbiassph_bf8(__m128i __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_cvtbiassph_bf8(
+__m128i test_mm_cvts_biasph_bf8(__m128i __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_cvts_biasph_bf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtbiasph2bf8s128(
-  return _mm_cvtbiassph_bf8(__A, __B);
+  return _mm_cvts_biasph_bf8(__A, __B);
 }
 
-__m128i test_mm_mask_cvtbiassph_bf8(__m128i __W, __mmask8 __U, __m128i __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_mask_cvtbiassph_bf8(
+__m128i test_mm_mask_cvts_biasph_bf8(__m128i __W, __mmask8 __U, __m128i __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_mask_cvts_biasph_bf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtbiasph2bf8s128(
-  return _mm_mask_cvtbiassph_bf8(__W, __U, __A, __B);
+  return _mm_mask_cvts_biasph_bf8(__W, __U, __A, __B);
 }
 
-__m128i test_mm_maskz_cvtbiassph_bf8(__mmask8 __U, __m128i __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_maskz_cvtbiassph_bf8(
+__m128i test_mm_maskz_cvts_biasph_bf8(__mmask8 __U, __m128i __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_maskz_cvts_biasph_bf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtbiasph2bf8s128(
-  return _mm_maskz_cvtbiassph_bf8(__U, __A, __B);
+  return _mm_maskz_cvts_biasph_bf8(__U, __A, __B);
 }
 
-__m128i test_mm256_cvtbiassph_bf8(__m256i __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_cvtbiassph_bf8(
+__m128i test_mm256_cvts_biasph_bf8(__m256i __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_cvts_biasph_bf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtbiasph2bf8s256(
-  return _mm256_cvtbiassph_bf8(__A, __B);
+  return _mm256_cvts_biasph_bf8(__A, __B);
 }
 
-__m128i test_mm256_mask_cvtbiassph_bf8(__m128i __W, __mmask16 __U, __m256i __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_mask_cvtbiassph_bf8(
+__m128i test_mm256_mask_cvts_biasph_bf8(__m128i __W, __mmask16 __U, __m256i __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_mask_cvts_biasph_bf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtbiasph2bf8s256(
-  return _mm256_mask_cvtbiassph_bf8(__W, __U, __A, __B);
+  return _mm256_mask_cvts_biasph_bf8(__W, __U, __A, __B);
 }
 
-__m128i test_mm256_maskz_cvtbiassph_bf8(__mmask16 __U, __m256i __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_maskz_cvtbiassph_bf8(
+__m128i test_mm256_maskz_cvts_biasph_bf8(__mmask16 __U, __m256i __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_maskz_cvts_biasph_bf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtbiasph2bf8s256(
-  return _mm256_maskz_cvtbiassph_bf8(__U, __A, __B);
+  return _mm256_maskz_cvts_biasph_bf8(__U, __A, __B);
 }
 
 __m128i test_mm_cvtbiasph_hf8(__m128i __A, __m128h __B) {
@@ -167,40 +167,40 @@ __m128i test_mm256_maskz_cvtbiasph_hf8(__mmask16 __U, __m256i __A, __m256h __B) 
   return _mm256_maskz_cvtbiasph_hf8(__U, __A, __B);
 }
 
-__m128i test_mm_cvtbiassph_hf8(__m128i __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_cvtbiassph_hf8(
+__m128i test_mm_cvts_biasph_hf8(__m128i __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_cvts_biasph_hf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtbiasph2hf8s128(
-  return _mm_cvtbiassph_hf8(__A, __B);
+  return _mm_cvts_biasph_hf8(__A, __B);
 }
 
-__m128i test_mm_mask_cvtbiassph_hf8(__m128i __W, __mmask8 __U, __m128i __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_mask_cvtbiassph_hf8(
+__m128i test_mm_mask_cvts_biasph_hf8(__m128i __W, __mmask8 __U, __m128i __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_mask_cvts_biasph_hf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtbiasph2hf8s128(
-  return _mm_mask_cvtbiassph_hf8(__W, __U, __A, __B);
+  return _mm_mask_cvts_biasph_hf8(__W, __U, __A, __B);
 }
 
-__m128i test_mm_maskz_cvtbiassph_hf8(__mmask8 __U, __m128i __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_maskz_cvtbiassph_hf8(
+__m128i test_mm_maskz_cvts_biasph_hf8(__mmask8 __U, __m128i __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_maskz_cvts_biasph_hf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtbiasph2hf8s128(
-  return _mm_maskz_cvtbiassph_hf8(__U, __A, __B);
+  return _mm_maskz_cvts_biasph_hf8(__U, __A, __B);
 }
 
-__m128i test_mm256_cvtbiassph_hf8(__m256i __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_cvtbiassph_hf8(
+__m128i test_mm256_cvts_biasph_hf8(__m256i __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_cvts_biasph_hf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtbiasph2hf8s256(
-  return _mm256_cvtbiassph_hf8(__A, __B);
+  return _mm256_cvts_biasph_hf8(__A, __B);
 }
 
-__m128i test_mm256_mask_cvtbiassph_hf8(__m128i __W, __mmask16 __U, __m256i __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_mask_cvtbiassph_hf8(
+__m128i test_mm256_mask_cvts_biasph_hf8(__m128i __W, __mmask16 __U, __m256i __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_mask_cvts_biasph_hf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtbiasph2hf8s256(
-  return _mm256_mask_cvtbiassph_hf8(__W, __U, __A, __B);
+  return _mm256_mask_cvts_biasph_hf8(__W, __U, __A, __B);
 }
 
-__m128i test_mm256_maskz_cvtbiassph_hf8(__mmask16 __U, __m256i __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_maskz_cvtbiassph_hf8(
+__m128i test_mm256_maskz_cvts_biasph_hf8(__mmask16 __U, __m256i __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_maskz_cvts_biasph_hf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtbiasph2hf8s256(
-  return _mm256_maskz_cvtbiassph_hf8(__U, __A, __B);
+  return _mm256_maskz_cvts_biasph_hf8(__U, __A, __B);
 }
 
 __m128i test_mm_cvt2ph_bf8(__m128h __A, __m128h __B) {

--- a/clang/test/CodeGen/X86/avx10_2convert-builtins.c
+++ b/clang/test/CodeGen/X86/avx10_2convert-builtins.c
@@ -247,48 +247,48 @@ __m256i test_mm256_maskz_cvt2ph_bf8(__mmask32 __U, __m256h __A, __m256h __B) {
   return _mm256_maskz_cvt2ph_bf8(__U, __A, __B);
 }
 
-__m128i test_mm_cvts2ph_bf8(__m128h __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_cvts2ph_bf8(
+__m128i test_mm_cvts_2ph_bf8(__m128h __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_cvts_2ph_bf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.vcvt2ph2bf8s128(
-  return _mm_cvts2ph_bf8(__A, __B);
+  return _mm_cvts_2ph_bf8(__A, __B);
 }
 
-__m128i test_mm_mask_cvts2ph_bf8(__m128i __W, __mmask16 __U, __m128h __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_mask_cvts2ph_bf8(
+__m128i test_mm_mask_cvts_2ph_bf8(__m128i __W, __mmask16 __U, __m128h __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_mask_cvts_2ph_bf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.vcvt2ph2bf8s128(
   // CHECK: select <16 x i1> %{{.*}}, <16 x i8> %{{.*}}, <16 x i8> %{{.*}}
   // CHECK: ret <2 x i64> %{{.*}}
-  return _mm_mask_cvts2ph_bf8(__W, __U, __A, __B);
+  return _mm_mask_cvts_2ph_bf8(__W, __U, __A, __B);
 }
 
-__m128i test_mm_maskz_cvts2ph_bf8(__mmask16 __U, __m128h __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_maskz_cvts2ph_bf8(
+__m128i test_mm_maskz_cvts_2ph_bf8(__mmask16 __U, __m128h __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_maskz_cvts_2ph_bf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.vcvt2ph2bf8s128(
   // CHECK: zeroinitializer
   // CHECK: select <16 x i1> %{{.*}}, <16 x i8> %{{.*}}, <16 x i8> %{{.*}}
-  return _mm_maskz_cvts2ph_bf8(__U, __A, __B);
+  return _mm_maskz_cvts_2ph_bf8(__U, __A, __B);
 }
 
-__m256i test_mm256_cvts2ph_bf8(__m256h __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_cvts2ph_bf8(
+__m256i test_mm256_cvts_2ph_bf8(__m256h __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_cvts_2ph_bf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.vcvt2ph2bf8s256(
-  return _mm256_cvts2ph_bf8(__A, __B);
+  return _mm256_cvts_2ph_bf8(__A, __B);
 }
 
-__m256i test_mm256_mask_cvts2ph_bf8(__m256i __W, __mmask32 __U, __m256h __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_mask_cvts2ph_bf8(
+__m256i test_mm256_mask_cvts_2ph_bf8(__m256i __W, __mmask32 __U, __m256h __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_mask_cvts_2ph_bf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.vcvt2ph2bf8s256(
   // CHECK: select <32 x i1> %{{.*}}, <32 x i8> %{{.*}}, <32 x i8> %{{.*}}
   // CHECK: ret <4 x i64> %{{.*}}
-  return _mm256_mask_cvts2ph_bf8(__W, __U, __A, __B);
+  return _mm256_mask_cvts_2ph_bf8(__W, __U, __A, __B);
 }
 
-__m256i test_mm256_maskz_cvts2ph_bf8(__mmask32 __U, __m256h __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_maskz_cvts2ph_bf8(
+__m256i test_mm256_maskz_cvts_2ph_bf8(__mmask32 __U, __m256h __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_maskz_cvts_2ph_bf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.vcvt2ph2bf8s256(
   // CHECK: zeroinitializer
   // CHECK: select <32 x i1> %{{.*}}, <32 x i8> %{{.*}}, <32 x i8> %{{.*}}
-  return _mm256_maskz_cvts2ph_bf8(__U, __A, __B);
+  return _mm256_maskz_cvts_2ph_bf8(__U, __A, __B);
 }
 
 __m128i test_mm_cvt2ph_hf8(__m128h __A, __m128h __B) {
@@ -335,48 +335,48 @@ __m256i test_mm256_maskz_cvt2ph_hf8(__mmask32 __U, __m256h __A, __m256h __B) {
   return _mm256_maskz_cvt2ph_hf8(__U, __A, __B);
 }
 
-__m128i test_mm_cvts2ph_hf8(__m128h __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_cvts2ph_hf8(
+__m128i test_mm_cvts_2ph_hf8(__m128h __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_cvts_2ph_hf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.vcvt2ph2hf8s128(
-  return _mm_cvts2ph_hf8(__A, __B);
+  return _mm_cvts_2ph_hf8(__A, __B);
 }
 
-__m128i test_mm_mask_cvts2ph_hf8(__m128i __W, __mmask16 __U, __m128h __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_mask_cvts2ph_hf8(
+__m128i test_mm_mask_cvts_2ph_hf8(__m128i __W, __mmask16 __U, __m128h __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_mask_cvts_2ph_hf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.vcvt2ph2hf8s128(
   // CHECK: select <16 x i1> %{{.*}}, <16 x i8> %{{.*}}, <16 x i8> %{{.*}}
   // CHECK: ret <2 x i64> %{{.*}}
-  return _mm_mask_cvts2ph_hf8(__W, __U, __A, __B);
+  return _mm_mask_cvts_2ph_hf8(__W, __U, __A, __B);
 }
 
-__m128i test_mm_maskz_cvts2ph_hf8(__mmask16 __U, __m128h __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_maskz_cvts2ph_hf8(
+__m128i test_mm_maskz_cvts_2ph_hf8(__mmask16 __U, __m128h __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_maskz_cvts_2ph_hf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.vcvt2ph2hf8s128(
   // CHECK: zeroinitializer
   // CHECK: select <16 x i1> %{{.*}}, <16 x i8> %{{.*}}, <16 x i8> %{{.*}}
-  return _mm_maskz_cvts2ph_hf8(__U, __A, __B);
+  return _mm_maskz_cvts_2ph_hf8(__U, __A, __B);
 }
 
-__m256i test_mm256_cvts2ph_hf8(__m256h __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_cvts2ph_hf8(
+__m256i test_mm256_cvts_2ph_hf8(__m256h __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_cvts_2ph_hf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.vcvt2ph2hf8s256(
-  return _mm256_cvts2ph_hf8(__A, __B);
+  return _mm256_cvts_2ph_hf8(__A, __B);
 }
 
-__m256i test_mm256_mask_cvts2ph_hf8(__m256i __W, __mmask32 __U, __m256h __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_mask_cvts2ph_hf8(
+__m256i test_mm256_mask_cvts_2ph_hf8(__m256i __W, __mmask32 __U, __m256h __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_mask_cvts_2ph_hf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.vcvt2ph2hf8s256(
   // CHECK: select <32 x i1> %{{.*}}, <32 x i8> %{{.*}}, <32 x i8> %{{.*}}
   // CHECK: ret <4 x i64> %{{.*}}
-  return _mm256_mask_cvts2ph_hf8(__W, __U, __A, __B);
+  return _mm256_mask_cvts_2ph_hf8(__W, __U, __A, __B);
 }
 
-__m256i test_mm256_maskz_cvts2ph_hf8(__mmask32 __U, __m256h __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_maskz_cvts2ph_hf8(
+__m256i test_mm256_maskz_cvts_2ph_hf8(__mmask32 __U, __m256h __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_maskz_cvts_2ph_hf8(
   // CHECK: call <32 x i8> @llvm.x86.avx10.vcvt2ph2hf8s256(
   // CHECK: zeroinitializer
   // CHECK: select <32 x i1> %{{.*}}, <32 x i8> %{{.*}}, <32 x i8> %{{.*}}
-  return _mm256_maskz_cvts2ph_hf8(__U, __A, __B);
+  return _mm256_maskz_cvts_2ph_hf8(__U, __A, __B);
 }
 
 __m128h test_mm_cvthf8_ph(__m128i __A) {
@@ -451,40 +451,40 @@ __m128i test_mm256_maskz_cvtph_bf8(__mmask16 __A, __m256h __B) {
   return _mm256_maskz_cvtph_bf8(__A, __B);
 }
 
-__m128i test_mm_cvtsph_bf8(__m128h __A) {
-  // CHECK-LABEL: @test_mm_cvtsph_bf8(
+__m128i test_mm_cvts_ph_bf8(__m128h __A) {
+  // CHECK-LABEL: @test_mm_cvts_ph_bf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtph2bf8s128(
-  return _mm_cvtsph_bf8(__A);
+  return _mm_cvts_ph_bf8(__A);
 }
 
-__m128i test_mm_mask_cvtsph_bf8(__m128i __A, __mmask8 __B, __m128h __C) {
-  // CHECK-LABEL: @test_mm_mask_cvtsph_bf8(
+__m128i test_mm_mask_cvts_ph_bf8(__m128i __A, __mmask8 __B, __m128h __C) {
+  // CHECK-LABEL: @test_mm_mask_cvts_ph_bf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtph2bf8s128(
-  return _mm_mask_cvtsph_bf8(__A, __B, __C);
+  return _mm_mask_cvts_ph_bf8(__A, __B, __C);
 }
 
-__m128i test_mm_maskz_cvtsph_bf8(__mmask8 __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_maskz_cvtsph_bf8(
+__m128i test_mm_maskz_cvts_ph_bf8(__mmask8 __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_maskz_cvts_ph_bf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtph2bf8s128(
-  return _mm_maskz_cvtsph_bf8(__A, __B);
+  return _mm_maskz_cvts_ph_bf8(__A, __B);
 }
 
-__m128i test_mm256_cvtsph_bf8(__m256h __A) {
-  // CHECK-LABEL: @test_mm256_cvtsph_bf8(
+__m128i test_mm256_cvts_ph_bf8(__m256h __A) {
+  // CHECK-LABEL: @test_mm256_cvts_ph_bf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtph2bf8s256(
-  return _mm256_cvtsph_bf8(__A);
+  return _mm256_cvts_ph_bf8(__A);
 }
 
-__m128i test_mm256_mask_cvtsph_bf8(__m128i __A, __mmask16 __B, __m256h __C) {
-  // CHECK-LABEL: @test_mm256_mask_cvtsph_bf8(
+__m128i test_mm256_mask_cvts_ph_bf8(__m128i __A, __mmask16 __B, __m256h __C) {
+  // CHECK-LABEL: @test_mm256_mask_cvts_ph_bf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtph2bf8s256(
-  return _mm256_mask_cvtsph_bf8(__A, __B, __C);
+  return _mm256_mask_cvts_ph_bf8(__A, __B, __C);
 }
 
-__m128i test_mm256_maskz_cvtsph_bf8(__mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_maskz_cvtsph_bf8(
+__m128i test_mm256_maskz_cvts_ph_bf8(__mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_maskz_cvts_ph_bf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtph2bf8s256(
-  return _mm256_maskz_cvtsph_bf8(__A, __B);
+  return _mm256_maskz_cvts_ph_bf8(__A, __B);
 }
 
 __m128i test_mm_cvtph_hf8(__m128h __A) {
@@ -523,40 +523,40 @@ __m128i test_mm256_maskz_cvtph_hf8(__mmask16 __A, __m256h __B) {
   return _mm256_maskz_cvtph_hf8(__A, __B);
 }
 
-__m128i test_mm_cvtsph_hf8(__m128h __A) {
-  // CHECK-LABEL: @test_mm_cvtsph_hf8(
+__m128i test_mm_cvts_ph_hf8(__m128h __A) {
+  // CHECK-LABEL: @test_mm_cvts_ph_hf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtph2hf8s128(
-  return _mm_cvtsph_hf8(__A);
+  return _mm_cvts_ph_hf8(__A);
 }
 
-__m128i test_mm_mask_cvtsph_hf8(__m128i __A, __mmask8 __B, __m128h __C) {
-  // CHECK-LABEL: @test_mm_mask_cvtsph_hf8(
+__m128i test_mm_mask_cvts_ph_hf8(__m128i __A, __mmask8 __B, __m128h __C) {
+  // CHECK-LABEL: @test_mm_mask_cvts_ph_hf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtph2hf8s128(
-  return _mm_mask_cvtsph_hf8(__A, __B, __C);
+  return _mm_mask_cvts_ph_hf8(__A, __B, __C);
 }
 
-__m128i test_mm_maskz_cvtsph_hf8(__mmask8 __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_maskz_cvtsph_hf8(
+__m128i test_mm_maskz_cvts_ph_hf8(__mmask8 __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_maskz_cvts_ph_hf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtph2hf8s128(
-  return _mm_maskz_cvtsph_hf8(__A, __B);
+  return _mm_maskz_cvts_ph_hf8(__A, __B);
 }
 
-__m128i test_mm256_cvtsph_hf8(__m256h __A) {
-  // CHECK-LABEL: @test_mm256_cvtsph_hf8(
+__m128i test_mm256_cvts_ph_hf8(__m256h __A) {
+  // CHECK-LABEL: @test_mm256_cvts_ph_hf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtph2hf8s256(
-  return _mm256_cvtsph_hf8(__A);
+  return _mm256_cvts_ph_hf8(__A);
 }
 
-__m128i test_mm256_mask_cvtsph_hf8(__m128i __A, __mmask16 __B, __m256h __C) {
-  // CHECK-LABEL: @test_mm256_mask_cvtsph_hf8(
+__m128i test_mm256_mask_cvts_ph_hf8(__m128i __A, __mmask16 __B, __m256h __C) {
+  // CHECK-LABEL: @test_mm256_mask_cvts_ph_hf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtph2hf8s256(
-  return _mm256_mask_cvtsph_hf8(__A, __B, __C);
+  return _mm256_mask_cvts_ph_hf8(__A, __B, __C);
 }
 
-__m128i test_mm256_maskz_cvtsph_hf8(__mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_maskz_cvtsph_hf8(
+__m128i test_mm256_maskz_cvts_ph_hf8(__mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_maskz_cvts_ph_hf8(
   // CHECK: call <16 x i8> @llvm.x86.avx10.mask.vcvtph2hf8s256(
-  return _mm256_maskz_cvtsph_hf8(__A, __B);
+  return _mm256_maskz_cvts_ph_hf8(__A, __B);
 }
 
 __m256h test_mm256_cvtbf8_ph(__m128i A) {

--- a/clang/test/CodeGen/X86/avx10_2satcvt-builtins.c
+++ b/clang/test/CodeGen/X86/avx10_2satcvt-builtins.c
@@ -5,599 +5,599 @@
 
 #include <immintrin.h>
 
-__m128i test_mm_ipcvtbf16_epi8(__m128bh __A) {
-  // CHECK-LABEL: @test_mm_ipcvtbf16_epi8(
+__m128i test_mm_ipcvts_bf16_epi8(__m128bh __A) {
+  // CHECK-LABEL: @test_mm_ipcvts_bf16_epi8(
   // CHECK: @llvm.x86.avx10.vcvtbf162ibs128
-  return _mm_ipcvtbf16_epi8(__A);
+  return _mm_ipcvts_bf16_epi8(__A);
 }
 
-__m128i test_mm_mask_ipcvtbf16_epi8(__m128i __S, __mmask8 __A, __m128bh __B) {
-  // CHECK-LABEL: @test_mm_mask_ipcvtbf16_epi8(
+__m128i test_mm_mask_ipcvts_bf16_epi8(__m128i __S, __mmask8 __A, __m128bh __B) {
+  // CHECK-LABEL: @test_mm_mask_ipcvts_bf16_epi8(
   // CHECK: @llvm.x86.avx10.vcvtbf162ibs128
   // CHECK: select <8 x i1> %{{.*}}, <8 x i16> %{{.*}}, <8 x i16> %{{.*}}
-  return _mm_mask_ipcvtbf16_epi8(__S, __A, __B);
+  return _mm_mask_ipcvts_bf16_epi8(__S, __A, __B);
 }
 
-__m128i test_mm_maskz_ipcvtbf16_epi8(__mmask8 __A, __m128bh __B) {
-  // CHECK-LABEL: @test_mm_maskz_ipcvtbf16_epi8(
+__m128i test_mm_maskz_ipcvts_bf16_epi8(__mmask8 __A, __m128bh __B) {
+  // CHECK-LABEL: @test_mm_maskz_ipcvts_bf16_epi8(
   // CHECK: @llvm.x86.avx10.vcvtbf162ibs128
   // CHECK: zeroinitializer
   // CHECK: select <8 x i1> %{{.*}}, <8 x i16> %{{.*}}, <8 x i16> %{{.*}}
-  return _mm_maskz_ipcvtbf16_epi8(__A, __B);
+  return _mm_maskz_ipcvts_bf16_epi8(__A, __B);
 }
 
-__m256i test_mm256_ipcvtbf16_epi8(__m256bh __A) {
-  // CHECK-LABEL: @test_mm256_ipcvtbf16_epi8(
+__m256i test_mm256_ipcvts_bf16_epi8(__m256bh __A) {
+  // CHECK-LABEL: @test_mm256_ipcvts_bf16_epi8(
   // CHECK: @llvm.x86.avx10.vcvtbf162ibs256
-  return _mm256_ipcvtbf16_epi8(__A);
+  return _mm256_ipcvts_bf16_epi8(__A);
 }
 
-__m256i test_mm256_mask_ipcvtbf16_epi8(__m256i __S, __mmask16 __A, __m256bh __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvtbf16_epi8(
+__m256i test_mm256_mask_ipcvts_bf16_epi8(__m256i __S, __mmask16 __A, __m256bh __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvts_bf16_epi8(
   // CHECK: @llvm.x86.avx10.vcvtbf162ibs256
   // CHECK: select <16 x i1> %{{.*}}, <16 x i16> %{{.*}}, <16 x i16> %{{.*}}
-  return _mm256_mask_ipcvtbf16_epi8(__S, __A, __B);
+  return _mm256_mask_ipcvts_bf16_epi8(__S, __A, __B);
 }
 
-__m256i test_mm256_maskz_ipcvtbf16_epi8(__mmask16 __A, __m256bh __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvtbf16_epi8(
+__m256i test_mm256_maskz_ipcvts_bf16_epi8(__mmask16 __A, __m256bh __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvts_bf16_epi8(
   // CHECK: @llvm.x86.avx10.vcvtbf162ibs256
   // CHECK: zeroinitializer
   // CHECK: select <16 x i1> %{{.*}}, <16 x i16> %{{.*}}, <16 x i16> %{{.*}}
-  return _mm256_maskz_ipcvtbf16_epi8(__A, __B);
+  return _mm256_maskz_ipcvts_bf16_epi8(__A, __B);
 }
 
-__m128i test_mm_ipcvtbf16_epu8(__m128bh __A) {
-  // CHECK-LABEL: @test_mm_ipcvtbf16_epu8(
+__m128i test_mm_ipcvts_bf16_epu8(__m128bh __A) {
+  // CHECK-LABEL: @test_mm_ipcvts_bf16_epu8(
   // CHECK: @llvm.x86.avx10.vcvtbf162iubs128
-  return _mm_ipcvtbf16_epu8(__A);
+  return _mm_ipcvts_bf16_epu8(__A);
 }
 
-__m128i test_mm_mask_ipcvtbf16_epu8(__m128i __S, __mmask8 __A, __m128bh __B) {
-  // CHECK-LABEL: @test_mm_mask_ipcvtbf16_epu8(
-  // CHECK: @llvm.x86.avx10.vcvtbf162iubs128
-  // CHECK: select <8 x i1> %{{.*}}, <8 x i16> %{{.*}}, <8 x i16> %{{.*}}
-  return _mm_mask_ipcvtbf16_epu8(__S, __A, __B);
-}
-
-__m128i test_mm_maskz_ipcvtbf16_epu8(__mmask8 __A, __m128bh __B) {
-  // CHECK-LABEL: @test_mm_maskz_ipcvtbf16_epu8(
+__m128i test_mm_mask_ipcvts_bf16_epu8(__m128i __S, __mmask8 __A, __m128bh __B) {
+  // CHECK-LABEL: @test_mm_mask_ipcvts_bf16_epu8(
   // CHECK: @llvm.x86.avx10.vcvtbf162iubs128
   // CHECK: select <8 x i1> %{{.*}}, <8 x i16> %{{.*}}, <8 x i16> %{{.*}}
-  return _mm_maskz_ipcvtbf16_epu8(__A, __B);
+  return _mm_mask_ipcvts_bf16_epu8(__S, __A, __B);
 }
 
-__m256i test_mm256_ipcvtbf16_epu8(__m256bh __A) {
-  // CHECK-LABEL: @test_mm256_ipcvtbf16_epu8(
+__m128i test_mm_maskz_ipcvts_bf16_epu8(__mmask8 __A, __m128bh __B) {
+  // CHECK-LABEL: @test_mm_maskz_ipcvts_bf16_epu8(
+  // CHECK: @llvm.x86.avx10.vcvtbf162iubs128
+  // CHECK: select <8 x i1> %{{.*}}, <8 x i16> %{{.*}}, <8 x i16> %{{.*}}
+  return _mm_maskz_ipcvts_bf16_epu8(__A, __B);
+}
+
+__m256i test_mm256_ipcvts_bf16_epu8(__m256bh __A) {
+  // CHECK-LABEL: @test_mm256_ipcvts_bf16_epu8(
   // CHECK: @llvm.x86.avx10.vcvtbf162iubs256
-  return _mm256_ipcvtbf16_epu8(__A);
+  return _mm256_ipcvts_bf16_epu8(__A);
 }
 
-__m256i test_mm256_mask_ipcvtbf16_epu8(__m256i __S, __mmask16 __A, __m256bh __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvtbf16_epu8(
+__m256i test_mm256_mask_ipcvts_bf16_epu8(__m256i __S, __mmask16 __A, __m256bh __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvts_bf16_epu8(
   // CHECK: @llvm.x86.avx10.vcvtbf162iubs256
   // CHECK: select <16 x i1> %{{.*}}, <16 x i16> %{{.*}}, <16 x i16> %{{.*}}
-  return _mm256_mask_ipcvtbf16_epu8(__S, __A, __B);
+  return _mm256_mask_ipcvts_bf16_epu8(__S, __A, __B);
 }
 
-__m256i test_mm256_maskz_ipcvtbf16_epu8(__mmask16 __A, __m256bh __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvtbf16_epu8(
+__m256i test_mm256_maskz_ipcvts_bf16_epu8(__mmask16 __A, __m256bh __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvts_bf16_epu8(
   // CHECK: @llvm.x86.avx10.vcvtbf162iubs256
   // CHECK: zeroinitializer
   // CHECK: select <16 x i1> %{{.*}}, <16 x i16> %{{.*}}, <16 x i16> %{{.*}}
-  return _mm256_maskz_ipcvtbf16_epu8(__A, __B);
+  return _mm256_maskz_ipcvts_bf16_epu8(__A, __B);
 }
 
-__m128i test_mm_ipcvtph_epi8(__m128h __A) {
-  // CHECK-LABEL: @test_mm_ipcvtph_epi8(
+__m128i test_mm_ipcvts_ph_epi8(__m128h __A) {
+  // CHECK-LABEL: @test_mm_ipcvts_ph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2ibs128
-  return _mm_ipcvtph_epi8(__A);
+  return _mm_ipcvts_ph_epi8(__A);
 }
 
-__m128i test_mm_mask_ipcvtph_epi8(__m128i __S, __mmask8 __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_mask_ipcvtph_epi8(
+__m128i test_mm_mask_ipcvts_ph_epi8(__m128i __S, __mmask8 __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_mask_ipcvts_ph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2ibs128
-  return _mm_mask_ipcvtph_epi8(__S, __A, __B);
+  return _mm_mask_ipcvts_ph_epi8(__S, __A, __B);
 }
 
-__m128i test_mm_maskz_ipcvtph_epi8(__mmask8 __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_maskz_ipcvtph_epi8(
+__m128i test_mm_maskz_ipcvts_ph_epi8(__mmask8 __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_maskz_ipcvts_ph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2ibs128
-  return _mm_maskz_ipcvtph_epi8(__A, __B);
+  return _mm_maskz_ipcvts_ph_epi8(__A, __B);
 }
 
-__m256i test_mm256_ipcvtph_epi8(__m256h __A) {
-  // CHECK-LABEL: @test_mm256_ipcvtph_epi8(
+__m256i test_mm256_ipcvts_ph_epi8(__m256h __A) {
+  // CHECK-LABEL: @test_mm256_ipcvts_ph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2ibs256
-  return _mm256_ipcvtph_epi8(__A);
+  return _mm256_ipcvts_ph_epi8(__A);
 }
 
-__m256i test_mm256_mask_ipcvtph_epi8(__m256i __S, __mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvtph_epi8(
+__m256i test_mm256_mask_ipcvts_ph_epi8(__m256i __S, __mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvts_ph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2ibs256
-  return _mm256_mask_ipcvtph_epi8(__S, __A, __B);
+  return _mm256_mask_ipcvts_ph_epi8(__S, __A, __B);
 }
 
-__m256i test_mm256_maskz_ipcvtph_epi8(__mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvtph_epi8(
+__m256i test_mm256_maskz_ipcvts_ph_epi8(__mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvts_ph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2ibs256
-  return _mm256_maskz_ipcvtph_epi8(__A, __B);
+  return _mm256_maskz_ipcvts_ph_epi8(__A, __B);
 }
 
-__m256i test_mm256_ipcvt_roundph_epi8(__m256h __A) {
-  // CHECK-LABEL: @test_mm256_ipcvt_roundph_epi8(
+__m256i test_mm256_ipcvts_roundph_epi8(__m256h __A) {
+  // CHECK-LABEL: @test_mm256_ipcvts_roundph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2ibs256
-  return _mm256_ipcvt_roundph_epi8(__A, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm256_ipcvts_roundph_epi8(__A, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m256i test_mm256_mask_ipcvt_roundph_epi8(__m256i __S, __mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvt_roundph_epi8(
+__m256i test_mm256_mask_ipcvts_roundph_epi8(__m256i __S, __mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvts_roundph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2ibs256
-  return _mm256_mask_ipcvt_roundph_epi8(__S, __A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm256_mask_ipcvts_roundph_epi8(__S, __A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
-__m256i test_mm256_maskz_ipcvt_roundph_epi8(__mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvt_roundph_epi8(
+__m256i test_mm256_maskz_ipcvts_roundph_epi8(__mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvts_roundph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2ibs256
-  return _mm256_maskz_ipcvt_roundph_epi8(__A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm256_maskz_ipcvts_roundph_epi8(__A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m128i test_mm_ipcvtph_epu8(__m128h __A) {
-  // CHECK-LABEL: @test_mm_ipcvtph_epu8(
+__m128i test_mm_ipcvts_ph_epu8(__m128h __A) {
+  // CHECK-LABEL: @test_mm_ipcvts_ph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2iubs128
-  return _mm_ipcvtph_epu8(__A);
+  return _mm_ipcvts_ph_epu8(__A);
 }
 
-__m128i test_mm_mask_ipcvtph_epu8(__m128i __S, __mmask8 __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_mask_ipcvtph_epu8(
+__m128i test_mm_mask_ipcvts_ph_epu8(__m128i __S, __mmask8 __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_mask_ipcvts_ph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2iubs128
-  return _mm_mask_ipcvtph_epu8(__S, __A, __B);
+  return _mm_mask_ipcvts_ph_epu8(__S, __A, __B);
 }
 
-__m128i test_mm_maskz_ipcvtph_epu8(__mmask8 __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_maskz_ipcvtph_epu8(
+__m128i test_mm_maskz_ipcvts_ph_epu8(__mmask8 __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_maskz_ipcvts_ph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2iubs128
-  return _mm_maskz_ipcvtph_epu8(__A, __B);
+  return _mm_maskz_ipcvts_ph_epu8(__A, __B);
 }
 
-__m256i test_mm256_ipcvtph_epu8(__m256h __A) {
-  // CHECK-LABEL: @test_mm256_ipcvtph_epu8(
+__m256i test_mm256_ipcvts_ph_epu8(__m256h __A) {
+  // CHECK-LABEL: @test_mm256_ipcvts_ph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2iubs256
-  return _mm256_ipcvtph_epu8(__A);
+  return _mm256_ipcvts_ph_epu8(__A);
 }
 
-__m256i test_mm256_mask_ipcvtph_epu8(__m256i __S, __mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvtph_epu8(
+__m256i test_mm256_mask_ipcvts_ph_epu8(__m256i __S, __mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvts_ph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2iubs256
-  return _mm256_mask_ipcvtph_epu8(__S, __A, __B);
+  return _mm256_mask_ipcvts_ph_epu8(__S, __A, __B);
 }
 
-__m256i test_mm256_maskz_ipcvtph_epu8(__mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvtph_epu8(
+__m256i test_mm256_maskz_ipcvts_ph_epu8(__mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvts_ph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2iubs256
-  return _mm256_maskz_ipcvtph_epu8(__A, __B);
+  return _mm256_maskz_ipcvts_ph_epu8(__A, __B);
 }
 
-__m256i test_mm256_ipcvt_roundph_epu8(__m256h __A) {
-  // CHECK-LABEL: @test_mm256_ipcvt_roundph_epu8(
+__m256i test_mm256_ipcvts_roundph_epu8(__m256h __A) {
+  // CHECK-LABEL: @test_mm256_ipcvts_roundph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2iubs256
-  return _mm256_ipcvt_roundph_epu8(__A, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm256_ipcvts_roundph_epu8(__A, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m256i test_mm256_mask_ipcvt_roundph_epu8(__m256i __S, __mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvt_roundph_epu8(
+__m256i test_mm256_mask_ipcvts_roundph_epu8(__m256i __S, __mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvts_roundph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2iubs256
-  return _mm256_mask_ipcvt_roundph_epu8(__S, __A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm256_mask_ipcvts_roundph_epu8(__S, __A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
-__m256i test_mm256_maskz_ipcvt_roundph_epu8(__mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvt_roundph_epu8(
+__m256i test_mm256_maskz_ipcvts_roundph_epu8(__mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvts_roundph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtph2iubs256
-  return _mm256_maskz_ipcvt_roundph_epu8(__A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm256_maskz_ipcvts_roundph_epu8(__A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m128i test_mm_ipcvtps_epi8(__m128 __A) {
-  // CHECK-LABEL: @test_mm_ipcvtps_epi8(
+__m128i test_mm_ipcvts_ps_epi8(__m128 __A) {
+  // CHECK-LABEL: @test_mm_ipcvts_ps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2ibs128
-  return _mm_ipcvtps_epi8(__A);
+  return _mm_ipcvts_ps_epi8(__A);
 }
 
-__m128i test_mm_mask_ipcvtps_epi8(__m128i __S, __mmask8 __A, __m128 __B) {
-  // CHECK-LABEL: @test_mm_mask_ipcvtps_epi8(
+__m128i test_mm_mask_ipcvts_ps_epi8(__m128i __S, __mmask8 __A, __m128 __B) {
+  // CHECK-LABEL: @test_mm_mask_ipcvts_ps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2ibs128
-  return _mm_mask_ipcvtps_epi8(__S, __A, __B);
+  return _mm_mask_ipcvts_ps_epi8(__S, __A, __B);
 }
 
-__m128i test_mm_maskz_ipcvtps_epi8(__mmask8 __A, __m128 __B) {
-  // CHECK-LABEL: @test_mm_maskz_ipcvtps_epi8(
+__m128i test_mm_maskz_ipcvts_ps_epi8(__mmask8 __A, __m128 __B) {
+  // CHECK-LABEL: @test_mm_maskz_ipcvts_ps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2ibs128
-  return _mm_maskz_ipcvtps_epi8(__A, __B);
+  return _mm_maskz_ipcvts_ps_epi8(__A, __B);
 }
 
-__m256i test_mm256_ipcvtps_epi8(__m256 __A) {
-  // CHECK-LABEL: @test_mm256_ipcvtps_epi8(
+__m256i test_mm256_ipcvts_ps_epi8(__m256 __A) {
+  // CHECK-LABEL: @test_mm256_ipcvts_ps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2ibs256
-  return _mm256_ipcvtps_epi8(__A);
+  return _mm256_ipcvts_ps_epi8(__A);
 }
 
-__m256i test_mm256_mask_ipcvtps_epi8(__m256i __S, __mmask8 __A, __m256 __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvtps_epi8(
+__m256i test_mm256_mask_ipcvts_ps_epi8(__m256i __S, __mmask8 __A, __m256 __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvts_ps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2ibs256
-  return _mm256_mask_ipcvtps_epi8(__S, __A, __B);
+  return _mm256_mask_ipcvts_ps_epi8(__S, __A, __B);
 }
 
-__m256i test_mm256_maskz_ipcvtps_epi8(__mmask8 __A, __m256 __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvtps_epi8(
+__m256i test_mm256_maskz_ipcvts_ps_epi8(__mmask8 __A, __m256 __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvts_ps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2ibs256
-  return _mm256_maskz_ipcvtps_epi8(__A, __B);
+  return _mm256_maskz_ipcvts_ps_epi8(__A, __B);
 }
 
-__m256i test_mm256_ipcvt_roundps_epi8(__m256 __A) {
-  // CHECK-LABEL: @test_mm256_ipcvt_roundps_epi8(
+__m256i test_mm256_ipcvts_roundps_epi8(__m256 __A) {
+  // CHECK-LABEL: @test_mm256_ipcvts_roundps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2ibs256
-  return _mm256_ipcvt_roundps_epi8(__A, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm256_ipcvts_roundps_epi8(__A, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m256i test_mm256_mask_ipcvt_roundps_epi8(__m256i __S, __mmask8 __A, __m256 __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvt_roundps_epi8(
+__m256i test_mm256_mask_ipcvts_roundps_epi8(__m256i __S, __mmask8 __A, __m256 __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvts_roundps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2ibs256
-  return _mm256_mask_ipcvt_roundps_epi8(__S, __A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm256_mask_ipcvts_roundps_epi8(__S, __A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m256i test_mm256_maskz_ipcvt_roundps_epi8(__mmask8 __A, __m256 __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvt_roundps_epi8(
+__m256i test_mm256_maskz_ipcvts_roundps_epi8(__mmask8 __A, __m256 __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvts_roundps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2ibs256
-  return _mm256_maskz_ipcvt_roundps_epi8(__A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm256_maskz_ipcvts_roundps_epi8(__A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m128i test_mm_ipcvtps_epu8(__m128 __A) {
-  // CHECK-LABEL: @test_mm_ipcvtps_epu8(
+__m128i test_mm_ipcvts_ps_epu8(__m128 __A) {
+  // CHECK-LABEL: @test_mm_ipcvts_ps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2iubs128
-  return _mm_ipcvtps_epu8(__A);
+  return _mm_ipcvts_ps_epu8(__A);
 }
 
-__m128i test_mm_mask_ipcvtps_epu8(__m128i __S, __mmask8 __A, __m128 __B) {
-  // CHECK-LABEL: @test_mm_mask_ipcvtps_epu8(
+__m128i test_mm_mask_ipcvts_ps_epu8(__m128i __S, __mmask8 __A, __m128 __B) {
+  // CHECK-LABEL: @test_mm_mask_ipcvts_ps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2iubs128
-  return _mm_mask_ipcvtps_epu8(__S, __A, __B);
+  return _mm_mask_ipcvts_ps_epu8(__S, __A, __B);
 }
 
-__m128i test_mm_maskz_ipcvtps_epu8(__mmask8 __A, __m128 __B) {
-  // CHECK-LABEL: @test_mm_maskz_ipcvtps_epu8(
+__m128i test_mm_maskz_ipcvts_ps_epu8(__mmask8 __A, __m128 __B) {
+  // CHECK-LABEL: @test_mm_maskz_ipcvts_ps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2iubs128
-  return _mm_maskz_ipcvtps_epu8(__A, __B);
+  return _mm_maskz_ipcvts_ps_epu8(__A, __B);
 }
 
-__m256i test_mm256_ipcvtps_epu8(__m256 __A) {
-  // CHECK-LABEL: @test_mm256_ipcvtps_epu8(
+__m256i test_mm256_ipcvts_ps_epu8(__m256 __A) {
+  // CHECK-LABEL: @test_mm256_ipcvts_ps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2iubs256
-  return _mm256_ipcvtps_epu8(__A);
+  return _mm256_ipcvts_ps_epu8(__A);
 }
 
-__m256i test_mm256_mask_ipcvtps_epu8(__m256i __S, __mmask8 __A, __m256 __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvtps_epu8(
+__m256i test_mm256_mask_ipcvts_ps_epu8(__m256i __S, __mmask8 __A, __m256 __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvts_ps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2iubs256
-  return _mm256_mask_ipcvtps_epu8(__S, __A, __B);
+  return _mm256_mask_ipcvts_ps_epu8(__S, __A, __B);
 }
 
-__m256i test_mm256_maskz_ipcvtps_epu8(__mmask8 __A, __m256 __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvtps_epu8(
+__m256i test_mm256_maskz_ipcvts_ps_epu8(__mmask8 __A, __m256 __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvts_ps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2iubs256
-  return _mm256_maskz_ipcvtps_epu8(__A, __B);
+  return _mm256_maskz_ipcvts_ps_epu8(__A, __B);
 }
 
-__m256i test_mm256_ipcvt_roundps_epu8(__m256 __A) {
-  // CHECK-LABEL: @test_mm256_ipcvt_roundps_epu8(
+__m256i test_mm256_ipcvts_roundps_epu8(__m256 __A) {
+  // CHECK-LABEL: @test_mm256_ipcvts_roundps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2iubs256
-  return _mm256_ipcvt_roundps_epu8(__A, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm256_ipcvts_roundps_epu8(__A, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m256i test_mm256_mask_ipcvt_roundps_epu8(__m256i __S, __mmask8 __A, __m256 __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvt_roundps_epu8(
+__m256i test_mm256_mask_ipcvts_roundps_epu8(__m256i __S, __mmask8 __A, __m256 __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvts_roundps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2iubs256
-  return _mm256_mask_ipcvt_roundps_epu8(__S, __A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm256_mask_ipcvts_roundps_epu8(__S, __A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m256i test_mm256_maskz_ipcvt_roundps_epu8(__mmask8 __A, __m256 __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvt_roundps_epu8(
+__m256i test_mm256_maskz_ipcvts_roundps_epu8(__mmask8 __A, __m256 __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvts_roundps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvtps2iubs256
-  return _mm256_maskz_ipcvt_roundps_epu8(__A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
+  return _mm256_maskz_ipcvts_roundps_epu8(__A, __B, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC);
 }
 
-__m128i test_mm_ipcvttbf16_epi8(__m128bh __A) {
-  // CHECK-LABEL: @test_mm_ipcvttbf16_epi8(
+__m128i test_mm_ipcvtts_bf16_epi8(__m128bh __A) {
+  // CHECK-LABEL: @test_mm_ipcvtts_bf16_epi8(
   // CHECK: @llvm.x86.avx10.vcvttbf162ibs128
-  return _mm_ipcvttbf16_epi8(__A);
+  return _mm_ipcvtts_bf16_epi8(__A);
 }
 
-__m128i test_mm_mask_ipcvttbf16_epi8(__m128i __S, __mmask8 __A, __m128bh __B) {
-  // CHECK-LABEL: @test_mm_mask_ipcvttbf16_epi8(
+__m128i test_mm_mask_ipcvtts_bf16_epi8(__m128i __S, __mmask8 __A, __m128bh __B) {
+  // CHECK-LABEL: @test_mm_mask_ipcvtts_bf16_epi8(
   // CHECK: @llvm.x86.avx10.vcvttbf162ibs128
   // CHECK: select <8 x i1> %{{.*}}, <8 x i16> %{{.*}}, <8 x i16> %{{.*}}
-  return _mm_mask_ipcvttbf16_epi8(__S, __A, __B);
+  return _mm_mask_ipcvtts_bf16_epi8(__S, __A, __B);
 }
 
-__m128i test_mm_maskz_ipcvttbf16_epi8(__mmask8 __A, __m128bh __B) {
-  // CHECK-LABEL: @test_mm_maskz_ipcvttbf16_epi8(
+__m128i test_mm_maskz_ipcvtts_bf16_epi8(__mmask8 __A, __m128bh __B) {
+  // CHECK-LABEL: @test_mm_maskz_ipcvtts_bf16_epi8(
   // CHECK: @llvm.x86.avx10.vcvttbf162ibs128
   // CHECK: zeroinitializer
   // CHECK: select <8 x i1> %{{.*}}, <8 x i16> %{{.*}}, <8 x i16> %{{.*}}
-  return _mm_maskz_ipcvttbf16_epi8(__A, __B);
+  return _mm_maskz_ipcvtts_bf16_epi8(__A, __B);
 }
 
-__m256i test_mm256_ipcvttbf16_epi8(__m256bh __A) {
-  // CHECK-LABEL: @test_mm256_ipcvttbf16_epi8(
+__m256i test_mm256_ipcvtts_bf16_epi8(__m256bh __A) {
+  // CHECK-LABEL: @test_mm256_ipcvtts_bf16_epi8(
   // CHECK: @llvm.x86.avx10.vcvttbf162ibs256
-  return _mm256_ipcvttbf16_epi8(__A);
+  return _mm256_ipcvtts_bf16_epi8(__A);
 }
 
-__m256i test_mm256_mask_ipcvttbf16_epi8(__m256i __S, __mmask16 __A, __m256bh __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvttbf16_epi8(
+__m256i test_mm256_mask_ipcvtts_bf16_epi8(__m256i __S, __mmask16 __A, __m256bh __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvtts_bf16_epi8(
   // CHECK: @llvm.x86.avx10.vcvttbf162ibs256
   // CHECK: select <16 x i1> %{{.*}}, <16 x i16> %{{.*}}, <16 x i16> %{{.*}}
-  return _mm256_mask_ipcvttbf16_epi8(__S, __A, __B);
+  return _mm256_mask_ipcvtts_bf16_epi8(__S, __A, __B);
 }
 
-__m256i test_mm256_maskz_ipcvttbf16_epi8(__mmask16 __A, __m256bh __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvttbf16_epi8(
+__m256i test_mm256_maskz_ipcvtts_bf16_epi8(__mmask16 __A, __m256bh __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvtts_bf16_epi8(
   // CHECK: @llvm.x86.avx10.vcvttbf162ibs256
   // CHECK: zeroinitializer
   // CHECK: select <16 x i1> %{{.*}}, <16 x i16> %{{.*}}, <16 x i16> %{{.*}}
-  return _mm256_maskz_ipcvttbf16_epi8(__A, __B);
+  return _mm256_maskz_ipcvtts_bf16_epi8(__A, __B);
 }
 
-__m128i test_mm_ipcvttbf16_epu8(__m128bh __A) {
-  // CHECK-LABEL: @test_mm_ipcvttbf16_epu8(
+__m128i test_mm_ipcvtts_bf16_epu8(__m128bh __A) {
+  // CHECK-LABEL: @test_mm_ipcvtts_bf16_epu8(
   // CHECK: @llvm.x86.avx10.vcvttbf162iubs128
-  return _mm_ipcvttbf16_epu8(__A);
+  return _mm_ipcvtts_bf16_epu8(__A);
 }
 
-__m128i test_mm_mask_ipcvttbf16_epu8(__m128i __S, __mmask8 __A, __m128bh __B) {
-  // CHECK-LABEL: @test_mm_mask_ipcvttbf16_epu8(
+__m128i test_mm_mask_ipcvtts_bf16_epu8(__m128i __S, __mmask8 __A, __m128bh __B) {
+  // CHECK-LABEL: @test_mm_mask_ipcvtts_bf16_epu8(
   // CHECK: @llvm.x86.avx10.vcvttbf162iubs128
   // CHECK: select <8 x i1> %{{.*}}, <8 x i16> %{{.*}}, <8 x i16> %{{.*}}
-  return _mm_mask_ipcvttbf16_epu8(__S, __A, __B);
+  return _mm_mask_ipcvtts_bf16_epu8(__S, __A, __B);
 }
 
-__m128i test_mm_maskz_ipcvttbf16_epu8(__mmask8 __A, __m128bh __B) {
-  // CHECK-LABEL: @test_mm_maskz_ipcvttbf16_epu8(
+__m128i test_mm_maskz_ipcvtts_bf16_epu8(__mmask8 __A, __m128bh __B) {
+  // CHECK-LABEL: @test_mm_maskz_ipcvtts_bf16_epu8(
   // CHECK: @llvm.x86.avx10.vcvttbf162iubs128
   // CHECK: zeroinitializer
   // CHECK: select <8 x i1> %{{.*}}, <8 x i16> %{{.*}}, <8 x i16> %{{.*}}
-  return _mm_maskz_ipcvttbf16_epu8(__A, __B);
+  return _mm_maskz_ipcvtts_bf16_epu8(__A, __B);
 }
 
-__m256i test_mm256_ipcvttbf16_epu8(__m256bh __A) {
-  // CHECK-LABEL: @test_mm256_ipcvttbf16_epu8(
+__m256i test_mm256_ipcvtts_bf16_epu8(__m256bh __A) {
+  // CHECK-LABEL: @test_mm256_ipcvtts_bf16_epu8(
   // CHECK: @llvm.x86.avx10.vcvttbf162iubs256
-  return _mm256_ipcvttbf16_epu8(__A);
+  return _mm256_ipcvtts_bf16_epu8(__A);
 }
 
-__m256i test_mm256_mask_ipcvttbf16_epu8(__m256i __S, __mmask16 __A, __m256bh __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvttbf16_epu8(
+__m256i test_mm256_mask_ipcvtts_bf16_epu8(__m256i __S, __mmask16 __A, __m256bh __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvtts_bf16_epu8(
   // CHECK: @llvm.x86.avx10.vcvttbf162iubs256
   // CHECK: select <16 x i1> %{{.*}}, <16 x i16> %{{.*}}, <16 x i16> %{{.*}}
-  return _mm256_mask_ipcvttbf16_epu8(__S, __A, __B);
+  return _mm256_mask_ipcvtts_bf16_epu8(__S, __A, __B);
 }
 
-__m256i test_mm256_maskz_ipcvttbf16_epu8(__mmask16 __A, __m256bh __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvttbf16_epu8(
+__m256i test_mm256_maskz_ipcvtts_bf16_epu8(__mmask16 __A, __m256bh __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvtts_bf16_epu8(
   // CHECK: @llvm.x86.avx10.vcvttbf162iubs256
   // CHECK: zeroinitializer
   // CHECK: select <16 x i1> %{{.*}}, <16 x i16> %{{.*}}, <16 x i16> %{{.*}}
-  return _mm256_maskz_ipcvttbf16_epu8(__A, __B);
+  return _mm256_maskz_ipcvtts_bf16_epu8(__A, __B);
 }
 
-__m128i test_mm_ipcvttph_epi8(__m128h __A) {
-  // CHECK-LABEL: @test_mm_ipcvttph_epi8(
+__m128i test_mm_ipcvtts_ph_epi8(__m128h __A) {
+  // CHECK-LABEL: @test_mm_ipcvtts_ph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2ibs128
-  return _mm_ipcvttph_epi8(__A);
+  return _mm_ipcvtts_ph_epi8(__A);
 }
 
-__m128i test_mm_mask_ipcvttph_epi8(__m128i __S, __mmask8 __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_mask_ipcvttph_epi8(
+__m128i test_mm_mask_ipcvtts_ph_epi8(__m128i __S, __mmask8 __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_mask_ipcvtts_ph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2ibs128
-  return _mm_mask_ipcvttph_epi8(__S, __A, __B);
+  return _mm_mask_ipcvtts_ph_epi8(__S, __A, __B);
 }
 
-__m128i test_mm_maskz_ipcvttph_epi8(__mmask8 __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_maskz_ipcvttph_epi8(
+__m128i test_mm_maskz_ipcvtts_ph_epi8(__mmask8 __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_maskz_ipcvtts_ph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2ibs128
-  return _mm_maskz_ipcvttph_epi8(__A, __B);
+  return _mm_maskz_ipcvtts_ph_epi8(__A, __B);
 }
 
-__m256i test_mm256_ipcvttph_epi8(__m256h __A) {
-  // CHECK-LABEL: @test_mm256_ipcvttph_epi8(
+__m256i test_mm256_ipcvtts_ph_epi8(__m256h __A) {
+  // CHECK-LABEL: @test_mm256_ipcvtts_ph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2ibs256
-  return _mm256_ipcvttph_epi8(__A);
+  return _mm256_ipcvtts_ph_epi8(__A);
 }
 
-__m256i test_mm256_mask_ipcvttph_epi8(__m256i __S, __mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvttph_epi8(
+__m256i test_mm256_mask_ipcvtts_ph_epi8(__m256i __S, __mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvtts_ph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2ibs256
-  return _mm256_mask_ipcvttph_epi8(__S, __A, __B);
+  return _mm256_mask_ipcvtts_ph_epi8(__S, __A, __B);
 }
 
-__m256i test_mm256_maskz_ipcvttph_epi8(__mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvttph_epi8(
+__m256i test_mm256_maskz_ipcvtts_ph_epi8(__mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvtts_ph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2ibs256
-  return _mm256_maskz_ipcvttph_epi8(__A, __B);
+  return _mm256_maskz_ipcvtts_ph_epi8(__A, __B);
 }
 
-__m256i test_mm256_ipcvtt_roundph_epi8(__m256h __A) {
-  // CHECK-LABEL: @test_mm256_ipcvtt_roundph_epi8(
+__m256i test_mm256_ipcvtts_roundph_epi8(__m256h __A) {
+  // CHECK-LABEL: @test_mm256_ipcvtts_roundph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2ibs256
-  return _mm256_ipcvtt_roundph_epi8(__A, _MM_FROUND_NO_EXC);
+  return _mm256_ipcvtts_roundph_epi8(__A, _MM_FROUND_NO_EXC);
 }
 
-__m256i test_mm256_mask_ipcvtt_roundph_epi8(__m256i __S, __mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvtt_roundph_epi8(
+__m256i test_mm256_mask_ipcvtts_roundph_epi8(__m256i __S, __mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvtts_roundph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2ibs256
-  return _mm256_mask_ipcvtt_roundph_epi8(__S, __A, __B, _MM_FROUND_NO_EXC);
+  return _mm256_mask_ipcvtts_roundph_epi8(__S, __A, __B, _MM_FROUND_NO_EXC);
 }
 
-__m256i test_mm256_maskz_ipcvtt_roundph_epi8(__mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvtt_roundph_epi8(
+__m256i test_mm256_maskz_ipcvtts_roundph_epi8(__mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvtts_roundph_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2ibs256
-  return _mm256_maskz_ipcvtt_roundph_epi8(__A, __B, _MM_FROUND_NO_EXC);
+  return _mm256_maskz_ipcvtts_roundph_epi8(__A, __B, _MM_FROUND_NO_EXC);
 }
 
-__m128i test_mm_ipcvttph_epu8(__m128h __A) {
-  // CHECK-LABEL: @test_mm_ipcvttph_epu8(
+__m128i test_mm_ipcvtts_ph_epu8(__m128h __A) {
+  // CHECK-LABEL: @test_mm_ipcvtts_ph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2iubs128
-  return _mm_ipcvttph_epu8(__A);
+  return _mm_ipcvtts_ph_epu8(__A);
 }
 
-__m128i test_mm_mask_ipcvttph_epu8(__m128i __S, __mmask8 __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_mask_ipcvttph_epu8(
+__m128i test_mm_mask_ipcvtts_ph_epu8(__m128i __S, __mmask8 __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_mask_ipcvtts_ph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2iubs128
-  return _mm_mask_ipcvttph_epu8(__S, __A, __B);
+  return _mm_mask_ipcvtts_ph_epu8(__S, __A, __B);
 }
 
-__m128i test_mm_maskz_ipcvttph_epu8(__mmask8 __A, __m128h __B) {
-  // CHECK-LABEL: @test_mm_maskz_ipcvttph_epu8(
+__m128i test_mm_maskz_ipcvtts_ph_epu8(__mmask8 __A, __m128h __B) {
+  // CHECK-LABEL: @test_mm_maskz_ipcvtts_ph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2iubs128
-  return _mm_maskz_ipcvttph_epu8(__A, __B);
+  return _mm_maskz_ipcvtts_ph_epu8(__A, __B);
 }
 
-__m256i test_mm256_ipcvttph_epu8(__m256h __A) {
-  // CHECK-LABEL: @test_mm256_ipcvttph_epu8(
+__m256i test_mm256_ipcvtts_ph_epu8(__m256h __A) {
+  // CHECK-LABEL: @test_mm256_ipcvtts_ph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2iubs256
-  return _mm256_ipcvttph_epu8(__A);
+  return _mm256_ipcvtts_ph_epu8(__A);
 }
 
-__m256i test_mm256_mask_ipcvttph_epu8(__m256i __S, __mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvttph_epu8(
+__m256i test_mm256_mask_ipcvtts_ph_epu8(__m256i __S, __mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvtts_ph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2iubs256
-  return _mm256_mask_ipcvttph_epu8(__S, __A, __B);
+  return _mm256_mask_ipcvtts_ph_epu8(__S, __A, __B);
 }
 
-__m256i test_mm256_maskz_ipcvttph_epu8(__mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvttph_epu8(
+__m256i test_mm256_maskz_ipcvtts_ph_epu8(__mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvtts_ph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2iubs256
-  return _mm256_maskz_ipcvttph_epu8(__A, __B);
+  return _mm256_maskz_ipcvtts_ph_epu8(__A, __B);
 }
 
-__m256i test_mm256_ipcvtt_roundph_epu8(__m256h __A) {
-  // CHECK-LABEL: @test_mm256_ipcvtt_roundph_epu8(
+__m256i test_mm256_ipcvtts_roundph_epu8(__m256h __A) {
+  // CHECK-LABEL: @test_mm256_ipcvtts_roundph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2iubs256
-  return _mm256_ipcvtt_roundph_epu8(__A, _MM_FROUND_NO_EXC);
+  return _mm256_ipcvtts_roundph_epu8(__A, _MM_FROUND_NO_EXC);
 }
 
-__m256i test_mm256_mask_ipcvtt_roundph_epu8(__m256i __S, __mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvtt_roundph_epu8(
+__m256i test_mm256_mask_ipcvtts_roundph_epu8(__m256i __S, __mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvtts_roundph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2iubs256
-  return _mm256_mask_ipcvtt_roundph_epu8(__S, __A, __B, _MM_FROUND_NO_EXC);
+  return _mm256_mask_ipcvtts_roundph_epu8(__S, __A, __B, _MM_FROUND_NO_EXC);
 }
 
-__m256i test_mm256_maskz_ipcvtt_roundph_epu8(__mmask16 __A, __m256h __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvtt_roundph_epu8(
+__m256i test_mm256_maskz_ipcvtts_roundph_epu8(__mmask16 __A, __m256h __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvtts_roundph_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttph2iubs256
-  return _mm256_maskz_ipcvtt_roundph_epu8(__A, __B, _MM_FROUND_NO_EXC);
+  return _mm256_maskz_ipcvtts_roundph_epu8(__A, __B, _MM_FROUND_NO_EXC);
 }
 
-__m128i test_mm_ipcvttps_epi8(__m128 __A) {
-  // CHECK-LABEL: @test_mm_ipcvttps_epi8(
+__m128i test_mm_ipcvtts_ps_epi8(__m128 __A) {
+  // CHECK-LABEL: @test_mm_ipcvtts_ps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2ibs128
-  return _mm_ipcvttps_epi8(__A);
+  return _mm_ipcvtts_ps_epi8(__A);
 }
 
-__m128i test_mm_mask_ipcvttps_epi8(__m128i __S, __mmask8 __A, __m128 __B) {
-  // CHECK-LABEL: @test_mm_mask_ipcvttps_epi8(
+__m128i test_mm_mask_ipcvtts_ps_epi8(__m128i __S, __mmask8 __A, __m128 __B) {
+  // CHECK-LABEL: @test_mm_mask_ipcvtts_ps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2ibs128
-  return _mm_mask_ipcvttps_epi8(__S, __A, __B);
+  return _mm_mask_ipcvtts_ps_epi8(__S, __A, __B);
 }
 
-__m128i test_mm_maskz_ipcvttps_epi8(__mmask8 __A, __m128 __B) {
-  // CHECK-LABEL: @test_mm_maskz_ipcvttps_epi8(
+__m128i test_mm_maskz_ipcvtts_ps_epi8(__mmask8 __A, __m128 __B) {
+  // CHECK-LABEL: @test_mm_maskz_ipcvtts_ps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2ibs128
-  return _mm_maskz_ipcvttps_epi8(__A, __B);
+  return _mm_maskz_ipcvtts_ps_epi8(__A, __B);
 }
 
-__m256i test_mm256_ipcvttps_epi8(__m256 __A) {
-  // CHECK-LABEL: @test_mm256_ipcvttps_epi8(
+__m256i test_mm256_ipcvtts_ps_epi8(__m256 __A) {
+  // CHECK-LABEL: @test_mm256_ipcvtts_ps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2ibs256
-  return _mm256_ipcvttps_epi8(__A);
+  return _mm256_ipcvtts_ps_epi8(__A);
 }
 
-__m256i test_mm256_mask_ipcvttps_epi8(__m256i __S, __mmask8 __A, __m256 __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvttps_epi8(
+__m256i test_mm256_mask_ipcvtts_ps_epi8(__m256i __S, __mmask8 __A, __m256 __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvtts_ps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2ibs256
-  return _mm256_mask_ipcvttps_epi8(__S, __A, __B);
+  return _mm256_mask_ipcvtts_ps_epi8(__S, __A, __B);
 }
 
-__m256i test_mm256_maskz_ipcvttps_epi8(__mmask8 __A, __m256 __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvttps_epi8(
+__m256i test_mm256_maskz_ipcvtts_ps_epi8(__mmask8 __A, __m256 __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvtts_ps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2ibs256
-  return _mm256_maskz_ipcvttps_epi8(__A, __B);
+  return _mm256_maskz_ipcvtts_ps_epi8(__A, __B);
 }
 
-__m256i test_mm256_ipcvtt_roundps_epi8(__m256 __A) {
-  // CHECK-LABEL: @test_mm256_ipcvtt_roundps_epi8(
+__m256i test_mm256_ipcvtts_roundps_epi8(__m256 __A) {
+  // CHECK-LABEL: @test_mm256_ipcvtts_roundps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2ibs256
-  return _mm256_ipcvtt_roundps_epi8(__A, _MM_FROUND_NO_EXC);
+  return _mm256_ipcvtts_roundps_epi8(__A, _MM_FROUND_NO_EXC);
 }
 
-__m256i test_mm256_mask_ipcvtt_roundps_epi8(__m256i __S, __mmask8 __A, __m256 __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvtt_roundps_epi8(
+__m256i test_mm256_mask_ipcvtts_roundps_epi8(__m256i __S, __mmask8 __A, __m256 __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvtts_roundps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2ibs256
-  return _mm256_mask_ipcvtt_roundps_epi8(__S, __A, __B, _MM_FROUND_NO_EXC);
+  return _mm256_mask_ipcvtts_roundps_epi8(__S, __A, __B, _MM_FROUND_NO_EXC);
 }
 
-__m256i test_mm256_maskz_ipcvtt_roundps_epi8(__mmask8 __A, __m256 __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvtt_roundps_epi8(
+__m256i test_mm256_maskz_ipcvtts_roundps_epi8(__mmask8 __A, __m256 __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvtts_roundps_epi8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2ibs256
-  return _mm256_maskz_ipcvtt_roundps_epi8(__A, __B, _MM_FROUND_NO_EXC);
+  return _mm256_maskz_ipcvtts_roundps_epi8(__A, __B, _MM_FROUND_NO_EXC);
 }
 
-__m128i test_mm_ipcvttps_epu8(__m128 __A) {
-  // CHECK-LABEL: @test_mm_ipcvttps_epu8(
+__m128i test_mm_ipcvtts_ps_epu8(__m128 __A) {
+  // CHECK-LABEL: @test_mm_ipcvtts_ps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2iubs128
-  return _mm_ipcvttps_epu8(__A);
+  return _mm_ipcvtts_ps_epu8(__A);
 }
 
-__m128i test_mm_mask_ipcvttps_epu8(__m128i __S, __mmask8 __A, __m128 __B) {
-  // CHECK-LABEL: @test_mm_mask_ipcvttps_epu8(
+__m128i test_mm_mask_ipcvtts_ps_epu8(__m128i __S, __mmask8 __A, __m128 __B) {
+  // CHECK-LABEL: @test_mm_mask_ipcvtts_ps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2iubs128
-  return _mm_mask_ipcvttps_epu8(__S, __A, __B);
+  return _mm_mask_ipcvtts_ps_epu8(__S, __A, __B);
 }
 
-__m128i test_mm_maskz_ipcvttps_epu8(__mmask8 __A, __m128 __B) {
-  // CHECK-LABEL: @test_mm_maskz_ipcvttps_epu8(
+__m128i test_mm_maskz_ipcvtts_ps_epu8(__mmask8 __A, __m128 __B) {
+  // CHECK-LABEL: @test_mm_maskz_ipcvtts_ps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2iubs128
-  return _mm_maskz_ipcvttps_epu8(__A, __B);
+  return _mm_maskz_ipcvtts_ps_epu8(__A, __B);
 }
 
-__m256i test_mm256_ipcvttps_epu8(__m256 __A) {
-  // CHECK-LABEL: @test_mm256_ipcvttps_epu8(
+__m256i test_mm256_ipcvtts_ps_epu8(__m256 __A) {
+  // CHECK-LABEL: @test_mm256_ipcvtts_ps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2iubs256
-  return _mm256_ipcvttps_epu8(__A);
+  return _mm256_ipcvtts_ps_epu8(__A);
 }
 
-__m256i test_mm256_mask_ipcvttps_epu8(__m256i __S, __mmask8 __A, __m256 __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvttps_epu8(
+__m256i test_mm256_mask_ipcvtts_ps_epu8(__m256i __S, __mmask8 __A, __m256 __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvtts_ps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2iubs256
-  return _mm256_mask_ipcvttps_epu8(__S, __A, __B);
+  return _mm256_mask_ipcvtts_ps_epu8(__S, __A, __B);
 }
 
-__m256i test_mm256_maskz_ipcvttps_epu8(__mmask8 __A, __m256 __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvttps_epu8(
+__m256i test_mm256_maskz_ipcvtts_ps_epu8(__mmask8 __A, __m256 __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvtts_ps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2iubs256
-  return _mm256_maskz_ipcvttps_epu8(__A, __B);
+  return _mm256_maskz_ipcvtts_ps_epu8(__A, __B);
 }
 
-__m256i test_mm256_ipcvtt_roundps_epu8(__m256 __A) {
-  // CHECK-LABEL: @test_mm256_ipcvtt_roundps_epu8(
+__m256i test_mm256_ipcvtts_roundps_epu8(__m256 __A) {
+  // CHECK-LABEL: @test_mm256_ipcvtts_roundps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2iubs256
-  return _mm256_ipcvtt_roundps_epu8(__A, _MM_FROUND_NO_EXC);
+  return _mm256_ipcvtts_roundps_epu8(__A, _MM_FROUND_NO_EXC);
 }
 
-__m256i test_mm256_mask_ipcvtt_roundps_epu8(__m256i __S, __mmask8 __A, __m256 __B) {
-  // CHECK-LABEL: @test_mm256_mask_ipcvtt_roundps_epu8(
+__m256i test_mm256_mask_ipcvtts_roundps_epu8(__m256i __S, __mmask8 __A, __m256 __B) {
+  // CHECK-LABEL: @test_mm256_mask_ipcvtts_roundps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2iubs256
-  return _mm256_mask_ipcvtt_roundps_epu8(__S, __A, __B, _MM_FROUND_NO_EXC);
+  return _mm256_mask_ipcvtts_roundps_epu8(__S, __A, __B, _MM_FROUND_NO_EXC);
 }
 
-__m256i test_mm256_maskz_ipcvtt_roundps_epu8(__mmask8 __A, __m256 __B) {
-  // CHECK-LABEL: @test_mm256_maskz_ipcvtt_roundps_epu8(
+__m256i test_mm256_maskz_ipcvtts_roundps_epu8(__mmask8 __A, __m256 __B) {
+  // CHECK-LABEL: @test_mm256_maskz_ipcvtts_roundps_epu8(
   // CHECK: @llvm.x86.avx10.mask.vcvttps2iubs256
-  return _mm256_maskz_ipcvtt_roundps_epu8(__A, __B, _MM_FROUND_NO_EXC);
+  return _mm256_maskz_ipcvtts_roundps_epu8(__A, __B, _MM_FROUND_NO_EXC);
 }

--- a/clang/test/CodeGen/X86/avx10_2satcvtds-builtins-x64.c
+++ b/clang/test/CodeGen/X86/avx10_2satcvtds-builtins-x64.c
@@ -5,97 +5,97 @@
 
 // scalar
 
-int test_mm_cvttssd_i32(__m128d __A) {
-  // CHECK-LABEL: @test_mm_cvttssd_i32
+int test_mm_cvtts_sd_i32(__m128d __A) {
+  // CHECK-LABEL: @test_mm_cvtts_sd_i32
   // CHECK: @llvm.x86.avx10.vcvttsd2sis
   return _mm_cvtts_roundsd_i32(__A, _MM_FROUND_NO_EXC);
 }
 
-int test_mm_cvttssd_si32(__m128d __A) {
-  // CHECK-LABEL: @test_mm_cvttssd_si32(
+int test_mm_cvtts_sd_si32(__m128d __A) {
+  // CHECK-LABEL: @test_mm_cvtts_sd_si32(
   // CHECK: @llvm.x86.avx10.vcvttsd2sis(<2 x double>
   return _mm_cvtts_roundsd_si32(__A, _MM_FROUND_NO_EXC);
 }
 
-unsigned test_mm_cvttssd_u32(__m128d __A) {
-  // CHECK-LABEL: @test_mm_cvttssd_u32(
+unsigned test_mm_cvtts_sd_u32(__m128d __A) {
+  // CHECK-LABEL: @test_mm_cvtts_sd_u32(
   // CHECK: @llvm.x86.avx10.vcvttsd2usis(<2 x double>
   return _mm_cvtts_roundsd_u32(__A, _MM_FROUND_NO_EXC);
 }
 
-int test_mm_cvttsss_i32(__m128 __A) {
-  // CHECK-LABEL: @test_mm_cvttsss_i32(
+int test_mm_cvtts_ss_i32(__m128 __A) {
+  // CHECK-LABEL: @test_mm_cvtts_ss_i32(
   // CHECK: @llvm.x86.avx10.vcvttss2sis(<4 x float>
   return _mm_cvtts_roundss_i32(__A, _MM_FROUND_NO_EXC);
 }
 
-int test_mm_cvttsss_si32(__m128 __A) {
-  // CHECK-LABEL: @test_mm_cvttsss_si32(
+int test_mm_cvtts_ss_si32(__m128 __A) {
+  // CHECK-LABEL: @test_mm_cvtts_ss_si32(
   // CHECK: @llvm.x86.avx10.vcvttss2sis(<4 x float>
   return _mm_cvtts_roundss_si32(__A, _MM_FROUND_NO_EXC);
 }
 
-unsigned test_mm_cvttsss_u32(__m128 __A) {
-  // CHECK-LABEL: @test_mm_cvttsss_u32(
+unsigned test_mm_cvtts_ss_u32(__m128 __A) {
+  // CHECK-LABEL: @test_mm_cvtts_ss_u32(
   // CHECK: @llvm.x86.avx10.vcvttss2usis(<4 x float>
   return _mm_cvtts_roundss_u32(__A, _MM_FROUND_NO_EXC);
 }
 
 // vector
 // 128 bit
-__m128i test_mm_cvttspd_epi64(__m128d A){
-    // CHECK-LABEL: @test_mm_cvttspd_epi64
+__m128i test_mm_cvtts_pd_epi64(__m128d A){
+    // CHECK-LABEL: @test_mm_cvtts_pd_epi64
     // CHECK: @llvm.x86.avx10.mask.vcvttpd2qqs.128(<2 x double>
-    return _mm_cvttspd_epi64(A);
+    return _mm_cvtts_pd_epi64(A);
 }
 
-__m128i test_mm_mask_cvttspd_epi64(__m128i W, __mmask8 U, __m128d A){
-    // CHECK-LABEL: @test_mm_mask_cvttspd_epi64
+__m128i test_mm_mask_cvtts_pd_epi64(__m128i W, __mmask8 U, __m128d A){
+    // CHECK-LABEL: @test_mm_mask_cvtts_pd_epi64
     // CHECK: @llvm.x86.avx10.mask.vcvttpd2qqs.128(<2 x double>
-    return _mm_mask_cvttspd_epi64(W, U,  A);
+    return _mm_mask_cvtts_pd_epi64(W, U,  A);
 }
 
-__m128i test_mm_maskz_cvttspd_epi64(__mmask8 U,__m128d A){
-    // CHECK-LABEL: @test_mm_maskz_cvttspd_epi64
+__m128i test_mm_maskz_cvtts_pd_epi64(__mmask8 U,__m128d A){
+    // CHECK-LABEL: @test_mm_maskz_cvtts_pd_epi64
     // CHECK: @llvm.x86.avx10.mask.vcvttpd2qqs.128(<2 x double>
-    return _mm_maskz_cvttspd_epi64(U, A);
+    return _mm_maskz_cvtts_pd_epi64(U, A);
 }
 
-__m128i test_mm_cvttspd_epu64(__m128d A){
-    // CHECK-LABEL: @test_mm_cvttspd_epu64
+__m128i test_mm_cvtts_pd_epu64(__m128d A){
+    // CHECK-LABEL: @test_mm_cvtts_pd_epu64
     // CHECK: @llvm.x86.avx10.mask.vcvttpd2uqqs.128(<2 x double>
-    return _mm_cvttspd_epu64(A);
+    return _mm_cvtts_pd_epu64(A);
 }
 
-__m128i test_mm_mask_cvttspd_epu64(__m128i W, __mmask8 U, __m128d A){
-    // CHECK-LABEL: @test_mm_mask_cvttspd_epu64
+__m128i test_mm_mask_cvtts_pd_epu64(__m128i W, __mmask8 U, __m128d A){
+    // CHECK-LABEL: @test_mm_mask_cvtts_pd_epu64
     // CHECK: @llvm.x86.avx10.mask.vcvttpd2uqqs.128(<2 x double>
-    return _mm_mask_cvttspd_epu64(W, U,  A);
+    return _mm_mask_cvtts_pd_epu64(W, U,  A);
 }
 
-__m128i test_mm_maskz_cvttspd_epu64(__mmask8 U,__m128d A){
-    // CHECK-LABEL: @test_mm_maskz_cvttspd_epu64
+__m128i test_mm_maskz_cvtts_pd_epu64(__mmask8 U,__m128d A){
+    // CHECK-LABEL: @test_mm_maskz_cvtts_pd_epu64
     // CHECK: @llvm.x86.avx10.mask.vcvttpd2uqqs.128(<2 x double>
-    return _mm_maskz_cvttspd_epu64(U, A);
+    return _mm_maskz_cvtts_pd_epu64(U, A);
 }
 
 // 256 bit
-__m256i test_mm256_cvttspd_epi64(__m256d A){
-// CHECK-LABEL: @test_mm256_cvttspd_epi64
+__m256i test_mm256_cvtts_pd_epi64(__m256d A){
+// CHECK-LABEL: @test_mm256_cvtts_pd_epi64
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2qqs.round.256(<4 x double>
-    return _mm256_cvttspd_epi64(A);
+    return _mm256_cvtts_pd_epi64(A);
 }
 
-__m256i test_mm256_mask_cvttspd_epi64(__m256i W,__mmask8 U, __m256d A){
-// CHECK-LABEL: @test_mm256_mask_cvttspd_epi64
+__m256i test_mm256_mask_cvtts_pd_epi64(__m256i W,__mmask8 U, __m256d A){
+// CHECK-LABEL: @test_mm256_mask_cvtts_pd_epi64
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2qqs.round.256(<4 x double>
-    return _mm256_mask_cvttspd_epi64(W,U, A);
+    return _mm256_mask_cvtts_pd_epi64(W,U, A);
 }
 
-__m256i test_mm256_maskz_cvttspd_epi64(__mmask8 U, __m256d A){
-// CHECK-LABEL: @test_mm256_maskz_cvttspd_epi64
+__m256i test_mm256_maskz_cvtts_pd_epi64(__mmask8 U, __m256d A){
+// CHECK-LABEL: @test_mm256_maskz_cvtts_pd_epi64
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2qqs.round.256(<4 x double>
-    return _mm256_maskz_cvttspd_epi64(U, A);
+    return _mm256_maskz_cvtts_pd_epi64(U, A);
 }
 
 __m256i test_mm256_cvtts_roundpd_epi64(__m256d A){
@@ -116,22 +116,22 @@ __m256i test_mm256_maskz_cvtts_roundpd_epi64(__mmask8 U, __m256d A){
     return _mm256_maskz_cvtts_roundpd_epi64(U,A,_MM_FROUND_NEARBYINT );
 }
 
-__m256i test_mm256_cvttspd_epu64(__m256d A){
-// CHECK-LABEL: @test_mm256_cvttspd_epu64
+__m256i test_mm256_cvtts_pd_epu64(__m256d A){
+// CHECK-LABEL: @test_mm256_cvtts_pd_epu64
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2uqqs.round.256(<4 x double>
-    return _mm256_cvttspd_epu64(A);
+    return _mm256_cvtts_pd_epu64(A);
 }
 
-__m256i test_mm256_mask_cvttspd_epu64(__m256i W,__mmask8 U, __m256d A){
-// CHECK-LABEL: @test_mm256_mask_cvttspd_epu64
+__m256i test_mm256_mask_cvtts_pd_epu64(__m256i W,__mmask8 U, __m256d A){
+// CHECK-LABEL: @test_mm256_mask_cvtts_pd_epu64
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2uqqs.round.256(<4 x double>
-    return _mm256_mask_cvttspd_epu64(W,U, A);
+    return _mm256_mask_cvtts_pd_epu64(W,U, A);
 }
 
-__m256i test_mm256_maskz_cvttspd_epu64(__mmask8 U, __m256d A){
-// CHECK-LABEL: @test_mm256_maskz_cvttspd_epu64
+__m256i test_mm256_maskz_cvtts_pd_epu64(__mmask8 U, __m256d A){
+// CHECK-LABEL: @test_mm256_maskz_cvtts_pd_epu64
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2uqqs.round.256(<4 x double>
-    return _mm256_maskz_cvttspd_epu64(U, A);
+    return _mm256_maskz_cvtts_pd_epu64(U, A);
 }
 
 __m256i test_mm256_cvtts_roundpd_epu64(__m256d A){
@@ -153,58 +153,58 @@ __m256i test_mm256_maskz_cvtts_roundpd_epu64(__mmask8 U, __m256d A){
 }
 
 // 128 bit
-__m128i test_mm_cvttsps_epi64(__m128 A){
-    // CHECK-LABEL: @test_mm_cvttsps_epi64
+__m128i test_mm_cvtts_ps_epi64(__m128 A){
+    // CHECK-LABEL: @test_mm_cvtts_ps_epi64
     // CHECK: @llvm.x86.avx10.mask.vcvttps2qqs.128(<4 x float>
-    return _mm_cvttsps_epi64(A);
+    return _mm_cvtts_ps_epi64(A);
 }
 
-__m128i test_mm_mask_cvttsps_epi64(__m128i W, __mmask8 U, __m128 A){
-    // CHECK-LABEL: @test_mm_mask_cvttsps_epi64
+__m128i test_mm_mask_cvtts_ps_epi64(__m128i W, __mmask8 U, __m128 A){
+    // CHECK-LABEL: @test_mm_mask_cvtts_ps_epi64
     // CHECK: @llvm.x86.avx10.mask.vcvttps2qqs.128(<4 x float>
-    return _mm_mask_cvttsps_epi64(W, U,  A);
+    return _mm_mask_cvtts_ps_epi64(W, U,  A);
 }
 
-__m128i test_mm_maskz_cvttsps_epi64(__mmask8 U,__m128 A){
-    // CHECK-LABEL: @test_mm_maskz_cvttsps_epi64
+__m128i test_mm_maskz_cvtts_ps_epi64(__mmask8 U,__m128 A){
+    // CHECK-LABEL: @test_mm_maskz_cvtts_ps_epi64
     // CHECK: @llvm.x86.avx10.mask.vcvttps2qqs.128(<4 x float>
-    return _mm_maskz_cvttsps_epi64(U, A);
+    return _mm_maskz_cvtts_ps_epi64(U, A);
 }
 
-__m128i test_mm_cvttsps_epu64(__m128 A){
-    // CHECK-LABEL: @test_mm_cvttsps_epu64
+__m128i test_mm_cvtts_ps_epu64(__m128 A){
+    // CHECK-LABEL: @test_mm_cvtts_ps_epu64
     // CHECK: @llvm.x86.avx10.mask.vcvttps2uqqs.128(<4 x float>
-    return _mm_cvttsps_epu64(A);
+    return _mm_cvtts_ps_epu64(A);
 }
 
-__m128i test_mm_mask_cvttsps_epu64(__m128i W, __mmask8 U, __m128 A){
-    // CHECK-LABEL: @test_mm_mask_cvttsps_epu64
+__m128i test_mm_mask_cvtts_ps_epu64(__m128i W, __mmask8 U, __m128 A){
+    // CHECK-LABEL: @test_mm_mask_cvtts_ps_epu64
     // CHECK: @llvm.x86.avx10.mask.vcvttps2uqqs.128(<4 x float>
-    return _mm_mask_cvttsps_epu64(W, U,  A);
+    return _mm_mask_cvtts_ps_epu64(W, U,  A);
 }
 
-__m128i test_mm_maskz_cvttsps_epu64(__mmask8 U,__m128 A){
-    // CHECK-LABEL: @test_mm_maskz_cvttsps_epu64
+__m128i test_mm_maskz_cvtts_ps_epu64(__mmask8 U,__m128 A){
+    // CHECK-LABEL: @test_mm_maskz_cvtts_ps_epu64
     // CHECK: @llvm.x86.avx10.mask.vcvttps2uqqs.128(<4 x float>
-    return _mm_maskz_cvttsps_epu64(U, A);
+    return _mm_maskz_cvtts_ps_epu64(U, A);
 }
 
-__m256i test_mm256_cvttsps_epi64(__m128 A){
-// CHECK-LABEL: @test_mm256_cvttsps_epi64
+__m256i test_mm256_cvtts_ps_epi64(__m128 A){
+// CHECK-LABEL: @test_mm256_cvtts_ps_epi64
 // CHECK: @llvm.x86.avx10.mask.vcvttps2qqs.round.256(<4 x float>
-  return _mm256_cvttsps_epi64(A);
+  return _mm256_cvtts_ps_epi64(A);
 }
 
-__m256i test_mm256_mask_cvttsps_epi64(__m256i W,__mmask8 U, __m128 A){
-// CHECK-LABEL: @test_mm256_mask_cvttsps_epi64
+__m256i test_mm256_mask_cvtts_ps_epi64(__m256i W,__mmask8 U, __m128 A){
+// CHECK-LABEL: @test_mm256_mask_cvtts_ps_epi64
 // CHECK: @llvm.x86.avx10.mask.vcvttps2qqs.round.256(<4 x float>
-    return _mm256_mask_cvttsps_epi64(W,U, A);
+    return _mm256_mask_cvtts_ps_epi64(W,U, A);
 }
 
-__m256i test_mm256_maskz_cvttsps_epi64(__mmask8 U, __m128 A){
-// CHECK-LABEL: @test_mm256_maskz_cvttsps_epi64
+__m256i test_mm256_maskz_cvtts_ps_epi64(__mmask8 U, __m128 A){
+// CHECK-LABEL: @test_mm256_maskz_cvtts_ps_epi64
 // CHECK: @llvm.x86.avx10.mask.vcvttps2qqs.round.256(<4 x float>
-    return _mm256_maskz_cvttsps_epi64(U, A);
+    return _mm256_maskz_cvtts_ps_epi64(U, A);
 }
 
 __m256i test_mm256_cvtts_roundps_epi64(__m128 A){
@@ -225,22 +225,22 @@ __m256i test_mm256_maskz_cvtts_roundps_epi64(__mmask8 U, __m128 A){
     return _mm256_maskz_cvtts_roundps_epi64(U,A,_MM_FROUND_NEARBYINT );
 }
 
-__m256i test_mm256_cvttsps_epu64(__m128 A){
-// CHECK-LABEL: @test_mm256_cvttsps_epu64
+__m256i test_mm256_cvtts_ps_epu64(__m128 A){
+// CHECK-LABEL: @test_mm256_cvtts_ps_epu64
 // CHECK: @llvm.x86.avx10.mask.vcvttps2uqqs.round.256(<4 x float>
-  return _mm256_cvttsps_epu64(A);
+  return _mm256_cvtts_ps_epu64(A);
 }
 
-__m256i test_mm256_mask_cvttsps_epu64(__m256i W,__mmask8 U, __m128 A){
-// CHECK-LABEL: @test_mm256_mask_cvttsps_epu64
+__m256i test_mm256_mask_cvtts_ps_epu64(__m256i W,__mmask8 U, __m128 A){
+// CHECK-LABEL: @test_mm256_mask_cvtts_ps_epu64
 // CHECK: @llvm.x86.avx10.mask.vcvttps2uqqs.round.256(<4 x float>
-    return _mm256_mask_cvttsps_epu64(W,U, A);
+    return _mm256_mask_cvtts_ps_epu64(W,U, A);
 }
 
-__m256i test_mm256_maskz_cvttsps_epu64(__mmask8 U, __m128 A){
-// CHECK-LABEL: @test_mm256_maskz_cvttsps_epu64
+__m256i test_mm256_maskz_cvtts_ps_epu64(__mmask8 U, __m128 A){
+// CHECK-LABEL: @test_mm256_maskz_cvtts_ps_epu64
 // CHECK: @llvm.x86.avx10.mask.vcvttps2uqqs.round.256(<4 x float>
-    return _mm256_maskz_cvttsps_epu64(U, A);
+    return _mm256_maskz_cvtts_ps_epu64(U, A);
 }
 
 __m256i test_mm256_cvtts_roundps_epu64(__m128 A){

--- a/clang/test/CodeGen/X86/avx10_2satcvtds-builtins.c
+++ b/clang/test/CodeGen/X86/avx10_2satcvtds-builtins.c
@@ -4,40 +4,40 @@
 #include <immintrin.h>
 #include <stddef.h>
 
-__m128i test_mm_cvttspd_epi32(__m128d A){
-// CHECK-LABEL: @test_mm_cvttspd_epi32
+__m128i test_mm_cvtts_pd_epi32(__m128d A){
+// CHECK-LABEL: @test_mm_cvtts_pd_epi32
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2dqs.128(<2 x double>
-  return _mm_cvttspd_epi32(A);
+  return _mm_cvtts_pd_epi32(A);
 }
 
-__m128i test_mm_mask_cvttspd_epi32(__m128i W, __mmask8 U, __m128d A){
-// CHECK-LABEL: @test_mm_mask_cvttspd_epi32
+__m128i test_mm_mask_cvtts_pd_epi32(__m128i W, __mmask8 U, __m128d A){
+// CHECK-LABEL: @test_mm_mask_cvtts_pd_epi32
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2dqs.128(<2 x double>
-    return _mm_mask_cvttspd_epi32(W,U,A);
+    return _mm_mask_cvtts_pd_epi32(W,U,A);
 }
 
-__m128i test_mm_maskz_cvttspd_epi32( __mmask8 U, __m128d A){
-// CHECK-LABEL: @test_mm_maskz_cvttspd_epi32(
+__m128i test_mm_maskz_cvtts_pd_epi32( __mmask8 U, __m128d A){
+// CHECK-LABEL: @test_mm_maskz_cvtts_pd_epi32(
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2dqs.128(<2 x double>
-    return _mm_maskz_cvttspd_epi32(U,A);
+    return _mm_maskz_cvtts_pd_epi32(U,A);
 }
 
-__m128i test_mm256_cvttspd_epi32(__m256d A){
-// CHECK-LABEL: @test_mm256_cvttspd_epi32
+__m128i test_mm256_cvtts_pd_epi32(__m256d A){
+// CHECK-LABEL: @test_mm256_cvtts_pd_epi32
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2dqs.round.256(<4 x double>
-  return _mm256_cvttspd_epi32(A);
+  return _mm256_cvtts_pd_epi32(A);
 }
 
-__m128i test_mm256_mask_cvttspd_epi32(__m128i W,__mmask8 U, __m256d A){
-// CHECK-LABEL: @test_mm256_mask_cvttspd_epi32
+__m128i test_mm256_mask_cvtts_pd_epi32(__m128i W,__mmask8 U, __m256d A){
+// CHECK-LABEL: @test_mm256_mask_cvtts_pd_epi32
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2dqs.round.256(<4 x double>
-    return _mm256_mask_cvttspd_epi32(W,U,A);
+    return _mm256_mask_cvtts_pd_epi32(W,U,A);
 }
 
-__m128i test_mm256_maskz_cvttspd_epi32(__mmask8 U, __m256d A){
-// CHECK-LABEL: @test_mm256_maskz_cvttspd_epi32
+__m128i test_mm256_maskz_cvtts_pd_epi32(__mmask8 U, __m256d A){
+// CHECK-LABEL: @test_mm256_maskz_cvtts_pd_epi32
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2dqs.round.256(<4 x double>
-    return _mm256_maskz_cvttspd_epi32(U,A);
+    return _mm256_maskz_cvtts_pd_epi32(U,A);
 }
 
 __m128i test_mm256_cvtts_roundpd_epi32(__m256d A){
@@ -58,41 +58,41 @@ __m128i test_mm256_maskz_cvtts_roundpd_epi32(__mmask8 U, __m256d A){
     return _mm256_maskz_cvtts_roundpd_epi32(U,A,_MM_FROUND_NEARBYINT);
 }
 
-__m128i test_mm_cvttspd_epu32(__m128d A){
-// CHECK-LABEL: @test_mm_cvttspd_epu32
+__m128i test_mm_cvtts_pd_epu32(__m128d A){
+// CHECK-LABEL: @test_mm_cvtts_pd_epu32
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2udqs.128(<2 x double>
-  return _mm_cvttspd_epu32(A);
+  return _mm_cvtts_pd_epu32(A);
 }
 
-__m128i test_mm_mask_cvttspd_epu32(__m128i W, __mmask8 U, __m128d A){
-// CHECK-LABEL: @test_mm_mask_cvttspd_epu32
+__m128i test_mm_mask_cvtts_pd_epu32(__m128i W, __mmask8 U, __m128d A){
+// CHECK-LABEL: @test_mm_mask_cvtts_pd_epu32
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2udqs.128(<2 x double>
-    return _mm_mask_cvttspd_epu32(W,U,A);
+    return _mm_mask_cvtts_pd_epu32(W,U,A);
 }
 
-__m128i test_mm_maskz_cvttspd_epu32( __mmask8 U, __m128d A){
-// CHECK-LABEL: @test_mm_maskz_cvttspd_epu32
+__m128i test_mm_maskz_cvtts_pd_epu32( __mmask8 U, __m128d A){
+// CHECK-LABEL: @test_mm_maskz_cvtts_pd_epu32
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2udqs.128(<2 x double>
-    return _mm_maskz_cvttspd_epu32(U,A);
+    return _mm_maskz_cvtts_pd_epu32(U,A);
 }
 
 
-__m128i test_mm256_cvttspd_epu32(__m256d A){
-// CHECK-LABEL: @test_mm256_cvttspd_epu32
+__m128i test_mm256_cvtts_pd_epu32(__m256d A){
+// CHECK-LABEL: @test_mm256_cvtts_pd_epu32
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2udqs.round.256(<4 x double>
-  return _mm256_cvttspd_epu32(A);
+  return _mm256_cvtts_pd_epu32(A);
 }
 
-__m128i test_mm256_mask_cvttspd_epu32(__m128i W,__mmask8 U, __m256d A){
-// CHECK-LABEL: @test_mm256_mask_cvttspd_epu32
+__m128i test_mm256_mask_cvtts_pd_epu32(__m128i W,__mmask8 U, __m256d A){
+// CHECK-LABEL: @test_mm256_mask_cvtts_pd_epu32
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2udqs.round.256(<4 x double>
-    return _mm256_mask_cvttspd_epu32(W,U,A);
+    return _mm256_mask_cvtts_pd_epu32(W,U,A);
 }
 
-__m128i test_mm256_maskz_cvttspd_epu32(__mmask8 U, __m256d A){
-// CHECK-LABEL: @test_mm256_maskz_cvttspd_epu32
+__m128i test_mm256_maskz_cvtts_pd_epu32(__mmask8 U, __m256d A){
+// CHECK-LABEL: @test_mm256_maskz_cvtts_pd_epu32
 // CHECK: @llvm.x86.avx10.mask.vcvttpd2udqs.round.256(<4 x double>
-    return _mm256_maskz_cvttspd_epu32(U,A);
+    return _mm256_maskz_cvtts_pd_epu32(U,A);
 }
 
 __m128i test_mm256_cvtts_roundpd_epu32(__m256d A){
@@ -113,40 +113,40 @@ __m128i test_mm256_maskz_cvtts_roundpd_epu32(__mmask8 U, __m256d A){
     return _mm256_maskz_cvtts_roundpd_epu32(U,A,_MM_FROUND_NEARBYINT);
 }
 
-__m128i test_mm_cvttsps_epi32(__m128 A){
-// CHECK-LABEL: @test_mm_cvttsps_epi32
+__m128i test_mm_cvtts_ps_epi32(__m128 A){
+// CHECK-LABEL: @test_mm_cvtts_ps_epi32
 // CHECK: @llvm.x86.avx10.mask.vcvttps2dqs.128(<4 x float>
-  return _mm_cvttsps_epi32(A);
+  return _mm_cvtts_ps_epi32(A);
 }
 
-__m128i test_mm_mask_cvttsps_epi32(__m128i W, __mmask8 U, __m128 A){
-// CHECK-LABEL: @test_mm_mask_cvttsps_epi32
+__m128i test_mm_mask_cvtts_ps_epi32(__m128i W, __mmask8 U, __m128 A){
+// CHECK-LABEL: @test_mm_mask_cvtts_ps_epi32
 // CHECK: @llvm.x86.avx10.mask.vcvttps2dqs.128(<4 x float>
-    return _mm_mask_cvttsps_epi32(W,U,A);
+    return _mm_mask_cvtts_ps_epi32(W,U,A);
 }
 
-__m128i test_mm_maskz_cvttsps_epi32( __mmask8 U, __m128 A){
-// CHECK-LABEL: @test_mm_maskz_cvttsps_epi32
+__m128i test_mm_maskz_cvtts_ps_epi32( __mmask8 U, __m128 A){
+// CHECK-LABEL: @test_mm_maskz_cvtts_ps_epi32
 // CHECK: @llvm.x86.avx10.mask.vcvttps2dqs.128(<4 x float>
-    return _mm_maskz_cvttsps_epi32(U,A);
+    return _mm_maskz_cvtts_ps_epi32(U,A);
 }
 
-__m256i test_mm256_cvttsps_epi32(__m256 A){
-// CHECK-LABEL: @test_mm256_cvttsps_epi32
+__m256i test_mm256_cvtts_ps_epi32(__m256 A){
+// CHECK-LABEL: @test_mm256_cvtts_ps_epi32
 // CHECK: @llvm.x86.avx10.mask.vcvttps2dqs.round.256(<8 x float>
-  return _mm256_cvttsps_epi32(A);
+  return _mm256_cvtts_ps_epi32(A);
 }
 
-__m256i test_mm256_mask_cvttsps_epi32(__m256i W,__mmask8 U, __m256 A){
-// CHECK-LABEL: @test_mm256_mask_cvttsps_epi32
+__m256i test_mm256_mask_cvtts_ps_epi32(__m256i W,__mmask8 U, __m256 A){
+// CHECK-LABEL: @test_mm256_mask_cvtts_ps_epi32
 // CHECK: @llvm.x86.avx10.mask.vcvttps2dqs.round.256(<8 x float>
-    return _mm256_mask_cvttsps_epi32(W,U,A);
+    return _mm256_mask_cvtts_ps_epi32(W,U,A);
 }
 
-__m256i test_mm256_maskz_cvttsps_epi32(__mmask8 U, __m256 A){
-// CHECK-LABEL: @test_mm256_maskz_cvttsps_epi32
+__m256i test_mm256_maskz_cvtts_ps_epi32(__mmask8 U, __m256 A){
+// CHECK-LABEL: @test_mm256_maskz_cvtts_ps_epi32
 // CHECK: @llvm.x86.avx10.mask.vcvttps2dqs.round.256(<8 x float>
-    return _mm256_maskz_cvttsps_epi32(U,A);
+    return _mm256_maskz_cvtts_ps_epi32(U,A);
 }
 
 __m256i test_mm256_cvtts_roundps_epi32(__m256 A){
@@ -167,40 +167,40 @@ __m256i test_mm256_maskz_cvtts_roundps_epi32(__mmask8 U, __m256 A){
     return _mm256_maskz_cvtts_roundps_epi32(U,A,_MM_FROUND_NEARBYINT);
 }
 
-__m128i test_mm_cvttsps_epu32(__m128 A){
-// CHECK-LABEL: @test_mm_cvttsps_epu32
+__m128i test_mm_cvtts_ps_epu32(__m128 A){
+// CHECK-LABEL: @test_mm_cvtts_ps_epu32
 // CHECK: @llvm.x86.avx10.mask.vcvttps2udqs.128(<4 x float>
-  return _mm_cvttsps_epu32(A);
+  return _mm_cvtts_ps_epu32(A);
 }
 
-__m128i test_mm_mask_cvttsps_epu32(__m128i W, __mmask8 U, __m128 A){
-// CHECK-LABEL: @test_mm_mask_cvttsps_epu32
+__m128i test_mm_mask_cvtts_ps_epu32(__m128i W, __mmask8 U, __m128 A){
+// CHECK-LABEL: @test_mm_mask_cvtts_ps_epu32
 // CHECK: @llvm.x86.avx10.mask.vcvttps2udqs.128(<4 x float>
-    return _mm_mask_cvttsps_epu32(W,U,A);
+    return _mm_mask_cvtts_ps_epu32(W,U,A);
 }
 
-__m128i test_mm_maskz_cvttsps_epu32( __mmask8 U, __m128 A){
-// CHECK-LABEL: @test_mm_maskz_cvttsps_epu32
+__m128i test_mm_maskz_cvtts_ps_epu32( __mmask8 U, __m128 A){
+// CHECK-LABEL: @test_mm_maskz_cvtts_ps_epu32
 // CHECK: @llvm.x86.avx10.mask.vcvttps2udqs.128(<4 x float>
-    return _mm_maskz_cvttsps_epu32(U,A);
+    return _mm_maskz_cvtts_ps_epu32(U,A);
 }
 
-__m256i test_mm256_cvttsps_epu32(__m256 A){
-// CHECK-LABEL: @test_mm256_cvttsps_epu32
+__m256i test_mm256_cvtts_ps_epu32(__m256 A){
+// CHECK-LABEL: @test_mm256_cvtts_ps_epu32
 // CHECK: @llvm.x86.avx10.mask.vcvttps2udqs.round.256(<8 x float>
-  return _mm256_cvttsps_epu32(A);
+  return _mm256_cvtts_ps_epu32(A);
 }
 
-__m256i test_mm256_mask_cvttsps_epu32(__m256i W,__mmask8 U, __m256 A){
-// CHECK-LABEL: @test_mm256_mask_cvttsps_epu32
+__m256i test_mm256_mask_cvtts_ps_epu32(__m256i W,__mmask8 U, __m256 A){
+// CHECK-LABEL: @test_mm256_mask_cvtts_ps_epu32
 // CHECK: @llvm.x86.avx10.mask.vcvttps2udqs.round.256(<8 x float>
-    return _mm256_mask_cvttsps_epu32(W,U,A);
+    return _mm256_mask_cvtts_ps_epu32(W,U,A);
 }
 
-__m256i test_mm256_maskz_cvttsps_epu32(__mmask8 U, __m256 A){
-// CHECK-LABEL: @test_mm256_maskz_cvttsps_epu32
+__m256i test_mm256_maskz_cvtts_ps_epu32(__mmask8 U, __m256 A){
+// CHECK-LABEL: @test_mm256_maskz_cvtts_ps_epu32
 // CHECK: @llvm.x86.avx10.mask.vcvttps2udqs.round.256(<8 x float>
-    return _mm256_maskz_cvttsps_epu32(U,A);
+    return _mm256_maskz_cvtts_ps_epu32(U,A);
 }
 
 __m256i test_mm256_cvtts_roundps_epu32(__m256 A){


### PR DESCRIPTION
- Add '_' after cvt[t]s intrinsics when 's' is for saturation;
- Add 's_' for all ipcvt[t] intrinsics since they are all saturation ones;
- Move 's' after 'cvt' and add '_' after it for prior `biass` intrinsics;

This is to solve potential confusion since 's' before a type usually represents for scalar.

Synced with GCC folks and they will change in the same way.