### PR TITLE
[lldb] Use *Set::insert_range and a range constructor (NFC)

### DIFF
--- a/lldb/source/Host/common/NativeProcessProtocol.cpp
+++ b/lldb/source/Host/common/NativeProcessProtocol.cpp
@@ -43,7 +43,7 @@ lldb_private::Status NativeProcessProtocol::Interrupt() {
 
 Status NativeProcessProtocol::IgnoreSignals(llvm::ArrayRef<int> signals) {
   m_signals_to_ignore.clear();
-  m_signals_to_ignore.insert(signals.begin(), signals.end());
+  m_signals_to_ignore.insert_range(signals);
   return Status();
 }
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/CxxModuleHandler.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/CxxModuleHandler.cpp
@@ -42,7 +42,7 @@ CxxModuleHandler::CxxModuleHandler(ASTImporter &importer, ASTContext *target)
       "allocator",
       "pair",
   };
-  m_supported_templates.insert(supported_names.begin(), supported_names.end());
+  m_supported_templates.insert_range(supported_names);
 }
 
 /// Builds a list of scopes that point into the given context.

--- a/lldb/tools/lldb-dap/Handler/SetInstructionBreakpointsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SetInstructionBreakpointsRequestHandler.cpp
@@ -213,9 +213,8 @@ void SetInstructionBreakpointsRequestHandler::operator()(
   // Disable any instruction breakpoints that aren't in this request.
   // There is no call to remove instruction breakpoints other than calling this
   // function with a smaller or empty "breakpoints" list.
-  llvm::DenseSet<lldb::addr_t> seen;
-  for (const auto &addr : dap.instruction_breakpoints)
-    seen.insert(addr.first);
+  llvm::DenseSet<lldb::addr_t> seen(
+      llvm::from_range, llvm::make_first_range(dap.instruction_breakpoints));
 
   for (const auto &bp : *breakpoints) {
     const auto *bp_obj = bp.getAsObject();


### PR DESCRIPTION
This patch uses *Set::insert_range and a range constructor of DenseSet
to clean up the code to populate sets.
