### PR TITLE
[libc++] Ensure that we vectorize algorithms on all Clang-based compilers

### DIFF
--- a/libcxx/include/__algorithm/simd_utils.h
+++ b/libcxx/include/__algorithm/simd_utils.h
@@ -26,7 +26,9 @@ _LIBCPP_PUSH_MACROS
 #include <__undef_macros>
 
 // TODO: Find out how altivec changes things and allow vectorizations there too.
-#if _LIBCPP_STD_VER >= 14 && defined(_LIBCPP_COMPILER_CLANG_BASED) && !defined(__ALTIVEC__)
+// TODO: Simplify this condition once we stop building with AppleClang 15 in the CI.
+#if _LIBCPP_STD_VER >= 14 && defined(_LIBCPP_COMPILER_CLANG_BASED) && !defined(__ALTIVEC__) &&                         \
+    !(defined(_LIBCPP_APPLE_CLANG_VER) && _LIBCPP_APPLE_CLANG_VER < 1600)
 #  define _LIBCPP_HAS_ALGORITHM_VECTOR_UTILS 1
 #else
 #  define _LIBCPP_HAS_ALGORITHM_VECTOR_UTILS 0

--- a/libcxx/include/__algorithm/simd_utils.h
+++ b/libcxx/include/__algorithm/simd_utils.h
@@ -26,7 +26,7 @@ _LIBCPP_PUSH_MACROS
 #include <__undef_macros>
 
 // TODO: Find out how altivec changes things and allow vectorizations there too.
-#if _LIBCPP_STD_VER >= 14 && defined(_LIBCPP_CLANG_VER) && !defined(__ALTIVEC__)
+#if _LIBCPP_STD_VER >= 14 && defined(_LIBCPP_COMPILER_CLANG_BASED) && !defined(__ALTIVEC__)
 #  define _LIBCPP_HAS_ALGORITHM_VECTOR_UTILS 1
 #else
 #  define _LIBCPP_HAS_ALGORITHM_VECTOR_UTILS 0

--- a/libcxx/test/libcxx/algorithms/vectorization.compile.pass.cpp
+++ b/libcxx/test/libcxx/algorithms/vectorization.compile.pass.cpp
@@ -9,6 +9,14 @@
 // We don't know how to vectorize algorithms on GCC
 // XFAIL: gcc
 
+// XFAIL: FROZEN-CXX03-HEADERS-FIXME
+
+// We don't vectorize algorithms before C++14
+// XFAIL: c++03, c++11
+
+// We don't vectorize algorithms on AIX right now.
+// XFAIL: target={{.+}}-aix{{.*}}
+
 // This test ensures that we enable the vectorization of algorithms on the expected
 // platforms.
 

--- a/libcxx/test/libcxx/algorithms/vectorization.compile.pass.cpp
+++ b/libcxx/test/libcxx/algorithms/vectorization.compile.pass.cpp
@@ -17,6 +17,9 @@
 // We don't vectorize algorithms on AIX right now.
 // XFAIL: target={{.+}}-aix{{.*}}
 
+// We don't vectorize on AppleClang 15 since that apparently breaks std::mismatch
+// XFAIL: apple-clang-15
+
 // This test ensures that we enable the vectorization of algorithms on the expected
 // platforms.
 

--- a/libcxx/test/libcxx/algorithms/vectorization.compile.pass.cpp
+++ b/libcxx/test/libcxx/algorithms/vectorization.compile.pass.cpp
@@ -22,6 +22,10 @@
 
 #include <algorithm>
 
+#ifndef _LIBCPP_VECTORIZE_ALGORITHMS
+#  error It looks like the test needs to be updated since _LIBCPP_VECTORIZE_ALGORITHMS isn't defined anymore
+#endif
+
 #if !_LIBCPP_VECTORIZE_ALGORITHMS
 #  error Algorithms should be vectorized on this platform
 #endif

--- a/libcxx/test/libcxx/algorithms/vectorization.compile.pass.cpp
+++ b/libcxx/test/libcxx/algorithms/vectorization.compile.pass.cpp
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// We don't know how to vectorize algorithms on GCC
+// XFAIL: gcc
+
+// This test ensures that we enable the vectorization of algorithms on the expected
+// platforms.
+
+#include <algorithm>
+
+#if !_LIBCPP_VECTORIZE_ALGORITHMS
+#  error Algorithms should be vectorized on this platform
+#endif


### PR DESCRIPTION
Otherwise, we wouldn't vectorize on compilers like AppleClang when in reality we know perfectly well how to do it.