### PR TITLE
Minor unused variable error for sanitizer builds

### DIFF
--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -11761,7 +11761,7 @@ void OMPClauseReader::VisitOMPReductionClause(OMPReductionClause *C) {
   unsigned NumFlags = Record.readInt();
   SmallVector<bool, 16> Flags;
   Flags.reserve(NumFlags);
-  for (unsigned I : llvm::seq<unsigned>(NumFlags))
+  for ([[maybe_unused]] unsigned I : llvm::seq<unsigned>(NumFlags))
     Flags.push_back(Record.readInt());
   C->setPrivateVariableReductionFlags(Flags);
 }


### PR DESCRIPTION
Fix #132371
Minor error ,  sanitizer builds are failing for unused variable.  
sanitizer-aarch64-linux/build/llvm-project/clang/lib/Serialization/ASTReader.cpp:11764:17: error: unused variable 'I' [-Werror,-Wunused-variable]
 11764 |   for (unsigned I : llvm::seq<unsigned>(NumFlags))

This was modified as part of [https://github.com/llvm/llvm-project/pull/129938](https://github.com/llvm/llvm-project/pull/129938) , which got missed. 