### PR TITLE
[mlir] Use *Set::insert_range (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/IR/TargetEnv.h
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TargetEnv.h
@@ -27,11 +27,9 @@ public:
   TargetEnv() {}
   explicit TargetEnv(const SmallVectorImpl<Profile> &profiles,
                      const SmallVectorImpl<Extension> &extensions) {
-    for (Profile prof : profiles)
-      enabledProfiles.insert(prof);
+    enabledProfiles.insert_range(profiles);
 
-    for (Extension ext : extensions)
-      enabledExtensions.insert(ext);
+    enabledExtensions.insert_range(extensions);
   }
 
   void addProfile(Profile p) { enabledProfiles.insert(p); }

--- a/mlir/lib/Analysis/Liveness.cpp
+++ b/mlir/lib/Analysis/Liveness.cpp
@@ -68,14 +68,11 @@ struct BlockInfoBuilder {
     // operands as used. All defined value will be removed from the used set
     // at the end.
     block->walk([&](Operation *op) {
-      for (Value result : op->getResults())
-        defValues.insert(result);
-      for (Value operand : op->getOperands())
-        useValues.insert(operand);
+      defValues.insert_range(op->getResults());
+      useValues.insert_range(op->getOperands());
       for (Region &region : op->getRegions())
         for (Block &child : region.getBlocks())
-          for (BlockArgument arg : child.getArguments())
-            defValues.insert(arg);
+          defValues.insert_range(child.getArguments());
     });
     llvm::set_subtract(useValues, defValues);
   }

--- a/mlir/lib/Analysis/TopologicalSortUtils.cpp
+++ b/mlir/lib/Analysis/TopologicalSortUtils.cpp
@@ -116,11 +116,8 @@ bool mlir::computeTopologicalSorting(
     return true;
 
   // The set of operations that have not yet been scheduled.
-  DenseSet<Operation *> unscheduledOps;
-
   // Mark all operations as unscheduled.
-  for (Operation *op : ops)
-    unscheduledOps.insert(op);
+  DenseSet<Operation *> unscheduledOps(llvm::from_range, ops);
 
   unsigned nextScheduledOp = 0;
 

--- a/mlir/lib/Dialect/Func/TransformOps/FuncTransformOps.cpp
+++ b/mlir/lib/Dialect/Func/TransformOps/FuncTransformOps.cpp
@@ -51,8 +51,7 @@ transform::CastAndCallOp::apply(transform::TransformRewriter &rewriter,
 
   SetVector<Value> outputs;
   if (getOutputs()) {
-    for (auto output : state.getPayloadValues(getOutputs()))
-      outputs.insert(output);
+    outputs.insert_range(state.getPayloadValues(getOutputs()));
 
     // Verify that the set of output values to be replaced is unique.
     if (outputs.size() !=

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMMemorySlot.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMMemorySlot.cpp
@@ -1345,8 +1345,7 @@ static bool memcpyCanRewire(MemcpyLike op, const DestructurableMemorySlot &slot,
     return false;
 
   if (op.getSrc() == slot.ptr)
-    for (Attribute index : llvm::make_first_range(slot.subelementTypes))
-      usedIndices.insert(index);
+    usedIndices.insert_range(llvm::make_first_range(slot.subelementTypes));
 
   return true;
 }

--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -4390,9 +4390,7 @@ static bool isInvalidPackingPosSpecification(ArrayRef<int64_t> dimsPos,
   size_t dimsPosSize = dimsPos.size();
   if (dimsPosSize > rank)
     return true;
-  DenseSet<int64_t> uniqued;
-  for (int64_t dim : dimsPos)
-    uniqued.insert(dim);
+  DenseSet<int64_t> uniqued(llvm::from_range, dimsPos);
   if (dimsPosSize != uniqued.size())
     return true;
   return llvm::any_of(dimsPos, [rank](int64_t dimPos) {

--- a/mlir/lib/Dialect/Linalg/Transforms/Detensorize.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/Detensorize.cpp
@@ -458,8 +458,7 @@ struct LinalgDetensorize
       });
 
       for (Block &block : llvm::drop_begin(func.getFunctionBody(), 1))
-        for (BlockArgument blockArgument : block.getArguments())
-          blockArgsToDetensor.insert(blockArgument);
+        blockArgsToDetensor.insert_range(block.getArguments());
     }
   };
 

--- a/mlir/lib/Dialect/MLProgram/Transforms/PipelineGlobalOps.cpp
+++ b/mlir/lib/Dialect/MLProgram/Transforms/PipelineGlobalOps.cpp
@@ -104,11 +104,9 @@ LogicalResult MLProgramPipelineGlobals::buildGlobalMap(ModuleOp module) {
           work.push_back(symbol);
       });
 
-      for (auto load : opLoadSymbols[work[i]])
-        loadSymbols.insert(load);
+      loadSymbols.insert_range(opLoadSymbols[work[i]]);
 
-      for (auto store : opStoreSymbols[work[i]])
-        storeSymbols.insert(store);
+      storeSymbols.insert_range(opStoreSymbols[work[i]]);
     }
 
     loadSymbolsMap[thisSymbol] = std::move(loadSymbols);

--- a/mlir/lib/Dialect/SCF/IR/SCF.cpp
+++ b/mlir/lib/Dialect/SCF/IR/SCF.cpp
@@ -4052,9 +4052,7 @@ struct WhileRemoveDuplicatedResults : public OpRewritePattern<WhileOp> {
     ConditionOp condOp = op.getConditionOp();
     ValueRange condOpArgs = condOp.getArgs();
 
-    llvm::SmallPtrSet<Value, 8> argsSet;
-    for (Value arg : condOpArgs)
-      argsSet.insert(arg);
+    llvm::SmallPtrSet<Value, 8> argsSet(llvm::from_range, condOpArgs);
 
     if (argsSet.size() == condOpArgs.size())
       return rewriter.notifyMatchFailure(op, "No results to remove");

--- a/mlir/lib/Dialect/SCF/Transforms/LoopPipelining.cpp
+++ b/mlir/lib/Dialect/SCF/Transforms/LoopPipelining.cpp
@@ -207,9 +207,7 @@ bool LoopPipelinerInternal::initializeLoopInfo(
 static SetVector<Value> getNestedOperands(Operation *op) {
   SetVector<Value> operands;
   op->walk([&](Operation *nestedOp) {
-    for (Value operand : nestedOp->getOperands()) {
-      operands.insert(operand);
-    }
+    operands.insert_range(nestedOp->getOperands());
   });
   return operands;
 }

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVEnums.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVEnums.cpp
@@ -99,8 +99,7 @@ spirv::getRecursiveImpliedCapabilities(spirv::Capability cap) {
   // TODO: This is insufficient; find a better way to handle this
   // (e.g., using static lists) if this turns out to be a bottleneck.
   for (unsigned i = 0; i < allCaps.size(); ++i)
-    for (Capability c : getDirectImpliedCapabilities(allCaps[i]))
-      allCaps.insert(c);
+    allCaps.insert_range(getDirectImpliedCapabilities(allCaps[i]));
 
   return allCaps.takeVector();
 }

--- a/mlir/lib/Dialect/SPIRV/IR/TargetAndABI.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/TargetAndABI.cpp
@@ -23,20 +23,17 @@ using namespace mlir;
 
 spirv::TargetEnv::TargetEnv(spirv::TargetEnvAttr targetAttr)
     : targetAttr(targetAttr) {
-  for (spirv::Extension ext : targetAttr.getExtensions())
-    givenExtensions.insert(ext);
+  givenExtensions.insert_range(targetAttr.getExtensions());
 
   // Add extensions implied by the current version.
-  for (spirv::Extension ext :
-       spirv::getImpliedExtensions(targetAttr.getVersion()))
-    givenExtensions.insert(ext);
+  givenExtensions.insert_range(
+      spirv::getImpliedExtensions(targetAttr.getVersion()));
 
   for (spirv::Capability cap : targetAttr.getCapabilities()) {
     givenCapabilities.insert(cap);
 
     // Add capabilities implied by the current capability.
-    for (spirv::Capability c : spirv::getRecursiveImpliedCapabilities(cap))
-      givenCapabilities.insert(c);
+    givenCapabilities.insert_range(spirv::getRecursiveImpliedCapabilities(cap));
   }
 }
 

--- a/mlir/lib/Transforms/SROA.cpp
+++ b/mlir/lib/Transforms/SROA.cpp
@@ -154,10 +154,8 @@ static void destructureSlot(
     statistics.maxSubelementAmount->updateMax(slot.subelementTypes.size());
 
   SetVector<Operation *> usersToRewire;
-  for (Operation *user : llvm::make_first_range(info.userToBlockingUses))
-    usersToRewire.insert(user);
-  for (DestructurableAccessorOpInterface accessor : info.accessors)
-    usersToRewire.insert(accessor);
+  usersToRewire.insert_range(llvm::make_first_range(info.userToBlockingUses));
+  usersToRewire.insert_range(info.accessors);
   usersToRewire = mlir::topologicalSort(usersToRewire);
 
   llvm::SmallVector<Operation *> toErase;

--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -154,8 +154,7 @@ struct ConversionValueMapping {
         next = it->second;
       }
     });
-    for (Value v : newVal)
-      mappedTo.insert(v);
+    mappedTo.insert_range(newVal);
 
     mapping[std::forward<OldVal>(oldVal)] = std::forward<NewVal>(newVal);
   }

--- a/mlir/lib/Transforms/Utils/InliningUtils.cpp
+++ b/mlir/lib/Transforms/Utils/InliningUtils.cpp
@@ -251,9 +251,7 @@ static void handleResultImpl(InlinerInterface &interface, OpBuilder &builder,
   SmallVector<DictionaryAttr> resultAttributes;
   for (auto [result, resAttr] : llvm::zip(results, resAttrs)) {
     // Store the original result users before running the handler.
-    DenseSet<Operation *> resultUsers;
-    for (Operation *user : result.getUsers())
-      resultUsers.insert(user);
+    DenseSet<Operation *> resultUsers(llvm::from_range, result.getUsers());
 
     Value newResult =
         interface.handleResult(builder, call, callable, result, resAttr);


### PR DESCRIPTION
We can use *Set::insert_range to collapse:

  for (auto Elem : Range)
    Set.insert(E);

down to:

  Set.insert_range(Range);

In some cases, we can further fold that into the set declaration.
