### PR TITLE
[clang-tidy] Fix `thread_local` false positives in `misc-use-internal-linkage` check 

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/UseInternalLinkageCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UseInternalLinkageCheck.cpp
@@ -130,7 +130,10 @@ void UseInternalLinkageCheck::registerMatchers(MatchFinder *Finder) {
                                 isMain())))
           .bind("fn"),
       this);
-  Finder->addMatcher(varDecl(Common, hasGlobalStorage()).bind("var"), this);
+  Finder->addMatcher(
+      varDecl(Common, hasGlobalStorage(), unless(hasThreadStorageDuration()))
+          .bind("var"),
+      this);
 }
 
 static constexpr StringRef Message =

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -164,7 +164,9 @@ Changes in existing checks
 
 - Improved :doc:`misc-use-internal-linkage
   <clang-tidy/checks/misc/use-internal-linkage>` check by fix false positives
-  for function or variable in header file which contains macro expansion.
+  for function or variable in header file which contains macro expansion and
+  excluding variables with ``thread_local`` storage class specifier from being
+  matched.
 
 - Improved :doc:`modernize-use-default-member-init
   <clang-tidy/checks/modernize/use-default-member-init>` check by matching

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-var.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/use-internal-linkage-var.cpp
@@ -31,6 +31,8 @@ extern int global_extern;
 
 static int global_static;
 
+thread_local int global_thread_local;
+
 namespace {
 static int global_anonymous_ns;
 namespace NS {
@@ -41,6 +43,7 @@ static int global_anonymous_ns;
 static void f(int para) {
   int local;
   static int local_static;
+  thread_local int local_thread_local;
 }
 
 struct S {


### PR DESCRIPTION
Based on C++ standard (see issue https://github.com/llvm/llvm-project/issues/131679) and [StackOverflow](https://stackoverflow.com/questions/22794382/are-c11-thread-local-variables-automatically-static) `thread_local` variables are implicitly `static` so we should not suggest adding `static` on a `thread_local` variables. I'd appreciate if someone else will confirm this too because reading standard is tricky.

However, many people still use `static` and `thread_local` together: [github code-search](https://github.com/search?type=code&q=%22static+thread_local%22+language%3AC%2B%2B). Maybe disabling warnings on `thread_local` should be made as a flag? WDYT?

Closes https://github.com/llvm/llvm-project/issues/131679.