### PR TITLE
[readobj][ELFExtendedAttrParser] Add destructor with error handling

### DIFF
--- a/llvm/include/llvm/Support/ELFAttrParserExtended.h
+++ b/llvm/include/llvm/Support/ELFAttrParserExtended.h
@@ -35,6 +35,7 @@ protected:
                        const unsigned Tag);
 
 public:
+  virtual ~ELFExtendedAttrParser() { static_cast<void>(!Cursor.takeError()); }
   Error parse(ArrayRef<uint8_t> Section, llvm::endianness Endian) override;
 
   std::optional<unsigned> getAttributeValue(unsigned Tag) const override;

--- a/llvm/test/MC/AArch64/build-attributes-asm-arch-specific-empty.s
+++ b/llvm/test/MC/AArch64/build-attributes-asm-arch-specific-empty.s
@@ -1,0 +1,6 @@
+// RUN: llvm-mc -triple=aarch64 -filetype=obj %s | llvm-readelf --arch-specific - | FileCheck %s --check-prefix=CHECK
+
+// test llvm-readelf with empty file.
+
+// CHECK: BuildAttributes {
+// CHECK-NEXT: }

--- a/llvm/test/MC/AArch64/build-attributes-asm-arch-specific.s
+++ b/llvm/test/MC/AArch64/build-attributes-asm-arch-specific.s
@@ -1,0 +1,62 @@
+// RUN: llvm-mc -triple=aarch64 -filetype=obj %s | llvm-readelf --arch-specific - | FileCheck %s --check-prefix=ASM
+
+// ASM: BuildAttributes {
+// ASM-NEXT: FormatVersion: 0x41
+// ASM-NEXT:  Section 1 {
+// ASM-NEXT:    SectionLength: 21
+// ASM-NEXT:    VendorName: subsection_a Optionality: optional Type: uleb128
+// ASM-NEXT:    Attributes {
+// ASM-NEXT:      7: 11
+// ASM-NEXT:    }
+// ASM-NEXT:  }
+// ASM-NEXT:  Section 2 {
+// ASM-NEXT:    SectionLength: 32
+// ASM-NEXT:    VendorName: aeabi_subsection Optionality: optional Type: ntbs
+// ASM-NEXT:    Attributes {
+// ASM-NEXT:      5: "Value"
+// ASM-NEXT:    }
+// ASM-NEXT:  }
+// ASM-NEXT:  Section 3 {
+// ASM-NEXT:    SectionLength: 22
+// ASM-NEXT:    VendorName: subsection_b Optionality: required Type: uleb128
+// ASM-NEXT:    Attributes {
+// ASM-NEXT:      6: 536
+// ASM-NEXT:    }
+// ASM-NEXT:  }
+// ASM-NEXT:  Section 4 {
+// ASM-NEXT:    SectionLength: 26
+// ASM-NEXT:    VendorName: aeabi_pauthabi Optionality: required Type: uleb128
+// ASM-NEXT:    Attributes {
+// ASM-NEXT:      Tag_PAuth_Platform: 9
+// ASM-NEXT:      Tag_PAuth_Schema: 777
+// ASM-NEXT:    }
+// ASM-NEXT:  }
+// ASM-NEXT:  Section 5 {
+// ASM-NEXT:    SectionLength: 35
+// ASM-NEXT:    VendorName: aeabi_feature_and_bits Optionality: optional Type: uleb128
+// ASM-NEXT:    Attributes {
+// ASM-NEXT:      Tag_Feature_BTI: 1
+// ASM-NEXT:      Tag_Feature_PAC: 1
+// ASM-NEXT:      Tag_Feature_GCS: 1
+// ASM-NEXT:    }
+// ASM-NEXT:  }
+// ASM-NEXT: }
+
+
+.aeabi_subsection subsection_a, optional, uleb128
+.aeabi_subsection aeabi_subsection, optional, ntbs
+.aeabi_subsection subsection_b, required, uleb128
+.aeabi_subsection aeabi_pauthabi, required, uleb128
+.aeabi_attribute Tag_PAuth_Platform, 7
+.aeabi_attribute Tag_PAuth_Schema, 777
+.aeabi_attribute Tag_PAuth_Platform, 9
+.aeabi_subsection aeabi_feature_and_bits, optional, uleb128
+.aeabi_attribute Tag_Feature_BTI, 1
+.aeabi_attribute Tag_Feature_PAC, 1
+.aeabi_attribute Tag_Feature_GCS, 1
+.aeabi_subsection aeabi_subsection, optional, ntbs
+.aeabi_attribute 5, "Value"
+.aeabi_subsection subsection_b, required, uleb128
+.aeabi_attribute 6, 536
+.aeabi_subsection subsection_a, optional, uleb128
+.aeabi_attribute 7, 11


### PR DESCRIPTION
ELFExtendedAttrParser lacked a destructor that properly handled errors, causing `llvm-readobj --arch-specific` to crash when the AArch64 Build Attributes section was empty.

This commit adds error handling in the destructor and introduces test files for `--arch-specific` to cover both an empty AArch64 Build Attributes section and a populated one.

Fixes:
https://github.com/sivan-shani/llvm-project/commit/b1ebfac1859c4fd1db3620098f6af4fd98e6174d