### PR TITLE
[lldb-dap] Stop linking explicitly against pthread

### DIFF
--- a/lldb/tools/lldb-dap/CMakeLists.txt
+++ b/lldb/tools/lldb-dap/CMakeLists.txt
@@ -1,8 +1,3 @@
-if (HAVE_LIBPTHREAD)
-  list(APPEND extra_libs pthread)
-endif ()
-
-
 if(APPLE)
   configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/lldb-dap-Info.plist.in
@@ -73,7 +68,7 @@ add_lldb_tool(lldb-dap
   Handler/TestGetTargetBreakpointsRequestHandler.cpp
   Handler/ThreadsRequestHandler.cpp
   Handler/VariablesRequestHandler.cpp
-  
+
   Protocol/ProtocolBase.cpp
   Protocol/ProtocolTypes.cpp
   Protocol/ProtocolRequests.cpp
@@ -81,7 +76,6 @@ add_lldb_tool(lldb-dap
   LINK_LIBS
     liblldb
     lldbHost
-    ${extra_libs}
 
   LINK_COMPONENTS
     Option


### PR DESCRIPTION
I can't figure out why this would be necessary. Nothing is checking if libpthread is available, nothing in lldb-dap is relying on libpthread directly and nothing else in LLDB is doing this.