### PR TITLE
Revert f9146ccbe940d8b8eb15e7686a511a28eb0abc6b

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/libc_configure_options.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_configure_options.bzl
@@ -44,11 +44,6 @@ LIBC_CONFIGURE_OPTIONS = [
     # "LIBC_COPT_STRTOFLOAT_DISABLE_EISEL_LEMIRE",
     # "LIBC_COPT_STRTOFLOAT_DISABLE_SIMPLE_DECIMAL_CONVERSION",
 
-    # Documentation in libc/src/errno/...
-    # Since we're only using Bazel for overlay build for now, explicitly
-    # enforce using the system-provided errno in both tests and release build.
-    "LIBC_ERRNO_MODE=LIBC_ERRNO_MODE_SYSTEM",
-
     # Documentation in libc/src/__support/libc_assert.h
     # "LIBC_COPT_USE_C_ASSERT",
 ]


### PR DESCRIPTION
This reverts commit f9146ccbe940d8b8eb15e7686a511a28eb0abc6b ([libc][bazel] explicitly use system-provided errno in Bazel builds. (#130663))

This change causes problems in Bazel builds where system errno is set to non-zero before the tests even begin to run - see PR #131650 for the disucssion on how to address this.