### PR TITLE
[flang] Expose -m64 option

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4678,7 +4678,7 @@ def mqdsp6_compat : Flag<["-"], "mqdsp6-compat">, Group<m_Group>,
   HelpText<"Enable hexagon-qdsp6 backward compatibility">,
   MarshallingInfoFlag<LangOpts<"HexagonQdsp6Compat">>;
 def m64 : Flag<["-"], "m64">, Group<m_Group>, Flags<[NoXarchOption]>,
-  Visibility<[ClangOption, CLOption, DXCOption]>;
+  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>;
 def maix64 : Flag<["-"], "maix64">, Group<m_Group>, Flags<[NoXarchOption]>;
 def mx32 : Flag<["-"], "mx32">, Group<m_Group>, Flags<[NoXarchOption]>,
   Visibility<[ClangOption, CLOption, DXCOption]>;

--- a/flang/test/Driver/m64-option.f90
+++ b/flang/test/Driver/m64-option.f90
@@ -1,0 +1,7 @@
+! Check support of -m64.
+! RUN: %flang -target i386-pc-win32 -m64 -### - %s 2>&1 | FileCheck -check-prefix=M64 %s
+! RUN: %flang -target x86_64-linux-gnu -m64 -### - %s 2>&1 | FileCheck -check-prefix=M64 %s
+! RUN: %flang -target x86_64-unknown-windows -m64 -### - %s 2>&1 | FileCheck -check-prefix=M64 %s
+! RUN: %flang -target x86_64-unknown-macosx -m64 -### - %s 2>&1 | FileCheck -check-prefix=M64 %s
+
+! M64: "-triple" "x86_64-{{.*}}"


### PR DESCRIPTION
Exposes  `-m32` and `-m64` options for Flang. 
These options can be used to build libraries or tools (e.g. OpenBlas).