### PR TITLE
[YAML] fix output incorrect format for block scalar string

### DIFF
--- a/llvm/lib/Support/YAMLTraits.cpp
+++ b/llvm/lib/Support/YAMLTraits.cpp
@@ -725,18 +725,18 @@ void Output::blockScalarString(StringRef &S) {
   if (!StateStack.empty())
     newLineCheck();
   output(" |");
-  outputNewLine();
 
   unsigned Indent = StateStack.empty() ? 1 : StateStack.size();
 
   auto Buffer = MemoryBuffer::getMemBuffer(S, "", false);
   for (line_iterator Lines(*Buffer, false); !Lines.is_at_end(); ++Lines) {
+    outputNewLine();
     for (unsigned I = 0; I < Indent; ++I) {
       output("  ");
     }
     output(*Lines);
-    outputNewLine();
   }
+  outputUpToEndOfLine("");
 }
 
 void Output::scalarTag(std::string &Tag) {

--- a/llvm/unittests/Support/YAMLIOTest.cpp
+++ b/llvm/unittests/Support/YAMLIOTest.cpp
@@ -1298,7 +1298,7 @@ TEST(YAMLIO, TestScalarAfterBlockScalar) {
 - block_scalac:     |
     AA
     BB
-scalar:          a
+  scalar:          a
 ...
 )");
 }


### PR DESCRIPTION
After outputting block scalar string, the indent will be wrong.
This patch fixes Padding after block scalar string to ensure the correct format of yaml.

The new added ut will fail in main.
```diff
@@ -3,4 +3,4 @@
     Just a block
     scalar doc
-scalar:          a
+  scalar:          a
 ...\n
```