### PR TITLE
[RISCV] Make RequiredExtensions for intrinsics scalable to more than 32 extensions. NFC

### DIFF
--- a/clang/include/clang/Support/RISCVVIntrinsicUtils.h
+++ b/clang/include/clang/Support/RISCVVIntrinsicUtils.h
@@ -483,7 +483,7 @@ public:
 
 // RVVRequire should be sync'ed with target features, but only
 // required features used in riscv_vector.td.
-enum RVVRequire : uint32_t {
+enum RVVRequire {
   RVV_REQ_RV64,
   RVV_REQ_Zvfhmin,
   RVV_REQ_Xsfvcp,

--- a/clang/include/clang/Support/RISCVVIntrinsicUtils.h
+++ b/clang/include/clang/Support/RISCVVIntrinsicUtils.h
@@ -484,29 +484,27 @@ public:
 // RVVRequire should be sync'ed with target features, but only
 // required features used in riscv_vector.td.
 enum RVVRequire : uint32_t {
-  RVV_REQ_None = 0,
-  RVV_REQ_RV64 = 1 << 0,
-  RVV_REQ_Zvfhmin = 1 << 1,
-  RVV_REQ_Xsfvcp = 1 << 2,
-  RVV_REQ_Xsfvfnrclipxfqf = 1 << 3,
-  RVV_REQ_Xsfvfwmaccqqq = 1 << 4,
-  RVV_REQ_Xsfvqmaccdod = 1 << 5,
-  RVV_REQ_Xsfvqmaccqoq = 1 << 6,
-  RVV_REQ_Zvbb = 1 << 7,
-  RVV_REQ_Zvbc = 1 << 8,
-  RVV_REQ_Zvkb = 1 << 9,
-  RVV_REQ_Zvkg = 1 << 10,
-  RVV_REQ_Zvkned = 1 << 11,
-  RVV_REQ_Zvknha = 1 << 12,
-  RVV_REQ_Zvknhb = 1 << 13,
-  RVV_REQ_Zvksed = 1 << 14,
-  RVV_REQ_Zvksh = 1 << 15,
-  RVV_REQ_Zvfbfwma = 1 << 16,
-  RVV_REQ_Zvfbfmin = 1 << 17,
-  RVV_REQ_Zvfh = 1 << 18,
-  RVV_REQ_Experimental = 1 << 19,
-
-  LLVM_MARK_AS_BITMASK_ENUM(RVV_REQ_Experimental)
+  RVV_REQ_RV64,
+  RVV_REQ_Zvfhmin,
+  RVV_REQ_Xsfvcp,
+  RVV_REQ_Xsfvfnrclipxfqf,
+  RVV_REQ_Xsfvfwmaccqqq,
+  RVV_REQ_Xsfvqmaccdod,
+  RVV_REQ_Xsfvqmaccqoq,
+  RVV_REQ_Zvbb,
+  RVV_REQ_Zvbc,
+  RVV_REQ_Zvkb,
+  RVV_REQ_Zvkg,
+  RVV_REQ_Zvkned,
+  RVV_REQ_Zvknha,
+  RVV_REQ_Zvknhb,
+  RVV_REQ_Zvksed,
+  RVV_REQ_Zvksh,
+  RVV_REQ_Zvfbfwma,
+  RVV_REQ_Zvfbfmin,
+  RVV_REQ_Zvfh,
+  RVV_REQ_Experimental,
+  RVV_REQ_NUM,
 };
 
 // Raw RVV intrinsic info, used to expand later.
@@ -518,6 +516,9 @@ struct RVVIntrinsicRecord {
   // Overloaded intrinsic name, could be empty if it can be computed from Name.
   // e.g. vadd
   const char *OverloadedName;
+
+  // Required target features for this intrinsic.
+  uint32_t RequiredExtensions[(RVV_REQ_NUM + 31) / 32];
 
   // Prototype for this intrinsic, index of RVVSignatureTable.
   uint16_t PrototypeIndex;
@@ -536,9 +537,6 @@ struct RVVIntrinsicRecord {
 
   // Length of overloaded intrinsic suffix.
   uint8_t OverloadedSuffixSize;
-
-  // Required target features for this intrinsic.
-  uint32_t RequiredExtensions;
 
   // Supported type, mask of BasicType.
   uint8_t TypeRangeMask;

--- a/clang/lib/Sema/SemaRISCV.cpp
+++ b/clang/lib/Sema/SemaRISCV.cpp
@@ -206,7 +206,7 @@ public:
 void RISCVIntrinsicManagerImpl::ConstructRVVIntrinsics(
     ArrayRef<RVVIntrinsicRecord> Recs, IntrinsicKind K) {
   const TargetInfo &TI = Context.getTargetInfo();
-  static const std::pair<const char *, RVVRequire> FeatureCheckList[] = {
+  static const std::pair<const char *, unsigned> FeatureCheckList[] = {
       {"64bit", RVV_REQ_RV64},
       {"xsfvcp", RVV_REQ_Xsfvcp},
       {"xsfvfnrclipxfqf", RVV_REQ_Xsfvfnrclipxfqf},
@@ -232,7 +232,8 @@ void RISCVIntrinsicManagerImpl::ConstructRVVIntrinsics(
   for (auto &Record : Recs) {
     // Check requirements.
     if (llvm::any_of(FeatureCheckList, [&](const auto &Item) {
-          return (Record.RequiredExtensions & Item.second) == Item.second &&
+          return ((Record.RequiredExtensions[Item.second / 32] &
+                   (1U << (Item.second % 32))) != 0) &&
                  !TI.hasFeature(Item.first);
         }))
       continue;

--- a/clang/lib/Support/RISCVVIntrinsicUtils.cpp
+++ b/clang/lib/Support/RISCVVIntrinsicUtils.cpp
@@ -1204,13 +1204,16 @@ raw_ostream &operator<<(raw_ostream &OS, const RVVIntrinsicRecord &Record) {
     OS << "nullptr,";
   else
     OS << "\"" << Record.OverloadedName << "\",";
+  OS << "{";
+  for (uint32_t Exts : Record.RequiredExtensions)
+    OS << Exts << ',';
+  OS << "},";
   OS << Record.PrototypeIndex << ",";
   OS << Record.SuffixIndex << ",";
   OS << Record.OverloadedSuffixIndex << ",";
   OS << (int)Record.PrototypeLength << ",";
   OS << (int)Record.SuffixLength << ",";
   OS << (int)Record.OverloadedSuffixSize << ",";
-  OS << Record.RequiredExtensions << ",";
   OS << (int)Record.TypeRangeMask << ",";
   OS << (int)Record.Log2LMULMask << ",";
   OS << (int)Record.NF << ",";

--- a/clang/utils/TableGen/RISCVVEmitter.cpp
+++ b/clang/utils/TableGen/RISCVVEmitter.cpp
@@ -45,7 +45,7 @@ struct SemaRecord {
   unsigned Log2LMULMask;
 
   // Required extensions for this intrinsic.
-  uint32_t RequiredExtensions;
+  uint32_t RequiredExtensions[(RVV_REQ_Experimental + 31) / 32];
 
   // Prototype for this intrinsic.
   SmallVector<PrototypeDescriptor> Prototype;
@@ -769,9 +769,9 @@ void RVVEmitter::createRVVIntrinsics(
 
     SR.Log2LMULMask = Log2LMULMask;
 
-    SR.RequiredExtensions = 0;
+    memset(SR.RequiredExtensions, 0, sizeof(SR.RequiredExtensions));
     for (auto RequiredFeature : RequiredFeatures) {
-      RVVRequire RequireExt =
+      unsigned RequireExt =
           StringSwitch<RVVRequire>(RequiredFeature)
               .Case("RV64", RVV_REQ_RV64)
               .Case("Zvfhmin", RVV_REQ_Zvfhmin)
@@ -792,10 +792,8 @@ void RVVEmitter::createRVVIntrinsics(
               .Case("Zvfbfwma", RVV_REQ_Zvfbfwma)
               .Case("Zvfbfmin", RVV_REQ_Zvfbfmin)
               .Case("Zvfh", RVV_REQ_Zvfh)
-              .Case("Experimental", RVV_REQ_Experimental)
-              .Default(RVV_REQ_None);
-      assert(RequireExt != RVV_REQ_None && "Unrecognized required feature?");
-      SR.RequiredExtensions |= RequireExt;
+              .Case("Experimental", RVV_REQ_Experimental);
+      SR.RequiredExtensions[RequireExt / 32] |= 1U << (RequireExt % 32);
     }
 
     SR.NF = NF;
@@ -839,7 +837,8 @@ void RVVEmitter::createRVVIntrinsicRecords(std::vector<RVVIntrinsicRecord> &Out,
     R.PrototypeLength = SR.Prototype.size();
     R.SuffixLength = SR.Suffix.size();
     R.OverloadedSuffixSize = SR.OverloadedSuffix.size();
-    R.RequiredExtensions = SR.RequiredExtensions;
+    memcpy(R.RequiredExtensions, SR.RequiredExtensions,
+           sizeof(R.RequiredExtensions));
     R.TypeRangeMask = SR.TypeRangeMask;
     R.Log2LMULMask = SR.Log2LMULMask;
     R.NF = SR.NF;

--- a/clang/utils/TableGen/RISCVVEmitter.cpp
+++ b/clang/utils/TableGen/RISCVVEmitter.cpp
@@ -45,7 +45,7 @@ struct SemaRecord {
   unsigned Log2LMULMask;
 
   // Required extensions for this intrinsic.
-  uint32_t RequiredExtensions[(RVV_REQ_Experimental + 31) / 32];
+  uint32_t RequiredExtensions[(RVV_REQ_NUM + 31) / 32];
 
   // Prototype for this intrinsic.
   SmallVector<PrototypeDescriptor> Prototype;


### PR DESCRIPTION
We have more than 32 extensions in our downstream and had to change this type from uint32_t to uint64_t.

To simplify our downstream and make the code more flexible, I propose to make it an array of uint32_t that we can size based on the number of extensions. I really wanted to use std::bitset, but we have to print the bits to a .inc file which can't easily be done with std::bitset.