### PR TITLE
[lldb] Fix tests to resolve symlinks when checking paths

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -722,17 +722,15 @@ class Base(unittest.TestCase):
 
     def getSourceDir(self):
         """Return the full path to the current test."""
-        return os.path.realpath(os.path.join(configuration.test_src_root, self.mydir))
+        return os.path.join(configuration.test_src_root, self.mydir)
 
     def getBuildDirBasename(self):
         return self.__class__.__module__ + "." + self.testMethodName
 
     def getBuildDir(self):
         """Return the full path to the current test."""
-        return os.path.realpath(
-            os.path.join(
-                configuration.test_build_dir, self.mydir, self.getBuildDirBasename()
-            )
+        return os.path.join(
+            configuration.test_build_dir, self.mydir, self.getBuildDirBasename()
         )
 
     def makeBuildDir(self):

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -722,15 +722,17 @@ class Base(unittest.TestCase):
 
     def getSourceDir(self):
         """Return the full path to the current test."""
-        return os.path.join(configuration.test_src_root, self.mydir)
+        return os.path.realpath(os.path.join(configuration.test_src_root, self.mydir))
 
     def getBuildDirBasename(self):
         return self.__class__.__module__ + "." + self.testMethodName
 
     def getBuildDir(self):
         """Return the full path to the current test."""
-        return os.path.join(
-            configuration.test_build_dir, self.mydir, self.getBuildDirBasename()
+        return os.path.realpath(
+            os.path.join(
+                configuration.test_build_dir, self.mydir, self.getBuildDirBasename()
+            )
         )
 
     def makeBuildDir(self):

--- a/lldb/test/API/commands/process/launch/TestProcessLaunch.py
+++ b/lldb/test/API/commands/process/launch/TestProcessLaunch.py
@@ -220,7 +220,7 @@ class ProcessLaunchTestCase(TestBase):
         mywd = "my_working_dir"
         out_file_name = "my_working_dir_test.out"
 
-        my_working_dir_path = self.getBuildArtifact(mywd)
+        my_working_dir_path = Path(self.getBuildArtifact(mywd)).resolve()
         lldbutil.mkdir_p(my_working_dir_path)
         out_file_path = os.path.join(my_working_dir_path, out_file_name)
         another_working_dir_path = Path(

--- a/lldb/test/API/source-manager/TestSourceManager.py
+++ b/lldb/test/API/source-manager/TestSourceManager.py
@@ -35,7 +35,7 @@ class SourceManagerTestCase(TestBase):
         # Call super's setUp().
         TestBase.setUp(self)
         # Find the line number to break inside main().
-        self.file = self.getBuildArtifact("main-copy.c")
+        self.file = os.path.realpath(self.getBuildArtifact("main-copy.c"))
         self.line = line_number("main.c", "// Set break point at this line.")
 
     def modify_content(self):


### PR DESCRIPTION
The inferior used in the process launch test prints out its working
directory using the `getcwd` function, which is not allowed to return
symbolic links in the path components. When testing against the output
from `getcwd` we should resolve the full path to match the expected
output.

The source manager test sets a breakpoint on a main-copy.c file that is
copied into the build output directory. The source manager resolves this
path to its real location. When testing the output from the source cache
we need to resolve the expected path in the test to remove symlinks.