### PR TITLE
[RISCV] Remove the mucounteren alternate name for CSR 0x320.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSystemOperands.td
+++ b/llvm/lib/Target/RISCV/RISCVSystemOperands.td
@@ -301,8 +301,6 @@ foreach i = 3...31 in
 // Machine Counter Setup
 //===----------------------------------------------------------------------===//
 def : SysReg<"mcountinhibit", 0x320>;
-let isAltName = 1 in
-def : SysReg<"mucounteren", 0x320>;
 
 // mhpmevent3-mhpmevent31 at 0x323-0x33F.
 foreach i = 3...31 in

--- a/llvm/test/MC/RISCV/machine-csr-names.s
+++ b/llvm/test/MC/RISCV/machine-csr-names.s
@@ -1972,20 +1972,6 @@ csrrs t1, mcountinhibit, zero
 # uimm12
 csrrs t2, 0x320, zero
 
-# mucounteren
-# name
-# CHECK-INST: csrrs t1, mcountinhibit, zero
-# CHECK-ENC:  encoding: [0x73,0x23,0x00,0x32]
-# CHECK-INST-ALIAS: csrr t1, mcountinhibit
-# uimm12
-# CHECK-INST: csrrs t2, mcountinhibit, zero
-# CHECK-ENC:  encoding: [0xf3,0x23,0x00,0x32]
-# CHECK-INST-ALIAS: csrr t2, mcountinhibit
-# name
-csrrs t1, mucounteren, zero
-# uimm12
-csrrs t2, 0x320, zero
-
 # mhpmevent3
 # name
 # CHECK-INST: csrrs t1, mhpmevent3, zero


### PR DESCRIPTION
This is the old name for 0x320 from privilege spec 1.9. It has different semantics than mcountinhibit that is at that address now.

It doesn't look like binutils supports this name anymore so I don't think llvm should.