### PR TITLE
[ADT] Add SmallSet::insert_range

### DIFF
--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_ADT_SMALLSET_H
 #define LLVM_ADT_SMALLSET_H
 
+#include "llvm/ADT/ADL.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator.h"
@@ -188,6 +189,10 @@ public:
   void insert(IterT I, IterT E) {
     for (; I != E; ++I)
       insert(*I);
+  }
+
+  template <typename Range> void insert_range(Range &&R) {
+    insert(adl_begin(R), adl_end(R));
   }
 
   bool erase(const T &V) {

--- a/llvm/unittests/ADT/SmallSetTest.cpp
+++ b/llvm/unittests/ADT/SmallSetTest.cpp
@@ -127,6 +127,13 @@ TEST(SmallSetTest, InsertPerfectFwd) {
   }
 }
 
+TEST(SmallSetTest, InsertRange) {
+  SmallSet<int, 4> s1;
+  constexpr unsigned Args[] = {3, 1, 2};
+  s1.insert_range(Args);
+  EXPECT_THAT(s1, ::testing::UnorderedElementsAre(1, 2, 3));
+}
+
 TEST(SmallSetTest, Grow) {
   SmallSet<int, 4> s1;
 


### PR DESCRIPTION
This patch adds SmallSet::insert_range for consistency with
DenseSet::insert_range and std::set::insert_range from C++23.
