### PR TITLE
[RISCV] Set mayRaiseFPException = 0 on FCVT_D_W(U).

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoD.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoD.td
@@ -144,12 +144,14 @@ foreach Ext = DExts in {
                                      "fcvt.wu.d">,
                    Sched<[WriteFCvtF64ToI32, ReadFCvtF64ToI32]>;
 
-  defm FCVT_D_W : FPUnaryOp_r_frmlegacy_m<0b1101001, 0b00000, Ext, Ext.PrimaryTy, GPR,
-                                          "fcvt.d.w">,
+  let mayRaiseFPException = 0 in
+  defm FCVT_D_W : FPUnaryOp_r_frmlegacy_m<0b1101001, 0b00000, Ext,
+                                          Ext.PrimaryTy, GPR, "fcvt.d.w">,
                   Sched<[WriteFCvtI32ToF64, ReadFCvtI32ToF64]>;
 
-  defm FCVT_D_WU : FPUnaryOp_r_frmlegacy_m<0b1101001, 0b00001, Ext, Ext.PrimaryTy, GPR,
-                                           "fcvt.d.wu">,
+  let mayRaiseFPException = 0 in
+  defm FCVT_D_WU : FPUnaryOp_r_frmlegacy_m<0b1101001, 0b00001, Ext,
+                                           Ext.PrimaryTy, GPR, "fcvt.d.wu">,
                    Sched<[WriteFCvtI32ToF64, ReadFCvtI32ToF64]>;
 } // foreach Ext = DExts
 

--- a/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/itofp-rv32.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/itofp-rv32.mir
@@ -59,7 +59,7 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[FCVT_D_W:%[0-9]+]]:fpr64 = nofpexcept FCVT_D_W [[COPY]], 0
+    ; CHECK-NEXT: [[FCVT_D_W:%[0-9]+]]:fpr64 = FCVT_D_W [[COPY]], 0
     ; CHECK-NEXT: $f10_d = COPY [[FCVT_D_W]]
     ; CHECK-NEXT: PseudoRET implicit $f10_d
     %0:gprb(s32) = COPY $x10
@@ -81,7 +81,7 @@ body:             |
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x10
-    ; CHECK-NEXT: [[FCVT_D_WU:%[0-9]+]]:fpr64 = nofpexcept FCVT_D_WU [[COPY]], 0
+    ; CHECK-NEXT: [[FCVT_D_WU:%[0-9]+]]:fpr64 = FCVT_D_WU [[COPY]], 0
     ; CHECK-NEXT: $f10_d = COPY [[FCVT_D_WU]]
     ; CHECK-NEXT: PseudoRET implicit $f10_d
     %0:gprb(s32) = COPY $x10

--- a/llvm/test/CodeGen/RISCV/double-imm.ll
+++ b/llvm/test/CodeGen/RISCV/double-imm.ll
@@ -123,9 +123,9 @@ define dso_local double @negzero_sel(i16 noundef %a, double noundef %d) nounwind
 ; CHECK32D-LABEL: negzero_sel:
 ; CHECK32D:       # %bb.0: # %entry
 ; CHECK32D-NEXT:    slli a0, a0, 16
-; CHECK32D-NEXT:    fcvt.d.w fa5, zero
 ; CHECK32D-NEXT:    beqz a0, .LBB4_2
 ; CHECK32D-NEXT:  # %bb.1: # %entry
+; CHECK32D-NEXT:    fcvt.d.w fa5, zero
 ; CHECK32D-NEXT:    fneg.d fa0, fa5
 ; CHECK32D-NEXT:  .LBB4_2: # %entry
 ; CHECK32D-NEXT:    ret
@@ -143,10 +143,10 @@ define dso_local double @negzero_sel(i16 noundef %a, double noundef %d) nounwind
 ; CHECKRV32ZDINX-LABEL: negzero_sel:
 ; CHECKRV32ZDINX:       # %bb.0: # %entry
 ; CHECKRV32ZDINX-NEXT:    slli a0, a0, 16
-; CHECKRV32ZDINX-NEXT:    fcvt.d.w a4, zero
 ; CHECKRV32ZDINX-NEXT:    beqz a0, .LBB4_2
 ; CHECKRV32ZDINX-NEXT:  # %bb.1: # %entry
-; CHECKRV32ZDINX-NEXT:    fneg.d a2, a4
+; CHECKRV32ZDINX-NEXT:    fcvt.d.w a0, zero
+; CHECKRV32ZDINX-NEXT:    fneg.d a2, a0
 ; CHECKRV32ZDINX-NEXT:    j .LBB4_3
 ; CHECKRV32ZDINX-NEXT:  .LBB4_2:
 ; CHECKRV32ZDINX-NEXT:    mv a3, a2

--- a/llvm/test/CodeGen/RISCV/frm-dependency.ll
+++ b/llvm/test/CodeGen/RISCV/frm-dependency.ll
@@ -87,16 +87,17 @@ define double @fcvt_d_w(i32 %a) nounwind {
   ; RV32IF-NEXT:   liveins: $x10
   ; RV32IF-NEXT: {{  $}}
   ; RV32IF-NEXT:   [[COPY:%[0-9]+]]:gpr = COPY $x10
-  ; RV32IF-NEXT:   %1:fpr64 = nofpexcept FCVT_D_W [[COPY]]
-  ; RV32IF-NEXT:   $f10_d = COPY %1
+  ; RV32IF-NEXT:   [[FCVT_D_W:%[0-9]+]]:fpr64 = FCVT_D_W [[COPY]], 0
+  ; RV32IF-NEXT:   $f10_d = COPY [[FCVT_D_W]]
   ; RV32IF-NEXT:   PseudoRET implicit $f10_d
+  ;
   ; RV64IF-LABEL: name: fcvt_d_w
   ; RV64IF: bb.0 (%ir-block.0):
   ; RV64IF-NEXT:   liveins: $x10
   ; RV64IF-NEXT: {{  $}}
   ; RV64IF-NEXT:   [[COPY:%[0-9]+]]:gpr = COPY $x10
-  ; RV64IF-NEXT:   %1:fpr64 = nofpexcept FCVT_D_W [[COPY]]
-  ; RV64IF-NEXT:   $f10_d = COPY %1
+  ; RV64IF-NEXT:   [[FCVT_D_W:%[0-9]+]]:fpr64 = FCVT_D_W [[COPY]], 0
+  ; RV64IF-NEXT:   $f10_d = COPY [[FCVT_D_W]]
   ; RV64IF-NEXT:   PseudoRET implicit $f10_d
   %1 = sitofp i32 %a to double
   ret double %1


### PR DESCRIPTION
No exception flags are listed for the instruction here https://github.com/riscv/riscv-isa-manual/blob/1929d45a059979c55b070fba414d97d530a44c99/src/rvwmo.adoc#source-and-destination-register-listings

The input is an integer which can't be NAN so the NV(invalid) exception can't be raised. The conversion is exact so it can't raise NX(inexact), UF(underflow), or OF(overflow). The instructions are not divide so they can't raise DZ(divide by zero).

Fixes #133192.