### PR TITLE
MIPS: Implement isAsCheapAsAMove for addiu

### DIFF
--- a/llvm/lib/Target/Mips/MipsInstrInfo.cpp
+++ b/llvm/lib/Target/Mips/MipsInstrInfo.cpp
@@ -678,6 +678,22 @@ bool MipsInstrInfo::HasLoadDelaySlot(const MachineInstr &MI) const {
   }
 }
 
+bool MipsInstrInfo::isAsCheapAsAMove(const MachineInstr &MI) const {
+  const unsigned Opcode = MI.getOpcode();
+  switch (Opcode) {
+  default:
+    break;
+  case Mips::ADDiu:
+  case Mips::ADDiu_MM:
+  case Mips::DADDiu:
+    return ((MI.getOperand(2).isImm() && MI.getOperand(2).getImm() == 0) ||
+            (MI.getOperand(1).isReg() &&
+             (MI.getOperand(1).getReg() == Mips::ZERO ||
+              MI.getOperand(1).getReg() == Mips::ZERO_64)));
+  }
+  return MI.isAsCheapAsAMove();
+}
+
 /// Return the number of bytes of code the specified instruction may be.
 unsigned MipsInstrInfo::getInstSizeInBytes(const MachineInstr &MI) const {
   switch (MI.getOpcode()) {

--- a/llvm/lib/Target/Mips/MipsInstrInfo.h
+++ b/llvm/lib/Target/Mips/MipsInstrInfo.h
@@ -113,6 +113,8 @@ public:
   /// Predicate to determine if an instruction has a load delay slot.
   bool HasLoadDelaySlot(const MachineInstr &MI) const;
 
+  bool isAsCheapAsAMove(const MachineInstr &MI) const override;
+
   /// Insert nop instruction when hazard condition is found
   void insertNoop(MachineBasicBlock &MBB,
                   MachineBasicBlock::iterator MI) const override;


### PR DESCRIPTION
Set `addiu` as `isAsCheapAsAMove` only when the src register or imm is zero only.

If other cases are set `isAsCheapAsAMove`, MachineLICM will reject to hoist it.