### PR TITLE
[lldb/gdb-remote] Do not crash on an invalid server response

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.h
@@ -168,7 +168,7 @@ public:
                                     GDBRemoteCommunication &server);
 
   /// Expand GDB run-length encoding.
-  static std::string ExpandRLE(std::string);
+  static std::optional<std::string> ExpandRLE(std::string);
 
 protected:
   std::chrono::seconds m_packet_timeout;


### PR DESCRIPTION
An invalid RLE sequence in the received packet could result in an out-of-bounds reading that could cause a crash.