### PR TITLE
[flang] Generate quadmath_wrapper.h for Flang Evaluate.

### DIFF
--- a/flang-rt/CMakeLists.txt
+++ b/flang-rt/CMakeLists.txt
@@ -290,44 +290,6 @@ set(HAVE_BACKTRACE ${Backtrace_FOUND})
 set(BACKTRACE_HEADER ${Backtrace_HEADER})
 
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  if (NOT DEFINED FLANG_RT_GCC_RESOURCE_DIR)
-    set(FLANG_RT_GCC_RESOURCE_DIR "FLANG_RT_GCC_RESOURCE_DIR-NOTFOUND")
-    execute_process(
-      COMMAND "${CMAKE_CXX_COMPILER}" -v -c "${FLANG_RT_SOURCE_DIR}/cmake/clang_gcc_root.cpp" ${CMAKE_CXX_FLAGS} -###
-      ERROR_FILE "${CMAKE_CURRENT_BINARY_DIR}/clang_gcc_root_result"
-    )
-    file(STRINGS "${CMAKE_CURRENT_BINARY_DIR}/clang_gcc_root_result" _errorresult)
-    foreach (_line IN LISTS _errorresult)
-      string(REGEX MATCH
-        "^Selected GCC installation: (.+)$"
-        _match
-        "${_line}")
-      if (CMAKE_MATCH_1)
-        set(FLANG_RT_GCC_RESOURCE_DIR "${CMAKE_MATCH_1}")
-        message(STATUS "Found GCC installation selected by Clang: ${FLANG_RT_GCC_RESOURCE_DIR}")
-        break()
-      endif ()
-    endforeach ()
-    set(FLANG_RT_GCC_RESOURCE_DIR "${FLANG_RT_GCC_RESOURCE_DIR}" CACHE INTERNAL "Path to GCC's resource dir selected by Clang" FORCE)
-  endif ()
-endif ()
-
-check_include_file("quadmath.h" FOUND_QUADMATH_H)
-if (FOUND_QUADMATH_H)
-  message(STATUS "quadmath.h found without additional include paths")
-  set(FLANG_RT_INCLUDE_QUADMATH_H "<quadmath.h>")
-elseif (FLANG_RT_GCC_RESOURCE_DIR)
-  cmake_push_check_state()
-    list(APPEND CMAKE_REQUIRED_INCLUDES "${FLANG_RT_GCC_RESOURCE_DIR}/include")
-    check_include_file("quadmath.h" FOUND_GCC_QUADMATH_H)
-  cmake_pop_check_state()
-  if (FOUND_GCC_QUADMATH_H)
-    message(STATUS "quadmath.h found in Clang's selected GCC installation")
-    set(FLANG_RT_INCLUDE_QUADMATH_H "\"${FLANG_RT_GCC_RESOURCE_DIR}/include/quadmath.h\"")
-  endif ()
-endif ()
-
 #####################
 # Build Preparation #
 #####################
@@ -351,7 +313,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 
 configure_file(cmake/config.h.cmake.in config.h)
-if (FLANG_RT_INCLUDE_QUADMATH_H)
+if (FLANG_INCLUDE_QUADMATH_H)
   configure_file("cmake/quadmath_wrapper.h.in" "${FLANG_RT_BINARY_DIR}/quadmath_wrapper.h")
 endif ()
 

--- a/flang-rt/cmake/clang_gcc_root.cpp
+++ b/flang-rt/cmake/clang_gcc_root.cpp
@@ -1,1 +1,0 @@
-int main() { return 0; }

