### PR TITLE
[mlir][LLVM] Delete `LLVMFixedVectorType` and `LLVMScalableVectorType`

### DIFF
--- a/mlir/docs/Dialects/LLVM.md
+++ b/mlir/docs/Dialects/LLVM.md
@@ -327,11 +327,9 @@ multiple of some fixed size in case of _scalable_ vectors, and the element type.
 Vectors cannot be nested and only 1D vectors are supported. Scalable vectors are
 still considered 1D.
 
-LLVM dialect uses built-in vector types for _fixed_-size vectors of built-in
-types, and provides additional types for fixed-sized vectors of LLVM dialect
-types (`LLVMFixedVectorType`) and scalable vectors of any types
-(`LLVMScalableVectorType`). These two additional types share the following
-syntax:
+The LLVM dialect uses built-in vector types for _fixed_-size vectors of built-in
+types, and provides additional types for scalable vectors of any types
+(`LLVMScalableVectorType`):
 
 ```
   llvm-vec-type ::= `!llvm.vec<` (`?` `x`)? integer-literal `x` type `>`

--- a/mlir/docs/Dialects/LLVM.md
+++ b/mlir/docs/Dialects/LLVM.md
@@ -327,18 +327,7 @@ multiple of some fixed size in case of _scalable_ vectors, and the element type.
 Vectors cannot be nested and only 1D vectors are supported. Scalable vectors are
 still considered 1D.
 
-The LLVM dialect uses built-in vector types for _fixed_-size vectors of built-in
-types, and provides additional types for scalable vectors of any types
-(`LLVMScalableVectorType`):
-
-```
-  llvm-vec-type ::= `!llvm.vec<` (`?` `x`)? integer-literal `x` type `>`
-```
-
-Note that the sets of element types supported by built-in and LLVM dialect
-vector types are mutually exclusive, e.g., the built-in vector type does not
-accept `!llvm.ptr` and the LLVM dialect fixed-width vector type does not
-accept `i32`.
+The LLVM dialect uses built-in vector type.
 
 The following functions are provided to operate on any kind of the vector types
 compatible with the LLVM dialect:
@@ -358,8 +347,8 @@ compatible with the LLVM dialect:
 
 ```mlir
 vector<42 x i32>                   // Vector of 42 32-bit integers.
-!llvm.vec<42 x ptr>                // Vector of 42 pointers.
-!llvm.vec<? x 4 x i32>             // Scalable vector of 32-bit integers with
+vector<42 x !llvm.ptr>             // Vector of 42 pointers.
+vector<[4] x i32>                  // Scalable vector of 32-bit integers with
                                    // size divisible by 4.
 !llvm.array<2 x vector<2 x i32>>   // Array of 2 vectors of 2 32-bit integers.
 !llvm.array<2 x vec<2 x ptr>> // Array of 2 vectors of 2 pointers.

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.h
@@ -66,7 +66,6 @@ namespace LLVM {
   }
 
 DEFINE_TRIVIAL_LLVM_TYPE(LLVMVoidType, "llvm.void");
-DEFINE_TRIVIAL_LLVM_TYPE(LLVMPPCFP128Type, "llvm.ppc_fp128");
 DEFINE_TRIVIAL_LLVM_TYPE(LLVMTokenType, "llvm.token");
 DEFINE_TRIVIAL_LLVM_TYPE(LLVMLabelType, "llvm.label");
 DEFINE_TRIVIAL_LLVM_TYPE(LLVMMetadataType, "llvm.metadata");

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.td
@@ -289,38 +289,6 @@ def LLVMPointerType : LLVMType<"LLVMPointer", "ptr", [
 }
 
 //===----------------------------------------------------------------------===//
-// LLVMScalableVectorType
-//===----------------------------------------------------------------------===//
-
-def LLVMScalableVectorType : LLVMType<"LLVMScalableVector", "vec"> {
-  let summary = "LLVM scalable vector type";
-  let description = [{
-    LLVM dialect scalable vector type, represents a sequence of elements of
-    unknown length that is known to be divisible by some constant. These
-    elements can be processed as one in SIMD context.
-  }];
-
-  let typeName = "llvm.scalable_vec";
-
-  let parameters = (ins "Type":$elementType, "unsigned":$minNumElements);
-  let assemblyFormat = [{
-    `<` `?` `x` $minNumElements `x` ` ` custom<PrettyLLVMType>($elementType) `>`
-  }];
-
-  let genVerifyDecl = 1;
-
-  let builders = [
-    TypeBuilderWithInferredContext<(ins "Type":$elementType,
-                                        "unsigned":$minNumElements)>
-  ];
-
-  let extraClassDeclaration = [{
-    /// Checks if the given type can be used in a vector type.
-    static bool isValidElementType(Type type);
-  }];
-}
-
-//===----------------------------------------------------------------------===//
 // LLVMTargetExtType
 //===----------------------------------------------------------------------===//
 

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMTypes.td
@@ -289,38 +289,6 @@ def LLVMPointerType : LLVMType<"LLVMPointer", "ptr", [
 }
 
 //===----------------------------------------------------------------------===//
