### PR TITLE
Revert "[ExecutionEngine] Avoid repeated hash lookups (NFC)"

### DIFF
--- a/llvm/lib/ExecutionEngine/RuntimeDyld/Targets/RuntimeDyldMachOARM.h
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/Targets/RuntimeDyldMachOARM.h
@@ -307,14 +307,14 @@ private:
     // This is an ARM branch relocation, need to use a stub function.
     // Look up for existing stub.
     SectionEntry &Section = Sections[RE.SectionID];
-    auto [It, Inserted] = Stubs.try_emplace(Value);
+    RuntimeDyldMachO::StubMap::const_iterator i = Stubs.find(Value);
     uint8_t *Addr;
-    if (!Inserted) {
-      Addr = Section.getAddressWithOffset(It->second);
+    if (i != Stubs.end()) {
+      Addr = Section.getAddressWithOffset(i->second);
     } else {
       // Create a new stub function.
       assert(Section.getStubOffset() % 4 == 0 && "Misaligned stub");
-      It->second = Section.getStubOffset();
+      Stubs[Value] = Section.getStubOffset();
       uint32_t StubOpcode = 0;
       if (RE.RelType == MachO::ARM_RELOC_BR24)
         StubOpcode = 0xe51ff004; // ldr pc, [pc, #-4]

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/Targets/RuntimeDyldMachOX86_64.h
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/Targets/RuntimeDyldMachOX86_64.h
@@ -131,12 +131,12 @@ private:
     assert(RE.IsPCRel);
     assert(RE.Size == 2);
     Value.Offset -= RE.Addend;
-    auto [It, Inserted] = Stubs.try_emplace(Value);
+    RuntimeDyldMachO::StubMap::const_iterator i = Stubs.find(Value);
     uint8_t *Addr;
-    if (!Inserted) {
-      Addr = Section.getAddressWithOffset(It->second);
+    if (i != Stubs.end()) {
+      Addr = Section.getAddressWithOffset(i->second);
     } else {
-      It->second = Section.getStubOffset();
+      Stubs[Value] = Section.getStubOffset();
       uint8_t *GOTEntry = Section.getAddressWithOffset(Section.getStubOffset());
       RelocationEntry GOTRE(RE.SectionID, Section.getStubOffset(),
                             MachO::X86_64_RELOC_UNSIGNED, Value.Offset, false,


### PR DESCRIPTION
Reverts llvm/llvm-project#132587

Due to causing test failures on several of Linaro's buildbots. Several MLIR test failures and at least one test timing out.

I doubt it's the patch itself, but instead an issue it has uncovered. Revert while we dig into that.