### PR TITLE
[lldb][NFC] Break ThreadMemory into smaller abstractions

### DIFF
--- a/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.cpp
+++ b/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.cpp
@@ -259,8 +259,8 @@ ThreadSP OperatingSystemPython::CreateThreadFromThreadInfo(
   if (!thread_sp) {
     if (did_create_ptr)
       *did_create_ptr = true;
-    thread_sp = std::make_shared<ThreadMemory>(*m_process, tid, name, queue,
-                                               reg_data_addr);
+    thread_sp = std::make_shared<ThreadMemoryProvidingNameAndQueue>(
+        *m_process, tid, name, queue, reg_data_addr);
   }
 
   if (core_number < core_thread_list.GetSize(false)) {

--- a/lldb/source/Plugins/Process/Utility/ThreadMemory.cpp
+++ b/lldb/source/Plugins/Process/Utility/ThreadMemory.cpp
@@ -20,18 +20,17 @@
 using namespace lldb;
 using namespace lldb_private;
 
-ThreadMemory::ThreadMemory(Process &process, lldb::tid_t tid,
-                           const ValueObjectSP &thread_info_valobj_sp)
-    : Thread(process, tid), m_backing_thread_sp(),
-      m_thread_info_valobj_sp(thread_info_valobj_sp), m_name(), m_queue(),
-      m_register_data_addr(LLDB_INVALID_ADDRESS) {}
+ThreadMemoryProvidingNameAndQueue::ThreadMemoryProvidingNameAndQueue(
+    Process &process, lldb::tid_t tid,
+    const ValueObjectSP &thread_info_valobj_sp)
+    : ThreadMemoryProvidingName(process, tid, LLDB_INVALID_ADDRESS, ""),
+      m_thread_info_valobj_sp(thread_info_valobj_sp), m_queue() {}
 
-ThreadMemory::ThreadMemory(Process &process, lldb::tid_t tid,
-                           llvm::StringRef name, llvm::StringRef queue,
-                           lldb::addr_t register_data_addr)
-    : Thread(process, tid), m_backing_thread_sp(), m_thread_info_valobj_sp(),
-      m_name(std::string(name)), m_queue(std::string(queue)),
-      m_register_data_addr(register_data_addr) {}
+ThreadMemoryProvidingNameAndQueue::ThreadMemoryProvidingNameAndQueue(
+    Process &process, lldb::tid_t tid, llvm::StringRef name,
+    llvm::StringRef queue, lldb::addr_t register_data_addr)
+    : ThreadMemoryProvidingName(process, tid, register_data_addr, name),
+      m_thread_info_valobj_sp(), m_queue(std::string(queue)) {}
 
 ThreadMemory::~ThreadMemory() { DestroyThread(); }
 


### PR DESCRIPTION
ThreadMemory attempts to be a class abstracting the notion of a "fake" Thread that is backed by a "real" thread. According to its documentation, it is meant to be a class forwarding most methods to the backing thread, but it does so only for a handful of methods.

Along the way, it also tries to represent a Thread that may or may not have a different name, and may or may not have a different queue from the backing thread. This can be problematic for a couple of reasons:

1. It forces all users into this optional behavior.
2. The forwarding behavior is incomplete: not all methods are currently being forwarded properly. Some of them involve queues and seem to have been intentionally left unimplemented.

This commit creates the following separation:

ThreadMemory <- ThreadMemoryProvidingName <- ThreadMemoryProvidingNameAndQueue

ThreadMemory captures the notion of a backed thread that _really_ forwards all methods to the backing thread. (Missing methods should be implemented in a later commit, and allowing them to be implemented without changing behavior of other derived classes is the main purpose of this refactor).

ThreadMemoryProvidingNameAndQueue is a ThreadMemory that allows users to override the thread name. If a name is present, it is used; otherwise the forwarding behavior is used.

ThreadMemoryProvidingNameAndQueue is a ThreadMemoryProvidingName that allows users to override queue information. If queue information is present, it is used; otherwise, the forwarding behavior is used.

With this separation, we can more explicitly implement missing methods of the base class and override them, if needed, in ThreadMemoryProvidingNameAndQueue. But this commit really is NFC, no new methods are implemented and no method implementation is changed.