### PR TITLE
[clang-doc][NFC] Remove unnecessary directory cleanup

### DIFF
--- a/clang-tools-extra/test/clang-doc/single-file-public.cpp
+++ b/clang-tools-extra/test/clang-doc/single-file-public.cpp
@@ -1,5 +1,4 @@
-// RUN: rm -rf %t
-// RUN: mkdir %t
+// RUN: rm -rf %t && mkdir -p %t
 // RUN: echo "" > %t/compile_flags.txt
 // RUN: cp "%s" "%t/test.cpp"
 // RUN: clang-doc --doxygen --public --executor=standalone -p %t %t/test.cpp -output=%t/docs
@@ -7,7 +6,6 @@
 //   (which we don't know in advance). This checks the record file by searching
 //   for a name with a 40-char USR name.
 // RUN: find %t/docs -regex ".*/[0-9A-F]*.yaml" -exec cat {} ";" | FileCheck %s --check-prefix=CHECK
-// RUN: rm -rf %t
 
 class Record {
 private:
@@ -30,7 +28,7 @@ void Record::function_public() {}
 // CHECK-NEXT:     Name:             'GlobalNamespace'
 // CHECK-NEXT:     QualName:         'GlobalNamespace'
 // CHECK-NEXT: DefLocation:
-// CHECK-NEXT:   LineNumber:      12
+// CHECK-NEXT:   LineNumber:      10
 // CHECK-NEXT:   Filename:        '{{.*}}'
 // CHECK-NEXT: TagType:         Class
 // CHECK-NEXT: ChildFunctions:
@@ -45,10 +43,10 @@ void Record::function_public() {}
 // CHECK-NEXT:         Name:            'GlobalNamespace'
 // CHECK-NEXT:         QualName:        'GlobalNamespace'
 // CHECK-NEXT:     DefLocation:
-// CHECK-NEXT:         LineNumber:      22
+// CHECK-NEXT:         LineNumber:      20
 // CHECK-NEXT:         Filename:        '{{.*}}'
 // CHECK-NEXT:     Location:
-// CHECK-NEXT:       - LineNumber:      17
+// CHECK-NEXT:       - LineNumber:      15
 // CHECK-NEXT:         Filename:        '{{.*}}'
 // CHECK-NEXT:     IsMethod:        true
 // CHECK-NEXT:     Parent:

--- a/clang-tools-extra/test/clang-doc/single-file.cpp
+++ b/clang-tools-extra/test/clang-doc/single-file.cpp
@@ -1,10 +1,8 @@
-// RUN: rm -rf %t
-// RUN: mkdir %t
+// RUN: rm -rf %t && mkdir -p %t
 // RUN: echo "" > %t/compile_flags.txt
 // RUN: cp "%s" "%t/test.cpp"
 // RUN: clang-doc --doxygen --executor=standalone -p %t %t/test.cpp -output=%t/docs
-// RUN: cat %t/docs/index.yaml | FileCheck %s --check-prefix=CHECK
-// RUN: rm -rf %t
+// RUN: FileCheck %s -input-file=%t/docs/index.yaml --check-prefix=CHECK
 
 void function(int x);
 
@@ -16,10 +14,10 @@ void function(int x) {}
 // CHECK-NEXT:   - USR:             '{{([0-9A-F]{40})}}'
 // CHECK-NEXT:    Name:            'function'
 // CHECK-NEXT:    DefLocation:
-// CHECK-NEXT:      LineNumber:      11
+// CHECK-NEXT:      LineNumber:      9
 // CHECK-NEXT:      Filename:        '{{.*}}
 // CHECK-NEXT:    Location:
-// CHECK-NEXT:      - LineNumber:      9
+// CHECK-NEXT:      - LineNumber:      7
 // CHECK-NEXT:        Filename:        '{{.*}}'
 // CHECK-NEXT:    Params:
 // CHECK-NEXT:      - Type:

--- a/clang-tools-extra/test/clang-doc/test-path-abs.cpp
+++ b/clang-tools-extra/test/clang-doc/test-path-abs.cpp
@@ -1,6 +1,6 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: rm -rf %t && mkdir -p %t
 // RUN: clang-doc --format=html --executor=standalone %s --output=%t
 // RUN: FileCheck %s -input-file=%t/index_json.js  -check-prefix=JSON-INDEX
-// RUN: rm -rf %t
 
 // JSON-INDEX: var RootPath = "{{.*}}test-path-abs.cpp.tmp";
+


### PR DESCRIPTION
The tests all remove the directory at test start, and it only prevents
inspecting the test artifacts to remove them at the end of the test run.