### PR TITLE
[libc++] Make sure that __desugars_to isn't tripped up by reference_wrapper, const and ref qualifiers

### DIFF
--- a/libcxx/include/__algorithm/sort.h
+++ b/libcxx/include/__algorithm/sort.h
@@ -34,7 +34,6 @@
 #include <__type_traits/is_constant_evaluated.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/is_trivially_copyable.h>
-#include <__type_traits/remove_cvref.h>
 #include <__utility/move.h>
 #include <__utility/pair.h>
 #include <climits>
@@ -52,8 +51,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Compare, class _Iter, class _Tp = typename iterator_traits<_Iter>::value_type>
 inline const bool __use_branchless_sort =
     __libcpp_is_contiguous_iterator<_Iter>::value && __is_cheap_to_copy<_Tp> && is_arithmetic<_Tp>::value &&
-    (__desugars_to_v<__less_tag, __remove_cvref_t<_Compare>, _Tp, _Tp> ||
-     __desugars_to_v<__greater_tag, __remove_cvref_t<_Compare>, _Tp, _Tp>);
+    (__desugars_to_v<__less_tag, _Compare, _Tp, _Tp> || __desugars_to_v<__greater_tag, _Compare, _Tp, _Tp>);
 
 namespace __detail {
 

--- a/libcxx/include/__algorithm/stable_sort.h
+++ b/libcxx/include/__algorithm/stable_sort.h
@@ -29,7 +29,6 @@
 #include <__type_traits/is_integral.h>
 #include <__type_traits/is_same.h>
 #include <__type_traits/is_trivially_assignable.h>
-#include <__type_traits/remove_cvref.h>
 #include <__utility/move.h>
 #include <__utility/pair.h>
 
@@ -246,8 +245,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX26 void __stable_sort(
   }
 
 #if _LIBCPP_STD_VER >= 17
-  constexpr auto __default_comp =
-      __desugars_to_v<__totally_ordered_less_tag, __remove_cvref_t<_Compare>, value_type, value_type >;
+  constexpr auto __default_comp = __desugars_to_v<__totally_ordered_less_tag, _Compare, value_type, value_type >;
   constexpr auto __integral_value =
       is_integral_v<value_type > && is_same_v< value_type&, __iter_reference<_RandomAccessIterator>>;
   constexpr auto __allowed_radix_sort = __default_comp && __integral_value;

--- a/libcxx/include/__functional/reference_wrapper.h
+++ b/libcxx/include/__functional/reference_wrapper.h
@@ -15,6 +15,7 @@
 #include <__config>
 #include <__functional/weak_result_type.h>
 #include <__memory/addressof.h>
+#include <__type_traits/desugars_to.h>
 #include <__type_traits/enable_if.h>
 #include <__type_traits/invoke.h>
 #include <__type_traits/is_const.h>
@@ -148,6 +149,11 @@ template <class _Tp>
 void ref(const _Tp&&) = delete;
 template <class _Tp>
 void cref(const _Tp&&) = delete;
+
+// Let desugars-to pass through std::reference_wrapper
+template <class _CanonicalTag, class _Operation, class... _Args>
+inline const bool __desugars_to_v<_CanonicalTag, reference_wrapper<_Operation>, _Args...> =
+    __desugars_to_v<_CanonicalTag, _Operation, _Args...>;
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__type_traits/desugars_to.h
+++ b/libcxx/include/__type_traits/desugars_to.h
@@ -53,15 +53,9 @@ template <class _CanonicalTag, class _Operation, class... _Args>
 inline const bool __desugars_to_v = false;
 
 // For the purpose of determining whether something desugars to something else,
-// we disregard the cv-refs of the operation itself.
+// we disregard const and ref qualifiers on the operation itself.
 template <class _CanonicalTag, class _Operation, class... _Args>
 inline const bool __desugars_to_v<_CanonicalTag, _Operation const, _Args...> =
-    __desugars_to_v<_CanonicalTag, _Operation, _Args...>;
-template <class _CanonicalTag, class _Operation, class... _Args>
-inline const bool __desugars_to_v<_CanonicalTag, _Operation volatile, _Args...> =
-    __desugars_to_v<_CanonicalTag, _Operation, _Args...>;
-template <class _CanonicalTag, class _Operation, class... _Args>
-inline const bool __desugars_to_v<_CanonicalTag, _Operation const volatile, _Args...> =
     __desugars_to_v<_CanonicalTag, _Operation, _Args...>;
 template <class _CanonicalTag, class _Operation, class... _Args>
 inline const bool __desugars_to_v<_CanonicalTag, _Operation&, _Args...> =

--- a/libcxx/include/__type_traits/desugars_to.h
+++ b/libcxx/include/__type_traits/desugars_to.h
@@ -52,6 +52,24 @@ struct __totally_ordered_less_tag {};
 template <class _CanonicalTag, class _Operation, class... _Args>
 inline const bool __desugars_to_v = false;
 
+// For the purpose of determining whether something desugars to something else,
+// we disregard the cv-refs of the operation itself.
+template <class _CanonicalTag, class _Operation, class... _Args>
+inline const bool __desugars_to_v<_CanonicalTag, _Operation const, _Args...> =
+    __desugars_to_v<_CanonicalTag, _Operation, _Args...>;
+template <class _CanonicalTag, class _Operation, class... _Args>
+inline const bool __desugars_to_v<_CanonicalTag, _Operation volatile, _Args...> =
+    __desugars_to_v<_CanonicalTag, _Operation, _Args...>;
+template <class _CanonicalTag, class _Operation, class... _Args>
+inline const bool __desugars_to_v<_CanonicalTag, _Operation const volatile, _Args...> =
+    __desugars_to_v<_CanonicalTag, _Operation, _Args...>;
+template <class _CanonicalTag, class _Operation, class... _Args>
+inline const bool __desugars_to_v<_CanonicalTag, _Operation&, _Args...> =
+    __desugars_to_v<_CanonicalTag, _Operation, _Args...>;
+template <class _CanonicalTag, class _Operation, class... _Args>
+inline const bool __desugars_to_v<_CanonicalTag, _Operation&&, _Args...> =
+    __desugars_to_v<_CanonicalTag, _Operation, _Args...>;
+
 _LIBCPP_END_NAMESPACE_STD
 
 #endif // _LIBCPP___TYPE_TRAITS_DESUGARS_TO_H

--- a/libcxx/test/libcxx/type_traits/desugars_to.compile.pass.cpp
+++ b/libcxx/test/libcxx/type_traits/desugars_to.compile.pass.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: FROZEN-CXX03-HEADERS-FIXME
+
 #include <__type_traits/desugars_to.h>
 
 struct Tag {};

--- a/libcxx/test/libcxx/type_traits/desugars_to.compile.pass.cpp
+++ b/libcxx/test/libcxx/type_traits/desugars_to.compile.pass.cpp
@@ -8,6 +8,9 @@
 
 // UNSUPPORTED: FROZEN-CXX03-HEADERS-FIXME
 
+// This test requires variable templates
+// UNSUPPORTED: gcc && c++11
+
 #include <__type_traits/desugars_to.h>
 
 struct Tag {};

--- a/libcxx/test/libcxx/type_traits/desugars_to.compile.pass.cpp
+++ b/libcxx/test/libcxx/type_traits/desugars_to.compile.pass.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <__type_traits/desugars_to.h>
+
+struct Tag {};
+struct Operation {};
+template <>
+bool const std::__desugars_to_v<Tag, Operation> = true;
+
+void tests() {
+  // Make sure that __desugars_to is false by default
+  {
+    struct Foo {};
+    static_assert(!std::__desugars_to_v<Tag, Foo>, "");
+  }
+
+  // Make sure that __desugars_to bypasses cv and ref qualifiers on the operation
+  {
+    static_assert(std::__desugars_to_v<Tag, Operation>, ""); // no quals
+    static_assert(std::__desugars_to_v<Tag, Operation const>, "");
+    static_assert(std::__desugars_to_v<Tag, Operation volatile>, "");
+    static_assert(std::__desugars_to_v<Tag, Operation const volatile>, "");
+
+    static_assert(std::__desugars_to_v<Tag, Operation&>, "");
+    static_assert(std::__desugars_to_v<Tag, Operation const&>, "");
+    static_assert(std::__desugars_to_v<Tag, Operation volatile&>, "");
+    static_assert(std::__desugars_to_v<Tag, Operation const volatile&>, "");
+
+    static_assert(std::__desugars_to_v<Tag, Operation&&>, "");
+    static_assert(std::__desugars_to_v<Tag, Operation const&&>, "");
+    static_assert(std::__desugars_to_v<Tag, Operation volatile&&>, "");
+    static_assert(std::__desugars_to_v<Tag, Operation const volatile&&>, "");
+  }
+}

--- a/libcxx/test/libcxx/type_traits/desugars_to.compile.pass.cpp
+++ b/libcxx/test/libcxx/type_traits/desugars_to.compile.pass.cpp
@@ -28,21 +28,15 @@ void tests() {
     static_assert(!std::__desugars_to_v<Tag, Foo>, "");
   }
 
-  // Make sure that __desugars_to bypasses cv and ref qualifiers on the operation
+  // Make sure that __desugars_to bypasses const and ref qualifiers on the operation
   {
     static_assert(std::__desugars_to_v<Tag, Operation>, ""); // no quals
     static_assert(std::__desugars_to_v<Tag, Operation const>, "");
-    static_assert(std::__desugars_to_v<Tag, Operation volatile>, "");
-    static_assert(std::__desugars_to_v<Tag, Operation const volatile>, "");
 
     static_assert(std::__desugars_to_v<Tag, Operation&>, "");
     static_assert(std::__desugars_to_v<Tag, Operation const&>, "");
-    static_assert(std::__desugars_to_v<Tag, Operation volatile&>, "");
-    static_assert(std::__desugars_to_v<Tag, Operation const volatile&>, "");
 
     static_assert(std::__desugars_to_v<Tag, Operation&&>, "");
     static_assert(std::__desugars_to_v<Tag, Operation const&&>, "");
-    static_assert(std::__desugars_to_v<Tag, Operation volatile&&>, "");
-    static_assert(std::__desugars_to_v<Tag, Operation const volatile&&>, "");
   }
 }

