### PR TITLE
[libc++] Validate exception throwing for vector mutators on max_size violation

### DIFF
--- a/libcxx/test/std/containers/sequences/vector.bool/append_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/append_range.pass.cpp
@@ -65,8 +65,5 @@ int main(int, char**) {
   test();
   static_assert(test());
 
-  // Note: `test_append_range_exception_safety_throwing_copy` doesn't apply because copying booleans cannot throw.
-  test_append_range_exception_safety_throwing_allocator<std::vector, bool>();
-
   return 0;
 }

--- a/libcxx/test/std/containers/sequences/vector.bool/append_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/append_range.pass.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "../insert_range_sequence_containers.h"
+#include "test_allocator.h"
 #include "test_macros.h"
 
 // Tested cases:
@@ -55,6 +56,15 @@ constexpr bool test() {
 
       v.append_range(in);
       assert(std::ranges::equal(v, std::vector<bool>{0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1}));
+    }
+
+    { // Ensure that appending an empty range has no effect
+      std::vector<bool, limited_allocator<bool, 10> > v;
+      v.resize(v.max_size(), true);
+      std::vector<bool> a;
+      v.append_range(a);
+      for (std::size_t i = 0; i < v.size(); ++i)
+        assert(v[i] == true);
     }
   }
 

--- a/libcxx/test/std/containers/sequences/vector.bool/append_range_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/append_range_exceptions.pass.cpp
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
+// UNSUPPORTED: no-exceptions
+
+// <vector>
+// vector<bool>
+
+// template<container-compatible-range<bool> R>
+//   constexpr void append_range(R&& rg); // C++23
+
+#include <cassert>
+#include <vector>
+
+#include "../insert_range_sequence_containers.h"
+#include "test_allocator.h"
+
+void test() {
+  // Note: `test_append_range_exception_safety_throwing_copy` doesn't apply because copying booleans cannot throw.
+  test_append_range_exception_safety_throwing_allocator<std::vector, bool>();
+
+  {
+    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
+    Vec v(Vec().max_size() - 2, true);
+    bool a[] = {false, true, false};
+    try {
+      v.append_range(a);
+      assert(false);
+    } catch (const std::length_error&) {
+      assert(v.size() == v.max_size() - 2);
+      for (std::size_t i = 0; i < v.size(); ++i)
+        assert(v[i] == true);
+    }
+  }
+  {
+    std::vector<bool, limited_allocator<bool, 10> > v(10, true);
+    bool a[10 * 65536] = {};
+    try {
+      v.append_range(a);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == 10);
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == true);
+    }
+  }
+}
+
+int main(int, char**) {
+  test();
+
+  return 0;
+}

--- a/libcxx/test/std/containers/sequences/vector.bool/append_range_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/append_range_exceptions.pass.cpp
@@ -26,7 +26,7 @@ int main(int, char**) {
   // Note: `test_append_range_exception_safety_throwing_copy` doesn't apply because copying booleans cannot throw.
   test_append_range_exception_safety_throwing_allocator<std::vector, bool>();
 
-  {
+  { // Attempt to append more elements to a non-empty vector<bool> than its maximum possible size
     std::vector<bool, limited_allocator<bool, 10> > v;
     v.resize(v.max_size() - 2, true);
     bool a[] = {false, true, false};
@@ -39,16 +39,14 @@ int main(int, char**) {
         assert(v[i] == true);
     }
   }
-  {
-    std::vector<bool, limited_allocator<bool, 10> > v(5, true);
-    bool a[v.max_size()] = {}; // A large enough array to trigger a length_error when appended
+  { // Attempt to append more elements to an empty vector<bool> than its maximum possible size
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    bool a[v.max_size() + 1] = {}; // A large enough array to trigger a length_error when appended
     try {
       v.append_range(a);
       assert(false);
     } catch (const std::length_error&) {
-      assert(v.size() == 5);
-      for (std::size_t i = 0; i != v.size(); ++i)
-        assert(v[i] == true);
+      assert(v.empty());
     }
   }
 

--- a/libcxx/test/std/containers/sequences/vector.bool/emplace_back_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/emplace_back_exceptions.pass.cpp
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11
+// UNSUPPORTED: no-exceptions
+
+// <vector>
+// vector<bool>
+
+// template <class... Args>
+//     reference emplace_back(Args&&... args); // reference in C++17
+
+#include <cassert>
+#include <vector>
+
+#include "test_allocator.h"
+
+int main(int, char**) {
+  using Vec = std::vector<bool, limited_allocator<bool, 10> >;
+  Vec v(Vec().max_size(), true);
+  try {
+    v.emplace_back(true);
+    assert(false);
+  } catch (...) {
+    assert(v.size() == v.max_size());
+    for (std::size_t i = 0; i != v.size(); ++i)
+      assert(v[i] == true);
+  }
+
+  return 0;
+}

--- a/libcxx/test/std/containers/sequences/vector.bool/emplace_back_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/emplace_back_exceptions.pass.cpp
@@ -24,6 +24,8 @@
 int main(int, char**) {
   std::vector<bool, limited_allocator<bool, 10> > v;
   v.resize(v.max_size(), true);
+
+  // Attempt to append one more element to a vector<bool> that is already at its maximum possible size
   try {
     v.emplace_back(true);
     assert(false);

--- a/libcxx/test/std/containers/sequences/vector.bool/emplace_back_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/emplace_back_exceptions.pass.cpp
@@ -16,17 +16,18 @@
 //     reference emplace_back(Args&&... args); // reference in C++17
 
 #include <cassert>
+#include <stdexcept>
 #include <vector>
 
 #include "test_allocator.h"
 
 int main(int, char**) {
-  using Vec = std::vector<bool, limited_allocator<bool, 10> >;
-  Vec v(Vec().max_size(), true);
+  std::vector<bool, limited_allocator<bool, 10> > v;
+  v.resize(v.max_size(), true);
   try {
     v.emplace_back(true);
     assert(false);
-  } catch (...) {
+  } catch (const std::length_error&) {
     assert(v.size() == v.max_size());
     for (std::size_t i = 0; i != v.size(); ++i)
       assert(v[i] == true);

--- a/libcxx/test/std/containers/sequences/vector.bool/emplace_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/emplace_exceptions.pass.cpp
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11
+// UNSUPPORTED: no-exceptions
+
+// <vector>
+// vector<bool>
+
+// template <class... Args> iterator emplace(const_iterator pos, Args&&... args);
+
+#include <cassert>
+#include <vector>
+
+#include "test_allocator.h"
+
+void test() {
+  {
+    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
+    Vec v(Vec().max_size(), true);
+    try {
+      v.emplace(v.begin(), true);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == v.max_size());
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == true);
+    }
+  }
+  {
+    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
+    Vec v(Vec().max_size(), true);
+    try {
+      v.emplace(v.end(), true);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == v.max_size());
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == true);
+    }
+  }
+  {
+    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
+    Vec v(Vec().max_size(), true);
+    try {
+      v.emplace(v.begin() + v.size() / 2, true);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == v.max_size());
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == true);
+    }
+  }
+}
+
+int main(int, char**) {
+  test();
+
+  return 0;
+}

--- a/libcxx/test/std/containers/sequences/vector.bool/emplace_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/emplace_exceptions.pass.cpp
@@ -21,7 +21,7 @@
 #include "test_allocator.h"
 
 int main(int, char**) {
-  {
+  { // Attempt to insert an element at the beginning of a vector<bool> that is already at its maximum possible size
     std::vector<bool, limited_allocator<bool, 10> > v;
     v.resize(v.max_size(), true);
     try {
@@ -33,7 +33,7 @@ int main(int, char**) {
         assert(v[i] == true);
     }
   }
-  {
+  { // Attempt to insert an element at the end of a vector<bool> that is already at its maximum possible size
     std::vector<bool, limited_allocator<bool, 10> > v;
     v.resize(v.max_size(), true);
     try {
@@ -45,7 +45,7 @@ int main(int, char**) {
         assert(v[i] == true);
     }
   }
-  {
+  { // Attempt to insert an element in the middle of a vector<bool> that is already at its maximum possible size
     std::vector<bool, limited_allocator<bool, 10> > v;
     v.resize(v.max_size(), true);
     try {

--- a/libcxx/test/std/containers/sequences/vector.bool/emplace_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/emplace_exceptions.pass.cpp
@@ -15,51 +15,48 @@
 // template <class... Args> iterator emplace(const_iterator pos, Args&&... args);
 
 #include <cassert>
+#include <stdexcept>
 #include <vector>
 
 #include "test_allocator.h"
 
-void test() {
+int main(int, char**) {
   {
-    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
-    Vec v(Vec().max_size(), true);
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    v.resize(v.max_size(), true);
     try {
       v.emplace(v.begin(), true);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == v.max_size());
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == true);
     }
   }
   {
-    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
-    Vec v(Vec().max_size(), true);
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    v.resize(v.max_size(), true);
     try {
       v.emplace(v.end(), true);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == v.max_size());
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == true);
     }
   }
   {
-    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
-    Vec v(Vec().max_size(), true);
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    v.resize(v.max_size(), true);
     try {
       v.emplace(v.begin() + v.size() / 2, true);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == v.max_size());
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == true);
     }
   }
-}
-
-int main(int, char**) {
-  test();
 
   return 0;
 }

--- a/libcxx/test/std/containers/sequences/vector.bool/insert_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/insert_exceptions.pass.cpp
@@ -1,0 +1,108 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: no-exceptions
+
+// <vector>
+// vector<bool>
+
+// iterator insert(const_iterator position, const value_type& x);
+// iterator insert(const_iterator position, size_type n, const value_type& x);
+// iterator insert(const_iterator p, initializer_list<value_type> il);
+// template <class Iter>
+//   iterator insert(const_iterator position, Iter first, Iter last);
+
+#include <cassert>
+#include <vector>
+
+#include "test_allocator.h"
+#include "test_macros.h"
+
+void test() {
+  {
+    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
+    Vec v(Vec().max_size(), true);
+    try {
+      v.insert(v.begin(), false);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == v.max_size());
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == true);
+    }
+  }
+  {
+    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
+    Vec v(Vec().max_size(), false);
+    try {
+      v.insert(v.end(), 0);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == v.max_size());
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == false);
+    }
+  }
+  {
+    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
+    Vec v(Vec().max_size(), true);
+    try {
+      v.insert(v.begin() + v.size() / 2, false);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == v.max_size());
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == true);
+    }
+  }
+  {
+    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
+    Vec v(Vec().max_size(), true);
+    try {
+      v.insert(v.begin(), 1, false);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == v.max_size());
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == true);
+    }
+  }
+  {
+    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
+    Vec v(Vec().max_size() - 2, true);
+    bool a[] = {true, false, true};
+    try {
+      v.insert(v.begin() + v.size() / 2, std::begin(a), std::end(a));
+      assert(false);
+    } catch (...) {
+      assert(v.size() == v.max_size() - 2);
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == true);
+    }
+  }
+#if TEST_STD_VER >= 11
+  {
+    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
+    Vec v(Vec().max_size() - 2, true);
+    try {
+      v.insert(v.begin(), {true, false, true});
+      assert(false);
+    } catch (...) {
+      assert(v.size() == v.max_size() - 2);
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == true);
+    }
+  }
+#endif
+}
+
+int main(int, char**) {
+  test();
+
+  return 0;
+}

