### PR TITLE
[LLDB][NFC] Added the interface DWARFExpression::Delegate to break dependencies and reduce lldb-server size

### DIFF
--- a/lldb/include/lldb/Expression/DWARFExpression.h
+++ b/lldb/include/lldb/Expression/DWARFExpression.h
@@ -43,9 +43,8 @@ public:
     virtual uint16_t GetVersion() const = 0;
     virtual dw_addr_t GetBaseAddress() const = 0;
     virtual uint8_t GetAddressByteSize() const = 0;
-    virtual llvm::Error GetDIEBitSizeAndSign(uint64_t die_offset,
-                                             uint64_t &bit_size,
-                                             bool &sign) = 0;
+    virtual llvm::Expected<std::pair<uint64_t, bool>>
+    GetDIEBitSizeAndSign(uint64_t relative_die_offset) const = 0;
     virtual dw_addr_t ReadAddressFromDebugAddrSection(uint32_t index) const = 0;
     virtual lldb::offset_t
     GetVendorDWARFOpcodeSize(const DataExtractor &data,

--- a/lldb/include/lldb/Expression/DWARFExpression.h
+++ b/lldb/include/lldb/Expression/DWARFExpression.h
@@ -23,7 +23,7 @@ namespace lldb_private {
 
 namespace plugin {
 namespace dwarf {
-class DWARFUnit;
+class DWARFUnitInterface;
 } // namespace dwarf
 } // namespace plugin
 
@@ -65,20 +65,20 @@ public:
   /// \return
   ///     The address specified by the operation, if the operation exists, or
   ///     an llvm::Error otherwise.
-  llvm::Expected<lldb::addr_t>
-  GetLocation_DW_OP_addr(const plugin::dwarf::DWARFUnit *dwarf_cu) const;
+  llvm::Expected<lldb::addr_t> GetLocation_DW_OP_addr(
+      const plugin::dwarf::DWARFUnitInterface *dwarf_cu) const;
 
-  bool Update_DW_OP_addr(const plugin::dwarf::DWARFUnit *dwarf_cu,
+  bool Update_DW_OP_addr(const plugin::dwarf::DWARFUnitInterface *dwarf_cu,
                          lldb::addr_t file_addr);
 
   void UpdateValue(uint64_t const_value, lldb::offset_t const_value_byte_size,
                    uint8_t addr_byte_size);
 
-  bool
-  ContainsThreadLocalStorage(const plugin::dwarf::DWARFUnit *dwarf_cu) const;
+  bool ContainsThreadLocalStorage(
+      const plugin::dwarf::DWARFUnitInterface *dwarf_cu) const;
 
   bool LinkThreadLocalStorage(
-      const plugin::dwarf::DWARFUnit *dwarf_cu,
+      const plugin::dwarf::DWARFUnitInterface *dwarf_cu,
       std::function<lldb::addr_t(lldb::addr_t file_addr)> const
           &link_address_callback);
 
@@ -132,13 +132,14 @@ public:
   static llvm::Expected<Value>
   Evaluate(ExecutionContext *exe_ctx, RegisterContext *reg_ctx,
            lldb::ModuleSP module_sp, const DataExtractor &opcodes,
-           const plugin::dwarf::DWARFUnit *dwarf_cu,
+           const plugin::dwarf::DWARFUnitInterface *dwarf_cu,
            const lldb::RegisterKind reg_set, const Value *initial_value_ptr,
            const Value *object_address_ptr);
 
-  static bool ParseDWARFLocationList(const plugin::dwarf::DWARFUnit *dwarf_cu,
-                                     const DataExtractor &data,
-                                     DWARFExpressionList *loc_list);
+  static bool
+  ParseDWARFLocationList(const plugin::dwarf::DWARFUnitInterface *dwarf_cu,
+                         const DataExtractor &data,
+                         DWARFExpressionList *loc_list);
 
   bool GetExpressionData(DataExtractor &data) const {
     data = m_data;

--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -38,8 +38,6 @@
 #include "lldb/Target/Thread.h"
 #include "llvm/DebugInfo/DWARF/DWARFExpression.h"
 
-#include "Plugins/SymbolFile/DWARF/DWARFUnit.h"
-
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::dwarf;
@@ -389,6 +387,16 @@ GetOpcodeDataSize(const DataExtractor &data, const lldb::offset_t data_offset,
     return dwarf_cu->GetVendorDWARFOpcodeSize(data, data_offset, op);
 
   return LLDB_INVALID_OFFSET;
+}
+
+static const char *DW_OP_value_to_name(uint32_t val) {
+  static char invalid[100];
+  llvm::StringRef llvmstr = llvm::dwarf::OperationEncodingString(val);
+  if (llvmstr.empty()) {
+    snprintf(invalid, sizeof(invalid), "Unknown DW_OP constant: 0x%x", val);
+    return invalid;
+  }
+  return llvmstr.data();
 }
 
 llvm::Expected<lldb::addr_t> DWARFExpression::GetLocation_DW_OP_addr(

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
@@ -240,7 +240,7 @@ bool DWARFDebugInfoEntry::GetDIENamesAndRanges(
                 data = DataExtractor(data, offset, data.GetByteSize() - offset);
                 if (lo_pc != LLDB_INVALID_ADDRESS) {
                   assert(lo_pc >= cu->GetBaseAddress());
-                  cu->ParseDWARFLocationList(data, frame_base);
+                  cu->ParseDWARFLocationList(data, *frame_base);
                   frame_base->SetFuncFileAddress(lo_pc);
                 } else
                   set_frame_base_loclist_addr = true;

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDebugInfoEntry.cpp
@@ -240,7 +240,7 @@ bool DWARFDebugInfoEntry::GetDIENamesAndRanges(
                 data = DataExtractor(data, offset, data.GetByteSize() - offset);
                 if (lo_pc != LLDB_INVALID_ADDRESS) {
                   assert(lo_pc >= cu->GetBaseAddress());
-                  DWARFExpression::ParseDWARFLocationList(cu, data, frame_base);
+                  cu->ParseDWARFLocationList(data, frame_base);
                   frame_base->SetFuncFileAddress(lo_pc);
                 } else
                   set_frame_base_loclist_addr = true;

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDefines.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDefines.cpp
@@ -23,15 +23,5 @@ llvm::StringRef DW_TAG_value_to_name(dw_tag_t tag) {
   return s_unknown_tag_name;
 }
 
-const char *DW_OP_value_to_name(uint32_t val) {
-  static char invalid[100];
-  llvm::StringRef llvmstr = llvm::dwarf::OperationEncodingString(val);
-  if (llvmstr.empty()) {
-    snprintf(invalid, sizeof(invalid), "Unknown DW_OP constant: 0x%x", val);
-    return invalid;
-  }
-  return llvmstr.data();
-}
-
 } // namespace dwarf
 } // namespace lldb_private::plugin

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDefines.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDefines.h
@@ -17,8 +17,6 @@ namespace dwarf {
 
 llvm::StringRef DW_TAG_value_to_name(dw_tag_t tag);
 
-const char *DW_OP_value_to_name(uint32_t val);
-
 } // namespace dwarf
 } // namespace lldb_private::plugin
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFFormValue.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFFormValue.cpp
@@ -44,8 +44,8 @@ bool DWARFFormValue::ExtractValue(const DWARFDataExtractor &data,
     switch (m_form) {
     case DW_FORM_addr:
       assert(m_unit);
-      m_value.uval =
-          data.GetMaxU64(offset_ptr, DWARFUnit::GetAddressByteSize(m_unit));
+      m_value.uval = data.GetMaxU64(
+          offset_ptr, DWARFUnitInterface::GetAddressByteSize(m_unit));
       break;
     case DW_FORM_block1:
       m_value.uval = data.GetU8(offset_ptr);
@@ -242,7 +242,7 @@ bool DWARFFormValue::SkipValue(dw_form_t form,
 
   // Compile unit address sized values
   case DW_FORM_addr:
-    *offset_ptr += DWARFUnit::GetAddressByteSize(unit);
+    *offset_ptr += DWARFUnitInterface::GetAddressByteSize(unit);
     return true;
 
   case DW_FORM_ref_addr:

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFFormValue.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFFormValue.cpp
@@ -44,8 +44,8 @@ bool DWARFFormValue::ExtractValue(const DWARFDataExtractor &data,
     switch (m_form) {
     case DW_FORM_addr:
       assert(m_unit);
-      m_value.uval = data.GetMaxU64(
-          offset_ptr, DWARFUnitInterface::GetAddressByteSize(m_unit));
+      m_value.uval =
+          data.GetMaxU64(offset_ptr, DWARFUnit::GetAddressByteSize(m_unit));
       break;
     case DW_FORM_block1:
       m_value.uval = data.GetU8(offset_ptr);
@@ -242,7 +242,7 @@ bool DWARFFormValue::SkipValue(dw_form_t form,
 
   // Compile unit address sized values
   case DW_FORM_addr:
-    *offset_ptr += DWARFUnitInterface::GetAddressByteSize(unit);
+    *offset_ptr += DWARFUnit::GetAddressByteSize(unit);
     return true;
 
   case DW_FORM_ref_addr:

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFUnit.h
@@ -39,7 +39,7 @@ enum DWARFProducer {
   eProducerOther
 };
 
-class DWARFUnit : public UserID, public DWARFExpression::Delegate {
+class DWARFUnit : public DWARFExpression::Delegate, public UserID {
   using die_iterator_range =
       llvm::iterator_range<DWARFDebugInfoEntry::collection::iterator>;
 
@@ -153,8 +153,8 @@ public:
   /// error or if the attribute is not present.
   llvm::StringRef PeekDIEName(dw_offset_t die_offset);
 
-  llvm::Error GetDIEBitSizeAndSign(uint64_t die_offset, uint64_t &bit_size,
-                                   bool &sign) override;
+  llvm::Expected<std::pair<uint64_t, bool>>
+  GetDIEBitSizeAndSign(uint64_t relative_die_offset) const override;
 
   lldb::offset_t GetVendorDWARFOpcodeSize(const DataExtractor &data,
                                           const lldb::offset_t data_offset,
@@ -165,7 +165,7 @@ public:
                               std::vector<Value> &stack) const override;
 
   bool ParseDWARFLocationList(const DataExtractor &data,
-                              DWARFExpressionList *loc_list) const;
+                              DWARFExpressionList &loc_list) const;
 
   DWARFUnit &GetNonSkeletonUnit();
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -3296,7 +3296,7 @@ static DWARFExpressionList GetExprListFromAtLocation(DWARFFormValue form_value,
   if (data.ValidOffset(offset)) {
     data = DataExtractor(data, offset, data.GetByteSize() - offset);
     const DWARFUnit *dwarf_cu = form_value.GetUnit();
-    if (dwarf_cu->ParseDWARFLocationList(data, &location_list))
+    if (dwarf_cu->ParseDWARFLocationList(data, location_list))
       location_list.SetFuncFileAddress(func_low_pc);
   }
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -3296,7 +3296,7 @@ static DWARFExpressionList GetExprListFromAtLocation(DWARFFormValue form_value,
   if (data.ValidOffset(offset)) {
     data = DataExtractor(data, offset, data.GetByteSize() - offset);
     const DWARFUnit *dwarf_cu = form_value.GetUnit();
-    if (DWARFExpression::ParseDWARFLocationList(dwarf_cu, data, &location_list))
+    if (dwarf_cu->ParseDWARFLocationList(data, &location_list))
       location_list.SetFuncFileAddress(func_low_pc);
   }
 


### PR DESCRIPTION
This patch addresses the issue #129543.

After this patch DWARFExpression does not call DWARFUnit directly and does not depend on lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp and a lot of clang code.

After this patch the size of lldb-server binary (Linux Aarch64) is reduced from 42MB to 13MB with LLVM 20.0.0
and from 47MB to 17MB with LLVM 21.0.0.