### PR TITLE
[clang-format] Allow `Language: Cpp` for C files

### DIFF
--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -2123,23 +2123,20 @@ std::error_code parseConfiguration(llvm::MemoryBufferRef Config,
   FormatStyle::FormatStyleSet StyleSet;
   bool LanguageFound = false;
   for (const FormatStyle &Style : llvm::reverse(Styles)) {
-    if (Style.Language != FormatStyle::LK_None)
+    const auto Lang = Style.Language;
+    if (Lang != FormatStyle::LK_None)
       StyleSet.Add(Style);
-    if (Style.Language == Language)
+    if (Lang == Language ||
+        // For backward compatibility.
+        (Lang == FormatStyle::LK_Cpp && Language == FormatStyle::LK_C)) {
       LanguageFound = true;
+    }
   }
   if (!LanguageFound) {
-    if (Styles.empty())
+    if (Styles.empty() || Styles[0].Language != FormatStyle::LK_None)
       return make_error_code(ParseError::Unsuitable);
-    auto DefaultStyle = Styles[0];
-    auto &DefaultLanguage = DefaultStyle.Language;
-    if (DefaultLanguage != FormatStyle::LK_None &&
-        // For backward compatibility.
-        !(DefaultLanguage == FormatStyle::LK_Cpp &&
-          Language == FormatStyle::LK_C)) {
-      return make_error_code(ParseError::Unsuitable);
-    }
-    DefaultLanguage = Language;
+    FormatStyle DefaultStyle = Styles[0];
+    DefaultStyle.Language = Language;
     StyleSet.Add(std::move(DefaultStyle));
   }
   *Style = *StyleSet.Get(Language);
@@ -2173,8 +2170,14 @@ FormatStyle::FormatStyleSet::Get(FormatStyle::LanguageKind Language) const {
   if (!Styles)
     return std::nullopt;
   auto It = Styles->find(Language);
-  if (It == Styles->end())
-    return std::nullopt;
+  if (It == Styles->end()) {
+    if (Language != FormatStyle::LK_C)
+      return std::nullopt;
+    // For backward compatibility.
+    It = Styles->find(FormatStyle::LK_Cpp);
+    if (It == Styles->end())
+      return std::nullopt;
+  }
   FormatStyle Style = It->second;
   Style.StyleSet = *this;
   return Style;

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -2129,10 +2129,17 @@ std::error_code parseConfiguration(llvm::MemoryBufferRef Config,
       LanguageFound = true;
   }
   if (!LanguageFound) {
-    if (Styles.empty() || Styles[0].Language != FormatStyle::LK_None)
+    if (Styles.empty())
       return make_error_code(ParseError::Unsuitable);
-    FormatStyle DefaultStyle = Styles[0];
-    DefaultStyle.Language = Language;
+    auto DefaultStyle = Styles[0];
+    auto &DefaultLanguage = DefaultStyle.Language;
+    if (DefaultLanguage != FormatStyle::LK_None &&
+        // For backward compatibility.
+        !(DefaultLanguage == FormatStyle::LK_Cpp &&
+          Language == FormatStyle::LK_C)) {
+      return make_error_code(ParseError::Unsuitable);
+    }
+    DefaultLanguage = Language;
     StyleSet.Add(std::move(DefaultStyle));
   }
   *Style = *StyleSet.Get(Language);

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -1230,6 +1230,12 @@ TEST(ConfigParseTest, ParsesConfigurationWithLanguages) {
               IndentWidth, 56u);
 }
 
+TEST(ConfigParseTest, AllowCppForC) {
+  FormatStyle Style = {};
+  Style.Language = FormatStyle::LK_C;
+  EXPECT_EQ(parseConfiguration("Language: Cpp", &Style), ParseError::Success);
+}
+
 TEST(ConfigParseTest, UsesLanguageForBasedOnStyle) {
   FormatStyle Style = {};
   Style.Language = FormatStyle::LK_JavaScript;

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -1234,6 +1234,20 @@ TEST(ConfigParseTest, AllowCppForC) {
   FormatStyle Style = {};
   Style.Language = FormatStyle::LK_C;
   EXPECT_EQ(parseConfiguration("Language: Cpp", &Style), ParseError::Success);
+
+  CHECK_PARSE("---\n"
+              "IndentWidth: 4\n"
+              "---\n"
+              "Language: Cpp\n"
+              "IndentWidth: 8\n",
+              IndentWidth, 8u);
+
+  EXPECT_EQ(parseConfiguration("---\n"
+                               "Language: ObjC\n"
+                               "---\n"
+                               "Language: Cpp\n",
+                               &Style),
+            ParseError::Success);
 }
 
 TEST(ConfigParseTest, UsesLanguageForBasedOnStyle) {


### PR DESCRIPTION
Fix #132832