### PR TITLE
[lldb][NFC] Fix test settings JSON check to compare expected path list.

### DIFF
--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -1022,7 +1022,7 @@ class SettingsCommandTestCase(TestBase):
         path2 = os.path.join(self.getSourceDir(), "tmp2")
         self.runCmd("settings set %s '%s' '%s'" % (setting_path, path1, path2))
         settings_json = self.get_setting_json(setting_path)
-        self.assertEqual(settings_json, setting_value)
+        self.assertEqual(settings_json, [path1, path2])
 
         # Test OptionValueFormatEntity
         setting_value = """thread #${thread.index}{, name = \\'${thread.name}\\


### PR DESCRIPTION
Previously, the test compared the JSON output to `setting_value` which was incorrect. Updated the assertion to validate against the correct list of paths `[path1, path2]` to ensure accurate test behavior.

Ran the test on the local computer 