### PR TITLE
[SystemZ] Add pass initialization for `CopyPhysRegs` pass

### DIFF
--- a/llvm/lib/Target/SystemZ/SystemZTargetMachine.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZTargetMachine.cpp
@@ -48,6 +48,7 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeSystemZTarget() {
   initializeSystemZPostRewritePass(PR);
   initializeSystemZTDCPassPass(PR);
   initializeSystemZDAGToDAGISelLegacyPass(PR);
+  initializeSystemZCopyPhysRegsPass(PR);
 }
 
 static std::string computeDataLayout(const Triple &TT) {


### PR DESCRIPTION
This commit adds an initialization to `SystemZTargetMachine` for the `SystemZCopyPhysRegs` pass that was thus far  missing. This will enable, e.g., to run tests for that pass via `llc --run-pass=systemz-copy-physregs`.