### PR TITLE
[Clang][Driver] Override complex number calculation method by -fno-fast-math

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2995,8 +2995,8 @@ static void RenderFloatingPointOptions(const ToolChain &TC, const Driver &D,
   StringRef Float16ExcessPrecision = "";
   StringRef BFloat16ExcessPrecision = "";
   LangOptions::ComplexRangeKind Range = LangOptions::ComplexRangeKind::CX_None;
-  std::string ComplexRangeStr = "";
-  std::string GccRangeComplexOption = "";
+  std::string ComplexRangeStr;
+  std::string GccRangeComplexOption;
   std::string LastComplexRangeOption;
 
   auto setComplexRange = [&](LangOptions::ComplexRangeKind NewRange) {

--- a/clang/test/Driver/range.c
+++ b/clang/test/Driver/range.c
@@ -177,14 +177,45 @@
 // RUN: %clang -### -target x86_64 -ffast-math -fcomplex-arithmetic=basic -c %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=BASIC %s
 
-// BASIC: -complex-range=basic
-// FULL: -complex-range=full
-// PRMTD: -complex-range=promoted
-// BASIC-NOT: -complex-range=improved
-// CHECK-NOT: -complex-range=basic
-// IMPRVD: -complex-range=improved
-// IMPRVD-NOT: -complex-range=basic
-// CHECK-NOT: -complex-range=improved
+// RUN: %clang -### -target x86_64 -fcx-limited-range -fno-fast-math \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL,WARN21 %s
+
+// RUN: %clang -### -Werror -target x86_64 -fno-cx-limited-range -fno-fast-math \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+
+// RUN: %clang -### -target x86_64 -fcx-fortran-rules -fno-fast-math \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL,WARN22 %s
+
+// RUN: %clang -### -Werror -target x86_64 -fno-cx-fortran-rules -fno-fast-math \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+
+// RUN: %clang -### -Werror -target x86_64 -ffast-math -fno-fast-math \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+
+// RUN: %clang -### -target x86_64 -fcomplex-arithmetic=basic -fno-fast-math \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL,WARN23 %s
+
+// RUN: %clang -### -target x86_64 -fcomplex-arithmetic=promoted -fno-fast-math \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL,WARN24 %s
+
+// RUN: %clang -### -target x86_64 -fcomplex-arithmetic=improved -fno-fast-math \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL,WARN25 %s
+
+// RUN: %clang -### -Werror -target x86_64 -fcomplex-arithmetic=full -fno-fast-math \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+
+// RUN: %clang -### -target x86_64 -ffp-model=aggressive -fno-fast-math \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL,WARN23 %s
+
+// RUN: %clang -### -target x86_64 -ffp-model=fast -fno-fast-math \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL,WARN24 %s
+
+// RUN: %clang -### -Werror -target x86_64 -ffp-model=precise -fno-fast-math \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+
+// RUN: %clang -### -Werror -target x86_64 -ffp-model=strict -fno-fast-math \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+
 
 // WARN1: warning: overriding '-fcx-limited-range' option with '-fcx-fortran-rules' [-Woverriding-option]
 // WARN2: warning: overriding '-fno-cx-limited-range' option with '-fcx-fortran-rules' [-Woverriding-option]
@@ -196,5 +227,19 @@
 // WARN14: overriding '-complex-range=promoted' option with '-fcx-limited-range' [-Woverriding-option]
 // WARN17: warning: overriding '-fcomplex-arithmetic=full' option with '-fcomplex-arithmetic=basic' [-Woverriding-option]
 // WARN20: warning: overriding '-fcx-fortran-rules' option with '-fcx-limited-range' [-Woverriding-option]
+// WARN21: warning: overriding '-fcx-limited-range' option with '-fcomplex-arithmetic=full' [-Woverriding-option]
+// WARN22: warning: overriding '-fcx-fortran-rules' option with '-fcomplex-arithmetic=full' [-Woverriding-option]
+// WARN23: warning: overriding '-fcomplex-arithmetic=basic' option with '-fcomplex-arithmetic=full' [-Woverriding-option]
+// WARN24: warning: overriding '-fcomplex-arithmetic=promoted' option with '-fcomplex-arithmetic=full' [-Woverriding-option]
+// WARN25: warning: overriding '-fcomplex-arithmetic=improved' option with '-fcomplex-arithmetic=full' [-Woverriding-option]
+
+// BASIC: -complex-range=basic
+// FULL: -complex-range=full
+// PRMTD: -complex-range=promoted
+// BASIC-NOT: -complex-range=improved
+// CHECK-NOT: -complex-range=basic
+// IMPRVD: -complex-range=improved
+// IMPRVD-NOT: -complex-range=basic
+// CHECK-NOT: -complex-range=improved
 
 // ERR: error: unsupported argument 'foo' to option '-fcomplex-arithmetic='

--- a/clang/test/Driver/range.c
+++ b/clang/test/Driver/range.c
@@ -216,6 +216,44 @@
 // RUN: %clang -### -Werror -target x86_64 -ffp-model=strict -fno-fast-math \
 // RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
 
+// RUN: %clang -### -target x86_64 -fno-fast-math -fcx-limited-range \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=BASIC,WARN26 %s
+
+// RUN: %clang -### -target x86_64 -fno-fast-math -fno-cx-limited-range \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+
+// RUN: %clang -### -target x86_64 -fno-fast-math -fcx-fortran-rules \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=IMPRVD,WARN27 %s
+
+// RUN: %clang -### -target x86_64 -fno-fast-math -fno-cx-fortran-rules \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+
+// RUN: %clang -### -Werror -target x86_64 -fno-fast-math -ffast-math \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=BASIC %s
+
+// RUN: %clang -### -target x86_64 -fno-fast-math -fcomplex-arithmetic=basic \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=BASIC %s
+
+// RUN: %clang -### -target x86_64 -fno-fast-math -fcomplex-arithmetic=promoted \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=PRMTD %s
+
+// RUN: %clang -### -target x86_64 -fno-fast-math -fcomplex-arithmetic=improved \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=IMPRVD %s
+
+// RUN: %clang -### -Werror -target x86_64 -fno-fast-math -fcomplex-arithmetic=full \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+
+// RUN: %clang -### -target x86_64 -fno-fast-math -ffp-model=aggressive \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=BASIC %s
+
+// RUN: %clang -### -target x86_64 -fno-fast-math -ffp-model=fast \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=PRMTD,WARN31 %s
+
+// RUN: %clang -### -Werror -target x86_64 -fno-fast-math -ffp-model=precise \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+
+// RUN: %clang -### -Werror -target x86_64 -fno-fast-math -ffp-model=strict \
+// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
 
 // WARN1: warning: overriding '-fcx-limited-range' option with '-fcx-fortran-rules' [-Woverriding-option]
 // WARN2: warning: overriding '-fno-cx-limited-range' option with '-fcx-fortran-rules' [-Woverriding-option]
@@ -232,6 +270,12 @@
 // WARN23: warning: overriding '-fcomplex-arithmetic=basic' option with '-fcomplex-arithmetic=full' [-Woverriding-option]
 // WARN24: warning: overriding '-fcomplex-arithmetic=promoted' option with '-fcomplex-arithmetic=full' [-Woverriding-option]
 // WARN25: warning: overriding '-fcomplex-arithmetic=improved' option with '-fcomplex-arithmetic=full' [-Woverriding-option]
+// WARN26: warning: overriding '-complex-range=full' option with '-fcx-limited-range' [-Woverriding-option]
+// WARN27: warning: overriding '-complex-range=full' option with '-fcx-fortran-rules' [-Woverriding-option]
+// WARN28: warning: overriding '-complex-range=full' option with '-fcomplex-arithmetic=basic' [-Woverriding-option]
+// WARN29: warning: overriding '-complex-range=full' option with '-fcomplex-arithmetic=promoted' [-Woverriding-option]
+// WARN30: warning: overriding '-complex-range=full' option with '-fcomplex-arithmetic=improved' [-Woverriding-option]
+// WARN31: warning: overriding '-fcomplex-arithmetic=full' option with '-fcomplex-arithmetic=promoted' [-Woverriding-option]
 
 // BASIC: -complex-range=basic
 // FULL: -complex-range=full

--- a/clang/test/Driver/range.c
+++ b/clang/test/Driver/range.c
@@ -177,83 +177,83 @@
 // RUN: %clang -### -target x86_64 -ffast-math -fcomplex-arithmetic=basic -c %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=BASIC %s
 
-// RUN: %clang -### -target x86_64 -fcx-limited-range -fno-fast-math \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL,WARN21 %s
+// RUN: %clang -### --target=x86_64 -fcx-limited-range -fno-fast-math \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=RANGE,WARN21 %s
 
-// RUN: %clang -### -Werror -target x86_64 -fno-cx-limited-range -fno-fast-math \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+// RUN: %clang -### -Werror --target=x86_64 -fno-cx-limited-range -fno-fast-math \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=RANGE %s
 
-// RUN: %clang -### -target x86_64 -fcx-fortran-rules -fno-fast-math \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL,WARN22 %s
+// RUN: %clang -### --target=x86_64 -fcx-fortran-rules -fno-fast-math \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=RANGE,WARN22 %s
 
-// RUN: %clang -### -Werror -target x86_64 -fno-cx-fortran-rules -fno-fast-math \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+// RUN: %clang -### -Werror --target=x86_64 -fno-cx-fortran-rules -fno-fast-math \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=RANGE %s
 
-// RUN: %clang -### -Werror -target x86_64 -ffast-math -fno-fast-math \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+// RUN: %clang -### -Werror --target=x86_64 -ffast-math -fno-fast-math \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=RANGE %s
 
-// RUN: %clang -### -target x86_64 -fcomplex-arithmetic=basic -fno-fast-math \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL,WARN23 %s
+// RUN: %clang -### --target=x86_64 -fcomplex-arithmetic=basic -fno-fast-math \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=RANGE,WARN23 %s
 
-// RUN: %clang -### -target x86_64 -fcomplex-arithmetic=promoted -fno-fast-math \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL,WARN24 %s
+// RUN: %clang -### --target=x86_64 -fcomplex-arithmetic=promoted -fno-fast-math \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=RANGE,WARN24 %s
 
-// RUN: %clang -### -target x86_64 -fcomplex-arithmetic=improved -fno-fast-math \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL,WARN25 %s
+// RUN: %clang -### --target=x86_64 -fcomplex-arithmetic=improved -fno-fast-math \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=RANGE,WARN25 %s
 
-// RUN: %clang -### -Werror -target x86_64 -fcomplex-arithmetic=full -fno-fast-math \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+// RUN: %clang -### -Werror --target=x86_64 -fcomplex-arithmetic=full -fno-fast-math \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=RANGE %s
 
-// RUN: %clang -### -target x86_64 -ffp-model=aggressive -fno-fast-math \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL,WARN23 %s
+// RUN: %clang -### -Werror --target=x86_64 -ffp-model=aggressive -fno-fast-math \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=RANGE %s
 
-// RUN: %clang -### -target x86_64 -ffp-model=fast -fno-fast-math \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL,WARN24 %s
+// RUN: %clang -### -Werror --target=x86_64 -ffp-model=fast -fno-fast-math \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=RANGE %s
 
-// RUN: %clang -### -Werror -target x86_64 -ffp-model=precise -fno-fast-math \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+// RUN: %clang -### -Werror --target=x86_64 -ffp-model=precise -fno-fast-math \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=RANGE %s
 
-// RUN: %clang -### -Werror -target x86_64 -ffp-model=strict -fno-fast-math \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+// RUN: %clang -### -Werror --target=x86_64 -ffp-model=strict -fno-fast-math \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=RANGE %s
 
-// RUN: %clang -### -target x86_64 -fno-fast-math -fcx-limited-range \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=BASIC,WARN26 %s
+// RUN: %clang -### -Werror --target=x86_64 -fno-fast-math -fcx-limited-range \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=BASIC %s
 
-// RUN: %clang -### -target x86_64 -fno-fast-math -fno-cx-limited-range \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+// RUN: %clang -### -Werror --target=x86_64 -fno-fast-math -fno-cx-limited-range \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
 
-// RUN: %clang -### -target x86_64 -fno-fast-math -fcx-fortran-rules \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=IMPRVD,WARN27 %s
+// RUN: %clang -### -Werror --target=x86_64 -fno-fast-math -fcx-fortran-rules \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=IMPRVD %s
 
-// RUN: %clang -### -target x86_64 -fno-fast-math -fno-cx-fortran-rules \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+// RUN: %clang -### -Werror --target=x86_64 -fno-fast-math -fno-cx-fortran-rules \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
 
-// RUN: %clang -### -Werror -target x86_64 -fno-fast-math -ffast-math \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=BASIC %s
+// RUN: %clang -### -Werror --target=x86_64 -fno-fast-math -ffast-math \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=BASIC %s
 
-// RUN: %clang -### -target x86_64 -fno-fast-math -fcomplex-arithmetic=basic \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=BASIC %s
+// RUN: %clang -### -Werror --target=x86_64 -fno-fast-math -fcomplex-arithmetic=basic \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=BASIC %s
 
-// RUN: %clang -### -target x86_64 -fno-fast-math -fcomplex-arithmetic=promoted \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=PRMTD %s
+// RUN: %clang -### -Werror --target=x86_64 -fno-fast-math -fcomplex-arithmetic=promoted \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=PRMTD %s
 
-// RUN: %clang -### -target x86_64 -fno-fast-math -fcomplex-arithmetic=improved \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=IMPRVD %s
+// RUN: %clang -### -Werror --target=x86_64 -fno-fast-math -fcomplex-arithmetic=improved \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=IMPRVD %s
 
-// RUN: %clang -### -Werror -target x86_64 -fno-fast-math -fcomplex-arithmetic=full \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+// RUN: %clang -### -Werror --target=x86_64 -fno-fast-math -fcomplex-arithmetic=full \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
 
-// RUN: %clang -### -target x86_64 -fno-fast-math -ffp-model=aggressive \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=BASIC %s
+// RUN: %clang -### -Werror --target=x86_64 -fno-fast-math -ffp-model=aggressive \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=BASIC %s
 
-// RUN: %clang -### -target x86_64 -fno-fast-math -ffp-model=fast \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=PRMTD,WARN31 %s
+// RUN: %clang -### -Werror --target=x86_64 -fno-fast-math -ffp-model=fast \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=PRMTD %s
 
-// RUN: %clang -### -Werror -target x86_64 -fno-fast-math -ffp-model=precise \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+// RUN: %clang -### -Werror --target=x86_64 -fno-fast-math -ffp-model=precise \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
 
-// RUN: %clang -### -Werror -target x86_64 -fno-fast-math -ffp-model=strict \
-// RUN: -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
+// RUN: %clang -### -Werror --target=x86_64 -fno-fast-math -ffp-model=strict \
+// RUN:   -c %s 2>&1 | FileCheck --check-prefixes=FULL %s
 
 // WARN1: warning: overriding '-fcx-limited-range' option with '-fcx-fortran-rules' [-Woverriding-option]
 // WARN2: warning: overriding '-fno-cx-limited-range' option with '-fcx-fortran-rules' [-Woverriding-option]
@@ -265,17 +265,11 @@
 // WARN14: overriding '-complex-range=promoted' option with '-fcx-limited-range' [-Woverriding-option]
 // WARN17: warning: overriding '-fcomplex-arithmetic=full' option with '-fcomplex-arithmetic=basic' [-Woverriding-option]
 // WARN20: warning: overriding '-fcx-fortran-rules' option with '-fcx-limited-range' [-Woverriding-option]
-// WARN21: warning: overriding '-fcx-limited-range' option with '-fcomplex-arithmetic=full' [-Woverriding-option]
-// WARN22: warning: overriding '-fcx-fortran-rules' option with '-fcomplex-arithmetic=full' [-Woverriding-option]
-// WARN23: warning: overriding '-fcomplex-arithmetic=basic' option with '-fcomplex-arithmetic=full' [-Woverriding-option]
-// WARN24: warning: overriding '-fcomplex-arithmetic=promoted' option with '-fcomplex-arithmetic=full' [-Woverriding-option]
-// WARN25: warning: overriding '-fcomplex-arithmetic=improved' option with '-fcomplex-arithmetic=full' [-Woverriding-option]
-// WARN26: warning: overriding '-complex-range=full' option with '-fcx-limited-range' [-Woverriding-option]
-// WARN27: warning: overriding '-complex-range=full' option with '-fcx-fortran-rules' [-Woverriding-option]
-// WARN28: warning: overriding '-complex-range=full' option with '-fcomplex-arithmetic=basic' [-Woverriding-option]
-// WARN29: warning: overriding '-complex-range=full' option with '-fcomplex-arithmetic=promoted' [-Woverriding-option]
-// WARN30: warning: overriding '-complex-range=full' option with '-fcomplex-arithmetic=improved' [-Woverriding-option]
-// WARN31: warning: overriding '-fcomplex-arithmetic=full' option with '-fcomplex-arithmetic=promoted' [-Woverriding-option]
+// WARN21: warning: overriding '-fcx-limited-range' option with '-fno-fast-math' [-Woverriding-option]
+// WARN22: warning: overriding '-fcx-fortran-rules' option with '-fno-fast-math' [-Woverriding-option]
+// WARN23: warning: overriding '-fcomplex-arithmetic=basic' option with '-fno-fast-math' [-Woverriding-option]
+// WARN24: warning: overriding '-fcomplex-arithmetic=promoted' option with '-fno-fast-math' [-Woverriding-option]
+// WARN25: warning: overriding '-fcomplex-arithmetic=improved' option with '-fno-fast-math' [-Woverriding-option]
 
 // BASIC: -complex-range=basic
 // FULL: -complex-range=full
@@ -285,5 +279,6 @@
 // IMPRVD: -complex-range=improved
 // IMPRVD-NOT: -complex-range=basic
 // CHECK-NOT: -complex-range=improved
+// RANGE-NOT: -complex-range=
 
 // ERR: error: unsupported argument 'foo' to option '-fcomplex-arithmetic='


### PR DESCRIPTION
…st-math

This patch fixes a bug where -fno-fast-math doesn't revert the complex number calculation method to the default. The priority of overriding options related to complex number calculations differs slightly from GCC, as discussed in:

https://discourse.llvm.org/t/the-priority-of-fno-fast-math-regarding-complex-number-calculations/84679

I will post another patch to add a warning that the option overriding rules are incompatible with GCC.
In that patch, I will also fix the conditions for warnings related to other complex number options.