### PR TITLE
[libc] Fix unresolved stdio symbols

### DIFF
--- a/libc/src/stdio/CMakeLists.txt
+++ b/libc/src/stdio/CMakeLists.txt
@@ -21,10 +21,7 @@ endfunction(add_stdio_entrypoint_object)
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
 endif()
-
-if(NOT LIBC_TARGET_OS_IS_BAREMETAL AND NOT LIBC_TARGET_OS_IS_GPU)
-  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/generic)
-endif()
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/generic)
 
 if(NOT LLVM_LIBC_FULL_BUILD)
   list(APPEND use_system_file "COMPILE_OPTIONS" "-DLIBC_COPT_STDIO_USE_SYSTEM_FILE")

--- a/libc/src/stdio/generic/CMakeLists.txt
+++ b/libc/src/stdio/generic/CMakeLists.txt
@@ -1,4 +1,16 @@
-add_entrypoint_object(
+# Helper to only add the generic implementations if they aren't handled by a
+# more specific implementation.
+# TODO: This should probably be cleaned up and formalized.
+function(add_generic_entrypoint_object name)
+  if(NOT TARGET libc.src.stdio.${LIBC_TARGET_OS}.${name})
+    add_entrypoint_object(
+      ${name}
+      ${ARGN}
+    )
+  endif()
+endfunction(add_generic_entrypoint_object)
+
+add_generic_entrypoint_object(
   clearerr
   SRCS
     clearerr.cpp
@@ -10,7 +22,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   clearerr_unlocked
   SRCS
     clearerr_unlocked.cpp
@@ -22,7 +34,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   feof
   SRCS
     feof.cpp
@@ -34,7 +46,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   feof_unlocked
   SRCS
     feof_unlocked.cpp
@@ -46,7 +58,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   ferror
   SRCS
     ferror.cpp
@@ -58,7 +70,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   ferror_unlocked
   SRCS
     ferror_unlocked.cpp
@@ -70,7 +82,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   fileno
   SRCS
     fileno.cpp
@@ -82,7 +94,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   fflush
   SRCS
     fflush.cpp
@@ -95,7 +107,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   fseek
   SRCS
     fseek.cpp
@@ -107,7 +119,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   ftell
   SRCS
     ftell.cpp
@@ -119,7 +131,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   fseeko
   SRCS
     fseeko.cpp
@@ -131,7 +143,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   ftello
   SRCS
     ftello.cpp
@@ -143,7 +155,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   fopen
   SRCS
     fopen.cpp
@@ -155,7 +167,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   fclose
   SRCS
     fclose.cpp
@@ -168,7 +180,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   fread_unlocked
   SRCS
     fread_unlocked.cpp
@@ -181,7 +193,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   fread
   SRCS
     fread.cpp
@@ -194,7 +206,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   fputs
   SRCS
     fputs.cpp
@@ -207,7 +219,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   puts
   SRCS
     puts.cpp
@@ -220,7 +232,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_stdout
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   fwrite_unlocked
   SRCS
     fwrite_unlocked.cpp
@@ -233,7 +245,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   fwrite
   SRCS
     fwrite.cpp
@@ -246,7 +258,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   fputc
   SRCS
     fputc.cpp
@@ -259,7 +271,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   putc
   SRCS
     putc.cpp
@@ -272,7 +284,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   putchar
   SRCS
     putchar.cpp
@@ -285,7 +297,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   fgetc
   SRCS
     fgetc.cpp
@@ -298,7 +310,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   fgetc_unlocked
   SRCS
     fgetc_unlocked.cpp
@@ -311,7 +323,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   getc
   SRCS
     getc.cpp
@@ -324,7 +336,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   getc_unlocked
   SRCS
     getc_unlocked.cpp
@@ -337,7 +349,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   getchar
   SRCS
     getchar.cpp
@@ -350,7 +362,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   getchar_unlocked
   SRCS
     getchar_unlocked.cpp
@@ -385,7 +397,7 @@ if(LLVM_LIBC_FULL_BUILD)
   )
 endif()
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   printf
   SRCS
     printf.cpp
@@ -395,7 +407,7 @@ add_entrypoint_object(
     ${printf_deps}
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   vprintf
   SRCS
     vprintf.cpp
@@ -405,7 +417,7 @@ add_entrypoint_object(
     ${printf_deps}
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   fprintf
   SRCS
     fprintf.cpp
@@ -415,7 +427,7 @@ add_entrypoint_object(
     ${fprintf_deps}
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   vfprintf
   SRCS
     vfprintf.cpp
@@ -439,7 +451,7 @@ if(LLVM_LIBC_FULL_BUILD AND NOT LIBC_TARGET_OS_IS_GPU)
   )
 endif()
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   fscanf
   SRCS
     fscanf.cpp
@@ -449,7 +461,7 @@ add_entrypoint_object(
     ${scanf_deps}
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   vfscanf
   SRCS
     vfscanf.cpp
@@ -459,7 +471,7 @@ add_entrypoint_object(
     ${scanf_deps}
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   scanf
   SRCS
     scanf.cpp
@@ -469,7 +481,7 @@ add_entrypoint_object(
     ${scanf_deps}
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   vscanf
   SRCS
     vscanf.cpp
@@ -479,7 +491,7 @@ add_entrypoint_object(
     ${scanf_deps}
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   fgets
   SRCS
     fgets.cpp
@@ -492,7 +504,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   ungetc
   SRCS
     ungetc.cpp
@@ -504,7 +516,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_file
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   stdin
   SRCS
     stdin.cpp
@@ -516,7 +528,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_stdin
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   stdout
   SRCS
     stdout.cpp
@@ -528,7 +540,7 @@ add_entrypoint_object(
     libc.src.__support.File.platform_stdout
 )
 
-add_entrypoint_object(
+add_generic_entrypoint_object(
   stderr
   SRCS
     stderr.cpp


### PR DESCRIPTION
Summary:
We have 'generic' implementations for some functions stdio functions.
The current logic mandates that all generic functions are implemented by
the target. This obviously isn't true and this caused the GPU builds to
fail once baremtal added some extra ones.

This patch changes the logic to always include the generic sources only
if they aren't already defined. This can probably be cleaned up and
formalized later, since this pattern is copied in many places, but for
now this fixes the failing GPU build bots.
