### PR TITLE
[lldb] Ignore registers that the debugserver fails to read

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbreverse.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbreverse.py
@@ -300,7 +300,10 @@ class ReverseTestBase(GDBProxyTestBase):
             for index in sorted(self.general_purpose_register_info.keys()):
                 reply = self.pass_through(f"p{index:x};thread:{thread_id:x};")
                 if reply == "" or reply[0] == "E":
-                    raise ValueError("Can't read register")
+                    # Mac debugserver tells us about registers that it won't let
+                    # us actually read. Ignore those registers.
+                    self.logger.debug(f"Failed to read register {index:x}")
+                    continue
                 registers[index] = reply
             thread_snapshot = ThreadSnapshot(thread_id, registers)
             thread_sp = self.get_register(

--- a/lldb/test/API/functionalities/reverse-execution/TestReverseContinueBreakpoints.py
+++ b/lldb/test/API/functionalities/reverse-execution/TestReverseContinueBreakpoints.py
@@ -11,13 +11,11 @@ from lldbsuite.test import lldbutil
 class TestReverseContinueBreakpoints(ReverseTestBase):
     @skipIfRemote
     @skipIf(macos_version=["<", "15.0"])
-    @skipIf(oslist=lldbplatformutil.getDarwinOSTriples(), archs=["x86_64"])
     def test_reverse_continue(self):
         self.reverse_continue_internal(async_mode=False)
 
     @skipIfRemote
     @skipIf(macos_version=["<", "15.0"])
-    @skipIf(oslist=lldbplatformutil.getDarwinOSTriples(), archs=["x86_64"])
     def test_reverse_continue_async(self):
         self.reverse_continue_internal(async_mode=True)
 
@@ -47,13 +45,11 @@ class TestReverseContinueBreakpoints(ReverseTestBase):
 
     @skipIfRemote
     @skipIf(macos_version=["<", "15.0"])
-    @skipIf(oslist=lldbplatformutil.getDarwinOSTriples(), archs=["x86_64"])
     def test_reverse_continue_breakpoint(self):
         self.reverse_continue_breakpoint_internal(async_mode=False)
 
     @skipIfRemote
     @skipIf(macos_version=["<", "15.0"])
-    @skipIf(oslist=lldbplatformutil.getDarwinOSTriples(), archs=["x86_64"])
     def test_reverse_continue_breakpoint_async(self):
         self.reverse_continue_breakpoint_internal(async_mode=True)
 
@@ -72,13 +68,11 @@ class TestReverseContinueBreakpoints(ReverseTestBase):
 
     @skipIfRemote
     @skipIf(macos_version=["<", "15.0"])
-    @skipIf(oslist=lldbplatformutil.getDarwinOSTriples(), archs=["x86_64"])
     def test_reverse_continue_skip_breakpoint(self):
         self.reverse_continue_skip_breakpoint_internal(async_mode=False)
 
     @skipIfRemote
     @skipIf(macos_version=["<", "15.0"])
-    @skipIf(oslist=lldbplatformutil.getDarwinOSTriples(), archs=["x86_64"])
     def test_reverse_continue_skip_breakpoint_async(self):
         self.reverse_continue_skip_breakpoint_internal(async_mode=True)
 
@@ -104,13 +98,11 @@ class TestReverseContinueBreakpoints(ReverseTestBase):
 
     @skipIfRemote
     @skipIf(macos_version=["<", "15.0"])
-    @skipIf(oslist=lldbplatformutil.getDarwinOSTriples(), archs=["x86_64"])
     def test_continue_preserves_direction(self):
         self.continue_preserves_direction_internal(async_mode=False)
 
     @skipIfRemote
     @skipIf(macos_version=["<", "15.0"])
-    @skipIf(oslist=lldbplatformutil.getDarwinOSTriples(), archs=["x86_64"])
     def test_continue_preserves_direction_asyhc(self):
         self.continue_preserves_direction_internal(async_mode=True)
 

--- a/lldb/test/API/functionalities/reverse-execution/TestReverseContinueWatchpoints.py
+++ b/lldb/test/API/functionalities/reverse-execution/TestReverseContinueWatchpoints.py
@@ -11,13 +11,11 @@ from lldbsuite.test import lldbutil
 class TestReverseContinueWatchpoints(ReverseTestBase):
     @skipIfRemote
     @skipIf(macos_version=["<", "15.0"])
-    @skipIf(oslist=lldbplatformutil.getDarwinOSTriples(), archs=["x86_64"])
     def test_reverse_continue_watchpoint(self):
         self.reverse_continue_watchpoint_internal(async_mode=False)
 
     @skipIfRemote
     @skipIf(macos_version=["<", "15.0"])
-    @skipIf(oslist=lldbplatformutil.getDarwinOSTriples(), archs=["x86_64"])
     def test_reverse_continue_watchpoint_async(self):
         self.reverse_continue_watchpoint_internal(async_mode=True)
 
@@ -63,13 +61,11 @@ class TestReverseContinueWatchpoints(ReverseTestBase):
 
     @skipIfRemote
     @skipIf(macos_version=["<", "15.0"])
-    @skipIf(oslist=lldbplatformutil.getDarwinOSTriples(), archs=["x86_64"])
     def test_reverse_continue_skip_watchpoint(self):
         self.reverse_continue_skip_watchpoint_internal(async_mode=False)
 
     @skipIfRemote
     @skipIf(macos_version=["<", "15.0"])
-    @skipIf(oslist=lldbplatformutil.getDarwinOSTriples(), archs=["x86_64"])
     def test_reverse_continue_skip_watchpoint_async(self):
         self.reverse_continue_skip_watchpoint_internal(async_mode=True)
 


### PR DESCRIPTION
On Mac x86-64, the debugserver reports a register ('ds' at least) but returns an error when we try to read it. Just skip storing such registers in snapshots so we won't try to restore them.