### PR TITLE
[clang-repl] Implement LoadDynamicLibrary for clang-repl wasm use cases

### DIFF
--- a/clang/lib/Interpreter/IncrementalExecutor.h
+++ b/clang/lib/Interpreter/IncrementalExecutor.h
@@ -57,7 +57,7 @@ public:
   virtual llvm::Error removeModule(PartialTranslationUnit &PTU);
   virtual llvm::Error runCtors() const;
   virtual llvm::Error cleanUp();
-  llvm::Expected<llvm::orc::ExecutorAddr>
+  virtual llvm::Expected<llvm::orc::ExecutorAddr>
   getSymbolAddress(llvm::StringRef Name, SymbolNameKind NameKind) const;
 
   llvm::orc::LLJIT &GetExecutionEngine() { return *Jit; }

--- a/clang/lib/Interpreter/Interpreter.cpp
+++ b/clang/lib/Interpreter/Interpreter.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Support/VirtualFileSystem.h"
 #ifdef __EMSCRIPTEN__
 #include "Wasm.h"
+#include <dlfcn.h>
 #endif // __EMSCRIPTEN__
 
 #include "clang/AST/ASTConsumer.h"
@@ -711,6 +712,14 @@ llvm::Error Interpreter::Undo(unsigned N) {
 }
 
 llvm::Error Interpreter::LoadDynamicLibrary(const char *name) {
+#ifdef __EMSCRIPTEN__
+  void *handle = dlopen(name, RTLD_NOW | RTLD_GLOBAL);
+  if (!handle) {
+    llvm::errs() << dlerror() << '\n';
+    return llvm::make_error<llvm::StringError>("Failed to load dynamic library",
+                                               llvm::inconvertibleErrorCode());
+  }
+#else
   auto EE = getExecutionEngine();
   if (!EE)
     return EE.takeError();
@@ -722,6 +731,7 @@ llvm::Error Interpreter::LoadDynamicLibrary(const char *name) {
     EE->getMainJITDylib().addGenerator(std::move(*DLSG));
   else
     return DLSG.takeError();
+#endif
 
   return llvm::Error::success();
 }

--- a/clang/lib/Interpreter/Wasm.cpp
+++ b/clang/lib/Interpreter/Wasm.cpp
@@ -144,6 +144,19 @@ llvm::Error WasmIncrementalExecutor::cleanUp() {
   return llvm::Error::success();
 }
 
+llvm::Expected<llvm::orc::ExecutorAddr>
+WasmIncrementalExecutor::getSymbolAddress(llvm::StringRef Name,
+                                          SymbolNameKind NameKind) const {
+  void *Sym = dlsym(RTLD_DEFAULT, Name.str().c_str());
+  if (!Sym) {
+    return llvm::make_error<llvm::StringError>("dlsym failed for symbol: " +
+                                                   Name.str(),
+                                               llvm::inconvertibleErrorCode());
+  }
+
+  return llvm::orc::ExecutorAddr::fromPtr(Sym);
+}
+
 WasmIncrementalExecutor::~WasmIncrementalExecutor() = default;
 
 } // namespace clang

--- a/clang/lib/Interpreter/Wasm.h
+++ b/clang/lib/Interpreter/Wasm.h
@@ -29,6 +29,8 @@ public:
   llvm::Error removeModule(PartialTranslationUnit &PTU) override;
   llvm::Error runCtors() const override;
   llvm::Error cleanUp() override;
+  llvm::Expected<llvm::orc::ExecutorAddr>
+  getSymbolAddress(llvm::StringRef Name, SymbolNameKind NameKind) const;
 
   ~WasmIncrementalExecutor() override;
 };

--- a/clang/lib/Interpreter/Wasm.h
+++ b/clang/lib/Interpreter/Wasm.h
@@ -30,7 +30,7 @@ public:
   llvm::Error runCtors() const override;
   llvm::Error cleanUp() override;
   llvm::Expected<llvm::orc::ExecutorAddr>
-  getSymbolAddress(llvm::StringRef Name, SymbolNameKind NameKind) const;
+  getSymbolAddress(llvm::StringRef Name, SymbolNameKind NameKind) const override;;
 
   ~WasmIncrementalExecutor() override;
 };

--- a/clang/lib/Interpreter/Wasm.h
+++ b/clang/lib/Interpreter/Wasm.h
@@ -30,7 +30,8 @@ public:
   llvm::Error runCtors() const override;
   llvm::Error cleanUp() override;
   llvm::Expected<llvm::orc::ExecutorAddr>
-  getSymbolAddress(llvm::StringRef Name, SymbolNameKind NameKind) const override;;
+  getSymbolAddress(llvm::StringRef Name,
+                   SymbolNameKind NameKind) const override;
 
   ~WasmIncrementalExecutor() override;
 };


### PR DESCRIPTION
**Currently we don't make use of the JIT for the wasm use cases so the approach using the execution engine won't work in these cases.**

Rather if we use dlopen. We should be able to do the following (demonstrating through a toy project)

1) Make use of LoadDynamicLibrary through the given implementation

```
extern "C" EMSCRIPTEN_KEEPALIVE int load_library(const char *name) {
  auto Err = Interp->LoadDynamicLibrary(name);
  if (Err) {
    llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(), "load_library error: ");
    return -1;
  }
  return 0;
}
```
2) Add a button to call load_library once the library has been added in our MEMFS (currently we have symengine built as a SIDE MODULE and we are loading it)



https://github.com/user-attachments/assets/141d48c1-b9a0-4149-b4c8-f978051f2599