-// LLVMFixedVectorType
-//===----------------------------------------------------------------------===//
-
-def LLVMFixedVectorType : LLVMType<"LLVMFixedVector", "vec"> {
-  let summary = "LLVM fixed vector type";
-  let description = [{
-    LLVM dialect vector type that supports all element types that are supported
-    in LLVM vectors but that are not supported by the builtin MLIR vector type.
-    E.g., LLVMFixedVectorType supports LLVM pointers as element type.
-  }];
-
-  let typeName = "llvm.fixed_vec";
-
-  let parameters = (ins "Type":$elementType, "unsigned":$numElements);
-  let assemblyFormat = [{
-    `<` $numElements `x` custom<PrettyLLVMType>($elementType) `>`
-  }];
-
-  let genVerifyDecl = 1;
-
-  let builders = [
-    TypeBuilderWithInferredContext<(ins "Type":$elementType,
-                                        "unsigned":$numElements)>
-  ];
-
-  let extraClassDeclaration = [{
-    /// Checks if the given type can be used in a vector type.
-    static bool isValidElementType(Type type);
-  }];
-}
-
-//===----------------------------------------------------------------------===//
 // LLVMScalableVectorType
 //===----------------------------------------------------------------------===//
 
@@ -397,6 +365,19 @@ def LLVMX86AMXType : LLVMType<"LLVMX86AMX", "x86_amx"> {
   let description = [{
     The x86_amx type represents a value held in an AMX tile register on an x86
     machine. Can only be used in AMX intrinsics calls.
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// LLVMPPCFP128Type
+//===----------------------------------------------------------------------===//
+
+def LLVMPPCFP128Type : LLVMType<"LLVMPPCFP128", "ppc_fp128",
+    [DeclareTypeInterfaceMethods<FloatTypeInterface, ["getFloatSemantics"]>]> {
+  let summary = "128 bit FP type with IBM double-double semantics";
+  let description = [{
+    A 128 bit floating-point type with IBM double-double semantics.
+    See S_PPCDoubleDouble in APFloat.h for details.
   }];
 }
 

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3154,8 +3154,11 @@ OpFoldResult LLVM::ZeroOp::fold(FoldAdaptor) {
 /// account nested types. Supported types are `VectorType` and `LLVMArrayType`.
 /// Everything else is treated as a scalar.
 static int64_t getNumElements(Type t) {
-  if (auto vecType = dyn_cast<VectorType>(t))
+  if (auto vecType = dyn_cast<VectorType>(t)) {
+    assert(!vecType.isScalable() &&
+           "number of elements of a scalable vector type is unknown");
     return vecType.getNumElements() * getNumElements(vecType.getElementType());
+  }
   if (auto arrayType = dyn_cast<LLVM::LLVMArrayType>(t))
     return arrayType.getNumElements() *
            getNumElements(arrayType.getElementType());

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -687,8 +687,6 @@ static Type extractVectorElementType(Type type) {
     return vectorType.getElementType();
   if (auto scalableVectorType = llvm::dyn_cast<LLVMScalableVectorType>(type))
     return scalableVectorType.getElementType();
-  if (auto fixedVectorType = llvm::dyn_cast<LLVMFixedVectorType>(type))
-    return fixedVectorType.getElementType();
   return type;
 }
 
@@ -725,20 +723,19 @@ static void destructureIndices(Type currType, ArrayRef<GEPArg> indices,
     if (rawConstantIndices.size() == 1 || !currType)
       continue;
 
-    currType =
-        TypeSwitch<Type, Type>(currType)
-            .Case<VectorType, LLVMScalableVectorType, LLVMFixedVectorType,
-                  LLVMArrayType>([](auto containerType) {
-              return containerType.getElementType();
-            })
-            .Case([&](LLVMStructType structType) -> Type {
-              int64_t memberIndex = rawConstantIndices.back();
-              if (memberIndex >= 0 && static_cast<size_t>(memberIndex) <
-                                          structType.getBody().size())
-                return structType.getBody()[memberIndex];
-              return nullptr;
-            })
-            .Default(Type(nullptr));
+    currType = TypeSwitch<Type, Type>(currType)
+                   .Case<VectorType, LLVMScalableVectorType, LLVMArrayType>(
+                       [](auto containerType) {
+                         return containerType.getElementType();
+                       })
+                   .Case([&](LLVMStructType structType) -> Type {
+                     int64_t memberIndex = rawConstantIndices.back();
+                     if (memberIndex >= 0 && static_cast<size_t>(memberIndex) <
+                                                 structType.getBody().size())
+                       return structType.getBody()[memberIndex];
+                     return nullptr;
+                   })
+                   .Default(Type(nullptr));
   }
 }
 
@@ -839,11 +836,11 @@ verifyStructIndices(Type baseGEPType, unsigned indexPos,
         return verifyStructIndices(elementTypes[gepIndex], indexPos + 1,
                                    indices, emitOpError);
       })
-      .Case<VectorType, LLVMScalableVectorType, LLVMFixedVectorType,
-            LLVMArrayType>([&](auto containerType) -> LogicalResult {
-        return verifyStructIndices(containerType.getElementType(), indexPos + 1,
-                                   indices, emitOpError);
-      })
+      .Case<VectorType, LLVMScalableVectorType, LLVMArrayType>(
+          [&](auto containerType) -> LogicalResult {
+            return verifyStructIndices(containerType.getElementType(),
+                                       indexPos + 1, indices, emitOpError);
+          })
       .Default([&](auto otherType) -> LogicalResult {
         return emitOpError()
                << "type " << otherType << " cannot be indexed (index #"
@@ -3157,16 +3154,14 @@ OpFoldResult LLVM::ZeroOp::fold(FoldAdaptor) {
 //===----------------------------------------------------------------------===//
 
 /// Compute the total number of elements in the given type, also taking into
-/// account nested types. Supported types are `VectorType`, `LLVMArrayType` and
-/// `LLVMFixedVectorType`. Everything else is treated as a scalar.
+/// account nested types. Supported types are `VectorType` and `LLVMArrayType`.
+/// Everything else is treated as a scalar.
 static int64_t getNumElements(Type t) {
   if (auto vecType = dyn_cast<VectorType>(t))
     return vecType.getNumElements() * getNumElements(vecType.getElementType());
   if (auto arrayType = dyn_cast<LLVM::LLVMArrayType>(t))
     return arrayType.getNumElements() *
            getNumElements(arrayType.getElementType());
-  if (auto vecType = dyn_cast<LLVMFixedVectorType>(t))
-    return vecType.getNumElements() * getNumElements(vecType.getElementType());
   assert(!isa<LLVM::LLVMScalableVectorType>(t) &&
          "number of elements of a scalable vector type is unknown");
   return 1;
@@ -3184,8 +3179,6 @@ static bool hasScalableVectorType(Type t) {
   }
   if (auto arrayType = dyn_cast<LLVM::LLVMArrayType>(t))
     return hasScalableVectorType(arrayType.getElementType());
-  if (auto vecType = dyn_cast<LLVMFixedVectorType>(t))
-    return hasScalableVectorType(vecType.getElementType());
   return false;
 }
 
@@ -3265,8 +3258,7 @@ LogicalResult LLVM::ConstantOp::verify() {
                << "scalable vector type requires a splat attribute";
       return success();
     }
-    if (!isa<VectorType, LLVM::LLVMArrayType, LLVM::LLVMFixedVectorType>(
-            getType()))
+    if (!isa<VectorType, LLVM::LLVMArrayType>(getType()))
       return emitOpError() << "expected vector or array type";
     // The number of elements of the attribute and the type must match.
     int64_t attrNumElements;
@@ -3515,8 +3507,7 @@ LogicalResult LLVM::BitcastOp::verify() {
   if (!resultType)
     return success();
 
-  auto isVector =
-      llvm::IsaPred<VectorType, LLVMScalableVectorType, LLVMFixedVectorType>;
+  auto isVector = llvm::IsaPred<VectorType, LLVMScalableVectorType>;
 
   // Due to bitcast requiring both operands to be of the same size, it is not
   // possible for only one of the two to be a pointer of vectors.
@@ -3982,7 +3973,6 @@ void LLVMDialect::initialize() {
 
   // clang-format off
   addTypes<LLVMVoidType,
-           LLVMPPCFP128Type,
            LLVMTokenType,
            LLVMLabelType,
            LLVMMetadataType>();

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -685,8 +685,6 @@ GEPIndicesAdaptor<ValueRange> GEPOp::getIndices() {
 static Type extractVectorElementType(Type type) {
   if (auto vectorType = llvm::dyn_cast<VectorType>(type))
     return vectorType.getElementType();
-  if (auto scalableVectorType = llvm::dyn_cast<LLVMScalableVectorType>(type))
-    return scalableVectorType.getElementType();
   return type;
 }
 
@@ -724,10 +722,9 @@ static void destructureIndices(Type currType, ArrayRef<GEPArg> indices,
       continue;
 
     currType = TypeSwitch<Type, Type>(currType)
-                   .Case<VectorType, LLVMScalableVectorType, LLVMArrayType>(
-                       [](auto containerType) {
-                         return containerType.getElementType();
-                       })
+                   .Case<VectorType, LLVMArrayType>([](auto containerType) {
+                     return containerType.getElementType();
+                   })
                    .Case([&](LLVMStructType structType) -> Type {
                      int64_t memberIndex = rawConstantIndices.back();
                      if (memberIndex >= 0 && static_cast<size_t>(memberIndex) <
@@ -836,7 +833,7 @@ verifyStructIndices(Type baseGEPType, unsigned indexPos,
         return verifyStructIndices(elementTypes[gepIndex], indexPos + 1,
                                    indices, emitOpError);
       })
-      .Case<VectorType, LLVMScalableVectorType, LLVMArrayType>(
+      .Case<VectorType, LLVMArrayType>(
           [&](auto containerType) -> LogicalResult {
             return verifyStructIndices(containerType.getElementType(),
                                        indexPos + 1, indices, emitOpError);
@@ -3162,16 +3159,12 @@ static int64_t getNumElements(Type t) {
   if (auto arrayType = dyn_cast<LLVM::LLVMArrayType>(t))
     return arrayType.getNumElements() *
            getNumElements(arrayType.getElementType());
-  assert(!isa<LLVM::LLVMScalableVectorType>(t) &&
-         "number of elements of a scalable vector type is unknown");
   return 1;
 }
 
 /// Check if the given type is a scalable vector type or a vector/array type
 /// that contains a nested scalable vector type.
 static bool hasScalableVectorType(Type t) {
-  if (isa<LLVM::LLVMScalableVectorType>(t))
-    return true;
   if (auto vecType = dyn_cast<VectorType>(t)) {
     if (vecType.isScalable())
       return true;
@@ -3507,7 +3500,7 @@ LogicalResult LLVM::BitcastOp::verify() {
   if (!resultType)
     return success();
 
-  auto isVector = llvm::IsaPred<VectorType, LLVMScalableVectorType>;
+  auto isVector = llvm::IsaPred<VectorType>;
 
   // Due to bitcast requiring both operands to be of the same size, it is not
   // possible for only one of the two to be a pointer of vectors.

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMMemorySlot.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMMemorySlot.cpp
@@ -137,7 +137,7 @@ static bool isSupportedTypeForConversion(Type type) {
   // LLVM vector types are only used for either pointers or target specific
   // types. These types cannot be casted in the general case, thus the memory
   // optimizations do not support them.
-  if (isa<LLVM::LLVMFixedVectorType, LLVM::LLVMScalableVectorType>(type))
+  if (isa<LLVM::LLVMScalableVectorType>(type))
     return false;
 
   if (auto vectorType = dyn_cast<VectorType>(type)) {

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMMemorySlot.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMMemorySlot.cpp
@@ -134,12 +134,6 @@ static bool isSupportedTypeForConversion(Type type) {
   if (isa<LLVM::LLVMStructType, LLVM::LLVMArrayType>(type))
     return false;
 
-  // LLVM vector types are only used for either pointers or target specific
-  // types. These types cannot be casted in the general case, thus the memory
-  // optimizations do not support them.
-  if (isa<LLVM::LLVMScalableVectorType>(type))
-    return false;
-
   if (auto vectorType = dyn_cast<VectorType>(type)) {
     // Vectors of pointers cannot be casted.
     if (isa<LLVM::LLVMPointerType>(vectorType.getElementType()))

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMTypeSyntax.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMTypeSyntax.cpp
@@ -40,7 +40,6 @@ static StringRef getTypeKeyword(Type type) {
       .Case<LLVMMetadataType>([&](Type) { return "metadata"; })
       .Case<LLVMFunctionType>([&](Type) { return "func"; })
       .Case<LLVMPointerType>([&](Type) { return "ptr"; })
-      .Case<LLVMScalableVectorType>([&](Type) { return "vec"; })
       .Case<LLVMArrayType>([&](Type) { return "array"; })
       .Case<LLVMStructType>([&](Type) { return "struct"; })
       .Case<LLVMTargetExtType>([&](Type) { return "target"; })
@@ -103,9 +102,8 @@ void mlir::LLVM::detail::printType(Type type, AsmPrinter &printer) {
   printer << getTypeKeyword(type);
 
   llvm::TypeSwitch<Type>(type)
-      .Case<LLVMPointerType, LLVMArrayType, LLVMScalableVectorType,
-            LLVMFunctionType, LLVMTargetExtType, LLVMStructType>(
-          [&](auto type) { type.print(printer); });
+      .Case<LLVMPointerType, LLVMArrayType, LLVMFunctionType, LLVMTargetExtType,
+            LLVMStructType>([&](auto type) { type.print(printer); });
 }
 
 //===----------------------------------------------------------------------===//
@@ -113,41 +111,6 @@ void mlir::LLVM::detail::printType(Type type, AsmPrinter &printer) {
 //===----------------------------------------------------------------------===//
 
 static ParseResult dispatchParse(AsmParser &parser, Type &type);
-
-/// Parses an LLVM dialect vector type.
-///   llvm-type ::= `vec<` `? x`? integer `x` llvm-type `>`
-/// Supports both fixed and scalable vectors.
-static Type parseVectorType(AsmParser &parser) {
-  SmallVector<int64_t, 2> dims;
-  SMLoc dimPos, typePos;
-  Type elementType;
-  SMLoc loc = parser.getCurrentLocation();
-  if (parser.parseLess() || parser.getCurrentLocation(&dimPos) ||
-      parser.parseDimensionList(dims, /*allowDynamic=*/true) ||
-      parser.getCurrentLocation(&typePos) ||
-      dispatchParse(parser, elementType) || parser.parseGreater())
-    return Type();
-
-  // We parsed a generic dimension list, but vectors only support two forms:
-  //  - single non-dynamic entry in the list (fixed vector);
-  //  - two elements, the first dynamic (indicated by ShapedType::kDynamic)
-  //  and the second
-  //    non-dynamic (scalable vector).
-  if (dims.empty() || dims.size() > 2 ||
-      ((dims.size() == 2) ^ (ShapedType::isDynamic(dims[0]))) ||
-      (dims.size() == 2 && ShapedType::isDynamic(dims[1]))) {
-    parser.emitError(dimPos)
-        << "expected '? x <integer> x <type>' or '<integer> x <type>'";
-    return Type();
-  }
-
-  bool isScalable = dims.size() == 2;
-  if (!isScalable) {
-    parser.emitError(dimPos) << "expected scalable vector";
-    return Type();
-  }
-  return parser.getChecked<LLVMScalableVectorType>(loc, elementType, dims[1]);
-}
 
 /// Attempts to set the body of an identified structure type. Reports a parsing
 /// error at `subtypesLoc` in case of failure.
@@ -307,7 +270,6 @@ static Type dispatchParse(AsmParser &parser, bool allowAny = true) {
       .Case("metadata", [&] { return LLVMMetadataType::get(ctx); })
       .Case("func", [&] { return LLVMFunctionType::parse(parser); })
       .Case("ptr", [&] { return LLVMPointerType::parse(parser); })
-      .Case("vec", [&] { return parseVectorType(parser); })
       .Case("array", [&] { return LLVMArrayType::parse(parser); })
       .Case("struct", [&] { return LLVMStructType::parse(parser); })
       .Case("target", [&] { return LLVMTargetExtType::parse(parser); })

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
@@ -822,23 +822,17 @@ bool mlir::LLVM::isCompatibleVectorType(Type type) {
 }
 
 Type mlir::LLVM::getVectorElementType(Type type) {
-  return llvm::TypeSwitch<Type, Type>(type)
-      .Case<VectorType>([](auto ty) { return ty.getElementType(); })
-      .Default([](Type) -> Type {
-        llvm_unreachable("incompatible with LLVM vector type");
-      });
+  auto vecTy = dyn_cast<VectorType>(type);
+  assert(vecTy && "incompatible with LLVM vector type");
+  return vecTy.getElementType();
 }
 
 llvm::ElementCount mlir::LLVM::getVectorNumElements(Type type) {
-  return llvm::TypeSwitch<Type, llvm::ElementCount>(type)
-      .Case([](VectorType ty) {
-        if (ty.isScalable())
-          return llvm::ElementCount::getScalable(ty.getNumElements());
-        return llvm::ElementCount::getFixed(ty.getNumElements());
-      })
-      .Default([](Type) -> llvm::ElementCount {
-        llvm_unreachable("incompatible with LLVM vector type");
-      });
+  auto vecTy = dyn_cast<VectorType>(type);
+  assert(vecTy && "incompatible with LLVM vector type");
+  if (vecTy.isScalable())
+    return llvm::ElementCount::getScalable(vecTy.getNumElements());
+  return llvm::ElementCount::getFixed(vecTy.getNumElements());
 }
 
 bool mlir::LLVM::isScalableVectorType(Type vectorType) {

--- a/mlir/lib/Target/LLVMIR/TypeFromLLVM.cpp
+++ b/mlir/lib/Target/LLVMIR/TypeFromLLVM.cpp
@@ -130,8 +130,8 @@ private:
 
   /// Translates the given scalable-vector type.
   Type translate(llvm::ScalableVectorType *type) {
-    return LLVM::LLVMScalableVectorType::get(
-        translateType(type->getElementType()), type->getMinNumElements());
+    return LLVM::getScalableVectorType(translateType(type->getElementType()),
+                                       type->getMinNumElements());
   }
 
   /// Translates the given target extension type.

--- a/mlir/lib/Target/LLVMIR/TypeToLLVM.cpp
+++ b/mlir/lib/Target/LLVMIR/TypeToLLVM.cpp
@@ -72,8 +72,8 @@ public:
             })
             .Case<LLVM::LLVMArrayType, IntegerType, LLVM::LLVMFunctionType,
                   LLVM::LLVMPointerType, LLVM::LLVMStructType,
-                  LLVM::LLVMFixedVectorType, LLVM::LLVMScalableVectorType,
-                  VectorType, LLVM::LLVMTargetExtType>(
+                  LLVM::LLVMScalableVectorType, VectorType,
+                  LLVM::LLVMTargetExtType>(
                 [this](auto type) { return this->translate(type); })
             .Default([](Type t) -> llvm::Type * {
               llvm_unreachable("unknown LLVM dialect type");
@@ -139,12 +139,6 @@ private:
     if (type.isScalable())
       return llvm::ScalableVectorType::get(translateType(type.getElementType()),
                                            type.getNumElements());
-    return llvm::FixedVectorType::get(translateType(type.getElementType()),
-                                      type.getNumElements());
-  }
-
-  /// Translates the given fixed-vector type.
-  llvm::Type *translate(LLVM::LLVMFixedVectorType type) {
     return llvm::FixedVectorType::get(translateType(type.getElementType()),
                                       type.getNumElements());
   }

--- a/mlir/lib/Target/LLVMIR/TypeToLLVM.cpp
+++ b/mlir/lib/Target/LLVMIR/TypeToLLVM.cpp
@@ -71,8 +71,7 @@ public:
               return llvm::Type::getX86_AMXTy(context);
             })
             .Case<LLVM::LLVMArrayType, IntegerType, LLVM::LLVMFunctionType,
-                  LLVM::LLVMPointerType, LLVM::LLVMStructType,
-                  LLVM::LLVMScalableVectorType, VectorType,
+                  LLVM::LLVMPointerType, LLVM::LLVMStructType, VectorType,
                   LLVM::LLVMTargetExtType>(
                 [this](auto type) { return this->translate(type); })
             .Default([](Type t) -> llvm::Type * {
@@ -141,12 +140,6 @@ private:
                                            type.getNumElements());
     return llvm::FixedVectorType::get(translateType(type.getElementType()),
                                       type.getNumElements());
-  }
-
-  /// Translates the given scalable-vector type.
-  llvm::Type *translate(LLVM::LLVMScalableVectorType type) {
-    return llvm::ScalableVectorType::get(translateType(type.getElementType()),
-                                         type.getMinNumElements());
   }
 
   /// Translates the given target extension type.

--- a/mlir/test/Dialect/LLVMIR/mem2reg.mlir
+++ b/mlir/test/Dialect/LLVMIR/mem2reg.mlir
@@ -1033,7 +1033,7 @@ llvm.func @scalable_vector() -> i16 {
 llvm.func @scalable_llvm_vector() -> i16 {
   %0 = llvm.mlir.constant(1 : i32) : i32
   // CHECK: llvm.alloca
-  %1 = llvm.alloca %0 x !llvm.vec<? x 4 x ppc_fp128> : (i32) -> !llvm.ptr
+  %1 = llvm.alloca %0 x vector<[4] x !llvm.ppc_fp128> : (i32) -> !llvm.ptr
   %2 = llvm.load %1 : !llvm.ptr -> i16
   llvm.return %2 : i16
 }

--- a/mlir/test/Dialect/LLVMIR/types-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/types-invalid.mlir
@@ -118,34 +118,6 @@ func.func @identified_struct_with_void() {
 
 // -----
 
-func.func @dynamic_vector() {
-  // expected-error @+1 {{expected '? x <integer> x <type>' or '<integer> x <type>'}}
-  "some.op"() : () -> !llvm.vec<? x ptr>
-}
-
-// -----
-
-func.func @dynamic_scalable_vector() {
-  // expected-error @+1 {{expected '? x <integer> x <type>' or '<integer> x <type>'}}
-  "some.op"() : () -> !llvm.vec<?x? x ptr>
-}
-
-// -----
-
-func.func @unscalable_vector() {
-  // expected-error @+1 {{expected '? x <integer> x <type>' or '<integer> x <type>'}}
-  "some.op"() : () -> !llvm.vec<4x4 x ptr>
-}
-
-// -----
-
-func.func @scalable_void_vector() {
-  // expected-error @+1 {{invalid vector element type}}
-  "some.op"() : () -> !llvm.vec<?x4 x void>
-}
-
-// -----
-
 // expected-error @+1 {{unexpected type, expected keyword}}
 func.func private @unexpected_type() -> !llvm.tensor<*xf32>
 

--- a/mlir/test/Dialect/LLVMIR/types-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/types-invalid.mlir
@@ -139,20 +139,6 @@ func.func @unscalable_vector() {
 
 // -----
 
-func.func @zero_vector() {
-  // expected-error @+1 {{the number of vector elements must be positive}}
-  "some.op"() : () -> !llvm.vec<0 x ptr>
-}
-
-// -----
-
-func.func @nested_vector() {
-  // expected-error @+1 {{invalid vector element type}}
-  "some.op"() : () -> !llvm.vec<2 x vector<2xi32>>
-}
-
-// -----
-
 func.func @scalable_void_vector() {
   // expected-error @+1 {{invalid vector element type}}
   "some.op"() : () -> !llvm.vec<?x4 x void>
@@ -167,11 +153,6 @@ func.func private @unexpected_type() -> !llvm.tensor<*xf32>
 
 // expected-error @+1 {{unexpected type, expected keyword}}
 func.func private @unexpected_type() -> !llvm.f32
-
-// -----
-
-// expected-error @below {{cannot use !llvm.vec for built-in primitives, use 'vector' instead}}
-func.func private @llvm_vector_primitive() -> !llvm.vec<4 x f32>
 
 // -----
 

--- a/mlir/test/Dialect/LLVMIR/types.mlir
+++ b/mlir/test/Dialect/LLVMIR/types.mlir
@@ -72,10 +72,10 @@ func.func @vec() {
   "some.op"() : () -> vector<4xi32>
   // CHECK: vector<4xf32>
   "some.op"() : () -> vector<4xf32>
-  // CHECK: !llvm.vec<? x 4 x i32>
-  "some.op"() : () -> !llvm.vec<? x 4 x i32>
-  // CHECK: !llvm.vec<? x 8 x f16>
-  "some.op"() : () -> !llvm.vec<? x 8 x f16>
+  // CHECK: vector<[4]xi32>
+  "some.op"() : () -> vector<[4] x i32>
+  // CHECK: vector<[8]xf16>
+  "some.op"() : () -> vector<[8] x f16>
   // CHECK: vector<4x!llvm.ptr>
   "some.op"() : () -> vector<4x!llvm.ptr>
   // CHECK: vector<4x!llvm.ppc_fp128>

--- a/mlir/test/Dialect/LLVMIR/types.mlir
+++ b/mlir/test/Dialect/LLVMIR/types.mlir
@@ -78,6 +78,8 @@ func.func @vec() {
   "some.op"() : () -> !llvm.vec<? x 8 x f16>
   // CHECK: vector<4x!llvm.ptr>
   "some.op"() : () -> vector<4x!llvm.ptr>
+  // CHECK: vector<4x!llvm.ppc_fp128>
+  "some.op"() : () -> vector<4x!llvm.ppc_fp128>
   return
 }
 

--- a/mlir/test/Target/LLVMIR/Import/intrinsic.ll
+++ b/mlir/test/Target/LLVMIR/Import/intrinsic.ll
@@ -882,7 +882,7 @@ define void @invariant_group(ptr %0) {
 
 ; CHECK-LABEL: llvm.func @vector_insert
 define void @vector_insert(<vscale x 4 x float> %0, <4 x float> %1) {
-  ; CHECK: llvm.intr.vector.insert %{{.*}}, %{{.*}}[4] : vector<4xf32> into !llvm.vec<? x 4 x  f32>
+  ; CHECK: llvm.intr.vector.insert %{{.*}}, %{{.*}}[4] : vector<4xf32> into vector<[4]xf32>
   %3 = call <vscale x 4 x float>  @llvm.vector.insert.nxv4f32.v4f32(<vscale x 4 x float> %0, <4 x float> %1, i64 4);
   ret void
 }
@@ -898,7 +898,7 @@ define void @vector_extract(<vscale x 4 x float> %0) {
 define void @vector_deinterleave2(<4 x double> %0, <vscale x 8 x i32> %1) {
   ; CHECK: "llvm.intr.vector.deinterleave2"(%{{.*}}) : (vector<4xf64>) -> !llvm.struct<(vector<2xf64>, vector<2xf64>)>
   %3 = call { <2 x double>, <2 x double> } @llvm.vector.deinterleave2.v4f64(<4 x double> %0);
-  ; CHECK: "llvm.intr.vector.deinterleave2"(%{{.*}}) : (!llvm.vec<? x 8 x i32>) -> !llvm.struct<(vec<? x 4 x i32>, vec<? x 4 x i32>)>
+  ; CHECK: "llvm.intr.vector.deinterleave2"(%{{.*}}) : (vector<[8]xi32>) -> !llvm.struct<(vector<[4]xi32>, vector<[4]xi32>)>
   %4 = call { <vscale x 4 x i32>, <vscale x 4 x i32> } @llvm.vector.deinterleave2.nxv8i32(<vscale x 8 x i32> %1);
   ret void
 }

--- a/mlir/test/Target/LLVMIR/llvmir-types.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-types.mlir
@@ -81,9 +81,9 @@ llvm.func @return_v4_float() -> vector<4xf32>
 // CHECK: declare <vscale x 4 x float> @return_vs_4_float()
 llvm.func @return_vs_4_float() -> vector<[4]xf32>
 // CHECK: declare <vscale x 4 x i32> @return_vs_4_i32()
-llvm.func @return_vs_4_i32() -> !llvm.vec<?x4 x i32>
+llvm.func @return_vs_4_i32() -> vector<[4]xi32>
 // CHECK: declare <vscale x 8 x half> @return_vs_8_half()
-llvm.func @return_vs_8_half() -> !llvm.vec<?x8 x f16>
+llvm.func @return_vs_8_half() -> vector<[8]xf16>
 // CHECK: declare <4 x ptr> @return_v_4_pi8()
 llvm.func @return_v_4_pi8() -> vector<4x!llvm.ptr>
 


### PR DESCRIPTION
Since #125690, the MLIR vector type supports `!llvm.ptr` as an element type. The only remaining element type for `LLVMFixedVectorType` is now `LLVMPPCFP128Type`.

This commit turns `LLVMPPCFP128Type` into a proper FP type (by implementing `FloatTypeInterface`), so that the MLIR vector type accepts it as an element type. This makes `LLVMFixedVectorType` obsolete. `LLVMScalableVectorType` is also obsolete. This commit deletes `LLVMFixedVectorType` and `LLVMScalableVectorType`.

Note for LLVM integration: Use `VectorType` instead of `LLVMFixedVectorType` and `LLVMScalableVectorType`.

