### PR TITLE
[Clang] [NFC] Introduce a helper for emitting compatibility diagnostics

### DIFF
--- a/clang/include/clang/Basic/CMakeLists.txt
+++ b/clang/include/clang/Basic/CMakeLists.txt
@@ -8,6 +8,11 @@ macro(clang_diag_gen component)
     -gen-clang-diags-enums -clang-component=${component}
     SOURCE Diagnostic.td
     TARGET ClangDiagnostic${component}Enums)
+
+  clang_tablegen(Diagnostic${component}CompatEnums.inc
+    -gen-clang-diags-compat-enums -clang-component=${component}
+    SOURCE Diagnostic.td
+    TARGET ClangDiagnostic${component}CompatEnums)
 endmacro(clang_diag_gen)
 
 clang_diag_gen(Analysis)

--- a/clang/include/clang/Basic/CMakeLists.txt
+++ b/clang/include/clang/Basic/CMakeLists.txt
@@ -36,6 +36,11 @@ clang_tablegen(DiagnosticIndexName.inc -gen-clang-diags-index-name
   SOURCE Diagnostic.td
   TARGET ClangDiagnosticIndexName)
 
+clang_tablegen(DiagnosticAllCompatEnums.inc
+  -gen-clang-diags-compat-enums
+  SOURCE Diagnostic.td
+  TARGET ClangDiagnosticAllCompatEnums)
+
 clang_tablegen(AttrList.inc -gen-clang-attr-list
   -I ${CMAKE_CURRENT_SOURCE_DIR}/../../
   SOURCE Attr.td

--- a/clang/include/clang/Basic/CMakeLists.txt
+++ b/clang/include/clang/Basic/CMakeLists.txt
@@ -9,10 +9,10 @@ macro(clang_diag_gen component)
     SOURCE Diagnostic.td
     TARGET ClangDiagnostic${component}Enums)
 
-  clang_tablegen(Diagnostic${component}CompatEnums.inc
-    -gen-clang-diags-compat-enums -clang-component=${component}
+  clang_tablegen(Diagnostic${component}CompatIDs.inc
+    -gen-clang-diags-compat-ids -clang-component=${component}
     SOURCE Diagnostic.td
-    TARGET ClangDiagnostic${component}CompatEnums)
+    TARGET ClangDiagnostic${component}CompatIDs)
 endmacro(clang_diag_gen)
 
 clang_diag_gen(Analysis)
@@ -36,10 +36,10 @@ clang_tablegen(DiagnosticIndexName.inc -gen-clang-diags-index-name
   SOURCE Diagnostic.td
   TARGET ClangDiagnosticIndexName)
 
-clang_tablegen(DiagnosticAllCompatEnums.inc
-  -gen-clang-diags-compat-enums
+clang_tablegen(DiagnosticAllCompatIDs.inc
+  -gen-clang-diags-compat-ids
   SOURCE Diagnostic.td
-  TARGET ClangDiagnosticAllCompatEnums)
+  TARGET ClangDiagnosticAllCompatIDs)
 
 clang_tablegen(AttrList.inc -gen-clang-attr-list
   -I ${CMAKE_CURRENT_SOURCE_DIR}/../../

--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -63,10 +63,6 @@ enum TokenKind : unsigned short;
 
 } // namespace tok
 
-namespace diag_compat {
-enum SemaCompatDiagId : unsigned;
-} // namespace diag_compat
-
 /// Annotates a diagnostic with some code that should be
 /// inserted, removed, or replaced to fix the problem.
 ///

--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -1794,7 +1794,6 @@ void ProcessWarningOptions(DiagnosticsEngine &Diags,
                            const DiagnosticOptions &Opts,
                            llvm::vfs::FileSystem &VFS, bool ReportDiags = true);
 void EscapeStringForDiagnostic(StringRef Str, SmallVectorImpl<char> &OutStr);
-unsigned GetCompatDiagId(const LangOptions& LangOpts, unsigned CompatDiagId);
 } // namespace clang
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTIC_H

--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -63,6 +63,10 @@ enum TokenKind : unsigned short;
 
 } // namespace tok
 
+namespace diag_compat {
+enum SemaCompatDiagId : unsigned;
+} // namespace diag_compat
+
 /// Annotates a diagnostic with some code that should be
 /// inserted, removed, or replaced to fix the problem.
 ///
@@ -1794,6 +1798,7 @@ void ProcessWarningOptions(DiagnosticsEngine &Diags,
                            const DiagnosticOptions &Opts,
                            llvm::vfs::FileSystem &VFS, bool ReportDiags = true);
 void EscapeStringForDiagnostic(StringRef Str, SmallVectorImpl<char> &OutStr);
+unsigned GetCompatDiagId(const LangOptions& LangOpts, unsigned CompatDiagId);
 } // namespace clang
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTIC_H

--- a/clang/include/clang/Basic/Diagnostic.td
+++ b/clang/include/clang/Basic/Diagnostic.td
@@ -155,6 +155,19 @@ class DefaultWarnNoWerror {
 }
 class DefaultRemark { Severity DefaultSeverity = SEV_Remark; }
 
+class CompatWarningId<string name, int std, string diag, string diag_pre> {
+  string Component = ?;
+  string Name = name;
+  string Diag = diag;
+  string DiagPre = diag_pre;
+  int Std = std;
+
+  // This is unused, but Tablegen will complain if it's missing because we define
+  // the compatibility ids in the same place as the other diagnostics (which means
+  // that we'll be inside a 'let CategoryName = "" in { ... }' block).
+  string CategoryName = ?;
+}
+
 // C++ compatibility warnings.
 multiclass CXXCompat<
     string message,
@@ -178,6 +191,11 @@ multiclass CXXCompat<
                                      "CXX98Compat",
                                      "CXXPre"#std_ver#"Compat"))>,
         DefaultIgnore;
+
+    def : CompatWarningId<
+        NAME, std_ver,
+        "compat_cxx"#std_ver#"_"#NAME,
+        "compat_pre_cxx"#std_ver#"_"#NAME>;
 }
 
 // These generate pairs of C++ compatibility warnings of the form:

--- a/clang/include/clang/Basic/DiagnosticAST.h
+++ b/clang/include/clang/Basic/DiagnosticAST.h
@@ -39,7 +39,9 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM_END()                                                 \
+  }                                                                            \
+  ;
 #define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
 #include "clang/Basic/DiagnosticASTCompatEnums.inc"
 #undef DIAG_COMPAT_ENUM

--- a/clang/include/clang/Basic/DiagnosticAST.h
+++ b/clang/include/clang/Basic/DiagnosticAST.h
@@ -39,7 +39,7 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                 \
+#define DIAG_COMPAT_IDS_END()                                                  \
   }                                                                            \
   ;
 #define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,

--- a/clang/include/clang/Basic/DiagnosticAST.h
+++ b/clang/include/clang/Basic/DiagnosticAST.h
@@ -36,6 +36,16 @@ enum {
 #undef DIAG_ENUM_ITEM
 #undef DIAG_ENUM
 } // end namespace diag
+
+namespace diag_compat {
+#define DIAG_COMPAT_ENUM_BEGIN() enum {
+#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticASTCompatEnums.inc"
+#undef DIAG_COMPAT_ENUM
+#undef DIAG_COMPAT_ENUM_BEGIN
+#undef DIAG_COMPAT_ENUM_END
+} // end namespace diag_compat
 } // end namespace clang
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICAST_H

--- a/clang/include/clang/Basic/DiagnosticAST.h
+++ b/clang/include/clang/Basic/DiagnosticAST.h
@@ -38,15 +38,15 @@ enum {
 } // end namespace diag
 
 namespace diag_compat {
-#define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END()                                                 \
+#define DIAG_COMPAT_IDS_BEGIN() enum {
+#define DIAG_COMPAT_IDS_END()                                                 \
   }                                                                            \
   ;
-#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticASTCompatEnums.inc"
-#undef DIAG_COMPAT_ENUM
-#undef DIAG_COMPAT_ENUM_BEGIN
-#undef DIAG_COMPAT_ENUM_END
+#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticASTCompatIDs.inc"
+#undef DIAG_COMPAT_ID
+#undef DIAG_COMPAT_IDS_BEGIN
+#undef DIAG_COMPAT_IDS_END
 } // end namespace diag_compat
 } // end namespace clang
 

--- a/clang/include/clang/Basic/DiagnosticAnalysis.h
+++ b/clang/include/clang/Basic/DiagnosticAnalysis.h
@@ -37,15 +37,15 @@ enum {
 } // end namespace diag
 
 namespace diag_compat {
-#define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END()                                                 \
+#define DIAG_COMPAT_IDS_BEGIN() enum {
+#define DIAG_COMPAT_IDS_END()                                                 \
   }                                                                            \
   ;
-#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticAnalysisCompatEnums.inc"
-#undef DIAG_COMPAT_ENUM
-#undef DIAG_COMPAT_ENUM_BEGIN
-#undef DIAG_COMPAT_ENUM_END
+#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticAnalysisCompatIDs.inc"
+#undef DIAG_COMPAT_ID
+#undef DIAG_COMPAT_IDS_BEGIN
+#undef DIAG_COMPAT_IDS_END
 } // end namespace diag_compat
 } // end namespace clang
 

--- a/clang/include/clang/Basic/DiagnosticAnalysis.h
+++ b/clang/include/clang/Basic/DiagnosticAnalysis.h
@@ -38,7 +38,7 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                 \
+#define DIAG_COMPAT_IDS_END()                                                  \
   }                                                                            \
   ;
 #define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,

--- a/clang/include/clang/Basic/DiagnosticAnalysis.h
+++ b/clang/include/clang/Basic/DiagnosticAnalysis.h
@@ -38,7 +38,9 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM_END()                                                 \
+  }                                                                            \
+  ;
 #define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
 #include "clang/Basic/DiagnosticAnalysisCompatEnums.inc"
 #undef DIAG_COMPAT_ENUM

--- a/clang/include/clang/Basic/DiagnosticAnalysis.h
+++ b/clang/include/clang/Basic/DiagnosticAnalysis.h
@@ -35,6 +35,16 @@ enum {
 #undef DIAG_ENUM_ITEM
 #undef DIAG_ENUM
 } // end namespace diag
+
+namespace diag_compat {
+#define DIAG_COMPAT_ENUM_BEGIN() enum {
+#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticAnalysisCompatEnums.inc"
+#undef DIAG_COMPAT_ENUM
+#undef DIAG_COMPAT_ENUM_BEGIN
+#undef DIAG_COMPAT_ENUM_END
+} // end namespace diag_compat
 } // end namespace clang
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICANALYSIS_H

--- a/clang/include/clang/Basic/DiagnosticComment.h
+++ b/clang/include/clang/Basic/DiagnosticComment.h
@@ -36,6 +36,16 @@ enum {
 #undef DIAG_ENUM_ITEM
 #undef DIAG_ENUM
 } // end namespace diag
