### PR TITLE
[flang] Allow macro replacement in numeric kind suffix

### DIFF
--- a/flang/lib/Parser/prescan.h
+++ b/flang/lib/Parser/prescan.h
@@ -186,7 +186,9 @@ private:
   const char *SkipWhiteSpaceAndCComments(const char *) const;
   const char *SkipCComment(const char *) const;
   bool NextToken(TokenSequence &);
-  bool ExponentAndKind(TokenSequence &);
+  bool HandleExponent(TokenSequence &);
+  bool HandleKindSuffix(TokenSequence &);
+  bool HandleExponentAndOrKindSuffix(TokenSequence &);
   void QuotedCharacterLiteral(TokenSequence &, const char *start);
   void Hollerith(TokenSequence &, int count, const char *start);
   bool PadOutCharacterLiteral(TokenSequence &);

--- a/flang/test/Preprocessing/kind-suffix.F90
+++ b/flang/test/Preprocessing/kind-suffix.F90
@@ -1,0 +1,6 @@
+! RUN: %flang -E %s 2>&1 | FileCheck %s
+#define n k
+parameter(n=4)
+!CHECK: print *,1_k
+print *,1_n
+end


### PR DESCRIPTION
When a numeric value has a kind suffix containing an identifier, allow macro replacement for that identifier by treating it as its own token.

Fixes https://github.com/llvm/llvm-project/issues/131548.