### PR TITLE
[libc] Migrate sys/socket tests to use ErrnoCheckingTest.

### DIFF
--- a/libc/test/UnitTest/ErrnoSetterMatcher.h
+++ b/libc/test/UnitTest/ErrnoSetterMatcher.h
@@ -101,9 +101,13 @@ public:
 
     if constexpr (!ignore_errno()) {
       if (!errno_cmp.compare(actual_errno)) {
-        tlog << "Expected errno to be " << errno_cmp.str() << " \""
-             << get_error_string(errno_cmp.expected) << "\" but got \""
-             << get_error_string(actual_errno) << "\".\n";
+        auto expected_str = try_get_errno_name(errno_cmp.expected);
+        auto actual_str = try_get_errno_name(actual_errno);
+        tlog << "Expected errno to be " << errno_cmp.str() << " "
+             << (expected_str ? *expected_str : "<unknown>")
+             << "(" << errno_cmp.expected << ") but got "
+             << (actual_str? *actual_str : "<unknown>")
+             << "(" << actual_errno << ").\n";
       }
     }
   }

--- a/libc/test/UnitTest/ErrnoSetterMatcher.h
+++ b/libc/test/UnitTest/ErrnoSetterMatcher.h
@@ -104,10 +104,10 @@ public:
         auto expected_str = try_get_errno_name(errno_cmp.expected);
         auto actual_str = try_get_errno_name(actual_errno);
         tlog << "Expected errno to be " << errno_cmp.str() << " "
-             << (expected_str ? *expected_str : "<unknown>")
-             << "(" << errno_cmp.expected << ") but got "
-             << (actual_str? *actual_str : "<unknown>")
-             << "(" << actual_errno << ").\n";
+             << (expected_str ? *expected_str : "<unknown>") << "("
+             << errno_cmp.expected << ") but got "
+             << (actual_str ? *actual_str : "<unknown>") << "(" << actual_errno
+             << ").\n";
       }
     }
   }

