### PR TITLE
[clang] Implement some missing interfaces for DelegatingDeserializationListener

### DIFF
--- a/clang/include/clang/Serialization/ASTDeserializationListener.h
+++ b/clang/include/clang/Serialization/ASTDeserializationListener.h
@@ -27,6 +27,8 @@ class MacroInfo;
 class Module;
 class SourceLocation;
 
+// IMPORTANT: when you add a new interface to this class, please update the
+// DelegatingDeserializationListener below.
 class ASTDeserializationListener {
 public:
   virtual ~ASTDeserializationListener();
@@ -44,6 +46,11 @@ public:
   ///        unqualified.
   virtual void TypeRead(serialization::TypeIdx Idx, QualType T) { }
   /// A decl was deserialized from the AST file.
+  //
+  // Note: Implementors should be cautious when introducing additional
+  // serialization (e.g., printing the qualified name of the declaration) within
+  // the callback. Doing so may lead to unintended and complex side effects, or
+  // even cause a crash.
   virtual void DeclRead(GlobalDeclID ID, const Decl *D) {}
   /// A predefined decl was built during the serialization.
   virtual void PredefinedDeclBuilt(PredefinedDeclIDs ID, const Decl *D) {}
@@ -58,6 +65,70 @@ public:
   virtual void ModuleImportRead(serialization::SubmoduleID ID,
                                 SourceLocation ImportLoc) {}
 };
-}
+
+class DelegatingDeserializationListener : public ASTDeserializationListener {
+  ASTDeserializationListener *Previous;
+  bool DeletePrevious;
+
+public:
+  explicit DelegatingDeserializationListener(
+      ASTDeserializationListener *Previous, bool DeletePrevious)
+      : Previous(Previous), DeletePrevious(DeletePrevious) {}
+  ~DelegatingDeserializationListener() override {
+    if (DeletePrevious)
+      delete Previous;
+  }
+
+  DelegatingDeserializationListener(const DelegatingDeserializationListener &) =
+      delete;
+  DelegatingDeserializationListener &
+  operator=(const DelegatingDeserializationListener &) = delete;
+
+  void ReaderInitialized(ASTReader *Reader) override {
+    if (Previous)
+      Previous->ReaderInitialized(Reader);
+  }
+  void IdentifierRead(serialization::IdentifierID ID,
+                      IdentifierInfo *II) override {
+    if (Previous)
+      Previous->IdentifierRead(ID, II);
+  }
+  void MacroRead(serialization::MacroID ID, MacroInfo *MI) override {
+    if (Previous)
+      Previous->MacroRead(ID, MI);
+  }
+  void TypeRead(serialization::TypeIdx Idx, QualType T) override {
+    if (Previous)
+      Previous->TypeRead(Idx, T);
+  }
+  void DeclRead(GlobalDeclID ID, const Decl *D) override {
+    if (Previous)
+      Previous->DeclRead(ID, D);
+  }
+  void PredefinedDeclBuilt(PredefinedDeclIDs ID, const Decl *D) override {
+    if (Previous)
+      Previous->PredefinedDeclBuilt(ID, D);
+  }
+  void SelectorRead(serialization::SelectorID ID, Selector Sel) override {
+    if (Previous)
+      Previous->SelectorRead(ID, Sel);
+  }
+  void MacroDefinitionRead(serialization::PreprocessedEntityID PPID,
+                           MacroDefinitionRecord *MD) override {
+    if (Previous)
+      Previous->MacroDefinitionRead(PPID, MD);
+  }
+  void ModuleRead(serialization::SubmoduleID ID, Module *Mod) override {
+    if (Previous)
+      Previous->ModuleRead(ID, Mod);
+  }
+  void ModuleImportRead(serialization::SubmoduleID ID,
+                        SourceLocation ImportLoc) override {
+    if (Previous)
+      Previous->ModuleImportRead(ID, ImportLoc);
+  }
+};
+
+} // namespace clang
 
 #endif

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -49,52 +49,6 @@ LLVM_INSTANTIATE_REGISTRY(FrontendPluginRegistry)
 
 namespace {
 
-class DelegatingDeserializationListener : public ASTDeserializationListener {
-  ASTDeserializationListener *Previous;
-  bool DeletePrevious;
-
-public:
-  explicit DelegatingDeserializationListener(
-      ASTDeserializationListener *Previous, bool DeletePrevious)
-      : Previous(Previous), DeletePrevious(DeletePrevious) {}
-  ~DelegatingDeserializationListener() override {
-    if (DeletePrevious)
-      delete Previous;
-  }
-
-  DelegatingDeserializationListener(const DelegatingDeserializationListener &) =
-      delete;
-  DelegatingDeserializationListener &
-  operator=(const DelegatingDeserializationListener &) = delete;
-
-  void ReaderInitialized(ASTReader *Reader) override {
-    if (Previous)
-      Previous->ReaderInitialized(Reader);
-  }
-  void IdentifierRead(serialization::IdentifierID ID,
-                      IdentifierInfo *II) override {
-    if (Previous)
-      Previous->IdentifierRead(ID, II);
-  }
-  void TypeRead(serialization::TypeIdx Idx, QualType T) override {
-    if (Previous)
-      Previous->TypeRead(Idx, T);
-  }
-  void DeclRead(GlobalDeclID ID, const Decl *D) override {
-    if (Previous)
-      Previous->DeclRead(ID, D);
-  }
-  void SelectorRead(serialization::SelectorID ID, Selector Sel) override {
-    if (Previous)
-      Previous->SelectorRead(ID, Sel);
-  }
-  void MacroDefinitionRead(serialization::PreprocessedEntityID PPID,
-                           MacroDefinitionRecord *MD) override {
-    if (Previous)
-      Previous->MacroDefinitionRead(PPID, MD);
-  }
-};
-
 /// Dumps deserialized declarations.
 class DeserializedDeclsDumper : public DelegatingDeserializationListener {
 public:


### PR DESCRIPTION
Split from the https://github.com/llvm/llvm-project/pull/133395 per the review comment.

This patch also moves the `DelegatingDeserializationListener` close to `ASTDeserializationListener`.