### PR TITLE
[RISCV] Add Qualcomn uC Xqcisync Synchronization And Delay Extension

### DIFF
--- a/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
+++ b/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
@@ -663,14 +663,15 @@ static constexpr FeatureBitset XRivosFeatureGroup = {
 };
 
 static constexpr FeatureBitset XqciFeatureGroup = {
-    RISCV::FeatureVendorXqcia,   RISCV::FeatureVendorXqciac,
-    RISCV::FeatureVendorXqcibi,  RISCV::FeatureVendorXqcibm,
-    RISCV::FeatureVendorXqcicli, RISCV::FeatureVendorXqcicm,
-    RISCV::FeatureVendorXqcics,  RISCV::FeatureVendorXqcicsr,
-    RISCV::FeatureVendorXqciint, RISCV::FeatureVendorXqcilb,
-    RISCV::FeatureVendorXqcili,  RISCV::FeatureVendorXqcilia,
-    RISCV::FeatureVendorXqcilo,  RISCV::FeatureVendorXqcilsm,
-    RISCV::FeatureVendorXqcisim, RISCV::FeatureVendorXqcisls,
+    RISCV::FeatureVendorXqcia,    RISCV::FeatureVendorXqciac,
+    RISCV::FeatureVendorXqcibi,   RISCV::FeatureVendorXqcibm,
+    RISCV::FeatureVendorXqcicli,  RISCV::FeatureVendorXqcicm,
+    RISCV::FeatureVendorXqcics,   RISCV::FeatureVendorXqcicsr,
+    RISCV::FeatureVendorXqciint,  RISCV::FeatureVendorXqcilb,
+    RISCV::FeatureVendorXqcili,   RISCV::FeatureVendorXqcilia,
+    RISCV::FeatureVendorXqcilo,   RISCV::FeatureVendorXqcilsm,
+    RISCV::FeatureVendorXqcisim,  RISCV::FeatureVendorXqcisls,
+    RISCV::FeatureVendorXqcisync,
 };
 
 static constexpr FeatureBitset XSfVectorGroup = {

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -1422,6 +1422,14 @@ def HasVendorXqcilo
       AssemblerPredicate<(all_of FeatureVendorXqcilo),
                          "'Xqcilo' (Qualcomm uC Large Offset Load Store Extension)">;
 
+def FeatureVendorXqcisync
+    : RISCVExperimentalExtension<0, 2, "Qualcomm uC Synchronization And Delay Extension">;
+
+def HasVendorXqcisync
+    : Predicate<"Subtarget->hasVendorXqcisync()">,
+      AssemblerPredicate<(all_of FeatureVendorXqcisync),
+                         "'Xqcisync' (Qualcomm uC Synchronization And Delay Extension)">;
+
 def FeatureVendorXqccmp
     : RISCVExperimentalExtension<0, 1,
                                  "Qualcomm 16-bit Push/Pop and Double Moves",

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
@@ -446,6 +446,24 @@ class QCIRVInst48EJ<bits<2> func2, string opcodestr>
   let Inst{6-0} = 0b0011111;
 }
 
+class QCIRVInstCSync<bits<6> func1, string opcodestr>
+    : RVInst16<(outs), (ins uimm3:$slist), opcodestr,
+               "$slist", [], InstFormatCB> {
+  bits<3> slist;
+  let Inst{15-10} = func1;
+  let Inst{9-7} = slist{2-0};
+  let Inst{6-0} = 0b0000001;
+}
+
+class QCIRVInstSync<bits<7> func1, string opcodestr>
+    : RVInst<(outs), (ins uimm5:$imm), opcodestr,
+               "$imm", [], InstFormatI> {
+  bits<5> imm;
+  let Inst{31-25} = func1;
+  let Inst{24-20} = imm{4-0};
+  let Inst{19-0} = 0b00000011000000010011;
+}
+
 //===----------------------------------------------------------------------===//
 // Instructions
 //===----------------------------------------------------------------------===//
@@ -778,6 +796,27 @@ let mayLoad = 0, mayStore = 0, hasSideEffects = 1 in {
   }
 } // mayLoad = 0, mayStore = 0, hasSideEffects = 1
 } // Predicates = [HasVendorXqcisim, IsRV32]
+
+let Predicates = [HasVendorXqcisync, IsRV32] in {
+let mayLoad = 0, mayStore = 0, hasSideEffects = 1 in {
+  def QC_C_DELAY : RVInst16<(outs), (ins uimm5nonzero:$imm), "qc.c.delay",
+                            "$imm", [], InstFormatCI> {
+    bits<5> imm;
+    let Inst{15-7} = 0b000000000;
+    let Inst{6-2} = imm{4-0};
+    let Inst{1-0} = 0b10;
+  }
+  def QC_C_SYNC : QCIRVInstCSync<0b100000, "qc.c.sync">;
+  def QC_C_SYNCR : QCIRVInstCSync<0b100001, "qc.c.syncr">;
+  def QC_C_SYNCWF: QCIRVInstCSync<0b100100, "qc.c.syncwf">;
+  def QC_C_SYNCWL: QCIRVInstCSync<0b100101, "qc.c.syncwl">;
+  def QC_SYNC: QCIRVInstSync<0b0001000, "qc.sync">;
+  def QC_SYNCR: QCIRVInstSync<0b0010000, "qc.syncr">;
+  def QC_SYNCWF: QCIRVInstSync<0b0100000, "qc.syncwf">;
+  def QC_SYNCWL: QCIRVInstSync<0b1000000, "qc.syncwl">;
+
+} // mayLoad = 0, mayStore = 0, hasSideEffects = 1
+} // Predicates = [HasVendorXqcisync, IsRV32]
 
 } // DecoderNamespace = "Xqci"
 

