### PR TITLE
[github] pre-cache llvm-project in Linux CI Docker images

### DIFF
--- a/.github/workflows/containers/github-action-ci/Dockerfile
+++ b/.github/workflows/containers/github-action-ci/Dockerfile
@@ -94,3 +94,14 @@ RUN mkdir actions-runner && \
     tar xzf ./actions-runner-linux-x64-$GITHUB_RUNNER_VERSION.tar.gz && \
     rm ./actions-runner-linux-x64-$GITHUB_RUNNER_VERSION.tar.gz
 
+# Pre-cache llvm-project in these images; this works with the premerge action
+# to speed up runs; cloning LLVM fresh takes >1min otherwise.
+#
+# A local experiment showed an explicit `git gc --aggressive` reduced this
+# layer's size by ~800MB (4.1GB -> 3.3GB). Disable GC'ing
+# afterward, so we don't waste time trying to do that in CI.
+RUN \
+  git clone https://github.com/llvm/llvm-project --tags && \
+  cd llvm-project && \
+  git gc --aggressive && \
+  git config gc.auto 0


### PR DESCRIPTION
**Meta**: I'm not familiar with the actual deployment process here, but I'd _ideally_ like to be able to test this PR prior to submitting it. Not sure whether that'll be worth the effort compared to landing it (or splitting it, waiting for the new Docker image to appear, then messing with the `premerge.yaml` part of this) though?

Any guidance on how to test any part of this out-of-production is appreciated. :) 

=====

Linux CI bots take a bit over a minute to fully set their git repos up, always starting from scratch. This can end up being a significant percentage of their overall runtime.

If llvm-project is built into the images & used as a cache, we could potentially speed that up quite a bit. Try it out and see.

If this is successful, should be easy to port to Windows CI, too. I'm preferring to start small though.