### PR TITLE
[lldb] Move two methods from Platfrom -> Host (NFC)

### DIFF
--- a/lldb/include/lldb/Host/HostInfoBase.h
+++ b/lldb/include/lldb/Host/HostInfoBase.h
@@ -126,6 +126,8 @@ public:
 
   static FileSpec GetXcodeContentsDirectory() { return {}; }
   static FileSpec GetXcodeDeveloperDirectory() { return {}; }
+  static FileSpec GetCurrentXcodeToolchainDirectory() { return {}; }
+  static FileSpec GetCurrentCommandLineToolsDirectory() { return {}; }
 
   struct SDKOptions {
     std::optional<XcodeSDK> XcodeSDKSelection;

--- a/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
+++ b/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
@@ -30,6 +30,8 @@ public:
   static FileSpec GetProgramFileSpec();
   static FileSpec GetXcodeContentsDirectory();
   static FileSpec GetXcodeDeveloperDirectory();
+  static FileSpec GetCurrentXcodeToolchainDirectory();
+  static FileSpec GetCurrentCommandLineToolsDirectory();
 
   /// Query xcrun to find an Xcode SDK directory.
   ///
@@ -50,6 +52,9 @@ protected:
   static bool ComputeHeaderDirectory(FileSpec &file_spec);
   static bool ComputeSystemPluginsDirectory(FileSpec &file_spec);
   static bool ComputeUserPluginsDirectory(FileSpec &file_spec);
+
+  static std::string FindComponentInPath(llvm::StringRef path,
+                                         llvm::StringRef component);
 };
 }
 

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1337,33 +1337,6 @@ lldb_private::Status PlatformDarwin::FindBundleBinaryInExecSearchPaths(
   return Status();
 }
 
-std::string PlatformDarwin::FindComponentInPath(llvm::StringRef path,
-                                                llvm::StringRef component) {
-  auto begin = llvm::sys::path::begin(path);
-  auto end = llvm::sys::path::end(path);
-  for (auto it = begin; it != end; ++it) {
-    if (it->contains(component)) {
-      llvm::SmallString<128> buffer;
-      llvm::sys::path::append(buffer, begin, ++it,
-                              llvm::sys::path::Style::posix);
-      return buffer.str().str();
-    }
-  }
-  return {};
-}
-
-FileSpec PlatformDarwin::GetCurrentToolchainDirectory() {
-  if (FileSpec fspec = HostInfo::GetShlibDir())
-    return FileSpec(FindComponentInPath(fspec.GetPath(), ".xctoolchain"));
-  return {};
-}
-
-FileSpec PlatformDarwin::GetCurrentCommandLineToolsDirectory() {
-  if (FileSpec fspec = HostInfo::GetShlibDir())
-    return FileSpec(FindComponentInPath(fspec.GetPath(), "CommandLineTools"));
-  return {};
-}
-
 llvm::Triple::OSType PlatformDarwin::GetHostOSType() {
 #if !defined(__APPLE__)
   return llvm::Triple::MacOSX;

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -117,13 +117,6 @@ public:
   llvm::Expected<StructuredData::DictionarySP>
   FetchExtendedCrashInformation(Process &process) override;
 
-  /// Return the toolchain directory the current LLDB instance is located in.
-  static FileSpec GetCurrentToolchainDirectory();
-
-  /// Return the command line tools directory the current LLDB instance is
-  /// located in.
-  static FileSpec GetCurrentCommandLineToolsDirectory();
-
   llvm::Expected<std::pair<XcodeSDK, bool>>
   GetSDKPathFromDebugInfo(Module &module) override;
 
@@ -198,9 +191,6 @@ protected:
       const ModuleSpec &module_spec, Process *process,
       lldb::ModuleSP &module_sp, const FileSpecList *module_search_paths_ptr,
       llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules, bool *did_create_ptr);