+
+namespace diag_compat {
+#define DIAG_COMPAT_ENUM_BEGIN() enum {
+#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticCommentCompatEnums.inc"
+#undef DIAG_COMPAT_ENUM
+#undef DIAG_COMPAT_ENUM_BEGIN
+#undef DIAG_COMPAT_ENUM_END
+} // end namespace diag_compat
 } // end namespace clang
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICCOMMENT_H

--- a/clang/include/clang/Basic/DiagnosticComment.h
+++ b/clang/include/clang/Basic/DiagnosticComment.h
@@ -39,7 +39,7 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                 \
+#define DIAG_COMPAT_IDS_END()                                                  \
   }                                                                            \
   ;
 #define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,

--- a/clang/include/clang/Basic/DiagnosticComment.h
+++ b/clang/include/clang/Basic/DiagnosticComment.h
@@ -39,7 +39,9 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM_END()                                                 \
+  }                                                                            \
+  ;
 #define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
 #include "clang/Basic/DiagnosticCommentCompatEnums.inc"
 #undef DIAG_COMPAT_ENUM

--- a/clang/include/clang/Basic/DiagnosticComment.h
+++ b/clang/include/clang/Basic/DiagnosticComment.h
@@ -38,15 +38,15 @@ enum {
 } // end namespace diag
 
 namespace diag_compat {
-#define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END()                                                 \
+#define DIAG_COMPAT_IDS_BEGIN() enum {
+#define DIAG_COMPAT_IDS_END()                                                 \
   }                                                                            \
   ;
-#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticCommentCompatEnums.inc"
-#undef DIAG_COMPAT_ENUM
-#undef DIAG_COMPAT_ENUM_BEGIN
-#undef DIAG_COMPAT_ENUM_END
+#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticCommentCompatIDs.inc"
+#undef DIAG_COMPAT_ID
+#undef DIAG_COMPAT_IDS_BEGIN
+#undef DIAG_COMPAT_IDS_END
 } // end namespace diag_compat
 } // end namespace clang
 

--- a/clang/include/clang/Basic/DiagnosticCrossTU.h
+++ b/clang/include/clang/Basic/DiagnosticCrossTU.h
@@ -39,7 +39,9 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM_END()                                                 \
+  }                                                                            \
+  ;
 #define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
 #include "clang/Basic/DiagnosticCrossTUCompatEnums.inc"
 #undef DIAG_COMPAT_ENUM

--- a/clang/include/clang/Basic/DiagnosticCrossTU.h
+++ b/clang/include/clang/Basic/DiagnosticCrossTU.h
@@ -39,7 +39,7 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                 \
+#define DIAG_COMPAT_IDS_END()                                                  \
   }                                                                            \
   ;
 #define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,

--- a/clang/include/clang/Basic/DiagnosticCrossTU.h
+++ b/clang/include/clang/Basic/DiagnosticCrossTU.h
@@ -36,6 +36,16 @@ enum {
 #undef DIAG_ENUM_ITEM
 #undef DIAG_ENUM
 } // end namespace diag
+
+namespace diag_compat {
+#define DIAG_COMPAT_ENUM_BEGIN() enum {
+#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticCrossTUCompatEnums.inc"
+#undef DIAG_COMPAT_ENUM
+#undef DIAG_COMPAT_ENUM_BEGIN
+#undef DIAG_COMPAT_ENUM_END
+} // end namespace diag_compat
 } // end namespace clang
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICCROSSTU_H

--- a/clang/include/clang/Basic/DiagnosticCrossTU.h
+++ b/clang/include/clang/Basic/DiagnosticCrossTU.h
@@ -38,15 +38,15 @@ enum {
 } // end namespace diag
 
 namespace diag_compat {
-#define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END()                                                 \
+#define DIAG_COMPAT_IDS_BEGIN() enum {
+#define DIAG_COMPAT_IDS_END()                                                 \
   }                                                                            \
   ;
-#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticCrossTUCompatEnums.inc"
-#undef DIAG_COMPAT_ENUM
-#undef DIAG_COMPAT_ENUM_BEGIN
-#undef DIAG_COMPAT_ENUM_END
+#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticCrossTUCompatIDs.inc"
+#undef DIAG_COMPAT_ID
+#undef DIAG_COMPAT_IDS_BEGIN
+#undef DIAG_COMPAT_IDS_END
 } // end namespace diag_compat
 } // end namespace clang
 

--- a/clang/include/clang/Basic/DiagnosticDriver.h
+++ b/clang/include/clang/Basic/DiagnosticDriver.h
@@ -36,6 +36,16 @@ enum {
 #undef DIAG_ENUM_ITEM
 #undef DIAG_ENUM
 } // end namespace diag
+
+namespace diag_compat {
+#define DIAG_COMPAT_ENUM_BEGIN() enum {
+#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticDriverCompatEnums.inc"
+#undef DIAG_COMPAT_ENUM
+#undef DIAG_COMPAT_ENUM_BEGIN
+#undef DIAG_COMPAT_ENUM_END
+} // end namespace diag_compat
 } // end namespace clang
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICDRIVER_H

--- a/clang/include/clang/Basic/DiagnosticDriver.h
+++ b/clang/include/clang/Basic/DiagnosticDriver.h
@@ -39,7 +39,7 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                 \
+#define DIAG_COMPAT_IDS_END()                                                  \
   }                                                                            \
   ;
 #define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,

--- a/clang/include/clang/Basic/DiagnosticDriver.h
+++ b/clang/include/clang/Basic/DiagnosticDriver.h
@@ -38,15 +38,15 @@ enum {
 } // end namespace diag
 
 namespace diag_compat {
-#define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END()                                                 \
+#define DIAG_COMPAT_IDS_BEGIN() enum {
+#define DIAG_COMPAT_IDS_END()                                                 \
   }                                                                            \
   ;
-#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticDriverCompatEnums.inc"
-#undef DIAG_COMPAT_ENUM
-#undef DIAG_COMPAT_ENUM_BEGIN
-#undef DIAG_COMPAT_ENUM_END
+#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticDriverCompatIDs.inc"
+#undef DIAG_COMPAT_ID
+#undef DIAG_COMPAT_IDS_BEGIN
+#undef DIAG_COMPAT_IDS_END
 } // end namespace diag_compat
 } // end namespace clang
 

--- a/clang/include/clang/Basic/DiagnosticDriver.h
+++ b/clang/include/clang/Basic/DiagnosticDriver.h
@@ -39,7 +39,9 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM_END()                                                 \
+  }                                                                            \
+  ;
 #define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
 #include "clang/Basic/DiagnosticDriverCompatEnums.inc"
 #undef DIAG_COMPAT_ENUM

--- a/clang/include/clang/Basic/DiagnosticFrontend.h
+++ b/clang/include/clang/Basic/DiagnosticFrontend.h
@@ -36,6 +36,16 @@ enum {
 #undef DIAG_ENUM_ITEM
 #undef DIAG_ENUM
 } // end namespace diag
+
+namespace diag_compat {
+#define DIAG_COMPAT_ENUM_BEGIN() enum {
+#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticFrontendCompatEnums.inc"
+#undef DIAG_COMPAT_ENUM
+#undef DIAG_COMPAT_ENUM_BEGIN
+#undef DIAG_COMPAT_ENUM_END
+} // end namespace diag_compat
 } // end namespace clang
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICFRONTEND_H

--- a/clang/include/clang/Basic/DiagnosticFrontend.h
+++ b/clang/include/clang/Basic/DiagnosticFrontend.h
@@ -39,7 +39,9 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM_END()                                                 \
+  }                                                                            \
+  ;
 #define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
 #include "clang/Basic/DiagnosticFrontendCompatEnums.inc"
 #undef DIAG_COMPAT_ENUM

--- a/clang/include/clang/Basic/DiagnosticFrontend.h
+++ b/clang/include/clang/Basic/DiagnosticFrontend.h
@@ -39,7 +39,7 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                 \
+#define DIAG_COMPAT_IDS_END()                                                  \
   }                                                                            \
   ;
 #define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,

--- a/clang/include/clang/Basic/DiagnosticFrontend.h
+++ b/clang/include/clang/Basic/DiagnosticFrontend.h
@@ -38,15 +38,15 @@ enum {
 } // end namespace diag
 
 namespace diag_compat {
-#define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END()                                                 \
+#define DIAG_COMPAT_IDS_BEGIN() enum {
+#define DIAG_COMPAT_IDS_END()                                                 \
   }                                                                            \
   ;
-#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticFrontendCompatEnums.inc"
-#undef DIAG_COMPAT_ENUM
-#undef DIAG_COMPAT_ENUM_BEGIN
-#undef DIAG_COMPAT_ENUM_END
+#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticFrontendCompatIDs.inc"
+#undef DIAG_COMPAT_ID
+#undef DIAG_COMPAT_IDS_BEGIN
+#undef DIAG_COMPAT_IDS_END
 } // end namespace diag_compat
 } // end namespace clang
 

--- a/clang/include/clang/Basic/DiagnosticIDs.h
+++ b/clang/include/clang/Basic/DiagnosticIDs.h
@@ -105,9 +105,11 @@ namespace clang {
     };
   }
 
-namespace diag_compat {
+  namespace diag_compat {
 #define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM_END()                                               \
+    }                                                                          \
+    ;
 #define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
 #include "clang/Basic/DiagnosticCommonCompatEnums.inc"
 #undef DIAG_COMPAT_ENUM
@@ -477,7 +479,8 @@ public:
 
   /// Get the appropriate diagnostic Id to use for issuing a compatibility
   /// diagnostic. For use by the various DiagCompat() helpers.
-  static unsigned getCompatDiagId(const LangOptions& LangOpts, unsigned CompatDiagId);
+  static unsigned getCompatDiagId(const LangOptions &LangOpts,
+                                  unsigned CompatDiagId);
 
 private:
   /// Classify the specified diagnostic ID into a Level, consumable by

--- a/clang/include/clang/Basic/DiagnosticIDs.h
+++ b/clang/include/clang/Basic/DiagnosticIDs.h
@@ -104,6 +104,16 @@ namespace clang {
     };
   }
 
