### PR TITLE
[compiler-rt][tests][AIX] Use /opt/freeware/bin/env

### DIFF
--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -395,9 +395,10 @@ if config.have_disable_symbolizer_path_search:
         if sanitizer not in config.environment:
             config.environment[sanitizer] = symbolizer_path
 
+env_utility = "/opt/freeware/bin/env" if config.host_os == "AIX" else "env"
 env_unset_command = " ".join(f"-u {var}" for var in tool_symbolizer_path_list)
 config.substitutions.append(
-    ("%env_unset_tool_symbolizer_path", f"env {env_unset_command}")
+    ("%env_unset_tool_symbolizer_path", f"{env_utility} {env_unset_command}")
 )
 
 # Allow tests to be executed on a simulator or remotely.


### PR DESCRIPTION
`env -u` is not supported by the system `env` utility on AIX.
`/opt/freeware/bin/env` is the standard path for the GNU coreutils `env` utility as distributed by the AIX Toolbox for Open Source Software.
Adding `/opt/freeware/bin` to `PATH` causes issues by picking up other utilities that are less capable, in an AIX context, than the system ones.
This patch modifies the relevant usage of `env` to use (on AIX) the full path to `/opt/freeware/bin/env`.
