### PR TITLE
[RISCV] Canonicalize foldable branch conditions in optimizeCondBranch

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -998,6 +998,26 @@ static RISCVCC::CondCode getCondFromBranchOpc(unsigned Opc) {
   }
 }
 
+
+static bool evaluateCondBranch(unsigned CC, int64_t C0, int64_t C1) {
+  switch (CC) {
+  default:
+    llvm_unreachable("Unexpected CC");
+  case RISCVCC::COND_EQ:
+    return C0 == C1;
+  case RISCVCC::COND_NE:
+    return C0 != C1;
+  case RISCVCC::COND_LT:
+    return C0 < C1;
+  case RISCVCC::COND_GE:
+    return C0 >= C1;
+  case RISCVCC::COND_LTU:
+    return (uint64_t)C0 < (uint64_t)C1;
+  case RISCVCC::COND_GEU:
+    return (uint64_t)C0 >= (uint64_t)C1;
+  }
+}
+
 // The contents of values added to Cond are not examined outside of
 // RISCVInstrInfo, giving us flexibility in what to push to it. For RISCV, we
 // push BranchOpcode, Reg1, Reg2.
@@ -1295,6 +1315,49 @@ bool RISCVInstrInfo::optimizeCondBranch(MachineInstr &MI) const {
   RISCVCC::CondCode CC = static_cast<RISCVCC::CondCode>(Cond[0].getImm());
   assert(CC != RISCVCC::COND_INVALID);
 
+  auto modifyBranch = [&]() {
+    // Build the new branch and remove the old one.
+    BuildMI(*MBB, MI, MI.getDebugLoc(),
+            getBrCond(static_cast<RISCVCC::CondCode>(Cond[0].getImm())))
+        .add(Cond[1])
+        .add(Cond[2])
+        .addMBB(TBB);
+    MI.eraseFromParent();
+  };
+
+  // Right now we only care about LI (i.e. ADDI x0, imm)
+  auto isLoadImm = [](const MachineInstr *MI, int64_t &Imm) -> bool {
+    if (MI->getOpcode() == RISCV::ADDI && MI->getOperand(1).isReg() &&
+        MI->getOperand(1).getReg() == RISCV::X0) {
+      Imm = MI->getOperand(2).getImm();
+      return true;
+    }
+    return false;
+  };
+  // Either a load from immediate instruction or X0.
+  auto isFromLoadImm = [&](const MachineOperand &Op, int64_t &Imm) -> bool {
+    if (!Op.isReg())
+      return false;
+    Register Reg = Op.getReg();
+    if (Reg == RISCV::X0) {
+      Imm = 0;
+      return true;
+    }
+    return Reg.isVirtual() && isLoadImm(MRI.getVRegDef(Reg), Imm);
+  };
+
+  // Canonicalize conditional branches which can be constant folded into
+  // beqz or bnez.  We can't modify the CFG here.
+  int64_t C0, C1;
+  if (isFromLoadImm(Cond[1], C0) && isFromLoadImm(Cond[2], C1)) {
+    unsigned NewCC =
+      evaluateCondBranch(CC, C0, C1) ? RISCVCC::COND_EQ : RISCVCC::COND_NE;
+    Cond[0] = MachineOperand::CreateImm(NewCC);
+    Cond[1] = Cond[2] = MachineOperand::CreateReg(RISCV::X0, /*isDef=*/false);
+    modifyBranch();
+    return true;
+  }
+
   if (CC == RISCVCC::COND_EQ || CC == RISCVCC::COND_NE)
     return false;
 
@@ -1315,24 +1378,6 @@ bool RISCVInstrInfo::optimizeCondBranch(MachineInstr &MI) const {
   //
   // To make sure this optimization is really beneficial, we only
   // optimize for cases where Y had only one use (i.e. only used by the branch).
-
-  // Right now we only care about LI (i.e. ADDI x0, imm)
-  auto isLoadImm = [](const MachineInstr *MI, int64_t &Imm) -> bool {
-    if (MI->getOpcode() == RISCV::ADDI && MI->getOperand(1).isReg() &&
-        MI->getOperand(1).getReg() == RISCV::X0) {
-      Imm = MI->getOperand(2).getImm();
-      return true;
-    }
-    return false;
-  };
-  // Either a load from immediate instruction or X0.
-  auto isFromLoadImm = [&](const MachineOperand &Op, int64_t &Imm) -> bool {
-    if (!Op.isReg())
-      return false;
-    Register Reg = Op.getReg();
-    return Reg.isVirtual() && isLoadImm(MRI.getVRegDef(Reg), Imm);
-  };
-
   MachineOperand &LHS = MI.getOperand(0);
   MachineOperand &RHS = MI.getOperand(1);
   // Try to find the register for constant Z; return
@@ -1350,8 +1395,6 @@ bool RISCVInstrInfo::optimizeCondBranch(MachineInstr &MI) const {
     return Register();
   };
 
-  bool Modify = false;
-  int64_t C0;
   if (isFromLoadImm(LHS, C0) && MRI.hasOneUse(LHS.getReg())) {
     // Might be case 1.
     // Signed integer overflow is UB. (UINT64_MAX is bigger so we don't need
@@ -1364,7 +1407,8 @@ bool RISCVInstrInfo::optimizeCondBranch(MachineInstr &MI) const {
         // We might extend the live range of Z, clear its kill flag to
         // account for this.
         MRI.clearKillFlags(RegZ);
-        Modify = true;
+        modifyBranch();
+        return true;
       }
   } else if (isFromLoadImm(RHS, C0) && MRI.hasOneUse(RHS.getReg())) {
     // Might be case 2.
@@ -1378,22 +1422,12 @@ bool RISCVInstrInfo::optimizeCondBranch(MachineInstr &MI) const {
         // We might extend the live range of Z, clear its kill flag to
         // account for this.
         MRI.clearKillFlags(RegZ);
-        Modify = true;
+        modifyBranch();
+        return true;
       }
   }
 
-  if (!Modify)
-    return false;
-
-  // Build the new branch and remove the old one.
-  BuildMI(*MBB, MI, MI.getDebugLoc(),
-          getBrCond(static_cast<RISCVCC::CondCode>(Cond[0].getImm())))
-      .add(Cond[1])
-      .add(Cond[2])
-      .addMBB(TBB);
-  MI.eraseFromParent();
-
-  return true;
+  return false;
 }
 
 MachineBasicBlock *

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -998,7 +998,6 @@ static RISCVCC::CondCode getCondFromBranchOpc(unsigned Opc) {
   }
 }
 
