### PR TITLE
[llvm] Use *Set::insert_range (NFC)

### DIFF
--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -553,7 +553,7 @@ Error StructType::checkBody(ArrayRef<Type *> Elements) {
     if (Ty == this)
       return createStringError(Twine("identified structure type '") +
                                getName() + "' is recursive");
-    Worklist.insert(Ty->subtype_begin(), Ty->subtype_end());
+    Worklist.insert_range(Ty->subtypes());
   }
   return Error::success();
 }

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -7215,7 +7215,7 @@ void Verifier::verifyCompileUnits() {
   auto *CUs = M.getNamedMetadata("llvm.dbg.cu");
   SmallPtrSet<const Metadata *, 2> Listed;
   if (CUs)
-    Listed.insert(CUs->op_begin(), CUs->op_end());
+    Listed.insert_range(CUs->operands());
   for (const auto *CU : CUVisited)
     CheckDI(Listed.count(CU), "DICompileUnit not listed in llvm.dbg.cu", CU);
   CUVisited.clear();

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -1439,9 +1439,9 @@ public:
         AddStream(std::move(AddStream)), Cache(std::move(Cache)),
         ShouldEmitIndexFiles(ShouldEmitIndexFiles) {
     auto &Defs = CombinedIndex.cfiFunctionDefs();
-    CfiFunctionDefs.insert(Defs.guid_begin(), Defs.guid_end());
+    CfiFunctionDefs.insert_range(Defs.guids());
     auto &Decls = CombinedIndex.cfiFunctionDecls();
-    CfiFunctionDecls.insert(Decls.guid_begin(), Decls.guid_end());
+    CfiFunctionDecls.insert_range(Decls.guids());
   }
 
   virtual Error runThinLTOBackendThread(

--- a/llvm/lib/Transforms/Scalar/LowerMatrixIntrinsics.cpp
+++ b/llvm/lib/Transforms/Scalar/LowerMatrixIntrinsics.cpp
@@ -1972,7 +1972,7 @@ public:
         if (CurrI->mayHaveSideEffects() || CurrI->mayReadFromMemory())
           return;
         ToHoist.push_back(CurrI);
-        WorkList.insert(CurrI->op_begin(), CurrI->op_end());
+        WorkList.insert_range(CurrI->operands());
       }
 
       sort(ToHoist, [this](Instruction *A, Instruction *B) {

--- a/llvm/lib/Transforms/Utils/LoopUnrollAndJam.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUnrollAndJam.cpp
@@ -102,7 +102,7 @@ static bool partitionOuterLoopBlocks(
     Loop &Root, Loop &JamLoop, BasicBlockSet &JamLoopBlocks,
     DenseMap<Loop *, BasicBlockSet> &ForeBlocksMap,
     DenseMap<Loop *, BasicBlockSet> &AftBlocksMap, DominatorTree &DT) {
-  JamLoopBlocks.insert(JamLoop.block_begin(), JamLoop.block_end());
+  JamLoopBlocks.insert_range(JamLoop.blocks());
 
   for (Loop *L : Root.getLoopsInPreorder()) {
     if (L == &JamLoop)
@@ -122,7 +122,7 @@ static bool partitionOuterLoopBlocks(Loop *L, Loop *SubLoop,
                                      BasicBlockSet &SubLoopBlocks,
                                      BasicBlockSet &AftBlocks,
                                      DominatorTree *DT) {
-  SubLoopBlocks.insert(SubLoop->block_begin(), SubLoop->block_end());
+  SubLoopBlocks.insert_range(SubLoop->blocks());
   return partitionLoopBlocks(*L, ForeBlocks, AftBlocks, *DT);
 }
 

--- a/llvm/lib/Transforms/Utils/LoopUtils.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUtils.cpp
@@ -701,7 +701,7 @@ void llvm::deleteDeadLoop(Loop *L, DominatorTree *DT, ScalarEvolution *SE,
     // otherwise our loop iterators won't work.
 
     SmallPtrSet<BasicBlock *, 8> blocks;
-    blocks.insert(L->block_begin(), L->block_end());
+    blocks.insert_range(L->blocks());
     for (BasicBlock *BB : blocks)
       LI->removeBlock(BB);
 

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -2970,7 +2970,7 @@ void InnerLoopVectorizer::sinkScalarOperands(Instruction *PredInst) {
       // may have failed to sink I's operands (recursively), which we try
       // (again) here.
       if (I->getParent() == PredBB) {
-        Worklist.insert(I->op_begin(), I->op_end());
+        Worklist.insert_range(I->operands());
         continue;
       }
 
@@ -2985,7 +2985,7 @@ void InnerLoopVectorizer::sinkScalarOperands(Instruction *PredInst) {
       // Move the instruction to the beginning of the predicated block, and add
       // it's operands to the worklist.
       I->moveBefore(PredBB->getFirstInsertionPt());
-      Worklist.insert(I->op_begin(), I->op_end());
+      Worklist.insert_range(I->operands());
 
       // The sinking may have enabled other instructions to be sunk, so we will
       // need to iterate.

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -582,7 +582,7 @@ static SmallVector<VPUser *> collectUsersRecursively(VPValue *V) {
     if (isa<VPHeaderPHIRecipe>(Cur))
       continue;
     for (VPValue *V : Cur->definedValues())
-      Users.insert(V->user_begin(), V->user_end());
+      Users.insert_range(V->users());
   }
   return Users.takeVector();
 }


### PR DESCRIPTION
DenseSet, SmallPtrSet, SmallSet, SetVector, and StringSet recently
gained C++23-style insert_range.  This patch uses insert_range with
iterator ranges.  For each case, I've verified that foos is defined as
make_range(foo_begin(), foo_end()) or in a similar manner.
