### PR TITLE
[clang] Update C++ DR status page

### DIFF
--- a/clang/test/CXX/drs/cwg14xx.cpp
+++ b/clang/test/CXX/drs/cwg14xx.cpp
@@ -57,7 +57,7 @@ namespace cwg1423 { // cwg1423: 11
 
 // cwg1425: na abi
 
-namespace cwg1432 { // cwg1432: 16
+namespace cwg1432 { // cwg1432: 16 open 2022-11-11
 #if __cplusplus >= 201103L
   namespace class_template_partial_spec {
     template<typename T> T declval();

--- a/clang/test/CXX/drs/cwg4xx.cpp
+++ b/clang/test/CXX/drs/cwg4xx.cpp
@@ -1062,7 +1062,7 @@ namespace cwg471 { // cwg471: 2.8
   //   expected-note@#cwg471-G-using {{declared private here}}
 } // namespace cwg471
 
-namespace cwg472 { // cwg472: no drafting 2011-04
+namespace cwg472 { // cwg472: no open 2011-04
 struct B {
   int i; // #cwg472-i
 };

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -1177,7 +1177,7 @@
   </tr>
   <tr class="open" id="189">
     <td><a href="https://cplusplus.github.io/CWG/issues/189.html">189</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Definition of <I>operator</I> and <I>punctuator</I></td>
     <td align="center">Not resolved</td>
   </tr>
@@ -1995,7 +1995,7 @@ of class templates</td>
   </tr>
   <tr class="open" id="325">
     <td><a href="https://cplusplus.github.io/CWG/issues/325.html">325</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>When are default arguments parsed?</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -2259,7 +2259,7 @@ of class templates</td>
   </tr>
   <tr class="open" id="369">
     <td><a href="https://cplusplus.github.io/CWG/issues/369.html">369</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Are <TT>new</TT>/<TT>delete</TT> identifiers or <I>preprocessing-op-or-punc</I>?</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -2877,7 +2877,7 @@ of class templates</td>
   </tr>
   <tr class="open" id="472">
     <td><a href="https://cplusplus.github.io/CWG/issues/472.html">472</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Casting across protected inheritance</td>
     <td align="center">
       <details>
@@ -3223,7 +3223,7 @@ of class templates</td>
   </tr>
   <tr class="open" id="529">
     <td><a href="https://cplusplus.github.io/CWG/issues/529.html">529</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Use of <TT>template&lt;&gt;</TT> with &#8220;explicitly-specialized&#8221; class templates</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -3599,7 +3599,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/591.html">591</a></td>
     <td>CD4</td>
     <td>When a dependent base class is the current instantiation</td>
-    <td class="full" align="center">Clang 20</td>
+    <td class="unreleased" align="center">Clang 20</td>
   </tr>
   <tr id="592">
     <td><a href="https://cplusplus.github.io/CWG/issues/592.html">592</a></td>
@@ -4385,7 +4385,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/722.html">722</a></td>
     <td>CD2</td>
     <td>Can <TT>nullptr</TT> be passed to an ellipsis?</td>
-    <td class="full" align="center">Clang 20</td>
+    <td class="unreleased" align="center">Clang 20</td>
   </tr>
   <tr id="726">
     <td><a href="https://cplusplus.github.io/CWG/issues/726.html">726</a></td>
@@ -5253,7 +5253,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="901">
     <td><a href="https://cplusplus.github.io/CWG/issues/901.html">901</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Deleted <TT>operator delete</TT></td>
     <td align="center">Not resolved</td>
   </tr>
@@ -7083,7 +7083,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1211">
     <td><a href="https://cplusplus.github.io/CWG/issues/1211.html">1211</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Misaligned lvalues</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -7491,7 +7491,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1279">
     <td><a href="https://cplusplus.github.io/CWG/issues/1279.html">1279</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Additional differences between C++ 2003 and C++ 2011</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -7515,7 +7515,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1283">
     <td><a href="https://cplusplus.github.io/CWG/issues/1283.html">1283</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Static data members of classes with typedef name for linkage purposes</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -7533,7 +7533,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1286">
     <td><a href="https://cplusplus.github.io/CWG/issues/1286.html">1286</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Equivalence of alias templates</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -8241,7 +8241,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1404">
     <td><a href="https://cplusplus.github.io/CWG/issues/1404.html">1404</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Object reallocation in unions</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -8407,11 +8407,15 @@ and <I>POD class</I></td>
     <td>Exceptions from other than <I>throw-expression</I>s</td>
     <td class="unknown" align="center">Unknown</td>
   </tr>
-  <tr id="1432">
+  <tr class="open" id="1432">
     <td><a href="https://cplusplus.github.io/CWG/issues/1432.html">1432</a></td>
-    <td>C++17</td>
+    <td>open</td>
     <td>Newly-ambiguous variadic template expansions</td>
-    <td class="full" align="center">Clang 16</td>
+    <td align="center">
+      <details>
+        <summary>Not resolved</summary>
+        Clang 16 implements 2022-11-11 resolution
+      </details></td>
   </tr>
   <tr id="1433">
     <td><a href="https://cplusplus.github.io/CWG/issues/1433.html">1433</a></td>
@@ -8919,7 +8923,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1517">
     <td><a href="https://cplusplus.github.io/CWG/issues/1517.html">1517</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Unclear/missing description of behavior during construction/destruction</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -9069,7 +9073,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1542">
     <td><a href="https://cplusplus.github.io/CWG/issues/1542.html">1542</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Compound assignment of <I>braced-init-list</I></td>
     <td align="center">Not resolved</td>
   </tr>
@@ -9105,7 +9109,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1548">
     <td><a href="https://cplusplus.github.io/CWG/issues/1548.html">1548</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Copy/move construction and conversion functions</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -9625,7 +9629,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1634">
     <td><a href="https://cplusplus.github.io/CWG/issues/1634.html">1634</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Temporary storage duration</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -9751,7 +9755,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1655">
     <td><a href="https://cplusplus.github.io/CWG/issues/1655.html">1655</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Line endings in raw string literals</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -10027,7 +10031,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1701">
     <td><a href="https://cplusplus.github.io/CWG/issues/1701.html">1701</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Array vs sequence in object representation</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -10075,7 +10079,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1709">
     <td><a href="https://cplusplus.github.io/CWG/issues/1709.html">1709</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Stringizing raw string literals containing newline</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -10129,7 +10133,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1718">
     <td><a href="https://cplusplus.github.io/CWG/issues/1718.html">1718</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Macro invocation spanning end-of-file</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -10159,7 +10163,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1723">
     <td><a href="https://cplusplus.github.io/CWG/issues/1723.html">1723</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Multicharacter user-defined character literals</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -10231,7 +10235,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1735">
     <td><a href="https://cplusplus.github.io/CWG/issues/1735.html">1735</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Out-of-range literals in <I>user-defined-literal</I>s</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -10713,7 +10717,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/1815.html">1815</a></td>
     <td>CD4</td>
     <td>Lifetime extension in aggregate initialization</td>
-    <td class="full" align="center">Clang 20</td>
+    <td class="unreleased" align="center">Clang 20</td>
   </tr>
   <tr id="1816">
     <td><a href="https://cplusplus.github.io/CWG/issues/1816.html">1816</a></td>
@@ -10723,7 +10727,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1817">
     <td><a href="https://cplusplus.github.io/CWG/issues/1817.html">1817</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Linkage specifications and nested scopes</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -11029,7 +11033,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1868">
     <td><a href="https://cplusplus.github.io/CWG/issues/1868.html">1868</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Meaning of &#8220;placeholder type&#8221;</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -11155,7 +11159,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1889">
     <td><a href="https://cplusplus.github.io/CWG/issues/1889.html">1889</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Unclear effect of <TT>#pragma</TT> on conformance</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -11231,7 +11235,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1901">
     <td><a href="https://cplusplus.github.io/CWG/issues/1901.html">1901</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td><I>punctuator</I> referenced but not defined</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -11687,7 +11691,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1977">
     <td><a href="https://cplusplus.github.io/CWG/issues/1977.html">1977</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Contradictory results of failed destructor lookup</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -11783,7 +11787,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="1993">
     <td><a href="https://cplusplus.github.io/CWG/issues/1993.html">1993</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Use of <TT>template&lt;&gt;</TT> defining member of explicit specialization</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -12161,7 +12165,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2056">
     <td><a href="https://cplusplus.github.io/CWG/issues/2056.html">2056</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Member function calls in partially-initialized class objects</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -12263,7 +12267,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2073">
     <td><a href="https://cplusplus.github.io/CWG/issues/2073.html">2073</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Allocating memory for exception objects</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -12365,7 +12369,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2090">
     <td><a href="https://cplusplus.github.io/CWG/issues/2090.html">2090</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Dependency via non-dependent base class</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -12515,7 +12519,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2115">
     <td><a href="https://cplusplus.github.io/CWG/issues/2115.html">2115</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Order of implicit destruction vs release of automatic storage</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -12527,7 +12531,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2117">
     <td><a href="https://cplusplus.github.io/CWG/issues/2117.html">2117</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Explicit specializations and <TT>constexpr</TT> function templates</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -12593,7 +12597,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2128">
     <td><a href="https://cplusplus.github.io/CWG/issues/2128.html">2128</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Imprecise rule for reference member initializer</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -12649,7 +12653,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2137.html">2137</a></td>
     <td>CD4</td>
     <td>List-initialization from object of same type</td>
-    <td class="full" align="center">Clang 20</td>
+    <td class="unreleased" align="center">Clang 20</td>
   </tr>
   <tr id="2138">
     <td><a href="https://cplusplus.github.io/CWG/issues/2138.html">2138</a></td>
@@ -13799,7 +13803,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2329">
     <td><a href="https://cplusplus.github.io/CWG/issues/2329.html">2329</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Virtual base classes and generated assignment operators</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -13937,7 +13941,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2351.html">2351</a></td>
     <td>CD5</td>
     <td><TT>void{}</TT></td>
-    <td class="full" align="center">Clang 20</td>
+    <td class="unreleased" align="center">Clang 20</td>
   </tr>
   <tr id="2352">
     <td><a href="https://cplusplus.github.io/CWG/issues/2352.html">2352</a></td>
@@ -14601,7 +14605,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2462">
     <td><a href="https://cplusplus.github.io/CWG/issues/2462.html">2462</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Problems with the omission of the <TT>typename</TT> keyword</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -14637,7 +14641,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2468">
     <td><a href="https://cplusplus.github.io/CWG/issues/2468.html">2468</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Omission of the <TT>typename</TT> keyword in a member template parameter list</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -14667,7 +14671,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2473">
     <td><a href="https://cplusplus.github.io/CWG/issues/2473.html">2473</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Parentheses in pseudo-destructor calls</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -14781,7 +14785,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2492">
     <td><a href="https://cplusplus.github.io/CWG/issues/2492.html">2492</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Comparing user-defined conversion sequences in list-initialization</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -14979,7 +14983,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2525">
     <td><a href="https://cplusplus.github.io/CWG/issues/2525.html">2525</a></td>
-    <td>drafting</td>
+    <td>open</td>
     <td>Incorrect definition of implicit conversion sequence</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -15113,7 +15117,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2547.html">2547</a></td>
     <td>DRWP</td>
     <td>Defaulted comparison operator function for non-classes</td>
-    <td class="full" align="center">Clang 20</td>
+    <td class="unreleased" align="center">Clang 20</td>
   </tr>
   <tr id="2548">
     <td><a href="https://cplusplus.github.io/CWG/issues/2548.html">2548</a></td>
@@ -15123,7 +15127,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2549">
     <td><a href="https://cplusplus.github.io/CWG/issues/2549.html">2549</a></td>
-    <td>review</td>
+    <td>ready</td>
     <td>Implicitly moving the operand of a <I>throw-expression</I> in unevaluated contexts</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -15359,7 +15363,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2586.html">2586</a></td>
     <td>CD6</td>
     <td>Explicit object parameter for assignment and comparison</td>
-    <td class="full" align="center">Clang 20</td>
+    <td class="unreleased" align="center">Clang 20</td>
   </tr>
   <tr class="open" id="2587">
     <td><a href="https://cplusplus.github.io/CWG/issues/2587.html">2587</a></td>
@@ -15605,13 +15609,13 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2627.html">2627</a></td>
     <td>C++23</td>
     <td>Bit-fields and narrowing conversions</td>
-    <td class="full" align="center">Clang 20</td>
+    <td class="unreleased" align="center">Clang 20</td>
   </tr>
   <tr id="2628">
     <td><a href="https://cplusplus.github.io/CWG/issues/2628.html">2628</a></td>
     <td>DRWP</td>
     <td>Implicit deduction guides should propagate constraints</td>
-    <td class="full" align="center">Clang 20</td>
+    <td class="unreleased" align="center">Clang 20</td>
   </tr>
   <tr id="2629">
     <td><a href="https://cplusplus.github.io/CWG/issues/2629.html">2629</a></td>
@@ -16059,7 +16063,7 @@ and <I>POD class</I></td>
   </tr>
   <tr class="open" id="2703">
     <td><a href="https://cplusplus.github.io/CWG/issues/2703.html">2703</a></td>
-    <td>review</td>
+    <td>ready</td>
     <td>Three-way comparison requiring strong ordering for floating-point types, take 2</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -16085,7 +16089,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2707.html">2707</a></td>
     <td>DRWP</td>
     <td>Deduction guides cannot have a trailing <I>requires-clause</I></td>
-    <td class="full" align="center">Clang 20</td>
+    <td class="unreleased" align="center">Clang 20</td>
   </tr>
   <tr id="2708">
     <td><a href="https://cplusplus.github.io/CWG/issues/2708.html">2708</a></td>
@@ -16337,7 +16341,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2749.html">2749</a></td>
     <td>DRWP</td>
     <td>Treatment of "pointer to void" for relational comparisons</td>
-    <td class="full" align="center">Clang 20</td>
+    <td class="unreleased" align="center">Clang 20</td>
   </tr>
   <tr id="2750">
     <td><a href="https://cplusplus.github.io/CWG/issues/2750.html">2750</a></td>
@@ -16722,7 +16726,7 @@ objects</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2813.html">2813</a></td>
     <td>DRWP</td>
     <td>Class member access with prvalues</td>
-    <td class="full" align="center">Clang 20</td>
+    <td class="unreleased" align="center">Clang 20</td>
   </tr>
   <tr id="2814">
     <td><a href="https://cplusplus.github.io/CWG/issues/2814.html">2814</a></td>
@@ -17330,7 +17334,7 @@ objects</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2913.html">2913</a></td>
     <td>DR</td>
     <td>Grammar for <I>deduction-guide</I> has <I>requires-clause</I> in the wrong position</td>
-    <td class="full" align="center">Clang 20</td>
+    <td class="unreleased" align="center">Clang 20</td>
   </tr>
   <tr class="open" id="2914">
     <td><a href="https://cplusplus.github.io/CWG/issues/2914.html">2914</a></td>
@@ -17342,7 +17346,7 @@ objects</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2915.html">2915</a></td>
     <td>DR</td>
     <td>Explicit object parameters of type <TT>void</TT></td>
-    <td class="full" align="center">Clang 20</td>
+    <td class="unreleased" align="center">Clang 20</td>
   </tr>
   <tr class="open" id="2916">
     <td><a href="https://cplusplus.github.io/CWG/issues/2916.html">2916</a></td>
@@ -17388,7 +17392,7 @@ objects</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2922.html">2922</a></td>
     <td>DR</td>
     <td>constexpr placement-new is too permissive</td>
-    <td class="full" align="center">Clang 20</td>
+    <td class="unreleased" align="center">Clang 20</td>
   </tr>
   <tr class="open" id="2923">
     <td><a href="https://cplusplus.github.io/CWG/issues/2923.html">2923</a></td>
@@ -17512,7 +17516,7 @@ objects</td>
   </tr>
   <tr class="open" id="2943">
     <td><a href="https://cplusplus.github.io/CWG/issues/2943.html">2943</a></td>
-    <td>open</td>
+    <td>ready</td>
     <td>Discarding a void return value</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -17674,7 +17678,7 @@ objects</td>
   </tr>
   <tr class="open" id="2970">
     <td><a href="https://cplusplus.github.io/CWG/issues/2970.html">2970</a></td>
-    <td>open</td>
+    <td>ready</td>
     <td>Races with <TT>volatile sig_atomic_t</TT> bit-fields</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -17710,13 +17714,13 @@ objects</td>
   </tr>
   <tr class="open" id="2976">
     <td><a href="https://cplusplus.github.io/CWG/issues/2976.html">2976</a></td>
-    <td>open</td>
+    <td>review</td>
     <td>Transferring control out of a function</td>
     <td align="center">Not resolved</td>
   </tr>
   <tr class="open" id="2977">
     <td><a href="https://cplusplus.github.io/CWG/issues/2977.html">2977</a></td>
-    <td>open</td>
+    <td>review</td>
     <td>Initialization with string literals</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -17764,7 +17768,7 @@ objects</td>
   </tr>
   <tr class="open" id="2985">
     <td><a href="https://cplusplus.github.io/CWG/issues/2985.html">2985</a></td>
-    <td>open</td>
+    <td>tentatively ready</td>
     <td>Unclear rules for reference initialization with conversion</td>
     <td align="center">Not resolved</td>
   </tr>
@@ -17772,6 +17776,138 @@ objects</td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2986.html">2986</a></td>
     <td>open</td>
     <td>Creating objects within a mutable member of a const object</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2987">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2987.html">2987</a></td>
+    <td>open</td>
+    <td>Remove dilapidated wording from <TT>static_cast</TT></td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2988">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2988.html">2988</a></td>
+    <td>open</td>
+    <td>Is a closure type from a <I>lambda-expression</I> appearing in a <I>concept-definition</I> a TU-local entity?</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2989">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2989.html">2989</a></td>
+    <td>open</td>
+    <td>Remove misleading general allowance for parentheses</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2990">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2990.html">2990</a></td>
+    <td>ready</td>
+    <td>Exporting redeclarations of namespaces</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2991">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2991.html">2991</a></td>
+    <td>open</td>
+    <td>"array size" is vague</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2992">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2992.html">2992</a></td>
+    <td>open</td>
+    <td>Labels do not have names</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2993">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2993.html">2993</a></td>
+    <td>open</td>
+    <td>Body of a destructor</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2994">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2994.html">2994</a></td>
+    <td>open</td>
+    <td>Allowing template parameters following template parameter packs that are pack expansions</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2995">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2995.html">2995</a></td>
+    <td>open</td>
+    <td>Meaning of flowing off the end of a function</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2996">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2996.html">2996</a></td>
+    <td>open</td>
+    <td>Impenetrable definition of atomic constraint</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2997">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2997.html">2997</a></td>
+    <td>open</td>
+    <td>Defaulted functions with deleted definition</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2998">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2998.html">2998</a></td>
+    <td>open</td>
+    <td>Missing deduction consistency check for partial ordering</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="2999">
+    <td><a href="https://cplusplus.github.io/CWG/issues/2999.html">2999</a></td>
+    <td>open</td>
+    <td>Trivial unions changing existing behavior</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3000">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3000.html">3000</a></td>
+    <td>open</td>
+    <td>Handling of cv-qualified class types in conditional operator</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3001">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3001.html">3001</a></td>
+    <td>open</td>
+    <td>Inconsistent restrictions for <TT>static_cast</TT> on pointers to out-of-lifetime objects</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3002">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3002.html">3002</a></td>
+    <td>open</td>
+    <td>Template parameter/argument confusion</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3003">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3003.html">3003</a></td>
+    <td>open</td>
+    <td>Naming a deducible template for class template argument deduction</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3004">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3004.html">3004</a></td>
+    <td>open</td>
+    <td>Pointer arithmetic on array of unknown bound</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3005">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3005.html">3005</a></td>
+    <td>open</td>
+    <td>Function parameters should never be name-independent</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3006">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3006.html">3006</a></td>
+    <td>open</td>
+    <td>Vague restrictions for explicit instantiations of class templates</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3007">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3007.html">3007</a></td>
+    <td>open</td>
+    <td>Access checking during synthesis of defaulted comparison operator, take 2</td>
+    <td align="center">Not resolved</td>
+  </tr>
+  <tr class="open" id="3008">
+    <td><a href="https://cplusplus.github.io/CWG/issues/3008.html">3008</a></td>
+    <td>open</td>
+    <td>Missing Annex C entry for <TT>void</TT> object declarations</td>
     <td align="center">Not resolved</td>
   </tr></table>
 


### PR DESCRIPTION
CWG472 is one of the CWG issues that were assigned to Mike Miller with `drafting` status, but recently got back to `open`, because Mike is no longer active in CWG. Nothing to be done here, except for changing the status.

CWG1432 was recently reopened after a CWG reflector discussion. I changed the status to claim that we test for the previous resolution. 