### PR TITLE
[clang][bytecode] Fix zero-init of atomic floating point objects

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -4033,6 +4033,9 @@ template <class Emitter> bool Compiler<Emitter>::visitBool(const Expr *E) {
 template <class Emitter>
 bool Compiler<Emitter>::visitZeroInitializer(PrimType T, QualType QT,
                                              const Expr *E) {
+  if (const auto *AT = QT->getAs<AtomicType>())
+    QT = AT->getValueType();
+
   switch (T) {
   case PT_Bool:
     return this->emitZeroBool(E);

--- a/clang/test/AST/ByteCode/floats.cpp
+++ b/clang/test/AST/ByteCode/floats.cpp
@@ -175,7 +175,10 @@ namespace ZeroInit {
   static_assert(a.f == 0.0f, "");
 
   constexpr A<double> b{12};
-  static_assert(a.f == 0.0, "");
+  static_assert(b.f == 0.0, "");
+
+  constexpr A<_Atomic(float)> c{12};
+  static_assert(c.f == 0.0, "");
 };
 
 namespace LongDouble {


### PR DESCRIPTION
We can't pass the AtomicType along to ASTContext::getFloatTypeSemantics.