### PR TITLE
[clang][dataflow] Add matcher for pointer-like types to be cached

### DIFF
--- a/clang/include/clang/Analysis/FlowSensitive/SmartPointerAccessorCaching.h
+++ b/clang/include/clang/Analysis/FlowSensitive/SmartPointerAccessorCaching.h
@@ -58,7 +58,9 @@ namespace clang::dataflow {
 /// for `std::optional`, we assume the (Matcher, TransferFunction) case
 /// with custom handling is ordered early so that these generic cases
 /// do not trigger.
+ast_matchers::StatementMatcher isPointerLikeOperatorStar();
 ast_matchers::StatementMatcher isSmartPointerLikeOperatorStar();
+ast_matchers::StatementMatcher isPointerLikeOperatorArrow();
 ast_matchers::StatementMatcher isSmartPointerLikeOperatorArrow();
 ast_matchers::StatementMatcher isSmartPointerLikeValueMethodCall();
 ast_matchers::StatementMatcher isSmartPointerLikeGetMethodCall();

--- a/clang/unittests/Analysis/FlowSensitive/SmartPointerAccessorCachingTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/SmartPointerAccessorCachingTest.cpp
@@ -46,14 +46,61 @@ TEST(SmartPointerAccessorCachingTest, MatchesClassWithStarArrowGet) {
                       "int target(std::unique_ptr<S> P) { return (*P).i; }",
                       isSmartPointerLikeOperatorStar()));
   EXPECT_TRUE(matches(Decls,
+                      "int target(std::unique_ptr<S> P) { return (*P).i; }",
+                      isPointerLikeOperatorStar()));
+
+  EXPECT_TRUE(matches(Decls,
                       "int target(std::unique_ptr<S> P) { return P->i; }",
                       isSmartPointerLikeOperatorArrow()));
+  EXPECT_TRUE(matches(Decls,
+                      "int target(std::unique_ptr<S> P) { return P->i; }",
+                      isPointerLikeOperatorArrow()));
+
   EXPECT_TRUE(matches(Decls,
                       "int target(std::unique_ptr<S> P) { return P.get()->i; }",
                       isSmartPointerLikeGetMethodCall()));
 
   EXPECT_TRUE(matches(Decls, "int target(UniquePtrAlias<S> P) { return P->i; }",
                       isSmartPointerLikeOperatorArrow()));
+  EXPECT_TRUE(matches(Decls, "int target(UniquePtrAlias<S> P) { return P->i; }",
+                      isPointerLikeOperatorArrow()));
+}
+
+TEST(SmartPointerAccessorCachingTest, MatchesClassWithStarArrow) {
+  llvm::StringRef Decls(R"cc(
+    namespace std {
+    template <class T>
+    struct unique_ptr {
+      T* operator->() const;
+      T& operator*() const;
+    };
+    }  // namespace std
+
+    template <class T>
+    using UniquePtrAlias = std::unique_ptr<T>;
+
+    struct S { int i; };
+  )cc");
+
+  EXPECT_FALSE(matches(Decls,
+                       "int target(std::unique_ptr<S> P) { return (*P).i; }",
+                       isSmartPointerLikeOperatorStar()));
+  EXPECT_TRUE(matches(Decls,
+                      "int target(std::unique_ptr<S> P) { return (*P).i; }",
+                      isPointerLikeOperatorStar()));
+
+  EXPECT_FALSE(matches(Decls,
+                       "int target(std::unique_ptr<S> P) { return P->i; }",
+                       isSmartPointerLikeOperatorArrow()));
+  EXPECT_TRUE(matches(Decls,
+                      "int target(std::unique_ptr<S> P) { return P->i; }",
+                      isPointerLikeOperatorArrow()));
+
+  EXPECT_FALSE(matches(Decls,
+                       "int target(UniquePtrAlias<S> P) { return P->i; }",
+                       isSmartPointerLikeOperatorArrow()));
+  EXPECT_TRUE(matches(Decls, "int target(UniquePtrAlias<S> P) { return P->i; }",
+                      isPointerLikeOperatorArrow()));
 }
 
 TEST(SmartPointerAccessorCachingTest, NoMatchIfUnexpectedReturnTypes) {
@@ -76,14 +123,24 @@ TEST(SmartPointerAccessorCachingTest, NoMatchIfUnexpectedReturnTypes) {
                        "int target(std::unique_ptr<S, T> P) { return (*P).i; }",
                        isSmartPointerLikeOperatorStar()));
   EXPECT_FALSE(matches(Decls,
+                       "int target(std::unique_ptr<S, T> P) { return (*P).i; }",
+                       isPointerLikeOperatorStar()));
+
+  EXPECT_FALSE(matches(Decls,
                        "int target(std::unique_ptr<S, T> P) { return P->j; }",
                        isSmartPointerLikeOperatorArrow()));
+  EXPECT_FALSE(matches(Decls,
+                       "int target(std::unique_ptr<S, T> P) { return P->j; }",
+                       isPointerLikeOperatorArrow()));
   // The class matching arguably accidentally matches, just because the
   // instantiation is with S, S. Hopefully doesn't happen too much in real code
   // with such operator* and operator-> overloads.
   EXPECT_TRUE(matches(Decls,
                       "int target(std::unique_ptr<S, S> P) { return P->i; }",
                       isSmartPointerLikeOperatorArrow()));
