### PR TITLE
[RISCV] Add assembler support for Zvqdotq.

### DIFF
--- a/clang/test/Driver/print-supported-extensions-riscv.c
+++ b/clang/test/Driver/print-supported-extensions-riscv.c
@@ -190,6 +190,7 @@
 // CHECK-NEXT:     zalasr               0.1       'Zalasr' (Load-Acquire and Store-Release Instructions)
 // CHECK-NEXT:     zvbc32e              0.7       'Zvbc32e' (Vector Carryless Multiplication with 32-bits elements)
 // CHECK-NEXT:     zvkgs                0.7       'Zvkgs' (Vector-Scalar GCM instructions for Cryptography)
+// CHECK-NEXT:     zvqdotq              0.0       'Zvqdotq' (Vector quad widening 4D Dot Product)
 // CHECK-NEXT:     sdext                1.0       'Sdext' (External debugger)
 // CHECK-NEXT:     sdtrig               1.0       'Sdtrig' (Debugger triggers)
 // CHECK-NEXT:     smctr                1.0       'Smctr' (Control Transfer Records Machine Level)

--- a/clang/test/Preprocessor/riscv-target-features.c
+++ b/clang/test/Preprocessor/riscv-target-features.c
@@ -202,6 +202,7 @@
 // CHECK-NOT: __riscv_zvfbfmin {{.*$}}
 // CHECK-NOT: __riscv_zvfbfwma {{.*$}}
 // CHECK-NOT: __riscv_zvkgs {{.*$}}
+// CHECK-NOT: __riscv_zvqdotq {{.*$}}
 
 // RUN: %clang --target=riscv32-unknown-linux-gnu \
 // RUN:   -march=rv32ia -E -dM %s \
@@ -1760,6 +1761,14 @@
 // RUN:   -march=rv64i_zve32x_zvkgs0p7 -E -dM %s \
 // RUN:   -o - | FileCheck --check-prefix=CHECK-ZVKGS-EXT %s
 // CHECK-ZVKGS-EXT: __riscv_zvkgs 7000{{$}}
+
+// RUN: %clang --target=riscv32 -menable-experimental-extensions \
+// RUN:   -march=rv32i_zve32x_zvqdotq0p0 -E -dM %s \
+// RUN:   -o - | FileCheck --check-prefix=CHECK-ZVqdotq-EXT %s
+// RUN: %clang --target=riscv64 -menable-experimental-extensions \
+// RUN:   -march=rv64i_zve32x_zvqdotq0p0 -E -dM %s \
+// RUN:   -o - | FileCheck --check-prefix=CHECK-ZVqdotq-EXT %s
+// CHECK-ZVqdotq-EXT: __riscv_zvqdotq 0{{$}}
 
 // RUN: %clang -target riscv32 -menable-experimental-extensions \
 // RUN:   -march=rv32izicfiss1p0 -E -dM %s \

--- a/llvm/docs/RISCVUsage.rst
+++ b/llvm/docs/RISCVUsage.rst
@@ -337,6 +337,9 @@ The primary goal of experimental support is to assist in the process of ratifica
 ``experimental-svukte``
   LLVM implements the `0.3 draft specification <https://github.com/riscv/riscv-isa-manual/pull/1564>`__.
 
+``experimental-zvqdotq``
+  LLVM implements the `0.0.1 draft specification <https://github.com/riscv/riscv-dot-product/releases/tag/v0.0.1>`__.
+
 To use an experimental extension from `clang`, you must add `-menable-experimental-extensions` to the command line, and specify the exact version of the experimental extension you are using.  To use an experimental extension with LLVM's internal developer tools (e.g. `llc`, `llvm-objdump`, `llvm-mc`), you must prefix the extension name with `experimental-`.  Note that you don't need to specify the version with internal tools, and shouldn't include the `experimental-` prefix with `clang`.
 
 Vendor Extensions

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -132,6 +132,7 @@ Changes to the RISC-V Backend
   extension.
 * Adds assembler support for the 'Zclsd` (Compressed Load/Store Pair Instructions)
   extension.
