### PR TITLE
[LLVM-C][OCaml] Update OCaml bindings to match LLVMMetadataKind in C API

### DIFF
--- a/llvm/bindings/ocaml/debuginfo/llvm_debuginfo.ml
+++ b/llvm/bindings/ocaml/debuginfo/llvm_debuginfo.ml
@@ -139,6 +139,11 @@ module MetadataKind = struct
     | DIMacroMetadataKind
     | DIMacroFileMetadataKind
     | DICommonBlockMetadataKind
+    | DIStringTypeMetadataKind
+    | DIGenericSubrangeMetadataKind
+    | DIArgListMetadataKind
+    | DIAssignIDMetadataKind
+    | DISubrangeTypeMetadataKind
 end
 
 (** The amount of debug information to emit. *)

--- a/llvm/bindings/ocaml/debuginfo/llvm_debuginfo.mli
+++ b/llvm/bindings/ocaml/debuginfo/llvm_debuginfo.mli
@@ -143,6 +143,11 @@ module MetadataKind : sig
     | DIMacroMetadataKind
     | DIMacroFileMetadataKind
     | DICommonBlockMetadataKind
+    | DIStringTypeMetadataKind
+    | DIGenericSubrangeMetadataKind
+    | DIArgListMetadataKind
+    | DIAssignIDMetadataKind
+    | DISubrangeTypeMetadataKind
 end
 
 (** The amount of debug information to emit. *)

--- a/llvm/include/llvm-c/DebugInfo.h
+++ b/llvm/include/llvm-c/DebugInfo.h
@@ -158,6 +158,8 @@ typedef enum {
 /**
  * The kind of metadata nodes.
  */
+// NOTE: New entries should always be appended instead of matching the order
+// in Metadata.def.
 enum {
   LLVMMDStringMetadataKind,
   LLVMConstantAsMetadataMetadataKind,
@@ -172,7 +174,6 @@ enum {
   LLVMDIEnumeratorMetadataKind,
   LLVMDIBasicTypeMetadataKind,
   LLVMDIDerivedTypeMetadataKind,
-  LLVMDISubrangeTypeMetadataKind,
   LLVMDICompositeTypeMetadataKind,
   LLVMDISubroutineTypeMetadataKind,
   LLVMDIFileMetadataKind,
@@ -196,6 +197,7 @@ enum {
   LLVMDIGenericSubrangeMetadataKind,
   LLVMDIArgListMetadataKind,
   LLVMDIAssignIDMetadataKind,
+  LLVMDISubrangeTypeMetadataKind,
 };
 typedef unsigned LLVMMetadataKind;
 


### PR DESCRIPTION
Inserting a new enum constant in the middle of the enum breaks the ABI for that enum. Commit e298fc2 introduced this issue, which was revealed because the OCaml binding tests failed.