### PR TITLE
[clang-tidy][C++20] Add support for Initialization Forwarding in structs and Nested Objects within modernize-use-emplace

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -197,6 +197,10 @@ Changes in existing checks
   <clang-tidy/checks/modernize/use-designated-initializers>` check by avoiding
   diagnosing designated initializers for ``std::array`` initializations.
 
+- Improved :doc:`modernize-use-emplace
+  <clang-tidy/checks/modernize/use-emplace>` check by adding support for C++20
+  Argument forwarding inside ``struct`` type objects.
+
 - Improved :doc:`modernize-use-ranges
   <clang-tidy/checks/modernize/use-ranges>` check by updating suppress 
   warnings logic for ``nullptr`` in ``std::find``.


### PR DESCRIPTION
Aims to address: #115841

C++20 introduced argument forwarding for temporal objects(either aggregates or struct types with constructor initialization) within `emplace_back` calls. I've applied similar rules as they were used in constructor expressions when called with c++20.  I'd love to get some feedback related to my test coverage and more possible edge cases I might've missed.

Note: C++20 introduced functional initialization/forwarding as well, this could be targeted in a different PR.