+namespace diag_compat {
+#define DIAG_COMPAT_ENUM_BEGIN() enum {
+#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticCommonCompatEnums.inc"
+#undef DIAG_COMPAT_ENUM
+#undef DIAG_COMPAT_ENUM_BEGIN
+#undef DIAG_COMPAT_ENUM_END
+  } // end namespace diag_compat
+
 class DiagnosticMapping {
   LLVM_PREFERRED_TYPE(diag::Severity)
   unsigned Severity : 3;

--- a/clang/include/clang/Basic/DiagnosticIDs.h
+++ b/clang/include/clang/Basic/DiagnosticIDs.h
@@ -106,15 +106,15 @@ namespace clang {
   }
 
   namespace diag_compat {
-#define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END()                                               \
+#define DIAG_COMPAT_IDS_BEGIN() enum {
+#define DIAG_COMPAT_IDS_END()                                               \
     }                                                                          \
     ;
-#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticCommonCompatEnums.inc"
-#undef DIAG_COMPAT_ENUM
-#undef DIAG_COMPAT_ENUM_BEGIN
-#undef DIAG_COMPAT_ENUM_END
+#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticCommonCompatIDs.inc"
+#undef DIAG_COMPAT_ID
+#undef DIAG_COMPAT_IDS_BEGIN
+#undef DIAG_COMPAT_IDS_END
   } // end namespace diag_compat
 
 class DiagnosticMapping {

--- a/clang/include/clang/Basic/DiagnosticIDs.h
+++ b/clang/include/clang/Basic/DiagnosticIDs.h
@@ -25,6 +25,7 @@
 namespace clang {
   class DiagnosticsEngine;
   class DiagnosticBuilder;
+  class LangOptions;
   class SourceLocation;
 
   // Import the diagnostic enums themselves.
@@ -473,6 +474,10 @@ public:
   /// Get the diagnostic option with the closest edit distance to the
   /// given group name.
   static StringRef getNearestOption(diag::Flavor Flavor, StringRef Group);
+
+  /// Get the appropriate diagnostic Id to use for issuing a compatibility
+  /// diagnostic. For use by the various DiagCompat() helpers.
+  static unsigned getCompatDiagId(const LangOptions& LangOpts, unsigned CompatDiagId);
 
 private:
   /// Classify the specified diagnostic ID into a Level, consumable by

--- a/clang/include/clang/Basic/DiagnosticIDs.h
+++ b/clang/include/clang/Basic/DiagnosticIDs.h
@@ -107,7 +107,7 @@ namespace clang {
 
   namespace diag_compat {
 #define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                               \
+#define DIAG_COMPAT_IDS_END()                                                \
     }                                                                          \
     ;
 #define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,

--- a/clang/include/clang/Basic/DiagnosticIDs.h
+++ b/clang/include/clang/Basic/DiagnosticIDs.h
@@ -479,8 +479,8 @@ public:
 
   /// Get the appropriate diagnostic Id to use for issuing a compatibility
   /// diagnostic. For use by the various DiagCompat() helpers.
-  static unsigned getCompatDiagId(const LangOptions &LangOpts,
-                                  unsigned CompatDiagId);
+  static unsigned getCXXCompatDiagId(const LangOptions &LangOpts,
+                                     unsigned CompatDiagId);
 
 private:
   /// Classify the specified diagnostic ID into a Level, consumable by

--- a/clang/include/clang/Basic/DiagnosticInstallAPI.h
+++ b/clang/include/clang/Basic/DiagnosticInstallAPI.h
@@ -37,15 +37,15 @@ enum {
 } // namespace diag
 
 namespace diag_compat {
-#define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END()                                                 \
+#define DIAG_COMPAT_IDS_BEGIN() enum {
+#define DIAG_COMPAT_IDS_END()                                                 \
   }                                                                            \
   ;
-#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticInstallAPICompatEnums.inc"
-#undef DIAG_COMPAT_ENUM
-#undef DIAG_COMPAT_ENUM_BEGIN
-#undef DIAG_COMPAT_ENUM_END
+#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticInstallAPICompatIDs.inc"
+#undef DIAG_COMPAT_ID
+#undef DIAG_COMPAT_IDS_BEGIN
+#undef DIAG_COMPAT_IDS_END
 } // end namespace diag_compat
 } // namespace clang
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICINSTALLAPI_H

--- a/clang/include/clang/Basic/DiagnosticInstallAPI.h
+++ b/clang/include/clang/Basic/DiagnosticInstallAPI.h
@@ -35,5 +35,15 @@ enum {
 #undef DIAG_ENUM_ITEM
 #undef DIAG_ENUM
 } // namespace diag
+
+namespace diag_compat {
+#define DIAG_COMPAT_ENUM_BEGIN() enum {
+#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticInstallAPICompatEnums.inc"
+#undef DIAG_COMPAT_ENUM
+#undef DIAG_COMPAT_ENUM_BEGIN
+#undef DIAG_COMPAT_ENUM_END
+} // end namespace diag_compat
 } // namespace clang
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICINSTALLAPI_H

--- a/clang/include/clang/Basic/DiagnosticInstallAPI.h
+++ b/clang/include/clang/Basic/DiagnosticInstallAPI.h
@@ -38,7 +38,7 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                 \
+#define DIAG_COMPAT_IDS_END()                                                  \
   }                                                                            \
   ;
 #define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,

--- a/clang/include/clang/Basic/DiagnosticInstallAPI.h
+++ b/clang/include/clang/Basic/DiagnosticInstallAPI.h
@@ -38,7 +38,9 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM_END()                                                 \
+  }                                                                            \
+  ;
 #define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
 #include "clang/Basic/DiagnosticInstallAPICompatEnums.inc"
 #undef DIAG_COMPAT_ENUM

--- a/clang/include/clang/Basic/DiagnosticLex.h
+++ b/clang/include/clang/Basic/DiagnosticLex.h
@@ -38,7 +38,7 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                 \
+#define DIAG_COMPAT_IDS_END()                                                  \
   }                                                                            \
   ;
 #define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,

--- a/clang/include/clang/Basic/DiagnosticLex.h
+++ b/clang/include/clang/Basic/DiagnosticLex.h
@@ -38,7 +38,9 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM_END()                                                 \
+  }                                                                            \
+  ;
 #define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
 #include "clang/Basic/DiagnosticLexCompatEnums.inc"
 #undef DIAG_COMPAT_ENUM

--- a/clang/include/clang/Basic/DiagnosticLex.h
+++ b/clang/include/clang/Basic/DiagnosticLex.h
@@ -35,6 +35,16 @@ enum {
 #undef DIAG_ENUM_ITEM
 #undef DIAG_ENUM
 } // end namespace diag
+
+namespace diag_compat {
+#define DIAG_COMPAT_ENUM_BEGIN() enum {
+#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticLexCompatEnums.inc"
+#undef DIAG_COMPAT_ENUM
+#undef DIAG_COMPAT_ENUM_BEGIN
+#undef DIAG_COMPAT_ENUM_END
+} // end namespace diag_compat
 } // end namespace clang
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICLEX_H

--- a/clang/include/clang/Basic/DiagnosticLex.h
+++ b/clang/include/clang/Basic/DiagnosticLex.h
@@ -37,15 +37,15 @@ enum {
 } // end namespace diag
 
 namespace diag_compat {
-#define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END()                                                 \
+#define DIAG_COMPAT_IDS_BEGIN() enum {
+#define DIAG_COMPAT_IDS_END()                                                 \
   }                                                                            \
   ;
-#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticLexCompatEnums.inc"
-#undef DIAG_COMPAT_ENUM
-#undef DIAG_COMPAT_ENUM_BEGIN
-#undef DIAG_COMPAT_ENUM_END
+#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticLexCompatIDs.inc"
+#undef DIAG_COMPAT_ID
+#undef DIAG_COMPAT_IDS_BEGIN
+#undef DIAG_COMPAT_IDS_END
 } // end namespace diag_compat
 } // end namespace clang
 

--- a/clang/include/clang/Basic/DiagnosticParse.h
+++ b/clang/include/clang/Basic/DiagnosticParse.h
@@ -36,6 +36,16 @@ enum {
 #undef DIAG_ENUM_ITEM
 #undef DIAG_ENUM
 } // end namespace diag
+
+namespace diag_compat {
+#define DIAG_COMPAT_ENUM_BEGIN() enum {
+#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticParseCompatEnums.inc"
+#undef DIAG_COMPAT_ENUM
+#undef DIAG_COMPAT_ENUM_BEGIN
+#undef DIAG_COMPAT_ENUM_END
+} // end namespace diag_compat
 } // end namespace clang
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICPARSE_H

--- a/clang/include/clang/Basic/DiagnosticParse.h
+++ b/clang/include/clang/Basic/DiagnosticParse.h
@@ -39,7 +39,7 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                 \
+#define DIAG_COMPAT_IDS_END()                                                  \
   }                                                                            \
   ;
 #define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,

--- a/clang/include/clang/Basic/DiagnosticParse.h
+++ b/clang/include/clang/Basic/DiagnosticParse.h
@@ -39,7 +39,9 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM_END()                                                 \
+  }                                                                            \
+  ;
 #define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
 #include "clang/Basic/DiagnosticParseCompatEnums.inc"
 #undef DIAG_COMPAT_ENUM

--- a/clang/include/clang/Basic/DiagnosticParse.h
+++ b/clang/include/clang/Basic/DiagnosticParse.h
@@ -38,15 +38,15 @@ enum {
 } // end namespace diag
 
 namespace diag_compat {
-#define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END()                                                 \
+#define DIAG_COMPAT_IDS_BEGIN() enum {
+#define DIAG_COMPAT_IDS_END()                                                 \
   }                                                                            \
   ;
-#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticParseCompatEnums.inc"
-#undef DIAG_COMPAT_ENUM
-#undef DIAG_COMPAT_ENUM_BEGIN
-#undef DIAG_COMPAT_ENUM_END
+#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticParseCompatIDs.inc"
+#undef DIAG_COMPAT_ID
+#undef DIAG_COMPAT_IDS_BEGIN
+#undef DIAG_COMPAT_IDS_END
 } // end namespace diag_compat
 } // end namespace clang
 

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -11,6 +11,12 @@
 //===----------------------------------------------------------------------===//
 
 let Component = "Parse" in {
+let CategoryName = "Parse Issue" in {
+// C++11 compatibility with C++98.
+defm enum_fixed_underlying_type : CXX11Compat<
+  "enumeration types with a fixed underlying type are",
+  /*ext_warn=*/false>;
+}
 
 def err_asm_qualifier_ignored : Error<
   "expected 'volatile', 'inline', 'goto', or '('">, CatInlineAsm;
@@ -107,9 +113,6 @@ def err_enumerator_list_missing_comma : Error<
   "missing ',' between enumerators">;
 def err_enumerator_unnamed_no_def : Error<
   "unnamed enumeration must be a definition">;
-def ext_cxx11_enum_fixed_underlying_type : Extension<
-  "enumeration types with a fixed underlying type are a C++11 extension">,
-  InGroup<CXX11>;
 def ext_ms_c_enum_fixed_underlying_type : Extension<
   "enumeration types with a fixed underlying type are a Microsoft extension">,
   InGroup<MicrosoftFixedEnum>;
@@ -119,9 +122,6 @@ def ext_c23_enum_fixed_underlying_type : Extension<
 def warn_c17_compat_enum_fixed_underlying_type : Warning<
   "enumeration types with a fixed underlying type are incompatible with C standards before C23">,
   DefaultIgnore, InGroup<CPre23Compat>;
-def warn_cxx98_compat_enum_fixed_underlying_type : Warning<
-  "enumeration types with a fixed underlying type are incompatible with C++98">,
-  InGroup<CXX98Compat>, DefaultIgnore;
 def ext_enum_base_in_type_specifier : ExtWarn<
   "non-defining declaration of enumeration with a fixed underlying type is "
   "only permitted as a standalone declaration"

--- a/clang/include/clang/Basic/DiagnosticRefactoring.h
+++ b/clang/include/clang/Basic/DiagnosticRefactoring.h
@@ -36,6 +36,16 @@ enum {
 #undef DIAG_ENUM_ITEM
 #undef DIAG_ENUM
 } // end namespace diag
+
+namespace diag_compat {
+#define DIAG_COMPAT_ENUM_BEGIN() enum {
+#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticRefactoringCompatEnums.inc"
+#undef DIAG_COMPAT_ENUM
+#undef DIAG_COMPAT_ENUM_BEGIN
+#undef DIAG_COMPAT_ENUM_END
+} // end namespace diag_compat
 } // end namespace clang
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICREFACTORING_H

