### PR TITLE
[LLD][AArch64] Mark .plt with PURECODE flag if all input sections also have it

### DIFF
--- a/lld/test/ELF/aarch64-execute-only-plt.s
+++ b/lld/test/ELF/aarch64-execute-only-plt.s
@@ -2,60 +2,33 @@
 // RUN: rm -rf %t && split-file %s %t && cd %t
 
 // RUN: llvm-mc -filetype=obj -triple=aarch64 start.s -o start.o
-// RUN: llvm-mc -filetype=obj -triple=aarch64 foo-xo-same-section.s -o foo-xo-same-section.o
-// RUN: llvm-mc -filetype=obj -triple=aarch64 foo-rx-same-section.s -o foo-rx-same-section.o
-// RUN: llvm-mc -filetype=obj -triple=aarch64 foo-xo-different-section.s -o foo-xo-different-section.o
-// RUN: llvm-mc -filetype=obj -triple=aarch64 foo-rx-different-section.s -o foo-rx-different-section.o
+// RUN: llvm-mc -filetype=obj -triple=aarch64 xo-same-section.s -o xo-same-section.o
+// RUN: llvm-mc -filetype=obj -triple=aarch64 rx-same-section.s -o rx-same-section.o
+// RUN: llvm-mc -filetype=obj -triple=aarch64 xo-different-section.s -o xo-different-section.o
+// RUN: llvm-mc -filetype=obj -triple=aarch64 rx-different-section.s -o rx-different-section.o
 // RUN: llvm-mc -filetype=obj -triple=aarch64 %p/Inputs/plt-aarch64.s -o plt.o
 // RUN: ld.lld -shared plt.o -soname=t2.so -o plt.so
-// RUN: ld.lld start.o foo-xo-same-section.o plt.so -o xo-same-section
-// RUN: ld.lld start.o foo-rx-same-section.o plt.so -o rx-same-section
-// RUN: ld.lld start.o foo-xo-different-section.o plt.so -o xo-different-section
-// RUN: ld.lld start.o foo-rx-different-section.o plt.so -o rx-different-section
-// RUN: llvm-readobj -S -l xo-same-section | FileCheck --check-prefix=CHECK-XO %s
-// RUN: llvm-readobj -S -l rx-same-section | FileCheck --check-prefix=CHECK-RX %s
-// RUN: llvm-readobj -S -l xo-different-section | FileCheck --check-prefix=CHECK-XO %s
-// RUN: llvm-readobj -S -l rx-different-section | FileCheck --check-prefix=CHECK-RX %s
+// RUN: ld.lld start.o xo-same-section.o plt.so -o xo-same-section
+// RUN: ld.lld start.o rx-same-section.o plt.so -o rx-same-section
+// RUN: ld.lld start.o xo-different-section.o plt.so -o xo-different-section
+// RUN: ld.lld start.o rx-different-section.o plt.so -o rx-different-section
+// RUN: llvm-readelf -S -l xo-same-section | FileCheck --check-prefix=CHECK-XO %s
+// RUN: llvm-readelf -S -l rx-same-section | FileCheck --check-prefix=CHECK-RX %s
+// RUN: llvm-readelf -S -l xo-different-section | FileCheck --check-prefix=CHECK-XO %s
+// RUN: llvm-readelf -S -l rx-different-section | FileCheck --check-prefix=CHECK-RX %s
 // RUN: llvm-objdump -d --no-show-raw-insn xo-same-section | FileCheck --check-prefix=DISASM %s
 // RUN: llvm-objdump -d --no-show-raw-insn rx-same-section | FileCheck --check-prefix=DISASM %s
 // RUN: llvm-objdump -d --no-show-raw-insn xo-different-section | FileCheck --check-prefix=DISASM %s
 // RUN: llvm-objdump -d --no-show-raw-insn rx-different-section | FileCheck --check-prefix=DISASM %s
 
-// CHECK-XO:         Name: .plt
-// CHECK-XO-NEXT:    Type: SHT_PROGBITS
-// CHECK-XO-NEXT:    Flags [
-// CHECK-XO-NEXT:      SHF_AARCH64_PURECODE
-// CHECK-XO-NEXT:      SHF_ALLOC
-// CHECK-XO-NEXT:      SHF_EXECINSTR
-// CHECK-XO-NEXT:    ]
-// CHECK-XO-NEXT:    Address: 0x2102E0
+///          Name Type     Address          Off    Size   ES Flg Lk Inf Al
+// CHECK-XO: .plt PROGBITS 00000000002102e0 0002e0 000040 00 AXy  0   0 16
+// CHECK-RX: .plt PROGBITS 00000000002102e0 0002e0 000040 00  AX  0   0 16
 
 /// The address of .plt above should be within this program header.
