### PR TITLE
[lldb] Show target.debug-file-search-paths setting from  python SBDebugger

### DIFF
--- a/lldb/include/lldb/Interpreter/OptionValueFileSpecList.h
+++ b/lldb/include/lldb/Interpreter/OptionValueFileSpecList.h
@@ -33,6 +33,8 @@ public:
   void DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
                  uint32_t dump_mask) override;
 
+  llvm::json::Value ToJSON(const ExecutionContext *exe_ctx) override;
+
   Status
   SetValueFromString(llvm::StringRef value,
                      VarSetOperationType op = eVarSetOperationAssign) override;

--- a/lldb/include/lldb/Utility/FileSpec.h
+++ b/lldb/include/lldb/Utility/FileSpec.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/JSON.h"
 #include "llvm/Support/Path.h"
 
 #include <cstddef>
@@ -213,6 +214,17 @@ public:
   /// \param[in] s
   ///     The stream to which to dump the object description.
   void Dump(llvm::raw_ostream &s) const;
+
+  ///
+  /// Convert the filespec object to a json value.
+  ///
+  /// Convert the filespec object to a json value. If the object contains a
+  /// valid directory name, it will be displayed followed by a directory
+  /// delimiter, and the filename.
+  ///
+  /// \return
+  ///     A json value representation of a filespec.
+  llvm::json::Value ToJSON() const;
 
   Style GetPathStyle() const;
 

--- a/lldb/include/lldb/Utility/FileSpec.h
+++ b/lldb/include/lldb/Utility/FileSpec.h
@@ -215,7 +215,6 @@ public:
   ///     The stream to which to dump the object description.
   void Dump(llvm::raw_ostream &s) const;
 
-  ///
   /// Convert the filespec object to a json value.
   ///
   /// Convert the filespec object to a json value. If the object contains a

--- a/lldb/source/Interpreter/OptionValueFileSpecList.cpp
+++ b/lldb/source/Interpreter/OptionValueFileSpecList.cpp
@@ -44,10 +44,10 @@ void OptionValueFileSpecList::DumpValue(const ExecutionContext *exe_ctx,
 llvm::json::Value
 OptionValueFileSpecList::ToJSON(const ExecutionContext *exe_ctx) {
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
-  llvm::json::Array spec_list;
-  for (const auto &file_spec : m_current_value) 
-    spec_list.emplace_back(file_spec.ToJSON());
-  return spec_list;
+  llvm::json::Array array;
+  for (const auto &file_spec : m_current_value)
+    array.emplace_back(file_spec.ToJSON());
+  return array;
 }
 
 Status OptionValueFileSpecList::SetValueFromString(llvm::StringRef value,

--- a/lldb/source/Interpreter/OptionValueFileSpecList.cpp
+++ b/lldb/source/Interpreter/OptionValueFileSpecList.cpp
@@ -41,6 +41,16 @@ void OptionValueFileSpecList::DumpValue(const ExecutionContext *exe_ctx,
   }
 }
 
+llvm::json::Value
+OptionValueFileSpecList::ToJSON(const ExecutionContext *exe_ctx) {
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
+  llvm::json::Array spec_list;
+  for (const auto &file_spec : m_current_value) {
+    spec_list.emplace_back(file_spec.ToJSON());
+  }
+  return spec_list;
+}
+
 Status OptionValueFileSpecList::SetValueFromString(llvm::StringRef value,
                                                    VarSetOperationType op) {
   std::lock_guard<std::recursive_mutex> lock(m_mutex);

--- a/lldb/source/Interpreter/OptionValueFileSpecList.cpp
+++ b/lldb/source/Interpreter/OptionValueFileSpecList.cpp
@@ -45,9 +45,8 @@ llvm::json::Value
 OptionValueFileSpecList::ToJSON(const ExecutionContext *exe_ctx) {
   std::lock_guard<std::recursive_mutex> lock(m_mutex);
   llvm::json::Array spec_list;
-  for (const auto &file_spec : m_current_value) {
+  for (const auto &file_spec : m_current_value) 
     spec_list.emplace_back(file_spec.ToJSON());
-  }
   return spec_list;
 }
 

--- a/lldb/source/Utility/FileSpec.cpp
+++ b/lldb/source/Utility/FileSpec.cpp
@@ -331,10 +331,10 @@ void FileSpec::Dump(llvm::raw_ostream &s) const {
 }
 
 llvm::json::Value FileSpec::ToJSON() const {
-  std::string file_spec{};
-  llvm::raw_string_ostream stream(file_spec);
+  std::string str{};
+  llvm::raw_string_ostream stream(str);
   this->Dump(stream);
-  return llvm::json::Value(std::move(file_spec));
+  return llvm::json::Value(std::move(str));
 }
 
 FileSpec::Style FileSpec::GetPathStyle() const { return m_style; }

--- a/lldb/source/Utility/FileSpec.cpp
+++ b/lldb/source/Utility/FileSpec.cpp
@@ -331,7 +331,7 @@ void FileSpec::Dump(llvm::raw_ostream &s) const {
 }
 
 llvm::json::Value FileSpec::ToJSON() const {
-  std::string str{};
+  std::string str;
   llvm::raw_string_ostream stream(str);
   this->Dump(stream);
   return llvm::json::Value(std::move(str));

--- a/lldb/source/Utility/FileSpec.cpp
+++ b/lldb/source/Utility/FileSpec.cpp
@@ -330,6 +330,13 @@ void FileSpec::Dump(llvm::raw_ostream &s) const {
     s << path_separator;
 }
 
+llvm::json::Value FileSpec::ToJSON() const {
+  std::string file_spec{};
+  llvm::raw_string_ostream stream(file_spec);
+  this->Dump(stream);
+  return llvm::json::Value(std::move(file_spec));
+}
+
 FileSpec::Style FileSpec::GetPathStyle() const { return m_style; }
 
 void FileSpec::SetDirectory(ConstString directory) {

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -1016,6 +1016,13 @@ class SettingsCommandTestCase(TestBase):
         settings_json = self.get_setting_json(setting_path)
         self.assertEqual(settings_json, setting_value)
 
+        # Test OptionValueFileSpec and OptionValueFileSpecList
+        setting_path = "target.debug-file-search-paths"
+        setting_value = ["/tmp" "/tmp2"]
+        self.runCmd("settings set %s %s" % (setting_path, " ".join(setting_value)))
+        settings_json = self.get_setting_json(setting_path)
+        self.assertEqual(settings_json, setting_value)
+
         # Test OptionValueFormatEntity
         setting_value = """thread #${thread.index}{, name = \\'${thread.name}\\
         '}{, queue = ${ansi.fg.green}\\'${thread.queue}\\'${ansi.normal}}{,


### PR DESCRIPTION
Fixes #110756 