### PR TITLE
[llvm][cmake] Quote CMAKE_CXX_COMPILER_ID in string comparison

### DIFF
--- a/llvm/cmake/modules/CheckProblematicConfigurations.cmake
+++ b/llvm/cmake/modules/CheckProblematicConfigurations.cmake
@@ -11,7 +11,7 @@ endmacro()
 
 # MSVC and /arch:AVX is untested and have created problems before. See:
 # https://github.com/llvm/llvm-project/issues/54645
-if(${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL MSVC)
   string(TOLOWER "${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS}" _FLAGS)
   if(_FLAGS MATCHES "/arch:avx[0-9]*")
     log_problematic("Compiling LLVM with MSVC and the /arch:AVX flag is known to cause issues with parts of LLVM.\nSee https://github.com/llvm/llvm-project/issues/54645 for details.\nUse clang-cl if you want to enable AVX instructions.")

--- a/llvm/cmake/modules/CheckProblematicConfigurations.cmake
+++ b/llvm/cmake/modules/CheckProblematicConfigurations.cmake
@@ -11,7 +11,7 @@ endmacro()
 
 # MSVC and /arch:AVX is untested and have created problems before. See:
 # https://github.com/llvm/llvm-project/issues/54645
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL MSVC)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   string(TOLOWER "${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS}" _FLAGS)
   if(_FLAGS MATCHES "/arch:avx[0-9]*")
     log_problematic("Compiling LLVM with MSVC and the /arch:AVX flag is known to cause issues with parts of LLVM.\nSee https://github.com/llvm/llvm-project/issues/54645 for details.\nUse clang-cl if you want to enable AVX instructions.")


### PR DESCRIPTION
We're seeing following configuration error when building the `runtimes` target on our buildbots:
```
CMake Error at /Users/ec2-user/jenkins/workspace/llvm.org/lldb-cmake-sanitized/llvm-project/llvm/cmake/modules/CheckProblematicConfigurations.cmake:14 (if):
  if given arguments:

    "STREQUAL" "MSVC"

  Unknown arguments specified
Call Stack (most recent call first):
  /Users/ec2-user/jenkins/workspace/llvm.org/lldb-cmake-sanitized/llvm-project/llvm/cmake/modules/HandleLLVMOptions.cmake:10 (include)
  CMakeLists.txt:175 (include)
```

If I understand correctly this happens because ${CMAKE_CXX_COMPILER_ID} is empty. Quoting it should make the comparison work for those cases.