### PR TITLE
[libclc] Move fmod, remainder & remquo to the CLC library

### DIFF
--- a/libclc/clc/include/clc/math/binary_def_via_fp32.inc
+++ b/libclc/clc/include/clc/math/binary_def_via_fp32.inc
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define __CLC_FUNCTION __clc_remainder
-#define __CLC_BODY <clc/math/binary_decl_tt.inc>
-#include <clc/math/gentype.inc>
-#undef __CLC_FUNCTION
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __CLC_FUNCTION(__CLC_GENTYPE x,
+                                                    __CLC_GENTYPE y) {
+  return __CLC_CONVERT_GENTYPE(
+      __CLC_FUNCTION(__CLC_CONVERT_FLOATN(x), __CLC_CONVERT_FLOATN(y)));
+}

--- a/libclc/clc/include/clc/math/clc_fmod.h
+++ b/libclc/clc/include/clc/math/clc_fmod.h
@@ -6,7 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_MATH_CLC_FMOD_H__
+#define __CLC_MATH_CLC_FMOD_H__
+
 #define __CLC_FUNCTION __clc_fmod
-#define __CLC_BODY <clc/math/binary_decl_tt.inc>
+#define __CLC_BODY <clc/shared/binary_decl.inc>
+
 #include <clc/math/gentype.inc>
+
+#undef __CLC_BODY
 #undef __CLC_FUNCTION
+
+#endif // __CLC_MATH_CLC_FMOD_H__

--- a/libclc/clc/include/clc/math/clc_remainder.h
+++ b/libclc/clc/include/clc/math/clc_remainder.h
@@ -6,9 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/clc.h>
-#include <clc/math/clc_remainder.h>
+#ifndef __CLC_MATH_CLC_REMAINDER_H__
+#define __CLC_MATH_CLC_REMAINDER_H__
 
-#define FUNCTION remainder
-#define __CLC_BODY <clc/shared/binary_def.inc>
+#define __CLC_FUNCTION __clc_remainder
+#define __CLC_BODY <clc/shared/binary_decl.inc>
+
 #include <clc/math/gentype.inc>
+
+#undef __CLC_BODY
+#undef __CLC_FUNCTION
+
+#endif // __CLC_MATH_CLC_REMAINDER_H__

--- a/libclc/clc/include/clc/math/clc_remquo.h
+++ b/libclc/clc/include/clc/math/clc_remquo.h
@@ -6,4 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE __CLC_FUNCTION(__CLC_GENTYPE x, __CLC_GENTYPE y, __CLC_ADDRESS_SPACE __CLC_INTN *q);
+#ifndef __CLC_MATH_CLC_REMQUO_H__
+#define __CLC_MATH_CLC_REMQUO_H__
+
+#define __CLC_FUNCTION __clc_remquo
+
+#define __CLC_BODY <clc/math/remquo_decl.inc>
+#define __CLC_ADDRESS_SPACE private
+#include <clc/math/gentype.inc>
+
+#undef __CLC_ADDRESS_SPACE
+#undef __CLC_BODY
+#undef __CLC_FUNCTION
+
+#endif // __CLC_MATH_CLC_REMQUO_H__

--- a/libclc/clc/include/clc/math/gentype.inc
+++ b/libclc/clc/include/clc/math/gentype.inc
@@ -68,6 +68,7 @@
 #define __CLC_CONVERT_S_GENTYPE __CLC_XCONCAT(__clc_convert_, __CLC_S_GENTYPE)
 #define __CLC_CONVERT_U_GENTYPE __CLC_XCONCAT(__clc_convert_, __CLC_U_GENTYPE)
 
+#if (!defined(__HALF_ONLY) && !defined(__DOUBLE_ONLY))
 #define __CLC_SCALAR_GENTYPE float
 #define __CLC_FPSIZE 32
 #define __CLC_FP_LIT(x) x##F
@@ -133,7 +134,9 @@
 #undef __CLC_FPSIZE
 #undef __CLC_SCALAR_GENTYPE
 
-#ifndef __FLOAT_ONLY
+#endif
+
+#if (!defined(__HALF_ONLY) && !defined(__FLOAT_ONLY))
 #ifdef cl_khr_fp64
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable
 
@@ -204,7 +207,7 @@
 #endif
 #endif
 
-#ifndef __FLOAT_ONLY
+#if (!defined(__FLOAT_ONLY) && !defined(__DOUBLE_ONLY))
 #ifdef cl_khr_fp16
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 

