### PR TITLE
WIP: [clang] Store in exprs the conveed arguments for function calls.

### DIFF
--- a/clang/include/clang/AST/ASTImporter.h
+++ b/clang/include/clang/AST/ASTImporter.h
@@ -489,6 +489,13 @@ class TypeSourceInfo;
     /// error.
     llvm::Expected<APValue> Import(const APValue &FromValue);
 
+    /// Import the given C++ TemplateArgumentList from the "from"
+    /// context into the "to" context.
+    ///
+    /// \returns The equivalent initializer in the "to" context, or the import
+    /// error.
+    llvm::Expected<TemplateArgumentList *> Import(const TemplateArgumentList *);
+
     /// Import the definition of the given declaration, including all of
     /// the declarations it contains.
     [[nodiscard]] llvm::Error ImportDefinition(Decl *From);

--- a/clang/include/clang/AST/DeclTemplate.h
+++ b/clang/include/clang/AST/DeclTemplate.h
@@ -265,7 +265,7 @@ public:
 
   /// Create a new template argument list that copies the given set of
   /// template arguments.
-  static TemplateArgumentList *CreateCopy(ASTContext &Context,
+  static TemplateArgumentList *CreateCopy(const ASTContext &Context,
                                           ArrayRef<TemplateArgument> Args);
 
   /// Retrieve the template argument at a given index.

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -1274,6 +1274,8 @@ class DeclRefExpr final
   /// The declaration that we are referencing.
   ValueDecl *D;
 
+  const TemplateArgumentList *ConvertedArgs;
+
   /// Provides source/type location info for the declaration name
   /// embedded in D.
   DeclarationNameLoc DNLoc;
@@ -1298,7 +1300,8 @@ class DeclRefExpr final
               SourceLocation TemplateKWLoc, ValueDecl *D,
               bool RefersToEnclosingVariableOrCapture,
               const DeclarationNameInfo &NameInfo, NamedDecl *FoundD,
-              const TemplateArgumentListInfo *TemplateArgs, QualType T,
+              const TemplateArgumentListInfo *TemplateArgs,
+              const TemplateArgumentList *ConvertedArgs, QualType T,
               ExprValueKind VK, NonOdrUseReason NOUR);
 
   /// Construct an empty declaration reference expression.
@@ -1317,6 +1320,7 @@ public:
          bool RefersToEnclosingVariableOrCapture, SourceLocation NameLoc,
          QualType T, ExprValueKind VK, NamedDecl *FoundD = nullptr,
          const TemplateArgumentListInfo *TemplateArgs = nullptr,
+         const TemplateArgumentList *ConvertedArgs = nullptr,
          NonOdrUseReason NOUR = NOUR_None);
 
   static DeclRefExpr *
@@ -1326,6 +1330,7 @@ public:
          const DeclarationNameInfo &NameInfo, QualType T, ExprValueKind VK,
          NamedDecl *FoundD = nullptr,
          const TemplateArgumentListInfo *TemplateArgs = nullptr,
+         const TemplateArgumentList *ConvertedArgs = nullptr,
          NonOdrUseReason NOUR = NOUR_None);
 
   /// Construct an empty declaration reference expression.
@@ -1432,6 +1437,8 @@ public:
       return nullptr;
     return getTrailingObjects<TemplateArgumentLoc>();
   }
+
+  const TemplateArgumentList *getConvertedArgs() const { return ConvertedArgs; }
 
   /// Retrieve the number of template arguments provided as part of this
   /// template-id.
@@ -3248,6 +3255,8 @@ class MemberExpr final
   /// In X.F, this is the decl referenced by F.
   ValueDecl *MemberDecl;
 
+  const TemplateArgumentList *Deduced;
+
   /// MemberDNLoc - Provides source/type location info for the
   /// declaration name embedded in MemberDecl.
   DeclarationNameLoc MemberDNLoc;
@@ -3277,21 +3286,21 @@ class MemberExpr final
              NestedNameSpecifierLoc QualifierLoc, SourceLocation TemplateKWLoc,
              ValueDecl *MemberDecl, DeclAccessPair FoundDecl,
              const DeclarationNameInfo &NameInfo,
-             const TemplateArgumentListInfo *TemplateArgs, QualType T,
-             ExprValueKind VK, ExprObjectKind OK, NonOdrUseReason NOUR);
+             const TemplateArgumentListInfo *TemplateArgs,
+             const TemplateArgumentList *Deduced, QualType T, ExprValueKind VK,
+             ExprObjectKind OK, NonOdrUseReason NOUR);
   MemberExpr(EmptyShell Empty)
       : Expr(MemberExprClass, Empty), Base(), MemberDecl() {}
 
 public:
-  static MemberExpr *Create(const ASTContext &C, Expr *Base, bool IsArrow,
-                            SourceLocation OperatorLoc,
-                            NestedNameSpecifierLoc QualifierLoc,
-                            SourceLocation TemplateKWLoc, ValueDecl *MemberDecl,
-                            DeclAccessPair FoundDecl,
-                            DeclarationNameInfo MemberNameInfo,
-                            const TemplateArgumentListInfo *TemplateArgs,
-                            QualType T, ExprValueKind VK, ExprObjectKind OK,
-                            NonOdrUseReason NOUR);
+  static MemberExpr *
+  Create(const ASTContext &C, Expr *Base, bool IsArrow,
+         SourceLocation OperatorLoc, NestedNameSpecifierLoc QualifierLoc,
+         SourceLocation TemplateKWLoc, ValueDecl *MemberDecl,
+         DeclAccessPair FoundDecl, DeclarationNameInfo MemberNameInfo,
+         const TemplateArgumentListInfo *TemplateArgs,
+         const TemplateArgumentList *Deduced, QualType T, ExprValueKind VK,
+         ExprObjectKind OK, NonOdrUseReason NOUR);
 
   /// Create an implicit MemberExpr, with no location, qualifier, template
   /// arguments, and so on. Suitable only for non-static member access.
@@ -3302,7 +3311,8 @@ public:
     return Create(C, Base, IsArrow, SourceLocation(), NestedNameSpecifierLoc(),
                   SourceLocation(), MemberDecl,
                   DeclAccessPair::make(MemberDecl, MemberDecl->getAccess()),
-                  DeclarationNameInfo(), nullptr, T, VK, OK, NOUR_None);
+                  DeclarationNameInfo(), nullptr, /*Deduced=*/{}, T, VK, OK,
+                  NOUR_None);
   }
 
   static MemberExpr *CreateEmpty(const ASTContext &Context, bool HasQualifier,
@@ -3327,6 +3337,8 @@ public:
                                   getMemberDecl()->getAccess());
     return *getTrailingObjects<DeclAccessPair>();
   }
+
+  const TemplateArgumentList *getDeduced() const { return Deduced; }
 
   /// Determines whether this member expression actually had
   /// a C++ nested-name-specifier prior to the name of the member, e.g.,

--- a/clang/include/clang/Sema/Initialization.h
+++ b/clang/include/clang/Sema/Initialization.h
@@ -957,6 +957,7 @@ public:
       bool HadMultipleCandidates;
       FunctionDecl *Function;
       DeclAccessPair FoundDecl;
