### PR TITLE
[mlir][IntegerRangeAnalysis] expose maybeReplaceWithConstant

### DIFF
--- a/mlir/include/mlir/Analysis/DataFlow/IntegerRangeAnalysis.h
+++ b/mlir/include/mlir/Analysis/DataFlow/IntegerRangeAnalysis.h
@@ -22,6 +22,7 @@
 #include "mlir/Interfaces/InferIntRangeInterface.h"
 
 namespace mlir {
+class RewriterBase;
 namespace dataflow {
 
 /// This lattice element represents the integer value range of an SSA value.
@@ -82,6 +83,9 @@ LogicalResult staticallyNonNegative(DataFlowSolver &solver, Operation *op);
 /// Note, the results of this query may not be accurate for `index` if you plan
 /// to use a non-64-bit index.
 LogicalResult staticallyNonNegative(DataFlowSolver &solver, Value v);
+
+LogicalResult maybeReplaceWithConstant(DataFlowSolver &solver,
+                                       RewriterBase &rewriter, Value value);
 
 } // end namespace dataflow
 } // end namespace mlir

--- a/mlir/lib/Dialect/Arith/Transforms/IntRangeOptimizations.cpp
+++ b/mlir/lib/Dialect/Arith/Transforms/IntRangeOptimizations.cpp
@@ -57,10 +57,10 @@ static void copyIntegerRange(DataFlowSolver &solver, Value oldVal,
       *oldState);
 }
 
+namespace mlir::dataflow {
 /// Patterned after SCCP
-static LogicalResult maybeReplaceWithConstant(DataFlowSolver &solver,
-                                              PatternRewriter &rewriter,
-                                              Value value) {
+LogicalResult maybeReplaceWithConstant(DataFlowSolver &solver,
+                                       RewriterBase &rewriter, Value value) {
   if (value.use_empty())
     return failure();
   std::optional<APInt> maybeConstValue = getMaybeConstantValue(solver, value);
@@ -95,6 +95,7 @@ static LogicalResult maybeReplaceWithConstant(DataFlowSolver &solver,
   rewriter.replaceAllUsesWith(value, constOp->getResult(0));
   return success();
 }
+} // namespace mlir::dataflow
 
 namespace {
 class DataFlowListener : public RewriterBase::Listener {


### PR DESCRIPTION
This PR exposes `maybeReplaceWithConstant` in headers for downstream use.