+  EXPECT_TRUE(matches(Decls,
+                      "int target(std::unique_ptr<S, S> P) { return P->i; }",
+                      isPointerLikeOperatorArrow()));
 }
 
 TEST(SmartPointerAccessorCachingTest, NoMatchIfBinaryStar) {
@@ -103,6 +160,9 @@ TEST(SmartPointerAccessorCachingTest, NoMatchIfBinaryStar) {
   EXPECT_FALSE(
       matches(Decls, "int target(std::unique_ptr<S> P) { return (P * 10).i; }",
               isSmartPointerLikeOperatorStar()));
+  EXPECT_FALSE(
+      matches(Decls, "int target(std::unique_ptr<S> P) { return (P * 10).i; }",
+              isPointerLikeOperatorStar()));
 }
 
 TEST(SmartPointerAccessorCachingTest, NoMatchIfNoConstOverloads) {
@@ -123,8 +183,16 @@ TEST(SmartPointerAccessorCachingTest, NoMatchIfNoConstOverloads) {
                        "int target(std::unique_ptr<S> P) { return (*P).i; }",
                        isSmartPointerLikeOperatorStar()));
   EXPECT_FALSE(matches(Decls,
+                       "int target(std::unique_ptr<S> P) { return (*P).i; }",
+                       isPointerLikeOperatorStar()));
+
+  EXPECT_FALSE(matches(Decls,
                        "int target(std::unique_ptr<S> P) { return P->i; }",
                        isSmartPointerLikeOperatorArrow()));
+  EXPECT_FALSE(matches(Decls,
+                       "int target(std::unique_ptr<S> P) { return P->i; }",
+                       isPointerLikeOperatorArrow()));
+
   EXPECT_FALSE(
       matches(Decls, "int target(std::unique_ptr<S> P) { return P.get()->i; }",
               isSmartPointerLikeGetMethodCall()));
@@ -146,6 +214,10 @@ TEST(SmartPointerAccessorCachingTest, NoMatchIfNoStarMethod) {
   EXPECT_FALSE(matches(Decls,
                        "int target(std::unique_ptr<S> P) { return P->i; }",
                        isSmartPointerLikeOperatorArrow()));
+  EXPECT_FALSE(matches(Decls,
+                       "int target(std::unique_ptr<S> P) { return P->i; }",
+                       isPointerLikeOperatorArrow()));
+
   EXPECT_FALSE(matches(Decls,
                        "int target(std::unique_ptr<S> P) { return P->i; }",
                        isSmartPointerLikeGetMethodCall()));
@@ -172,14 +244,30 @@ TEST(SmartPointerAccessorCachingTest, MatchesWithValueAndNonConstOverloads) {
       Decls, "int target(std::optional<S> &NonConst) { return (*NonConst).i; }",
       isSmartPointerLikeOperatorStar()));
   EXPECT_TRUE(matches(
+      Decls, "int target(std::optional<S> &NonConst) { return (*NonConst).i; }",
+      isPointerLikeOperatorStar()));
+
+  EXPECT_TRUE(matches(
       Decls, "int target(const std::optional<S> &Const) { return (*Const).i; }",
       isSmartPointerLikeOperatorStar()));
+  EXPECT_TRUE(matches(
+      Decls, "int target(const std::optional<S> &Const) { return (*Const).i; }",
+      isPointerLikeOperatorStar()));
+
   EXPECT_TRUE(matches(
       Decls, "int target(std::optional<S> &NonConst) { return NonConst->i; }",
       isSmartPointerLikeOperatorArrow()));
   EXPECT_TRUE(matches(
+      Decls, "int target(std::optional<S> &NonConst) { return NonConst->i; }",
+      isPointerLikeOperatorArrow()));
+
+  EXPECT_TRUE(matches(
       Decls, "int target(const std::optional<S> &Const) { return Const->i; }",
       isSmartPointerLikeOperatorArrow()));
+  EXPECT_TRUE(matches(
+      Decls, "int target(const std::optional<S> &Const) { return Const->i; }",
+      isPointerLikeOperatorArrow()));
+
   EXPECT_TRUE(matches(
       Decls,
       "int target(std::optional<S> &NonConst) { return NonConst.value().i; }",
@@ -216,14 +304,32 @@ TEST(SmartPointerAccessorCachingTest, MatchesWithTypeAliases) {
       isSmartPointerLikeOperatorStar()));
   EXPECT_TRUE(matches(
       Decls,
+      "int target(HasGetAndValue<S> &NonConst) { return (*NonConst).i; }",
+      isPointerLikeOperatorStar()));
+
+  EXPECT_TRUE(matches(
+      Decls,
       "int target(const HasGetAndValue<S> &Const) { return (*Const).i; }",
       isSmartPointerLikeOperatorStar()));
+  EXPECT_TRUE(matches(
+      Decls,
+      "int target(const HasGetAndValue<S> &Const) { return (*Const).i; }",
+      isPointerLikeOperatorStar()));
+
   EXPECT_TRUE(matches(
       Decls, "int target(HasGetAndValue<S> &NonConst) { return NonConst->i; }",
       isSmartPointerLikeOperatorArrow()));
   EXPECT_TRUE(matches(
+      Decls, "int target(HasGetAndValue<S> &NonConst) { return NonConst->i; }",
+      isPointerLikeOperatorArrow()));
+
+  EXPECT_TRUE(matches(
       Decls, "int target(const HasGetAndValue<S> &Const) { return Const->i; }",
       isSmartPointerLikeOperatorArrow()));
+  EXPECT_TRUE(matches(
+      Decls, "int target(const HasGetAndValue<S> &Const) { return Const->i; }",
+      isPointerLikeOperatorArrow()));
+
   EXPECT_TRUE(matches(
       Decls,
       "int target(HasGetAndValue<S> &NonConst) { return NonConst.value().i; }",


### PR DESCRIPTION
This is used e.g. for iterators.
