### PR TITLE
[lldb][Instrumentation] GetPreferredAsanModule should be no-op on non-Darwin platforms

### DIFF
--- a/lldb/source/Plugins/InstrumentationRuntime/Utility/Utility.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/Utility/Utility.cpp
@@ -18,6 +18,10 @@ namespace lldb_private {
 ///< This helper searches the target for such a dylib. Returns nullptr if no
 ///< such dylib was found.
 lldb::ModuleSP GetPreferredAsanModule(const Target &target) {
+  // Currently only supported on Darwin.
+  if (!target.GetArchitecture().GetTriple().isOSDarwin())
+    return nullptr;
+
   lldb::ModuleSP module;
   llvm::Regex pattern(R"(libclang_rt\.asan_.*_dynamic\.dylib)");
   target.GetImages().ForEach([&](const lldb::ModuleSP &m) {


### PR DESCRIPTION
The regex we use to find the compiler-rt library is already Darwin-specific, so no need to run this on non-Darwin platforms.