### PR TITLE
[flang] Disable 3 x86-64 tests on non-x86-64

### DIFF
--- a/flang/test/Lower/Intrinsics/product.f90
+++ b/flang/test/Lower/Intrinsics/product.f90
@@ -1,3 +1,4 @@
+! REQUIRES: x86_64-registered-target
 ! RUN: bbc --use-desc-for-alloc=false -emit-fir -hlfir=false %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPproduct_test(

--- a/flang/test/Lower/Intrinsics/sum.f90
+++ b/flang/test/Lower/Intrinsics/sum.f90
@@ -1,3 +1,4 @@
+! REQUIRES: x86_64-registered-target
 ! RUN: bbc --use-desc-for-alloc=false -emit-fir -hlfir=false %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func @_QPsum_test(

--- a/flang/test/Lower/complex-operations.f90
+++ b/flang/test/Lower/complex-operations.f90
@@ -1,4 +1,5 @@
 ! REQUIRES: flang-supports-f128-math
+! REQUIRES: x86_64-registered-target
 ! RUN: bbc -hlfir=false %s -o - | FileCheck %s
 
 ! CHECK-LABEL: @_QPadd_test


### PR DESCRIPTION
Now that COMPLEX(KIND=10) is properly disabled where 80-bit floating-point types are not available, three tests that were not peculiar to x86-64 are failing on other targets.  Make them specific to x86-64.