### PR TITLE
Ubsan: warn on -fsanitize-trap=undefined ignored when passed on its own

### DIFF
--- a/clang/lib/Driver/SanitizerArgs.cpp
+++ b/clang/lib/Driver/SanitizerArgs.cpp
@@ -728,7 +728,9 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
   RecoverableKinds |= AlwaysRecoverable;
   RecoverableKinds &= ~Unrecoverable;
   RecoverableKinds &= Kinds;
-
+  if ((TrappingKinds & SanitizerKind::Undefined) &&
+      !(Kinds & SanitizerKind::Undefined))
+    llvm::errs() << "Warning: -fsanitize-trap=undefined ignored\n";
   TrappingKinds &= Kinds;
   RecoverableKinds &= ~TrappingKinds;
 


### PR DESCRIPTION
As @delcypher proposed, when the -fsanitize-trap=undefined flag is passed on its own the compiler silently ignores it. Currently Clang requires that the -fsanitize= flag is also passed. 
This PR warn about this behavior.