-
-  static std::string FindComponentInPath(llvm::StringRef path,
-                                         llvm::StringRef component);
 
   // The OSType where lldb is running.
   static llvm::Triple::OSType GetHostOSType();

--- a/lldb/unittests/Host/HostInfoTest.cpp
+++ b/lldb/unittests/Host/HostInfoTest.cpp
@@ -104,3 +104,26 @@ TEST(HostInfoTestInitialization, InitTwice) {
     EXPECT_EQ(Version, HostInfo::GetOSVersion());
   }
 }
+
+#ifdef __APPLE__
+struct HostInfoTester : public HostInfoMacOSX {
+public:
+  using HostInfoMacOSX::FindComponentInPath;
+};
+
+TEST_F(HostInfoTest, FindComponentInPath) {
+  EXPECT_EQ("/path/to/foo",
+            HostInfoTester::FindComponentInPath("/path/to/foo/", "foo"));
+
+  EXPECT_EQ("/path/to/foo",
+            HostInfoTester::FindComponentInPath("/path/to/foo", "foo"));
+
+  EXPECT_EQ("/path/to/foobar",
+            HostInfoTester::FindComponentInPath("/path/to/foobar", "foo"));
+
+  EXPECT_EQ("/path/to/foobar",
+            HostInfoTester::FindComponentInPath("/path/to/foobar", "bar"));
+
+  EXPECT_EQ("", HostInfoTester::FindComponentInPath("/path/to/foo", "bar"));
+}
+#endif

--- a/lldb/unittests/Platform/PlatformDarwinTest.cpp
+++ b/lldb/unittests/Platform/PlatformDarwinTest.cpp
@@ -17,11 +17,6 @@
 using namespace lldb;
 using namespace lldb_private;
 
-struct PlatformDarwinTester : public PlatformDarwin {
-public:
-  using PlatformDarwin::FindComponentInPath;
-};
-
 TEST(PlatformDarwinTest, TestParseVersionBuildDir) {
   llvm::VersionTuple V;
   llvm::StringRef D;
@@ -48,21 +43,4 @@ TEST(PlatformDarwinTest, TestParseVersionBuildDir) {
 
   std::tie(V, D) = PlatformDarwin::ParseVersionBuildDir("3.4.5");
   EXPECT_EQ(llvm::VersionTuple(3, 4, 5), V);
-}
-
-TEST(PlatformDarwinTest, FindComponentInPath) {
-  EXPECT_EQ("/path/to/foo",
-            PlatformDarwinTester::FindComponentInPath("/path/to/foo/", "foo"));
-
-  EXPECT_EQ("/path/to/foo",
-            PlatformDarwinTester::FindComponentInPath("/path/to/foo", "foo"));
-
-  EXPECT_EQ("/path/to/foobar", PlatformDarwinTester::FindComponentInPath(
-                                   "/path/to/foobar", "foo"));
-
-  EXPECT_EQ("/path/to/foobar", PlatformDarwinTester::FindComponentInPath(
-                                   "/path/to/foobar", "bar"));
-
-  EXPECT_EQ("",
-            PlatformDarwinTester::FindComponentInPath("/path/to/foo", "bar"));
 }


### PR DESCRIPTION
This moves two functions from Platform to Host:

  1. GetCurrentXcodeToolchainDirectory
  2. GetCurrentCommandLineToolsDirectory.

These two functions caused a layering violation in the Swift fork, which added a dependency from lldbHost to lldbPlatform. As show by this PR, there's no need for these two functions to live in Platform, and we already have similar functions in Host.

We have various layering violations but this one is particularly bad, because lldb-dap started depending on lldbHost. On the Swift fork, this library was depending on lldbPlatform which pulled in various Swift files, which libLLDB needs, but lldb-dap itself does not. We were missing RPATHs to resume them, so in the current nightly, lldb-dap crashes because the dynamic loader can't find the missing Swift libs.

rdar://146537366