### PR TITLE
[NVPTX] Auto-Upgrade !"align" metadata on return values to stackalign

### DIFF
--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -5077,9 +5077,6 @@ bool static upgradeSingleNVVMAnnotation(GlobalValue *GV, StringRef K,
         mdconst::extract<ConstantInt>(V)->getZExtValue();
     const unsigned Idx = (AlignIdxValuePair >> 16);
     const Align StackAlign = Align(AlignIdxValuePair & 0xFFFF);
-    // TODO: Skip adding the stackalign attribute for returns, for now.
-    if (!Idx)
-      return false;
     cast<Function>(GV)->addAttributeAtIndex(
         Idx, Attribute::getWithStackAlignment(GV->getContext(), StackAlign));
     return true;

--- a/llvm/lib/Target/NVPTX/NVPTXUtilities.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXUtilities.cpp
@@ -327,25 +327,6 @@ std::optional<unsigned> getMaxNReg(const Function &F) {
   return getFnAttrParsedInt(F, "nvvm.maxnreg");
 }
 
-MaybeAlign getAlign(const Function &F, unsigned Index) {
-  // First check the alignstack metadata
-  if (MaybeAlign StackAlign =
-          F.getAttributes().getAttributes(Index).getStackAlignment())
-    return StackAlign;
-
-  // check the legacy nvvm metadata only for the return value since llvm does
-  // not support stackalign attribute for this.
-  if (Index == 0) {
-    std::vector<unsigned> Vs;
-    if (findAllNVVMAnnotation(&F, "align", Vs))
-      for (unsigned V : Vs)
-        if ((V >> 16) == Index)
-          return Align(V & 0xFFFF);
-  }
-
-  return std::nullopt;
-}
-
 MaybeAlign getAlign(const CallInst &I, unsigned Index) {
   // First check the alignstack metadata
   if (MaybeAlign StackAlign =

--- a/llvm/lib/Target/NVPTX/NVPTXUtilities.h
+++ b/llvm/lib/Target/NVPTX/NVPTXUtilities.h
@@ -65,7 +65,10 @@ inline bool isKernelFunction(const Function &F) {
 
 bool isParamGridConstant(const Value &);
 
-MaybeAlign getAlign(const Function &, unsigned);
+inline MaybeAlign getAlign(const Function &F, unsigned Index) {
+  return F.getAttributes().getAttributes(Index).getStackAlignment();
+}
+
 MaybeAlign getAlign(const CallInst &, unsigned);
 Function *getMaybeBitcastedCallee(const CallBase *CB);
 

--- a/llvm/test/CodeGen/NVPTX/upgrade-nvvm-annotations.ll
+++ b/llvm/test/CodeGen/NVPTX/upgrade-nvvm-annotations.ll
@@ -2,7 +2,7 @@
 ; RUN: opt < %s -passes=verify -S | FileCheck %s
 
 define i32 @test_align(i32 %a, i32 %b) {
-; CHECK-LABEL: define i32 @test_align(
+; CHECK-LABEL: define alignstack(8) i32 @test_align(
 ; CHECK-SAME: i32 alignstack(8) [[A:%.*]], i32 alignstack(16) [[B:%.*]]) {
 ; CHECK-NEXT:    ret i32 0
 ;
@@ -123,6 +123,4 @@ define void @test_cluster_dim() {
 ; CHECK: attributes #[[ATTR7]] = { "nvvm.maxntid"="1,1,100" }
 ; CHECK: attributes #[[ATTR8]] = { "nvvm.reqntid"="31,32,33" }
 ; CHECK: attributes #[[ATTR9]] = { "nvvm.cluster_dim"="101,102,103" }
-;.
-; CHECK: [[META0:![0-9]+]] = !{ptr @test_align, !"align", i32 8}
 ;.


### PR DESCRIPTION
This commit follows up 0191307b by auto-upgrading !"align" metadata on return values to stackalign. This allows us to remove all logic to check the metadata from NVPTXUtilities.