+      const TemplateArgumentList *ConvertedArgs;
     };
 
     union {
@@ -1262,9 +1263,10 @@ public:
   ///
   /// \param Function the function to which the overloaded function reference
   /// resolves.
-  void AddAddressOverloadResolutionStep(FunctionDecl *Function,
-                                        DeclAccessPair Found,
-                                        bool HadMultipleCandidates);
+  void
+  AddAddressOverloadResolutionStep(FunctionDecl *Function, DeclAccessPair Found,
+                                   const TemplateArgumentList *ConvertedArgs,
+                                   bool HadMultipleCandidates);
 
   /// Add a new step in the initialization that performs a derived-to-
   /// base cast.

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -961,6 +961,9 @@ class Sema;
       StandardConversionSequence FinalConversion;
     };
 
+    /// Deduced Arguments for Function Templates.
+    const TemplateArgumentList *Deduced;
+
     /// Get RewriteKind value in OverloadCandidateRewriteKind type (This
     /// function is to workaround the spurious GCC bitfield enum warning)
     OverloadCandidateRewriteKind getRewriteKind() const {

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -6856,7 +6856,8 @@ public:
                    const CXXScopeSpec *SS = nullptr,
                    NamedDecl *FoundD = nullptr,
                    SourceLocation TemplateKWLoc = SourceLocation(),
-                   const TemplateArgumentListInfo *TemplateArgs = nullptr);
+                   const TemplateArgumentListInfo *TemplateArgs = nullptr,
+                   const TemplateArgumentList *ConvertArgs = nullptr);
 
   /// BuildDeclRefExpr - Build an expression that references a
   /// declaration that does not require a closure capture.
@@ -6865,7 +6866,8 @@ public:
                    const DeclarationNameInfo &NameInfo,
                    NestedNameSpecifierLoc NNS, NamedDecl *FoundD = nullptr,
                    SourceLocation TemplateKWLoc = SourceLocation(),
-                   const TemplateArgumentListInfo *TemplateArgs = nullptr);
+                   const TemplateArgumentListInfo *TemplateArgs = nullptr,
+                   const TemplateArgumentList *ConvertArgs = nullptr);
 
   bool UseArgumentDependentLookup(const CXXScopeSpec &SS, const LookupResult &R,
                                   bool HasTrailingLParen);
@@ -6887,6 +6889,7 @@ public:
       const CXXScopeSpec &SS, const DeclarationNameInfo &NameInfo, NamedDecl *D,
       NamedDecl *FoundD = nullptr,
       const TemplateArgumentListInfo *TemplateArgs = nullptr,
+      const TemplateArgumentList *ConvertedArgs = nullptr,
       bool AcceptInvalidDecl = false);
 
   // ExpandFunctionLocalPredefinedMacros - Returns a new vector of Tokens,
@@ -8700,14 +8703,13 @@ public:
                                    SourceLocation TemplateKWLoc,
                                    UnqualifiedId &Member, Decl *ObjCImpDecl);
 
-  MemberExpr *
-  BuildMemberExpr(Expr *Base, bool IsArrow, SourceLocation OpLoc,
-                  NestedNameSpecifierLoc NNS, SourceLocation TemplateKWLoc,
-                  ValueDecl *Member, DeclAccessPair FoundDecl,
-                  bool HadMultipleCandidates,
-                  const DeclarationNameInfo &MemberNameInfo, QualType Ty,
-                  ExprValueKind VK, ExprObjectKind OK,
-                  const TemplateArgumentListInfo *TemplateArgs = nullptr);
+  MemberExpr *BuildMemberExpr(
+      Expr *Base, bool IsArrow, SourceLocation OpLoc,
+      NestedNameSpecifierLoc NNS, SourceLocation TemplateKWLoc,
+      ValueDecl *Member, DeclAccessPair FoundDecl, bool HadMultipleCandidates,
+      const DeclarationNameInfo &MemberNameInfo, QualType Ty, ExprValueKind VK,
+      ExprObjectKind OK, const TemplateArgumentListInfo *TemplateArgs = nullptr,
+      const TemplateArgumentList *Deduced = nullptr);
 
   // Check whether the declarations we found through a nested-name
   // specifier in a member expression are actually members of the base
@@ -10299,6 +10301,7 @@ public:
       ADLCallKind IsADLCandidate = ADLCallKind::NotADL,
       ConversionSequenceList EarlyConversions = {},
       OverloadCandidateParamOrder PO = {},
+      const TemplateArgumentList *Deduced = nullptr,
       bool AggregateCandidateDeduction = false, bool StrictPackMatch = false);
 
   /// Add all of the function declarations in the given function set to
@@ -10335,6 +10338,7 @@ public:
                           bool PartialOverloading = false,
                           ConversionSequenceList EarlyConversions = {},
                           OverloadCandidateParamOrder PO = {},
+                          const TemplateArgumentList *Deduced = nullptr,
                           bool StrictPackMatch = false);
 
   /// Add a C++ member function template as a candidate to the candidate
@@ -10543,6 +10547,7 @@ public:
   FunctionDecl *
   ResolveAddressOfOverloadedFunction(Expr *AddressOfExpr, QualType TargetType,
                                      bool Complain, DeclAccessPair &Found,
+                                     const TemplateArgumentList *&ConvertedArgs,
                                      bool *pHadMultipleCandidates = nullptr);
 
   /// Given an expression that refers to an overloaded function, try to
@@ -10576,7 +10581,9 @@ public:
   /// If no template-ids are found, no diagnostics are emitted and NULL is
   /// returned.
   FunctionDecl *ResolveSingleFunctionTemplateSpecialization(
-      OverloadExpr *ovl, bool Complain = false, DeclAccessPair *Found = nullptr,
+      OverloadExpr *ovl, TemplateArgumentListInfo &ExplicitTemplateArgs,
+      const TemplateArgumentList *&ConvertedArgs, bool Complain = false,
+      DeclAccessPair *Found = nullptr,
       TemplateSpecCandidateSet *FailedTSC = nullptr,
       bool ForTypeDeduction = false);
 
@@ -10761,11 +10768,14 @@ public:
   /// perhaps a '&' around it). We have resolved the overloaded function
   /// to the function declaration Fn, so patch up the expression E to
   /// refer (possibly indirectly) to Fn. Returns the new expr.
-  ExprResult FixOverloadedFunctionReference(Expr *E, DeclAccessPair FoundDecl,
-                                            FunctionDecl *Fn);
-  ExprResult FixOverloadedFunctionReference(ExprResult,
-                                            DeclAccessPair FoundDecl,
-                                            FunctionDecl *Fn);
+  ExprResult
+  FixOverloadedFunctionReference(Expr *E, DeclAccessPair FoundDecl,
+                                 FunctionDecl *Fn,
+                                 const TemplateArgumentList *Deduced);
+  ExprResult
+  FixOverloadedFunctionReference(ExprResult, DeclAccessPair FoundDecl,
+                                 FunctionDecl *Fn,
+                                 const TemplateArgumentList *Deduced);
 
   /// - Returns a selector which best matches given argument list or
   /// nullptr if none could be found
@@ -11545,7 +11555,8 @@ public:
   DeclResult CheckVarTemplateId(VarTemplateDecl *Template,
                                 SourceLocation TemplateLoc,
                                 SourceLocation TemplateNameLoc,
-                                const TemplateArgumentListInfo &TemplateArgs);
+                                const TemplateArgumentListInfo &TemplateArgs,
+                                const TemplateArgumentList *&ConvertedArgs);
 
   /// Form a reference to the specialization of the given variable template
   /// corresponding to the specified argument list, or a null-but-valid result