+* Adds experimental assembler support for Zvqdotq.
 
 Changes to the WebAssembly Backend
 ----------------------------------

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -820,6 +820,16 @@ def FeatureStdExtZvksc
 def FeatureStdExtZvksg
     : RISCVExtension<1, 0, "shorthand for 'Zvks' and 'Zvkg'",
                      [FeatureStdExtZvks, FeatureStdExtZvkg]>;
+
+// Vector quad widening dot product
+
+def FeatureStdExtZvqdotq
+    : RISCVExperimentalExtension<0, 0, "Vector quad widening 4D Dot Product",
+                                 [FeatureStdExtZve32x]>;
+def HasStdExtZvqdotq : Predicate<"Subtarget->hasStdExtZvqdotq()">,
+                       AssemblerPredicate<(all_of FeatureStdExtZvqdotq),
+                           "'Zvqdotq' (Vector quad widening 4D Dot Product)">;
+
 // Vector instruction predicates
 
 def HasVInstructions    : Predicate<"Subtarget->hasVInstructions()">,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -2138,6 +2138,7 @@ include "RISCVInstrInfoZk.td"
 // Vector
 include "RISCVInstrInfoV.td"
 include "RISCVInstrInfoZvk.td"
+include "RISCVInstrInfoZvqdotq.td"
 
 // Integer
 include "RISCVInstrInfoZimop.td"

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZvqdotq.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZvqdotq.td
@@ -1,0 +1,28 @@
+//===-- RISCVInstrInfoZvqdot.td - 'Zvqdotq' instructions ---*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file describes the RISC-V instructions from the standard 'Zvqdotq'
+// extension.
+// This version is still experimental as the 'Zvqdotq' extension hasn't been
+// ratified yet.
+//
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Instructions
+//===----------------------------------------------------------------------===//
+
+let Predicates = [HasStdExtZvqdotq] in {
+  def VQDOT_VV   : VALUVV<0b101100, OPMVV, "vqdot.vv">;
+  def VQDOT_VX   : VALUVX<0b101100, OPMVX, "vqdot.vx">;
+  def VQDOTU_VV  : VALUVV<0b101000, OPMVV, "vqdotu.vv">;
+  def VQDOTU_VX  : VALUVX<0b101000, OPMVX, "vqdotu.vx">;
+  def VQDOTSU_VV : VALUVV<0b101010, OPMVV, "vqdotsu.vv">;
+  def VQDOTSU_VX : VALUVX<0b101010, OPMVX, "vqdotsu.vx">;
+  def VQDOTUS_VX : VALUVX<0b101110, OPMVX, "vqdotus.vx">;
+} // Predicates = [HasStdExtZvqdotq]

--- a/llvm/test/CodeGen/RISCV/attributes.ll
+++ b/llvm/test/CodeGen/RISCV/attributes.ll
@@ -126,6 +126,7 @@
 ; RUN: llc -mtriple=riscv32 -mattr=+zve64x -mattr=+zvksg %s -o - | FileCheck --check-prefix=RV32ZVKSG %s
 ; RUN: llc -mtriple=riscv32 -mattr=+zve32x -mattr=+zvksh %s -o - | FileCheck --check-prefix=RV32ZVKSH %s
 ; RUN: llc -mtriple=riscv32 -mattr=+zve32x -mattr=+zvkt %s -o - | FileCheck --check-prefix=RV32ZVKT %s
+; RUN: llc -mtriple=riscv32 -mattr=+zve32x -mattr=+experimental-zvqdotq %s -o - | FileCheck --check-prefix=RV32ZVQDOTQ %s
 ; RUN: llc -mtriple=riscv32 -mattr=+zvfh %s -o - | FileCheck --check-prefix=RV32ZVFH %s
 ; RUN: llc -mtriple=riscv32 -mattr=+zicond %s -o - | FileCheck --check-prefix=RV32ZICOND %s
 ; RUN: llc -mtriple=riscv32 -mattr=+zilsd %s -o - | FileCheck --check-prefix=RV32ZILSD %s
