### PR TITLE
[clang] resugar decltype of MemberExpr

### DIFF
--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -616,6 +616,10 @@ protected:
     LLVM_PREFERRED_TYPE(NonOdrUseReason)
     unsigned NonOdrUseReason : 2;
 
+    /// Consider a different type for the MemberDecl this MemberExpr refers to.
+    LLVM_PREFERRED_TYPE(bool)
+    unsigned HasResugaredDeclType : 1;
+
     /// This is the location of the -> or . in the expression.
     SourceLocation OperatorLoc;
   };

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -8709,7 +8709,8 @@ public:
       NestedNameSpecifierLoc NNS, SourceLocation TemplateKWLoc,
       ValueDecl *Member, DeclAccessPair FoundDecl, bool HadMultipleCandidates,
       const DeclarationNameInfo &MemberNameInfo, QualType Ty, ExprValueKind VK,
-      ExprObjectKind OK, const TemplateArgumentListInfo *TemplateArgs = nullptr,
+      ExprObjectKind OK, QualType DeclType = QualType(),
+      const TemplateArgumentListInfo *TemplateArgs = nullptr,
       const TemplateArgumentList *Deduced = nullptr);
 
   // Check whether the declarations we found through a nested-name
@@ -8758,7 +8759,7 @@ public:
   ExprResult BuildFieldReferenceExpr(Expr *BaseExpr, bool IsArrow,
                                      SourceLocation OpLoc,
                                      const NestedNameSpecifierLoc &NNS,
-                                     FieldDecl *Field, QualType FieldType,
+                                     FieldDecl *Field, QualType FieldDeclType,
                                      DeclAccessPair FoundDecl,
                                      const DeclarationNameInfo &MemberNameInfo);
 
@@ -14013,6 +14014,7 @@ public:
   QualType resugar(const Type *Base, NamedDecl *ND,
                    ArrayRef<TemplateArgument> Args, QualType T);
   QualType resugar(DeclRefExpr *DRE, ValueDecl *VD);
+  QualType resugar(MemberExpr *ME, ValueDecl *VD);
 
   /// Performs template instantiation for all implicit template
   /// instantiations we have seen until this point.

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -8452,6 +8452,7 @@ ExpectedStmt ASTNodeImporter::VisitMemberExpr(MemberExpr *E) {
   auto ToDecl = importChecked(Err, E->getFoundDecl().getDecl());
   auto ToName = importChecked(Err, E->getMemberNameInfo().getName());
   auto ToLoc = importChecked(Err, E->getMemberNameInfo().getLoc());
+  auto ToDeclType = importChecked(Err, E->getDeclType());
   if (Err)
     return std::move(Err);
 
@@ -8473,7 +8474,7 @@ ExpectedStmt ASTNodeImporter::VisitMemberExpr(MemberExpr *E) {
                             ToOperatorLoc, ToQualifierLoc, ToTemplateKeywordLoc,
                             ToMemberDecl, ToFoundDecl, ToMemberNameInfo,
                             ResInfo, ToDeduced, ToType, E->getValueKind(),
-                            E->getObjectKind(), E->isNonOdrUse());
+                            ToDeclType, E->getObjectKind(), E->isNonOdrUse());
 }
 
 ExpectedStmt

--- a/clang/lib/Analysis/BodyFarm.cpp
+++ b/clang/lib/Analysis/BodyFarm.cpp
@@ -232,7 +232,7 @@ MemberExpr *ASTMaker::makeMemberExpression(Expr *base, ValueDecl *MemberDecl,
       SourceLocation(), MemberDecl, FoundDecl,
       DeclarationNameInfo(MemberDecl->getDeclName(), SourceLocation()),
       /* TemplateArgumentListInfo=*/nullptr, /*Deduced=*/nullptr,
-      MemberDecl->getType(), ValueKind, OK_Ordinary, NOUR_None);
+      MemberDecl->getType(), ValueKind, QualType(), OK_Ordinary, NOUR_None);
 }
 
 ValueDecl *ASTMaker::findMemberField(const RecordDecl *RD, StringRef Name) {

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -1867,7 +1867,7 @@ static DeclRefExpr *tryToConvertMemberExprToDeclRefExpr(CodeGenFunction &CGF,
     return DeclRefExpr::Create(
         CGF.getContext(), NestedNameSpecifierLoc(), SourceLocation(), VD,
         /*RefersToEnclosingVariableOrCapture=*/false, ME->getExprLoc(),
-        ME->getType(), ME->getValueKind(), QualType(), nullptr, nullptr,
+        ME->getType(), ME->getValueKind(), ME->getDeclType(), nullptr, nullptr,
         nullptr, ME->isNonOdrUse());
   }
   return nullptr;

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -19537,7 +19537,8 @@ static ExprResult rebuildPotentialResultsAsNonOdrUsed(Sema &S, Expr *E,
           ME->getQualifierLoc(), ME->getTemplateKeywordLoc(),
           ME->getMemberDecl(), ME->getFoundDecl(), ME->getMemberNameInfo(),
           CopiedTemplateArgs(ME), ME->getDeduced(), ME->getType(),
-          ME->getValueKind(), ME->getObjectKind(), ME->isNonOdrUse());
+          ME->getValueKind(), ME->getDeclType(), ME->getObjectKind(),
+          ME->isNonOdrUse());
     }
 
     if (ME->getMemberDecl()->isCXXInstanceMember())
