### PR TITLE
[clang-doc] Format test files

### DIFF
--- a/clang-tools-extra/test/clang-doc/DR-131697.cpp
+++ b/clang-tools-extra/test/clang-doc/DR-131697.cpp
@@ -13,10 +13,8 @@ int main() {
 }
 
 //--- compile_commands.json
-[
-{
-  "directory": "foo",
-  "file":"main.cpp",
-  "command":"clang main.cpp -c"
-}
-]
+[{
+  "directory" : "foo",
+  "file" : "main.cpp",
+  "command" : "clang main.cpp -c"
+}]

--- a/clang-tools-extra/test/clang-doc/Inputs/basic-project/src/Calculator.cpp
+++ b/clang-tools-extra/test/clang-doc/Inputs/basic-project/src/Calculator.cpp
@@ -1,17 +1,17 @@
 #include "Calculator.h"
 
 int Calculator::add(int a, int b) {
-    return a + b;
+  return a + b;
 }
 
 int Calculator::subtract(int a, int b) {
-    return a - b;
+  return a - b;
 }
 
 int Calculator::multiply(int a, int b) {
-    return a * b;
+  return a * b;
 }
 
 double Calculator::divide(int a, int b) {
-    return static_cast<double>(a) / b;
+  return static_cast<double>(a) / b;
 }

--- a/clang-tools-extra/test/clang-doc/Inputs/basic-project/src/Circle.cpp
+++ b/clang-tools-extra/test/clang-doc/Inputs/basic-project/src/Circle.cpp
@@ -3,10 +3,9 @@
 Circle::Circle(double radius) : radius_(radius) {}
 
 double Circle::area() const {
-    return 3.141 * radius_ * radius_;
+  return 3.141 * radius_ * radius_;
 }
 
 double Circle::perimeter() const {
-    return 3.141 * radius_;
+  return 3.141 * radius_;
 }
-

--- a/clang-tools-extra/test/clang-doc/Inputs/basic-project/src/Rectangle.cpp
+++ b/clang-tools-extra/test/clang-doc/Inputs/basic-project/src/Rectangle.cpp
@@ -1,12 +1,12 @@
 #include "Rectangle.h"
 
 Rectangle::Rectangle(double width, double height)
-        : width_(width), height_(height) {}
+    : width_(width), height_(height) {}
 
 double Rectangle::area() const {
-    return width_ * height_;
+  return width_ * height_;
 }
 
 double Rectangle::perimeter() const {
-    return 2 * (width_ + height_);
+  return 2 * (width_ + height_);
 }

--- a/clang-tools-extra/test/clang-doc/enum.cpp
+++ b/clang-tools-extra/test/clang-doc/enum.cpp
@@ -14,16 +14,15 @@
 // RUN: FileCheck %s < %t/Vehicles/index.md --check-prefix=MD-VEHICLES-LINE
 // RUN: FileCheck %s < %t/Vehicles/index.md --check-prefix=MD-VEHICLES
 
-
 /**
  * @brief For specifying RGB colors
  */
 enum Color {
-// MD-INDEX-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE-1]]*
-// HTML-INDEX-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
-  Red, ///< Comment 1
+  // MD-INDEX-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE-1]]*
+  // HTML-INDEX-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
+  Red,   ///< Comment 1
   Green, ///< Comment 2
-  Blue ///< Comment 3
+  Blue   ///< Comment 3
 };
 
 // MD-INDEX: ## Enums
