### PR TITLE
Introduce XRay object mapping file to enable symbolization for DSOs

### DIFF
--- a/compiler-rt/include/xray/xray_interface.h
+++ b/compiler-rt/include/xray/xray_interface.h
@@ -165,6 +165,12 @@ extern int32_t __xray_unpack_object_id(int32_t PackedId);
 /// high bits are truncated.
 extern int32_t __xray_pack_id(int32_t FuncId, int32_t ObjId);
 
+/// Returns the path from which the given object (executable or DSO) was loaded
+/// from.
+/// The returned string is owned by the XRay runtime and remains valid until the
+/// end of execution.
+extern const char* __xray_object_path(int32_t ObjId);
+
 /// Initialize the required XRay data structures. This is useful in cases where
 /// users want to control precisely when the XRay instrumentation data
 /// structures are initialized, for example when the XRay library is built with

--- a/compiler-rt/include/xray/xray_interface.h
+++ b/compiler-rt/include/xray/xray_interface.h
@@ -169,7 +169,7 @@ extern int32_t __xray_pack_id(int32_t FuncId, int32_t ObjId);
 /// from.
 /// The returned string is owned by the XRay runtime and remains valid until the
 /// end of execution.
-extern const char* __xray_object_path(int32_t ObjId);
+extern const char *__xray_object_path(int32_t ObjId);
 
 /// Initialize the required XRay data structures. This is useful in cases where
 /// users want to control precisely when the XRay instrumentation data

