### PR TITLE
Change check for "shift > Type::BITS" to avoid offset greater than total bits.

### DIFF
--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -335,7 +335,7 @@ template <size_t Bits> struct DyadicFloat {
                  .get_val();
 
     MantissaType round_mask =
-        shift > MantissaType::BITS ? 0 : MantissaType(1) << (shift - 1);
+        shift - 1 >= MantissaType::BITS ? 0 : MantissaType(1) << (shift - 1);
     MantissaType sticky_mask = round_mask - MantissaType(1);
 
     bool round_bit = !(mantissa & round_mask).is_zero();


### PR DESCRIPTION
nexttowardf16_test is resulting in calling shift and for some reason not meeting the invariant where offset is less than bits. Change the if statement to directly check if shift - 1 meets the conditions. 