### PR TITLE
[compiler-rt] Propagate sysroot from CMake to msan tests

### DIFF
--- a/compiler-rt/lib/msan/tests/CMakeLists.txt
+++ b/compiler-rt/lib/msan/tests/CMakeLists.txt
@@ -63,7 +63,11 @@ set(MSAN_UNITTEST_LINK_FLAGS
   # inputs.
 )
 
-append_list_if(COMPILER_RT_HAS_LIBDL -ldl MSAN_UNITTEST_LINK_FLAGS)
+if (LINUX)
+  append_list_if(CMAKE_SYSROOT "--sysroot=${CMAKE_SYSROOT}" MSAN_UNITTEST_LINK_FLAGS)
+endif()
+
+  append_list_if(COMPILER_RT_HAS_LIBDL -ldl MSAN_UNITTEST_LINK_FLAGS)
 
 macro(msan_compile obj_list source arch kind cflags)
   sanitizer_test_compile(

--- a/compiler-rt/lib/msan/tests/CMakeLists.txt
+++ b/compiler-rt/lib/msan/tests/CMakeLists.txt
@@ -63,11 +63,10 @@ set(MSAN_UNITTEST_LINK_FLAGS
   # inputs.
 )
 
-if (LINUX)
-  append_list_if(CMAKE_SYSROOT "--sysroot=${CMAKE_SYSROOT}" MSAN_UNITTEST_LINK_FLAGS)
-endif()
+append_list_if(CMAKE_SYSROOT "--sysroot=${CMAKE_SYSROOT}" MSAN_UNITTEST_COMMON_CFLAGS)
+append_list_if(CMAKE_SYSROOT "--sysroot=${CMAKE_SYSROOT}" MSAN_UNITTEST_LINK_FLAGS)
 
-  append_list_if(COMPILER_RT_HAS_LIBDL -ldl MSAN_UNITTEST_LINK_FLAGS)
+append_list_if(COMPILER_RT_HAS_LIBDL -ldl MSAN_UNITTEST_LINK_FLAGS)
 
 macro(msan_compile obj_list source arch kind cflags)
   sanitizer_test_compile(

--- a/compiler-rt/test/msan/lit.cfg.py
+++ b/compiler-rt/test/msan/lit.cfg.py
@@ -18,6 +18,11 @@ clang_msan_cflags = (
     ]
     + [config.target_cflags]
     + config.debug_info_flags
+    + (
+        ["--sysroot", config.cmake_sysroot]
+        if config.cmake_sysroot and config.host_os == "Linux"
+        else []
+    )
 )
 # Some Msan tests leverage backtrace() which requires libexecinfo on FreeBSD.
 if config.host_os == "FreeBSD":

--- a/compiler-rt/test/msan/lit.cfg.py
+++ b/compiler-rt/test/msan/lit.cfg.py
@@ -18,12 +18,9 @@ clang_msan_cflags = (
     ]
     + [config.target_cflags]
     + config.debug_info_flags
-    + (
-        ["--sysroot", config.cmake_sysroot]
-        if config.cmake_sysroot and config.host_os == "Linux"
-        else []
-    )
 )
+if config.cmake_sysroot:
+    clang_msan_cflags += [f"--sysroot={config.cmake_sysroot}"]
 # Some Msan tests leverage backtrace() which requires libexecinfo on FreeBSD.
 if config.host_os == "FreeBSD":
     clang_msan_cflags += ["-lexecinfo", "-fPIC"]

--- a/compiler-rt/test/msan/lit.site.cfg.py.in
+++ b/compiler-rt/test/msan/lit.site.cfg.py.in
@@ -6,6 +6,7 @@ config.target_cflags = "@MSAN_TEST_TARGET_CFLAGS@"
 config.target_arch = "@MSAN_TEST_TARGET_ARCH@"
 config.use_lld = @MSAN_TEST_USE_LLD@
 config.use_thinlto = @MSAN_TEST_USE_THINLTO@
+config.cmake_sysroot = "@CMAKE_SYSROOT@"
 
 # Load common config for all compiler-rt lit tests.
 lit_config.load_config(config, "@COMPILER_RT_BINARY_DIR@/test/lit.common.configured")


### PR DESCRIPTION
Some msan tests requires rpc/xdr.h, which is no longer available in some newer glibc. In build systems with hermetic sysroot set through CMake, this issue can be solved by setting the sysroot to CMAKE_SYSROOT for these tests. This patch implements it.