### PR TITLE
[compiler-rt][builtins] Add missing flag for builtins standalone build

### DIFF
--- a/compiler-rt/cmake/builtin-config-ix.cmake
+++ b/compiler-rt/cmake/builtin-config-ix.cmake
@@ -25,6 +25,7 @@ builtin_check_c_compiler_flag(-fconvergent-functions COMPILER_RT_HAS_FCONVERGENT
 builtin_check_c_compiler_flag("-Xclang -mcode-object-version=none" COMPILER_RT_HAS_CODE_OBJECT_VERSION_FLAG)
 builtin_check_c_compiler_flag(-Wbuiltin-declaration-mismatch COMPILER_RT_HAS_WBUILTIN_DECLARATION_MISMATCH_FLAG)
 builtin_check_c_compiler_flag(/Zl COMPILER_RT_HAS_ZL_FLAG)
+builtin_check_c_compiler_flag(-fcf-protection=full COMPILER_RT_HAS_FCF_PROTECTION_FLAG)
 
 builtin_check_c_compiler_source(COMPILER_RT_HAS_ATOMIC_KEYWORD
 "


### PR DESCRIPTION
When builtins are built with runtimes, it is built before compiler-rt, and this makes some of the HAS_XXX_FLAGs missing. In this case, the COMPILER_RT_HAS_FCF_PROTECTION_FLAG is missing which makes it impossible to enable CET in this case. This patch addresses this issue by also check for such flag in standalone build instead of relying on the compiler-rt's detection.