### PR TITLE
[clang][bytecode] Compile most recent function decl

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1360,7 +1360,8 @@ static bool checkConstructor(InterpState &S, CodePtr OpPC, const Function *Func,
 
 static void compileFunction(InterpState &S, const Function *Func) {
   Compiler<ByteCodeEmitter>(S.getContext(), S.P)
-      .compileFunc(Func->getDecl(), const_cast<Function *>(Func));
+      .compileFunc(Func->getDecl()->getMostRecentDecl(),
+                   const_cast<Function *>(Func));
 }
 
 bool CallVar(InterpState &S, CodePtr OpPC, const Function *Func,

--- a/clang/test/AST/ByteCode/records.cpp
+++ b/clang/test/AST/ByteCode/records.cpp
@@ -1759,3 +1759,15 @@ namespace IncompleteTypes {
   }
   static_assert(foo(), "");
 }
+
+namespace RedeclaredCtor {
+
+  struct __sp_mut {
+    void *__lx_;
+    constexpr __sp_mut(void *) noexcept;
+  };
+  int mut_back[1];
+
+  constexpr __sp_mut::__sp_mut(void *p) noexcept : __lx_(p) {}
+  constexpr __sp_mut muts = &mut_back[0];
+}


### PR DESCRIPTION
We used to always do this because all calls went through the code path that calls getMostRecentDecl(). Do it now, too.