### PR TITLE
[libcxx] Remove clang-18 workaround in picolib build

### DIFF
--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -204,6 +204,11 @@ function test-armv7m-picolibc() {
 
     step "Generating CMake for compiler-rt"
     flags="--sysroot=${INSTALL_DIR}"
+    # LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON means that we produce a file
+    # libclang_rt.builtins.a that will be installed to lib/armv7m-unknown-none-eabi/.
+    # With LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF, the filename includes the
+    # architecture name, which is not what Clang's driver expects to find.
+    # The install location will however be wrong, we correct that below.
     ${CMAKE} \
         -S "${MONOREPO_ROOT}/compiler-rt" \
         -B "${BUILD_DIR}/compiler-rt" \
@@ -226,13 +231,8 @@ function test-armv7m-picolibc() {
 
     step "Installing compiler-rt"
     ${NINJA} -vC "${BUILD_DIR}/compiler-rt" install
-
-    # Prior to clang 19, armv7m-none-eabi normalised to armv7m-none-unknown-eabi.
-    # clang 19 changed this to armv7m-unknown-none-eabi. So for as long as 18.x
-    # is supported, we have to ask clang what the triple will be.
-    NORMALISED_TARGET_TRIPLE=$(${CC-cc} --target=armv7m-none-eabi -print-target-triple)
-    # Without this step linking fails later in the build.
-    mv "${BUILD_DIR}/install/lib/${NORMALISED_TARGET_TRIPLE}"/* "${BUILD_DIR}/install/lib"
+    # Move compiler-rt libs into the same directory as all the picolib objects.
+    mv "${BUILD_DIR}/install/lib/armv7m-unknown-none-eabi"/* "${BUILD_DIR}/install/lib"
 
     check-runtimes
 }

--- a/libcxx/utils/ci/run-buildbot
+++ b/libcxx/utils/ci/run-buildbot
@@ -205,10 +205,12 @@ function test-armv7m-picolibc() {
     step "Generating CMake for compiler-rt"
     flags="--sysroot=${INSTALL_DIR}"
     # LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON means that we produce a file
-    # libclang_rt.builtins.a that will be installed to lib/armv7m-unknown-none-eabi/.
+    # libclang_rt.builtins.a that will be installed to
+    # ${INSTALL_DIR}/lib/armv7m-unknown-none-eabi/.
     # With LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF, the filename includes the
     # architecture name, which is not what Clang's driver expects to find.
-    # The install location will however be wrong, we correct that below.
+    # The install location will however be wrong with
+    # LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON, so we correct that below.
     ${CMAKE} \
         -S "${MONOREPO_ROOT}/compiler-rt" \
         -B "${BUILD_DIR}/compiler-rt" \
@@ -232,7 +234,7 @@ function test-armv7m-picolibc() {
     step "Installing compiler-rt"
     ${NINJA} -vC "${BUILD_DIR}/compiler-rt" install
     # Move compiler-rt libs into the same directory as all the picolib objects.
-    mv "${BUILD_DIR}/install/lib/armv7m-unknown-none-eabi"/* "${BUILD_DIR}/install/lib"
+    mv "${INSTALL_DIR}/lib/armv7m-unknown-none-eabi"/* "${INSTALL_DIR}/lib"
 
     check-runtimes
 }


### PR DESCRIPTION
clang-19 changed how Arm triples were normalised and so while we supported 18 and 19, we could not hard code the path here.

Now that Linaro's bots are running clang-19, and libcxx is going to drop clang-18 support (https://github.com/llvm/llvm-project/pull/130142) I have simplified it by hard coding the path again.

I also looked into why this exists in the first place. It was added in https://reviews.llvm.org/D154246 but not questioned at the time.

It is due to the way we build compiler-rt, which is due to the final layout we need in the install:
1. The builtins library must be called libclang_rt.builtins.a for clang to find it. There must not be an architecture name in the filename.
2. That builtins library must be directly in lib/, next to picolib's installed files.

To achieve number 1 we must set LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON. However, that causes the file to be installed in a per-target dir which breaks number 2. So to fix that, we move the builtins library up one level into lib/.

The alternative is to turn off per-target dirs, which results in a builtin file with an arch in the name, then rename and move that file (since it gets installed into lib/generic/).

So in the end, it's the same amount of hacks. I think it's best to keep the one that uses LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON, as this is the recommended way to built these days.