### PR TITLE
[lldb-dap] Ensure logging statements are written as a single chunk.

### DIFF
--- a/lldb/tools/lldb-dap/CMakeLists.txt
+++ b/lldb/tools/lldb-dap/CMakeLists.txt
@@ -23,6 +23,7 @@ add_lldb_tool(lldb-dap
   Breakpoint.cpp
   BreakpointBase.cpp
   DAP.cpp
+  DAPLog.cpp
   EventHelper.cpp
   ExceptionBreakpoint.cpp
   FifoFiles.cpp

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -68,8 +68,7 @@ const char DEV_NULL[] = "/dev/null";
 
 namespace lldb_dap {
 
-DAP::DAP(llvm::StringRef path, Log *log,
-         const ReplMode default_repl_mode,
+DAP::DAP(llvm::StringRef path, Log *log, const ReplMode default_repl_mode,
          std::vector<std::string> pre_init_commands, Transport &transport)
     : debug_adapter_path(path), log(log), transport(transport),
       broadcaster("lldb-dap"), exception_breakpoints(),

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -68,7 +68,7 @@ const char DEV_NULL[] = "/dev/null";
 
 namespace lldb_dap {
 
-DAP::DAP(llvm::StringRef path, std::ofstream *log,
+DAP::DAP(llvm::StringRef path, Log *log,
          const ReplMode default_repl_mode,
          std::vector<std::string> pre_init_commands, Transport &transport)
     : debug_adapter_path(path), log(log), transport(transport),

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -144,7 +144,7 @@ struct SendEventRequestHandler : public lldb::SBCommandPluginInterface {
 
 struct DAP {
   llvm::StringRef debug_adapter_path;
-  std::ofstream *log;
+  Log *log;
   Transport &transport;
   lldb::SBFile in;
   OutputRedirector out;
@@ -211,14 +211,14 @@ struct DAP {
   /// \param[in] path
   ///     Path to the lldb-dap binary.
   /// \param[in] log
-  ///     Log file stream, if configured.
+  ///     Log stream, if configured.
   /// \param[in] default_repl_mode
   ///     Default repl mode behavior, as configured by the binary.
   /// \param[in] pre_init_commands
   ///     LLDB commands to execute as soon as the debugger instance is allocaed.
   /// \param[in] transport
   ///     Transport for this debug session.
-  DAP(llvm::StringRef path, std::ofstream *log,
+  DAP(llvm::StringRef path, Log *log,
       const ReplMode default_repl_mode,
       std::vector<std::string> pre_init_commands, Transport &transport);
 

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -218,8 +218,7 @@ struct DAP {
   ///     LLDB commands to execute as soon as the debugger instance is allocaed.
   /// \param[in] transport
   ///     Transport for this debug session.
-  DAP(llvm::StringRef path, Log *log,
-      const ReplMode default_repl_mode,
+  DAP(llvm::StringRef path, Log *log, const ReplMode default_repl_mode,
       std::vector<std::string> pre_init_commands, Transport &transport);
 
   ~DAP();

--- a/lldb/tools/lldb-dap/DAPForward.h
+++ b/lldb/tools/lldb-dap/DAPForward.h
@@ -19,6 +19,7 @@ struct SourceBreakpoint;
 struct Watchpoint;
 struct InstructionBreakpoint;
 struct DAP;
+class Log;
 class BaseRequestHandler;
 class ResponseHandler;
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/DAPLog.cpp
+++ b/lldb/tools/lldb-dap/DAPLog.cpp
@@ -1,0 +1,26 @@
+//===-- DAPLog.cpp --------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "DAPLog.h"
+#include "llvm/ADT/StringRef.h"
+#include <fstream>
+#include <mutex>
+
+using namespace llvm;
+
+namespace lldb_dap {
+
+Log::Log(StringRef filename) : m_stream(std::ofstream(filename.str())) {}
+
+void Log::WriteMessage(StringRef message) {
+  std::scoped_lock<std::mutex> lock(m_mutex);
+  m_stream << message.str();
+  m_stream.flush();
+}
+
+} // namespace lldb_dap

--- a/lldb/tools/lldb-dap/DAPLog.cpp
+++ b/lldb/tools/lldb-dap/DAPLog.cpp
@@ -8,18 +8,23 @@
 
 #include "DAPLog.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+#include <chrono>
 #include <fstream>
 #include <mutex>
+#include <system_error>
 
 using namespace llvm;
 
 namespace lldb_dap {
 
-Log::Log(StringRef filename) : m_stream(std::ofstream(filename.str())) {}
+Log::Log(StringRef filename, std::error_code &EC) : m_stream(filename, EC) {}
 
 void Log::WriteMessage(StringRef message) {
   std::scoped_lock<std::mutex> lock(m_mutex);
-  m_stream << message.str();
+  std::chrono::duration<double> now{
+      std::chrono::system_clock::now().time_since_epoch()};
+  m_stream << formatv("{0:f9} ", now.count()).str() << message << "\n";
   m_stream.flush();
 }
 

--- a/lldb/tools/lldb-dap/DAPLog.cpp
+++ b/lldb/tools/lldb-dap/DAPLog.cpp
@@ -10,7 +10,6 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 #include <chrono>
-#include <fstream>
 #include <mutex>
 #include <system_error>
 
@@ -21,7 +20,7 @@ namespace lldb_dap {
 Log::Log(StringRef filename, std::error_code &EC) : m_stream(filename, EC) {}
 
 void Log::WriteMessage(StringRef message) {
-  std::scoped_lock<std::mutex> lock(m_mutex);
+  std::lock_guard<std::mutex> lock(m_mutex);
   std::chrono::duration<double> now{
       std::chrono::system_clock::now().time_since_epoch()};
   m_stream << formatv("{0:f9} ", now.count()).str() << message << "\n";

--- a/lldb/tools/lldb-dap/DAPLog.h
+++ b/lldb/tools/lldb-dap/DAPLog.h
@@ -54,15 +54,20 @@
 
 namespace lldb_dap {
 
-class Log {
+/// Log manages the lldb-dap log file, used with the corresponding `DAP_LOG` and
+/// `DAP_LOG_ERROR` helpers.
+class Log final {
 public:
-  Log(std::ofstream stream) : m_stream(std::move(stream)) {}
+  /// Creates a log file with the given filename.
+  Log(llvm::StringRef filename);
 
-  void WriteMessage(llvm::StringRef message) {
-    std::scoped_lock<std::mutex> lock(m_mutex);
-    m_stream << message.str();
-    m_stream.flush();
-  }
+  /// Log is not copyable.
+  /// @{
+  Log(const Log &) = delete;
+  void operator=(const Log &) = delete;
+  /// @}
+
+  void WriteMessage(llvm::StringRef message);
 
 private:
   std::mutex m_mutex;

--- a/lldb/tools/lldb-dap/DAPLog.h
+++ b/lldb/tools/lldb-dap/DAPLog.h
@@ -9,17 +9,19 @@
 #ifndef LLDB_TOOLS_LLDB_DAP_DAPLOG_H
 #define LLDB_TOOLS_LLDB_DAP_DAPLOG_H
 
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/FormatVariadic.h"
 #include <chrono>
 #include <fstream>
+#include <mutex>
 #include <string>
 
 // Write a message to log, if logging is enabled.
 #define DAP_LOG(log, ...)                                                      \
   do {                                                                         \
-    ::std::ofstream *log_private = (log);                                      \
+    ::lldb_dap::Log *log_private = (log);                                      \
     if (log_private) {                                                         \
       ::std::chrono::duration<double> now{                                     \
           ::std::chrono::system_clock::now().time_since_epoch()};              \
@@ -27,8 +29,7 @@
       ::llvm::raw_string_ostream os(out);                                      \
       os << ::llvm::formatv("{0:f9} ", now.count()).str()                      \
          << ::llvm::formatv(__VA_ARGS__).str() << "\n";                        \
-      *log_private << out;                                                     \
-      log_private->flush();                                                    \
+      log_private->WriteMessage(out);                                          \
     }                                                                          \
   } while (0)
 
@@ -36,7 +37,7 @@
 // with {0}. Error is cleared regardless of whether logging is enabled.
 #define DAP_LOG_ERROR(log, error, ...)                                         \
   do {                                                                         \
-    ::std::ofstream *log_private = (log);                                      \
+    ::lldb_dap::Log *log_private = (log);                                      \
     ::llvm::Error error_private = (error);                                     \
     if (log_private && error_private) {                                        \
       ::std::chrono::duration<double> now{                                     \
@@ -46,13 +47,27 @@
       os << ::llvm::formatv("{0:f9} ", now.count()).str()                      \
          << ::lldb_dap::FormatError(::std::move(error_private), __VA_ARGS__)   \
          << "\n";                                                              \
-      *log_private << out;                                                     \
-      log_private->flush();                                                    \
+      log_private->WriteMessage(out);                                          \
     } else                                                                     \
       ::llvm::consumeError(::std::move(error_private));                        \
   } while (0)
 
 namespace lldb_dap {
+
+class Log {
+public:
+  Log(std::ofstream stream) : m_stream(std::move(stream)) {}
+
+  void WriteMessage(llvm::StringRef message) {
+    std::scoped_lock<std::mutex> lock(m_mutex);
+    m_stream << message.str();
+    m_stream.flush();
+  }
+
+private:
+  std::mutex m_mutex;
+  std::ofstream m_stream;
+};
 
 template <typename... Args>
 inline auto FormatError(llvm::Error error, const char *format, Args &&...args) {

--- a/lldb/tools/lldb-dap/DAPLog.h
+++ b/lldb/tools/lldb-dap/DAPLog.h
@@ -23,8 +23,12 @@
     if (log_private) {                                                         \
       ::std::chrono::duration<double> now{                                     \
           ::std::chrono::system_clock::now().time_since_epoch()};              \
-      *log_private << ::llvm::formatv("{0:f9} ", now.count()).str()            \
-                   << ::llvm::formatv(__VA_ARGS__).str() << std::endl;         \
+      ::std::string out;                                                       \
+      ::llvm::raw_string_ostream os(out);                                      \
+      os << ::llvm::formatv("{0:f9} ", now.count()).str()                      \
+         << ::llvm::formatv(__VA_ARGS__).str() << "\n";                        \
+      *log_private << out;                                                     \
+      log_private->flush();                                                    \
     }                                                                          \
   } while (0)
 
@@ -37,10 +41,13 @@
     if (log_private && error_private) {                                        \
       ::std::chrono::duration<double> now{                                     \
           std::chrono::system_clock::now().time_since_epoch()};                \
-      *log_private << ::llvm::formatv("{0:f9} ", now.count()).str()            \
-                   << ::lldb_dap::FormatError(::std::move(error_private),      \
-                                              __VA_ARGS__)                     \
-                   << std::endl;                                               \
+      ::std::string out;                                                       \
+      ::llvm::raw_string_ostream os(out);                                      \
+      os << ::llvm::formatv("{0:f9} ", now.count()).str()                      \
+         << ::lldb_dap::FormatError(::std::move(error_private), __VA_ARGS__)   \
+         << "\n";                                                              \
+      *log_private << out;                                                     \
+      log_private->flush();                                                    \
     } else                                                                     \
       ::llvm::consumeError(::std::move(error_private));                        \
   } while (0)

--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -8,6 +8,7 @@
 
 #include "EventHelper.h"
 #include "DAP.h"
+#include "DAPLog.h"
 #include "JSONUtils.h"
 #include "LLDBUtils.h"
 #include "lldb/API/SBFileSpec.h"

--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -178,15 +178,13 @@ void SendThreadStoppedEvent(DAP &dap) {
           SendThreadExitedEvent(dap, tid);
       }
     } else {
-      if (dap.log)
-        *dap.log << "error: SendThreadStoppedEvent() when process"
-                    " isn't stopped ("
-                 << lldb::SBDebugger::StateAsCString(state) << ')' << std::endl;
+      DAP_LOG(
+          dap.log,
+          "error: SendThreadStoppedEvent() when process isn't stopped ({0})",
+          lldb::SBDebugger::StateAsCString(state));
     }
   } else {
-    if (dap.log)
-      *dap.log << "error: SendThreadStoppedEvent() invalid process"
-               << std::endl;
+    DAP_LOG(dap.log, "error: SendThreadStoppedEvent() invalid process");
   }
   dap.RunStopCommands();
 }

--- a/lldb/tools/lldb-dap/Transport.cpp
+++ b/lldb/tools/lldb-dap/Transport.cpp
@@ -63,8 +63,8 @@ static constexpr StringLiteral kHeaderSeparator = "\r\n\r\n";
 
 namespace lldb_dap {
 
-Transport::Transport(StringRef client_name, Log *log,
-                     IOObjectSP input, IOObjectSP output)
+Transport::Transport(StringRef client_name, Log *log, IOObjectSP input,
+                     IOObjectSP output)
     : m_client_name(client_name), m_log(log), m_input(std::move(input)),
       m_output(std::move(output)) {}
 

--- a/lldb/tools/lldb-dap/Transport.cpp
+++ b/lldb/tools/lldb-dap/Transport.cpp
@@ -63,7 +63,7 @@ static constexpr StringLiteral kHeaderSeparator = "\r\n\r\n";
 
 namespace lldb_dap {
 
-Transport::Transport(StringRef client_name, std::ofstream *log,
+Transport::Transport(StringRef client_name, Log *log,
                      IOObjectSP input, IOObjectSP output)
     : m_client_name(client_name), m_log(log), m_input(std::move(input)),
       m_output(std::move(output)) {}

--- a/lldb/tools/lldb-dap/Transport.h
+++ b/lldb/tools/lldb-dap/Transport.h
@@ -14,11 +14,11 @@
 #ifndef LLDB_TOOLS_LLDB_DAP_TRANSPORT_H
 #define LLDB_TOOLS_LLDB_DAP_TRANSPORT_H
 
+#include "DAPLog.h"
 #include "Protocol/ProtocolBase.h"
 #include "lldb/lldb-forward.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
-#include <fstream>
 #include <optional>
 
 namespace lldb_dap {
@@ -27,8 +27,8 @@ namespace lldb_dap {
 /// with the client.
 class Transport {
 public:
-  Transport(llvm::StringRef client_name, std::ofstream *log,
-            lldb::IOObjectSP input, lldb::IOObjectSP output);
+  Transport(llvm::StringRef client_name, Log *log, lldb::IOObjectSP input,
+            lldb::IOObjectSP output);
   ~Transport() = default;
 
   /// Transport is not copyable.
@@ -51,7 +51,7 @@ public:
 
 private:
   llvm::StringRef m_client_name;
-  std::ofstream *m_log;
+  Log *m_log;
   lldb::IOObjectSP m_input;
   lldb::IOObjectSP m_output;
 };

--- a/lldb/tools/lldb-dap/Transport.h
+++ b/lldb/tools/lldb-dap/Transport.h
@@ -14,7 +14,7 @@
 #ifndef LLDB_TOOLS_LLDB_DAP_TRANSPORT_H
 #define LLDB_TOOLS_LLDB_DAP_TRANSPORT_H
 
-#include "DAPLog.h"
+#include "DAPForward.h"
 #include "Protocol/ProtocolBase.h"
 #include "lldb/lldb-forward.h"
 #include "llvm/ADT/StringRef.h"

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -487,7 +487,7 @@ int main(int argc, char *argv[]) {
   std::unique_ptr<Log> log = nullptr;
   const char *log_file_path = getenv("LLDBDAP_LOG");
   if (log_file_path)
-    log = std::make_unique<Log>(std::ofstream(log_file_path));
+    log = std::make_unique<Log>(log_file_path);
 
   // Initialize LLDB first before we do anything.
   lldb::SBError error = lldb::SBDebugger::InitializeWithErrorHandling();

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -281,7 +281,7 @@ validateConnection(llvm::StringRef conn) {
 
 static llvm::Error
 serveConnection(const Socket::SocketProtocol &protocol, const std::string &name,
-                std::ofstream *log, llvm::StringRef program_path,
+                Log *log, llvm::StringRef program_path,
                 const ReplMode default_repl_mode,
                 const std::vector<std::string> &pre_init_commands) {
   Status status;
@@ -484,10 +484,10 @@ int main(int argc, char *argv[]) {
   }
 #endif
 
-  std::unique_ptr<std::ofstream> log = nullptr;
+  std::unique_ptr<Log> log = nullptr;
   const char *log_file_path = getenv("LLDBDAP_LOG");
   if (log_file_path)
-    log = std::make_unique<std::ofstream>(log_file_path);
+    log = std::make_unique<Log>(std::ofstream(log_file_path));
 
   // Initialize LLDB first before we do anything.
   lldb::SBError error = lldb::SBDebugger::InitializeWithErrorHandling();


### PR DESCRIPTION
I noticed this while debugging some unit tests that the logs occasionally would intersperse two log statements.

Previously, it was possible for a log statement to have two messages interspersed since the timestamp and log statement were two different writes to the log stream.

Instead, combine the logging into a single buffer first before printing.