### PR TITLE
[offload] Remove bad assert in StaticLoopChunker::Distribute

### DIFF
--- a/offload/DeviceRTL/src/Workshare.cpp
+++ b/offload/DeviceRTL/src/Workshare.cpp
@@ -820,7 +820,6 @@ public:
     Ty ThreadChunk = 0;
     Ty NumThreads = 1;
     Ty TId = 0;
-    ASSERT(TId == mapping::getThreadIdInBlock(), "Bad thread id");
 
     // All teams need to participate.
     Ty NumBlocks = mapping::getNumberOfBlocksInKernel();

--- a/offload/test/offloading/fortran/target-teams-dist-nest-par.f90
+++ b/offload/test/offloading/fortran/target-teams-dist-nest-par.f90
@@ -1,0 +1,26 @@
+! REQUIRES: flang, amdgpu
+
+! RUN: %libomptarget-compile-fortran-generic
+! RUN: %libomptarget-run-generic 2>&1 | %fcheck-generic
+program main
+  integer :: array(10) = 0
+  integer :: x, y, z
+  !$omp target
+  !$omp teams distribute private(x, y)
+  OuterLoopOne: do x=1,1
+     array(2) = 42
+     OuterLoopTwo: do y=1,1
+        !$omp parallel do private(z)
+        InnerLoopOne: do z=1,10
+           array(z) = 20
+        enddo InnerLoopOne
+        !$omp end parallel do
+     enddo OuterLoopTwo
+  enddo OuterLoopOne
+  !$omp end teams distribute
+  !$omp end target
+  ! Expected to print all 20's
+  print *, array
+end program main
+
+! CHECK: 20 20 20 20 20 20 20 20 20 20


### PR DESCRIPTION
When building with asserts enabled, this can actually cause strange miscompilations because an incorrect llvm.assume is generated at the point of the assertion.