### PR TITLE
[LoongArch][MC] Add support for disassembly option "no-aliases"

### DIFF
--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchInstPrinter.cpp
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchInstPrinter.cpp
@@ -26,6 +26,11 @@ using namespace llvm;
 #include "LoongArchGenAsmWriter.inc"
 
 static cl::opt<bool>
+    NoAliases("loongarch-no-aliases",
+              cl::desc("Disable the emission of assembler pseudo instructions"),
+              cl::init(false), cl::Hidden);
+
+static cl::opt<bool>
     NumericReg("loongarch-numeric-reg",
                cl::desc("Print numeric register names rather than the ABI "
                         "names (such as $r0 instead of $zero)"),
@@ -37,6 +42,11 @@ static cl::opt<bool>
 // be an easier way to allow these options in all these tools, without doing it
 // this way.
 bool LoongArchInstPrinter::applyTargetSpecificCLOption(StringRef Opt) {
+  if (Opt == "no-aliases") {
+    PrintAliases = false;
+    return true;
+  }
+
   if (Opt == "numeric") {
     NumericReg = true;
     return true;
@@ -49,7 +59,7 @@ void LoongArchInstPrinter::printInst(const MCInst *MI, uint64_t Address,
                                      StringRef Annot,
                                      const MCSubtargetInfo &STI,
                                      raw_ostream &O) {
-  if (!printAliasInstr(MI, Address, STI, O))
+  if (!PrintAliases || NoAliases || !printAliasInstr(MI, Address, STI, O))
     printInstruction(MI, Address, STI, O);
   printAnnotation(O, Annot);
 }

--- a/llvm/test/MC/LoongArch/Misc/no-aliases.s
+++ b/llvm/test/MC/LoongArch/Misc/no-aliases.s
@@ -1,0 +1,24 @@
+# RUN: llvm-mc --triple=loongarch32 --loongarch-no-aliases %s \
+# RUN:     | FileCheck %s
+# RUN: llvm-mc --triple=loongarch32 -M no-aliases %s \
+# RUN:     | FileCheck %s
+# RUN: llvm-mc --triple=loongarch32 --filetype=obj %s -o %t.32
+# RUN: llvm-objdump -d -M no-aliases %t.32 | FileCheck %s
+
+# RUN: llvm-mc --triple=loongarch64 --loongarch-no-aliases %s \
+# RUN:     | FileCheck %s
+# RUN: llvm-mc --triple=loongarch64 -M no-aliases %s \
+# RUN:     | FileCheck %s
+# RUN: llvm-mc --triple=loongarch64 --filetype=obj %s -o %t.64
+# RUN: llvm-objdump -d -M no-aliases %t.64 | FileCheck %s
+
+# Also test passing multiple disassembly options at once.
+# RUN: llvm-objdump -d -M no-aliases,numeric %t.64 | FileCheck --check-prefix=CHECK-NUMERIC %s
+
+foo:
+    # CHECK:              or $a0, $r21, $zero
+    # CHECK-NEXT:         jirl $zero, $ra, 0
+    # CHECK-NUMERIC:      or $r4, $r21, $r0
+    # CHECK-NUMERIC-NEXT: jirl $r0, $r1, 0
+    move $a0, $r21
+    ret


### PR DESCRIPTION
This parallels the GNU Binutils feature's usage. A hidden command-line option `--loongarch-no-aliases` is also added, similar to how `--loongarch-numeric-reg` is for the `numeric` option.