### PR TITLE
[lldb] Improve default statusline colors to work with more color schemes

### DIFF
--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -178,7 +178,7 @@ let Definition = "debugger" in {
     Desc<"Whether to show a statusline at the bottom of the terminal.">;
   def StatuslineFormat: Property<"statusline-format", "FormatEntity">,
     Global,
-    DefaultStringValue<"${ansi.bg.blue}${ansi.fg.black}{${target.file.basename}}{ | ${line.file.basename}:${line.number}:${line.column}}{ | ${thread.stop-reason}}{ | {${progress.count} }${progress.message}}">,
+    DefaultStringValue<"${ansi.negative}{${target.file.basename}}{ | ${line.file.basename}:${line.number}:${line.column}}{ | ${thread.stop-reason}}{ | {${progress.count} }${progress.message}}">,
     Desc<"The default statusline format string.">;
   def UseSourceCache: Property<"use-source-cache", "Boolean">,
     Global,


### PR DESCRIPTION
Use the reverse video [1] font effect (`${ansi.negative}`) as the default for the statusline. Inverting the foreground and background color has a better change as looking reasonably good, compared to picking an arbitrary color.

[1] https://en.wikipedia.org/wiki/Reverse_video