### PR TITLE
[NFC][flang] Added deduction guide for StaticDescriptor class.

### DIFF
--- a/flang-rt/include/flang-rt/runtime/descriptor.h
+++ b/flang-rt/include/flang-rt/runtime/descriptor.h
@@ -481,5 +481,8 @@ private:
   char storage_[byteSize]{};
 };
 
+// Deduction guide to avoid warnings from older versions of clang.
+StaticDescriptor() -> StaticDescriptor<maxRank, false, 0>;
+
 } // namespace Fortran::runtime
 #endif // FLANG_RT_RUNTIME_DESCRIPTOR_H_


### PR DESCRIPTION
I keep getting these warnings when building with clang-17:
`warning: 'StaticDescriptor' may not intend to support class template argument deduction [-Wctad-maybe-unsupported]`

This change should help avoiding them.
