### PR TITLE
Remove iOS 5 check for tailcalls on ARM

### DIFF
--- a/llvm/lib/Target/ARM/ARMSubtarget.cpp
+++ b/llvm/lib/Target/ARM/ARMSubtarget.cpp
@@ -226,9 +226,6 @@ void ARMSubtarget::initSubtargetFeatures(StringRef CPU, StringRef FS) {
 
   SupportsTailCall = !isThumb1Only() || hasV8MBaselineOps();
 
-  if (isTargetMachO() && isTargetIOS() && getTargetTriple().isOSVersionLT(5, 0))
-    SupportsTailCall = false;
-
   switch (IT) {
   case DefaultIT:
     RestrictIT = false;

--- a/llvm/test/CodeGen/ARM/2010-11-29-PrologueBug.ll
+++ b/llvm/test/CodeGen/ARM/2010-11-29-PrologueBug.ll
@@ -9,8 +9,8 @@ entry:
 ; CHECK: mov r7, sp
 ; CHECK: bl _foo
 ; CHECK: bl _foo
-; CHECK: bl _foo
-; CHECK: pop {r7, pc}
+; CHECK: pop
+; CHECK: b
 
   %0 = tail call ptr @foo(ptr %x) nounwind
   %1 = tail call ptr @foo(ptr %0) nounwind

--- a/llvm/test/CodeGen/ARM/ldm.ll
+++ b/llvm/test/CodeGen/ARM/ldm.ll
@@ -5,9 +5,9 @@
 
 define i32 @t1() {
 ; CHECK-LABEL: t1:
-; CHECK: pop
+; CHECK: ldrd
 ; V4T-LABEL: t1:
-; V4T: pop
+; V4T: ldm
         %tmp = load i32, ptr @X            ; <i32> [#uses=1]
         %tmp3 = load i32, ptr getelementptr ([0 x i32], ptr @X, i32 0, i32 1)           ; <i32> [#uses=1]
         %tmp4 = tail call i32 @f1( i32 %tmp, i32 %tmp3 )                ; <i32> [#uses=1]
@@ -16,9 +16,9 @@ define i32 @t1() {
 
 define i32 @t2() {
 ; CHECK-LABEL: t2:
-; CHECK: pop
+; CHECK: ldm
 ; V4T-LABEL: t2:
-; V4T: pop
+; V4T: ldm
         %tmp = load i32, ptr getelementptr ([0 x i32], ptr @X, i32 0, i32 2)            ; <i32> [#uses=1]
         %tmp3 = load i32, ptr getelementptr ([0 x i32], ptr @X, i32 0, i32 3)           ; <i32> [#uses=1]
         %tmp5 = load i32, ptr getelementptr ([0 x i32], ptr @X, i32 0, i32 4)           ; <i32> [#uses=1]

--- a/llvm/test/CodeGen/ARM/zextload_demandedbits.ll
+++ b/llvm/test/CodeGen/ARM/zextload_demandedbits.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s -mtriple="arm-apple-ios3.0.0" | FileCheck %s
+; RUN: llc < %s -mtriple="armv4t-apple-ios3.0.0" | FileCheck %s
 
 target datalayout = "e-p:32:32:32-i1:8:32-i8:8:32-i16:16:32-i32:32:32-i64:32:64-f32:32:32-f64:32:64-v64:32:64-v128:32:128-a0:0:32-n32-S32"
 
@@ -10,8 +10,7 @@ target datalayout = "e-p:32:32:32-i1:8:32-i8:8:32-i16:16:32-i32:32:32-i64:32:64-
 ; CHECK: quux
 ; CHECK: lsl
 ; CHECK: asr
-; CHECK: bl
-; CHECK: pop
+; CHECK: b
 define void @quux(ptr %arg) {
 bb:
   %tmp1 = getelementptr inbounds %struct.eggs, ptr %arg, i32 0, i32 1

--- a/llvm/test/CodeGen/ARM/zextload_demandedbits.ll
+++ b/llvm/test/CodeGen/ARM/zextload_demandedbits.ll
@@ -1,4 +1,4 @@
-; RUN: llc < %s -mtriple="armv4t-apple-ios3.0.0" | FileCheck %s
+; RUN: llc < %s -mtriple="arm-apple-ios3.0.0" | FileCheck %s
 
 target datalayout = "e-p:32:32:32-i1:8:32-i8:8:32-i16:16:32-i32:32:32-i64:32:64-f32:32:32-f64:32:64-v64:32:64-v128:32:128-a0:0:32-n32-S32"
 


### PR DESCRIPTION
Fixes #102053

The check was added in 8decdc472f308b13d7fb7fd50c3919db086c0417, and at the time iOS 5 was the latest iOS version, before that commit tail calls were disabled for all ARMv7 targets.  Testing a build of wasm3 with the patch on a device running iOS 3.0 shows a noticeable performance improvement and no issues.