### PR TITLE
[AMDGPU] Tweak address space definitions. NFC.

### DIFF
--- a/llvm/include/llvm/Support/AMDGPUAddrSpace.h
+++ b/llvm/include/llvm/Support/AMDGPUAddrSpace.h
@@ -31,8 +31,8 @@ enum : unsigned {
   GLOBAL_ADDRESS = 1, ///< Address space for global memory (RAT0, VTX0).
   REGION_ADDRESS = 2, ///< Address space for region memory. (GDS)
 
-  CONSTANT_ADDRESS = 4, ///< Address space for constant memory (VTX2).
   LOCAL_ADDRESS = 3,    ///< Address space for local memory.
+  CONSTANT_ADDRESS = 4, ///< Address space for constant memory (VTX2).
   PRIVATE_ADDRESS = 5,  ///< Address space for private memory.
 
   CONSTANT_ADDRESS_32BIT = 6, ///< Address space for 32-bit constant memory.

--- a/llvm/lib/Target/AMDGPU/AMDGPU.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.h
@@ -537,11 +537,11 @@ static inline bool addrspacesMayAlias(unsigned AS1, unsigned AS2) {
   // This array is indexed by address space value enum elements 0 ... to 9
   // clang-format off
   static const bool ASAliasRules[10][10] = {
-    /*                       Flat   Global Region  Group Constant Private Const32 BufFatPtr BufRsrc BufStrdPtr */
+    /*                       Flat   Global Region  Local Constant Private Const32 BufFatPtr BufRsrc BufStrdPtr */
     /* Flat     */            {true,  true,  false, true,  true,  true,  true,  true,  true,  true},
     /* Global   */            {true,  true,  false, false, true,  false, true,  true,  true,  true},
     /* Region   */            {false, false, true,  false, false, false, false, false, false, false},
-    /* Group    */            {true,  false, false, true,  false, false, false, false, false, false},
+    /* Local    */            {true,  false, false, true,  false, false, false, false, false, false},
     /* Constant */            {true,  true,  false, false, false, false, true,  true,  true,  true},
     /* Private  */            {true,  false, false, false, false, true,  false, false, false, false},
     /* Constant 32-bit */     {true,  true,  false, false, true,  false, false, true,  true,  true},


### PR DESCRIPTION
Define address spaces in numerical order. Fix comments to refer to
"local" instead of "group" address space.
