### PR TITLE
[lld] Use *Set::insert_range (NFC)

### DIFF
--- a/lld/ELF/LinkerScript.cpp
+++ b/lld/ELF/LinkerScript.cpp
@@ -797,7 +797,7 @@ void LinkerScript::processSectionCommands() {
   if (!potentialSpillLists.empty()) {
     DenseSet<StringRef> insertNames;
     for (InsertCommand &ic : insertCommands)
-      insertNames.insert(ic.names.begin(), ic.names.end());
+      insertNames.insert_range(ic.names);
     for (SectionCommand *&base : sectionCommands) {
       auto *osd = dyn_cast<OutputDesc>(base);
       if (!osd)

--- a/lld/wasm/Writer.cpp
+++ b/lld/wasm/Writer.cpp
@@ -588,7 +588,7 @@ void Writer::populateTargetFeatures() {
 
   if (ctx.arg.extraFeatures.has_value()) {
     auto &extraFeatures = *ctx.arg.extraFeatures;
-    allowed.insert(extraFeatures.begin(), extraFeatures.end());
+    allowed.insert_range(extraFeatures);
   }
 
   // Only infer used features if user did not specify features
@@ -596,7 +596,7 @@ void Writer::populateTargetFeatures() {
 
   if (!inferFeatures) {
     auto &explicitFeatures = *ctx.arg.features;
-    allowed.insert(explicitFeatures.begin(), explicitFeatures.end());
+    allowed.insert_range(explicitFeatures);
     if (!ctx.arg.checkFeatures)
       goto done;
   }


### PR DESCRIPTION
DenseSet, SmallPtrSet, SmallSet, SetVector, and StringSet recently
gained C++23-style insert_range.  This patch replaces:

  Dest.insert(Src.begin(), Src.end());

with:

  Dest.insert_range(Src);