--- a/clang/include/clang/Sema/SemaCUDA.h
+++ b/clang/include/clang/Sema/SemaCUDA.h
@@ -229,8 +229,8 @@ public:
   /// calling priority.
   void EraseUnwantedMatches(
       const FunctionDecl *Caller,
-      llvm::SmallVectorImpl<std::pair<DeclAccessPair, FunctionDecl *>>
-          &Matches);
+      llvm::SmallVectorImpl<std::tuple<DeclAccessPair, FunctionDecl *,
+                                       const TemplateArgumentList *>> &Matches);
 
   /// Given a implicit special member, infer its CUDA target from the
   /// calls it needs to make to underlying base/field special members.

--- a/clang/lib/AST/DeclTemplate.cpp
+++ b/clang/lib/AST/DeclTemplate.cpp
@@ -950,7 +950,7 @@ TemplateArgumentList::TemplateArgumentList(ArrayRef<TemplateArgument> Args)
 }
 
 TemplateArgumentList *
-TemplateArgumentList::CreateCopy(ASTContext &Context,
+TemplateArgumentList::CreateCopy(const ASTContext &Context,
                                  ArrayRef<TemplateArgument> Args) {
   void *Mem = Context.Allocate(totalSizeToAlloc<TemplateArgument>(Args.size()));
   return new (Mem) TemplateArgumentList(Args);

--- a/clang/lib/Analysis/BodyFarm.cpp
+++ b/clang/lib/Analysis/BodyFarm.cpp
@@ -231,8 +231,8 @@ MemberExpr *ASTMaker::makeMemberExpression(Expr *base, ValueDecl *MemberDecl,
       C, base, IsArrow, SourceLocation(), NestedNameSpecifierLoc(),
       SourceLocation(), MemberDecl, FoundDecl,
       DeclarationNameInfo(MemberDecl->getDeclName(), SourceLocation()),
-      /* TemplateArgumentListInfo=*/ nullptr, MemberDecl->getType(), ValueKind,
-      OK_Ordinary, NOUR_None);
+      /* TemplateArgumentListInfo=*/nullptr, /*Deduced=*/nullptr,
+      MemberDecl->getType(), ValueKind, OK_Ordinary, NOUR_None);
 }
 
 ValueDecl *ASTMaker::findMemberField(const RecordDecl *RD, StringRef Name) {

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -1867,7 +1867,8 @@ static DeclRefExpr *tryToConvertMemberExprToDeclRefExpr(CodeGenFunction &CGF,
     return DeclRefExpr::Create(
         CGF.getContext(), NestedNameSpecifierLoc(), SourceLocation(), VD,
         /*RefersToEnclosingVariableOrCapture=*/false, ME->getExprLoc(),
-        ME->getType(), ME->getValueKind(), nullptr, nullptr, ME->isNonOdrUse());
+        ME->getType(), ME->getValueKind(), nullptr, nullptr, nullptr,
+        ME->isNonOdrUse());
   }
   return nullptr;
 }

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -4629,7 +4629,7 @@ ExprResult Sema::BuiltinAtomicOverloaded(ExprResult TheCallResult) {
   DeclRefExpr *NewDRE = DeclRefExpr::Create(
       Context, DRE->getQualifierLoc(), SourceLocation(), NewBuiltinDecl,
       /*enclosing*/ false, DRE->getLocation(), Context.BuiltinFnTy,
-      DRE->getValueKind(), nullptr, nullptr, DRE->isNonOdrUse());
+      DRE->getValueKind(), nullptr, nullptr, nullptr, DRE->isNonOdrUse());
 
   // Set the callee in the CallExpr.
   // FIXME: This loses syntactic information.

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -1816,7 +1816,8 @@ static void handleRestrictAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
       return;
     }
   } else if (auto *ULE = dyn_cast<UnresolvedLookupExpr>(DeallocE)) {
-    DeallocFD = S.ResolveSingleFunctionTemplateSpecialization(ULE, true);
+    DeclAccessPair DAP;
+    DeallocFD = S.resolveAddressOfSingleOverloadCandidate(ULE, DAP);
     DeallocNI = ULE->getNameInfo();
     if (!DeallocFD) {
       S.Diag(DeallocLoc, diag::err_attribute_malloc_arg_not_function)
@@ -3610,9 +3611,14 @@ static void handleCleanupAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
       return;
     }
   } else if (auto *ULE = dyn_cast<UnresolvedLookupExpr>(E)) {
-    if (ULE->hasExplicitTemplateArgs())
+    if (ULE->hasExplicitTemplateArgs()) {
       S.Diag(Loc, diag::warn_cleanup_ext);
-    FD = S.ResolveSingleFunctionTemplateSpecialization(ULE, true);
+      TemplateArgumentListInfo ExplicitTemplateArgs;
+      const TemplateArgumentList *ConvertedArgs;
+      ULE->copyTemplateArgumentsInto(ExplicitTemplateArgs);
+      FD = S.ResolveSingleFunctionTemplateSpecialization(
+          ULE, ExplicitTemplateArgs, ConvertedArgs, /*Complain=*/true);
+    }
     NI = ULE->getNameInfo();
     if (!FD) {
       S.Diag(Loc, diag::err_attribute_cleanup_arg_not_function) << 2

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -2232,11 +2232,12 @@ Sema::BuildDeclRefExpr(ValueDecl *D, QualType Ty, ExprValueKind VK,
                        const DeclarationNameInfo &NameInfo,
                        const CXXScopeSpec *SS, NamedDecl *FoundD,
                        SourceLocation TemplateKWLoc,
-                       const TemplateArgumentListInfo *TemplateArgs) {
+                       const TemplateArgumentListInfo *TemplateArgs,
+                       const TemplateArgumentList *ConvertedArgs) {
   NestedNameSpecifierLoc NNS =
       SS ? SS->getWithLocInContext(Context) : NestedNameSpecifierLoc();
   return BuildDeclRefExpr(D, Ty, VK, NameInfo, NNS, FoundD, TemplateKWLoc,
-                          TemplateArgs);
+                          TemplateArgs, ConvertedArgs);
 }
 
 // CUDA/HIP: Check whether a captured reference variable is referencing a
@@ -2301,13 +2302,16 @@ Sema::BuildDeclRefExpr(ValueDecl *D, QualType Ty, ExprValueKind VK,
                        const DeclarationNameInfo &NameInfo,
                        NestedNameSpecifierLoc NNS, NamedDecl *FoundD,
                        SourceLocation TemplateKWLoc,
-                       const TemplateArgumentListInfo *TemplateArgs) {
+                       const TemplateArgumentListInfo *TemplateArgs,
+                       const TemplateArgumentList *ConvertedArgs) {
   bool RefersToCapturedVariable = isa<VarDecl, BindingDecl>(D) &&
                                   NeedToCaptureVariable(D, NameInfo.getLoc());
 
-  DeclRefExpr *E = DeclRefExpr::Create(
-      Context, NNS, TemplateKWLoc, D, RefersToCapturedVariable, NameInfo, Ty,
-      VK, FoundD, TemplateArgs, getNonOdrUseReasonInCurrentContext(D));
+  assert(!TemplateArgs || ConvertedArgs);
+  DeclRefExpr *E = DeclRefExpr::Create(Context, NNS, TemplateKWLoc, D,
+                                       RefersToCapturedVariable, NameInfo, Ty,
+                                       VK, FoundD, TemplateArgs, ConvertedArgs,
+                                       getNonOdrUseReasonInCurrentContext(D));
   MarkDeclRefReferenced(E);
 
   // C++ [except.spec]p17:
@@ -3221,7 +3225,7 @@ ExprResult Sema::BuildDeclarationNameExpr(const CXXScopeSpec &SS,
       !R.getAsSingle<FunctionTemplateDecl>() &&
       !ShouldLookupResultBeMultiVersionOverload(R))
     return BuildDeclarationNameExpr(SS, R.getLookupNameInfo(), R.getFoundDecl(),
-                                    R.getRepresentativeDecl(), nullptr,
+                                    R.getRepresentativeDecl(), nullptr, nullptr,
                                     AcceptInvalidDecl);
 
   // We only need to check the declaration if there's exactly one
@@ -3252,10 +3256,11 @@ static void diagnoseUncapturableValueReferenceOrBinding(Sema &S,
 ExprResult Sema::BuildDeclarationNameExpr(
     const CXXScopeSpec &SS, const DeclarationNameInfo &NameInfo, NamedDecl *D,
     NamedDecl *FoundD, const TemplateArgumentListInfo *TemplateArgs,
-    bool AcceptInvalidDecl) {
+    const TemplateArgumentList *ConvertedArgs, bool AcceptInvalidDecl) {
   assert(D && "Cannot refer to a NULL declaration");
   assert(!isa<FunctionTemplateDecl>(D) &&
          "Cannot refer unambiguously to a function template");
+  assert(!TemplateArgs || ConvertedArgs);
 
   SourceLocation Loc = NameInfo.getLoc();
   if (CheckDeclInExpr(*this, Loc, D, AcceptInvalidDecl)) {
@@ -3485,9 +3490,9 @@ ExprResult Sema::BuildDeclarationNameExpr(
     break;
   }
 
-  auto *E =
-      BuildDeclRefExpr(VD, type, valueKind, NameInfo, &SS, FoundD,
-                       /*FIXME: TemplateKWLoc*/ SourceLocation(), TemplateArgs);
+  auto *E = BuildDeclRefExpr(VD, type, valueKind, NameInfo, &SS, FoundD,
+                             /*FIXME: TemplateKWLoc*/ SourceLocation(),
+                             TemplateArgs, ConvertedArgs);
   // Clang AST consumers assume a DeclRefExpr refers to a valid decl. We
   // wrap a DeclRefExpr referring to an invalid decl with a dependent-type
   // RecoveryExpr to avoid follow-up semantic analysis (thus prevent bogus
@@ -6657,7 +6662,7 @@ ExprResult Sema::BuildCallExpr(Scope *Scope, Expr *Fn, SourceLocation LParenLoc,
         Fn = DeclRefExpr::Create(
             Context, FDecl->getQualifierLoc(), SourceLocation(), FDecl, false,
             SourceLocation(), FDecl->getType(), Fn->getValueKind(), FDecl,
-            nullptr, DRE->isNonOdrUse());
+            nullptr, nullptr, DRE->isNonOdrUse());
       }
     }
   } else if (auto *ME = dyn_cast<MemberExpr>(NakedFn))
@@ -9758,9 +9763,10 @@ Sema::CheckSingleAssignmentConstraints(QualType LHSType, ExprResult &CallerRHS,
     // As a set of extensions to C, we support overloading on functions. These
     // functions need to be resolved here.
     DeclAccessPair DAP;
+    const TemplateArgumentList *ConvertedArgs;
     if (FunctionDecl *FD = ResolveAddressOfOverloadedFunction(
-            RHS.get(), LHSType, /*Complain=*/false, DAP))
-      RHS = FixOverloadedFunctionReference(RHS.get(), DAP, FD);
+            RHS.get(), LHSType, /*Complain=*/false, DAP, ConvertedArgs))
+      RHS = FixOverloadedFunctionReference(RHS.get(), DAP, FD, ConvertedArgs);
     else
       return Incompatible;
   }
