### PR TITLE
[SelectionDAG] Not issue TRAP node if naked function

### DIFF
--- a/llvm/include/llvm/IR/Instructions.h
+++ b/llvm/include/llvm/IR/Instructions.h
@@ -4497,6 +4497,9 @@ public:
     return isa<Instruction>(V) && classof(cast<Instruction>(V));
   }
 
+  // Whether to do target lowering in SelectionDAG.
+  bool shouldLowerToTrap(bool TrapUnreachable, bool NoTrapAfterNoreturn) const;
+
 private:
   BasicBlock *getSuccessor(unsigned idx) const {
     llvm_unreachable("UnreachableInst has no successors!");

--- a/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
@@ -1854,17 +1854,12 @@ bool FastISel::selectOperator(const User *I, unsigned Opcode) {
   }
 
   case Instruction::Unreachable: {
-    if (TM.Options.TrapUnreachable) {
-      if (TM.Options.NoTrapAfterNoreturn) {
-        const auto *Call =
-            dyn_cast_or_null<CallInst>(cast<Instruction>(I)->getPrevNode());
-        if (Call && Call->doesNotReturn())
-          return true;
-      }
+    auto UI = cast<UnreachableInst>(I);
+    if (!UI->shouldLowerToTrap(TM.Options.TrapUnreachable,
+                               TM.Options.NoTrapAfterNoreturn))
+      return true;
 
-      return fastEmit_(MVT::Other, MVT::Other, ISD::TRAP) != 0;
-    }
-    return true;
+    return fastEmit_(MVT::Other, MVT::Other, ISD::TRAP) != 0;
   }
 
   case Instruction::Alloca:

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -3501,18 +3501,9 @@ void SelectionDAGBuilder::visitIndirectBr(const IndirectBrInst &I) {
 }
 
 void SelectionDAGBuilder::visitUnreachable(const UnreachableInst &I) {
-  if (!DAG.getTarget().Options.TrapUnreachable)
+  if (!I.shouldLowerToTrap(DAG.getTarget().Options.TrapUnreachable,
+                           DAG.getTarget().Options.NoTrapAfterNoreturn))
     return;
-
-  // We may be able to ignore unreachable behind a noreturn call.
-  if (const CallInst *Call = dyn_cast_or_null<CallInst>(I.getPrevNode());
-      Call && Call->doesNotReturn()) {
-    if (DAG.getTarget().Options.NoTrapAfterNoreturn)
-      return;
-    // Do not emit an additional trap instruction.
-    if (Call->isNonContinuableTrap())
-      return;
-  }
 
   DAG.setRoot(DAG.getNode(ISD::TRAP, getCurSDLoc(), MVT::Other, DAG.getRoot()));
 }

--- a/llvm/test/CodeGen/WebAssembly/naked-fn-with-frame-pointer.ll
+++ b/llvm/test/CodeGen/WebAssembly/naked-fn-with-frame-pointer.ll
@@ -9,13 +9,11 @@ define dso_local void @naked() naked "frame-pointer"="all" {
 ; CHECK-32:         .functype naked () -> ()
 ; CHECK-32-NEXT:  # %bb.0:
 ; CHECK-32-NEXT:    call main
-; CHECK-32-NEXT:    unreachable
 ;
 ; CHECK-64-LABEL: naked:
 ; CHECK-64:         .functype naked () -> ()
 ; CHECK-64-NEXT:  # %bb.0:
 ; CHECK-64-NEXT:    call main
-; CHECK-64-NEXT:    unreachable
   call void @main()
   unreachable
 }

--- a/llvm/test/CodeGen/X86/naked-fn-with-unreachable-trap.ll
+++ b/llvm/test/CodeGen/X86/naked-fn-with-unreachable-trap.ll
@@ -1,0 +1,11 @@
+; RUN: llc -o - %s -mtriple=x86_64-linux-gnu -trap-unreachable | FileCheck %s
+; RUN: llc -o - %s -mtriple=x86_64-linux-gnu -trap-unreachable -fast-isel | FileCheck %s
+
+define dso_local void @foo() #0 {
+entry:
+  tail call void asm sideeffect "movl 3,%eax", "~{dirflag},~{fpsr},~{flags}"()
+  unreachable
+}
+; CHECK-NOT: ud2
+
+attributes #0 = { naked }


### PR DESCRIPTION
In [1], Nikita Popov suggested that during lowering 'unreachable' insn should not generate extra code for naked functions, and this applies to all architectures. Note that for naked functions, 'unreachable' insn is necessary in IR since the basic block needs a terminator to end.

This patch checked whether a function is naked function or not. If it is a naked function, 'unreachable' insn will not generate ISD::TRAP.

  [1] https://github.com/llvm/llvm-project/pull/131731