### PR TITLE
llvm-reduce: Make some error messages more consistent

### DIFF
--- a/llvm/test/tools/llvm-reduce/fail-execute-test.test
+++ b/llvm/test/tools/llvm-reduce/fail-execute-test.test
@@ -1,4 +1,4 @@
 # RUN: export LSAN_OPTIONS=detect_leaks=0
 # RUN: not llvm-reduce --test=%s.NotAFileInTestingDir %p/Inputs/test-output-format.ll 2>&1 | FileCheck -DFILENAME=%s.NotAFileInTestingDir --strict-whitespace %s
 
-# CHECK: Error running interesting-ness test: {{(Executable "[[FILENAME]]" doesn't exist$)?(program not executable$)?}}
+# CHECK: error: running interesting-ness test: {{(Executable "[[FILENAME]]" doesn't exist$)?(program not executable$)?}}

--- a/llvm/test/tools/llvm-reduce/fail-output-file.test
+++ b/llvm/test/tools/llvm-reduce/fail-output-file.test
@@ -1,0 +1,7 @@
+# Python on an empty file will always succeed as interesting
+# RUN: touch %t
+
+# Fail on attempt to write to output directory
+# RUN: not llvm-reduce --delta-passes=instructions -o %s/CannotOpenFile --test %python --test-arg %t %p/Inputs/test-output-format.ll 2>&1 | FileCheck %s
+
+# CHECK: error: opening output file: Not a directory

--- a/llvm/test/tools/llvm-reduce/fail-output-file.test
+++ b/llvm/test/tools/llvm-reduce/fail-output-file.test
@@ -1,7 +1,7 @@
 # Python on an empty file will always succeed as interesting
 # RUN: touch %t
 
-# Fail on attempt to write to output directory
-# RUN: not llvm-reduce --delta-passes=instructions -o %s/CannotOpenFile --test %python --test-arg %t %p/Inputs/test-output-format.ll 2>&1 | FileCheck %s
+# Fail on attempt to write output to a directory
+# RUN: not llvm-reduce --delta-passes=instructions -o %p/Inputs --test %python --test-arg %t %p/Inputs/test-output-format.ll 2>&1 | FileCheck  -DMSG=%errc_EISDIR %s
 
-# CHECK: error: opening output file: Not a directory
+# CHECK: error: opening output file: [[MSG]]

--- a/llvm/tools/llvm-reduce/TestRunner.cpp
+++ b/llvm/tools/llvm-reduce/TestRunner.cpp
@@ -45,9 +45,8 @@ int TestRunner::run(StringRef Filename) const {
                           /*SecondsToWait=*/0, /*MemoryLimit=*/0, &ErrMsg);
 
   if (Result < 0) {
-    Error E = make_error<StringError>("Error running interesting-ness test: " +
-                                          ErrMsg,
-                                      inconvertibleErrorCode());
+    Error E = make_error<StringError>(
+        "running interesting-ness test: " + ErrMsg, inconvertibleErrorCode());
     WithColor::error(errs(), ToolName) << toString(std::move(E)) << '\n';
     exit(1);
   }
@@ -61,7 +60,8 @@ void TestRunner::writeOutput(StringRef Message) {
                      EmitBitcode && !Program->isMIR() ? sys::fs::OF_None
                                                       : sys::fs::OF_Text);
   if (EC) {
-    errs() << "Error opening output file: " << EC.message() << "!\n";
+    WithColor::error(errs(), ToolName)
+        << "opening output file: " << EC.message() << '\n';
     exit(1);
   }
 


### PR DESCRIPTION
The coding standards states that error messages should start with
a lowercase. Also use WithColor, and add missing test coverage for
the failed to write to output file case.