### PR TITLE
[NFC][analyzer] Correct example code in VirtualCall docs

### DIFF
--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -563,7 +563,7 @@ pure virtual – but may be still surprising for the programmer.)
 .. code-block:: cpp
 
  struct A {
-   virtual void getKind() = 0;
+   virtual int getKind() = 0;
 
    A() {
      // warn: This calls the pure virtual method A::getKind().
@@ -888,7 +888,7 @@ checker does not report them**.
 .. code-block:: cpp
 
  struct A {
-   virtual void getKind();
+   virtual int getKind();
 
    A() {
      // warn: This calls A::getKind() even if we are constructing an instance


### PR DESCRIPTION
Oops, I noticed these just after merging my commit 9762b8e1757601a719d926f7df77c207617adfdd.