### PR TITLE
[AArch64] Always add PURECODE flag to empty .text if "+execute-only" is set

### DIFF
--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFStreamer.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFStreamer.cpp
@@ -27,6 +27,7 @@
 #include "llvm/MC/MCELFStreamer.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCObjectFileInfo.h"
 #include "llvm/MC/MCSectionELF.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSubtargetInfo.h"
@@ -498,6 +499,23 @@ void AArch64TargetELFStreamer::finish() {
       for (auto &F : S.getWriter().getFileNames())
         F.second += llvm::lower_bound(Idx, F.second) - Idx.begin();
     }
+  }
+
+  // The mix of execute-only and non-execute-only at link time is
+  // non-execute-only. To avoid the empty implicitly created .text
+  // section from making the whole .text section non-execute-only, we
+  // mark it execute-only if it is empty and there is at least one
+  // execute-only section in the object.
+  if (any_of(Asm, [](const MCSection &Sec) {
+        return cast<MCSectionELF>(Sec).getFlags() & ELF::SHF_AARCH64_PURECODE;
+      })) {
+    auto *Text =
+        static_cast<MCSectionELF *>(Ctx.getObjectFileInfo()->getTextSection());
+    for (auto &F : *Text)
+      if (auto *DF = dyn_cast<MCDataFragment>(&F))
+        if (!DF->getContents().empty())
+          return;
+    Text->setFlags(Text->getFlags() | ELF::SHF_AARCH64_PURECODE);
   }
 
   MCSectionELF *MemtagSec = nullptr;

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFStreamer.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFStreamer.cpp
@@ -27,7 +27,6 @@
 #include "llvm/MC/MCELFStreamer.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCInst.h"
-#include "llvm/MC/MCObjectFileInfo.h"
 #include "llvm/MC/MCSectionELF.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSubtargetInfo.h"
@@ -499,23 +498,6 @@ void AArch64TargetELFStreamer::finish() {
       for (auto &F : S.getWriter().getFileNames())
         F.second += llvm::lower_bound(Idx, F.second) - Idx.begin();
     }
-  }
-
-  // The mix of execute-only and non-execute-only at link time is
-  // non-execute-only. To avoid the empty implicitly created .text
-  // section from making the whole .text section non-execute-only, we
-  // mark it execute-only if it is empty and there is at least one
-  // execute-only section in the object.
-  if (any_of(Asm, [](const MCSection &Sec) {
-        return cast<MCSectionELF>(Sec).getFlags() & ELF::SHF_AARCH64_PURECODE;
-      })) {
-    auto *Text =
-        static_cast<MCSectionELF *>(Ctx.getObjectFileInfo()->getTextSection());
-    for (auto &F : *Text)
-      if (auto *DF = dyn_cast<MCDataFragment>(&F))
-        if (!DF->getContents().empty())
-          return;
-    Text->setFlags(Text->getFlags() | ELF::SHF_AARCH64_PURECODE);
   }
 
   MCSectionELF *MemtagSec = nullptr;

--- a/llvm/test/CodeGen/AArch64/execute-only-empty.ll
+++ b/llvm/test/CodeGen/AArch64/execute-only-empty.ll
@@ -1,0 +1,13 @@
+; RUN: llc -filetype=obj -mtriple=aarch64 -mattr=+execute-only %s -o %t.o
+; RUN: llvm-readobj -S %t.o | FileCheck %s
+
+; CHECK:         Name: .text
+; CHECK-NEXT:    Type: SHT_PROGBITS
+; CHECK-NEXT:    Flags [
+; CHECK-NEXT:      SHF_AARCH64_PURECODE
+; CHECK-NEXT:      SHF_ALLOC
+; CHECK-NEXT:      SHF_EXECINSTR
+; CHECK-NEXT:    ]
+; CHECK-NEXT:    Address:
+; CHECK-NEXT:    Offset:
+; CHECK-NEXT:    Size: 0


### PR DESCRIPTION
Previously, the `SHF_AARCH64_PURECODE` section flag wasn't added to the implicitly created `.text` section if the module didn't contain any functions, because no other section had the flag set.

Now, the `SHF_AARCH64_PURECODE` is always added if the "+execute-only" target feature is set for the module during compilation.