### PR TITLE
[SBProgress] Add swig support for `with` statement in Python

### DIFF
--- a/lldb/bindings/interface/SBProgressDocstrings.i
+++ b/lldb/bindings/interface/SBProgressDocstrings.i
@@ -52,6 +52,13 @@ Non-deterministic progresses behave the same, but omit the total in the construc
     # Explicitly send a progressEnd, otherwise this will be sent
     # when the python runtime cleans up this object.
     non_deterministic_progress.Finalize()
+
+Additionally for Python, progress is supported in a with statement. ::
+    with lldb.SBProgress('Non deterministic progress, 'Detail', lldb.SBDebugger) as progress:
+        for i in range(10):
+            progress.Increment(1)
+    # The progress object is automatically finalized when the with statement
+
 ") lldb::SBProgress;    
 
 %feature("docstring",

--- a/lldb/bindings/interface/SBProgressDocstrings.i
+++ b/lldb/bindings/interface/SBProgressDocstrings.i
@@ -46,7 +46,7 @@ rely on the garbage collection when using lldb.SBProgress.
 
 Non-deterministic progresses behave the same, but omit the total in the constructor. ::
 
-    non_deterministic_progress = lldb.SBProgress('Non deterministic progress, 'Detail', lldb.SBDebugger)
+    non_deterministic_progress = lldb.SBProgress('Non deterministic progress', 'Detail', lldb.SBDebugger)
     for i in range(10):
         non_deterministic_progress.Increment(1)
     # Explicitly send a progressEnd, otherwise this will be sent
@@ -54,7 +54,7 @@ Non-deterministic progresses behave the same, but omit the total in the construc
     non_deterministic_progress.Finalize()
 
 Additionally for Python, progress is supported in a with statement. ::
-    with lldb.SBProgress('Non deterministic progress, 'Detail', lldb.SBDebugger) as progress:
+    with lldb.SBProgress('Non deterministic progress', 'Detail', lldb.SBDebugger) as progress:
         for i in range(10):
             progress.Increment(1)
     # The progress object is automatically finalized when the with statement

--- a/lldb/bindings/interface/SBProgressExtensions.i
+++ b/lldb/bindings/interface/SBProgressExtensions.i
@@ -1,0 +1,13 @@
+%extend lldb::SBProgress {
+#ifdef SWIGPYTHON
+    %pythoncode %{
+        def __enter__(self):
+            '''No-op for with statement'''
+            pass
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            '''Finalize the progress object'''
+            self.Finalize()
+    %}
+#endif
+}

--- a/lldb/bindings/interfaces.swig
+++ b/lldb/bindings/interfaces.swig
@@ -200,6 +200,7 @@
 %include "./interface/SBModuleSpecExtensions.i"
 %include "./interface/SBModuleSpecListExtensions.i"
 %include "./interface/SBProcessExtensions.i"
+%include "./interface/SBProgressExtensions.i"
 %include "./interface/SBProcessInfoListExtensions.i"
 %include "./interface/SBQueueItemExtensions.i"
 %include "./interface/SBScriptObjectExtensions.i"

--- a/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
+++ b/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
@@ -67,16 +67,6 @@ class ProgressTesterCommand:
     def get_long_help(self):
         return self.help_string
 
-    def __get__progress(self, debugger, total):
-        if total is None:
-            progress = lldb.SBProgress(
-                "Progress tester", "Initial Indeterminate Detail", debugger
-            )
-        else:
-            progress = lldb.SBProgress(
-                "Progress tester", "Initial Detail", total, debugger
-            )
-
     def __init__(self, debugger, unused):
         self.parser = self.create_options()
         self.help_string = self.parser.format_help()
@@ -90,9 +80,17 @@ class ProgressTesterCommand:
             return
 
         total = cmd_options.total
+        if total is None:
+            progress = lldb.SBProgress(
+                "Progress tester", "Initial Indeterminate Detail", debugger
+            )
+        else:
+            progress = lldb.SBProgress(
+                "Progress tester", "Initial Detail", total, debugger
+            )
         # Check to see if total is set to None to indicate an indeterminate progress
         # then default to 10 steps.
-        with self.__get_progress(debugger, total) as progress:
+        with progress:
             if total is None:
                 total = 10
 
@@ -102,9 +100,6 @@ class ProgressTesterCommand:
                 else:
                     progress.Increment(1, f"Step {i}")
                 time.sleep(cmd_options.seconds)
-
-        # Not required for deterministic progress, but required for indeterminate progress.
-        progress.Finalize()
 
 
 def __lldb_init_module(debugger, dict):


### PR DESCRIPTION
We recently added an explicit finalize to SBProgress, #128966. I realized while adding some additional implementations of SBProgress that we should to add `with` support for ease of use. This patch addresses adding and `__enter()__` method (which a no-op) and an `__exit()__` to swig. I also refactor the emitter for the test to leverage `with` instead of explicitly calling finalize, and I've updated the docstrings.