### PR TITLE
[NFC] [dataflow] generalize smart pointer caching

### DIFF
--- a/clang/include/clang/Analysis/FlowSensitive/SmartPointerAccessorCaching.h
+++ b/clang/include/clang/Analysis/FlowSensitive/SmartPointerAccessorCaching.h
@@ -62,8 +62,10 @@ ast_matchers::StatementMatcher isPointerLikeOperatorStar();
 ast_matchers::StatementMatcher isSmartPointerLikeOperatorStar();
 ast_matchers::StatementMatcher isPointerLikeOperatorArrow();
 ast_matchers::StatementMatcher isSmartPointerLikeOperatorArrow();
-ast_matchers::StatementMatcher isSmartPointerLikeValueMethodCall();
-ast_matchers::StatementMatcher isSmartPointerLikeGetMethodCall();
+ast_matchers::StatementMatcher
+isSmartPointerLikeValueMethodCall(clang::StringRef MethodName = "value");
+ast_matchers::StatementMatcher
+isSmartPointerLikeGetMethodCall(clang::StringRef MethodName = "get");
 
 // Common transfer functions.
 

--- a/clang/lib/Analysis/FlowSensitive/SmartPointerAccessorCaching.cpp
+++ b/clang/lib/Analysis/FlowSensitive/SmartPointerAccessorCaching.cpp
@@ -45,7 +45,7 @@ CanQualType valueLikeReturnType(QualType RT) {
 CanQualType pointerLikeReturnType(const CXXRecordDecl &RD) {
   // We may want to cache this search, but in current profiles it hasn't shown
   // up as a hot spot (possibly because there aren't many hits, relatively).
-  CanQualType StarReturnType, ArrowReturnType, GetReturnType, ValueReturnType;
+  CanQualType StarReturnType, ArrowReturnType;
   for (const auto *MD : RD.methods()) {
     // We only consider methods that are const and have zero parameters.
     // It may be that there is a non-const overload for the method, but

--- a/clang/lib/Analysis/FlowSensitive/SmartPointerAccessorCaching.cpp
+++ b/clang/lib/Analysis/FlowSensitive/SmartPointerAccessorCaching.cpp
@@ -79,9 +79,8 @@ QualType findReturnType(const CXXRecordDecl &RD, StringRef MethodName) {
         MD->getOverloadedOperator() != OO_None)
       continue;
     clang::IdentifierInfo *II = MD->getIdentifier();
-    if (II && II->isStr(MethodName)) {
+    if (II && II->isStr(MethodName))
       return MD->getReturnType();
-    }
   }
   return {};
 }

--- a/clang/lib/Analysis/FlowSensitive/SmartPointerAccessorCaching.cpp
+++ b/clang/lib/Analysis/FlowSensitive/SmartPointerAccessorCaching.cpp
@@ -93,39 +93,37 @@ QualType findReturnType(const CXXRecordDecl &RD, StringRef MethodName) {
 // its own anonymous namespace instead of in clang::dataflow.
 namespace {
 
+using clang::dataflow::findReturnType;
+using clang::dataflow::getLikeReturnType;
+using clang::dataflow::pointerLikeReturnType;
+using clang::dataflow::valueLikeReturnType;
+
 AST_MATCHER_P(clang::CXXRecordDecl, smartPointerClassWithGetLike,
               clang::StringRef, MethodName) {
-  auto RT = clang::dataflow::pointerLikeReturnType(Node);
+  auto RT = pointerLikeReturnType(Node);
   if (RT.isNull())
     return false;
-  return clang::dataflow::getLikeReturnType(
-             clang::dataflow::findReturnType(Node, MethodName)) == RT;
+  return getLikeReturnType(findReturnType(Node, MethodName)) == RT;
 }
 
 AST_MATCHER_P(clang::CXXRecordDecl, smartPointerClassWithValueLike,
               clang::StringRef, MethodName) {
-  auto RT = clang::dataflow::pointerLikeReturnType(Node);
+  auto RT = pointerLikeReturnType(Node);
   if (RT.isNull())
     return false;
-  return clang::dataflow::valueLikeReturnType(
-             clang::dataflow::findReturnType(Node, MethodName)) == RT;
+  return valueLikeReturnType(findReturnType(Node, MethodName)) == RT;
 }
 
 AST_MATCHER(clang::CXXRecordDecl, smartPointerClassWithGetOrValue) {
-  auto RT = clang::dataflow::pointerLikeReturnType(Node);
+  auto RT = pointerLikeReturnType(Node);
   if (RT.isNull())
     return false;
-  if (clang::dataflow::getLikeReturnType(
-          clang::dataflow::findReturnType(Node, "get")) == RT)
-    return true;
-  if (clang::dataflow::valueLikeReturnType(
-          clang::dataflow::findReturnType(Node, "value")) == RT)
-    return true;
-  return false;
+  return getLikeReturnType(findReturnType(Node, "get")) == RT ||
+         valueLikeReturnType(findReturnType(Node, "value")) == RT;
 }
 
 AST_MATCHER(clang::CXXRecordDecl, pointerClass) {
-  return !clang::dataflow::pointerLikeReturnType(Node).isNull();
+  return !pointerLikeReturnType(Node).isNull();
 }
 
 } // namespace

--- a/clang/lib/Analysis/FlowSensitive/SmartPointerAccessorCaching.cpp
+++ b/clang/lib/Analysis/FlowSensitive/SmartPointerAccessorCaching.cpp
@@ -2,6 +2,7 @@
 
 #include "clang/AST/CanonicalType.h"
 #include "clang/AST/DeclCXX.h"
+#include "clang/AST/Type.h"
 #include "clang/ASTMatchers/ASTMatchers.h"
 #include "clang/ASTMatchers/ASTMatchersMacros.h"
 #include "clang/Basic/OperatorKinds.h"
@@ -23,8 +24,7 @@ using ast_matchers::pointerType;
 using ast_matchers::referenceType;
 using ast_matchers::returns;
 
-bool hasSmartPointerClassShape(const CXXRecordDecl &RD, bool &HasGet,
-                               bool &HasValue) {
+CanQualType pointerLikeReturnType(const CXXRecordDecl &RD) {
   // We may want to cache this search, but in current profiles it hasn't shown
   // up as a hot spot (possibly because there aren't many hits, relatively).
   bool HasArrow = false;
@@ -55,38 +55,47 @@ bool hasSmartPointerClassShape(const CXXRecordDecl &RD, bool &HasGet,
                               .getUnqualifiedType();
       }
       break;
-    case OO_None: {
-      IdentifierInfo *II = MD->getIdentifier();
-      if (II == nullptr)
-        continue;
-      if (II->isStr("get")) {
-        if (MD->getReturnType()->isPointerType()) {
-          HasGet = true;
-          GetReturnType = MD->getReturnType()
-                              ->getPointeeType()
-                              ->getCanonicalTypeUnqualified()
-                              .getUnqualifiedType();
-        }
-      } else if (II->isStr("value")) {
-        if (MD->getReturnType()->isReferenceType()) {
-          HasValue = true;
-          ValueReturnType = MD->getReturnType()
-                                .getNonReferenceType()
-                                ->getCanonicalTypeUnqualified()
-                                .getUnqualifiedType();
-        }
-      }
-    } break;
     default:
       break;
     }
   }
+  if (HasStar && HasArrow && StarReturnType == ArrowReturnType)
+    return StarReturnType;
 
-  if (!HasStar || !HasArrow || StarReturnType != ArrowReturnType)
-    return false;
-  HasGet = HasGet && (GetReturnType == StarReturnType);
-  HasValue = HasValue && (ValueReturnType == StarReturnType);
-  return true;
+  return {};
+}
+CanQualType getLikeReturnType(QualType RT) {
+  if (!RT.isNull() && RT->isPointerType()) {
+    return RT->getPointeeType()
+        ->getCanonicalTypeUnqualified()
+        .getUnqualifiedType();
+  }
+  return {};
+}
+
+CanQualType valueLikeReturnType(QualType RT) {
+  if (!RT.isNull() && RT->isReferenceType()) {
+    return RT.getNonReferenceType()
+        ->getCanonicalTypeUnqualified()
+        .getUnqualifiedType();
+  }
+  return {};
+}
+
+QualType findReturnType(const CXXRecordDecl &RD, StringRef MethodName) {
+  for (const auto *MD : RD.methods()) {
+    // We only consider methods that are const and have zero parameters.
+    // It may be that there is a non-const overload for the method, but
+    // there should at least be a const overload as well.
+    if (!MD->isConst() || MD->getNumParams() != 0 ||
+        MD->getOverloadedOperator() != OO_None)
+      continue;
+    clang::IdentifierInfo *II = MD->getIdentifier();
+    if (II && II->isStr(MethodName)) {
+      return MD->getReturnType();
+    }
+  }
+  return {};
 }
 
 } // namespace
