### PR TITLE
[LV] Get FMFs from VectorBuilder in createSimpleReduction. NFC

### DIFF
--- a/llvm/include/llvm/IR/VectorBuilder.h
+++ b/llvm/include/llvm/IR/VectorBuilder.h
@@ -87,6 +87,9 @@ public:
     StaticVectorLength = ElementCount::getFixed(NewFixedVL);
     return *this;
   }
+
+  FastMathFlags &getFastMathFlags() const { return Builder.getFastMathFlags(); }
+
   // TODO: setStaticVL(ElementCount) for scalable types.
 
   // Emit a VP intrinsic call that mimics a regular instruction.

--- a/llvm/include/llvm/IR/VectorBuilder.h
+++ b/llvm/include/llvm/IR/VectorBuilder.h
@@ -88,7 +88,10 @@ public:
     return *this;
   }
 
-  FastMathFlags &getFastMathFlags() const { return Builder.getFastMathFlags(); }
+  /// Get the flags to be applied to created floating point ops.
+  const FastMathFlags &getFastMathFlags() const {
+    return Builder.getFastMathFlags();
+  }
 
   // TODO: setStaticVL(ElementCount) for scalable types.
 

--- a/llvm/include/llvm/Transforms/Utils/LoopUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/LoopUtils.h
@@ -411,8 +411,7 @@ Value *createSimpleReduction(IRBuilderBase &B, Value *Src,
                              RecurKind RdxKind);
 /// Overloaded function to generate vector-predication intrinsics for
 /// reduction.
-Value *createSimpleReduction(VectorBuilder &VB, Value *Src, RecurKind RdxKind,
-                             FastMathFlags FMFs);
+Value *createSimpleReduction(VectorBuilder &VB, Value *Src, RecurKind RdxKind);
 
 /// Create a reduction of the given vector \p Src for a reduction of the
 /// kind RecurKind::IAnyOf or RecurKind::FAnyOf. The reduction operation is

--- a/llvm/lib/Transforms/Utils/LoopUtils.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUtils.cpp
@@ -1333,14 +1333,15 @@ Value *llvm::createSimpleReduction(IRBuilderBase &Builder, Value *Src,
 }
 
 Value *llvm::createSimpleReduction(VectorBuilder &VBuilder, Value *Src,
-                                   RecurKind Kind, FastMathFlags FMFs) {
+                                   RecurKind Kind) {
   assert(!RecurrenceDescriptor::isAnyOfRecurrenceKind(Kind) &&
          !RecurrenceDescriptor::isFindLastIVRecurrenceKind(Kind) &&
          "AnyOf or FindLastIV reductions are not supported.");
   Intrinsic::ID Id = getReductionIntrinsicID(Kind);
   auto *SrcTy = cast<VectorType>(Src->getType());
   Type *SrcEltTy = SrcTy->getElementType();
-  Value *Iden = getRecurrenceIdentity(Kind, SrcEltTy, FMFs);
+  Value *Iden =
+      getRecurrenceIdentity(Kind, SrcEltTy, VBuilder.getFastMathFlags());
   Value *Ops[] = {Iden, Src};
   return VBuilder.createSimpleReduction(Id, SrcTy, Ops);
 }

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -2358,7 +2358,7 @@ void VPReductionEVLRecipe::execute(VPTransformState &State) {
   if (isOrdered()) {
     NewRed = createOrderedReduction(VBuilder, Kind, VecOp, Prev);
   } else {
-    NewRed = createSimpleReduction(VBuilder, VecOp, Kind, getFastMathFlags());
+    NewRed = createSimpleReduction(VBuilder, VecOp, Kind);
     if (RecurrenceDescriptor::isMinMaxRecurrenceKind(Kind))
       NewRed = createMinMaxOp(Builder, Kind, NewRed, Prev);
     else


### PR DESCRIPTION
The other createSimpleReduction takes the FMFs from the IRBuilder, so this aligns the VectorBuilder variant to do the same and reduce the possibility of there being a mismatch in flags.

Stacked on #132014
