### PR TITLE
[lldb] Create a default rate limit constant in Progress (NFC)

### DIFF
--- a/lldb/include/lldb/Core/Progress.h
+++ b/lldb/include/lldb/Core/Progress.h
@@ -115,6 +115,10 @@ public:
   /// Used to indicate a non-deterministic progress report
   static constexpr uint64_t kNonDeterministicTotal = UINT64_MAX;
 
+  /// The default rate limit for high frequency progress reports.
+  static constexpr std::chrono::milliseconds kDefaultRateLimit =
+      std::chrono::milliseconds(20);
+
 private:
   void ReportProgress();
   static std::atomic<uint64_t> g_id;

--- a/lldb/include/lldb/Core/Progress.h
+++ b/lldb/include/lldb/Core/Progress.h
@@ -115,8 +115,8 @@ public:
   /// Used to indicate a non-deterministic progress report
   static constexpr uint64_t kNonDeterministicTotal = UINT64_MAX;
 
-  /// The default rate limit for high frequency progress reports.
-  static constexpr std::chrono::milliseconds kDefaultRateLimit =
+  /// The default report time for high frequency progress reports.
+  static constexpr std::chrono::milliseconds kDefaultHighFrequencyReportTime =
       std::chrono::milliseconds(20);
 
 private:

--- a/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
@@ -81,7 +81,7 @@ void ManualDWARFIndex::Index() {
   const uint64_t total_progress = units_to_index.size() * 2 + 8;
   Progress progress("Manually indexing DWARF", module_desc.GetData(),
                     total_progress, /*debugger=*/nullptr,
-                    /*minimum_report_time=*/std::chrono::milliseconds(20));
+                    Progress::kDefaultRateLimit);
 
   // Share one thread pool across operations to avoid the overhead of
   // recreating the threads.

--- a/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
@@ -81,7 +81,7 @@ void ManualDWARFIndex::Index() {
   const uint64_t total_progress = units_to_index.size() * 2 + 8;
   Progress progress("Manually indexing DWARF", module_desc.GetData(),
                     total_progress, /*debugger=*/nullptr,
-                    Progress::kDefaultRateLimit);
+                    Progress::kDefaultHighFrequencyReportTime);
 
   // Share one thread pool across operations to avoid the overhead of
   // recreating the threads.

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -723,8 +723,7 @@ void SymbolFileDWARFDebugMap::ForEachSymbolFile(
     std::function<IterationAction(SymbolFileDWARF &)> closure) {
   const size_t num_oso_idxs = m_compile_unit_infos.size();
   Progress progress(std::move(description), "", num_oso_idxs,
-                    /*debugger=*/nullptr,
-                    /*minimum_report_time=*/std::chrono::milliseconds(20));
+                    /*debugger=*/nullptr, Progress::kDefaultRateLimit);
   for (uint32_t oso_idx = 0; oso_idx < num_oso_idxs; ++oso_idx) {
     if (SymbolFileDWARF *oso_dwarf = GetSymbolFileByOSOIndex(oso_idx)) {
       progress.Increment(oso_idx, oso_dwarf->GetObjectFile()

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -723,7 +723,8 @@ void SymbolFileDWARFDebugMap::ForEachSymbolFile(
     std::function<IterationAction(SymbolFileDWARF &)> closure) {
   const size_t num_oso_idxs = m_compile_unit_infos.size();
   Progress progress(std::move(description), "", num_oso_idxs,
-                    /*debugger=*/nullptr, Progress::kDefaultRateLimit);
+                    /*debugger=*/nullptr,
+                    Progress::kDefaultHighFrequencyReportTime);
   for (uint32_t oso_idx = 0; oso_idx < num_oso_idxs; ++oso_idx) {
     if (SymbolFileDWARF *oso_dwarf = GetSymbolFileByOSOIndex(oso_idx)) {
       progress.Increment(oso_idx, oso_dwarf->GetObjectFile()


### PR DESCRIPTION
In #133211, Greg suggested making the rate limit configurable through a setting. Although adding the setting is easy, the two places where we currently use rate limiting aren't tied to a particular debugger. Although it'd be possible to hook up, given how few progress events currently implement rate limiting, I don't think it's worth threading this through, if that's even possible.

I still think it's a good idea to be consistent and make it easy to pick the same rate limiting value, so I've moved it into a constant in the Progress class.