### PR TITLE
[sanitizer] actually run preadv2 test

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/preadv2.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/preadv2.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -O0 %s -o %t
+// RUN: %clangxx -O0 %s -o %t && %run %t
 
 // REQUIRES: glibc
 


### PR DESCRIPTION
it seems the %run was accidentally omitted, otherwise the `assert` calls
would not make sense