@@ -49,8 +48,8 @@ enum Color {
  * @brief Shape Types
  */
 enum class Shapes {
-// MD-INDEX-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE-1]]*
-// HTML-INDEX-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
+  // MD-INDEX-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE-1]]*
+  // HTML-INDEX-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
 
   /// Comment 1
   Circle,
@@ -77,22 +76,20 @@ enum class Shapes {
 // HTML-INDEX: <td>2</td>
 // HTML-INDEX: <p> Comment 3</p>
 
-
-
 class Animals {
-// MD-ANIMAL-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE-1]]*
-// HTML-ANIMAL-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
+  // MD-ANIMAL-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE-1]]*
+  // HTML-ANIMAL-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
 public:
-      /**
-       * @brief specify what animal the class is
-       */
-      enum AnimalType {
-// MD-ANIMAL-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE-1]]*
-// HTML-ANIMAL-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
-          Dog, ///< Man's best friend
-          Cat, ///< Man's other best friend
-          Iguana ///< A lizard
-      };
+  /**
+   * @brief specify what animal the class is
+   */
+  enum AnimalType {
+    // MD-ANIMAL-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE-1]]*
+    // HTML-ANIMAL-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
+    Dog,   ///< Man's best friend
+    Cat,   ///< Man's other best friend
+    Iguana ///< A lizard
+  };
 };
 
 // HTML-ANIMAL: <h1>class Animals</h1>
@@ -108,7 +105,6 @@ public:
 // HTML-ANIMAL: <td>2</td>
 // HTML-ANIMAL: <p> A lizard</p>
 
-
 // MD-ANIMAL: # class Animals
 // MD-ANIMAL: ## Enums
 // MD-ANIMAL: | enum AnimalType |
@@ -118,21 +114,20 @@ public:
 // MD-ANIMAL: | Iguana |
 // MD-ANIMAL: **brief** specify what animal the class is
 
-
 namespace Vehicles {
-    /**
-     * @brief specify type of car
-     */
-    enum Car {
-// MD-VEHICLES-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE-1]]*
-// HTML-VEHICLES-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
+/**
+ * @brief specify type of car
+ */
+enum Car {
+  // MD-VEHICLES-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp#[[@LINE-1]]*
+  // HTML-VEHICLES-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}enum.cpp</p>
 
-       Sedan, ///< Comment 1
-       SUV, ///< Comment 2
-       Pickup, ///< Comment 3
-       Hatchback ///< Comment 4
-    };
-}
+  Sedan,    ///< Comment 1
+  SUV,      ///< Comment 2
+  Pickup,   ///< Comment 3
+  Hatchback ///< Comment 4
+};
+} // namespace Vehicles
 
 // MD-VEHICLES: # namespace Vehicles
 // MD-VEHICLES: ## Enums
@@ -158,7 +153,6 @@ namespace Vehicles {
 // HTML-VEHICLES: <td>Hatchback</td>
 // HTML-VEHICLES: <td>3</td>
 // HTML-VEHICLES: <p> Comment 4</p>
-
 
 enum ColorUserSpecified {
   RedUserSpecified = 'A',

--- a/clang-tools-extra/test/clang-doc/namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/namespace.cpp
@@ -39,22 +39,19 @@
 // RUN: FileCheck %s < %t/all_files.md -check-prefix=MD-ALL-FILES
 // RUN: FileCheck %s < %t/index.md -check-prefix=MD-INDEX
 
-
-
 // Anonymous Namespace
-namespace
-{
-    void anonFunction() {}
+namespace {
+void anonFunction() {}
 // MD-ANON-INDEX-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp#[[@LINE-1]]*
 // HTML-ANON-INDEX-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp</p>
 
-    class AnonClass {};
+class AnonClass {};
 // MD-ANON-CLASS-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp#[[@LINE-1]]*
 // HTML-ANON-CLASS-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp</p>
 
 // MD-ANON-CLASS: # class AnonClass
 // HTML-ANON-CLASS: <h1>class AnonClass</h1>
-}
+} // namespace
 
 // MD-ANON-INDEX: # namespace @nonymous_namespace
 // MD-ANON-INDEX:  Anonymous Namespace
@@ -72,16 +69,15 @@ namespace
 // HTML-ANON-INDEX: <h3 id="{{([0-9A-F]{40})}}">anonFunction</h3>
 // HTML-ANON-INDEX: <p>void anonFunction()</p>
 
-
 // Primary Namespace
 namespace PrimaryNamespace {
-    // Function in PrimaryNamespace
-    void functionInPrimaryNamespace() {}
+// Function in PrimaryNamespace
+void functionInPrimaryNamespace() {}
 // MD-PRIMARY-INDEX-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp#[[@LINE-1]]*
 // HTML-PRIMARY-INDEX-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp</p>
 
-    // Class in PrimaryNamespace
-    class ClassInPrimaryNamespace {};
+// Class in PrimaryNamespace
+class ClassInPrimaryNamespace {};
 // MD-PRIMARY-CLASS-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp#[[@LINE-1]]*
 // HTML-PRIMARY-CLASS-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp</p>
 
@@ -91,15 +87,15 @@ namespace PrimaryNamespace {
 // HTML-PRIMARY-CLASS: <h1>class ClassInPrimaryNamespace</h1>
 // HTML-PRIMARY-CLASS: <p> Class in PrimaryNamespace</p>
 
-    // Nested namespace
-    namespace NestedNamespace {
-        // Function in NestedNamespace
-        void functionInNestedNamespace() {}
+// Nested namespace
+namespace NestedNamespace {
+// Function in NestedNamespace
+void functionInNestedNamespace() {}
 // MD-NESTED-INDEX-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp#[[@LINE-1]]*
 // HTML-NESTED-INDEX-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp</p>
 
-        // Class in NestedNamespace
-        class ClassInNestedNamespace {};
+// Class in NestedNamespace
+class ClassInNestedNamespace {};
 // MD-NESTED-CLASS-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp#[[@LINE-1]]*
 // HTML-NESTED-CLASS-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp</p>
 
@@ -108,7 +104,7 @@ namespace PrimaryNamespace {
 
 // HTML-NESTED-CLASS: <h1>class ClassInNestedNamespace</h1>
 // HTML-NESTED-CLASS: <p> Class in NestedNamespace</p>
-    }
+} // namespace NestedNamespace
 
 // MD-NESTED-INDEX: # namespace NestedNamespace
 // MD-NESTED-INDEX: Nested namespace
@@ -127,7 +123,7 @@ namespace PrimaryNamespace {
 // HTML-NESTED-INDEX: <h3 id="{{([0-9A-F]{40})}}">functionInNestedNamespace</h3>
 // HTML-NESTED-INDEX: <p>void functionInNestedNamespace()</p>
 // HTML-NESTED-INDEX: <p> Function in NestedNamespace</p>
-}
+} // namespace PrimaryNamespace
 
 // MD-PRIMARY-INDEX: # namespace PrimaryNamespace
 // MD-PRIMARY-INDEX:  Primary Namespace
@@ -151,16 +147,15 @@ namespace PrimaryNamespace {
 // HTML-PRIMARY-INDEX: <p>void functionInPrimaryNamespace()</p>
 // HTML-PRIMARY-INDEX: <p> Function in PrimaryNamespace</p>
 
-
 // AnotherNamespace
 namespace AnotherNamespace {
-    // Function in AnotherNamespace
-    void functionInAnotherNamespace() {}
+// Function in AnotherNamespace
+void functionInAnotherNamespace() {}
 // MD-ANOTHER-INDEX-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp#[[@LINE-1]]*
 // HTML-ANOTHER-INDEX-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp</p>
 
-    // Class in AnotherNamespace
-    class ClassInAnotherNamespace {};
+// Class in AnotherNamespace
+class ClassInAnotherNamespace {};
 // MD-ANOTHER-CLASS-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp#[[@LINE-1]]*
 // HTML-ANOTHER-CLASS-LINE: <p>Defined at line [[@LINE-2]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}namespace.cpp</p>
 
@@ -170,7 +165,7 @@ namespace AnotherNamespace {
 // HTML-ANOTHER-CLASS: <h1>class ClassInAnotherNamespace</h1>
 // HTML-ANOTHER-CLASS: <p> Class in AnotherNamespace</p>
 
-}
+} // namespace AnotherNamespace
 
 // MD-ANOTHER-INDEX: # namespace AnotherNamespace
 // MD-ANOTHER-INDEX: AnotherNamespace
@@ -275,13 +270,11 @@ namespace AnotherNamespace {
 // HTML-GLOBAL-INDEX: <li>AnotherNamespace</li>
 // HTML-GLOBAL-INDEX: <li>PrimaryNamespace</li>
 
-
 // MD-GLOBAL-INDEX: # Global Namespace
 // MD-GLOBAL-INDEX: ## Namespaces
 // MD-GLOBAL-INDEX: * [@nonymous_namespace](..{{[\/]}}@nonymous_namespace{{[\/]}}index.md)
 // MD-GLOBAL-INDEX: * [AnotherNamespace](..{{[\/]}}AnotherNamespace{{[\/]}}index.md)
 // MD-GLOBAL-INDEX: * [PrimaryNamespace](..{{[\/]}}PrimaryNamespace{{[\/]}}index.md)
-
 
 // MD-ALL-FILES: # All Files
 // MD-ALL-FILES: ## [@nonymous_namespace](@nonymous_namespace{{[\/]}}index.md)

--- a/clang-tools-extra/test/clang-doc/single-file-public.cpp
+++ b/clang-tools-extra/test/clang-doc/single-file-public.cpp
@@ -9,10 +9,10 @@
 
 class Record {
 private:
-	void function_private();
+  void function_private();
 
 public:
-	void function_public();
+  void function_public();
 };
 
 void Record::function_private() {}

--- a/clang-tools-extra/test/clang-doc/templates.cpp
+++ b/clang-tools-extra/test/clang-doc/templates.cpp
@@ -19,7 +19,7 @@
 // MD: # Global Namespace
 // MD: ## Functions
 
-template<class... T>
+template <class... T>
 void ParamPackFunction(T... args);
 
 // YAML-NEXT: ChildFunctions:
@@ -44,7 +44,7 @@ void ParamPackFunction(T... args);
 // MD: ### ParamPackFunction
 // MD: *void ParamPackFunction(T... args)*
 
-template<typename T, int U = 1>
+template <typename T, int U = 1>
 void function(T x) {}
 
 // YAML-NEXT:   - USR:             '{{([0-9A-F]{40})}}'
@@ -70,7 +70,7 @@ void function(T x) {}
 // MD: *void function(T x)*
 // MD: *Defined at {{.*}}templates.cpp#[[# @LINE - 23]]*
 
-template<>
+template <>
 void function<bool, 0>(bool x) {}
 
 // YAML-NEXT:   - USR:             '{{([0-9A-F]{40})}}'
@@ -101,13 +101,13 @@ void function<bool, 0>(bool x) {}
 /// A Tuple type
 ///
 /// Does Tuple things.
-template<typename ...Tys>
-struct tuple{};
+template <typename... Tys>
+struct tuple {};
 
 /// A function with a tuple parameter
 ///
 /// \param t The input to func_with_tuple_param
-tuple<int,int,bool> func_with_tuple_param(tuple<int,int,bool> t){ return t;}
+tuple<int, int, bool> func_with_tuple_param(tuple<int, int, bool> t) { return t; }
 
 // YAML-NEXT:   - USR:             '{{([0-9A-F]{40})}}'
 // YAML-NEXT:    Name:            'func_with_tuple_param'
@@ -154,4 +154,3 @@ tuple<int,int,bool> func_with_tuple_param(tuple<int,int,bool> t){ return t;}
 // MD: *Defined at {{.*}}templates.cpp#[[# @LINE - 44]]*
 // MD:  A function with a tuple parameter
 // MD: **t** The input to func_with_tuple_param
-

--- a/clang-tools-extra/test/clang-doc/test-path-abs.cpp
+++ b/clang-tools-extra/test/clang-doc/test-path-abs.cpp
@@ -3,4 +3,3 @@
 // RUN: FileCheck %s -input-file=%t/index_json.js  -check-prefix=JSON-INDEX
 
 // JSON-INDEX: var RootPath = "{{.*}}test-path-abs.cpp.tmp";
-


### PR DESCRIPTION
Many of the test files had an inconsistent formatting. This patch ran
clang-format over them using the project's .clang-format file, with
column limit = 0, to prevent test directives from being split over
multiple lines.