### PR TITLE
[LLVM][PDB] Use IsUnsigned flag for APInt correctly

### DIFF
--- a/llvm/include/llvm/DebugInfo/PDB/PDBTypes.h
+++ b/llvm/include/llvm/DebugInfo/PDB/PDBTypes.h
@@ -510,7 +510,9 @@ struct Variant {
 
 #define VARIANT_APSINT(Enum, NumBits, IsUnsigned)                              \
   case PDB_VariantType::Enum:                                                  \
-    return APSInt(APInt(NumBits, Value.Enum), IsUnsigned);
+    return APSInt(                                                             \
+        APInt(NumBits, static_cast<uint64_t>(Value.Enum), !IsUnsigned),        \
+        IsUnsigned);
 
   APSInt toAPSInt() const {
     switch (Type) {

--- a/llvm/unittests/DebugInfo/PDB/CMakeLists.txt
+++ b/llvm/unittests/DebugInfo/PDB/CMakeLists.txt
@@ -10,6 +10,7 @@ add_llvm_unittest_with_input_files(DebugInfoPDBTests
   NativeSymbolReuseTest.cpp
   StringTableBuilderTest.cpp
   PDBApiTest.cpp
+  PDBVariantTest.cpp
   )
 
 target_link_libraries(DebugInfoPDBTests PRIVATE LLVMTestingSupport)

--- a/llvm/unittests/DebugInfo/PDB/PDBVariantTest.cpp
+++ b/llvm/unittests/DebugInfo/PDB/PDBVariantTest.cpp
@@ -1,0 +1,60 @@
+//===- llvm/unittest/DebugInfo/PDB/PDBVariantTest.cpp ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+
+#include "llvm/DebugInfo/PDB/PDBTypes.h"
+
+using namespace llvm;
+using namespace llvm::pdb;
+
+namespace {
+
+template <typename T> class PDBVariantIntegerTest : public testing::Test {
+public:
+  std::vector<T> getTestIntegers() {
+    if constexpr (std::is_same_v<T, bool>) {
+      return {true, false};
+    } else {
+      std::vector<T> Integers{0, 1, 32, std::numeric_limits<T>::min(),
+                              std::numeric_limits<T>::max()};
+      if constexpr (std::is_signed_v<T>) {
+        Integers.emplace_back(-1);
+        Integers.emplace_back(-65);
+      }
+      return Integers;
+    }
+  }
+};
+
+using TestTypes = testing::Types<bool, int8_t, uint8_t, int16_t, uint16_t,
+                                 int32_t, uint32_t, int64_t, uint64_t>;
+
+} // namespace
+
+TYPED_TEST_SUITE(PDBVariantIntegerTest, TestTypes);
+
+TYPED_TEST(PDBVariantIntegerTest, ToAPSInt) {
+  for (TypeParam IntegerValue : this->getTestIntegers()) {
+    const Variant VariantValue(IntegerValue);
+
+    const APSInt APSIntValue = VariantValue.toAPSInt();
+    EXPECT_EQ(APSIntValue.isSigned(), std::is_signed_v<TypeParam>)
+        << "Unexpected 'isSigned()' result for '" << IntegerValue << "'";
+    bool IsNegative = false;
+    if constexpr (!std::is_same_v<TypeParam, bool>) {
+      IsNegative = IntegerValue < 0;
+    }
+    EXPECT_EQ(APSIntValue.isNegative(), IsNegative)
+        << "Unexpected 'isNegative()' result for '" << IntegerValue << "'";
+
+    SmallString<20> String;
+    APSIntValue.toString(String);
+    EXPECT_EQ(String.str().str(), std::to_string(IntegerValue));
+  }
+}


### PR DESCRIPTION
Hello.

This patch fixes an assertion that occurs in `APInt`.

The assertion can be reproduced with LLDB test `python_api/thread/TestThreadAPI.py` (it fails).

Here is a stack trace:

```
Exception Code: 0x80000003
  #0 0x00007ffb3b5c3f8b HandleAbort D:\Projects\github\llvm-project-fork\llvm\lib\Support\Windows\Signals.inc:429:0
  #1 0x00007ffc08df1ae9 (C:\WINDOWS\System32\ucrtbase.dll+0xc1ae9)
  #2 0x00007ffc08dd4c11 (C:\WINDOWS\System32\ucrtbase.dll+0xa4c11)
  #3 0x00007ffc08df2ae6 (C:\WINDOWS\System32\ucrtbase.dll+0xc2ae6)
  #4 0x00007ffc08df2cc1 (C:\WINDOWS\System32\ucrtbase.dll+0xc2cc1)
  #5 0x00007ffb3a5e1201 llvm::APInt::APInt(unsigned int, unsigned __int64, bool, bool) D:\Projects\github\llvm-project-fork\llvm\include\llvm\ADT\APInt.h:127:0
  #6 0x00007ffb3b4b9a55 llvm::pdb::Variant::toAPSInt(void) const D:\Projects\github\llvm-project-fork\llvm\include\llvm\DebugInfo\PDB\PDBTypes.h:518:0
  #7 0x00007ffb3b4a4d84 PDBASTParser::AddRecordMembers(class lldb_private::SymbolFile &, class lldb_private::CompilerType &, class llvm::pdb::ConcreteSymbolEnumerator<class llvm::pdb::PDBSymbolData> &, struct lldb_private::ClangASTImporter::LayoutInfo &) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\SymbolFile\PDB\PDBASTParser.cpp:1316:0
  #8 0x00007ffb3b4a4380 PDBASTParser::CompleteTypeFromUDT(class lldb_private::SymbolFile &, class lldb_private::CompilerType &, class llvm::pdb::PDBSymbolTypeUDT &) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\SymbolFile\PDB\PDBASTParser.cpp:1222:0
  #9 0x00007ffb3b4a1dd3 PDBASTParser::CompleteTypeFromPDB(class lldb_private::CompilerType &) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\SymbolFile\PDB\PDBASTParser.cpp:827:0
 #10 0x00007ffb3b47b401 SymbolFilePDB::CompleteType(class lldb_private::CompilerType &) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\SymbolFile\PDB\SymbolFilePDB.cpp:610:0
 #11 0x00007ffb3a7f77f4 lldb_private::Type::ResolveCompilerType(enum lldb_private::Type::ResolveState) D:\Projects\github\llvm-project-fork\lldb\source\Symbol\Type.cpp:739:0
 #12 0x00007ffb3a7f625a lldb_private::Type::GetFullCompilerType(void) D:\Projects\github\llvm-project-fork\lldb\source\Symbol\Type.cpp:773:0
 #13 0x00007ffb3b49fcc3 PDBASTParser::CreateLLDBTypeFromPDBType(class llvm::pdb::PDBSymbol const &) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\SymbolFile\PDB\PDBASTParser.cpp:564:0
 #14 0x00007ffb3b47af34 SymbolFilePDB::ResolveTypeUID(unsigned __int64) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\SymbolFile\PDB\SymbolFilePDB.cpp:577:0
 #15 0x00007ffb3b4a2fbf PDBASTParser::GetDeclContextForSymbol(class llvm::pdb::PDBSymbol const &) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\SymbolFile\PDB\PDBASTParser.cpp:1013:0
 #16 0x00007ffb3b4a35e5 PDBASTParser::GetDeclContextContainingSymbol(class llvm::pdb::PDBSymbol const &) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\SymbolFile\PDB\PDBASTParser.cpp:1066:0
 #17 0x00007ffb3b4a2377 PDBASTParser::GetDeclForSymbol(class llvm::pdb::PDBSymbol const &) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\SymbolFile\PDB\PDBASTParser.cpp:908:0
 #18 0x00007ffb3b4a3a71 PDBASTParser::ParseDeclsForDeclContext(class clang::DeclContext const *) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\SymbolFile\PDB\PDBASTParser.cpp:1123:0
 #19 0x00007ffb3b47c596 SymbolFilePDB::ParseDeclsForContext(class lldb_private::CompilerDeclContext) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\SymbolFile\PDB\SymbolFilePDB.cpp:725:0
 #20 0x00007ffb3b4ed55e lldb_private::TypeSystemClang::DeclContextFindDeclByName(void *, class lldb_private::ConstString, bool) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\TypeSystem\Clang\TypeSystemClang.cpp:9336:0
 #21 0x00007ffb3a883a72 lldb_private::CompilerDeclContext::FindDeclByName(class lldb_private::ConstString, bool) D:\Projects\github\llvm-project-fork\lldb\source\Symbol\CompilerDeclContext.cpp:20:0
 #22 0x00007ffb3d0826e1 lldb_private::ClangExpressionDeclMap::LookupLocalVariable(struct lldb_private::NameSearchContext &, class lldb_private::ConstString, class lldb_private::SymbolContext &, class lldb_private::CompilerDeclContext const &) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\ExpressionParser\Clang\ClangExpressionDeclMap.cpp:1080:0
 #23 0x00007ffb3d08031e lldb_private::ClangExpressionDeclMap::FindExternalVisibleDecls(struct lldb_private::NameSearchContext &, class std::shared_ptr<class lldb_private::Module>, class lldb_private::CompilerDeclContext const &) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\ExpressionParser\Clang\ClangExpressionDeclMap.cpp:1418:0
 #24 0x00007ffb3d07fa4b lldb_private::ClangExpressionDeclMap::FindExternalVisibleDecls(struct lldb_private::NameSearchContext &) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\ExpressionParser\Clang\ClangExpressionDeclMap.cpp:724:0
 #25 0x00007ffb3d00a802 lldb_private::ClangASTSource::FindExternalVisibleDeclsByName(class clang::DeclContext const *, class clang::DeclarationName, class clang::DeclContext const *) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\ExpressionParser\Clang\ClangASTSource.cpp:181:0
 #26 0x00007ffb3b542e73 lldb_private::ClangASTSource::ClangASTSourceProxy::FindExternalVisibleDeclsByName(class clang::DeclContext const *, class clang::DeclarationName, class clang::DeclContext const *) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\ExpressionParser\Clang\ClangASTSource.h:220:0
 #27 0x00007ffb42fb849f clang::DeclContext::lookupImpl(class clang::DeclarationName, class clang::DeclContext const *) const D:\Projects\github\llvm-project-fork\clang\lib\AST\DeclBase.cpp:1916:0
 #28 0x00007ffb42fb7723 clang::DeclContext::lookup(class clang::DeclarationName) const D:\Projects\github\llvm-project-fork\clang\lib\AST\DeclBase.cpp:1876:0
 #29 0x00007ffb411cbd7e LookupDirect D:\Projects\github\llvm-project-fork\clang\lib\Sema\SemaLookup.cpp:1122:0
 #30 0x00007ffb411cc396 CppNamespaceLookup D:\Projects\github\llvm-project-fork\clang\lib\Sema\SemaLookup.cpp:1219:0
 #31 0x00007ffb411999db clang::Sema::CppLookupName(class clang::LookupResult &, class clang::Scope *) D:\Projects\github\llvm-project-fork\clang\lib\Sema\SemaLookup.cpp:1518:0
 #32 0x00007ffb4119287b clang::Sema::LookupName(class clang::LookupResult &, class clang::Scope *, bool, bool) D:\Projects\github\llvm-project-fork\clang\lib\Sema\SemaLookup.cpp:2274:0
 #33 0x00007ffb41193612 clang::Sema::LookupParsedName(class clang::LookupResult &, class clang::Scope *, class clang::CXXScopeSpec *, class clang::QualType, bool, bool) D:\Projects\github\llvm-project-fork\clang\lib\Sema\SemaLookup.cpp:2720:0
 #34 0x00007ffb4122b501 clang::Sema::ClassifyName(class clang::Scope *, class clang::CXXScopeSpec &, class clang::IdentifierInfo *&, class clang::SourceLocation, class clang::Token const &, class clang::CorrectionCandidateCallback *) D:\Projects\github\llvm-project-fork\clang\lib\Sema\SemaDecl.cpp:898:0
 #35 0x00007ffb40b46092 clang::Parser::TryAnnotateName(class clang::CorrectionCandidateCallback *, enum clang::ImplicitTypenameContext) D:\Projects\github\llvm-project-fork\clang\lib\Parse\Parser.cpp:1823:0
 #36 0x00007ffb40c799af clang::Parser::ParseStatementOrDeclarationAfterAttributes(class llvm::SmallVector<class clang::Stmt *, 32> &, enum clang::Parser::ParsedStmtContext, class clang::SourceLocation *, class clang::ParsedAttributes &, class clang::ParsedAttributes &) D:\Projects\github\llvm-project-fork\clang\lib\Parse\ParseStmt.cpp:223:0
 #37 0x00007ffb40c7952d clang::Parser::ParseStatementOrDeclaration(class llvm::SmallVector<class clang::Stmt *, 32> &, enum clang::Parser::ParsedStmtContext, class clang::SourceLocation *) D:\Projects\github\llvm-project-fork\clang\lib\Parse\ParseStmt.cpp:127:0
 #38 0x00007ffb40c7e09a clang::Parser::ParseCompoundStatementBody(bool) D:\Projects\github\llvm-project-fork\clang\lib\Parse\ParseStmt.cpp:1267:0
 #39 0x00007ffb40c86f0c clang::Parser::ParseFunctionStatementBody(class clang::Decl *, class clang::Parser::ParseScope &) D:\Projects\github\llvm-project-fork\clang\lib\Parse\ParseStmt.cpp:2585:0
 #40 0x00007ffb40b4cee9 clang::Parser::ParseFunctionDefinition(class clang::ParsingDeclarator &, struct clang::Parser::ParsedTemplateInfo const &, class clang::Parser::LateParsedAttrList *) D:\Projects\github\llvm-project-fork\clang\lib\Parse\Parser.cpp:1520:0
 #41 0x00007ffb40b9e897 clang::Parser::ParseDeclGroup(class clang::ParsingDeclSpec &, enum clang::DeclaratorContext, class clang::ParsedAttributes &, struct clang::Parser::ParsedTemplateInfo &, class clang::SourceLocation *, struct clang::Parser::ForRangeInit *) D:\Projects\github\llvm-project-fork\clang\lib\Parse\ParseDecl.cpp:2460:0
 #42 0x00007ffb40b4b754 clang::Parser::ParseDeclOrFunctionDefInternal(class clang::ParsedAttributes &, class clang::ParsedAttributes &, class clang::ParsingDeclSpec &, enum clang::AccessSpecifier) D:\Projects\github\llvm-project-fork\clang\lib\Parse\Parser.cpp:1244:0
 #43 0x00007ffb40b4ad56 clang::Parser::ParseDeclarationOrFunctionDefinition(class clang::ParsedAttributes &, class clang::ParsedAttributes &, class clang::ParsingDeclSpec *, enum clang::AccessSpecifier) D:\Projects\github\llvm-project-fork\clang\lib\Parse\Parser.cpp:1266:0
 #44 0x00007ffb40b4a5db clang::Parser::ParseExternalDeclaration(class clang::ParsedAttributes &, class clang::ParsedAttributes &, class clang::ParsingDeclSpec *) D:\Projects\github\llvm-project-fork\clang\lib\Parse\Parser.cpp:1069:0
 #45 0x00007ffb40b43a62 clang::Parser::ParseTopLevelDecl(class clang::OpaquePtr<class clang::DeclGroupRef> &, enum clang::Sema::ModuleImportState &) D:\Projects\github\llvm-project-fork\clang\lib\Parse\Parser.cpp:758:0
 #46 0x00007ffb40b6332a clang::ParseAST(class clang::Sema &, bool, bool) D:\Projects\github\llvm-project-fork\clang\lib\Parse\ParseAST.cpp:171:0
 #47 0x00007ffb3d044da4 lldb_private::ClangExpressionParser::ParseInternal(class lldb_private::DiagnosticManager &, class clang::CodeCompleteConsumer *, unsigned int, unsigned int) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\ExpressionParser\Clang\ClangExpressionParser.cpp:1348:0
 #48 0x00007ffb3d04249b lldb_private::ClangExpressionParser::Parse(class lldb_private::DiagnosticManager &) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\ExpressionParser\Clang\ClangExpressionParser.cpp:1205:0
 #49 0x00007ffb3d02d7ac lldb_private::ClangUserExpression::TryParse(class lldb_private::DiagnosticManager &, class lldb_private::ExecutionContext &, enum lldb_private::ExecutionPolicy, bool, bool) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\ExpressionParser\Clang\ClangUserExpression.cpp:579:0
 #50 0x00007ffb3d02cb70 lldb_private::ClangUserExpression::Parse(class lldb_private::DiagnosticManager &, class lldb_private::ExecutionContext &, enum lldb_private::ExecutionPolicy, bool, bool) D:\Projects\github\llvm-project-fork\lldb\source\Plugins\ExpressionParser\Clang\ClangUserExpression.cpp:673:0
 #51 0x00007ffb3a6b5cdb lldb_private::UserExpression::Evaluate(class lldb_private::ExecutionContext &, class lldb_private::EvaluateExpressionOptions const &, class llvm::StringRef, class llvm::StringRef, class std::shared_ptr<class lldb_private::ValueObject> &, class std::basic_string<char, struct std::char_traits<char>, class std::allocator<char>> *, class lldb_private::ValueObject *) D:\Projects\github\llvm-project-fork\lldb\source\Expression\UserExpression.cpp:279:0
 #52 0x00007ffb3a8e7aab lldb_private::Target::EvaluateExpression(class llvm::StringRef, class lldb_private::ExecutionContextScope *, class std::shared_ptr<class lldb_private::ValueObject> &, class lldb_private::EvaluateExpressionOptions const &, class std::basic_string<char, struct std::char_traits<char>, class std::allocator<char>> *, class lldb_private::ValueObject *) D:\Projects\github\llvm-project-fork\lldb\source\Target\Target.cpp:2853:0
 #53 0x00007ffb3ce06c2d lldb_private::CommandObjectExpression::EvaluateExpression(class llvm::StringRef, class lldb_private::Stream &, class lldb_private::Stream &, class lldb_private::CommandReturnObject &) D:\Projects\github\llvm-project-fork\lldb\source\Commands\CommandObjectExpression.cpp:428:0
 #54 0x00007ffb3ce0683a lldb_private::CommandObjectExpression::DoExecute(class llvm::StringRef, class lldb_private::CommandReturnObject &) D:\Projects\github\llvm-project-fork\lldb\source\Commands\CommandObjectExpression.cpp:668:0
 #55 0x00007ffb3a71dcd4 lldb_private::CommandObjectRaw::Execute(char const *, class lldb_private::CommandReturnObject &) D:\Projects\github\llvm-project-fork\lldb\source\Interpreter\CommandObject.cpp:855:0
 #56 0x00007ffb3a72a489 lldb_private::CommandInterpreter::HandleCommand(char const *, enum lldb_private::LazyBool, class lldb_private::CommandReturnObject &, bool) D:\Projects\github\llvm-project-fork\lldb\source\Interpreter\CommandInterpreter.cpp:2128:0
 #57 0x00007ffb3a140354 lldb::SBCommandInterpreter::HandleCommand(char const *, class lldb::SBExecutionContext &, class lldb::SBCommandReturnObject &, bool) D:\Projects\github\llvm-project-fork\lldb\source\API\SBCommandInterpreter.cpp:196:0
 #58 0x00007ffb3a140093 lldb::SBCommandInterpreter::HandleCommand(char const *, class lldb::SBCommandReturnObject &, bool) D:\Projects\github\llvm-project-fork\lldb\source\API\SBCommandInterpreter.cpp:176:0
 #59 0x00007ffb3a33387f _wrap_SBCommandInterpreter_HandleCommand__SWIG_0 D:\Projects\github\llvm-project-fork\llvm\cmake-build-relwithdebinfo\tools\lldb\bindings\python\LLDBWrapPython.cpp:16709:0
 #60 0x00007ffb3a334957 _wrap_SBCommandInterpreter_HandleCommand D:\Projects\github\llvm-project-fork\llvm\cmake-build-relwithdebinfo\tools\lldb\bindings\python\LLDBWrapPython.cpp:16939:0
```