### PR TITLE
Thread Safety Analysis: Check managed capabilities of returned scoped capability

### DIFF
--- a/clang/include/clang/Analysis/Analyses/ThreadSafety.h
+++ b/clang/include/clang/Analysis/Analyses/ThreadSafety.h
@@ -243,10 +243,13 @@ public:
   /// \param Kind -- The kind of the expected mutex.
   /// \param Expected -- The name of the expected mutex.
   /// \param Actual -- The name of the actual mutex.
+  /// \param ForParam -- Indicates whether the note applies to a function
+  /// parameter.
   virtual void handleUnmatchedUnderlyingMutexes(SourceLocation Loc,
                                                 SourceLocation DLoc,
                                                 Name ScopeName, StringRef Kind,
-                                                Name Expected, Name Actual) {}
+                                                Name Expected, Name Actual,
+                                                bool ForParam) {}
 
   /// Warn when we get fewer underlying mutexes than expected.
   /// \param Loc -- The location of the call expression.
@@ -254,10 +257,13 @@ public:
   /// \param ScopeName -- The name of the scope passed to the function.
   /// \param Kind -- The kind of the expected mutex.
   /// \param Expected -- The name of the expected mutex.
+  /// \param ForParam -- Indicates whether the note applies to a function
+  /// parameter.
   virtual void handleExpectMoreUnderlyingMutexes(SourceLocation Loc,
                                                  SourceLocation DLoc,
                                                  Name ScopeName, StringRef Kind,
-                                                 Name Expected) {}
+                                                 Name Expected, bool ForParam) {
+  }
 
   /// Warn when we get more underlying mutexes than expected.
   /// \param Loc -- The location of the call expression.
@@ -265,11 +271,13 @@ public:
   /// \param ScopeName -- The name of the scope passed to the function.
   /// \param Kind -- The kind of the actual mutex.
   /// \param Actual -- The name of the actual mutex.
+  /// \param ForParam -- Indicates whether the note applies to a function
+  /// parameter.
   virtual void handleExpectFewerUnderlyingMutexes(SourceLocation Loc,
                                                   SourceLocation DLoc,
                                                   Name ScopeName,
-                                                  StringRef Kind, Name Actual) {
-  }
+                                                  StringRef Kind, Name Actual,
+                                                  bool ForParam) {}
 
   /// Warn that L1 cannot be acquired before L2.
   virtual void handleLockAcquiredBefore(StringRef Kind, Name L1Name,

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -4117,8 +4117,8 @@ def warn_expect_more_underlying_mutexes : Warning<
 def warn_expect_fewer_underlying_mutexes : Warning<
   "did not expect %0 '%2' to be managed by '%1'">,
   InGroup<ThreadSafetyAnalysis>, DefaultIgnore;
-def note_managed_mismatch_here_for_param : Note<
-  "see attribute on parameter here">;
+def note_managed_mismatch_here : Note<
+  "see attribute on %select{function|parameter}0 here">;
 
 
 // Thread safety warnings negative capabilities

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -1799,11 +1799,11 @@ class ThreadSafetyReporter : public clang::threadSafety::ThreadSafetyHandler {
                : getNotes();
   }
 
-  OptionalNotes makeManagedMismatchNoteForParam(SourceLocation DeclLoc) {
+  OptionalNotes makeManagedMismatchNote(SourceLocation DeclLoc, bool forParam) {
     return DeclLoc.isValid()
                ? getNotes(PartialDiagnosticAt(
-                     DeclLoc,
-                     S.PDiag(diag::note_managed_mismatch_here_for_param)))
+                     DeclLoc, S.PDiag(diag::note_managed_mismatch_here)
+                                  << forParam))
                : getNotes();
   }
 
@@ -1829,34 +1829,35 @@ class ThreadSafetyReporter : public clang::threadSafety::ThreadSafetyHandler {
 
   void handleUnmatchedUnderlyingMutexes(SourceLocation Loc, SourceLocation DLoc,
                                         Name scopeName, StringRef Kind,
-                                        Name expected, Name actual) override {
+                                        Name expected, Name actual,
+                                        bool forParam) override {
     PartialDiagnosticAt Warning(Loc,
                                 S.PDiag(diag::warn_unmatched_underlying_mutexes)
                                     << Kind << scopeName << expected << actual);
     Warnings.emplace_back(std::move(Warning),
-                          makeManagedMismatchNoteForParam(DLoc));
+                          makeManagedMismatchNote(DLoc, forParam));
   }
 
   void handleExpectMoreUnderlyingMutexes(SourceLocation Loc,
                                          SourceLocation DLoc, Name scopeName,
-                                         StringRef Kind,
-                                         Name expected) override {
+                                         StringRef Kind, Name expected,
+                                         bool forParam) override {
     PartialDiagnosticAt Warning(
         Loc, S.PDiag(diag::warn_expect_more_underlying_mutexes)
                  << Kind << scopeName << expected);
     Warnings.emplace_back(std::move(Warning),
-                          makeManagedMismatchNoteForParam(DLoc));
+                          makeManagedMismatchNote(DLoc, forParam));
   }
 
   void handleExpectFewerUnderlyingMutexes(SourceLocation Loc,
                                           SourceLocation DLoc, Name scopeName,
-                                          StringRef Kind,
-                                          Name actual) override {
+                                          StringRef Kind, Name actual,
+                                          bool forParam) override {
     PartialDiagnosticAt Warning(
         Loc, S.PDiag(diag::warn_expect_fewer_underlying_mutexes)
                  << Kind << scopeName << actual);
     Warnings.emplace_back(std::move(Warning),
-                          makeManagedMismatchNoteForParam(DLoc));
+                          makeManagedMismatchNote(DLoc, forParam));
   }
 
   void handleInvalidLockExp(SourceLocation Loc) override {


### PR DESCRIPTION
Verify that the return value of type scoped lockable manages the mutexes expected by the function annotations.