### PR TITLE
[Clang][AMDGPU] Use size_t to compare with npos

### DIFF
--- a/clang/tools/amdgpu-arch/AMDGPUArchByHIP.cpp
+++ b/clang/tools/amdgpu-arch/AMDGPUArchByHIP.cpp
@@ -98,7 +98,7 @@ static std::vector<std::string> getSearchPaths() {
 // Custom comparison function for dll name
 static bool compareVersions(StringRef A, StringRef B) {
   auto ParseVersion = [](StringRef S) -> VersionTuple {
-    unsigned Pos = S.find_last_of('_');
+    size_t Pos = S.find_last_of('_');
     StringRef VerStr = (Pos == StringRef::npos) ? S : S.substr(Pos + 1);
     VersionTuple Vt;
     (void)Vt.tryParse(VerStr);


### PR DESCRIPTION
Fix error

llvm\clang\tools\amdgpu-arch\AMDGPUArchByHIP.cpp(102,29): error: result of comparison of constant 18446744073709551615 with expression of type 'unsigned int' is always false [-Werror,-Wtautological-constant-out-of-range-compare]
102 |     StringRef VerStr = (Pos == StringRef::npos) ? S : S.substr(Pos + 1);