--- a/compiler-rt/lib/xray/xray_basic_logging.cpp
+++ b/compiler-rt/lib/xray/xray_basic_logging.cpp
@@ -450,9 +450,8 @@ static void writeObjectMapping() {
     Report("Writing object mapping file.\n");
 
   char MapFilename[256] = {};
-  int NeededLength = internal_snprintf(
-      MapFilename, sizeof(MapFilename), "%s.map.yaml",
-      LW->GetFilename());
+  int NeededLength = internal_snprintf(MapFilename, sizeof(MapFilename),
+                                       "%s.map.yaml", LW->GetFilename());
   if (NeededLength > int(sizeof(MapFilename))) {
     Report("XRay map file name too long (%d): %s\n", NeededLength, MapFilename);
     return;
@@ -488,7 +487,6 @@ XRayLogFlushStatus basicLoggingFlush() XRAY_NEVER_INSTRUMENT {
 // This is a handler that, effectively, does nothing.
 void basicLoggingHandleArg0Empty(int32_t, XRayEntryType) XRAY_NEVER_INSTRUMENT {
 }
-
 
 bool basicLogDynamicInitializer() XRAY_NEVER_INSTRUMENT {
   XRayLogImpl Impl{
@@ -532,7 +530,10 @@ bool basicLogDynamicInitializer() XRAY_NEVER_INSTRUMENT {
     pthread_once(&DynamicOnce, +[] {
       static void *FakeTLD = nullptr;
       FakeTLD = &getThreadLocalData();
-      Atexit(+[] { TLDDestructor(FakeTLD); writeObjectMapping(); });
+      Atexit(+[] {
+        TLDDestructor(FakeTLD);
+        writeObjectMapping();
+      });
     });
   }
   return true;

--- a/compiler-rt/lib/xray/xray_init.cpp
+++ b/compiler-rt/lib/xray/xray_init.cpp
@@ -12,8 +12,13 @@
 //===----------------------------------------------------------------------===//
 
 #include <fcntl.h>
+#include <string.h>
 #include <strings.h>
 #include <unistd.h>
+
+#ifdef __ELF__
+#include <link.h>
+#endif
 
 #include "sanitizer_common/sanitizer_common.h"
 #include "xray/xray_interface.h"
@@ -62,6 +67,56 @@ atomic_uint8_t XRayFlagsInitialized{0};
 // A mutex to allow only one thread to initialize the XRay data structures.
 SpinMutex XRayInitMutex;
 
+
+namespace {
+
+struct DlIteratePhdrData {
+  intptr_t TargetSledAddr{0};
+  const char* Path{nullptr};
+  bool Found{false};
+};
+
+const char* DetectObjPath(bool IsDSO, uint64_t Addr) XRAY_NEVER_INSTRUMENT {
+  if (IsDSO) {
+    // Detection of DSO paths only supported for ELF
+#ifdef __ELF__
+    // Look for the given address by iterating over the loaded DSOs
+    DlIteratePhdrData Data;
+    Data.TargetSledAddr = Addr;
+    dl_iterate_phdr([](dl_phdr_info *info, size_t size, void *arg) -> int {
+      auto *data = (DlIteratePhdrData *)arg;
+      data->Found = false;
+      for (int i = 0; i < info->dlpi_phnum; i++) {
+        const auto *phdr = &info->dlpi_phdr[i];
+        if (phdr->p_type != PT_LOAD)
+          continue;
+        intptr_t beg = info->dlpi_addr + phdr->p_vaddr;
+        intptr_t end = beg + phdr->p_memsz;
+
+        if (beg <= data->TargetSledAddr && data->TargetSledAddr < end) {
+          data->Path = info->dlpi_name;
+          data->Found = true;
+          return 1;
+        }
+      }
+      return 0;
+    }, &Data);
+    if (Data.Found) {
+      return Data.Path;
+    }
+#endif
+    return nullptr;
+  }
+
+  // If the address is in the main executable, use the built-in sanitizer
+  // functionality.
+  __sanitizer::UpdateProcessName();
+  const char* ExecName = __sanitizer::GetProcessName();
+  // TODO: Is this the full path?
+  return ExecName;
+}
+}
+
 // Registers XRay sleds and trampolines coming from the main executable or one
 // of the linked DSOs.
 // Returns the object ID if registration is successful, -1 otherwise.
@@ -106,6 +161,14 @@ __xray_register_sleds(const XRaySledEntry *SledsBegin,
 
   if (Verbosity())
     Report("Registering %d new functions!\n", SledMap.Functions);
+
+  const char* Path = DetectObjPath(FromDSO, SledsBegin->address());
+  if (Path) {
+    // Copy needed because DSO path is freed when unloaded.
+    SledMap.Path = internal_strdup(Path);
+  } else {
+    Report("Unable to determine load path for address %x\n", SledsBegin->address());
+  }
 
   {
     SpinMutexLock Guard(&XRayInstrMapMutex);

--- a/compiler-rt/lib/xray/xray_interface.cpp
+++ b/compiler-rt/lib/xray/xray_interface.cpp
@@ -689,7 +689,7 @@ int32_t __xray_pack_id(int32_t FuncId, int32_t ObjId) {
   return __xray::MakePackedId(FuncId, ObjId);
 }
 
-const char* __xray_object_path(int32_t ObjId) {
+const char *__xray_object_path(int32_t ObjId) {
   SpinMutexLock Guard(&XRayInstrMapMutex);
   if (ObjId < 0 || static_cast<uint32_t>(ObjId) >=
                        atomic_load(&XRayNumObjects, memory_order_acquire))
@@ -699,7 +699,7 @@ const char* __xray_object_path(int32_t ObjId) {
 
 #include <stdio.h>
 
-bool __xray_write_object_mapping(const char* outfile) XRAY_NEVER_INSTRUMENT {
+bool __xray_write_object_mapping(const char *outfile) XRAY_NEVER_INSTRUMENT {
   // TODO: Use low-level IO API?
   FILE *of = fopen(outfile, "w");
   if (!of) {
@@ -712,10 +712,11 @@ bool __xray_write_object_mapping(const char* outfile) XRAY_NEVER_INSTRUMENT {
   fprintf(of, "objects:\n");
   int NumObjects = __xray_num_objects();
   for (int ObjId = 0; ObjId < NumObjects; ObjId++) {
-    auto* Path = __xray_object_path(ObjId);
+    auto *Path = __xray_object_path(ObjId);
     if (!Path)
       Report("Unknown path for object %d. The XRay mapping file may be "
-             "incomplete.\n", ObjId);
+             "incomplete.\n",
+             ObjId);
     fprintf(of, "  - id: %d\n", ObjId);
     fprintf(of, "    path: \"%s\"\n", Path ? Path : "");
   }

--- a/compiler-rt/lib/xray/xray_interface_internal.h
+++ b/compiler-rt/lib/xray/xray_interface_internal.h
@@ -107,7 +107,7 @@ extern int32_t __xray_register_dso(const XRaySledEntry *SledsBegin,
 
 extern bool __xray_deregister_dso(int32_t ObjId);
 
-extern bool __xray_write_object_mapping(const char* outfile);
+extern bool __xray_write_object_mapping(const char *outfile);
 }
 
 namespace __xray {
@@ -139,7 +139,7 @@ struct XRaySledMap {
   XRayTrampolines Trampolines;
   bool FromDSO;
   bool Loaded;
-  const char* Path;
+  const char *Path;
 };
 
 bool patchFunctionEntry(bool Enable, uint32_t FuncId, const XRaySledEntry &Sled,

--- a/compiler-rt/lib/xray/xray_interface_internal.h
+++ b/compiler-rt/lib/xray/xray_interface_internal.h
@@ -106,6 +106,8 @@ extern int32_t __xray_register_dso(const XRaySledEntry *SledsBegin,
                                    XRayTrampolines Trampolines);
 
 extern bool __xray_deregister_dso(int32_t ObjId);
+
+extern bool __xray_write_object_mapping(const char* outfile);
 }
 
 namespace __xray {
@@ -137,6 +139,7 @@ struct XRaySledMap {
   XRayTrampolines Trampolines;
   bool FromDSO;
   bool Loaded;
+  const char* Path;
 };
 
 bool patchFunctionEntry(bool Enable, uint32_t FuncId, const XRaySledEntry &Sled,

--- a/compiler-rt/lib/xray/xray_utils.cpp
+++ b/compiler-rt/lib/xray/xray_utils.cpp
@@ -155,9 +155,7 @@ void LogWriter::WriteAll(const char *Begin, const char *End) XRAY_NEVER_INSTRUME
   }
 }
 
-const char* LogWriter::GetFilename() XRAY_NEVER_INSTRUMENT {
-  return Filename;
-}
+const char *LogWriter::GetFilename() XRAY_NEVER_INSTRUMENT { return Filename; }
 
 void LogWriter::Flush() XRAY_NEVER_INSTRUMENT {
   fsync(Fd);

--- a/compiler-rt/lib/xray/xray_utils.cpp
+++ b/compiler-rt/lib/xray/xray_utils.cpp
@@ -124,7 +124,7 @@ LogWriter *LogWriter::Open() XRAY_NEVER_INSTRUMENT {
   Report("XRay: " FORMAT_DUMPFILE "\n", ProfileSinkName, VmoName);
 
   LogWriter *LW = reinterpret_cast<LogWriter *>(InternalAlloc(sizeof(LogWriter)));
-  new (LW) LogWriter(Vmo);
+  new (LW) LogWriter(Vmo, VmoName);
   return LW;
 }
 
@@ -153,6 +153,10 @@ void LogWriter::WriteAll(const char *Begin, const char *End) XRAY_NEVER_INSTRUME
       break;
     Begin += Written;
   }
+}
+
+const char* LogWriter::GetFilename() XRAY_NEVER_INSTRUMENT {
+  return Filename;
 }
 
 void LogWriter::Flush() XRAY_NEVER_INSTRUMENT {
@@ -187,7 +191,7 @@ LogWriter *LogWriter::Open() XRAY_NEVER_INSTRUMENT {
     Report("XRay: Log file in '%s'\n", TmpFilename);
 
   LogWriter *LW = allocate<LogWriter>();
-  new (LW) LogWriter(Fd);
+  new (LW) LogWriter(Fd, TmpFilename);
   return LW;
 }
 

--- a/compiler-rt/lib/xray/xray_utils.h
+++ b/compiler-rt/lib/xray/xray_utils.h
@@ -31,7 +31,7 @@ public:
 #if SANITIZER_FUCHSIA
  LogWriter(zx_handle_t Vmo) : Vmo(Vmo) {}
 #else
-  explicit LogWriter(int Fd, const char* Filename) : Fd(Fd) {
+  explicit LogWriter(int Fd, const char *Filename) : Fd(Fd) {
     internal_strlcpy(this->Filename, Filename, sizeof(this->Filename));
   }
 #endif
@@ -40,7 +40,7 @@ public:
  // Write a character range into a log.
  void WriteAll(const char *Begin, const char *End);
 
- const char* GetFilename();
+ const char *GetFilename();
 
  void Flush();
 

--- a/compiler-rt/lib/xray/xray_utils.h
+++ b/compiler-rt/lib/xray/xray_utils.h
@@ -31,12 +31,16 @@ public:
 #if SANITIZER_FUCHSIA
  LogWriter(zx_handle_t Vmo) : Vmo(Vmo) {}
 #else
-  explicit LogWriter(int Fd) : Fd(Fd) {}
+  explicit LogWriter(int Fd, const char* Filename) : Fd(Fd) {
+    internal_strlcpy(this->Filename, Filename, sizeof(this->Filename));
+  }
 #endif
  ~LogWriter();
 
  // Write a character range into a log.
  void WriteAll(const char *Begin, const char *End);
+
+ const char* GetFilename();
 
  void Flush();
 
@@ -52,6 +56,7 @@ private:
 #else
  int Fd = -1;
 #endif
+ char Filename[256];
 };
 
 constexpr size_t gcd(size_t a, size_t b) {

--- a/compiler-rt/test/xray/TestCases/Posix/basic-mode-dso.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/basic-mode-dso.cpp
@@ -5,6 +5,7 @@
 // RUN: %clangxx_xray -g -fPIC -fxray-instrument -fxray-shared -std=c++11 %t/main.cpp %t/testlib.so -Wl,-rpath,%t -o %t/main.o
 
 // RUN: XRAY_OPTIONS="patch_premain=false,xray_mode=xray-basic,xray_logfile_base=basic-mode-dso-,verbosity=1" XRAY_BASIC_OPTIONS="func_duration_threshold_us=0" %run %t/main.o 2>&1 | FileCheck %s
+// RUN: rm -f basic-mode-dso-*.map.yaml
 // RUN: %llvm_xray account --format=csv --sort=funcid "`ls basic-mode-dso-* | head -1`" | FileCheck --check-prefix=ACCOUNT %s
 // RUN: rm basic-mode-dso-*
 


### PR DESCRIPTION
Prototype implementation for DSO function resolution for XRay. 
- Adds the `__xray_object_path` API function to look up the binary path of a loaded DSO
- At the end of tracing, writes out a YAML file, containing the mapping of object IDs to binaries
- Extends `llvm-xray extract` to allow generating a combined instrumentation map file, given the mapping YAML as input