### PR TITLE
[lldb][AIX] clang-format for common Host.cpp

### DIFF
--- a/lldb/source/Host/common/Host.cpp
+++ b/lldb/source/Host/common/Host.cpp
@@ -17,11 +17,11 @@
 #include <grp.h>
 #include <netdb.h>
 #include <pwd.h>
+#include <spawn.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/wait.h>
 #include <unistd.h>
-#include <spawn.h>
 #endif
 
 #if defined(__APPLE__)
@@ -194,8 +194,8 @@ MonitorChildProcessThreadFunction(::pid_t pid,
 
     const ::pid_t wait_pid = ::waitpid(pid, &status, 0);
 
-    LLDB_LOG(log, "::waitpid({0}, &status, 0) => pid = {1}, status = {2:x}", pid,
-             wait_pid, status);
+    LLDB_LOG(log, "::waitpid({0}, &status, 0) => pid = {1}, status = {2:x}",
+             pid, wait_pid, status);
 
     if (CheckForMonitorCancellation())
       return nullptr;
@@ -612,7 +612,7 @@ void llvm::format_provider<WaitStatus>::format(const WaitStatus &WS,
 
   assert(Options.empty());
   const char *desc;
-  switch(WS.type) {
+  switch (WS.type) {
   case WaitStatus::Exit:
     desc = "Exited with status";
     break;


### PR DESCRIPTION
This PR is in reference to porting LLDB on AIX.

Link to discussions on llvm discourse and github:

1. https://discourse.llvm.org/t/port-lldb-to-ibm-aix/80640
2. https://github.com/llvm/llvm-project/issues/101657
The complete changes for porting are present in this draft PR:
https://github.com/llvm/llvm-project/pull/102601

Clang-format for common/Host.cpp for the followup changes