### PR TITLE
[clang-tidy] Fix false positives in `bugprone-crtp-constructor-accessibility` check

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/CrtpConstructorAccessibilityCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/CrtpConstructorAccessibilityCheck.cpp
@@ -157,7 +157,7 @@ void CrtpConstructorAccessibilityCheck::check(
   }
 
   for (auto &&Ctor : CRTPDeclaration->ctors()) {
-    if (Ctor->getAccess() == AS_private)
+    if (Ctor->getAccess() == AS_private || Ctor->isDeleted())
       continue;
 
     const bool IsPublic = Ctor->getAccess() == AS_public;

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -148,6 +148,11 @@ New check aliases
 Changes in existing checks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Improved :doc:`bugprone-crtp-constructor-accessibility
+  <clang-tidy/checks/bugprone/crtp-constructor-accessibility>` check by fixing
+  false positives on deleted constructors that cannot be used to construct
+  objects, even if they have public or protected access.
+
 - Improved :doc:`bugprone-optional-value-conversion
   <clang-tidy/checks/bugprone/optional-value-conversion>` check to detect
   conversion in argument of ``std::make_optional``.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/crtp-constructor-accessibility.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/crtp-constructor-accessibility.rst
@@ -65,7 +65,8 @@ Example:
 To ensure that no accidental instantiation happens, the best practice is to 
 make the constructor private and declare the derived class as friend. Note
 that as a tradeoff, this also gives the derived class access to every other
-private members of the CRTP.
+private members of the CRTP. However, constructors can still be public or
+protected if they are deleted.
 
 Example:
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/crtp-constructor-accessibility.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/crtp-constructor-accessibility.cpp
@@ -253,3 +253,34 @@ void foo() {
     (void) A;
 }
 } // namespace no_warning_unsupported
+
+namespace public_copy_move_constructors_deleted {
+template <typename T>
+class CRTP
+{
+    CRTP() = default;
+    friend T;
+  public:
+    CRTP(const CRTP&) = delete;
+    CRTP(CRTP&&) = delete;
+};
+
+class A : CRTP<A> {};
+
+} // namespace public_copy_move_constructors_deleted
+
+namespace public_copy_protected_move_constructor_deleted {
+template <typename T>
+class CRTP
+{
+    CRTP() = default;
+    friend T;
+  public:
+    CRTP(const CRTP&) = delete;
+  protected:
+    CRTP(CRTP&&) = delete;
+};
+
+class A : CRTP<A> {};
+
+} // namespace public_copy_protected_move_constructor_deleted


### PR DESCRIPTION
Fix false positives in `bugprone-crtp-constructor-accessibility` check on deleted constructors that cannot be used to construct objects, even if they have public or protected access.

Closes https://github.com/llvm/llvm-project/issues/131737.