### PR TITLE
[Target] Use *Set::insert_range (NFC)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.h
@@ -495,7 +495,7 @@ public:
   /// Add a LOH directive of this @p Kind and this @p Args.
   void addLOHDirective(MCLOHType Kind, MILOHArgs Args) {
     LOHContainerSet.push_back(MILOHDirective(Kind, Args));
-    LOHRelated.insert(Args.begin(), Args.end());
+    LOHRelated.insert_range(Args);
   }
 
   SmallVectorImpl<ForwardedRegister> &getForwardedMustTailRegParms() {

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
@@ -395,7 +395,7 @@ AArch64Subtarget::AArch64Subtarget(const Triple &TT, StringRef CPU,
 
   auto TRI = getRegisterInfo();
   StringSet<> ReservedRegNames;
-  ReservedRegNames.insert(ReservedRegsForRA.begin(), ReservedRegsForRA.end());
+  ReservedRegNames.insert_range(ReservedRegsForRA);
   for (unsigned i = 0; i < 29; ++i) {
     if (ReservedRegNames.count(TRI->getName(AArch64::X0 + i)))
       ReserveXRegisterForRA.set(i);

--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -1042,7 +1042,7 @@ bool AMDGPUPromoteAllocaImpl::tryPromoteAllocaToVector(AllocaInst &Alloca) {
   // Delete all instructions. On the first pass, new dummy loads may have been
   // added so we need to collect them too.
   DenseSet<Instruction *> InstsToDelete(WorkList.begin(), WorkList.end());
-  InstsToDelete.insert(DeferredLoads.begin(), DeferredLoads.end());
+  InstsToDelete.insert_range(DeferredLoads);
   for (Instruction *I : InstsToDelete) {
     assert(I->use_empty());
     I->eraseFromParent();

--- a/llvm/lib/Target/AMDGPU/AMDGPUSplitModule.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUSplitModule.cpp
@@ -569,7 +569,7 @@ void SplitGraph::buildGraph(CallGraph &CG) {
         LLVM_DEBUG(dbgs() << "    indirect call found\n");
         FnsWithIndirectCalls.push_back(&Fn);
       } else if (!KnownCallees.empty())
-        DirectCallees.insert(KnownCallees.begin(), KnownCallees.end());
+        DirectCallees.insert_range(KnownCallees);
     }
 
     Node &N = getNode(Cache, Fn);

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -1795,7 +1795,7 @@ bool PreRARematStage::sinkTriviallyRematInsts(const GCNSubtarget &ST,
   // Collect only regions that has a rematerializable def as a live-in.
   SmallSet<unsigned, 16> ImpactedRegions;
   for (const auto &It : RematDefToLiveInRegions)
-    ImpactedRegions.insert(It.second.begin(), It.second.end());
+    ImpactedRegions.insert_range(It.second);
 
   // Make copies of register pressure and live-ins cache that will be updated
   // as we rematerialize.

--- a/llvm/lib/Target/ARM/ARMConstantPoolValue.cpp
+++ b/llvm/lib/Target/ARM/ARMConstantPoolValue.cpp
@@ -196,7 +196,7 @@ int ARMConstantPoolConstant::getExistingMachineCPValue(MachineConstantPool *CP,
     auto *CPV = static_cast<ARMConstantPoolValue*>(
         CP->getConstants()[index].Val.MachineCPVal);
     auto *Constant = cast<ARMConstantPoolConstant>(CPV);
-    Constant->GVars.insert(GVars.begin(), GVars.end());
+    Constant->GVars.insert_range(GVars);
   }
   return index;
 }

--- a/llvm/lib/Target/ARM/ARMLowOverheadLoops.cpp
+++ b/llvm/lib/Target/ARM/ARMLowOverheadLoops.cpp
@@ -568,7 +568,7 @@ static bool TryRemove(MachineInstr *MI, ReachingDefAnalysis &RDA,
     }
     if (!ModifiedITs.empty())
       return false;
-    Killed.insert(RemoveITs.begin(), RemoveITs.end());
+    Killed.insert_range(RemoveITs);
     return true;
   };
 
@@ -577,7 +577,7 @@ static bool TryRemove(MachineInstr *MI, ReachingDefAnalysis &RDA,
     return false;
 
   if (WontCorruptITs(Uses, RDA)) {
-    ToRemove.insert(Uses.begin(), Uses.end());
+    ToRemove.insert_range(Uses);
     LLVM_DEBUG(dbgs() << "ARM Loops: Able to remove: " << *MI
                << " - can also remove:\n";
                for (auto *Use : Uses)
@@ -586,7 +586,7 @@ static bool TryRemove(MachineInstr *MI, ReachingDefAnalysis &RDA,
     SmallPtrSet<MachineInstr*, 4> Killed;
     RDA.collectKilledOperands(MI, Killed);
     if (WontCorruptITs(Killed, RDA)) {
-      ToRemove.insert(Killed.begin(), Killed.end());
+      ToRemove.insert_range(Killed);
       LLVM_DEBUG(for (auto *Dead : Killed)
                    dbgs() << "   - " << *Dead);
     }
@@ -759,7 +759,7 @@ bool LowOverheadLoop::ValidateTailPredicate() {
     SmallPtrSet<MachineInstr*, 2> Ignore;
     unsigned ExpectedVectorWidth = getTailPredVectorWidth(VCTP->getOpcode());
 
-    Ignore.insert(VCTPs.begin(), VCTPs.end());
+    Ignore.insert_range(VCTPs);
 
     if (TryRemove(Def, RDA, ElementChain, Ignore)) {
       bool FoundSub = false;
@@ -781,7 +781,7 @@ bool LowOverheadLoop::ValidateTailPredicate() {
           return false;
         }
       }
-      ToRemove.insert(ElementChain.begin(), ElementChain.end());
+      ToRemove.insert_range(ElementChain);
     }
   }
 
@@ -795,7 +795,7 @@ bool LowOverheadLoop::ValidateTailPredicate() {
     if (auto *Def = RDA.getUniqueReachingMIDef(
             &Preheader->back(), VCTP->getOperand(1).getReg().asMCReg())) {
       SmallPtrSet<MachineInstr*, 2> Ignore;
-      Ignore.insert(VCTPs.begin(), VCTPs.end());
+      Ignore.insert_range(VCTPs);
       TryRemove(Def, RDA, ToRemove, Ignore);
     }
   }
@@ -1693,7 +1693,7 @@ void ARMLowOverheadLoops::ConvertVPTBlocks(LowOverheadLoop &LoLoop) {
     }
   }
 
-  LoLoop.ToRemove.insert(LoLoop.VCTPs.begin(), LoLoop.VCTPs.end());
+  LoLoop.ToRemove.insert_range(LoLoop.VCTPs);
 }
 
 void ARMLowOverheadLoops::Expand(LowOverheadLoop &LoLoop) {

--- a/llvm/lib/Target/ARM/ARMParallelDSP.cpp
+++ b/llvm/lib/Target/ARM/ARMParallelDSP.cpp
@@ -534,7 +534,7 @@ bool ARMParallelDSP::MatchSMLAD(Function &F) {
 
       InsertParallelMACs(R);
       Changed = true;
-      AllAdds.insert(R.getAdds().begin(), R.getAdds().end());
+      AllAdds.insert_range(R.getAdds());
       LLVM_DEBUG(dbgs() << "BB after inserting parallel MACs:\n" << BB);
     }
   }

--- a/llvm/lib/Target/Hexagon/BitTracker.cpp
+++ b/llvm/lib/Target/Hexagon/BitTracker.cpp
@@ -942,7 +942,7 @@ void BT::visitBranchesFrom(const MachineInstr &BI) {
         else
           dbgs() << "\n  does not fall through\n";
       }
-      Targets.insert(BTs.begin(), BTs.end());
+      Targets.insert_range(BTs);
     }
     ++It;
   } while (FallsThrough && It != End);

--- a/llvm/lib/Target/Hexagon/HexagonCommonGEP.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonCommonGEP.cpp
@@ -399,7 +399,7 @@ void HexagonCommonGEP::processGepInst(GetElementPtrInst *GepI,
   // After last node has been created, update the use information.
   if (!Us.empty()) {
     PN->Flags |= GepNode::Used;
-    Uses[PN].insert(Us.begin(), Us.end());
+    Uses[PN].insert_range(Us);
   }
 
   // Link the last node with the originating GEP instruction. This is to
@@ -606,7 +606,7 @@ void HexagonCommonGEP::common() {
       // original values of Min.
       if (NF & GepNode::Used) {
         auto &U = Uses[N];
-        MinUs.insert(U.begin(), U.end());
+        MinUs.insert_range(U);
       }
       Flags |= NF;
     }

--- a/llvm/lib/Target/Hexagon/HexagonConstExtenders.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonConstExtenders.cpp
@@ -1470,7 +1470,7 @@ void HCE::assignInits(const ExtRoot &ER, unsigned Begin, unsigned End,
              ExtValue(ED).Offset == EV.Offset;
     };
     if (all_of(P.second, SameValue)) {
-      F->second.insert(P.second.begin(), P.second.end());
+      F->second.insert_range(P.second);
       P.second.clear();
     }
   }

--- a/llvm/lib/Target/Hexagon/HexagonISelDAGToDAGHVX.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonISelDAGToDAGHVX.cpp
@@ -195,9 +195,9 @@ bool Coloring::color() {
     Q.insert(N);
     for (unsigned I = 0; I != Q.size(); ++I) {
       NodeSet &Ns = Edges[Q[I]];
-      Q.insert(Ns.begin(), Ns.end());
+      Q.insert_range(Ns);
     }
-    FirstQ.insert(Q.begin(), Q.end());
+    FirstQ.insert_range(Q);
   };
   for (Node N : Needed)
     Enqueue(N);

--- a/llvm/lib/Target/Hexagon/HexagonLoopIdiomRecognition.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonLoopIdiomRecognition.cpp
@@ -1325,7 +1325,7 @@ bool PolynomialMultiplyRecognize::convertShiftsToLeft(BasicBlock *LoopB,
     // Found a cycle.
     C.insert(&I);
     classifyCycle(&I, C, Early, Late);
-    Cycled.insert(C.begin(), C.end());
+    Cycled.insert_range(C);
     RShifts.insert(&I);
   }
 

--- a/llvm/lib/Target/PowerPC/PPCISelDAGToDAG.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelDAGToDAG.cpp
@@ -7236,7 +7236,7 @@ static bool PeepholePPC64ZExtGather(SDValue Op32,
       return false;
 
     ToPromote.insert(Op32.getNode());
-    ToPromote.insert(ToPromote1.begin(), ToPromote1.end());
+    ToPromote.insert_range(ToPromote1);
     return true;
   }
 
@@ -7253,7 +7253,7 @@ static bool PeepholePPC64ZExtGather(SDValue Op32,
       return false;
 
     ToPromote.insert(Op32.getNode());
-    ToPromote.insert(ToPromote1.begin(), ToPromote1.end());
+    ToPromote.insert_range(ToPromote1);
     return true;
   }
 
@@ -7269,7 +7269,7 @@ static bool PeepholePPC64ZExtGather(SDValue Op32,
       return false;
 
     ToPromote.insert(Op32.getNode());
-    ToPromote.insert(ToPromote1.begin(), ToPromote1.end());
+    ToPromote.insert_range(ToPromote1);
     return true;
   }
 
@@ -7287,10 +7287,10 @@ static bool PeepholePPC64ZExtGather(SDValue Op32,
     ToPromote.insert(Op32.getNode());
 
     if (Op0OK)
-      ToPromote.insert(ToPromote1.begin(), ToPromote1.end());
+      ToPromote.insert_range(ToPromote1);
 
     if (Op1OK)
-      ToPromote.insert(ToPromote2.begin(), ToPromote2.end());
+      ToPromote.insert_range(ToPromote2);
 
     return true;
   }
@@ -7310,7 +7310,7 @@ static bool PeepholePPC64ZExtGather(SDValue Op32,
     ToPromote.insert(Op32.getNode());
 
     if (Op0OK)
-      ToPromote.insert(ToPromote1.begin(), ToPromote1.end());
+      ToPromote.insert_range(ToPromote1);
 
     return true;
   }

--- a/llvm/lib/Target/SPIRV/Analysis/SPIRVConvergenceRegionAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/Analysis/SPIRVConvergenceRegionAnalysis.cpp
@@ -284,7 +284,7 @@ public:
               return false;
             return Token.value() == CT.value();
           });
