### PR TITLE
[libc] Fix `size_t` and `unsigned long` mismatch on riscv32 in test.

### DIFF
--- a/libc/test/src/search/lsearch_test.cpp
+++ b/libc/test/src/search/lsearch_test.cpp
@@ -44,7 +44,7 @@ TEST(LlvmLibcLsearchTest, SearchNonExistent) {
   void *ret = LIBC_NAMESPACE::lsearch(&key, list, &len, sizeof(int), compar);
   ASSERT_TRUE(ret == &list[3]);
   ASSERT_EQ(key, list[3]);
-  ASSERT_EQ(len, 4UL);
+  ASSERT_EQ(len, size_t{4});
 }
 
 TEST(LlvmLibcLsearchTest, SearchExceptional) {


### PR DESCRIPTION
Fix regression: https://github.com/llvm/llvm-project/pull/131431#issuecomment-2735029529