### PR TITLE
[NFC][libc++][chrono] Removes dead code.

### DIFF
--- a/libcxx/include/__chrono/convert_to_tm.h
+++ b/libcxx/include/__chrono/convert_to_tm.h
@@ -143,22 +143,16 @@ _LIBCPP_HIDE_FROM_ABI _Tm __convert_to_tm(const _ChronoT& __value) {
 #  endif
 
   if constexpr (__is_time_point<_ChronoT>) {
-    if constexpr (same_as<typename _ChronoT::clock, chrono::system_clock>)
-      return std::__convert_to_tm<_Tm>(__value);
-#  if _LIBCPP_HAS_TIME_ZONE_DATABASE && _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
-#    if _LIBCPP_HAS_EXPERIMENTAL_TZDB
-    else if constexpr (same_as<typename _ChronoT::clock, chrono::utc_clock>)
-      return std::__convert_to_tm<_Tm>(__value);
-    else if constexpr (same_as<typename _ChronoT::clock, chrono::tai_clock>)
-      return std::__convert_to_tm<_Tm>(__value);
-#    endif // _LIBCPP_HAS_EXPERIMENTAL_TZDB
-#  endif   // _LIBCPP_HAS_TIME_ZONE_DATABASE && _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
-    else if constexpr (same_as<typename _ChronoT::clock, chrono::file_clock>)
+    if constexpr (same_as<typename _ChronoT::clock, chrono::file_clock>)
       return std::__convert_to_tm<_Tm>(_ChronoT::clock::to_sys(__value));
     else if constexpr (same_as<typename _ChronoT::clock, chrono::local_t>)
       return std::__convert_to_tm<_Tm>(chrono::sys_time<typename _ChronoT::duration>{__value.time_since_epoch()});
-    else
+    else {
+      // Note that some clocks have specializations __convert_to_tm for their
+      // time_point. These don't need to be added here. They do not trigger
+      // this assert.
       static_assert(sizeof(_ChronoT) == 0, "TODO: Add the missing clock specialization");
+    }
   } else if constexpr (chrono::__is_duration_v<_ChronoT>) {
     // [time.format]/6
     //   ...  However, if a flag refers to a "time of day" (e.g. %H, %I, %p,


### PR DESCRIPTION
For certain time_points there are specializations of __convert_to_tm. This means the non-specialized version is never called. This means some of the `if constexpr` will never be true. These are removed.

Since there is a `static_assert` accidental removal of the specialization will make the code ill-formed.