### PR TITLE
[LLDB] Refactored CPlusPlusLanguage::MethodName to break lldb-server dependencies

### DIFF
--- a/lldb/include/lldb/Core/Mangled.h
+++ b/lldb/include/lldb/Core/Mangled.h
@@ -246,6 +246,8 @@ public:
   ///     for s, otherwise the enumerator for the mangling scheme detected.
   static Mangled::ManglingScheme GetManglingScheme(llvm::StringRef const name);
 
+  static bool IsCPPMangledName(llvm::StringRef name);
+
   /// Decode a serialized version of this object from data.
   ///
   /// \param data

--- a/lldb/include/lldb/Core/Mangled.h
+++ b/lldb/include/lldb/Core/Mangled.h
@@ -246,7 +246,7 @@ public:
   ///     for s, otherwise the enumerator for the mangling scheme detected.
   static Mangled::ManglingScheme GetManglingScheme(llvm::StringRef const name);
 
-  static bool IsCPPMangledName(llvm::StringRef name);
+  static bool IsMangledName(llvm::StringRef name);
 
   /// Decode a serialized version of this object from data.
   ///

--- a/lldb/include/lldb/Core/RichManglingContext.h
+++ b/lldb/include/lldb/Core/RichManglingContext.h
@@ -12,6 +12,7 @@
 #include "lldb/lldb-forward.h"
 #include "lldb/lldb-private.h"
 
+#include "lldb/Target/Language.h"
 #include "lldb/Utility/ConstString.h"
 
 #include "llvm/ADT/Any.h"
@@ -67,11 +68,7 @@ private:
   char *m_ipd_buf;
   size_t m_ipd_buf_size = 2048;
 
-  /// Members for PluginCxxLanguage
-  /// Cannot forward declare inner class CPlusPlusLanguage::MethodName. The
-  /// respective header is in Plugins and including it from here causes cyclic
-  /// dependency. Instead keep a llvm::Any and cast it on-access in the cpp.
-  llvm::Any m_cxx_method_parser;
+  std::unique_ptr<Language::MethodName> m_cxx_method_parser;
 
   /// Clean up memory when using PluginCxxLanguage
   void ResetCxxMethodParser();
@@ -81,15 +78,6 @@ private:
 
   /// Uniform handling of string buffers for ItaniumPartialDemangler.
   llvm::StringRef processIPDStrResult(char *ipd_res, size_t res_len);
-
-  /// Cast the given parser to the given type. Ideally we would have a type
-  /// trait to deduce \a ParserT from a given InfoProvider, but unfortunately we
-  /// can't access CPlusPlusLanguage::MethodName from within the header.
-  template <class ParserT> static ParserT *get(llvm::Any parser) {
-    assert(parser.has_value());
-    assert(llvm::any_cast<ParserT *>(&parser));
-    return *llvm::any_cast<ParserT *>(&parser);
-  }
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Target/Language.h
+++ b/lldb/include/lldb/Target/Language.h
@@ -214,6 +214,104 @@ public:
     return std::vector<Language::MethodNameVariant>();
   };
 
