### PR TITLE
llvm-reduce: Preserve uselistorder when writing thinlto bitcode

### DIFF
--- a/llvm/test/tools/llvm-reduce/thinlto-preserve-uselistorder.ll
+++ b/llvm/test/tools/llvm-reduce/thinlto-preserve-uselistorder.ll
@@ -1,0 +1,19 @@
+; RUN: opt --thinlto-bc --thinlto-split-lto-unit %s -o %t.0
+; RUN: llvm-reduce -write-tmp-files-as-bitcode --delta-passes=instructions %t.0 -o %t.1 \
+; RUN:     --test %python --test-arg %p/Inputs/llvm-dis-and-filecheck.py --test-arg llvm-dis --test-arg FileCheck --test-arg --check-prefix=INTERESTING --test-arg %s
+; RUN: llvm-dis --preserve-ll-uselistorder %t.1 -o %t.2
+; RUN: FileCheck --check-prefix=RESULT %s < %t.2
+
+define i32 @func(i32 %arg0, i32 %arg1) {
+entry:
+  %add0 = add i32 %arg0, 0
+  %add1 = add i32 %add0, 0
+  %add2 = add i32 %add1, 0
+  %add3 = add i32 %arg1, 0
+  %add4 = add i32 %add2, %add3
+  ret i32 %add4
+}
+
+; INTERESTING: uselistorder i32 0
+; RESULT: uselistorder i32 0, { 0, 2, 1 }
+uselistorder i32 0, { 3, 2, 1, 0 }

--- a/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
+++ b/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
@@ -776,7 +776,11 @@ void ReducerWorkItem::readBitcode(MemoryBufferRef Data, LLVMContext &Ctx,
 }
 
 void ReducerWorkItem::writeBitcode(raw_ostream &OutStream) const {
+  const bool ShouldPreserveUseListOrder = true;
+
   if (LTOInfo && LTOInfo->IsThinLTO && LTOInfo->EnableSplitLTOUnit) {
+    // FIXME: This should not depend on the pass manager. There are hidden
+    // transforms that may happen inside ThinLTOBitcodeWriterPass
     PassBuilder PB;
     LoopAnalysisManager LAM;
     FunctionAnalysisManager FAM;
@@ -788,7 +792,8 @@ void ReducerWorkItem::writeBitcode(raw_ostream &OutStream) const {
     PB.registerLoopAnalyses(LAM);
     PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
     ModulePassManager MPM;
-    MPM.addPass(ThinLTOBitcodeWriterPass(OutStream, nullptr));
+    MPM.addPass(ThinLTOBitcodeWriterPass(OutStream, nullptr,
+                                         ShouldPreserveUseListOrder));
     MPM.run(*M, MAM);
   } else {
     std::unique_ptr<ModuleSummaryIndex> Index;
@@ -797,8 +802,8 @@ void ReducerWorkItem::writeBitcode(raw_ostream &OutStream) const {
       Index = std::make_unique<ModuleSummaryIndex>(
           buildModuleSummaryIndex(*M, nullptr, &PSI));
     }
-    WriteBitcodeToFile(getModule(), OutStream,
-                       /*ShouldPreserveUseListOrder=*/true, Index.get());
+    WriteBitcodeToFile(getModule(), OutStream, ShouldPreserveUseListOrder,
+                       Index.get());
   }
 }
 

--- a/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
+++ b/llvm/tools/llvm-reduce/ReducerWorkItem.cpp
@@ -779,8 +779,6 @@ void ReducerWorkItem::writeBitcode(raw_ostream &OutStream) const {
   const bool ShouldPreserveUseListOrder = true;
 
   if (LTOInfo && LTOInfo->IsThinLTO && LTOInfo->EnableSplitLTOUnit) {
-    // FIXME: This should not depend on the pass manager. There are hidden
-    // transforms that may happen inside ThinLTOBitcodeWriterPass
     PassBuilder PB;
     LoopAnalysisManager LAM;
     FunctionAnalysisManager FAM;


### PR DESCRIPTION
Fixes #63621