### PR TITLE
[AMDGPU][True16][Clang] support true16 target feature in clang driver

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5182,6 +5182,9 @@ defm wavefrontsize64 : SimpleMFlag<"wavefrontsize64",
 defm amdgpu_precise_memory_op
     : SimpleMFlag<"amdgpu-precise-memory-op", "Enable", "Disable",
                   " precise memory mode (AMDGPU only)">;
+defm real_true16: SimpleMFlag<"real-true16",
+  "enable real-true16 in GFX11Plus", "enable real-true16 mode",
+  " real-true16 mode (AMDGPU only)">;
 
 def munsafe_fp_atomics : Flag<["-"], "munsafe-fp-atomics">,
   Visibility<[ClangOption, CC1Option]>, Alias<fatomic_ignore_denormal_mode>;

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -707,6 +707,10 @@ void amdgpu::getAMDGPUTargetFeatures(const Driver &D,
                    options::OPT_mno_amdgpu_precise_memory_op, false))
     Features.push_back("+precise-memory");
 
+  if (Args.hasFlag(options::OPT_mreal_true16, options::OPT_mno_real_true16,
+                   false))
+    Features.push_back("+real-true16");
+
   handleTargetFeaturesGroup(D, Triple, Args, Features,
                             options::OPT_m_amdgpu_Features_Group);
 }

--- a/clang/test/Driver/amdgpu-features.c
+++ b/clang/test/Driver/amdgpu-features.c
@@ -38,3 +38,8 @@
 
 // RUN: %clang -### -target amdgcn -mcpu=gfx1010 -mno-amdgpu-precise-memory-op %s 2>&1 | FileCheck --check-prefix=NO-PREC-MEM %s
 // NO-PREC-MEM-NOT: {{".*precise-memory"}}
+
+// RUN: %clang -### -target amdgcn -mcpu=gfx1100 -mreal-true16 %s 2>&1 | FileCheck --check-prefix=REAL16 %s
+// RUN: %clang -### -target amdgcn -mcpu=gfx1100 -mno-real-true16 %s 2>&1 | FileCheck --check-prefix=NO-REAL16 %s
+// REAL16: "-target-feature" "+real-true16"
+// NO-REAL16-NOT: {{".*real-true16"}}


### PR DESCRIPTION
Add a true16 clang option to turn on true16 mode(by default off) in amdgpu.

This allows to turn on true16 and enable testing for this feature. This patch be removed after we validated true16 feature and set it to be the default mode.