--- a/llvm/lib/TargetParser/RISCVISAInfo.cpp
+++ b/llvm/lib/TargetParser/RISCVISAInfo.cpp
@@ -747,7 +747,7 @@ Error RISCVISAInfo::checkDependency() {
       {"xqcia"},   {"xqciac"},  {"xqcibi"},  {"xqcibm"},
       {"xqcicli"}, {"xqcicm"},  {"xqcics"},  {"xqcicsr"},
       {"xqciint"}, {"xqcilb"},  {"xqcili"},  {"xqcilia"},
-      {"xqcilo"},  {"xqcilsm"}, {"xqcisim"}, {"xqcisls"}};
+      {"xqcilo"},  {"xqcilsm"}, {"xqcisim"}, {"xqcisls"},{"xqcisync"}};
   static constexpr StringLiteral ZcdOverlaps[] = {
       {"zcmt"}, {"zcmp"}, {"xqccmp"}, {"xqciac"}, {"xqcicm"}};
 

--- a/llvm/test/CodeGen/RISCV/attributes.ll
+++ b/llvm/test/CodeGen/RISCV/attributes.ll
@@ -426,6 +426,7 @@
 ; RV32XQCILSM: .attribute 5, "rv32i2p1_xqcilsm0p2"
 ; RV32XQCISIM: attribute 5, "rv32i2p1_zca1p0_xqcisim0p2"
 ; RV32XQCISLS: .attribute 5, "rv32i2p1_xqcisls0p2"
+; RV32XQCISYNC: .attribute 5, "rv32i2p1_zca1p0_xqcisync0p2"
 ; RV32ZAAMO: .attribute 5, "rv32i2p1_zaamo1p0"
 ; RV32ZALRSC: .attribute 5, "rv32i2p1_zalrsc1p0"
 ; RV32ZCA: .attribute 5, "rv32i2p1_zca1p0"

