### PR TITLE
[mlir][SCFToEmitC] Don't convert unsupported types in EmitC

### DIFF
--- a/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitCPass.cpp
+++ b/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitCPass.cpp
@@ -33,9 +33,9 @@ struct ConvertMemRefToEmitCPass
 
     // Fallback for other types.
     converter.addConversion([](Type type) -> std::optional<Type> {
-      if (emitc::isSupportedEmitCType(type))
-        return type;
-      return {};
+      if (!emitc::isSupportedEmitCType(type))
+        return {};
+      return type;
     });
 
     populateMemRefToEmitCTypeConversion(converter);

--- a/mlir/lib/Conversion/SCFToEmitC/SCFToEmitC.cpp
+++ b/mlir/lib/Conversion/SCFToEmitC/SCFToEmitC.cpp
@@ -319,10 +319,12 @@ void mlir::populateSCFToEmitCConversionPatterns(RewritePatternSet &patterns,
 void SCFToEmitCPass::runOnOperation() {
   RewritePatternSet patterns(&getContext());
   TypeConverter typeConverter;
-  // Fallback converter
-  // See note https://mlir.llvm.org/docs/DialectConversion/#type-converter
-  // Type converters are called most to least recently inserted
-  typeConverter.addConversion([](Type t) { return t; });
+  // Fallback for other types.
+  typeConverter.addConversion([](Type type) -> std::optional<Type> {
+    if (!emitc::isSupportedEmitCType(type))
+      return {};
+    return type;
+  });
   populateEmitCSizeTTypeConversions(typeConverter);
   populateSCFToEmitCConversionPatterns(patterns, typeConverter);
 

--- a/mlir/test/Conversion/SCFToEmitC/scf-to-emitc-failed.mlir
+++ b/mlir/test/Conversion/SCFToEmitC/scf-to-emitc-failed.mlir
@@ -1,0 +1,10 @@
+// RUN: mlir-opt -convert-scf-to-emitc %s -split-input-file -verify-diagnostics
+
+func.func @unsupported_type_vector(%arg0 : index, %arg1 : index, %arg2 : index) -> vector<3xindex> {
+  %zero = arith.constant dense<0> : vector<3xindex>
+  // expected-error@+1 {{failed to legalize operation 'scf.for'}}
+  %r = scf.for %i0 = %arg0 to %arg1 step %arg2 iter_args(%acc = %zero) -> vector<3xindex> {
+    scf.yield %acc : vector<3xindex>
+  }
+  return %r : vector<3xindex>
+}


### PR DESCRIPTION
This PR adds check for unsupported types in emitc, which fixes a crash. Fixes #131442.