@@ -14246,14 +14252,19 @@ QualType Sema::CheckAddressOfOperand(ExprResult &OrigOp, SourceLocation OpLoc) {
       }
 
       OverloadExpr *Ovl = cast<OverloadExpr>(E);
-      if (isa<UnresolvedMemberExpr>(Ovl))
-        if (!ResolveSingleFunctionTemplateSpecialization(Ovl)) {
-          Diag(OpLoc, diag::err_invalid_form_pointer_member_function)
-            << OrigOp.get()->getSourceRange();
-          return QualType();
-        }
-
-      return Context.OverloadTy;
+      if (!isa<UnresolvedMemberExpr>(Ovl))
+        return Context.OverloadTy;
+      if (Ovl->hasExplicitTemplateArgs()) {
+        TemplateArgumentListInfo ExplicitTemplateArgs;
+        Ovl->copyTemplateArgumentsInto(ExplicitTemplateArgs);
+        const TemplateArgumentList *ConvertedArgs;
+        if (ResolveSingleFunctionTemplateSpecialization(
+                Ovl, ExplicitTemplateArgs, ConvertedArgs))
+          return Context.OverloadTy;
+      }
+      Diag(OpLoc, diag::err_invalid_form_pointer_member_function)
+          << OrigOp.get()->getSourceRange();
+      return QualType();
     }
 
     if (PTy->getKind() == BuiltinType::UnknownAny)
@@ -19473,7 +19484,8 @@ static ExprResult rebuildPotentialResultsAsNonOdrUsed(Sema &S, Expr *E,
         S.Context, DRE->getQualifierLoc(), DRE->getTemplateKeywordLoc(),
         DRE->getDecl(), DRE->refersToEnclosingVariableOrCapture(),
         DRE->getNameInfo(), DRE->getType(), DRE->getValueKind(),
-        DRE->getFoundDecl(), CopiedTemplateArgs(DRE), NOUR);
+        DRE->getFoundDecl(), CopiedTemplateArgs(DRE), DRE->getConvertedArgs(),
+        NOUR);
   }
 
   case Expr::FunctionParmPackExprClass: {
@@ -19519,8 +19531,8 @@ static ExprResult rebuildPotentialResultsAsNonOdrUsed(Sema &S, Expr *E,
           S.Context, Base.get(), ME->isArrow(), ME->getOperatorLoc(),
           ME->getQualifierLoc(), ME->getTemplateKeywordLoc(),
           ME->getMemberDecl(), ME->getFoundDecl(), ME->getMemberNameInfo(),
-          CopiedTemplateArgs(ME), ME->getType(), ME->getValueKind(),
-          ME->getObjectKind(), ME->isNonOdrUse());
+          CopiedTemplateArgs(ME), ME->getDeduced(), ME->getType(),
+          ME->getValueKind(), ME->getObjectKind(), ME->isNonOdrUse());
     }
 
     if (ME->getMemberDecl()->isCXXInstanceMember())
