### PR TITLE
[AMDGPU] Use MapVector instead of DenseMap (NFC)

### DIFF
--- a/llvm/lib/Target/AMDGPU/SILowerI1Copies.cpp
+++ b/llvm/lib/Target/AMDGPU/SILowerI1Copies.cpp
@@ -109,8 +109,7 @@ class PhiIncomingAnalysis {
 
   // For each reachable basic block, whether it is a source in the induced
   // subgraph of the CFG.
-  DenseMap<MachineBasicBlock *, bool> ReachableMap;
-  SmallVector<MachineBasicBlock *, 4> ReachableOrdered;
+  MapVector<MachineBasicBlock *, bool> ReachableMap;
   SmallVector<MachineBasicBlock *, 4> Stack;
   SmallVector<MachineBasicBlock *, 4> Predecessors;
 
@@ -129,13 +128,11 @@ public:
   void analyze(MachineBasicBlock &DefBlock, ArrayRef<Incoming> Incomings) {
     assert(Stack.empty());
     ReachableMap.clear();
-    ReachableOrdered.clear();
     Predecessors.clear();
 
     // Insert the def block first, so that it acts as an end point for the
     // traversal.
     ReachableMap.try_emplace(&DefBlock, false);
-    ReachableOrdered.push_back(&DefBlock);
 
     for (auto Incoming : Incomings) {
       MachineBasicBlock *MBB = Incoming.Block;
@@ -145,7 +142,6 @@ public:
       }
 
       ReachableMap.try_emplace(MBB, false);
-      ReachableOrdered.push_back(MBB);
 
       // If this block has a divergent terminator and the def block is its
       // post-dominator, the wave may first visit the other successors.
@@ -155,14 +151,11 @@ public:
 
     while (!Stack.empty()) {
       MachineBasicBlock *MBB = Stack.pop_back_val();
-      if (!ReachableMap.try_emplace(MBB, false).second)
-        continue;
-      ReachableOrdered.push_back(MBB);
-
-      append_range(Stack, MBB->successors());
+      if (ReachableMap.try_emplace(MBB, false).second)
+        append_range(Stack, MBB->successors());
     }
 
-    for (MachineBasicBlock *MBB : ReachableOrdered) {
+    for (auto &[MBB, Reachable] : ReachableMap) {
       bool HaveReachablePred = false;
       for (MachineBasicBlock *Pred : MBB->predecessors()) {
         if (ReachableMap.count(Pred)) {
@@ -172,7 +165,7 @@ public:
         }
       }
       if (!HaveReachablePred)
-        ReachableMap[MBB] = true;
+        Reachable = true;
       if (HaveReachablePred) {
         for (MachineBasicBlock *UnreachablePred : Stack) {
           if (!llvm::is_contained(Predecessors, UnreachablePred))


### PR DESCRIPTION
This patch combines:

  DenseMap<MachineBasicBlock *, bool> ReachableMap;
  SmallVector<MachineBasicBlock *, 4> ReachableOrdered;

into:

  MapVector<MachineBasicBlock *, bool> ReachableMap;

because we add elements to the two data structures in lockstep, and we
care about preserving the insertion order.

As a side benefit, we get to avoid hash lookups at:

  ReachableMap[MBB] = true;
