### PR TITLE
[Driver] Use a range constructor of StringSet (NFC)

### DIFF
--- a/clang/lib/Driver/Job.cpp
+++ b/clang/lib/Driver/Job.cpp
@@ -140,9 +140,7 @@ void Command::buildArgvForResponseFile(
     return;
   }
 
-  llvm::StringSet<> Inputs;
-  for (const auto *InputName : InputFileList)
-    Inputs.insert(InputName);
+  llvm::StringSet<> Inputs(llvm::from_range, InputFileList);
   Out.push_back(Executable);
 
   if (PrependArg)

--- a/clang/lib/Driver/Multilib.cpp
+++ b/clang/lib/Driver/Multilib.cpp
@@ -60,9 +60,7 @@ void Multilib::print(raw_ostream &OS) const {
 bool Multilib::operator==(const Multilib &Other) const {
   // Check whether the flags sets match
   // allowing for the match to be order invariant
-  llvm::StringSet<> MyFlags;
-  for (const auto &Flag : Flags)
-    MyFlags.insert(Flag);
+  llvm::StringSet<> MyFlags(llvm::from_range, Flags);
 
   for (const auto &Flag : Other.Flags)
     if (!MyFlags.contains(Flag))
@@ -272,9 +270,7 @@ bool MultilibSet::select(
 
 llvm::StringSet<>
 MultilibSet::expandFlags(const Multilib::flags_list &InFlags) const {
-  llvm::StringSet<> Result;
-  for (const auto &F : InFlags)
-    Result.insert(F);
+  llvm::StringSet<> Result(llvm::from_range, InFlags);
   for (const FlagMatcher &M : FlagMatchers) {
     std::string RegexString(M.Match);
 


### PR DESCRIPTION
This patch uses a range constructor to collapse:

  llvm::StringSet<> Dest;
  for (const auto &S : Src)
    Dest.insert(S);

down to:

  llvm::StringSet<> Dest(llvm::from_range, Src);
