### PR TITLE
[lldb] Fix double free in CommandPluginInterfaceImplementation

### DIFF
--- a/lldb/source/API/SBCommandInterpreter.cpp
+++ b/lldb/source/API/SBCommandInterpreter.cpp
@@ -77,7 +77,7 @@ protected:
     SBDebugger debugger_sb(m_interpreter.GetDebugger().shared_from_this());
     m_backend->DoExecute(debugger_sb, command.GetArgumentVector(), sb_return);
   }
-  std::shared_ptr<lldb::SBCommandPluginInterface> m_backend;
+  lldb::SBCommandPluginInterface *m_backend;
   std::optional<std::string> m_auto_repeat_command;
 };
 } // namespace lldb_private


### PR DESCRIPTION
The class was taking ownership of the SBCommandPluginInterface pointer it was passed in, by wrapping it in a shared pointer. This causes a double free in the unit test when the object is destroyed and the same pointer gets freed once when the SBCommandPluginInterface goes away and then again when the shared pointer hits a zero refcount.