@@ -278,6 +279,7 @@
 ; RUN: llc -mtriple=riscv64 -mattr=+zve32x -mattr=+zvksg %s -o - | FileCheck --check-prefix=RV64ZVKSG %s
 ; RUN: llc -mtriple=riscv64 -mattr=+zve32x -mattr=+zvksh %s -o - | FileCheck --check-prefix=RV64ZVKSH %s
 ; RUN: llc -mtriple=riscv64 -mattr=+zve32x -mattr=+zvkt %s -o - | FileCheck --check-prefix=RV64ZVKT %s
+; RUN: llc -mtriple=riscv64 -mattr=+zve32x -mattr=+experimental-zvqdotq %s -o - | FileCheck --check-prefix=RV64ZVQDOTQ %s
 ; RUN: llc -mtriple=riscv64 -mattr=+zvfh %s -o - | FileCheck --check-prefix=RV64ZVFH %s
 ; RUN: llc -mtriple=riscv64 -mattr=+zicond %s -o - | FileCheck --check-prefix=RV64ZICOND %s
 ; RUN: llc -mtriple=riscv64 -mattr=+zimop %s -o - | FileCheck --check-prefix=RV64ZIMOP %s
@@ -453,6 +455,7 @@
 ; RV32ZVKSG: .attribute 5, "rv32i2p1_zicsr2p0_zve32x1p0_zve64x1p0_zvkb1p0_zvkg1p0_zvks1p0_zvksed1p0_zvksg1p0_zvksh1p0_zvkt1p0_zvl32b1p0_zvl64b1p0"
 ; RV32ZVKSH: .attribute 5, "rv32i2p1_zicsr2p0_zve32x1p0_zvksh1p0_zvl32b1p0"
 ; RV32ZVKT: .attribute 5, "rv32i2p1_zicsr2p0_zve32x1p0_zvkt1p0_zvl32b1p0"
+; RV32ZVQDOTQ: .attribute 5, "rv32i2p1_zicsr2p0_zve32x1p0_zvl32b1p0_zvqdotq0p0"
 ; RV32ZVFH: .attribute 5, "rv32i2p1_f2p2_zicsr2p0_zfhmin1p0_zve32f1p0_zve32x1p0_zvfh1p0_zvfhmin1p0_zvl32b1p0"
 ; RV32ZICOND: .attribute 5, "rv32i2p1_zicond1p0"
 ; RV32ZILSD: .attribute 5, "rv32i2p1_zilsd1p0"
@@ -602,6 +605,7 @@
 ; RV64ZVKSG: .attribute 5, "rv64i2p1_zicsr2p0_zve32x1p0_zvkb1p0_zvkg1p0_zvks1p0_zvksed1p0_zvksg1p0_zvksh1p0_zvkt1p0_zvl32b1p0"
 ; RV64ZVKSH: .attribute 5, "rv64i2p1_zicsr2p0_zve32x1p0_zvksh1p0_zvl32b1p0"
 ; RV64ZVKT: .attribute 5, "rv64i2p1_zicsr2p0_zve32x1p0_zvkt1p0_zvl32b1p0"
+; RV64ZVQDOTQ: .attribute 5, "rv64i2p1_zicsr2p0_zve32x1p0_zvl32b1p0_zvqdotq0p0"
 ; RV64ZVFH: .attribute 5, "rv64i2p1_f2p2_zicsr2p0_zfhmin1p0_zve32f1p0_zve32x1p0_zvfh1p0_zvfhmin1p0_zvl32b1p0"
 ; RV64ZICOND: .attribute 5, "rv64i2p1_zicond1p0"
 ; RV64ZIMOP: .attribute 5, "rv64i2p1_zimop1p0"

--- a/llvm/test/MC/RISCV/attribute-arch.s
+++ b/llvm/test/MC/RISCV/attribute-arch.s
@@ -174,6 +174,9 @@
 .attribute arch, "rv32i_zvkt1p0"
 # CHECK: attribute      5, "rv32i2p1_zvkt1p0"
 
+.attribute arch, "rv32i_zvqdotq0p0"
+# CHECK: attribute      5, "rv32i2p1_zicsr2p0_zve32x1p0_zvl32b1p0_zvqdotq0p0"
+
 .attribute arch, "rv32izbs1p0"
 # CHECK: attribute      5, "rv32i2p1_zbs1p0"
 

