### PR TITLE
[DirectX] Fix build error if set BUILD_SHARED_LIBS

### DIFF
--- a/llvm/unittests/Target/DirectX/CMakeLists.txt
+++ b/llvm/unittests/Target/DirectX/CMakeLists.txt
@@ -4,12 +4,17 @@ include_directories(
   )
 
 set(LLVM_LINK_COMPONENTS
+  Analysis
   AsmParser
   Core
   DirectXCodeGen
+  DirectXDesc
+  DirectXInfo
   DirectXPointerTypeAnalysis
+  MC
   Passes
   Support
+  TargetParser
   )
 
 add_llvm_target_unittest(DirectXTests


### PR DESCRIPTION
If enable `BUILD_SHARED_LIBS`, it will build each component as shared library. If some compoenents are not set in `LLVM_LINK_COMPONENTS`, the linker will complain that symbols are not found.
This change adds the missing components.