### PR TITLE
[clang][OpenMP] Fix bug #62099 - use hash value when inode ID cannot be determined

### DIFF
--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -9582,7 +9582,7 @@ OpenMPIRBuilder::getTargetEntryUniqueInfo(FileIdentifierInfoCallbackTy CallBack,
   // If the inode ID could not be determined, create a hash value
   // the current file name and use that as an ID.
   if (EC)
-    FileID = hash_value(FileIDInfo);
+    FileID = hash_value(std::get<0>(FileIDInfo));
   else
     FileID = ID.getFile();
 

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -9579,14 +9579,12 @@ OpenMPIRBuilder::getTargetEntryUniqueInfo(FileIdentifierInfoCallbackTy CallBack,
   auto FileIDInfo = CallBack();
   uint64_t FileID{0};
   auto EC = sys::fs::getUniqueID(std::get<0>(FileIDInfo), ID);
-  if (EC) {
-    // The inode ID could not be determined, so create a hash value
-    // the current file name and use that as an ID.
+  // If the inode ID could not be determined, create a hash value
+  // the current file name and use that as an ID.
+  if (EC)
     FileID = hash_value(FileIDInfo);
-  }
-  else {
+  else
     FileID = ID.getFile();
-  }
 
   return TargetRegionEntryInfo(ParentName, ID.getDevice(), FileID,
                                std::get<1>(FileIDInfo));

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -9577,8 +9577,8 @@ OpenMPIRBuilder::getTargetEntryUniqueInfo(FileIdentifierInfoCallbackTy CallBack,
                                           StringRef ParentName) {
   sys::fs::UniqueID ID;
   auto FileIDInfo = CallBack();
-  uint64_t FileID{0};
-  auto EC = sys::fs::getUniqueID(std::get<0>(FileIDInfo), ID);
+  uint64_t FileID = 0;
+  std::error_code EC = sys::fs::getUniqueID(std::get<0>(FileIDInfo), ID);
   // If the inode ID could not be determined, create a hash value
   // the current file name and use that as an ID.
   if (EC)


### PR DESCRIPTION
When creating the name of an outlined region, Clang uses the file's inode ID to generate a unique name.  When the file does not exist, this causes a fatal abort of the compiler.  This PR switches to a has value that is used instead.