@@ -96,36 +105,39 @@ bool hasSmartPointerClassShape(const CXXRecordDecl &RD, bool &HasGet,
 // its own anonymous namespace instead of in clang::dataflow.
 namespace {
 
-AST_MATCHER(clang::CXXRecordDecl, smartPointerClassWithGet) {
-  bool HasGet = false;
-  bool HasValue = false;
-  bool HasStarAndArrow =
-      clang::dataflow::hasSmartPointerClassShape(Node, HasGet, HasValue);
-  return HasStarAndArrow && HasGet;
+AST_MATCHER_P(clang::CXXRecordDecl, smartPointerClassWithGetLike,
+              clang::StringRef, MethodName) {
+  auto RT = clang::dataflow::pointerLikeReturnType(Node);
+  if (RT.isNull())
+    return false;
+  return clang::dataflow::getLikeReturnType(
+             clang::dataflow::findReturnType(Node, MethodName)) == RT;
 }
 
-AST_MATCHER(clang::CXXRecordDecl, smartPointerClassWithValue) {
-  bool HasGet = false;
-  bool HasValue = false;
-  bool HasStarAndArrow =
-      clang::dataflow::hasSmartPointerClassShape(Node, HasGet, HasValue);
-  return HasStarAndArrow && HasValue;
+AST_MATCHER_P(clang::CXXRecordDecl, smartPointerClassWithValueLike,
+              clang::StringRef, MethodName) {
+  auto RT = clang::dataflow::pointerLikeReturnType(Node);
+  if (RT.isNull())
+    return false;
+  return clang::dataflow::valueLikeReturnType(
+             clang::dataflow::findReturnType(Node, MethodName)) == RT;
 }
 
 AST_MATCHER(clang::CXXRecordDecl, smartPointerClassWithGetOrValue) {
-  bool HasGet = false;
-  bool HasValue = false;
-  bool HasStarAndArrow =
-      clang::dataflow::hasSmartPointerClassShape(Node, HasGet, HasValue);
-  return HasStarAndArrow && (HasGet || HasValue);
+  auto RT = clang::dataflow::pointerLikeReturnType(Node);
+  if (RT.isNull())
+    return false;
+  if (clang::dataflow::getLikeReturnType(
+          clang::dataflow::findReturnType(Node, "get")) == RT)
+    return true;
+  if (clang::dataflow::valueLikeReturnType(
+          clang::dataflow::findReturnType(Node, "value")) == RT)
+    return true;
+  return false;
 }
 
 AST_MATCHER(clang::CXXRecordDecl, pointerClass) {
-  bool HasGet = false;
-  bool HasValue = false;
-  bool HasStarAndArrow =
-      clang::dataflow::hasSmartPointerClassShape(Node, HasGet, HasValue);
-  return HasStarAndArrow;
+  return !clang::dataflow::pointerLikeReturnType(Node).isNull();
 }
 
 } // namespace
@@ -164,16 +176,19 @@ ast_matchers::StatementMatcher isPointerLikeOperatorArrow() {
                            ofClass(pointerClass()))));
 }
 