-          RegionBlocks.insert(N.begin(), N.end());
+          RegionBlocks.insert_range(N);
         }
       }
 

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
@@ -100,7 +100,7 @@ public:
   void addCapabilities(const CapabilityList &ToAdd);
   void addCapability(Capability::Capability ToAdd) { addCapabilities({ToAdd}); }
   void addExtensions(const ExtensionList &ToAdd) {
-    AllExtensions.insert(ToAdd.begin(), ToAdd.end());
+    AllExtensions.insert_range(ToAdd);
   }
   void addExtension(Extension::Extension ToAdd) { AllExtensions.insert(ToAdd); }
   // Add the given requirements to the lists. If constraints conflict, or these

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
@@ -160,7 +160,7 @@ void SPIRVSubtarget::initAvailableExtInstSets() {
 void SPIRVSubtarget::initAvailableExtensions(
     const std::set<SPIRV::Extension::Extension> &AllowedExtIds) {
   AvailableExtensions.clear();
-  AvailableExtensions.insert(AllowedExtIds.begin(), AllowedExtIds.end());
+  AvailableExtensions.insert_range(AllowedExtIds);
 
   accountForAMDShaderTrinaryMinmax();
 }

--- a/llvm/lib/Target/SystemZ/SystemZRegisterInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZRegisterInfo.cpp
@@ -59,7 +59,7 @@ static void addHints(ArrayRef<MCPhysReg> Order,
                      const TargetRegisterClass *RC,
                      const MachineRegisterInfo *MRI) {
   SmallSet<unsigned, 4> CopyHints;
-  CopyHints.insert(Hints.begin(), Hints.end());
+  CopyHints.insert_range(Hints);
   Hints.clear();
   for (MCPhysReg Reg : Order)
     if (CopyHints.count(Reg) &&

--- a/llvm/lib/Target/X86/X86CmovConversion.cpp
+++ b/llvm/lib/Target/X86/X86CmovConversion.cpp
@@ -416,7 +416,7 @@ bool X86CmovConverterPass::checkForProfitableCmovCandidates(
 
   SmallPtrSet<MachineInstr *, 4> CmovInstructions;
   for (auto &Group : CmovInstGroups)
-    CmovInstructions.insert(Group.begin(), Group.end());
+    CmovInstructions.insert_range(Group);
 
   //===--------------------------------------------------------------------===//
   // Step 1: Calculate instruction depth and loop depth.

--- a/llvm/lib/Target/X86/X86RegisterInfo.cpp
+++ b/llvm/lib/Target/X86/X86RegisterInfo.cpp
@@ -1214,7 +1214,7 @@ bool X86RegisterInfo::getRegAllocationHints(Register VirtReg,
   };
 
   SmallSet<MCPhysReg, 4> CopyHints;
-  CopyHints.insert(Hints.begin(), Hints.end());
+  CopyHints.insert_range(Hints);
   Hints.clear();
   for (auto Hint : CopyHints) {
     if (RC.contains(Hint) && !MRI->isReserved(Hint))


### PR DESCRIPTION
DenseSet, SmallPtrSet, SmallSet, SetVector, and StringSet recently
gained C++23-style insert_range.  This patch replaces:

  Dest.insert(Src.begin(), Src.end());

with:

  Dest.insert_range(Src);

This patch does not touch custom begin like succ_begin for now.
