### PR TITLE
[Docs] Fix concat vectors

### DIFF
--- a/llvm/docs/GlobalISel/GenericOpcode.rst
+++ b/llvm/docs/GlobalISel/GenericOpcode.rst
@@ -729,8 +729,8 @@ Concatenate vectors to form a longer vector.
 
 .. code-block:: none
 
-  %4:_(<16 x i32>) = G_CONCAT_VECTORS %3:_(<4 x i32>), %2:_(<4 x i32>),
-                                      %1:_(<4 x i32>), %0:_(<4 x i32>)
+  %4:_(<16 x i32>) = G_CONCAT_VECTORS %0:_(<4 x i32>), %1:_(<4 x i32>),
+                                      %2:_(<4 x i32>), %3:_(<4 x i32>)
 
 
 G_BUILD_VECTOR, G_BUILD_VECTOR_TRUNC

--- a/llvm/docs/GlobalISel/GenericOpcode.rst
+++ b/llvm/docs/GlobalISel/GenericOpcode.rst
@@ -725,7 +725,13 @@ Mixing scalable vectors and fixed vectors are not allowed.
 G_CONCAT_VECTORS
 ^^^^^^^^^^^^^^^^
 
-Concatenate two vectors to form a longer vector.
+Concatenate vectors to form a longer vector.
+
+.. code-block:: none
+
+  %4:_(<16 x i32>) = G_CONCAT_VECTORS %3:_(<4 x i32>), %2:_(<4 x i32>),
+                                      %1:_(<4 x i32>), %0:_(<4 x i32>)
+
 
 G_BUILD_VECTOR, G_BUILD_VECTOR_TRUNC
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
GenericOpcodes.td states that the number of operands are variadic.

let InOperandList = (ins type1:$src0, variable_ops);

X86 supports up to 4 inputs. The example uses 512-bit aka AVX-512 to make it look real and show the effect of the ~many operands.

Test plan: ninja docs-llvm-html