### PR TITLE
[MIPS] Define SubTargetFeature for i6500 cpu

### DIFF
--- a/clang/test/CodeGen/Mips/subtarget-feature-test.c
+++ b/clang/test/CodeGen/Mips/subtarget-feature-test.c
@@ -1,6 +1,5 @@
 // RUN: %clang --target=mips64-linux-gnu -mcpu=i6400 -o %t -c %s 2>&1 | FileCheck --allow-empty %s
 // CHECK-NOT: {{.*}} is not a recognized feature for this target
 
-
 // RUN: %clang --target=mips64-linux-gnu -mcpu=i6500 -o %t -c %s 2>&1 | FileCheck --allow-empty %s
 // CHECK-NOT: {{.*}} is not a recognized feature for this target

--- a/clang/test/CodeGen/Mips/subtarget-feature-test.c
+++ b/clang/test/CodeGen/Mips/subtarget-feature-test.c
@@ -1,0 +1,6 @@
+// RUN: %clang --target=mips64-linux-gnu -mcpu=i6400 -o %t -c %s 2>&1 | FileCheck --allow-empty %s
+// CHECK-NOT: {{.*}} is not a recognized feature for this target
+
+
+// RUN: %clang --target=mips64-linux-gnu -mcpu=i6500 -o %t -c %s 2>&1 | FileCheck --allow-empty %s
+// CHECK-NOT: {{.*}} is not a recognized feature for this target

--- a/llvm/lib/Target/Mips/Mips.td
+++ b/llvm/lib/Target/Mips/Mips.td
@@ -242,7 +242,11 @@ def ImplP5600 : SubtargetFeature<"p5600", "ProcImpl",
 // same CPU architecture.
 def ImplI6400
     : SubtargetFeature<"i6400", "ProcImpl", "MipsSubtarget::CPU::I6400",
-                       "MIPS I6400/I6500 Processors", [FeatureMips64r6]>;
+                       "MIPS I6400 Processor", [FeatureMips64r6]>;
+
+def ImplI6500
+    : SubtargetFeature<"i6500", "ProcImpl", "MipsSubtarget::CPU::I6500",
+                       "MIPS I6500 Processor", [FeatureMips64r6]>;
 
 class Proc<string Name, list<SubtargetFeature> Features>
  : ProcessorModel<Name, MipsGenericModel, Features>;
@@ -268,7 +272,7 @@ def : Proc<"octeon", [FeatureMips64r2, FeatureCnMips]>;
 def : Proc<"octeon+", [FeatureMips64r2, FeatureCnMips, FeatureCnMipsP]>;
 def : ProcessorModel<"p5600", MipsP5600Model, [ImplP5600]>;
 def : ProcessorModel<"i6400", NoSchedModel, [ImplI6400]>;
-def : ProcessorModel<"i6500", NoSchedModel, [ImplI6400]>;
+def : ProcessorModel<"i6500", NoSchedModel, [ImplI6500]>;
 
 def MipsAsmParser : AsmParser {
   let ShouldEmitMatchRegisterName = 0;

--- a/llvm/lib/Target/Mips/MipsSubtarget.h
+++ b/llvm/lib/Target/Mips/MipsSubtarget.h
@@ -43,7 +43,7 @@ class MipsSubtarget : public MipsGenSubtargetInfo {
     Mips3, Mips4, Mips5, Mips64, Mips64r2, Mips64r3, Mips64r5, Mips64r6
   };
 
-  enum class CPU { P5600, I6400 };
+  enum class CPU { P5600, I6400, I6500 };
 
   // Used to avoid printing dsp warnings multiple times.
   static bool DspWarningPrinted;


### PR DESCRIPTION
PR #130587 defined same SubTargetFeature for CPUs i6400 and i6500 which resulted into following warning when -mcpu=i6500 was used:

+i6500' is not a recognized feature for this target (ignoring feature)

This PR fixes above issue by defining separate SubTargetFeature for i6500.