### PR TITLE
[flang] Fix slp-vectorize.f90 test

### DIFF
--- a/flang/test/Driver/slp-vectorize.f90
+++ b/flang/test/Driver/slp-vectorize.f90
@@ -6,8 +6,8 @@
 ! RUN: %flang -### -S -O3 %s 2>&1 | FileCheck -check-prefix=CHECK-SLP-VECTORIZE %s
 ! RUN: %flang -### -S -Os %s 2>&1 | FileCheck -check-prefix=CHECK-SLP-VECTORIZE %s
 ! RUN: %flang -### -S -Oz %s 2>&1 | FileCheck -check-prefix=CHECK-SLP-VECTORIZE %s
-! RUN: %flang_fc1 -emit-llvm -O2 -vectorize-slp -mllvm -print-pipeline-passes %s 2>&1 | FileCheck -check-prefix=CHECK-SLP-VECTORIZER %s
-! RUN: %flang_fc1 -emit-llvm -O2 -mllvm -print-pipeline-passes %s 2>&1 | FileCheck -check-prefix=CHECK-NO-SLP-VECTORIZER %s
+! RUN: %flang_fc1 -emit-llvm -O2 -vectorize-slp -mllvm -print-pipeline-passes -o /dev/null %s 2>&1 | FileCheck -check-prefix=CHECK-SLP-VECTORIZER %s
+! RUN: %flang_fc1 -emit-llvm -O2 -mllvm -print-pipeline-passes -o /dev/null %s 2>&1 | FileCheck -check-prefix=CHECK-NO-SLP-VECTORIZER %s
 ! CHECK-SLP-VECTORIZE: "-vectorize-slp"
 ! CHECK-NO-SLP-VECTORIZE-NOT: "-no-vectorize-slp"
 ! CHECK-SLP-VECTORIZER: slp-vectorizer


### PR DESCRIPTION
The test was missing "-o /dev/null" and inadvertently generating a .ll file in the test directory.