### PR TITLE
[clang][HeuristicResolver] Apply default argument heuristic in resolveDeclRefExpr as well

### DIFF
--- a/clang-tools-extra/clangd/unittests/XRefsTests.cpp
+++ b/clang-tools-extra/clangd/unittests/XRefsTests.cpp
@@ -1091,7 +1091,7 @@ TEST(LocateSymbol, All) {
       )objc",
       R"cpp(
         struct PointerIntPairInfo {
-          static void *getPointer(void *Value);
+          static void *$decl[[getPointer]](void *Value);
         };
 
         template <typename Info = PointerIntPairInfo> struct PointerIntPair {

--- a/clang/lib/Sema/HeuristicResolver.cpp
+++ b/clang/lib/Sema/HeuristicResolver.cpp
@@ -315,9 +315,9 @@ std::vector<const NamedDecl *> HeuristicResolverImpl::resolveMemberExpr(
 
 std::vector<const NamedDecl *>
 HeuristicResolverImpl::resolveDeclRefExpr(const DependentScopeDeclRefExpr *RE) {
-  return resolveDependentMember(
-      resolveNestedNameSpecifierToType(RE->getQualifier()), RE->getDeclName(),
-      StaticFilter);
+  QualType Qualifier = resolveNestedNameSpecifierToType(RE->getQualifier());
+  Qualifier = simplifyType(Qualifier, nullptr, /*UnwrapPointer=*/false);
+  return resolveDependentMember(Qualifier, RE->getDeclName(), StaticFilter);
 }
 
 std::vector<const NamedDecl *>

--- a/clang/unittests/Sema/HeuristicResolverTest.cpp
+++ b/clang/unittests/Sema/HeuristicResolverTest.cpp
@@ -463,6 +463,23 @@ TEST(HeuristicResolver, DeclRefExpr_StaticMethod) {
       cxxMethodDecl(hasName("bar")).bind("output"));
 }
 
+TEST(HeuristicResolver, DeclRefExpr_DefaultTemplateArgument) {
+  std::string Code = R"cpp(
+    struct Default {
+      static void foo();
+    };
+    template <typename T = Default>
+    void bar() {
+      T::foo();
+    }
+  )cpp";
+  // Test resolution of "foo" in "T::foo()".
+  expectResolution(
+      Code, &HeuristicResolver::resolveDeclRefExpr,
+      dependentScopeDeclRefExpr(hasDependentName("foo")).bind("input"),
+      cxxMethodDecl(hasName("foo")).bind("output"));
+}
+
 TEST(HeuristicResolver, DeclRefExpr_StaticOverloads) {
   std::string Code = R"cpp(
     template <typename T>


### PR DESCRIPTION
This is a follow-up to https://github.com/llvm/llvm-project/pull/131074. After moving the default argument heuristic to `simplifyType` as per [this discussion](https://github.com/llvm/llvm-project/pull/131074#discussion_r2006918564), I realized that this made it no longer apply to the `DependentScopeDeclRefExpr` case, because that wasn't using `simplifyType`.

This patch fixes that, with an added testcase.