### PR TITLE
[clang-doc] Correct improper file paths in HTML output

### DIFF
--- a/clang-tools-extra/clang-doc/assets/index.js
+++ b/clang-tools-extra/clang-doc/assets/index.js
@@ -2,8 +2,8 @@ function genLink(Ref) {
   // we treat the file paths different depending on if we're
   // serving via a http server or viewing from a local
   var Path = window.location.protocol.startsWith("file") ?
-      `${window.location.protocol}//${window.location.host}/${Ref.Path}` :
-      `${window.location.protocol}//${RootPath}/${Ref.Path}`;
+      `${window.location.protocol}//${RootPath}/${Ref.Path}` :
+      `${window.location.protocol}//${window.location.host}/${Ref.Path}`;
   if (Ref.RefType === "namespace") {
     Path = `${Path}/index.html`
   } else if (Ref.Path === "") {


### PR DESCRIPTION
In index.js the logic of the ternary operator was backwards, preventing
us from generating the correct file paths, or relative paths in the HTML
output.