### PR TITLE
[libc] Add exceptional values for sinhf16/coshf16

### DIFF
--- a/libc/src/math/generic/coshf16.cpp
+++ b/libc/src/math/generic/coshf16.cpp
@@ -42,7 +42,7 @@ static constexpr fputil::ExceptValues<float16, 9> COSHF16_EXCEPTS_POS = {{
     {0x497cU, 0x7715U, 1U, 0U, 1U},
 }};
 
-static constexpr fputil::ExceptValues<float16, 4> COSHF16_EXCEPTS_NEG = {{
+static constexpr fputil::ExceptValues<float16, 6> COSHF16_EXCEPTS_NEG = {{
     // x = -0x1.6ap-5, coshf16(x) = 0x1p+0 (RZ)
     {0xa9a8U, 0x3c00U, 1U, 0U, 1U},
     // x = -0x1.b6p+0, coshf16(x) = 0x1.6d8p+1 (RZ)
@@ -51,6 +51,10 @@ static constexpr fputil::ExceptValues<float16, 4> COSHF16_EXCEPTS_NEG = {{
     {0xc4a2U, 0x526dU, 1U, 0U, 0U},
     // x = -0x1.5fp+3, coshf16(x) = 0x1.c54p+14 (RZ)
     {0xc97cU, 0x7715U, 1U, 0U, 1U},
+    // x = -0x1.8c4p+0, coshf16(x) = 0x1.3a8p+1 (RZ)
+    {0xbe31U, 0x40eaU, 1U, 0U, 0U},
+    // x = -0x1.994p+0, coshf16(x) = 0x1.498p+1 (RZ)
+    {0xbe65U, 0x4126U, 1U, 0U, 0U},
 }};
 #endif // !LIBC_MATH_HAS_SKIP_ACCURATE_PASS
 

--- a/libc/src/math/generic/sinhf16.cpp
+++ b/libc/src/math/generic/sinhf16.cpp
@@ -21,7 +21,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 #ifndef LIBC_MATH_HAS_SKIP_ACCURATE_PASS
-static constexpr fputil::ExceptValues<float16, 16> SINHF16_EXCEPTS_POS = {{
+static constexpr fputil::ExceptValues<float16, 17> SINHF16_EXCEPTS_POS = {{
     // x = 0x1.714p-5, sinhf16(x) = 0x1.714p-5 (RZ)
     {0x29c5U, 0x29c5U, 1U, 0U, 1U},
     // x = 0x1.25p-4, sinhf16(x) = 0x1.25p-4 (RZ)
@@ -54,9 +54,11 @@ static constexpr fputil::ExceptValues<float16, 16> SINHF16_EXCEPTS_POS = {{
     {0x4629U, 0x5b65U, 1U, 0U, 1U},
     // x = 0x1.5fp+3, sinhf16(x) = 0x1.c54p+14 (RZ)
     {0x497cU, 0x7715U, 1U, 0U, 1U},
+    // x = 0x1.3c8p+1, sinhf16(x) = 0x1.78ap+2 (RZ)
+    {0x40f2U, 0x45e2U, 1U, 0U, 1U},
 }};
 
-static constexpr fputil::ExceptValues<float16, 12> SINHF16_EXCEPTS_NEG = {{
+static constexpr fputil::ExceptValues<float16, 13> SINHF16_EXCEPTS_NEG = {{
     // x = -0x1.714p-5, sinhf16(x) = -0x1.714p-5 (RZ)
     {0xa9c5U, 0xa9c5U, 0U, 1U, 1U},
     // x = -0x1.25p-4, sinhf16(x) = -0x1.25p-4 (RZ)
@@ -81,6 +83,8 @@ static constexpr fputil::ExceptValues<float16, 12> SINHF16_EXCEPTS_NEG = {{
     {0xc629U, 0xdb65U, 0U, 1U, 1U},
     // x = -0x1.5fp+3, sinhf16(x) = -0x1.c54p+14 (RZ)
     {0xc97cU, 0xf715U, 0U, 1U, 1U},
+    // x = -0x1.3c8p+1, sinhf16(x) = -0x1.78ap+2 (RZ)
+    {0xc0f2U, 0xc5e2U, 0U, 1U, 1U},
 }};
 #endif // !LIBC_MATH_HAS_SKIP_ACCURATE_PASS
 


### PR DESCRIPTION
The rounding of the result when using an FMA instruction for hyperbolic
sin/cos on float16 was off by 1 bit for a few cases. This patch adds
extra exceptional cases to handle these.
