### PR TITLE
[mlir][mesh] Exit after `signalPassFailure` to fix a crash

### DIFF
--- a/mlir/lib/Dialect/Mesh/Transforms/ShardingPropagation.cpp
+++ b/mlir/lib/Dialect/Mesh/Transforms/ShardingPropagation.cpp
@@ -369,7 +369,7 @@ struct ShardingPropagation
     OpBuilder builder(ctx);
     if (!region.hasOneBlock()) {
       funcOp.emitOpError() << "only one block is supported!";
-      signalPassFailure();
+      return signalPassFailure();
     }
     Block &block = region.front();
 

--- a/mlir/test/Dialect/Mesh/sharding-propagation-failed.mlir
+++ b/mlir/test/Dialect/Mesh/sharding-propagation-failed.mlir
@@ -1,0 +1,4 @@
+// RUN: mlir-opt --pass-pipeline="builtin.module(func.func(sharding-propagation))" %s -verify-diagnostics
+
+// expected-error @+1 {{'func.func' op only one block is supported!}}
+func.func private @no_block_function(i64)


### PR DESCRIPTION
Fixes #131435.