### PR TITLE
[ARM] Fix undefined behavior in `isLegalAddImmediate`

### DIFF
--- a/llvm/include/llvm/Support/MathExtras.h
+++ b/llvm/include/llvm/Support/MathExtras.h
@@ -595,6 +595,15 @@ inline int64_t SignExtend64(uint64_t X, unsigned B) {
   return int64_t(X << (64 - B)) >> (64 - B);
 }
 
+/// Return the absolute value of a signed integer, converted to the
+/// corresponding unsigned integer type. Avoids undefined behavior in std::abs
+/// when you pass it INT_MIN or similar.
+template <typename T, typename U = std::make_unsigned_t<T>>
+constexpr U AbsoluteValue(T X) {
+  // If X is negative, cast it to the unsigned type _before_ negating it.
+  return X < 0 ? -static_cast<U>(X) : X;
+}
+
 /// Subtract two unsigned integers, X and Y, of type T and return the absolute
 /// value of the result.
 template <typename U, typename V, typename T = common_uint<U, V>>

--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -19691,7 +19691,7 @@ bool ARMTargetLowering::isLegalICmpImmediate(int64_t Imm) const {
 /// immediate into a register.
 bool ARMTargetLowering::isLegalAddImmediate(int64_t Imm) const {
   // Same encoding for add/sub, just flip the sign.
-  int64_t AbsImm = std::abs(Imm);
+  uint64_t AbsImm = AbsoluteValue(Imm);
   if (!Subtarget->isThumb())
     return ARM_AM::getSOImmVal(AbsImm) != -1;
   if (Subtarget->isThumb2())


### PR DESCRIPTION
Building clang under UBsan, it reported an integer overflow in this function when the input value was -2^63, because it's UB to pass the maximum negative value of an integer type to `std::abs`.

Fixed by adding a new absolute-value function in `MathExtras.h` whose return type is the unsigned version of the argument type, and using that instead.

(This seems like the kind of thing C++ should have already had, but apparently it doesn't, and I couldn't find an existing one in LLVM Support either.)