### PR TITLE
[libc] Remove extraneous ASSERT_ERRNO_* macro definitions

### DIFF
--- a/libc/test/UnitTest/ZxTest.h
+++ b/libc/test/UnitTest/ZxTest.h
@@ -14,14 +14,6 @@
 
 #define WITH_SIGNAL(X) #X
 
-// These macros are used in string unittests.
-#define ASSERT_ERRNO_EQ(VAL)                                                   \
-  ASSERT_EQ(VAL, static_cast<int>(LIBC_NAMESPACE::libc_errno))
-#define ASSERT_ERRNO_SUCCESS()                                                 \
-  ASSERT_EQ(0, static_cast<int>(LIBC_NAMESPACE::libc_errno))
-#define ASSERT_ERRNO_FAILURE()                                                 \
-  ASSERT_NE(0, static_cast<int>(LIBC_NAMESPACE::libc_errno))
-
 #ifndef EXPECT_DEATH
 // Since zxtest has ASSERT_DEATH but not EXPECT_DEATH, wrap calling it
 // in a lambda returning void to swallow any early returns so that this


### PR DESCRIPTION
These are no longer meant to be defined in each
framework-specific header, but ZxTest.h wasn't updated.
