### PR TITLE
[MLIR][LLVM] Fix debug value/declare import in face of landing pads

### DIFF
--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -2512,7 +2512,22 @@ ModuleImport::processDebugIntrinsic(llvm::DbgVariableIntrinsic *dbgIntr,
     Block *dominatedBlock = (*dominatedBlocks.begin())->getBlock();
     builder.setInsertionPoint(dominatedBlock->getTerminator());
   } else {
-    builder.setInsertionPointAfterValue(*argOperand);
+    Value insertPt = *argOperand;
+    if (!op) {
+      // The value might be coming from a phi value and is now a block argument,
+      // which means the insertion point is set to the start of the block. If
+      // this block is a target destination of an invoke, the insertion point
+      // must happen after the landing pad operation.
+      auto blockArg = llvm::cast<BlockArgument>(*argOperand);
+      mlir::Block *insertionBlock = blockArg.getOwner();
+      if (!insertionBlock->empty() &&
+          isa<LandingpadOp>(insertionBlock->front())) {
+        auto landingPad = cast<LandingpadOp>(insertionBlock->front());
+        insertPt = landingPad.getRes();
+      }
+    }
+
+    builder.setInsertionPointAfterValue(insertPt);
   }
   auto locationExprAttr =
       debugImporter->translateExpression(dbgIntr->getExpression());


### PR DESCRIPTION
Debug value/declare operations imported before landing pad operations at the bb start break invoke op verification:

```
error: first operation in unwind destination should be a llvm.landingpad operation
```

This this issue by making the placement slightly more smart.