### PR TITLE
llvm-reduce: Filter function based on uses before removing arguments

### DIFF
--- a/llvm/test/tools/llvm-reduce/reduce-arguments-invoke.ll
+++ b/llvm/test/tools/llvm-reduce/reduce-arguments-invoke.ll
@@ -1,0 +1,41 @@
+; RUN: llvm-reduce %s -o %t --abort-on-invalid-reduction --delta-passes=arguments --test FileCheck --test-arg %s --test-arg --check-prefix=INTERESTING --test-arg --input-file
+; RUN: FileCheck %s --input-file %t --check-prefix=REDUCED
+
+; Test that we don't break the callsite for an unhandled invoke
+
+declare void @did_not_throw(i32)
+declare void @thrown()
+
+; INTERESTING-LABEL: define i32 @maybe_throwing_callee(
+
+; REDUCED-LABEL: define i32 @maybe_throwing_callee(i32 %arg0, i32 %arg1) {
+define i32 @maybe_throwing_callee(i32 %arg0, i32 %arg1) {
+  call void @thrown()
+  ret i32 %arg1
+}
+
+@initializer_user = global [1 x ptr] [ptr @maybe_throwing_callee ]
+
+; REDUCED-LABEL: define void @caller()
+; REDUCED: %i0 = invoke i32 @maybe_throwing_callee(i32 0, i32 0) #0
+define void @caller(i32 %arg0, ptr %arg1) personality ptr @__gxx_personality_v0 {
+bb:
+  %val = load i32, ptr %arg1
+  %i0 = invoke i32 @maybe_throwing_callee(i32 0, i32 0) nofree
+          to label %bb3 unwind label %bb1
+
+bb1:
+  landingpad { ptr, i32 }
+  catch ptr null
+  call void @thrown()
+  br label %bb4
+
+bb3:
+  call void @did_not_throw(i32 %i0)
+  br label %bb4
+
+bb4:
+  ret void
+}
+
+declare i32 @__gxx_personality_v0(...)

--- a/llvm/test/tools/llvm-reduce/reduce-arguments-non-callee-use.ll
+++ b/llvm/test/tools/llvm-reduce/reduce-arguments-non-callee-use.ll
@@ -1,0 +1,32 @@
+; RUN: llvm-reduce %s -o %t --abort-on-invalid-reduction --delta-passes=arguments --test FileCheck --test-arg %s --test-arg --check-prefix=INTERESTING --test-arg --input-file
+; RUN: FileCheck %s --input-file %t --check-prefix=REDUCED
+
+; INTERESTING: @initializer_user
+; REDUCED: @initializer_user = global [1 x ptr] [ptr @captured_func]
+@initializer_user = global [1 x ptr] [ptr @captured_func ]
+
+; INTERESTING-LABEL: define i32 @captured_func(
+
+; REDUCED-LABEL: define i32 @captured_func() {
+define i32 @captured_func(i32 %a, i32 %b) {
+  %mul = mul i32 %a, %b
+  ret i32 %mul
+}
+
+; INTERESTING-LABEL: declare void @captures(
+declare void @captures(i32, ptr, i32)
+
+
+; INTERESTING-LABEL: define i32 @caller(
+; INTERESTING: = call
+; INTERESTING: = call
+
+; REDUCED-LABEL: define i32 @caller(i32 %a, i32 %b) {
+; REDUCED: %call0 = call i32 @captures(i32 %a, ptr @captured_func, i32 %b)
+; REDUCED: %call1 = call i32 @captured_func()
+define i32 @caller(i32 %a, i32 %b) {
+  %call0 = call i32 @captures(i32 %a, ptr @captured_func, i32 %b)
+  %call1 = call i32 @captured_func(i32 %a, i32 %b)
+  %add = add i32 %call0, %call1
+  ret i32 %add
+}


### PR DESCRIPTION
Invokes and others are not handled, so this was leaving broken callsites
behind for anything other than CallInst