### PR TITLE
[clang-tidy][NFC][doc] improve "options" sections of `bugprone-` and `modernize-` checks

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/assert-side-effect.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/assert-side-effect.rst
@@ -15,6 +15,7 @@ Options
 .. option:: AssertMacros
 
    A comma-separated list of the names of assert macros to be checked.
+   Default is `assert,NSAssert,NSCAssert`.
 
 .. option:: CheckFunctionCalls
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/capturing-this-in-member-variable.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/capturing-this-in-member-variable.rst
@@ -32,6 +32,9 @@ Possible fixes:
     object types.
   - passing ``this`` pointer as parameter 
 
+Options
+-------
+
 .. option:: FunctionWrapperTypes
 
   A semicolon-separated list of names of types. Used to specify function

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/signed-char-misuse.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/signed-char-misuse.rst
@@ -104,13 +104,16 @@ so both arguments will have the same type.
     return false;
   }
 
+Options
+-------
+
 .. option:: CharTypdefsToIgnore
 
   A semicolon-separated list of typedef names. In this list, we can list
   typedefs for ``char`` or ``signed char``, which will be ignored by the
   check. This is useful when a typedef introduces an integer alias like
   ``sal_Int8`` or ``int8_t``. In this case, human misinterpretation is not
-  an issue.
+  an issue. Default is an empty string.
 
 .. option:: DiagnoseSignedUnsignedCharComparisons
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-enum-usage.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-enum-usage.rst
@@ -71,6 +71,7 @@ Examples:
 
 Options
 -------
+
 .. option:: StrictMode
 
    Default value: 0.

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-stringview-data-usage.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/suspicious-stringview-data-usage.rst
@@ -43,6 +43,9 @@ lead to a compilation error due to the explicit nature of the ``std::string``
 constructor. Consequently, developers might opt for ``sv.data()`` to resolve the
 compilation error, albeit introducing potential hazards as discussed.
 
+Options
+-------
+
 .. option:: StringViewTypes
 
   Option allows users to specify custom string view-like types for analysis. It

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/too-small-loop-variable.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/too-small-loop-variable.rst
@@ -32,6 +32,9 @@ It's recommended to enable the compiler warning
 `-Wtautological-constant-out-of-range-compare` as well, since check does not
 inspect compile-time constant loop boundaries to avoid overlaps with the warning.
 
+Options
+-------
+
 .. option:: MagnitudeBitsUpperLimit
 
   Upper limit for the magnitude bits of the loop variable. If it's set the check

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/unhandled-self-assignment.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/unhandled-self-assignment.rst
@@ -118,6 +118,9 @@ temporary object into ``this`` (needs a move assignment operator):
     }
   };
 
+Options
+-------
+
 .. option:: WarnOnlyIfThisHasSuspiciousField
 
   When `true`, the check will warn only if the container class of the copy

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/unintended-char-ostream-output.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/unintended-char-ostream-output.rst
@@ -39,6 +39,9 @@ Or cast to char to explicitly indicate that output should be a character.
 
   std::cout << static_cast<char>(v);
 
+Options
+-------
+
 .. option:: CastTypeName
 
   When `CastTypeName` is specified, the fix-it will use `CastTypeName` as the

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-bind.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-bind.rst
@@ -50,8 +50,9 @@ Options
   of every placeholder parameter list. Without this, it is possible for a fix-it
   to perform an incorrect transformation in the case where the result of the ``bind``
   is used in the context of a type erased functor such as ``std::function`` which
-  allows mismatched arguments. For example:
+  allows mismatched arguments. Default is is `false`.
 
+For example:
 
 .. code-block:: c++
 

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-c-arrays.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-c-arrays.rst
@@ -62,6 +62,9 @@ Similarly, the ``main()`` function is ignored. Its second and third parameters
 can be either ``char* argv[]`` or ``char** argv``, but cannot be
 ``std::array<>``.
 
