### PR TITLE
[clang-tidy][NFC] improve documentation for `bugprone-argument-comment` check

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/argument-comment.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/argument-comment.rst
@@ -24,18 +24,19 @@ Options
 
 .. option:: StrictMode
 
-   When `false` (default value), the check will ignore leading and trailing
+   When `false`, the check will ignore leading and trailing
    underscores and case when comparing names -- otherwise they are taken into
-   account.
+   account. Default is `false`.
 
 .. option:: IgnoreSingleArgument
 
-   When `true`, the check will ignore the single argument.
+   When `true`, the check will ignore the single argument. Default is `false`.
 
 .. option:: CommentBoolLiterals
 
    When `true`, the check will add argument comments in the format
    ``/*ParameterName=*/`` right before the boolean literal argument.
+   Default is `false`.
 
 Before:
 
@@ -55,8 +56,9 @@ After:
 
 .. option:: CommentIntegerLiterals
 
-   When true, the check will add argument comments in the format
+   When `true`, the check will add argument comments in the format
    ``/*ParameterName=*/`` right before the integer literal argument.
+   Default is `false`.
 
 Before:
 
@@ -76,8 +78,9 @@ After:
 
 .. option:: CommentFloatLiterals
 
-   When true, the check will add argument comments in the format
+   When `true`, the check will add argument comments in the format
    ``/*ParameterName=*/`` right before the float/double literal argument.
+   Default is `false`.
 
 Before:
 
@@ -97,8 +100,9 @@ After:
 
 .. option:: CommentStringLiterals
 
-   When true, the check will add argument comments in the format
+   When `true`, the check will add argument comments in the format
    ``/*ParameterName=*/`` right before the string literal argument.
+   Default is `false`.
 
 Before:
 
@@ -122,8 +126,9 @@ After:
 
 .. option:: CommentCharacterLiterals
 
-   When true, the check will add argument comments in the format
+   When `true`, the check will add argument comments in the format
    ``/*ParameterName=*/`` right before the character literal argument.
+   Default is `false`.
 
 Before:
 
@@ -143,8 +148,9 @@ After:
 
 .. option:: CommentUserDefinedLiterals
 
-   When true, the check will add argument comments in the format
+   When `true`, the check will add argument comments in the format
    ``/*ParameterName=*/`` right before the user defined literal argument.
+   Default is `false`.
 
 Before:
 
@@ -168,8 +174,9 @@ After:
 
 .. option:: CommentNullPtrs
 
-   When true, the check will add argument comments in the format
+   When `true`, the check will add argument comments in the format
    ``/*ParameterName=*/`` right before the nullptr literal argument.
+   Default is `false`.
 
 Before:
 


### PR DESCRIPTION
Improve docs for `bugprone-argument-comment` check by writing explicitly default values for options.
Before this change, it was unclear what values are default.