### PR TITLE
Add a new affordance that the Python module in a dSYM

### DIFF
--- a/lldb/bindings/python/python-wrapper.swig
+++ b/lldb/bindings/python/python-wrapper.swig
@@ -966,6 +966,28 @@ bool lldb_private::python::SWIGBridge::LLDBSWIGPythonRunScriptKeywordValue(
   return true;
 }
 
+bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallModuleNewTarget(
+    const char *python_module_name, const char *session_dictionary_name,
+    lldb::TargetSP target_sp) {
+  std::string python_function_name_string = python_module_name;
+  python_function_name_string += ".__lldb_module_added_to_target";
+  const char *python_function_name = python_function_name_string.c_str();
+
+  PyErr_Cleaner py_err_cleaner(true);
+
+  auto dict = PythonModule::MainModule().ResolveName<PythonDictionary>(
+      session_dictionary_name);
+  auto pfunc = PythonObject::ResolveNameWithDictionary<PythonCallable>(
+      python_function_name, dict);
+
+  if (!pfunc.IsAllocated())
+    return true;
+
+  pfunc(SWIGBridge::ToSWIGWrapper(std::move(target_sp)), dict);
+
+  return true;
+}
+
 bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallModuleInit(
     const char *python_module_name, const char *session_dictionary_name,
     lldb::DebuggerSP debugger) {

--- a/lldb/include/lldb/Interpreter/ScriptInterpreter.h
+++ b/lldb/include/lldb/Interpreter/ScriptInterpreter.h
@@ -522,7 +522,8 @@ public:
   LoadScriptingModule(const char *filename, const LoadScriptOptions &options,
                       lldb_private::Status &error,
                       StructuredData::ObjectSP *module_sp = nullptr,
-                      FileSpec extra_search_dir = {});
+                      FileSpec extra_search_dir = {},
+                      lldb::TargetSP loaded_into_target_sp = {});
 
   virtual bool IsReservedWord(const char *word) { return false; }
 

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1486,7 +1486,7 @@ bool Module::LoadScriptingResourceInTarget(Target *target, Status &error,
             LoadScriptOptions options;
             bool did_load = script_interpreter->LoadScriptingModule(
                 scripting_stream.GetData(), options, error,
-                /*module_sp*/ nullptr, /*extra_path*/ {}, 
+                /*module_sp*/ nullptr, /*extra_path*/ {},
                 target->shared_from_this());
             if (!did_load)
               return false;

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1485,7 +1485,9 @@ bool Module::LoadScriptingResourceInTarget(Target *target, Status &error,
             scripting_fspec.Dump(scripting_stream.AsRawOstream());
             LoadScriptOptions options;
             bool did_load = script_interpreter->LoadScriptingModule(
-                scripting_stream.GetData(), options, error);
+                scripting_stream.GetData(), options, error,
+                /*module_sp*/ nullptr, /*extra_path*/ {}, 
+                target->shared_from_this());
             if (!did_load)
               return false;
           }

--- a/lldb/source/Interpreter/ScriptInterpreter.cpp
+++ b/lldb/source/Interpreter/ScriptInterpreter.cpp
@@ -48,12 +48,10 @@ StructuredData::DictionarySP ScriptInterpreter::GetInterpreterInfo() {
   return nullptr;
 }
 
