### PR TITLE
[Mips] Fix clang compile error when -march=p5600 with -mmsa

### DIFF
--- a/clang/lib/Basic/Targets/Mips.cpp
+++ b/clang/lib/Basic/Targets/Mips.cpp
@@ -69,12 +69,12 @@ void MipsTargetInfo::fillValidCPUList(
 
 unsigned MipsTargetInfo::getISARev() const {
   return llvm::StringSwitch<unsigned>(getCPU())
-             .Cases("mips32", "mips64", 1)
-             .Cases("mips32r2", "mips64r2", "octeon", "octeon+", 2)
-             .Cases("mips32r3", "mips64r3", 3)
-             .Cases("mips32r5", "mips64r5", 5)
-             .Cases("mips32r6", "mips64r6", 6)
-             .Default(0);
+      .Cases("mips32", "mips64", 1)
+      .Cases("mips32r2", "mips64r2", "octeon", "octeon+", 2)
+      .Cases("mips32r3", "mips64r3", 3)
+      .Cases("mips32r5", "mips64r5", "p5600", 5)
+      .Cases("mips32r6", "mips64r6", 6)
+      .Default(0);
 }
 
 void MipsTargetInfo::getTargetDefines(const LangOptions &Opts,

--- a/clang/test/Driver/mips-abi.c
+++ b/clang/test/Driver/mips-abi.c
@@ -115,6 +115,20 @@
 // MIPS-ARCH-P5600: "-target-cpu" "p5600"
 // MIPS-ARCH-P5600: "-target-abi" "o32"
 //
+// RUN: %clang --target=mips-linux-gnu -### -c %s \
+// RUN:        -march=p5600 -mmsa -mnan=2008 2>&1 \
+// RUN:   | FileCheck -check-prefix=MIPS-ARCH-P5600-MSA %s
+// MIPS-ARCH-P5600-MSA: "-target-cpu" "p5600"
+// MIPS-ARCH-P5600-MSA: "-target-feature" "+msa"
+// MIPS-ARCH-P5600-MSA: "-target-feature" "+fp64"
+//
+// RUN: %clang --target=mips-linux-gnu -### -c %s \
+// RUN:        -march=p5600 -mmsa -mnan=2008 2>&1 \
+// RUN:   | FileCheck -check-prefix=MIPS-ARCH-P5600-NAN2008 %s
+// MIPS-ARCH-P5600-NAN2008: "-target-cpu" "p5600"
+// MIPS-ARCH-P5600-NAN2008: "-target-feature" "+nan2008"
+// MIPS-ARCH-P5600-NAN2008: "-target-feature" "+abs2008"
+//
 // RUN: not %clang --target=mips-linux-gnu -c %s \
 // RUN:        -march=p5600 -mabi=64 2>&1 \
 // RUN:   | FileCheck -check-prefix=MIPS-ARCH-P5600-N64 %s


### PR DESCRIPTION
When -march=p5600 with -mmsa, the result of getISARev is 0, so report error. Append p5600 to cases mips32r5.

Fix #91948.