### PR TITLE
[libc][NFC] Remove incorrect file level dependency in CMake

### DIFF
--- a/libc/test/src/__support/CMakeLists.txt
+++ b/libc/test/src/__support/CMakeLists.txt
@@ -272,7 +272,6 @@ if(NOT LIBC_TARGET_OS_IS_GPU)
   add_custom_command(TARGET libc_str_to_float_comparison_test
                      POST_BUILD
                      COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:libc_str_to_float_comparison_test> ${float_test_file}
-                     DEPENDS ${float_test_file}
                      COMMENT "Test the strtof and strtod implementations against precomputed results."
                      VERBATIM)
 endif()


### PR DESCRIPTION
Summary:
CMake doesn't support this type of dependency so it keeps emitting a
warning. Just remove it, because it's not doing anything currently
anyway. If we really wanted this to work you'd need to add a custom
target that has a dependency on the output of a custom command, but that
would only be worhwhile if we ever expected this file to change.
