### PR TITLE
[AArch64] Add FEAT_FPAC to Neoverse V2

### DIFF
--- a/clang/test/Driver/aarch64-mcpu-native.c
+++ b/clang/test/Driver/aarch64-mcpu-native.c
@@ -22,6 +22,7 @@
 // CHECK-FEAT-NV2:    FEAT_FHM                                               Enable FP16 FML instructions
 // CHECK-FEAT-NV2:    FEAT_FP                                                Enable Armv8.0-A Floating Point Extensions
 // CHECK-FEAT-NV2:    FEAT_FP16                                              Enable half-precision floating-point data processing
+// CHECK-FEAT-NV2:    FEAT_FPAC                                              Enable Armv8.3-A Pointer Authentication Faulting enhancement
 // CHECK-FEAT-NV2:    FEAT_FRINTTS                                           Enable FRInt[32|64][Z|X] instructions that round a floating-point number to an integer (in FP format) forcing it to fit into a 32- or 64-bit int
 // CHECK-FEAT-NV2:    FEAT_FlagM                                             Enable Armv8.4-A Flag Manipulation instructions
 // CHECK-FEAT-NV2:    FEAT_FlagM2                                            Enable alternative NZCV format for floating point comparisons

--- a/clang/test/Driver/print-enabled-extensions/aarch64-grace.c
+++ b/clang/test/Driver/print-enabled-extensions/aarch64-grace.c
@@ -21,6 +21,7 @@
 // CHECK-NEXT:     FEAT_FHM                                               Enable FP16 FML instructions
 // CHECK-NEXT:     FEAT_FP                                                Enable Armv8.0-A Floating Point Extensions
 // CHECK-NEXT:     FEAT_FP16                                              Enable half-precision floating-point data processing
+// CHECK-NEXT:     FEAT_FPAC                                              Enable Armv8.3-A Pointer Authentication Faulting enhancement
 // CHECK-NEXT:     FEAT_FRINTTS                                           Enable FRInt[32|64][Z|X] instructions that round a floating-point number to an integer (in FP format) forcing it to fit into a 32- or 64-bit int
 // CHECK-NEXT:     FEAT_FlagM                                             Enable Armv8.4-A Flag Manipulation instructions
 // CHECK-NEXT:     FEAT_FlagM2                                            Enable alternative NZCV format for floating point comparisons

--- a/clang/test/Driver/print-enabled-extensions/aarch64-neoverse-v2.c
+++ b/clang/test/Driver/print-enabled-extensions/aarch64-neoverse-v2.c
@@ -20,6 +20,7 @@
 // CHECK-NEXT:     FEAT_FHM                                               Enable FP16 FML instructions
 // CHECK-NEXT:     FEAT_FP                                                Enable Armv8.0-A Floating Point Extensions
 // CHECK-NEXT:     FEAT_FP16                                              Enable half-precision floating-point data processing
+// CHECK-NEXT:     FEAT_FPAC                                              Enable Armv8.3-A Pointer Authentication Faulting enhancement
 // CHECK-NEXT:     FEAT_FRINTTS                                           Enable FRInt[32|64][Z|X] instructions that round a floating-point number to an integer (in FP format) forcing it to fit into a 32- or 64-bit int
 // CHECK-NEXT:     FEAT_FlagM                                             Enable Armv8.4-A Flag Manipulation instructions
 // CHECK-NEXT:     FEAT_FlagM2                                            Enable alternative NZCV format for floating point comparisons

--- a/llvm/lib/Target/AArch64/AArch64Processors.td
+++ b/llvm/lib/Target/AArch64/AArch64Processors.td
@@ -1015,7 +1015,7 @@ def ProcessorFeatures {
                                        FeatureCCIDX,
                                        FeatureSVE, FeatureSVE2, FeatureSSBS, FeatureFullFP16, FeatureDotProd,
                                        FeatureComplxNum, FeatureCRC, FeatureFPARMv8, FeatureJS, FeatureLSE,
-                                       FeaturePAuth, FeatureRAS, FeatureRCPC, FeatureRDM];
+                                       FeaturePAuth, FeatureRAS, FeatureRCPC, FeatureRDM, FeatureFPAC];
   list<SubtargetFeature> NeoverseV3 = [HasV9_2aOps, FeatureETE, FeatureFP16FML,
                                       FeatureFullFP16, FeatureLS64, FeatureMTE,
                                       FeaturePerfMon, FeatureRandGen, FeatureSPE,


### PR DESCRIPTION
This feature is supported in Grace, but wasn't specified in the CPU definition. This is not important for codegen, but is good for completeness, and good for other tools that could query the CPU definition (e.g. llvm-exegesis).