### PR TITLE
[NFC][CostModel][ARM] Remove redundant lambda capture

### DIFF
--- a/llvm/lib/Target/ARM/ARMTargetTransformInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMTargetTransformInfo.cpp
@@ -1486,7 +1486,7 @@ InstructionCost ARMTTIImpl::getArithmeticInstrCost(
     auto IsExtInst = [](const Value *V) -> bool {
       return isa<ZExtInst>(V) || isa<SExtInst>(V);
     };
-    auto IsExtensionFromHalf = [&, IsExtInst](const Value *V) -> bool {
+    auto IsExtensionFromHalf = [](const Value *V) -> bool {
       return cast<Instruction>(V)->getOperand(0)->getType()->isIntegerTy(16);
     };
 


### PR DESCRIPTION
Buildbot failures were caused by PR #122713. This
was due to unused captures in a lambda function.