### PR TITLE
[libc] Add maintainers file

### DIFF
--- a/libc/Maintainers.rst
+++ b/libc/Maintainers.rst
@@ -26,10 +26,17 @@ Math
 ----
 | Tue Ly
 | lntue\@google.com (email), `lntue <https://github.com/lntue>`_ (github)
+| Nicolas Celik
+| its.overmighty\@gmail.com (email), `OverMighty <https://github.com/overmighty>`_ (github)
 
 Threading
 ---------
 | Yifan Zhu
 | yifanzhu\@rochester.edu (email), `Schrodinger ZHU Yifan <https://github.com/schrodingerzhu>`_ (github)
+
+UEFI
+----
+| Tristan Ross
+| tristan.ross\@midstall.com (email), `RossComputerGuy <https://github.com/RossComputerGuy>`_ (github)
 
 .. TODO: add "Inactive Maintainers" section when needed.

--- a/libc/Maintainers.rst
+++ b/libc/Maintainers.rst
@@ -17,6 +17,16 @@ Lead Maintainer
 | Michael Jones
 | michaelrj\@google.com (email), `michaelrj-google <https://github.com/michaelrj-google>`_ (github)
 
+Baremetal
+---------
+| Petr Hosek
+| phosek\@google.com (email), `petrhosek <https://github.com/petrhosek>`_ (github)
+
+Fixed Point
+-----------
+| Leonard Chan
+| leonardchan\@google.com (email), `PiJoules <https://github.com/PiJoules>`_ (github)
+
 GPU
 ---
 | Joseph Huber

--- a/libc/Maintainers.rst
+++ b/libc/Maintainers.rst
@@ -1,0 +1,35 @@
+=====================
+LLVM-libc Maintainers
+=====================
+
+This file is a list of the
+`maintainers <https://llvm.org/docs/DeveloperPolicy.html#maintainers>`_ for
+LLVM-libc. The following people are the active maintainers for the project.
+Please reach out to them for code reviews, questions about their area of
+expertise, or other assistance.
+
+.. contents::
+   :depth: 1
+   :local:
+
+Lead Maintainer
+---------------
+| Michael Jones
+| michaelrj\@google.com (email), `michaelrj-google <https://github.com/michaelrj-google>`_ (github)
+
+GPU
+---
+| Joseph Huber
+| joseph.huber\@amd.com (email), `jhuber6 <https://github.com/jhuber6>`_ (github)
+
+Math
+----
+| Tue Ly
+| lntue\@google.com (email), `lntue <https://github.com/lntue>`_ (github)
+
+Threading
+---------
+| Yifan Zhu
+| yifanzhu\@rochester.edu (email), `Schrodinger ZHU Yifan <https://github.com/schrodingerzhu>`_ (github)
+
+.. TODO: add "Inactive Maintainers" section when needed.

--- a/libc/docs/CMakeLists.txt
+++ b/libc/docs/CMakeLists.txt
@@ -8,7 +8,12 @@ if (SPHINX_FOUND)
     # want the dynamically generated .rst files to pollute the source tree.
     add_custom_target(copy-libc-rst-docs
       COMMAND "${CMAKE_COMMAND}" -E copy_directory
-              "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+              "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}"
+
+      COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+              "${CMAKE_CURRENT_SOURCE_DIR}/../Maintainers.rst"
+              "${CMAKE_CURRENT_BINARY_DIR}"
+      )
 
     # For headers that are nested in directories, we need to
     # `mkdir $build_dir/libc/docs/headers/$dir` since the above copy_directory

--- a/libc/docs/Maintainers.rst
+++ b/libc/docs/Maintainers.rst
@@ -1,0 +1,1 @@
+.. include:: ../Maintainers.rst

--- a/libc/docs/index.rst
+++ b/libc/docs/index.rst
@@ -71,6 +71,7 @@ LLVM-libc aspires to a unique place in the software ecosystem.  The goals are:
    :maxdepth: 1
    :caption: Development
 
+   Maintainers
    build_and_test
    dev/index.rst
    porting

--- a/llvm/Maintainers.md
+++ b/llvm/Maintainers.md
@@ -467,6 +467,8 @@ Some subprojects maintain their own list of per-component maintainers.
 
 [libc++ maintainers](https://github.com/llvm/llvm-project/blob/main/libcxx/Maintainers.md)
 
+[Libc maintainers](https://github.com/llvm/llvm-project/blob/main/libc/Maintainers.rst)
+
 [libclc maintainers](https://github.com/llvm/llvm-project/blob/main/libclc/Maintainers.md)
 
 [LLD maintainers](https://github.com/llvm/llvm-project/blob/main/lld/Maintainers.md)


### PR DESCRIPTION
Based on #133297 by jhuber.

LLVM-libc needs a maintainers file, this patch adds an initial set.
The file is based on `clang/maintainers.rst` and
https://llvm.org/docs/DeveloperPolicy.html#maintainers.