-bool ScriptInterpreter::LoadScriptingModule(const char *filename,
-                                            const LoadScriptOptions &options,
-                                            lldb_private::Status &error,
-                                            StructuredData::ObjectSP *module_sp,
-                                            FileSpec extra_search_dir,
-                                            lldb::TargetSP loaded_into_target_sp) {
+bool ScriptInterpreter::LoadScriptingModule(
+    const char *filename, const LoadScriptOptions &options,
+    lldb_private::Status &error, StructuredData::ObjectSP *module_sp,
+    FileSpec extra_search_dir, lldb::TargetSP loaded_into_target_sp) {
   error = Status::FromErrorString(
       "This script interpreter does not support importing modules.");
   return false;

--- a/lldb/source/Interpreter/ScriptInterpreter.cpp
+++ b/lldb/source/Interpreter/ScriptInterpreter.cpp
@@ -52,7 +52,8 @@ bool ScriptInterpreter::LoadScriptingModule(const char *filename,
                                             const LoadScriptOptions &options,
                                             lldb_private::Status &error,
                                             StructuredData::ObjectSP *module_sp,
-                                            FileSpec extra_search_dir) {
+                                            FileSpec extra_search_dir,
+                                            lldb::TargetSP loaded_into_target_sp) {
   error = Status::FromErrorString(
       "This script interpreter does not support importing modules.");
   return false;

--- a/lldb/source/Plugins/ScriptInterpreter/Python/SWIGPythonBridge.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/SWIGPythonBridge.h
@@ -215,10 +215,11 @@ public:
                                            const char *session_dictionary_name,
                                            lldb::DebuggerSP debugger);
 
-  static bool LLDBSwigPythonCallModuleNewTarget(const char *python_module_name,
-                                           const char *session_dictionary_name,
-                                           lldb::TargetSP target);
-                                           
+  static bool
+  LLDBSwigPythonCallModuleNewTarget(const char *python_module_name,
+                                    const char *session_dictionary_name,
+                                    lldb::TargetSP target);
+
   static python::PythonObject
   LLDBSWIGPythonCreateOSPlugin(const char *python_class_name,
                                const char *session_dictionary_name,

--- a/lldb/source/Plugins/ScriptInterpreter/Python/SWIGPythonBridge.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/SWIGPythonBridge.h
@@ -215,6 +215,10 @@ public:
                                            const char *session_dictionary_name,
                                            lldb::DebuggerSP debugger);
 
+  static bool LLDBSwigPythonCallModuleNewTarget(const char *python_module_name,
+                                           const char *session_dictionary_name,
+                                           lldb::TargetSP target);
+                                           
   static python::PythonObject
   LLDBSWIGPythonCreateOSPlugin(const char *python_class_name,
                                const char *session_dictionary_name,

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -2316,7 +2316,8 @@ uint64_t replace_all(std::string &str, const std::string &oldStr,
 bool ScriptInterpreterPythonImpl::LoadScriptingModule(
     const char *pathname, const LoadScriptOptions &options,
     lldb_private::Status &error, StructuredData::ObjectSP *module_sp,
-    FileSpec extra_search_dir) {
+    FileSpec extra_search_dir,
+    lldb::TargetSP target_sp) {
   namespace fs = llvm::sys::fs;
   namespace path = llvm::sys::path;
 
@@ -2495,6 +2496,12 @@ bool ScriptInterpreterPythonImpl::LoadScriptingModule(
           PyRefType::Owned, static_cast<PyObject *>(module_pyobj)));
   }
 
+  // Finally, if we got a target passed in, then we should tell the new module
+  // about this target:
+  if (target_sp) {
+    return SWIGBridge::LLDBSwigPythonCallModuleNewTarget(module_name.c_str(),
+        m_dictionary_name.c_str(), target_sp);
+  }
   return true;
 }
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -2316,8 +2316,7 @@ uint64_t replace_all(std::string &str, const std::string &oldStr,
 bool ScriptInterpreterPythonImpl::LoadScriptingModule(
     const char *pathname, const LoadScriptOptions &options,
     lldb_private::Status &error, StructuredData::ObjectSP *module_sp,
-    FileSpec extra_search_dir,
-    lldb::TargetSP target_sp) {
+    FileSpec extra_search_dir, lldb::TargetSP target_sp) {
   namespace fs = llvm::sys::fs;
   namespace path = llvm::sys::path;
 
@@ -2499,8 +2498,8 @@ bool ScriptInterpreterPythonImpl::LoadScriptingModule(
   // Finally, if we got a target passed in, then we should tell the new module
   // about this target:
   if (target_sp) {
-    return SWIGBridge::LLDBSwigPythonCallModuleNewTarget(module_name.c_str(),
-        m_dictionary_name.c_str(), target_sp);
+    return SWIGBridge::LLDBSwigPythonCallModuleNewTarget(
+        module_name.c_str(), m_dictionary_name.c_str(), target_sp);
   }
   return true;
 }

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -2497,10 +2497,10 @@ bool ScriptInterpreterPythonImpl::LoadScriptingModule(
 
   // Finally, if we got a target passed in, then we should tell the new module
   // about this target:
-  if (target_sp) {
+  if (target_sp)
     return SWIGBridge::LLDBSwigPythonCallModuleNewTarget(
         module_name.c_str(), m_dictionary_name.c_str(), target_sp);
-  }
+
   return true;
 }
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPythonImpl.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPythonImpl.h
@@ -245,7 +245,8 @@ public:
                            const LoadScriptOptions &options,
                            lldb_private::Status &error,
                            StructuredData::ObjectSP *module_sp = nullptr,
-                           FileSpec extra_search_dir = {}) override;
+                           FileSpec extra_search_dir = {},
+                           lldb::TargetSP loaded_into_target_sp = {}) override;
 
   bool IsReservedWord(const char *word) override;
 

--- a/lldb/test/API/macosx/dsym_modules/Makefile
+++ b/lldb/test/API/macosx/dsym_modules/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
+
+include Makefile.rules

--- a/lldb/test/API/macosx/dsym_modules/TestdSYMModuleInit.py
+++ b/lldb/test/API/macosx/dsym_modules/TestdSYMModuleInit.py
@@ -10,59 +10,54 @@ import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
+
 @skipUnlessDarwin
 class TestdSYMModuleInit(TestBase):
-
     @no_debug_info_test
     def test_add_module(self):
         """This loads a file into a target and ensures that the python module was
-           correctly added and the two intialization functions are called."""
+        correctly added and the two intialization functions are called."""
         self.exe_name = "has_dsym"
-        self.py_name = self.exe_name+".py"
+        self.py_name = self.exe_name + ".py"
 
         # Now load the target the first time into the debugger:
         self.runCmd("settings set target.load-script-from-symbol-file true")
         self.interp = self.dbg.GetCommandInterpreter()
 
-        executable = self.build_dsym(self.exe_name+"_1")
+        executable = self.build_dsym(self.exe_name + "_1")
         target = self.createTestTarget(file_path=executable)
-        self.check_answers(executable, ['1', '1', "has_dsym_1"])
+        self.check_answers(executable, ["1", "1", "has_dsym_1"])
 
         # Now make a second target and make sure both get called:
-        executable_2 = self.build_dsym(self.exe_name+"_2")
+        executable_2 = self.build_dsym(self.exe_name + "_2")
         target_2 = self.createTestTarget(file_path=executable_2)
-        self.check_answers(executable_2, ['2', '2', "has_dsym_2"])
-        
+        self.check_answers(executable_2, ["2", "2", "has_dsym_2"])
+
     def check_answers(self, name, answers):
         result = lldb.SBCommandReturnObject()
         self.interp.HandleCommand("report_command", result)
-        self.assertTrue(result.Succeeded(), f"report_command succeeded {result.GetError()}")
+        self.assertTrue(
+            result.Succeeded(), f"report_command succeeded {result.GetError()}"
+        )
 
         cmd_results = result.GetOutput().split()
         self.assertEqual(answers[0], cmd_results[0], "Right number of module imports")
         self.assertEqual(answers[1], cmd_results[1], "Right number of target notices")
         self.assertIn(answers[2], name, "Right target name")
-        
 
     def build_dsym(self, name):
-        self.build(debug_info="dsym", dictionary={"EXE" : name})
+        self.build(debug_info="dsym", dictionary={"EXE": name})
         executable = self.getBuildArtifact(name)
-        dsym_path = self.getBuildArtifact(name+".dSYM")
+        dsym_path = self.getBuildArtifact(name + ".dSYM")
         python_dir_path = dsym_path
-        python_dir_path = os.path.join(
-            dsym_path, "Contents", "Resources", "Python"
-        )
+        python_dir_path = os.path.join(dsym_path, "Contents", "Resources", "Python")
         if not os.path.exists(python_dir_path):
             os.mkdir(python_dir_path)
 
-        python_file_name = name+".py"
-        
-        module_dest_path = os.path.join(
-            python_dir_path, python_file_name 
-        )
+        python_file_name = name + ".py"
+
+        module_dest_path = os.path.join(python_dir_path, python_file_name)
         module_origin_path = os.path.join(self.getSourceDir(), self.py_name)
         shutil.copy(module_origin_path, module_dest_path)
 
         return executable
-    
-        

--- a/lldb/test/API/macosx/dsym_modules/TestdSYMModuleInit.py
+++ b/lldb/test/API/macosx/dsym_modules/TestdSYMModuleInit.py
@@ -1,0 +1,68 @@
+"""
+Test that we read in the Python module from a dSYM, and run the
+init in debugger and the init in target routines.
+"""
+
+import os, shutil
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+@skipUnlessDarwin
+class TestdSYMModuleInit(TestBase):
+
+    @no_debug_info_test
+    def test_add_module(self):
+        """This loads a file into a target and ensures that the python module was
+           correctly added and the two intialization functions are called."""
+        self.exe_name = "has_dsym"
+        self.py_name = self.exe_name+".py"
+
+        # Now load the target the first time into the debugger:
+        self.runCmd("settings set target.load-script-from-symbol-file true")
+        self.interp = self.dbg.GetCommandInterpreter()
+
+        executable = self.build_dsym(self.exe_name+"_1")
+        target = self.createTestTarget(file_path=executable)
+        self.check_answers(executable, ['1', '1', "has_dsym_1"])
+
+        # Now make a second target and make sure both get called:
+        executable_2 = self.build_dsym(self.exe_name+"_2")
+        target_2 = self.createTestTarget(file_path=executable_2)
+        self.check_answers(executable_2, ['2', '2', "has_dsym_2"])
+        
+    def check_answers(self, name, answers):
+        result = lldb.SBCommandReturnObject()
+        self.interp.HandleCommand("report_command", result)
+        self.assertTrue(result.Succeeded(), f"report_command succeeded {result.GetError()}")
+
+        cmd_results = result.GetOutput().split()
+        self.assertEqual(answers[0], cmd_results[0], "Right number of module imports")
+        self.assertEqual(answers[1], cmd_results[1], "Right number of target notices")
+        self.assertIn(answers[2], name, "Right target name")
+        
+
+    def build_dsym(self, name):
+        self.build(debug_info="dsym", dictionary={"EXE" : name})
+        executable = self.getBuildArtifact(name)
+        dsym_path = self.getBuildArtifact(name+".dSYM")
+        python_dir_path = dsym_path
+        python_dir_path = os.path.join(
+            dsym_path, "Contents", "Resources", "Python"
+        )
+        if not os.path.exists(python_dir_path):
+            os.mkdir(python_dir_path)
+
+        python_file_name = name+".py"
+        
+        module_dest_path = os.path.join(
+            python_dir_path, python_file_name 
+        )
+        module_origin_path = os.path.join(self.getSourceDir(), self.py_name)
+        shutil.copy(module_origin_path, module_dest_path)
+
+        return executable
+    
+        

--- a/lldb/test/API/macosx/dsym_modules/has_dsym.py
+++ b/lldb/test/API/macosx/dsym_modules/has_dsym.py
@@ -1,0 +1,21 @@
+import lldb
+
+def report_command(debugger, command, exe_ctx, result, internal_dict):
+    result.AppendMessage(f"{lldb.num_module_inits} {lldb.num_target_inits} \"{lldb.target_name}\"")
+    result.SetStatus(lldb.eReturnStatusSuccessFinishResult)
+    
+def __lldb_init_module(debugger, internal_dict):
+    # We only want to make one copy of the report command so it will be shared
+    if "has_dsym_1" in __name__:
+        # lldb is a convenient place to store our counters.
+        lldb.num_module_inits = 0
+        lldb.num_target_inits = 0
+        lldb.target_name = "<unknown>"
+        
+        debugger.HandleCommand(f"command script add -o -f '{__name__}.report_command' report_command")
+
+    lldb.num_module_inits += 1
+
+def __lldb_module_added_to_target(target, internal_dict):
+    lldb.num_target_inits += 1
+    target_name = target.executable.fullpath

--- a/lldb/test/API/macosx/dsym_modules/has_dsym.py
+++ b/lldb/test/API/macosx/dsym_modules/has_dsym.py
@@ -1,9 +1,13 @@
 import lldb
 
+
 def report_command(debugger, command, exe_ctx, result, internal_dict):
-    result.AppendMessage(f"{lldb.num_module_inits} {lldb.num_target_inits} \"{lldb.target_name}\"")
+    result.AppendMessage(
+        f'{lldb.num_module_inits} {lldb.num_target_inits} "{lldb.target_name}"'
+    )
     result.SetStatus(lldb.eReturnStatusSuccessFinishResult)
-    
+
+
 def __lldb_init_module(debugger, internal_dict):
     # We only want to make one copy of the report command so it will be shared
     if "has_dsym_1" in __name__:
@@ -11,10 +15,13 @@ def __lldb_init_module(debugger, internal_dict):
         lldb.num_module_inits = 0
         lldb.num_target_inits = 0
         lldb.target_name = "<unknown>"
-        
-        debugger.HandleCommand(f"command script add -o -f '{__name__}.report_command' report_command")
+
+        debugger.HandleCommand(
+            f"command script add -o -f '{__name__}.report_command' report_command"
+        )
 
     lldb.num_module_inits += 1
+
 
 def __lldb_module_added_to_target(target, internal_dict):
     lldb.num_target_inits += 1

--- a/lldb/test/API/macosx/dsym_modules/main.c
+++ b/lldb/test/API/macosx/dsym_modules/main.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+int global_test_var = 10;
+
+int
+main()
+{
+  int test_var = 10;
+  printf ("Set a breakpoint here: %d.\n", test_var);
+  //% test_var = self.frame().FindVariable("test_var")
+  //% test_value = test_var.GetValueAsUnsigned()
+  //% self.assertSuccess(test_var.GetError(), "Failed to fetch test_var")
+  //% self.assertEqual(test_value, 10, "Failed to get the right value for test_var")
+  return global_test_var;
+}

--- a/lldb/test/API/macosx/dsym_modules/main.c
+++ b/lldb/test/API/macosx/dsym_modules/main.c
@@ -2,14 +2,13 @@
 
 int global_test_var = 10;
 
-int
-main()
-{
+int main() {
   int test_var = 10;
-  printf ("Set a breakpoint here: %d.\n", test_var);
+  printf("Set a breakpoint here: %d.\n", test_var);
   //% test_var = self.frame().FindVariable("test_var")
   //% test_value = test_var.GetValueAsUnsigned()
   //% self.assertSuccess(test_var.GetError(), "Failed to fetch test_var")
-  //% self.assertEqual(test_value, 10, "Failed to get the right value for test_var")
+  //% self.assertEqual(test_value, 10, "Failed to get the right value for
+  //test_var")
   return global_test_var;
 }

--- a/lldb/test/API/macosx/dsym_modules/main.c
+++ b/lldb/test/API/macosx/dsym_modules/main.c
@@ -5,10 +5,5 @@ int global_test_var = 10;
 int main() {
   int test_var = 10;
   printf("Set a breakpoint here: %d.\n", test_var);
-  //% test_var = self.frame().FindVariable("test_var")
-  //% test_value = test_var.GetValueAsUnsigned()
-  //% self.assertSuccess(test_var.GetError(), "Failed to fetch test_var")
-  //% self.assertEqual(test_value, 10, "Failed to get the right value for
-  //test_var")
   return global_test_var;
 }

--- a/lldb/unittests/ScriptInterpreter/Python/PythonTestSuite.cpp
+++ b/lldb/unittests/ScriptInterpreter/Python/PythonTestSuite.cpp
@@ -230,6 +230,13 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallModuleInit(
   return false;
 }
 
+bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallModuleNewTarget(
+    const char *python_module_name, const char *session_dictionary_name,
+    lldb::TargetSP target) {
+  return false;   
+}
+
+
 python::PythonObject
 lldb_private::python::SWIGBridge::LLDBSWIGPythonCreateOSPlugin(
     const char *python_class_name, const char *session_dictionary_name,

--- a/lldb/unittests/ScriptInterpreter/Python/PythonTestSuite.cpp
+++ b/lldb/unittests/ScriptInterpreter/Python/PythonTestSuite.cpp
@@ -233,9 +233,8 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallModuleInit(
 bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallModuleNewTarget(
     const char *python_module_name, const char *session_dictionary_name,
     lldb::TargetSP target) {
-  return false;   
+  return false;
 }
-
 
 python::PythonObject
 lldb_private::python::SWIGBridge::LLDBSWIGPythonCreateOSPlugin(


### PR DESCRIPTION
So the dSYM can be told what target it has been loaded into.

When lldb is loading modules, while creating a target, it will run "command script import" on any Python modules in Resources/Python in the dSYM.  However, this happens WHILE the target is being created, so it is not yet in the target list.  That means that these scripts can't act on the target that they a part of when they get loaded.

This patch adds a new python API that lldb will call:

__lldb_module_added_to_target

if it is defined in the module, passing in the Target the module was being added to, so that code in these dSYM's don't have to guess.