### PR TITLE
[Docs] Document freestanding requirements

### DIFF
--- a/clang/docs/CommandGuide/clang.rst
+++ b/clang/docs/CommandGuide/clang.rst
@@ -262,9 +262,10 @@ Language Selection and Mode Options
 .. option:: -ffreestanding
 
  Indicate that the file should be compiled for a freestanding, not a hosted,
- environment. Note that it is assumed that a freestanding environment will
- additionally provide `memcpy`, `memmove`, `memset` and `memcmp`
- implementations, as these are needed for efficient codegen for many programs.
+ environment. Note that a freestanding build still requires linking against a C
+ Standard Library which supports the freestanding interfaces for the specified
+ language mode and target environment. This includes functions like `memcpy`,
+ `memmove`, `memset` and `memcmp`.
 
 .. option:: -fno-builtin
 

--- a/clang/docs/CommandGuide/clang.rst
+++ b/clang/docs/CommandGuide/clang.rst
@@ -265,7 +265,7 @@ Language Selection and Mode Options
  environment. Note that a freestanding build still requires linking against a C
  Standard Library which supports the freestanding interfaces for the specified
  language mode and target environment. This includes functions like `memcpy`,
- `memmove`, `memset` and `memcmp`.
+ `memmove`, and `memset`.
 
 .. option:: -fno-builtin
 

--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -1082,7 +1082,7 @@ Passing the ``-ffreestanding`` flag causes Clang to build for a freestanding
 * builtin functions are disabled by default (``-fno-builtins``),
 * unwind tables are disabled by default 
   (``fno-asynchronous-unwind-tables -fno-unwind-tables``), and
-* allows ``main`` to be used as a regular symbol.
+* does not treat the global ``main`` function as a special function.
 
 An implementation of the following runtime library functions must always be
 provided with the usual semantics, as Clang will generate calls to them:

--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -1079,8 +1079,9 @@ Passing the ``-ffreestanding`` flag causes Clang to build for a freestanding
 (rather than a hosted) environment. The flag has the following effects:
 
 * the ``__STDC_HOSTED__`` predefined macro will expand to ``0``,
-* builtin functions are disabled (``-fno-builtins``),
-* unwind tables are disabled (``fno-asynchronous-unwind-tables -fno-unwind-tables``), and
+* builtin functions are disabled by default (``-fno-builtins``),
+* unwind tables are disabled by default 
+  (``fno-asynchronous-unwind-tables -fno-unwind-tables``), and
 * allows ``main`` to be used as a regular symbol.
 
 A freestanding environment is not one which has no C standard library support.

--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -1076,13 +1076,11 @@ Language and Target-Independent Features
 Freestanding Builds
 -------------------
 Passing the ``-ffreestanding`` flag causes Clang to build for a freestanding
-(rather than a hosted) environment. The ``__STDC_HOSTED__`` predefined macro
-will expand to ``0`` in a freestanding environment. In such an environment,
-execution of the program may happen without an operating system and so a
-startup function (e.g., ``main``) may not be automatically called, though file
-scope objects which need to run startup code (constructors in C++,
-``__attribute__((constructor))``, etc) are executed via implementation-defined
-means such as ``__cxx_global_var_init``.
+(rather than a hosted) environment. The flag has the following effects:
+
+* the ``__STDC_HOSTED__`` predefined macro will expand to ``0``,
+* builtin functions are disabled (``-fno-builtins``), and
+* unwind tables are disabled (``fno-asynchronous-unwind-tables -fno-unwind-tables``)
 
 A freestanding environment is not one which has no C standard library support.
 A conforming freestanding C standard library implementation is required. Clang
@@ -1093,9 +1091,8 @@ Clause 4 (Conformance) of the C standard. Additionally, Clang requires the
 following runtime interfaces to be provided:
 
   * `memcpy`,
-  * `memmove`,
-  * `memset`, and
-  * `memcmp`.
+  * `memmove`, and
+  * `memset`.
 
 Controlling Errors and Warnings
 -------------------------------

--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -1073,6 +1073,30 @@ inputs. Here is some example of ``$``-prefixed options:
 Language and Target-Independent Features
 ========================================
 
+Freestanding Builds
+-------------------
+Passing the ``-ffreestanding`` flag causes Clang to build for a freestanding
+(rather than a hosted) environment. The ``__STDC_HOSTED__`` predefined macro
+will expand to ``0`` in a freestanding environment. In such an environment,
+execution of the program may happen without an operating system and so a
+startup function (e.g., ``main``) may not be automatically called, though file
+scope objects which need to run startup code (constructors in C++,
+``__attribute__((constructor))``, etc) are executed via implementation-defined
+means such as ``__cxx_global_var_init``.
+
+A freestanding environment is not one which has no C standard library support.
+A conforming freestanding C standard library implementation is required. Clang
+supplies some of the header files needed for a freestanding execution, such as
+``<stdarg.h>``, ``<limits.h>``, ``<stdint.h>``, etc. However, Clang still
+requires the runtime freestanding library to provide the interfaces required by
+Clause 4 (Conformance) of the C standard. Additionally, Clang requires the
+following runtime interfaces to be provided:
+
+  * `memcpy`,
+  * `memmove`,
+  * `memset`, and
+  * `memcmp`.
+
 Controlling Errors and Warnings
 -------------------------------
 

