### PR TITLE
[CIR] Fix unary op folding

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -110,7 +110,6 @@ struct MissingFeatures {
   static bool brCondOp() { return false; }
   static bool switchOp() { return false; }
   static bool tryOp() { return false; }
-  static bool unaryOp() { return false; }
   static bool selectOp() { return false; }
   static bool complexCreateOp() { return false; }
   static bool complexRealOp() { return false; }

--- a/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRCanonicalize.cpp
@@ -121,15 +121,14 @@ void CIRCanonicalizePass::runOnOperation() {
     assert(!cir::MissingFeatures::brCondOp());
     assert(!cir::MissingFeatures::switchOp());
     assert(!cir::MissingFeatures::tryOp());
-    assert(!cir::MissingFeatures::unaryOp());
     assert(!cir::MissingFeatures::selectOp());
     assert(!cir::MissingFeatures::complexCreateOp());
     assert(!cir::MissingFeatures::complexRealOp());
     assert(!cir::MissingFeatures::complexImagOp());
     assert(!cir::MissingFeatures::callOp());
-    // CastOp here is to perform a manual `fold` in
-    // applyOpPatternsGreedily
-    if (isa<BrOp, ScopeOp, CastOp>(op))
+    // CastOp and UnaryOp are here to perform a manual `fold` in
+    // applyOpPatternsGreedily.
+    if (isa<BrOp, ScopeOp, CastOp, UnaryOp>(op))
       ops.push_back(op);
   });
 

--- a/clang/test/CIR/Transforms/canonicalize.cir
+++ b/clang/test/CIR/Transforms/canonicalize.cir
@@ -36,8 +36,8 @@ module {
     %1 = cir.unary(not, %0) : !cir.bool, !cir.bool
     cir.return %1 : !cir.bool
   }
-  // CHECK:  cir.func @unary_not(%arg0: !cir.bool) -> !cir.bool
-  // CHECK:     cir.return %arg0 : !cir.bool
+  // CHECK:      cir.func @unary_not(%arg0: !cir.bool) -> !cir.bool
+  // CHECK-NEXT:   cir.return %arg0 : !cir.bool
 
   cir.func @cast1(%arg0: !cir.bool) -> !cir.bool {
     %0 = cir.cast(bool_to_int, %arg0 : !cir.bool), !s32i

--- a/clang/test/CIR/Transforms/canonicalize.cir
+++ b/clang/test/CIR/Transforms/canonicalize.cir
@@ -31,6 +31,14 @@ module {
   // CHECK-NEXT:   cir.return
   // CHECK-NEXT: }
 
+  cir.func @unary_not(%arg0: !cir.bool) -> !cir.bool {
+    %0 = cir.unary(not, %arg0) : !cir.bool, !cir.bool
+    %1 = cir.unary(not, %0) : !cir.bool, !cir.bool
+    cir.return %1 : !cir.bool
+  }
+  // CHECK:  cir.func @unary_not(%arg0: !cir.bool) -> !cir.bool
+  // CHECK:     cir.return %arg0 : !cir.bool
+
   cir.func @cast1(%arg0: !cir.bool) -> !cir.bool {
     %0 = cir.cast(bool_to_int, %arg0 : !cir.bool), !s32i
     %1 = cir.cast(int_to_bool, %0 : !s32i), !cir.bool


### PR DESCRIPTION
Unary ops had previously been omitted from the list of ops handled in the CIRCanonicalizePass. Although the incubator code doesn't use them directly, the mlir folding code does.

This change enables folding of unary ops by adding them to the list.