### PR TITLE
llvm-reduce: Fix operand reduction asserting on target ext types

### DIFF
--- a/llvm/test/tools/llvm-reduce/reduce-operands-target-ext-ty.ll
+++ b/llvm/test/tools/llvm-reduce/reduce-operands-target-ext-ty.ll
@@ -1,0 +1,25 @@
+; RUN: llvm-reduce --abort-on-invalid-reduction --delta-passes=operands-zero --test FileCheck --test-arg %s --test-arg --input-file %s -o %t
+; RUN: FileCheck --check-prefixes=CHECK,ZERO %s < %t
+
+; RUN: llvm-reduce --abort-on-invalid-reduction --delta-passes=operands-one --test FileCheck --test-arg %s --test-arg --input-file %s -o %t
+; RUN: FileCheck --check-prefixes=CHECK,ONE %s < %t
+
+declare void @uses_ext_ty(target("sometarget.sometype"))
+
+; CHECK-LABEL: @foo(
+; ZERO: call void @uses_ext_ty(target("sometarget.sometype") poison)
+; ONE: call void @uses_ext_ty(target("sometarget.sometype") %arg)
+define void @foo(target("sometarget.sometype") %arg) {
+  call void @uses_ext_ty(target("sometarget.sometype") %arg)
+  ret void
+}
+
+declare void @uses_zeroinit_ext_ty(target("sometarget.sometype"))
+
+; CHECK-LABEL: @bar(
+; ZERO: call void @uses_zeroinit_ext_ty(target("spirv.sometype") zeroinitializer)
+; ONE: call void @uses_zeroinit_ext_ty(target("spirv.sometype") %arg)
+define void @bar(target("spirv.sometype") %arg) {
+  call void @uses_zeroinit_ext_ty(target("spirv.sometype") %arg)
+  ret void
+}

--- a/llvm/test/tools/llvm-reduce/reduce-operands-target-ext-ty.ll
+++ b/llvm/test/tools/llvm-reduce/reduce-operands-target-ext-ty.ll
@@ -6,8 +6,9 @@
 
 declare void @uses_ext_ty(target("sometarget.sometype"))
 
+; TODO: Should support reduce to poison
 ; CHECK-LABEL: @foo(
-; ZERO: call void @uses_ext_ty(target("sometarget.sometype") poison)
+; ZERO: call void @uses_ext_ty(target("sometarget.sometype") %arg)
 ; ONE: call void @uses_ext_ty(target("sometarget.sometype") %arg)
 define void @foo(target("sometarget.sometype") %arg) {
   call void @uses_ext_ty(target("sometarget.sometype") %arg)

--- a/llvm/tools/llvm-reduce/deltas/ReduceOperands.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperands.cpp
@@ -140,7 +140,9 @@ void llvm::reduceOperandsZeroDeltaPass(TestRunner &Test) {
         return nullptr;
       if (TET->hasProperty(TargetExtType::HasZeroInit))
         return ConstantTargetNone::get(TET);
-      return PoisonValue::get(TET);
+
+      // TODO: Poison reduction for this case
+      return nullptr;
     }
 
     // Don't replace existing zeroes.

--- a/llvm/tools/llvm-reduce/deltas/ReduceOperands.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperands.cpp
@@ -135,6 +135,13 @@ void llvm::reduceOperandsZeroDeltaPass(TestRunner &Test) {
       if (switchCaseExists(Op, ConstantInt::get(IntTy, 0)))
         return nullptr;
     // Don't replace existing zeroes.
+
+    if (auto *TET = dyn_cast<TargetExtType>(Op->getType())) {
+      if (TET->hasProperty(TargetExtType::HasZeroInit))
+        return ConstantTargetNone::get(TET);
+      return PoisonValue::get(TET);
+    }
+
     return isZero(Op) ? nullptr : Constant::getNullValue(Op->getType());
   };
   runDeltaPass(

--- a/llvm/tools/llvm-reduce/deltas/ReduceOperands.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperands.cpp
@@ -134,14 +134,16 @@ void llvm::reduceOperandsZeroDeltaPass(TestRunner &Test) {
     if (auto *IntTy = dyn_cast<IntegerType>(Op->getType()))
       if (switchCaseExists(Op, ConstantInt::get(IntTy, 0)))
         return nullptr;
-    // Don't replace existing zeroes.
 
     if (auto *TET = dyn_cast<TargetExtType>(Op->getType())) {
+      if (isa<ConstantTargetNone, PoisonValue>(Op))
+        return nullptr;
       if (TET->hasProperty(TargetExtType::HasZeroInit))
         return ConstantTargetNone::get(TET);
       return PoisonValue::get(TET);
     }
 
+    // Don't replace existing zeroes.
     return isZero(Op) ? nullptr : Constant::getNullValue(Op->getType());
   };
   runDeltaPass(


### PR DESCRIPTION
Not all TargetExtTypes support zeroinit, so use poison as a substitute
if unavailable.