### PR TITLE
[llvm] Use *Set::insert_range (NFC)

### DIFF
--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -5103,8 +5103,7 @@ private:
       indicatePessimisticFixpoint();
       return;
     }
-    for (const MemberTy &C : R.Set)
-      Set.insert(C);
+    Set.insert_range(R.Set);
     UndefIsContained |= R.undefIsContained();
     checkAndInvalidate();
   }

--- a/llvm/include/llvm/Transforms/Utils/LockstepReverseIterator.h
+++ b/llvm/include/llvm/Transforms/Utils/LockstepReverseIterator.h
@@ -57,8 +57,7 @@ public:
     Fail = false;
     if constexpr (!EarlyFailure) {
       this->ActiveBlocks.clear();
-      for (BasicBlock *BB : Blocks)
-        this->ActiveBlocks.insert(BB);
+      this->ActiveBlocks.insert_range(Blocks);
     }
     Insts.clear();
     for (BasicBlock *BB : Blocks) {

--- a/llvm/lib/ExecutionEngine/MCJIT/MCJIT.h
+++ b/llvm/lib/ExecutionEngine/MCJIT/MCJIT.h
@@ -150,8 +150,7 @@ class MCJIT : public ExecutionEngine {
     }
 
     void markAllLoadedModulesAsFinalized() {
-      for (Module *M : LoadedModules)
-        FinalizedModules.insert(M);
+      FinalizedModules.insert_range(LoadedModules);
       LoadedModules.clear();
     }
 

--- a/llvm/lib/ExecutionEngine/Orc/Core.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Core.cpp
@@ -1261,8 +1261,7 @@ JITDylib::RemoveTrackerResult JITDylib::IL_removeTracker(ResourceTracker &RT) {
   if (&RT == DefaultTracker.get()) {
     SymbolNameSet TrackedSymbols;
     for (auto &KV : TrackerSymbols)
-      for (auto &Sym : KV.second)
-        TrackedSymbols.insert(Sym);
+      TrackedSymbols.insert_range(KV.second);
 
     for (auto &KV : Symbols) {
       auto &Sym = KV.first;
@@ -1346,8 +1345,7 @@ void JITDylib::transferTracker(ResourceTracker &DstRT, ResourceTracker &SrcRT) {
       if (DstMRs.empty())
         DstMRs = std::move(SrcMRs);
       else
-        for (auto *MR : SrcMRs)
-          DstMRs.insert(MR);
+        DstMRs.insert_range(SrcMRs);
       // Erase SrcRT entry in TrackerMRs. Use &SrcRT key rather than iterator I
       // for this, since I may have been invalidated by 'TrackerMRs[&DstRT]'.
       TrackerMRs.erase(&SrcRT);
@@ -1371,8 +1369,7 @@ void JITDylib::transferTracker(ResourceTracker &DstRT, ResourceTracker &SrcRT) {
 
     SymbolNameSet CurrentlyTrackedSymbols;
     for (auto &KV : TrackerSymbols)
-      for (auto &Sym : KV.second)
-        CurrentlyTrackedSymbols.insert(Sym);
+      CurrentlyTrackedSymbols.insert_range(KV.second);
 
     for (auto &KV : Symbols) {
       auto &Sym = KV.first;

--- a/llvm/lib/ExecutionEngine/Orc/LinkGraphLinkingLayer.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LinkGraphLinkingLayer.cpp
@@ -396,16 +396,13 @@ private:
 
         for (auto *FB : BI.AnonEdges) {
           auto &FBI = BlockInfos[FB];
-          for (auto *BB : BI.AnonBackEdges)
-            FBI.AnonBackEdges.insert(BB);
+          FBI.AnonBackEdges.insert_range(BI.AnonBackEdges);
         }
 
         for (auto *BB : BI.AnonBackEdges) {
           auto &BBI = BlockInfos[BB];
-          for (auto *SD : BI.SymbolDeps)
-            BBI.SymbolDeps.insert(SD);
-          for (auto *FB : BI.AnonEdges)
-            BBI.AnonEdges.insert(FB);
+          BBI.SymbolDeps.insert_range(BI.SymbolDeps);
+          BBI.AnonEdges.insert_range(BI.AnonEdges);
         }
       }
 

--- a/llvm/lib/FileCheck/FileCheck.cpp
+++ b/llvm/lib/FileCheck/FileCheck.cpp
@@ -2491,14 +2491,10 @@ static bool ValidatePrefixes(StringRef Kind, StringSet<> &UniquePrefixes,
 bool FileCheck::ValidateCheckPrefixes() {
   StringSet<> UniquePrefixes;
   // Add default prefixes to catch user-supplied duplicates of them below.
-  if (Req.CheckPrefixes.empty()) {
-    for (const char *Prefix : DefaultCheckPrefixes)
-      UniquePrefixes.insert(Prefix);
-  }
-  if (Req.CommentPrefixes.empty()) {
-    for (const char *Prefix : DefaultCommentPrefixes)
-      UniquePrefixes.insert(Prefix);
-  }
+  if (Req.CheckPrefixes.empty())
+    UniquePrefixes.insert_range(DefaultCheckPrefixes);
+  if (Req.CommentPrefixes.empty())
+    UniquePrefixes.insert_range(DefaultCommentPrefixes);
   // Do not validate the default prefixes, or diagnostics about duplicates might
   // incorrectly indicate that they were supplied by the user.
   if (!ValidatePrefixes("check", UniquePrefixes, Req.CheckPrefixes))

--- a/llvm/lib/IR/Assumptions.cpp
+++ b/llvm/lib/IR/Assumptions.cpp
@@ -42,8 +42,7 @@ DenseSet<StringRef> getAssumptions(const Attribute &A) {
   SmallVector<StringRef, 8> Strings;
   A.getValueAsString().split(Strings, ",");
 
-  for (StringRef Str : Strings)
-    Assumptions.insert(Str);
+  Assumptions.insert_range(Strings);
   return Assumptions;
 }
 

--- a/llvm/lib/LTO/LTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/LTOCodeGenerator.cpp
@@ -142,8 +142,7 @@ LTOCodeGenerator::LTOCodeGenerator(LLVMContext &Context)
 LTOCodeGenerator::~LTOCodeGenerator() = default;
 
 void LTOCodeGenerator::setAsmUndefinedRefs(LTOModule *Mod) {
-  for (const StringRef &Undef : Mod->getAsmUndefinedRefs())
-    AsmUndefinedRefs.insert(Undef);
+  AsmUndefinedRefs.insert_range(Mod->getAsmUndefinedRefs());
 }
 
 bool LTOCodeGenerator::addModule(LTOModule *Mod) {

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -1057,8 +1057,7 @@ void ThinLTOCodeGenerator::run() {
   std::map<ValueInfo, std::vector<VTableSlotSummary>> LocalWPDTargetsMap;
   std::set<GlobalValue::GUID> ExportedGUIDs;
   runWholeProgramDevirtOnIndex(*Index, ExportedGUIDs, LocalWPDTargetsMap);
-  for (auto GUID : ExportedGUIDs)
-    GUIDPreservedSymbols.insert(GUID);
+  GUIDPreservedSymbols.insert_range(ExportedGUIDs);
 
   // Compute prevailing symbols
   DenseMap<GlobalValue::GUID, const GlobalValueSummary *> PrevailingCopy;

--- a/llvm/tools/bugpoint/CrashDebugger.cpp
+++ b/llvm/tools/bugpoint/CrashDebugger.cpp
@@ -417,9 +417,8 @@ void simpleSimplifyCfg(Function &F, SmallVectorImpl<BasicBlock *> &BBs) {
   // undefined behavior into unreachables, but bugpoint was the thing that
   // generated the undefined behavior, and we don't want it to kill the entire
   // program.
-  SmallPtrSet<BasicBlock *, 16> Visited;
-  for (auto *BB : depth_first(&F.getEntryBlock()))
-    Visited.insert(BB);
+  SmallPtrSet<BasicBlock *, 16> Visited(llvm::from_range,
+                                        depth_first(&F.getEntryBlock()));
 
   SmallVector<BasicBlock *, 16> Unreachable;
   for (auto &BB : F)
@@ -917,9 +916,7 @@ bool ReduceCrashingNamedMD::TestNamedMDs(std::vector<std::string> &NamedMDs) {
   outs() << ": ";
 
   // Make a StringMap for faster lookup
-  StringSet<> Names;
-  for (const std::string &Name : NamedMDs)
-    Names.insert(Name);
+  StringSet<> Names(llvm::from_range, NamedMDs);
 
   // First collect all the metadata to delete in a vector, then
   // delete them all at once to avoid invalidating the iterator

--- a/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
+++ b/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
@@ -343,11 +343,9 @@ static std::unique_ptr<MachineFunction> cloneMF(MachineFunction *SrcMF,
     }
   }
 
-  DenseSet<const uint32_t *> ConstRegisterMasks;
-
   // Track predefined/named regmasks which we ignore.
-  for (const uint32_t *Mask : TRI->getRegMasks())
-    ConstRegisterMasks.insert(Mask);
+  DenseSet<const uint32_t *> ConstRegisterMasks(llvm::from_range,
+                                                TRI->getRegMasks());
 
   // Clone instructions.
   for (auto &SrcMBB : *SrcMF) {

--- a/llvm/tools/llvm-reduce/deltas/ReduceRegisterMasks.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceRegisterMasks.cpp
@@ -24,8 +24,7 @@ static void reduceMasksInFunction(Oracle &O, MachineFunction &MF) {
 
   // Track predefined/named regmasks which we ignore.
   const unsigned NumRegs = TRI->getNumRegs();
-  for (const uint32_t *Mask : TRI->getRegMasks())
-    ConstRegisterMasks.insert(Mask);
+  ConstRegisterMasks.insert_range(TRI->getRegMasks());
 
   for (MachineBasicBlock &MBB : MF) {
     for (MachineInstr &MI : MBB) {


### PR DESCRIPTION
We can use *Set::insert_range to collapse:

  for (auto Elem : Range)
    Set.insert(E);

down to:

  Set.insert_range(Range);

In some cases, we can further fold that into the set declaration.
