### PR TITLE
[Clang] Ensure the instantiation of array initializers for decltype/_typeof operator

### DIFF
--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -9544,6 +9544,8 @@ QualType Sema::BuildTypeofExprType(Expr *E, TypeOfKind Kind) {
     QualType T = E->getType();
     if (const TagType *TT = T->getAs<TagType>())
       DiagnoseUseOfDecl(TT->getDecl(), E->getExprLoc());
+    // E might refer to an array whose initializer isn't instantiated yet.
+    // Complete the type of E if possible.
     getCompletedType(E);
   }
   return Context.getTypeOfExprType(E, Kind);
@@ -9590,6 +9592,8 @@ QualType Sema::getDecltypeForExpr(Expr *E) {
   if (E->isTypeDependent())
     return Context.DependentTy;
 
+  // IDExpr might refer to an array whose initializer isn't instantiated yet.
+  // Complete the type of IDExpr if possible.
   getCompletedType(IDExpr);
 
   // C++11 [dcl.type.simple]p4:

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -9544,6 +9544,7 @@ QualType Sema::BuildTypeofExprType(Expr *E, TypeOfKind Kind) {
     QualType T = E->getType();
     if (const TagType *TT = T->getAs<TagType>())
       DiagnoseUseOfDecl(TT->getDecl(), E->getExprLoc());
+    getCompletedType(E);
   }
   return Context.getTypeOfExprType(E, Kind);
 }
@@ -9588,6 +9589,8 @@ QualType Sema::getDecltypeForExpr(Expr *E) {
 
   if (E->isTypeDependent())
     return Context.DependentTy;
+
+  getCompletedType(IDExpr);
 
   // C++11 [dcl.type.simple]p4:
   //   The type denoted by decltype(e) is defined as follows:

--- a/clang/test/SemaCXX/cxx1y-variable-templates_top_level.cpp
+++ b/clang/test/SemaCXX/cxx1y-variable-templates_top_level.cpp
@@ -472,6 +472,18 @@ namespace VexingParse {
 
 namespace GH79750 {
 
+template <unsigned...values>
+constexpr unsigned array[]{ values... };
+
+// Test if the unevaluated operators trigger instantiation of the array initializer.
+static_assert(__is_same(__typeof(array<1, 2, 3, 4, 5>),  const unsigned[5]), "");
+
+static_assert(__is_same(decltype(array<1, 2, 3, 4>),  const unsigned[4]), "");
+
+}
+
+namespace GH79750_2 {
+
 enum class Values { A };
 
 template<typename E>


### PR DESCRIPTION
This is a follow-up to a9672515ce, per Richard's suggestion we should ensure the instantiation for these unevaluated operators as well.

No release entry because the issue being fixed was already claimed resolved in that patch (though not intended).

Fixes https://github.com/llvm/llvm-project/issues/79750