-ast_matchers::StatementMatcher isSmartPointerLikeValueMethodCall() {
+ast_matchers::StatementMatcher
+isSmartPointerLikeValueMethodCall(clang::StringRef MethodName) {
   return cxxMemberCallExpr(callee(cxxMethodDecl(
       parameterCountIs(0), returns(hasCanonicalType(referenceType())),
-      hasName("value"), ofClass(smartPointerClassWithValue()))));
+      hasName(MethodName),
+      ofClass(smartPointerClassWithValueLike(MethodName)))));
 }
 
-ast_matchers::StatementMatcher isSmartPointerLikeGetMethodCall() {
+ast_matchers::StatementMatcher
+isSmartPointerLikeGetMethodCall(clang::StringRef MethodName) {
   return cxxMemberCallExpr(callee(cxxMethodDecl(
       parameterCountIs(0), returns(hasCanonicalType(pointerType())),
-      hasName("get"), ofClass(smartPointerClassWithGet()))));
+      hasName(MethodName), ofClass(smartPointerClassWithGetLike(MethodName)))));
 }
 
 const FunctionDecl *

--- a/clang/unittests/Analysis/FlowSensitive/SmartPointerAccessorCachingTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/SmartPointerAccessorCachingTest.cpp
@@ -348,5 +348,45 @@ TEST(SmartPointerAccessorCachingTest, MatchesWithTypeAliases) {
       isSmartPointerLikeGetMethodCall()));
 }
 
