### PR TITLE
[llvm-objdump] Fix Wunused-but-set-variable warning in ELFDump.cpp (NFC)

### DIFF
--- a/llvm/tools/llvm-objdump/ELFDump.cpp
+++ b/llvm/tools/llvm-objdump/ELFDump.cpp
@@ -405,11 +405,12 @@ template <class ELFT> void ELFDumper<ELFT>::printSymbolVersion() {
         Shdr.sh_type != ELF::SHT_GNU_verdef)
       continue;
 
-    ArrayRef<uint8_t> Contents =
+    [[maybe_unused]] ArrayRef<uint8_t> Contents =
         unwrapOrError(Elf.getSectionContents(Shdr), FileName);
     const typename ELFT::Shdr *StrTabSec =
         unwrapOrError(Elf.getSection(Shdr.sh_link), FileName);
-    StringRef StrTab = unwrapOrError(Elf.getStringTable(*StrTabSec), FileName);
+    [[maybe_unused]] StringRef StrTab =
+        unwrapOrError(Elf.getStringTable(*StrTabSec), FileName);
 
     if (Shdr.sh_type == ELF::SHT_GNU_verneed) {
       printSymbolVersionDependency(Shdr);


### PR DESCRIPTION
llvm-project/llvm/tools/llvm-objdump/ELFDump.cpp:408:23: warning: variable ‘Contents’ set but not used [-Wunused-but-set-variable]
  408 |     ArrayRef<uint8_t> Contents =
      |                       ^~~~~~~~
llvm-project/llvm/tools/llvm-objdump/ELFDump.cpp:412:15: warning: variable ‘StrTab’ set but not used [-Wunused-but-set-variable]
  412 |     StringRef StrTab = unwrapOrError(Elf.getStringTable(*StrTabSec), FileName);
      |               ^~~~~~