### PR TITLE
[libc++][NFC] Re-run libcxx/include through clang-format

### DIFF
--- a/libcxx/include/__cxx03/__format/buffer.h
+++ b/libcxx/include/__cxx03/__format/buffer.h
@@ -488,8 +488,8 @@ protected:
 /// The buffer that counts and limits the number of insertions.
 template <class _OutIt, __fmt_char_type _CharT>
   requires(output_iterator<_OutIt, const _CharT&>)
-struct _LIBCPP_TEMPLATE_VIS __format_to_n_buffer final
-    : public __format_to_n_buffer_base< _OutIt, _CharT, __enable_direct_output<_OutIt, _CharT>> {
+struct _LIBCPP_TEMPLATE_VIS
+__format_to_n_buffer final : public __format_to_n_buffer_base< _OutIt, _CharT, __enable_direct_output<_OutIt, _CharT>> {
   using _Base = __format_to_n_buffer_base<_OutIt, _CharT, __enable_direct_output<_OutIt, _CharT>>;
   using _Size = iter_difference_t<_OutIt>;
 

--- a/libcxx/include/__cxx03/__format/container_adaptor.h
+++ b/libcxx/include/__cxx03/__format/container_adaptor.h
@@ -55,16 +55,16 @@ public:
 };
 
 template <class _CharT, class _Tp, formattable<_CharT> _Container>
-struct _LIBCPP_TEMPLATE_VIS formatter<queue<_Tp, _Container>, _CharT>
-    : public __formatter_container_adaptor<queue<_Tp, _Container>, _CharT> {};
+struct _LIBCPP_TEMPLATE_VIS
+formatter<queue<_Tp, _Container>, _CharT> : public __formatter_container_adaptor<queue<_Tp, _Container>, _CharT> {};
 
 template <class _CharT, class _Tp, class _Container, class _Compare>
 struct _LIBCPP_TEMPLATE_VIS formatter<priority_queue<_Tp, _Container, _Compare>, _CharT>
     : public __formatter_container_adaptor<priority_queue<_Tp, _Container, _Compare>, _CharT> {};
 
 template <class _CharT, class _Tp, formattable<_CharT> _Container>
-struct _LIBCPP_TEMPLATE_VIS formatter<stack<_Tp, _Container>, _CharT>
-    : public __formatter_container_adaptor<stack<_Tp, _Container>, _CharT> {};
+struct _LIBCPP_TEMPLATE_VIS
+formatter<stack<_Tp, _Container>, _CharT> : public __formatter_container_adaptor<stack<_Tp, _Container>, _CharT> {};
 
 #endif //_LIBCPP_STD_VER >= 23
 

--- a/libcxx/include/__cxx03/__format/formatter_output.h
+++ b/libcxx/include/__cxx03/__format/formatter_output.h
@@ -100,8 +100,8 @@ __padding_size(size_t __size, size_t __width, __format_spec::__alignment __align
 ///
 /// This uses a "mass output function" of __format::__output_buffer when possible.
 template <__fmt_char_type _CharT, __fmt_char_type _OutCharT = _CharT>
-_LIBCPP_HIDE_FROM_ABI auto
-__copy(basic_string_view<_CharT> __str, output_iterator<const _OutCharT&> auto __out_it) -> decltype(__out_it) {
+_LIBCPP_HIDE_FROM_ABI auto __copy(basic_string_view<_CharT> __str, output_iterator<const _OutCharT&> auto __out_it)
+    -> decltype(__out_it) {
   if constexpr (std::same_as<decltype(__out_it), std::back_insert_iterator<__format::__output_buffer<_OutCharT>>>) {
     __out_it.__get_container()->__copy(__str);
     return __out_it;
@@ -116,16 +116,16 @@ __copy(basic_string_view<_CharT> __str, output_iterator<const _OutCharT&> auto _
 template <contiguous_iterator _Iterator,
           __fmt_char_type _CharT    = typename iterator_traits<_Iterator>::value_type,
           __fmt_char_type _OutCharT = _CharT>
-_LIBCPP_HIDE_FROM_ABI auto
-__copy(_Iterator __first, _Iterator __last, output_iterator<const _OutCharT&> auto __out_it) -> decltype(__out_it) {
+_LIBCPP_HIDE_FROM_ABI auto __copy(_Iterator __first, _Iterator __last, output_iterator<const _OutCharT&> auto __out_it)
+    -> decltype(__out_it) {
   return __formatter::__copy(basic_string_view{__first, __last}, std::move(__out_it));
 }
 
 template <contiguous_iterator _Iterator,
           __fmt_char_type _CharT    = typename iterator_traits<_Iterator>::value_type,
           __fmt_char_type _OutCharT = _CharT>
-_LIBCPP_HIDE_FROM_ABI auto
-__copy(_Iterator __first, size_t __n, output_iterator<const _OutCharT&> auto __out_it) -> decltype(__out_it) {
+_LIBCPP_HIDE_FROM_ABI auto __copy(_Iterator __first, size_t __n, output_iterator<const _OutCharT&> auto __out_it)
+    -> decltype(__out_it) {
   return __formatter::__copy(basic_string_view{std::to_address(__first), __n}, std::move(__out_it));
 }
 
@@ -136,11 +136,9 @@ template <contiguous_iterator _Iterator,
           __fmt_char_type _CharT    = typename iterator_traits<_Iterator>::value_type,
           __fmt_char_type _OutCharT = _CharT,
           class _UnaryOperation>
-_LIBCPP_HIDE_FROM_ABI auto
-__transform(_Iterator __first,
-            _Iterator __last,
-            output_iterator<const _OutCharT&> auto __out_it,
-            _UnaryOperation __operation) -> decltype(__out_it) {
+_LIBCPP_HIDE_FROM_ABI auto __transform(
+    _Iterator __first, _Iterator __last, output_iterator<const _OutCharT&> auto __out_it, _UnaryOperation __operation)
+    -> decltype(__out_it) {
   if constexpr (std::same_as<decltype(__out_it), std::back_insert_iterator<__format::__output_buffer<_OutCharT>>>) {
     __out_it.__get_container()->__transform(__first, __last, std::move(__operation));
     return __out_it;

--- a/libcxx/include/__cxx03/__format/formatter_string.h
+++ b/libcxx/include/__cxx03/__format/formatter_string.h
@@ -118,8 +118,8 @@ struct _LIBCPP_TEMPLATE_VIS formatter<_CharT[_Size], _CharT> : public __formatte
 
 // Formatter std::string.
 template <__fmt_char_type _CharT, class _Traits, class _Allocator>
-struct _LIBCPP_TEMPLATE_VIS formatter<basic_string<_CharT, _Traits, _Allocator>, _CharT>
-    : public __formatter_string<_CharT> {
+struct _LIBCPP_TEMPLATE_VIS
+formatter<basic_string<_CharT, _Traits, _Allocator>, _CharT> : public __formatter_string<_CharT> {
   using _Base = __formatter_string<_CharT>;
 
   template <class _FormatContext>

--- a/libcxx/include/__cxx03/__format/formatter_tuple.h
+++ b/libcxx/include/__cxx03/__format/formatter_tuple.h
@@ -136,12 +136,12 @@ private:
 };
 
 template <__fmt_char_type _CharT, formattable<_CharT>... _Args>
-struct _LIBCPP_TEMPLATE_VIS formatter<pair<_Args...>, _CharT>
-    : public __formatter_tuple<_CharT, pair<_Args...>, _Args...> {};
+struct _LIBCPP_TEMPLATE_VIS
+formatter<pair<_Args...>, _CharT> : public __formatter_tuple<_CharT, pair<_Args...>, _Args...> {};
 
 template <__fmt_char_type _CharT, formattable<_CharT>... _Args>
-struct _LIBCPP_TEMPLATE_VIS formatter<tuple<_Args...>, _CharT>
-    : public __formatter_tuple<_CharT, tuple<_Args...>, _Args...> {};
+struct _LIBCPP_TEMPLATE_VIS
+formatter<tuple<_Args...>, _CharT> : public __formatter_tuple<_CharT, tuple<_Args...>, _Args...> {};
 
 #endif //_LIBCPP_STD_VER >= 23
 

--- a/libcxx/include/__cxx03/__functional/bind_back.h
+++ b/libcxx/include/__cxx03/__functional/bind_back.h
@@ -52,7 +52,7 @@ struct __bind_back_t : __perfect_forward<__bind_back_op<tuple_size_v<_BoundArgs>
 
 template <class _Fn, class... _Args>
   requires is_constructible_v<decay_t<_Fn>, _Fn> && is_move_constructible_v<decay_t<_Fn>> &&
-               (is_constructible_v<decay_t<_Args>, _Args> && ...) && (is_move_constructible_v<decay_t<_Args>> && ...)
+           (is_constructible_v<decay_t<_Args>, _Args> && ...) && (is_move_constructible_v<decay_t<_Args>> && ...)
 _LIBCPP_HIDE_FROM_ABI constexpr auto __bind_back(_Fn&& __f, _Args&&... __args) noexcept(
     noexcept(__bind_back_t<decay_t<_Fn>, tuple<decay_t<_Args>...>>(
         std::forward<_Fn>(__f), std::forward_as_tuple(std::forward<_Args>(__args)...))))

--- a/libcxx/include/__cxx03/__functional/bind_front.h
+++ b/libcxx/include/__cxx03/__functional/bind_front.h
@@ -29,8 +29,9 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 struct __bind_front_op {
   template <class... _Args>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Args&&... __args) const noexcept(
-      noexcept(std::invoke(std::forward<_Args>(__args)...))) -> decltype(std::invoke(std::forward<_Args>(__args)...)) {
+  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Args&&... __args) const
+      noexcept(noexcept(std::invoke(std::forward<_Args>(__args)...)))
+          -> decltype(std::invoke(std::forward<_Args>(__args)...)) {
     return std::invoke(std::forward<_Args>(__args)...);
   }
 };

--- a/libcxx/include/__cxx03/__functional/binder1st.h
+++ b/libcxx/include/__cxx03/__functional/binder1st.h
@@ -22,8 +22,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_BINDERS)
 
 template <class _Operation>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 binder1st
-    : public __unary_function<typename _Operation::second_argument_type, typename _Operation::result_type> {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11
+binder1st : public __unary_function<typename _Operation::second_argument_type, typename _Operation::result_type> {
 protected:
   _Operation op;
   typename _Operation::first_argument_type value;

--- a/libcxx/include/__cxx03/__functional/binder2nd.h
+++ b/libcxx/include/__cxx03/__functional/binder2nd.h
@@ -22,8 +22,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_BINDERS)
 
 template <class _Operation>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 binder2nd
-    : public __unary_function<typename _Operation::first_argument_type, typename _Operation::result_type> {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11
+binder2nd : public __unary_function<typename _Operation::first_argument_type, typename _Operation::result_type> {
 protected:
   _Operation op;
   typename _Operation::second_argument_type value;

--- a/libcxx/include/__cxx03/__functional/function.h
+++ b/libcxx/include/__cxx03/__functional/function.h
@@ -114,7 +114,7 @@ _LIBCPP_HIDE_FROM_ABI bool __not_null(_Fp* __ptr) {
 }
 
 template <class _Ret, class _Class>
-_LIBCPP_HIDE_FROM_ABI bool __not_null(_Ret _Class::*__ptr) {
+_LIBCPP_HIDE_FROM_ABI bool __not_null(_Ret _Class::* __ptr) {
   return __ptr;
 }
 
@@ -492,7 +492,7 @@ template <typename _Fun>
 struct __use_small_storage
     : public integral_constant<
           bool,
-          sizeof(_Fun) <= sizeof(__policy_storage)&& _LIBCPP_ALIGNOF(_Fun) <= _LIBCPP_ALIGNOF(__policy_storage) &&
+          sizeof(_Fun) <= sizeof(__policy_storage) && _LIBCPP_ALIGNOF(_Fun) <= _LIBCPP_ALIGNOF(__policy_storage) &&
               is_trivially_copy_constructible<_Fun>::value && is_trivially_destructible<_Fun>::value> {};
 
 // Policy contains information about how to copy, destroy, and move the

--- a/libcxx/include/__cxx03/__functional/mem_fn.h
+++ b/libcxx/include/__cxx03/__functional/mem_fn.h
@@ -45,7 +45,7 @@ public:
 };
 
 template <class _Rp, class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __mem_fn<_Rp _Tp::*> mem_fn(_Rp _Tp::*__pm) _NOEXCEPT {
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __mem_fn<_Rp _Tp::*> mem_fn(_Rp _Tp::* __pm) _NOEXCEPT {
   return __mem_fn<_Rp _Tp::*>(__pm);
 }
 

--- a/libcxx/include/__cxx03/__functional/mem_fun_ref.h
+++ b/libcxx/include/__cxx03/__functional/mem_fun_ref.h
@@ -89,8 +89,8 @@ public:
 };
 
 template <class _Sp, class _Tp, class _Ap>
-class _LIBCPP_TEMPLATE_VIS
-_LIBCPP_DEPRECATED_IN_CXX11 const_mem_fun1_t : public __binary_function<const _Tp*, _Ap, _Sp> {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11
+const_mem_fun1_t : public __binary_function<const _Tp*, _Ap, _Sp> {
   _Sp (_Tp::*__p_)(_Ap) const;
 
 public:

--- a/libcxx/include/__cxx03/__functional/operations.h
+++ b/libcxx/include/__cxx03/__functional/operations.h
@@ -206,8 +206,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS bit_and<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) &
-                        std::forward<_T2>(__u))) -> decltype(std::forward<_T1>(__t) & std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) & std::forward<_T2>(__u)))
+          -> decltype(std::forward<_T1>(__t) & std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) & std::forward<_T2>(__u);
   }
   typedef void is_transparent;
@@ -424,8 +424,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS greater_equal<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) >=
-                        std::forward<_T2>(__u))) -> decltype(std::forward<_T1>(__t) >= std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) >= std::forward<_T2>(__u)))
+          -> decltype(std::forward<_T1>(__t) >= std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) >= std::forward<_T2>(__u);
   }
   typedef void is_transparent;

--- a/libcxx/include/__cxx03/__functional/pointer_to_binary_function.h
+++ b/libcxx/include/__cxx03/__functional/pointer_to_binary_function.h
@@ -22,8 +22,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_BINDERS)
 
 template <class _Arg1, class _Arg2, class _Result>
-class _LIBCPP_TEMPLATE_VIS
-_LIBCPP_DEPRECATED_IN_CXX11 pointer_to_binary_function : public __binary_function<_Arg1, _Arg2, _Result> {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11
+pointer_to_binary_function : public __binary_function<_Arg1, _Arg2, _Result> {
   _Result (*__f_)(_Arg1, _Arg2);
 
 public:

--- a/libcxx/include/__cxx03/__functional/pointer_to_unary_function.h
+++ b/libcxx/include/__cxx03/__functional/pointer_to_unary_function.h
@@ -22,8 +22,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_BINDERS)
 
 template <class _Arg, class _Result>
-class _LIBCPP_TEMPLATE_VIS
-_LIBCPP_DEPRECATED_IN_CXX11 pointer_to_unary_function : public __unary_function<_Arg, _Result> {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11
+pointer_to_unary_function : public __unary_function<_Arg, _Result> {
   _Result (*__f_)(_Arg);
 
 public:

--- a/libcxx/include/__cxx03/__functional/unary_negate.h
+++ b/libcxx/include/__cxx03/__functional/unary_negate.h
@@ -22,8 +22,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_NEGATORS)
 
 template <class _Predicate>
-class _LIBCPP_TEMPLATE_VIS
-_LIBCPP_DEPRECATED_IN_CXX17 unary_negate : public __unary_function<typename _Predicate::argument_type, bool> {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17
+unary_negate : public __unary_function<typename _Predicate::argument_type, bool> {
   _Predicate __pred_;
 
 public:

--- a/libcxx/include/__cxx03/__iterator/access.h
+++ b/libcxx/include/__cxx03/__iterator/access.h
@@ -54,8 +54,8 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 auto end(const _Cp& __c) -> 
 #  if _LIBCPP_STD_VER >= 14
 
 template <class _Cp>
-_LIBCPP_HIDE_FROM_ABI constexpr auto
-cbegin(const _Cp& __c) noexcept(noexcept(std::begin(__c))) -> decltype(std::begin(__c)) {
+_LIBCPP_HIDE_FROM_ABI constexpr auto cbegin(const _Cp& __c) noexcept(noexcept(std::begin(__c)))
+    -> decltype(std::begin(__c)) {
   return std::begin(__c);
 }
 

--- a/libcxx/include/__cxx03/__iterator/concepts.h
+++ b/libcxx/include/__cxx03/__iterator/concepts.h
@@ -70,10 +70,10 @@ using iter_common_reference_t = common_reference_t<iter_reference_t<_Tp>, iter_v
 // [iterator.concept.writable]
 template <class _Out, class _Tp>
 concept indirectly_writable = requires(_Out&& __o, _Tp&& __t) {
-  *__o                                             = std::forward<_Tp>(__t); // not required to be equality-preserving
-  *std::forward<_Out>(__o)                         = std::forward<_Tp>(__t); // not required to be equality-preserving
-  const_cast<const iter_reference_t<_Out>&&>(*__o) = std::forward<_Tp>(__t); // not required to be equality-preserving
-  const_cast<const iter_reference_t<_Out>&&>(*std::forward<_Out>(__o)) =
+  *__o                                              = std::forward<_Tp>(__t); // not required to be equality-preserving
+  *std::forward<_Out>(__o)                          = std::forward<_Tp>(__t); // not required to be equality-preserving
+  const_cast<const iter_reference_t<_Out> &&>(*__o) = std::forward<_Tp>(__t); // not required to be equality-preserving
+  const_cast<const iter_reference_t<_Out> &&>(*std::forward<_Out>(__o)) =
       std::forward<_Tp>(__t); // not required to be equality-preserving
 };
 

--- a/libcxx/include/__cxx03/__iterator/empty.h
+++ b/libcxx/include/__cxx03/__iterator/empty.h
@@ -23,8 +23,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 17
 
 template <class _Cont>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto
-empty(const _Cont& __c) noexcept(noexcept(__c.empty())) -> decltype(__c.empty()) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto empty(const _Cont& __c) noexcept(noexcept(__c.empty()))
+    -> decltype(__c.empty()) {
   return __c.empty();
 }
 

--- a/libcxx/include/__cxx03/__iterator/move_iterator.h
+++ b/libcxx/include/__cxx03/__iterator/move_iterator.h
@@ -291,8 +291,8 @@ operator>=(const move_iterator<_Iter1>& __x, const move_iterator<_Iter2>& __y) {
 #if _LIBCPP_STD_VER >= 20
 template <class _Iter1, three_way_comparable_with<_Iter1> _Iter2>
 inline _LIBCPP_HIDE_FROM_ABI constexpr auto
-operator<=>(const move_iterator<_Iter1>& __x,
-            const move_iterator<_Iter2>& __y) -> compare_three_way_result_t<_Iter1, _Iter2> {
+operator<=>(const move_iterator<_Iter1>& __x, const move_iterator<_Iter2>& __y)
+    -> compare_three_way_result_t<_Iter1, _Iter2> {
   return __x.base() <=> __y.base();
 }
 #endif // _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__cxx03/__iterator/reverse_iterator.h
+++ b/libcxx/include/__cxx03/__iterator/reverse_iterator.h
@@ -284,8 +284,8 @@ operator<=>(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>&
 #ifndef _LIBCPP_CXX03_LANG
 template <class _Iter1, class _Iter2>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 auto
-operator-(const reverse_iterator<_Iter1>& __x,
-          const reverse_iterator<_Iter2>& __y) -> decltype(__y.base() - __x.base()) {
+operator-(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>& __y)
+    -> decltype(__y.base() - __x.base()) {
   return __y.base() - __x.base();
 }
 #else

--- a/libcxx/include/__cxx03/__iterator/size.h
+++ b/libcxx/include/__cxx03/__iterator/size.h
@@ -35,9 +35,9 @@ _LIBCPP_HIDE_FROM_ABI constexpr size_t size(const _Tp (&)[_Sz]) noexcept {
 
 #  if _LIBCPP_STD_VER >= 20
 template <class _Cont>
-_LIBCPP_HIDE_FROM_ABI constexpr auto
-ssize(const _Cont& __c) noexcept(noexcept(static_cast<common_type_t<ptrdiff_t, make_signed_t<decltype(__c.size())>>>(
-    __c.size()))) -> common_type_t<ptrdiff_t, make_signed_t<decltype(__c.size())>> {
+_LIBCPP_HIDE_FROM_ABI constexpr auto ssize(const _Cont& __c) noexcept(
+    noexcept(static_cast<common_type_t<ptrdiff_t, make_signed_t<decltype(__c.size())>>>(__c.size())))
+    -> common_type_t<ptrdiff_t, make_signed_t<decltype(__c.size())>> {
   return static_cast<common_type_t<ptrdiff_t, make_signed_t<decltype(__c.size())>>>(__c.size());
 }
 

--- a/libcxx/include/__cxx03/__mdspan/mdspan.h
+++ b/libcxx/include/__cxx03/__mdspan/mdspan.h
@@ -269,13 +269,13 @@ private:
 #  if _LIBCPP_STD_VER >= 26
 template <class _ElementType, class... _OtherIndexTypes>
   requires((is_convertible_v<_OtherIndexTypes, size_t> && ...) && (sizeof...(_OtherIndexTypes) > 0))
-explicit mdspan(_ElementType*,
-                _OtherIndexTypes...) -> mdspan<_ElementType, extents<size_t, __maybe_static_ext<_OtherIndexTypes>...>>;
+explicit mdspan(_ElementType*, _OtherIndexTypes...)
+    -> mdspan<_ElementType, extents<size_t, __maybe_static_ext<_OtherIndexTypes>...>>;
 #  else
 template <class _ElementType, class... _OtherIndexTypes>
   requires((is_convertible_v<_OtherIndexTypes, size_t> && ...) && (sizeof...(_OtherIndexTypes) > 0))
-explicit mdspan(_ElementType*,
-                _OtherIndexTypes...) -> mdspan<_ElementType, dextents<size_t, sizeof...(_OtherIndexTypes)>>;
+explicit mdspan(_ElementType*, _OtherIndexTypes...)
+    -> mdspan<_ElementType, dextents<size_t, sizeof...(_OtherIndexTypes)>>;
 #  endif
 
 template <class _Pointer>

--- a/libcxx/include/__cxx03/__memory/allocator.h
+++ b/libcxx/include/__cxx03/__memory/allocator.h
@@ -172,8 +172,8 @@ public:
 // TODO(LLVM 20): Remove the escape hatch
 #ifdef _LIBCPP_ENABLE_REMOVED_ALLOCATOR_CONST
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS allocator<const _Tp>
-    : private __non_trivial_if<!is_void<_Tp>::value, allocator<const _Tp> > {
+class _LIBCPP_TEMPLATE_VIS
+allocator<const _Tp> : private __non_trivial_if<!is_void<_Tp>::value, allocator<const _Tp> > {
   static_assert(!is_volatile<_Tp>::value, "std::allocator does not support volatile types");
 
 public:

--- a/libcxx/include/__cxx03/__memory/pointer_traits.h
+++ b/libcxx/include/__cxx03/__memory/pointer_traits.h
@@ -243,8 +243,8 @@ inline _LIBCPP_HIDE_FROM_ABI constexpr auto to_address(_Tp* __p) noexcept {
 }
 
 template <class _Pointer>
-inline _LIBCPP_HIDE_FROM_ABI constexpr auto
-to_address(const _Pointer& __p) noexcept -> decltype(std::__to_address(__p)) {
+inline _LIBCPP_HIDE_FROM_ABI constexpr auto to_address(const _Pointer& __p) noexcept
+    -> decltype(std::__to_address(__p)) {
   return std::__to_address(__p);
 }
 #endif

--- a/libcxx/include/__cxx03/__ranges/access.h
+++ b/libcxx/include/__cxx03/__ranges/access.h
@@ -191,8 +191,9 @@ struct __fn {
 
   template <class _Tp>
     requires is_rvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(
-      noexcept(ranges::end(static_cast<const _Tp&&>(__t)))) -> decltype(ranges::end(static_cast<const _Tp&&>(__t))) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+      noexcept(noexcept(ranges::end(static_cast<const _Tp&&>(__t))))
+          -> decltype(ranges::end(static_cast<const _Tp&&>(__t))) {
     return ranges::end(static_cast<const _Tp&&>(__t));
   }
 };

--- a/libcxx/include/__cxx03/__ranges/all.h
+++ b/libcxx/include/__cxx03/__ranges/all.h
@@ -39,8 +39,9 @@ namespace __all {
 struct __fn : __range_adaptor_closure<__fn> {
   template <class _Tp>
     requires ranges::view<decay_t<_Tp>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(
-      noexcept(_LIBCPP_AUTO_CAST(std::forward<_Tp>(__t)))) -> decltype(_LIBCPP_AUTO_CAST(std::forward<_Tp>(__t))) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+      noexcept(noexcept(_LIBCPP_AUTO_CAST(std::forward<_Tp>(__t))))
+          -> decltype(_LIBCPP_AUTO_CAST(std::forward<_Tp>(__t))) {
     return _LIBCPP_AUTO_CAST(std::forward<_Tp>(__t));
   }
 

--- a/libcxx/include/__cxx03/__ranges/common_view.h
+++ b/libcxx/include/__cxx03/__ranges/common_view.h
@@ -114,14 +114,16 @@ namespace __common {
 struct __fn : __range_adaptor_closure<__fn> {
   template <class _Range>
     requires common_range<_Range>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const noexcept(
-      noexcept(views::all(std::forward<_Range>(__range)))) -> decltype(views::all(std::forward<_Range>(__range))) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const
+      noexcept(noexcept(views::all(std::forward<_Range>(__range))))
+          -> decltype(views::all(std::forward<_Range>(__range))) {
     return views::all(std::forward<_Range>(__range));
   }
 
   template <class _Range>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const noexcept(noexcept(common_view{
-      std::forward<_Range>(__range)})) -> decltype(common_view{std::forward<_Range>(__range)}) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const
+      noexcept(noexcept(common_view{std::forward<_Range>(__range)}))
+          -> decltype(common_view{std::forward<_Range>(__range)}) {
     return common_view{std::forward<_Range>(__range)};
   }
 };

--- a/libcxx/include/__cxx03/__ranges/counted.h
+++ b/libcxx/include/__cxx03/__ranges/counted.h
@@ -51,8 +51,9 @@ struct __fn {
   }
 
   template <random_access_iterator _It>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __go(_It __it, iter_difference_t<_It> __count) noexcept(
-      noexcept(subrange(__it, __it + __count))) -> decltype(subrange(__it, __it + __count)) {
+  _LIBCPP_HIDE_FROM_ABI static constexpr auto
+  __go(_It __it, iter_difference_t<_It> __count) noexcept(noexcept(subrange(__it, __it + __count)))
+      -> decltype(subrange(__it, __it + __count)) {
     return subrange(__it, __it + __count);
   }
 

--- a/libcxx/include/__cxx03/__ranges/data.h
+++ b/libcxx/include/__cxx03/__ranges/data.h
@@ -83,8 +83,9 @@ struct __fn {
 
   template <class _Tp>
     requires is_rvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(
-      noexcept(ranges::data(static_cast<const _Tp&&>(__t)))) -> decltype(ranges::data(static_cast<const _Tp&&>(__t))) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+      noexcept(noexcept(ranges::data(static_cast<const _Tp&&>(__t))))
+          -> decltype(ranges::data(static_cast<const _Tp&&>(__t))) {
     return ranges::data(static_cast<const _Tp&&>(__t));
   }
 };

--- a/libcxx/include/__cxx03/__ranges/drop_view.h
+++ b/libcxx/include/__cxx03/__ranges/drop_view.h
@@ -289,14 +289,14 @@ struct __fn {
   template <class _Range, convertible_to<range_difference_t<_Range>> _Np, class _RawRange = remove_cvref_t<_Range>>
   // Note: without specifically excluding the other cases, GCC sees this overload as ambiguous with the other
   // overloads.
-    requires(!(__is_empty_view<_RawRange> ||
+    requires(
+        !(__is_empty_view<_RawRange> ||
 #  if _LIBCPP_STD_VER >= 23
-               __is_repeat_specialization<_RawRange> ||
+          __is_repeat_specialization<_RawRange> ||
 #  endif
-               (__is_subrange_specialization_with_store_size<_RawRange> && sized_range<_RawRange> &&
-                random_access_range<_RawRange>) ||
-               (__is_passthrough_specialization<_RawRange> && sized_range<_RawRange> &&
-                random_access_range<_RawRange>)))
+          (__is_subrange_specialization_with_store_size<_RawRange> && sized_range<_RawRange> &&
+           random_access_range<_RawRange>) ||
+          (__is_passthrough_specialization<_RawRange> && sized_range<_RawRange> && random_access_range<_RawRange>)))
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range, _Np&& __n) const
       noexcept(noexcept(drop_view(std::forward<_Range>(__range), std::forward<_Np>(__n))))
           -> decltype(drop_view(std::forward<_Range>(__range), std::forward<_Np>(__n))) {

--- a/libcxx/include/__cxx03/__ranges/lazy_split_view.h
+++ b/libcxx/include/__cxx03/__ranges/lazy_split_view.h
@@ -103,7 +103,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI constexpr auto begin() {
     if constexpr (forward_range<_View>) {
-      return __outer_iterator < __simple_view<_View> && __simple_view < _Pattern >> {*this, ranges::begin(__base_)};
+      return __outer_iterator< __simple_view<_View> && __simple_view< _Pattern >>{*this, ranges::begin(__base_)};
     } else {
       __current_.__emplace(ranges::begin(__base_));
       return __outer_iterator<false>{*this};
@@ -119,7 +119,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr auto end()
     requires forward_range<_View> && common_range<_View>
   {
-    return __outer_iterator < __simple_view<_View> && __simple_view < _Pattern >> {*this, ranges::end(__base_)};
+    return __outer_iterator< __simple_view<_View> && __simple_view< _Pattern >>{*this, ranges::end(__base_)};
   }
 
   _LIBCPP_HIDE_FROM_ABI constexpr auto end() const {
@@ -403,8 +403,8 @@ template <class _Range, class _Pattern>
 lazy_split_view(_Range&&, _Pattern&&) -> lazy_split_view<views::all_t<_Range>, views::all_t<_Pattern>>;
 
 template <input_range _Range>
-lazy_split_view(_Range&&,
-                range_value_t<_Range>) -> lazy_split_view<views::all_t<_Range>, single_view<range_value_t<_Range>>>;
+lazy_split_view(_Range&&, range_value_t<_Range>)
+    -> lazy_split_view<views::all_t<_Range>, single_view<range_value_t<_Range>>>;
 
 namespace views {
 namespace __lazy_split_view {

--- a/libcxx/include/__cxx03/__ranges/rend.h
+++ b/libcxx/include/__cxx03/__ranges/rend.h
@@ -104,8 +104,9 @@ struct __fn {
 
   template <class _Tp>
     requires is_rvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(
-      noexcept(ranges::rend(static_cast<const _Tp&&>(__t)))) -> decltype(ranges::rend(static_cast<const _Tp&&>(__t))) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+      noexcept(noexcept(ranges::rend(static_cast<const _Tp&&>(__t))))
+          -> decltype(ranges::rend(static_cast<const _Tp&&>(__t))) {
     return ranges::rend(static_cast<const _Tp&&>(__t));
   }
 };

--- a/libcxx/include/__cxx03/__ranges/reverse_view.h
+++ b/libcxx/include/__cxx03/__ranges/reverse_view.h
@@ -181,8 +181,9 @@ struct __fn : __range_adaptor_closure<__fn> {
   template <class _Range>
     requires(!__is_reverse_view<remove_cvref_t<_Range>> && !__is_sized_reverse_subrange<remove_cvref_t<_Range>> &&
              !__is_unsized_reverse_subrange<remove_cvref_t<_Range>>)
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const noexcept(noexcept(reverse_view{
-      std::forward<_Range>(__range)})) -> decltype(reverse_view{std::forward<_Range>(__range)}) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const
+      noexcept(noexcept(reverse_view{std::forward<_Range>(__range)}))
+          -> decltype(reverse_view{std::forward<_Range>(__range)}) {
     return reverse_view{std::forward<_Range>(__range)};
   }
 };

--- a/libcxx/include/__cxx03/__ranges/subrange.h
+++ b/libcxx/include/__cxx03/__ranges/subrange.h
@@ -200,11 +200,12 @@ template <input_or_output_iterator _Iter, sentinel_for<_Iter> _Sent>
 subrange(_Iter, _Sent, make_unsigned_t<iter_difference_t<_Iter>>) -> subrange<_Iter, _Sent, subrange_kind::sized>;
 
 template <borrowed_range _Range>
-subrange(_Range&&) -> subrange<iterator_t<_Range>,
-                               sentinel_t<_Range>,
-                               (sized_range<_Range> || sized_sentinel_for<sentinel_t<_Range>, iterator_t<_Range>>)
-                                   ? subrange_kind::sized
-                                   : subrange_kind::unsized>;
+subrange(_Range&&)
+    -> subrange<iterator_t<_Range>,
+                sentinel_t<_Range>,
+                (sized_range<_Range> || sized_sentinel_for<sentinel_t<_Range>, iterator_t<_Range>>)
+                    ? subrange_kind::sized
+                    : subrange_kind::unsized>;
 
 template <borrowed_range _Range>
 subrange(_Range&&, make_unsigned_t<range_difference_t<_Range>>)

--- a/libcxx/include/__cxx03/__string/char_traits.h
+++ b/libcxx/include/__cxx03/__string/char_traits.h
@@ -259,8 +259,8 @@ struct _LIBCPP_TEMPLATE_VIS char_traits<wchar_t> : __char_traits_base<wchar_t, w
 #ifndef _LIBCPP_HAS_NO_CHAR8_T
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS char_traits<char8_t>
-    : __char_traits_base<char8_t, unsigned int, static_cast<unsigned int>(EOF)> {
+struct _LIBCPP_TEMPLATE_VIS
+char_traits<char8_t> : __char_traits_base<char8_t, unsigned int, static_cast<unsigned int>(EOF)> {
   static _LIBCPP_HIDE_FROM_ABI constexpr int
   compare(const char_type* __s1, const char_type* __s2, size_t __n) noexcept {
     return std::__constexpr_memcmp(__s1, __s2, __element_count(__n));
@@ -279,8 +279,8 @@ struct _LIBCPP_TEMPLATE_VIS char_traits<char8_t>
 #endif // _LIBCPP_HAS_NO_CHAR8_T
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS char_traits<char16_t>
-    : __char_traits_base<char16_t, uint_least16_t, static_cast<uint_least16_t>(0xFFFF)> {
+struct _LIBCPP_TEMPLATE_VIS
+char_traits<char16_t> : __char_traits_base<char16_t, uint_least16_t, static_cast<uint_least16_t>(0xFFFF)> {
   _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX17 int
   compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT;
   _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX17 size_t length(const char_type* __s) _NOEXCEPT;
@@ -314,8 +314,8 @@ inline _LIBCPP_CONSTEXPR_SINCE_CXX17 size_t char_traits<char16_t>::length(const 
 }
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS char_traits<char32_t>
-    : __char_traits_base<char32_t, uint_least32_t, static_cast<uint_least32_t>(0xFFFFFFFF)> {
+struct _LIBCPP_TEMPLATE_VIS
+char_traits<char32_t> : __char_traits_base<char32_t, uint_least32_t, static_cast<uint_least32_t>(0xFFFFFFFF)> {
   _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX17 int
   compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT;
   _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX17 size_t length(const char_type* __s) _NOEXCEPT;

--- a/libcxx/include/__cxx03/__thread/support/c11.h
+++ b/libcxx/include/__cxx03/__thread/support/c11.h
@@ -31,7 +31,8 @@ using __libcpp_timespec_t = ::timespec;
 typedef mtx_t __libcpp_mutex_t;
 // mtx_t is a struct so using {} for initialization is valid.
 #define _LIBCPP_MUTEX_INITIALIZER                                                                                      \
-  {}
+  {                                                                                                                    \
+  }
 
 typedef mtx_t __libcpp_recursive_mutex_t;
 
@@ -82,7 +83,8 @@ inline _LIBCPP_HIDE_FROM_ABI int __libcpp_mutex_destroy(__libcpp_mutex_t* __m) {
 typedef cnd_t __libcpp_condvar_t;
 // cnd_t is a struct so using {} for initialization is valid.
 #define _LIBCPP_CONDVAR_INITIALIZER                                                                                    \
-  {}
+  {                                                                                                                    \
+  }
 
 inline _LIBCPP_HIDE_FROM_ABI int __libcpp_condvar_signal(__libcpp_condvar_t* __cv) {
   return cnd_signal(__cv) == thrd_success ? 0 : EINVAL;

--- a/libcxx/include/__cxx03/__tuple/sfinae_helpers.h
+++ b/libcxx/include/__cxx03/__tuple/sfinae_helpers.h
@@ -35,8 +35,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 struct __tuple_sfinae_base {
   template <template <class, class...> class _Trait, class... _LArgs, class... _RArgs>
-  static auto __do_test(__tuple_types<_LArgs...>,
-                        __tuple_types<_RArgs...>) -> __all<__enable_if_t<_Trait<_LArgs, _RArgs>::value, bool>{true}...>;
+  static auto __do_test(__tuple_types<_LArgs...>, __tuple_types<_RArgs...>)
+      -> __all<__enable_if_t<_Trait<_LArgs, _RArgs>::value, bool>{true}...>;
   template <template <class...> class>
   static auto __do_test(...) -> false_type;
 

--- a/libcxx/include/__cxx03/__tuple/tuple_size.h
+++ b/libcxx/include/__cxx03/__tuple/tuple_size.h
@@ -30,15 +30,17 @@ template <class _Tp, class...>
 using __enable_if_tuple_size_imp = _Tp;
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS tuple_size<__enable_if_tuple_size_imp< const _Tp,
-                                                                   __enable_if_t<!is_volatile<_Tp>::value>,
-                                                                   integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
+struct _LIBCPP_TEMPLATE_VIS
+tuple_size<__enable_if_tuple_size_imp< const _Tp,
+                                       __enable_if_t<!is_volatile<_Tp>::value>,
+                                       integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
     : public integral_constant<size_t, tuple_size<_Tp>::value> {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS tuple_size<__enable_if_tuple_size_imp< volatile _Tp,
-                                                                   __enable_if_t<!is_const<_Tp>::value>,
-                                                                   integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
+struct _LIBCPP_TEMPLATE_VIS
+tuple_size<__enable_if_tuple_size_imp< volatile _Tp,
+                                       __enable_if_t<!is_const<_Tp>::value>,
+                                       integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
     : public integral_constant<size_t, tuple_size<_Tp>::value> {};
 
 template <class _Tp>

--- a/libcxx/include/__cxx03/__type_traits/common_type.h
+++ b/libcxx/include/__cxx03/__type_traits/common_type.h
@@ -89,8 +89,8 @@ struct _LIBCPP_TEMPLATE_VIS common_type<_Tp, _Up>
 // bullet 4 - sizeof...(Tp) > 2
 
 template <class _Tp, class _Up, class _Vp, class... _Rest>
-struct _LIBCPP_TEMPLATE_VIS common_type<_Tp, _Up, _Vp, _Rest...>
-    : __common_type_impl<__common_types<_Tp, _Up, _Vp, _Rest...> > {};
+struct _LIBCPP_TEMPLATE_VIS
+common_type<_Tp, _Up, _Vp, _Rest...> : __common_type_impl<__common_types<_Tp, _Up, _Vp, _Rest...> > {};
 
 #if _LIBCPP_STD_VER >= 14
 template <class... _Tp>

--- a/libcxx/include/__cxx03/__type_traits/invoke.h
+++ b/libcxx/include/__cxx03/__type_traits/invoke.h
@@ -248,8 +248,8 @@ struct _LIBCPP_TEMPLATE_VIS is_nothrow_invocable : integral_constant<bool, __not
 };
 
 template <class _Ret, class _Fn, class... _Args>
-struct _LIBCPP_TEMPLATE_VIS is_nothrow_invocable_r
-    : integral_constant<bool, __nothrow_invokable_r<_Ret, _Fn, _Args...>::value> {};
+struct _LIBCPP_TEMPLATE_VIS
+is_nothrow_invocable_r : integral_constant<bool, __nothrow_invokable_r<_Ret, _Fn, _Args...>::value> {};
 
 template <class _Fn, class... _Args>
 inline constexpr bool is_nothrow_invocable_v = is_nothrow_invocable<_Fn, _Args...>::value;

--- a/libcxx/include/__cxx03/__type_traits/is_arithmetic.h
+++ b/libcxx/include/__cxx03/__type_traits/is_arithmetic.h
@@ -21,8 +21,8 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_arithmetic
-    : public integral_constant<bool, is_integral<_Tp>::value || is_floating_point<_Tp>::value> {};
+struct _LIBCPP_TEMPLATE_VIS
+is_arithmetic : public integral_constant<bool, is_integral<_Tp>::value || is_floating_point<_Tp>::value> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__cxx03/__type_traits/is_constructible.h
+++ b/libcxx/include/__cxx03/__type_traits/is_constructible.h
@@ -29,8 +29,8 @@ inline constexpr bool is_constructible_v = __is_constructible(_Tp, _Args...);
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_copy_constructible
-    : public integral_constant<bool, __is_constructible(_Tp, __add_lvalue_reference_t<const _Tp>)> {};
+struct _LIBCPP_TEMPLATE_VIS
+is_copy_constructible : public integral_constant<bool, __is_constructible(_Tp, __add_lvalue_reference_t<const _Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -38,8 +38,8 @@ inline constexpr bool is_copy_constructible_v = is_copy_constructible<_Tp>::valu
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_move_constructible
-    : public integral_constant<bool, __is_constructible(_Tp, __add_rvalue_reference_t<_Tp>)> {};
+struct _LIBCPP_TEMPLATE_VIS
+is_move_constructible : public integral_constant<bool, __is_constructible(_Tp, __add_rvalue_reference_t<_Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__cxx03/__type_traits/is_literal_type.h
+++ b/libcxx/include/__cxx03/__type_traits/is_literal_type.h
@@ -20,8 +20,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_TYPE_TRAITS)
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS
-_LIBCPP_DEPRECATED_IN_CXX17 is_literal_type : public integral_constant<bool, __is_literal_type(_Tp)> {};
+struct _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17
+is_literal_type : public integral_constant<bool, __is_literal_type(_Tp)> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__cxx03/__type_traits/is_nothrow_constructible.h
+++ b/libcxx/include/__cxx03/__type_traits/is_nothrow_constructible.h
@@ -21,8 +21,8 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template < class _Tp, class... _Args>
-struct _LIBCPP_TEMPLATE_VIS is_nothrow_constructible
-    : public integral_constant<bool, __is_nothrow_constructible(_Tp, _Args...)> {};
+struct _LIBCPP_TEMPLATE_VIS
+is_nothrow_constructible : public integral_constant<bool, __is_nothrow_constructible(_Tp, _Args...)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp, class... _Args>
@@ -48,8 +48,8 @@ inline constexpr bool is_nothrow_move_constructible_v = is_nothrow_move_construc
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_nothrow_default_constructible
-    : public integral_constant<bool, __is_nothrow_constructible(_Tp)> {};
+struct _LIBCPP_TEMPLATE_VIS
+is_nothrow_default_constructible : public integral_constant<bool, __is_nothrow_constructible(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__cxx03/__type_traits/is_nothrow_destructible.h
+++ b/libcxx/include/__cxx03/__type_traits/is_nothrow_destructible.h
@@ -39,8 +39,8 @@ struct __libcpp_is_nothrow_destructible<true, _Tp>
     : public integral_constant<bool, noexcept(std::declval<_Tp>().~_Tp()) > {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_nothrow_destructible
-    : public __libcpp_is_nothrow_destructible<is_destructible<_Tp>::value, _Tp> {};
+struct _LIBCPP_TEMPLATE_VIS
+is_nothrow_destructible : public __libcpp_is_nothrow_destructible<is_destructible<_Tp>::value, _Tp> {};
 
 template <class _Tp, size_t _Ns>
 struct _LIBCPP_TEMPLATE_VIS is_nothrow_destructible<_Tp[_Ns]> : public is_nothrow_destructible<_Tp> {};

--- a/libcxx/include/__cxx03/__type_traits/is_pointer.h
+++ b/libcxx/include/__cxx03/__type_traits/is_pointer.h
@@ -50,8 +50,8 @@ template <class _Tp> struct __libcpp_remove_objc_qualifiers<_Tp __unsafe_unretai
 #  endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_pointer
-    : public __libcpp_is_pointer<typename __libcpp_remove_objc_qualifiers<__remove_cv_t<_Tp> >::type> {};
+struct _LIBCPP_TEMPLATE_VIS
+is_pointer : public __libcpp_is_pointer<typename __libcpp_remove_objc_qualifiers<__remove_cv_t<_Tp> >::type> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__cxx03/__type_traits/is_trivially_constructible.h
+++ b/libcxx/include/__cxx03/__type_traits/is_trivially_constructible.h
@@ -21,8 +21,8 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class... _Args>
-struct _LIBCPP_TEMPLATE_VIS is_trivially_constructible
-    : integral_constant<bool, __is_trivially_constructible(_Tp, _Args...)> {};
+struct _LIBCPP_TEMPLATE_VIS
+is_trivially_constructible : integral_constant<bool, __is_trivially_constructible(_Tp, _Args...)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp, class... _Args>
@@ -48,8 +48,8 @@ inline constexpr bool is_trivially_move_constructible_v = is_trivially_move_cons
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_trivially_default_constructible
-    : public integral_constant<bool, __is_trivially_constructible(_Tp)> {};
+struct _LIBCPP_TEMPLATE_VIS
+is_trivially_default_constructible : public integral_constant<bool, __is_trivially_constructible(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__cxx03/__type_traits/is_trivially_destructible.h
+++ b/libcxx/include/__cxx03/__type_traits/is_trivially_destructible.h
@@ -22,8 +22,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if __has_builtin(__is_trivially_destructible)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_trivially_destructible
-    : public integral_constant<bool, __is_trivially_destructible(_Tp)> {};
+struct _LIBCPP_TEMPLATE_VIS
+is_trivially_destructible : public integral_constant<bool, __is_trivially_destructible(_Tp)> {};
 
 #elif __has_builtin(__has_trivial_destructor)
 

--- a/libcxx/include/__cxx03/__utility/forward_like.h
+++ b/libcxx/include/__cxx03/__utility/forward_like.h
@@ -34,8 +34,8 @@ template <class _Ap, class _Bp>
 using _ForwardLike = _OverrideRef<_Ap&&, _CopyConst<remove_reference_t<_Ap>, remove_reference_t<_Bp>>>;
 
 template <class _Tp, class _Up>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto
-forward_like(_LIBCPP_LIFETIMEBOUND _Up&& __ux) noexcept -> _ForwardLike<_Tp, _Up> {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto forward_like(_LIBCPP_LIFETIMEBOUND _Up&& __ux) noexcept
+    -> _ForwardLike<_Tp, _Up> {
   return static_cast<_ForwardLike<_Tp, _Up>>(__ux);
 }
 

--- a/libcxx/include/__cxx03/bitset
+++ b/libcxx/include/__cxx03/bitset
@@ -607,8 +607,8 @@ template <size_t _Size>
 struct hash<bitset<_Size> >;
 
 template <size_t _Size>
-class _LIBCPP_TEMPLATE_VIS bitset
-    : private __bitset<_Size == 0 ? 0 : (_Size - 1) / (sizeof(size_t) * CHAR_BIT) + 1, _Size> {
+class _LIBCPP_TEMPLATE_VIS
+bitset : private __bitset<_Size == 0 ? 0 : (_Size - 1) / (sizeof(size_t) * CHAR_BIT) + 1, _Size> {
 public:
   static const unsigned __n_words = _Size == 0 ? 0 : (_Size - 1) / (sizeof(size_t) * CHAR_BIT) + 1;
   typedef __bitset<__n_words, _Size> base;

--- a/libcxx/include/__cxx03/codecvt
+++ b/libcxx/include/__cxx03/codecvt
@@ -433,8 +433,8 @@ protected:
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _Elem, unsigned long _Maxcode = 0x10ffff, codecvt_mode _Mode = (codecvt_mode)0>
-class _LIBCPP_TEMPLATE_VIS
-_LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf16 : public __codecvt_utf16<_Elem, _Mode & little_endian> {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17
+codecvt_utf16 : public __codecvt_utf16<_Elem, _Mode & little_endian> {
 public:
   _LIBCPP_HIDE_FROM_ABI explicit codecvt_utf16(size_t __refs = 0)
       : __codecvt_utf16<_Elem, _Mode & little_endian>(__refs, _Maxcode, _Mode) {}

--- a/libcxx/include/__cxx03/condition_variable
+++ b/libcxx/include/__cxx03/condition_variable
@@ -192,12 +192,16 @@ public:
 inline condition_variable_any::condition_variable_any() : __mut_(make_shared<mutex>()) {}
 
 inline void condition_variable_any::notify_one() _NOEXCEPT {
-  { lock_guard<mutex> __lx(*__mut_); }
+  {
+    lock_guard<mutex> __lx(*__mut_);
+  }
   __cv_.notify_one();
 }
 
 inline void condition_variable_any::notify_all() _NOEXCEPT {
-  { lock_guard<mutex> __lx(*__mut_); }
+  {
+    lock_guard<mutex> __lx(*__mut_);
+  }
   __cv_.notify_all();
 }
 

--- a/libcxx/include/__cxx03/cwchar
+++ b/libcxx/include/__cxx03/cwchar
@@ -227,7 +227,7 @@ __constexpr_wmemcmp(const wchar_t* __lhs, const wchar_t* __rhs, size_t __count) 
 
 template <class _Tp, class _Up>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp* __constexpr_wmemchr(_Tp* __str, _Up __value, size_t __count) {
-  static_assert(sizeof(_Tp) == sizeof(wchar_t)&& _LIBCPP_ALIGNOF(_Tp) >= _LIBCPP_ALIGNOF(wchar_t) &&
+  static_assert(sizeof(_Tp) == sizeof(wchar_t) && _LIBCPP_ALIGNOF(_Tp) >= _LIBCPP_ALIGNOF(wchar_t) &&
                     __libcpp_is_trivially_equality_comparable<_Tp, _Tp>::value,
                 "Calling wmemchr on non-trivially equality comparable types is unsafe.");
 

--- a/libcxx/include/__cxx03/istream
+++ b/libcxx/include/__cxx03/istream
@@ -529,13 +529,13 @@ operator>>(basic_istream<_CharT, _Traits>& __is, _CharT (&__buf)[_Np]) {
 template <class _Traits, size_t _Np>
 inline _LIBCPP_HIDE_FROM_ABI basic_istream<char, _Traits>&
 operator>>(basic_istream<char, _Traits>& __is, unsigned char (&__buf)[_Np]) {
-  return __is >> (char(&)[_Np])__buf;
+  return __is >> (char (&)[_Np])__buf;
 }
 
 template <class _Traits, size_t _Np>
 inline _LIBCPP_HIDE_FROM_ABI basic_istream<char, _Traits>&
 operator>>(basic_istream<char, _Traits>& __is, signed char (&__buf)[_Np]) {
-  return __is >> (char(&)[_Np])__buf;
+  return __is >> (char (&)[_Np])__buf;
 }
 
 #else

--- a/libcxx/include/__cxx03/map
+++ b/libcxx/include/__cxx03/map
@@ -1471,9 +1471,8 @@ template <class _Key,
           class _Allocator = allocator<pair<const _Key, _Tp>>,
           class            = enable_if_t<!__is_allocator<_Compare>::value, void>,
           class            = enable_if_t<__is_allocator<_Allocator>::value, void>>
-map(initializer_list<pair<_Key, _Tp>>,
-    _Compare   = _Compare(),
-    _Allocator = _Allocator()) -> map<remove_const_t<_Key>, _Tp, _Compare, _Allocator>;
+map(initializer_list<pair<_Key, _Tp>>, _Compare = _Compare(), _Allocator = _Allocator())
+    -> map<remove_const_t<_Key>, _Tp, _Compare, _Allocator>;
 
 template <class _InputIterator,
           class _Allocator,
@@ -1492,8 +1491,8 @@ map(from_range_t, _Range&&, _Allocator)
 #  endif
 
 template <class _Key, class _Tp, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
-map(initializer_list<pair<_Key, _Tp>>,
-    _Allocator) -> map<remove_const_t<_Key>, _Tp, less<remove_const_t<_Key>>, _Allocator>;
+map(initializer_list<pair<_Key, _Tp>>, _Allocator)
+    -> map<remove_const_t<_Key>, _Tp, less<remove_const_t<_Key>>, _Allocator>;
 #endif
 
 #ifndef _LIBCPP_CXX03_LANG
@@ -2050,9 +2049,8 @@ template <class _Key,
           class _Allocator = allocator<pair<const _Key, _Tp>>,
           class            = enable_if_t<!__is_allocator<_Compare>::value, void>,
           class            = enable_if_t<__is_allocator<_Allocator>::value, void>>
-multimap(initializer_list<pair<_Key, _Tp>>,
-         _Compare   = _Compare(),
-         _Allocator = _Allocator()) -> multimap<remove_const_t<_Key>, _Tp, _Compare, _Allocator>;
+multimap(initializer_list<pair<_Key, _Tp>>, _Compare = _Compare(), _Allocator = _Allocator())
+    -> multimap<remove_const_t<_Key>, _Tp, _Compare, _Allocator>;
 
 template <class _InputIterator,
           class _Allocator,
@@ -2071,8 +2069,8 @@ multimap(from_range_t, _Range&&, _Allocator)
 #  endif
 
 template <class _Key, class _Tp, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
-multimap(initializer_list<pair<_Key, _Tp>>,
-         _Allocator) -> multimap<remove_const_t<_Key>, _Tp, less<remove_const_t<_Key>>, _Allocator>;
+multimap(initializer_list<pair<_Key, _Tp>>, _Allocator)
+    -> multimap<remove_const_t<_Key>, _Tp, less<remove_const_t<_Key>>, _Allocator>;
 #endif
 
 #ifndef _LIBCPP_CXX03_LANG

--- a/libcxx/include/__cxx03/queue
+++ b/libcxx/include/__cxx03/queue
@@ -449,14 +449,12 @@ template <class _InputIterator,
           class _Alloc,
           __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0,
           __enable_if_t<__is_allocator<_Alloc>::value, int>                        = 0>
-queue(_InputIterator,
-      _InputIterator,
-      _Alloc) -> queue<__iter_value_type<_InputIterator>, deque<__iter_value_type<_InputIterator>, _Alloc>>;
+queue(_InputIterator, _InputIterator, _Alloc)
+    -> queue<__iter_value_type<_InputIterator>, deque<__iter_value_type<_InputIterator>, _Alloc>>;
 
 template <ranges::input_range _Range, class _Alloc, __enable_if_t<__is_allocator<_Alloc>::value, int> = 0>
-queue(from_range_t,
-      _Range&&,
-      _Alloc) -> queue<ranges::range_value_t<_Range>, deque<ranges::range_value_t<_Range>, _Alloc>>;
+queue(from_range_t, _Range&&, _Alloc)
+    -> queue<ranges::range_value_t<_Range>, deque<ranges::range_value_t<_Range>, _Alloc>>;
 #endif
 
 template <class _Tp, class _Container>
@@ -939,8 +937,8 @@ swap(priority_queue<_Tp, _Container, _Compare>& __x, priority_queue<_Tp, _Contai
 }
 
 template <class _Tp, class _Container, class _Compare, class _Alloc>
-struct _LIBCPP_TEMPLATE_VIS uses_allocator<priority_queue<_Tp, _Container, _Compare>, _Alloc>
-    : public uses_allocator<_Container, _Alloc> {};
+struct _LIBCPP_TEMPLATE_VIS
+uses_allocator<priority_queue<_Tp, _Container, _Compare>, _Alloc> : public uses_allocator<_Container, _Alloc> {};
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__cxx03/regex
+++ b/libcxx/include/__cxx03/regex
@@ -2267,8 +2267,8 @@ typedef basic_regex<wchar_t> wregex;
 #endif
 
 template <class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(regex)
-    _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wregex)) basic_regex {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(regex) _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wregex))
+    basic_regex {
 public:
   // types:
   typedef _CharT value_type;

--- a/libcxx/include/__cxx03/set
+++ b/libcxx/include/__cxx03/set
@@ -922,15 +922,13 @@ template <class _InputIterator,
           class _Allocator,
           class = enable_if_t<__has_input_iterator_category<_InputIterator>::value, void>,
           class = enable_if_t<__is_allocator<_Allocator>::value, void>>
-set(_InputIterator,
-    _InputIterator,
-    _Allocator) -> set<__iter_value_type<_InputIterator>, less<__iter_value_type<_InputIterator>>, _Allocator>;
+set(_InputIterator, _InputIterator, _Allocator)
+    -> set<__iter_value_type<_InputIterator>, less<__iter_value_type<_InputIterator>>, _Allocator>;
 
 #  if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
-set(from_range_t,
-    _Range&&,
-    _Allocator) -> set<ranges::range_value_t<_Range>, less<ranges::range_value_t<_Range>>, _Allocator>;
+set(from_range_t, _Range&&, _Allocator)
+    -> set<ranges::range_value_t<_Range>, less<ranges::range_value_t<_Range>>, _Allocator>;
 #  endif
 
 template <class _Key, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
@@ -1373,9 +1371,8 @@ template <class _Key,
           class _Allocator = allocator<_Key>,
           class            = enable_if_t<__is_allocator<_Allocator>::value, void>,
           class            = enable_if_t<!__is_allocator<_Compare>::value, void>>
-multiset(initializer_list<_Key>,
-         _Compare   = _Compare(),
-         _Allocator = _Allocator()) -> multiset<_Key, _Compare, _Allocator>;
+multiset(initializer_list<_Key>, _Compare = _Compare(), _Allocator = _Allocator())
+    -> multiset<_Key, _Compare, _Allocator>;
 
 template <class _InputIterator,
           class _Allocator,
@@ -1386,9 +1383,8 @@ multiset(_InputIterator, _InputIterator, _Allocator)
 
 #  if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
-multiset(from_range_t,
-         _Range&&,
-         _Allocator) -> multiset<ranges::range_value_t<_Range>, less<ranges::range_value_t<_Range>>, _Allocator>;
+multiset(from_range_t, _Range&&, _Allocator)
+    -> multiset<ranges::range_value_t<_Range>, less<ranges::range_value_t<_Range>>, _Allocator>;
 #  endif
 
 template <class _Key, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>

--- a/libcxx/include/__cxx03/shared_mutex
+++ b/libcxx/include/__cxx03/shared_mutex
@@ -218,8 +218,8 @@ public:
 };
 #    endif
 
-class _LIBCPP_EXPORTED_FROM_ABI
-_LIBCPP_THREAD_SAFETY_ANNOTATION(__capability__("shared_timed_mutex")) shared_timed_mutex {
+class _LIBCPP_EXPORTED_FROM_ABI _LIBCPP_THREAD_SAFETY_ANNOTATION(__capability__("shared_timed_mutex"))
+shared_timed_mutex {
   __shared_mutex_base __base_;
 
 public:

--- a/libcxx/include/__cxx03/span
+++ b/libcxx/include/__cxx03/span
@@ -326,8 +326,8 @@ public:
   }
 
   template <size_t _Offset, size_t _Count = dynamic_extent>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto
-  subspan() const noexcept -> span<element_type, _Count != dynamic_extent ? _Count : _Extent - _Offset> {
+  _LIBCPP_HIDE_FROM_ABI constexpr auto subspan() const noexcept
+      -> span<element_type, _Count != dynamic_extent ? _Count : _Extent - _Offset> {
     static_assert(_Offset <= _Extent, "span<T, N>::subspan<Offset, Count>(): Offset out of range");
     static_assert(_Count == dynamic_extent || _Count <= _Extent - _Offset,
                   "span<T, N>::subspan<Offset, Count>(): Offset + Count out of range");

--- a/libcxx/include/__cxx03/stack
+++ b/libcxx/include/__cxx03/stack
@@ -304,14 +304,12 @@ template <class _InputIterator,
           class _Alloc,
           __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0,
           __enable_if_t<__is_allocator<_Alloc>::value, int>                        = 0>
-stack(_InputIterator,
-      _InputIterator,
-      _Alloc) -> stack<__iter_value_type<_InputIterator>, deque<__iter_value_type<_InputIterator>, _Alloc>>;
+stack(_InputIterator, _InputIterator, _Alloc)
+    -> stack<__iter_value_type<_InputIterator>, deque<__iter_value_type<_InputIterator>, _Alloc>>;
 
 template <ranges::input_range _Range, class _Alloc, __enable_if_t<__is_allocator<_Alloc>::value, int> = 0>
-stack(from_range_t,
-      _Range&&,
-      _Alloc) -> stack<ranges::range_value_t<_Range>, deque<ranges::range_value_t<_Range>, _Alloc>>;
+stack(from_range_t, _Range&&, _Alloc)
+    -> stack<ranges::range_value_t<_Range>, deque<ranges::range_value_t<_Range>, _Alloc>>;
 
 #endif
 

--- a/libcxx/include/__cxx03/string
+++ b/libcxx/include/__cxx03/string
@@ -2277,8 +2277,8 @@ template <class _CharT,
           class _Traits,
           class _Allocator = allocator<_CharT>,
           class            = enable_if_t<__is_allocator<_Allocator>::value> >
-explicit basic_string(basic_string_view<_CharT, _Traits>,
-                      const _Allocator& = _Allocator()) -> basic_string<_CharT, _Traits, _Allocator>;
+explicit basic_string(basic_string_view<_CharT, _Traits>, const _Allocator& = _Allocator())
+    -> basic_string<_CharT, _Traits, _Allocator>;
 
 template <class _CharT,
           class _Traits,

--- a/libcxx/include/__cxx03/tuple
+++ b/libcxx/include/__cxx03/tuple
@@ -455,8 +455,8 @@ template <class _Indx, class... _Tp>
 struct __tuple_impl;
 
 template <size_t... _Indx, class... _Tp>
-struct _LIBCPP_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp...>
-    : public __tuple_leaf<_Indx, _Tp>... {
+struct _LIBCPP_DECLSPEC_EMPTY_BASES
+    __tuple_impl<__tuple_indices<_Indx...>, _Tp...> : public __tuple_leaf<_Indx, _Tp>... {
   _LIBCPP_HIDE_FROM_ABI constexpr __tuple_impl() noexcept(
       __all<is_nothrow_default_constructible<_Tp>::value...>::value) {}
 

--- a/libcxx/include/__cxx03/unordered_map
+++ b/libcxx/include/__cxx03/unordered_map
@@ -2234,12 +2234,12 @@ template <class _Key,
           class            = enable_if_t<!is_integral<_Hash>::value>,
           class            = enable_if_t<!__is_allocator<_Pred>::value>,
           class            = enable_if_t<__is_allocator<_Allocator>::value>>
-unordered_multimap(
-    initializer_list<pair<_Key, _Tp>>,
-    typename allocator_traits<_Allocator>::size_type = 0,
-    _Hash                                            = _Hash(),
-    _Pred                                            = _Pred(),
-    _Allocator = _Allocator()) -> unordered_multimap<remove_const_t<_Key>, _Tp, _Hash, _Pred, _Allocator>;
+unordered_multimap(initializer_list<pair<_Key, _Tp>>,
+                   typename allocator_traits<_Allocator>::size_type = 0,
+                   _Hash                                            = _Hash(),
+                   _Pred                                            = _Pred(),
+                   _Allocator                                       = _Allocator())
+    -> unordered_multimap<remove_const_t<_Key>, _Tp, _Hash, _Pred, _Allocator>;
 
 template <class _InputIterator,
           class _Allocator,

--- a/libcxx/include/__cxx03/unordered_set
+++ b/libcxx/include/__cxx03/unordered_set
@@ -925,13 +925,13 @@ template <ranges::input_range _Range,
           class            = enable_if_t<!is_integral<_Hash>::value>,
           class            = enable_if_t<!__is_allocator<_Pred>::value>,
           class            = enable_if_t<__is_allocator<_Allocator>::value>>
-unordered_set(
-    from_range_t,
-    _Range&&,
-    typename allocator_traits<_Allocator>::size_type = 0,
-    _Hash                                            = _Hash(),
-    _Pred                                            = _Pred(),
-    _Allocator = _Allocator()) -> unordered_set<ranges::range_value_t<_Range>, _Hash, _Pred, _Allocator>; // C++23
+unordered_set(from_range_t,
+              _Range&&,
+              typename allocator_traits<_Allocator>::size_type = 0,
+              _Hash                                            = _Hash(),
+              _Pred                                            = _Pred(),
+              _Allocator                                       = _Allocator())
+    -> unordered_set<ranges::range_value_t<_Range>, _Hash, _Pred, _Allocator>; // C++23
 #  endif
 
 template <class _Tp,

--- a/libcxx/include/__cxx03/variant
+++ b/libcxx/include/__cxx03/variant
@@ -759,8 +759,8 @@ class _LIBCPP_TEMPLATE_VIS __dtor;
 
 #  define _LIBCPP_VARIANT_DESTRUCTOR(destructible_trait, destructor_definition, destroy)                               \
     template <class... _Types>                                                                                         \
-    class _LIBCPP_TEMPLATE_VIS __dtor<__traits<_Types...>, destructible_trait>                                         \
-        : public __base<destructible_trait, _Types...> {                                                               \
+    class _LIBCPP_TEMPLATE_VIS                                                                                         \
+    __dtor<__traits<_Types...>, destructible_trait> : public __base<destructible_trait, _Types...> {                   \
       using __base_type = __base<destructible_trait, _Types...>;                                                       \
       using __index_t   = typename __base_type::__index_t;                                                             \
                                                                                                                        \
@@ -837,8 +837,8 @@ class _LIBCPP_TEMPLATE_VIS __move_constructor;
 
 #  define _LIBCPP_VARIANT_MOVE_CONSTRUCTOR(move_constructible_trait, move_constructor_definition)                      \
     template <class... _Types>                                                                                         \
-    class _LIBCPP_TEMPLATE_VIS __move_constructor<__traits<_Types...>, move_constructible_trait>                       \
-        : public __ctor<__traits<_Types...>> {                                                                         \
+    class _LIBCPP_TEMPLATE_VIS                                                                                         \
+    __move_constructor<__traits<_Types...>, move_constructible_trait> : public __ctor<__traits<_Types...>> {           \
       using __base_type = __ctor<__traits<_Types...>>;                                                                 \
                                                                                                                        \
     public:                                                                                                            \
@@ -859,8 +859,7 @@ _LIBCPP_VARIANT_MOVE_CONSTRUCTOR(
 _LIBCPP_VARIANT_MOVE_CONSTRUCTOR(
     _Trait::_Available,
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __move_constructor(__move_constructor&& __that) noexcept(
-        __all<is_nothrow_move_constructible_v<_Types>...>::value)
-    : __move_constructor(__valueless_t{}) {
+        __all<is_nothrow_move_constructible_v<_Types>...>::value) : __move_constructor(__valueless_t{}) {
       this->__generic_construct(*this, std::move(__that));
     } _LIBCPP_EAT_SEMICOLON);
 
@@ -896,8 +895,9 @@ _LIBCPP_VARIANT_COPY_CONSTRUCTOR(
 
 _LIBCPP_VARIANT_COPY_CONSTRUCTOR(
     _Trait::_Available,
-    _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __copy_constructor(const __copy_constructor& __that)
-    : __copy_constructor(__valueless_t{}) { this->__generic_construct(*this, __that); } _LIBCPP_EAT_SEMICOLON);
+    _LIBCPP_HIDE_FROM_ABI
+    _LIBCPP_CONSTEXPR_SINCE_CXX20 __copy_constructor(const __copy_constructor& __that) : __copy_constructor(
+        __valueless_t{}) { this->__generic_construct(*this, __that); } _LIBCPP_EAT_SEMICOLON);
 
 _LIBCPP_VARIANT_COPY_CONSTRUCTOR(
     _Trait::_Unavailable,
@@ -964,8 +964,8 @@ class _LIBCPP_TEMPLATE_VIS __move_assignment;
 
 #  define _LIBCPP_VARIANT_MOVE_ASSIGNMENT(move_assignable_trait, move_assignment_definition)                           \
     template <class... _Types>                                                                                         \
-    class _LIBCPP_TEMPLATE_VIS __move_assignment<__traits<_Types...>, move_assignable_trait>                           \
-        : public __assignment<__traits<_Types...>> {                                                                   \
+    class _LIBCPP_TEMPLATE_VIS                                                                                         \
+    __move_assignment<__traits<_Types...>, move_assignable_trait> : public __assignment<__traits<_Types...>> {         \
       using __base_type = __assignment<__traits<_Types...>>;                                                           \
                                                                                                                        \
     public:                                                                                                            \
@@ -1003,8 +1003,8 @@ class _LIBCPP_TEMPLATE_VIS __copy_assignment;
 
 #  define _LIBCPP_VARIANT_COPY_ASSIGNMENT(copy_assignable_trait, copy_assignment_definition)                           \
     template <class... _Types>                                                                                         \
-    class _LIBCPP_TEMPLATE_VIS __copy_assignment<__traits<_Types...>, copy_assignable_trait>                           \
-        : public __move_assignment<__traits<_Types...>> {                                                              \
+    class _LIBCPP_TEMPLATE_VIS                                                                                         \
+    __copy_assignment<__traits<_Types...>, copy_assignable_trait> : public __move_assignment<__traits<_Types...>> {    \
       using __base_type = __move_assignment<__traits<_Types...>>;                                                      \
                                                                                                                        \
     public:                                                                                                            \
@@ -1588,8 +1588,8 @@ visit(_Visitor&& __visitor, _Vs&&... __vs) {
 
 template <class... _Types>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 auto
-swap(variant<_Types...>& __lhs,
-     variant<_Types...>& __rhs) noexcept(noexcept(__lhs.swap(__rhs))) -> decltype(__lhs.swap(__rhs)) {
+swap(variant<_Types...>& __lhs, variant<_Types...>& __rhs) noexcept(noexcept(__lhs.swap(__rhs)))
+    -> decltype(__lhs.swap(__rhs)) {
   return __lhs.swap(__rhs);
 }
 

--- a/libcxx/include/__cxx03/vector
+++ b/libcxx/include/__cxx03/vector
@@ -2894,8 +2894,8 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 size_t vector<bool, _Allocator>::__hash_code() con
 }
 
 template <class _Allocator>
-struct _LIBCPP_TEMPLATE_VIS hash<vector<bool, _Allocator> >
-    : public __unary_function<vector<bool, _Allocator>, size_t> {
+struct _LIBCPP_TEMPLATE_VIS
+hash<vector<bool, _Allocator> > : public __unary_function<vector<bool, _Allocator>, size_t> {
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 size_t
   operator()(const vector<bool, _Allocator>& __vec) const _NOEXCEPT {
     return __vec.__hash_code();

--- a/libcxx/include/__format/container_adaptor.h
+++ b/libcxx/include/__format/container_adaptor.h
@@ -55,16 +55,16 @@ public:
 };
 
 template <class _CharT, class _Tp, formattable<_CharT> _Container>
-struct _LIBCPP_TEMPLATE_VIS formatter<queue<_Tp, _Container>, _CharT>
-    : public __formatter_container_adaptor<queue<_Tp, _Container>, _CharT> {};
+struct _LIBCPP_TEMPLATE_VIS
+formatter<queue<_Tp, _Container>, _CharT> : public __formatter_container_adaptor<queue<_Tp, _Container>, _CharT> {};
 
 template <class _CharT, class _Tp, class _Container, class _Compare>
 struct _LIBCPP_TEMPLATE_VIS formatter<priority_queue<_Tp, _Container, _Compare>, _CharT>
     : public __formatter_container_adaptor<priority_queue<_Tp, _Container, _Compare>, _CharT> {};
 
 template <class _CharT, class _Tp, formattable<_CharT> _Container>
-struct _LIBCPP_TEMPLATE_VIS formatter<stack<_Tp, _Container>, _CharT>
-    : public __formatter_container_adaptor<stack<_Tp, _Container>, _CharT> {};
+struct _LIBCPP_TEMPLATE_VIS
+formatter<stack<_Tp, _Container>, _CharT> : public __formatter_container_adaptor<stack<_Tp, _Container>, _CharT> {};
 
 #endif // _LIBCPP_STD_VER >= 23
 

--- a/libcxx/include/__format/formatter_output.h
+++ b/libcxx/include/__format/formatter_output.h
@@ -101,8 +101,8 @@ __padding_size(size_t __size, size_t __width, __format_spec::__alignment __align
 ///
 /// This uses a "mass output function" of __format::__output_buffer when possible.
 template <__fmt_char_type _CharT, __fmt_char_type _OutCharT = _CharT>
-_LIBCPP_HIDE_FROM_ABI auto
-__copy(basic_string_view<_CharT> __str, output_iterator<const _OutCharT&> auto __out_it) -> decltype(__out_it) {
+_LIBCPP_HIDE_FROM_ABI auto __copy(basic_string_view<_CharT> __str, output_iterator<const _OutCharT&> auto __out_it)
+    -> decltype(__out_it) {
   if constexpr (std::same_as<decltype(__out_it), std::back_insert_iterator<__format::__output_buffer<_OutCharT>>>) {
     __out_it.__get_container()->__copy(__str);
     return __out_it;
@@ -117,16 +117,16 @@ __copy(basic_string_view<_CharT> __str, output_iterator<const _OutCharT&> auto _
 template <contiguous_iterator _Iterator,
           __fmt_char_type _CharT    = typename iterator_traits<_Iterator>::value_type,
           __fmt_char_type _OutCharT = _CharT>
-_LIBCPP_HIDE_FROM_ABI auto
-__copy(_Iterator __first, _Iterator __last, output_iterator<const _OutCharT&> auto __out_it) -> decltype(__out_it) {
+_LIBCPP_HIDE_FROM_ABI auto __copy(_Iterator __first, _Iterator __last, output_iterator<const _OutCharT&> auto __out_it)
+    -> decltype(__out_it) {
   return __formatter::__copy(basic_string_view{__first, __last}, std::move(__out_it));
 }
 
 template <contiguous_iterator _Iterator,
           __fmt_char_type _CharT    = typename iterator_traits<_Iterator>::value_type,
           __fmt_char_type _OutCharT = _CharT>
-_LIBCPP_HIDE_FROM_ABI auto
-__copy(_Iterator __first, size_t __n, output_iterator<const _OutCharT&> auto __out_it) -> decltype(__out_it) {
+_LIBCPP_HIDE_FROM_ABI auto __copy(_Iterator __first, size_t __n, output_iterator<const _OutCharT&> auto __out_it)
+    -> decltype(__out_it) {
   return __formatter::__copy(basic_string_view{std::to_address(__first), __n}, std::move(__out_it));
 }
 
@@ -137,11 +137,9 @@ template <contiguous_iterator _Iterator,
           __fmt_char_type _CharT    = typename iterator_traits<_Iterator>::value_type,
           __fmt_char_type _OutCharT = _CharT,
           class _UnaryOperation>
-_LIBCPP_HIDE_FROM_ABI auto
-__transform(_Iterator __first,
-            _Iterator __last,
-            output_iterator<const _OutCharT&> auto __out_it,
-            _UnaryOperation __operation) -> decltype(__out_it) {
+_LIBCPP_HIDE_FROM_ABI auto __transform(
+    _Iterator __first, _Iterator __last, output_iterator<const _OutCharT&> auto __out_it, _UnaryOperation __operation)
+    -> decltype(__out_it) {
   if constexpr (std::same_as<decltype(__out_it), std::back_insert_iterator<__format::__output_buffer<_OutCharT>>>) {
     __out_it.__get_container()->__transform(__first, __last, std::move(__operation));
     return __out_it;

--- a/libcxx/include/__format/formatter_string.h
+++ b/libcxx/include/__format/formatter_string.h
@@ -100,8 +100,8 @@ struct _LIBCPP_TEMPLATE_VIS formatter<_CharT[_Size], _CharT> : public __formatte
 
 // Formatter std::string.
 template <__fmt_char_type _CharT, class _Traits, class _Allocator>
-struct _LIBCPP_TEMPLATE_VIS formatter<basic_string<_CharT, _Traits, _Allocator>, _CharT>
-    : public __formatter_string<_CharT> {
+struct _LIBCPP_TEMPLATE_VIS
+formatter<basic_string<_CharT, _Traits, _Allocator>, _CharT> : public __formatter_string<_CharT> {
   using _Base _LIBCPP_NODEBUG = __formatter_string<_CharT>;
 
   template <class _FormatContext>

--- a/libcxx/include/__format/formatter_tuple.h
+++ b/libcxx/include/__format/formatter_tuple.h
@@ -136,12 +136,12 @@ private:
 };
 
 template <__fmt_char_type _CharT, formattable<_CharT>... _Args>
-struct _LIBCPP_TEMPLATE_VIS formatter<pair<_Args...>, _CharT>
-    : public __formatter_tuple<_CharT, pair<_Args...>, _Args...> {};
+struct _LIBCPP_TEMPLATE_VIS
+formatter<pair<_Args...>, _CharT> : public __formatter_tuple<_CharT, pair<_Args...>, _Args...> {};
 
 template <__fmt_char_type _CharT, formattable<_CharT>... _Args>
-struct _LIBCPP_TEMPLATE_VIS formatter<tuple<_Args...>, _CharT>
-    : public __formatter_tuple<_CharT, tuple<_Args...>, _Args...> {};
+struct _LIBCPP_TEMPLATE_VIS
+formatter<tuple<_Args...>, _CharT> : public __formatter_tuple<_CharT, tuple<_Args...>, _Args...> {};
 
 #endif // _LIBCPP_STD_VER >= 23
 

--- a/libcxx/include/__functional/bind_back.h
+++ b/libcxx/include/__functional/bind_back.h
@@ -52,7 +52,7 @@ struct __bind_back_t : __perfect_forward<__bind_back_op<tuple_size_v<_BoundArgs>
 
 template <class _Fn, class... _Args>
   requires is_constructible_v<decay_t<_Fn>, _Fn> && is_move_constructible_v<decay_t<_Fn>> &&
-               (is_constructible_v<decay_t<_Args>, _Args> && ...) && (is_move_constructible_v<decay_t<_Args>> && ...)
+           (is_constructible_v<decay_t<_Args>, _Args> && ...) && (is_move_constructible_v<decay_t<_Args>> && ...)
 _LIBCPP_HIDE_FROM_ABI constexpr auto __bind_back(_Fn&& __f, _Args&&... __args) noexcept(
     noexcept(__bind_back_t<decay_t<_Fn>, tuple<decay_t<_Args>...>>(
         std::forward<_Fn>(__f), std::forward_as_tuple(std::forward<_Args>(__args)...))))

--- a/libcxx/include/__functional/bind_front.h
+++ b/libcxx/include/__functional/bind_front.h
@@ -29,8 +29,9 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 struct __bind_front_op {
   template <class... _Args>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Args&&... __args) const noexcept(
-      noexcept(std::invoke(std::forward<_Args>(__args)...))) -> decltype(std::invoke(std::forward<_Args>(__args)...)) {
+  _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Args&&... __args) const
+      noexcept(noexcept(std::invoke(std::forward<_Args>(__args)...)))
+          -> decltype(std::invoke(std::forward<_Args>(__args)...)) {
     return std::invoke(std::forward<_Args>(__args)...);
   }
 };

--- a/libcxx/include/__functional/binder1st.h
+++ b/libcxx/include/__functional/binder1st.h
@@ -22,8 +22,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_BINDERS)
 
 template <class _Operation>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 binder1st
-    : public __unary_function<typename _Operation::second_argument_type, typename _Operation::result_type> {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11
+binder1st : public __unary_function<typename _Operation::second_argument_type, typename _Operation::result_type> {
 protected:
   _Operation op;
   typename _Operation::first_argument_type value;

--- a/libcxx/include/__functional/binder2nd.h
+++ b/libcxx/include/__functional/binder2nd.h
@@ -22,8 +22,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_BINDERS)
 
 template <class _Operation>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 binder2nd
-    : public __unary_function<typename _Operation::first_argument_type, typename _Operation::result_type> {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11
+binder2nd : public __unary_function<typename _Operation::first_argument_type, typename _Operation::result_type> {
 protected:
   _Operation op;
   typename _Operation::second_argument_type value;

--- a/libcxx/include/__functional/function.h
+++ b/libcxx/include/__functional/function.h
@@ -113,7 +113,7 @@ _LIBCPP_HIDE_FROM_ABI bool __not_null(_Fp* __ptr) {
 }
 
 template <class _Ret, class _Class>
-_LIBCPP_HIDE_FROM_ABI bool __not_null(_Ret _Class::*__ptr) {
+_LIBCPP_HIDE_FROM_ABI bool __not_null(_Ret _Class::* __ptr) {
   return __ptr;
 }
 
@@ -498,7 +498,7 @@ template <typename _Fun>
 struct __use_small_storage
     : public integral_constant<
           bool,
-          sizeof(_Fun) <= sizeof(__policy_storage)&& _LIBCPP_ALIGNOF(_Fun) <= _LIBCPP_ALIGNOF(__policy_storage) &&
+          sizeof(_Fun) <= sizeof(__policy_storage) && _LIBCPP_ALIGNOF(_Fun) <= _LIBCPP_ALIGNOF(__policy_storage) &&
               is_trivially_copy_constructible<_Fun>::value && is_trivially_destructible<_Fun>::value> {};
 
 // Policy contains information about how to copy, destroy, and move the

--- a/libcxx/include/__functional/mem_fn.h
+++ b/libcxx/include/__functional/mem_fn.h
@@ -43,7 +43,7 @@ public:
 };
 
 template <class _Rp, class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __mem_fn<_Rp _Tp::*> mem_fn(_Rp _Tp::*__pm) _NOEXCEPT {
+inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __mem_fn<_Rp _Tp::*> mem_fn(_Rp _Tp::* __pm) _NOEXCEPT {
   return __mem_fn<_Rp _Tp::*>(__pm);
 }
 

--- a/libcxx/include/__functional/mem_fun_ref.h
+++ b/libcxx/include/__functional/mem_fun_ref.h
@@ -89,8 +89,8 @@ public:
 };
 
 template <class _Sp, class _Tp, class _Ap>
-class _LIBCPP_TEMPLATE_VIS
-_LIBCPP_DEPRECATED_IN_CXX11 const_mem_fun1_t : public __binary_function<const _Tp*, _Ap, _Sp> {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11
+const_mem_fun1_t : public __binary_function<const _Tp*, _Ap, _Sp> {
   _Sp (_Tp::*__p_)(_Ap) const;
 
 public:

--- a/libcxx/include/__functional/operations.h
+++ b/libcxx/include/__functional/operations.h
@@ -208,8 +208,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS bit_and<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) &
-                        std::forward<_T2>(__u))) -> decltype(std::forward<_T1>(__t) & std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) & std::forward<_T2>(__u)))
+          -> decltype(std::forward<_T1>(__t) & std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) & std::forward<_T2>(__u);
   }
   typedef void is_transparent;
@@ -428,8 +428,8 @@ template <>
 struct _LIBCPP_TEMPLATE_VIS greater_equal<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
-      noexcept(noexcept(std::forward<_T1>(__t) >=
-                        std::forward<_T2>(__u))) -> decltype(std::forward<_T1>(__t) >= std::forward<_T2>(__u)) {
+      noexcept(noexcept(std::forward<_T1>(__t) >= std::forward<_T2>(__u)))
+          -> decltype(std::forward<_T1>(__t) >= std::forward<_T2>(__u)) {
     return std::forward<_T1>(__t) >= std::forward<_T2>(__u);
   }
   typedef void is_transparent;

--- a/libcxx/include/__functional/pointer_to_binary_function.h
+++ b/libcxx/include/__functional/pointer_to_binary_function.h
@@ -22,8 +22,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_BINDERS)
 
 template <class _Arg1, class _Arg2, class _Result>
-class _LIBCPP_TEMPLATE_VIS
-_LIBCPP_DEPRECATED_IN_CXX11 pointer_to_binary_function : public __binary_function<_Arg1, _Arg2, _Result> {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11
+pointer_to_binary_function : public __binary_function<_Arg1, _Arg2, _Result> {
   _Result (*__f_)(_Arg1, _Arg2);
 
 public:

--- a/libcxx/include/__functional/pointer_to_unary_function.h
+++ b/libcxx/include/__functional/pointer_to_unary_function.h
@@ -22,8 +22,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_BINDERS)
 
 template <class _Arg, class _Result>
-class _LIBCPP_TEMPLATE_VIS
-_LIBCPP_DEPRECATED_IN_CXX11 pointer_to_unary_function : public __unary_function<_Arg, _Result> {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11
+pointer_to_unary_function : public __unary_function<_Arg, _Result> {
   _Result (*__f_)(_Arg);
 
 public:

--- a/libcxx/include/__functional/unary_negate.h
+++ b/libcxx/include/__functional/unary_negate.h
@@ -22,8 +22,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_NEGATORS)
 
 template <class _Predicate>
-class _LIBCPP_TEMPLATE_VIS
-_LIBCPP_DEPRECATED_IN_CXX17 unary_negate : public __unary_function<typename _Predicate::argument_type, bool> {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17
+unary_negate : public __unary_function<typename _Predicate::argument_type, bool> {
   _Predicate __pred_;
 
 public:

--- a/libcxx/include/__iterator/access.h
+++ b/libcxx/include/__iterator/access.h
@@ -54,8 +54,8 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 auto end(const _Cp& __c) -> 
 #  if _LIBCPP_STD_VER >= 14
 
 template <class _Cp>
-_LIBCPP_HIDE_FROM_ABI constexpr auto
-cbegin(const _Cp& __c) noexcept(noexcept(std::begin(__c))) -> decltype(std::begin(__c)) {
+_LIBCPP_HIDE_FROM_ABI constexpr auto cbegin(const _Cp& __c) noexcept(noexcept(std::begin(__c)))
+    -> decltype(std::begin(__c)) {
   return std::begin(__c);
 }
 

--- a/libcxx/include/__iterator/concepts.h
+++ b/libcxx/include/__iterator/concepts.h
@@ -97,10 +97,10 @@ using iter_common_reference_t = common_reference_t<iter_reference_t<_Tp>, __indi
 // [iterator.concept.writable]
 template <class _Out, class _Tp>
 concept indirectly_writable = requires(_Out&& __o, _Tp&& __t) {
-  *__o                                             = std::forward<_Tp>(__t); // not required to be equality-preserving
-  *std::forward<_Out>(__o)                         = std::forward<_Tp>(__t); // not required to be equality-preserving
-  const_cast<const iter_reference_t<_Out>&&>(*__o) = std::forward<_Tp>(__t); // not required to be equality-preserving
-  const_cast<const iter_reference_t<_Out>&&>(*std::forward<_Out>(__o)) =
+  *__o                                              = std::forward<_Tp>(__t); // not required to be equality-preserving
+  *std::forward<_Out>(__o)                          = std::forward<_Tp>(__t); // not required to be equality-preserving
+  const_cast<const iter_reference_t<_Out> &&>(*__o) = std::forward<_Tp>(__t); // not required to be equality-preserving
+  const_cast<const iter_reference_t<_Out> &&>(*std::forward<_Out>(__o)) =
       std::forward<_Tp>(__t); // not required to be equality-preserving
 };
 

--- a/libcxx/include/__iterator/empty.h
+++ b/libcxx/include/__iterator/empty.h
@@ -22,8 +22,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 17
 
 template <class _Cont>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto
-empty(const _Cont& __c) noexcept(noexcept(__c.empty())) -> decltype(__c.empty()) {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto empty(const _Cont& __c) noexcept(noexcept(__c.empty()))
+    -> decltype(__c.empty()) {
   return __c.empty();
 }
 

--- a/libcxx/include/__iterator/move_iterator.h
+++ b/libcxx/include/__iterator/move_iterator.h
@@ -291,8 +291,8 @@ operator>=(const move_iterator<_Iter1>& __x, const move_iterator<_Iter2>& __y) {
 #if _LIBCPP_STD_VER >= 20
 template <class _Iter1, three_way_comparable_with<_Iter1> _Iter2>
 inline _LIBCPP_HIDE_FROM_ABI constexpr auto
-operator<=>(const move_iterator<_Iter1>& __x,
-            const move_iterator<_Iter2>& __y) -> compare_three_way_result_t<_Iter1, _Iter2> {
+operator<=>(const move_iterator<_Iter1>& __x, const move_iterator<_Iter2>& __y)
+    -> compare_three_way_result_t<_Iter1, _Iter2> {
   return __x.base() <=> __y.base();
 }
 #endif // _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__iterator/reverse_iterator.h
+++ b/libcxx/include/__iterator/reverse_iterator.h
@@ -286,8 +286,8 @@ operator<=>(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>&
 #ifndef _LIBCPP_CXX03_LANG
 template <class _Iter1, class _Iter2>
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 auto
-operator-(const reverse_iterator<_Iter1>& __x,
-          const reverse_iterator<_Iter2>& __y) -> decltype(__y.base() - __x.base()) {
+operator-(const reverse_iterator<_Iter1>& __x, const reverse_iterator<_Iter2>& __y)
+    -> decltype(__y.base() - __x.base()) {
   return __y.base() - __x.base();
 }
 #else

--- a/libcxx/include/__iterator/size.h
+++ b/libcxx/include/__iterator/size.h
@@ -36,9 +36,9 @@ _LIBCPP_HIDE_FROM_ABI constexpr size_t size(const _Tp (&)[_Sz]) noexcept {
 
 #  if _LIBCPP_STD_VER >= 20
 template <class _Cont>
-_LIBCPP_HIDE_FROM_ABI constexpr auto
-ssize(const _Cont& __c) noexcept(noexcept(static_cast<common_type_t<ptrdiff_t, make_signed_t<decltype(__c.size())>>>(
-    __c.size()))) -> common_type_t<ptrdiff_t, make_signed_t<decltype(__c.size())>> {
+_LIBCPP_HIDE_FROM_ABI constexpr auto ssize(const _Cont& __c) noexcept(
+    noexcept(static_cast<common_type_t<ptrdiff_t, make_signed_t<decltype(__c.size())>>>(__c.size())))
+    -> common_type_t<ptrdiff_t, make_signed_t<decltype(__c.size())>> {
   return static_cast<common_type_t<ptrdiff_t, make_signed_t<decltype(__c.size())>>>(__c.size());
 }
 

--- a/libcxx/include/__mdspan/mdspan.h
+++ b/libcxx/include/__mdspan/mdspan.h
@@ -267,13 +267,13 @@ private:
 #  if _LIBCPP_STD_VER >= 26
 template <class _ElementType, class... _OtherIndexTypes>
   requires((is_convertible_v<_OtherIndexTypes, size_t> && ...) && (sizeof...(_OtherIndexTypes) > 0))
-explicit mdspan(_ElementType*,
-                _OtherIndexTypes...) -> mdspan<_ElementType, extents<size_t, __maybe_static_ext<_OtherIndexTypes>...>>;
+explicit mdspan(_ElementType*, _OtherIndexTypes...)
+    -> mdspan<_ElementType, extents<size_t, __maybe_static_ext<_OtherIndexTypes>...>>;
 #  else
 template <class _ElementType, class... _OtherIndexTypes>
   requires((is_convertible_v<_OtherIndexTypes, size_t> && ...) && (sizeof...(_OtherIndexTypes) > 0))
-explicit mdspan(_ElementType*,
-                _OtherIndexTypes...) -> mdspan<_ElementType, dextents<size_t, sizeof...(_OtherIndexTypes)>>;
+explicit mdspan(_ElementType*, _OtherIndexTypes...)
+    -> mdspan<_ElementType, dextents<size_t, sizeof...(_OtherIndexTypes)>>;
 #  endif
 
 template <class _Pointer>

--- a/libcxx/include/__memory/pointer_traits.h
+++ b/libcxx/include/__memory/pointer_traits.h
@@ -245,8 +245,8 @@ inline _LIBCPP_HIDE_FROM_ABI constexpr auto to_address(_Tp* __p) noexcept {
 }
 
 template <class _Pointer>
-inline _LIBCPP_HIDE_FROM_ABI constexpr auto
-to_address(const _Pointer& __p) noexcept -> decltype(std::__to_address(__p)) {
+inline _LIBCPP_HIDE_FROM_ABI constexpr auto to_address(const _Pointer& __p) noexcept
+    -> decltype(std::__to_address(__p)) {
   return std::__to_address(__p);
 }
 #endif

--- a/libcxx/include/__ranges/access.h
+++ b/libcxx/include/__ranges/access.h
@@ -191,8 +191,9 @@ struct __fn {
 
   template <class _Tp>
     requires is_rvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(
-      noexcept(ranges::end(static_cast<const _Tp&&>(__t)))) -> decltype(ranges::end(static_cast<const _Tp&&>(__t))) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+      noexcept(noexcept(ranges::end(static_cast<const _Tp&&>(__t))))
+          -> decltype(ranges::end(static_cast<const _Tp&&>(__t))) {
     return ranges::end(static_cast<const _Tp&&>(__t));
   }
 };

--- a/libcxx/include/__ranges/all.h
+++ b/libcxx/include/__ranges/all.h
@@ -39,8 +39,9 @@ namespace __all {
 struct __fn : __range_adaptor_closure<__fn> {
   template <class _Tp>
     requires ranges::view<decay_t<_Tp>>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(
-      noexcept(_LIBCPP_AUTO_CAST(std::forward<_Tp>(__t)))) -> decltype(_LIBCPP_AUTO_CAST(std::forward<_Tp>(__t))) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+      noexcept(noexcept(_LIBCPP_AUTO_CAST(std::forward<_Tp>(__t))))
+          -> decltype(_LIBCPP_AUTO_CAST(std::forward<_Tp>(__t))) {
     return _LIBCPP_AUTO_CAST(std::forward<_Tp>(__t));
   }
 

--- a/libcxx/include/__ranges/common_view.h
+++ b/libcxx/include/__ranges/common_view.h
@@ -114,14 +114,16 @@ namespace __common {
 struct __fn : __range_adaptor_closure<__fn> {
   template <class _Range>
     requires common_range<_Range>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const noexcept(
-      noexcept(views::all(std::forward<_Range>(__range)))) -> decltype(views::all(std::forward<_Range>(__range))) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const
+      noexcept(noexcept(views::all(std::forward<_Range>(__range))))
+          -> decltype(views::all(std::forward<_Range>(__range))) {
     return views::all(std::forward<_Range>(__range));
   }
 
   template <class _Range>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const noexcept(noexcept(common_view{
-      std::forward<_Range>(__range)})) -> decltype(common_view{std::forward<_Range>(__range)}) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const
+      noexcept(noexcept(common_view{std::forward<_Range>(__range)}))
+          -> decltype(common_view{std::forward<_Range>(__range)}) {
     return common_view{std::forward<_Range>(__range)};
   }
 };

--- a/libcxx/include/__ranges/counted.h
+++ b/libcxx/include/__ranges/counted.h
@@ -51,8 +51,9 @@ struct __fn {
   }
 
   template <random_access_iterator _It>
-  _LIBCPP_HIDE_FROM_ABI static constexpr auto __go(_It __it, iter_difference_t<_It> __count) noexcept(
-      noexcept(subrange(__it, __it + __count))) -> decltype(subrange(__it, __it + __count)) {
+  _LIBCPP_HIDE_FROM_ABI static constexpr auto
+  __go(_It __it, iter_difference_t<_It> __count) noexcept(noexcept(subrange(__it, __it + __count)))
+      -> decltype(subrange(__it, __it + __count)) {
     return subrange(__it, __it + __count);
   }
 

--- a/libcxx/include/__ranges/data.h
+++ b/libcxx/include/__ranges/data.h
@@ -83,8 +83,9 @@ struct __fn {
 
   template <class _Tp>
     requires is_rvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(
-      noexcept(ranges::data(static_cast<const _Tp&&>(__t)))) -> decltype(ranges::data(static_cast<const _Tp&&>(__t))) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+      noexcept(noexcept(ranges::data(static_cast<const _Tp&&>(__t))))
+          -> decltype(ranges::data(static_cast<const _Tp&&>(__t))) {
     return ranges::data(static_cast<const _Tp&&>(__t));
   }
 };

--- a/libcxx/include/__ranges/drop_view.h
+++ b/libcxx/include/__ranges/drop_view.h
@@ -289,14 +289,14 @@ struct __fn {
   template <class _Range, convertible_to<range_difference_t<_Range>> _Np, class _RawRange = remove_cvref_t<_Range>>
   // Note: without specifically excluding the other cases, GCC sees this overload as ambiguous with the other
   // overloads.
-    requires(!(__is_empty_view<_RawRange> ||
+    requires(
+        !(__is_empty_view<_RawRange> ||
 #  if _LIBCPP_STD_VER >= 23
-               __is_repeat_specialization<_RawRange> ||
+          __is_repeat_specialization<_RawRange> ||
 #  endif
-               (__is_subrange_specialization_with_store_size<_RawRange> && sized_range<_RawRange> &&
-                random_access_range<_RawRange>) ||
-               (__is_passthrough_specialization<_RawRange> && sized_range<_RawRange> &&
-                random_access_range<_RawRange>)))
+          (__is_subrange_specialization_with_store_size<_RawRange> && sized_range<_RawRange> &&
+           random_access_range<_RawRange>) ||
+          (__is_passthrough_specialization<_RawRange> && sized_range<_RawRange> && random_access_range<_RawRange>)))
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range, _Np&& __n) const
       noexcept(noexcept(drop_view(std::forward<_Range>(__range), std::forward<_Np>(__n))))
           -> decltype(drop_view(std::forward<_Range>(__range), std::forward<_Np>(__n))) {

--- a/libcxx/include/__ranges/lazy_split_view.h
+++ b/libcxx/include/__ranges/lazy_split_view.h
@@ -104,7 +104,7 @@ public:
 
   _LIBCPP_HIDE_FROM_ABI constexpr auto begin() {
     if constexpr (forward_range<_View>) {
-      return __outer_iterator < __simple_view<_View> && __simple_view < _Pattern >> {*this, ranges::begin(__base_)};
+      return __outer_iterator< __simple_view<_View> && __simple_view< _Pattern >>{*this, ranges::begin(__base_)};
     } else {
       __current_.__emplace(ranges::begin(__base_));
       return __outer_iterator<false>{*this};
@@ -120,7 +120,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI constexpr auto end()
     requires forward_range<_View> && common_range<_View>
   {
-    return __outer_iterator < __simple_view<_View> && __simple_view < _Pattern >> {*this, ranges::end(__base_)};
+    return __outer_iterator< __simple_view<_View> && __simple_view< _Pattern >>{*this, ranges::end(__base_)};
   }
 
   _LIBCPP_HIDE_FROM_ABI constexpr auto end() const {
@@ -404,8 +404,8 @@ template <class _Range, class _Pattern>
 lazy_split_view(_Range&&, _Pattern&&) -> lazy_split_view<views::all_t<_Range>, views::all_t<_Pattern>>;
 
 template <input_range _Range>
-lazy_split_view(_Range&&,
-                range_value_t<_Range>) -> lazy_split_view<views::all_t<_Range>, single_view<range_value_t<_Range>>>;
+lazy_split_view(_Range&&, range_value_t<_Range>)
+    -> lazy_split_view<views::all_t<_Range>, single_view<range_value_t<_Range>>>;
 
 namespace views {
 namespace __lazy_split_view {

--- a/libcxx/include/__ranges/rend.h
+++ b/libcxx/include/__ranges/rend.h
@@ -104,8 +104,9 @@ struct __fn {
 
   template <class _Tp>
     requires is_rvalue_reference_v<_Tp&&>
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const noexcept(
-      noexcept(ranges::rend(static_cast<const _Tp&&>(__t)))) -> decltype(ranges::rend(static_cast<const _Tp&&>(__t))) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Tp&& __t) const
+      noexcept(noexcept(ranges::rend(static_cast<const _Tp&&>(__t))))
+          -> decltype(ranges::rend(static_cast<const _Tp&&>(__t))) {
     return ranges::rend(static_cast<const _Tp&&>(__t));
   }
 };

--- a/libcxx/include/__ranges/reverse_view.h
+++ b/libcxx/include/__ranges/reverse_view.h
@@ -182,8 +182,9 @@ struct __fn : __range_adaptor_closure<__fn> {
   template <class _Range>
     requires(!__is_reverse_view<remove_cvref_t<_Range>> && !__is_sized_reverse_subrange<remove_cvref_t<_Range>> &&
              !__is_unsized_reverse_subrange<remove_cvref_t<_Range>>)
-  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const noexcept(noexcept(reverse_view{
-      std::forward<_Range>(__range)})) -> decltype(reverse_view{std::forward<_Range>(__range)}) {
+  [[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto operator()(_Range&& __range) const
+      noexcept(noexcept(reverse_view{std::forward<_Range>(__range)}))
+          -> decltype(reverse_view{std::forward<_Range>(__range)}) {
     return reverse_view{std::forward<_Range>(__range)};
   }
 };

--- a/libcxx/include/__ranges/subrange.h
+++ b/libcxx/include/__ranges/subrange.h
@@ -201,11 +201,12 @@ template <input_or_output_iterator _Iter, sentinel_for<_Iter> _Sent>
 subrange(_Iter, _Sent, make_unsigned_t<iter_difference_t<_Iter>>) -> subrange<_Iter, _Sent, subrange_kind::sized>;
 
 template <borrowed_range _Range>
-subrange(_Range&&) -> subrange<iterator_t<_Range>,
-                               sentinel_t<_Range>,
-                               (sized_range<_Range> || sized_sentinel_for<sentinel_t<_Range>, iterator_t<_Range>>)
-                                   ? subrange_kind::sized
-                                   : subrange_kind::unsized>;
+subrange(_Range&&)
+    -> subrange<iterator_t<_Range>,
+                sentinel_t<_Range>,
+                (sized_range<_Range> || sized_sentinel_for<sentinel_t<_Range>, iterator_t<_Range>>)
+                    ? subrange_kind::sized
+                    : subrange_kind::unsized>;
 
 template <borrowed_range _Range>
 subrange(_Range&&, make_unsigned_t<range_difference_t<_Range>>)

--- a/libcxx/include/__string/char_traits.h
+++ b/libcxx/include/__string/char_traits.h
@@ -260,8 +260,8 @@ struct _LIBCPP_TEMPLATE_VIS char_traits<wchar_t> : __char_traits_base<wchar_t, w
 #if _LIBCPP_HAS_CHAR8_T
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS char_traits<char8_t>
-    : __char_traits_base<char8_t, unsigned int, static_cast<unsigned int>(EOF)> {
+struct _LIBCPP_TEMPLATE_VIS
+char_traits<char8_t> : __char_traits_base<char8_t, unsigned int, static_cast<unsigned int>(EOF)> {
   static _LIBCPP_HIDE_FROM_ABI constexpr int
   compare(const char_type* __s1, const char_type* __s2, size_t __n) noexcept {
     return std::__constexpr_memcmp(__s1, __s2, __element_count(__n));
@@ -280,8 +280,8 @@ struct _LIBCPP_TEMPLATE_VIS char_traits<char8_t>
 #endif // _LIBCPP_HAS_CHAR8_T
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS char_traits<char16_t>
-    : __char_traits_base<char16_t, uint_least16_t, static_cast<uint_least16_t>(0xFFFF)> {
+struct _LIBCPP_TEMPLATE_VIS
+char_traits<char16_t> : __char_traits_base<char16_t, uint_least16_t, static_cast<uint_least16_t>(0xFFFF)> {
   _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX17 int
   compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT;
   _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX17 size_t length(const char_type* __s) _NOEXCEPT;
@@ -315,8 +315,8 @@ inline _LIBCPP_CONSTEXPR_SINCE_CXX17 size_t char_traits<char16_t>::length(const 
 }
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS char_traits<char32_t>
-    : __char_traits_base<char32_t, uint_least32_t, static_cast<uint_least32_t>(0xFFFFFFFF)> {
+struct _LIBCPP_TEMPLATE_VIS
+char_traits<char32_t> : __char_traits_base<char32_t, uint_least32_t, static_cast<uint_least32_t>(0xFFFFFFFF)> {
   _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX17 int
   compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT;
   _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX17 size_t length(const char_type* __s) _NOEXCEPT;

--- a/libcxx/include/__thread/support/c11.h
+++ b/libcxx/include/__thread/support/c11.h
@@ -31,7 +31,8 @@ using __libcpp_timespec_t = ::timespec;
 typedef mtx_t __libcpp_mutex_t;
 // mtx_t is a struct so using {} for initialization is valid.
 #define _LIBCPP_MUTEX_INITIALIZER                                                                                      \
-  {}
+  {                                                                                                                    \
+  }
 
 typedef mtx_t __libcpp_recursive_mutex_t;
 
@@ -82,7 +83,8 @@ inline _LIBCPP_HIDE_FROM_ABI int __libcpp_mutex_destroy(__libcpp_mutex_t* __m) {
 typedef cnd_t __libcpp_condvar_t;
 // cnd_t is a struct so using {} for initialization is valid.
 #define _LIBCPP_CONDVAR_INITIALIZER                                                                                    \
-  {}
+  {                                                                                                                    \
+  }
 
 inline _LIBCPP_HIDE_FROM_ABI int __libcpp_condvar_signal(__libcpp_condvar_t* __cv) {
   return cnd_signal(__cv) == thrd_success ? 0 : EINVAL;

--- a/libcxx/include/__tuple/sfinae_helpers.h
+++ b/libcxx/include/__tuple/sfinae_helpers.h
@@ -35,8 +35,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 struct __tuple_sfinae_base {
   template <template <class, class...> class _Trait, class... _LArgs, class... _RArgs>
-  static auto __do_test(__tuple_types<_LArgs...>,
-                        __tuple_types<_RArgs...>) -> __all<__enable_if_t<_Trait<_LArgs, _RArgs>::value, bool>{true}...>;
+  static auto __do_test(__tuple_types<_LArgs...>, __tuple_types<_RArgs...>)
+      -> __all<__enable_if_t<_Trait<_LArgs, _RArgs>::value, bool>{true}...>;
   template <template <class...> class>
   static auto __do_test(...) -> false_type;
 

--- a/libcxx/include/__tuple/tuple_size.h
+++ b/libcxx/include/__tuple/tuple_size.h
@@ -32,15 +32,17 @@ template <class _Tp, class...>
 using __enable_if_tuple_size_imp _LIBCPP_NODEBUG = _Tp;
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS tuple_size<__enable_if_tuple_size_imp< const _Tp,
-                                                                   __enable_if_t<!is_volatile<_Tp>::value>,
-                                                                   integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
+struct _LIBCPP_TEMPLATE_VIS
+tuple_size<__enable_if_tuple_size_imp< const _Tp,
+                                       __enable_if_t<!is_volatile<_Tp>::value>,
+                                       integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
     : public integral_constant<size_t, tuple_size<_Tp>::value> {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS tuple_size<__enable_if_tuple_size_imp< volatile _Tp,
-                                                                   __enable_if_t<!is_const<_Tp>::value>,
-                                                                   integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
+struct _LIBCPP_TEMPLATE_VIS
+tuple_size<__enable_if_tuple_size_imp< volatile _Tp,
+                                       __enable_if_t<!is_const<_Tp>::value>,
+                                       integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
     : public integral_constant<size_t, tuple_size<_Tp>::value> {};
 
 template <class _Tp>

--- a/libcxx/include/__type_traits/common_type.h
+++ b/libcxx/include/__type_traits/common_type.h
@@ -103,8 +103,8 @@ struct _LIBCPP_TEMPLATE_VIS common_type<_Tp, _Up>
 // bullet 4 - sizeof...(Tp) > 2
 
 template <class _Tp, class _Up, class _Vp, class... _Rest>
-struct _LIBCPP_TEMPLATE_VIS common_type<_Tp, _Up, _Vp, _Rest...>
-    : __common_type_impl<__common_types<_Tp, _Up, _Vp, _Rest...> > {};
+struct _LIBCPP_TEMPLATE_VIS
+common_type<_Tp, _Up, _Vp, _Rest...> : __common_type_impl<__common_types<_Tp, _Up, _Vp, _Rest...> > {};
 
 #endif
 

--- a/libcxx/include/__type_traits/enable_if.h
+++ b/libcxx/include/__type_traits/enable_if.h
@@ -18,7 +18,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <bool, class _Tp = void>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS enable_if{};
+struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS enable_if {};
 
 _LIBCPP_DIAGNOSTIC_PUSH
 #if __has_warning("-Winvalid-specialization")

--- a/libcxx/include/__type_traits/is_nothrow_destructible.h
+++ b/libcxx/include/__type_traits/is_nothrow_destructible.h
@@ -40,8 +40,8 @@ struct __libcpp_is_nothrow_destructible<true, _Tp>
     : public integral_constant<bool, noexcept(std::declval<_Tp>().~_Tp()) > {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_nothrow_destructible
-    : public __libcpp_is_nothrow_destructible<is_destructible<_Tp>::value, _Tp> {};
+struct _LIBCPP_TEMPLATE_VIS
+is_nothrow_destructible : public __libcpp_is_nothrow_destructible<is_destructible<_Tp>::value, _Tp> {};
 
 template <class _Tp, size_t _Ns>
 struct _LIBCPP_TEMPLATE_VIS is_nothrow_destructible<_Tp[_Ns]> : public is_nothrow_destructible<_Tp> {};

--- a/libcxx/include/__type_traits/is_pointer.h
+++ b/libcxx/include/__type_traits/is_pointer.h
@@ -50,8 +50,8 @@ template <class _Tp> struct __libcpp_remove_objc_qualifiers<_Tp __unsafe_unretai
 #  endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_pointer
-    : public __libcpp_is_pointer<typename __libcpp_remove_objc_qualifiers<__remove_cv_t<_Tp> >::type> {};
+struct _LIBCPP_TEMPLATE_VIS
+is_pointer : public __libcpp_is_pointer<typename __libcpp_remove_objc_qualifiers<__remove_cv_t<_Tp> >::type> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/result_of.h
+++ b/libcxx/include/__type_traits/result_of.h
@@ -25,9 +25,9 @@ template <class _Callable>
 struct _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_NO_SPECIALIZATIONS result_of;
 
 _LIBCPP_DIAGNOSTIC_PUSH
-#if __has_warning("-Winvalid-specialization")
+#  if __has_warning("-Winvalid-specialization")
 _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Winvalid-specialization")
-#endif
+#  endif
 template <class _Fp, class... _Args>
 struct _LIBCPP_TEMPLATE_VIS result_of<_Fp(_Args...)> : __invoke_result<_Fp, _Args...> {};
 _LIBCPP_DIAGNOSTIC_POP

--- a/libcxx/include/__utility/forward_like.h
+++ b/libcxx/include/__utility/forward_like.h
@@ -35,8 +35,8 @@ template <class _Ap, class _Bp>
 using _ForwardLike _LIBCPP_NODEBUG = _OverrideRef<_Ap&&, _CopyConst<remove_reference_t<_Ap>, remove_reference_t<_Bp>>>;
 
 template <class _Tp, class _Up>
-[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto
-forward_like(_LIBCPP_LIFETIMEBOUND _Up&& __ux) noexcept -> _ForwardLike<_Tp, _Up> {
+[[nodiscard]] _LIBCPP_HIDE_FROM_ABI constexpr auto forward_like(_LIBCPP_LIFETIMEBOUND _Up&& __ux) noexcept
+    -> _ForwardLike<_Tp, _Up> {
   return static_cast<_ForwardLike<_Tp, _Up>>(__ux);
 }
 

--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -1109,8 +1109,8 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 size_t vector<bool, _Allocator>::__hash_code() con
 }
 
 template <class _Allocator>
-struct _LIBCPP_TEMPLATE_VIS hash<vector<bool, _Allocator> >
-    : public __unary_function<vector<bool, _Allocator>, size_t> {
+struct _LIBCPP_TEMPLATE_VIS
+hash<vector<bool, _Allocator> > : public __unary_function<vector<bool, _Allocator>, size_t> {
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 size_t
   operator()(const vector<bool, _Allocator>& __vec) const _NOEXCEPT {
     return __vec.__hash_code();

--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -606,8 +606,8 @@ template <size_t _Size>
 struct hash<bitset<_Size> >;
 
 template <size_t _Size>
-class _LIBCPP_TEMPLATE_VIS bitset
-    : private __bitset<_Size == 0 ? 0 : (_Size - 1) / (sizeof(size_t) * CHAR_BIT) + 1, _Size> {
+class _LIBCPP_TEMPLATE_VIS
+bitset : private __bitset<_Size == 0 ? 0 : (_Size - 1) / (sizeof(size_t) * CHAR_BIT) + 1, _Size> {
 public:
   static const unsigned __n_words = _Size == 0 ? 0 : (_Size - 1) / (sizeof(size_t) * CHAR_BIT) + 1;
   typedef __bitset<__n_words, _Size> __base;

--- a/libcxx/include/codecvt
+++ b/libcxx/include/codecvt
@@ -439,8 +439,8 @@ protected:
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _Elem, unsigned long _Maxcode = 0x10ffff, codecvt_mode _Mode = (codecvt_mode)0>
-class _LIBCPP_TEMPLATE_VIS
-_LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf16 : public __codecvt_utf16<_Elem, _Mode & little_endian> {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17
+codecvt_utf16 : public __codecvt_utf16<_Elem, _Mode & little_endian> {
 public:
   _LIBCPP_HIDE_FROM_ABI explicit codecvt_utf16(size_t __refs = 0)
       : __codecvt_utf16<_Elem, _Mode & little_endian>(__refs, _Maxcode, _Mode) {}

--- a/libcxx/include/condition_variable
+++ b/libcxx/include/condition_variable
@@ -195,12 +195,16 @@ public:
 inline condition_variable_any::condition_variable_any() : __mut_(make_shared<mutex>()) {}
 
 inline void condition_variable_any::notify_one() _NOEXCEPT {
-  { lock_guard<mutex> __lx(*__mut_); }
+  {
+    lock_guard<mutex> __lx(*__mut_);
+  }
   __cv_.notify_one();
 }
 
 inline void condition_variable_any::notify_all() _NOEXCEPT {
-  { lock_guard<mutex> __lx(*__mut_); }
+  {
+    lock_guard<mutex> __lx(*__mut_);
+  }
   __cv_.notify_all();
 }
 

--- a/libcxx/include/cwchar
+++ b/libcxx/include/cwchar
@@ -231,7 +231,7 @@ __constexpr_wmemcmp(const wchar_t* __lhs, const wchar_t* __rhs, size_t __count) 
 
 template <class _Tp, class _Up>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp* __constexpr_wmemchr(_Tp* __str, _Up __value, size_t __count) {
-  static_assert(sizeof(_Tp) == sizeof(wchar_t)&& _LIBCPP_ALIGNOF(_Tp) >= _LIBCPP_ALIGNOF(wchar_t) &&
+  static_assert(sizeof(_Tp) == sizeof(wchar_t) && _LIBCPP_ALIGNOF(_Tp) >= _LIBCPP_ALIGNOF(wchar_t) &&
                     __libcpp_is_trivially_equality_comparable<_Tp, _Tp>::value,
                 "Calling wmemchr on non-trivially equality comparable types is unsafe.");
 

--- a/libcxx/include/istream
+++ b/libcxx/include/istream
@@ -536,13 +536,13 @@ operator>>(basic_istream<_CharT, _Traits>& __is, _CharT (&__buf)[_Np]) {
 template <class _Traits, size_t _Np>
 inline _LIBCPP_HIDE_FROM_ABI basic_istream<char, _Traits>&
 operator>>(basic_istream<char, _Traits>& __is, unsigned char (&__buf)[_Np]) {
-  return __is >> (char(&)[_Np])__buf;
+  return __is >> (char (&)[_Np])__buf;
 }
 
 template <class _Traits, size_t _Np>
 inline _LIBCPP_HIDE_FROM_ABI basic_istream<char, _Traits>&
 operator>>(basic_istream<char, _Traits>& __is, signed char (&__buf)[_Np]) {
-  return __is >> (char(&)[_Np])__buf;
+  return __is >> (char (&)[_Np])__buf;
 }
 
 #    else

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -3114,7 +3114,9 @@ public:
   }
   _LIBCPP_HIDE_FROM_ABI wide_string from_bytes(const char* __first, const char* __last);
 
-  _LIBCPP_HIDE_FROM_ABI byte_string to_bytes(_Elem __wchar) { return to_bytes(std::addressof(__wchar), std::addressof(__wchar) + 1); }
+  _LIBCPP_HIDE_FROM_ABI byte_string to_bytes(_Elem __wchar) {
+    return to_bytes(std::addressof(__wchar), std::addressof(__wchar) + 1);
+  }
   _LIBCPP_HIDE_FROM_ABI byte_string to_bytes(const _Elem* __wptr) {
     return to_bytes(__wptr, __wptr + char_traits<_Elem>::length(__wptr));
   }

--- a/libcxx/include/map
+++ b/libcxx/include/map
@@ -1479,9 +1479,8 @@ template <class _Key,
           class _Allocator = allocator<pair<const _Key, _Tp>>,
           class            = enable_if_t<!__is_allocator<_Compare>::value, void>,
           class            = enable_if_t<__is_allocator<_Allocator>::value, void>>
-map(initializer_list<pair<_Key, _Tp>>,
-    _Compare   = _Compare(),
-    _Allocator = _Allocator()) -> map<remove_const_t<_Key>, _Tp, _Compare, _Allocator>;
+map(initializer_list<pair<_Key, _Tp>>, _Compare = _Compare(), _Allocator = _Allocator())
+    -> map<remove_const_t<_Key>, _Tp, _Compare, _Allocator>;
 
 template <class _InputIterator,
           class _Allocator,
@@ -1500,8 +1499,8 @@ map(from_range_t, _Range&&, _Allocator)
 #    endif
 
 template <class _Key, class _Tp, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
-map(initializer_list<pair<_Key, _Tp>>,
-    _Allocator) -> map<remove_const_t<_Key>, _Tp, less<remove_const_t<_Key>>, _Allocator>;
+map(initializer_list<pair<_Key, _Tp>>, _Allocator)
+    -> map<remove_const_t<_Key>, _Tp, less<remove_const_t<_Key>>, _Allocator>;
 #  endif
 
 #  ifndef _LIBCPP_CXX03_LANG
@@ -2068,9 +2067,8 @@ template <class _Key,
           class _Allocator = allocator<pair<const _Key, _Tp>>,
           class            = enable_if_t<!__is_allocator<_Compare>::value, void>,
           class            = enable_if_t<__is_allocator<_Allocator>::value, void>>
-multimap(initializer_list<pair<_Key, _Tp>>,
-         _Compare   = _Compare(),
-         _Allocator = _Allocator()) -> multimap<remove_const_t<_Key>, _Tp, _Compare, _Allocator>;
+multimap(initializer_list<pair<_Key, _Tp>>, _Compare = _Compare(), _Allocator = _Allocator())
+    -> multimap<remove_const_t<_Key>, _Tp, _Compare, _Allocator>;
 
 template <class _InputIterator,
           class _Allocator,
@@ -2089,8 +2087,8 @@ multimap(from_range_t, _Range&&, _Allocator)
 #    endif
 
 template <class _Key, class _Tp, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
-multimap(initializer_list<pair<_Key, _Tp>>,
-         _Allocator) -> multimap<remove_const_t<_Key>, _Tp, less<remove_const_t<_Key>>, _Allocator>;
+multimap(initializer_list<pair<_Key, _Tp>>, _Allocator)
+    -> multimap<remove_const_t<_Key>, _Tp, less<remove_const_t<_Key>>, _Allocator>;
 #  endif
 
 #  ifndef _LIBCPP_CXX03_LANG

--- a/libcxx/include/queue
+++ b/libcxx/include/queue
@@ -452,14 +452,12 @@ template <class _InputIterator,
           class _Alloc,
           __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0,
           __enable_if_t<__is_allocator<_Alloc>::value, int>                        = 0>
-queue(_InputIterator,
-      _InputIterator,
-      _Alloc) -> queue<__iter_value_type<_InputIterator>, deque<__iter_value_type<_InputIterator>, _Alloc>>;
+queue(_InputIterator, _InputIterator, _Alloc)
+    -> queue<__iter_value_type<_InputIterator>, deque<__iter_value_type<_InputIterator>, _Alloc>>;
 
 template <ranges::input_range _Range, class _Alloc, __enable_if_t<__is_allocator<_Alloc>::value, int> = 0>
-queue(from_range_t,
-      _Range&&,
-      _Alloc) -> queue<ranges::range_value_t<_Range>, deque<ranges::range_value_t<_Range>, _Alloc>>;
+queue(from_range_t, _Range&&, _Alloc)
+    -> queue<ranges::range_value_t<_Range>, deque<ranges::range_value_t<_Range>, _Alloc>>;
 #  endif
 
 template <class _Tp, class _Container>
@@ -942,8 +940,8 @@ swap(priority_queue<_Tp, _Container, _Compare>& __x, priority_queue<_Tp, _Contai
 }
 
 template <class _Tp, class _Container, class _Compare, class _Alloc>
-struct _LIBCPP_TEMPLATE_VIS uses_allocator<priority_queue<_Tp, _Container, _Compare>, _Alloc>
-    : public uses_allocator<_Container, _Alloc> {};
+struct _LIBCPP_TEMPLATE_VIS
+uses_allocator<priority_queue<_Tp, _Container, _Compare>, _Alloc> : public uses_allocator<_Container, _Alloc> {};
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -2177,7 +2177,8 @@ void __bracket_expression<_CharT, _Traits>::__exec(__state& __s) const {
             }
           }
           if (!__equivalences_.empty()) {
-            string_type __s2 = __traits_.transform_primary(std::addressof(__ch2.first), std::addressof(__ch2.first) + 2);
+            string_type __s2 =
+                __traits_.transform_primary(std::addressof(__ch2.first), std::addressof(__ch2.first) + 2);
             for (size_t __i = 0; __i < __equivalences_.size(); ++__i) {
               if (__s2 == __equivalences_[__i]) {
                 __found = true;
@@ -2225,7 +2226,8 @@ void __bracket_expression<_CharT, _Traits>::__exec(__state& __s) const {
       }
     }
     if (!__ranges_.empty()) {
-      string_type __s2 = __collate_ ? __traits_.transform(std::addressof(__ch), std::addressof(__ch) + 1) : string_type(1, __ch);
+      string_type __s2 =
+          __collate_ ? __traits_.transform(std::addressof(__ch), std::addressof(__ch) + 1) : string_type(1, __ch);
       for (size_t __i = 0; __i < __ranges_.size(); ++__i) {
         if (__ranges_[__i].first <= __s2 && __s2 <= __ranges_[__i].second) {
           __found = true;
@@ -2271,8 +2273,8 @@ typedef basic_regex<wchar_t> wregex;
 #  endif
 
 template <class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(regex)
-    _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wregex)) basic_regex {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(regex) _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wregex))
+    basic_regex {
 public:
   // types:
   typedef _CharT value_type;
@@ -5678,7 +5680,8 @@ template <class _BidirectionalIterator, class _CharT, class _Traits>
 bool regex_token_iterator<_BidirectionalIterator, _CharT, _Traits>::operator==(const regex_token_iterator& __x) const {
   if (__result_ == nullptr && __x.__result_ == nullptr)
     return true;
-  if (__result_ == std::addressof(__suffix_) && __x.__result_ == std::addressof(__x.__suffix_) && __suffix_ == __x.__suffix_)
+  if (__result_ == std::addressof(__suffix_) && __x.__result_ == std::addressof(__x.__suffix_) &&
+      __suffix_ == __x.__suffix_)
     return true;
   if (__result_ == nullptr || __x.__result_ == nullptr)
     return false;

--- a/libcxx/include/set
+++ b/libcxx/include/set
@@ -933,15 +933,13 @@ template <class _InputIterator,
           class _Allocator,
           class = enable_if_t<__has_input_iterator_category<_InputIterator>::value, void>,
           class = enable_if_t<__is_allocator<_Allocator>::value, void>>
-set(_InputIterator,
-    _InputIterator,
-    _Allocator) -> set<__iter_value_type<_InputIterator>, less<__iter_value_type<_InputIterator>>, _Allocator>;
+set(_InputIterator, _InputIterator, _Allocator)
+    -> set<__iter_value_type<_InputIterator>, less<__iter_value_type<_InputIterator>>, _Allocator>;
 
 #    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
-set(from_range_t,
-    _Range&&,
-    _Allocator) -> set<ranges::range_value_t<_Range>, less<ranges::range_value_t<_Range>>, _Allocator>;
+set(from_range_t, _Range&&, _Allocator)
+    -> set<ranges::range_value_t<_Range>, less<ranges::range_value_t<_Range>>, _Allocator>;
 #    endif
 
 template <class _Key, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
@@ -1394,9 +1392,8 @@ template <class _Key,
           class _Allocator = allocator<_Key>,
           class            = enable_if_t<__is_allocator<_Allocator>::value, void>,
           class            = enable_if_t<!__is_allocator<_Compare>::value, void>>
-multiset(initializer_list<_Key>,
-         _Compare   = _Compare(),
-         _Allocator = _Allocator()) -> multiset<_Key, _Compare, _Allocator>;
+multiset(initializer_list<_Key>, _Compare = _Compare(), _Allocator = _Allocator())
+    -> multiset<_Key, _Compare, _Allocator>;
 
 template <class _InputIterator,
           class _Allocator,
@@ -1407,9 +1404,8 @@ multiset(_InputIterator, _InputIterator, _Allocator)
 
 #    if _LIBCPP_STD_VER >= 23
 template <ranges::input_range _Range, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>
-multiset(from_range_t,
-         _Range&&,
-         _Allocator) -> multiset<ranges::range_value_t<_Range>, less<ranges::range_value_t<_Range>>, _Allocator>;
+multiset(from_range_t, _Range&&, _Allocator)
+    -> multiset<ranges::range_value_t<_Range>, less<ranges::range_value_t<_Range>>, _Allocator>;
 #    endif
 
 template <class _Key, class _Allocator, class = enable_if_t<__is_allocator<_Allocator>::value, void>>

--- a/libcxx/include/shared_mutex
+++ b/libcxx/include/shared_mutex
@@ -221,8 +221,8 @@ public:
 };
 #      endif
 
-class _LIBCPP_EXPORTED_FROM_ABI
-_LIBCPP_THREAD_SAFETY_ANNOTATION(__capability__("shared_timed_mutex")) shared_timed_mutex {
+class _LIBCPP_EXPORTED_FROM_ABI _LIBCPP_THREAD_SAFETY_ANNOTATION(__capability__("shared_timed_mutex"))
+shared_timed_mutex {
   __shared_mutex_base __base_;
 
 public:

--- a/libcxx/include/span
+++ b/libcxx/include/span
@@ -332,8 +332,8 @@ public:
   }
 
   template <size_t _Offset, size_t _Count = dynamic_extent>
-  _LIBCPP_HIDE_FROM_ABI constexpr auto
-  subspan() const noexcept -> span<element_type, _Count != dynamic_extent ? _Count : _Extent - _Offset> {
+  _LIBCPP_HIDE_FROM_ABI constexpr auto subspan() const noexcept
+      -> span<element_type, _Count != dynamic_extent ? _Count : _Extent - _Offset> {
     static_assert(_Offset <= _Extent, "span<T, N>::subspan<Offset, Count>(): Offset out of range");
     static_assert(_Count == dynamic_extent || _Count <= _Extent - _Offset,
                   "span<T, N>::subspan<Offset, Count>(): Offset + Count out of range");

--- a/libcxx/include/stack
+++ b/libcxx/include/stack
@@ -307,14 +307,12 @@ template <class _InputIterator,
           class _Alloc,
           __enable_if_t<__has_input_iterator_category<_InputIterator>::value, int> = 0,
           __enable_if_t<__is_allocator<_Alloc>::value, int>                        = 0>
-stack(_InputIterator,
-      _InputIterator,
-      _Alloc) -> stack<__iter_value_type<_InputIterator>, deque<__iter_value_type<_InputIterator>, _Alloc>>;
+stack(_InputIterator, _InputIterator, _Alloc)
+    -> stack<__iter_value_type<_InputIterator>, deque<__iter_value_type<_InputIterator>, _Alloc>>;
 
 template <ranges::input_range _Range, class _Alloc, __enable_if_t<__is_allocator<_Alloc>::value, int> = 0>
-stack(from_range_t,
-      _Range&&,
-      _Alloc) -> stack<ranges::range_value_t<_Range>, deque<ranges::range_value_t<_Range>, _Alloc>>;
+stack(from_range_t, _Range&&, _Alloc)
+    -> stack<ranges::range_value_t<_Range>, deque<ranges::range_value_t<_Range>, _Alloc>>;
 
 #  endif
 

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -462,8 +462,8 @@ template <class _Indx, class... _Tp>
 struct __tuple_impl;
 
 template <size_t... _Indx, class... _Tp>
-struct _LIBCPP_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp...>
-    : public __tuple_leaf<_Indx, _Tp>... {
+struct _LIBCPP_DECLSPEC_EMPTY_BASES
+    __tuple_impl<__tuple_indices<_Indx...>, _Tp...> : public __tuple_leaf<_Indx, _Tp>... {
   _LIBCPP_HIDE_FROM_ABI constexpr __tuple_impl() noexcept(
       __all<is_nothrow_default_constructible<_Tp>::value...>::value) {}
 

--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -2258,12 +2258,12 @@ template <class _Key,
           class            = enable_if_t<!is_integral<_Hash>::value>,
           class            = enable_if_t<!__is_allocator<_Pred>::value>,
           class            = enable_if_t<__is_allocator<_Allocator>::value>>
-unordered_multimap(
-    initializer_list<pair<_Key, _Tp>>,
-    typename allocator_traits<_Allocator>::size_type = 0,
-    _Hash                                            = _Hash(),
-    _Pred                                            = _Pred(),
-    _Allocator = _Allocator()) -> unordered_multimap<remove_const_t<_Key>, _Tp, _Hash, _Pred, _Allocator>;
+unordered_multimap(initializer_list<pair<_Key, _Tp>>,
+                   typename allocator_traits<_Allocator>::size_type = 0,
+                   _Hash                                            = _Hash(),
+                   _Pred                                            = _Pred(),
+                   _Allocator                                       = _Allocator())
+    -> unordered_multimap<remove_const_t<_Key>, _Tp, _Hash, _Pred, _Allocator>;
 
 template <class _InputIterator,
           class _Allocator,

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -941,13 +941,13 @@ template <ranges::input_range _Range,
           class            = enable_if_t<!is_integral<_Hash>::value>,
           class            = enable_if_t<!__is_allocator<_Pred>::value>,
           class            = enable_if_t<__is_allocator<_Allocator>::value>>
-unordered_set(
-    from_range_t,
-    _Range&&,
-    typename allocator_traits<_Allocator>::size_type = 0,
-    _Hash                                            = _Hash(),
-    _Pred                                            = _Pred(),
-    _Allocator = _Allocator()) -> unordered_set<ranges::range_value_t<_Range>, _Hash, _Pred, _Allocator>; // C++23
+unordered_set(from_range_t,
+              _Range&&,
+              typename allocator_traits<_Allocator>::size_type = 0,
+              _Hash                                            = _Hash(),
+              _Pred                                            = _Pred(),
+              _Allocator                                       = _Allocator())
+    -> unordered_set<ranges::range_value_t<_Range>, _Hash, _Pred, _Allocator>; // C++23
 #    endif
 
 template <class _Tp,

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -752,8 +752,8 @@ class _LIBCPP_TEMPLATE_VIS __dtor;
 
 #    define _LIBCPP_VARIANT_DESTRUCTOR(destructible_trait, destructor_definition, destroy)                             \
       template <class... _Types>                                                                                       \
-      class _LIBCPP_TEMPLATE_VIS __dtor<__traits<_Types...>, destructible_trait>                                       \
-          : public __base<destructible_trait, _Types...> {                                                             \
+      class _LIBCPP_TEMPLATE_VIS                                                                                       \
+      __dtor<__traits<_Types...>, destructible_trait> : public __base<destructible_trait, _Types...> {                 \
         using __base_type _LIBCPP_NODEBUG = __base<destructible_trait, _Types...>;                                     \
         using __index_t _LIBCPP_NODEBUG   = typename __base_type::__index_t;                                           \
                                                                                                                        \
@@ -830,8 +830,8 @@ class _LIBCPP_TEMPLATE_VIS __move_constructor;
 
 #    define _LIBCPP_VARIANT_MOVE_CONSTRUCTOR(move_constructible_trait, move_constructor_definition)                    \
       template <class... _Types>                                                                                       \
-      class _LIBCPP_TEMPLATE_VIS __move_constructor<__traits<_Types...>, move_constructible_trait>                     \
-          : public __ctor<__traits<_Types...>> {                                                                       \
+      class _LIBCPP_TEMPLATE_VIS                                                                                       \
+      __move_constructor<__traits<_Types...>, move_constructible_trait> : public __ctor<__traits<_Types...>> {         \
         using __base_type _LIBCPP_NODEBUG = __ctor<__traits<_Types...>>;                                               \
                                                                                                                        \
       public:                                                                                                          \
@@ -852,8 +852,7 @@ _LIBCPP_VARIANT_MOVE_CONSTRUCTOR(
 _LIBCPP_VARIANT_MOVE_CONSTRUCTOR(
     _Trait::_Available,
     _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __move_constructor(__move_constructor&& __that) noexcept(
-        __all<is_nothrow_move_constructible_v<_Types>...>::value)
-    : __move_constructor(__valueless_t{}) {
+        __all<is_nothrow_move_constructible_v<_Types>...>::value) : __move_constructor(__valueless_t{}) {
       this->__generic_construct(*this, std::move(__that));
     } _LIBCPP_EAT_SEMICOLON);
 
@@ -889,8 +888,9 @@ _LIBCPP_VARIANT_COPY_CONSTRUCTOR(
 
 _LIBCPP_VARIANT_COPY_CONSTRUCTOR(
     _Trait::_Available,
-    _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __copy_constructor(const __copy_constructor& __that)
-    : __copy_constructor(__valueless_t{}) { this->__generic_construct(*this, __that); } _LIBCPP_EAT_SEMICOLON);
+    _LIBCPP_HIDE_FROM_ABI
+    _LIBCPP_CONSTEXPR_SINCE_CXX20 __copy_constructor(const __copy_constructor& __that) : __copy_constructor(
+        __valueless_t{}) { this->__generic_construct(*this, __that); } _LIBCPP_EAT_SEMICOLON);
 
 _LIBCPP_VARIANT_COPY_CONSTRUCTOR(
     _Trait::_Unavailable,
@@ -957,8 +957,8 @@ class _LIBCPP_TEMPLATE_VIS __move_assignment;
 
 #    define _LIBCPP_VARIANT_MOVE_ASSIGNMENT(move_assignable_trait, move_assignment_definition)                         \
       template <class... _Types>                                                                                       \
-      class _LIBCPP_TEMPLATE_VIS __move_assignment<__traits<_Types...>, move_assignable_trait>                         \
-          : public __assignment<__traits<_Types...>> {                                                                 \
+      class _LIBCPP_TEMPLATE_VIS                                                                                       \
+      __move_assignment<__traits<_Types...>, move_assignable_trait> : public __assignment<__traits<_Types...>> {       \
         using __base_type _LIBCPP_NODEBUG = __assignment<__traits<_Types...>>;                                         \
                                                                                                                        \
       public:                                                                                                          \
@@ -996,8 +996,8 @@ class _LIBCPP_TEMPLATE_VIS __copy_assignment;
 
 #    define _LIBCPP_VARIANT_COPY_ASSIGNMENT(copy_assignable_trait, copy_assignment_definition)                         \
       template <class... _Types>                                                                                       \
-      class _LIBCPP_TEMPLATE_VIS __copy_assignment<__traits<_Types...>, copy_assignable_trait>                         \
-          : public __move_assignment<__traits<_Types...>> {                                                            \
+      class _LIBCPP_TEMPLATE_VIS                                                                                       \
+      __copy_assignment<__traits<_Types...>, copy_assignable_trait> : public __move_assignment<__traits<_Types...>> {  \
         using __base_type _LIBCPP_NODEBUG = __move_assignment<__traits<_Types...>>;                                    \
                                                                                                                        \
       public:                                                                                                          \
@@ -1579,8 +1579,8 @@ visit(_Visitor&& __visitor, _Vs&&... __vs) {
 
 template <class... _Types>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 auto
-swap(variant<_Types...>& __lhs,
-     variant<_Types...>& __rhs) noexcept(noexcept(__lhs.swap(__rhs))) -> decltype(__lhs.swap(__rhs)) {
+swap(variant<_Types...>& __lhs, variant<_Types...>& __rhs) noexcept(noexcept(__lhs.swap(__rhs)))
+    -> decltype(__lhs.swap(__rhs)) {
   return __lhs.swap(__rhs);
 }
 


### PR DESCRIPTION
This is a small re-adjustment of libcxx/include with the current version of clang-format we use in the CI.