### PR TITLE
[Darwin][Test][leaks] Disable leak detection for asan tests on non-Intel Darwin devices

### DIFF
--- a/compiler-rt/test/asan/lit.cfg.py
+++ b/compiler-rt/test/asan/lit.cfg.py
@@ -25,8 +25,13 @@ config.name = "AddressSanitizer" + config.name_suffix
 default_asan_opts = list(config.default_sanitizer_opts)
 
 # On Darwin, leak checking is not enabled by default. Enable on macOS
-# tests to prevent regressions
-if config.host_os == "Darwin" and config.apple_platform == "osx":
+# tests to prevent regressions.
+# Currently, detect_leaks for asan tests only work on Intel MacOS.
+if (
+    config.host_os == "Darwin"
+    and config.apple_platform == "osx"
+    and config.target_arch == "x86_64"
+):
     default_asan_opts += ["detect_leaks=1"]
 
 default_asan_opts_str = ":".join(default_asan_opts)
@@ -273,7 +278,11 @@ leak_detection_linux = (
     and (not config.android)
     and (config.target_arch in ["x86_64", "i386", "riscv64", "loongarch64"])
 )
-leak_detection_mac = (config.host_os == "Darwin") and (config.apple_platform == "osx")
+leak_detection_mac = (
+    (config.host_os == "Darwin")
+    and (config.apple_platform == "osx")
+    and (config.target_arch == "x86_64")
+)
 leak_detection_netbsd = (config.host_os == "NetBSD") and (
     config.target_arch in ["x86_64", "i386"]
 )


### PR DESCRIPTION
`detect_leaks` option for asan does not work well on Apple Silicon (arm64) MacOS devices and results in hundreds of ASan test failures when run with this option set for all tests.

We should not add this option for tests unless we are targeting an x86_64 device for Darwin, where this seems to be tested and working well.

rdar://147069153