### PR TITLE
[flang] Include needed CMake files.

### DIFF
--- a/flang/cmake/modules/FlangCommon.cmake
+++ b/flang/cmake/modules/FlangCommon.cmake
@@ -10,6 +10,9 @@
 #
 #===------------------------------------------------------------------------===#
 
+include(CheckCSourceCompiles)
+include(CheckIncludeFile)
+
 # The out of tree builds of the compiler and the Fortran runtime
 # must use the same setting of FLANG_RUNTIME_F128_MATH_LIB
 # to be composable. Failure to synchronize this setting may result


### PR DESCRIPTION
`FlangCommon.cmake` uses some CMake macros without including
the corresponding modules. This change makes it self-sufficient.
