### PR TITLE
[libc][time] Fix -Wshorten-64-to-32 warning

### DIFF
--- a/libc/src/time/time_utils.cpp
+++ b/libc/src/time/time_utils.cpp
@@ -102,10 +102,10 @@ cpp::optional<time_t> mktime_internal(const tm *tm_out) {
 
   // TODO: https://github.com/llvm/llvm-project/issues/121962
   // Need to handle timezone and update of tm_isdst.
-  time_t seconds = tm_out->tm_sec +
-                   tm_out->tm_min * time_constants::SECONDS_PER_MIN +
-                   tm_out->tm_hour * time_constants::SECONDS_PER_HOUR +
-                   total_days * time_constants::SECONDS_PER_DAY;
+  time_t seconds = static_cast<time_t>(
+      tm_out->tm_sec + tm_out->tm_min * time_constants::SECONDS_PER_MIN +
+      tm_out->tm_hour * time_constants::SECONDS_PER_HOUR +
+      total_days * time_constants::SECONDS_PER_DAY);
   return seconds;
 }
 


### PR DESCRIPTION
This breaks builds of libc with top of tree clang under -Werror.