### PR TITLE
wip [CodeGen] MachineModuleInfo: Take Target as a reference (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineModuleInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineModuleInfo.h
@@ -109,9 +109,9 @@ class MachineModuleInfo {
   MachineModuleInfo &operator=(MachineModuleInfo &&MMII) = delete;
 
 public:
-  explicit MachineModuleInfo(const TargetMachine *TM = nullptr);
+  explicit MachineModuleInfo(const TargetMachine &TM);
 
-  explicit MachineModuleInfo(const TargetMachine *TM, MCContext *ExtContext);
+  explicit MachineModuleInfo(const TargetMachine &TM, MCContext *ExtContext);
 
   MachineModuleInfo(MachineModuleInfo &&MMII);
 

--- a/llvm/lib/CodeGen/MachineModuleInfo.cpp
+++ b/llvm/lib/CodeGen/MachineModuleInfo.cpp
@@ -48,21 +48,21 @@ MachineModuleInfo::MachineModuleInfo(MachineModuleInfo &&MMI)
   TheModule = MMI.TheModule;
 }
 
-MachineModuleInfo::MachineModuleInfo(const TargetMachine *TM)
-    : TM(*TM), Context(TM->getTargetTriple(), TM->getMCAsmInfo(),
-                       TM->getMCRegisterInfo(), TM->getMCSubtargetInfo(),
-                       nullptr, &TM->Options.MCOptions, false) {
-  Context.setObjectFileInfo(TM->getObjFileLowering());
+MachineModuleInfo::MachineModuleInfo(const TargetMachine &TM)
+    : TM(TM),
+      Context(TM.getTargetTriple(), TM.getMCAsmInfo(), TM.getMCRegisterInfo(),
+              TM.getMCSubtargetInfo(), nullptr, &TM.Options.MCOptions, false) {
+  Context.setObjectFileInfo(TM.getObjFileLowering());
   initialize();
 }
 
-MachineModuleInfo::MachineModuleInfo(const TargetMachine *TM,
+MachineModuleInfo::MachineModuleInfo(const TargetMachine &TM,
                                      MCContext *ExtContext)
-    : TM(*TM), Context(TM->getTargetTriple(), TM->getMCAsmInfo(),
-                       TM->getMCRegisterInfo(), TM->getMCSubtargetInfo(),
-                       nullptr, &TM->Options.MCOptions, false),
+    : TM(TM),
+      Context(TM.getTargetTriple(), TM.getMCAsmInfo(), TM.getMCRegisterInfo(),
+              TM.getMCSubtargetInfo(), nullptr, &TM.Options.MCOptions, false),
       ExternalContext(ExtContext) {
-  Context.setObjectFileInfo(TM->getObjFileLowering());
+  Context.setObjectFileInfo(TM.getObjFileLowering());
   initialize();
 }
 
@@ -152,13 +152,13 @@ FunctionPass *llvm::createFreeMachineFunctionPass() {
 
 MachineModuleInfoWrapperPass::MachineModuleInfoWrapperPass(
     const TargetMachine *TM)
-    : ImmutablePass(ID), MMI(TM) {
+    : ImmutablePass(ID), MMI(*TM) {
   initializeMachineModuleInfoWrapperPassPass(*PassRegistry::getPassRegistry());
 }
 
 MachineModuleInfoWrapperPass::MachineModuleInfoWrapperPass(
     const TargetMachine *TM, MCContext *ExtContext)
-    : ImmutablePass(ID), MMI(TM, ExtContext) {
+    : ImmutablePass(ID), MMI(*TM, ExtContext) {
   initializeMachineModuleInfoWrapperPassPass(*PassRegistry::getPassRegistry());
 }
 

--- a/llvm/tools/llc/NewPMDriver.cpp
+++ b/llvm/tools/llc/NewPMDriver.cpp
@@ -107,7 +107,7 @@ int llvm::compileModuleWithNewPM(
   Opt.DebugPM = DebugPM;
   Opt.RegAlloc = RegAlloc;
 
-  MachineModuleInfo MMI(Target.get());
+  MachineModuleInfo MMI(*Target);
 
   PassInstrumentationCallbacks PIC;
   StandardInstrumentations SI(Context, Opt.DebugPM,

--- a/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
+++ b/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
@@ -520,7 +520,7 @@ ReducerWorkItem::clone(const TargetMachine *TM) const {
     // MachineModuleInfo contains a lot of other state used during codegen which
     // we won't be using here, but we should be able to ignore it (although this
     // is pretty ugly).
-    CloneMMM->MMI = std::make_unique<MachineModuleInfo>(TM);
+    CloneMMM->MMI = std::make_unique<MachineModuleInfo>(*TM);
 
     for (const Function &F : getModule()) {
       if (auto *MF = MMI->getMachineFunction(F))


### PR DESCRIPTION
MMI seems to require the TargetMachine.