### PR TITLE
release/20.x: [clang][docs] Move -Wnontrivial-memcall to added flags.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -545,6 +545,11 @@ New Compiler Flags
 - The ``-Warray-compare-cxx26`` warning has been added to warn about array comparison
   starting from C++26, this warning is enabled as an error by default.
 
+- The ``-Wnontrivial-memcall`` warning has been added to warn about
+  passing non-trivially-copyable destination parameter to ``memcpy``,
+  ``memset`` and similar functions for which it is a documented undefined
+  behavior. It is implied by ``-Wnontrivial-memaccess``
+
 - clang-cl and clang-dxc now support ``-fdiagnostics-color=[auto|never|always]``
   in addition to ``-f[no-]color-diagnostics``.
 
@@ -575,11 +580,6 @@ Modified Compiler Flags
   ``-fveclib=ArmPL`` and ``-fveclib=SLEEF``. This gives Clang more opportunities
   to utilize these vector libraries. The behavior for all other vector function
   libraries remains unchanged.
-
-- The ``-Wnontrivial-memcall`` warning has been added to warn about
-  passing non-trivially-copyable destination parameter to ``memcpy``,
-  ``memset`` and similar functions for which it is a documented undefined
-  behavior. It is implied by ``-Wnontrivial-memaccess``
 
 - Added ``-fmodules-reduced-bmi`` flag corresponding to
   ``-fexperimental-modules-reduced-bmi`` flag. The ``-fmodules-reduced-bmi`` flag


### PR DESCRIPTION
-Wnon-trivial-memcall was incorrectly added to modified flags instead of added flags. This commit moves it to the added compiler flags.