### PR TITLE
[TableGen][MCSched] Update error messages on the range of Acquire/ReleaseAtCycle

### DIFF
--- a/llvm/test/TableGen/AcquireAtCycle.td
+++ b/llvm/test/TableGen/AcquireAtCycle.td
@@ -55,8 +55,7 @@ def : WriteRes<WriteInst_B, [ResX2]> {
     let ReleaseAtCycles = [1];
 }
 def : WriteRes<WriteInst_C, [ResX0]> {
-// Both AcquireAtCycle and ReleaseAtCycle are allowed
-// to be zero at the same time.
+// AcquireAtCycle and ReleaseAtCycle are allowed to be the same.
 // CORRECT-NEXT: { 1, 0, 0} // #5
     let ReleaseAtCycles = [0];
 }

--- a/llvm/test/TableGen/AcquireAtCycle.td
+++ b/llvm/test/TableGen/AcquireAtCycle.td
@@ -26,6 +26,7 @@ def ResX2 : ProcResource<1>; // X2
 let OutOperandList = (outs), InOperandList = (ins) in {
   def Inst_A : Instruction;
   def Inst_B : Instruction;
+  def Inst_C : Instruction;
 }
 
 let CompleteModel = 0 in {
@@ -34,6 +35,7 @@ let CompleteModel = 0 in {
 
 def WriteInst_A : SchedWrite;
 def WriteInst_B : SchedWrite;
+def WriteInst_C : SchedWrite;
 
 let SchedModel = SchedModel_A in {
 // Check the generated data when there are no semantic issues.
@@ -49,8 +51,14 @@ def : WriteRes<WriteInst_A, [ResX0, ResX1, ResX2]> {
 }
 def : WriteRes<WriteInst_B, [ResX2]> {
 // If unspecified, AcquireAtCycle is set to 0.
-// CORRECT-NEXT: { 3, 1, 0} // #4
+// CORRECT-NEXT: { 3, 1, 0}, // #4
     let ReleaseAtCycles = [1];
+}
+def : WriteRes<WriteInst_C, [ResX0]> {
+// Both AcquireAtCycle and ReleaseAtCycle are allowed
+// to be zero at the same time.
+// CORRECT-NEXT: { 1, 0, 0} // #5
+    let ReleaseAtCycles = [0];
 }
 #endif // CORRECT
 
@@ -63,7 +71,7 @@ def : WriteRes<WriteInst_A, [ResX0, ResX1, ResX2]> {
 #endif
 
 #ifdef WRONG_VALUE
-// WRONG_VALUE: AcquireAtCycle.td:[[@LINE+1]]:1: error: Inconsistent resource cycles: AcquireAtCycles < ReleaseAtCycles must hold
+// WRONG_VALUE: AcquireAtCycle.td:[[@LINE+1]]:1: error: Inconsistent resource cycles: AcquireAtCycles <= ReleaseAtCycles must hold
 def : WriteRes<WriteInst_A, [ResX0, ResX1, ResX2]> {
     let ReleaseAtCycles = [2, 4, 3];
     let AcquireAtCycles = [0, 1, 8];
@@ -80,6 +88,7 @@ def : WriteRes<WriteInst_A, [ResX0]> {
 
 def : InstRW<[WriteInst_A], (instrs Inst_A)>;
 def : InstRW<[WriteInst_B], (instrs Inst_B)>;
+def : InstRW<[WriteInst_C], (instrs Inst_C)>;
 }
 
 def ProcessorA: ProcessorModel<"ProcessorA", SchedModel_A, []>;

--- a/llvm/utils/TableGen/SubtargetEmitter.cpp
+++ b/llvm/utils/TableGen/SubtargetEmitter.cpp
@@ -1245,7 +1245,7 @@ void SubtargetEmitter::genSchedClassTables(const CodeGenProcModel &ProcModel,
             PrintFatalError(
                 WriteRes->getLoc(),
                 Twine("Inconsistent resource cycles: AcquireAtCycles "
-                      "< ReleaseAtCycles must hold."));
+                      "<= ReleaseAtCycles must hold."));
           }
           if (AcquireAtCycles[PRIdx] < 0) {
             PrintFatalError(WriteRes->getLoc(),


### PR DESCRIPTION
I was looking at the value range of AcquireAtCycle / ReleaseAtCycle, and I noticed that while the TableGen error messages said AcquireAtCycle has to be less than ReleaseAtCycle, in reality they are actually allowed to be the same. This patch fixes it and add more test cases.