### PR TITLE
[lldb] Adjust skips on reverse continue tests

### DIFF
--- a/lldb/test/API/functionalities/reverse-execution/TestReverseContinueBreakpoints.py
+++ b/lldb/test/API/functionalities/reverse-execution/TestReverseContinueBreakpoints.py
@@ -10,12 +10,10 @@ from lldbsuite.test import lldbutil
 
 class TestReverseContinueBreakpoints(ReverseTestBase):
     @skipIfRemote
-    @skipIf(macos_version=["<", "15.0"])
     def test_reverse_continue(self):
         self.reverse_continue_internal(async_mode=False)
 
     @skipIfRemote
-    @skipIf(macos_version=["<", "15.0"])
     def test_reverse_continue_async(self):
         self.reverse_continue_internal(async_mode=True)
 
@@ -44,12 +42,10 @@ class TestReverseContinueBreakpoints(ReverseTestBase):
         self.assertEqual(process.GetExitStatus(), 0)
 
     @skipIfRemote
-    @skipIf(macos_version=["<", "15.0"])
     def test_reverse_continue_breakpoint(self):
         self.reverse_continue_breakpoint_internal(async_mode=False)
 
     @skipIfRemote
-    @skipIf(macos_version=["<", "15.0"])
     def test_reverse_continue_breakpoint_async(self):
         self.reverse_continue_breakpoint_internal(async_mode=True)
 
@@ -67,12 +63,10 @@ class TestReverseContinueBreakpoints(ReverseTestBase):
         self.assertEqual(threads_now, initial_threads)
 
     @skipIfRemote
-    @skipIf(macos_version=["<", "15.0"])
     def test_reverse_continue_skip_breakpoint(self):
         self.reverse_continue_skip_breakpoint_internal(async_mode=False)
 
     @skipIfRemote
-    @skipIf(macos_version=["<", "15.0"])
     def test_reverse_continue_skip_breakpoint_async(self):
         self.reverse_continue_skip_breakpoint_internal(async_mode=True)
 
@@ -97,12 +91,10 @@ class TestReverseContinueBreakpoints(ReverseTestBase):
         )
 
     @skipIfRemote
-    @skipIf(macos_version=["<", "15.0"])
     def test_continue_preserves_direction(self):
         self.continue_preserves_direction_internal(async_mode=False)
 
     @skipIfRemote
-    @skipIf(macos_version=["<", "15.0"])
     def test_continue_preserves_direction_asyhc(self):
         self.continue_preserves_direction_internal(async_mode=True)
 

--- a/lldb/test/API/functionalities/reverse-execution/TestReverseContinueWatchpoints.py
+++ b/lldb/test/API/functionalities/reverse-execution/TestReverseContinueWatchpoints.py
@@ -10,12 +10,14 @@ from lldbsuite.test import lldbutil
 
 class TestReverseContinueWatchpoints(ReverseTestBase):
     @skipIfRemote
-    @skipIf(macos_version=["<", "15.0"])
+    # Watchpoints don't work in single-step mode
+    @skipIf(macos_version=["<", "15.0"], archs=["arm64"])
     def test_reverse_continue_watchpoint(self):
         self.reverse_continue_watchpoint_internal(async_mode=False)
 
     @skipIfRemote
-    @skipIf(macos_version=["<", "15.0"])
+    # Watchpoints don't work in single-step mode
+    @skipIf(macos_version=["<", "15.0"], archs=["arm64"])
     def test_reverse_continue_watchpoint_async(self):
         self.reverse_continue_watchpoint_internal(async_mode=True)
 
@@ -60,12 +62,14 @@ class TestReverseContinueWatchpoints(ReverseTestBase):
         )
 
     @skipIfRemote
-    @skipIf(macos_version=["<", "15.0"])
+    # Watchpoints don't work in single-step mode
+    @skipIf(macos_version=["<", "15.0"], archs=["arm64"])
     def test_reverse_continue_skip_watchpoint(self):
         self.reverse_continue_skip_watchpoint_internal(async_mode=False)
 
     @skipIfRemote
-    @skipIf(macos_version=["<", "15.0"])
+    # Watchpoints don't work in single-step mode
+    @skipIf(macos_version=["<", "15.0"], archs=["arm64"])
     def test_reverse_continue_skip_watchpoint_async(self):
         self.reverse_continue_skip_watchpoint_internal(async_mode=True)
 


### PR DESCRIPTION
The x86-specific issue has been fixed with #132122. Watchpoint tests fail on aarch64 with macos<15.0 due to a kernel bug.