### PR TITLE
[LLDB] Fix tests on Windows 

### DIFF
--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -343,6 +343,6 @@ if "XDG_CACHE_HOME" in os.environ:
 
 # Transfer some environment variables into the tests on Windows build host.
 if platform.system() == "Windows":
-    for v in ["SystemDrive"]:
+    for v in ["SystemDrive", "APPDATA"]:
         if v in os.environ:
             config.environment[v] = os.environ[v]

--- a/lldb/test/API/python_api/watchpoint/watchlocation/TestTargetWatchAddress.py
+++ b/lldb/test/API/python_api/watchpoint/watchlocation/TestTargetWatchAddress.py
@@ -201,8 +201,8 @@ class TargetWatchpointCreateByAddressPITestCase(TestBase):
                 value.GetValueAsUnsigned(), 365, wp_opts, error
             )
             self.assertFalse(watchpoint)
-            self.expect(
+            # The message depends on whether the lldb-server implementation or the in-process implementation is used.
+            self.assertRegex(
                 error.GetCString(),
-                exe=False,
-                substrs=["Setting one of the watchpoint resources failed"],
+                "Can't enable watchpoint|Setting one of the watchpoint resources failed",
             )

--- a/lldb/test/Shell/Diagnostics/TestDump.test
+++ b/lldb/test/Shell/Diagnostics/TestDump.test
@@ -5,11 +5,11 @@
 # RUN: rm -rf %t.existing
 # RUN: mkdir -p %t.existing
 # RUN: %lldb -o 'diagnostics dump -d %t.existing'
-# RUN: file %t.existing | FileCheck %s
+# RUN: test -d %t.existing
 
 # Dump to a non-existing directory.
 # RUN: rm -rf %t.nonexisting
 # RUN: %lldb -o 'diagnostics dump -d %t.nonexisting'
-# RUN: file %t.nonexisting | FileCheck %s
+# RUN: test -d %t.nonexisting
 
 # CHECK: directory


### PR DESCRIPTION
Hello,

I'm working on LLDB on Windows and have encountered some issues with the tests.

1) Many tests fail to start on Windows due to an import exception:
```
Traceback (most recent call last):
  File "D:\Projects\github\llvm-project-fork\lldb\test\API\dotest.py", line 8, in <module>
    lldbsuite.test.run_suite()
  File "D:\Projects\github\llvm-project-fork\lldb\packages\Python\lldbsuite\test\dotest.py", line 1042, in run_suite
    checkLibcxxSupport()
  File "D:\Projects\github\llvm-project-fork\lldb\packages\Python\lldbsuite\test\dotest.py", line 799, in checkLibcxxSupport
    result, reason = canRunLibcxxTests()
  File "D:\Projects\github\llvm-project-fork\lldb\packages\Python\lldbsuite\test\dotest.py", line 770, in canRunLibcxxTests
    from lldbsuite.test import lldbplatformutil
  File "D:\Projects\github\llvm-project-fork\lldb\packages\Python\lldbsuite\test\lldbplatformutil.py", line 11, in <module>
    from packaging import version
ModuleNotFoundError: No module named 'packaging'
```

I think this exception occurs due to missing environment variables. I fixed the test setup to use the original environment variables.

2) `file` utility is not available on Windows, so I fixed the test to use `test -d` instead.

3) There is a minor difference in the watchpoint error message on Windows.

Please take a look.

Thanks!