### PR TITLE
[HLSL] Add new double overloads for math builtins

### DIFF
--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -394,6 +394,10 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
     // HLSL Version
     Builder.defineMacro("__HLSL_VERSION",
                         Twine((unsigned)LangOpts.getHLSLVersion()));
+    Builder.defineMacro("__HLSL_202x",
+                        Twine((unsigned)LangOptions::HLSLLangStd::HLSL_202x));
+    Builder.defineMacro("__HLSL_202y",
+                        Twine((unsigned)LangOptions::HLSLLangStd::HLSL_202y));
 
     if (LangOpts.NativeHalfType)
       Builder.defineMacro("__HLSL_ENABLE_16_BIT", "1");

--- a/clang/lib/Headers/hlsl.h
+++ b/clang/lib/Headers/hlsl.h
@@ -22,7 +22,9 @@
 
 // HLSL standard library function declarations/definitions.
 #include "hlsl/hlsl_alias_intrinsics.h"
+#if __HLSL_VERSION <= __HLSL_202x
 #include "hlsl/hlsl_compat_overloads.h"
+#endif
 #include "hlsl/hlsl_intrinsics.h"
 
 #if defined(__clang__)

--- a/clang/lib/Headers/hlsl/hlsl_compat_overloads.h
+++ b/clang/lib/Headers/hlsl/hlsl_compat_overloads.h
@@ -17,41 +17,37 @@ namespace hlsl {
 // help keep this file manageable as it grows.
 
 #define _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(fn)                                 \
-  constexpr float fn(double V) { return fn((float)V); }    \
-  constexpr float2 fn(double2 V) { return fn((float2)V); } \
-  constexpr float3 fn(double3 V) { return fn((float3)V); } \
+  constexpr float fn(double V) { return fn((float)V); }                        \
+  constexpr float2 fn(double2 V) { return fn((float2)V); }                     \
+  constexpr float3 fn(double3 V) { return fn((float3)V); }                     \
   constexpr float4 fn(double4 V) { return fn((float4)V); }
 
 #define _DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(fn)                                \
   constexpr float fn(double V1, double V2) {                                   \
-    return fn((float)V1, (float)V2);   \
+    return fn((float)V1, (float)V2);                                           \
   }                                                                            \
   constexpr float2 fn(double2 V1, double2 V2) {                                \
-    return fn((float2)V1, (float2)V2); \
+    return fn((float2)V1, (float2)V2);                                         \
   }                                                                            \
   constexpr float3 fn(double3 V1, double3 V2) {                                \
-    return fn((float3)V1, (float3)V2); \
+    return fn((float3)V1, (float3)V2);                                         \
   }                                                                            \
   constexpr float4 fn(double4 V1, double4 V2) {                                \
-    return fn((float4)V1, (float4)V2); \
+    return fn((float4)V1, (float4)V2);                                         \
   }
 
 #define _DXC_COMPAT_TERNARY_DOUBLE_OVERLOADS(fn)                               \
   constexpr float fn(double V1, double V2, double V3) {                        \
-    return fn((float)V1, (float)V2,    \
-              (float)V3);                                  \
+    return fn((float)V1, (float)V2, (float)V3);                                \
   }                                                                            \
   constexpr float2 fn(double2 V1, double2 V2, double2 V3) {                    \
-    return fn((float2)V1, (float2)V2,  \
-              (float2)V3);                                 \
+    return fn((float2)V1, (float2)V2, (float2)V3);                             \
   }                                                                            \
   constexpr float3 fn(double3 V1, double3 V2, double3 V3) {                    \
-    return fn((float3)V1, (float3)V2,  \
-              (float3)V3);                                 \
+    return fn((float3)V1, (float3)V2, (float3)V3);                             \
   }                                                                            \
   constexpr float4 fn(double4 V1, double4 V2, double4 V3) {                    \
-    return fn((float4)V1, (float4)V2,  \
-              (float4)V3);                                 \
+    return fn((float4)V1, (float4)V2, (float4)V3);                             \
   }
 
 //===----------------------------------------------------------------------===//
@@ -153,15 +149,9 @@ _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(frac)
 //===----------------------------------------------------------------------===//
 
 constexpr bool isinf(double V) { return isinf((float)V); }
-constexpr bool2 isinf(double2 V) {
-  return isinf((float2)V);
-}
-constexpr bool3 isinf(double3 V) {
-  return isinf((float3)V);
-}
-constexpr bool4 isinf(double4 V) {
-  return isinf((float4)V);
-}
+constexpr bool2 isinf(double2 V) { return isinf((float2)V); }
+constexpr bool3 isinf(double3 V) { return isinf((float3)V); }
+constexpr bool4 isinf(double4 V) { return isinf((float4)V); }
 
 //===----------------------------------------------------------------------===//
 // lerp builtins overloads

--- a/clang/lib/Headers/hlsl/hlsl_compat_overloads.h
+++ b/clang/lib/Headers/hlsl/hlsl_compat_overloads.h
@@ -17,41 +17,41 @@ namespace hlsl {
 // help keep this file manageable as it grows.
 
 #define _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(fn)                                 \
-  constexpr float fn(double V) { return fn(__detail::imp_cast<float>(V)); }    \
-  constexpr float2 fn(double2 V) { return fn(__detail::imp_cast<float2>(V)); } \
-  constexpr float3 fn(double3 V) { return fn(__detail::imp_cast<float3>(V)); } \
-  constexpr float4 fn(double4 V) { return fn(__detail::imp_cast<float4>(V)); }
+  constexpr float fn(double V) { return fn((float)V); }    \
+  constexpr float2 fn(double2 V) { return fn((float2)V); } \
+  constexpr float3 fn(double3 V) { return fn((float3)V); } \
+  constexpr float4 fn(double4 V) { return fn((float4)V); }
 
 #define _DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(fn)                                \
   constexpr float fn(double V1, double V2) {                                   \
-    return fn(__detail::imp_cast<float>(V1), __detail::imp_cast<float>(V2));   \
+    return fn((float)V1, (float)V2);   \
   }                                                                            \
   constexpr float2 fn(double2 V1, double2 V2) {                                \
-    return fn(__detail::imp_cast<float2>(V1), __detail::imp_cast<float2>(V2)); \
+    return fn((float2)V1, (float2)V2); \
   }                                                                            \
   constexpr float3 fn(double3 V1, double3 V2) {                                \
-    return fn(__detail::imp_cast<float3>(V1), __detail::imp_cast<float3>(V2)); \
+    return fn((float3)V1, (float3)V2); \
   }                                                                            \
   constexpr float4 fn(double4 V1, double4 V2) {                                \
-    return fn(__detail::imp_cast<float4>(V1), __detail::imp_cast<float4>(V2)); \
+    return fn((float4)V1, (float4)V2); \
   }
 
 #define _DXC_COMPAT_TERNARY_DOUBLE_OVERLOADS(fn)                               \
   constexpr float fn(double V1, double V2, double V3) {                        \
-    return fn(__detail::imp_cast<float>(V1), __detail::imp_cast<float>(V2),    \
-              __detail::imp_cast<float>(V3));                                  \
+    return fn((float)V1, (float)V2,    \
+              (float)V3);                                  \
   }                                                                            \
   constexpr float2 fn(double2 V1, double2 V2, double2 V3) {                    \
-    return fn(__detail::imp_cast<float2>(V1), __detail::imp_cast<float2>(V2),  \
-              __detail::imp_cast<float2>(V3));                                 \
+    return fn((float2)V1, (float2)V2,  \
+              (float2)V3);                                 \
   }                                                                            \
   constexpr float3 fn(double3 V1, double3 V2, double3 V3) {                    \
-    return fn(__detail::imp_cast<float3>(V1), __detail::imp_cast<float3>(V2),  \
-              __detail::imp_cast<float3>(V3));                                 \
+    return fn((float3)V1, (float3)V2,  \
+              (float3)V3);                                 \
   }                                                                            \
   constexpr float4 fn(double4 V1, double4 V2, double4 V3) {                    \
-    return fn(__detail::imp_cast<float4>(V1), __detail::imp_cast<float4>(V2),  \
-              __detail::imp_cast<float4>(V3));                                 \
+    return fn((float4)V1, (float4)V2,  \
+              (float4)V3);                                 \
   }
 
 //===----------------------------------------------------------------------===//
@@ -177,15 +177,15 @@ _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(frac)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-constexpr bool isinf(double V) { return isinf(__detail::imp_cast<float>(V)); }
+constexpr bool isinf(double V) { return isinf((float)V); }
 constexpr bool2 isinf(double2 V) {
-  return isinf(__detail::imp_cast<float2>(V));
+  return isinf((float2)V);
 }
 constexpr bool3 isinf(double3 V) {
-  return isinf(__detail::imp_cast<float3>(V));
+  return isinf((float3)V);
 }
 constexpr bool4 isinf(double4 V) {
-  return isinf(__detail::imp_cast<float4>(V));
+  return isinf((float4)V);
 }
 #endif
 

--- a/clang/lib/Headers/hlsl/hlsl_compat_overloads.h
+++ b/clang/lib/Headers/hlsl/hlsl_compat_overloads.h
@@ -58,41 +58,31 @@ namespace hlsl {
 // acos builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(acos)
-#endif
 
 //===----------------------------------------------------------------------===//
 // asin builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(asin)
-#endif
 
 //===----------------------------------------------------------------------===//
 // atan builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(atan)
-#endif
 
 //===----------------------------------------------------------------------===//
 // atan2 builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(atan2)
-#endif
 
 //===----------------------------------------------------------------------===//
 // ceil builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(ceil)
-#endif
 
 //===----------------------------------------------------------------------===//
 // clamp builtins overloads
@@ -120,63 +110,48 @@ clamp(vector<T, N> p0, T p1, T p2) {
 // cos builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(cos)
-#endif
 
 //===----------------------------------------------------------------------===//
 // cosh builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(cosh)
-#endif
 
 //===----------------------------------------------------------------------===//
 // degrees builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(degrees)
-#endif
 
 //===----------------------------------------------------------------------===//
 // exp builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(exp)
-#endif
 
 //===----------------------------------------------------------------------===//
 // exp2 builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(exp2)
-#endif
 
 //===----------------------------------------------------------------------===//
 // floor builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(floor)
-#endif
 
 //===----------------------------------------------------------------------===//
 // frac builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(frac)
-#endif
 
 //===----------------------------------------------------------------------===//
 // isinf builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 constexpr bool isinf(double V) { return isinf((float)V); }
 constexpr bool2 isinf(double2 V) {
   return isinf((float2)V);
@@ -187,39 +162,30 @@ constexpr bool3 isinf(double3 V) {
 constexpr bool4 isinf(double4 V) {
   return isinf((float4)V);
 }
-#endif
 
 //===----------------------------------------------------------------------===//
 // lerp builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_TERNARY_DOUBLE_OVERLOADS(lerp)
-#endif
 
 //===----------------------------------------------------------------------===//
 // log builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(log)
-#endif
 
 //===----------------------------------------------------------------------===//
 // log10 builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(log10)
-#endif
 
 //===----------------------------------------------------------------------===//
 // log2 builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(log2)
-#endif
 
 //===----------------------------------------------------------------------===//
 // max builtins overloads
@@ -257,97 +223,73 @@ min(T p0, vector<T, N> p1) {
 // normalize builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(normalize)
-#endif
 
 //===----------------------------------------------------------------------===//
 // pow builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(pow)
-#endif
 
 //===----------------------------------------------------------------------===//
 // rsqrt builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(rsqrt)
-#endif
 
 //===----------------------------------------------------------------------===//
 // round builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(round)
-#endif
 
 //===----------------------------------------------------------------------===//
 // sin builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(sin)
-#endif
 
 //===----------------------------------------------------------------------===//
 // sinh builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(sinh)
-#endif
 
 //===----------------------------------------------------------------------===//
 // sqrt builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(sqrt)
-#endif
 
 //===----------------------------------------------------------------------===//
 // step builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(step)
-#endif
 
 //===----------------------------------------------------------------------===//
 // tan builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(tan)
-#endif
 
 //===----------------------------------------------------------------------===//
 // tanh builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(tanh)
-#endif
 
 //===----------------------------------------------------------------------===//
 // trunc builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(trunc)
-#endif
 
 //===----------------------------------------------------------------------===//
 // radians builtins overloads
 //===----------------------------------------------------------------------===//
 
-#if __HLSL_VERSION <= __HLSL_202x
 _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(radians)
-#endif
 
 } // namespace hlsl
 #endif // _HLSL_COMPAT_OVERLOADS_H_

--- a/clang/lib/Headers/hlsl/hlsl_compat_overloads.h
+++ b/clang/lib/Headers/hlsl/hlsl_compat_overloads.h
@@ -16,13 +16,13 @@ namespace hlsl {
 // unsigned integer and floating point. Keeping this ordering consistent will
 // help keep this file manageable as it grows.
 
-#define DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(fn)                                  \
+#define _DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(fn)                                 \
   constexpr float fn(double V) { return fn(__detail::imp_cast<float>(V)); }    \
   constexpr float2 fn(double2 V) { return fn(__detail::imp_cast<float2>(V)); } \
   constexpr float3 fn(double3 V) { return fn(__detail::imp_cast<float3>(V)); } \
   constexpr float4 fn(double4 V) { return fn(__detail::imp_cast<float4>(V)); }
 
-#define DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(fn)                                 \
+#define _DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(fn)                                \
   constexpr float fn(double V1, double V2) {                                   \
     return fn(__detail::imp_cast<float>(V1), __detail::imp_cast<float>(V2));   \
   }                                                                            \
@@ -36,7 +36,7 @@ namespace hlsl {
     return fn(__detail::imp_cast<float4>(V1), __detail::imp_cast<float4>(V2)); \
   }
 
-#define DXC_COMPAT_TERNARY_DOUBLE_OVERLOADS(fn)                                \
+#define _DXC_COMPAT_TERNARY_DOUBLE_OVERLOADS(fn)                               \
   constexpr float fn(double V1, double V2, double V3) {                        \
     return fn(__detail::imp_cast<float>(V1), __detail::imp_cast<float>(V2),    \
               __detail::imp_cast<float>(V3));                                  \
@@ -59,7 +59,7 @@ namespace hlsl {
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(acos)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(acos)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -67,7 +67,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(acos)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(asin)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(asin)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -75,7 +75,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(asin)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(atan)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(atan)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -83,7 +83,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(atan)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(atan2)
+_DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(atan2)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -91,7 +91,7 @@ DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(atan2)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(ceil)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(ceil)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -121,7 +121,7 @@ clamp(vector<T, N> p0, T p1, T p2) {
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(cos)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(cos)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -129,7 +129,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(cos)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(cosh)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(cosh)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -137,7 +137,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(cosh)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(degrees)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(degrees)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -145,7 +145,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(degrees)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(exp)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(exp)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -153,7 +153,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(exp)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(exp2)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(exp2)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -161,7 +161,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(exp2)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(floor)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(floor)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -169,7 +169,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(floor)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(frac)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(frac)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -194,7 +194,7 @@ constexpr bool4 isinf(double4 V) {
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_TERNARY_DOUBLE_OVERLOADS(lerp)
+_DXC_COMPAT_TERNARY_DOUBLE_OVERLOADS(lerp)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -202,7 +202,7 @@ DXC_COMPAT_TERNARY_DOUBLE_OVERLOADS(lerp)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(log)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(log)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -210,7 +210,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(log)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(log10)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(log10)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -218,7 +218,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(log10)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(log2)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(log2)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -258,7 +258,7 @@ min(T p0, vector<T, N> p1) {
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(normalize)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(normalize)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -266,7 +266,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(normalize)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(pow)
+_DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(pow)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -274,7 +274,7 @@ DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(pow)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(rsqrt)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(rsqrt)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -282,7 +282,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(rsqrt)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(round)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(round)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -290,7 +290,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(round)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(sin)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(sin)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -298,7 +298,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(sin)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(sinh)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(sinh)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -306,7 +306,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(sinh)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(sqrt)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(sqrt)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -314,7 +314,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(sqrt)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(step)
+_DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(step)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -322,7 +322,7 @@ DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(step)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(tan)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(tan)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -330,7 +330,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(tan)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(tanh)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(tanh)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -338,7 +338,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(tanh)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(trunc)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(trunc)
 #endif
 
 //===----------------------------------------------------------------------===//
@@ -346,7 +346,7 @@ DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(trunc)
 //===----------------------------------------------------------------------===//
 
 #if __HLSL_VERSION <= __HLSL_202x
-DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(radians)
+_DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(radians)
 #endif
 
 } // namespace hlsl

--- a/clang/lib/Headers/hlsl/hlsl_compat_overloads.h
+++ b/clang/lib/Headers/hlsl/hlsl_compat_overloads.h
@@ -16,6 +16,84 @@ namespace hlsl {
 // unsigned integer and floating point. Keeping this ordering consistent will
 // help keep this file manageable as it grows.
 
+#define DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(fn)                                  \
+  constexpr float fn(double V) { return fn(__detail::imp_cast<float>(V)); }    \
+  constexpr float2 fn(double2 V) { return fn(__detail::imp_cast<float2>(V)); } \
+  constexpr float3 fn(double3 V) { return fn(__detail::imp_cast<float3>(V)); } \
+  constexpr float4 fn(double4 V) { return fn(__detail::imp_cast<float4>(V)); }
+
+#define DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(fn)                                 \
+  constexpr float fn(double V1, double V2) {                                   \
+    return fn(__detail::imp_cast<float>(V1), __detail::imp_cast<float>(V2));   \
+  }                                                                            \
+  constexpr float2 fn(double2 V1, double2 V2) {                                \
+    return fn(__detail::imp_cast<float2>(V1), __detail::imp_cast<float2>(V2)); \
+  }                                                                            \
+  constexpr float3 fn(double3 V1, double3 V2) {                                \
+    return fn(__detail::imp_cast<float3>(V1), __detail::imp_cast<float3>(V2)); \
+  }                                                                            \
+  constexpr float4 fn(double4 V1, double4 V2) {                                \
+    return fn(__detail::imp_cast<float4>(V1), __detail::imp_cast<float4>(V2)); \
+  }
+
+#define DXC_COMPAT_TERNARY_DOUBLE_OVERLOADS(fn)                                \
+  constexpr float fn(double V1, double V2, double V3) {                        \
+    return fn(__detail::imp_cast<float>(V1), __detail::imp_cast<float>(V2),    \
+              __detail::imp_cast<float>(V3));                                  \
+  }                                                                            \
+  constexpr float2 fn(double2 V1, double2 V2, double2 V3) {                    \
+    return fn(__detail::imp_cast<float2>(V1), __detail::imp_cast<float2>(V2),  \
+              __detail::imp_cast<float2>(V3));                                 \
+  }                                                                            \
+  constexpr float3 fn(double3 V1, double3 V2, double3 V3) {                    \
+    return fn(__detail::imp_cast<float3>(V1), __detail::imp_cast<float3>(V2),  \
+              __detail::imp_cast<float3>(V3));                                 \
+  }                                                                            \
+  constexpr float4 fn(double4 V1, double4 V2, double4 V3) {                    \
+    return fn(__detail::imp_cast<float4>(V1), __detail::imp_cast<float4>(V2),  \
+              __detail::imp_cast<float4>(V3));                                 \
+  }
+
+//===----------------------------------------------------------------------===//
+// acos builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(acos)
+#endif
+
+//===----------------------------------------------------------------------===//
+// asin builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(asin)
+#endif
+
+//===----------------------------------------------------------------------===//
+// atan builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(atan)
+#endif
+
+//===----------------------------------------------------------------------===//
+// atan2 builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(atan2)
+#endif
+
+//===----------------------------------------------------------------------===//
+// ceil builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(ceil)
+#endif
+
 //===----------------------------------------------------------------------===//
 // clamp builtins overloads
 //===----------------------------------------------------------------------===//
@@ -39,7 +117,112 @@ clamp(vector<T, N> p0, T p1, T p2) {
 }
 
 //===----------------------------------------------------------------------===//
-// max builtin overloads
+// cos builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(cos)
+#endif
+
+//===----------------------------------------------------------------------===//
+// cosh builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(cosh)
+#endif
+
+//===----------------------------------------------------------------------===//
+// degrees builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(degrees)
+#endif
+
+//===----------------------------------------------------------------------===//
+// exp builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(exp)
+#endif
+
+//===----------------------------------------------------------------------===//
+// exp2 builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(exp2)
+#endif
+
+//===----------------------------------------------------------------------===//
+// floor builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(floor)
+#endif
+
+//===----------------------------------------------------------------------===//
+// frac builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(frac)
+#endif
+
+//===----------------------------------------------------------------------===//
+// isinf builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+constexpr bool isinf(double V) { return isinf(__detail::imp_cast<float>(V)); }
+constexpr bool2 isinf(double2 V) {
+  return isinf(__detail::imp_cast<float2>(V));
+}
+constexpr bool3 isinf(double3 V) {
+  return isinf(__detail::imp_cast<float3>(V));
+}
+constexpr bool4 isinf(double4 V) {
+  return isinf(__detail::imp_cast<float4>(V));
+}
+#endif
+
+//===----------------------------------------------------------------------===//
+// lerp builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_TERNARY_DOUBLE_OVERLOADS(lerp)
+#endif
+
+//===----------------------------------------------------------------------===//
+// log builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(log)
+#endif
+
+//===----------------------------------------------------------------------===//
+// log10 builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(log10)
+#endif
+
+//===----------------------------------------------------------------------===//
+// log2 builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(log2)
+#endif
+
+//===----------------------------------------------------------------------===//
+// max builtins overloads
 //===----------------------------------------------------------------------===//
 
 template <typename T, uint N>
@@ -55,7 +238,7 @@ max(T p0, vector<T, N> p1) {
 }
 
 //===----------------------------------------------------------------------===//
-// min builtin overloads
+// min builtins overloads
 //===----------------------------------------------------------------------===//
 
 template <typename T, uint N>
@@ -69,6 +252,102 @@ constexpr __detail::enable_if_t<(N > 1 && N <= 4), vector<T, N>>
 min(T p0, vector<T, N> p1) {
   return min((vector<T, N>)p0, p1);
 }
+
+//===----------------------------------------------------------------------===//
+// normalize builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(normalize)
+#endif
+
+//===----------------------------------------------------------------------===//
+// pow builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(pow)
+#endif
+
+//===----------------------------------------------------------------------===//
+// rsqrt builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(rsqrt)
+#endif
+
+//===----------------------------------------------------------------------===//
+// round builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(round)
+#endif
+
+//===----------------------------------------------------------------------===//
+// sin builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(sin)
+#endif
+
+//===----------------------------------------------------------------------===//
+// sinh builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(sinh)
+#endif
+
+//===----------------------------------------------------------------------===//
+// sqrt builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(sqrt)
+#endif
+
+//===----------------------------------------------------------------------===//
+// step builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_BINARY_DOUBLE_OVERLOADS(step)
+#endif
+
+//===----------------------------------------------------------------------===//
+// tan builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(tan)
+#endif
+
+//===----------------------------------------------------------------------===//
+// tanh builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(tanh)
+#endif
+
+//===----------------------------------------------------------------------===//
+// trunc builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(trunc)
+#endif
+
+//===----------------------------------------------------------------------===//
+// radians builtins overloads
+//===----------------------------------------------------------------------===//
+
+#if __HLSL_VERSION <= __HLSL_202x
+DXC_COMPAT_UNARY_DOUBLE_OVERLOADS(radians)
+#endif
 
 } // namespace hlsl
 #endif // _HLSL_COMPAT_OVERLOADS_H_

--- a/clang/lib/Headers/hlsl/hlsl_detail.h
+++ b/clang/lib/Headers/hlsl/hlsl_detail.h
@@ -49,6 +49,8 @@ template <typename T, int N>
 using HLSL_FIXED_VECTOR =
     vector<__detail::enable_if_t<(N > 1 && N <= 4), T>, N>;
 
+template <typename T, typename R> constexpr T imp_cast(R Val) { return Val; }
+
 } // namespace __detail
 } // namespace hlsl
 #endif //_HLSL_HLSL_DETAILS_H_

--- a/clang/lib/Headers/hlsl/hlsl_detail.h
+++ b/clang/lib/Headers/hlsl/hlsl_detail.h
@@ -49,8 +49,6 @@ template <typename T, int N>
 using HLSL_FIXED_VECTOR =
     vector<__detail::enable_if_t<(N > 1 && N <= 4), T>, N>;
 
-template <typename T, typename R> constexpr T imp_cast(R Val) { return Val; }
-
 } // namespace __detail
 } // namespace hlsl
 #endif //_HLSL_HLSL_DETAILS_H_

--- a/clang/test/CodeGenHLSL/builtins/acos.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/acos.hlsl
@@ -57,3 +57,27 @@ float3 test_acos_float3 ( float3 p0 ) {
 float4 test_acos_float4 ( float4 p0 ) {
   return acos ( p0 );
 }
+
+// CHECK-LABEL: test_acos_double
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.acos.f32
+float test_acos_double ( double p0 ) {
+  return acos ( p0 );
+}
+
+// CHECK-LABEL: test_acos_double2
+// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.acos.v2f32
+float2 test_acos_double2 ( double2 p0 ) {
+  return acos ( p0 );
+}
+
+// CHECK-LABEL: test_acos_double3
+// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.acos.v3f32
+float3 test_acos_double3 ( double3 p0 ) {
+  return acos ( p0 );
+}
+
+// CHECK-LABEL: test_acos_double4
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.acos.v4f32
+float4 test_acos_double4 ( double4 p0 ) {
+  return acos ( p0 );
+}

--- a/clang/test/CodeGenHLSL/builtins/asin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/asin.hlsl
@@ -57,3 +57,27 @@ float3 test_asin_float3 ( float3 p0 ) {
 float4 test_asin_float4 ( float4 p0 ) {
   return asin ( p0 );
 }
+
+// CHECK-LABEL: test_asin_double
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.asin.f32
+float test_asin_double ( double p0 ) {
+  return asin ( p0 );
+}
+
+// CHECK-LABEL: test_asin_double2
+// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.asin.v2f32
+float2 test_asin_double2 ( double2 p0 ) {
+  return asin ( p0 );
+}
+
+// CHECK-LABEL: test_asin_double3
+// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.asin.v3f32
+float3 test_asin_double3 ( double3 p0 ) {
+  return asin ( p0 );
+}
+
+// CHECK-LABEL: test_asin_double4
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.asin.v4f32
+float4 test_asin_double4 ( double4 p0 ) {
+  return asin ( p0 );
+}

--- a/clang/test/CodeGenHLSL/builtins/atan.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/atan.hlsl
@@ -57,3 +57,27 @@ float3 test_atan_float3 ( float3 p0 ) {
 float4 test_atan_float4 ( float4 p0 ) {
   return atan ( p0 );
 }
+
+// CHECK-LABEL: test_atan_double
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.atan.f32
+float test_atan_double ( double p0 ) {
+  return atan ( p0 );
+}
+
+// CHECK-LABEL: test_atan_double2
+// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.atan.v2f32
+float2 test_atan_double2 ( double2 p0 ) {
+  return atan ( p0 );
+}
+
+// CHECK-LABEL: test_atan_double3
+// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.atan.v3f32
+float3 test_atan_double3 ( double3 p0 ) {
+  return atan ( p0 );
+}
+
+// CHECK-LABEL: test_atan_double4
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.atan.v4f32
+float4 test_atan_double4 ( double4 p0 ) {
+  return atan ( p0 );
+}

--- a/clang/test/CodeGenHLSL/builtins/atan2.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/atan2.hlsl
@@ -57,3 +57,27 @@ float3 test_atan2_float3 (float3 p0, float3 p1) {
 float4 test_atan2_float4 (float4 p0, float4 p1) {
   return atan2(p0, p1);
 }
+
+// CHECK-LABEL: test_atan2_double
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.atan2.f32
+float test_atan2_double (double p0, double p1) {
+  return atan2(p0, p1);
+}
+
+// CHECK-LABEL: test_atan2_double2
+// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.atan2.v2f32
+float2 test_atan2_double2 (double2 p0, double2 p1) {
+  return atan2(p0, p1);
+}
+
+// CHECK-LABEL: test_atan2_double3
+// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.atan2.v3f32
+float3 test_atan2_double3 (double3 p0, double3 p1) {
+  return atan2(p0, p1);
+}
+
+// CHECK-LABEL: test_atan2_double4
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.atan2.v4f32
+float4 test_atan2_double4 (double4 p0, double4 p1) {
+  return atan2(p0, p1);
+}

--- a/clang/test/CodeGenHLSL/builtins/ceil.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/ceil.hlsl
@@ -40,3 +40,16 @@ float3 test_ceil_float3(float3 p0) { return ceil(p0); }
 // CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> @_Z16test_ceil_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.ceil.v4f32(
 float4 test_ceil_float4(float4 p0) { return ceil(p0); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) float {{.*}}test_ceil_double
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.ceil.f32(
+float test_ceil_double(double p0) { return ceil(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <2 x float> {{.*}}test_ceil_double2
+// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.ceil.v2f32(
+float2 test_ceil_double2(double2 p0) { return ceil(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <3 x float> {{.*}}test_ceil_double3
+// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.ceil.v3f32(
+float3 test_ceil_double3(double3 p0) { return ceil(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_ceil_double4
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.ceil.v4f32(
+float4 test_ceil_double4(double4 p0) { return ceil(p0); }

--- a/clang/test/CodeGenHLSL/builtins/cos.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/cos.hlsl
@@ -38,3 +38,16 @@ float3 test_cos_float3(float3 p0) { return cos(p0); }
 // CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> @_Z15test_cos_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.cos.v4f32
 float4 test_cos_float4(float4 p0) { return cos(p0); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) float {{.*}}test_cos_double
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.cos.f32(
+float test_cos_double(double p0) { return cos(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <2 x float> {{.*}}test_cos_double2
+// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.cos.v2f32
+float2 test_cos_double2(double2 p0) { return cos(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <3 x float> {{.*}}test_cos_double3
+// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.cos.v3f32
+float3 test_cos_double3(double3 p0) { return cos(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_cos_double4
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.cos.v4f32
+float4 test_cos_double4(double4 p0) { return cos(p0); }

--- a/clang/test/CodeGenHLSL/builtins/cosh.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/cosh.hlsl
@@ -57,3 +57,27 @@ float3 test_cosh_float3 ( float3 p0 ) {
 float4 test_cosh_float4 ( float4 p0 ) {
   return cosh ( p0 );
 }
+
+// CHECK-LABEL: test_cosh_double
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.cosh.f32
+float test_cosh_double ( double p0 ) {
+  return cosh ( p0 );
+}
+
+// CHECK-LABEL: test_cosh_double2
+// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.cosh.v2f32
+float2 test_cosh_double2 ( double2 p0 ) {
+  return cosh ( p0 );
+}
+
+// CHECK-LABEL: test_cosh_double3
+// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.cosh.v3f32
+float3 test_cosh_double3 ( double3 p0 ) {
+  return cosh ( p0 );
+}
+
+// CHECK-LABEL: test_cosh_double4
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.cosh.v4f32
+float4 test_cosh_double4 ( double4 p0 ) {
+  return cosh ( p0 );
+}

--- a/clang/test/CodeGenHLSL/builtins/degrees.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/degrees.hlsl
@@ -62,3 +62,20 @@ float3 test_degrees_float3(float3 p0) { return degrees(p0); }
 // CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].degrees.v4f32
 // CHECK: ret <4 x float> %hlsl.degrees
 float4 test_degrees_float4(float4 p0) { return degrees(p0); }
+
+// CHECK: define [[FNATTRS]] float @
+// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].degrees.f32(
+// CHECK: ret float %hlsl.degrees
+float test_degrees_double(double p0) { return degrees(p0); }
+// CHECK: define [[FNATTRS]] <2 x float> @
+// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].degrees.v2f32
+// CHECK: ret <2 x float> %hlsl.degrees
+float2 test_degrees_double2(double2 p0) { return degrees(p0); }
+// CHECK: define [[FNATTRS]] <3 x float> @
+// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].degrees.v3f32
+// CHECK: ret <3 x float> %hlsl.degrees
+float3 test_degrees_double3(double3 p0) { return degrees(p0); }
+// CHECK: define [[FNATTRS]] <4 x float> @
+// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].degrees.v4f32
+// CHECK: ret <4 x float> %hlsl.degrees
+float4 test_degrees_double4(double4 p0) { return degrees(p0); }

--- a/clang/test/CodeGenHLSL/builtins/exp.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/exp.hlsl
@@ -50,3 +50,20 @@ float3 test_exp_float3(float3 p0) { return exp(p0); }
 // CHECK: %elt.exp = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.exp.v4f32
 // CHECK: ret <4 x float> %elt.exp
 float4 test_exp_float4(float4 p0) { return exp(p0); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) float {{.*}}test_exp_double
+// CHECK: %elt.exp = call reassoc nnan ninf nsz arcp afn float @llvm.exp.f32(
+// CHECK: ret float %elt.exp
+float test_exp_double(double p0) { return exp(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <2 x float> {{.*}}test_exp_double2
+// CHECK: %elt.exp = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.exp.v2f32
+// CHECK: ret <2 x float> %elt.exp
+float2 test_exp_double2(double2 p0) { return exp(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <3 x float> {{.*}}test_exp_double3
+// CHECK: %elt.exp = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.exp.v3f32
+// CHECK: ret <3 x float> %elt.exp
+float3 test_exp_double3(double3 p0) { return exp(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_exp_double4
+// CHECK: %elt.exp = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.exp.v4f32
+// CHECK: ret <4 x float> %elt.exp
+float4 test_exp_double4(double4 p0) { return exp(p0); }

--- a/clang/test/CodeGenHLSL/builtins/exp2.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/exp2.hlsl
@@ -50,3 +50,20 @@ float3 test_exp2_float3(float3 p0) { return exp2(p0); }
 // CHECK: %elt.exp2 = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.exp2.v4f32
 // CHECK: ret <4 x float> %elt.exp2
 float4 test_exp2_float4(float4 p0) { return exp2(p0); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) float {{.*}}test_exp2_double
+// CHECK: %elt.exp2 = call reassoc nnan ninf nsz arcp afn float @llvm.exp2.f32(
+// CHECK: ret float %elt.exp2
+float test_exp2_double(double p0) { return exp2(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <2 x float> {{.*}}test_exp2_double2
+// CHECK: %elt.exp2 = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.exp2.v2f32
+// CHECK: ret <2 x float> %elt.exp2
+float2 test_exp2_double2(double2 p0) { return exp2(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <3 x float> {{.*}}test_exp2_double3
+// CHECK: %elt.exp2 = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.exp2.v3f32
+// CHECK: ret <3 x float> %elt.exp2
+float3 test_exp2_double3(double3 p0) { return exp2(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_exp2_double4
+// CHECK: %elt.exp2 = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.exp2.v4f32
+// CHECK: ret <4 x float> %elt.exp2
+float4 test_exp2_double4(double4 p0) { return exp2(p0); }

--- a/clang/test/CodeGenHLSL/builtins/floor.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/floor.hlsl
@@ -40,3 +40,16 @@ float3 test_floor_float3(float3 p0) { return floor(p0); }
 // CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> @_Z17test_floor_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.floor.v4f32(
 float4 test_floor_float4(float4 p0) { return floor(p0); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) float {{.*}}test_floor_double
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.floor.f32(
+float test_floor_double(double p0) { return floor(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <2 x float> {{.*}}test_floor_double2
+// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.floor.v2f32(
+float2 test_floor_double2(double2 p0) { return floor(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <3 x float> {{.*}}test_floor_double3
+// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.floor.v3f32(
+float3 test_floor_double3(double3 p0) { return floor(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_floor_double4
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.floor.v4f32(
+float4 test_floor_double4(double4 p0) { return floor(p0); }

--- a/clang/test/CodeGenHLSL/builtins/frac.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/frac.hlsl
@@ -62,3 +62,20 @@ float3 test_frac_float3(float3 p0) { return frac(p0); }
 // CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].frac.v4f32
 // CHECK: ret <4 x float> %hlsl.frac
 float4 test_frac_float4(float4 p0) { return frac(p0); }
+
+// CHECK: define [[FNATTRS]] float @
+// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].frac.f32(
+// CHECK: ret float %hlsl.frac
+float test_frac_double(double p0) { return frac(p0); }
+// CHECK: define [[FNATTRS]] <2 x float> @
+// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].frac.v2f32
+// CHECK: ret <2 x float> %hlsl.frac
+float2 test_frac_double2(double2 p0) { return frac(p0); }
+// CHECK: define [[FNATTRS]] <3 x float> @
+// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].frac.v3f32
+// CHECK: ret <3 x float> %hlsl.frac
+float3 test_frac_double3(double3 p0) { return frac(p0); }
+// CHECK: define [[FNATTRS]] <4 x float> @
+// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].frac.v4f32
+// CHECK: ret <4 x float> %hlsl.frac
+float4 test_frac_double4(double4 p0) { return frac(p0); }

--- a/clang/test/CodeGenHLSL/builtins/isinf.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/isinf.hlsl
@@ -43,3 +43,20 @@ bool3 test_isinf_float3(float3 p0) { return isinf(p0); }
 // CHECK: %dx.isinf = call <4 x i1> @llvm.dx.isinf.v4f32
 // CHECK: ret <4 x i1> %dx.isinf
 bool4 test_isinf_float4(float4 p0) { return isinf(p0); }
+
+// CHECK: define noundef i1 @
+// CHECK: %dx.isinf = call i1 @llvm.dx.isinf.f32(
+// CHECK: ret i1 %dx.isinf
+bool test_isinf_double(double p0) { return isinf(p0); }
+// CHECK: define noundef <2 x i1> @
+// CHECK: %dx.isinf = call <2 x i1> @llvm.dx.isinf.v2f32
+// CHECK: ret <2 x i1> %dx.isinf
+bool2 test_isinf_double2(double2 p0) { return isinf(p0); }
+// CHECK: define noundef <3 x i1> @
+// CHECK: %dx.isinf = call <3 x i1> @llvm.dx.isinf.v3f32
+// CHECK: ret <3 x i1> %dx.isinf
+bool3 test_isinf_double3(double3 p0) { return isinf(p0); }
+// CHECK: define noundef <4 x i1> @
+// CHECK: %dx.isinf = call <4 x i1> @llvm.dx.isinf.v4f32
+// CHECK: ret <4 x i1> %dx.isinf
+bool4 test_isinf_double4(double4 p0) { return isinf(p0); }

--- a/clang/test/CodeGenHLSL/builtins/lerp.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/lerp.hlsl
@@ -56,3 +56,23 @@ float3 test_lerp_float3(float3 p0) { return lerp(p0, p0, p0); }
 // CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> %{{.*}}, <4 x float> %{{.*}}, <4 x float> %{{.*}})
 // CHECK: ret <4 x float> %hlsl.lerp
 float4 test_lerp_float4(float4 p0) { return lerp(p0, p0, p0); }
+
+// CHECK-LABEL: test_lerp_double
+// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].lerp.f32(float %{{.*}}, float %{{.*}}, float %{{.*}})
+// CHECK: ret float %hlsl.lerp
+float test_lerp_double(double p0) { return lerp(p0, p0, p0); }
+
+// CHECK-LABEL: test_lerp_double2
+// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].lerp.v2f32(<2 x float> %{{.*}}, <2 x float> %{{.*}}, <2 x float> %{{.*}})
+// CHECK: ret <2 x float> %hlsl.lerp
+float2 test_lerp_double2(double2 p0) { return lerp(p0, p0, p0); }
+
+// CHECK-LABEL: test_lerp_double3
+// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].lerp.v3f32(<3 x float> %{{.*}}, <3 x float> %{{.*}}, <3 x float> %{{.*}})
+// CHECK: ret <3 x float> %hlsl.lerp
+float3 test_lerp_double3(double3 p0) { return lerp(p0, p0, p0); }
+
+// CHECK-LABEL: test_lerp_double4
+// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].lerp.v4f32(<4 x float> %{{.*}}, <4 x float> %{{.*}}, <4 x float> %{{.*}})
+// CHECK: ret <4 x float> %hlsl.lerp
+float4 test_lerp_double4(double4 p0) { return lerp(p0, p0, p0); }

--- a/clang/test/CodeGenHLSL/builtins/log.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/log.hlsl
@@ -38,3 +38,16 @@ float3 test_log_float3(float3 p0) { return log(p0); }
 // CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> @_Z15test_log_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log.v4f32
 float4 test_log_float4(float4 p0) { return log(p0); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) float {{.*}}test_log_double
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.log.f32(
+float test_log_double(double p0) { return log(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <2 x float> {{.*}}test_log_double2
+// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.log.v2f32
+float2 test_log_double2(double2 p0) { return log(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <3 x float> {{.*}}test_log_double3
+// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.log.v3f32
+float3 test_log_double3(double3 p0) { return log(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_log_double4
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log.v4f32
+float4 test_log_double4(double4 p0) { return log(p0); }

--- a/clang/test/CodeGenHLSL/builtins/log10.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/log10.hlsl
@@ -38,3 +38,16 @@ float3 test_log10_float3(float3 p0) { return log10(p0); }
 // CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> @_Z17test_log10_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log10.v4f32
 float4 test_log10_float4(float4 p0) { return log10(p0); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) float {{.*}}test_log10_double
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.log10.f32(
+float test_log10_double(double p0) { return log10(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <2 x float> {{.*}}test_log10_double2
+// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.log10.v2f32
+float2 test_log10_double2(double2 p0) { return log10(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <3 x float> {{.*}}test_log10_double3
+// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.log10.v3f32
+float3 test_log10_double3(double3 p0) { return log10(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_log10_double4
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log10.v4f32
+float4 test_log10_double4(double4 p0) { return log10(p0); }

--- a/clang/test/CodeGenHLSL/builtins/log2.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/log2.hlsl
@@ -38,3 +38,16 @@ float3 test_log2_float3(float3 p0) { return log2(p0); }
 // CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> @_Z16test_log2_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log2.v4f32
 float4 test_log2_float4(float4 p0) { return log2(p0); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) float {{.*}}test_log2_double
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.log2.f32(
+float test_log2_double(double p0) { return log2(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <2 x float> {{.*}}test_log2_double2
+// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.log2.v2f32
+float2 test_log2_double2(double2 p0) { return log2(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <3 x float> {{.*}}test_log2_double3
+// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.log2.v3f32
+float3 test_log2_double3(double3 p0) { return log2(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_log2_double4
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.log2.v4f32
+float4 test_log2_double4(double4 p0) { return log2(p0); }

--- a/clang/test/CodeGenHLSL/builtins/normalize.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/normalize.hlsl
@@ -83,3 +83,33 @@ float4 test_length_float4(float4 p0)
 {
     return normalize(p0);
 }
+
+// CHECK: define [[FNATTRS]] float @
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].normalize.f32(float
+// CHECK: ret float
+float test_normalize_double(double p0)
+{
+    return normalize(p0);
+}
+// CHECK: define [[FNATTRS]] <2 x float> @
+// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].normalize.v2f32(<2 x float>
+
+// CHECK: ret <2 x float> %hlsl.normalize
+float2 test_normalize_double2(double2 p0)
+{
+    return normalize(p0);
+}
+// CHECK: define [[FNATTRS]] <3 x float> @
+// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].normalize.v3f32(
+// CHECK: ret <3 x float> %hlsl.normalize
+float3 test_normalize_double3(double3 p0)
+{
+    return normalize(p0);
+}
+// CHECK: define [[FNATTRS]] <4 x float> @
+// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].normalize.v4f32(
+// CHECK: ret <4 x float> %hlsl.normalize
+float4 test_length_double4(double4 p0)
+{
+    return normalize(p0);
+}

--- a/clang/test/CodeGenHLSL/builtins/pow.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/pow.hlsl
@@ -38,3 +38,16 @@ float3 test_pow_float3(float3 p0, float3 p1) { return pow(p0, p1); }
 // CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> @_Z15test_pow_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.pow.v4f32
 float4 test_pow_float4(float4 p0, float4 p1) { return pow(p0, p1); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) float {{.*}}test_pow_double
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.pow.f32(
+float test_pow_double(double p0, double p1) { return pow(p0, p1); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <2 x float> {{.*}}test_pow_double2
+// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.pow.v2f32
+float2 test_pow_double2(double2 p0, double2 p1) { return pow(p0, p1); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <3 x float> {{.*}}test_pow_double3
+// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.pow.v3f32
+float3 test_pow_double3(double3 p0, double3 p1) { return pow(p0, p1); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_pow_double4
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.pow.v4f32
+float4 test_pow_double4(double4 p0, double4 p1) { return pow(p0, p1); }

--- a/clang/test/CodeGenHLSL/builtins/radians.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/radians.hlsl
@@ -64,3 +64,19 @@ float3 test_radians_float3(float3 p0) { return radians(p0); }
 // CHECK: ret <4 x float> %{{.*}}
 float4 test_radians_float4(float4 p0) { return radians(p0); }
 
+// CHECK: define [[FNATTRS]] float @
+// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].radians.f32(
+// CHECK: ret float %{{.*}}
+float test_radians_double(double p0) { return radians(p0); }
+// CHECK: define [[FNATTRS]] <2 x float> @
+// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].radians.v2f32
+// CHECK: ret <2 x float> %{{.*}}
+float2 test_radians_double2(double2 p0) { return radians(p0); }
+// CHECK: define [[FNATTRS]] <3 x float> @
+// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].radians.v3f32
+// CHECK: ret <3 x float> %{{.*}}
+float3 test_radians_double3(double3 p0) { return radians(p0); }
+// CHECK: define [[FNATTRS]] <4 x float> @
+// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].radians.v4f32
+// CHECK: ret <4 x float> %{{.*}}
+float4 test_radians_double4(double4 p0) { return radians(p0); }

--- a/clang/test/CodeGenHLSL/builtins/round.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/round.hlsl
@@ -50,3 +50,20 @@ float3 test_round_float3(float3 p0) { return round(p0); }
 // CHECK: %elt.roundeven = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
 // CHECK: ret <4 x float> %elt.roundeven
 float4 test_round_float4(float4 p0) { return round(p0); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) float {{.*}}test_round_double
+// CHECK: %elt.roundeven = call reassoc nnan ninf nsz arcp afn float @llvm.roundeven.f32(
+// CHECK: ret float %elt.roundeven
+float test_round_double(double p0) { return round(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <2 x float> {{.*}}test_round_double2
+// CHECK: %elt.roundeven = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.roundeven.v2f32
+// CHECK: ret <2 x float> %elt.roundeven
+float2 test_round_double2(double2 p0) { return round(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <3 x float> {{.*}}test_round_double3
+// CHECK: %elt.roundeven = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.roundeven.v3f32
+// CHECK: ret <3 x float> %elt.roundeven
+float3 test_round_double3(double3 p0) { return round(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_round_double4
+// CHECK: %elt.roundeven = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.roundeven.v4f32
+// CHECK: ret <4 x float> %elt.roundeven
+float4 test_round_double4(double4 p0) { return round(p0); }

--- a/clang/test/CodeGenHLSL/builtins/rsqrt.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/rsqrt.hlsl
@@ -62,3 +62,20 @@ float3 test_rsqrt_float3(float3 p0) { return rsqrt(p0); }
 // CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].rsqrt.v4f32
 // CHECK: ret <4 x float> %hlsl.rsqrt
 float4 test_rsqrt_float4(float4 p0) { return rsqrt(p0); }
+
+// CHECK: define [[FNATTRS]] float @
+// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].rsqrt.f32(
+// CHECK: ret float %hlsl.rsqrt
+float test_rsqrt_double(double p0) { return rsqrt(p0); }
+// CHECK: define [[FNATTRS]] <2 x float> @
+// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].rsqrt.v2f32
+// CHECK: ret <2 x float> %hlsl.rsqrt
+float2 test_rsqrt_double2(double2 p0) { return rsqrt(p0); }
+// CHECK: define [[FNATTRS]] <3 x float> @
+// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].rsqrt.v3f32
+// CHECK: ret <3 x float> %hlsl.rsqrt
+float3 test_rsqrt_double3(double3 p0) { return rsqrt(p0); }
+// CHECK: define [[FNATTRS]] <4 x float> @
+// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].rsqrt.v4f32
+// CHECK: ret <4 x float> %hlsl.rsqrt
+float4 test_rsqrt_double4(double4 p0) { return rsqrt(p0); }

--- a/clang/test/CodeGenHLSL/builtins/sin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/sin.hlsl
@@ -38,3 +38,16 @@ float3 test_sin_float3(float3 p0) { return sin(p0); }
 // CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> @_Z15test_sin_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.sin.v4f32
 float4 test_sin_float4(float4 p0) { return sin(p0); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) float {{.*}}test_sin_double
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.sin.f32(
+float test_sin_double(double p0) { return sin(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <2 x float> {{.*}}test_sin_double2
+// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.sin.v2f32
+float2 test_sin_double2(double2 p0) { return sin(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <3 x float> {{.*}}test_sin_double3
+// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.sin.v3f32
+float3 test_sin_double3(double3 p0) { return sin(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_sin_double4
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.sin.v4f32
+float4 test_sin_double4(double4 p0) { return sin(p0); }

--- a/clang/test/CodeGenHLSL/builtins/sinh.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/sinh.hlsl
@@ -57,3 +57,27 @@ float3 test_sinh_float3 ( float3 p0 ) {
 float4 test_sinh_float4 ( float4 p0 ) {
   return sinh ( p0 );
 }
+
+// CHECK-LABEL: test_sinh_double
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.sinh.f32
+float test_sinh_double ( double p0 ) {
+  return sinh ( p0 );
+}
+
+// CHECK-LABEL: test_sinh_double2
+// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.sinh.v2f32
+float2 test_sinh_double2 ( double2 p0 ) {
+  return sinh ( p0 );
+}
+
+// CHECK-LABEL: test_sinh_double3
+// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.sinh.v3f32
+float3 test_sinh_double3 ( double3 p0 ) {
+  return sinh ( p0 );
+}
+
+// CHECK-LABEL: test_sinh_double4
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.sinh.v4f32
+float4 test_sinh_double4 ( double4 p0 ) {
+  return sinh ( p0 );
+}

--- a/clang/test/CodeGenHLSL/builtins/sqrt.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/sqrt.hlsl
@@ -50,3 +50,20 @@ float3 test_sqrt_float3(float3 p0) { return sqrt(p0); }
 // CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.sqrt.v4f32
 // CHECK: ret <4 x float> %{{.*}}
 float4 test_sqrt_float4(float4 p0) { return sqrt(p0); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) float {{.*}}test_sqrt_double
+// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn float @llvm.sqrt.f32(
+// CHECK: ret float %{{.*}}
+float test_sqrt_double(double p0) { return sqrt(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <2 x float> {{.*}}test_sqrt_double2
+// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.sqrt.v2f32
+// CHECK: ret <2 x float> %{{.*}}
+float2 test_sqrt_double2(double2 p0) { return sqrt(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <3 x float> {{.*}}test_sqrt_double3
+// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.sqrt.v3f32
+// CHECK: ret <3 x float> %{{.*}}
+float3 test_sqrt_double3(double3 p0) { return sqrt(p0); }
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_sqrt_double4
+// CHECK: %{{.*}} = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.sqrt.v4f32
+// CHECK: ret <4 x float> %{{.*}}
+float4 test_sqrt_double4(double4 p0) { return sqrt(p0); }

--- a/clang/test/CodeGenHLSL/builtins/step.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/step.hlsl
@@ -82,3 +82,32 @@ float4 test_step_float4(float4 p0, float4 p1)
 {
     return step(p0, p1);
 }
+
+// CHECK: define [[FNATTRS]] float @
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.[[TARGET]].step.f32(float
+// CHECK: ret float
+float test_step_double(double p0, double p1)
+{
+    return step(p0, p1);
+}
+// CHECK: define [[FNATTRS]] <2 x float> @
+// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.[[TARGET]].step.v2f32(
+// CHECK: ret <2 x float> %hlsl.step
+float2 test_step_double2(double2 p0, double2 p1)
+{
+    return step(p0, p1);
+}
+// CHECK: define [[FNATTRS]] <3 x float> @
+// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.[[TARGET]].step.v3f32(
+// CHECK: ret <3 x float> %hlsl.step
+float3 test_step_double3(double3 p0, double3 p1)
+{
+    return step(p0, p1);
+}
+// CHECK: define [[FNATTRS]] <4 x float> @
+// CHECK: %hlsl.step = call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.[[TARGET]].step.v4f32(
+// CHECK: ret <4 x float> %hlsl.step
+float4 test_step_double4(double4 p0, double4 p1)
+{
+    return step(p0, p1);
+}

--- a/clang/test/CodeGenHLSL/builtins/tan.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/tan.hlsl
@@ -57,3 +57,27 @@ float3 test_tan_float3 ( float3 p0 ) {
 float4 test_tan_float4 ( float4 p0 ) {
   return tan ( p0 );
 }
+
+// CHECK-LABEL: test_tan_double
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.tan.f32
+float test_tan_double ( double p0 ) {
+  return tan ( p0 );
+}
+
+// CHECK-LABEL: test_tan_double2
+// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.tan.v2f32
+float2 test_tan_double2 ( double2 p0 ) {
+  return tan ( p0 );
+}
+
+// CHECK-LABEL: test_tan_double3
+// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.tan.v3f32
+float3 test_tan_double3 ( double3 p0 ) {
+  return tan ( p0 );
+}
+
+// CHECK-LABEL: test_tan_double4
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.tan.v4f32
+float4 test_tan_double4 ( double4 p0 ) {
+  return tan ( p0 );
+}

--- a/clang/test/CodeGenHLSL/builtins/tanh.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/tanh.hlsl
@@ -57,3 +57,27 @@ float3 test_tanh_float3 ( float3 p0 ) {
 float4 test_tanh_float4 ( float4 p0 ) {
   return tanh ( p0 );
 }
+
+// CHECK-LABEL: test_tanh_double
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.tanh.f32
+float test_tanh_double ( double p0 ) {
+  return tanh ( p0 );
+}
+
+// CHECK-LABEL: test_tanh_double2
+// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.tanh.v2f32
+float2 test_tanh_double2 ( double2 p0 ) {
+  return tanh ( p0 );
+}
+
+// CHECK-LABEL: test_tanh_double3
+// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.tanh.v3f32
+float3 test_tanh_double3 ( double3 p0 ) {
+  return tanh ( p0 );
+}
+
+// CHECK-LABEL: test_tanh_double4
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.tanh.v4f32
+float4 test_tanh_double4 ( double4 p0 ) {
+  return tanh ( p0 );
+}

--- a/clang/test/CodeGenHLSL/builtins/trunc.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/trunc.hlsl
@@ -44,3 +44,19 @@ float3 test_trunc_float3(float3 p0) { return trunc(p0); }
 // CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> @_Z17test_trunc_float4
 // CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.trunc.v4f32
 float4 test_trunc_float4(float4 p0) { return trunc(p0); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) float {{.*}}test_trunc_double
+// CHECK: call reassoc nnan ninf nsz arcp afn float @llvm.trunc.f32(
+float test_trunc_double(double p0) { return trunc(p0); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) <2 x float> {{.*}}test_trunc_double2
+// CHECK: call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.trunc.v2f32
+float2 test_trunc_double2(double2 p0) { return trunc(p0); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) <3 x float> {{.*}}test_trunc_double3
+// CHECK: call reassoc nnan ninf nsz arcp afn <3 x float> @llvm.trunc.v3f32
+float3 test_trunc_double3(double3 p0) { return trunc(p0); }
+
+// CHECK-LABEL: define noundef nofpclass(nan inf) <4 x float> {{.*}}test_trunc_double4
+// CHECK: call reassoc nnan ninf nsz arcp afn <4 x float> @llvm.trunc.v4f32
+float4 test_trunc_double4(double4 p0) { return trunc(p0); }


### PR DESCRIPTION
Add double overloads which cast the double to a float and call the float builtin.
Makes these double overloads conditional on hlsl version 202x or earlier.
Add tests
Closes #128228 