### PR TITLE
[clang] Consistently use "load" to refer to populating clang::ModuleMap

### DIFF
--- a/clang-tools-extra/modularize/ModuleAssistant.cpp
+++ b/clang-tools-extra/modularize/ModuleAssistant.cpp
@@ -129,8 +129,8 @@ Module *Module::findSubModule(llvm::StringRef SubName) {
 // Implementation functions:
 
 // Reserved keywords in module.modulemap syntax.
-// Keep in sync with keywords in module map parser in Lex/ModuleMap.cpp,
-// such as in ModuleMapParser::consumeToken().
+// Keep in sync with keywords in module map parser in Lex/ModuleMapFile.cpp,
+// such as in ModuleMapFileParser::consumeToken().
 static const char *const ReservedNames[] = {
   "config_macros", "export",   "module", "conflict", "framework",
   "requires",      "exclude",  "header", "private",  "explicit",

--- a/clang/include/clang/Lex/ModuleMap.h
+++ b/clang/include/clang/Lex/ModuleMap.h
@@ -43,7 +43,7 @@ class FileManager;
 class HeaderSearch;
 class SourceManager;
 
-/// A mechanism to observe the actions of the module map parser as it
+/// A mechanism to observe the actions of the module map loader as it
 /// reads module map files.
 class ModuleMapCallbacks {
   virtual void anchor();
@@ -195,7 +195,7 @@ public:
   using AdditionalModMapsSet = llvm::DenseSet<FileEntryRef>;
 
 private:
-  friend class ModuleMapParser;
+  friend class ModuleMapLoader;
 
   using HeadersMap = llvm::DenseMap<FileEntryRef, SmallVector<KnownHeader, 1>>;
 
@@ -259,9 +259,9 @@ private:
 
   llvm::DenseMap<const Module *, AdditionalModMapsSet> AdditionalModMaps;
 
-  /// Describes whether we haved parsed a particular file as a module
+  /// Describes whether we haved loaded a particular file as a module
   /// map.
-  llvm::DenseMap<const FileEntry *, bool> ParsedModuleMap;
+  llvm::DenseMap<const FileEntry *, bool> LoadedModuleMap;
 
   /// Resolve the given export declaration into an actual export
   /// declaration.
@@ -693,10 +693,10 @@ public:
   void addHeader(Module *Mod, Module::Header Header,
                  ModuleHeaderRole Role, bool Imported = false);
 
-  /// Parse the given module map file, and record any modules we
+  /// Load the given module map file, and record any modules we
   /// encounter.
   ///
-  /// \param File The file to be parsed.
+  /// \param File The file to be loaded.
   ///
   /// \param IsSystem Whether this module map file is in a system header
   /// directory, and therefore should be considered a system module.
@@ -713,10 +713,10 @@ public:
   ///        that caused us to load this module map file, if any.
   ///
   /// \returns true if an error occurred, false otherwise.
-  bool parseModuleMapFile(FileEntryRef File, bool IsSystem,
-                          DirectoryEntryRef HomeDir, FileID ID = FileID(),
-                          unsigned *Offset = nullptr,
-                          SourceLocation ExternModuleLoc = SourceLocation());
+  bool loadModuleMapFile(FileEntryRef File, bool IsSystem,
+                         DirectoryEntryRef HomeDir, FileID ID = FileID(),
+                         unsigned *Offset = nullptr,
+                         SourceLocation ExternModuleLoc = SourceLocation());
 
   /// Dump the contents of the module map, for debugging purposes.
   void dump();

--- a/clang/lib/Lex/HeaderSearch.cpp
+++ b/clang/lib/Lex/HeaderSearch.cpp
@@ -1783,7 +1783,7 @@ HeaderSearch::loadModuleMapFileImpl(FileEntryRef File, bool IsSystem,
   if (!AddResult.second)
     return AddResult.first->second ? LMM_AlreadyLoaded : LMM_InvalidModuleMap;
 
-  if (ModMap.parseModuleMapFile(File, IsSystem, Dir, ID, Offset)) {
+  if (ModMap.loadModuleMapFile(File, IsSystem, Dir, ID, Offset)) {
     LoadedModuleMaps[File] = false;
     return LMM_InvalidModuleMap;
   }
@@ -1791,7 +1791,7 @@ HeaderSearch::loadModuleMapFileImpl(FileEntryRef File, bool IsSystem,
   // Try to load a corresponding private module map.
   if (OptionalFileEntryRef PMMFile =
           getPrivateModuleMap(File, FileMgr, Diags)) {
-    if (ModMap.parseModuleMapFile(*PMMFile, IsSystem, Dir)) {
+    if (ModMap.loadModuleMapFile(*PMMFile, IsSystem, Dir)) {
       LoadedModuleMaps[File] = false;
       return LMM_InvalidModuleMap;
     }


### PR DESCRIPTION
Now that we have ModuleMapFile.cpp which parses module maps, it's confusing what ModuleMap::parseModuleMapFile actually does. HeaderSearch already called this loading a module map, so consistently use that term in ModuleMap too.

An upcoming patch will allow just parsing a module map without loading the modules from it.