### PR TITLE
[libc++] Remove the need for _LIBCPP_TEMPLATE_VIS

### DIFF
--- a/libcxx/.clang-format
+++ b/libcxx/.clang-format
@@ -45,7 +45,6 @@ AttributeMacros: [
                   '_LIBCPP_OVERRIDABLE_FUNC_VIS',
                   '_LIBCPP_STANDALONE_DEBUG',
                   '_LIBCPP_TEMPLATE_DATA_VIS',
-                  '_LIBCPP_TEMPLATE_VIS',
                   '_LIBCPP_THREAD_SAFETY_ANNOTATION',
                   '_LIBCPP_USING_IF_EXISTS',
                   '_LIBCPP_WEAK',

--- a/libcxx/docs/DesignDocs/VisibilityMacros.rst
+++ b/libcxx/docs/DesignDocs/VisibilityMacros.rst
@@ -64,25 +64,13 @@ Visibility Macros
   ABI, we should create a new _LIBCPP_HIDE_FROM_ABI_AFTER_XXX macro, and we can
   use it to start removing symbols from the ABI after that stable version.
 
-**_LIBCPP_TEMPLATE_VIS**
-  Mark a type's typeinfo and vtable as having default visibility.
-  This macro has no effect on the visibility of the type's member functions.
-
-  **GCC Behavior**: GCC does not support Clang's `type_visibility(...)`
-  attribute. With GCC the `visibility(...)` attribute is used and member
-  functions are affected.
-
-  **Windows Behavior**: DLLs do not support dllimport/export on class templates.
-  The macro has an empty definition on this platform.
-
 **_LIBCPP_EXTERN_TEMPLATE_TYPE_VIS**
   Mark the member functions, typeinfo, and vtable of the type named in
   an extern template declaration as being exported by the libc++ library.
   This attribute must be specified on all extern class template declarations.
 
-  This macro is used to override the `_LIBCPP_TEMPLATE_VIS` attribute
-  specified on the primary template and to export the member functions produced
-  by the explicit instantiation in the dylib.
+  This macro is used to export the member functions produced by the explicit
+  instantiation in the dylib.
 
   **Windows Behavior**: `extern template` and `dllexport` are fundamentally
   incompatible *on a class template* on Windows; the former suppresses

--- a/libcxx/include/__chrono/duration.h
+++ b/libcxx/include/__chrono/duration.h
@@ -32,7 +32,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace chrono {
 
 template <class _Rep, class _Period = ratio<1> >
-class _LIBCPP_TEMPLATE_VIS duration;
+class duration;
 
 template <class _Tp>
 inline const bool __is_duration_v = false;
@@ -52,7 +52,7 @@ inline const bool __is_duration_v<const volatile duration<_Rep, _Period> > = tru
 } // namespace chrono
 
 template <class _Rep1, class _Period1, class _Rep2, class _Period2>
-struct _LIBCPP_TEMPLATE_VIS common_type<chrono::duration<_Rep1, _Period1>, chrono::duration<_Rep2, _Period2> > {
+struct common_type<chrono::duration<_Rep1, _Period1>, chrono::duration<_Rep2, _Period2> > {
   typedef chrono::duration<typename common_type<_Rep1, _Rep2>::type, __ratio_gcd<_Period1, _Period2> > type;
 };
 
@@ -107,7 +107,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _ToDuration duration_cast(const d
 }
 
 template <class _Rep>
-struct _LIBCPP_TEMPLATE_VIS treat_as_floating_point : is_floating_point<_Rep> {};
+struct treat_as_floating_point : is_floating_point<_Rep> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Rep>
@@ -115,7 +115,7 @@ inline constexpr bool treat_as_floating_point_v = treat_as_floating_point<_Rep>:
 #endif
 
 template <class _Rep>
-struct _LIBCPP_TEMPLATE_VIS duration_values {
+struct duration_values {
 public:
   _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR _Rep zero() _NOEXCEPT { return _Rep(0); }
   _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR _Rep max() _NOEXCEPT { return numeric_limits<_Rep>::max(); }
@@ -156,7 +156,7 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _ToDuration round(const duration<
 // duration
 
 template <class _Rep, class _Period>
-class _LIBCPP_TEMPLATE_VIS duration {
+class duration {
   static_assert(!__is_duration_v<_Rep>, "A duration representation can not be a duration");
   static_assert(__is_ratio_v<_Period>, "Second template parameter of duration must be a std::ratio");
   static_assert(_Period::num > 0, "duration period must be positive");

--- a/libcxx/include/__chrono/formatter.h
+++ b/libcxx/include/__chrono/formatter.h
@@ -698,7 +698,7 @@ __format_chrono(const _Tp& __value,
 } // namespace __formatter
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS __formatter_chrono {
+struct __formatter_chrono {
 public:
   template <class _ParseContext>
   _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator
@@ -716,7 +716,7 @@ public:
 };
 
 template <class _Duration, __fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::sys_time<_Duration>, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::sys_time<_Duration>, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -730,7 +730,7 @@ public:
 #      if _LIBCPP_HAS_EXPERIMENTAL_TZDB
 
 template <class _Duration, __fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::utc_time<_Duration>, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::utc_time<_Duration>, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -741,7 +741,7 @@ public:
 };
 
 template <class _Duration, __fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::tai_time<_Duration>, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::tai_time<_Duration>, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -752,7 +752,7 @@ public:
 };
 
 template <class _Duration, __fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::gps_time<_Duration>, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::gps_time<_Duration>, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -766,7 +766,7 @@ public:
 #    endif   // _LIBCPP_HAS_TIME_ZONE_DATABASE && _LIBCPP_HAS_FILESYSTEM
 
 template <class _Duration, __fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::file_time<_Duration>, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::file_time<_Duration>, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -777,7 +777,7 @@ public:
 };
 
 template <class _Duration, __fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::local_time<_Duration>, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::local_time<_Duration>, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -811,7 +811,7 @@ public:
 };
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::day, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::day, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -822,7 +822,7 @@ public:
 };
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::month, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::month, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -833,7 +833,7 @@ public:
 };
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::year, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::year, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -844,7 +844,7 @@ public:
 };
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::weekday, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::weekday, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -855,7 +855,7 @@ public:
 };
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::weekday_indexed, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::weekday_indexed, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -866,7 +866,7 @@ public:
 };
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::weekday_last, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::weekday_last, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -877,7 +877,7 @@ public:
 };
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::month_day, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::month_day, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -888,7 +888,7 @@ public:
 };
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::month_day_last, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::month_day_last, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -899,7 +899,7 @@ public:
 };
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::month_weekday, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::month_weekday, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -910,7 +910,7 @@ public:
 };
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::month_weekday_last, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::month_weekday_last, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -921,7 +921,7 @@ public:
 };
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::year_month, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::year_month, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -932,7 +932,7 @@ public:
 };
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::year_month_day, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::year_month_day, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -943,7 +943,7 @@ public:
 };
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::year_month_day_last, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::year_month_day_last, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -954,7 +954,7 @@ public:
 };
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::year_month_weekday, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::year_month_weekday, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 
@@ -965,7 +965,7 @@ public:
 };
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<chrono::year_month_weekday_last, _CharT> : public __formatter_chrono<_CharT> {
+struct formatter<chrono::year_month_weekday_last, _CharT> : public __formatter_chrono<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __formatter_chrono<_CharT>;
 

--- a/libcxx/include/__chrono/parser_std_format_spec.h
+++ b/libcxx/include/__chrono/parser_std_format_spec.h
@@ -139,7 +139,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr void __validate_time_zone(__flags __flags) {
 }
 
 template <class _CharT>
-class _LIBCPP_TEMPLATE_VIS __parser_chrono {
+class __parser_chrono {
   using _ConstIterator _LIBCPP_NODEBUG = typename basic_format_parse_context<_CharT>::const_iterator;
 
 public:

--- a/libcxx/include/__chrono/time_point.h
+++ b/libcxx/include/__chrono/time_point.h
@@ -31,7 +31,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace chrono {
 
 template <class _Clock, class _Duration = typename _Clock::duration>
-class _LIBCPP_TEMPLATE_VIS time_point {
+class time_point {
   static_assert(__is_duration_v<_Duration>, "Second template parameter of time_point must be a std::chrono::duration");
 
 public:
@@ -76,8 +76,7 @@ public:
 } // namespace chrono
 
 template <class _Clock, class _Duration1, class _Duration2>
-struct _LIBCPP_TEMPLATE_VIS
-common_type<chrono::time_point<_Clock, _Duration1>, chrono::time_point<_Clock, _Duration2> > {
+struct common_type<chrono::time_point<_Clock, _Duration1>, chrono::time_point<_Clock, _Duration2> > {
   typedef chrono::time_point<_Clock, typename common_type<_Duration1, _Duration2>::type> type;
 };
 

--- a/libcxx/include/__compare/common_comparison_category.h
+++ b/libcxx/include/__compare/common_comparison_category.h
@@ -72,7 +72,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr auto __get_comp_type() {
 
 // [cmp.common], common comparison category type
 template <class... _Ts>
-struct _LIBCPP_TEMPLATE_VIS common_comparison_category {
+struct common_comparison_category {
   using type _LIBCPP_NODEBUG = decltype(__comp_detail::__get_comp_type<_Ts...>());
 };
 

--- a/libcxx/include/__compare/compare_three_way.h
+++ b/libcxx/include/__compare/compare_three_way.h
@@ -22,7 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 20
 
-struct _LIBCPP_TEMPLATE_VIS compare_three_way {
+struct compare_three_way {
   template <class _T1, class _T2>
     requires three_way_comparable_with<_T1, _T2>
   constexpr _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const

--- a/libcxx/include/__compare/compare_three_way_result.h
+++ b/libcxx/include/__compare/compare_three_way_result.h
@@ -34,8 +34,7 @@ struct _LIBCPP_HIDE_FROM_ABI __compare_three_way_result<
 };
 
 template <class _Tp, class _Up = _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS compare_three_way_result
-    : __compare_three_way_result<_Tp, _Up, void> {};
+struct _LIBCPP_NO_SPECIALIZATIONS compare_three_way_result : __compare_three_way_result<_Tp, _Up, void> {};
 
 template <class _Tp, class _Up = _Tp>
 using compare_three_way_result_t = typename compare_three_way_result<_Tp, _Up>::type;

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -389,9 +389,8 @@ typedef __char32_t char32_t;
 
 #    define _LIBCPP_HIDDEN
 #    define _LIBCPP_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
-#    define _LIBCPP_TEMPLATE_VIS
 #    define _LIBCPP_TEMPLATE_DATA_VIS
-#    define _LIBCPP_TYPE_VISIBILITY_DEFAULT
+#    define _LIBCPP_NAMESPACE_VISIBILITY
 
 #  else
 
@@ -419,17 +418,12 @@ typedef __char32_t char32_t;
 #      define _LIBCPP_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS
 #    endif
 
-// GCC doesn't support the type_visibility attribute, so we have to keep the visibility attribute on templates
-#    if !defined(_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS) && !__has_attribute(__type_visibility__)
-#      define _LIBCPP_TEMPLATE_VIS __attribute__((__visibility__("default")))
-#    else
-#      define _LIBCPP_TEMPLATE_VIS
-#    endif
-
 #    if !defined(_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS) && __has_attribute(__type_visibility__)
-#      define _LIBCPP_TYPE_VISIBILITY_DEFAULT __attribute__((__type_visibility__("default")))
+#      define _LIBCPP_NAMESPACE_VISIBILITY __attribute__((__type_visibility__("default")))
+#    elif !defined(_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS)
+#      define _LIBCPP_NAMESPACE_VISIBILITY __attribute__((__visibility__("default")))
 #    else
-#      define _LIBCPP_TYPE_VISIBILITY_DEFAULT
+#      define _LIBCPP_NAMESPACE_VISIBILITY
 #    endif
 
 #  endif // defined(_LIBCPP_OBJECT_FORMAT_COFF)
@@ -579,7 +573,7 @@ typedef __char32_t char32_t;
 
 // clang-format off
 #  define _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD                                                                      \
-    _LIBCPP_PUSH_EXTENSION_DIAGNOSTICS namespace _LIBCPP_TYPE_VISIBILITY_DEFAULT std {
+    _LIBCPP_PUSH_EXTENSION_DIAGNOSTICS namespace _LIBCPP_NAMESPACE_VISIBILITY std {
 
 #  define _LIBCPP_END_UNVERSIONED_NAMESPACE_STD } _LIBCPP_POP_EXTENSION_DIAGNOSTICS
 

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -577,15 +577,17 @@ typedef __char32_t char32_t;
 #    define _LIBCPP_POP_EXTENSION_DIAGNOSTICS
 #  endif
 
-// Inline namespaces are available in Clang/GCC/MSVC regardless of C++ dialect.
 // clang-format off
-#  define _LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_PUSH_EXTENSION_DIAGNOSTICS                                               \
-                                      namespace _LIBCPP_TYPE_VISIBILITY_DEFAULT std {                                  \
-                               inline namespace _LIBCPP_ABI_NAMESPACE {
-#  define _LIBCPP_END_NAMESPACE_STD }} _LIBCPP_POP_EXTENSION_DIAGNOSTICS
+#  define _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD                                                                      \
+    _LIBCPP_PUSH_EXTENSION_DIAGNOSTICS namespace _LIBCPP_TYPE_VISIBILITY_DEFAULT std {
 
-#define _LIBCPP_BEGIN_NAMESPACE_EXPERIMENTAL namespace std { namespace experimental {
-#define _LIBCPP_END_NAMESPACE_EXPERIMENTAL }}
+#  define _LIBCPP_END_UNVERSIONED_NAMESPACE_STD } _LIBCPP_POP_EXTENSION_DIAGNOSTICS
+
+#  define _LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD inline namespace _LIBCPP_ABI_NAMESPACE {
+#  define _LIBCPP_END_NAMESPACE_STD } _LIBCPP_END_UNVERSIONED_NAMESPACE_STD
+
+#define _LIBCPP_BEGIN_NAMESPACE_EXPERIMENTAL _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD namespace experimental {
+#define _LIBCPP_END_NAMESPACE_EXPERIMENTAL } _LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 
 #define _LIBCPP_BEGIN_NAMESPACE_LFTS _LIBCPP_BEGIN_NAMESPACE_EXPERIMENTAL inline namespace fundamentals_v1 {
 #define _LIBCPP_END_NAMESPACE_LFTS } _LIBCPP_END_NAMESPACE_EXPERIMENTAL

--- a/libcxx/include/__coroutine/coroutine_handle.h
+++ b/libcxx/include/__coroutine/coroutine_handle.h
@@ -28,10 +28,10 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 // [coroutine.handle]
 template <class _Promise = void>
-struct _LIBCPP_TEMPLATE_VIS coroutine_handle;
+struct coroutine_handle;
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS coroutine_handle<void> {
+struct coroutine_handle<void> {
 public:
   // [coroutine.handle.con], construct/reset
   constexpr coroutine_handle() noexcept = default;
@@ -93,7 +93,7 @@ operator<=>(coroutine_handle<> __x, coroutine_handle<> __y) noexcept {
 }
 
 template <class _Promise>
-struct _LIBCPP_TEMPLATE_VIS coroutine_handle {
+struct coroutine_handle {
 public:
   // [coroutine.handle.con], construct/reset
   constexpr coroutine_handle() noexcept = default;

--- a/libcxx/include/__coroutine/noop_coroutine_handle.h
+++ b/libcxx/include/__coroutine/noop_coroutine_handle.h
@@ -28,7 +28,7 @@ struct noop_coroutine_promise {};
 
 // [coroutine.handle.noop]
 template <>
-struct _LIBCPP_TEMPLATE_VIS coroutine_handle<noop_coroutine_promise> {
+struct coroutine_handle<noop_coroutine_promise> {
 public:
   // [coroutine.handle.noop.conv], conversion
   _LIBCPP_HIDE_FROM_ABI constexpr operator coroutine_handle<>() const noexcept {

--- a/libcxx/include/__cstddef/byte.h
+++ b/libcxx/include/__cstddef/byte.h
@@ -19,7 +19,7 @@
 #endif
 
 #if _LIBCPP_STD_VER >= 17
-namespace std { // purposefully not versioned
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 
 enum class byte : unsigned char {};
 
@@ -79,7 +79,7 @@ template <class _Integer, __enable_if_t<is_integral<_Integer>::value, int> = 0>
   return static_cast<_Integer>(__b);
 }
 
-} // namespace std
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 #endif // _LIBCPP_STD_VER >= 17
 
 #endif // _LIBCPP___CSTDDEF_BYTE_H

--- a/libcxx/include/__exception/exception.h
+++ b/libcxx/include/__exception/exception.h
@@ -21,7 +21,7 @@
 #  pragma GCC system_header
 #endif
 
-namespace std { // purposefully not using versioning namespace
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 
 #if defined(_LIBCPP_ABI_VCRUNTIME) && (!defined(_HAS_EXCEPTIONS) || _HAS_EXCEPTIONS != 0)
 // The std::exception class was already included above, but we're explicit about this condition here for clarity.
@@ -89,6 +89,6 @@ public:
 };
 #endif // !_LIBCPP_ABI_VCRUNTIME
 
-} // namespace std
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 
 #endif // _LIBCPP___EXCEPTION_EXCEPTION_H

--- a/libcxx/include/__exception/exception_ptr.h
+++ b/libcxx/include/__exception/exception_ptr.h
@@ -52,7 +52,7 @@ _LIBCPP_OVERRIDABLE_FUNC_VIS __cxa_exception* __cxa_init_primary_exception(
 
 #endif
 
-namespace std { // purposefully not using versioning namespace
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 
 #ifndef _LIBCPP_ABI_MICROSOFT
 
@@ -171,6 +171,6 @@ _LIBCPP_HIDE_FROM_ABI exception_ptr make_exception_ptr(_Ep __e) _NOEXCEPT {
 }
 
 #endif // _LIBCPP_ABI_MICROSOFT
-} // namespace std
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 
 #endif // _LIBCPP___EXCEPTION_EXCEPTION_PTR_H

--- a/libcxx/include/__exception/nested_exception.h
+++ b/libcxx/include/__exception/nested_exception.h
@@ -27,7 +27,7 @@
 #  pragma GCC system_header
 #endif
 
-namespace std { // purposefully not using versioning namespace
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 
 class _LIBCPP_EXPORTED_FROM_ABI nested_exception {
   exception_ptr __ptr_;
@@ -95,6 +95,6 @@ inline _LIBCPP_HIDE_FROM_ABI void rethrow_if_nested(const _Ep& __e) {
 template <class _Ep, __enable_if_t<!__can_dynamic_cast<_Ep, nested_exception>::value, int> = 0>
 inline _LIBCPP_HIDE_FROM_ABI void rethrow_if_nested(const _Ep&) {}
 
-} // namespace std
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 
 #endif // _LIBCPP___EXCEPTION_NESTED_EXCEPTION_H

--- a/libcxx/include/__exception/operations.h
+++ b/libcxx/include/__exception/operations.h
@@ -15,7 +15,7 @@
 #  pragma GCC system_header
 #endif
 
-namespace std { // purposefully not using versioning namespace
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_UNEXPECTED_FUNCTIONS) ||                             \
     defined(_LIBCPP_BUILDING_LIBRARY)
 using unexpected_handler = void (*)();
@@ -37,6 +37,6 @@ class _LIBCPP_EXPORTED_FROM_ABI exception_ptr;
 
 _LIBCPP_EXPORTED_FROM_ABI exception_ptr current_exception() _NOEXCEPT;
 [[__noreturn__]] _LIBCPP_EXPORTED_FROM_ABI void rethrow_exception(exception_ptr);
-} // namespace std
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 
 #endif // _LIBCPP___EXCEPTION_OPERATIONS_H

--- a/libcxx/include/__exception/terminate.h
+++ b/libcxx/include/__exception/terminate.h
@@ -15,8 +15,8 @@
 #  pragma GCC system_header
 #endif
 
-namespace std { // purposefully not using versioning namespace
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 [[__noreturn__]] _LIBCPP_EXPORTED_FROM_ABI void terminate() _NOEXCEPT;
-} // namespace std
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 
 #endif // _LIBCPP___EXCEPTION_TERMINATE_H

--- a/libcxx/include/__format/buffer.h
+++ b/libcxx/include/__format/buffer.h
@@ -179,7 +179,7 @@ private:
 /// The latter option allows formatted_size to use the output buffer without
 /// ever writing anything to the buffer.
 template <__fmt_char_type _CharT>
-class _LIBCPP_TEMPLATE_VIS __output_buffer {
+class __output_buffer {
 public:
   using value_type _LIBCPP_NODEBUG           = _CharT;
   using __prepare_write_type _LIBCPP_NODEBUG = void (*)(__output_buffer<_CharT>&, size_t);
@@ -339,18 +339,18 @@ concept __insertable =
 
 /// Extract the container type of a \ref back_insert_iterator.
 template <class _It>
-struct _LIBCPP_TEMPLATE_VIS __back_insert_iterator_container {
+struct __back_insert_iterator_container {
   using type _LIBCPP_NODEBUG = void;
 };
 
 template <__insertable _Container>
-struct _LIBCPP_TEMPLATE_VIS __back_insert_iterator_container<back_insert_iterator<_Container>> {
+struct __back_insert_iterator_container<back_insert_iterator<_Container>> {
   using type _LIBCPP_NODEBUG = _Container;
 };
 
 // A dynamically growing buffer.
 template <__fmt_char_type _CharT>
-class _LIBCPP_TEMPLATE_VIS __allocating_buffer : public __output_buffer<_CharT> {
+class __allocating_buffer : public __output_buffer<_CharT> {
 public:
   __allocating_buffer(const __allocating_buffer&)            = delete;
   __allocating_buffer& operator=(const __allocating_buffer&) = delete;
@@ -407,7 +407,7 @@ private:
 
 // A buffer that directly writes to the underlying buffer.
 template <class _OutIt, __fmt_char_type _CharT>
-class _LIBCPP_TEMPLATE_VIS __direct_iterator_buffer : public __output_buffer<_CharT> {
+class __direct_iterator_buffer : public __output_buffer<_CharT> {
 public:
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI explicit __direct_iterator_buffer(_OutIt __out_it)
       : __direct_iterator_buffer{__out_it, nullptr} {}
@@ -436,7 +436,7 @@ private:
 
 // A buffer that writes its output to the end of a container.
 template <class _OutIt, __fmt_char_type _CharT>
-class _LIBCPP_TEMPLATE_VIS __container_inserter_buffer : public __output_buffer<_CharT> {
+class __container_inserter_buffer : public __output_buffer<_CharT> {
 public:
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI explicit __container_inserter_buffer(_OutIt __out_it)
       : __container_inserter_buffer{__out_it, nullptr} {}
@@ -477,7 +477,7 @@ private:
 // Unlike the __container_inserter_buffer this class' performance does benefit
 // from allocating and then inserting.
 template <class _OutIt, __fmt_char_type _CharT>
-class _LIBCPP_TEMPLATE_VIS __iterator_buffer : public __allocating_buffer<_CharT> {
+class __iterator_buffer : public __allocating_buffer<_CharT> {
 public:
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI explicit __iterator_buffer(_OutIt __out_it)
       : __allocating_buffer<_CharT>{}, __out_it_{std::move(__out_it)} {}
@@ -495,7 +495,7 @@ private:
 
 // Selects the type of the buffer used for the output iterator.
 template <class _OutIt, __fmt_char_type _CharT>
-class _LIBCPP_TEMPLATE_VIS __buffer_selector {
+class __buffer_selector {
   using _Container _LIBCPP_NODEBUG = __back_insert_iterator_container<_OutIt>::type;
 
 public:
@@ -509,7 +509,7 @@ public:
 
 // A buffer that counts and limits the number of insertions.
 template <class _OutIt, __fmt_char_type _CharT>
-class _LIBCPP_TEMPLATE_VIS __format_to_n_buffer : private __buffer_selector<_OutIt, _CharT>::type {
+class __format_to_n_buffer : private __buffer_selector<_OutIt, _CharT>::type {
 public:
   using _Base _LIBCPP_NODEBUG = __buffer_selector<_OutIt, _CharT>::type;
 
@@ -533,7 +533,7 @@ private:
 // Since formatted_size only needs to know the size, the output itself is
 // discarded.
 template <__fmt_char_type _CharT>
-class _LIBCPP_TEMPLATE_VIS __formatted_size_buffer : private __output_buffer<_CharT> {
+class __formatted_size_buffer : private __output_buffer<_CharT> {
 public:
   using _Base _LIBCPP_NODEBUG = __output_buffer<_CharT>;
 
@@ -576,7 +576,7 @@ private:
 // This class uses its own buffer management, since using vector
 // would lead to a circular include with formatter for vector<bool>.
 template <__fmt_char_type _CharT>
-class _LIBCPP_TEMPLATE_VIS __retarget_buffer {
+class __retarget_buffer {
   using _Alloc _LIBCPP_NODEBUG = allocator<_CharT>;
 
 public:

--- a/libcxx/include/__format/container_adaptor.h
+++ b/libcxx/include/__format/container_adaptor.h
@@ -35,7 +35,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // adaptor headers. To use the format functions users already include <format>.
 
 template <class _Adaptor, class _CharT>
-struct _LIBCPP_TEMPLATE_VIS __formatter_container_adaptor {
+struct __formatter_container_adaptor {
 private:
   using __maybe_const_container _LIBCPP_NODEBUG = __fmt_maybe_const<typename _Adaptor::container_type, _CharT>;
   using __maybe_const_adaptor _LIBCPP_NODEBUG   = __maybe_const<is_const_v<__maybe_const_container>, _Adaptor>;
@@ -55,15 +55,15 @@ public:
 };
 
 template <class _CharT, class _Tp, formattable<_CharT> _Container>
-struct _LIBCPP_TEMPLATE_VIS formatter<queue<_Tp, _Container>, _CharT>
+struct formatter<queue<_Tp, _Container>, _CharT>
     : public __formatter_container_adaptor<queue<_Tp, _Container>, _CharT> {};
 
 template <class _CharT, class _Tp, class _Container, class _Compare>
-struct _LIBCPP_TEMPLATE_VIS formatter<priority_queue<_Tp, _Container, _Compare>, _CharT>
+struct formatter<priority_queue<_Tp, _Container, _Compare>, _CharT>
     : public __formatter_container_adaptor<priority_queue<_Tp, _Container, _Compare>, _CharT> {};
 
 template <class _CharT, class _Tp, formattable<_CharT> _Container>
-struct _LIBCPP_TEMPLATE_VIS formatter<stack<_Tp, _Container>, _CharT>
+struct formatter<stack<_Tp, _Container>, _CharT>
     : public __formatter_container_adaptor<stack<_Tp, _Container>, _CharT> {};
 
 #endif // _LIBCPP_STD_VER >= 23

--- a/libcxx/include/__format/format_arg.h
+++ b/libcxx/include/__format/format_arg.h
@@ -277,9 +277,9 @@ public:
 };
 
 template <class _Context>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS basic_format_arg {
+class _LIBCPP_NO_SPECIALIZATIONS basic_format_arg {
 public:
-  class _LIBCPP_TEMPLATE_VIS handle;
+  class handle;
 
   _LIBCPP_HIDE_FROM_ABI basic_format_arg() noexcept : __type_{__format::__arg_t::__none} {}
 
@@ -355,7 +355,7 @@ public:
 };
 
 template <class _Context>
-class _LIBCPP_TEMPLATE_VIS basic_format_arg<_Context>::handle {
+class basic_format_arg<_Context>::handle {
 public:
   _LIBCPP_HIDE_FROM_ABI void format(basic_format_parse_context<char_type>& __parse_ctx, _Context& __ctx) const {
     __handle_.__format_(__parse_ctx, __ctx, __handle_.__ptr_);

--- a/libcxx/include/__format/format_arg_store.h
+++ b/libcxx/include/__format/format_arg_store.h
@@ -247,7 +247,7 @@ struct __unpacked_format_arg_store {
 } // namespace __format
 
 template <class _Context, class... _Args>
-struct _LIBCPP_TEMPLATE_VIS __format_arg_store {
+struct __format_arg_store {
   _LIBCPP_HIDE_FROM_ABI __format_arg_store(_Args&... __args) noexcept {
     if constexpr (sizeof...(_Args) != 0) {
       if constexpr (__format::__use_packed_format_arg_store(sizeof...(_Args)))

--- a/libcxx/include/__format/format_args.h
+++ b/libcxx/include/__format/format_args.h
@@ -26,7 +26,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 20
 
 template <class _Context>
-class _LIBCPP_TEMPLATE_VIS basic_format_args {
+class basic_format_args {
 public:
   template <class... _Args>
   _LIBCPP_HIDE_FROM_ABI basic_format_args(const __format_arg_store<_Context, _Args...>& __store) noexcept

--- a/libcxx/include/__format/format_context.h
+++ b/libcxx/include/__format/format_context.h
@@ -42,7 +42,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _OutIt, class _CharT>
   requires output_iterator<_OutIt, const _CharT&>
-class _LIBCPP_TEMPLATE_VIS basic_format_context;
+class basic_format_context;
 
 #  if _LIBCPP_HAS_LOCALIZATION
 /**
@@ -72,12 +72,7 @@ using wformat_context = basic_format_context< back_insert_iterator<__format::__o
 
 template <class _OutIt, class _CharT>
   requires output_iterator<_OutIt, const _CharT&>
-class
-    // clang-format off
-    _LIBCPP_TEMPLATE_VIS
-    _LIBCPP_PREFERRED_NAME(format_context)
-    _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wformat_context))
-    // clang-format on
+class _LIBCPP_PREFERRED_NAME(format_context) _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wformat_context))
     basic_format_context {
 public:
   using iterator  = _OutIt;
@@ -153,7 +148,7 @@ public:
 // Here the width of an element in input is determined dynamically.
 // Note when the top-level element has no width the retargeting is not needed.
 template <class _CharT>
-class _LIBCPP_TEMPLATE_VIS basic_format_context<typename __format::__retarget_buffer<_CharT>::__iterator, _CharT> {
+class basic_format_context<typename __format::__retarget_buffer<_CharT>::__iterator, _CharT> {
 public:
   using iterator  = typename __format::__retarget_buffer<_CharT>::__iterator;
   using char_type = _CharT;

--- a/libcxx/include/__format/format_functions.h
+++ b/libcxx/include/__format/format_functions.h
@@ -83,7 +83,7 @@ namespace __format {
 /// When parsing a handle which is not enabled the code is ill-formed.
 /// This helper uses the parser of the appropriate formatter for the stored type.
 template <class _CharT>
-class _LIBCPP_TEMPLATE_VIS __compile_time_handle {
+class __compile_time_handle {
 public:
   template <class _ParseContext>
   _LIBCPP_HIDE_FROM_ABI constexpr void __parse(_ParseContext& __ctx) const {
@@ -110,7 +110,7 @@ private:
 // Dummy format_context only providing the parts used during constant
 // validation of the basic_format_string.
 template <class _CharT>
-struct _LIBCPP_TEMPLATE_VIS __compile_time_basic_format_context {
+struct __compile_time_basic_format_context {
 public:
   using char_type = _CharT;
 
@@ -339,12 +339,12 @@ _LIBCPP_HIDE_FROM_ABI constexpr typename _Ctx::iterator __vformat_to(_ParseCtx&&
 
 #  if _LIBCPP_STD_VER >= 26
 template <class _CharT>
-struct _LIBCPP_TEMPLATE_VIS __runtime_format_string {
+struct __runtime_format_string {
 private:
   basic_string_view<_CharT> __str_;
 
   template <class _Cp, class... _Args>
-  friend struct _LIBCPP_TEMPLATE_VIS basic_format_string;
+  friend struct basic_format_string;
 
 public:
   _LIBCPP_HIDE_FROM_ABI __runtime_format_string(basic_string_view<_CharT> __s) noexcept : __str_(__s) {}
@@ -362,7 +362,7 @@ _LIBCPP_HIDE_FROM_ABI inline __runtime_format_string<wchar_t> runtime_format(wst
 #  endif // _LIBCPP_STD_VER >= 26
 
 template <class _CharT, class... _Args>
-struct _LIBCPP_TEMPLATE_VIS basic_format_string {
+struct basic_format_string {
   template <class _Tp>
     requires convertible_to<const _Tp&, basic_string_view<_CharT>>
   consteval basic_format_string(const _Tp& __str) : __str_{__str} {

--- a/libcxx/include/__format/format_parse_context.h
+++ b/libcxx/include/__format/format_parse_context.h
@@ -24,7 +24,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 20
 
 template <class _CharT>
-class _LIBCPP_TEMPLATE_VIS basic_format_parse_context {
+class basic_format_parse_context {
 public:
   using char_type      = _CharT;
   using const_iterator = typename basic_string_view<_CharT>::const_iterator;

--- a/libcxx/include/__format/format_string.h
+++ b/libcxx/include/__format/format_string.h
@@ -29,7 +29,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 namespace __format {
 
 template <contiguous_iterator _Iterator>
-struct _LIBCPP_TEMPLATE_VIS __parse_number_result {
+struct __parse_number_result {
   _Iterator __last;
   uint32_t __value;
 };

--- a/libcxx/include/__format/format_to_n_result.h
+++ b/libcxx/include/__format/format_to_n_result.h
@@ -22,7 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 20
 
 template <class _OutIt>
-struct _LIBCPP_TEMPLATE_VIS format_to_n_result {
+struct format_to_n_result {
   _OutIt out;
   iter_difference_t<_OutIt> size;
 };

--- a/libcxx/include/__format/formatter.h
+++ b/libcxx/include/__format/formatter.h
@@ -37,7 +37,7 @@ struct __disabled_formatter {
 /// - is_copy_assignable_v<F>, and
 /// - is_move_assignable_v<F>.
 template <class _Tp, class _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter : __disabled_formatter {};
+struct formatter : __disabled_formatter {};
 
 #  if _LIBCPP_STD_VER >= 23
 

--- a/libcxx/include/__format/formatter_bool.h
+++ b/libcxx/include/__format/formatter_bool.h
@@ -33,7 +33,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 20
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<bool, _CharT> {
+struct formatter<bool, _CharT> {
 public:
   template <class _ParseContext>
   _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {

--- a/libcxx/include/__format/formatter_char.h
+++ b/libcxx/include/__format/formatter_char.h
@@ -31,7 +31,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 20
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS __formatter_char {
+struct __formatter_char {
 public:
   template <class _ParseContext>
   _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
@@ -75,14 +75,14 @@ public:
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS formatter<char, char> : public __formatter_char<char> {};
+struct formatter<char, char> : public __formatter_char<char> {};
 
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
-struct _LIBCPP_TEMPLATE_VIS formatter<char, wchar_t> : public __formatter_char<wchar_t> {};
+struct formatter<char, wchar_t> : public __formatter_char<wchar_t> {};
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS formatter<wchar_t, wchar_t> : public __formatter_char<wchar_t> {};
+struct formatter<wchar_t, wchar_t> : public __formatter_char<wchar_t> {};
 #  endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 #  if _LIBCPP_STD_VER >= 23

--- a/libcxx/include/__format/formatter_floating_point.h
+++ b/libcxx/include/__format/formatter_floating_point.h
@@ -140,7 +140,7 @@ struct __traits<double> {
 /// Depending on the maximum size required for a value, the buffer is allocated
 /// on the stack or the heap.
 template <floating_point _Fp>
-class _LIBCPP_TEMPLATE_VIS __float_buffer {
+class __float_buffer {
   using _Traits _LIBCPP_NODEBUG = __traits<_Fp>;
 
 public:
@@ -750,7 +750,7 @@ __format_floating_point(_Tp __value, _FormatContext& __ctx, __format_spec::__par
 } // namespace __formatter
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS __formatter_floating_point {
+struct __formatter_floating_point {
 public:
   template <class _ParseContext>
   _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
@@ -768,11 +768,11 @@ public:
 };
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<float, _CharT> : public __formatter_floating_point<_CharT> {};
+struct formatter<float, _CharT> : public __formatter_floating_point<_CharT> {};
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<double, _CharT> : public __formatter_floating_point<_CharT> {};
+struct formatter<double, _CharT> : public __formatter_floating_point<_CharT> {};
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<long double, _CharT> : public __formatter_floating_point<_CharT> {};
+struct formatter<long double, _CharT> : public __formatter_floating_point<_CharT> {};
 
 #  if _LIBCPP_STD_VER >= 23
 template <>

--- a/libcxx/include/__format/formatter_integer.h
+++ b/libcxx/include/__format/formatter_integer.h
@@ -30,7 +30,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 20
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS __formatter_integer {
+struct __formatter_integer {
 public:
   template <class _ParseContext>
   _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
@@ -58,34 +58,34 @@ public:
 
 // Signed integral types.
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<signed char, _CharT> : public __formatter_integer<_CharT> {};
+struct formatter<signed char, _CharT> : public __formatter_integer<_CharT> {};
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<short, _CharT> : public __formatter_integer<_CharT> {};
+struct formatter<short, _CharT> : public __formatter_integer<_CharT> {};
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<int, _CharT> : public __formatter_integer<_CharT> {};
+struct formatter<int, _CharT> : public __formatter_integer<_CharT> {};
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<long, _CharT> : public __formatter_integer<_CharT> {};
+struct formatter<long, _CharT> : public __formatter_integer<_CharT> {};
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<long long, _CharT> : public __formatter_integer<_CharT> {};
+struct formatter<long long, _CharT> : public __formatter_integer<_CharT> {};
 #  if _LIBCPP_HAS_INT128
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<__int128_t, _CharT> : public __formatter_integer<_CharT> {};
+struct formatter<__int128_t, _CharT> : public __formatter_integer<_CharT> {};
 #  endif
 
 // Unsigned integral types.
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<unsigned char, _CharT> : public __formatter_integer<_CharT> {};
+struct formatter<unsigned char, _CharT> : public __formatter_integer<_CharT> {};
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<unsigned short, _CharT> : public __formatter_integer<_CharT> {};
+struct formatter<unsigned short, _CharT> : public __formatter_integer<_CharT> {};
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<unsigned, _CharT> : public __formatter_integer<_CharT> {};
+struct formatter<unsigned, _CharT> : public __formatter_integer<_CharT> {};
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<unsigned long, _CharT> : public __formatter_integer<_CharT> {};
+struct formatter<unsigned long, _CharT> : public __formatter_integer<_CharT> {};
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<unsigned long long, _CharT> : public __formatter_integer<_CharT> {};
+struct formatter<unsigned long long, _CharT> : public __formatter_integer<_CharT> {};
 #  if _LIBCPP_HAS_INT128
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<__uint128_t, _CharT> : public __formatter_integer<_CharT> {};
+struct formatter<__uint128_t, _CharT> : public __formatter_integer<_CharT> {};
 #  endif
 
 #  if _LIBCPP_STD_VER >= 23

--- a/libcxx/include/__format/formatter_integral.h
+++ b/libcxx/include/__format/formatter_integral.h
@@ -404,17 +404,17 @@ __format_integer(_Tp __value, _FormatContext& __ctx, __format_spec::__parsed_spe
 //
 
 template <class _CharT>
-struct _LIBCPP_TEMPLATE_VIS __bool_strings;
+struct __bool_strings;
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS __bool_strings<char> {
+struct __bool_strings<char> {
   static constexpr string_view __true{"true"};
   static constexpr string_view __false{"false"};
 };
 
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
-struct _LIBCPP_TEMPLATE_VIS __bool_strings<wchar_t> {
+struct __bool_strings<wchar_t> {
   static constexpr wstring_view __true{L"true"};
   static constexpr wstring_view __false{L"false"};
 };

--- a/libcxx/include/__format/formatter_pointer.h
+++ b/libcxx/include/__format/formatter_pointer.h
@@ -29,7 +29,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 20
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS __formatter_pointer {
+struct __formatter_pointer {
 public:
   template <class _ParseContext>
   _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
@@ -59,11 +59,11 @@ public:
 // - template<> struct formatter<void*, charT>;
 // - template<> struct formatter<const void*, charT>;
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<nullptr_t, _CharT> : public __formatter_pointer<_CharT> {};
+struct formatter<nullptr_t, _CharT> : public __formatter_pointer<_CharT> {};
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<void*, _CharT> : public __formatter_pointer<_CharT> {};
+struct formatter<void*, _CharT> : public __formatter_pointer<_CharT> {};
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<const void*, _CharT> : public __formatter_pointer<_CharT> {};
+struct formatter<const void*, _CharT> : public __formatter_pointer<_CharT> {};
 
 #  if _LIBCPP_STD_VER >= 23
 template <>

--- a/libcxx/include/__format/formatter_string.h
+++ b/libcxx/include/__format/formatter_string.h
@@ -29,7 +29,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 20
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS __formatter_string {
+struct __formatter_string {
 public:
   template <class _ParseContext>
   _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {
@@ -58,7 +58,7 @@ public:
 
 // Formatter const char*.
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<const _CharT*, _CharT> : public __formatter_string<_CharT> {
+struct formatter<const _CharT*, _CharT> : public __formatter_string<_CharT> {
   using _Base _LIBCPP_NODEBUG = __formatter_string<_CharT>;
 
   template <class _FormatContext>
@@ -77,7 +77,7 @@ struct _LIBCPP_TEMPLATE_VIS formatter<const _CharT*, _CharT> : public __formatte
 
 // Formatter char*.
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<_CharT*, _CharT> : public formatter<const _CharT*, _CharT> {
+struct formatter<_CharT*, _CharT> : public formatter<const _CharT*, _CharT> {
   using _Base _LIBCPP_NODEBUG = formatter<const _CharT*, _CharT>;
 
   template <class _FormatContext>
@@ -88,7 +88,7 @@ struct _LIBCPP_TEMPLATE_VIS formatter<_CharT*, _CharT> : public formatter<const 
 
 // Formatter char[].
 template <__fmt_char_type _CharT, size_t _Size>
-struct _LIBCPP_TEMPLATE_VIS formatter<_CharT[_Size], _CharT> : public __formatter_string<_CharT> {
+struct formatter<_CharT[_Size], _CharT> : public __formatter_string<_CharT> {
   using _Base _LIBCPP_NODEBUG = __formatter_string<_CharT>;
 
   template <class _FormatContext>
@@ -100,7 +100,7 @@ struct _LIBCPP_TEMPLATE_VIS formatter<_CharT[_Size], _CharT> : public __formatte
 
 // Formatter std::string.
 template <__fmt_char_type _CharT, class _Traits, class _Allocator>
-struct _LIBCPP_TEMPLATE_VIS formatter<basic_string<_CharT, _Traits, _Allocator>, _CharT>
+struct formatter<basic_string<_CharT, _Traits, _Allocator>, _CharT>
     : public __formatter_string<_CharT> {
   using _Base _LIBCPP_NODEBUG = __formatter_string<_CharT>;
 
@@ -114,7 +114,7 @@ struct _LIBCPP_TEMPLATE_VIS formatter<basic_string<_CharT, _Traits, _Allocator>,
 
 // Formatter std::string_view.
 template <__fmt_char_type _CharT, class _Traits>
-struct _LIBCPP_TEMPLATE_VIS formatter<basic_string_view<_CharT, _Traits>, _CharT> : public __formatter_string<_CharT> {
+struct formatter<basic_string_view<_CharT, _Traits>, _CharT> : public __formatter_string<_CharT> {
   using _Base _LIBCPP_NODEBUG = __formatter_string<_CharT>;
 
   template <class _FormatContext>

--- a/libcxx/include/__format/formatter_tuple.h
+++ b/libcxx/include/__format/formatter_tuple.h
@@ -36,7 +36,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 23
 
 template <__fmt_char_type _CharT, class _Tuple, formattable<_CharT>... _Args>
-struct _LIBCPP_TEMPLATE_VIS __formatter_tuple {
+struct __formatter_tuple {
   _LIBCPP_HIDE_FROM_ABI constexpr void set_separator(basic_string_view<_CharT> __separator) noexcept {
     __separator_ = __separator;
   }
@@ -136,12 +136,10 @@ private:
 };
 
 template <__fmt_char_type _CharT, formattable<_CharT>... _Args>
-struct _LIBCPP_TEMPLATE_VIS formatter<pair<_Args...>, _CharT>
-    : public __formatter_tuple<_CharT, pair<_Args...>, _Args...> {};
+struct formatter<pair<_Args...>, _CharT> : public __formatter_tuple<_CharT, pair<_Args...>, _Args...> {};
 
 template <__fmt_char_type _CharT, formattable<_CharT>... _Args>
-struct _LIBCPP_TEMPLATE_VIS formatter<tuple<_Args...>, _CharT>
-    : public __formatter_tuple<_CharT, tuple<_Args...>, _Args...> {};
+struct formatter<tuple<_Args...>, _CharT> : public __formatter_tuple<_CharT, tuple<_Args...>, _Args...> {};
 
 #endif // _LIBCPP_STD_VER >= 23
 

--- a/libcxx/include/__format/parser_std_format_spec.h
+++ b/libcxx/include/__format/parser_std_format_spec.h
@@ -335,7 +335,7 @@ static_assert(is_trivially_copyable_v<__parsed_specifications<wchar_t>>);
 /// set to zero. That way they can be repurposed if a future revision of the
 /// Standards adds new fields to std-format-spec.
 template <class _CharT>
-class _LIBCPP_TEMPLATE_VIS __parser {
+class __parser {
 public:
   // Parses the format specification.
   //

--- a/libcxx/include/__format/range_default_formatter.h
+++ b/libcxx/include/__format/range_default_formatter.h
@@ -52,7 +52,7 @@ _LIBCPP_DIAGNOSTIC_POP
 // There is no definition of this struct, it's purely intended to be used to
 // generate diagnostics.
 template <class _Rp>
-struct _LIBCPP_TEMPLATE_VIS __instantiated_the_primary_template_of_format_kind;
+struct __instantiated_the_primary_template_of_format_kind;
 
 template <class _Rp>
 constexpr range_format format_kind = [] {
@@ -88,12 +88,12 @@ inline constexpr range_format format_kind<_Rp> = [] {
 }();
 
 template <range_format _Kp, ranges::input_range _Rp, class _CharT>
-struct _LIBCPP_TEMPLATE_VIS __range_default_formatter;
+struct __range_default_formatter;
 
 // Required specializations
 
 template <ranges::input_range _Rp, class _CharT>
-struct _LIBCPP_TEMPLATE_VIS __range_default_formatter<range_format::sequence, _Rp, _CharT> {
+struct __range_default_formatter<range_format::sequence, _Rp, _CharT> {
 private:
   using __maybe_const_r _LIBCPP_NODEBUG = __fmt_maybe_const<_Rp, _CharT>;
   range_formatter<remove_cvref_t<ranges::range_reference_t<__maybe_const_r>>, _CharT> __underlying_;
@@ -120,7 +120,7 @@ public:
 };
 
 template <ranges::input_range _Rp, class _CharT>
-struct _LIBCPP_TEMPLATE_VIS __range_default_formatter<range_format::map, _Rp, _CharT> {
+struct __range_default_formatter<range_format::map, _Rp, _CharT> {
 private:
   using __maybe_const_map _LIBCPP_NODEBUG = __fmt_maybe_const<_Rp, _CharT>;
   using __element_type _LIBCPP_NODEBUG    = remove_cvref_t<ranges::range_reference_t<__maybe_const_map>>;
@@ -148,7 +148,7 @@ public:
 };
 
 template <ranges::input_range _Rp, class _CharT>
-struct _LIBCPP_TEMPLATE_VIS __range_default_formatter<range_format::set, _Rp, _CharT> {
+struct __range_default_formatter<range_format::set, _Rp, _CharT> {
 private:
   using __maybe_const_set _LIBCPP_NODEBUG = __fmt_maybe_const<_Rp, _CharT>;
   using __element_type _LIBCPP_NODEBUG    = remove_cvref_t<ranges::range_reference_t<__maybe_const_set>>;
@@ -173,7 +173,7 @@ public:
 
 template <range_format _Kp, ranges::input_range _Rp, class _CharT>
   requires(_Kp == range_format::string || _Kp == range_format::debug_string)
-struct _LIBCPP_TEMPLATE_VIS __range_default_formatter<_Kp, _Rp, _CharT> {
+struct __range_default_formatter<_Kp, _Rp, _CharT> {
 private:
   // This deviates from the Standard, there the exposition only type is
   //   formatter<basic_string<charT>, charT> underlying_;
@@ -205,7 +205,7 @@ public:
 
 template <ranges::input_range _Rp, class _CharT>
   requires(format_kind<_Rp> != range_format::disabled && formattable<ranges::range_reference_t<_Rp>, _CharT>)
-struct _LIBCPP_TEMPLATE_VIS formatter<_Rp, _CharT> : __range_default_formatter<format_kind<_Rp>, _Rp, _CharT> {};
+struct formatter<_Rp, _CharT> : __range_default_formatter<format_kind<_Rp>, _Rp, _CharT> {};
 
 #endif // _LIBCPP_STD_VER >= 23
 

--- a/libcxx/include/__format/range_formatter.h
+++ b/libcxx/include/__format/range_formatter.h
@@ -39,7 +39,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _CharT = char>
   requires same_as<remove_cvref_t<_Tp>, _Tp> && formattable<_Tp, _CharT>
-struct _LIBCPP_TEMPLATE_VIS range_formatter {
+struct range_formatter {
   _LIBCPP_HIDE_FROM_ABI constexpr void set_separator(basic_string_view<_CharT> __separator) noexcept {
     __separator_ = __separator;
   }

--- a/libcxx/include/__functional/binary_function.h
+++ b/libcxx/include/__functional/binary_function.h
@@ -21,7 +21,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
 
 template <class _Arg1, class _Arg2, class _Result>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 binary_function {
+struct _LIBCPP_DEPRECATED_IN_CXX11 binary_function {
   typedef _Arg1 first_argument_type;
   typedef _Arg2 second_argument_type;
   typedef _Result result_type;

--- a/libcxx/include/__functional/binary_negate.h
+++ b/libcxx/include/__functional/binary_negate.h
@@ -22,7 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_NEGATORS)
 
 template <class _Predicate>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 binary_negate
+class _LIBCPP_DEPRECATED_IN_CXX17 binary_negate
     : public __binary_function<typename _Predicate::first_argument_type,
                                typename _Predicate::second_argument_type,
                                bool> {

--- a/libcxx/include/__functional/binder1st.h
+++ b/libcxx/include/__functional/binder1st.h
@@ -22,8 +22,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_BINDERS)
 
 template <class _Operation>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 binder1st
-    : public __unary_function<typename _Operation::second_argument_type, typename _Operation::result_type> {
+class _LIBCPP_DEPRECATED_IN_CXX11
+binder1st : public __unary_function<typename _Operation::second_argument_type, typename _Operation::result_type> {
 protected:
   _Operation op;
   typename _Operation::first_argument_type value;

--- a/libcxx/include/__functional/binder2nd.h
+++ b/libcxx/include/__functional/binder2nd.h
@@ -22,8 +22,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_BINDERS)
 
 template <class _Operation>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 binder2nd
-    : public __unary_function<typename _Operation::first_argument_type, typename _Operation::result_type> {
+class _LIBCPP_DEPRECATED_IN_CXX11
+binder2nd : public __unary_function<typename _Operation::first_argument_type, typename _Operation::result_type> {
 protected:
   _Operation op;
   typename _Operation::second_argument_type value;

--- a/libcxx/include/__functional/boyer_moore_searcher.h
+++ b/libcxx/include/__functional/boyer_moore_searcher.h
@@ -88,7 +88,7 @@ public:
 template <class _RandomAccessIterator1,
           class _Hash            = hash<typename iterator_traits<_RandomAccessIterator1>::value_type>,
           class _BinaryPredicate = equal_to<>>
-class _LIBCPP_TEMPLATE_VIS boyer_moore_searcher {
+class boyer_moore_searcher {
 private:
   using difference_type = typename std::iterator_traits<_RandomAccessIterator1>::difference_type;
   using value_type      = typename std::iterator_traits<_RandomAccessIterator1>::value_type;
@@ -219,7 +219,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(boyer_moore_searcher);
 template <class _RandomAccessIterator1,
           class _Hash            = hash<typename iterator_traits<_RandomAccessIterator1>::value_type>,
           class _BinaryPredicate = equal_to<>>
-class _LIBCPP_TEMPLATE_VIS boyer_moore_horspool_searcher {
+class boyer_moore_horspool_searcher {
 private:
   using difference_type = typename iterator_traits<_RandomAccessIterator1>::difference_type;
   using value_type      = typename iterator_traits<_RandomAccessIterator1>::value_type;

--- a/libcxx/include/__functional/default_searcher.h
+++ b/libcxx/include/__functional/default_searcher.h
@@ -27,7 +27,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 // default searcher
 template <class _ForwardIterator, class _BinaryPredicate = equal_to<>>
-class _LIBCPP_TEMPLATE_VIS default_searcher {
+class default_searcher {
 public:
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20
   default_searcher(_ForwardIterator __f, _ForwardIterator __l, _BinaryPredicate __p = _BinaryPredicate())

--- a/libcxx/include/__functional/function.h
+++ b/libcxx/include/__functional/function.h
@@ -86,7 +86,7 @@ _LIBCPP_DIAGNOSTIC_POP
 }
 
 template <class _Fp>
-class _LIBCPP_TEMPLATE_VIS function; // undefined
+class function; // undefined
 
 namespace __function {
 
@@ -234,7 +234,7 @@ public:
 // __base provides an abstract interface for copyable functors.
 
 template <class _Fp>
-class _LIBCPP_TEMPLATE_VIS __base;
+class __base;
 
 template <class _Rp, class... _ArgTypes>
 class __base<_Rp(_ArgTypes...)> {
@@ -827,7 +827,7 @@ public:
 } // namespace __function
 
 template <class _Rp, class... _ArgTypes>
-class _LIBCPP_TEMPLATE_VIS function<_Rp(_ArgTypes...)>
+class function<_Rp(_ArgTypes...)>
     : public __function::__maybe_derive_from_unary_function<_Rp(_ArgTypes...)>,
       public __function::__maybe_derive_from_binary_function<_Rp(_ArgTypes...)> {
 #  ifndef _LIBCPP_ABI_OPTIMIZED_FUNCTION

--- a/libcxx/include/__functional/hash.h
+++ b/libcxx/include/__functional/hash.h
@@ -326,7 +326,7 @@ _LIBCPP_HIDE_FROM_ABI inline size_t __hash_combine(size_t __lhs, size_t __rhs) _
 }
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS hash<_Tp*> : public __unary_function<_Tp*, size_t> {
+struct hash<_Tp*> : public __unary_function<_Tp*, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(_Tp* __v) const _NOEXCEPT {
     union {
       _Tp* __t;
@@ -338,76 +338,76 @@ struct _LIBCPP_TEMPLATE_VIS hash<_Tp*> : public __unary_function<_Tp*, size_t> {
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<bool> : public __unary_function<bool, size_t> {
+struct hash<bool> : public __unary_function<bool, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(bool __v) const _NOEXCEPT { return static_cast<size_t>(__v); }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<char> : public __unary_function<char, size_t> {
+struct hash<char> : public __unary_function<char, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(char __v) const _NOEXCEPT { return static_cast<size_t>(__v); }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<signed char> : public __unary_function<signed char, size_t> {
+struct hash<signed char> : public __unary_function<signed char, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(signed char __v) const _NOEXCEPT { return static_cast<size_t>(__v); }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<unsigned char> : public __unary_function<unsigned char, size_t> {
+struct hash<unsigned char> : public __unary_function<unsigned char, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(unsigned char __v) const _NOEXCEPT { return static_cast<size_t>(__v); }
 };
 
 #if _LIBCPP_HAS_CHAR8_T
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<char8_t> : public __unary_function<char8_t, size_t> {
+struct hash<char8_t> : public __unary_function<char8_t, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(char8_t __v) const _NOEXCEPT { return static_cast<size_t>(__v); }
 };
 #endif // _LIBCPP_HAS_CHAR8_T
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<char16_t> : public __unary_function<char16_t, size_t> {
+struct hash<char16_t> : public __unary_function<char16_t, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(char16_t __v) const _NOEXCEPT { return static_cast<size_t>(__v); }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<char32_t> : public __unary_function<char32_t, size_t> {
+struct hash<char32_t> : public __unary_function<char32_t, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(char32_t __v) const _NOEXCEPT { return static_cast<size_t>(__v); }
 };
 
 #if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<wchar_t> : public __unary_function<wchar_t, size_t> {
+struct hash<wchar_t> : public __unary_function<wchar_t, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(wchar_t __v) const _NOEXCEPT { return static_cast<size_t>(__v); }
 };
 #endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<short> : public __unary_function<short, size_t> {
+struct hash<short> : public __unary_function<short, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(short __v) const _NOEXCEPT { return static_cast<size_t>(__v); }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<unsigned short> : public __unary_function<unsigned short, size_t> {
+struct hash<unsigned short> : public __unary_function<unsigned short, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(unsigned short __v) const _NOEXCEPT { return static_cast<size_t>(__v); }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<int> : public __unary_function<int, size_t> {
+struct hash<int> : public __unary_function<int, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(int __v) const _NOEXCEPT { return static_cast<size_t>(__v); }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<unsigned int> : public __unary_function<unsigned int, size_t> {
+struct hash<unsigned int> : public __unary_function<unsigned int, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(unsigned int __v) const _NOEXCEPT { return static_cast<size_t>(__v); }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<long> : public __unary_function<long, size_t> {
+struct hash<long> : public __unary_function<long, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(long __v) const _NOEXCEPT { return static_cast<size_t>(__v); }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<unsigned long> : public __unary_function<unsigned long, size_t> {
+struct hash<unsigned long> : public __unary_function<unsigned long, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(unsigned long __v) const _NOEXCEPT {
     static_assert(sizeof(size_t) >= sizeof(unsigned long),
                   "This would be a terrible hash function on a platform where size_t is smaller than unsigned long");
@@ -416,23 +416,23 @@ struct _LIBCPP_TEMPLATE_VIS hash<unsigned long> : public __unary_function<unsign
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<long long> : public __scalar_hash<long long> {};
+struct hash<long long> : public __scalar_hash<long long> {};
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<unsigned long long> : public __scalar_hash<unsigned long long> {};
+struct hash<unsigned long long> : public __scalar_hash<unsigned long long> {};
 
 #if _LIBCPP_HAS_INT128
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<__int128_t> : public __scalar_hash<__int128_t> {};
+struct hash<__int128_t> : public __scalar_hash<__int128_t> {};
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<__uint128_t> : public __scalar_hash<__uint128_t> {};
+struct hash<__uint128_t> : public __scalar_hash<__uint128_t> {};
 
 #endif
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<float> : public __scalar_hash<float> {
+struct hash<float> : public __scalar_hash<float> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(float __v) const _NOEXCEPT {
     // -0.0 and 0.0 should return same hash
     if (__v == 0.0f)
@@ -442,7 +442,7 @@ struct _LIBCPP_TEMPLATE_VIS hash<float> : public __scalar_hash<float> {
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<double> : public __scalar_hash<double> {
+struct hash<double> : public __scalar_hash<double> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(double __v) const _NOEXCEPT {
     // -0.0 and 0.0 should return same hash
     if (__v == 0.0)
@@ -452,7 +452,7 @@ struct _LIBCPP_TEMPLATE_VIS hash<double> : public __scalar_hash<double> {
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<long double> : public __scalar_hash<long double> {
+struct hash<long double> : public __scalar_hash<long double> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(long double __v) const _NOEXCEPT {
     // -0.0 and 0.0 should return same hash
     if (__v == 0.0L)
@@ -494,26 +494,26 @@ struct _LIBCPP_TEMPLATE_VIS hash<long double> : public __scalar_hash<long double
 };
 
 template <class _Tp, bool = is_enum<_Tp>::value>
-struct _LIBCPP_TEMPLATE_VIS __enum_hash : public __unary_function<_Tp, size_t> {
+struct __enum_hash : public __unary_function<_Tp, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(_Tp __v) const _NOEXCEPT {
     typedef typename underlying_type<_Tp>::type type;
     return hash<type>()(static_cast<type>(__v));
   }
 };
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS __enum_hash<_Tp, false> {
+struct __enum_hash<_Tp, false> {
   __enum_hash()                              = delete;
   __enum_hash(__enum_hash const&)            = delete;
   __enum_hash& operator=(__enum_hash const&) = delete;
 };
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS hash : public __enum_hash<_Tp> {};
+struct hash : public __enum_hash<_Tp> {};
 
 #if _LIBCPP_STD_VER >= 17
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<nullptr_t> : public __unary_function<nullptr_t, size_t> {
+struct hash<nullptr_t> : public __unary_function<nullptr_t, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(nullptr_t) const _NOEXCEPT { return 662607004ull; }
 };
 #endif

--- a/libcxx/include/__functional/mem_fun_ref.h
+++ b/libcxx/include/__functional/mem_fun_ref.h
@@ -23,7 +23,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_BINDERS)
 
 template <class _Sp, class _Tp>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 mem_fun_t : public __unary_function<_Tp*, _Sp> {
+class _LIBCPP_DEPRECATED_IN_CXX11 mem_fun_t : public __unary_function<_Tp*, _Sp> {
   _Sp (_Tp::*__p_)();
 
 public:
@@ -32,7 +32,7 @@ public:
 };
 
 template <class _Sp, class _Tp, class _Ap>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 mem_fun1_t : public __binary_function<_Tp*, _Ap, _Sp> {
+class _LIBCPP_DEPRECATED_IN_CXX11 mem_fun1_t : public __binary_function<_Tp*, _Ap, _Sp> {
   _Sp (_Tp::*__p_)(_Ap);
 
 public:
@@ -51,7 +51,7 @@ _LIBCPP_DEPRECATED_IN_CXX11 inline _LIBCPP_HIDE_FROM_ABI mem_fun1_t<_Sp, _Tp, _A
 }
 
 template <class _Sp, class _Tp>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 mem_fun_ref_t : public __unary_function<_Tp, _Sp> {
+class _LIBCPP_DEPRECATED_IN_CXX11 mem_fun_ref_t : public __unary_function<_Tp, _Sp> {
   _Sp (_Tp::*__p_)();
 
 public:
@@ -60,7 +60,7 @@ public:
 };
 
 template <class _Sp, class _Tp, class _Ap>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 mem_fun1_ref_t : public __binary_function<_Tp, _Ap, _Sp> {
+class _LIBCPP_DEPRECATED_IN_CXX11 mem_fun1_ref_t : public __binary_function<_Tp, _Ap, _Sp> {
   _Sp (_Tp::*__p_)(_Ap);
 
 public:
@@ -80,7 +80,7 @@ mem_fun_ref(_Sp (_Tp::*__f)(_Ap)) {
 }
 
 template <class _Sp, class _Tp>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 const_mem_fun_t : public __unary_function<const _Tp*, _Sp> {
+class _LIBCPP_DEPRECATED_IN_CXX11 const_mem_fun_t : public __unary_function<const _Tp*, _Sp> {
   _Sp (_Tp::*__p_)() const;
 
 public:
@@ -89,8 +89,7 @@ public:
 };
 
 template <class _Sp, class _Tp, class _Ap>
-class _LIBCPP_TEMPLATE_VIS
-_LIBCPP_DEPRECATED_IN_CXX11 const_mem_fun1_t : public __binary_function<const _Tp*, _Ap, _Sp> {
+class _LIBCPP_DEPRECATED_IN_CXX11 const_mem_fun1_t : public __binary_function<const _Tp*, _Ap, _Sp> {
   _Sp (_Tp::*__p_)(_Ap) const;
 
 public:
@@ -110,7 +109,7 @@ mem_fun(_Sp (_Tp::*__f)(_Ap) const) {
 }
 
 template <class _Sp, class _Tp>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 const_mem_fun_ref_t : public __unary_function<_Tp, _Sp> {
+class _LIBCPP_DEPRECATED_IN_CXX11 const_mem_fun_ref_t : public __unary_function<_Tp, _Sp> {
   _Sp (_Tp::*__p_)() const;
 
 public:
@@ -119,7 +118,7 @@ public:
 };
 
 template <class _Sp, class _Tp, class _Ap>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 const_mem_fun1_ref_t : public __binary_function<_Tp, _Ap, _Sp> {
+class _LIBCPP_DEPRECATED_IN_CXX11 const_mem_fun1_ref_t : public __binary_function<_Tp, _Ap, _Sp> {
   _Sp (_Tp::*__p_)(_Ap) const;
 
 public:

--- a/libcxx/include/__functional/operations.h
+++ b/libcxx/include/__functional/operations.h
@@ -31,7 +31,7 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS plus : __binary_function<_Tp, _Tp, _Tp> {
+struct plus : __binary_function<_Tp, _Tp, _Tp> {
   typedef _Tp __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _Tp operator()(const _Tp& __x, const _Tp& __y) const {
     return __x + __y;
@@ -49,7 +49,7 @@ inline const bool __desugars_to_v<__plus_tag, plus<void>, _Tp, _Up> = true;
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS plus<void> {
+struct plus<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
       noexcept(noexcept(std::forward<_T1>(__t) + std::forward<_T2>(__u))) //
@@ -65,7 +65,7 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS minus : __binary_function<_Tp, _Tp, _Tp> {
+struct minus : __binary_function<_Tp, _Tp, _Tp> {
   typedef _Tp __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _Tp operator()(const _Tp& __x, const _Tp& __y) const {
     return __x - __y;
@@ -75,7 +75,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(minus);
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS minus<void> {
+struct minus<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
       noexcept(noexcept(std::forward<_T1>(__t) - std::forward<_T2>(__u))) //
@@ -91,7 +91,7 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS multiplies : __binary_function<_Tp, _Tp, _Tp> {
+struct multiplies : __binary_function<_Tp, _Tp, _Tp> {
   typedef _Tp __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _Tp operator()(const _Tp& __x, const _Tp& __y) const {
     return __x * __y;
@@ -101,7 +101,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(multiplies);
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS multiplies<void> {
+struct multiplies<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
       noexcept(noexcept(std::forward<_T1>(__t) * std::forward<_T2>(__u))) //
@@ -117,7 +117,7 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS divides : __binary_function<_Tp, _Tp, _Tp> {
+struct divides : __binary_function<_Tp, _Tp, _Tp> {
   typedef _Tp __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _Tp operator()(const _Tp& __x, const _Tp& __y) const {
     return __x / __y;
@@ -127,7 +127,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(divides);
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS divides<void> {
+struct divides<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
       noexcept(noexcept(std::forward<_T1>(__t) / std::forward<_T2>(__u))) //
@@ -143,7 +143,7 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS modulus : __binary_function<_Tp, _Tp, _Tp> {
+struct modulus : __binary_function<_Tp, _Tp, _Tp> {
   typedef _Tp __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _Tp operator()(const _Tp& __x, const _Tp& __y) const {
     return __x % __y;
@@ -153,7 +153,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(modulus);
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS modulus<void> {
+struct modulus<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
       noexcept(noexcept(std::forward<_T1>(__t) % std::forward<_T2>(__u))) //
@@ -169,7 +169,7 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS negate : __unary_function<_Tp, _Tp> {
+struct negate : __unary_function<_Tp, _Tp> {
   typedef _Tp __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _Tp operator()(const _Tp& __x) const { return -__x; }
 };
@@ -177,7 +177,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(negate);
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS negate<void> {
+struct negate<void> {
   template <class _Tp>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_Tp&& __x) const
       noexcept(noexcept(-std::forward<_Tp>(__x))) //
@@ -195,7 +195,7 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS bit_and : __binary_function<_Tp, _Tp, _Tp> {
+struct bit_and : __binary_function<_Tp, _Tp, _Tp> {
   typedef _Tp __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _Tp operator()(const _Tp& __x, const _Tp& __y) const {
     return __x & __y;
@@ -205,7 +205,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(bit_and);
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS bit_and<void> {
+struct bit_and<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
       noexcept(noexcept(std::forward<_T1>(__t) &
@@ -218,13 +218,13 @@ struct _LIBCPP_TEMPLATE_VIS bit_and<void> {
 
 #if _LIBCPP_STD_VER >= 14
 template <class _Tp = void>
-struct _LIBCPP_TEMPLATE_VIS bit_not : __unary_function<_Tp, _Tp> {
+struct bit_not : __unary_function<_Tp, _Tp> {
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _Tp operator()(const _Tp& __x) const { return ~__x; }
 };
 _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(bit_not);
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS bit_not<void> {
+struct bit_not<void> {
   template <class _Tp>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_Tp&& __x) const
       noexcept(noexcept(~std::forward<_Tp>(__x))) //
@@ -240,7 +240,7 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS bit_or : __binary_function<_Tp, _Tp, _Tp> {
+struct bit_or : __binary_function<_Tp, _Tp, _Tp> {
   typedef _Tp __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _Tp operator()(const _Tp& __x, const _Tp& __y) const {
     return __x | __y;
@@ -250,7 +250,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(bit_or);
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS bit_or<void> {
+struct bit_or<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
       noexcept(noexcept(std::forward<_T1>(__t) | std::forward<_T2>(__u))) //
@@ -266,7 +266,7 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS bit_xor : __binary_function<_Tp, _Tp, _Tp> {
+struct bit_xor : __binary_function<_Tp, _Tp, _Tp> {
   typedef _Tp __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _Tp operator()(const _Tp& __x, const _Tp& __y) const {
     return __x ^ __y;
@@ -276,7 +276,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(bit_xor);
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS bit_xor<void> {
+struct bit_xor<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
       noexcept(noexcept(std::forward<_T1>(__t) ^ std::forward<_T2>(__u))) //
@@ -294,7 +294,7 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS equal_to : __binary_function<_Tp, _Tp, bool> {
+struct equal_to : __binary_function<_Tp, _Tp, bool> {
   typedef bool __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool operator()(const _Tp& __x, const _Tp& __y) const {
     return __x == __y;
@@ -304,7 +304,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(equal_to);
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS equal_to<void> {
+struct equal_to<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
       noexcept(noexcept(std::forward<_T1>(__t) == std::forward<_T2>(__u))) //
@@ -329,7 +329,7 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS not_equal_to : __binary_function<_Tp, _Tp, bool> {
+struct not_equal_to : __binary_function<_Tp, _Tp, bool> {
   typedef bool __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool operator()(const _Tp& __x, const _Tp& __y) const {
     return __x != __y;
@@ -339,7 +339,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(not_equal_to);
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS not_equal_to<void> {
+struct not_equal_to<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
       noexcept(noexcept(std::forward<_T1>(__t) != std::forward<_T2>(__u))) //
@@ -351,7 +351,7 @@ struct _LIBCPP_TEMPLATE_VIS not_equal_to<void> {
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS less : __binary_function<_Tp, _Tp, bool> {
+struct less : __binary_function<_Tp, _Tp, bool> {
   typedef bool __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool operator()(const _Tp& __x, const _Tp& __y) const {
     return __x < __y;
@@ -367,7 +367,7 @@ inline const bool __desugars_to_v<__totally_ordered_less_tag, less<_Tp>, _Tp, _T
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS less<void> {
+struct less<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
       noexcept(noexcept(std::forward<_T1>(__t) < std::forward<_T2>(__u))) //
@@ -389,7 +389,7 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS less_equal : __binary_function<_Tp, _Tp, bool> {
+struct less_equal : __binary_function<_Tp, _Tp, bool> {
   typedef bool __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool operator()(const _Tp& __x, const _Tp& __y) const {
     return __x <= __y;
@@ -399,7 +399,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(less_equal);
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS less_equal<void> {
+struct less_equal<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
       noexcept(noexcept(std::forward<_T1>(__t) <= std::forward<_T2>(__u))) //
@@ -415,7 +415,7 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS greater_equal : __binary_function<_Tp, _Tp, bool> {
+struct greater_equal : __binary_function<_Tp, _Tp, bool> {
   typedef bool __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool operator()(const _Tp& __x, const _Tp& __y) const {
     return __x >= __y;
@@ -425,7 +425,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(greater_equal);
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS greater_equal<void> {
+struct greater_equal<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
       noexcept(noexcept(std::forward<_T1>(__t) >=
@@ -441,7 +441,7 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS greater : __binary_function<_Tp, _Tp, bool> {
+struct greater : __binary_function<_Tp, _Tp, bool> {
   typedef bool __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool operator()(const _Tp& __x, const _Tp& __y) const {
     return __x > __y;
@@ -454,7 +454,7 @@ inline const bool __desugars_to_v<__greater_tag, greater<_Tp>, _Tp, _Tp> = true;
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS greater<void> {
+struct greater<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
       noexcept(noexcept(std::forward<_T1>(__t) > std::forward<_T2>(__u))) //
@@ -475,7 +475,7 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS logical_and : __binary_function<_Tp, _Tp, bool> {
+struct logical_and : __binary_function<_Tp, _Tp, bool> {
   typedef bool __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool operator()(const _Tp& __x, const _Tp& __y) const {
     return __x && __y;
@@ -485,7 +485,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(logical_and);
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS logical_and<void> {
+struct logical_and<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
       noexcept(noexcept(std::forward<_T1>(__t) && std::forward<_T2>(__u))) //
@@ -501,7 +501,7 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS logical_not : __unary_function<_Tp, bool> {
+struct logical_not : __unary_function<_Tp, bool> {
   typedef bool __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool operator()(const _Tp& __x) const { return !__x; }
 };
@@ -509,7 +509,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(logical_not);
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS logical_not<void> {
+struct logical_not<void> {
   template <class _Tp>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_Tp&& __x) const
       noexcept(noexcept(!std::forward<_Tp>(__x))) //
@@ -525,7 +525,7 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS logical_or : __binary_function<_Tp, _Tp, bool> {
+struct logical_or : __binary_function<_Tp, _Tp, bool> {
   typedef bool __result_type; // used by valarray
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool operator()(const _Tp& __x, const _Tp& __y) const {
     return __x || __y;
@@ -535,7 +535,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(logical_or);
 
 #if _LIBCPP_STD_VER >= 14
 template <>
-struct _LIBCPP_TEMPLATE_VIS logical_or<void> {
+struct logical_or<void> {
   template <class _T1, class _T2>
   _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI auto operator()(_T1&& __t, _T2&& __u) const
       noexcept(noexcept(std::forward<_T1>(__t) || std::forward<_T2>(__u))) //

--- a/libcxx/include/__functional/pointer_to_binary_function.h
+++ b/libcxx/include/__functional/pointer_to_binary_function.h
@@ -22,8 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_BINDERS)
 
 template <class _Arg1, class _Arg2, class _Result>
-class _LIBCPP_TEMPLATE_VIS
-_LIBCPP_DEPRECATED_IN_CXX11 pointer_to_binary_function : public __binary_function<_Arg1, _Arg2, _Result> {
+class _LIBCPP_DEPRECATED_IN_CXX11 pointer_to_binary_function : public __binary_function<_Arg1, _Arg2, _Result> {
   _Result (*__f_)(_Arg1, _Arg2);
 
 public:

--- a/libcxx/include/__functional/pointer_to_unary_function.h
+++ b/libcxx/include/__functional/pointer_to_unary_function.h
@@ -22,8 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_BINDERS)
 
 template <class _Arg, class _Result>
-class _LIBCPP_TEMPLATE_VIS
-_LIBCPP_DEPRECATED_IN_CXX11 pointer_to_unary_function : public __unary_function<_Arg, _Result> {
+class _LIBCPP_DEPRECATED_IN_CXX11 pointer_to_unary_function : public __unary_function<_Arg, _Result> {
   _Result (*__f_)(_Arg);
 
 public:

--- a/libcxx/include/__functional/reference_wrapper.h
+++ b/libcxx/include/__functional/reference_wrapper.h
@@ -30,7 +30,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS reference_wrapper : public __weak_result_type<_Tp> {
+class reference_wrapper : public __weak_result_type<_Tp> {
 public:
   // types
   typedef _Tp type;

--- a/libcxx/include/__functional/unary_function.h
+++ b/libcxx/include/__functional/unary_function.h
@@ -20,7 +20,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 14 || defined(_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
 
 template <class _Arg, class _Result>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 unary_function {
+struct _LIBCPP_DEPRECATED_IN_CXX11 unary_function {
   typedef _Arg argument_type;
   typedef _Result result_type;
 };

--- a/libcxx/include/__functional/unary_negate.h
+++ b/libcxx/include/__functional/unary_negate.h
@@ -22,8 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_NEGATORS)
 
 template <class _Predicate>
-class _LIBCPP_TEMPLATE_VIS
-_LIBCPP_DEPRECATED_IN_CXX17 unary_negate : public __unary_function<typename _Predicate::argument_type, bool> {
+class _LIBCPP_DEPRECATED_IN_CXX17 unary_negate : public __unary_function<typename _Predicate::argument_type, bool> {
   _Predicate __pred_;
 
 public:

--- a/libcxx/include/__fwd/array.h
+++ b/libcxx/include/__fwd/array.h
@@ -20,7 +20,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, size_t _Size>
-struct _LIBCPP_TEMPLATE_VIS array;
+struct array;
 
 template <size_t _Ip, class _Tp, size_t _Size>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp& get(array<_Tp, _Size>&) _NOEXCEPT;

--- a/libcxx/include/__fwd/byte.h
+++ b/libcxx/include/__fwd/byte.h
@@ -16,11 +16,11 @@
 #endif
 
 #if _LIBCPP_STD_VER >= 17
-namespace std { // purposefully not versioned
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 
 enum class byte : unsigned char;
 
-} // namespace std
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 #endif // _LIBCPP_STD_VER >= 17
 
 #endif // _LIBCPP___FWD_BYTE_H

--- a/libcxx/include/__fwd/complex.h
+++ b/libcxx/include/__fwd/complex.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS complex;
+class complex;
 
 #if _LIBCPP_STD_VER >= 26
 

--- a/libcxx/include/__fwd/deque.h
+++ b/libcxx/include/__fwd/deque.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _Allocator = allocator<_Tp> >
-class _LIBCPP_TEMPLATE_VIS deque;
+class deque;
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__fwd/format.h
+++ b/libcxx/include/__fwd/format.h
@@ -22,14 +22,14 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 20
 
 template <class _Context>
-class _LIBCPP_TEMPLATE_VIS basic_format_arg;
+class basic_format_arg;
 
 template <class _OutIt, class _CharT>
   requires output_iterator<_OutIt, const _CharT&>
-class _LIBCPP_TEMPLATE_VIS basic_format_context;
+class basic_format_context;
 
 template <class _Tp, class _CharT = char>
-struct _LIBCPP_TEMPLATE_VIS formatter;
+struct formatter;
 
 #endif // _LIBCPP_STD_VER >= 20
 

--- a/libcxx/include/__fwd/fstream.h
+++ b/libcxx/include/__fwd/fstream.h
@@ -19,13 +19,13 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _CharT, class _Traits = char_traits<_CharT> >
-class _LIBCPP_TEMPLATE_VIS basic_filebuf;
+class basic_filebuf;
 template <class _CharT, class _Traits = char_traits<_CharT> >
-class _LIBCPP_TEMPLATE_VIS basic_ifstream;
+class basic_ifstream;
 template <class _CharT, class _Traits = char_traits<_CharT> >
-class _LIBCPP_TEMPLATE_VIS basic_ofstream;
+class basic_ofstream;
 template <class _CharT, class _Traits = char_traits<_CharT> >
-class _LIBCPP_TEMPLATE_VIS basic_fstream;
+class basic_fstream;
 
 using filebuf  = basic_filebuf<char>;
 using ifstream = basic_ifstream<char>;

--- a/libcxx/include/__fwd/functional.h
+++ b/libcxx/include/__fwd/functional.h
@@ -22,13 +22,13 @@ template <class _Tp = void>
 #else
 template <class _Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS less;
+struct less;
 
 template <class>
-struct _LIBCPP_TEMPLATE_VIS hash;
+struct hash;
 
 template <class>
-class _LIBCPP_TEMPLATE_VIS reference_wrapper;
+class reference_wrapper;
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__fwd/ios.h
+++ b/libcxx/include/__fwd/ios.h
@@ -21,7 +21,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 class _LIBCPP_EXPORTED_FROM_ABI ios_base;
 
 template <class _CharT, class _Traits = char_traits<_CharT> >
-class _LIBCPP_TEMPLATE_VIS basic_ios;
+class basic_ios;
 
 using ios = basic_ios<char>;
 #if _LIBCPP_HAS_WIDE_CHARACTERS

--- a/libcxx/include/__fwd/istream.h
+++ b/libcxx/include/__fwd/istream.h
@@ -19,10 +19,10 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _CharT, class _Traits = char_traits<_CharT> >
-class _LIBCPP_TEMPLATE_VIS basic_istream;
+class basic_istream;
 
 template <class _CharT, class _Traits = char_traits<_CharT> >
-class _LIBCPP_TEMPLATE_VIS basic_iostream;
+class basic_iostream;
 
 using istream  = basic_istream<char>;
 using iostream = basic_iostream<char>;

--- a/libcxx/include/__fwd/map.h
+++ b/libcxx/include/__fwd/map.h
@@ -21,10 +21,10 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Key, class _Tp, class _Compare = less<_Key>, class _Allocator = allocator<pair<const _Key, _Tp> > >
-class _LIBCPP_TEMPLATE_VIS map;
+class map;
 
 template <class _Key, class _Tp, class _Compare = less<_Key>, class _Allocator = allocator<pair<const _Key, _Tp> > >
-class _LIBCPP_TEMPLATE_VIS multimap;
+class multimap;
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__fwd/memory.h
+++ b/libcxx/include/__fwd/memory.h
@@ -18,10 +18,10 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS allocator;
+class allocator;
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS shared_ptr;
+class shared_ptr;
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__fwd/memory_resource.h
+++ b/libcxx/include/__fwd/memory_resource.h
@@ -21,7 +21,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 namespace pmr {
 template <class _ValueType>
-class _LIBCPP_AVAILABILITY_PMR _LIBCPP_TEMPLATE_VIS polymorphic_allocator;
+class _LIBCPP_AVAILABILITY_PMR polymorphic_allocator;
 } // namespace pmr
 
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/__fwd/ostream.h
+++ b/libcxx/include/__fwd/ostream.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _CharT, class _Traits = char_traits<_CharT> >
-class _LIBCPP_TEMPLATE_VIS basic_ostream;
+class basic_ostream;
 
 using ostream = basic_ostream<char>;
 

--- a/libcxx/include/__fwd/pair.h
+++ b/libcxx/include/__fwd/pair.h
@@ -20,7 +20,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class, class>
-struct _LIBCPP_TEMPLATE_VIS pair;
+struct pair;
 
 template <size_t _Ip, class _T1, class _T2>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 typename tuple_element<_Ip, pair<_T1, _T2> >::type&

--- a/libcxx/include/__fwd/queue.h
+++ b/libcxx/include/__fwd/queue.h
@@ -21,10 +21,10 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _Container = deque<_Tp> >
-class _LIBCPP_TEMPLATE_VIS queue;
+class queue;
 
 template <class _Tp, class _Container = vector<_Tp>, class _Compare = less<typename _Container::value_type> >
-class _LIBCPP_TEMPLATE_VIS priority_queue;
+class priority_queue;
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__fwd/set.h
+++ b/libcxx/include/__fwd/set.h
@@ -20,10 +20,10 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Key, class _Compare = less<_Key>, class _Allocator = allocator<_Key> >
-class _LIBCPP_TEMPLATE_VIS set;
+class set;
 
 template <class _Key, class _Compare = less<_Key>, class _Allocator = allocator<_Key> >
-class _LIBCPP_TEMPLATE_VIS multiset;
+class multiset;
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__fwd/sstream.h
+++ b/libcxx/include/__fwd/sstream.h
@@ -20,14 +20,14 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _CharT, class _Traits = char_traits<_CharT>, class _Allocator = allocator<_CharT> >
-class _LIBCPP_TEMPLATE_VIS basic_stringbuf;
+class basic_stringbuf;
 
 template <class _CharT, class _Traits = char_traits<_CharT>, class _Allocator = allocator<_CharT> >
-class _LIBCPP_TEMPLATE_VIS basic_istringstream;
+class basic_istringstream;
 template <class _CharT, class _Traits = char_traits<_CharT>, class _Allocator = allocator<_CharT> >
-class _LIBCPP_TEMPLATE_VIS basic_ostringstream;
+class basic_ostringstream;
 template <class _CharT, class _Traits = char_traits<_CharT>, class _Allocator = allocator<_CharT> >
-class _LIBCPP_TEMPLATE_VIS basic_stringstream;
+class basic_stringstream;
 
 using stringbuf     = basic_stringbuf<char>;
 using istringstream = basic_istringstream<char>;

--- a/libcxx/include/__fwd/stack.h
+++ b/libcxx/include/__fwd/stack.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _Container = deque<_Tp> >
-class _LIBCPP_TEMPLATE_VIS stack;
+class stack;
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__fwd/streambuf.h
+++ b/libcxx/include/__fwd/streambuf.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _CharT, class _Traits = char_traits<_CharT> >
-class _LIBCPP_TEMPLATE_VIS basic_streambuf;
+class basic_streambuf;
 
 using streambuf = basic_streambuf<char>;
 

--- a/libcxx/include/__fwd/string.h
+++ b/libcxx/include/__fwd/string.h
@@ -20,7 +20,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _CharT>
-struct _LIBCPP_TEMPLATE_VIS char_traits;
+struct char_traits;
 template <>
 struct char_traits<char>;
 
@@ -40,7 +40,7 @@ struct char_traits<wchar_t>;
 #endif
 
 template <class _CharT, class _Traits = char_traits<_CharT>, class _Allocator = allocator<_CharT> >
-class _LIBCPP_TEMPLATE_VIS basic_string;
+class basic_string;
 
 using string = basic_string<char>;
 

--- a/libcxx/include/__fwd/string_view.h
+++ b/libcxx/include/__fwd/string_view.h
@@ -20,7 +20,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _CharT, class _Traits = char_traits<_CharT> >
-class _LIBCPP_TEMPLATE_VIS basic_string_view;
+class basic_string_view;
 
 typedef basic_string_view<char> string_view;
 #if _LIBCPP_HAS_CHAR8_T

--- a/libcxx/include/__fwd/subrange.h
+++ b/libcxx/include/__fwd/subrange.h
@@ -28,7 +28,7 @@ enum class subrange_kind : bool { unsized, sized };
 
 template <input_or_output_iterator _Iter, sentinel_for<_Iter> _Sent, subrange_kind _Kind>
   requires(_Kind == subrange_kind::sized || !sized_sentinel_for<_Sent, _Iter>)
-class _LIBCPP_TEMPLATE_VIS subrange;
+class subrange;
 
 template <size_t _Index, class _Iter, class _Sent, subrange_kind _Kind>
   requires((_Index == 0 && copyable<_Iter>) || _Index == 1)

--- a/libcxx/include/__fwd/tuple.h
+++ b/libcxx/include/__fwd/tuple.h
@@ -19,15 +19,15 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <size_t, class>
-struct _LIBCPP_TEMPLATE_VIS tuple_element;
+struct tuple_element;
 
 #ifndef _LIBCPP_CXX03_LANG
 
 template <class...>
-class _LIBCPP_TEMPLATE_VIS tuple;
+class tuple;
 
 template <class>
-struct _LIBCPP_TEMPLATE_VIS tuple_size;
+struct tuple_size;
 
 template <size_t _Ip, class... _Tp>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 typename tuple_element<_Ip, tuple<_Tp...> >::type&

--- a/libcxx/include/__fwd/variant.h
+++ b/libcxx/include/__fwd/variant.h
@@ -21,16 +21,16 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 17
 
 template <class... _Types>
-class _LIBCPP_TEMPLATE_VIS variant;
+class variant;
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS variant_size;
+struct variant_size;
 
 template <class _Tp>
 inline constexpr size_t variant_size_v = variant_size<_Tp>::value;
 
 template <size_t _Ip, class _Tp>
-struct _LIBCPP_TEMPLATE_VIS variant_alternative;
+struct variant_alternative;
 
 template <size_t _Ip, class _Tp>
 using variant_alternative_t = typename variant_alternative<_Ip, _Tp>::type;

--- a/libcxx/include/__fwd/vector.h
+++ b/libcxx/include/__fwd/vector.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _Alloc = allocator<_Tp> >
-class _LIBCPP_TEMPLATE_VIS vector;
+class vector;
 
 template <class _Allocator>
 class vector<bool, _Allocator>;

--- a/libcxx/include/__hash_table
+++ b/libcxx/include/__hash_table
@@ -154,17 +154,17 @@ template <class _Tp, class _Hash, class _Equal, class _Alloc>
 class __hash_table;
 
 template <class _NodePtr>
-class _LIBCPP_TEMPLATE_VIS __hash_iterator;
+class __hash_iterator;
 template <class _ConstNodePtr>
-class _LIBCPP_TEMPLATE_VIS __hash_const_iterator;
+class __hash_const_iterator;
 template <class _NodePtr>
-class _LIBCPP_TEMPLATE_VIS __hash_local_iterator;
+class __hash_local_iterator;
 template <class _ConstNodePtr>
-class _LIBCPP_TEMPLATE_VIS __hash_const_local_iterator;
+class __hash_const_local_iterator;
 template <class _HashIterator>
-class _LIBCPP_TEMPLATE_VIS __hash_map_iterator;
+class __hash_map_iterator;
 template <class _HashIterator>
-class _LIBCPP_TEMPLATE_VIS __hash_map_const_iterator;
+class __hash_map_const_iterator;
 
 template <class _Tp>
 struct __hash_key_value_types {
@@ -273,7 +273,7 @@ struct __make_hash_node_types {
 };
 
 template <class _NodePtr>
-class _LIBCPP_TEMPLATE_VIS __hash_iterator {
+class __hash_iterator {
   typedef __hash_node_types<_NodePtr> _NodeTypes;
   typedef _NodePtr __node_pointer;
   typedef typename _NodeTypes::__next_pointer __next_pointer;
@@ -327,17 +327,17 @@ private:
   template <class, class, class, class>
   friend class __hash_table;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __hash_const_iterator;
+  friend class __hash_const_iterator;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __hash_map_iterator;
+  friend class __hash_map_iterator;
   template <class, class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_map;
+  friend class unordered_map;
   template <class, class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_multimap;
+  friend class unordered_multimap;
 };
 
 template <class _NodePtr>
-class _LIBCPP_TEMPLATE_VIS __hash_const_iterator {
+class __hash_const_iterator {
   static_assert(!is_const<typename pointer_traits<_NodePtr>::element_type>::value, "");
   typedef __hash_node_types<_NodePtr> _NodeTypes;
   typedef _NodePtr __node_pointer;
@@ -395,15 +395,15 @@ private:
   template <class, class, class, class>
   friend class __hash_table;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __hash_map_const_iterator;
+  friend class __hash_map_const_iterator;
   template <class, class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_map;
+  friend class unordered_map;
   template <class, class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_multimap;
+  friend class unordered_multimap;
 };
 
 template <class _NodePtr>
-class _LIBCPP_TEMPLATE_VIS __hash_local_iterator {
+class __hash_local_iterator {
   typedef __hash_node_types<_NodePtr> _NodeTypes;
   typedef _NodePtr __node_pointer;
   typedef typename _NodeTypes::__next_pointer __next_pointer;
@@ -468,13 +468,13 @@ private:
   template <class, class, class, class>
   friend class __hash_table;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __hash_const_local_iterator;
+  friend class __hash_const_local_iterator;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __hash_map_iterator;
+  friend class __hash_map_iterator;
 };
 
 template <class _ConstNodePtr>
-class _LIBCPP_TEMPLATE_VIS __hash_const_local_iterator {
+class __hash_const_local_iterator {
   typedef __hash_node_types<_ConstNodePtr> _NodeTypes;
   typedef _ConstNodePtr __node_pointer;
   typedef typename _NodeTypes::__next_pointer __next_pointer;
@@ -553,7 +553,7 @@ private:
   template <class, class, class, class>
   friend class __hash_table;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __hash_map_const_iterator;
+  friend class __hash_map_const_iterator;
 };
 
 template <class _Alloc>
@@ -1021,9 +1021,9 @@ private:
   _LIBCPP_HIDE_FROM_ABI __next_pointer __detach() _NOEXCEPT;
 
   template <class, class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_map;
+  friend class unordered_map;
   template <class, class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_multimap;
+  friend class unordered_multimap;
 };
 
 template <class _Tp, class _Hash, class _Equal, class _Alloc>

--- a/libcxx/include/__ios/fpos.h
+++ b/libcxx/include/__ios/fpos.h
@@ -20,7 +20,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _StateT>
-class _LIBCPP_TEMPLATE_VIS fpos {
+class fpos {
 private:
   _StateT __st_;
   streamoff __off_;

--- a/libcxx/include/__iterator/back_insert_iterator.h
+++ b/libcxx/include/__iterator/back_insert_iterator.h
@@ -28,7 +28,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _Container>
-class _LIBCPP_TEMPLATE_VIS back_insert_iterator
+class back_insert_iterator
 #if _LIBCPP_STD_VER <= 14 || !defined(_LIBCPP_ABI_NO_ITERATOR_BASES)
     : public iterator<output_iterator_tag, void, void, void, void>
 #endif

--- a/libcxx/include/__iterator/front_insert_iterator.h
+++ b/libcxx/include/__iterator/front_insert_iterator.h
@@ -28,7 +28,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _Container>
-class _LIBCPP_TEMPLATE_VIS front_insert_iterator
+class front_insert_iterator
 #if _LIBCPP_STD_VER <= 14 || !defined(_LIBCPP_ABI_NO_ITERATOR_BASES)
     : public iterator<output_iterator_tag, void, void, void, void>
 #endif

--- a/libcxx/include/__iterator/insert_iterator.h
+++ b/libcxx/include/__iterator/insert_iterator.h
@@ -37,7 +37,7 @@ using __insert_iterator_iter_t _LIBCPP_NODEBUG = typename _Container::iterator;
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _Container>
-class _LIBCPP_TEMPLATE_VIS insert_iterator
+class insert_iterator
 #if _LIBCPP_STD_VER <= 14 || !defined(_LIBCPP_ABI_NO_ITERATOR_BASES)
     : public iterator<output_iterator_tag, void, void, void, void>
 #endif

--- a/libcxx/include/__iterator/istream_iterator.h
+++ b/libcxx/include/__iterator/istream_iterator.h
@@ -27,7 +27,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _Tp, class _CharT = char, class _Traits = char_traits<_CharT>, class _Distance = ptrdiff_t>
-class _LIBCPP_TEMPLATE_VIS istream_iterator
+class istream_iterator
 #if _LIBCPP_STD_VER <= 14 || !defined(_LIBCPP_ABI_NO_ITERATOR_BASES)
     : public iterator<input_iterator_tag, _Tp, _Distance, const _Tp*, const _Tp&>
 #endif

--- a/libcxx/include/__iterator/istreambuf_iterator.h
+++ b/libcxx/include/__iterator/istreambuf_iterator.h
@@ -27,7 +27,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS istreambuf_iterator
+class istreambuf_iterator
 #if _LIBCPP_STD_VER <= 14 || !defined(_LIBCPP_ABI_NO_ITERATOR_BASES)
     : public iterator<input_iterator_tag, _CharT, typename _Traits::off_type, _CharT*, _CharT>
 #endif

--- a/libcxx/include/__iterator/iterator.h
+++ b/libcxx/include/__iterator/iterator.h
@@ -20,7 +20,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Category, class _Tp, class _Distance = ptrdiff_t, class _Pointer = _Tp*, class _Reference = _Tp&>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 iterator {
+struct _LIBCPP_DEPRECATED_IN_CXX17 iterator {
   typedef _Tp value_type;
   typedef _Distance difference_type;
   typedef _Pointer pointer;

--- a/libcxx/include/__iterator/iterator_traits.h
+++ b/libcxx/include/__iterator/iterator_traits.h
@@ -64,15 +64,15 @@ using iter_reference_t = decltype(*std::declval<_Tp&>());
 #endif // _LIBCPP_STD_VER >= 20
 
 template <class _Iter>
-struct _LIBCPP_TEMPLATE_VIS iterator_traits;
+struct iterator_traits;
 
-struct _LIBCPP_TEMPLATE_VIS input_iterator_tag {};
-struct _LIBCPP_TEMPLATE_VIS output_iterator_tag {};
-struct _LIBCPP_TEMPLATE_VIS forward_iterator_tag : public input_iterator_tag {};
-struct _LIBCPP_TEMPLATE_VIS bidirectional_iterator_tag : public forward_iterator_tag {};
-struct _LIBCPP_TEMPLATE_VIS random_access_iterator_tag : public bidirectional_iterator_tag {};
+struct input_iterator_tag {};
+struct output_iterator_tag {};
+struct forward_iterator_tag : public input_iterator_tag {};
+struct bidirectional_iterator_tag : public forward_iterator_tag {};
+struct random_access_iterator_tag : public bidirectional_iterator_tag {};
 #if _LIBCPP_STD_VER >= 20
-struct _LIBCPP_TEMPLATE_VIS contiguous_iterator_tag : public random_access_iterator_tag {};
+struct contiguous_iterator_tag : public random_access_iterator_tag {};
 #endif
 
 template <class _Iter>
@@ -399,7 +399,7 @@ struct __iterator_traits<_Iter, true>
 //    the client expects instead of failing at compile time.
 
 template <class _Iter>
-struct _LIBCPP_TEMPLATE_VIS iterator_traits : __iterator_traits<_Iter, __has_iterator_typedefs<_Iter>::value> {
+struct iterator_traits : __iterator_traits<_Iter, __has_iterator_typedefs<_Iter>::value> {
   using __primary_template _LIBCPP_NODEBUG = iterator_traits;
 };
 #endif // _LIBCPP_STD_VER >= 20
@@ -408,7 +408,7 @@ template <class _Tp>
 #if _LIBCPP_STD_VER >= 20
   requires is_object_v<_Tp>
 #endif
-struct _LIBCPP_TEMPLATE_VIS iterator_traits<_Tp*> {
+struct iterator_traits<_Tp*> {
   typedef ptrdiff_t difference_type;
   typedef __remove_cv_t<_Tp> value_type;
   typedef _Tp* pointer;

--- a/libcxx/include/__iterator/move_iterator.h
+++ b/libcxx/include/__iterator/move_iterator.h
@@ -64,7 +64,7 @@ concept __move_iter_comparable = requires {
 #endif // _LIBCPP_STD_VER >= 20
 
 template <class _Iter>
-class _LIBCPP_TEMPLATE_VIS move_iterator
+class move_iterator
 #if _LIBCPP_STD_VER >= 20
     : public __move_iter_category_base<_Iter>
 #endif

--- a/libcxx/include/__iterator/move_sentinel.h
+++ b/libcxx/include/__iterator/move_sentinel.h
@@ -27,7 +27,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 20
 
 template <semiregular _Sent>
-class _LIBCPP_TEMPLATE_VIS move_sentinel {
+class move_sentinel {
 public:
   _LIBCPP_HIDE_FROM_ABI move_sentinel() = default;
 

--- a/libcxx/include/__iterator/ostream_iterator.h
+++ b/libcxx/include/__iterator/ostream_iterator.h
@@ -26,7 +26,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _Tp, class _CharT = char, class _Traits = char_traits<_CharT> >
-class _LIBCPP_TEMPLATE_VIS ostream_iterator
+class ostream_iterator
 #if _LIBCPP_STD_VER <= 14 || !defined(_LIBCPP_ABI_NO_ITERATOR_BASES)
     : public iterator<output_iterator_tag, void, void, void, void>
 #endif

--- a/libcxx/include/__iterator/ostreambuf_iterator.h
+++ b/libcxx/include/__iterator/ostreambuf_iterator.h
@@ -27,7 +27,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS ostreambuf_iterator
+class ostreambuf_iterator
 #if _LIBCPP_STD_VER <= 14 || !defined(_LIBCPP_ABI_NO_ITERATOR_BASES)
     : public iterator<output_iterator_tag, void, void, void, void>
 #endif

--- a/libcxx/include/__iterator/reverse_iterator.h
+++ b/libcxx/include/__iterator/reverse_iterator.h
@@ -48,7 +48,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _Iter>
-class _LIBCPP_TEMPLATE_VIS reverse_iterator
+class reverse_iterator
 #if _LIBCPP_STD_VER <= 14 || !defined(_LIBCPP_ABI_NO_ITERATOR_BASES)
     : public iterator<typename iterator_traits<_Iter>::iterator_category,
                       typename iterator_traits<_Iter>::value_type,

--- a/libcxx/include/__iterator/wrap_iter.h
+++ b/libcxx/include/__iterator/wrap_iter.h
@@ -112,9 +112,9 @@ private:
   template <class _CharT, class _Traits>
   friend class basic_string_view;
   template <class _Tp, class _Alloc>
-  friend class _LIBCPP_TEMPLATE_VIS vector;
+  friend class vector;
   template <class _Tp, size_t>
-  friend class _LIBCPP_TEMPLATE_VIS span;
+  friend class span;
   template <class _Tp, size_t _Size>
   friend struct array;
 };
@@ -236,7 +236,7 @@ struct __libcpp_is_contiguous_iterator<__wrap_iter<_It> > : true_type {};
 #endif
 
 template <class _It>
-struct _LIBCPP_TEMPLATE_VIS pointer_traits<__wrap_iter<_It> > {
+struct pointer_traits<__wrap_iter<_It> > {
   typedef __wrap_iter<_It> pointer;
   typedef typename pointer_traits<_It>::element_type element_type;
   typedef typename pointer_traits<_It>::difference_type difference_type;

--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -173,7 +173,7 @@ inline _LIBCPP_HIDE_FROM_ABI const _Facet& use_facet(const locale& __l) {
 // template <class _CharT> class collate;
 
 template <class _CharT>
-class _LIBCPP_TEMPLATE_VIS collate : public locale::facet {
+class collate : public locale::facet {
 public:
   typedef _CharT char_type;
   typedef basic_string<char_type> string_type;
@@ -245,7 +245,7 @@ extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS collate<wchar_t>;
 // template <class CharT> class collate_byname;
 
 template <class _CharT>
-class _LIBCPP_TEMPLATE_VIS collate_byname;
+class collate_byname;
 
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI collate_byname<char> : public collate<char> {
@@ -449,7 +449,7 @@ public:
 };
 
 template <class _CharT>
-class _LIBCPP_TEMPLATE_VIS ctype;
+class ctype;
 
 #if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
@@ -616,7 +616,7 @@ protected:
 // template <class CharT> class ctype_byname;
 
 template <class _CharT>
-class _LIBCPP_TEMPLATE_VIS ctype_byname;
+class ctype_byname;
 
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI ctype_byname<char> : public ctype<char> {
@@ -742,7 +742,7 @@ public:
 // template <class internT, class externT, class stateT> class codecvt;
 
 template <class _InternT, class _ExternT, class _StateT>
-class _LIBCPP_TEMPLATE_VIS codecvt;
+class codecvt;
 
 // template <> class codecvt<char, char, mbstate_t>
 
@@ -1235,7 +1235,7 @@ protected:
 // template <class _InternT, class _ExternT, class _StateT> class codecvt_byname
 
 template <class _InternT, class _ExternT, class _StateT>
-class _LIBCPP_TEMPLATE_VIS codecvt_byname : public codecvt<_InternT, _ExternT, _StateT> {
+class codecvt_byname : public codecvt<_InternT, _ExternT, _StateT> {
 public:
   _LIBCPP_HIDE_FROM_ABI explicit codecvt_byname(const char* __nm, size_t __refs = 0)
       : codecvt<_InternT, _ExternT, _StateT>(__nm, __refs) {}
@@ -1411,7 +1411,7 @@ struct _LIBCPP_EXPORTED_FROM_ABI __widen_from_utf8<32> : public codecvt<char32_t
 // template <class charT> class numpunct
 
 template <class _CharT>
-class _LIBCPP_TEMPLATE_VIS numpunct;
+class numpunct;
 
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI numpunct<char> : public locale::facet {
@@ -1476,7 +1476,7 @@ protected:
 // template <class charT> class numpunct_byname
 
 template <class _CharT>
-class _LIBCPP_TEMPLATE_VIS numpunct_byname;
+class numpunct_byname;
 
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI numpunct_byname<char> : public numpunct<char> {

--- a/libcxx/include/__memory/allocator.h
+++ b/libcxx/include/__memory/allocator.h
@@ -38,7 +38,7 @@ class allocator;
 // These specializations shouldn't be marked _LIBCPP_DEPRECATED_IN_CXX17.
 // Specializing allocator<void> is deprecated, but not using it.
 template <>
-class _LIBCPP_TEMPLATE_VIS allocator<void> {
+class allocator<void> {
 public:
   _LIBCPP_DEPRECATED_IN_CXX17 typedef void* pointer;
   _LIBCPP_DEPRECATED_IN_CXX17 typedef const void* const_pointer;
@@ -77,7 +77,7 @@ struct __non_trivial_if<true, _Unique> {
 //       allocator<void> trivial in C++20.
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS allocator : private __non_trivial_if<!is_void<_Tp>::value, allocator<_Tp> > {
+class allocator : private __non_trivial_if<!is_void<_Tp>::value, allocator<_Tp> > {
   static_assert(!is_const<_Tp>::value, "std::allocator does not support const types");
   static_assert(!is_volatile<_Tp>::value, "std::allocator does not support volatile types");
 

--- a/libcxx/include/__memory/allocator_arg_t.h
+++ b/libcxx/include/__memory/allocator_arg_t.h
@@ -23,7 +23,7 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-struct _LIBCPP_TEMPLATE_VIS allocator_arg_t {
+struct allocator_arg_t {
   explicit allocator_arg_t() = default;
 };
 

--- a/libcxx/include/__memory/allocator_traits.h
+++ b/libcxx/include/__memory/allocator_traits.h
@@ -237,7 +237,7 @@ _LIBCPP_CTAD_SUPPORTED_FOR_TYPE(allocation_result);
 #endif // _LIBCPP_STD_VER
 
 template <class _Alloc>
-struct _LIBCPP_TEMPLATE_VIS allocator_traits {
+struct allocator_traits {
   using allocator_type                         = _Alloc;
   using value_type                             = typename allocator_type::value_type;
   using pointer                                = __pointer<value_type, allocator_type>;

--- a/libcxx/include/__memory/auto_ptr.h
+++ b/libcxx/include/__memory/auto_ptr.h
@@ -26,7 +26,7 @@ struct _LIBCPP_DEPRECATED_IN_CXX11 auto_ptr_ref {
 };
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 auto_ptr {
+class _LIBCPP_DEPRECATED_IN_CXX11 auto_ptr {
 private:
   _Tp* __ptr_;
 
@@ -80,7 +80,7 @@ public:
 };
 
 template <>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX11 auto_ptr<void> {
+class _LIBCPP_DEPRECATED_IN_CXX11 auto_ptr<void> {
 public:
   typedef void element_type;
 };

--- a/libcxx/include/__memory/inout_ptr.h
+++ b/libcxx/include/__memory/inout_ptr.h
@@ -35,7 +35,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 23
 
 template <class _Smart, class _Pointer, class... _Args>
-class _LIBCPP_TEMPLATE_VIS inout_ptr_t {
+class inout_ptr_t {
   static_assert(!__is_specialization_v<_Smart, shared_ptr>, "std::shared_ptr<> is not supported with std::inout_ptr.");
 
 public:

--- a/libcxx/include/__memory/out_ptr.h
+++ b/libcxx/include/__memory/out_ptr.h
@@ -34,7 +34,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 23
 
 template <class _Smart, class _Pointer, class... _Args>
-class _LIBCPP_TEMPLATE_VIS out_ptr_t {
+class out_ptr_t {
   static_assert(!__is_specialization_v<_Smart, shared_ptr> || sizeof...(_Args) > 0,
                 "Using std::shared_ptr<> without a deleter in std::out_ptr is not supported.");
 

--- a/libcxx/include/__memory/pointer_traits.h
+++ b/libcxx/include/__memory/pointer_traits.h
@@ -146,10 +146,10 @@ public:
 };
 
 template <class _Ptr>
-struct _LIBCPP_TEMPLATE_VIS pointer_traits : __pointer_traits_impl<_Ptr> {};
+struct pointer_traits : __pointer_traits_impl<_Ptr> {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS pointer_traits<_Tp*> {
+struct pointer_traits<_Tp*> {
   typedef _Tp* pointer;
   typedef _Tp element_type;
   typedef ptrdiff_t difference_type;

--- a/libcxx/include/__memory/raw_storage_iterator.h
+++ b/libcxx/include/__memory/raw_storage_iterator.h
@@ -30,7 +30,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _OutputIterator, class _Tp>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 raw_storage_iterator
+class _LIBCPP_DEPRECATED_IN_CXX17 raw_storage_iterator
 #  if _LIBCPP_STD_VER <= 14 || !defined(_LIBCPP_ABI_NO_ITERATOR_BASES)
     : public iterator<output_iterator_tag, void, void, void, void>
 #  endif

--- a/libcxx/include/__memory/shared_ptr.h
+++ b/libcxx/include/__memory/shared_ptr.h
@@ -90,7 +90,7 @@ public:
 }
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS weak_ptr;
+class weak_ptr;
 
 template <class _Tp, class _Dp, class _Alloc>
 class __shared_ptr_pointer : public __shared_weak_count {
@@ -218,7 +218,7 @@ private:
 
 struct __shared_ptr_dummy_rebind_allocator_type;
 template <>
-class _LIBCPP_TEMPLATE_VIS allocator<__shared_ptr_dummy_rebind_allocator_type> {
+class allocator<__shared_ptr_dummy_rebind_allocator_type> {
 public:
   template <class _Other>
   struct rebind {
@@ -227,7 +227,7 @@ public:
 };
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS enable_shared_from_this;
+class enable_shared_from_this;
 
 // http://eel.is/c++draft/util.sharedptr#util.smartptr.shared.general-6
 // A pointer type Y* is said to be compatible with a pointer type T*
@@ -304,7 +304,7 @@ using __shared_ptr_nullptr_deleter_ctor_reqs _LIBCPP_NODEBUG =
 #endif
 
 template <class _Tp>
-class _LIBCPP_SHARED_PTR_TRIVIAL_ABI _LIBCPP_TEMPLATE_VIS shared_ptr {
+class _LIBCPP_SHARED_PTR_TRIVIAL_ABI shared_ptr {
   struct __nullptr_sfinae_tag {};
 
 public:
@@ -711,9 +711,9 @@ private:
   struct __shared_ptr_default_delete<_Yp[], _Un> : default_delete<_Yp[]> {};
 
   template <class _Up>
-  friend class _LIBCPP_TEMPLATE_VIS shared_ptr;
+  friend class shared_ptr;
   template <class _Up>
-  friend class _LIBCPP_TEMPLATE_VIS weak_ptr;
+  friend class weak_ptr;
 };
 
 #if _LIBCPP_STD_VER >= 17
@@ -1202,7 +1202,7 @@ inline _LIBCPP_HIDE_FROM_ABI _Dp* get_deleter(const shared_ptr<_Tp>& __p) _NOEXC
 #endif // _LIBCPP_HAS_RTTI
 
 template <class _Tp>
-class _LIBCPP_SHARED_PTR_TRIVIAL_ABI _LIBCPP_TEMPLATE_VIS weak_ptr {
+class _LIBCPP_SHARED_PTR_TRIVIAL_ABI weak_ptr {
 public:
 #if _LIBCPP_STD_VER >= 17
   typedef remove_extent_t<_Tp> element_type;
@@ -1263,9 +1263,9 @@ public:
   }
 
   template <class _Up>
-  friend class _LIBCPP_TEMPLATE_VIS weak_ptr;
+  friend class weak_ptr;
   template <class _Up>
-  friend class _LIBCPP_TEMPLATE_VIS shared_ptr;
+  friend class shared_ptr;
 };
 
 #if _LIBCPP_STD_VER >= 17
@@ -1383,7 +1383,7 @@ struct owner_less;
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS owner_less<shared_ptr<_Tp> > : __binary_function<shared_ptr<_Tp>, shared_ptr<_Tp>, bool> {
+struct owner_less<shared_ptr<_Tp> > : __binary_function<shared_ptr<_Tp>, shared_ptr<_Tp>, bool> {
   _LIBCPP_HIDE_FROM_ABI bool operator()(shared_ptr<_Tp> const& __x, shared_ptr<_Tp> const& __y) const _NOEXCEPT {
     return __x.owner_before(__y);
   }
@@ -1396,7 +1396,7 @@ struct _LIBCPP_TEMPLATE_VIS owner_less<shared_ptr<_Tp> > : __binary_function<sha
 };
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS owner_less<weak_ptr<_Tp> > : __binary_function<weak_ptr<_Tp>, weak_ptr<_Tp>, bool> {
+struct owner_less<weak_ptr<_Tp> > : __binary_function<weak_ptr<_Tp>, weak_ptr<_Tp>, bool> {
   _LIBCPP_HIDE_FROM_ABI bool operator()(weak_ptr<_Tp> const& __x, weak_ptr<_Tp> const& __y) const _NOEXCEPT {
     return __x.owner_before(__y);
   }
@@ -1410,7 +1410,7 @@ struct _LIBCPP_TEMPLATE_VIS owner_less<weak_ptr<_Tp> > : __binary_function<weak_
 
 #if _LIBCPP_STD_VER >= 17
 template <>
-struct _LIBCPP_TEMPLATE_VIS owner_less<void> {
+struct owner_less<void> {
   template <class _Tp, class _Up>
   _LIBCPP_HIDE_FROM_ABI bool operator()(shared_ptr<_Tp> const& __x, shared_ptr<_Up> const& __y) const _NOEXCEPT {
     return __x.owner_before(__y);
@@ -1432,7 +1432,7 @@ struct _LIBCPP_TEMPLATE_VIS owner_less<void> {
 #endif
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS enable_shared_from_this {
+class enable_shared_from_this {
   mutable weak_ptr<_Tp> __weak_this_;
 
 protected:
@@ -1456,10 +1456,10 @@ public:
 };
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS hash;
+struct hash;
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS hash<shared_ptr<_Tp> > {
+struct hash<shared_ptr<_Tp> > {
 #if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
   _LIBCPP_DEPRECATED_IN_CXX17 typedef shared_ptr<_Tp> argument_type;
   _LIBCPP_DEPRECATED_IN_CXX17 typedef size_t result_type;

--- a/libcxx/include/__memory/unique_ptr.h
+++ b/libcxx/include/__memory/unique_ptr.h
@@ -62,7 +62,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS default_delete {
+struct default_delete {
   static_assert(!is_function<_Tp>::value, "default_delete cannot be instantiated for function types");
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR default_delete() _NOEXCEPT = default;
@@ -78,7 +78,7 @@ struct _LIBCPP_TEMPLATE_VIS default_delete {
 };
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS default_delete<_Tp[]> {
+struct default_delete<_Tp[]> {
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR default_delete() _NOEXCEPT = default;
 
   template <class _Up, __enable_if_t<is_convertible<_Up (*)[], _Tp (*)[]>::value, int> = 0>
@@ -126,7 +126,7 @@ struct __unique_ptr_deleter_sfinae<_Deleter&> {
 #endif
 
 template <class _Tp, class _Dp = default_delete<_Tp> >
-class _LIBCPP_UNIQUE_PTR_TRIVIAL_ABI _LIBCPP_TEMPLATE_VIS unique_ptr {
+class _LIBCPP_UNIQUE_PTR_TRIVIAL_ABI unique_ptr {
 public:
   typedef _Tp element_type;
   typedef _Dp deleter_type;
@@ -393,7 +393,7 @@ private:
 };
 
 template <class _Tp, class _Dp>
-class _LIBCPP_UNIQUE_PTR_TRIVIAL_ABI _LIBCPP_TEMPLATE_VIS unique_ptr<_Tp[], _Dp> {
+class _LIBCPP_UNIQUE_PTR_TRIVIAL_ABI unique_ptr<_Tp[], _Dp> {
 public:
   typedef _Tp element_type;
   typedef _Dp deleter_type;
@@ -783,13 +783,13 @@ void make_unique_for_overwrite(_Args&&...) = delete;
 #endif // _LIBCPP_STD_VER >= 20
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS hash;
+struct hash;
 
 template <class _Tp, class _Dp>
 #ifdef _LIBCPP_CXX03_LANG
-struct _LIBCPP_TEMPLATE_VIS hash<unique_ptr<_Tp, _Dp> >
+struct hash<unique_ptr<_Tp, _Dp> >
 #else
-struct _LIBCPP_TEMPLATE_VIS hash<__enable_hash_helper< unique_ptr<_Tp, _Dp>, typename unique_ptr<_Tp, _Dp>::pointer> >
+struct hash<__enable_hash_helper< unique_ptr<_Tp, _Dp>, typename unique_ptr<_Tp, _Dp>::pointer> >
 #endif
 {
 #if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)

--- a/libcxx/include/__memory/uses_allocator.h
+++ b/libcxx/include/__memory/uses_allocator.h
@@ -40,7 +40,7 @@ template <class _Tp, class _Alloc>
 struct __uses_allocator<_Tp, _Alloc, false> : public false_type {};
 
 template <class _Tp, class _Alloc>
-struct _LIBCPP_TEMPLATE_VIS uses_allocator : public __uses_allocator<_Tp, _Alloc> {};
+struct uses_allocator : public __uses_allocator<_Tp, _Alloc> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp, class _Alloc>

--- a/libcxx/include/__memory_resource/polymorphic_allocator.h
+++ b/libcxx/include/__memory_resource/polymorphic_allocator.h
@@ -41,7 +41,7 @@ template <class _ValueType
           = byte
 #  endif
           >
-class _LIBCPP_AVAILABILITY_PMR _LIBCPP_TEMPLATE_VIS polymorphic_allocator {
+class _LIBCPP_AVAILABILITY_PMR polymorphic_allocator {
 
 public:
   using value_type = _ValueType;

--- a/libcxx/include/__mutex/lock_guard.h
+++ b/libcxx/include/__mutex/lock_guard.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Mutex>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_THREAD_SAFETY_ANNOTATION(scoped_lockable) lock_guard {
+class _LIBCPP_THREAD_SAFETY_ANNOTATION(scoped_lockable) lock_guard {
 public:
   typedef _Mutex mutex_type;
 

--- a/libcxx/include/__mutex/once_flag.h
+++ b/libcxx/include/__mutex/once_flag.h
@@ -31,7 +31,7 @@ _LIBCPP_PUSH_MACROS
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-struct _LIBCPP_TEMPLATE_VIS once_flag;
+struct once_flag;
 
 #ifndef _LIBCPP_CXX03_LANG
 
@@ -48,7 +48,7 @@ _LIBCPP_HIDE_FROM_ABI void call_once(once_flag&, const _Callable&);
 
 #endif // _LIBCPP_CXX03_LANG
 
-struct _LIBCPP_TEMPLATE_VIS once_flag {
+struct once_flag {
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR once_flag() _NOEXCEPT : __state_(_Unset) {}
   once_flag(const once_flag&)            = delete;
   once_flag& operator=(const once_flag&) = delete;

--- a/libcxx/include/__mutex/unique_lock.h
+++ b/libcxx/include/__mutex/unique_lock.h
@@ -25,7 +25,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Mutex>
-class _LIBCPP_TEMPLATE_VIS unique_lock {
+class unique_lock {
 public:
   typedef _Mutex mutex_type;
 

--- a/libcxx/include/__new/align_val_t.h
+++ b/libcxx/include/__new/align_val_t.h
@@ -16,8 +16,7 @@
 #  pragma GCC system_header
 #endif
 
-// purposefully not using versioning namespace
-namespace std {
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 #if _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION && !defined(_LIBCPP_ABI_VCRUNTIME)
 #  ifndef _LIBCPP_CXX03_LANG
 enum class align_val_t : size_t {};
@@ -25,6 +24,6 @@ enum class align_val_t : size_t {};
 enum align_val_t { __zero = 0, __max = (size_t)-1 };
 #  endif
 #endif
-} // namespace std
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 
 #endif // _LIBCPP___NEW_ALIGN_VAL_T_H

--- a/libcxx/include/__new/destroying_delete_t.h
+++ b/libcxx/include/__new/destroying_delete_t.h
@@ -16,15 +16,14 @@
 #endif
 
 #if _LIBCPP_STD_VER >= 20
-// purposefully not using versioning namespace
-namespace std {
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 // Enable the declaration even if the compiler doesn't support the language
 // feature.
 struct destroying_delete_t {
   explicit destroying_delete_t() = default;
 };
 inline constexpr destroying_delete_t destroying_delete{};
-} // namespace std
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 #endif
 
 #endif // _LIBCPP___NEW_DESTROYING_DELETE_T_H

--- a/libcxx/include/__new/exceptions.h
+++ b/libcxx/include/__new/exceptions.h
@@ -17,8 +17,7 @@
 #  pragma GCC system_header
 #endif
 
-// purposefully not using versioning namespace
-namespace std {
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 #if !defined(_LIBCPP_ABI_VCRUNTIME)
 
 class _LIBCPP_EXPORTED_FROM_ABI bad_alloc : public exception {
@@ -69,6 +68,6 @@ public:
   _LIBCPP_VERBOSE_ABORT("bad_array_new_length was thrown in -fno-exceptions mode");
 #endif
 }
-} // namespace std
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 
 #endif // _LIBCPP___NEW_EXCEPTIONS_H

--- a/libcxx/include/__new/new_handler.h
+++ b/libcxx/include/__new/new_handler.h
@@ -18,12 +18,11 @@
 #if defined(_LIBCPP_ABI_VCRUNTIME)
 #  include <new.h>
 #else
-// purposefully not using versioning namespace
-namespace std {
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 typedef void (*new_handler)();
 _LIBCPP_EXPORTED_FROM_ABI new_handler set_new_handler(new_handler) _NOEXCEPT;
 _LIBCPP_EXPORTED_FROM_ABI new_handler get_new_handler() _NOEXCEPT;
-} // namespace std
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 #endif // _LIBCPP_ABI_VCRUNTIME
 
 #endif // _LIBCPP___NEW_NEW_HANDLER_H

--- a/libcxx/include/__new/nothrow_t.h
+++ b/libcxx/include/__new/nothrow_t.h
@@ -18,13 +18,12 @@
 #if defined(_LIBCPP_ABI_VCRUNTIME)
 #  include <new.h>
 #else
-// purposefully not using versioning namespace
-namespace std {
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 struct _LIBCPP_EXPORTED_FROM_ABI nothrow_t {
   explicit nothrow_t() = default;
 };
 extern _LIBCPP_EXPORTED_FROM_ABI const nothrow_t nothrow;
-} // namespace std
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 #endif // _LIBCPP_ABI_VCRUNTIME
 
 #endif // _LIBCPP___NEW_NOTHROW_T_H

--- a/libcxx/include/__node_handle
+++ b/libcxx/include/__node_handle
@@ -80,7 +80,7 @@ template <class _NodeType, class _Alloc>
 struct __generic_container_node_destructor;
 
 template <class _NodeType, class _Alloc, template <class, class> class _MapOrSetSpecifics>
-class _LIBCPP_TEMPLATE_VIS __basic_node_handle
+class __basic_node_handle
     : public _MapOrSetSpecifics< _NodeType, __basic_node_handle<_NodeType, _Alloc, _MapOrSetSpecifics>> {
   template <class _Tp, class _Compare, class _Allocator>
   friend class __tree;
@@ -194,7 +194,7 @@ template <class _NodeType, class _Alloc>
 using __map_node_handle _LIBCPP_NODEBUG = __basic_node_handle< _NodeType, _Alloc, __map_node_handle_specifics>;
 
 template <class _Iterator, class _NodeType>
-struct _LIBCPP_TEMPLATE_VIS __insert_return_type {
+struct __insert_return_type {
   _Iterator position;
   bool inserted;
   _NodeType node;

--- a/libcxx/include/__ostream/basic_ostream.h
+++ b/libcxx/include/__ostream/basic_ostream.h
@@ -41,7 +41,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS basic_ostream : virtual public basic_ios<_CharT, _Traits> {
+class basic_ostream : virtual public basic_ios<_CharT, _Traits> {
 public:
   // types (inherited from basic_ios (27.5.4)):
   typedef _CharT char_type;
@@ -71,7 +71,7 @@ protected:
 
 public:
   // 27.7.2.4 Prefix/suffix:
-  class _LIBCPP_TEMPLATE_VIS sentry;
+  class sentry;
 
   // 27.7.2.6 Formatted output:
   inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1 basic_ostream& operator<<(basic_ostream& (*__pf)(basic_ostream&)) {
@@ -181,7 +181,7 @@ protected:
 };
 
 template <class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS basic_ostream<_CharT, _Traits>::sentry {
+class basic_ostream<_CharT, _Traits>::sentry {
   bool __ok_;
   basic_ostream<_CharT, _Traits>& __os_;
 

--- a/libcxx/include/__random/bernoulli_distribution.h
+++ b/libcxx/include/__random/bernoulli_distribution.h
@@ -23,12 +23,12 @@ _LIBCPP_PUSH_MACROS
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-class _LIBCPP_TEMPLATE_VIS bernoulli_distribution {
+class bernoulli_distribution {
 public:
   // types
   typedef bool result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     double __p_;
 
   public:

--- a/libcxx/include/__random/binomial_distribution.h
+++ b/libcxx/include/__random/binomial_distribution.h
@@ -25,14 +25,14 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _IntType = int>
-class _LIBCPP_TEMPLATE_VIS binomial_distribution {
+class binomial_distribution {
   static_assert(__libcpp_random_is_valid_inttype<_IntType>::value, "IntType must be a supported integer type");
 
 public:
   // types
   typedef _IntType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     result_type __t_;
     double __p_;
     double __pr_;

--- a/libcxx/include/__random/cauchy_distribution.h
+++ b/libcxx/include/__random/cauchy_distribution.h
@@ -26,7 +26,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _RealType = double>
-class _LIBCPP_TEMPLATE_VIS cauchy_distribution {
+class cauchy_distribution {
   static_assert(__libcpp_random_is_valid_realtype<_RealType>::value,
                 "RealType must be a supported floating-point type");
 
@@ -34,7 +34,7 @@ public:
   // types
   typedef _RealType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     result_type __a_;
     result_type __b_;
 

--- a/libcxx/include/__random/chi_squared_distribution.h
+++ b/libcxx/include/__random/chi_squared_distribution.h
@@ -25,7 +25,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _RealType = double>
-class _LIBCPP_TEMPLATE_VIS chi_squared_distribution {
+class chi_squared_distribution {
   static_assert(__libcpp_random_is_valid_realtype<_RealType>::value,
                 "RealType must be a supported floating-point type");
 
@@ -33,7 +33,7 @@ public:
   // types
   typedef _RealType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     result_type __n_;
 
   public:

--- a/libcxx/include/__random/discard_block_engine.h
+++ b/libcxx/include/__random/discard_block_engine.h
@@ -28,7 +28,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Engine, size_t __p, size_t __r>
-class _LIBCPP_TEMPLATE_VIS discard_block_engine {
+class discard_block_engine {
   _Engine __e_;
   int __n_;
 

--- a/libcxx/include/__random/discrete_distribution.h
+++ b/libcxx/include/__random/discrete_distribution.h
@@ -28,14 +28,14 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _IntType = int>
-class _LIBCPP_TEMPLATE_VIS discrete_distribution {
+class discrete_distribution {
   static_assert(__libcpp_random_is_valid_inttype<_IntType>::value, "IntType must be a supported integer type");
 
 public:
   // types
   typedef _IntType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     vector<double> __p_;
 
   public:

--- a/libcxx/include/__random/exponential_distribution.h
+++ b/libcxx/include/__random/exponential_distribution.h
@@ -27,7 +27,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _RealType = double>
-class _LIBCPP_TEMPLATE_VIS exponential_distribution {
+class exponential_distribution {
   static_assert(__libcpp_random_is_valid_realtype<_RealType>::value,
                 "RealType must be a supported floating-point type");
 
@@ -35,7 +35,7 @@ public:
   // types
   typedef _RealType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     result_type __lambda_;
 
   public:

--- a/libcxx/include/__random/extreme_value_distribution.h
+++ b/libcxx/include/__random/extreme_value_distribution.h
@@ -26,7 +26,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _RealType = double>
-class _LIBCPP_TEMPLATE_VIS extreme_value_distribution {
+class extreme_value_distribution {
   static_assert(__libcpp_random_is_valid_realtype<_RealType>::value,
                 "RealType must be a supported floating-point type");
 
@@ -34,7 +34,7 @@ public:
   // types
   typedef _RealType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     result_type __a_;
     result_type __b_;
 

--- a/libcxx/include/__random/fisher_f_distribution.h
+++ b/libcxx/include/__random/fisher_f_distribution.h
@@ -25,7 +25,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _RealType = double>
-class _LIBCPP_TEMPLATE_VIS fisher_f_distribution {
+class fisher_f_distribution {
   static_assert(__libcpp_random_is_valid_realtype<_RealType>::value,
                 "RealType must be a supported floating-point type");
 
@@ -33,7 +33,7 @@ public:
   // types
   typedef _RealType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     result_type __m_;
     result_type __n_;
 

--- a/libcxx/include/__random/gamma_distribution.h
+++ b/libcxx/include/__random/gamma_distribution.h
@@ -27,7 +27,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _RealType = double>
-class _LIBCPP_TEMPLATE_VIS gamma_distribution {
+class gamma_distribution {
   static_assert(__libcpp_random_is_valid_realtype<_RealType>::value,
                 "RealType must be a supported floating-point type");
 
@@ -35,7 +35,7 @@ public:
   // types
   typedef _RealType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     result_type __alpha_;
     result_type __beta_;
 

--- a/libcxx/include/__random/geometric_distribution.h
+++ b/libcxx/include/__random/geometric_distribution.h
@@ -25,14 +25,14 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _IntType = int>
-class _LIBCPP_TEMPLATE_VIS geometric_distribution {
+class geometric_distribution {
   static_assert(__libcpp_random_is_valid_inttype<_IntType>::value, "IntType must be a supported integer type");
 
 public:
   // types
   typedef _IntType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     double __p_;
 
   public:

--- a/libcxx/include/__random/independent_bits_engine.h
+++ b/libcxx/include/__random/independent_bits_engine.h
@@ -31,7 +31,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Engine, size_t __w, class _UIntType>
-class _LIBCPP_TEMPLATE_VIS independent_bits_engine {
+class independent_bits_engine {
   template <class _UInt, _UInt _R0, size_t _Wp, size_t _Mp>
   class __get_n {
     static _LIBCPP_CONSTEXPR const size_t _Dt = numeric_limits<_UInt>::digits;

--- a/libcxx/include/__random/linear_congruential_engine.h
+++ b/libcxx/include/__random/linear_congruential_engine.h
@@ -220,7 +220,7 @@ struct __lce_ta<__a, __c, __m, (unsigned short)(-1), __mode> {
 };
 
 template <class _UIntType, _UIntType __a, _UIntType __c, _UIntType __m>
-class _LIBCPP_TEMPLATE_VIS linear_congruential_engine;
+class linear_congruential_engine;
 
 template <class _CharT, class _Traits, class _Up, _Up _Ap, _Up _Cp, _Up _Np>
 _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _Traits>&
@@ -231,7 +231,7 @@ _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>&
 operator>>(basic_istream<_CharT, _Traits>& __is, linear_congruential_engine<_Up, _Ap, _Cp, _Np>& __x);
 
 template <class _UIntType, _UIntType __a, _UIntType __c, _UIntType __m>
-class _LIBCPP_TEMPLATE_VIS linear_congruential_engine {
+class linear_congruential_engine {
 public:
   // types
   typedef _UIntType result_type;

--- a/libcxx/include/__random/lognormal_distribution.h
+++ b/libcxx/include/__random/lognormal_distribution.h
@@ -26,7 +26,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _RealType = double>
-class _LIBCPP_TEMPLATE_VIS lognormal_distribution {
+class lognormal_distribution {
   static_assert(__libcpp_random_is_valid_realtype<_RealType>::value,
                 "RealType must be a supported floating-point type");
 
@@ -34,7 +34,7 @@ public:
   // types
   typedef _RealType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     result_type __m_;
     result_type __s_;
 

--- a/libcxx/include/__random/mersenne_twister_engine.h
+++ b/libcxx/include/__random/mersenne_twister_engine.h
@@ -42,7 +42,7 @@ template <class _UIntType,
           _UIntType __c,
           size_t __l,
           _UIntType __f>
-class _LIBCPP_TEMPLATE_VIS mersenne_twister_engine;
+class mersenne_twister_engine;
 
 template <class _UInt,
           size_t _Wp,
@@ -134,7 +134,7 @@ template <class _UIntType,
           _UIntType __c,
           size_t __l,
           _UIntType __f>
-class _LIBCPP_TEMPLATE_VIS mersenne_twister_engine {
+class mersenne_twister_engine {
 public:
   // types
   typedef _UIntType result_type;

--- a/libcxx/include/__random/negative_binomial_distribution.h
+++ b/libcxx/include/__random/negative_binomial_distribution.h
@@ -28,14 +28,14 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _IntType = int>
-class _LIBCPP_TEMPLATE_VIS negative_binomial_distribution {
+class negative_binomial_distribution {
   static_assert(__libcpp_random_is_valid_inttype<_IntType>::value, "IntType must be a supported integer type");
 
 public:
   // types
   typedef _IntType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     result_type __k_;
     double __p_;
 

--- a/libcxx/include/__random/normal_distribution.h
+++ b/libcxx/include/__random/normal_distribution.h
@@ -26,7 +26,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _RealType = double>
-class _LIBCPP_TEMPLATE_VIS normal_distribution {
+class normal_distribution {
   static_assert(__libcpp_random_is_valid_realtype<_RealType>::value,
                 "RealType must be a supported floating-point type");
 
@@ -34,7 +34,7 @@ public:
   // types
   typedef _RealType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     result_type __mean_;
     result_type __stddev_;
 

--- a/libcxx/include/__random/piecewise_constant_distribution.h
+++ b/libcxx/include/__random/piecewise_constant_distribution.h
@@ -29,7 +29,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _RealType = double>
-class _LIBCPP_TEMPLATE_VIS piecewise_constant_distribution {
+class piecewise_constant_distribution {
   static_assert(__libcpp_random_is_valid_realtype<_RealType>::value,
                 "RealType must be a supported floating-point type");
 
@@ -37,7 +37,7 @@ public:
   // types
   typedef _RealType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     vector<result_type> __b_;
     vector<result_type> __densities_;
     vector<result_type> __areas_;

--- a/libcxx/include/__random/piecewise_linear_distribution.h
+++ b/libcxx/include/__random/piecewise_linear_distribution.h
@@ -30,7 +30,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _RealType = double>
-class _LIBCPP_TEMPLATE_VIS piecewise_linear_distribution {
+class piecewise_linear_distribution {
   static_assert(__libcpp_random_is_valid_realtype<_RealType>::value,
                 "RealType must be a supported floating-point type");
 
@@ -38,7 +38,7 @@ public:
   // types
   typedef _RealType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     vector<result_type> __b_;
     vector<result_type> __densities_;
     vector<result_type> __areas_;

--- a/libcxx/include/__random/poisson_distribution.h
+++ b/libcxx/include/__random/poisson_distribution.h
@@ -29,14 +29,14 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _IntType = int>
-class _LIBCPP_TEMPLATE_VIS poisson_distribution {
+class poisson_distribution {
   static_assert(__libcpp_random_is_valid_inttype<_IntType>::value, "IntType must be a supported integer type");
 
 public:
   // types
   typedef _IntType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     double __mean_;
     double __s_;
     double __d_;

--- a/libcxx/include/__random/seed_seq.h
+++ b/libcxx/include/__random/seed_seq.h
@@ -30,7 +30,7 @@ _LIBCPP_PUSH_MACROS
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-class _LIBCPP_TEMPLATE_VIS seed_seq {
+class seed_seq {
 public:
   // types
   typedef uint32_t result_type;

--- a/libcxx/include/__random/shuffle_order_engine.h
+++ b/libcxx/include/__random/shuffle_order_engine.h
@@ -52,7 +52,7 @@ public:
 };
 
 template <class _Engine, size_t __k>
-class _LIBCPP_TEMPLATE_VIS shuffle_order_engine {
+class shuffle_order_engine {
   static_assert(0 < __k, "shuffle_order_engine invalid parameters");
 
 public:

--- a/libcxx/include/__random/student_t_distribution.h
+++ b/libcxx/include/__random/student_t_distribution.h
@@ -27,7 +27,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _RealType = double>
-class _LIBCPP_TEMPLATE_VIS student_t_distribution {
+class student_t_distribution {
   static_assert(__libcpp_random_is_valid_realtype<_RealType>::value,
                 "RealType must be a supported floating-point type");
 
@@ -35,7 +35,7 @@ public:
   // types
   typedef _RealType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     result_type __n_;
 
   public:

--- a/libcxx/include/__random/subtract_with_carry_engine.h
+++ b/libcxx/include/__random/subtract_with_carry_engine.h
@@ -30,7 +30,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _UIntType, size_t __w, size_t __s, size_t __r>
-class _LIBCPP_TEMPLATE_VIS subtract_with_carry_engine;
+class subtract_with_carry_engine;
 
 template <class _UInt, size_t _Wp, size_t _Sp, size_t _Rp>
 _LIBCPP_HIDE_FROM_ABI bool operator==(const subtract_with_carry_engine<_UInt, _Wp, _Sp, _Rp>& __x,
@@ -49,7 +49,7 @@ _LIBCPP_HIDE_FROM_ABI basic_istream<_CharT, _Traits>&
 operator>>(basic_istream<_CharT, _Traits>& __is, subtract_with_carry_engine<_UInt, _Wp, _Sp, _Rp>& __x);
 
 template <class _UIntType, size_t __w, size_t __s, size_t __r>
-class _LIBCPP_TEMPLATE_VIS subtract_with_carry_engine {
+class subtract_with_carry_engine {
 public:
   // types
   typedef _UIntType result_type;

--- a/libcxx/include/__random/uniform_real_distribution.h
+++ b/libcxx/include/__random/uniform_real_distribution.h
@@ -25,7 +25,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _RealType = double>
-class _LIBCPP_TEMPLATE_VIS uniform_real_distribution {
+class uniform_real_distribution {
   static_assert(__libcpp_random_is_valid_realtype<_RealType>::value,
                 "RealType must be a supported floating-point type");
 
@@ -33,7 +33,7 @@ public:
   // types
   typedef _RealType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     result_type __a_;
     result_type __b_;
 

--- a/libcxx/include/__random/weibull_distribution.h
+++ b/libcxx/include/__random/weibull_distribution.h
@@ -26,7 +26,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _RealType = double>
-class _LIBCPP_TEMPLATE_VIS weibull_distribution {
+class weibull_distribution {
   static_assert(__libcpp_random_is_valid_realtype<_RealType>::value,
                 "RealType must be a supported floating-point type");
 
@@ -34,7 +34,7 @@ public:
   // types
   typedef _RealType result_type;
 
-  class _LIBCPP_TEMPLATE_VIS param_type {
+  class param_type {
     result_type __a_;
     result_type __b_;
 

--- a/libcxx/include/__ranges/non_propagating_cache.h
+++ b/libcxx/include/__ranges/non_propagating_cache.h
@@ -36,7 +36,7 @@ namespace ranges {
 // may refer to internal details of the source view.
 template <class _Tp>
   requires is_object_v<_Tp>
-class _LIBCPP_TEMPLATE_VIS __non_propagating_cache {
+class __non_propagating_cache {
   struct __from_tag {};
   struct __forward_tag {};
 

--- a/libcxx/include/__ranges/subrange.h
+++ b/libcxx/include/__ranges/subrange.h
@@ -72,7 +72,7 @@ template <input_or_output_iterator _Iter,
           sentinel_for<_Iter> _Sent = _Iter,
           subrange_kind _Kind       = sized_sentinel_for<_Sent, _Iter> ? subrange_kind::sized : subrange_kind::unsized>
   requires(_Kind == subrange_kind::sized || !sized_sentinel_for<_Sent, _Iter>)
-class _LIBCPP_TEMPLATE_VIS subrange : public view_interface<subrange<_Iter, _Sent, _Kind>> {
+class subrange : public view_interface<subrange<_Iter, _Sent, _Kind>> {
 public:
   // Note: this is an internal implementation detail that is public only for internal usage.
   static constexpr bool _StoreSize = (_Kind == subrange_kind::sized && !sized_sentinel_for<_Sent, _Iter>);

--- a/libcxx/include/__string/char_traits.h
+++ b/libcxx/include/__string/char_traits.h
@@ -78,7 +78,7 @@ exposition-only to document what members a char_traits specialization should pro
 // char_traits<char>
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS char_traits<char> {
+struct char_traits<char> {
   using char_type  = char;
   using int_type   = int;
   using off_type   = streamoff;
@@ -236,7 +236,7 @@ struct __char_traits_base {
 
 #if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
-struct _LIBCPP_TEMPLATE_VIS char_traits<wchar_t> : __char_traits_base<wchar_t, wint_t, static_cast<wint_t>(WEOF)> {
+struct char_traits<wchar_t> : __char_traits_base<wchar_t, wint_t, static_cast<wint_t>(WEOF)> {
   static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX17 int
   compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT {
     if (__n == 0)
@@ -260,8 +260,7 @@ struct _LIBCPP_TEMPLATE_VIS char_traits<wchar_t> : __char_traits_base<wchar_t, w
 #if _LIBCPP_HAS_CHAR8_T
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS char_traits<char8_t>
-    : __char_traits_base<char8_t, unsigned int, static_cast<unsigned int>(EOF)> {
+struct char_traits<char8_t> : __char_traits_base<char8_t, unsigned int, static_cast<unsigned int>(EOF)> {
   static _LIBCPP_HIDE_FROM_ABI constexpr int
   compare(const char_type* __s1, const char_type* __s2, size_t __n) noexcept {
     return std::__constexpr_memcmp(__s1, __s2, __element_count(__n));
@@ -280,8 +279,7 @@ struct _LIBCPP_TEMPLATE_VIS char_traits<char8_t>
 #endif // _LIBCPP_HAS_CHAR8_T
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS char_traits<char16_t>
-    : __char_traits_base<char16_t, uint_least16_t, static_cast<uint_least16_t>(0xFFFF)> {
+struct char_traits<char16_t> : __char_traits_base<char16_t, uint_least16_t, static_cast<uint_least16_t>(0xFFFF)> {
   _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX17 int
   compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT;
   _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX17 size_t length(const char_type* __s) _NOEXCEPT;
@@ -315,8 +313,7 @@ inline _LIBCPP_CONSTEXPR_SINCE_CXX17 size_t char_traits<char16_t>::length(const 
 }
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS char_traits<char32_t>
-    : __char_traits_base<char32_t, uint_least32_t, static_cast<uint_least32_t>(0xFFFFFFFF)> {
+struct char_traits<char32_t> : __char_traits_base<char32_t, uint_least32_t, static_cast<uint_least32_t>(0xFFFFFFFF)> {
   _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX17 int
   compare(const char_type* __s1, const char_type* __s2, size_t __n) _NOEXCEPT;
   _LIBCPP_HIDE_FROM_ABI static _LIBCPP_CONSTEXPR_SINCE_CXX17 size_t length(const char_type* __s) _NOEXCEPT;

--- a/libcxx/include/__system_error/error_code.h
+++ b/libcxx/include/__system_error/error_code.h
@@ -26,7 +26,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_error_code_enum : public false_type {};
+struct is_error_code_enum : public false_type {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -131,7 +131,7 @@ inline _LIBCPP_HIDE_FROM_ABI strong_ordering operator<=>(const error_code& __x, 
 #endif // _LIBCPP_STD_VER <= 17
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<error_code> : public __unary_function<error_code, size_t> {
+struct hash<error_code> : public __unary_function<error_code, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(const error_code& __ec) const _NOEXCEPT {
     return static_cast<size_t>(__ec.value());
   }

--- a/libcxx/include/__system_error/error_condition.h
+++ b/libcxx/include/__system_error/error_condition.h
@@ -25,7 +25,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_error_condition_enum : public false_type {};
+struct is_error_condition_enum : public false_type {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -33,11 +33,11 @@ inline constexpr bool is_error_condition_enum_v = is_error_condition_enum<_Tp>::
 #endif
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS is_error_condition_enum<errc> : true_type {};
+struct is_error_condition_enum<errc> : true_type {};
 
 #ifdef _LIBCPP_CXX03_LANG
 template <>
-struct _LIBCPP_TEMPLATE_VIS is_error_condition_enum<errc::__lx> : true_type {};
+struct is_error_condition_enum<errc::__lx> : true_type {};
 #endif
 
 namespace __adl_only {
@@ -118,7 +118,7 @@ operator<=>(const error_condition& __x, const error_condition& __y) noexcept {
 #endif // _LIBCPP_STD_VER <= 17
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<error_condition> : public __unary_function<error_condition, size_t> {
+struct hash<error_condition> : public __unary_function<error_condition, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(const error_condition& __ec) const _NOEXCEPT {
     return static_cast<size_t>(__ec.value());
   }

--- a/libcxx/include/__thread/formatter.h
+++ b/libcxx/include/__thread/formatter.h
@@ -34,7 +34,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #  if _LIBCPP_HAS_THREADS
 
 template <__fmt_char_type _CharT>
-struct _LIBCPP_TEMPLATE_VIS formatter<__thread_id, _CharT> {
+struct formatter<__thread_id, _CharT> {
 public:
   template <class _ParseContext>
   _LIBCPP_HIDE_FROM_ABI constexpr typename _ParseContext::iterator parse(_ParseContext& __ctx) {

--- a/libcxx/include/__thread/id.h
+++ b/libcxx/include/__thread/id.h
@@ -34,7 +34,7 @@ _LIBCPP_HIDE_FROM_ABI __thread_id get_id() _NOEXCEPT;
 template <>
 struct hash<__thread_id>;
 
-class _LIBCPP_TEMPLATE_VIS __thread_id {
+class __thread_id {
   // FIXME: pthread_t is a pointer on Darwin but a long on Linux.
   // NULL is the no-thread value on Darwin.  Someone needs to check
   // on other platforms.  We assume 0 works everywhere for now.
@@ -72,7 +72,7 @@ private:
 
   friend __thread_id this_thread::get_id() _NOEXCEPT;
   friend class _LIBCPP_EXPORTED_FROM_ABI thread;
-  friend struct _LIBCPP_TEMPLATE_VIS hash<__thread_id>;
+  friend struct hash<__thread_id>;
 };
 
 inline _LIBCPP_HIDE_FROM_ABI bool operator==(__thread_id __x, __thread_id __y) _NOEXCEPT {

--- a/libcxx/include/__thread/thread.h
+++ b/libcxx/include/__thread/thread.h
@@ -119,7 +119,7 @@ void __thread_specific_ptr<_Tp>::set_pointer(pointer __p) {
 }
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<__thread_id> : public __unary_function<__thread_id, size_t> {
+struct hash<__thread_id> : public __unary_function<__thread_id, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(__thread_id __v) const _NOEXCEPT {
     return hash<__libcpp_thread_id>()(__v.__id_);
   }

--- a/libcxx/include/__tree
+++ b/libcxx/include/__tree
@@ -53,9 +53,9 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Tp, class _Compare, class _Allocator>
 class __tree;
 template <class _Tp, class _NodePtr, class _DiffType>
-class _LIBCPP_TEMPLATE_VIS __tree_iterator;
+class __tree_iterator;
 template <class _Tp, class _ConstNodePtr, class _DiffType>
-class _LIBCPP_TEMPLATE_VIS __tree_const_iterator;
+class __tree_const_iterator;
 
 template <class _Pointer>
 class __tree_end_node;
@@ -70,9 +70,9 @@ struct __value_type;
 template <class _Allocator>
 class __map_node_destructor;
 template <class _TreeIterator>
-class _LIBCPP_TEMPLATE_VIS __map_iterator;
+class __map_iterator;
 template <class _TreeIterator>
-class _LIBCPP_TEMPLATE_VIS __map_const_iterator;
+class __map_const_iterator;
 
 /*
 
@@ -707,7 +707,7 @@ struct __generic_container_node_destructor<__tree_node<_Tp, _VoidPtr>, _Alloc> :
 #endif
 
 template <class _Tp, class _NodePtr, class _DiffType>
-class _LIBCPP_TEMPLATE_VIS __tree_iterator {
+class __tree_iterator {
   typedef __tree_node_types<_NodePtr> _NodeTypes;
   typedef _NodePtr __node_pointer;
   typedef typename _NodeTypes::__node_base_pointer __node_base_pointer;
@@ -770,21 +770,21 @@ private:
   template <class, class, class>
   friend class __tree;
   template <class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS __tree_const_iterator;
+  friend class __tree_const_iterator;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __map_iterator;
+  friend class __map_iterator;
   template <class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS map;
+  friend class map;
   template <class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS multimap;
+  friend class multimap;
   template <class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS set;
+  friend class set;
   template <class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS multiset;
+  friend class multiset;
 };
 
 template <class _Tp, class _NodePtr, class _DiffType>
-class _LIBCPP_TEMPLATE_VIS __tree_const_iterator {
+class __tree_const_iterator {
   typedef __tree_node_types<_NodePtr> _NodeTypes;
   typedef typename _NodeTypes::__node_pointer __node_pointer;
   typedef typename _NodeTypes::__node_base_pointer __node_base_pointer;
@@ -856,15 +856,15 @@ private:
   template <class, class, class>
   friend class __tree;
   template <class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS map;
+  friend class map;
   template <class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS multimap;
+  friend class multimap;
   template <class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS set;
+  friend class set;
   template <class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS multiset;
+  friend class multiset;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __map_const_iterator;
+  friend class __map_const_iterator;
 };
 
 template <class _Tp, class _Compare>
@@ -1313,9 +1313,9 @@ private:
   };
 
   template <class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS map;
+  friend class map;
   template <class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS multimap;
+  friend class multimap;
 };
 
 template <class _Tp, class _Compare, class _Allocator>

--- a/libcxx/include/__tuple/sfinae_helpers.h
+++ b/libcxx/include/__tuple/sfinae_helpers.h
@@ -58,7 +58,7 @@ struct __tuple_constructible<_Tp, _Up, true, true>
                                                    typename __make_tuple_types<_Up>::type > {};
 
 template <size_t _Ip, class... _Tp>
-struct _LIBCPP_TEMPLATE_VIS tuple_element<_Ip, tuple<_Tp...> > {
+struct tuple_element<_Ip, tuple<_Tp...> > {
   using type _LIBCPP_NODEBUG = typename tuple_element<_Ip, __tuple_types<_Tp...> >::type;
 };
 

--- a/libcxx/include/__tuple/tuple_element.h
+++ b/libcxx/include/__tuple/tuple_element.h
@@ -21,27 +21,27 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <size_t _Ip, class _Tp>
-struct _LIBCPP_TEMPLATE_VIS tuple_element;
+struct tuple_element;
 
 template <size_t _Ip, class _Tp>
-struct _LIBCPP_TEMPLATE_VIS tuple_element<_Ip, const _Tp> {
+struct tuple_element<_Ip, const _Tp> {
   using type _LIBCPP_NODEBUG = const typename tuple_element<_Ip, _Tp>::type;
 };
 
 template <size_t _Ip, class _Tp>
-struct _LIBCPP_TEMPLATE_VIS tuple_element<_Ip, volatile _Tp> {
+struct tuple_element<_Ip, volatile _Tp> {
   using type _LIBCPP_NODEBUG = volatile typename tuple_element<_Ip, _Tp>::type;
 };
 
 template <size_t _Ip, class _Tp>
-struct _LIBCPP_TEMPLATE_VIS tuple_element<_Ip, const volatile _Tp> {
+struct tuple_element<_Ip, const volatile _Tp> {
   using type _LIBCPP_NODEBUG = const volatile typename tuple_element<_Ip, _Tp>::type;
 };
 
 #ifndef _LIBCPP_CXX03_LANG
 
 template <size_t _Ip, class... _Types>
-struct _LIBCPP_TEMPLATE_VIS tuple_element<_Ip, __tuple_types<_Types...> > {
+struct tuple_element<_Ip, __tuple_types<_Types...> > {
   static_assert(_Ip < sizeof...(_Types), "tuple_element index out of range");
   using type _LIBCPP_NODEBUG = __type_pack_element<_Ip, _Types...>;
 };

--- a/libcxx/include/__tuple/tuple_size.h
+++ b/libcxx/include/__tuple/tuple_size.h
@@ -25,45 +25,44 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS tuple_size;
+struct tuple_size;
 
 #if !defined(_LIBCPP_CXX03_LANG)
 template <class _Tp, class...>
 using __enable_if_tuple_size_imp _LIBCPP_NODEBUG = _Tp;
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS tuple_size<__enable_if_tuple_size_imp< const _Tp,
-                                                                   __enable_if_t<!is_volatile<_Tp>::value>,
-                                                                   integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
+struct tuple_size<__enable_if_tuple_size_imp<const _Tp,
+                                             __enable_if_t<!is_volatile<_Tp>::value>,
+                                             integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
     : public integral_constant<size_t, tuple_size<_Tp>::value> {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS tuple_size<__enable_if_tuple_size_imp< volatile _Tp,
-                                                                   __enable_if_t<!is_const<_Tp>::value>,
-                                                                   integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
+struct tuple_size<__enable_if_tuple_size_imp<volatile _Tp,
+                                             __enable_if_t<!is_const<_Tp>::value>,
+                                             integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
     : public integral_constant<size_t, tuple_size<_Tp>::value> {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS
-tuple_size<__enable_if_tuple_size_imp<const volatile _Tp, integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
+struct tuple_size<__enable_if_tuple_size_imp<const volatile _Tp, integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
     : public integral_constant<size_t, tuple_size<_Tp>::value> {};
 
 #else
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS tuple_size<const _Tp> : public tuple_size<_Tp> {};
+struct tuple_size<const _Tp> : public tuple_size<_Tp> {};
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS tuple_size<volatile _Tp> : public tuple_size<_Tp> {};
+struct tuple_size<volatile _Tp> : public tuple_size<_Tp> {};
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS tuple_size<const volatile _Tp> : public tuple_size<_Tp> {};
+struct tuple_size<const volatile _Tp> : public tuple_size<_Tp> {};
 #endif
 
 #ifndef _LIBCPP_CXX03_LANG
 
 template <class... _Tp>
-struct _LIBCPP_TEMPLATE_VIS tuple_size<tuple<_Tp...> > : public integral_constant<size_t, sizeof...(_Tp)> {};
+struct tuple_size<tuple<_Tp...> > : public integral_constant<size_t, sizeof...(_Tp)> {};
 
 template <class... _Tp>
-struct _LIBCPP_TEMPLATE_VIS tuple_size<__tuple_types<_Tp...> > : public integral_constant<size_t, sizeof...(_Tp)> {};
+struct tuple_size<__tuple_types<_Tp...> > : public integral_constant<size_t, sizeof...(_Tp)> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/add_cv_quals.h
+++ b/libcxx/include/__type_traits/add_cv_quals.h
@@ -18,7 +18,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS add_const {
+struct _LIBCPP_NO_SPECIALIZATIONS add_const {
   using type _LIBCPP_NODEBUG = const _Tp;
 };
 
@@ -28,7 +28,7 @@ using add_const_t = typename add_const<_Tp>::type;
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS add_cv {
+struct _LIBCPP_NO_SPECIALIZATIONS add_cv {
   using type _LIBCPP_NODEBUG = const volatile _Tp;
 };
 
@@ -38,7 +38,7 @@ using add_cv_t = typename add_cv<_Tp>::type;
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS add_volatile {
+struct _LIBCPP_NO_SPECIALIZATIONS add_volatile {
   using type _LIBCPP_NODEBUG = volatile _Tp;
 };
 

--- a/libcxx/include/__type_traits/aligned_storage.h
+++ b/libcxx/include/__type_traits/aligned_storage.h
@@ -68,7 +68,7 @@ struct __find_max_align<__type_list<_Head, _Tail...>, _Len>
           __select_align<_Len, _Head::value, __find_max_align<__type_list<_Tail...>, _Len>::value>::value> {};
 
 template <size_t _Len, size_t _Align = __find_max_align<__all_types, _Len>::value>
-struct _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS aligned_storage {
+struct _LIBCPP_DEPRECATED_IN_CXX23 _LIBCPP_NO_SPECIALIZATIONS aligned_storage {
   union _ALIGNAS(_Align) type {
     unsigned char __data[(_Len + _Align - 1) / _Align * _Align];
   };

--- a/libcxx/include/__type_traits/alignment_of.h
+++ b/libcxx/include/__type_traits/alignment_of.h
@@ -20,8 +20,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS alignment_of
-    : public integral_constant<size_t, _LIBCPP_ALIGNOF(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS alignment_of : public integral_constant<size_t, _LIBCPP_ALIGNOF(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/common_type.h
+++ b/libcxx/include/__type_traits/common_type.h
@@ -70,7 +70,7 @@ struct __common_type_impl {};
 template <class... _Tp>
 struct __common_types;
 template <class... _Tp>
-struct _LIBCPP_TEMPLATE_VIS common_type;
+struct common_type;
 
 template <class _Tp, class _Up>
 struct __common_type_impl< __common_types<_Tp, _Up>, __void_t<typename common_type<_Tp, _Up>::type> > {
@@ -84,18 +84,18 @@ struct __common_type_impl<__common_types<_Tp, _Up, _Vp, _Rest...>, __void_t<type
 // bullet 1 - sizeof...(Tp) == 0
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS common_type<> {};
+struct common_type<> {};
 
 // bullet 2 - sizeof...(Tp) == 1
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS common_type<_Tp> : public common_type<_Tp, _Tp> {};
+struct common_type<_Tp> : public common_type<_Tp, _Tp> {};
 
 // bullet 3 - sizeof...(Tp) == 2
 
 // sub-bullet 1 - "If is_same_v<T1, D1> is false or ..."
 template <class _Tp, class _Up>
-struct _LIBCPP_TEMPLATE_VIS common_type<_Tp, _Up>
+struct common_type<_Tp, _Up>
     : __conditional_t<_IsSame<_Tp, __decay_t<_Tp> >::value && _IsSame<_Up, __decay_t<_Up> >::value,
                       __common_type2_imp<_Tp, _Up>,
                       common_type<__decay_t<_Tp>, __decay_t<_Up> > > {};
@@ -103,8 +103,7 @@ struct _LIBCPP_TEMPLATE_VIS common_type<_Tp, _Up>
 // bullet 4 - sizeof...(Tp) > 2
 
 template <class _Tp, class _Up, class _Vp, class... _Rest>
-struct _LIBCPP_TEMPLATE_VIS common_type<_Tp, _Up, _Vp, _Rest...>
-    : __common_type_impl<__common_types<_Tp, _Up, _Vp, _Rest...> > {};
+struct common_type<_Tp, _Up, _Vp, _Rest...> : __common_type_impl<__common_types<_Tp, _Up, _Vp, _Rest...> > {};
 
 #endif
 

--- a/libcxx/include/__type_traits/conditional.h
+++ b/libcxx/include/__type_traits/conditional.h
@@ -36,7 +36,7 @@ template <bool _Cond, class _IfRes, class _ElseRes>
 using _If _LIBCPP_NODEBUG = typename _IfImpl<_Cond>::template _Select<_IfRes, _ElseRes>;
 
 template <bool _Bp, class _If, class _Then>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS conditional {
+struct _LIBCPP_NO_SPECIALIZATIONS conditional {
   using type _LIBCPP_NODEBUG = _If;
 };
 
@@ -45,7 +45,7 @@ _LIBCPP_DIAGNOSTIC_PUSH
 _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Winvalid-specialization")
 #endif
 template <class _If, class _Then>
-struct _LIBCPP_TEMPLATE_VIS conditional<false, _If, _Then> {
+struct conditional<false, _If, _Then> {
   using type _LIBCPP_NODEBUG = _Then;
 };
 _LIBCPP_DIAGNOSTIC_POP

--- a/libcxx/include/__type_traits/decay.h
+++ b/libcxx/include/__type_traits/decay.h
@@ -50,7 +50,7 @@ public:
 };
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS decay {
+struct decay {
 private:
   using _Up _LIBCPP_NODEBUG = __libcpp_remove_reference_t<_Tp>;
 

--- a/libcxx/include/__type_traits/dependent_type.h
+++ b/libcxx/include/__type_traits/dependent_type.h
@@ -18,7 +18,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, bool>
-struct _LIBCPP_TEMPLATE_VIS __dependent_type : public _Tp {};
+struct __dependent_type : public _Tp {};
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__type_traits/enable_if.h
+++ b/libcxx/include/__type_traits/enable_if.h
@@ -18,14 +18,14 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <bool, class _Tp = void>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS enable_if{};
+struct _LIBCPP_NO_SPECIALIZATIONS enable_if{};
 
 _LIBCPP_DIAGNOSTIC_PUSH
 #if __has_warning("-Winvalid-specialization")
 _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Winvalid-specialization")
 #endif
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS enable_if<true, _Tp> {
+struct enable_if<true, _Tp> {
   typedef _Tp type;
 };
 _LIBCPP_DIAGNOSTIC_POP

--- a/libcxx/include/__type_traits/extent.h
+++ b/libcxx/include/__type_traits/extent.h
@@ -22,7 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if __has_builtin(__array_extent)
 
 template <class _Tp, size_t _Dim = 0>
-struct _LIBCPP_NO_SPECIALIZATIONS _LIBCPP_TEMPLATE_VIS extent : integral_constant<size_t, __array_extent(_Tp, _Dim)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS extent : integral_constant<size_t, __array_extent(_Tp, _Dim)> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp, unsigned _Ip = 0>
@@ -32,15 +32,15 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr size_t extent_v = __array_extent(_Tp
 #else // __has_builtin(__array_extent)
 
 template <class _Tp, unsigned _Ip = 0>
-struct _LIBCPP_TEMPLATE_VIS extent : public integral_constant<size_t, 0> {};
+struct extent : public integral_constant<size_t, 0> {};
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS extent<_Tp[], 0> : public integral_constant<size_t, 0> {};
+struct extent<_Tp[], 0> : public integral_constant<size_t, 0> {};
 template <class _Tp, unsigned _Ip>
-struct _LIBCPP_TEMPLATE_VIS extent<_Tp[], _Ip> : public integral_constant<size_t, extent<_Tp, _Ip - 1>::value> {};
+struct extent<_Tp[], _Ip> : public integral_constant<size_t, extent<_Tp, _Ip - 1>::value> {};
 template <class _Tp, size_t _Np>
-struct _LIBCPP_TEMPLATE_VIS extent<_Tp[_Np], 0> : public integral_constant<size_t, _Np> {};
+struct extent<_Tp[_Np], 0> : public integral_constant<size_t, _Np> {};
 template <class _Tp, size_t _Np, unsigned _Ip>
-struct _LIBCPP_TEMPLATE_VIS extent<_Tp[_Np], _Ip> : public integral_constant<size_t, extent<_Tp, _Ip - 1>::value> {};
+struct extent<_Tp[_Np], _Ip> : public integral_constant<size_t, extent<_Tp, _Ip - 1>::value> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp, unsigned _Ip = 0>

--- a/libcxx/include/__type_traits/has_unique_object_representation.h
+++ b/libcxx/include/__type_traits/has_unique_object_representation.h
@@ -22,7 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 17
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS has_unique_object_representations
+struct _LIBCPP_NO_SPECIALIZATIONS has_unique_object_representations
     // TODO: We work around a Clang and GCC bug in __has_unique_object_representations by using remove_all_extents
     //       even though it should not be necessary. This was reported to the compilers:
     //         - Clang: https://github.com/llvm/llvm-project/issues/95311

--- a/libcxx/include/__type_traits/has_virtual_destructor.h
+++ b/libcxx/include/__type_traits/has_virtual_destructor.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS has_virtual_destructor
+struct _LIBCPP_NO_SPECIALIZATIONS has_virtual_destructor
     : public integral_constant<bool, __has_virtual_destructor(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17

--- a/libcxx/include/__type_traits/integral_constant.h
+++ b/libcxx/include/__type_traits/integral_constant.h
@@ -18,7 +18,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, _Tp __v>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS integral_constant {
+struct _LIBCPP_NO_SPECIALIZATIONS integral_constant {
   static inline _LIBCPP_CONSTEXPR const _Tp value = __v;
   typedef _Tp value_type;
   typedef integral_constant type;

--- a/libcxx/include/__type_traits/invoke.h
+++ b/libcxx/include/__type_traits/invoke.h
@@ -278,11 +278,10 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Ret __invoke_r(_Args&&... _
 // is_invocable
 
 template <class _Fn, class... _Args>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_invocable : bool_constant<__is_invocable_v<_Fn, _Args...>> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_invocable : bool_constant<__is_invocable_v<_Fn, _Args...>> {};
 
 template <class _Ret, class _Fn, class... _Args>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_invocable_r
-    : bool_constant<__is_invocable_r_v<_Ret, _Fn, _Args...>> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_invocable_r : bool_constant<__is_invocable_r_v<_Ret, _Fn, _Args...>> {};
 
 template <class _Fn, class... _Args>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_invocable_v = __is_invocable_v<_Fn, _Args...>;
@@ -293,11 +292,10 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_invocable_r_v = __is_invocab
 // is_nothrow_invocable
 
 template <class _Fn, class... _Args>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_nothrow_invocable
-    : bool_constant<__nothrow_invokable<_Fn, _Args...>::value> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_invocable : bool_constant<__nothrow_invokable<_Fn, _Args...>::value> {};
 
 template <class _Ret, class _Fn, class... _Args>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_nothrow_invocable_r
+struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_invocable_r
     : bool_constant<__nothrow_invokable_r<_Ret, _Fn, _Args...>::value> {};
 
 template <class _Fn, class... _Args>
@@ -308,7 +306,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_nothrow_invocable_r_v =
     is_nothrow_invocable_r<_Ret, _Fn, _Args...>::value;
 
 template <class _Fn, class... _Args>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS invoke_result : __invoke_result<_Fn, _Args...> {};
+struct _LIBCPP_NO_SPECIALIZATIONS invoke_result : __invoke_result<_Fn, _Args...> {};
 
 template <class _Fn, class... _Args>
 using invoke_result_t = typename invoke_result<_Fn, _Args...>::type;

--- a/libcxx/include/__type_traits/is_abstract.h
+++ b/libcxx/include/__type_traits/is_abstract.h
@@ -19,8 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_abstract
-    : public integral_constant<bool, __is_abstract(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_abstract : public integral_constant<bool, __is_abstract(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_aggregate.h
+++ b/libcxx/include/__type_traits/is_aggregate.h
@@ -21,8 +21,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 17
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_aggregate
-    : public integral_constant<bool, __is_aggregate(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_aggregate : public integral_constant<bool, __is_aggregate(_Tp)> {};
 
 template <class _Tp>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_aggregate_v = __is_aggregate(_Tp);

--- a/libcxx/include/__type_traits/is_arithmetic.h
+++ b/libcxx/include/__type_traits/is_arithmetic.h
@@ -21,7 +21,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_arithmetic
+struct _LIBCPP_NO_SPECIALIZATIONS is_arithmetic
     : public integral_constant<bool, is_integral<_Tp>::value || is_floating_point<_Tp>::value> {};
 
 #if _LIBCPP_STD_VER >= 17

--- a/libcxx/include/__type_traits/is_array.h
+++ b/libcxx/include/__type_traits/is_array.h
@@ -23,7 +23,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
     (!defined(_LIBCPP_COMPILER_CLANG_BASED) || (defined(_LIBCPP_CLANG_VER) && _LIBCPP_CLANG_VER >= 1900))
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_array : _BoolConstant<__is_array(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_array : _BoolConstant<__is_array(_Tp)> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -33,11 +33,11 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_array_v = __is_array(_Tp);
 #else
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_array : public false_type {};
+struct is_array : public false_type {};
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_array<_Tp[]> : public true_type {};
+struct is_array<_Tp[]> : public true_type {};
 template <class _Tp, size_t _Np>
-struct _LIBCPP_TEMPLATE_VIS is_array<_Tp[_Np]> : public true_type {};
+struct is_array<_Tp[_Np]> : public true_type {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_assignable.h
+++ b/libcxx/include/__type_traits/is_assignable.h
@@ -21,7 +21,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _Up>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_assignable : _BoolConstant<__is_assignable(_Tp, _Up)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_assignable : _BoolConstant<__is_assignable(_Tp, _Up)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp, class _Arg>
@@ -29,7 +29,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_assignable_v = __is_assignab
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_copy_assignable
+struct _LIBCPP_NO_SPECIALIZATIONS is_copy_assignable
     : public integral_constant<bool,
                                __is_assignable(__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<const _Tp>)> {};
 
@@ -39,7 +39,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_copy_assignable_v = is_copy_
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_move_assignable
+struct _LIBCPP_NO_SPECIALIZATIONS is_move_assignable
     : public integral_constant<bool, __is_assignable(__add_lvalue_reference_t<_Tp>, __add_rvalue_reference_t<_Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17

--- a/libcxx/include/__type_traits/is_base_of.h
+++ b/libcxx/include/__type_traits/is_base_of.h
@@ -19,8 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Bp, class _Dp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_base_of
-    : public integral_constant<bool, __is_base_of(_Bp, _Dp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_base_of : public integral_constant<bool, __is_base_of(_Bp, _Dp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Bp, class _Dp>
@@ -31,7 +30,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_base_of_v = __is_base_of(_Bp
 #  if __has_builtin(__builtin_is_virtual_base_of)
 
 template <class _Base, class _Derived>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_virtual_base_of
+struct _LIBCPP_NO_SPECIALIZATIONS is_virtual_base_of
     : public bool_constant<__builtin_is_virtual_base_of(_Base, _Derived)> {};
 
 template <class _Base, class _Derived>

--- a/libcxx/include/__type_traits/is_bounded_array.h
+++ b/libcxx/include/__type_traits/is_bounded_array.h
@@ -27,14 +27,14 @@ inline const bool __is_bounded_array_v<_Tp[_Np]> = true;
 #if _LIBCPP_STD_VER >= 20
 
 template <class>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_bounded_array : false_type {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_bounded_array : false_type {};
 
 _LIBCPP_DIAGNOSTIC_PUSH
 #  if __has_warning("-Winvalid-specialization")
 _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Winvalid-specialization")
 #  endif
 template <class _Tp, size_t _Np>
-struct _LIBCPP_TEMPLATE_VIS is_bounded_array<_Tp[_Np]> : true_type {};
+struct is_bounded_array<_Tp[_Np]> : true_type {};
 _LIBCPP_DIAGNOSTIC_POP
 
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_class.h
+++ b/libcxx/include/__type_traits/is_class.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_class : public integral_constant<bool, __is_class(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_class : public integral_constant<bool, __is_class(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_compound.h
+++ b/libcxx/include/__type_traits/is_compound.h
@@ -22,7 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if __has_builtin(__is_compound)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_compound : _BoolConstant<__is_compound(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_compound : _BoolConstant<__is_compound(_Tp)> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -32,7 +32,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_compound_v = __is_compound(_
 #else // __has_builtin(__is_compound)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_compound : public integral_constant<bool, !is_fundamental<_Tp>::value> {};
+struct is_compound : public integral_constant<bool, !is_fundamental<_Tp>::value> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_const.h
+++ b/libcxx/include/__type_traits/is_const.h
@@ -21,7 +21,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if __has_builtin(__is_const)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_const : _BoolConstant<__is_const(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_const : _BoolConstant<__is_const(_Tp)> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -31,9 +31,9 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_const_v = __is_const(_Tp);
 #else
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_const : public false_type {};
+struct is_const : public false_type {};
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_const<_Tp const> : public true_type {};
+struct is_const<_Tp const> : public true_type {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_constructible.h
+++ b/libcxx/include/__type_traits/is_constructible.h
@@ -21,8 +21,8 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class... _Args>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_constructible
-    : public integral_constant<bool, __is_constructible(_Tp, _Args...)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_constructible : public integral_constant<bool, __is_constructible(_Tp, _Args...)> {
+};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp, class... _Args>
@@ -30,7 +30,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_constructible_v = __is_const
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_copy_constructible
+struct _LIBCPP_NO_SPECIALIZATIONS is_copy_constructible
     : public integral_constant<bool, __is_constructible(_Tp, __add_lvalue_reference_t<const _Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
@@ -39,7 +39,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_copy_constructible_v = is_co
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_move_constructible
+struct _LIBCPP_NO_SPECIALIZATIONS is_move_constructible
     : public integral_constant<bool, __is_constructible(_Tp, __add_rvalue_reference_t<_Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
@@ -48,8 +48,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_move_constructible_v = is_mo
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_default_constructible
-    : public integral_constant<bool, __is_constructible(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_default_constructible : public integral_constant<bool, __is_constructible(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_convertible.h
+++ b/libcxx/include/__type_traits/is_convertible.h
@@ -19,8 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _T1, class _T2>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_convertible
-    : public integral_constant<bool, __is_convertible(_T1, _T2)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_convertible : public integral_constant<bool, __is_convertible(_T1, _T2)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _From, class _To>

--- a/libcxx/include/__type_traits/is_destructible.h
+++ b/libcxx/include/__type_traits/is_destructible.h
@@ -25,7 +25,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if __has_builtin(__is_destructible)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_destructible : _BoolConstant<__is_destructible(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_destructible : _BoolConstant<__is_destructible(_Tp)> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_empty.h
+++ b/libcxx/include/__type_traits/is_empty.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_empty : public integral_constant<bool, __is_empty(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_empty : public integral_constant<bool, __is_empty(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_enum.h
+++ b/libcxx/include/__type_traits/is_enum.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_enum : public integral_constant<bool, __is_enum(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_enum : public integral_constant<bool, __is_enum(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -29,7 +29,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_enum_v = __is_enum(_Tp);
 #if _LIBCPP_STD_VER >= 23
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_scoped_enum : bool_constant<__is_scoped_enum(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_scoped_enum : bool_constant<__is_scoped_enum(_Tp)> {};
 
 template <class _Tp>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_scoped_enum_v = __is_scoped_enum(_Tp);

--- a/libcxx/include/__type_traits/is_final.h
+++ b/libcxx/include/__type_traits/is_final.h
@@ -19,11 +19,11 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS __libcpp_is_final : public integral_constant<bool, __is_final(_Tp)> {};
+struct __libcpp_is_final : public integral_constant<bool, __is_final(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 14
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_final : public integral_constant<bool, __is_final(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_final : public integral_constant<bool, __is_final(_Tp)> {};
 #endif
 
 #if _LIBCPP_STD_VER >= 17

--- a/libcxx/include/__type_traits/is_floating_point.h
+++ b/libcxx/include/__type_traits/is_floating_point.h
@@ -27,8 +27,7 @@ template <>          struct __libcpp_is_floating_point<long double> : public tru
 // clang-format on
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_floating_point
-    : public __libcpp_is_floating_point<__remove_cv_t<_Tp> > {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_floating_point : public __libcpp_is_floating_point<__remove_cv_t<_Tp> > {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_function.h
+++ b/libcxx/include/__type_traits/is_function.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_function : integral_constant<bool, __is_function(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_function : integral_constant<bool, __is_function(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_fundamental.h
+++ b/libcxx/include/__type_traits/is_fundamental.h
@@ -23,7 +23,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if __has_builtin(__is_fundamental)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_fundamental : _BoolConstant<__is_fundamental(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_fundamental : _BoolConstant<__is_fundamental(_Tp)> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -33,7 +33,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_fundamental_v = __is_fundame
 #else // __has_builtin(__is_fundamental)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_fundamental
+struct is_fundamental
     : public integral_constant<bool, is_void<_Tp>::value || __is_null_pointer_v<_Tp> || is_arithmetic<_Tp>::value> {};
 
 #  if _LIBCPP_STD_VER >= 17

--- a/libcxx/include/__type_traits/is_implicit_lifetime.h
+++ b/libcxx/include/__type_traits/is_implicit_lifetime.h
@@ -22,8 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #  if __has_builtin(__builtin_is_implicit_lifetime)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_implicit_lifetime
-    : public bool_constant<__builtin_is_implicit_lifetime(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_implicit_lifetime : public bool_constant<__builtin_is_implicit_lifetime(_Tp)> {};
 
 template <class _Tp>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_implicit_lifetime_v = __builtin_is_implicit_lifetime(_Tp);

--- a/libcxx/include/__type_traits/is_integral.h
+++ b/libcxx/include/__type_traits/is_integral.h
@@ -50,7 +50,7 @@ template <>          struct __libcpp_is_integral<__uint128_t>        { enum { va
 #if __has_builtin(__is_integral)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_integral : _BoolConstant<__is_integral(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_integral : _BoolConstant<__is_integral(_Tp)> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -60,7 +60,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_integral_v = __is_integral(_
 #else
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_integral : public _BoolConstant<__libcpp_is_integral<__remove_cv_t<_Tp> >::value> {};
+struct is_integral : public _BoolConstant<__libcpp_is_integral<__remove_cv_t<_Tp> >::value> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_literal_type.h
+++ b/libcxx/include/__type_traits/is_literal_type.h
@@ -20,7 +20,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_TYPE_TRAITS)
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_NO_SPECIALIZATIONS is_literal_type
+struct _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_NO_SPECIALIZATIONS is_literal_type
     : public integral_constant<bool, __is_literal_type(_Tp)> {};
 
 #  if _LIBCPP_STD_VER >= 17

--- a/libcxx/include/__type_traits/is_member_pointer.h
+++ b/libcxx/include/__type_traits/is_member_pointer.h
@@ -19,15 +19,13 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_member_pointer : _BoolConstant<__is_member_pointer(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_member_pointer : _BoolConstant<__is_member_pointer(_Tp)> {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_member_object_pointer
-    : _BoolConstant<__is_member_object_pointer(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_member_object_pointer : _BoolConstant<__is_member_object_pointer(_Tp)> {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_member_function_pointer
-    : _BoolConstant<__is_member_function_pointer(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_member_function_pointer : _BoolConstant<__is_member_function_pointer(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_nothrow_assignable.h
+++ b/libcxx/include/__type_traits/is_nothrow_assignable.h
@@ -21,7 +21,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _Arg>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_nothrow_assignable
+struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_assignable
     : public integral_constant<bool, __is_nothrow_assignable(_Tp, _Arg)> {};
 
 #if _LIBCPP_STD_VER >= 17
@@ -30,7 +30,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_nothrow_assignable_v = __is_
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_nothrow_copy_assignable
+struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_copy_assignable
     : public integral_constant<
           bool,
           __is_nothrow_assignable(__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<const _Tp>)> {};
@@ -41,7 +41,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_nothrow_copy_assignable_v = 
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_nothrow_move_assignable
+struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_move_assignable
     : public integral_constant<bool,
                                __is_nothrow_assignable(__add_lvalue_reference_t<_Tp>, __add_rvalue_reference_t<_Tp>)> {
 };

--- a/libcxx/include/__type_traits/is_nothrow_constructible.h
+++ b/libcxx/include/__type_traits/is_nothrow_constructible.h
@@ -21,7 +21,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template < class _Tp, class... _Args>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_nothrow_constructible
+struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_constructible
     : public integral_constant<bool, __is_nothrow_constructible(_Tp, _Args...)> {};
 
 #if _LIBCPP_STD_VER >= 17
@@ -31,7 +31,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_nothrow_constructible_v =
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_nothrow_copy_constructible
+struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_copy_constructible
     : public integral_constant< bool, __is_nothrow_constructible(_Tp, __add_lvalue_reference_t<const _Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
@@ -41,7 +41,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_nothrow_copy_constructible_v
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_nothrow_move_constructible
+struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_move_constructible
     : public integral_constant<bool, __is_nothrow_constructible(_Tp, __add_rvalue_reference_t<_Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
@@ -51,7 +51,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_nothrow_move_constructible_v
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_nothrow_default_constructible
+struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_default_constructible
     : public integral_constant<bool, __is_nothrow_constructible(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17

--- a/libcxx/include/__type_traits/is_nothrow_destructible.h
+++ b/libcxx/include/__type_traits/is_nothrow_destructible.h
@@ -24,8 +24,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if __has_builtin(__is_nothrow_destructible)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_nothrow_destructible
-    : integral_constant<bool, __is_nothrow_destructible(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_destructible : integral_constant<bool, __is_nothrow_destructible(_Tp)> {};
 
 #else
 
@@ -40,17 +39,16 @@ struct __libcpp_is_nothrow_destructible<true, _Tp>
     : public integral_constant<bool, noexcept(std::declval<_Tp>().~_Tp()) > {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_nothrow_destructible
-    : public __libcpp_is_nothrow_destructible<is_destructible<_Tp>::value, _Tp> {};
+struct is_nothrow_destructible : public __libcpp_is_nothrow_destructible<is_destructible<_Tp>::value, _Tp> {};
 
 template <class _Tp, size_t _Ns>
-struct _LIBCPP_TEMPLATE_VIS is_nothrow_destructible<_Tp[_Ns]> : public is_nothrow_destructible<_Tp> {};
+struct is_nothrow_destructible<_Tp[_Ns]> : public is_nothrow_destructible<_Tp> {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_nothrow_destructible<_Tp&> : public true_type {};
+struct is_nothrow_destructible<_Tp&> : public true_type {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_nothrow_destructible<_Tp&&> : public true_type {};
+struct is_nothrow_destructible<_Tp&&> : public true_type {};
 
 #endif // __has_builtin(__is_nothrow_destructible)
 

--- a/libcxx/include/__type_traits/is_null_pointer.h
+++ b/libcxx/include/__type_traits/is_null_pointer.h
@@ -24,8 +24,7 @@ inline const bool __is_null_pointer_v = __is_same(__remove_cv(_Tp), nullptr_t);
 
 #if _LIBCPP_STD_VER >= 14
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_null_pointer
-    : integral_constant<bool, __is_null_pointer_v<_Tp>> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_null_pointer : integral_constant<bool, __is_null_pointer_v<_Tp>> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_object.h
+++ b/libcxx/include/__type_traits/is_object.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_object : _BoolConstant<__is_object(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_object : _BoolConstant<__is_object(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_pod.h
+++ b/libcxx/include/__type_traits/is_pod.h
@@ -19,8 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS
-_LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_NO_SPECIALIZATIONS is_pod : public integral_constant<bool, __is_pod(_Tp)> {};
+struct _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_NO_SPECIALIZATIONS is_pod : public integral_constant<bool, __is_pod(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_pointer.h
+++ b/libcxx/include/__type_traits/is_pointer.h
@@ -22,7 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if __has_builtin(__is_pointer)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_pointer : _BoolConstant<__is_pointer(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_pointer : _BoolConstant<__is_pointer(_Tp)> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -50,8 +50,7 @@ template <class _Tp> struct __libcpp_remove_objc_qualifiers<_Tp __unsafe_unretai
 #  endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_pointer
-    : public __libcpp_is_pointer<typename __libcpp_remove_objc_qualifiers<__remove_cv_t<_Tp> >::type> {};
+struct is_pointer : public __libcpp_is_pointer<typename __libcpp_remove_objc_qualifiers<__remove_cv_t<_Tp> >::type> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_polymorphic.h
+++ b/libcxx/include/__type_traits/is_polymorphic.h
@@ -19,8 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_polymorphic
-    : public integral_constant<bool, __is_polymorphic(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_polymorphic : public integral_constant<bool, __is_polymorphic(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_reference.h
+++ b/libcxx/include/__type_traits/is_reference.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_reference : _BoolConstant<__is_reference(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_reference : _BoolConstant<__is_reference(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -29,12 +29,10 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_reference_v = __is_reference
 #if __has_builtin(__is_lvalue_reference) && __has_builtin(__is_rvalue_reference)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_lvalue_reference : _BoolConstant<__is_lvalue_reference(_Tp)> {
-};
+struct _LIBCPP_NO_SPECIALIZATIONS is_lvalue_reference : _BoolConstant<__is_lvalue_reference(_Tp)> {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_rvalue_reference : _BoolConstant<__is_rvalue_reference(_Tp)> {
-};
+struct _LIBCPP_NO_SPECIALIZATIONS is_rvalue_reference : _BoolConstant<__is_rvalue_reference(_Tp)> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -46,14 +44,14 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_rvalue_reference_v = __is_rv
 #else // __has_builtin(__is_lvalue_reference)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_lvalue_reference : public false_type {};
+struct is_lvalue_reference : public false_type {};
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_lvalue_reference<_Tp&> : public true_type {};
+struct is_lvalue_reference<_Tp&> : public true_type {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_rvalue_reference : public false_type {};
+struct is_rvalue_reference : public false_type {};
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_rvalue_reference<_Tp&&> : public true_type {};
+struct is_rvalue_reference<_Tp&&> : public true_type {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_same.h
+++ b/libcxx/include/__type_traits/is_same.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _Up>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_same : _BoolConstant<__is_same(_Tp, _Up)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_same : _BoolConstant<__is_same(_Tp, _Up)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp, class _Up>

--- a/libcxx/include/__type_traits/is_scalar.h
+++ b/libcxx/include/__type_traits/is_scalar.h
@@ -26,7 +26,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if __has_builtin(__is_scalar)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_scalar : _BoolConstant<__is_scalar(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_scalar : _BoolConstant<__is_scalar(_Tp)> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -44,7 +44,7 @@ struct __is_block<_Rp (^)(_Args...)> : true_type {};
 
 // clang-format off
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_scalar
+struct is_scalar
     : public integral_constant<
           bool, is_arithmetic<_Tp>::value ||
                 is_member_pointer<_Tp>::value ||
@@ -55,7 +55,7 @@ struct _LIBCPP_TEMPLATE_VIS is_scalar
 // clang-format on
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS is_scalar<nullptr_t> : public true_type {};
+struct is_scalar<nullptr_t> : public true_type {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_signed.h
+++ b/libcxx/include/__type_traits/is_signed.h
@@ -23,7 +23,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if __has_builtin(__is_signed)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_signed : _BoolConstant<__is_signed(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_signed : _BoolConstant<__is_signed(_Tp)> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -45,7 +45,7 @@ template <class _Tp>
 struct __libcpp_is_signed<_Tp, false> : public false_type {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_signed : public __libcpp_is_signed<_Tp> {};
+struct is_signed : public __libcpp_is_signed<_Tp> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_standard_layout.h
+++ b/libcxx/include/__type_traits/is_standard_layout.h
@@ -19,8 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_standard_layout
-    : public integral_constant<bool, __is_standard_layout(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_standard_layout : public integral_constant<bool, __is_standard_layout(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_swappable.h
+++ b/libcxx/include/__type_traits/is_swappable.h
@@ -77,30 +77,27 @@ template <class _Tp, class _Up>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_swappable_with_v = __is_swappable_with_v<_Tp, _Up>;
 
 template <class _Tp, class _Up>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_swappable_with
-    : bool_constant<is_swappable_with_v<_Tp, _Up>> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_swappable_with : bool_constant<is_swappable_with_v<_Tp, _Up>> {};
 
 template <class _Tp>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_swappable_v =
     is_swappable_with_v<__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<_Tp>>;
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_swappable : bool_constant<is_swappable_v<_Tp>> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_swappable : bool_constant<is_swappable_v<_Tp>> {};
 
 template <class _Tp, class _Up>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_nothrow_swappable_with_v = __is_nothrow_swappable_with_v<_Tp, _Up>;
 
 template <class _Tp, class _Up>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_nothrow_swappable_with
-    : bool_constant<is_nothrow_swappable_with_v<_Tp, _Up>> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_swappable_with : bool_constant<is_nothrow_swappable_with_v<_Tp, _Up>> {};
 
 template <class _Tp>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_nothrow_swappable_v =
     is_nothrow_swappable_with_v<__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<_Tp>>;
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_nothrow_swappable
-    : bool_constant<is_nothrow_swappable_v<_Tp>> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_swappable : bool_constant<is_nothrow_swappable_v<_Tp>> {};
 
 #endif // _LIBCPP_STD_VER >= 17
 

--- a/libcxx/include/__type_traits/is_trivial.h
+++ b/libcxx/include/__type_traits/is_trivial.h
@@ -19,8 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_trivial : public integral_constant<bool, __is_trivial(_Tp)> {
-};
+struct _LIBCPP_NO_SPECIALIZATIONS is_trivial : public integral_constant<bool, __is_trivial(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_trivially_assignable.h
+++ b/libcxx/include/__type_traits/is_trivially_assignable.h
@@ -30,7 +30,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_trivially_assignable_v = __i
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_trivially_copy_assignable
+struct _LIBCPP_NO_SPECIALIZATIONS is_trivially_copy_assignable
     : public integral_constant<
           bool,
           __is_trivially_assignable(__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<const _Tp>)> {};
@@ -42,7 +42,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_trivially_copy_assignable_v 
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_trivially_move_assignable
+struct _LIBCPP_NO_SPECIALIZATIONS is_trivially_move_assignable
     : public integral_constant<
           bool,
           __is_trivially_assignable(__add_lvalue_reference_t<_Tp>, __add_rvalue_reference_t<_Tp>)> {};

--- a/libcxx/include/__type_traits/is_trivially_constructible.h
+++ b/libcxx/include/__type_traits/is_trivially_constructible.h
@@ -21,7 +21,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class... _Args>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_trivially_constructible
+struct _LIBCPP_NO_SPECIALIZATIONS is_trivially_constructible
     : integral_constant<bool, __is_trivially_constructible(_Tp, _Args...)> {};
 
 #if _LIBCPP_STD_VER >= 17
@@ -31,7 +31,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_trivially_constructible_v =
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_trivially_copy_constructible
+struct _LIBCPP_NO_SPECIALIZATIONS is_trivially_copy_constructible
     : public integral_constant<bool, __is_trivially_constructible(_Tp, __add_lvalue_reference_t<const _Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
@@ -41,7 +41,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_trivially_copy_constructible
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_trivially_move_constructible
+struct _LIBCPP_NO_SPECIALIZATIONS is_trivially_move_constructible
     : public integral_constant<bool, __is_trivially_constructible(_Tp, __add_rvalue_reference_t<_Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
@@ -51,7 +51,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_trivially_move_constructible
 #endif
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_trivially_default_constructible
+struct _LIBCPP_NO_SPECIALIZATIONS is_trivially_default_constructible
     : public integral_constant<bool, __is_trivially_constructible(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17

--- a/libcxx/include/__type_traits/is_trivially_copyable.h
+++ b/libcxx/include/__type_traits/is_trivially_copyable.h
@@ -20,8 +20,8 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_trivially_copyable
-    : public integral_constant<bool, __is_trivially_copyable(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_trivially_copyable : public integral_constant<bool, __is_trivially_copyable(_Tp)> {
+};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_trivially_destructible.h
+++ b/libcxx/include/__type_traits/is_trivially_destructible.h
@@ -22,13 +22,13 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if __has_builtin(__is_trivially_destructible)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_trivially_destructible
+struct _LIBCPP_NO_SPECIALIZATIONS is_trivially_destructible
     : public integral_constant<bool, __is_trivially_destructible(_Tp)> {};
 
 #elif __has_builtin(__has_trivial_destructor)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_trivially_destructible
+struct is_trivially_destructible
     : public integral_constant<bool, is_destructible<_Tp>::value&& __has_trivial_destructor(_Tp)> {};
 
 #else

--- a/libcxx/include/__type_traits/is_unbounded_array.h
+++ b/libcxx/include/__type_traits/is_unbounded_array.h
@@ -26,14 +26,14 @@ inline const bool __is_unbounded_array_v<_Tp[]> = true;
 #if _LIBCPP_STD_VER >= 20
 
 template <class>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_unbounded_array : false_type {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_unbounded_array : false_type {};
 
 _LIBCPP_DIAGNOSTIC_PUSH
 #  if __has_warning("-Winvalid-specialization")
 _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Winvalid-specialization")
 #  endif
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_unbounded_array<_Tp[]> : true_type {};
+struct is_unbounded_array<_Tp[]> : true_type {};
 _LIBCPP_DIAGNOSTIC_POP
 
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_union.h
+++ b/libcxx/include/__type_traits/is_union.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_union : public integral_constant<bool, __is_union(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_union : public integral_constant<bool, __is_union(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_unsigned.h
+++ b/libcxx/include/__type_traits/is_unsigned.h
@@ -23,7 +23,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if __has_builtin(__is_unsigned)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_unsigned : _BoolConstant<__is_unsigned(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_unsigned : _BoolConstant<__is_unsigned(_Tp)> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -45,7 +45,7 @@ template <class _Tp>
 struct __libcpp_is_unsigned<_Tp, false> : public false_type {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_unsigned : public __libcpp_is_unsigned<_Tp> {};
+struct is_unsigned : public __libcpp_is_unsigned<_Tp> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_void.h
+++ b/libcxx/include/__type_traits/is_void.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_void : _BoolConstant<__is_same(__remove_cv(_Tp), void)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_void : _BoolConstant<__is_same(__remove_cv(_Tp), void)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_volatile.h
+++ b/libcxx/include/__type_traits/is_volatile.h
@@ -21,7 +21,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if __has_builtin(__is_volatile)
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS is_volatile : _BoolConstant<__is_volatile(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_volatile : _BoolConstant<__is_volatile(_Tp)> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -31,9 +31,9 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_volatile_v = __is_volatile(_
 #else
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_volatile : public false_type {};
+struct is_volatile : public false_type {};
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS is_volatile<_Tp volatile> : public true_type {};
+struct is_volatile<_Tp volatile> : public true_type {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/rank.h
+++ b/libcxx/include/__type_traits/rank.h
@@ -28,16 +28,16 @@ struct rank : integral_constant<size_t, __array_rank(_Tp)> {};
 #else
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS rank : public integral_constant<size_t, 0> {};
+struct _LIBCPP_NO_SPECIALIZATIONS rank : public integral_constant<size_t, 0> {};
 
 _LIBCPP_DIAGNOSTIC_PUSH
 #  if __has_warning("-Winvalid-specialization")
 _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Winvalid-specialization")
 #  endif
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS rank<_Tp[]> : public integral_constant<size_t, rank<_Tp>::value + 1> {};
+struct rank<_Tp[]> : public integral_constant<size_t, rank<_Tp>::value + 1> {};
 template <class _Tp, size_t _Np>
-struct _LIBCPP_TEMPLATE_VIS rank<_Tp[_Np]> : public integral_constant<size_t, rank<_Tp>::value + 1> {};
+struct rank<_Tp[_Np]> : public integral_constant<size_t, rank<_Tp>::value + 1> {};
 _LIBCPP_DIAGNOSTIC_POP
 
 #endif // __has_builtin(__array_rank)

--- a/libcxx/include/__type_traits/reference_constructs_from_temporary.h
+++ b/libcxx/include/__type_traits/reference_constructs_from_temporary.h
@@ -21,7 +21,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 23 && __has_builtin(__reference_constructs_from_temporary)
 
 template <class _Tp, class _Up>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS reference_constructs_from_temporary
+struct _LIBCPP_NO_SPECIALIZATIONS reference_constructs_from_temporary
     : public bool_constant<__reference_constructs_from_temporary(_Tp, _Up)> {};
 
 template <class _Tp, class _Up>

--- a/libcxx/include/__type_traits/reference_converts_from_temporary.h
+++ b/libcxx/include/__type_traits/reference_converts_from_temporary.h
@@ -21,7 +21,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 23 && __has_builtin(__reference_converts_from_temporary)
 
 template <class _Tp, class _Up>
-struct _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS reference_converts_from_temporary
+struct _LIBCPP_NO_SPECIALIZATIONS reference_converts_from_temporary
     : public bool_constant<__reference_converts_from_temporary(_Tp, _Up)> {};
 
 template <class _Tp, class _Up>

--- a/libcxx/include/__type_traits/remove_all_extents.h
+++ b/libcxx/include/__type_traits/remove_all_extents.h
@@ -28,15 +28,15 @@ template <class _Tp>
 using __remove_all_extents_t _LIBCPP_NODEBUG = __remove_all_extents(_Tp);
 #else
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS remove_all_extents {
+struct remove_all_extents {
   typedef _Tp type;
 };
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS remove_all_extents<_Tp[]> {
+struct remove_all_extents<_Tp[]> {
   typedef typename remove_all_extents<_Tp>::type type;
 };
 template <class _Tp, size_t _Np>
-struct _LIBCPP_TEMPLATE_VIS remove_all_extents<_Tp[_Np]> {
+struct remove_all_extents<_Tp[_Np]> {
   typedef typename remove_all_extents<_Tp>::type type;
 };
 

--- a/libcxx/include/__type_traits/remove_const.h
+++ b/libcxx/include/__type_traits/remove_const.h
@@ -27,11 +27,11 @@ template <class _Tp>
 using __remove_const_t _LIBCPP_NODEBUG = __remove_const(_Tp);
 #else
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS remove_const {
+struct remove_const {
   typedef _Tp type;
 };
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS remove_const<const _Tp> {
+struct remove_const<const _Tp> {
   typedef _Tp type;
 };
 

--- a/libcxx/include/__type_traits/remove_extent.h
+++ b/libcxx/include/__type_traits/remove_extent.h
@@ -28,15 +28,15 @@ template <class _Tp>
 using __remove_extent_t _LIBCPP_NODEBUG = __remove_extent(_Tp);
 #else
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS remove_extent {
+struct remove_extent {
   typedef _Tp type;
 };
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS remove_extent<_Tp[]> {
+struct remove_extent<_Tp[]> {
   typedef _Tp type;
 };
 template <class _Tp, size_t _Np>
-struct _LIBCPP_TEMPLATE_VIS remove_extent<_Tp[_Np]> {
+struct remove_extent<_Tp[_Np]> {
   typedef _Tp type;
 };
 

--- a/libcxx/include/__type_traits/remove_pointer.h
+++ b/libcxx/include/__type_traits/remove_pointer.h
@@ -32,11 +32,11 @@ using __remove_pointer_t _LIBCPP_NODEBUG = __remove_pointer(_Tp);
 #  endif
 #else
 // clang-format off
-template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer                      {using type _LIBCPP_NODEBUG = _Tp;};
-template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer<_Tp*>                {using type _LIBCPP_NODEBUG = _Tp;};
-template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer<_Tp* const>          {using type _LIBCPP_NODEBUG = _Tp;};
-template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer<_Tp* volatile>       {using type _LIBCPP_NODEBUG = _Tp;};
-template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_pointer<_Tp* const volatile> {using type _LIBCPP_NODEBUG = _Tp;};
+template <class _Tp> struct remove_pointer                      {using type _LIBCPP_NODEBUG = _Tp;};
+template <class _Tp> struct remove_pointer<_Tp*>                {using type _LIBCPP_NODEBUG = _Tp;};
+template <class _Tp> struct remove_pointer<_Tp* const>          {using type _LIBCPP_NODEBUG = _Tp;};
+template <class _Tp> struct remove_pointer<_Tp* volatile>       {using type _LIBCPP_NODEBUG = _Tp;};
+template <class _Tp> struct remove_pointer<_Tp* const volatile> {using type _LIBCPP_NODEBUG = _Tp;};
 // clang-format on
 
 template <class _Tp>

--- a/libcxx/include/__type_traits/remove_volatile.h
+++ b/libcxx/include/__type_traits/remove_volatile.h
@@ -27,11 +27,11 @@ template <class _Tp>
 using __remove_volatile_t _LIBCPP_NODEBUG = __remove_volatile(_Tp);
 #else
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS remove_volatile {
+struct remove_volatile {
   typedef _Tp type;
 };
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS remove_volatile<volatile _Tp> {
+struct remove_volatile<volatile _Tp> {
   typedef _Tp type;
 };
 

--- a/libcxx/include/__type_traits/result_of.h
+++ b/libcxx/include/__type_traits/result_of.h
@@ -29,7 +29,7 @@ _LIBCPP_DIAGNOSTIC_PUSH
 _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Winvalid-specialization")
 #endif
 template <class _Fp, class... _Args>
-struct _LIBCPP_TEMPLATE_VIS result_of<_Fp(_Args...)> : __invoke_result<_Fp, _Args...> {};
+struct result_of<_Fp(_Args...)> : __invoke_result<_Fp, _Args...> {};
 _LIBCPP_DIAGNOSTIC_POP
 
 #  if _LIBCPP_STD_VER >= 14

--- a/libcxx/include/__utility/in_place.h
+++ b/libcxx/include/__utility/in_place.h
@@ -28,14 +28,14 @@ struct _LIBCPP_EXPORTED_FROM_ABI in_place_t {
 inline constexpr in_place_t in_place{};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS in_place_type_t {
+struct in_place_type_t {
   _LIBCPP_HIDE_FROM_ABI explicit in_place_type_t() = default;
 };
 template <class _Tp>
 inline constexpr in_place_type_t<_Tp> in_place_type{};
 
 template <size_t _Idx>
-struct _LIBCPP_TEMPLATE_VIS in_place_index_t {
+struct in_place_index_t {
   _LIBCPP_HIDE_FROM_ABI explicit in_place_index_t() = default;
 };
 template <size_t _Idx>

--- a/libcxx/include/__utility/integer_sequence.h
+++ b/libcxx/include/__utility/integer_sequence.h
@@ -46,7 +46,7 @@ using __make_indices_imp _LIBCPP_NODEBUG =
 #if _LIBCPP_STD_VER >= 14
 
 template <class _Tp, _Tp... _Ip>
-struct _LIBCPP_TEMPLATE_VIS integer_sequence {
+struct integer_sequence {
   typedef _Tp value_type;
   static_assert(is_integral<_Tp>::value, "std::integer_sequence can only be instantiated with an integral type");
   static _LIBCPP_HIDE_FROM_ABI constexpr size_t size() noexcept { return sizeof...(_Ip); }

--- a/libcxx/include/__utility/pair.h
+++ b/libcxx/include/__utility/pair.h
@@ -57,7 +57,7 @@ struct __non_trivially_copyable_base {
 };
 
 template <class _T1, class _T2>
-struct _LIBCPP_TEMPLATE_VIS pair
+struct pair
 #if defined(_LIBCPP_DEPRECATED_ABI_DISABLE_PAIR_TRIVIAL_COPY_CTOR)
     : private __non_trivially_copyable_base<_T1, _T2>
 #endif
@@ -536,20 +536,20 @@ make_pair(_T1&& __t1, _T2&& __t2) {
 }
 
 template <class _T1, class _T2>
-struct _LIBCPP_TEMPLATE_VIS tuple_size<pair<_T1, _T2> > : public integral_constant<size_t, 2> {};
+struct tuple_size<pair<_T1, _T2> > : public integral_constant<size_t, 2> {};
 
 template <size_t _Ip, class _T1, class _T2>
-struct _LIBCPP_TEMPLATE_VIS tuple_element<_Ip, pair<_T1, _T2> > {
+struct tuple_element<_Ip, pair<_T1, _T2> > {
   static_assert(_Ip < 2, "Index out of bounds in std::tuple_element<std::pair<T1, T2>>");
 };
 
 template <class _T1, class _T2>
-struct _LIBCPP_TEMPLATE_VIS tuple_element<0, pair<_T1, _T2> > {
+struct tuple_element<0, pair<_T1, _T2> > {
   using type _LIBCPP_NODEBUG = _T1;
 };
 
 template <class _T1, class _T2>
-struct _LIBCPP_TEMPLATE_VIS tuple_element<1, pair<_T1, _T2> > {
+struct tuple_element<1, pair<_T1, _T2> > {
   using type _LIBCPP_NODEBUG = _T2;
 };
 

--- a/libcxx/include/__utility/piecewise_construct.h
+++ b/libcxx/include/__utility/piecewise_construct.h
@@ -17,7 +17,7 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-struct _LIBCPP_TEMPLATE_VIS piecewise_construct_t {
+struct piecewise_construct_t {
   explicit piecewise_construct_t() = default;
 };
 

--- a/libcxx/include/__variant/monostate.h
+++ b/libcxx/include/__variant/monostate.h
@@ -23,7 +23,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 17
 
-struct _LIBCPP_TEMPLATE_VIS monostate {};
+struct monostate {};
 
 _LIBCPP_HIDE_FROM_ABI inline constexpr bool operator==(monostate, monostate) noexcept { return true; }
 
@@ -48,7 +48,7 @@ _LIBCPP_HIDE_FROM_ABI inline constexpr bool operator>=(monostate, monostate) noe
 #  endif // _LIBCPP_STD_VER >= 20
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<monostate> {
+struct hash<monostate> {
 #  if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
   using argument_type _LIBCPP_DEPRECATED_IN_CXX17 = monostate;
   using result_type _LIBCPP_DEPRECATED_IN_CXX17   = size_t;

--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -84,7 +84,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _Allocator /* = allocator<_Tp> */>
-class _LIBCPP_TEMPLATE_VIS vector {
+class vector {
 public:
   //
   // Types

--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -75,7 +75,7 @@ struct __has_storage_type<vector<bool, _Allocator> > {
 };
 
 template <class _Allocator>
-class _LIBCPP_TEMPLATE_VIS vector<bool, _Allocator> {
+class vector<bool, _Allocator> {
 public:
   typedef vector __self;
   typedef bool value_type;
@@ -519,7 +519,7 @@ private:
   friend class __bit_iterator<vector, false>;
   friend class __bit_iterator<vector, true>;
   friend struct __bit_array<vector>;
-  friend struct _LIBCPP_TEMPLATE_VIS hash<vector>;
+  friend struct hash<vector>;
 };
 
 template <class _Allocator>
@@ -1109,8 +1109,7 @@ _LIBCPP_CONSTEXPR_SINCE_CXX20 size_t vector<bool, _Allocator>::__hash_code() con
 }
 
 template <class _Allocator>
-struct _LIBCPP_TEMPLATE_VIS hash<vector<bool, _Allocator> >
-    : public __unary_function<vector<bool, _Allocator>, size_t> {
+struct hash<vector<bool, _Allocator> > : public __unary_function<vector<bool, _Allocator>, size_t> {
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 size_t
   operator()(const vector<bool, _Allocator>& __vec) const _NOEXCEPT {
     return __vec.__hash_code();

--- a/libcxx/include/__vector/vector_bool_formatter.h
+++ b/libcxx/include/__vector/vector_bool_formatter.h
@@ -26,7 +26,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Tp, class _CharT>
 // Since is-vector-bool-reference is only used once it's inlined here.
   requires same_as<typename _Tp::__container, vector<bool, typename _Tp::__container::allocator_type>>
-struct _LIBCPP_TEMPLATE_VIS formatter<_Tp, _CharT> {
+struct formatter<_Tp, _CharT> {
 private:
   formatter<bool, _CharT> __underlying_;
 

--- a/libcxx/include/any
+++ b/libcxx/include/any
@@ -139,7 +139,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 }
 
 // Forward declarations
-class _LIBCPP_TEMPLATE_VIS any;
+class any;
 
 template <class _ValueType>
 _LIBCPP_HIDE_FROM_ABI add_pointer_t<add_const_t<_ValueType>> any_cast(any const*) _NOEXCEPT;
@@ -166,7 +166,7 @@ template <class _Tp>
 struct _LargeHandler;
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS __unique_typeinfo {
+struct __unique_typeinfo {
   static constexpr int __id = 0;
 };
 
@@ -189,7 +189,7 @@ using _Handler _LIBCPP_NODEBUG = conditional_t< _IsSmallObject<_Tp>::value, _Sma
 
 } // namespace __any_imp
 
-class _LIBCPP_TEMPLATE_VIS any {
+class any {
 public:
   // construct/destruct
   _LIBCPP_HIDE_FROM_ABI constexpr any() _NOEXCEPT : __h_(nullptr) {}
@@ -316,7 +316,7 @@ private:
 
 namespace __any_imp {
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _SmallHandler {
+struct _SmallHandler {
   _LIBCPP_HIDE_FROM_ABI static void*
   __handle(_Action __act, any const* __this, any* __other, type_info const* __info, const void* __fallback_info) {
     switch (__act) {
@@ -383,7 +383,7 @@ private:
 };
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS _LargeHandler {
+struct _LargeHandler {
   _LIBCPP_HIDE_FROM_ABI static void*
   __handle(_Action __act, any const* __this, any* __other, type_info const* __info, void const* __fallback_info) {
     switch (__act) {

--- a/libcxx/include/any
+++ b/libcxx/include/any
@@ -119,12 +119,12 @@ namespace std {
 _LIBCPP_PUSH_MACROS
 #  include <__undef_macros>
 
-namespace std {
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 class _LIBCPP_EXPORTED_FROM_ABI _LIBCPP_AVAILABILITY_BAD_ANY_CAST bad_any_cast : public bad_cast {
 public:
   const char* what() const _NOEXCEPT override;
 };
-} // namespace std
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 

--- a/libcxx/include/array
+++ b/libcxx/include/array
@@ -172,7 +172,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, size_t _Size>
-struct _LIBCPP_TEMPLATE_VIS array {
+struct array {
   using __trivially_relocatable _LIBCPP_NODEBUG =
       __conditional_t<__libcpp_is_trivially_relocatable<_Tp>::value, array, void>;
 
@@ -298,7 +298,7 @@ struct _LIBCPP_TEMPLATE_VIS array {
 };
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS array<_Tp, 0> {
+struct array<_Tp, 0> {
   // types:
   using __self _LIBCPP_NODEBUG = array;
   using value_type             = _Tp;
@@ -492,10 +492,10 @@ inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void swap(array<_Tp, 
 }
 
 template <class _Tp, size_t _Size>
-struct _LIBCPP_TEMPLATE_VIS tuple_size<array<_Tp, _Size> > : public integral_constant<size_t, _Size> {};
+struct tuple_size<array<_Tp, _Size> > : public integral_constant<size_t, _Size> {};
 
 template <size_t _Ip, class _Tp, size_t _Size>
-struct _LIBCPP_TEMPLATE_VIS tuple_element<_Ip, array<_Tp, _Size> > {
+struct tuple_element<_Ip, array<_Tp, _Size> > {
   static_assert(_Ip < _Size, "Index out of bounds in std::tuple_element<> (std::array)");
   using type _LIBCPP_NODEBUG = _Tp;
 };

--- a/libcxx/include/bitset
+++ b/libcxx/include/bitset
@@ -601,13 +601,12 @@ inline _LIBCPP_CONSTEXPR __bitset<0, 0>::__bitset() _NOEXCEPT {}
 inline _LIBCPP_CONSTEXPR __bitset<0, 0>::__bitset(unsigned long long) _NOEXCEPT {}
 
 template <size_t _Size>
-class _LIBCPP_TEMPLATE_VIS bitset;
+class bitset;
 template <size_t _Size>
 struct hash<bitset<_Size> >;
 
 template <size_t _Size>
-class _LIBCPP_TEMPLATE_VIS bitset
-    : private __bitset<_Size == 0 ? 0 : (_Size - 1) / (sizeof(size_t) * CHAR_BIT) + 1, _Size> {
+class bitset : private __bitset<_Size == 0 ? 0 : (_Size - 1) / (sizeof(size_t) * CHAR_BIT) + 1, _Size> {
 public:
   static const unsigned __n_words = _Size == 0 ? 0 : (_Size - 1) / (sizeof(size_t) * CHAR_BIT) + 1;
   typedef __bitset<__n_words, _Size> __base;
@@ -951,7 +950,7 @@ operator^(const bitset<_Size>& __x, const bitset<_Size>& __y) _NOEXCEPT {
 }
 
 template <size_t _Size>
-struct _LIBCPP_TEMPLATE_VIS hash<bitset<_Size> > : public __unary_function<bitset<_Size>, size_t> {
+struct hash<bitset<_Size> > : public __unary_function<bitset<_Size>, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(const bitset<_Size>& __bs) const _NOEXCEPT { return __bs.__hash_code(); }
 };
 

--- a/libcxx/include/codecvt
+++ b/libcxx/include/codecvt
@@ -196,7 +196,7 @@ protected:
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _Elem, unsigned long _Maxcode = 0x10ffff, codecvt_mode _Mode = (codecvt_mode)0>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf8 : public __codecvt_utf8<_Elem> {
+class _LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf8 : public __codecvt_utf8<_Elem> {
 public:
   _LIBCPP_HIDE_FROM_ABI explicit codecvt_utf8(size_t __refs = 0) : __codecvt_utf8<_Elem>(__refs, _Maxcode, _Mode) {}
 
@@ -439,8 +439,7 @@ protected:
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _Elem, unsigned long _Maxcode = 0x10ffff, codecvt_mode _Mode = (codecvt_mode)0>
-class _LIBCPP_TEMPLATE_VIS
-_LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf16 : public __codecvt_utf16<_Elem, _Mode & little_endian> {
+class _LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf16 : public __codecvt_utf16<_Elem, _Mode & little_endian> {
 public:
   _LIBCPP_HIDE_FROM_ABI explicit codecvt_utf16(size_t __refs = 0)
       : __codecvt_utf16<_Elem, _Mode & little_endian>(__refs, _Maxcode, _Mode) {}
@@ -571,7 +570,7 @@ protected:
 
 _LIBCPP_SUPPRESS_DEPRECATED_PUSH
 template <class _Elem, unsigned long _Maxcode = 0x10ffff, codecvt_mode _Mode = (codecvt_mode)0>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf8_utf16 : public __codecvt_utf8_utf16<_Elem> {
+class _LIBCPP_DEPRECATED_IN_CXX17 codecvt_utf8_utf16 : public __codecvt_utf8_utf16<_Elem> {
 public:
   _LIBCPP_HIDE_FROM_ABI explicit codecvt_utf8_utf16(size_t __refs = 0)
       : __codecvt_utf8_utf16<_Elem>(__refs, _Maxcode, _Mode) {}

--- a/libcxx/include/complex
+++ b/libcxx/include/complex
@@ -283,7 +283,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS complex;
+class complex;
 
 template <class _Tp, __enable_if_t<is_floating_point<_Tp>::value, int> = 0>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 complex<_Tp>
@@ -302,7 +302,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 complex<_Tp>
 operator/(const complex<_Tp>& __x, const complex<_Tp>& __y);
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS complex {
+class complex {
 public:
   typedef _Tp value_type;
 
@@ -393,9 +393,9 @@ public:
 };
 
 template <>
-class _LIBCPP_TEMPLATE_VIS complex<double>;
+class complex<double>;
 template <>
-class _LIBCPP_TEMPLATE_VIS complex<long double>;
+class complex<long double>;
 
 struct __from_builtin_tag {};
 
@@ -415,7 +415,7 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR __complex_t<_Tp> __make_complex(_Tp __re
 }
 
 template <>
-class _LIBCPP_TEMPLATE_VIS complex<float> {
+class complex<float> {
   float __re_;
   float __im_;
 
@@ -512,7 +512,7 @@ public:
 };
 
 template <>
-class _LIBCPP_TEMPLATE_VIS complex<double> {
+class complex<double> {
   double __re_;
   double __im_;
 
@@ -612,7 +612,7 @@ public:
 };
 
 template <>
-class _LIBCPP_TEMPLATE_VIS complex<long double> {
+class complex<long double> {
   long double __re_;
   long double __im_;
 

--- a/libcxx/include/deque
+++ b/libcxx/include/deque
@@ -283,7 +283,7 @@ template <class _ValueType,
               __deque_block_size<_ValueType, _DiffType>::value
 #  endif
           >
-class _LIBCPP_TEMPLATE_VIS __deque_iterator {
+class __deque_iterator {
   typedef _MapPointer __map_iterator;
 
 public:
@@ -444,9 +444,9 @@ private:
         __ptr_(__p) {}
 
   template <class _Tp, class _Ap>
-  friend class _LIBCPP_TEMPLATE_VIS deque;
+  friend class deque;
   template <class _Vp, class _Pp, class _Rp, class _MP, class _Dp, _Dp>
-  friend class _LIBCPP_TEMPLATE_VIS __deque_iterator;
+  friend class __deque_iterator;
 
   template <class>
   friend struct __segmented_iterator_traits;
@@ -486,7 +486,7 @@ const _DiffType __deque_iterator<_ValueType, _Pointer, _Reference, _MapPointer, 
     __deque_block_size<_ValueType, _DiffType>::value;
 
 template <class _Tp, class _Allocator /*= allocator<_Tp>*/>
-class _LIBCPP_TEMPLATE_VIS deque {
+class deque {
 public:
   // types:
 

--- a/libcxx/include/experimental/type_traits
+++ b/libcxx/include/experimental/type_traits
@@ -87,16 +87,16 @@ _LIBCPP_BEGIN_NAMESPACE_LFTS
 // 3.3.2, Other type transformations
 /*
 template <class>
-class _LIBCPP_TEMPLATE_VIS raw_invocation_type;
+class raw_invocation_type;
 
 template <class _Fn, class ..._Args>
-class _LIBCPP_TEMPLATE_VIS raw_invocation_type<_Fn(_Args...)>;
+class raw_invocation_type<_Fn(_Args...)>;
 
 template <class>
-class _LIBCPP_TEMPLATE_VIS invokation_type;
+class invokation_type;
 
 template <class _Fn, class ..._Args>
-class _LIBCPP_TEMPLATE_VIS invokation_type<_Fn(_Args...)>;
+class invokation_type<_Fn(_Args...)>;
 
 template <class _Tp>
 using invokation_type_t = typename invokation_type<_Tp>::type;

--- a/libcxx/include/experimental/utility
+++ b/libcxx/include/experimental/utility
@@ -42,7 +42,7 @@ inline namespace fundamentals_v1 {
 
 _LIBCPP_BEGIN_NAMESPACE_LFTS
 
-struct _LIBCPP_TEMPLATE_VIS erased_type {};
+struct erased_type {};
 
 _LIBCPP_END_NAMESPACE_LFTS
 

--- a/libcxx/include/ext/__hash
+++ b/libcxx/include/ext/__hash
@@ -20,64 +20,64 @@
 namespace __gnu_cxx {
 
 template <typename _Tp>
-struct _LIBCPP_TEMPLATE_VIS hash {};
+struct hash {};
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<const char*> : public std::__unary_function<const char*, size_t> {
+struct hash<const char*> : public std::__unary_function<const char*, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(const char* __c) const _NOEXCEPT {
     return std::__do_string_hash(__c, __c + strlen(__c));
   }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<char*> : public std::__unary_function<char*, size_t> {
+struct hash<char*> : public std::__unary_function<char*, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(char* __c) const _NOEXCEPT {
     return std::__do_string_hash<const char*>(__c, __c + strlen(__c));
   }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<char> : public std::__unary_function<char, size_t> {
+struct hash<char> : public std::__unary_function<char, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(char __c) const _NOEXCEPT { return __c; }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<signed char> : public std::__unary_function<signed char, size_t> {
+struct hash<signed char> : public std::__unary_function<signed char, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(signed char __c) const _NOEXCEPT { return __c; }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<unsigned char> : public std::__unary_function<unsigned char, size_t> {
+struct hash<unsigned char> : public std::__unary_function<unsigned char, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(unsigned char __c) const _NOEXCEPT { return __c; }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<short> : public std::__unary_function<short, size_t> {
+struct hash<short> : public std::__unary_function<short, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(short __c) const _NOEXCEPT { return __c; }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<unsigned short> : public std::__unary_function<unsigned short, size_t> {
+struct hash<unsigned short> : public std::__unary_function<unsigned short, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(unsigned short __c) const _NOEXCEPT { return __c; }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<int> : public std::__unary_function<int, size_t> {
+struct hash<int> : public std::__unary_function<int, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(int __c) const _NOEXCEPT { return __c; }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<unsigned int> : public std::__unary_function<unsigned int, size_t> {
+struct hash<unsigned int> : public std::__unary_function<unsigned int, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(unsigned int __c) const _NOEXCEPT { return __c; }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<long> : public std::__unary_function<long, size_t> {
+struct hash<long> : public std::__unary_function<long, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(long __c) const _NOEXCEPT { return __c; }
 };
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<unsigned long> : public std::__unary_function<unsigned long, size_t> {
+struct hash<unsigned long> : public std::__unary_function<unsigned long, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(unsigned long __c) const _NOEXCEPT { return __c; }
 };
 } // namespace __gnu_cxx

--- a/libcxx/include/ext/hash_map
+++ b/libcxx/include/ext/hash_map
@@ -338,7 +338,7 @@ public:
 };
 
 template <class _HashIterator>
-class _LIBCPP_TEMPLATE_VIS __hash_map_iterator {
+class __hash_map_iterator {
   _HashIterator __i_;
 
   typedef const typename _HashIterator::value_type::first_type key_type;
@@ -376,19 +376,19 @@ public:
   }
 
   template <class, class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS hash_map;
+  friend class hash_map;
   template <class, class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS hash_multimap;
+  friend class hash_multimap;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __hash_const_iterator;
+  friend class __hash_const_iterator;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __hash_const_local_iterator;
+  friend class __hash_const_local_iterator;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __hash_map_const_iterator;
+  friend class __hash_map_const_iterator;
 };
 
 template <class _HashIterator>
-class _LIBCPP_TEMPLATE_VIS __hash_map_const_iterator {
+class __hash_map_const_iterator {
   _HashIterator __i_;
 
   typedef const typename _HashIterator::value_type::first_type key_type;
@@ -430,13 +430,13 @@ public:
   }
 
   template <class, class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS hash_map;
+  friend class hash_map;
   template <class, class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS hash_multimap;
+  friend class hash_multimap;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __hash_const_iterator;
+  friend class __hash_const_iterator;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __hash_const_local_iterator;
+  friend class __hash_const_local_iterator;
 };
 
 template <class _Key,
@@ -444,7 +444,7 @@ template <class _Key,
           class _Hash  = hash<_Key>,
           class _Pred  = std::equal_to<_Key>,
           class _Alloc = std::allocator<std::pair<const _Key, _Tp> > >
-class _LIBCPP_TEMPLATE_VIS hash_map {
+class hash_map {
 public:
   // types
   typedef _Key key_type;
@@ -670,7 +670,7 @@ template <class _Key,
           class _Hash  = hash<_Key>,
           class _Pred  = std::equal_to<_Key>,
           class _Alloc = std::allocator<std::pair<const _Key, _Tp> > >
-class _LIBCPP_TEMPLATE_VIS hash_multimap {
+class hash_multimap {
 public:
   // types
   typedef _Key key_type;

--- a/libcxx/include/ext/hash_set
+++ b/libcxx/include/ext/hash_set
@@ -219,7 +219,7 @@ template <class _Value,
           class _Hash  = hash<_Value>,
           class _Pred  = std::equal_to<_Value>,
           class _Alloc = std::allocator<_Value> >
-class _LIBCPP_TEMPLATE_VIS hash_set {
+class hash_set {
 public:
   // types
   typedef _Value key_type;
@@ -398,7 +398,7 @@ template <class _Value,
           class _Hash  = hash<_Value>,
           class _Pred  = std::equal_to<_Value>,
           class _Alloc = std::allocator<_Value> >
-class _LIBCPP_TEMPLATE_VIS hash_multiset {
+class hash_multiset {
 public:
   // types
   typedef _Value key_type;

--- a/libcxx/include/forward_list
+++ b/libcxx/include/forward_list
@@ -350,12 +350,12 @@ public:
 };
 
 template <class _Tp, class _Alloc = allocator<_Tp> >
-class _LIBCPP_TEMPLATE_VIS forward_list;
+class forward_list;
 template <class _NodeConstPtr>
-class _LIBCPP_TEMPLATE_VIS __forward_list_const_iterator;
+class __forward_list_const_iterator;
 
 template <class _NodePtr>
-class _LIBCPP_TEMPLATE_VIS __forward_list_iterator {
+class __forward_list_iterator {
   typedef __forward_node_traits<_NodePtr> __traits;
   typedef typename __traits::__node_pointer __node_pointer;
   typedef typename __traits::__begin_node_pointer __begin_node_pointer;
@@ -378,9 +378,9 @@ class _LIBCPP_TEMPLATE_VIS __forward_list_iterator {
       : __ptr_(__traits::__as_iter_node(__p)) {}
 
   template <class, class>
-  friend class _LIBCPP_TEMPLATE_VIS forward_list;
+  friend class forward_list;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __forward_list_const_iterator;
+  friend class __forward_list_const_iterator;
 
 public:
   typedef forward_iterator_tag iterator_category;
@@ -415,7 +415,7 @@ public:
 };
 
 template <class _NodeConstPtr>
-class _LIBCPP_TEMPLATE_VIS __forward_list_const_iterator {
+class __forward_list_const_iterator {
   static_assert(!is_const<typename pointer_traits<_NodeConstPtr>::element_type>::value, "");
   typedef _NodeConstPtr _NodePtr;
 
@@ -637,7 +637,7 @@ void __forward_list_base<_Tp, _Alloc>::clear() _NOEXCEPT {
 }
 
 template <class _Tp, class _Alloc /*= allocator<_Tp>*/>
-class _LIBCPP_TEMPLATE_VIS forward_list : private __forward_list_base<_Tp, _Alloc> {
+class forward_list : private __forward_list_base<_Tp, _Alloc> {
   typedef __forward_list_base<_Tp, _Alloc> __base;
   typedef typename __base::__node_allocator __node_allocator;
   typedef typename __base::__node_type __node_type;

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -225,7 +225,7 @@ _LIBCPP_EXPORTED_FROM_ABI void* __filebuf_windows_native_handle(FILE* __file) no
 #    endif
 
 template <class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS basic_filebuf : public basic_streambuf<_CharT, _Traits> {
+class basic_filebuf : public basic_streambuf<_CharT, _Traits> {
 public:
   typedef _CharT char_type;
   typedef _Traits traits_type;
@@ -1095,7 +1095,7 @@ void basic_filebuf<_CharT, _Traits>::__write_mode() {
 // basic_ifstream
 
 template <class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS basic_ifstream : public basic_istream<_CharT, _Traits> {
+class basic_ifstream : public basic_istream<_CharT, _Traits> {
 public:
   typedef _CharT char_type;
   typedef _Traits traits_type;
@@ -1251,7 +1251,7 @@ inline void basic_ifstream<_CharT, _Traits>::close() {
 // basic_ofstream
 
 template <class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS basic_ofstream : public basic_ostream<_CharT, _Traits> {
+class basic_ofstream : public basic_ostream<_CharT, _Traits> {
 public:
   typedef _CharT char_type;
   typedef _Traits traits_type;
@@ -1410,7 +1410,7 @@ inline void basic_ofstream<_CharT, _Traits>::close() {
 // basic_fstream
 
 template <class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS basic_fstream : public basic_iostream<_CharT, _Traits> {
+class basic_fstream : public basic_iostream<_CharT, _Traits> {
 public:
   typedef _CharT char_type;
   typedef _Traits traits_type;

--- a/libcxx/include/future
+++ b/libcxx/include/future
@@ -427,11 +427,11 @@ _LIBCPP_DECLARE_STRONG_ENUM(future_errc){
 _LIBCPP_DECLARE_STRONG_ENUM_EPILOG(future_errc)
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS is_error_code_enum<future_errc> : public true_type {};
+struct is_error_code_enum<future_errc> : public true_type {};
 
 #    ifdef _LIBCPP_CXX03_LANG
 template <>
-struct _LIBCPP_TEMPLATE_VIS is_error_code_enum<future_errc::__lx> : public true_type {};
+struct is_error_code_enum<future_errc::__lx> : public true_type {};
 #    endif
 
 // enum class launch
@@ -907,14 +907,14 @@ void __async_assoc_state<void, _Fp>::__on_zero_shared() _NOEXCEPT {
 }
 
 template <class _Rp>
-class _LIBCPP_TEMPLATE_VIS promise;
+class promise;
 template <class _Rp>
-class _LIBCPP_TEMPLATE_VIS shared_future;
+class shared_future;
 
 // future
 
 template <class _Rp>
-class _LIBCPP_TEMPLATE_VIS future;
+class future;
 
 template <class _Rp, class _Fp>
 _LIBCPP_HIDE_FROM_ABI future<_Rp> __make_deferred_assoc_state(_Fp&& __f);
@@ -923,7 +923,7 @@ template <class _Rp, class _Fp>
 _LIBCPP_HIDE_FROM_ABI future<_Rp> __make_async_assoc_state(_Fp&& __f);
 
 template <class _Rp>
-class _LIBCPP_TEMPLATE_VIS future {
+class future {
   __assoc_state<_Rp>* __state_;
 
   explicit _LIBCPP_HIDE_FROM_ABI future(__assoc_state<_Rp>* __state);
@@ -994,7 +994,7 @@ _Rp future<_Rp>::get() {
 }
 
 template <class _Rp>
-class _LIBCPP_TEMPLATE_VIS future<_Rp&> {
+class future<_Rp&> {
   __assoc_state<_Rp&>* __state_;
 
   explicit _LIBCPP_HIDE_FROM_ABI future(__assoc_state<_Rp&>* __state);
@@ -1119,7 +1119,7 @@ template <class _Callable>
 class packaged_task;
 
 template <class _Rp>
-class _LIBCPP_TEMPLATE_VIS promise {
+class promise {
   __assoc_state<_Rp>* __state_;
 
   _LIBCPP_HIDE_FROM_ABI explicit promise(nullptr_t) _NOEXCEPT : __state_(nullptr) {}
@@ -1236,7 +1236,7 @@ void promise<_Rp>::set_exception_at_thread_exit(exception_ptr __p) {
 // promise<R&>
 
 template <class _Rp>
-class _LIBCPP_TEMPLATE_VIS promise<_Rp&> {
+class promise<_Rp&> {
   __assoc_state<_Rp&>* __state_;
 
   _LIBCPP_HIDE_FROM_ABI explicit promise(nullptr_t) _NOEXCEPT : __state_(nullptr) {}
@@ -1391,7 +1391,7 @@ inline _LIBCPP_HIDE_FROM_ABI void swap(promise<_Rp>& __x, promise<_Rp>& __y) _NO
 }
 
 template <class _Rp, class _Alloc>
-struct _LIBCPP_TEMPLATE_VIS uses_allocator<promise<_Rp>, _Alloc> : public true_type {};
+struct uses_allocator<promise<_Rp>, _Alloc> : public true_type {};
 
 // packaged_task
 
@@ -1610,7 +1610,7 @@ inline _Rp __packaged_task_function<_Rp(_ArgTypes...)>::operator()(_ArgTypes... 
 }
 
 template <class _Rp, class... _ArgTypes>
-class _LIBCPP_TEMPLATE_VIS packaged_task<_Rp(_ArgTypes...)> {
+class packaged_task<_Rp(_ArgTypes...)> {
 public:
   using result_type _LIBCPP_DEPRECATED = _Rp; // extension
 
@@ -1704,7 +1704,7 @@ void packaged_task<_Rp(_ArgTypes...)>::reset() {
 }
 
 template <class... _ArgTypes>
-class _LIBCPP_TEMPLATE_VIS packaged_task<void(_ArgTypes...)> {
+class packaged_task<void(_ArgTypes...)> {
 public:
   using result_type _LIBCPP_DEPRECATED = void; // extension
 
@@ -1815,7 +1815,7 @@ swap(packaged_task<_Rp(_ArgTypes...)>& __x, packaged_task<_Rp(_ArgTypes...)>& __
 
 #    if _LIBCPP_STD_VER <= 14
 template <class _Callable, class _Alloc>
-struct _LIBCPP_TEMPLATE_VIS uses_allocator<packaged_task<_Callable>, _Alloc> : public true_type {};
+struct uses_allocator<packaged_task<_Callable>, _Alloc> : public true_type {};
 #    endif
 
 template <class _Rp, class _Fp>
@@ -1899,7 +1899,7 @@ async(_Fp&& __f, _Args&&... __args) {
 // shared_future
 
 template <class _Rp>
-class _LIBCPP_TEMPLATE_VIS shared_future {
+class shared_future {
   __assoc_state<_Rp>* __state_;
 
 public:
@@ -1955,7 +1955,7 @@ shared_future<_Rp>& shared_future<_Rp>::operator=(const shared_future& __rhs) _N
 }
 
 template <class _Rp>
-class _LIBCPP_TEMPLATE_VIS shared_future<_Rp&> {
+class shared_future<_Rp&> {
   __assoc_state<_Rp&>* __state_;
 
 public:

--- a/libcxx/include/initializer_list
+++ b/libcxx/include/initializer_list
@@ -59,7 +59,7 @@ namespace std // purposefully not versioned
 #  ifndef _LIBCPP_CXX03_LANG
 
 template <class _Ep>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS initializer_list {
+class _LIBCPP_NO_SPECIALIZATIONS initializer_list {
   const _Ep* __begin_;
   size_t __size_;
 

--- a/libcxx/include/ios
+++ b/libcxx/include/ios
@@ -418,11 +418,11 @@ _LIBCPP_DECLARE_STRONG_ENUM(io_errc){stream = 1};
 _LIBCPP_DECLARE_STRONG_ENUM_EPILOG(io_errc)
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS is_error_code_enum<io_errc> : public true_type {};
+struct is_error_code_enum<io_errc> : public true_type {};
 
 #    ifdef _LIBCPP_CXX03_LANG
 template <>
-struct _LIBCPP_TEMPLATE_VIS is_error_code_enum<io_errc::__lx> : public true_type {};
+struct is_error_code_enum<io_errc::__lx> : public true_type {};
 #    endif
 
 _LIBCPP_EXPORTED_FROM_ABI const error_category& iostream_category() _NOEXCEPT;
@@ -559,7 +559,7 @@ private:
 };
 
 template <class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS basic_ios : public ios_base {
+class basic_ios : public ios_base {
 public:
   // types:
   typedef _CharT char_type;

--- a/libcxx/include/iosfwd
+++ b/libcxx/include/iosfwd
@@ -127,12 +127,12 @@ using wosyncstream = basic_osyncstream<wchar_t>;  // C++20
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _CharT, class _Traits = char_traits<_CharT> >
-class _LIBCPP_TEMPLATE_VIS istreambuf_iterator;
+class istreambuf_iterator;
 template <class _CharT, class _Traits = char_traits<_CharT> >
-class _LIBCPP_TEMPLATE_VIS ostreambuf_iterator;
+class ostreambuf_iterator;
 
 template <class _State>
-class _LIBCPP_TEMPLATE_VIS fpos;
+class fpos;
 typedef fpos<mbstate_t> streampos;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
 typedef fpos<mbstate_t> wstreampos;

--- a/libcxx/include/istream
+++ b/libcxx/include/istream
@@ -189,7 +189,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS basic_istream : virtual public basic_ios<_CharT, _Traits> {
+class basic_istream : virtual public basic_ios<_CharT, _Traits> {
   streamsize __gc_;
 
   _LIBCPP_HIDE_FROM_ABI void __inc_gcount() {
@@ -228,7 +228,7 @@ public:
   basic_istream& operator=(const basic_istream& __rhs) = delete;
 
   // 27.7.1.1.3 Prefix/suffix:
-  class _LIBCPP_TEMPLATE_VIS sentry;
+  class sentry;
 
   // 27.7.1.2 Formatted input:
   inline _LIBCPP_HIDE_FROM_ABI_AFTER_V1 basic_istream& operator>>(basic_istream& (*__pf)(basic_istream&)) {
@@ -305,7 +305,7 @@ public:
 };
 
 template <class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS basic_istream<_CharT, _Traits>::sentry {
+class basic_istream<_CharT, _Traits>::sentry {
   bool __ok_;
 
 public:
@@ -1167,9 +1167,7 @@ _LIBCPP_HIDE_FROM_ABI _Stream&& operator>>(_Stream&& __is, _Tp&& __x) {
 }
 
 template <class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS basic_iostream
-    : public basic_istream<_CharT, _Traits>,
-      public basic_ostream<_CharT, _Traits> {
+class basic_iostream : public basic_istream<_CharT, _Traits>, public basic_ostream<_CharT, _Traits> {
 public:
   // types:
   typedef _CharT char_type;

--- a/libcxx/include/limits
+++ b/libcxx/include/limits
@@ -462,7 +462,7 @@ protected:
 };
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS numeric_limits : private __libcpp_numeric_limits<_Tp> {
+class numeric_limits : private __libcpp_numeric_limits<_Tp> {
   typedef __libcpp_numeric_limits<_Tp> __base;
   typedef typename __base::type type;
 
@@ -521,13 +521,13 @@ public:
 };
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS numeric_limits<const _Tp> : public numeric_limits<_Tp> {};
+class numeric_limits<const _Tp> : public numeric_limits<_Tp> {};
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS numeric_limits<volatile _Tp> : public numeric_limits<_Tp> {};
+class numeric_limits<volatile _Tp> : public numeric_limits<_Tp> {};
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS numeric_limits<const volatile _Tp> : public numeric_limits<_Tp> {};
+class numeric_limits<const volatile _Tp> : public numeric_limits<_Tp> {};
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/list
+++ b/libcxx/include/list
@@ -339,14 +339,14 @@ public:
 };
 
 template <class _Tp, class _Alloc = allocator<_Tp> >
-class _LIBCPP_TEMPLATE_VIS list;
+class list;
 template <class _Tp, class _Alloc>
 class __list_imp;
 template <class _Tp, class _VoidPtr>
-class _LIBCPP_TEMPLATE_VIS __list_const_iterator;
+class __list_const_iterator;
 
 template <class _Tp, class _VoidPtr>
-class _LIBCPP_TEMPLATE_VIS __list_iterator {
+class __list_iterator {
   typedef __list_node_pointer_traits<_Tp, _VoidPtr> _NodeTraits;
   typedef typename _NodeTraits::__base_pointer __base_pointer;
 
@@ -404,7 +404,7 @@ public:
 };
 
 template <class _Tp, class _VoidPtr>
-class _LIBCPP_TEMPLATE_VIS __list_const_iterator {
+class __list_const_iterator {
   typedef __list_node_pointer_traits<_Tp, _VoidPtr> _NodeTraits;
   typedef typename _NodeTraits::__base_pointer __base_pointer;
 
@@ -654,7 +654,7 @@ void __list_imp<_Tp, _Alloc>::swap(__list_imp& __c)
 }
 
 template <class _Tp, class _Alloc /*= allocator<_Tp>*/>
-class _LIBCPP_TEMPLATE_VIS list : private __list_imp<_Tp, _Alloc> {
+class list : private __list_imp<_Tp, _Alloc> {
   typedef __list_imp<_Tp, _Alloc> __base;
   typedef typename __base::__node_type __node_type;
   typedef typename __base::__node_allocator __node_allocator;

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -567,7 +567,7 @@ extern template struct _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __num_get<wchar_t>;
 #    endif
 
 template <class _CharT, class _InputIterator = istreambuf_iterator<_CharT> >
-class _LIBCPP_TEMPLATE_VIS num_get : public locale::facet, private __num_get<_CharT> {
+class num_get : public locale::facet, private __num_get<_CharT> {
 public:
   typedef _CharT char_type;
   typedef _InputIterator iter_type;
@@ -1166,7 +1166,7 @@ extern template struct _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __num_put<wchar_t>;
 #    endif
 
 template <class _CharT, class _OutputIterator = ostreambuf_iterator<_CharT> >
-class _LIBCPP_TEMPLATE_VIS num_put : public locale::facet, private __num_put<_CharT> {
+class num_put : public locale::facet, private __num_put<_CharT> {
 public:
   typedef _CharT char_type;
   typedef _OutputIterator iter_type;
@@ -1425,7 +1425,7 @@ public:
 };
 
 template <class _CharT>
-class _LIBCPP_TEMPLATE_VIS __time_get_c_storage {
+class __time_get_c_storage {
 protected:
   typedef basic_string<_CharT> string_type;
 
@@ -1473,7 +1473,7 @@ _LIBCPP_EXPORTED_FROM_ABI const wstring& __time_get_c_storage<wchar_t>::__X() co
 #    endif
 
 template <class _CharT, class _InputIterator = istreambuf_iterator<_CharT> >
-class _LIBCPP_TEMPLATE_VIS time_get : public locale::facet, public time_base, private __time_get_c_storage<_CharT> {
+class time_get : public locale::facet, public time_base, private __time_get_c_storage<_CharT> {
 public:
   typedef _CharT char_type;
   typedef _InputIterator iter_type;
@@ -1938,7 +1938,7 @@ protected:
 };
 
 template <class _CharT>
-class _LIBCPP_TEMPLATE_VIS __time_get_storage : public __time_get {
+class __time_get_storage : public __time_get {
 protected:
   typedef basic_string<_CharT> string_type;
 
@@ -1990,9 +1990,7 @@ _LIBCPP_TIME_GET_STORAGE_EXPLICIT_INSTANTIATION(wchar_t)
 #    undef _LIBCPP_TIME_GET_STORAGE_EXPLICIT_INSTANTIATION
 
 template <class _CharT, class _InputIterator = istreambuf_iterator<_CharT> >
-class _LIBCPP_TEMPLATE_VIS time_get_byname
-    : public time_get<_CharT, _InputIterator>,
-      private __time_get_storage<_CharT> {
+class time_get_byname : public time_get<_CharT, _InputIterator>, private __time_get_storage<_CharT> {
 public:
   typedef time_base::dateorder dateorder;
   typedef _InputIterator iter_type;
@@ -2039,7 +2037,7 @@ protected:
 };
 
 template <class _CharT, class _OutputIterator = ostreambuf_iterator<_CharT> >
-class _LIBCPP_TEMPLATE_VIS time_put : public locale::facet, private __time_put {
+class time_put : public locale::facet, private __time_put {
 public:
   typedef _CharT char_type;
   typedef _OutputIterator iter_type;
@@ -2114,7 +2112,7 @@ extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_put<wchar_t>;
 #    endif
 
 template <class _CharT, class _OutputIterator = ostreambuf_iterator<_CharT> >
-class _LIBCPP_TEMPLATE_VIS time_put_byname : public time_put<_CharT, _OutputIterator> {
+class time_put_byname : public time_put<_CharT, _OutputIterator> {
 public:
   _LIBCPP_HIDE_FROM_ABI explicit time_put_byname(const char* __nm, size_t __refs = 0)
       : time_put<_CharT, _OutputIterator>(__nm, __refs) {}
@@ -2146,7 +2144,7 @@ public:
 // moneypunct
 
 template <class _CharT, bool _International = false>
-class _LIBCPP_TEMPLATE_VIS moneypunct : public locale::facet, public money_base {
+class moneypunct : public locale::facet, public money_base {
 public:
   typedef _CharT char_type;
   typedef basic_string<char_type> string_type;
@@ -2202,7 +2200,7 @@ extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct<wchar_t, true>
 // moneypunct_byname
 
 template <class _CharT, bool _International = false>
-class _LIBCPP_TEMPLATE_VIS moneypunct_byname : public moneypunct<_CharT, _International> {
+class moneypunct_byname : public moneypunct<_CharT, _International> {
 public:
   typedef money_base::pattern pattern;
   typedef _CharT char_type;
@@ -2325,7 +2323,7 @@ extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __money_get<wchar_t>;
 #    endif
 
 template <class _CharT, class _InputIterator = istreambuf_iterator<_CharT> >
-class _LIBCPP_TEMPLATE_VIS money_get : public locale::facet, private __money_get<_CharT> {
+class money_get : public locale::facet, private __money_get<_CharT> {
 public:
   typedef _CharT char_type;
   typedef _InputIterator iter_type;
@@ -2817,7 +2815,7 @@ extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __money_put<wchar_t>;
 #    endif
 
 template <class _CharT, class _OutputIterator = ostreambuf_iterator<_CharT> >
-class _LIBCPP_TEMPLATE_VIS money_put : public locale::facet, private __money_put<_CharT> {
+class money_put : public locale::facet, private __money_put<_CharT> {
 public:
   typedef _CharT char_type;
   typedef _OutputIterator iter_type;
@@ -2972,7 +2970,7 @@ public:
 };
 
 template <class _CharT>
-class _LIBCPP_TEMPLATE_VIS messages : public locale::facet, public messages_base {
+class messages : public locale::facet, public messages_base {
 public:
   typedef _CharT char_type;
   typedef basic_string<_CharT> string_type;
@@ -3048,7 +3046,7 @@ extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS messages<wchar_t>;
 #    endif
 
 template <class _CharT>
-class _LIBCPP_TEMPLATE_VIS messages_byname : public messages<_CharT> {
+class messages_byname : public messages<_CharT> {
 public:
   typedef messages_base::catalog catalog;
   typedef basic_string<_CharT> string_type;
@@ -3072,7 +3070,7 @@ template <class _Codecvt,
           class _Elem      = wchar_t,
           class _WideAlloc = allocator<_Elem>,
           class _ByteAlloc = allocator<char> >
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 wstring_convert {
+class _LIBCPP_DEPRECATED_IN_CXX17 wstring_convert {
 public:
   typedef basic_string<char, char_traits<char>, _ByteAlloc> byte_string;
   typedef basic_string<_Elem, char_traits<_Elem>, _WideAlloc> wide_string;
@@ -3283,7 +3281,7 @@ wstring_convert<_Codecvt, _Elem, _WideAlloc, _ByteAlloc>::to_bytes(const _Elem* 
 }
 
 template <class _Codecvt, class _Elem = wchar_t, class _Tr = char_traits<_Elem> >
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DEPRECATED_IN_CXX17 wbuffer_convert : public basic_streambuf<_Elem, _Tr> {
+class _LIBCPP_DEPRECATED_IN_CXX17 wbuffer_convert : public basic_streambuf<_Elem, _Tr> {
 public:
   // types:
   typedef _Elem char_type;

--- a/libcxx/include/map
+++ b/libcxx/include/map
@@ -855,7 +855,7 @@ struct __extract_key_value_types<__value_type<_Key, _Tp> > {
 };
 
 template <class _TreeIterator>
-class _LIBCPP_TEMPLATE_VIS __map_iterator {
+class __map_iterator {
   typedef typename _TreeIterator::_NodeTypes _NodeTypes;
   typedef typename _TreeIterator::__pointer_traits __pointer_traits;
 
@@ -903,15 +903,15 @@ public:
   }
 
   template <class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS map;
+  friend class map;
   template <class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS multimap;
+  friend class multimap;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __map_const_iterator;
+  friend class __map_const_iterator;
 };
 
 template <class _TreeIterator>
-class _LIBCPP_TEMPLATE_VIS __map_const_iterator {
+class __map_const_iterator {
   typedef typename _TreeIterator::_NodeTypes _NodeTypes;
   typedef typename _TreeIterator::__pointer_traits __pointer_traits;
 
@@ -961,15 +961,15 @@ public:
   }
 
   template <class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS map;
+  friend class map;
   template <class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS multimap;
+  friend class multimap;
   template <class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS __tree_const_iterator;
+  friend class __tree_const_iterator;
 };
 
 template <class _Key, class _Tp, class _Compare, class _Allocator>
-class _LIBCPP_TEMPLATE_VIS map {
+class map {
 public:
   // types:
   typedef _Key key_type;
@@ -983,7 +983,7 @@ public:
   static_assert(is_same<typename allocator_type::value_type, value_type>::value,
                 "Allocator::value_type must be same type as value_type");
 
-  class _LIBCPP_TEMPLATE_VIS value_compare : public __binary_function<value_type, value_type, bool> {
+  class value_compare : public __binary_function<value_type, value_type, bool> {
     friend class map;
 
   protected:
@@ -1025,9 +1025,9 @@ public:
 #  endif
 
   template <class _Key2, class _Value2, class _Comp2, class _Alloc2>
-  friend class _LIBCPP_TEMPLATE_VIS map;
+  friend class map;
   template <class _Key2, class _Value2, class _Comp2, class _Alloc2>
-  friend class _LIBCPP_TEMPLATE_VIS multimap;
+  friend class multimap;
 
   _LIBCPP_HIDE_FROM_ABI map() _NOEXCEPT_(
       is_nothrow_default_constructible<allocator_type>::value&& is_nothrow_default_constructible<key_compare>::value&&
@@ -1654,7 +1654,7 @@ struct __container_traits<map<_Key, _Tp, _Compare, _Allocator> > {
 };
 
 template <class _Key, class _Tp, class _Compare, class _Allocator>
-class _LIBCPP_TEMPLATE_VIS multimap {
+class multimap {
 public:
   // types:
   typedef _Key key_type;
@@ -1669,7 +1669,7 @@ public:
   static_assert(is_same<typename allocator_type::value_type, value_type>::value,
                 "Allocator::value_type must be same type as value_type");
 
-  class _LIBCPP_TEMPLATE_VIS value_compare : public __binary_function<value_type, value_type, bool> {
+  class value_compare : public __binary_function<value_type, value_type, bool> {
     friend class multimap;
 
   protected:
@@ -1708,9 +1708,9 @@ public:
 #  endif
 
   template <class _Key2, class _Value2, class _Comp2, class _Alloc2>
-  friend class _LIBCPP_TEMPLATE_VIS map;
+  friend class map;
   template <class _Key2, class _Value2, class _Comp2, class _Alloc2>
-  friend class _LIBCPP_TEMPLATE_VIS multimap;
+  friend class multimap;
 
   _LIBCPP_HIDE_FROM_ABI multimap() _NOEXCEPT_(
       is_nothrow_default_constructible<allocator_type>::value&& is_nothrow_default_constructible<key_compare>::value&&

--- a/libcxx/include/mutex
+++ b/libcxx/include/mutex
@@ -423,10 +423,10 @@ inline _LIBCPP_HIDE_FROM_ABI void lock(_L0& __l0, _L1& __l1, _L2& __l2, _L3&... 
 
 #    if _LIBCPP_STD_VER >= 17
 template <class... _Mutexes>
-class _LIBCPP_TEMPLATE_VIS scoped_lock;
+class scoped_lock;
 
 template <>
-class _LIBCPP_TEMPLATE_VIS scoped_lock<> {
+class scoped_lock<> {
 public:
   [[nodiscard]] _LIBCPP_HIDE_FROM_ABI explicit scoped_lock() {}
   ~scoped_lock() = default;
@@ -438,7 +438,7 @@ public:
 };
 
 template <class _Mutex>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_THREAD_SAFETY_ANNOTATION(scoped_lockable) scoped_lock<_Mutex> {
+class _LIBCPP_THREAD_SAFETY_ANNOTATION(scoped_lockable) scoped_lock<_Mutex> {
 public:
   typedef _Mutex mutex_type;
 
@@ -463,7 +463,7 @@ public:
 };
 
 template <class... _MArgs>
-class _LIBCPP_TEMPLATE_VIS scoped_lock {
+class scoped_lock {
   static_assert(sizeof...(_MArgs) > 1, "At least 2 lock types required");
   typedef tuple<_MArgs&...> _MutexTuple;
 

--- a/libcxx/include/optional
+++ b/libcxx/include/optional
@@ -1268,7 +1268,7 @@ _LIBCPP_HIDE_FROM_ABI constexpr optional<_Tp> make_optional(initializer_list<_Up
 }
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS hash< __enable_hash_helper<optional<_Tp>, remove_const_t<_Tp>> > {
+struct hash<__enable_hash_helper<optional<_Tp>, remove_const_t<_Tp>>> {
 #    if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
   _LIBCPP_DEPRECATED_IN_CXX17 typedef optional<_Tp> argument_type;
   _LIBCPP_DEPRECATED_IN_CXX17 typedef size_t result_type;

--- a/libcxx/include/queue
+++ b/libcxx/include/queue
@@ -299,7 +299,7 @@ template <class _Tp, class _Container>
 _LIBCPP_HIDE_FROM_ABI bool operator<(const queue<_Tp, _Container>& __x, const queue<_Tp, _Container>& __y);
 
 template <class _Tp, class _Container /*= deque<_Tp>*/>
-class _LIBCPP_TEMPLATE_VIS queue {
+class queue {
 public:
   typedef _Container container_type;
   typedef typename container_type::value_type value_type;
@@ -510,11 +510,10 @@ inline _LIBCPP_HIDE_FROM_ABI void swap(queue<_Tp, _Container>& __x, queue<_Tp, _
 }
 
 template <class _Tp, class _Container, class _Alloc>
-struct _LIBCPP_TEMPLATE_VIS uses_allocator<queue<_Tp, _Container>, _Alloc> : public uses_allocator<_Container, _Alloc> {
-};
+struct uses_allocator<queue<_Tp, _Container>, _Alloc> : public uses_allocator<_Container, _Alloc> {};
 
 template <class _Tp, class _Container, class _Compare>
-class _LIBCPP_TEMPLATE_VIS priority_queue {
+class priority_queue {
 public:
   typedef _Container container_type;
   typedef _Compare value_compare;
@@ -942,8 +941,7 @@ swap(priority_queue<_Tp, _Container, _Compare>& __x, priority_queue<_Tp, _Contai
 }
 
 template <class _Tp, class _Container, class _Compare, class _Alloc>
-struct _LIBCPP_TEMPLATE_VIS uses_allocator<priority_queue<_Tp, _Container, _Compare>, _Alloc>
-    : public uses_allocator<_Container, _Alloc> {};
+struct uses_allocator<priority_queue<_Tp, _Container, _Compare>, _Alloc> : public uses_allocator<_Container, _Alloc> {};
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/ratio
+++ b/libcxx/include/ratio
@@ -229,7 +229,7 @@ public:
 };
 
 template <intmax_t _Num, intmax_t _Den = 1>
-class _LIBCPP_TEMPLATE_VIS ratio {
+class ratio {
   static_assert(__static_abs<_Num> >= 0, "ratio numerator is out of range");
   static_assert(_Den != 0, "ratio divide by 0");
   static_assert(__static_abs<_Den> > 0, "ratio denominator is out of range");
@@ -290,7 +290,7 @@ using ratio_multiply = typename __ratio_multiply<_R1, _R2>::type;
 #  else // _LIBCPP_CXX03_LANG
 
 template <class _R1, class _R2>
-struct _LIBCPP_TEMPLATE_VIS ratio_multiply : public __ratio_multiply<_R1, _R2>::type {};
+struct ratio_multiply : public __ratio_multiply<_R1, _R2>::type {};
 
 #  endif // _LIBCPP_CXX03_LANG
 
@@ -316,7 +316,7 @@ using ratio_divide = typename __ratio_divide<_R1, _R2>::type;
 #  else // _LIBCPP_CXX03_LANG
 
 template <class _R1, class _R2>
-struct _LIBCPP_TEMPLATE_VIS ratio_divide : public __ratio_divide<_R1, _R2>::type {};
+struct ratio_divide : public __ratio_divide<_R1, _R2>::type {};
 
 #  endif // _LIBCPP_CXX03_LANG
 
@@ -345,7 +345,7 @@ using ratio_add = typename __ratio_add<_R1, _R2>::type;
 #  else // _LIBCPP_CXX03_LANG
 
 template <class _R1, class _R2>
-struct _LIBCPP_TEMPLATE_VIS ratio_add : public __ratio_add<_R1, _R2>::type {};
+struct ratio_add : public __ratio_add<_R1, _R2>::type {};
 
 #  endif // _LIBCPP_CXX03_LANG
 
@@ -374,20 +374,20 @@ using ratio_subtract = typename __ratio_subtract<_R1, _R2>::type;
 #  else // _LIBCPP_CXX03_LANG
 
 template <class _R1, class _R2>
-struct _LIBCPP_TEMPLATE_VIS ratio_subtract : public __ratio_subtract<_R1, _R2>::type {};
+struct ratio_subtract : public __ratio_subtract<_R1, _R2>::type {};
 
 #  endif // _LIBCPP_CXX03_LANG
 
 // ratio_equal
 
 template <class _R1, class _R2>
-struct _LIBCPP_TEMPLATE_VIS ratio_equal : _BoolConstant<(_R1::num == _R2::num && _R1::den == _R2::den)> {
+struct ratio_equal : _BoolConstant<(_R1::num == _R2::num && _R1::den == _R2::den)> {
   static_assert(__is_ratio_v<_R1>, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
   static_assert(__is_ratio_v<_R2>, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
 };
 
 template <class _R1, class _R2>
-struct _LIBCPP_TEMPLATE_VIS ratio_not_equal : _BoolConstant<!ratio_equal<_R1, _R2>::value> {
+struct ratio_not_equal : _BoolConstant<!ratio_equal<_R1, _R2>::value> {
   static_assert(__is_ratio_v<_R1>, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
   static_assert(__is_ratio_v<_R2>, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
 };
@@ -441,25 +441,25 @@ struct __ratio_less<_R1, _R2, -1LL, -1LL> {
 };
 
 template <class _R1, class _R2>
-struct _LIBCPP_TEMPLATE_VIS ratio_less : _BoolConstant<__ratio_less<_R1, _R2>::value> {
+struct ratio_less : _BoolConstant<__ratio_less<_R1, _R2>::value> {
   static_assert(__is_ratio_v<_R1>, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
   static_assert(__is_ratio_v<_R2>, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
 };
 
 template <class _R1, class _R2>
-struct _LIBCPP_TEMPLATE_VIS ratio_less_equal : _BoolConstant<!ratio_less<_R2, _R1>::value> {
+struct ratio_less_equal : _BoolConstant<!ratio_less<_R2, _R1>::value> {
   static_assert(__is_ratio_v<_R1>, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
   static_assert(__is_ratio_v<_R2>, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
 };
 
 template <class _R1, class _R2>
-struct _LIBCPP_TEMPLATE_VIS ratio_greater : _BoolConstant<ratio_less<_R2, _R1>::value> {
+struct ratio_greater : _BoolConstant<ratio_less<_R2, _R1>::value> {
   static_assert(__is_ratio_v<_R1>, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
   static_assert(__is_ratio_v<_R2>, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
 };
 
 template <class _R1, class _R2>
-struct _LIBCPP_TEMPLATE_VIS ratio_greater_equal : _BoolConstant<!ratio_less<_R1, _R2>::value> {
+struct ratio_greater_equal : _BoolConstant<!ratio_less<_R1, _R2>::value> {
   static_assert(__is_ratio_v<_R1>, "[ratio.general]/2 requires R1 to be a specialisation of the ratio template");
   static_assert(__is_ratio_v<_R2>, "[ratio.general]/2 requires R2 to be a specialisation of the ratio template");
 };

--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -996,7 +996,7 @@ template <regex_constants::error_type _Ev>
 }
 
 template <class _CharT>
-struct _LIBCPP_TEMPLATE_VIS regex_traits {
+struct regex_traits {
 public:
   typedef _CharT char_type;
   typedef basic_string<char_type> string_type;
@@ -1305,10 +1305,10 @@ template <class _CharT>
 class __node;
 
 template <class _BidirectionalIterator>
-class _LIBCPP_TEMPLATE_VIS sub_match;
+class sub_match;
 
 template <class _BidirectionalIterator, class _Allocator = allocator<sub_match<_BidirectionalIterator> > >
-class _LIBCPP_TEMPLATE_VIS match_results;
+class match_results;
 
 template <class _CharT>
 struct __state {
@@ -2263,7 +2263,7 @@ template <class _CharT, class _Traits>
 class __lookahead;
 
 template <class _CharT, class _Traits = regex_traits<_CharT> >
-class _LIBCPP_TEMPLATE_VIS basic_regex;
+class basic_regex;
 
 typedef basic_regex<char> regex;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
@@ -2271,8 +2271,7 @@ typedef basic_regex<wchar_t> wregex;
 #  endif
 
 template <class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(regex)
-    _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wregex)) basic_regex {
+class _LIBCPP_PREFERRED_NAME(regex) _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wregex)) basic_regex {
 public:
   // types:
   typedef _CharT value_type;
@@ -4191,9 +4190,8 @@ typedef sub_match<wstring::const_iterator> wssub_match;
 #  endif
 
 template <class _BidirectionalIterator>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(csub_match)
-    _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wcsub_match)) _LIBCPP_PREFERRED_NAME(ssub_match)
-        _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wssub_match)) sub_match
+class _LIBCPP_PREFERRED_NAME(csub_match) _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wcsub_match))
+    _LIBCPP_PREFERRED_NAME(ssub_match) _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wssub_match)) sub_match
     : public pair<_BidirectionalIterator, _BidirectionalIterator> {
 public:
   typedef _BidirectionalIterator iterator;
@@ -4537,7 +4535,7 @@ typedef match_results<wstring::const_iterator> wsmatch;
 #  endif
 
 template <class _BidirectionalIterator, class _Allocator>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(cmatch) _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wcmatch))
+class _LIBCPP_PREFERRED_NAME(cmatch) _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wcmatch))
     _LIBCPP_PREFERRED_NAME(smatch) _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wsmatch)) match_results {
 public:
   typedef _Allocator allocator_type;
@@ -5322,7 +5320,7 @@ regex_match(const basic_string<_CharT, _ST, _SA>& __s,
 template <class _BidirectionalIterator,
           class _CharT  = typename iterator_traits<_BidirectionalIterator>::value_type,
           class _Traits = regex_traits<_CharT> >
-class _LIBCPP_TEMPLATE_VIS regex_iterator;
+class regex_iterator;
 
 typedef regex_iterator<const char*> cregex_iterator;
 typedef regex_iterator<string::const_iterator> sregex_iterator;
@@ -5332,9 +5330,9 @@ typedef regex_iterator<wstring::const_iterator> wsregex_iterator;
 #  endif
 
 template <class _BidirectionalIterator, class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(cregex_iterator)
-    _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wcregex_iterator)) _LIBCPP_PREFERRED_NAME(sregex_iterator)
-        _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wsregex_iterator)) regex_iterator {
+class _LIBCPP_PREFERRED_NAME(cregex_iterator) _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wcregex_iterator))
+    _LIBCPP_PREFERRED_NAME(sregex_iterator) _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wsregex_iterator))
+        regex_iterator {
 public:
   typedef basic_regex<_CharT, _Traits> regex_type;
   typedef match_results<_BidirectionalIterator> value_type;
@@ -5452,7 +5450,7 @@ regex_iterator<_BidirectionalIterator, _CharT, _Traits>::operator++() {
 template <class _BidirectionalIterator,
           class _CharT  = typename iterator_traits<_BidirectionalIterator>::value_type,
           class _Traits = regex_traits<_CharT> >
-class _LIBCPP_TEMPLATE_VIS regex_token_iterator;
+class regex_token_iterator;
 
 typedef regex_token_iterator<const char*> cregex_token_iterator;
 typedef regex_token_iterator<string::const_iterator> sregex_token_iterator;
@@ -5462,7 +5460,7 @@ typedef regex_token_iterator<wstring::const_iterator> wsregex_token_iterator;
 #  endif
 
 template <class _BidirectionalIterator, class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(cregex_token_iterator)
+class _LIBCPP_PREFERRED_NAME(cregex_token_iterator)
     _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wcregex_token_iterator))
         _LIBCPP_PREFERRED_NAME(sregex_token_iterator)
             _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wsregex_token_iterator)) regex_token_iterator {

--- a/libcxx/include/scoped_allocator
+++ b/libcxx/include/scoped_allocator
@@ -334,7 +334,7 @@ struct __outermost<_Alloc, true> {
 };
 
 template <class _OuterAlloc, class... _InnerAllocs>
-class _LIBCPP_TEMPLATE_VIS scoped_allocator_adaptor<_OuterAlloc, _InnerAllocs...>
+class scoped_allocator_adaptor<_OuterAlloc, _InnerAllocs...>
     : public __scoped_allocator_storage<_OuterAlloc, _InnerAllocs...> {
   typedef __scoped_allocator_storage<_OuterAlloc, _InnerAllocs...> _Base;
   typedef allocator_traits<_OuterAlloc> _OuterTraits;

--- a/libcxx/include/set
+++ b/libcxx/include/set
@@ -571,7 +571,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Key, class _Compare, class _Allocator>
-class _LIBCPP_TEMPLATE_VIS set {
+class set {
 public:
   // types:
   typedef _Key key_type;
@@ -609,9 +609,9 @@ public:
 #  endif
 
   template <class _Key2, class _Compare2, class _Alloc2>
-  friend class _LIBCPP_TEMPLATE_VIS set;
+  friend class set;
   template <class _Key2, class _Compare2, class _Alloc2>
-  friend class _LIBCPP_TEMPLATE_VIS multiset;
+  friend class multiset;
 
   _LIBCPP_HIDE_FROM_ABI set() _NOEXCEPT_(
       is_nothrow_default_constructible<allocator_type>::value&& is_nothrow_default_constructible<key_compare>::value&&
@@ -1033,7 +1033,7 @@ struct __container_traits<set<_Key, _Compare, _Allocator> > {
 };
 
 template <class _Key, class _Compare, class _Allocator>
-class _LIBCPP_TEMPLATE_VIS multiset {
+class multiset {
 public:
   // types:
   typedef _Key key_type;
@@ -1070,9 +1070,9 @@ public:
 #  endif
 
   template <class _Key2, class _Compare2, class _Alloc2>
-  friend class _LIBCPP_TEMPLATE_VIS set;
+  friend class set;
   template <class _Key2, class _Compare2, class _Alloc2>
-  friend class _LIBCPP_TEMPLATE_VIS multiset;
+  friend class multiset;
 
   // construct/copy/destroy:
   _LIBCPP_HIDE_FROM_ABI multiset() _NOEXCEPT_(

--- a/libcxx/include/span
+++ b/libcxx/include/span
@@ -229,7 +229,7 @@ template <class _Sentinel, class _It>
 concept __span_compatible_sentinel_for = sized_sentinel_for<_Sentinel, _It> && !is_convertible_v<_Sentinel, size_t>;
 
 template <typename _Tp, size_t _Extent>
-class _LIBCPP_TEMPLATE_VIS span {
+class span {
 public:
   //  constants and types
   using element_type    = _Tp;
@@ -412,7 +412,7 @@ private:
 };
 
 template <typename _Tp>
-class _LIBCPP_TEMPLATE_VIS span<_Tp, dynamic_extent> {
+class span<_Tp, dynamic_extent> {
 public:
   //  constants and types
   using element_type    = _Tp;

--- a/libcxx/include/sstream
+++ b/libcxx/include/sstream
@@ -342,7 +342,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // Class template basic_stringbuf [stringbuf]
 
 template <class _CharT, class _Traits, class _Allocator>
-class _LIBCPP_TEMPLATE_VIS basic_stringbuf : public basic_streambuf<_CharT, _Traits> {
+class basic_stringbuf : public basic_streambuf<_CharT, _Traits> {
 public:
   typedef _CharT char_type;
   typedef _Traits traits_type;
@@ -864,7 +864,7 @@ typename basic_stringbuf<_CharT, _Traits, _Allocator>::pos_type basic_stringbuf<
 // Class template basic_istringstream [istringstream]
 
 template <class _CharT, class _Traits, class _Allocator>
-class _LIBCPP_TEMPLATE_VIS basic_istringstream : public basic_istream<_CharT, _Traits> {
+class basic_istringstream : public basic_istream<_CharT, _Traits> {
 public:
   typedef _CharT char_type;
   typedef _Traits traits_type;
@@ -1000,7 +1000,7 @@ swap(basic_istringstream<_CharT, _Traits, _Allocator>& __x, basic_istringstream<
 // Class template basic_ostringstream [ostringstream]
 
 template <class _CharT, class _Traits, class _Allocator>
-class _LIBCPP_TEMPLATE_VIS basic_ostringstream : public basic_ostream<_CharT, _Traits> {
+class basic_ostringstream : public basic_ostream<_CharT, _Traits> {
 public:
   typedef _CharT char_type;
   typedef _Traits traits_type;
@@ -1138,7 +1138,7 @@ swap(basic_ostringstream<_CharT, _Traits, _Allocator>& __x, basic_ostringstream<
 // Class template basic_stringstream [stringstream]
 
 template <class _CharT, class _Traits, class _Allocator>
-class _LIBCPP_TEMPLATE_VIS basic_stringstream : public basic_iostream<_CharT, _Traits> {
+class basic_stringstream : public basic_iostream<_CharT, _Traits> {
 public:
   typedef _CharT char_type;
   typedef _Traits traits_type;

--- a/libcxx/include/stack
+++ b/libcxx/include/stack
@@ -153,7 +153,7 @@ template <class _Tp, class _Container>
 _LIBCPP_HIDE_FROM_ABI bool operator<(const stack<_Tp, _Container>& __x, const stack<_Tp, _Container>& __y);
 
 template <class _Tp, class _Container /*= deque<_Tp>*/>
-class _LIBCPP_TEMPLATE_VIS stack {
+class stack {
 public:
   typedef _Container container_type;
   typedef typename container_type::value_type value_type;
@@ -366,8 +366,7 @@ inline _LIBCPP_HIDE_FROM_ABI void swap(stack<_Tp, _Container>& __x, stack<_Tp, _
 }
 
 template <class _Tp, class _Container, class _Alloc>
-struct _LIBCPP_TEMPLATE_VIS uses_allocator<stack<_Tp, _Container>, _Alloc> : public uses_allocator<_Container, _Alloc> {
-};
+struct uses_allocator<stack<_Tp, _Container>, _Alloc> : public uses_allocator<_Container, _Alloc> {};
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/streambuf
+++ b/libcxx/include/streambuf
@@ -134,7 +134,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS basic_streambuf {
+class basic_streambuf {
 public:
   // types:
   typedef _CharT char_type;

--- a/libcxx/include/syncstream
+++ b/libcxx/include/syncstream
@@ -248,7 +248,7 @@ private:
 // Therefore the allocator used in the constructor is passed to the
 // basic_string. The class does not keep a copy of this allocator.
 template <class _CharT, class _Traits, class _Allocator>
-class _LIBCPP_TEMPLATE_VIS basic_syncbuf : public basic_streambuf<_CharT, _Traits> {
+class basic_syncbuf : public basic_streambuf<_CharT, _Traits> {
 public:
   using char_type      = _CharT;
   using traits_type    = _Traits;
@@ -439,7 +439,7 @@ swap(basic_syncbuf<_CharT, _Traits, _Allocator>& __lhs, basic_syncbuf<_CharT, _T
 // basic_osyncstream
 
 template <class _CharT, class _Traits, class _Allocator>
-class _LIBCPP_TEMPLATE_VIS basic_osyncstream : public basic_ostream<_CharT, _Traits> {
+class basic_osyncstream : public basic_ostream<_CharT, _Traits> {
 public:
   using char_type   = _CharT;
   using traits_type = _Traits;

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -535,7 +535,7 @@ __memberwise_forward_assign(_Dest& __dest, _Source&& __source, __tuple_types<_Up
 }
 
 template <class... _Tp>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_NO_SPECIALIZATIONS tuple {
+class _LIBCPP_NO_SPECIALIZATIONS tuple {
   typedef __tuple_impl<typename __make_tuple_indices<sizeof...(_Tp)>::type, _Tp...> _BaseT;
 
   _BaseT __base_;
@@ -1010,7 +1010,7 @@ _LIBCPP_DIAGNOSTIC_PUSH
 _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Winvalid-specialization")
 #    endif
 template <>
-class _LIBCPP_TEMPLATE_VIS tuple<> {
+class tuple<> {
 public:
   constexpr tuple() _NOEXCEPT = default;
   template <class _Alloc>
@@ -1366,7 +1366,7 @@ tuple_cat(_Tuple0&& __t0, _Tuples&&... __tpls) {
 }
 
 template <class... _Tp, class _Alloc>
-struct _LIBCPP_TEMPLATE_VIS uses_allocator<tuple<_Tp...>, _Alloc> : true_type {};
+struct uses_allocator<tuple<_Tp...>, _Alloc> : true_type {};
 
 #    if _LIBCPP_STD_VER >= 17
 #      define _LIBCPP_NOEXCEPT_RETURN(...)                                                                             \

--- a/libcxx/include/typeindex
+++ b/libcxx/include/typeindex
@@ -62,7 +62,7 @@ struct hash<type_index>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-class _LIBCPP_TEMPLATE_VIS type_index {
+class type_index {
   const type_info* __t_;
 
 public:
@@ -91,10 +91,10 @@ public:
 };
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS hash;
+struct hash;
 
 template <>
-struct _LIBCPP_TEMPLATE_VIS hash<type_index> : public __unary_function<type_index, size_t> {
+struct hash<type_index> : public __unary_function<type_index, size_t> {
   _LIBCPP_HIDE_FROM_ABI size_t operator()(type_index __index) const _NOEXCEPT { return __index.hash_code(); }
 };
 

--- a/libcxx/include/typeinfo
+++ b/libcxx/include/typeinfo
@@ -354,7 +354,7 @@ public:
 
 #  if defined(_LIBCPP_ABI_VCRUNTIME) && _HAS_EXCEPTIONS == 0
 
-namespace std {
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 
 class bad_cast : public exception {
 public:
@@ -372,7 +372,7 @@ private:
   bad_typeid(const char* const __message) _NOEXCEPT : exception(__message) {}
 };
 
-} // namespace std
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 
 #  endif // defined(_LIBCPP_ABI_VCRUNTIME) && _HAS_EXCEPTIONS == 0
 

--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -925,7 +925,7 @@ public:
 #  endif
 
 template <class _HashIterator>
-class _LIBCPP_TEMPLATE_VIS __hash_map_iterator {
+class __hash_map_iterator {
   _HashIterator __i_;
 
   typedef __hash_node_types_from_iterator<_HashIterator> _NodeTypes;
@@ -964,19 +964,19 @@ public:
 #  endif
 
   template <class, class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_map;
+  friend class unordered_map;
   template <class, class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_multimap;
+  friend class unordered_multimap;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __hash_const_iterator;
+  friend class __hash_const_iterator;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __hash_const_local_iterator;
+  friend class __hash_const_local_iterator;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __hash_map_const_iterator;
+  friend class __hash_map_const_iterator;
 };
 
 template <class _HashIterator>
-class _LIBCPP_TEMPLATE_VIS __hash_map_const_iterator {
+class __hash_map_const_iterator {
   _HashIterator __i_;
 
   typedef __hash_node_types_from_iterator<_HashIterator> _NodeTypes;
@@ -1020,13 +1020,13 @@ public:
 #  endif
 
   template <class, class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_map;
+  friend class unordered_map;
   template <class, class, class, class, class>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_multimap;
+  friend class unordered_multimap;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __hash_const_iterator;
+  friend class __hash_const_iterator;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS __hash_const_local_iterator;
+  friend class __hash_const_local_iterator;
 };
 
 template <class _Key, class _Tp, class _Hash, class _Pred, class _Alloc>
@@ -1037,7 +1037,7 @@ template <class _Key,
           class _Hash  = hash<_Key>,
           class _Pred  = equal_to<_Key>,
           class _Alloc = allocator<pair<const _Key, _Tp> > >
-class _LIBCPP_TEMPLATE_VIS unordered_map {
+class unordered_map {
 public:
   // types
   typedef _Key key_type;
@@ -1093,9 +1093,9 @@ public:
 #  endif
 
   template <class _Key2, class _Tp2, class _Hash2, class _Pred2, class _Alloc2>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_map;
+  friend class unordered_map;
   template <class _Key2, class _Tp2, class _Hash2, class _Pred2, class _Alloc2>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_multimap;
+  friend class unordered_multimap;
 
   _LIBCPP_HIDE_FROM_ABI unordered_map() _NOEXCEPT_(is_nothrow_default_constructible<__table>::value) {}
   explicit _LIBCPP_HIDE_FROM_ABI
@@ -1850,7 +1850,7 @@ template <class _Key,
           class _Hash  = hash<_Key>,
           class _Pred  = equal_to<_Key>,
           class _Alloc = allocator<pair<const _Key, _Tp> > >
-class _LIBCPP_TEMPLATE_VIS unordered_multimap {
+class unordered_multimap {
 public:
   // types
   typedef _Key key_type;
@@ -1901,9 +1901,9 @@ public:
 #  endif
 
   template <class _Key2, class _Tp2, class _Hash2, class _Pred2, class _Alloc2>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_map;
+  friend class unordered_map;
   template <class _Key2, class _Tp2, class _Hash2, class _Pred2, class _Alloc2>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_multimap;
+  friend class unordered_multimap;
 
   _LIBCPP_HIDE_FROM_ABI unordered_multimap() _NOEXCEPT_(is_nothrow_default_constructible<__table>::value) {}
   explicit _LIBCPP_HIDE_FROM_ABI

--- a/libcxx/include/unordered_set
+++ b/libcxx/include/unordered_set
@@ -594,7 +594,7 @@ template <class _Value, class _Hash, class _Pred, class _Alloc>
 class unordered_multiset;
 
 template <class _Value, class _Hash = hash<_Value>, class _Pred = equal_to<_Value>, class _Alloc = allocator<_Value> >
-class _LIBCPP_TEMPLATE_VIS unordered_set {
+class unordered_set {
 public:
   // types
   typedef _Value key_type;
@@ -630,9 +630,9 @@ public:
 #  endif
 
   template <class _Value2, class _Hash2, class _Pred2, class _Alloc2>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_set;
+  friend class unordered_set;
   template <class _Value2, class _Hash2, class _Pred2, class _Alloc2>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_multiset;
+  friend class unordered_multiset;
 
   _LIBCPP_HIDE_FROM_ABI unordered_set() _NOEXCEPT_(is_nothrow_default_constructible<__table>::value) {}
   explicit _LIBCPP_HIDE_FROM_ABI
@@ -1199,7 +1199,7 @@ struct __container_traits<unordered_set<_Value, _Hash, _Pred, _Alloc> > {
 };
 
 template <class _Value, class _Hash = hash<_Value>, class _Pred = equal_to<_Value>, class _Alloc = allocator<_Value> >
-class _LIBCPP_TEMPLATE_VIS unordered_multiset {
+class unordered_multiset {
 public:
   // types
   typedef _Value key_type;
@@ -1233,9 +1233,9 @@ public:
 #  endif
 
   template <class _Value2, class _Hash2, class _Pred2, class _Alloc2>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_set;
+  friend class unordered_set;
   template <class _Value2, class _Hash2, class _Pred2, class _Alloc2>
-  friend class _LIBCPP_TEMPLATE_VIS unordered_multiset;
+  friend class unordered_multiset;
 
   _LIBCPP_HIDE_FROM_ABI unordered_multiset() _NOEXCEPT_(is_nothrow_default_constructible<__table>::value) {}
   explicit _LIBCPP_HIDE_FROM_ABI

--- a/libcxx/include/valarray
+++ b/libcxx/include/valarray
@@ -382,9 +382,9 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS valarray;
+class valarray;
 
-class _LIBCPP_TEMPLATE_VIS slice {
+class slice {
   size_t __start_;
   size_t __size_;
   size_t __stride_;
@@ -409,14 +409,14 @@ public:
 };
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS slice_array;
+class slice_array;
 class _LIBCPP_EXPORTED_FROM_ABI gslice;
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS gslice_array;
+class gslice_array;
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS mask_array;
+class mask_array;
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS indirect_array;
+class indirect_array;
 
 template <class _Tp>
 _LIBCPP_HIDE_FROM_ABI _Tp* begin(valarray<_Tp>& __v);
@@ -638,7 +638,7 @@ public:
   template <class>
   friend class __val_expr;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS valarray;
+  friend class valarray;
 };
 
 template <class _ValExpr>
@@ -780,7 +780,7 @@ template <class _Tp>
 struct __val_expr_use_member_functions<indirect_array<_Tp> > : true_type {};
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS valarray {
+class valarray {
 public:
   typedef _Tp value_type;
   typedef _Tp __result_type;
@@ -918,17 +918,17 @@ public:
 
 private:
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS valarray;
+  friend class valarray;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS slice_array;
+  friend class slice_array;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS gslice_array;
+  friend class gslice_array;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS mask_array;
+  friend class mask_array;
   template <class>
   friend class __mask_expr;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS indirect_array;
+  friend class indirect_array;
   template <class>
   friend class __indirect_expr;
   template <class>
@@ -1038,7 +1038,7 @@ struct _BinaryOp<_Op, valarray<_Tp>, valarray<_Tp> > {
 // slice_array
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS slice_array {
+class slice_array {
 public:
   typedef _Tp value_type;
 
@@ -1268,7 +1268,7 @@ private:
 // gslice_array
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS gslice_array {
+class gslice_array {
 public:
   typedef _Tp value_type;
 
@@ -1453,7 +1453,7 @@ inline void gslice_array<_Tp>::operator=(const value_type& __x) const {
 // mask_array
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS mask_array {
+class mask_array {
 public:
   typedef _Tp value_type;
 
@@ -1658,7 +1658,7 @@ public:
 // indirect_array
 
 template <class _Tp>
-class _LIBCPP_TEMPLATE_VIS indirect_array {
+class indirect_array {
 public:
   typedef _Tp value_type;
 
@@ -1860,7 +1860,7 @@ public:
   template <class>
   friend class __val_expr;
   template <class>
-  friend class _LIBCPP_TEMPLATE_VIS valarray;
+  friend class valarray;
 };
 
 template <class _ValExpr>

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -317,29 +317,29 @@ __throw_bad_variant_access() {
 
 // variant_size
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS variant_size<const _Tp> : variant_size<_Tp> {};
+struct variant_size<const _Tp> : variant_size<_Tp> {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS variant_size<volatile _Tp> : variant_size<_Tp> {};
+struct variant_size<volatile _Tp> : variant_size<_Tp> {};
 
 template <class _Tp>
-struct _LIBCPP_TEMPLATE_VIS variant_size<const volatile _Tp> : variant_size<_Tp> {};
+struct variant_size<const volatile _Tp> : variant_size<_Tp> {};
 
 template <class... _Types>
-struct _LIBCPP_TEMPLATE_VIS variant_size<variant<_Types...>> : integral_constant<size_t, sizeof...(_Types)> {};
+struct variant_size<variant<_Types...>> : integral_constant<size_t, sizeof...(_Types)> {};
 
 // variant_alternative
 template <size_t _Ip, class _Tp>
-struct _LIBCPP_TEMPLATE_VIS variant_alternative<_Ip, const _Tp> : add_const<variant_alternative_t<_Ip, _Tp>> {};
+struct variant_alternative<_Ip, const _Tp> : add_const<variant_alternative_t<_Ip, _Tp>> {};
 
 template <size_t _Ip, class _Tp>
-struct _LIBCPP_TEMPLATE_VIS variant_alternative<_Ip, volatile _Tp> : add_volatile<variant_alternative_t<_Ip, _Tp>> {};
+struct variant_alternative<_Ip, volatile _Tp> : add_volatile<variant_alternative_t<_Ip, _Tp>> {};
 
 template <size_t _Ip, class _Tp>
-struct _LIBCPP_TEMPLATE_VIS variant_alternative<_Ip, const volatile _Tp> : add_cv<variant_alternative_t<_Ip, _Tp>> {};
+struct variant_alternative<_Ip, const volatile _Tp> : add_cv<variant_alternative_t<_Ip, _Tp>> {};
 
 template <size_t _Ip, class... _Types>
-struct _LIBCPP_TEMPLATE_VIS variant_alternative<_Ip, variant<_Types...>> {
+struct variant_alternative<_Ip, variant<_Types...>> {
   static_assert(_Ip < sizeof...(_Types), "Index out of bounds in std::variant_alternative<>");
   using type _LIBCPP_NODEBUG = __type_pack_element<_Ip, _Types...>;
 };
@@ -658,7 +658,7 @@ private:
 #    define _LIBCPP_EAT_SEMICOLON static_assert(true, "")
 
 template <size_t _Index, class _Tp>
-struct _LIBCPP_TEMPLATE_VIS __alt {
+struct __alt {
   using __value_type _LIBCPP_NODEBUG = _Tp;
   static constexpr size_t __index    = _Index;
 
@@ -670,14 +670,14 @@ struct _LIBCPP_TEMPLATE_VIS __alt {
 };
 
 template <_Trait _DestructibleTrait, size_t _Index, class... _Types>
-union _LIBCPP_TEMPLATE_VIS __union;
+union __union;
 
 template <_Trait _DestructibleTrait, size_t _Index>
-union _LIBCPP_TEMPLATE_VIS __union<_DestructibleTrait, _Index> {};
+union __union<_DestructibleTrait, _Index> {};
 
 #    define _LIBCPP_VARIANT_UNION(destructible_trait, destructor_definition)                                           \
       template <size_t _Index, class _Tp, class... _Types>                                                             \
-      union _LIBCPP_TEMPLATE_VIS __union<destructible_trait, _Index, _Tp, _Types...> {                                 \
+      union __union<destructible_trait, _Index, _Tp, _Types...> {                                                      \
       public:                                                                                                          \
         _LIBCPP_HIDE_FROM_ABI explicit constexpr __union(__valueless_t) noexcept : __dummy{} {}                        \
                                                                                                                        \
@@ -712,7 +712,7 @@ _LIBCPP_VARIANT_UNION(_Trait::_Unavailable, _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTE
 #    undef _LIBCPP_VARIANT_UNION
 
 template <_Trait _DestructibleTrait, class... _Types>
-class _LIBCPP_TEMPLATE_VIS __base {
+class __base {
 public:
   using __index_t _LIBCPP_NODEBUG = __variant_index_t<sizeof...(_Types)>;
 
@@ -748,12 +748,11 @@ protected:
 };
 
 template <class _Traits, _Trait = _Traits::__destructible_trait>
-class _LIBCPP_TEMPLATE_VIS __dtor;
+class __dtor;
 
 #    define _LIBCPP_VARIANT_DESTRUCTOR(destructible_trait, destructor_definition, destroy)                             \
       template <class... _Types>                                                                                       \
-      class _LIBCPP_TEMPLATE_VIS __dtor<__traits<_Types...>, destructible_trait>                                       \
-          : public __base<destructible_trait, _Types...> {                                                             \
+      class __dtor<__traits<_Types...>, destructible_trait> : public __base<destructible_trait, _Types...> {           \
         using __base_type _LIBCPP_NODEBUG = __base<destructible_trait, _Types...>;                                     \
         using __index_t _LIBCPP_NODEBUG   = typename __base_type::__index_t;                                           \
                                                                                                                        \
@@ -799,7 +798,7 @@ _LIBCPP_VARIANT_DESTRUCTOR(_Trait::_Unavailable,
 #    undef _LIBCPP_VARIANT_DESTRUCTOR
 
 template <class _Traits>
-class _LIBCPP_TEMPLATE_VIS __ctor : public __dtor<_Traits> {
+class __ctor : public __dtor<_Traits> {
   using __base_type _LIBCPP_NODEBUG = __dtor<_Traits>;
 
 public:
@@ -826,12 +825,11 @@ protected:
 };
 
 template <class _Traits, _Trait = _Traits::__move_constructible_trait>
-class _LIBCPP_TEMPLATE_VIS __move_constructor;
+class __move_constructor;
 
 #    define _LIBCPP_VARIANT_MOVE_CONSTRUCTOR(move_constructible_trait, move_constructor_definition)                    \
       template <class... _Types>                                                                                       \
-      class _LIBCPP_TEMPLATE_VIS __move_constructor<__traits<_Types...>, move_constructible_trait>                     \
-          : public __ctor<__traits<_Types...>> {                                                                       \
+      class __move_constructor<__traits<_Types...>, move_constructible_trait> : public __ctor<__traits<_Types...>> {   \
         using __base_type _LIBCPP_NODEBUG = __ctor<__traits<_Types...>>;                                               \
                                                                                                                        \
       public:                                                                                                          \
@@ -864,11 +862,11 @@ _LIBCPP_VARIANT_MOVE_CONSTRUCTOR(
 #    undef _LIBCPP_VARIANT_MOVE_CONSTRUCTOR
 
 template <class _Traits, _Trait = _Traits::__copy_constructible_trait>
-class _LIBCPP_TEMPLATE_VIS __copy_constructor;
+class __copy_constructor;
 
 #    define _LIBCPP_VARIANT_COPY_CONSTRUCTOR(copy_constructible_trait, copy_constructor_definition)                    \
       template <class... _Types>                                                                                       \
-      class _LIBCPP_TEMPLATE_VIS __copy_constructor<__traits<_Types...>, copy_constructible_trait>                     \
+      class __copy_constructor<__traits<_Types...>, copy_constructible_trait>                                          \
           : public __move_constructor<__traits<_Types...>> {                                                           \
         using __base_type _LIBCPP_NODEBUG = __move_constructor<__traits<_Types...>>;                                   \
                                                                                                                        \
@@ -899,7 +897,7 @@ _LIBCPP_VARIANT_COPY_CONSTRUCTOR(
 #    undef _LIBCPP_VARIANT_COPY_CONSTRUCTOR
 
 template <class _Traits>
-class _LIBCPP_TEMPLATE_VIS __assignment : public __copy_constructor<_Traits> {
+class __assignment : public __copy_constructor<_Traits> {
   using __base_type _LIBCPP_NODEBUG = __copy_constructor<_Traits>;
 
 public:
@@ -953,12 +951,11 @@ protected:
 };
 
 template <class _Traits, _Trait = _Traits::__move_assignable_trait>
-class _LIBCPP_TEMPLATE_VIS __move_assignment;
+class __move_assignment;
 
 #    define _LIBCPP_VARIANT_MOVE_ASSIGNMENT(move_assignable_trait, move_assignment_definition)                         \
       template <class... _Types>                                                                                       \
-      class _LIBCPP_TEMPLATE_VIS __move_assignment<__traits<_Types...>, move_assignable_trait>                         \
-          : public __assignment<__traits<_Types...>> {                                                                 \
+      class __move_assignment<__traits<_Types...>, move_assignable_trait> : public __assignment<__traits<_Types...>> { \
         using __base_type _LIBCPP_NODEBUG = __assignment<__traits<_Types...>>;                                         \
                                                                                                                        \
       public:                                                                                                          \
@@ -992,11 +989,11 @@ _LIBCPP_VARIANT_MOVE_ASSIGNMENT(
 #    undef _LIBCPP_VARIANT_MOVE_ASSIGNMENT
 
 template <class _Traits, _Trait = _Traits::__copy_assignable_trait>
-class _LIBCPP_TEMPLATE_VIS __copy_assignment;
+class __copy_assignment;
 
 #    define _LIBCPP_VARIANT_COPY_ASSIGNMENT(copy_assignable_trait, copy_assignment_definition)                         \
       template <class... _Types>                                                                                       \
-      class _LIBCPP_TEMPLATE_VIS __copy_assignment<__traits<_Types...>, copy_assignable_trait>                         \
+      class __copy_assignment<__traits<_Types...>, copy_assignable_trait>                                              \
           : public __move_assignment<__traits<_Types...>> {                                                            \
         using __base_type _LIBCPP_NODEBUG = __move_assignment<__traits<_Types...>>;                                    \
                                                                                                                        \
@@ -1030,7 +1027,7 @@ _LIBCPP_VARIANT_COPY_ASSIGNMENT(_Trait::_Unavailable,
 #    undef _LIBCPP_VARIANT_COPY_ASSIGNMENT
 
 template <class... _Types>
-class _LIBCPP_TEMPLATE_VIS __impl : public __copy_assignment<__traits<_Types...>> {
+class __impl : public __copy_assignment<__traits<_Types...>> {
   using __base_type _LIBCPP_NODEBUG = __copy_assignment<__traits<_Types...>>;
 
 public:
@@ -1157,7 +1154,7 @@ visit(_Visitor&& __visitor, _Vs&&... __vs);
 #    endif
 
 template <class... _Types>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_DECLSPEC_EMPTY_BASES _LIBCPP_NO_SPECIALIZATIONS variant
+class _LIBCPP_DECLSPEC_EMPTY_BASES _LIBCPP_NO_SPECIALIZATIONS variant
     : private __sfinae_ctor_base< __all<is_copy_constructible_v<_Types>...>::value,
                                   __all<is_move_constructible_v<_Types>...>::value>,
       private __sfinae_assign_base<
@@ -1585,7 +1582,7 @@ swap(variant<_Types...>& __lhs,
 }
 
 template <class... _Types>
-struct _LIBCPP_TEMPLATE_VIS hash< __enable_hash_helper<variant<_Types...>, remove_const_t<_Types>...>> {
+struct hash< __enable_hash_helper<variant<_Types...>, remove_const_t<_Types>...>> {
 #    if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_BINDER_TYPEDEFS)
   using argument_type _LIBCPP_DEPRECATED_IN_CXX17 = variant<_Types...>;
   using result_type _LIBCPP_DEPRECATED_IN_CXX17   = size_t;

--- a/libcxx/include/variant
+++ b/libcxx/include/variant
@@ -283,14 +283,14 @@ namespace std {
 _LIBCPP_PUSH_MACROS
 #  include <__undef_macros>
 
-namespace std { // explicitly not using versioning namespace
+_LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 
 class _LIBCPP_EXPORTED_FROM_ABI _LIBCPP_AVAILABILITY_BAD_VARIANT_ACCESS bad_variant_access : public exception {
 public:
   const char* what() const _NOEXCEPT override;
 };
 
-} // namespace std
+_LIBCPP_END_UNVERSIONED_NAMESPACE_STD
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 


### PR DESCRIPTION
Since almost all of our symbols are explicitly annotated with visibility macros, this makes almost no difference to the actual visibility of symbols. Not having to annotate types at the cost of having a few more symbols with default visibility on GCC seems like the right choice to me.
