### PR TITLE
[WIP] [flang] Always lower ALLOCATE/DEALLOCATE to runtime calls.

### DIFF
--- a/flang/lib/Lower/Allocatable.cpp
+++ b/flang/lib/Lower/Allocatable.cpp
@@ -468,11 +468,11 @@ private:
   }
 
   void genSimpleAllocation(const Allocation &alloc,
-      const fir::MutableBoxValue &box) {  
+                           const fir::MutableBoxValue &box) {
     bool isCudaSymbol = Fortran::semantics::HasCUDAAttr(alloc.getSymbol());
-    
+
     unsigned allocatorIdx = Fortran::lower::getAllocatorIdx(alloc.getSymbol());
-  
+
     if (isCudaSymbol) {
       bool inlineAllocation = !box.isDerived() && !errorManager.hasStatSpec() &&
                               !alloc.type.IsPolymorphic() &&
@@ -501,7 +501,8 @@ private:
       stat = genRuntimeAllocate(builder, loc, box, errorManager);
       setPinnedToFalse();
     } else {
-      stat = genCudaAllocate(builder, loc, box, errorManager, alloc.getSymbol());
+      stat =
+          genCudaAllocate(builder, loc, box, errorManager, alloc.getSymbol());
     }
     fir::factory::syncMutableBoxFromIRBox(builder, loc, box);
     postAllocationAction(alloc);
@@ -866,21 +867,21 @@ genDeallocate(fir::FirOpBuilder &builder,
   if (!isCudaSymbol) {
     // For non-CUDA symbols, always use runtime deallocation.
     errorManager.genStatCheck(builder, loc);
-    stat = genRuntimeDeallocate(builder, loc, box, errorManager, declaredTypeDesc);
-  }
-  else {
+    stat =
+        genRuntimeDeallocate(builder, loc, box, errorManager, declaredTypeDesc);
+  } else {
     bool inlineDeallocation =
-    !box.isDerived() && !box.isPolymorphic() && !box.hasAssumedRank() &&
-    !box.isUnlimitedPolymorphic() && !errorManager.hasStatSpec() &&
-    !useAllocateRuntime && !box.isPointer();
+        !box.isDerived() && !box.isPolymorphic() && !box.hasAssumedRank() &&
+        !box.isUnlimitedPolymorphic() && !errorManager.hasStatSpec() &&
+        !useAllocateRuntime && !box.isPointer();
 
-    if (inlineDeallocation && isCudaDeviceContext) {  
-      // Inline deallocation for CUDA when conditions hold.  
-      stat = fir::factory::genFreemem(builder, loc, box);  
-    } else {  
-      // Otherwise, use the CUDA-specific runtime deallocation.  
-      errorManager.genStatCheck(builder, loc);  
-      stat = genCudaDeallocate(builder, loc, box, errorManager, *symbol);  
+    if (inlineDeallocation && isCudaDeviceContext) {
+      // Inline deallocation for CUDA when conditions hold.
+      stat = fir::factory::genFreemem(builder, loc, box);
+    } else {
+      // Otherwise, use the CUDA-specific runtime deallocation.
+      errorManager.genStatCheck(builder, loc);
+      stat = genCudaDeallocate(builder, loc, box, errorManager, *symbol);
     }
   }
   fir::factory::syncMutableBoxFromIRBox(builder, loc, box);

--- a/flang/test/HLFIR/dummy_deallocation.f90
+++ b/flang/test/HLFIR/dummy_deallocation.f90
@@ -5,10 +5,10 @@
 ! is not deallocated in entry SUB_B.
 
 ! CHECK-LABEL: func.func @_QPsub_a
-! CHECK: fir.freemem
+! CHECK: fir.call @_FortranAAllocatableDeallocate
 
 ! CHECK-LABEL: func.func @_QPsub_b
-! CHECK-NOT: fir.freemem
+! CHECK-NOT: fir.call @_FortranAAllocatableDeallocate
 SUBROUTINE SUB_A(A)
   INTEGER, INTENT(out), ALLOCATABLE, DIMENSION (:) :: A
   RETURN

--- a/flang/test/Lower/CUDA/cuda-allocatable.cuf
+++ b/flang/test/Lower/CUDA/cuda-allocatable.cuf
@@ -124,7 +124,7 @@ end subroutine
 ! CHECK: fir.call @_FortranAAllocatableSetBounds
 ! CHECK: %{{.*}} = cuf.allocate %[[BOX_A_DECL]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> source(%[[LOAD_B]] : !fir.box<!fir.heap<!fir.array<?xf32>>>) {data_attr = #cuf.cuda<device>} -> i32
 ! CHECK: fir.if
-! CHECK: fir.freemem
+! CHECK: fir.call @_FortranAAllocatableDeallocate
 ! CHECK: fir.if %{{.*}} {
 ! CHECK:   %{{.*}} = cuf.deallocate %[[BOX_A_DECL]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>> {data_attr = #cuf.cuda<device>} -> i32
 ! CHECK: }
@@ -206,6 +206,7 @@ end
 ! CHECK-LABEL: func.func @_QPsetpinned()  
 ! CHECK: %[[PLOG:.*]] = fir.alloca !fir.logical<4> {bindc_name = "plog", uniq_name = "_QFsetpinnedEplog"}
 ! CHECK: %[[PLOG_DECL:.*]]:2 = hlfir.declare %[[PLOG]] {uniq_name = "_QFsetpinnedEplog"} : (!fir.ref<!fir.logical<4>>) -> (!fir.ref<!fir.logical<4>>, !fir.ref<!fir.logical<4>>)
+! CHECK: fir.call @_FortranAAllocatableAllocate
 ! CHECK: %[[FALSE:.*]] = arith.constant false
 ! CHECK: %[[FLASE_CONV:.*]] = fir.convert %[[FALSE]] : (i1) -> !fir.logical<4>
 ! CHECK: fir.store %[[FLASE_CONV]] to %[[PLOG_DECL]]#0 : !fir.ref<!fir.logical<4>>

--- a/flang/test/Lower/HLFIR/allocatable-and-pointer-status-change.f90
+++ b/flang/test/Lower/HLFIR/allocatable-and-pointer-status-change.f90
@@ -4,108 +4,158 @@
 
 subroutine allocation(x)
   character(*), allocatable :: x(:)
-! CHECK-LABEL: func.func @_QPallocation(
-! CHECK:  %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_0:[a-z0-9]*]] typeparams %[[VAL_2:[a-z0-9]*]] dummy_scope %{{[0-9]+}} {fortran_attrs = #fir.var_attrs<allocatable>,  {{.*}}Ex
   deallocate(x)
-! CHECK:  %[[VAL_4:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
-! CHECK:  %[[VAL_5:.*]] = fir.box_addr %[[VAL_4]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>) -> !fir.heap<!fir.array<?x!fir.char<1,?>>>
-! CHECK:  fir.freemem %[[VAL_5]] : !fir.heap<!fir.array<?x!fir.char<1,?>>>
-! CHECK:  %[[VAL_6:.*]] = fir.zero_bits !fir.heap<!fir.array<?x!fir.char<1,?>>>
-! CHECK:  %[[VAL_7:.*]] = arith.constant 0 : index
-! CHECK:  %[[VAL_8:.*]] = fir.shape %[[VAL_7]] : (index) -> !fir.shape<1>
-! CHECK:  %[[VAL_9:.*]] = fir.embox %[[VAL_6]](%[[VAL_8]]) typeparams %[[VAL_2]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>
   allocate(x(100))
-! CHECK:  %[[VAL_10:.*]] = arith.constant 100 : i32
-! CHECK:  %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (i32) -> index
-! CHECK:  %[[VAL_12:.*]] = arith.constant 0 : index
-! CHECK:  %[[VAL_13:.*]] = arith.cmpi sgt, %[[VAL_11]], %[[VAL_12]] : index
-! CHECK:  %[[VAL_14:.*]] = arith.select %[[VAL_13]], %[[VAL_11]], %[[VAL_12]] : index
-! CHECK:  %[[VAL_15:.*]] = fir.allocmem !fir.array<?x!fir.char<1,?>>(%[[VAL_2]] : index), %[[VAL_14]] {fir.must_be_heap = true, uniq_name = "_QFallocationEx.alloc"}
-! CHECK:  %[[VAL_16:.*]] = fir.shape %[[VAL_14]] : (index) -> !fir.shape<1>
-! CHECK:  %[[VAL_17:.*]] = fir.embox %[[VAL_15]](%[[VAL_16]]) typeparams %[[VAL_2]] : (!fir.heap<!fir.array<?x!fir.char<1,?>>>, !fir.shape<1>, index) -> !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>
-! CHECK:  fir.store %[[VAL_17]] to %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
 end subroutine
+! CHECK-LABEL:   func.func @_QPallocation(
+! CHECK-SAME:                             %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>> {fir.bindc_name = "x"}) {
+! CHECK:           %[[VAL_1:.*]] = fir.dummy_scope : !fir.dscope
+! CHECK:           %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
+! CHECK:           %[[VAL_3:.*]] = fir.box_elesize %[[VAL_2]] : (!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>) -> index
+! CHECK:           %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_0]] typeparams %[[VAL_3]] dummy_scope %[[VAL_1]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocationEx"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>, index, !fir.dscope) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>)
+! CHECK:           %[[VAL_5:.*]] = arith.constant false
+! CHECK:           %[[VAL_6:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_7:.*]] = fir.address_of(@_QQclXca783e65b88d3c02cf95fcee70c426bc) : !fir.ref<!fir.char<1,96>>
+! CHECK:           %[[VAL_8:.*]] = arith.constant 7 : i32
+! CHECK:           %[[VAL_9:.*]] = fir.convert %[[VAL_4]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_10:.*]] = fir.convert %[[VAL_7]] : (!fir.ref<!fir.char<1,96>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_11:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_9]], %[[VAL_5]], %[[VAL_6]], %[[VAL_10]], %[[VAL_8]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_12:.*]] = arith.constant false
+! CHECK:           %[[VAL_13:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_14:.*]] = fir.address_of(@_QQclXca783e65b88d3c02cf95fcee70c426bc) : !fir.ref<!fir.char<1,96>>
+! CHECK:           %[[VAL_15:.*]] = arith.constant 8 : i32
+! CHECK:           %[[VAL_16:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_17:.*]] = arith.constant 100 : i32
+! CHECK:           %[[VAL_18:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_4]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_16]] : (index) -> i64
+! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_17]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_19]], %[[VAL_18]], %[[VAL_20]], %[[VAL_21]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_22:.*]] = fir.convert %[[VAL_4]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_23:.*]] = fir.convert %[[VAL_14]] : (!fir.ref<!fir.char<1,96>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_24:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_22]], %[[VAL_12]], %[[VAL_13]], %[[VAL_23]], %[[VAL_15]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           return
+! CHECK:         }
 
 subroutine pointer_assignment(p, ziel)
   real, pointer :: p(:)
   real, target :: ziel(42:)
-! CHECK-LABEL: func.func @_QPpointer_assignment(
-! CHECK:  %[[VAL_2:.*]]:2 = hlfir.declare %[[VAL_0:[a-z0-9]*]] dummy_scope %{{[0-9]+}} {fortran_attrs = #fir.var_attrs<pointer>,  {{.*}}Ep
-! CHECK:  %[[VAL_6:.*]]:2 = hlfir.declare %[[VAL_1:[a-z0-9]*]](%[[VAL_5:[a-z0-9]*]]) dummy_scope %{{[0-9]+}} {fortran_attrs = #fir.var_attrs<target>,  {{.*}}Eziel
   p => ziel
-! CHECK:  %[[VAL_7:.*]] = fir.shift %[[VAL_4:.*]] : (index) -> !fir.shift<1>
-! CHECK:  %[[VAL_8:.*]] = fir.rebox %[[VAL_6]]#1(%[[VAL_7]]) : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
-! CHECK:  fir.store %[[VAL_8]] to %[[VAL_2]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
   p => ziel(42:77:3)
-! CHECK:  %[[VAL_14:.*]] = hlfir.designate %{{.*}}#0 (%{{.*}}:%{{.*}}:%{{.*}})  shape %{{.*}} : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<12xf32>>
-! CHECK:  %[[VAL_15:.*]] = fir.rebox %[[VAL_14]] : (!fir.box<!fir.array<12xf32>>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
-! CHECK:  fir.store %[[VAL_15]] to %[[VAL_2]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
 end subroutine
+! CHECK-LABEL:   func.func @_QPpointer_assignment(
+! CHECK-SAME:                                     %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>> {fir.bindc_name = "p"},
+! CHECK-SAME:                                     %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "ziel", fir.target}) {
+! CHECK:           %[[VAL_2:.*]] = fir.dummy_scope : !fir.dscope
+! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_0]] dummy_scope %[[VAL_2]] {fortran_attrs = {{.*}}<pointer>, uniq_name = "_QFpointer_assignmentEp"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>)
+! CHECK:           %[[VAL_4:.*]] = arith.constant 42 : i64
+! CHECK:           %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i64) -> index
+! CHECK:           %[[VAL_6:.*]] = fir.shift %[[VAL_5]] : (index) -> !fir.shift<1>
+! CHECK:           %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_1]](%[[VAL_6]]) dummy_scope %[[VAL_2]] {fortran_attrs = {{.*}}<target>, uniq_name = "_QFpointer_assignmentEziel"} : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
+! CHECK:           %[[VAL_8:.*]] = fir.shift %[[VAL_5]] : (index) -> !fir.shift<1>
+! CHECK:           %[[VAL_9:.*]] = fir.rebox %[[VAL_7]]#1(%[[VAL_8]]) : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+! CHECK:           fir.store %[[VAL_9]] to %[[VAL_3]]#1 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:           %[[VAL_10:.*]] = arith.constant 42 : index
+! CHECK:           %[[VAL_11:.*]] = arith.constant 77 : index
+! CHECK:           %[[VAL_12:.*]] = arith.constant 3 : index
+! CHECK:           %[[VAL_13:.*]] = arith.constant 12 : index
+! CHECK:           %[[VAL_14:.*]] = fir.shape %[[VAL_13]] : (index) -> !fir.shape<1>
+! CHECK:           %[[VAL_15:.*]] = hlfir.designate %[[VAL_7]]#0 (%[[VAL_10]]:%[[VAL_11]]:%[[VAL_12]])  shape %[[VAL_14]] : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<12xf32>>
+! CHECK:           %[[VAL_16:.*]] = fir.rebox %[[VAL_15]] : (!fir.box<!fir.array<12xf32>>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+! CHECK:           fir.store %[[VAL_16]] to %[[VAL_3]]#1 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:           return
+! CHECK:         }
 
 subroutine pointer_remapping(p, ziel)
   real, pointer :: p(:, :)
   real, target :: ziel(10, 20, 30)
-! CHECK-LABEL: func.func @_QPpointer_remapping(
-! CHECK:  %[[VAL_2:.*]]:2 = hlfir.declare %[[VAL_0:[a-z0-9]*]] dummy_scope %{{[0-9]+}} {fortran_attrs = #fir.var_attrs<pointer>,  {{.*}}Ep
-! CHECK:  %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_1:[a-z0-9]*]](%[[VAL_6:[a-z0-9]*]]) dummy_scope %{{[0-9]+}} {fortran_attrs = #fir.var_attrs<target>,  {{.*}}Eziel
   p(2:7, 3:102) => ziel
-! CHECK:  %[[VAL_8:.*]] = arith.constant 2 : i64
-! CHECK:  %[[VAL_9:.*]] = arith.constant 7 : i64
-! CHECK:  %[[VAL_10:.*]] = arith.constant 3 : i64
-! CHECK:  %[[VAL_11:.*]] = arith.constant 102 : i64
-! CHECK:  %[[VAL_12:.*]] = arith.constant 1 : index
-! CHECK:  %[[VAL_13:.*]] = fir.convert %[[VAL_8]] : (i64) -> index
-! CHECK:  %[[VAL_14:.*]] = fir.convert %[[VAL_9]] : (i64) -> index
-! CHECK:  %[[VAL_15:.*]] = arith.subi %[[VAL_14]], %[[VAL_13]] : index
-! CHECK:  %[[VAL_16:.*]] = arith.addi %[[VAL_15]], %[[VAL_12]] : index
-! CHECK:  %[[VAL_17:.*]] = fir.convert %[[VAL_10]] : (i64) -> index
-! CHECK:  %[[VAL_18:.*]] = fir.convert %[[VAL_11]] : (i64) -> index
-! CHECK:  %[[VAL_19:.*]] = arith.subi %[[VAL_18]], %[[VAL_17]] : index
-! CHECK:  %[[VAL_20:.*]] = arith.addi %[[VAL_19]], %[[VAL_12]] : index
-! CHECK:  %[[VAL_21:.*]] = fir.convert %[[VAL_7]]#0 : (!fir.ref<!fir.array<10x20x30xf32>>) -> !fir.ref<!fir.array<?x?xf32>>
-! CHECK:  %[[VAL_22:.*]] = fir.shape_shift %[[VAL_8]], %[[VAL_16]], %[[VAL_10]], %[[VAL_20]] : (i64, index, i64, index) -> !fir.shapeshift<2>
-! CHECK:  %[[VAL_23:.*]] = fir.embox %[[VAL_21]](%[[VAL_22]]) : (!fir.ref<!fir.array<?x?xf32>>, !fir.shapeshift<2>) -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
-! CHECK:  fir.store %[[VAL_23]] to %[[VAL_2]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
 end subroutine
+! CHECK-LABEL:   func.func @_QPpointer_remapping(
+! CHECK-SAME:                                    %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>> {fir.bindc_name = "p"},
+! CHECK-SAME:                                    %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.ref<!fir.array<10x20x30xf32>> {fir.bindc_name = "ziel", fir.target}) {
+! CHECK:           %[[VAL_2:.*]] = fir.dummy_scope : !fir.dscope
+! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_0]] dummy_scope %[[VAL_2]] {fortran_attrs = {{.*}}<pointer>, uniq_name = "_QFpointer_remappingEp"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>)
+! CHECK:           %[[VAL_4:.*]] = arith.constant 10 : index
+! CHECK:           %[[VAL_5:.*]] = arith.constant 20 : index
+! CHECK:           %[[VAL_6:.*]] = arith.constant 30 : index
+! CHECK:           %[[VAL_7:.*]] = fir.shape %[[VAL_4]], %[[VAL_5]], %[[VAL_6]] : (index, index, index) -> !fir.shape<3>
+! CHECK:           %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_1]](%[[VAL_7]]) dummy_scope %[[VAL_2]] {fortran_attrs = {{.*}}<target>, uniq_name = "_QFpointer_remappingEziel"} : (!fir.ref<!fir.array<10x20x30xf32>>, !fir.shape<3>, !fir.dscope) -> (!fir.ref<!fir.array<10x20x30xf32>>, !fir.ref<!fir.array<10x20x30xf32>>)
+! CHECK:           %[[VAL_9:.*]] = arith.constant 2 : i64
+! CHECK:           %[[VAL_10:.*]] = arith.constant 7 : i64
+! CHECK:           %[[VAL_11:.*]] = arith.constant 3 : i64
+! CHECK:           %[[VAL_12:.*]] = arith.constant 102 : i64
+! CHECK:           %[[VAL_13:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_9]] : (i64) -> index
+! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_10]] : (i64) -> index
+! CHECK:           %[[VAL_16:.*]] = arith.subi %[[VAL_15]], %[[VAL_14]] : index
+! CHECK:           %[[VAL_17:.*]] = arith.addi %[[VAL_16]], %[[VAL_13]] : index
+! CHECK:           %[[VAL_18:.*]] = fir.convert %[[VAL_11]] : (i64) -> index
+! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_12]] : (i64) -> index
+! CHECK:           %[[VAL_20:.*]] = arith.subi %[[VAL_19]], %[[VAL_18]] : index
+! CHECK:           %[[VAL_21:.*]] = arith.addi %[[VAL_20]], %[[VAL_13]] : index
+! CHECK:           %[[VAL_22:.*]] = fir.convert %[[VAL_8]]#1 : (!fir.ref<!fir.array<10x20x30xf32>>) -> !fir.ref<!fir.array<?x?xf32>>
+! CHECK:           %[[VAL_23:.*]] = fir.shape_shift %[[VAL_9]], %[[VAL_17]], %[[VAL_11]], %[[VAL_21]] : (i64, index, i64, index) -> !fir.shapeshift<2>
+! CHECK:           %[[VAL_24:.*]] = fir.embox %[[VAL_22]](%[[VAL_23]]) : (!fir.ref<!fir.array<?x?xf32>>, !fir.shapeshift<2>) -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
+! CHECK:           fir.store %[[VAL_24]] to %[[VAL_3]]#1 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
+! CHECK:           return
+! CHECK:         }
 
 subroutine alloc_comp(x)
   type t
      real, allocatable :: a(:)
   end type
   type(t) :: x(10)
-! CHECK-LABEL: func.func @_QPalloc_comp(
-! CHECK:  %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_0:[a-z0-9]*]](%[[VAL_2:[a-z0-9]*]]) {{.*}}Ex
   allocate(x(10_8)%a(100_8))
-! CHECK:  %[[VAL_4:.*]] = arith.constant 10 : index
-! CHECK:  %[[VAL_5:.*]] = hlfir.designate %[[VAL_3]]#0 (%[[VAL_4]])  : (!fir.ref<!fir.array<10x!fir.type<_QFalloc_compTt{a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>, index) -> !fir.ref<!fir.type<_QFalloc_compTt{a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
-! CHECK:  %[[VAL_6:.*]] = hlfir.designate %[[VAL_5]]{"a"}   {fortran_attrs = #fir.var_attrs<allocatable>} : (!fir.ref<!fir.type<_QFalloc_compTt{a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
-! CHECK:  %[[VAL_7:.*]] = arith.constant 100 : i64
-! CHECK:  %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (i64) -> index
-! CHECK:  %[[VAL_9:.*]] = arith.constant 0 : index
-! CHECK:  %[[VAL_10:.*]] = arith.cmpi sgt, %[[VAL_8]], %[[VAL_9]] : index
-! CHECK:  %[[VAL_11:.*]] = arith.select %[[VAL_10]], %[[VAL_8]], %[[VAL_9]] : index
-! CHECK:  %[[VAL_12:.*]] = fir.allocmem !fir.array<?xf32>, %[[VAL_11]] {fir.must_be_heap = true, uniq_name = "_QFalloc_compEa.alloc"}
-! CHECK:  %[[VAL_13:.*]] = fir.shape %[[VAL_11]] : (index) -> !fir.shape<1>
-! CHECK:  %[[VAL_14:.*]] = fir.embox %[[VAL_12]](%[[VAL_13]]) : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xf32>>>
-! CHECK:  fir.store %[[VAL_14]] to %[[VAL_6]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 end subroutine
+! CHECK-LABEL:   func.func @_QPalloc_comp(
+! CHECK-SAME:                             %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.ref<!fir.array<10x!fir.type<_QFalloc_compTt{a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>> {fir.bindc_name = "x"}) {
+! CHECK:           %[[VAL_1:.*]] = fir.dummy_scope : !fir.dscope
+! CHECK:           %[[VAL_2:.*]] = arith.constant 10 : index
+! CHECK:           %[[VAL_3:.*]] = fir.shape %[[VAL_2]] : (index) -> !fir.shape<1>
+! CHECK:           %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_0]](%[[VAL_3]]) dummy_scope %[[VAL_1]] {uniq_name = "_QFalloc_compEx"} : (!fir.ref<!fir.array<10x!fir.type<_QFalloc_compTt{a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>, !fir.shape<1>, !fir.dscope) -> (!fir.ref<!fir.array<10x!fir.type<_QFalloc_compTt{a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>, !fir.ref<!fir.array<10x!fir.type<_QFalloc_compTt{a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>)
+! CHECK:           %[[VAL_5:.*]] = arith.constant false
+! CHECK:           %[[VAL_6:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_7:.*]] = fir.address_of(@_QQclXca783e65b88d3c02cf95fcee70c426bc) : !fir.ref<!fir.char<1,96>>
+! CHECK:           %[[VAL_8:.*]] = arith.constant 109 : i32
+! CHECK:           %[[VAL_9:.*]] = arith.constant 10 : index
+! CHECK:           %[[VAL_10:.*]] = hlfir.designate %[[VAL_4]]#0 (%[[VAL_9]])  : (!fir.ref<!fir.array<10x!fir.type<_QFalloc_compTt{a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>, index) -> !fir.ref<!fir.type<_QFalloc_compTt{a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
+! CHECK:           %[[VAL_11:.*]] = hlfir.designate %[[VAL_10]]{"a"}   {fortran_attrs = {{.*}}<allocatable>} : (!fir.ref<!fir.type<_QFalloc_compTt{a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+! CHECK:           %[[VAL_12:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_13:.*]] = arith.constant 100 : i64
+! CHECK:           %[[VAL_14:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_11]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_12]] : (index) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_15]], %[[VAL_14]], %[[VAL_16]], %[[VAL_13]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_11]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_18:.*]] = fir.convert %[[VAL_7]] : (!fir.ref<!fir.char<1,96>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_19:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_17]], %[[VAL_5]], %[[VAL_6]], %[[VAL_18]], %[[VAL_8]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           return
+! CHECK:         }
 
 subroutine ptr_comp_assign(x, ziel)
   type t
      real, pointer :: p(:)
   end type
   type(t) :: x(10)
-! CHECK-LABEL: func.func @_QPptr_comp_assign(
-! CHECK:  %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_0:[a-z0-9]*]](%[[VAL_3:[a-z0-9]*]]) {{.*}}Ex
   real, target :: ziel(100)
   x(9_8)%p => ziel
-! CHECK:  %[[VAL_5:.*]] = arith.constant 100 : index
-! CHECK:  %[[VAL_6:.*]] = fir.shape %[[VAL_5]] : (index) -> !fir.shape<1>
-! CHECK:  %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_1:[a-z0-9]*]](%[[VAL_6:[a-z0-9]*]]) dummy_scope %{{[0-9]+}} {fortran_attrs = #fir.var_attrs<target>,  {{.*}}Eziel
-! CHECK:  %[[VAL_8:.*]] = arith.constant 9 : index
-! CHECK:  %[[VAL_9:.*]] = hlfir.designate %[[VAL_4]]#0 (%[[VAL_8]])  : (!fir.ref<!fir.array<10x!fir.type<_QFptr_comp_assignTt{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>, index) -> !fir.ref<!fir.type<_QFptr_comp_assignTt{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
-! CHECK:  %[[VAL_10:.*]] = hlfir.designate %[[VAL_9]]{"p"}   {fortran_attrs = #fir.var_attrs<pointer>} : (!fir.ref<!fir.type<_QFptr_comp_assignTt{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
-! CHECK:  %[[VAL_11:.*]] = fir.shape %[[VAL_5]] : (index) -> !fir.shape<1>
-! CHECK:  %[[VAL_12:.*]] = fir.embox %[[VAL_7]]#0(%[[VAL_11]]) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
-! CHECK:  fir.store %[[VAL_12]] to %[[VAL_10]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
 end subroutine
+! CHECK-LABEL:   func.func @_QPptr_comp_assign(
+! CHECK-SAME:                                  %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.ref<!fir.array<10x!fir.type<_QFptr_comp_assignTt{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>> {fir.bindc_name = "x"},
+! CHECK-SAME:                                  %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.ref<!fir.array<100xf32>> {fir.bindc_name = "ziel", fir.target}) {
+! CHECK:           %[[VAL_2:.*]] = fir.dummy_scope : !fir.dscope
+! CHECK:           %[[VAL_3:.*]] = arith.constant 10 : index
+! CHECK:           %[[VAL_4:.*]] = fir.shape %[[VAL_3]] : (index) -> !fir.shape<1>
+! CHECK:           %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_0]](%[[VAL_4]]) dummy_scope %[[VAL_2]] {uniq_name = "_QFptr_comp_assignEx"} : (!fir.ref<!fir.array<10x!fir.type<_QFptr_comp_assignTt{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>, !fir.shape<1>, !fir.dscope) -> (!fir.ref<!fir.array<10x!fir.type<_QFptr_comp_assignTt{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>, !fir.ref<!fir.array<10x!fir.type<_QFptr_comp_assignTt{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>)
+! CHECK:           %[[VAL_6:.*]] = arith.constant 100 : index
+! CHECK:           %[[VAL_7:.*]] = fir.shape %[[VAL_6]] : (index) -> !fir.shape<1>
+! CHECK:           %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_1]](%[[VAL_7]]) dummy_scope %[[VAL_2]] {fortran_attrs = {{.*}}<target>, uniq_name = "_QFptr_comp_assignEziel"} : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>, !fir.dscope) -> (!fir.ref<!fir.array<100xf32>>, !fir.ref<!fir.array<100xf32>>)
+! CHECK:           %[[VAL_9:.*]] = arith.constant 9 : index
+! CHECK:           %[[VAL_10:.*]] = hlfir.designate %[[VAL_5]]#0 (%[[VAL_9]])  : (!fir.ref<!fir.array<10x!fir.type<_QFptr_comp_assignTt{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>, index) -> !fir.ref<!fir.type<_QFptr_comp_assignTt{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
+! CHECK:           %[[VAL_11:.*]] = hlfir.designate %[[VAL_10]]{"p"}   {fortran_attrs = {{.*}}<pointer>} : (!fir.ref<!fir.type<_QFptr_comp_assignTt{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:           %[[VAL_12:.*]] = fir.shape %[[VAL_6]] : (index) -> !fir.shape<1>
+! CHECK:           %[[VAL_13:.*]] = fir.embox %[[VAL_8]]#1(%[[VAL_12]]) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+! CHECK:           fir.store %[[VAL_13]] to %[[VAL_11]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:           return
+! CHECK:         }

--- a/flang/test/Lower/HLFIR/allocatable-and-pointer-status-change.f90
+++ b/flang/test/Lower/HLFIR/allocatable-and-pointer-status-change.f90
@@ -17,7 +17,7 @@ end subroutine
 ! CHECK:           %[[VAL_6:.*]] = fir.absent !fir.box<none>
 ! CHECK:           %[[VAL_7:.*]] = fir.address_of(@_QQclXca783e65b88d3c02cf95fcee70c426bc) : !fir.ref<!fir.char<1,96>>
 ! CHECK:           %[[VAL_8:.*]] = arith.constant 7 : i32
-! CHECK:           %[[VAL_9:.*]] = fir.convert %[[VAL_4]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_9:.*]] = fir.convert %[[VAL_4]]#0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_10:.*]] = fir.convert %[[VAL_7]] : (!fir.ref<!fir.char<1,96>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_11:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_9]], %[[VAL_5]], %[[VAL_6]], %[[VAL_10]], %[[VAL_8]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:           %[[VAL_12:.*]] = arith.constant false
@@ -27,11 +27,11 @@ end subroutine
 ! CHECK:           %[[VAL_16:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_17:.*]] = arith.constant 100 : i32
 ! CHECK:           %[[VAL_18:.*]] = arith.constant 0 : i32
-! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_4]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_4]]#0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_16]] : (index) -> i64
 ! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_17]] : (i32) -> i64
 ! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_19]], %[[VAL_18]], %[[VAL_20]], %[[VAL_21]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
-! CHECK:           %[[VAL_22:.*]] = fir.convert %[[VAL_4]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_22:.*]] = fir.convert %[[VAL_4]]#0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_23:.*]] = fir.convert %[[VAL_14]] : (!fir.ref<!fir.char<1,96>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_24:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_22]], %[[VAL_12]], %[[VAL_13]], %[[VAL_23]], %[[VAL_15]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:           return
@@ -54,7 +54,7 @@ end subroutine
 ! CHECK:           %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_1]](%[[VAL_6]]) dummy_scope %[[VAL_2]] {fortran_attrs = {{.*}}<target>, uniq_name = "_QFpointer_assignmentEziel"} : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>, !fir.dscope) -> (!fir.box<!fir.array<?xf32>>, !fir.box<!fir.array<?xf32>>)
 ! CHECK:           %[[VAL_8:.*]] = fir.shift %[[VAL_5]] : (index) -> !fir.shift<1>
 ! CHECK:           %[[VAL_9:.*]] = fir.rebox %[[VAL_7]]#1(%[[VAL_8]]) : (!fir.box<!fir.array<?xf32>>, !fir.shift<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
-! CHECK:           fir.store %[[VAL_9]] to %[[VAL_3]]#1 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:           fir.store %[[VAL_9]] to %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
 ! CHECK:           %[[VAL_10:.*]] = arith.constant 42 : index
 ! CHECK:           %[[VAL_11:.*]] = arith.constant 77 : index
 ! CHECK:           %[[VAL_12:.*]] = arith.constant 3 : index
@@ -62,7 +62,7 @@ end subroutine
 ! CHECK:           %[[VAL_14:.*]] = fir.shape %[[VAL_13]] : (index) -> !fir.shape<1>
 ! CHECK:           %[[VAL_15:.*]] = hlfir.designate %[[VAL_7]]#0 (%[[VAL_10]]:%[[VAL_11]]:%[[VAL_12]])  shape %[[VAL_14]] : (!fir.box<!fir.array<?xf32>>, index, index, index, !fir.shape<1>) -> !fir.box<!fir.array<12xf32>>
 ! CHECK:           %[[VAL_16:.*]] = fir.rebox %[[VAL_15]] : (!fir.box<!fir.array<12xf32>>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
-! CHECK:           fir.store %[[VAL_16]] to %[[VAL_3]]#1 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
+! CHECK:           fir.store %[[VAL_16]] to %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
 ! CHECK:           return
 ! CHECK:         }
 
@@ -94,10 +94,10 @@ end subroutine
 ! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_12]] : (i64) -> index
 ! CHECK:           %[[VAL_20:.*]] = arith.subi %[[VAL_19]], %[[VAL_18]] : index
 ! CHECK:           %[[VAL_21:.*]] = arith.addi %[[VAL_20]], %[[VAL_13]] : index
-! CHECK:           %[[VAL_22:.*]] = fir.convert %[[VAL_8]]#1 : (!fir.ref<!fir.array<10x20x30xf32>>) -> !fir.ref<!fir.array<?x?xf32>>
+! CHECK:           %[[VAL_22:.*]] = fir.convert %[[VAL_8]]#0 : (!fir.ref<!fir.array<10x20x30xf32>>) -> !fir.ref<!fir.array<?x?xf32>>
 ! CHECK:           %[[VAL_23:.*]] = fir.shape_shift %[[VAL_9]], %[[VAL_17]], %[[VAL_11]], %[[VAL_21]] : (i64, index, i64, index) -> !fir.shapeshift<2>
 ! CHECK:           %[[VAL_24:.*]] = fir.embox %[[VAL_22]](%[[VAL_23]]) : (!fir.ref<!fir.array<?x?xf32>>, !fir.shapeshift<2>) -> !fir.box<!fir.ptr<!fir.array<?x?xf32>>>
-! CHECK:           fir.store %[[VAL_24]] to %[[VAL_3]]#1 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
+! CHECK:           fir.store %[[VAL_24]] to %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x?xf32>>>>
 ! CHECK:           return
 ! CHECK:         }
 
@@ -117,12 +117,12 @@ end subroutine
 ! CHECK:           %[[VAL_5:.*]] = arith.constant false
 ! CHECK:           %[[VAL_6:.*]] = fir.absent !fir.box<none>
 ! CHECK:           %[[VAL_7:.*]] = fir.address_of(@_QQclXca783e65b88d3c02cf95fcee70c426bc) : !fir.ref<!fir.char<1,96>>
-! CHECK:           %[[VAL_8:.*]] = arith.constant 109 : i32
+! CHECK:           %[[VAL_8:.*]] = arith.constant {{.*}} : i32
 ! CHECK:           %[[VAL_9:.*]] = arith.constant 10 : index
 ! CHECK:           %[[VAL_10:.*]] = hlfir.designate %[[VAL_4]]#0 (%[[VAL_9]])  : (!fir.ref<!fir.array<10x!fir.type<_QFalloc_compTt{a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>>, index) -> !fir.ref<!fir.type<_QFalloc_compTt{a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>
 ! CHECK:           %[[VAL_11:.*]] = hlfir.designate %[[VAL_10]]{"a"}   {fortran_attrs = {{.*}}<allocatable>} : (!fir.ref<!fir.type<_QFalloc_compTt{a:!fir.box<!fir.heap<!fir.array<?xf32>>>}>>) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 ! CHECK:           %[[VAL_12:.*]] = arith.constant 1 : index
-! CHECK:           %[[VAL_13:.*]] = arith.constant 100 : i64
+! CHECK:           %[[VAL_13:.*]] = arith.constant {{.*}} : i64
 ! CHECK:           %[[VAL_14:.*]] = arith.constant 0 : i32
 ! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_11]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_12]] : (index) -> i64
@@ -155,7 +155,7 @@ end subroutine
 ! CHECK:           %[[VAL_10:.*]] = hlfir.designate %[[VAL_5]]#0 (%[[VAL_9]])  : (!fir.ref<!fir.array<10x!fir.type<_QFptr_comp_assignTt{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>>, index) -> !fir.ref<!fir.type<_QFptr_comp_assignTt{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>
 ! CHECK:           %[[VAL_11:.*]] = hlfir.designate %[[VAL_10]]{"p"}   {fortran_attrs = {{.*}}<pointer>} : (!fir.ref<!fir.type<_QFptr_comp_assignTt{p:!fir.box<!fir.ptr<!fir.array<?xf32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
 ! CHECK:           %[[VAL_12:.*]] = fir.shape %[[VAL_6]] : (index) -> !fir.shape<1>
-! CHECK:           %[[VAL_13:.*]] = fir.embox %[[VAL_8]]#1(%[[VAL_12]]) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
+! CHECK:           %[[VAL_13:.*]] = fir.embox %[[VAL_8]]#0(%[[VAL_12]]) : (!fir.ref<!fir.array<100xf32>>, !fir.shape<1>) -> !fir.box<!fir.ptr<!fir.array<?xf32>>>
 ! CHECK:           fir.store %[[VAL_13]] to %[[VAL_11]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xf32>>>>
 ! CHECK:           return
 ! CHECK:         }

--- a/flang/test/Lower/HLFIR/allocatable-end-of-scope-dealloc.f90
+++ b/flang/test/Lower/HLFIR/allocatable-end-of-scope-dealloc.f90
@@ -34,12 +34,13 @@ end subroutine
 ! CHECK:  %[[VAL_9:.*]] = arith.constant 0 : i64
 ! CHECK:  %[[VAL_10:.*]] = arith.cmpi ne, %[[VAL_8]], %[[VAL_9]] : i64
 ! CHECK:  fir.if %[[VAL_10]] {
-! CHECK:    %[[VAL_11:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<f32>>>
-! CHECK:    %[[VAL_12:.*]] = fir.box_addr %[[VAL_11]] : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
-! CHECK:    fir.freemem %[[VAL_12]] : !fir.heap<f32>
-! CHECK:    %[[VAL_13:.*]] = fir.zero_bits !fir.heap<f32>
-! CHECK:    %[[VAL_14:.*]] = fir.embox %[[VAL_13]] : (!fir.heap<f32>) -> !fir.box<!fir.heap<f32>>
-! CHECK:    fir.store %[[VAL_14]] to %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<f32>>>
+! CHECK:    %[[VAL_11:.*]] = arith.constant false
+! CHECK:    %[[VAL_12:.*]] = fir.absent !fir.box<none>
+! CHECK:    %[[VAL_13:.*]] = fir.address_of(@_QQclX572920c036ca2a0767a89e67f96902da) : !fir.ref<!fir.char<1,91>>
+! CHECK:    %[[VAL_14:.*]] = arith.constant 23 : i32
+! CHECK:    %[[VAL_15:.*]] = fir.convert %[[VAL_3]]#1 : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:    %[[VAL_16:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1,91>>) -> !fir.ref<i8>
+! CHECK:    %[[VAL_17:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_15]], %[[VAL_11]], %[[VAL_12]], %[[VAL_16]], %[[VAL_14]])
 ! CHECK:  }
 
 subroutine multiple_return(cdt)
@@ -59,7 +60,7 @@ end subroutine
 ! CHECK:  cf.br ^bb3
 ! CHECK: ^bb3:
 ! CHECK:  fir.if {{.*}} {
-! CHECK:    fir.freemem
+! CHECK:    fir.call @_FortranAAllocatableDeallocate
 ! CHECK:  }
 ! CHECK:  return
 
@@ -105,7 +106,7 @@ end subroutine
 ! CHECK-LABEL:   func.func @_QPsimple_block(
 ! CHECK:  fir.call @_QPbar
 ! CHECK:  fir.if {{.*}} {
-! CHECK:    fir.freemem
+! CHECK:    fir.call @_FortranAAllocatableDeallocate
 ! CHECK:  }
 ! CHECK:  fir.call @_QPbar_after_block
 
@@ -123,13 +124,13 @@ end subroutine
 ! CHECK:  cf.cond_br %{{.*}}, ^bb1, ^bb2
 ! CHECK: ^bb1:
 ! CHECK:  fir.if {{.*}} {
-! CHECK:    fir.freemem
+! CHECK:    fir.call @_FortranAAllocatableDeallocate
 ! CHECK:  }
 ! CHECK:  cf.br ^bb3
 ! CHECK: ^bb2:
 ! CHECK:  fir.call @_QPbar
 ! CHECK:  fir.if {{.*}} {
-! CHECK:    fir.freemem
+! CHECK:    fir.call @_FortranAAllocatableDeallocate
 ! CHECK:  }
 ! CHECK:  fir.call @_QPbar_after_block
 ! CHECK:  cf.br ^bb3

--- a/flang/test/Lower/HLFIR/allocatable-end-of-scope-dealloc.f90
+++ b/flang/test/Lower/HLFIR/allocatable-end-of-scope-dealloc.f90
@@ -38,7 +38,7 @@ end subroutine
 ! CHECK:    %[[VAL_12:.*]] = fir.absent !fir.box<none>
 ! CHECK:    %[[VAL_13:.*]] = fir.address_of(@_QQclX572920c036ca2a0767a89e67f96902da) : !fir.ref<!fir.char<1,91>>
 ! CHECK:    %[[VAL_14:.*]] = arith.constant 23 : i32
-! CHECK:    %[[VAL_15:.*]] = fir.convert %[[VAL_3]]#1 : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:    %[[VAL_15:.*]] = fir.convert %[[VAL_3]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:    %[[VAL_16:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1,91>>) -> !fir.ref<i8>
 ! CHECK:    %[[VAL_17:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_15]], %[[VAL_11]], %[[VAL_12]], %[[VAL_16]], %[[VAL_14]])
 ! CHECK:  }

--- a/flang/test/Lower/HLFIR/custom-intrinsic.f90
+++ b/flang/test/Lower/HLFIR/custom-intrinsic.f90
@@ -716,25 +716,25 @@ end subroutine
 ! CHECK:           %[[VAL_17:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_18:.*]] = arith.constant 1 : i32
 ! CHECK:           %[[VAL_19:.*]] = arith.constant 0 : i32
-! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_4]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_4]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_17]] : (index) -> i64
 ! CHECK:           %[[VAL_22:.*]] = fir.convert %[[VAL_18]] : (i32) -> i64
 ! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_20]], %[[VAL_19]], %[[VAL_21]], %[[VAL_22]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
 ! CHECK:           %[[VAL_23:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_24:.*]] = arith.constant 2 : i32
 ! CHECK:           %[[VAL_25:.*]] = arith.constant 1 : i32
-! CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_4]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_4]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_27:.*]] = fir.convert %[[VAL_23]] : (index) -> i64
 ! CHECK:           %[[VAL_28:.*]] = fir.convert %[[VAL_24]] : (i32) -> i64
 ! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_26]], %[[VAL_25]], %[[VAL_27]], %[[VAL_28]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
 ! CHECK:           %[[VAL_29:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_30:.*]] = arith.constant 3 : i32
 ! CHECK:           %[[VAL_31:.*]] = arith.constant 2 : i32
-! CHECK:           %[[VAL_32:.*]] = fir.convert %[[VAL_4]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_32:.*]] = fir.convert %[[VAL_4]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_33:.*]] = fir.convert %[[VAL_29]] : (index) -> i64
 ! CHECK:           %[[VAL_34:.*]] = fir.convert %[[VAL_30]] : (i32) -> i64
 ! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_32]], %[[VAL_31]], %[[VAL_33]], %[[VAL_34]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
-! CHECK:           %[[VAL_35:.*]] = fir.convert %[[VAL_4]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_35:.*]] = fir.convert %[[VAL_4]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_36:.*]] = fir.convert %[[VAL_15]] : (!fir.ref<!fir.char<1,75>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_37:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_35]], %[[VAL_13]], %[[VAL_14]], %[[VAL_36]], %[[VAL_16]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:           %[[VAL_38:.*]] = arith.constant false
@@ -744,25 +744,25 @@ end subroutine
 ! CHECK:           %[[VAL_42:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_43:.*]] = arith.constant 1 : i32
 ! CHECK:           %[[VAL_44:.*]] = arith.constant 0 : i32
-! CHECK:           %[[VAL_45:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_45:.*]] = fir.convert %[[VAL_5]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_46:.*]] = fir.convert %[[VAL_42]] : (index) -> i64
 ! CHECK:           %[[VAL_47:.*]] = fir.convert %[[VAL_43]] : (i32) -> i64
 ! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_45]], %[[VAL_44]], %[[VAL_46]], %[[VAL_47]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
 ! CHECK:           %[[VAL_48:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_49:.*]] = arith.constant 2 : i32
 ! CHECK:           %[[VAL_50:.*]] = arith.constant 1 : i32
-! CHECK:           %[[VAL_51:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_51:.*]] = fir.convert %[[VAL_5]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_52:.*]] = fir.convert %[[VAL_48]] : (index) -> i64
 ! CHECK:           %[[VAL_53:.*]] = fir.convert %[[VAL_49]] : (i32) -> i64
 ! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_51]], %[[VAL_50]], %[[VAL_52]], %[[VAL_53]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
 ! CHECK:           %[[VAL_54:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_55:.*]] = arith.constant 3 : i32
 ! CHECK:           %[[VAL_56:.*]] = arith.constant 2 : i32
-! CHECK:           %[[VAL_57:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_57:.*]] = fir.convert %[[VAL_5]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_58:.*]] = fir.convert %[[VAL_54]] : (index) -> i64
 ! CHECK:           %[[VAL_59:.*]] = fir.convert %[[VAL_55]] : (i32) -> i64
 ! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_57]], %[[VAL_56]], %[[VAL_58]], %[[VAL_59]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
-! CHECK:           %[[VAL_60:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_60:.*]] = fir.convert %[[VAL_5]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_61:.*]] = fir.convert %[[VAL_40]] : (!fir.ref<!fir.char<1,75>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_62:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_60]], %[[VAL_38]], %[[VAL_39]], %[[VAL_61]], %[[VAL_41]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:           %[[VAL_63:.*]] = arith.constant false
@@ -772,28 +772,28 @@ end subroutine
 ! CHECK:           %[[VAL_67:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_68:.*]] = arith.constant 1 : i32
 ! CHECK:           %[[VAL_69:.*]] = arith.constant 0 : i32
-! CHECK:           %[[VAL_70:.*]] = fir.convert %[[VAL_6]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_70:.*]] = fir.convert %[[VAL_6]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_71:.*]] = fir.convert %[[VAL_67]] : (index) -> i64
 ! CHECK:           %[[VAL_72:.*]] = fir.convert %[[VAL_68]] : (i32) -> i64
 ! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_70]], %[[VAL_69]], %[[VAL_71]], %[[VAL_72]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
 ! CHECK:           %[[VAL_73:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_74:.*]] = arith.constant 2 : i32
 ! CHECK:           %[[VAL_75:.*]] = arith.constant 1 : i32
-! CHECK:           %[[VAL_76:.*]] = fir.convert %[[VAL_6]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_76:.*]] = fir.convert %[[VAL_6]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_77:.*]] = fir.convert %[[VAL_73]] : (index) -> i64
 ! CHECK:           %[[VAL_78:.*]] = fir.convert %[[VAL_74]] : (i32) -> i64
 ! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_76]], %[[VAL_75]], %[[VAL_77]], %[[VAL_78]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
 ! CHECK:           %[[VAL_79:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_80:.*]] = arith.constant 3 : i32
 ! CHECK:           %[[VAL_81:.*]] = arith.constant 2 : i32
-! CHECK:           %[[VAL_82:.*]] = fir.convert %[[VAL_6]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_82:.*]] = fir.convert %[[VAL_6]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_83:.*]] = fir.convert %[[VAL_79]] : (index) -> i64
 ! CHECK:           %[[VAL_84:.*]] = fir.convert %[[VAL_80]] : (i32) -> i64
 ! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_82]], %[[VAL_81]], %[[VAL_83]], %[[VAL_84]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
-! CHECK:           %[[VAL_85:.*]] = fir.convert %[[VAL_6]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_85:.*]] = fir.convert %[[VAL_6]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_86:.*]] = fir.convert %[[VAL_65]] : (!fir.ref<!fir.char<1,75>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_87:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_85]], %[[VAL_63]], %[[VAL_64]], %[[VAL_86]], %[[VAL_66]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
-! CHECK:           %[[VAL_88:.*]] = fir.load %[[VAL_6]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>
+! CHECK:           %[[VAL_88:.*]] = fir.load %[[VAL_6]]{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>
 ! CHECK:           %[[VAL_89:.*]] = fir.box_addr %[[VAL_88]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>) -> !fir.heap<!fir.array<?x?x?xi32>>
 ! CHECK:           %[[VAL_90:.*]] = fir.convert %[[VAL_89]] : (!fir.heap<!fir.array<?x?x?xi32>>) -> i64
 ! CHECK:           %[[VAL_91:.*]] = arith.constant 0 : i64

--- a/flang/test/Lower/HLFIR/custom-intrinsic.f90
+++ b/flang/test/Lower/HLFIR/custom-intrinsic.f90
@@ -696,149 +696,177 @@ subroutine allocatables_test(a, b, c)
   c = min(a, b, c)
 end subroutine
 ! CHECK-LABEL:   func.func @_QPallocatables_test(
-! CHECK-SAME:                                    %[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>> {fir.bindc_name = "a"},
-! CHECK-SAME:                                    %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>> {fir.bindc_name = "b"},
-! CHECK-SAME:                                    %[[VAL_2:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>> {fir.bindc_name = "c"}) {
-! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_0]] dummy_scope %{{[0-9]+}} {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFallocatables_testEa"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>)
-! CHECK:           %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_1]] dummy_scope %{{[0-9]+}} {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFallocatables_testEb"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>)
-! CHECK:           %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_2]] dummy_scope %{{[0-9]+}} {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFallocatables_testEc"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>)
-! CHECK:           %[[VAL_6:.*]] = fir.address_of(@_QFallocatables_testECnx) : !fir.ref<i32>
-! CHECK:           %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_6]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QFallocatables_testECnx"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:           %[[VAL_8:.*]] = fir.address_of(@_QFallocatables_testECny) : !fir.ref<i32>
-! CHECK:           %[[VAL_9:.*]]:2 = hlfir.declare %[[VAL_8]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QFallocatables_testECny"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:           %[[VAL_10:.*]] = fir.address_of(@_QFallocatables_testECnz) : !fir.ref<i32>
-! CHECK:           %[[VAL_11:.*]]:2 = hlfir.declare %[[VAL_10]] {fortran_attrs = #fir.var_attrs<parameter>, uniq_name = "_QFallocatables_testECnz"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:           %[[VAL_12:.*]] = arith.constant 1 : i32
-! CHECK:           %[[VAL_13:.*]] = fir.convert %[[VAL_12]] : (i32) -> index
-! CHECK:           %[[VAL_14:.*]] = arith.constant 2 : i32
-! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_14]] : (i32) -> index
-! CHECK:           %[[VAL_16:.*]] = arith.constant 3 : i32
-! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_16]] : (i32) -> index
-! CHECK:           %[[VAL_18:.*]] = arith.constant 0 : index
-! CHECK:           %[[VAL_19:.*]] = arith.cmpi sgt, %[[VAL_13]], %[[VAL_18]] : index
-! CHECK:           %[[VAL_20:.*]] = arith.select %[[VAL_19]], %[[VAL_13]], %[[VAL_18]] : index
-! CHECK:           %[[VAL_21:.*]] = arith.constant 0 : index
-! CHECK:           %[[VAL_22:.*]] = arith.cmpi sgt, %[[VAL_15]], %[[VAL_21]] : index
-! CHECK:           %[[VAL_23:.*]] = arith.select %[[VAL_22]], %[[VAL_15]], %[[VAL_21]] : index
-! CHECK:           %[[VAL_24:.*]] = arith.constant 0 : index
-! CHECK:           %[[VAL_25:.*]] = arith.cmpi sgt, %[[VAL_17]], %[[VAL_24]] : index
-! CHECK:           %[[VAL_26:.*]] = arith.select %[[VAL_25]], %[[VAL_17]], %[[VAL_24]] : index
-! CHECK:           %[[VAL_27:.*]] = fir.allocmem !fir.array<?x?x?xi32>, %[[VAL_20]], %[[VAL_23]], %[[VAL_26]] {fir.must_be_heap = true, uniq_name = "_QFallocatables_testEa.alloc"}
-! CHECK:           %[[VAL_28:.*]] = fir.shape %[[VAL_20]], %[[VAL_23]], %[[VAL_26]] : (index, index, index) -> !fir.shape<3>
-! CHECK:           %[[VAL_29:.*]] = fir.embox %[[VAL_27]](%[[VAL_28]]) : (!fir.heap<!fir.array<?x?x?xi32>>, !fir.shape<3>) -> !fir.box<!fir.heap<!fir.array<?x?x?xi32>>>
-! CHECK:           fir.store %[[VAL_29]] to %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>
-! CHECK:           %[[VAL_30:.*]] = arith.constant 1 : i32
-! CHECK:           %[[VAL_31:.*]] = fir.convert %[[VAL_30]] : (i32) -> index
-! CHECK:           %[[VAL_32:.*]] = arith.constant 2 : i32
-! CHECK:           %[[VAL_33:.*]] = fir.convert %[[VAL_32]] : (i32) -> index
-! CHECK:           %[[VAL_34:.*]] = arith.constant 3 : i32
-! CHECK:           %[[VAL_35:.*]] = fir.convert %[[VAL_34]] : (i32) -> index
-! CHECK:           %[[VAL_36:.*]] = arith.constant 0 : index
-! CHECK:           %[[VAL_37:.*]] = arith.cmpi sgt, %[[VAL_31]], %[[VAL_36]] : index
-! CHECK:           %[[VAL_38:.*]] = arith.select %[[VAL_37]], %[[VAL_31]], %[[VAL_36]] : index
-! CHECK:           %[[VAL_39:.*]] = arith.constant 0 : index
-! CHECK:           %[[VAL_40:.*]] = arith.cmpi sgt, %[[VAL_33]], %[[VAL_39]] : index
-! CHECK:           %[[VAL_41:.*]] = arith.select %[[VAL_40]], %[[VAL_33]], %[[VAL_39]] : index
-! CHECK:           %[[VAL_42:.*]] = arith.constant 0 : index
-! CHECK:           %[[VAL_43:.*]] = arith.cmpi sgt, %[[VAL_35]], %[[VAL_42]] : index
-! CHECK:           %[[VAL_44:.*]] = arith.select %[[VAL_43]], %[[VAL_35]], %[[VAL_42]] : index
-! CHECK:           %[[VAL_45:.*]] = fir.allocmem !fir.array<?x?x?xi32>, %[[VAL_38]], %[[VAL_41]], %[[VAL_44]] {fir.must_be_heap = true, uniq_name = "_QFallocatables_testEb.alloc"}
-! CHECK:           %[[VAL_46:.*]] = fir.shape %[[VAL_38]], %[[VAL_41]], %[[VAL_44]] : (index, index, index) -> !fir.shape<3>
-! CHECK:           %[[VAL_47:.*]] = fir.embox %[[VAL_45]](%[[VAL_46]]) : (!fir.heap<!fir.array<?x?x?xi32>>, !fir.shape<3>) -> !fir.box<!fir.heap<!fir.array<?x?x?xi32>>>
-! CHECK:           fir.store %[[VAL_47]] to %[[VAL_4]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>
-! CHECK:           %[[VAL_48:.*]] = arith.constant 1 : i32
-! CHECK:           %[[VAL_49:.*]] = fir.convert %[[VAL_48]] : (i32) -> index
-! CHECK:           %[[VAL_50:.*]] = arith.constant 2 : i32
-! CHECK:           %[[VAL_51:.*]] = fir.convert %[[VAL_50]] : (i32) -> index
-! CHECK:           %[[VAL_52:.*]] = arith.constant 3 : i32
-! CHECK:           %[[VAL_53:.*]] = fir.convert %[[VAL_52]] : (i32) -> index
-! CHECK:           %[[VAL_54:.*]] = arith.constant 0 : index
-! CHECK:           %[[VAL_55:.*]] = arith.cmpi sgt, %[[VAL_49]], %[[VAL_54]] : index
-! CHECK:           %[[VAL_56:.*]] = arith.select %[[VAL_55]], %[[VAL_49]], %[[VAL_54]] : index
-! CHECK:           %[[VAL_57:.*]] = arith.constant 0 : index
-! CHECK:           %[[VAL_58:.*]] = arith.cmpi sgt, %[[VAL_51]], %[[VAL_57]] : index
-! CHECK:           %[[VAL_59:.*]] = arith.select %[[VAL_58]], %[[VAL_51]], %[[VAL_57]] : index
-! CHECK:           %[[VAL_60:.*]] = arith.constant 0 : index
-! CHECK:           %[[VAL_61:.*]] = arith.cmpi sgt, %[[VAL_53]], %[[VAL_60]] : index
-! CHECK:           %[[VAL_62:.*]] = arith.select %[[VAL_61]], %[[VAL_53]], %[[VAL_60]] : index
-! CHECK:           %[[VAL_63:.*]] = fir.allocmem !fir.array<?x?x?xi32>, %[[VAL_56]], %[[VAL_59]], %[[VAL_62]] {fir.must_be_heap = true, uniq_name = "_QFallocatables_testEc.alloc"}
-! CHECK:           %[[VAL_64:.*]] = fir.shape %[[VAL_56]], %[[VAL_59]], %[[VAL_62]] : (index, index, index) -> !fir.shape<3>
-! CHECK:           %[[VAL_65:.*]] = fir.embox %[[VAL_63]](%[[VAL_64]]) : (!fir.heap<!fir.array<?x?x?xi32>>, !fir.shape<3>) -> !fir.box<!fir.heap<!fir.array<?x?x?xi32>>>
-! CHECK:           fir.store %[[VAL_65]] to %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>
-! CHECK:           %[[VAL_66:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>
-! CHECK:           %[[VAL_67:.*]] = fir.box_addr %[[VAL_66]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>) -> !fir.heap<!fir.array<?x?x?xi32>>
-! CHECK:           %[[VAL_68:.*]] = fir.convert %[[VAL_67]] : (!fir.heap<!fir.array<?x?x?xi32>>) -> i64
-! CHECK:           %[[VAL_69:.*]] = arith.constant 0 : i64
-! CHECK:           %[[VAL_70:.*]] = arith.cmpi ne, %[[VAL_68]], %[[VAL_69]] : i64
-! CHECK:           %[[VAL_71:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>
-! CHECK:           %[[VAL_72:.*]] = arith.constant 0 : index
-! CHECK:           %[[VAL_73:.*]]:3 = fir.box_dims %[[VAL_71]], %[[VAL_72]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
-! CHECK:           %[[VAL_74:.*]] = arith.constant 1 : index
-! CHECK:           %[[VAL_75:.*]]:3 = fir.box_dims %[[VAL_71]], %[[VAL_74]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
-! CHECK:           %[[VAL_76:.*]] = arith.constant 2 : index
-! CHECK:           %[[VAL_77:.*]]:3 = fir.box_dims %[[VAL_71]], %[[VAL_76]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
-! CHECK:           %[[VAL_78:.*]] = fir.shape %[[VAL_73]]#1, %[[VAL_75]]#1, %[[VAL_77]]#1 : (index, index, index) -> !fir.shape<3>
-! CHECK:           %[[VAL_79:.*]] = fir.load %[[VAL_4]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>
-! CHECK:           %[[VAL_80:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>
-! CHECK:           %[[VAL_81:.*]] = hlfir.elemental %[[VAL_78]] unordered : (!fir.shape<3>) -> !hlfir.expr<?x?x?xi32> {
-! CHECK:           ^bb0(%[[VAL_82:.*]]: index, %[[VAL_83:.*]]: index, %[[VAL_84:.*]]: index):
-! CHECK:             %[[VAL_85:.*]] = arith.constant 0 : index
-! CHECK:             %[[VAL_86:.*]]:3 = fir.box_dims %[[VAL_71]], %[[VAL_85]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
-! CHECK:             %[[VAL_87:.*]] = arith.constant 1 : index
-! CHECK:             %[[VAL_88:.*]]:3 = fir.box_dims %[[VAL_71]], %[[VAL_87]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
-! CHECK:             %[[VAL_89:.*]] = arith.constant 2 : index
-! CHECK:             %[[VAL_90:.*]]:3 = fir.box_dims %[[VAL_71]], %[[VAL_89]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
-! CHECK:             %[[VAL_91:.*]] = arith.constant 1 : index
-! CHECK:             %[[VAL_92:.*]] = arith.subi %[[VAL_86]]#0, %[[VAL_91]] : index
-! CHECK:             %[[VAL_93:.*]] = arith.addi %[[VAL_82]], %[[VAL_92]] : index
-! CHECK:             %[[VAL_94:.*]] = arith.subi %[[VAL_88]]#0, %[[VAL_91]] : index
-! CHECK:             %[[VAL_95:.*]] = arith.addi %[[VAL_83]], %[[VAL_94]] : index
-! CHECK:             %[[VAL_96:.*]] = arith.subi %[[VAL_90]]#0, %[[VAL_91]] : index
-! CHECK:             %[[VAL_97:.*]] = arith.addi %[[VAL_84]], %[[VAL_96]] : index
-! CHECK:             %[[VAL_98:.*]] = hlfir.designate %[[VAL_71]] (%[[VAL_93]], %[[VAL_95]], %[[VAL_97]])  : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index, index, index) -> !fir.ref<i32>
-! CHECK:             %[[VAL_99:.*]] = fir.load %[[VAL_98]] : !fir.ref<i32>
-! CHECK:             %[[VAL_100:.*]] = arith.constant 0 : index
-! CHECK:             %[[VAL_101:.*]]:3 = fir.box_dims %[[VAL_79]], %[[VAL_100]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
-! CHECK:             %[[VAL_102:.*]] = arith.constant 1 : index
-! CHECK:             %[[VAL_103:.*]]:3 = fir.box_dims %[[VAL_79]], %[[VAL_102]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
-! CHECK:             %[[VAL_104:.*]] = arith.constant 2 : index
-! CHECK:             %[[VAL_105:.*]]:3 = fir.box_dims %[[VAL_79]], %[[VAL_104]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
-! CHECK:             %[[VAL_106:.*]] = arith.constant 1 : index
-! CHECK:             %[[VAL_107:.*]] = arith.subi %[[VAL_101]]#0, %[[VAL_106]] : index
-! CHECK:             %[[VAL_108:.*]] = arith.addi %[[VAL_82]], %[[VAL_107]] : index
-! CHECK:             %[[VAL_109:.*]] = arith.subi %[[VAL_103]]#0, %[[VAL_106]] : index
-! CHECK:             %[[VAL_110:.*]] = arith.addi %[[VAL_83]], %[[VAL_109]] : index
-! CHECK:             %[[VAL_111:.*]] = arith.subi %[[VAL_105]]#0, %[[VAL_106]] : index
-! CHECK:             %[[VAL_112:.*]] = arith.addi %[[VAL_84]], %[[VAL_111]] : index
-! CHECK:             %[[VAL_113:.*]] = hlfir.designate %[[VAL_79]] (%[[VAL_108]], %[[VAL_110]], %[[VAL_112]])  : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index, index, index) -> !fir.ref<i32>
-! CHECK:             %[[VAL_114:.*]] = fir.load %[[VAL_113]] : !fir.ref<i32>
-! CHECK:             %[[VAL_115:.*]] = arith.cmpi slt, %[[VAL_99]], %[[VAL_114]] : i32
-! CHECK:             %[[VAL_116:.*]] = arith.select %[[VAL_115]], %[[VAL_99]], %[[VAL_114]] : i32
-! CHECK:             %[[VAL_117:.*]] = fir.if %[[VAL_70]] -> (i32) {
-! CHECK:               %[[VAL_118:.*]] = arith.constant 0 : index
-! CHECK:               %[[VAL_119:.*]]:3 = fir.box_dims %[[VAL_80]], %[[VAL_118]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
-! CHECK:               %[[VAL_120:.*]] = arith.constant 1 : index
-! CHECK:               %[[VAL_121:.*]]:3 = fir.box_dims %[[VAL_80]], %[[VAL_120]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
-! CHECK:               %[[VAL_122:.*]] = arith.constant 2 : index
-! CHECK:               %[[VAL_123:.*]]:3 = fir.box_dims %[[VAL_80]], %[[VAL_122]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
-! CHECK:               %[[VAL_124:.*]] = arith.constant 1 : index
-! CHECK:               %[[VAL_125:.*]] = arith.subi %[[VAL_119]]#0, %[[VAL_124]] : index
-! CHECK:               %[[VAL_126:.*]] = arith.addi %[[VAL_82]], %[[VAL_125]] : index
-! CHECK:               %[[VAL_127:.*]] = arith.subi %[[VAL_121]]#0, %[[VAL_124]] : index
-! CHECK:               %[[VAL_128:.*]] = arith.addi %[[VAL_83]], %[[VAL_127]] : index
-! CHECK:               %[[VAL_129:.*]] = arith.subi %[[VAL_123]]#0, %[[VAL_124]] : index
-! CHECK:               %[[VAL_130:.*]] = arith.addi %[[VAL_84]], %[[VAL_129]] : index
-! CHECK:               %[[VAL_131:.*]] = hlfir.designate %[[VAL_80]] (%[[VAL_126]], %[[VAL_128]], %[[VAL_130]])  : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index, index, index) -> !fir.ref<i32>
-! CHECK:               %[[VAL_132:.*]] = fir.load %[[VAL_131]] : !fir.ref<i32>
-! CHECK:               %[[VAL_133:.*]] = arith.cmpi slt, %[[VAL_116]], %[[VAL_132]] : i32
-! CHECK:               %[[VAL_134:.*]] = arith.select %[[VAL_133]], %[[VAL_116]], %[[VAL_132]] : i32
-! CHECK:               fir.result %[[VAL_134]] : i32
+! CHECK-SAME:                                    %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>> {fir.bindc_name = "a"},
+! CHECK-SAME:                                    %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>> {fir.bindc_name = "b"},
+! CHECK-SAME:                                    %[[VAL_2:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>> {fir.bindc_name = "c"}) {
+! CHECK:           %[[VAL_3:.*]] = fir.dummy_scope : !fir.dscope
+! CHECK:           %[[VAL_4:.*]]:2 = hlfir.declare %[[VAL_0]] dummy_scope %[[VAL_3]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatables_testEa"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>)
+! CHECK:           %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_1]] dummy_scope %[[VAL_3]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatables_testEb"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>)
+! CHECK:           %[[VAL_6:.*]]:2 = hlfir.declare %[[VAL_2]] dummy_scope %[[VAL_3]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatables_testEc"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>, !fir.dscope) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>)
+! CHECK:           %[[VAL_7:.*]] = fir.address_of(@_QFallocatables_testECnx) : !fir.ref<i32>
+! CHECK:           %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_7]] {fortran_attrs = {{.*}}<parameter>, uniq_name = "_QFallocatables_testECnx"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:           %[[VAL_9:.*]] = fir.address_of(@_QFallocatables_testECny) : !fir.ref<i32>
+! CHECK:           %[[VAL_10:.*]]:2 = hlfir.declare %[[VAL_9]] {fortran_attrs = {{.*}}<parameter>, uniq_name = "_QFallocatables_testECny"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:           %[[VAL_11:.*]] = fir.address_of(@_QFallocatables_testECnz) : !fir.ref<i32>
+! CHECK:           %[[VAL_12:.*]]:2 = hlfir.declare %[[VAL_11]] {fortran_attrs = {{.*}}<parameter>, uniq_name = "_QFallocatables_testECnz"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:           %[[VAL_13:.*]] = arith.constant false
+! CHECK:           %[[VAL_14:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_15:.*]] = fir.address_of(@_QQclX9ac8f8ca39400c93d3d5d265c9eadfd7) : !fir.ref<!fir.char<1,75>>
+! CHECK:           %[[VAL_16:.*]] = arith.constant 692 : i32
+! CHECK:           %[[VAL_17:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_18:.*]] = arith.constant 1 : i32
+! CHECK:           %[[VAL_19:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_4]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_17]] : (index) -> i64
+! CHECK:           %[[VAL_22:.*]] = fir.convert %[[VAL_18]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_20]], %[[VAL_19]], %[[VAL_21]], %[[VAL_22]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_23:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_24:.*]] = arith.constant 2 : i32
+! CHECK:           %[[VAL_25:.*]] = arith.constant 1 : i32
+! CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_4]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_27:.*]] = fir.convert %[[VAL_23]] : (index) -> i64
+! CHECK:           %[[VAL_28:.*]] = fir.convert %[[VAL_24]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_26]], %[[VAL_25]], %[[VAL_27]], %[[VAL_28]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_29:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_30:.*]] = arith.constant 3 : i32
+! CHECK:           %[[VAL_31:.*]] = arith.constant 2 : i32
+! CHECK:           %[[VAL_32:.*]] = fir.convert %[[VAL_4]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_33:.*]] = fir.convert %[[VAL_29]] : (index) -> i64
+! CHECK:           %[[VAL_34:.*]] = fir.convert %[[VAL_30]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_32]], %[[VAL_31]], %[[VAL_33]], %[[VAL_34]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_35:.*]] = fir.convert %[[VAL_4]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_36:.*]] = fir.convert %[[VAL_15]] : (!fir.ref<!fir.char<1,75>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_37:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_35]], %[[VAL_13]], %[[VAL_14]], %[[VAL_36]], %[[VAL_16]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_38:.*]] = arith.constant false
+! CHECK:           %[[VAL_39:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_40:.*]] = fir.address_of(@_QQclX9ac8f8ca39400c93d3d5d265c9eadfd7) : !fir.ref<!fir.char<1,75>>
+! CHECK:           %[[VAL_41:.*]] = arith.constant 693 : i32
+! CHECK:           %[[VAL_42:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_43:.*]] = arith.constant 1 : i32
+! CHECK:           %[[VAL_44:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_45:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_46:.*]] = fir.convert %[[VAL_42]] : (index) -> i64
+! CHECK:           %[[VAL_47:.*]] = fir.convert %[[VAL_43]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_45]], %[[VAL_44]], %[[VAL_46]], %[[VAL_47]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_48:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_49:.*]] = arith.constant 2 : i32
+! CHECK:           %[[VAL_50:.*]] = arith.constant 1 : i32
+! CHECK:           %[[VAL_51:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_52:.*]] = fir.convert %[[VAL_48]] : (index) -> i64
+! CHECK:           %[[VAL_53:.*]] = fir.convert %[[VAL_49]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_51]], %[[VAL_50]], %[[VAL_52]], %[[VAL_53]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_54:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_55:.*]] = arith.constant 3 : i32
+! CHECK:           %[[VAL_56:.*]] = arith.constant 2 : i32
+! CHECK:           %[[VAL_57:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_58:.*]] = fir.convert %[[VAL_54]] : (index) -> i64
+! CHECK:           %[[VAL_59:.*]] = fir.convert %[[VAL_55]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_57]], %[[VAL_56]], %[[VAL_58]], %[[VAL_59]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_60:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_61:.*]] = fir.convert %[[VAL_40]] : (!fir.ref<!fir.char<1,75>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_62:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_60]], %[[VAL_38]], %[[VAL_39]], %[[VAL_61]], %[[VAL_41]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_63:.*]] = arith.constant false
+! CHECK:           %[[VAL_64:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_65:.*]] = fir.address_of(@_QQclX9ac8f8ca39400c93d3d5d265c9eadfd7) : !fir.ref<!fir.char<1,75>>
+! CHECK:           %[[VAL_66:.*]] = arith.constant 694 : i32
+! CHECK:           %[[VAL_67:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_68:.*]] = arith.constant 1 : i32
+! CHECK:           %[[VAL_69:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_70:.*]] = fir.convert %[[VAL_6]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_71:.*]] = fir.convert %[[VAL_67]] : (index) -> i64
+! CHECK:           %[[VAL_72:.*]] = fir.convert %[[VAL_68]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_70]], %[[VAL_69]], %[[VAL_71]], %[[VAL_72]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_73:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_74:.*]] = arith.constant 2 : i32
+! CHECK:           %[[VAL_75:.*]] = arith.constant 1 : i32
+! CHECK:           %[[VAL_76:.*]] = fir.convert %[[VAL_6]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_77:.*]] = fir.convert %[[VAL_73]] : (index) -> i64
+! CHECK:           %[[VAL_78:.*]] = fir.convert %[[VAL_74]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_76]], %[[VAL_75]], %[[VAL_77]], %[[VAL_78]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_79:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_80:.*]] = arith.constant 3 : i32
+! CHECK:           %[[VAL_81:.*]] = arith.constant 2 : i32
+! CHECK:           %[[VAL_82:.*]] = fir.convert %[[VAL_6]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_83:.*]] = fir.convert %[[VAL_79]] : (index) -> i64
+! CHECK:           %[[VAL_84:.*]] = fir.convert %[[VAL_80]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_82]], %[[VAL_81]], %[[VAL_83]], %[[VAL_84]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_85:.*]] = fir.convert %[[VAL_6]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_86:.*]] = fir.convert %[[VAL_65]] : (!fir.ref<!fir.char<1,75>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_87:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_85]], %[[VAL_63]], %[[VAL_64]], %[[VAL_86]], %[[VAL_66]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_88:.*]] = fir.load %[[VAL_6]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>
+! CHECK:           %[[VAL_89:.*]] = fir.box_addr %[[VAL_88]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>) -> !fir.heap<!fir.array<?x?x?xi32>>
+! CHECK:           %[[VAL_90:.*]] = fir.convert %[[VAL_89]] : (!fir.heap<!fir.array<?x?x?xi32>>) -> i64
+! CHECK:           %[[VAL_91:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_92:.*]] = arith.cmpi ne, %[[VAL_90]], %[[VAL_91]] : i64
+! CHECK:           %[[VAL_93:.*]] = fir.load %[[VAL_4]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>
+! CHECK:           %[[VAL_94:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_95:.*]]:3 = fir.box_dims %[[VAL_93]], %[[VAL_94]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_96:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_97:.*]]:3 = fir.box_dims %[[VAL_93]], %[[VAL_96]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_98:.*]] = arith.constant 2 : index
+! CHECK:           %[[VAL_99:.*]]:3 = fir.box_dims %[[VAL_93]], %[[VAL_98]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_100:.*]] = fir.shape %[[VAL_95]]#1, %[[VAL_97]]#1, %[[VAL_99]]#1 : (index, index, index) -> !fir.shape<3>
+! CHECK:           %[[VAL_101:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>
+! CHECK:           %[[VAL_102:.*]] = fir.load %[[VAL_6]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>
+! CHECK:           %[[VAL_103:.*]] = hlfir.elemental %[[VAL_100]] unordered : (!fir.shape<3>) -> !hlfir.expr<?x?x?xi32> {
+! CHECK:           ^bb0(%[[VAL_104:.*]]: index, %[[VAL_105:.*]]: index, %[[VAL_106:.*]]: index):
+! CHECK:             %[[VAL_107:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_108:.*]]:3 = fir.box_dims %[[VAL_93]], %[[VAL_107]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_109:.*]] = arith.constant 1 : index
+! CHECK:             %[[VAL_110:.*]]:3 = fir.box_dims %[[VAL_93]], %[[VAL_109]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_111:.*]] = arith.constant 2 : index
+! CHECK:             %[[VAL_112:.*]]:3 = fir.box_dims %[[VAL_93]], %[[VAL_111]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_113:.*]] = arith.constant 1 : index
+! CHECK:             %[[VAL_114:.*]] = arith.subi %[[VAL_108]]#0, %[[VAL_113]] : index
+! CHECK:             %[[VAL_115:.*]] = arith.addi %[[VAL_104]], %[[VAL_114]] : index
+! CHECK:             %[[VAL_116:.*]] = arith.subi %[[VAL_110]]#0, %[[VAL_113]] : index
+! CHECK:             %[[VAL_117:.*]] = arith.addi %[[VAL_105]], %[[VAL_116]] : index
+! CHECK:             %[[VAL_118:.*]] = arith.subi %[[VAL_112]]#0, %[[VAL_113]] : index
+! CHECK:             %[[VAL_119:.*]] = arith.addi %[[VAL_106]], %[[VAL_118]] : index
+! CHECK:             %[[VAL_120:.*]] = hlfir.designate %[[VAL_93]] (%[[VAL_115]], %[[VAL_117]], %[[VAL_119]])  : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index, index, index) -> !fir.ref<i32>
+! CHECK:             %[[VAL_121:.*]] = fir.load %[[VAL_120]] : !fir.ref<i32>
+! CHECK:             %[[VAL_122:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_123:.*]]:3 = fir.box_dims %[[VAL_101]], %[[VAL_122]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_124:.*]] = arith.constant 1 : index
+! CHECK:             %[[VAL_125:.*]]:3 = fir.box_dims %[[VAL_101]], %[[VAL_124]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_126:.*]] = arith.constant 2 : index
+! CHECK:             %[[VAL_127:.*]]:3 = fir.box_dims %[[VAL_101]], %[[VAL_126]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_128:.*]] = arith.constant 1 : index
+! CHECK:             %[[VAL_129:.*]] = arith.subi %[[VAL_123]]#0, %[[VAL_128]] : index
+! CHECK:             %[[VAL_130:.*]] = arith.addi %[[VAL_104]], %[[VAL_129]] : index
+! CHECK:             %[[VAL_131:.*]] = arith.subi %[[VAL_125]]#0, %[[VAL_128]] : index
+! CHECK:             %[[VAL_132:.*]] = arith.addi %[[VAL_105]], %[[VAL_131]] : index
+! CHECK:             %[[VAL_133:.*]] = arith.subi %[[VAL_127]]#0, %[[VAL_128]] : index
+! CHECK:             %[[VAL_134:.*]] = arith.addi %[[VAL_106]], %[[VAL_133]] : index
+! CHECK:             %[[VAL_135:.*]] = hlfir.designate %[[VAL_101]] (%[[VAL_130]], %[[VAL_132]], %[[VAL_134]])  : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index, index, index) -> !fir.ref<i32>
+! CHECK:             %[[VAL_136:.*]] = fir.load %[[VAL_135]] : !fir.ref<i32>
+! CHECK:             %[[VAL_137:.*]] = arith.cmpi slt, %[[VAL_121]], %[[VAL_136]] : i32
+! CHECK:             %[[VAL_138:.*]] = arith.select %[[VAL_137]], %[[VAL_121]], %[[VAL_136]] : i32
+! CHECK:             %[[VAL_139:.*]] = fir.if %[[VAL_92]] -> (i32) {
+! CHECK:               %[[VAL_140:.*]] = arith.constant 0 : index
+! CHECK:               %[[VAL_141:.*]]:3 = fir.box_dims %[[VAL_102]], %[[VAL_140]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
+! CHECK:               %[[VAL_142:.*]] = arith.constant 1 : index
+! CHECK:               %[[VAL_143:.*]]:3 = fir.box_dims %[[VAL_102]], %[[VAL_142]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
+! CHECK:               %[[VAL_144:.*]] = arith.constant 2 : index
+! CHECK:               %[[VAL_145:.*]]:3 = fir.box_dims %[[VAL_102]], %[[VAL_144]] : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index) -> (index, index, index)
+! CHECK:               %[[VAL_146:.*]] = arith.constant 1 : index
+! CHECK:               %[[VAL_147:.*]] = arith.subi %[[VAL_141]]#0, %[[VAL_146]] : index
+! CHECK:               %[[VAL_148:.*]] = arith.addi %[[VAL_104]], %[[VAL_147]] : index
+! CHECK:               %[[VAL_149:.*]] = arith.subi %[[VAL_143]]#0, %[[VAL_146]] : index
+! CHECK:               %[[VAL_150:.*]] = arith.addi %[[VAL_105]], %[[VAL_149]] : index
+! CHECK:               %[[VAL_151:.*]] = arith.subi %[[VAL_145]]#0, %[[VAL_146]] : index
+! CHECK:               %[[VAL_152:.*]] = arith.addi %[[VAL_106]], %[[VAL_151]] : index
+! CHECK:               %[[VAL_153:.*]] = hlfir.designate %[[VAL_102]] (%[[VAL_148]], %[[VAL_150]], %[[VAL_152]])  : (!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>, index, index, index) -> !fir.ref<i32>
+! CHECK:               %[[VAL_154:.*]] = fir.load %[[VAL_153]] : !fir.ref<i32>
+! CHECK:               %[[VAL_155:.*]] = arith.cmpi slt, %[[VAL_138]], %[[VAL_154]] : i32
+! CHECK:               %[[VAL_156:.*]] = arith.select %[[VAL_155]], %[[VAL_138]], %[[VAL_154]] : i32
+! CHECK:               fir.result %[[VAL_156]] : i32
 ! CHECK:             } else {
-! CHECK:               fir.result %[[VAL_116]] : i32
+! CHECK:               fir.result %[[VAL_138]] : i32
 ! CHECK:             }
-! CHECK:             hlfir.yield_element %[[VAL_135:.*]] : i32
+! CHECK:             hlfir.yield_element %[[VAL_139]] : i32
 ! CHECK:           }
-! CHECK:           hlfir.assign %[[VAL_136:.*]] to %[[VAL_5]]#0 realloc : !hlfir.expr<?x?x?xi32>, !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>
-! CHECK:           hlfir.destroy %[[VAL_136]] : !hlfir.expr<?x?x?xi32>
+! CHECK:           hlfir.assign %[[VAL_103]] to %[[VAL_6]]#0 realloc : !hlfir.expr<?x?x?xi32>, !fir.ref<!fir.box<!fir.heap<!fir.array<?x?x?xi32>>>>
+! CHECK:           hlfir.destroy %[[VAL_103]] : !hlfir.expr<?x?x?xi32>
 ! CHECK:           return
 ! CHECK:         }

--- a/flang/test/Lower/HLFIR/intrinsic-dynamically-optional.f90
+++ b/flang/test/Lower/HLFIR/intrinsic-dynamically-optional.f90
@@ -104,52 +104,105 @@ subroutine test_optional_as_addr
   deallocate(to)
 end subroutine
 ! CHECK-LABEL:   func.func @_QPtest_optional_as_addr() {
-! CHECK:           %[[FROM_STACK:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = "from", uniq_name = "_QFtest_optional_as_addrEfrom"}
-! CHECK:           %[[NULLPTR:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
-! CHECK:           %[[C0:.*]] = arith.constant 0 : index
-! CHECK:           %[[ZERO_SHAPE:.*]] = fir.shape %[[C0]] : (index) -> !fir.shape<1>
-! CHECK:           %[[ZERO_BOX:.*]] = fir.embox %[[NULLPTR]](%[[ZERO_SHAPE]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:           fir.store %[[ZERO_BOX]] to %[[FROM_STACK]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:           %[[FROM_VAR:.*]]:2 = hlfir.declare %[[FROM_STACK]]
-! CHECK:           %[[STAT_STACK:.*]] = fir.alloca !fir.box<!fir.heap<i32>> {bindc_name = "stat", uniq_name = "_QFtest_optional_as_addrEstat"}
-! CHECK:           %[[STAT_NULLPTR:.*]] = fir.zero_bits !fir.heap<i32>
-! CHECK:           %[[STAT_NULLBOX:.*]] = fir.embox %[[STAT_NULLPTR]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
-! CHECK:           fir.store %[[STAT_NULLBOX]] to %[[STAT_STACK]] : !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:           %[[STAT_VAR:.*]]:2 = hlfir.declare %[[STAT_STACK]]
-! CHECK:           %[[TO_STACK:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = "to", uniq_name = "_QFtest_optional_as_addrEto"}
-! CHECK:           %[[TO_NULLPTR:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
-! CHECK:           %[[C0_1:.*]] = arith.constant 0 : index
-! CHECK:           %[[TO_ZERO_SHAPE:.*]] = fir.shape %[[C0_1]] : (index) -> !fir.shape<1>
-! CHECK:           %[[TO_NULLBOX:.*]] = fir.embox %[[TO_NULLPTR]](%[[TO_ZERO_SHAPE]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:           fir.store %[[TO_NULLBOX]] to %[[TO_STACK]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:           %[[TO_VAR:.*]]:2 = hlfir.declare %[[TO_STACK]]
-! CHECK:           %[[C20_I32:.*]] = arith.constant 20 : i32
-! CHECK:           %[[C20:.*]] = fir.convert %[[C20_I32]] : (i32) -> index
-! CHECK:           %[[C0_2:.*]] = arith.constant 0 : index
-! CHECK:           %[[CMPI:.*]] = arith.cmpi sgt, %[[C20]], %[[C0_2]] : index
-! CHECK:           %[[ALLOC_SZ:.*]] = arith.select %[[CMPI]], %[[C20]], %[[C0_2]] : index
-! CHECK:           %[[FROM_ALLOC:.*]] = fir.allocmem !fir.array<?xi32>, %[[ALLOC_SZ]] {fir.must_be_heap = true, uniq_name = "_QFtest_optional_as_addrEfrom.alloc"}
-! CHECK:           %[[FROM_SHAPE:.*]] = fir.shape %[[ALLOC_SZ]] : (index) -> !fir.shape<1>
-! CHECK:           %[[FROM_BOX:.*]] = fir.embox %[[FROM_ALLOC]](%[[FROM_SHAPE]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:           fir.store %[[FROM_BOX]] to %[[FROM_VAR]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:           %[[STAT_BOX:.*]] = fir.load %[[STAT_VAR]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:           %[[STAT_ADDR:.*]] = fir.box_addr %[[STAT_BOX]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
-! CHECK:           %[[ABSENT:.*]] = fir.absent !fir.box<none>
-! CHECK:           %[[TRUE:.*]] = arith.constant true
-! CHECK:           %[[VAL_25:.*]] = fir.address_of({{.*}}) : !fir.ref<!fir.char<{{.*}}>>
-! CHECK:           %[[VAL_26:.*]] = arith.constant {{.*}} : i32
-! CHECK:           %[[VAL_27:.*]] = fir.zero_bits !fir.ref<none>
-! CHECK:           %[[VAL_28:.*]] = fir.convert %[[TO_VAR]]#0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
-! CHECK:           %[[VAL_29:.*]] = fir.convert %[[FROM_VAR]]#0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
-! CHECK:           %[[VAL_30:.*]] = fir.convert %[[VAL_25]] : (!fir.ref<!fir.char<{{.*}}>>) -> !fir.ref<i8>
-! CHECK:           %[[RES:.*]] = fir.call @_FortranAMoveAlloc(%[[VAL_28]], %[[VAL_29]], %[[VAL_27]], %[[TRUE]], %[[ABSENT]], %[[VAL_30]], %[[VAL_26]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, !fir.ref<!fir.box<none>>, !fir.ref<none>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
-! CHECK:           %[[STAT_INT:.*]] = fir.convert %[[STAT_ADDR]] : (!fir.heap<i32>) -> i64
-! CHECK:           %[[C0_3:.*]] = arith.constant 0 : i64
-! CHECK:           %[[STAT_NOT_NULL:.*]] = arith.cmpi ne, %[[STAT_INT]], %[[C0_3]] : i64
-! CHECK:           fir.if %[[STAT_NOT_NULL]] {
-! CHECK:             fir.store %[[RES]] to %[[STAT_ADDR]] : !fir.heap<i32>
+! CHECK:           %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = "from", uniq_name = "_QFtest_optional_as_addrEfrom"}
+! CHECK:           %[[VAL_1:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
+! CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_3:.*]] = fir.shape %[[VAL_2]] : (index) -> !fir.shape<1>
+! CHECK:           %[[VAL_4:.*]] = fir.embox %[[VAL_1]](%[[VAL_3]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_4]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFtest_optional_as_addrEfrom"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
+! CHECK:           %[[VAL_6:.*]] = fir.alloca !fir.box<!fir.heap<i32>> {bindc_name = "stat", uniq_name = "_QFtest_optional_as_addrEstat"}
+! CHECK:           %[[VAL_7:.*]] = fir.zero_bits !fir.heap<i32>
+! CHECK:           %[[VAL_8:.*]] = fir.embox %[[VAL_7]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
+! CHECK:           fir.store %[[VAL_8]] to %[[VAL_6]] : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:           %[[VAL_9:.*]]:2 = hlfir.declare %[[VAL_6]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFtest_optional_as_addrEstat"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
+! CHECK:           %[[VAL_10:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = "to", uniq_name = "_QFtest_optional_as_addrEto"}
+! CHECK:           %[[VAL_11:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
+! CHECK:           %[[VAL_12:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_13:.*]] = fir.shape %[[VAL_12]] : (index) -> !fir.shape<1>
+! CHECK:           %[[VAL_14:.*]] = fir.embox %[[VAL_11]](%[[VAL_13]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_14]] to %[[VAL_10]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_15:.*]]:2 = hlfir.declare %[[VAL_10]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFtest_optional_as_addrEto"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
+! CHECK:           %[[VAL_16:.*]] = arith.constant false
+! CHECK:           %[[VAL_17:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_18:.*]] = fir.address_of(@_QQclXa514fea0665eb481f11db615a3b4888a) : !fir.ref<!fir.char<1,89>>
+! CHECK:           %[[VAL_19:.*]] = arith.constant 102 : i32
+! CHECK:           %[[VAL_20:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_21:.*]] = arith.constant 20 : i32
+! CHECK:           %[[VAL_22:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_23:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_24:.*]] = fir.convert %[[VAL_20]] : (index) -> i64
+! CHECK:           %[[VAL_25:.*]] = fir.convert %[[VAL_21]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_23]], %[[VAL_22]], %[[VAL_24]], %[[VAL_25]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_27:.*]] = fir.convert %[[VAL_18]] : (!fir.ref<!fir.char<1,89>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_28:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_26]], %[[VAL_16]], %[[VAL_17]], %[[VAL_27]], %[[VAL_19]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_29:.*]] = fir.load %[[VAL_9]]#1 : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:           %[[VAL_30:.*]] = fir.box_addr %[[VAL_29]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:           %[[VAL_31:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_32:.*]] = arith.constant true
+! CHECK:           %[[VAL_33:.*]] = fir.address_of(@_QQclXa514fea0665eb481f11db615a3b4888a) : !fir.ref<!fir.char<1,89>>
+! CHECK:           %[[VAL_34:.*]] = arith.constant 103 : i32
+! CHECK:           %[[VAL_35:.*]] = fir.zero_bits !fir.ref<none>
+! CHECK:           %[[VAL_36:.*]] = fir.convert %[[VAL_15]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_37:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_38:.*]] = fir.convert %[[VAL_33]] : (!fir.ref<!fir.char<1,89>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_39:.*]] = fir.call @_FortranAMoveAlloc(%[[VAL_36]], %[[VAL_37]], %[[VAL_35]], %[[VAL_32]], %[[VAL_31]], %[[VAL_38]], %[[VAL_34]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, !fir.ref<!fir.box<none>>, !fir.ref<none>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_40:.*]] = fir.convert %[[VAL_30]] : (!fir.heap<i32>) -> i64
+! CHECK:           %[[VAL_41:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_42:.*]] = arith.cmpi ne, %[[VAL_40]], %[[VAL_41]] : i64
+! CHECK:           fir.if %[[VAL_42]] {
+! CHECK:             fir.store %[[VAL_39]] to %[[VAL_30]] : !fir.heap<i32>
 ! CHECK:           }
-!                  [...]
+! CHECK:           %[[VAL_43:.*]] = arith.constant false
+! CHECK:           %[[VAL_44:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_45:.*]] = fir.address_of(@_QQclXa514fea0665eb481f11db615a3b4888a) : !fir.ref<!fir.char<1,89>>
+! CHECK:           %[[VAL_46:.*]] = arith.constant 104 : i32
+! CHECK:           %[[VAL_47:.*]] = fir.convert %[[VAL_15]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_48:.*]] = fir.convert %[[VAL_45]] : (!fir.ref<!fir.char<1,89>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_49:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_47]], %[[VAL_43]], %[[VAL_44]], %[[VAL_48]], %[[VAL_46]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_50:.*]] = fir.load %[[VAL_15]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_51:.*]] = fir.box_addr %[[VAL_50]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:           %[[VAL_52:.*]] = fir.convert %[[VAL_51]] : (!fir.heap<!fir.array<?xi32>>) -> i64
+! CHECK:           %[[VAL_53:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_54:.*]] = arith.cmpi ne, %[[VAL_52]], %[[VAL_53]] : i64
+! CHECK:           fir.if %[[VAL_54]] {
+! CHECK:             %[[VAL_55:.*]] = arith.constant false
+! CHECK:             %[[VAL_56:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_57:.*]] = fir.address_of(@_QQclXa514fea0665eb481f11db615a3b4888a) : !fir.ref<!fir.char<1,89>>
+! CHECK:             %[[VAL_58:.*]] = arith.constant 99 : i32
+! CHECK:             %[[VAL_59:.*]] = fir.convert %[[VAL_15]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_60:.*]] = fir.convert %[[VAL_57]] : (!fir.ref<!fir.char<1,89>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_61:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_59]], %[[VAL_55]], %[[VAL_56]], %[[VAL_60]], %[[VAL_58]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           }
+! CHECK:           %[[VAL_62:.*]] = fir.load %[[VAL_9]]#1 : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:           %[[VAL_63:.*]] = fir.box_addr %[[VAL_62]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:           %[[VAL_64:.*]] = fir.convert %[[VAL_63]] : (!fir.heap<i32>) -> i64
+! CHECK:           %[[VAL_65:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_66:.*]] = arith.cmpi ne, %[[VAL_64]], %[[VAL_65]] : i64
+! CHECK:           fir.if %[[VAL_66]] {
+! CHECK:             %[[VAL_67:.*]] = arith.constant false
+! CHECK:             %[[VAL_68:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_69:.*]] = fir.address_of(@_QQclXa514fea0665eb481f11db615a3b4888a) : !fir.ref<!fir.char<1,89>>
+! CHECK:             %[[VAL_70:.*]] = arith.constant 99 : i32
+! CHECK:             %[[VAL_71:.*]] = fir.convert %[[VAL_9]]#1 : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_72:.*]] = fir.convert %[[VAL_69]] : (!fir.ref<!fir.char<1,89>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_73:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_71]], %[[VAL_67]], %[[VAL_68]], %[[VAL_72]], %[[VAL_70]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           }
+! CHECK:           %[[VAL_74:.*]] = fir.load %[[VAL_5]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_75:.*]] = fir.box_addr %[[VAL_74]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:           %[[VAL_76:.*]] = fir.convert %[[VAL_75]] : (!fir.heap<!fir.array<?xi32>>) -> i64
+! CHECK:           %[[VAL_77:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_78:.*]] = arith.cmpi ne, %[[VAL_76]], %[[VAL_77]] : i64
+! CHECK:           fir.if %[[VAL_78]] {
+! CHECK:             %[[VAL_79:.*]] = arith.constant false
+! CHECK:             %[[VAL_80:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_81:.*]] = fir.address_of(@_QQclXa514fea0665eb481f11db615a3b4888a) : !fir.ref<!fir.char<1,89>>
+! CHECK:             %[[VAL_82:.*]] = arith.constant 99 : i32
+! CHECK:             %[[VAL_83:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_84:.*]] = fir.convert %[[VAL_81]] : (!fir.ref<!fir.char<1,89>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_85:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_83]], %[[VAL_79]], %[[VAL_80]], %[[VAL_84]], %[[VAL_82]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           }
 ! CHECK:           return
 ! CHECK:         }
 

--- a/flang/test/Lower/HLFIR/intrinsic-dynamically-optional.f90
+++ b/flang/test/Lower/HLFIR/intrinsic-dynamically-optional.f90
@@ -130,22 +130,22 @@ end subroutine
 ! CHECK:           %[[VAL_20:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_21:.*]] = arith.constant 20 : i32
 ! CHECK:           %[[VAL_22:.*]] = arith.constant 0 : i32
-! CHECK:           %[[VAL_23:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_23:.*]] = fir.convert %[[VAL_5]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_24:.*]] = fir.convert %[[VAL_20]] : (index) -> i64
 ! CHECK:           %[[VAL_25:.*]] = fir.convert %[[VAL_21]] : (i32) -> i64
 ! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_23]], %[[VAL_22]], %[[VAL_24]], %[[VAL_25]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
-! CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_5]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_27:.*]] = fir.convert %[[VAL_18]] : (!fir.ref<!fir.char<1,89>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_28:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_26]], %[[VAL_16]], %[[VAL_17]], %[[VAL_27]], %[[VAL_19]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
-! CHECK:           %[[VAL_29:.*]] = fir.load %[[VAL_9]]#1 : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:           %[[VAL_29:.*]] = fir.load %[[VAL_9]]{{.*}} : !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:           %[[VAL_30:.*]] = fir.box_addr %[[VAL_29]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
 ! CHECK:           %[[VAL_31:.*]] = fir.absent !fir.box<none>
 ! CHECK:           %[[VAL_32:.*]] = arith.constant true
 ! CHECK:           %[[VAL_33:.*]] = fir.address_of(@_QQclXa514fea0665eb481f11db615a3b4888a) : !fir.ref<!fir.char<1,89>>
 ! CHECK:           %[[VAL_34:.*]] = arith.constant 103 : i32
 ! CHECK:           %[[VAL_35:.*]] = fir.zero_bits !fir.ref<none>
-! CHECK:           %[[VAL_36:.*]] = fir.convert %[[VAL_15]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
-! CHECK:           %[[VAL_37:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_36:.*]] = fir.convert %[[VAL_15]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_37:.*]] = fir.convert %[[VAL_5]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_38:.*]] = fir.convert %[[VAL_33]] : (!fir.ref<!fir.char<1,89>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_39:.*]] = fir.call @_FortranAMoveAlloc(%[[VAL_36]], %[[VAL_37]], %[[VAL_35]], %[[VAL_32]], %[[VAL_31]], %[[VAL_38]], %[[VAL_34]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, !fir.ref<!fir.box<none>>, !fir.ref<none>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:           %[[VAL_40:.*]] = fir.convert %[[VAL_30]] : (!fir.heap<i32>) -> i64
@@ -158,10 +158,10 @@ end subroutine
 ! CHECK:           %[[VAL_44:.*]] = fir.absent !fir.box<none>
 ! CHECK:           %[[VAL_45:.*]] = fir.address_of(@_QQclXa514fea0665eb481f11db615a3b4888a) : !fir.ref<!fir.char<1,89>>
 ! CHECK:           %[[VAL_46:.*]] = arith.constant 104 : i32
-! CHECK:           %[[VAL_47:.*]] = fir.convert %[[VAL_15]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_47:.*]] = fir.convert %[[VAL_15]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_48:.*]] = fir.convert %[[VAL_45]] : (!fir.ref<!fir.char<1,89>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_49:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_47]], %[[VAL_43]], %[[VAL_44]], %[[VAL_48]], %[[VAL_46]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
-! CHECK:           %[[VAL_50:.*]] = fir.load %[[VAL_15]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_50:.*]] = fir.load %[[VAL_15]]{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_51:.*]] = fir.box_addr %[[VAL_50]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
 ! CHECK:           %[[VAL_52:.*]] = fir.convert %[[VAL_51]] : (!fir.heap<!fir.array<?xi32>>) -> i64
 ! CHECK:           %[[VAL_53:.*]] = arith.constant 0 : i64
@@ -171,11 +171,11 @@ end subroutine
 ! CHECK:             %[[VAL_56:.*]] = fir.absent !fir.box<none>
 ! CHECK:             %[[VAL_57:.*]] = fir.address_of(@_QQclXa514fea0665eb481f11db615a3b4888a) : !fir.ref<!fir.char<1,89>>
 ! CHECK:             %[[VAL_58:.*]] = arith.constant 99 : i32
-! CHECK:             %[[VAL_59:.*]] = fir.convert %[[VAL_15]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_59:.*]] = fir.convert %[[VAL_15]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:             %[[VAL_60:.*]] = fir.convert %[[VAL_57]] : (!fir.ref<!fir.char<1,89>>) -> !fir.ref<i8>
 ! CHECK:             %[[VAL_61:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_59]], %[[VAL_55]], %[[VAL_56]], %[[VAL_60]], %[[VAL_58]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:           }
-! CHECK:           %[[VAL_62:.*]] = fir.load %[[VAL_9]]#1 : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:           %[[VAL_62:.*]] = fir.load %[[VAL_9]]{{.*}} : !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:           %[[VAL_63:.*]] = fir.box_addr %[[VAL_62]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
 ! CHECK:           %[[VAL_64:.*]] = fir.convert %[[VAL_63]] : (!fir.heap<i32>) -> i64
 ! CHECK:           %[[VAL_65:.*]] = arith.constant 0 : i64
@@ -185,11 +185,11 @@ end subroutine
 ! CHECK:             %[[VAL_68:.*]] = fir.absent !fir.box<none>
 ! CHECK:             %[[VAL_69:.*]] = fir.address_of(@_QQclXa514fea0665eb481f11db615a3b4888a) : !fir.ref<!fir.char<1,89>>
 ! CHECK:             %[[VAL_70:.*]] = arith.constant 99 : i32
-! CHECK:             %[[VAL_71:.*]] = fir.convert %[[VAL_9]]#1 : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_71:.*]] = fir.convert %[[VAL_9]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:             %[[VAL_72:.*]] = fir.convert %[[VAL_69]] : (!fir.ref<!fir.char<1,89>>) -> !fir.ref<i8>
 ! CHECK:             %[[VAL_73:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_71]], %[[VAL_67]], %[[VAL_68]], %[[VAL_72]], %[[VAL_70]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:           }
-! CHECK:           %[[VAL_74:.*]] = fir.load %[[VAL_5]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_74:.*]] = fir.load %[[VAL_5]]{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_75:.*]] = fir.box_addr %[[VAL_74]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
 ! CHECK:           %[[VAL_76:.*]] = fir.convert %[[VAL_75]] : (!fir.heap<!fir.array<?xi32>>) -> i64
 ! CHECK:           %[[VAL_77:.*]] = arith.constant 0 : i64
@@ -199,7 +199,7 @@ end subroutine
 ! CHECK:             %[[VAL_80:.*]] = fir.absent !fir.box<none>
 ! CHECK:             %[[VAL_81:.*]] = fir.address_of(@_QQclXa514fea0665eb481f11db615a3b4888a) : !fir.ref<!fir.char<1,89>>
 ! CHECK:             %[[VAL_82:.*]] = arith.constant 99 : i32
-! CHECK:             %[[VAL_83:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_83:.*]] = fir.convert %[[VAL_5]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:             %[[VAL_84:.*]] = fir.convert %[[VAL_81]] : (!fir.ref<!fir.char<1,89>>) -> !fir.ref<i8>
 ! CHECK:             %[[VAL_85:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_83]], %[[VAL_79]], %[[VAL_80]], %[[VAL_84]], %[[VAL_82]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:           }

--- a/flang/test/Lower/Intrinsics/len.f90
+++ b/flang/test/Lower/Intrinsics/len.f90
@@ -51,10 +51,19 @@ end subroutine
 subroutine len_test_array_local_alloc(i)
   integer :: i
   character(:), allocatable :: c(:)
+! CHECK:  %[[VAL_1:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>> {bindc_name = "c", uniq_name = "_QFlen_test_array_local_allocEc"}
+! CHECK:  %[[VAL_2:.*]] = fir.alloca !fir.heap<!fir.array<?x!fir.char<1,?>>> {uniq_name = "_QFlen_test_array_local_allocEc.addr"}
+! CHECK:  %[[VAL_3:.*]] = fir.alloca index {uniq_name = "_QFlen_test_array_local_allocEc.lb0"}
+! CHECK:  %[[VAL_4:.*]] = fir.alloca index {uniq_name = "_QFlen_test_array_local_allocEc.ext0"}
 ! CHECK:  %[[VAL_5:.*]] = fir.alloca index {uniq_name = "_QFlen_test_array_local_allocEc.len"}
 ! CHECK:  %[[VAL_7:.*]] = arith.constant 10 : i32
-! CHECK:  %[[VAL_10:.*]] = fir.convert %[[VAL_7]] : (i32) -> index
-! CHECK:  fir.store %[[VAL_10]] to %[[VAL_5]] : !fir.ref<index>
+! CHECK:  %[[VAL_12:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:  %[[VAL_13:.*]] = fir.load %[[VAL_4]] : !fir.ref<index>
+! CHECK:  %[[VAL_14:.*]] = fir.load %[[VAL_5]] : !fir.ref<index>
+! CHECK:  %[[VAL_15:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<!fir.array<?x!fir.char<1,?>>>>
+! CHECK:  %[[VAL_16:.*]] = fir.shape_shift %[[VAL_12]], %[[VAL_13]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:  %[[VAL_17:.*]] = fir.embox %[[VAL_15]](%[[VAL_16]]) typeparams %[[VAL_14]]
+! CHECK:  fir.store %[[VAL_17]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?x!fir.char<1,?>>>>>
   allocate(character(10):: c(100))
 ! CHECK:  %[[VAL_13:.*]] = fir.load %[[VAL_5]] : !fir.ref<index>
 ! CHECK:  %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (index) -> i32

--- a/flang/test/Lower/Intrinsics/move_alloc.f90
+++ b/flang/test/Lower/Intrinsics/move_alloc.f90
@@ -1,63 +1,426 @@
   ! RUN: bbc --use-desc-for-alloc=false -emit-fir -hlfir=false %s -o - | FileCheck  %s
   ! RUN: %flang_fc1 -mllvm --use-desc-for-alloc=false -emit-fir -flang-deprecated-no-hlfir %s -o - | FileCheck %s
 
-! CHECK-LABEL: to_from_only
 subroutine to_from_only
-  ! CHECK: %[[a1:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
-  ! CHECK: %[[b1:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
   integer, allocatable :: from(:), to(:)
   allocate(from(20))
-  ! CHECK: %[[errMsg:.*]] = fir.absent !fir.box<none>
-  ! CHECK: %[[false:.*]] = arith.constant false
-  ! CHECK-DAG: %[[a2:.*]] = fir.convert %[[a1]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK-DAG: %[[b2:.*]] = fir.convert %[[b1]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   call move_alloc(from, to)
-  ! CHECK: fir.call @_FortranAMoveAlloc(%[[b2]], %[[a2]], %{{.*}}, %[[false]], %[[errMsg]], %{{.*}}, %{{.*}}) fastmath<contract> : (!fir.ref<!fir.box<none>>, !fir.ref<!fir.box<none>>, !fir.ref<none>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
-  ! CHECK-DAG:  %[[a3:.*]] = fir.load %[[a1:.*]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  ! CHECK-DAG:  %[[a4:.*]] = fir.box_addr %[[a3]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-  ! CHECK-DAG:  %[[b3:.*]] = fir.load %[[b1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  ! CHECK-DAG:  %[[b4:.*]] = fir.box_addr %[[b3:.*]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
 end subroutine to_from_only
+! CHECK-LABEL:   func.func @_QPto_from_only() {
+! CHECK:           %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = "from", uniq_name = "_QFto_from_onlyEfrom"}
+! CHECK:           %[[VAL_1:.*]] = fir.alloca !fir.heap<!fir.array<?xi32>> {uniq_name = "_QFto_from_onlyEfrom.addr"}
+! CHECK:           %[[VAL_2:.*]] = fir.alloca index {uniq_name = "_QFto_from_onlyEfrom.lb0"}
+! CHECK:           %[[VAL_3:.*]] = fir.alloca index {uniq_name = "_QFto_from_onlyEfrom.ext0"}
+! CHECK:           %[[VAL_4:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
+! CHECK:           fir.store %[[VAL_4]] to %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_5:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = "to", uniq_name = "_QFto_from_onlyEto"}
+! CHECK:           %[[VAL_6:.*]] = fir.alloca !fir.heap<!fir.array<?xi32>> {uniq_name = "_QFto_from_onlyEto.addr"}
+! CHECK:           %[[VAL_7:.*]] = fir.alloca index {uniq_name = "_QFto_from_onlyEto.lb0"}
+! CHECK:           %[[VAL_8:.*]] = fir.alloca index {uniq_name = "_QFto_from_onlyEto.ext0"}
+! CHECK:           %[[VAL_9:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
+! CHECK:           fir.store %[[VAL_9]] to %[[VAL_6]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_10:.*]] = arith.constant false
+! CHECK:           %[[VAL_11:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_12:.*]] = fir.address_of(@_QQclX8c4f3bfd49fac4527014c85e4d2f3268) : !fir.ref<!fir.char<1,74>>
+! CHECK:           %[[VAL_13:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_14:.*]] = fir.load %[[VAL_2]] : !fir.ref<index>
+! CHECK:           %[[VAL_15:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:           %[[VAL_16:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_17:.*]] = fir.shape_shift %[[VAL_14]], %[[VAL_15]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:           %[[VAL_18:.*]] = fir.embox %[[VAL_16]](%[[VAL_17]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_18]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_19:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_20:.*]] = arith.constant 20 : i32
+! CHECK:           %[[VAL_21:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_22:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_23:.*]] = fir.convert %[[VAL_19]] : (index) -> i64
+! CHECK:           %[[VAL_24:.*]] = fir.convert %[[VAL_20]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_22]], %[[VAL_21]], %[[VAL_23]], %[[VAL_24]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_25:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_12]] : (!fir.ref<!fir.char<1,74>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_27:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_25]], %[[VAL_10]], %[[VAL_11]], %[[VAL_26]], %[[VAL_13]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_28:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_29:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_30:.*]]:3 = fir.box_dims %[[VAL_28]], %[[VAL_29]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_31:.*]] = fir.box_addr %[[VAL_28]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:           fir.store %[[VAL_31]] to %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_30]]#1 to %[[VAL_3]] : !fir.ref<index>
+! CHECK:           fir.store %[[VAL_30]]#0 to %[[VAL_2]] : !fir.ref<index>
+! CHECK:           %[[VAL_32:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_33:.*]] = fir.load %[[VAL_2]] : !fir.ref<index>
+! CHECK:           %[[VAL_34:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:           %[[VAL_35:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_36:.*]] = fir.shape_shift %[[VAL_33]], %[[VAL_34]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:           %[[VAL_37:.*]] = fir.embox %[[VAL_35]](%[[VAL_36]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_37]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_38:.*]] = fir.load %[[VAL_7]] : !fir.ref<index>
+! CHECK:           %[[VAL_39:.*]] = fir.load %[[VAL_8]] : !fir.ref<index>
+! CHECK:           %[[VAL_40:.*]] = fir.load %[[VAL_6]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_41:.*]] = fir.shape_shift %[[VAL_38]], %[[VAL_39]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:           %[[VAL_42:.*]] = fir.embox %[[VAL_40]](%[[VAL_41]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_42]] to %[[VAL_5]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_43:.*]] = arith.constant false
+! CHECK:           %[[VAL_44:.*]] = fir.address_of(@_QQclX8c4f3bfd49fac4527014c85e4d2f3268) : !fir.ref<!fir.char<1,74>>
+! CHECK:           %[[VAL_45:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_46:.*]] = fir.zero_bits !fir.ref<none>
+! CHECK:           %[[VAL_47:.*]] = fir.convert %[[VAL_5]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_48:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_49:.*]] = fir.convert %[[VAL_44]] : (!fir.ref<!fir.char<1,74>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_50:.*]] = fir.call @_FortranAMoveAlloc(%[[VAL_47]], %[[VAL_48]], %[[VAL_46]], %[[VAL_43]], %[[VAL_32]], %[[VAL_49]], %[[VAL_45]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, !fir.ref<!fir.box<none>>, !fir.ref<none>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_51:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_52:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_53:.*]]:3 = fir.box_dims %[[VAL_51]], %[[VAL_52]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_54:.*]] = fir.box_addr %[[VAL_51]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:           fir.store %[[VAL_54]] to %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_53]]#1 to %[[VAL_3]] : !fir.ref<index>
+! CHECK:           fir.store %[[VAL_53]]#0 to %[[VAL_2]] : !fir.ref<index>
+! CHECK:           %[[VAL_55:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_56:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_57:.*]]:3 = fir.box_dims %[[VAL_55]], %[[VAL_56]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_58:.*]] = fir.box_addr %[[VAL_55]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:           fir.store %[[VAL_58]] to %[[VAL_6]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_57]]#1 to %[[VAL_8]] : !fir.ref<index>
+! CHECK:           fir.store %[[VAL_57]]#0 to %[[VAL_7]] : !fir.ref<index>
+! CHECK:           %[[VAL_59:.*]] = fir.load %[[VAL_6]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_60:.*]] = fir.convert %[[VAL_59]] : (!fir.heap<!fir.array<?xi32>>) -> i64
+! CHECK:           %[[VAL_61:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_62:.*]] = arith.cmpi ne, %[[VAL_60]], %[[VAL_61]] : i64
+! CHECK:           fir.if %[[VAL_62]] {
+! CHECK:             %[[VAL_63:.*]] = arith.constant false
+! CHECK:             %[[VAL_64:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_65:.*]] = fir.address_of(@_QQclX8c4f3bfd49fac4527014c85e4d2f3268) : !fir.ref<!fir.char<1,74>>
+! CHECK:             %[[VAL_66:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_67:.*]] = fir.load %[[VAL_7]] : !fir.ref<index>
+! CHECK:             %[[VAL_68:.*]] = fir.load %[[VAL_8]] : !fir.ref<index>
+! CHECK:             %[[VAL_69:.*]] = fir.load %[[VAL_6]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             %[[VAL_70:.*]] = fir.shape_shift %[[VAL_67]], %[[VAL_68]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:             %[[VAL_71:.*]] = fir.embox %[[VAL_69]](%[[VAL_70]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_71]] to %[[VAL_5]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_72:.*]] = fir.convert %[[VAL_5]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_73:.*]] = fir.convert %[[VAL_65]] : (!fir.ref<!fir.char<1,74>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_74:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_72]], %[[VAL_63]], %[[VAL_64]], %[[VAL_73]], %[[VAL_66]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:             %[[VAL_75:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_76:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_77:.*]]:3 = fir.box_dims %[[VAL_75]], %[[VAL_76]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_78:.*]] = fir.box_addr %[[VAL_75]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:             fir.store %[[VAL_78]] to %[[VAL_6]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_77]]#1 to %[[VAL_8]] : !fir.ref<index>
+! CHECK:             fir.store %[[VAL_77]]#0 to %[[VAL_7]] : !fir.ref<index>
+! CHECK:           }
+! CHECK:           %[[VAL_79:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_80:.*]] = fir.convert %[[VAL_79]] : (!fir.heap<!fir.array<?xi32>>) -> i64
+! CHECK:           %[[VAL_81:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_82:.*]] = arith.cmpi ne, %[[VAL_80]], %[[VAL_81]] : i64
+! CHECK:           fir.if %[[VAL_82]] {
+! CHECK:             %[[VAL_83:.*]] = arith.constant false
+! CHECK:             %[[VAL_84:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_85:.*]] = fir.address_of(@_QQclX8c4f3bfd49fac4527014c85e4d2f3268) : !fir.ref<!fir.char<1,74>>
+! CHECK:             %[[VAL_86:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_87:.*]] = fir.load %[[VAL_2]] : !fir.ref<index>
+! CHECK:             %[[VAL_88:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:             %[[VAL_89:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             %[[VAL_90:.*]] = fir.shape_shift %[[VAL_87]], %[[VAL_88]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:             %[[VAL_91:.*]] = fir.embox %[[VAL_89]](%[[VAL_90]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_91]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_92:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_93:.*]] = fir.convert %[[VAL_85]] : (!fir.ref<!fir.char<1,74>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_94:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_92]], %[[VAL_83]], %[[VAL_84]], %[[VAL_93]], %[[VAL_86]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:             %[[VAL_95:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_96:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_97:.*]]:3 = fir.box_dims %[[VAL_95]], %[[VAL_96]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_98:.*]] = fir.box_addr %[[VAL_95]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:             fir.store %[[VAL_98]] to %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_97]]#1 to %[[VAL_3]] : !fir.ref<index>
+! CHECK:             fir.store %[[VAL_97]]#0 to %[[VAL_2]] : !fir.ref<index>
+! CHECK:           }
+! CHECK:           return
+! CHECK:         }
 
-! CHECK-LABEL: to_from_stat
 subroutine to_from_stat
-  ! CHECK-DAG: %[[a1:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
-  ! CHECK-DAG: %[[b1:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
   integer, allocatable :: from(:), to(:)
-  ! CHECK-DAG: %[[stat1:.*]] = fir.alloca i32
   integer :: stat
   allocate(from(20))
-  ! CHECK: %[[errMsg:.*]] = fir.absent !fir.box<none>
-  ! CHECK: %[[true:.*]] = arith.constant true
-  ! CHECK-DAG: %[[a2:.*]] = fir.convert %[[a1]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK-DAG: %[[b2:.*]] = fir.convert %[[b1]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   call move_alloc(from, to, stat)
-  ! CHECK: %[[stat:.*]] = fir.call @_FortranAMoveAlloc(%[[b2]], %[[a2]], %{{.*}}, %[[true]], %[[errMsg]], %{{.*}}, %{{.*}}) fastmath<contract> : (!fir.ref<!fir.box<none>>, !fir.ref<!fir.box<none>>, !fir.ref<none>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
-  ! CHECK-DAG:  %[[a3:.*]] = fir.load %[[a1:.*]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  ! CHECK-DAG:  %[[a4:.*]] = fir.box_addr %[[a3]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-  ! CHECK-DAG:  %[[b3:.*]] = fir.load %[[b1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  ! CHECK-DAG:  %[[b4:.*]] = fir.box_addr %[[b3:.*]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
 end subroutine to_from_stat
+! CHECK-LABEL:   func.func @_QPto_from_stat() {
+! CHECK:           %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = "from", uniq_name = "_QFto_from_statEfrom"}
+! CHECK:           %[[VAL_1:.*]] = fir.alloca !fir.heap<!fir.array<?xi32>> {uniq_name = "_QFto_from_statEfrom.addr"}
+! CHECK:           %[[VAL_2:.*]] = fir.alloca index {uniq_name = "_QFto_from_statEfrom.lb0"}
+! CHECK:           %[[VAL_3:.*]] = fir.alloca index {uniq_name = "_QFto_from_statEfrom.ext0"}
+! CHECK:           %[[VAL_4:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
+! CHECK:           fir.store %[[VAL_4]] to %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_5:.*]] = fir.alloca i32 {bindc_name = "stat", uniq_name = "_QFto_from_statEstat"}
+! CHECK:           %[[VAL_6:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = "to", uniq_name = "_QFto_from_statEto"}
+! CHECK:           %[[VAL_7:.*]] = fir.alloca !fir.heap<!fir.array<?xi32>> {uniq_name = "_QFto_from_statEto.addr"}
+! CHECK:           %[[VAL_8:.*]] = fir.alloca index {uniq_name = "_QFto_from_statEto.lb0"}
+! CHECK:           %[[VAL_9:.*]] = fir.alloca index {uniq_name = "_QFto_from_statEto.ext0"}
+! CHECK:           %[[VAL_10:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
+! CHECK:           fir.store %[[VAL_10]] to %[[VAL_7]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_11:.*]] = arith.constant false
+! CHECK:           %[[VAL_12:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_13:.*]] = fir.address_of(@_QQclX8c4f3bfd49fac4527014c85e4d2f3268) : !fir.ref<!fir.char<1,74>>
+! CHECK:           %[[VAL_14:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_15:.*]] = fir.load %[[VAL_2]] : !fir.ref<index>
+! CHECK:           %[[VAL_16:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:           %[[VAL_17:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_18:.*]] = fir.shape_shift %[[VAL_15]], %[[VAL_16]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:           %[[VAL_19:.*]] = fir.embox %[[VAL_17]](%[[VAL_18]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_19]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_20:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_21:.*]] = arith.constant 20 : i32
+! CHECK:           %[[VAL_22:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_23:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_24:.*]] = fir.convert %[[VAL_20]] : (index) -> i64
+! CHECK:           %[[VAL_25:.*]] = fir.convert %[[VAL_21]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_23]], %[[VAL_22]], %[[VAL_24]], %[[VAL_25]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_27:.*]] = fir.convert %[[VAL_13]] : (!fir.ref<!fir.char<1,74>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_28:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_26]], %[[VAL_11]], %[[VAL_12]], %[[VAL_27]], %[[VAL_14]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_29:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_30:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_31:.*]]:3 = fir.box_dims %[[VAL_29]], %[[VAL_30]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_32:.*]] = fir.box_addr %[[VAL_29]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:           fir.store %[[VAL_32]] to %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_31]]#1 to %[[VAL_3]] : !fir.ref<index>
+! CHECK:           fir.store %[[VAL_31]]#0 to %[[VAL_2]] : !fir.ref<index>
+! CHECK:           %[[VAL_33:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_34:.*]] = fir.load %[[VAL_2]] : !fir.ref<index>
+! CHECK:           %[[VAL_35:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:           %[[VAL_36:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_37:.*]] = fir.shape_shift %[[VAL_34]], %[[VAL_35]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:           %[[VAL_38:.*]] = fir.embox %[[VAL_36]](%[[VAL_37]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_38]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_39:.*]] = fir.load %[[VAL_8]] : !fir.ref<index>
+! CHECK:           %[[VAL_40:.*]] = fir.load %[[VAL_9]] : !fir.ref<index>
+! CHECK:           %[[VAL_41:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_42:.*]] = fir.shape_shift %[[VAL_39]], %[[VAL_40]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:           %[[VAL_43:.*]] = fir.embox %[[VAL_41]](%[[VAL_42]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_43]] to %[[VAL_6]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_44:.*]] = arith.constant true
+! CHECK:           %[[VAL_45:.*]] = fir.address_of(@_QQclX8c4f3bfd49fac4527014c85e4d2f3268) : !fir.ref<!fir.char<1,74>>
+! CHECK:           %[[VAL_46:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_47:.*]] = fir.zero_bits !fir.ref<none>
+! CHECK:           %[[VAL_48:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_49:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_50:.*]] = fir.convert %[[VAL_45]] : (!fir.ref<!fir.char<1,74>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_51:.*]] = fir.call @_FortranAMoveAlloc(%[[VAL_48]], %[[VAL_49]], %[[VAL_47]], %[[VAL_44]], %[[VAL_33]], %[[VAL_50]], %[[VAL_46]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, !fir.ref<!fir.box<none>>, !fir.ref<none>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_52:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_53:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_54:.*]]:3 = fir.box_dims %[[VAL_52]], %[[VAL_53]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_55:.*]] = fir.box_addr %[[VAL_52]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:           fir.store %[[VAL_55]] to %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_54]]#1 to %[[VAL_3]] : !fir.ref<index>
+! CHECK:           fir.store %[[VAL_54]]#0 to %[[VAL_2]] : !fir.ref<index>
+! CHECK:           %[[VAL_56:.*]] = fir.load %[[VAL_6]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_57:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_58:.*]]:3 = fir.box_dims %[[VAL_56]], %[[VAL_57]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_59:.*]] = fir.box_addr %[[VAL_56]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:           fir.store %[[VAL_59]] to %[[VAL_7]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_58]]#1 to %[[VAL_9]] : !fir.ref<index>
+! CHECK:           fir.store %[[VAL_58]]#0 to %[[VAL_8]] : !fir.ref<index>
+! CHECK:           %[[VAL_60:.*]] = fir.convert %[[VAL_5]] : (!fir.ref<i32>) -> i64
+! CHECK:           %[[VAL_61:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_62:.*]] = arith.cmpi ne, %[[VAL_60]], %[[VAL_61]] : i64
+! CHECK:           fir.if %[[VAL_62]] {
+! CHECK:             fir.store %[[VAL_51]] to %[[VAL_5]] : !fir.ref<i32>
+! CHECK:           }
+! CHECK:           %[[VAL_63:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_64:.*]] = fir.convert %[[VAL_63]] : (!fir.heap<!fir.array<?xi32>>) -> i64
+! CHECK:           %[[VAL_65:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_66:.*]] = arith.cmpi ne, %[[VAL_64]], %[[VAL_65]] : i64
+! CHECK:           fir.if %[[VAL_66]] {
+! CHECK:             %[[VAL_67:.*]] = arith.constant false
+! CHECK:             %[[VAL_68:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_69:.*]] = fir.address_of(@_QQclX8c4f3bfd49fac4527014c85e4d2f3268) : !fir.ref<!fir.char<1,74>>
+! CHECK:             %[[VAL_70:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_71:.*]] = fir.load %[[VAL_8]] : !fir.ref<index>
+! CHECK:             %[[VAL_72:.*]] = fir.load %[[VAL_9]] : !fir.ref<index>
+! CHECK:             %[[VAL_73:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             %[[VAL_74:.*]] = fir.shape_shift %[[VAL_71]], %[[VAL_72]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:             %[[VAL_75:.*]] = fir.embox %[[VAL_73]](%[[VAL_74]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_75]] to %[[VAL_6]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_76:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_77:.*]] = fir.convert %[[VAL_69]] : (!fir.ref<!fir.char<1,74>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_78:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_76]], %[[VAL_67]], %[[VAL_68]], %[[VAL_77]], %[[VAL_70]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:             %[[VAL_79:.*]] = fir.load %[[VAL_6]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_80:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_81:.*]]:3 = fir.box_dims %[[VAL_79]], %[[VAL_80]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_82:.*]] = fir.box_addr %[[VAL_79]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:             fir.store %[[VAL_82]] to %[[VAL_7]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_81]]#1 to %[[VAL_9]] : !fir.ref<index>
+! CHECK:             fir.store %[[VAL_81]]#0 to %[[VAL_8]] : !fir.ref<index>
+! CHECK:           }
+! CHECK:           %[[VAL_83:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_84:.*]] = fir.convert %[[VAL_83]] : (!fir.heap<!fir.array<?xi32>>) -> i64
+! CHECK:           %[[VAL_85:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_86:.*]] = arith.cmpi ne, %[[VAL_84]], %[[VAL_85]] : i64
+! CHECK:           fir.if %[[VAL_86]] {
+! CHECK:             %[[VAL_87:.*]] = arith.constant false
+! CHECK:             %[[VAL_88:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_89:.*]] = fir.address_of(@_QQclX8c4f3bfd49fac4527014c85e4d2f3268) : !fir.ref<!fir.char<1,74>>
+! CHECK:             %[[VAL_90:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_91:.*]] = fir.load %[[VAL_2]] : !fir.ref<index>
+! CHECK:             %[[VAL_92:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:             %[[VAL_93:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             %[[VAL_94:.*]] = fir.shape_shift %[[VAL_91]], %[[VAL_92]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:             %[[VAL_95:.*]] = fir.embox %[[VAL_93]](%[[VAL_94]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_95]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_96:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_97:.*]] = fir.convert %[[VAL_89]] : (!fir.ref<!fir.char<1,74>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_98:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_96]], %[[VAL_87]], %[[VAL_88]], %[[VAL_97]], %[[VAL_90]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:             %[[VAL_99:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_100:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_101:.*]]:3 = fir.box_dims %[[VAL_99]], %[[VAL_100]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_102:.*]] = fir.box_addr %[[VAL_99]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:             fir.store %[[VAL_102]] to %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_101]]#1 to %[[VAL_3]] : !fir.ref<index>
+! CHECK:             fir.store %[[VAL_101]]#0 to %[[VAL_2]] : !fir.ref<index>
+! CHECK:           }
+! CHECK:           return
+! CHECK:         }
 
-! CHECK-LABEL: to_from_stat_errmsg
 subroutine to_from_stat_errmsg
-  ! CHECK-DAG: %[[errMsg1:.*]] = fir.alloca !fir.char<1,64>
-  ! CHECK-DAG: %[[a1:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
-  ! CHECK-DAG: %[[b1:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
   integer, allocatable :: from(:), to(:)
-  ! CHECK-DAG: %[[stat1:.*]] = fir.alloca i32
   integer :: stat
   character :: errMsg*64
   allocate(from(20))
-  ! CHECK: %[[errMsg2:.*]] = fir.embox %[[errMsg1]] : (!fir.ref<!fir.char<1,64>>) -> !fir.box<!fir.char<1,64>>
-  ! CHECK: %[[true:.*]] = arith.constant true
-  ! CHECK-DAG: %[[errMsg3:.*]] = fir.convert %[[errMsg2]] : (!fir.box<!fir.char<1,64>>) -> !fir.box<none>
-  ! CHECK-DAG: %[[a2:.*]] = fir.convert %[[a1]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
-  ! CHECK-DAG: %[[b2:.*]] = fir.convert %[[b1]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
   call move_alloc(from, to, stat, errMsg)
-  ! CHECK: %[[stat:.*]] = fir.call @_FortranAMoveAlloc(%[[b2]], %[[a2]], %{{.*}}, %[[true]], %[[errMsg3]], %{{.*}}, %{{.*}}) fastmath<contract> : (!fir.ref<!fir.box<none>>, !fir.ref<!fir.box<none>>, !fir.ref<none>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
-  ! CHECK-DAG:  %[[a3:.*]] = fir.load %[[a1:.*]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  ! CHECK-DAG:  %[[a4:.*]] = fir.box_addr %[[a3]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-  ! CHECK-DAG:  %[[b3:.*]] = fir.load %[[b1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  ! CHECK-DAG:  %[[b4:.*]] = fir.box_addr %[[b3:.*]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
 end subroutine to_from_stat_errmsg
+! CHECK-LABEL:   func.func @_QPto_from_stat_errmsg() {
+! CHECK:           %[[VAL_0:.*]] = fir.alloca !fir.char<1,64> {bindc_name = "errmsg", uniq_name = "_QFto_from_stat_errmsgEerrmsg"}
+! CHECK:           %[[VAL_1:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = "from", uniq_name = "_QFto_from_stat_errmsgEfrom"}
+! CHECK:           %[[VAL_2:.*]] = fir.alloca !fir.heap<!fir.array<?xi32>> {uniq_name = "_QFto_from_stat_errmsgEfrom.addr"}
+! CHECK:           %[[VAL_3:.*]] = fir.alloca index {uniq_name = "_QFto_from_stat_errmsgEfrom.lb0"}
+! CHECK:           %[[VAL_4:.*]] = fir.alloca index {uniq_name = "_QFto_from_stat_errmsgEfrom.ext0"}
+! CHECK:           %[[VAL_5:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
+! CHECK:           fir.store %[[VAL_5]] to %[[VAL_2]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_6:.*]] = fir.alloca i32 {bindc_name = "stat", uniq_name = "_QFto_from_stat_errmsgEstat"}
+! CHECK:           %[[VAL_7:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = "to", uniq_name = "_QFto_from_stat_errmsgEto"}
+! CHECK:           %[[VAL_8:.*]] = fir.alloca !fir.heap<!fir.array<?xi32>> {uniq_name = "_QFto_from_stat_errmsgEto.addr"}
+! CHECK:           %[[VAL_9:.*]] = fir.alloca index {uniq_name = "_QFto_from_stat_errmsgEto.lb0"}
+! CHECK:           %[[VAL_10:.*]] = fir.alloca index {uniq_name = "_QFto_from_stat_errmsgEto.ext0"}
+! CHECK:           %[[VAL_11:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
+! CHECK:           fir.store %[[VAL_11]] to %[[VAL_8]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_12:.*]] = arith.constant false
+! CHECK:           %[[VAL_13:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_14:.*]] = fir.address_of(@_QQclX8c4f3bfd49fac4527014c85e4d2f3268) : !fir.ref<!fir.char<1,74>>
+! CHECK:           %[[VAL_15:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_16:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:           %[[VAL_17:.*]] = fir.load %[[VAL_4]] : !fir.ref<index>
+! CHECK:           %[[VAL_18:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_19:.*]] = fir.shape_shift %[[VAL_16]], %[[VAL_17]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:           %[[VAL_20:.*]] = fir.embox %[[VAL_18]](%[[VAL_19]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_20]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_21:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_22:.*]] = arith.constant 20 : i32
+! CHECK:           %[[VAL_23:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_24:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_25:.*]] = fir.convert %[[VAL_21]] : (index) -> i64
+! CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_22]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_24]], %[[VAL_23]], %[[VAL_25]], %[[VAL_26]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_27:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_28:.*]] = fir.convert %[[VAL_14]] : (!fir.ref<!fir.char<1,74>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_29:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_27]], %[[VAL_12]], %[[VAL_13]], %[[VAL_28]], %[[VAL_15]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_30:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_31:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_32:.*]]:3 = fir.box_dims %[[VAL_30]], %[[VAL_31]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_33:.*]] = fir.box_addr %[[VAL_30]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:           fir.store %[[VAL_33]] to %[[VAL_2]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_32]]#1 to %[[VAL_4]] : !fir.ref<index>
+! CHECK:           fir.store %[[VAL_32]]#0 to %[[VAL_3]] : !fir.ref<index>
+! CHECK:           %[[VAL_34:.*]] = fir.embox %[[VAL_0]] : (!fir.ref<!fir.char<1,64>>) -> !fir.box<!fir.char<1,64>>
+! CHECK:           %[[VAL_35:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:           %[[VAL_36:.*]] = fir.load %[[VAL_4]] : !fir.ref<index>
+! CHECK:           %[[VAL_37:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_38:.*]] = fir.shape_shift %[[VAL_35]], %[[VAL_36]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:           %[[VAL_39:.*]] = fir.embox %[[VAL_37]](%[[VAL_38]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_39]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_40:.*]] = fir.load %[[VAL_9]] : !fir.ref<index>
+! CHECK:           %[[VAL_41:.*]] = fir.load %[[VAL_10]] : !fir.ref<index>
+! CHECK:           %[[VAL_42:.*]] = fir.load %[[VAL_8]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_43:.*]] = fir.shape_shift %[[VAL_40]], %[[VAL_41]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:           %[[VAL_44:.*]] = fir.embox %[[VAL_42]](%[[VAL_43]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_44]] to %[[VAL_7]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_45:.*]] = arith.constant true
+! CHECK:           %[[VAL_46:.*]] = fir.address_of(@_QQclX8c4f3bfd49fac4527014c85e4d2f3268) : !fir.ref<!fir.char<1,74>>
+! CHECK:           %[[VAL_47:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_48:.*]] = fir.zero_bits !fir.ref<none>
+! CHECK:           %[[VAL_49:.*]] = fir.convert %[[VAL_7]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_50:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_51:.*]] = fir.convert %[[VAL_34]] : (!fir.box<!fir.char<1,64>>) -> !fir.box<none>
+! CHECK:           %[[VAL_52:.*]] = fir.convert %[[VAL_46]] : (!fir.ref<!fir.char<1,74>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_53:.*]] = fir.call @_FortranAMoveAlloc(%[[VAL_49]], %[[VAL_50]], %[[VAL_48]], %[[VAL_45]], %[[VAL_51]], %[[VAL_52]], %[[VAL_47]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, !fir.ref<!fir.box<none>>, !fir.ref<none>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_54:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_55:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_56:.*]]:3 = fir.box_dims %[[VAL_54]], %[[VAL_55]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_57:.*]] = fir.box_addr %[[VAL_54]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:           fir.store %[[VAL_57]] to %[[VAL_2]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_56]]#1 to %[[VAL_4]] : !fir.ref<index>
+! CHECK:           fir.store %[[VAL_56]]#0 to %[[VAL_3]] : !fir.ref<index>
+! CHECK:           %[[VAL_58:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_59:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_60:.*]]:3 = fir.box_dims %[[VAL_58]], %[[VAL_59]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_61:.*]] = fir.box_addr %[[VAL_58]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:           fir.store %[[VAL_61]] to %[[VAL_8]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           fir.store %[[VAL_60]]#1 to %[[VAL_10]] : !fir.ref<index>
+! CHECK:           fir.store %[[VAL_60]]#0 to %[[VAL_9]] : !fir.ref<index>
+! CHECK:           %[[VAL_62:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<i32>) -> i64
+! CHECK:           %[[VAL_63:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_64:.*]] = arith.cmpi ne, %[[VAL_62]], %[[VAL_63]] : i64
+! CHECK:           fir.if %[[VAL_64]] {
+! CHECK:             fir.store %[[VAL_53]] to %[[VAL_6]] : !fir.ref<i32>
+! CHECK:           }
+! CHECK:           %[[VAL_65:.*]] = fir.load %[[VAL_8]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_66:.*]] = fir.convert %[[VAL_65]] : (!fir.heap<!fir.array<?xi32>>) -> i64
+! CHECK:           %[[VAL_67:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_68:.*]] = arith.cmpi ne, %[[VAL_66]], %[[VAL_67]] : i64
+! CHECK:           fir.if %[[VAL_68]] {
+! CHECK:             %[[VAL_69:.*]] = arith.constant false
+! CHECK:             %[[VAL_70:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_71:.*]] = fir.address_of(@_QQclX8c4f3bfd49fac4527014c85e4d2f3268) : !fir.ref<!fir.char<1,74>>
+! CHECK:             %[[VAL_72:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_73:.*]] = fir.load %[[VAL_9]] : !fir.ref<index>
+! CHECK:             %[[VAL_74:.*]] = fir.load %[[VAL_10]] : !fir.ref<index>
+! CHECK:             %[[VAL_75:.*]] = fir.load %[[VAL_8]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             %[[VAL_76:.*]] = fir.shape_shift %[[VAL_73]], %[[VAL_74]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:             %[[VAL_77:.*]] = fir.embox %[[VAL_75]](%[[VAL_76]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_77]] to %[[VAL_7]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_78:.*]] = fir.convert %[[VAL_7]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_79:.*]] = fir.convert %[[VAL_71]] : (!fir.ref<!fir.char<1,74>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_80:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_78]], %[[VAL_69]], %[[VAL_70]], %[[VAL_79]], %[[VAL_72]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:             %[[VAL_81:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_82:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_83:.*]]:3 = fir.box_dims %[[VAL_81]], %[[VAL_82]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_84:.*]] = fir.box_addr %[[VAL_81]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:             fir.store %[[VAL_84]] to %[[VAL_8]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_83]]#1 to %[[VAL_10]] : !fir.ref<index>
+! CHECK:             fir.store %[[VAL_83]]#0 to %[[VAL_9]] : !fir.ref<index>
+! CHECK:           }
+! CHECK:           %[[VAL_85:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           %[[VAL_86:.*]] = fir.convert %[[VAL_85]] : (!fir.heap<!fir.array<?xi32>>) -> i64
+! CHECK:           %[[VAL_87:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_88:.*]] = arith.cmpi ne, %[[VAL_86]], %[[VAL_87]] : i64
+! CHECK:           fir.if %[[VAL_88]] {
+! CHECK:             %[[VAL_89:.*]] = arith.constant false
+! CHECK:             %[[VAL_90:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_91:.*]] = fir.address_of(@_QQclX8c4f3bfd49fac4527014c85e4d2f3268) : !fir.ref<!fir.char<1,74>>
+! CHECK:             %[[VAL_92:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_93:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:             %[[VAL_94:.*]] = fir.load %[[VAL_4]] : !fir.ref<index>
+! CHECK:             %[[VAL_95:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             %[[VAL_96:.*]] = fir.shape_shift %[[VAL_93]], %[[VAL_94]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:             %[[VAL_97:.*]] = fir.embox %[[VAL_95]](%[[VAL_96]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_97]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_98:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_99:.*]] = fir.convert %[[VAL_91]] : (!fir.ref<!fir.char<1,74>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_100:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_98]], %[[VAL_89]], %[[VAL_90]], %[[VAL_99]], %[[VAL_92]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:             %[[VAL_101:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_102:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_103:.*]]:3 = fir.box_dims %[[VAL_101]], %[[VAL_102]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_104:.*]] = fir.box_addr %[[VAL_101]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:             fir.store %[[VAL_104]] to %[[VAL_2]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_103]]#1 to %[[VAL_4]] : !fir.ref<index>
+! CHECK:             fir.store %[[VAL_103]]#0 to %[[VAL_3]] : !fir.ref<index>
+! CHECK:           }
+! CHECK:           return
+! CHECK:         }

--- a/flang/test/Lower/Intrinsics/system_clock.f90
+++ b/flang/test/Lower/Intrinsics/system_clock.f90
@@ -30,115 +30,181 @@ subroutine system_clock_test()
 ! print*, m
 end subroutine
 
-! CHECK-LABEL: @_QPss
 subroutine ss(count)
-  ! CHECK:   %[[V_0:[0-9]+]] = fir.alloca !fir.box<!fir.heap<i64>> {bindc_name = "count_max", uniq_name = "_QFssEcount_max"}
-  ! CHECK:   %[[V_1:[0-9]+]] = fir.alloca !fir.heap<i64> {uniq_name = "_QFssEcount_max.addr"}
-  ! CHECK:   %[[V_2:[0-9]+]] = fir.zero_bits !fir.heap<i64>
-  ! CHECK:   fir.store %[[V_2]] to %[[V_1]] : !fir.ref<!fir.heap<i64>>
-  ! CHECK:   %[[V_3:[0-9]+]] = fir.alloca !fir.box<!fir.ptr<i64>> {bindc_name = "count_rate", uniq_name = "_QFssEcount_rate"}
-  ! CHECK:   %[[V_4:[0-9]+]] = fir.alloca !fir.ptr<i64> {uniq_name = "_QFssEcount_rate.addr"}
-  ! CHECK:   %[[V_5:[0-9]+]] = fir.zero_bits !fir.ptr<i64>
-  ! CHECK:   fir.store %[[V_5]] to %[[V_4]] : !fir.ref<!fir.ptr<i64>>
-  ! CHECK:   %[[V_6:[0-9]+]] = fir.alloca i64 {bindc_name = "count_rate_", fir.target, uniq_name = "_QFssEcount_rate_"}
-  ! CHECK:   %[[V_7:[0-9]+]] = fir.convert %[[V_6]] : (!fir.ref<i64>) -> !fir.ptr<i64>
-  ! CHECK:   fir.store %[[V_7]] to %[[V_4]] : !fir.ref<!fir.ptr<i64>>
-  ! CHECK:   %[[V_8:[0-9]+]] = fir.allocmem i64 {fir.must_be_heap = true, uniq_name = "_QFssEcount_max.alloc"}
-  ! CHECK:   fir.store %[[V_8]] to %[[V_1]] : !fir.ref<!fir.heap<i64>>
-  ! CHECK:   %[[V_9:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<!fir.ptr<i64>>
-  ! CHECK:   %[[V_10:[0-9]+]] = fir.load %[[V_1]] : !fir.ref<!fir.heap<i64>>
-  ! CHECK:   %[[V_11:[0-9]+]] = fir.is_present %arg0 : (!fir.ref<i64>) -> i1
-  ! CHECK:   fir.if %[[V_11]] {
-  ! CHECK:     %[[V_29:[0-9]+]] = fir.call @_FortranASystemClockCount(%c8{{.*}}_i32) {{.*}}: (i32) -> i64
-  ! CHECK:     fir.store %[[V_29]] to %arg0 : !fir.ref<i64>
-  ! CHECK:   }
-  ! CHECK:   %[[V_12:[0-9]+]] = fir.convert %[[V_9]] : (!fir.ptr<i64>) -> i64
-  ! CHECK:   %[[V_13:[0-9]+]] = arith.cmpi ne, %[[V_12]], %c0{{.*}} : i64
-  ! CHECK:   fir.if %[[V_13]] {
-  ! CHECK:     %[[V_29:[0-9]+]] = fir.call @_FortranASystemClockCountRate(%c8{{.*}}_i32) {{.*}}: (i32) -> i64
-  ! CHECK:     fir.store %[[V_29]] to %[[V_9]] : !fir.ptr<i64>
-  ! CHECK:   }
-  ! CHECK:   %[[V_14:[0-9]+]] = fir.convert %[[V_10]] : (!fir.heap<i64>) -> i64
-  ! CHECK:   %[[V_15:[0-9]+]] = arith.cmpi ne, %[[V_14]], %c0{{.*}} : i64
-  ! CHECK:   fir.if %[[V_15]] {
-  ! CHECK:     %[[V_29]] = fir.call @_FortranASystemClockCountMax(%c8{{.*}}_i32) {{.*}}: (i32) -> i64
-  ! CHECK:     fir.store %[[V_29]] to %[[V_10]] : !fir.heap<i64>
-  ! CHECK:   }
-  ! CHECK:   %[[V_16:[0-9]+]] = fir.is_present %arg0 : (!fir.ref<i64>) -> i1
-  ! CHECK:   fir.if %[[V_16]] {
-  ! CHECK:     %[[V_31:[0-9]+]] = fir.call @_FortranAioBeginExternalListOutput
-  ! CHECK:     %[[V_32:[0-9]+]] = fir.load %arg0 : !fir.ref<i64>
-  ! CHECK:     %[[V_33:[0-9]+]] = fir.call @_FortranAioOutputInteger64(%[[V_31]], %[[V_32]]) {{.*}}: (!fir.ref<i8>, i64) -> i1
-  ! CHECK:     %[[V_34:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<!fir.ptr<i64>>
-  ! CHECK:     %[[V_35:[0-9]+]] = fir.load %[[V_34]] : !fir.ptr<i64>
-  ! CHECK:     %[[V_36:[0-9]+]] = fir.call @_FortranAioOutputInteger64(%[[V_31]], %[[V_35]]) {{.*}}: (!fir.ref<i8>, i64) -> i1
-  ! CHECK:     %[[V_37:[0-9]+]] = fir.load %[[V_1]] : !fir.ref<!fir.heap<i64>>
-  ! CHECK:     %[[V_38:[0-9]+]] = fir.load %[[V_37]] : !fir.heap<i64>
-  ! CHECK:     %[[V_39:[0-9]+]] = fir.call @_FortranAioOutputInteger64(%[[V_31]], %[[V_38]]) {{.*}}: (!fir.ref<i8>, i64) -> i1
-  ! CHECK:     %[[V_40:[0-9]+]] = fir.call @_FortranAioEndIoStatement(%[[V_31]]) {{.*}}: (!fir.ref<i8>) -> i32
-  ! CHECK:   } else {
-  ! CHECK:     %[[V_29:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<!fir.ptr<i64>>
-  ! CHECK:     %[[V_30:[0-9]+]] = fir.load %[[V_1]] : !fir.ref<!fir.heap<i64>>
-  ! CHECK:     %[[V_31:[0-9]+]] = fir.convert %[[V_29]] : (!fir.ptr<i64>) -> i64
-  ! CHECK:     %[[V_32:[0-9]+]] = arith.cmpi ne, %[[V_31]], %c0{{.*}} : i64
-  ! CHECK:     fir.if %[[V_32]] {
-  ! CHECK:       %[[V_45:[0-9]+]] = fir.call @_FortranASystemClockCountRate(%c8{{.*}}_i32) {{.*}}: (i32) -> i64
-  ! CHECK:       fir.store %[[V_45]] to %[[V_29]] : !fir.ptr<i64>
-  ! CHECK:     }
-  ! CHECK:     %[[V_33:[0-9]+]] = fir.convert %[[V_30]] : (!fir.heap<i64>) -> i64
-  ! CHECK:     %[[V_34:[0-9]+]] = arith.cmpi ne, %[[V_33]], %c0{{.*}} : i64
-  ! CHECK:     fir.if %[[V_34]] {
-  ! CHECK:       %[[V_45]] = fir.call @_FortranASystemClockCountMax(%c8{{.*}}_i32) {{.*}}: (i32) -> i64
-  ! CHECK:       fir.store %[[V_45]] to %[[V_30]] : !fir.heap<i64>
-  ! CHECK:     }
-  ! CHECK:     %[[V_37:[0-9]+]] = fir.call @_FortranAioBeginExternalListOutput
-  ! CHECK:     %[[V_38:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<!fir.ptr<i64>>
-  ! CHECK:     %[[V_39:[0-9]+]] = fir.load %[[V_38]] : !fir.ptr<i64>
-  ! CHECK:     %[[V_40:[0-9]+]] = fir.call @_FortranAioOutputInteger64(%[[V_37]], %[[V_39]]) {{.*}}: (!fir.ref<i8>, i64) -> i1
-  ! CHECK:     %[[V_41:[0-9]+]] = fir.load %[[V_1]] : !fir.ref<!fir.heap<i64>>
-  ! CHECK:     %[[V_42:[0-9]+]] = fir.load %[[V_41]] : !fir.heap<i64>
-  ! CHECK:     %[[V_43:[0-9]+]] = fir.call @_FortranAioOutputInteger64(%[[V_37]], %[[V_42]]) {{.*}}: (!fir.ref<i8>, i64) -> i1
-  ! CHECK:     %[[V_44:[0-9]+]] = fir.call @_FortranAioEndIoStatement(%[[V_37]]) {{.*}}: (!fir.ref<i8>) -> i32
-  ! CHECK:   }
-  ! CHECK:   %[[V_17:[0-9]+]] = fir.is_present %arg0 : (!fir.ref<i64>) -> i1
-  ! CHECK:   fir.if %[[V_17]] {
-  ! CHECK:     %[[C_0:c[0-9a-z_]+]] = arith.constant 0 : i64
-  ! CHECK:     fir.store %[[C_0]] to %arg0 : !fir.ref<i64>
-  ! CHECK:   }
-  ! CHECK:   %[[V_18:[0-9]+]] = fir.zero_bits !fir.ptr<i64>
-  ! CHECK:   fir.store %[[V_18]] to %[[V_4]] : !fir.ref<!fir.ptr<i64>>
-  ! CHECK:   %[[V_19:[0-9]+]] = fir.load %[[V_1]] : !fir.ref<!fir.heap<i64>>
-  ! CHECK:   fir.freemem %[[V_19]] : !fir.heap<i64>
-  ! CHECK:   %[[V_20:[0-9]+]] = fir.zero_bits !fir.heap<i64>
-  ! CHECK:   fir.store %[[V_20]] to %[[V_1]] : !fir.ref<!fir.heap<i64>>
-  ! CHECK:   %[[V_21:[0-9]+]] = fir.load %[[V_4]] : !fir.ref<!fir.ptr<i64>>
-  ! CHECK:   %[[V_22:[0-9]+]] = fir.load %[[V_1]] : !fir.ref<!fir.heap<i64>>
-  ! CHECK:   %[[V_23:[0-9]+]] = fir.is_present %arg0 : (!fir.ref<i64>) -> i1
-  ! CHECK:   fir.if %[[V_23]] {
-  ! CHECK:     %[[V_29]] = fir.call @_FortranASystemClockCount(%c8{{.*}}_i32) {{.*}}: (i32) -> i64
-  ! CHECK:     fir.store %[[V_29]] to %arg0 : !fir.ref<i64>
-  ! CHECK:   }
-  ! CHECK:   %[[V_24:[0-9]+]] = fir.convert %[[V_21]] : (!fir.ptr<i64>) -> i64
-  ! CHECK:   %[[V_25:[0-9]+]] = arith.cmpi ne, %[[V_24]], %c0{{.*}} : i64
-  ! CHECK:   fir.if %[[V_25]] {
-  ! CHECK:     %[[V_29]] = fir.call @_FortranASystemClockCountRate(%c8{{.*}}_i32) {{.*}}: (i32) -> i64
-  ! CHECK:     fir.store %[[V_29]] to %[[V_21]] : !fir.ptr<i64>
-  ! CHECK:   }
-  ! CHECK:   %[[V_26:[0-9]+]] = fir.convert %[[V_22]] : (!fir.heap<i64>) -> i64
-  ! CHECK:   %[[V_27:[0-9]+]] = arith.cmpi ne, %[[V_26]], %c0{{.*}} : i64
-  ! CHECK:   fir.if %[[V_27]] {
-  ! CHECK:     %[[V_29]] = fir.call @_FortranASystemClockCountMax(%c8{{.*}}_i32) {{.*}}: (i32) -> i64
-  ! CHECK:     fir.store %[[V_29]] to %[[V_22]] : !fir.heap<i64>
-  ! CHECK:   }
-  ! CHECK:   %[[V_28:[0-9]+]] = fir.is_present %arg0 : (!fir.ref<i64>) -> i1
-  ! CHECK:   fir.if %[[V_28]] {
-  ! CHECK:     %[[V_31]] = fir.call @_FortranAioBeginExternalListOutput
-  ! CHECK:     %[[V_32]] = fir.load %arg0 : !fir.ref<i64>
-  ! CHECK:     %[[V_33]] = fir.call @_FortranAioOutputInteger64(%[[V_31]], %[[V_32]]) {{.*}}: (!fir.ref<i8>, i64) -> i1
-  ! CHECK:     %[[V_34]] = fir.call @_FortranAioEndIoStatement(%[[V_31]]) {{.*}}: (!fir.ref<i8>) -> i32
-  ! CHECK:   }
-  ! CHECK:   return
-  ! CHECK: }
+! CHECK-LABEL:   func.func @_QPss(
+! CHECK-SAME:                     %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.ref<i64> {fir.bindc_name = "count", fir.optional}) {
+! CHECK:           %[[VAL_1:.*]] = fir.alloca !fir.box<!fir.heap<i64>> {bindc_name = "count_max", uniq_name = "_QFssEcount_max"}
+! CHECK:           %[[VAL_2:.*]] = fir.alloca !fir.heap<i64> {uniq_name = "_QFssEcount_max.addr"}
+! CHECK:           %[[VAL_3:.*]] = fir.zero_bits !fir.heap<i64>
+! CHECK:           fir.store %[[VAL_3]] to %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
+! CHECK:           %[[VAL_4:.*]] = fir.alloca !fir.box<!fir.ptr<i64>> {bindc_name = "count_rate", uniq_name = "_QFssEcount_rate"}
+! CHECK:           %[[VAL_5:.*]] = fir.alloca !fir.ptr<i64> {uniq_name = "_QFssEcount_rate.addr"}
+! CHECK:           %[[VAL_6:.*]] = fir.zero_bits !fir.ptr<i64>
+! CHECK:           fir.store %[[VAL_6]] to %[[VAL_5]] : !fir.ref<!fir.ptr<i64>>
+! CHECK:           %[[VAL_7:.*]] = fir.alloca i64 {bindc_name = "count_rate_", fir.target, uniq_name = "_QFssEcount_rate_"}
+! CHECK:           %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (!fir.ref<i64>) -> !fir.ptr<i64>
+! CHECK:           fir.store %[[VAL_8]] to %[[VAL_5]] : !fir.ref<!fir.ptr<i64>>
+! CHECK:           %[[VAL_9:.*]] = arith.constant false
+! CHECK:           %[[VAL_10:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_11:.*]] = fir.address_of(@_QQclX0146bbb9ee5e88a6e67c6c1cf8871123) : !fir.ref<!fir.char<1,76>>
+! CHECK:           %[[VAL_12:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_13:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
+! CHECK:           %[[VAL_14:.*]] = fir.embox %[[VAL_13]] : (!fir.heap<i64>) -> !fir.box<!fir.heap<i64>>
+! CHECK:           fir.store %[[VAL_14]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<i64>>>
+! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<i64>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_11]] : (!fir.ref<!fir.char<1,76>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_17:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_15]], %[[VAL_9]], %[[VAL_10]], %[[VAL_16]], %[[VAL_12]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_18:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<i64>>>
+! CHECK:           %[[VAL_19:.*]] = fir.box_addr %[[VAL_18]] : (!fir.box<!fir.heap<i64>>) -> !fir.heap<i64>
+! CHECK:           fir.store %[[VAL_19]] to %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
+! CHECK:           %[[VAL_20:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.ptr<i64>>
+! CHECK:           %[[VAL_21:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
+! CHECK:           %[[VAL_22:.*]] = fir.is_present %[[VAL_0]] : (!fir.ref<i64>) -> i1
+! CHECK:           fir.if %[[VAL_22]] {
+! CHECK:             %[[VAL_23:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_24:.*]] = fir.call @_FortranASystemClockCount(%[[VAL_23]]) fastmath<contract> : (i32) -> i64
+! CHECK:             fir.store %[[VAL_24]] to %[[VAL_0]] : !fir.ref<i64>
+! CHECK:           }
+! CHECK:           %[[VAL_25:.*]] = fir.convert %[[VAL_20]] : (!fir.ptr<i64>) -> i64
+! CHECK:           %[[VAL_26:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_27:.*]] = arith.cmpi ne, %[[VAL_25]], %[[VAL_26]] : i64
+! CHECK:           fir.if %[[VAL_27]] {
+! CHECK:             %[[VAL_28:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_29:.*]] = fir.call @_FortranASystemClockCountRate(%[[VAL_28]]) fastmath<contract> : (i32) -> i64
+! CHECK:             fir.store %[[VAL_29]] to %[[VAL_20]] : !fir.ptr<i64>
+! CHECK:           }
+! CHECK:           %[[VAL_30:.*]] = fir.convert %[[VAL_21]] : (!fir.heap<i64>) -> i64
+! CHECK:           %[[VAL_31:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_32:.*]] = arith.cmpi ne, %[[VAL_30]], %[[VAL_31]] : i64
+! CHECK:           fir.if %[[VAL_32]] {
+! CHECK:             %[[VAL_33:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_34:.*]] = fir.call @_FortranASystemClockCountMax(%[[VAL_33]]) fastmath<contract> : (i32) -> i64
+! CHECK:             fir.store %[[VAL_34]] to %[[VAL_21]] : !fir.heap<i64>
+! CHECK:           }
+! CHECK:           %[[VAL_35:.*]] = fir.is_present %[[VAL_0]] : (!fir.ref<i64>) -> i1
+! CHECK:           fir.if %[[VAL_35]] {
+! CHECK:             %[[VAL_36:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_37:.*]] = fir.address_of(@_QQclX0146bbb9ee5e88a6e67c6c1cf8871123) : !fir.ref<!fir.char<1,76>>
+! CHECK:             %[[VAL_38:.*]] = fir.convert %[[VAL_37]] : (!fir.ref<!fir.char<1,76>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_39:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_40:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_36]], %[[VAL_38]], %[[VAL_39]]) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:             %[[VAL_41:.*]] = fir.load %[[VAL_0]] : !fir.ref<i64>
+! CHECK:             %[[VAL_42:.*]] = fir.call @_FortranAioOutputInteger64(%[[VAL_40]], %[[VAL_41]]) fastmath<contract> : (!fir.ref<i8>, i64) -> i1
+! CHECK:             %[[VAL_43:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.ptr<i64>>
+! CHECK:             %[[VAL_44:.*]] = fir.load %[[VAL_43]] : !fir.ptr<i64>
+! CHECK:             %[[VAL_45:.*]] = fir.call @_FortranAioOutputInteger64(%[[VAL_40]], %[[VAL_44]]) fastmath<contract> : (!fir.ref<i8>, i64) -> i1
+! CHECK:             %[[VAL_46:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
+! CHECK:             %[[VAL_47:.*]] = fir.load %[[VAL_46]] : !fir.heap<i64>
+! CHECK:             %[[VAL_48:.*]] = fir.call @_FortranAioOutputInteger64(%[[VAL_40]], %[[VAL_47]]) fastmath<contract> : (!fir.ref<i8>, i64) -> i1
+! CHECK:             %[[VAL_49:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_40]]) fastmath<contract> : (!fir.ref<i8>) -> i32
+! CHECK:           } else {
+! CHECK:             %[[VAL_50:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.ptr<i64>>
+! CHECK:             %[[VAL_51:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
+! CHECK:             %[[VAL_52:.*]] = fir.convert %[[VAL_50]] : (!fir.ptr<i64>) -> i64
+! CHECK:             %[[VAL_53:.*]] = arith.constant 0 : i64
+! CHECK:             %[[VAL_54:.*]] = arith.cmpi ne, %[[VAL_52]], %[[VAL_53]] : i64
+! CHECK:             fir.if %[[VAL_54]] {
+! CHECK:               %[[VAL_55:.*]] = arith.constant {{.*}} : i32
+! CHECK:               %[[VAL_56:.*]] = fir.call @_FortranASystemClockCountRate(%[[VAL_55]]) fastmath<contract> : (i32) -> i64
+! CHECK:               fir.store %[[VAL_56]] to %[[VAL_50]] : !fir.ptr<i64>
+! CHECK:             }
+! CHECK:             %[[VAL_57:.*]] = fir.convert %[[VAL_51]] : (!fir.heap<i64>) -> i64
+! CHECK:             %[[VAL_58:.*]] = arith.constant 0 : i64
+! CHECK:             %[[VAL_59:.*]] = arith.cmpi ne, %[[VAL_57]], %[[VAL_58]] : i64
+! CHECK:             fir.if %[[VAL_59]] {
+! CHECK:               %[[VAL_60:.*]] = arith.constant {{.*}} : i32
+! CHECK:               %[[VAL_61:.*]] = fir.call @_FortranASystemClockCountMax(%[[VAL_60]]) fastmath<contract> : (i32) -> i64
+! CHECK:               fir.store %[[VAL_61]] to %[[VAL_51]] : !fir.heap<i64>
+! CHECK:             }
+! CHECK:             %[[VAL_62:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_63:.*]] = fir.address_of(@_QQclX0146bbb9ee5e88a6e67c6c1cf8871123) : !fir.ref<!fir.char<1,76>>
+! CHECK:             %[[VAL_64:.*]] = fir.convert %[[VAL_63]] : (!fir.ref<!fir.char<1,76>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_65:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_66:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_62]], %[[VAL_64]], %[[VAL_65]]) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:             %[[VAL_67:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.ptr<i64>>
+! CHECK:             %[[VAL_68:.*]] = fir.load %[[VAL_67]] : !fir.ptr<i64>
+! CHECK:             %[[VAL_69:.*]] = fir.call @_FortranAioOutputInteger64(%[[VAL_66]], %[[VAL_68]]) fastmath<contract> : (!fir.ref<i8>, i64) -> i1
+! CHECK:             %[[VAL_70:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
+! CHECK:             %[[VAL_71:.*]] = fir.load %[[VAL_70]] : !fir.heap<i64>
+! CHECK:             %[[VAL_72:.*]] = fir.call @_FortranAioOutputInteger64(%[[VAL_66]], %[[VAL_71]]) fastmath<contract> : (!fir.ref<i8>, i64) -> i1
+! CHECK:             %[[VAL_73:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_66]]) fastmath<contract> : (!fir.ref<i8>) -> i32
+! CHECK:           }
+! CHECK:           %[[VAL_74:.*]] = fir.is_present %[[VAL_0]] : (!fir.ref<i64>) -> i1
+! CHECK:           fir.if %[[VAL_74]] {
+! CHECK:             %[[VAL_75:.*]] = arith.constant 0 : i64
+! CHECK:             fir.store %[[VAL_75]] to %[[VAL_0]] : !fir.ref<i64>
+! CHECK:           }
+! CHECK:           %[[VAL_76:.*]] = fir.zero_bits !fir.ptr<i64>
+! CHECK:           fir.store %[[VAL_76]] to %[[VAL_5]] : !fir.ref<!fir.ptr<i64>>
+! CHECK:           %[[VAL_77:.*]] = arith.constant false
+! CHECK:           %[[VAL_78:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_79:.*]] = fir.address_of(@_QQclX0146bbb9ee5e88a6e67c6c1cf8871123) : !fir.ref<!fir.char<1,76>>
+! CHECK:           %[[VAL_80:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_81:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
+! CHECK:           %[[VAL_82:.*]] = fir.embox %[[VAL_81]] : (!fir.heap<i64>) -> !fir.box<!fir.heap<i64>>
+! CHECK:           fir.store %[[VAL_82]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<i64>>>
+! CHECK:           %[[VAL_83:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<i64>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_84:.*]] = fir.convert %[[VAL_79]] : (!fir.ref<!fir.char<1,76>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_85:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_83]], %[[VAL_77]], %[[VAL_78]], %[[VAL_84]], %[[VAL_80]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_86:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<i64>>>
+! CHECK:           %[[VAL_87:.*]] = fir.box_addr %[[VAL_86]] : (!fir.box<!fir.heap<i64>>) -> !fir.heap<i64>
+! CHECK:           fir.store %[[VAL_87]] to %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
+! CHECK:           %[[VAL_88:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.ptr<i64>>
+! CHECK:           %[[VAL_89:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
+! CHECK:           %[[VAL_90:.*]] = fir.is_present %[[VAL_0]] : (!fir.ref<i64>) -> i1
+! CHECK:           fir.if %[[VAL_90]] {
+! CHECK:             %[[VAL_91:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_92:.*]] = fir.call @_FortranASystemClockCount(%[[VAL_91]]) fastmath<contract> : (i32) -> i64
+! CHECK:             fir.store %[[VAL_92]] to %[[VAL_0]] : !fir.ref<i64>
+! CHECK:           }
+! CHECK:           %[[VAL_93:.*]] = fir.convert %[[VAL_88]] : (!fir.ptr<i64>) -> i64
+! CHECK:           %[[VAL_94:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_95:.*]] = arith.cmpi ne, %[[VAL_93]], %[[VAL_94]] : i64
+! CHECK:           fir.if %[[VAL_95]] {
+! CHECK:             %[[VAL_96:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_97:.*]] = fir.call @_FortranASystemClockCountRate(%[[VAL_96]]) fastmath<contract> : (i32) -> i64
+! CHECK:             fir.store %[[VAL_97]] to %[[VAL_88]] : !fir.ptr<i64>
+! CHECK:           }
+! CHECK:           %[[VAL_98:.*]] = fir.convert %[[VAL_89]] : (!fir.heap<i64>) -> i64
+! CHECK:           %[[VAL_99:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_100:.*]] = arith.cmpi ne, %[[VAL_98]], %[[VAL_99]] : i64
+! CHECK:           fir.if %[[VAL_100]] {
+! CHECK:             %[[VAL_101:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_102:.*]] = fir.call @_FortranASystemClockCountMax(%[[VAL_101]]) fastmath<contract> : (i32) -> i64
+! CHECK:             fir.store %[[VAL_102]] to %[[VAL_89]] : !fir.heap<i64>
+! CHECK:           }
+! CHECK:           %[[VAL_103:.*]] = fir.is_present %[[VAL_0]] : (!fir.ref<i64>) -> i1
+! CHECK:           fir.if %[[VAL_103]] {
+! CHECK:             %[[VAL_104:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_105:.*]] = fir.address_of(@_QQclX0146bbb9ee5e88a6e67c6c1cf8871123) : !fir.ref<!fir.char<1,76>>
+! CHECK:             %[[VAL_106:.*]] = fir.convert %[[VAL_105]] : (!fir.ref<!fir.char<1,76>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_107:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_108:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_104]], %[[VAL_106]], %[[VAL_107]]) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:             %[[VAL_109:.*]] = fir.load %[[VAL_0]] : !fir.ref<i64>
+! CHECK:             %[[VAL_110:.*]] = fir.call @_FortranAioOutputInteger64(%[[VAL_108]], %[[VAL_109]]) fastmath<contract> : (!fir.ref<i8>, i64) -> i1
+! CHECK:             %[[VAL_111:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_108]]) fastmath<contract> : (!fir.ref<i8>) -> i32
+! CHECK:           }
+! CHECK:           %[[VAL_112:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
+! CHECK:           %[[VAL_113:.*]] = fir.convert %[[VAL_112]] : (!fir.heap<i64>) -> i64
+! CHECK:           %[[VAL_114:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_115:.*]] = arith.cmpi ne, %[[VAL_113]], %[[VAL_114]] : i64
+! CHECK:           fir.if %[[VAL_115]] {
+! CHECK:             %[[VAL_116:.*]] = arith.constant false
+! CHECK:             %[[VAL_117:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_118:.*]] = fir.address_of(@_QQclX0146bbb9ee5e88a6e67c6c1cf8871123) : !fir.ref<!fir.char<1,76>>
+! CHECK:             %[[VAL_119:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_120:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
+! CHECK:             %[[VAL_121:.*]] = fir.embox %[[VAL_120]] : (!fir.heap<i64>) -> !fir.box<!fir.heap<i64>>
+! CHECK:             fir.store %[[VAL_121]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<i64>>>
+! CHECK:             %[[VAL_122:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<i64>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_123:.*]] = fir.convert %[[VAL_118]] : (!fir.ref<!fir.char<1,76>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_124:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_122]], %[[VAL_116]], %[[VAL_117]], %[[VAL_123]], %[[VAL_119]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:             %[[VAL_125:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<i64>>>
+! CHECK:             %[[VAL_126:.*]] = fir.box_addr %[[VAL_125]] : (!fir.box<!fir.heap<i64>>) -> !fir.heap<i64>
+! CHECK:             fir.store %[[VAL_126]] to %[[VAL_2]] : !fir.ref<!fir.heap<i64>>
+! CHECK:           }
+! CHECK:           return
+! CHECK:         }
 
   integer(8), optional :: count
   integer(8), target :: count_rate_

--- a/flang/test/Lower/OpenACC/acc-declare-unwrap-defaultbounds.f90
+++ b/flang/test/Lower/OpenACC/acc-declare-unwrap-defaultbounds.f90
@@ -239,19 +239,14 @@ module acc_declare
 
     allocate(a(100))
 
-! CHECK: %{{.*}} = fir.allocmem !fir.array<?xi32>, %{{.*}} {fir.must_be_heap = true, uniq_name = "_QMacc_declareFacc_declare_allocateEa.alloc"}
-! CHECK: fir.store %{{.*}} to %{{.*}} {acc.declare_action = #acc.declare_action<postAlloc = @_QMacc_declareFacc_declare_allocateEa_acc_declare_update_desc_post_alloc>} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK: fir.call @_FortranAAllocatableAllocate
 
     deallocate(a)
 
-! CHECK: %{{.*}} = fir.box_addr %{{.*}} {acc.declare_action = #acc.declare_action<preDealloc = @_QMacc_declareFacc_declare_allocateEa_acc_declare_update_desc_pre_dealloc>} : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-
-! CHECK: fir.freemem %{{.*}} : !fir.heap<!fir.array<?xi32>>
-! CHECK: fir.store %{{.*}} to %{{.*}} {acc.declare_action = #acc.declare_action<postDealloc = @_QMacc_declareFacc_declare_allocateEa_acc_declare_update_desc_post_dealloc>} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK: fir.call @_FortranAAllocatableDeallocate
 
 ! CHECK: fir.if
-! CHECK: fir.freemem %{{.*}} : !fir.heap<!fir.array<?xi32>>
-! CHECK: fir.store %{{.*}} to %{{.*}}#0 {acc.declare_action = #acc.declare_action<postDealloc = @_QMacc_declareFacc_declare_allocateEa_acc_declare_update_desc_post_dealloc>} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK: fir.call @_FortranAAllocatableDeallocate
 ! CHECK: }
 
   end subroutine
@@ -440,15 +435,14 @@ contains
   subroutine init()
     use acc_declare_allocatable_test
     allocate(data1(100))
-! CHECK: fir.store %{{.*}} to %{{.*}} {acc.declare_action = #acc.declare_action<postAlloc = @_QMacc_declare_allocatable_testEdata1_acc_declare_update_desc_post_alloc>} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK: fir.call @_FortranAAllocatableAllocate
   end subroutine
 
   subroutine finalize()
     use acc_declare_allocatable_test
     deallocate(data1)
-! CHECK: %{{.*}} = fir.box_addr %{{.*}} {acc.declare_action = #acc.declare_action<preDealloc = @_QMacc_declare_allocatable_testEdata1_acc_declare_update_desc_pre_dealloc>} : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! CHECK: fir.store %{{.*}} to %{{.*}} {acc.declare_action = #acc.declare_action<postDealloc = @_QMacc_declare_allocatable_testEdata1_acc_declare_update_desc_post_dealloc>} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-  end subroutine
+! CHECK: fir.call @_FortranAAllocatableDeallocate
+end subroutine
 end module
 
 module acc_declare_allocatable_test3

--- a/flang/test/Lower/OpenACC/acc-declare.f90
+++ b/flang/test/Lower/OpenACC/acc-declare.f90
@@ -231,19 +231,14 @@ module acc_declare
 
     allocate(a(100))
 
-! CHECK: %{{.*}} = fir.allocmem !fir.array<?xi32>, %{{.*}} {fir.must_be_heap = true, uniq_name = "_QMacc_declareFacc_declare_allocateEa.alloc"}
-! CHECK: fir.store %{{.*}} to %{{.*}} {acc.declare_action = #acc.declare_action<postAlloc = @_QMacc_declareFacc_declare_allocateEa_acc_declare_update_desc_post_alloc>} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK: %{{.*}} = fir.call @_FortranAAllocatableAllocate
 
     deallocate(a)
 
-! CHECK: %{{.*}} = fir.box_addr %{{.*}} {acc.declare_action = #acc.declare_action<preDealloc = @_QMacc_declareFacc_declare_allocateEa_acc_declare_update_desc_pre_dealloc>} : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-
-! CHECK: fir.freemem %{{.*}} : !fir.heap<!fir.array<?xi32>>
-! CHECK: fir.store %{{.*}} to %{{.*}} {acc.declare_action = #acc.declare_action<postDealloc = @_QMacc_declareFacc_declare_allocateEa_acc_declare_update_desc_post_dealloc>} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK: %{{.*}} = fir.call @_FortranAAllocatableDeallocate
 
 ! CHECK: fir.if
-! CHECK: fir.freemem %{{.*}} : !fir.heap<!fir.array<?xi32>>
-! CHECK: fir.store %{{.*}} to %{{.*}}#0 {acc.declare_action = #acc.declare_action<postDealloc = @_QMacc_declareFacc_declare_allocateEa_acc_declare_update_desc_post_dealloc>} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK: %{{.*}} = fir.call @_FortranAAllocatableDeallocate
 ! CHECK: }
 
   end subroutine
@@ -401,14 +396,13 @@ contains
   subroutine init()
     use acc_declare_allocatable_test
     allocate(data1(100))
-! CHECK: fir.store %{{.*}} to %{{.*}} {acc.declare_action = #acc.declare_action<postAlloc = @_QMacc_declare_allocatable_testEdata1_acc_declare_update_desc_post_alloc>} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK: fir.call @_FortranAAllocatableAllocate
   end subroutine
 
   subroutine finalize()
     use acc_declare_allocatable_test
     deallocate(data1)
-! CHECK: %{{.*}} = fir.box_addr %{{.*}} {acc.declare_action = #acc.declare_action<preDealloc = @_QMacc_declare_allocatable_testEdata1_acc_declare_update_desc_pre_dealloc>} : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! CHECK: fir.store %{{.*}} to %{{.*}} {acc.declare_action = #acc.declare_action<postDealloc = @_QMacc_declare_allocatable_testEdata1_acc_declare_update_desc_post_dealloc>} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK: fir.call @_FortranAAllocatableDeallocate
   end subroutine
 end module
 

--- a/flang/test/Lower/OpenMP/allocatable-array-bounds.f90
+++ b/flang/test/Lower/OpenMP/allocatable-array-bounds.f90
@@ -95,20 +95,35 @@ end subroutine assumed_shape_array
 end module assumed_allocatable_array_routines
 
 !HOST-LABEL: func.func @_QPcall_assumed_shape_and_size_array() {
-!HOST: %[[ALLOCA:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = "arr_read_write", uniq_name = "_QFcall_assumed_shape_and_size_arrayEarr_read_write"}
-!HOST: %[[DECLARE:.*]]:2 = hlfir.declare %[[ALLOCA]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFcall_assumed_shape_and_size_arrayEarr_read_write"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
-!HOST: %[[ALLOCA_MEM:.*]] = fir.allocmem !fir.array<?xi32>, %{{.*}} {fir.must_be_heap = true, uniq_name = "_QFcall_assumed_shape_and_size_arrayEarr_read_write.alloc"}
-!HOST: %[[SHAPE:.*]] = fir.shape %{{.*}} : (index) -> !fir.shape<1>
-!HOST: %[[EMBOX:.*]] = fir.embox %[[ALLOCA_MEM]](%[[SHAPE]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-!HOST: fir.store %[[EMBOX]] to %[[DECLARE]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-!HOST: %[[LOAD:.*]] = fir.load %[[DECLARE]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-!HOST: %[[CONSTANT_1:.*]] = arith.constant 10 : index
-!HOST: %[[CONSTANT_2:.*]] = arith.constant 20 : index
-!HOST: %[[CONSTANT_3:.*]] = arith.constant 1 : index
-!HOST: %[[CONSTANT_4:.*]] = arith.constant 11 : index
-!HOST: %[[SHAPE:.*]] = fir.shape %[[CONSTANT_4]] : (index) -> !fir.shape<1>
-!HOST: %[[DESIGNATE:.*]] = hlfir.designate %[[LOAD]] (%[[CONSTANT_1]]:%[[CONSTANT_2]]:%[[CONSTANT_3]])  shape %[[SHAPE]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index, index, index, !fir.shape<1>) -> !fir.ref<!fir.array<11xi32>>
-!HOST: fir.call @_QPassumed_size_array(%[[DESIGNATE]]) fastmath<contract> : (!fir.ref<!fir.array<11xi32>>) -> ()
+!HOST: %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = "arr_read_write", uniq_name = "_QFcall_assumed_shape_and_size_arrayEarr_read_write"}
+!HOST: %[[VAL_1:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
+!HOST: %[[VAL_2:.*]] = arith.constant 0 : index
+!HOST: %[[VAL_3:.*]] = fir.shape %[[VAL_2]] : (index) -> !fir.shape<1>
+!HOST: %[[VAL_4:.*]] = fir.embox %[[VAL_1]](%[[VAL_3]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+!HOST: fir.store %[[VAL_4]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+!HOST: %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFcall_assumed_shape_and_size_arrayEarr_read_write"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
+!HOST: %[[VAL_6:.*]] = arith.constant false
+!HOST: %[[VAL_7:.*]] = fir.absent !fir.box<none>
+!HOST: %[[VAL_8:.*]] = fir.address_of(@_QQclX406d77a864a01343bfa72d1eaaccf436) : !fir.ref<!fir.char<1,84>>
+!HOST: %[[VAL_9:.*]] = arith.constant {{.*}} : i32
+!HOST: %[[VAL_10:.*]] = arith.constant 1 : index
+!HOST: %[[VAL_11:.*]] = arith.constant {{.*}} : i32
+!HOST: %[[VAL_12:.*]] = arith.constant 0 : i32
+!HOST: %[[VAL_13:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+!HOST: %[[VAL_14:.*]] = fir.convert %[[VAL_10]] : (index) -> i64
+!HOST: %[[VAL_15:.*]] = fir.convert %[[VAL_11]] : (i32) -> i64
+!HOST: fir.call @_FortranAAllocatableSetBounds(%[[VAL_13]], %[[VAL_12]], %[[VAL_14]], %[[VAL_15]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+!HOST: %[[VAL_16:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+!HOST: %[[VAL_17:.*]] = fir.convert %[[VAL_8]] : (!fir.ref<!fir.char<1,84>>) -> !fir.ref<i8>
+!HOST: %[[VAL_18:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_16]], %[[VAL_6]], %[[VAL_7]], %[[VAL_17]], %[[VAL_9]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+!HOST: %[[VAL_19:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+!HOST: %[[VAL_20:.*]] = arith.constant {{.*}} : index
+!HOST: %[[VAL_21:.*]] = arith.constant {{.*}} : index
+!HOST: %[[VAL_22:.*]] = arith.constant 1 : index
+!HOST: %[[VAL_23:.*]] = arith.constant {{.*}} : index
+!HOST: %[[VAL_24:.*]] = fir.shape %[[VAL_23]] : (index) -> !fir.shape<1>
+!HOST: %[[VAL_25:.*]] = hlfir.designate %[[VAL_19]] (%[[VAL_20]]:%[[VAL_21]]:%[[VAL_22]])  shape %[[VAL_24]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index, index, index, !fir.shape<1>) -> !fir.ref<!fir.array<11xi32>>
+!HOST: fir.call @_QPassumed_size_array(%[[VAL_25]]) fastmath<contract> : (!fir.ref<!fir.array<11xi32>>) -> ()
 subroutine call_assumed_shape_and_size_array
     use assumed_allocatable_array_routines
     integer, allocatable :: arr_read_write(:)

--- a/flang/test/Lower/OpenMP/allocatable-array-bounds.f90
+++ b/flang/test/Lower/OpenMP/allocatable-array-bounds.f90
@@ -109,11 +109,11 @@ end module assumed_allocatable_array_routines
 !HOST: %[[VAL_10:.*]] = arith.constant 1 : index
 !HOST: %[[VAL_11:.*]] = arith.constant {{.*}} : i32
 !HOST: %[[VAL_12:.*]] = arith.constant 0 : i32
-!HOST: %[[VAL_13:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+!HOST: %[[VAL_13:.*]] = fir.convert %[[VAL_5]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 !HOST: %[[VAL_14:.*]] = fir.convert %[[VAL_10]] : (index) -> i64
 !HOST: %[[VAL_15:.*]] = fir.convert %[[VAL_11]] : (i32) -> i64
 !HOST: fir.call @_FortranAAllocatableSetBounds(%[[VAL_13]], %[[VAL_12]], %[[VAL_14]], %[[VAL_15]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
-!HOST: %[[VAL_16:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+!HOST: %[[VAL_16:.*]] = fir.convert %[[VAL_5]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 !HOST: %[[VAL_17:.*]] = fir.convert %[[VAL_8]] : (!fir.ref<!fir.char<1,84>>) -> !fir.ref<i8>
 !HOST: %[[VAL_18:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_16]], %[[VAL_6]], %[[VAL_7]], %[[VAL_17]], %[[VAL_9]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 !HOST: %[[VAL_19:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>

--- a/flang/test/Lower/OpenMP/allocatable-multiple-vars.f90
+++ b/flang/test/Lower/OpenMP/allocatable-multiple-vars.f90
@@ -22,7 +22,7 @@ end subroutine
 ! CHECK:      omp.parallel {
 ! CHECK:        fir.allocmem
 ! CHECK:        fir.allocmem
-! CHECK:        fir.freemem
-! CHECK:        fir.freemem
+! CHECK:        @_FortranAAllocatableDeallocate
+! CHECK:        @_FortranAAllocatableDeallocate
 ! CHECK:        omp.terminator
 ! CHECK-NEXT: }

--- a/flang/test/Lower/OpenMP/copyin.f90
+++ b/flang/test/Lower/OpenMP/copyin.f90
@@ -146,7 +146,7 @@ end
 ! CHECK:           %[[VAL_4:.*]] = omp.threadprivate %[[VAL_3]]#0 : !fir.ref<i32> -> !fir.ref<i32>
 ! CHECK:           %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_4]] {uniq_name = "_QFcombined_parallel_worksharing_loopEx6"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:           omp.parallel {
-! CHECK:             %[[VAL_6:.*]] = omp.threadprivate %[[VAL_3]]#1 : !fir.ref<i32> -> !fir.ref<i32>
+! CHECK:             %[[VAL_6:.*]] = omp.threadprivate %[[VAL_3]]{{.*}} : !fir.ref<i32> -> !fir.ref<i32>
 ! CHECK:             %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_6]] {uniq_name = "_QFcombined_parallel_worksharing_loopEx6"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:             %[[VAL_8:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<i32>
 ! CHECK:             hlfir.assign %[[VAL_8]] to %[[VAL_7]]#0 : i32, !fir.ref<i32>
@@ -157,8 +157,8 @@ end
 ! CHECK:             omp.wsloop private(@_QFcombined_parallel_worksharing_loopEi_private_i32 %[[VAL_1]]#0 -> %[[VAL_12:.*]] : !fir.ref<i32>) {
 ! CHECK:               omp.loop_nest (%[[VAL_13:.*]]) : i32 = (%[[VAL_9]]) to (%[[VAL_10]]) inclusive step (%[[VAL_11]]) {
 ! CHECK:                 %[[VAL_14:.*]]:2 = hlfir.declare %[[VAL_12]] {uniq_name = "_QFcombined_parallel_worksharing_loopEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:                 hlfir.assign %[[VAL_13]] to %[[VAL_14]]#1 : i32, !fir.ref<i32>
-! CHECK:                 fir.call @_QPsub4(%[[VAL_7]]#1) fastmath<contract> : (!fir.ref<i32>) -> ()
+! CHECK:                 hlfir.assign %[[VAL_13]] to %[[VAL_14]]{{.*}} : i32, !fir.ref<i32>
+! CHECK:                 fir.call @_QPsub4(%[[VAL_7]]{{.*}}) fastmath<contract> : (!fir.ref<i32>) -> ()
 ! CHECK:                 omp.yield
 ! CHECK:               }
 ! CHECK:             }
@@ -321,7 +321,7 @@ end subroutine
 ! CHECK:             omp.wsloop private(@_QFcommon_2Ei_private_i32 %[[VAL_1]]#0 -> %[[VAL_35:.*]] : !fir.ref<i32>) {
 ! CHECK:               omp.loop_nest (%[[VAL_36:.*]]) : i32 = (%[[VAL_32]]) to (%[[VAL_33]]) inclusive step (%[[VAL_34]]) {
 ! CHECK:                 %[[VAL_37:.*]]:2 = hlfir.declare %[[VAL_35]] {uniq_name = "_QFcommon_2Ei"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:                 hlfir.assign %[[VAL_36]] to %[[VAL_37]]#1 : i32, !fir.ref<i32>
+! CHECK:                 hlfir.assign %[[VAL_36]] to %[[VAL_37]]{{.*}} : i32, !fir.ref<i32>
 ! CHECK:                 %[[VAL_38:.*]] = fir.load %[[VAL_29]]#0 : !fir.ref<i32>
 ! CHECK:                 %[[VAL_39:.*]] = fir.load %[[VAL_37]]#0 : !fir.ref<i32>
 ! CHECK:                 %[[VAL_40:.*]] = arith.addi %[[VAL_38]], %[[VAL_39]] : i32
@@ -349,11 +349,11 @@ end subroutine
 ! CHECK-LABEL:   func.func @_QPpointer() {
 ! CHECK:           %[[VAL_0:.*]] = fir.address_of(@_QFpointerEp) : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = {{.*}}<pointer>, uniq_name = "_QFpointerEp"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>)
-! CHECK:           %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>> -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]{{.*}} : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>> -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {fortran_attrs = {{.*}}<pointer>, uniq_name = "_QFpointerEp"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>)
 ! CHECK:           omp.parallel {
 ! CHECK:             %[[VAL_4:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {pinned}
-! CHECK:             %[[VAL_5:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>> -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_5:.*]] = omp.threadprivate %[[VAL_1]]{{.*}} : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>> -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
 ! CHECK:             %[[VAL_6:.*]]:2 = hlfir.declare %[[VAL_5]] {fortran_attrs = {{.*}}<pointer>, uniq_name = "_QFpointerEp"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>)
 ! CHECK:             %[[VAL_7:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
 ! CHECK:             fir.store %[[VAL_7]] to %[[VAL_6]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
@@ -363,7 +363,7 @@ end subroutine
 ! CHECK:             %[[VAL_10:.*]] = fir.box_addr %[[VAL_9]]#0 : (!fir.box<!fir.ptr<!fir.array<?xi32>>>) -> !fir.ptr<!fir.array<?xi32>>
 ! CHECK:             %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (!fir.ptr<!fir.array<?xi32>>) -> !fir.ref<!fir.array<?xi32>>
 ! CHECK:             fir.call @_QPsub7(%[[VAL_11]]) fastmath<contract> : (!fir.ref<!fir.array<?xi32>>) -> ()
-! CHECK:             hlfir.copy_out %[[VAL_4]], %[[VAL_9]]#1 to %[[VAL_8]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, i1, !fir.box<!fir.ptr<!fir.array<?xi32>>>) -> ()
+! CHECK:             hlfir.copy_out %[[VAL_4]], %[[VAL_9]]{{.*}} to %[[VAL_8]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, i1, !fir.box<!fir.ptr<!fir.array<?xi32>>>) -> ()
 ! CHECK:             omp.terminator
 ! CHECK:           }
 ! CHECK:           return
@@ -380,10 +380,10 @@ end subroutine
 ! CHECK-LABEL:   func.func @_QPallocatable() {
 ! CHECK:           %[[VAL_0:.*]] = fir.address_of(@_QFallocatableEp) : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatableEp"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
-! CHECK:           %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatableEp"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK:           omp.parallel {
-! CHECK:             %[[VAL_4:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_4:.*]] = omp.threadprivate %[[VAL_1]]{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:             %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_4]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatableEp"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK:             %[[VAL_6:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:             %[[VAL_7:.*]] = fir.box_addr %[[VAL_6]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
@@ -394,7 +394,7 @@ end subroutine
 ! CHECK:               %[[VAL_11:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:               hlfir.assign %[[VAL_11]] to %[[VAL_5]]#0 realloc : !fir.box<!fir.heap<!fir.array<?xi32>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:             } else {
-! CHECK:               %[[VAL_12:.*]] = fir.load %[[VAL_5]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:               %[[VAL_12:.*]] = fir.load %[[VAL_5]]{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:               %[[VAL_13:.*]] = fir.box_addr %[[VAL_12]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
 ! CHECK:               %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (!fir.heap<!fir.array<?xi32>>) -> i64
 ! CHECK:               %[[VAL_15:.*]] = arith.constant 0 : i64
@@ -404,7 +404,7 @@ end subroutine
 ! CHECK:                 %[[VAL_18:.*]] = fir.absent !fir.box<none>
 ! CHECK:                 %[[VAL_19:.*]] = fir.address_of(@_QQclX3573f88d1792380f265b3d2ede411e3d) : !fir.ref<!fir.char<1,66>>
 ! CHECK:                 %[[VAL_20:.*]] = arith.constant {{.*}} : i32
-! CHECK:                 %[[VAL_21:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:                 %[[VAL_21:.*]] = fir.convert %[[VAL_5]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:                 %[[VAL_22:.*]] = fir.convert %[[VAL_19]] : (!fir.ref<!fir.char<1,66>>) -> !fir.ref<i8>
 ! CHECK:                 %[[VAL_23:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_21]], %[[VAL_17]], %[[VAL_18]], %[[VAL_22]], %[[VAL_20]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:               }
@@ -430,10 +430,10 @@ end subroutine
 ! CHECK-LABEL:   func.func @_QPallocatable2() {
 ! CHECK:           %[[VAL_0:.*]] = fir.address_of(@_QFallocatable2Ea) : !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatable2Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
-! CHECK:           %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<!fir.box<!fir.heap<i32>>> -> !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:           %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]{{.*}} : !fir.ref<!fir.box<!fir.heap<i32>>> -> !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatable2Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
 ! CHECK:           omp.parallel {
-! CHECK:             %[[VAL_4:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<!fir.box<!fir.heap<i32>>> -> !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:             %[[VAL_4:.*]] = omp.threadprivate %[[VAL_1]]{{.*}} : !fir.ref<!fir.box<!fir.heap<i32>>> -> !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:             %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_4]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatable2Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
 ! CHECK:             %[[VAL_6:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:             %[[VAL_7:.*]] = fir.box_addr %[[VAL_6]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
@@ -446,7 +446,7 @@ end subroutine
 ! CHECK:               %[[VAL_13:.*]] = fir.load %[[VAL_12]] : !fir.heap<i32>
 ! CHECK:               hlfir.assign %[[VAL_13]] to %[[VAL_5]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:             } else {
-! CHECK:               %[[VAL_14:.*]] = fir.load %[[VAL_5]]#1 : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:               %[[VAL_14:.*]] = fir.load %[[VAL_5]]{{.*}} : !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:               %[[VAL_15:.*]] = fir.box_addr %[[VAL_14]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
 ! CHECK:               %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (!fir.heap<i32>) -> i64
 ! CHECK:               %[[VAL_17:.*]] = arith.constant 0 : i64
@@ -456,7 +456,7 @@ end subroutine
 ! CHECK:                 %[[VAL_20:.*]] = fir.absent !fir.box<none>
 ! CHECK:                 %[[VAL_21:.*]] = fir.address_of(@_QQclX3573f88d1792380f265b3d2ede411e3d) : !fir.ref<!fir.char<1,66>>
 ! CHECK:                 %[[VAL_22:.*]] = arith.constant {{.*}} : i32
-! CHECK:                 %[[VAL_23:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:                 %[[VAL_23:.*]] = fir.convert %[[VAL_5]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:                 %[[VAL_24:.*]] = fir.convert %[[VAL_21]] : (!fir.ref<!fir.char<1,66>>) -> !fir.ref<i8>
 ! CHECK:                 %[[VAL_25:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_23]], %[[VAL_19]], %[[VAL_20]], %[[VAL_24]], %[[VAL_22]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:               }
@@ -480,19 +480,19 @@ end subroutine
 ! CHECK-LABEL:   func.func @_QPallocatable3() {
 ! CHECK:           %[[VAL_0:.*]] = fir.address_of(@_QFallocatable3Ea) : !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatable3Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
-! CHECK:           %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<!fir.box<!fir.heap<i32>>> -> !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:           %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]{{.*}} : !fir.ref<!fir.box<!fir.heap<i32>>> -> !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatable3Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
 ! CHECK:           %[[VAL_4:.*]] = arith.constant false
 ! CHECK:           %[[VAL_5:.*]] = fir.absent !fir.box<none>
 ! CHECK:           %[[VAL_6:.*]] = fir.address_of(@_QQclX3573f88d1792380f265b3d2ede411e3d) : !fir.ref<!fir.char<1,66>>
 ! CHECK:           %[[VAL_7:.*]] = arith.constant {{.*}} : i32
-! CHECK:           %[[VAL_8:.*]] = fir.convert %[[VAL_3]]#1 : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_8:.*]] = fir.convert %[[VAL_3]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_9:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.char<1,66>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_10:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_8]], %[[VAL_4]], %[[VAL_5]], %[[VAL_9]], %[[VAL_7]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:           %[[VAL_11:.*]] = arith.constant 10 : i32
 ! CHECK:           hlfir.assign %[[VAL_11]] to %[[VAL_3]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:           omp.parallel {
-! CHECK:             %[[VAL_12:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<!fir.box<!fir.heap<i32>>> -> !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:             %[[VAL_12:.*]] = omp.threadprivate %[[VAL_1]]{{.*}} : !fir.ref<!fir.box<!fir.heap<i32>>> -> !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:             %[[VAL_13:.*]]:2 = hlfir.declare %[[VAL_12]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatable3Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
 ! CHECK:             %[[VAL_14:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:             %[[VAL_15:.*]] = fir.box_addr %[[VAL_14]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
@@ -505,7 +505,7 @@ end subroutine
 ! CHECK:               %[[VAL_21:.*]] = fir.load %[[VAL_20]] : !fir.heap<i32>
 ! CHECK:               hlfir.assign %[[VAL_21]] to %[[VAL_13]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:             } else {
-! CHECK:               %[[VAL_22:.*]] = fir.load %[[VAL_13]]#1 : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:               %[[VAL_22:.*]] = fir.load %[[VAL_13]]{{.*}} : !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:               %[[VAL_23:.*]] = fir.box_addr %[[VAL_22]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
 ! CHECK:               %[[VAL_24:.*]] = fir.convert %[[VAL_23]] : (!fir.heap<i32>) -> i64
 ! CHECK:               %[[VAL_25:.*]] = arith.constant 0 : i64
@@ -515,7 +515,7 @@ end subroutine
 ! CHECK:                 %[[VAL_28:.*]] = fir.absent !fir.box<none>
 ! CHECK:                 %[[VAL_29:.*]] = fir.address_of(@_QQclX3573f88d1792380f265b3d2ede411e3d) : !fir.ref<!fir.char<1,66>>
 ! CHECK:                 %[[VAL_30:.*]] = arith.constant {{.*}} : i32
-! CHECK:                 %[[VAL_31:.*]] = fir.convert %[[VAL_13]]#1 : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:                 %[[VAL_31:.*]] = fir.convert %[[VAL_13]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:                 %[[VAL_32:.*]] = fir.convert %[[VAL_29]] : (!fir.ref<!fir.char<1,66>>) -> !fir.ref<i8>
 ! CHECK:                 %[[VAL_33:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_31]], %[[VAL_27]], %[[VAL_28]], %[[VAL_32]], %[[VAL_30]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:               }

--- a/flang/test/Lower/OpenMP/copyin.f90
+++ b/flang/test/Lower/OpenMP/copyin.f90
@@ -86,33 +86,33 @@ subroutine copyin_char_chararray()
 end
 
 ! CHECK-LABEL:   func.func @_QPcopyin_derived_type() {
-! CHECK:           %[[VAL_0:.*]] = fir.address_of(@_QFcopyin_derived_typeE.b.my_type.t_arr) : !fir.ref<!fir.array<2x1x!fir.type<_QM__fortran_type_infoTvalue{{[<]?}}{genre:i8,__padding0:!fir.array<7xi8>,value:i64}{{[>]?}}>>>
+! CHECK:           %[[VAL_0:.*]] = fir.address_of(@_QFcopyin_derived_typeE.b.my_type.t_arr) : !fir.ref<!fir.array<2x1x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>
 ! CHECK:           %[[VAL_1:.*]] = arith.constant 0 : index
 ! CHECK:           %[[VAL_2:.*]] = arith.constant 2 : index
 ! CHECK:           %[[VAL_3:.*]] = arith.constant 0 : index
 ! CHECK:           %[[VAL_4:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_5:.*]] = fir.shape_shift %[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]] : (index, index, index, index) -> !fir.shapeshift<2>
-! CHECK:           %[[VAL_6:.*]]:2 = hlfir.declare %[[VAL_0]](%[[VAL_5]]) {{{.*}}, uniq_name = "_QFcopyin_derived_typeE.b.my_type.t_arr"}
+! CHECK:           %[[VAL_6:.*]]:2 = hlfir.declare %[[VAL_0]](%[[VAL_5]]) {fortran_attrs = {{.*}}<target>, uniq_name = "_QFcopyin_derived_typeE.b.my_type.t_arr"} : (!fir.ref<!fir.array<2x1x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>, !fir.shapeshift<2>) -> (!fir.box<!fir.array<2x1x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>, !fir.ref<!fir.array<2x1x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>)
 ! CHECK:           %[[VAL_7:.*]] = fir.address_of(@_QFcopyin_derived_typeE.n.t_i) : !fir.ref<!fir.char<1,3>>
 ! CHECK:           %[[VAL_8:.*]] = arith.constant 3 : index
-! CHECK:           %[[VAL_9:.*]]:2 = hlfir.declare %[[VAL_7]] typeparams %[[VAL_8]] {{{.*}}, uniq_name = "_QFcopyin_derived_typeE.n.t_i"}
+! CHECK:           %[[VAL_9:.*]]:2 = hlfir.declare %[[VAL_7]] typeparams %[[VAL_8]] {fortran_attrs = {{.*}}<target>, uniq_name = "_QFcopyin_derived_typeE.n.t_i"} : (!fir.ref<!fir.char<1,3>>, index) -> (!fir.ref<!fir.char<1,3>>, !fir.ref<!fir.char<1,3>>)
 ! CHECK:           %[[VAL_10:.*]] = fir.address_of(@_QFcopyin_derived_typeE.n.t_arr) : !fir.ref<!fir.char<1,5>>
 ! CHECK:           %[[VAL_11:.*]] = arith.constant 5 : index
-! CHECK:           %[[VAL_12:.*]]:2 = hlfir.declare %[[VAL_10]] typeparams %[[VAL_11]] {{{.*}}, uniq_name = "_QFcopyin_derived_typeE.n.t_arr"}
+! CHECK:           %[[VAL_12:.*]]:2 = hlfir.declare %[[VAL_10]] typeparams %[[VAL_11]] {fortran_attrs = {{.*}}<target>, uniq_name = "_QFcopyin_derived_typeE.n.t_arr"} : (!fir.ref<!fir.char<1,5>>, index) -> (!fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>)
 ! CHECK:           %[[VAL_13:.*]] = fir.address_of(@_QFcopyin_derived_typeE.n.my_type) : !fir.ref<!fir.char<1,7>>
 ! CHECK:           %[[VAL_14:.*]] = arith.constant 7 : index
-! CHECK:           %[[VAL_15:.*]]:2 = hlfir.declare %[[VAL_13]] typeparams %[[VAL_14]] {{{.*}}, uniq_name = "_QFcopyin_derived_typeE.n.my_type"}
+! CHECK:           %[[VAL_15:.*]]:2 = hlfir.declare %[[VAL_13]] typeparams %[[VAL_14]] {fortran_attrs = {{.*}}<target>, uniq_name = "_QFcopyin_derived_typeE.n.my_type"} : (!fir.ref<!fir.char<1,7>>, index) -> (!fir.ref<!fir.char<1,7>>, !fir.ref<!fir.char<1,7>>)
 ! CHECK:           %[[VAL_16:.*]] = fir.address_of(@_QFcopyin_derived_typeEx5) : !fir.ref<!fir.type<_QFcopyin_derived_typeTmy_type{t_i:i32,t_arr:!fir.array<5xi32>}>>
 ! CHECK:           %[[VAL_17:.*]]:2 = hlfir.declare %[[VAL_16]] {uniq_name = "_QFcopyin_derived_typeEx5"} : (!fir.ref<!fir.type<_QFcopyin_derived_typeTmy_type{t_i:i32,t_arr:!fir.array<5xi32>}>>) -> (!fir.ref<!fir.type<_QFcopyin_derived_typeTmy_type{t_i:i32,t_arr:!fir.array<5xi32>}>>, !fir.ref<!fir.type<_QFcopyin_derived_typeTmy_type{t_i:i32,t_arr:!fir.array<5xi32>}>>)
 ! CHECK:           %[[VAL_18:.*]] = omp.threadprivate %[[VAL_17]]#0 : !fir.ref<!fir.type<_QFcopyin_derived_typeTmy_type{t_i:i32,t_arr:!fir.array<5xi32>}>> -> !fir.ref<!fir.type<_QFcopyin_derived_typeTmy_type{t_i:i32,t_arr:!fir.array<5xi32>}>>
 ! CHECK:           %[[VAL_19:.*]]:2 = hlfir.declare %[[VAL_18]] {uniq_name = "_QFcopyin_derived_typeEx5"} : (!fir.ref<!fir.type<_QFcopyin_derived_typeTmy_type{t_i:i32,t_arr:!fir.array<5xi32>}>>) -> (!fir.ref<!fir.type<_QFcopyin_derived_typeTmy_type{t_i:i32,t_arr:!fir.array<5xi32>}>>, !fir.ref<!fir.type<_QFcopyin_derived_typeTmy_type{t_i:i32,t_arr:!fir.array<5xi32>}>>)
-! CHECK:           %[[VAL_20:.*]] = fir.address_of(@_QFcopyin_derived_typeE.c.my_type)
+! CHECK:           %[[VAL_20:.*]] = fir.address_of(@_QFcopyin_derived_typeE.c.my_type) : !fir.ref<!fir.array<2x!fir.type<_QM__fortran_type_infoTcomponent{name:!fir.box<!fir.ptr<!fir.char<1,?>>>,genre:i8,category:i8,kind:i8,rank:i8,__padding0:!fir.array<4xi8>,offset:i64,characterlen:!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>,derived:!fir.box<!fir.ptr<!fir.type<_QM__fortran_type_infoTderivedtype{binding:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTbinding{proc:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>,name:!fir.box<!fir.ptr<!fir.char<1,?>>>}>>>>,name:!fir.box<!fir.ptr<!fir.char<1,?>>>,sizeinbytes:i64,uninstantiated:!fir.box<!fir.ptr<!fir.type<_QM__fortran_type_infoTderivedtype>>>,kindparameter:!fir.box<!fir.ptr<!fir.array<?xi64>>>,lenparameterkind:!fir.box<!fir.ptr<!fir.array<?xi8>>>,component:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTcomponent>>>>,procptr:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTprocptrcomponent{name:!fir.box<!fir.ptr<!fir.char<1,?>>>,offset:i64,initialization:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>}>>>>,special:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTspecialbinding{which:i8,isargdescriptorset:i8,istypebound:i8,isargcontiguousset:i8,__padding0:!fir.array<4xi8>,proc:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>}>>>>,specialbitset:i32,hasparent:i8,noinitializationneeded:i8,nodestructionneeded:i8,nofinalizationneeded:i8,__padding0:!fir.array<4xi8>}>>>,lenvalue:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>>,bounds:!fir.box<!fir.ptr<!fir.array<?x?x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>>,initialization:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>>
 ! CHECK:           %[[VAL_21:.*]] = arith.constant 0 : index
 ! CHECK:           %[[VAL_22:.*]] = arith.constant 2 : index
 ! CHECK:           %[[VAL_23:.*]] = fir.shape_shift %[[VAL_21]], %[[VAL_22]] : (index, index) -> !fir.shapeshift<1>
-! CHECK:           %[[VAL_24:.*]]:2 = hlfir.declare %[[VAL_20]](%[[VAL_23]]) {{{.*}}, uniq_name = "_QFcopyin_derived_typeE.c.my_type"}
-! CHECK:           %[[VAL_25:.*]] = fir.address_of(@_QFcopyin_derived_typeE.dt.my_type)
-! CHECK:           %[[VAL_26:.*]]:2 = hlfir.declare %[[VAL_25]] {{{.*}}, uniq_name = "_QFcopyin_derived_typeE.dt.my_type"}
+! CHECK:           %[[VAL_24:.*]]:2 = hlfir.declare %[[VAL_20]](%[[VAL_23]]) {fortran_attrs = {{.*}}<target>, uniq_name = "_QFcopyin_derived_typeE.c.my_type"} : (!fir.ref<!fir.array<2x!fir.type<_QM__fortran_type_infoTcomponent{name:!fir.box<!fir.ptr<!fir.char<1,?>>>,genre:i8,category:i8,kind:i8,rank:i8,__padding0:!fir.array<4xi8>,offset:i64,characterlen:!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>,derived:!fir.box<!fir.ptr<!fir.type<_QM__fortran_type_infoTderivedtype{binding:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTbinding{proc:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>,name:!fir.box<!fir.ptr<!fir.char<1,?>>>}>>>>,name:!fir.box<!fir.ptr<!fir.char<1,?>>>,sizeinbytes:i64,uninstantiated:!fir.box<!fir.ptr<!fir.type<_QM__fortran_type_infoTderivedtype>>>,kindparameter:!fir.box<!fir.ptr<!fir.array<?xi64>>>,lenparameterkind:!fir.box<!fir.ptr<!fir.array<?xi8>>>,component:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTcomponent>>>>,procptr:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTprocptrcomponent{name:!fir.box<!fir.ptr<!fir.char<1,?>>>,offset:i64,initialization:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>}>>>>,special:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTspecialbinding{which:i8,isargdescriptorset:i8,istypebound:i8,isargcontiguousset:i8,__padding0:!fir.array<4xi8>,proc:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>}>>>>,specialbitset:i32,hasparent:i8,noinitializationneeded:i8,nodestructionneeded:i8,nofinalizationneeded:i8,__padding0:!fir.array<4xi8>}>>>,lenvalue:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>>,bounds:!fir.box<!fir.ptr<!fir.array<?x?x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>>,initialization:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>>, !fir.shapeshift<1>) -> (!fir.box<!fir.array<2x!fir.type<_QM__fortran_type_infoTcomponent{name:!fir.box<!fir.ptr<!fir.char<1,?>>>,genre:i8,category:i8,kind:i8,rank:i8,__padding0:!fir.array<4xi8>,offset:i64,characterlen:!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>,derived:!fir.box<!fir.ptr<!fir.type<_QM__fortran_type_infoTderivedtype{binding:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTbinding{proc:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>,name:!fir.box<!fir.ptr<!fir.char<1,?>>>}>>>>,name:!fir.box<!fir.ptr<!fir.char<1,?>>>,sizeinbytes:i64,uninstantiated:!fir.box<!fir.ptr<!fir.type<_QM__fortran_type_infoTderivedtype>>>,kindparameter:!fir.box<!fir.ptr<!fir.array<?xi64>>>,lenparameterkind:!fir.box<!fir.ptr<!fir.array<?xi8>>>,component:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTcomponent>>>>,procptr:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTprocptrcomponent{name:!fir.box<!fir.ptr<!fir.char<1,?>>>,offset:i64,initialization:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>}>>>>,special:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTspecialbinding{which:i8,isargdescriptorset:i8,istypebound:i8,isargcontiguousset:i8,__padding0:!fir.array<4xi8>,proc:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>}>>>>,specialbitset:i32,hasparent:i8,noinitializationneeded:i8,nodestructionneeded:i8,nofinalizationneeded:i8,__padding0:!fir.array<4xi8>}>>>,lenvalue:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>>,bounds:!fir.box<!fir.ptr<!fir.array<?x?x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>>,initialization:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>>, !fir.ref<!fir.array<2x!fir.type<_QM__fortran_type_infoTcomponent{name:!fir.box<!fir.ptr<!fir.char<1,?>>>,genre:i8,category:i8,kind:i8,rank:i8,__padding0:!fir.array<4xi8>,offset:i64,characterlen:!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>,derived:!fir.box<!fir.ptr<!fir.type<_QM__fortran_type_infoTderivedtype{binding:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTbinding{proc:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>,name:!fir.box<!fir.ptr<!fir.char<1,?>>>}>>>>,name:!fir.box<!fir.ptr<!fir.char<1,?>>>,sizeinbytes:i64,uninstantiated:!fir.box<!fir.ptr<!fir.type<_QM__fortran_type_infoTderivedtype>>>,kindparameter:!fir.box<!fir.ptr<!fir.array<?xi64>>>,lenparameterkind:!fir.box<!fir.ptr<!fir.array<?xi8>>>,component:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTcomponent>>>>,procptr:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTprocptrcomponent{name:!fir.box<!fir.ptr<!fir.char<1,?>>>,offset:i64,initialization:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>}>>>>,special:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTspecialbinding{which:i8,isargdescriptorset:i8,istypebound:i8,isargcontiguousset:i8,__padding0:!fir.array<4xi8>,proc:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>}>>>>,specialbitset:i32,hasparent:i8,noinitializationneeded:i8,nodestructionneeded:i8,nofinalizationneeded:i8,__padding0:!fir.array<4xi8>}>>>,lenvalue:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>>,bounds:!fir.box<!fir.ptr<!fir.array<?x?x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>>,initialization:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>>)
+! CHECK:           %[[VAL_25:.*]] = fir.address_of(@_QFcopyin_derived_typeE.dt.my_type) : !fir.ref<!fir.type<_QM__fortran_type_infoTderivedtype{binding:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTbinding{proc:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>,name:!fir.box<!fir.ptr<!fir.char<1,?>>>}>>>>,name:!fir.box<!fir.ptr<!fir.char<1,?>>>,sizeinbytes:i64,uninstantiated:!fir.box<!fir.ptr<!fir.type<_QM__fortran_type_infoTderivedtype>>>,kindparameter:!fir.box<!fir.ptr<!fir.array<?xi64>>>,lenparameterkind:!fir.box<!fir.ptr<!fir.array<?xi8>>>,component:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTcomponent{name:!fir.box<!fir.ptr<!fir.char<1,?>>>,genre:i8,category:i8,kind:i8,rank:i8,__padding0:!fir.array<4xi8>,offset:i64,characterlen:!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>,derived:!fir.box<!fir.ptr<!fir.type<_QM__fortran_type_infoTderivedtype>>>,lenvalue:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>>,bounds:!fir.box<!fir.ptr<!fir.array<?x?x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>>,initialization:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>>>,procptr:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTprocptrcomponent{name:!fir.box<!fir.ptr<!fir.char<1,?>>>,offset:i64,initialization:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>}>>>>,special:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTspecialbinding{which:i8,isargdescriptorset:i8,istypebound:i8,isargcontiguousset:i8,__padding0:!fir.array<4xi8>,proc:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>}>>>>,specialbitset:i32,hasparent:i8,noinitializationneeded:i8,nodestructionneeded:i8,nofinalizationneeded:i8,__padding0:!fir.array<4xi8>}>>
+! CHECK:           %[[VAL_26:.*]]:2 = hlfir.declare %[[VAL_25]] {fortran_attrs = {{.*}}<target>, uniq_name = "_QFcopyin_derived_typeE.dt.my_type"} : (!fir.ref<!fir.type<_QM__fortran_type_infoTderivedtype{binding:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTbinding{proc:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>,name:!fir.box<!fir.ptr<!fir.char<1,?>>>}>>>>,name:!fir.box<!fir.ptr<!fir.char<1,?>>>,sizeinbytes:i64,uninstantiated:!fir.box<!fir.ptr<!fir.type<_QM__fortran_type_infoTderivedtype>>>,kindparameter:!fir.box<!fir.ptr<!fir.array<?xi64>>>,lenparameterkind:!fir.box<!fir.ptr<!fir.array<?xi8>>>,component:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTcomponent{name:!fir.box<!fir.ptr<!fir.char<1,?>>>,genre:i8,category:i8,kind:i8,rank:i8,__padding0:!fir.array<4xi8>,offset:i64,characterlen:!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>,derived:!fir.box<!fir.ptr<!fir.type<_QM__fortran_type_infoTderivedtype>>>,lenvalue:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>>,bounds:!fir.box<!fir.ptr<!fir.array<?x?x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>>,initialization:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>>>,procptr:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTprocptrcomponent{name:!fir.box<!fir.ptr<!fir.char<1,?>>>,offset:i64,initialization:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>}>>>>,special:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTspecialbinding{which:i8,isargdescriptorset:i8,istypebound:i8,isargcontiguousset:i8,__padding0:!fir.array<4xi8>,proc:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>}>>>>,specialbitset:i32,hasparent:i8,noinitializationneeded:i8,nodestructionneeded:i8,nofinalizationneeded:i8,__padding0:!fir.array<4xi8>}>>) -> (!fir.ref<!fir.type<_QM__fortran_type_infoTderivedtype{binding:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTbinding{proc:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>,name:!fir.box<!fir.ptr<!fir.char<1,?>>>}>>>>,name:!fir.box<!fir.ptr<!fir.char<1,?>>>,sizeinbytes:i64,uninstantiated:!fir.box<!fir.ptr<!fir.type<_QM__fortran_type_infoTderivedtype>>>,kindparameter:!fir.box<!fir.ptr<!fir.array<?xi64>>>,lenparameterkind:!fir.box<!fir.ptr<!fir.array<?xi8>>>,component:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTcomponent{name:!fir.box<!fir.ptr<!fir.char<1,?>>>,genre:i8,category:i8,kind:i8,rank:i8,__padding0:!fir.array<4xi8>,offset:i64,characterlen:!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>,derived:!fir.box<!fir.ptr<!fir.type<_QM__fortran_type_infoTderivedtype>>>,lenvalue:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>>,bounds:!fir.box<!fir.ptr<!fir.array<?x?x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>>,initialization:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>>>,procptr:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTprocptrcomponent{name:!fir.box<!fir.ptr<!fir.char<1,?>>>,offset:i64,initialization:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>}>>>>,special:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTspecialbinding{which:i8,isargdescriptorset:i8,istypebound:i8,isargcontiguousset:i8,__padding0:!fir.array<4xi8>,proc:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>}>>>>,specialbitset:i32,hasparent:i8,noinitializationneeded:i8,nodestructionneeded:i8,nofinalizationneeded:i8,__padding0:!fir.array<4xi8>}>>, !fir.ref<!fir.type<_QM__fortran_type_infoTderivedtype{binding:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTbinding{proc:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>,name:!fir.box<!fir.ptr<!fir.char<1,?>>>}>>>>,name:!fir.box<!fir.ptr<!fir.char<1,?>>>,sizeinbytes:i64,uninstantiated:!fir.box<!fir.ptr<!fir.type<_QM__fortran_type_infoTderivedtype>>>,kindparameter:!fir.box<!fir.ptr<!fir.array<?xi64>>>,lenparameterkind:!fir.box<!fir.ptr<!fir.array<?xi8>>>,component:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTcomponent{name:!fir.box<!fir.ptr<!fir.char<1,?>>>,genre:i8,category:i8,kind:i8,rank:i8,__padding0:!fir.array<4xi8>,offset:i64,characterlen:!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>,derived:!fir.box<!fir.ptr<!fir.type<_QM__fortran_type_infoTderivedtype>>>,lenvalue:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>>,bounds:!fir.box<!fir.ptr<!fir.array<?x?x!fir.type<_QM__fortran_type_infoTvalue{genre:i8,__padding0:!fir.array<7xi8>,value:i64}>>>>,initialization:!fir.type<_QM__fortran_builtinsT__builtin_c_ptr{__address:i64}>}>>>>,procptr:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTprocptrcomponent{name:!fir.box<!fir.ptr<!fir.char<1,?>>>,offset:i64,initialization:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>}>>>>,special:!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QM__fortran_type_infoTspecialbinding{which:i8,isargdescriptorset:i8,istypebound:i8,isargcontiguousset:i8,__padding0:!fir.array<4xi8>,proc:!fir.type<_QM__fortran_builtinsT__builtin_c_funptr{__address:i64}>}>>>>,specialbitset:i32,hasparent:i8,noinitializationneeded:i8,nodestructionneeded:i8,nofinalizationneeded:i8,__padding0:!fir.array<4xi8>}>>)
 ! CHECK:           omp.parallel {
 ! CHECK:             %[[VAL_27:.*]] = omp.threadprivate %[[VAL_17]]#0 : !fir.ref<!fir.type<_QFcopyin_derived_typeTmy_type{t_i:i32,t_arr:!fir.array<5xi32>}>> -> !fir.ref<!fir.type<_QFcopyin_derived_typeTmy_type{t_i:i32,t_arr:!fir.array<5xi32>}>>
 ! CHECK:             %[[VAL_28:.*]]:2 = hlfir.declare %[[VAL_27]] {uniq_name = "_QFcopyin_derived_typeEx5"} : (!fir.ref<!fir.type<_QFcopyin_derived_typeTmy_type{t_i:i32,t_arr:!fir.array<5xi32>}>>) -> (!fir.ref<!fir.type<_QFcopyin_derived_typeTmy_type{t_i:i32,t_arr:!fir.array<5xi32>}>>, !fir.ref<!fir.type<_QFcopyin_derived_typeTmy_type{t_i:i32,t_arr:!fir.array<5xi32>}>>)
@@ -146,23 +146,19 @@ end
 ! CHECK:           %[[VAL_4:.*]] = omp.threadprivate %[[VAL_3]]#0 : !fir.ref<i32> -> !fir.ref<i32>
 ! CHECK:           %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_4]] {uniq_name = "_QFcombined_parallel_worksharing_loopEx6"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:           omp.parallel {
-
-! CHECK:             %[[VAL_8:.*]] = omp.threadprivate %[[VAL_3]]#0 : !fir.ref<i32> -> !fir.ref<i32>
-! CHECK:             %[[VAL_9:.*]]:2 = hlfir.declare %[[VAL_8]] {uniq_name = "_QFcombined_parallel_worksharing_loopEx6"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:             %[[VAL_10:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<i32>
-! CHECK:             hlfir.assign %[[VAL_10]] to %[[VAL_9]]#0 : i32, !fir.ref<i32>
-
+! CHECK:             %[[VAL_6:.*]] = omp.threadprivate %[[VAL_3]]#1 : !fir.ref<i32> -> !fir.ref<i32>
+! CHECK:             %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_6]] {uniq_name = "_QFcombined_parallel_worksharing_loopEx6"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:             %[[VAL_8:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<i32>
+! CHECK:             hlfir.assign %[[VAL_8]] to %[[VAL_7]]#0 : i32, !fir.ref<i32>
 ! CHECK:             omp.barrier
-
-
+! CHECK:             %[[VAL_9:.*]] = arith.constant 1 : i32
+! CHECK:             %[[VAL_10:.*]] = fir.load %[[VAL_7]]#0 : !fir.ref<i32>
 ! CHECK:             %[[VAL_11:.*]] = arith.constant 1 : i32
-! CHECK:             %[[VAL_12:.*]] = fir.load %[[VAL_9]]#0 : !fir.ref<i32>
-! CHECK:             %[[VAL_13:.*]] = arith.constant 1 : i32
-! CHECK:             omp.wsloop private(@{{.*}} %{{.*}} -> %[[VAL_6:.*]] : !fir.ref<i32>) {
-! CHECK-NEXT:          omp.loop_nest (%[[VAL_14:.*]]) : i32 = (%[[VAL_11]]) to (%[[VAL_12]]) inclusive step (%[[VAL_13]]) {
-! CHECK:                 %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_6]] {uniq_name = "_QFcombined_parallel_worksharing_loopEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:                 hlfir.assign %[[VAL_14]] to %[[VAL_7]]#0 : i32, !fir.ref<i32>
-! CHECK:                 fir.call @_QPsub4(%[[VAL_9]]#0) fastmath<contract> : (!fir.ref<i32>) -> ()
+! CHECK:             omp.wsloop private(@_QFcombined_parallel_worksharing_loopEi_private_i32 %[[VAL_1]]#0 -> %[[VAL_12:.*]] : !fir.ref<i32>) {
+! CHECK:               omp.loop_nest (%[[VAL_13:.*]]) : i32 = (%[[VAL_9]]) to (%[[VAL_10]]) inclusive step (%[[VAL_11]]) {
+! CHECK:                 %[[VAL_14:.*]]:2 = hlfir.declare %[[VAL_12]] {uniq_name = "_QFcombined_parallel_worksharing_loopEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:                 hlfir.assign %[[VAL_13]] to %[[VAL_14]]#1 : i32, !fir.ref<i32>
+! CHECK:                 fir.call @_QPsub4(%[[VAL_7]]#1) fastmath<contract> : (!fir.ref<i32>) -> ()
 ! CHECK:                 omp.yield
 ! CHECK:               }
 ! CHECK:             }
@@ -303,34 +299,33 @@ end subroutine
 ! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_16]] : (!fir.ref<i8>) -> !fir.ref<i32>
 ! CHECK:           %[[VAL_18:.*]]:2 = hlfir.declare %[[VAL_17]] {uniq_name = "_QFcommon_2Ey"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:           omp.parallel {
-
-! CHECK:             %[[VAL_21:.*]] = omp.threadprivate %[[VAL_2]] : !fir.ref<!fir.array<8xi8>> -> !fir.ref<!fir.array<8xi8>>
-! CHECK:             %[[VAL_22:.*]] = fir.convert %[[VAL_21]] : (!fir.ref<!fir.array<8xi8>>) -> !fir.ref<!fir.array<?xi8>>
-! CHECK:             %[[VAL_23:.*]] = arith.constant 0 : index
-! CHECK:             %[[VAL_24:.*]] = fir.coordinate_of %[[VAL_22]], %[[VAL_23]] : (!fir.ref<!fir.array<?xi8>>, index) -> !fir.ref<i8>
-! CHECK:             %[[VAL_25:.*]] = fir.convert %[[VAL_24]] : (!fir.ref<i8>) -> !fir.ref<i32>
-! CHECK:             %[[VAL_26:.*]]:2 = hlfir.declare %[[VAL_25]] {uniq_name = "_QFcommon_2Ex"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:             %[[VAL_27:.*]] = fir.convert %[[VAL_21]] : (!fir.ref<!fir.array<8xi8>>) -> !fir.ref<!fir.array<?xi8>>
-! CHECK:             %[[VAL_28:.*]] = arith.constant 4 : index
-! CHECK:             %[[VAL_29:.*]] = fir.coordinate_of %[[VAL_27]], %[[VAL_28]] : (!fir.ref<!fir.array<?xi8>>, index) -> !fir.ref<i8>
-! CHECK:             %[[VAL_30:.*]] = fir.convert %[[VAL_29]] : (!fir.ref<i8>) -> !fir.ref<i32>
-! CHECK:             %[[VAL_31:.*]]:2 = hlfir.declare %[[VAL_30]] {uniq_name = "_QFcommon_2Ey"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:             %[[VAL_32:.*]] = fir.load %[[VAL_13]]#0 : !fir.ref<i32>
-! CHECK:             hlfir.assign %[[VAL_32]] to %[[VAL_26]]#0 : i32, !fir.ref<i32>
-! CHECK:             %[[VAL_33:.*]] = fir.load %[[VAL_18]]#0 : !fir.ref<i32>
-! CHECK:             hlfir.assign %[[VAL_33]] to %[[VAL_31]]#0 : i32, !fir.ref<i32>
+! CHECK:             %[[VAL_19:.*]] = omp.threadprivate %[[VAL_2]] : !fir.ref<!fir.array<8xi8>> -> !fir.ref<!fir.array<8xi8>>
+! CHECK:             %[[VAL_20:.*]] = fir.convert %[[VAL_19]] : (!fir.ref<!fir.array<8xi8>>) -> !fir.ref<!fir.array<?xi8>>
+! CHECK:             %[[VAL_21:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_22:.*]] = fir.coordinate_of %[[VAL_20]], %[[VAL_21]] : (!fir.ref<!fir.array<?xi8>>, index) -> !fir.ref<i8>
+! CHECK:             %[[VAL_23:.*]] = fir.convert %[[VAL_22]] : (!fir.ref<i8>) -> !fir.ref<i32>
+! CHECK:             %[[VAL_24:.*]]:2 = hlfir.declare %[[VAL_23]] {uniq_name = "_QFcommon_2Ex"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:             %[[VAL_25:.*]] = fir.convert %[[VAL_19]] : (!fir.ref<!fir.array<8xi8>>) -> !fir.ref<!fir.array<?xi8>>
+! CHECK:             %[[VAL_26:.*]] = arith.constant 4 : index
+! CHECK:             %[[VAL_27:.*]] = fir.coordinate_of %[[VAL_25]], %[[VAL_26]] : (!fir.ref<!fir.array<?xi8>>, index) -> !fir.ref<i8>
+! CHECK:             %[[VAL_28:.*]] = fir.convert %[[VAL_27]] : (!fir.ref<i8>) -> !fir.ref<i32>
+! CHECK:             %[[VAL_29:.*]]:2 = hlfir.declare %[[VAL_28]] {uniq_name = "_QFcommon_2Ey"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:             %[[VAL_30:.*]] = fir.load %[[VAL_13]]#0 : !fir.ref<i32>
+! CHECK:             hlfir.assign %[[VAL_30]] to %[[VAL_24]]#0 : i32, !fir.ref<i32>
+! CHECK:             %[[VAL_31:.*]] = fir.load %[[VAL_18]]#0 : !fir.ref<i32>
+! CHECK:             hlfir.assign %[[VAL_31]] to %[[VAL_29]]#0 : i32, !fir.ref<i32>
 ! CHECK:             omp.barrier
+! CHECK:             %[[VAL_32:.*]] = arith.constant 1 : i32
+! CHECK:             %[[VAL_33:.*]] = fir.load %[[VAL_24]]#0 : !fir.ref<i32>
 ! CHECK:             %[[VAL_34:.*]] = arith.constant 1 : i32
-! CHECK:             %[[VAL_35:.*]] = fir.load %[[VAL_26]]#0 : !fir.ref<i32>
-! CHECK:             %[[VAL_36:.*]] = arith.constant 1 : i32
-! CHECK:             omp.wsloop private(@{{.*}} %{{.*}} -> %[[VAL_19:.*]] : !fir.ref<i32>) {
-! CHECK-NEXT:          omp.loop_nest (%[[VAL_37:.*]]) : i32 = (%[[VAL_34]]) to (%[[VAL_35]]) inclusive step (%[[VAL_36]]) {
-! CHECK:             %[[VAL_20:.*]]:2 = hlfir.declare %[[VAL_19]] {uniq_name = "_QFcommon_2Ei"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:                 hlfir.assign %[[VAL_37]] to %[[VAL_20]]#0 : i32, !fir.ref<i32>
-! CHECK:                 %[[VAL_38:.*]] = fir.load %[[VAL_31]]#0 : !fir.ref<i32>
-! CHECK:                 %[[VAL_39:.*]] = fir.load %[[VAL_20]]#0 : !fir.ref<i32>
+! CHECK:             omp.wsloop private(@_QFcommon_2Ei_private_i32 %[[VAL_1]]#0 -> %[[VAL_35:.*]] : !fir.ref<i32>) {
+! CHECK:               omp.loop_nest (%[[VAL_36:.*]]) : i32 = (%[[VAL_32]]) to (%[[VAL_33]]) inclusive step (%[[VAL_34]]) {
+! CHECK:                 %[[VAL_37:.*]]:2 = hlfir.declare %[[VAL_35]] {uniq_name = "_QFcommon_2Ei"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:                 hlfir.assign %[[VAL_36]] to %[[VAL_37]]#1 : i32, !fir.ref<i32>
+! CHECK:                 %[[VAL_38:.*]] = fir.load %[[VAL_29]]#0 : !fir.ref<i32>
+! CHECK:                 %[[VAL_39:.*]] = fir.load %[[VAL_37]]#0 : !fir.ref<i32>
 ! CHECK:                 %[[VAL_40:.*]] = arith.addi %[[VAL_38]], %[[VAL_39]] : i32
-! CHECK:                 hlfir.assign %[[VAL_40]] to %[[VAL_31]]#0 : i32, !fir.ref<i32>
+! CHECK:                 hlfir.assign %[[VAL_40]] to %[[VAL_29]]#0 : i32, !fir.ref<i32>
 ! CHECK:                 omp.yield
 ! CHECK:               }
 ! CHECK:             }
@@ -353,13 +348,13 @@ end subroutine
 
 ! CHECK-LABEL:   func.func @_QPpointer() {
 ! CHECK:           %[[VAL_0:.*]] = fir.address_of(@_QFpointerEp) : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFpointerEp"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>)
-! CHECK:           %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>> -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFpointerEp"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>)
+! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = {{.*}}<pointer>, uniq_name = "_QFpointerEp"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>)
+! CHECK:           %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>> -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {fortran_attrs = {{.*}}<pointer>, uniq_name = "_QFpointerEp"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>)
 ! CHECK:           omp.parallel {
 ! CHECK:             %[[VAL_4:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {pinned}
-! CHECK:             %[[VAL_5:.*]] = omp.threadprivate %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>> -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:             %[[VAL_6:.*]]:2 = hlfir.declare %[[VAL_5]] {fortran_attrs = #fir.var_attrs<pointer>, uniq_name = "_QFpointerEp"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>)
+! CHECK:             %[[VAL_5:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>> -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_6:.*]]:2 = hlfir.declare %[[VAL_5]] {fortran_attrs = {{.*}}<pointer>, uniq_name = "_QFpointerEp"} : (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>)
 ! CHECK:             %[[VAL_7:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
 ! CHECK:             fir.store %[[VAL_7]] to %[[VAL_6]]#0 : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
 ! CHECK:             omp.barrier
@@ -384,41 +379,41 @@ end subroutine
 
 ! CHECK-LABEL:   func.func @_QPallocatable() {
 ! CHECK:           %[[VAL_0:.*]] = fir.address_of(@_QFallocatableEp) : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFallocatableEp"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
-! CHECK:           %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFallocatableEp"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
+! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatableEp"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
+! CHECK:           %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatableEp"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK:           omp.parallel {
-! CHECK:             %[[VAL_4:.*]] = omp.threadprivate %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:             %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_4]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFallocatableEp"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
+! CHECK:             %[[VAL_4:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_4]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatableEp"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK:             %[[VAL_6:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:             %[[VAL_7:.*]] = fir.box_addr %[[VAL_6]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
 ! CHECK:             %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (!fir.heap<!fir.array<?xi32>>) -> i64
-! CHECK:             %[[C0_I64:.*]] = arith.constant 0 : i64
-! CHECK:             %[[VAL_9:.*]] = arith.cmpi ne, %[[VAL_8]], %[[C0_I64]] : i64
-! CHECK:             fir.if %[[VAL_9]] {
-! CHECK:               %[[VAL_10:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:             hlfir.assign %[[VAL_10]] to %[[VAL_5]]#0 realloc : !fir.box<!fir.heap<!fir.array<?xi32>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_9:.*]] = arith.constant 0 : i64
+! CHECK:             %[[VAL_10:.*]] = arith.cmpi ne, %[[VAL_8]], %[[VAL_9]] : i64
+! CHECK:             fir.if %[[VAL_10]] {
+! CHECK:               %[[VAL_11:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:               hlfir.assign %[[VAL_11]] to %[[VAL_5]]#0 realloc : !fir.box<!fir.heap<!fir.array<?xi32>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:             } else {
-! CHECK:              %[[VAL_10:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:              %[[VAL_11:.*]] = fir.box_addr %[[VAL_10]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! CHECK:              %[[VAL_12:.*]] = fir.convert %[[VAL_11]] : (!fir.heap<!fir.array<?xi32>>) -> i64
-! CHECK:              %[[C0_I64_0:.*]] = arith.constant 0 : i64
-! CHECK:              %[[VAL_13:.*]] = arith.cmpi ne, %[[VAL_12]], %[[C0_I64_0]] : i64
-! CHECK:              fir.if %[[VAL_13]] {
-! CHECK:               %[[VAL_14:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:                %[[VAL_15:.*]] = fir.box_addr %[[VAL_14]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! CHECK:                fir.freemem %[[VAL_15]] : !fir.heap<!fir.array<?xi32>>
-! CHECK:                %[[VAL_16:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
-! CHECK:                %[[C0:.*]] = arith.constant 0 : index
-! CHECK:                %[[VAL_17:.*]] = fir.shape %[[C0]] : (index) -> !fir.shape<1>
-! CHECK:                %[[VAL_18:.*]] = fir.embox %[[VAL_16]](%[[VAL_17]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:                fir.store %[[VAL_18]] to %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:              }
+! CHECK:               %[[VAL_12:.*]] = fir.load %[[VAL_5]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:               %[[VAL_13:.*]] = fir.box_addr %[[VAL_12]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:               %[[VAL_14:.*]] = fir.convert %[[VAL_13]] : (!fir.heap<!fir.array<?xi32>>) -> i64
+! CHECK:               %[[VAL_15:.*]] = arith.constant 0 : i64
+! CHECK:               %[[VAL_16:.*]] = arith.cmpi ne, %[[VAL_14]], %[[VAL_15]] : i64
+! CHECK:               fir.if %[[VAL_16]] {
+! CHECK:                 %[[VAL_17:.*]] = arith.constant false
+! CHECK:                 %[[VAL_18:.*]] = fir.absent !fir.box<none>
+! CHECK:                 %[[VAL_19:.*]] = fir.address_of(@_QQclX3573f88d1792380f265b3d2ede411e3d) : !fir.ref<!fir.char<1,66>>
+! CHECK:                 %[[VAL_20:.*]] = arith.constant {{.*}} : i32
+! CHECK:                 %[[VAL_21:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:                 %[[VAL_22:.*]] = fir.convert %[[VAL_19]] : (!fir.ref<!fir.char<1,66>>) -> !fir.ref<i8>
+! CHECK:                 %[[VAL_23:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_21]], %[[VAL_17]], %[[VAL_18]], %[[VAL_22]], %[[VAL_20]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:               }
+! CHECK:             }
 ! CHECK:             omp.barrier
-! CHECK:             %[[VAL_19:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:             %[[VAL_20:.*]] = fir.box_addr %[[VAL_19]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! CHECK:             %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (!fir.heap<!fir.array<?xi32>>) -> !fir.ref<!fir.array<?xi32>>
-! CHECK:             fir.call @_QPsub8(%[[VAL_21]]) fastmath<contract> : (!fir.ref<!fir.array<?xi32>>) -> ()
+! CHECK:             %[[VAL_24:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_25:.*]] = fir.box_addr %[[VAL_24]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:             %[[VAL_26:.*]] = fir.convert %[[VAL_25]] : (!fir.heap<!fir.array<?xi32>>) -> !fir.ref<!fir.array<?xi32>>
+! CHECK:             fir.call @_QPsub8(%[[VAL_26]]) fastmath<contract> : (!fir.ref<!fir.array<?xi32>>) -> ()
 ! CHECK:             omp.terminator
 ! CHECK:           }
 ! CHECK:           return
@@ -434,12 +429,12 @@ end subroutine
 
 ! CHECK-LABEL:   func.func @_QPallocatable2() {
 ! CHECK:           %[[VAL_0:.*]] = fir.address_of(@_QFallocatable2Ea) : !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFallocatable2Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
-! CHECK:           %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>> -> !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFallocatable2Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
+! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatable2Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
+! CHECK:           %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<!fir.box<!fir.heap<i32>>> -> !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatable2Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
 ! CHECK:           omp.parallel {
-! CHECK:             %[[VAL_4:.*]] = omp.threadprivate %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>> -> !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:             %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_4]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFallocatable2Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
+! CHECK:             %[[VAL_4:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<!fir.box<!fir.heap<i32>>> -> !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:             %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_4]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatable2Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
 ! CHECK:             %[[VAL_6:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:             %[[VAL_7:.*]] = fir.box_addr %[[VAL_6]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
 ! CHECK:             %[[VAL_8:.*]] = fir.convert %[[VAL_7]] : (!fir.heap<i32>) -> i64
@@ -451,22 +446,24 @@ end subroutine
 ! CHECK:               %[[VAL_13:.*]] = fir.load %[[VAL_12]] : !fir.heap<i32>
 ! CHECK:               hlfir.assign %[[VAL_13]] to %[[VAL_5]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:             } else {
-! CHECK:               %[[VAL_11:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:               %[[VAL_15:.*]] = fir.box_addr  %[[VAL_11]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:               %[[VAL_14:.*]] = fir.load %[[VAL_5]]#1 : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:               %[[VAL_15:.*]] = fir.box_addr %[[VAL_14]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
 ! CHECK:               %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (!fir.heap<i32>) -> i64
-! CHECK:               %[[C0_I64_0:.*]] = arith.constant 0 : i64
-! CHECK:               %[[VAL_17:.*]] = arith.cmpi ne, %[[VAL_16]], %[[C0_I64_0]] : i64
-! CHECK:               fir.if %[[VAL_17]] {
-! CHECK:                 %[[VAL_18:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:                 %[[VAL_19:.*]] = fir.box_addr %[[VAL_18]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
-! CHECK:                 fir.freemem %[[VAL_19]] : !fir.heap<i32>
-! CHECK:                 %[[VAL_20:.*]] = fir.zero_bits !fir.heap<i32>
-! CHECK:                 %[[VAL_21:.*]] = fir.embox %[[VAL_20]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
-! CHECK:                 fir.store %[[VAL_21]] to %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:               %[[VAL_17:.*]] = arith.constant 0 : i64
+! CHECK:               %[[VAL_18:.*]] = arith.cmpi ne, %[[VAL_16]], %[[VAL_17]] : i64
+! CHECK:               fir.if %[[VAL_18]] {
+! CHECK:                 %[[VAL_19:.*]] = arith.constant false
+! CHECK:                 %[[VAL_20:.*]] = fir.absent !fir.box<none>
+! CHECK:                 %[[VAL_21:.*]] = fir.address_of(@_QQclX3573f88d1792380f265b3d2ede411e3d) : !fir.ref<!fir.char<1,66>>
+! CHECK:                 %[[VAL_22:.*]] = arith.constant {{.*}} : i32
+! CHECK:                 %[[VAL_23:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:                 %[[VAL_24:.*]] = fir.convert %[[VAL_21]] : (!fir.ref<!fir.char<1,66>>) -> !fir.ref<i8>
+! CHECK:                 %[[VAL_25:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_23]], %[[VAL_19]], %[[VAL_20]], %[[VAL_24]], %[[VAL_22]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:               }
+! CHECK:             }
 ! CHECK:             omp.barrier
-! CHECK:             %[[VAL_22:.*]] = arith.constant 1 : i32
-! CHECK:             hlfir.assign %[[VAL_22]] to %[[VAL_5]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:             %[[VAL_26:.*]] = arith.constant 1 : i32
+! CHECK:             hlfir.assign %[[VAL_26]] to %[[VAL_5]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:             omp.terminator
 ! CHECK:           }
 ! CHECK:           return
@@ -480,55 +477,60 @@ subroutine allocatable2()
   !$omp end parallel
 end subroutine
 
-! CHECK:    func.func @_QPallocatable3() {
-! CHECK:      %[[VAL_0:.*]] = fir.address_of(@_QFallocatable3Ea) : !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:      %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFallocatable3Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
-! CHECK:      %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>> -> !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:       %[[VAL_3:.*]]:2  = hlfir.declare %[[VAL_2]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFallocatable3Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
-! CHECK:      %[[VAL_4:.*]] = fir.allocmem i32 {fir.must_be_heap = true, uniq_name = "_QFallocatable3Ea.alloc"}
-! CHECK:      %[[VAL_5:.*]] = fir.embox %[[VAL_4]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
-! CHECK:      fir.store %[[VAL_5]] to %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:      %[[C10_I32:.*]] = arith.constant 10 : i32
-! CHECK:      hlfir.assign %[[C10_I32]] to %[[VAL_3]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:      omp.parallel {
-! CHECK:        %[[VAL_6:.*]] = omp.threadprivate %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>> -> !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:        %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_6]] {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFallocatable3Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
-! CHECK:        %[[VAL_8:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:        %[[VAL_9:.*]] = fir.box_addr %[[VAL_8]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
-! CHECK:        %[[VAL_10:.*]] = fir.convert %[[VAL_9]] : (!fir.heap<i32>) -> i64
-! CHECK:        %[[C10_I64:.*]] = arith.constant 0 : i64
-! CHECK:        %[[VAL_11:.*]] = arith.cmpi ne, %[[VAL_10]], %[[C10_I64]] : i64
-! CHECK:        fir.if %[[VAL_11]] {
-! CHECK:         %[[VAL_12:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:         %[[VAL_13:.*]] = fir.box_addr %[[VAL_12]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
-! CHECK:          %[[VAL_14:.*]] = fir.load %[[VAL_13]] : !fir.heap<i32>
-! CHECK:          hlfir.assign %[[VAL_14]] to %[[VAL_7]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:        } else {
-! CHECK:           %[[VAL_12:.*]] = fir.load %[[VAL_7]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:           %[[VAL_15:.*]] = fir.box_addr %[[VAL_12]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
-! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (!fir.heap<i32>) -> i64
-! CHECK:           %[[C0_I64_0:.*]] = arith.constant 0 : i64
-! CHECK:           %[[VAL_17:.*]] = arith.cmpi ne, %[[VAL_16]], %[[C0_I64_0]] : i64
-! CHECK:           fir.if %[[VAL_17]] {
-! CHECK:             %[[VAL_18:.*]] = fir.load %[[VAL_7]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:             %[[VAL_19:.*]] = fir.box_addr %[[VAL_18]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
-! CHECK:             fir.freemem %[[VAL_19]] : !fir.heap<i32>
-! CHECK:             %[[VAL_20:.*]] = fir.zero_bits !fir.heap<i32>
-! CHECK:             %[[VAL_21:.*]] = fir.embox %[[VAL_20]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
-! CHECK:             fir.store %[[VAL_21]] to %[[VAL_7]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK-LABEL:   func.func @_QPallocatable3() {
+! CHECK:           %[[VAL_0:.*]] = fir.address_of(@_QFallocatable3Ea) : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatable3Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
+! CHECK:           %[[VAL_2:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<!fir.box<!fir.heap<i32>>> -> !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatable3Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
+! CHECK:           %[[VAL_4:.*]] = arith.constant false
+! CHECK:           %[[VAL_5:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_6:.*]] = fir.address_of(@_QQclX3573f88d1792380f265b3d2ede411e3d) : !fir.ref<!fir.char<1,66>>
+! CHECK:           %[[VAL_7:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_8:.*]] = fir.convert %[[VAL_3]]#1 : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_9:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.char<1,66>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_10:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_8]], %[[VAL_4]], %[[VAL_5]], %[[VAL_9]], %[[VAL_7]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_11:.*]] = arith.constant 10 : i32
+! CHECK:           hlfir.assign %[[VAL_11]] to %[[VAL_3]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:           omp.parallel {
+! CHECK:             %[[VAL_12:.*]] = omp.threadprivate %[[VAL_1]]#1 : !fir.ref<!fir.box<!fir.heap<i32>>> -> !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:             %[[VAL_13:.*]]:2 = hlfir.declare %[[VAL_12]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFallocatable3Ea"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
+! CHECK:             %[[VAL_14:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:             %[[VAL_15:.*]] = fir.box_addr %[[VAL_14]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:             %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (!fir.heap<i32>) -> i64
+! CHECK:             %[[VAL_17:.*]] = arith.constant 0 : i64
+! CHECK:             %[[VAL_18:.*]] = arith.cmpi ne, %[[VAL_16]], %[[VAL_17]] : i64
+! CHECK:             fir.if %[[VAL_18]] {
+! CHECK:               %[[VAL_19:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:               %[[VAL_20:.*]] = fir.box_addr %[[VAL_19]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:               %[[VAL_21:.*]] = fir.load %[[VAL_20]] : !fir.heap<i32>
+! CHECK:               hlfir.assign %[[VAL_21]] to %[[VAL_13]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:             } else {
+! CHECK:               %[[VAL_22:.*]] = fir.load %[[VAL_13]]#1 : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:               %[[VAL_23:.*]] = fir.box_addr %[[VAL_22]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:               %[[VAL_24:.*]] = fir.convert %[[VAL_23]] : (!fir.heap<i32>) -> i64
+! CHECK:               %[[VAL_25:.*]] = arith.constant 0 : i64
+! CHECK:               %[[VAL_26:.*]] = arith.cmpi ne, %[[VAL_24]], %[[VAL_25]] : i64
+! CHECK:               fir.if %[[VAL_26]] {
+! CHECK:                 %[[VAL_27:.*]] = arith.constant false
+! CHECK:                 %[[VAL_28:.*]] = fir.absent !fir.box<none>
+! CHECK:                 %[[VAL_29:.*]] = fir.address_of(@_QQclX3573f88d1792380f265b3d2ede411e3d) : !fir.ref<!fir.char<1,66>>
+! CHECK:                 %[[VAL_30:.*]] = arith.constant {{.*}} : i32
+! CHECK:                 %[[VAL_31:.*]] = fir.convert %[[VAL_13]]#1 : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:                 %[[VAL_32:.*]] = fir.convert %[[VAL_29]] : (!fir.ref<!fir.char<1,66>>) -> !fir.ref<i8>
+! CHECK:                 %[[VAL_33:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_31]], %[[VAL_27]], %[[VAL_28]], %[[VAL_32]], %[[VAL_30]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:               }
+! CHECK:             }
+! CHECK:             omp.barrier
+! CHECK:             %[[VAL_34:.*]] = fir.load %[[VAL_13]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:             %[[VAL_35:.*]] = fir.box_addr %[[VAL_34]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:             %[[VAL_36:.*]] = fir.load %[[VAL_35]] : !fir.heap<i32>
+! CHECK:             %[[VAL_37:.*]] = arith.constant 1 : i32
+! CHECK:             %[[VAL_38:.*]] = arith.addi %[[VAL_36]], %[[VAL_37]] : i32
+! CHECK:             hlfir.assign %[[VAL_38]] to %[[VAL_13]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:             omp.terminator
 ! CHECK:           }
-! CHECK:          }
-! CHECK:        omp.barrier
-! CHECK:        %[[VAL_22:.*]] = fir.load %7#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:        %[[VAL_23:.*]] = fir.box_addr %[[VAL_22]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
-! CHECK:       %[[VAL_24:.*]] = fir.load %[[VAL_23]] : !fir.heap<i32>
-! CHECK:        %[[C1_I32:.*]] = arith.constant 1 : i32
-! CHECK:        %[[VAL_25:.*]]= arith.addi %[[VAL_24]], %[[C1_I32]] : i32
-! CHECK:        hlfir.assign %[[VAL_25]]to %[[VAL_7]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:        omp.terminator
-! CHECK:      }
-! CHECK:      return
-! CHECK:    }
+! CHECK:           return
+! CHECK:         }
 subroutine allocatable3()
   integer, allocatable, save :: a
   !$omp threadprivate(a)

--- a/flang/test/Lower/OpenMP/lastprivate-allocatable.f90
+++ b/flang/test/Lower/OpenMP/lastprivate-allocatable.f90
@@ -1,31 +1,48 @@
 ! RUN: %flang_fc1 -emit-hlfir -o - -fopenmp %s | FileCheck %s
 ! RUN: bbc -emit-hlfir -o - -fopenmp %s | FileCheck %s
 
-! CHECK-LABEL:   func.func @_QQmain()
+! CHECK-LABEL:   func.func @_QQmain() attributes {fir.bindc_name = "lastprivate_allocatable"} {
 ! CHECK:           %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.heap<i32>> {bindc_name = "a", uniq_name = "_QFEa"}
 ! CHECK:           %[[VAL_1:.*]] = fir.zero_bits !fir.heap<i32>
 ! CHECK:           %[[VAL_2:.*]] = fir.embox %[[VAL_1]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
 ! CHECK:           fir.store %[[VAL_2]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEa"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
+! CHECK:           %[[VAL_4:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFEi"}
+! CHECK:           %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_4]] {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:           omp.parallel {
-! CHECK:             omp.wsloop private(@{{.*}} %{{.*}} -> %{{.*}}, @{{.*}} %{{.*}} -> %[[VAL_17:.*]] : !fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<i32>) {
-! CHECK:               omp.loop_nest
-! CHECK:                   %[[VAL_16:.*]]:2 = hlfir.declare %{{.*}} {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEa"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
-! CHECK:                   %[[VAL_18:.*]]:2 = hlfir.declare %[[VAL_17]] {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-
-!                        [...]
-!                        if this is the last iteration
-! CHECK:                 fir.if %{{.*}} {
-!                          store loop IV
-! CHECK:                   hlfir.assign %{{.*}} to %[[VAL_18]]#0 : i32, !fir.ref<i32>
-!                          assign private variable to original copy: realloc
-! CHECK:                   %[[VAL_23:.*]] = fir.load %[[VAL_16]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:             omp.barrier
+! CHECK:             %[[VAL_6:.*]] = arith.constant 1 : i32
+! CHECK:             %[[VAL_7:.*]] = arith.constant 1 : i32
+! CHECK:             %[[VAL_8:.*]] = arith.constant 1 : i32
+! CHECK:             omp.wsloop private(@_QFEa_private_box_heap_i32 %[[VAL_3]]#0 -> %[[VAL_9:.*]], @_QFEi_private_i32 %[[VAL_5]]#0 -> %[[VAL_10:.*]] : !fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<i32>) {
+! CHECK:               omp.loop_nest (%[[VAL_11:.*]]) : i32 = (%[[VAL_6]]) to (%[[VAL_7]]) inclusive step (%[[VAL_8]]) {
+! CHECK:                 %[[VAL_12:.*]]:2 = hlfir.declare %[[VAL_9]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEa"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
+! CHECK:                 %[[VAL_13:.*]]:2 = hlfir.declare %[[VAL_10]] {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:                 hlfir.assign %[[VAL_11]] to %[[VAL_13]]#0 : i32, !fir.ref<i32>
+! CHECK:                 %[[VAL_14:.*]] = arith.constant 42 : i32
+! CHECK:                 hlfir.assign %[[VAL_14]] to %[[VAL_12]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:                 %[[VAL_15:.*]] = arith.constant 1 : i32
+! CHECK:                 %[[VAL_16:.*]] = arith.constant 1 : i32
+! CHECK:                 %[[VAL_17:.*]] = arith.addi %[[VAL_11]], %[[VAL_16]] : i32
+! CHECK:                 %[[VAL_18:.*]] = arith.constant 0 : i32
+! CHECK:                 %[[VAL_19:.*]] = arith.cmpi slt, %[[VAL_16]], %[[VAL_18]] : i32
+! CHECK:                 %[[VAL_20:.*]] = arith.cmpi slt, %[[VAL_17]], %[[VAL_15]] : i32
+! CHECK:                 %[[VAL_21:.*]] = arith.cmpi sgt, %[[VAL_17]], %[[VAL_15]] : i32
+! CHECK:                 %[[VAL_22:.*]] = arith.select %[[VAL_19]], %[[VAL_20]], %[[VAL_21]] : i1
+! CHECK:                 fir.if %[[VAL_22]] {
+! CHECK:                   hlfir.assign %[[VAL_17]] to %[[VAL_13]]#0 : i32, !fir.ref<i32>
+! CHECK:                   %[[VAL_23:.*]] = fir.load %[[VAL_12]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:                   %[[VAL_24:.*]] = fir.box_addr %[[VAL_23]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
 ! CHECK:                   %[[VAL_25:.*]] = fir.load %[[VAL_24]] : !fir.heap<i32>
 ! CHECK:                   hlfir.assign %[[VAL_25]] to %[[VAL_3]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK-NEXT:            }
-! CHECK-NEXT:            omp.yield
-! CHECK-NEXT:          }
+! CHECK:                 }
+! CHECK:                 omp.yield
+! CHECK:               }
+! CHECK:             }
+! CHECK:             omp.terminator
+! CHECK:           }
+! CHECK:           return
+! CHECK:         }
 program lastprivate_allocatable
   integer, allocatable :: a
   integer :: i
@@ -38,23 +55,115 @@ program lastprivate_allocatable
   ! a should be allocated here
 end program
 
-! CHECK-LABEL:  func @_QPlastprivate_realloc()
-! CHECK:          %[[A:.*]]:2 = hlfir.declare %{{.*}} {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFlastprivate_reallocEa"} :
-! CHECK-SAME:       (!fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>) ->
-! CHECK-SAME:       (!fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>)
-! CHECK:          omp.parallel {
-! CHECK:            %[[A_PRIV:.*]]:2 = hlfir.declare %{{.*}} {fortran_attrs = #fir.var_attrs<allocatable>, uniq_name = "_QFlastprivate_reallocEa"} :
-! CHECK-SAME:         (!fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>) ->
-! CHECK-SAME:         (!fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>)
-! CHECK:            omp.sections {
-! CHECK:              omp.section {
-! CHECK:                fir.load
-! CHECK:                %[[TEMP:.*]] = fir.load %[[A_PRIV:.*]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>
-! CHECK:                hlfir.assign %[[TEMP]] to %[[A]]#0 realloc : !fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>,
-! CHECK-SAME:             !fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>
-! CHECK:              }
-! CHECK:            }
-! CHECK:          }
+! CHECK-LABEL:   func.func @_QPlastprivate_realloc() {
+! CHECK:           %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>> {bindc_name = "a", uniq_name = "_QFlastprivate_reallocEa"}
+! CHECK:           %[[VAL_1:.*]] = fir.zero_bits !fir.heap<!fir.array<?xcomplex<f32>>>
+! CHECK:           %[[VAL_2:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_3:.*]] = fir.shape %[[VAL_2]] : (index) -> !fir.shape<1>
+! CHECK:           %[[VAL_4:.*]] = fir.embox %[[VAL_1]](%[[VAL_3]]) : (!fir.heap<!fir.array<?xcomplex<f32>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>
+! CHECK:           fir.store %[[VAL_4]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>
+! CHECK:           %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_0]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFlastprivate_reallocEa"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>)
+! CHECK:           %[[VAL_6:.*]] = arith.constant false
+! CHECK:           %[[VAL_7:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_8:.*]] = fir.address_of(@_QQclX9c577f22af2c5c17f89170ff454cf10e) : !fir.ref<!fir.char<1,83>>
+! CHECK:           %[[VAL_9:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_10:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_11:.*]] = arith.constant 2 : i32
+! CHECK:           %[[VAL_12:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_13:.*]] = fir.convert %[[VAL_5]]#0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_10]] : (index) -> i64
+! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_11]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_13]], %[[VAL_12]], %[[VAL_14]], %[[VAL_15]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_5]]#0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_8]] : (!fir.ref<!fir.char<1,83>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_18:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_16]], %[[VAL_6]], %[[VAL_7]], %[[VAL_17]], %[[VAL_9]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           omp.parallel {
+! CHECK:             %[[VAL_19:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>> {bindc_name = "a", pinned, uniq_name = "_QFlastprivate_reallocEa"}
+! CHECK:             %[[VAL_20:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>
+! CHECK:             %[[VAL_21:.*]] = fir.box_addr %[[VAL_20]] : (!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>) -> !fir.heap<!fir.array<?xcomplex<f32>>>
+! CHECK:             %[[VAL_22:.*]] = fir.convert %[[VAL_21]] : (!fir.heap<!fir.array<?xcomplex<f32>>>) -> i64
+! CHECK:             %[[VAL_23:.*]] = arith.constant 0 : i64
+! CHECK:             %[[VAL_24:.*]] = arith.cmpi ne, %[[VAL_22]], %[[VAL_23]] : i64
+! CHECK:             fir.if %[[VAL_24]] {
+! CHECK:               %[[VAL_25:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>
+! CHECK:               %[[VAL_26:.*]] = arith.constant 0 : index
+! CHECK:               %[[VAL_27:.*]]:3 = fir.box_dims %[[VAL_25]], %[[VAL_26]] : (!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>, index) -> (index, index, index)
+! CHECK:               %[[VAL_28:.*]] = arith.constant 0 : index
+! CHECK:               %[[VAL_29:.*]] = arith.cmpi sgt, %[[VAL_27]]#1, %[[VAL_28]] : index
+! CHECK:               %[[VAL_30:.*]] = arith.select %[[VAL_29]], %[[VAL_27]]#1, %[[VAL_28]] : index
+! CHECK:               %[[VAL_31:.*]] = fir.allocmem !fir.array<?xcomplex<f32>>, %[[VAL_30]] {fir.must_be_heap = true, uniq_name = "_QFlastprivate_reallocEa.alloc"}
+! CHECK:               %[[VAL_32:.*]] = fir.shape_shift %[[VAL_27]]#0, %[[VAL_30]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:               %[[VAL_33:.*]] = fir.embox %[[VAL_31]](%[[VAL_32]]) : (!fir.heap<!fir.array<?xcomplex<f32>>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>
+! CHECK:               fir.store %[[VAL_33]] to %[[VAL_19]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>
+! CHECK:             } else {
+! CHECK:               %[[VAL_34:.*]] = fir.zero_bits !fir.heap<!fir.array<?xcomplex<f32>>>
+! CHECK:               %[[VAL_35:.*]] = arith.constant 0 : index
+! CHECK:               %[[VAL_36:.*]] = fir.shape %[[VAL_35]] : (index) -> !fir.shape<1>
+! CHECK:               %[[VAL_37:.*]] = fir.embox %[[VAL_34]](%[[VAL_36]]) : (!fir.heap<!fir.array<?xcomplex<f32>>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>
+! CHECK:               fir.store %[[VAL_37]] to %[[VAL_19]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>
+! CHECK:             }
+! CHECK:             %[[VAL_38:.*]]:2 = hlfir.declare %[[VAL_19]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFlastprivate_reallocEa"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>)
+! CHECK:             omp.sections {
+! CHECK:               omp.section {
+! CHECK:                 %[[VAL_39:.*]] = arith.constant false
+! CHECK:                 %[[VAL_40:.*]] = fir.absent !fir.box<none>
+! CHECK:                 %[[VAL_41:.*]] = fir.address_of(@_QQclX9c577f22af2c5c17f89170ff454cf10e) : !fir.ref<!fir.char<1,83>>
+! CHECK:                 %[[VAL_42:.*]] = arith.constant {{.*}} : i32
+! CHECK:                 %[[VAL_43:.*]] = fir.convert %[[VAL_38]]#0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:                 %[[VAL_44:.*]] = fir.convert %[[VAL_41]] : (!fir.ref<!fir.char<1,83>>) -> !fir.ref<i8>
+! CHECK:                 %[[VAL_45:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_43]], %[[VAL_39]], %[[VAL_40]], %[[VAL_44]], %[[VAL_42]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:                 %[[VAL_46:.*]] = arith.constant false
+! CHECK:                 %[[VAL_47:.*]] = fir.absent !fir.box<none>
+! CHECK:                 %[[VAL_48:.*]] = fir.address_of(@_QQclX9c577f22af2c5c17f89170ff454cf10e) : !fir.ref<!fir.char<1,83>>
+! CHECK:                 %[[VAL_49:.*]] = arith.constant {{.*}} : i32
+! CHECK:                 %[[VAL_50:.*]] = arith.constant 1 : index
+! CHECK:                 %[[VAL_51:.*]] = arith.constant 3 : i32
+! CHECK:                 %[[VAL_52:.*]] = arith.constant 0 : i32
+! CHECK:                 %[[VAL_53:.*]] = fir.convert %[[VAL_38]]#0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:                 %[[VAL_54:.*]] = fir.convert %[[VAL_50]] : (index) -> i64
+! CHECK:                 %[[VAL_55:.*]] = fir.convert %[[VAL_51]] : (i32) -> i64
+! CHECK:                 fir.call @_FortranAAllocatableSetBounds(%[[VAL_53]], %[[VAL_52]], %[[VAL_54]], %[[VAL_55]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:                 %[[VAL_56:.*]] = fir.convert %[[VAL_38]]#0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:                 %[[VAL_57:.*]] = fir.convert %[[VAL_48]] : (!fir.ref<!fir.char<1,83>>) -> !fir.ref<i8>
+! CHECK:                 %[[VAL_58:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_56]], %[[VAL_46]], %[[VAL_47]], %[[VAL_57]], %[[VAL_49]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:                 %[[VAL_59:.*]] = fir.load %[[VAL_38]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>
+! CHECK:                 hlfir.assign %[[VAL_59]] to %[[VAL_5]]#0 realloc : !fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>
+! CHECK:                 omp.terminator
+! CHECK:               }
+! CHECK:               omp.terminator
+! CHECK:             }
+! CHECK:             %[[VAL_60:.*]] = fir.load %[[VAL_38]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>
+! CHECK:             %[[VAL_61:.*]] = fir.box_addr %[[VAL_60]] : (!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>) -> !fir.heap<!fir.array<?xcomplex<f32>>>
+! CHECK:             %[[VAL_62:.*]] = fir.convert %[[VAL_61]] : (!fir.heap<!fir.array<?xcomplex<f32>>>) -> i64
+! CHECK:             %[[VAL_63:.*]] = arith.constant 0 : i64
+! CHECK:             %[[VAL_64:.*]] = arith.cmpi ne, %[[VAL_62]], %[[VAL_63]] : i64
+! CHECK:             fir.if %[[VAL_64]] {
+! CHECK:               %[[VAL_65:.*]] = arith.constant false
+! CHECK:               %[[VAL_66:.*]] = fir.absent !fir.box<none>
+! CHECK:               %[[VAL_67:.*]] = fir.address_of(@_QQclX9c577f22af2c5c17f89170ff454cf10e) : !fir.ref<!fir.char<1,83>>
+! CHECK:               %[[VAL_68:.*]] = arith.constant {{.*}} : i32
+! CHECK:               %[[VAL_69:.*]] = fir.convert %[[VAL_38]]#0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:               %[[VAL_70:.*]] = fir.convert %[[VAL_67]] : (!fir.ref<!fir.char<1,83>>) -> !fir.ref<i8>
+! CHECK:               %[[VAL_71:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_69]], %[[VAL_65]], %[[VAL_66]], %[[VAL_70]], %[[VAL_68]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:             }
+! CHECK:             omp.terminator
+! CHECK:           }
+! CHECK:           %[[VAL_72:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>
+! CHECK:           %[[VAL_73:.*]] = fir.box_addr %[[VAL_72]] : (!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>) -> !fir.heap<!fir.array<?xcomplex<f32>>>
+! CHECK:           %[[VAL_74:.*]] = fir.convert %[[VAL_73]] : (!fir.heap<!fir.array<?xcomplex<f32>>>) -> i64
+! CHECK:           %[[VAL_75:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_76:.*]] = arith.cmpi ne, %[[VAL_74]], %[[VAL_75]] : i64
+! CHECK:           fir.if %[[VAL_76]] {
+! CHECK:             %[[VAL_77:.*]] = arith.constant false
+! CHECK:             %[[VAL_78:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_79:.*]] = fir.address_of(@_QQclX9c577f22af2c5c17f89170ff454cf10e) : !fir.ref<!fir.char<1,83>>
+! CHECK:             %[[VAL_80:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_81:.*]] = fir.convert %[[VAL_5]]#0 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xcomplex<f32>>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_82:.*]] = fir.convert %[[VAL_79]] : (!fir.ref<!fir.char<1,83>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_83:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_81]], %[[VAL_77]], %[[VAL_78]], %[[VAL_82]], %[[VAL_80]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           }
+! CHECK:           return
+! CHECK:         }
 subroutine lastprivate_realloc()
   complex, allocatable :: a(:)
 

--- a/flang/test/Lower/OpenMP/parallel-reduction-allocatable-array.f90
+++ b/flang/test/Lower/OpenMP/parallel-reduction-allocatable-array.f90
@@ -92,11 +92,11 @@ end program
 ! CHECK:           %[[VAL_8:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_9:.*]] = arith.constant 2 : i32
 ! CHECK:           %[[VAL_10:.*]] = arith.constant 0 : i32
-! CHECK:           %[[VAL_11:.*]] = fir.convert %[[VAL_3]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_11:.*]] = fir.convert %[[VAL_3]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_12:.*]] = fir.convert %[[VAL_8]] : (index) -> i64
 ! CHECK:           %[[VAL_13:.*]] = fir.convert %[[VAL_9]] : (i32) -> i64
 ! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_11]], %[[VAL_10]], %[[VAL_12]], %[[VAL_13]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
-! CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_3]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_3]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.char<1,96>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_16:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_14]], %[[VAL_4]], %[[VAL_5]], %[[VAL_15]], %[[VAL_7]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:           omp.parallel {
@@ -107,7 +107,7 @@ end program
 ! CHECK:               omp.loop_nest (%[[VAL_22:.*]]) : i32 = (%[[VAL_17]]) to (%[[VAL_18]]) inclusive step (%[[VAL_19]]) {
 ! CHECK:                 %[[VAL_23:.*]]:2 = hlfir.declare %[[VAL_20]] {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:                 %[[VAL_24:.*]]:2 = hlfir.declare %[[VAL_21]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEr"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
-! CHECK:                 hlfir.assign %[[VAL_22]] to %[[VAL_23]]#1 : i32, !fir.ref<i32>
+! CHECK:                 hlfir.assign %[[VAL_22]] to %[[VAL_23]]{{.*}} : i32, !fir.ref<i32>
 ! CHECK:                 %[[VAL_25:.*]] = fir.load %[[VAL_23]]#0 : !fir.ref<i32>
 ! CHECK:                 %[[VAL_26:.*]] = fir.load %[[VAL_24]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:                 %[[VAL_27:.*]] = arith.constant 1 : index
@@ -130,7 +130,7 @@ end program
 ! CHECK:           %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (!fir.ref<!fir.char<1,96>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_38:.*]] = arith.constant 17 : i32
 ! CHECK:           %[[VAL_39:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_35]], %[[VAL_37]], %[[VAL_38]]) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:           %[[VAL_40:.*]] = fir.load %[[VAL_3]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_40:.*]] = fir.load %[[VAL_3]]{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_41:.*]] = fir.convert %[[VAL_40]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_42:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_39]], %[[VAL_41]]) fastmath<contract> : (!fir.ref<i8>, !fir.box<none>) -> i1
 ! CHECK:           %[[VAL_43:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_39]]) fastmath<contract> : (!fir.ref<i8>) -> i32

--- a/flang/test/Lower/OpenMP/parallel-reduction-allocatable-array.f90
+++ b/flang/test/Lower/OpenMP/parallel-reduction-allocatable-array.f90
@@ -19,38 +19,38 @@ print *,r
 end program
 
 ! CHECK-LABEL:   omp.declare_reduction @add_reduction_byref_box_heap_Uxi32 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> alloc {
-! CHECK:           %[[VAL_10:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:           omp.yield(%[[VAL_10]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
+! CHECK:           %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           omp.yield(%[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK-LABEL:   } init {
-! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, %[[ALLOC:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>):
-! CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
-! CHECK:           %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:           %[[ADDR:.*]] = fir.box_addr %[[VAL_2]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! CHECK:           %[[ADDRI:.*]] = fir.convert %[[ADDR]] : (!fir.heap<!fir.array<?xi32>>) -> i64
-! CHECK:           %[[C0_I64:.*]] = arith.constant 0 : i64
-! CHECK:           %[[IS_NULL:.*]] = arith.cmpi eq, %[[ADDRI]], %[[C0_I64]] : i64
-! CHECK:           fir.if %[[IS_NULL]] {
-! CHECK:             %[[C0_INDEX:.*]] = arith.constant 0 : index
-! CHECK:             %[[SHAPE:.*]] = fir.shape %[[C0_INDEX]]
-! CHECK:             %[[NULL_BOX:.*]] = fir.embox %[[ADDR]](%[[SHAPE]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:             fir.store %[[NULL_BOX]] to %[[ALLOC]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.heap<
+! CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_3:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_4:.*]] = fir.box_addr %[[VAL_3]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:           %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (!fir.heap<!fir.array<?xi32>>) -> i64
+! CHECK:           %[[VAL_6:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_7:.*]] = arith.cmpi eq, %[[VAL_5]], %[[VAL_6]] : i64
+! CHECK:           fir.if %[[VAL_7]] {
+! CHECK:             %[[VAL_8:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_9:.*]] = fir.shape %[[VAL_8]] : (index) -> !fir.shape<1>
+! CHECK:             %[[VAL_10:.*]] = fir.embox %[[VAL_4]](%[[VAL_9]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_10]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           } else {
-! CHECK:             %[[VAL_3:.*]] = arith.constant 0 : index
-! CHECK:             %[[VAL_4:.*]]:3 = fir.box_dims %[[VAL_2]], %[[VAL_3]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:             %[[VAL_5:.*]] = fir.shape %[[VAL_4]]#1 : (index) -> !fir.shape<1>
-! CHECK:             %[[VAL_6:.*]] = fir.allocmem !fir.array<?xi32>, %[[VAL_4]]#1 {bindc_name = ".tmp", uniq_name = ""}
-! CHECK:             %[[VAL_7:.*]] = arith.constant true
-! CHECK:             %[[VAL_8:.*]]:2 = hlfir.declare %[[VAL_6]](%[[VAL_5]]) {uniq_name = ".tmp"} : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> (!fir.box<!fir.array<?xi32>>, !fir.heap<!fir.array<?xi32>>)
-! CHECK:             %[[C0:.*]] = arith.constant 0 : index
-! CHECK:             %[[DIMS:.*]]:3 = fir.box_dims %[[VAL_2]], %[[C0]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:             %[[SHIFT:.*]] = fir.shape_shift %[[DIMS]]#0, %[[DIMS]]#1 : (index, index) -> !fir.shapeshift<1>
-! CHECK:             %[[REBOX:.*]] = fir.rebox %[[VAL_8]]#0(%[[SHIFT]]) : (!fir.box<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:             hlfir.assign %[[VAL_1]] to %[[REBOX]] : i32, !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:             fir.store %[[REBOX]] to %[[ALLOC]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_11:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_12:.*]]:3 = fir.box_dims %[[VAL_3]], %[[VAL_11]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_13:.*]] = fir.shape %[[VAL_12]]#1 : (index) -> !fir.shape<1>
+! CHECK:             %[[VAL_14:.*]] = fir.allocmem !fir.array<?xi32>, %[[VAL_12]]#1 {bindc_name = ".tmp", uniq_name = ""}
+! CHECK:             %[[VAL_15:.*]] = arith.constant true
+! CHECK:             %[[VAL_16:.*]]:2 = hlfir.declare %[[VAL_14]](%[[VAL_13]]) {uniq_name = ".tmp"} : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> (!fir.box<!fir.array<?xi32>>, !fir.heap<!fir.array<?xi32>>)
+! CHECK:             %[[VAL_17:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_18:.*]]:3 = fir.box_dims %[[VAL_3]], %[[VAL_17]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_19:.*]] = fir.shape_shift %[[VAL_18]]#0, %[[VAL_18]]#1 : (index, index) -> !fir.shapeshift<1>
+! CHECK:             %[[VAL_20:.*]] = fir.rebox %[[VAL_16]]#0(%[[VAL_19]]) : (!fir.box<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             hlfir.assign %[[VAL_2]] to %[[VAL_20]] : i32, !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_20]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           }
-! CHECK:           omp.yield(%[[ALLOC]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
-! CHECK:         } combiner {
-! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>):
+! CHECK:           omp.yield(%[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
+! CHECK-LABEL:   } combiner {
+! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.heap<
 ! CHECK:           %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_3:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_4:.*]] = arith.constant 0 : index
@@ -67,8 +67,8 @@ end program
 ! CHECK:             fir.store %[[VAL_13]] to %[[VAL_9]] : !fir.ref<i32>
 ! CHECK:           }
 ! CHECK:           omp.yield(%[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
-! CHECK:         }  cleanup {
-! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>):
+! CHECK-LABEL:   } cleanup {
+! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<
 ! CHECK:           %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_2:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
 ! CHECK:           %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.heap<!fir.array<?xi32>>) -> i64
@@ -85,38 +85,54 @@ end program
 ! CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %[[VAL_0]] {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:           %[[VAL_2:.*]] = fir.address_of(@_QFEr) : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_3:.*]]:2 = hlfir.declare %[[VAL_2]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEr"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
-! CHECK:           %[[VAL_4:.*]] = arith.constant 2 : i32
-! CHECK:           %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (i32) -> index
-! CHECK:           %[[VAL_6:.*]] = arith.constant 0 : index
-! CHECK:           %[[VAL_7:.*]] = arith.cmpi sgt, %[[VAL_5]], %[[VAL_6]] : index
-! CHECK:           %[[VAL_8:.*]] = arith.select %[[VAL_7]], %[[VAL_5]], %[[VAL_6]] : index
-! CHECK:           %[[VAL_9:.*]] = fir.allocmem !fir.array<?xi32>, %[[VAL_8]] {fir.must_be_heap = true, uniq_name = "_QFEr.alloc"}
-! CHECK:           %[[VAL_10:.*]] = fir.shape %[[VAL_8]] : (index) -> !fir.shape<1>
-! CHECK:           %[[VAL_11:.*]] = fir.embox %[[VAL_9]](%[[VAL_10]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:           fir.store %[[VAL_11]] to %[[VAL_3]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_4:.*]] = arith.constant false
+! CHECK:           %[[VAL_5:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_6:.*]] = fir.address_of(@_QQclX631fe30e1f6e089e15ae2bda4e306e13) : !fir.ref<!fir.char<1,96>>
+! CHECK:           %[[VAL_7:.*]] = arith.constant 8 : i32
+! CHECK:           %[[VAL_8:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_9:.*]] = arith.constant 2 : i32
+! CHECK:           %[[VAL_10:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_11:.*]] = fir.convert %[[VAL_3]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_12:.*]] = fir.convert %[[VAL_8]] : (index) -> i64
+! CHECK:           %[[VAL_13:.*]] = fir.convert %[[VAL_9]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_11]], %[[VAL_10]], %[[VAL_12]], %[[VAL_13]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_3]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_6]] : (!fir.ref<!fir.char<1,96>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_16:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_14]], %[[VAL_4]], %[[VAL_5]], %[[VAL_15]], %[[VAL_7]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:           omp.parallel {
-! CHECK:             %[[VAL_14:.*]] = arith.constant 0 : i32
-! CHECK:             %[[VAL_15:.*]] = arith.constant 10 : i32
-! CHECK:             %[[VAL_16:.*]] = arith.constant 1 : i32
-! CHECK:             omp.wsloop private(@{{.*}} %{{.*}}#0 -> %[[VAL_12:.*]] : !fir.ref<i32>) reduction(byref @add_reduction_byref_box_heap_Uxi32 %[[VAL_3]]#0 -> %[[VAL_17:.*]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) {
-! CHECK-NEXT:          omp.loop_nest (%[[VAL_18:.*]]) : i32 = (%[[VAL_14]]) to (%[[VAL_15]]) inclusive step (%[[VAL_16]]) {
-! CHECK:                 %[[VAL_13:.*]]:2 = hlfir.declare %[[VAL_12]] {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:                 %[[VAL_19:.*]]:2 = hlfir.declare %[[VAL_17]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEr"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
-! CHECK:                 hlfir.assign %[[VAL_18]] to %[[VAL_13]]#0 : i32, !fir.ref<i32>
-! CHECK:                 %[[VAL_20:.*]] = fir.load %[[VAL_13]]#0 : !fir.ref<i32>
-! CHECK:                 %[[VAL_21:.*]] = fir.load %[[VAL_19]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:                 %[[VAL_22:.*]] = arith.constant 1 : index
-! CHECK:                 %[[VAL_23:.*]] = hlfir.designate %[[VAL_21]] (%[[VAL_22]])  : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> !fir.ref<i32>
-! CHECK:                 hlfir.assign %[[VAL_20]] to %[[VAL_23]] : i32, !fir.ref<i32>
-! CHECK:                 %[[VAL_24:.*]] = fir.load %[[VAL_13]]#0 : !fir.ref<i32>
-! CHECK:                 %[[VAL_25:.*]] = arith.constant 0 : i32
-! CHECK:                 %[[VAL_26:.*]] = arith.subi %[[VAL_25]], %[[VAL_24]] : i32
-! CHECK:                 %[[VAL_27:.*]] = fir.load %[[VAL_19]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:                 %[[VAL_28:.*]] = arith.constant 2 : index
-! CHECK:                 %[[VAL_29:.*]] = hlfir.designate %[[VAL_27]] (%[[VAL_28]])  : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> !fir.ref<i32>
-! CHECK:                 hlfir.assign %[[VAL_26]] to %[[VAL_29]] : i32, !fir.ref<i32>
+! CHECK:             %[[VAL_17:.*]] = arith.constant 0 : i32
+! CHECK:             %[[VAL_18:.*]] = arith.constant 10 : i32
+! CHECK:             %[[VAL_19:.*]] = arith.constant 1 : i32
+! CHECK:             omp.wsloop private(@_QFEi_private_i32 %[[VAL_1]]#0 -> %[[VAL_20:.*]] : !fir.ref<i32>) reduction(byref @add_reduction_byref_box_heap_Uxi32 %[[VAL_3]]#0 -> %[[VAL_21:.*]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) {
+! CHECK:               omp.loop_nest (%[[VAL_22:.*]]) : i32 = (%[[VAL_17]]) to (%[[VAL_18]]) inclusive step (%[[VAL_19]]) {
+! CHECK:                 %[[VAL_23:.*]]:2 = hlfir.declare %[[VAL_20]] {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:                 %[[VAL_24:.*]]:2 = hlfir.declare %[[VAL_21]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEr"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
+! CHECK:                 hlfir.assign %[[VAL_22]] to %[[VAL_23]]#1 : i32, !fir.ref<i32>
+! CHECK:                 %[[VAL_25:.*]] = fir.load %[[VAL_23]]#0 : !fir.ref<i32>
+! CHECK:                 %[[VAL_26:.*]] = fir.load %[[VAL_24]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:                 %[[VAL_27:.*]] = arith.constant 1 : index
+! CHECK:                 %[[VAL_28:.*]] = hlfir.designate %[[VAL_26]] (%[[VAL_27]])  : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> !fir.ref<i32>
+! CHECK:                 hlfir.assign %[[VAL_25]] to %[[VAL_28]] : i32, !fir.ref<i32>
+! CHECK:                 %[[VAL_29:.*]] = fir.load %[[VAL_23]]#0 : !fir.ref<i32>
+! CHECK:                 %[[VAL_30:.*]] = arith.constant 0 : i32
+! CHECK:                 %[[VAL_31:.*]] = arith.subi %[[VAL_30]], %[[VAL_29]] : i32
+! CHECK:                 %[[VAL_32:.*]] = fir.load %[[VAL_24]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:                 %[[VAL_33:.*]] = arith.constant 2 : index
+! CHECK:                 %[[VAL_34:.*]] = hlfir.designate %[[VAL_32]] (%[[VAL_33]])  : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> !fir.ref<i32>
+! CHECK:                 hlfir.assign %[[VAL_31]] to %[[VAL_34]] : i32, !fir.ref<i32>
 ! CHECK:                 omp.yield
 ! CHECK:               }
 ! CHECK:             }
 ! CHECK:             omp.terminator
 ! CHECK:           }
+! CHECK:           %[[VAL_35:.*]] = arith.constant 6 : i32
+! CHECK:           %[[VAL_36:.*]] = fir.address_of(@_QQclX631fe30e1f6e089e15ae2bda4e306e13) : !fir.ref<!fir.char<1,96>>
+! CHECK:           %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (!fir.ref<!fir.char<1,96>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_38:.*]] = arith.constant 17 : i32
+! CHECK:           %[[VAL_39:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_35]], %[[VAL_37]], %[[VAL_38]]) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_40:.*]] = fir.load %[[VAL_3]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_41:.*]] = fir.convert %[[VAL_40]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.box<none>
+! CHECK:           %[[VAL_42:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_39]], %[[VAL_41]]) fastmath<contract> : (!fir.ref<i8>, !fir.box<none>) -> i1
+! CHECK:           %[[VAL_43:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_39]]) fastmath<contract> : (!fir.ref<i8>) -> i32
+! CHECK:           return
+! CHECK:         }

--- a/flang/test/Lower/OpenMP/parallel-reduction-mixed.f90
+++ b/flang/test/Lower/OpenMP/parallel-reduction-mixed.f90
@@ -36,7 +36,7 @@ end subroutine proc
 
 !CHECK: [[MALLOC_BB]]:
 !CHECK-NOT: omp.par.{{.*}}:
-!CHECK: call ptr @malloc(i{{(32)|(64)}} 80)
+!CHECK: call i32 @_FortranAAllocatableAllocate
 
 !CHECK: %[[RED_ARR_0:.*]] = getelementptr inbounds [2 x ptr], ptr %red.array, i64 0, i64 0
 !CHECK: store ptr %[[F_priv]], ptr %[[RED_ARR_0:.*]]

--- a/flang/test/Lower/OpenMP/wsloop-reduction-allocatable-array-minmax.f90
+++ b/flang/test/Lower/OpenMP/wsloop-reduction-allocatable-array-minmax.f90
@@ -33,38 +33,38 @@ program reduce15
 end program
 
 ! CHECK-LABEL:   omp.declare_reduction @min_byref_box_heap_Uxi32 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> alloc {
-! CHECK:           %[[VAL_3:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:           omp.yield(%[[VAL_3]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
+! CHECK:           %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:          omp.yield(%[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK-LABEL:   } init {
-! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, %[[ALLOC:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>):
-! CHECK:           %[[VAL_1:.*]] = arith.constant 2147483647 : i32
-! CHECK:           %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:           %[[VAL_4:.*]] = fir.box_addr %[[VAL_2]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.heap<
+! CHECK:           %[[VAL_2:.*]] = arith.constant 2147483647 : i32
+! CHECK:           %[[VAL_3:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_4:.*]] = fir.box_addr %[[VAL_3]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
 ! CHECK:           %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (!fir.heap<!fir.array<?xi32>>) -> i64
 ! CHECK:           %[[VAL_6:.*]] = arith.constant 0 : i64
 ! CHECK:           %[[VAL_7:.*]] = arith.cmpi eq, %[[VAL_5]], %[[VAL_6]] : i64
 ! CHECK:           fir.if %[[VAL_7]] {
-! CHECK:             %[[C0:.*]] = arith.constant 0 : index
-! CHECK:             %[[SHAPE:.*]] = fir.shape %[[C0]]
-! CHECK:             %[[VAL_8:.*]] = fir.embox %[[VAL_4]](%[[SHAPE]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:             fir.store %[[VAL_8]] to %[[ALLOC]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_8:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_9:.*]] = fir.shape %[[VAL_8]] : (index) -> !fir.shape<1>
+! CHECK:             %[[VAL_10:.*]] = fir.embox %[[VAL_4]](%[[VAL_9]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_10]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           } else {
-! CHECK:             %[[VAL_9:.*]] = arith.constant 0 : index
-! CHECK:             %[[VAL_10:.*]]:3 = fir.box_dims %[[VAL_2]], %[[VAL_9]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:             %[[VAL_11:.*]] = fir.shape %[[VAL_10]]#1 : (index) -> !fir.shape<1>
-! CHECK:             %[[VAL_12:.*]] = fir.allocmem !fir.array<?xi32>, %[[VAL_10]]#1 {bindc_name = ".tmp", uniq_name = ""}
-! CHECK:             %[[VAL_13:.*]] = arith.constant true
-! CHECK:             %[[VAL_14:.*]]:2 = hlfir.declare %[[VAL_12]](%[[VAL_11]]) {uniq_name = ".tmp"} : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> (!fir.box<!fir.array<?xi32>>, !fir.heap<!fir.array<?xi32>>)
-! CHECK:             %[[VAL_15:.*]] = arith.constant 0 : index
-! CHECK:             %[[VAL_16:.*]]:3 = fir.box_dims %[[VAL_2]], %[[VAL_15]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:             %[[VAL_17:.*]] = fir.shape_shift %[[VAL_16]]#0, %[[VAL_16]]#1 : (index, index) -> !fir.shapeshift<1>
-! CHECK:             %[[VAL_18:.*]] = fir.rebox %[[VAL_14]]#0(%[[VAL_17]]) : (!fir.box<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:             hlfir.assign %[[VAL_1]] to %[[VAL_18]] : i32, !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:             fir.store %[[VAL_18]] to %[[ALLOC]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_11:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_12:.*]]:3 = fir.box_dims %[[VAL_3]], %[[VAL_11]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_13:.*]] = fir.shape %[[VAL_12]]#1 : (index) -> !fir.shape<1>
+! CHECK:             %[[VAL_14:.*]] = fir.allocmem !fir.array<?xi32>, %[[VAL_12]]#1 {bindc_name = ".tmp", uniq_name = ""}
+! CHECK:             %[[VAL_15:.*]] = arith.constant true
+! CHECK:             %[[VAL_16:.*]]:2 = hlfir.declare %[[VAL_14]](%[[VAL_13]]) {uniq_name = ".tmp"} : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> (!fir.box<!fir.array<?xi32>>, !fir.heap<!fir.array<?xi32>>)
+! CHECK:             %[[VAL_17:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_18:.*]]:3 = fir.box_dims %[[VAL_3]], %[[VAL_17]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_19:.*]] = fir.shape_shift %[[VAL_18]]#0, %[[VAL_18]]#1 : (index, index) -> !fir.shapeshift<1>
+! CHECK:             %[[VAL_20:.*]] = fir.rebox %[[VAL_16]]#0(%[[VAL_19]]) : (!fir.box<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             hlfir.assign %[[VAL_2]] to %[[VAL_20]] : i32, !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_20]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           }
-! CHECK:           omp.yield(%[[ALLOC]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
+! CHECK:           omp.yield(%[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK-LABEL:   } combiner {
-! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>):
+! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.heap<
 ! CHECK:           %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_3:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_4:.*]] = arith.constant 0 : index
@@ -81,8 +81,8 @@ end program
 ! CHECK:             fir.store %[[VAL_13]] to %[[VAL_9]] : !fir.ref<i32>
 ! CHECK:           }
 ! CHECK:           omp.yield(%[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
-! CHECK-LABEL:   }  cleanup {
-! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>):
+! CHECK-LABEL:   } cleanup {
+! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<
 ! CHECK:           %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_2:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
 ! CHECK:           %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.heap<!fir.array<?xi32>>) -> i64
@@ -95,38 +95,38 @@ end program
 ! CHECK:         }
 
 ! CHECK-LABEL:   omp.declare_reduction @max_byref_box_heap_Uxi32 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> alloc {
-! CHECK:           %[[VAL_3:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:           omp.yield(%[[VAL_3]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
+! CHECK:           %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:           omp.yield(%[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK-LABEL:   } init {
-! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, %[[ALLOC:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>):
-! CHECK:           %[[VAL_1:.*]] = arith.constant -2147483648 : i32
-! CHECK:           %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:           %[[VAL_4:.*]] = fir.box_addr %[[VAL_2]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.heap<
+! CHECK:           %[[VAL_2:.*]] = arith.constant -2147483648 : i32
+! CHECK:           %[[VAL_3:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_4:.*]] = fir.box_addr %[[VAL_3]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
 ! CHECK:           %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (!fir.heap<!fir.array<?xi32>>) -> i64
 ! CHECK:           %[[VAL_6:.*]] = arith.constant 0 : i64
 ! CHECK:           %[[VAL_7:.*]] = arith.cmpi eq, %[[VAL_5]], %[[VAL_6]] : i64
 ! CHECK:           fir.if %[[VAL_7]] {
-! CHECK:             %[[C0:.*]] = arith.constant 0 : index
-! CHECK:             %[[SHAPE:.*]] = fir.shape %[[C0]]
-! CHECK:             %[[VAL_8:.*]] = fir.embox %[[VAL_4]](%[[SHAPE]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:             fir.store %[[VAL_8]] to %[[ALLOC]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_8:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_9:.*]] = fir.shape %[[VAL_8]] : (index) -> !fir.shape<1>
+! CHECK:             %[[VAL_10:.*]] = fir.embox %[[VAL_4]](%[[VAL_9]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_10]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           } else {
-! CHECK:             %[[VAL_9:.*]] = arith.constant 0 : index
-! CHECK:             %[[VAL_10:.*]]:3 = fir.box_dims %[[VAL_2]], %[[VAL_9]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:             %[[VAL_11:.*]] = fir.shape %[[VAL_10]]#1 : (index) -> !fir.shape<1>
-! CHECK:             %[[VAL_12:.*]] = fir.allocmem !fir.array<?xi32>, %[[VAL_10]]#1 {bindc_name = ".tmp", uniq_name = ""}
-! CHECK:             %[[VAL_13:.*]] = arith.constant true
-! CHECK:             %[[VAL_14:.*]]:2 = hlfir.declare %[[VAL_12]](%[[VAL_11]]) {uniq_name = ".tmp"} : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> (!fir.box<!fir.array<?xi32>>, !fir.heap<!fir.array<?xi32>>)
-! CHECK:             %[[VAL_15:.*]] = arith.constant 0 : index
-! CHECK:             %[[VAL_16:.*]]:3 = fir.box_dims %[[VAL_2]], %[[VAL_15]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:             %[[VAL_17:.*]] = fir.shape_shift %[[VAL_16]]#0, %[[VAL_16]]#1 : (index, index) -> !fir.shapeshift<1>
-! CHECK:             %[[VAL_18:.*]] = fir.rebox %[[VAL_14]]#0(%[[VAL_17]]) : (!fir.box<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:             hlfir.assign %[[VAL_1]] to %[[VAL_18]] : i32, !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:             fir.store %[[VAL_18]] to %[[ALLOC]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_11:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_12:.*]]:3 = fir.box_dims %[[VAL_3]], %[[VAL_11]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_13:.*]] = fir.shape %[[VAL_12]]#1 : (index) -> !fir.shape<1>
+! CHECK:             %[[VAL_14:.*]] = fir.allocmem !fir.array<?xi32>, %[[VAL_12]]#1 {bindc_name = ".tmp", uniq_name = ""}
+! CHECK:             %[[VAL_15:.*]] = arith.constant true
+! CHECK:             %[[VAL_16:.*]]:2 = hlfir.declare %[[VAL_14]](%[[VAL_13]]) {uniq_name = ".tmp"} : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> (!fir.box<!fir.array<?xi32>>, !fir.heap<!fir.array<?xi32>>)
+! CHECK:             %[[VAL_17:.*]] = arith.constant 0 : index
+! CHECK:             %[[VAL_18:.*]]:3 = fir.box_dims %[[VAL_3]], %[[VAL_17]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_19:.*]] = fir.shape_shift %[[VAL_18]]#0, %[[VAL_18]]#1 : (index, index) -> !fir.shapeshift<1>
+! CHECK:             %[[VAL_20:.*]] = fir.rebox %[[VAL_16]]#0(%[[VAL_19]]) : (!fir.box<!fir.array<?xi32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             hlfir.assign %[[VAL_2]] to %[[VAL_20]] : i32, !fir.box<!fir.heap<!fir.array<?xi32>>>
+! CHECK:             fir.store %[[VAL_20]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           }
-! CHECK:           omp.yield(%[[ALLOC]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
+! CHECK:           omp.yield(%[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK-LABEL:   } combiner {
-! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>):
+! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.heap<
 ! CHECK:           %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_3:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_4:.*]] = arith.constant 0 : index
@@ -143,8 +143,8 @@ end program
 ! CHECK:             fir.store %[[VAL_13]] to %[[VAL_9]] : !fir.ref<i32>
 ! CHECK:           }
 ! CHECK:           omp.yield(%[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
-! CHECK-LABEL:   }  cleanup {
-! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>):
+! CHECK-LABEL:   } cleanup {
+! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<
 ! CHECK:           %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_2:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
 ! CHECK:           %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.heap<!fir.array<?xi32>>) -> i64
@@ -167,137 +167,184 @@ end program
 ! CHECK:           %[[VAL_7:.*]]:2 = hlfir.declare %[[VAL_6]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEmins"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
 ! CHECK:           %[[VAL_8:.*]] = fir.address_of(@_QFECsize) : !fir.ref<i32>
 ! CHECK:           %[[VAL_9:.*]]:2 = hlfir.declare %[[VAL_8]] {fortran_attrs = {{.*}}<parameter>, uniq_name = "_QFECsize"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:           %[[VAL_10:.*]] = arith.constant 10 : i32
-! CHECK:           %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (i32) -> index
-! CHECK:           %[[VAL_12:.*]] = arith.constant 0 : index
-! CHECK:           %[[VAL_13:.*]] = arith.cmpi sgt, %[[VAL_11]], %[[VAL_12]] : index
-! CHECK:           %[[VAL_14:.*]] = arith.select %[[VAL_13]], %[[VAL_11]], %[[VAL_12]] : index
-! CHECK:           %[[VAL_15:.*]] = fir.allocmem !fir.array<?xi32>, %[[VAL_14]] {fir.must_be_heap = true, uniq_name = "_QFEarr.alloc"}
-! CHECK:           %[[VAL_16:.*]] = fir.shape %[[VAL_14]] : (index) -> !fir.shape<1>
-! CHECK:           %[[VAL_17:.*]] = fir.embox %[[VAL_15]](%[[VAL_16]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:           fir.store %[[VAL_17]] to %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:           %[[VAL_18:.*]] = arith.constant 10 : i32
-! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_18]] : (i32) -> index
-! CHECK:           %[[VAL_20:.*]] = arith.constant 0 : index
-! CHECK:           %[[VAL_21:.*]] = arith.cmpi sgt, %[[VAL_19]], %[[VAL_20]] : index
-! CHECK:           %[[VAL_22:.*]] = arith.select %[[VAL_21]], %[[VAL_19]], %[[VAL_20]] : index
-! CHECK:           %[[VAL_23:.*]] = fir.allocmem !fir.array<?xi32>, %[[VAL_22]] {fir.must_be_heap = true, uniq_name = "_QFEmaxes.alloc"}
-! CHECK:           %[[VAL_24:.*]] = fir.shape %[[VAL_22]] : (index) -> !fir.shape<1>
-! CHECK:           %[[VAL_25:.*]] = fir.embox %[[VAL_23]](%[[VAL_24]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:           fir.store %[[VAL_25]] to %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:           %[[VAL_26:.*]] = arith.constant 10 : i32
-! CHECK:           %[[VAL_27:.*]] = fir.convert %[[VAL_26]] : (i32) -> index
-! CHECK:           %[[VAL_28:.*]] = arith.constant 0 : index
-! CHECK:           %[[VAL_29:.*]] = arith.cmpi sgt, %[[VAL_27]], %[[VAL_28]] : index
-! CHECK:           %[[VAL_30:.*]] = arith.select %[[VAL_29]], %[[VAL_27]], %[[VAL_28]] : index
-! CHECK:           %[[VAL_31:.*]] = fir.allocmem !fir.array<?xi32>, %[[VAL_30]] {fir.must_be_heap = true, uniq_name = "_QFEmins.alloc"}
-! CHECK:           %[[VAL_32:.*]] = fir.shape %[[VAL_30]] : (index) -> !fir.shape<1>
-! CHECK:           %[[VAL_33:.*]] = fir.embox %[[VAL_31]](%[[VAL_32]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:           fir.store %[[VAL_33]] to %[[VAL_7]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:           %[[VAL_34:.*]] = arith.constant 5 : i32
-! CHECK:           hlfir.assign %[[VAL_34]] to %[[VAL_5]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:           %[[VAL_35:.*]] = arith.constant 5 : i32
-! CHECK:           hlfir.assign %[[VAL_35]] to %[[VAL_7]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:           %[[VAL_36:.*]] = arith.constant 1 : i32
-! CHECK:           %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (i32) -> index
-! CHECK:           %[[VAL_38:.*]] = arith.constant 10 : i32
-! CHECK:           %[[VAL_39:.*]] = fir.convert %[[VAL_38]] : (i32) -> index
+! CHECK:           %[[VAL_10:.*]] = arith.constant false
+! CHECK:           %[[VAL_11:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_12:.*]] = fir.address_of(@_QQclXac4c37b3854f12f47cc92e78ed179316) : !fir.ref<!fir.char<1,101>>
+! CHECK:           %[[VAL_13:.*]] = arith.constant 8 : i32
+! CHECK:           %[[VAL_14:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_15:.*]] = arith.constant 10 : i32
+! CHECK:           %[[VAL_16:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_1]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_18:.*]] = fir.convert %[[VAL_14]] : (index) -> i64
+! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_15]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_17]], %[[VAL_16]], %[[VAL_18]], %[[VAL_19]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_1]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_12]] : (!fir.ref<!fir.char<1,101>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_22:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_20]], %[[VAL_10]], %[[VAL_11]], %[[VAL_21]], %[[VAL_13]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_23:.*]] = arith.constant false
+! CHECK:           %[[VAL_24:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_25:.*]] = fir.address_of(@_QQclXac4c37b3854f12f47cc92e78ed179316) : !fir.ref<!fir.char<1,101>>
+! CHECK:           %[[VAL_26:.*]] = arith.constant 9 : i32
+! CHECK:           %[[VAL_27:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_28:.*]] = arith.constant 10 : i32
+! CHECK:           %[[VAL_29:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_30:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_31:.*]] = fir.convert %[[VAL_27]] : (index) -> i64
+! CHECK:           %[[VAL_32:.*]] = fir.convert %[[VAL_28]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_30]], %[[VAL_29]], %[[VAL_31]], %[[VAL_32]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_33:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_34:.*]] = fir.convert %[[VAL_25]] : (!fir.ref<!fir.char<1,101>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_35:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_33]], %[[VAL_23]], %[[VAL_24]], %[[VAL_34]], %[[VAL_26]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_36:.*]] = arith.constant false
+! CHECK:           %[[VAL_37:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_38:.*]] = fir.address_of(@_QQclXac4c37b3854f12f47cc92e78ed179316) : !fir.ref<!fir.char<1,101>>
+! CHECK:           %[[VAL_39:.*]] = arith.constant 10 : i32
 ! CHECK:           %[[VAL_40:.*]] = arith.constant 1 : index
-! CHECK:           %[[VAL_41:.*]] = fir.convert %[[VAL_37]] : (index) -> i32
-! CHECK:           %[[VAL_42:.*]]:2 = fir.do_loop %[[VAL_43:.*]] = %[[VAL_37]] to %[[VAL_39]] step %[[VAL_40]] iter_args(%[[VAL_44:.*]] = %[[VAL_41]]) -> (index, i32) {
-! CHECK:             fir.store %[[VAL_44]] to %[[VAL_3]]#0 : !fir.ref<i32>
-! CHECK:             %[[VAL_45:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<i32>
-! CHECK:             %[[VAL_46:.*]] = fir.load %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:             %[[VAL_47:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<i32>
-! CHECK:             %[[VAL_48:.*]] = fir.convert %[[VAL_47]] : (i32) -> i64
-! CHECK:             %[[VAL_49:.*]] = hlfir.designate %[[VAL_46]] (%[[VAL_48]])  : (!fir.box<!fir.heap<!fir.array<?xi32>>>, i64) -> !fir.ref<i32>
-! CHECK:             hlfir.assign %[[VAL_45]] to %[[VAL_49]] : i32, !fir.ref<i32>
-! CHECK:             %[[VAL_50:.*]] = arith.addi %[[VAL_43]], %[[VAL_40]] overflow<nsw> : index
-! CHECK:             %[[VAL_51:.*]] = fir.convert %[[VAL_40]] : (index) -> i32
-! CHECK:             %[[VAL_52:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<i32>
-! CHECK:             %[[VAL_53:.*]] = arith.addi %[[VAL_52]], %[[VAL_51]] overflow<nsw> : i32
-! CHECK:             fir.result %[[VAL_50]], %[[VAL_53]] : index, i32
+! CHECK:           %[[VAL_41:.*]] = arith.constant 10 : i32
+! CHECK:           %[[VAL_42:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_43:.*]] = fir.convert %[[VAL_7]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_44:.*]] = fir.convert %[[VAL_40]] : (index) -> i64
+! CHECK:           %[[VAL_45:.*]] = fir.convert %[[VAL_41]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_43]], %[[VAL_42]], %[[VAL_44]], %[[VAL_45]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_46:.*]] = fir.convert %[[VAL_7]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_47:.*]] = fir.convert %[[VAL_38]] : (!fir.ref<!fir.char<1,101>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_48:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_46]], %[[VAL_36]], %[[VAL_37]], %[[VAL_47]], %[[VAL_39]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_49:.*]] = arith.constant 5 : i32
+! CHECK:           hlfir.assign %[[VAL_49]] to %[[VAL_5]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_50:.*]] = arith.constant 5 : i32
+! CHECK:           hlfir.assign %[[VAL_50]] to %[[VAL_7]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_51:.*]] = arith.constant 1 : i32
+! CHECK:           %[[VAL_52:.*]] = fir.convert %[[VAL_51]] : (i32) -> index
+! CHECK:           %[[VAL_53:.*]] = arith.constant 10 : i32
+! CHECK:           %[[VAL_54:.*]] = fir.convert %[[VAL_53]] : (i32) -> index
+! CHECK:           %[[VAL_55:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_56:.*]] = fir.convert %[[VAL_52]] : (index) -> i32
+! CHECK:           %[[VAL_57:.*]]:2 = fir.do_loop %[[VAL_58:.*]] = %[[VAL_52]] to %[[VAL_54]] step %[[VAL_55]] iter_args(%[[VAL_59:.*]] = %[[VAL_56]]) -> (index, i32) {
+! CHECK:             fir.store %[[VAL_59]] to %[[VAL_3]]#1 : !fir.ref<i32>
+! CHECK:             %[[VAL_60:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<i32>
+! CHECK:             %[[VAL_61:.*]] = fir.load %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_62:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<i32>
+! CHECK:             %[[VAL_63:.*]] = fir.convert %[[VAL_62]] : (i32) -> i64
+! CHECK:             %[[VAL_64:.*]] = hlfir.designate %[[VAL_61]] (%[[VAL_63]])  : (!fir.box<!fir.heap<!fir.array<?xi32>>>, i64) -> !fir.ref<i32>
+! CHECK:             hlfir.assign %[[VAL_60]] to %[[VAL_64]] : i32, !fir.ref<i32>
+! CHECK:             %[[VAL_65:.*]] = arith.addi %[[VAL_58]], %[[VAL_55]] overflow<nsw> : index
+! CHECK:             %[[VAL_66:.*]] = fir.convert %[[VAL_55]] : (index) -> i32
+! CHECK:             %[[VAL_67:.*]] = fir.load %[[VAL_3]]#1 : !fir.ref<i32>
+! CHECK:             %[[VAL_68:.*]] = arith.addi %[[VAL_67]], %[[VAL_66]] overflow<nsw> : i32
+! CHECK:             fir.result %[[VAL_65]], %[[VAL_68]] : index, i32
 ! CHECK:           }
-! CHECK:           fir.store %[[VAL_54:.*]]#1 to %[[VAL_3]]#0 : !fir.ref<i32>
+! CHECK:           fir.store %[[VAL_69:.*]]#1 to %[[VAL_3]]#1 : !fir.ref<i32>
 ! CHECK:           omp.parallel {
-! CHECK:             %[[VAL_57:.*]] = arith.constant 1 : i32
-! CHECK:             %[[VAL_58:.*]] = arith.constant 10 : i32
-! CHECK:             %[[VAL_59:.*]] = arith.constant 1 : i32
-! CHECK:             omp.wsloop private(@{{.*}} %{{.*}}#0 -> %[[VAL_55:.*]] : !fir.ref<i32>) reduction(byref @max_byref_box_heap_Uxi32 %[[VAL_5]]#0 -> %[[VAL_60:.*]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) {
-! CHECK:               omp.loop_nest (%[[VAL_61:.*]]) : i32 = (%[[VAL_57]]) to (%[[VAL_58]]) inclusive step (%[[VAL_59]]) {
-! CHECK:                 %[[VAL_56:.*]]:2 = hlfir.declare %[[VAL_55]] {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:                 %[[VAL_62:.*]]:2 = hlfir.declare %[[VAL_60]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEmaxes"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
-! CHECK:                 hlfir.assign %[[VAL_61]] to %[[VAL_56]]#0 : i32, !fir.ref<i32>
-! CHECK:                 %[[VAL_63:.*]] = fir.load %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:                 %[[VAL_64:.*]] = arith.constant 0 : index
-! CHECK:                 %[[VAL_65:.*]]:3 = fir.box_dims %[[VAL_63]], %[[VAL_64]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:                 %[[VAL_66:.*]] = fir.shape %[[VAL_65]]#1 : (index) -> !fir.shape<1>
-! CHECK:                 %[[VAL_67:.*]] = fir.load %[[VAL_62]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:                 %[[VAL_68:.*]] = hlfir.elemental %[[VAL_66]] unordered : (!fir.shape<1>) -> !hlfir.expr<?xi32> {
-! CHECK:                 ^bb0(%[[VAL_69:.*]]: index):
-! CHECK:                   %[[VAL_70:.*]] = arith.constant 0 : index
-! CHECK:                   %[[VAL_71:.*]]:3 = fir.box_dims %[[VAL_63]], %[[VAL_70]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:                   %[[VAL_72:.*]] = arith.constant 1 : index
-! CHECK:                   %[[VAL_73:.*]] = arith.subi %[[VAL_71]]#0, %[[VAL_72]] : index
-! CHECK:                   %[[VAL_74:.*]] = arith.addi %[[VAL_69]], %[[VAL_73]] : index
-! CHECK:                   %[[VAL_75:.*]] = hlfir.designate %[[VAL_63]] (%[[VAL_74]])  : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> !fir.ref<i32>
-! CHECK:                   %[[VAL_76:.*]] = fir.load %[[VAL_75]] : !fir.ref<i32>
-! CHECK:                   %[[VAL_77:.*]] = arith.constant 0 : index
-! CHECK:                   %[[VAL_78:.*]]:3 = fir.box_dims %[[VAL_67]], %[[VAL_77]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:                   %[[VAL_79:.*]] = arith.constant 1 : index
-! CHECK:                   %[[VAL_80:.*]] = arith.subi %[[VAL_78]]#0, %[[VAL_79]] : index
-! CHECK:                   %[[VAL_81:.*]] = arith.addi %[[VAL_69]], %[[VAL_80]] : index
-! CHECK:                   %[[VAL_82:.*]] = hlfir.designate %[[VAL_67]] (%[[VAL_81]])  : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> !fir.ref<i32>
-! CHECK:                   %[[VAL_83:.*]] = fir.load %[[VAL_82]] : !fir.ref<i32>
-! CHECK:                   %[[VAL_84:.*]] = arith.cmpi sgt, %[[VAL_76]], %[[VAL_83]] : i32
-! CHECK:                   %[[VAL_85:.*]] = arith.select %[[VAL_84]], %[[VAL_76]], %[[VAL_83]] : i32
-! CHECK:                   hlfir.yield_element %[[VAL_85]] : i32
+! CHECK:             %[[VAL_70:.*]] = arith.constant 1 : i32
+! CHECK:             %[[VAL_71:.*]] = arith.constant 10 : i32
+! CHECK:             %[[VAL_72:.*]] = arith.constant 1 : i32
+! CHECK:             omp.wsloop private(@_QFEi_private_i32 %[[VAL_3]]#0 -> %[[VAL_73:.*]] : !fir.ref<i32>) reduction(byref @max_byref_box_heap_Uxi32 %[[VAL_5]]#0 -> %[[VAL_74:.*]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) {
+! CHECK:               omp.loop_nest (%[[VAL_75:.*]]) : i32 = (%[[VAL_70]]) to (%[[VAL_71]]) inclusive step (%[[VAL_72]]) {
+! CHECK:                 %[[VAL_76:.*]]:2 = hlfir.declare %[[VAL_73]] {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:                 %[[VAL_77:.*]]:2 = hlfir.declare %[[VAL_74]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEmaxes"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
+! CHECK:                 hlfir.assign %[[VAL_75]] to %[[VAL_76]]#1 : i32, !fir.ref<i32>
+! CHECK:                 %[[VAL_78:.*]] = fir.load %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:                 %[[VAL_79:.*]] = arith.constant 0 : index
+! CHECK:                 %[[VAL_80:.*]]:3 = fir.box_dims %[[VAL_78]], %[[VAL_79]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:                 %[[VAL_81:.*]] = fir.shape %[[VAL_80]]#1 : (index) -> !fir.shape<1>
+! CHECK:                 %[[VAL_82:.*]] = fir.load %[[VAL_77]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:                 %[[VAL_83:.*]] = hlfir.elemental %[[VAL_81]] unordered : (!fir.shape<1>) -> !hlfir.expr<?xi32> {
+! CHECK:                 ^bb0(%[[VAL_84:.*]]: index):
+! CHECK:                   %[[VAL_85:.*]] = arith.constant 0 : index
+! CHECK:                   %[[VAL_86:.*]]:3 = fir.box_dims %[[VAL_78]], %[[VAL_85]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:                   %[[VAL_87:.*]] = arith.constant 1 : index
+! CHECK:                   %[[VAL_88:.*]] = arith.subi %[[VAL_86]]#0, %[[VAL_87]] : index
+! CHECK:                   %[[VAL_89:.*]] = arith.addi %[[VAL_84]], %[[VAL_88]] : index
+! CHECK:                   %[[VAL_90:.*]] = hlfir.designate %[[VAL_78]] (%[[VAL_89]])  : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> !fir.ref<i32>
+! CHECK:                   %[[VAL_91:.*]] = fir.load %[[VAL_90]] : !fir.ref<i32>
+! CHECK:                   %[[VAL_92:.*]] = arith.constant 0 : index
+! CHECK:                   %[[VAL_93:.*]]:3 = fir.box_dims %[[VAL_82]], %[[VAL_92]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:                   %[[VAL_94:.*]] = arith.constant 1 : index
+! CHECK:                   %[[VAL_95:.*]] = arith.subi %[[VAL_93]]#0, %[[VAL_94]] : index
+! CHECK:                   %[[VAL_96:.*]] = arith.addi %[[VAL_84]], %[[VAL_95]] : index
+! CHECK:                   %[[VAL_97:.*]] = hlfir.designate %[[VAL_82]] (%[[VAL_96]])  : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> !fir.ref<i32>
+! CHECK:                   %[[VAL_98:.*]] = fir.load %[[VAL_97]] : !fir.ref<i32>
+! CHECK:                   %[[VAL_99:.*]] = arith.cmpi sgt, %[[VAL_91]], %[[VAL_98]] : i32
+! CHECK:                   %[[VAL_100:.*]] = arith.select %[[VAL_99]], %[[VAL_91]], %[[VAL_98]] : i32
+! CHECK:                   hlfir.yield_element %[[VAL_100]] : i32
 ! CHECK:                 }
-! CHECK:                 hlfir.assign %[[VAL_68]] to %[[VAL_62]]#0 realloc : !hlfir.expr<?xi32>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:                 hlfir.destroy %[[VAL_68]] : !hlfir.expr<?xi32>
+! CHECK:                 hlfir.assign %[[VAL_83]] to %[[VAL_77]]#0 realloc : !hlfir.expr<?xi32>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:                 hlfir.destroy %[[VAL_83]] : !hlfir.expr<?xi32>
 ! CHECK:                 omp.yield
 ! CHECK:               }
 ! CHECK:             }
 ! CHECK:             omp.terminator
 ! CHECK:           }
 ! CHECK:           omp.parallel {
-! CHECK:             %[[VAL_89:.*]] = arith.constant 1 : i32
-! CHECK:             %[[VAL_90:.*]] = arith.constant 10 : i32
-! CHECK:             %[[VAL_91:.*]] = arith.constant 1 : i32
-! CHECK:             omp.wsloop private(@{{.*}} %{{.*}}#0 -> %[[VAL_87:.*]] : !fir.ref<i32>) reduction(byref @min_byref_box_heap_Uxi32 %[[VAL_7]]#0 -> %[[VAL_92:.*]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) {
-! CHECK:               omp.loop_nest (%[[VAL_93:.*]]) : i32 = (%[[VAL_89]]) to (%[[VAL_90]]) inclusive step (%[[VAL_91]]) {
-! CHECK:                 %[[VAL_88:.*]]:2 = hlfir.declare %[[VAL_87]] {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:                 %[[VAL_94:.*]]:2 = hlfir.declare %[[VAL_92]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEmins"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
-! CHECK:                 hlfir.assign %[[VAL_93]] to %[[VAL_88]]#0 : i32, !fir.ref<i32>
-! CHECK:                 %[[VAL_95:.*]] = fir.load %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:                 %[[VAL_96:.*]] = arith.constant 0 : index
-! CHECK:                 %[[VAL_97:.*]]:3 = fir.box_dims %[[VAL_95]], %[[VAL_96]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:                 %[[VAL_98:.*]] = fir.shape %[[VAL_97]]#1 : (index) -> !fir.shape<1>
-! CHECK:                 %[[VAL_99:.*]] = fir.load %[[VAL_94]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:                 %[[VAL_100:.*]] = hlfir.elemental %[[VAL_98]] unordered : (!fir.shape<1>) -> !hlfir.expr<?xi32> {
-! CHECK:                 ^bb0(%[[VAL_101:.*]]: index):
-! CHECK:                   %[[VAL_102:.*]] = arith.constant 0 : index
-! CHECK:                   %[[VAL_103:.*]]:3 = fir.box_dims %[[VAL_95]], %[[VAL_102]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:                   %[[VAL_104:.*]] = arith.constant 1 : index
-! CHECK:                   %[[VAL_105:.*]] = arith.subi %[[VAL_103]]#0, %[[VAL_104]] : index
-! CHECK:                   %[[VAL_106:.*]] = arith.addi %[[VAL_101]], %[[VAL_105]] : index
-! CHECK:                   %[[VAL_107:.*]] = hlfir.designate %[[VAL_95]] (%[[VAL_106]])  : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> !fir.ref<i32>
-! CHECK:                   %[[VAL_108:.*]] = fir.load %[[VAL_107]] : !fir.ref<i32>
-! CHECK:                   %[[VAL_109:.*]] = arith.constant 0 : index
-! CHECK:                   %[[VAL_110:.*]]:3 = fir.box_dims %[[VAL_99]], %[[VAL_109]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:                   %[[VAL_111:.*]] = arith.constant 1 : index
-! CHECK:                   %[[VAL_112:.*]] = arith.subi %[[VAL_110]]#0, %[[VAL_111]] : index
-! CHECK:                   %[[VAL_113:.*]] = arith.addi %[[VAL_101]], %[[VAL_112]] : index
-! CHECK:                   %[[VAL_114:.*]] = hlfir.designate %[[VAL_99]] (%[[VAL_113]])  : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> !fir.ref<i32>
-! CHECK:                   %[[VAL_115:.*]] = fir.load %[[VAL_114]] : !fir.ref<i32>
-! CHECK:                   %[[VAL_116:.*]] = arith.cmpi slt, %[[VAL_108]], %[[VAL_115]] : i32
-! CHECK:                   %[[VAL_117:.*]] = arith.select %[[VAL_116]], %[[VAL_108]], %[[VAL_115]] : i32
-! CHECK:                   hlfir.yield_element %[[VAL_117]] : i32
+! CHECK:             %[[VAL_101:.*]] = arith.constant 1 : i32
+! CHECK:             %[[VAL_102:.*]] = arith.constant 10 : i32
+! CHECK:             %[[VAL_103:.*]] = arith.constant 1 : i32
+! CHECK:             omp.wsloop private(@_QFEi_private_i32 %[[VAL_3]]#0 -> %[[VAL_104:.*]] : !fir.ref<i32>) reduction(byref @min_byref_box_heap_Uxi32 %[[VAL_7]]#0 -> %[[VAL_105:.*]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) {
+! CHECK:               omp.loop_nest (%[[VAL_106:.*]]) : i32 = (%[[VAL_101]]) to (%[[VAL_102]]) inclusive step (%[[VAL_103]]) {
+! CHECK:                 %[[VAL_107:.*]]:2 = hlfir.declare %[[VAL_104]] {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:                 %[[VAL_108:.*]]:2 = hlfir.declare %[[VAL_105]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEmins"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
+! CHECK:                 hlfir.assign %[[VAL_106]] to %[[VAL_107]]#1 : i32, !fir.ref<i32>
+! CHECK:                 %[[VAL_109:.*]] = fir.load %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:                 %[[VAL_110:.*]] = arith.constant 0 : index
+! CHECK:                 %[[VAL_111:.*]]:3 = fir.box_dims %[[VAL_109]], %[[VAL_110]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:                 %[[VAL_112:.*]] = fir.shape %[[VAL_111]]#1 : (index) -> !fir.shape<1>
+! CHECK:                 %[[VAL_113:.*]] = fir.load %[[VAL_108]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:                 %[[VAL_114:.*]] = hlfir.elemental %[[VAL_112]] unordered : (!fir.shape<1>) -> !hlfir.expr<?xi32> {
+! CHECK:                 ^bb0(%[[VAL_115:.*]]: index):
+! CHECK:                   %[[VAL_116:.*]] = arith.constant 0 : index
+! CHECK:                   %[[VAL_117:.*]]:3 = fir.box_dims %[[VAL_109]], %[[VAL_116]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:                   %[[VAL_118:.*]] = arith.constant 1 : index
+! CHECK:                   %[[VAL_119:.*]] = arith.subi %[[VAL_117]]#0, %[[VAL_118]] : index
+! CHECK:                   %[[VAL_120:.*]] = arith.addi %[[VAL_115]], %[[VAL_119]] : index
+! CHECK:                   %[[VAL_121:.*]] = hlfir.designate %[[VAL_109]] (%[[VAL_120]])  : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> !fir.ref<i32>
+! CHECK:                   %[[VAL_122:.*]] = fir.load %[[VAL_121]] : !fir.ref<i32>
+! CHECK:                   %[[VAL_123:.*]] = arith.constant 0 : index
+! CHECK:                   %[[VAL_124:.*]]:3 = fir.box_dims %[[VAL_113]], %[[VAL_123]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:                   %[[VAL_125:.*]] = arith.constant 1 : index
+! CHECK:                   %[[VAL_126:.*]] = arith.subi %[[VAL_124]]#0, %[[VAL_125]] : index
+! CHECK:                   %[[VAL_127:.*]] = arith.addi %[[VAL_115]], %[[VAL_126]] : index
+! CHECK:                   %[[VAL_128:.*]] = hlfir.designate %[[VAL_113]] (%[[VAL_127]])  : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> !fir.ref<i32>
+! CHECK:                   %[[VAL_129:.*]] = fir.load %[[VAL_128]] : !fir.ref<i32>
+! CHECK:                   %[[VAL_130:.*]] = arith.cmpi slt, %[[VAL_122]], %[[VAL_129]] : i32
+! CHECK:                   %[[VAL_131:.*]] = arith.select %[[VAL_130]], %[[VAL_122]], %[[VAL_129]] : i32
+! CHECK:                   hlfir.yield_element %[[VAL_131]] : i32
 ! CHECK:                 }
-! CHECK:                 hlfir.assign %[[VAL_100]] to %[[VAL_94]]#0 realloc : !hlfir.expr<?xi32>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:                 hlfir.destroy %[[VAL_100]] : !hlfir.expr<?xi32>
+! CHECK:                 hlfir.assign %[[VAL_114]] to %[[VAL_108]]#0 realloc : !hlfir.expr<?xi32>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:                 hlfir.destroy %[[VAL_114]] : !hlfir.expr<?xi32>
 ! CHECK:                 omp.yield
 ! CHECK:               }
 ! CHECK:             }
 ! CHECK:             omp.terminator
 ! CHECK:           }
+! CHECK:           %[[VAL_132:.*]] = arith.constant 6 : i32
+! CHECK:           %[[VAL_133:.*]] = fir.address_of(@_QQclXac4c37b3854f12f47cc92e78ed179316) : !fir.ref<!fir.char<1,101>>
+! CHECK:           %[[VAL_134:.*]] = fir.convert %[[VAL_133]] : (!fir.ref<!fir.char<1,101>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_135:.*]] = arith.constant 31 : i32
+! CHECK:           %[[VAL_136:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_132]], %[[VAL_134]], %[[VAL_135]]) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_137:.*]] = fir.address_of(@_QQclX6D61783A20) : !fir.ref<!fir.char<1,5>>
+! CHECK:           %[[VAL_138:.*]] = arith.constant 5 : index
+! CHECK:           %[[VAL_139:.*]]:2 = hlfir.declare %[[VAL_137]] typeparams %[[VAL_138]] {fortran_attrs = {{.*}}<parameter>, uniq_name = "_QQclX6D61783A20"} : (!fir.ref<!fir.char<1,5>>, index) -> (!fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>)
+! CHECK:           %[[VAL_140:.*]] = fir.convert %[[VAL_139]]#1 : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_141:.*]] = fir.convert %[[VAL_138]] : (index) -> i64
+! CHECK:           %[[VAL_142:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_136]], %[[VAL_140]], %[[VAL_141]]) fastmath<contract> : (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
+! CHECK:           %[[VAL_143:.*]] = fir.load %[[VAL_5]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_144:.*]] = fir.convert %[[VAL_143]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.box<none>
+! CHECK:           %[[VAL_145:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_136]], %[[VAL_144]]) fastmath<contract> : (!fir.ref<i8>, !fir.box<none>) -> i1
+! CHECK:           %[[VAL_146:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_136]]) fastmath<contract> : (!fir.ref<i8>) -> i32
+! CHECK:           %[[VAL_147:.*]] = arith.constant 6 : i32
+! CHECK:           %[[VAL_148:.*]] = fir.address_of(@_QQclXac4c37b3854f12f47cc92e78ed179316) : !fir.ref<!fir.char<1,101>>
+! CHECK:           %[[VAL_149:.*]] = fir.convert %[[VAL_148]] : (!fir.ref<!fir.char<1,101>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_150:.*]] = arith.constant 32 : i32
+! CHECK:           %[[VAL_151:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_147]], %[[VAL_149]], %[[VAL_150]]) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_152:.*]] = fir.address_of(@_QQclX6D696E3A20) : !fir.ref<!fir.char<1,5>>
+! CHECK:           %[[VAL_153:.*]] = arith.constant 5 : index
+! CHECK:           %[[VAL_154:.*]]:2 = hlfir.declare %[[VAL_152]] typeparams %[[VAL_153]] {fortran_attrs = {{.*}}<parameter>, uniq_name = "_QQclX6D696E3A20"} : (!fir.ref<!fir.char<1,5>>, index) -> (!fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>)
+! CHECK:           %[[VAL_155:.*]] = fir.convert %[[VAL_154]]#1 : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_156:.*]] = fir.convert %[[VAL_153]] : (index) -> i64
+! CHECK:           %[[VAL_157:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_151]], %[[VAL_155]], %[[VAL_156]]) fastmath<contract> : (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
+! CHECK:           %[[VAL_158:.*]] = fir.load %[[VAL_7]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_159:.*]] = fir.convert %[[VAL_158]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.box<none>
+! CHECK:           %[[VAL_160:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_151]], %[[VAL_159]]) fastmath<contract> : (!fir.ref<i8>, !fir.box<none>) -> i1
+! CHECK:           %[[VAL_161:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_151]]) fastmath<contract> : (!fir.ref<i8>) -> i32
+! CHECK:           return
+! CHECK:         }

--- a/flang/test/Lower/OpenMP/wsloop-reduction-allocatable-array-minmax.f90
+++ b/flang/test/Lower/OpenMP/wsloop-reduction-allocatable-array-minmax.f90
@@ -174,11 +174,11 @@ end program
 ! CHECK:           %[[VAL_14:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_15:.*]] = arith.constant 10 : i32
 ! CHECK:           %[[VAL_16:.*]] = arith.constant 0 : i32
-! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_1]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_1]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_18:.*]] = fir.convert %[[VAL_14]] : (index) -> i64
 ! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_15]] : (i32) -> i64
 ! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_17]], %[[VAL_16]], %[[VAL_18]], %[[VAL_19]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
-! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_1]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_1]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_12]] : (!fir.ref<!fir.char<1,101>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_22:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_20]], %[[VAL_10]], %[[VAL_11]], %[[VAL_21]], %[[VAL_13]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:           %[[VAL_23:.*]] = arith.constant false
@@ -188,11 +188,11 @@ end program
 ! CHECK:           %[[VAL_27:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_28:.*]] = arith.constant 10 : i32
 ! CHECK:           %[[VAL_29:.*]] = arith.constant 0 : i32
-! CHECK:           %[[VAL_30:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_30:.*]] = fir.convert %[[VAL_5]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_31:.*]] = fir.convert %[[VAL_27]] : (index) -> i64
 ! CHECK:           %[[VAL_32:.*]] = fir.convert %[[VAL_28]] : (i32) -> i64
 ! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_30]], %[[VAL_29]], %[[VAL_31]], %[[VAL_32]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
-! CHECK:           %[[VAL_33:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_33:.*]] = fir.convert %[[VAL_5]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_34:.*]] = fir.convert %[[VAL_25]] : (!fir.ref<!fir.char<1,101>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_35:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_33]], %[[VAL_23]], %[[VAL_24]], %[[VAL_34]], %[[VAL_26]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:           %[[VAL_36:.*]] = arith.constant false
@@ -202,11 +202,11 @@ end program
 ! CHECK:           %[[VAL_40:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_41:.*]] = arith.constant 10 : i32
 ! CHECK:           %[[VAL_42:.*]] = arith.constant 0 : i32
-! CHECK:           %[[VAL_43:.*]] = fir.convert %[[VAL_7]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_43:.*]] = fir.convert %[[VAL_7]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_44:.*]] = fir.convert %[[VAL_40]] : (index) -> i64
 ! CHECK:           %[[VAL_45:.*]] = fir.convert %[[VAL_41]] : (i32) -> i64
 ! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_43]], %[[VAL_42]], %[[VAL_44]], %[[VAL_45]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
-! CHECK:           %[[VAL_46:.*]] = fir.convert %[[VAL_7]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_46:.*]] = fir.convert %[[VAL_7]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_47:.*]] = fir.convert %[[VAL_38]] : (!fir.ref<!fir.char<1,101>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_48:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_46]], %[[VAL_36]], %[[VAL_37]], %[[VAL_47]], %[[VAL_39]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:           %[[VAL_49:.*]] = arith.constant 5 : i32
@@ -220,7 +220,7 @@ end program
 ! CHECK:           %[[VAL_55:.*]] = arith.constant 1 : index
 ! CHECK:           %[[VAL_56:.*]] = fir.convert %[[VAL_52]] : (index) -> i32
 ! CHECK:           %[[VAL_57:.*]]:2 = fir.do_loop %[[VAL_58:.*]] = %[[VAL_52]] to %[[VAL_54]] step %[[VAL_55]] iter_args(%[[VAL_59:.*]] = %[[VAL_56]]) -> (index, i32) {
-! CHECK:             fir.store %[[VAL_59]] to %[[VAL_3]]#1 : !fir.ref<i32>
+! CHECK:             fir.store %[[VAL_59]] to %[[VAL_3]]{{.*}} : !fir.ref<i32>
 ! CHECK:             %[[VAL_60:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<i32>
 ! CHECK:             %[[VAL_61:.*]] = fir.load %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:             %[[VAL_62:.*]] = fir.load %[[VAL_3]]#0 : !fir.ref<i32>
@@ -229,11 +229,11 @@ end program
 ! CHECK:             hlfir.assign %[[VAL_60]] to %[[VAL_64]] : i32, !fir.ref<i32>
 ! CHECK:             %[[VAL_65:.*]] = arith.addi %[[VAL_58]], %[[VAL_55]] overflow<nsw> : index
 ! CHECK:             %[[VAL_66:.*]] = fir.convert %[[VAL_55]] : (index) -> i32
-! CHECK:             %[[VAL_67:.*]] = fir.load %[[VAL_3]]#1 : !fir.ref<i32>
+! CHECK:             %[[VAL_67:.*]] = fir.load %[[VAL_3]]{{.*}} : !fir.ref<i32>
 ! CHECK:             %[[VAL_68:.*]] = arith.addi %[[VAL_67]], %[[VAL_66]] overflow<nsw> : i32
 ! CHECK:             fir.result %[[VAL_65]], %[[VAL_68]] : index, i32
 ! CHECK:           }
-! CHECK:           fir.store %[[VAL_69:.*]]#1 to %[[VAL_3]]#1 : !fir.ref<i32>
+! CHECK:           fir.store %[[VAL_69:.*]]{{.*}} to %[[VAL_3]]{{.*}} : !fir.ref<i32>
 ! CHECK:           omp.parallel {
 ! CHECK:             %[[VAL_70:.*]] = arith.constant 1 : i32
 ! CHECK:             %[[VAL_71:.*]] = arith.constant 10 : i32
@@ -242,11 +242,11 @@ end program
 ! CHECK:               omp.loop_nest (%[[VAL_75:.*]]) : i32 = (%[[VAL_70]]) to (%[[VAL_71]]) inclusive step (%[[VAL_72]]) {
 ! CHECK:                 %[[VAL_76:.*]]:2 = hlfir.declare %[[VAL_73]] {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:                 %[[VAL_77:.*]]:2 = hlfir.declare %[[VAL_74]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEmaxes"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
-! CHECK:                 hlfir.assign %[[VAL_75]] to %[[VAL_76]]#1 : i32, !fir.ref<i32>
+! CHECK:                 hlfir.assign %[[VAL_75]] to %[[VAL_76]]{{.*}} : i32, !fir.ref<i32>
 ! CHECK:                 %[[VAL_78:.*]] = fir.load %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:                 %[[VAL_79:.*]] = arith.constant 0 : index
 ! CHECK:                 %[[VAL_80:.*]]:3 = fir.box_dims %[[VAL_78]], %[[VAL_79]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:                 %[[VAL_81:.*]] = fir.shape %[[VAL_80]]#1 : (index) -> !fir.shape<1>
+! CHECK:                 %[[VAL_81:.*]] = fir.shape %[[VAL_80]]{{.*}} : (index) -> !fir.shape<1>
 ! CHECK:                 %[[VAL_82:.*]] = fir.load %[[VAL_77]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:                 %[[VAL_83:.*]] = hlfir.elemental %[[VAL_81]] unordered : (!fir.shape<1>) -> !hlfir.expr<?xi32> {
 ! CHECK:                 ^bb0(%[[VAL_84:.*]]: index):
@@ -283,11 +283,11 @@ end program
 ! CHECK:               omp.loop_nest (%[[VAL_106:.*]]) : i32 = (%[[VAL_101]]) to (%[[VAL_102]]) inclusive step (%[[VAL_103]]) {
 ! CHECK:                 %[[VAL_107:.*]]:2 = hlfir.declare %[[VAL_104]] {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:                 %[[VAL_108:.*]]:2 = hlfir.declare %[[VAL_105]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEmins"} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>)
-! CHECK:                 hlfir.assign %[[VAL_106]] to %[[VAL_107]]#1 : i32, !fir.ref<i32>
+! CHECK:                 hlfir.assign %[[VAL_106]] to %[[VAL_107]]{{.*}} : i32, !fir.ref<i32>
 ! CHECK:                 %[[VAL_109:.*]] = fir.load %[[VAL_1]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:                 %[[VAL_110:.*]] = arith.constant 0 : index
 ! CHECK:                 %[[VAL_111:.*]]:3 = fir.box_dims %[[VAL_109]], %[[VAL_110]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:                 %[[VAL_112:.*]] = fir.shape %[[VAL_111]]#1 : (index) -> !fir.shape<1>
+! CHECK:                 %[[VAL_112:.*]] = fir.shape %[[VAL_111]]{{.*}} : (index) -> !fir.shape<1>
 ! CHECK:                 %[[VAL_113:.*]] = fir.load %[[VAL_108]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:                 %[[VAL_114:.*]] = hlfir.elemental %[[VAL_112]] unordered : (!fir.shape<1>) -> !hlfir.expr<?xi32> {
 ! CHECK:                 ^bb0(%[[VAL_115:.*]]: index):
@@ -324,10 +324,10 @@ end program
 ! CHECK:           %[[VAL_137:.*]] = fir.address_of(@_QQclX6D61783A20) : !fir.ref<!fir.char<1,5>>
 ! CHECK:           %[[VAL_138:.*]] = arith.constant 5 : index
 ! CHECK:           %[[VAL_139:.*]]:2 = hlfir.declare %[[VAL_137]] typeparams %[[VAL_138]] {fortran_attrs = {{.*}}<parameter>, uniq_name = "_QQclX6D61783A20"} : (!fir.ref<!fir.char<1,5>>, index) -> (!fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>)
-! CHECK:           %[[VAL_140:.*]] = fir.convert %[[VAL_139]]#1 : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_140:.*]] = fir.convert %[[VAL_139]]{{.*}} : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_141:.*]] = fir.convert %[[VAL_138]] : (index) -> i64
 ! CHECK:           %[[VAL_142:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_136]], %[[VAL_140]], %[[VAL_141]]) fastmath<contract> : (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
-! CHECK:           %[[VAL_143:.*]] = fir.load %[[VAL_5]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_143:.*]] = fir.load %[[VAL_5]]{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_144:.*]] = fir.convert %[[VAL_143]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_145:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_136]], %[[VAL_144]]) fastmath<contract> : (!fir.ref<i8>, !fir.box<none>) -> i1
 ! CHECK:           %[[VAL_146:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_136]]) fastmath<contract> : (!fir.ref<i8>) -> i32
@@ -339,10 +339,10 @@ end program
 ! CHECK:           %[[VAL_152:.*]] = fir.address_of(@_QQclX6D696E3A20) : !fir.ref<!fir.char<1,5>>
 ! CHECK:           %[[VAL_153:.*]] = arith.constant 5 : index
 ! CHECK:           %[[VAL_154:.*]]:2 = hlfir.declare %[[VAL_152]] typeparams %[[VAL_153]] {fortran_attrs = {{.*}}<parameter>, uniq_name = "_QQclX6D696E3A20"} : (!fir.ref<!fir.char<1,5>>, index) -> (!fir.ref<!fir.char<1,5>>, !fir.ref<!fir.char<1,5>>)
-! CHECK:           %[[VAL_155:.*]] = fir.convert %[[VAL_154]]#1 : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_155:.*]] = fir.convert %[[VAL_154]]{{.*}} : (!fir.ref<!fir.char<1,5>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_156:.*]] = fir.convert %[[VAL_153]] : (index) -> i64
 ! CHECK:           %[[VAL_157:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_151]], %[[VAL_155]], %[[VAL_156]]) fastmath<contract> : (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
-! CHECK:           %[[VAL_158:.*]] = fir.load %[[VAL_7]]#1 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_158:.*]] = fir.load %[[VAL_7]]{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
 ! CHECK:           %[[VAL_159:.*]] = fir.convert %[[VAL_158]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.box<none>
 ! CHECK:           %[[VAL_160:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_151]], %[[VAL_159]]) fastmath<contract> : (!fir.ref<i8>, !fir.box<none>) -> i1
 ! CHECK:           %[[VAL_161:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_151]]) fastmath<contract> : (!fir.ref<i8>) -> i32

--- a/flang/test/Lower/OpenMP/wsloop-reduction-allocatable.f90
+++ b/flang/test/Lower/OpenMP/wsloop-reduction-allocatable.f90
@@ -76,7 +76,7 @@ end program
 ! CHECK:           %[[VAL_7:.*]] = fir.absent !fir.box<none>
 ! CHECK:           %[[VAL_8:.*]] = fir.address_of(@_QQclX100ec2b8f633a84df3b7cc2ad55f845c) : !fir.ref<!fir.char<1,88>>
 ! CHECK:           %[[VAL_9:.*]] = arith.constant 8 : i32
-! CHECK:           %[[VAL_10:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_10:.*]] = fir.convert %[[VAL_5]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
 ! CHECK:           %[[VAL_11:.*]] = fir.convert %[[VAL_8]] : (!fir.ref<!fir.char<1,88>>) -> !fir.ref<i8>
 ! CHECK:           %[[VAL_12:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_10]], %[[VAL_6]], %[[VAL_7]], %[[VAL_11]], %[[VAL_9]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! CHECK:           %[[VAL_13:.*]] = arith.constant 0 : i32
@@ -89,7 +89,7 @@ end program
 ! CHECK:               omp.loop_nest (%[[VAL_19:.*]]) : i32 = (%[[VAL_14]]) to (%[[VAL_15]]) inclusive step (%[[VAL_16]]) {
 ! CHECK:                 %[[VAL_20:.*]]:2 = hlfir.declare %[[VAL_17]] {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
 ! CHECK:                 %[[VAL_21:.*]]:2 = hlfir.declare %[[VAL_18]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEr"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
-! CHECK:                 hlfir.assign %[[VAL_19]] to %[[VAL_20]]#1 : i32, !fir.ref<i32>
+! CHECK:                 hlfir.assign %[[VAL_19]] to %[[VAL_20]]{{.*}} : i32, !fir.ref<i32>
 ! CHECK:                 %[[VAL_22:.*]] = fir.load %[[VAL_20]]#0 : !fir.ref<i32>
 ! CHECK:                 hlfir.assign %[[VAL_22]] to %[[VAL_21]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:                 omp.yield

--- a/flang/test/Lower/OpenMP/wsloop-reduction-allocatable.f90
+++ b/flang/test/Lower/OpenMP/wsloop-reduction-allocatable.f90
@@ -18,29 +18,30 @@ print *,r
 
 end program
 
+
 ! CHECK-LABEL:   omp.declare_reduction @add_reduction_byref_box_heap_i32 : !fir.ref<!fir.box<!fir.heap<i32>>> alloc {
-! CHECK:           %[[VAL_2:.*]] = fir.alloca !fir.box<!fir.heap<i32>>
-! CHECK:           omp.yield(%[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<i32>>>)
+! CHECK:           %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.heap<i32>>
+! CHECK:           omp.yield(%[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<i32>>>)
 ! CHECK-LABEL:   } init {
-! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<i32>>>, %[[ALLOC:.*]]: !fir.ref<!fir.box<!fir.heap<i32>>>):
-! CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
-! CHECK:           %[[LOAD:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:           %[[ADDR:.*]] = fir.box_addr %[[LOAD]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
-! CHECK:           %[[ADDRI:.*]] = fir.convert %[[ADDR]] : (!fir.heap<i32>) -> i64
-! CHECK:           %[[C0_I64:.*]] = arith.constant 0 : i64
-! CHECK:           %[[IS_NULL:.*]] = arith.cmpi eq, %[[ADDRI]], %[[C0_I64]] : i64
-! CHECK:           fir.if %[[IS_NULL]] {
-! CHECK:             %[[NULL_BOX:.*]] = fir.embox %[[ADDR]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
-! CHECK:             fir.store %[[NULL_BOX]] to %[[ALLOC]] : !fir.ref<!fir.box<!fir.heap<i32>>
+! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<i32>>>, %[[VAL_1:.*]]: !fir.ref<!fir.box<
+! CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_3:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:           %[[VAL_4:.*]] = fir.box_addr %[[VAL_3]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:           %[[VAL_5:.*]] = fir.convert %[[VAL_4]] : (!fir.heap<i32>) -> i64
+! CHECK:           %[[VAL_6:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_7:.*]] = arith.cmpi eq, %[[VAL_5]], %[[VAL_6]] : i64
+! CHECK:           fir.if %[[VAL_7]] {
+! CHECK:             %[[VAL_8:.*]] = fir.embox %[[VAL_4]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
+! CHECK:             fir.store %[[VAL_8]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:           } else {
-! CHECK:             %[[VAL_3:.*]] = fir.allocmem i32
-! CHECK:             fir.store %[[VAL_1]] to %[[VAL_3]] : !fir.heap<i32>
-! CHECK:             %[[VAL_4:.*]] = fir.embox %[[VAL_3]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
-! CHECK:             fir.store %[[VAL_4]] to %[[ALLOC]] : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:             %[[VAL_9:.*]] = fir.allocmem i32 {bindc_name = "", uniq_name = ""}
+! CHECK:             fir.store %[[VAL_2]] to %[[VAL_9]] : !fir.heap<i32>
+! CHECK:             %[[VAL_10:.*]] = fir.embox %[[VAL_9]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
+! CHECK:             fir.store %[[VAL_10]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:           }
-! CHECK:           omp.yield(%[[ALLOC]] : !fir.ref<!fir.box<!fir.heap<i32>>>)
-! CHECK:         } combiner {
-! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<i32>>>, %[[VAL_1:.*]]: !fir.ref<!fir.box<!fir.heap<i32>>>):
+! CHECK:           omp.yield(%[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<i32>>>)
+! CHECK-LABEL:   } combiner {
+! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<i32>>>, %[[VAL_1:.*]]: !fir.ref<!fir.box<
 ! CHECK:           %[[VAL_2:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:           %[[VAL_3:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:           %[[VAL_4:.*]] = fir.box_addr %[[VAL_2]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
@@ -50,8 +51,8 @@ end program
 ! CHECK:           %[[VAL_8:.*]] = arith.addi %[[VAL_6]], %[[VAL_7]] : i32
 ! CHECK:           fir.store %[[VAL_8]] to %[[VAL_4]] : !fir.heap<i32>
 ! CHECK:           omp.yield(%[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<i32>>>)
-! CHECK:         }  cleanup {
-! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<!fir.heap<i32>>>):
+! CHECK-LABEL:   } cleanup {
+! CHECK:         ^bb0(%[[VAL_0:.*]]: !fir.ref<!fir.box<
 ! CHECK:           %[[VAL_1:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:           %[[VAL_2:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
 ! CHECK:           %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.heap<i32>) -> i64
@@ -71,25 +72,41 @@ end program
 ! CHECK:           %[[VAL_4:.*]] = fir.embox %[[VAL_3]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
 ! CHECK:           fir.store %[[VAL_4]] to %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:           %[[VAL_5:.*]]:2 = hlfir.declare %[[VAL_2]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEr"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
-! CHECK:           %[[VAL_6:.*]] = fir.allocmem i32 {fir.must_be_heap = true, uniq_name = "_QFEr.alloc"}
-! CHECK:           %[[VAL_7:.*]] = fir.embox %[[VAL_6]] : (!fir.heap<i32>) -> !fir.box<!fir.heap<i32>>
-! CHECK:           fir.store %[[VAL_7]] to %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
-! CHECK:           %[[VAL_8:.*]] = arith.constant 0 : i32
-! CHECK:           hlfir.assign %[[VAL_8]] to %[[VAL_5]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:           %[[VAL_6:.*]] = arith.constant false
+! CHECK:           %[[VAL_7:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_8:.*]] = fir.address_of(@_QQclX100ec2b8f633a84df3b7cc2ad55f845c) : !fir.ref<!fir.char<1,88>>
+! CHECK:           %[[VAL_9:.*]] = arith.constant 8 : i32
+! CHECK:           %[[VAL_10:.*]] = fir.convert %[[VAL_5]]#1 : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_11:.*]] = fir.convert %[[VAL_8]] : (!fir.ref<!fir.char<1,88>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_12:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_10]], %[[VAL_6]], %[[VAL_7]], %[[VAL_11]], %[[VAL_9]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_13:.*]] = arith.constant 0 : i32
+! CHECK:           hlfir.assign %[[VAL_13]] to %[[VAL_5]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:           omp.parallel {
-! CHECK:             %[[VAL_11:.*]] = arith.constant 0 : i32
-! CHECK:             %[[VAL_12:.*]] = arith.constant 10 : i32
-! CHECK:             %[[VAL_13:.*]] = arith.constant 1 : i32
-! CHECK:             omp.wsloop private(@{{.*}} %{{.*}}#0 -> %[[VAL_9:.*]] : !fir.ref<i32>) reduction(byref @add_reduction_byref_box_heap_i32 %[[VAL_5]]#0 -> %[[VAL_14:.*]] : !fir.ref<!fir.box<!fir.heap<i32>>>) {
-! CHECK-NEXT:          omp.loop_nest (%[[VAL_15:.*]]) : i32 = (%[[VAL_11]]) to (%[[VAL_12]]) inclusive step (%[[VAL_13]]) {
-! CHECK:                 %[[VAL_10:.*]]:2 = hlfir.declare %[[VAL_9]] {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
-! CHECK:                 %[[VAL_16:.*]]:2 = hlfir.declare %[[VAL_14]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEr"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
-! CHECK:                 hlfir.assign %[[VAL_15]] to %[[VAL_10]]#0 : i32, !fir.ref<i32>
-! CHECK:                 %[[VAL_17:.*]] = fir.load %[[VAL_10]]#0 : !fir.ref<i32>
-! CHECK:                 hlfir.assign %[[VAL_17]] to %[[VAL_16]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:             %[[VAL_14:.*]] = arith.constant 0 : i32
+! CHECK:             %[[VAL_15:.*]] = arith.constant 10 : i32
+! CHECK:             %[[VAL_16:.*]] = arith.constant 1 : i32
+! CHECK:             omp.wsloop private(@_QFEi_private_i32 %[[VAL_1]]#0 -> %[[VAL_17:.*]] : !fir.ref<i32>) reduction(byref @add_reduction_byref_box_heap_i32 %[[VAL_5]]#0 -> %[[VAL_18:.*]] : !fir.ref<!fir.box<!fir.heap<i32>>>) {
+! CHECK:               omp.loop_nest (%[[VAL_19:.*]]) : i32 = (%[[VAL_14]]) to (%[[VAL_15]]) inclusive step (%[[VAL_16]]) {
+! CHECK:                 %[[VAL_20:.*]]:2 = hlfir.declare %[[VAL_17]] {uniq_name = "_QFEi"} : (!fir.ref<i32>) -> (!fir.ref<i32>, !fir.ref<i32>)
+! CHECK:                 %[[VAL_21:.*]]:2 = hlfir.declare %[[VAL_18]] {fortran_attrs = {{.*}}<allocatable>, uniq_name = "_QFEr"} : (!fir.ref<!fir.box<!fir.heap<i32>>>) -> (!fir.ref<!fir.box<!fir.heap<i32>>>, !fir.ref<!fir.box<!fir.heap<i32>>>)
+! CHECK:                 hlfir.assign %[[VAL_19]] to %[[VAL_20]]#1 : i32, !fir.ref<i32>
+! CHECK:                 %[[VAL_22:.*]] = fir.load %[[VAL_20]]#0 : !fir.ref<i32>
+! CHECK:                 hlfir.assign %[[VAL_22]] to %[[VAL_21]]#0 realloc : i32, !fir.ref<!fir.box<!fir.heap<i32>>>
 ! CHECK:                 omp.yield
 ! CHECK:               }
 ! CHECK:             }
 ! CHECK:             omp.terminator
 ! CHECK:           }
+! CHECK:           %[[VAL_23:.*]] = arith.constant 6 : i32
+! CHECK:           %[[VAL_24:.*]] = fir.address_of(@_QQclX100ec2b8f633a84df3b7cc2ad55f845c) : !fir.ref<!fir.char<1,88>>
+! CHECK:           %[[VAL_25:.*]] = fir.convert %[[VAL_24]] : (!fir.ref<!fir.char<1,88>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_26:.*]] = arith.constant 17 : i32
+! CHECK:           %[[VAL_27:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_23]], %[[VAL_25]], %[[VAL_26]]) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_28:.*]] = fir.load %[[VAL_5]]#0 : !fir.ref<!fir.box<!fir.heap<i32>>>
+! CHECK:           %[[VAL_29:.*]] = fir.box_addr %[[VAL_28]] : (!fir.box<!fir.heap<i32>>) -> !fir.heap<i32>
+! CHECK:           %[[VAL_30:.*]] = fir.load %[[VAL_29]] : !fir.heap<i32>
+! CHECK:           %[[VAL_31:.*]] = fir.call @_FortranAioOutputInteger32(%[[VAL_27]], %[[VAL_30]]) fastmath<contract> : (!fir.ref<i8>, i32) -> i1
+! CHECK:           %[[VAL_32:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_27]]) fastmath<contract> : (!fir.ref<i8>) -> i32
+! CHECK:           return
+! CHECK:         }
 

--- a/flang/test/Lower/allocatables.f90
+++ b/flang/test/Lower/allocatables.f90
@@ -1,66 +1,183 @@
 ! RUN: bbc --use-desc-for-alloc=false -emit-fir -hlfir=false %s -o - | FileCheck %s
 
 ! Test lowering of allocatables using runtime for allocate/deallcoate statements.
-! CHECK-LABEL: _QPfooscalar
 subroutine fooscalar()
   ! Test lowering of local allocatable specification
   real, allocatable :: x
-  ! CHECK: %[[xAddrVar:.*]] = fir.alloca !fir.heap<f32> {{{.*}}uniq_name = "_QFfooscalarEx.addr"}
-  ! CHECK: %[[nullAddr:.*]] = fir.zero_bits !fir.heap<f32>
-  ! CHECK: fir.store %[[nullAddr]] to %[[xAddrVar]] : !fir.ref<!fir.heap<f32>>
-
   ! Test allocation of local allocatables
   allocate(x)
-  ! CHECK: %[[alloc:.*]] = fir.allocmem f32 {{{.*}}uniq_name = "_QFfooscalarEx.alloc"}
-  ! CHECK: fir.store %[[alloc]] to %[[xAddrVar]] : !fir.ref<!fir.heap<f32>>
-
   ! Test reading allocatable bounds and extents
   print *, x
-  ! CHECK: %[[xAddr1:.*]] = fir.load %[[xAddrVar]] : !fir.ref<!fir.heap<f32>>
-  ! CHECK: = fir.load %[[xAddr1]] : !fir.heap<f32>
-
   ! Test deallocation
   deallocate(x)
-  ! CHECK: %[[xAddr2:.*]] = fir.load %[[xAddrVar]] : !fir.ref<!fir.heap<f32>>
-  ! CHECK: fir.freemem %[[xAddr2]]
-  ! CHECK: %[[nullAddr1:.*]] = fir.zero_bits !fir.heap<f32>
-  ! fir.store %[[nullAddr1]] to %[[xAddrVar]] : !fir.ref<!fir.heap<f32>>
 end subroutine
+! CHECK-LABEL:   func.func @_QPfooscalar() {
+! CHECK:           %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.heap<f32>> {bindc_name = "x", uniq_name = "_QFfooscalarEx"}
+! CHECK:           %[[VAL_1:.*]] = fir.alloca !fir.heap<f32> {uniq_name = "_QFfooscalarEx.addr"}
+! CHECK:           %[[VAL_2:.*]] = fir.zero_bits !fir.heap<f32>
+! CHECK:           fir.store %[[VAL_2]] to %[[VAL_1]] : !fir.ref<!fir.heap<f32>>
+! CHECK:           %[[VAL_3:.*]] = arith.constant false
+! CHECK:           %[[VAL_4:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_5:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_6:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_7:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<f32>>
+! CHECK:           %[[VAL_8:.*]] = fir.embox %[[VAL_7]] : (!fir.heap<f32>) -> !fir.box<!fir.heap<f32>>
+! CHECK:           fir.store %[[VAL_8]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+! CHECK:           %[[VAL_9:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_10:.*]] = fir.convert %[[VAL_5]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_11:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_9]], %[[VAL_3]], %[[VAL_4]], %[[VAL_10]], %[[VAL_6]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_12:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+! CHECK:           %[[VAL_13:.*]] = fir.box_addr %[[VAL_12]] : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
+! CHECK:           fir.store %[[VAL_13]] to %[[VAL_1]] : !fir.ref<!fir.heap<f32>>
+! CHECK:           %[[VAL_14:.*]] = arith.constant 6 : i32
+! CHECK:           %[[VAL_15:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_15]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_17:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_18:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_14]], %[[VAL_16]], %[[VAL_17]]) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_19:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<f32>>
+! CHECK:           %[[VAL_20:.*]] = fir.load %[[VAL_19]] : !fir.heap<f32>
+! CHECK:           %[[VAL_21:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_18]], %[[VAL_20]]) fastmath<contract> : (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_22:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_18]]) fastmath<contract> : (!fir.ref<i8>) -> i32
+! CHECK:           %[[VAL_23:.*]] = arith.constant false
+! CHECK:           %[[VAL_24:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_25:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_26:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_27:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<f32>>
+! CHECK:           %[[VAL_28:.*]] = fir.embox %[[VAL_27]] : (!fir.heap<f32>) -> !fir.box<!fir.heap<f32>>
+! CHECK:           fir.store %[[VAL_28]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+! CHECK:           %[[VAL_29:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_30:.*]] = fir.convert %[[VAL_25]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_31:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_29]], %[[VAL_23]], %[[VAL_24]], %[[VAL_30]], %[[VAL_26]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_32:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+! CHECK:           %[[VAL_33:.*]] = fir.box_addr %[[VAL_32]] : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
+! CHECK:           fir.store %[[VAL_33]] to %[[VAL_1]] : !fir.ref<!fir.heap<f32>>
+! CHECK:           %[[VAL_34:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<f32>>
+! CHECK:           %[[VAL_35:.*]] = fir.convert %[[VAL_34]] : (!fir.heap<f32>) -> i64
+! CHECK:           %[[VAL_36:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_37:.*]] = arith.cmpi ne, %[[VAL_35]], %[[VAL_36]] : i64
+! CHECK:           fir.if %[[VAL_37]] {
+! CHECK:             %[[VAL_38:.*]] = arith.constant false
+! CHECK:             %[[VAL_39:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_40:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:             %[[VAL_41:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_42:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<f32>>
+! CHECK:             %[[VAL_43:.*]] = fir.embox %[[VAL_42]] : (!fir.heap<f32>) -> !fir.box<!fir.heap<f32>>
+! CHECK:             fir.store %[[VAL_43]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+! CHECK:             %[[VAL_44:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.heap<f32>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_45:.*]] = fir.convert %[[VAL_40]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_46:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_44]], %[[VAL_38]], %[[VAL_39]], %[[VAL_45]], %[[VAL_41]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:             %[[VAL_47:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<f32>>>
+! CHECK:             %[[VAL_48:.*]] = fir.box_addr %[[VAL_47]] : (!fir.box<!fir.heap<f32>>) -> !fir.heap<f32>
+! CHECK:             fir.store %[[VAL_48]] to %[[VAL_1]] : !fir.ref<!fir.heap<f32>>
+! CHECK:           }
+! CHECK:           return
+! CHECK:         }
 
-! CHECK-LABEL: _QPfoodim1
 subroutine foodim1()
   ! Test lowering of local allocatable specification
   real, allocatable :: x(:)
-  ! CHECK-DAG: %[[xAddrVar:.*]] = fir.alloca !fir.heap<!fir.array<?xf32>> {{{.*}}uniq_name = "_QFfoodim1Ex.addr"}
-  ! CHECK-DAG: %[[xLbVar:.*]] = fir.alloca index {{{.*}}uniq_name = "_QFfoodim1Ex.lb0"}
-  ! CHECK-DAG: %[[xExtVar:.*]] = fir.alloca index {{{.*}}uniq_name = "_QFfoodim1Ex.ext0"}
-  ! CHECK: %[[nullAddr:.*]] = fir.zero_bits !fir.heap<!fir.array<?xf32>>
-  ! CHECK: fir.store %[[nullAddr]] to %[[xAddrVar]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
-
   ! Test allocation of local allocatables
   allocate(x(42:100))
-  ! CHECK-DAG: %[[c42:.*]] = fir.convert %c42{{.*}} : (i32) -> index
-  ! CHECK-DAG: %[[c100:.*]] = fir.convert %c100_i32 : (i32) -> index
-  ! CHECK-DAG: %[[diff:.*]] = arith.subi %[[c100]], %[[c42]] : index
-  ! CHECK: %[[rawExtent:.*]] = arith.addi %[[diff]], %c1{{.*}} : index
-  ! CHECK: %[[extentPositive:.*]] = arith.cmpi sgt, %[[rawExtent]], %c0{{.*}} : index
-  ! CHECK: %[[extent:.*]] = arith.select %[[extentPositive]], %[[rawExtent]], %c0{{.*}} : index
-  ! CHECK: %[[alloc:.*]] = fir.allocmem !fir.array<?xf32>, %[[extent]] {{{.*}}uniq_name = "_QFfoodim1Ex.alloc"}
-  ! CHECK-DAG: fir.store %[[alloc]] to %[[xAddrVar]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
-  ! CHECK-DAG: fir.store %[[extent]] to %[[xExtVar]] : !fir.ref<index>
-  ! CHECK-DAG: fir.store %[[c42]] to %[[xLbVar]] : !fir.ref<index>
-
   ! Test reading allocatable bounds and extents
   print *, x(42)
-  ! CHECK-DAG: fir.load %[[xLbVar]] : !fir.ref<index>
-  ! CHECK-DAG: fir.load %[[xAddrVar]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
-
   deallocate(x)
-  ! CHECK: %[[xAddr1:.*]] = fir.load %1 : !fir.ref<!fir.heap<!fir.array<?xf32>>>
-  ! CHECK: fir.freemem %[[xAddr1]]
-  ! CHECK: %[[nullAddr1:.*]] = fir.zero_bits !fir.heap<!fir.array<?xf32>>
-  ! CHECK: fir.store %[[nullAddr1]] to %[[xAddrVar]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
 end subroutine
+! CHECK-LABEL:   func.func @_QPfoodim1() {
+! CHECK:           %[[VAL_0:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xf32>>> {bindc_name = "x", uniq_name = "_QFfoodim1Ex"}
+! CHECK:           %[[VAL_1:.*]] = fir.alloca !fir.heap<!fir.array<?xf32>> {uniq_name = "_QFfoodim1Ex.addr"}
+! CHECK:           %[[VAL_2:.*]] = fir.alloca index {uniq_name = "_QFfoodim1Ex.lb0"}
+! CHECK:           %[[VAL_3:.*]] = fir.alloca index {uniq_name = "_QFfoodim1Ex.ext0"}
+! CHECK:           %[[VAL_4:.*]] = fir.zero_bits !fir.heap<!fir.array<?xf32>>
+! CHECK:           fir.store %[[VAL_4]] to %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
+! CHECK:           %[[VAL_5:.*]] = arith.constant false
+! CHECK:           %[[VAL_6:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_7:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_8:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_9:.*]] = fir.load %[[VAL_2]] : !fir.ref<index>
+! CHECK:           %[[VAL_10:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:           %[[VAL_11:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
+! CHECK:           %[[VAL_12:.*]] = fir.shape_shift %[[VAL_9]], %[[VAL_10]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:           %[[VAL_13:.*]] = fir.embox %[[VAL_11]](%[[VAL_12]]) : (!fir.heap<!fir.array<?xf32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xf32>>>
+! CHECK:           fir.store %[[VAL_13]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+! CHECK:           %[[VAL_14:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_15:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_16:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_17:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_18:.*]] = fir.convert %[[VAL_14]] : (i32) -> i64
+! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_15]] : (i32) -> i64
+! CHECK:           fir.call @_FortranAAllocatableSetBounds(%[[VAL_17]], %[[VAL_16]], %[[VAL_18]], %[[VAL_19]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i32, i64, i64) -> ()
+! CHECK:           %[[VAL_20:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_7]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_22:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_20]], %[[VAL_5]], %[[VAL_6]], %[[VAL_21]], %[[VAL_8]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_23:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+! CHECK:           %[[VAL_24:.*]] = arith.constant {{.*}} : index
+! CHECK:           %[[VAL_25:.*]]:3 = fir.box_dims %[[VAL_23]], %[[VAL_24]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_26:.*]] = fir.box_addr %[[VAL_23]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
+! CHECK:           fir.store %[[VAL_26]] to %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
+! CHECK:           fir.store %[[VAL_25]]#1 to %[[VAL_3]] : !fir.ref<index>
+! CHECK:           fir.store %[[VAL_25]]#0 to %[[VAL_2]] : !fir.ref<index>
+! CHECK:           %[[VAL_27:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_28:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_29:.*]] = fir.convert %[[VAL_28]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_30:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_31:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_27]], %[[VAL_29]], %[[VAL_30]]) fastmath<contract> : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_32:.*]] = fir.load %[[VAL_2]] : !fir.ref<index>
+! CHECK:           %[[VAL_33:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
+! CHECK:           %[[VAL_34:.*]] = arith.constant {{.*}} : i64
+! CHECK:           %[[VAL_35:.*]] = fir.convert %[[VAL_32]] : (index) -> i64
+! CHECK:           %[[VAL_36:.*]] = arith.subi %[[VAL_34]], %[[VAL_35]] : i64
+! CHECK:           %[[VAL_37:.*]] = fir.coordinate_of %[[VAL_33]], %[[VAL_36]] : (!fir.heap<!fir.array<?xf32>>, i64) -> !fir.ref<f32>
+! CHECK:           %[[VAL_38:.*]] = fir.load %[[VAL_37]] : !fir.ref<f32>
+! CHECK:           %[[VAL_39:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_31]], %[[VAL_38]]) fastmath<contract> : (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_40:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_31]]) fastmath<contract> : (!fir.ref<i8>) -> i32
+! CHECK:           %[[VAL_41:.*]] = arith.constant false
+! CHECK:           %[[VAL_42:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_43:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_44:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_45:.*]] = fir.load %[[VAL_2]] : !fir.ref<index>
+! CHECK:           %[[VAL_46:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:           %[[VAL_47:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
+! CHECK:           %[[VAL_48:.*]] = fir.shape_shift %[[VAL_45]], %[[VAL_46]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:           %[[VAL_49:.*]] = fir.embox %[[VAL_47]](%[[VAL_48]]) : (!fir.heap<!fir.array<?xf32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xf32>>>
+! CHECK:           fir.store %[[VAL_49]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+! CHECK:           %[[VAL_50:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_51:.*]] = fir.convert %[[VAL_43]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_52:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_50]], %[[VAL_41]], %[[VAL_42]], %[[VAL_51]], %[[VAL_44]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_53:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+! CHECK:           %[[VAL_54:.*]] = arith.constant {{.*}} : index
+! CHECK:           %[[VAL_55:.*]]:3 = fir.box_dims %[[VAL_53]], %[[VAL_54]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_56:.*]] = fir.box_addr %[[VAL_53]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
+! CHECK:           fir.store %[[VAL_56]] to %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
+! CHECK:           fir.store %[[VAL_55]]#1 to %[[VAL_3]] : !fir.ref<index>
+! CHECK:           fir.store %[[VAL_55]]#0 to %[[VAL_2]] : !fir.ref<index>
+! CHECK:           %[[VAL_57:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
+! CHECK:           %[[VAL_58:.*]] = fir.convert %[[VAL_57]] : (!fir.heap<!fir.array<?xf32>>) -> i64
+! CHECK:           %[[VAL_59:.*]] = arith.constant {{.*}} : i64
+! CHECK:           %[[VAL_60:.*]] = arith.cmpi ne, %[[VAL_58]], %[[VAL_59]] : i64
+! CHECK:           fir.if %[[VAL_60]] {
+! CHECK:             %[[VAL_61:.*]] = arith.constant false
+! CHECK:             %[[VAL_62:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_63:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:             %[[VAL_64:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_65:.*]] = fir.load %[[VAL_2]] : !fir.ref<index>
+! CHECK:             %[[VAL_66:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:             %[[VAL_67:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
+! CHECK:             %[[VAL_68:.*]] = fir.shape_shift %[[VAL_65]], %[[VAL_66]] : (index, index) -> !fir.shapeshift<1>
+! CHECK:             %[[VAL_69:.*]] = fir.embox %[[VAL_67]](%[[VAL_68]]) : (!fir.heap<!fir.array<?xf32>>, !fir.shapeshift<1>) -> !fir.box<!fir.heap<!fir.array<?xf32>>>
+! CHECK:             fir.store %[[VAL_69]] to %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+! CHECK:             %[[VAL_70:.*]] = fir.convert %[[VAL_0]] : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_71:.*]] = fir.convert %[[VAL_63]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_72:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_70]], %[[VAL_61]], %[[VAL_62]], %[[VAL_71]], %[[VAL_64]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:             %[[VAL_73:.*]] = fir.load %[[VAL_0]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+! CHECK:             %[[VAL_74:.*]] = arith.constant {{.*}} : index
+! CHECK:             %[[VAL_75:.*]]:3 = fir.box_dims %[[VAL_73]], %[[VAL_74]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>, index) -> (index, index, index)
+! CHECK:             %[[VAL_76:.*]] = fir.box_addr %[[VAL_73]] : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
+! CHECK:             fir.store %[[VAL_76]] to %[[VAL_1]] : !fir.ref<!fir.heap<!fir.array<?xf32>>>
+! CHECK:             fir.store %[[VAL_75]]#1 to %[[VAL_3]] : !fir.ref<index>
+! CHECK:             fir.store %[[VAL_75]]#0 to %[[VAL_2]] : !fir.ref<index>
+! CHECK:           }
+! CHECK:           return
+! CHECK:         }
 
 ! CHECK-LABEL: _QPfoodim2
 subroutine foodim2()
@@ -74,82 +191,358 @@ subroutine foodim2()
 end subroutine
 
 ! test lowering of character allocatables. Focus is placed on the length handling
-! CHECK-LABEL: _QPchar_deferred(
 subroutine char_deferred(n)
   integer :: n
   character(:), allocatable :: c
-  ! CHECK-DAG: %[[cAddrVar:.*]] = fir.alloca !fir.heap<!fir.char<1,?>> {{{.*}}uniq_name = "_QFchar_deferredEc.addr"}
-  ! CHECK-DAG: %[[cLenVar:.*]] = fir.alloca index {{{.*}}uniq_name = "_QFchar_deferredEc.len"}
   allocate(character(10):: c)
-  ! CHECK: %[[c10:.]] = fir.convert %c10_i32 : (i32) -> index
-  ! CHECK: fir.allocmem !fir.char<1,?>(%[[c10]] : index) {{{.*}}uniq_name = "_QFchar_deferredEc.alloc"}
-  ! CHECK: fir.store %[[c10]] to %[[cLenVar]] : !fir.ref<index>
   deallocate(c)
-  ! CHECK: fir.freemem %{{.*}}
   allocate(character(n):: c)
-  ! CHECK: %[[n:.*]] = fir.load %arg0 : !fir.ref<i32>
-  ! CHECK: %[[nPositive:.*]] = arith.cmpi sgt, %[[n]], %c0{{.*}} : i32
-  ! CHECK: %[[ns:.*]] = arith.select %[[nPositive]], %[[n]], %c0{{.*}} : i32
-  ! CHECK: %[[ni:.*]] = fir.convert %[[ns]] : (i32) -> index
-  ! CHECK: fir.allocmem !fir.char<1,?>(%[[ni]] : index) {{{.*}}uniq_name = "_QFchar_deferredEc.alloc"}
-  ! CHECK: fir.store %[[ni]] to %[[cLenVar]] : !fir.ref<index>
-
   call bar(c)
-  ! CHECK-DAG: %[[cLen:.*]] = fir.load %[[cLenVar]] : !fir.ref<index>
-  ! CHECK-DAG: %[[cAddr:.*]] = fir.load %[[cAddrVar]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
-  ! CHECK: fir.emboxchar %[[cAddr]], %[[cLen]] : (!fir.heap<!fir.char<1,?>>, index) -> !fir.boxchar<1>
 end subroutine
+! CHECK-LABEL:   func.func @_QPchar_deferred(
+! CHECK-SAME:                                %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.ref<i32> {fir.bindc_name = "n"}) {
+! CHECK:           %[[VAL_1:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {bindc_name = "c", uniq_name = "_QFchar_deferredEc"}
+! CHECK:           %[[VAL_2:.*]] = fir.alloca !fir.heap<!fir.char<1,?>> {uniq_name = "_QFchar_deferredEc.addr"}
+! CHECK:           %[[VAL_3:.*]] = fir.alloca index {uniq_name = "_QFchar_deferredEc.len"}
+! CHECK:           %[[VAL_4:.*]] = fir.zero_bits !fir.heap<!fir.char<1,?>>
+! CHECK:           fir.store %[[VAL_4]] to %[[VAL_2]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_5:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_6:.*]] = arith.constant false
+! CHECK:           %[[VAL_7:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_8:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_9:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_10:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:           %[[VAL_11:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_12:.*]] = fir.embox %[[VAL_11]] typeparams %[[VAL_10]] : (!fir.heap<!fir.char<1,?>>, index) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+! CHECK:           fir.store %[[VAL_12]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:           %[[VAL_13:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_14:.*]] = fir.convert %[[VAL_5]] : (i32) -> i64
+! CHECK:           %[[VAL_15:.*]] = arith.constant 1 : i32
+! CHECK:           %[[VAL_16:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_17:.*]] = arith.constant 0 : i32
+! CHECK:           fir.call @_FortranAAllocatableInitCharacterForAllocate(%[[VAL_13]], %[[VAL_14]], %[[VAL_15]], %[[VAL_16]], %[[VAL_17]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i64, i32, i32, i32) -> ()
+! CHECK:           %[[VAL_18:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_19:.*]] = fir.convert %[[VAL_8]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_20:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_18]], %[[VAL_6]], %[[VAL_7]], %[[VAL_19]], %[[VAL_9]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_21:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:           %[[VAL_22:.*]] = fir.box_elesize %[[VAL_21]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> index
+! CHECK:           %[[VAL_23:.*]] = fir.box_addr %[[VAL_21]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+! CHECK:           fir.store %[[VAL_23]] to %[[VAL_2]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           fir.store %[[VAL_22]] to %[[VAL_3]] : !fir.ref<index>
+! CHECK:           %[[VAL_24:.*]] = arith.constant false
+! CHECK:           %[[VAL_25:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_26:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_27:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_28:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:           %[[VAL_29:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_30:.*]] = fir.embox %[[VAL_29]] typeparams %[[VAL_28]] : (!fir.heap<!fir.char<1,?>>, index) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+! CHECK:           fir.store %[[VAL_30]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:           %[[VAL_31:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_32:.*]] = fir.convert %[[VAL_26]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_33:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_31]], %[[VAL_24]], %[[VAL_25]], %[[VAL_32]], %[[VAL_27]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_34:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:           %[[VAL_35:.*]] = fir.box_elesize %[[VAL_34]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> index
+! CHECK:           %[[VAL_36:.*]] = fir.box_addr %[[VAL_34]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+! CHECK:           fir.store %[[VAL_36]] to %[[VAL_2]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           fir.store %[[VAL_35]] to %[[VAL_3]] : !fir.ref<index>
+! CHECK:           %[[VAL_37:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:           %[[VAL_38:.*]] = arith.constant false
+! CHECK:           %[[VAL_39:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_40:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_41:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_42:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:           %[[VAL_43:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_44:.*]] = fir.embox %[[VAL_43]] typeparams %[[VAL_42]] : (!fir.heap<!fir.char<1,?>>, index) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+! CHECK:           fir.store %[[VAL_44]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:           %[[VAL_45:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_46:.*]] = fir.convert %[[VAL_37]] : (i32) -> i64
+! CHECK:           %[[VAL_47:.*]] = arith.constant 1 : i32
+! CHECK:           %[[VAL_48:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_49:.*]] = arith.constant 0 : i32
+! CHECK:           fir.call @_FortranAAllocatableInitCharacterForAllocate(%[[VAL_45]], %[[VAL_46]], %[[VAL_47]], %[[VAL_48]], %[[VAL_49]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i64, i32, i32, i32) -> ()
+! CHECK:           %[[VAL_50:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_51:.*]] = fir.convert %[[VAL_40]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_52:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_50]], %[[VAL_38]], %[[VAL_39]], %[[VAL_51]], %[[VAL_41]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_53:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:           %[[VAL_54:.*]] = fir.box_elesize %[[VAL_53]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> index
+! CHECK:           %[[VAL_55:.*]] = fir.box_addr %[[VAL_53]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+! CHECK:           fir.store %[[VAL_55]] to %[[VAL_2]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           fir.store %[[VAL_54]] to %[[VAL_3]] : !fir.ref<index>
+! CHECK:           %[[VAL_56:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:           %[[VAL_57:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_58:.*]] = fir.emboxchar %[[VAL_57]], %[[VAL_56]] : (!fir.heap<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:           fir.call @_QPbar(%[[VAL_58]]) fastmath<contract> : (!fir.boxchar<1>) -> ()
+! CHECK:           %[[VAL_59:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_60:.*]] = fir.convert %[[VAL_59]] : (!fir.heap<!fir.char<1,?>>) -> i64
+! CHECK:           %[[VAL_61:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_62:.*]] = arith.cmpi ne, %[[VAL_60]], %[[VAL_61]] : i64
+! CHECK:           fir.if %[[VAL_62]] {
+! CHECK:             %[[VAL_63:.*]] = arith.constant false
+! CHECK:             %[[VAL_64:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_65:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:             %[[VAL_66:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_67:.*]] = fir.load %[[VAL_3]] : !fir.ref<index>
+! CHECK:             %[[VAL_68:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:             %[[VAL_69:.*]] = fir.embox %[[VAL_68]] typeparams %[[VAL_67]] : (!fir.heap<!fir.char<1,?>>, index) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+! CHECK:             fir.store %[[VAL_69]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:             %[[VAL_70:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_71:.*]] = fir.convert %[[VAL_65]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_72:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_70]], %[[VAL_63]], %[[VAL_64]], %[[VAL_71]], %[[VAL_66]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:             %[[VAL_73:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:             %[[VAL_74:.*]] = fir.box_elesize %[[VAL_73]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> index
+! CHECK:             %[[VAL_75:.*]] = fir.box_addr %[[VAL_73]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+! CHECK:             fir.store %[[VAL_75]] to %[[VAL_2]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:             fir.store %[[VAL_74]] to %[[VAL_3]] : !fir.ref<index>
+! CHECK:           }
+! CHECK:           return
+! CHECK:         }
 
-! CHECK-LABEL: _QPchar_explicit_cst(
 subroutine char_explicit_cst(n)
   integer :: n
   character(10), allocatable :: c
-  ! CHECK-DAG: %[[cLen:.*]] = arith.constant 10 : index
-  ! CHECK-DAG: %[[cAddrVar:.*]] = fir.alloca !fir.heap<!fir.char<1,10>> {{{.*}}uniq_name = "_QFchar_explicit_cstEc.addr"}
-  ! CHECK-NOT: "_QFchar_explicit_cstEc.len"
   allocate(c)
-  ! CHECK: fir.allocmem !fir.char<1,10> {{{.*}}uniq_name = "_QFchar_explicit_cstEc.alloc"}
   deallocate(c)
-  ! CHECK: fir.freemem %{{.*}}
   allocate(character(n):: c)
-  ! CHECK: fir.allocmem !fir.char<1,10> {{{.*}}uniq_name = "_QFchar_explicit_cstEc.alloc"}
   deallocate(c)
-  ! CHECK: fir.freemem %{{.*}}
   allocate(character(10):: c)
-  ! CHECK: fir.allocmem !fir.char<1,10> {{{.*}}uniq_name = "_QFchar_explicit_cstEc.alloc"}
   call bar(c)
-  ! CHECK: %[[cAddr:.*]] = fir.load %[[cAddrVar]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
-  ! CHECK: fir.emboxchar %[[cAddr]], %[[cLen]] : (!fir.heap<!fir.char<1,10>>, index) -> !fir.boxchar<1>
 end subroutine
+! CHECK-LABEL:   func.func @_QPchar_explicit_cst(
+! CHECK-SAME:                                    %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.ref<i32> {fir.bindc_name = "n"}) {
+! CHECK:           %[[VAL_1:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,10>>> {bindc_name = "c", uniq_name = "_QFchar_explicit_cstEc"}
+! CHECK:           %[[VAL_2:.*]] = arith.constant {{.*}} : index
+! CHECK:           %[[VAL_3:.*]] = fir.alloca !fir.heap<!fir.char<1,10>> {uniq_name = "_QFchar_explicit_cstEc.addr"}
+! CHECK:           %[[VAL_4:.*]] = fir.zero_bits !fir.heap<!fir.char<1,10>>
+! CHECK:           fir.store %[[VAL_4]] to %[[VAL_3]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
+! CHECK:           %[[VAL_5:.*]] = arith.constant false
+! CHECK:           %[[VAL_6:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_7:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_8:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_9:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
+! CHECK:           %[[VAL_10:.*]] = fir.embox %[[VAL_9]] : (!fir.heap<!fir.char<1,10>>) -> !fir.box<!fir.heap<!fir.char<1,10>>>
+! CHECK:           fir.store %[[VAL_10]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+! CHECK:           %[[VAL_11:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_12:.*]] = fir.convert %[[VAL_7]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_13:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_11]], %[[VAL_5]], %[[VAL_6]], %[[VAL_12]], %[[VAL_8]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_14:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+! CHECK:           %[[VAL_15:.*]] = fir.box_addr %[[VAL_14]] : (!fir.box<!fir.heap<!fir.char<1,10>>>) -> !fir.heap<!fir.char<1,10>>
+! CHECK:           fir.store %[[VAL_15]] to %[[VAL_3]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
+! CHECK:           %[[VAL_16:.*]] = arith.constant false
+! CHECK:           %[[VAL_17:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_18:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_19:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_20:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
+! CHECK:           %[[VAL_21:.*]] = fir.embox %[[VAL_20]] : (!fir.heap<!fir.char<1,10>>) -> !fir.box<!fir.heap<!fir.char<1,10>>>
+! CHECK:           fir.store %[[VAL_21]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+! CHECK:           %[[VAL_22:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_23:.*]] = fir.convert %[[VAL_18]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_24:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_22]], %[[VAL_16]], %[[VAL_17]], %[[VAL_23]], %[[VAL_19]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_25:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+! CHECK:           %[[VAL_26:.*]] = fir.box_addr %[[VAL_25]] : (!fir.box<!fir.heap<!fir.char<1,10>>>) -> !fir.heap<!fir.char<1,10>>
+! CHECK:           fir.store %[[VAL_26]] to %[[VAL_3]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
+! CHECK:           %[[VAL_27:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:           %[[VAL_28:.*]] = arith.constant false
+! CHECK:           %[[VAL_29:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_30:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_31:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_32:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
+! CHECK:           %[[VAL_33:.*]] = fir.embox %[[VAL_32]] : (!fir.heap<!fir.char<1,10>>) -> !fir.box<!fir.heap<!fir.char<1,10>>>
+! CHECK:           fir.store %[[VAL_33]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+! CHECK:           %[[VAL_34:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_35:.*]] = fir.convert %[[VAL_27]] : (i32) -> i64
+! CHECK:           %[[VAL_36:.*]] = arith.constant 1 : i32
+! CHECK:           %[[VAL_37:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_38:.*]] = arith.constant 0 : i32
+! CHECK:           fir.call @_FortranAAllocatableInitCharacterForAllocate(%[[VAL_34]], %[[VAL_35]], %[[VAL_36]], %[[VAL_37]], %[[VAL_38]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i64, i32, i32, i32) -> ()
+! CHECK:           %[[VAL_39:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_40:.*]] = fir.convert %[[VAL_30]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_41:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_39]], %[[VAL_28]], %[[VAL_29]], %[[VAL_40]], %[[VAL_31]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_42:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+! CHECK:           %[[VAL_43:.*]] = fir.box_addr %[[VAL_42]] : (!fir.box<!fir.heap<!fir.char<1,10>>>) -> !fir.heap<!fir.char<1,10>>
+! CHECK:           fir.store %[[VAL_43]] to %[[VAL_3]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
+! CHECK:           %[[VAL_44:.*]] = arith.constant false
+! CHECK:           %[[VAL_45:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_46:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_47:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_48:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
+! CHECK:           %[[VAL_49:.*]] = fir.embox %[[VAL_48]] : (!fir.heap<!fir.char<1,10>>) -> !fir.box<!fir.heap<!fir.char<1,10>>>
+! CHECK:           fir.store %[[VAL_49]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+! CHECK:           %[[VAL_50:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_51:.*]] = fir.convert %[[VAL_46]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_52:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_50]], %[[VAL_44]], %[[VAL_45]], %[[VAL_51]], %[[VAL_47]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_53:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+! CHECK:           %[[VAL_54:.*]] = fir.box_addr %[[VAL_53]] : (!fir.box<!fir.heap<!fir.char<1,10>>>) -> !fir.heap<!fir.char<1,10>>
+! CHECK:           fir.store %[[VAL_54]] to %[[VAL_3]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
+! CHECK:           %[[VAL_55:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_56:.*]] = arith.constant false
+! CHECK:           %[[VAL_57:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_58:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_59:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_60:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
+! CHECK:           %[[VAL_61:.*]] = fir.embox %[[VAL_60]] : (!fir.heap<!fir.char<1,10>>) -> !fir.box<!fir.heap<!fir.char<1,10>>>
+! CHECK:           fir.store %[[VAL_61]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+! CHECK:           %[[VAL_62:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_63:.*]] = fir.convert %[[VAL_55]] : (i32) -> i64
+! CHECK:           %[[VAL_64:.*]] = arith.constant 1 : i32
+! CHECK:           %[[VAL_65:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_66:.*]] = arith.constant 0 : i32
+! CHECK:           fir.call @_FortranAAllocatableInitCharacterForAllocate(%[[VAL_62]], %[[VAL_63]], %[[VAL_64]], %[[VAL_65]], %[[VAL_66]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i64, i32, i32, i32) -> ()
+! CHECK:           %[[VAL_67:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_68:.*]] = fir.convert %[[VAL_58]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_69:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_67]], %[[VAL_56]], %[[VAL_57]], %[[VAL_68]], %[[VAL_59]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_70:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+! CHECK:           %[[VAL_71:.*]] = fir.box_addr %[[VAL_70]] : (!fir.box<!fir.heap<!fir.char<1,10>>>) -> !fir.heap<!fir.char<1,10>>
+! CHECK:           fir.store %[[VAL_71]] to %[[VAL_3]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
+! CHECK:           %[[VAL_72:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
+! CHECK:           %[[VAL_73:.*]] = fir.emboxchar %[[VAL_72]], %[[VAL_2]] : (!fir.heap<!fir.char<1,10>>, index) -> !fir.boxchar<1>
+! CHECK:           fir.call @_QPbar(%[[VAL_73]]) fastmath<contract> : (!fir.boxchar<1>) -> ()
+! CHECK:           %[[VAL_74:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
+! CHECK:           %[[VAL_75:.*]] = fir.convert %[[VAL_74]] : (!fir.heap<!fir.char<1,10>>) -> i64
+! CHECK:           %[[VAL_76:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_77:.*]] = arith.cmpi ne, %[[VAL_75]], %[[VAL_76]] : i64
+! CHECK:           fir.if %[[VAL_77]] {
+! CHECK:             %[[VAL_78:.*]] = arith.constant false
+! CHECK:             %[[VAL_79:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_80:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:             %[[VAL_81:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_82:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
+! CHECK:             %[[VAL_83:.*]] = fir.embox %[[VAL_82]] : (!fir.heap<!fir.char<1,10>>) -> !fir.box<!fir.heap<!fir.char<1,10>>>
+! CHECK:             fir.store %[[VAL_83]] to %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+! CHECK:             %[[VAL_84:.*]] = fir.convert %[[VAL_1]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_85:.*]] = fir.convert %[[VAL_80]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_86:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_84]], %[[VAL_78]], %[[VAL_79]], %[[VAL_85]], %[[VAL_81]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:             %[[VAL_87:.*]] = fir.load %[[VAL_1]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,10>>>>
+! CHECK:             %[[VAL_88:.*]] = fir.box_addr %[[VAL_87]] : (!fir.box<!fir.heap<!fir.char<1,10>>>) -> !fir.heap<!fir.char<1,10>>
+! CHECK:             fir.store %[[VAL_88]] to %[[VAL_3]] : !fir.ref<!fir.heap<!fir.char<1,10>>>
+! CHECK:           }
+! CHECK:           return
+! CHECK:         }
 
-! CHECK-LABEL: _QPchar_explicit_dyn(
 subroutine char_explicit_dyn(l1, l2)
   integer :: l1, l2
   character(l1), allocatable :: c
-  ! CHECK: %[[l1:.*]] = fir.load %arg0 : !fir.ref<i32>
-  ! CHECK: %[[c0_i32:.*]] = arith.constant 0 : i32
-  ! CHECK: %[[cmp:.*]] = arith.cmpi sgt, %[[l1]], %[[c0_i32]] : i32
-  ! CHECK: %[[cLen:.*]] = arith.select %[[cmp]], %[[l1]], %[[c0_i32]] : i32
-  ! CHECK: %[[cAddrVar:.*]] = fir.alloca !fir.heap<!fir.char<1,?>> {{{.*}}uniq_name = "_QFchar_explicit_dynEc.addr"}
-  ! CHECK-NOT: "_QFchar_explicit_dynEc.len"
   allocate(c)
-  ! CHECK: %[[cLenCast1:.*]] = fir.convert %[[cLen]] : (i32) -> index
-  ! CHECK: fir.allocmem !fir.char<1,?>(%[[cLenCast1]] : index) {{{.*}}uniq_name = "_QFchar_explicit_dynEc.alloc"}
   deallocate(c)
-  ! CHECK: fir.freemem %{{.*}}
   allocate(character(l2):: c)
-  ! CHECK: %[[cLenCast2:.*]] = fir.convert %[[cLen]] : (i32) -> index
-  ! CHECK: fir.allocmem !fir.char<1,?>(%[[cLenCast2]] : index) {{{.*}}uniq_name = "_QFchar_explicit_dynEc.alloc"}
   deallocate(c)
-  ! CHECK: fir.freemem %{{.*}}
   allocate(character(10):: c)
-  ! CHECK: %[[cLenCast3:.*]] = fir.convert %[[cLen]] : (i32) -> index
-  ! CHECK: fir.allocmem !fir.char<1,?>(%[[cLenCast3]] : index) {{{.*}}uniq_name = "_QFchar_explicit_dynEc.alloc"}
   call bar(c)
-  ! CHECK-DAG: %[[cLenCast4:.*]] = fir.convert %[[cLen]] : (i32) -> index
-  ! CHECK-DAG: %[[cAddr:.*]] = fir.load %[[cAddrVar]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
-  ! CHECK: fir.emboxchar %[[cAddr]], %[[cLenCast4]] : (!fir.heap<!fir.char<1,?>>, index) -> !fir.boxchar<1>
 end subroutine
+! CHECK-LABEL:   func.func @_QPchar_explicit_dyn(
+! CHECK-SAME:                                    %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.ref<i32> {fir.bindc_name = "l1"},
+! CHECK-SAME:                                    %[[VAL_1:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.ref<i32> {fir.bindc_name = "l2"}) {
+! CHECK:           %[[VAL_2:.*]] = fir.alloca !fir.box<!fir.heap<!fir.char<1,?>>> {bindc_name = "c", uniq_name = "_QFchar_explicit_dynEc"}
+! CHECK:           %[[VAL_3:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
+! CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_5:.*]] = arith.cmpi sgt, %[[VAL_3]], %[[VAL_4]] : i32
+! CHECK:           %[[VAL_6:.*]] = arith.select %[[VAL_5]], %[[VAL_3]], %[[VAL_4]] : i32
+! CHECK:           %[[VAL_7:.*]] = fir.alloca !fir.heap<!fir.char<1,?>> {uniq_name = "_QFchar_explicit_dynEc.addr"}
+! CHECK:           %[[VAL_8:.*]] = fir.zero_bits !fir.heap<!fir.char<1,?>>
+! CHECK:           fir.store %[[VAL_8]] to %[[VAL_7]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_9:.*]] = arith.constant false
+! CHECK:           %[[VAL_10:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_11:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_12:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_13:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_14:.*]] = fir.embox %[[VAL_13]] typeparams %[[VAL_6]] : (!fir.heap<!fir.char<1,?>>, i32) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+! CHECK:           fir.store %[[VAL_14]] to %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:           %[[VAL_15:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_16:.*]] = fir.convert %[[VAL_11]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_17:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_15]], %[[VAL_9]], %[[VAL_10]], %[[VAL_16]], %[[VAL_12]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_18:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:           %[[VAL_19:.*]] = fir.box_addr %[[VAL_18]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+! CHECK:           fir.store %[[VAL_19]] to %[[VAL_7]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_20:.*]] = arith.constant false
+! CHECK:           %[[VAL_21:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_22:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_23:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_24:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_25:.*]] = fir.embox %[[VAL_24]] typeparams %[[VAL_6]] : (!fir.heap<!fir.char<1,?>>, i32) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+! CHECK:           fir.store %[[VAL_25]] to %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:           %[[VAL_26:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_27:.*]] = fir.convert %[[VAL_22]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_28:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_26]], %[[VAL_20]], %[[VAL_21]], %[[VAL_27]], %[[VAL_23]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_29:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:           %[[VAL_30:.*]] = fir.box_addr %[[VAL_29]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+! CHECK:           fir.store %[[VAL_30]] to %[[VAL_7]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_31:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
+! CHECK:           %[[VAL_32:.*]] = arith.constant false
+! CHECK:           %[[VAL_33:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_34:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_35:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_36:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_37:.*]] = fir.embox %[[VAL_36]] typeparams %[[VAL_6]] : (!fir.heap<!fir.char<1,?>>, i32) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+! CHECK:           fir.store %[[VAL_37]] to %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:           %[[VAL_38:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_39:.*]] = fir.convert %[[VAL_31]] : (i32) -> i64
+! CHECK:           %[[VAL_40:.*]] = arith.constant 1 : i32
+! CHECK:           %[[VAL_41:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_42:.*]] = arith.constant 0 : i32
+! CHECK:           fir.call @_FortranAAllocatableInitCharacterForAllocate(%[[VAL_38]], %[[VAL_39]], %[[VAL_40]], %[[VAL_41]], %[[VAL_42]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i64, i32, i32, i32) -> ()
+! CHECK:           %[[VAL_43:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_44:.*]] = fir.convert %[[VAL_34]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_45:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_43]], %[[VAL_32]], %[[VAL_33]], %[[VAL_44]], %[[VAL_35]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_46:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:           %[[VAL_47:.*]] = fir.box_addr %[[VAL_46]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+! CHECK:           fir.store %[[VAL_47]] to %[[VAL_7]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_48:.*]] = arith.constant false
+! CHECK:           %[[VAL_49:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_50:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_51:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_52:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_53:.*]] = fir.embox %[[VAL_52]] typeparams %[[VAL_6]] : (!fir.heap<!fir.char<1,?>>, i32) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+! CHECK:           fir.store %[[VAL_53]] to %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:           %[[VAL_54:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_55:.*]] = fir.convert %[[VAL_50]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_56:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_54]], %[[VAL_48]], %[[VAL_49]], %[[VAL_55]], %[[VAL_51]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_57:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:           %[[VAL_58:.*]] = fir.box_addr %[[VAL_57]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+! CHECK:           fir.store %[[VAL_58]] to %[[VAL_7]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_59:.*]] = arith.constant 10 : i32
+! CHECK:           %[[VAL_60:.*]] = arith.constant false
+! CHECK:           %[[VAL_61:.*]] = fir.absent !fir.box<none>
+! CHECK:           %[[VAL_62:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:           %[[VAL_63:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_64:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_65:.*]] = fir.embox %[[VAL_64]] typeparams %[[VAL_6]] : (!fir.heap<!fir.char<1,?>>, i32) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+! CHECK:           fir.store %[[VAL_65]] to %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:           %[[VAL_66:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_67:.*]] = fir.convert %[[VAL_59]] : (i32) -> i64
+! CHECK:           %[[VAL_68:.*]] = arith.constant 1 : i32
+! CHECK:           %[[VAL_69:.*]] = arith.constant 0 : i32
+! CHECK:           %[[VAL_70:.*]] = arith.constant 0 : i32
+! CHECK:           fir.call @_FortranAAllocatableInitCharacterForAllocate(%[[VAL_66]], %[[VAL_67]], %[[VAL_68]], %[[VAL_69]], %[[VAL_70]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i64, i32, i32, i32) -> ()
+! CHECK:           %[[VAL_71:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:           %[[VAL_72:.*]] = fir.convert %[[VAL_62]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_73:.*]] = fir.call @_FortranAAllocatableAllocate(%[[VAL_71]], %[[VAL_60]], %[[VAL_61]], %[[VAL_72]], %[[VAL_63]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           %[[VAL_74:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:           %[[VAL_75:.*]] = fir.box_addr %[[VAL_74]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+! CHECK:           fir.store %[[VAL_75]] to %[[VAL_7]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_76:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_77:.*]] = fir.convert %[[VAL_6]] : (i32) -> index
+! CHECK:           %[[VAL_78:.*]] = fir.emboxchar %[[VAL_76]], %[[VAL_77]] : (!fir.heap<!fir.char<1,?>>, index) -> !fir.boxchar<1>
+! CHECK:           fir.call @_QPbar(%[[VAL_78]]) fastmath<contract> : (!fir.boxchar<1>) -> ()
+! CHECK:           %[[VAL_79:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           %[[VAL_80:.*]] = fir.convert %[[VAL_79]] : (!fir.heap<!fir.char<1,?>>) -> i64
+! CHECK:           %[[VAL_81:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_82:.*]] = arith.cmpi ne, %[[VAL_80]], %[[VAL_81]] : i64
+! CHECK:           fir.if %[[VAL_82]] {
+! CHECK:             %[[VAL_83:.*]] = arith.constant false
+! CHECK:             %[[VAL_84:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_85:.*]] = fir.address_of(@_QQclX8b6dcfbb2269977a79a6d83c61c3b19e) : !fir.ref<!fir.char<1,65>>
+! CHECK:             %[[VAL_86:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_87:.*]] = fir.load %[[VAL_7]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:             %[[VAL_88:.*]] = fir.embox %[[VAL_87]] typeparams %[[VAL_6]] : (!fir.heap<!fir.char<1,?>>, i32) -> !fir.box<!fir.heap<!fir.char<1,?>>>
+! CHECK:             fir.store %[[VAL_88]] to %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:             %[[VAL_89:.*]] = fir.convert %[[VAL_2]] : (!fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_90:.*]] = fir.convert %[[VAL_85]] : (!fir.ref<!fir.char<1,65>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_91:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_89]], %[[VAL_83]], %[[VAL_84]], %[[VAL_90]], %[[VAL_86]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:             %[[VAL_92:.*]] = fir.load %[[VAL_2]] : !fir.ref<!fir.box<!fir.heap<!fir.char<1,?>>>>
+! CHECK:             %[[VAL_93:.*]] = fir.box_addr %[[VAL_92]] : (!fir.box<!fir.heap<!fir.char<1,?>>>) -> !fir.heap<!fir.char<1,?>>
+! CHECK:             fir.store %[[VAL_93]] to %[[VAL_7]] : !fir.ref<!fir.heap<!fir.char<1,?>>>
+! CHECK:           }
+! CHECK:           return
+! CHECK:         }
 
 ! CHECK-LABEL: _QPspecifiers(
 subroutine specifiers

--- a/flang/test/Lower/derived-allocatable-components.f90
+++ b/flang/test/Lower/derived-allocatable-components.f90
@@ -385,21 +385,25 @@ subroutine allocate_real(a0_0, a1_0, a0_1, a1_1)
   type(real_a0) :: a0_0, a0_1(100)
   type(real_a1) :: a1_0, a1_1(100)
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a0_0]], p
-  ! CHECK: fir.store {{.*}} to %[[coor]]
+  ! CHECK: %[[conv:.*]] = fir.convert %[[coor]]
+  ! CHECK: fir.call @_FortranAAllocatableAllocate(%[[conv]]
   allocate(a0_0%p)
 
   ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a0_1]], %{{.*}}
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], p
-  ! CHECK: fir.store {{.*}} to %[[coor]]
+  ! CHECK: %[[conv:.*]] = fir.convert %[[coor]]
+  ! CHECK: fir.call @_FortranAAllocatableAllocate(%[[conv]]
   allocate(a0_1(5)%p)
 
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_0]], p
-  ! CHECK: fir.store {{.*}} to %[[coor]]
+  ! CHECK: %[[conv:.*]] = fir.convert %[[coor]]
+  ! CHECK: fir.call @_FortranAAllocatableSetBounds(%[[conv]]
   allocate(a1_0%p(100))
 
   ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a1_1]], %{{.*}}
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], p
-  ! CHECK: fir.store {{.*}} to %[[coor]]
+  ! CHECK: %[[conv:.*]] = fir.convert %[[coor]]
+  ! CHECK: fir.call @_FortranAAllocatableSetBounds(%[[conv]]
   allocate(a1_1(5)%p(100))
 end subroutine
 
@@ -409,21 +413,25 @@ subroutine allocate_cst_char(a0_0, a1_0, a0_1, a1_1)
   type(cst_char_a0) :: a0_0, a0_1(100)
   type(cst_char_a1) :: a1_0, a1_1(100)
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a0_0]], p
-  ! CHECK: fir.store {{.*}} to %[[coor]]
+  ! CHECK: %[[conv:.*]] = fir.convert %[[coor]]
+  ! CHECK: fir.call @_FortranAAllocatableAllocate(%[[conv]]
   allocate(a0_0%p)
 
   ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a0_1]], %{{.*}}
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], p
-  ! CHECK: fir.store {{.*}} to %[[coor]]
+  ! CHECK: %[[conv:.*]] = fir.convert %[[coor]]
+  ! CHECK: fir.call @_FortranAAllocatableAllocate(%[[conv]]
   allocate(a0_1(5)%p)
 
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_0]], p
-  ! CHECK: fir.store {{.*}} to %[[coor]]
+  ! CHECK: %[[conv:.*]] = fir.convert %[[coor]]
+  ! CHECK: fir.call @_FortranAAllocatableSetBounds(%[[conv]]
   allocate(a1_0%p(100))
 
   ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a1_1]], %{{.*}}
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], p
-  ! CHECK: fir.store {{.*}} to %[[coor]]
+  ! CHECK: %[[conv:.*]] = fir.convert %[[coor]]
+  ! CHECK: fir.call @_FortranAAllocatableSetBounds(%[[conv]]
   allocate(a1_1(5)%p(100))
 end subroutine
 
@@ -433,21 +441,25 @@ subroutine allocate_def_char(a0_0, a1_0, a0_1, a1_1)
   type(def_char_a0) :: a0_0, a0_1(100)
   type(def_char_a1) :: a1_0, a1_1(100)
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a0_0]], p
-  ! CHECK: fir.store {{.*}} to %[[coor]]
+  ! CHECK: %[[conv:.*]] = fir.convert %[[coor]]
+  ! CHECK: fir.call @_FortranAAllocatableInitCharacterForAllocate(%[[conv]]
   allocate(character(18)::a0_0%p)
 
   ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a0_1]], %{{.*}}
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], p
-  ! CHECK: fir.store {{.*}} to %[[coor]]
+  ! CHECK: %[[conv:.*]] = fir.convert %[[coor]]
+  ! CHECK: fir.call @_FortranAAllocatableInitCharacterForAllocate(%[[conv]]
   allocate(character(18)::a0_1(5)%p)
 
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_0]], p
-  ! CHECK: fir.store {{.*}} to %[[coor]]
+  ! CHECK: %[[conv:.*]] = fir.convert %[[coor]]
+  ! CHECK: fir.call @_FortranAAllocatableInitCharacterForAllocate(%[[conv]]
   allocate(character(18)::a1_0%p(100))
 
   ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a1_1]], %{{.*}}
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], p
-  ! CHECK: fir.store {{.*}} to %[[coor]]
+  ! CHECK: %[[conv:.*]] = fir.convert %[[coor]]
+  ! CHECK: fir.call @_FortranAAllocatableInitCharacterForAllocate(%[[conv]]
   allocate(character(18)::a1_1(5)%p(100))
 end subroutine
 
@@ -461,21 +473,25 @@ subroutine deallocate_real(a0_0, a1_0, a0_1, a1_1)
   type(real_a0) :: a0_0, a0_1(100)
   type(real_a1) :: a1_0, a1_1(100)
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a0_0]], p
-  ! CHECK: fir.store {{.*}} to %[[coor]]
+  ! CHECK: %[[conv:.*]] = fir.convert %[[coor]]
+  ! CHECK: fir.call @_FortranAAllocatableDeallocate(%[[conv]]
   deallocate(a0_0%p)
 
   ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a0_1]], %{{.*}}
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], p
-  ! CHECK: fir.store {{.*}} to %[[coor]]
+  ! CHECK: %[[conv:.*]] = fir.convert %[[coor]]
+  ! CHECK: fir.call @_FortranAAllocatableDeallocate(%[[conv]]
   deallocate(a0_1(5)%p)
 
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[a1_0]], p
-  ! CHECK: fir.store {{.*}} to %[[coor]]
+  ! CHECK: %[[conv:.*]] = fir.convert %[[coor]]
+  ! CHECK: fir.call @_FortranAAllocatableDeallocate(%[[conv]]
   deallocate(a1_0%p)
 
   ! CHECK-DAG: %[[coor0:.*]] = fir.coordinate_of %[[a1_1]], %{{.*}}
   ! CHECK: %[[coor:.*]] = fir.coordinate_of %[[coor0]], p
-  ! CHECK: fir.store {{.*}} to %[[coor]]
+  ! CHECK: %[[conv:.*]] = fir.convert %[[coor]]
+  ! CHECK: fir.call @_FortranAAllocatableDeallocate(%[[conv]]
   deallocate(a1_1(5)%p)
 end subroutine
 

--- a/flang/test/Lower/intentout-deallocate.f90
+++ b/flang/test/Lower/intentout-deallocate.f90
@@ -56,16 +56,15 @@ contains
 ! CHECK: %[[BOX_ADDR_PTR:.*]] = fir.convert %[[BOX_ADDR]] : (!fir.heap<!fir.array<?xi32>>) -> i64
 ! CHECK: %[[C0:.*]] = arith.constant 0 : i64
 ! CHECK: %[[IS_ALLOCATED:.*]] = arith.cmpi ne, %[[BOX_ADDR_PTR]], %[[C0]] : i64
-! CHECK: fir.if %[[IS_ALLOCATED]] {
-! CHECK:   %[[BOX:.*]] = fir.load %[[ARG0]]{{[#0]*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:   %[[BOX_ADDR:.*]] = fir.box_addr %[[BOX]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! CHECK:   fir.freemem %[[BOX_ADDR]] : !fir.heap<!fir.array<?xi32>>
-! CHECK:   %[[ZERO:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
-! CHECK:   %[[C0:.*]] = arith.constant 0 : index
-! CHECK:   %[[SHAPE:.*]] = fir.shape %[[C0]] : (index) -> !fir.shape<1>
-! CHECK:   %[[EMBOX:.*]] = fir.embox %[[ZERO]](%[[SHAPE]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:   fir.store %[[EMBOX]] to %[[ARG0]]{{[#0]*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK: }
+! CHECK:   fir.if %[[IS_ALLOCATED]] {
+! CHECK:     %[[VAL_6:.*]] = arith.constant false
+! CHECK:     %[[VAL_7:.*]] = fir.absent !fir.box<none>
+! CHECK:     %[[VAL_8:.*]] = fir.address_of(@_QQclXec1fdecbdab00016d5f81c67562024e7) : !fir.ref<!fir.char<1,73>>
+! CHECK:     %[[VAL_9:.*]] = arith.constant 38 : i32
+! CHECK:     %[[VAL_10:.*]] = fir.convert {{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:     %[[VAL_11:.*]] = fir.convert %[[VAL_8]] : (!fir.ref<!fir.char<1,73>>) -> !fir.ref<i8>
+! CHECK:     %[[VAL_12:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_10]], %[[VAL_6]], %[[VAL_7]], %[[VAL_11]], %[[VAL_9]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:   }
 
   subroutine sub2()
     integer, allocatable :: a(:)
@@ -78,15 +77,14 @@ contains
 ! FIR-LABEL: func.func @_QMmod1Psub2()
 ! FIR: %[[BOX:.*]] = fir.alloca !fir.box<!fir.heap<!fir.array<?xi32>>> {bindc_name = "a", uniq_name = "_QMmod1Fsub2Ea"}
 ! FIR: %[[BOX_ALLOC:.*]] = fir.alloca !fir.heap<!fir.array<?xi32>> {uniq_name = "_QMmod1Fsub2Ea.addr"}
+! FIR: fir.call @_FortranAAllocatableAllocate
 ! FIR: %[[BOX_ADDR:.*]] = fir.load %[[BOX_ALLOC]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
 ! FIR: %[[BOX_ADDR_PTR:.*]] = fir.convert %[[BOX_ADDR]] : (!fir.heap<!fir.array<?xi32>>) -> i64
 ! FIR: %[[C0:.*]] = arith.constant 0 : i64
 ! FIR: %[[IS_ALLOCATED:.*]] = arith.cmpi ne, %[[BOX_ADDR_PTR]], %[[C0]] : i64
 ! FIR: fir.if %[[IS_ALLOCATED]] {
-! FIR:   %[[LOAD:.*]] = fir.load %[[BOX_ALLOC]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
-! FIR:   fir.freemem %[[LOAD]] : !fir.heap<!fir.array<?xi32>>
-! FIR:   %[[ZERO:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
-! FIR:   fir.store %[[ZERO]] to %[[BOX_ALLOC]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
+! FIR:    %[[CONV:.*]] = fir.convert %[[BOX]]
+! FIR:    %[[FREE:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[CONV]], {{.*}}
 ! FIR: }
 ! FIR: %[[LOAD:.*]] = fir.load %[[BOX_ALLOC]] : !fir.ref<!fir.heap<!fir.array<?xi32>>>
 ! FIR: %{{.*}} = fir.embox %[[LOAD]](%{{.*}}) : (!fir.heap<!fir.array<?xi32>>, !fir.shapeshift<
@@ -100,14 +98,14 @@ contains
 ! HLFIR: %[[C0:.*]] = arith.constant 0 : i64
 ! HLFIR: %[[IS_ALLOCATED:.*]] = arith.cmpi ne, %[[BOX_ADDR_PTR]], %[[C0]] : i64
 ! HLFIR: fir.if %[[IS_ALLOCATED]] {
-! HLFIR:   %[[BOX:.*]] = fir.load %[[ARG0]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! HLFIR:   %[[BOX_ADDR:.*]] = fir.box_addr %[[BOX]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! HLFIR:   fir.freemem %[[BOX_ADDR]] : !fir.heap<!fir.array<?xi32>>
-! HLFIR:   %[[ZERO:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
-! HLFIR:   %[[C0:.*]] = arith.constant 0 : index
-! HLFIR:   %[[SHAPE:.*]] = fir.shape %[[C0]] : (index) -> !fir.shape<1>
-! HLFIR:   %[[EMBOX:.*]] = fir.embox %[[ZERO]](%[[SHAPE]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! HLFIR:   fir.store %[[EMBOX]] to %[[ARG0]]#0 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! HLFIR:   %[[VAL_24:.*]] = arith.constant false
+! HLFIR:   %[[VAL_25:.*]] = fir.absent !fir.box<none>
+! HLFIR:   %[[VAL_26:.*]] = fir.address_of(@_QQclXec1fdecbdab00016d5f81c67562024e7) : !fir.ref<!fir.char<1,73>>
+! HLFIR:   %[[VAL_27:.*]] = arith.constant {{.*}} : i32
+! HLFIR:   %[[VAL_28:.*]] = fir.convert %[[ARG0]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! HLFIR:   %[[VAL_29:.*]] = fir.convert %[[VAL_26]] : (!fir.ref<!fir.char<1,73>>) -> !fir.ref<i8>
+! HLFIR:   %[[VAL_30:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_28]], %[[VAL_24]], %[[VAL_25]], %[[VAL_29]], %[[VAL_27]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! HLFIR: }
 ! HLFIR: fir.call @sub3(%[[ARG0]]#0) {{.*}}: (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> ()
 
   subroutine sub4()
@@ -180,24 +178,25 @@ contains
 ! CHECK-LABEL: func.func @_QMmod1Psub9(
 ! FIR-SAME:  %[[ARG0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {fir.bindc_name = "a", fir.optional})
 ! HLFIR: %[[ARG0:.*]]:2 = hlfir.declare {{.*}}"_QMmod1Fsub9Ea"
-! CHECK: %[[IS_PRESENT:.*]] = fir.is_present %[[ARG0]]{{[#0]*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> i1
-! CHECK: fir.if %[[IS_PRESENT]] {
-! CHECK:   %[[BOX:.*]] = fir.load %[[ARG0]]{{[#0]*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:   %[[BOX_ADDR:.*]] = fir.box_addr %[[BOX]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! CHECK:   %[[BOX_ADDR_PTR:.*]] = fir.convert %[[BOX_ADDR]] : (!fir.heap<!fir.array<?xi32>>) -> i64
-! CHECK:   %[[C0:.*]] = arith.constant 0 : i64
-! CHECK:   %[[IS_ALLOCATED:.*]] = arith.cmpi ne, %[[BOX_ADDR_PTR]], %[[C0]] : i64
-! CHECK:   fir.if %[[IS_ALLOCATED]] {
-! CHECK:     %[[BOX:.*]] = fir.load %[[ARG0]]{{[#0]*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:     %[[BOX_ADDR:.*]] = fir.box_addr %[[BOX]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! CHECK:     fir.freemem %[[BOX_ADDR]] : !fir.heap<!fir.array<?xi32>>
-! CHECK:     %[[ZERO:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
-! CHECK:     %[[C0:.*]] = arith.constant 0 : index
-! CHECK:     %[[SHAPE:.*]] = fir.shape %[[C0]] : (index) -> !fir.shape<1>
-! CHECK:     %[[EMBOX:.*]] = fir.embox %[[ZERO]](%[[SHAPE]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:     fir.store %[[EMBOX]] to %[[ARG0]]{{[#0]*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:   }
-! CHECK: }
+! CHECK:           %[[VAL_1:.*]] = fir.is_present %[[ARG0]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> i1
+! CHECK:           fir.if %[[VAL_1]] {
+! CHECK:             %[[VAL_2:.*]] = fir.load %[[ARG0]]{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:             %[[VAL_3:.*]] = fir.box_addr %[[VAL_2]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:             %[[VAL_4:.*]] = fir.convert %[[VAL_3]] : (!fir.heap<!fir.array<?xi32>>) -> i64
+! CHECK:             %[[VAL_5:.*]] = arith.constant 0 : i64
+! CHECK:             %[[VAL_6:.*]] = arith.cmpi ne, %[[VAL_4]], %[[VAL_5]] : i64
+! CHECK:             fir.if %[[VAL_6]] {
+! CHECK:               %[[VAL_7:.*]] = arith.constant false
+! CHECK:               %[[VAL_8:.*]] = fir.absent !fir.box<none>
+! CHECK:               %[[VAL_9:.*]] = fir.address_of(@_QQclXec1fdecbdab00016d5f81c67562024e7) : !fir.ref<!fir.char<1,73>>
+! CHECK:               %[[VAL_10:.*]] = arith.constant {{.*}} : i32
+! CHECK:               %[[VAL_11:.*]] = fir.convert %[[ARG0]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:               %[[VAL_12:.*]] = fir.convert %[[VAL_9]] : (!fir.ref<!fir.char<1,73>>) -> !fir.ref<i8>
+! CHECK:               %[[VAL_13:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_11]], %[[VAL_7]], %[[VAL_8]], %[[VAL_12]], %[[VAL_10]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:             }
+! CHECK:           }
+! CHECK:           return
+! CHECK:         }
 
   subroutine sub10(a)
     integer, intent(out), allocatable :: a(:)
@@ -208,21 +207,24 @@ contains
 ! CHECK-LABEL: func.func @_QMmod1Psub10(
 ! FIR-SAME: %[[ARG0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {fir.bindc_name = "a"}) {
 ! HLFIR: %[[ARG0:.*]]:2 = hlfir.declare {{.*}}"_QMmod1Fsub10Ea"
-! CHECK: %[[LOAD:.*]] = fir.load %[[ARG0]]{{[#0]*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK: %[[BOX_ADDR:.*]] = fir.box_addr %[[LOAD]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! CHECK: %[[BOX_ADDR_PTR:.*]] = fir.convert %[[BOX_ADDR]] : (!fir.heap<!fir.array<?xi32>>) -> i64
-! CHECK: %[[C0:.*]] = arith.constant 0 : i64
-! CHECK: %[[IS_ALLOCATED:.*]] = arith.cmpi ne, %[[BOX_ADDR_PTR]], %[[C0]] : i64
-! CHECK: fir.if %[[IS_ALLOCATED]] {
-! CHECK:   %[[BOX:.*]] = fir.load %[[ARG0]]{{[#0]*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:   %[[BOX_ADDR:.*]] = fir.box_addr %[[BOX]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! CHECK:   fir.freemem %[[BOX_ADDR]] : !fir.heap<!fir.array<?xi32>>
-! CHECK:   %[[ZERO:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
-! CHECK:   %[[C0:.*]] = arith.constant 0 : index
-! CHECK:   %[[SHAPE:.*]] = fir.shape %[[C0]] : (index) -> !fir.shape<1>
-! CHECK:   %[[EMBOX:.*]] = fir.embox %[[ZERO]](%[[SHAPE]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:   fir.store %[[EMBOX]] to %[[ARG0]]{{[#0]*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK: }
+! CHECK:           %[[VAL_1:.*]] = fir.load %[[ARG0]]{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_2:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:           %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.heap<!fir.array<?xi32>>) -> i64
+! CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_5:.*]] = arith.cmpi ne, %[[VAL_3]], %[[VAL_4]] : i64
+! CHECK:           fir.if %[[VAL_5]] {
+! CHECK:             %[[VAL_6:.*]] = arith.constant false
+! CHECK:             %[[VAL_7:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_8:.*]] = fir.address_of(@_QQclXec1fdecbdab00016d5f81c67562024e7) : !fir.ref<!fir.char<1,73>>
+! CHECK:             %[[VAL_9:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_10:.*]] = fir.convert %[[ARG0]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_11:.*]] = fir.convert %[[VAL_8]] : (!fir.ref<!fir.char<1,73>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_12:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_10]], %[[VAL_6]], %[[VAL_7]], %[[VAL_11]], %[[VAL_9]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           }
+! CHECK:           cf.br ^bb1
+! CHECK:         ^bb1:  // pred: ^bb0
+! CHECK:           return
+! CHECK:         }
 
 ! CHECK-LABEL: func.func @_QMmod1Psub11() {
 ! CHECK-NOT: fir.freemem
@@ -235,40 +237,46 @@ contains
 ! CHECK-LABEL: func.func @_QMmod1Psub12(
 ! FIR-SAME: %[[ARG0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {fir.bindc_name = "a"}) {
 ! HLFIR: %[[ARG0:.*]]:2 = hlfir.declare {{.*}}"_QMmod1Fsub12Ea"
-! CHECK: %[[LOAD:.*]] = fir.load %[[ARG0]]{{[#0]*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK: %[[BOX_ADDR:.*]] = fir.box_addr %[[LOAD]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! CHECK: %[[BOX_ADDR_PTR:.*]] = fir.convert %[[BOX_ADDR]] : (!fir.heap<!fir.array<?xi32>>) -> i64
-! CHECK: %[[C0:.*]] = arith.constant 0 : i64
-! CHECK: %[[IS_ALLOCATED:.*]] = arith.cmpi ne, %[[BOX_ADDR_PTR]], %[[C0]] : i64
-! CHECK: fir.if %[[IS_ALLOCATED]] {
-! CHECK:   %[[BOX:.*]] = fir.load %[[ARG0]]{{[#0]*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:   %[[BOX_ADDR:.*]] = fir.box_addr %[[BOX]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! CHECK:   fir.freemem %[[BOX_ADDR]] : !fir.heap<!fir.array<?xi32>>
-! CHECK:   %[[ZERO:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
-! CHECK:   %[[C0:.*]] = arith.constant 0 : index
-! CHECK:   %[[SHAPE:.*]] = fir.shape %[[C0]] : (index) -> !fir.shape<1>
-! CHECK:   %[[EMBOX:.*]] = fir.embox %[[ZERO]](%[[SHAPE]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:   fir.store %[[EMBOX]] to %[[ARG0]]{{[#0]*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK: }
+! CHECK:           %[[VAL_1:.*]] = fir.load %[[ARG0]]{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_2:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:           %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.heap<!fir.array<?xi32>>) -> i64
+! CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_5:.*]] = arith.cmpi ne, %[[VAL_3]], %[[VAL_4]] : i64
+! CHECK:           fir.if %[[VAL_5]] {
+! CHECK:             %[[VAL_6:.*]] = arith.constant false
+! CHECK:             %[[VAL_7:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_8:.*]] = fir.address_of(@_QQclXec1fdecbdab00016d5f81c67562024e7) : !fir.ref<!fir.char<1,73>>
+! CHECK:             %[[VAL_9:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_10:.*]] = fir.convert %[[ARG0]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_11:.*]] = fir.convert %[[VAL_8]] : (!fir.ref<!fir.char<1,73>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_12:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_10]], %[[VAL_6]], %[[VAL_7]], %[[VAL_11]], %[[VAL_9]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           }
+! CHECK:           cf.br ^bb1
+! CHECK:         ^bb1:  // pred: ^bb0
+! CHECK:           return
+! CHECK:         }
 
 ! CHECK-LABEL: func.func @_QMmod1Psub13(
 ! FIR-SAME: %[[ARG0:.*]]: !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {fir.bindc_name = "a"}) {
 ! HLFIR: %[[ARG0:.*]]:2 = hlfir.declare {{.*}}"_QMmod1Fsub12Ea"
-! CHECK: %[[LOAD:.*]] = fir.load %[[ARG0]]{{[#0]*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK: %[[BOX_ADDR:.*]] = fir.box_addr %[[LOAD]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! CHECK: %[[BOX_ADDR_PTR:.*]] = fir.convert %[[BOX_ADDR]] : (!fir.heap<!fir.array<?xi32>>) -> i64
-! CHECK: %[[C0:.*]] = arith.constant 0 : i64
-! CHECK: %[[IS_ALLOCATED:.*]] = arith.cmpi ne, %[[BOX_ADDR_PTR]], %[[C0]] : i64
-! CHECK: fir.if %[[IS_ALLOCATED]] {
-! CHECK:   %[[BOX:.*]] = fir.load %[[ARG0]]{{[#0]*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:   %[[BOX_ADDR:.*]] = fir.box_addr %[[BOX]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! CHECK:   fir.freemem %[[BOX_ADDR]] : !fir.heap<!fir.array<?xi32>>
-! CHECK:   %[[ZERO:.*]] = fir.zero_bits !fir.heap<!fir.array<?xi32>>
-! CHECK:   %[[C0:.*]] = arith.constant 0 : index
-! CHECK:   %[[SHAPE:.*]] = fir.shape %[[C0]] : (index) -> !fir.shape<1>
-! CHECK:   %[[EMBOX:.*]] = fir.embox %[[ZERO]](%[[SHAPE]]) : (!fir.heap<!fir.array<?xi32>>, !fir.shape<1>) -> !fir.box<!fir.heap<!fir.array<?xi32>>>
-! CHECK:   fir.store %[[EMBOX]] to %[[ARG0]]{{[#0]*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK: }
+! CHECK:           %[[VAL_1:.*]] = fir.load %[[ARG0]]{{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_2:.*]] = fir.box_addr %[[VAL_1]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
+! CHECK:           %[[VAL_3:.*]] = fir.convert %[[VAL_2]] : (!fir.heap<!fir.array<?xi32>>) -> i64
+! CHECK:           %[[VAL_4:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_5:.*]] = arith.cmpi ne, %[[VAL_3]], %[[VAL_4]] : i64
+! CHECK:           fir.if %[[VAL_5]] {
+! CHECK:             %[[VAL_6:.*]] = arith.constant false
+! CHECK:             %[[VAL_7:.*]] = fir.absent !fir.box<none>
+! CHECK:             %[[VAL_8:.*]] = fir.address_of(@_QQclXec1fdecbdab00016d5f81c67562024e7) : !fir.ref<!fir.char<1,73>>
+! CHECK:             %[[VAL_9:.*]] = arith.constant {{.*}} : i32
+! CHECK:             %[[VAL_10:.*]] = fir.convert %[[ARG0]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! CHECK:             %[[VAL_11:.*]] = fir.convert %[[VAL_8]] : (!fir.ref<!fir.char<1,73>>) -> !fir.ref<i8>
+! CHECK:             %[[VAL_12:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_10]], %[[VAL_6]], %[[VAL_7]], %[[VAL_11]], %[[VAL_9]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
+! CHECK:           }
+! CHECK:           cf.br ^bb1
+! CHECK:         ^bb1:  // pred: ^bb0
+! CHECK:           return
+! CHECK:         }
 
 
   subroutine sub14(p)

--- a/flang/test/Lower/intentout-deallocate.f90
+++ b/flang/test/Lower/intentout-deallocate.f90
@@ -102,7 +102,7 @@ contains
 ! HLFIR:   %[[VAL_25:.*]] = fir.absent !fir.box<none>
 ! HLFIR:   %[[VAL_26:.*]] = fir.address_of(@_QQclXec1fdecbdab00016d5f81c67562024e7) : !fir.ref<!fir.char<1,73>>
 ! HLFIR:   %[[VAL_27:.*]] = arith.constant {{.*}} : i32
-! HLFIR:   %[[VAL_28:.*]] = fir.convert %[[ARG0]]#1 : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
+! HLFIR:   %[[VAL_28:.*]] = fir.convert %[[ARG0]]{{.*}} : (!fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>) -> !fir.ref<!fir.box<none>>
 ! HLFIR:   %[[VAL_29:.*]] = fir.convert %[[VAL_26]] : (!fir.ref<!fir.char<1,73>>) -> !fir.ref<i8>
 ! HLFIR:   %[[VAL_30:.*]] = fir.call @_FortranAAllocatableDeallocate(%[[VAL_28]], %[[VAL_24]], %[[VAL_25]], %[[VAL_29]], %[[VAL_27]]) fastmath<contract> : (!fir.ref<!fir.box<none>>, i1, !fir.box<none>, !fir.ref<i8>, i32) -> i32
 ! HLFIR: }

--- a/flang/test/Lower/io-implied-do-fixes.f90
+++ b/flang/test/Lower/io-implied-do-fixes.f90
@@ -24,11 +24,12 @@ end subroutine
 
 ! CHECK-LABEL: func @_QPido2
 ! CHECK: %[[J_REF_ADDR:.*]] = fir.alloca !fir.heap<i32> {uniq_name = "_QFido2Eiptr.addr"}
+! CHECK: fir.call @_FortranAioBeginExternalListOutput
 ! CHECK: %[[J_ADDR:.*]] = fir.load %[[J_REF_ADDR]] : !fir.ref<!fir.heap<i32>>
 ! CHECK: %[[J_VAL_FINAL:.*]] = fir.do_loop %[[J_VAL:.*]] = %{{.*}} to %{{.*}} step %{{.*}} -> index {
 ! CHECK: %[[J_VAL_CVT1:.*]] = fir.convert %[[J_VAL]] : (index) -> i32
 ! CHECK: fir.store %[[J_VAL_CVT1]] to %[[J_ADDR]] : !fir.heap<i32>
-! CHECK: %[[J_VAL_NEXT:.*]] = arith.addi %[[J_VAL]], %{{[^ ]*}} overflow<nsw> : index
+! CHECK: %[[J_VAL_NEXT:.*]] = arith.addi %[[J_VAL]], %{{[^ ]*}}
 ! CHECK: fir.result %[[J_VAL_NEXT]] : index
 ! CHECK: }
 ! CHECK: %[[J_VAL_CVT2:.*]] = fir.convert %[[J_VAL_FINAL]] : (index) -> i32
@@ -41,6 +42,7 @@ end subroutine
 
 ! CHECK-LABEL: func @_QPido3
 ! CHECK:  %[[J_REF_ADDR:.*]] = fir.alloca !fir.heap<i32> {uniq_name = "_QFido3Ej.addr"}
+! CHECK: fir.call @_FortranAioBeginExternalListOutput
 ! CHECK:  %[[J_ADDR:.*]] = fir.load %[[J_REF_ADDR]] : !fir.ref<!fir.heap<i32>>
 ! CHECK:  %[[J_VAL_FINAL:.*]]:2 = fir.iterate_while (%[[J_VAL:.*]] = %{{.*}} to %{{.*}} step %{{.*}}) and (%[[OK:.*]] = {{.*}}) -> (index, i1) {
 ! CHECK:    %[[J_VAL_CVT1:.*]] = fir.convert %[[J_VAL]] : (index) -> i32


### PR DESCRIPTION
ALLOCATE/DEALLOCATE statements in flang are lowered to malloc/free in simpler cases and to runtime calls in complex cases. This PR always lowers ALLOCATE/DEALLOCATE to runtime calls.