### PR TITLE
[MLIR][LLVM] Add weak_odr to allowed linkage for alias

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -2595,6 +2595,7 @@ LogicalResult AliasOp::verify() {
   case Linkage::Internal:
   case Linkage::Private:
   case Linkage::Weak:
+  case Linkage::WeakODR:
   case Linkage::Linkonce:
   case Linkage::LinkonceODR:
   case Linkage::AvailableExternally:

--- a/mlir/test/Dialect/LLVMIR/alias.mlir
+++ b/mlir/test/Dialect/LLVMIR/alias.mlir
@@ -26,23 +26,23 @@ llvm.mlir.alias external @_ZTV1D : !llvm.struct<(array<3 x ptr>)> {
 
 // -----
 
-llvm.mlir.global external @zed(42 : i32) : i32
+llvm.mlir.global weak_odr @zed(42 : i32) : i32
 
-llvm.mlir.alias external @foo : i32 {
+llvm.mlir.alias weak_odr @foo : i32 {
   %0 = llvm.mlir.addressof @zed : !llvm.ptr
   llvm.return %0 : !llvm.ptr
 }
 
-llvm.mlir.alias external @foo2 : i16 {
+llvm.mlir.alias weak_odr @foo2 : i16 {
   %0 = llvm.mlir.addressof @zed : !llvm.ptr
   llvm.return %0 : !llvm.ptr
 }
 
-// CHECK: llvm.mlir.alias external @foo : i32 {
+// CHECK: llvm.mlir.alias weak_odr @foo : i32 {
 // CHECK:   %[[ADDR:.*]] = llvm.mlir.addressof @zed : !llvm.ptr
 // CHECK:   llvm.return %[[ADDR]] : !llvm.ptr
 // CHECK: }
-// CHECK: llvm.mlir.alias external @foo2 : i16 {
+// CHECK: llvm.mlir.alias weak_odr @foo2 : i16 {
 // CHECK:   %[[ADDR:.*]] = llvm.mlir.addressof @zed : !llvm.ptr
 // CHECK:   llvm.return %[[ADDR]] : !llvm.ptr
 // CHECK: }

--- a/mlir/test/Target/LLVMIR/Import/alias.ll
+++ b/mlir/test/Target/LLVMIR/Import/alias.ll
@@ -62,6 +62,13 @@ entry:
 
 ; // -----
 
+@glob.private2 = private constant [32 x i32] zeroinitializer
+@glob2 = weak_odr hidden alias [32 x i32], inttoptr (i64 add (i64 ptrtoint (ptr @glob.private2 to i64), i64 1234) to ptr)
+
+; CHECK: llvm.mlir.alias weak_odr hidden @glob2 {dso_local} : !llvm.array<32 x i32> {
+
+; // -----
+
 @g1 = private global i32 0
 @g2 = internal constant ptr @a1
 @g3 = internal constant ptr @a2


### PR DESCRIPTION
I missed this when originally introduced the feature (note the verifier message already contains it), this fixes a small bug.