### PR TITLE
[NFC][X86][ISel] Remove the unused assert

### DIFF
--- a/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/X86/X86ISelDAGToDAG.cpp
@@ -184,8 +184,6 @@ namespace {
 
       // OptFor[Min]Size are used in pattern predicates that isel is matching.
       OptForMinSize = MF.getFunction().hasMinSize();
-      assert((!OptForMinSize || MF.getFunction().hasOptSize()) &&
-             "OptForMinSize implies OptForSize");
       return SelectionDAGISel::runOnMachineFunction(MF);
     }
 


### PR DESCRIPTION
The condition of assert is always true, so just remove it.
OptForMinSize means hasMinSize(), which is hasFnAttribute(Attribute::MinSize). 
hasOptSize() is hasFnAttribute(Attribute::OptimizeForSize) || hasMinSize().
 So, '!hasMinSize() || hasFnAttribute(Attribute::OptimizeForSize) || hasMinSize()' is awalys true.

---------------------------------
llvm/include/llvm/IR/Function.h

```
/// Optimize this function for minimum size (-Oz).
  bool hasMinSize() const { return hasFnAttribute(Attribute::MinSize); }

  /// Optimize this function for size (-Os) or minimum size (-Oz).
  bool hasOptSize() const {
    return hasFnAttribute(Attribute::OptimizeForSize) || hasMinSize();
  }
```