### PR TITLE
[clang-tidy] Improve `readability-function-size`: count class member initializers as statements

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/FunctionSizeCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/FunctionSizeCheck.h
@@ -47,6 +47,7 @@ private:
   const std::optional<unsigned> ParameterThreshold;
   const std::optional<unsigned> NestingThreshold;
   const std::optional<unsigned> VariableThreshold;
+  const bool CountMemberInitAsStmt;
 
   static constexpr std::optional<unsigned> DefaultLineThreshold = std::nullopt;
   static constexpr std::optional<unsigned> DefaultStatementThreshold = 800U;
@@ -58,6 +59,7 @@ private:
       std::nullopt;
   static constexpr std::optional<unsigned> DefaultVariableThreshold =
       std::nullopt;
+  static constexpr bool DefaultCountMemberInitAsStmt = true;
 };
 
 } // namespace clang::tidy::readability

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -245,6 +245,11 @@ Changes in existing checks
   tolerating fix-it breaking compilation when functions is used as pointers
   to avoid matching usage of functions within the current compilation unit.
 
+- Improved :doc:`readability-function-size
+  <clang-tidy/checks/readability/function-size>` check by adding new option
+  `CountMemberInitAsStmt` that allows counting class member initializers in
+  constructors as statements.
+
 - Improved :doc:`readability-math-missing-parentheses
   <clang-tidy/checks/readability/math-missing-parentheses>` check by fixing
   false negatives where math expressions are the operand of assignment operators

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/function-size.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/function-size.rst
@@ -43,3 +43,8 @@ Options
    The default is `none` (ignore the number of variables).
    Please note that function parameters and variables declared in lambdas,
    GNU Statement Expressions, and nested class inline functions are not counted.