+Options
+-------
+
 .. option:: AllowStringArrays
 
   When set to `true` (default is `false`), variables of character array type

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/loop-convert.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/loop-convert.rst
@@ -140,6 +140,9 @@ however the check can be configured to work without C++20 by specifying a
 function to reverse a range and optionally the header file where that function
 lives.
 
+Options
+-------
+
 .. option:: UseCxx20ReverseRanges
 
    When set to true convert loops when in C++20 or later mode using

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/make-shared.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/make-shared.rst
@@ -53,4 +53,4 @@ Options
 
    If set to non-zero, the check does not suggest edits that will transform
    default initialization into value initialization, as this can cause
-   performance regressions. Default is `1`.
+   performance regressions. Default is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/make-shared.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/make-shared.rst
@@ -51,6 +51,6 @@ Options
 
 .. option:: IgnoreDefaultInitialization
 
-   If set to non-zero, the check does not suggest edits that will transform
+   If set to `false`, the check does not suggest edits that will transform
    default initialization into value initialization, as this can cause
    performance regressions. Default is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/make-unique.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/make-unique.rst
@@ -53,4 +53,4 @@ Options
 
    If set to non-zero, the check does not suggest edits that will transform
    default initialization into value initialization, as this can cause
-   performance regressions. Default is `1`.
+   performance regressions. Default is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/make-unique.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/make-unique.rst
@@ -51,6 +51,6 @@ Options
 
 .. option:: IgnoreDefaultInitialization
 
-   If set to non-zero, the check does not suggest edits that will transform
+   If set to `false`, the check does not suggest edits that will transform
    default initialization into value initialization, as this can cause
    performance regressions. Default is `true`.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/raw-string-literal.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/raw-string-literal.rst
@@ -45,6 +45,9 @@ An escaped horizontal tab, form feed, or vertical tab prevents the string
 literal from being converted. The presence of a horizontal tab, form feed or
 vertical tab in source code is not visually obvious.
 
+Options
+-------
+
 .. option:: DelimiterStem
 
   Custom delimiter to escape characters in raw string literals. It is used in

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-emplace.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-emplace.rst
@@ -163,7 +163,11 @@ Options
     Semicolon-separated list of containers without their template parameters
     and some ``emplace``-like method of the container. Example:
     ``vector::emplace_back``. Those methods will be checked for improper use and
-    the check will report when a temporary is unnecessarily created.
+    the check will report when a temporary is unnecessarily created. Default
+    containers with their ``emplace``-like methods are ``vector``, ``deque``,
+    ``forward_list``, ``list``, ``set``, ``map``, ``multiset``, ``multimap``,
+    ``unordered_set``, ``unordered_map``, ``unordered_multiset``,
+    ``unordered_multimap``, ``stack``, ``queue``, ``priority_queue``.
 
 Example
 ^^^^^^^

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-emplace.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-emplace.rst
@@ -163,11 +163,8 @@ Options
     Semicolon-separated list of containers without their template parameters
     and some ``emplace``-like method of the container. Example:
     ``vector::emplace_back``. Those methods will be checked for improper use and
-    the check will report when a temporary is unnecessarily created. Default
-    containers with their ``emplace``-like methods are ``vector``, ``deque``,
-    ``forward_list``, ``list``, ``set``, ``map``, ``multiset``, ``multimap``,
-    ``unordered_set``, ``unordered_map``, ``unordered_multiset``,
-    ``unordered_multimap``, ``stack``, ``queue``, ``priority_queue``.
+    the check will report when a temporary is unnecessarily created. All STL
+    containers with such member functions are supported by default.
 
 Example
 ^^^^^^^


### PR DESCRIPTION
Improved "options" sections of `bugprone-` and `modernize-` checks:

1. Added `Options` keyword to be a delimiter between "body" and "options" parts of docs
2. Added default values where was absent.
3. Improved readability of some default values by converting `1` to `true`.