### PR TITLE
[libclc] link_bc target should depends on target builtins.link.clc-arch_suffix

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -413,7 +413,7 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
       GEN_FILES ${opencl_gen_files}
       ALIASES ${${d}_aliases}
       # Link in the CLC builtins and internalize their symbols
-      INTERNAL_LINK_DEPENDENCIES $<TARGET_PROPERTY:builtins.link.clc-${arch_suffix},TARGET_FILE>
+      INTERNAL_LINK_DEPENDENCIES builtins.link.clc-${arch_suffix}
     )
   endforeach( d )
 endforeach( t )

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -312,7 +312,7 @@ function(add_libclc_builtin_set)
     )
     set( internal_link_depend_files )
     foreach( tgt ${ARG_INTERNAL_LINK_DEPENDENCIES} )
-      list( APPEND internal_link_depend_files $<TARGET_PROPERTY:tgt,TARGET_FILE> )
+      list( APPEND internal_link_depend_files $<TARGET_PROPERTY:${tgt},TARGET_FILE> )
     endforeach()
     link_bc(
       INTERNALIZE

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -210,7 +210,7 @@ endfunction()
 #      Optimization options (for opt)
 #  * ALIASES <string> ...
 #      List of aliases
-#  * INTERNAL_LINK_DEPENDENCIES <string> ...
+#  * INTERNAL_LINK_DEPENDENCIES <target> ...
 #      A list of extra bytecode file's targets. The bitcode files will be linked
 #      into the builtin library. Symbols from these link dependencies will be
 #      internalized during linking.
@@ -310,11 +310,15 @@ function(add_libclc_builtin_set)
       INPUTS ${bytecode_files}
       DEPENDENCIES ${builtins_comp_lib_tgt}
     )
+    set( internal_link_depend_files )
+    foreach( tgt ${ARG_INTERNAL_LINK_DEPENDENCIES} )
+      list( APPEND internal_link_depend_files $<TARGET_PROPERTY:tgt,TARGET_FILE> )
+    endforeach()
     link_bc(
       INTERNALIZE
       TARGET ${builtins_link_lib_tgt}
       INPUTS $<TARGET_PROPERTY:${builtins_link_lib_tmp_tgt},TARGET_FILE>
-        $<TARGET_PROPERTY:${ARG_INTERNAL_LINK_DEPENDENCIES},TARGET_FILE>
+        ${internal_link_depend_files}
       DEPENDENCIES ${builtins_link_lib_tmp_tgt} ${ARG_INTERNAL_LINK_DEPENDENCIES}
     )
   endif()

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -211,8 +211,9 @@ endfunction()
 #  * ALIASES <string> ...
 #      List of aliases
 #  * INTERNAL_LINK_DEPENDENCIES <string> ...
-#      A list of extra bytecode files to link into the builtin library. Symbols
-#      from these link dependencies will be internalized during linking.
+#      A list of extra bytecode file's targets. The bitcode files will be linked
+#      into the builtin library. Symbols from these link dependencies will be
+#      internalized during linking.
 function(add_libclc_builtin_set)
   cmake_parse_arguments(ARG
     "CLC_INTERNAL"
@@ -313,8 +314,8 @@ function(add_libclc_builtin_set)
       INTERNALIZE
       TARGET ${builtins_link_lib_tgt}
       INPUTS $<TARGET_PROPERTY:${builtins_link_lib_tmp_tgt},TARGET_FILE>
-        ${ARG_INTERNAL_LINK_DEPENDENCIES}
-      DEPENDENCIES ${builtins_link_lib_tmp_tgt}
+        $<TARGET_PROPERTY:${ARG_INTERNAL_LINK_DEPENDENCIES},TARGET_FILE>
+      DEPENDENCIES ${builtins_link_lib_tmp_tgt} ${ARG_INTERNAL_LINK_DEPENDENCIES}
     )
   endif()
 


### PR DESCRIPTION
Currently link_bc command depends on the bitcode file that is associated with custom target builtins.link.clc-arch_suffix.
On windows we randomly see following error:
`
  Generating builtins.link.clc-${ARCH}--.bc
  Generating builtins.link.libspirv-${ARCH}.bc
  error : The requested operation cannot be performed on a file with a user-mapped section open.
`
I suspect that builtins.link.clc-${ARCH}--.bc file is being generated while it is being used in link_bc.
This PR adds target-level dependency to ensure builtins.link.clc-${ARCH}--.bc is generated first.