--- a/libclc/clc/include/clc/math/remquo_decl.inc
+++ b/libclc/clc/include/clc/math/remquo_decl.inc
@@ -6,11 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define __CLC_FUNCTION __clc_remquo
-
-#define __CLC_BODY <clc/math/remquo.inc>
-#define __CLC_ADDRESS_SPACE private
-#include <clc/math/gentype.inc>
-#undef __CLC_ADDRESS_SPACE
-
-#undef __CLC_FUNCTION
+_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE __CLC_FUNCTION(
+    __CLC_GENTYPE x, __CLC_GENTYPE y, __CLC_ADDRESS_SPACE __CLC_INTN *q);

--- a/libclc/clc/lib/generic/SOURCES
+++ b/libclc/clc/lib/generic/SOURCES
@@ -33,6 +33,7 @@ math/clc_copysign.cl
 math/clc_ep_log.cl
 math/clc_fabs.cl
 math/clc_fma.cl
+math/clc_fmod.cl
 math/clc_floor.cl
 math/clc_frexp.cl
 math/clc_hypot.cl

--- a/libclc/clc/lib/generic/SOURCES
+++ b/libclc/clc/lib/generic/SOURCES
@@ -45,6 +45,7 @@ math/clc_mad.cl
 math/clc_modf.cl
 math/clc_nan.cl
 math/clc_nextafter.cl
+math/clc_remainder.cl
 math/clc_rint.cl
 math/clc_round.cl
 math/clc_rsqrt.cl

--- a/libclc/clc/lib/generic/SOURCES
+++ b/libclc/clc/lib/generic/SOURCES
@@ -47,6 +47,7 @@ math/clc_modf.cl
 math/clc_nan.cl
 math/clc_nextafter.cl
 math/clc_remainder.cl
+math/clc_remquo.cl
 math/clc_rint.cl
 math/clc_round.cl
 math/clc_rsqrt.cl

--- a/libclc/clc/lib/generic/math/clc_remainder.cl
+++ b/libclc/clc/lib/generic/math/clc_remainder.cl
@@ -6,17 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/clc.h>
 #include <clc/clc_convert.h>
 #include <clc/clcmacro.h>
 #include <clc/integer/clc_clz.h>
+#include <clc/internal/clc.h>
 #include <clc/math/clc_floor.h>
 #include <clc/math/clc_fma.h>
-#include <clc/math/clc_subnormal_config.h>
+#include <clc/math/clc_ldexp.h>
+#include <clc/math/clc_remainder.h>
 #include <clc/math/clc_trunc.h>
 #include <clc/math/math.h>
 #include <clc/shared/clc_max.h>
-#include <math/clc_remainder.h>
 
 _CLC_DEF _CLC_OVERLOAD float __clc_remainder(float x, float y) {
   int ux = __clc_as_int(x);
@@ -77,6 +77,9 @@ _CLC_BINARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, float, __clc_remainder, float,
                       float);
 
 #ifdef cl_khr_fp64
