### PR TITLE
[asan] Print diagnostic if unlimited stack size detected

### DIFF
--- a/compiler-rt/lib/asan/asan_rtl.cpp
+++ b/compiler-rt/lib/asan/asan_rtl.cpp
@@ -461,7 +461,7 @@ static bool AsanInitInternal() {
     // re-exec without ASLR, which solves most shadow mapping compatibility
     // issues.
   }
-#endif
+#endif  // SANITIZER_POSIX
 
   InitializeShadowMemory();
 

--- a/compiler-rt/lib/asan/asan_rtl.cpp
+++ b/compiler-rt/lib/asan/asan_rtl.cpp
@@ -453,8 +453,9 @@ static bool AsanInitInternal() {
 
 #if SANITIZER_POSIX
   if (StackSizeIsUnlimited()) {
-    VPrintf(1, "WARNING: Unlimited stack size detected. This may affect "
-               "compatibility with the shadow mappings.\n");
+    VPrintf(1,
+            "WARNING: Unlimited stack size detected. This may affect "
+            "compatibility with the shadow mappings.\n");
     // MSan and TSan re-exec with a fixed size stack. We don't do that because
     // it may break the program. InitializeShadowMemory() will, if needed,
     // re-exec without ASLR, which solves most shadow mapping compatibility

--- a/compiler-rt/lib/asan/asan_rtl.cpp
+++ b/compiler-rt/lib/asan/asan_rtl.cpp
@@ -451,6 +451,17 @@ static bool AsanInitInternal() {
 
   DisableCoreDumperIfNecessary();
 
+#if SANITIZER_POSIX
+  if (StackSizeIsUnlimited()) {
+    VPrintf(1, "WARNING: Unlimited stack size detected. This may affect "
+               "compatibility with the shadow mappings.\n");
+    // MSan and TSan re-exec with a fixed size stack. We don't do that because
+    // it may break the program. InitializeShadowMemory() will, if needed,
+    // re-exec without ASLR, which solves most shadow mapping compatibility
+    // issues.
+  }
+#endif
+
   InitializeShadowMemory();
 
   AsanTSDInit(PlatformTSDDtor);


### PR DESCRIPTION
This adds a diagnostic message if the stack size is unlimited. This would have simplified the diagnosis of
https://github.com/google/sanitizers/issues/856#issuecomment-2747076811; we anticipate this may help diagnose future issues too.