### PR TITLE
[ADT] Add DenseSet(llvm::from_t, Range)

### DIFF
--- a/llvm/include/llvm/ADT/DenseSet.h
+++ b/llvm/include/llvm/ADT/DenseSet.h
@@ -17,6 +17,7 @@
 #include "llvm/ADT/ADL.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/type_traits.h"
 #include <cstddef>
@@ -77,6 +78,10 @@ public:
       : DenseSetImpl(PowerOf2Ceil(Elems.size())) {
     insert(Elems.begin(), Elems.end());
   }
+
+  template <typename Range>
+  DenseSetImpl(llvm::from_range_t, Range &&R)
+      : DenseSetImpl(adl_begin(R), adl_end(R)) {}
 
   bool empty() const { return TheMap.empty(); }
   size_type size() const { return TheMap.size(); }

--- a/llvm/include/llvm/ADT/STLForwardCompat.h
+++ b/llvm/include/llvm/ADT/STLForwardCompat.h
@@ -67,6 +67,12 @@ template <typename Enum>
   return static_cast<std::underlying_type_t<Enum>>(E);
 }
 
+// A tag for constructors accepting ranges.
+struct from_range_t {
+  explicit from_range_t() = default;
+};
+inline constexpr from_range_t from_range{};
+
 } // namespace llvm
 
 #endif // LLVM_ADT_STLFORWARDCOMPAT_H

--- a/llvm/unittests/ADT/DenseSetTest.cpp
+++ b/llvm/unittests/ADT/DenseSetTest.cpp
@@ -39,6 +39,12 @@ TEST(DenseSetTest, CtorRange) {
   EXPECT_THAT(set, ::testing::UnorderedElementsAre(1, 2, 3));
 }
 
+TEST(DenseSetTest, CtorRangeImplicitConversion) {
+  constexpr char Args[] = {3, 1, 2};
+  llvm::DenseSet<unsigned> set(llvm::from_range, Args);
+  EXPECT_THAT(set, ::testing::UnorderedElementsAre(1, 2, 3));
+}
+
 TEST(SmallDenseSetTest, CtorRange) {
   constexpr unsigned Args[] = {9, 7, 8};
   llvm::SmallDenseSet<unsigned> set(llvm::from_range, Args);

--- a/llvm/unittests/ADT/DenseSetTest.cpp
+++ b/llvm/unittests/ADT/DenseSetTest.cpp
@@ -39,6 +39,12 @@ TEST(DenseSetTest, CtorRange) {
   EXPECT_THAT(set, ::testing::UnorderedElementsAre(1, 2, 3));
 }
 
+TEST(SmallDenseSetTest, CtorRange) {
+  constexpr unsigned Args[] = {9, 7, 8};
+  llvm::SmallDenseSet<unsigned> set(llvm::from_range, Args);
+  EXPECT_THAT(set, ::testing::UnorderedElementsAre(7, 8, 9));
+}
+
 TEST(DenseSetTest, InsertRange) {
   llvm::DenseSet<unsigned> set;
   constexpr unsigned Args[] = {3, 1, 2};

--- a/llvm/unittests/ADT/DenseSetTest.cpp
+++ b/llvm/unittests/ADT/DenseSetTest.cpp
@@ -33,6 +33,12 @@ TEST(DenseSetTest, DoubleEntrySetTest) {
   EXPECT_EQ(0u, set.count(2));
 }
 
+TEST(DenseSetTest, CtorRange) {
+  constexpr unsigned Args[] = {3, 1, 2};
+  llvm::DenseSet<unsigned> set(llvm::from_range, Args);
+  EXPECT_THAT(set, ::testing::UnorderedElementsAre(1, 2, 3));
+}
+
 TEST(DenseSetTest, InsertRange) {
   llvm::DenseSet<unsigned> set;
   constexpr unsigned Args[] = {3, 1, 2};


### PR DESCRIPTION
This patch adds a constructor of the form:

  DenseSet Set(llvm::from_range, Range)

while forward-porting std::from_range from c++23.
