### PR TITLE
[compiler-rt][Darwin][x86] Fix instrprof-darwin-exports test (#131425)

### DIFF
--- a/compiler-rt/test/profile/instrprof-darwin-exports.c
+++ b/compiler-rt/test/profile/instrprof-darwin-exports.c
@@ -7,13 +7,13 @@
 // just "_main" produces no warnings or errors.
 //
 // RUN: echo "_main" > %t.exports
-// RUN: %clang_pgogen -Werror -Wl,-exported_symbols_list,%t.exports -o %t %s 2>&1 | tee %t.log
-// RUN: %clang_profgen -Werror -fcoverage-mapping -Wl,-exported_symbols_list,%t.exports -o %t %s 2>&1 | tee -a %t.log
+// RUN: %clang_pgogen -Werror -Wl,-exported_symbols_list,%t.exports -Wl,-w -o %t %s 2>&1 | tee %t.log
+// RUN: %clang_profgen -Werror -fcoverage-mapping -Wl,-exported_symbols_list,%t.exports -Wl,-w -o %t %s 2>&1 | tee -a %t.log
 // RUN: cat %t.log | count 0
 
 // 2) Ditto (1), but for GCOV.
 //
-// RUN: %clang -Werror -Wl,-exported_symbols_list,%t.exports --coverage -o %t.gcov %s | tee -a %t.gcov.log
+// RUN: %clang -Werror -Wl,-exported_symbols_list,%t.exports -Wl,-w --coverage -o %t.gcov %s | tee -a %t.gcov.log
 // RUN: cat %t.gcov.log | count 0
 
 // 3) The default set of weak external symbols should match the set of symbols


### PR DESCRIPTION
ld64 issues a warning about section alignment which was counted as an unexpected exported symbol and the test failed.

Fixed by disabling all linker warnings using -Wl,-w.

cherry-picked from commit 94426df66a8d7c2321f9e197e5ef9636b0d5ce70