### PR TITLE
[clang][bytecode] Add Descriptor::getDataType()

### DIFF
--- a/clang/lib/AST/ByteCode/Descriptor.h
+++ b/clang/lib/AST/ByteCode/Descriptor.h
@@ -207,6 +207,7 @@ public:
 
   QualType getType() const;
   QualType getElemQualType() const;
+  QualType getDataType(const ASTContext &Ctx) const;
   SourceLocation getLocation() const;
   SourceInfo getLoc() const;
 

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -158,6 +158,8 @@ static QualType getElemType(const Pointer &P) {
     return T->getAs<PointerType>()->getPointeeType();
   if (Desc->isArray())
     return Desc->getElemQualType();
+  if (const auto *AT = T->getAsArrayTypeUnsafe())
+    return AT->getElementType();
   return T;
 }
 


### PR DESCRIPTION
This returns the type of data in the Block, which might be different than the type of the expression or declaration we created the block for. This lets us remove some special cases from CheckNewDeleteForms() and CheckNewTypeMismatch().