### PR TITLE
[libc++][test] Small fixes for time tests

### DIFF
--- a/libcxx/test/std/time/time.clock/time.clock.gps/types.compile.pass.cpp
+++ b/libcxx/test/std/time/time.clock/time.clock.gps/types.compile.pass.cpp
@@ -36,11 +36,11 @@
 #include "test_macros.h"
 
 // class gps_clock
-using rep                = std::chrono::gps_clock::rep;
-using period             = std::chrono::gps_clock::period;
-using duration           = std::chrono::gps_clock::duration;
-using time_point         = std::chrono::gps_clock::time_point;
-constexpr bool is_steady = std::chrono::gps_clock::is_steady;
+using rep                                 = std::chrono::gps_clock::rep;
+using period                              = std::chrono::gps_clock::period;
+using duration                            = std::chrono::gps_clock::duration;
+using time_point                          = std::chrono::gps_clock::time_point;
+[[maybe_unused]] constexpr bool is_steady = std::chrono::gps_clock::is_steady;
 
 // Tests the values. part of them are implementation defined.
 LIBCPP_STATIC_ASSERT(std::same_as<rep, std::chrono::utc_clock::rep>);

--- a/libcxx/test/std/time/time.clock/time.clock.tai/types.compile.pass.cpp
+++ b/libcxx/test/std/time/time.clock/time.clock.tai/types.compile.pass.cpp
@@ -36,11 +36,11 @@
 #include "test_macros.h"
 
 // class tai_clock
-using rep                = std::chrono::tai_clock::rep;
-using period             = std::chrono::tai_clock::period;
-using duration           = std::chrono::tai_clock::duration;
-using time_point         = std::chrono::tai_clock::time_point;
-constexpr bool is_steady = std::chrono::tai_clock::is_steady;
+using rep                                 = std::chrono::tai_clock::rep;
+using period                              = std::chrono::tai_clock::period;
+using duration                            = std::chrono::tai_clock::duration;
+using time_point                          = std::chrono::tai_clock::time_point;
+[[maybe_unused]] constexpr bool is_steady = std::chrono::tai_clock::is_steady;
 
 // Tests the values. part of them are implementation defined.
 LIBCPP_STATIC_ASSERT(std::same_as<rep, std::chrono::utc_clock::rep>);

--- a/libcxx/test/std/time/time.syn/formatter.tai_time.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.tai_time.pass.cpp
@@ -268,9 +268,6 @@ static void test_valid_values_day() {
         lfmt,
         cr::tai_seconds(1'613'259'090s)); // 23:31:30 TAI Friday, 13 February 2009
 
-  // Use the global locale (fr_FR)
-  check(SV("%d='01'\t%Od='01'\t%e=' 1'\t%Oe=' 1'\n"),
-        lfmt,
 #else // defined(_WIN32) || defined(__APPLE__) || defined(_AIX) || defined(__FreeBSD__)
   check(loc,
         SV("%d='01'\t%Od='一'\t%e=' 1'\t%Oe='一'\n"),


### PR DESCRIPTION
* Fix copy-paste damage in `formatter.tai_time.pass.cpp`.
  + Comparing the `#if` to the `#else` case, it's clear that this half-copied check should be removed.
* Mark `is_steady` as `[[maybe_unused]]`.
  + It's only used within `LIBCPP_STATIC_ASSERT`.
