### PR TITLE
Disable some tests on bazel

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -204,6 +204,22 @@ math_test(
     hdrs = ["FmaTest.h"],
 )
 
+# TODO: Reenable these tests once they pass at Google.
+# math_test(
+#     name = "f16fma",
+#     hdrs = ["FmaTest.h"],
+# )
+# 
+# math_test(
+#     name = "f16fmaf",
+#     hdrs = ["FmaTest.h"],
+# )
+# 
+# math_test(
+#     name = "f16fmal",
+#     hdrs = ["FmaTest.h"],
+# )
+
 math_test(
     name = "dmull",
     hdrs = ["MulTest.h"],
@@ -460,6 +476,12 @@ math_test(
 )
 
 # TODO: Add fma, fmaf, fmal, fmaf128 tests.
+
+# TODO: Reenable this test once it passes at Google.
+# math_test(
+#     name = "fmaf16",
+#     hdrs = ["FmaTest.h"],
+# )
 
 math_test(
     name = "fmax",

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -205,21 +205,6 @@ math_test(
 )
 
 math_test(
-    name = "f16fma",
-    hdrs = ["FmaTest.h"],
-)
-
-math_test(
-    name = "f16fmaf",
-    hdrs = ["FmaTest.h"],
-)
-
-math_test(
-    name = "f16fmal",
-    hdrs = ["FmaTest.h"],
-)
-
-math_test(
     name = "dmull",
     hdrs = ["MulTest.h"],
 )
@@ -475,11 +460,6 @@ math_test(
 )
 
 # TODO: Add fma, fmaf, fmal, fmaf128 tests.
-
-math_test(
-    name = "fmaf16",
-    hdrs = ["FmaTest.h"],
-)
 
 math_test(
     name = "fmax",


### PR DESCRIPTION
These tests failed at Google after #130757.  Disable them in bazel for the time being.