### PR TITLE
[Github] Simplify Getting Changed Files in Code Formatting Workflow

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -21,14 +21,7 @@ jobs:
       - name: Fetch LLVM sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Checkout through merge base
-        uses: rmacklin/fetch-through-merge-base@bfe4d03a86f9afa52bc1a70e9814fc92a07f7b75 # v0.3.0
-        with:
-          base_ref: ${{ github.event.pull_request.base.ref }}
-          head_ref: ${{ github.event.pull_request.head.sha }}
-          deepen_length: 500
+          fetch-depth: 2
 
       - name: Get changed files
         id: changed-files
@@ -36,6 +29,8 @@ jobs:
         with:
           separator: ","
           skip_initial_fetch: true
+          base_sha: 'HEAD~1'
+          sha: 'HEAD'
 
       # We need to pull the script from the main branch, so that we ensure
       # we get the latest version of this script.
@@ -89,8 +84,8 @@ jobs:
             --write-comment-to-file \
             --token ${{ secrets.GITHUB_TOKEN }} \
             --issue-number $GITHUB_PR_NUMBER \
-            --start-rev $(git merge-base $START_REV $END_REV) \
-            --end-rev $END_REV \
+            --start-rev HEAD~1 \
+            --end-rev HEAD \
             --changed-files "$CHANGED_FILES"
 
       - uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 #v4.3.0


### PR DESCRIPTION
This patch changes getting changed files in the pr code format job to just checking out the previous two commits (the merge commit and its porent, the current commit latest in main), which allows us to just diff the merge commit. This means we do not have to checkout the ref through the merge base, which should save approximately a minute per job (or much more in some cases where the PR is particularly out of date).