### PR TITLE
[SPIR-V] Mark XFAIL the test case that fails with LLVM_ENABLE_EXPENSIVE_CHECKS enabled

### DIFF
--- a/llvm/test/CodeGen/SPIRV/structurizer/cf.switch.ifstmt.simple2.ll
+++ b/llvm/test/CodeGen/SPIRV/structurizer/cf.switch.ifstmt.simple2.ll
@@ -1,6 +1,9 @@
 ; RUN: llc -mtriple=spirv-unknown-vulkan-compute -O0 %s -o - | FileCheck %s
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan-compute %s -o - -filetype=obj | spirv-val %}
 
+; TODO: This test currently fails with LLVM_ENABLE_EXPENSIVE_CHECKS enabled
+; XFAIL: expensive_checks
+
 ; static int foo() { return 200; }
 ;
 ; static int process() {


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/130605 structurizer/cf.switch.ifstmt.simple2.ll test case starts failing with the "PHI operand is not live-out from predecessor" diagnostic message. This test case didn't include usual "-verify-machineinstrs" argument and the fail was missed before https://github.com/llvm/llvm-project/pull/130605 merging.

The problem looks not blocking, because the test case successfully passes its CHECK's. This PR is to fix the build process by mark the test case as XFAIL when LLVM_ENABLE_EXPENSIVE_CHECKS is enabled.

Investigation of the Machine Verifier complaint is to do. The issue is created: https://github.com/llvm/llvm-project/issues/133141