-// CHECK-XO:         VirtualAddress: 0x2102C8
-// CHECK-XO-NEXT:    PhysicalAddress: 0x2102C8
-// CHECK-XO-NEXT:    FileSize: 88
-// CHECK-XO-NEXT:    MemSize: 88
-// CHECK-XO-NEXT:    Flags [
-// CHECK-XO-NEXT:      PF_X
-// CHECK-XO-NEXT:    ]
-
-// CHECK-RX:         Name: .plt
-// CHECK-RX-NEXT:    Type: SHT_PROGBITS
-// CHECK-RX-NEXT:    Flags [
-// CHECK-RX-NEXT:      SHF_ALLOC
-// CHECK-RX-NEXT:      SHF_EXECINSTR
-// CHECK-RX-NEXT:    ]
-// CHECK-RX-NEXT:    Address: 0x2102E0
-
-/// The address of .plt above should be within this program header.
-// CHECK-RX:         VirtualAddress: 0x2102C8
-// CHECK-RX-NEXT:    PhysicalAddress: 0x2102C8
-// CHECK-RX-NEXT:    FileSize: 88
-// CHECK-RX-NEXT:    MemSize: 88
-// CHECK-RX-NEXT:    Flags [
-// CHECK-RX-NEXT:      PF_R
-// CHECK-RX-NEXT:      PF_X
-// CHECK-RX-NEXT:    ]
+///          Type Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
+// CHECK-XO: LOAD 0x0002c8 0x00000000002102c8 0x00000000002102c8 0x000058 0x000058   E 0x10000
+// CHECK-RX: LOAD 0x0002c8 0x00000000002102c8 0x00000000002102c8 0x000058 0x000058 R E 0x10000
 
 // DISASM-LABEL: Disassembly of section .plt:
 // DISASM-LABEL: <.plt>:
@@ -90,25 +63,25 @@ _start:
   bl weak
   ret
 
-//--- foo-xo-same-section.s
+//--- xo-same-section.s
 .section .text,"axy",@progbits,unique,0
 .global foo
 foo:
   ret
 
-//--- foo-rx-same-section.s
+//--- rx-same-section.s
 .section .text,"ax",@progbits,unique,0
 .global foo
 foo:
   ret
 
-//--- foo-xo-different-section.s
+//--- xo-different-section.s
 .section .foo,"axy",@progbits,unique,0
 .global foo
 foo:
   ret
 
-//--- foo-rx-different-section.s
+//--- rx-different-section.s
 .section .foo,"ax",@progbits,unique,0
 .global foo
 foo:

