### PR TITLE
[libclc] Pass -fapprox-func when compiling 'native' builtins

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -268,9 +268,9 @@ set_source_files_properties(
   ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_exp.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_exp10.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_exp2.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_log.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_log10.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_log2.cl
-  ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_log.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_powr.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_recip.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_rsqrt.cl
@@ -278,8 +278,8 @@ set_source_files_properties(
   ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_sqrt.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_tan.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/amdgpu/lib/math/native_exp.cl
-  ${CMAKE_CURRENT_SOURCE_DIR}/amdgpu/lib/math/native_log10.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/amdgpu/lib/math/native_log.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/amdgpu/lib/math/native_log10.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/r600/lib/math/native_rsqrt.cl
   PROPERTIES COMPILE_OPTIONS -fapprox-func
 )

--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -262,6 +262,28 @@ if ( clspv-- IN_LIST LIBCLC_TARGETS_TO_BUILD OR clspv64-- IN_LIST LIBCLC_TARGETS
   set_target_properties( generate-clspv-convert.cl PROPERTIES FOLDER "libclc/Sourcegenning" )
 endif()
 
+set_source_files_properties(
+  ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_cos.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_divide.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_exp.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_exp10.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_exp2.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_log10.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_log2.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_log.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_powr.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_recip.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_rsqrt.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_sin.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_sqrt.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_tan.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/amdgpu/lib/math/native_exp.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/amdgpu/lib/math/native_log10.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/amdgpu/lib/math/native_log.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/r600/lib/math/native_rsqrt.cl
+  PROPERTIES COMPILE_OPTIONS -fapprox-func
+)
+
 enable_testing()
 
 foreach( t ${LIBCLC_TARGETS_TO_BUILD} )

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -260,7 +260,6 @@ function(add_libclc_builtin_set)
     endif()
 
     get_filename_component( file_dir ${file} DIRECTORY )
-    get_filename_component( input_filename ${file} NAME_WE )
 
     set( file_specific_compile_options )
     get_source_file_property( compile_opts ${file} COMPILE_OPTIONS)

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -262,19 +262,17 @@ function(add_libclc_builtin_set)
     get_filename_component( file_dir ${file} DIRECTORY )
     get_filename_component( input_filename ${file} NAME_WE )
 
-    # If this is a 'native' function (as judged by its filename beginning with
-    # "(clc_)?native_") then pass extra args.
-    set( native_flag )
-    string( REGEX MATCH "^(clc_)?native_" is_native "${input_filename}" )
-    if( NOT "${is_native}" STREQUAL "" )
-      set( native_flag -fapprox-func )
+    set( file_specific_compile_options )
+    get_source_file_property( compile_opts ${file} COMPILE_OPTIONS)
+    if( compile_opts )
+      set( file_specific_compile_options "${compile_opts}" )
     endif()
 
     compile_to_bc(
       TRIPLE ${ARG_TRIPLE}
       INPUT ${input_file}
       OUTPUT ${output_file}
-      EXTRA_OPTS -fno-builtin -nostdlib ${native_flag}
+      EXTRA_OPTS -fno-builtin -nostdlib "${file_specific_compile_options}"
         "${ARG_COMPILE_FLAGS}" -I${CMAKE_CURRENT_SOURCE_DIR}/${file_dir}
       DEPENDENCIES ${input_file_dep}
     )

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -260,12 +260,21 @@ function(add_libclc_builtin_set)
     endif()
 
     get_filename_component( file_dir ${file} DIRECTORY )
+    get_filename_component( input_filename ${file} NAME_WE )
+
+    # If this is a 'native' function (as judged by its filename beginning with
+    # "(clc_)?native_") then pass extra args.
+    set( native_flag )
+    string( REGEX MATCH "^(clc_)?native_" is_native "${input_filename}" )
+    if( NOT "${is_native}" STREQUAL "" )
+      set( native_flag -fapprox-func )
+    endif()
 
     compile_to_bc(
       TRIPLE ${ARG_TRIPLE}
       INPUT ${input_file}
       OUTPUT ${output_file}
-      EXTRA_OPTS -fno-builtin -nostdlib
+      EXTRA_OPTS -fno-builtin -nostdlib ${native_flag}
         "${ARG_COMPILE_FLAGS}" -I${CMAKE_CURRENT_SOURCE_DIR}/${file_dir}
       DEPENDENCIES ${input_file_dep}
     )


### PR DESCRIPTION
The libclc build system isn't well set up to pass arbitrary options to arbitrary source files in a non-intrusive way. There isn't currently any other motivating example to warrant rewriting the build system just to satisfy this requirement. So this commit uses a filename-based approach to inserting this option into the list of compile flags.