### PR TITLE
[Docs] Clarify that `reassoc` isn't just for reassociation

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -3971,8 +3971,9 @@ output, given the original flags.
    for places where this can apply to LLVM's intrinsic math functions.
 
 ``reassoc``
-   Allow reassociation transformations for floating-point instructions.
-   This may dramatically change results in floating-point.
+   Allow algebraically equivalent transformations for floating-point
+   instructions such as reassociation transformations. This may dramatically
+   change results in floating-point.
 
 .. _uselistorder:
 


### PR DESCRIPTION
The `reassoc` fast-math flag allows a much wider array of algebraic transformations than just strictly reassociations. In some cases it does commutations, distributions, and folds away redundant inverse operations...

While it might make sense to fix the flag naming at some point, in the meantime we should at least have the docs be accurate to avoid confusion.