### PR TITLE
llvm-reduce: Make run-ir-passes error more consistent

### DIFF
--- a/llvm/test/tools/llvm-reduce/run-ir-passes-error.ll
+++ b/llvm/test/tools/llvm-reduce/run-ir-passes-error.ll
@@ -1,0 +1,18 @@
+; RUN: not llvm-reduce --abort-on-invalid-reduction --delta-passes=ir-passes --ir-passes=does-not-parse --test FileCheck --test-arg --check-prefixes=CHECK-INTERESTINGNESS --test-arg %s --test-arg --input-file %s -o /dev/null 2>&1 | FileCheck -check-prefix=ERR %s
+
+; CHECK-INTERESTINGNESS-LABEL: @f1
+; ERR: LLVM ERROR: unknown pass name 'does-not-parse'
+
+define i32 @f1(i32 %a) {
+  %b = add i32 %a, 5
+  %c = add i32 %b, 5
+  ret i32 %c
+}
+
+define i32 @f2(i32 %a) {
+  %b = add i32 %a, 5
+  %c = add i32 %b, 5
+  ret i32 %c
+}
+
+declare void @f3()

--- a/llvm/tools/llvm-reduce/deltas/RunIRPasses.cpp
+++ b/llvm/tools/llvm-reduce/deltas/RunIRPasses.cpp
@@ -43,10 +43,8 @@ static void runPasses(Oracle &O, ReducerWorkItem &WorkItem) {
   PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
 
   ModulePassManager MPM;
-  if (auto Err = PB.parsePassPipeline(MPM, PassPipeline)) {
-    errs() << toString(std::move(Err)) << "\n";
-    report_fatal_error("Error constructing pass pipeline");
-  }
+  if (auto Err = PB.parsePassPipeline(MPM, PassPipeline))
+    report_fatal_error(std::move(Err), false);
   MPM.run(Program, MAM);
 }
 


### PR DESCRIPTION
Avoid capitalized Error. This loses the "Error constructing pass pipeline"
part, and just forwards the error to the default report_fatal_error case. Not
sure if it's worth trying to keep.