### PR TITLE
[MC] Account for AcquireAtCycle in getReciprocalThroughput

### DIFF
--- a/llvm/lib/MC/MCSchedule.cpp
+++ b/llvm/lib/MC/MCSchedule.cpp
@@ -96,19 +96,22 @@ int MCSchedModel::computeInstrLatency(const MCSubtargetInfo &STI,
 double
 MCSchedModel::getReciprocalThroughput(const MCSubtargetInfo &STI,
                                       const MCSchedClassDesc &SCDesc) {
-  std::optional<double> Throughput;
+  std::optional<double> MinThroughput;
   const MCSchedModel &SM = STI.getSchedModel();
   const MCWriteProcResEntry *I = STI.getWriteProcResBegin(&SCDesc);
   const MCWriteProcResEntry *E = STI.getWriteProcResEnd(&SCDesc);
   for (; I != E; ++I) {
-    if (!I->ReleaseAtCycle)
+    if (!I->ReleaseAtCycle || I->ReleaseAtCycle == I->AcquireAtCycle)
       continue;
+    assert(I->ReleaseAtCycle > I->AcquireAtCycle);
     unsigned NumUnits = SM.getProcResource(I->ProcResourceIdx)->NumUnits;
-    double Temp = NumUnits * 1.0 / I->ReleaseAtCycle;
-    Throughput = Throughput ? std::min(*Throughput, Temp) : Temp;
+    double Throughput =
+        double(NumUnits) / double(I->ReleaseAtCycle - I->AcquireAtCycle);
+    MinThroughput =
+        MinThroughput ? std::min(*MinThroughput, Throughput) : Throughput;
   }
-  if (Throughput)
-    return 1.0 / *Throughput;
+  if (MinThroughput)
+    return 1.0 / *MinThroughput;
 
   // If no throughput value was calculated, assume that we can execute at the
   // maximum issue width scaled by number of micro-ops for the schedule class.

--- a/llvm/lib/MC/MCSchedule.cpp
+++ b/llvm/lib/MC/MCSchedule.cpp
@@ -103,7 +103,7 @@ MCSchedModel::getReciprocalThroughput(const MCSubtargetInfo &STI,
   for (; I != E; ++I) {
     if (!I->ReleaseAtCycle || I->ReleaseAtCycle == I->AcquireAtCycle)
       continue;
-    assert(I->ReleaseAtCycle > I->AcquireAtCycle);
+    assert(I->ReleaseAtCycle > I->AcquireAtCycle && "invalid resource segment");
     unsigned NumUnits = SM.getProcResource(I->ProcResourceIdx)->NumUnits;
     double Throughput =
         double(NumUnits) / double(I->ReleaseAtCycle - I->AcquireAtCycle);

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/different-lmul-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/different-lmul-instruments.s
@@ -28,9 +28,9 @@ vadd.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/different-sew-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/different-sew-instruments.s
@@ -29,9 +29,9 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   241.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   115.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/disable-im.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/disable-im.s
@@ -31,11 +31,11 @@ vadd.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/fractional-lmul-data.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/fractional-lmul-data.s
@@ -29,9 +29,9 @@ vdiv.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      56    57.00                       vdiv.vv	v12, v12, v12
+# CHECK-NEXT:  1      56    56.00                       vdiv.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      30    31.00                       vdiv.vv	v12, v12, v12
+# CHECK-NEXT:  1      30    30.00                       vdiv.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-at-start.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-at-start.s
@@ -25,7 +25,7 @@ vadd.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-in-middle.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-in-middle.s
@@ -25,9 +25,9 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  1      4     17.00                       vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     1.00                        vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-in-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-in-region.s
@@ -29,7 +29,7 @@ vadd.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-straddles-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/lmul-instrument-straddles-region.s
@@ -30,7 +30,7 @@ vadd.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/multiple-same-lmul-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/multiple-same-lmul-instruments.s
@@ -33,13 +33,13 @@ vsub.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
-# CHECK-NEXT:  1      4     3.00                        vsub.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     2.00                        vsub.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vadd.vv	v12, v12, v12
-# CHECK-NEXT:  1      4     9.00                        vsub.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     8.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     8.00                        vsub.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/multiple-same-sew-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/multiple-same-sew-instruments.s
@@ -34,13 +34,13 @@ vdivu.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   115.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   115.00                      vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  1      114   115.00                      vdivu.vv	v8, v8, v12
+# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      114   114.00                      vdivu.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e32, m1, tu, mu
-# CHECK-NEXT:  1      112   113.00                      vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  1      112   113.00                      vdivu.vv	v8, v8, v12
+# CHECK-NEXT:  1      112   112.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      112   112.00                      vdivu.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/needs-sew-but-only-lmul.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/needs-sew-but-only-lmul.s
@@ -28,8 +28,8 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   241.00                      vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  1      240   241.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/no-vsetvli-to-start.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/no-vsetvli-to-start.s
@@ -24,9 +24,9 @@ vadd.vv v12, v12, v12
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  1      4     17.00                       vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/reductions.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/reductions.s
@@ -241,211 +241,211 @@ vfredmin.vs  v4, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      46    47.00                       vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    46.00                       vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      46    47.00                       vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    46.00                       vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      46    47.00                       vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    46.00                       vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      47    48.00                       vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      47    47.00                       vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      49    50.00                       vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      49    49.00                       vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      53    54.00                       vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      53    53.00                       vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      61    62.00                       vredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      61    61.00                       vredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      41    42.00                       vredand.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    41.00                       vredand.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      41    42.00                       vredand.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    41.00                       vredand.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      42    43.00                       vredand.vs	v4, v8, v12
+# CHECK-NEXT:  1      42    42.00                       vredand.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      44    45.00                       vredand.vs	v4, v8, v12
+# CHECK-NEXT:  1      44    44.00                       vredand.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      48    49.00                       vredand.vs	v4, v8, v12
+# CHECK-NEXT:  1      48    48.00                       vredand.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      56    57.00                       vredand.vs	v4, v8, v12
+# CHECK-NEXT:  1      56    56.00                       vredand.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      36    37.00                       vredor.vs	v4, v8, v12
+# CHECK-NEXT:  1      36    36.00                       vredor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      37    38.00                       vredor.vs	v4, v8, v12
+# CHECK-NEXT:  1      37    37.00                       vredor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      39    40.00                       vredor.vs	v4, v8, v12
+# CHECK-NEXT:  1      39    39.00                       vredor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      43    44.00                       vredor.vs	v4, v8, v12
+# CHECK-NEXT:  1      43    43.00                       vredor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      51    52.00                       vredor.vs	v4, v8, v12
+# CHECK-NEXT:  1      51    51.00                       vredor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      32    33.00                       vredxor.vs	v4, v8, v12
+# CHECK-NEXT:  1      32    32.00                       vredxor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      34    35.00                       vredxor.vs	v4, v8, v12
+# CHECK-NEXT:  1      34    34.00                       vredxor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      38    39.00                       vredxor.vs	v4, v8, v12
+# CHECK-NEXT:  1      38    38.00                       vredxor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      46    47.00                       vredxor.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    46.00                       vredxor.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      46    47.00                       vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    46.00                       vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      46    47.00                       vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    46.00                       vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      46    47.00                       vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    46.00                       vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      47    48.00                       vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  1      47    47.00                       vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      49    50.00                       vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  1      49    49.00                       vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      53    54.00                       vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  1      53    53.00                       vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      61    62.00                       vredmaxu.vs	v4, v8, v12
+# CHECK-NEXT:  1      61    61.00                       vredmaxu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      41    42.00                       vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    41.00                       vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      41    42.00                       vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    41.00                       vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      42    43.00                       vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      42    42.00                       vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      44    45.00                       vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      44    44.00                       vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      48    49.00                       vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      48    48.00                       vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      56    57.00                       vredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      56    56.00                       vredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      36    37.00                       vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  1      36    36.00                       vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      37    38.00                       vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  1      37    37.00                       vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      39    40.00                       vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  1      39    39.00                       vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      43    44.00                       vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  1      43    43.00                       vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      51    52.00                       vredminu.vs	v4, v8, v12
+# CHECK-NEXT:  1      51    51.00                       vredminu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      32    33.00                       vredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      32    32.00                       vredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      34    35.00                       vredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      34    34.00                       vredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      38    39.00                       vredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      38    38.00                       vredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      46    47.00                       vredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    46.00                       vredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      46    47.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    46.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      46    47.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    46.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      46    47.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    46.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      47    48.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      47    47.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      49    50.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      49    49.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      53    54.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      53    53.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      61    62.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      61    61.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      41    42.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    41.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      41    42.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    41.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      42    43.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      42    42.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      44    45.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      44    44.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      48    49.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      48    48.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      56    57.00                       vwredsumu.vs	v4, v8, v12
+# CHECK-NEXT:  1      56    56.00                       vwredsumu.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      36    37.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      36    36.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      37    38.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      37    37.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      39    40.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      39    39.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      43    44.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      43    43.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      51    52.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      51    51.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      61    62.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      61    61.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      61    62.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      61    61.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      61    62.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      61    61.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      61    62.00                       vwredsum.vs	v4, v8, v12
+# CHECK-NEXT:  1      61    61.00                       vwredsum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      48    49.00                       vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      48    48.00                       vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      96    97.00                       vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      96    96.00                       vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      192   193.00                      vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      192   192.00                      vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      384   385.00                      vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      384   384.00                      vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      768   769.00                      vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      768   768.00                      vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1536   1537.00                      vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      1536   1536.00                      vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      48    49.00                       vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      48    48.00                       vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      96    97.00                       vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      96    96.00                       vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      192   193.00                      vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      192   192.00                      vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      384   385.00                      vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      384   384.00                      vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      768   769.00                      vfwredosum.vs	v4, v8, v12
+# CHECK-NEXT:  1      768   768.00                      vfwredosum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      41    42.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    41.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      41    42.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    41.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      42    43.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      42    42.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      44    45.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      44    44.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      48    49.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      48    48.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      56    57.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      56    56.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      36    37.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      36    36.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      37    38.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      37    37.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      39    40.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      39    39.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      43    44.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      43    43.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      51    52.00                       vfwredusum.vs	v4, v8, v12
+# CHECK-NEXT:  1      51    51.00                       vfwredusum.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      41    42.00                       vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    41.00                       vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      41    42.00                       vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      41    41.00                       vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      42    43.00                       vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      42    42.00                       vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      44    45.00                       vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      44    44.00                       vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      48    49.00                       vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      48    48.00                       vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      56    57.00                       vfredmax.vs	v4, v8, v12
+# CHECK-NEXT:  1      56    56.00                       vfredmax.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      36    37.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      36    36.00                       vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      37    38.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      37    37.00                       vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      39    40.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      39    39.00                       vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      43    44.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      43    43.00                       vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      51    52.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      51    51.00                       vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      32    33.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      32    32.00                       vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      34    35.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      34    34.00                       vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      38    39.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      38    38.00                       vfredmin.vs	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      46    47.00                       vfredmin.vs	v4, v8, v12
+# CHECK-NEXT:  1      46    46.00                       vfredmin.vs	v4, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-at-start.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-at-start.s
@@ -26,7 +26,7 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   241.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-in-middle.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-in-middle.s
@@ -30,9 +30,9 @@ vdiv.vv v8, v8, v12
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  1      1920   1921.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      1920   1920.00                      vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  1      912   913.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      912   912.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-in-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-in-region.s
@@ -30,7 +30,7 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   115.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-straddles-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-straddles-region.s
@@ -31,7 +31,7 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   115.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/strided-load-store.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/strided-load-store.s
@@ -143,105 +143,105 @@ vlse64.v v1, (a1), a2
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      11    9.00    *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      11    9.00    *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      11    9.00    *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      11    9.00    *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      19    17.00   *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      19    17.00   *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      19    17.00   *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      19    17.00   *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      35    33.00   *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      35    33.00   *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      35    33.00   *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      35    33.00   *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      35    32.00   *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      35    32.00   *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      35    32.00   *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      35    32.00   *                   vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      67    65.00   *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      67    65.00   *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      67    65.00   *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      67    65.00   *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      67    64.00   *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      67    64.00   *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      67    64.00   *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      67    64.00   *                   vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      131   129.00  *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      131   129.00  *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      131   129.00  *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      131   128.00  *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      131   128.00  *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      131   128.00  *                   vlse32.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      259   257.00  *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      259   257.00  *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      259   256.00  *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      259   256.00  *                   vlse16.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      515   513.00  *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      515   512.00  *                   vlse8.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      11    9.00    *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      11    9.00    *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      11    9.00    *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      11    9.00    *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      19    17.00   *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      19    17.00   *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      19    17.00   *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      19    17.00   *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      35    33.00   *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      35    33.00   *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      35    33.00   *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      35    33.00   *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      35    32.00   *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      35    32.00   *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      35    32.00   *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      35    32.00   *                   vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      67    65.00   *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      67    65.00   *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      67    65.00   *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      67    65.00   *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      67    64.00   *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      67    64.00   *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      67    64.00   *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      67    64.00   *                   vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      131   129.00  *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      131   129.00  *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      131   129.00  *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      131   128.00  *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      131   128.00  *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      131   128.00  *                   vlse32.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      259   257.00  *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      259   257.00  *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      259   256.00  *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      259   256.00  *                   vlse16.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      11    9.00    *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      11    9.00    *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      11    9.00    *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      11    9.00    *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      19    17.00   *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      19    17.00   *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      19    17.00   *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      19    17.00   *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      35    33.00   *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      35    33.00   *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      35    33.00   *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      35    33.00   *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      35    32.00   *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      35    32.00   *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      35    32.00   *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      35    32.00   *                   vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      67    65.00   *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      67    65.00   *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      67    65.00   *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      67    65.00   *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      67    64.00   *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      67    64.00   *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      67    64.00   *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      67    64.00   *                   vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      131   129.00  *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      131   129.00  *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      131   129.00  *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      131   128.00  *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      131   128.00  *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      131   128.00  *                   vlse32.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      11    9.00    *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      11    9.00    *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      11    9.00    *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      11    9.00    *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      19    17.00   *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      19    17.00   *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      19    17.00   *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      19    17.00   *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      35    33.00   *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      35    33.00   *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      35    33.00   *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      35    33.00   *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      35    32.00   *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      35    32.00   *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      35    32.00   *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      35    32.00   *                   vlse64.v	v1, (a1), a2
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      67    65.00   *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      67    65.00   *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      67    65.00   *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      67    65.00   *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      67    64.00   *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      67    64.00   *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      67    64.00   *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      67    64.00   *                   vlse64.v	v1, (a1), a2
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/strided-load-x0.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/strided-load-x0.s
@@ -55,31 +55,31 @@ vle64.v v1, (a1)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      19    17.00   *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      19    17.00   *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      19    17.00   *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      19    17.00   *                   vlse64.v	v1, (a1), a2
-# CHECK-NEXT:  1      19    17.00   *                   vlse8.v	v1, (a1), zero
-# CHECK-NEXT:  1      19    17.00   *                   vlse16.v	v1, (a1), zero
-# CHECK-NEXT:  1      19    17.00   *                   vlse32.v	v1, (a1), zero
-# CHECK-NEXT:  1      19    17.00   *                   vlse64.v	v1, (a1), zero
-# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a1)
-# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a1)
-# CHECK-NEXT:  1      4     3.00    *                   vle32.v	v1, (a1)
-# CHECK-NEXT:  1      4     5.00    *                   vle64.v	v1, (a1)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      11    9.00    *                   vlse8.v	v1, (a1), a2
-# CHECK-NEXT:  1      11    9.00    *                   vlse16.v	v1, (a1), a2
-# CHECK-NEXT:  1      11    9.00    *                   vlse32.v	v1, (a1), a2
-# CHECK-NEXT:  1      11    9.00    *                   vlse64.v	v1, (a1), a2
-# CHECK-NEXT:  1      11    9.00    *                   vlse8.v	v1, (a1), zero
-# CHECK-NEXT:  1      11    9.00    *                   vlse16.v	v1, (a1), zero
-# CHECK-NEXT:  1      11    9.00    *                   vlse32.v	v1, (a1), zero
-# CHECK-NEXT:  1      11    9.00    *                   vlse64.v	v1, (a1), zero
-# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a1)
-# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a1)
+# CHECK-NEXT:  1      19    16.00   *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      19    16.00   *                   vlse8.v	v1, (a1), zero
+# CHECK-NEXT:  1      19    16.00   *                   vlse16.v	v1, (a1), zero
+# CHECK-NEXT:  1      19    16.00   *                   vlse32.v	v1, (a1), zero
+# CHECK-NEXT:  1      19    16.00   *                   vlse64.v	v1, (a1), zero
+# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a1)
+# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a1)
 # CHECK-NEXT:  1      4     2.00    *                   vle32.v	v1, (a1)
-# CHECK-NEXT:  1      4     3.00    *                   vle64.v	v1, (a1)
+# CHECK-NEXT:  1      4     4.00    *                   vle64.v	v1, (a1)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      11    8.00    *                   vlse8.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse16.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse32.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse64.v	v1, (a1), a2
+# CHECK-NEXT:  1      11    8.00    *                   vlse8.v	v1, (a1), zero
+# CHECK-NEXT:  1      11    8.00    *                   vlse16.v	v1, (a1), zero
+# CHECK-NEXT:  1      11    8.00    *                   vlse32.v	v1, (a1), zero
+# CHECK-NEXT:  1      11    8.00    *                   vlse64.v	v1, (a1), zero
+# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a1)
+# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a1)
+# CHECK-NEXT:  1      4     1.00    *                   vle32.v	v1, (a1)
+# CHECK-NEXT:  1      4     2.00    *                   vle64.v	v1, (a1)
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vector-integer-arithmetic.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vector-integer-arithmetic.s
@@ -793,732 +793,732 @@ vmv.v.v v4, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vadd.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     1.00                        vadd.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vadd.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     1.00                        vadd.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vadd.vi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vsub.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      4     4.00                        vsub.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  1      4     8.00                        vrsub.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  1      4     16.00                       vrsub.vi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vadd.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vadd.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vadd.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vsub.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vsub.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vrsub.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vrsub.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      4     4.00                        vsub.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      4     8.00                        vsub.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  1      4     16.00                       vrsub.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vrsub.vi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vadd.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vadd.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vadd.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vsub.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vsub.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vrsub.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vrsub.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vadd.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vadd.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     4.00                        vadd.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vadd.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     8.00                        vadd.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vsub.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     16.00                       vsub.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vsub.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     2.00                        vsub.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vrsub.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     4.00                        vrsub.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vrsub.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     8.00                        vrsub.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vadd.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     16.00                       vadd.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwaddu.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     1.00                        vwaddu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwaddu.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     1.00                        vwaddu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwsubu.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     1.00                        vwsubu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vwsubu.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     2.00                        vwsubu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vwadd.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     4.00                        vwadd.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwadd.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     8.00                        vwadd.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwsub.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     8.00                        vwsub.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwsub.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     1.00                        vwsub.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwaddu.wv	v4, v8, v12
+# CHECK-NEXT:  1      8     1.00                        vwaddu.wv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vwaddu.wx	v4, v8, a0
+# CHECK-NEXT:  1      8     2.00                        vwaddu.wx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vwsubu.wv	v4, v8, v12
+# CHECK-NEXT:  1      8     4.00                        vwsubu.wv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwsubu.wx	v4, v8, a0
+# CHECK-NEXT:  1      8     8.00                        vwsubu.wx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwadd.wv	v4, v8, v12
+# CHECK-NEXT:  1      8     8.00                        vwadd.wv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwadd.wx	v4, v8, a0
+# CHECK-NEXT:  1      8     1.00                        vwadd.wx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vwsub.wv	v4, v8, v12
+# CHECK-NEXT:  1      8     2.00                        vwsub.wv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vwsub.wx	v4, v8, a0
+# CHECK-NEXT:  1      8     4.00                        vwsub.wx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwaddu.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     8.00                        vwaddu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwaddu.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     8.00                        vwaddu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     2.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     1.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     1.00                        vsext.vf2	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     1.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vzext.vf2	v4, v8
 # CHECK-NEXT:  1      4     2.00                        vsext.vf2	v4, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     3.00                        vsext.vf2	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     5.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     4.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     4.00                        vsext.vf2	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     9.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     8.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     8.00                        vsext.vf2	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     17.00                       vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     16.00                       vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     16.00                       vsext.vf2	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     1.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     1.00                        vzext.vf4	v4, v8
+# CHECK-NEXT:  1      4     1.00                        vsext.vf4	v4, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vzext.vf2	v4, v8
 # CHECK-NEXT:  1      4     2.00                        vsext.vf2	v4, v8
 # CHECK-NEXT:  1      4     2.00                        vzext.vf4	v4, v8
 # CHECK-NEXT:  1      4     2.00                        vsext.vf4	v4, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     3.00                        vsext.vf2	v4, v8
-# CHECK-NEXT:  1      4     3.00                        vzext.vf4	v4, v8
-# CHECK-NEXT:  1      4     3.00                        vsext.vf4	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     5.00                        vsext.vf2	v4, v8
-# CHECK-NEXT:  1      4     5.00                        vzext.vf4	v4, v8
-# CHECK-NEXT:  1      4     5.00                        vsext.vf4	v4, v8
+# CHECK-NEXT:  1      4     4.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     4.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     4.00                        vzext.vf4	v4, v8
+# CHECK-NEXT:  1      4     4.00                        vsext.vf4	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     9.00                        vsext.vf2	v4, v8
-# CHECK-NEXT:  1      4     9.00                        vzext.vf4	v4, v8
-# CHECK-NEXT:  1      4     9.00                        vsext.vf4	v4, v8
+# CHECK-NEXT:  1      4     8.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     8.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     8.00                        vzext.vf4	v4, v8
+# CHECK-NEXT:  1      4     8.00                        vsext.vf4	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     17.00                       vsext.vf2	v4, v8
-# CHECK-NEXT:  1      4     17.00                       vzext.vf4	v4, v8
-# CHECK-NEXT:  1      4     17.00                       vsext.vf4	v4, v8
+# CHECK-NEXT:  1      4     16.00                       vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     16.00                       vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     16.00                       vzext.vf4	v4, v8
+# CHECK-NEXT:  1      4     16.00                       vsext.vf4	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     3.00                        vsext.vf2	v4, v8
-# CHECK-NEXT:  1      4     3.00                        vzext.vf4	v4, v8
-# CHECK-NEXT:  1      4     3.00                        vsext.vf4	v4, v8
-# CHECK-NEXT:  1      4     3.00                        vzext.vf8	v4, v8
-# CHECK-NEXT:  1      4     3.00                        vsext.vf8	v4, v8
+# CHECK-NEXT:  1      4     2.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     2.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     2.00                        vzext.vf4	v4, v8
+# CHECK-NEXT:  1      4     2.00                        vsext.vf4	v4, v8
+# CHECK-NEXT:  1      4     2.00                        vzext.vf8	v4, v8
+# CHECK-NEXT:  1      4     2.00                        vsext.vf8	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     5.00                        vsext.vf2	v4, v8
-# CHECK-NEXT:  1      4     5.00                        vzext.vf4	v4, v8
-# CHECK-NEXT:  1      4     5.00                        vsext.vf4	v4, v8
-# CHECK-NEXT:  1      4     5.00                        vzext.vf8	v4, v8
-# CHECK-NEXT:  1      4     5.00                        vsext.vf8	v4, v8
+# CHECK-NEXT:  1      4     4.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     4.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     4.00                        vzext.vf4	v4, v8
+# CHECK-NEXT:  1      4     4.00                        vsext.vf4	v4, v8
+# CHECK-NEXT:  1      4     4.00                        vzext.vf8	v4, v8
+# CHECK-NEXT:  1      4     4.00                        vsext.vf8	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     9.00                        vsext.vf2	v4, v8
-# CHECK-NEXT:  1      4     9.00                        vzext.vf4	v4, v8
-# CHECK-NEXT:  1      4     9.00                        vsext.vf4	v4, v8
-# CHECK-NEXT:  1      4     9.00                        vzext.vf8	v4, v8
-# CHECK-NEXT:  1      4     9.00                        vsext.vf8	v4, v8
+# CHECK-NEXT:  1      4     8.00                        vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     8.00                        vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     8.00                        vzext.vf4	v4, v8
+# CHECK-NEXT:  1      4     8.00                        vsext.vf4	v4, v8
+# CHECK-NEXT:  1      4     8.00                        vzext.vf8	v4, v8
+# CHECK-NEXT:  1      4     8.00                        vsext.vf8	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vzext.vf2	v4, v8
-# CHECK-NEXT:  1      4     17.00                       vsext.vf2	v4, v8
-# CHECK-NEXT:  1      4     17.00                       vzext.vf4	v4, v8
-# CHECK-NEXT:  1      4     17.00                       vsext.vf4	v4, v8
-# CHECK-NEXT:  1      4     17.00                       vzext.vf8	v4, v8
-# CHECK-NEXT:  1      4     17.00                       vsext.vf8	v4, v8
+# CHECK-NEXT:  1      4     16.00                       vzext.vf2	v4, v8
+# CHECK-NEXT:  1      4     16.00                       vsext.vf2	v4, v8
+# CHECK-NEXT:  1      4     16.00                       vzext.vf4	v4, v8
+# CHECK-NEXT:  1      4     16.00                       vsext.vf4	v4, v8
+# CHECK-NEXT:  1      4     16.00                       vzext.vf8	v4, v8
+# CHECK-NEXT:  1      4     16.00                       vsext.vf8	v4, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vadc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      4     1.00                        vadc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vadc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      4     1.00                        vadc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vadc.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      4     1.00                        vadc.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vmadc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      4     2.00                        vmadc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vmadc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      4     4.00                        vmadc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vmadc.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      4     8.00                        vmadc.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vmadc.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     16.00                       vmadc.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmadc.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     1.00                        vmadc.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmadc.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     1.00                        vmadc.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vsbc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      4     2.00                        vsbc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vsbc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      4     4.00                        vsbc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vmsbc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      4     8.00                        vmsbc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vmsbc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      4     16.00                       vmsbc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmsbc.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     1.00                        vmsbc.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vmsbc.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     2.00                        vmsbc.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vadc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      4     4.00                        vadc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vadc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      4     8.00                        vadc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vadc.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      4     16.00                       vadc.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vmadc.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      4     2.00                        vmadc.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vmadc.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      4     4.00                        vmadc.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vmadc.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      4     8.00                        vmadc.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vmadc.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     16.00                       vmadc.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vand.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vand.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vand.vi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vor.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      4     4.00                        vor.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  1      4     8.00                        vor.vi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  1      4     16.00                       vxor.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vxor.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vxor.vi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vand.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vand.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vand.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vor.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vor.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vor.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vxor.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vxor.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vxor.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vand.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vand.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     4.00                        vand.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vand.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     8.00                        vand.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vor.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     16.00                       vor.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vor.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     1.00                        vor.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vor.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     2.00                        vor.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vxor.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     4.00                        vxor.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vxor.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     8.00                        vxor.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vxor.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     16.00                       vxor.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vand.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     2.00                        vand.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vand.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     4.00                        vand.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vand.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     8.00                        vand.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vor.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     16.00                       vor.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vsll.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vsll.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vsll.vi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      8     2.00                        vsrl.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      8     4.00                        vsrl.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  1      8     8.00                        vsrl.vi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  1      8     16.00                       vsra.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vsra.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vsra.vi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  1      8     2.00                        vsll.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vsll.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vsll.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vsrl.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vsrl.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vsrl.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vsra.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vsra.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vsra.vi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vsll.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vsll.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     4.00                        vsll.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vsll.vi	v4, v8, 0
+# CHECK-NEXT:  1      8     8.00                        vsll.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vsrl.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     16.00                       vsrl.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vsrl.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     1.00                        vsrl.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vsrl.vi	v4, v8, 0
+# CHECK-NEXT:  1      8     2.00                        vsrl.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vsra.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     4.00                        vsra.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vsra.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     8.00                        vsra.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vsra.vi	v4, v8, 0
+# CHECK-NEXT:  1      8     16.00                       vsra.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vsll.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     2.00                        vsll.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vsll.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     4.00                        vsll.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vsll.vi	v4, v8, 0
+# CHECK-NEXT:  1      8     8.00                        vsll.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vsrl.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     16.00                       vsrl.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vnsrl.wv	v4, v8, v12
+# CHECK-NEXT:  1      8     1.00                        vnsrl.wv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vnsrl.wx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      8     2.00                        vnsrl.wi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      8     4.00                        vnsra.wv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      8     8.00                        vnsra.wx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  1      8     16.00                       vnsra.wi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  1      8     16.00                       vnsrl.wv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vnsrl.wx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      8     2.00                        vnsrl.wi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
+# CHECK-NEXT:  1      8     4.00                        vnsra.wv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      8     8.00                        vnsra.wx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      8     16.00                       vnsra.wi	v4, v8, 0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  1      8     16.00                       vnsrl.wv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
 # CHECK-NEXT:  1      8     2.00                        vnsrl.wx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vnsrl.wi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vnsra.wv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vnsra.wx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vnsra.wi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vnsrl.wv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vnsrl.wx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vnsrl.wi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vnsra.wv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vnsra.wx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vnsra.wi	v4, v8, 0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vnsrl.wv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vnsrl.wx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vnsrl.wi	v4, v8, 0
+# CHECK-NEXT:  1      8     4.00                        vnsrl.wi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vnsra.wv	v4, v8, v12
+# CHECK-NEXT:  1      8     8.00                        vnsra.wv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vnsra.wx	v4, v8, a0
+# CHECK-NEXT:  1      8     16.00                       vnsra.wx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vnsra.wi	v4, v8, 0
+# CHECK-NEXT:  1      8     16.00                       vnsra.wi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vnsrl.wv	v4, v8, v12
+# CHECK-NEXT:  1      8     4.00                        vnsrl.wv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vnsrl.wx	v4, v8, a0
+# CHECK-NEXT:  1      8     8.00                        vnsrl.wx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vnsrl.wi	v4, v8, 0
+# CHECK-NEXT:  1      8     16.00                       vnsrl.wi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vnsra.wv	v4, v8, v12
+# CHECK-NEXT:  1      8     16.00                       vnsra.wv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmseq.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     1.00                        vmseq.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmseq.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     1.00                        vmseq.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmseq.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     1.00                        vmseq.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      5     3.00                        vmsne.vv	v4, v8, v12
+# CHECK-NEXT:  1      5     2.00                        vmsne.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      7     5.00                        vmsne.vx	v4, v8, a0
+# CHECK-NEXT:  1      7     4.00                        vmsne.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      11    9.00                        vmsne.vi	v4, v8, 0
+# CHECK-NEXT:  1      11    8.00                        vmsne.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      19    17.00                       vmsltu.vv	v4, v8, v12
+# CHECK-NEXT:  1      19    16.00                       vmsltu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmsltu.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     1.00                        vmsltu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmslt.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     1.00                        vmslt.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      5     3.00                        vmslt.vx	v4, v8, a0
+# CHECK-NEXT:  1      5     2.00                        vmslt.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      7     5.00                        vmsleu.vv	v4, v8, v12
+# CHECK-NEXT:  1      7     4.00                        vmsleu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      11    9.00                        vmsleu.vx	v4, v8, a0
+# CHECK-NEXT:  1      11    8.00                        vmsleu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      19    17.00                       vmsleu.vi	v4, v8, 0
+# CHECK-NEXT:  1      19    16.00                       vmsleu.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmsle.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     1.00                        vmsle.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      5     3.00                        vmsle.vx	v4, v8, a0
+# CHECK-NEXT:  1      5     2.00                        vmsle.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      7     5.00                        vmsle.vi	v4, v8, 0
+# CHECK-NEXT:  1      7     4.00                        vmsle.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      11    9.00                        vmsgtu.vx	v4, v8, a0
+# CHECK-NEXT:  1      11    8.00                        vmsgtu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      19    17.00                       vmsgtu.vi	v4, v8, 0
+# CHECK-NEXT:  1      19    16.00                       vmsgtu.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      5     3.00                        vmsgt.vx	v4, v8, a0
+# CHECK-NEXT:  1      5     2.00                        vmsgt.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      7     5.00                        vmsgt.vi	v4, v8, 0
+# CHECK-NEXT:  1      7     4.00                        vmsgt.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      11    9.00                        vmseq.vv	v4, v8, v12
+# CHECK-NEXT:  1      11    8.00                        vmseq.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      19    17.00                       vmseq.vx	v4, v8, a0
+# CHECK-NEXT:  1      19    16.00                       vmseq.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmsle.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     1.00                        vmsle.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmsleu.vi	v4, v8, 0
+# CHECK-NEXT:  1      4     1.00                        vmsleu.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmsne.vv	v4, v8, v8
+# CHECK-NEXT:  1      4     1.00                        vmsne.vv	v4, v8, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      5     3.00                        vmsgtu.vi	v4, v8, 0
+# CHECK-NEXT:  1      5     2.00                        vmsgtu.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      7     5.00                        vmsgt.vi	v4, v8, 0
+# CHECK-NEXT:  1      7     4.00                        vmsgt.vi	v4, v8, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      11    9.00                        vmseq.vv	v4, v8, v8
+# CHECK-NEXT:  1      11    8.00                        vmseq.vv	v4, v8, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmsgt.vi	v4, v8, -1
+# CHECK-NEXT:  1      4     1.00                        vmsgt.vi	v4, v8, -1
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmslt.vx	v4, v8, a0
-# CHECK-NEXT:  1      4     2.00                        vmnot.m	v4, v4
+# CHECK-NEXT:  1      4     1.00                        vmslt.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     1.00                        vmnot.m	v4, v4
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      5     3.00                        vmsltu.vx	v4, v8, a1
-# CHECK-NEXT:  1      4     2.00                        vmnot.m	v4, v4
+# CHECK-NEXT:  1      5     2.00                        vmsltu.vx	v4, v8, a1
+# CHECK-NEXT:  1      4     1.00                        vmnot.m	v4, v4
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vminu.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     1.00                        vminu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vminu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vmin.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vmin.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      4     4.00                        vmaxu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  1      4     8.00                        vmaxu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  1      4     16.00                       vmax.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vmax.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vminu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vminu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      4     4.00                        vmin.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      4     8.00                        vmin.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  1      4     16.00                       vmaxu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vmaxu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      4     2.00                        vmax.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      4     4.00                        vmax.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      4     8.00                        vminu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  1      4     16.00                       vminu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vmin.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vmin.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vmaxu.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vmaxu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vmax.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmax.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vminu.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vminu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vmin.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vmin.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vmaxu.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmaxu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vmax.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vmax.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vminu.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vminu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vmin.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vmin.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     4.00                        vmin.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vmaxu.vv	v4, v8, v12
+# CHECK-NEXT:  1      4     8.00                        vmaxu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vmaxu.vx	v4, v8, a0
+# CHECK-NEXT:  1      4     16.00                       vmaxu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vmul.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     1.00                        vmul.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vmul.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vmulh.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      8     2.00                        vmulh.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      8     4.00                        vmulhu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  1      8     8.00                        vmulhu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  1      8     16.00                       vmulhsu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vmulhsu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vmul.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  1      8     2.00                        vmul.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      8     4.00                        vmulh.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      8     8.00                        vmulh.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  1      8     16.00                       vmulhu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vmulhu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      8     2.00                        vmulhsu.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      8     4.00                        vmulhsu.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      8     8.00                        vmul.vv	v4, v8, v12
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  1      8     16.00                       vmul.vx	v4, v8, a0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  1      8     2.00                        vmulh.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vmulh.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vmulhu.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vmulhu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vmulhsu.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vmulhsu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vmul.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vmul.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vmulh.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vmulh.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vmulhu.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vmulhu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vmulhsu.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vmulhsu.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vmul.vv	v4, v8, v12
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vmul.vx	v4, v8, a0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vmulh.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vmulh.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     4.00                        vmulh.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vmulhu.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     8.00                        vmulhu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vmulhu.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     16.00                       vmulhu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      30    31.00                       vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  1      30    30.00                       vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      60    61.00                       vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  1      60    60.00                       vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      120   121.00                      vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  1      120   120.00                      vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   241.00                      vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  1      240   240.00                      vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      480   481.00                      vremu.vv	v4, v8, v12
+# CHECK-NEXT:  1      480   480.00                      vremu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      960   961.00                      vremu.vx	v4, v8, a0
+# CHECK-NEXT:  1      960   960.00                      vremu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1920   1921.00                      vrem.vv	v4, v8, v12
+# CHECK-NEXT:  1      1920   1920.00                      vrem.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      30    31.00                       vrem.vx	v4, v8, a0
+# CHECK-NEXT:  1      30    30.00                       vrem.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      60    61.00                       vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  1      60    60.00                       vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      120   121.00                      vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  1      120   120.00                      vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      240   241.00                      vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      480   481.00                      vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  1      480   480.00                      vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      960   961.00                      vremu.vv	v4, v8, v12
+# CHECK-NEXT:  1      960   960.00                      vremu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      56    57.00                       vremu.vx	v4, v8, a0
+# CHECK-NEXT:  1      56    56.00                       vremu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      112   113.00                      vrem.vv	v4, v8, v12
+# CHECK-NEXT:  1      112   112.00                      vrem.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      224   225.00                      vrem.vx	v4, v8, a0
+# CHECK-NEXT:  1      224   224.00                      vrem.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      448   449.00                      vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  1      448   448.00                      vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      896   897.00                      vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  1      896   896.00                      vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   115.00                      vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      228   229.00                      vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  1      228   228.00                      vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      456   457.00                      vremu.vv	v4, v8, v12
+# CHECK-NEXT:  1      456   456.00                      vremu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      912   913.00                      vremu.vx	v4, v8, a0
+# CHECK-NEXT:  1      912   912.00                      vremu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwmul.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     1.00                        vwmul.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwmul.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     1.00                        vwmul.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwmulu.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     1.00                        vwmulu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vwmulu.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     2.00                        vwmulu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vwmulsu.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     4.00                        vwmulsu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwmulsu.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     8.00                        vwmulsu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwmul.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     8.00                        vwmul.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwmul.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     1.00                        vwmul.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwmulu.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     1.00                        vwmulu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vwmulu.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     2.00                        vwmulu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vwmulsu.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     4.00                        vwmulsu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwmulsu.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     8.00                        vwmulsu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwmul.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     8.00                        vwmul.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwmul.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     1.00                        vwmul.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vwmulu.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     2.00                        vwmulu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vwmulu.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     4.00                        vwmulu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwmulsu.vv	v4, v8, v12
+# CHECK-NEXT:  1      8     8.00                        vwmulsu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwmulsu.vx	v4, v8, a0
+# CHECK-NEXT:  1      8     8.00                        vwmulsu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vmacc.vv	v4, v12, v8
+# CHECK-NEXT:  1      8     1.00                        vmacc.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vmacc.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vnmsac.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      8     2.00                        vnmsac.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      8     4.00                        vmadd.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  1      8     8.00                        vmadd.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  1      8     16.00                       vnmsub.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vnmsub.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vmacc.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  1      8     2.00                        vmacc.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      8     4.00                        vnmsac.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      8     8.00                        vnmsac.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  1      8     16.00                       vmadd.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vmadd.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
+# CHECK-NEXT:  1      8     2.00                        vnmsub.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
+# CHECK-NEXT:  1      8     4.00                        vnmsub.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
+# CHECK-NEXT:  1      8     8.00                        vmacc.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
+# CHECK-NEXT:  1      8     16.00                       vmacc.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
 # CHECK-NEXT:  1      8     2.00                        vnmsac.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vnmsac.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vmadd.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vmadd.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vnmsub.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vnmsub.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vmacc.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vmacc.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vnmsac.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vnmsac.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vmadd.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vmadd.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vnmsub.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vnmsub.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vmacc.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vmacc.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vnmsac.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vnmsac.vx	v4, a0, v8
+# CHECK-NEXT:  1      8     4.00                        vnmsac.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vmadd.vv	v4, v12, v8
+# CHECK-NEXT:  1      8     8.00                        vmadd.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      8     17.00                       vmadd.vx	v4, a0, v8
+# CHECK-NEXT:  1      8     16.00                       vmadd.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwmaccu.vv	v4, v12, v8
+# CHECK-NEXT:  1      8     1.00                        vwmaccu.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwmaccu.vx	v4, a0, v8
+# CHECK-NEXT:  1      8     1.00                        vwmaccu.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vwmacc.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      8     2.00                        vwmacc.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      8     4.00                        vwmaccsu.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
+# CHECK-NEXT:  1      8     8.00                        vwmaccsu.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
+# CHECK-NEXT:  1      8     8.00                        vwmaccus.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vwmaccu.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vwmaccu.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
 # CHECK-NEXT:  1      8     2.00                        vwmacc.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vwmacc.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vwmaccsu.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwmaccsu.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwmaccus.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
+# CHECK-NEXT:  1      8     4.00                        vwmacc.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
+# CHECK-NEXT:  1      8     8.00                        vwmaccsu.vv	v4, v12, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
+# CHECK-NEXT:  1      8     8.00                        vwmaccsu.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
+# CHECK-NEXT:  1      8     1.00                        vwmaccus.vx	v4, a0, v8
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
 # CHECK-NEXT:  1      8     2.00                        vwmaccu.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwmaccu.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vwmacc.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vwmacc.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwmaccsu.vv	v4, v12, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwmaccsu.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      8     2.00                        vwmaccus.vx	v4, a0, v8
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      8     3.00                        vwmaccu.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      8     5.00                        vwmaccu.vx	v4, a0, v8
+# CHECK-NEXT:  1      8     4.00                        vwmaccu.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwmacc.vv	v4, v12, v8
+# CHECK-NEXT:  1      8     8.00                        vwmacc.vv	v4, v12, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      8     9.00                        vwmacc.vx	v4, a0, v8
+# CHECK-NEXT:  1      8     8.00                        vwmacc.vx	v4, a0, v8
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      4     1.00                        vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
 # CHECK-NEXT:  1      4     2.00                        vmerge.vvm	v4, v8, v12, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmerge.vxm	v4, v8, a0, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmerge.vim	v4, v8, 0, v0
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      4     4.00                        vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      4     8.00                        vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      4     16.00                       vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      4     1.00                        vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      4     1.00                        vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      4     2.00                        vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      4     4.00                        vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      4     8.00                        vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      4     16.00                       vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      4     1.00                        vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      4     2.00                        vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      4     4.00                        vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      4     8.00                        vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      4     16.00                       vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      4     2.00                        vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vmerge.vxm	v4, v8, a0, v0
+# CHECK-NEXT:  1      4     4.00                        vmerge.vxm	v4, v8, a0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vmerge.vim	v4, v8, 0, v0
+# CHECK-NEXT:  1      4     8.00                        vmerge.vim	v4, v8, 0, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vmerge.vvm	v4, v8, v12, v0
+# CHECK-NEXT:  1      4     16.00                       vmerge.vvm	v4, v8, v12, v0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmv.v.v	v4, v12
+# CHECK-NEXT:  1      4     1.00                        vmv.v.v	v4, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      4     1.00                        vmv.v.x	v4, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmv.v.i	v4, 0
+# CHECK-NEXT:  1      4     1.00                        vmv.v.i	v4, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vmv.v.v	v4, v12
+# CHECK-NEXT:  1      4     2.00                        vmv.v.v	v4, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      4     4.00                        vmv.v.x	v4, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vmv.v.i	v4, 0
+# CHECK-NEXT:  1      4     8.00                        vmv.v.i	v4, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vmv.v.v	v4, v12
+# CHECK-NEXT:  1      4     16.00                       vmv.v.v	v4, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      4     1.00                        vmv.v.x	v4, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmv.v.i	v4, 0
+# CHECK-NEXT:  1      4     1.00                        vmv.v.i	v4, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vmv.v.v	v4, v12
+# CHECK-NEXT:  1      4     2.00                        vmv.v.v	v4, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      4     4.00                        vmv.v.x	v4, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vmv.v.i	v4, 0
+# CHECK-NEXT:  1      4     8.00                        vmv.v.i	v4, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vmv.v.v	v4, v12
+# CHECK-NEXT:  1      4     16.00                       vmv.v.v	v4, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      4     1.00                        vmv.v.x	v4, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vmv.v.i	v4, 0
+# CHECK-NEXT:  1      4     2.00                        vmv.v.i	v4, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vmv.v.v	v4, v12
+# CHECK-NEXT:  1      4     4.00                        vmv.v.v	v4, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      4     8.00                        vmv.v.x	v4, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vmv.v.i	v4, 0
+# CHECK-NEXT:  1      4     16.00                       vmv.v.i	v4, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vmv.v.v	v4, v12
+# CHECK-NEXT:  1      4     2.00                        vmv.v.v	v4, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00                        vmv.v.x	v4, a0
+# CHECK-NEXT:  1      4     4.00                        vmv.v.x	v4, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00                        vmv.v.i	v4, 0
+# CHECK-NEXT:  1      4     8.00                        vmv.v.i	v4, 0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vmv.v.v	v4, v12
+# CHECK-NEXT:  1      4     16.00                       vmv.v.v	v4, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vle-vse.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vle-vse.s
@@ -431,405 +431,405 @@ vsm.v    v1, (a0)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     4.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     8.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00   *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     16.00   *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     5.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     4.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     9.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     8.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     5.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     4.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vle8.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     5.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     4.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     9.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     8.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     17.00   *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     16.00   *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     4.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     8.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00   *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     16.00   *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     5.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     4.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     9.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     8.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     5.00    *                   vle16.v	v1, (a0)
+# CHECK-NEXT:  1      4     4.00    *                   vle16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     5.00    *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     9.00    *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     17.00   *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
 # CHECK-NEXT:  1      4     2.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      4     4.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      4     8.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      4     16.00   *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      4     1.00    *                   vle32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     5.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      4     4.00    *                   vle32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     9.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      4     8.00    *                   vle32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     17.00   *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      4     16.00   *                   vle32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     2.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      4     1.00    *                   vle32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      4     4.00    *                   vle32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      4     8.00    *                   vle32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00   *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      4     16.00   *                   vle32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      4     1.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
 # CHECK-NEXT:  1      4     2.00    *                   vle32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vle32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     5.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      4     4.00    *                   vle32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     9.00    *                   vle32.v	v1, (a0)
+# CHECK-NEXT:  1      4     8.00    *                   vle32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     5.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      4     4.00    *                   vle64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     9.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      4     8.00    *                   vle64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     17.00   *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      4     16.00   *                   vle64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     5.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      4     4.00    *                   vle64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     9.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      4     8.00    *                   vle64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     17.00   *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      4     16.00   *                   vle64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     5.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      4     4.00    *                   vle64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     9.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      4     8.00    *                   vle64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     17.00   *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      4     16.00   *                   vle64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vle64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     5.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      4     4.00    *                   vle64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     9.00    *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      4     8.00    *                   vle64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00   *                   vle64.v	v1, (a0)
+# CHECK-NEXT:  1      4     16.00   *                   vle64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     5.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     4.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     9.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     8.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     17.00          *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     16.00          *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     5.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     4.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     9.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     8.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     5.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     4.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vse8.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse8.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     5.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     4.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     9.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     8.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     17.00          *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     16.00          *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     5.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     4.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     9.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     8.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     17.00          *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     16.00          *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     5.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     4.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     9.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     8.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     5.00           *            vse16.v	v1, (a0)
+# CHECK-NEXT:  1      1     4.00           *            vse16.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vse32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     5.00           *            vse32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     9.00           *            vse32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     17.00          *            vse32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
 # CHECK-NEXT:  1      1     2.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
+# CHECK-NEXT:  1      1     4.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
+# CHECK-NEXT:  1      1     8.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
+# CHECK-NEXT:  1      1     16.00          *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
+# CHECK-NEXT:  1      1     1.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     5.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     4.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     9.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     8.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     17.00          *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     16.00          *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     2.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     1.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     5.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     4.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     9.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     8.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     17.00          *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     16.00          *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
+# CHECK-NEXT:  1      1     1.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
 # CHECK-NEXT:  1      1     2.00           *            vse32.v	v1, (a0)
-# CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     5.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     4.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     9.00           *            vse32.v	v1, (a0)
+# CHECK-NEXT:  1      1     8.00           *            vse32.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     5.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     4.00           *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     9.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     8.00           *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     17.00          *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     16.00          *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     5.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     4.00           *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     9.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     8.00           *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     17.00          *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     16.00          *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     5.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     4.00           *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     9.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     8.00           *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     17.00          *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     16.00          *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     5.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     4.00           *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     9.00           *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     8.00           *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     17.00          *            vse64.v	v1, (a0)
+# CHECK-NEXT:  1      1     16.00          *            vse64.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      4     3.00    *                   vlm.v	v1, (a0)
+# CHECK-NEXT:  1      4     2.00    *                   vlm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1     3.00           *            vsm.v	v1, (a0)
+# CHECK-NEXT:  1      1     2.00           *            vsm.v	v1, (a0)
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetivli-lmul-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetivli-lmul-instrument.s
@@ -26,9 +26,9 @@ vadd.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetivli	zero, 8, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetivli	zero, 8, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetivli-lmul-sew-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetivli-lmul-sew-instrument.s
@@ -26,9 +26,9 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetivli	zero, 8, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   241.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetivli	zero, 8, e32, m8, tu, mu
-# CHECK-NEXT:  1      896   897.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      896   896.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetvli-lmul-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetvli-lmul-instrument.s
@@ -26,9 +26,9 @@ vadd.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      4     3.00                        vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     2.00                        vadd.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  1      4     17.00                       vadd.vv	v12, v12, v12
+# CHECK-NEXT:  1      4     16.00                       vadd.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetvli-lmul-sew-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetvli-lmul-sew-instrument.s
@@ -26,9 +26,9 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   241.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e32, m8, tu, mu
-# CHECK-NEXT:  1      896   897.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      896   896.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - SiFive7FDiv


### PR DESCRIPTION
Previously `MCSchedModel::getReciprocalThroughput` ignored `AcquireAtCycle` completey, this patch fixes it by using the largest `(ReleaseAtCycle - AcquireAtCycle) / NumUnits` as inverse throughput.

Here are some technical explanations: https://myhsu.xyz/llvm-sched-interval-throughput