### PR TITLE
[RISCV][WIP] Branch to Absolute Address

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -557,9 +557,7 @@ public:
     return IsValid && VK == RISCVMCExpr::VK_None;
   }
 
-  bool isBranchOffset() const {
-    return isImm();
-  }
+  bool isBranchOffset() const { return isImm(); }
 
   // Predicate methods for AsmOperands defined in RISCVInstrInfo.td
 
@@ -2014,7 +2012,8 @@ ParseStatus RISCVAsmParser::parseImmediate(OperandVector &Operands) {
   return ParseStatus::Success;
 }
 
-ParseStatus RISCVAsmParser::parseBranchOffsetImmediate(OperandVector &Operands) {
+ParseStatus
+RISCVAsmParser::parseBranchOffsetImmediate(OperandVector &Operands) {
   SMLoc S = getLoc();
   SMLoc E;
   const MCExpr *Res;
@@ -2045,7 +2044,8 @@ ParseStatus RISCVAsmParser::parseBranchOffsetImmediate(OperandVector &Operands) 
     // AbsSym->setVariableValue(Zero);
     getStreamer().emitAssignment(AbsSym, Zero);
 
-    Res = MCBinaryExpr::createAdd(MCSymbolRefExpr::create(AbsSym, getContext()), Res, getContext());
+    Res = MCBinaryExpr::createAdd(MCSymbolRefExpr::create(AbsSym, getContext()),
+                                  Res, getContext());
     break;
   }
   case AsmToken::Percent: {

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.cpp
@@ -109,7 +109,8 @@ void RISCVInstPrinter::printBranchOperand(const MCInst *MI, uint64_t Address,
     // find out if it is absolute symbol reference to an opaque zero
     if (const auto *BE = dyn_cast<MCBinaryExpr>(MO.getExpr())) {
       if (const auto *SRE = dyn_cast<MCSymbolRefExpr>(BE->getLHS())) {
-        if (const auto *SymVal = dyn_cast<MCConstantExpr>(SRE->getSymbol().getVariableValue(/*false*/))) {
+        if (const auto *SymVal = dyn_cast<MCConstantExpr>(
+                SRE->getSymbol().getVariableValue(/*false*/))) {
           if (BE->getOpcode() == MCBinaryExpr::Add && SymVal->getValue() == 0) {
             BE->getRHS()->print(O, &MAI);
             return;
@@ -120,7 +121,6 @@ void RISCVInstPrinter::printBranchOperand(const MCInst *MI, uint64_t Address,
 
     MO.getExpr()->print(O, &MAI);
   }
-
 
   if (!MO.isImm())
     return printOperand(MI, OpNo, STI, O);

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -275,6 +275,29 @@ def simm12 : RISCVSImmLeafOp<12> {
 def simm12_no6 : ImmLeaf<XLenVT, [{
   return isInt<12>(Imm) && !isInt<6>(Imm) && isInt<12>(-Imm);}]>;
 
+
+def BranchOffsetAsmOperand : AsmOperandClass {
+  let Name = "BranchOffset";
+  let RenderMethod = "addImmOperands";
+  let ParserMethod = "parseBranchOffsetImmediate";
+  let DiagnosticType = !strconcat("Invalid", Name);
+  let DiagnosticString = "operand must be an absolute address or an expression";
+}
+
+def branch_offset : Operand<OtherVT> {
+  let ParserMatchClass = BranchOffsetAsmOperand;
+  let PrintMethod = "printBranchOperand";
+  let EncoderMethod = "getImmOpValueAsr1";
+  let DecoderMethod = "decodeSImmOperandAndLsl1<13>";
+  let MCOperandPredicate = [{
+    int64_t Imm;
+    if (MCOp.evaluateAsConstantImm(Imm))
+      return isShiftedInt<12, 1>(Imm);
+    return MCOp.isBareSymbolRef();
+  }];
+  let OperandType = "OPERAND_PCREL";
+}
+
 // A 13-bit signed immediate where the least significant bit is zero.
 def bare_simm13_lsb0 : Operand<OtherVT> {
   let ParserMatchClass = BareSImmNLsb0AsmOperand<13>;
@@ -532,7 +555,7 @@ include "RISCVInstrFormatsV.td"
 
 class BranchCC_rri<bits<3> funct3, string opcodestr>
     : RVInstB<funct3, OPC_BRANCH, (outs),
-              (ins GPR:$rs1, GPR:$rs2, bare_simm13_lsb0:$imm12),
+              (ins GPR:$rs1, GPR:$rs2, branch_offset:$imm12),
               opcodestr, "$rs1, $rs2, $imm12">,
       Sched<[WriteJmp, ReadJmp, ReadJmp]> {
   let isBranch = 1;


### PR DESCRIPTION
Today, if you feed e.g. `beq a0, a1, 60` into LLVM's assembler, you get back something like this: (i.e., the `60` is directly used in the encoding).

```
00000000 <.text>:
       0: <encoding> beq a0, a1, 60 <.text+60>
```

If you feed the same into binutils, you get back something like this (i.e., the `60` is treated like an absolute address):
```
00000000 <.text>:
       0: <encoding> bne a0, a1, 8 <.text+0x8>
       4: <encoding> j 4 <.text+0x4>
             R_RISCV_JAL *ABS*+0x3c
```

[Craig reminded me of this recently](https://github.com/llvm/llvm-project/pull/131996#discussion_r2004045898) and Ana mentioned that there had been previous discussions about this, but did not recall the resolution.

---

There are drawbacks to how binutils works. It cannot really ever say a specific immediate is "wrong", because only the linker resolves these, whereas in LLVM we can catch some issues like that a bit earlier, but obviously we're catching issues in something subtly different.

---

This PR is a pile of hacks to make LLVM's assembler work like binutils. None of this code is particularly nice, but I hope some of it might be a good place to start discussing whether we want to make this change? (I didn't find a previous discussion of this in the issue tracker, but maybe I didn't look hard enough)

There are almost certainly nicer ways to do this, but this is the way I managed today. There are almost certainly some bugs here too, especially in the printing code.

