### PR TITLE
[libc] Temporarily disable the type trait test affected by issue 132494.

### DIFF
--- a/libc/test/src/__support/CPP/type_traits_test.cpp
+++ b/libc/test/src/__support/CPP/type_traits_test.cpp
@@ -334,7 +334,9 @@ TEST(LlvmLibcTypeTraitsTest, is_class) {
   // Neither other types.
   EXPECT_FALSE((is_class_v<Union>));
   EXPECT_FALSE((is_class_v<int>));
-  EXPECT_FALSE((is_class_v<EnumClass>));
+  // TODO: Re-enable the test after
+  // https://github.com/llvm/llvm-project/issues/132494 is fixed.
+  // EXPECT_FALSE((is_class_v<EnumClass>));
 }
 
 TYPED_TEST(LlvmLibcTypeTraitsTest, is_const, UnqualObjectTypes) {


### PR DESCRIPTION
This test causes clang to crash due to #132494.