### PR TITLE
[BPF] Add default cpu change in ReleaseNotes

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -1299,6 +1299,11 @@ AVR Support
 
 - Reject C/C++ compilation for avr1 devices which have no SRAM.
 
+BPF Support
+^^^^^^^^^^^
+
+- Make ``-mcpu=v3`` as the default.
+
 DWARF Support in Clang
 ----------------------
 


### PR DESCRIPTION
The pull request [1] changed bpf default cpu from -mcpu=v1 to
-mcpu=v3 in clang20. Recently in [1], Yuval Deutscher suggested
to add an entry to clang20 ReleaseNotes so users can easily find
the change from documentation.

  [1] https://github.com/llvm/llvm-project/pull/107008