### PR TITLE
[RISCV] Add attribute vscale_range(2,1024) to the tests for removing zero_extend on RV64. NFC

### DIFF
--- a/llvm/test/CodeGen/RISCV/rvv/vadd-vp.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vadd-vp.ll
@@ -1425,32 +1425,15 @@ define <vscale x 32 x i32> @vadd_vi_nxv32i32_evl_nx8(<vscale x 32 x i32> %va, <v
   ret <vscale x 32 x i32> %v
 }
 
-; FIXME: The upper half of the operation is doing nothing but we don't catch
-; that on RV64; we issue a usubsat(and (vscale x 16), 0xffffffff, vscale x 16)
-; (the "original" %evl is the "and", due to known-bits issues with legalizing
-; the i32 %evl to i64) and this isn't detected as 0.
-; This could be resolved in the future with more detailed KnownBits analysis
-; for ISD::VSCALE.
+; The attribute vscale_range(2,1024) given here can remove the zero_extend for
+; the i32 %evl to i64 on RV64 through KnownBits analysis.
 
-define <vscale x 32 x i32> @vadd_vi_nxv32i32_evl_nx16(<vscale x 32 x i32> %va, <vscale x 32 x i1> %m) {
-; RV32-LABEL: vadd_vi_nxv32i32_evl_nx16:
-; RV32:       # %bb.0:
-; RV32-NEXT:    vsetvli a0, zero, e32, m8, ta, ma
-; RV32-NEXT:    vadd.vi v8, v8, -1, v0.t
-; RV32-NEXT:    ret
-;
-; RV64-LABEL: vadd_vi_nxv32i32_evl_nx16:
-; RV64:       # %bb.0:
-; RV64-NEXT:    csrr a0, vlenb
-; RV64-NEXT:    srli a0, a0, 2
-; RV64-NEXT:    vsetvli a1, zero, e8, mf2, ta, ma
-; RV64-NEXT:    vslidedown.vx v24, v0, a0
-; RV64-NEXT:    vsetvli a0, zero, e32, m8, ta, ma
-; RV64-NEXT:    vadd.vi v8, v8, -1, v0.t
-; RV64-NEXT:    vmv1r.v v0, v24
-; RV64-NEXT:    vsetivli zero, 0, e32, m8, ta, ma
-; RV64-NEXT:    vadd.vi v16, v16, -1, v0.t
-; RV64-NEXT:    ret
+define <vscale x 32 x i32> @vadd_vi_nxv32i32_evl_nx16(<vscale x 32 x i32> %va, <vscale x 32 x i1> %m) vscale_range(2,1024) {
+; CHECK-LABEL: vadd_vi_nxv32i32_evl_nx16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vsetvli a0, zero, e32, m8, ta, ma
+; CHECK-NEXT:    vadd.vi v8, v8, -1, v0.t
+; CHECK-NEXT:    ret
   %evl = call i32 @llvm.vscale.i32()
   %evl0 = mul i32 %evl, 16
   %v = call <vscale x 32 x i32> @llvm.vp.add.nxv32i32(<vscale x 32 x i32> %va, <vscale x 32 x i32> splat (i32 -1), <vscale x 32 x i1> %m, i32 %evl0)

--- a/llvm/test/CodeGen/RISCV/rvv/vmax-vp.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vmax-vp.ll
@@ -1060,32 +1060,15 @@ define <vscale x 32 x i32> @vmax_vx_nxv32i32_evl_nx8(<vscale x 32 x i32> %va, i3
   ret <vscale x 32 x i32> %v
 }
 
-; FIXME: The upper half of the operation is doing nothing but we don't catch
-; that on RV64; we issue a usubsat(and (vscale x 16), 0xffffffff, vscale x 16)
-; (the "original" %evl is the "and", due to known-bits issues with legalizing
-; the i32 %evl to i64) and this isn't detected as 0.
-; This could be resolved in the future with more detailed KnownBits analysis
-; for ISD::VSCALE.
+; The attribute vscale_range(2,1024) given here can remove the zero_extend for
+; the i32 %evl to i64 on RV64 through KnownBits analysis.
 
-define <vscale x 32 x i32> @vmax_vx_nxv32i32_evl_nx16(<vscale x 32 x i32> %va, i32 %b, <vscale x 32 x i1> %m) {
-; RV32-LABEL: vmax_vx_nxv32i32_evl_nx16:
-; RV32:       # %bb.0:
-; RV32-NEXT:    vsetvli a1, zero, e32, m8, ta, ma
-; RV32-NEXT:    vmax.vx v8, v8, a0, v0.t
-; RV32-NEXT:    ret
-;
-; RV64-LABEL: vmax_vx_nxv32i32_evl_nx16:
-; RV64:       # %bb.0:
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    srli a1, a1, 2
-; RV64-NEXT:    vsetvli a2, zero, e8, mf2, ta, ma
-; RV64-NEXT:    vslidedown.vx v24, v0, a1
-; RV64-NEXT:    vsetvli a1, zero, e32, m8, ta, ma
-; RV64-NEXT:    vmax.vx v8, v8, a0, v0.t
-; RV64-NEXT:    vmv1r.v v0, v24
-; RV64-NEXT:    vsetivli zero, 0, e32, m8, ta, ma
-; RV64-NEXT:    vmax.vx v16, v16, a0, v0.t
-; RV64-NEXT:    ret
+define <vscale x 32 x i32> @vmax_vx_nxv32i32_evl_nx16(<vscale x 32 x i32> %va, i32 %b, <vscale x 32 x i1> %m) vscale_range(2,1024) {
+; CHECK-LABEL: vmax_vx_nxv32i32_evl_nx16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vsetvli a1, zero, e32, m8, ta, ma
+; CHECK-NEXT:    vmax.vx v8, v8, a0, v0.t
+; CHECK-NEXT:    ret
   %elt.head = insertelement <vscale x 32 x i32> poison, i32 %b, i32 0
   %vb = shufflevector <vscale x 32 x i32> %elt.head, <vscale x 32 x i32> poison, <vscale x 32 x i32> zeroinitializer
   %evl = call i32 @llvm.vscale.i32()

--- a/llvm/test/CodeGen/RISCV/rvv/vmaxu-vp.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vmaxu-vp.ll
@@ -1059,32 +1059,15 @@ define <vscale x 32 x i32> @vmaxu_vx_nxv32i32_evl_nx8(<vscale x 32 x i32> %va, i
   ret <vscale x 32 x i32> %v
 }
 
-; FIXME: The upper half of the operation is doing nothing but we don't catch
-; that on RV64; we issue a usubsat(and (vscale x 16), 0xffffffff, vscale x 16)
-; (the "original" %evl is the "and", due to known-bits issues with legalizing
-; the i32 %evl to i64) and this isn't detected as 0.
-; This could be resolved in the future with more detailed KnownBits analysis
-; for ISD::VSCALE.
+; The attribute vscale_range(2,1024) given here can remove the zero_extend for
+; the i32 %evl to i64 on RV64 through KnownBits analysis.
 
-define <vscale x 32 x i32> @vmaxu_vx_nxv32i32_evl_nx16(<vscale x 32 x i32> %va, i32 %b, <vscale x 32 x i1> %m) {
-; RV32-LABEL: vmaxu_vx_nxv32i32_evl_nx16:
-; RV32:       # %bb.0:
-; RV32-NEXT:    vsetvli a1, zero, e32, m8, ta, ma
-; RV32-NEXT:    vmaxu.vx v8, v8, a0, v0.t
-; RV32-NEXT:    ret
-;
-; RV64-LABEL: vmaxu_vx_nxv32i32_evl_nx16:
-; RV64:       # %bb.0:
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    srli a1, a1, 2
-; RV64-NEXT:    vsetvli a2, zero, e8, mf2, ta, ma
-; RV64-NEXT:    vslidedown.vx v24, v0, a1
-; RV64-NEXT:    vsetvli a1, zero, e32, m8, ta, ma
-; RV64-NEXT:    vmaxu.vx v8, v8, a0, v0.t
-; RV64-NEXT:    vmv1r.v v0, v24
-; RV64-NEXT:    vsetivli zero, 0, e32, m8, ta, ma
-; RV64-NEXT:    vmaxu.vx v16, v16, a0, v0.t
-; RV64-NEXT:    ret
+define <vscale x 32 x i32> @vmaxu_vx_nxv32i32_evl_nx16(<vscale x 32 x i32> %va, i32 %b, <vscale x 32 x i1> %m) vscale_range(2,1024) {
+; CHECK-LABEL: vmaxu_vx_nxv32i32_evl_nx16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vsetvli a1, zero, e32, m8, ta, ma
+; CHECK-NEXT:    vmaxu.vx v8, v8, a0, v0.t
+; CHECK-NEXT:    ret
   %elt.head = insertelement <vscale x 32 x i32> poison, i32 %b, i32 0
   %vb = shufflevector <vscale x 32 x i32> %elt.head, <vscale x 32 x i32> poison, <vscale x 32 x i32> zeroinitializer
   %evl = call i32 @llvm.vscale.i32()

--- a/llvm/test/CodeGen/RISCV/rvv/vmin-vp.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vmin-vp.ll
@@ -1060,32 +1060,15 @@ define <vscale x 32 x i32> @vmin_vx_nxv32i32_evl_nx8(<vscale x 32 x i32> %va, i3
   ret <vscale x 32 x i32> %v
 }
 
-; FIXME: The upper half of the operation is doing nothing but we don't catch
-; that on RV64; we issue a usubsat(and (vscale x 16), 0xffffffff, vscale x 16)
-; (the "original" %evl is the "and", due to known-bits issues with legalizing
-; the i32 %evl to i64) and this isn't detected as 0.
-; This could be resolved in the future with more detailed KnownBits analysis
-; for ISD::VSCALE.
+; The attribute vscale_range(2,1024) given here can remove the zero_extend for
+; the i32 %evl to i64 on RV64 through KnownBits analysis.
 
-define <vscale x 32 x i32> @vmin_vx_nxv32i32_evl_nx16(<vscale x 32 x i32> %va, i32 %b, <vscale x 32 x i1> %m) {
-; RV32-LABEL: vmin_vx_nxv32i32_evl_nx16:
-; RV32:       # %bb.0:
-; RV32-NEXT:    vsetvli a1, zero, e32, m8, ta, ma
-; RV32-NEXT:    vmin.vx v8, v8, a0, v0.t
-; RV32-NEXT:    ret
-;
-; RV64-LABEL: vmin_vx_nxv32i32_evl_nx16:
-; RV64:       # %bb.0:
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    srli a1, a1, 2
-; RV64-NEXT:    vsetvli a2, zero, e8, mf2, ta, ma
-; RV64-NEXT:    vslidedown.vx v24, v0, a1
-; RV64-NEXT:    vsetvli a1, zero, e32, m8, ta, ma
-; RV64-NEXT:    vmin.vx v8, v8, a0, v0.t
-; RV64-NEXT:    vmv1r.v v0, v24
-; RV64-NEXT:    vsetivli zero, 0, e32, m8, ta, ma
-; RV64-NEXT:    vmin.vx v16, v16, a0, v0.t
-; RV64-NEXT:    ret
+define <vscale x 32 x i32> @vmin_vx_nxv32i32_evl_nx16(<vscale x 32 x i32> %va, i32 %b, <vscale x 32 x i1> %m) vscale_range(2,1024) {
+; CHECK-LABEL: vmin_vx_nxv32i32_evl_nx16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vsetvli a1, zero, e32, m8, ta, ma
+; CHECK-NEXT:    vmin.vx v8, v8, a0, v0.t
+; CHECK-NEXT:    ret
   %elt.head = insertelement <vscale x 32 x i32> poison, i32 %b, i32 0
   %vb = shufflevector <vscale x 32 x i32> %elt.head, <vscale x 32 x i32> poison, <vscale x 32 x i32> zeroinitializer
   %evl = call i32 @llvm.vscale.i32()

--- a/llvm/test/CodeGen/RISCV/rvv/vminu-vp.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vminu-vp.ll
@@ -1059,32 +1059,15 @@ define <vscale x 32 x i32> @vminu_vx_nxv32i32_evl_nx8(<vscale x 32 x i32> %va, i
   ret <vscale x 32 x i32> %v
 }
 
-; FIXME: The upper half of the operation is doing nothing but we don't catch
-; that on RV64; we issue a usubsat(and (vscale x 16), 0xffffffff, vscale x 16)
-; (the "original" %evl is the "and", due to known-bits issues with legalizing
-; the i32 %evl to i64) and this isn't detected as 0.
-; This could be resolved in the future with more detailed KnownBits analysis
-; for ISD::VSCALE.
+; The attribute vscale_range(2,1024) given here can remove the zero_extend for
+; the i32 %evl to i64 on RV64 through KnownBits analysis.
 
-define <vscale x 32 x i32> @vminu_vx_nxv32i32_evl_nx16(<vscale x 32 x i32> %va, i32 %b, <vscale x 32 x i1> %m) {
-; RV32-LABEL: vminu_vx_nxv32i32_evl_nx16:
-; RV32:       # %bb.0:
-; RV32-NEXT:    vsetvli a1, zero, e32, m8, ta, ma
-; RV32-NEXT:    vminu.vx v8, v8, a0, v0.t
-; RV32-NEXT:    ret
-;
-; RV64-LABEL: vminu_vx_nxv32i32_evl_nx16:
-; RV64:       # %bb.0:
-; RV64-NEXT:    csrr a1, vlenb
-; RV64-NEXT:    srli a1, a1, 2
-; RV64-NEXT:    vsetvli a2, zero, e8, mf2, ta, ma
-; RV64-NEXT:    vslidedown.vx v24, v0, a1
-; RV64-NEXT:    vsetvli a1, zero, e32, m8, ta, ma
-; RV64-NEXT:    vminu.vx v8, v8, a0, v0.t
-; RV64-NEXT:    vmv1r.v v0, v24
-; RV64-NEXT:    vsetivli zero, 0, e32, m8, ta, ma
-; RV64-NEXT:    vminu.vx v16, v16, a0, v0.t
-; RV64-NEXT:    ret
+define <vscale x 32 x i32> @vminu_vx_nxv32i32_evl_nx16(<vscale x 32 x i32> %va, i32 %b, <vscale x 32 x i1> %m) vscale_range(2,1024) {
+; CHECK-LABEL: vminu_vx_nxv32i32_evl_nx16:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vsetvli a1, zero, e32, m8, ta, ma
+; CHECK-NEXT:    vminu.vx v8, v8, a0, v0.t
+; CHECK-NEXT:    ret
   %elt.head = insertelement <vscale x 32 x i32> poison, i32 %b, i32 0
   %vb = shufflevector <vscale x 32 x i32> %elt.head, <vscale x 32 x i32> poison, <vscale x 32 x i32> zeroinitializer
   %evl = call i32 @llvm.vscale.i32()


### PR DESCRIPTION
The attribute `vscale_range(2,1024)` is added to each function by default when the V extension is enabled, 
so that the zero_extend for the i32 %evl to i64 on RV64 would be removed usually.