### PR TITLE
[Clang] Check PP presence when printing stats

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -373,6 +373,8 @@ Miscellaneous Bug Fixes
 Miscellaneous Clang Crashes Fixed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Fixed crash when ``-print-stats`` is enabled in compiling IR files. (#GH131608)
+
 OpenACC Specific Changes
 ------------------------
 

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -1120,10 +1120,14 @@ void FrontendAction::EndSourceFile() {
 
   if (CI.getFrontendOpts().ShowStats) {
     llvm::errs() << "\nSTATISTICS FOR '" << getCurrentFileOrBufferName() << "':\n";
-    CI.getPreprocessor().PrintStats();
-    CI.getPreprocessor().getIdentifierTable().PrintStats();
-    CI.getPreprocessor().getHeaderSearchInfo().PrintStats();
-    CI.getSourceManager().PrintStats();
+    if (CI.hasPreprocessor()) {
+      CI.getPreprocessor().PrintStats();
+      CI.getPreprocessor().getIdentifierTable().PrintStats();
+      CI.getPreprocessor().getHeaderSearchInfo().PrintStats();
+    }
+    if (CI.hasSourceManager()) {
+      CI.getSourceManager().PrintStats();
+    }
     llvm::errs() << "\n";
   }
 

--- a/clang/test/Frontend/print-stats.c
+++ b/clang/test/Frontend/print-stats.c
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -print-stats \
+// RUN:    -emit-llvm -x ir /dev/null -o - 2>&1 | FileCheck %s --check-prefix=CHECK-IR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -print-stats \
+// RUN:    -emit-llvm -x c /dev/null -o - 2>&1 | FileCheck %s --check-prefix=CHECK-C
+
+// CHECK-IR: *** Source Manager Stats
+// CHECK-IR: *** File Manager Stats
+// CHECK-IR: *** Virtual File System Stats
+
+// CHECK-C: *** Semantic Analysis Stats
+// CHECK-C: *** Analysis Based Warnings Stats
+// CHECK-C: *** AST Context Stats
+// CHECK-C: *** Decl Stats
+// CHECK-C: *** Stmt/Expr Stats
+// CHECK-C: *** Preprocessor Stats
+// CHECK-C: *** Identifier Table Stats
+// CHECK-C: *** HeaderSearch Stats
+// CHECK-C: *** Source Manager Stats
+// CHECK-C: *** File Manager Stats
+// CHECK-C: *** Virtual File System Stats


### PR DESCRIPTION
Front-end option `-print-stats` can be used to print statistics around the compilation process. But clang with this options will crash when input is IR file. This patch fixes the crash by checking preprocessor presence before invoking it.