### PR TITLE
[lldb] Consider "hidden" frames in ThreadPlanShouldStopHere

### DIFF
--- a/lldb/include/lldb/Target/Thread.h
+++ b/lldb/include/lldb/Target/Thread.h
@@ -942,7 +942,8 @@ public:
   virtual lldb::ThreadPlanSP QueueThreadPlanForStepOutNoShouldStop(
       bool abort_other_plans, SymbolContext *addr_context, bool first_insn,
       bool stop_other_threads, Vote report_stop_vote, Vote report_run_vote,
-      uint32_t frame_idx, Status &status, bool continue_to_next_branch = false);
+      uint32_t frame_idx, Status &status, bool continue_to_next_branch = false,
+      const Flags *flags = nullptr);
 
   /// Gets the plan used to step through the code that steps from a function
   /// call site at the current PC into the actual function call.

--- a/lldb/include/lldb/Target/ThreadPlanShouldStopHere.h
+++ b/lldb/include/lldb/Target/ThreadPlanShouldStopHere.h
@@ -60,7 +60,8 @@ public:
     eAvoidInlines = (1 << 0),
     eStepInAvoidNoDebug = (1 << 1),
     eStepOutAvoidNoDebug = (1 << 2),
-    eStepOutPastThunks = (1 << 3)
+    eStepOutPastThunks = (1 << 3),
+    eStepOutPastHiddenFunctions = (1 << 4),
   };
 
   // Constructors and Destructors

--- a/lldb/include/lldb/Target/ThreadPlanStepOut.h
+++ b/lldb/include/lldb/Target/ThreadPlanStepOut.h
@@ -22,7 +22,8 @@ public:
                     Vote report_run_vote, uint32_t frame_idx,
                     LazyBool step_out_avoids_code_without_debug_info,
                     bool continue_to_next_branch = false,
-                    bool gather_return_value = true);
+                    bool gather_return_value = true,
+                    const Flags *flags = nullptr);
 
   ~ThreadPlanStepOut() override;
 

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -1356,13 +1356,14 @@ ThreadPlanSP Thread::QueueThreadPlanForStepOut(
 ThreadPlanSP Thread::QueueThreadPlanForStepOutNoShouldStop(
     bool abort_other_plans, SymbolContext *addr_context, bool first_insn,
     bool stop_other_threads, Vote report_stop_vote, Vote report_run_vote,
-    uint32_t frame_idx, Status &status, bool continue_to_next_branch) {
+    uint32_t frame_idx, Status &status, bool continue_to_next_branch,
+    const Flags *flags) {
   const bool calculate_return_value =
       false; // No need to calculate the return value here.
   ThreadPlanSP thread_plan_sp(new ThreadPlanStepOut(
       *this, addr_context, first_insn, stop_other_threads, report_stop_vote,
       report_run_vote, frame_idx, eLazyBoolNo, continue_to_next_branch,
-      calculate_return_value));
+      calculate_return_value, flags));
 
   ThreadPlanStepOut *new_plan =
       static_cast<ThreadPlanStepOut *>(thread_plan_sp.get());

--- a/lldb/source/Target/ThreadPlanShouldStopHere.cpp
+++ b/lldb/source/Target/ThreadPlanShouldStopHere.cpp
@@ -177,7 +177,7 @@ ThreadPlanSP ThreadPlanShouldStopHere::DefaultStepFromHereCallback(
     return_plan_sp =
         current_plan->GetThread().QueueThreadPlanForStepOutNoShouldStop(
             false, nullptr, true, stop_others, eVoteNo, eVoteNoOpinion,
-            frame_index, status, true);
+            frame_index, status, true, &flags);
   return return_plan_sp;
 }
 


### PR DESCRIPTION
Patch [1] introduced the notion of "hidden" frames, which are recognized by language plugins and can be hidden in backtraces. They also affect stepping out: when stepping out of a frame, if its parent frame is "hidden", then the debugger steps out to the parent's parent.

However, this is problematic when stepping out is done as part of a larger plan. For example, when stepping through, the debugger is often in some frame A, then pushes some frame B, and decides to step out of B and back to A. If A is a hidden frame, LLDB currenly steps out past it, which is not what the step through plan intended.

To address this issue, we create a new flag for the ShouldStopHere base class to allow for stepping past hidden frames. This flag is now the default for stepping out.  Furthermore,
`ThreadPlanShouldStopHere::DefaultStepFromHereCallback` now passes its own set of flags to the constructor of ThreadPlanStepOut.

One potentially controversial choice: all StepOut plans created through `ThreadPlanShouldStopHere::DefaultStepFromHereCallback` will pass on their set of flags to ThreadPlanStepOut, which will disable the behavior of stepping past hidden frames.

[1]: https://github.com/llvm/llvm-project/pull/104523

rdar://147065566