### PR TITLE
[analyzer] Remove deprecated option VirtualCall:PureOnly

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -464,6 +464,11 @@ Crash and bug fixes
 Improvements
 ^^^^^^^^^^^^
 
+- The checker option ``optin.cplusplus.VirtualCall:PureOnly`` was removed,
+  because it had been deprecated since 2019 and it has no valid usecase (it had
+  been kept for compatibility with the pre-2019 status, setting it to true is
+  equivalent to completely disabling the checker).
+
 Moved checkers
 ^^^^^^^^^^^^^^
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -465,8 +465,8 @@ Improvements
 ^^^^^^^^^^^^
 
 - The checker option ``optin.cplusplus.VirtualCall:PureOnly`` was removed,
-  because it had been deprecated since 2019 and it has no valid usecase (it had
-  been kept for compatibility with the pre-2019 status, setting it to true is
+  because it had been deprecated since 2019 and it is completely useless (it
+  was kept only for compatibility with pre-2019 versions, setting it to true is
   equivalent to completely disabling the checker).
 
 Moved checkers

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -750,24 +750,14 @@ def UninitializedObjectChecker: Checker<"UninitializedObject">,
   ]>,
   Documentation<HasDocumentation>;
 
-def VirtualCallChecker : Checker<"VirtualCall">,
-  HelpText<"Check virtual function calls during construction/destruction">,
-  CheckerOptions<[
-    CmdLineOption<Boolean,
-                  "ShowFixIts",
-                  "Enable fix-it hints for this checker",
-                  "false",
-                  InAlpha>,
-    CmdLineOption<Boolean,
-                  "PureOnly",
-                  "Disables the checker. Keeps cplusplus.PureVirtualCall "
-                  "enabled. This option is only provided for backwards "
-                  "compatibility.",
-                  "false",
-                  InAlpha>
-  ]>,
-  Dependencies<[VirtualCallModeling]>,
-  Documentation<HasDocumentation>;
+def VirtualCallChecker
+    : Checker<"VirtualCall">,
+      HelpText<"Check virtual function calls during construction/destruction">,
+      CheckerOptions<[CmdLineOption<Boolean, "ShowFixIts",
+                                    "Enable fix-it hints for this checker",
+                                    "false", InAlpha>]>,
+      Dependencies<[VirtualCallModeling]>,
+      Documentation<HasDocumentation>;
 
 } // end: "optin.cplusplus"
 

--- a/clang/lib/StaticAnalyzer/Checkers/VirtualCallChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/VirtualCallChecker.cpp
@@ -214,14 +214,11 @@ void ento::registerPureVirtualCallChecker(CheckerManager &Mgr) {
 
 void ento::registerVirtualCallChecker(CheckerManager &Mgr) {
   auto *Chk = Mgr.getChecker<VirtualCallChecker>();
-  if (!Mgr.getAnalyzerOptions().getCheckerBooleanOption(
-          Mgr.getCurrentCheckerName(), "PureOnly")) {
-    Chk->BT_Impure = std::make_unique<BugType>(
-        Mgr.getCurrentCheckerName(), "Unexpected loss of virtual dispatch",
-        categories::CXXObjectLifecycle);
-    Chk->ShowFixIts = Mgr.getAnalyzerOptions().getCheckerBooleanOption(
-        Mgr.getCurrentCheckerName(), "ShowFixIts");
-  }
+  Chk->BT_Impure = std::make_unique<BugType>(
+      Mgr.getCurrentCheckerName(), "Unexpected loss of virtual dispatch",
+      categories::CXXObjectLifecycle);
+  Chk->ShowFixIts = Mgr.getAnalyzerOptions().getCheckerBooleanOption(
+      Mgr.getCurrentCheckerName(), "ShowFixIts");
 }
 
 bool ento::shouldRegisterVirtualCallModeling(const CheckerManager &mgr) {

--- a/clang/test/Analysis/analyzer-config.c
+++ b/clang/test/Analysis/analyzer-config.c
@@ -108,7 +108,6 @@
 // CHECK-NEXT: optin.cplusplus.UninitializedObject:IgnoreRecordsWithField = ""
 // CHECK-NEXT: optin.cplusplus.UninitializedObject:NotesAsWarnings = false
 // CHECK-NEXT: optin.cplusplus.UninitializedObject:Pedantic = false
-// CHECK-NEXT: optin.cplusplus.VirtualCall:PureOnly = false
 // CHECK-NEXT: optin.cplusplus.VirtualCall:ShowFixIts = false
 // CHECK-NEXT: optin.osx.cocoa.localizability.NonLocalizedStringChecker:AggressiveReport = false
 // CHECK-NEXT: optin.performance.Padding:AllowedPad = 24

--- a/clang/test/Analysis/virtualcall.cpp
+++ b/clang/test/Analysis/virtualcall.cpp
@@ -6,28 +6,10 @@
 // RUN:                    -analyzer-checker=debug.ExprInspection \
 // RUN:                    -std=c++11 -verify=pure -std=c++11 %s
 
-// RUN: %clang_analyze_cc1 -analyzer-checker=core,optin.cplusplus.VirtualCall \
-// RUN:                    -analyzer-config \
-// RUN:                        optin.cplusplus.VirtualCall:PureOnly=true \
-// RUN:                    -analyzer-checker=debug.ExprInspection \
-// RUN:                    -std=c++11 -verify=none %s
-
 // RUN: %clang_analyze_cc1 -analyzer-checker=core,cplusplus.PureVirtualCall \
 // RUN:                    -analyzer-checker=optin.cplusplus.VirtualCall \
 // RUN:                    -analyzer-checker=debug.ExprInspection \
 // RUN:                    -std=c++11 -verify=pure,impure -std=c++11 %s
-
-// RUN: %clang_analyze_cc1 -analyzer-checker=core,cplusplus.PureVirtualCall \
-// RUN:                    -analyzer-checker=optin.cplusplus.VirtualCall \
-// RUN:                    -analyzer-config \
-// RUN:                        optin.cplusplus.VirtualCall:PureOnly=true \
-// RUN:                    -analyzer-checker=debug.ExprInspection \
-// RUN:                    -std=c++11 -verify=pure %s
-
-
-// We expect no diagnostics when all checks are disabled.
-// none-no-diagnostics
-
 
 #include "virtualcall.h"
 


### PR DESCRIPTION
VirtualCallChecker.cpp implements two related checkers:
 - `optin.cplusplus.VirtualCall` which reports situations when constructors or destructors call virtual methods (which is bugprone because it does not trigger virtual dispatch, but can be legitmate).
 - `cplusplus.PureVirtualCall` reports situations when constructors or destructors call _pure_ virtual methods, which is an error.

Six years ago these two bug types were both reported by the same checker (called `optin.cplusplus.VirtualCall`) and it had an option called `PureOnly` which limited its output to the pure case.

When (in 2019) the two checker parts were separated by the commit d3971fe97b64785c079d64bf4c8c3e2b5e1f85a1, the option `PureOnly` was preserved for the sake of compatibility, but it is no longer useful (when it is set to true, it just suppresses all reports from `optin.cplusplus.VirtualCall`) so it was marked as deprecated.

I'm removing this deprecated option now because it is no longer relevant and its presence caused minor complications when I was porting `VirtualCallChecker.cpp` to the new multipart checker framework (introduced in 27099982da2f5a6c2d282d6b385e79d080669546).