### PR TITLE
[lldb] Add RegisterCheckpoint overload for register methods in RegisterContextThreadMemory

### DIFF
--- a/lldb/source/Plugins/Process/Utility/RegisterContextThreadMemory.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextThreadMemory.cpp
@@ -114,11 +114,27 @@ bool RegisterContextThreadMemory::ReadAllRegisterValues(
   return false;
 }
 
+bool RegisterContextThreadMemory::ReadAllRegisterValues(
+    lldb_private::RegisterCheckpoint &reg_checkpoint) {
+  UpdateRegisterContext();
+  if (m_reg_ctx_sp)
+    return m_reg_ctx_sp->ReadAllRegisterValues(reg_checkpoint);
+  return false;
+}
+
 bool RegisterContextThreadMemory::WriteAllRegisterValues(
     const lldb::DataBufferSP &data_sp) {
   UpdateRegisterContext();
   if (m_reg_ctx_sp)
     return m_reg_ctx_sp->WriteAllRegisterValues(data_sp);
+  return false;
+}
+
+bool RegisterContextThreadMemory::WriteAllRegisterValues(
+    const lldb_private::RegisterCheckpoint &reg_checkpoint) {
+  UpdateRegisterContext();
+  if (m_reg_ctx_sp)
+    return m_reg_ctx_sp->WriteAllRegisterValues(reg_checkpoint);
   return false;
 }
 

--- a/lldb/source/Plugins/Process/Utility/RegisterContextThreadMemory.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextThreadMemory.h
@@ -52,8 +52,12 @@ public:
   // so these API's should only be used when this behavior is needed.
 
   bool ReadAllRegisterValues(lldb::WritableDataBufferSP &data_sp) override;
+  bool ReadAllRegisterValues(
+      lldb_private::RegisterCheckpoint &reg_checkpoint) override;
 
   bool WriteAllRegisterValues(const lldb::DataBufferSP &data_sp) override;
+  bool WriteAllRegisterValues(
+      const lldb_private::RegisterCheckpoint &reg_checkpoint) override;
 
   bool CopyFromRegisterContext(lldb::RegisterContextSP context);
 


### PR DESCRIPTION
These allow for more efficient saving/restoring state after an expression is evaluated.