--- a/clang/include/clang/Basic/DiagnosticRefactoring.h
+++ b/clang/include/clang/Basic/DiagnosticRefactoring.h
@@ -39,7 +39,7 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                 \
+#define DIAG_COMPAT_IDS_END()                                                  \
   }                                                                            \
   ;
 #define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,

--- a/clang/include/clang/Basic/DiagnosticRefactoring.h
+++ b/clang/include/clang/Basic/DiagnosticRefactoring.h
@@ -39,7 +39,9 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM_END()                                                 \
+  }                                                                            \
+  ;
 #define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
 #include "clang/Basic/DiagnosticRefactoringCompatEnums.inc"
 #undef DIAG_COMPAT_ENUM

--- a/clang/include/clang/Basic/DiagnosticRefactoring.h
+++ b/clang/include/clang/Basic/DiagnosticRefactoring.h
@@ -38,15 +38,15 @@ enum {
 } // end namespace diag
 
 namespace diag_compat {
-#define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END()                                                 \
+#define DIAG_COMPAT_IDS_BEGIN() enum {
+#define DIAG_COMPAT_IDS_END()                                                 \
   }                                                                            \
   ;
-#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticRefactoringCompatEnums.inc"
-#undef DIAG_COMPAT_ENUM
-#undef DIAG_COMPAT_ENUM_BEGIN
-#undef DIAG_COMPAT_ENUM_END
+#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticRefactoringCompatIDs.inc"
+#undef DIAG_COMPAT_ID
+#undef DIAG_COMPAT_IDS_BEGIN
+#undef DIAG_COMPAT_IDS_END
 } // end namespace diag_compat
 } // end namespace clang
 

--- a/clang/include/clang/Basic/DiagnosticSema.h
+++ b/clang/include/clang/Basic/DiagnosticSema.h
@@ -39,15 +39,15 @@ enum {
 } // end namespace diag
 
 namespace diag_compat {
-#define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END()                                                 \
+#define DIAG_COMPAT_IDS_BEGIN() enum {
+#define DIAG_COMPAT_IDS_END()                                                 \
   }                                                                            \
   ;
-#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticSemaCompatEnums.inc"
-#undef DIAG_COMPAT_ENUM
-#undef DIAG_COMPAT_ENUM_BEGIN
-#undef DIAG_COMPAT_ENUM_END
+#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticSemaCompatIDs.inc"
+#undef DIAG_COMPAT_ID
+#undef DIAG_COMPAT_IDS_BEGIN
+#undef DIAG_COMPAT_IDS_END
 } // end namespace diag_compat
 } // end namespace clang
 

--- a/clang/include/clang/Basic/DiagnosticSema.h
+++ b/clang/include/clang/Basic/DiagnosticSema.h
@@ -40,7 +40,9 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM_END()                                                 \
+  }                                                                            \
+  ;
 #define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
 #include "clang/Basic/DiagnosticSemaCompatEnums.inc"
 #undef DIAG_COMPAT_ENUM

--- a/clang/include/clang/Basic/DiagnosticSema.h
+++ b/clang/include/clang/Basic/DiagnosticSema.h
@@ -40,7 +40,7 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                 \
+#define DIAG_COMPAT_IDS_END()                                                  \
   }                                                                            \
   ;
 #define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,

--- a/clang/include/clang/Basic/DiagnosticSema.h
+++ b/clang/include/clang/Basic/DiagnosticSema.h
@@ -35,7 +35,16 @@ enum {
 #undef DIAG_ENUM_END
 #undef DIAG_ENUM_ITEM
 #undef DIAG_ENUM
+
 } // end namespace diag
+
+namespace diag_compat {
+#define DIAG_COMPAT_ENUM(name, ...) name,
+enum SemaCompatDiagId : unsigned {
+#include "clang/Basic/DiagnosticSemaCompatEnums.inc"
+};
+#undef DIAG_COMPAT_ENUM
+} // end namespace diag_compat
 } // end namespace clang
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICSEMA_H

--- a/clang/include/clang/Basic/DiagnosticSema.h
+++ b/clang/include/clang/Basic/DiagnosticSema.h
@@ -39,11 +39,13 @@ enum {
 } // end namespace diag
 
 namespace diag_compat {
-#define DIAG_COMPAT_ENUM(name, ...) name,
-enum SemaCompatDiagId : unsigned {
+#define DIAG_COMPAT_ENUM_BEGIN() enum {
+#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
 #include "clang/Basic/DiagnosticSemaCompatEnums.inc"
-};
 #undef DIAG_COMPAT_ENUM
+#undef DIAG_COMPAT_ENUM_BEGIN
+#undef DIAG_COMPAT_ENUM_END
 } // end namespace diag_compat
 } // end namespace clang
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -61,7 +61,7 @@ defm decomp_decl_cond : CXX26Compat<"structured binding declaration in a conditi
 
 // Compatibility warnings duplicated across multiple language versions.
 foreach std = [14, 20, 23] in {
-  defm constexpr_body_invalid_stmt : CXXCompat<
+  defm cxx#std#_constexpr_body_invalid_stmt : CXXCompat<
     "use of this statement in a constexpr %select{function|constructor}0 is", std>;
 }
 

--- a/clang/include/clang/Basic/DiagnosticSerialization.h
+++ b/clang/include/clang/Basic/DiagnosticSerialization.h
@@ -36,6 +36,16 @@ enum {
 #undef DIAG_ENUM_ITEM
 #undef DIAG_ENUM
 } // end namespace diag
+
+namespace diag_compat {
+#define DIAG_COMPAT_ENUM_BEGIN() enum {
+#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticSerializationCompatEnums.inc"
+#undef DIAG_COMPAT_ENUM
+#undef DIAG_COMPAT_ENUM_BEGIN
+#undef DIAG_COMPAT_ENUM_END
+} // end namespace diag_compat
 } // end namespace clang
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICSERIALIZATION_H

--- a/clang/include/clang/Basic/DiagnosticSerialization.h
+++ b/clang/include/clang/Basic/DiagnosticSerialization.h
@@ -39,7 +39,9 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END() };
+#define DIAG_COMPAT_ENUM_END()                                                 \
+  }                                                                            \
+  ;
 #define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
 #include "clang/Basic/DiagnosticSerializationCompatEnums.inc"
 #undef DIAG_COMPAT_ENUM

--- a/clang/include/clang/Basic/DiagnosticSerialization.h
+++ b/clang/include/clang/Basic/DiagnosticSerialization.h
@@ -39,7 +39,7 @@ enum {
 
 namespace diag_compat {
 #define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                 \
+#define DIAG_COMPAT_IDS_END()                                                  \
   }                                                                            \
   ;
 #define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,

--- a/clang/include/clang/Basic/DiagnosticSerialization.h
+++ b/clang/include/clang/Basic/DiagnosticSerialization.h
@@ -38,15 +38,15 @@ enum {
 } // end namespace diag
 
 namespace diag_compat {
-#define DIAG_COMPAT_ENUM_BEGIN() enum {
-#define DIAG_COMPAT_ENUM_END()                                                 \
+#define DIAG_COMPAT_IDS_BEGIN() enum {
+#define DIAG_COMPAT_IDS_END()                                                 \
   }                                                                            \
   ;
-#define DIAG_COMPAT_ENUM(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticSerializationCompatEnums.inc"
-#undef DIAG_COMPAT_ENUM
-#undef DIAG_COMPAT_ENUM_BEGIN
-#undef DIAG_COMPAT_ENUM_END
+#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/DiagnosticSerializationCompatIDs.inc"
+#undef DIAG_COMPAT_ID
+#undef DIAG_COMPAT_IDS_BEGIN
+#undef DIAG_COMPAT_IDS_END
 } // end namespace diag_compat
 } // end namespace clang
 

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -1264,7 +1264,7 @@ public:
   }
 
   DiagnosticBuilder DiagCompat(SourceLocation Loc, unsigned CompatDiagId);
-  DiagnosticBuilder DiagCompat(const Token& Tok, unsigned CompatDiagId);
+  DiagnosticBuilder DiagCompat(const Token &Tok, unsigned CompatDiagId);
   DiagnosticBuilder DiagCompat(unsigned CompatDiagId) {
     return DiagCompat(Tok, CompatDiagId);
   }

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -1263,6 +1263,12 @@ public:
     return Diag(Tok, DiagID);
   }
 
+  DiagnosticBuilder DiagCompat(SourceLocation Loc, unsigned CompatDiagId);
+  DiagnosticBuilder DiagCompat(const Token& Tok, unsigned CompatDiagId);
+  DiagnosticBuilder DiagCompat(unsigned CompatDiagId) {
+    return DiagCompat(Tok, CompatDiagId);
+  }
+
 private:
   void SuggestParentheses(SourceLocation Loc, unsigned DK,
                           SourceRange ParenRange);

--- a/clang/include/clang/Sema/SemaBase.h
+++ b/clang/include/clang/Sema/SemaBase.h
@@ -220,8 +220,7 @@ public:
                              bool DeferHint = false);
 
   /// Emit a compatibility diagnostic.
-  SemaDiagnosticBuilder DiagCompat(SourceLocation Loc,
-                                   diag_compat::SemaCompatDiagId CompatDiagId,
+  SemaDiagnosticBuilder DiagCompat(SourceLocation Loc, unsigned CompatDiagId,
                                    bool DeferHint = false);
 
   /// Build a partial diagnostic.

--- a/clang/include/clang/Sema/SemaBase.h
+++ b/clang/include/clang/Sema/SemaBase.h
@@ -219,6 +219,11 @@ public:
   SemaDiagnosticBuilder Diag(SourceLocation Loc, const PartialDiagnostic &PD,
                              bool DeferHint = false);
 
+  /// Emit a compatibility diagnostic.
+  SemaDiagnosticBuilder DiagCompat(SourceLocation Loc,
+                                   diag_compat::SemaCompatDiagId CompatDiagId,
+                                   bool DeferHint = false);
+
   /// Build a partial diagnostic.
   PartialDiagnostic PDiag(unsigned DiagID = 0);
 };

