### PR TITLE
[RISCV] Add ($rs1) InstAliases with no immediate for Zilsd/Zclsd.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZclsd.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZclsd.td
@@ -60,7 +60,7 @@ class PairCStore_rri<bits<3> funct3, string OpcodeStr,
                      DAGOperand RC, DAGOperand opnd>
     : RVInst16CS<funct3, 0b00, (outs), (ins RC:$rs2,GPRCMem:$rs1, opnd:$imm),
                  OpcodeStr, "$rs2, ${imm}(${rs1})">;
-                 
+
 //===----------------------------------------------------------------------===//
 // Instructions
 //===----------------------------------------------------------------------===//
@@ -90,6 +90,21 @@ def C_SD_RV32 : PairCStore_rri<0b111, "c.sd", GPRPairCRV32, uimm8_lsb000>,
   let Inst{6-5} = imm{7-6};
 }
 }// Predicates = [HasStdExtZclsd, IsRV32], DecoderNamespace = "ZcOverlap"
+
+//===----------------------------------------------------------------------===//
+// Assembler Pseudo Instructions
+//===----------------------------------------------------------------------===//
+
+let Predicates = [HasStdExtZclsd, IsRV32] in {
+def : InstAlias<"c.ld $rd, (${rs1})",
+                (C_LD_RV32 GPRPairCRV32:$rd, GPRCMem:$rs1, 0), 0>;
+def : InstAlias<"c.sd $rs2, (${rs1})",
+                (C_SD_RV32 GPRPairCRV32:$rs2, GPRCMem:$rs1, 0), 0>;
+def : InstAlias<"c.ldsp $rd, (${rs1})",
+                (C_LDSP_RV32 GPRPairNoX0RV32:$rd, SPMem:$rs1, 0), 0>;
+def : InstAlias<"c.sdsp $rs2, (${rs1})",
+                (C_SDSP_RV32 GPRPairRV32:$rs2, SPMem:$rs1, 0), 0>;
+}
 
 //===----------------------------------------------------------------------===//
 // Compress Instruction tablegen backend.

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZilsd.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZilsd.td
@@ -36,3 +36,12 @@ def LD_RV32 : PairLoad_ri<"ld", GPRPairRV32>, Sched<[WriteLDD, ReadMemBase]>;
 def SD_RV32 : PairStore_rri<"sd", GPRPairRV32>, Sched<[WriteSTD, ReadStoreData,
                             ReadMemBase]>;
 } // Predicates = [HasStdExtZilsd, IsRV32], DecoderNamespace = "RV32Only"
+
+//===----------------------------------------------------------------------===//
+// Assembler Pseudo Instructions
+//===----------------------------------------------------------------------===//
+
+let Predicates = [HasStdExtZilsd, IsRV32] in {
+def : InstAlias<"ld $rd, (${rs1})", (LD_RV32 GPRPairRV32:$rd, GPR:$rs1, 0), 0>;
+def : InstAlias<"sd $rs2, (${rs1})", (SD_RV32 GPRPairRV32:$rs2, GPR:$rs1, 0), 0>;
+}

--- a/llvm/test/MC/RISCV/rv32zclsd-alias-valid.c
+++ b/llvm/test/MC/RISCV/rv32zclsd-alias-valid.c
@@ -1,0 +1,20 @@
+# RUN: llvm-mc -triple=riscv32 -mattr=+zclsd -M no-aliases < %s \
+# RUN:     | FileCheck -check-prefixes=CHECK-EXPAND %s
+# RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+zclsd < %s \
+# RUN:     | llvm-objdump --no-print-imm-hex --mattr=+zclsd -d -M no-aliases - \
+# RUN:     | FileCheck -check-prefixes=CHECK-EXPAND %s
+
+# CHECK-EXPAND: c.ld s0, 0(s1)
+c.ld x8, (x9)
+# CHECK-EXPAND: c.sd s0, 0(s1)
+c.sd x8, (x9)
+# CHECK-EXPAND: c.ldsp s0, 0(sp)
+c.ldsp x8, (x2)
+# CHECK-EXPAND: c.sdsp s0, 0(sp)
+c.sdsp x8, (x2)
+# CHECK-EXPAND: c.ldsp s2, 0(sp)
+c.ldsp x18, (x2)
+# CHECK-EXPAND: c.sdsp s2, 0(sp)
+c.sdsp x18, (x2)
+# CHECK-EXPAND: c.sdsp zero, 0(sp)
+c.sdsp x0, (x2)

--- a/llvm/test/MC/RISCV/rv32zilsd-alias-valid.s
+++ b/llvm/test/MC/RISCV/rv32zilsd-alias-valid.s
@@ -1,0 +1,10 @@
+# RUN: llvm-mc %s -triple=riscv32 -mattr=+zilsd -M no-aliases \
+# RUN:     | FileCheck -check-prefixes=CHECK-EXPAND %s
+# RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+zilsd < %s \
+# RUN:     | llvm-objdump --no-print-imm-hex --mattr=+zilsd -M no-aliases -d - \
+# RUN:     | FileCheck -check-prefixes=CHECK-EXPAND %s
+
+# CHECK-EXPAND: ld a0, 0(a1)
+ld x10, (x11)
+# CHECK-EXPAND: sd a0, 0(a1)
+sd x10, (x11)


### PR DESCRIPTION
This matches what we do for other loads and stores.