### PR TITLE
[memprof] Report an error when buildid and profile do not match

### DIFF
--- a/llvm/lib/ProfileData/MemProfReader.cpp
+++ b/llvm/lib/ProfileData/MemProfReader.cpp
@@ -444,7 +444,11 @@ Error RawMemProfReader::setupForSymbolization() {
       ProfiledTextSegmentEnd = Entry.End;
     }
   }
-  assert(NumMatched != 0 && "No matching executable segments in segment info.");
+  if (NumMatched == 0)
+    return make_error<StringError>(
+        Twine("No matching executable segments found in binary ") +
+            Binary.getBinary()->getFileName(),
+        inconvertibleErrorCode());
   assert((PreferredTextSegmentAddress == 0 ||
           (PreferredTextSegmentAddress == ProfiledTextSegmentStart)) &&
          "Expect text segment address to be 0 or equal to profiled text "

--- a/llvm/test/tools/llvm-profdata/memprof-buildid.test
+++ b/llvm/test/tools/llvm-profdata/memprof-buildid.test
@@ -15,10 +15,8 @@ CHECK: Build ID: [[ID:[[:xdigit:]]+]]
 COM: Then match it with the profdata output.
 CHECK-COUNT-1: BuildId: {{.*}}[[ID]]
 
-Test that profile build id does not match build id in the binary
-RUN: not llvm-profdata show --memory %p/Inputs/buildid.memprofraw --profiled-binary %p/Inputs/basic.memprofexe -o - 2>&1 | FileCheck %s -check-prefix=BUILDID-NOT-MATCH
-
 Test error message when profile build id does not match build id in a different binary.
+RUN: not llvm-profdata show --memory %p/Inputs/buildid.memprofraw --profiled-binary %p/Inputs/basic.memprofexe -o - 2>&1 | FileCheck %s -check-prefix=BUILDID-NOT-MATCH
 RUN: not llvm-profdata merge %p/Inputs/buildid.memprofraw %p/Inputs/basic.memprofraw  --profiled-binary %p/Inputs/basic.memprofexe -o %t4.prof 2>&1 | FileCheck %s -check-prefix=BUILDID-NOT-MATCH
 
 BUILDID-NOT-MATCH: No matching executable segments found in binary

--- a/llvm/test/tools/llvm-profdata/memprof-buildid.test
+++ b/llvm/test/tools/llvm-profdata/memprof-buildid.test
@@ -14,3 +14,11 @@ CHECK: Build ID: [[ID:[[:xdigit:]]+]]
 
 COM: Then match it with the profdata output.
 CHECK-COUNT-1: BuildId: {{.*}}[[ID]]
+
+Test that profile build id does not match build id in the binary
+RUN: not llvm-profdata show --memory %p/Inputs/buildid.memprofraw --profiled-binary %p/Inputs/basic.memprofexe -o - 2>&1 | FileCheck %s -check-prefix=BUILDID-NOT-MATCH
+
+Test error message when profile build id does not match build id in a different binary.
+RUN: not llvm-profdata merge %p/Inputs/buildid.memprofraw %p/Inputs/basic.memprofraw  --profiled-binary %p/Inputs/basic.memprofexe -o %t4.prof 2>&1 | FileCheck %s -check-prefix=BUILDID-NOT-MATCH
+
+BUILDID-NOT-MATCH: No matching executable segments found in binary


### PR DESCRIPTION
## Problem
When the build ids of the profile and binary do not match, the error reported by llvm-profdata is `no entries in callstack map after symbolization`, but the root cause of this problem is the **build id mismatch**.
## Trigger scenario
For example, when performing `memprof` optimization on `clang`, `rawprofile` is collected through `ninja clang`. In addition to running clang, some other programs will also be executed, and these programs will also generate rawprofile. When `no entries in callstack map after symbolization` appears during `llvm-profdata merge`, users may mistakenly think that the **instrumentation failed or other reasons**, and will **not directly realize that the binary and profile do not match**.

## Changed
Currently, when the build id does not match, an assert error is triggered only in debug mode. Change it to directly return an error when the build id does not match.
