### PR TITLE
[RISCV] Add shift-add (SH1ADD, ...) to isCopyInstrImpl

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -1772,6 +1772,16 @@ RISCVInstrInfo::isCopyInstrImpl(const MachineInstr &MI) const {
         MI.getOperand(1).isReg())
       return DestSourcePair{MI.getOperand(0), MI.getOperand(1)};
     break;
+  case RISCV::SH1ADD:
+  case RISCV::SH1ADD_UW:
+  case RISCV::SH2ADD:
+  case RISCV::SH2ADD_UW:
+  case RISCV::SH3ADD:
+  case RISCV::SH3ADD_UW:
+    if (MI.getOperand(1).isReg() && MI.getOperand(1).getReg() == RISCV::X0 &&
+        MI.getOperand(2).isReg())
+      return DestSourcePair{MI.getOperand(0), MI.getOperand(2)};
+    break;
   case RISCV::FSGNJ_D:
   case RISCV::FSGNJ_S:
   case RISCV::FSGNJ_H:

--- a/llvm/unittests/Target/RISCV/RISCVInstrInfoTest.cpp
+++ b/llvm/unittests/Target/RISCV/RISCVInstrInfoTest.cpp
@@ -179,6 +179,26 @@ TEST_P(RISCVInstrInfoTest, IsCopyInstrImpl) {
   ASSERT_TRUE(MI9Res.has_value());
   EXPECT_EQ(MI9Res->Destination->getReg(), RISCV::X1);
   EXPECT_EQ(MI9Res->Source->getReg(), RISCV::X2);
+
+  // SH1ADD(_UW), SH2ADD(_UW), SH3ADD(_UW).
+  for (unsigned Opc : {RISCV::SH1ADD, RISCV::SH1ADD_UW, RISCV::SH2ADD,
+                       RISCV::SH2ADD_UW, RISCV::SH3ADD, RISCV::SH3ADD_UW}) {
+    MachineInstr *MI10 = BuildMI(*MF, DL, TII->get(Opc), RISCV::X1)
+                             .addReg(RISCV::X2)
+                             .addReg(RISCV::X3)
+                             .getInstr();
+    auto MI10Res = TII->isCopyInstrImpl(*MI10);
+    EXPECT_FALSE(MI10Res.has_value());
+
+    MachineInstr *MI11 = BuildMI(*MF, DL, TII->get(Opc), RISCV::X1)
+                             .addReg(RISCV::X0)
+                             .addReg(RISCV::X2)
+                             .getInstr();
+    auto MI11Res = TII->isCopyInstrImpl(*MI11);
+    ASSERT_TRUE(MI11Res.has_value());
+    EXPECT_EQ(MI11Res->Destination->getReg(), RISCV::X1);
+    EXPECT_EQ(MI11Res->Source->getReg(), RISCV::X2);
+  }
 }
 
 TEST_P(RISCVInstrInfoTest, GetMemOperandsWithOffsetWidth) {


### PR DESCRIPTION
As with #132002, these do show up in a compilation of llvm-test-suite (including SPEC 2007). We remove 30-40 static instances so this isn't anything earth shattering.

rs2 is always added to the other shifted (and potentially extended) operand unmodified, so rs1==zero is equivalent to a copy.