### PR TITLE
[ADT] Add SmallPtrSet::insert_range

### DIFF
--- a/llvm/include/llvm/ADT/SmallPtrSet.h
+++ b/llvm/include/llvm/ADT/SmallPtrSet.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_ADT_SMALLPTRSET_H
 #define LLVM_ADT_SMALLPTRSET_H
 
+#include "llvm/ADT/ADL.h"
 #include "llvm/ADT/EpochTracker.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/ReverseIteration.h"
@@ -467,6 +468,10 @@ public:
 
   void insert(std::initializer_list<PtrType> IL) {
     insert(IL.begin(), IL.end());
+  }
+
+  template <typename Range> void insert_range(Range &&R) {
+    insert(adl_begin(R), adl_end(R));
   }
 
   iterator begin() const {

--- a/llvm/unittests/ADT/SmallPtrSetTest.cpp
+++ b/llvm/unittests/ADT/SmallPtrSetTest.cpp
@@ -411,6 +411,14 @@ TEST(SmallPtrSetTest, RemoveIf) {
   EXPECT_FALSE(Removed);
 }
 
+TEST(SmallPtrSetTest, InsertRange) {
+  int Vals[3] = {0, 1, 2};
+  SmallPtrSet<int *, 4> Set;
+  int *Args[] = {&Vals[2], &Vals[0], &Vals[1]};
+  Set.insert_range(Args);
+  EXPECT_THAT(Set, UnorderedElementsAre(&Vals[0], &Vals[1], &Vals[2]));
+}
+
 TEST(SmallPtrSetTest, Reserve) {
   // Check that we don't do anything silly when using reserve().
   SmallPtrSet<int *, 4> Set;


### PR DESCRIPTION
This pach adds SmallPtrSet::insert_range for consistency with
DenseSet::insert_range and std::set::insert_range from C++23.
