### PR TITLE
[alpha.webkit.RawPtrRefMemberChecker] The checker doesn't warn Objective-C types in ivars.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
@@ -160,7 +160,6 @@ public:
       return;
     if (auto *PropCXXRD = PropType->getPointeeCXXRecordDecl()) {
       std::optional<bool> IsCompatible = isPtrCompatible(QT, PropCXXRD);
-      fprintf(stderr, "IsCompatible=%d\n", IsCompatible ? *IsCompatible : -1);
       if (IsCompatible && *IsCompatible)
         reportBug(PD, PropType, PropCXXRD, CD);
     } else {

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
@@ -113,6 +113,12 @@ public:
   void visitObjCDecl(const ObjCContainerDecl *CD) const {
     if (BR->getSourceManager().isInSystemHeader(CD->getLocation()))
       return;
+
+    ObjCContainerDecl::PropertyMap map;
+    CD->collectPropertiesToImplement(map);
+    for (auto it : map)
+      visitObjCPropertyDecl(CD, it.second);
+
     if (auto *ID = dyn_cast<ObjCInterfaceDecl>(CD)) {
       for (auto *Ivar : ID->ivars())
         visitIvarDecl(CD, Ivar);
@@ -142,6 +148,28 @@ public:
         auto *Desugared = PointeeType->getUnqualifiedDesugaredType();
         if (auto *ObjCType = dyn_cast_or_null<ObjCInterfaceType>(Desugared))
           reportBug(Ivar, IvarType, ObjCType->getDecl(), CD);
+      }
+    }
+  }
+
+  void visitObjCPropertyDecl(const ObjCContainerDecl *CD,
+                             const ObjCPropertyDecl *PD) const {
+    auto QT = PD->getType();
+    const Type *PropType = QT.getTypePtrOrNull();
+    if (!PropType)
+      return;
+    if (auto *PropCXXRD = PropType->getPointeeCXXRecordDecl()) {
+      std::optional<bool> IsCompatible = isPtrCompatible(QT, PropCXXRD);
+      fprintf(stderr, "IsCompatible=%d\n", IsCompatible ? *IsCompatible : -1);
+      if (IsCompatible && *IsCompatible)
+        reportBug(PD, PropType, PropCXXRD, CD);
+    } else {
+      std::optional<bool> IsCompatible = isPtrCompatible(QT, nullptr);
+      auto *PointeeType = PropType->getPointeeType().getTypePtrOrNull();
+      if (IsCompatible && *IsCompatible) {
+        auto *Desugared = PointeeType->getUnqualifiedDesugaredType();
+        if (auto *ObjCType = dyn_cast_or_null<ObjCInterfaceType>(Desugared))
+          reportBug(PD, PropType, ObjCType->getDecl(), CD);
       }
     }
   }
@@ -191,9 +219,12 @@ public:
     SmallString<100> Buf;
     llvm::raw_svector_ostream Os(Buf);
 
-    if (isa<ObjCContainerDecl>(ClassCXXRD))
-      Os << "Instance variable ";
-    else
+    if (isa<ObjCContainerDecl>(ClassCXXRD)) {
+      if (isa<ObjCPropertyDecl>(Member))
+        Os << "Property ";
+      else
+        Os << "Instance variable ";
+    } else
       Os << "Member variable ";
     printQuotedName(Os, Member);
     Os << " in ";

--- a/clang/test/Analysis/Checkers/WebKit/mock-system-header.h
+++ b/clang/test/Analysis/Checkers/WebKit/mock-system-header.h
@@ -34,7 +34,7 @@ typedef const struct __attribute__((objc_bridge(NSString))) __CFString * CFStrin
 
 #ifdef __OBJC__
 @class NSString;
-@interface SystemObject : NSObject {
+@interface SystemObject {
   NSString *ns_string;
   CFStringRef cf_string;
 }

--- a/clang/test/Analysis/Checkers/WebKit/mock-system-header.h
+++ b/clang/test/Analysis/Checkers/WebKit/mock-system-header.h
@@ -29,3 +29,14 @@ enum os_log_type_t : uint8_t {
 typedef struct os_log_s *os_log_t;
 os_log_t os_log_create(const char *subsystem, const char *category);
 void os_log_msg(os_log_t oslog, os_log_type_t type, const char *msg, ...);
+
+typedef const struct __attribute__((objc_bridge(NSString))) __CFString * CFStringRef;
+
+#ifdef __OBJC__
+@class NSString;
+@interface SystemObject : NSObject {
+  NSString *ns_string;
+  CFStringRef cf_string;
+}
+@end
+#endif

--- a/clang/test/Analysis/Checkers/WebKit/unretained-members.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-members.mm
@@ -66,4 +66,6 @@ namespace ignore_unions {
   CFStringRef cf_string;
   // expected-warning@-1{{Instance variable 'cf_string' in 'AnotherObject' is a retainable type 'CFStringRef'; member variables must be a RetainPtr}}
 }
+@property(nonatomic, strong) NSString *prop_string;
+// expected-warning@-1{{Property 'prop_string' in 'AnotherObject' is a raw pointer to retainable type 'NSString'; member variables must be a RetainPtr}}
 @end

--- a/clang/test/Analysis/Checkers/WebKit/unretained-members.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-members.mm
@@ -1,7 +1,8 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.NoUnretainedMemberChecker -verify %s
 
 #include "objc-mock-types.h"
-
+#include "mock-system-header.h"
+#if 0
 namespace members {
 
   struct Foo {
@@ -58,3 +59,12 @@ namespace ignore_unions {
 
   void forceTmplToInstantiate(RefPtr<SomeObj>) {}
 }
+#endif
+
+@interface AnotherObject : NSObject {
+  NSString *ns_string;
+  // expected-warning@-1{{Instance variable 'ns_string' in 'AnotherObject' is a raw pointer to retainable type 'NSString'; member variables must be a RetainPtr}}
+  CFStringRef cf_string;
+  // expected-warning@-1{{Instance variable 'cf_string' in 'AnotherObject' is a retainable type 'CFStringRef'; member variables must be a RetainPtr}}
+}
+@end

--- a/clang/test/Analysis/Checkers/WebKit/unretained-members.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-members.mm
@@ -2,7 +2,7 @@
 
 #include "objc-mock-types.h"
 #include "mock-system-header.h"
-#if 0
+
 namespace members {
 
   struct Foo {
@@ -59,7 +59,6 @@ namespace ignore_unions {
 
   void forceTmplToInstantiate(RefPtr<SomeObj>) {}
 }
-#endif
 
 @interface AnotherObject : NSObject {
   NSString *ns_string;


### PR DESCRIPTION
This PR fixes the bug that we weren't generating warnings when a raw poiner is used to point to a NS type in Objective-C ivars. Also fix the bug that we weren't suppressing this warning in system headers.