--- a/libcxx/test/std/containers/sequences/vector.bool/insert_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/insert_exceptions.pass.cpp
@@ -18,68 +18,69 @@
 //   iterator insert(const_iterator position, Iter first, Iter last);
 
 #include <cassert>
+#include <stdexcept>
 #include <vector>
 
 #include "test_allocator.h"
 #include "test_macros.h"
 
-void test() {
+int main(int, char**) {
   {
-    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
-    Vec v(Vec().max_size(), true);
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    v.resize(v.max_size(), true);
     try {
       v.insert(v.begin(), false);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == v.max_size());
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == true);
     }
   }
   {
-    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
-    Vec v(Vec().max_size(), false);
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    v.resize(v.max_size(), false);
     try {
       v.insert(v.end(), 0);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == v.max_size());
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == false);
     }
   }
   {
-    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
-    Vec v(Vec().max_size(), true);
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    v.resize(v.max_size(), true);
     try {
       v.insert(v.begin() + v.size() / 2, false);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == v.max_size());
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == true);
     }
   }
   {
-    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
-    Vec v(Vec().max_size(), true);
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    v.resize(v.max_size(), true);
     try {
       v.insert(v.begin(), 1, false);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == v.max_size());
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == true);
     }
   }
   {
-    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
-    Vec v(Vec().max_size() - 2, true);
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    v.resize(v.max_size() - 2, true);
     bool a[] = {true, false, true};
     try {
       v.insert(v.begin() + v.size() / 2, std::begin(a), std::end(a));
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == v.max_size() - 2);
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == true);
@@ -87,22 +88,18 @@ void test() {
   }
 #if TEST_STD_VER >= 11
   {
-    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
-    Vec v(Vec().max_size() - 2, true);
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    v.resize(v.max_size() - 2, true);
     try {
       v.insert(v.begin(), {true, false, true});
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == v.max_size() - 2);
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == true);
     }
   }
 #endif
-}
-
-int main(int, char**) {
-  test();
 
   return 0;
 }

