### PR TITLE
[ADT] Add StringSet::insert_range

### DIFF
--- a/llvm/include/llvm/ADT/StringSet.h
+++ b/llvm/include/llvm/ADT/StringSet.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_ADT_STRINGSET_H
 #define LLVM_ADT_STRINGSET_H
 
+#include "llvm/ADT/ADL.h"
 #include "llvm/ADT/StringMap.h"
 
 namespace llvm {
@@ -43,6 +44,10 @@ public:
   void insert(InputIt begin, InputIt end) {
     for (auto it = begin; it != end; ++it)
       insert(*it);
+  }
+
+  template <typename Range> void insert_range(Range &&R) {
+    insert(adl_begin(R), adl_end(R));
   }
 
   template <typename ValueTy>

--- a/llvm/unittests/ADT/StringSetTest.cpp
+++ b/llvm/unittests/ADT/StringSetTest.cpp
@@ -81,4 +81,14 @@ TEST_F(StringSetTest, Equal) {
   ASSERT_TRUE(A == A);
 }
 
+TEST_F(StringSetTest, InsertRange) {
+  StringSet<> Set;
+  const char *Args[] = {"chair", "desk", "bed"};
+  Set.insert_range(Args);
+  EXPECT_EQ(Set.size(), 3U);
+  EXPECT_TRUE(Set.contains("bed"));
+  EXPECT_TRUE(Set.contains("chair"));
+  EXPECT_TRUE(Set.contains("desk"));
+}
+
 } // end anonymous namespace


### PR DESCRIPTION
This pach adds StringSet::insert_range for consistency with
DenseSet::insert_range and std::set::insert_range from C++23.

In the unit test, I'm using contains instead of
testing::UnorderedElementsAre because the latter doesn't seem to work
with char *.