@@ -19554,7 +19555,7 @@ static ExprResult rebuildPotentialResultsAsNonOdrUsed(Sema &S, Expr *E,
         S.Context, ME->getBase(), ME->isArrow(), ME->getOperatorLoc(),
         ME->getQualifierLoc(), ME->getTemplateKeywordLoc(), ME->getMemberDecl(),
         ME->getFoundDecl(), ME->getMemberNameInfo(), CopiedTemplateArgs(ME),
-        ME->getDeduced(), ME->getType(), ME->getValueKind(),
+        ME->getDeduced(), ME->getType(), ME->getValueKind(), ME->getDeclType(),
         ME->getObjectKind(), NOUR);
   }
 
@@ -19905,17 +19906,9 @@ static void DoMarkVarDeclReferenced(
             DRE->setType(SemaRef.resugar(DRE, DRE->getDecl()));
           DRE->recomputeDependency();
         } else if (auto *ME = dyn_cast_or_null<MemberExpr>(E)) {
-          ME->setMemberDecl(ME->getMemberDecl());
-          CXXScopeSpec SS;
-          SS.Adopt(ME->getQualifierLoc());
-          assert(ME->template_arguments().size() == 0 ||
-                 ME->getDeduced() != nullptr);
-          QualType T =
-              ME->getDeduced()
-                  ? SemaRef.resugar(SS.getScopeRep(), ME->getMemberDecl(),
-                                    ME->getDeduced()->asArray(), ME->getType())
-                  : SemaRef.resugar(SS.getScopeRep(), ME->getType());
-          ME->setType(T);
+          if (ME->getType()->isUndeducedType())
+            ME->setType(SemaRef.resugar(ME, ME->getMemberDecl()));
+          ME->recomputeDependency();
         }
       } else if (FirstInstantiation) {
         SemaRef.PendingInstantiations

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -16645,13 +16645,14 @@ Sema::FixOverloadedFunctionReference(Expr *E, DeclAccessPair Found,
     } else
       Base = MemExpr->getBase();
 
+    QualType DeclType = Deduced ? resugar(BasePointeeType, Fn,
+                                          Deduced->asArray(), Fn->getType())
+                                : resugar(BasePointeeType, Fn->getType());
     ExprValueKind valueKind;
     QualType Type;
     if (cast<CXXMethodDecl>(Fn)->isStatic()) {
       valueKind = VK_LValue;
-      Type = Deduced ? resugar(BasePointeeType, Fn, Deduced->asArray(),
-                               Fn->getType())
-                     : resugar(BasePointeeType, Fn->getType());
+      Type = DeclType;
     } else {
       valueKind = VK_PRValue;
       Type = Context.BoundMemberTy;
@@ -16661,7 +16662,7 @@ Sema::FixOverloadedFunctionReference(Expr *E, DeclAccessPair Found,
         Base, MemExpr->isArrow(), MemExpr->getOperatorLoc(),
         MemExpr->getQualifierLoc(), MemExpr->getTemplateKeywordLoc(), Fn, Found,
         /*HadMultipleCandidates=*/true, MemExpr->getMemberNameInfo(), Type,
-        valueKind, OK_Ordinary, TemplateArgs, Deduced);
+        valueKind, OK_Ordinary, DeclType, TemplateArgs, Deduced);
   }
 
   llvm_unreachable("Invalid reference to overloaded function");

--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -948,6 +948,17 @@ QualType Sema::resugar(DeclRefExpr *DRE, ValueDecl *VD) {
   DRE->setDeclType(NewT);
   return NewT;
 }
