### PR TITLE
[ItaniumDemangle] Unconditionally parse substitution template arguments

### DIFF
--- a/libcxxabi/src/demangle/ItaniumDemangle.h
+++ b/libcxxabi/src/demangle/ItaniumDemangle.h
@@ -4626,10 +4626,10 @@ Node *AbstractManglingParser<Derived, Alloc>::parseType() {
       //   <template-template-param> ::= <template-param>
       //                             ::= <substitution>
       //
-      // If this is followed by some <template-args>, and we're permitted to
-      // parse them, take the second production.
+      // If this is followed by some <template-args>, take the second
+      // production.
 
-      if (look() == 'I' && (!IsSubst || TryToParseTemplateArgs)) {
+      if (look() == 'I') {
         if (!IsSubst)
           Subs.push_back(Result);
         Node *TA = getDerived().parseTemplateArgs();

--- a/llvm/include/llvm/Demangle/ItaniumDemangle.h
+++ b/llvm/include/llvm/Demangle/ItaniumDemangle.h
@@ -4626,10 +4626,10 @@ Node *AbstractManglingParser<Derived, Alloc>::parseType() {
       //   <template-template-param> ::= <template-param>
       //                             ::= <substitution>
       //
-      // If this is followed by some <template-args>, and we're permitted to
-      // parse them, take the second production.
+      // If this is followed by some <template-args>, take the second
+      // production.
 
-      if (look() == 'I' && (!IsSubst || TryToParseTemplateArgs)) {
+      if (look() == 'I') {
         if (!IsSubst)
           Subs.push_back(Result);
         Node *TA = getDerived().parseTemplateArgs();


### PR DESCRIPTION
With the current mangled name parser, when we try to parse a type name inside the template argument of an operator, we end up not parsing any template arguments of substitutions, which ends up causing things to fail in certain cases. This is compliant with the Itanium ABI documentation as far as I can tell.

I tried to look through the git history to find out why the limitation on parsing template arguments for substitutions inside of operators existed, but I only ended up at the import commit, so I suspect the original motivation is lost to time.

A regression test from LLVM has been added.