### PR TITLE
Fix globals being wrongly tagged after global optimization step

### DIFF
--- a/llvm/include/llvm/IR/GlobalValue.h
+++ b/llvm/include/llvm/IR/GlobalValue.h
@@ -362,6 +362,7 @@ public:
   void setSanitizerMetadata(SanitizerMetadata Meta);
   void removeSanitizerMetadata();
   void setNoSanitizeMetadata();
+  void disableSanitizerMetadataGlobalTagging();
 
   bool isTagged() const {
     return hasSanitizerMetadata() && getSanitizerMetadata().Memtag;

--- a/llvm/lib/IR/Globals.cpp
+++ b/llvm/lib/IR/Globals.cpp
@@ -266,6 +266,16 @@ void GlobalValue::setNoSanitizeMetadata() {
   setSanitizerMetadata(Meta);
 }
 
+void GlobalValue::disableSanitizerMetadataGlobalTagging() {
+  if (!isTagged()) {
+    return;
+  }
+
+  auto MD = getSanitizerMetadata();
+  MD.Memtag = false;
+  setSanitizerMetadata(MD);
+}
+
 StringRef GlobalObject::getSectionImpl() const {
   assert(hasSection());
   return getContext().pImpl->GlobalObjectSections[this];

--- a/llvm/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/llvm/lib/Transforms/IPO/GlobalOpt.cpp
@@ -1525,6 +1525,7 @@ processInternalGlobal(GlobalVariable *GV, const GlobalStatus &GS,
     if (GS.Ordering == AtomicOrdering::NotAtomic) {
       assert(!GV->isConstant() && "Expected a non-constant global");
       GV->setConstant(true);
+      GV->disableSanitizerMetadataGlobalTagging();
       Changed = true;
     }
 
@@ -2257,8 +2258,10 @@ static bool EvaluateStaticConstructor(Function *F, const DataLayout &DL,
                       << " stores.\n");
     for (const auto &Pair : NewInitializers)
       Pair.first->setInitializer(Pair.second);
-    for (GlobalVariable *GV : Eval.getInvariants())
+    for (GlobalVariable *GV : Eval.getInvariants()) {
       GV->setConstant(true);
+      GV->disableSanitizerMetadataGlobalTagging();
+    }
   }
 
   return EvalSuccess;


### PR DESCRIPTION
Global tagging for MTE is currently only supported for non-RO data. Most cases are already handled, but some global variables are late marked as RO, and the SanitizerMetadata must be updated.