### PR TITLE
[AArch64] Bugfix when using execute-only and memtag sanitizer together

### DIFF
--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFStreamer.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFStreamer.cpp
@@ -511,11 +511,17 @@ void AArch64TargetELFStreamer::finish() {
       })) {
     auto *Text =
         static_cast<MCSectionELF *>(Ctx.getObjectFileInfo()->getTextSection());
-    for (auto &F : *Text)
-      if (auto *DF = dyn_cast<MCDataFragment>(&F))
-        if (!DF->getContents().empty())
-          return;
-    Text->setFlags(Text->getFlags() | ELF::SHF_AARCH64_PURECODE);
+    bool Empty = true;
+    for (auto &F : *Text) {
+      if (auto *DF = dyn_cast<MCDataFragment>(&F)) {
+        if (!DF->getContents().empty()) {
+          Empty = false;
+          break;
+        }
+      }
+    }
+    if (Empty)
+      Text->setFlags(Text->getFlags() | ELF::SHF_AARCH64_PURECODE);
   }
 
   MCSectionELF *MemtagSec = nullptr;

--- a/llvm/test/MC/AArch64/execute-only-memtag.ll
+++ b/llvm/test/MC/AArch64/execute-only-memtag.ll
@@ -1,0 +1,18 @@
+; RUN: llc %s -mtriple=aarch64-linux-android31 -filetype=obj -o %t.o
+; RUN: llvm-readelf -r %t.o | FileCheck %s
+
+; CHECK:      Relocation section '.rela.memtag.globals.static' at offset {{.*}} contains 1 entries:
+; CHECK-NEXT:      Type      {{.*}} Symbol's Name
+; CHECK-NEXT: R_AARCH64_NONE {{.*}} global
+
+@global = global i32 1, sanitize_memtag
+
+define void @foo() {
+  ret void
+}
+
+define void @bar() #0 {
+  ret void
+}
+
+attributes #0 = { "target-features"="+execute-only" }


### PR DESCRIPTION
Support for execute-only code generation (#125687) introduced a bug in the case where the memtag sanitizer is used in a module containing a mix of execute-only and non-execute-only functions.

The bug is caused by using `return` instead of `break` to short-circuit a loop, which meant that the rest of the function dealing with memtag sanitizer logic wasn't run.