-
 static bool evaluateCondBranch(unsigned CC, int64_t C0, int64_t C1) {
   switch (CC) {
   default:
@@ -1351,7 +1350,7 @@ bool RISCVInstrInfo::optimizeCondBranch(MachineInstr &MI) const {
   int64_t C0, C1;
   if (isFromLoadImm(Cond[1], C0) && isFromLoadImm(Cond[2], C1)) {
     unsigned NewCC =
-      evaluateCondBranch(CC, C0, C1) ? RISCVCC::COND_EQ : RISCVCC::COND_NE;
+        evaluateCondBranch(CC, C0, C1) ? RISCVCC::COND_EQ : RISCVCC::COND_NE;
     Cond[0] = MachineOperand::CreateImm(NewCC);
     Cond[1] = Cond[2] = MachineOperand::CreateReg(RISCV::X0, /*isDef=*/false);
     modifyBranch();

--- a/llvm/test/CodeGen/RISCV/bfloat-br-fcmp.ll
+++ b/llvm/test/CodeGen/RISCV/bfloat-br-fcmp.ll
@@ -11,8 +11,7 @@ declare bfloat @dummy(bfloat)
 define void @br_fcmp_false(bfloat %a, bfloat %b) nounwind {
 ; RV32IZFBFMIN-LABEL: br_fcmp_false:
 ; RV32IZFBFMIN:       # %bb.0:
-; RV32IZFBFMIN-NEXT:    li a0, 1
-; RV32IZFBFMIN-NEXT:    bnez a0, .LBB0_2
+; RV32IZFBFMIN-NEXT:    beqz zero, .LBB0_2
 ; RV32IZFBFMIN-NEXT:  # %bb.1: # %if.then
 ; RV32IZFBFMIN-NEXT:    ret
 ; RV32IZFBFMIN-NEXT:  .LBB0_2: # %if.else
@@ -22,8 +21,7 @@ define void @br_fcmp_false(bfloat %a, bfloat %b) nounwind {
 ;
 ; RV64IZFBFMIN-LABEL: br_fcmp_false:
 ; RV64IZFBFMIN:       # %bb.0:
-; RV64IZFBFMIN-NEXT:    li a0, 1
-; RV64IZFBFMIN-NEXT:    bnez a0, .LBB0_2
+; RV64IZFBFMIN-NEXT:    beqz zero, .LBB0_2
 ; RV64IZFBFMIN-NEXT:  # %bb.1: # %if.then
 ; RV64IZFBFMIN-NEXT:    ret
 ; RV64IZFBFMIN-NEXT:  .LBB0_2: # %if.else
@@ -583,8 +581,7 @@ if.then:
 define void @br_fcmp_true(bfloat %a, bfloat %b) nounwind {
 ; RV32IZFBFMIN-LABEL: br_fcmp_true:
 ; RV32IZFBFMIN:       # %bb.0:
-; RV32IZFBFMIN-NEXT:    li a0, 1
-; RV32IZFBFMIN-NEXT:    bnez a0, .LBB16_2
+; RV32IZFBFMIN-NEXT:    beqz zero, .LBB16_2
 ; RV32IZFBFMIN-NEXT:  # %bb.1: # %if.else
 ; RV32IZFBFMIN-NEXT:    ret
 ; RV32IZFBFMIN-NEXT:  .LBB16_2: # %if.then
@@ -594,8 +591,7 @@ define void @br_fcmp_true(bfloat %a, bfloat %b) nounwind {
 ;
 ; RV64IZFBFMIN-LABEL: br_fcmp_true:
 ; RV64IZFBFMIN:       # %bb.0:
-; RV64IZFBFMIN-NEXT:    li a0, 1
-; RV64IZFBFMIN-NEXT:    bnez a0, .LBB16_2
+; RV64IZFBFMIN-NEXT:    beqz zero, .LBB16_2
 ; RV64IZFBFMIN-NEXT:  # %bb.1: # %if.else
 ; RV64IZFBFMIN-NEXT:    ret
 ; RV64IZFBFMIN-NEXT:  .LBB16_2: # %if.then

--- a/llvm/test/CodeGen/RISCV/double-br-fcmp.ll
+++ b/llvm/test/CodeGen/RISCV/double-br-fcmp.ll
@@ -14,8 +14,7 @@ declare void @exit(i32)
 define void @br_fcmp_false(double %a, double %b) nounwind {
 ; RV32IFD-LABEL: br_fcmp_false:
 ; RV32IFD:       # %bb.0:
-; RV32IFD-NEXT:    li a0, 1
-; RV32IFD-NEXT:    bnez a0, .LBB0_2
+; RV32IFD-NEXT:    beqz zero, .LBB0_2
 ; RV32IFD-NEXT:  # %bb.1: # %if.then
 ; RV32IFD-NEXT:    ret
 ; RV32IFD-NEXT:  .LBB0_2: # %if.else
@@ -25,8 +24,7 @@ define void @br_fcmp_false(double %a, double %b) nounwind {
 ;
 ; RV64IFD-LABEL: br_fcmp_false:
 ; RV64IFD:       # %bb.0:
-; RV64IFD-NEXT:    li a0, 1
-; RV64IFD-NEXT:    bnez a0, .LBB0_2
+; RV64IFD-NEXT:    beqz zero, .LBB0_2
 ; RV64IFD-NEXT:  # %bb.1: # %if.then
 ; RV64IFD-NEXT:    ret
 ; RV64IFD-NEXT:  .LBB0_2: # %if.else
@@ -36,8 +34,7 @@ define void @br_fcmp_false(double %a, double %b) nounwind {
 ;
 ; RV32IZFINXZDINX-LABEL: br_fcmp_false:
 ; RV32IZFINXZDINX:       # %bb.0:
-; RV32IZFINXZDINX-NEXT:    li a0, 1
-; RV32IZFINXZDINX-NEXT:    bnez a0, .LBB0_2
+; RV32IZFINXZDINX-NEXT:    beqz zero, .LBB0_2
 ; RV32IZFINXZDINX-NEXT:  # %bb.1: # %if.then
 ; RV32IZFINXZDINX-NEXT:    ret
 ; RV32IZFINXZDINX-NEXT:  .LBB0_2: # %if.else
@@ -47,8 +44,7 @@ define void @br_fcmp_false(double %a, double %b) nounwind {
 ;
 ; RV64IZFINXZDINX-LABEL: br_fcmp_false:
 ; RV64IZFINXZDINX:       # %bb.0:
-; RV64IZFINXZDINX-NEXT:    li a0, 1
-; RV64IZFINXZDINX-NEXT:    bnez a0, .LBB0_2
+; RV64IZFINXZDINX-NEXT:    beqz zero, .LBB0_2
 ; RV64IZFINXZDINX-NEXT:  # %bb.1: # %if.then
 ; RV64IZFINXZDINX-NEXT:    ret
 ; RV64IZFINXZDINX-NEXT:  .LBB0_2: # %if.else
@@ -897,8 +893,7 @@ if.then:
 define void @br_fcmp_true(double %a, double %b) nounwind {
 ; RV32IFD-LABEL: br_fcmp_true:
 ; RV32IFD:       # %bb.0:
-; RV32IFD-NEXT:    li a0, 1
-; RV32IFD-NEXT:    bnez a0, .LBB16_2
+; RV32IFD-NEXT:    beqz zero, .LBB16_2
 ; RV32IFD-NEXT:  # %bb.1: # %if.else
 ; RV32IFD-NEXT:    ret
 ; RV32IFD-NEXT:  .LBB16_2: # %if.then
@@ -908,8 +903,7 @@ define void @br_fcmp_true(double %a, double %b) nounwind {
 ;
 ; RV64IFD-LABEL: br_fcmp_true:
 ; RV64IFD:       # %bb.0:
-; RV64IFD-NEXT:    li a0, 1
-; RV64IFD-NEXT:    bnez a0, .LBB16_2
+; RV64IFD-NEXT:    beqz zero, .LBB16_2
 ; RV64IFD-NEXT:  # %bb.1: # %if.else
 ; RV64IFD-NEXT:    ret
 ; RV64IFD-NEXT:  .LBB16_2: # %if.then
@@ -919,8 +913,7 @@ define void @br_fcmp_true(double %a, double %b) nounwind {
 ;
 ; RV32IZFINXZDINX-LABEL: br_fcmp_true:
 ; RV32IZFINXZDINX:       # %bb.0:
-; RV32IZFINXZDINX-NEXT:    li a0, 1
-; RV32IZFINXZDINX-NEXT:    bnez a0, .LBB16_2
+; RV32IZFINXZDINX-NEXT:    beqz zero, .LBB16_2
 ; RV32IZFINXZDINX-NEXT:  # %bb.1: # %if.else
 ; RV32IZFINXZDINX-NEXT:    ret
 ; RV32IZFINXZDINX-NEXT:  .LBB16_2: # %if.then
@@ -930,8 +923,7 @@ define void @br_fcmp_true(double %a, double %b) nounwind {
 ;
 ; RV64IZFINXZDINX-LABEL: br_fcmp_true:
 ; RV64IZFINXZDINX:       # %bb.0:
-; RV64IZFINXZDINX-NEXT:    li a0, 1
-; RV64IZFINXZDINX-NEXT:    bnez a0, .LBB16_2
+; RV64IZFINXZDINX-NEXT:    beqz zero, .LBB16_2
 ; RV64IZFINXZDINX-NEXT:  # %bb.1: # %if.else
 ; RV64IZFINXZDINX-NEXT:    ret
 ; RV64IZFINXZDINX-NEXT:  .LBB16_2: # %if.then

--- a/llvm/test/CodeGen/RISCV/float-br-fcmp.ll
+++ b/llvm/test/CodeGen/RISCV/float-br-fcmp.ll
@@ -15,8 +15,7 @@ declare float @dummy(float)
 define void @br_fcmp_false(float %a, float %b) nounwind {
 ; RV32IF-LABEL: br_fcmp_false:
 ; RV32IF:       # %bb.0:
-; RV32IF-NEXT:    li a0, 1
-; RV32IF-NEXT:    bnez a0, .LBB0_2
+; RV32IF-NEXT:    beqz zero, .LBB0_2
 ; RV32IF-NEXT:  # %bb.1: # %if.then
 ; RV32IF-NEXT:    ret
 ; RV32IF-NEXT:  .LBB0_2: # %if.else
@@ -26,8 +25,7 @@ define void @br_fcmp_false(float %a, float %b) nounwind {
 ;
 ; RV64IF-LABEL: br_fcmp_false:
 ; RV64IF:       # %bb.0:
-; RV64IF-NEXT:    li a0, 1
-; RV64IF-NEXT:    bnez a0, .LBB0_2
+; RV64IF-NEXT:    beqz zero, .LBB0_2
 ; RV64IF-NEXT:  # %bb.1: # %if.then
 ; RV64IF-NEXT:    ret
 ; RV64IF-NEXT:  .LBB0_2: # %if.else
@@ -37,8 +35,7 @@ define void @br_fcmp_false(float %a, float %b) nounwind {
 ;
 ; RV32IZFINX-LABEL: br_fcmp_false:
 ; RV32IZFINX:       # %bb.0:
-; RV32IZFINX-NEXT:    li a0, 1
-; RV32IZFINX-NEXT:    bnez a0, .LBB0_2
+; RV32IZFINX-NEXT:    beqz zero, .LBB0_2
 ; RV32IZFINX-NEXT:  # %bb.1: # %if.then
 ; RV32IZFINX-NEXT:    ret
 ; RV32IZFINX-NEXT:  .LBB0_2: # %if.else
@@ -48,8 +45,7 @@ define void @br_fcmp_false(float %a, float %b) nounwind {
 ;
 ; RV64IZFINX-LABEL: br_fcmp_false:
 ; RV64IZFINX:       # %bb.0:
-; RV64IZFINX-NEXT:    li a0, 1
-; RV64IZFINX-NEXT:    bnez a0, .LBB0_2
+; RV64IZFINX-NEXT:    beqz zero, .LBB0_2
 ; RV64IZFINX-NEXT:  # %bb.1: # %if.then
 ; RV64IZFINX-NEXT:    ret
 ; RV64IZFINX-NEXT:  .LBB0_2: # %if.else
@@ -898,8 +894,7 @@ if.then:
 define void @br_fcmp_true(float %a, float %b) nounwind {
 ; RV32IF-LABEL: br_fcmp_true:
 ; RV32IF:       # %bb.0:
-; RV32IF-NEXT:    li a0, 1
-; RV32IF-NEXT:    bnez a0, .LBB16_2
+; RV32IF-NEXT:    beqz zero, .LBB16_2
 ; RV32IF-NEXT:  # %bb.1: # %if.else
 ; RV32IF-NEXT:    ret
 ; RV32IF-NEXT:  .LBB16_2: # %if.then
@@ -909,8 +904,7 @@ define void @br_fcmp_true(float %a, float %b) nounwind {
 ;
 ; RV64IF-LABEL: br_fcmp_true:
 ; RV64IF:       # %bb.0:
-; RV64IF-NEXT:    li a0, 1
-; RV64IF-NEXT:    bnez a0, .LBB16_2
+; RV64IF-NEXT:    beqz zero, .LBB16_2
 ; RV64IF-NEXT:  # %bb.1: # %if.else
 ; RV64IF-NEXT:    ret
 ; RV64IF-NEXT:  .LBB16_2: # %if.then
@@ -920,8 +914,7 @@ define void @br_fcmp_true(float %a, float %b) nounwind {
 ;
 ; RV32IZFINX-LABEL: br_fcmp_true:
 ; RV32IZFINX:       # %bb.0:
-; RV32IZFINX-NEXT:    li a0, 1
-; RV32IZFINX-NEXT:    bnez a0, .LBB16_2
+; RV32IZFINX-NEXT:    beqz zero, .LBB16_2
 ; RV32IZFINX-NEXT:  # %bb.1: # %if.else
 ; RV32IZFINX-NEXT:    ret
 ; RV32IZFINX-NEXT:  .LBB16_2: # %if.then
@@ -931,8 +924,7 @@ define void @br_fcmp_true(float %a, float %b) nounwind {
 ;
 ; RV64IZFINX-LABEL: br_fcmp_true:
 ; RV64IZFINX:       # %bb.0:
-; RV64IZFINX-NEXT:    li a0, 1
-; RV64IZFINX-NEXT:    bnez a0, .LBB16_2
+; RV64IZFINX-NEXT:    beqz zero, .LBB16_2
 ; RV64IZFINX-NEXT:  # %bb.1: # %if.else
 ; RV64IZFINX-NEXT:    ret
 ; RV64IZFINX-NEXT:  .LBB16_2: # %if.then

--- a/llvm/test/CodeGen/RISCV/half-br-fcmp.ll
+++ b/llvm/test/CodeGen/RISCV/half-br-fcmp.ll
@@ -23,8 +23,7 @@ declare half @dummy(half)
 define void @br_fcmp_false(half %a, half %b) nounwind {
 ; RV32IZFH-LABEL: br_fcmp_false:
 ; RV32IZFH:       # %bb.0:
-; RV32IZFH-NEXT:    li a0, 1
-; RV32IZFH-NEXT:    bnez a0, .LBB0_2
+; RV32IZFH-NEXT:    beqz zero, .LBB0_2
 ; RV32IZFH-NEXT:  # %bb.1: # %if.then
 ; RV32IZFH-NEXT:    ret
 ; RV32IZFH-NEXT:  .LBB0_2: # %if.else
@@ -34,8 +33,7 @@ define void @br_fcmp_false(half %a, half %b) nounwind {
 ;
 ; RV64IZFH-LABEL: br_fcmp_false:
 ; RV64IZFH:       # %bb.0:
-; RV64IZFH-NEXT:    li a0, 1
-; RV64IZFH-NEXT:    bnez a0, .LBB0_2
+; RV64IZFH-NEXT:    beqz zero, .LBB0_2
 ; RV64IZFH-NEXT:  # %bb.1: # %if.then
 ; RV64IZFH-NEXT:    ret
 ; RV64IZFH-NEXT:  .LBB0_2: # %if.else
@@ -45,8 +43,7 @@ define void @br_fcmp_false(half %a, half %b) nounwind {
 ;
 ; RV32IZHINX-LABEL: br_fcmp_false:
 ; RV32IZHINX:       # %bb.0:
-; RV32IZHINX-NEXT:    li a0, 1
-; RV32IZHINX-NEXT:    bnez a0, .LBB0_2
+; RV32IZHINX-NEXT:    beqz zero, .LBB0_2
 ; RV32IZHINX-NEXT:  # %bb.1: # %if.then
 ; RV32IZHINX-NEXT:    ret
 ; RV32IZHINX-NEXT:  .LBB0_2: # %if.else
@@ -56,8 +53,7 @@ define void @br_fcmp_false(half %a, half %b) nounwind {
 ;
 ; RV64IZHINX-LABEL: br_fcmp_false:
 ; RV64IZHINX:       # %bb.0:
-; RV64IZHINX-NEXT:    li a0, 1
-; RV64IZHINX-NEXT:    bnez a0, .LBB0_2
+; RV64IZHINX-NEXT:    beqz zero, .LBB0_2
 ; RV64IZHINX-NEXT:  # %bb.1: # %if.then
 ; RV64IZHINX-NEXT:    ret
 ; RV64IZHINX-NEXT:  .LBB0_2: # %if.else
@@ -67,8 +63,7 @@ define void @br_fcmp_false(half %a, half %b) nounwind {
 ;
 ; RV32IZFHMIN-LABEL: br_fcmp_false:
 ; RV32IZFHMIN:       # %bb.0:
-; RV32IZFHMIN-NEXT:    li a0, 1
-; RV32IZFHMIN-NEXT:    bnez a0, .LBB0_2
+; RV32IZFHMIN-NEXT:    beqz zero, .LBB0_2
 ; RV32IZFHMIN-NEXT:  # %bb.1: # %if.then
 ; RV32IZFHMIN-NEXT:    ret
 ; RV32IZFHMIN-NEXT:  .LBB0_2: # %if.else
@@ -78,8 +73,7 @@ define void @br_fcmp_false(half %a, half %b) nounwind {
 ;
 ; RV64IZFHMIN-LABEL: br_fcmp_false:
 ; RV64IZFHMIN:       # %bb.0:
-; RV64IZFHMIN-NEXT:    li a0, 1
-; RV64IZFHMIN-NEXT:    bnez a0, .LBB0_2
+; RV64IZFHMIN-NEXT:    beqz zero, .LBB0_2
 ; RV64IZFHMIN-NEXT:  # %bb.1: # %if.then
 ; RV64IZFHMIN-NEXT:    ret
 ; RV64IZFHMIN-NEXT:  .LBB0_2: # %if.else
@@ -89,8 +83,7 @@ define void @br_fcmp_false(half %a, half %b) nounwind {
 ;
 ; RV32IZHINXMIN-LABEL: br_fcmp_false:
 ; RV32IZHINXMIN:       # %bb.0:
-; RV32IZHINXMIN-NEXT:    li a0, 1
-; RV32IZHINXMIN-NEXT:    bnez a0, .LBB0_2
+; RV32IZHINXMIN-NEXT:    beqz zero, .LBB0_2
 ; RV32IZHINXMIN-NEXT:  # %bb.1: # %if.then
 ; RV32IZHINXMIN-NEXT:    ret
 ; RV32IZHINXMIN-NEXT:  .LBB0_2: # %if.else
@@ -100,8 +93,7 @@ define void @br_fcmp_false(half %a, half %b) nounwind {
 ;
 ; RV64IZHINXMIN-LABEL: br_fcmp_false:
 ; RV64IZHINXMIN:       # %bb.0:
-; RV64IZHINXMIN-NEXT:    li a0, 1
-; RV64IZHINXMIN-NEXT:    bnez a0, .LBB0_2
+; RV64IZHINXMIN-NEXT:    beqz zero, .LBB0_2
 ; RV64IZHINXMIN-NEXT:  # %bb.1: # %if.then
 ; RV64IZHINXMIN-NEXT:    ret
 ; RV64IZHINXMIN-NEXT:  .LBB0_2: # %if.else
@@ -1762,8 +1754,7 @@ if.then:
 define void @br_fcmp_true(half %a, half %b) nounwind {
 ; RV32IZFH-LABEL: br_fcmp_true:
 ; RV32IZFH:       # %bb.0:
-; RV32IZFH-NEXT:    li a0, 1
-; RV32IZFH-NEXT:    bnez a0, .LBB16_2
+; RV32IZFH-NEXT:    beqz zero, .LBB16_2
 ; RV32IZFH-NEXT:  # %bb.1: # %if.else
 ; RV32IZFH-NEXT:    ret
 ; RV32IZFH-NEXT:  .LBB16_2: # %if.then
@@ -1773,8 +1764,7 @@ define void @br_fcmp_true(half %a, half %b) nounwind {
 ;
 ; RV64IZFH-LABEL: br_fcmp_true:
 ; RV64IZFH:       # %bb.0:
-; RV64IZFH-NEXT:    li a0, 1
-; RV64IZFH-NEXT:    bnez a0, .LBB16_2
+; RV64IZFH-NEXT:    beqz zero, .LBB16_2
 ; RV64IZFH-NEXT:  # %bb.1: # %if.else
 ; RV64IZFH-NEXT:    ret
 ; RV64IZFH-NEXT:  .LBB16_2: # %if.then
@@ -1784,8 +1774,7 @@ define void @br_fcmp_true(half %a, half %b) nounwind {
 ;
 ; RV32IZHINX-LABEL: br_fcmp_true:
 ; RV32IZHINX:       # %bb.0:
-; RV32IZHINX-NEXT:    li a0, 1
-; RV32IZHINX-NEXT:    bnez a0, .LBB16_2
+; RV32IZHINX-NEXT:    beqz zero, .LBB16_2
 ; RV32IZHINX-NEXT:  # %bb.1: # %if.else
 ; RV32IZHINX-NEXT:    ret
 ; RV32IZHINX-NEXT:  .LBB16_2: # %if.then
@@ -1795,8 +1784,7 @@ define void @br_fcmp_true(half %a, half %b) nounwind {
 ;
 ; RV64IZHINX-LABEL: br_fcmp_true:
 ; RV64IZHINX:       # %bb.0:
-; RV64IZHINX-NEXT:    li a0, 1
-; RV64IZHINX-NEXT:    bnez a0, .LBB16_2
+; RV64IZHINX-NEXT:    beqz zero, .LBB16_2
 ; RV64IZHINX-NEXT:  # %bb.1: # %if.else
 ; RV64IZHINX-NEXT:    ret
 ; RV64IZHINX-NEXT:  .LBB16_2: # %if.then
@@ -1806,8 +1794,7 @@ define void @br_fcmp_true(half %a, half %b) nounwind {
 ;
 ; RV32IZFHMIN-LABEL: br_fcmp_true:
 ; RV32IZFHMIN:       # %bb.0:
-; RV32IZFHMIN-NEXT:    li a0, 1
-; RV32IZFHMIN-NEXT:    bnez a0, .LBB16_2
+; RV32IZFHMIN-NEXT:    beqz zero, .LBB16_2
 ; RV32IZFHMIN-NEXT:  # %bb.1: # %if.else
 ; RV32IZFHMIN-NEXT:    ret
 ; RV32IZFHMIN-NEXT:  .LBB16_2: # %if.then
@@ -1817,8 +1804,7 @@ define void @br_fcmp_true(half %a, half %b) nounwind {
 ;
 ; RV64IZFHMIN-LABEL: br_fcmp_true:
 ; RV64IZFHMIN:       # %bb.0:
-; RV64IZFHMIN-NEXT:    li a0, 1
-; RV64IZFHMIN-NEXT:    bnez a0, .LBB16_2
+; RV64IZFHMIN-NEXT:    beqz zero, .LBB16_2
 ; RV64IZFHMIN-NEXT:  # %bb.1: # %if.else
 ; RV64IZFHMIN-NEXT:    ret
 ; RV64IZFHMIN-NEXT:  .LBB16_2: # %if.then
@@ -1828,8 +1814,7 @@ define void @br_fcmp_true(half %a, half %b) nounwind {
 ;
 ; RV32IZHINXMIN-LABEL: br_fcmp_true:
 ; RV32IZHINXMIN:       # %bb.0:
-; RV32IZHINXMIN-NEXT:    li a0, 1
-; RV32IZHINXMIN-NEXT:    bnez a0, .LBB16_2
+; RV32IZHINXMIN-NEXT:    beqz zero, .LBB16_2
 ; RV32IZHINXMIN-NEXT:  # %bb.1: # %if.else
 ; RV32IZHINXMIN-NEXT:    ret
 ; RV32IZHINXMIN-NEXT:  .LBB16_2: # %if.then
@@ -1839,8 +1824,7 @@ define void @br_fcmp_true(half %a, half %b) nounwind {
 ;
 ; RV64IZHINXMIN-LABEL: br_fcmp_true:
 ; RV64IZHINXMIN:       # %bb.0:
-; RV64IZHINXMIN-NEXT:    li a0, 1
-; RV64IZHINXMIN-NEXT:    bnez a0, .LBB16_2
+; RV64IZHINXMIN-NEXT:    beqz zero, .LBB16_2
 ; RV64IZHINXMIN-NEXT:  # %bb.1: # %if.else
 ; RV64IZHINXMIN-NEXT:    ret
 ; RV64IZHINXMIN-NEXT:  .LBB16_2: # %if.then

--- a/llvm/test/CodeGen/RISCV/machine-sink-load-immediate.ll
+++ b/llvm/test/CodeGen/RISCV/machine-sink-load-immediate.ll
@@ -13,76 +13,72 @@ define i1 @sink_li(ptr %text, ptr %text.addr.0) nounwind {
 ; CHECK-NEXT:    mv s0, a0
 ; CHECK-NEXT:    call toupper
 ; CHECK-NEXT:    li a1, 0
-; CHECK-NEXT:    beqz s0, .LBB0_26
-; CHECK-NEXT:  # %bb.1: # %while.body.preheader
-; CHECK-NEXT:    li a2, 1
-; CHECK-NEXT:    li a3, 9
-; CHECK-NEXT:    li a4, 32
-; CHECK-NEXT:  .LBB0_2: # %while.body
+; CHECK-NEXT:    beqz s0, .LBB0_25
+; CHECK-NEXT:  .LBB0_1: # %while.body
 ; CHECK-NEXT:    # =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    bnez a2, .LBB0_4
-; CHECK-NEXT:  # %bb.3: # %while.body
-; CHECK-NEXT:    # in Loop: Header=BB0_2 Depth=1
-; CHECK-NEXT:    bne a2, a3, .LBB0_16
-; CHECK-NEXT:  .LBB0_4: # %while.body.1
-; CHECK-NEXT:    # in Loop: Header=BB0_2 Depth=1
-; CHECK-NEXT:    bnez a2, .LBB0_6
-; CHECK-NEXT:  # %bb.5: # %while.body.1
-; CHECK-NEXT:    # in Loop: Header=BB0_2 Depth=1
-; CHECK-NEXT:    bne a2, a3, .LBB0_17
-; CHECK-NEXT:  .LBB0_6: # %while.body.3
-; CHECK-NEXT:    # in Loop: Header=BB0_2 Depth=1
-; CHECK-NEXT:    bnez a2, .LBB0_8
-; CHECK-NEXT:  # %bb.7: # %while.body.3
-; CHECK-NEXT:    # in Loop: Header=BB0_2 Depth=1
-; CHECK-NEXT:    bne a2, a4, .LBB0_19
-; CHECK-NEXT:  .LBB0_8: # %while.body.4
-; CHECK-NEXT:    # in Loop: Header=BB0_2 Depth=1
-; CHECK-NEXT:    bnez a2, .LBB0_10
-; CHECK-NEXT:  # %bb.9: # %while.body.4
-; CHECK-NEXT:    # in Loop: Header=BB0_2 Depth=1
-; CHECK-NEXT:    bne a2, a4, .LBB0_21
-; CHECK-NEXT:  .LBB0_10: # %while.body.5
-; CHECK-NEXT:    # in Loop: Header=BB0_2 Depth=1
-; CHECK-NEXT:    bnez a2, .LBB0_12
-; CHECK-NEXT:  # %bb.11: # %while.body.5
-; CHECK-NEXT:    # in Loop: Header=BB0_2 Depth=1
-; CHECK-NEXT:    bne a2, a3, .LBB0_23
-; CHECK-NEXT:  .LBB0_12: # %while.body.6
-; CHECK-NEXT:    # in Loop: Header=BB0_2 Depth=1
-; CHECK-NEXT:    bnez a2, .LBB0_2
+; CHECK-NEXT:    beqz zero, .LBB0_3
+; CHECK-NEXT:  # %bb.2: # %while.body
+; CHECK-NEXT:    # in Loop: Header=BB0_1 Depth=1
+; CHECK-NEXT:    beqz zero, .LBB0_15
+; CHECK-NEXT:  .LBB0_3: # %while.body.1
+; CHECK-NEXT:    # in Loop: Header=BB0_1 Depth=1
+; CHECK-NEXT:    beqz zero, .LBB0_5
+; CHECK-NEXT:  # %bb.4: # %while.body.1
+; CHECK-NEXT:    # in Loop: Header=BB0_1 Depth=1
+; CHECK-NEXT:    beqz zero, .LBB0_16
+; CHECK-NEXT:  .LBB0_5: # %while.body.3
+; CHECK-NEXT:    # in Loop: Header=BB0_1 Depth=1
+; CHECK-NEXT:    beqz zero, .LBB0_7
+; CHECK-NEXT:  # %bb.6: # %while.body.3
+; CHECK-NEXT:    # in Loop: Header=BB0_1 Depth=1
+; CHECK-NEXT:    beqz zero, .LBB0_18
+; CHECK-NEXT:  .LBB0_7: # %while.body.4
+; CHECK-NEXT:    # in Loop: Header=BB0_1 Depth=1
+; CHECK-NEXT:    beqz zero, .LBB0_9
+; CHECK-NEXT:  # %bb.8: # %while.body.4
+; CHECK-NEXT:    # in Loop: Header=BB0_1 Depth=1
+; CHECK-NEXT:    beqz zero, .LBB0_20
+; CHECK-NEXT:  .LBB0_9: # %while.body.5
+; CHECK-NEXT:    # in Loop: Header=BB0_1 Depth=1
+; CHECK-NEXT:    beqz zero, .LBB0_11
+; CHECK-NEXT:  # %bb.10: # %while.body.5
+; CHECK-NEXT:    # in Loop: Header=BB0_1 Depth=1
+; CHECK-NEXT:    beqz zero, .LBB0_22
+; CHECK-NEXT:  .LBB0_11: # %while.body.6
+; CHECK-NEXT:    # in Loop: Header=BB0_1 Depth=1
+; CHECK-NEXT:    beqz zero, .LBB0_1
+; CHECK-NEXT:  # %bb.12: # %while.body.6
+; CHECK-NEXT:    # in Loop: Header=BB0_1 Depth=1
+; CHECK-NEXT:    bnez zero, .LBB0_1
 ; CHECK-NEXT:  # %bb.13: # %while.body.6
-; CHECK-NEXT:    # in Loop: Header=BB0_2 Depth=1
-; CHECK-NEXT:    beq a2, a3, .LBB0_2
-; CHECK-NEXT:  # %bb.14: # %while.body.6
-; CHECK-NEXT:    beqz a2, .LBB0_24
-; CHECK-NEXT:  # %bb.15: # %strdup.exit.split.loop.exit126
+; CHECK-NEXT:    bnez zero, .LBB0_23
+; CHECK-NEXT:  # %bb.14: # %strdup.exit.split.loop.exit126
 ; CHECK-NEXT:    addi s0, s1, 7
-; CHECK-NEXT:    j .LBB0_25
-; CHECK-NEXT:  .LBB0_16: # %while.body
-; CHECK-NEXT:    beqz a2, .LBB0_26
-; CHECK-NEXT:    j .LBB0_18
-; CHECK-NEXT:  .LBB0_17: # %while.body.1
-; CHECK-NEXT:    beqz a2, .LBB0_24
-; CHECK-NEXT:  .LBB0_18: # %strdup.exit.loopexit
+; CHECK-NEXT:    j .LBB0_24
+; CHECK-NEXT:  .LBB0_15: # %while.body
+; CHECK-NEXT:    bnez zero, .LBB0_25
+; CHECK-NEXT:    j .LBB0_17
+; CHECK-NEXT:  .LBB0_16: # %while.body.1
+; CHECK-NEXT:    bnez zero, .LBB0_23
+; CHECK-NEXT:  .LBB0_17: # %strdup.exit.loopexit
 ; CHECK-NEXT:    li s0, 0
-; CHECK-NEXT:    j .LBB0_25
-; CHECK-NEXT:  .LBB0_19: # %while.body.3
-; CHECK-NEXT:    beqz a2, .LBB0_24
-; CHECK-NEXT:  # %bb.20: # %strdup.exit.split.loop.exit120
+; CHECK-NEXT:    j .LBB0_24
+; CHECK-NEXT:  .LBB0_18: # %while.body.3
+; CHECK-NEXT:    bnez zero, .LBB0_23
+; CHECK-NEXT:  # %bb.19: # %strdup.exit.split.loop.exit120
 ; CHECK-NEXT:    addi s0, s1, 4
-; CHECK-NEXT:    j .LBB0_25
-; CHECK-NEXT:  .LBB0_21: # %while.body.4
-; CHECK-NEXT:    beqz a2, .LBB0_24
-; CHECK-NEXT:  # %bb.22: # %strdup.exit.split.loop.exit122
+; CHECK-NEXT:    j .LBB0_24
+; CHECK-NEXT:  .LBB0_20: # %while.body.4
+; CHECK-NEXT:    bnez zero, .LBB0_23
+; CHECK-NEXT:  # %bb.21: # %strdup.exit.split.loop.exit122
 ; CHECK-NEXT:    addi s0, s1, 5
-; CHECK-NEXT:    j .LBB0_25
-; CHECK-NEXT:  .LBB0_23: # %while.body.5
-; CHECK-NEXT:    bnez a2, .LBB0_25
-; CHECK-NEXT:  .LBB0_24:
+; CHECK-NEXT:    j .LBB0_24
+; CHECK-NEXT:  .LBB0_22: # %while.body.5
+; CHECK-NEXT:    beqz zero, .LBB0_24
+; CHECK-NEXT:  .LBB0_23:
 ; CHECK-NEXT:    li a1, 0
-; CHECK-NEXT:    j .LBB0_26
-; CHECK-NEXT:  .LBB0_25: # %strdup.exit
+; CHECK-NEXT:    j .LBB0_25
+; CHECK-NEXT:  .LBB0_24: # %strdup.exit
 ; CHECK-NEXT:    li s1, 0
 ; CHECK-NEXT:    mv s2, a0
 ; CHECK-NEXT:    li a0, 0
@@ -93,7 +89,7 @@ define i1 @sink_li(ptr %text, ptr %text.addr.0) nounwind {
 ; CHECK-NEXT:    li a2, 0
 ; CHECK-NEXT:    jalr s1
 ; CHECK-NEXT:    li a1, 1
-; CHECK-NEXT:  .LBB0_26: # %return
+; CHECK-NEXT:  .LBB0_25: # %return
 ; CHECK-NEXT:    mv a0, a1
 ; CHECK-NEXT:    ld ra, 24(sp) # 8-byte Folded Reload
 ; CHECK-NEXT:    ld s0, 16(sp) # 8-byte Folded Reload


### PR DESCRIPTION
optimizeCondBranch isn't allowed to modify the CFG, but it can rewrite the branch condition freely.  However, If we could fold a conditional branch to an unconditional one (aside from that restriction), we can also rewrite it into some canonical conditional branch instead.

Looking at the diffs, the only cases this catches in tree tests are cases where we could have constant folded during lowering from IR, but didn't.  This is inspired by trying to salvage code from https://github.com/llvm/llvm-project/pull/131684 which might be useful.  Given the test impact, it's of questionable merits. The main advantage over only the late cleanup pass is that it kills off the LIs for the constants early - which can help e.g. register allocation.