### PR TITLE
[lldb] Respect LaunchInfo::SetExecutable in ProcessLauncherPosixFork

### DIFF
--- a/lldb/source/Host/posix/ProcessLauncherPosixFork.cpp
+++ b/lldb/source/Host/posix/ProcessLauncherPosixFork.cpp
@@ -94,6 +94,7 @@ struct ForkLaunchInfo {
   bool debug;
   bool disable_aslr;
   std::string wd;
+  std::string executable;
   const char **argv;
   Environment::Envp envp;
   std::vector<ForkFileAction> actions;
@@ -194,7 +195,8 @@ struct ForkLaunchInfo {
   }
 
   // Execute.  We should never return...
-  execve(info.argv[0], const_cast<char *const *>(info.argv), info.envp);
+  execve(info.executable.c_str(), const_cast<char *const *>(info.argv),
+         info.envp);
 
 #if defined(__linux__)
   if (errno == ETXTBSY) {
@@ -207,7 +209,8 @@ struct ForkLaunchInfo {
     // Since this state should clear up quickly, wait a while and then give it
     // one more go.
     usleep(50000);
-    execve(info.argv[0], const_cast<char *const *>(info.argv), info.envp);
+    execve(info.executable.c_str(), const_cast<char *const *>(info.argv),
+           info.envp);
   }
 #endif
 
@@ -236,6 +239,7 @@ ForkLaunchInfo::ForkLaunchInfo(const ProcessLaunchInfo &info)
       debug(info.GetFlags().Test(eLaunchFlagDebug)),
       disable_aslr(info.GetFlags().Test(eLaunchFlagDisableASLR)),
       wd(info.GetWorkingDirectory().GetPath()),
+      executable(info.GetExecutableFile().GetPath()),
       argv(info.GetArguments().GetConstArgumentVector()),
       envp(info.GetEnvironment().getEnvp()), actions(MakeForkActions(info)) {}
 

--- a/lldb/unittests/Host/HostTest.cpp
+++ b/lldb/unittests/Host/HostTest.cpp
@@ -7,11 +7,23 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Host/Host.h"
+#include "TestingSupport/SubsystemRAII.h"
+#include "lldb/Host/FileSystem.h"
+#include "lldb/Host/ProcessLaunchInfo.h"
 #include "lldb/Utility/ProcessInfo.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
+#include <future>
 
 using namespace lldb_private;
 using namespace llvm;
+
+// From TestMain.cpp.
+extern const char *TestMainArgv0;
+
+static cl::opt<uint64_t> test_arg("test-arg");
 
 TEST(Host, WaitStatusFormat) {
   EXPECT_EQ("W01", formatv("{0:g}", WaitStatus{WaitStatus::Exit, 1}).str());
@@ -45,4 +57,33 @@ TEST(Host, ProcessInstanceInfoCumulativeSystemTimeIsValid) {
   EXPECT_TRUE(info.CumulativeSystemTimeIsValid());
   info.SetCumulativeSystemTime(ProcessInstanceInfo::timespec{1, 0});
   EXPECT_TRUE(info.CumulativeSystemTimeIsValid());
+}
+
+TEST(Host, LaunchProcessSetsArgv0) {
+  SubsystemRAII<FileSystem> subsystems;
+
+  static constexpr StringLiteral TestArgv0 = "HelloArgv0";
+  if (test_arg != 0) {
+    // In subprocess
+    if (TestMainArgv0 != TestArgv0) {
+      errs() << formatv("Got '{0}' for argv[0]\n", TestMainArgv0);
+      exit(1);
+    }
+    exit(0);
+  }
+
+  ProcessLaunchInfo info;
+  info.SetExecutableFile(
+      FileSpec(llvm::sys::fs::getMainExecutable(TestMainArgv0, &test_arg)),
+      /*add_exe_file_as_first_arg=*/false);
+  info.GetArguments().AppendArgument("HelloArgv0");
+  info.GetArguments().AppendArgument(
+      "--gtest_filter=Host.LaunchProcessSetsArgv0");
+  info.GetArguments().AppendArgument("--test-arg=47");
+  std::promise<int> exit_status;
+  info.SetMonitorProcessCallback([&](lldb::pid_t pid, int signal, int status) {
+    exit_status.set_value(status);
+  });
+  ASSERT_THAT_ERROR(Host::LaunchProcess(info).takeError(), Succeeded());
+  ASSERT_THAT(exit_status.get_future().get(), 0);
 }


### PR DESCRIPTION
Using argv[0] for this was incorrect. I'm ignoring LaunchInfo::SetArg0, as that's what darwin and windows launchers do (they use the first element of the args vector instead).

I picked up the funny unit test re-exec method from the llvm unit tests.