### PR TITLE
[analyzer] Fix format attribute handling in GenericTaintChecker

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/GenericTaintChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/GenericTaintChecker.cpp
@@ -1080,7 +1080,23 @@ static bool getPrintfFormatArgumentNum(const CallEvent &Call,
   const ArgIdxTy CallNumArgs = fromArgumentCount(Call.getNumArgs());
 
   for (const auto *Format : FDecl->specific_attrs<FormatAttr>()) {
+    // The format attribute uses 1-based parameter indexing, for example
+    // plain `printf(const char *fmt, ...)` would be annotated with
+    // `__format__(__printf__, 1, 2)`, so we need to subtract 1 to get a
+    // 0-based index. (This checker uses 0-based parameter indices.)
     ArgNum = Format->getFormatIdx() - 1;
+    // The format attribute also counts the implicit `this` parameter of
+    // methods, so e.g. in `SomeClass::method(const char *fmt, ...)` could be
+    // annotated with `__format__(__printf__, 2, 3)`. This checker doesn't
+    // count the implicit `this` parameter, so in this case we need to subtract
+    // one again.
+    // FIXME: Apparently the implementation of the format attribute doesn't
+    // support methods with an explicit object parameter, so we cannot
+    // implement proper support for that rare case either.
+    const CXXMethodDecl *MDecl = dyn_cast<CXXMethodDecl>(FDecl);
+    if (MDecl && !MDecl->isStatic())
+      ArgNum--;
+
     if ((Format->getType()->getName() == "printf") && CallNumArgs > ArgNum)
       return true;
   }

--- a/clang/test/Analysis/taint-generic.cpp
+++ b/clang/test/Analysis/taint-generic.cpp
@@ -186,10 +186,9 @@ struct Foo {
     int n;
     fscanf(stdin, "%d", &n); // Get a tainted value.
                              
-    // FIXME: The analyzer misinterprets the parameter indices in the format
+    // The analyzer used to misinterpret the parameter indices in the format
     // attribute when the format attribute is applied to a method.
-    log_method("This number is suspicious: %d\n", n);
-    // expected-warning@-1 {{Untrusted data is used as a format string}}
+    log_method("This number is suspicious: %d\n", n); // no-warning
   }
 
   __attribute__((__format__ (__printf__, 1, 2)))

--- a/clang/test/Analysis/taint-generic.cpp
+++ b/clang/test/Analysis/taint-generic.cpp
@@ -165,13 +165,13 @@ void top() {
 
 namespace format_attribute {
 __attribute__((__format__ (__printf__, 1, 2)))
-void log_nonmethod(const char *fmt, ...);
+void log_freefunc(const char *fmt, ...);
 
-void test_format_attribute_nonmethod() {
+void test_format_attribute_freefunc() {
   int n;
   fscanf(stdin, "%d", &n); // Get a tainted value.
                            
-  log_nonmethod("This number is suspicious: %d\n", n); // no-warning
+  log_freefunc("This number is suspicious: %d\n", n); // no-warning
 }
 
 struct Foo {


### PR DESCRIPTION
Previously `optin.taint.GenericTaint` misinterpreted the parameter indices and produced false positives in situations when a [format attribute](https://clang.llvm.org/docs/AttributeReference.html#format) is applied on a non-static method. This commit fixes this bug