### PR TITLE
[DebugInfo] Use heterogenous lookups with std::map (NFC)

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFVerifier.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFVerifier.h
@@ -37,7 +37,7 @@ struct AggregationData {
 
 class OutputCategoryAggregator {
 private:
-  std::map<std::string, AggregationData> Aggregation;
+  std::map<std::string, AggregationData, std::less<>> Aggregation;
   bool IncludeDetail;
 
 public:

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -2194,7 +2194,7 @@ void OutputCategoryAggregator::EnumerateResults(
 }
 void OutputCategoryAggregator::EnumerateDetailedResultsFor(
     StringRef category, std::function<void(StringRef, unsigned)> handleCounts) {
-  const auto Agg = Aggregation.find(std::string(category));
+  const auto Agg = Aggregation.find(category);
   if (Agg != Aggregation.end()) {
     for (const auto &[name, aggData] : Agg->second.DetailedCounts) {
       handleCounts(name, aggData);


### PR DESCRIPTION
Heterogenous lookups allow us to call find with StringRef, avoiding a
temporary heap allocation of std::string.
