### PR TITLE
[clang-doc] Add regression test for test comments in macros

### DIFF
--- a/clang-tools-extra/test/clang-doc/comments-in-macros.cpp
+++ b/clang-tools-extra/test/clang-doc/comments-in-macros.cpp
@@ -10,8 +10,8 @@
 // RUN: FileCheck %s < %t/GlobalNamespace/MyClass.html --check-prefix=HTML-MYCLASS
 
 #define DECLARE_METHODS                                           \
-    /**   							  \
-     * @brief Declare a method to calculate the sum of two numbers\
+    /**   							  
+     * @brief Declare a method to calculate the sum of two numbers
      */                                                           \
     int Add(int a, int b) {                                       \
         return a + b;                                             \

--- a/clang-tools-extra/test/clang-doc/comments-in-macros.cpp
+++ b/clang-tools-extra/test/clang-doc/comments-in-macros.cpp
@@ -28,8 +28,8 @@
 
 class MyClass {
 public:
-// MD-MYCLASS-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}macro.cpp#[[@LINE+2]]*
-// HTML-MYCLASS-LINE: <p>Defined at line [[@LINE+1]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}macro.cpp</p>
+// MD-MYCLASS-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}comments-in-macros.cpp#[[@LINE+2]]*
+// HTML-MYCLASS-LINE: <p>Defined at line [[@LINE+1]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}comments-in-macros.cpp</p>
     DECLARE_METHODS
 };
 

--- a/clang-tools-extra/test/clang-doc/comments-in-macros.cpp
+++ b/clang-tools-extra/test/clang-doc/comments-in-macros.cpp
@@ -3,6 +3,7 @@
 // RUN: clang-doc --format=md --doxygen --output=%t --executor=standalone %s
 // RUN: FileCheck %s < %t/GlobalNamespace/MyClass.md --check-prefix=MD-MYCLASS-LINE
 // RUN: FileCheck %s < %t/GlobalNamespace/MyClass.md --check-prefix=MD-MYCLASS
+
 // RUN: clang-doc --format=html --doxygen --output=%t --executor=standalone %s
 // RUN: FileCheck %s < %t/GlobalNamespace/MyClass.html --check-prefix=HTML-MYCLASS-LINE
 // RUN: FileCheck %s < %t/GlobalNamespace/MyClass.html --check-prefix=HTML-MYCLASS
@@ -11,8 +12,7 @@
     /**   							  \
      * @brief Declare a method to calculate the sum of two numbers\
      */                                                           \
-    int Add(int a, int b)                                         \
-    {                                                             \
+    int Add(int a, int b) {                                       \
         return a + b;                                             \
     }
 

--- a/clang-tools-extra/test/clang-doc/comments-in-macros.cpp
+++ b/clang-tools-extra/test/clang-doc/comments-in-macros.cpp
@@ -1,11 +1,11 @@
 // Fixes #59819. The underlying problem was fixed in https://reviews.llvm.org/D142560, but this patch adds a proper regression test.
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: clang-doc --format=md --doxygen --output=%t --executor=standalone %s
-// RUN: FileCheck %s < %t/GlobalNamespace/MyClass.md --check-prefix=MD-MyClass-LINE
-// RUN: FileCheck %s < %t/GlobalNamespace/MyClass.md --check-prefix=MD-MyClass
+// RUN: FileCheck %s < %t/GlobalNamespace/MyClass.md --check-prefix=MD-MYCLASS-LINE
+// RUN: FileCheck %s < %t/GlobalNamespace/MyClass.md --check-prefix=MD-MYCLASS
 // RUN: clang-doc --format=html --doxygen --output=%t --executor=standalone %s
-// RUN: FileCheck %s < %t/GlobalNamespace/MyClass.html --check-prefix=HTML-MyClass-LINE
-// RUN: FileCheck %s < %t/GlobalNamespace/MyClass.html --check-prefix=HTML-MyClass
+// RUN: FileCheck %s < %t/GlobalNamespace/MyClass.html --check-prefix=HTML-MYCLASS-LINE
+// RUN: FileCheck %s < %t/GlobalNamespace/MyClass.html --check-prefix=HTML-MYCLASS
 
 #define DECLARE_METHODS                                           \
     /**   							  \
@@ -16,20 +16,19 @@
         return a + b;                                             \
     }
 
-// MD-MyClass: ### Add
-// MD-MyClass: *public int Add(int a, int b)*
-// MD-MyClass: **brief** Declare a method to calculate the sum of two numbers
+// MD-MYCLASS: ### Add
+// MD-MYCLASS: *public int Add(int a, int b)*
+// MD-MYCLASS: **brief** Declare a method to calculate the sum of two numbers
 
-// HTML-MyClass: <p>public int Add(int a, int b)</p>
-// HTML-MyClass: <div>brief</div>
-// HTML-MyClass: <p> Declare a method to calculate the sum of two numbers</p>
+// HTML-MYCLASS: <p>public int Add(int a, int b)</p>
+// HTML-MYCLASS: <div>brief</div>
+// HTML-MYCLASS: <p> Declare a method to calculate the sum of two numbers</p>
 
 
 class MyClass {
 public:
-// MD-MyClass-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}macro.cpp#[[@LINE+2]]*
-// HTML-MyClass-LINE: <p>Defined at line [[@LINE+1]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}macro.cpp</p>
+// MD-MYCLASS-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}macro.cpp#[[@LINE+2]]*
+// HTML-MYCLASS-LINE: <p>Defined at line [[@LINE+1]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}macro.cpp</p>
     DECLARE_METHODS
 };
-
 

--- a/clang-tools-extra/test/clang-doc/comments-in-macros.cpp
+++ b/clang-tools-extra/test/clang-doc/comments-in-macros.cpp
@@ -1,9 +1,9 @@
 // Fixes #59819. The underlying problem was fixed in https://reviews.llvm.org/D142560, but this patch adds a proper regression test.
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: clang-doc --format=md --doxygen --output=%t --executor=standalone %s
-// RUN: clang-doc --format=html --doxygen --output=%t --executor=standalone %s
 // RUN: FileCheck %s < %t/GlobalNamespace/MyClass.md --check-prefix=MD-MyClass-LINE
 // RUN: FileCheck %s < %t/GlobalNamespace/MyClass.md --check-prefix=MD-MyClass
+// RUN: clang-doc --format=html --doxygen --output=%t --executor=standalone %s
 // RUN: FileCheck %s < %t/GlobalNamespace/MyClass.html --check-prefix=HTML-MyClass-LINE
 // RUN: FileCheck %s < %t/GlobalNamespace/MyClass.html --check-prefix=HTML-MyClass
 

--- a/clang-tools-extra/test/clang-doc/comments-in-macros.cpp
+++ b/clang-tools-extra/test/clang-doc/comments-in-macros.cpp
@@ -1,0 +1,35 @@
+// Fixes #59819. The underlying problem was fixed in https://reviews.llvm.org/D142560, but this patch adds a proper regression test.
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --format=md --doxygen --output=%t --executor=standalone %s
+// RUN: clang-doc --format=html --doxygen --output=%t --executor=standalone %s
+// RUN: FileCheck %s < %t/GlobalNamespace/MyClass.md --check-prefix=MD-MyClass-LINE
+// RUN: FileCheck %s < %t/GlobalNamespace/MyClass.md --check-prefix=MD-MyClass
+// RUN: FileCheck %s < %t/GlobalNamespace/MyClass.html --check-prefix=HTML-MyClass-LINE
+// RUN: FileCheck %s < %t/GlobalNamespace/MyClass.html --check-prefix=HTML-MyClass
+
+#define DECLARE_METHODS                                           \
+    /**   							  \
+     * @brief Declare a method to calculate the sum of two numbers\
+     */                                                           \
+    int Add(int a, int b)                                         \
+    {                                                             \
+        return a + b;                                             \
+    }
+
+// MD-MyClass: ### Add
+// MD-MyClass: *public int Add(int a, int b)*
+// MD-MyClass: **brief** Declare a method to calculate the sum of two numbers
+
+// HTML-MyClass: <p>public int Add(int a, int b)</p>
+// HTML-MyClass: <div>brief</div>
+// HTML-MyClass: <p> Declare a method to calculate the sum of two numbers</p>
+
+
+class MyClass {
+public:
+// MD-MyClass-LINE: *Defined at {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}macro.cpp#[[@LINE+2]]*
+// HTML-MyClass-LINE: <p>Defined at line [[@LINE+1]] of file {{.*}}clang-tools-extra{{[\/]}}test{{[\/]}}clang-doc{{[\/]}}macro.cpp</p>
+    DECLARE_METHODS
+};
+
+

--- a/clang-tools-extra/test/clang-doc/comments-in-macros.cpp
+++ b/clang-tools-extra/test/clang-doc/comments-in-macros.cpp
@@ -1,4 +1,5 @@
-// Fixes #59819. The underlying problem was fixed in https://reviews.llvm.org/D142560, but this patch adds a proper regression test.
+// Regression test for https://github.com/llvm/llvm-project/issues/59819
+
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: clang-doc --format=md --doxygen --output=%t --executor=standalone %s
 // RUN: FileCheck %s < %t/GlobalNamespace/MyClass.md --check-prefix=MD-MYCLASS-LINE


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/59819. The underlying problem was fixed in https://reviews.llvm.org/D142560, but this patch adds a proper regression test.