### PR TITLE
[lldb] Make GetRowForFunctionOffset compatible with discontinuous functions

### DIFF
--- a/lldb/include/lldb/Symbol/UnwindPlan.h
+++ b/lldb/include/lldb/Symbol/UnwindPlan.h
@@ -450,11 +450,12 @@ public:
   void InsertRow(Row row, bool replace_existing = false);
 
   // Returns a pointer to the best row for the given offset into the function's
-  // instructions. If offset is -1 it indicates that the function start is
-  // unknown - the final row in the UnwindPlan is returned. In practice, the
-  // UnwindPlan for a function with no known start address will be the
-  // architectural default UnwindPlan which will only have one row.
-  const UnwindPlan::Row *GetRowForFunctionOffset(int offset) const;
+  // instructions. If offset is std::nullopt it indicates that the function
+  // start is unknown - the final row in the UnwindPlan is returned. In
+  // practice, the UnwindPlan for a function with no known start address will be
+  // the architectural default UnwindPlan which will only have one row.
+  const UnwindPlan::Row *
+  GetRowForFunctionOffset(std::optional<int> offset) const;
 
   lldb::RegisterKind GetRegisterKind() const { return m_register_kind; }
 

--- a/lldb/include/lldb/Target/RegisterContextUnwind.h
+++ b/lldb/include/lldb/Target/RegisterContextUnwind.h
@@ -228,18 +228,17 @@ private:
   lldb_private::Address m_start_pc;
   lldb_private::Address m_current_pc;
 
-  int m_current_offset; // how far into the function we've executed; -1 if
-                        // unknown
-                        // 0 if no instructions have been executed yet.
+  /// How far into the function we've executed. 0 if no instructions have been
+  /// executed yet, std::nullopt if unknown.
+  std::optional<int> m_current_offset;
 
-  // 0 if no instructions have been executed yet.
-  // On architectures where the return address on the stack points
-  // to the instruction after the CALL, this value will have 1
-  // subtracted from it.  Else a function that ends in a CALL will
-  // have an offset pointing into the next function's address range.
+  // How far into the function we've executed. 0 if no instructions have been
+  // executed yet, std::nullopt if unknown. On architectures where the return
+  // address on the stack points to the instruction after the CALL, this value
+  // will have 1 subtracted from it. Otherwise, a function that ends in a CALL
+  // will have an offset pointing into the next function's address range.
   // m_current_pc has the actual address of the "current" pc.
-  int m_current_offset_backed_up_one; // how far into the function we've
-                                      // executed; -1 if unknown
+  std::optional<int> m_current_offset_backed_up_one;
 
   bool m_behaves_like_zeroth_frame; // this frame behaves like frame zero
 

--- a/lldb/source/Symbol/UnwindPlan.cpp
+++ b/lldb/source/Symbol/UnwindPlan.cpp
@@ -417,9 +417,10 @@ void UnwindPlan::InsertRow(Row row, bool replace_existing) {
   }
 }
 
-const UnwindPlan::Row *UnwindPlan::GetRowForFunctionOffset(int offset) const {
-  auto it = offset == -1 ? m_row_list.end()
-                         : llvm::upper_bound(m_row_list, offset, RowLess());
+const UnwindPlan::Row *
+UnwindPlan::GetRowForFunctionOffset(std::optional<int> offset) const {
+  auto it = offset ? llvm::upper_bound(m_row_list, *offset, RowLess())
+                   : m_row_list.end();
   if (it == m_row_list.begin())
     return nullptr;
   // upper_bound returns the row strictly greater than our desired offset, which


### PR DESCRIPTION
The function had special handling for -1, but that is incompatible with functions whose entry point is not the first address. Use std::nullopt instead.