### PR TITLE
[libc][bazel] Create a libc_header_library macro for hand-in-hand.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -9,6 +9,7 @@ load("@rules_python//python:defs.bzl", "py_binary")
 load(
     ":libc_build_rules.bzl",
     "libc_function",
+    "libc_header_library",
     "libc_math_function",
     "libc_support_library",
 )
@@ -1589,12 +1590,28 @@ libc_support_library(
 
 ########################## externally shared targets ###########################
 
+# TODO: Remove this once downstream users are migrated to libcxx_shared_headers.
 libc_support_library(
     name = "libc_external_common",
     hdrs = glob(
         ["shared/*.h"],
         exclude = ["shared/rpc_server.h"],
     ),
+    deps = [
+        ":__support_common",
+        ":__support_fputil_fp_bits",
+        ":__support_str_to_float",
+        ":__support_str_to_integer",
+    ],
+)
+
+libc_header_library(
+    name = "libcxx_shared_headers",
+    hdrs = [
+        "shared/fp_bits.h",
+        "shared/str_to_float.h",
+        "shared/str_to_integer.h",
+    ],
     deps = [
         ":__support_common",
         ":__support_fputil_fp_bits",

--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -165,6 +165,42 @@ def libc_release_library(
         **kwargs
     )
 
+def libc_header_library(name, hdrs, deps = [], **kwargs):
+    """Creates a header-only library to share libc functionality.
+
+    Args:
+      name: Name of the cc_library target.
+      hdrs: List of headers to be shared.
+      deps: The list of libc_support_library dependencies if any.
+      **kwargs: All other attributes relevant for the cc_library rule.
+    """
+
+    # Combine sources from dependencies to create a single cc_library target.
+    native.filegroup(
+        name = name + "_hdr_deps",
+        srcs = [dep + "_srcs" for dep in deps],
+    )
+    native.cc_library(
+        name = name + "_textual_hdr_library",
+        textual_hdrs = [dep + "_textual_hdrs" for dep in deps],
+    )
+    native.cc_library(
+        name = name,
+        # Technically speaking, we should put _hdr_deps in srcs, as they are
+        # not a part of this cc_library interface. However, we keep it here to
+        # workaround the presence of .cpp files in _hdr_deps - we need to
+        # fix that and enforce their absence, since libc_header_library
+        # should be header-only and not produce any object files.
+        # See PR #133126 which tracks it.
+        hdrs = hdrs + [":" + name + "_hdr_deps"],
+        deps = [":" + name + "_textual_hdr_library"],
+        # copts don't really matter, since it's a header-only library, but we
+        # need proper -I flags for header validation, which are specified in
+        # libc_common_copts().
+        copts = libc_common_copts(),
+        **kwargs
+    )
+
 def libc_math_function(
         name,
         additional_deps = None):


### PR DESCRIPTION
Create a proper way to build header-only libraries for llvm-libc code sharing. Use it to group headers that can be shared with libcxx for std::from_chars() implementation.

It mostly works, though the macro needs to be updated to enforce that no .cpp files are listed in dependencies (it's not the case now) - see PR #133126.