--- a/llvm/test/MC/RISCV/xqcisync-invalid.s
+++ b/llvm/test/MC/RISCV/xqcisync-invalid.s
@@ -1,0 +1,101 @@
+# Xqcisync - Qualcomm uC Synchronization And Delay Extension
+# RUN: not llvm-mc -triple riscv32 -mattr=+experimental-xqcisync < %s 2>&1 \
+# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-PLUS,CHECK-IMM %s
+# RUN: not llvm-mc -triple riscv32 -mattr=-experimental-xqcisync < %s 2>&1 \
+# RUN:     | FileCheck -check-prefixes=CHECK,CHECK-MINUS,CHECK-EXT %s
+
+# CHECK-PLUS: :[[@LINE+2]]:12: error: immediate must be an integer in the range [1, 31]
+# CHECK-MINUS: :[[@LINE+1]]:12: error: invalid operand for instruction
+qc.c.delay 0
+
+# CHECK: :[[@LINE+1]]:1: error: too few operands for instruction
+qc.c.delay
+
+# CHECK-IMM: :[[@LINE+1]]:12: error: immediate must be an integer in the range [1, 31]
+qc.c.delay 32
+
+# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Synchronization And Delay Extension)
+qc.c.delay 5
+
+# CHECK-PLUS: :[[@LINE+2]]:11: error: immediate must be an integer in the range [0, 7]
+# CHECK-MINUS: :[[@LINE+1]]:11: error: invalid operand for instruction
+qc.c.sync 8
+
+# CHECK: :[[@LINE+1]]:1: error: too few operands for instruction
+qc.c.sync
+
+# CHECK-IMM: :[[@LINE+1]]:11: error: immediate must be an integer in the range [0, 7]
+qc.c.sync -1
+
+# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Synchronization And Delay Extension)
+qc.c.sync 3
+
+# CHECK-PLUS: :[[@LINE+2]]:12: error: immediate must be an integer in the range [0, 7]
+# CHECK-MINUS: :[[@LINE+1]]:12: error: invalid operand for instruction
+qc.c.syncr 10
+
+# CHECK: :[[@LINE+1]]:1: error: too few operands for instruction
+qc.c.syncr
+
+# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Synchronization And Delay Extension)
+qc.c.syncr 3
+
+# CHECK-PLUS: :[[@LINE+2]]:13: error: immediate must be an integer in the range [0, 7]
+# CHECK-MINUS: :[[@LINE+1]]:13: error: invalid operand for instruction
+qc.c.syncwf 8
+
+# CHECK: :[[@LINE+1]]:1: error: too few operands for instruction
+qc.c.syncwf
+
+# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Synchronization And Delay Extension)
+qc.c.syncwf 5
+
+# CHECK-PLUS: :[[@LINE+2]]:13: error: immediate must be an integer in the range [0, 7]
+# CHECK-MINUS: :[[@LINE+1]]:13: error: invalid operand for instruction
+qc.c.syncwl 8
+
+# CHECK: :[[@LINE+1]]:1: error: too few operands for instruction
+qc.c.syncwl
+
+# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Synchronization And Delay Extension)
+qc.c.syncwl 7
+
+# CHECK-PLUS: :[[@LINE+2]]:9: error: immediate must be an integer in the range [0, 31]
+# CHECK-MINUS: :[[@LINE+1]]:9: error: invalid operand for instruction
+qc.sync 32
+
+# CHECK: :[[@LINE+1]]:1: error: too few operands for instruction
+qc.sync
+
+# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Synchronization And Delay Extension)
+qc.sync 10
+
+# CHECK-PLUS: :[[@LINE+2]]:10: error: immediate must be an integer in the range [0, 31]
+# CHECK-MINUS: :[[@LINE+1]]:10: error: invalid operand for instruction
+qc.syncr -1
+
+# CHECK: :[[@LINE+1]]:1: error: too few operands for instruction
+qc.syncr
+
+# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Synchronization And Delay Extension)
+qc.syncr 10
+
+# CHECK-PLUS: :[[@LINE+2]]:11: error: immediate must be an integer in the range [0, 31]
+# CHECK-MINUS: :[[@LINE+1]]:11: error: invalid operand for instruction
+qc.syncwf 33
+
+# CHECK: :[[@LINE+1]]:1: error: too few operands for instruction
+qc.syncwf
+
+# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Synchronization And Delay Extension)
+qc.syncwf 10
+
+# CHECK-PLUS: :[[@LINE+2]]:11: error: immediate must be an integer in the range [0, 31]
+# CHECK-MINUS: :[[@LINE+1]]:11: error: invalid operand for instruction
+qc.syncwl -1
+
+# CHECK: :[[@LINE+1]]:1: error: too few operands for instruction
+qc.syncwl
+
+# CHECK-EXT: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcisync' (Qualcomm uC Synchronization And Delay Extension)
+qc.syncwl 10

--- a/llvm/test/MC/RISCV/xqcisync-valid.s
+++ b/llvm/test/MC/RISCV/xqcisync-valid.s
@@ -1,0 +1,42 @@
+# Xqcisync - Qualcomm uC Synchronization And Delay Extension
+# RUN: llvm-mc -triple=riscv32 -mattr=+experimental-xqcisync < %s -show-encoding \
+# RUN:     | FileCheck -check-prefixes=CHECK-ENC,CHECK-INST %s
+# RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+experimental-xqcisync < %s \
+# RUN:     | llvm-objdump --mattr=+experimental-xqcisync --no-print-imm-hex -d - \
+# RUN:     | FileCheck -check-prefix=CHECK-INST %s
+
+# CHECK-INST: qc.c.delay 5
+# CHECK-ENC: encoding: [0x16,0x00]
+qc.c.delay 5
+
+# CHECK-INST: qc.c.sync 3
+# CHECK-ENC: encoding: [0x81,0x81]
+qc.c.sync 3
+
+# CHECK-INST: qc.c.syncr 3
+# CHECK-ENC: encoding: [0x81,0x85]
+qc.c.syncr 3
+
+# CHECK-INST: qc.c.syncwf 5
+# CHECK-ENC: encoding: [0x81,0x92]
+qc.c.syncwf 5
+
+# CHECK-INST: qc.c.syncwl 7
+# CHECK-ENC: encoding: [0x81,0x97]
+qc.c.syncwl 7
+
+# CHECK-INST: qc.sync 10
+# CHECK-ENC: encoding: [0x13,0x30,0xa0,0x10]
+qc.sync 10
+
+# CHECK-INST: qc.syncr 10
+# CHECK-ENC: encoding: [0x13,0x30,0xa0,0x20]
+qc.syncr 10
+
+# CHECK-INST: qc.syncwf 10
+# CHECK-ENC: encoding: [0x13,0x30,0xa0,0x40]
+qc.syncwf 10
+
+# CHECK-INST: qc.syncwl 10
+# CHECK-ENC: encoding: [0x13,0x30,0xa0,0x80]
+qc.syncwl 10


### PR DESCRIPTION
The Xqcisync extension includes nine instructions, eight for non-memory-mapped devices synchronization and delay instruction. Synchronization instructions are kind of IO fences that work with special devices synchronization signals

The current spec can be found at: https://github.com/quic/riscv-unified-db/releases/tag/Xqci-0.7.0

This patch adds assembler only support.