### PR TITLE
[ASan] Move early exit checks outside "instrumentFunction()" to avoid…

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -1314,9 +1314,12 @@ PreservedAnalyses AddressSanitizerPass::run(Module &M,
   for (Function &F : M) {
     if (F.empty())
       continue;
-    if (F.getLinkage() == GlobalValue::AvailableExternallyLinkage) continue;
-    if (!ClDebugFunc.empty() && ClDebugFunc == F.getName()) continue;
-    if (F.getName().starts_with("__asan_")) continue;
+    if (F.getLinkage() == GlobalValue::AvailableExternallyLinkage)
+      continue;
+    if (!ClDebugFunc.empty() && ClDebugFunc == F.getName())
+      continue;
+    if (F.getName().starts_with("__asan_"))
+      continue;
     if (F.isPresplitCoroutine())
       continue;
     AddressSanitizer FunctionSanitizer(

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -1312,6 +1312,13 @@ PreservedAnalyses AddressSanitizerPass::run(Module &M,
   const StackSafetyGlobalInfo *const SSGI =
       ClUseStackSafety ? &MAM.getResult<StackSafetyGlobalAnalysis>(M) : nullptr;
   for (Function &F : M) {
+    if (F.empty())
+      continue;
+    if (F.getLinkage() == GlobalValue::AvailableExternallyLinkage) continue;
+    if (!ClDebugFunc.empty() && ClDebugFunc == F.getName()) continue;
+    if (F.getName().starts_with("__asan_")) continue;
+    if (F.isPresplitCoroutine())
+      continue;
     AddressSanitizer FunctionSanitizer(
         M, SSGI, Options.InstrumentationWithCallsThreshold,
         Options.MaxInlinePoisoningSize, Options.CompileKernel, Options.Recover,
@@ -2989,14 +2996,6 @@ bool AddressSanitizer::suppressInstrumentationSiteForDebug(int &Instrumented) {
 
 bool AddressSanitizer::instrumentFunction(Function &F,
                                           const TargetLibraryInfo *TLI) {
-  if (F.empty())
-    return false;
-  if (F.getLinkage() == GlobalValue::AvailableExternallyLinkage) return false;
-  if (!ClDebugFunc.empty() && ClDebugFunc == F.getName()) return false;
-  if (F.getName().starts_with("__asan_")) return false;
-  if (F.isPresplitCoroutine())
-    return false;
-
   bool FunctionModified = false;
 
   // Do not apply any instrumentation for naked functions.


### PR DESCRIPTION
… unnecessary FunctionSanitizer construction (NFC)

This patch moves several early-exit checks (e.g., empty function, etc.) out of `AddressSanitizer::instrumentFunction` and into the caller. This change avoids unnecessary construction of FunctionSanitizer when instrumentation is not needed.