### PR TITLE
[Clang] Correct the DeclRefExpr's Type after the initializer gets instantiated

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -355,6 +355,7 @@ Bug Fixes to C++ Support
 - Correctly diagnoses if unresolved using declarations shadows template paramters (#GH129411)
 - Clang was previously coalescing volatile writes to members of volatile base class subobjects.
   The issue has been addressed by propagating qualifiers during derived-to-base conversions in the AST. (#GH127824)
+- Correctly propagates the instantiated array type to the ``DeclRefExpr`` that refers to it. (#GH79750), (#GH113936), (#GH133047)
 - Fixed a Clang regression in C++20 mode where unresolved dependent call expressions were created inside non-dependent contexts (#GH122892)
 - Clang now emits the ``-Wunused-variable`` warning when some structured bindings are unused
   and the ``[[maybe_unused]]`` attribute is not applied. (#GH125810)

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -19852,7 +19852,8 @@ static void DoMarkVarDeclReferenced(
         // The size of an incomplete array type can be updated by
         // instantiating the initializer. The DeclRefExpr's type should be
         // updated accordingly too, or users of it would be confused!
-        SemaRef.getCompletedType(E);
+        if (E)
+          SemaRef.getCompletedType(E);
 
         // Re-set the member to trigger a recomputation of the dependence bits
         // for the expression.

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -19849,11 +19849,14 @@ static void DoMarkVarDeclReferenced(
           SemaRef.InstantiateVariableDefinition(PointOfInstantiation, Var);
         });
 
-        // Re-set the member to trigger a recomputation of the dependence bits
-        // for the expression.
-        if (auto *DRE = dyn_cast_or_null<DeclRefExpr>(E))
+        if (auto *DRE = dyn_cast_or_null<DeclRefExpr>(E)) {
+          // Re-set the member to trigger a recomputation of the dependence bits
+          // for the expression.
           DRE->setDecl(DRE->getDecl());
-        else if (auto *ME = dyn_cast_or_null<MemberExpr>(E))
+          if (SemaRef.Context.getAsIncompleteArrayType(DRE->getType()) &&
+              !SemaRef.Context.getAsIncompleteArrayType(Var->getType()))
+            DRE->setType(Var->getType());
+        } else if (auto *ME = dyn_cast_or_null<MemberExpr>(E))
           ME->setMemberDecl(ME->getMemberDecl());
       } else if (FirstInstantiation) {
         SemaRef.PendingInstantiations

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -19853,6 +19853,12 @@ static void DoMarkVarDeclReferenced(
           // Re-set the member to trigger a recomputation of the dependence bits
           // for the expression.
           DRE->setDecl(DRE->getDecl());
+          // The size of an incomplete array type can be updated by
+          // instantiating the initializer. The DeclRefExpr's type should be
+          // updated accordingly too, or users of it would be confused!
+          //
+          // FIXME: Do we need to recompute the type for all the Decls, as in
+          // BuildDeclarationNameExpr?
           if (SemaRef.Context.getAsIncompleteArrayType(DRE->getType()) &&
               !SemaRef.Context.getAsIncompleteArrayType(Var->getType()))
             DRE->setType(Var->getType());

--- a/clang/test/SemaCXX/cxx1y-variable-templates_top_level.cpp
+++ b/clang/test/SemaCXX/cxx1y-variable-templates_top_level.cpp
@@ -467,3 +467,29 @@ namespace VexingParse {
   template <typename> int var; // expected-note {{declared here}}
   int x(var); // expected-error {{use of variable template 'var' requires template arguments}}
 }
+
+#ifndef PRECXX11
+
+namespace GH79750 {
+
+enum class Values { A };
+
+template<typename E>
+constexpr Values values[] = {E::A};
+
+constexpr auto r = values<Values>[0] == Values::A;
+
+}
+
+namespace GH113956 {
+
+template <class T, T... VALUES>
+struct C {
+  static constexpr T VALUEARRAY[] = {VALUES...};
+};
+
+static_assert(C<int, 0,1,2,3,4>::VALUEARRAY[3] == 3, "");
+static_assert(C<int, 0,1,2,3,4>::VALUEARRAY[0] == 0, "");
+
+}
+#endif


### PR DESCRIPTION
The instantiation of a VarDecl's initializer might be deferred until the variable is actually used. However, we were still building the DeclRefExpr with a type that could later be changed by the initializer's instantiation, which is incorrect when incomplete arrays are involved.

Fixes #79750
Fixes #113936
Fixes #133047

