### PR TITLE
[support][nfc] MD5: Undef macros after use

### DIFF
--- a/llvm/lib/Support/MD5.cpp
+++ b/llvm/lib/Support/MD5.cpp
@@ -296,3 +296,11 @@ MD5::MD5Result MD5::hash(ArrayRef<uint8_t> Data) {
 
   return Res;
 }
+
+#undef F
+#undef G
+#undef H
+#undef I
+#undef STEP
+#undef SET
+#undef GET


### PR DESCRIPTION
I'm experimenting with amalgamating Support lib into single cpp and leaking a bunch of 1-letter macros is not nice.