### PR TITLE
[clang-tidy][misc-const-correctness] fix fp when using const array type.

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
@@ -81,16 +81,14 @@ void ConstCorrectnessCheck::storeOptions(ClangTidyOptions::OptionMap &Opts) {
 }
 
 void ConstCorrectnessCheck::registerMatchers(MatchFinder *Finder) {
-  const auto ConstType = hasType(
-      qualType(isConstQualified(),
-               // pointee check will check the const pointer and const array
-               unless(pointerType()), unless(arrayType())));
+  const auto ConstType =
+      hasType(qualType(isConstQualified(),
+                       // pointee check will check the constness of pointer
+                       unless(pointerType())));
 
   const auto ConstReference = hasType(references(isConstQualified()));
   const auto RValueReference = hasType(
       referenceType(anyOf(rValueReferenceType(), unless(isSpelledAsLValue()))));
-  const auto ConstArrayType =
-      hasType(arrayType(hasElementType(isConstQualified())));
 
   const auto TemplateType = anyOf(
       hasType(hasCanonicalType(templateTypeParmType())),
@@ -117,7 +115,7 @@ void ConstCorrectnessCheck::registerMatchers(MatchFinder *Finder) {
   // Example: `int i = 10` would match `int i`.
   const auto LocalValDecl = varDecl(
       isLocal(), hasInitializer(anything()),
-      unless(anyOf(ConstType, ConstReference, ConstArrayType, TemplateType,
+      unless(anyOf(ConstType, ConstReference, TemplateType,
                    hasInitializer(isInstantiationDependent()), AutoTemplateType,
                    RValueReference, FunctionPointerRef,
                    hasType(cxxRecordDecl(isLambda())), isImplicit(),

--- a/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
@@ -163,7 +163,6 @@ void ConstCorrectnessCheck::check(const MatchFinder::MatchResult &Result) {
 
   VariableCategory VC = VariableCategory::Value;
   const QualType VT = Variable->getType();
-  VT->dump();
   if (VT->isReferenceType()) {
     VC = VariableCategory::Reference;
   } else if (VT->isPointerType()) {

--- a/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
@@ -172,7 +172,6 @@ void ConstCorrectnessCheck::check(const MatchFinder::MatchResult &Result) {
     if (ArrayT->getElementType()->isPointerType())
       VC = VariableCategory::Pointer;
   }
-  llvm::errs() << (int)VC << "\n";
 
   auto CheckValue = [&]() {
     // The scope is only registered if the analysis shall be run.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -146,7 +146,8 @@ Changes in existing checks
   `AllowedTypes`, that excludes specified types from const-correctness
   checking and fixing false positives when modifying variant by ``operator[]``
   with template in parameters and supporting to check pointee mutation by
-  `AnalyzePointers` option.
+  `AnalyzePointers` option and fixing false positives when using const array
+  type.
 
 - Improved :doc:`misc-redundant-expression
   <clang-tidy/checks/misc/redundant-expression>` check by providing additional

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-values.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-values.cpp
@@ -1007,3 +1007,11 @@ template <typename T> void f() {
   x[T{}] = 3;
 }
 } // namespace gh127776_false_positive
+
+namespace gh132931_false_positive {
+using T = const int;
+void valid(int i) {
+  const int arr0[] = {1, 2, 3};
+  T arr1[] = {1, 2, 3};
+}
+} // namespace gh132931_false_positive


### PR DESCRIPTION
Fixed: #132931
const array is immutable in C/C++ language design, we don't need to
check constness for it.
