### PR TITLE
[IR] improve hashing quality for ValueInfo

### DIFF
--- a/llvm/include/llvm/IR/ModuleSummaryIndex.h
+++ b/llvm/include/llvm/IR/ModuleSummaryIndex.h
@@ -300,7 +300,7 @@ template <> struct DenseMapInfo<ValueInfo> {
     assert(isSpecialKey(L) || isSpecialKey(R) || (L.haveGVs() == R.haveGVs()));
     return L.getRef() == R.getRef();
   }
-  static unsigned getHashValue(ValueInfo I) { return (uintptr_t)I.getRef(); }
+  static unsigned getHashValue(ValueInfo I) { return hash_value(I.getRef()); }
 };
 
 // For optional hinted size reporting, holds a pair of the full stack id


### PR DESCRIPTION
The current hashing quality for `ValueInfo` is poor because it uses pointers as the hash value, which can negatively impact performance in various places that use a `DenseSet`/`Map` of `ValueInfo`. In one observed case, `ModuleSummaryIndex::propagateAttributes()` was taking about 25 minutes to complete on a ThinLTO application. Profiling revealed that the majority of this time was spent operating on the `MarkedNonReadWriteOnly` set.

With the improved hashing, the execution time for `propagateAttributes` is dramatically reduced to less than 10 seconds.