### PR TITLE
[clang][Sema] Fix typo in 'offsetof' diagnostics

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7031,10 +7031,10 @@ def err_offsetof_incomplete_type : Error<
 def err_offsetof_record_type : Error<
   "offsetof requires struct, union, or class type, %0 invalid">;
 def err_offsetof_array_type : Error<"offsetof requires array type, %0 invalid">;
-def ext_offsetof_non_pod_type : ExtWarn<"offset of on non-POD type %0">,
+def ext_offsetof_non_pod_type : ExtWarn<"offsetof on non-POD type %0">,
   InGroup<InvalidOffsetof>;
 def ext_offsetof_non_standardlayout_type : ExtWarn<
-  "offset of on non-standard-layout type %0">, InGroup<InvalidOffsetof>;
+  "offsetof on non-standard-layout type %0">, InGroup<InvalidOffsetof>;
 def err_offsetof_bitfield : Error<"cannot compute offset of bit-field %0">;
 def err_offsetof_field_of_virtual_base : Error<
   "invalid application of 'offsetof' to a field of a virtual base">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7031,7 +7031,7 @@ def err_offsetof_incomplete_type : Error<
 def err_offsetof_record_type : Error<
   "offsetof requires struct, union, or class type, %0 invalid">;
 def err_offsetof_array_type : Error<"offsetof requires array type, %0 invalid">;
-def ext_offsetof_non_pod_type : ExtWarn<"offsetof on non-POD type %0">,
+def ext_offsetof_non_pod_type : ExtWarn<"'offsetof' on non-POD type %0">,
   InGroup<InvalidOffsetof>;
 def ext_offsetof_non_standardlayout_type : ExtWarn<
   "offsetof on non-standard-layout type %0">, InGroup<InvalidOffsetof>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7034,7 +7034,7 @@ def err_offsetof_array_type : Error<"offsetof requires array type, %0 invalid">;
 def ext_offsetof_non_pod_type : ExtWarn<"'offsetof' on non-POD type %0">,
   InGroup<InvalidOffsetof>;
 def ext_offsetof_non_standardlayout_type : ExtWarn<
-  "offsetof on non-standard-layout type %0">, InGroup<InvalidOffsetof>;
+  "'offsetof' on non-standard-layout type %0">, InGroup<InvalidOffsetof>;
 def err_offsetof_bitfield : Error<"cannot compute offset of bit-field %0">;
 def err_offsetof_field_of_virtual_base : Error<
   "invalid application of 'offsetof' to a field of a virtual base">;

