### PR TITLE
[HLSL] Include SPIRV in LLVM_TARGETS_TO_BUILD in the HLSL cmake cache

### DIFF
--- a/clang/cmake/caches/HLSL.cmake
+++ b/clang/cmake/caches/HLSL.cmake
@@ -1,13 +1,10 @@
 # Including the native target is important because some of LLVM's tests fail if
 # you don't.
-set(LLVM_TARGETS_TO_BUILD Native CACHE STRING "")
+set(LLVM_TARGETS_TO_BUILD "Native;SPIRV" CACHE STRING "")
 
-# Include the DirectX target for DXIL code generation, eventually we'll include
-# SPIR-V here too.
-set(LLVM_EXPERIMENTAL_TARGETS_TO_BUILD "DirectX;SPIRV" CACHE STRING "")
+# Include the DirectX target for DXIL code generation.
+set(LLVM_EXPERIMENTAL_TARGETS_TO_BUILD "DirectX" CACHE STRING "")
 
-# HLSL support is currently limted to clang, eventually it will expand to
-# clang-tools-extra too.
 set(LLVM_ENABLE_PROJECTS "clang;clang-tools-extra" CACHE STRING "")
 
 set(CLANG_ENABLE_HLSL On CACHE BOOL "")


### PR DESCRIPTION
Since SPIRV is no longer an experimental target this wasn't actually enabling it any more.