### PR TITLE
[Lex][Clang] Add checking to HeaderMapImpl::getString to make it more robust

### DIFF
--- a/clang/lib/Lex/HeaderMap.cpp
+++ b/clang/lib/Lex/HeaderMap.cpp
@@ -155,10 +155,11 @@ std::optional<StringRef> HeaderMapImpl::getString(unsigned StrTabIdx) const {
 
   const char *Data = FileBuffer->getBufferStart() + StrTabIdx;
   unsigned MaxLen = FileBuffer->getBufferSize() - StrTabIdx;
-  unsigned Len = strnlen(Data, MaxLen);
 
   if (MaxLen == 0)
     return std::nullopt;
+
+  unsigned Len = strnlen(Data, MaxLen);
 
   // Check whether the buffer is null-terminated.
   if (Len == MaxLen && Data[Len - 1])

--- a/clang/lib/Lex/HeaderMap.cpp
+++ b/clang/lib/Lex/HeaderMap.cpp
@@ -157,6 +157,9 @@ std::optional<StringRef> HeaderMapImpl::getString(unsigned StrTabIdx) const {
   unsigned MaxLen = FileBuffer->getBufferSize() - StrTabIdx;
   unsigned Len = strnlen(Data, MaxLen);
 
+  if (MaxLen == 0)
+    return std::nullopt;
+
   // Check whether the buffer is null-terminated.
   if (Len == MaxLen && Data[Len - 1])
     return std::nullopt;


### PR DESCRIPTION
Static analysis identified the Len - 1 expression in HeaderMapImpl::getString as problematic if Len is zero. After filing this issue:

https://github.com/llvm/llvm-project/issues/130185

Indeed we should be checking MaxLen and verify it is not zero as well.

Fixes: https://github.com/llvm/llvm-project/issues/130185