### PR TITLE
Revert "[Premerge] Add flang-rt (#128678)"

### DIFF
--- a/.ci/compute-projects.sh
+++ b/.ci/compute-projects.sh
@@ -18,14 +18,15 @@ function compute-projects-to-test() {
   shift
   projects=${@}
   for project in ${projects}; do
+    echo "${project}"
     case ${project} in
     lld)
-      for p in lld bolt cross-project-tests; do
+      for p in bolt cross-project-tests; do
         echo $p
       done
     ;;
     llvm)
-      for p in llvm bolt clang clang-tools-extra lld lldb mlir polly; do
+      for p in bolt clang clang-tools-extra lld lldb mlir polly; do
         echo $p
       done
       # Flang is not stable in Windows CI at the moment
@@ -35,30 +36,21 @@ function compute-projects-to-test() {
     ;;
     clang)
       # lldb is temporarily removed to alleviate Linux pre-commit CI waiting times
-      for p in clang clang-tools-extra compiler-rt cross-project-tests; do
+      for p in clang-tools-extra compiler-rt cross-project-tests; do
         echo $p
       done
     ;;
     clang-tools-extra)
-      for p in clang-tools-extra libc; do
-        echo $p
-      done
+      echo libc
     ;;
     mlir)
-      echo mlir
-      # Flang is not stable in Windows CI at the moment
-      if [[ $isForWindows == 0 ]]; then
-        echo flang
-      fi
-    ;;
-    flang-rt)
       # Flang is not stable in Windows CI at the moment
       if [[ $isForWindows == 0 ]]; then
         echo flang
       fi
     ;;
     *)
-      echo "${project}"
+      # Nothing to do
     ;;
     esac
   done
@@ -70,11 +62,6 @@ function compute-runtimes-to-test() {
     case ${project} in
     clang)
       for p in libcxx libcxxabi libunwind; do
-        echo $p
-      done
-    ;;
-    flang)
-      for p in flang-rt; do
         echo $p
       done
     ;;

--- a/.ci/generate-buildkite-pipeline-premerge
+++ b/.ci/generate-buildkite-pipeline-premerge
@@ -73,7 +73,7 @@ fi
 # needs while letting them run on the infrastructure provided by LLVM.
 
 # Figure out which projects need to be built on each platform
-all_projects="bolt clang clang-tools-extra compiler-rt cross-project-tests flang flang-rt libc libclc lld lldb llvm mlir openmp polly pstl"
+all_projects="bolt clang clang-tools-extra compiler-rt cross-project-tests flang libc libclc lld lldb llvm mlir openmp polly pstl"
 modified_projects="$(keep-modified-projects ${all_projects})"
 
 linux_projects_to_test=$(exclude-linux $(compute-projects-to-test 0 ${modified_projects}))

--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -65,7 +65,6 @@ cmake -S "${MONOREPO_ROOT}"/llvm -B "${BUILD_DIR}" \
       -D CMAKE_CXX_FLAGS=-gmlt \
       -D LLVM_CCACHE_BUILD=ON \
       -D MLIR_ENABLE_BINDINGS_PYTHON=ON \
-      -D FLANG_ENABLE_FLANG_RT=OFF \
       -D CMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
 
 echo "--- ninja"
@@ -96,9 +95,6 @@ if [[ "${runtimes}" != "" ]]; then
   cmake -S "${MONOREPO_ROOT}/runtimes" -B "${RUNTIMES_BUILD_DIR}" -GNinja \
       -D CMAKE_C_COMPILER="${INSTALL_DIR}/bin/clang" \
       -D CMAKE_CXX_COMPILER="${INSTALL_DIR}/bin/clang++" \
-      -D CMAKE_Fortran_COMPILER="${BUILD_DIR}/bin/flang" \
-      -D CMAKE_Fortran_COMPILER_WORKS=ON \
-      -D LLVM_BINARY_DIR="${BUILD_DIR}" \
       -D LLVM_ENABLE_RUNTIMES="${runtimes}" \
       -D LIBCXX_CXX_ABI=libcxxabi \
       -D CMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -117,9 +113,6 @@ if [[ "${runtimes}" != "" ]]; then
   cmake -S "${MONOREPO_ROOT}/runtimes" -B "${RUNTIMES_BUILD_DIR}" -GNinja \
       -D CMAKE_C_COMPILER="${INSTALL_DIR}/bin/clang" \
       -D CMAKE_CXX_COMPILER="${INSTALL_DIR}/bin/clang++" \
-      -D CMAKE_Fortran_COMPILER="${BUILD_DIR}/bin/flang" \
-      -D CMAKE_Fortran_COMPILER_WORKS=ON \
-      -D LLVM_BINARY_DIR="${BUILD_DIR}" \
       -D LLVM_ENABLE_RUNTIMES="${runtimes}" \
       -D LIBCXX_CXX_ABI=libcxxabi \
       -D CMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -138,9 +131,6 @@ if [[ "${runtimes}" != "" ]]; then
   cmake -S "${MONOREPO_ROOT}/runtimes" -B "${RUNTIMES_BUILD_DIR}" -GNinja \
       -D CMAKE_C_COMPILER="${INSTALL_DIR}/bin/clang" \
       -D CMAKE_CXX_COMPILER="${INSTALL_DIR}/bin/clang++" \
-      -D CMAKE_Fortran_COMPILER="${BUILD_DIR}/bin/flang" \
-      -D CMAKE_Fortran_COMPILER_WORKS=ON \
-      -D LLVM_BINARY_DIR="${BUILD_DIR}" \
       -D LLVM_ENABLE_RUNTIMES="${runtimes}" \
       -D LIBCXX_CXX_ABI=libcxxabi \
       -D CMAKE_BUILD_TYPE=RelWithDebInfo \

--- a/flang-rt/README.md
+++ b/flang-rt/README.md
@@ -124,7 +124,7 @@ $ ninja install
 
 ## Configuration Option Reference
 
-Flang-RT has the following configuration options. This is in
+Flang-RT has the followign configuration options. This is in
 addition to the build options the LLVM_ENABLE_RUNTIMES mechanism and
 CMake itself provide.
 


### PR DESCRIPTION
This reverts commit 95d28fe503cc3d2bc0bb980442d3defaf199ea5a.

I did not fully realize the implications of this change when reviewing. With how it is set up currently, it causes clang and all of the runtimes to be built and tested everytime a change to MLIR is made. This is a large regression in build/test time, which seems to have been causing large queueing delays.

Reverting for now. Once we rework the runtimes build for premerge (which I hope to do soon, ideally in the next week), I will make sure flang-rt gets added in.