### PR TITLE
[libc] Disable dl_iterate_phdr entrypoint for linux fullbuild

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -842,9 +842,6 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.arpa.inet.ntohl
     libc.src.arpa.inet.ntohs
 
-    # link.h entrypoints
-    libc.src.link.dl_iterate_phdr
-
     # pthread.h entrypoints
     libc.src.pthread.pthread_atfork
     libc.src.pthread.pthread_attr_destroy

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -795,9 +795,6 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.arpa.inet.ntohl
     libc.src.arpa.inet.ntohs
 
-    # link.h entrypoints
-    libc.src.link.dl_iterate_phdr
-
     # pthread.h entrypoints
     libc.src.pthread.pthread_atfork
     libc.src.pthread.pthread_attr_destroy

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -960,9 +960,6 @@ if(LLVM_LIBC_FULL_BUILD)
     libc.src.arpa.inet.ntohl
     libc.src.arpa.inet.ntohs
 
-    # link.h entrypoints
-    libc.src.link.dl_iterate_phdr
-
     # pthread.h entrypoints
     libc.src.pthread.pthread_atfork
     libc.src.pthread.pthread_attr_destroy


### PR DESCRIPTION
There are some issues with typedef conflicts between libc headers
and Linux kernel headers arising.  Disable building the new code
for Linux for now.
