### PR TITLE
[BOLT] Gadget scanner: analyze functions without CFG information

### DIFF
--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -804,6 +804,19 @@ public:
     return iterator_range<const_cfi_iterator>(cie_begin(), cie_end());
   }
 
+  /// Iterate over instructions (only if CFG is unavailable or not built yet).
+  iterator_range<InstrMapType::iterator> instrs() {
+    assert(!hasCFG() && "Iterate over basic blocks instead");
+    return make_range(Instructions.begin(), Instructions.end());
+  }
+  iterator_range<InstrMapType::const_iterator> instrs() const {
+    assert(!hasCFG() && "Iterate over basic blocks instead");
+    return make_range(Instructions.begin(), Instructions.end());
+  }
+
+  /// Returns whether there are any labels at Offset.
+  bool hasLabelAt(unsigned Offset) const { return Labels.count(Offset) != 0; }
+
   /// Iterate over all jump tables associated with this function.
   iterator_range<std::map<uint64_t, JumpTable *>::const_iterator>
   jumpTables() const {

--- a/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
@@ -223,6 +223,21 @@ f_unreachable_instruction:
         ret
         .size f_unreachable_instruction, .-f_unreachable_instruction
 
+// Expected false positive: without CFG, the state is reset to all-unsafe
+// after an unconditional branch.
+
+        .globl  state_is_reset_after_indirect_branch_nocfg
+        .type   state_is_reset_after_indirect_branch_nocfg,@function
+state_is_reset_after_indirect_branch_nocfg:
+// CHECK-LABEL: GS-PAUTH: non-protected ret found in function state_is_reset_after_indirect_branch_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:         ret
+// CHECK-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
+        adr     x2, 1f
+        br      x2
+1:
+        ret
+        .size state_is_reset_after_indirect_branch_nocfg, .-state_is_reset_after_indirect_branch_nocfg
+
 /// Now do a basic sanity check on every different Authentication instruction:
 
         .globl  f_autiasp

--- a/bolt/test/binary-analysis/AArch64/gs-pauth-calls.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pauth-calls.s
@@ -429,6 +429,324 @@ bad_indirect_call_mem_chain_of_auts_multi_bb:
         ret
         .size bad_indirect_call_mem_chain_of_auts_multi_bb, .-bad_indirect_call_mem_chain_of_auts_multi_bb
 
+// Tests for CFG-unaware analysis.
+//
+// All these tests use an instruction sequence like this
+//
+//      adr x2, 1f
+//      br  x2
+//    1:
+//      ; ...
+//
+// to make BOLT unable to reconstruct the control flow. Note that one can easily
+// tell whether the report corresponds to a function with or without CFG:
+// normally, the location of the gadget is described like this:
+//
+//     ... found in function <function_name>, basic block <basic block name>, at address <address>
+//
+// When CFG information is not available, this is reduced to
+//
+//     ... found in function <function_name>, at address <address>
+
+        .globl  good_direct_call_nocfg
+        .type   good_direct_call_nocfg,@function
+good_direct_call_nocfg:
+// CHECK-NOT: good_direct_call_nocfg
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        bl      callee
+
+        adr     x2, 1f
+        br      x2
+1:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size good_direct_call_nocfg, .-good_direct_call_nocfg
+
+        .globl  good_indirect_call_arg_nocfg
+        .type   good_indirect_call_arg_nocfg,@function
+good_indirect_call_arg_nocfg:
+// CHECK-NOT: good_indirect_call_arg_nocfg
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        autia   x0, x1
+        blr     x0
+
+        adr     x2, 1f
+        br      x2
+1:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size good_indirect_call_arg_nocfg, .-good_indirect_call_arg_nocfg
+
+        .globl  good_indirect_call_mem_nocfg
+        .type   good_indirect_call_mem_nocfg,@function
+good_indirect_call_mem_nocfg:
+// CHECK-NOT: good_indirect_call_mem_nocfg
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        ldr     x16, [x0]
+        autia   x16, x0
+        blr     x16
+
+        adr     x2, 1f
+        br      x2
+1:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size good_indirect_call_mem_nocfg, .-good_indirect_call_mem_nocfg
+
+        .globl  good_indirect_call_arg_v83_nocfg
+        .type   good_indirect_call_arg_v83_nocfg,@function
+good_indirect_call_arg_v83_nocfg:
+// CHECK-NOT: good_indirect_call_arg_v83_nocfg
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        blraa   x0, x1
+
+        adr     x2, 1f
+        br      x2
+1:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size good_indirect_call_arg_v83_nocfg, .-good_indirect_call_arg_v83_nocfg
+
+        .globl  good_indirect_call_mem_v83_nocfg
+        .type   good_indirect_call_mem_v83_nocfg,@function
+good_indirect_call_mem_v83_nocfg:
+// CHECK-NOT: good_indirect_call_mem_v83_nocfg
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        ldr     x16, [x0]
+        blraa   x16, x0
+
+        adr     x2, 1f
+        br      x2
+1:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size good_indirect_call_mem_v83_nocfg, .-good_indirect_call_mem_v83_nocfg
+
+        .globl  bad_indirect_call_arg_nocfg
+        .type   bad_indirect_call_arg_nocfg,@function
+bad_indirect_call_arg_nocfg:
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function bad_indirect_call_arg_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:         blr     x0
+// CHECK-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        blr     x0
+
+        adr     x2, 1f
+        br      x2
+1:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size bad_indirect_call_arg_nocfg, .-bad_indirect_call_arg_nocfg
+
+        .globl  obscure_indirect_call_arg_nocfg
+        .type   obscure_indirect_call_arg_nocfg,@function
+obscure_indirect_call_arg_nocfg:
+// CHECK-NOCFG-LABEL: GS-PAUTH: non-protected call found in function obscure_indirect_call_arg_nocfg, at address
+// CHECK-NOCFG-NEXT:  The instruction is     {{[0-9a-f]+}}:         blr     x0
+// CHECK-NOCFG-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        autia   x0, x1 // not observed by the checker
+        b       1f
+1:
+        // The register state is pessimistically reset after a label, thus
+        // the below branch instruction is reported as non-protected - this is
+        // a known false-positive.
+        blr     x0
+
+        adr     x2, 1f
+        br      x2
+1:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size obscure_good_indirect_call_arg_nocfg, .-obscure_good_indirect_call_arg_nocfg
+
+        .globl  safe_lr_at_function_entry_nocfg
+        .type   safe_lr_at_function_entry_nocfg,@function
+safe_lr_at_function_entry_nocfg:
+// CHECK-NOT: safe_lr_at_function_entry_nocfg
+        cbz     x0, 1f
+        ret                            // LR is safe at the start of the function
+1:
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        adr     x2, 2f
+        br      x2
+2:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size safe_lr_at_function_entry_nocfg, .-safe_lr_at_function_entry_nocfg
+
+        .globl  lr_is_never_unsafe_before_first_inst_nocfg
+        .type   lr_is_never_unsafe_before_first_inst_nocfg,@function
+// CHECK-NOT: lr_is_never_unsafe_before_first_inst_nocfg
+lr_is_never_unsafe_before_first_inst_nocfg:
+1:
+        // The register state is never reset before the first instruction of
+        // the function. This can lead to a known false-negative if LR is
+        // clobbered and then a jump to the very first instruction of the
+        // function is performed.
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        mov     x30, x0
+        cbz     x1, 1b
+
+        adr     x2, 2f
+        br      x2
+2:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size lr_is_never_unsafe_before_first_inst_nocfg, .-lr_is_never_unsafe_before_first_inst_nocfg
+
+        .globl  bad_indirect_call_mem_nocfg
+        .type   bad_indirect_call_mem_nocfg,@function
+bad_indirect_call_mem_nocfg:
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function bad_indirect_call_mem_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:         blr     x16
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldr     x16, [x0]
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        ldr     x16, [x0]
+        blr     x16
+
+        adr     x2, 1f
+        br      x2
+1:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size bad_indirect_call_mem_nocfg, .-bad_indirect_call_mem_nocfg
+
+        .globl  bad_indirect_call_arg_clobber_nocfg
+        .type   bad_indirect_call_arg_clobber_nocfg,@function
+bad_indirect_call_arg_clobber_nocfg:
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function bad_indirect_call_arg_clobber_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:         blr     x0
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      mov     w0, w2
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        autia   x0, x1
+        mov     w0, w2
+        blr     x0
+
+        adr     x2, 1f
+        br      x2
+1:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size bad_indirect_call_arg_clobber_nocfg, .-bad_indirect_call_arg_clobber_nocfg
+
+        .globl  bad_indirect_call_mem_clobber_nocfg
+        .type   bad_indirect_call_mem_clobber_nocfg,@function
+bad_indirect_call_mem_clobber_nocfg:
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function bad_indirect_call_mem_clobber_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:         blr     x16
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      mov     w16, w2
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        ldr     x16, [x0]
+        autia   x16, x0
+        mov     w16, w2
+        blr     x16
+
+        adr     x2, 1f
+        br      x2
+1:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size bad_indirect_call_mem_clobber_nocfg, .-bad_indirect_call_mem_clobber_nocfg
+
+        .globl  good_indirect_call_mem_chain_of_auts_nocfg
+        .type   good_indirect_call_mem_chain_of_auts_nocfg,@function
+good_indirect_call_mem_chain_of_auts_nocfg:
+// CHECK-NOT: good_indirect_call_mem_chain_of_auts_nocfg
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        ldr     x16, [x0]
+        autda   x16, x1
+        ldr     x16, [x16]
+        autia   x16, x0
+        blr     x16
+
+        adr     x2, 1f
+        br      x2
+1:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size good_indirect_call_mem_chain_of_auts_nocfg, .-good_indirect_call_mem_chain_of_auts_nocfg
+
+        .globl  bad_indirect_call_mem_chain_of_auts_nocfg
+        .type   bad_indirect_call_mem_chain_of_auts_nocfg,@function
+bad_indirect_call_mem_chain_of_auts_nocfg:
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function bad_indirect_call_mem_chain_of_auts_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:         blr     x16
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldr     x16, [x16]
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        ldr     x16, [x0]
+        autda   x16, x1
+        ldr     x16, [x16]
+        // Missing AUT of x16. The fact that x16 was authenticated above has nothing to do with it.
+        blr     x16
+
+        adr     x2, 1f
+        br      x2
+1:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size bad_indirect_call_mem_chain_of_auts_nocfg, .-bad_indirect_call_mem_chain_of_auts_nocfg
+
 // Test tail calls. To somewhat decrease the number of test cases and not
 // duplicate all of the above, only implement "mem" variant of test cases and
 // mostly test negative cases.
@@ -536,6 +854,109 @@ bad_indirect_tailcall_mem_clobber_multi_bb:
 1:
         br      x16
         .size bad_indirect_tailcall_mem_clobber_multi_bb, .-bad_indirect_tailcall_mem_clobber_multi_bb
+
+        .globl  good_direct_tailcall_nocfg
+        .type   good_direct_tailcall_nocfg,@function
+good_direct_tailcall_nocfg:
+// CHECK-NOT: good_direct_tailcall_nocfg
+        adr     x2, 1f
+        br      x2
+1:
+        b       callee
+        .size good_direct_tailcall_nocfg, .-good_direct_tailcall_nocfg
+
+        .globl  good_indirect_tailcall_mem_nocfg
+        .type   good_indirect_tailcall_mem_nocfg,@function
+good_indirect_tailcall_mem_nocfg:
+// CHECK-NOT: good_indirect_tailcall_mem_nocfg
+        adr     x2, 1f
+        br      x2
+1:
+        ldr     x16, [x0]
+        autia   x16, x0
+        br      x16
+        .size good_indirect_tailcall_mem_nocfg, .-good_indirect_tailcall_mem_nocfg
+
+        .globl  good_indirect_tailcall_mem_v83_nocfg
+        .type   good_indirect_tailcall_mem_v83_nocfg,@function
+good_indirect_tailcall_mem_v83_nocfg:
+// CHECK-NOT: good_indirect_tailcall_mem_v83_nocfg
+        adr     x2, 1f
+        br      x2
+1:
+        ldr     x16, [x0]
+        braa    x16, x0
+        .size good_indirect_tailcall_mem_v83_nocfg, .-good_indirect_tailcall_mem_v83_nocfg
+
+        .globl  bad_indirect_tailcall_mem_nocfg
+        .type   bad_indirect_tailcall_mem_nocfg,@function
+bad_indirect_tailcall_mem_nocfg:
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function bad_indirect_tailcall_mem_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:         br      x16
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldr     x16, [x0]
+        adr     x2, 1f
+        br      x2
+1:
+        ldr     x16, [x0]
+        br      x16
+        .size bad_indirect_tailcall_mem_nocfg, .-bad_indirect_tailcall_mem_nocfg
+
+        .globl  bad_indirect_tailcall_mem_clobber_nocfg
+        .type   bad_indirect_tailcall_mem_clobber_nocfg,@function
+bad_indirect_tailcall_mem_clobber_nocfg:
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function bad_indirect_tailcall_mem_clobber_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:         br      x16
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      mov     w16, w2
+        adr     x2, 1f
+        br      x2
+1:
+        ldr     x16, [x0]
+        autia   x16, x0
+        mov     w16, w2
+        br      x16
+        .size bad_indirect_tailcall_mem_clobber_nocfg, .-bad_indirect_tailcall_mem_clobber_nocfg
+
+        .globl  bad_indirect_tailcall_mem_chain_of_auts_nocfg
+        .type   bad_indirect_tailcall_mem_chain_of_auts_nocfg,@function
+bad_indirect_tailcall_mem_chain_of_auts_nocfg:
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function bad_indirect_tailcall_mem_chain_of_auts_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:         br      x16
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldr     x16, [x16]
+        adr     x2, 1f
+        br      x2
+1:
+        ldr     x16, [x0]
+        autda   x16, x1
+        ldr     x16, [x16]
+        // Missing AUT of x16. The fact that x16 was authenticated above has nothing to do with it.
+        br      x16
+        .size bad_indirect_tailcall_mem_chain_of_auts_nocfg, .-bad_indirect_tailcall_mem_chain_of_auts_nocfg
+
+        .globl  state_is_reset_at_branch_destination_nocfg
+        .type   state_is_reset_at_branch_destination_nocfg,@function
+state_is_reset_at_branch_destination_nocfg:
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function state_is_reset_at_branch_destination_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:         blr      x0
+// CHECK-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        b       1f
+        autia   x0, x1  // skipped
+1:
+        blr     x0
+
+        adr     x2, 2f
+        br      x2
+2:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size state_is_reset_at_branch_destination_nocfg, .-state_is_reset_at_branch_destination_nocfg
 
 // Test that calling a function is considered as invalidating safety of every
 // register. Note that we only have to consider "returning" function calls
@@ -692,6 +1113,156 @@ indirect_call_invalidates_safety:
         ret
         .size indirect_call_invalidates_safety, .-indirect_call_invalidates_safety
 
+        .globl  direct_call_invalidates_safety_nocfg
+        .type   direct_call_invalidates_safety_nocfg,@function
+direct_call_invalidates_safety_nocfg:
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function direct_call_invalidates_safety_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      blr     x2
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      bl      callee
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function direct_call_invalidates_safety_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      blr     x8
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      bl      callee
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function direct_call_invalidates_safety_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      blr     x10
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      bl      callee
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function direct_call_invalidates_safety_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      blr     x16
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      bl      callee
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function direct_call_invalidates_safety_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      blr     x18
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      bl      callee
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function direct_call_invalidates_safety_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      blr     x20
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      bl      callee
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        mov     x2, x0
+        autiza  x2
+        bl      callee
+        blr     x2
+
+        mov     x8, x0
+        autiza  x8
+        bl      callee
+        blr     x8
+
+        mov     x10, x0
+        autiza  x10
+        bl      callee
+        blr     x10
+
+        mov     x16, x0
+        autiza  x16
+        bl      callee
+        blr     x16
+
+        mov     x18, x0
+        autiza  x18
+        bl      callee
+        blr     x18
+
+        mov     x20, x0
+        autiza  x20
+        bl      callee
+        blr     x20
+
+        adr     x2, 1f
+        br      x2
+1:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size direct_call_invalidates_safety_nocfg, .-direct_call_invalidates_safety_nocfg
+
+        .globl  indirect_call_invalidates_safety_nocfg
+        .type   indirect_call_invalidates_safety_nocfg,@function
+indirect_call_invalidates_safety_nocfg:
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function indirect_call_invalidates_safety_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      blr     x2
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      blr     x2
+// Check that only one error is reported per pair of BLRs.
+// CHECK-NOT:   The instruction is     {{[0-9a-f]+}}:      blr     x2
+
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function indirect_call_invalidates_safety_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      blr     x8
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      blr     x8
+// CHECK-NOT:   The instruction is     {{[0-9a-f]+}}:      blr     x8
+
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function indirect_call_invalidates_safety_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      blr     x10
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      blr     x10
+// CHECK-NOT:   The instruction is     {{[0-9a-f]+}}:      blr     x10
+
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function indirect_call_invalidates_safety_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      blr     x16
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      blr     x16
+// CHECK-NOT:   The instruction is     {{[0-9a-f]+}}:      blr     x16
+
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function indirect_call_invalidates_safety_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      blr     x18
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      blr     x18
+// CHECK-NOT:   The instruction is     {{[0-9a-f]+}}:      blr     x18
+
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function indirect_call_invalidates_safety_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      blr     x20
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      blr     x20
+// CHECK-NOT:   The instruction is     {{[0-9a-f]+}}:      blr     x20
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        mov     x2, x0
+        autiza  x2
+        blr     x2              // protected call, but makes x2 unsafe
+        blr     x2              // unprotected call
+
+        mov     x8, x0
+        autiza  x8
+        blr     x8              // protected call, but makes x8 unsafe
+        blr     x8              // unprotected call
+
+        mov     x10, x0
+        autiza  x10
+        blr     x10             // protected call, but makes x10 unsafe
+        blr     x10             // unprotected call
+
+        mov     x16, x0
+        autiza  x16
+        blr     x16             // protected call, but makes x16 unsafe
+        blr     x16             // unprotected call
+
+        mov     x18, x0
+        autiza  x18
+        blr     x18             // protected call, but makes x18 unsafe
+        blr     x18             // unprotected call
+
+        mov     x20, x0
+        autiza  x20
+        blr     x20             // protected call, but makes x20 unsafe
+        blr     x20             // unprotected call
+
+        adr     x2, 1f
+        br      x2
+1:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size indirect_call_invalidates_safety_nocfg, .-indirect_call_invalidates_safety_nocfg
+
 // Test that fused auth+use Armv8.3 instruction do not mark register as safe.
 
         .globl  blraa_no_mark_safe
@@ -721,6 +1292,28 @@ blraa_no_mark_safe:
         autiasp
         ret
         .size blraa_no_mark_safe, .-blraa_no_mark_safe
+
+        .globl  blraa_no_mark_safe_nocfg
+        .type   blraa_no_mark_safe_nocfg,@function
+blraa_no_mark_safe_nocfg:
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function blraa_no_mark_safe_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      blr     x0
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      blraa   x0, x1
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        blraa   x0, x1  // safe, no write-back, clobbers everything
+        blr     x0      // detected as unsafe
+
+        adr     x2, 1f
+        br      x2
+1:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size blraa_no_mark_safe_nocfg, .-blraa_no_mark_safe_nocfg
 
 // Check that the correct set of registers is used to compute the set of last
 // writing instructions: both x16 and x17 are tracked in this function, but
@@ -773,6 +1366,65 @@ last_insts_writing_to_reg:
         autiasp
         ret
         .size last_insts_writing_to_reg, .-last_insts_writing_to_reg
+
+        .globl  last_insts_writing_to_reg_nocfg
+        .type   last_insts_writing_to_reg_nocfg,@function
+last_insts_writing_to_reg_nocfg:
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function last_insts_writing_to_reg_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:         blr     x16
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldr     x16, [x0]
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function last_insts_writing_to_reg_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:         blr     x17
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldr     x17, [x1]
+        paciasp
+        stp     x29, x30, [sp, #-16]!
+        mov     x29, sp
+
+        ldr     x16, [x0]
+        blr     x16
+        ldr     x17, [x1]
+        blr     x17
+
+        adr     x2, 1f
+        br      x2
+1:
+        ldp     x29, x30, [sp], #16
+        autiasp
+        ret
+        .size last_insts_writing_to_reg_nocfg, .-last_insts_writing_to_reg_nocfg
+
+// Test that the instructions reported to the user are not cluttered with
+// annotations attached by data-flow analysis or its CFG-unaware counterpart.
+
+        .globl  printed_instrs_dataflow
+        .type   printed_instrs_dataflow,@function
+printed_instrs_dataflow:
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function printed_instrs_dataflow, basic block {{[^,]+}}, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:         br      x0 # TAILCALL{{ *$}}
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldr     x0, [x0]{{ *$}}
+// CHECK-NEXT:  This happens in the following basic block:
+// CHECK-NEXT:  {{[0-9a-f]+}}:   ldr     x0, [x0]{{ *$}}
+// CHECK-NEXT:  {{[0-9a-f]+}}:   br      x0 # TAILCALL{{ *$}}
+        ldr     x0, [x0]
+        br      x0
+        .size   printed_instrs_dataflow, .-printed_instrs_dataflow
+
+        .globl  printed_instrs_nocfg
+        .type   printed_instrs_nocfg,@function
+printed_instrs_nocfg:
+// CHECK-LABEL: GS-PAUTH: non-protected call found in function printed_instrs_nocfg, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:         br      x0 # UNKNOWN CONTROL FLOW # Offset: 12{{ *$}}
+// CHECK-NEXT:  The 1 instructions that write to the affected registers after any authentication are:
+// CHECK-NEXT:  1.     {{[0-9a-f]+}}:      ldr     x0, [x0]{{ *$}}
+        adr     x2, 1f
+        br      x2
+1:
+        ldr     x0, [x0]
+        br      x0
+        .size   printed_instrs_nocfg, .-printed_instrs_nocfg
 
         .globl  main
         .type   main,@function

--- a/bolt/test/binary-analysis/AArch64/gs-pauth-debug-output.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pauth-debug-output.s
@@ -57,7 +57,7 @@ simple:
 // CHECK-NEXT:     .. result: (src-state<SafeToDerefRegs: , Insts: >)
 // CHECK-NEXT:   SrcSafetyAnalysis::ComputeNext(   b       [[BB1]], src-state<SafeToDerefRegs: , Insts: >)
 // CHECK-NEXT:     .. result: (src-state<SafeToDerefRegs: , Insts: >)
-// CHECK-NEXT:   SrcSafetyAnalysis::Confluence(
+// CHECK-NEXT:   DataflowSrcSafetyAnalysis::Confluence(
 // CHECK-NEXT:     State 1: src-state<empty>
 // CHECK-NEXT:     State 2: src-state<SafeToDerefRegs: , Insts: >)
 // CHECK-NEXT:     merged state: src-state<SafeToDerefRegs: , Insts: >
@@ -71,7 +71,7 @@ simple:
 // CHECK-NEXT:     .. result: (src-state<SafeToDerefRegs: LR W30 W30_HI , Insts: >)
 // CHECK-NEXT:   SrcSafetyAnalysis::ComputeNext(   ret     x30, src-state<SafeToDerefRegs: LR W30 W30_HI , Insts: >)
 // CHECK-NEXT:     .. result: (src-state<SafeToDerefRegs: LR W30 W30_HI , Insts: >)
-// CHECK-NEXT:   SrcSafetyAnalysis::Confluence(
+// CHECK-NEXT:   DataflowSrcSafetyAnalysis::Confluence(
 // CHECK-NEXT:     State 1: src-state<SafeToDerefRegs: , Insts: >
 // CHECK-NEXT:     State 2: src-state<SafeToDerefRegs: , Insts: >)
 // CHECK-NEXT:     merged state: src-state<SafeToDerefRegs: , Insts: >
@@ -94,27 +94,27 @@ simple:
 // CHECK-NEXT: }
 // CHECK-NEXT: [[BB0]] (3 instructions, align : 1)
 // CHECK-NEXT:   Entry Point
-// CHECK-NEXT:     00000000:   paciasp # SrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
-// CHECK-NEXT:     00000004:   stp     x29, x30, [sp, #-0x10]! # SrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
-// CHECK-NEXT:     00000008:   b       [[BB1]] # SrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
+// CHECK-NEXT:     00000000:   paciasp # DataflowSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
+// CHECK-NEXT:     00000004:   stp     x29, x30, [sp, #-0x10]! # DataflowSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
+// CHECK-NEXT:     00000008:   b       [[BB1]] # DataflowSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
 // CHECK-NEXT:   Successors: [[BB1]]
 // CHECK-EMPTY:
 // CHECK-NEXT: [[BB1]] (5 instructions, align : 1)
 // CHECK-NEXT:   Predecessors: [[BB0]]
-// CHECK-NEXT:     0000000c:   autiza  x0 # SrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
-// CHECK-NEXT:     00000010:   blr     x0 # SrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
-// CHECK-NEXT:     00000014:   ldp     x29, x30, [sp], #0x10 # SrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
-// CHECK-NEXT:     00000018:   autiasp # SrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
-// CHECK-NEXT:     0000001c:   ret # SrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
+// CHECK-NEXT:     0000000c:   autiza  x0 # DataflowSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
+// CHECK-NEXT:     00000010:   blr     x0 # DataflowSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
+// CHECK-NEXT:     00000014:   ldp     x29, x30, [sp], #0x10 # DataflowSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
+// CHECK-NEXT:     00000018:   autiasp # DataflowSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
+// CHECK-NEXT:     0000001c:   ret # DataflowSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
 // CHECK-EMPTY:
 // CHECK-NEXT: DWARF CFI Instructions:
 // CHECK-NEXT:     <empty>
 // CHECK-NEXT: End of Function "simple"
 // CHECK-EMPTY:
-// PAUTH-NEXT:   Found call inst:     00000000:        blr     x0 # SrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
+// PAUTH-NEXT:   Found call inst:     00000000:        blr     x0 # DataflowSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
 // PAUTH-NEXT:     Call destination reg: X0
 // PAUTH-NEXT:     SafeToDerefRegs: W0 X0 W0_HI{{[ \t]*$}}
-// CHECK-NEXT:   Found RET inst:     00000000:         ret # SrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
+// CHECK-NEXT:   Found RET inst:     00000000:         ret # DataflowSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
 // CHECK-NEXT:     RetReg: LR
 // CHECK-NEXT:     Authenticated reg: (none)
 // CHECK-NEXT:     SafeToDerefRegs: LR W30 W30_HI{{[ \t]*$}}
@@ -141,7 +141,7 @@ clobber:
 // The above output was printed after first run of analysis
 
 // CHECK-EMPTY:
-// CHECK-NEXT:   Found RET inst:     00000000:         ret # SrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
+// CHECK-NEXT:   Found RET inst:     00000000:         ret # DataflowSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
 // CHECK-NEXT:     RetReg: LR
 // CHECK-NEXT:     Authenticated reg: (none)
 // CHECK-NEXT:     SafeToDerefRegs: W30_HI{{[ \t]*$}}
@@ -160,8 +160,96 @@ clobber:
 // Iterating over the reports and attaching clobbering info:
 
 // CHECK-EMPTY:
-// CHECK-NEXT:   Attaching clobbering info to:     00000000:         ret # SrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: [0](0x{{[0-9a-f]+}} )>
+// CHECK-NEXT:   Attaching clobbering info to:     00000000:         ret # DataflowSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: [0](0x{{[0-9a-f]+}} )>
 
+        .globl  nocfg
+        .type   nocfg,@function
+nocfg:
+        adr     x0, 1f
+        br      x0
+1:
+        ret
+        .size nocfg, .-nocfg
+
+// CHECK-LABEL:Analyzing in function nocfg, AllocatorId 1
+// CHECK-NEXT: Binary Function "nocfg"  {
+// CHECK-NEXT:   Number      : 3
+// CHECK-NEXT:   State       : disassembled
+// ...
+// CHECK:        IsSimple    : 0
+// CHECK-NEXT:   IsMultiEntry: 1
+// CHECK-NEXT:   IsSplit     : 0
+// CHECK-NEXT:   BB Count    : 0
+// CHECK-NEXT:   Secondary Entry Points : __ENTRY_nocfg@0x[[ENTRY_ADDR:[0-9a-f]+]]
+// CHECK-NEXT: }
+// CHECK-NEXT: .{{[A-Za-z0-9]+}}:
+// CHECK-NEXT:     00000000:   adr     x0, __ENTRY_nocfg@0x[[ENTRY_ADDR]]
+// CHECK-NEXT:     00000004:   br      x0 # UNKNOWN CONTROL FLOW # Offset: 4
+// CHECK-NEXT: __ENTRY_nocfg@0x[[ENTRY_ADDR]] (Entry Point):
+// CHECK-NEXT: .{{[A-Za-z0-9]+}}:
+// CHECK-NEXT:     00000008:   ret # Offset: 8
+// CHECK-NEXT: DWARF CFI Instructions:
+// CHECK-NEXT:     <empty>
+// CHECK-NEXT: End of Function "nocfg"
+// CHECK-EMPTY:
+// CHECK-NEXT: Running src register safety analysis...
+// CHECK-NEXT:   SrcSafetyAnalysis::ComputeNext(   adr     x0, __ENTRY_nocfg@0x[[ENTRY_ADDR]], src-state<SafeToDerefRegs: LR W30 W30_HI , Insts: >)
+// CHECK-NEXT:     .. result: (src-state<SafeToDerefRegs: LR W0 W30 X0 W0_HI W30_HI , Insts: >)
+// CHECK-NEXT:   SrcSafetyAnalysis::ComputeNext(  br      x0, src-state<SafeToDerefRegs: LR W0 W30 X0 W0_HI W30_HI , Insts: >)
+// CHECK-NEXT:     .. result: (src-state<SafeToDerefRegs: LR W0 W30 X0 W0_HI W30_HI , Insts: >)
+// CHECK-NEXT:   Due to label, resetting the state before:     00000000:       ret # Offset: 8
+// CHECK-NEXT:   SrcSafetyAnalysis::ComputeNext(  ret     x30, src-state<SafeToDerefRegs: , Insts: >)
+// CHECK-NEXT:     .. result: (src-state<SafeToDerefRegs: , Insts: >)
+// CHECK-NEXT: After src register safety analysis:
+// CHECK-NEXT: Binary Function "nocfg"  {
+// CHECK-NEXT:   Number      : 3
+// CHECK-NEXT:   State       : disassembled
+// ...
+// CHECK:        Secondary Entry Points : __ENTRY_nocfg@0x[[ENTRY_ADDR]]
+// CHECK-NEXT: }
+// CHECK-NEXT: .{{[A-Za-z0-9]+}}:
+// CHECK-NEXT:     00000000:   adr     x0, __ENTRY_nocfg@0x[[ENTRY_ADDR]] # CFGUnawareSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
+// CHECK-NEXT:     00000004:   br      x0 # UNKNOWN CONTROL FLOW # Offset: 4 # CFGUnawareSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
+// CHECK-NEXT: __ENTRY_nocfg@0x[[ENTRY_ADDR]] (Entry Point):
+// CHECK-NEXT: .{{[A-Za-z0-9]+}}:
+// CHECK-NEXT:     00000008:   ret # Offset: 8 # CFGUnawareSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
+// CHECK-NEXT: DWARF CFI Instructions:
+// CHECK-NEXT:     <empty>
+// CHECK-NEXT: End of Function "nocfg"
+// CHECK-EMPTY:
+// PAUTH-NEXT:   Found call inst:     00000000:        br      x0 # UNKNOWN CONTROL FLOW # Offset: 4 # CFGUnawareSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
+// PAUTH-NEXT:     Call destination reg: X0
+// PAUTH-NEXT:     SafeToDerefRegs: LR W0 W30 X0 W0_HI W30_HI
+// CHECK-NEXT:   Found RET inst:     00000000:         ret # Offset: 8 # CFGUnawareSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: >
+// CHECK-NEXT:     RetReg: LR
+// CHECK-NEXT:     Authenticated reg: (none)
+// CHECK-NEXT:     SafeToDerefRegs:
+// CHECK-EMPTY:
+// CHECK-NEXT: Running detailed src register safety analysis...
+// CHECK-NEXT:   SrcSafetyAnalysis::ComputeNext(   adr     x0, __ENTRY_nocfg@0x[[ENTRY_ADDR]], src-state<SafeToDerefRegs: LR W30 W30_HI , Insts: [0]()>)
+// CHECK-NEXT:     .. result: (src-state<SafeToDerefRegs: LR W0 W30 X0 W0_HI W30_HI , Insts: [0]()>)
+// CHECK-NEXT:   SrcSafetyAnalysis::ComputeNext(  br      x0, src-state<SafeToDerefRegs: LR W0 W30 X0 W0_HI W30_HI , Insts: [0]()>)
+// CHECK-NEXT:     .. result: (src-state<SafeToDerefRegs: LR W0 W30 X0 W0_HI W30_HI , Insts: [0]()>)
+// CHECK-NEXT:   Due to label, resetting the state before:     00000000:       ret # Offset: 8
+// CHECK-NEXT:   SrcSafetyAnalysis::ComputeNext(  ret     x30, src-state<SafeToDerefRegs: , Insts: [0]()>)
+// CHECK-NEXT:     .. result: (src-state<SafeToDerefRegs: , Insts: [0]()>)
+// CHECK-NEXT: After detailed src register safety analysis:
+// CHECK-NEXT: Binary Function "nocfg"  {
+// CHECK-NEXT:   Number      : 3
+// ...
+// CHECK:        Secondary Entry Points : __ENTRY_nocfg@0x[[ENTRY_ADDR]]
+// CHECK-NEXT: }
+// CHECK-NEXT: .{{[A-Za-z0-9]+}}:
+// CHECK-NEXT:     00000000:   adr     x0, __ENTRY_nocfg@0x[[ENTRY_ADDR]] # CFGUnawareSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: [0]()>
+// CHECK-NEXT:     00000004:   br      x0 # UNKNOWN CONTROL FLOW # Offset: 4 # CFGUnawareSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: [0]()>
+// CHECK-NEXT: __ENTRY_nocfg@0x[[ENTRY_ADDR]] (Entry Point):
+// CHECK-NEXT: .{{[A-Za-z0-9]+}}:
+// CHECK-NEXT:     00000008:   ret # Offset: 8 # CFGUnawareSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: [0]()>
+// CHECK-NEXT: DWARF CFI Instructions:
+// CHECK-NEXT:     <empty>
+// CHECK-NEXT: End of Function "nocfg"
+// CHECK-EMPTY:
+// CHECK-NEXT:   Attaching clobbering info to:     00000000:   ret # Offset: 8 # CFGUnawareSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, Insts: [0]()>
 
 // CHECK-LABEL:Analyzing in function main, AllocatorId 1
         .globl  main


### PR DESCRIPTION
Support simple analysis of the functions for which BOLT is unable to
reconstruct the CFG. This patch is inspired by the approach implemented
by Kristof Beyls in the original prototype of gadget scanner, but a
CFG-unaware counterpart of the data-flow analysis is implemented
instead of separate version of gadget detector, as multiple gadget kinds
are detected now.