--- a/flang-rt/lib/quadmath/CMakeLists.txt
+++ b/flang-rt/lib/quadmath/CMakeLists.txt
@@ -78,7 +78,7 @@ target_include_directories(FortranFloat128MathILib INTERFACE
 
 if (FLANG_RUNTIME_F128_MATH_LIB)
   if (${FLANG_RUNTIME_F128_MATH_LIB} STREQUAL "libquadmath")
-    if(FLANG_RT_INCLUDE_QUADMATH_H)
+    if(FLANG_INCLUDE_QUADMATH_H)
       add_compile_definitions(HAS_QUADMATHLIB)
     else()
       message(FATAL_ERROR

--- a/flang/cmake/modules/FlangCommon.cmake
+++ b/flang/cmake/modules/FlangCommon.cmake
@@ -37,3 +37,49 @@ check_c_source_compiles(
    int main() { return 0; }
   "
   HAVE_LDBL_MANT_DIG_113)
+
+# Discover the GCC installation, when the build compiler is Clang,
+# and try to find quadmath.h there. Set FLANG_INCLUDE_QUADMATH_H
+# to the path to quadmath.h, if found.
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  if (NOT DEFINED FLANG_GCC_RESOURCE_DIR)
+    set(FLANG_GCC_RESOURCE_DIR "FLANG_GCC_RESOURCE_DIR-NOTFOUND")
+    # Prepare CMAKE_CXX_FLAGS so that they can be passed to execute_process
+    # as separate flags.
+    separate_arguments(flags UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
+    set(hash_flag "-###")
+    set(command ${CMAKE_CXX_COMPILER} ${flags} ${hash_flag} -v)
+    execute_process(
+      COMMAND ${command}
+      ERROR_FILE "${CMAKE_CURRENT_BINARY_DIR}/clang_gcc_root_result"
+    )
+    file(STRINGS "${CMAKE_CURRENT_BINARY_DIR}/clang_gcc_root_result" _errorresult)
+    foreach (_line IN LISTS _errorresult)
+      string(REGEX MATCH
+        "^Selected GCC installation: (.+)$"
+        _match
+        "${_line}")
+      if (CMAKE_MATCH_1)
+        set(FLANG_GCC_RESOURCE_DIR "${CMAKE_MATCH_1}")
+        message(STATUS "Found GCC installation selected by Clang: ${FLANG_GCC_RESOURCE_DIR}")
+        break()
+      endif ()
+    endforeach ()
+    set(FLANG_GCC_RESOURCE_DIR "${FLANG_GCC_RESOURCE_DIR}" CACHE INTERNAL "Path to GCC's resource dir selected by Clang" FORCE)
+  endif ()
+endif ()
+
+check_include_file("quadmath.h" FOUND_QUADMATH_H)
+if (FOUND_QUADMATH_H)
+  message(STATUS "quadmath.h found without additional include paths")
+  set(FLANG_INCLUDE_QUADMATH_H "<quadmath.h>")
+elseif (FLANG_GCC_RESOURCE_DIR)
+  cmake_push_check_state()
+    list(APPEND CMAKE_REQUIRED_INCLUDES "${FLANG_GCC_RESOURCE_DIR}/include")
+    check_include_file("quadmath.h" FOUND_GCC_QUADMATH_H)
+  cmake_pop_check_state()
+  if (FOUND_GCC_QUADMATH_H)
+    message(STATUS "quadmath.h found in Clang's selected GCC installation")
+    set(FLANG_INCLUDE_QUADMATH_H "\"${FLANG_GCC_RESOURCE_DIR}/include/quadmath.h\"")
+  endif ()
+endif ()

--- a/flang/cmake/modules/FlangCommon.cmake
+++ b/flang/cmake/modules/FlangCommon.cmake
@@ -47,10 +47,8 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # Prepare CMAKE_CXX_FLAGS so that they can be passed to execute_process
     # as separate flags.
     separate_arguments(flags UNIX_COMMAND "${CMAKE_CXX_FLAGS}")
-    set(hash_flag "-###")
-    set(command ${CMAKE_CXX_COMPILER} ${flags} ${hash_flag} -v)
     execute_process(
-      COMMAND ${command}
+      COMMAND "${CMAKE_CXX_COMPILER}" ${flags} -v "-###"
       ERROR_FILE "${CMAKE_CURRENT_BINARY_DIR}/clang_gcc_root_result"
     )
     file(STRINGS "${CMAKE_CURRENT_BINARY_DIR}/clang_gcc_root_result" _errorresult)

--- a/flang/cmake/quadmath_wrapper.h.in
+++ b/flang/cmake/quadmath_wrapper.h.in
@@ -6,4 +6,18 @@
  *
  *===----------------------------------------------------------------------===*/
 
+#ifdef __clang_major__
+/*
+ * _Complex inside quadmath.h triggers c99-extension warnings,
+ * when this header file is included into a C++ file.
+ * Disable them just during the inclusion of quadmath.h.
+ */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wc99-extensions"
+#endif
+
 #include ${FLANG_INCLUDE_QUADMATH_H}
+
+#ifdef __clang_major__
+#pragma clang diagnostic pop
+#endif

--- a/flang/lib/Evaluate/CMakeLists.txt
+++ b/flang/lib/Evaluate/CMakeLists.txt
@@ -21,12 +21,12 @@ if (LIBPGMATH_DIR)
   endif()
 endif()
 
-check_include_file(quadmath.h FOUND_QUADMATH_HEADER)
 check_library_exists(quadmath sinq "" FOUND_QUADMATH_LIB)
-if(FOUND_QUADMATH_HEADER AND FOUND_QUADMATH_LIB)
+if (FLANG_INCLUDE_QUADMATH_H AND FOUND_QUADMATH_LIB)
+  configure_file("${FLANG_SOURCE_DIR}/cmake/quadmath_wrapper.h.in" "${CMAKE_CURRENT_BINARY_DIR}/quadmath_wrapper.h")
   add_compile_definitions(HAS_QUADMATHLIB)
   set(QUADMATHLIB quadmath)
-endif()
+endif ()
 
 add_flang_library(FortranEvaluate
   call.cpp

--- a/flang/lib/Evaluate/host.h
+++ b/flang/lib/Evaluate/host.h
@@ -18,7 +18,7 @@
 // to safely refer to this hardware type.
 
 #if HAS_QUADMATHLIB
-#include "quadmath.h"
+#include "quadmath_wrapper.h"
 #include "flang/Common/float128.h"
 #endif
 #include "flang/Evaluate/type.h"

--- a/flang/lib/Evaluate/intrinsics-library.cpp
+++ b/flang/lib/Evaluate/intrinsics-library.cpp
@@ -23,7 +23,7 @@
 #include <complex>
 #include <functional>
 #if HAS_QUADMATHLIB
-#include "quadmath.h"
+#include "quadmath_wrapper.h"
 #endif
 #include "flang/Common/float128.h"
 #include "flang/Common/float80.h"


### PR DESCRIPTION
When building Flang with Clang, we need to do the same quadmath.h
wrapping as we do for flang-rt. I extracted the CMake code
into FlangCommon.cmake, and cleaned up the arguments passing
to execute_process (note that `-###` was treated as `-` in the original
code, because `#` starts a comment). I believe the Clang command
does not require the input source file, so I removed it as well.
