### PR TITLE
[alpha.webkit.RetainPtrCtorAdoptChecker] Recognize mutableCopy from literal as +1

### DIFF
--- a/clang/test/Analysis/Checkers/WebKit/objc-mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/objc-mock-types.h
@@ -1,6 +1,8 @@
 @class NSString;
 @class NSArray;
 @class NSMutableArray;
+@class NSDictionary;
+@class NSMutableDictionary;
 #define nil ((id)0)
 #define CF_BRIDGED_TYPE(T) __attribute__((objc_bridge(T)))
 #define CF_BRIDGED_MUTABLE_TYPE(T) __attribute__((objc_bridge_mutable(T)))
@@ -90,12 +92,14 @@ __attribute__((objc_root_class))
 - (NSEnumerator *)keyEnumerator;
 + (id)dictionary;
 + (id)dictionaryWithObject:(id)object forKey:(id <NSCopying>)key;
+- (NSMutableDictionary *)mutableCopy;
 + (instancetype)dictionaryWithObjects:(const id [])objects forKeys:(const id <NSCopying> [])keys count:(NSUInteger)cnt;
 @end
 
 @interface NSArray : NSObject <NSCopying, NSFastEnumeration>
 - (NSUInteger)count;
 - (NSEnumerator *)objectEnumerator;
+- (NSMutableArray *)mutableCopy;
 + (NSArray *)arrayWithObjects:(const id [])objects count:(NSUInteger)count;
 @end
 

--- a/clang/test/Analysis/Checkers/WebKit/objc-mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/objc-mock-types.h
@@ -108,6 +108,7 @@ __attribute__((objc_root_class))
 - (NSString *)stringByAppendingString:(NSString *)aString;
 - ( const char *)UTF8String;
 - (id)initWithUTF8String:(const char *)nullTerminatedCString;
+- (NSString *)copy;
 + (id)stringWithUTF8String:(const char *)nullTerminatedCString;
 @end
 

--- a/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use-arc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use-arc.mm
@@ -103,3 +103,7 @@ void mutable_copy() {
     @"Content-Type": @"text/html",
   }.mutableCopy);
 }
+
+void string_copy(NSString *str) {
+  RetainPtr<NSString> copy = adoptNS(str.copy);
+}

--- a/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use-arc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use-arc.mm
@@ -97,3 +97,9 @@ RetainPtr<CFArrayRef> create_cf_array();
 RetainPtr<id> return_bridge_cast() {
   return bridge_cast<CFArrayRef, NSArray>(create_cf_array());
 }
+
+void mutable_copy() {
+  RetainPtr<NSMutableDictionary> mutableArray = adoptNS(@{
+    @"Content-Type": @"text/html",
+  }.mutableCopy);
+}

--- a/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use-arc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use-arc.mm
@@ -98,10 +98,16 @@ RetainPtr<id> return_bridge_cast() {
   return bridge_cast<CFArrayRef, NSArray>(create_cf_array());
 }
 
-void mutable_copy() {
-  RetainPtr<NSMutableDictionary> mutableArray = adoptNS(@{
+void mutable_copy_dictionary() {
+  RetainPtr<NSMutableDictionary> mutableDictionary = adoptNS(@{
     @"Content-Type": @"text/html",
   }.mutableCopy);
+}
+
+void mutable_copy_array() {
+  RetainPtr<NSMutableArray> mutableArray = adoptNS(@[
+      @"foo",
+  ].mutableCopy);
 }
 
 void string_copy(NSString *str) {

--- a/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use.mm
+++ b/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use.mm
@@ -103,3 +103,7 @@ void mutable_copy() {
     @"Content-Type": @"text/html",
   }.mutableCopy);
 }
+
+void string_copy(NSString *str) {
+  RetainPtr<NSString> copy = adoptNS(str.copy);
+}

--- a/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use.mm
+++ b/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use.mm
@@ -97,3 +97,9 @@ RetainPtr<CFArrayRef> create_cf_array();
 RetainPtr<id> return_bridge_cast() {
   return bridge_cast<CFArrayRef, NSArray>(create_cf_array());
 }
+
+void mutable_copy() {
+  RetainPtr<NSMutableDictionary> mutableArray = adoptNS(@{
+    @"Content-Type": @"text/html",
+  }.mutableCopy);
+}

--- a/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use.mm
+++ b/clang/test/Analysis/Checkers/WebKit/retain-ptr-ctor-adopt-use.mm
@@ -98,10 +98,16 @@ RetainPtr<id> return_bridge_cast() {
   return bridge_cast<CFArrayRef, NSArray>(create_cf_array());
 }
 
-void mutable_copy() {
-  RetainPtr<NSMutableDictionary> mutableArray = adoptNS(@{
+void mutable_copy_dictionary() {
+  RetainPtr<NSMutableDictionary> mutableDictionary = adoptNS(@{
     @"Content-Type": @"text/html",
   }.mutableCopy);
+}
+
+void mutable_copy_array() {
+  RetainPtr<NSMutableArray> mutableArray = adoptNS(@[
+      @"foo",
+  ].mutableCopy);
 }
 
 void string_copy(NSString *str) {


### PR DESCRIPTION
This PR adds the support for recognizing the return value of copy / mutableCopy as +1. isAllocInit and isOwned now traverses PseudoObjectExpr to its last semantic expression.