### PR TITLE
Fix bazel build for 8437b7f5.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -1591,7 +1591,10 @@ libc_support_library(
 
 libc_support_library(
     name = "libc_external_common",
-    hdrs = glob(["shared/*.h"]),
+    hdrs = glob(
+        ["shared/*.h"],
+        exclude = ["shared/rpc_server.h"],
+    ),
     deps = [
         ":__support_common",
         ":__support_fputil_fp_bits",


### PR DESCRIPTION
When using parse_headers validation, rpc_server.h fails to build, since we don't expose any of the RPC deps in the Bazel build.

So at least for now, just exclude it.