### PR TITLE
[opt][timers] Fix time-passes.ll test failing on reversed iterators

### DIFF
--- a/llvm/test/Other/time-passes.ll
+++ b/llvm/test/Other/time-passes.ll
@@ -14,7 +14,6 @@
 ; RUN: rm -f %t; opt < %s -disable-output -passes='default<O2>' -time-passes -info-output-file=%t
 ; RUN:   cat %t | FileCheck %s --check-prefix=TIME
 ;
-
 ; TIME: Analysis execution timing report
 ; TIME: Total Execution Time:
 ; TIME: Name
@@ -63,7 +62,6 @@
 ; TIME-PER-PASS-NOT:   LoopSimplifyPass #
 ; TIME-PER-PASS-NOT:   VerifierPass #
 ; TIME: Total{{$}}
-
 
 define i32 @foo() {
   %res = add i32 5, 4

--- a/llvm/test/Other/time-passes.ll
+++ b/llvm/test/Other/time-passes.ll
@@ -14,6 +14,24 @@
 ; RUN: rm -f %t; opt < %s -disable-output -passes='default<O2>' -time-passes -info-output-file=%t
 ; RUN:   cat %t | FileCheck %s --check-prefix=TIME
 ;
+
+; TIME: Analysis execution timing report
+; TIME: Total Execution Time:
+; TIME: Name
+; TIME-PER-RUN-DAG:      ScalarEvolutionAnalysis
+; TIME-PER-RUN-DAG:      LoopAnalysis
+; TIME-PER-RUN-DAG:      DominatorTreeAnalysis
+; TIME-PER-RUN-DAG:      TargetLibraryAnalysis
+; TIME-PER-PASS-DAG:   ScalarEvolutionAnalysis
+; TIME-PER-PASS-DAG:   LoopAnalysis
+; TIME-PER-PASS-DAG:   DominatorTreeAnalysis
+; TIME-PER-PASS-DAG:   TargetLibraryAnalysis
+; TIME-PER-PASS-NOT:   ScalarEvolutionAnalysis #
+; TIME-PER-PASS-NOT:   LoopAnalysis #
+; TIME-PER-PASS-NOT:   DominatorTreeAnalysis #
+; TIME-PER-PASS-NOT:   TargetLibraryAnalysis #
+; TIME: Total{{$}}
+
 ; TIME: Pass execution timing report
 ; TIME: Total Execution Time:
 ; TIME: Name
@@ -46,22 +64,6 @@
 ; TIME-PER-PASS-NOT:   VerifierPass #
 ; TIME: Total{{$}}
 
-; TIME: Analysis execution timing report
-; TIME: Total Execution Time:
-; TIME: Name
-; TIME-PER-RUN-DAG:      ScalarEvolutionAnalysis
-; TIME-PER-RUN-DAG:      LoopAnalysis
-; TIME-PER-RUN-DAG:      DominatorTreeAnalysis
-; TIME-PER-RUN-DAG:      TargetLibraryAnalysis
-; TIME-PER-PASS-DAG:   ScalarEvolutionAnalysis
-; TIME-PER-PASS-DAG:   LoopAnalysis
-; TIME-PER-PASS-DAG:   DominatorTreeAnalysis
-; TIME-PER-PASS-DAG:   TargetLibraryAnalysis
-; TIME-PER-PASS-NOT:   ScalarEvolutionAnalysis #
-; TIME-PER-PASS-NOT:   LoopAnalysis #
-; TIME-PER-PASS-NOT:   DominatorTreeAnalysis #
-; TIME-PER-PASS-NOT:   TargetLibraryAnalysis #
-; TIME: Total{{$}}
 
 define i32 @foo() {
   %res = add i32 5, 4

--- a/llvm/tools/opt/NewPMDriver.cpp
+++ b/llvm/tools/opt/NewPMDriver.cpp
@@ -14,6 +14,7 @@
 
 #include "NewPMDriver.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Analysis/AliasAnalysis.h"
 #include "llvm/Analysis/CGSCCPassManager.h"
@@ -30,6 +31,7 @@
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Passes/StandardInstrumentations.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Timer.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
@@ -563,6 +565,9 @@ bool llvm::runPassPipeline(
 
   if (DebugifyEach && !DebugifyExport.empty())
     exportDebugifyStats(DebugifyExport, Debugify.getDebugifyStatsMap());
+
+  TimerGroup::printAll(*CreateInfoOutputFile());
+  TimerGroup::clearAll();
 
   return true;
 }

--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -48,7 +48,6 @@
 #include "llvm/Support/SystemUtils.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/TimeProfiler.h"
-#include "llvm/Support/Timer.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/YAMLTraits.h"
 #include "llvm/Target/TargetMachine.h"
@@ -723,16 +722,14 @@ extern "C" int optMain(
     // The user has asked to use the new pass manager and provided a pipeline
     // string. Hand off the rest of the functionality to the new code for that
     // layer.
-    bool result = runPassPipeline(
-        argv[0], *M, TM.get(), &TLII, Out.get(), ThinLinkOut.get(),
-        RemarksFile.get(), Pipeline, PluginList, PassBuilderCallbacks, OK, VK,
-        PreserveAssemblyUseListOrder, PreserveBitcodeUseListOrder,
-        EmitSummaryIndex, EmitModuleHash, EnableDebugify,
-        VerifyDebugInfoPreserve, UnifiedLTO);
-
-    llvm::TimerGroup::printAll(*llvm::CreateInfoOutputFile());
-    llvm::TimerGroup::clearAll();
-    return result ? 0 : 1;
+    return runPassPipeline(
+               argv[0], *M, TM.get(), &TLII, Out.get(), ThinLinkOut.get(),
+               RemarksFile.get(), Pipeline, PluginList, PassBuilderCallbacks,
+               OK, VK, PreserveAssemblyUseListOrder,
+               PreserveBitcodeUseListOrder, EmitSummaryIndex, EmitModuleHash,
+               EnableDebugify, VerifyDebugInfoPreserve, UnifiedLTO)
+               ? 0
+               : 1;
   }
 
   if (OptLevelO0 || OptLevelO1 || OptLevelO2 || OptLevelOs || OptLevelOz ||
@@ -907,9 +904,6 @@ extern "C" int optMain(
 
   if (ThinLinkOut)
     ThinLinkOut->keep();
-
-  llvm::TimerGroup::printAll(*llvm::CreateInfoOutputFile());
-  llvm::TimerGroup::clearAll();
 
   return 0;
 }

--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -723,12 +723,12 @@ extern "C" int optMain(
     // The user has asked to use the new pass manager and provided a pipeline
     // string. Hand off the rest of the functionality to the new code for that
     // layer.
-    bool result =  runPassPipeline(
-               argv[0], *M, TM.get(), &TLII, Out.get(), ThinLinkOut.get(),
-               RemarksFile.get(), Pipeline, PluginList, PassBuilderCallbacks,
-               OK, VK, PreserveAssemblyUseListOrder,
-               PreserveBitcodeUseListOrder, EmitSummaryIndex, EmitModuleHash,
-               EnableDebugify, VerifyDebugInfoPreserve, UnifiedLTO);
+    bool result = runPassPipeline(
+        argv[0], *M, TM.get(), &TLII, Out.get(), ThinLinkOut.get(),
+        RemarksFile.get(), Pipeline, PluginList, PassBuilderCallbacks, OK, VK,
+        PreserveAssemblyUseListOrder, PreserveBitcodeUseListOrder,
+        EmitSummaryIndex, EmitModuleHash, EnableDebugify,
+        VerifyDebugInfoPreserve, UnifiedLTO);
 
     llvm::TimerGroup::printAll(*llvm::CreateInfoOutputFile());
     llvm::TimerGroup::clearAll();

--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -48,6 +48,7 @@
 #include "llvm/Support/SystemUtils.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/TimeProfiler.h"
+#include "llvm/Support/Timer.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/YAMLTraits.h"
 #include "llvm/Target/TargetMachine.h"
@@ -722,14 +723,16 @@ extern "C" int optMain(
     // The user has asked to use the new pass manager and provided a pipeline
     // string. Hand off the rest of the functionality to the new code for that
     // layer.
-    return runPassPipeline(
+    bool result =  runPassPipeline(
                argv[0], *M, TM.get(), &TLII, Out.get(), ThinLinkOut.get(),
                RemarksFile.get(), Pipeline, PluginList, PassBuilderCallbacks,
                OK, VK, PreserveAssemblyUseListOrder,
                PreserveBitcodeUseListOrder, EmitSummaryIndex, EmitModuleHash,
-               EnableDebugify, VerifyDebugInfoPreserve, UnifiedLTO)
-               ? 0
-               : 1;
+               EnableDebugify, VerifyDebugInfoPreserve, UnifiedLTO);
+
+    llvm::TimerGroup::printAll(*llvm::CreateInfoOutputFile());
+    llvm::TimerGroup::clearAll();
+    return result ? 0 : 1;
   }
 
   if (OptLevelO0 || OptLevelO1 || OptLevelO2 || OptLevelOs || OptLevelOz ||
@@ -904,6 +907,9 @@ extern "C" int optMain(
 
   if (ThinLinkOut)
     ThinLinkOut->keep();
+
+  llvm::TimerGroup::printAll(*llvm::CreateInfoOutputFile());
+  llvm::TimerGroup::clearAll();
 
   return 0;
 }


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/131217 was submitted, time-passes.ll fails because `opt` prints `-time-report` when `ManagedTimerGlobals` is destroyed. `ManagedTimerGlobals` stores `TimerGroup`s in an unordered map, so the ordering of the output `TimerGroup`s depends on the underlying iterator.

To fix this, we do what Clang does and use
`llvm::TimerGroup::printAll(...)`, which *is* deterministic. This is also what Clang does. This does put move analysis section before the pass section for `-time-report`, but again, this is also what Clang currently does.