### PR TITLE
[LLVM] Fix llvm-gpu-loader use in standalone

### DIFF
--- a/cmake/Modules/FindLibcCommonUtils.cmake
+++ b/cmake/Modules/FindLibcCommonUtils.cmake
@@ -7,7 +7,7 @@
 #===--------------------------------------------------------------------===//
 
 if(NOT TARGET llvm-libc-common-utilities)
-  set(libc_path ${CMAKE_CURRENT_LIST_DIR}/../../libc)
+  set(libc_path ${LLVM_MAIN_SRC_DIR}/../libc)
   if (EXISTS ${libc_path} AND IS_DIRECTORY ${libc_path})
     add_library(llvm-libc-common-utilities INTERFACE)
     # TODO: Reorganize the libc shared section so that it can be included without

--- a/llvm/tools/CMakeLists.txt
+++ b/llvm/tools/CMakeLists.txt
@@ -9,7 +9,7 @@
 # traversing each directory.
 create_llvm_tool_options()
 
-if(NOT LLVM_COMPILER_IS_GCC_COMPATIBLE)
+if(NOT LLVM_COMPILER_IS_GCC_COMPATIBLE OR NOT TARGET llvm-libc-common-utilities)
   set(LLVM_TOOL_LLVM_GPU_LOADER_BUILD OFF)
 endif()
 


### PR DESCRIPTION
Fixes the standalone builds of LLVM itself. In nixpkgs, we create a trimmed down copy of the LLVM monorepo for compatibility with older LLVM releases. We don't include libc in this copy which causes the `llvm-libc-common-utilities` target to not be defined. This causes `llvm-gpu-loader` to try linking to `llvm-libc-common-utilities` but fails due to the target not existing.