### PR TITLE
[mlir] IntegerRangeAnalysis: return initialized state for noninteger values

### DIFF
--- a/mlir/lib/Interfaces/InferIntRangeInterface.cpp
+++ b/mlir/lib/Interfaces/InferIntRangeInterface.cpp
@@ -134,9 +134,6 @@ raw_ostream &mlir::operator<<(raw_ostream &os, const ConstantIntRanges &range) {
 
 IntegerValueRange IntegerValueRange::getMaxRange(Value value) {
   unsigned width = ConstantIntRanges::getStorageBitwidth(value.getType());
-  if (width == 0)
-    return {};
-
   APInt umin = APInt::getMinValue(width);
   APInt umax = APInt::getMaxValue(width);
   APInt smin = width != 0 ? APInt::getSignedMinValue(width) : umin;

--- a/mlir/test/Dialect/Arith/int-range-interface.mlir
+++ b/mlir/test/Dialect/Arith/int-range-interface.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt -int-range-optimizations -canonicalize %s | FileCheck %s
+// RUN: mlir-opt -allow-unregistered-dialect -int-range-optimizations -canonicalize %s | FileCheck %s
 
 // CHECK-LABEL: func @add_min_max
 // CHECK: %[[c3:.*]] = arith.constant 3 : index
@@ -1011,5 +1011,21 @@ func.func @zero_trip_loop2() {
   scf.for %arg0 = %idx1 to %idx1 step %idxm1 {
     %138 = index.floordivs %arg0, %arg0
   }
+  return
+}
+
+// CHECK-LABEL: @noninteger_operation_result
+func.func @noninteger_operation_result(%lb: index, %ub: index, %step: index, %cond: i1) {
+  %c1_i32 = arith.constant 1 : i32
+
+  %0 = "some_fp_op"() : () -> f32
+  // CHECK: [[OUTS:%.*]]:2 = scf.for
+  %outs:2 = scf.for %i = %lb to %ub step %step iter_args(%a = %c1_i32, %b = %0) -> (i32, f32) {
+    %1 = "some_int_op"() : () -> i32
+    scf.yield %1, %0 : i32, f32
+  }
+
+  %result = arith.select %cond, %c1_i32, %outs#0 : i32
+  "use"(%result) : (i32) -> ()
   return
 }


### PR DESCRIPTION
Otherwise, the state for noninteger values remains uninitialized, causing the analysis to return bogus results.