### PR TITLE
[flang] accept character type in fir::changeTypeShape

### DIFF
--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -1326,7 +1326,8 @@ changeTypeShape(mlir::Type type,
       })
       .Default([&](mlir::Type t) -> mlir::Type {
         assert((fir::isa_trivial(t) || llvm::isa<fir::RecordType>(t) ||
-                llvm::isa<mlir::NoneType>(t)) &&
+                llvm::isa<mlir::NoneType>(t) ||
+                llvm::isa<fir::CharacterType>(t)) &&
                "unexpected FIR leaf type");
         if (newShape)
           return fir::SequenceType::get(*newShape, t);

--- a/flang/test/HLFIR/order_assignments/forall-pointer-assignment-scheduling.f90
+++ b/flang/test/HLFIR/order_assignments/forall-pointer-assignment-scheduling.f90
@@ -85,6 +85,21 @@ end subroutine
 ! CHECK-NEXT: conflict: R/W
 ! CHECK-NEXT: run 1 save    : forall/region_assign1/lhs
 ! CHECK-NEXT: run 2 evaluate: forall/region_assign1
+
+subroutine test_character_no_conflict(c)
+ type tc
+    character(10), pointer :: p
+ end type
+ character(10), target :: c(10)
+ integer(8) :: i
+ type(tc) a(10)
+ forall(i=1:10)
+   a(i)%p => c(i)
+ end forall
+end subroutine
+! CHECK: ------------ scheduling forall in _QMforall_pointersPtest_character_no_conflict ------------
+! CHECK-NEXT: run 1 evaluate: forall/region_assign1
+
 end module
 
 ! End to end test provided for debugging purpose (not run by lit).


### PR DESCRIPTION
There is no reason for character element type to be forbidden in this helper.
The assert was firing in character pointer assignment in FORALL after #130772 added a usage of this helper.