--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -1084,17 +1084,23 @@ Passing the ``-ffreestanding`` flag causes Clang to build for a freestanding
   (``fno-asynchronous-unwind-tables -fno-unwind-tables``), and
 * allows ``main`` to be used as a regular symbol.
 
-A freestanding environment is not one which has no C standard library support.
-A conforming freestanding C standard library implementation is required. Clang
-supplies some of the header files needed for a freestanding execution, such as
-``<stdarg.h>``, ``<limits.h>``, ``<stdint.h>``, etc. However, Clang still
-requires the runtime freestanding library to provide the interfaces required by
-Clause 4 (Conformance) of the C standard. Additionally, Clang requires the
-following runtime interfaces to be provided:
+An implementation of the following runtime library functions must always be
+provided with the usual semantics, as Clang will generate calls to them:
 
-  * `memcpy`,
-  * `memmove`, and
-  * `memset`.
+* ``memcpy``,
+* ``memmove``, and
+* ``memset``.
+
+Clang does not, by itself, provide a full "conforming freestanding
+implementation". If you wish to have a conforming freestanding implementation,
+you must provide a freestanding C library. While Clang provides some of the
+required header files, it does not provide all of them, nor any library
+implementations.
+
+Conversely, when ``-ffreestanding`` is specified, Clang does not require you to
+provide a conforming freestanding implementation library. Clang will not make
+any assumptions as to the availability or semantics of standard-library
+functions other than those mentioned above.
 
 Controlling Errors and Warnings
 -------------------------------

--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -1079,8 +1079,10 @@ Passing the ``-ffreestanding`` flag causes Clang to build for a freestanding
 (rather than a hosted) environment. The flag has the following effects:
 
 * the ``__STDC_HOSTED__`` predefined macro will expand to ``0``,
-* builtin functions are disabled (``-fno-builtins``), and
-* unwind tables are disabled (``fno-asynchronous-unwind-tables -fno-unwind-tables``)
+* builtin functions are disabled (``-fno-builtins``),
+* unwind tables are disabled (``fno-asynchronous-unwind-tables -fno-unwind-tables``),
+* allows ``main`` to be used as a regular function, and
+* removes implicit system header search paths and link libraries.
 
 A freestanding environment is not one which has no C standard library support.
 A conforming freestanding C standard library implementation is required. Clang

--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -1080,9 +1080,8 @@ Passing the ``-ffreestanding`` flag causes Clang to build for a freestanding
 
 * the ``__STDC_HOSTED__`` predefined macro will expand to ``0``,
 * builtin functions are disabled (``-fno-builtins``),
-* unwind tables are disabled (``fno-asynchronous-unwind-tables -fno-unwind-tables``),
-* allows ``main`` to be used as a regular function, and
-* removes implicit system header search paths and link libraries.
+* unwind tables are disabled (``fno-asynchronous-unwind-tables -fno-unwind-tables``), and
+* allows ``main`` to be used as a regular symbol.
 
 A freestanding environment is not one which has no C standard library support.
 A conforming freestanding C standard library implementation is required. Clang

--- a/clang/www/c_status.html
+++ b/clang/www/c_status.html
@@ -535,11 +535,6 @@ conformance.</p>
     </tr>
     <!-- Apr 2021 Papers -->
     <tr>
-      <td>String functions for freestanding implementations</td>
-      <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2524.htm">N2524</a></td>
-      <td class="none" align="center">No</td>
-    </tr>
-    <tr>
       <td>Digit separators</td>
       <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2626.pdf">N2626</a></td>
       <td class="full" align="center">Clang 13</td>


### PR DESCRIPTION
This adds some initial documentation about freestanding requirements for Clang. The most critical part of the documentation is spelling out that a conforming freestanding C Standard Library is required; Clang will not be providing the headers for <string.h> in C23 which expose a number of symbols in freestanding mode.

The docs also make it clear that in addition to a conforming freestanding C standard library, the library must provide some additional symbols which LLVM requires.

These docs are not comprehensive, this is just getting the bare bones in place so that they can be expanded later.

This also updates the C status page to make it clear that we don't have anything to do for WG14 N2524 which adds string interfaces to freestanding mode.