### PR TITLE
[Driver] Add linker options to support statical linking to shared flang-rt on AIX.

### DIFF
--- a/clang/lib/Driver/ToolChains/AIX.cpp
+++ b/clang/lib/Driver/ToolChains/AIX.cpp
@@ -127,8 +127,15 @@ void aix::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   // Force static linking when "-static" is present.
-  if (Args.hasArg(options::OPT_static))
+  if (Args.hasArg(options::OPT_static)) {
     CmdArgs.push_back("-bnso");
+    // The folllowing linker options are needed to statically link to the
+    // shared libflang_rt.runtime.a on AIX
+    CmdArgs.push_back("-bI:/usr/lib/syscalls.exp");
+    CmdArgs.push_back("-bI:/usr/lib/aio.exp");
+    CmdArgs.push_back("-bI:/usr/lib/threads.exp");
+    CmdArgs.push_back("-lcrypt");
+  }
 
   // Add options for shared libraries.
   if (Args.hasArg(options::OPT_shared)) {

--- a/clang/lib/Driver/ToolChains/AIX.cpp
+++ b/clang/lib/Driver/ToolChains/AIX.cpp
@@ -134,7 +134,6 @@ void aix::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       // The folllowing linker options are needed to statically link to the
       // shared libflang_rt.runtime.a on AIX
       CmdArgs.push_back("-bI:/usr/lib/syscalls.exp");
-      CmdArgs.push_back("-bI:/usr/lib/aio.exp");
       CmdArgs.push_back("-bI:/usr/lib/threads.exp");
       CmdArgs.push_back("-lcrypt");
     }

--- a/clang/lib/Driver/ToolChains/AIX.cpp
+++ b/clang/lib/Driver/ToolChains/AIX.cpp
@@ -129,12 +129,15 @@ void aix::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   // Force static linking when "-static" is present.
   if (Args.hasArg(options::OPT_static)) {
     CmdArgs.push_back("-bnso");
-    // The folllowing linker options are needed to statically link to the
-    // shared libflang_rt.runtime.a on AIX
-    CmdArgs.push_back("-bI:/usr/lib/syscalls.exp");
-    CmdArgs.push_back("-bI:/usr/lib/aio.exp");
-    CmdArgs.push_back("-bI:/usr/lib/threads.exp");
-    CmdArgs.push_back("-lcrypt");
+
+    if (D.IsFlangMode()) {
+      // The folllowing linker options are needed to statically link to the
+      // shared libflang_rt.runtime.a on AIX
+      CmdArgs.push_back("-bI:/usr/lib/syscalls.exp");
+      CmdArgs.push_back("-bI:/usr/lib/aio.exp");
+      CmdArgs.push_back("-bI:/usr/lib/threads.exp");
+      CmdArgs.push_back("-lcrypt");
+    }
   }
 
   // Add options for shared libraries.


### PR DESCRIPTION
This is to support statical linking to shared `flang-rt` on AIX.
Users should be able to do `flang -static t.f`. The `a.out` generated should not have dependencies on the shared libraries. 