### PR TITLE
[HLSL] add CustomTypeChecking to float builtins

### DIFF
--- a/clang/include/clang/Basic/Builtins.td
+++ b/clang/include/clang/Basic/Builtins.td
@@ -4869,7 +4869,7 @@ def HLSLWaveReadLaneAt : LangBuiltin<"HLSL_LANG"> {
 
 def HLSLClamp : LangBuiltin<"HLSL_LANG"> {
   let Spellings = ["__builtin_hlsl_elementwise_clamp"];
-  let Attributes = [NoThrow, Const];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
   let Prototype = "void(...)";
 }
 
@@ -4881,13 +4881,13 @@ def HLSLCross: LangBuiltin<"HLSL_LANG"> {
 
 def HLSLDegrees : LangBuiltin<"HLSL_LANG"> {
   let Spellings = ["__builtin_hlsl_elementwise_degrees"];
-  let Attributes = [NoThrow, Const];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
   let Prototype = "void(...)";
 }
 
 def HLSLDotProduct : LangBuiltin<"HLSL_LANG"> {
   let Spellings = ["__builtin_hlsl_dot"];
-  let Attributes = [NoThrow, Const];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
   let Prototype = "void(...)";
 }
 
@@ -4917,7 +4917,7 @@ def HLSLFirstBitLow : LangBuiltin<"HLSL_LANG"> {
 
 def HLSLFrac : LangBuiltin<"HLSL_LANG"> {
   let Spellings = ["__builtin_hlsl_elementwise_frac"];
-  let Attributes = [NoThrow, Const];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
   let Prototype = "void(...)";
 }
 
@@ -4929,7 +4929,7 @@ def HLSLIsinf : LangBuiltin<"HLSL_LANG"> {
 
 def HLSLLerp : LangBuiltin<"HLSL_LANG"> {
   let Spellings = ["__builtin_hlsl_lerp"];
-  let Attributes = [NoThrow, Const];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
   let Prototype = "void(...)";
 }
 
@@ -4941,25 +4941,25 @@ def HLSLMad : LangBuiltin<"HLSL_LANG"> {
 
 def HLSLNormalize : LangBuiltin<"HLSL_LANG"> {
   let Spellings = ["__builtin_hlsl_normalize"];
-  let Attributes = [NoThrow, Const];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
   let Prototype = "void(...)";
 }
 
 def HLSLRcp : LangBuiltin<"HLSL_LANG"> {
   let Spellings = ["__builtin_hlsl_elementwise_rcp"];
-  let Attributes = [NoThrow, Const];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
   let Prototype = "void(...)";
 }
 
 def HLSLRSqrt : LangBuiltin<"HLSL_LANG"> {
   let Spellings = ["__builtin_hlsl_elementwise_rsqrt"];
-  let Attributes = [NoThrow, Const];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
   let Prototype = "void(...)";
 }
 
 def HLSLSaturate : LangBuiltin<"HLSL_LANG"> {
   let Spellings = ["__builtin_hlsl_elementwise_saturate"];
-  let Attributes = [NoThrow, Const];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
   let Prototype = "void(...)";
 }
 
@@ -4983,7 +4983,7 @@ def HLSLStep: LangBuiltin<"HLSL_LANG"> {
 
 def HLSLRadians : LangBuiltin<"HLSL_LANG"> {
   let Spellings = ["__builtin_hlsl_elementwise_radians"];
-  let Attributes = [NoThrow, Const];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
   let Prototype = "void(...)";
 }
 
@@ -5001,7 +5001,7 @@ def HLSLSplitDouble: LangBuiltin<"HLSL_LANG"> {
 
 def HLSLClip: LangBuiltin<"HLSL_LANG"> {
   let Spellings = ["__builtin_hlsl_elementwise_clip"];
-  let Attributes = [NoThrow, Const];
+  let Attributes = [NoThrow, Const, CustomTypeChecking];
   let Prototype = "void(...)";
 }
 

--- a/clang/test/CodeGenHLSL/builtins/clamp-builtin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/clamp-builtin.hlsl
@@ -1,8 +1,12 @@
 // RUN: %clang_cc1 -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -fnative-half-type -emit-llvm -disable-llvm-passes -o - | FileCheck %s
 
-// CHECK-LABEL: builtin_test_clamp_int4
-// CHECK: %hlsl.clamp = call <4 x i32> @llvm.dx.sclamp.v4i32(<4 x i32> %0, <4 x i32> %1, <4 x i32> %2)
-// CHECK: ret <4 x i32> %hlsl.clamp
-int4 builtin_test_clamp_int4(int4 p0, int4 p1, int4 p2) {
-  return __builtin_hlsl_elementwise_clamp(p0, p1, p2);
-}
+
+// CHECK-LABEL: builtin_clamp_half
+// CHECK: %hlsl.clamp = call reassoc nnan ninf nsz arcp afn half @llvm.dx.nclamp.f16(half %{{.*}}, half %{{.*}}, half %{{.*}})
+// CHECK: ret half %hlsl.clamp
+half builtin_clamp_half(half p0) { return __builtin_hlsl_elementwise_clamp(p0, p0, p0); }
+
+// CHECK-LABEL: builtin_clamp_float
+// CHECK: %hlsl.clamp = call reassoc nnan ninf nsz arcp afn float @llvm.dx.nclamp.f32(float %{{.*}}, float %{{.*}}, float %{{.*}})
+// CHECK: ret float %hlsl.clamp
+float builtin_clamp_float(float p0) { return __builtin_hlsl_elementwise_clamp(p0, p0, p0); }

--- a/clang/test/CodeGenHLSL/builtins/clip-builtin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/clip-builtin.hlsl
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -fnative-half-type -emit-llvm -disable-llvm-passes -o - | FileCheck %s
+
+// CHECK:      define void @{{.*}}builtin_clip_float{{.*}}(float {{.*}} [[P0:%.*]])
+// CHECK:      [[LOAD:%.*]] = load float, ptr [[P0]].addr, align 4
+// CHECK-NEXT: [[FCMP:%.*]] = fcmp reassoc nnan ninf nsz arcp afn olt float [[LOAD]], 0.000000e+00
+// CHECK-NO:   call i1 @llvm.dx.any
+// CHECK-NEXT: call void @llvm.dx.discard(i1 [[FCMP]])
+void builtin_clip_float (float p0) {
+  __builtin_hlsl_elementwise_clip(p0);
+}

--- a/clang/test/CodeGenHLSL/builtins/degrees-builtin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/degrees-builtin.hlsl
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -fnative-half-type -emit-llvm -disable-llvm-passes -o - | FileCheck %s
+
+
+// CHECK-LABEL: builtin_degrees_half
+// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn half @llvm.dx.degrees.f16(half %{{.*}})
+// CHECK: ret half  %hlsl.degrees
+half builtin_degrees_half(half p0) {
+  return __builtin_hlsl_elementwise_degrees(p0);
+}
+
+// CHECK-LABEL: builtin_degrees_float
+// CHECK: %hlsl.degrees = call reassoc nnan ninf nsz arcp afn float @llvm.dx.degrees.f32(float %{{.*}})
+// CHECK: ret float  %hlsl.degrees
+float builtin_degrees_float (float p0) {
+  return __builtin_hlsl_elementwise_degrees(p0);
+}

--- a/clang/test/CodeGenHLSL/builtins/dot-builtin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/dot-builtin.hlsl
@@ -1,30 +1,23 @@
 // RUN: %clang_cc1 -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -fnative-half-type -emit-llvm -disable-llvm-passes -o - | FileCheck %s
 
-// CHECK-LABEL: builtin_bool_to_float_type_promotion
-// CHECK: %conv1 = uitofp i1 %loadedv to double
-// CHECK: %hlsl.dot = fmul reassoc nnan ninf nsz arcp afn double %conv, %conv1
-// CHECK: %conv2 = fptrunc reassoc nnan ninf nsz arcp afn double %hlsl.dot to float
-// CHECK: ret float %conv2
-float builtin_bool_to_float_type_promotion ( float p0, bool p1 ) {
-  return __builtin_hlsl_dot ( (double)p0, (double)p1 );
+
+// CHECK-LABEL: builtin_dot_half
+// CHECK: %hlsl.dot = fmul reassoc nnan ninf nsz arcp afn half %{{.*}}, %{{.*}}
+// CHECK: ret half  %hlsl.dot
+half builtin_dot_half ( half p0, half p1 ) {
+  return __builtin_hlsl_dot (p0, p1 );
 }
 
-// CHECK-LABEL: builtin_bool_to_float_arg1_type_promotion
-// CHECK: %conv = uitofp i1 %loadedv to double
-// CHECK: %conv1 = fpext reassoc nnan ninf nsz arcp afn float %1 to double
-// CHECK: %hlsl.dot = fmul reassoc nnan ninf nsz arcp afn double %conv, %conv1
-// CHECK: %conv2 = fptrunc reassoc nnan ninf nsz arcp afn double %hlsl.dot to float
-// CHECK: ret float %conv2
-float builtin_bool_to_float_arg1_type_promotion ( bool p0, float p1 ) {
-  return __builtin_hlsl_dot ( (double)p0, (double)p1 );
+// CHECK-LABEL: builtin_dot_float
+// CHECK: %hlsl.dot = fmul reassoc nnan ninf nsz arcp afn float %{{.*}}, %{{.*}}
+// CHECK: ret float  %hlsl.dot
+float builtin_dot_float ( float p0, float p1 ) {
+  return __builtin_hlsl_dot (p0, p1 );
 }
 
-// CHECK-LABEL: builtin_dot_int_to_float_promotion
-// CHECK: %conv = fpext reassoc nnan ninf nsz arcp afn float %0 to double
-// CHECK: %conv1 = sitofp i32 %1 to double
-// CHECK: dot = fmul reassoc nnan ninf nsz arcp afn double %conv, %conv1
-// CHECK: %conv2 = fptrunc reassoc nnan ninf nsz arcp afn double %hlsl.dot to float
-// CHECK: ret float %conv2
-float builtin_dot_int_to_float_promotion ( float p0, int p1 ) {
-  return __builtin_hlsl_dot ( (double)p0, (double)p1 );
+// CHECK-LABEL: builtin_dot_double
+// CHECK: %hlsl.dot = fmul reassoc nnan ninf nsz arcp afn double %{{.*}}, %{{.*}}
+// CHECK: ret double %hlsl.dot
+double builtin_dot_double( double p0, double p1 ) {
+  return __builtin_hlsl_dot (p0, p1 );
 }

--- a/clang/test/CodeGenHLSL/builtins/frac-builtin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/frac-builtin.hlsl
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -fnative-half-type -emit-llvm -disable-llvm-passes -o - | FileCheck %s
+
+
+// CHECK-LABEL: builtin_frac_half
+// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn half @llvm.dx.frac.f16(half %{{.*}})
+// CHECK: ret half  %hlsl.frac
+half builtin_frac_half(half p0) {
+  return __builtin_hlsl_elementwise_frac(p0);
+}
+
+// CHECK-LABEL: builtin_frac_float
+// CHECK: %hlsl.frac = call reassoc nnan ninf nsz arcp afn float @llvm.dx.frac.f32(float %{{.*}})
+// CHECK: ret float  %hlsl.frac
+float builtin_frac_float (float p0) {
+  return __builtin_hlsl_elementwise_frac(p0);
+}

--- a/clang/test/CodeGenHLSL/builtins/lerp-builtin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/lerp-builtin.hlsl
@@ -1,15 +1,12 @@
 // RUN: %clang_cc1 -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -fnative-half-type -emit-llvm -disable-llvm-passes -o - | FileCheck %s
 
-// CHECK-LABEL: builtin_lerp_half_vector
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <3 x half> @llvm.dx.lerp.v3f16(<3 x half> %0, <3 x half> %1, <3 x half> %2)
-// CHECK: ret <3 x half> %hlsl.lerp
-half3 builtin_lerp_half_vector (half3 p0) {
-  return __builtin_hlsl_lerp ( p0, p0, p0 );
-}
 
-// CHECK-LABEL: builtin_lerp_floar_vector
-// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn <2 x float> @llvm.dx.lerp.v2f32(<2 x float> %0, <2 x float> %1, <2 x float> %2)
-// CHECK: ret <2 x float> %hlsl.lerp
-float2 builtin_lerp_floar_vector ( float2 p0) {
-  return __builtin_hlsl_lerp ( p0, p0, p0 );
-}
+// CHECK-LABEL: builtin_lerp_half
+// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn half @llvm.dx.lerp.f16(half %{{.*}}, half %{{.*}}, half %{{.*}})
+// CHECK: ret half %hlsl.lerp
+half builtin_lerp_half(half p0) { return __builtin_hlsl_lerp(p0, p0, p0); }
+
+// CHECK-LABEL: builtin_lerp_float
+// CHECK: %hlsl.lerp = call reassoc nnan ninf nsz arcp afn float @llvm.dx.lerp.f32(float %{{.*}}, float %{{.*}}, float %{{.*}})
+// CHECK: ret float %hlsl.lerp
+float builtin_lerp_float(float p0) { return __builtin_hlsl_lerp(p0, p0, p0); }

--- a/clang/test/CodeGenHLSL/builtins/normalize-builtin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/normalize-builtin.hlsl
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -fnative-half-type -emit-llvm -disable-llvm-passes -o - | FileCheck %s
+
+
+// CHECK-LABEL: builtin_normalize_half
+// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn half @llvm.dx.normalize.f16(half %{{.*}})
+// CHECK: ret half  %hlsl.normalize
+half builtin_normalize_half(half p0) {
+  return __builtin_hlsl_normalize(p0);
+}
+
+// CHECK-LABEL: builtin_normalize_float
+// CHECK: %hlsl.normalize = call reassoc nnan ninf nsz arcp afn float @llvm.dx.normalize.f32(float %{{.*}})
+// CHECK: ret float  %hlsl.normalize
+float builtin_normalize_float (float p0) {
+  return __builtin_hlsl_normalize(p0);
+}

--- a/clang/test/CodeGenHLSL/builtins/radians-builtin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/radians-builtin.hlsl
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -fnative-half-type -emit-llvm -disable-llvm-passes -o - | FileCheck %s
+
+
+// CHECK-LABEL: builtin_radians_half
+// CHECK: %hlsl.radians = call reassoc nnan ninf nsz arcp afn half @llvm.dx.radians.f16(half %{{.*}})
+// CHECK: ret half  %hlsl.radians
+half builtin_radians_half(half p0) {
+  return __builtin_hlsl_elementwise_radians(p0);
+}
+
+// CHECK-LABEL: builtin_radians_float
+// CHECK: %hlsl.radians = call reassoc nnan ninf nsz arcp afn float @llvm.dx.radians.f32(float %{{.*}})
+// CHECK: ret float  %hlsl.radians
+float builtin_radians_float (float p0) {
+  return __builtin_hlsl_elementwise_radians(p0);
+}

--- a/clang/test/CodeGenHLSL/builtins/rcp-builtin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/rcp-builtin.hlsl
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -fnative-half-type -emit-llvm -disable-llvm-passes -o - | FileCheck %s
+
+
+// CHECK-LABEL: builtin_rcp_half
+// CHECK: %hlsl.rcp = fdiv reassoc nnan ninf nsz arcp afn half 0xH3C00, %{{.*}}
+// CHECK: ret half  %hlsl.rcp
+half builtin_rcp_half(half p0) {
+  return __builtin_hlsl_elementwise_rcp(p0);
+}
+
+// CHECK-LABEL: builtin_rcp_float
+// CHECK: %hlsl.rcp = fdiv reassoc nnan ninf nsz arcp afn float  1.000000e+00, %{{.*}}
+// CHECK: ret float  %hlsl.rcp
+float builtin_rcp_float(float p0) {
+  return __builtin_hlsl_elementwise_rcp(p0);
+}

--- a/clang/test/CodeGenHLSL/builtins/rsqrt-builtin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/rsqrt-builtin.hlsl
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -fnative-half-type -emit-llvm -disable-llvm-passes -o - | FileCheck %s
+
+
+// CHECK-LABEL: builtin_rsqrt_half
+// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn half @llvm.dx.rsqrt.f16(half %{{.*}})
+// CHECK: ret half  %hlsl.rsqrt
+half builtin_rsqrt_half(half p0) {
+  return __builtin_hlsl_elementwise_rsqrt(p0);
+}
+
+// CHECK-LABEL: builtin_rsqrt_float
+// CHECK: %hlsl.rsqrt = call reassoc nnan ninf nsz arcp afn float @llvm.dx.rsqrt.f32(float %{{.*}})
+// CHECK: ret float  %hlsl.rsqrt
+float builtin_rsqrt_float (float p0) {
+  return __builtin_hlsl_elementwise_rsqrt(p0);
+}

--- a/clang/test/CodeGenHLSL/builtins/saturate-builtin.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/saturate-builtin.hlsl
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -finclude-default-header -x hlsl -triple dxil-pc-shadermodel6.3-library %s -fnative-half-type -emit-llvm -disable-llvm-passes -o - | FileCheck %s
+
+
+// CHECK-LABEL: builtin_saturate_half
+// CHECK: %hlsl.saturate = call reassoc nnan ninf nsz arcp afn half @llvm.dx.saturate.f16(half %{{.*}})
+// CHECK: ret half  %hlsl.saturate
+half builtin_saturate_half(half p0) {
+  return __builtin_hlsl_elementwise_saturate(p0);
+}
+
+// CHECK-LABEL: builtin_saturate_float
+// CHECK: %hlsl.saturate = call reassoc nnan ninf nsz arcp afn float @llvm.dx.saturate.f32(float %{{.*}})
+// CHECK: ret float  %hlsl.saturate
+float builtin_saturate_float (float p0) {
+  return __builtin_hlsl_elementwise_saturate(p0);
+}

--- a/clang/test/SemaHLSL/BuiltIns/clamp-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/clamp-errors.hlsl
@@ -35,9 +35,9 @@ float2 test_scalar_first_arg3(float p0, float2 p1) {
   // expected-error@-1 {{call to 'clamp' is ambiguous}}
 }
 
-float3 test_thing(float3 p0, float2 p1) {
+float3 test_clamp_vector_size_last_arg_mismatch(float3 p0, float2 p1) {
   return clamp(p0, p0, p1);
-  // expected-error@-1 {{cannot initialize return object of type 'float3' (aka 'vector<float, 3>') with an rvalue of type 'vector<float, 2>' (vector of 2 'float' values)}}
+  // expected-error@-1 {{all arguments to 'clamp' must have the same type}}
 }
 
 typedef float float5 __attribute__((ext_vector_type(5)));
@@ -48,13 +48,12 @@ float5 vec_too_big(float5 p0) {
   // expected-error@-1 {{call to 'clamp' is ambiguous}}
 }
 
-float2 test_clamp_vector_size_mismatch(float3 p0, float2 p1) {
+float2 test_clamp_vector_size_ret_mismatch(float3 p0, float3 p1) {
   return clamp(p0, p0, p1);
   // expected-warning@-1 {{implicit conversion truncates vector: 'float3' (aka 'vector<float, 3>') to 'vector<float, 2>' (vector of 2 'float' values)}}
-  // expected-warning@-2 {{implicit conversion truncates vector: 'float3' (aka 'vector<float, 3>') to 'vector<float, 2>' (vector of 2 'float' values)}}
 }
 
-float2 test_clamp_builtin_vector_size_mismatch(float3 p0, float2 p1) {
+float2 test_clamp_builtin_vector_size_first_arg_mismatch(float3 p0, float2 p1) {
   return __builtin_hlsl_elementwise_clamp(p0, p1, p1);
   // expected-error@-1 {{all arguments to '__builtin_hlsl_elementwise_clamp' must have the same type}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/clip-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/clip-errors.hlsl
@@ -16,12 +16,17 @@ void test_first_arg_type_mismatch(bool p) {
  // expected-error@-1 {{invalid operand of type 'bool' where 'float' or a vector of such type is required}} 
 }
 
-void test_first_arg_type_mismatch_3(half3 p) {
+void test_first_arg_type_mismatch_2(half3 p) {
   __builtin_hlsl_elementwise_clip(p);
  // expected-error@-1 {{invalid operand of type 'half3' (aka 'vector<half, 3>') where 'float' or a vector of such type is required}} 
 }
 
-void test_first_arg_type_mismatch_3(double p) {
+void test_first_arg_type_mismatch_3(half p) {
+  __builtin_hlsl_elementwise_clip(p);
+ // expected-error@-1 {{invalid operand of type 'half' where 'float' or a vector of such type is required}} 
+}
+
+void test_first_arg_type_mismatch_4(double p) {
   __builtin_hlsl_elementwise_clip(p);
  // expected-error@-1 {{invalid operand of type 'double' where 'float' or a vector of such type is required}} 
 }

--- a/clang/test/SemaHLSL/BuiltIns/dot-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/dot-errors.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -verify-ignore-unexpected
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -verify-ignore-unexpected=note
 
 float test_no_second_arg(float2 p0) {
   return __builtin_hlsl_dot(p0);
@@ -17,7 +17,7 @@ float test_dot_no_second_arg(float2 p0) {
 
 float test_dot_vector_size_mismatch(float3 p0, float2 p1) {
   return dot(p0, p1);
-  // expected-warning@-1 {{implicit conversion truncates vector: 'float3' (aka 'vector<float, 3>') to 'vector<float, 2>' (vector of 2 'float' values)}}
+  // expected-error@-1 {{all arguments to 'dot' must have the same type}}
 }
 
 float test_dot_builtin_vector_size_mismatch(float3 p0, float2 p1) {
@@ -104,7 +104,7 @@ float test_builtin_dot_int_vect_to_float_vec_promotion(int2 p0, float p1) {
   // expected-error@-1 {{all arguments to '__builtin_hlsl_dot' must be vectors}}
 }
 
-int test_builtin_dot_bool_type_promotion(bool p0, bool p1) {
+int test_builtin_dot_bool_type_promotion(bool p0, float p1) {
   return __builtin_hlsl_dot(p0, p1);
   // expected-error@-1 {{1st argument must be a vector, integer or floating-point type (was 'bool')}}
 }
@@ -116,4 +116,14 @@ double test_dot_double(double2 p0, double2 p1) {
 double test_dot_double_builtin(double2 p0, double2 p1) {
   return __builtin_hlsl_dot(p0, p1);
   // expected-error@-1 {{passing 'double2' (aka 'vector<double, 2>') to parameter of incompatible type '__attribute__((__vector_size__(2 * sizeof(float)))) float' (vector of 2 'float' values)}}
+}
+
+float builtin_bool_to_float_type_promotion ( float p0, bool p1 ) {
+  return __builtin_hlsl_dot ( p0, p1 );
+   // expected-error@-1 {{are of different types ('float' vs 'bool')}}
+}
+
+float builtin_dot_int_to_float_promotion ( float p0, int p1 ) {
+  return __builtin_hlsl_dot (p0, p1 );
+  // expected-error@-1 {{are of different types ('float' vs 'int')}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/frac-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/frac-errors.hlsl
@@ -26,14 +26,3 @@ float2 builtin_frac_int2_to_float2_promotion(int2 p1) {
   // expected-error@-1 {{passing 'int2' (aka 'vector<int, 2>') to parameter of incompatible type '__attribute__((__vector_size__(2 * sizeof(float)))) float' (vector of 2 'float' values)}}
 }
 
-// builtins are variadic functions and so are subject to DefaultVariadicArgumentPromotion
-half builtin_frac_half_scalar (half p0) {
-  return __builtin_hlsl_elementwise_frac (p0);
-  // expected-error@-1 {{passing 'double' to parameter of incompatible type 'float'}}
-}
-
-float builtin_frac_float_scalar ( float p0) {
-  return __builtin_hlsl_elementwise_frac (p0);
-  // expected-error@-1 {{passing 'double' to parameter of incompatible type 'float'}}
-}
-

--- a/clang/test/SemaHLSL/BuiltIns/lerp-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/lerp-errors.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -verify-ignore-unexpected
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.6-library %s -fnative-half-type -emit-llvm-only -disable-llvm-passes -verify -verify-ignore-unexpected=note
 
 float2 test_no_second_arg(float2 p0) {
   return __builtin_hlsl_lerp(p0);
@@ -25,16 +25,14 @@ float2 test_lerp_vector_trunc_warn1(float3 p0) {
   // expected-warning@-1 {{implicit conversion truncates vector: 'float3' (aka 'vector<float, 3>') to 'vector<float, 2>' (vector of 2 'float' values)}}
 }
 
-float2 test_lerp_vector_trunc_warn2(float3 p0, float2 p1) {
+float2 test_lerp_vector_size_mismatch1(float3 p0, float2 p1) {
   return lerp(p0, p0, p1);
-  // expected-warning@-1 {{implicit conversion truncates vector: 'float3' (aka 'vector<float, 3>') to 'vector<float, 2>' (vector of 2 'float' values)}}
-  // expected-warning@-2 {{implicit conversion truncates vector: 'float3' (aka 'vector<float, 3>') to 'vector<float, 2>' (vector of 2 'float' values)}}
+  // expected-error@-1 {{all arguments to 'lerp' must have the same type}}
 }
 
-float2 test_lerp_vector_trunc_warn3(float3 p0, float2 p1) {
+float2 test_lerp_vector_size_mismatch2(float3 p0, float2 p1) {
   return lerp(p0, p1, p0);
-  // expected-warning@-1 {{implicit conversion truncates vector: 'float3' (aka 'vector<float, 3>') to 'vector<float, 2>' (vector of 2 'float' values)}}
-  // expected-warning@-2 {{implicit conversion truncates vector: 'float3' (aka 'vector<float, 3>') to 'vector<float, 2>' (vector of 2 'float' values)}}
+  // expected-error@-1 {{all arguments to 'lerp' must have the same type}}
 }
 
 float2 test_lerp_builtin_vector_size_mismatch_Arg1(float3 p0, float2 p1) {
@@ -125,17 +123,4 @@ float builtin_lerp_int_to_float_promotion(float p0, int p1) {
 float4 test_lerp_int4(int4 p0, int4 p1, int4 p2) {
   return __builtin_hlsl_lerp(p0, p1, p2);
   // expected-error@-1 {{1st argument must be a scalar or vector of floating-point types (was 'int4' (aka 'vector<int, 4>'))}}
-}
-
-// note: DefaultVariadicArgumentPromotion --> DefaultArgumentPromotion has already promoted to double
-// we don't know anymore that the input was half when __builtin_hlsl_lerp is called so we default to float
-// for expected type
-half builtin_lerp_half_scalar (half p0) {
-  return __builtin_hlsl_lerp ( p0, p0, p0 );
-  // expected-error@-1 {{passing 'double' to parameter of incompatible type 'float'}}
-}
-
-float builtin_lerp_float_scalar ( float p0) {
-  return __builtin_hlsl_lerp ( p0, p0, p0 );
-  // expected-error@-1 {{passing 'double' to parameter of incompatible type 'float'}}
 }

--- a/clang/test/SemaHLSL/BuiltIns/rsqrt-errors.hlsl
+++ b/clang/test/SemaHLSL/BuiltIns/rsqrt-errors.hlsl
@@ -26,13 +26,7 @@ float2 builtin_rsqrt_int2_to_float2_promotion(int2 p1) {
   // expected-error@-1 {{passing 'int2' (aka 'vector<int, 2>') to parameter of incompatible type '__attribute__((__vector_size__(2 * sizeof(float)))) float' (vector of 2 'float' values)}}
 }
 
-// builtins are variadic functions and so are subject to DefaultVariadicArgumentPromotion
-half builtin_rsqrt_half_scalar (half p0) {
-  return __builtin_hlsl_elementwise_rsqrt (p0);
-  // expected-error@-1 {{passing 'double' to parameter of incompatible type 'float'}}
-}
-
-float builtin_rsqrt_float_scalar ( float p0) {
-  return __builtin_hlsl_elementwise_rsqrt (p0);
+double builtin_rsqrt_double(double p0) {
+  return __builtin_hlsl_elementwise_rsqrt(p0);
   // expected-error@-1 {{passing 'double' to parameter of incompatible type 'float'}}
 }


### PR DESCRIPTION
- Add CustomTypeChecking to HLSL builtins that take float arguments
- Add new builtin tests to confirm CustomTypeChecking doesn't promote scalar float arguments aren't promoted to double
- fixes #133440