### PR TITLE
Move X86-specific MCSymbolRefExpr::VariantKind to X86MCExpr::Specifier

### DIFF
--- a/llvm/include/llvm/MC/MCExpr.h
+++ b/llvm/include/llvm/MC/MCExpr.h
@@ -199,14 +199,10 @@ public:
     VK_GOT,
     VK_GOTENT,
     VK_GOTOFF,
-    VK_GOTREL,
-    VK_PCREL,
     VK_GOTPCREL,
-    VK_GOTPCREL_NORELAX,
     VK_GOTTPOFF,
     VK_INDNTPOFF,
     VK_NTPOFF,
-    VK_GOTNTPOFF,
     VK_PLT,
     VK_TLSGD,
     VK_TLSLD,
@@ -223,7 +219,6 @@ public:
     VK_GOTPAGE,
     VK_GOTPAGEOFF,
     VK_SECREL,
-    VK_SIZE,    // symbol@SIZE
     VK_WEAKREF, // The link between the symbols in .weakref foo, bar
     VK_FUNCDESC,
     VK_GOTFUNCDESC,
@@ -231,9 +226,6 @@ public:
     VK_TLSGD_FDPIC,
     VK_TLSLDM_FDPIC,
     VK_GOTTPOFF_FDPIC,
-
-    VK_X86_ABS8,
-    VK_X86_PLTOFF,
 
     VK_ARM_NONE,
     VK_ARM_GOT_PREL,
@@ -261,8 +253,7 @@ public:
     VK_AMDGPU_ABS32_LO,      // symbol@abs32@lo
     VK_AMDGPU_ABS32_HI,      // symbol@abs32@hi
 
-    VK_TPREL,
-    VK_DTPREL
+    FirstTargetSpecifier,
   };
 
 private:

--- a/llvm/lib/MC/ELFObjectWriter.cpp
+++ b/llvm/lib/MC/ELFObjectWriter.cpp
@@ -1269,7 +1269,6 @@ bool ELFObjectWriter::shouldRelocateWithSymbol(const MCAssembler &Asm,
   case MCSymbolRefExpr::VK_GOT:
   case MCSymbolRefExpr::VK_PLT:
   case MCSymbolRefExpr::VK_GOTPCREL:
-  case MCSymbolRefExpr::VK_GOTPCREL_NORELAX:
     return true;
   }
 
@@ -1526,16 +1525,13 @@ void ELFObjectWriter::fixSymbolsInTLSFixups(MCAssembler &Asm,
     case MCSymbolRefExpr::VK_GOTTPOFF:
     case MCSymbolRefExpr::VK_INDNTPOFF:
     case MCSymbolRefExpr::VK_NTPOFF:
-    case MCSymbolRefExpr::VK_GOTNTPOFF:
     case MCSymbolRefExpr::VK_TLSCALL:
     case MCSymbolRefExpr::VK_TLSDESC:
     case MCSymbolRefExpr::VK_TLSGD:
     case MCSymbolRefExpr::VK_TLSLD:
     case MCSymbolRefExpr::VK_TLSLDM:
     case MCSymbolRefExpr::VK_TPOFF:
-    case MCSymbolRefExpr::VK_TPREL:
     case MCSymbolRefExpr::VK_DTPOFF:
-    case MCSymbolRefExpr::VK_DTPREL:
       break;
     }
     Asm.registerSymbol(symRef.getSymbol());

--- a/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -2116,7 +2116,7 @@ bool X86AsmParser::ParseIntelExpression(IntelExprStateMachine &SM, SMLoc &End) {
         if (IDVal == "f" || IDVal == "b") {
           MCSymbol *Sym =
               getContext().getDirectionalLocalSymbol(IntVal, IDVal == "b");
-          MCSymbolRefExpr::VariantKind Variant = MCSymbolRefExpr::VK_None;
+          auto Variant = X86MCExpr::VK_None;
           const MCExpr *Val =
               MCSymbolRefExpr::create(Sym, Variant, getContext());
           if (IDVal == "b" && Sym->isUndefined())
@@ -2263,7 +2263,7 @@ bool X86AsmParser::ParseIntelInlineAsmIdentifier(
     return false;
   // Create the symbol reference.
   MCSymbol *Sym = getContext().getOrCreateSymbol(Identifier);
-  MCSymbolRefExpr::VariantKind Variant = MCSymbolRefExpr::VK_None;
+  auto Variant = X86MCExpr::VK_None;
   Val = MCSymbolRefExpr::create(Sym, Variant, getParser().getContext());
   return false;
 }

--- a/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
@@ -9,6 +9,7 @@
 #include "MCTargetDesc/X86BaseInfo.h"
 #include "MCTargetDesc/X86EncodingOptimization.h"
 #include "MCTargetDesc/X86FixupKinds.h"
+#include "MCTargetDesc/X86MCExpr.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/BinaryFormat/MachO.h"
@@ -360,7 +361,7 @@ static bool hasVariantSymbol(const MCInst &MI) {
       continue;
     const MCExpr &Expr = *Operand.getExpr();
     if (Expr.getKind() == MCExpr::SymbolRef &&
-        cast<MCSymbolRefExpr>(Expr).getKind() != MCSymbolRefExpr::VK_None)
+        getSpecifier(cast<MCSymbolRefExpr>(&Expr)) != X86MCExpr::VK_None)
       return true;
   }
   return false;
@@ -746,7 +747,7 @@ bool X86AsmBackend::fixupNeedsRelaxationAdvanced(const MCAssembler &Asm,
     MCValue Target;
     if (Fixup.getValue()->evaluateAsRelocatable(Target, &Asm) &&
         Target.getSymA() &&
-        Target.getSymA()->getKind() == MCSymbolRefExpr::VK_X86_ABS8)
+        getSpecifier(Target.getSymA()) == X86MCExpr::VK_ABS8)
       return false;
   }
   return true;

--- a/llvm/lib/Target/X86/MCTargetDesc/X86ELFObjectWriter.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86ELFObjectWriter.cpp
@@ -233,7 +233,7 @@ static unsigned getRelocType64(MCContext &Ctx, SMLoc Loc,
   case X86MCExpr::VK_GOTPCREL_NORELAX:
     checkIs32(Ctx, Loc, Type);
     return ELF::R_X86_64_GOTPCREL;
-  case X86MCExpr::VK_X86_PLTOFF:
+  case X86MCExpr::VK_PLTOFF:
     checkIs64(Ctx, Loc, Type);
     return ELF::R_X86_64_PLTOFF64;
   }

--- a/llvm/lib/Target/X86/MCTargetDesc/X86ELFObjectWriter.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86ELFObjectWriter.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "MCTargetDesc/X86FixupKinds.h"
+#include "MCTargetDesc/X86MCExpr.h"
 #include "MCTargetDesc/X86MCTargetDesc.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/MC/MCAsmInfo.h"
