### PR TITLE
[CIR] Upstream support for type aliases

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -31,6 +31,20 @@ struct CIROpAsmDialectInterface : public OpAsmDialectInterface {
   using OpAsmDialectInterface::OpAsmDialectInterface;
 
   AliasResult getAlias(Type type, raw_ostream &os) const final {
+    if (auto intType = dyn_cast<cir::IntType>(type)) {
+      // We only provide alias for standard integer types (i.e. integer types
+      // whose width is a power of 2 and at least 8).
+      unsigned width = intType.getWidth();
+      if (width < 8 || !llvm::isPowerOf2_32(width))
+        return AliasResult::NoAlias;
+      os << intType.getAlias();
+      return AliasResult::OverridableAlias;
+    }
+    if (auto voidType = dyn_cast<cir::VoidType>(type)) {
+      os << voidType.getAlias();
+      return AliasResult::OverridableAlias;
+    }
+
     return AliasResult::NoAlias;
   }
 

--- a/clang/test/CIR/CodeGen/array.cpp
+++ b/clang/test/CIR/CodeGen/array.cpp
@@ -1,41 +1,41 @@
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o - 2>&1 | FileCheck %s
 
 int a[10];
-// CHECK: cir.global external @a : !cir.array<!cir.int<s, 32> x 10>
+// CHECK: cir.global external @a : !cir.array<!s32i x 10>
 
 int aa[10][5];
-// CHECK: cir.global external @aa : !cir.array<!cir.array<!cir.int<s, 32> x 5> x 10>
+// CHECK: cir.global external @aa : !cir.array<!cir.array<!s32i x 5> x 10>
 
 extern int b[10];
-// CHECK: cir.global external @b : !cir.array<!cir.int<s, 32> x 10>
+// CHECK: cir.global external @b : !cir.array<!s32i x 10>
 
 extern int bb[10][5];
-// CHECK: cir.global external @bb : !cir.array<!cir.array<!cir.int<s, 32> x 5> x 10>
+// CHECK: cir.global external @bb : !cir.array<!cir.array<!s32i x 5> x 10>
 
 int c[10] = {};
-// CHECK: cir.global external @c = #cir.zero : !cir.array<!cir.int<s, 32> x 10>
+// CHECK: cir.global external @c = #cir.zero : !cir.array<!s32i x 10>
 
 int d[3] = {1, 2, 3};
-// CHECK: cir.global external @d = #cir.const_array<[#cir.int<1> : !cir.int<s, 32>, #cir.int<2> : !cir.int<s, 32>, #cir.int<3> : !cir.int<s, 32>]> : !cir.array<!cir.int<s, 32> x 3>
+// CHECK: cir.global external @d = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i]> : !cir.array<!s32i x 3>
 
 int dd[3][2] = {{1, 2}, {3, 4}, {5, 6}};
-// CHECK: cir.global external @dd = #cir.const_array<[#cir.const_array<[#cir.int<1> : !cir.int<s, 32>, #cir.int<2> : !cir.int<s, 32>]> : !cir.array<!cir.int<s, 32> x 2>, #cir.const_array<[#cir.int<3> : !cir.int<s, 32>, #cir.int<4> : !cir.int<s, 32>]> : !cir.array<!cir.int<s, 32> x 2>, #cir.const_array<[#cir.int<5> : !cir.int<s, 32>, #cir.int<6> : !cir.int<s, 32>]> : !cir.array<!cir.int<s, 32> x 2>]> : !cir.array<!cir.array<!cir.int<s, 32> x 2> x 3>
+// CHECK: cir.global external @dd = #cir.const_array<[#cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<3> : !s32i, #cir.int<4> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<5> : !s32i, #cir.int<6> : !s32i]> : !cir.array<!s32i x 2>]> : !cir.array<!cir.array<!s32i x 2> x 3>
 
 int e[10] = {1, 2};
-// CHECK: cir.global external @e = #cir.const_array<[#cir.int<1> : !cir.int<s, 32>, #cir.int<2> : !cir.int<s, 32>], trailing_zeros> : !cir.array<!cir.int<s, 32> x 10>
+// CHECK: cir.global external @e = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i], trailing_zeros> : !cir.array<!s32i x 10>
 
 int f[5] = {1, 2};
-// CHECK: cir.global external @f = #cir.const_array<[#cir.int<1> : !cir.int<s, 32>, #cir.int<2> : !cir.int<s, 32>, #cir.int<0> : !cir.int<s, 32>, #cir.int<0> : !cir.int<s, 32>, #cir.int<0> : !cir.int<s, 32>]> : !cir.array<!cir.int<s, 32> x 5>
+// CHECK: cir.global external @f = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<0> : !s32i, #cir.int<0> : !s32i, #cir.int<0> : !s32i]> : !cir.array<!s32i x 5>
 
 void func() {
   int l[10];
-  // CHECK: %[[ARR:.*]] = cir.alloca !cir.array<!cir.int<s, 32> x 10>, !cir.ptr<!cir.array<!cir.int<s, 32> x 10>>, ["l"]
+  // CHECK: %[[ARR:.*]] = cir.alloca !cir.array<!s32i x 10>, !cir.ptr<!cir.array<!s32i x 10>>, ["l"]
 }
 
 void func2(int p[10]) {}
-// CHECK: cir.func @func2(%arg0: !cir.ptr<!cir.int<s, 32>>
-// CHECK: cir.alloca !cir.ptr<!cir.int<s, 32>>, !cir.ptr<!cir.ptr<!cir.int<s, 32>>>, ["p", init]
+// CHECK: cir.func @func2(%arg0: !cir.ptr<!s32i>
+// CHECK: cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["p", init]
 
 void func3(int pp[10][5]) {}
-// CHECK: cir.func @func3(%arg0: !cir.ptr<!cir.array<!cir.int<s, 32> x 5>>
-// CHECK: cir.alloca !cir.ptr<!cir.array<!cir.int<s, 32> x 5>>, !cir.ptr<!cir.ptr<!cir.array<!cir.int<s, 32> x 5>>>
+// CHECK: cir.func @func3(%arg0: !cir.ptr<!cir.array<!s32i x 5>>
+// CHECK: cir.alloca !cir.ptr<!cir.array<!s32i x 5>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 5>>>

--- a/clang/test/CIR/CodeGen/basic.c
+++ b/clang/test/CIR/CodeGen/basic.c
@@ -13,17 +13,15 @@ int f1(int i) {
 }
 
 //      CIR: module
-// CIR-NEXT: cir.func @f1(%arg0: !cir.int<s, 32> loc({{.*}})) -> !cir.int<s, 32>
-// CIR-NEXT:   %[[I_PTR:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["i", init] {alignment = 4 : i64}
-// CIR-NEXT:   %[[RV:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["__retval"] {alignment = 4 : i64}
-// CIR-NEXT:   cir.store %arg0, %[[I_PTR]] : !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>
-// CIR-NEXT:   %[[I_IGNORED:.*]] = cir.load %[[I_PTR]] : !cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>
-// CIR-NEXT:   %[[I:.*]] = cir.load %[[I_PTR]] : !cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>
-// CIR-NEXT:   cir.store %[[I]], %[[RV]] : !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>
-// CIR-NEXT:   cir.br ^[[BB1:[^ ]+]]
-// CIR-NEXT: ^[[BB1]]:
-// CIR-NEXT:   %[[R:.*]] = cir.load %[[RV]] : !cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>
-// CIR-NEXT:   cir.return %[[R]] : !cir.int<s, 32>
+// CIR-NEXT: cir.func @f1(%arg0: !s32i loc({{.*}})) -> !s32i
+// CIR-NEXT:   %[[I_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
+// CIR-NEXT:   %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
+// CIR-NEXT:   cir.store %arg0, %[[I_PTR]] : !s32i, !cir.ptr<!s32i>
+// CIR-NEXT:   %[[I_IGNORED:.*]] = cir.load %[[I_PTR]] : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:   %[[I:.*]] = cir.load %[[I_PTR]] : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:   cir.store %[[I]], %[[RV]] : !s32i, !cir.ptr<!s32i>
+// CIR-NEXT:   %[[R:.*]] = cir.load %[[RV]] : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:   cir.return %[[R]] : !s32i
 
 //      LLVM: define i32 @f1(i32 %[[IP:.*]])
 // LLVM-NEXT:   %[[I_PTR:.*]] = alloca i32, i64 1, align 4
@@ -32,8 +30,6 @@ int f1(int i) {
 // LLVM-NEXT:   %[[I_IGNORED:.*]] = load i32, ptr %[[I_PTR]], align 4
 // LLVM-NEXT:   %[[I:.*]] = load i32, ptr %[[I_PTR]], align 4
 // LLVM-NEXT:   store i32 %[[I]], ptr %[[RV]], align 4
-// LLVM-NEXT:   br label %[[BB1:.*]]
-//      LLVM: [[BB1]]:
 // LLVM-NEXT:   %[[R:.*]] = load i32, ptr %[[RV]], align 4
 // LLVM-NEXT:   ret i32 %[[R]]
 
@@ -47,20 +43,16 @@ int f1(int i) {
 
 int f2(void) { return 3; }
 
-//      CIR: cir.func @f2() -> !cir.int<s, 32>
-// CIR-NEXT:   %[[RV:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["__retval"] {alignment = 4 : i64}
-// CIR-NEXT:   %[[THREE:.*]] = cir.const #cir.int<3> : !cir.int<s, 32>
-// CIR-NEXT:   cir.store %[[THREE]], %[[RV]] : !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>
-// CIR-NEXT:   cir.br ^[[BB1:[^ ]+]]
-// CIR-NEXT: ^[[BB1]]:
-// CIR-NEXT:   %[[R:.*]] = cir.load %0 : !cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>
-// CIR-NEXT:   cir.return %[[R]] : !cir.int<s, 32>
+//      CIR: cir.func @f2() -> !s32i
+// CIR-NEXT:   %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
+// CIR-NEXT:   %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
+// CIR-NEXT:   cir.store %[[THREE]], %[[RV]] : !s32i, !cir.ptr<!s32i>
+// CIR-NEXT:   %[[R:.*]] = cir.load %0 : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:   cir.return %[[R]] : !s32i
 
 //      LLVM: define i32 @f2()
 // LLVM-NEXT:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM-NEXT:   store i32 3, ptr %[[RV]], align 4
-// LLVM-NEXT:   br label %[[BB1:.*]]
-//      LLVM: [[BB1]]:
 // LLVM-NEXT:   %[[R:.*]] = load i32, ptr %[[RV]], align 4
 // LLVM-NEXT:   ret i32 %[[R]]
 
@@ -73,17 +65,15 @@ int f3(void) {
   return i;
 }
 
-//      CIR: cir.func @f3() -> !cir.int<s, 32>
-// CIR-NEXT:   %[[RV:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["__retval"] {alignment = 4 : i64}
-// CIR-NEXT:   %[[I_PTR:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["i", init] {alignment = 4 : i64}
-// CIR-NEXT:   %[[THREE:.*]] = cir.const #cir.int<3> : !cir.int<s, 32>
-// CIR-NEXT:   cir.store %[[THREE]], %[[I_PTR]] : !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>
-// CIR-NEXT:   %[[I:.*]] = cir.load %[[I_PTR]] : !cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>
-// CIR-NEXT:   cir.store %[[I]], %[[RV]] : !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>
-// CIR-NEXT:   cir.br ^[[BB1:[^ ]+]]
-// CIR-NEXT: ^[[BB1]]:
-// CIR-NEXT:   %[[R:.*]] = cir.load %[[RV]] : !cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>
-// CIR-NEXT:   cir.return %[[R]] : !cir.int<s, 32>
+//      CIR: cir.func @f3() -> !s32i
+// CIR-NEXT:   %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
+// CIR-NEXT:   %[[I_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
+// CIR-NEXT:   %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
+// CIR-NEXT:   cir.store %[[THREE]], %[[I_PTR]] : !s32i, !cir.ptr<!s32i>
+// CIR-NEXT:   %[[I:.*]] = cir.load %[[I_PTR]] : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:   cir.store %[[I]], %[[RV]] : !s32i, !cir.ptr<!s32i>
+// CIR-NEXT:   %[[R:.*]] = cir.load %[[RV]] : !cir.ptr<!s32i>, !s32i
+// CIR-NEXT:   cir.return %[[R]] : !s32i
 
 //      LLVM: define i32 @f3()
 // LLVM-NEXT:   %[[RV:.*]] = alloca i32, i64 1, align 4
@@ -91,8 +81,6 @@ int f3(void) {
 // LLVM-NEXT:   store i32 3, ptr %[[I_PTR]], align 4
 // LLVM-NEXT:   %[[I:.*]] = load i32, ptr %[[I_PTR]], align 4
 // LLVM-NEXT:   store i32 %[[I]], ptr %[[RV]], align 4
-// LLVM-NEXT:   br label %[[BB1:.*]]
-//      LLVM: [[BB1]]:
 // LLVM-NEXT:   %[[R:.*]] = load i32, ptr %[[RV]], align 4
 // LLVM-NEXT:   ret i32 %[[R]]
 

--- a/clang/test/CIR/CodeGen/basic.cpp
+++ b/clang/test/CIR/CodeGen/basic.cpp
@@ -6,51 +6,51 @@ int f1() {
 }
 
 // CHECK: module
-// CHECK: cir.func @f1() -> !cir.int<s, 32>
-// CHECK:    %[[RV:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["__retval"] {alignment = 4 : i64}
-// CHECK:    %[[I_PTR:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["i"] {alignment = 4 : i64}
-// CHECK:    %[[I:.*]] = cir.load %[[I_PTR]] : !cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>
-// CHECK:    cir.store %[[I]], %[[RV]] : !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>
-// CHECK:    %[[R:.*]] = cir.load %[[RV]] : !cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>
-// CHECK:    cir.return %[[R]] : !cir.int<s, 32>
+// CHECK: cir.func @f1() -> !s32i
+// CHECK:    %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
+// CHECK:    %[[I_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i"] {alignment = 4 : i64}
+// CHECK:    %[[I:.*]] = cir.load %[[I_PTR]] : !cir.ptr<!s32i>, !s32i
+// CHECK:    cir.store %[[I]], %[[RV]] : !s32i, !cir.ptr<!s32i>
+// CHECK:    %[[R:.*]] = cir.load %[[RV]] : !cir.ptr<!s32i>, !s32i
+// CHECK:    cir.return %[[R]] : !s32i
 
 int f2() {
   const int i = 2;
   return i;
 }
 
-// CHECK: cir.func @f2() -> !cir.int<s, 32>
-// CHECK:    %[[RV:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["__retval"] {alignment = 4 : i64}
-// CHECK:    %[[I_PTR:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["i", init, const] {alignment = 4 : i64}
-// CHECK:    %[[TWO:.*]] = cir.const #cir.int<2> : !cir.int<s, 32>
-// CHECK:    cir.store %[[TWO]], %[[I_PTR]] : !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>
-// CHECK:    %[[I:.*]] = cir.load %[[I_PTR]] : !cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>
-// CHECK:    cir.store %[[I]], %[[RV]] : !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>
-// CHECK:    %[[R:.*]] = cir.load %[[RV]] : !cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>
-// CHECK:    cir.return %[[R]] : !cir.int<s, 32>
+// CHECK: cir.func @f2() -> !s32i
+// CHECK:    %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
+// CHECK:    %[[I_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init, const] {alignment = 4 : i64}
+// CHECK:    %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
+// CHECK:    cir.store %[[TWO]], %[[I_PTR]] : !s32i, !cir.ptr<!s32i>
+// CHECK:    %[[I:.*]] = cir.load %[[I_PTR]] : !cir.ptr<!s32i>, !s32i
+// CHECK:    cir.store %[[I]], %[[RV]] : !s32i, !cir.ptr<!s32i>
+// CHECK:    %[[R:.*]] = cir.load %[[RV]] : !cir.ptr<!s32i>, !s32i
+// CHECK:    cir.return %[[R]] : !s32i
 
 int f3(int i) {
   return i;
 }
 
-// CHECK: cir.func @f3(%[[ARG:.*]]: !cir.int<s, 32> loc({{.*}})) -> !cir.int<s, 32>
-// CHECK:   %[[ARG_ALLOCA:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["i", init] {alignment = 4 : i64}
-// CHECK:   %[[RV:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["__retval"] {alignment = 4 : i64}
-// CHECK:   cir.store %[[ARG]], %[[ARG_ALLOCA]] : !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>
-// CHECK:   %[[ARG_VAL:.*]] = cir.load %[[ARG_ALLOCA]] : !cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>
-// CHECK:   cir.store %[[ARG_VAL]], %[[RV]] : !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>
-// CHECK:   %[[R:.*]] = cir.load %[[RV]] : !cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>
-// CHECK:   cir.return %[[R]] : !cir.int<s, 32>
+// CHECK: cir.func @f3(%[[ARG:.*]]: !s32i loc({{.*}})) -> !s32i
+// CHECK:   %[[ARG_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
+// CHECK:   %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
+// CHECK:   cir.store %[[ARG]], %[[ARG_ALLOCA]] : !s32i, !cir.ptr<!s32i>
+// CHECK:   %[[ARG_VAL:.*]] = cir.load %[[ARG_ALLOCA]] : !cir.ptr<!s32i>, !s32i
+// CHECK:   cir.store %[[ARG_VAL]], %[[RV]] : !s32i, !cir.ptr<!s32i>
+// CHECK:   %[[R:.*]] = cir.load %[[RV]] : !cir.ptr<!s32i>, !s32i
+// CHECK:   cir.return %[[R]] : !s32i
 
 int f4(const int i) {
   return i;
 }
 
-// CHECK: cir.func @f4(%[[ARG:.*]]: !cir.int<s, 32> loc({{.*}})) -> !cir.int<s, 32>
-// CHECK:   %[[ARG_ALLOCA:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["i", init, const] {alignment = 4 : i64}
-// CHECK:   %[[RV:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["__retval"] {alignment = 4 : i64}
-// CHECK:   cir.store %[[ARG]], %[[ARG_ALLOCA]] : !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>
-// CHECK:   %[[ARG_VAL:.*]] = cir.load %[[ARG_ALLOCA]] : !cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>
-// CHECK:   cir.store %[[ARG_VAL]], %[[RV]] : !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>
-// CHECK:   %[[R:.*]] = cir.load %[[RV]] : !cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>
-// CHECK:   cir.return %[[R]] : !cir.int<s, 32>
+// CHECK: cir.func @f4(%[[ARG:.*]]: !s32i loc({{.*}})) -> !s32i
+// CHECK:   %[[ARG_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init, const] {alignment = 4 : i64}
+// CHECK:   %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
+// CHECK:   cir.store %[[ARG]], %[[ARG_ALLOCA]] : !s32i, !cir.ptr<!s32i>
+// CHECK:   %[[ARG_VAL:.*]] = cir.load %[[ARG_ALLOCA]] : !cir.ptr<!s32i>, !s32i
+// CHECK:   cir.store %[[ARG_VAL]], %[[RV]] : !s32i, !cir.ptr<!s32i>
+// CHECK:   %[[R:.*]] = cir.load %[[RV]] : !cir.ptr<!s32i>, !s32i
+// CHECK:   cir.return %[[R]] : !s32i

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -8,14 +8,14 @@ unsigned char cxxstaticcast_0(unsigned int x) {
 }
 
 // CIR: cir.func @cxxstaticcast_0
-// CIR:    %[[XPTR:[0-9]+]] = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["x", init] {alignment = 4 : i64}
-// CIR:    %[[RV:[0-9]+]] = cir.alloca !cir.int<u, 8>, !cir.ptr<!cir.int<u, 8>>, ["__retval"] {alignment = 1 : i64}
-// CIR:    cir.store %arg0, %[[XPTR]] : !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>
-// CIR:    %[[XVAL:[0-9]+]] = cir.load %[[XPTR]] : !cir.ptr<!cir.int<u, 32>>, !cir.int<u, 32>
-// CIR:    %[[CASTED:[0-9]+]] = cir.cast(integral, %[[XVAL]] : !cir.int<u, 32>), !cir.int<u, 8>
-// CIR:    cir.store %[[CASTED]], %[[RV]] : !cir.int<u, 8>, !cir.ptr<!cir.int<u, 8>>
-// CIR:    %[[R:[0-9]+]] = cir.load %1 : !cir.ptr<!cir.int<u, 8>>, !cir.int<u, 8>
-// CIR:    cir.return %[[R]] : !cir.int<u, 8>
+// CIR:    %[[XPTR:[0-9]+]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["x", init] {alignment = 4 : i64}
+// CIR:    %[[RV:[0-9]+]] = cir.alloca !u8i, !cir.ptr<!u8i>, ["__retval"] {alignment = 1 : i64}
+// CIR:    cir.store %arg0, %[[XPTR]] : !u32i, !cir.ptr<!u32i>
+// CIR:    %[[XVAL:[0-9]+]] = cir.load %[[XPTR]] : !cir.ptr<!u32i>, !u32i
+// CIR:    %[[CASTED:[0-9]+]] = cir.cast(integral, %[[XVAL]] : !u32i), !u8i
+// CIR:    cir.store %[[CASTED]], %[[RV]] : !u8i, !cir.ptr<!u8i>
+// CIR:    %[[R:[0-9]+]] = cir.load %1 : !cir.ptr<!u8i>, !u8i
+// CIR:    cir.return %[[R]] : !u8i
 // CIR:  }
 
 // LLVM: define i8 @cxxstaticcast_0(i32 %{{[0-9]+}})
@@ -31,41 +31,41 @@ int cStyleCasts_0(unsigned x1, int x2, float x3, short x4, double x5) {
 // LLVM: define i32 @cStyleCasts_0
 
   char a = (char)x1; // truncate
-  // CIR: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !cir.int<u, 32>), !cir.int<s, 8>
+  // CIR: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !u32i), !s8i
   // LLVM: %{{[0-9]+}} = trunc i32 %{{[0-9]+}} to i8
 
   short b = (short)x2; // truncate with sign
-  // CIR: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !cir.int<s, 32>), !cir.int<s, 16>
+  // CIR: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !s32i), !s16i
   // LLVM: %{{[0-9]+}} = trunc i32 %{{[0-9]+}} to i16
 
   long long c = (long long)x1; // zero extend
-  // CIR: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !cir.int<u, 32>), !cir.int<s, 64>
+  // CIR: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !u32i), !s64i
   // LLVM: %{{[0-9]+}} = zext i32 %{{[0-9]+}} to i64
 
   long long d = (long long)x2; // sign extend
-  // CIR: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !cir.int<s, 32>), !cir.int<s, 64>
+  // CIR: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !s32i), !s64i
   // LLVM: %{{[0-9]+}} = sext i32 %{{[0-9]+}} to i64
 
   unsigned ui = (unsigned)x2; // sign drop
-  // CIR: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !cir.int<s, 32>), !cir.int<u, 32>
+  // CIR: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !s32i), !u32i
 
   int si = (int)x1; // sign add
-  // CIR: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !cir.int<u, 32>), !cir.int<s, 32>
+  // CIR: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !u32i), !s32i
 
   bool ib;
   int bi = (int)ib; // bool to int
-  // CIR: %{{[0-9]+}} = cir.cast(bool_to_int, %{{[0-9]+}} : !cir.bool), !cir.int<s, 32>
+  // CIR: %{{[0-9]+}} = cir.cast(bool_to_int, %{{[0-9]+}} : !cir.bool), !s32i
   // LLVM: %{{[0-9]+}} = zext i1 %{{[0-9]+}} to i32
 
   #ifdef CIR_ONLY
   bool b2 = x2; // int to bool
-  // CIR: %{{[0-9]+}} = cir.cast(int_to_bool, %{{[0-9]+}} : !cir.int<s, 32>), !cir.bool
+  // CIR: %{{[0-9]+}} = cir.cast(int_to_bool, %{{[0-9]+}} : !s32i), !cir.bool
   #endif
 
   #ifdef CIR_ONLY
   void *p;
    bool b3 = p; // ptr to bool
-  // CIR: %{{[0-9]+}} = cir.cast(ptr_to_bool, %{{[0-9]+}} : !cir.ptr<!cir.void>), !cir.bool
+  // CIR: %{{[0-9]+}} = cir.cast(ptr_to_bool, %{{[0-9]+}} : !cir.ptr<!void>), !cir.bool
   #endif
 
   float f;
@@ -83,11 +83,11 @@ bool cptr(void *d) {
   return x;
 }
 
-// CIR: cir.func @cptr(%arg0: !cir.ptr<!cir.void>
-// CIR:   %[[DPTR:[0-9]+]] = cir.alloca !cir.ptr<!cir.void>, !cir.ptr<!cir.ptr<!cir.void>>, ["d", init] {alignment = 8 : i64}
+// CIR: cir.func @cptr(%arg0: !cir.ptr<!void>
+// CIR:   %[[DPTR:[0-9]+]] = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["d", init] {alignment = 8 : i64}
 
-// CIR:   %[[DVAL:[0-9]+]] = cir.load %[[DPTR]] : !cir.ptr<!cir.ptr<!cir.void>>, !cir.ptr<!cir.void>
-// CIR:   %{{[0-9]+}} = cir.cast(ptr_to_bool, %[[DVAL]] : !cir.ptr<!cir.void>), !cir.bool
+// CIR:   %[[DVAL:[0-9]+]] = cir.load %[[DPTR]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
+// CIR:   %{{[0-9]+}} = cir.cast(ptr_to_bool, %[[DVAL]] : !cir.ptr<!void>), !cir.bool
 #endif
 
 void should_not_cast() {

--- a/clang/test/CIR/CodeGen/local-vars.cpp
+++ b/clang/test/CIR/CodeGen/local-vars.cpp
@@ -22,27 +22,27 @@ void test() {
 
 // CHECK: module
 // CHECK: cir.func @test()
-// CHECK:    %[[I_PTR:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["i", init] {alignment = 4 : i64}
-// CHECK:    %[[L_PTR:.*]] = cir.alloca !cir.int<s, 64>, !cir.ptr<!cir.int<s, 64>>, ["l", init] {alignment = 8 : i64}
+// CHECK:    %[[I_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
+// CHECK:    %[[L_PTR:.*]] = cir.alloca !s64i, !cir.ptr<!s64i>, ["l", init] {alignment = 8 : i64}
 // CHECK:    %[[F_PTR:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["f", init] {alignment = 4 : i64}
 // CHECK:    %[[D_PTR:.*]] = cir.alloca !cir.double, !cir.ptr<!cir.double>, ["d", init] {alignment = 8 : i64}
 // CHECK:    %[[B1_PTR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["b1", init] {alignment = 1 : i64}
 // CHECK:    %[[B2_PTR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["b2", init] {alignment = 1 : i64}
-// CHECK:    %[[CI_PTR:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["ci", init, const] {alignment = 4 : i64}
-// CHECK:    %[[CL_PTR:.*]] = cir.alloca !cir.int<s, 64>, !cir.ptr<!cir.int<s, 64>>, ["cl", init, const] {alignment = 8 : i64}
+// CHECK:    %[[CI_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["ci", init, const] {alignment = 4 : i64}
+// CHECK:    %[[CL_PTR:.*]] = cir.alloca !s64i, !cir.ptr<!s64i>, ["cl", init, const] {alignment = 8 : i64}
 // CHECK:    %[[CF_PTR:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["cf", init, const] {alignment = 4 : i64}
 // CHECK:    %[[CD_PTR:.*]] = cir.alloca !cir.double, !cir.ptr<!cir.double>, ["cd", init, const] {alignment = 8 : i64}
 // CHECK:    %[[CB1_PTR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cb1", init, const] {alignment = 1 : i64}
 // CHECK:    %[[CB2_PTR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["cb2", init, const] {alignment = 1 : i64}
-// CHECK:    %[[UII_PTR:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["uii"] {alignment = 4 : i64}
-// CHECK:    %[[UIL_PTR:.*]] = cir.alloca !cir.int<s, 64>, !cir.ptr<!cir.int<s, 64>>, ["uil"] {alignment = 8 : i64}
+// CHECK:    %[[UII_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["uii"] {alignment = 4 : i64}
+// CHECK:    %[[UIL_PTR:.*]] = cir.alloca !s64i, !cir.ptr<!s64i>, ["uil"] {alignment = 8 : i64}
 // CHECK:    %[[UIF_PTR:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["uif"] {alignment = 4 : i64}
 // CHECK:    %[[UID_PTR:.*]] = cir.alloca !cir.double, !cir.ptr<!cir.double>, ["uid"] {alignment = 8 : i64}
 // CHECK:    %[[UIB_PTR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["uib"] {alignment = 1 : i64}
-// CHECK:    %[[ONE:.*]] = cir.const #cir.int<1> : !cir.int<s, 32>
-// CHECK:    cir.store %[[ONE]], %[[I_PTR]] : !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>
-// CHECK:    %[[TWO:.*]] = cir.const #cir.int<2> : !cir.int<s, 64>
-// CHECK:    cir.store %[[TWO]], %[[L_PTR]] : !cir.int<s, 64>, !cir.ptr<!cir.int<s, 64>>
+// CHECK:    %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
+// CHECK:    cir.store %[[ONE]], %[[I_PTR]] : !s32i, !cir.ptr<!s32i>
+// CHECK:    %[[TWO:.*]] = cir.const #cir.int<2> : !s64i
+// CHECK:    cir.store %[[TWO]], %[[L_PTR]] : !s64i, !cir.ptr<!s64i>
 // CHECK:    %[[THREE:.*]] = cir.const #cir.fp<3.0{{.*}}> : !cir.float
 // CHECK:    cir.store %[[THREE]], %[[F_PTR]] : !cir.float, !cir.ptr<!cir.float>
 // CHECK:    %[[FOUR:.*]] = cir.const #cir.fp<4.0{{.*}}> : !cir.double
@@ -51,10 +51,10 @@ void test() {
 // CHECK:    cir.store %[[TRUE]], %[[B1_PTR]] : !cir.bool, !cir.ptr<!cir.bool>
 // CHECK:    %[[FALSE:.*]] = cir.const #false
 // CHECK:    cir.store %[[FALSE]], %[[B2_PTR]] : !cir.bool, !cir.ptr<!cir.bool>
-// CHECK:    %[[ONEC:.*]] = cir.const #cir.int<1> : !cir.int<s, 32>
-// CHECK:    cir.store %[[ONEC]], %[[CI_PTR]] : !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>
-// CHECK:    %[[TWOC:.*]] = cir.const #cir.int<2> : !cir.int<s, 64>
-// CHECK:    cir.store %[[TWOC]], %[[CL_PTR]] : !cir.int<s, 64>, !cir.ptr<!cir.int<s, 64>>
+// CHECK:    %[[ONEC:.*]] = cir.const #cir.int<1> : !s32i
+// CHECK:    cir.store %[[ONEC]], %[[CI_PTR]] : !s32i, !cir.ptr<!s32i>
+// CHECK:    %[[TWOC:.*]] = cir.const #cir.int<2> : !s64i
+// CHECK:    cir.store %[[TWOC]], %[[CL_PTR]] : !s64i, !cir.ptr<!s64i>
 // CHECK:    %[[THREEC:.*]] = cir.const #cir.fp<3.0{{.*}}> : !cir.float
 // CHECK:    cir.store %[[THREEC]], %[[CF_PTR]] : !cir.float, !cir.ptr<!cir.float>
 // CHECK:    %[[FOURC:.*]] = cir.const #cir.fp<4.0{{.*}}> : !cir.double

--- a/clang/test/CIR/CodeGen/unary-expr-or-type-trait.cpp
+++ b/clang/test/CIR/CodeGen/unary-expr-or-type-trait.cpp
@@ -2,46 +2,46 @@
 
 void foo() {
   unsigned long b = sizeof(bool);
-  // CHECK: cir.const #cir.int<1> : !cir.int<u, 64>
+  // CHECK: cir.const #cir.int<1> : !u64i
 
   unsigned long i = sizeof(int);
-  // CHECK: cir.const #cir.int<4> : !cir.int<u, 64>
+  // CHECK: cir.const #cir.int<4> : !u64i
 
   unsigned long l =  sizeof(long);
-  // CHECK: cir.const #cir.int<8> : !cir.int<u, 64>
+  // CHECK: cir.const #cir.int<8> : !u64i
 
   unsigned long f =  sizeof(float);
-  // CHECK: cir.const #cir.int<4> : !cir.int<u, 64>
+  // CHECK: cir.const #cir.int<4> : !u64i
 
   unsigned long d =  sizeof(double);
-  // CHECK: cir.const #cir.int<8> : !cir.int<u, 64>
+  // CHECK: cir.const #cir.int<8> : !u64i
 
   unsigned long iArr = sizeof(int[5]);
-  // CHECK: cir.const #cir.int<20> : !cir.int<u, 64>
+  // CHECK: cir.const #cir.int<20> : !u64i
 
   unsigned long dArr =  sizeof(double[5]);
-  // CHECK: cir.const #cir.int<40> : !cir.int<u, 64>
+  // CHECK: cir.const #cir.int<40> : !u64i
 }
 
 void foo2() {
   unsigned long b = alignof(bool);
-  // CHECK: cir.const #cir.int<1> : !cir.int<u, 64>
+  // CHECK: cir.const #cir.int<1> : !u64i
 
   unsigned long i = alignof(int);
-  // CHECK: cir.const #cir.int<4> : !cir.int<u, 64>
+  // CHECK: cir.const #cir.int<4> : !u64i
 
   unsigned long l =  alignof(long);
-  // CHECK: cir.const #cir.int<8> : !cir.int<u, 64>
+  // CHECK: cir.const #cir.int<8> : !u64i
 
   unsigned long f =  alignof(float);
-  // CHECK: cir.const #cir.int<4> : !cir.int<u, 64>
+  // CHECK: cir.const #cir.int<4> : !u64i
 
   unsigned long d =  alignof(double);
-  // CHECK: cir.const #cir.int<8> : !cir.int<u, 64>
+  // CHECK: cir.const #cir.int<8> : !u64i
 
   unsigned long iArr = alignof(int[5]);
-  // CHECK: cir.const #cir.int<4> : !cir.int<u, 64>
+  // CHECK: cir.const #cir.int<4> : !u64i
 
   unsigned long dArr =  alignof(double[5]);
-  // CHECK: cir.const #cir.int<8> : !cir.int<u, 64>
+  // CHECK: cir.const #cir.int<8> : !u64i
 }

--- a/clang/test/CIR/CodeGen/unary.cpp
+++ b/clang/test/CIR/CodeGen/unary.cpp
@@ -10,8 +10,8 @@ unsigned up0() {
   return +a;
 }
 
-// CHECK: cir.func @up0() -> !cir.int<u, 32>
-// CHECK:   %[[A:.*]] = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["a", init]
+// CHECK: cir.func @up0() -> !u32i
+// CHECK:   %[[A:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init]
 // CHECK:   %[[INPUT:.*]] = cir.load %[[A]]
 // CHECK:   %[[OUTPUT:.*]] = cir.unary(plus, %[[INPUT]])
 
@@ -31,8 +31,8 @@ unsigned um0() {
   return -a;
 }
 
-// CHECK: cir.func @um0() -> !cir.int<u, 32>
-// CHECK:   %[[A:.*]] = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["a", init]
+// CHECK: cir.func @um0() -> !u32i
+// CHECK:   %[[A:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init]
 // CHECK:   %[[INPUT:.*]] = cir.load %[[A]]
 // CHECK:   %[[OUTPUT:.*]] = cir.unary(minus, %[[INPUT]])
 
@@ -54,8 +54,8 @@ unsigned un0() {
   return ~a; // a ^ -1 , not
 }
 
-// CHECK: cir.func @un0() -> !cir.int<u, 32>
-// CHECK:   %[[A:.*]] = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["a", init]
+// CHECK: cir.func @un0() -> !u32i
+// CHECK:   %[[A:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init]
 // CHECK:   %[[INPUT:.*]] = cir.load %[[A]]
 // CHECK:   %[[OUTPUT:.*]] = cir.unary(not, %[[INPUT]])
 
@@ -78,10 +78,10 @@ int inc0() {
   return a;
 }
 
-// CHECK: cir.func @inc0() -> !cir.int<s, 32>
-// CHECK:   %[[A:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["a", init]
-// CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !cir.int<s, 32>
-// CHECK:   cir.store %[[ATMP]], %[[A]] : !cir.int<s, 32>
+// CHECK: cir.func @inc0() -> !s32i
+// CHECK:   %[[A:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
+// CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !s32i
+// CHECK:   cir.store %[[ATMP]], %[[A]] : !s32i
 // CHECK:   %[[INPUT:.*]] = cir.load %[[A]]
 // CHECK:   %[[INCREMENTED:.*]] = cir.unary(inc, %[[INPUT]])
 // CHECK:   cir.store %[[INCREMENTED]], %[[A]]
@@ -106,10 +106,10 @@ int dec0() {
   return a;
 }
 
-// CHECK: cir.func @dec0() -> !cir.int<s, 32>
-// CHECK:   %[[A:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["a", init]
-// CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !cir.int<s, 32>
-// CHECK:   cir.store %[[ATMP]], %[[A]] : !cir.int<s, 32>
+// CHECK: cir.func @dec0() -> !s32i
+// CHECK:   %[[A:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
+// CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !s32i
+// CHECK:   cir.store %[[ATMP]], %[[A]] : !s32i
 // CHECK:   %[[INPUT:.*]] = cir.load %[[A]]
 // CHECK:   %[[INCREMENTED:.*]] = cir.unary(dec, %[[INPUT]])
 // CHECK:   cir.store %[[INCREMENTED]], %[[A]]
@@ -134,10 +134,10 @@ int inc1() {
   return a;
 }
 
-// CHECK: cir.func @inc1() -> !cir.int<s, 32>
-// CHECK:   %[[A:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["a", init]
-// CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !cir.int<s, 32>
-// CHECK:   cir.store %[[ATMP]], %[[A]] : !cir.int<s, 32>
+// CHECK: cir.func @inc1() -> !s32i
+// CHECK:   %[[A:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
+// CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !s32i
+// CHECK:   cir.store %[[ATMP]], %[[A]] : !s32i
 // CHECK:   %[[INPUT:.*]] = cir.load %[[A]]
 // CHECK:   %[[INCREMENTED:.*]] = cir.unary(inc, %[[INPUT]])
 // CHECK:   cir.store %[[INCREMENTED]], %[[A]]
@@ -162,10 +162,10 @@ int dec1() {
   return a;
 }
 
-// CHECK: cir.func @dec1() -> !cir.int<s, 32>
-// CHECK:   %[[A:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["a", init]
-// CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !cir.int<s, 32>
-// CHECK:   cir.store %[[ATMP]], %[[A]] : !cir.int<s, 32>
+// CHECK: cir.func @dec1() -> !s32i
+// CHECK:   %[[A:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
+// CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !s32i
+// CHECK:   cir.store %[[ATMP]], %[[A]] : !s32i
 // CHECK:   %[[INPUT:.*]] = cir.load %[[A]]
 // CHECK:   %[[INCREMENTED:.*]] = cir.unary(dec, %[[INPUT]])
 // CHECK:   cir.store %[[INCREMENTED]], %[[A]]
@@ -191,11 +191,11 @@ int inc2() {
   return b;
 }
 
-// CHECK: cir.func @inc2() -> !cir.int<s, 32>
-// CHECK:   %[[A:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["a", init]
-// CHECK:   %[[B:.*]] = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["b", init]
-// CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !cir.int<s, 32>
-// CHECK:   cir.store %[[ATMP]], %[[A]] : !cir.int<s, 32>
+// CHECK: cir.func @inc2() -> !s32i
+// CHECK:   %[[A:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
+// CHECK:   %[[B:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init]
+// CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !s32i
+// CHECK:   cir.store %[[ATMP]], %[[A]] : !s32i
 // CHECK:   %[[ATOB:.*]] = cir.load %[[A]]
 // CHECK:   %[[INCREMENTED:.*]] = cir.unary(inc, %[[ATOB]])
 // CHECK:   cir.store %[[INCREMENTED]], %[[A]]

--- a/clang/test/CIR/IR/array.cir
+++ b/clang/test/CIR/IR/array.cir
@@ -1,62 +1,64 @@
 // RUN: cir-opt %s | FileCheck %s
 
+!s32i = !cir.int<s, 32>
+
 module  {
 
-cir.global external @a : !cir.array<!cir.int<s, 32> x 10>
-// CHECK: cir.global external @a : !cir.array<!cir.int<s, 32> x 10>
+cir.global external @a : !cir.array<!s32i x 10>
+// CHECK: cir.global external @a : !cir.array<!s32i x 10>
 
-cir.global external @aa : !cir.array<!cir.array<!cir.int<s, 32> x 10> x 10>
-// CHECK: cir.global external @aa : !cir.array<!cir.array<!cir.int<s, 32> x 10> x 10>
+cir.global external @aa : !cir.array<!cir.array<!s32i x 10> x 10>
+// CHECK: cir.global external @aa : !cir.array<!cir.array<!s32i x 10> x 10>
 
-cir.global external @b : !cir.array<!cir.int<s, 32> x 10>
-// CHECK: cir.global external @b : !cir.array<!cir.int<s, 32> x 10>
+cir.global external @b : !cir.array<!s32i x 10>
+// CHECK: cir.global external @b : !cir.array<!s32i x 10>
 
-cir.global external @bb : !cir.array<!cir.array<!cir.int<s, 32> x 10> x 10>
-// CHECK: cir.global external @bb : !cir.array<!cir.array<!cir.int<s, 32> x 10> x 10>
+cir.global external @bb : !cir.array<!cir.array<!s32i x 10> x 10>
+// CHECK: cir.global external @bb : !cir.array<!cir.array<!s32i x 10> x 10>
 
-cir.global external @c = #cir.zero : !cir.array<!cir.int<s, 32> x 10>
-// CHECK: cir.global external @c = #cir.zero : !cir.array<!cir.int<s, 32> x 10>
+cir.global external @c = #cir.zero : !cir.array<!s32i x 10>
+// CHECK: cir.global external @c = #cir.zero : !cir.array<!s32i x 10>
 
-cir.global external @d = #cir.const_array<[#cir.int<1> : !cir.int<s, 32>, #cir.int<2> : !cir.int<s, 32>, #cir.int<3> : !cir.int<s, 32>]> : !cir.array<!cir.int<s, 32> x 3>
-// CHECK: cir.global external @d = #cir.const_array<[#cir.int<1> : !cir.int<s, 32>, #cir.int<2> : !cir.int<s, 32>, #cir.int<3> : !cir.int<s, 32>]> : !cir.array<!cir.int<s, 32> x 3>
+cir.global external @d = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i]> : !cir.array<!s32i x 3>
+// CHECK: cir.global external @d = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i]> : !cir.array<!s32i x 3>
 
-cir.global external @dd = #cir.const_array<[#cir.const_array<[#cir.int<1> : !cir.int<s, 32>, #cir.int<2> : !cir.int<s, 32>]> : !cir.array<!cir.int<s, 32> x 2>, #cir.const_array<[#cir.int<3> : !cir.int<s, 32>, #cir.int<4> : !cir.int<s, 32>]> : !cir.array<!cir.int<s, 32> x 2>, #cir.const_array<[#cir.int<5> : !cir.int<s, 32>, #cir.int<6> : !cir.int<s, 32>]> : !cir.array<!cir.int<s, 32> x 2>]> : !cir.array<!cir.array<!cir.int<s, 32> x 2> x 3>
-// CHECK: cir.global external @dd = #cir.const_array<[#cir.const_array<[#cir.int<1> : !cir.int<s, 32>, #cir.int<2> : !cir.int<s, 32>]> : !cir.array<!cir.int<s, 32> x 2>, #cir.const_array<[#cir.int<3> : !cir.int<s, 32>, #cir.int<4> : !cir.int<s, 32>]> : !cir.array<!cir.int<s, 32> x 2>, #cir.const_array<[#cir.int<5> : !cir.int<s, 32>, #cir.int<6> : !cir.int<s, 32>]> : !cir.array<!cir.int<s, 32> x 2>]> : !cir.array<!cir.array<!cir.int<s, 32> x 2> x 3>
+cir.global external @dd = #cir.const_array<[#cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<3> : !s32i, #cir.int<4> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<5> : !s32i, #cir.int<6> : !s32i]> : !cir.array<!s32i x 2>]> : !cir.array<!cir.array<!s32i x 2> x 3>
+// CHECK: cir.global external @dd = #cir.const_array<[#cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<3> : !s32i, #cir.int<4> : !s32i]> : !cir.array<!s32i x 2>, #cir.const_array<[#cir.int<5> : !s32i, #cir.int<6> : !s32i]> : !cir.array<!s32i x 2>]> : !cir.array<!cir.array<!s32i x 2> x 3>
 
-cir.global external @e = #cir.const_array<[#cir.int<1> : !cir.int<s, 32>, #cir.int<2> : !cir.int<s, 32>], trailing_zeros> : !cir.array<!cir.int<s, 32> x 10>
-// CHECK: cir.global external @e = #cir.const_array<[#cir.int<1> : !cir.int<s, 32>, #cir.int<2> : !cir.int<s, 32>], trailing_zeros> : !cir.array<!cir.int<s, 32> x 10>
+cir.global external @e = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i], trailing_zeros> : !cir.array<!s32i x 10>
+// CHECK: cir.global external @e = #cir.const_array<[#cir.int<1> : !s32i, #cir.int<2> : !s32i], trailing_zeros> : !cir.array<!s32i x 10>
 
 cir.func @func() {
-  %0 = cir.alloca !cir.array<!cir.int<s, 32> x 10>, !cir.ptr<!cir.array<!cir.int<s, 32> x 10>>, ["l"] {alignment = 4 : i64}
+  %0 = cir.alloca !cir.array<!s32i x 10>, !cir.ptr<!cir.array<!s32i x 10>>, ["l"] {alignment = 4 : i64}
   cir.return
 }
 
 // CHECK: cir.func @func() {
-// CHECK:   %0 = cir.alloca !cir.array<!cir.int<s, 32> x 10>, !cir.ptr<!cir.array<!cir.int<s, 32> x 10>>, ["l"] {alignment = 4 : i64}
+// CHECK:   %0 = cir.alloca !cir.array<!s32i x 10>, !cir.ptr<!cir.array<!s32i x 10>>, ["l"] {alignment = 4 : i64}
 // CHECK:   cir.return
 // CHECK: }
 
-cir.func @func2(%arg0: !cir.ptr<!cir.int<s, 32>>) {
-  %0 = cir.alloca !cir.ptr<!cir.int<s, 32>>, !cir.ptr<!cir.ptr<!cir.int<s, 32>>>, ["p", init] {alignment = 8 : i64}
-  cir.store %arg0, %0 : !cir.ptr<!cir.int<s, 32>>, !cir.ptr<!cir.ptr<!cir.int<s, 32>>>
+cir.func @func2(%arg0: !cir.ptr<!s32i>) {
+  %0 = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["p", init] {alignment = 8 : i64}
+  cir.store %arg0, %0 : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
   cir.return
 }
 
-// CHECK: cir.func @func2(%arg0: !cir.ptr<!cir.int<s, 32>>) {
-// CHECK:   %0 = cir.alloca !cir.ptr<!cir.int<s, 32>>, !cir.ptr<!cir.ptr<!cir.int<s, 32>>>, ["p", init] {alignment = 8 : i64}
-// CHECK:   cir.store %arg0, %0 : !cir.ptr<!cir.int<s, 32>>, !cir.ptr<!cir.ptr<!cir.int<s, 32>>>
+// CHECK: cir.func @func2(%arg0: !cir.ptr<!s32i>) {
+// CHECK:   %0 = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["p", init] {alignment = 8 : i64}
+// CHECK:   cir.store %arg0, %0 : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
 // CHECK:   cir.return
 // CHECK: }
 
-cir.func @func3(%arg0: !cir.ptr<!cir.array<!cir.int<s, 32> x 10>>) {
-  %0 = cir.alloca !cir.ptr<!cir.array<!cir.int<s, 32> x 10>>, !cir.ptr<!cir.ptr<!cir.array<!cir.int<s, 32> x 10>>>, ["pp", init] {alignment = 8 : i64}
-  cir.store %arg0, %0 : !cir.ptr<!cir.array<!cir.int<s, 32> x 10>>, !cir.ptr<!cir.ptr<!cir.array<!cir.int<s, 32> x 10>>>
+cir.func @func3(%arg0: !cir.ptr<!cir.array<!s32i x 10>>) {
+  %0 = cir.alloca !cir.ptr<!cir.array<!s32i x 10>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 10>>>, ["pp", init] {alignment = 8 : i64}
+  cir.store %arg0, %0 : !cir.ptr<!cir.array<!s32i x 10>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 10>>>
   cir.return
 }
 
-// CHECK: cir.func @func3(%arg0: !cir.ptr<!cir.array<!cir.int<s, 32> x 10>>) {
-// CHECK:   %0 = cir.alloca !cir.ptr<!cir.array<!cir.int<s, 32> x 10>>, !cir.ptr<!cir.ptr<!cir.array<!cir.int<s, 32> x 10>>>, ["pp", init] {alignment = 8 : i64}
-// CHECK:   cir.store %arg0, %0 : !cir.ptr<!cir.array<!cir.int<s, 32> x 10>>, !cir.ptr<!cir.ptr<!cir.array<!cir.int<s, 32> x 10>>>
+// CHECK: cir.func @func3(%arg0: !cir.ptr<!cir.array<!s32i x 10>>) {
+// CHECK:   %0 = cir.alloca !cir.ptr<!cir.array<!s32i x 10>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 10>>>, ["pp", init] {alignment = 8 : i64}
+// CHECK:   cir.store %arg0, %0 : !cir.ptr<!cir.array<!s32i x 10>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 10>>>
 // CHECK:   cir.return
 // CHECK: }
 

--- a/clang/test/CIR/IR/cast.cir
+++ b/clang/test/CIR/IR/cast.cir
@@ -15,9 +15,9 @@ module  {
   }
 }
 
-// CHECK: cir.func @yolo(%arg0: !cir.int<s, 32>)
-// CHECK: %0 = cir.cast(int_to_bool, %arg0 : !cir.int<s, 32>), !cir.bool
-// CHECK: %1 = cir.const #cir.int<0> : !cir.int<s, 32>
+// CHECK: cir.func @yolo(%arg0: !s32i)
+// CHECK: %0 = cir.cast(int_to_bool, %arg0 : !s32i), !cir.bool
+// CHECK: %1 = cir.const #cir.int<0> : !s32i
 
 // CHECK: cir.func @bitcast
-// CHECK: %0 = cir.cast(bitcast, %arg0 : !cir.ptr<!cir.int<s, 32>>), !cir.ptr<f32>
+// CHECK: %0 = cir.cast(bitcast, %arg0 : !cir.ptr<!s32i>), !cir.ptr<f32>

--- a/clang/test/CIR/IR/func.cir
+++ b/clang/test/CIR/IR/func.cir
@@ -1,5 +1,10 @@
 // RUN: cir-opt %s | FileCheck %s
 
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+!u32i = !cir.int<u, 32>
+!u64i = !cir.int<u, 64>
+
 module {
 // void empty() { }
 cir.func @empty() {
@@ -18,13 +23,13 @@ cir.func @voidret() {
 // CHECK: }
 
 // int intfunc() { return 42; }
-cir.func @intfunc() -> !cir.int<s, 32> {
-  %0 = cir.const #cir.int<42> : !cir.int<s, 32>
-  cir.return %0 : !cir.int<s, 32>
+cir.func @intfunc() -> !s32i {
+  %0 = cir.const #cir.int<42> : !s32i
+  cir.return %0 : !s32i
 }
-// CHECK: cir.func @intfunc() -> !cir.int<s, 32> {
-// CHECK:   %[[VAL:.*]] = cir.const #cir.int<42> : !cir.int<s, 32>
-// CHECK:   cir.return %[[VAL]] : !cir.int<s, 32>
+// CHECK: cir.func @intfunc() -> !s32i {
+// CHECK:   %[[VAL:.*]] = cir.const #cir.int<42> : !s32i
+// CHECK:   cir.return %[[VAL]] : !s32i
 // CHECK: }
 
 // int scopes() {
@@ -34,52 +39,52 @@ cir.func @intfunc() -> !cir.int<s, 32> {
 //    }
 //  }
 //}
-cir.func @scopes() -> !cir.int<s, 32> {
+cir.func @scopes() -> !s32i {
   cir.scope {
     cir.scope {
-      %0 = cir.const #cir.int<99> : !cir.int<s, 32>
-      cir.return %0 : !cir.int<s, 32>
+      %0 = cir.const #cir.int<99> : !s32i
+      cir.return %0 : !s32i
     }
   }
   cir.trap
 }
-// CHECK: cir.func @scopes() -> !cir.int<s, 32> {
+// CHECK: cir.func @scopes() -> !s32i {
 // CHECK:   cir.scope {
 // CHECK:     cir.scope {
-// CHECK:       %[[VAL:.*]] = cir.const #cir.int<99> : !cir.int<s, 32>
-// CHECK:       cir.return %[[VAL]] : !cir.int<s, 32>
+// CHECK:       %[[VAL:.*]] = cir.const #cir.int<99> : !s32i
+// CHECK:       cir.return %[[VAL]] : !s32i
 // CHECK:     }
 // CHECK:   }
 // CHECK:   cir.trap
 // CHECK: }
 
 // long longfunc() { return 42l; }
-cir.func @longfunc() -> !cir.int<s, 64> {
-  %0 = cir.const #cir.int<42> : !cir.int<s, 64>
-  cir.return %0 : !cir.int<s, 64>
+cir.func @longfunc() -> !s64i {
+  %0 = cir.const #cir.int<42> : !s64i
+  cir.return %0 : !s64i
 }
-// CHECK: cir.func @longfunc() -> !cir.int<s, 64>
-// CHECK:   %0 = cir.const #cir.int<42> : !cir.int<s, 64>
-// CHECK:   cir.return %0 : !cir.int<s, 64>
+// CHECK: cir.func @longfunc() -> !s64i
+// CHECK:   %0 = cir.const #cir.int<42> : !s64i
+// CHECK:   cir.return %0 : !s64i
 // CHECK: }
 
 // unsigned unsignedfunc() { return 42u; }
-cir.func @unsignedfunc() -> !cir.int<u, 32> {
-  %0 = cir.const #cir.int<42> : !cir.int<u, 32>
-  cir.return %0 : !cir.int<u, 32>
+cir.func @unsignedfunc() -> !u32i {
+  %0 = cir.const #cir.int<42> : !u32i
+  cir.return %0 : !u32i
 }
-// CHECK: cir.func @unsignedfunc() -> !cir.int<u, 32>
-// CHECK:   %[[VAL:.*]] = cir.const #cir.int<42> : !cir.int<u, 32>
-// CHECK:   cir.return %[[VAL]] : !cir.int<u, 32>
+// CHECK: cir.func @unsignedfunc() -> !u32i
+// CHECK:   %[[VAL:.*]] = cir.const #cir.int<42> : !u32i
+// CHECK:   cir.return %[[VAL]] : !u32i
 // CHECK: }
 
 // unsigned long long ullfunc() { return 42ull; }
-cir.func @ullfunc() -> !cir.int<u, 64> {
-  %0 = cir.const #cir.int<42> : !cir.int<u, 64>
-  cir.return %0 : !cir.int<u, 64>
+cir.func @ullfunc() -> !u64i {
+  %0 = cir.const #cir.int<42> : !u64i
+  cir.return %0 : !u64i
 }
-// CHECK: cir.func @ullfunc() -> !cir.int<u, 64>
-// CHECK:   %[[VAL:.*]] = cir.const #cir.int<42> : !cir.int<u, 64>
-// CHECK:   cir.return %[[VAL:.*]] : !cir.int<u, 64>
+// CHECK: cir.func @ullfunc() -> !u64i
+// CHECK:   %[[VAL:.*]] = cir.const #cir.int<42> : !u64i
+// CHECK:   cir.return %[[VAL:.*]] : !u64i
 // CHECK: }
 }

--- a/clang/test/CIR/IR/global-var-linkage.cir
+++ b/clang/test/CIR/IR/global-var-linkage.cir
@@ -1,18 +1,20 @@
 // RUN: cir-opt %s -o %t.cir
 // RUN: FileCheck --input-file=%t.cir %s
 
+!s32i = !cir.int<s, 32>
+
 module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
-  cir.global external @aaaa : !cir.int<s, 32>
-  cir.global internal @bbbb : !cir.int<s, 32>
-  cir.global linkonce_odr @cccc : !cir.int<s, 32>
-  cir.global internal @ffff = #cir.int<0> : !cir.int<s, 32>
-  cir.global weak_odr @dddd : !cir.int<s, 32>
+  cir.global external @aaaa : !s32i
+  cir.global internal @bbbb : !s32i
+  cir.global linkonce_odr @cccc : !s32i
+  cir.global internal @ffff = #cir.int<0> : !s32i
+  cir.global weak_odr @dddd : !s32i
 }
 
 // CHECK: module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
-// CHECK:   cir.global external @aaaa : !cir.int<s, 32>
-// CHECK:   cir.global internal @bbbb : !cir.int<s, 32>
-// CHECK:   cir.global linkonce_odr @cccc : !cir.int<s, 32>
-// CHECK:   cir.global internal @ffff = #cir.int<0> : !cir.int<s, 32>
-// CHECK:   cir.global weak_odr @dddd : !cir.int<s, 32>
+// CHECK:   cir.global external @aaaa : !s32i
+// CHECK:   cir.global internal @bbbb : !s32i
+// CHECK:   cir.global linkonce_odr @cccc : !s32i
+// CHECK:   cir.global internal @ffff = #cir.int<0> : !s32i
+// CHECK:   cir.global weak_odr @dddd : !s32i
 // CHECK: }

--- a/clang/test/CIR/IR/global.cir
+++ b/clang/test/CIR/IR/global.cir
@@ -1,23 +1,35 @@
 // RUN: cir-opt %s -o - | FileCheck %s
 
+!s8i = !cir.int<s, 8>
+!s16i = !cir.int<s, 16>
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+!s128i = !cir.int<s, 128>
+!u8i = !cir.int<u, 8>
+!u16i = !cir.int<u, 16>
+!u32i = !cir.int<u, 32>
+!u64i = !cir.int<u, 64>
+!u128i = !cir.int<u, 128>
+!void = !cir.void
+
 module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
-  cir.global external @c : !cir.int<s, 8>
-  cir.global external @sc : !cir.int<s, 8>
-  cir.global external @uc : !cir.int<u, 8>
-  cir.global external @ss : !cir.int<s, 16>
-  cir.global external @us = #cir.int<100> : !cir.int<u, 16>
-  cir.global external @si = #cir.int<42> : !cir.int<s, 32>
-  cir.global external @ui : !cir.int<u, 32>
-  cir.global external @sl : !cir.int<s, 64>
-  cir.global external @ul : !cir.int<u, 64>
-  cir.global external @sll : !cir.int<s, 64>
-  cir.global external @ull = #cir.int<123456> : !cir.int<u, 64>
-  cir.global external @s128 : !cir.int<s, 128>
-  cir.global external @u128 : !cir.int<u, 128>
-  cir.global external @wc : !cir.int<s, 32>
-  cir.global external @c8 : !cir.int<u, 8>
-  cir.global external @c16 : !cir.int<u, 16>
-  cir.global external @c32 : !cir.int<u, 32>
+  cir.global external @c : !s8i
+  cir.global external @sc : !s8i
+  cir.global external @uc : !u8i
+  cir.global external @ss : !s16i
+  cir.global external @us = #cir.int<100> : !u16i
+  cir.global external @si = #cir.int<42> : !s32i
+  cir.global external @ui : !u32i
+  cir.global external @sl : !s64i
+  cir.global external @ul : !u64i
+  cir.global external @sll : !s64i
+  cir.global external @ull = #cir.int<123456> : !u64i
+  cir.global external @s128 : !s128i
+  cir.global external @u128 : !u128i
+  cir.global external @wc : !s32i
+  cir.global external @c8 : !u8i
+  cir.global external @c16 : !u16i
+  cir.global external @c32 : !u32i
   cir.global external @sb20 : !cir.int<s, 20>
   cir.global external @ub48 : !cir.int<u, 48>
   cir.global external @f16 : !cir.f16
@@ -26,32 +38,32 @@ module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
   cir.global external @d = #cir.fp<1.250000e+00> : !cir.double
   cir.global external @ld : !cir.long_double<!cir.f80>
   cir.global external @f128 : !cir.f128
-  cir.global external @vp : !cir.ptr<!cir.void>
-  cir.global external @ip = #cir.ptr<null> : !cir.ptr<!cir.int<s, 32>>
+  cir.global external @vp : !cir.ptr<!void>
+  cir.global external @ip = #cir.ptr<null> : !cir.ptr<!s32i>
   cir.global external @dp : !cir.ptr<!cir.double>
-  cir.global external @cpp : !cir.ptr<!cir.ptr<!cir.int<s, 8>>>
+  cir.global external @cpp : !cir.ptr<!cir.ptr<!s8i>>
   cir.global external @fp : !cir.ptr<!cir.func<()>>
-  cir.global external @fpii = #cir.ptr<null> : !cir.ptr<!cir.func<(!cir.int<s, 32>) -> !cir.int<s, 32>>>
-  cir.global external @fpvar : !cir.ptr<!cir.func<(!cir.int<s, 32>, ...)>>
+  cir.global external @fpii = #cir.ptr<null> : !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+  cir.global external @fpvar : !cir.ptr<!cir.func<(!s32i, ...)>>
 }
 
-// CHECK: cir.global external @c : !cir.int<s, 8>
-// CHECK: cir.global external @sc : !cir.int<s, 8>
-// CHECK: cir.global external @uc : !cir.int<u, 8>
-// CHECK: cir.global external @ss : !cir.int<s, 16>
+// CHECK: cir.global external @c : !s8i
+// CHECK: cir.global external @sc : !s8i
+// CHECK: cir.global external @uc : !u8i
+// CHECK: cir.global external @ss : !s16i
 // CHECK: cir.global external @us = #cir.int<100>
 // CHECK: cir.global external @si = #cir.int<42>
-// CHECK: cir.global external @ui : !cir.int<u, 32>
-// CHECK: cir.global external @sl : !cir.int<s, 64>
-// CHECK: cir.global external @ul : !cir.int<u, 64>
-// CHECK: cir.global external @sll : !cir.int<s, 64>
-// CHECK: cir.global external @ull = #cir.int<123456> : !cir.int<u, 64>
-// CHECK: cir.global external @s128 : !cir.int<s, 128>
-// CHECK: cir.global external @u128 : !cir.int<u, 128>
-// CHECK: cir.global external @wc : !cir.int<s, 32>
-// CHECK: cir.global external @c8 : !cir.int<u, 8>
-// CHECK: cir.global external @c16 : !cir.int<u, 16>
-// CHECK: cir.global external @c32 : !cir.int<u, 32>
+// CHECK: cir.global external @ui : !u32i
+// CHECK: cir.global external @sl : !s64i
+// CHECK: cir.global external @ul : !u64i
+// CHECK: cir.global external @sll : !s64i
+// CHECK: cir.global external @ull = #cir.int<123456> : !u64i
+// CHECK: cir.global external @s128 : !s128i
+// CHECK: cir.global external @u128 : !u128i
+// CHECK: cir.global external @wc : !s32i
+// CHECK: cir.global external @c8 : !u8i
+// CHECK: cir.global external @c16 : !u16i
+// CHECK: cir.global external @c32 : !u32i
 // CHECK: cir.global external @sb20 : !cir.int<s, 20>
 // CHECK: cir.global external @ub48 : !cir.int<u, 48>
 // CHECK: cir.global external @f16 : !cir.f16
@@ -60,10 +72,10 @@ module attributes {cir.triple = "x86_64-unknown-linux-gnu"} {
 // CHECK: cir.global external @d = #cir.fp<1.250000e+00> : !cir.double
 // CHECK: cir.global external @ld : !cir.long_double<!cir.f80>
 // CHECK: cir.global external @f128 : !cir.f128
-// CHECK: cir.global external @vp : !cir.ptr<!cir.void>
-// CHECK: cir.global external @ip = #cir.ptr<null> : !cir.ptr<!cir.int<s, 32>>
+// CHECK: cir.global external @vp : !cir.ptr<!void>
+// CHECK: cir.global external @ip = #cir.ptr<null> : !cir.ptr<!s32i>
 // CHECK: cir.global external @dp : !cir.ptr<!cir.double>
-// CHECK: cir.global external @cpp : !cir.ptr<!cir.ptr<!cir.int<s, 8>>>
+// CHECK: cir.global external @cpp : !cir.ptr<!cir.ptr<!s8i>>
 // CHECK: cir.global external @fp : !cir.ptr<!cir.func<()>>
-// CHECK: cir.global external @fpii = #cir.ptr<null> : !cir.ptr<!cir.func<(!cir.int<s, 32>) -> !cir.int<s, 32>>>
-// CHECK: cir.global external @fpvar : !cir.ptr<!cir.func<(!cir.int<s, 32>, ...)>>
+// CHECK: cir.global external @fpii = #cir.ptr<null> : !cir.ptr<!cir.func<(!s32i) -> !s32i>>
+// CHECK: cir.global external @fpvar : !cir.ptr<!cir.func<(!s32i, ...)>>

--- a/clang/test/CIR/Lowering/func-simple.cpp
+++ b/clang/test/CIR/Lowering/func-simple.cpp
@@ -30,13 +30,11 @@ int scopes() {
 // CHECK:   br label %[[LABEL2:.*]]
 // CHECK: [[LABEL2]]:
 // CHECK:   store i32 99, ptr %[[RV]], align 4
-// CHECK:   br label %[[LABEL3:.*]]
-// CHECK: [[LABEL3]]:
 // CHECK:   %[[R:.*]] = load i32, ptr %[[RV]], align 4
 // CHECK:   ret i32 %[[R]]
-// CHECK: [[LABEL4:.*]]:
-// CHECK:   br label %[[LABEL5:.*]]
-// CHECK: [[LABEL5]]:
+// CHECK: [[LABEL3:.*]]:
+// CHECK:   br label %[[LABEL4:.*]]
+// CHECK: [[LABEL4]]:
 // CHECK:   call void @llvm.trap()
 // CHECK:   unreachable
 // CHECK: }

--- a/clang/test/CIR/Transforms/canonicalize.cir
+++ b/clang/test/CIR/Transforms/canonicalize.cir
@@ -1,20 +1,24 @@
 // RUN: cir-opt %s -cir-canonicalize -o - | FileCheck %s
 
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+!u32i = !cir.int<u, 32>
+
 module {
   cir.func @redundant_br() {
     cir.br ^bb1
   ^bb1:  // pred: ^bb0
-    %0 = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["a", init] {alignment = 4 : i64}
-    %1 = cir.const #cir.int<4> : !cir.int<u, 32>
-    cir.store %1, %0 : !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>
+    %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init] {alignment = 4 : i64}
+    %1 = cir.const #cir.int<4> : !u32i
+    cir.store %1, %0 : !u32i, !cir.ptr<!u32i>
     cir.br ^bb2
   ^bb2:  // pred: ^bb1
     cir.return
   }
   // CHECK:      cir.func @redundant_br() {
-  // CHECK-NEXT:   %[[A:.*]] = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["a", init] {alignment = 4 : i64}
-  // CHECK-NEXT:   %[[FOUR:.*]] = cir.const #cir.int<4> : !cir.int<u, 32>
-  // CHECK-NEXT:   cir.store %[[FOUR]], %[[A]] : !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>
+  // CHECK-NEXT:   %[[A:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init] {alignment = 4 : i64}
+  // CHECK-NEXT:   %[[FOUR:.*]] = cir.const #cir.int<4> : !u32i
+  // CHECK-NEXT:   cir.store %[[FOUR]], %[[A]] : !u32i, !cir.ptr<!u32i>
   // CHECK-NEXT:   cir.return
   // CHECK-NEXT: }
 
@@ -28,34 +32,34 @@ module {
   // CHECK-NEXT: }
 
   cir.func @cast1(%arg0: !cir.bool) -> !cir.bool {
-    %0 = cir.cast(bool_to_int, %arg0 : !cir.bool), !cir.int<s, 32>
-    %1 = cir.cast(int_to_bool, %0 : !cir.int<s, 32>), !cir.bool
+    %0 = cir.cast(bool_to_int, %arg0 : !cir.bool), !s32i
+    %1 = cir.cast(int_to_bool, %0 : !s32i), !cir.bool
     cir.return %1 : !cir.bool
   }
   // CHECK:      cir.func @cast1(%[[ARG0:.*]]: !cir.bool) -> !cir.bool
   // CHECK-NEXT:   cir.return %[[ARG0]] : !cir.bool
 
-  cir.func @cast2(%arg0: !cir.int<s, 32>) -> !cir.bool {
-    %0 = cir.cast(int_to_bool, %arg0 : !cir.int<s, 32>), !cir.bool
-    %1 = cir.cast(bool_to_int, %0 : !cir.bool), !cir.int<s, 32>
-    %2 = cir.cast(integral, %1 : !cir.int<s, 32>), !cir.int<s, 64>
-    %3 = cir.cast(int_to_bool, %2 : !cir.int<s, 64>), !cir.bool
+  cir.func @cast2(%arg0: !s32i) -> !cir.bool {
+    %0 = cir.cast(int_to_bool, %arg0 : !s32i), !cir.bool
+    %1 = cir.cast(bool_to_int, %0 : !cir.bool), !s32i
+    %2 = cir.cast(integral, %1 : !s32i), !s64i
+    %3 = cir.cast(int_to_bool, %2 : !s64i), !cir.bool
     cir.return %3 : !cir.bool
   }
-  // CHECK:      cir.func @cast2(%[[ARG0:.*]]: !cir.int<s, 32>) -> !cir.bool
-  // CHECK-NEXT:   %[[CAST:.*]] = cir.cast(int_to_bool, %[[ARG0]] : !cir.int<s, 32>), !cir.bool
+  // CHECK:      cir.func @cast2(%[[ARG0:.*]]: !s32i) -> !cir.bool
+  // CHECK-NEXT:   %[[CAST:.*]] = cir.cast(int_to_bool, %[[ARG0]] : !s32i), !cir.bool
   // CHECK-NEXT:   cir.return %[[CAST]] : !cir.bool
 
-  cir.func @no_fold_cast(%arg0: !cir.int<s, 32>) -> !cir.int<s, 64> {
-    %0 = cir.cast(int_to_bool, %arg0 : !cir.int<s, 32>), !cir.bool
-    %1 = cir.cast(bool_to_int, %0 : !cir.bool), !cir.int<s, 32>
-    %2 = cir.cast(integral, %1 : !cir.int<s, 32>), !cir.int<s, 64>
-    cir.return %2 : !cir.int<s, 64>
+  cir.func @no_fold_cast(%arg0: !s32i) -> !s64i {
+    %0 = cir.cast(int_to_bool, %arg0 : !s32i), !cir.bool
+    %1 = cir.cast(bool_to_int, %0 : !cir.bool), !s32i
+    %2 = cir.cast(integral, %1 : !s32i), !s64i
+    cir.return %2 : !s64i
   }
-  // CHECK:      cir.func @no_fold_cast(%[[ARG0:.*]]: !cir.int<s, 32>) -> !cir.int<s, 64>
-  // CHECK-NEXT:   %[[CAST:.*]] = cir.cast(int_to_bool, %[[ARG0]] : !cir.int<s, 32>), !cir.bool
-  // CHECK-NEXT:   %[[CAST2:.*]] = cir.cast(bool_to_int, %[[CAST]] : !cir.bool), !cir.int<s, 32>
-  // CHECK-NEXT:   %[[CAST3:.*]] = cir.cast(integral, %[[CAST2]] : !cir.int<s, 32>), !cir.int<s, 64>
-  // CHECK-NEXT:   cir.return %[[CAST3]] : !cir.int<s, 64>
+  // CHECK:      cir.func @no_fold_cast(%[[ARG0:.*]]: !s32i) -> !s64i
+  // CHECK-NEXT:   %[[CAST:.*]] = cir.cast(int_to_bool, %[[ARG0]] : !s32i), !cir.bool
+  // CHECK-NEXT:   %[[CAST2:.*]] = cir.cast(bool_to_int, %[[CAST]] : !cir.bool), !s32i
+  // CHECK-NEXT:   %[[CAST3:.*]] = cir.cast(integral, %[[CAST2]] : !s32i), !s64i
+  // CHECK-NEXT:   cir.return %[[CAST3]] : !s64i
 
 }

--- a/clang/test/CIR/Transforms/scope.cir
+++ b/clang/test/CIR/Transforms/scope.cir
@@ -1,20 +1,22 @@
 // RUN: cir-opt %s -cir-flatten-cfg -o - | FileCheck %s
 
+!u32i = !cir.int<u, 32>
+
 module {
   cir.func @foo() {
     cir.scope {
-      %0 = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["a", init] {alignment = 4 : i64}
-      %1 = cir.const #cir.int<4> : !cir.int<u, 32>
-      cir.store %1, %0 : !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>
+      %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init] {alignment = 4 : i64}
+      %1 = cir.const #cir.int<4> : !u32i
+      cir.store %1, %0 : !u32i, !cir.ptr<!u32i>
     }
     cir.return
   }
 // CHECK:  cir.func @foo() {
 // CHECK:    cir.br ^bb1
 // CHECK:  ^bb1:  // pred: ^bb0
-// CHECK:    %0 = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["a", init] {alignment = 4 : i64}
-// CHECK:    %1 = cir.const #cir.int<4> : !cir.int<u, 32>
-// CHECK:    cir.store %1, %0 : !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>
+// CHECK:    %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init] {alignment = 4 : i64}
+// CHECK:    %1 = cir.const #cir.int<4> : !u32i
+// CHECK:    cir.store %1, %0 : !u32i, !cir.ptr<!u32i>
 // CHECK:    cir.br ^bb2
 // CHECK:  ^bb2:  // pred: ^bb1
 // CHECK:    cir.return
@@ -30,29 +32,29 @@ module {
 // CHECK:    cir.return
 // CHECK:  }
 
-  cir.func @scope_with_return() -> !cir.int<u, 32> {
-    %0 = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["__retval"] {alignment = 4 : i64}
+  cir.func @scope_with_return() -> !u32i {
+    %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["__retval"] {alignment = 4 : i64}
     cir.scope {
-      %2 = cir.const #cir.int<0> : !cir.int<u, 32>
-      cir.store %2, %0 : !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>
-      %3 = cir.load %0 : !cir.ptr<!cir.int<u, 32>>, !cir.int<u, 32>
-      cir.return %3 : !cir.int<u, 32>
+      %2 = cir.const #cir.int<0> : !u32i
+      cir.store %2, %0 : !u32i, !cir.ptr<!u32i>
+      %3 = cir.load %0 : !cir.ptr<!u32i>, !u32i
+      cir.return %3 : !u32i
     }
-    %1 = cir.load %0 : !cir.ptr<!cir.int<u, 32>>, !cir.int<u, 32>
-    cir.return %1 : !cir.int<u, 32>
+    %1 = cir.load %0 : !cir.ptr<!u32i>, !u32i
+    cir.return %1 : !u32i
   }
 
-// CHECK:  cir.func @scope_with_return() -> !cir.int<u, 32> {
-// CHECK:    %0 = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["__retval"] {alignment = 4 : i64}
+// CHECK:  cir.func @scope_with_return() -> !u32i {
+// CHECK:    %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:    cir.br ^bb1
 // CHECK:  ^bb1:  // pred: ^bb0
-// CHECK:    %1 = cir.const #cir.int<0> : !cir.int<u, 32>
-// CHECK:    cir.store %1, %0 : !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>
-// CHECK:    %2 = cir.load %0 : !cir.ptr<!cir.int<u, 32>>, !cir.int<u, 32>
-// CHECK:    cir.return %2 : !cir.int<u, 32>
+// CHECK:    %1 = cir.const #cir.int<0> : !u32i
+// CHECK:    cir.store %1, %0 : !u32i, !cir.ptr<!u32i>
+// CHECK:    %2 = cir.load %0 : !cir.ptr<!u32i>, !u32i
+// CHECK:    cir.return %2 : !u32i
 // CHECK:  ^bb2:  // no predecessors
-// CHECK:    %3 = cir.load %0 : !cir.ptr<!cir.int<u, 32>>, !cir.int<u, 32>
-// CHECK:    cir.return %3 : !cir.int<u, 32>
+// CHECK:    %3 = cir.load %0 : !cir.ptr<!u32i>, !u32i
+// CHECK:    cir.return %3 : !u32i
 // CHECK:  }
 
 }

--- a/clang/test/CIR/func-simple.cpp
+++ b/clang/test/CIR/func-simple.cpp
@@ -8,20 +8,16 @@ void empty() { }
 
 void voidret() { return; }
 // CHECK: cir.func @voidret() {
-// CHECK:   cir.br ^bb1
-// CHECK: ^bb1:
 // CHECK:   cir.return
 // CHECK: }
 
 int intfunc() { return 42; }
-// CHECK: cir.func @intfunc() -> !cir.int<s, 32> {
-// CHECK:   %0 = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["__retval"] {alignment = 4 : i64}
-// CHECK:   %1 = cir.const #cir.int<42> : !cir.int<s, 32>
-// CHECK:   cir.store %1, %0 : !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>
-// CHECK:   cir.br ^bb1
-// CHECK: ^bb1:
-// CHECK:   %2 = cir.load %0 : !cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>
-// CHECK:   cir.return %2 : !cir.int<s, 32>
+// CHECK: cir.func @intfunc() -> !s32i {
+// CHECK:   %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
+// CHECK:   %1 = cir.const #cir.int<42> : !s32i
+// CHECK:   cir.store %1, %0 : !s32i, !cir.ptr<!s32i>
+// CHECK:   %2 = cir.load %0 : !cir.ptr<!s32i>, !s32i
+// CHECK:   cir.return %2 : !s32i
 // CHECK: }
 
 int scopes() {
@@ -31,52 +27,44 @@ int scopes() {
     }
   }
 }
-// CHECK: cir.func @scopes() -> !cir.int<s, 32> {
-// CHECK:   %0 = cir.alloca !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>, ["__retval"] {alignment = 4 : i64}
+// CHECK: cir.func @scopes() -> !s32i {
+// CHECK:   %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:   cir.scope {
 // CHECK:     cir.scope {
-// CHECK:       %1 = cir.const #cir.int<99> : !cir.int<s, 32>
-// CHECK:       cir.store %1, %0 : !cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>
-// CHECK:       cir.br ^bb1
-// CHECK:     ^bb1:
-// CHECK:       %2 = cir.load %0 : !cir.ptr<!cir.int<s, 32>>, !cir.int<s, 32>
-// CHECK:       cir.return %2 : !cir.int<s, 32>
+// CHECK:       %1 = cir.const #cir.int<99> : !s32i
+// CHECK:       cir.store %1, %0 : !s32i, !cir.ptr<!s32i>
+// CHECK:       %2 = cir.load %0 : !cir.ptr<!s32i>, !s32i
+// CHECK:       cir.return %2 : !s32i
 // CHECK:     }
 // CHECK:   }
 // CHECK:   cir.trap
 // CHECK: }
 
 long longfunc() { return 42l; }
-// CHECK: cir.func @longfunc() -> !cir.int<s, 64>
-// CHECK:   %0 = cir.alloca !cir.int<s, 64>, !cir.ptr<!cir.int<s, 64>>, ["__retval"] {alignment = 8 : i64}
-// CHECK:   %1 = cir.const #cir.int<42> : !cir.int<s, 64>
-// CHECK:   cir.store %1, %0 : !cir.int<s, 64>, !cir.ptr<!cir.int<s, 64>>
-// CHECK:   cir.br ^bb1
-// CHECK: ^bb1:
-// CHECK:   %2 = cir.load %0 : !cir.ptr<!cir.int<s, 64>>, !cir.int<s, 64>
-// CHECK:   cir.return %2 : !cir.int<s, 64>
+// CHECK: cir.func @longfunc() -> !s64i
+// CHECK:   %0 = cir.alloca !s64i, !cir.ptr<!s64i>, ["__retval"] {alignment = 8 : i64}
+// CHECK:   %1 = cir.const #cir.int<42> : !s64i
+// CHECK:   cir.store %1, %0 : !s64i, !cir.ptr<!s64i>
+// CHECK:   %2 = cir.load %0 : !cir.ptr<!s64i>, !s64i
+// CHECK:   cir.return %2 : !s64i
 // CHECK: }
 
 unsigned unsignedfunc() { return 42u; }
-// CHECK: cir.func @unsignedfunc() -> !cir.int<u, 32>
-// CHECK:   %0 = cir.alloca !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>, ["__retval"] {alignment = 4 : i64}
-// CHECK:   %1 = cir.const #cir.int<42> : !cir.int<u, 32>
-// CHECK:   cir.store %1, %0 : !cir.int<u, 32>, !cir.ptr<!cir.int<u, 32>>
-// CHECK:   cir.br ^bb1
-// CHECK: ^bb1:
-// CHECK:   %2 = cir.load %0 : !cir.ptr<!cir.int<u, 32>>, !cir.int<u, 32>
-// CHECK:   cir.return %2 : !cir.int<u, 32>
+// CHECK: cir.func @unsignedfunc() -> !u32i
+// CHECK:   %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["__retval"] {alignment = 4 : i64}
+// CHECK:   %1 = cir.const #cir.int<42> : !u32i
+// CHECK:   cir.store %1, %0 : !u32i, !cir.ptr<!u32i>
+// CHECK:   %2 = cir.load %0 : !cir.ptr<!u32i>, !u32i
+// CHECK:   cir.return %2 : !u32i
 // CHECK: }
 
 unsigned long long ullfunc() { return 42ull; }
-// CHECK: cir.func @ullfunc() -> !cir.int<u, 64>
-// CHECK:   %0 = cir.alloca !cir.int<u, 64>, !cir.ptr<!cir.int<u, 64>>, ["__retval"] {alignment = 8 : i64}
-// CHECK:   %1 = cir.const #cir.int<42> : !cir.int<u, 64>
-// CHECK:   cir.store %1, %0 : !cir.int<u, 64>, !cir.ptr<!cir.int<u, 64>>
-// CHECK:   cir.br ^bb1
-// CHECK: ^bb1:
-// CHECK:   %2 = cir.load %0 : !cir.ptr<!cir.int<u, 64>>, !cir.int<u, 64>
-// CHECK:   cir.return %2 : !cir.int<u, 64>
+// CHECK: cir.func @ullfunc() -> !u64i
+// CHECK:   %0 = cir.alloca !u64i, !cir.ptr<!u64i>, ["__retval"] {alignment = 8 : i64}
+// CHECK:   %1 = cir.const #cir.int<42> : !u64i
+// CHECK:   cir.store %1, %0 : !u64i, !cir.ptr<!u64i>
+// CHECK:   %2 = cir.load %0 : !cir.ptr<!u64i>, !u64i
+// CHECK:   cir.return %2 : !u64i
 // CHECK: }
 
 bool boolfunc() { return true; }
@@ -84,8 +72,6 @@ bool boolfunc() { return true; }
 // CHECK:   %0 = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["__retval"] {alignment = 1 : i64}
 // CHECK:   %1 = cir.const #true
 // CHECK:   cir.store %1, %0 : !cir.bool, !cir.ptr<!cir.bool>
-// CHECK:   cir.br ^bb1
-// CHECK: ^bb1:
 // CHECK:   %2 = cir.load %0 : !cir.ptr<!cir.bool>, !cir.bool
 // CHECK:   cir.return %2 : !cir.bool
 // CHECK: }
@@ -95,8 +81,6 @@ float floatfunc() { return 42.42f; }
 // CHECK:   %0 = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["__retval"] {alignment = 4 : i64}
 // CHECK:   %1 = cir.const #cir.fp<4.242
 // CHECK:   cir.store %1, %0 : !cir.float, !cir.ptr<!cir.float>
-// CHECK:   cir.br ^bb1
-// CHECK: ^bb1:
 // CHECK:   %2 = cir.load %0 : !cir.ptr<!cir.float>, !cir.float
 // CHECK:   cir.return %2 : !cir.float
 // CHECK: }
@@ -106,8 +90,6 @@ double doublefunc() { return 42.42; }
 // CHECK:   %0 = cir.alloca !cir.double, !cir.ptr<!cir.double>, ["__retval"] {alignment = 8 : i64}
 // CHECK:   %1 = cir.const #cir.fp<4.242
 // CHECK:   cir.store %1, %0 : !cir.double, !cir.ptr<!cir.double>
-// CHECK:   cir.br ^bb1
-// CHECK: ^bb1:
 // CHECK:   %2 = cir.load %0 : !cir.ptr<!cir.double>, !cir.double
 // CHECK:   cir.return %2 : !cir.double
 // CHECK: }

--- a/clang/test/CIR/global-var-simple.cpp
+++ b/clang/test/CIR/global-var-simple.cpp
@@ -2,55 +2,55 @@
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o -  | FileCheck %s
 
 char c;
-// CHECK: cir.global external @c : !cir.int<s, 8>
+// CHECK: cir.global external @c : !s8i
 
 signed char sc;
-// CHECK: cir.global external @sc : !cir.int<s, 8>
+// CHECK: cir.global external @sc : !s8i
 
 unsigned char uc;
-// CHECK: cir.global external @uc : !cir.int<u, 8>
+// CHECK: cir.global external @uc : !u8i
 
 short ss;
-// CHECK: cir.global external @ss : !cir.int<s, 16>
+// CHECK: cir.global external @ss : !s16i
 
 unsigned short us = 100;
-// CHECK: cir.global external @us = #cir.int<100> : !cir.int<u, 16>
+// CHECK: cir.global external @us = #cir.int<100> : !u16i
 
 int si = 42;
-// CHECK: cir.global external @si = #cir.int<42> : !cir.int<s, 32>
+// CHECK: cir.global external @si = #cir.int<42> : !s32i
 
 unsigned ui;
-// CHECK: cir.global external @ui : !cir.int<u, 32>
+// CHECK: cir.global external @ui : !u32i
 
 long sl;
-// CHECK: cir.global external @sl : !cir.int<s, 64>
+// CHECK: cir.global external @sl : !s64i
 
 unsigned long ul;
-// CHECK: cir.global external @ul : !cir.int<u, 64>
+// CHECK: cir.global external @ul : !u64i
 
 long long sll;
-// CHECK: cir.global external @sll : !cir.int<s, 64>
+// CHECK: cir.global external @sll : !s64i
 
 unsigned long long ull = 123456;
-// CHECK: cir.global external @ull = #cir.int<123456> : !cir.int<u, 64>
+// CHECK: cir.global external @ull = #cir.int<123456> : !u64i
 
 __int128 s128;
-// CHECK: cir.global external @s128 : !cir.int<s, 128>
+// CHECK: cir.global external @s128 : !s128i
 
 unsigned __int128 u128;
-// CHECK: cir.global external @u128 : !cir.int<u, 128>
+// CHECK: cir.global external @u128 : !u128i
 
 wchar_t wc;
-// CHECK: cir.global external @wc : !cir.int<s, 32>
+// CHECK: cir.global external @wc : !s32i
 
 char8_t c8;
-// CHECK: cir.global external @c8 : !cir.int<u, 8>
+// CHECK: cir.global external @c8 : !u8i
 
 char16_t c16;
-// CHECK: cir.global external @c16 : !cir.int<u, 16>
+// CHECK: cir.global external @c16 : !u16i
 
 char32_t c32;
-// CHECK: cir.global external @c32 : !cir.int<u, 32>
+// CHECK: cir.global external @c32 : !u32i
 
 _BitInt(20) sb20;
 // CHECK: cir.global external @sb20 : !cir.int<s, 20>
@@ -80,22 +80,22 @@ __float128 f128;
 // CHECK: cir.global external @f128 : !cir.f128
 
 void *vp;
-// CHECK: cir.global external @vp : !cir.ptr<!cir.void>
+// CHECK: cir.global external @vp : !cir.ptr<!void>
 
 int *ip = 0;
-// CHECK: cir.global external @ip = #cir.ptr<null> : !cir.ptr<!cir.int<s, 32>>
+// CHECK: cir.global external @ip = #cir.ptr<null> : !cir.ptr<!s32i>
 
 double *dp;
 // CHECK: cir.global external @dp : !cir.ptr<!cir.double>
 
 char **cpp;
-// CHECK: cir.global external @cpp : !cir.ptr<!cir.ptr<!cir.int<s, 8>>>
+// CHECK: cir.global external @cpp : !cir.ptr<!cir.ptr<!s8i>>
 
 void (*fp)();
 // CHECK: cir.global external @fp : !cir.ptr<!cir.func<()>>
 
 int (*fpii)(int) = 0;
-// CHECK: cir.global external @fpii = #cir.ptr<null> : !cir.ptr<!cir.func<(!cir.int<s, 32>) -> !cir.int<s, 32>>>
+// CHECK: cir.global external @fpii = #cir.ptr<null> : !cir.ptr<!cir.func<(!s32i) -> !s32i>>
 
 void (*fpvar)(int, ...);
-// CHECK: cir.global external @fpvar : !cir.ptr<!cir.func<(!cir.int<s, 32>, ...)>>
+// CHECK: cir.global external @fpvar : !cir.ptr<!cir.func<(!s32i, ...)>>

--- a/clang/test/CIR/mlprint.c
+++ b/clang/test/CIR/mlprint.c
@@ -7,7 +7,7 @@ int foo(void) {
 }
 
 // CIR:  IR Dump After CIRCanonicalize (cir-canonicalize)
-// CIR:  cir.func @foo() -> !cir.int<s, 32>
+// CIR:  cir.func @foo() -> !s32i
 // LLVM: IR Dump After cir::direct::ConvertCIRToLLVMPass (cir-flat-to-llvm)
 // LLVM: llvm.func @foo() -> i32
 // LLVM: IR Dump After

--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Test runner infrastructure for Clang. This configures the Clang test trees
-# for use by Lit, and delegates to LLVM's lit test handlers.
+# for use by Lit, and delegates to LLVM's lit test handlers.int
 
 llvm_canonicalize_cmake_booleans(
   CLANG_BUILD_EXAMPLES
@@ -89,6 +89,7 @@ list(APPEND CLANG_TEST_DEPS
 if(CLANG_ENABLE_CIR)
   list(APPEND CLANG_TEST_DEPS
     cir-opt
+    cir-translate
     )
 endif()
 

--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Test runner infrastructure for Clang. This configures the Clang test trees
-# for use by Lit, and delegates to LLVM's lit test handlers.int
+# for use by Lit, and delegates to LLVM's lit test handlers.
 
 llvm_canonicalize_cmake_booleans(
   CLANG_BUILD_EXAMPLES


### PR DESCRIPTION
CIR uses aliases for standard integer types and void. This change adds upstream support for those aliases and updates existing tests.