### PR TITLE
[Clang] Fix UB in #131515

### DIFF
--- a/clang/include/clang/AST/ExprCXX.h
+++ b/clang/include/clang/AST/ExprCXX.h
@@ -2777,7 +2777,7 @@ class TypeTraitExpr final
                 ArrayRef<TypeSourceInfo *> Args, SourceLocation RParenLoc,
                 std::variant<bool, APValue> Value);
 
-  TypeTraitExpr(EmptyShell Empty) : Expr(TypeTraitExprClass, Empty) {}
+  TypeTraitExpr(EmptyShell Empty, bool IsStoredAsBool);
 
   size_t numTrailingObjects(OverloadToken<TypeSourceInfo *>) const {
     return getNumArgs();

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -1681,7 +1681,7 @@ std::optional<unsigned> Sema::GetDecompositionElementCount(QualType T,
   llvm::APSInt TupleSize(Ctx.getTypeSize(Ctx.getSizeType()));
   switch (isTupleLike(*this, Loc, T, TupleSize)) {
   case IsTupleLike::Error:
-    return {};
+    return std::nullopt;
   case IsTupleLike::TupleLike:
     return TupleSize.getExtValue();
   case IsTupleLike::NotTupleLike:
@@ -1706,7 +1706,7 @@ std::optional<unsigned> Sema::GetDecompositionElementCount(QualType T,
       RD->fields(), [](FieldDecl *FD) { return !FD->isUnnamedBitField(); });
 
   if (CheckMemberDecompositionFields(*this, Loc, OrigRD, T, BasePair))
-    return true;
+    return std::nullopt;
 
   return NumFields;
 }

--- a/clang/test/SemaCXX/builtin-structured-binding-size.cpp
+++ b/clang/test/SemaCXX/builtin-structured-binding-size.cpp
@@ -40,9 +40,9 @@ static_assert(__builtin_structured_binding_size(S5) == 2);
 // expected-error@-1 {{static assertion failed due to requirement '__builtin_structured_binding_size(S5) == 2'}} \
 // expected-note@-1 {{expression evaluates to '1 == 2'}}
 static_assert(__builtin_structured_binding_size(S6) == 2);
-// expected-error@-1 {{static assertion failed due to requirement '__builtin_structured_binding_size(S6) == 2'}} \
 // expected-error@-1 {{cannot decompose class type 'S6' because it has an anonymous union member}} \
-// expected-note@-1 {{expression evaluates to '1 == 2'}}
+// expected-error@-1 {{type 'S6' cannot be decomposed}} \
+// expected-error@-1 {{static assertion expression is not an integral constant expression}} \
 // expected-note@#note-anon-union {{declared here}}
 static_assert(__builtin_structured_binding_size(S7) == 1);
 


### PR DESCRIPTION
It turns out trailing objects are uninitialized
and APValue assignment operator requires a fully initialized object.

Additionally,  do some drive-by post-commit-review fixes.