### PR TITLE
[TextAPI] Track RPaths in the order its provided via command line.

### DIFF
--- a/llvm/lib/TextAPI/InterfaceFile.cpp
+++ b/llvm/lib/TextAPI/InterfaceFile.cpp
@@ -59,14 +59,11 @@ void InterfaceFile::addRPath(StringRef RPath, const Target &InputTarget) {
     return;
   using RPathEntryT = const std::pair<Target, std::string>;
   RPathEntryT Entry(InputTarget, RPath);
-  auto Iter =
-      lower_bound(RPaths, Entry,
-                  [](RPathEntryT &LHS, RPathEntryT &RHS) { return LHS < RHS; });
 
-  if ((Iter != RPaths.end()) && (*Iter == Entry))
+  if (is_contained(RPaths, Entry))
     return;
 
-  RPaths.emplace(Iter, Entry);
+  RPaths.emplace_back(Entry);
 }
 
 void InterfaceFile::addTarget(const Target &Target) {

--- a/llvm/test/tools/llvm-readtapi/compare-rpath-order.test
+++ b/llvm/test/tools/llvm-readtapi/compare-rpath-order.test
@@ -1,0 +1,14 @@
+; RUN: rm -rf %t
+; RUN: split-file %s %t  
+; RUN: not llvm-readtapi --compare %t/rpaths_diff_order.tbd  %t/rpaths.tbd 2>&1 | FileCheck %s 
+
+; CHECK: < {{.*}}rpaths_diff_order.tbd
+; CHECK: > {{.*}}rpaths.tbd
+
+; CHECK: 'Run Path Search Paths' differ by order
+
+//--- rpaths_diff_order.tbd
+{"main_library":{"exported_symbols":[{"text":{"global":["_foo"]}}],"rpaths": [{"paths": ["/usr/lib/swift", "@loader_path/../../../"]}], "flags":[{"attributes":["not_app_extension_safe"]}],"install_names":[{"name":"@rpath/libFake.dylib"}],"target_info":[{"min_deployment":"13","target":"x86_64-macos"},{"min_deployment":"13","target":"arm64-macos"}]},"tapi_tbd_version":5}
+
+//--- rpaths.tbd
+{"main_library":{"exported_symbols":[{"text":{"global":["_foo"]}}],"rpaths": [{"paths": [ "@loader_path/../../../", "/usr/lib/swift"]}], "flags":[{"attributes":["not_app_extension_safe"]}],"install_names":[{"name":"@rpath/libFake.dylib"}],"target_info":[{"min_deployment":"13","target":"x86_64-macos"},{"min_deployment":"13","target":"arm64-macos"}]},"tapi_tbd_version":5}

--- a/llvm/tools/llvm-readtapi/DiffEngine.cpp
+++ b/llvm/tools/llvm-readtapi/DiffEngine.cpp
@@ -449,8 +449,10 @@ template <typename T> void sortTargetValues(std::vector<T> &TargValues) {
 
 template <typename T>
 void printVecVal(std::string Indent, const DiffOutput &Attr, raw_ostream &OS) {
-  if (Attr.Values.empty())
+  if (Attr.Values.empty()) {
+    OS << Indent << "'" << Attr.Name << "' differ by order\n";
     return;
+  }
 
   OS << Indent << Attr.Name << "\n";
 


### PR DESCRIPTION
RPaths are basically search paths for how to load dependent libraries. The order they appear is the order the linker will search, we should preserve that order in tbd files.

* Additionally add this level of detection to llvm-readtapi.

resolves: rdar://145603347