### PR TITLE
[libc++][test] Fix issues found by MSVC's STL

### DIFF
--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
@@ -289,7 +289,7 @@ TEST_CONSTEXPR_CXX26 void test() {
     vec[5]                             = 6;
     getGlobalMemCounter()->throw_after = 0;
     std::stable_partition(
-        forward_iterator<int*>(vec.data()), forward_iterator<int*>(vec.data() + vec.size()), [](int i) {
+        bidirectional_iterator<int*>(vec.data()), bidirectional_iterator<int*>(vec.data() + vec.size()), [](int i) {
           return i < 5;
         });
     assert(std::is_partitioned(vec.begin(), vec.end(), [](int i) { return i < 5; }));

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.rotate/rotate.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.rotate/rotate.pass.cpp
@@ -439,7 +439,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
   types::for_each(types::forward_iterator_list<int*>(), TestIter());
 
 #if TEST_STD_VER >= 11
-  if (TEST_STD_VER >= 23 || !TEST_IS_CONSTANT_EVALUATED)
+  if (TEST_STD_AT_LEAST_23_OR_RUNTIME_EVALUATED)
     types::for_each(types::forward_iterator_list<std::unique_ptr<int>*>(), TestUniquePtr());
 #endif
 

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.swap/swap_ranges.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.swap/swap_ranges.pass.cpp
@@ -144,7 +144,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
 
 #if TEST_STD_VER >= 11
   // We can't test unique_ptr in constant evaluation before C++23 as it's constexpr only since C++23.
-  if (TEST_STD_VER >= 23 || !TEST_IS_CONSTANT_EVALUATED)
+  if (TEST_STD_AT_LEAST_23_OR_RUNTIME_EVALUATED)
     types::for_each(types::forward_iterator_list<std::unique_ptr<int>*>(), TestUniquePtr());
 #endif
 

--- a/libcxx/test/std/algorithms/alg.sorting/alg.merge/inplace_merge_comp.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.sorting/alg.merge/inplace_merge_comp.pass.cpp
@@ -161,11 +161,9 @@ TEST_CONSTEXPR_CXX26 bool test() {
     std::sort(ia, ia + M, indirect_less());
     std::sort(ia + M, ia + N, indirect_less());
     std::inplace_merge(ia, ia + M, ia + N, indirect_less());
-    if (N > 0) {
-      assert(*ia[0] == 0);
-      assert(*ia[N - 1] == N - 1);
-      assert(std::is_sorted(ia, ia + N, indirect_less()));
-    }
+    assert(*ia[0] == 0);
+    assert(*ia[N - 1] == N - 1);
+    assert(std::is_sorted(ia, ia + N, indirect_less()));
     delete[] ia;
   }
 #endif // TEST_STD_VER >= 11

--- a/libcxx/test/std/containers/sequences/array/assert.iterators.pass.cpp
+++ b/libcxx/test/std/containers/sequences/array/assert.iterators.pass.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: has-unix-headers, libcpp-has-abi-bounded-iterators-in-std-array
+// REQUIRES: has-unix-headers
+// REQUIRES: libcpp-has-abi-bounded-iterators-in-std-array
 // UNSUPPORTED: c++03
 // UNSUPPORTED: libcpp-hardening-mode=none
 // XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing

--- a/libcxx/test/std/containers/sequences/vector.bool/max_size.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/max_size.pass.cpp
@@ -71,7 +71,7 @@ TEST_CONSTEXPR_CXX20 bool tests() {
   // Test with various allocators and different `size_type`s
   {
     test(std::vector<bool>());
-    test(std::vector<bool, std::allocator<int> >());
+    test(std::vector<bool, std::allocator<bool> >());
     test(std::vector<bool, min_allocator<bool> >());
     test(std::vector<bool, test_allocator<bool> >(test_allocator<bool>(1)));
     test(std::vector<bool, other_allocator<bool> >(other_allocator<bool>(5)));

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/assert.push_back.invalidation.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/assert.push_back.invalidation.pass.cpp
@@ -14,7 +14,8 @@
 // the insertion point remain valid but those at or after the insertion point,
 // including the past-the-end iterator, are invalidated.
 
-// REQUIRES: has-unix-headers, libcpp-has-abi-bounded-iterators-in-vector
+// REQUIRES: has-unix-headers
+// REQUIRES: libcpp-has-abi-bounded-iterators-in-vector
 // UNSUPPORTED: c++03
 // UNSUPPORTED: libcpp-hardening-mode=none
 // XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing

--- a/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
@@ -46,7 +46,7 @@ void test_tellg(std::streamoff total_size) {
     ofs.open(p, std::ios::out | std::ios::binary);
     assert(ofs.is_open());
     for (std::streamoff size = 0; size < total_size;) {
-      std::size_t n = std::min(static_cast<std::streamoff>(data.size()), total_size - size);
+      std::streamoff n = std::min(static_cast<std::streamoff>(data.size()), total_size - size);
       ofs.write(data.data(), n);
       size += n;
     }

--- a/libcxx/test/std/input.output/iostream.format/print.fun/no_file_description.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/no_file_description.pass.cpp
@@ -10,7 +10,8 @@
 // UNSUPPORTED: no-filesystem
 // UNSUPPORTED: GCC-ALWAYS_INLINE-FIXME
 
-// XFAIL: msvc, target={{.+}}-windows-gnu
+// XFAIL: msvc
+// XFAIL: target={{.+}}-windows-gnu
 // XFAIL: availability-fp_to_chars-missing
 
 // fmemopen is available starting in Android M (API 23)

--- a/libcxx/test/std/numerics/numeric.ops/numeric.ops.gcd/gcd.pass.cpp
+++ b/libcxx/test/std/numerics/numeric.ops/numeric.ops.gcd/gcd.pass.cpp
@@ -39,7 +39,7 @@ constexpr struct {
     {36, 18, 18},
     {25, 30, 5},
     {24, 16, 8},
-    {128, 100, 4}};
+    {124, 100, 4}};
 
 template <typename Input1, typename Input2, typename Output>
 constexpr bool test0(int in1, int in2, int out)

--- a/libcxx/test/std/time/time.clock/time.clock.utc/types.compile.pass.cpp
+++ b/libcxx/test/std/time/time.clock/time.clock.utc/types.compile.pass.cpp
@@ -36,11 +36,11 @@
 #include "test_macros.h"
 
 // class utc_clock
-using rep                = std::chrono::utc_clock::rep;
-using period             = std::chrono::utc_clock::period;
-using duration           = std::chrono::utc_clock::duration;
-using time_point         = std::chrono::utc_clock::time_point;
-constexpr bool is_steady = std::chrono::utc_clock::is_steady;
+using rep                                 = std::chrono::utc_clock::rep;
+using period                              = std::chrono::utc_clock::period;
+using duration                            = std::chrono::utc_clock::duration;
+using time_point                          = std::chrono::utc_clock::time_point;
+[[maybe_unused]] constexpr bool is_steady = std::chrono::utc_clock::is_steady;
 
 // Tests the values. Some of them are implementation-defined.
 LIBCPP_STATIC_ASSERT(std::same_as<rep, std::chrono::system_clock::rep>);

--- a/libcxx/test/std/utilities/utility/utility.swap/swap_array.pass.cpp
+++ b/libcxx/test/std/utilities/utility/utility.swap/swap_array.pass.cpp
@@ -137,7 +137,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
     static_assert(noexcept(std::swap(ma, ma)), "");
   }
 
-  if (TEST_STD_VER >= 23 || !TEST_IS_CONSTANT_EVALUATED)
+  if (TEST_STD_AT_LEAST_23_OR_RUNTIME_EVALUATED)
     test_unique_ptr();
 #endif
 

--- a/libcxx/test/support/min_allocator.h
+++ b/libcxx/test/support/min_allocator.h
@@ -481,7 +481,7 @@ struct tiny_size_allocator {
 
   template <class U>
   struct rebind {
-    using other = tiny_size_allocator<MaxSize, T>;
+    using other = tiny_size_allocator<MaxSize, U>;
   };
 
   tiny_size_allocator() = default;

--- a/libcxx/test/support/sized_allocator.h
+++ b/libcxx/test/support/sized_allocator.h
@@ -37,10 +37,12 @@ public:
   TEST_CONSTEXPR_CXX20 T* allocate(size_type n) {
     if (n > max_size())
       TEST_THROW(std::bad_array_new_length());
-    return std::allocator<T>().allocate(n);
+    return std::allocator<T>().allocate(static_cast<std::size_t>(n));
   }
 
-  TEST_CONSTEXPR_CXX20 void deallocate(T* p, size_type n) TEST_NOEXCEPT { std::allocator<T>().deallocate(p, n); }
+  TEST_CONSTEXPR_CXX20 void deallocate(T* p, size_type n) TEST_NOEXCEPT {
+    std::allocator<T>().deallocate(p, static_cast<std::size_t>(n));
+  }
 
   TEST_CONSTEXPR size_type max_size() const TEST_NOEXCEPT {
     return std::numeric_limits<size_type>::max() / sizeof(value_type);


### PR DESCRIPTION
* libcxx/test/support/min_allocator.h
  + Fix `tiny_size_allocator::rebind` which mistakenly said `T` instead of `U`.
* libcxx/test/std/algorithms/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
  + `std::stable_partition` requires bidirectional iterators.
* libcxx/test/std/containers/sequences/vector.bool/max_size.pass.cpp
  + Fix allocator type given to `std::vector<bool>`. The element types are required to match, [N5008](https://isocpp.org/files/papers/N5008.pdf) \[container.alloc.reqmts\]/5: "*Mandates:* `allocator_type::value_type` is the same as `X::value_type`."
* libcxx/test/std/time/time.clock/time.clock.utc/types.compile.pass.cpp
  + Mark `is_steady` as `[[maybe_unused]]`, as it appears within `LIBCPP_STATIC_ASSERT` only.
* libcxx/test/std/algorithms/alg.modifying.operations/alg.rotate/rotate.pass.cpp
* libcxx/test/std/algorithms/alg.modifying.operations/alg.swap/swap_ranges.pass.cpp
* libcxx/test/std/utilities/utility/utility.swap/swap_array.pass.cpp
  + Fix MSVC warning C4127 "conditional expression is constant". `TEST_STD_AT_LEAST_23_OR_RUNTIME_EVALUATED` was introduced for this purpose, so it should be used consistently.
* libcxx/test/std/numerics/numeric.ops/numeric.ops.gcd/gcd.pass.cpp
  + Fix `gcd()` precondition violation for `signed char`. This test case was causing `-128` to be passed as a `signed char` to `gcd()`, which is forbidden.
* libcxx/test/std/containers/sequences/array/assert.iterators.pass.cpp
* libcxx/test/std/containers/sequences/vector/vector.modifiers/assert.push_back.invalidation.pass.cpp
* libcxx/test/std/input.output/iostream.format/print.fun/no_file_description.pass.cpp
  + Split some REQUIRES and XFAIL lines. This is a "nice to have" for MSVC's internal test harness, which is extremely simple and looks for exact comment matches to skip tests. We can recognize the specific lines "REQUIRES: has-unix-headers" and "XFAIL: msvc", but it's a headache to maintain if they're chained with other conditions.
* libcxx/test/support/sized_allocator.h
  + Fix x86 truncation warnings. `std::allocator` takes `std::size_t`, so we need to `static_cast`.
* libcxx/test/std/input.output/file.streams/fstreams/ifstream.members/offset_range.pass.cpp
  + Fix x86 truncation warning. `std::min()` is returning `std::streamoff`, which was being unnecessarily narrowed to `std::size_t`.
* libcxx/test/std/algorithms/alg.sorting/alg.merge/inplace_merge_comp.pass.cpp
  + Fix MSVC warning C4127 "conditional expression is constant" for an always-true branch. This was very recently introduced by #129008 making `N` constexpr. As it's a local constant just nine lines above, we don't need to test whether 100 is greater than 0.