### PR TITLE
[libcxx] Export the formatter_integral for module build.

### DIFF
--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -945,9 +945,9 @@ module std [system] {
     module to_chars                   { header "__charconv/to_chars.h" }
     module to_chars_base_10           { header "__charconv/to_chars_base_10.h" }
     module to_chars_floating_point    { header "__charconv/to_chars_floating_point.h" }
-    module to_chars_integral          {
+    module to_chars_integral {
       header "__charconv/to_chars_integral.h"
-      export std.charconv.to_chars_result
+      export *  // TODO: Workaround for https://github.com/llvm/llvm-project/issues/120108
     }
     module to_chars_result            { header "__charconv/to_chars_result.h" }
     module traits                     { header "__charconv/traits.h" }
@@ -1354,7 +1354,10 @@ module std [system] {
     module formatter_char                     { header "__format/formatter_char.h" }
     module formatter_floating_point           { header "__format/formatter_floating_point.h" }
     module formatter_integer                  { header "__format/formatter_integer.h" }
-    module formatter_integral                 { header "__format/formatter_integral.h" }
+    module formatter_integral {
+      header "__format/formatter_integral.h"
+      export * // TODO: Workaround for https://github.com/llvm/llvm-project/issues/120108
+    }
     module formatter_output                   { header "__format/formatter_output.h" }
     module formatter_pointer                  { header "__format/formatter_pointer.h" }
     module formatter_string                   { header "__format/formatter_string.h" }


### PR DESCRIPTION
Chromium encounters another similar issue, https://crbug.com/400870610. Workaround #120108 by adding necessary `export *`.

In Chromium, the `vulkan_to_string.hpp` file (included by `VkStringify.cpp`) uses the `std::format` function. The relevant include path is `format_functions.h -> __format/format_integer.h -> __format/formatter_integral.h -> __charconv/to_chars_integral.h`

When building `VkStringify.cpp` with libc++ modules, some internal function templates fail to instantiate due to template unreachability (caused by the clang bug #120108). This leads to linker errors, as seen in the build failures:  

```
[478/479] 1m17.00s F SOLINK ./libvk_swiftshader.so
FAILED: 69e60d00-0e9a-45f0-9725-ff80fb25c239 "./libvk_swiftshader.so" SOLINK ./libvk_swiftshader.so
...
ld.lld: error: undefined hidden symbol: char* std::__Cr::__itoa::__append10<unsigned int>(char*, unsigned int)
>>> referenced by VkStringify.cpp            
>>>               obj/third_party/swiftshader/src/Vulkan/_swiftshader_libvulkan/VkStringify.o:(std::__Cr::__itoa::__base_10_u32(char*, unsigned int))
```