### PR TITLE
[CI] Don't count canceled buildkite builds

### DIFF
--- a/.ci/metrics/metrics.py
+++ b/.ci/metrics/metrics.py
@@ -215,25 +215,14 @@ def buildkite_get_metrics(
             if job["name"] not in BUILDKITE_WORKFLOW_TO_TRACK:
                 continue
 
+            # Don't count canceled jobs.
+            if job["canceled_at"]:
+                continue
+
             created_at = dateutil.parser.isoparse(job["created_at"])
-            scheduled_at = (
-                created_at
-                if job["scheduled_at"] is None
-                else dateutil.parser.isoparse(job["scheduled_at"])
-            )
-            started_at = (
-                scheduled_at
-                if job["started_at"] is None
-                else dateutil.parser.isoparse(job["started_at"])
-            )
-            if job["canceled_at"] is None:
-                finished_at = (
-                    started_at
-                    if job["finished_at"] is None
-                    else dateutil.parser.isoparse(job["finished_at"])
-                )
-            else:
-                finished_at = dateutil.parser.isoparse(job["canceled_at"])
+            scheduled_at = dateutil.parser.isoparse(job["scheduled_at"])
+            started_at = dateutil.parser.isoparse(job["started_at"])
+            finished_at = dateutil.parser.isoparse(job["finished_at"])
 
             job_name = BUILDKITE_WORKFLOW_TO_TRACK[job["name"]]
             queue_time = (started_at - scheduled_at).seconds


### PR DESCRIPTION
We don't count canceled jobs on GCP, so we shouldn't count canceled jobs on Buildkite neither.