--- a/libcxx/test/libcxx/type_traits/desugars_to.compile.pass.cpp
+++ b/libcxx/test/libcxx/type_traits/desugars_to.compile.pass.cpp
@@ -12,8 +12,11 @@
 
 struct Tag {};
 struct Operation {};
+
+namespace std {
 template <>
-bool const std::__desugars_to_v<Tag, Operation> = true;
+bool const __desugars_to_v<Tag, Operation> = true;
+}
 
 void tests() {
   // Make sure that __desugars_to is false by default

--- a/libcxx/test/libcxx/utilities/function.objects/refwrap/desugars_to.compile.pass.cpp
+++ b/libcxx/test/libcxx/utilities/function.objects/refwrap/desugars_to.compile.pass.cpp
@@ -20,8 +20,11 @@
 
 struct Operation {};
 struct Tag {};
+
+namespace std {
 template <>
-bool const std::__desugars_to_v<Tag, Operation> = true;
+bool const __desugars_to_v<Tag, Operation> = true;
+}
 
 static_assert(std::__desugars_to_v<Tag, Operation>, "something is wrong with the test");
 

--- a/libcxx/test/libcxx/utilities/function.objects/refwrap/desugars_to.compile.pass.cpp
+++ b/libcxx/test/libcxx/utilities/function.objects/refwrap/desugars_to.compile.pass.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// UNSUPPORTED: FROZEN-CXX03-HEADERS-FIXME
+
 // <functional>
 
 // reference_wrapper

--- a/libcxx/test/libcxx/utilities/function.objects/refwrap/desugars_to.compile.pass.cpp
+++ b/libcxx/test/libcxx/utilities/function.objects/refwrap/desugars_to.compile.pass.cpp
@@ -14,6 +14,7 @@
 // std::__desugars_to internal helper.
 
 #include <functional>
+#include <__type_traits/desugars_to.h>
 
 struct Operation {};
 struct Tag {};

--- a/libcxx/test/libcxx/utilities/function.objects/refwrap/desugars_to.compile.pass.cpp
+++ b/libcxx/test/libcxx/utilities/function.objects/refwrap/desugars_to.compile.pass.cpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <functional>
+
+// reference_wrapper
+
+// Ensure that std::reference_wrapper does not inhibit optimizations based on the
+// std::__desugars_to internal helper.
+
+#include <functional>
+
+static_assert(std::__desugars_to_v<std::__equal_tag, std::equal_to<void>, int, int>,
+              "something is wrong with the test");
+
+// make sure we pass through reference_wrapper
+static_assert(std::__desugars_to_v<std::__equal_tag, std::reference_wrapper<std::equal_to<void> >, int, int>, "");
+static_assert(std::__desugars_to_v<std::__equal_tag, std::reference_wrapper<std::equal_to<void> const>, int, int>, "");

--- a/libcxx/test/libcxx/utilities/function.objects/refwrap/desugars_to.compile.pass.cpp
+++ b/libcxx/test/libcxx/utilities/function.objects/refwrap/desugars_to.compile.pass.cpp
@@ -15,9 +15,13 @@
 
 #include <functional>
 
-static_assert(std::__desugars_to_v<std::__equal_tag, std::equal_to<void>, int, int>,
-              "something is wrong with the test");
+struct Operation {};
+struct Tag {};
+template <>
+bool const std::__desugars_to_v<Tag, Operation> = true;
+
+static_assert(std::__desugars_to_v<Tag, Operation>, "something is wrong with the test");
 
 // make sure we pass through reference_wrapper
-static_assert(std::__desugars_to_v<std::__equal_tag, std::reference_wrapper<std::equal_to<void> >, int, int>, "");
-static_assert(std::__desugars_to_v<std::__equal_tag, std::reference_wrapper<std::equal_to<void> const>, int, int>, "");
+static_assert(std::__desugars_to_v<Tag, std::reference_wrapper<Operation> >, "");
+static_assert(std::__desugars_to_v<Tag, std::reference_wrapper<Operation const> >, "");

--- a/libcxx/test/libcxx/utilities/function.objects/refwrap/desugars_to.compile.pass.cpp
+++ b/libcxx/test/libcxx/utilities/function.objects/refwrap/desugars_to.compile.pass.cpp
@@ -8,6 +8,9 @@
 
 // UNSUPPORTED: FROZEN-CXX03-HEADERS-FIXME
 
+// This test requires variable templates
+// UNSUPPORTED: gcc && c++11
+
 // <functional>
 
 // reference_wrapper


### PR DESCRIPTION
Previously, const and ref qualification on an operation would cause __desugars_to to report false, which would lead to unnecessary pessimizations. The same holds for reference_wrapper.

In practice, const and ref qualifications on the operation itself are not relevant to determining whether an operation desugars to something else or not, so can be ignored.

We are not stripping volatile qualifiers from operations in this patch because we feel that this requires additional discussion.

Fixes #129312