### PR TITLE
[lld][MachO] Add --disable_verify flag

### DIFF
--- a/lld/MachO/Config.h
+++ b/lld/MachO/Config.h
@@ -219,6 +219,7 @@ struct Configuration {
   llvm::StringRef csProfilePath;
   bool pgoWarnMismatch;
   bool warnThinArchiveMissingMembers;
+  bool disableVerify;
 
   bool callGraphProfileSort = false;
   llvm::StringRef printSymbolOrder;

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1832,6 +1832,7 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
       args.hasFlag(OPT_warn_thin_archive_missing_members,
                    OPT_no_warn_thin_archive_missing_members, true);
   config->generateUuid = !args.hasArg(OPT_no_uuid);
+  config->disableVerify = args.hasArg(OPT_disable_verify);
 
   auto IncompatWithCGSort = [&](StringRef firstArgStr) {
     // Throw an error only if --call-graph-profile-sort is explicitly specified

--- a/lld/MachO/LTO.cpp
+++ b/lld/MachO/LTO.cpp
@@ -60,6 +60,7 @@ static lto::Config createConfig() {
   c.CSIRProfile = std::string(config->csProfilePath);
   c.RunCSIRInstr = config->csProfileGenerate;
   c.PGOWarnMismatch = config->pgoWarnMismatch;
+  c.DisableVerify = config->disableVerify;
   c.OptLevel = config->ltoo;
   c.CGOptLevel = config->ltoCgo;
   if (config->saveTemps)

--- a/lld/MachO/Options.td
+++ b/lld/MachO/Options.td
@@ -100,6 +100,9 @@ def lto_CGO: Joined<["--"], "lto-CGO">,
     HelpText<"Set codegen optimization level for LTO (default: 2)">,
     MetaVarName<"<cgopt-level>">,
     Group<grp_lld>;
+def disable_verify : Flag<["--"], "disable_verify">,
+                     HelpText<"Do not verify LLVM modules during LTO">,
+                     Group<grp_lld>;
 def thinlto_cache_policy_eq: Joined<["--"], "thinlto-cache-policy=">,
     HelpText<"Pruning policy for the ThinLTO cache">,
     Group<grp_lld>;
@@ -197,9 +200,6 @@ def cs_profile_generate: Flag<["--"], "cs-profile-generate">,
     HelpText<"Perform context sensitive PGO instrumentation">, Group<grp_lld>;
 def cs_profile_path: Joined<["--"], "cs-profile-path=">,
     HelpText<"Context sensitive profile file path">, Group<grp_lld>;
-def disable_verify : Flag<["--"], "disable_verify">,
-                     HelpText<"Do not verify LLVM modules">,
-                     Group<grp_lld>;
 defm pgo_warn_mismatch: BB<"pgo-warn-mismatch",
   "turn on warnings about profile cfg mismatch (default)",
   "turn off warnings about profile cfg mismatch">, Group<grp_lld>;

--- a/lld/MachO/Options.td
+++ b/lld/MachO/Options.td
@@ -197,6 +197,9 @@ def cs_profile_generate: Flag<["--"], "cs-profile-generate">,
     HelpText<"Perform context sensitive PGO instrumentation">, Group<grp_lld>;
 def cs_profile_path: Joined<["--"], "cs-profile-path=">,
     HelpText<"Context sensitive profile file path">, Group<grp_lld>;
+def disable_verify : Flag<["--"], "disable_verify">,
+                     HelpText<"Do not verify LLVM modules">,
+                     Group<grp_lld>;
 defm pgo_warn_mismatch: BB<"pgo-warn-mismatch",
   "turn on warnings about profile cfg mismatch (default)",
   "turn off warnings about profile cfg mismatch">, Group<grp_lld>;

--- a/lld/test/MachO/verify.ll
+++ b/lld/test/MachO/verify.ll
@@ -1,0 +1,16 @@
+; REQUIRES: x86
+
+; RUN: llvm-as %s -o %t.o
+; RUN: %lld -dylib %t.o -o %t2 --lto-debug-pass-manager 2>&1 | FileCheck %s --check-prefix=VERIFY
+; RUN: %lld -dylib %t.o -o %t2 --lto-debug-pass-manager --disable_verify 2>&1 | FileCheck %s --implicit-check-not=VerifierPass
+
+target triple = "x86_64-apple-darwin"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+
+define void @_start() {
+entry:
+  ret void
+}
+
+; VERIFY: Running pass: VerifierPass
+; VERIFY: Running pass: VerifierPass


### PR DESCRIPTION
The `--disable_verify` flag is implemented for ELF and is used to disable LLVM module verification.
https://github.com/llvm/llvm-project/blob/93afd8f9ac69d08bd743ef668c59403362c05d7a/lld/ELF/Options.td#L661
This allows us to quickly suppress verification errors.