### PR TITLE
Headers: prefer `corecrt_malloc.h` to `malloc.h`

### DIFF
--- a/clang/lib/Headers/mm_malloc.h
+++ b/clang/lib/Headers/mm_malloc.h
@@ -13,7 +13,11 @@
 #include <stdlib.h>
 
 #ifdef _WIN32
-#include <malloc.h>
+# if defined(__MINGW32__)
+#   include <malloc.h>
+# else
+#   include <corecrt_malloc.h>
+# endif
 #else
 #ifndef __cplusplus
 extern int posix_memalign(void **__memptr, size_t __alignment, size_t __size);


### PR DESCRIPTION
This allows us to target a lower level library (corecrt) rather than the higher level library (ucrt) which can be helpful in mordularising the SDK.