--- a/libcxx/test/std/containers/sequences/vector.bool/insert_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/insert_exceptions.pass.cpp
@@ -25,7 +25,7 @@
 #include "test_macros.h"
 
 int main(int, char**) {
-  {
+  { // Attempt to insert an element at the beginning of a vector<bool> that is already at its maximum possible size
     std::vector<bool, limited_allocator<bool, 10> > v;
     v.resize(v.max_size(), true);
     try {
@@ -37,7 +37,7 @@ int main(int, char**) {
         assert(v[i] == true);
     }
   }
-  {
+  { // Attempt to insert an element at the end of a vector<bool> that is already at its maximum possible size
     std::vector<bool, limited_allocator<bool, 10> > v;
     v.resize(v.max_size(), false);
     try {
@@ -49,7 +49,7 @@ int main(int, char**) {
         assert(v[i] == false);
     }
   }
-  {
+  { // Attempt to insert an element in the middle of a vector<bool> that is already at its maximum possible size
     std::vector<bool, limited_allocator<bool, 10> > v;
     v.resize(v.max_size(), true);
     try {
@@ -61,19 +61,7 @@ int main(int, char**) {
         assert(v[i] == true);
     }
   }
-  {
-    std::vector<bool, limited_allocator<bool, 10> > v;
-    v.resize(v.max_size(), true);
-    try {
-      v.insert(v.begin(), 1, false);
-      assert(false);
-    } catch (const std::length_error&) {
-      assert(v.size() == v.max_size());
-      for (std::size_t i = 0; i != v.size(); ++i)
-        assert(v[i] == true);
-    }
-  }
-  {
+  { // Attempt to insert an iterator range to a vector<bool> that would exceed its maximum possible size
     std::vector<bool, limited_allocator<bool, 10> > v;
     v.resize(v.max_size() - 2, true);
     bool a[] = {true, false, true};
@@ -87,7 +75,7 @@ int main(int, char**) {
     }
   }
 #if TEST_STD_VER >= 11
-  {
+  { // Attempt to insert an initializer_list to a vector<bool> that would exceed its maximum possible size
     std::vector<bool, limited_allocator<bool, 10> > v;
     v.resize(v.max_size() - 2, true);
     try {

--- a/libcxx/test/std/containers/sequences/vector.bool/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/insert_range.pass.cpp
@@ -84,9 +84,6 @@ int main(int, char**) {
   test();
   static_assert(test());
 
-  // Note: `test_insert_range_exception_safety_throwing_copy` doesn't apply because copying booleans cannot throw.
-  test_insert_range_exception_safety_throwing_allocator<std::vector, bool>();
-
 #ifndef TEST_HAS_NO_LOCALIZATION
   test_counted_istream_view();
 #endif

--- a/libcxx/test/std/containers/sequences/vector.bool/insert_range_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/insert_range_exceptions.pass.cpp
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
+// UNSUPPORTED: no-exceptions
+
+// <vector>
+// vector<bool>
+
+// template<container-compatible-range<T> R>
+//   constexpr iterator insert_range(const_iterator position, R&& rg); // C++23
+
+#include <cassert>
+#include <vector>
+
+#include "../insert_range_sequence_containers.h"
+#include "test_allocator.h"
+
+void test() {
+  // Note: `test_insert_range_exception_safety_throwing_copy` doesn't apply because copying booleans cannot throw.
+  test_insert_range_exception_safety_throwing_allocator<std::vector, bool>();
+
+  {
+    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
+    Vec v(Vec().max_size() - 2, true);
+    bool a[] = {true, false, true};
+    try {
+      v.insert_range(v.end(), a);
+      assert(false);
+    } catch (const std::length_error&) {
+      assert(v.size() == v.max_size() - 2);
+      for (std::size_t i = 0; i < v.size(); ++i)
+        assert(v[i] == true);
+    }
+  }
+  {
+    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
+    Vec v(Vec().max_size() - 2, false);
+    bool a[] = {true, false, true};
+    try {
+      v.insert_range(v.begin(), a);
+      assert(false);
+    } catch (const std::length_error&) {
+      assert(v.size() == v.max_size() - 2);
+      for (std::size_t i = 0; i < v.size(); ++i)
+        assert(v[i] == false);
+    }
+  }
+  {
+    std::vector<bool, limited_allocator<bool, 10> > v(10, true);
+    bool a[10 * 65536] = {};
+    try {
+      v.insert_range(v.begin() + v.size() / 2, a);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == 10);
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == true);
+    }
+  }
+}
+
+int main(int, char**) {
+  test();
+
+  return 0;
+}

--- a/libcxx/test/std/containers/sequences/vector.bool/insert_range_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/insert_range_exceptions.pass.cpp
@@ -26,7 +26,7 @@ int main(int, char**) {
   // Note: `test_insert_range_exception_safety_throwing_copy` doesn't apply because copying booleans cannot throw.
   test_insert_range_exception_safety_throwing_allocator<std::vector, bool>();
 
-  {
+  { // Attempt to insert a range at the end of a vector<bool> that would exceed its maximum possible size
     std::vector<bool, limited_allocator<bool, 10> > v;
     v.resize(v.max_size() - 2, true);
     bool a[] = {true, false, true};
@@ -39,7 +39,7 @@ int main(int, char**) {
         assert(v[i] == true);
     }
   }
-  {
+  { // Attempt to insert a range at the beginning of a vector<bool> that would exceed its maximum possible size
     std::vector<bool, limited_allocator<bool, 10> > v;
     v.resize(v.max_size() - 2, false);
     bool a[] = {true, false, true};
@@ -52,7 +52,7 @@ int main(int, char**) {
         assert(v[i] == false);
     }
   }
-  {
+  { // Attempt to insert a range in the middle of a vector<bool> that would exceed its maximum possible size
     std::vector<bool, limited_allocator<bool, 10> > v(5, true);
     bool a[v.max_size()] = {};
     try {

--- a/libcxx/test/std/containers/sequences/vector.bool/insert_range_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/insert_range_exceptions.pass.cpp
@@ -16,18 +16,19 @@
 //   constexpr iterator insert_range(const_iterator position, R&& rg); // C++23
 
 #include <cassert>
+#include <stdexcept>
 #include <vector>
 
 #include "../insert_range_sequence_containers.h"
 #include "test_allocator.h"
 
-void test() {
+int main(int, char**) {
   // Note: `test_insert_range_exception_safety_throwing_copy` doesn't apply because copying booleans cannot throw.
   test_insert_range_exception_safety_throwing_allocator<std::vector, bool>();
 
   {
-    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
-    Vec v(Vec().max_size() - 2, true);
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    v.resize(v.max_size() - 2, true);
     bool a[] = {true, false, true};
     try {
       v.insert_range(v.end(), a);
@@ -39,8 +40,8 @@ void test() {
     }
   }
   {
-    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
-    Vec v(Vec().max_size() - 2, false);
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    v.resize(v.max_size() - 2, false);
     bool a[] = {true, false, true};
     try {
       v.insert_range(v.begin(), a);
@@ -52,21 +53,17 @@ void test() {
     }
   }
   {
-    std::vector<bool, limited_allocator<bool, 10> > v(10, true);
-    bool a[10 * 65536] = {};
+    std::vector<bool, limited_allocator<bool, 10> > v(5, true);
+    bool a[v.max_size()] = {};
     try {
       v.insert_range(v.begin() + v.size() / 2, a);
       assert(false);
-    } catch (...) {
-      assert(v.size() == 10);
+    } catch (const std::length_error&) {
+      assert(v.size() == 5);
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == true);
     }
   }
-}
-
-int main(int, char**) {
-  test();
 
   return 0;
 }

--- a/libcxx/test/std/containers/sequences/vector.bool/push_back_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/push_back_exceptions.pass.cpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: no-exceptions
+
+// <vector>
+// vector<bool>
+
+// void push_back(const value_type& x);
+
+#include <cassert>
+#include <vector>
+
+#include "test_allocator.h"
+
+int main(int, char**) {
+  using Vec = std::vector<bool, limited_allocator<bool, 10> >;
+  Vec v(Vec().max_size(), true);
+  try {
+    v.push_back(true);
+    assert(false);
+  } catch (...) {
+    assert(v.size() == v.max_size());
+    for (std::size_t i = 0; i != v.size(); ++i)
+      assert(v[i] == true);
+  }
+
+  return 0;
+}

--- a/libcxx/test/std/containers/sequences/vector.bool/push_back_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/push_back_exceptions.pass.cpp
@@ -20,6 +20,7 @@
 #include "test_allocator.h"
 
 int main(int, char**) {
+  // Attempt to push back an element into a vector<bool> that is already at its maximum possible size
   std::vector<bool, limited_allocator<bool, 10> > v;
   v.resize(v.max_size(), true);
   try {

--- a/libcxx/test/std/containers/sequences/vector.bool/push_back_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/push_back_exceptions.pass.cpp
@@ -14,17 +14,18 @@
 // void push_back(const value_type& x);
 
 #include <cassert>
+#include <stdexcept>
 #include <vector>
 
 #include "test_allocator.h"
 
 int main(int, char**) {
-  using Vec = std::vector<bool, limited_allocator<bool, 10> >;
-  Vec v(Vec().max_size(), true);
+  std::vector<bool, limited_allocator<bool, 10> > v;
+  v.resize(v.max_size(), true);
   try {
     v.push_back(true);
     assert(false);
-  } catch (...) {
+  } catch (const std::length_error&) {
     assert(v.size() == v.max_size());
     for (std::size_t i = 0; i != v.size(); ++i)
       assert(v[i] == true);

--- a/libcxx/test/std/containers/sequences/vector.bool/reserve.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/reserve.pass.cpp
@@ -13,7 +13,6 @@
 
 #include <vector>
 #include <cassert>
-#include <stdexcept>
 
 #include "test_macros.h"
 #include "min_allocator.h"
@@ -55,23 +54,6 @@ TEST_CONSTEXPR_CXX20 bool tests() {
     v.reserve(150);
     assert(v.size() == 100);
     assert(v.capacity() >= 150);
-  }
-#endif
-#ifndef TEST_HAS_NO_EXCEPTIONS
-  if (!TEST_IS_CONSTANT_EVALUATED) {
-    std::vector<bool, limited_allocator<bool, 10> > v;
-    v.reserve(5);
-    try {
-      // A typical implementation would allocate chunks of bits.
-      // In libc++ the chunk has the same size as the machine word. It is
-      // reasonable to assume that in practice no implementation would use
-      // 64 kB or larger chunks.
-      v.reserve(10 * 65536);
-      assert(false);
-    } catch (const std::length_error&) {
-      // no-op
-    }
-    assert(v.capacity() >= 5);
   }
 #endif
 

--- a/libcxx/test/std/containers/sequences/vector.bool/reserve_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/reserve_exceptions.pass.cpp
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: no-exceptions
+
+// <vector>
+// vector<bool>
+
+// void reserve(size_type n);
+
+#include <cassert>
+#include <stdexcept>
+#include <vector>
+
+#include "test_allocator.h"
+
+void test() {
+  {
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    v.reserve(5);
+    try {
+      // A typical implementation would allocate chunks of bits.
+      // In libc++ the chunk has the same size as the machine word. It is
+      // reasonable to assume that in practice no implementation would use
+      // 64 kB or larger chunks.
+      v.reserve(10 * 65536);
+      assert(false);
+    } catch (const std::length_error&) {
+      assert(v.empty());
+      assert(v.capacity() >= 5);
+    }
+  }
+  {
+    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
+    Vec v(Vec().max_size(), true);
+    try {
+      v.reserve(v.max_size() + 1);
+      assert(false);
+    } catch (const std::length_error&) {
+      assert(v.size() == v.max_size());
+      for (std::size_t i = 0; i < v.size(); ++i)
+        assert(v[i] == true);
+    }
+  }
+  {
+    bool a[] = {true, false, true, false, true};
+    std::vector<bool> v(std::begin(a), std::end(a));
+    try {
+      v.reserve(v.max_size() + 1);
+      assert(false);
+    } catch (const std::length_error&) {
+      assert(v.size() == 5);
+      assert(v.capacity() >= 5);
+      for (std::size_t i = 0; i < v.size(); ++i)
+        assert(v[i] == a[i]);
+    }
+  }
+}
+
+int main(int, char**) {
+  test();
+  return 0;
+}

--- a/libcxx/test/std/containers/sequences/vector.bool/reserve_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/reserve_exceptions.pass.cpp
@@ -19,7 +19,7 @@
 
 #include "test_allocator.h"
 
-void test() {
+int main(int, char**) {
   {
     std::vector<bool, limited_allocator<bool, 10> > v;
     v.reserve(5);
@@ -36,8 +36,8 @@ void test() {
     }
   }
   {
-    using Vec = std::vector<bool, limited_allocator<bool, 10> >;
-    Vec v(Vec().max_size(), true);
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    v.resize(v.max_size(), true);
     try {
       v.reserve(v.max_size() + 1);
       assert(false);
@@ -60,9 +60,6 @@ void test() {
         assert(v[i] == a[i]);
     }
   }
-}
 
-int main(int, char**) {
-  test();
   return 0;
 }

--- a/libcxx/test/std/containers/sequences/vector.bool/reserve_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/reserve_exceptions.pass.cpp
@@ -20,7 +20,7 @@
 #include "test_allocator.h"
 
 int main(int, char**) {
-  {
+  { // Attempt to reserve more space than the maximum possible size of a vector<bool>
     std::vector<bool, limited_allocator<bool, 10> > v;
     v.reserve(5);
     try {
@@ -35,7 +35,7 @@ int main(int, char**) {
       assert(v.capacity() >= 5);
     }
   }
-  {
+  { // Attempt to reserve more space for a vector<bool> that is already at its maximum possible size
     std::vector<bool, limited_allocator<bool, 10> > v;
     v.resize(v.max_size(), true);
     try {
@@ -47,7 +47,7 @@ int main(int, char**) {
         assert(v[i] == true);
     }
   }
-  {
+  { // Attempt to reserve 1 more space than the maximum possible size of a vector<bool>
     bool a[] = {true, false, true, false, true};
     std::vector<bool> v(std::begin(a), std::end(a));
     try {

--- a/libcxx/test/std/containers/sequences/vector.bool/resize_size_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/resize_size_exceptions.pass.cpp
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: no-exceptions
+
+// <vector>
+// vector<bool>
+
+// void resize(size_type sz);
+
+#include <algorithm>
+#include <cassert>
+#include <stdexcept>
+#include <vector>
+
+#include "test_allocator.h"
+
+void test() {
+  {
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    v.resize(5);
+    try {
+      // It is reasonable to assume that no vector<bool> implementation would use
+      // 64 kB or larger chunk size for the underlying bits storage.
+      v.resize(10 * 65536); // 10 * max_chunk_size
+      assert(false);
+    } catch (const std::length_error&) {
+      assert(v.size() == 5);
+      assert(v.capacity() >= 5);
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(!v[i]);
+    }
+  }
+  {
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    v.resize(v.max_size() / 2);
+    try {
+      v.resize(v.max_size() + 1);
+      assert(false);
+    } catch (const std::length_error&) {
+      assert(v.size() == v.max_size() / 2);
+      for (std::size_t i = 0; i < v.size(); ++i)
+        assert(v[i] == false);
+    }
+  }
+  {
+    bool a[] = {true, false, true, false, true};
+    std::vector<bool> v(std::begin(a), std::end(a));
+    try {
+      v.resize(v.max_size() + 1);
+      assert(false);
+    } catch (const std::length_error&) {
+      assert(v.size() == 5);
+      assert(v.capacity() >= 5);
+      assert(std::equal(v.begin(), v.end(), std::begin(a)));
+    }
+  }
+}
+
+int main(int, char**) {
+  test();
+  return 0;
+}

--- a/libcxx/test/std/containers/sequences/vector.bool/resize_size_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/resize_size_exceptions.pass.cpp
@@ -20,14 +20,11 @@
 
 #include "test_allocator.h"
 
-void test() {
+int main(int, char**) {
   {
-    std::vector<bool, limited_allocator<bool, 10> > v;
-    v.resize(5);
+    std::vector<bool, limited_allocator<bool, 10> > v(5, false);
     try {
-      // It is reasonable to assume that no vector<bool> implementation would use
-      // 64 kB or larger chunk size for the underlying bits storage.
-      v.resize(10 * 65536); // 10 * max_chunk_size
+      v.resize(v.max_size() + 1);
       assert(false);
     } catch (const std::length_error&) {
       assert(v.size() == 5);
@@ -60,9 +57,6 @@ void test() {
       assert(std::equal(v.begin(), v.end(), std::begin(a)));
     }
   }
-}
 
-int main(int, char**) {
-  test();
   return 0;
 }

--- a/libcxx/test/std/containers/sequences/vector.bool/resize_size_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/resize_size_exceptions.pass.cpp
@@ -21,7 +21,7 @@
 #include "test_allocator.h"
 
 int main(int, char**) {
-  {
+  { // Attempt to resize a non-empty vector<bool> to a size greater than its maximum possible size
     std::vector<bool, limited_allocator<bool, 10> > v(5, false);
     try {
       v.resize(v.max_size() + 1);
@@ -33,19 +33,16 @@ int main(int, char**) {
         assert(!v[i]);
     }
   }
-  {
+  { // Attempt to resize an empty vector<bool> to a size greater than its maximum possible size
     std::vector<bool, limited_allocator<bool, 10> > v;
-    v.resize(v.max_size() / 2);
     try {
       v.resize(v.max_size() + 1);
       assert(false);
     } catch (const std::length_error&) {
-      assert(v.size() == v.max_size() / 2);
-      for (std::size_t i = 0; i < v.size(); ++i)
-        assert(v[i] == false);
+      assert(v.empty());
     }
   }
-  {
+  { // Attempt to resize a vector<bool> with standard allocator to a size greater than its maximum possible size
     bool a[] = {true, false, true, false, true};
     std::vector<bool> v(std::begin(a), std::end(a));
     try {

--- a/libcxx/test/std/containers/sequences/vector.bool/resize_size_value_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/resize_size_value_exceptions.pass.cpp
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
+// UNSUPPORTED: no-exceptions
+
+// <vector>
+
+// template<container-compatible-range<T> R>
+//   constexpr iterator insert_range(const_iterator position, R&& rg); // C++23
+
+#include <algorithm>
+#include <cassert>
+#include <stdexcept>
+#include <vector>
+
+#include "../insert_range_sequence_containers.h"
+#include "test_allocator.h"
+
+void test() {
+  {
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    v.resize(5);
+    try {
+      // It is reasonable to assume that no vector<bool> implementation would use
+      // 64 kB or larger chunk size for the underlying bits storage.
+      v.resize(10 * 65536, true); // 10 * max_chunk_size
+      assert(false);
+    } catch (const std::length_error&) {
+      assert(v.size() == 5);
+      assert(v.capacity() >= 5);
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(!v[i]);
+    }
+  }
+  {
+    std::vector<bool, limited_allocator<bool, 10> > v;
+    v.resize(v.max_size() / 2);
+    try {
+      v.resize(v.max_size() + 1, true);
+      assert(false);
+    } catch (const std::length_error&) {
+      assert(v.size() == v.max_size() / 2);
+      for (std::size_t i = 0; i < v.size(); ++i)
+        assert(v[i] == false);
+    }
+  }
+  {
+    bool a[] = {true, false, true, false, true};
+    std::vector<bool> v(std::begin(a), std::end(a));
+    try {
+      v.resize(v.max_size() + 1, true);
+      assert(false);
+    } catch (const std::length_error&) {
+      assert(v.size() == 5);
+      assert(v.capacity() >= 5);
+      assert(std::equal(v.begin(), v.end(), std::begin(a)));
+    }
+  }
+}
+
+int main(int, char**) {
+  test();
+
+  return 0;
+}

--- a/libcxx/test/std/containers/sequences/vector.bool/resize_size_value_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/resize_size_value_exceptions.pass.cpp
@@ -23,7 +23,7 @@
 #include "test_allocator.h"
 
 int main(int, char**) {
-  {
+  { // Attempt to resize a non-empty vector<bool> to a size greater than its maximum possible size
     std::vector<bool, limited_allocator<bool, 10> > v(5, false);
     try {
       v.resize(v.max_size() + 1, true);
@@ -35,19 +35,16 @@ int main(int, char**) {
         assert(!v[i]);
     }
   }
-  {
+  { // Attempt to resize an empty vector<bool> to a size greater than its maximum possible size
     std::vector<bool, limited_allocator<bool, 10> > v;
-    v.resize(v.max_size() / 2);
     try {
       v.resize(v.max_size() + 1, true);
       assert(false);
     } catch (const std::length_error&) {
-      assert(v.size() == v.max_size() / 2);
-      for (std::size_t i = 0; i < v.size(); ++i)
-        assert(v[i] == false);
+      assert(v.empty());
     }
   }
-  {
+  { // Attempt to resize a vector<bool> with standard allocator to a size greater than its maximum possible size
     bool a[] = {true, false, true, false, true};
     std::vector<bool> v(std::begin(a), std::end(a));
     try {

--- a/libcxx/test/std/containers/sequences/vector.bool/resize_size_value_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/resize_size_value_exceptions.pass.cpp
@@ -22,14 +22,11 @@
 #include "../insert_range_sequence_containers.h"
 #include "test_allocator.h"
 
-void test() {
+int main(int, char**) {
   {
-    std::vector<bool, limited_allocator<bool, 10> > v;
-    v.resize(5);
+    std::vector<bool, limited_allocator<bool, 10> > v(5, false);
     try {
-      // It is reasonable to assume that no vector<bool> implementation would use
-      // 64 kB or larger chunk size for the underlying bits storage.
-      v.resize(10 * 65536, true); // 10 * max_chunk_size
+      v.resize(v.max_size() + 1, true);
       assert(false);
     } catch (const std::length_error&) {
       assert(v.size() == 5);
@@ -62,10 +59,6 @@ void test() {
       assert(std::equal(v.begin(), v.end(), std::begin(a)));
     }
   }
-}
-
-int main(int, char**) {
-  test();
 
   return 0;
 }

--- a/libcxx/test/std/containers/sequences/vector/vector.capacity/reserve_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.capacity/reserve_exceptions.pass.cpp
@@ -8,6 +8,10 @@
 
 // UNSUPPORTED: no-exceptions
 
+// <vector>
+
+// void reserve(size_type n);
+
 // This test file validates that std::vector<T>::reserve provides the strong exception guarantee if T is
 // Cpp17MoveInsertable and no exception is thrown by the move constructor of T during the reserve call.
 // It also checks that if T's move constructor is not noexcept, reserve provides only the basic exception
@@ -36,7 +40,8 @@ void test_allocation_exception_for_strong_guarantee(
   std::size_t old_cap  = v.capacity();
 
   try {
-    v.reserve(new_cap);
+    v.reserve(new_cap); // Expected exception
+    assert(false);
   } catch (...) { // std::length_error, std::bad_alloc
     assert(v.data() == old_data);
     assert(v.size() == old_size);
@@ -61,7 +66,8 @@ void test_copy_ctor_exception_for_strong_guarantee(std::vector<throwing_data<T>,
   std::size_t new_cap        = 2 * old_cap;
 
   try {
-    v.reserve(new_cap);
+    v.reserve(new_cap); // Expected exception
+    assert(false);
   } catch (...) {
     assert(v.data() == old_data);
     assert(v.size() == old_size);
@@ -83,7 +89,8 @@ void test_move_ctor_exception_for_basic_guarantee(std::vector<move_only_throwing
     v.emplace_back(values[i], throw_after);
 
   try {
-    v.reserve(2 * v.capacity());
+    v.reserve(2 * v.capacity()); // Expected exception
+    assert(false);
   } catch (...) {
     use_unspecified_but_valid_state_vector(v);
   }

--- a/libcxx/test/std/containers/sequences/vector/vector.capacity/resize_size_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.capacity/resize_size_exceptions.pass.cpp
@@ -8,6 +8,10 @@
 
 // UNSUPPORTED: no-exceptions
 
+// <vector>
+
+// void resize(size_type sz);
+
 // This test file validates that std::vector<T>::resize(size_type) provides the strong exception guarantee
 // if no exception is thrown by the move constructor of T during the resize call. It also checks that if
 // T's move constructor is not noexcept, resize provides only the basic exception guarantee.
@@ -35,7 +39,8 @@ void test_allocation_exception_for_strong_guarantee(
   std::size_t old_cap  = v.capacity();
 
   try {
-    v.resize(new_size);
+    v.resize(new_size); // Expected exception
+    assert(false);
   } catch (...) { // std::length_error, std::bad_alloc
     assert(v.data() == old_data);
     assert(v.size() == old_size);
@@ -60,7 +65,8 @@ void test_default_ctor_exception_for_strong_guarantee(
   std::size_t new_size       = old_size + 1;
 
   try {
-    v.resize(new_size);
+    v.resize(new_size); // Expected exception
+    assert(false);
   } catch (...) {
     assert(v.data() == old_data);
     assert(v.size() == old_size);
@@ -85,7 +91,8 @@ void test_copy_ctor_exception_for_strong_guarantee(std::vector<throwing_data<T>,
   std::size_t new_size       = 2 * old_cap;
 
   try {
-    v.resize(new_size);
+    v.resize(new_size); // Expected exception
+    assert(false);
   } catch (...) {
     assert(v.data() == old_data);
     assert(v.size() == old_size);
@@ -107,7 +114,8 @@ void test_move_ctor_exception_for_basic_guarantee(std::vector<move_only_throwing
     v.emplace_back(values[i], throw_after);
 
   try {
-    v.resize(2 * v.capacity());
+    v.resize(2 * v.capacity()); // Expected exception
+    assert(false);
   } catch (...) {
     use_unspecified_but_valid_state_vector(v);
   }

--- a/libcxx/test/std/containers/sequences/vector/vector.capacity/resize_size_value_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.capacity/resize_size_value_exceptions.pass.cpp
@@ -8,6 +8,10 @@
 
 // UNSUPPORTED: no-exceptions
 
+// <vector>
+
+// void resize(size_type sz, const value_type& x);
+
 // Check that std::vector<T>::resize(size_type sz, const value_type& x) provides the strong exception guarantee
 // if T is Cpp17CopyInsertable.
 
@@ -33,7 +37,8 @@ void test_allocation_exception_for_strong_guarantee(
   std::size_t old_cap  = v.capacity();
 
   try {
-    v.resize(new_size, values.empty() ? T() : values[0]);
+    v.resize(new_size, values.empty() ? T() : values[0]); // Expected exception
+    assert(false);
   } catch (...) { // std::length_error, std::bad_alloc
     assert(v.data() == old_data);
     assert(v.size() == old_size);
@@ -60,7 +65,8 @@ void test_copy_ctor_exception_for_strong_guarantee(std::vector<throwing_data<T>,
   try {
     int n = new_size - old_size + 1;
     throwing_data<T> t(T(), n);
-    v.resize(new_size, t);
+    v.resize(new_size, t); // Expected exception
+    assert(false);
   } catch (...) {
     assert(v.data() == old_data);
     assert(v.size() == old_size);

--- a/libcxx/test/std/containers/sequences/vector/vector.capacity/shrink_to_fit_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.capacity/shrink_to_fit_exceptions.pass.cpp
@@ -8,6 +8,10 @@
 
 // UNSUPPORTED: no-exceptions
 
+// <vector>
+
+// void shrink_to_fit();
+
 // This test file validates that std::vector<T>::shrink_to_fit provides the strong exception guarantee when
 // T is Cpp17MoveInsertable and its move constructor does not throw exceptions during the shrink_to_fit
 // call. Additionally, it checks that for move-only types where T's move constructor is not noexcept, only

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/append_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/append_range.pass.cpp
@@ -63,8 +63,5 @@ int main(int, char**) {
   test();
   static_assert(test());
 
-  test_append_range_exception_safety_throwing_copy<std::vector>();
-  test_append_range_exception_safety_throwing_allocator<std::vector, int>();
-
   return 0;
 }

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/append_range_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/append_range_exceptions.pass.cpp
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
+// UNSUPPORTED: no-exceptions
+
+// <vector>
+
+// template<container-compatible-range<T> R>
+//   constexpr void append_range(R&& rg); // C++23
+
+#include <cassert>
+#include <vector>
+
+#include "../../insert_range_sequence_containers.h"
+#include "test_allocator.h"
+
+void test() {
+  test_append_range_exception_safety_throwing_copy<std::vector>();
+  test_append_range_exception_safety_throwing_allocator<std::vector, int>();
+
+  {
+    std::vector<int, limited_allocator<int, 10> > v(8, 42);
+    int a[] = {1, 2, 3};
+    try {
+      v.append_range(a);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == 8);
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == 42);
+    }
+  }
+}
+
+int main(int, char**) {
+  test();
+
+  return 0;
+}

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/append_range_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/append_range_exceptions.pass.cpp
@@ -15,12 +15,13 @@
 //   constexpr void append_range(R&& rg); // C++23
 
 #include <cassert>
+#include <stdexcept>
 #include <vector>
 
 #include "../../insert_range_sequence_containers.h"
 #include "test_allocator.h"
 
-void test() {
+int main(int, char**) {
   test_append_range_exception_safety_throwing_copy<std::vector>();
   test_append_range_exception_safety_throwing_allocator<std::vector, int>();
 
@@ -30,16 +31,12 @@ void test() {
     try {
       v.append_range(a);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == 8);
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == 42);
     }
   }
-}
-
-int main(int, char**) {
-  test();
 
   return 0;
 }

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/append_range_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/append_range_exceptions.pass.cpp
@@ -25,6 +25,7 @@ int main(int, char**) {
   test_append_range_exception_safety_throwing_copy<std::vector>();
   test_append_range_exception_safety_throwing_allocator<std::vector, int>();
 
+  // Attempt to append a range to a vector that would exceed its maximum possible size
   {
     std::vector<int, limited_allocator<int, 10> > v(8, 42);
     int a[] = {1, 2, 3};

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/emplace_back_exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/emplace_back_exception_safety.pass.cpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03
+// UNSUPPORTED: no-exceptions
+
+// <vector>
+
+// template <class... Args>
+//     reference emplace_back(Args&&... args); // reference in C++17
+
+#include <cassert>
+#include <vector>
+
+#include "test_allocator.h"
+
+int main(int, char**) {
+  std::vector<int, limited_allocator<int, 10> > v(10, 42);
+  try {
+    v.emplace_back(0);
+    assert(false);
+  } catch (...) {
+    assert(v.size() == v.max_size());
+    for (std::size_t i = 0; i != v.size(); ++i)
+      assert(v[i] == 42); // Strong exception safety guarantee
+  }
+
+  return 0;
+}

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/emplace_back_exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/emplace_back_exception_safety.pass.cpp
@@ -15,6 +15,7 @@
 //     reference emplace_back(Args&&... args); // reference in C++17
 
 #include <cassert>
+#include <stdexcept>
 #include <vector>
 
 #include "test_allocator.h"
@@ -24,7 +25,7 @@ int main(int, char**) {
   try {
     v.emplace_back(0);
     assert(false);
-  } catch (...) {
+  } catch (const std::length_error&) {
     assert(v.size() == v.max_size());
     for (std::size_t i = 0; i != v.size(); ++i)
       assert(v[i] == 42); // Strong exception safety guarantee

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/emplace_back_exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/emplace_back_exception_safety.pass.cpp
@@ -21,6 +21,7 @@
 #include "test_allocator.h"
 
 int main(int, char**) {
+  // Attempt to append an element to a vector that is already at its maximum possible size
   std::vector<int, limited_allocator<int, 10> > v(10, 42);
   try {
     v.emplace_back(0);

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/emplace_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/emplace_exceptions.pass.cpp
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03
+// UNSUPPORTED: no-exceptions
+
+// <vector>
+
+// template <class... Args> iterator emplace(const_iterator pos, Args&&... args);
+
+#include <cassert>
+#include <vector>
+
+#include "test_allocator.h"
+
+void test() {
+  {
+    std::vector<int, limited_allocator<int, 10> > v(10, 42);
+    try {
+      v.emplace(v.begin(), 0);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == v.max_size());
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == 42);
+    }
+  }
+  {
+    std::vector<int, limited_allocator<int, 10> > v(10, 42);
+    try {
+      v.emplace(v.end(), 0);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == v.max_size());
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == 42);
+    }
+  }
+  {
+    std::vector<int, limited_allocator<int, 10> > v(10, 42);
+    try {
+      v.emplace(v.begin() + v.size() / 2, 0);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == v.max_size());
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == 42);
+    }
+  }
+}
+
+int main(int, char**) {
+  test();
+
+  return 0;
+}

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/emplace_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/emplace_exceptions.pass.cpp
@@ -14,17 +14,18 @@
 // template <class... Args> iterator emplace(const_iterator pos, Args&&... args);
 
 #include <cassert>
+#include <stdexcept>
 #include <vector>
 
 #include "test_allocator.h"
 
-void test() {
+int main(int, char**) {
   {
     std::vector<int, limited_allocator<int, 10> > v(10, 42);
     try {
       v.emplace(v.begin(), 0);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == v.max_size());
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == 42);
@@ -35,7 +36,7 @@ void test() {
     try {
       v.emplace(v.end(), 0);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == v.max_size());
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == 42);
@@ -46,16 +47,12 @@ void test() {
     try {
       v.emplace(v.begin() + v.size() / 2, 0);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == v.max_size());
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == 42);
     }
   }
-}
-
-int main(int, char**) {
-  test();
 
   return 0;
 }

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/emplace_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/emplace_exceptions.pass.cpp
@@ -20,7 +20,7 @@
 #include "test_allocator.h"
 
 int main(int, char**) {
-  {
+  { // Attempt to emplace an element at the beginning of a vector that is already at its maximum possible size
     std::vector<int, limited_allocator<int, 10> > v(10, 42);
     try {
       v.emplace(v.begin(), 0);
@@ -31,7 +31,7 @@ int main(int, char**) {
         assert(v[i] == 42);
     }
   }
-  {
+  { // Attempt to emplace an element at the end of a vector that is already at its maximum possible size
     std::vector<int, limited_allocator<int, 10> > v(10, 42);
     try {
       v.emplace(v.end(), 0);
@@ -42,7 +42,7 @@ int main(int, char**) {
         assert(v[i] == 42);
     }
   }
-  {
+  { // Attempt to emplace an element in the middle of a vector that is already at its maximum possible size
     std::vector<int, limited_allocator<int, 10> > v(10, 42);
     try {
       v.emplace(v.begin() + v.size() / 2, 0);

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_exceptions.pass.cpp
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: no-exceptions
+
+// <vector>
+
+// iterator insert(const_iterator position, const value_type& x);
+// iterator insert(const_iterator position, size_type n, const value_type& x);
+// iterator insert(const_iterator p, initializer_list<value_type> il);
+// template <class Iter>
+//   iterator insert(const_iterator position, Iter first, Iter last);
+
+#include <cassert>
+#include <vector>
+
+#include "test_allocator.h"
+#include "test_macros.h"
+
+void test() {
+  {
+    std::vector<int, limited_allocator<int, 10> > v(10, 42);
+    try {
+      v.insert(v.begin(), 0);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == v.max_size());
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == 42);
+    }
+  }
+  {
+    std::vector<int, limited_allocator<int, 10> > v(10, 42);
+    try {
+      v.insert(v.end(), 0);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == v.max_size());
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == 42);
+    }
+  }
+  {
+    std::vector<int, limited_allocator<int, 10> > v(10, 42);
+    try {
+      v.insert(v.begin() + v.size() / 2, 0);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == v.max_size());
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == 42);
+    }
+  }
+  {
+    std::vector<int, limited_allocator<int, 10> > v(8, 42);
+    try {
+      v.insert(v.begin(), 3, 0);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == 8);
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == 42);
+    }
+  }
+  {
+    std::vector<int, limited_allocator<int, 10> > v(8, 42);
+    int a[] = {1, 2, 3};
+    try {
+      v.insert(v.begin() + v.size() / 2, std::begin(a), std::end(a));
+      assert(false);
+    } catch (...) {
+      assert(v.size() == 8);
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == 42);
+    }
+  }
+#if TEST_STD_VER >= 11
+  {
+    std::vector<int, limited_allocator<int, 10> > v(8, 42);
+    try {
+      v.insert(v.begin(), {1, 2, 3});
+      assert(false);
+    } catch (...) {
+      assert(v.size() == 8);
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == 42);
+    }
+  }
+#endif
+}
+
+int main(int, char**) {
+  test();
+
+  return 0;
+}

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_exceptions.pass.cpp
@@ -24,7 +24,7 @@
 #include "test_macros.h"
 
 int main(int, char**) {
-  {
+  { // Attempt to insert an element at the beginning of a vector that is already at its maximum possible size
     std::vector<int, limited_allocator<int, 10> > v(10, 42);
     try {
       v.insert(v.begin(), 0);
@@ -35,7 +35,7 @@ int main(int, char**) {
         assert(v[i] == 42);
     }
   }
-  {
+  { // Attempt to insert an element at the end of a vector that is already at its maximum possible size
     std::vector<int, limited_allocator<int, 10> > v(10, 42);
     try {
       v.insert(v.end(), 0);
@@ -46,7 +46,7 @@ int main(int, char**) {
         assert(v[i] == 42);
     }
   }
-  {
+  { // Attempt to insert an element in the middle of a vector that is already at its maximum possible size
     std::vector<int, limited_allocator<int, 10> > v(10, 42);
     try {
       v.insert(v.begin() + v.size() / 2, 0);
@@ -57,7 +57,7 @@ int main(int, char**) {
         assert(v[i] == 42);
     }
   }
-  {
+  { // Attempt to insert n elements at the beginning of a vector that would exceed its maximum possible size
     std::vector<int, limited_allocator<int, 10> > v(8, 42);
     try {
       v.insert(v.begin(), 3, 0);
@@ -68,7 +68,7 @@ int main(int, char**) {
         assert(v[i] == 42);
     }
   }
-  {
+  { // Attempt to insert an iterator range to a vector that would exceed its maximum possible size
     std::vector<int, limited_allocator<int, 10> > v(8, 42);
     int a[] = {1, 2, 3};
     try {
@@ -81,7 +81,7 @@ int main(int, char**) {
     }
   }
 #if TEST_STD_VER >= 11
-  {
+  { // Attempt to insert an initializer_list to a vector that would exceed its maximum possible size
     std::vector<int, limited_allocator<int, 10> > v(8, 42);
     try {
       v.insert(v.begin(), {1, 2, 3});

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_exceptions.pass.cpp
@@ -17,18 +17,19 @@
 //   iterator insert(const_iterator position, Iter first, Iter last);
 
 #include <cassert>
+#include <stdexcept>
 #include <vector>
 
 #include "test_allocator.h"
 #include "test_macros.h"
 
-void test() {
+int main(int, char**) {
   {
     std::vector<int, limited_allocator<int, 10> > v(10, 42);
     try {
       v.insert(v.begin(), 0);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == v.max_size());
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == 42);
@@ -39,7 +40,7 @@ void test() {
     try {
       v.insert(v.end(), 0);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == v.max_size());
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == 42);
@@ -50,7 +51,7 @@ void test() {
     try {
       v.insert(v.begin() + v.size() / 2, 0);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == v.max_size());
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == 42);
@@ -61,7 +62,7 @@ void test() {
     try {
       v.insert(v.begin(), 3, 0);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == 8);
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == 42);
@@ -73,7 +74,7 @@ void test() {
     try {
       v.insert(v.begin() + v.size() / 2, std::begin(a), std::end(a));
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == 8);
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == 42);
@@ -85,17 +86,13 @@ void test() {
     try {
       v.insert(v.begin(), {1, 2, 3});
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == 8);
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == 42);
     }
   }
 #endif
-}
-
-int main(int, char**) {
-  test();
 
   return 0;
 }

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_range.pass.cpp
@@ -99,9 +99,6 @@ int main(int, char**) {
 
   static_assert(test_constraints_insert_range<std::vector, int, double>());
 
-  test_insert_range_exception_safety_throwing_copy<std::vector>();
-  test_insert_range_exception_safety_throwing_allocator<std::vector, int>();
-
 #ifndef TEST_HAS_NO_LOCALIZATION
   test_counted_istream_view();
 #endif

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_range_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_range_exceptions.pass.cpp
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17, c++20
+// UNSUPPORTED: no-exceptions
+
+// <vector>
+
+// template<container-compatible-range<T> R>
+//   constexpr iterator insert_range(const_iterator position, R&& rg); // C++23
+
+#include <cassert>
+#include <vector>
+
+#include "../../insert_range_sequence_containers.h"
+#include "test_allocator.h"
+
+void test() {
+  test_insert_range_exception_safety_throwing_copy<std::vector>();
+  test_insert_range_exception_safety_throwing_allocator<std::vector, int>();
+
+  {
+    std::vector<int, limited_allocator<int, 10> > v(8, 42);
+    int a[] = {1, 2, 3};
+    try {
+      v.insert_range(v.begin(), a);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == 8);
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == 42);
+    }
+  }
+  {
+    std::vector<int, limited_allocator<int, 10> > v(8, 42);
+    int a[] = {1, 2, 3};
+    try {
+      v.insert_range(v.end(), a);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == 8);
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == 42);
+    }
+  }
+  {
+    std::vector<int, limited_allocator<int, 10> > v(10, 42);
+    int a[] = {1, 2, 3};
+    try {
+      v.insert_range(v.begin() + v.size() / 2, a);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == 10);
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == 42);
+    }
+  }
+}
+
+int main(int, char**) {
+  test();
+
+  return 0;
+}

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_range_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_range_exceptions.pass.cpp
@@ -25,7 +25,7 @@ int main(int, char**) {
   test_insert_range_exception_safety_throwing_copy<std::vector>();
   test_insert_range_exception_safety_throwing_allocator<std::vector, int>();
 
-  {
+  { // Attempt to insert a range at the beginning of a vector that would exceed its maximum possible size
     std::vector<int, limited_allocator<int, 10> > v(8, 42);
     int a[] = {1, 2, 3};
     try {
@@ -37,7 +37,7 @@ int main(int, char**) {
         assert(v[i] == 42);
     }
   }
-  {
+  { // Attempt to insert a range at the end of a vector that would exceed its maximum possible size
     std::vector<int, limited_allocator<int, 10> > v(8, 42);
     int a[] = {1, 2, 3};
     try {
@@ -49,7 +49,7 @@ int main(int, char**) {
         assert(v[i] == 42);
     }
   }
-  {
+  { // Attempt to insert a range in the middle of a vector that would exceed its maximum possible size
     std::vector<int, limited_allocator<int, 10> > v(10, 42);
     int a[] = {1, 2, 3};
     try {

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_range_exceptions.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/insert_range_exceptions.pass.cpp
@@ -15,12 +15,13 @@
 //   constexpr iterator insert_range(const_iterator position, R&& rg); // C++23
 
 #include <cassert>
+#include <stdexcept>
 #include <vector>
 
 #include "../../insert_range_sequence_containers.h"
 #include "test_allocator.h"
 
-void test() {
+int main(int, char**) {
   test_insert_range_exception_safety_throwing_copy<std::vector>();
   test_insert_range_exception_safety_throwing_allocator<std::vector, int>();
 
@@ -30,7 +31,7 @@ void test() {
     try {
       v.insert_range(v.begin(), a);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == 8);
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == 42);
@@ -42,7 +43,7 @@ void test() {
     try {
       v.insert_range(v.end(), a);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == 8);
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == 42);
@@ -54,16 +55,12 @@ void test() {
     try {
       v.insert_range(v.begin() + v.size() / 2, a);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == 10);
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == 42);
     }
   }
-}
-
-int main(int, char**) {
-  test();
 
   return 0;
 }

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/push_back_exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/push_back_exception_safety.pass.cpp
@@ -10,10 +10,11 @@
 
 // void push_back(const value_type& x);
 
-#include <vector>
 #include <cassert>
+#include <vector>
 
 #include "asan_testing.h"
+#include "test_allocator.h"
 #include "test_macros.h"
 
 // Flag that makes the copy constructor for CMyClass throw an exception
@@ -85,6 +86,18 @@ int main(int, char**) {
   } catch (...) {
     assert(vec == vec2);
     assert(is_contiguous_container_asan_correct(vec));
+  }
+
+  {
+    std::vector<int, limited_allocator<int, 10> > v(10, 42);
+    try {
+      v.push_back(0);
+      assert(false);
+    } catch (...) {
+      assert(v.size() == v.max_size());
+      for (std::size_t i = 0; i != v.size(); ++i)
+        assert(v[i] == 42); // Strong exception safety guarantee
+    }
   }
 #endif
 

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/push_back_exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/push_back_exception_safety.pass.cpp
@@ -89,7 +89,7 @@ int main(int, char**) {
     assert(is_contiguous_container_asan_correct(vec));
   }
 
-  {
+  { // Attempt to push back an element into a vector that is already at its maximum possible size
     std::vector<int, limited_allocator<int, 10> > v(10, 42);
     try {
       v.push_back(0);

--- a/libcxx/test/std/containers/sequences/vector/vector.modifiers/push_back_exception_safety.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.modifiers/push_back_exception_safety.pass.cpp
@@ -11,6 +11,7 @@
 // void push_back(const value_type& x);
 
 #include <cassert>
+#include <stdexcept>
 #include <vector>
 
 #include "asan_testing.h"
@@ -93,7 +94,7 @@ int main(int, char**) {
     try {
       v.push_back(0);
       assert(false);
-    } catch (...) {
+    } catch (const std::length_error&) {
       assert(v.size() == v.max_size());
       for (std::size_t i = 0; i != v.size(); ++i)
         assert(v[i] == 42); // Strong exception safety guarantee


### PR DESCRIPTION
This patch ensures that `std::vector` and `vector<bool>` raise expected exceptions when vector's `size()` would otherwise exceed `max_size()` limit due to mutator operations. It also validates that the vector remains unchanged  when such exception is raised, ensuring the strong exception safety guarantee when conditions ([[vector.capacity]](https://eel.is/c++draft/vector.capacity#4), [[vector.modifiers]](https://eel.is/c++draft/vector.modifiers#2)) are met: 
- `reserve`, `resize`, `shrink_to_fit`: If an exception is thrown other than by the move constructor of a non-`Cpp17CopyInsertable` type, there are no effects.
- `{push, emplace}_back`: If an exception is thrown while inserting a single element at the end and T is `Cpp17CopyInsertable` or `is_nothrow_move_constructible_v<T>` is true, there are no effects.
- `emplace, insert, insert_range, append_range`: If an exception is thrown other than by the copy constructor, move constructor, assignment operator, or move assignment operator of `T` or by any `InputIterator` operation, there are no effects.

This patch focuses only on exceptions triggered when exceeding the `max_size()` limit, in order to fix issue #40963. However, a more extensive testing for other sources of exceptions—such as those caused by copy/move constructors, allocators, assignment operators, or reallocation scenarios—need to be added, which will be pursued as a further work.

Closes #40963