### PR TITLE
[Analysis] Avoid repeated hash lookups (NFC)

### DIFF
--- a/llvm/include/llvm/Analysis/InstructionPrecedenceTracking.h
+++ b/llvm/include/llvm/Analysis/InstructionPrecedenceTracking.h
@@ -33,9 +33,6 @@ class InstructionPrecedenceTracking {
   // special instructions.
   DenseMap<const BasicBlock *, const Instruction *> FirstSpecialInsts;
 
-  // Fills information about the given block's special instructions.
-  void fill(const BasicBlock *BB);
-
 #ifndef NDEBUG
   /// Asserts that the cached info for \p BB is up-to-date. This helps to catch
   /// the usage error of accessing a block without properly invalidating after a

--- a/llvm/lib/Analysis/InstructionPrecedenceTracking.cpp
+++ b/llvm/lib/Analysis/InstructionPrecedenceTracking.cpp
@@ -47,11 +47,17 @@ const Instruction *InstructionPrecedenceTracking::getFirstSpecialInstruction(
     validate(BB);
 #endif
 
-  if (!FirstSpecialInsts.contains(BB)) {
-    fill(BB);
-    assert(FirstSpecialInsts.contains(BB) && "Must be!");
+  auto [It, Inserted] = FirstSpecialInsts.try_emplace(BB);
+  if (Inserted) {
+    for (const auto &I : *BB) {
+      NumInstScanned++;
+      if (isSpecialInstruction(&I)) {
+        It->second = &I;
+        break;
+      }
+    }
   }
-  return FirstSpecialInsts[BB];
+  return It->second;
 }
 
 bool InstructionPrecedenceTracking::hasSpecialInstructions(
@@ -64,20 +70,6 @@ bool InstructionPrecedenceTracking::isPreceededBySpecialInstruction(
   const Instruction *MaybeFirstSpecial =
       getFirstSpecialInstruction(Insn->getParent());
   return MaybeFirstSpecial && MaybeFirstSpecial->comesBefore(Insn);
-}
-
-void InstructionPrecedenceTracking::fill(const BasicBlock *BB) {
-  FirstSpecialInsts.erase(BB);
-  for (const auto &I : *BB) {
-    NumInstScanned++;
-    if (isSpecialInstruction(&I)) {
-      FirstSpecialInsts[BB] = &I;
-      return;
-    }
-  }
-
-  // Mark this block as having no special instructions.
-  FirstSpecialInsts[BB] = nullptr;
 }
 
 #ifndef NDEBUG


### PR DESCRIPTION
FirstSpecialInsts caches the first special instruction for each basic
block.  This patch "inlines" fill into getFirstSpecialInstruction, the
sole caller, to eliminate repeated hash lookups.