--- a/clang/lib/Basic/Diagnostic.cpp
+++ b/clang/lib/Basic/Diagnostic.cpp
@@ -1353,12 +1353,16 @@ unsigned clang::GetCompatDiagId(const LangOptions &LangOpts,
   // actual numbers don't really matter for this, but the definitions of the
   // compat diags in the Tablegen file uses the standard version, so we base
   // our encoding on that.
-#define DIAG_COMPAT_ENUM(Name, Std, Diag, DiagPre)                             \
+#define DIAG_COMPAT_ENUM_BEGIN()
+#define DIAG_COMPAT_ENUM_END()
+#define DIAG_COMPAT_ENUM(Value, Name, Std, Diag, DiagPre)                      \
   {Std == 98 ? 1998 : 2000 + Std, diag::Diag, diag::DiagPre},
   static constexpr CompatDiag Diags[] {
-#include "clang/Basic/DiagnosticSemaCompatEnums.inc"
+#include "clang/Basic/DiagnosticAllCompatEnums.inc"
   };
 #undef DIAG_COMPAT_ENUM
+#undef DIAG_COMPAT_ENUM_BEGIN
+#undef DIAG_COMPAT_ENUM_END
 
   assert(CompatDiagId < std::size(Diags) && "Invalid compat diag id");
 

--- a/clang/lib/Basic/Diagnostic.cpp
+++ b/clang/lib/Basic/Diagnostic.cpp
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "clang/Basic/AllDiagnostics.h"
 #include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/AllDiagnostics.h"
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/DiagnosticDriver.h"
 #include "clang/Basic/DiagnosticError.h"

--- a/clang/lib/Basic/Diagnostic.cpp
+++ b/clang/lib/Basic/Diagnostic.cpp
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/Basic/Diagnostic.h"
-#include "clang/Basic/AllDiagnostics.h"
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/DiagnosticDriver.h"
 #include "clang/Basic/DiagnosticError.h"
@@ -40,7 +39,6 @@
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <cassert>
-#include <clang/Basic/LangOptions.h>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>

--- a/clang/lib/Basic/Diagnostic.cpp
+++ b/clang/lib/Basic/Diagnostic.cpp
@@ -1341,51 +1341,6 @@ FormatDiagnostic(const char *DiagStr, const char *DiagEnd,
   OutStr.append(Tree.begin(), Tree.end());
 }
 
-unsigned clang::GetCompatDiagId(const LangOptions &LangOpts,
-                                unsigned CompatDiagId) {
-  struct CompatDiag {
-    unsigned StdVer;
-    unsigned DiagId;
-    unsigned PreDiagId;
-  };
-
-  // We encode the standard version such that C++98 < C++11 < C++14 etc. The
-  // actual numbers don't really matter for this, but the definitions of the
-  // compat diags in the Tablegen file uses the standard version, so we base
-  // our encoding on that.
-#define DIAG_COMPAT_ENUM_BEGIN()
-#define DIAG_COMPAT_ENUM_END()
-#define DIAG_COMPAT_ENUM(Value, Name, Std, Diag, DiagPre)                      \
-  {Std == 98 ? 1998 : 2000 + Std, diag::Diag, diag::DiagPre},
-  static constexpr CompatDiag Diags[] {
-#include "clang/Basic/DiagnosticAllCompatEnums.inc"
-  };
-#undef DIAG_COMPAT_ENUM
-#undef DIAG_COMPAT_ENUM_BEGIN
-#undef DIAG_COMPAT_ENUM_END
-
-  assert(CompatDiagId < std::size(Diags) && "Invalid compat diag id");
-
-  unsigned StdVer = [&] {
-    if (LangOpts.CPlusPlus26)
-      return 2026;
-    if (LangOpts.CPlusPlus23)
-      return 2023;
-    if (LangOpts.CPlusPlus20)
-      return 2020;
-    if (LangOpts.CPlusPlus17)
-      return 2017;
-    if (LangOpts.CPlusPlus14)
-      return 2014;
-    if (LangOpts.CPlusPlus11)
-      return 2011;
-    return 1998;
-  }();
-
-  const CompatDiag& D = Diags[CompatDiagId];
-  return StdVer >= D.StdVer ? D.DiagId : D.PreDiagId;
-}
-
 StoredDiagnostic::StoredDiagnostic(DiagnosticsEngine::Level Level, unsigned ID,
                                    StringRef Message)
     : ID(ID), Level(Level), Message(Message) {}

--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -785,8 +785,8 @@ unsigned DiagnosticIDs::getCompatDiagId(const LangOptions &LangOpts,
 #define DIAG_COMPAT_ENUM_BEGIN()
 #define DIAG_COMPAT_ENUM_END()
 #define DIAG_COMPAT_ENUM(Value, Name, Std, Diag, DiagPre)                      \
-{Std == 98 ? 1998 : 2000 + Std, diag::Diag, diag::DiagPre},
-  static constexpr CompatDiag Diags[] {
+  {Std == 98 ? 1998 : 2000 + Std, diag::Diag, diag::DiagPre},
+  static constexpr CompatDiag Diags[]{
 #include "clang/Basic/DiagnosticAllCompatEnums.inc"
   };
 #undef DIAG_COMPAT_ENUM
@@ -811,10 +811,9 @@ unsigned DiagnosticIDs::getCompatDiagId(const LangOptions &LangOpts,
     return 1998;
   }();
 
-  const CompatDiag& D = Diags[CompatDiagId];
+  const CompatDiag &D = Diags[CompatDiagId];
   return StdVer >= D.StdVer ? D.DiagId : D.PreDiagId;
 }
-
 
 /// ProcessDiag - This is the method used to report a diagnostic that is
 /// finally fully formed.

--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -784,7 +784,7 @@ unsigned DiagnosticIDs::getCompatDiagId(const LangOptions &LangOpts,
   // our encoding on that.
 #define DIAG_COMPAT_IDS_BEGIN()
 #define DIAG_COMPAT_IDS_END()
-#define DIAG_COMPAT_ID(Value, Name, Std, Diag, DiagPre)                      \
+#define DIAG_COMPAT_ID(Value, Name, Std, Diag, DiagPre)                        \
   {Std == 98 ? 1998 : 2000 + Std, diag::Diag, diag::DiagPre},
   static constexpr CompatDiag Diags[]{
 #include "clang/Basic/DiagnosticAllCompatIDs.inc"

--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -13,6 +13,7 @@
 #include "clang/Basic/DiagnosticIDs.h"
 #include "clang/Basic/AllDiagnostics.h"
 #include "clang/Basic/DiagnosticCategories.h"
+#include "clang/Basic/LangOptions.h"
 #include "clang/Basic/SourceManager.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
@@ -768,6 +769,52 @@ StringRef DiagnosticIDs::getNearestOption(diag::Flavor Flavor,
 
   return Best;
 }
+
+unsigned DiagnosticIDs::getCompatDiagId(const LangOptions &LangOpts,
+                                        unsigned CompatDiagId) {
+  struct CompatDiag {
+    unsigned StdVer;
+    unsigned DiagId;
+    unsigned PreDiagId;
+  };
+
+  // We encode the standard version such that C++98 < C++11 < C++14 etc. The
+  // actual numbers don't really matter for this, but the definitions of the
+  // compat diags in the Tablegen file uses the standard version, so we base
+  // our encoding on that.
+#define DIAG_COMPAT_ENUM_BEGIN()
+#define DIAG_COMPAT_ENUM_END()
+#define DIAG_COMPAT_ENUM(Value, Name, Std, Diag, DiagPre)                      \
+{Std == 98 ? 1998 : 2000 + Std, diag::Diag, diag::DiagPre},
+  static constexpr CompatDiag Diags[] {
+#include "clang/Basic/DiagnosticAllCompatEnums.inc"
+  };
+#undef DIAG_COMPAT_ENUM
+#undef DIAG_COMPAT_ENUM_BEGIN
+#undef DIAG_COMPAT_ENUM_END
+
+  assert(CompatDiagId < std::size(Diags) && "Invalid compat diag id");
+
+  unsigned StdVer = [&] {
+    if (LangOpts.CPlusPlus26)
+      return 2026;
+    if (LangOpts.CPlusPlus23)
+      return 2023;
+    if (LangOpts.CPlusPlus20)
+      return 2020;
+    if (LangOpts.CPlusPlus17)
+      return 2017;
+    if (LangOpts.CPlusPlus14)
+      return 2014;
+    if (LangOpts.CPlusPlus11)
+      return 2011;
+    return 1998;
+  }();
+
+  const CompatDiag& D = Diags[CompatDiagId];
+  return StdVer >= D.StdVer ? D.DiagId : D.PreDiagId;
+}
+
 
 /// ProcessDiag - This is the method used to report a diagnostic that is
 /// finally fully formed.

--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -780,8 +780,8 @@ unsigned DiagnosticIDs::getCompatDiagId(const LangOptions &LangOpts,
 
   // We encode the standard version such that C++98 < C++11 < C++14 etc. The
   // actual numbers don't really matter for this, but the definitions of the
-  // compat diags in the Tablegen file uses the standard version, so we base
-  // our encoding on that.
+  // compat diags in the Tablegen file use the standard version number (i.e.
+  // 98, 11, 14, etc.), so we base the encoding here on that.
 #define DIAG_COMPAT_IDS_BEGIN()
 #define DIAG_COMPAT_IDS_END()
 #define DIAG_COMPAT_ID(Value, Name, Std, Diag, DiagPre)                        \

--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -782,16 +782,16 @@ unsigned DiagnosticIDs::getCompatDiagId(const LangOptions &LangOpts,
   // actual numbers don't really matter for this, but the definitions of the
   // compat diags in the Tablegen file uses the standard version, so we base
   // our encoding on that.
-#define DIAG_COMPAT_ENUM_BEGIN()
-#define DIAG_COMPAT_ENUM_END()
-#define DIAG_COMPAT_ENUM(Value, Name, Std, Diag, DiagPre)                      \
+#define DIAG_COMPAT_IDS_BEGIN()
+#define DIAG_COMPAT_IDS_END()
+#define DIAG_COMPAT_ID(Value, Name, Std, Diag, DiagPre)                      \
   {Std == 98 ? 1998 : 2000 + Std, diag::Diag, diag::DiagPre},
   static constexpr CompatDiag Diags[]{
-#include "clang/Basic/DiagnosticAllCompatEnums.inc"
+#include "clang/Basic/DiagnosticAllCompatIDs.inc"
   };
-#undef DIAG_COMPAT_ENUM
-#undef DIAG_COMPAT_ENUM_BEGIN
-#undef DIAG_COMPAT_ENUM_END
+#undef DIAG_COMPAT_ID
+#undef DIAG_COMPAT_IDS_BEGIN
+#undef DIAG_COMPAT_IDS_END
 
   assert(CompatDiagId < std::size(Diags) && "Invalid compat diag id");
 

--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -770,8 +770,8 @@ StringRef DiagnosticIDs::getNearestOption(diag::Flavor Flavor,
   return Best;
 }
 
-unsigned DiagnosticIDs::getCompatDiagId(const LangOptions &LangOpts,
-                                        unsigned CompatDiagId) {
+unsigned DiagnosticIDs::getCXXCompatDiagId(const LangOptions &LangOpts,
+                                           unsigned CompatDiagId) {
   struct CompatDiag {
     unsigned StdVer;
     unsigned DiagId;

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -5450,11 +5450,8 @@ void Parser::ParseEnumSpecifier(SourceLocation StartLoc, DeclSpec &DS,
       BaseRange = SourceRange(ColonLoc, DeclaratorInfo.getSourceRange().getEnd());
 
       if (!getLangOpts().ObjC) {
-        if (getLangOpts().CPlusPlus11)
-          Diag(ColonLoc, diag::warn_cxx98_compat_enum_fixed_underlying_type)
-              << BaseRange;
-        else if (getLangOpts().CPlusPlus)
-          Diag(ColonLoc, diag::ext_cxx11_enum_fixed_underlying_type)
+        if (getLangOpts().CPlusPlus)
+          DiagCompat(ColonLoc, diag_compat::enum_fixed_underlying_type)
               << BaseRange;
         else if (getLangOpts().MicrosoftExt && !getLangOpts().C23)
           Diag(ColonLoc, diag::ext_ms_c_enum_fixed_underlying_type)

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -89,6 +89,15 @@ DiagnosticBuilder Parser::Diag(const Token &Tok, unsigned DiagID) {
   return Diag(Tok.getLocation(), DiagID);
 }
 
+DiagnosticBuilder Parser::DiagCompat(SourceLocation Loc,
+                                     unsigned CompatDiagId) {
+  return Diag(Loc, GetCompatDiagId(getLangOpts(), CompatDiagId));
+}
+
+DiagnosticBuilder Parser::DiagCompat(const Token &Tok, unsigned CompatDiagId) {
+  return DiagCompat(Tok.getLocation(), CompatDiagId);
+}
+
 /// Emits a diagnostic suggesting parentheses surrounding a
 /// given range.
 ///

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -91,7 +91,7 @@ DiagnosticBuilder Parser::Diag(const Token &Tok, unsigned DiagID) {
 
 DiagnosticBuilder Parser::DiagCompat(SourceLocation Loc,
                                      unsigned CompatDiagId) {
-  return Diag(Loc, GetCompatDiagId(getLangOpts(), CompatDiagId));
+  return Diag(Loc, DiagnosticIDs::getCompatDiagId(getLangOpts(), CompatDiagId));
 }
 
 DiagnosticBuilder Parser::DiagCompat(const Token &Tok, unsigned CompatDiagId) {

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -91,7 +91,8 @@ DiagnosticBuilder Parser::Diag(const Token &Tok, unsigned DiagID) {
 
 DiagnosticBuilder Parser::DiagCompat(SourceLocation Loc,
                                      unsigned CompatDiagId) {
-  return Diag(Loc, DiagnosticIDs::getCompatDiagId(getLangOpts(), CompatDiagId));
+  return Diag(Loc,
+              DiagnosticIDs::getCXXCompatDiagId(getLangOpts(), CompatDiagId));
 }
 
 DiagnosticBuilder Parser::DiagCompat(const Token &Tok, unsigned CompatDiagId) {

--- a/clang/lib/Sema/SemaBase.cpp
+++ b/clang/lib/Sema/SemaBase.cpp
@@ -88,4 +88,10 @@ Sema::SemaDiagnosticBuilder SemaBase::Diag(SourceLocation Loc,
   return Diag(Loc, PD.getDiagID(), DeferHint) << PD;
 }
 
+SemaBase::SemaDiagnosticBuilder
+SemaBase::DiagCompat(SourceLocation Loc,
+                     diag_compat::SemaCompatDiagId CompatDiagId,
+                     bool DeferHint) {
+  return Diag(Loc, GetCompatDiagId(getLangOpts(), CompatDiagId), DeferHint);
+}
 } // namespace clang

--- a/clang/lib/Sema/SemaBase.cpp
+++ b/clang/lib/Sema/SemaBase.cpp
@@ -88,10 +88,9 @@ Sema::SemaDiagnosticBuilder SemaBase::Diag(SourceLocation Loc,
   return Diag(Loc, PD.getDiagID(), DeferHint) << PD;
 }
 
-SemaBase::SemaDiagnosticBuilder
-SemaBase::DiagCompat(SourceLocation Loc,
-                     diag_compat::SemaCompatDiagId CompatDiagId,
-                     bool DeferHint) {
+SemaBase::SemaDiagnosticBuilder SemaBase::DiagCompat(SourceLocation Loc,
+                                                     unsigned CompatDiagId,
+                                                     bool DeferHint) {
   return Diag(Loc, GetCompatDiagId(getLangOpts(), CompatDiagId), DeferHint);
 }
 } // namespace clang

--- a/clang/lib/Sema/SemaBase.cpp
+++ b/clang/lib/Sema/SemaBase.cpp
@@ -91,6 +91,7 @@ Sema::SemaDiagnosticBuilder SemaBase::Diag(SourceLocation Loc,
 SemaBase::SemaDiagnosticBuilder SemaBase::DiagCompat(SourceLocation Loc,
                                                      unsigned CompatDiagId,
                                                      bool DeferHint) {
-  return Diag(Loc, GetCompatDiagId(getLangOpts(), CompatDiagId), DeferHint);
+  return Diag(Loc, DiagnosticIDs::getCompatDiagId(getLangOpts(), CompatDiagId),
+              DeferHint);
 }
 } // namespace clang

--- a/clang/lib/Sema/SemaBase.cpp
+++ b/clang/lib/Sema/SemaBase.cpp
@@ -91,7 +91,8 @@ Sema::SemaDiagnosticBuilder SemaBase::Diag(SourceLocation Loc,
 SemaBase::SemaDiagnosticBuilder SemaBase::DiagCompat(SourceLocation Loc,
                                                      unsigned CompatDiagId,
                                                      bool DeferHint) {
-  return Diag(Loc, DiagnosticIDs::getCompatDiagId(getLangOpts(), CompatDiagId),
+  return Diag(Loc,
+              DiagnosticIDs::getCXXCompatDiagId(getLangOpts(), CompatDiagId),
               DeferHint);
 }
 } // namespace clang

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7647,10 +7647,7 @@ NamedDecl *Sema::ActOnVariableDeclarator(
           IsVariableTemplate = true;
 
           // Only C++1y supports variable templates (N3651).
-          Diag(D.getIdentifierLoc(),
-               getLangOpts().CPlusPlus14
-                   ? diag::compat_cxx14_variable_template
-                   : diag::compat_pre_cxx14_variable_template);
+          DiagCompat(D.getIdentifierLoc(), diag_compat::variable_template);
         }
       }
     } else {
@@ -7716,10 +7713,8 @@ NamedDecl *Sema::ActOnVariableDeclarator(
           } else if (RD->isUnion()) {
             // C++98 [class.union]p1: If a union contains a static data member,
             // the program is ill-formed. C++11 drops this restriction.
-            Diag(D.getIdentifierLoc(),
-                 getLangOpts().CPlusPlus11
-                     ? diag::compat_cxx11_static_data_member_in_union
-                     : diag::compat_pre_cxx11_static_data_member_in_union)
+            DiagCompat(D.getIdentifierLoc(),
+                       diag_compat::static_data_member_in_union)
                 << Name;
           }
         }

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -807,10 +807,8 @@ Sema::ActOnDecompositionDeclarator(Scope *S, Declarator &D,
       for (auto Loc : BadSpecifierLocs)
         Err << SourceRange(Loc, Loc);
     } else if (!CPlusPlus20Specifiers.empty()) {
-      auto &&Warn = Diag(CPlusPlus20SpecifierLocs.front(),
-                         getLangOpts().CPlusPlus20
-                             ? diag::compat_cxx20_decomp_decl_spec
-                             : diag::compat_pre_cxx20_decomp_decl_spec);
+      auto &&Warn = DiagCompat(CPlusPlus20SpecifierLocs.front(),
+                               diag_compat::decomp_decl_spec);
       Warn << (int)CPlusPlus20Specifiers.size()
            << llvm::join(CPlusPlus20Specifiers.begin(),
                          CPlusPlus20Specifiers.end(), " ");
@@ -2040,10 +2038,8 @@ static bool CheckConstexprDeclStmt(Sema &SemaRef, const FunctionDecl *Dcl,
       // C++1y allows types to be defined, not just declared.
       if (cast<TagDecl>(DclIt)->isThisDeclarationADefinition()) {
         if (Kind == Sema::CheckConstexprKind::Diagnose) {
-          SemaRef.Diag(DS->getBeginLoc(),
-                       SemaRef.getLangOpts().CPlusPlus14
-                           ? diag::compat_cxx14_constexpr_type_definition
-                           : diag::compat_pre_cxx14_constexpr_type_definition)
+          SemaRef.DiagCompat(DS->getBeginLoc(),
+                             diag_compat::constexpr_type_definition)
               << isa<CXXConstructorDecl>(Dcl);
         } else if (!SemaRef.getLangOpts().CPlusPlus14) {
           return false;
@@ -2068,10 +2064,8 @@ static bool CheckConstexprDeclStmt(Sema &SemaRef, const FunctionDecl *Dcl,
       if (VD->isThisDeclarationADefinition()) {
         if (VD->isStaticLocal()) {
           if (Kind == Sema::CheckConstexprKind::Diagnose) {
-            SemaRef.Diag(VD->getLocation(),
-                         SemaRef.getLangOpts().CPlusPlus23
-                             ? diag::compat_cxx23_constexpr_static_var
-                             : diag::compat_pre_cxx23_constexpr_static_var)
+            SemaRef.DiagCompat(VD->getLocation(),
+                               diag_compat::constexpr_static_var)
                 << isa<CXXConstructorDecl>(Dcl)
                 << (VD->getTLSKind() == VarDecl::TLS_Dynamic);
           } else if (!SemaRef.getLangOpts().CPlusPlus23) {
@@ -2091,11 +2085,8 @@ static bool CheckConstexprDeclStmt(Sema &SemaRef, const FunctionDecl *Dcl,
         if (!VD->getType()->isDependentType() &&
             !VD->hasInit() && !VD->isCXXForRangeDecl()) {
           if (Kind == Sema::CheckConstexprKind::Diagnose) {
-            SemaRef.Diag(
-                VD->getLocation(),
-                SemaRef.getLangOpts().CPlusPlus20
-                    ? diag::compat_cxx20_constexpr_local_var_no_init
-                    : diag::compat_pre_cxx20_constexpr_local_var_no_init)
+            SemaRef.DiagCompat(VD->getLocation(),
+                               diag_compat::constexpr_local_var_no_init)
                 << isa<CXXConstructorDecl>(Dcl);
           } else if (!SemaRef.getLangOpts().CPlusPlus20) {
             return false;
@@ -2104,10 +2095,7 @@ static bool CheckConstexprDeclStmt(Sema &SemaRef, const FunctionDecl *Dcl,
         }
       }
       if (Kind == Sema::CheckConstexprKind::Diagnose) {
-        SemaRef.Diag(VD->getLocation(),
-                     SemaRef.getLangOpts().CPlusPlus14
-                         ? diag::compat_cxx14_constexpr_local_var
-                         : diag::compat_pre_cxx14_constexpr_local_var)
+        SemaRef.DiagCompat(VD->getLocation(), diag_compat::constexpr_local_var)
             << isa<CXXConstructorDecl>(Dcl);
       } else if (!SemaRef.getLangOpts().CPlusPlus14) {
         return false;
@@ -2177,10 +2165,8 @@ static bool CheckConstexprCtorInitializer(Sema &SemaRef,
   if (!Inits.count(Field)) {
     if (Kind == Sema::CheckConstexprKind::Diagnose) {
       if (!Diagnosed) {
-        SemaRef.Diag(Dcl->getLocation(),
-                     SemaRef.getLangOpts().CPlusPlus20
-                         ? diag::compat_cxx20_constexpr_ctor_missing_init
-                         : diag::compat_pre_cxx20_constexpr_ctor_missing_init);
+        SemaRef.DiagCompat(Dcl->getLocation(),
+                           diag_compat::constexpr_ctor_missing_init);
         Diagnosed = true;
       }
       SemaRef.Diag(Field->getLocation(),
@@ -2391,10 +2377,8 @@ static bool CheckConstexprFunctionBody(Sema &SemaRef, const FunctionDecl *Dcl,
       break;
 
     case Sema::CheckConstexprKind::Diagnose:
-      SemaRef.Diag(Body->getBeginLoc(),
-                   SemaRef.getLangOpts().CPlusPlus20
-                       ? diag::compat_cxx20_constexpr_function_try_block
-                       : diag::compat_pre_cxx20_constexpr_function_try_block)
+      SemaRef.DiagCompat(Body->getBeginLoc(),
+                         diag_compat::constexpr_function_try_block)
           << isa<CXXConstructorDecl>(Dcl);
       break;
     }
@@ -2444,11 +2428,8 @@ static bool CheckConstexprFunctionBody(Sema &SemaRef, const FunctionDecl *Dcl,
       if (Constructor->getNumCtorInitializers() == 0 &&
           RD->hasVariantMembers()) {
         if (Kind == Sema::CheckConstexprKind::Diagnose) {
-          SemaRef.Diag(
-              Dcl->getLocation(),
-              SemaRef.getLangOpts().CPlusPlus20
-                  ? diag::compat_cxx20_constexpr_union_ctor_no_init
-                  : diag::compat_pre_cxx20_constexpr_union_ctor_no_init);
+          SemaRef.DiagCompat(Dcl->getLocation(),
+                             diag_compat::constexpr_union_ctor_no_init);
         } else if (!SemaRef.getLangOpts().CPlusPlus20) {
           return false;
         }
@@ -2511,11 +2492,8 @@ static bool CheckConstexprFunctionBody(Sema &SemaRef, const FunctionDecl *Dcl,
     } else if (ReturnStmts.size() > 1) {
       switch (Kind) {
       case Sema::CheckConstexprKind::Diagnose:
-        SemaRef.Diag(
-            ReturnStmts.back(),
-            SemaRef.getLangOpts().CPlusPlus14
-                ? diag::compat_cxx14_constexpr_body_multiple_return
-                : diag::compat_pre_cxx14_constexpr_body_multiple_return);
+        SemaRef.DiagCompat(ReturnStmts.back(),
+                           diag_compat::constexpr_body_multiple_return);
         for (unsigned I = 0; I < ReturnStmts.size() - 1; ++I)
           SemaRef.Diag(ReturnStmts[I],
                        diag::note_constexpr_body_previous_return);

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -2421,22 +2421,13 @@ static bool CheckConstexprFunctionBody(Sema &SemaRef, const FunctionDecl *Dcl,
         (Cxx1yLoc.isValid() && !SemaRef.getLangOpts().CPlusPlus17))
       return false;
   } else if (Cxx2bLoc.isValid()) {
-    SemaRef.Diag(Cxx2bLoc,
-                 SemaRef.getLangOpts().CPlusPlus23
-                     ? diag::compat_cxx23_constexpr_body_invalid_stmt
-                     : diag::compat_pre_cxx23_constexpr_body_invalid_stmt)
+    SemaRef.DiagCompat(Cxx2bLoc, diag_compat::cxx23_constexpr_body_invalid_stmt)
         << isa<CXXConstructorDecl>(Dcl);
   } else if (Cxx2aLoc.isValid()) {
-    SemaRef.Diag(Cxx2aLoc,
-                 SemaRef.getLangOpts().CPlusPlus20
-                     ? diag::compat_cxx20_constexpr_body_invalid_stmt
-                     : diag::compat_pre_cxx20_constexpr_body_invalid_stmt)
+    SemaRef.DiagCompat(Cxx2aLoc, diag_compat::cxx20_constexpr_body_invalid_stmt)
         << isa<CXXConstructorDecl>(Dcl);
   } else if (Cxx1yLoc.isValid()) {
-    SemaRef.Diag(Cxx1yLoc,
-                 SemaRef.getLangOpts().CPlusPlus14
-                     ? diag::compat_cxx14_constexpr_body_invalid_stmt
-                     : diag::compat_pre_cxx14_constexpr_body_invalid_stmt)
+    SemaRef.DiagCompat(Cxx1yLoc, diag_compat::cxx14_constexpr_body_invalid_stmt)
         << isa<CXXConstructorDecl>(Dcl);
   }
 
@@ -17824,9 +17815,7 @@ Decl *Sema::ActOnFriendTypeDecl(Scope *S, const DeclSpec &DS,
           << FixItHint::CreateInsertion(getLocForEndOfToken(FriendLoc),
                                         InsertionText);
     } else {
-      Diag(FriendLoc, getLangOpts().CPlusPlus11
-                          ? diag::compat_cxx11_nonclass_type_friend
-                          : diag::compat_pre_cxx11_nonclass_type_friend)
+      DiagCompat(FriendLoc, diag_compat::nonclass_type_friend)
           << T << DS.getSourceRange();
     }
   }

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -6483,9 +6483,7 @@ ExprResult Sema::ActOnCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
   if (const auto *ULE = dyn_cast<UnresolvedLookupExpr>(Fn);
       ULE && ULE->hasExplicitTemplateArgs() &&
       ULE->decls_begin() == ULE->decls_end()) {
-    Diag(Fn->getExprLoc(), getLangOpts().CPlusPlus20
-                               ? diag::compat_cxx20_adl_only_template_id
-                               : diag::compat_pre_cxx20_adl_only_template_id)
+    DiagCompat(Fn->getExprLoc(), diag_compat::adl_only_template_id)
         << ULE->getName();
   }
 

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -2235,10 +2235,7 @@ static bool DiagnoseDefaultTemplateArgument(Sema &S,
     //   template-argument, that declaration shall be a definition and shall be
     //   the only declaration of the function template in the translation unit.
     // (C++98/03 doesn't have this wording; see DR226).
-    S.Diag(ParamLoc,
-           S.getLangOpts().CPlusPlus11
-               ? diag::compat_cxx11_templ_default_in_function_templ
-               : diag::compat_pre_cxx11_templ_default_in_function_templ)
+    S.DiagCompat(ParamLoc, diag_compat::templ_default_in_function_templ)
         << DefArgRange;
     return false;
 
@@ -6427,10 +6424,7 @@ static bool CheckTemplateArgumentAddressOfObjectOrFunction(
     bool ExtraParens = false;
     while (ParenExpr *Parens = dyn_cast<ParenExpr>(Arg)) {
       if (!Invalid && !ExtraParens) {
-        S.Diag(Arg->getBeginLoc(),
-               S.getLangOpts().CPlusPlus11
-                   ? diag::compat_cxx11_template_arg_extra_parens
-                   : diag::compat_pre_cxx11_template_arg_extra_parens)
+        S.DiagCompat(Arg->getBeginLoc(), diag_compat::template_arg_extra_parens)
             << Arg->getSourceRange();
         ExtraParens = true;
       }
@@ -6650,10 +6644,7 @@ CheckTemplateArgumentPointerToMember(Sema &S, NonTypeTemplateParmDecl *Param,
   bool ExtraParens = false;
   while (ParenExpr *Parens = dyn_cast<ParenExpr>(Arg)) {
     if (!Invalid && !ExtraParens) {
-      S.Diag(Arg->getBeginLoc(),
-             S.getLangOpts().CPlusPlus11
-                 ? diag::compat_cxx11_template_arg_extra_parens
-                 : diag::compat_pre_cxx11_template_arg_extra_parens)
+      S.DiagCompat(Arg->getBeginLoc(), diag_compat::template_arg_extra_parens)
           << Arg->getSourceRange();
       ExtraParens = true;
     }
@@ -10635,9 +10626,7 @@ TypeResult Sema::ActOnTypenameType(Scope *S, SourceLocation TypenameLoc,
     return true;
 
   if (TypenameLoc.isValid() && S && !S->getTemplateParamParent())
-    Diag(TypenameLoc, getLangOpts().CPlusPlus11
-                          ? diag::compat_cxx11_typename_outside_of_template
-                          : diag::compat_pre_cxx11_typename_outside_of_template)
+    DiagCompat(TypenameLoc, diag_compat::typename_outside_of_template)
         << FixItHint::CreateRemoval(TypenameLoc);
 
   NestedNameSpecifierLoc QualifierLoc = SS.getWithLocInContext(Context);

--- a/clang/test/Misc/show-diag-options.c
+++ b/clang/test/Misc/show-diag-options.c
@@ -18,7 +18,7 @@ void test(int x, int y) {
   // BASE: {{.*}}: warning: {{[a-z ]+$}}
   // OPTION: {{.*}}: warning: {{[a-z ]+}} [-Wparentheses]
   // OPTION_ERROR: {{.*}}: error: {{[a-z ]+}} [-Werror,-Wparentheses]
-  // CATEGORY_ID: {{.*}}: warning: {{[a-z ]+}} [2]
+  // CATEGORY_ID: {{.*}}: warning: {{[a-z ]+}} [{{[0-9]+}}]
   // CATEGORY_NAME: {{.*}}: warning: {{[a-z ]+}} [Semantic Issue]
   // OPTION_ERROR_CATEGORY: {{.*}}: error: {{[a-z ]+}} [-Werror,-Wparentheses,Semantic Issue]
 

--- a/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
+++ b/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
@@ -1539,11 +1539,12 @@ void clang::EmitClangDiagsCompatEnums(const llvm::RecordKeeper &Records,
     StringRef DiagPre = R.getValueAsString("DiagPre");
     int64_t CXXStdVer = R.getValueAsInt("Std");
 
-    // We don't want to create empty enums since some compilers (including Clang)
-    // warn about that, so these macros are used to avoid having to unconditionally
-    // write 'enum {' and '};' in the headers.
+    // We don't want to create empty enums since some compilers (including
+    // Clang) warn about that, so these macros are used to avoid having to
+    // unconditionally write 'enum {' and '};' in the headers.
     if (PrevComponent != DiagComponent) {
-      if (!PrevComponent.empty()) OS << "DIAG_COMPAT_ENUM_END()\n";
+      if (!PrevComponent.empty())
+        OS << "DIAG_COMPAT_ENUM_END()\n";
       OS << "DIAG_COMPAT_ENUM_BEGIN()\n";
       PrevComponent = DiagComponent;
     }
@@ -1557,7 +1558,8 @@ void clang::EmitClangDiagsCompatEnums(const llvm::RecordKeeper &Records,
     OS << ")\n";
   }
 
-  if (!PrevComponent.empty()) OS << "DIAG_COMPAT_ENUM_END()\n";
+  if (!PrevComponent.empty())
+    OS << "DIAG_COMPAT_ENUM_END()\n";
 }
 
 /// ClangDiagsEnumsEmitter - The top-level class emits .def files containing

--- a/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
+++ b/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
@@ -1520,8 +1520,8 @@ static void verifyDiagnosticWording(const Record &Diag) {
 }
 
 /// ClangDiagsCompatIDsEmitter - Emit a set of 'compatibility diagnostic ids'
-/// that map set of 2 regular diagnostic ids each and which are used to simplify
-/// emitting compatibility warnings.
+/// that map to a set of 2 regular diagnostic ids each and which are used to
+/// simplify emitting compatibility warnings.
 void clang::EmitClangDiagsCompatIDs(const llvm::RecordKeeper &Records,
                                     llvm::raw_ostream &OS,
                                     const std::string &Component) {

--- a/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
+++ b/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
@@ -1519,12 +1519,12 @@ static void verifyDiagnosticWording(const Record &Diag) {
   // #pragma clang, or --unwindlib=libgcc.
 }
 
-/// ClangDiagsCompatEnumsEmitter - Emit an enumeration that maps a
-/// 'compatibility diagnostic id' to a set of 2 regular diagnostic
-/// ids to simplify emitting compatibility warnings.
-void clang::EmitClangDiagsCompatEnums(const llvm::RecordKeeper &Records,
-                                      llvm::raw_ostream &OS,
-                                      const std::string &Component) {
+/// ClangDiagsCompatIDsEmitter - Emit a set of 'compatibility diagnostic ids'
+/// that map set of 2 regular diagnostic ids each and which are used to simplify
+/// emitting compatibility warnings.
+void clang::EmitClangDiagsCompatIDs(const llvm::RecordKeeper &Records,
+                                    llvm::raw_ostream &OS,
+                                    const std::string &Component) {
   ArrayRef<const Record *> Ids =
       Records.getAllDerivedDefinitions("CompatWarningId");
 
@@ -1544,8 +1544,8 @@ void clang::EmitClangDiagsCompatEnums(const llvm::RecordKeeper &Records,
     // unconditionally write 'enum {' and '};' in the headers.
     if (PrevComponent != DiagComponent) {
       if (!PrevComponent.empty())
-        OS << "DIAG_COMPAT_ENUM_END()\n";
-      OS << "DIAG_COMPAT_ENUM_BEGIN()\n";
+        OS << "DIAG_COMPAT_IDS_END()\n";
+      OS << "DIAG_COMPAT_IDS_BEGIN()\n";
       PrevComponent = DiagComponent;
     }
 
@@ -1553,13 +1553,13 @@ void clang::EmitClangDiagsCompatEnums(const llvm::RecordKeeper &Records,
     // name, e.g. 'constexpr_body_invalid_stmt' exists for C++14/20/23. It would
     // be nice if we could combine all of them into a single compatibility diag
     // id.
-    OS << "DIAG_COMPAT_ENUM(" << I << ",";
+    OS << "DIAG_COMPAT_ID(" << I << ",";
     OS << CompatDiagName << "," << CXXStdVer << "," << Diag << "," << DiagPre;
     OS << ")\n";
   }
 
   if (!PrevComponent.empty())
-    OS << "DIAG_COMPAT_ENUM_END()\n";
+    OS << "DIAG_COMPAT_IDS_END()\n";
 }
 
 /// ClangDiagsEnumsEmitter - The top-level class emits .def files containing

--- a/clang/utils/TableGen/TableGen.cpp
+++ b/clang/utils/TableGen/TableGen.cpp
@@ -178,7 +178,7 @@ cl::opt<ActionType> Action(
         clEnumValN(GenClangBuiltinTemplates, "gen-clang-builtin-templates",
                    "Generate clang builtins list"),
         clEnumValN(GenClangDiagsCompatIDs, "gen-clang-diags-compat-ids",
-                   "Generate Clang diagnostic compatibility enums"),
+                   "Generate Clang diagnostic compatibility ids"),
         clEnumValN(GenClangDiagsDefs, "gen-clang-diags-defs",
                    "Generate Clang diagnostics definitions"),
         clEnumValN(GenClangDiagsEnums, "gen-clang-diags-enums",

--- a/clang/utils/TableGen/TableGen.cpp
+++ b/clang/utils/TableGen/TableGen.cpp
@@ -48,7 +48,7 @@ enum ActionType {
   GenClangBasicWriter,
   GenClangBuiltins,
   GenClangBuiltinTemplates,
-  GenClangDiagsCompatEnums,
+  GenClangDiagsCompatIDs,
   GenClangDiagsDefs,
   GenClangDiagsEnums,
   GenClangDiagGroups,
@@ -177,7 +177,7 @@ cl::opt<ActionType> Action(
                    "Generate clang builtins list"),
         clEnumValN(GenClangBuiltinTemplates, "gen-clang-builtin-templates",
                    "Generate clang builtins list"),
-        clEnumValN(GenClangDiagsCompatEnums, "gen-clang-diags-compat-enums",
+        clEnumValN(GenClangDiagsCompatIDs, "gen-clang-diags-compat-ids",
                    "Generate Clang diagnostic compatibility enums"),
         clEnumValN(GenClangDiagsDefs, "gen-clang-diags-defs",
                    "Generate Clang diagnostics definitions"),
@@ -402,8 +402,8 @@ bool ClangTableGenMain(raw_ostream &OS, const RecordKeeper &Records) {
   case GenClangBuiltinTemplates:
     EmitClangBuiltinTemplates(Records, OS);
     break;
-  case GenClangDiagsCompatEnums:
-    EmitClangDiagsCompatEnums(Records, OS, ClangComponent);
+  case GenClangDiagsCompatIDs:
+    EmitClangDiagsCompatIDs(Records, OS, ClangComponent);
     break;
   case GenClangDiagsDefs:
     EmitClangDiagsDefs(Records, OS, ClangComponent);

--- a/clang/utils/TableGen/TableGen.cpp
+++ b/clang/utils/TableGen/TableGen.cpp
@@ -48,6 +48,7 @@ enum ActionType {
   GenClangBasicWriter,
   GenClangBuiltins,
   GenClangBuiltinTemplates,
+  GenClangDiagsCompatEnums,
   GenClangDiagsDefs,
   GenClangDiagsEnums,
   GenClangDiagGroups,
@@ -176,6 +177,8 @@ cl::opt<ActionType> Action(
                    "Generate clang builtins list"),
         clEnumValN(GenClangBuiltinTemplates, "gen-clang-builtin-templates",
                    "Generate clang builtins list"),
+        clEnumValN(GenClangDiagsCompatEnums, "gen-clang-diags-compat-enums",
+                   "Generate Clang diagnostic compatibility enums"),
         clEnumValN(GenClangDiagsDefs, "gen-clang-diags-defs",
                    "Generate Clang diagnostics definitions"),
         clEnumValN(GenClangDiagsEnums, "gen-clang-diags-enums",
@@ -398,6 +401,9 @@ bool ClangTableGenMain(raw_ostream &OS, const RecordKeeper &Records) {
     break;
   case GenClangBuiltinTemplates:
     EmitClangBuiltinTemplates(Records, OS);
+    break;
+  case GenClangDiagsCompatEnums:
+    EmitClangDiagsCompatEnums(Records, OS, ClangComponent);
     break;
   case GenClangDiagsDefs:
     EmitClangDiagsDefs(Records, OS, ClangComponent);

--- a/clang/utils/TableGen/TableGenBackends.h
+++ b/clang/utils/TableGen/TableGenBackends.h
@@ -91,6 +91,9 @@ void EmitClangBuiltins(const llvm::RecordKeeper &Records,
 void EmitClangBuiltinTemplates(const llvm::RecordKeeper &Records,
                                llvm::raw_ostream &OS);
 
+void EmitClangDiagsCompatEnums(const llvm::RecordKeeper &Records,
+                               llvm::raw_ostream &OS,
+                               const std::string &Component);
 void EmitClangDiagsDefs(const llvm::RecordKeeper &Records,
                         llvm::raw_ostream &OS, const std::string &Component);
 void EmitClangDiagsEnums(const llvm::RecordKeeper &Records,

--- a/clang/utils/TableGen/TableGenBackends.h
+++ b/clang/utils/TableGen/TableGenBackends.h
@@ -91,7 +91,7 @@ void EmitClangBuiltins(const llvm::RecordKeeper &Records,
 void EmitClangBuiltinTemplates(const llvm::RecordKeeper &Records,
                                llvm::raw_ostream &OS);
 
-void EmitClangDiagsCompatEnums(const llvm::RecordKeeper &Records,
+void EmitClangDiagsCompatIDs(const llvm::RecordKeeper &Records,
                                llvm::raw_ostream &OS,
                                const std::string &Component);
 void EmitClangDiagsDefs(const llvm::RecordKeeper &Records,

--- a/clang/utils/TableGen/TableGenBackends.h
+++ b/clang/utils/TableGen/TableGenBackends.h
@@ -92,8 +92,8 @@ void EmitClangBuiltinTemplates(const llvm::RecordKeeper &Records,
                                llvm::raw_ostream &OS);
 
 void EmitClangDiagsCompatIDs(const llvm::RecordKeeper &Records,
-                               llvm::raw_ostream &OS,
-                               const std::string &Component);
+                             llvm::raw_ostream &OS,
+                             const std::string &Component);
 void EmitClangDiagsDefs(const llvm::RecordKeeper &Records,
                         llvm::raw_ostream &OS, const std::string &Component);
 void EmitClangDiagsEnums(const llvm::RecordKeeper &Records,


### PR DESCRIPTION
This is a follow-up to #132129.

Currently, only `Parser` and `SemaBase` get a `DiagCompat()` helper; I’m planning to keep refactoring compatibility warnings and add more helpers to other classes as needed. I also refactored a single parser compat warning just to make sure everything works properly when diagnostics across multiple components (i.e. Sema and Parser in this case) are involved.

Another thing I noticed is that the `DiagnosticAST.h`, `DiagnosticAnalysis.h`, etc. headers are quite repetitive; I think we should be able to tablegen those as well; I’m planning to explore that in a separate pr after this because updating all of them every time I changed something while working on this pr has been rather tedious.