### PR TITLE
[release/18.x][backport][libc++abi] Use __has_feature check to enable usage of thread_local for exception storage

### DIFF
--- a/libcxxabi/src/cxa_exception_storage.cpp
+++ b/libcxxabi/src/cxa_exception_storage.cpp
@@ -24,7 +24,7 @@ extern "C" {
 } // extern "C"
 } // namespace __cxxabiv1
 
-#elif defined(HAS_THREAD_LOCAL)
+#elif __has_feature(cxx_thread_local)
 
 namespace __cxxabiv1 {
 namespace {


### PR DESCRIPTION
This is a backport of original commit #97591 to 18.x release.