### PR TITLE
[ADT] Add range constructors to *Set

### DIFF
--- a/llvm/include/llvm/ADT/SetVector.h
+++ b/llvm/include/llvm/ADT/SetVector.h
@@ -24,6 +24,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Compiler.h"
 #include <cassert>
@@ -81,6 +82,10 @@ public:
   SetVector(It Start, It End) {
     insert(Start, End);
   }
+
+  template <typename Range>
+  SetVector(llvm::from_range_t, Range &&R)
+      : SetVector(adl_begin(R), adl_end(R)) {}
 
   ArrayRef<value_type> getArrayRef() const { return vector_; }
 

--- a/llvm/include/llvm/ADT/SmallPtrSet.h
+++ b/llvm/include/llvm/ADT/SmallPtrSet.h
@@ -17,6 +17,7 @@
 
 #include "llvm/ADT/ADL.h"
 #include "llvm/ADT/EpochTracker.h"
+#include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/ReverseIteration.h"
 #include "llvm/Support/type_traits.h"
@@ -555,6 +556,10 @@ public:
   SmallPtrSet(It I, It E) : BaseT(SmallStorage, SmallSizePowTwo) {
     this->insert(I, E);
   }
+
+  template <typename Range>
+  SmallPtrSet(llvm::from_range_t, Range &&R)
+      : SmallPtrSet(adl_begin(R), adl_end(R)) {}
 
   SmallPtrSet(std::initializer_list<PtrType> IL)
       : BaseT(SmallStorage, SmallSizePowTwo) {

--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -15,6 +15,7 @@
 #define LLVM_ADT_SMALLSET_H
 
 #include "llvm/ADT/ADL.h"
+#include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator.h"
@@ -155,6 +156,10 @@ public:
   template <typename IterT> SmallSet(IterT Begin, IterT End) {
     insert(Begin, End);
   }
+
+  template <typename Range>
+  SmallSet(llvm::from_range_t, Range &&R)
+      : SmallSet(adl_begin(R), adl_end(R)) {}
 
   template <typename RangeT>
   explicit SmallSet(const iterator_range<RangeT> &R) {

--- a/llvm/include/llvm/ADT/StringSet.h
+++ b/llvm/include/llvm/ADT/StringSet.h
@@ -15,6 +15,7 @@
 #define LLVM_ADT_STRINGSET_H
 
 #include "llvm/ADT/ADL.h"
+#include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/StringMap.h"
 
 namespace llvm {
@@ -29,6 +30,9 @@ public:
   StringSet(std::initializer_list<StringRef> initializer) {
     for (StringRef str : initializer)
       insert(str);
+  }
+  template <typename Range> StringSet(llvm::from_range_t, Range &&R) {
+    insert(adl_begin(R), adl_end(R));
   }
   template <typename Container> explicit StringSet(Container &&C) {
     for (auto &&Str : C)

--- a/llvm/unittests/ADT/SetVectorTest.cpp
+++ b/llvm/unittests/ADT/SetVectorTest.cpp
@@ -88,6 +88,12 @@ TEST(SetVector, ConstPtrKeyTest) {
   EXPECT_FALSE(S.contains((const int *)&j));
 }
 
+TEST(SetVector, CtorRange) {
+  constexpr unsigned Args[] = {3, 1, 2};
+  SetVector<unsigned> Set(llvm::from_range, Args);
+  EXPECT_THAT(Set, ::testing::ElementsAre(3, 1, 2));
+}
+
 TEST(SetVector, InsertRange) {
   SetVector<unsigned> Set;
   constexpr unsigned Args[] = {3, 1, 2};

--- a/llvm/unittests/ADT/SmallPtrSetTest.cpp
+++ b/llvm/unittests/ADT/SmallPtrSetTest.cpp
@@ -411,6 +411,15 @@ TEST(SmallPtrSetTest, RemoveIf) {
   EXPECT_FALSE(Removed);
 }
 
+TEST(SmallPtrSetTest, CtorRange) {
+  int V0 = 0;
+  int V1 = 1;
+  int V2 = 2;
+  int *Args[] = {&V2, &V0, &V1};
+  SmallPtrSet<int *, 4> Set(llvm::from_range, Args);
+  EXPECT_THAT(Set, UnorderedElementsAre(&V0, &V1, &V2));
+}
+
 TEST(SmallPtrSetTest, InsertRange) {
   int V0 = 0;
   int V1 = 1;

--- a/llvm/unittests/ADT/SmallSetTest.cpp
+++ b/llvm/unittests/ADT/SmallSetTest.cpp
@@ -127,6 +127,12 @@ TEST(SmallSetTest, InsertPerfectFwd) {
   }
 }
 
+TEST(SmallSetTest, CtorRange) {
+  constexpr unsigned Args[] = {3, 1, 2};
+  SmallSet<int, 4> s1(llvm::from_range, Args);
+  EXPECT_THAT(s1, ::testing::UnorderedElementsAre(1, 2, 3));
+}
+
 TEST(SmallSetTest, InsertRange) {
   SmallSet<int, 4> s1;
   constexpr unsigned Args[] = {3, 1, 2};

--- a/llvm/unittests/ADT/StringSetTest.cpp
+++ b/llvm/unittests/ADT/StringSetTest.cpp
@@ -81,6 +81,15 @@ TEST_F(StringSetTest, Equal) {
   ASSERT_TRUE(A == A);
 }
 
+TEST_F(StringSetTest, CtorRange) {
+  const char *Args[] = {"chair", "desk", "bed"};
+  StringSet<> Set(llvm::from_range, Args);
+  EXPECT_EQ(Set.size(), 3U);
+  EXPECT_TRUE(Set.contains("bed"));
+  EXPECT_TRUE(Set.contains("chair"));
+  EXPECT_TRUE(Set.contains("desk"));
+}
+
 TEST_F(StringSetTest, InsertRange) {
   StringSet<> Set;
   const char *Args[] = {"chair", "desk", "bed"};


### PR DESCRIPTION
DenseSet recently gained a range constructor:

  DenseSet<T> Dest(llvm::from_range, Src);

This patch adds the same signature to SetVector, SmallPtrSet,
SmallSet, and StringSet for consistency.
