### PR TITLE
[KeyInstr] Inline atom info

### DIFF
--- a/llvm/lib/IR/DebugLoc.cpp
+++ b/llvm/lib/IR/DebugLoc.cpp
@@ -135,6 +135,7 @@ DebugLoc DebugLoc::appendInlinedAt(const DebugLoc &DL, DILocation *InlinedAt,
   // Starting from the top, rebuild the nodes to point to the new inlined-at
   // location (then rebuilding the rest of the chain behind it) and update the
   // map of already-constructed inlined-at nodes.
+  // Key Instructions: InlinedAt fields don't need atom info.
   for (const DILocation *MD : reverse(InlinedAtLocations))
     Cache[MD] = Last = DILocation::getDistinct(
         Ctx, MD->getLine(), MD->getColumn(), MD->getScope(), Last);

--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -1819,7 +1819,8 @@ static DebugLoc inlineDebugLoc(DebugLoc OrigDL, DILocation *InlinedAt,
                                DenseMap<const MDNode *, MDNode *> &IANodes) {
   auto IA = DebugLoc::appendInlinedAt(OrigDL, InlinedAt, Ctx, IANodes);
   return DILocation::get(Ctx, OrigDL.getLine(), OrigDL.getCol(),
-                         OrigDL.getScope(), IA);
+                         OrigDL.getScope(), IA, OrigDL.isImplicitCode(),
+                         OrigDL->getAtomGroup(), OrigDL->getAtomRank());
 }
 
 /// Update inlined instructions' line numbers to

--- a/llvm/test/DebugInfo/KeyInstructions/Generic/inline.ll
+++ b/llvm/test/DebugInfo/KeyInstructions/Generic/inline.ll
@@ -16,20 +16,20 @@ entry:
   %a.addr = alloca i32, align 4
   %x = alloca i32, align 4
   store i32 %a, ptr %a.addr, align 4
-  %0 = load i32, ptr %a.addr, align 4, !dbg !18
-  %mul = mul nsw i32 %0, 2, !dbg !18
+  %0 = load i32, ptr %a.addr, align 4
+  %mul = mul nsw i32 %0, 2
   %add = add nsw i32 %mul, 1, !dbg !19
   store i32 %add, ptr %x, align 4, !dbg !20
-  ret void, !dbg !22
+  ret void
 }
 
 define hidden void @_Z1gi(i32 noundef %b) !dbg !23 {
 entry:
   %b.addr = alloca i32, align 4
   store i32 %b, ptr %b.addr, align 4
-  %0 = load i32, ptr %b.addr, align 4, !dbg !24
+  %0 = load i32, ptr %b.addr, align 4
   call void @_Z1fi(i32 noundef %0), !dbg !24
-  ret void, !dbg !25
+  ret void
 }
 
 !llvm.dbg.cu = !{!0}
@@ -44,10 +44,8 @@ entry:
 !11 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 1, type: !12, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
 !12 = !DISubroutineType(types: !13)
 !13 = !{}
-!18 = !DILocation(line: 2, scope: !11)
 !19 = !DILocation(line: 2, scope: !11, atomGroup: 1, atomRank: 2)
 !20 = !DILocation(line: 2, scope: !11, atomGroup: 1, atomRank: 1)
-!22 = !DILocation(line: 3, scope: !11, atomGroup: 2, atomRank: 1)
 !23 = distinct !DISubprogram(name: "g", scope: !1, file: !1, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
 !24 = !DILocation(line: 5, scope: !23)
-!25 = !DILocation(line: 6, scope: !23, atomGroup: 1, atomRank: 1)
+

--- a/llvm/test/DebugInfo/KeyInstructions/Generic/inline.ll
+++ b/llvm/test/DebugInfo/KeyInstructions/Generic/inline.ll
@@ -1,0 +1,53 @@
+; RUN: opt %s -passes=inline -S -o - | FileCheck %s
+
+;; Inline `f` into `g`. The inlined assignment store and add should retain
+;; their atom info.
+
+; CHECK: _Z1gi
+; CHECK-NOT: _Z1fi
+; CHECK: %add.i = add nsw i32 %mul.i, 1, !dbg [[G1R2:!.*]]
+; CHECK-NEXT: store i32 %add.i, ptr %x.i, align 4, !dbg [[G1R1:!.*]]
+
+; CHECK: [[G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+; CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+
+define hidden void @_Z1fi(i32 noundef %a) !dbg !11 {
+entry:
+  %a.addr = alloca i32, align 4
+  %x = alloca i32, align 4
+  store i32 %a, ptr %a.addr, align 4
+  %0 = load i32, ptr %a.addr, align 4, !dbg !18
+  %mul = mul nsw i32 %0, 2, !dbg !18
+  %add = add nsw i32 %mul, 1, !dbg !19
+  store i32 %add, ptr %x, align 4, !dbg !20
+  ret void, !dbg !22
+}
+
+define hidden void @_Z1gi(i32 noundef %b) !dbg !23 {
+entry:
+  %b.addr = alloca i32, align 4
+  store i32 %b, ptr %b.addr, align 4
+  %0 = load i32, ptr %b.addr, align 4, !dbg !24
+  call void @_Z1fi(i32 noundef %0), !dbg !24
+  ret void, !dbg !25
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3}
+!llvm.ident = !{!10}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_17, file: !1, producer: "clang version 19.0.0", isOptimized: true, runtimeVersion: 0, emissionKind: LineTablesOnly, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "test.cpp", directory: "/")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!10 = !{!"clang version 19.0.0"}
+!11 = distinct !DISubprogram(name: "f", scope: !1, file: !1, line: 1, type: !12, scopeLine: 1, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
+!12 = !DISubroutineType(types: !13)
+!13 = !{}
+!18 = !DILocation(line: 2, scope: !11)
+!19 = !DILocation(line: 2, scope: !11, atomGroup: 1, atomRank: 2)
+!20 = !DILocation(line: 2, scope: !11, atomGroup: 1, atomRank: 1)
+!22 = !DILocation(line: 3, scope: !11, atomGroup: 2, atomRank: 1)
+!23 = distinct !DISubprogram(name: "g", scope: !1, file: !1, line: 4, type: !12, scopeLine: 4, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
+!24 = !DILocation(line: 5, scope: !23)
+!25 = !DILocation(line: 6, scope: !23, atomGroup: 1, atomRank: 1)


### PR DESCRIPTION
Source atom groups are identified by an atom group number and inlined-at pair,
so we simply can copy the atom numbers into the caller when inlining.