### PR TITLE
[libc][CPP] correct cmpxchg failure ordering inference

### DIFF
--- a/libc/src/__support/CPP/atomic.h
+++ b/libc/src/__support/CPP/atomic.h
@@ -256,22 +256,6 @@ template <typename T> struct AtomicRef {
 private:
   T *ptr;
 
-  LIBC_INLINE static int order(MemoryOrder mem_ord) {
-    return static_cast<int>(mem_ord);
-  }
-
-  LIBC_INLINE static int scope(MemoryScope mem_scope) {
-    return static_cast<int>(mem_scope);
-  }
-
-  LIBC_INLINE static constexpr int infer_failure_order(MemoryOrder mem_ord) {
-    if (mem_ord == MemoryOrder::RELEASE)
-      return order(MemoryOrder::RELAXED);
-    if (mem_ord == MemoryOrder::ACQ_REL)
-      return order(MemoryOrder::ACQUIRE);
-    return order(mem_ord);
-  }
-
 public:
   // Constructor from T reference
   LIBC_INLINE explicit constexpr AtomicRef(T &obj) : ptr(&obj) {}

--- a/libc/src/__support/CPP/atomic.h
+++ b/libc/src/__support/CPP/atomic.h
@@ -62,6 +62,14 @@ private:
     return static_cast<int>(mem_scope);
   }
 
+  LIBC_INLINE static constexpr int infer_failure_order(MemoryOrder mem_ord) {
+    if (mem_ord == MemoryOrder::RELEASE)
+      return order(MemoryOrder::RELAXED);
+    if (mem_ord == MemoryOrder::ACQ_REL)
+      return order(MemoryOrder::ACQUIRE);
+    return order(mem_ord);
+  }
+
   LIBC_INLINE static T *addressof(T &ref) { return __builtin_addressof(ref); }
 
   // Require types that are 1, 2, 4, 8, or 16 bytes in length to be aligned to
@@ -129,7 +137,7 @@ public:
       [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) {
     return __atomic_compare_exchange(addressof(val), addressof(expected),
                                      addressof(desired), false, order(mem_ord),
-                                     order(mem_ord));
+                                     infer_failure_order(mem_ord));
   }
 
   // Atomic compare exchange (separate success and failure memory orders)
@@ -148,7 +156,7 @@ public:
       [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) {
     return __atomic_compare_exchange(addressof(val), addressof(expected),
                                      addressof(desired), true, order(mem_ord),
-                                     order(mem_ord));
+                                     infer_failure_order(mem_ord));
   }
 
   // Atomic compare exchange (weak version with separate success and failure
@@ -252,6 +260,14 @@ private:
     return static_cast<int>(mem_scope);
   }
 
+  LIBC_INLINE static constexpr int infer_failure_order(MemoryOrder mem_ord) {
+    if (mem_ord == MemoryOrder::RELEASE)
+      return order(MemoryOrder::RELAXED);
+    if (mem_ord == MemoryOrder::ACQ_REL)
+      return order(MemoryOrder::ACQUIRE);
+    return order(mem_ord);
+  }
+
 public:
   // Constructor from T reference
   LIBC_INLINE explicit constexpr AtomicRef(T &obj) : ptr(&obj) {}
@@ -298,7 +314,8 @@ public:
       T &expected, T desired, MemoryOrder mem_ord = MemoryOrder::SEQ_CST,
       [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) const {
     return __atomic_compare_exchange(ptr, &expected, &desired, false,
-                                     order(mem_ord), order(mem_ord));
+                                     order(mem_ord),
+                                     infer_failure_order(mem_ord));
   }
 
   // Atomic compare exchange (strong, separate success/failure memory orders)

--- a/libc/src/__support/CPP/atomic.h
+++ b/libc/src/__support/CPP/atomic.h
@@ -40,8 +40,7 @@ enum class MemoryScope : int {
 #endif
 };
 
