### PR TITLE
[libc] Enable 'mktime' for the GPU

### DIFF
--- a/libc/cmake/modules/LLVMLibCTestRules.cmake
+++ b/libc/cmake/modules/LLVMLibCTestRules.cmake
@@ -643,7 +643,7 @@ function(add_libc_hermetic test_name)
   cmake_parse_arguments(
     "HERMETIC_TEST"
     "IS_GPU_BENCHMARK" # Optional arguments
-    "SUITE" # Single value arguments
+    "SUITE;CXX_STANDARD" # Single value arguments
     "SRCS;HDRS;DEPENDS;ARGS;ENV;COMPILE_OPTIONS;LINK_LIBRARIES;LOADER_ARGS" # Multi-value arguments
     ${ARGN}
   )
@@ -720,10 +720,14 @@ function(add_libc_hermetic test_name)
     ${HERMETIC_TEST_SRCS}
     ${HERMETIC_TEST_HDRS}
   )
+
+  if(NOT HERMETIC_TEST_CXX_STANDARD)
+    set(HERMETIC_TEST_CXX_STANDARD ${CMAKE_CXX_STANDARD})
+  endif()
   set_target_properties(${fq_build_target_name}
     PROPERTIES
       RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-      #OUTPUT_NAME ${fq_target_name}
+      CXX_STANDARD ${HERMETIC_TEST_CXX_STANDARD}
   )
 
   target_include_directories(${fq_build_target_name} SYSTEM PRIVATE ${LIBC_INCLUDE_DIR})

--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -261,6 +261,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.time.nanosleep
     libc.src.time.strftime
     libc.src.time.strftime_l
+    libc.src.time.mktime
 
     # wchar.h entrypoints
     libc.src.wchar.wcslen

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -261,6 +261,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.time.nanosleep
     libc.src.time.strftime
     libc.src.time.strftime_l
+    libc.src.time.mktime
 
     # wchar.h entrypoints
     libc.src.wchar.wcslen

--- a/libc/test/src/time/CMakeLists.txt
+++ b/libc/test/src/time/CMakeLists.txt
@@ -148,7 +148,7 @@ add_libc_unittest(
     libc.src.time.time_constants
 )
 
-add_libc_unittest(
+add_libc_test(
   mktime_test
   SUITE
     libc_time_unittests

--- a/libc/test/src/time/mktime_test.cpp
+++ b/libc/test/src/time/mktime_test.cpp
@@ -18,6 +18,10 @@ using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 using LIBC_NAMESPACE::time_constants::Month;
 
+#ifndef EOVERFLOW
+#define EOVERFLOW 0
+#endif
+
 static inline constexpr int tm_year(int year) {
   return year - LIBC_NAMESPACE::time_constants::TIME_YEAR_BASE;
 }


### PR DESCRIPTION
Summary:
This is a dependency on `strftime` which we provide, so we should have
this.
