### PR TITLE
[SystemZ] Implement basic `isCopyInstrImpl`

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZInstrFP.td
+++ b/llvm/lib/Target/SystemZ/SystemZInstrFP.td
@@ -42,13 +42,15 @@ let isAsCheapAsAMove = 1, isMoveImm = 1 in {
 }
 
 // Moves between two floating-point registers.
-def LER : UnaryRR <"ler", 0x38,   null_frag, FP32,  FP32>;
-def LDR : UnaryRR <"ldr", 0x28,   null_frag, FP64,  FP64>;
-def LXR : UnaryRRE<"lxr", 0xB365, null_frag, FP128, FP128>;
+let isMoveReg = 1 in  {
+  def LER : UnaryRR <"ler", 0x38,   null_frag, FP32,  FP32>;
+  def LDR : UnaryRR <"ldr", 0x28,   null_frag, FP64,  FP64>;
+  def LXR : UnaryRRE<"lxr", 0xB365, null_frag, FP128, FP128>;
+  // For z13 we prefer LDR over LER to avoid partial register dependencies.
+  let isCodeGenOnly = 1 in
+    def LDR32 : UnaryRR<"ldr", 0x28, null_frag, FP32, FP32>;
+}
 
-// For z13 we prefer LDR over LER to avoid partial register dependencies.
-let isCodeGenOnly = 1 in
-  def LDR32 : UnaryRR<"ldr", 0x28, null_frag, FP32, FP32>;
 
 // Moves between two floating-point registers that also set the condition
 // codes. Note that these instructions will turn SNaNs into QNaNs and should

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
@@ -2316,3 +2316,12 @@ bool SystemZInstrInfo::getConstValDefinedInReg(const MachineInstr &MI,
 
   return false;
 }
+
+std::optional<DestSourcePair>
+SystemZInstrInfo::isCopyInstrImpl(const MachineInstr &MI) const {
+  // if MI is a simple single-register copy operation, return operand pair
+  if (MI.isMoveReg())
+    return DestSourcePair(MI.getOperand(0), MI.getOperand(1));
+
+  return std::nullopt;
+}

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.h
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.h
@@ -386,6 +386,9 @@ public:
 
   bool getConstValDefinedInReg(const MachineInstr &MI, const Register Reg,
                                int64_t &ImmVal) const override;
+
+  std::optional<DestSourcePair>
+  isCopyInstrImpl(const MachineInstr &MI) const override;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.td
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.td
@@ -424,8 +424,10 @@ defm CondStore64 : CondStores<GR64, simple_store,
 //===----------------------------------------------------------------------===//
 
 // Register moves.
-def LR  : UnaryRR <"lr",  0x18,   null_frag, GR32, GR32>;
-def LGR : UnaryRRE<"lgr", 0xB904, null_frag, GR64, GR64>;
+let isMoveReg = 1 in {
+  def LR  : UnaryRR <"lr",  0x18,   null_frag, GR32, GR32>;
+  def LGR : UnaryRRE<"lgr", 0xB904, null_frag, GR64, GR64>;
+}
 
 let Defs = [CC], CCValues = 0xE, CompareZeroCCMask = 0xE in {
   def LTR  : UnaryRR <"ltr",  0x12,   null_frag, GR32, GR32>;

--- a/llvm/lib/Target/SystemZ/SystemZInstrVector.td
+++ b/llvm/lib/Target/SystemZ/SystemZInstrVector.td
@@ -12,9 +12,11 @@
 
 let Predicates = [FeatureVector] in {
   // Register move.
-  def VLR : UnaryVRRa<"vlr", 0xE756, null_frag, v128any, v128any>;
-  def VLR32 : UnaryAliasVRR<null_frag, v32sb, v32sb>;
-  def VLR64 : UnaryAliasVRR<null_frag, v64db, v64db>;
+  let isMoveReg = 1 in {
+    def VLR : UnaryVRRa<"vlr", 0xE756, null_frag, v128any, v128any>;
+    def VLR32 : UnaryAliasVRR<null_frag, v32sb, v32sb>;
+    def VLR64 : UnaryAliasVRR<null_frag, v64db, v64db>;
+  }
 
   // Load GR from VR element.
   def VLGV  : BinaryVRScGeneric<"vlgv", 0xE721>;


### PR DESCRIPTION
As a first step toward implementing SystemZ support for instr-ref-based debug info tracking, this commit adds a basic implementation for the previously absent `SystemZInstrInfo::isCopyInstrImpl`.

This is accomplished by adding a new flag called `isMoveReg` on the relevant instructions and calling upon that bit of information to implement the function. Which instructions to add the flag to was based on the implementation of `SystemZInstrInfo::copyPhysReg`. The full list of instructions is as follows:

#### General-Purpose Registers
- `lr`
- `lgr`
#### Floating Point Registers
- `ler`
- `ldr`
- `lxr`
#### Vector Registers
- `vlr`