### PR TITLE
[ADT] Add a range constructor to SmallSetVector

### DIFF
--- a/llvm/include/llvm/ADT/SetVector.h
+++ b/llvm/include/llvm/ADT/SetVector.h
@@ -386,6 +386,10 @@ public:
   SmallSetVector(It Start, It End) {
     this->insert(Start, End);
   }
+
+  template <typename Range>
+  SmallSetVector(llvm::from_range_t, Range &&R)
+      : SmallSetVector(adl_begin(R), adl_end(R)) {}
 };
 
 } // end namespace llvm

--- a/llvm/unittests/ADT/SetVectorTest.cpp
+++ b/llvm/unittests/ADT/SetVectorTest.cpp
@@ -100,3 +100,9 @@ TEST(SetVector, InsertRange) {
   Set.insert_range(Args);
   EXPECT_THAT(Set, ::testing::ElementsAre(3, 1, 2));
 }
+
+TEST(SmallSetVector, CtorRange) {
+  constexpr unsigned Args[] = {3, 1, 2};
+  SmallSetVector<unsigned, 4> Set(llvm::from_range, Args);
+  EXPECT_THAT(Set, ::testing::ElementsAre(3, 1, 2));
+}


### PR DESCRIPTION
DenseSet recently gained a range constructor:

  DenseSet<T> Dest(llvm::from_range, Src);

This patch adds the same signature to SmallSetVector for consistency.
