### PR TITLE
[RISCV] Add alias names for tdata1 and tdata3 CSRs.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSystemOperands.td
+++ b/llvm/lib/Target/RISCV/RISCVSystemOperands.td
@@ -324,8 +324,20 @@ def : SysReg<"scountinhibit", 0x120>;
 //===----------------------------------------------------------------------===//
 def : SysReg<"tselect", 0x7A0>;
 def : SysReg<"tdata1", 0x7A1>;
+let isAltName = 1 in {
+def : SysReg<"mcontrol", 0x7A1>;
+def : SysReg<"mcontrol6", 0x7A1>;
+def : SysReg<"icount", 0x7A1>;
+def : SysReg<"itrigger", 0x7A1>;
+def : SysReg<"etrigger", 0x7A1>;
+def : SysReg<"tmexttrigger", 0x7A1>;
+}
 def : SysReg<"tdata2", 0x7A2>;
 def : SysReg<"tdata3", 0x7A3>;
+let isAltName = 1 in {
+def : SysReg<"textra32", 0x7A3>;
+def : SysReg<"textra64", 0x7A3>;
+}
 def : SysReg<"tinfo", 0x7A4>;
 def : SysReg<"tcontrol", 0x7A5>;
 def : SysReg<"mcontext", 0x7A8>;

--- a/llvm/test/MC/RISCV/machine-csr-names.s
+++ b/llvm/test/MC/RISCV/machine-csr-names.s
@@ -1392,6 +1392,54 @@ csrrs t1, tdata1, zero
 # uimm12
 csrrs t2, 0x7A1, zero
 
+# mcontrol (alias for tdata1)
+# name
+# CHECK-INST: csrrs t1, tdata1, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x10,0x7a]
+# CHECK-INST-ALIAS: csrr t1, tdata1
+# name
+csrrs t1, mcontrol, zero
+
+# mcontrol6 (alias for tdata1)
+# name
+# CHECK-INST: csrrs t1, tdata1, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x10,0x7a]
+# CHECK-INST-ALIAS: csrr t1, tdata1
+# name
+csrrs t1, mcontrol6, zero
+
+# icount (alias for tdata1)
+# name
+# CHECK-INST: csrrs t1, tdata1, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x10,0x7a]
+# CHECK-INST-ALIAS: csrr t1, tdata1
+# name
+csrrs t1, icount, zero
+
+# itrigger (alias for tdata1)
+# name
+# CHECK-INST: csrrs t1, tdata1, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x10,0x7a]
+# CHECK-INST-ALIAS: csrr t1, tdata1
+# name
+csrrs t1, itrigger, zero
+
+# etrigger (alias for tdata1)
+# name
+# CHECK-INST: csrrs t1, tdata1, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x10,0x7a]
+# CHECK-INST-ALIAS: csrr t1, tdata1
+# name
+csrrs t1, etrigger, zero
+
+# tmexttrigger (alias for tdata1)
+# name
+# CHECK-INST: csrrs t1, tdata1, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x10,0x7a]
+# CHECK-INST-ALIAS: csrr t1, tdata1
+# name
+csrrs t1, tmexttrigger, zero
+
 # tdata2
 # name
 # CHECK-INST: csrrs t1, tdata2, zero
@@ -1418,6 +1466,22 @@ csrrs t2, 0x7A2, zero
 csrrs t1, tdata3, zero
 # uimm12
 csrrs t2, 0x7A3, zero
+
+# textra32 (alias for tdata3)
+# name
+# CHECK-INST: csrrs t1, tdata3, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x30,0x7a]
+# CHECK-INST-ALIAS: csrr t1, tdata3
+# name
+csrrs t1, textra32, zero
+
+# textra64 (alias for tdata3)
+# name
+# CHECK-INST: csrrs t1, tdata3, zero
+# CHECK-ENC: encoding: [0x73,0x23,0x30,0x7a]
+# CHECK-INST-ALIAS: csrr t1, tdata3
+# name
+csrrs t1, textra64, zero
 
 # tinfo
 # name


### PR DESCRIPTION
The RISC-V Debug Specification defines multiple names for these CSRs. https://github.com/riscv/riscv-debug-spec/releases/tag/1.0