### PR TITLE
[flang] add QSORT extension intrinsic to the runtime

### DIFF
--- a/flang-rt/lib/runtime/extensions.cpp
+++ b/flang-rt/lib/runtime/extensions.cpp
@@ -20,6 +20,7 @@
 #include <cstring>
 #include <ctime>
 #include <signal.h>
+#include <stdlib.h>
 #include <thread>
 
 #ifdef _WIN32
@@ -261,6 +262,11 @@ int RTNAME(Chdir)(const char *name) {
 }
 
 int FORTRAN_PROCEDURE_NAME(ierrno)() { return errno; }
+
+void FORTRAN_PROCEDURE_NAME(qsort)(int *array, int *len, int *isize,
+    int (*compar)(const void *, const void *)) {
+  qsort(array, *len, *isize, compar);
+}
 
 } // namespace Fortran::runtime
 } // extern "C"

--- a/flang/docs/Intrinsics.md
+++ b/flang/docs/Intrinsics.md
@@ -1106,3 +1106,34 @@ end program chdir_func
 - **Standard:** GNU extension
 - **Class:** function
 - **Syntax:** `RESULT = IERRNO()`
+
+### Non-Standard Intrinsics: QSORT
+
+#### Description
+
+```
+SUBROUTINE QSORT(ARRAY, LEN, ISIZE, COMPAR)
+  TYPE(*) :: ARRAY(*)
+  INTEGER(4) :: LEN, ISIZE
+  INTERFACE
+    INTEGER(4) FUNCTION COMPAR(A, B)
+      TYPE(*) :: A, B
+    END FUNCTION
+  END INTERFACE
+END SUBROUTINE
+```
+
+Sort `ARRAY` in place in ascending order given the comparison function `COMPAR`.
+The array number of elements is given by `LEN` and the element byte size is given
+by `ISIZE`.
+
+`COMPAR` function takes the addresses of element `A` and `B` and must return:
+- a negative value if `A` < `B`
+- zero if `A` == `B`
+- a positive value otherwise. 
+
+#### Usage and Info
+
+- **Standard:** lib3f (section 3f of old man pages).
+- **Class:** subroutine
+- **Syntax:** `CALL QSORT(ARRAY, LEN, ISIZE, COMPAR)`


### PR DESCRIPTION
Add support for legacy Fortran intrinsic QSORT from lib3f (used to be described in section 3f of the man pages. The best documentation I could find online is https://docs.oracle.com/cd/E19205-01/820-4180/man3f/index.html).

Since I do not think there is any standard sorting intrinsic in Fortran, this is still a relevant extension.

Example usage:

```
integer function  icompar(a,b)
 integer :: a, b
 icompar = merge(-1, merge(0, 1, a.eq.b), a.lt.b)
end function

  external :: icompar
  integer :: x(10) = [2,1,10,8,9,5,3,4,6,7]
  call qsort(x, 10,4, icompar)
  print *, x
end
```