+QualType Sema::resugar(MemberExpr *ME, ValueDecl *VD) {
+  assert(ME->template_arguments().size() == 0 || ME->getDeduced() != nullptr);
+  const NestedNameSpecifier *NNS =
+      ME->getQualifierLoc().getNestedNameSpecifier();
+  QualType T = VD->getType();
+  QualType NewT = ME->getDeduced()
+                      ? SemaRef.resugar(NNS, VD, ME->getDeduced()->asArray(), T)
+                      : SemaRef.resugar(NNS, T);
+  ME->setDeclType(NewT);
+  return NewT;
+}
 
 /// \brief Determine whether the declaration found is acceptable as the name
 /// of a template and, if so, return that template declaration. Otherwise,

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -9622,7 +9622,7 @@ QualType Sema::getDecltypeForExpr(Expr *E) {
   if (const auto *ME = dyn_cast<MemberExpr>(IDExpr)) {
     if (const auto *VD = ME->getMemberDecl())
       if (isa<FieldDecl>(VD) || isa<VarDecl>(VD))
-        return VD->getType();
+        return ME->getDeclType();
   } else if (const auto *IR = dyn_cast<ObjCIvarRefExpr>(IDExpr)) {
     return IR->getDecl()->getType();
   } else if (const auto *PR = dyn_cast<ObjCPropertyRefExpr>(IDExpr)) {

--- a/clang/lib/Serialization/ASTReaderStmt.cpp
+++ b/clang/lib/Serialization/ASTReaderStmt.cpp
@@ -1064,6 +1064,7 @@ void ASTStmtReader::VisitMemberExpr(MemberExpr *E) {
   bool HasQualifier = CurrentUnpackingBits->getNextBit();
   bool HasFoundDecl = CurrentUnpackingBits->getNextBit();
   bool HasTemplateInfo = CurrentUnpackingBits->getNextBit();
+  bool HasResugaredDeclType = CurrentUnpackingBits->getNextBit();
   unsigned NumTemplateArgs = Record.readInt();
 
   E->Base = Record.readSubExpr();
@@ -1074,6 +1075,7 @@ void ASTStmtReader::VisitMemberExpr(MemberExpr *E) {
   E->MemberExprBits.HasQualifier = HasQualifier;
   E->MemberExprBits.HasFoundDecl = HasFoundDecl;
   E->MemberExprBits.HasTemplateKWAndArgsInfo = HasTemplateInfo;
+  E->MemberExprBits.HasResugaredDeclType = HasResugaredDeclType;
   E->MemberExprBits.HadMultipleCandidates = CurrentUnpackingBits->getNextBit();
   E->MemberExprBits.NonOdrUseReason =
       CurrentUnpackingBits->getNextBits(/*Width=*/2);
@@ -1094,6 +1096,9 @@ void ASTStmtReader::VisitMemberExpr(MemberExpr *E) {
     ReadTemplateKWAndArgsInfo(
         *E->getTrailingObjects<ASTTemplateKWAndArgsInfo>(),
         E->getTrailingObjects<TemplateArgumentLoc>(), NumTemplateArgs);
+
+  if (HasResugaredDeclType)
+    *E->getTrailingObjects<QualType>() = Record.readQualType();
 }
 
 void ASTStmtReader::VisitObjCIsaExpr(ObjCIsaExpr *E) {
@@ -3295,9 +3300,11 @@ Stmt *ASTReader::ReadStmtFromStream(ModuleFile &F) {
       bool HasQualifier = ExprMemberBits.getNextBit();
       bool HasFoundDecl = ExprMemberBits.getNextBit();
       bool HasTemplateInfo = ExprMemberBits.getNextBit();
+      bool HasResugaredDeclType = ExprMemberBits.getNextBit();
       unsigned NumTemplateArgs = Record[ASTStmtReader::NumExprFields + 1];
       S = MemberExpr::CreateEmpty(Context, HasQualifier, HasFoundDecl,
-                                  HasTemplateInfo, NumTemplateArgs);
+                                  HasTemplateInfo, NumTemplateArgs,
+                                  HasResugaredDeclType);
       break;
     }
 

--- a/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -1009,6 +1009,7 @@ void ASTStmtWriter::VisitMemberExpr(MemberExpr *E) {
   CurrentPackingBits.addBit(HasQualifier);
   CurrentPackingBits.addBit(HasFoundDecl);
   CurrentPackingBits.addBit(HasTemplateInfo);
+  CurrentPackingBits.addBit(E->HasResugaredDeclType());
   Record.push_back(NumTemplateArgs);
 
   Record.AddStmt(E->getBase());
@@ -1037,6 +1038,9 @@ void ASTStmtWriter::VisitMemberExpr(MemberExpr *E) {
   if (HasTemplateInfo)
     AddTemplateKWAndArgsInfo(*E->getTrailingObjects<ASTTemplateKWAndArgsInfo>(),
                              E->getTrailingObjects<TemplateArgumentLoc>());
+
+  if (E->HasResugaredDeclType())
+    Record.writeQualType(E->getDeclType());
 
   Code = serialization::EXPR_MEMBER;
 }

--- a/clang/test/Sema/Resugar/resugar-expr.cpp
+++ b/clang/test/Sema/Resugar/resugar-expr.cpp
@@ -50,9 +50,8 @@ template <class A1> struct A {
   ();
 };
 
-// FIXME: resugar this
 Z x1 = decltype(A<Int>().a){}();
-// expected-error@-1 {{with an rvalue of type 'int'}}
+// expected-error@-1 {{with an rvalue of type 'Int' (aka 'int')}}
 } // namespace t5
 
 namespace t6 {


### PR DESCRIPTION
This keeps around the resugared DeclType for MemberExpr, which is otherwise partially lost as the expression type removes top level references.

This helps 'decltype' resugaring work without any loss of information.