+TEST(SmartPointerAccessorCachingTest, Renamed) {
+  llvm::StringRef Decls(R"cc(
+    namespace std {
+    template <class T>
+    struct unique_ptr {
+      T* operator->() const;
+      T& operator*() const;
+      T* Get() const;
+      T& Value() const;
+    };
+    }  // namespace std
+
+    template <class T>
+    using UniquePtrAlias = std::unique_ptr<T>;
+
+    struct S { int i; };
+  )cc");
+
+  EXPECT_TRUE(matches(Decls,
+                      "int target(std::unique_ptr<S> P) { return (*P).i; }",
+                      isPointerLikeOperatorStar()));
+
+  EXPECT_TRUE(matches(Decls,
+                      "int target(std::unique_ptr<S> P) { return P->i; }",
+                      isPointerLikeOperatorArrow()));
+
+  EXPECT_TRUE(matches(Decls,
+                      "int target(std::unique_ptr<S> P) { return P.Get()->i; }",
+                      isSmartPointerLikeGetMethodCall("Get")));
+
+  EXPECT_TRUE(
+      matches(Decls, "int target(std::unique_ptr<S> P) { return P.Value().i; }",
+              isSmartPointerLikeValueMethodCall("Value")));
+
+  EXPECT_TRUE(matches(Decls, "int target(UniquePtrAlias<S> P) { return P->i; }",
+                      isPointerLikeOperatorArrow()));
+  EXPECT_TRUE(matches(Decls, "int target(UniquePtrAlias<S> P) { return P->i; }",
+                      isPointerLikeOperatorArrow()));
+}
+
 } // namespace
 } // namespace clang::dataflow

--- a/clang/unittests/Analysis/FlowSensitive/SmartPointerAccessorCachingTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/SmartPointerAccessorCachingTest.cpp
@@ -377,16 +377,16 @@ TEST(SmartPointerAccessorCachingTest, Renamed) {
   EXPECT_TRUE(matches(Decls,
                       "int target(std::unique_ptr<S> P) { return P.Get()->i; }",
                       isSmartPointerLikeGetMethodCall("Get")));
-  EXPECT_TRUE(
-      matches(Decls, "int target(UniquePtrAlias<S> P) { return P.Get()->i; }",
-              isSmartPointerLikeGetMethodCall("Get")));
+  EXPECT_TRUE(matches(Decls,
+                      "int target(UniquePtrAlias<S> P) { return P.Get()->i; }",
+                      isSmartPointerLikeGetMethodCall("Get")));
 
   EXPECT_TRUE(
       matches(Decls, "int target(std::unique_ptr<S> P) { return P.Value().i; }",
               isSmartPointerLikeValueMethodCall("Value")));
-  EXPECT_TRUE(
-      matches(Decls, "int target(UniquePtrAlias<S> P) { return P.Value().i; }",
-              isSmartPointerLikeValueMethodCall("Value")));
+  EXPECT_TRUE(matches(Decls,
+                      "int target(UniquePtrAlias<S> P) { return P.Value().i; }",
+                      isSmartPointerLikeValueMethodCall("Value")));
 
   EXPECT_TRUE(matches(Decls, "int target(UniquePtrAlias<S> P) { return P->i; }",
                       isPointerLikeOperatorArrow()));

--- a/clang/unittests/Analysis/FlowSensitive/SmartPointerAccessorCachingTest.cpp
+++ b/clang/unittests/Analysis/FlowSensitive/SmartPointerAccessorCachingTest.cpp
@@ -377,13 +377,17 @@ TEST(SmartPointerAccessorCachingTest, Renamed) {
   EXPECT_TRUE(matches(Decls,
                       "int target(std::unique_ptr<S> P) { return P.Get()->i; }",
                       isSmartPointerLikeGetMethodCall("Get")));
+  EXPECT_TRUE(
+      matches(Decls, "int target(UniquePtrAlias<S> P) { return P.Get()->i; }",
+              isSmartPointerLikeGetMethodCall("Get")));
 
   EXPECT_TRUE(
       matches(Decls, "int target(std::unique_ptr<S> P) { return P.Value().i; }",
               isSmartPointerLikeValueMethodCall("Value")));
+  EXPECT_TRUE(
+      matches(Decls, "int target(UniquePtrAlias<S> P) { return P.Value().i; }",
+              isSmartPointerLikeValueMethodCall("Value")));
 
-  EXPECT_TRUE(matches(Decls, "int target(UniquePtrAlias<S> P) { return P->i; }",
-                      isPointerLikeOperatorArrow()));
   EXPECT_TRUE(matches(Decls, "int target(UniquePtrAlias<S> P) { return P->i; }",
                       isPointerLikeOperatorArrow()));
 }


### PR DESCRIPTION
This allows us to use it for classes that use other names than get /
value.