-namespace atomic {
-
+namespace impl {
 LIBC_INLINE constexpr int order(MemoryOrder mem_ord) {
   return static_cast<int>(mem_ord);
 }
@@ -61,6 +60,7 @@ LIBC_INLINE constexpr int infer_failure_order(MemoryOrder mem_ord) {
     return order(MemoryOrder::ACQUIRE);
   return order(mem_ord);
 }
+} // namespace impl
 
 template <typename T> struct Atomic {
   static_assert(is_trivially_copyable_v<T> && is_copy_constructible_v<T> &&
@@ -111,10 +111,11 @@ public:
        [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) {
     T res;
 #if __has_builtin(__scoped_atomic_load)
-    __scoped_atomic_load(addressof(val), addressof(res), order(mem_ord),
-                         scope(mem_scope));
+    __scoped_atomic_load(impl::addressof(val), impl::addressof(res),
+                         impl::order(mem_ord), impl::scope(mem_scope));
 #else
-    __atomic_load(addressof(val), addressof(res), order(mem_ord));
+    __atomic_load(impl::addressof(val), impl::addressof(res),
+                  impl::order(mem_ord));
 #endif
     return res;
   }
@@ -129,10 +130,11 @@ public:
   store(T rhs, MemoryOrder mem_ord = MemoryOrder::SEQ_CST,
         [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) {
 #if __has_builtin(__scoped_atomic_store)
-    __scoped_atomic_store(addressof(val), addressof(rhs), order(mem_ord),
-                          scope(mem_scope));
+    __scoped_atomic_store(impl::addressof(val), impl::addressof(rhs),
+                          impl::order(mem_ord), impl::scope(mem_scope));
 #else
-    __atomic_store(addressof(val), addressof(rhs), order(mem_ord));
+    __atomic_store(impl::addressof(val), impl::addressof(rhs),
+                   impl::order(mem_ord));
 #endif
   }
 
@@ -140,9 +142,10 @@ public:
   LIBC_INLINE bool compare_exchange_strong(
       T &expected, T desired, MemoryOrder mem_ord = MemoryOrder::SEQ_CST,
       [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) {
-    return __atomic_compare_exchange(addressof(val), addressof(expected),
-                                     addressof(desired), false, order(mem_ord),
-                                     infer_failure_order(mem_ord));
+    return __atomic_compare_exchange(
+        impl::addressof(val), impl::addressof(expected),
+        impl::addressof(desired), false, impl::order(mem_ord),
+        impl::infer_failure_order(mem_ord));
   }
 
   // Atomic compare exchange (separate success and failure memory orders)
@@ -151,17 +154,19 @@ public:
       MemoryOrder failure_order,
       [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) {
     return __atomic_compare_exchange(
-        addressof(val), addressof(expected), addressof(desired), false,
-        order(success_order), order(failure_order));
+        impl::addressof(val), impl::addressof(expected),
+        impl::addressof(desired), false, impl::order(success_order),
+        impl::order(failure_order));
   }
 
   // Atomic compare exchange (weak version)
   LIBC_INLINE bool compare_exchange_weak(
       T &expected, T desired, MemoryOrder mem_ord = MemoryOrder::SEQ_CST,
       [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) {
-    return __atomic_compare_exchange(addressof(val), addressof(expected),
-                                     addressof(desired), true, order(mem_ord),
-                                     infer_failure_order(mem_ord));
+    return __atomic_compare_exchange(
+        impl::addressof(val), impl::addressof(expected),
+        impl::addressof(desired), true, impl::order(mem_ord),
+        impl::infer_failure_order(mem_ord));
   }
 
   // Atomic compare exchange (weak version with separate success and failure
@@ -171,8 +176,9 @@ public:
       MemoryOrder failure_order,
       [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) {
     return __atomic_compare_exchange(
-        addressof(val), addressof(expected), addressof(desired), true,
-        order(success_order), order(failure_order));
+        impl::addressof(val), impl::addressof(expected),
+        impl::addressof(desired), true, impl::order(success_order),
+        impl::order(failure_order));
   }
 
   LIBC_INLINE T
@@ -180,11 +186,12 @@ public:
            [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) {
     T ret;
 #if __has_builtin(__scoped_atomic_exchange)
-    __scoped_atomic_exchange(addressof(val), addressof(desired), addressof(ret),
-                             order(mem_ord), scope(mem_scope));
+    __scoped_atomic_exchange(impl::addressof(val), impl::addressof(desired),
+                             impl::addressof(ret), impl::order(mem_ord),
+                             impl::scope(mem_scope));
 #else
-    __atomic_exchange(addressof(val), addressof(desired), addressof(ret),
-                      order(mem_ord));
+    __atomic_exchange(impl::addressof(val), impl::addressof(desired),
+                      impl::addressof(ret), impl::order(mem_ord));
 #endif
     return ret;
   }
@@ -194,10 +201,12 @@ public:
             [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) {
     static_assert(cpp::is_integral_v<T>, "T must be an integral type.");
 #if __has_builtin(__scoped_atomic_fetch_add)
-    return __scoped_atomic_fetch_add(addressof(val), increment, order(mem_ord),
-                                     scope(mem_scope));
+    return __scoped_atomic_fetch_add(impl::addressof(val), increment,
+                                     impl::order(mem_ord),
+                                     impl::scope(mem_scope));
 #else
-    return __atomic_fetch_add(addressof(val), increment, order(mem_ord));
+    return __atomic_fetch_add(impl::addressof(val), increment,
+                              impl::order(mem_ord));
 #endif
   }
 
@@ -206,10 +215,11 @@ public:
            [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) {
     static_assert(cpp::is_integral_v<T>, "T must be an integral type.");
 #if __has_builtin(__scoped_atomic_fetch_or)
-    return __scoped_atomic_fetch_or(addressof(val), mask, order(mem_ord),
-                                    scope(mem_scope));
+    return __scoped_atomic_fetch_or(impl::addressof(val), mask,
+                                    impl::order(mem_ord),
+                                    impl::scope(mem_scope));
 #else
-    return __atomic_fetch_or(addressof(val), mask, order(mem_ord));
+    return __atomic_fetch_or(impl::addressof(val), mask, impl::order(mem_ord));
 #endif
   }
 
@@ -218,10 +228,11 @@ public:
             [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) {
     static_assert(cpp::is_integral_v<T>, "T must be an integral type.");
 #if __has_builtin(__scoped_atomic_fetch_and)
-    return __scoped_atomic_fetch_and(addressof(val), mask, order(mem_ord),
-                                     scope(mem_scope));
+    return __scoped_atomic_fetch_and(impl::addressof(val), mask,
+                                     impl::order(mem_ord),
+                                     impl::scope(mem_scope));
 #else
-    return __atomic_fetch_and(addressof(val), mask, order(mem_ord));
+    return __atomic_fetch_and(impl::addressof(val), mask, impl::order(mem_ord));
 #endif
   }
 
@@ -230,10 +241,12 @@ public:
             [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) {
     static_assert(cpp::is_integral_v<T>, "T must be an integral type.");
 #if __has_builtin(__scoped_atomic_fetch_sub)
-    return __scoped_atomic_fetch_sub(addressof(val), decrement, order(mem_ord),
-                                     scope(mem_scope));
+    return __scoped_atomic_fetch_sub(impl::addressof(val), decrement,
+                                     impl::order(mem_ord),
+                                     impl::scope(mem_scope));
 #else
-    return __atomic_fetch_sub(addressof(val), decrement, order(mem_ord));
+    return __atomic_fetch_sub(impl::addressof(val), decrement,
+                              impl::order(mem_ord));
 #endif
   }
 
@@ -275,9 +288,10 @@ public:
        [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) const {
     T res;
 #if __has_builtin(__scoped_atomic_load)
-    __scoped_atomic_load(ptr, &res, order(mem_ord), scope(mem_scope));
+    __scoped_atomic_load(ptr, &res, impl::order(mem_ord),
+                         impl::scope(mem_scope));
 #else
-    __atomic_load(ptr, &res, order(mem_ord));
+    __atomic_load(ptr, &res, impl::order(mem_ord));
 #endif
     return res;
   }
@@ -292,9 +306,10 @@ public:
   store(T rhs, MemoryOrder mem_ord = MemoryOrder::SEQ_CST,
         [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) const {
 #if __has_builtin(__scoped_atomic_store)
-    __scoped_atomic_store(ptr, &rhs, order(mem_ord), scope(mem_scope));
+    __scoped_atomic_store(ptr, &rhs, impl::order(mem_ord),
+                          impl::scope(mem_scope));
 #else
-    __atomic_store(ptr, &rhs, order(mem_ord));
+    __atomic_store(ptr, &rhs, impl::order(mem_ord));
 #endif
   }
 
@@ -303,8 +318,8 @@ public:
       T &expected, T desired, MemoryOrder mem_ord = MemoryOrder::SEQ_CST,
       [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) const {
     return __atomic_compare_exchange(ptr, &expected, &desired, false,
-                                     order(mem_ord),
-                                     infer_failure_order(mem_ord));
+                                     impl::order(mem_ord),
+                                     impl::infer_failure_order(mem_ord));
   }
 
   // Atomic compare exchange (strong, separate success/failure memory orders)
@@ -313,8 +328,8 @@ public:
       MemoryOrder failure_order,
       [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) const {
     return __atomic_compare_exchange(ptr, &expected, &desired, false,
-                                     order(success_order),
-                                     order(failure_order));
+                                     impl::order(success_order),
+                                     impl::order(failure_order));
   }
 
   // Atomic exchange
@@ -323,10 +338,10 @@ public:
            [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) const {
     T ret;
 #if __has_builtin(__scoped_atomic_exchange)
-    __scoped_atomic_exchange(ptr, &desired, &ret, order(mem_ord),
-                             scope(mem_scope));
+    __scoped_atomic_exchange(ptr, &desired, &ret, impl::order(mem_ord),
+                             impl::scope(mem_scope));
 #else
-    __atomic_exchange(ptr, &desired, &ret, order(mem_ord));
+    __atomic_exchange(ptr, &desired, &ret, impl::order(mem_ord));
 #endif
     return ret;
   }
@@ -336,10 +351,10 @@ public:
       [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) const {
     static_assert(cpp::is_integral_v<T>, "T must be an integral type.");
 #if __has_builtin(__scoped_atomic_fetch_add)
-    return __scoped_atomic_fetch_add(ptr, increment, order(mem_ord),
-                                     scope(mem_scope));
+    return __scoped_atomic_fetch_add(ptr, increment, impl::order(mem_ord),
+                                     impl::scope(mem_scope));
 #else
-    return __atomic_fetch_add(ptr, increment, order(mem_ord));
+    return __atomic_fetch_add(ptr, increment, impl::order(mem_ord));
 #endif
   }
 
@@ -348,10 +363,10 @@ public:
            [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) const {
     static_assert(cpp::is_integral_v<T>, "T must be an integral type.");
 #if __has_builtin(__scoped_atomic_fetch_or)
-    return __scoped_atomic_fetch_or(ptr, mask, order(mem_ord),
-                                    scope(mem_scope));
+    return __scoped_atomic_fetch_or(ptr, mask, impl::order(mem_ord),
+                                    impl::scope(mem_scope));
 #else
-    return __atomic_fetch_or(ptr, mask, order(mem_ord));
+    return __atomic_fetch_or(ptr, mask, impl::order(mem_ord));
 #endif
   }
 
@@ -360,10 +375,10 @@ public:
       [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) const {
     static_assert(cpp::is_integral_v<T>, "T must be an integral type.");
 #if __has_builtin(__scoped_atomic_fetch_and)
-    return __scoped_atomic_fetch_and(ptr, mask, order(mem_ord),
-                                     scope(mem_scope));
+    return __scoped_atomic_fetch_and(ptr, mask, impl::order(mem_ord),
+                                     impl::scope(mem_scope));
 #else
-    return __atomic_fetch_and(ptr, mask, order(mem_ord));
+    return __atomic_fetch_and(ptr, mask, impl::order(mem_ord));
 #endif
   }
 
@@ -372,10 +387,10 @@ public:
       [[maybe_unused]] MemoryScope mem_scope = MemoryScope::DEVICE) const {
     static_assert(cpp::is_integral_v<T>, "T must be an integral type.");
 #if __has_builtin(__scoped_atomic_fetch_sub)
-    return __scoped_atomic_fetch_sub(ptr, decrement, order(mem_ord),
-                                     scope(mem_scope));
+    return __scoped_atomic_fetch_sub(ptr, decrement, impl::order(mem_ord),
+                                     impl::scope(mem_scope));
 #else
-    return __atomic_fetch_sub(ptr, decrement, order(mem_ord));
+    return __atomic_fetch_sub(ptr, decrement, impl::order(mem_ord));
 #endif
   }
 };
@@ -408,11 +423,6 @@ LIBC_INLINE void atomic_signal_fence([[maybe_unused]] MemoryOrder mem_ord) {
   asm volatile("" ::: "memory");
 #endif
 }
-} // namespace atomic
-
-using atomic::Atomic;
-using atomic::AtomicRef;
-
 } // namespace cpp
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/__support/CPP/atomic.h
+++ b/libc/src/__support/CPP/atomic.h
@@ -49,6 +49,7 @@ LIBC_INLINE constexpr int order(MemoryOrder mem_ord) {
 LIBC_INLINE constexpr int scope(MemoryScope mem_scope) {
   return static_cast<int>(mem_scope);
 }
+
 template <class T> LIBC_INLINE T *addressof(T &ref) {
   return __builtin_addressof(ref);
 }


### PR DESCRIPTION
See https://en.cppreference.com/w/cpp/atomic/atomic/compare_exchange. The failure order should be inferred from the success order if it is not explicitly specified.