### PR TITLE
[openmp][nfc] Use builtin align in the devicertl

### DIFF
--- a/offload/DeviceRTL/src/State.cpp
+++ b/offload/DeviceRTL/src/State.cpp
@@ -89,8 +89,8 @@ private:
   /// Compute the size of the storage space reserved for a thread.
   uint32_t computeThreadStorageTotal() {
     uint32_t NumLanesInBlock = mapping::getNumberOfThreadsInBlock();
-    return utils::alignDown((state::SharedScratchpadSize / NumLanesInBlock),
-                            allocator::ALIGNMENT);
+    return __builtin_align_down(state::SharedScratchpadSize / NumLanesInBlock,
+                                allocator::ALIGNMENT);
   }
 
   /// Return the top address of the warp data stack, that is the first address
@@ -121,7 +121,7 @@ void *SharedMemorySmartStackTy::push(uint64_t Bytes) {
   // First align the number of requested bytes.
   /// FIXME: The stack shouldn't require worst-case padding. Alignment needs to
   /// be passed in as an argument and the stack rewritten to support it.
-  uint64_t AlignedBytes = utils::alignPtr(Bytes, allocator::ALIGNMENT);
+  uint64_t AlignedBytes = __builtin_align_up(Bytes, allocator::ALIGNMENT);
 
   uint32_t StorageTotal = computeThreadStorageTotal();
 
@@ -149,7 +149,7 @@ void *SharedMemorySmartStackTy::push(uint64_t Bytes) {
 }
 
 void SharedMemorySmartStackTy::pop(void *Ptr, uint64_t Bytes) {
-  uint64_t AlignedBytes = utils::alignPtr(Bytes, allocator::ALIGNMENT);
+  uint64_t AlignedBytes = __builtin_align_up(Bytes, allocator::ALIGNMENT);
   if (utils::isSharedMemPtr(Ptr)) {
     int TId = mapping::getThreadIdInBlock();
     Usage[TId] -= AlignedBytes;

--- a/offload/include/Shared/Utils.h
+++ b/offload/include/Shared/Utils.h
@@ -34,10 +34,6 @@ template <typename Ty1, typename Ty2> Ty1 *advancePtr(Ty1 *Ptr, Ty2 Offset) {
 template <typename Ty1, typename Ty2> inline Ty1 alignPtr(Ty1 V, Ty2 Align) {
   return reinterpret_cast<Ty1>(((uintptr_t(V) + Align - 1) / Align) * Align);
 }
-/// Return \p V aligned "downwards" according to \p Align.
-template <typename Ty1, typename Ty2> inline Ty1 alignDown(Ty1 V, Ty2 Align) {
-  return V - V % Align;
-}
 
 /// Round up \p V to a \p Boundary.
 template <typename Ty> inline Ty roundUp(Ty V, Ty Boundary) {


### PR DESCRIPTION
Noticed while extracting the smartstack as a test case