### PR TITLE
[clang-tidy] Skip system macros in readability-identifier-naming check

### DIFF
--- a/clang-tools-extra/clang-tidy/utils/RenamerClangTidyCheck.cpp
+++ b/clang-tools-extra/clang-tidy/utils/RenamerClangTidyCheck.cpp
@@ -194,6 +194,8 @@ public:
       return;
     if (SM.isWrittenInCommandLineFile(MacroNameTok.getLocation()))
       return;
+    if (SM.isInSystemHeader(MacroNameTok.getLocation()))
+      return;
     Check->checkMacro(MacroNameTok, Info, SM);
   }
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -163,7 +163,7 @@ Changes in existing checks
 
 - Improved :doc:`bugprone-reserved-identifier
   <clang-tidy/checks/bugprone/reserved-identifier>` check by ignoring
-  declarations in system headers.
+  declarations and macros in system headers.
 
 - Improved :doc:`bugprone-signed-char-misuse
   <clang-tidy/checks/bugprone/signed-char-misuse>` check by fixing
@@ -229,8 +229,8 @@ Changes in existing checks
 
 - Improved :doc:`readability-identifier-naming
   <clang-tidy/checks/readability/identifier-naming>` check by ignoring
-  declarations in system headers. The documentation is also improved to
-  differentiate the general options from the specific ones.
+  declarations and macros in system headers. The documentation is also improved
+  to differentiate the general options from the specific ones.
 
 - Improved :doc:`readability-qualified-auto
   <clang-tidy/checks/readability/qualified-auto>` check by adding the option


### PR DESCRIPTION
Currently, the check is processing system macros. Most importantly, it tries to find .clang-tidy files associated with those files, if the option GetConfigPerFile (on by default) is active.

This is problematic for a number of reasons:

- System macros cannot be acted upon (renamed), so it's wasted work.
- When the main .cpp file includes a system header, clang-tidy tries to find the .clang-tidy file for that system header. When that system header is a 3rd-party repository, they may have their own .clang-tidy file, which may not be compatible with the current version of clang-tidy. So, clang-tidy may fail to analyze our main.cpp file, only because it includes a 3rd-party system header whose .clang-tidy file is incompatible with our clang-tidy binary.

Therefore, skip system macros in this check.

This reduces the amount of unwanted warnings as follows:
    
On trunk:
Suppressed 11448 warnings (11448 in non-user code).
    
With this patch:
Suppressed 4824 warnings (4824 in non-user code).
    
The runtime is pretty much unchanged.