### PR TITLE
[clang] Use *Set::insert_range (NFC)

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExplodedGraph.h
@@ -485,7 +485,7 @@ public:
     if (empty())
       Impl = S.Impl;
     else
-      Impl.insert(S.begin(), S.end());
+      Impl.insert_range(S);
   }
 
   iterator begin() { return Impl.begin(); }

--- a/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -3304,7 +3304,7 @@ void MicrosoftRecordLayoutBuilder::computeVtorDispSet(
     if (MethodRange.begin() == MethodRange.end())
       BasesWithOverriddenMethods.insert(MD->getParent());
     else
-      Work.insert(MethodRange.begin(), MethodRange.end());
+      Work.insert_range(MethodRange);
     // We've finished processing this element, remove it from the working set.
     Work.erase(MD);
   }

--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -4298,7 +4298,7 @@ static void applyGadgets(const Decl *D, FixableGadgetList FixableGadgets,
           HasParm = true;
       }
       if (HasParm)
-        GrpsUnionForParms.insert(VarGroup.begin(), VarGroup.end());
+        GrpsUnionForParms.insert_range(VarGroup);
     }
   }
 

--- a/clang/lib/Driver/Multilib.cpp
+++ b/clang/lib/Driver/Multilib.cpp
@@ -288,7 +288,7 @@ MultilibSet::expandFlags(const Multilib::flags_list &InFlags) const {
     assert(Regex.isValid());
     if (llvm::any_of(InFlags,
                      [&Regex](StringRef F) { return Regex.match(F); })) {
-      Result.insert(M.Flags.begin(), M.Flags.end());
+      Result.insert_range(M.Flags);
     }
   }
   return Result;

--- a/clang/lib/Sema/SemaAttr.cpp
+++ b/clang/lib/Sema/SemaAttr.cpp
@@ -1267,7 +1267,7 @@ void Sema::ActOnPragmaMSFunction(
     return;
   }
 
-  MSFunctionNoBuiltins.insert(NoBuiltins.begin(), NoBuiltins.end());
+  MSFunctionNoBuiltins.insert_range(NoBuiltins);
 }
 
 void Sema::AddRangeBasedOptnone(FunctionDecl *FD) {

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -18920,7 +18920,7 @@ void DelegatingCycleHelper(CXXConstructorDecl* Ctor,
   // We know that beyond here, we aren't chaining into a cycle.
   if (!Target || !Target->isDelegatingConstructor() ||
       Target->isInvalidDecl() || Valid.count(TCanonical)) {
-    Valid.insert(Current.begin(), Current.end());
+    Valid.insert_range(Current);
     Current.clear();
   // We've hit a cycle.
   } else if (TCanonical == Canonical || Invalid.count(TCanonical) ||
@@ -18947,7 +18947,7 @@ void DelegatingCycleHelper(CXXConstructorDecl* Ctor,
       }
     }
 
-    Invalid.insert(Current.begin(), Current.end());
+    Invalid.insert_range(Current);
     Current.clear();
   } else {
     DelegatingCycleHelper(Target, Valid, Invalid, Current, S);

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -17944,8 +17944,7 @@ void Sema::PopExpressionEvaluationContext() {
   // Otherwise, merge the contexts together.
   } else {
     Cleanup.mergeFrom(Rec.ParentCleanup);
-    MaybeODRUseExprs.insert(Rec.SavedMaybeODRUseExprs.begin(),
-                            Rec.SavedMaybeODRUseExprs.end());
+    MaybeODRUseExprs.insert_range(Rec.SavedMaybeODRUseExprs);
   }
 
   // Pop the current expression evaluation context off the stack.

--- a/clang/lib/Serialization/ASTReaderInternals.h
+++ b/clang/lib/Serialization/ASTReaderInternals.h
@@ -69,7 +69,7 @@ public:
         }
 
         // Switch to tracking found IDs in the set.
-        Found.insert(Data.begin(), Data.end());
+        Found.insert_range(Data);
       }
 
       if (Found.insert(ID).second)
@@ -191,7 +191,7 @@ public:
         }
 
         // Switch to tracking found IDs in the set.
-        Found.insert(Data.begin(), Data.end());
+        Found.insert_range(Data);
       }
 
       if (Found.insert(Info).second)

--- a/clang/lib/Serialization/MultiOnDiskHashTable.h
+++ b/clang/lib/Serialization/MultiOnDiskHashTable.h
@@ -127,7 +127,7 @@ private:
 
   void removeOverriddenTables() {
     llvm::DenseSet<file_type> Files;
-    Files.insert(PendingOverrides.begin(), PendingOverrides.end());
+    Files.insert_range(PendingOverrides);
     // Explicitly capture Files to work around an MSVC 2015 rejects-valid bug.
     auto ShouldRemove = [&Files](void *T) -> bool {
       auto *ODT = llvm::cast<OnDiskTable *>(Table::getFromOpaqueValue(T));

--- a/clang/lib/StaticAnalyzer/Frontend/CheckerRegistry.cpp
+++ b/clang/lib/StaticAnalyzer/Frontend/CheckerRegistry.cpp
@@ -223,7 +223,7 @@ void CheckerRegistry::initializeRegistry(const CheckerManager &Mgr) {
       continue;
     }
 
-    Tmp.insert(Deps.begin(), Deps.end());
+    Tmp.insert_range(Deps);
 
     // Enable the checker.
     Tmp.insert(&Checker);

--- a/clang/tools/libclang/Indexing.cpp
+++ b/clang/tools/libclang/Indexing.cpp
@@ -137,7 +137,7 @@ public:
 
   void addParsedRegions(ArrayRef<PPRegion> Regions) {
     std::lock_guard<std::mutex> MG(Mutex);
-    ParsedRegions.insert(Regions.begin(), Regions.end());
+    ParsedRegions.insert_range(Regions);
   }
 };
 

--- a/clang/unittests/Analysis/FlowSensitive/TypeErasedDataflowAnalysisTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/TypeErasedDataflowAnalysisTest.cpp
@@ -493,8 +493,7 @@ struct FunctionCallLattice {
     if (Other.CalledFunctions.empty())
       return LatticeJoinEffect::Unchanged;
     const size_t size_before = CalledFunctions.size();
-    CalledFunctions.insert(Other.CalledFunctions.begin(),
-                           Other.CalledFunctions.end());
+    CalledFunctions.insert_range(Other.CalledFunctions);
     return CalledFunctions.size() == size_before ? LatticeJoinEffect::Unchanged
                                                  : LatticeJoinEffect::Changed;
   }

--- a/clang/utils/TableGen/NeonEmitter.cpp
+++ b/clang/utils/TableGen/NeonEmitter.cpp
@@ -1661,7 +1661,7 @@ Intrinsic::DagEmitter::emitDagShuffle(const DagInit *DI) {
         }
       }
 
-      Elts.insert(Revved.begin(), Revved.end());
+      Elts.insert_range(Revved);
     }
   };
 


### PR DESCRIPTION
DenseSet, SmallPtrSet, SmallSet, SetVector, and StringSet recently
gained C++23-style insert_range.  This patch replaces:

  Dest.insert(Src.begin(), Src.end());

with:

  Dest.insert_range(Src);

This patch does not touch custom begin like succ_begin for now.
