### PR TITLE
[lld-macho] Don't double emit reexported libraries

### DIFF
--- a/lld/MachO/Writer.cpp
+++ b/lld/MachO/Writer.cpp
@@ -941,16 +941,17 @@ template <class LP> void Writer::createLoadCommands() {
     LoadCommandType lcType = LC_LOAD_DYLIB;
     if (dylibFile->reexport) {
       if (dylibFile->forceWeakImport)
-        warn(path::filename(dylibFile->getName()) + " is re-exported so cannot be weak-linked");
+        warn(path::filename(dylibFile->getName()) +
+             " is re-exported so cannot be weak-linked");
 
       lcType = LC_REEXPORT_DYLIB;
-    } else if (dylibFile->forceWeakImport || dylibFile->refState == RefState::Weak) {
+    } else if (dylibFile->forceWeakImport ||
+               dylibFile->refState == RefState::Weak) {
       lcType = LC_LOAD_WEAK_DYLIB;
     }
     in.header->addLoadCommand(make<LCDylib>(lcType, dylibFile->installName,
-                                        dylibFile->compatibilityVersion,
-                                        dylibFile->currentVersion));
-
+                                            dylibFile->compatibilityVersion,
+                                            dylibFile->currentVersion));
   }
 
   for (const auto &dyldEnv : config->dyldEnvs)

--- a/lld/test/MachO/sub-library.s
+++ b/lld/test/MachO/sub-library.s
@@ -42,6 +42,17 @@
 # REEXPORT-HEADERS-NOT: Load command
 # REEXPORT-HEADERS:     name    [[PATH]]
 
+## Check that specifying a library both with `l` and `reexport_library`
+## doesn't emit two load commands.
+# RUN: %lld -dylib -reexport_library %t/libgoodbye.dylib \
+# RUN:   -L%t -lgoodbye %t/libsuper.o -o %t/libsuper.dylib
+# RUN: llvm-otool -L %t/libsuper.dylib | FileCheck %s \
+# RUN:   --check-prefix=REEXPORT-DOUBLE -DPATH=%t/libgoodbye.dylib
+
+# REEXPORT-DOUBLE: [[PATH]]
+# REEXPORT-DOUBLE-SAME: reexport
+# REEXPORT-DOUBLE-NOT: [[PATH]]
+
 # RUN: llvm-mc -filetype=obj -triple=x86_64-apple-darwin %s -o %t/sub-library.o
 # RUN: %lld -o %t/sub-library -L%t -lsuper %t/sub-library.o
 


### PR DESCRIPTION
When a library is specified with both `-l` and `-reexport_libraries`, lld will emit two load commands for it, in contrast with ld64. 
In an upcoming version of macOS, this fails dyld validation; see https://crbug.com/404905688