### PR TITLE
[OFFLOAD] Stricter enforcement of user offload disable

### DIFF
--- a/offload/include/OffloadPolicy.h
+++ b/offload/include/OffloadPolicy.h
@@ -51,8 +51,8 @@ class OffloadPolicy {
 
 public:
   static bool isOffloadDisabled() {
-    return static_cast<kmp_target_offload_kind_t>(__kmpc_get_target_offload())
-            ==  tgt_disabled;
+    return static_cast<kmp_target_offload_kind_t>(
+               __kmpc_get_target_offload()) == tgt_disabled;
   }
 
   static const OffloadPolicy &get(PluginManager &PM) {

--- a/offload/include/OffloadPolicy.h
+++ b/offload/include/OffloadPolicy.h
@@ -53,11 +53,7 @@ class OffloadPolicy {
 
 public:
   static bool isOffloadDisabled() {
-    if((kmp_target_offload_kind_t)__kmpc_get_target_offload() == 
-        tgt_disabled) {
-      return true;
-    }
-    return false;
+    return static_cast<kmp_target_offload_kind_t>(__kmpc_get_target_offload()) ==  tgt_disabled);
   }
 
   static const OffloadPolicy &get(PluginManager &PM) {

--- a/offload/include/OffloadPolicy.h
+++ b/offload/include/OffloadPolicy.h
@@ -36,8 +36,6 @@ class OffloadPolicy {
       Kind = MANDATORY;
       return;
     default:
-      // User didn't specify a policy, decide
-      // based on number of devices discovered
       if (PM.getNumDevices()) {
         DP("Default TARGET OFFLOAD policy is now mandatory "
            "(devices were found)\n");

--- a/offload/include/OffloadPolicy.h
+++ b/offload/include/OffloadPolicy.h
@@ -51,7 +51,8 @@ class OffloadPolicy {
 
 public:
   static bool isOffloadDisabled() {
-    return static_cast<kmp_target_offload_kind_t>(__kmpc_get_target_offload()) ==  tgt_disabled);
+    return static_cast<kmp_target_offload_kind_t>(__kmpc_get_target_offload())
+            ==  tgt_disabled;
   }
 
   static const OffloadPolicy &get(PluginManager &PM) {

--- a/offload/libomptarget/OffloadRTL.cpp
+++ b/offload/libomptarget/OffloadRTL.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "OffloadPolicy.h"
 #include "OpenMP/OMPT/Callback.h"
 #include "PluginManager.h"
 

--- a/offload/libomptarget/OffloadRTL.cpp
+++ b/offload/libomptarget/OffloadRTL.cpp
@@ -40,10 +40,6 @@ void initRuntime() {
     llvm::omp::target::ompt::connectLibrary();
 #endif
 
-    if (OffloadPolicy::isOffloadDisabled()) {
-      DP("Offload is disabled. Skipping plugin initialization\n");
-      return;
-    }
     PM->init();
     PM->registerDelayedLibraries();
   }

--- a/offload/libomptarget/OffloadRTL.cpp
+++ b/offload/libomptarget/OffloadRTL.cpp
@@ -32,7 +32,7 @@ void initRuntime() {
   if (PM == nullptr)
     PM = new PluginManager();
 
-  if (OffloadPolicy::get().Kind == OffloadPolicy::DISABLED) {
+  if (OffloadPolicy::isOffloadDisabled()) {
     DP("Offload is disabled. Skipping library initialization\n");
     // Do only absolutely needed initialization
     return;

--- a/offload/libomptarget/OffloadRTL.cpp
+++ b/offload/libomptarget/OffloadRTL.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "OffloadPolicy.h"
 #include "OpenMP/OMPT/Callback.h"
 #include "PluginManager.h"
 
@@ -30,6 +31,12 @@ void initRuntime() {
 
   if (PM == nullptr)
     PM = new PluginManager();
+
+  if (OffloadPolicy::get().Kind == OffloadPolicy::DISABLED) {
+    DP("Offload is disabled. Skipping library initialization\n");
+    // Do only absolutely needed initialization
+    return;
+  }
 
   RefCount++;
   if (RefCount == 1) {

--- a/offload/libomptarget/OffloadRTL.cpp
+++ b/offload/libomptarget/OffloadRTL.cpp
@@ -32,12 +32,6 @@ void initRuntime() {
   if (PM == nullptr)
     PM = new PluginManager();
 
-  if (OffloadPolicy::isOffloadDisabled()) {
-    DP("Offload is disabled. Skipping library initialization\n");
-    // Do only absolutely needed initialization
-    return;
-  }
-
   RefCount++;
   if (RefCount == 1) {
     DP("Init offload library!\n");
@@ -46,6 +40,10 @@ void initRuntime() {
     llvm::omp::target::ompt::connectLibrary();
 #endif
 
+    if (OffloadPolicy::isOffloadDisabled()) {
+      DP("Offload is disabled. Skipping plugin initialization\n");
+      return;
+    }
     PM->init();
     PM->registerDelayedLibraries();
   }

--- a/offload/libomptarget/PluginManager.cpp
+++ b/offload/libomptarget/PluginManager.cpp
@@ -30,6 +30,11 @@ PluginManager *PM = nullptr;
 
 void PluginManager::init() {
   TIMESCOPE();
+  if (OffloadPolicy::isOffloadDisabled()) {
+    DP("Offload is disabled. Skipping plugin initialization\n");
+    return;
+  }
+
   DP("Loading RTLs...\n");
 
   // Attempt to create an instance of each supported plugin.

--- a/offload/libomptarget/PluginManager.cpp
+++ b/offload/libomptarget/PluginManager.cpp
@@ -11,10 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "PluginManager.h"
+#include "OffloadPolicy.h"
 #include "Shared/Debug.h"
 #include "Shared/Profile.h"
 #include "device.h"
-#include "OffloadPolicy.h"
 
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"

--- a/offload/libomptarget/PluginManager.cpp
+++ b/offload/libomptarget/PluginManager.cpp
@@ -14,6 +14,7 @@
 #include "Shared/Debug.h"
 #include "Shared/Profile.h"
 #include "device.h"
+#include "OffloadPolicy.h"
 
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"


### PR DESCRIPTION
If user specifies offload is disabled (e.g., OMP_TARGET_OFFLOAD=disable), disable library almost completely. This reduces resources spent to a minimum and ensures all APIs behave as if the only available device is the host device.

Currently some of the APIs behave as if there were devices avaible for offload even when under OMP_TARGET_OFFLOAD=disable.