### PR TITLE
[RISCV] Fix Variant Kind type for isUImm5Slist

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -775,7 +775,7 @@ public:
   bool isUImm5Slist() const {
     if (!isImm())
       return false;
-    RISCVMCExpr::VariantKind VK = RISCVMCExpr::VK_None;
+    RISCVMCExpr::Specifier VK = RISCVMCExpr::VK_None;
     int64_t Imm;
     bool IsConstantImm = evaluateConstantImm(getImm(), Imm, VK);
     return IsConstantImm &&


### PR DESCRIPTION
This was done in 42a8813 but the change was not done in #132184 causing build failures.