### PR TITLE
[mlir] Add nullptr checks in SparseElementsAttr parser 

### DIFF
--- a/mlir/lib/AsmParser/AttributeParser.cpp
+++ b/mlir/lib/AsmParser/AttributeParser.cpp
@@ -1085,6 +1085,8 @@ Attribute Parser::parseSparseElementsAttr(Type attrType) {
     indicesType = RankedTensorType::get(indiceParser.getShape(), indiceEltType);
   }
   auto indices = indiceParser.getAttr(indicesLoc, indicesType);
+  if (!indices)
+    return nullptr;
 
   // If the values are a splat, set the shape explicitly based on the number of
   // indices. The number of indices is encoded in the first dimension of the
@@ -1095,6 +1097,8 @@ Attribute Parser::parseSparseElementsAttr(Type attrType) {
           ? RankedTensorType::get({indicesType.getDimSize(0)}, valuesEltType)
           : RankedTensorType::get(valuesParser.getShape(), valuesEltType);
   auto values = valuesParser.getAttr(valuesLoc, valuesType);
+  if (!values)
+    return nullptr;
 
   // Build the sparse elements attribute by the indices and values.
   return getChecked<SparseElementsAttr>(loc, type, indices, values);

--- a/mlir/test/IR/invalid-builtin-attributes.mlir
+++ b/mlir/test/IR/invalid-builtin-attributes.mlir
@@ -109,6 +109,14 @@ func.func @invalid_tensor_literal() {
 
 // -----
 
+func.func @invalid_tensor_literal() {
+  // expected-error @+2 {{unexpected decimal integer literal for a floating point value}}
+  // expected-note @+1 {{add a trailing dot to make the literal a float}}
+  "foo"(){bar = sparse<[0, 0], 0101> : tensor<1xf16>} : () -> ()
+}
+
+// -----
+
 func.func @hexadecimal_float_leading_minus() {
   // expected-error @+1 {{hexadecimal float literal should not have a leading minus}}
   "foo"() {value = -0x7fff : f16} : () -> ()

--- a/mlir/test/IR/invalid-builtin-attributes.mlir
+++ b/mlir/test/IR/invalid-builtin-attributes.mlir
@@ -109,10 +109,16 @@ func.func @invalid_tensor_literal() {
 
 // -----
 
-func.func @invalid_tensor_literal() {
-  // expected-error @+2 {{unexpected decimal integer literal for a floating point value}}
-  // expected-note @+1 {{add a trailing dot to make the literal a float}}
-  "foo"(){bar = sparse<[0, 0], 0101> : tensor<1xf16>} : () -> ()
+func.func @invalid_sparse_indices() {
+  // expected-error @+1 {{expected integer elements, but parsed floating-point}}
+  "foo"(){bar = sparse<0.5, 1> : tensor<1xi16>} : () -> ()
+}
+
+// -----
+
+func.func @invalid_sparse_values() {
+  // expected-error @+1 {{expected integer elements, but parsed floating-point}}
+  "foo"(){bar = sparse<0, 1.1> : tensor<1xi16>} : () -> ()
 }
 
 // -----


### PR DESCRIPTION
This PR adds nullptr checks in the SparseElementsAttr parser to improve robustness and prevent crashes. Fixes #132891.