### PR TITLE
[libc][docs] Add dirent implementation status doc and include in CMakeLists

### DIFF
--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -39,6 +39,7 @@ if (SPHINX_FOUND)
       assert
       cpio
       ctype
+      dirent
       endian
       errno
       fenv
@@ -62,12 +63,12 @@ if (SPHINX_FOUND)
       sys/stat
       sys/statvfs
       sys/time
+      sys/utsname
       sys/wait
       termios
       threads
       uchar
       unistd
-      sys/utsname
       wchar
       wctype
     )

--- a/libc/docs/headers/index.rst
+++ b/libc/docs/headers/index.rst
@@ -10,6 +10,7 @@ Implementation Status
    complex
    cpio
    ctype
+   dirent
    endian
    errno
    fenv
@@ -34,13 +35,13 @@ Implementation Status
    sys/stat
    sys/statvfs
    sys/time
+   sys/utsname
    sys/wait
    termios
    threads
    time
    uchar
    unistd
-   sys/utsname
    wchar
    wctype
 ..

--- a/libc/utils/docgen/dirent.yaml
+++ b/libc/utils/docgen/dirent.yaml
@@ -1,0 +1,51 @@
+macros:
+  DT_BLK:
+    in-latest-posix: ''
+  DT_CHR:
+    in-latest-posix: ''
+  DT_DIR:
+    in-latest-posix: ''
+  DT_FIFO:
+    in-latest-posix: ''
+  DT_LNK:
+    in-latest-posix: ''
+  DT_REG:
+    in-latest-posix: ''
+  DT_SOCK:
+    in-latest-posix: ''
+  DT_UNKNOWN:
+    in-latest-posix: ''
+  DT_MQ:
+    in-latest-posix: ''
+  DT_SEM:
+    in-latest-posix: ''
+  DT_SHM:
+    in-latest-posix: ''
+  DT_TMO:
+    in-latest-posix: ''
+
+functions:
+  alphasort:
+    in-latest-posix: ''
+  closedir:
+    in-latest-posix: ''
+  dirfd:
+    in-latest-posix: ''
+  fdopendir:
+    in-latest-posix: ''
+  opendir:
+    in-latest-posix: ''
+  posix_getdents:
+    in-latest-posix: ''
+  readdir:
+    in-latest-posix: ''
+  readdir_r:
+    in-latest-posix: ''
+  rewinddir:
+    in-latest-posix: ''
+  scandir:
+    in-latest-posix: ''
+  seekdir:
+    in-latest-posix: ''
+  telldir:
+    in-latest-posix: ''


### PR DESCRIPTION
These changes tracks `dirent.h` for the implementation status of functions and macros, with respect to the issue ( https://github.com/llvm/llvm-project/issues/122006 ). 
