### PR TITLE
[clang][analyzer] Ignore unnamed bitfields in UninitializedObjectChecker

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
@@ -332,6 +332,10 @@ bool FindUninitializedFields::isNonUnionUninit(const TypedValueRegion *R,
     }
 
     if (isPrimitiveType(T)) {
+      if (I->isUnnamedBitField()) {
+        IsAnyFieldInitialized = true;
+        continue;
+      }
       if (isPrimitiveUninit(V)) {
         if (addFieldToUninits(LocalChain.add(RegularField(FR))))
           ContainsUninitField = true;

--- a/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
@@ -291,7 +291,9 @@ bool FindUninitializedFields::isNonUnionUninit(const TypedValueRegion *R,
 
   // Are all of this non-union's fields initialized?
   for (const FieldDecl *I : RD->fields()) {
-
+    if (I->isUnnamedBitField()) {
+      continue;
+    }
     const auto FieldVal =
         State->getLValue(I, loc::MemRegionVal(R)).castAs<loc::MemRegionVal>();
     const auto *FR = FieldVal.getRegionAs<FieldRegion>();
@@ -332,9 +334,6 @@ bool FindUninitializedFields::isNonUnionUninit(const TypedValueRegion *R,
     }
 
     if (isPrimitiveType(T)) {
-      if (I->isUnnamedBitField()) {
-        continue;
-      }
       if (isPrimitiveUninit(V)) {
         if (addFieldToUninits(LocalChain.add(RegularField(FR))))
           ContainsUninitField = true;

--- a/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UninitializedObject/UninitializedObjectChecker.cpp
@@ -333,7 +333,6 @@ bool FindUninitializedFields::isNonUnionUninit(const TypedValueRegion *R,
 
     if (isPrimitiveType(T)) {
       if (I->isUnnamedBitField()) {
-        IsAnyFieldInitialized = true;
         continue;
       }
       if (isPrimitiveUninit(V)) {

--- a/clang/test/Analysis/cxx-uninitialized-object.cpp
+++ b/clang/test/Analysis/cxx-uninitialized-object.cpp
@@ -1182,3 +1182,24 @@ void fComplexTest() {
   // TODO: we should emit a warning for x2.x and x2.y.
   ComplexUninitTest x2;
 }
+
+struct PaddingBitfieldTest {
+  int a;
+  long long : 7; // padding, previously flagged as uninitialized
+  PaddingBitfieldTest(int a) : a(a) {}
+};
+
+void fPaddingBitfieldTest() {
+  PaddingBitfieldTest pb(42);
+  // no-warning: Unnamed bitfield is now ignored, fixing false positive
+}
+
+struct NamedBitfieldTest {
+  int b; 
+  long long named : 7; // expected-note{{uninitialized field 'this->named'}}
+  NamedBitfieldTest(int b) : b(b) {} // expected-warning{{1 uninitialized field at the end of the constructor call}}
+};
+
+void fNamedBitfieldTest() {
+  NamedBitfieldTest nb(42); 
+}


### PR DESCRIPTION
Fixes #132001 

Edit ```isNonUnionUninit``` (caller of ```isPrimitiveUninit```): Add a check before calling ```isPrimitiveUninit```
```cpp
if (isPrimitiveType(T)) {
  if (I->isUnnamedBitField()) {
    continue;
  }
  if (isPrimitiveUninit(V)) {
    if (addFieldToUninits(LocalChain.add(RegularField(FR))))
      ContainsUninitField = true;
  }
  continue;
}
```

## **Test Results**
```bash
Testing Time: 221.93s

Total Discovered Tests: 991
  Unsupported      :  16 (1.61%)
  Passed           : 968 (97.68%)
  Expectedly Failed:   7 (0.71%)
[100%] Built target check-clang-analysis
```

## Testcase
```cpp
// test.cpp
struct S
{
    S(bool b)
    : b(b)
    {}
    bool b{false};
    long long : 7; // padding
};

void f()
{
    S s(true);
}
```
### Before Patch
<img width="954" alt="Screenshot 2025-03-22 at 1 02 08 AM" src="https://github.com/user-attachments/assets/557a81a7-d569-48b2-b7db-18513d9e271d" />

### After Patch
<img width="956" alt="Screenshot 2025-03-22 at 1 03 50 AM" src="https://github.com/user-attachments/assets/8e025041-e368-4e86-9e91-8f426333f2f3" />
