### PR TITLE
[libc++] Remove a few incorrect _LIBCPP_EXPORTED_FROM_ABI annotations

### DIFF
--- a/libcxx/docs/DesignDocs/VisibilityMacros.rst
+++ b/libcxx/docs/DesignDocs/VisibilityMacros.rst
@@ -33,7 +33,7 @@ Visibility Macros
   this macro applies `dllimport`/`dllexport` to the symbol, and on other
   platforms it gives the symbol default visibility. This macro should never be
   used on class templates. On classes it should only be used if the vtable
-  should be in the shared library.
+  lives in the built library.
 
 **_LIBCPP_OVERRIDABLE_FUNC_VIS**
   Mark a symbol as being exported by the libc++ library, but allow it to be

--- a/libcxx/docs/DesignDocs/VisibilityMacros.rst
+++ b/libcxx/docs/DesignDocs/VisibilityMacros.rst
@@ -31,7 +31,9 @@ Visibility Macros
   Mark a symbol as being part of our ABI. This includes functions that are part
   of the libc++ library, type information and other symbols. On Windows,
   this macro applies `dllimport`/`dllexport` to the symbol, and on other
-  platforms it gives the symbol default visibility.
+  platforms it gives the symbol default visibility. This macro should never be
+  used on class templates. On classes it should only be used if the vtable
+  should be in the shared library.
 
 **_LIBCPP_OVERRIDABLE_FUNC_VIS**
   Mark a symbol as being exported by the libc++ library, but allow it to be

--- a/libcxx/include/__charconv/from_chars_result.h
+++ b/libcxx/include/__charconv/from_chars_result.h
@@ -21,7 +21,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 17
 
-struct _LIBCPP_EXPORTED_FROM_ABI from_chars_result {
+struct from_chars_result {
   const char* ptr;
   errc ec;
 #  if _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__charconv/to_chars_result.h
+++ b/libcxx/include/__charconv/to_chars_result.h
@@ -21,7 +21,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 17
 
-struct _LIBCPP_EXPORTED_FROM_ABI to_chars_result {
+struct to_chars_result {
   char* ptr;
   errc ec;
 #  if _LIBCPP_STD_VER >= 20

--- a/libcxx/include/__filesystem/file_status.h
+++ b/libcxx/include/__filesystem/file_status.h
@@ -22,7 +22,7 @@
 
 _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM
 
-class _LIBCPP_EXPORTED_FROM_ABI file_status {
+class file_status {
 public:
   // constructors
   _LIBCPP_HIDE_FROM_ABI file_status() noexcept : file_status(file_type::none) {}

--- a/libcxx/include/__filesystem/path.h
+++ b/libcxx/include/__filesystem/path.h
@@ -861,7 +861,7 @@ public:
   }
 
   // iterators
-  class _LIBCPP_EXPORTED_FROM_ABI iterator;
+  class iterator;
   typedef iterator const_iterator;
 
   iterator begin() const;

--- a/libcxx/include/__filesystem/space_info.h
+++ b/libcxx/include/__filesystem/space_info.h
@@ -21,7 +21,7 @@
 
 _LIBCPP_BEGIN_NAMESPACE_FILESYSTEM
 
-struct _LIBCPP_EXPORTED_FROM_ABI space_info {
+struct space_info {
   uintmax_t capacity;
   uintmax_t free;
   uintmax_t available;

--- a/libcxx/include/__format/formatter_output.h
+++ b/libcxx/include/__format/formatter_output.h
@@ -45,7 +45,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace __formatter {
 
-struct _LIBCPP_EXPORTED_FROM_ABI __padding_size_result {
+struct __padding_size_result {
   size_t __before_;
   size_t __after_;
 };

--- a/libcxx/include/__memory_resource/pool_options.h
+++ b/libcxx/include/__memory_resource/pool_options.h
@@ -24,7 +24,7 @@ namespace pmr {
 
 // [mem.res.pool.options]
 
-struct _LIBCPP_EXPORTED_FROM_ABI pool_options {
+struct pool_options {
   size_t max_blocks_per_chunk        = 0;
   size_t largest_required_pool_block = 0;
 };

--- a/libcxx/include/__mutex/tag_types.h
+++ b/libcxx/include/__mutex/tag_types.h
@@ -17,15 +17,15 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-struct _LIBCPP_EXPORTED_FROM_ABI defer_lock_t {
+struct defer_lock_t {
   explicit defer_lock_t() = default;
 };
 
-struct _LIBCPP_EXPORTED_FROM_ABI try_to_lock_t {
+struct try_to_lock_t {
   explicit try_to_lock_t() = default;
 };
 
-struct _LIBCPP_EXPORTED_FROM_ABI adopt_lock_t {
+struct adopt_lock_t {
   explicit adopt_lock_t() = default;
 };
 

--- a/libcxx/include/__new/nothrow_t.h
+++ b/libcxx/include/__new/nothrow_t.h
@@ -19,7 +19,7 @@
 #  include <new.h>
 #else
 _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
-struct _LIBCPP_EXPORTED_FROM_ABI nothrow_t {
+struct nothrow_t {
   explicit nothrow_t() = default;
 };
 extern _LIBCPP_EXPORTED_FROM_ABI const nothrow_t nothrow;

--- a/libcxx/include/__system_error/error_category.h
+++ b/libcxx/include/__system_error/error_category.h
@@ -20,7 +20,7 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-class _LIBCPP_EXPORTED_FROM_ABI error_condition;
+class error_condition;
 class _LIBCPP_EXPORTED_FROM_ABI error_code;
 
 class _LIBCPP_HIDDEN __do_message;

--- a/libcxx/include/__thread/id.h
+++ b/libcxx/include/__thread/id.h
@@ -23,7 +23,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_HAS_THREADS
-class _LIBCPP_EXPORTED_FROM_ABI __thread_id;
+class __thread_id;
 
 namespace this_thread {
 

--- a/libcxx/include/__tuple/sfinae_helpers.h
+++ b/libcxx/include/__tuple/sfinae_helpers.h
@@ -19,7 +19,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #ifndef _LIBCPP_CXX03_LANG
 
-struct _LIBCPP_EXPORTED_FROM_ABI __check_tuple_constructor_fail {
+struct __check_tuple_constructor_fail {
   static _LIBCPP_HIDE_FROM_ABI constexpr bool __enable_explicit_default() { return false; }
   static _LIBCPP_HIDE_FROM_ABI constexpr bool __enable_implicit_default() { return false; }
   template <class...>

--- a/libcxx/include/__utility/in_place.h
+++ b/libcxx/include/__utility/in_place.h
@@ -22,7 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 17
 
-struct _LIBCPP_EXPORTED_FROM_ABI in_place_t {
+struct in_place_t {
   explicit in_place_t() = default;
 };
 inline constexpr in_place_t in_place{};


### PR DESCRIPTION
This has two benefits:
- It is less likely that the macro will be copy-pasted around when unnecessary
- We can drop `_LIBCPP_HIDE_FROM_ABI` from any member functions once we are able to make `_LIBCPP_HIDE_FROM_ABI` the default within libc++