+  class MethodName {
+  public:
+    MethodName() {}
+
+    MethodName(ConstString full)
+        : m_full(full), m_basename(), m_context(), m_arguments(),
+          m_qualifiers(), m_return_type(), m_scope_qualified(), m_parsed(false),
+          m_parse_error(false) {}
+
+    virtual ~MethodName() {};
+
+    void Clear() {
+      m_full.Clear();
+      m_basename = llvm::StringRef();
+      m_context = llvm::StringRef();
+      m_arguments = llvm::StringRef();
+      m_qualifiers = llvm::StringRef();
+      m_return_type = llvm::StringRef();
+      m_scope_qualified.clear();
+      m_parsed = false;
+      m_parse_error = false;
+    }
+
+    bool IsValid() {
+      if (!m_parsed)
+        Parse();
+      if (m_parse_error)
+        return false;
+      return (bool)m_full;
+    }
+
+    ConstString GetFullName() const { return m_full; }
+
+    llvm::StringRef GetBasename() {
+      if (!m_parsed)
+        Parse();
+      return m_basename;
+    }
+
+    llvm::StringRef GetContext() {
+      if (!m_parsed)
+        Parse();
+      return m_context;
+    }
+
+    llvm::StringRef GetArguments() {
+      if (!m_parsed)
+        Parse();
+      return m_arguments;
+    }
+
+    llvm::StringRef GetQualifiers() {
+      if (!m_parsed)
+        Parse();
+      return m_qualifiers;
+    }
+
+    llvm::StringRef GetReturnType() {
+      if (!m_parsed)
+        Parse();
+      return m_return_type;
+    }
+
+    std::string GetScopeQualifiedName() {
+      if (!m_parsed)
+        Parse();
+      return m_scope_qualified;
+    }
+
+  protected:
+    virtual void Parse() {
+      m_parsed = true;
+      m_parse_error = true;
+    }
+
+    ConstString m_full; // Full name:
+                        // "size_t lldb::SBTarget::GetBreakpointAtIndex(unsigned
+                        // int) const"
+    llvm::StringRef m_basename;    // Basename:     "GetBreakpointAtIndex"
+    llvm::StringRef m_context;     // Decl context: "lldb::SBTarget"
+    llvm::StringRef m_arguments;   // Arguments:    "(unsigned int)"
+    llvm::StringRef m_qualifiers;  // Qualifiers:   "const"
+    llvm::StringRef m_return_type; // Return type:  "size_t"
+    std::string m_scope_qualified;
+    bool m_parsed = false;
+    bool m_parse_error = false;
+  };
+
+  virtual std::unique_ptr<Language::MethodName>
+  GetMethodName(ConstString name) const {
+    return std::make_unique<Language::MethodName>(name);
+  };
+
+  virtual std::pair<lldb::FunctionNameType, llvm::StringRef>
+  GetFunctionNameInfo(ConstString name) const {
+    return std::pair{lldb::eFunctionNameTypeNone, llvm::StringRef()};
+  };
+
   /// Returns true iff the given symbol name is compatible with the mangling
   /// scheme of this language.
   ///

