### PR TITLE
[libc] Properly clear out errno in tests that check its value.

### DIFF
--- a/libc/test/src/math/smoke/FModTest.h
+++ b/libc/test/src/math/smoke/FModTest.h
@@ -19,10 +19,10 @@
 
 #define TEST_SPECIAL(x, y, expected, dom_err, expected_exception)              \
   LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT);                         \
+  LIBC_NAMESPACE::libc_errno = 0;                                              \
   EXPECT_FP_EQ(expected, f(x, y));                                             \
   EXPECT_MATH_ERRNO((dom_err) ? EDOM : 0);                                     \
-  EXPECT_FP_EXCEPTION(expected_exception);                                     \
-  LIBC_NAMESPACE::fputil::clear_except(FE_ALL_EXCEPT)
+  EXPECT_FP_EXCEPTION(expected_exception)
 
 #define TEST_REGULAR(x, y, expected) TEST_SPECIAL(x, y, expected, false, 0)
 

--- a/libc/test/src/sys/epoll/linux/epoll_create1_test.cpp
+++ b/libc/test/src/sys/epoll/linux/epoll_create1_test.cpp
@@ -15,6 +15,7 @@
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
 
 TEST(LlvmLibcEpollCreate1Test, Basic) {
+  LIBC_NAMESPACE::libc_errno = 0;
   int fd = LIBC_NAMESPACE::epoll_create1(0);
   ASSERT_GT(fd, 0);
   ASSERT_ERRNO_SUCCESS();
@@ -23,6 +24,7 @@ TEST(LlvmLibcEpollCreate1Test, Basic) {
 }
 
 TEST(LlvmLibcEpollCreate1Test, CloseOnExecute) {
+  LIBC_NAMESPACE::libc_errno = 0;
   int fd = LIBC_NAMESPACE::epoll_create1(EPOLL_CLOEXEC);
   ASSERT_GT(fd, 0);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/sys/epoll/linux/epoll_create_test.cpp
+++ b/libc/test/src/sys/epoll/linux/epoll_create_test.cpp
@@ -15,6 +15,7 @@
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
 
 TEST(LlvmLibcEpollCreateTest, Basic) {
+  LIBC_NAMESPACE::libc_errno = 0;
   int fd = LIBC_NAMESPACE::epoll_create(1);
   ASSERT_GT(fd, 0);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/sys/epoll/linux/epoll_ctl_test.cpp
+++ b/libc/test/src/sys/epoll/linux/epoll_ctl_test.cpp
@@ -19,6 +19,7 @@
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
 
 TEST(LlvmLibcEpollCtlTest, Basic) {
+  LIBC_NAMESPACE::libc_errno = 0;
   int epfd = LIBC_NAMESPACE::epoll_create1(0);
   ASSERT_GT(epfd, 0);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/sys/epoll/linux/epoll_pwait2_test.cpp
+++ b/libc/test/src/sys/epoll/linux/epoll_pwait2_test.cpp
@@ -20,6 +20,7 @@
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
 
 TEST(LlvmLibcEpollPwaitTest, Basic) {
+  LIBC_NAMESPACE::libc_errno = 0;
   int epfd = LIBC_NAMESPACE::epoll_create1(0);
   ASSERT_GT(epfd, 0);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/sys/epoll/linux/epoll_pwait_test.cpp
+++ b/libc/test/src/sys/epoll/linux/epoll_pwait_test.cpp
@@ -20,6 +20,7 @@
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
 
 TEST(LlvmLibcEpollPwaitTest, Basic) {
+  LIBC_NAMESPACE::libc_errno = 0;
   int epfd = LIBC_NAMESPACE::epoll_create1(0);
   ASSERT_GT(epfd, 0);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/sys/epoll/linux/epoll_wait_test.cpp
+++ b/libc/test/src/sys/epoll/linux/epoll_wait_test.cpp
@@ -19,6 +19,7 @@
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
 
 TEST(LlvmLibcEpollWaitTest, Basic) {
+  LIBC_NAMESPACE::libc_errno = 0;
   int epfd = LIBC_NAMESPACE::epoll_create1(0);
   ASSERT_GT(epfd, 0);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/sys/socket/linux/send_recv_test.cpp
+++ b/libc/test/src/sys/socket/linux/send_recv_test.cpp
@@ -23,17 +23,19 @@ TEST(LlvmLibcSendRecvTest, SucceedsWithSocketPair) {
 
   int sockpair[2] = {0, 0};
 
+  LIBC_NAMESPACE::libc_errno = 0;
   int result = LIBC_NAMESPACE::socketpair(AF_UNIX, SOCK_STREAM, 0, sockpair);
   ASSERT_EQ(result, 0);
   ASSERT_ERRNO_SUCCESS();
 
+  LIBC_NAMESPACE::libc_errno = 0;
   ssize_t send_result =
       LIBC_NAMESPACE::send(sockpair[0], TEST_MESSAGE, MESSAGE_LEN, 0);
   EXPECT_EQ(send_result, static_cast<ssize_t>(MESSAGE_LEN));
   ASSERT_ERRNO_SUCCESS();
 
+  LIBC_NAMESPACE::libc_errno = 0;
   char buffer[256];
-
   ssize_t recv_result =
       LIBC_NAMESPACE::recv(sockpair[1], buffer, sizeof(buffer), 0);
   ASSERT_EQ(recv_result, static_cast<ssize_t>(MESSAGE_LEN));
@@ -42,10 +44,12 @@ TEST(LlvmLibcSendRecvTest, SucceedsWithSocketPair) {
   ASSERT_STREQ(buffer, TEST_MESSAGE);
 
   // close both ends of the socket
+  LIBC_NAMESPACE::libc_errno = 0;
   result = LIBC_NAMESPACE::close(sockpair[0]);
   ASSERT_EQ(result, 0);
   ASSERT_ERRNO_SUCCESS();
 
+  LIBC_NAMESPACE::libc_errno = 0;
   result = LIBC_NAMESPACE::close(sockpair[1]);
   ASSERT_EQ(result, 0);
   ASSERT_ERRNO_SUCCESS();
@@ -55,19 +59,17 @@ TEST(LlvmLibcSendRecvTest, SendFails) {
   const char TEST_MESSAGE[] = "connection terminated";
   const size_t MESSAGE_LEN = sizeof(TEST_MESSAGE);
 
+  LIBC_NAMESPACE::libc_errno = 0;
   ssize_t send_result = LIBC_NAMESPACE::send(-1, TEST_MESSAGE, MESSAGE_LEN, 0);
   EXPECT_EQ(send_result, ssize_t(-1));
   ASSERT_ERRNO_FAILURE();
-
-  LIBC_NAMESPACE::libc_errno = 0; // reset errno to avoid test ordering issues.
 }
 
 TEST(LlvmLibcSendRecvTest, RecvFails) {
   char buffer[256];
 
+  LIBC_NAMESPACE::libc_errno = 0;
   ssize_t recv_result = LIBC_NAMESPACE::recv(-1, buffer, sizeof(buffer), 0);
   ASSERT_EQ(recv_result, ssize_t(-1));
   ASSERT_ERRNO_FAILURE();
-
-  LIBC_NAMESPACE::libc_errno = 0; // reset errno to avoid test ordering issues.
 }

--- a/libc/test/src/sys/socket/linux/sendmsg_recvmsg_test.cpp
+++ b/libc/test/src/sys/socket/linux/sendmsg_recvmsg_test.cpp
@@ -23,6 +23,7 @@ TEST(LlvmLibcSendMsgRecvMsgTest, SucceedsWithSocketPair) {
 
   int sockpair[2] = {0, 0};
 
+  LIBC_NAMESPACE::libc_errno = 0;
   int result = LIBC_NAMESPACE::socketpair(AF_UNIX, SOCK_STREAM, 0, sockpair);
   ASSERT_EQ(result, 0);
   ASSERT_ERRNO_SUCCESS();
@@ -41,6 +42,7 @@ TEST(LlvmLibcSendMsgRecvMsgTest, SucceedsWithSocketPair) {
   send_message.msg_controllen = 0;
   send_message.msg_flags = 0;
 
+  LIBC_NAMESPACE::libc_errno = 0;
   ssize_t send_result = LIBC_NAMESPACE::sendmsg(sockpair[0], &send_message, 0);
   EXPECT_EQ(send_result, static_cast<ssize_t>(MESSAGE_LEN));
   ASSERT_ERRNO_SUCCESS();
@@ -60,6 +62,7 @@ TEST(LlvmLibcSendMsgRecvMsgTest, SucceedsWithSocketPair) {
   recv_message.msg_controllen = 0;
   recv_message.msg_flags = 0;
 
+  LIBC_NAMESPACE::libc_errno = 0;
   ssize_t recv_result = LIBC_NAMESPACE::recvmsg(sockpair[1], &recv_message, 0);
   ASSERT_EQ(recv_result, static_cast<ssize_t>(MESSAGE_LEN));
   ASSERT_ERRNO_SUCCESS();
@@ -67,10 +70,12 @@ TEST(LlvmLibcSendMsgRecvMsgTest, SucceedsWithSocketPair) {
   ASSERT_STREQ(buffer, TEST_MESSAGE);
 
   // close both ends of the socket
+  LIBC_NAMESPACE::libc_errno = 0;
   result = LIBC_NAMESPACE::close(sockpair[0]);
   ASSERT_EQ(result, 0);
   ASSERT_ERRNO_SUCCESS();
 
+  LIBC_NAMESPACE::libc_errno = 0;
   result = LIBC_NAMESPACE::close(sockpair[1]);
   ASSERT_EQ(result, 0);
   ASSERT_ERRNO_SUCCESS();
@@ -94,11 +99,10 @@ TEST(LlvmLibcSendMsgRecvMsgTest, SendFails) {
   send_message.msg_controllen = 0;
   send_message.msg_flags = 0;
 
+  LIBC_NAMESPACE::libc_errno = 0;
   ssize_t send_result = LIBC_NAMESPACE::sendmsg(-1, &send_message, 0);
   EXPECT_EQ(send_result, ssize_t(-1));
   ASSERT_ERRNO_FAILURE();
-
-  LIBC_NAMESPACE::libc_errno = 0; // reset errno to avoid test ordering issues.
 }
 
 TEST(LlvmLibcSendMsgRecvMsgTest, RecvFails) {
@@ -117,9 +121,8 @@ TEST(LlvmLibcSendMsgRecvMsgTest, RecvFails) {
   recv_message.msg_controllen = 0;
   recv_message.msg_flags = 0;
 
+  LIBC_NAMESPACE::libc_errno = 0;
   ssize_t recv_result = LIBC_NAMESPACE::recvmsg(-1, &recv_message, 0);
   ASSERT_EQ(recv_result, ssize_t(-1));
   ASSERT_ERRNO_FAILURE();
-
-  LIBC_NAMESPACE::libc_errno = 0; // reset errno to avoid test ordering issues.
 }

--- a/libc/test/src/sys/socket/linux/sendto_recvfrom_test.cpp
+++ b/libc/test/src/sys/socket/linux/sendto_recvfrom_test.cpp
@@ -23,10 +23,12 @@ TEST(LlvmLibcSendToRecvFromTest, SucceedsWithSocketPair) {
 
   int sockpair[2] = {0, 0};
 
+  LIBC_NAMESPACE::libc_errno = 0;
   int result = LIBC_NAMESPACE::socketpair(AF_UNIX, SOCK_STREAM, 0, sockpair);
   ASSERT_EQ(result, 0);
   ASSERT_ERRNO_SUCCESS();
 
+  LIBC_NAMESPACE::libc_errno = 0;
   ssize_t send_result = LIBC_NAMESPACE::sendto(sockpair[0], TEST_MESSAGE,
                                                MESSAGE_LEN, 0, nullptr, 0);
   EXPECT_EQ(send_result, static_cast<ssize_t>(MESSAGE_LEN));
@@ -34,6 +36,7 @@ TEST(LlvmLibcSendToRecvFromTest, SucceedsWithSocketPair) {
 
   char buffer[256];
 
+  LIBC_NAMESPACE::libc_errno = 0;
   ssize_t recv_result = LIBC_NAMESPACE::recvfrom(sockpair[1], buffer,
                                                  sizeof(buffer), 0, nullptr, 0);
   ASSERT_EQ(recv_result, static_cast<ssize_t>(MESSAGE_LEN));
@@ -42,10 +45,12 @@ TEST(LlvmLibcSendToRecvFromTest, SucceedsWithSocketPair) {
   ASSERT_STREQ(buffer, TEST_MESSAGE);
 
   // close both ends of the socket
+  LIBC_NAMESPACE::libc_errno = 0;
   result = LIBC_NAMESPACE::close(sockpair[0]);
   ASSERT_EQ(result, 0);
   ASSERT_ERRNO_SUCCESS();
 
+  LIBC_NAMESPACE::libc_errno = 0;
   result = LIBC_NAMESPACE::close(sockpair[1]);
   ASSERT_EQ(result, 0);
   ASSERT_ERRNO_SUCCESS();
@@ -55,21 +60,19 @@ TEST(LlvmLibcSendToRecvFromTest, SendToFails) {
   const char TEST_MESSAGE[] = "connection terminated";
   const size_t MESSAGE_LEN = sizeof(TEST_MESSAGE);
 
+  LIBC_NAMESPACE::libc_errno = 0;
   ssize_t send_result =
       LIBC_NAMESPACE::sendto(-1, TEST_MESSAGE, MESSAGE_LEN, 0, nullptr, 0);
   EXPECT_EQ(send_result, ssize_t(-1));
   ASSERT_ERRNO_FAILURE();
-
-  LIBC_NAMESPACE::libc_errno = 0; // reset errno to avoid test ordering issues.
 }
 
 TEST(LlvmLibcSendToRecvFromTest, RecvFromFails) {
   char buffer[256];
 
+  LIBC_NAMESPACE::libc_errno = 0;
   ssize_t recv_result =
       LIBC_NAMESPACE::recvfrom(-1, buffer, sizeof(buffer), 0, nullptr, 0);
   ASSERT_EQ(recv_result, ssize_t(-1));
   ASSERT_ERRNO_FAILURE();
-
-  LIBC_NAMESPACE::libc_errno = 0; // reset errno to avoid test ordering issues.
 }

--- a/libc/test/src/sys/socket/linux/socket_test.cpp
+++ b/libc/test/src/sys/socket/linux/socket_test.cpp
@@ -16,6 +16,7 @@
 #include <sys/socket.h> // For AF_UNIX and SOCK_DGRAM
 
 TEST(LlvmLibcSocketTest, LocalSocket) {
+  LIBC_NAMESPACE::libc_errno = 0;
   int sock = LIBC_NAMESPACE::socket(AF_UNIX, SOCK_DGRAM, 0);
   ASSERT_GE(sock, 0);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/sys/socket/linux/socketpair_test.cpp
+++ b/libc/test/src/sys/socket/linux/socketpair_test.cpp
@@ -16,6 +16,7 @@
 #include <sys/socket.h> // For AF_UNIX and SOCK_DGRAM
 
 TEST(LlvmLibcSocketPairTest, LocalSocket) {
+  LIBC_NAMESPACE::libc_errno = 0;
   int sockpair[2] = {-1, -1};
   int result = LIBC_NAMESPACE::socketpair(AF_UNIX, SOCK_DGRAM, 0, sockpair);
   ASSERT_EQ(result, 0);
@@ -24,12 +25,14 @@ TEST(LlvmLibcSocketPairTest, LocalSocket) {
   ASSERT_GE(sockpair[0], 0);
   ASSERT_GE(sockpair[1], 0);
 
+  LIBC_NAMESPACE::libc_errno = 0;
   LIBC_NAMESPACE::close(sockpair[0]);
   LIBC_NAMESPACE::close(sockpair[1]);
   ASSERT_ERRNO_SUCCESS();
 }
 
 TEST(LlvmLibcSocketPairTest, SocketFails) {
+  LIBC_NAMESPACE::libc_errno = 0;
   int sockpair[2] = {-1, -1};
   int result = LIBC_NAMESPACE::socketpair(-1, -1, -1, sockpair);
   ASSERT_EQ(result, -1);

--- a/libc/test/src/unistd/pread_pwrite_test.cpp
+++ b/libc/test/src/unistd/pread_pwrite_test.cpp
@@ -34,6 +34,7 @@ TEST(LlvmLibcUniStd, PWriteAndPReadBackTest) {
 
   constexpr const char *FILENAME = "pread_pwrite.test";
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
+  LIBC_NAMESPACE::libc_errno = 0;
   int fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(fd, 0);
@@ -42,6 +43,7 @@ TEST(LlvmLibcUniStd, PWriteAndPReadBackTest) {
   ASSERT_THAT(LIBC_NAMESPACE::fsync(fd), Succeeds(0));
   ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
 
+  LIBC_NAMESPACE::libc_errno = 0;
   fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(fd, 0);
@@ -50,6 +52,7 @@ TEST(LlvmLibcUniStd, PWriteAndPReadBackTest) {
   ASSERT_THAT(LIBC_NAMESPACE::fsync(fd), Succeeds(0));
   ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
 
+  LIBC_NAMESPACE::libc_errno = 0;
   fd = LIBC_NAMESPACE::open(TEST_FILE, O_RDONLY);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(fd, 0);

--- a/libc/test/src/unistd/read_write_test.cpp
+++ b/libc/test/src/unistd/read_write_test.cpp
@@ -23,6 +23,7 @@ TEST(LlvmLibcUniStd, WriteAndReadBackTest) {
   constexpr const char *FILENAME = "__unistd_read_write.test";
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
 
+  LIBC_NAMESPACE::libc_errno = 0;
   int write_fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(write_fd, 0);
@@ -33,6 +34,7 @@ TEST(LlvmLibcUniStd, WriteAndReadBackTest) {
   ASSERT_THAT(LIBC_NAMESPACE::fsync(write_fd), Succeeds(0));
   ASSERT_THAT(LIBC_NAMESPACE::close(write_fd), Succeeds(0));
 
+  LIBC_NAMESPACE::libc_errno = 0;
   int read_fd = LIBC_NAMESPACE::open(TEST_FILE, O_RDONLY);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(read_fd, 0);

--- a/libc/test/src/unistd/unlink_test.cpp
+++ b/libc/test/src/unistd/unlink_test.cpp
@@ -19,6 +19,7 @@ TEST(LlvmLibcUnlinkTest, CreateAndUnlink) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
   constexpr const char *FILENAME = "unlink.test";
   auto TEST_FILE = libc_make_test_file_path(FILENAME);
+  LIBC_NAMESPACE::libc_errno = 0;
   int write_fd = LIBC_NAMESPACE::open(TEST_FILE, O_WRONLY | O_CREAT, S_IRWXU);
   ASSERT_ERRNO_SUCCESS();
   ASSERT_GT(write_fd, 0);


### PR DESCRIPTION
Make sure to set libc_errno to zero before calling the functions that may modify it, and subsequent errno verification. The tests modified below became more brittle after the change in
f9146ccbe940d8b8eb15e7686a511a28eb0abc6b which enabled system errno for unit tests (system errno is more likely to be set to a non-null value before the tests even begin to run).