### PR TITLE
[debuginfo-tests] Use built lldb for testing if available

### DIFF
--- a/cross-project-tests/debuginfo-tests/llgdb-tests/llgdb.py
+++ b/cross-project-tests/debuginfo-tests/llgdb-tests/llgdb.py
@@ -8,6 +8,14 @@ commands to run the tests in the debuginfo-tests repository with lldb.
 # Auto-detect lldb python module.
 import subprocess, platform, os, sys
 
+# Set the path to look first for the built lldb (in case it exists).
+llvm_libs_dir = os.environ["LLVM_LIBS_DIR"]
+built_lldb_path = os.path.join(
+    llvm_libs_dir,
+    f"python{sys.version_info.major}.{sys.version_info.minor}",
+    "site-packages",
+)
+sys.path.insert(0, built_lldb_path)
 try:
     # Just try for LLDB in case PYTHONPATH is already correctly setup.
     import lldb

--- a/cross-project-tests/debuginfo-tests/llgdb-tests/llgdb.py
+++ b/cross-project-tests/debuginfo-tests/llgdb-tests/llgdb.py
@@ -9,13 +9,10 @@ commands to run the tests in the debuginfo-tests repository with lldb.
 import subprocess, platform, os, sys
 
 # Set the path to look first for the built lldb (in case it exists).
-llvm_libs_dir = os.environ["LLVM_LIBS_DIR"]
-built_lldb_path = os.path.join(
-    llvm_libs_dir,
-    f"python{sys.version_info.major}.{sys.version_info.minor}",
-    "site-packages",
-)
-sys.path.insert(0, built_lldb_path)
+lldb_python_path = os.environ["LLDB_PYTHON_PATH"]
+if len(lldb_python_path) > 0:
+    sys.path.insert(0, lldb_python_path)
+
 try:
     # Just try for LLDB in case PYTHONPATH is already correctly setup.
     import lldb

--- a/cross-project-tests/debuginfo-tests/llgdb-tests/test_debuginfo.pl
+++ b/cross-project-tests/debuginfo-tests/llgdb-tests/test_debuginfo.pl
@@ -56,7 +56,7 @@ my $my_debugger = $ENV{'DEBUGGER'};
 if (!$my_debugger) {
     if ($use_lldb) {
         my $path = dirname(Cwd::abs_path($0));
-        $my_debugger = "/usr/bin/xcrun python3 $path/llgdb.py";
+        $my_debugger = "LLVM_LIBS_DIR=$ENV{'LLVM_LIBS_DIR'} /usr/bin/xcrun python3 $path/llgdb.py";
     } else {
         $my_debugger = "gdb";
     }

--- a/cross-project-tests/debuginfo-tests/llgdb-tests/test_debuginfo.pl
+++ b/cross-project-tests/debuginfo-tests/llgdb-tests/test_debuginfo.pl
@@ -56,7 +56,11 @@ my $my_debugger = $ENV{'DEBUGGER'};
 if (!$my_debugger) {
     if ($use_lldb) {
         my $path = dirname(Cwd::abs_path($0));
-        $my_debugger = "LLVM_LIBS_DIR=$ENV{'LLVM_LIBS_DIR'} /usr/bin/xcrun python3 $path/llgdb.py";
+        my $python_exec_path = $ENV{'PYTHON_EXEC_PATH'};
+        if (!$python_exec_path) {
+          $python_exec_path = 'python3';
+        }
+        $my_debugger = "LLDB_PYTHON_PATH=$ENV{'LLDB_PYTHON_PATH'} /usr/bin/xcrun $python_exec_path $path/llgdb.py";
     } else {
         $my_debugger = "gdb";
     }

--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -37,7 +37,10 @@ llvm_config.use_default_substitutions()
 tools = [
     ToolSubst(
         "%test_debuginfo",
-        command=os.path.join(
+        command="LLVM_LIBS_DIR="
+        + config.llvm_libs_dir
+        + " "
+        + os.path.join(
             config.cross_project_tests_src_root,
             "debuginfo-tests",
             "llgdb-tests",

--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -34,11 +34,19 @@ config.test_exec_root = config.cross_project_tests_obj_root
 
 llvm_config.use_default_substitutions()
 
+lldb_python_path = os.path.join(
+    config.llvm_libs_dir,
+    f"python{sys.version_info.major}.{sys.version_info.minor}",
+    "site-packages",
+)
+python_exec_path = sys.executable
 tools = [
     ToolSubst(
         "%test_debuginfo",
-        command="LLVM_LIBS_DIR="
-        + config.llvm_libs_dir
+        command="PYTHON_EXEC_PATH="
+        + python_exec_path
+        + " LLDB_PYTHON_PATH="
+        + lldb_python_path
         + " "
         + os.path.join(
             config.cross_project_tests_src_root,


### PR DESCRIPTION
The cross-project-tests's debuginfo-tests don't rely on lldb being built to run. While this is a good, a bug in the system lldb can cause a test to fail with no way of fixing it. This patch makes it so the tests use the built lldb instead if it's available.