### PR TITLE
[clang] Auto-detect which newline style to use for `cxx_dr_status.html`

### DIFF
--- a/clang/www/make_cxx_dr_status
+++ b/clang/www/make_cxx_dr_status
@@ -318,6 +318,22 @@ out_html.append('''\
 </html>
 ''')
 
-out_file = open(output, 'w')
+# Make an effort to remain consistent with the existing file.
+# We can't pick one newline style and use it on Windows,
+# because we can't be compatible with all 'autocrlf' modes at once.
+def detect_newline_style(file_path):
+  if not os.path.exists(file_path):
+    return '\n'
+  f = open(file_path)
+  f.readline()
+  if f.newlines is None:
+    return '\n'
+  if isinstance(f.newlines, str):
+    return f.newlines
+  newline = f.newlines[0]
+  print(f"Existing '{file_path}' has inconsistent newlines; picking '{newline.encode('unicode_escape').decode('utf-8')}'")
+  return newline
+    
+out_file = open(output, 'w', newline=detect_newline_style(output))
 out_file.write(''.join(out_html))
 out_file.close()


### PR DESCRIPTION
Aaron reported that `make_cxx_dr_status` replaces all newlines in `cxx_dr_status.html`, which makes for a huge diff. On Windows, we can't be compatible with all `autocrlf` modes at once, so this patch adds autodetection of newline style using the existing file, if one is present (which should be the case for all reasonable use cases).