@@ -19537,7 +19549,8 @@ static ExprResult rebuildPotentialResultsAsNonOdrUsed(Sema &S, Expr *E,
         S.Context, ME->getBase(), ME->isArrow(), ME->getOperatorLoc(),
         ME->getQualifierLoc(), ME->getTemplateKeywordLoc(), ME->getMemberDecl(),
         ME->getFoundDecl(), ME->getMemberNameInfo(), CopiedTemplateArgs(ME),
-        ME->getType(), ME->getValueKind(), ME->getObjectKind(), NOUR);
+        ME->getDeduced(), ME->getType(), ME->getValueKind(),
+        ME->getObjectKind(), NOUR);
   }
 
   case Expr::BinaryOperatorClass: {
@@ -21191,7 +21204,8 @@ ExprResult Sema::CheckPlaceholderExpr(Expr *E) {
             FD, FD->getType(), VK_LValue, DRE->getNameInfo(),
             DRE->hasQualifier() ? &SS : nullptr, DRE->getFoundDecl(),
             DRE->getTemplateKeywordLoc(),
-            DRE->hasExplicitTemplateArgs() ? &TemplateArgs : nullptr);
+            DRE->hasExplicitTemplateArgs() ? &TemplateArgs : nullptr,
+            DRE->getConvertedArgs());
       }
     }
 

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -2847,7 +2847,10 @@ bool Sema::FindAllocationFunctions(SourceLocation StartLoc, SourceRange Range,
 
   FoundDelete.suppressDiagnostics();
 
-  SmallVector<std::pair<DeclAccessPair,FunctionDecl*>, 2> Matches;
+  SmallVector<
+      std::tuple<DeclAccessPair, FunctionDecl *, const TemplateArgumentList *>,
+      2>
+      Matches;
 
   // Whether we're looking for a placement operator delete is dictated
   // by whether we selected a placement operator new, not by whether
@@ -2897,6 +2900,7 @@ bool Sema::FindAllocationFunctions(SourceLocation StartLoc, SourceRange Range,
                              DEnd = FoundDelete.end();
          D != DEnd; ++D) {
       FunctionDecl *Fn = nullptr;
+      const TemplateArgumentList *ConvertedArgs = nullptr;
       if (FunctionTemplateDecl *FnTmpl =
               dyn_cast<FunctionTemplateDecl>((*D)->getUnderlyingDecl())) {
         // Perform template argument deduction to try to match the
@@ -2905,14 +2909,15 @@ bool Sema::FindAllocationFunctions(SourceLocation StartLoc, SourceRange Range,
         if (DeduceTemplateArguments(FnTmpl, nullptr, ExpectedFunctionType, Fn,
                                     Info) != TemplateDeductionResult::Success)
           continue;
+        ConvertedArgs = Info.takeSugared();
       } else
         Fn = cast<FunctionDecl>((*D)->getUnderlyingDecl());
 
       if (Context.hasSameType(adjustCCAndNoReturn(Fn->getType(),
                                                   ExpectedFunctionType,
-                                                  /*AdjustExcpetionSpec*/true),
+                                                  /*AdjustExcpetionSpec=*/true),
                               ExpectedFunctionType))
-        Matches.push_back(std::make_pair(D.getPair(), Fn));
+        Matches.push_back({D.getPair(), Fn, ConvertedArgs});
     }
 
     if (getLangOpts().CUDA)
@@ -2932,12 +2937,12 @@ bool Sema::FindAllocationFunctions(SourceLocation StartLoc, SourceRange Range,
         /*WantAlign*/ hasNewExtendedAlignment(*this, AllocElemType),
         &BestDeallocFns);
     if (Selected)
-      Matches.push_back(std::make_pair(Selected.Found, Selected.FD));
+      Matches.push_back({Selected.Found, Selected.FD, nullptr});
     else {
       // If we failed to select an operator, all remaining functions are viable
       // but ambiguous.
       for (auto Fn : BestDeallocFns)
-        Matches.push_back(std::make_pair(Fn.Found, Fn.FD));
+        Matches.push_back({Fn.Found, Fn.FD, nullptr});
     }
   }
 
