### PR TITLE
[ADT] Remove old range constructors of SmallSet and StringSet

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -119,8 +119,8 @@ public:
   bool ReadHeaderSearchPaths(const HeaderSearchOptions &HSOpts,
                              bool Complain) override {
     std::vector<std::string> VFSOverlayFiles = HSOpts.VFSOverlayFiles;
-    PrebuiltModuleVFSMap.insert(
-        {CurrentFile, llvm::StringSet<>(VFSOverlayFiles)});
+    PrebuiltModuleVFSMap.try_emplace(CurrentFile, llvm::from_range,
+                                     VFSOverlayFiles);
     return checkHeaderSearchPaths(
         HSOpts, ExistingHSOpts, Complain ? &Diags : nullptr, ExistingLangOpts);
   }

--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -161,11 +161,6 @@ public:
   SmallSet(llvm::from_range_t, Range &&R)
       : SmallSet(adl_begin(R), adl_end(R)) {}
 
-  template <typename RangeT>
-  explicit SmallSet(const iterator_range<RangeT> &R) {
-    insert(R.begin(), R.end());
-  }
-
   SmallSet(std::initializer_list<T> L) { insert(L.begin(), L.end()); }
 
   SmallSet &operator=(const SmallSet &) = default;

--- a/llvm/include/llvm/ADT/StringSet.h
+++ b/llvm/include/llvm/ADT/StringSet.h
@@ -34,10 +34,6 @@ public:
   template <typename Range> StringSet(llvm::from_range_t, Range &&R) {
     insert(adl_begin(R), adl_end(R));
   }
-  template <typename Container> explicit StringSet(Container &&C) {
-    for (auto &&Str : C)
-      insert(Str);
-  }
   explicit StringSet(AllocatorTy a) : Base(a) {}
 
   std::pair<typename Base::iterator, bool> insert(StringRef key) {

--- a/llvm/unittests/ADT/SmallSetTest.cpp
+++ b/llvm/unittests/ADT/SmallSetTest.cpp
@@ -24,13 +24,6 @@ TEST(SmallSetTest, ConstructorIteratorPair) {
   EXPECT_THAT(S, testing::UnorderedElementsAreArray(L));
 }
 
-TEST(SmallSet, ConstructorRange) {
-  std::initializer_list<int> L = {1, 2, 3, 4, 5};
-
-  SmallSet<int, 4> S(llvm::make_range(std::begin(L), std::end(L)));
-  EXPECT_THAT(S, testing::UnorderedElementsAreArray(L));
-}
-
 TEST(SmallSet, ConstructorInitializerList) {
   std::initializer_list<int> L = {1, 2, 3, 4, 5};
   SmallSet<int, 4> S = {1, 2, 3, 4, 5};


### PR DESCRIPTION
This patch removes the old range constructors of SmallSet and
StringSet that do not take the llvm::from_range tag.  Since there are
so few uses, this patch directly removes them without going through
the deprecation process.
