### PR TITLE
[clang-doc] Avoid deref of invalid std::optional

### DIFF
--- a/clang-tools-extra/clang-doc/HTMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLGenerator.cpp
@@ -498,7 +498,7 @@ writeFileDefinition(const Location &L,
     return std::make_unique<TagNode>(
         HTMLTag::TAG_P, "Defined at line " + std::to_string(L.LineNumber) +
                             " of file " + L.Filename);
-  SmallString<128> FileURL(*RepositoryUrl);
+  SmallString<128> FileURL(RepositoryUrl.value_or(""));
   llvm::sys::path::append(
       FileURL, llvm::sys::path::Style::posix,
       // If we're on Windows, the file name will be in the wrong format, and

--- a/clang-tools-extra/test/clang-doc/DR-131697.cpp
+++ b/clang-tools-extra/test/clang-doc/DR-131697.cpp
@@ -1,0 +1,22 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: split-file %s %t
+// RUN: clang-doc -format=html %t/compile_commands.json %t/main.cpp
+
+//--- main.cpp
+
+class Foo {
+  void getFoo();
+};
+
+int main() {
+  return 0;
+}
+
+//--- compile_commands.json
+[
+{
+  "directory": "foo",
+  "file":"main.cpp",
+  "command":"clang main.cpp -c"
+}
+]


### PR DESCRIPTION
Since our existing guard is insufficient to prevent accessing the
std::optional when in an invalid state, guard the access with
`.value_or()`. This maintains the desired behavior, without running into
UB.

The new test should prevent regressions.

Fixes #131697