--- a/lld/test/ELF/aarch64-execute-only-plt.s
+++ b/lld/test/ELF/aarch64-execute-only-plt.s
@@ -1,0 +1,115 @@
+// REQUIRES: aarch64
+// RUN: rm -rf %t && split-file %s %t && cd %t
+
+// RUN: llvm-mc -filetype=obj -triple=aarch64 start.s -o start.o
+// RUN: llvm-mc -filetype=obj -triple=aarch64 foo-xo-same-section.s -o foo-xo-same-section.o
+// RUN: llvm-mc -filetype=obj -triple=aarch64 foo-rx-same-section.s -o foo-rx-same-section.o
+// RUN: llvm-mc -filetype=obj -triple=aarch64 foo-xo-different-section.s -o foo-xo-different-section.o
+// RUN: llvm-mc -filetype=obj -triple=aarch64 foo-rx-different-section.s -o foo-rx-different-section.o
+// RUN: llvm-mc -filetype=obj -triple=aarch64 %p/Inputs/plt-aarch64.s -o plt.o
+// RUN: ld.lld -shared plt.o -soname=t2.so -o plt.so
+// RUN: ld.lld start.o foo-xo-same-section.o plt.so -o xo-same-section
+// RUN: ld.lld start.o foo-rx-same-section.o plt.so -o rx-same-section
+// RUN: ld.lld start.o foo-xo-different-section.o plt.so -o xo-different-section
+// RUN: ld.lld start.o foo-rx-different-section.o plt.so -o rx-different-section
+// RUN: llvm-readobj -S -l xo-same-section | FileCheck --check-prefix=CHECK-XO %s
+// RUN: llvm-readobj -S -l rx-same-section | FileCheck --check-prefix=CHECK-RX %s
+// RUN: llvm-readobj -S -l xo-different-section | FileCheck --check-prefix=CHECK-XO %s
+// RUN: llvm-readobj -S -l rx-different-section | FileCheck --check-prefix=CHECK-RX %s
+// RUN: llvm-objdump -d --no-show-raw-insn xo-same-section | FileCheck --check-prefix=DISASM %s
+// RUN: llvm-objdump -d --no-show-raw-insn rx-same-section | FileCheck --check-prefix=DISASM %s
+// RUN: llvm-objdump -d --no-show-raw-insn xo-different-section | FileCheck --check-prefix=DISASM %s
+// RUN: llvm-objdump -d --no-show-raw-insn rx-different-section | FileCheck --check-prefix=DISASM %s
+
+// CHECK-XO:         Name: .plt
+// CHECK-XO-NEXT:    Type: SHT_PROGBITS
+// CHECK-XO-NEXT:    Flags [
+// CHECK-XO-NEXT:      SHF_AARCH64_PURECODE
+// CHECK-XO-NEXT:      SHF_ALLOC
+// CHECK-XO-NEXT:      SHF_EXECINSTR
+// CHECK-XO-NEXT:    ]
+// CHECK-XO-NEXT:    Address: 0x2102E0
+
+/// The address of .plt above should be within this program header.
+// CHECK-XO:         VirtualAddress: 0x2102C8
+// CHECK-XO-NEXT:    PhysicalAddress: 0x2102C8
+// CHECK-XO-NEXT:    FileSize: 88
+// CHECK-XO-NEXT:    MemSize: 88
+// CHECK-XO-NEXT:    Flags [
+// CHECK-XO-NEXT:      PF_X
+// CHECK-XO-NEXT:    ]
+
+// CHECK-RX:         Name: .plt
+// CHECK-RX-NEXT:    Type: SHT_PROGBITS
+// CHECK-RX-NEXT:    Flags [
+// CHECK-RX-NEXT:      SHF_ALLOC
+// CHECK-RX-NEXT:      SHF_EXECINSTR
+// CHECK-RX-NEXT:    ]
+// CHECK-RX-NEXT:    Address: 0x2102E0
+
+/// The address of .plt above should be within this program header.
+// CHECK-RX:         VirtualAddress: 0x2102C8
+// CHECK-RX-NEXT:    PhysicalAddress: 0x2102C8
+// CHECK-RX-NEXT:    FileSize: 88
+// CHECK-RX-NEXT:    MemSize: 88
+// CHECK-RX-NEXT:    Flags [
+// CHECK-RX-NEXT:      PF_R
+// CHECK-RX-NEXT:      PF_X
+// CHECK-RX-NEXT:    ]
+
+// DISASM-LABEL: Disassembly of section .plt:
+// DISASM-LABEL: <.plt>:
+// DISASM-NEXT:  2102e0: stp  x16, x30, [sp, #-0x10]!
+// DISASM-NEXT:          adrp x16, 0x230000 <weak+0x230000>
+// DISASM-NEXT:          ldr  x17, [x16, #0x400]
+// DISASM-NEXT:          add  x16, x16, #0x400
+// DISASM-NEXT:          br   x17
+// DISASM-NEXT:          nop
+// DISASM-NEXT:          nop
+// DISASM-NEXT:          nop
+
+// DISASM-LABEL: <bar@plt>:
+// DISASM-NEXT:  210300: adrp x16, 0x230000 <weak+0x230000>
+// DISASM-NEXT:          ldr  x17, [x16, #0x408]
+// DISASM-NEXT:          add  x16, x16, #0x408
+// DISASM-NEXT:          br   x17
+
+// DISASM-LABEL: <weak@plt>:
+// DISASM-NEXT:  210310: adrp x16, 0x230000 <weak+0x230000>
+// DISASM-NEXT:          ldr  x17, [x16, #0x410]
+// DISASM-NEXT:          add  x16, x16, #0x410
+// DISASM-NEXT:          br   x17
+
+//--- start.s
+.section .text,"axy",@progbits,unique,0
+.global _start, foo, bar
+.weak weak
+_start:
+  bl foo
+  bl bar
+  bl weak
+  ret
+
+//--- foo-xo-same-section.s
+.section .text,"axy",@progbits,unique,0
+.global foo
+foo:
+  ret
+
+//--- foo-rx-same-section.s
+.section .text,"ax",@progbits,unique,0
+.global foo
+foo:
+  ret
+
+//--- foo-xo-different-section.s
+.section .foo,"axy",@progbits,unique,0
+.global foo
+foo:
+  ret
+
+//--- foo-rx-different-section.s
+.section .foo,"ax",@progbits,unique,0
+.global foo
+foo:
+  ret


### PR DESCRIPTION
Mark the synthetic `.plt` section with the `SHF_AARCH64_PURECODE` section flag if all executable input sections also have that flag.

Without this change, if we were to compile a binary with `-mexecute-only`, the final executable will only have `.plt` not marked with the section flag, causing it to be placed in a different load segment. This leads to an extra page's worth of memory usage unnecessarily when running the executable.

A similar issue happens if we always set the section flag on `.plt` and compile a binary without `-mexecute-only`, so the solution should match the `SHF_AARCH64_PURECODE` section flags between `.plt` and all other executable sections.