### PR TITLE
[clang-doc][NFC] fix description typo

### DIFF
--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -521,7 +521,7 @@ struct ClangDocContext {
   // Path of CSS stylesheets that will be copied to OutDirectory and used to
   // style all HTML files.
   std::vector<std::string> UserStylesheets;
-  // JavaScript files that will be imported in allHTML file.
+  // JavaScript files that will be imported in all HTML files.
   std::vector<std::string> JsScripts;
   Index Idx;
 };


### PR DESCRIPTION
Fix the description typo for `JsScripts` in the context

discussed in #131280 