### PR TITLE
[asan][NFCI] Rename asan_(malloc_)?linux.cpp to ...unix.cpp

### DIFF
--- a/compiler-rt/lib/asan/CMakeLists.txt
+++ b/compiler-rt/lib/asan/CMakeLists.txt
@@ -13,10 +13,9 @@ set(ASAN_SOURCES
   asan_globals_win.cpp
   asan_interceptors.cpp
   asan_interceptors_memintrinsics.cpp
-  asan_linux.cpp
   asan_mac.cpp
-  asan_malloc_linux.cpp
   asan_malloc_mac.cpp
+  asan_malloc_unix.cpp
   asan_malloc_win.cpp
   asan_memory_profile.cpp
   asan_poisoning.cpp
@@ -29,6 +28,7 @@ set(ASAN_SOURCES
   asan_stats.cpp
   asan_suppressions.cpp
   asan_thread.cpp
+  asan_unix.cpp
   asan_win.cpp
   )
 

--- a/compiler-rt/lib/asan/asan_malloc_unix.cpp
+++ b/compiler-rt/lib/asan/asan_malloc_unix.cpp
@@ -1,4 +1,4 @@
-//===-- asan_malloc_linux.cpp ---------------------------------------------===//
+//===-- asan_malloc_unix.cpp ----------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -8,7 +8,7 @@
 //
 // This file is a part of AddressSanitizer, an address sanity checker.
 //
-// Linux-specific malloc interception.
+// Unix-like-specific malloc interception.
 // We simply define functions like malloc, free, realloc, etc.
 // They will replace the corresponding libc functions automagically.
 //===----------------------------------------------------------------------===//

--- a/compiler-rt/lib/asan/asan_unix.cpp
+++ b/compiler-rt/lib/asan/asan_unix.cpp
@@ -1,4 +1,4 @@
-//===-- asan_linux.cpp ----------------------------------------------------===//
+//===-- asan_unix.cpp -----------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/utils/gn/secondary/compiler-rt/lib/asan/BUILD.gn
+++ b/llvm/utils/gn/secondary/compiler-rt/lib/asan/BUILD.gn
@@ -33,10 +33,9 @@ if (current_toolchain == host_toolchain) {
     "asan_interface.inc",
     "asan_interface_internal.h",
     "asan_internal.h",
-    "asan_linux.cpp",
     "asan_mac.cpp",
-    "asan_malloc_linux.cpp",
     "asan_malloc_mac.cpp",
+    "asan_malloc_unix.cpp",
     "asan_malloc_win.cpp",
     "asan_mapping.h",
     "asan_memory_profile.cpp",
@@ -58,6 +57,7 @@ if (current_toolchain == host_toolchain) {
     "asan_suppressions.h",
     "asan_thread.cpp",
     "asan_thread.h",
+    "asan_unix.cpp",
     "asan_win.cpp",
   ]
   if (current_os != "mac" && current_os != "win") {


### PR DESCRIPTION
asan_(malloc_)?linux.cpp are misleadingly named because they cover many non-Linux OSes, such as BSDs, Fuchsia and Solaris. This is a footgun where changes may be made to these files without remembering it is not Linux-specific (e.g., I broke the Solaris build - see https://github.com/llvm/llvm-project/pull/131975#issuecomment-2741097471).

This patch mitigates the issue by renaming the files from ...linux to ...unix, which should hopefully give pause to anyone (me) when making Linux-specific changes.