+
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable
+
 _CLC_DEF _CLC_OVERLOAD double __clc_remainder(double x, double y) {
   ulong ux = __clc_as_ulong(x);
   ulong ax = ux & ~SIGNBIT_DP64;
@@ -104,7 +107,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_remainder(double x, double y) {
   // but it doesn't matter - it just means that we'll go round
   // the loop below one extra time.
   int ntimes = __clc_max(0, (xexp1 - yexp1) / 53);
-  double w = ldexp(dy, ntimes * 53);
+  double w = __clc_ldexp(dy, ntimes * 53);
   w = ntimes == 0 ? dy : w;
   double scale = ntimes == 0 ? 1.0 : 0x1.0p-53;
 
@@ -206,4 +209,16 @@ _CLC_DEF _CLC_OVERLOAD double __clc_remainder(double x, double y) {
 }
 _CLC_BINARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, double, __clc_remainder, double,
                       double);
+#endif
+
+#ifdef cl_khr_fp16
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+// Forward the half version of this builtin onto the float one
+#define __HALF_ONLY
+#define __CLC_FUNCTION __clc_remainder
+#define __CLC_BODY <clc/math/binary_def_via_fp32.inc>
+#include <clc/math/gentype.inc>
+
 #endif

--- a/libclc/clc/lib/generic/math/clc_remquo.cl
+++ b/libclc/clc/lib/generic/math/clc_remquo.cl
@@ -6,12 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/clc.h>
 #include <clc/clc_convert.h>
 #include <clc/clcmacro.h>
 #include <clc/integer/clc_clz.h>
+#include <clc/internal/clc.h>
 #include <clc/math/clc_floor.h>
 #include <clc/math/clc_fma.h>
+#include <clc/math/clc_ldexp.h>
 #include <clc/math/clc_subnormal_config.h>
 #include <clc/math/clc_trunc.h>
 #include <clc/math/math.h>
@@ -115,6 +116,9 @@ __VEC_REMQUO(float, 8, 4)
 __VEC_REMQUO(float, 16, 8)
 
 #ifdef cl_khr_fp64
+
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable
+
 _CLC_DEF _CLC_OVERLOAD double __clc_remquo(double x, double y,
                                            __private int *pquo) {
   ulong ux = __clc_as_ulong(x);
@@ -143,7 +147,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_remquo(double x, double y,
   // but it doesn't matter - it just means that we'll go round
   // the loop below one extra time.
   int ntimes = __clc_max(0, (xexp1 - yexp1) / 53);
-  double w = ldexp(dy, ntimes * 53);
+  double w = __clc_ldexp(dy, ntimes * 53);
   w = ntimes == 0 ? dy : w;
   double scale = ntimes == 0 ? 1.0 : 0x1.0p-53;
 

--- a/libclc/clspv/lib/SOURCES
+++ b/libclc/clspv/lib/SOURCES
@@ -21,7 +21,6 @@ subnormal_config.cl
 ../../generic/lib/math/clc_pow.cl
 ../../generic/lib/math/clc_pown.cl
 ../../generic/lib/math/clc_powr.cl
-../../generic/lib/math/clc_remainder.cl
 ../../generic/lib/math/clc_remquo.cl
 ../../generic/lib/math/clc_rootn.cl
 ../../generic/lib/math/clc_tan.cl

--- a/libclc/clspv/lib/SOURCES
+++ b/libclc/clspv/lib/SOURCES
@@ -20,7 +20,6 @@ subnormal_config.cl
 ../../generic/lib/math/clc_pow.cl
 ../../generic/lib/math/clc_pown.cl
 ../../generic/lib/math/clc_powr.cl
-../../generic/lib/math/clc_remquo.cl
 ../../generic/lib/math/clc_rootn.cl
 ../../generic/lib/math/clc_tan.cl
 ../../generic/lib/math/clc_tanpi.cl

--- a/libclc/clspv/lib/SOURCES
+++ b/libclc/clspv/lib/SOURCES
@@ -17,7 +17,6 @@ subnormal_config.cl
 ../../generic/lib/math/atanpi.cl
 ../../generic/lib/math/cbrt.cl
 ../../generic/lib/math/clc_exp10.cl
-../../generic/lib/math/clc_fmod.cl
 ../../generic/lib/math/clc_pow.cl
 ../../generic/lib/math/clc_pown.cl
 ../../generic/lib/math/clc_powr.cl

--- a/libclc/generic/include/clc/math/remquo.h
+++ b/libclc/generic/include/clc/math/remquo.h
@@ -8,17 +8,17 @@
 
 #define __CLC_FUNCTION remquo
 
-#define __CLC_BODY <clc/math/remquo.inc>
+#define __CLC_BODY <clc/math/remquo_decl.inc>
 #define __CLC_ADDRESS_SPACE global
 #include <clc/math/gentype.inc>
 #undef __CLC_ADDRESS_SPACE
 
-#define __CLC_BODY <clc/math/remquo.inc>
+#define __CLC_BODY <clc/math/remquo_decl.inc>
 #define __CLC_ADDRESS_SPACE local
 #include <clc/math/gentype.inc>
 #undef __CLC_ADDRESS_SPACE
 
-#define __CLC_BODY <clc/math/remquo.inc>
+#define __CLC_BODY <clc/math/remquo_decl.inc>
 #define __CLC_ADDRESS_SPACE private
 #include <clc/math/gentype.inc>
 #undef __CLC_ADDRESS_SPACE

--- a/libclc/generic/lib/SOURCES
+++ b/libclc/generic/lib/SOURCES
@@ -163,7 +163,6 @@ math/pown.cl
 math/clc_powr.cl
 math/powr.cl
 math/remainder.cl
-math/clc_remquo.cl
 math/remquo.cl
 math/rint.cl
 math/clc_rootn.cl

--- a/libclc/generic/lib/SOURCES
+++ b/libclc/generic/lib/SOURCES
@@ -108,7 +108,6 @@ math/floor.cl
 math/fma.cl
 math/fmax.cl
 math/fmin.cl
-math/clc_fmod.cl
 math/fmod.cl
 math/fract.cl
 math/frexp.cl

--- a/libclc/generic/lib/SOURCES
+++ b/libclc/generic/lib/SOURCES
@@ -163,7 +163,6 @@ math/clc_pown.cl
 math/pown.cl
 math/clc_powr.cl
 math/powr.cl
-math/clc_remainder.cl
 math/remainder.cl
 math/clc_remquo.cl
 math/remquo.cl

--- a/libclc/generic/lib/math/clc_fmod.cl
+++ b/libclc/generic/lib/math/clc_fmod.cl
@@ -16,7 +16,6 @@
 #include <clc/math/clc_trunc.h>
 #include <clc/math/math.h>
 #include <clc/shared/clc_max.h>
-#include <math/clc_remainder.h>
 
 _CLC_DEF _CLC_OVERLOAD float __clc_fmod(float x, float y) {
   int ux = __clc_as_int(x);

--- a/libclc/generic/lib/math/clc_remquo.cl
+++ b/libclc/generic/lib/math/clc_remquo.cl
@@ -16,7 +16,6 @@
 #include <clc/math/clc_trunc.h>
 #include <clc/math/math.h>
 #include <clc/shared/clc_max.h>
-#include <math/clc_remainder.h>
 
 _CLC_DEF _CLC_OVERLOAD float __clc_remquo(float x, float y,
                                           __private int *quo) {

--- a/libclc/generic/lib/math/fmod.cl
+++ b/libclc/generic/lib/math/fmod.cl
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/clc.h>
-#include <math/clc_fmod.h>
+#include <clc/math/clc_fmod.h>
 
-#define __CLC_FUNC fmod
-#define __CLC_BODY <clc_sw_binary.inc>
+#define FUNCTION fmod
+#define __CLC_BODY <clc/shared/binary_def.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/generic/lib/math/remquo.cl
+++ b/libclc/generic/lib/math/remquo.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/clc.h>
-#include <math/clc_remquo.h>
+#include <clc/math/clc_remquo.h>
 
 #define __CLC_BODY <remquo.inc>
 #define __CLC_ADDRESS_SPACE global

--- a/libclc/generic/lib/math/remquo.inc
+++ b/libclc/generic/lib/math/remquo.inc
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE remquo(__CLC_GENTYPE x, __CLC_GENTYPE y, __CLC_ADDRESS_SPACE __CLC_INTN *q) {
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE remquo(__CLC_GENTYPE x, __CLC_GENTYPE y,
+                                            __CLC_ADDRESS_SPACE __CLC_INTN *q) {
   __CLC_INTN local_q;
   __CLC_GENTYPE ret = __clc_remquo(x, y, &local_q);
   *q = local_q;

--- a/libclc/spirv/lib/SOURCES
+++ b/libclc/spirv/lib/SOURCES
@@ -41,7 +41,6 @@ subnormal_config.cl
 ../../generic/lib/math/clc_exp10.cl
 ../../generic/lib/math/exp10.cl
 math/fma.cl
-../../generic/lib/math/clc_fmod.cl
 ../../generic/lib/math/fmod.cl
 ../../generic/lib/math/fract.cl
 ../../generic/lib/math/frexp.cl

--- a/libclc/spirv/lib/SOURCES
+++ b/libclc/spirv/lib/SOURCES
@@ -65,7 +65,6 @@ math/fma.cl
 ../../generic/lib/math/pown.cl
 ../../generic/lib/math/clc_powr.cl
 ../../generic/lib/math/powr.cl
-../../generic/lib/math/clc_remainder.cl
 ../../generic/lib/math/remainder.cl
 ../../generic/lib/math/clc_remquo.cl
 ../../generic/lib/math/remquo.cl

--- a/libclc/spirv/lib/SOURCES
+++ b/libclc/spirv/lib/SOURCES
@@ -65,7 +65,6 @@ math/fma.cl
 ../../generic/lib/math/clc_powr.cl
 ../../generic/lib/math/powr.cl
 ../../generic/lib/math/remainder.cl
-../../generic/lib/math/clc_remquo.cl
 ../../generic/lib/math/remquo.cl
 ../../generic/lib/math/clc_rootn.cl
 ../../generic/lib/math/rootn.cl


### PR DESCRIPTION
These functions were already nominally in the CLC namespace; this commit just formally moves them over.

Note that 'half' versions of these CLC functions are now provided. Previously the corresponding OpenCL builtins would forward directly to the 'float' versions of the CLC builtins. Now the OpenCL builtins call the 'half' CLC builtins, which themselves call the 'float' CLC versions. This keeps the interface between the OpenCL and CLC libraries neater and keeps the CLC library self-contained.

No changes to the generated code for non-SPIR-V targets is observed.