### PR TITLE
[clang][bytecode] Fix base cast of nullptr without descriptor

### DIFF
--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -720,6 +720,10 @@ IntPointer IntPointer::atOffset(const ASTContext &ASTCtx,
 
 IntPointer IntPointer::baseCast(const ASTContext &ASTCtx,
                                 unsigned BaseOffset) const {
+  if (!Desc) {
+    assert(Value == 0);
+    return *this;
+  }
   const Record *R = Desc->ElemRecord;
   const Descriptor *BaseDesc = nullptr;
 

--- a/clang/test/AST/ByteCode/records.cpp
+++ b/clang/test/AST/ByteCode/records.cpp
@@ -1771,3 +1771,19 @@ namespace RedeclaredCtor {
   constexpr __sp_mut::__sp_mut(void *p) noexcept : __lx_(p) {}
   constexpr __sp_mut muts = &mut_back[0];
 }
+
+namespace IntegralBaseCast {
+  class A {};
+  class B : public A {};
+  struct S {
+    B *a;
+  };
+
+  constexpr int f() {
+    S s{};
+    A *a = s.a;
+    return 0;
+  }
+
+  static_assert(f() == 0, "");
+}


### PR DESCRIPTION
The missing descriptor should only happen if the pointer is null pointer.