### PR TITLE
llvm-reduce: Add -abort-on-invalid-reduction to more tests

### DIFF
--- a/llvm/test/tools/llvm-reduce/distinct-dimetadata-nullptr.ll
+++ b/llvm/test/tools/llvm-reduce/distinct-dimetadata-nullptr.ll
@@ -1,7 +1,7 @@
 ; Test checking that distinct metadata reduction pass handles null pointers properly.
 ; This test will lead to a crash if nullptrs inside distinct metadata are not handled correctly, in this case inside DICompileUnit
 
-; RUN: llvm-reduce --delta-passes=distinct-metadata --aggressive-named-md-reduction --test FileCheck --test-arg %s --test-arg --input-file %s -o %t
+; RUN: llvm-reduce -abort-on-invalid-reduction --delta-passes=distinct-metadata --aggressive-named-md-reduction --test FileCheck --test-arg %s --test-arg --input-file %s -o %t
 ; CHECK: {{.*}}distinct !DICompileUnit{{.*}}
 
 

--- a/llvm/test/tools/llvm-reduce/operands-to-args-metadata.ll
+++ b/llvm/test/tools/llvm-reduce/operands-to-args-metadata.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-reduce %s -o %t --delta-passes=operands-to-args --test FileCheck --test-arg %s --test-arg --input-file
+; RUN: llvm-reduce -abort-on-invalid-reduction %s -o %t --delta-passes=operands-to-args --test FileCheck --test-arg %s --test-arg --input-file
 
 ; CHECK: @foo
 

--- a/llvm/test/tools/llvm-reduce/reduce-distinct-metadata.ll
+++ b/llvm/test/tools/llvm-reduce/reduce-distinct-metadata.ll
@@ -1,6 +1,6 @@
 ; Test that every boring node is removed and all interesting distinct nodes remain after aggressive distinct metadata reduction.
 
-; RUN: llvm-reduce --aggressive-named-md-reduction --test %python --test-arg %p/Inputs/reduce-distinct-metadata.py %s -o %t
+; RUN: llvm-reduce -abort-on-invalid-reduction --aggressive-named-md-reduction --test %python --test-arg %p/Inputs/reduce-distinct-metadata.py %s -o %t
 ; RUN: FileCheck %s < %t
 
 ; CHECK-NOT: {{.*}}boring{{.*}}

--- a/llvm/test/tools/llvm-reduce/remove-attributes-from-intrinsics.ll
+++ b/llvm/test/tools/llvm-reduce/remove-attributes-from-intrinsics.ll
@@ -1,7 +1,7 @@
 ; We can't actually put attributes on intrinsic declarations, only on call sites.
 ;
