### PR TITLE
[Clang][NFC] Use MarkUsedTemplateParameters in building alias CTAD guides

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12590,6 +12590,10 @@ public:
   void MarkUsedTemplateParameters(const TemplateArgumentList &TemplateArgs,
                                   bool OnlyDeduced, unsigned Depth,
                                   llvm::SmallBitVector &Used);
+
+  void MarkUsedTemplateParameters(ArrayRef<TemplateArgument> TemplateArgs,
+                                  unsigned Depth, llvm::SmallBitVector &Used);
+
   void
   MarkDeducedTemplateParameters(const FunctionTemplateDecl *FunctionTemplate,
                                 llvm::SmallBitVector &Deduced) {

--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -7167,6 +7167,14 @@ Sema::MarkUsedTemplateParameters(const TemplateArgumentList &TemplateArgs,
                                  Depth, Used);
 }
 
+void Sema::MarkUsedTemplateParameters(ArrayRef<TemplateArgument> TemplateArgs,
+                                      unsigned Depth,
+                                      llvm::SmallBitVector &Used) {
+  for (unsigned I = 0, N = TemplateArgs.size(); I != N; ++I)
+    ::MarkUsedTemplateParameters(Context, TemplateArgs[I],
+                                 /*OnlyDeduced=*/false, Depth, Used);
+}
+
 void Sema::MarkDeducedTemplateParameters(
     ASTContext &Ctx, const FunctionTemplateDecl *FunctionTemplate,
     llvm::SmallBitVector &Deduced) {

--- a/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
+++ b/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
@@ -684,7 +684,8 @@ SmallVector<unsigned> TemplateParamsReferencedInTemplateArgumentList(
     ArrayRef<TemplateArgument> DeducedArgs) {
 
   llvm::SmallBitVector ReferencedTemplateParams(TemplateParamsList->size());
-  SemaRef.MarkUsedTemplateParameters(DeducedArgs, TemplateParamsList->getDepth(), ReferencedTemplateParams);
+  SemaRef.MarkUsedTemplateParameters(
+      DeducedArgs, TemplateParamsList->getDepth(), ReferencedTemplateParams);
 
   SmallVector<unsigned> Results;
   for (unsigned Index = 0; Index < TemplateParamsList->size(); ++Index) {

--- a/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
+++ b/clang/lib/Sema/SemaTemplateDeductionGuide.cpp
@@ -21,7 +21,6 @@
 #include "clang/AST/DeclFriend.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/DeclarationName.h"
-#include "clang/AST/DynamicRecursiveASTVisitor.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/OperationKinds.h"
@@ -681,54 +680,15 @@ private:
 // Find all template parameters that appear in the given DeducedArgs.
 // Return the indices of the template parameters in the TemplateParams.
 SmallVector<unsigned> TemplateParamsReferencedInTemplateArgumentList(
-    const TemplateParameterList *TemplateParamsList,
+    Sema &SemaRef, const TemplateParameterList *TemplateParamsList,
     ArrayRef<TemplateArgument> DeducedArgs) {
-  struct TemplateParamsReferencedFinder : DynamicRecursiveASTVisitor {
-    const TemplateParameterList *TemplateParamList;
-    llvm::BitVector ReferencedTemplateParams;
 
-    TemplateParamsReferencedFinder(
-        const TemplateParameterList *TemplateParamList)
-        : TemplateParamList(TemplateParamList),
-          ReferencedTemplateParams(TemplateParamList->size()) {}
-
-    bool VisitTemplateTypeParmType(TemplateTypeParmType *TTP) override {
-      // We use the index and depth to retrieve the corresponding template
-      // parameter from the parameter list, which is more robost.
-      Mark(TTP->getDepth(), TTP->getIndex());
-      return true;
-    }
-
-    bool VisitDeclRefExpr(DeclRefExpr *DRE) override {
-      MarkAppeared(DRE->getFoundDecl());
-      return true;
-    }
-
-    bool TraverseTemplateName(TemplateName Template) override {
-      if (auto *TD = Template.getAsTemplateDecl())
-        MarkAppeared(TD);
-      return DynamicRecursiveASTVisitor::TraverseTemplateName(Template);
-    }
-
-    void MarkAppeared(NamedDecl *ND) {
-      if (llvm::isa<NonTypeTemplateParmDecl, TemplateTypeParmDecl,
-                    TemplateTemplateParmDecl>(ND)) {
-        auto [Depth, Index] = getDepthAndIndex(ND);
-        Mark(Depth, Index);
-      }
-    }
-    void Mark(unsigned Depth, unsigned Index) {
-      if (Index < TemplateParamList->size() &&
-          TemplateParamList->getParam(Index)->getTemplateDepth() == Depth)
-        ReferencedTemplateParams.set(Index);
-    }
-  };
-  TemplateParamsReferencedFinder Finder(TemplateParamsList);
-  Finder.TraverseTemplateArguments(DeducedArgs);
+  llvm::SmallBitVector ReferencedTemplateParams(TemplateParamsList->size());
+  SemaRef.MarkUsedTemplateParameters(DeducedArgs, TemplateParamsList->getDepth(), ReferencedTemplateParams);
 
   SmallVector<unsigned> Results;
   for (unsigned Index = 0; Index < TemplateParamsList->size(); ++Index) {
-    if (Finder.ReferencedTemplateParams[Index])
+    if (ReferencedTemplateParams[Index])
       Results.push_back(Index);
   }
   return Results;
@@ -1084,7 +1044,7 @@ BuildDeductionGuideForTypeAlias(Sema &SemaRef,
   }
   auto DeducedAliasTemplateParams =
       TemplateParamsReferencedInTemplateArgumentList(
-          AliasTemplate->getTemplateParameters(), DeducedArgs);
+          SemaRef, AliasTemplate->getTemplateParameters(), DeducedArgs);
   // All template arguments null by default.
   SmallVector<TemplateArgument> TemplateArgsForBuildingFPrime(
       F->getTemplateParameters()->size());


### PR DESCRIPTION
It turns out that TemplateParamsReferencedInTemplateArgumentList() and MarkUsedTemplateParameters() have the similar goal, so let's drop the hand-written ASTVisitor.