### PR TITLE
[AsmParser] Correctly handle .ifeqs nested in other conditional directives

### DIFF
--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -5224,37 +5224,42 @@ bool AsmParser::parseDirectiveIfc(SMLoc DirectiveLoc, bool ExpectEqual) {
 /// parseDirectiveIfeqs
 ///   ::= .ifeqs string1, string2
 bool AsmParser::parseDirectiveIfeqs(SMLoc DirectiveLoc, bool ExpectEqual) {
-  if (Lexer.isNot(AsmToken::String)) {
-    if (ExpectEqual)
-      return TokError("expected string parameter for '.ifeqs' directive");
-    return TokError("expected string parameter for '.ifnes' directive");
-  }
-
-  StringRef String1 = getTok().getStringContents();
-  Lex();
-
-  if (Lexer.isNot(AsmToken::Comma)) {
-    if (ExpectEqual)
-      return TokError(
-          "expected comma after first string for '.ifeqs' directive");
-    return TokError("expected comma after first string for '.ifnes' directive");
-  }
-
-  Lex();
-
-  if (Lexer.isNot(AsmToken::String)) {
-    if (ExpectEqual)
-      return TokError("expected string parameter for '.ifeqs' directive");
-    return TokError("expected string parameter for '.ifnes' directive");
-  }
-
-  StringRef String2 = getTok().getStringContents();
-  Lex();
-
   TheCondStack.push_back(TheCondState);
   TheCondState.TheCond = AsmCond::IfCond;
-  TheCondState.CondMet = ExpectEqual == (String1 == String2);
-  TheCondState.Ignore = !TheCondState.CondMet;
+
+  if (TheCondState.Ignore) {
+    eatToEndOfStatement();
+  } else {
+    if (Lexer.isNot(AsmToken::String)) {
+      if (ExpectEqual)
+        return TokError("expected string parameter for '.ifeqs' directive");
+      return TokError("expected string parameter for '.ifnes' directive");
+    }
+
+    StringRef String1 = getTok().getStringContents();
+    Lex();
+
+    if (Lexer.isNot(AsmToken::Comma)) {
+      if (ExpectEqual)
+        return TokError(
+            "expected comma after first string for '.ifeqs' directive");
+      return TokError("expected comma after first string for '.ifnes' directive");
+    }
+
+    Lex();
+
+    if (Lexer.isNot(AsmToken::String)) {
+      if (ExpectEqual)
+        return TokError("expected string parameter for '.ifeqs' directive");
+      return TokError("expected string parameter for '.ifnes' directive");
+    }
+
+    StringRef String2 = getTok().getStringContents();
+    Lex();
+
+    TheCondState.CondMet = ExpectEqual == (String1 == String2);
+    TheCondState.Ignore = !TheCondState.CondMet;
+  }
 
   return false;
 }

--- a/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -5243,7 +5243,8 @@ bool AsmParser::parseDirectiveIfeqs(SMLoc DirectiveLoc, bool ExpectEqual) {
       if (ExpectEqual)
         return TokError(
             "expected comma after first string for '.ifeqs' directive");
-      return TokError("expected comma after first string for '.ifnes' directive");
+      return TokError(
+          "expected comma after first string for '.ifnes' directive");
     }
 
     Lex();

--- a/llvm/test/MC/AsmParser/ifeqs.s
+++ b/llvm/test/MC/AsmParser/ifeqs.s
@@ -18,3 +18,14 @@
 // CHECK-NOT: .byte 0
 // CHECK: .byte 1
 
+
+.if 0
+  .ifeqs "alpha", "alpha"
+    .byte 2
+  .else
+    .byte 3
+  .endif
+.endif
+
+// CHECK-NOT: .byte 2
+// CHECK-NOT: .byte 3

--- a/llvm/test/MC/AsmParser/ifnes.s
+++ b/llvm/test/MC/AsmParser/ifnes.s
@@ -20,3 +20,13 @@
 # CHECK: .byte 1
 .ifnes "equal", "equal" ; .byte 0 ; .else ; .byte 1 ; .endif
 
+.if 0
+  .ifnes "alpha", "alpha"
+    .byte 2
+  .else
+    .byte 3
+  .endif
+.endif
+
+// CHECK-NOT: .byte 2
+// CHECK-NOT: .byte 3


### PR DESCRIPTION
The parser function used for the .ifeqs and .ifnes directives was missing the check for whether we are currently in an ignored block of an outer conditional directive, causing the block to be evaluated when it should not, for example:

.if 0
  .ifeqs "a", "a"
    // Should not be evaluated, but is
    nop
  .endif
.endif