--- a/libc/test/src/sys/socket/linux/CMakeLists.txt
+++ b/libc/test/src/sys/socket/linux/CMakeLists.txt
@@ -11,6 +11,8 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sys.socket.socket
     libc.src.unistd.close
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -26,6 +28,8 @@ add_libc_unittest(
     libc.src.sys.socket.bind
     libc.src.stdio.remove
     libc.src.unistd.close
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -39,6 +43,8 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sys.socket.socketpair
     libc.src.unistd.close
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -54,6 +60,8 @@ add_libc_unittest(
     libc.src.sys.socket.send
     libc.src.sys.socket.recv
     libc.src.unistd.close
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -69,6 +77,8 @@ add_libc_unittest(
     libc.src.sys.socket.sendto
     libc.src.sys.socket.recvfrom
     libc.src.unistd.close
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )
 
 add_libc_unittest(
@@ -84,4 +94,6 @@ add_libc_unittest(
     libc.src.sys.socket.sendmsg
     libc.src.sys.socket.recvmsg
     libc.src.unistd.close
+    libc.test.UnitTest.ErrnoCheckingTest
+    libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sys/socket/linux/sendmsg_recvmsg_test.cpp
+++ b/libc/test/src/sys/socket/linux/sendmsg_recvmsg_test.cpp
@@ -12,20 +12,24 @@
 
 #include "src/unistd/close.h"
 
-#include "src/errno/libc_errno.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include <sys/socket.h> // For AF_UNIX and SOCK_DGRAM
 
-TEST(LlvmLibcSendMsgRecvMsgTest, SucceedsWithSocketPair) {
+using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
+using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using LlvmLibcSendMsgRecvMsgTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcSendMsgRecvMsgTest, SucceedsWithSocketPair) {
   const char TEST_MESSAGE[] = "connection successful";
   const size_t MESSAGE_LEN = sizeof(TEST_MESSAGE);
 
   int sockpair[2] = {0, 0};
 
-  int result = LIBC_NAMESPACE::socketpair(AF_UNIX, SOCK_STREAM, 0, sockpair);
-  ASSERT_EQ(result, 0);
-  ASSERT_ERRNO_SUCCESS();
+  ASSERT_THAT(LIBC_NAMESPACE::socketpair(AF_UNIX, SOCK_STREAM, 0, sockpair),
+              Succeeds(0));
 
   iovec send_msg_text;
   send_msg_text.iov_base =
@@ -41,9 +45,8 @@ TEST(LlvmLibcSendMsgRecvMsgTest, SucceedsWithSocketPair) {
   send_message.msg_controllen = 0;
   send_message.msg_flags = 0;
 
-  ssize_t send_result = LIBC_NAMESPACE::sendmsg(sockpair[0], &send_message, 0);
-  EXPECT_EQ(send_result, static_cast<ssize_t>(MESSAGE_LEN));
-  ASSERT_ERRNO_SUCCESS();
+  ASSERT_THAT(LIBC_NAMESPACE::sendmsg(sockpair[0], &send_message, 0),
+              Succeeds(static_cast<ssize_t>(MESSAGE_LEN)));
 
   char buffer[256];
 
@@ -60,23 +63,17 @@ TEST(LlvmLibcSendMsgRecvMsgTest, SucceedsWithSocketPair) {
   recv_message.msg_controllen = 0;
   recv_message.msg_flags = 0;
 
-  ssize_t recv_result = LIBC_NAMESPACE::recvmsg(sockpair[1], &recv_message, 0);
-  ASSERT_EQ(recv_result, static_cast<ssize_t>(MESSAGE_LEN));
-  ASSERT_ERRNO_SUCCESS();
+  ASSERT_THAT(LIBC_NAMESPACE::recvmsg(sockpair[1], &recv_message, 0),
+              Succeeds(static_cast<ssize_t>(MESSAGE_LEN)));
 
   ASSERT_STREQ(buffer, TEST_MESSAGE);
 
   // close both ends of the socket
-  result = LIBC_NAMESPACE::close(sockpair[0]);
-  ASSERT_EQ(result, 0);
-  ASSERT_ERRNO_SUCCESS();
-
-  result = LIBC_NAMESPACE::close(sockpair[1]);
-  ASSERT_EQ(result, 0);
-  ASSERT_ERRNO_SUCCESS();
+  ASSERT_THAT(LIBC_NAMESPACE::close(sockpair[0]), Succeeds(0));
+  ASSERT_THAT(LIBC_NAMESPACE::close(sockpair[1]), Succeeds(0));
 }
 
-TEST(LlvmLibcSendMsgRecvMsgTest, SendFails) {
+TEST_F(LlvmLibcSendMsgRecvMsgTest, SendFails) {
   const char TEST_MESSAGE[] = "connection terminated";
   const size_t MESSAGE_LEN = sizeof(TEST_MESSAGE);
 
@@ -94,14 +91,10 @@ TEST(LlvmLibcSendMsgRecvMsgTest, SendFails) {
   send_message.msg_controllen = 0;
   send_message.msg_flags = 0;
 
-  ssize_t send_result = LIBC_NAMESPACE::sendmsg(-1, &send_message, 0);
-  EXPECT_EQ(send_result, ssize_t(-1));
-  ASSERT_ERRNO_FAILURE();
-
-  LIBC_NAMESPACE::libc_errno = 0; // reset errno to avoid test ordering issues.
+  ASSERT_THAT(LIBC_NAMESPACE::sendmsg(-1, &send_message, 0), Fails(EBADF));
 }
 
-TEST(LlvmLibcSendMsgRecvMsgTest, RecvFails) {
+TEST_F(LlvmLibcSendMsgRecvMsgTest, RecvFails) {
   char buffer[256];
 
   iovec recv_msg_text;
@@ -117,9 +110,5 @@ TEST(LlvmLibcSendMsgRecvMsgTest, RecvFails) {
   recv_message.msg_controllen = 0;
   recv_message.msg_flags = 0;
 
-  ssize_t recv_result = LIBC_NAMESPACE::recvmsg(-1, &recv_message, 0);
-  ASSERT_EQ(recv_result, ssize_t(-1));
-  ASSERT_ERRNO_FAILURE();
-
-  LIBC_NAMESPACE::libc_errno = 0; // reset errno to avoid test ordering issues.
+  ASSERT_THAT(LIBC_NAMESPACE::recvmsg(-1, &recv_message, 0), Fails(EBADF));
 }

--- a/libc/test/src/sys/socket/linux/sendto_recvfrom_test.cpp
+++ b/libc/test/src/sys/socket/linux/sendto_recvfrom_test.cpp
@@ -12,64 +12,55 @@
 
 #include "src/unistd/close.h"
 
-#include "src/errno/libc_errno.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include <sys/socket.h> // For AF_UNIX and SOCK_DGRAM
 
-TEST(LlvmLibcSendToRecvFromTest, SucceedsWithSocketPair) {
+using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
+using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using LlvmLibcSendToRecvFromTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcSendToRecvFromTest, SucceedsWithSocketPair) {
   const char TEST_MESSAGE[] = "connection successful";
   const size_t MESSAGE_LEN = sizeof(TEST_MESSAGE);
 
   int sockpair[2] = {0, 0};
 
-  int result = LIBC_NAMESPACE::socketpair(AF_UNIX, SOCK_STREAM, 0, sockpair);
-  ASSERT_EQ(result, 0);
-  ASSERT_ERRNO_SUCCESS();
+  ASSERT_THAT(LIBC_NAMESPACE::socketpair(AF_UNIX, SOCK_STREAM, 0, sockpair),
+              Succeeds(0));
 
-  ssize_t send_result = LIBC_NAMESPACE::sendto(sockpair[0], TEST_MESSAGE,
-                                               MESSAGE_LEN, 0, nullptr, 0);
-  EXPECT_EQ(send_result, static_cast<ssize_t>(MESSAGE_LEN));
-  ASSERT_ERRNO_SUCCESS();
+  ASSERT_THAT(LIBC_NAMESPACE::sendto(sockpair[0], TEST_MESSAGE, MESSAGE_LEN, 0,
+                                     nullptr, 0),
+              Succeeds(static_cast<ssize_t>(MESSAGE_LEN)));
 
   char buffer[256];
 
-  ssize_t recv_result = LIBC_NAMESPACE::recvfrom(sockpair[1], buffer,
-                                                 sizeof(buffer), 0, nullptr, 0);
-  ASSERT_EQ(recv_result, static_cast<ssize_t>(MESSAGE_LEN));
-  ASSERT_ERRNO_SUCCESS();
+  ASSERT_THAT(LIBC_NAMESPACE::recvfrom(sockpair[1], buffer, sizeof(buffer), 0,
+                                       nullptr, 0),
+              Succeeds(static_cast<ssize_t>(MESSAGE_LEN)));
 
   ASSERT_STREQ(buffer, TEST_MESSAGE);
 
   // close both ends of the socket
-  result = LIBC_NAMESPACE::close(sockpair[0]);
-  ASSERT_EQ(result, 0);
-  ASSERT_ERRNO_SUCCESS();
-
-  result = LIBC_NAMESPACE::close(sockpair[1]);
-  ASSERT_EQ(result, 0);
-  ASSERT_ERRNO_SUCCESS();
+  ASSERT_THAT(LIBC_NAMESPACE::close(sockpair[0]), Succeeds(0));
+  ASSERT_THAT(LIBC_NAMESPACE::close(sockpair[1]), Succeeds(0));
 }
 
-TEST(LlvmLibcSendToRecvFromTest, SendToFails) {
+TEST_F(LlvmLibcSendToRecvFromTest, SendToFails) {
   const char TEST_MESSAGE[] = "connection terminated";
   const size_t MESSAGE_LEN = sizeof(TEST_MESSAGE);
 
-  ssize_t send_result =
-      LIBC_NAMESPACE::sendto(-1, TEST_MESSAGE, MESSAGE_LEN, 0, nullptr, 0);
-  EXPECT_EQ(send_result, ssize_t(-1));
-  ASSERT_ERRNO_FAILURE();
-
-  LIBC_NAMESPACE::libc_errno = 0; // reset errno to avoid test ordering issues.
+  ASSERT_THAT(
+      LIBC_NAMESPACE::sendto(-1, TEST_MESSAGE, MESSAGE_LEN, 0, nullptr, 0),
+      Fails(EBADF));
 }
 
-TEST(LlvmLibcSendToRecvFromTest, RecvFromFails) {
+TEST_F(LlvmLibcSendToRecvFromTest, RecvFromFails) {
   char buffer[256];
 
-  ssize_t recv_result =
-      LIBC_NAMESPACE::recvfrom(-1, buffer, sizeof(buffer), 0, nullptr, 0);
-  ASSERT_EQ(recv_result, ssize_t(-1));
-  ASSERT_ERRNO_FAILURE();
-
-  LIBC_NAMESPACE::libc_errno = 0; // reset errno to avoid test ordering issues.
+  ASSERT_THAT(
+      LIBC_NAMESPACE::recvfrom(-1, buffer, sizeof(buffer), 0, nullptr, 0),
+      Fails(EBADF));
 }

--- a/libc/test/src/sys/socket/linux/socket_test.cpp
+++ b/libc/test/src/sys/socket/linux/socket_test.cpp
@@ -10,15 +10,19 @@
 
 #include "src/unistd/close.h"
 
-#include "src/errno/libc_errno.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include <sys/socket.h> // For AF_UNIX and SOCK_DGRAM
 
-TEST(LlvmLibcSocketTest, LocalSocket) {
+using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using LlvmLibcSocketTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcSocketTest, LocalSocket) {
   int sock = LIBC_NAMESPACE::socket(AF_UNIX, SOCK_DGRAM, 0);
   ASSERT_GE(sock, 0);
   ASSERT_ERRNO_SUCCESS();
 
-  LIBC_NAMESPACE::close(sock);
+  ASSERT_THAT(LIBC_NAMESPACE::close(sock), Succeeds(0));
 }

--- a/utils/bazel/llvm-project-overlay/libc/test/src/sys/socket/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/sys/socket/BUILD.bazel
@@ -17,6 +17,9 @@ libc_test(
         "//libc:socket",
         "//libc:close",
     ],
+    deps = [
+        "//libc/test/UnitTest:errno_test_helpers",
+    ],
 )
 
 libc_test(
@@ -25,6 +28,9 @@ libc_test(
     libc_function_deps = [
         "//libc:socketpair",
         "//libc:close",
+    ],
+    deps = [
+        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -37,6 +43,9 @@ libc_test(
         "//libc:recv",
         "//libc:close",
     ],
+    deps = [
+        "//libc/test/UnitTest:errno_test_helpers",
+    ],
 )
 
 libc_test(
@@ -48,6 +57,9 @@ libc_test(
         "//libc:recvfrom",
         "//libc:close",
     ],
+    deps = [
+        "//libc/test/UnitTest:errno_test_helpers",
+    ],
 )
 
 libc_test(
@@ -58,5 +70,8 @@ libc_test(
         "//libc:sendmsg",
         "//libc:recvmsg",
         "//libc:close",
+    ],
+    deps = [
+        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )


### PR DESCRIPTION
Also use ErrnoSetterMatcher to verify the function return values and verify/clear out errno values. Fix the bug in ErrnoSetterMatcher error reporting machinery to properly convert errno values into errno names to make error messages easier to debug.