--- a/lldb/source/Core/CMakeLists.txt
+++ b/lldb/source/Core/CMakeLists.txt
@@ -71,8 +71,6 @@ add_lldb_library(lldbCore
     lldbUtility
     lldbValueObject
     lldbVersion
-    lldbPluginCPlusPlusLanguage
-    lldbPluginObjCLanguage
     ${LLDB_CURSES_LIBS}
 
   CLANG_LIBS

--- a/lldb/source/Core/CMakeLists.txt
+++ b/lldb/source/Core/CMakeLists.txt
@@ -16,8 +16,7 @@ if (LLDB_ENABLE_CURSES)
   endif()
 endif()
 
-# TODO: Add property `NO_PLUGIN_DEPENDENCIES` to lldbCore
-add_lldb_library(lldbCore
+add_lldb_library(lldbCore NO_PLUGIN_DEPENDENCIES
   Address.cpp
   AddressRange.cpp
   AddressRangeListImpl.cpp

--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -39,6 +39,11 @@ static inline bool cstring_is_mangled(llvm::StringRef s) {
 
 #pragma mark Mangled
 
+bool Mangled::IsCPPMangledName(llvm::StringRef name) {
+  Mangled::ManglingScheme scheme = Mangled::GetManglingScheme(name);
+  return (scheme != Mangled::eManglingSchemeNone);
+}
+
 Mangled::ManglingScheme Mangled::GetManglingScheme(llvm::StringRef const name) {
   if (name.empty())
     return Mangled::eManglingSchemeNone;

--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -33,15 +33,10 @@
 #include <cstring>
 using namespace lldb_private;
 
-static inline bool cstring_is_mangled(llvm::StringRef s) {
-  return Mangled::GetManglingScheme(s) != Mangled::eManglingSchemeNone;
-}
-
 #pragma mark Mangled
 
-bool Mangled::IsCPPMangledName(llvm::StringRef name) {
-  Mangled::ManglingScheme scheme = Mangled::GetManglingScheme(name);
-  return (scheme != Mangled::eManglingSchemeNone);
+bool Mangled::IsMangledName(llvm::StringRef name) {
+  return Mangled::GetManglingScheme(name) != Mangled::eManglingSchemeNone;
 }
 
 Mangled::ManglingScheme Mangled::GetManglingScheme(llvm::StringRef const name) {
@@ -126,7 +121,7 @@ int Mangled::Compare(const Mangled &a, const Mangled &b) {
 
 void Mangled::SetValue(ConstString name) {
   if (name) {
-    if (cstring_is_mangled(name.GetStringRef())) {
+    if (IsMangledName(name.GetStringRef())) {
       m_demangled.Clear();
       m_mangled = name;
     } else {

--- a/lldb/source/Core/RichManglingContext.cpp
+++ b/lldb/source/Core/RichManglingContext.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Core/RichManglingContext.h"
-#include "Plugins/Language/CPlusPlus/CPlusPlusLanguage.h"
 #include "lldb/Utility/LLDBLog.h"
 
 #include "llvm/ADT/StringRef.h"
@@ -24,9 +23,8 @@ RichManglingContext::~RichManglingContext() {
 void RichManglingContext::ResetCxxMethodParser() {
   // If we want to support parsers for other languages some day, we need a
   // switch here to delete the correct parser type.
-  if (m_cxx_method_parser.has_value()) {
+  if (m_cxx_method_parser) {
     assert(m_provider == PluginCxxLanguage);
-    delete get<CPlusPlusLanguage::MethodName>(m_cxx_method_parser);
     m_cxx_method_parser.reset();
   }
 }
@@ -58,8 +56,11 @@ bool RichManglingContext::FromItaniumName(ConstString mangled) {
 }
 
 bool RichManglingContext::FromCxxMethodName(ConstString demangled) {
+  auto *lang = Language::FindPlugin(eLanguageTypeC_plus_plus);
+  if (!lang)
+    return false;
   ResetProvider(PluginCxxLanguage);
-  m_cxx_method_parser = new CPlusPlusLanguage::MethodName(demangled);
+  m_cxx_method_parser = lang->GetMethodName(demangled);
   return true;
 }
 
@@ -70,8 +71,7 @@ bool RichManglingContext::IsCtorOrDtor() const {
     return m_ipd.isCtorOrDtor();
   case PluginCxxLanguage: {
     // We can only check for destructors here.
-    auto base_name =
-        get<CPlusPlusLanguage::MethodName>(m_cxx_method_parser)->GetBasename();
+    auto base_name = m_cxx_method_parser->GetBasename();
     return base_name.starts_with("~");
   }
   case None:
@@ -118,8 +118,7 @@ llvm::StringRef RichManglingContext::ParseFunctionBaseName() {
     return processIPDStrResult(buf, n);
   }
   case PluginCxxLanguage:
-    return get<CPlusPlusLanguage::MethodName>(m_cxx_method_parser)
-        ->GetBasename();
+    return m_cxx_method_parser->GetBasename();
   case None:
     return {};
   }
@@ -135,8 +134,7 @@ llvm::StringRef RichManglingContext::ParseFunctionDeclContextName() {
     return processIPDStrResult(buf, n);
   }
   case PluginCxxLanguage:
-    return get<CPlusPlusLanguage::MethodName>(m_cxx_method_parser)
-        ->GetContext();
+    return m_cxx_method_parser->GetContext();
   case None:
     return {};
   }
@@ -152,9 +150,7 @@ llvm::StringRef RichManglingContext::ParseFullName() {
     return processIPDStrResult(buf, n);
   }
   case PluginCxxLanguage:
-    return get<CPlusPlusLanguage::MethodName>(m_cxx_method_parser)
-        ->GetFullName()
-        .GetStringRef();
+    return m_cxx_method_parser->GetFullName().GetStringRef();
   case None:
     return {};
   }

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
@@ -36,6 +36,7 @@
 #include "lldb/Symbol/Variable.h"
 #include "lldb/Symbol/VariableList.h"
 #include "lldb/Target/ExecutionContext.h"
+#include "lldb/Target/Language.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/RegisterContext.h"
 #include "lldb/Target/StackFrame.h"
@@ -57,7 +58,6 @@
 #include "clang/AST/DeclarationName.h"
 #include "clang/AST/RecursiveASTVisitor.h"
 
-#include "Plugins/Language/CPlusPlus/CPlusPlusLanguage.h"
 #include "Plugins/LanguageRuntime/CPlusPlus/CPPLanguageRuntime.h"
 #include "Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h"
 
@@ -1811,7 +1811,7 @@ void ClangExpressionDeclMap::AddOneFunction(NameSearchContext &context,
     const auto lang = function->GetCompileUnit()->GetLanguage();
     const auto name = function->GetMangled().GetMangledName().AsCString();
     const bool extern_c =
-        (Language::LanguageIsC(lang) && !Mangled::IsCPPMangledName(name)) ||
+        (Language::LanguageIsC(lang) && !Mangled::IsMangledName(name)) ||
         (Language::LanguageIsObjC(lang) &&
          !Language::LanguageIsCPlusPlus(lang));
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
@@ -18,6 +18,7 @@
 #include "NameSearchContext.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 #include "lldb/Core/Address.h"
+#include "lldb/Core/Mangled.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Expression/DiagnosticManager.h"
@@ -1809,10 +1810,10 @@ void ClangExpressionDeclMap::AddOneFunction(NameSearchContext &context,
 
     const auto lang = function->GetCompileUnit()->GetLanguage();
     const auto name = function->GetMangled().GetMangledName().AsCString();
-    const bool extern_c = (Language::LanguageIsC(lang) &&
-                           !CPlusPlusLanguage::IsCPPMangledName(name)) ||
-                          (Language::LanguageIsObjC(lang) &&
-                           !Language::LanguageIsCPlusPlus(lang));
+    const bool extern_c =
+        (Language::LanguageIsC(lang) && !Mangled::IsCPPMangledName(name)) ||
+        (Language::LanguageIsObjC(lang) &&
+         !Language::LanguageIsCPlusPlus(lang));
 
     if (!extern_c) {
       TypeSystem *type_system = function->GetDeclContext().GetTypeSystem();

--- a/lldb/source/Plugins/Language/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_subdirectory(ClangCommon)
+
+# Preserve language plug-ins sorting.
 add_subdirectory(CPlusPlus)
 add_subdirectory(ObjC)
 add_subdirectory(ObjCPlusPlus)

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -72,7 +72,7 @@ CPlusPlusLanguage::GetMethodName(ConstString full_name) const {
 
 std::pair<FunctionNameType, llvm::StringRef>
 CPlusPlusLanguage::GetFunctionNameInfo(ConstString name) const {
-  if (Mangled::IsCPPMangledName(name.GetCString()))
+  if (Mangled::IsMangledName(name.GetCString()))
     return {eFunctionNameTypeFull, llvm::StringRef()};
 
   FunctionNameType func_name_type = eFunctionNameTypeNone;
@@ -99,7 +99,7 @@ CPlusPlusLanguage::GetFunctionNameInfo(ConstString name) const {
 
 bool CPlusPlusLanguage::SymbolNameFitsToLanguage(Mangled mangled) const {
   const char *mangled_name = mangled.GetMangledName().GetCString();
-  return mangled_name && Mangled::IsCPPMangledName(mangled_name);
+  return mangled_name && Mangled::IsMangledName(mangled_name);
 }
 
 ConstString CPlusPlusLanguage::GetDemangledFunctionNameWithoutArguments(

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -62,9 +62,44 @@ void CPlusPlusLanguage::Terminate() {
   PluginManager::UnregisterPlugin(CreateInstance);
 }
 
+std::unique_ptr<Language::MethodName>
+CPlusPlusLanguage::GetMethodName(ConstString full_name) const {
+  std::unique_ptr<CPlusPlusLanguage::CPPMethodName> cpp_method =
+      std::make_unique<CPlusPlusLanguage::CPPMethodName>(full_name);
+  cpp_method->IsValid();
+  return cpp_method;
+}
+
+std::pair<FunctionNameType, llvm::StringRef>
+CPlusPlusLanguage::GetFunctionNameInfo(ConstString name) const {
+  if (Mangled::IsCPPMangledName(name.GetCString()))
+    return {eFunctionNameTypeFull, llvm::StringRef()};
+
+  FunctionNameType func_name_type = eFunctionNameTypeNone;
+  CPlusPlusLanguage::CPPMethodName method(name);
+  llvm::StringRef basename = method.GetBasename();
+  if (basename.empty()) {
+    llvm::StringRef context;
+    func_name_type |=
+        (ExtractContextAndIdentifier(name.GetCString(), context, basename)
+             ? (eFunctionNameTypeMethod | eFunctionNameTypeBase)
+             : eFunctionNameTypeFull);
+  } else {
+    func_name_type |= (eFunctionNameTypeMethod | eFunctionNameTypeBase);
+  }
+
+  if (!method.GetQualifiers().empty()) {
+    // There is a 'const' or other qualifier following the end of the function
+    // parens, this can't be a eFunctionNameTypeBase.
+    func_name_type &= ~eFunctionNameTypeBase;
+  }
+
+  return {func_name_type, basename};
+}
+
 bool CPlusPlusLanguage::SymbolNameFitsToLanguage(Mangled mangled) const {
   const char *mangled_name = mangled.GetMangledName().GetCString();
-  return mangled_name && CPlusPlusLanguage::IsCPPMangledName(mangled_name);
+  return mangled_name && Mangled::IsCPPMangledName(mangled_name);
 }
 
 ConstString CPlusPlusLanguage::GetDemangledFunctionNameWithoutArguments(
@@ -81,7 +116,7 @@ ConstString CPlusPlusLanguage::GetDemangledFunctionNameWithoutArguments(
                                         // eventually handle eSymbolTypeData,
                                         // we will want this back)
     {
-      CPlusPlusLanguage::MethodName cxx_method(demangled_name);
+      CPlusPlusLanguage::CPPMethodName cxx_method(demangled_name);
       if (!cxx_method.GetBasename().empty()) {
         std::string shortname;
         if (!cxx_method.GetContext().empty())
@@ -104,17 +139,6 @@ Language *CPlusPlusLanguage::CreateInstance(lldb::LanguageType language) {
       language != eLanguageTypeObjC_plus_plus)
     return new CPlusPlusLanguage();
   return nullptr;
-}
-
-void CPlusPlusLanguage::MethodName::Clear() {
-  m_full.Clear();
-  m_basename = llvm::StringRef();
-  m_context = llvm::StringRef();
-  m_arguments = llvm::StringRef();
-  m_qualifiers = llvm::StringRef();
-  m_return_type = llvm::StringRef();
-  m_parsed = false;
-  m_parse_error = false;
 }
 
 static bool ReverseFindMatchingChars(const llvm::StringRef &s,
@@ -181,7 +205,7 @@ static bool PrettyPrintFunctionNameWithArgs(Stream &out_stream,
                                             char const *full_name,
                                             ExecutionContextScope *exe_scope,
                                             VariableList const &args) {
-  CPlusPlusLanguage::MethodName cpp_method{ConstString(full_name)};
+  CPlusPlusLanguage::CPPMethodName cpp_method{ConstString(full_name)};
 
   if (!cpp_method.IsValid())
     return false;
@@ -208,7 +232,7 @@ static bool PrettyPrintFunctionNameWithArgs(Stream &out_stream,
   return true;
 }
 
-bool CPlusPlusLanguage::MethodName::TrySimplifiedParse() {
+bool CPlusPlusLanguage::CPPMethodName::TrySimplifiedParse() {
   // This method tries to parse simple method definitions which are presumably
   // most comman in user programs. Definitions that can be parsed by this
   // function don't have return types and templates in the name.
@@ -251,7 +275,7 @@ bool CPlusPlusLanguage::MethodName::TrySimplifiedParse() {
   return false;
 }
 
-void CPlusPlusLanguage::MethodName::Parse() {
+void CPlusPlusLanguage::CPPMethodName::Parse() {
   if (!m_parsed && m_full) {
     if (TrySimplifiedParse()) {
       m_parse_error = false;
@@ -268,55 +292,19 @@ void CPlusPlusLanguage::MethodName::Parse() {
         m_parse_error = true;
       }
     }
+    if (m_context.empty()) {
+      m_scope_qualified = std::string(m_basename);
+    } else {
+      m_scope_qualified = m_context;
+      m_scope_qualified += "::";
+      m_scope_qualified += m_basename;
+    }
     m_parsed = true;
   }
 }
 
-llvm::StringRef CPlusPlusLanguage::MethodName::GetBasename() {
-  if (!m_parsed)
-    Parse();
-  return m_basename;
-}
-
-llvm::StringRef CPlusPlusLanguage::MethodName::GetContext() {
-  if (!m_parsed)
-    Parse();
-  return m_context;
-}
-
-llvm::StringRef CPlusPlusLanguage::MethodName::GetArguments() {
-  if (!m_parsed)
-    Parse();
-  return m_arguments;
-}
-
-llvm::StringRef CPlusPlusLanguage::MethodName::GetQualifiers() {
-  if (!m_parsed)
-    Parse();
-  return m_qualifiers;
-}
-
-llvm::StringRef CPlusPlusLanguage::MethodName::GetReturnType() {
-  if (!m_parsed)
-    Parse();
-  return m_return_type;
-}
-
-std::string CPlusPlusLanguage::MethodName::GetScopeQualifiedName() {
-  if (!m_parsed)
-    Parse();
-  if (m_context.empty())
-    return std::string(m_basename);
-
-  std::string res;
-  res += m_context;
-  res += "::";
-  res += m_basename;
-  return res;
-}
-
 llvm::StringRef
-CPlusPlusLanguage::MethodName::GetBasenameNoTemplateParameters() {
+CPlusPlusLanguage::CPPMethodName::GetBasenameNoTemplateParameters() {
   llvm::StringRef basename = GetBasename();
   size_t arg_start, arg_end;
   llvm::StringRef parens("<>", 2);
@@ -326,7 +314,7 @@ CPlusPlusLanguage::MethodName::GetBasenameNoTemplateParameters() {
   return basename;
 }
 
-bool CPlusPlusLanguage::MethodName::ContainsPath(llvm::StringRef path) {
+bool CPlusPlusLanguage::CPPMethodName::ContainsPath(llvm::StringRef path) {
   if (!m_parsed)
     Parse();
 
@@ -375,21 +363,9 @@ bool CPlusPlusLanguage::MethodName::ContainsPath(llvm::StringRef path) {
   return false;
 }
 
-bool CPlusPlusLanguage::IsCPPMangledName(llvm::StringRef name) {
-  // FIXME!! we should really run through all the known C++ Language plugins
-  // and ask each one if this is a C++ mangled name
-
-  Mangled::ManglingScheme scheme = Mangled::GetManglingScheme(name);
-
-  if (scheme == Mangled::eManglingSchemeNone)
-    return false;
-
-  return true;
-}
-
 bool CPlusPlusLanguage::DemangledNameContainsPath(llvm::StringRef path,
                                                   ConstString demangled) const {
-  MethodName demangled_name(demangled);
+  CPPMethodName demangled_name(demangled);
   return demangled_name.ContainsPath(path);
 }
 
@@ -588,7 +564,7 @@ ConstString CPlusPlusLanguage::FindBestAlternateFunctionMangledName(
   if (!demangled)
     return ConstString();
 
-  CPlusPlusLanguage::MethodName cpp_name(demangled);
+  CPlusPlusLanguage::CPPMethodName cpp_name(demangled);
   std::string scope_qualified_name = cpp_name.GetScopeQualifiedName();
 
   if (!scope_qualified_name.size())
@@ -611,7 +587,7 @@ ConstString CPlusPlusLanguage::FindBestAlternateFunctionMangledName(
     Mangled mangled(alternate_mangled_name);
     ConstString demangled = mangled.GetDemangledName();
 
-    CPlusPlusLanguage::MethodName alternate_cpp_name(demangled);
+    CPlusPlusLanguage::CPPMethodName alternate_cpp_name(demangled);
     if (!cpp_name.IsValid())
       continue;
 

--- a/lldb/source/Plugins/Language/ObjC/ObjCLanguage.cpp
+++ b/lldb/source/Plugins/Language/ObjC/ObjCLanguage.cpp
@@ -226,13 +226,11 @@ std::pair<FunctionNameType, llvm::StringRef>
 ObjCLanguage::GetFunctionNameInfo(ConstString name) const {
   FunctionNameType func_name_type = eFunctionNameTypeNone;
 
-  if (ObjCLanguage::IsPossibleObjCMethodName(name.GetCString())) {
+  if (ObjCLanguage::IsPossibleObjCMethodName(name.GetCString()))
     func_name_type = eFunctionNameTypeFull;
-  }
 
-  if (ObjCLanguage::IsPossibleObjCSelector(name.GetCString())) {
+  if (ObjCLanguage::IsPossibleObjCSelector(name.GetCString()))
     func_name_type |= eFunctionNameTypeSelector;
-  }
 
   return {func_name_type, llvm::StringRef()};
 }

--- a/lldb/source/Plugins/Language/ObjC/ObjCLanguage.cpp
+++ b/lldb/source/Plugins/Language/ObjC/ObjCLanguage.cpp
@@ -222,6 +222,21 @@ ObjCLanguage::GetMethodNameVariants(ConstString method_name) const {
   return variant_names;
 }
 
+std::pair<FunctionNameType, llvm::StringRef>
+ObjCLanguage::GetFunctionNameInfo(ConstString name) const {
+  FunctionNameType func_name_type = eFunctionNameTypeNone;
+
+  if (ObjCLanguage::IsPossibleObjCMethodName(name.GetCString())) {
+    func_name_type = eFunctionNameTypeFull;
+  }
+
+  if (ObjCLanguage::IsPossibleObjCSelector(name.GetCString())) {
+    func_name_type |= eFunctionNameTypeSelector;
+  }
+
+  return {func_name_type, llvm::StringRef()};
+}
+
 bool ObjCLanguage::SymbolNameFitsToLanguage(Mangled mangled) const {
   ConstString demangled_name = mangled.GetDemangledName();
   if (!demangled_name)

--- a/lldb/source/Plugins/Language/ObjC/ObjCLanguage.h
+++ b/lldb/source/Plugins/Language/ObjC/ObjCLanguage.h
@@ -142,6 +142,9 @@ public:
   std::vector<Language::MethodNameVariant>
   GetMethodNameVariants(ConstString method_name) const override;
 
+  std::pair<lldb::FunctionNameType, llvm::StringRef>
+  GetFunctionNameInfo(ConstString name) const override;
+
   bool SymbolNameFitsToLanguage(Mangled mangled) const override;
 
   lldb::TypeCategoryImplSP GetFormatters() override;

--- a/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
@@ -14,6 +14,7 @@
 #include "clang/Lex/Lexer.h"
 
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
+#include "lldb/Core/Mangled.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Symbol/CompileUnit.h"
@@ -53,7 +54,6 @@
 #include "llvm/DebugInfo/PDB/PDBSymbolTypeTypedef.h"
 #include "llvm/DebugInfo/PDB/PDBSymbolTypeUDT.h"
 
-#include "Plugins/Language/CPlusPlus/CPlusPlusLanguage.h"
 #include "Plugins/Language/CPlusPlus/MSVCUndecoratedNameParser.h"
 #include "Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.h"
 
@@ -1279,7 +1279,7 @@ void SymbolFilePDB::CacheFunctionNames() {
       if (name.empty())
         continue;
 
-      if (CPlusPlusLanguage::IsCPPMangledName(name.c_str())) {
+      if (Mangled::IsCPPMangledName(name.c_str())) {
         // PDB public symbol has mangled name for its associated function.
         if (auto vm_addr = pub_sym_up->getVirtualAddress()) {
           if (auto it = addr_ids.find(vm_addr); it != addr_ids.end())

--- a/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
@@ -1279,7 +1279,7 @@ void SymbolFilePDB::CacheFunctionNames() {
       if (name.empty())
         continue;
 
-      if (Mangled::IsCPPMangledName(name.c_str())) {
+      if (Mangled::IsMangledName(name.c_str())) {
         // PDB public symbol has mangled name for its associated function.
         if (auto vm_addr = pub_sym_up->getVirtualAddress()) {
           if (auto it = addr_ids.find(vm_addr); it != addr_ids.end())

--- a/lldb/unittests/Core/CMakeLists.txt
+++ b/lldb/unittests/Core/CMakeLists.txt
@@ -18,6 +18,7 @@ add_lldb_unittest(LLDBCoreTests
   LINK_LIBS
     lldbCore
     lldbHost
+    lldbPluginCPlusPlusLanguage
     lldbPluginObjectFileELF
     lldbPluginObjectFileMachO
     lldbPluginObjectFilePECOFF

--- a/lldb/unittests/Core/RichManglingContextTest.cpp
+++ b/lldb/unittests/Core/RichManglingContextTest.cpp
@@ -8,6 +8,8 @@
 
 #include "lldb/Core/RichManglingContext.h"
 
+#include "Plugins/Language/CPlusPlus/CPlusPlusLanguage.h"
+#include "TestingSupport/SubsystemRAII.h"
 #include "lldb/Utility/ConstString.h"
 
 #include "gtest/gtest.h"
@@ -27,6 +29,9 @@ TEST(RichManglingContextTest, Basic) {
 }
 
 TEST(RichManglingContextTest, FromCxxMethodName) {
+
+  SubsystemRAII<CPlusPlusLanguage> lang;
+
   RichManglingContext ItaniumRMC;
   ConstString mangled("_ZN3foo3barEv");
   EXPECT_TRUE(ItaniumRMC.FromItaniumName(mangled));
@@ -66,6 +71,8 @@ TEST(RichManglingContextTest, SwitchProvider) {
 
   EXPECT_TRUE(RMC.FromItaniumName(ConstString(mangled)));
   EXPECT_EQ("foo::bar()", RMC.ParseFullName());
+
+  SubsystemRAII<CPlusPlusLanguage> lang;
 
   EXPECT_TRUE(RMC.FromCxxMethodName(ConstString(demangled)));
   EXPECT_EQ("foo::bar()", RMC.ParseFullName());

--- a/lldb/unittests/Language/CPlusPlus/CPlusPlusLanguageTest.cpp
+++ b/lldb/unittests/Language/CPlusPlus/CPlusPlusLanguageTest.cpp
@@ -212,7 +212,7 @@ TEST(CPlusPlusLanguage, MethodNameParsing) {
        "A::operator<=>[abi:tag]<A::B>"}};
 
   for (const auto &test : test_cases) {
-    CPlusPlusLanguage::MethodName method(ConstString(test.input));
+    CPlusPlusLanguage::CPPMethodName method(ConstString(test.input));
     EXPECT_TRUE(method.IsValid()) << test.input;
     if (method.IsValid()) {
       EXPECT_EQ(test.return_type, method.GetReturnType().str());
@@ -243,22 +243,22 @@ TEST(CPlusPlusLanguage, InvalidMethodNameParsing) {
   };
 
   for (const auto &name : test_cases) {
-    CPlusPlusLanguage::MethodName method{ConstString(name)};
+    CPlusPlusLanguage::CPPMethodName method{ConstString(name)};
     EXPECT_FALSE(method.IsValid()) << name;
   }
 }
 
 TEST(CPlusPlusLanguage, ContainsPath) {
-  CPlusPlusLanguage::MethodName 
-      reference_1(ConstString("int foo::bar::func01(int a, double b)"));
-  CPlusPlusLanguage::MethodName
-      reference_2(ConstString("int foofoo::bar::func01(std::string a, int b)"));
-  CPlusPlusLanguage::MethodName reference_3(ConstString("int func01()"));
-  CPlusPlusLanguage::MethodName 
-      reference_4(ConstString("bar::baz::operator bool()"));
-  CPlusPlusLanguage::MethodName reference_5(
+  CPlusPlusLanguage::CPPMethodName reference_1(
+      ConstString("int foo::bar::func01(int a, double b)"));
+  CPlusPlusLanguage::CPPMethodName reference_2(
+      ConstString("int foofoo::bar::func01(std::string a, int b)"));
+  CPlusPlusLanguage::CPPMethodName reference_3(ConstString("int func01()"));
+  CPlusPlusLanguage::CPPMethodName reference_4(
+      ConstString("bar::baz::operator bool()"));
+  CPlusPlusLanguage::CPPMethodName reference_5(
       ConstString("bar::baz::operator bool<int, Type<double>>()"));
-  CPlusPlusLanguage::MethodName reference_6(ConstString(
+  CPlusPlusLanguage::CPPMethodName reference_6(ConstString(
       "bar::baz::operator<<<Type<double>, Type<std::vector<double>>>()"));
 
   EXPECT_TRUE(reference_1.ContainsPath(""));


### PR DESCRIPTION
This patch addresses the issue #129543.
After this patch the size of lldb-server is reduced by 9MB.

Co-authored-by: @bulbazord Alex Langford