--- a/llvm/test/MC/RISCV/rvv/zvqdotq-invalid.s
+++ b/llvm/test/MC/RISCV/rvv/zvqdotq-invalid.s
@@ -1,0 +1,10 @@
+# RUN: not llvm-mc -triple=riscv64 --mattr=+experimental-zvqdotq %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+
+vqdot.vv v0, v2, v4, v0.t
+# CHECK-ERROR: the destination vector register group cannot overlap the mask register
+# CHECK-ERROR-LABEL: vqdot.vv v0, v2, v4, v0.t
+
+vqdot.vx v0, v2, a0, v0.t
+# CHECK-ERROR: the destination vector register group cannot overlap the mask register
+# CHECK-ERROR-LABEL: vqdot.vx v0, v2, a0, v0.t

--- a/llvm/test/MC/RISCV/rvv/zvqdotq.s
+++ b/llvm/test/MC/RISCV/rvv/zvqdotq.s
@@ -1,0 +1,93 @@
+# RUN: llvm-mc -triple=riscv64 -show-encoding --mattr=+experimental-zvqdotq %s \
+# RUN:        | FileCheck %s --check-prefixes=CHECK-ENCODING,CHECK-INST
+# RUN: not llvm-mc -triple=riscv64 -show-encoding %s 2>&1 \
+# RUN:        | FileCheck %s --check-prefix=CHECK-ERROR
+# RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+experimental-zvqdotq %s \
+# RUN:        | llvm-objdump -d --mattr=+experimental-zvqdotq - \
+# RUN:        | FileCheck %s --check-prefix=CHECK-INST
+# RUN: llvm-mc -triple=riscv64 -filetype=obj --mattr=+experimental-zvqdotq %s \
+# RUN:        | llvm-objdump -d - | FileCheck %s --check-prefix=CHECK-UNKNOWN
+
+vqdot.vv v8, v4, v20, v0.t
+# CHECK-INST: vqdot.vv v8, v4, v20, v0.t
+# CHECK-ENCODING: [0x57,0x24,0x4a,0xb0]
+# CHECK-ERROR: instruction requires the following: 'Zvqdotq' (Vector quad widening 4D Dot Product){{$}}
+# CHECK-UNKNOWN: b04a2457 <unknown>
+
+vqdot.vv v8, v4, v20
+# CHECK-INST: vqdot.vv v8, v4, v20
+# CHECK-ENCODING: [0x57,0x24,0x4a,0xb2]
+# CHECK-ERROR: instruction requires the following: 'Zvqdotq' (Vector quad widening 4D Dot Product){{$}}
+# CHECK-UNKNOWN: b24a2457 <unknown>
+
+vqdotu.vv v8, v4, v20, v0.t
+# CHECK-INST: vqdotu.vv v8, v4, v20, v0.t
+# CHECK-ENCODING: [0x57,0x24,0x4a,0xa0]
+# CHECK-ERROR: instruction requires the following: 'Zvqdotq' (Vector quad widening 4D Dot Product){{$}}
+# CHECK-UNKNOWN: a04a2457 <unknown>
+
+vqdotu.vv v8, v4, v20
+# CHECK-INST: vqdotu.vv v8, v4, v20
+# CHECK-ENCODING: [0x57,0x24,0x4a,0xa2]
+# CHECK-ERROR: instruction requires the following: 'Zvqdotq' (Vector quad widening 4D Dot Product){{$}}
+# CHECK-UNKNOWN: a24a2457 <unknown>
+
+vqdotsu.vv v8, v4, v20, v0.t
+# CHECK-INST: vqdotsu.vv v8, v4, v20, v0.t
+# CHECK-ENCODING: [0x57,0x24,0x4a,0xa8]
+# CHECK-ERROR: instruction requires the following: 'Zvqdotq' (Vector quad widening 4D Dot Product){{$}}
+# CHECK-UNKNOWN: a84a2457 <unknown>
+
+vqdotsu.vv v8, v4, v20
+# CHECK-INST: vqdotsu.vv v8, v4, v20
+# CHECK-ENCODING: [0x57,0x24,0x4a,0xaa]
+# CHECK-ERROR: instruction requires the following: 'Zvqdotq' (Vector quad widening 4D Dot Product){{$}}
+# CHECK-UNKNOWN: aa4a2457 <unknown>
+
+vqdot.vx v8, v4, s4, v0.t
+# CHECK-INST: vqdot.vx v8, v4, s4, v0.t
+# CHECK-ENCODING: [0x57,0x64,0x4a,0xb0]
+# CHECK-ERROR: instruction requires the following: 'Zvqdotq' (Vector quad widening 4D Dot Product){{$}}
+# CHECK-UNKNOWN: b04a6457 <unknown>
+
+vqdot.vx v8, v4, s4
+# CHECK-INST: vqdot.vx v8, v4, s4
+# CHECK-ENCODING: [0x57,0x64,0x4a,0xb2]
+# CHECK-ERROR: instruction requires the following: 'Zvqdotq' (Vector quad widening 4D Dot Product){{$}}
+# CHECK-UNKNOWN: b24a6457 <unknown>
+
+vqdotu.vx v8, v4, s4, v0.t
+# CHECK-INST: vqdotu.vx v8, v4, s4, v0.t
+# CHECK-ENCODING: [0x57,0x64,0x4a,0xa0]
+# CHECK-ERROR: instruction requires the following: 'Zvqdotq' (Vector quad widening 4D Dot Product){{$}}
+# CHECK-UNKNOWN: a04a6457 <unknown>
+
+vqdotu.vx v8, v4, s4
+# CHECK-INST: vqdotu.vx v8, v4, s4
+# CHECK-ENCODING: [0x57,0x64,0x4a,0xa2]
+# CHECK-ERROR: instruction requires the following: 'Zvqdotq' (Vector quad widening 4D Dot Product){{$}}
+# CHECK-UNKNOWN: a24a6457 <unknown>
+
+vqdotsu.vx v8, v4, s4, v0.t
+# CHECK-INST: vqdotsu.vx v8, v4, s4, v0.t
+# CHECK-ENCODING: [0x57,0x64,0x4a,0xa8]
+# CHECK-ERROR: instruction requires the following: 'Zvqdotq' (Vector quad widening 4D Dot Product){{$}}
+# CHECK-UNKNOWN: a84a6457 <unknown>
+
+vqdotsu.vx v8, v4, s4
+# CHECK-INST: vqdotsu.vx v8, v4, s4
+# CHECK-ENCODING: [0x57,0x64,0x4a,0xaa]
+# CHECK-ERROR: instruction requires the following: 'Zvqdotq' (Vector quad widening 4D Dot Product){{$}}
+# CHECK-UNKNOWN: aa4a6457 <unknown>
+
+vqdotus.vx v8, v4, s4, v0.t
+# CHECK-INST: vqdotus.vx v8, v4, s4, v0.t
+# CHECK-ENCODING: [0x57,0x64,0x4a,0xb8]
+# CHECK-ERROR: instruction requires the following: 'Zvqdotq' (Vector quad widening 4D Dot Product){{$}}
+# CHECK-UNKNOWN: b84a6457 <unknown>
+
+vqdotus.vx v8, v4, s4
+# CHECK-INST: vqdotus.vx v8, v4, s4
+# CHECK-ENCODING: [0x57,0x64,0x4a,0xba]
+# CHECK-ERROR: instruction requires the following: 'Zvqdotq' (Vector quad widening 4D Dot Product){{$}}
+# CHECK-UNKNOWN: ba4a6457 <unknown>

--- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
+++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
@@ -1135,6 +1135,7 @@ Experimental extensions
     zalasr               0.1
     zvbc32e              0.7
     zvkgs                0.7
+    zvqdotq              0.0
     sdext                1.0
     sdtrig               1.0
     smctr                1.0


### PR DESCRIPTION
Based on the 0.0.1 spec here https://github.com/riscv/riscv-dot-product/releases/tag/v0.0.1