### PR TITLE
[NFC] Fix warning: variable II set but not used

### DIFF
--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -60,9 +60,10 @@ ParsedType Sema::getInheritingConstructorName(CXXScopeSpec &SS,
                                               SourceLocation NameLoc,
                                               const IdentifierInfo &Name) {
   NestedNameSpecifier *NNS = SS.getScopeRep();
+#ifndef NDEBUG
   if (const IdentifierInfo *II = NNS->getAsIdentifier())
     assert(II == &Name && "not a constructor name");
-
+#endif
   QualType Type(NNS->translateToType(Context), 0);
   // This reference to the type is located entirely at the location of the
   // final identifier in the qualified-id.


### PR DESCRIPTION
```
llvm-project/clang/lib/Sema/SemaExprCXX.cpp:63:29: warning: variable 'II' set but not used [-Wunused-but-set-variable]
   63 |   if (const IdentifierInfo *II = NNS->getAsIdentifier())
      |                             ^
```