### PR TITLE
[LLD] Ensure explicit PT_GNU_RELRO has correct p_align

### DIFF
--- a/lld/test/ELF/linkerscript/explicit-relro-phdr.test
+++ b/lld/test/ELF/linkerscript/explicit-relro-phdr.test
@@ -1,0 +1,21 @@
+## Test that a PT_GNU_RELRO phdr explicitly specified via a linker script
+## PHDRS command has the expected flags and alignment.
+
+# REQUIRES: x86
+# RUN: rm -rf %t && split-file %s %t
+# RUN: llvm-mc -filetype=obj -triple=x86_64 %t/relro.s -o %t.o
+
+# RUN: ld.lld %t.o -T %t/test.script -o %t.elf
+# RUN: llvm-readelf -l %t.elf | FileCheck %s
+
+##       Type      Offset  VirtAddr PhysAddr FileSiz MemSiz  Flg Align
+# CHECK: GNU_RELRO 0x[[#]] 0x[[#]]  0x[[#]]  0x[[#]] 0x[[#]] R   0x1
+
+#--- relro.s
+.section .data.rel.ro.test, "aw"
+.align 8
+.quad 0
+
+#--- test.script
+PHDRS { ph_gnu_relro PT_GNU_RELRO FLAGS (0x4); }
+SECTIONS { .data.rel.ro : { *(.data.rel.ro.*) } : ph_gnu_relro }


### PR DESCRIPTION
`PT_GNU_RELRO` was introduced by Jakub Jelinek in https://sourceware.org/legacy-ml/binutils/2004-01/msg00070.html (Jakub Jelinek - [RFC PATCH] Little hardening DSOs/executables against exploits). `p_align` for `PT_GNU_RELRO` has always been set to 1.

There was a regression in behavior for the value of `p_align` for explicitly defined `PT_GNU_RELRO` `phdrs` in:
https://github.com/llvm/llvm-project/commit/5a58e98c2018f8cfea71e34e9717da40201a966b.

Before the above change, `p_align` was set to 1: https://godbolt.org/z/vdEPne7Y7.
After the change, it was set to the largest alignment of any of the assigned sections: https://godbolt.org/z/E7r3xa7qj.

Fix this regression by forcing `p_align` to 1.
