### PR TITLE
[HLSL][RootSignature] Make Root Signature lexer keywords case-insensitive

### DIFF
--- a/clang/lib/Lex/LexHLSLRootSignature.cpp
+++ b/clang/lib/Lex/LexHLSLRootSignature.cpp
@@ -95,7 +95,7 @@ RootSignatureToken RootSignatureLexer::LexToken() {
 
   // Define a large string switch statement for all the keywords and enums
   auto Switch = llvm::StringSwitch<TokenKind>(TokSpelling);
-#define KEYWORD(NAME) Switch.Case(#NAME, TokenKind::kw_##NAME);
+#define KEYWORD(NAME) Switch.CaseLower(#NAME, TokenKind::kw_##NAME);
 #define ENUM(NAME, LIT) Switch.CaseLower(LIT, TokenKind::en_##NAME);
 #include "clang/Lex/HLSLRootSignatureTokenKinds.def"
 

--- a/clang/lib/Lex/LexHLSLRootSignature.cpp
+++ b/clang/lib/Lex/LexHLSLRootSignature.cpp
@@ -1,3 +1,11 @@
+//=== LexHLSLRootSignature.cpp - Lex Root Signature -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #include "clang/Lex/LexHLSLRootSignature.h"
 
 namespace clang {

--- a/clang/unittests/Lex/LexHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Lex/LexHLSLRootSignatureTest.cpp
@@ -120,6 +120,36 @@ TEST_F(LexHLSLRootSignatureTest, ValidLexAllTokensTest) {
   CheckTokens(Lexer, Tokens, Expected);
 }
 
+TEST_F(LexHLSLRootSignatureTest, ValidCaseInsensitiveKeywordsTest) {
+  // This test will check that we can lex keywords in an case-insensitive
+  // manner
+  const llvm::StringLiteral Source = R"cc(
+    DeScRiPtOrTaBlE
+
+    CBV srv UAV sampler
+    SPACE visibility FLAGS
+    numDescriptors OFFSET
+  )cc";
+  auto TokLoc = SourceLocation();
+  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+
+  SmallVector<hlsl::RootSignatureToken> Tokens;
+  SmallVector<hlsl::TokenKind> Expected = {
+      hlsl::TokenKind::kw_DescriptorTable,
+      hlsl::TokenKind::kw_CBV,
+      hlsl::TokenKind::kw_SRV,
+      hlsl::TokenKind::kw_UAV,
+      hlsl::TokenKind::kw_Sampler,
+      hlsl::TokenKind::kw_space,
+      hlsl::TokenKind::kw_visibility,
+      hlsl::TokenKind::kw_flags,
+      hlsl::TokenKind::kw_numDescriptors,
+      hlsl::TokenKind::kw_offset,
+  };
+
+  CheckTokens(Lexer, Tokens, Expected);
+}
+
 TEST_F(LexHLSLRootSignatureTest, ValidLexPeekTest) {
   // This test will check that we the peek api is correctly used
   const llvm::StringLiteral Source = R"cc(


### PR DESCRIPTION
From the corrections to the Root Signature specification here: https://github.com/llvm/wg-hlsl/issues/192. It was denoted that keywords are also case-insensitive in DXC.

This pr adjusts the lexer to adhere to the updated spec.

We also have a NFC to add a missing license to a file while in the area.