### PR TITLE
[libc] Update headers on aarch64

### DIFF
--- a/libc/config/linux/aarch64/headers.txt
+++ b/libc/config/linux/aarch64/headers.txt
@@ -1,43 +1,60 @@
 set(TARGET_PUBLIC_HEADERS
+    libc.include.arpa_inet
     libc.include.assert
     libc.include.complex
     libc.include.ctype
+    libc.include.dirent
     libc.include.dlfcn
     libc.include.elf
     libc.include.endian
     libc.include.errno
+    libc.include.fcntl
     libc.include.features
     libc.include.fenv
     libc.include.float
     libc.include.inttypes
     libc.include.limits
     libc.include.link
+    libc.include.locale
     libc.include.malloc
     libc.include.math
     libc.include.poll
     libc.include.pthread
+    libc.include.sched
     libc.include.search
+    libc.include.setjmp
     libc.include.signal
+    libc.include.spawn
     libc.include.stdbit
     libc.include.stdckdint
+    libc.include.stdfix
     libc.include.stdint
     libc.include.stdio
     libc.include.stdlib
     libc.include.string
     libc.include.strings
+    libc.include.sys_auxv
+    libc.include.sys_epoll
+    libc.include.sys_ioctl
     libc.include.sys_mman
+    libc.include.sys_prctl
+    libc.include.sys_queue
+    libc.include.sys_random
+    libc.include.sys_resource
+    libc.include.sys_select
     libc.include.sys_socket
+    libc.include.sys_stat
+    libc.include.sys_statvfs
     libc.include.sys_syscall
     libc.include.sys_time
-    libc.include.sysexits
+    libc.include.sys_types
+    libc.include.sys_utsname
     libc.include.sys_wait
+    libc.include.sysexits
+    libc.include.termios
     libc.include.threads
     libc.include.time
     libc.include.uchar
     libc.include.unistd
     libc.include.wchar
-
-    libc.include.sys_ioctl
-    # Disabled due to epoll_wait syscalls not being available on this platform.
-    # libc.include.sys_epoll
 )

--- a/libc/src/__support/OSUtil/linux/CMakeLists.txt
+++ b/libc/src/__support/OSUtil/linux/CMakeLists.txt
@@ -22,6 +22,7 @@ add_object_library(
     libc.hdr.types.struct_flock64
     libc.hdr.types.struct_f_owner_ex
     libc.hdr.types.off_t
+    libc.include.sys_syscall
 )
 
 add_header_library(


### PR DESCRIPTION
The entrypoints for aarch64 are mostly up to date, but the headers are
not. This patch fixes that, and also makes explicit the dependency from
OSUtils/linux on sys/syscalls.h
