### PR TITLE
[clang] fix crash with ADL for member pointers with dependent class

### DIFF
--- a/clang/lib/Sema/SemaLookup.cpp
+++ b/clang/lib/Sema/SemaLookup.cpp
@@ -3210,8 +3210,8 @@ addAssociatedClassesAndNamespaces(AssociatedLookup &Result, QualType Ty) {
     //        X.
     case Type::MemberPointer: {
       const MemberPointerType *MemberPtr = cast<MemberPointerType>(T);
-      addAssociatedClassesAndNamespaces(
-          Result, MemberPtr->getMostRecentCXXRecordDecl());
+      if (CXXRecordDecl *Class = MemberPtr->getMostRecentCXXRecordDecl())
+        addAssociatedClassesAndNamespaces(Result, Class);
       T = MemberPtr->getPointeeType().getTypePtr();
       continue;
     }

--- a/clang/test/SemaCXX/member-pointer.cpp
+++ b/clang/test/SemaCXX/member-pointer.cpp
@@ -355,3 +355,13 @@ namespace GH132401 {
   };
   template struct CallableHelper<void (QIODevice::*)()>;
 } // namespace GH132401
+
+namespace adl_dependent_class {
+  struct A {
+    template <class T> A(T);
+  };
+  struct C;
+  template <class T> void d(void (T::*)());
+  void f(A);
+  void g() { f(d<C>); }
+} // namespace adl_dependent_class


### PR DESCRIPTION
Fix crash when looking up associated namespaces for member pointers with an unknown class, due to dependency.

It was a regression introduced in https://github.com/llvm/llvm-project/pull/131965 and reported here: https://github.com/llvm/llvm-project/pull/132317#issuecomment-2752187095

No change notes since the regression was never released.