### PR TITLE
[clang] Fix nullptr dereference when checking friend default comparison

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -9039,8 +9039,7 @@ bool Sema::CheckExplicitlyDefaultedComparison(Scope *S, FunctionDecl *FD,
       return true;
 
     if (llvm::none_of(RD->friends(), [&](const FriendDecl *F) {
-          return FD->getCanonicalDecl() ==
-                 F->getFriendDecl()->getCanonicalDecl();
+          return declaresSameEntity(F->getFriendDecl(), FD);
         })) {
       Diag(FD->getLocation(), diag::err_defaulted_comparison_not_friend)
           << int(DCK) << int(0) << RD;


### PR DESCRIPTION
Fix a crash in `SemaDeclCXX.cpp` when defaulting a comparison operator that has been declared as a friend function alongside class friend declarations. When checking if a defaulted operator is a friend, the code would dereference the result of `FriendDecl::getFriendDecl()` without checking for nullptr, which occurs for class friend declarations.

The fix ensures we check that `getFriendDecl()` returns a non-null pointer before attempting to access its canonical declaration.

Fixes https://github.com/llvm/llvm-project/issues/132249