### PR TITLE
[flang] Remove mentions of evaluate::Variable<T>

### DIFF
--- a/flang/include/flang/Evaluate/traverse.h
+++ b/flang/include/flang/Evaluate/traverse.h
@@ -159,9 +159,6 @@ public:
   template <typename T> Result operator()(const Designator<T> &x) const {
     return visitor_(x.u);
   }
-  template <typename T> Result operator()(const Variable<T> &x) const {
-    return visitor_(x.u);
-  }
   Result operator()(const DescriptorInquiry &x) const {
     return visitor_(x.base());
   }

--- a/flang/include/flang/Evaluate/variable.h
+++ b/flang/include/flang/Evaluate/variable.h
@@ -44,7 +44,6 @@ using SymbolVector = std::vector<SymbolRef>;
 
 // Forward declarations
 struct DataRef;
-template <typename T> struct Variable;
 
 // Reference a base object in memory.  This can be a Fortran symbol,
 // static data (e.g., CHARACTER literal), or compiler-created temporary.

--- a/flang/include/flang/Semantics/dump-expr.h
+++ b/flang/include/flang/Semantics/dump-expr.h
@@ -106,11 +106,6 @@ private:
     Show(x.u);
     Outdent();
   }
-  template <typename T> void Show(const evaluate::Variable<T> &x) {
-    Indent("variable");
-    Show(x.u);
-    Outdent();
-  }
   void Show(const evaluate::DescriptorInquiry &x);
   void Show(const evaluate::SpecificIntrinsic &);
   void Show(const evaluate::ProcedureDesignator &x);

--- a/flang/lib/Lower/IterationSpace.cpp
+++ b/flang/lib/Lower/IterationSpace.cpp
@@ -165,10 +165,6 @@ private:
   RT find(const Fortran::evaluate::Designator<T> &x) {
     return find(x.u);
   }
-  template <typename T>
-  RT find(const Fortran::evaluate::Variable<T> &x) {
-    return find(x.u);
-  }
   RT find(const Fortran::evaluate::DescriptorInquiry &) { return {}; }
   RT find(const Fortran::evaluate::SpecificIntrinsic &) { return {}; }
   RT find(const Fortran::evaluate::ProcedureDesignator &x) { return {}; }


### PR DESCRIPTION
The template itself was not defined anywhere. The closest thing was a forward declaration in flang/include/flang/Evaluate/variable.h.