### PR TITLE
[clang][CI] Reuse build dir between C++26 and modules build of runtimes

### DIFF
--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -110,7 +110,11 @@ if [[ "${runtimes}" != "" ]]; then
 
   echo "--- cmake runtimes clang modules"
 
-  rm -rf "${RUNTIMES_BUILD_DIR}"
+  # We don't need to do a clean build of runtimes, because LIBCXX_TEST_PARAMS
+  # and LIBCXXABI_TEST_PARAMS only affect lit configuration, which successfully
+  # propagates without a clean build. Other that those two variables, builds
+  # are supposed to be the same.
+
   cmake -S "${MONOREPO_ROOT}/runtimes" -B "${RUNTIMES_BUILD_DIR}" -GNinja \
       -D CMAKE_C_COMPILER="${INSTALL_DIR}/bin/clang" \
       -D CMAKE_CXX_COMPILER="${INSTALL_DIR}/bin/clang++" \


### PR DESCRIPTION
Between C++26 and Clang modules build of runtimes, which are used as an additional testing for Clang, the only difference are `LIBCXX_TEST_PARAMS` and `LIBCXXABI_TEST_PARAMS`. Both of them are transformed into actual lit configuration lines, and put into `SERIALIZED_LIT_PARAMS`, which end up in `libcxx/test/cmake-bridge.cfg` via `configure_file` command. Notably, it seems that they are not used in any other way.

I checked that if those variables are changed, subsequent runs of CMake configuration step regenerate `cmake-bridge.cfg` with the new values. Which means that we don't need to do clean builds for every runtimes configuration we want to test.

I hope that together with #131913, this will be enough to alleviate Linux CI pains we're having, and we wouldn't have to make a tough choice between C++26 and Clang modules builds for pre-merge CI.