### PR TITLE
[clang][bytecode] Fix union copy/move operator active check

### DIFF
--- a/clang/lib/AST/ByteCode/Function.cpp
+++ b/clang/lib/AST/ByteCode/Function.cpp
@@ -35,10 +35,12 @@ Function::Function(Program &P, FunctionDeclTy Source, unsigned ArgSize,
       Kind = FunctionKind::Dtor;
     } else if (const auto *MD = dyn_cast<CXXMethodDecl>(F)) {
       Virtual = MD->isVirtual();
-      if (IsLambdaStaticInvoker) // MD->isLambdaStaticInvoker())
+      if (IsLambdaStaticInvoker)
         Kind = FunctionKind::LambdaStaticInvoker;
       else if (clang::isLambdaCallOperator(F))
         Kind = FunctionKind::LambdaCallOperator;
+      else if (MD->isCopyAssignmentOperator() || MD->isMoveAssignmentOperator())
+        Kind = FunctionKind::CopyOrMoveOperator;
     }
   }
 }

--- a/clang/lib/AST/ByteCode/Function.h
+++ b/clang/lib/AST/ByteCode/Function.h
@@ -91,6 +91,7 @@ public:
     Dtor,
     LambdaStaticInvoker,
     LambdaCallOperator,
+    CopyOrMoveOperator,
   };
   using ParamDescriptor = std::pair<PrimType, Descriptor *>;
 
@@ -159,6 +160,10 @@ public:
   bool isConstructor() const { return Kind == FunctionKind::Ctor; }
   /// Checks if the function is a destructor.
   bool isDestructor() const { return Kind == FunctionKind::Dtor; }
+  /// Checks if the function is copy or move operator.
+  bool isCopyOrMoveOperator() const {
+    return Kind == FunctionKind::CopyOrMoveOperator;
+  }
 
   /// Returns whether this function is a lambda static invoker,
   /// which we generate custom byte code for.

--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1449,6 +1449,7 @@ bool Call(InterpState &S, CodePtr OpPC, const Function *Func,
       if (!CheckInvoke(S, OpPC, ThisPtr))
         return cleanup();
       if (!Func->isConstructor() && !Func->isDestructor() &&
+          !Func->isCopyOrMoveOperator() &&
           !CheckActive(S, OpPC, ThisPtr, AK_MemberCall))
         return false;
     }

--- a/clang/test/AST/ByteCode/unions.cpp
+++ b/clang/test/AST/ByteCode/unions.cpp
@@ -570,4 +570,33 @@ namespace ActiveDestroy {
   static_assert(foo2());
 }
 
+namespace MoveOrAssignOp {
+  struct min_pointer {
+    int *ptr_;
+    constexpr min_pointer(int *p) : ptr_(p) {}
+    min_pointer() = default;
+  };
+
+  class F {
+    struct __long {
+      min_pointer __data_;
+    };
+    union __rep {
+      int __s;
+      __long __l;
+    } __rep_;
+
+  public:
+    constexpr F() {
+      __rep_ = __rep();
+      __rep_.__l.__data_ = nullptr;
+    }
+  };
+
+  constexpr bool foo() {
+    F f{};
+    return true;
+  }
+  static_assert(foo());
+}
 #endif


### PR DESCRIPTION
Don't call CheckActive for copy/move operators. They will activate the union member.