### PR TITLE
Limit modernize-use-nullptr to C++11/C23 and later

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseNullptrCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseNullptrCheck.cpp
@@ -505,7 +505,10 @@ void UseNullptrCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
 }
 
 void UseNullptrCheck::registerMatchers(MatchFinder *Finder) {
-  Finder->addMatcher(makeCastSequenceMatcher(IgnoredTypes), this);
+  // nullptr is supported starting from C++11 and C23.
+  if (getLangOpts().CPlusPlus11 || getLangOpts().C23) {
+    Finder->addMatcher(makeCastSequenceMatcher(IgnoredTypes), this);
+  }
 }
 
 void UseNullptrCheck::check(const MatchFinder::MatchResult &Result) {


### PR DESCRIPTION
`nullptr` is not supported on earlier versions of either standard, so the tidy should not diagnose earlier uses.