### PR TITLE
[libc++abi] Introduce LIBCXXABI_ENABLE_DEMANGLER

### DIFF
--- a/libcxxabi/CMakeLists.txt
+++ b/libcxxabi/CMakeLists.txt
@@ -46,6 +46,9 @@ include(CMakeDependentOption)
 include(HandleCompilerRT)
 
 # Define options.
+option(LIBCXXABI_ENABLE_DEMANGLER
+  "Provide support for demangling in the runtime.
+   When disabled, libc++abi does not support the name demangler API." ON)
 option(LIBCXXABI_ENABLE_EXCEPTIONS
   "Provide support for exceptions in the runtime.
   When disabled, libc++abi does not support stack unwinding and other exceptions-related features." ON)
@@ -129,8 +132,6 @@ option(LIBCXXABI_BAREMETAL "Build libc++abi for baremetal targets." OFF)
 # The default terminate handler attempts to demangle uncaught exceptions, which
 # causes extra I/O and demangling code to be pulled in.
 option(LIBCXXABI_SILENT_TERMINATE "Set this to make the terminate handler default to a silent alternative" OFF)
-option(LIBCXXABI_NON_DEMANGLING_TERMINATE "Set this to make the terminate handler
-avoid demangling" OFF)
 
 if (NOT LIBCXXABI_ENABLE_SHARED AND NOT LIBCXXABI_ENABLE_STATIC)
   message(FATAL_ERROR "libc++abi must be built as either a shared or static library.")
@@ -431,7 +432,7 @@ if (LIBCXXABI_SILENT_TERMINATE)
   add_definitions(-DLIBCXXABI_SILENT_TERMINATE)
 endif()
 
-if (LIBCXXABI_NON_DEMANGLING_TERMINATE)
+if (NOT LIBCXXABI_ENABLE_DEMANGLER)
   add_definitions(-DLIBCXXABI_NON_DEMANGLING_TERMINATE)
 endif()
 

--- a/libcxxabi/src/CMakeLists.txt
+++ b/libcxxabi/src/CMakeLists.txt
@@ -3,7 +3,6 @@ set(LIBCXXABI_SOURCES
   # C++ABI files
   cxa_aux_runtime.cpp
   cxa_default_handlers.cpp
-  cxa_demangle.cpp
   cxa_exception_storage.cpp
   cxa_guard.cpp
   cxa_handlers.cpp
@@ -18,6 +17,12 @@ set(LIBCXXABI_SOURCES
   fallback_malloc.cpp
   private_typeinfo.cpp
 )
+
+if (LIBCXXABI_ENABLE_DEMANGLER)
+  list(APPEND LIBCXXABI_SOURCES
+    cxa_demangle.cpp
+  )
+endif()
 
 if (LIBCXXABI_ENABLE_NEW_DELETE_DEFINITIONS)
   list(APPEND LIBCXXABI_SOURCES


### PR DESCRIPTION
This change introduces a `LIBCXXABI_ENABLE_DEMANGLER` CMake option that allows turning off the demangler API from being included in the build. This can be useful when trying to build a minimal version of libc++abi, e.g., for a baremetal target. The demangler is quite heavy in dependencies on libraries that are not easily available on such a target, and is not an essential component. As discussed in https://github.com/llvm/llvm-project/pull/72948, `LIBCXXABI_NON_DEMANGLING_TERMINATE` is removed, its functionality is now tied to the new `LIBCXXABI_ENABLE_DEMANGLER` option.