### PR TITLE
[RISCV] Update lld tests for the C ext implication change

### DIFF
--- a/lld/test/ELF/lto/riscv-attributes.ll
+++ b/lld/test/ELF/lto/riscv-attributes.ll
@@ -10,10 +10,10 @@
 ; CHECK:      BuildAttributes {
 ; CHECK-NEXT:   FormatVersion: 0x41
 ; CHECK-NEXT:   Section 1 {
-; CHECK-NEXT:     SectionLength: 98
+; CHECK-NEXT:     SectionLength: 119
 ; CHECK-NEXT:     Vendor: riscv
 ; CHECK-NEXT:     Tag: Tag_File (0x1)
-; CHECK-NEXT:     Size: 88
+; CHECK-NEXT:     Size: 109
 ; CHECK-NEXT:     FileAttributes {
 ; CHECK-NEXT:       Attribute {
 ; CHECK-NEXT:         Tag: 4
@@ -30,7 +30,7 @@
 ; CHECK-NEXT:       Attribute {
 ; CHECK-NEXT:         Tag: 5
 ; CHECK-NEXT:         TagName: arch
-; CHECK-NEXT:         Value: rv32i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zbb1p0{{$}}
+; CHECK-NEXT:         Value: rv32i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zca1p0_zcd1p0_zcf1p0_zbb1p0{{$}}
 ; CHECK-NEXT:       }
 ; CHECK-NEXT:     }
 ; CHECK-NEXT:   }

--- a/lld/test/ELF/riscv-attributes.s
+++ b/lld/test/ELF/riscv-attributes.s
@@ -104,20 +104,20 @@
 # UNKNOWN22:         warning: unknown22a.o:(.riscv.attributes): invalid tag 0x16 at offset 0x10
 
 # HDR:      Name              Type             Address          Off    Size   ES Flg Lk Inf Al
-# HDR:      .riscv.attributes RISCV_ATTRIBUTES 0000000000000000 000158 00005a 00      0   0  1{{$}}
+# HDR:      .riscv.attributes RISCV_ATTRIBUTES 0000000000000000 000158 000068 00      0   0  1{{$}}
 
 # HDR:      Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
 # HDR:      LOAD           0x000000 0x0000000000010000 0x0000000000010000 0x000158 0x000158 R   0x1000
 # HDR-NEXT: GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000 0x000000 RW  0
-# HDR-NEXT: ATTRIBUTES     0x000158 0x0000000000000000 0x0000000000000000 0x00005a 0x00005a R   0x1{{$}}
+# HDR-NEXT: ATTRIBUTES     0x000158 0x0000000000000000 0x0000000000000000 0x000068 0x000068 R   0x1{{$}}
 
 # CHECK:      BuildAttributes {
 # CHECK-NEXT:   FormatVersion: 0x41
 # CHECK-NEXT:   Section 1 {
-# CHECK-NEXT:     SectionLength: 89
+# CHECK-NEXT:     SectionLength: 103
 # CHECK-NEXT:     Vendor: riscv
 # CHECK-NEXT:     Tag: Tag_File (0x1)
-# CHECK-NEXT:     Size: 79
+# CHECK-NEXT:     Size: 93
 # CHECK-NEXT:     FileAttributes {
 # CHECK-NEXT:       Attribute {
 # CHECK-NEXT:         Tag: 4
@@ -128,7 +128,7 @@
 # CHECK-NEXT:       Attribute {
 # CHECK-NEXT:         Tag: 5
 # CHECK-NEXT:         TagName: arch
-# CHECK-NEXT:         Value: rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zmmul1p0_zaamo1p0_zalrsc1p0{{$}}
+# CHECK-NEXT:         Value: rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zca1p0_zcd1p0{{$}}
 # CHECK-NEXT:       }
 # CHECK-NEXT:     }
 # CHECK-NEXT:   }
@@ -137,10 +137,10 @@
 # CHECK2:      BuildAttributes {
 # CHECK2-NEXT:   FormatVersion: 0x41
 # CHECK2-NEXT:   Section 1 {
-# CHECK2-NEXT:     SectionLength: 132
+# CHECK2-NEXT:     SectionLength: 146
 # CHECK2-NEXT:     Vendor: riscv
 # CHECK2-NEXT:     Tag: Tag_File (0x1)
-# CHECK2-NEXT:     Size: 122
+# CHECK2-NEXT:     Size: 136
 # CHECK2-NEXT:     FileAttributes {
 # CHECK2-NEXT:       Attribute {
 # CHECK2-NEXT:         Tag: 4
@@ -167,7 +167,7 @@
 # CHECK2-NEXT:       Attribute {
 # CHECK2-NEXT:         Tag: 5
 # CHECK2-NEXT:         TagName: arch
-# CHECK2-NEXT:         Value: rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zkt1p0_zve32f1p0_zve32x1p0_zvl32b1p0{{$}}
+# CHECK2-NEXT:         Value: rv64i2p1_m2p0_a2p1_f2p2_d2p2_c2p0_zicsr2p0_zmmul1p0_zaamo1p0_zalrsc1p0_zca1p0_zcd1p0_zkt1p0_zve32f1p0_zve32x1p0_zvl32b1p0{{$}}
 # CHECK2-NEXT:       }
 # CHECK2-NEXT:     }
 # CHECK2-NEXT:   }


### PR DESCRIPTION
I forgot to test the lld in the last PR https://github.com/llvm/llvm-project/pull/132259 and causes a few failures, this sholud fixed them