-; RUN: llvm-reduce --test FileCheck --test-arg --check-prefixes=CHECK-ALL,CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t
-; RUN: cat %t | FileCheck --check-prefixes=CHECK-ALL,CHECK-FINAL %s
+; RUN: llvm-reduce -abort-on-invalid-reduction --test FileCheck --test-arg --check-prefixes=CHECK-ALL,CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t
+; RUN: FileCheck --check-prefixes=CHECK-ALL,CHECK-FINAL %s < %t
 
 define i32 @t(i32 %a) {
 ; CHECK-ALL-LABEL: @t(

--- a/llvm/test/tools/llvm-reduce/remove-function-bodies.ll
+++ b/llvm/test/tools/llvm-reduce/remove-function-bodies.ll
@@ -1,5 +1,5 @@
-; RUN: llvm-reduce --test FileCheck --test-arg --check-prefixes=CHECK-ALL,CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t
-; RUN: cat %t | FileCheck --check-prefixes=CHECK-ALL,CHECK-FINAL %s
+; RUN: llvm-reduce --abort-on-invalid-reduction --test FileCheck --test-arg --check-prefixes=CHECK-ALL,CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t
+; RUN: FileCheck --check-prefixes=CHECK-ALL,CHECK-FINAL %s < %t
 
 ; CHECK-INTERESTINGNESS: @callee(
 ; CHECK-FINAL: declare void @callee()

--- a/llvm/test/tools/llvm-reduce/remove-instructions.ll
+++ b/llvm/test/tools/llvm-reduce/remove-instructions.ll
@@ -1,6 +1,6 @@
 ; Test that llvm-reduce can remove uninteresting instructions.
 ;
-; RUN: llvm-reduce --test %python --test-arg %p/Inputs/remove-instructions.py %s -o %t
+; RUN: llvm-reduce -abort-on-invalid-reduction --test %python --test-arg %p/Inputs/remove-instructions.py %s -o %t
 ; RUN: cat %t | FileCheck -implicit-check-not=uninteresting %s
 ; REQUIRES: plugins
 

--- a/llvm/test/tools/llvm-reduce/remove-metadata.ll
+++ b/llvm/test/tools/llvm-reduce/remove-metadata.ll
@@ -1,10 +1,10 @@
 ; Test that llvm-reduce can remove uninteresting metadata from an IR file.
 ; The Metadata pass erases named & unnamed metadata nodes.
 ;
-; RUN: llvm-reduce --aggressive-named-md-reduction --test %python --test-arg %p/Inputs/remove-metadata.py %s -o %t
-; RUN: FileCheck --check-prefixes=AGGRESSIVE --implicit-check-not=! %s < %t 
+; RUN: llvm-reduce -abort-on-invalid-reduction --aggressive-named-md-reduction --test %python --test-arg %p/Inputs/remove-metadata.py %s -o %t
+; RUN: FileCheck --check-prefixes=AGGRESSIVE --implicit-check-not=! %s < %t
 
-; RUN: llvm-reduce --test %python --test-arg %p/Inputs/remove-metadata.py %s -o %t
+; RUN: llvm-reduce -abort-on-invalid-reduction --test %python --test-arg %p/Inputs/remove-metadata.py %s -o %t
 ; RUN: FileCheck --implicit-check-not=! %s < %t
 
 @global = global i32 0, !dbg !0

--- a/llvm/test/tools/llvm-reduce/remove-module-data.ll
+++ b/llvm/test/tools/llvm-reduce/remove-module-data.ll
@@ -1,7 +1,7 @@
 ; REQUIRES: x86-registered-target
 
 ; RUN: opt %s -S | FileCheck --check-prefix=CHECK-FILE %s
-; RUN: llvm-reduce --test FileCheck --test-arg --check-prefixes=CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t
+; RUN: llvm-reduce -abort-on-invalid-reduction --test FileCheck --test-arg --check-prefixes=CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t
 ; RUN: FileCheck --check-prefix=CHECK-FINAL %s < %t
 
 ; CHECK-INTERESTINGNESS: declare

--- a/llvm/test/tools/llvm-reduce/remove-multiple-use-of-args-in-same-instruction.ll
+++ b/llvm/test/tools/llvm-reduce/remove-multiple-use-of-args-in-same-instruction.ll
@@ -1,6 +1,6 @@
 ; Test that llvm-reduce can remove uninteresting function arguments from function definitions as well as their calls.
 ;
-; RUN: llvm-reduce --test FileCheck --test-arg --check-prefix=CHECK-ALL --test-arg %s --test-arg --input-file %s -o %t
+; RUN: llvm-reduce -abort-on-invalid-reduction --test FileCheck --test-arg --check-prefix=CHECK-ALL --test-arg %s --test-arg --input-file %s -o %t
 ; RUN: FileCheck --check-prefix=CHECK-ALL %s < %t
 
 ; CHECK-ALL: declare void @use(i32, i32, i32)

--- a/llvm/test/tools/llvm-reduce/skip-delta-passes.ll
+++ b/llvm/test/tools/llvm-reduce/skip-delta-passes.ll
@@ -1,10 +1,10 @@
-; RUN: llvm-reduce --delta-passes=attributes --test FileCheck --test-arg --check-prefixes=CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t
+; RUN: llvm-reduce -abort-on-invalid-reduction --delta-passes=attributes --test FileCheck --test-arg --check-prefixes=CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t
 ; RUN: FileCheck -check-prefix=RESULT %s < %t
 
-; RUN: llvm-reduce --delta-passes=instructions,attributes --skip-delta-passes=instructions --test FileCheck --test-arg --check-prefixes=CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t
+; RUN: llvm-reduce -abort-on-invalid-reduction --delta-passes=instructions,attributes --skip-delta-passes=instructions --test FileCheck --test-arg --check-prefixes=CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t
 ; RUN: FileCheck -check-prefix=RESULT %s < %t
 
-; RUN: not llvm-reduce --skip-delta-passes=foo --test FileCheck --test-arg --check-prefixes=CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t 2>&1 | FileCheck %s --check-prefix=ERROR
+; RUN: not llvm-reduce -abort-on-invalid-reduction --skip-delta-passes=foo --test FileCheck --test-arg --check-prefixes=CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o %t 2>&1 | FileCheck %s --check-prefix=ERROR
 
 
 ; CHECK-INTERESTINGNESS: @foo

--- a/llvm/test/tools/llvm-reduce/temporary-files-as-bitcode-split.ll
+++ b/llvm/test/tools/llvm-reduce/temporary-files-as-bitcode-split.ll
@@ -1,5 +1,5 @@
 ; RUN: opt --thinlto-bc --thinlto-split-lto-unit %s -o %t0
-; RUN: llvm-reduce -write-tmp-files-as-bitcode --delta-passes=function-bodies,basic-blocks %t0 -o %t1 \
+; RUN: llvm-reduce -abort-on-invalid-reduction -write-tmp-files-as-bitcode --delta-passes=function-bodies,basic-blocks %t0 -o %t1 \
 ; RUN:     --test %python --test-arg %p/Inputs/llvm-dis-and-filecheck.py --test-arg llvm-dis --test-arg FileCheck --test-arg --check-prefixes=CHECK-ALL,CHECK-INTERESTINGNESS --test-arg %s
 ; RUN: llvm-dis < %t1* | FileCheck --check-prefixes=CHECK-ALL,CHECK-FINAL %s
 

--- a/llvm/test/tools/llvm-reduce/temporary-files-as-bitcode.ll
+++ b/llvm/test/tools/llvm-reduce/temporary-files-as-bitcode.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-reduce -write-tmp-files-as-bitcode --delta-passes=function-bodies,basic-blocks %s -o %t \
+; RUN: llvm-reduce -abort-on-invalid-reduction -write-tmp-files-as-bitcode --delta-passes=function-bodies,basic-blocks %s -o %t \
 ; RUN:     --test %python --test-arg %p/Inputs/llvm-dis-and-filecheck.py --test-arg llvm-dis --test-arg FileCheck --test-arg --check-prefixes=CHECK-ALL,CHECK-INTERESTINGNESS --test-arg %s
 ; RUN: FileCheck --check-prefixes=CHECK-ALL,CHECK-FINAL %s < %t
 


### PR DESCRIPTION
If I flip the default, the only failures are in MIR tests.