### PR TITLE
[clang][RISCV] Fix RUN line and rename test name for pr129995

### DIFF
--- a/clang/test/CodeGen/RISCV/issue-129995.cpp
+++ b/clang/test/CodeGen/RISCV/issue-129995.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 triple riscv64 -emit-llvm -target-feature +m -target-feature +v -target-abi lp64d -o /dev/null %s
+// RUN: %clang_cc1 -triple riscv64 -emit-llvm -target-feature +m -target-feature +v -target-abi lp64d -o /dev/null %s
 
 struct a {
   using b = char __attribute__((vector_size(sizeof(char))));


### PR DESCRIPTION
ninja check-clang can not detect .cc suffix, so the typo is not
detected.
