### PR TITLE
[libc][bazel] Stop creatng "public" library targets in libc_function.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -1319,7 +1319,7 @@ libc_support_library(
             "src/__support/OSUtil/linux/aarch64/syscall.h",
             "src/__support/OSUtil/linux/x86_64/syscall.h",
         ],
-	"@platforms//os:windows": [],
+        "@platforms//os:windows": [],
     }),
     deps = [
         ":__support_common",
@@ -1361,7 +1361,7 @@ libc_support_library(
     textual_hdrs = select({
         "@platforms//os:macos": ["src/__support/OSUtil/darwin/io.h"],
         "@platforms//os:linux": ["src/__support/OSUtil/linux/io.h"],
-	"@platforms//os:windows": ["src/__support/OSUtil/windows/io.h"],
+        "@platforms//os:windows": ["src/__support/OSUtil/windows/io.h"],
     }),
     deps = [
         ":__support_common",
@@ -1885,8 +1885,8 @@ libc_support_library(
     name = "inv_trigf_utils",
     srcs = ["src/math/generic/inv_trigf_utils.cpp"],
     hdrs = [
-        "src/math/generic/inv_trigf_utils.h",
         "src/math/generic/atan_utils.h",
+        "src/math/generic/inv_trigf_utils.h",
     ],
     deps = [
         ":__support_common",
@@ -4186,7 +4186,6 @@ libc_function(
     name = "memcpy",
     srcs = ["src/string/memcpy.cpp"],
     hdrs = ["src/string/memcpy.h"],
-    weak = True,
     deps = [
         ":__support_common",
         ":string_memory_utils",
@@ -4197,7 +4196,6 @@ libc_function(
     name = "memset",
     srcs = ["src/string/memset.cpp"],
     hdrs = ["src/string/memset.h"],
-    weak = True,
     deps = [
         ":__support_common",
         ":string_memory_utils",
@@ -4208,7 +4206,6 @@ libc_function(
     name = "memmove",
     srcs = ["src/string/memmove.cpp"],
     hdrs = ["src/string/memmove.h"],
-    weak = True,
     deps = [
         ":__support_common",
         ":string_memory_utils",
@@ -4219,7 +4216,6 @@ libc_function(
     name = "mempcpy",
     srcs = ["src/string/mempcpy.cpp"],
     hdrs = ["src/string/mempcpy.h"],
-    weak = True,
     deps = [
         ":__support_common",
         ":string_memory_utils",
@@ -4240,7 +4236,6 @@ libc_function(
     name = "memcmp",
     srcs = ["src/string/memcmp.cpp"],
     hdrs = ["src/string/memcmp.h"],
-    weak = True,
     deps = [
         ":__support_common",
         ":__support_integer_operations",
@@ -4252,7 +4247,6 @@ libc_function(
     name = "bcmp",
     srcs = ["src/strings/bcmp.cpp"],
     hdrs = ["src/strings/bcmp.h"],
-    weak = True,
     deps = [
         ":__support_common",
         ":string_memory_utils",
@@ -4263,7 +4257,6 @@ libc_function(
     name = "bzero",
     srcs = ["src/strings/bzero.cpp"],
     hdrs = ["src/strings/bzero.h"],
-    weak = True,
     deps = [
         ":__support_common",
         ":string_memory_utils",
@@ -4749,7 +4742,6 @@ libc_function(
     name = "read",
     srcs = ["src/unistd/linux/read.cpp"],
     hdrs = ["src/unistd/read.h"],
-    weak = True,
     deps = [
         ":__support_common",
         ":__support_macros_sanitizer",
@@ -4898,7 +4890,6 @@ libc_function(
     name = "write",
     srcs = ["src/unistd/linux/write.cpp"],
     hdrs = ["src/unistd/write.h"],
-    weak = True,
     deps = [
         ":__support_common",
         ":__support_osutil_syscall",
@@ -5359,7 +5350,6 @@ libc_function(
     name = "socket",
     srcs = ["src/sys/socket/linux/socket.cpp"],
     hdrs = ["src/sys/socket/socket.h"],
-    weak = True,
     deps = [
         ":__support_common",
         ":__support_osutil_syscall",
@@ -5371,7 +5361,6 @@ libc_function(
     name = "socketpair",
     srcs = ["src/sys/socket/linux/socketpair.cpp"],
     hdrs = ["src/sys/socket/socketpair.h"],
-    weak = True,
     deps = [
         ":__support_common",
         ":__support_osutil_syscall",
@@ -5383,7 +5372,6 @@ libc_function(
     name = "send",
     srcs = ["src/sys/socket/linux/send.cpp"],
     hdrs = ["src/sys/socket/send.h"],
-    weak = True,
     deps = [
         ":__support_common",
         ":__support_osutil_syscall",
@@ -5398,7 +5386,6 @@ libc_function(
     name = "sendto",
     srcs = ["src/sys/socket/linux/sendto.cpp"],
     hdrs = ["src/sys/socket/sendto.h"],
-    weak = True,
     deps = [
         ":__support_common",
         ":__support_osutil_syscall",
@@ -5413,7 +5400,6 @@ libc_function(
     name = "sendmsg",
     srcs = ["src/sys/socket/linux/sendmsg.cpp"],
     hdrs = ["src/sys/socket/sendmsg.h"],
-    weak = True,
     deps = [
         ":__support_common",
         ":__support_osutil_syscall",
@@ -5427,7 +5413,6 @@ libc_function(
     name = "recv",
     srcs = ["src/sys/socket/linux/recv.cpp"],
     hdrs = ["src/sys/socket/recv.h"],
-    weak = True,
     deps = [
         ":__support_common",
         ":__support_osutil_syscall",
@@ -5442,7 +5427,6 @@ libc_function(
     name = "recvfrom",
     srcs = ["src/sys/socket/linux/recvfrom.cpp"],
     hdrs = ["src/sys/socket/recvfrom.h"],
-    weak = True,
     deps = [
         ":__support_common",
         ":__support_osutil_syscall",
@@ -5457,7 +5441,6 @@ libc_function(
     name = "recvmsg",
     srcs = ["src/sys/socket/linux/recvmsg.cpp"],
     hdrs = ["src/sys/socket/recvmsg.h"],
-    weak = True,
     deps = [
         ":__support_common",
         ":__support_osutil_syscall",
@@ -5477,7 +5460,6 @@ libc_function(
         "@platforms//os:linux": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    weak = True,
     deps = [
         ":__support_osutil_syscall",
         ":errno",
@@ -5492,7 +5474,6 @@ libc_function(
         "@platforms//os:linux": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    weak = True,
     deps = [
         ":__support_osutil_syscall",
         ":errno",
@@ -5507,7 +5488,6 @@ libc_function(
         "@platforms//os:linux": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    weak = True,
     deps = [
         ":__support_osutil_syscall",
         ":errno",
@@ -5524,7 +5504,6 @@ libc_function(
         "@platforms//os:linux": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    weak = True,
     deps = [
         ":__support_macros_sanitizer",
         ":__support_osutil_syscall",
@@ -5544,7 +5523,6 @@ libc_function(
         "@platforms//os:linux": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    weak = True,
     deps = [
         ":__support_macros_sanitizer",
         ":__support_osutil_syscall",
@@ -5564,7 +5542,6 @@ libc_function(
         "@platforms//os:linux": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    weak = True,
     deps = [
         ":__support_macros_sanitizer",
         ":__support_osutil_syscall",

--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -77,8 +77,7 @@ def _libc_library_filegroups(
         # and ensure the consistent and tightly controlled set of flags
         # (see libc_common_copts and libc_release_copts above) is used to build
         # libc code both for tests and for release configuration.
-        target_compatible_with = None,  # @unused
-        weak = False):  # @unused
+        target_compatible_with = None):  # @unused
     """Internal macro to collect sources and headers required to build a library.
     """
 
@@ -101,10 +100,7 @@ def libc_support_library(name, **kwargs):
     _libc_library(name = name, **kwargs)
     _libc_library_filegroups(name = name, is_function = False, **kwargs)
 
-def libc_function(
-        name,
-        weak = False,
-        **kwargs):
+def libc_function(name, **kwargs):
     """Add target for a libc function.
 
     This macro creates an internal cc_library that can be used to test this
@@ -114,7 +110,6 @@ def libc_function(
     Args:
       name: Target name. It is normally the name of the function this target is
             for.
-      weak: Make the symbol corresponding to the libc function "weak".
       **kwargs: Other attributes relevant for a cc_library. For example, deps.
     """
 
@@ -127,19 +122,6 @@ def libc_function(
     )
 
     _libc_library_filegroups(name = name, is_function = True, **kwargs)
-
-    # TODO(PR #130327): Remove this after downstream uses are migrated to libc_release_library.
-    # This second target is the llvm libc C function with default visibility.
-    func_attrs = [
-        "LLVM_LIBC_FUNCTION_ATTR_" + name + "='LLVM_LIBC_EMPTY, [[gnu::weak]]'",
-    ] if weak else []
-
-    _libc_library(
-        name = name,
-        copts = libc_release_copts(),
-        local_defines = func_attrs,
-        **kwargs
-    )
 
 def libc_release_library(
         name,


### PR DESCRIPTION
All downstream users are migrated, so we no longer need to produce "public"/"release" cc_library target for each libc_function macro invocation. Instead, we only create internal target (for testing), and some filegroups, which will be picked up by the libc_release_library invocation.

This allows us to get rid of "weak" argument to libc_function - this decision is also postponed to libc_release_library configuration.

Fixes #130327.