### PR TITLE
[clang] fix RecursiveASTVisitor traversal from type to decl

### DIFF
--- a/clang/include/clang/AST/RecursiveASTVisitor.h
+++ b/clang/include/clang/AST/RecursiveASTVisitor.h
@@ -1005,7 +1005,9 @@ DEF_TRAVERSE_TYPE(RValueReferenceType,
 
 DEF_TRAVERSE_TYPE(MemberPointerType, {
   TRY_TO(TraverseNestedNameSpecifier(T->getQualifier()));
-  TRY_TO(TraverseDecl(T->getMostRecentCXXRecordDecl()));
+  if (T->isSugared())
+    TRY_TO(TraverseType(
+        QualType(T->getMostRecentCXXRecordDecl()->getTypeForDecl(), 0)));
   TRY_TO(TraverseType(T->getPointeeType()));
 })
 

--- a/clang/test/SemaCXX/member-pointer.cpp
+++ b/clang/test/SemaCXX/member-pointer.cpp
@@ -344,3 +344,14 @@ namespace GH132494 {
   };
   template struct A<E>; // expected-note {{requested here}}
 } // namespace GH132494
+
+namespace GH132401 {
+  template <typename Func> struct CallableHelper {
+    static auto Resolve() -> Func;
+  };
+  struct QIODevice {
+    void d_func() { (void)d_ptr; }
+    int d_ptr;
+  };
+  template struct CallableHelper<void (QIODevice::*)()>;
+} // namespace GH132401


### PR DESCRIPTION
For that visitor, it is not expected that a type can traverse into a declaration. This makes the MemberPointer visitor conform to that rule.

This turns the base class visitor into a CXXRecordType visitor, and only performs that visit in case it points to something different than the qualifier does.

Fixes a regression reported here: https://github.com/llvm/llvm-project/pull/132401#issuecomment-2745184537
As this fixes a regression which has not been released, there are no release notes.