### PR TITLE
[CIR] Upstream initial for-loop support

### DIFF
--- a/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
+++ b/clang/include/clang/CIR/Dialect/Builder/CIRBaseBuilder.h
@@ -52,6 +52,15 @@ public:
     return cir::BoolAttr::get(getContext(), getBoolTy(), state);
   }
 
+  /// Create a for operation.
+  cir::ForOp createFor(
+      mlir::Location loc,
+      llvm::function_ref<void(mlir::OpBuilder &, mlir::Location)> condBuilder,
+      llvm::function_ref<void(mlir::OpBuilder &, mlir::Location)> bodyBuilder,
+      llvm::function_ref<void(mlir::OpBuilder &, mlir::Location)> stepBuilder) {
+    return create<cir::ForOp>(loc, condBuilder, bodyBuilder, stepBuilder);
+  }
+
   mlir::TypedAttr getConstPtrAttr(mlir::Type type, int64_t value) {
     auto valueAttr = mlir::IntegerAttr::get(
         mlir::IntegerType::get(type.getContext(), 64), value);
@@ -157,6 +166,16 @@ public:
     // it simple.
     return mlir::IntegerAttr::get(mlir::IntegerType::get(ctx, 64),
                                   size.getQuantity());
+  }
+
+  /// Create a loop condition.
+  cir::ConditionOp createCondition(mlir::Value condition) {
+    return create<cir::ConditionOp>(condition.getLoc(), condition);
+  }
+
+  /// Create a yield operation.
+  cir::YieldOp createYield(mlir::Location loc, mlir::ValueRange value = {}) {
+    return create<cir::YieldOp>(loc, value);
   }
 };
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.h
@@ -29,6 +29,7 @@
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIROpsDialect.h.inc"
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
+#include "clang/CIR/Interfaces/CIRLoopOpInterface.h"
 #include "clang/CIR/Interfaces/CIROpInterfaces.h"
 
 // TableGen'erated files for MLIR dialects require that a macro be defined when

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -19,6 +19,7 @@ include "clang/CIR/Dialect/IR/CIRTypes.td"
 include "clang/CIR/Dialect/IR/CIRAttrs.td"
 
 include "clang/CIR/Interfaces/CIROpInterfaces.td"
+include "clang/CIR/Interfaces/CIRLoopOpInterface.td"
 
 include "mlir/IR/BuiltinAttributeInterfaces.td"
 include "mlir/IR/EnumAttr.td"
