### PR TITLE
[InstCombine] Use MapVector for SourceAggregates.

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineVectorOps.cpp
@@ -1111,7 +1111,7 @@ Instruction *InstCombinerImpl::foldAggregateConstructionIntoAggregateReuse(
   // For each predecessor, what is the source aggregate,
   // from which all the elements were originally extracted from?
   // Note that we want for the map to have stable iteration order!
-  SmallDenseMap<BasicBlock *, Value *, 4> SourceAggregates;
+  SmallMapVector<BasicBlock *, Value *, 4> SourceAggregates;
   bool FoundSrcAgg = false;
   for (BasicBlock *Pred : Preds) {
     std::pair<decltype(SourceAggregates)::iterator, bool> IV =


### PR DESCRIPTION
foldAggregateConstructionIntoAggregateReuse iterates over the entries of SourceAggregates and the order of inserted instructions depends on the order of the iterator. Using a regular DenseMap can lead to non-deterministic value naming/numbering.

I don't think it can actually impact the generated binary, but it makes diffing IR more difficult. If desired, I could provide a test case showing the difference in naming.