### PR TITLE
[LLD] [COFF] Add a few more mingw libs to skip autoexports for

### DIFF
--- a/lld/COFF/MinGW.cpp
+++ b/lld/COFF/MinGW.cpp
@@ -52,7 +52,12 @@ AutoExporter::AutoExporter(
       "libflang_rt.runtime",
       "libunwind",
       "libmsvcrt",
+      "libmsvcrt-os",
       "libucrtbase",
+      "libucrt",
+      "libucrtapp",
+      "libpthread",
+      "libwinpthread",
   };
 
   excludeObjects = {


### PR DESCRIPTION
"libmsvcrt-os" was added to the list of excluded libs in binutils in 9d9c67b06c1bf4c4550e3de0eb575c2bfbe96df9 in 2017.

"libucrt" was added in c4a8df19ba0a82aa8dea88d9f72ed9e63cb1fa84 in 2022.

"libucrtapp" isn't in the binutils exclusion list yet, but I'll submit a patch for that soon. Since
0d403d5dd13ce22c07418058f3b640708992890c in mingw-w64 (in 2020), there's such a third variant of the UCRT import library available.

Since 18df3e8323dcf9fdfec56b5f12c04a9c723a0931 in 2025, "libpthread" and "libwinpthread" are also excluded.
