### PR TITLE
[flang] Catch bad usage case of whole assumed-size array

### DIFF
--- a/flang/include/flang/Semantics/expression.h
+++ b/flang/include/flang/Semantics/expression.h
@@ -258,16 +258,16 @@ public:
   // Builds a typed Designator from an untyped DataRef
   MaybeExpr Designate(DataRef &&);
 
+  // Allows a whole assumed-size array to appear for the lifetime of
+  // the returned value.
+  common::Restorer<bool> AllowWholeAssumedSizeArray(bool yes = true) {
+    return common::ScopedSet(isWholeAssumedSizeArrayOk_, yes);
+  }
+
 protected:
   int IntegerTypeSpecKind(const parser::IntegerTypeSpec &);
 
 private:
-  // Allows a whole assumed-size array to appear for the lifetime of
-  // the returned value.
-  common::Restorer<bool> AllowWholeAssumedSizeArray() {
-    return common::ScopedSet(isWholeAssumedSizeArrayOk_, true);
-  }
-
   // Allows an Expr to be a null pointer.
   common::Restorer<bool> AllowNullPointer() {
     return common::ScopedSet(isNullPointerOk_, true);

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -1915,7 +1915,9 @@ void ArrayConstructorContext::Add(const parser::AcValue::Triplet &triplet) {
 }
 
 void ArrayConstructorContext::Add(const parser::Expr &expr) {
-  auto restorer{exprAnalyzer_.GetContextualMessages().SetLocation(expr.source)};
+  auto restorer1{
+      exprAnalyzer_.GetContextualMessages().SetLocation(expr.source)};
+  auto restorer2{exprAnalyzer_.AllowWholeAssumedSizeArray(false)};
   Push(exprAnalyzer_.Analyze(expr));
 }
 

--- a/flang/test/Semantics/array-constr-values.f90
+++ b/flang/test/Semantics/array-constr-values.f90
@@ -2,9 +2,10 @@
 ! Confirm enforcement of constraints and restrictions in 7.8
 ! C7110, C7111, C7112, C7113, C7114, C7115
 
-subroutine arrayconstructorvalues()
+subroutine arrayconstructorvalues(asize)
   integer :: intarray(4)
   integer(KIND=8) :: k8 = 20
+  integer, intent(in) :: asize(*)
 
   TYPE EMPLOYEE
     INTEGER AGE
@@ -55,6 +56,9 @@ subroutine arrayconstructorvalues()
 
   !ERROR: Item is not suitable for use in an array constructor
   intarray(1:1) = [ arrayconstructorvalues ]
+
+  !ERROR: Whole assumed-size array 'asize' may not appear here without subscripts
+  intarray = [ asize ]
 end subroutine arrayconstructorvalues
 subroutine checkC7115()
   real, dimension(10), parameter :: good1 = [(99.9, i = 1, 10)]


### PR DESCRIPTION
Whole assumed-size arrays are generally not allowed outside specific contexts, where expression analysis notes that they can appear.  But contexts can nest, and in the case of an actual argument that turns out to be an array constructor, the permission to use a whole assumed-size array must be rescinded.

Fixes https://github.com/llvm/llvm-project/issues/131909.