+
+.. option:: CountMemberInitAsStmt
+
+   When `true`, count class member initializers in constructors as statements.
+   Default is `true`.

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/function-size-no-member-init-as-stmts.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/function-size-no-member-init-as-stmts.cpp
@@ -1,0 +1,64 @@
+// RUN: %check_clang_tidy %s readability-function-size %t -- \
+// RUN:     -config='{CheckOptions: { \
+// RUN:         readability-function-size.LineThreshold: 0, \
+// RUN:         readability-function-size.StatementThreshold: 0, \
+// RUN:         readability-function-size.BranchThreshold: 0, \
+// RUN:         readability-function-size.ParameterThreshold: 5, \
+// RUN:         readability-function-size.NestingThreshold: 2, \
+// RUN:         readability-function-size.VariableThreshold: 1, \
+// RUN:         readability-function-size.CountMemberInitAsStmt: false \
+// RUN:     }}'
+
+// Bad formatting is intentional, don't run clang-format over the whole file!
+
+void foo1() {
+}
+
+void foo2() {;}
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: function 'foo2' exceeds recommended size/complexity thresholds [readability-function-size]
+// CHECK-MESSAGES: :[[@LINE-2]]:6: note: 1 statements (threshold 0)
+
+struct A {
+  A(int c, int d) : a(0), b(c) { ; }
+  int a;
+  int b;
+};
+// CHECK-MESSAGES: :[[@LINE-4]]:3: warning: function 'A' exceeds recommended size/complexity thresholds [readability-function-size]
+// CHECK-MESSAGES: :[[@LINE-5]]:3: note: 1 statements (threshold 0)
+
+struct B {
+  B(int x, int y, int z) : a(x + y * z), b(), c_a(y, z) {
+    ;
+  }
+  int a;
+  int b;
+  A c_a;
+};
+// CHECK-MESSAGES: :[[@LINE-7]]:3: warning: function 'B' exceeds recommended size/complexity thresholds [readability-function-size]
+// CHECK-MESSAGES: :[[@LINE-8]]:3: note: 2 lines including whitespace and comments (threshold 0)
+// CHECK-MESSAGES: :[[@LINE-9]]:3: note: 1 statements (threshold 0)
+
+struct C : A, B {
+  // 0 statements
+  C() : A(0, 4), B(1, 2, 3) {}
+};
+
+template<typename T>
+struct TemplateC {
+  // 0 statements
+  TemplateC() : a(3) {}
+  T a;
+};
+
+template<typename T>
+struct TemplateD {
+  template<typename U>
+  TemplateD(U&& val) : member(val) { 
+    ;
+  }
+  
+  T member;
+};
+// CHECK-MESSAGES: :[[@LINE-6]]:3: warning: function 'TemplateD<T>' exceeds recommended size/complexity thresholds [readability-function-size]
+// CHECK-MESSAGES: :[[@LINE-7]]:3: note: 2 lines including whitespace and comments (threshold 0)
+// CHECK-MESSAGES: :[[@LINE-8]]:3: note: 1 statements (threshold 0)

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/function-size-no-member-init-as-stmts.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/function-size-no-member-init-as-stmts.cpp
@@ -62,3 +62,12 @@ struct TemplateD {
 // CHECK-MESSAGES: :[[@LINE-6]]:3: warning: function 'TemplateD<T>' exceeds recommended size/complexity thresholds [readability-function-size]
 // CHECK-MESSAGES: :[[@LINE-7]]:3: note: 2 lines including whitespace and comments (threshold 0)
 // CHECK-MESSAGES: :[[@LINE-8]]:3: note: 1 statements (threshold 0)
+
+void instantiate() {
+  TemplateC<int> c;
+  TemplateD<int> d(5);
+}
+// CHECK-MESSAGES: :[[@LINE-4]]:6: warning: function 'instantiate' exceeds recommended size/complexity thresholds [readability-function-size]
+// CHECK-MESSAGES: :[[@LINE-5]]:6: note: 3 lines including whitespace and comments (threshold 0)
+// CHECK-MESSAGES: :[[@LINE-6]]:6: note: 2 statements (threshold 0)
+// CHECK-MESSAGES: :[[@LINE-7]]:6: note: 2 variables (threshold 1)

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/function-size.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/function-size.cpp
@@ -319,3 +319,53 @@ void variables_16() {
 // CHECK-MESSAGES: :[[@LINE-5]]:6: note: 3 lines including whitespace and comments (threshold 0)
 // CHECK-MESSAGES: :[[@LINE-6]]:6: note: 4 statements (threshold 0)
 // CHECK-MESSAGES: :[[@LINE-7]]:6: note: 2 variables (threshold 1)
+
+struct A {
+  A(int c, int d) : a(0), b(c) { ; }
+  int a;
+  int b;
+};
+// CHECK-MESSAGES: :[[@LINE-4]]:3: warning: function 'A' exceeds recommended size/complexity thresholds [readability-function-size]
+// CHECK-MESSAGES: :[[@LINE-5]]:3: note: 3 statements (threshold 0)
+
+struct B {
+  B(int x, int y, int z) : a(x + y * z), b(), c_a(y, z) {
+    ;
+  }
+  int a;
+  int b;
+  A c_a;
+};
+// CHECK-MESSAGES: :[[@LINE-7]]:3: warning: function 'B' exceeds recommended size/complexity thresholds [readability-function-size]
+// CHECK-MESSAGES: :[[@LINE-8]]:3: note: 2 lines including whitespace and comments (threshold 0)
+// CHECK-MESSAGES: :[[@LINE-9]]:3: note: 4 statements (threshold 0)
+
+struct C : A, B {
+  C() : A(0, 4), B(1, 2, 3) {}
+};
+// CHECK-MESSAGES: :[[@LINE-2]]:3: warning: function 'C' exceeds recommended size/complexity thresholds [readability-function-size]
+// CHECK-MESSAGES: :[[@LINE-3]]:3: note: 2 statements (threshold 0)
+
+template<typename T>
+struct TemplateC {
+  // 0 statements
+  TemplateC() : a(3) {}
+  T a;
+};
+// CHECK-MESSAGES: :[[@LINE-3]]:3: warning: function 'TemplateC<T>' exceeds recommended size/complexity thresholds [readability-function-size]
+// CHECK-MESSAGES: :[[@LINE-4]]:3: note: 1 statements (threshold 0)
+
+template<typename T>
+struct TemplateD {
+  template<typename U>
+  TemplateD(U&& val) : member(val) { 
+    ;
+  }
+  
+  T member;
+};
+// CHECK-MESSAGES: :[[@LINE-6]]:3: warning: function 'TemplateD<T>' exceeds recommended size/complexity thresholds [readability-function-size]
+// CHECK-MESSAGES: :[[@LINE-7]]:3: note: 2 lines including whitespace and comments (threshold 0)
+// CHECK-MESSAGES: :[[@LINE-8]]:3: note: 2 statements (threshold 0)
+
+

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/function-size.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/function-size.cpp
@@ -368,4 +368,11 @@ struct TemplateD {
 // CHECK-MESSAGES: :[[@LINE-7]]:3: note: 2 lines including whitespace and comments (threshold 0)
 // CHECK-MESSAGES: :[[@LINE-8]]:3: note: 2 statements (threshold 0)
 
-
+void instantiate() {
+  TemplateC<int> c;
+  TemplateD<int> d(5);
+}
+// CHECK-MESSAGES: :[[@LINE-4]]:6: warning: function 'instantiate' exceeds recommended size/complexity thresholds [readability-function-size]
+// CHECK-MESSAGES: :[[@LINE-5]]:6: note: 3 lines including whitespace and comments (threshold 0)
+// CHECK-MESSAGES: :[[@LINE-6]]:6: note: 2 statements (threshold 0)
+// CHECK-MESSAGES: :[[@LINE-7]]:6: note: 2 variables (threshold 1)


### PR DESCRIPTION
Improve `readability-function-size` by counting class member initializers as statements.
Relates to https://github.com/llvm/llvm-project/issues/131126#issuecomment-2725906714.
