### PR TITLE
llvm-reduce: Avoid double map lookup

### DIFF
--- a/llvm/tools/llvm-reduce/deltas/ReduceDIMetadata.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceDIMetadata.cpp
@@ -39,7 +39,7 @@ void identifyUninterestingMDNodes(Oracle &O, MDNodeList &MDs) {
     MDNode *MD = ToLook.back();
     ToLook.pop_back();
 
-    if (Visited.count(MD))
+    if (!Visited.insert(MD))
       continue;
 
     // Determine if the current MDNode is DebugInfo
@@ -55,8 +55,6 @@ void identifyUninterestingMDNodes(Oracle &O, MDNodeList &MDs) {
     for (Metadata *Op : MD->operands())
       if (MDNode *OMD = dyn_cast_or_null<MDNode>(Op))
         ToLook.push_back(OMD);
-
-    Visited.insert(MD);
   }
 
   for (auto &T : Tuples) {


### PR DESCRIPTION
Check if insert succeeded or not. This would change behavior
if there are recursive MDNodes, but I'm not sure those are a thing.