### PR TITLE
[LoongArch] Allow recognition of `b{lt,gt,le,ge}z` in disassembly

### DIFF
--- a/llvm/lib/Target/LoongArch/LoongArchInstrInfo.td
+++ b/llvm/lib/Target/LoongArch/LoongArchInstrInfo.td
@@ -2294,11 +2294,15 @@ def : InstAlias<"move $dst, $src", (OR GPR:$dst, GPR:$src, R0)>;
 def : InstAlias<"ret", (JIRL R0, R1, 0)>;
 def : InstAlias<"jr $rj", (JIRL R0, GPR:$rj, 0)>;
 
-// Branches implemented with alias.
-// Always output the canonical mnemonic for the pseudo branch instructions.
-// The GNU tools emit the canonical mnemonic for the branch pseudo instructions
-// as well (e.g. "bgt" will be recognised by the assembler but never printed by
-// objdump). Match this behaviour by setting a zero weight.
+// Branches implemented with aliases.
+// Disassemble branch instructions not having a $zero operand to the
+// canonical mnemonics respectively, but disassemble BLT/BGE with a $zero
+// operand to the corresponding pseudo-instruction.
+// GNU Binutils behave like this since 2.41, e.g. "bgt" will be recognised
+// by the assembler but always disassembles as "blt" by objdump, while "bgtz"
+// will come back intact.
+// Match this behaviour by setting a zero weight for the b{gt,le}{,u}
+// patterns only.
 def : InstAlias<"bgt $rj, $rd, $imm16",
                 (BLT GPR:$rd, GPR:$rj, simm16_lsl2_br:$imm16), 0>;
 def : InstAlias<"bgtu $rj, $rd, $imm16",
@@ -2308,13 +2312,13 @@ def : InstAlias<"ble $rj, $rd, $imm16",
 def : InstAlias<"bleu $rj, $rd, $imm16",
                 (BGEU GPR:$rd, GPR:$rj, simm16_lsl2_br:$imm16), 0>;
 def : InstAlias<"bltz $rd, $imm16",
-                (BLT GPR:$rd, R0, simm16_lsl2_br:$imm16), 0>;
+                (BLT GPR:$rd, R0, simm16_lsl2_br:$imm16)>;
 def : InstAlias<"bgtz $rj, $imm16",
-                (BLT R0, GPR:$rj, simm16_lsl2_br:$imm16), 0>;
+                (BLT R0, GPR:$rj, simm16_lsl2_br:$imm16)>;
 def : InstAlias<"blez $rj, $imm16",
-                (BGE R0, GPR:$rj, simm16_lsl2_br:$imm16), 0>;
+                (BGE R0, GPR:$rj, simm16_lsl2_br:$imm16)>;
 def : InstAlias<"bgez $rd, $imm16",
-                (BGE GPR:$rd, R0, simm16_lsl2_br:$imm16), 0>;
+                (BGE GPR:$rd, R0, simm16_lsl2_br:$imm16)>;
 
 // Load immediate.
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0, isCodeGenOnly = 0,

--- a/llvm/test/MC/LoongArch/Macros/aliases-br.s
+++ b/llvm/test/MC/LoongArch/Macros/aliases-br.s
@@ -9,10 +9,10 @@ ble   $a1, $a0, 16
 bleu  $a1, $a0, 16
 # CHECK-NEXT: bgeu    $a0, $a1, 16
 bltz   $a0, 16
-# CHECK-NEXT: blt     $a0, $zero, 16
+# CHECK-NEXT: bltz    $a0, 16
 bgtz   $a0, 16
-# CHECK-NEXT: blt     $zero, $a0, 16
+# CHECK-NEXT: bgtz    $a0, 16
 blez   $a0, 16
-# CHECK-NEXT: bge     $zero, $a0, 16
+# CHECK-NEXT: blez    $a0, 16
 bgez   $a0, 16
-# CHECK-NEXT: bge     $a0, $zero, 16
+# CHECK-NEXT: bgez    $a0, 16


### PR DESCRIPTION
This behavior is implemented for GNU Binutils since 2.41, and benefits the readability of the disassembly output. Do the same for LLVM by removing the zero weight from the alias definitions respectively.