@@ -32,6 +33,8 @@ public:
 protected:
   unsigned getRelocType(MCContext &Ctx, const MCValue &Target,
                         const MCFixup &Fixup, bool IsPCRel) const override;
+  bool needsRelocateWithSymbol(const MCValue &Val, const MCSymbol &Sym,
+                               unsigned Type) const override;
 };
 
 } // end anonymous namespace
@@ -47,8 +50,7 @@ X86ELFObjectWriter::X86ELFObjectWriter(bool IsELF64, uint8_t OSABI,
 enum X86_64RelType { RT64_NONE, RT64_64, RT64_32, RT64_32S, RT64_16, RT64_8 };
 
 static X86_64RelType getType64(MCFixupKind Kind,
-                               MCSymbolRefExpr::VariantKind &Modifier,
-                               bool &IsPCRel) {
+                               X86MCExpr::Specifier &Specifier, bool &IsPCRel) {
   switch (unsigned(Kind)) {
   default:
     llvm_unreachable("Unimplemented");
@@ -58,11 +60,11 @@ static X86_64RelType getType64(MCFixupKind Kind,
     return RT64_64;
   case X86::reloc_signed_4byte:
   case X86::reloc_signed_4byte_relax:
-    if (Modifier == MCSymbolRefExpr::VK_None && !IsPCRel)
+    if (Specifier == X86MCExpr::VK_None && !IsPCRel)
       return RT64_32S;
     return RT64_32;
   case X86::reloc_global_offset_table:
-    Modifier = MCSymbolRefExpr::VK_GOT;
+    Specifier = X86MCExpr::VK_GOT;
     IsPCRel = true;
     return RT64_32;
   case FK_Data_4:
@@ -76,7 +78,7 @@ static X86_64RelType getType64(MCFixupKind Kind,
   case X86::reloc_riprel_4byte_relax_evex:
     return RT64_32;
   case X86::reloc_branch_4byte_pcrel:
-    Modifier = MCSymbolRefExpr::VK_PLT;
+    Specifier = X86MCExpr::VK_PLT;
     return RT64_32;
   case FK_PCRel_2:
   case FK_Data_2:
@@ -100,17 +102,17 @@ static void checkIs64(MCContext &Ctx, SMLoc Loc, X86_64RelType Type) {
 }
 
 static unsigned getRelocType64(MCContext &Ctx, SMLoc Loc,
-                               MCSymbolRefExpr::VariantKind Modifier,
+                               X86MCExpr::Specifier Specifier,
                                X86_64RelType Type, bool IsPCRel,
                                MCFixupKind Kind) {
-  switch (Modifier) {
+  switch (Specifier) {
   default:
     llvm_unreachable("Unimplemented");
-  case MCSymbolRefExpr::VK_None:
-  case MCSymbolRefExpr::VK_X86_ABS8:
+  case X86MCExpr::VK_None:
+  case X86MCExpr::VK_ABS8:
     switch (Type) {
     case RT64_NONE:
-      if (Modifier == MCSymbolRefExpr::VK_None)
+      if (Specifier == X86MCExpr::VK_None)
         return ELF::R_X86_64_NONE;
       llvm_unreachable("Unimplemented");
     case RT64_64:
@@ -125,7 +127,7 @@ static unsigned getRelocType64(MCContext &Ctx, SMLoc Loc,
       return IsPCRel ? ELF::R_X86_64_PC8 : ELF::R_X86_64_8;
     }
     llvm_unreachable("unexpected relocation type!");
-  case MCSymbolRefExpr::VK_GOT:
+  case X86MCExpr::VK_GOT:
     switch (Type) {
     case RT64_64:
       return IsPCRel ? ELF::R_X86_64_GOTPC64 : ELF::R_X86_64_GOT64;
@@ -138,12 +140,12 @@ static unsigned getRelocType64(MCContext &Ctx, SMLoc Loc,
       llvm_unreachable("Unimplemented");
     }
     llvm_unreachable("unexpected relocation type!");
-  case MCSymbolRefExpr::VK_GOTOFF:
+  case X86MCExpr::VK_GOTOFF:
     assert(!IsPCRel);
     if (Type != RT64_64)
       Ctx.reportError(Loc, "unsupported relocation type");
     return ELF::R_X86_64_GOTOFF64;
-  case MCSymbolRefExpr::VK_TPOFF:
+  case X86MCExpr::VK_TPOFF:
     assert(!IsPCRel);
     switch (Type) {
     case RT64_64:
@@ -157,7 +159,7 @@ static unsigned getRelocType64(MCContext &Ctx, SMLoc Loc,
       llvm_unreachable("Unimplemented");
     }
     llvm_unreachable("unexpected relocation type!");
-  case MCSymbolRefExpr::VK_DTPOFF:
+  case X86MCExpr::VK_DTPOFF:
     assert(!IsPCRel);
     switch (Type) {
     case RT64_64:
@@ -171,7 +173,7 @@ static unsigned getRelocType64(MCContext &Ctx, SMLoc Loc,
       llvm_unreachable("Unimplemented");
     }
     llvm_unreachable("unexpected relocation type!");
-  case MCSymbolRefExpr::VK_SIZE:
+  case X86MCExpr::VK_SIZE:
     assert(!IsPCRel);
     switch (Type) {
     case RT64_64:
@@ -185,16 +187,16 @@ static unsigned getRelocType64(MCContext &Ctx, SMLoc Loc,
       llvm_unreachable("Unimplemented");
     }
     llvm_unreachable("unexpected relocation type!");
-  case MCSymbolRefExpr::VK_TLSCALL:
+  case X86MCExpr::VK_TLSCALL:
     return ELF::R_X86_64_TLSDESC_CALL;
-  case MCSymbolRefExpr::VK_TLSDESC:
+  case X86MCExpr::VK_TLSDESC:
     return ((unsigned)Kind == X86::reloc_riprel_4byte_relax_rex2)
                ? ELF::R_X86_64_CODE_4_GOTPC32_TLSDESC
                : ELF::R_X86_64_GOTPC32_TLSDESC;
-  case MCSymbolRefExpr::VK_TLSGD:
+  case X86MCExpr::VK_TLSGD:
     checkIs32(Ctx, Loc, Type);
     return ELF::R_X86_64_TLSGD;
-  case MCSymbolRefExpr::VK_GOTTPOFF:
+  case X86MCExpr::VK_GOTTPOFF:
     checkIs32(Ctx, Loc, Type);
     if ((unsigned)Kind == X86::reloc_riprel_4byte_movq_load_rex2 ||
         (unsigned)Kind == X86::reloc_riprel_4byte_relax_rex2)
@@ -202,13 +204,13 @@ static unsigned getRelocType64(MCContext &Ctx, SMLoc Loc,
     else if ((unsigned)Kind == X86::reloc_riprel_4byte_relax_evex)
       return ELF::R_X86_64_CODE_6_GOTTPOFF;
     return ELF::R_X86_64_GOTTPOFF;
-  case MCSymbolRefExpr::VK_TLSLD:
+  case X86MCExpr::VK_TLSLD:
     checkIs32(Ctx, Loc, Type);
     return ELF::R_X86_64_TLSLD;
-  case MCSymbolRefExpr::VK_PLT:
+  case X86MCExpr::VK_PLT:
     checkIs32(Ctx, Loc, Type);
     return ELF::R_X86_64_PLT32;
-  case MCSymbolRefExpr::VK_GOTPCREL:
+  case X86MCExpr::VK_GOTPCREL:
     checkIs32(Ctx, Loc, Type);
     // Older versions of ld.bfd/ld.gold/lld
     // do not support GOTPCRELX/REX_GOTPCRELX/CODE_4_GOTPCRELX,
@@ -228,10 +230,10 @@ static unsigned getRelocType64(MCContext &Ctx, SMLoc Loc,
       return ELF::R_X86_64_CODE_4_GOTPCRELX;
     }
     llvm_unreachable("unexpected relocation type!");
-  case MCSymbolRefExpr::VK_GOTPCREL_NORELAX:
+  case X86MCExpr::VK_GOTPCREL_NORELAX:
     checkIs32(Ctx, Loc, Type);
     return ELF::R_X86_64_GOTPCREL;
-  case MCSymbolRefExpr::VK_X86_PLTOFF:
+  case X86MCExpr::VK_X86_PLTOFF:
     checkIs64(Ctx, Loc, Type);
     return ELF::R_X86_64_PLTOFF64;
   }
@@ -240,17 +242,17 @@ static unsigned getRelocType64(MCContext &Ctx, SMLoc Loc,
 enum X86_32RelType { RT32_NONE, RT32_32, RT32_16, RT32_8 };
 
 static unsigned getRelocType32(MCContext &Ctx, SMLoc Loc,
-                               MCSymbolRefExpr::VariantKind Modifier,
+                               X86MCExpr::Specifier Specifier,
                                X86_32RelType Type, bool IsPCRel,
                                MCFixupKind Kind) {
-  switch (Modifier) {
+  switch (Specifier) {
   default:
     llvm_unreachable("Unimplemented");
-  case MCSymbolRefExpr::VK_None:
-  case MCSymbolRefExpr::VK_X86_ABS8:
+  case X86MCExpr::VK_None:
+  case X86MCExpr::VK_ABS8:
     switch (Type) {
     case RT32_NONE:
-      if (Modifier == MCSymbolRefExpr::VK_None)
+      if (Specifier == X86MCExpr::VK_None)
         return ELF::R_386_NONE;
       llvm_unreachable("Unimplemented");
     case RT32_32:
@@ -261,7 +263,7 @@ static unsigned getRelocType32(MCContext &Ctx, SMLoc Loc,
       return IsPCRel ? ELF::R_386_PC8 : ELF::R_386_8;
     }
     llvm_unreachable("unexpected relocation type!");
-  case MCSymbolRefExpr::VK_GOT:
+  case X86MCExpr::VK_GOT:
     if (Type != RT32_32)
       break;
     if (IsPCRel)
@@ -274,55 +276,55 @@ static unsigned getRelocType32(MCContext &Ctx, SMLoc Loc,
     return Kind == MCFixupKind(X86::reloc_signed_4byte_relax)
                ? ELF::R_386_GOT32X
                : ELF::R_386_GOT32;
-  case MCSymbolRefExpr::VK_GOTOFF:
+  case X86MCExpr::VK_GOTOFF:
     assert(!IsPCRel);
     if (Type != RT32_32)
       break;
     return ELF::R_386_GOTOFF;
-  case MCSymbolRefExpr::VK_TLSCALL:
+  case X86MCExpr::VK_TLSCALL:
     return ELF::R_386_TLS_DESC_CALL;
-  case MCSymbolRefExpr::VK_TLSDESC:
+  case X86MCExpr::VK_TLSDESC:
     return ELF::R_386_TLS_GOTDESC;
-  case MCSymbolRefExpr::VK_TPOFF:
+  case X86MCExpr::VK_TPOFF:
     if (Type != RT32_32)
       break;
     assert(!IsPCRel);
     return ELF::R_386_TLS_LE_32;
-  case MCSymbolRefExpr::VK_DTPOFF:
+  case X86MCExpr::VK_DTPOFF:
     if (Type != RT32_32)
       break;
     assert(!IsPCRel);
     return ELF::R_386_TLS_LDO_32;
-  case MCSymbolRefExpr::VK_TLSGD:
+  case X86MCExpr::VK_TLSGD:
     if (Type != RT32_32)
       break;
     assert(!IsPCRel);
     return ELF::R_386_TLS_GD;
-  case MCSymbolRefExpr::VK_GOTTPOFF:
+  case X86MCExpr::VK_GOTTPOFF:
     if (Type != RT32_32)
       break;
     assert(!IsPCRel);
     return ELF::R_386_TLS_IE_32;
-  case MCSymbolRefExpr::VK_PLT:
+  case X86MCExpr::VK_PLT:
     if (Type != RT32_32)
       break;
     return ELF::R_386_PLT32;
-  case MCSymbolRefExpr::VK_INDNTPOFF:
+  case X86MCExpr::VK_INDNTPOFF:
     if (Type != RT32_32)
       break;
     assert(!IsPCRel);
     return ELF::R_386_TLS_IE;
-  case MCSymbolRefExpr::VK_NTPOFF:
+  case X86MCExpr::VK_NTPOFF:
     if (Type != RT32_32)
       break;
     assert(!IsPCRel);
     return ELF::R_386_TLS_LE;
-  case MCSymbolRefExpr::VK_GOTNTPOFF:
+  case X86MCExpr::VK_GOTNTPOFF:
     if (Type != RT32_32)
       break;
     assert(!IsPCRel);
     return ELF::R_386_TLS_GOTIE;
-  case MCSymbolRefExpr::VK_TLSLDM:
+  case X86MCExpr::VK_TLSLDM:
     if (Type != RT32_32)
       break;
     assert(!IsPCRel);
@@ -338,10 +340,29 @@ unsigned X86ELFObjectWriter::getRelocType(MCContext &Ctx, const MCValue &Target,
   MCFixupKind Kind = Fixup.getKind();
   if (Kind >= FirstLiteralRelocationKind)
     return Kind - FirstLiteralRelocationKind;
-  MCSymbolRefExpr::VariantKind Modifier = Target.getAccessVariant();
-  X86_64RelType Type = getType64(Kind, Modifier, IsPCRel);
+  auto Specifier = X86MCExpr::Specifier(Target.getAccessVariant());
+  switch (Specifier) {
+  case X86MCExpr::VK_GOTTPOFF:
+  case X86MCExpr::VK_INDNTPOFF:
+  case X86MCExpr::VK_NTPOFF:
+  case X86MCExpr::VK_GOTNTPOFF:
+  case X86MCExpr::VK_TLSCALL:
+  case X86MCExpr::VK_TLSDESC:
+  case X86MCExpr::VK_TLSGD:
+  case X86MCExpr::VK_TLSLD:
+  case X86MCExpr::VK_TLSLDM:
+  case X86MCExpr::VK_TPOFF:
+  case X86MCExpr::VK_DTPOFF:
+    if (auto *S = Target.getSymA())
+      cast<MCSymbolELF>(S->getSymbol()).setType(ELF::STT_TLS);
+    break;
+  default:
+    break;
+  }
+
+  X86_64RelType Type = getType64(Kind, Specifier, IsPCRel);
   if (getEMachine() == ELF::EM_X86_64)
-    return getRelocType64(Ctx, Fixup.getLoc(), Modifier, Type, IsPCRel, Kind);
+    return getRelocType64(Ctx, Fixup.getLoc(), Specifier, Type, IsPCRel, Kind);
 
   assert((getEMachine() == ELF::EM_386 || getEMachine() == ELF::EM_IAMCU) &&
          "Unsupported ELF machine type.");
@@ -364,7 +385,21 @@ unsigned X86ELFObjectWriter::getRelocType(MCContext &Ctx, const MCValue &Target,
     RelType = RT32_8;
     break;
   }
-  return getRelocType32(Ctx, Fixup.getLoc(), Modifier, RelType, IsPCRel, Kind);
+  return getRelocType32(Ctx, Fixup.getLoc(), Specifier, RelType, IsPCRel, Kind);
+}
+
+bool X86ELFObjectWriter::needsRelocateWithSymbol(const MCValue &V,
+                                                 const MCSymbol &Sym,
+                                                 unsigned Type) const {
+  switch (getSpecifier(V.getSymA())) {
+  case X86MCExpr::VK_GOT:
+  case X86MCExpr::VK_PLT:
+  case X86MCExpr::VK_GOTPCREL:
+  case X86MCExpr::VK_GOTPCREL_NORELAX:
+    return true;
+  default:
+    return false;
+  }
 }
 
 std::unique_ptr<MCObjectTargetWriter>

--- a/llvm/lib/Target/X86/MCTargetDesc/X86EncodingOptimization.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86EncodingOptimization.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "X86EncodingOptimization.h"
+#include "MCTargetDesc/X86MCExpr.h"
 #include "X86BaseInfo.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCInst.h"
@@ -374,7 +375,7 @@ bool X86::optimizeMOV(MCInst &MI, bool In64BitMode) {
   if (MI.getOperand(AddrOp).isExpr()) {
     const MCExpr *MCE = MI.getOperand(AddrOp).getExpr();
     if (const MCSymbolRefExpr *SRE = dyn_cast<MCSymbolRefExpr>(MCE))
-      if (SRE->getKind() == MCSymbolRefExpr::VK_TLVP)
+      if (getSpecifier(SRE) == X86MCExpr::VK_TLVP)
         Absolute = false;
   }
   if (Absolute && (MI.getOperand(AddrBase + X86::AddrBaseReg).getReg() ||
@@ -485,7 +486,7 @@ static bool optimizeToShortImmediateForm(MCInst &MI) {
   MCOperand &LastOp = MI.getOperand(MI.getNumOperands() - 1 - SkipOperands);
   if (LastOp.isExpr()) {
     const MCSymbolRefExpr *SRE = dyn_cast<MCSymbolRefExpr>(LastOp.getExpr());
-    if (!SRE || SRE->getKind() != MCSymbolRefExpr::VK_X86_ABS8)
+    if (!SRE || getSpecifier(SRE) != X86MCExpr::VK_ABS8)
       return false;
   } else if (LastOp.isImm()) {
     if (!isInt<8>(LastOp.getImm()))

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.cpp
@@ -52,7 +52,7 @@ const MCAsmInfo::VariantKindDesc variantKindDescs[] = {
     {X86MCExpr::VK_NTPOFF, "NTPOFF"},
     {X86MCExpr::VK_PCREL, "PCREL"},
     {X86MCExpr::VK_PLT, "PLT"},
-    {X86MCExpr::VK_X86_PLTOFF, "PLTOFF"},
+    {X86MCExpr::VK_PLTOFF, "PLTOFF"},
     {MCSymbolRefExpr::VK_SECREL, "SECREL32"},
     {X86MCExpr::VK_SIZE, "SIZE"},
     {X86MCExpr::VK_TLSCALL, "tlscall"},

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCAsmInfo.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "X86MCAsmInfo.h"
+#include "MCTargetDesc/X86MCExpr.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/Support/CommandLine.h"
@@ -35,34 +36,34 @@ MarkedJTDataRegions("mark-data-regions", cl::init(true),
   cl::Hidden);
 
 const MCAsmInfo::VariantKindDesc variantKindDescs[] = {
-    {MCSymbolRefExpr::VK_X86_ABS8, "ABS8"},
-    {MCSymbolRefExpr::VK_DTPOFF, "DTPOFF"},
-    {MCSymbolRefExpr::VK_DTPREL, "DTPREL"},
-    {MCSymbolRefExpr::VK_GOT, "GOT"},
-    {MCSymbolRefExpr::VK_GOTENT, "GOTENT"},
-    {MCSymbolRefExpr::VK_GOTNTPOFF, "GOTNTPOFF"},
-    {MCSymbolRefExpr::VK_GOTOFF, "GOTOFF"},
-    {MCSymbolRefExpr::VK_GOTPCREL, "GOTPCREL"},
-    {MCSymbolRefExpr::VK_GOTPCREL_NORELAX, "GOTPCREL_NORELAX"},
-    {MCSymbolRefExpr::VK_GOTREL, "GOTREL"},
-    {MCSymbolRefExpr::VK_GOTTPOFF, "GOTTPOFF"},
-    {MCSymbolRefExpr::VK_INDNTPOFF, "INDNTPOFF"},
+    {X86MCExpr::VK_ABS8, "ABS8"},
+    {X86MCExpr::VK_DTPOFF, "DTPOFF"},
+    {X86MCExpr::VK_DTPREL, "DTPREL"},
+    {X86MCExpr::VK_GOT, "GOT"},
+    {X86MCExpr::VK_GOTENT, "GOTENT"},
+    {X86MCExpr::VK_GOTNTPOFF, "GOTNTPOFF"},
+    {X86MCExpr::VK_GOTOFF, "GOTOFF"},
+    {X86MCExpr::VK_GOTPCREL, "GOTPCREL"},
+    {X86MCExpr::VK_GOTPCREL_NORELAX, "GOTPCREL_NORELAX"},
+    {X86MCExpr::VK_GOTREL, "GOTREL"},
+    {X86MCExpr::VK_GOTTPOFF, "GOTTPOFF"},
+    {X86MCExpr::VK_INDNTPOFF, "INDNTPOFF"},
     {MCSymbolRefExpr::VK_COFF_IMGREL32, "IMGREL"},
-    {MCSymbolRefExpr::VK_NTPOFF, "NTPOFF"},
-    {MCSymbolRefExpr::VK_PCREL, "PCREL"},
-    {MCSymbolRefExpr::VK_PLT, "PLT"},
-    {MCSymbolRefExpr::VK_X86_PLTOFF, "PLTOFF"},
+    {X86MCExpr::VK_NTPOFF, "NTPOFF"},
+    {X86MCExpr::VK_PCREL, "PCREL"},
+    {X86MCExpr::VK_PLT, "PLT"},
+    {X86MCExpr::VK_X86_PLTOFF, "PLTOFF"},
     {MCSymbolRefExpr::VK_SECREL, "SECREL32"},
-    {MCSymbolRefExpr::VK_SIZE, "SIZE"},
-    {MCSymbolRefExpr::VK_TLSCALL, "tlscall"},
-    {MCSymbolRefExpr::VK_TLSDESC, "tlsdesc"},
-    {MCSymbolRefExpr::VK_TLSGD, "TLSGD"},
-    {MCSymbolRefExpr::VK_TLSLD, "TLSLD"},
-    {MCSymbolRefExpr::VK_TLSLDM, "TLSLDM"},
-    {MCSymbolRefExpr::VK_TLVP, "TLVP"},
-    {MCSymbolRefExpr::VK_TLVPPAGE, "TLVPPAGE"},
-    {MCSymbolRefExpr::VK_TLVPPAGEOFF, "TLVPPAGEOFF"},
-    {MCSymbolRefExpr::VK_TPOFF, "TPOFF"},
+    {X86MCExpr::VK_SIZE, "SIZE"},
+    {X86MCExpr::VK_TLSCALL, "tlscall"},
+    {X86MCExpr::VK_TLSDESC, "tlsdesc"},
+    {X86MCExpr::VK_TLSGD, "TLSGD"},
+    {X86MCExpr::VK_TLSLD, "TLSLD"},
+    {X86MCExpr::VK_TLSLDM, "TLSLDM"},
+    {X86MCExpr::VK_TLVP, "TLVP"},
+    {X86MCExpr::VK_TLVPPAGE, "TLVPPAGE"},
+    {X86MCExpr::VK_TLVPPAGEOFF, "TLVPPAGEOFF"},
+    {X86MCExpr::VK_TPOFF, "TPOFF"},
 };
 
 void X86MCAsmInfoDarwin::anchor() { }
@@ -139,7 +140,7 @@ X86_64MCAsmInfoDarwin::getExprForPersonalitySymbol(const MCSymbol *Sym,
                                                    MCStreamer &Streamer) const {
   MCContext &Context = Streamer.getContext();
   const MCExpr *Res =
-    MCSymbolRefExpr::create(Sym, MCSymbolRefExpr::VK_GOTPCREL, Context);
+      MCSymbolRefExpr::create(Sym, X86MCExpr::VK_GOTPCREL, Context);
   const MCExpr *Four = MCConstantExpr::create(4, Context);
   return MCBinaryExpr::createAdd(Res, Four, Context);
 }

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCCodeEmitter.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCCodeEmitter.cpp
@@ -12,6 +12,7 @@
 
 #include "MCTargetDesc/X86BaseInfo.h"
 #include "MCTargetDesc/X86FixupKinds.h"
+#include "MCTargetDesc/X86MCExpr.h"
 #include "MCTargetDesc/X86MCTargetDesc.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/BinaryFormat/ELF.h"
@@ -483,7 +484,7 @@ startsWithGlobalOffsetTable(const MCExpr *Expr) {
 
 static bool hasSecRelSymbolRef(const MCExpr *Expr) {
   if (Expr->getKind() == MCExpr::SymbolRef) {
-    const MCSymbolRefExpr *Ref = static_cast<const MCSymbolRefExpr *>(Expr);
+    auto *Ref = static_cast<const MCSymbolRefExpr *>(Expr);
     return Ref->getKind() == MCSymbolRefExpr::VK_SECREL;
   }
   return false;
@@ -502,8 +503,8 @@ static bool isPCRel32Branch(const MCInst &MI, const MCInstrInfo &MCII) {
   if (!Op.isExpr())
     return false;
 
-  const MCSymbolRefExpr *Ref = dyn_cast<MCSymbolRefExpr>(Op.getExpr());
-  return Ref && Ref->getKind() == MCSymbolRefExpr::VK_None;
+  auto *Ref = dyn_cast<MCSymbolRefExpr>(Op.getExpr());
+  return Ref && getSpecifier(Ref) == X86MCExpr::VK_None;
 }
 
 unsigned X86MCCodeEmitter::getX86RegNum(const MCOperand &MO) const {
@@ -797,7 +798,7 @@ void X86MCCodeEmitter::emitMemModRMByte(
       // If the displacement is @tlscall, treat it as a zero.
       if (Disp.isExpr()) {
         auto *Sym = dyn_cast<MCSymbolRefExpr>(Disp.getExpr());
-        if (Sym && Sym->getKind() == MCSymbolRefExpr::VK_TLSCALL) {
+        if (Sym && getSpecifier(Sym) == X86MCExpr::VK_TLSCALL) {
           // This is exclusively used by call *a@tlscall(base). The relocation
           // (R_386_TLSCALL or R_X86_64_TLSCALL) applies to the beginning.
           Fixups.push_back(MCFixup::create(0, Sym, FK_NONE, MI.getLoc()));
@@ -1373,8 +1374,8 @@ PrefixKind X86MCCodeEmitter::emitREXPrefix(int MemOperand, const MCInst &MI,
       // handled as a special case here so that it also works for hand-written
       // assembly without the user needing to write REX, as with GNU as.
       const auto *Ref = dyn_cast<MCSymbolRefExpr>(MO.getExpr());
-      if (Ref && (Ref->getKind() == MCSymbolRefExpr::VK_GOTTPOFF ||
-                  Ref->getKind() == MCSymbolRefExpr::VK_TLSDESC)) {
+      if (Ref && (getSpecifier(Ref) == X86MCExpr::VK_GOTTPOFF ||
+                  getSpecifier(Ref) == X86MCExpr::VK_TLSDESC)) {
         Prefix.setLowerBound(REX);
       }
     }

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCExpr.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCExpr.h
@@ -50,7 +50,7 @@ public:
     VK_NTPOFF,
     VK_PCREL,
     VK_PLT,
-    VK_X86_PLTOFF,
+    VK_PLTOFF,
     VK_SIZE,
     VK_TLSCALL,
     VK_TLSDESC,

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCExpr.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCExpr.h
@@ -31,6 +31,38 @@ private:
   explicit X86MCExpr(MCRegister R) : Reg(R) {}
 
 public:
+  // Relocation specifier. Named VK_ for legacy reasons.
+  enum Specifier {
+    VK_None,
+
+    VK_ABS8 = MCSymbolRefExpr::FirstTargetSpecifier,
+    VK_DTPOFF,
+    VK_DTPREL,
+    VK_GOT,
+    VK_GOTENT,
+    VK_GOTNTPOFF,
+    VK_GOTOFF,
+    VK_GOTPCREL,
+    VK_GOTPCREL_NORELAX,
+    VK_GOTREL,
+    VK_GOTTPOFF,
+    VK_INDNTPOFF,
+    VK_NTPOFF,
+    VK_PCREL,
+    VK_PLT,
+    VK_X86_PLTOFF,
+    VK_SIZE,
+    VK_TLSCALL,
+    VK_TLSDESC,
+    VK_TLSGD,
+    VK_TLSLD,
+    VK_TLSLDM,
+    VK_TLVP,
+    VK_TLVPPAGE,
+    VK_TLVPPAGEOFF,
+    VK_TPOFF,
+  };
+
   /// @name Construction
   /// @{
 
@@ -72,6 +104,9 @@ public:
   }
 };
 
+static inline X86MCExpr::Specifier getSpecifier(const MCSymbolRefExpr *SRE) {
+  return X86MCExpr::Specifier(SRE->getKind());
+}
 } // end namespace llvm
 
 #endif

--- a/llvm/lib/Target/X86/MCTargetDesc/X86WinCOFFObjectWriter.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86WinCOFFObjectWriter.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "MCTargetDesc/X86FixupKinds.h"
+#include "MCTargetDesc/X86MCExpr.h"
 #include "MCTargetDesc/X86MCTargetDesc.h"
 #include "llvm/BinaryFormat/COFF.h"
 #include "llvm/MC/MCContext.h"
@@ -58,9 +59,8 @@ unsigned X86WinCOFFObjectWriter::getRelocType(MCContext &Ctx,
     }
   }
 
-  MCSymbolRefExpr::VariantKind Modifier = Target.isAbsolute() ?
-    MCSymbolRefExpr::VK_None : Target.getSymA()->getKind();
-
+  auto Modifier = Target.isAbsolute() ? MCSymbolRefExpr::VK_None
+                                      : Target.getSymA()->getKind();
   if (Is64Bit) {
     switch (FixupKind) {
     case FK_PCRel_4:

--- a/llvm/lib/Target/X86/MCTargetDesc/X86WinCOFFStreamer.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86WinCOFFStreamer.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "MCTargetDesc/X86MCExpr.h"
 #include "X86MCTargetDesc.h"
 #include "X86TargetStreamer.h"
 #include "llvm/MC/MCAsmBackend.h"

--- a/llvm/lib/Target/X86/MCTargetDesc/X86WinCOFFTargetStreamer.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86WinCOFFTargetStreamer.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "MCTargetDesc/X86MCExpr.h"
 #include "X86MCTargetDesc.h"
 #include "X86TargetStreamer.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"

--- a/llvm/lib/Target/X86/X86ISelLoweringCall.cpp
+++ b/llvm/lib/Target/X86/X86ISelLoweringCall.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "MCTargetDesc/X86MCExpr.h"
 #include "X86.h"
 #include "X86CallingConv.h"
 #include "X86FrameLowering.h"
@@ -471,8 +472,7 @@ X86TargetLowering::LowerCustomJumpTableEntry(const MachineJumpTableInfo *MJTI,
   assert(isPositionIndependent() && Subtarget.isPICStyleGOT());
   // In 32-bit ELF systems, our jump table entries are formed with @GOTOFF
   // entries.
-  return MCSymbolRefExpr::create(MBB->getSymbol(),
-                                 MCSymbolRefExpr::VK_GOTOFF, Ctx);
+  return MCSymbolRefExpr::create(MBB->getSymbol(), X86MCExpr::VK_GOTOFF, Ctx);
 }
 
 /// Returns relocation base for the given PIC jumptable.

--- a/llvm/lib/Target/X86/X86MCInstLower.cpp
+++ b/llvm/lib/Target/X86/X86MCInstLower.cpp
@@ -15,6 +15,7 @@
 #include "MCTargetDesc/X86BaseInfo.h"
 #include "MCTargetDesc/X86EncodingOptimization.h"
 #include "MCTargetDesc/X86InstComments.h"
+#include "MCTargetDesc/X86MCExpr.h"
 #include "MCTargetDesc/X86ShuffleDecode.h"
 #include "MCTargetDesc/X86TargetStreamer.h"
 #include "X86AsmPrinter.h"
@@ -232,7 +233,7 @@ MCOperand X86MCInstLower::LowerSymbolOperand(const MachineOperand &MO,
   // FIXME: We would like an efficient form for this, so we don't have to do a
   // lot of extra uniquing.
   const MCExpr *Expr = nullptr;
-  MCSymbolRefExpr::VariantKind RefKind = MCSymbolRefExpr::VK_None;
+  auto Specifier = X86MCExpr::VK_None;
 
   switch (MO.getTargetFlags()) {
   default:
@@ -245,61 +246,61 @@ MCOperand X86MCInstLower::LowerSymbolOperand(const MachineOperand &MO,
     break;
 
   case X86II::MO_TLVP:
-    RefKind = MCSymbolRefExpr::VK_TLVP;
+    Specifier = X86MCExpr::VK_TLVP;
     break;
   case X86II::MO_TLVP_PIC_BASE:
-    Expr = MCSymbolRefExpr::create(Sym, MCSymbolRefExpr::VK_TLVP, Ctx);
+    Expr = MCSymbolRefExpr::create(Sym, X86MCExpr::VK_TLVP, Ctx);
     // Subtract the pic base.
     Expr = MCBinaryExpr::createSub(
         Expr, MCSymbolRefExpr::create(MF.getPICBaseSymbol(), Ctx), Ctx);
     break;
   case X86II::MO_SECREL:
-    RefKind = MCSymbolRefExpr::VK_SECREL;
+    Specifier = X86MCExpr::Specifier(MCSymbolRefExpr::VK_SECREL);
     break;
   case X86II::MO_TLSGD:
-    RefKind = MCSymbolRefExpr::VK_TLSGD;
+    Specifier = X86MCExpr::VK_TLSGD;
     break;
   case X86II::MO_TLSLD:
-    RefKind = MCSymbolRefExpr::VK_TLSLD;
+    Specifier = X86MCExpr::VK_TLSLD;
     break;
   case X86II::MO_TLSLDM:
-    RefKind = MCSymbolRefExpr::VK_TLSLDM;
+    Specifier = X86MCExpr::VK_TLSLDM;
     break;
   case X86II::MO_GOTTPOFF:
-    RefKind = MCSymbolRefExpr::VK_GOTTPOFF;
+    Specifier = X86MCExpr::VK_GOTTPOFF;
     break;
   case X86II::MO_INDNTPOFF:
-    RefKind = MCSymbolRefExpr::VK_INDNTPOFF;
+    Specifier = X86MCExpr::VK_INDNTPOFF;
     break;
   case X86II::MO_TPOFF:
-    RefKind = MCSymbolRefExpr::VK_TPOFF;
+    Specifier = X86MCExpr::VK_TPOFF;
     break;
   case X86II::MO_DTPOFF:
-    RefKind = MCSymbolRefExpr::VK_DTPOFF;
+    Specifier = X86MCExpr::VK_DTPOFF;
     break;
   case X86II::MO_NTPOFF:
-    RefKind = MCSymbolRefExpr::VK_NTPOFF;
+    Specifier = X86MCExpr::VK_NTPOFF;
     break;
   case X86II::MO_GOTNTPOFF:
-    RefKind = MCSymbolRefExpr::VK_GOTNTPOFF;
+    Specifier = X86MCExpr::VK_GOTNTPOFF;
     break;
   case X86II::MO_GOTPCREL:
-    RefKind = MCSymbolRefExpr::VK_GOTPCREL;
+    Specifier = X86MCExpr::VK_GOTPCREL;
     break;
   case X86II::MO_GOTPCREL_NORELAX:
-    RefKind = MCSymbolRefExpr::VK_GOTPCREL_NORELAX;
+    Specifier = X86MCExpr::VK_GOTPCREL_NORELAX;
     break;
   case X86II::MO_GOT:
-    RefKind = MCSymbolRefExpr::VK_GOT;
+    Specifier = X86MCExpr::VK_GOT;
     break;
   case X86II::MO_GOTOFF:
-    RefKind = MCSymbolRefExpr::VK_GOTOFF;
+    Specifier = X86MCExpr::VK_GOTOFF;
     break;
   case X86II::MO_PLT:
-    RefKind = MCSymbolRefExpr::VK_PLT;
+    Specifier = X86MCExpr::VK_PLT;
     break;
   case X86II::MO_ABS8:
-    RefKind = MCSymbolRefExpr::VK_X86_ABS8;
+    Specifier = X86MCExpr::VK_ABS8;
     break;
   case X86II::MO_PIC_BASE_OFFSET:
   case X86II::MO_DARWIN_NONLAZY_PIC_BASE:
@@ -321,7 +322,7 @@ MCOperand X86MCInstLower::LowerSymbolOperand(const MachineOperand &MO,
   }
 
   if (!Expr)
-    Expr = MCSymbolRefExpr::create(Sym, RefKind, Ctx);
+    Expr = MCSymbolRefExpr::create(Sym, Specifier, Ctx);
 
   if (!MO.isJTI() && !MO.isMBB() && MO.getOffset())
     Expr = MCBinaryExpr::createAdd(
@@ -535,30 +536,30 @@ void X86AsmPrinter::LowerTlsAddr(X86MCInstLower &MCInstLowering,
   bool Is64BitsLP64 = getSubtarget().isTarget64BitLP64();
   MCContext &Ctx = OutStreamer->getContext();
 
-  MCSymbolRefExpr::VariantKind SRVK;
+  X86MCExpr::Specifier Specifier;
   switch (MI.getOpcode()) {
   case X86::TLS_addr32:
   case X86::TLS_addr64:
   case X86::TLS_addrX32:
-    SRVK = MCSymbolRefExpr::VK_TLSGD;
+    Specifier = X86MCExpr::VK_TLSGD;
     break;
   case X86::TLS_base_addr32:
-    SRVK = MCSymbolRefExpr::VK_TLSLDM;
+    Specifier = X86MCExpr::VK_TLSLDM;
     break;
   case X86::TLS_base_addr64:
   case X86::TLS_base_addrX32:
-    SRVK = MCSymbolRefExpr::VK_TLSLD;
+    Specifier = X86MCExpr::VK_TLSLD;
     break;
   case X86::TLS_desc32:
   case X86::TLS_desc64:
-    SRVK = MCSymbolRefExpr::VK_TLSDESC;
+    Specifier = X86MCExpr::VK_TLSDESC;
     break;
   default:
     llvm_unreachable("unexpected opcode");
   }
 
   const MCSymbolRefExpr *Sym = MCSymbolRefExpr::create(
-      MCInstLowering.GetSymbolFromOperand(MI.getOperand(3)), SRVK, Ctx);
+      MCInstLowering.GetSymbolFromOperand(MI.getOperand(3)), Specifier, Ctx);
 
   // Before binutils 2.41, ld has a bogus TLS relaxation error when the GD/LD
   // code sequence using R_X86_64_GOTPCREL (instead of R_X86_64_GOTPCRELX) is
@@ -568,10 +569,10 @@ void X86AsmPrinter::LowerTlsAddr(X86MCInstLower &MCInstLowering,
   bool UseGot = MMI->getModule()->getRtLibUseGOT() &&
                 Ctx.getTargetOptions()->X86RelaxRelocations;
 
-  if (SRVK == MCSymbolRefExpr::VK_TLSDESC) {
+  if (Specifier == X86MCExpr::VK_TLSDESC) {
     const MCSymbolRefExpr *Expr = MCSymbolRefExpr::create(
         MCInstLowering.GetSymbolFromOperand(MI.getOperand(3)),
-        MCSymbolRefExpr::VK_TLSCALL, Ctx);
+        X86MCExpr::VK_TLSCALL, Ctx);
     EmitAndCountInstruction(
         MCInstBuilder(Is64BitsLP64 ? X86::LEA64r : X86::LEA32r)
             .addReg(Is64BitsLP64 ? X86::RAX : X86::EAX)
@@ -588,7 +589,7 @@ void X86AsmPrinter::LowerTlsAddr(X86MCInstLower &MCInstLowering,
             .addExpr(Expr)
             .addReg(0));
   } else if (Is64Bits) {
-    bool NeedsPadding = SRVK == MCSymbolRefExpr::VK_TLSGD;
+    bool NeedsPadding = Specifier == X86MCExpr::VK_TLSGD;
     if (NeedsPadding && Is64BitsLP64)
       EmitAndCountInstruction(MCInstBuilder(X86::DATA16_PREFIX));
     EmitAndCountInstruction(MCInstBuilder(X86::LEA64r)
@@ -606,8 +607,8 @@ void X86AsmPrinter::LowerTlsAddr(X86MCInstLower &MCInstLowering,
       EmitAndCountInstruction(MCInstBuilder(X86::REX64_PREFIX));
     }
     if (UseGot) {
-      const MCExpr *Expr = MCSymbolRefExpr::create(
-          TlsGetAddr, MCSymbolRefExpr::VK_GOTPCREL, Ctx);
+      const MCExpr *Expr =
+          MCSymbolRefExpr::create(TlsGetAddr, X86MCExpr::VK_GOTPCREL, Ctx);
       EmitAndCountInstruction(MCInstBuilder(X86::CALL64m)
                                   .addReg(X86::RIP)
                                   .addImm(1)
@@ -615,13 +616,12 @@ void X86AsmPrinter::LowerTlsAddr(X86MCInstLower &MCInstLowering,
                                   .addExpr(Expr)
                                   .addReg(0));
     } else {
-      EmitAndCountInstruction(
-          MCInstBuilder(X86::CALL64pcrel32)
-              .addExpr(MCSymbolRefExpr::create(TlsGetAddr,
-                                               MCSymbolRefExpr::VK_PLT, Ctx)));
+      EmitAndCountInstruction(MCInstBuilder(X86::CALL64pcrel32)
+                                  .addExpr(MCSymbolRefExpr::create(
+                                      TlsGetAddr, X86MCExpr::VK_PLT, Ctx)));
     }
   } else {
-    if (SRVK == MCSymbolRefExpr::VK_TLSGD && !UseGot) {
+    if (Specifier == X86MCExpr::VK_TLSGD && !UseGot) {
       EmitAndCountInstruction(MCInstBuilder(X86::LEA32r)
                                   .addReg(X86::EAX)
                                   .addReg(0)
@@ -642,7 +642,7 @@ void X86AsmPrinter::LowerTlsAddr(X86MCInstLower &MCInstLowering,
     const MCSymbol *TlsGetAddr = Ctx.getOrCreateSymbol("___tls_get_addr");
     if (UseGot) {
       const MCExpr *Expr =
-          MCSymbolRefExpr::create(TlsGetAddr, MCSymbolRefExpr::VK_GOT, Ctx);
+          MCSymbolRefExpr::create(TlsGetAddr, X86MCExpr::VK_GOT, Ctx);
       EmitAndCountInstruction(MCInstBuilder(X86::CALL32m)
                                   .addReg(X86::EBX)
                                   .addImm(1)
@@ -650,10 +650,9 @@ void X86AsmPrinter::LowerTlsAddr(X86MCInstLower &MCInstLowering,
                                   .addExpr(Expr)
                                   .addReg(0));
     } else {
-      EmitAndCountInstruction(
-          MCInstBuilder(X86::CALLpcrel32)
-              .addExpr(MCSymbolRefExpr::create(TlsGetAddr,
-                                               MCSymbolRefExpr::VK_PLT, Ctx)));
+      EmitAndCountInstruction(MCInstBuilder(X86::CALLpcrel32)
+                                  .addExpr(MCSymbolRefExpr::create(
+                                      TlsGetAddr, X86MCExpr::VK_PLT, Ctx)));
     }
   }
 }

--- a/llvm/lib/Target/X86/X86TargetObjectFile.cpp
+++ b/llvm/lib/Target/X86/X86TargetObjectFile.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "X86TargetObjectFile.h"
+#include "MCTargetDesc/X86MCExpr.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCValue.h"
@@ -24,7 +25,7 @@ const MCExpr *X86_64MachoTargetObjectFile::getTTypeGlobalReference(
   if ((Encoding & DW_EH_PE_indirect) && (Encoding & DW_EH_PE_pcrel)) {
     const MCSymbol *Sym = TM.getSymbol(GV);
     const MCExpr *Res =
-      MCSymbolRefExpr::create(Sym, MCSymbolRefExpr::VK_GOTPCREL, getContext());
+        MCSymbolRefExpr::create(Sym, X86MCExpr::VK_GOTPCREL, getContext());
     const MCExpr *Four = MCConstantExpr::create(4, getContext());
     return MCBinaryExpr::createAdd(Res, Four, getContext());
   }
@@ -47,14 +48,18 @@ const MCExpr *X86_64MachoTargetObjectFile::getIndirectSymViaGOTPCRel(
   // foo@GOTPCREL+4+<offset>.
   unsigned FinalOff = Offset+MV.getConstant()+4;
   const MCExpr *Res =
-    MCSymbolRefExpr::create(Sym, MCSymbolRefExpr::VK_GOTPCREL, getContext());
+      MCSymbolRefExpr::create(Sym, X86MCExpr::VK_GOTPCREL, getContext());
   const MCExpr *Off = MCConstantExpr::create(FinalOff, getContext());
   return MCBinaryExpr::createAdd(Res, Off, getContext());
 }
 
+X86ELFTargetObjectFile::X86ELFTargetObjectFile() {
+  PLTRelativeVariantKind = MCSymbolRefExpr::VariantKind(X86MCExpr::VK_PLT);
+}
+
 const MCExpr *X86ELFTargetObjectFile::getDebugThreadLocalSymbol(
     const MCSymbol *Sym) const {
-  return MCSymbolRefExpr::create(Sym, MCSymbolRefExpr::VK_DTPOFF, getContext());
+  return MCSymbolRefExpr::create(Sym, X86MCExpr::VK_DTPOFF, getContext());
 }
 
 const MCExpr *X86_64ELFTargetObjectFile::getIndirectSymViaGOTPCRel(
@@ -62,7 +67,7 @@ const MCExpr *X86_64ELFTargetObjectFile::getIndirectSymViaGOTPCRel(
     int64_t Offset, MachineModuleInfo *MMI, MCStreamer &Streamer) const {
   int64_t FinalOffset = Offset + MV.getConstant();
   const MCExpr *Res =
-      MCSymbolRefExpr::create(Sym, MCSymbolRefExpr::VK_GOTPCREL, getContext());
+      MCSymbolRefExpr::create(Sym, X86MCExpr::VK_GOTPCREL, getContext());
   const MCExpr *Off = MCConstantExpr::create(FinalOffset, getContext());
   return MCBinaryExpr::createAdd(Res, Off, getContext());
 }

--- a/llvm/lib/Target/X86/X86TargetObjectFile.h
+++ b/llvm/lib/Target/X86/X86TargetObjectFile.h
@@ -40,9 +40,7 @@ namespace llvm {
   /// specialization (and as a base class for X86_64, which does).
   class X86ELFTargetObjectFile : public TargetLoweringObjectFileELF {
   public:
-    X86ELFTargetObjectFile() {
-      PLTRelativeVariantKind = MCSymbolRefExpr::VK_PLT;
-    }
+    X86ELFTargetObjectFile();
     /// Describe a TLS variable address within debug info.
     const MCExpr *getDebugThreadLocalSymbol(const MCSymbol *Sym) const override;
   };


### PR DESCRIPTION
Move target-specific members outside of MCSymbolRefExpr::VariantKind
(a legacy interface I am eliminating). Most changes are mechanic,
except:

* ELFObjectWriter::shouldRelocateWithSymbol
* The legacy generic code uses `ELFObjectWriter::fixSymbolsInTLSFixups`
  to set `STT_TLS` (and use an unnecessary expression walk). The better
  way is to do this in `getRelocType`, which I have done for
  AArch64, PowerPC, and RISC-V.

In the future, we should encode expressions with a relocation specifier
as X86MCExpr and use MCValue::RefKind to hold the specifier of the
relocatable expression.
https://maskray.me/blog/2025-03-16-relocation-generation-in-assemblers

While here, rename "Modifier' to "Specifier":

> "Relocation modifier", though concise, suggests adjustments happen during the linker's relocation step rather than the assembler's expression evaluation. I landed on "relocation specifier" as the winner. It's clear, aligns with Arm and IBM’s usage, and fits the assembler's role seamlessly.
