### PR TITLE
[AMDGPU][True16][CodeGen] remove v2i16 from srl pattern

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SIInstructions.td
@@ -2426,9 +2426,8 @@ def : GCNPat <(i1 imm:$imm),
 }
 
 let True16Predicate = UseRealTrue16Insts in
-foreach vt = [i32, v2i16] in
 def : GCNPat <
-  (vt (DivergentBinFrag<srl> VGPR_32:$src, (i32 16))),
+  (i32 (DivergentBinFrag<srl> VGPR_32:$src, (i32 16))),
   (REG_SEQUENCE VGPR_32, (i16 (EXTRACT_SUBREG $src, hi16)), lo16, (V_MOV_B16_t16_e64 0, (i16 0x0000), 0), hi16)
 >;
 


### PR DESCRIPTION
remove v2i16 from srl true16 pattern since 16bit right shift on v2i16 should not be applied with this pattern