### PR TITLE
[libc] Migrate sys/epoll tests to use ErrnoCheckingTest.

### DIFF
--- a/libc/test/src/sys/epoll/linux/CMakeLists.txt
+++ b/libc/test/src/sys/epoll/linux/CMakeLists.txt
@@ -11,6 +11,7 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sys.epoll.epoll_create
     libc.src.unistd.close
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -25,6 +26,7 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sys.epoll.epoll_create1
     libc.src.unistd.close
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -42,6 +44,7 @@ add_libc_unittest(
     libc.src.sys.epoll.epoll_ctl
     libc.src.unistd.pipe
     libc.src.unistd.close
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -60,6 +63,7 @@ add_libc_unittest(
     libc.src.sys.epoll.epoll_wait
     libc.src.unistd.pipe
     libc.src.unistd.close
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -78,6 +82,7 @@ add_libc_unittest(
     libc.src.sys.epoll.epoll_pwait
     libc.src.unistd.pipe
     libc.src.unistd.close
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -97,5 +102,6 @@ add_libc_unittest(
     libc.src.sys.epoll.epoll_pwait2
     libc.src.unistd.pipe
     libc.src.unistd.close
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sys/epoll/linux/epoll_create1_test.cpp
+++ b/libc/test/src/sys/epoll/linux/epoll_create1_test.cpp
@@ -6,15 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 #include "hdr/sys_epoll_macros.h"
-#include "src/errno/libc_errno.h"
 #include "src/sys/epoll/epoll_create1.h"
 #include "src/unistd/close.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcEpollCreate1Test = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcEpollCreate1Test, Basic) {
+TEST_F(LlvmLibcEpollCreate1Test, Basic) {
   int fd = LIBC_NAMESPACE::epoll_create1(0);
   ASSERT_GT(fd, 0);
   ASSERT_ERRNO_SUCCESS();
@@ -22,7 +23,7 @@ TEST(LlvmLibcEpollCreate1Test, Basic) {
   ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds());
 }
 
-TEST(LlvmLibcEpollCreate1Test, CloseOnExecute) {
+TEST_F(LlvmLibcEpollCreate1Test, CloseOnExecute) {
   int fd = LIBC_NAMESPACE::epoll_create1(EPOLL_CLOEXEC);
   ASSERT_GT(fd, 0);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/sys/epoll/linux/epoll_create_test.cpp
+++ b/libc/test/src/sys/epoll/linux/epoll_create_test.cpp
@@ -5,16 +5,17 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-#include "src/errno/libc_errno.h"
 #include "src/sys/epoll/epoll_create.h"
 #include "src/unistd/close.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 #include <sys/syscall.h> // For syscall numbers.
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcEpollCreateTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcEpollCreateTest, Basic) {
+TEST_F(LlvmLibcEpollCreateTest, Basic) {
   int fd = LIBC_NAMESPACE::epoll_create(1);
   ASSERT_GT(fd, 0);
   ASSERT_ERRNO_SUCCESS();
@@ -23,7 +24,7 @@ TEST(LlvmLibcEpollCreateTest, Basic) {
 }
 
 #ifdef SYS_epoll_create
-TEST(LlvmLibcEpollCreateTest, Fails) {
+TEST_F(LlvmLibcEpollCreateTest, Fails) {
   ASSERT_THAT(LIBC_NAMESPACE::epoll_create(0), Fails(EINVAL));
 }
 #endif

--- a/libc/test/src/sys/epoll/linux/epoll_ctl_test.cpp
+++ b/libc/test/src/sys/epoll/linux/epoll_ctl_test.cpp
@@ -8,17 +8,18 @@
 
 #include "hdr/sys_epoll_macros.h"
 #include "hdr/types/struct_epoll_event.h"
-#include "src/errno/libc_errno.h"
 #include "src/sys/epoll/epoll_create1.h"
 #include "src/sys/epoll/epoll_ctl.h"
 #include "src/unistd/close.h"
 #include "src/unistd/pipe.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcEpollCtlTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcEpollCtlTest, Basic) {
+TEST_F(LlvmLibcEpollCtlTest, Basic) {
   int epfd = LIBC_NAMESPACE::epoll_create1(0);
   ASSERT_GT(epfd, 0);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/sys/epoll/linux/epoll_pwait2_test.cpp
+++ b/libc/test/src/sys/epoll/linux/epoll_pwait2_test.cpp
@@ -8,18 +8,19 @@
 #include "hdr/sys_epoll_macros.h"
 #include "hdr/types/struct_epoll_event.h"
 #include "hdr/types/struct_timespec.h"
-#include "src/errno/libc_errno.h"
 #include "src/sys/epoll/epoll_create1.h"
 #include "src/sys/epoll/epoll_ctl.h"
 #include "src/sys/epoll/epoll_pwait2.h"
 #include "src/unistd/close.h"
 #include "src/unistd/pipe.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcEpollPwaitTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcEpollPwaitTest, Basic) {
+TEST_F(LlvmLibcEpollPwaitTest, Basic) {
   int epfd = LIBC_NAMESPACE::epoll_create1(0);
   ASSERT_GT(epfd, 0);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/sys/epoll/linux/epoll_pwait_test.cpp
+++ b/libc/test/src/sys/epoll/linux/epoll_pwait_test.cpp
@@ -7,19 +7,19 @@
 //===----------------------------------------------------------------------===//
 #include "hdr/sys_epoll_macros.h"
 #include "hdr/types/struct_epoll_event.h"
-#include "src/errno/libc_errno.h"
 #include "src/sys/epoll/epoll_create1.h"
 #include "src/sys/epoll/epoll_ctl.h"
 #include "src/sys/epoll/epoll_pwait.h"
 #include "src/unistd/close.h"
 #include "src/unistd/pipe.h"
-
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcEpollPwaitTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcEpollPwaitTest, Basic) {
+TEST_F(LlvmLibcEpollPwaitTest, Basic) {
   int epfd = LIBC_NAMESPACE::epoll_create1(0);
   ASSERT_GT(epfd, 0);
   ASSERT_ERRNO_SUCCESS();

--- a/libc/test/src/sys/epoll/linux/epoll_wait_test.cpp
+++ b/libc/test/src/sys/epoll/linux/epoll_wait_test.cpp
@@ -7,18 +7,19 @@
 //===----------------------------------------------------------------------===//
 #include "hdr/sys_epoll_macros.h"
 #include "hdr/types/struct_epoll_event.h"
-#include "src/errno/libc_errno.h"
 #include "src/sys/epoll/epoll_create1.h"
 #include "src/sys/epoll/epoll_ctl.h"
 #include "src/sys/epoll/epoll_wait.h"
 #include "src/unistd/close.h"
 #include "src/unistd/pipe.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
+using LlvmLibcEpollWaitTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcEpollWaitTest, Basic) {
+TEST_F(LlvmLibcEpollWaitTest, Basic) {
   int epfd = LIBC_NAMESPACE::epoll_create1(0);
   ASSERT_GT(epfd, 0);
   ASSERT_ERRNO_SUCCESS();

--- a/utils/bazel/llvm-project-overlay/libc/test/src/sys/epoll/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/sys/epoll/BUILD.bazel
@@ -2,7 +2,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Tests for LLVM libc string.h functions.
+# Tests for LLVM libc sys/epoll.h functions.
 
 load("//libc/test:libc_test_rules.bzl", "libc_test")
 
@@ -17,6 +17,9 @@ libc_test(
         "//libc:epoll_create",
         "//libc:close",
     ],
+    deps = [
+        "//libc/test/UnitTest:errno_test_helpers",
+    ],
 )
 
 libc_test(
@@ -28,6 +31,7 @@ libc_test(
     ],
     deps = [
         "//libc:hdr_sys_epoll_macros",
+        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -43,6 +47,7 @@ libc_test(
     deps = [
         "//libc:hdr_sys_epoll_macros",
         "//libc:types_struct_epoll_event",
+        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -59,6 +64,7 @@ libc_test(
     deps = [
         "//libc:hdr_sys_epoll_macros",
         "//libc:types_struct_epoll_event",
+        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -75,6 +81,7 @@ libc_test(
     deps = [
         "//libc:hdr_sys_epoll_macros",
         "//libc:types_struct_epoll_event",
+        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -92,5 +99,6 @@ libc_test(
         "//libc:hdr_sys_epoll_macros",
         "//libc:types_struct_epoll_event",
         "//libc:types_struct_timespec",
+        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )


### PR DESCRIPTION
This is similar to PR #132107 but for tests for sys/epoll.h functions.

ErrnoCheckingTest ensures that errno is properly reset at the beginning of the test case, and is validated at the end of it, so that the manual code such as the one proposed in PR #131650 would not be necessary.