### PR TITLE
[Sanitizers][Darwin][Test]  Remove community incompliant internal link from sources

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Darwin/malloc_zone.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Darwin/malloc_zone.cpp
@@ -17,7 +17,7 @@
 // UBSan does not install a malloc zone.
 // XFAIL: ubsan
 //
-// Currently fails on darwin/lsan rdar://145873843
+// Currently fails on darwin/lsan
 // XFAIL: darwin && lsan
 
 #include <malloc/malloc.h>


### PR DESCRIPTION
The malloc_zone.cpp test currently fails on Darwin hosts, in SanitizerCommon
tests with lsan enabled.

Need to XFAIL this test to buy time to investigate this failure. Also
we're trying to bring the number of test failing on Darwin bots to 0, to
get clearer signal of any new failures.

rdar://145873843
