### PR TITLE
[SBProgress][CLI] Configure sbprogress events to be emitted for the CLI

### DIFF
--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -2024,7 +2024,8 @@ lldb::thread_result_t Debugger::DefaultEventHandler() {
               }
             }
           } else if (broadcaster == &m_broadcaster) {
-            if (event_type & lldb::eBroadcastBitProgress)
+            if (event_type & lldb::eBroadcastBitProgress ||
+                event_type & lldb::eBroadcastBitExternalProgress)
               HandleProgressEvent(event_sp);
             else if (event_type & lldb::eBroadcastBitWarning)
               HandleDiagnosticEvent(event_sp);


### PR DESCRIPTION
In the original SBProgress patch, #123837, I didn't ensure the debugger was broadcasting these events to the CLI as SBProgress has far been focused on DAP. We had an internal ask to have SBProgress events broadcasted to the CLI so this patch addresses that.

<img width="387" alt="image" src="https://github.com/user-attachments/assets/5eb93a46-1db6-4d46-a6b7-2b2f9bbe71db" />
