### PR TITLE
[lldb] Require wide char support in unicode test

### DIFF
--- a/lldb/test/API/iohandler/unicode/TestUnicode.py
+++ b/lldb/test/API/iohandler/unicode/TestUnicode.py
@@ -16,6 +16,7 @@ class TestCase(PExpectTest):
     # under ASAN on a loaded machine..
     @skipIfAsan
     @skipIf(oslist=["linux"], archs=["arm", "aarch64"])  # Randomly fails on buildbot
+    @skipIfEditlineWideCharSupportMissing
     def test_unicode_input(self):
         self.launch()
 


### PR DESCRIPTION
The unicode test sends some unicode input to lldb through pexpect and expects the output to be echoed back in an error message. This only works correctly when editline was compiled with wide character support.

This commit modifies the test to require the necessary libedit configuration.