### PR TITLE
[clang][bytecode][NFC] Use getElemType() in __builtin_memchr as well

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -2053,9 +2053,7 @@ static bool interp__builtin_memchr(InterpState &S, CodePtr OpPC,
       (ID == Builtin::BIstrchr || ID == Builtin::BI__builtin_strchr);
 
   PrimType ElemT =
-      IsRawByte
-          ? PT_Sint8
-          : *S.getContext().classify(Ptr.getFieldDesc()->getElemQualType());
+      IsRawByte ? PT_Sint8 : *S.getContext().classify(getElemType(Ptr));
 
   size_t Index = Ptr.getIndex();
   size_t Step = 0;


### PR DESCRIPTION
For consistency.