### PR TITLE
[Analysis] Use *Set::insert_range (NFC)

### DIFF
--- a/llvm/lib/Analysis/CGSCCPassManager.cpp
+++ b/llvm/lib/Analysis/CGSCCPassManager.cpp
@@ -1071,8 +1071,7 @@ static LazyCallGraph::SCC &updateCGAndAnalysisManagerForPass(
 
   // We added a ref edge earlier for new call edges, promote those to call edges
   // alongside PromotedRefTargets.
-  for (Node *E : NewCallEdges)
-    PromotedRefTargets.insert(E);
+  PromotedRefTargets.insert_range(NewCallEdges);
 
   // Now promote ref edges into call edges.
   for (Node *CallTarget : PromotedRefTargets) {

--- a/llvm/lib/Analysis/FunctionPropertiesAnalysis.cpp
+++ b/llvm/lib/Analysis/FunctionPropertiesAnalysis.cpp
@@ -365,8 +365,7 @@ FunctionPropertiesUpdater::FunctionPropertiesUpdater(
   // finish().
   Successors.erase(&CallSiteBB);
 
-  for (const auto *BB : Successors)
-    LikelyToChangeBBs.insert(BB);
+  LikelyToChangeBBs.insert_range(Successors);
 
   // Commit the change. While some of the BBs accounted for above may play dual
   // role - e.g. caller's entry BB may be the same as the callsite BB - set

--- a/llvm/lib/Analysis/InlineCost.cpp
+++ b/llvm/lib/Analysis/InlineCost.cpp
@@ -2870,8 +2870,7 @@ InlineResult CallAnalyzer::analyze() {
 
     // If we're unable to select a particular successor, just count all of
     // them.
-    for (BasicBlock *Succ : successors(BB))
-      BBWorklist.insert(Succ);
+    BBWorklist.insert_range(successors(BB));
 
     onBlockAnalyzed(BB);
   }

--- a/llvm/lib/Analysis/MemorySSAUpdater.cpp
+++ b/llvm/lib/Analysis/MemorySSAUpdater.cpp
@@ -670,9 +670,8 @@ void MemorySSAUpdater::updateForClonedLoop(const LoopBlocksRPO &LoopBlocks,
                                            ArrayRef<BasicBlock *> ExitBlocks,
                                            const ValueToValueMapTy &VMap,
                                            bool IgnoreIncomingWithNoClones) {
-  SmallSetVector<BasicBlock *, 16> Blocks;
-  for (BasicBlock *BB : concat<BasicBlock *const>(LoopBlocks, ExitBlocks))
-    Blocks.insert(BB);
+  SmallSetVector<BasicBlock *, 16> Blocks(
+      llvm::from_range, concat<BasicBlock *const>(LoopBlocks, ExitBlocks));
 
   auto IsInClonedRegion = [&](BasicBlock *BB) { return Blocks.contains(BB); };
 

--- a/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
+++ b/llvm/lib/Analysis/ModuleSummaryAnalysis.cpp
@@ -637,12 +637,10 @@ static void computeFunctionSummary(
     // All new reference edges inserted in two loops below are either
     // read or write only. They will be grouped in the end of RefEdges
     // vector, so we can use a single integer value to identify them.
-    for (const auto &VI : LoadRefEdges)
-      RefEdges.insert(VI);
+    RefEdges.insert_range(LoadRefEdges);
 
     unsigned FirstWORef = RefEdges.size();
-    for (const auto &VI : StoreRefEdges)
-      RefEdges.insert(VI);
+    RefEdges.insert_range(StoreRefEdges);
 
     Refs = RefEdges.takeVector();
     for (; RefCnt < FirstWORef; ++RefCnt)

--- a/llvm/lib/Analysis/StackSafetyAnalysis.cpp
+++ b/llvm/lib/Analysis/StackSafetyAnalysis.cpp
@@ -672,8 +672,7 @@ void StackSafetyDataFlowAnalysis<CalleeTy>::updateOneNode(
                       << (UpdateToFullSet ? ", full-set" : "") << "] " << &FS
                       << "\n");
     // Callers of this function may need updating.
-    for (auto &CallerID : Callers[Callee])
-      WorkList.insert(CallerID);
+    WorkList.insert_range(Callers[Callee]);
 
     ++FS.UpdateCount;
   }

--- a/llvm/lib/Analysis/SyntheticCountsUtils.cpp
+++ b/llvm/lib/Analysis/SyntheticCountsUtils.cpp
@@ -23,11 +23,8 @@ template <typename CallGraphType>
 void SyntheticCountsUtils<CallGraphType>::propagateFromSCC(
     const SccTy &SCC, GetProfCountTy GetProfCount, AddCountTy AddCount) {
 
-  DenseSet<NodeRef> SCCNodes;
+  DenseSet<NodeRef> SCCNodes(llvm::from_range, SCC);
   SmallVector<std::pair<NodeRef, EdgeRef>, 8> SCCEdges, NonSCCEdges;
-
-  for (auto &Node : SCC)
-    SCCNodes.insert(Node);
 
   // Partition the edges coming out of the SCC into those whose destination is
   // in the SCC and the rest.


### PR DESCRIPTION
We can use *Set::insert_range to collapse:

  for (auto Elem : Range)
    Set.insert(E);

down to:

  Set.insert_range(Range);

In some cases, we can further fold that into the set declaration.
