### PR TITLE
[GlobalMerge][PPC] Don't merge globals in llvm.metadata section

### DIFF
--- a/llvm/lib/CodeGen/GlobalMerge.cpp
+++ b/llvm/lib/CodeGen/GlobalMerge.cpp
@@ -711,7 +711,8 @@ bool GlobalMergeImpl::run(Module &M) {
       continue;
 
     // Ignore all 'special' globals.
-    if (GV.getName().starts_with("llvm.") || GV.getName().starts_with(".llvm."))
+    if (GV.getName().starts_with("llvm.") ||
+        GV.getName().starts_with(".llvm.") || Section == "llvm.metadata")
       continue;
 
     // Ignore all "required" globals:

--- a/llvm/test/CodeGen/PowerPC/global-merge-llvm-metadata.ll
+++ b/llvm/test/CodeGen/PowerPC/global-merge-llvm-metadata.ll
@@ -1,0 +1,9 @@
+; RUN: llc -mtriple=powerpc64le-unknown-linux-gnu < %s | FileCheck %s
+
+@index = global i32 0, align 4
+@.str = private unnamed_addr constant [1 x i8] zeroinitializer, section "llvm.metadata"
+@.str.1 = private unnamed_addr constant [7 x i8] c"test.c\00", section "llvm.metadata" 
+@llvm.global.annotations = appending global [1 x { ptr, ptr, ptr, i32, ptr }] [{ ptr, ptr, ptr, i32, ptr } { ptr @index, ptr @.str, ptr @.str.1, i32 1, ptr null }], section "llvm.metadata"
+
+; CHECK-NOT: .set
+; CHECK-NOT: _MergedGlobals


### PR DESCRIPTION
The llvm.metadata section is not emitted and has special semantics. We should not merge globals in it, similarly to how we already skip merging of `llvm.xyz` globals.

Fixes https://github.com/llvm/llvm-project/issues/131394.