### PR TITLE
[lldb] Fix prologue size calculation for discontinuous functions

### DIFF
--- a/lldb/source/Symbol/Function.cpp
+++ b/lldb/source/Symbol/Function.cpp
@@ -662,10 +662,12 @@ uint32_t Function::GetPrologueByteSize() {
           }
         }
 
-        const addr_t func_start_file_addr =
-            m_range.GetBaseAddress().GetFileAddress();
-        const addr_t func_end_file_addr =
-            func_start_file_addr + m_range.GetByteSize();
+        AddressRange entry_range;
+        m_block.GetRangeContainingAddress(m_address, entry_range);
+        const addr_t range_start_file_addr = m_address.GetFileAddress();
+        const addr_t range_end_file_addr =
+            entry_range.GetBaseAddress().GetFileAddress() +
+            entry_range.GetByteSize();
 
         // Now calculate the offset to pass the subsequent line 0 entries.
         uint32_t first_non_zero_line = prologue_end_line_idx;
@@ -677,7 +679,7 @@ uint32_t Function::GetPrologueByteSize() {
               break;
           }
           if (line_entry.range.GetBaseAddress().GetFileAddress() >=
-              func_end_file_addr)
+              range_end_file_addr)
             break;
 
           first_non_zero_line++;
@@ -694,13 +696,13 @@ uint32_t Function::GetPrologueByteSize() {
 
         // Verify that this prologue end file address in the function's address
         // range just to be sure
-        if (func_start_file_addr < prologue_end_file_addr &&
-            prologue_end_file_addr < func_end_file_addr) {
-          m_prologue_byte_size = prologue_end_file_addr - func_start_file_addr;
+        if (range_start_file_addr < prologue_end_file_addr &&
+            prologue_end_file_addr < range_end_file_addr) {
+          m_prologue_byte_size = prologue_end_file_addr - range_start_file_addr;
         }
 
         if (prologue_end_file_addr < line_zero_end_file_addr &&
-            line_zero_end_file_addr < func_end_file_addr) {
+            line_zero_end_file_addr < range_end_file_addr) {
           m_prologue_byte_size +=
               line_zero_end_file_addr - prologue_end_file_addr;
         }

--- a/lldb/source/Symbol/Function.cpp
+++ b/lldb/source/Symbol/Function.cpp
@@ -664,7 +664,10 @@ uint32_t Function::GetPrologueByteSize() {
 
         AddressRange entry_range;
         m_block.GetRangeContainingAddress(m_address, entry_range);
-        const addr_t range_start_file_addr = m_address.GetFileAddress();
+
+        // Deliberately not starting at entry_range.GetBaseAddress() because the
+        // function entry point need not be the first address in the range.
+        const addr_t func_start_file_addr = m_address.GetFileAddress();
         const addr_t range_end_file_addr =
             entry_range.GetBaseAddress().GetFileAddress() +
             entry_range.GetByteSize();
@@ -694,11 +697,11 @@ uint32_t Function::GetPrologueByteSize() {
           }
         }
 
-        // Verify that this prologue end file address in the function's address
-        // range just to be sure
-        if (range_start_file_addr < prologue_end_file_addr &&
+        // Verify that this prologue end file address inside the function just
+        // to be sure
+        if (func_start_file_addr < prologue_end_file_addr &&
             prologue_end_file_addr < range_end_file_addr) {
-          m_prologue_byte_size = prologue_end_file_addr - range_start_file_addr;
+          m_prologue_byte_size = prologue_end_file_addr - func_start_file_addr;
         }
 
         if (prologue_end_file_addr < line_zero_end_file_addr &&


### PR DESCRIPTION
When searching for the end of prologue, I'm only iterating through the address range (~basic block) which contains the function entry point. The reason for that is that even if some other range somehow contained the end-of-prologue marker, the fact that it's in a different range would imply it's reachable through some form of control flow, and that's usually not a good place to set an function entry breakpoint.