### PR TITLE
[ADT] Add SetVector::insert_range

### DIFF
--- a/llvm/include/llvm/ADT/SetVector.h
+++ b/llvm/include/llvm/ADT/SetVector.h
@@ -20,6 +20,7 @@
 #ifndef LLVM_ADT_SETVECTOR_H
 #define LLVM_ADT_SETVECTOR_H
 
+#include "llvm/ADT/ADL.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
@@ -182,6 +183,10 @@ public:
   void insert(It Start, It End) {
     for (; Start != End; ++Start)
       insert(*Start);
+  }
+
+  template <typename Range> void insert_range(Range &&R) {
+    insert(adl_begin(R), adl_end(R));
   }
 
   /// Remove an item from the set vector.

--- a/llvm/unittests/ADT/SetVectorTest.cpp
+++ b/llvm/unittests/ADT/SetVectorTest.cpp
@@ -12,6 +12,7 @@
 
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 using namespace llvm;
@@ -85,4 +86,11 @@ TEST(SetVector, ConstPtrKeyTest) {
   S.set_subtract(T);
   EXPECT_FALSE(S.contains(&j));
   EXPECT_FALSE(S.contains((const int *)&j));
+}
+
+TEST(SetVector, InsertRange) {
+  SetVector<unsigned> Set;
+  constexpr unsigned Args[] = {3, 1, 2};
+  Set.insert_range(Args);
+  EXPECT_THAT(Set, ::testing::ElementsAre(3, 1, 2));
 }


### PR DESCRIPTION
This patch adds SetVector::insert_range for consistency with
DenseSet::insert_range and std::set::insert_range from C++23.
