### PR TITLE
[bazel] add missing dep to errno_test_helpers

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
@@ -80,6 +80,7 @@ libc_test_library(
     ],
     deps = [
         ":LibcUnitTest",
+        "//libc:__support_macros_config",
         "//libc:errno",
     ],
 )


### PR DESCRIPTION
Bazel doesn't complain, but downstream it's causing build failures.
