### PR TITLE
[clang] diagnose invalid member pointer class on instantiation

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6976,7 +6976,7 @@ def err_illegal_decl_mempointer_to_reference : Error<
 def err_illegal_decl_mempointer_to_void : Error<
   "'%0' declared as a member pointer to void">;
 def err_illegal_decl_mempointer_in_nonclass
-    : Error<"'%0' does not point into a class">;
+    : Error<"%0 does not point into a class">;
 def err_reference_to_void : Error<"cannot form a reference to 'void'">;
 def err_nonfunction_block_type : Error<
   "block pointer to non-function type is invalid">;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -14885,7 +14885,7 @@ public:
   ///
   /// \returns a member pointer type, if successful, or a NULL type if there was
   /// an error.
-  QualType BuildMemberPointerType(QualType T, NestedNameSpecifier *Qualifier,
+  QualType BuildMemberPointerType(QualType T, const CXXScopeSpec &SS,
                                   CXXRecordDecl *Cls, SourceLocation Loc,
                                   DeclarationName Entity);
 

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -864,8 +864,8 @@ public:
   /// By default, performs semantic analysis when building the member pointer
   /// type. Subclasses may override this routine to provide different behavior.
   QualType RebuildMemberPointerType(QualType PointeeType,
-                                    NestedNameSpecifier *Qualifier,
-                                    CXXRecordDecl *Cls, SourceLocation Sigil);
+                                    const CXXScopeSpec &SS, CXXRecordDecl *Cls,
+                                    SourceLocation Sigil);
 
   QualType RebuildObjCTypeParamType(const ObjCTypeParamDecl *Decl,
                                     SourceLocation ProtocolLAngleLoc,
@@ -5631,9 +5631,10 @@ TreeTransform<Derived>::TransformMemberPointerType(TypeLocBuilder &TLB,
       NewQualifierLoc.getNestedNameSpecifier() !=
           OldQualifierLoc.getNestedNameSpecifier() ||
       NewCls != OldCls) {
-    Result = getDerived().RebuildMemberPointerType(
-        PointeeType, NewQualifierLoc.getNestedNameSpecifier(), NewCls,
-        TL.getStarLoc());
+    CXXScopeSpec SS;
+    SS.Adopt(NewQualifierLoc);
+    Result = getDerived().RebuildMemberPointerType(PointeeType, SS, NewCls,
+                                                   TL.getStarLoc());
     if (Result.isNull())
       return QualType();
   }
@@ -17044,9 +17045,9 @@ TreeTransform<Derived>::RebuildReferenceType(QualType ReferentType,
 
 template <typename Derived>
 QualType TreeTransform<Derived>::RebuildMemberPointerType(
-    QualType PointeeType, NestedNameSpecifier *Qualifier, CXXRecordDecl *Cls,
+    QualType PointeeType, const CXXScopeSpec &SS, CXXRecordDecl *Cls,
     SourceLocation Sigil) {
-  return SemaRef.BuildMemberPointerType(PointeeType, Qualifier, Cls, Sigil,
+  return SemaRef.BuildMemberPointerType(PointeeType, SS, Cls, Sigil,
                                         getDerived().getBaseEntity());
 }
 

--- a/clang/test/SemaCXX/member-pointer.cpp
+++ b/clang/test/SemaCXX/member-pointer.cpp
@@ -333,3 +333,14 @@ namespace test9 {
   struct C { int BAR::*mp; };
   // expected-error@-1 {{'BAR' is not a class, namespace, or enumeration}}
 } // namespace test9
+
+namespace GH132494 {
+  enum E {};
+
+  void f(int E::*); // expected-error {{member pointer does not point into a class}}
+
+  template <class T> struct A {
+    int T::*foo; // expected-error {{'foo' does not point into a class}}
+  };
+  template struct A<E>; // expected-note {{requested here}}
+} // namespace GH132494

--- a/libc/test/src/__support/CPP/type_traits_test.cpp
+++ b/libc/test/src/__support/CPP/type_traits_test.cpp
@@ -334,9 +334,7 @@ TEST(LlvmLibcTypeTraitsTest, is_class) {
   // Neither other types.
   EXPECT_FALSE((is_class_v<Union>));
   EXPECT_FALSE((is_class_v<int>));
-  // TODO: Re-enable the test after
-  // https://github.com/llvm/llvm-project/issues/132494 is fixed.
-  // EXPECT_FALSE((is_class_v<EnumClass>));
+  EXPECT_FALSE((is_class_v<EnumClass>));
 }
 
 TYPED_TEST(LlvmLibcTypeTraitsTest, is_const, UnqualObjectTypes) {


### PR DESCRIPTION
This moves the diagnostic for member pointers pointing into non-class into BuildMemberPointer, so that it can be used from RebuildMemberPointer, when instantiating templates.

Also adds a minor tweak to the diagnostic when the member pointer is anonymous, which was previously untested.

Also reverts https://github.com/llvm/llvm-project/pull/132501, which disabled a failing test due to the regression which is now fixed.

No changelog, since this fixes a regression which has not been released yet.

Fixes https://github.com/llvm/llvm-project/issues/132494