### PR TITLE
[flang] Fix missed case of symbol renaming in module file generation

### DIFF
--- a/flang/lib/Evaluate/formatting.cpp
+++ b/flang/lib/Evaluate/formatting.cpp
@@ -129,7 +129,8 @@ llvm::raw_ostream &Constant<Type<TypeCategory::Character, KIND>>::AsFortran(
 llvm::raw_ostream &EmitVar(llvm::raw_ostream &o, const Symbol &symbol,
     std::optional<parser::CharBlock> name = std::nullopt) {
   const auto &renamings{symbol.owner().context().moduleFileOutputRenamings()};
-  if (auto iter{renamings.find(&symbol)}; iter != renamings.end()) {
+  if (auto iter{renamings.find(&symbol.GetUltimate())};
+      iter != renamings.end()) {
     return o << iter->second.ToString();
   } else if (name) {
     return o << name->ToString();

--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -348,7 +348,7 @@ void ModFileWriter::PrepareRenamings(const Scope &scope) {
     uses_ << DEREF(sMod->symbol()).name() << ",only:";
     if (rename != s->name()) {
       uses_ << rename << "=>";
-      renamings.emplace(&*s, rename);
+      renamings.emplace(&s->GetUltimate(), rename);
     }
     uses_ << s->name() << '\n';
     useExtraAttrs_ << "private::" << rename << '\n';

--- a/flang/test/Semantics/bug132435.f90
+++ b/flang/test/Semantics/bug132435.f90
@@ -1,0 +1,85 @@
+! RUN: %python %S/test_modfile.py %s %flang_fc1
+module m1
+  type foo
+    integer :: c1 = 123
+  end type
+end
+
+module m2
+  use m1, only: foo
+  type baz
+    type(foo) :: d = foo()
+  end type
+  type bar
+    type(baz) :: e = baz()
+  end type
+end
+
+module m3
+  use m1, only: m1foo => foo
+  type foo
+    type(m1foo), private :: c2 = m1foo()
+  end type
+end
+
+module m4
+  use m2, only: m3foo => foo
+  type foo
+    type(m3foo), private :: c3 = m3foo()
+  end type
+end
+
+module m5
+  use m2, only: m2bar => bar
+  use m4, only: foo
+  type blah
+    type(m2bar) :: f = m2bar()
+  end type
+end
+
+!Expect: m1.mod
+!module m1
+!type::foo
+!integer(4)::c1=123_4
+!end type
+!end
+
+!Expect: m2.mod
+!module m2
+!use m1,only:foo
+!type::baz
+!type(foo)::d=foo(c1=123_4)
+!end type
+!type::bar
+!type(baz)::e=baz(d=foo(c1=123_4))
+!end type
+!end
+
+!Expect: m3.mod
+!module m3
+!use m1,only:m1foo=>foo
+!type::foo
+!type(m1foo),private::c2=m1foo(c1=123_4)
+!end type
+!end
+
+!Expect: m4.mod
+!module m4
+!use m2,only:m3foo=>foo
+!type::foo
+!type(m3foo),private::c3=m3foo(c1=123_4)
+!end type
+!end
+
+!Expect: m5.mod
+!module m5
+!use m2,only:m2$foo=>foo
+!use m2,only:baz
+!use m2,only:m2bar=>bar
+!use m4,only:foo
+!private::m2$foo
+!private::baz
+!type::blah
+!type(m2bar)::f=m2bar(e=baz(d=m2$foo(c1=123_4)))
+!end type
+!end


### PR DESCRIPTION
The map of symbols requiring new local aliases for USE association needs to use the symbols' ultimate resolutions to avoid missing cases that can arise in convoluted codes with lots of confusing renamings.

Fixes https://github.com/llvm/llvm-project/issues/132435.