### PR TITLE
[lldb] Remove (deprecated) Function::GetAddressRange

### DIFF
--- a/lldb/include/lldb/Symbol/Function.h
+++ b/lldb/include/lldb/Symbol/Function.h
@@ -445,9 +445,6 @@ public:
 
   Function *CalculateSymbolContextFunction() override;
 
-  /// DEPRECATED: Use GetAddressRanges instead.
-  const AddressRange &GetAddressRange() { return m_range; }
-
   AddressRanges GetAddressRanges() { return m_block.GetRanges(); }
 
   /// Return the address of the function (its entry point). This address is also
@@ -657,11 +654,6 @@ protected:
 
   /// All lexical blocks contained in this function.
   Block m_block;
-
-  /// The function address range that covers the widest range needed to contain
-  /// all blocks. DEPRECATED: do not use this field in new code as the range may
-  /// include addresses belonging to other functions.
-  AddressRange m_range;
 
   /// The address (entry point) of the function.
   Address m_address;


### PR DESCRIPTION
All uses have been replaced by GetAddressRange*s* or GetAddress.

Also fix two internal uses of the range member.