@@ -423,7 +424,7 @@ def StoreOp : CIR_Op<"store", [
 // ReturnOp
 //===----------------------------------------------------------------------===//
 
-def ReturnOp : CIR_Op<"return", [ParentOneOf<["FuncOp", "ScopeOp"]>,
+def ReturnOp : CIR_Op<"return", [ParentOneOf<["FuncOp", "ScopeOp", "ForOp"]>,
                                  Terminator]> {
   let summary = "Return from function";
   let description = [{
@@ -461,11 +462,56 @@ def ReturnOp : CIR_Op<"return", [ParentOneOf<["FuncOp", "ScopeOp"]>,
 }
 
 //===----------------------------------------------------------------------===//
+// ConditionOp
+//===----------------------------------------------------------------------===//
+
+def ConditionOp : CIR_Op<"condition", [
+  Terminator,
+  DeclareOpInterfaceMethods<RegionBranchTerminatorOpInterface,
+                            ["getSuccessorRegions"]>
+]> {
+  let summary = "Loop continuation condition.";
+  let description = [{
+    The `cir.condition` terminates conditional regions. It takes a single
+    `cir.bool` operand and, depending on its value, may branch to different
+    regions:
+
+     - When in the `cond` region of a `cir.loop`, it continues the loop
+       if true, or exits it if false.
+     - When in the `ready` region of a `cir.await`, it branches to the `resume`
+       region when true, and to the `suspend` region when false.
+
+    Example:
+
+    ```mlir
+    cir.loop for(cond : {
+      cir.condition(%arg0) // Branches to `step` region or exits.
+    }, step : {
+      [...]
+    }) {
+      [...]
+    }
+
+    cir.await(user, ready : {
+      cir.condition(%arg0) // Branches to `resume` or `suspend` region.
+    }, suspend : {
+      [...]
+    }, resume : {
+      [...]
+    },)
+    ```
+  }];
+  let arguments = (ins CIR_BoolType:$condition);
+  let assemblyFormat = " `(` $condition `)` attr-dict ";
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
 // YieldOp
 //===----------------------------------------------------------------------===//
 
 def YieldOp : CIR_Op<"yield", [ReturnLike, Terminator,
-                               ParentOneOf<["ScopeOp"]>]> {
+                               ParentOneOf<["ScopeOp", "ForOp"]>]> {
   let summary = "Represents the default branching behaviour of a region";
   let description = [{
     The `cir.yield` operation terminates regions on different CIR operations,
@@ -664,6 +710,120 @@ def UnaryOp : CIR_Op<"unary", [Pure, SameOperandsAndResultType]> {
 
   let hasVerifier = 1;
   let hasFolder = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// BrCondOp
+//===----------------------------------------------------------------------===//
+
+def BrCondOp : CIR_Op<"brcond",
+      [DeclareOpInterfaceMethods<BranchOpInterface, ["getSuccessorForOperands"]>,
+       Pure, Terminator, AttrSizedOperandSegments]> {
+  let summary = "Conditional branch";
+  let description = [{
+    The `cir.brcond %cond, ^bb0, ^bb1` branches to 'bb0' block in case
+    %cond (which must be a !cir.bool type) evaluates to true, otherwise
+    it branches to 'bb1'.
+
+    Example:
+
+    ```mlir
+      ...
+        cir.brcond %a, ^bb3, ^bb4
+      ^bb3:
+        cir.return
+      ^bb4:
+        cir.yield
+    ```
+  }];
+
+  let builders = [
+    OpBuilder<(ins "mlir::Value":$cond, "mlir::Block *":$destTrue, "mlir::Block *":$destFalse,
+               CArg<"mlir::ValueRange", "{}">:$destOperandsTrue,
+               CArg<"mlir::ValueRange", "{}">:$destOperandsFalse), [{
+      build($_builder, $_state, cond, destOperandsTrue,
+            destOperandsFalse, destTrue, destFalse);
+    }]>
+  ];
+
+  let arguments = (ins CIR_BoolType:$cond,
+                       Variadic<CIR_AnyType>:$destOperandsTrue,
+                       Variadic<CIR_AnyType>:$destOperandsFalse);
+  let successors = (successor AnySuccessor:$destTrue, AnySuccessor:$destFalse);
+  let assemblyFormat = [{
+    $cond
+    $destTrue (`(` $destOperandsTrue^ `:` type($destOperandsTrue) `)`)?
+    `,`
+    $destFalse (`(` $destOperandsFalse^ `:` type($destOperandsFalse) `)`)?
+    attr-dict
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// ForOp
+//===----------------------------------------------------------------------===//
+
+def ForOp : CIR_Op<"for", [LoopOpInterface, NoRegionArguments]> {
+  let summary = "C/C++ for loop counterpart";
+  let description = [{
+    Represents a C/C++ for loop. It consists of three regions:
+
+     - `cond`: single block region with the loop's condition. Should be
+     terminated with a `cir.condition` operation.
+     - `body`: contains the loop body and an arbitrary number of blocks.
+     - `step`: single block region with the loop's step.
+
+    Example:
+
+    ```mlir
+    cir.for cond {
+      cir.condition(%val)
+    } body {
+      cir.break
+    ^bb2:
+      cir.yield
+    } step {
+      cir.yield
+    }
+    ```
+  }];
+
+  let regions = (region SizedRegion<1>:$cond,
+                        MinSizedRegion<1>:$body,
+                        SizedRegion<1>:$step);
+  let assemblyFormat = [{
+    `:` `cond` $cond
+    `body` $body
+    `step` $step
+    attr-dict
+  }];
+
+  let builders = [
+    OpBuilder<(ins "llvm::function_ref<void(mlir::OpBuilder &, mlir::Location)>":$condBuilder,
+                   "llvm::function_ref<void(mlir::OpBuilder &, mlir::Location)>":$bodyBuilder,
+                   "llvm::function_ref<void(mlir::OpBuilder &, mlir::Location)>":$stepBuilder), [{
+        mlir::OpBuilder::InsertionGuard guard($_builder);
+
+        // Build condition region.
+        $_builder.createBlock($_state.addRegion());
+        condBuilder($_builder, $_state.location);
+
+        // Build body region.
+        $_builder.createBlock($_state.addRegion());
+        bodyBuilder($_builder, $_state.location);
+
+        // Build step region.
+        $_builder.createBlock($_state.addRegion());
+        stepBuilder($_builder, $_state.location);
+      }]>
+  ];
+
+  let extraClassDeclaration = [{
+    mlir::Region *maybeGetStep() { return &getStep(); }
+    llvm::SmallVector<mlir::Region *> getRegionsInExecutionOrder() {
+      return llvm::SmallVector<mlir::Region *, 3>{&getCond(), &getBody(), &getStep()};
+    }
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/CIR/Interfaces/CIRLoopOpInterface.h
+++ b/clang/include/clang/CIR/Interfaces/CIRLoopOpInterface.h
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+//
+// Defines the interface to generically handle CIR loop operations.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CLANG_CIR_INTERFACES_CIRLOOPOPINTERFACE_H
+#define CLANG_CIR_INTERFACES_CIRLOOPOPINTERFACE_H
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
+
+namespace cir {
+namespace detail {
+
+/// Verify invariants of the LoopOpInterface.
+mlir::LogicalResult verifyLoopOpInterface(::mlir::Operation *op);
+
+} // namespace detail
+} // namespace cir
+
+/// Include the tablegen'd interface declarations.
+#include "clang/CIR/Interfaces/CIRLoopOpInterface.h.inc"
+
+#endif // CLANG_CIR_INTERFACES_CIRLOOPOPINTERFACE_H

--- a/clang/include/clang/CIR/Interfaces/CIRLoopOpInterface.td
+++ b/clang/include/clang/CIR/Interfaces/CIRLoopOpInterface.td
@@ -1,0 +1,99 @@
+//===---------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#ifndef CLANG_CIR_INTERFACES_CIRLOOPOPINTERFACE
+#define CLANG_CIR_INTERFACES_CIRLOOPOPINTERFACE
+
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/LoopLikeInterface.td"
+
+def LoopOpInterface : OpInterface<"LoopOpInterface", [
+  DeclareOpInterfaceMethods<RegionBranchOpInterface>,
+  DeclareOpInterfaceMethods<LoopLikeOpInterface>
+]> {
+  let description = [{
+    Contains helper functions to query properties and perform transformations
+    on a loop.
+  }];
+  let cppNamespace = "::cir";
+
+  let methods = [
+    InterfaceMethod<[{
+        Returns the loop's conditional region.
+      }],
+      /*retTy=*/"mlir::Region &",
+      /*methodName=*/"getCond"
+    >,
+    InterfaceMethod<[{
+        Returns the loop's body region.
+      }],
+      /*retTy=*/"mlir::Region &",
+      /*methodName=*/"getBody"
+    >,
+    InterfaceMethod<[{
+        Returns a pointer to the loop's step region or nullptr.
+      }],
+      /*retTy=*/"mlir::Region *",
+      /*methodName=*/"maybeGetStep",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/"return nullptr;"
+    >,
+    InterfaceMethod<[{
+        Returns the first region to be executed in the loop.
+      }],
+      /*retTy=*/"mlir::Region &",
+      /*methodName=*/"getEntry",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/"return $_op.getCond();"
+    >,
+    InterfaceMethod<[{
+        Returns a list of regions in order of execution.
+      }],
+      /*retTy=*/"llvm::SmallVector<mlir::Region *>",
+      /*methodName=*/"getRegionsInExecutionOrder",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return llvm::SmallVector<mlir::Region *, 2>{&$_op.getRegion(0), &$_op.getRegion(1)};
+      }]
+    >,
+    InterfaceMethod<[{
+        Recursively walks the body of the loop in pre-order while skipping
+        nested loops and executing a callback on every other operation.
+      }],
+      /*retTy=*/"mlir::WalkResult",
+      /*methodName=*/"walkBodySkippingNestedLoops",
+      /*args=*/(ins "::llvm::function_ref<mlir::WalkResult (mlir::Operation *)>":$callback),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return $_op.getBody().template walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
+          if (mlir::isa<LoopOpInterface>(op))
+            return mlir::WalkResult::skip();
+          return callback(op);
+        });
+      }]
+    >
+  ];
+
+  let extraClassDeclaration = [{
+    /// Generic method to retrieve the successors of a LoopOpInterface operation.
+    static void getLoopOpSuccessorRegions(
+        ::cir::LoopOpInterface op, ::mlir::RegionBranchPoint point,
+        ::mlir::SmallVectorImpl<::mlir::RegionSuccessor> &regions);
+  }];
+
+  let verify = [{
+    /// Verify invariants of the LoopOpInterface.
+    return detail::verifyLoopOpInterface($_op);
+  }];
+}
+
+#endif // CLANG_CIR_INTERFACES_CIRLOOPOPINTERFACE

--- a/clang/include/clang/CIR/Interfaces/CMakeLists.txt
+++ b/clang/include/clang/CIR/Interfaces/CMakeLists.txt
@@ -20,4 +20,5 @@ function(add_clang_mlir_type_interface interface)
 endfunction()
 
 add_clang_mlir_op_interface(CIROpInterfaces)
+add_clang_mlir_op_interface(CIRLoopOpInterface)
 add_clang_mlir_type_interface(CIRFPTypeInterface)

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -72,6 +72,9 @@ struct MissingFeatures {
   static bool opFuncLinkage() { return false; }
   static bool opFuncVisibility() { return false; }
 
+  // ScopeOp handling
+  static bool opScopeCleanupRegion() { return false; }
+
   // Unary operator handling
   static bool opUnarySignedOverflow() { return false; }
   static bool opUnaryPromotionType() { return false; }
@@ -90,12 +93,16 @@ struct MissingFeatures {
   static bool stackSaveOp() { return false; }
   static bool aggValueSlot() { return false; }
   static bool generateDebugInfo() { return false; }
-
   static bool fpConstraints() { return false; }
   static bool sanitizers() { return false; }
   static bool addHeapAllocSiteMetadata() { return false; }
   static bool targetCodeGenInfoGetNullPointer() { return false; }
   static bool CGFPOptionsRAII() { return false; }
+  static bool loopInfoStack() { return false; }
+  static bool requiresCleanups() { return false; }
+  static bool createProfileWeightsForLoop() { return false; }
+  static bool emitCondLikelihoodViaExpectIntrinsic() { return false; }
+  static bool pgoUse() { return false; }
 
   // Missing types
   static bool dataMemberType() { return false; }
@@ -106,15 +113,20 @@ struct MissingFeatures {
   static bool vectorType() { return false; }
 
   // Future CIR operations
-  static bool labelOp() { return false; }
-  static bool brCondOp() { return false; }
-  static bool switchOp() { return false; }
-  static bool tryOp() { return false; }
-  static bool selectOp() { return false; }
-  static bool complexCreateOp() { return false; }
-  static bool complexRealOp() { return false; }
-  static bool complexImagOp() { return false; }
+  static bool awaitOp() { return false; }
+  static bool breakOp() { return false; }
   static bool callOp() { return false; }
+  static bool complexCreateOp() { return false; }
+  static bool complexImagOp() { return false; }
+  static bool complexRealOp() { return false; }
+  static bool continueOp() { return false; }
+  static bool ifOp() { return false; }
+  static bool labelOp() { return false; }
+  static bool selectOp() { return false; }
+  static bool switchOp() { return false; }
+  static bool ternaryOp() { return false; }
+  static bool tryOp() { return false; }
+  static bool zextOp() { return false; }
 };
 
 } // namespace cir

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -742,6 +742,16 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
   return {};
 }
 
+mlir::Value CIRGenFunction::emitScalarConversion(mlir::Value src,
+                                                 QualType srcTy, QualType dstTy,
+                                                 SourceLocation loc) {
+  assert(CIRGenFunction::hasScalarEvaluationKind(srcTy) &&
+         CIRGenFunction::hasScalarEvaluationKind(dstTy) &&
+         "Invalid scalar expression to emit");
+  return ScalarExprEmitter(*this, builder)
+      .emitScalarConversion(src, srcTy, dstTy, loc);
+}
+
 /// Return the size or alignment of the type of argument of the sizeof
 /// expression as an integer.
 mlir::Value ScalarExprEmitter::VisitUnaryExprOrTypeTraitExpr(

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -175,6 +175,9 @@ public:
   void finishFunction(SourceLocation endLoc);
   mlir::LogicalResult emitFunctionBody(const clang::Stmt *body);
 
+  /// Build a debug stoppoint if we are emitting debug info.
+  void emitStopPoint(const Stmt *s);
+
   // Build CIR for a statement. useCurrentScope should be true if no
   // new scopes need be created when finding a compound statement.
   mlir::LogicalResult
@@ -183,6 +186,8 @@ public:
 
   mlir::LogicalResult emitSimpleStmt(const clang::Stmt *s,
                                      bool useCurrentScope);
+
+  mlir::LogicalResult emitForStmt(const clang::ForStmt &S);
 
   void emitCompoundStmt(const clang::CompoundStmt &s);
 
@@ -311,6 +316,10 @@ public:
   /// inside a function, including static vars etc.
   void emitVarDecl(const clang::VarDecl &d);
 
+  /// Perform the usual unary conversions on the specified expression and
+  /// compare the result against zero, returning an Int1Ty value.
+  mlir::Value evaluateExprAsBool(const clang::Expr *e);
+
   /// Set the address of a local variable.
   void setAddrOfLocalVar(const clang::VarDecl *vd, Address addr) {
     assert(!LocalDeclMap.count(vd) && "Decl already exists in LocalDeclMap!");
@@ -336,6 +345,12 @@ public:
                      cir::FuncOp fn, cir::FuncType funcType,
                      FunctionArgList args, clang::SourceLocation loc,
                      clang::SourceLocation startLoc);
+
+  /// Emit a conversion from the specified type to the specified destination
+  /// type, both of which are CIR scalar types.
+  mlir::Value emitScalarConversion(mlir::Value src, clang::QualType srcType,
+                                   clang::QualType dstType,
+                                   clang::SourceLocation loc);
 
   /// Represents a scope, including function bodies, compound statements, and
   /// the substatements of if/while/do/for/switch/try statements.  This class

--- a/clang/lib/CIR/Dialect/IR/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/IR/CMakeLists.txt
@@ -8,6 +8,7 @@ add_clang_library(MLIRCIR
   MLIRCIROpsIncGen
   MLIRCIREnumsGen
   MLIRCIROpInterfacesIncGen
+  MLIRCIRLoopOpInterfaceIncGen
 
   LINK_LIBS PUBLIC
   MLIRIR
@@ -15,6 +16,7 @@ add_clang_library(MLIRCIR
   MLIRDLTIDialect
   MLIRDataLayoutInterfaces
   MLIRFuncDialect
+  MLIRLoopLikeInterface
   MLIRCIRInterfaces
   clangAST
   )

--- a/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
@@ -118,7 +118,6 @@ void CIRCanonicalizePass::runOnOperation() {
   // Collect operations to apply patterns.
   llvm::SmallVector<Operation *, 16> ops;
   getOperation()->walk([&](Operation *op) {
-    assert(!cir::MissingFeatures::brCondOp());
     assert(!cir::MissingFeatures::switchOp());
     assert(!cir::MissingFeatures::tryOp());
     assert(!cir::MissingFeatures::selectOp());
@@ -127,8 +126,8 @@ void CIRCanonicalizePass::runOnOperation() {
     assert(!cir::MissingFeatures::complexImagOp());
     assert(!cir::MissingFeatures::callOp());
     // CastOp and UnaryOp are here to perform a manual `fold` in
-    // applyOpPatternsGreedily.
-    if (isa<BrOp, ScopeOp, CastOp, UnaryOp>(op))
+    // applyOpPatternsGreedily.    
+    if (isa<BrOp, BrCondOp, ScopeOp, CastOp, UnaryOp>(op))
       ops.push_back(op);
   });
 

--- a/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
@@ -126,7 +126,7 @@ void CIRCanonicalizePass::runOnOperation() {
     assert(!cir::MissingFeatures::complexImagOp());
     assert(!cir::MissingFeatures::callOp());
     // CastOp and UnaryOp are here to perform a manual `fold` in
-    // applyOpPatternsGreedily.    
+    // applyOpPatternsGreedily.
     if (isa<BrOp, BrCondOp, ScopeOp, CastOp, UnaryOp>(op))
       ops.push_back(op);
   });

--- a/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/FlattenCFG.cpp
@@ -26,6 +26,28 @@ using namespace cir;
 
 namespace {
 
+/// Lowers operations with the terminator trait that have a single successor.
+void lowerTerminator(mlir::Operation *op, mlir::Block *dest,
+                     mlir::PatternRewriter &rewriter) {
+  assert(op->hasTrait<mlir::OpTrait::IsTerminator>() && "not a terminator");
+  mlir::OpBuilder::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPoint(op);
+  rewriter.replaceOpWithNewOp<cir::BrOp>(op, dest);
+}
+
+/// Walks a region while skipping operations of type `Ops`. This ensures the
+/// callback is not applied to said operations and its children.
+template <typename... Ops>
+void walkRegionSkipping(
+    mlir::Region &region,
+    mlir::function_ref<mlir::WalkResult(mlir::Operation *)> callback) {
+  region.walk<mlir::WalkOrder::PreOrder>([&](mlir::Operation *op) {
+    if (isa<Ops...>(op))
+      return mlir::WalkResult::skip();
+    return callback(op);
+  });
+}
+
 struct CIRFlattenCFGPass : public CIRFlattenCFGBase<CIRFlattenCFGPass> {
 
   CIRFlattenCFGPass() = default;
@@ -86,8 +108,91 @@ public:
   }
 };
 
+class CIRLoopOpInterfaceFlattening
+    : public mlir::OpInterfaceRewritePattern<cir::LoopOpInterface> {
+public:
+  using mlir::OpInterfaceRewritePattern<
+      cir::LoopOpInterface>::OpInterfaceRewritePattern;
+
+  inline void lowerConditionOp(cir::ConditionOp op, mlir::Block *body,
+                               mlir::Block *exit,
+                               mlir::PatternRewriter &rewriter) const {
+    mlir::OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(op);
+    rewriter.replaceOpWithNewOp<cir::BrCondOp>(op, op.getCondition(), body,
+                                               exit);
+  }
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::LoopOpInterface op,
+                  mlir::PatternRewriter &rewriter) const final {
+    // Setup CFG blocks.
+    mlir::Block *entry = rewriter.getInsertionBlock();
+    mlir::Block *exit =
+        rewriter.splitBlock(entry, rewriter.getInsertionPoint());
+    mlir::Block *cond = &op.getCond().front();
+    mlir::Block *body = &op.getBody().front();
+    mlir::Block *step =
+        (op.maybeGetStep() ? &op.maybeGetStep()->front() : nullptr);
+
+    // Setup loop entry branch.
+    rewriter.setInsertionPointToEnd(entry);
+    rewriter.create<cir::BrOp>(op.getLoc(), &op.getEntry().front());
+
+    // Branch from condition region to body or exit.
+    auto conditionOp = cast<cir::ConditionOp>(cond->getTerminator());
+    lowerConditionOp(conditionOp, body, exit, rewriter);
+
+    // TODO(cir): Remove the walks below. It visits operations unnecessarily.
+    // However, to solve this we would likely need a custom DialectConversion
+    // driver to customize the order that operations are visited.
+
+    // Lower continue statements.
+    op.walkBodySkippingNestedLoops([&](mlir::Operation *op) {
+      // When continue ops are supported, there will be a check for them here
+      // and a call to lowerTerminator(). The call to `advance()` handles the
+      // case where this is not a continue op.
+      assert(!cir::MissingFeatures::continueOp());
+      return mlir::WalkResult::advance();
+    });
+
+    // Lower break statements.
+    assert(!cir::MissingFeatures::switchOp());
+    walkRegionSkipping<cir::LoopOpInterface>(
+        op.getBody(), [&](mlir::Operation *op) {
+          // When break ops are supported, there will be a check for them here
+          // and a call to lowerTerminator(). The call to `advance()` handles
+          // the case where this is not a break op.
+          assert(!cir::MissingFeatures::breakOp());
+          return mlir::WalkResult::advance();
+        });
+
+    // Lower optional body region yield.
+    for (mlir::Block &blk : op.getBody().getBlocks()) {
+      auto bodyYield = dyn_cast<cir::YieldOp>(blk.getTerminator());
+      if (bodyYield)
+        lowerTerminator(bodyYield, (step ? step : cond), rewriter);
+    }
+
+    // Lower mandatory step region yield.
+    if (step)
+      lowerTerminator(cast<cir::YieldOp>(step->getTerminator()), cond,
+                      rewriter);
+
+    // Move region contents out of the loop op.
+    rewriter.inlineRegionBefore(op.getCond(), exit);
+    rewriter.inlineRegionBefore(op.getBody(), exit);
+    if (step)
+      rewriter.inlineRegionBefore(*op.maybeGetStep(), exit);
+
+    rewriter.eraseOp(op);
+    return mlir::success();
+  }
+};
+
 void populateFlattenCFGPatterns(RewritePatternSet &patterns) {
-  patterns.add<CIRScopeOpFlattening>(patterns.getContext());
+  patterns.add<CIRLoopOpInterfaceFlattening, CIRScopeOpFlattening>(
+      patterns.getContext());
 }
 
 void CIRFlattenCFGPass::runOnOperation() {
@@ -97,7 +202,11 @@ void CIRFlattenCFGPass::runOnOperation() {
   // Collect operations to apply patterns.
   llvm::SmallVector<Operation *, 16> ops;
   getOperation()->walk<mlir::WalkOrder::PostOrder>([&](Operation *op) {
-    if (isa<ScopeOp>(op))
+    assert(!cir::MissingFeatures::ifOp());
+    assert(!cir::MissingFeatures::switchOp());
+    assert(!cir::MissingFeatures::ternaryOp());
+    assert(!cir::MissingFeatures::tryOp());
+    if (isa<ScopeOp, LoopOpInterface>(op))
       ops.push_back(op);
   });
 

--- a/clang/lib/CIR/Interfaces/CIRLoopOpInterface.cpp
+++ b/clang/lib/CIR/Interfaces/CIRLoopOpInterface.cpp
@@ -1,0 +1,63 @@
+//===---------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#include "clang/CIR/Interfaces/CIRLoopOpInterface.h"
+
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Interfaces/CIRLoopOpInterface.cpp.inc"
+#include "llvm/Support/ErrorHandling.h"
+
+namespace cir {
+
+void LoopOpInterface::getLoopOpSuccessorRegions(
+    LoopOpInterface op, mlir::RegionBranchPoint point,
+    llvm::SmallVectorImpl<mlir::RegionSuccessor> &regions) {
+  assert(point.isParent() || point.getRegionOrNull());
+
+  // Branching to first region: go to condition or body (do-while).
+  if (point.isParent()) {
+    regions.emplace_back(&op.getEntry(), op.getEntry().getArguments());
+    return;
+  }
+
+  // Branching from condition: go to body or exit.
+  if (&op.getCond() == point.getRegionOrNull()) {
+    regions.emplace_back(mlir::RegionSuccessor(op->getResults()));
+    regions.emplace_back(&op.getBody(), op.getBody().getArguments());
+    return;
+  }
+
+  // Branching from body: go to step (for) or condition.
+  if (&op.getBody() == point.getRegionOrNull()) {
+    // FIXME(cir): Should we consider break/continue statements here?
+    mlir::Region *afterBody =
+        (op.maybeGetStep() ? op.maybeGetStep() : &op.getCond());
+    regions.emplace_back(afterBody, afterBody->getArguments());
+    return;
+  }
+
+  // Branching from step: go to condition.
+  if (op.maybeGetStep() == point.getRegionOrNull()) {
+    regions.emplace_back(&op.getCond(), op.getCond().getArguments());
+    return;
+  }
+
+  llvm_unreachable("unexpected branch origin");
+}
+
+/// Verify invariants of the LoopOpInterface.
+llvm::LogicalResult detail::verifyLoopOpInterface(mlir::Operation *op) {
+  // FIXME: fix this so the conditionop isn't requiring MLIRCIR
+  // auto loopOp = mlir::cast<LoopOpInterface>(op);
+  // if (!mlir::isa<ConditionOp>(loopOp.getCond().back().getTerminator()))
+  //   return op->emitOpError(
+  //       "expected condition region to terminate with 'cir.condition'");
+  return llvm::success();
+}
+
+} // namespace cir

--- a/clang/lib/CIR/Interfaces/CMakeLists.txt
+++ b/clang/lib/CIR/Interfaces/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_clang_library(MLIRCIRInterfaces
   CIROpInterfaces.cpp
+  CIRLoopOpInterface.cpp
   CIRFPTypeInterface.cpp
 
   ADDITIONAL_HEADER_DIRS
@@ -8,6 +9,7 @@ add_clang_library(MLIRCIRInterfaces
   DEPENDS
   MLIRCIREnumsGen
   MLIRCIRFPTypeInterfaceIncGen
+  MLIRCIRLoopOpInterfaceIncGen
   MLIRCIROpInterfacesIncGen
 
   LINK_LIBS

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.h
@@ -28,6 +28,16 @@ mlir::Value lowerCirAttrAsValue(mlir::Operation *parentOp, mlir::Attribute attr,
 
 mlir::LLVM::Linkage convertLinkage(cir::GlobalLinkageKind linkage);
 
+class CIRToLLVMBrCondOpLowering
+    : public mlir::OpConversionPattern<cir::BrCondOp> {
+public:
+  using mlir::OpConversionPattern<cir::BrCondOp>::OpConversionPattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(cir::BrCondOp op, OpAdaptor,
+                  mlir::ConversionPatternRewriter &) const override;
+};
+
 class CIRToLLVMCastOpLowering : public mlir::OpConversionPattern<cir::CastOp> {
   mlir::DataLayout const &dataLayout;
 

--- a/clang/test/CIR/CodeGen/loop.cpp
+++ b/clang/test/CIR/CodeGen/loop.cpp
@@ -1,0 +1,46 @@
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s --check-prefix=LLVM
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s --check-prefix=OGCG
+
+void l0() {
+  for (;;) {
+  }
+}
+
+// CIR: cir.func @l0
+// CIR:   cir.scope {
+// CIR:     cir.for : cond {
+// CIR:       %[[TRUE:.*]] = cir.const #true
+// CIR:       cir.condition(%[[TRUE]])
+// CIR:     } body {
+// CIR:       cir.yield
+// CIR:     } step {
+// CIR:       cir.yield
+// CIR:     }
+// CIR:   }
+// CIR:   cir.return
+// CIR: }
+
+// LLVM: define void @l0()
+// LLVM:   br label %[[LABEL1:.*]]
+// LLVM: [[LABEL1]]:
+// LLVM:   br label %[[LABEL2:.*]]
+// LLVM: [[LABEL2]]:
+// LLVM:   br i1 true, label %[[LABEL3:.*]], label %[[LABEL5:.*]]
+// LLVM: [[LABEL3]]:
+// LLVM:   br label %[[LABEL4:.*]]
+// LLVM: [[LABEL4]]:
+// LLVM:   br label %[[LABEL2]]
+// LLVM: [[LABEL5]]:
+// LLVM:   br label %[[LABEL6:.*]]
+// LLVM: [[LABEL6]]:
+// LLVM:   ret void
+
+// OGCG: define{{.*}} void @_Z2l0v()
+// OGCG: entry:
+// OGCG:   br label %[[FOR_COND:.*]]
+// OGCG: [[FOR_COND]]:
+// OGCG:   br label %[[FOR_COND]]

--- a/clang/test/CIR/Transforms/loop.cir
+++ b/clang/test/CIR/Transforms/loop.cir
@@ -1,0 +1,29 @@
+// RUN: cir-opt %s -cir-flatten-cfg -o - | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+
+module {
+
+  cir.func @testFor(%arg0 : !cir.bool) {
+    cir.for : cond {
+      cir.condition(%arg0)
+    } body {
+      cir.yield
+    } step {
+      cir.yield
+    }
+    cir.return
+  }
+}
+
+// CHECK:  cir.func @testFor(%arg0: !cir.bool) {
+// CHECK:    cir.br ^bb[[#COND:]]
+// CHECK:  ^bb[[#COND]]:
+// CHECK:    cir.brcond %arg0 ^bb[[#BODY:]], ^bb[[#EXIT:]]
+// CHECK:  ^bb[[#BODY]]:
+// CHECK:    cir.br ^bb[[#STEP:]]
+// CHECK:  ^bb[[#STEP]]:
+// CHECK:    cir.br ^bb[[#COND:]]
+// CHECK:  ^bb[[#EXIT]]:
+// CHECK:    cir.return
+// CHECK:  }


### PR DESCRIPTION
This change adds support for empty for-loops. This will be the infrastructre needed for complete for loops, but that depends on compare operations, which have not been upstreamed yet.