### PR TITLE
Backport/20.x: [LoongArch] Fix the type of tls-le symbols

### DIFF
--- a/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchMCExpr.cpp
+++ b/llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchMCExpr.cpp
@@ -275,6 +275,7 @@ void LoongArchMCExpr::fixELFSymbolsInTLSFixups(MCAssembler &Asm) const {
   case VK_LoongArch_TLS_GD_HI20:
   case VK_LoongArch_TLS_DESC_PC_HI20:
   case VK_LoongArch_TLS_DESC_HI20:
+  case VK_LoongArch_TLS_LE_HI20_R:
   case VK_LoongArch_TLS_LD_PCREL20_S2:
   case VK_LoongArch_TLS_GD_PCREL20_S2:
   case VK_LoongArch_TLS_DESC_PCREL20_S2:

--- a/llvm/test/CodeGen/LoongArch/fix-tle-le-sym-type.ll
+++ b/llvm/test/CodeGen/LoongArch/fix-tle-le-sym-type.ll
@@ -5,12 +5,12 @@
 ; RUN: llvm-readelf -s %t-la64 | FileCheck %s --check-prefix=LA64
 
 ; LA32:      Symbol table '.symtab' contains [[#]] entries:
-; LA32-NEXT:    Num:    Value  Size Type    Bind   Vis      Ndx Name
-; LA32:              00000000     0 NOTYPE  GLOBAL DEFAULT  UND tls_sym
+; LA32-NEXT:    Num:    Value  Size Type  Bind   Vis      Ndx Name
+; LA32:              00000000     0 TLS   GLOBAL DEFAULT  UND tls_sym
 
 ; LA64:      Symbol table '.symtab' contains [[#]] entries:
-; LA64-NEXT:    Num:    Value          Size Type    Bind   Vis      Ndx Name
-; LA64:              0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND tls_sym
+; LA64-NEXT:    Num:    Value          Size Type  Bind   Vis      Ndx Name
+; LA64:              0000000000000000     0 TLS   GLOBAL DEFAULT  UND tls_sym
 
 @tls_sym = external thread_local(localexec) global i32
 


### PR DESCRIPTION
(cherry picked from commit d6dc74e19f5cdb6995b13329480e330aff113f96)