### PR TITLE
[clang] Fix overload resolution ranking of inherited constructors

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -358,6 +358,9 @@ Bug Fixes to C++ Support
 - Fixed a Clang regression in C++20 mode where unresolved dependent call expressions were created inside non-dependent contexts (#GH122892)
 - Clang now emits the ``-Wunused-variable`` warning when some structured bindings are unused
   and the ``[[maybe_unused]]`` attribute is not applied. (#GH125810)
+- Overload resolution tiebreaker for inherited constructors is now only
+  applied if their parameters have the same type, as required by the C++
+  standard. (#GH121331)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -40,7 +40,6 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/Casting.h"
 #include <algorithm>
 #include <cassert>
 #include <cstddef>

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -10730,7 +10730,8 @@ bool clang::isBetterOverloadCandidate(
       llvm::equal(Cand1.Function->parameters().take_front(NumArgs),
                   Cand2.Function->parameters().take_front(NumArgs),
                   [&](ParmVarDecl *P1, ParmVarDecl *P2) {
-                    return S.Context.hasSameUnqualifiedType(P1->getType(), P2->getType());
+                    return S.Context.hasSameUnqualifiedType(P1->getType(),
+                                                            P2->getType());
                   })) {
     auto *Cand1Class = cast<CXXRecordDecl>(Cand1.Function->getDeclContext());
     auto *Cand2Class = cast<CXXRecordDecl>(Cand2.Function->getDeclContext());

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -10729,6 +10729,8 @@ bool clang::isBetterOverloadCandidate(
       llvm::equal(Cand1.Function->parameters().take_front(NumArgs),
                   Cand2.Function->parameters().take_front(NumArgs),
                   [&](ParmVarDecl *P1, ParmVarDecl *P2) {
+                    // Top-level cv-qualifiers on function parameter
+                    // types are not part of the function type.
                     return S.Context.hasSameUnqualifiedType(P1->getType(),
                                                             P2->getType());
                   })) {

--- a/clang/test/CXX/drs/cwg22xx.cpp
+++ b/clang/test/CXX/drs/cwg22xx.cpp
@@ -169,6 +169,20 @@ B b;
 // since-cxx11-error@-1 {{call to implicitly-deleted default constructor of 'B'}}
 //   since-cxx11-note@#cwg2273-B {{default constructor of 'B' is implicitly deleted because base class 'A' has a deleted default constructor}}
 //   since-cxx11-note@#cwg2273-A {{'A' has been explicitly marked deleted here}}
+
+struct X {
+  X(float); // since-cxx11-note {{candidate inherited constructor}}
+  X(void*, int = 0) = delete;
+};
+
+struct Y : X {
+  using X::X; // since-cxx11-note {{constructor from base class 'X' inherited here}}
+  Y(double); // since-cxx11-note {{candidate constructor}}
+  Y(void* const, long = 1);
+};
+
+Y y = 1; // since-cxx11-error {{conversion from 'int' to 'Y' is ambiguous}}
+Y z = nullptr;
 #endif
 } // namespace cwg2273
 

--- a/clang/test/CXX/drs/cwg22xx.cpp
+++ b/clang/test/CXX/drs/cwg22xx.cpp
@@ -155,7 +155,7 @@ const D &d3(c); // FIXME ill-formed
 #endif
 } // namespace cwg2267
 
-namespace cwg2273 { // cwg2273: 3.3
+namespace cwg2273 { // cwg2273: 21
 #if __cplusplus >= 201103L
 struct A {
   A(int = 0) = delete; // #cwg2273-A
@@ -171,22 +171,26 @@ B b;
 //   since-cxx11-note@#cwg2273-A {{'A' has been explicitly marked deleted here}}
 
 struct X {
-  X(float); // since-cxx11-note {{candidate inherited constructor}}
+  X(float); // #cwg2273-X
   X(void*, int = 0) = delete;
 };
 
 struct Y : X {
-  using X::X; // since-cxx11-note {{constructor from base class 'X' inherited here}}
-  Y(double); // since-cxx11-note {{candidate constructor}}
+  using X::X; // #cwg2273-Y1
+  Y(double); // #cwg2273-Y2
   Y(void* const, long = 1);
 };
 
-Y y = 1; // since-cxx11-error {{conversion from 'int' to 'Y' is ambiguous}}
+Y y = 1;
+// since-cxx11-error@-1 {{conversion from 'int' to 'Y' is ambiguous}}
+//   since-cxx11-note@#cwg2273-X {{candidate inherited constructor}}
+//   since-cxx11-note@#cwg2273-Y1 {{constructor from base class 'X' inherited here}}
+//   since-cxx11-note@#cwg2273-Y2 {{candidate constructor}}
 Y z = nullptr;
 #endif
 } // namespace cwg2273
 
-namespace cwg2277 { // cwg2277: partial
+namespace cwg2277 { // cwg2277: 21
 #if __cplusplus >= 201103L
 struct A {
   A(int, int = 0);
@@ -202,7 +206,7 @@ struct B : A {
 
 void g() {
   B b{0};
-  b.f(0); // FIXME: this is well-formed for the same reason as initialization of 'b' above
+  b.f(0);
   // since-cxx11-error@-1 {{call to member function 'f' is ambiguous}}
   //   since-cxx11-note@#cwg2277-A-f {{candidate function}}
   //   since-cxx11-note@#cwg2277-B-f {{candidate function}}

--- a/clang/test/CXX/drs/cwg22xx.cpp
+++ b/clang/test/CXX/drs/cwg22xx.cpp
@@ -173,12 +173,17 @@ B b;
 struct X {
   X(float); // #cwg2273-X
   X(void*, int = 0) = delete;
+  X(int, const int*) = delete;
+  X(unsigned, int()) = delete;
 };
 
 struct Y : X {
   using X::X; // #cwg2273-Y1
   Y(double); // #cwg2273-Y2
   Y(void* const, long = 1);
+  using IA = int[42];
+  Y(int, const IA);
+  Y(unsigned, int (*)(void));
 };
 
 Y y = 1;
@@ -187,6 +192,8 @@ Y y = 1;
 //   since-cxx11-note@#cwg2273-Y1 {{constructor from base class 'X' inherited here}}
 //   since-cxx11-note@#cwg2273-Y2 {{candidate constructor}}
 Y z = nullptr;
+Y ya(1, nullptr);
+Y yf(1u, nullptr);
 #endif
 } // namespace cwg2273
 

--- a/clang/test/CXX/drs/cwg22xx.cpp
+++ b/clang/test/CXX/drs/cwg22xx.cpp
@@ -173,8 +173,8 @@ B b;
 struct X {
   X(float); // #cwg2273-X
   X(void*, int = 0) = delete;
-  X(int, const int*) = delete;
-  X(unsigned, int()) = delete;
+  X(int, const int*, int = 1) = delete;
+  X(unsigned, int(), int = 2) = delete;
 };
 
 struct Y : X {

--- a/clang/www/cxx_dr_status.html
+++ b/clang/www/cxx_dr_status.html
@@ -13469,7 +13469,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2273.html">2273</a></td>
     <td>CD5</td>
     <td>Inheriting constructors vs implicit default constructor</td>
-    <td class="full" align="center">Clang 3.3</td>
+    <td class="unreleased" align="center">Clang 21</td>
   </tr>
   <tr id="2274">
     <td><a href="https://cplusplus.github.io/CWG/issues/2274.html">2274</a></td>
@@ -13493,7 +13493,7 @@ and <I>POD class</I></td>
     <td><a href="https://cplusplus.github.io/CWG/issues/2277.html">2277</a></td>
     <td>CD5</td>
     <td>Ambiguity inheriting constructors with default arguments</td>
-    <td class="partial" align="center">Partial</td>
+    <td class="unreleased" align="center">Clang 21</td>
   </tr>
   <tr id="2278">
     <td><a href="https://cplusplus.github.io/CWG/issues/2278.html">2278</a></td>


### PR DESCRIPTION
Take parameter types of candidate constructors into account when deciding whether to apply the tiebreaker.

Fixes #121331