--- a/clang/test/SemaCXX/ms_struct.cpp
+++ b/clang/test/SemaCXX/ms_struct.cpp
@@ -25,7 +25,7 @@ struct B : public A {
 
 static_assert(__builtin_offsetof(B, d) == 12,
   "We can't allocate the bitfield into the padding under ms_struct");
-// expected-warning@-2 {{offset of on non-standard-layout type 'B'}}
+// expected-warning@-2 {{offsetof on non-standard-layout type 'B'}}
 
 struct C {
 #ifdef TEST_FOR_ERROR
@@ -39,5 +39,5 @@ struct C {
 
 static_assert(__builtin_offsetof(C, n) == 8,
               "long long field in ms_struct should be 8-byte aligned");
-// expected-warning@-2 {{offset of on non-standard-layout type 'C'}}
+// expected-warning@-2 {{offsetof on non-standard-layout type 'C'}}
 

--- a/clang/test/SemaCXX/ms_struct.cpp
+++ b/clang/test/SemaCXX/ms_struct.cpp
@@ -25,7 +25,7 @@ struct B : public A {
 
 static_assert(__builtin_offsetof(B, d) == 12,
   "We can't allocate the bitfield into the padding under ms_struct");
-// expected-warning@-2 {{offsetof on non-standard-layout type 'B'}}
+// expected-warning@-2 {{'offsetof' on non-standard-layout type 'B'}}
 
 struct C {
 #ifdef TEST_FOR_ERROR
@@ -39,5 +39,5 @@ struct C {
 
 static_assert(__builtin_offsetof(C, n) == 8,
               "long long field in ms_struct should be 8-byte aligned");
-// expected-warning@-2 {{offsetof on non-standard-layout type 'C'}}
+// expected-warning@-2 {{'offsetof' on non-standard-layout type 'C'}}
 

--- a/clang/test/SemaCXX/offsetof-0x.cpp
+++ b/clang/test/SemaCXX/offsetof-0x.cpp
@@ -11,7 +11,7 @@ struct P {
 };
 
 void f() {
-  int i = __builtin_offsetof(P, fieldThatPointsToANonPODType.m); // expected-warning{{offset of on non-standard-layout type 'P'}}
+  int i = __builtin_offsetof(P, fieldThatPointsToANonPODType.m); // expected-warning{{offsetof on non-standard-layout type 'P'}}
 }
 
 struct StandardLayout {

--- a/clang/test/SemaCXX/offsetof-0x.cpp
+++ b/clang/test/SemaCXX/offsetof-0x.cpp
@@ -11,7 +11,7 @@ struct P {
 };
 
 void f() {
-  int i = __builtin_offsetof(P, fieldThatPointsToANonPODType.m); // expected-warning{{offsetof on non-standard-layout type 'P'}}
+  int i = __builtin_offsetof(P, fieldThatPointsToANonPODType.m); // expected-warning{{'offsetof' on non-standard-layout type 'P'}}
 }
 
 struct StandardLayout {

--- a/clang/test/SemaCXX/offsetof.cpp
+++ b/clang/test/SemaCXX/offsetof.cpp
@@ -11,12 +11,12 @@ struct P {
 };
 
 void f() {
-  int i = __builtin_offsetof(P, fieldThatPointsToANonPODType.m); // expected-warning{{offset of on non-POD type 'P'}}
+  int i = __builtin_offsetof(P, fieldThatPointsToANonPODType.m); // expected-warning{{offsetof on non-POD type 'P'}}
 }
 
 struct Base { int x; };
 struct Derived : Base { int y; };
-int o = __builtin_offsetof(Derived, x); // expected-warning{{offset of on non-POD type}}
+int o = __builtin_offsetof(Derived, x); // expected-warning{{offsetof on non-POD type}}
 
 const int o2 = sizeof(__builtin_offsetof(Derived, x));
 
@@ -51,9 +51,9 @@ struct Derived2 : public Base1, public Base2 {
   int z;
 };
 
-int derived1[__builtin_offsetof(Derived2, x) == 0? 1 : -1]; // expected-warning{{offset of on non-POD type 'Derived2'}}
-int derived2[__builtin_offsetof(Derived2, y)  == 4? 1 : -1]; // expected-warning{{offset of on non-POD type 'Derived2'}}
-int derived3[__builtin_offsetof(Derived2, z)  == 8? 1 : -1]; // expected-warning{{offset of on non-POD type 'Derived2'}}
+int derived1[__builtin_offsetof(Derived2, x) == 0? 1 : -1]; // expected-warning{{offsetof on non-POD type 'Derived2'}}
+int derived2[__builtin_offsetof(Derived2, y)  == 4? 1 : -1]; // expected-warning{{offsetof on non-POD type 'Derived2'}}
+int derived3[__builtin_offsetof(Derived2, z)  == 8? 1 : -1]; // expected-warning{{offsetof on non-POD type 'Derived2'}}
 
 // offsetof referring to anonymous struct in base.
 // PR7769
@@ -66,7 +66,7 @@ struct foo {
 struct bar : public foo  {
 };
 
-int anonstruct[__builtin_offsetof(bar, x) == 0 ? 1 : -1]; // expected-warning{{offset of on non-POD type 'bar'}}
+int anonstruct[__builtin_offsetof(bar, x) == 0 ? 1 : -1]; // expected-warning{{offsetof on non-POD type 'bar'}}
 
 
 struct LtoRCheck {
@@ -81,7 +81,7 @@ struct Base {
   int Field;
 };
 struct Derived : virtual Base {
-  void Fun() { (void)__builtin_offsetof(Derived, Field); } // expected-warning {{offset of on non-POD type}} \
+  void Fun() { (void)__builtin_offsetof(Derived, Field); } // expected-warning {{offsetof on non-POD type}} \
                                                               expected-error {{invalid application of 'offsetof' to a field of a virtual base}}
 };
 }

--- a/clang/test/SemaCXX/offsetof.cpp
+++ b/clang/test/SemaCXX/offsetof.cpp
@@ -11,12 +11,12 @@ struct P {
 };
 
 void f() {
-  int i = __builtin_offsetof(P, fieldThatPointsToANonPODType.m); // expected-warning{{offsetof on non-POD type 'P'}}
+  int i = __builtin_offsetof(P, fieldThatPointsToANonPODType.m); // expected-warning{{'offsetof' on non-POD type 'P'}}
 }
 
 struct Base { int x; };
 struct Derived : Base { int y; };
-int o = __builtin_offsetof(Derived, x); // expected-warning{{offsetof on non-POD type}}
+int o = __builtin_offsetof(Derived, x); // expected-warning{{'offsetof' on non-POD type}}
 
 const int o2 = sizeof(__builtin_offsetof(Derived, x));
 
@@ -51,9 +51,9 @@ struct Derived2 : public Base1, public Base2 {
   int z;
 };
 
-int derived1[__builtin_offsetof(Derived2, x) == 0? 1 : -1]; // expected-warning{{offsetof on non-POD type 'Derived2'}}
-int derived2[__builtin_offsetof(Derived2, y)  == 4? 1 : -1]; // expected-warning{{offsetof on non-POD type 'Derived2'}}
-int derived3[__builtin_offsetof(Derived2, z)  == 8? 1 : -1]; // expected-warning{{offsetof on non-POD type 'Derived2'}}
+int derived1[__builtin_offsetof(Derived2, x) == 0? 1 : -1]; // expected-warning{{'offsetof' on non-POD type 'Derived2'}}
+int derived2[__builtin_offsetof(Derived2, y)  == 4? 1 : -1]; // expected-warning{{'offsetof' on non-POD type 'Derived2'}}
+int derived3[__builtin_offsetof(Derived2, z)  == 8? 1 : -1]; // expected-warning{{'offsetof' on non-POD type 'Derived2'}}
 
 // offsetof referring to anonymous struct in base.
 // PR7769
@@ -66,7 +66,7 @@ struct foo {
 struct bar : public foo  {
 };
 
-int anonstruct[__builtin_offsetof(bar, x) == 0 ? 1 : -1]; // expected-warning{{offsetof on non-POD type 'bar'}}
+int anonstruct[__builtin_offsetof(bar, x) == 0 ? 1 : -1]; // expected-warning{{'offsetof' on non-POD type 'bar'}}
 
 
 struct LtoRCheck {
@@ -81,7 +81,7 @@ struct Base {
   int Field;
 };
 struct Derived : virtual Base {
-  void Fun() { (void)__builtin_offsetof(Derived, Field); } // expected-warning {{offsetof on non-POD type}} \
+  void Fun() { (void)__builtin_offsetof(Derived, Field); } // expected-warning {{'offsetof' on non-POD type}} \
                                                               expected-error {{invalid application of 'offsetof' to a field of a virtual base}}
 };
 }


### PR DESCRIPTION
Before:
```
offset of on non-POD type
```
After:
```
offsetof on non-POD type
```