@@ -2946,7 +2951,7 @@ bool Sema::FindAllocationFunctions(SourceLocation StartLoc, SourceRange Range,
   //   function, that function will be called; otherwise, no
   //   deallocation function will be called.
   if (Matches.size() == 1) {
-    OperatorDelete = Matches[0].second;
+    OperatorDelete = std::get<1>(Matches[0]);
 
     // C++1z [expr.new]p23:
     //   If the lookup finds a usual deallocation function (3.7.4.2)
@@ -2985,7 +2990,7 @@ bool Sema::FindAllocationFunctions(SourceLocation StartLoc, SourceRange Range,
     }
 
     CheckAllocationAccess(StartLoc, Range, FoundDelete.getNamingClass(),
-                          Matches[0].first);
+                          std::get<0>(Matches[0]));
   } else if (!Matches.empty()) {
     // We found multiple suitable operators. Per [expr.new]p20, that means we
     // call no 'operator delete' function, but we should at least warn the user.
@@ -2994,8 +2999,8 @@ bool Sema::FindAllocationFunctions(SourceLocation StartLoc, SourceRange Range,
       << DeleteName << AllocElemType;
 
     for (auto &Match : Matches)
-      Diag(Match.second->getLocation(),
-           diag::note_member_declared_here) << DeleteName;
+      Diag(std::get<1>(Match)->getLocation(), diag::note_member_declared_here)
+          << DeleteName;
   }
 
   return false;
@@ -4353,15 +4358,17 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
   // Resolve overloaded function references.
   if (Context.hasSameType(FromType, Context.OverloadTy)) {
     DeclAccessPair Found;
-    FunctionDecl *Fn = ResolveAddressOfOverloadedFunction(From, ToType,
-                                                          true, Found);
+    const TemplateArgumentList *ConvertedArgs;
+    FunctionDecl *Fn = ResolveAddressOfOverloadedFunction(From, ToType, true,
+                                                          Found, ConvertedArgs);
     if (!Fn)
       return ExprError();
 
     if (DiagnoseUseOfDecl(Fn, From->getBeginLoc()))
       return ExprError();
 
-    ExprResult Res = FixOverloadedFunctionReference(From, Found, Fn);
+    ExprResult Res =
+        FixOverloadedFunctionReference(From, Found, Fn, ConvertedArgs);
     if (Res.isInvalid())
       return ExprError();
 

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -935,13 +935,14 @@ MemberExpr *Sema::BuildMemberExpr(
     SourceLocation TemplateKWLoc, ValueDecl *Member, DeclAccessPair FoundDecl,
     bool HadMultipleCandidates, const DeclarationNameInfo &MemberNameInfo,
     QualType Ty, ExprValueKind VK, ExprObjectKind OK,
-    const TemplateArgumentListInfo *TemplateArgs) {
+    const TemplateArgumentListInfo *TemplateArgs,
+    const TemplateArgumentList *Deduced) {
   assert((!IsArrow || Base->isPRValue()) &&
          "-> base must be a pointer prvalue");
-  MemberExpr *E =
-      MemberExpr::Create(Context, Base, IsArrow, OpLoc, NNS, TemplateKWLoc,
-                         Member, FoundDecl, MemberNameInfo, TemplateArgs, Ty,
-                         VK, OK, getNonOdrUseReasonInCurrentContext(Member));
+  MemberExpr *E = MemberExpr::Create(
+      Context, Base, IsArrow, OpLoc, NNS, TemplateKWLoc, Member, FoundDecl,
+      MemberNameInfo, TemplateArgs, Deduced, Ty, VK, OK,
+      getNonOdrUseReasonInCurrentContext(Member));
   E->setHadMultipleCandidates(HadMultipleCandidates);
   MarkMemberReferenced(E);
 
@@ -1232,8 +1233,10 @@ Sema::BuildMemberReferenceExpr(Expr *BaseExpr, QualType BaseExprType,
       return ExprError();
     }
 
-    DeclResult VDecl = CheckVarTemplateId(VarTempl, TemplateKWLoc,
-                                          MemberNameInfo.getLoc(), *TemplateArgs);
+    const TemplateArgumentList *ConvertedArgs;
+    DeclResult VDecl =
+        CheckVarTemplateId(VarTempl, TemplateKWLoc, MemberNameInfo.getLoc(),
+                           *TemplateArgs, ConvertedArgs);
     if (VDecl.isInvalid())
       return ExprError();
 
@@ -1251,7 +1254,7 @@ Sema::BuildMemberReferenceExpr(Expr *BaseExpr, QualType BaseExprType,
                            SS.getWithLocInContext(Context), TemplateKWLoc, Var,
                            FoundDecl, /*HadMultipleCandidates=*/false,
                            MemberNameInfo, Var->getType().getNonReferenceType(),
-                           VK_LValue, OK_Ordinary, TemplateArgs);
+                           VK_LValue, OK_Ordinary, TemplateArgs, ConvertedArgs);
   }
 
   // We found something that we didn't expect. Complain.

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -3895,17 +3895,16 @@ bool InitializationSequence::isConstructorInitialization() const {
   return !Steps.empty() && Steps.back().Kind == SK_ConstructorInitialization;
 }
 
-void
-InitializationSequence
-::AddAddressOverloadResolutionStep(FunctionDecl *Function,
-                                   DeclAccessPair Found,
-                                   bool HadMultipleCandidates) {
+void InitializationSequence ::AddAddressOverloadResolutionStep(
+    FunctionDecl *Function, DeclAccessPair Found,
+    const TemplateArgumentList *ConvertedArgs, bool HadMultipleCandidates) {
   Step S;
   S.Kind = SK_ResolveAddressOfOverloadedFunction;
   S.Type = Function->getType();
   S.Function.HadMultipleCandidates = HadMultipleCandidates;
   S.Function.Function = Function;
   S.Function.FoundDecl = Found;
+  S.Function.ConvertedArgs = ConvertedArgs;
   Steps.push_back(S);
 }
 
@@ -4697,13 +4696,12 @@ ResolveOverloadedFunctionForReferenceBinding(Sema &S,
   if (S.Context.getCanonicalType(UnqualifiedSourceType) ==
         S.Context.OverloadTy) {
     DeclAccessPair Found;
+    const TemplateArgumentList *ConvertedArgs;
     bool HadMultipleCandidates = false;
-    if (FunctionDecl *Fn
-        = S.ResolveAddressOfOverloadedFunction(Initializer,
-                                               UnqualifiedTargetType,
-                                               false, Found,
-                                               &HadMultipleCandidates)) {
-      Sequence.AddAddressOverloadResolutionStep(Fn, Found,
+    if (FunctionDecl *Fn = S.ResolveAddressOfOverloadedFunction(
+            Initializer, UnqualifiedTargetType, false, Found, ConvertedArgs,
+            &HadMultipleCandidates)) {
+      Sequence.AddAddressOverloadResolutionStep(Fn, Found, ConvertedArgs,
                                                 HadMultipleCandidates);
       SourceType = Fn->getType();
       UnqualifiedSourceType = SourceType.getUnqualifiedType();
@@ -6879,12 +6877,14 @@ void InitializationSequence::InitializeFrom(Sema &S,
 
     AddPassByIndirectCopyRestoreStep(DestType, ShouldCopy);
   } else if (ICS.isBad()) {
+    const TemplateArgumentList *ConvertedArgs;
     if (isLibstdcxxPointerReturnFalseHack(S, Entity, Initializer))
       AddZeroInitializationStep(Entity.getType());
     else if (DeclAccessPair Found;
              Initializer->getType() == Context.OverloadTy &&
              !S.ResolveAddressOfOverloadedFunction(Initializer, DestType,
-                                                   /*Complain=*/false, Found))
+                                                   /*Complain=*/false, Found,
+                                                   ConvertedArgs))
       SetFailed(InitializationSequence::FK_AddressOfOverloadFailed);
     else if (Initializer->getType()->isFunctionType() &&
              isExprAnUnaddressableFunction(S, Initializer))
@@ -7914,9 +7914,9 @@ ExprResult InitializationSequence::Perform(Sema &S,
       S.CheckAddressOfMemberAccess(CurInit.get(), Step->Function.FoundDecl);
       if (S.DiagnoseUseOfDecl(Step->Function.FoundDecl, Kind.getLocation()))
         return ExprError();
-      CurInit = S.FixOverloadedFunctionReference(CurInit,
-                                                 Step->Function.FoundDecl,
-                                                 Step->Function.Function);
+      CurInit = S.FixOverloadedFunctionReference(
+          CurInit, Step->Function.FoundDecl, Step->Function.Function,
+          Step->Function.ConvertedArgs);
       // We might get back another placeholder expression if we resolved to a
       // builtin.
       if (!CurInit.isInvalid())
@@ -8795,11 +8795,13 @@ bool InitializationSequence::Diagnose(Sema &S,
 
     if (OnlyArg->getType() == S.Context.OverloadTy) {
       DeclAccessPair Found;
+      const TemplateArgumentList *ConvertedArgs;
       if (FunctionDecl *FD = S.ResolveAddressOfOverloadedFunction(
               OnlyArg, DestType.getNonReferenceType(), /*Complain=*/false,
-              Found)) {
-        if (Expr *Resolved =
-                S.FixOverloadedFunctionReference(OnlyArg, Found, FD).get())
+              Found, ConvertedArgs)) {
+        if (Expr *Resolved = S.FixOverloadedFunctionReference(OnlyArg, Found,
+                                                              FD, ConvertedArgs)
+                                 .get())
           OnlyArg = Resolved;
       }
     }
@@ -8877,10 +8879,9 @@ bool InitializationSequence::Diagnose(Sema &S,
 
   case FK_AddressOfOverloadFailed: {
     DeclAccessPair Found;
-    S.ResolveAddressOfOverloadedFunction(OnlyArg,
-                                         DestType.getNonReferenceType(),
-                                         true,
-                                         Found);
+    const TemplateArgumentList *ConvertedArgs;
+    S.ResolveAddressOfOverloadedFunction(
+        OnlyArg, DestType.getNonReferenceType(), true, Found, ConvertedArgs);
     break;
   }
 

--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -4198,7 +4198,8 @@ TemplateDeductionResult Sema::FinishTemplateArgumentDeduction(
 /// Gets the type of a function for template-argument-deducton
 /// purposes when it's considered as part of an overload set.
 static QualType GetTypeOfFunction(Sema &S, const OverloadExpr::FindResult &R,
-                                  FunctionDecl *Fn) {
+                                  FunctionDecl *Fn,
+                                  ArrayRef<TemplateArgument> Args) {
   // We may need to deduce the return type of the function now.
   if (S.getLangOpts().CPlusPlus14 && Fn->getReturnType()->isUndeducedType() &&
       S.DeduceReturnType(Fn, R.Expression->getExprLoc(), /*Diagnose*/ false))
@@ -4240,6 +4241,11 @@ ResolveOverloadForDeduction(Sema &S, TemplateParameterList *TemplateParams,
   if (R.IsAddressOfOperand)
     TDF |= TDF_IgnoreQualifiers;
 
+  // Gather the explicit template arguments, if any.
+  TemplateArgumentListInfo ExplicitTemplateArgs;
+  if (Ovl->hasExplicitTemplateArgs())
+    Ovl->copyTemplateArgumentsInto(ExplicitTemplateArgs);
+
   // C++0x [temp.deduct.call]p6:
   //   When P is a function type, pointer to function type, or pointer
   //   to member function type:
@@ -4249,31 +4255,29 @@ ResolveOverloadForDeduction(Sema &S, TemplateParameterList *TemplateParams,
       !ParamType->isMemberFunctionPointerType()) {
     if (Ovl->hasExplicitTemplateArgs()) {
       // But we can still look for an explicit specialization.
+      const TemplateArgumentList *ConvertedArgs;
       if (FunctionDecl *ExplicitSpec =
               S.ResolveSingleFunctionTemplateSpecialization(
-                  Ovl, /*Complain=*/false,
+                  Ovl, ExplicitTemplateArgs, ConvertedArgs, /*Complain=*/false,
                   /*Found=*/nullptr, FailedTSC,
                   /*ForTypeDeduction=*/true))
-        return GetTypeOfFunction(S, R, ExplicitSpec);
+        return GetTypeOfFunction(S, R, ExplicitSpec, ConvertedArgs->asArray());
     }
 
     DeclAccessPair DAP;
     if (FunctionDecl *Viable =
             S.resolveAddressOfSingleOverloadCandidate(Arg, DAP))
-      return GetTypeOfFunction(S, R, Viable);
+      return GetTypeOfFunction(S, R, Viable, /*Args=*/{});
 
     return {};
   }
 
-  // Gather the explicit template arguments, if any.
-  TemplateArgumentListInfo ExplicitTemplateArgs;
-  if (Ovl->hasExplicitTemplateArgs())
-    Ovl->copyTemplateArgumentsInto(ExplicitTemplateArgs);
   QualType Match;
   for (UnresolvedSetIterator I = Ovl->decls_begin(),
          E = Ovl->decls_end(); I != E; ++I) {
     NamedDecl *D = (*I)->getUnderlyingDecl();
 
+    const TemplateArgumentList *ConvertedArgs = nullptr;
     if (FunctionTemplateDecl *FunTmpl = dyn_cast<FunctionTemplateDecl>(D)) {
       //   - If the argument is an overload set containing one or more
       //     function templates, the parameter is treated as a
@@ -4290,10 +4294,12 @@ ResolveOverloadForDeduction(Sema &S, TemplateParameterList *TemplateParams,
         continue;
 
       D = Specialization;
+      ConvertedArgs = Info.takeSugared();
     }
 
     FunctionDecl *Fn = cast<FunctionDecl>(D);
-    QualType ArgType = GetTypeOfFunction(S, R, Fn);
+    QualType ArgType = GetTypeOfFunction(
+        S, R, Fn, ConvertedArgs ? ConvertedArgs->asArray() : std::nullopt);
     if (ArgType.isNull()) continue;
 
     // Function-to-pointer conversion.

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1635,6 +1635,7 @@ namespace {
       }
       return Type;
     }
+    using inherited::TransformTemplateArgument;
     // Override the default version to handle a rewrite-template-arg-pack case
     // for building a deduction guide.
     bool TransformTemplateArgument(const TemplateArgumentLoc &Input,

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -597,6 +597,9 @@ public:
                         NamedDecl *FirstQualifierInScope = nullptr,
                         bool AllowInjectedClassName = false);
 
+  std::optional<TemplateArgument>
+  TransformTemplateArgument(const TemplateArgument &Arg);
+
   /// Transform the given template argument.
   ///
   /// By default, this operation transforms the type, expression, or
@@ -2707,11 +2710,12 @@ public:
                                 ValueDecl *VD,
                                 const DeclarationNameInfo &NameInfo,
                                 NamedDecl *Found,
-                                TemplateArgumentListInfo *TemplateArgs) {
+                                TemplateArgumentListInfo *TemplateArgs,
+                                const TemplateArgumentList *ConvertedArgs) {
     CXXScopeSpec SS;
     SS.Adopt(QualifierLoc);
     return getSema().BuildDeclarationNameExpr(SS, NameInfo, VD, Found,
-                                              TemplateArgs);
+                                              TemplateArgs, ConvertedArgs);
   }
 
   /// Build a new expression in parentheses.
@@ -4827,6 +4831,80 @@ TreeTransform<Derived>::TransformTemplateName(CXXScopeSpec &SS,
   llvm_unreachable("overloaded function decl survived to here");
 }
 
+template <typename Derived>
+std::optional<TemplateArgument>
+TreeTransform<Derived>::TransformTemplateArgument(const TemplateArgument &Arg) {
+  switch (auto Kind = Arg.getKind()) {
+  case TemplateArgument::Null:
+    llvm_unreachable("Unexpected TemplateArgument Null");
+  case TemplateArgument::Expression:
+    llvm_unreachable("Unexpected TemplateArgument Expr");
+
+  case TemplateArgument::Pack: {
+    SmallVector<TemplateArgument, 4> Args(Arg.getPackAsArray());
+    for (auto &I : Args) {
+      const auto Arg = getDerived().TransformTemplateArgument(I);
+      if (!Arg)
+        return std::nullopt;
+      I = *Arg;
+    }
+    return TemplateArgument(
+        TemplateArgumentList::CreateCopy(getSema().Context, Args)->asArray());
+  }
+
+  case TemplateArgument::Integral:
+  case TemplateArgument::NullPtr:
+  case TemplateArgument::Declaration:
+  case TemplateArgument::StructuralValue: {
+    QualType T = Arg.getNonTypeTemplateArgumentType();
+    QualType NewT = getDerived().TransformType(T);
+    if (NewT.isNull())
+      return std::nullopt;
+
+    ValueDecl *D = Arg.getKind() == TemplateArgument::Declaration
+                       ? Arg.getAsDecl()
+                       : nullptr;
+    ValueDecl *NewD = D ? cast_or_null<ValueDecl>(getDerived().TransformDecl(
+                              getDerived().getBaseLocation(), D))
+                        : nullptr;
+    if (D && !NewD)
+      return std::nullopt;
+    if (NewT == T && D == NewD)
+      return Arg;
+    if (Kind == TemplateArgument::Integral)
+      return TemplateArgument(getSema().Context, Arg.getAsIntegral(), NewT);
+    if (Kind == TemplateArgument::NullPtr)
+      return TemplateArgument(NewT, /*IsNullPtr=*/true);
+    if (Kind == TemplateArgument::StructuralValue)
+      return TemplateArgument(getSema().Context, NewT,
+                              Arg.getAsStructuralValue());
+    assert(Kind == TemplateArgument::Declaration);
+    return TemplateArgument(NewD, NewT);
+  }
+  case TemplateArgument::Type:
+    if (QualType T = getDerived().TransformType(Arg.getAsType()); !T.isNull())
+      return TemplateArgument(T);
+    return std::nullopt;
+  case TemplateArgument::Template: {
+    CXXScopeSpec SS;
+    if (TemplateName Template = getDerived().TransformTemplateName(
+            SS, Arg.getAsTemplate(), SourceLocation());
+        !Template.isNull())
+      return TemplateArgument(Template);
+    return std::nullopt;
+  }
+  case TemplateArgument::TemplateExpansion: {
+    CXXScopeSpec SS;
+    if (TemplateName Template = getDerived().TransformTemplateName(
+            SS, Arg.getAsTemplateOrTemplatePattern(), SourceLocation());
+        !Template.isNull())
+      return TemplateArgument(Template, Arg.getNumTemplateExpansions());
+    return std::nullopt;
+  }
+  }
+  llvm_unreachable("Unexpected Template Kind");
+}
+
 template<typename Derived>
 void TreeTransform<Derived>::InventTemplateArgumentLoc(
                                          const TemplateArgument &Arg,
@@ -4848,45 +4926,15 @@ bool TreeTransform<Derived>::TransformTemplateArgument(
   case TemplateArgument::Integral:
   case TemplateArgument::NullPtr:
   case TemplateArgument::Declaration:
-  case TemplateArgument::StructuralValue: {
+  case TemplateArgument::StructuralValue:
     // Transform a resolved template argument straight to a resolved template
     // argument. We get here when substituting into an already-substituted
     // template type argument during concept satisfaction checking.
-    QualType T = Arg.getNonTypeTemplateArgumentType();
-    QualType NewT = getDerived().TransformType(T);
-    if (NewT.isNull())
-      return true;
-
-    ValueDecl *D = Arg.getKind() == TemplateArgument::Declaration
-                       ? Arg.getAsDecl()
-                       : nullptr;
-    ValueDecl *NewD = D ? cast_or_null<ValueDecl>(getDerived().TransformDecl(
-                              getDerived().getBaseLocation(), D))
-                        : nullptr;
-    if (D && !NewD)
-      return true;
-
-    if (NewT == T && D == NewD)
-      Output = Input;
-    else if (Arg.getKind() == TemplateArgument::Integral)
-      Output = TemplateArgumentLoc(
-          TemplateArgument(getSema().Context, Arg.getAsIntegral(), NewT),
-          TemplateArgumentLocInfo());
-    else if (Arg.getKind() == TemplateArgument::NullPtr)
-      Output = TemplateArgumentLoc(TemplateArgument(NewT, /*IsNullPtr=*/true),
-                                   TemplateArgumentLocInfo());
-    else if (Arg.getKind() == TemplateArgument::Declaration)
-      Output = TemplateArgumentLoc(TemplateArgument(NewD, NewT),
-                                   TemplateArgumentLocInfo());
-    else if (Arg.getKind() == TemplateArgument::StructuralValue)
-      Output = TemplateArgumentLoc(
-          TemplateArgument(getSema().Context, NewT, Arg.getAsStructuralValue()),
-          TemplateArgumentLocInfo());
-    else
-      llvm_unreachable("unexpected template argument kind");
-
-    return false;
-  }
+    if (const auto Out = getDerived().TransformTemplateArgument(Arg)) {
+      Output = TemplateArgumentLoc(*Out, TemplateArgumentLocInfo());
+      return false;
+    }
+    return true;
 
   case TemplateArgument::Type: {
     TypeSourceInfo *DI = Input.getTypeSourceInfo();
@@ -7368,6 +7416,7 @@ QualType TreeTransform<Derived>::TransformTemplateSpecializationType(
             ArgIterator(*this, ConvertedArgs.begin()),
             ArgIterator(*this, ConvertedArgs.end()), NewTemplateArgs))
       return QualType();
+    assert(NewTemplateArgs.size() != 0);
   } else {
     using ArgIterator =
         TemplateArgumentLocContainerIterator<TemplateSpecializationTypeLoc>;
@@ -12881,9 +12930,22 @@ TreeTransform<Derived>::TransformDeclRefExpr(DeclRefExpr *E) {
                                                 TransArgs))
       return ExprError();
   }
+  const TemplateArgumentList *NewConvertedArgs = nullptr;
+  if (const TemplateArgumentList *OldConvertedArgs = E->getConvertedArgs()) {
+    assert(OldConvertedArgs->size() != 0);
+    SmallVector<TemplateArgument, 4> NewArgs(OldConvertedArgs->asArray());
+    for (auto I : NewArgs) {
+      const auto Arg = getDerived().TransformTemplateArgument(I);
+      if (!Arg)
+        return ExprError();
+      I = *Arg;
+    }
+    NewConvertedArgs =
+        TemplateArgumentList::CreateCopy(getSema().Context, NewArgs);
+  }
 
-  return getDerived().RebuildDeclRefExpr(QualifierLoc, ND, NameInfo,
-                                         Found, TemplateArgs);
+  return getDerived().RebuildDeclRefExpr(QualifierLoc, ND, NameInfo, Found,
+                                         TemplateArgs, NewConvertedArgs);
 }
 
 template<typename Derived>

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -9798,6 +9798,15 @@ void ASTRecordReader::readTemplateArgumentList(
     TemplArgs.push_back(readTemplateArgument(Canonicalize));
 }
 
+const TemplateArgumentList *
+ASTRecordReader::readTemplateArgumentList(bool Canonicalize) {
+  SmallVector<TemplateArgument, 8> Args;
+  readTemplateArgumentList(Args, Canonicalize);
+  if (Args.size() == 0)
+    return nullptr;
+  return TemplateArgumentList::CreateCopy(getContext(), Args);
+}
+
 /// Read a UnresolvedSet structure.
 void ASTRecordReader::readUnresolvedSet(LazyASTUnresolvedSet &Set) {
   unsigned NumDecls = readInt();

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -623,6 +623,7 @@ void ASTStmtReader::VisitDeclRefExpr(DeclRefExpr *E) {
   E->DeclRefExprBits.HasTemplateKWAndArgsInfo =
       CurrentUnpackingBits->getNextBit();
   E->DeclRefExprBits.CapturedByCopyInLambdaWithExplicitObjectParameter = false;
+
   unsigned NumTemplateArgs = 0;
   if (E->hasTemplateKWAndArgsInfo())
     NumTemplateArgs = Record.readInt();
@@ -640,6 +641,7 @@ void ASTStmtReader::VisitDeclRefExpr(DeclRefExpr *E) {
         E->getTrailingObjects<TemplateArgumentLoc>(), NumTemplateArgs);
 
   E->D = readDeclAs<ValueDecl>();
+  E->ConvertedArgs = Record.readTemplateArgumentList();
   E->setLocation(readSourceLocation());
   E->DNLoc = Record.readDeclarationNameLoc(E->getDecl()->getDeclName());
 }
@@ -1072,6 +1074,7 @@ void ASTStmtReader::VisitMemberExpr(MemberExpr *E) {
   E->MemberExprBits.NonOdrUseReason =
       CurrentUnpackingBits->getNextBits(/*Width=*/2);
   E->MemberExprBits.OperatorLoc = Record.readSourceLocation();
+  E->Deduced = Record.readTemplateArgumentList();
 
   if (HasQualifier)
     new (E->getTrailingObjects<NestedNameSpecifierLoc>())

--- a/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -2786,6 +2786,7 @@ void ASTWriter::WriteDeclAbbrevs() {
   // GetDeclFound, HasQualifier and ExplicitTemplateArgs should be 0.
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 5));
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // DeclRef
+  Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 1)); // ConvertedArgs
   Abv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // Location
   DeclRefExprAbbrev = Stream.EmitAbbrev(std::move(Abv));
 


### PR DESCRIPTION
WIP - Not ready for review

This keeps around in expressions the sugared converted arguments. This is a pre-requisite for adding some additional users of the resugaring transform.

Differential Revision: https://reviews.llvm.org/D134115