### PR TITLE
Lint: Replace -lint-abort-on-error cl::opt with pass parameter

### DIFF
--- a/llvm/include/llvm/Analysis/Lint.h
+++ b/llvm/include/llvm/Analysis/Lint.h
@@ -29,14 +29,20 @@ class Function;
 ///
 /// This should only be used for debugging, because it plays games with
 /// PassManagers and stuff.
-void lintModule(const Module &M);
+void lintModule(const Module &M, bool AbortOnError = false);
 
 // Lint a function.
-void lintFunction(const Function &F);
+void lintFunction(const Function &F, bool AbortOnError = false);
 
 class LintPass : public PassInfoMixin<LintPass> {
+  const bool AbortOnError;
+
 public:
+  LintPass(bool AbortOnError) : AbortOnError(AbortOnError) {}
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+
+  void printPipeline(raw_ostream &OS,
+                     function_ref<StringRef(StringRef)> MapClassName2PassName);
 };
 
 } // namespace llvm

--- a/llvm/lib/Analysis/Lint.cpp
+++ b/llvm/lib/Analysis/Lint.cpp
@@ -750,8 +750,7 @@ PreservedAnalyses LintPass::run(Function &F, FunctionAnalysisManager &AM) {
 
 void LintPass::printPipeline(
     raw_ostream &OS, function_ref<StringRef(StringRef)> MapClassName2PassName) {
-  static_cast<PassInfoMixin<LintPass> *>(this)->printPipeline(
-      OS, MapClassName2PassName);
+  PassInfoMixin<LintPass>::printPipeline(OS, MapClassName2PassName);
   if (AbortOnError)
     OS << "<abort-on-error>";
 }

--- a/llvm/lib/Analysis/Lint.cpp
+++ b/llvm/lib/Analysis/Lint.cpp
@@ -78,11 +78,6 @@
 
 using namespace llvm;
 
-static const char LintAbortOnErrorArgName[] = "lint-abort-on-error";
-static cl::opt<bool>
-    LintAbortOnError(LintAbortOnErrorArgName, cl::init(false),
-                     cl::desc("In the Lint pass, abort on errors."));
-
 namespace {
 namespace MemRef {
 static const unsigned Read = 1;
@@ -747,11 +742,18 @@ PreservedAnalyses LintPass::run(Function &F, FunctionAnalysisManager &AM) {
   Lint L(Mod, DL, AA, AC, DT, TLI);
   L.visit(F);
   dbgs() << L.MessagesStr.str();
-  if (LintAbortOnError && !L.MessagesStr.str().empty())
-    report_fatal_error(Twine("Linter found errors, aborting. (enabled by --") +
-                           LintAbortOnErrorArgName + ")",
-                       false);
+  if (AbortOnError && !L.MessagesStr.str().empty())
+    report_fatal_error(
+        "linter found errors, aborting. (enabled by abort-on-error)", false);
   return PreservedAnalyses::all();
+}
+
+void LintPass::printPipeline(
+    raw_ostream &OS, function_ref<StringRef(StringRef)> MapClassName2PassName) {
+  static_cast<PassInfoMixin<LintPass> *>(this)->printPipeline(
+      OS, MapClassName2PassName);
+  if (AbortOnError)
+    OS << "<abort-on-error>";
 }
 
 //===----------------------------------------------------------------------===//
@@ -760,7 +762,7 @@ PreservedAnalyses LintPass::run(Function &F, FunctionAnalysisManager &AM) {
 
 /// lintFunction - Check a function for errors, printing messages on stderr.
 ///
-void llvm::lintFunction(const Function &f) {
+void llvm::lintFunction(const Function &f, bool AbortOnError) {
   Function &F = const_cast<Function &>(f);
   assert(!F.isDeclaration() && "Cannot lint external functions");
 
@@ -775,14 +777,14 @@ void llvm::lintFunction(const Function &f) {
     AA.registerFunctionAnalysis<TypeBasedAA>();
     return AA;
   });
-  LintPass().run(F, FAM);
+  LintPass(AbortOnError).run(F, FAM);
 }
 
 /// lintModule - Check a module for errors, printing messages on stderr.
 ///
-void llvm::lintModule(const Module &M) {
+void llvm::lintModule(const Module &M, bool AbortOnError) {
   for (const Function &F : M) {
     if (!F.isDeclaration())
-      lintFunction(F);
+      lintFunction(F, AbortOnError);
   }
 }

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -681,6 +681,12 @@ Expected<HardwareLoopOptions> parseHardwareLoopOptions(StringRef Params) {
   return HardwareLoopOpts;
 }
 
+/// Parser of parameters for Lint pass.
+Expected<bool> parseLintOptions(StringRef Params) {
+  return PassBuilder::parseSinglePassOption(Params, "abort-on-error",
+                                            "LintPass");
+}
+
 /// Parser of parameters for LoopUnroll pass.
 Expected<LoopUnrollOptions> parseLoopUnrollOptions(StringRef Params) {
   LoopUnrollOptions UnrollOpts;

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -397,7 +397,6 @@ FUNCTION_PASS("kcfi", KCFIPass())
 FUNCTION_PASS("kernel-info", KernelInfoPrinter(TM))
 FUNCTION_PASS("lcssa", LCSSAPass())
 FUNCTION_PASS("libcalls-shrinkwrap", LibCallsShrinkWrapPass())
-FUNCTION_PASS("lint", LintPass())
 FUNCTION_PASS("load-store-vectorizer", LoadStoreVectorizerPass())
 FUNCTION_PASS("loop-data-prefetch", LoopDataPrefetchPass())
 FUNCTION_PASS("loop-distribute", LoopDistributePass())
@@ -543,6 +542,11 @@ FUNCTION_PASS_WITH_PARAMS(
     parseInstCombineOptions,
     "no-use-loop-info;use-loop-info;no-verify-fixpoint;verify-fixpoint;"
     "max-iterations=N")
+FUNCTION_PASS_WITH_PARAMS(
+    "lint", "LintPass",
+    [](bool AbortOnError) { return LintPass(AbortOnError); },
+    parseLintOptions,
+    "abort-on-error")
 FUNCTION_PASS_WITH_PARAMS(
     "loop-unroll", "LoopUnrollPass",
     [](LoopUnrollOptions Opts) { return LoopUnrollPass(Opts); },

--- a/llvm/test/Analysis/Lint/abort-on-error.ll
+++ b/llvm/test/Analysis/Lint/abort-on-error.ll
@@ -1,8 +1,8 @@
-; RUN: not opt -passes=lint -disable-output --lint-abort-on-error %s 2>&1 | FileCheck %s
+; RUN: not opt -passes='lint<abort-on-error>' -disable-output %s 2>&1 | FileCheck %s
 
 ; CHECK: Undefined behavior: Division by zero
 ; CHECK-NEXT:   %b = sdiv i32 %a, 0
-; CHECK-NEXT: LLVM ERROR: Linter found errors, aborting. (enabled by --lint-abort-on-error)
+; CHECK-NEXT: LLVM ERROR: linter found errors, aborting. (enabled by abort-on-error)
 
 define i32 @sdiv_by_zero(i32 %a) {
   %b = sdiv i32 %a, 0

--- a/llvm/test/Analysis/Lint/const-store.ll
+++ b/llvm/test/Analysis/Lint/const-store.ll
@@ -1,6 +1,6 @@
-; RUN: not opt --mtriple=amdgcn --passes=lint --lint-abort-on-error %s -disable-output 2>&1 | FileCheck %s
+; RUN: not opt --mtriple=amdgcn --passes='lint<abort-on-error>' %s -disable-output 2>&1 | FileCheck %s
 ; RUN: opt --mtriple=amdgcn --mcpu=gfx1030 --passes=lint %s -disable-output 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK0
-; RUN: opt --mtriple=x86_64 --passes=lint --lint-abort-on-error %s -disable-output 2>&1 | FileCheck %s --allow-empty --check-prefix=NOERR
+; RUN: opt --mtriple=x86_64 --passes='lint<abort-on-error>' %s -disable-output 2>&1 | FileCheck %s --allow-empty --check-prefix=NOERR
 ; NOERR: {{^$}}
 
 define amdgpu_kernel void @store_const(ptr addrspace(4) %out, i32 %a, i32 %b) {


### PR DESCRIPTION
Replace -lint-abort-on-error with -passes='lint<abort-on-error>'.
Also change error message to start with lowercase.

Printing to dbgs() in the run is also suspect, should probably be
moved to a print method on an analysis pass.