### PR TITLE
[NFC] LLVM reduce: remove unused variable

### DIFF
--- a/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp
@@ -109,7 +109,7 @@ static void replaceFunctionCalls(Function *OldF, Function *NewF) {
     NewCI->setAttributes(CI->getAttributes());
 
     if (auto *FPOp = dyn_cast<FPMathOperator>(NewCI))
-      NewCI->setFastMathFlags(CI->getFastMathFlags());
+      FPOp->setFastMathFlags(CI->getFastMathFlags());
 
     NewCI->copyMetadata(*CI);
 


### PR DESCRIPTION
addresses:


 

>LLVM Buildbot has detected a new failure on builder `sanitizer-aarch64-linux` running on `sanitizer-buildbot8` while building `llvm` at step 2 "annotate".
> 
> Full details are available at: https://lab.llvm.org/buildbot/#/builders/51/builds/13481
> 
> <details>
> <summary>Here is the relevant piece of the build log for the reference</summary>
> 
> ```
> Step 2 (annotate) failure: 'python ../sanitizer_buildbot/sanitizers/zorg/buildbot/builders/sanitizers/buildbot_selector.py' (failure)
> ...
> [5347/5481] Building Opts.inc...
> [5348/5481] Linking CXX executable bin/llvm-nm
> [5349/5481] Building CXX object tools/llvm-xray/CMakeFiles/llvm-xray.dir/func-id-helper.cpp.o
> [5350/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceInstructionFlags.cpp.o
> [5351/5481] Building CXX object tools/llvm-yaml-parser-fuzzer/CMakeFiles/llvm-yaml-parser-fuzzer.dir/yaml-parser-fuzzer.cpp.o
> [5352/5481] Building CXX object tools/llvm-strings/CMakeFiles/llvm-strings.dir/llvm-strings.cpp.o
> [5353/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsSkip.cpp.o
> [5354/5481] Linking CXX executable bin/llvm-yaml-parser-fuzzer
> [5355/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceInvokes.cpp.o
> [5356/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o
> FAILED: tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o 
> CCACHE_CPP2=yes CCACHE_HASHDIR=yes /usr/bin/ccache /home/b/sanitizer-aarch64-linux/build/llvm_build0/bin/clang++ -DGTEST_HAS_RTTI=0 -DLLVM_BUILD_STATIC -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/home/b/sanitizer-aarch64-linux/build/build_default/tools/llvm-reduce -I/home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/tools/llvm-reduce -I/home/b/sanitizer-aarch64-linux/build/build_default/include -I/home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/include -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG -std=c++17  -fno-exceptions -funwind-tables -fno-rtti -UNDEBUG -MD -MT tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o -MF tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o.d -o tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o -c /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp
> /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp:111:15: error: variable 'FPOp' set but not used [-Werror,-Wunused-but-set-variable]
>   111 |     if (auto *FPOp = dyn_cast<FPMathOperator>(NewCI))
>       |               ^
> 1 error generated.
> [5357/5481] Linking CXX executable bin/llvm-strings
> [5358/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceDIMetadata.cpp.o
> [5359/5481] Linking CXX shared module lib/Bye.so
> [5360/5481] Linking CXX shared module lib/ExampleIRTransforms.so
> [5361/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperands.cpp.o
> [5362/5481] Building CXX object tools/llvm-yaml-numeric-parser-fuzzer/CMakeFiles/llvm-yaml-numeric-parser-fuzzer.dir/yaml-numeric-parser-fuzzer.cpp.o
> [5363/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceUsingSimplifyCFG.cpp.o
> [5364/5481] Building CXX object tools/llvm-xray/CMakeFiles/llvm-xray.dir/xray-fdr-dump.cpp.o
> [5365/5481] Linking CXX executable bin/llvm-exegesis
> [5366/5481] Linking CXX executable bin/llvm-lto2
> [5367/5481] Building CXX object tools/opt/CMakeFiles/opt.dir/opt.cpp.o
> [5368/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceInstructionFlagsMIR.cpp.o
> [5369/5481] Building CXX object tools/sancov/CMakeFiles/sancov.dir/sancov-driver.cpp.o
> [5370/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/StripDebugInfo.cpp.o
> [5371/5481] Building CXX object tools/llvm-profgen/CMakeFiles/llvm-profgen.dir/MissingFrameInferrer.cpp.o
> [5372/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceMemoryOperations.cpp.o
> [5373/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceIRReferences.cpp.o
> [5374/5481] Building CXX object tools/llvm-opt-fuzzer/CMakeFiles/llvm-opt-fuzzer.dir/llvm-opt-fuzzer.cpp.o
> [5375/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandBundles.cpp.o
> [5376/5481] Building CXX object tools/llvm-readobj/CMakeFiles/llvm-readobj.dir/COFFDumper.cpp.o
> [5377/5481] Building CXX object tools/llvm-xray/CMakeFiles/llvm-xray.dir/xray-extract.cpp.o
> [5378/5481] Building CXX object tools/llvm-pdbutil/CMakeFiles/llvm-pdbutil.dir/llvm-pdbutil.cpp.o
> [5379/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceMetadata.cpp.o
> [5380/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/llvm-reduce.cpp.o
> [5381/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceRegisterMasks.cpp.o
> [5382/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceVirtualRegisters.cpp.o
> [5383/5481] Building CXX object tools/obj2yaml/CMakeFiles/obj2yaml.dir/minidump2yaml.cpp.o
> [5384/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceRegisterUses.cpp.o
> [5385/5481] Building CXX object tools/obj2yaml/CMakeFiles/obj2yaml.dir/archive2yaml.cpp.o
> [5386/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOpcodes.cpp.o
> [5387/5481] Building CXX object tools/obj2yaml/CMakeFiles/obj2yaml.dir/obj2yaml.cpp.o
> [5388/5481] Building CXX object tools/llvm-profgen/CMakeFiles/llvm-profgen.dir/CSPreInliner.cpp.o
> [5389/5481] Building CXX object tools/llvm-stress/CMakeFiles/llvm-stress.dir/llvm-stress.cpp.o
> Step 8 (build compiler-rt symbolizer) failure: build compiler-rt symbolizer (failure)
> ...
> [5347/5481] Building Opts.inc...
> [5348/5481] Linking CXX executable bin/llvm-nm
> [5349/5481] Building CXX object tools/llvm-xray/CMakeFiles/llvm-xray.dir/func-id-helper.cpp.o
> [5350/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceInstructionFlags.cpp.o
> [5351/5481] Building CXX object tools/llvm-yaml-parser-fuzzer/CMakeFiles/llvm-yaml-parser-fuzzer.dir/yaml-parser-fuzzer.cpp.o
> [5352/5481] Building CXX object tools/llvm-strings/CMakeFiles/llvm-strings.dir/llvm-strings.cpp.o
> [5353/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsSkip.cpp.o
> [5354/5481] Linking CXX executable bin/llvm-yaml-parser-fuzzer
> [5355/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceInvokes.cpp.o
> [5356/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o
> FAILED: tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o 
> CCACHE_CPP2=yes CCACHE_HASHDIR=yes /usr/bin/ccache /home/b/sanitizer-aarch64-linux/build/llvm_build0/bin/clang++ -DGTEST_HAS_RTTI=0 -DLLVM_BUILD_STATIC -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/home/b/sanitizer-aarch64-linux/build/build_default/tools/llvm-reduce -I/home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/tools/llvm-reduce -I/home/b/sanitizer-aarch64-linux/build/build_default/include -I/home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/include -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG -std=c++17  -fno-exceptions -funwind-tables -fno-rtti -UNDEBUG -MD -MT tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o -MF tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o.d -o tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o -c /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp
> /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp:111:15: error: variable 'FPOp' set but not used [-Werror,-Wunused-but-set-variable]
>   111 |     if (auto *FPOp = dyn_cast<FPMathOperator>(NewCI))
>       |               ^
> 1 error generated.
> [5357/5481] Linking CXX executable bin/llvm-strings
> [5358/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceDIMetadata.cpp.o
> [5359/5481] Linking CXX shared module lib/Bye.so
> [5360/5481] Linking CXX shared module lib/ExampleIRTransforms.so
> [5361/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperands.cpp.o
> [5362/5481] Building CXX object tools/llvm-yaml-numeric-parser-fuzzer/CMakeFiles/llvm-yaml-numeric-parser-fuzzer.dir/yaml-numeric-parser-fuzzer.cpp.o
> [5363/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceUsingSimplifyCFG.cpp.o
> [5364/5481] Building CXX object tools/llvm-xray/CMakeFiles/llvm-xray.dir/xray-fdr-dump.cpp.o
> [5365/5481] Linking CXX executable bin/llvm-exegesis
> [5366/5481] Linking CXX executable bin/llvm-lto2
> [5367/5481] Building CXX object tools/opt/CMakeFiles/opt.dir/opt.cpp.o
> [5368/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceInstructionFlagsMIR.cpp.o
> [5369/5481] Building CXX object tools/sancov/CMakeFiles/sancov.dir/sancov-driver.cpp.o
> [5370/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/StripDebugInfo.cpp.o
> [5371/5481] Building CXX object tools/llvm-profgen/CMakeFiles/llvm-profgen.dir/MissingFrameInferrer.cpp.o
> [5372/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceMemoryOperations.cpp.o
> [5373/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceIRReferences.cpp.o
> [5374/5481] Building CXX object tools/llvm-opt-fuzzer/CMakeFiles/llvm-opt-fuzzer.dir/llvm-opt-fuzzer.cpp.o
> [5375/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandBundles.cpp.o
> [5376/5481] Building CXX object tools/llvm-readobj/CMakeFiles/llvm-readobj.dir/COFFDumper.cpp.o
> [5377/5481] Building CXX object tools/llvm-xray/CMakeFiles/llvm-xray.dir/xray-extract.cpp.o
> [5378/5481] Building CXX object tools/llvm-pdbutil/CMakeFiles/llvm-pdbutil.dir/llvm-pdbutil.cpp.o
> [5379/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceMetadata.cpp.o
> [5380/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/llvm-reduce.cpp.o
> [5381/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceRegisterMasks.cpp.o
> [5382/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceVirtualRegisters.cpp.o
> [5383/5481] Building CXX object tools/obj2yaml/CMakeFiles/obj2yaml.dir/minidump2yaml.cpp.o
> [5384/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceRegisterUses.cpp.o
> [5385/5481] Building CXX object tools/obj2yaml/CMakeFiles/obj2yaml.dir/archive2yaml.cpp.o
> [5386/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOpcodes.cpp.o
> [5387/5481] Building CXX object tools/obj2yaml/CMakeFiles/obj2yaml.dir/obj2yaml.cpp.o
> [5388/5481] Building CXX object tools/llvm-profgen/CMakeFiles/llvm-profgen.dir/CSPreInliner.cpp.o
> [5389/5481] Building CXX object tools/llvm-stress/CMakeFiles/llvm-stress.dir/llvm-stress.cpp.o
> Step 9 (test compiler-rt symbolizer) failure: test compiler-rt symbolizer (failure)
> ...
> [2978/2982] Generating MSAN_INST_TEST_OBJECTS.msan_test.cpp.aarch64-with-call.o
> [2979/2982] Generating Msan-aarch64-with-call-Test
> [2980/2982] Generating MSAN_INST_TEST_OBJECTS.msan_test.cpp.aarch64.o
> [2981/2982] Generating Msan-aarch64-Test
> [2981/2982] Running compiler_rt regression tests
> llvm-lit: /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/utils/lit/lit/discovery.py:276: warning: input '/home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/interception/Unit' contained no tests
> llvm-lit: /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/utils/lit/lit/discovery.py:276: warning: input '/home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/sanitizer_common/Unit' contained no tests
> llvm-lit: /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/utils/lit/lit/main.py:72: note: The test suite configuration requested an individual test timeout of 0 seconds but a timeout of 900 seconds was requested on the command line. Forcing timeout to be 900 seconds.
> -- Testing: 6144 tests, 72 workers --
> Testing:  0.. 10.. 20.. 30.. 40.. 50.. 60.. 70.. 
> FAIL: TypeSanitizer-aarch64 :: anon-struct.c (4971 of 6144)
> ******************** TEST 'TypeSanitizer-aarch64 :: anon-struct.c' FAILED ********************
> Exit Code: 1
> 
> Command Output (stderr):
> --
> /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang  -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only   -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta   -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/anon-struct.c -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-struct.c.tmp &&  /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-struct.c.tmp >/home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-struct.c.tmp.out 2>&1 # RUN: at line 1
> + /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/anon-struct.c -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-struct.c.tmp
> ld: error: cannot open /home/b/sanitizer-aarch64-linux/build/build_default/lib/clang/21/lib/aarch64-unknown-linux-gnu/libclang_rt.tysan.a: No such file or directory
> clang: error: linker command failed with exit code 1 (use -v to see invocation)
> 
> --
> 
> ********************
> Testing:  0.. 10.. 20.. 30.. 40.. 50.. 60.. 70.. 
> FAIL: TypeSanitizer-aarch64 :: anon-same-struct.c (4972 of 6144)
> ******************** TEST 'TypeSanitizer-aarch64 :: anon-same-struct.c' FAILED ********************
> Exit Code: 1
> 
> Command Output (stderr):
> --
> /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang  -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only   -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta   -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/anon-same-struct.c -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-same-struct.c.tmp &&  /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-same-struct.c.tmp >/home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-same-struct.c.tmp.out 2>&1 # RUN: at line 1
> + /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/anon-same-struct.c -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-same-struct.c.tmp
> ld: error: cannot open /home/b/sanitizer-aarch64-linux/build/build_default/lib/clang/21/lib/aarch64-unknown-linux-gnu/libclang_rt.tysan.a: No such file or directory
> clang: error: linker command failed with exit code 1 (use -v to see invocation)
> 
> --
> 
> ********************
> Testing:  0.. 10.. 20.. 30.. 40.. 50.. 60.. 70.. 
> FAIL: TypeSanitizer-aarch64 :: constexpr-subobject.cpp (4974 of 6144)
> ******************** TEST 'TypeSanitizer-aarch64 :: constexpr-subobject.cpp' FAILED ********************
> Exit Code: 1
> 
> Command Output (stderr):
> --
> /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang  -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only   -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta   -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/constexpr-subobject.cpp -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/constexpr-subobject.cpp.tmp &&  /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/constexpr-subobject.cpp.tmp >/home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/constexpr-subobject.cpp.tmp.out 2>&1 # RUN: at line 1
> + /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/constexpr-subobject.cpp -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/constexpr-subobject.cpp.tmp
> ld: error: cannot open /home/b/sanitizer-aarch64-linux/build/build_default/lib/clang/21/lib/aarch64-unknown-linux-gnu/libclang_rt.tysan.a: No such file or directory
> Step 10 (build compiler-rt debug) failure: build compiler-rt debug (failure)
> ...
> -- Performing additional configure checks with target flags: -march=armv8-a -std=c11;-fPIC;-fno-builtin;-fvisibility=hidden
> -- Performing Test COMPILER_RT_HAS_aarch64_FLOAT16
> -- Performing Test COMPILER_RT_HAS_aarch64_FLOAT16 - Success
> -- Performing Test COMPILER_RT_HAS_aarch64_BFLOAT16
> -- Performing Test COMPILER_RT_HAS_aarch64_BFLOAT16 - Success
> -- For aarch64 builtins preferring aarch64/fp_mode.c to fp_mode.c
> -- Configuring done (1.1s)
> -- Generating done (0.0s)
> -- Build files have been written to: /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/builtins-bins
> [5467/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o
> FAILED: tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o 
> CCACHE_CPP2=yes CCACHE_HASHDIR=yes /usr/bin/ccache /home/b/sanitizer-aarch64-linux/build/llvm_build0/bin/clang++ -DGTEST_HAS_RTTI=0 -DLLVM_BUILD_STATIC -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/home/b/sanitizer-aarch64-linux/build/build_default/tools/llvm-reduce -I/home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/tools/llvm-reduce -I/home/b/sanitizer-aarch64-linux/build/build_default/include -I/home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/include -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG -std=c++17  -fno-exceptions -funwind-tables -fno-rtti -UNDEBUG -MD -MT tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o -MF tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o.d -o tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o -c /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp
> /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp:111:15: error: variable 'FPOp' set but not used [-Werror,-Wunused-but-set-variable]
>   111 |     if (auto *FPOp = dyn_cast<FPMathOperator>(NewCI))
>       |               ^
> 1 error generated.
> ninja: build stopped: subcommand failed.
> 
> How to reproduce locally: https://github.com/google/sanitizers/wiki/SanitizerBotReproduceBuild
> 
> 
> 
> 
> Step 11 (test compiler-rt debug) failure: test compiler-rt debug (failure)
> ...
> [2976/2980] Generating MSAN_INST_TEST_OBJECTS.msan_test.cpp.aarch64-with-call.o
> [2977/2980] Generating Msan-aarch64-with-call-Test
> [2978/2980] Generating MSAN_INST_TEST_OBJECTS.msan_test.cpp.aarch64.o
> [2979/2980] Generating Msan-aarch64-Test
> [2979/2980] Running compiler_rt regression tests
> llvm-lit: /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/utils/lit/lit/discovery.py:276: warning: input '/home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/interception/Unit' contained no tests
> llvm-lit: /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/utils/lit/lit/discovery.py:276: warning: input '/home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/sanitizer_common/Unit' contained no tests
> llvm-lit: /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/utils/lit/lit/main.py:72: note: The test suite configuration requested an individual test timeout of 0 seconds but a timeout of 900 seconds was requested on the command line. Forcing timeout to be 900 seconds.
> -- Testing: 3103 of 6145 tests, 72 workers --
> Testing:  0.. 10.. 20.. 30.. 40.. 50.. 60.. 70
> FAIL: TypeSanitizer-aarch64 :: anon-same-struct.c (2331 of 3103)
> ******************** TEST 'TypeSanitizer-aarch64 :: anon-same-struct.c' FAILED ********************
> Exit Code: 1
> 
> Command Output (stderr):
> --
> /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang  -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only   -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta   -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/anon-same-struct.c -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-same-struct.c.tmp &&  /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-same-struct.c.tmp >/home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-same-struct.c.tmp.out 2>&1 # RUN: at line 1
> + /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/anon-same-struct.c -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-same-struct.c.tmp
> ld: error: cannot open /home/b/sanitizer-aarch64-linux/build/build_default/lib/clang/21/lib/aarch64-unknown-linux-gnu/libclang_rt.tysan.a: No such file or directory
> clang: error: linker command failed with exit code 1 (use -v to see invocation)
> 
> --
> 
> ********************
> Testing:  0.. 10.. 20.. 30.. 40.. 50.. 60.. 70
> FAIL: TypeSanitizer-aarch64 :: anon-struct.c (2334 of 3103)
> ******************** TEST 'TypeSanitizer-aarch64 :: anon-struct.c' FAILED ********************
> Exit Code: 1
> 
> Command Output (stderr):
> --
> /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang  -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only   -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta   -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/anon-struct.c -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-struct.c.tmp &&  /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-struct.c.tmp >/home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-struct.c.tmp.out 2>&1 # RUN: at line 1
> + /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/anon-struct.c -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-struct.c.tmp
> ld: error: cannot open /home/b/sanitizer-aarch64-linux/build/build_default/lib/clang/21/lib/aarch64-unknown-linux-gnu/libclang_rt.tysan.a: No such file or directory
> clang: error: linker command failed with exit code 1 (use -v to see invocation)
> 
> --
> 
> ********************
> Testing:  0.. 10.. 20.. 30.. 40.. 50.. 60.. 70
> FAIL: TypeSanitizer-aarch64 :: constexpr-subobject.cpp (2342 of 3103)
> ******************** TEST 'TypeSanitizer-aarch64 :: constexpr-subobject.cpp' FAILED ********************
> Exit Code: 1
> 
> Command Output (stderr):
> --
> /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang  -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only   -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta   -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/constexpr-subobject.cpp -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/constexpr-subobject.cpp.tmp &&  /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/constexpr-subobject.cpp.tmp >/home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/constexpr-subobject.cpp.tmp.out 2>&1 # RUN: at line 1
> + /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/constexpr-subobject.cpp -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/constexpr-subobject.cpp.tmp
> ld: error: cannot open /home/b/sanitizer-aarch64-linux/build/build_default/lib/clang/21/lib/aarch64-unknown-linux-gnu/libclang_rt.tysan.a: No such file or directory
> Step 12 (build compiler-rt tsan_debug) failure: build compiler-rt tsan_debug (failure)
> ...
> -- Performing additional configure checks with target flags: -march=armv8-a -std=c11;-fPIC;-fno-builtin;-fvisibility=hidden
> -- Performing Test COMPILER_RT_HAS_aarch64_FLOAT16
> -- Performing Test COMPILER_RT_HAS_aarch64_FLOAT16 - Success
> -- Performing Test COMPILER_RT_HAS_aarch64_BFLOAT16
> -- Performing Test COMPILER_RT_HAS_aarch64_BFLOAT16 - Success
> -- For aarch64 builtins preferring aarch64/fp_mode.c to fp_mode.c
> -- Configuring done (1.1s)
> -- Generating done (0.0s)
> -- Build files have been written to: /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/builtins-bins
> [5448/5462] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o
> FAILED: tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o 
> CCACHE_CPP2=yes CCACHE_HASHDIR=yes /usr/bin/ccache /home/b/sanitizer-aarch64-linux/build/llvm_build0/bin/clang++ -DGTEST_HAS_RTTI=0 -DLLVM_BUILD_STATIC -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/home/b/sanitizer-aarch64-linux/build/build_default/tools/llvm-reduce -I/home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/tools/llvm-reduce -I/home/b/sanitizer-aarch64-linux/build/build_default/include -I/home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/include -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG -std=c++17  -fno-exceptions -funwind-tables -fno-rtti -UNDEBUG -MD -MT tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o -MF tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o.d -o tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o -c /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp
> /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp:111:15: error: variable 'FPOp' set but not used [-Werror,-Wunused-but-set-variable]
>   111 |     if (auto *FPOp = dyn_cast<FPMathOperator>(NewCI))
>       |               ^
> 1 error generated.
> ninja: build stopped: subcommand failed.
> 
> How to reproduce locally: https://github.com/google/sanitizers/wiki/SanitizerBotReproduceBuild
> 
> 
> 
> 
> Step 13 (build compiler-rt default) failure: build compiler-rt default (failure)
> ...
> -- Performing additional configure checks with target flags: -march=armv8-a -std=c11;-fPIC;-fno-builtin;-fvisibility=hidden;-fomit-frame-pointer
> -- Performing Test COMPILER_RT_HAS_aarch64_FLOAT16
> -- Performing Test COMPILER_RT_HAS_aarch64_FLOAT16 - Success
> -- Performing Test COMPILER_RT_HAS_aarch64_BFLOAT16
> -- Performing Test COMPILER_RT_HAS_aarch64_BFLOAT16 - Success
> -- For aarch64 builtins preferring aarch64/fp_mode.c to fp_mode.c
> -- Configuring done (1.1s)
> -- Generating done (0.0s)
> -- Build files have been written to: /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/builtins-bins
> [5467/5481] Building CXX object tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o
> FAILED: tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o 
> CCACHE_CPP2=yes CCACHE_HASHDIR=yes /usr/bin/ccache /home/b/sanitizer-aarch64-linux/build/llvm_build0/bin/clang++ -DGTEST_HAS_RTTI=0 -DLLVM_BUILD_STATIC -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/home/b/sanitizer-aarch64-linux/build/build_default/tools/llvm-reduce -I/home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/tools/llvm-reduce -I/home/b/sanitizer-aarch64-linux/build/build_default/include -I/home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/include -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG -std=c++17  -fno-exceptions -funwind-tables -fno-rtti -UNDEBUG -MD -MT tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o -MF tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o.d -o tools/llvm-reduce/CMakeFiles/llvm-reduce.dir/deltas/ReduceOperandsToArgs.cpp.o -c /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp
> /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp:111:15: error: variable 'FPOp' set but not used [-Werror,-Wunused-but-set-variable]
>   111 |     if (auto *FPOp = dyn_cast<FPMathOperator>(NewCI))
>       |               ^
> 1 error generated.
> ninja: build stopped: subcommand failed.
> 
> How to reproduce locally: https://github.com/google/sanitizers/wiki/SanitizerBotReproduceBuild
> 
> 
> 
> 
> Step 14 (test compiler-rt default) failure: test compiler-rt default (failure)
> ...
> [2976/2980] Generating MSAN_INST_TEST_OBJECTS.msan_test.cpp.aarch64-with-call.o
> [2977/2980] Generating Msan-aarch64-with-call-Test
> [2978/2980] Generating MSAN_INST_TEST_OBJECTS.msan_test.cpp.aarch64.o
> [2979/2980] Generating Msan-aarch64-Test
> [2979/2980] Running compiler_rt regression tests
> llvm-lit: /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/utils/lit/lit/discovery.py:276: warning: input '/home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/interception/Unit' contained no tests
> llvm-lit: /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/utils/lit/lit/discovery.py:276: warning: input '/home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/sanitizer_common/Unit' contained no tests
> llvm-lit: /home/b/sanitizer-aarch64-linux/build/llvm-project/llvm/utils/lit/lit/main.py:72: note: The test suite configuration requested an individual test timeout of 0 seconds but a timeout of 900 seconds was requested on the command line. Forcing timeout to be 900 seconds.
> -- Testing: 6144 tests, 72 workers --
> Testing:  0.. 10.. 20.. 30.. 40.. 50.. 60.. 70.. 
> FAIL: TypeSanitizer-aarch64 :: anon-same-struct.c (4970 of 6144)
> ******************** TEST 'TypeSanitizer-aarch64 :: anon-same-struct.c' FAILED ********************
> Exit Code: 1
> 
> Command Output (stderr):
> --
> /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang  -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only   -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta   -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/anon-same-struct.c -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-same-struct.c.tmp &&  /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-same-struct.c.tmp >/home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-same-struct.c.tmp.out 2>&1 # RUN: at line 1
> + /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/anon-same-struct.c -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/anon-same-struct.c.tmp
> ld: error: cannot open /home/b/sanitizer-aarch64-linux/build/build_default/lib/clang/21/lib/aarch64-unknown-linux-gnu/libclang_rt.tysan.a: No such file or directory
> clang: error: linker command failed with exit code 1 (use -v to see invocation)
> 
> --
> 
> ********************
> Testing:  0.. 10.. 20.. 30.. 40.. 50.. 60.. 70.. 
> FAIL: TypeSanitizer-aarch64 :: int-long.c (4971 of 6144)
> ******************** TEST 'TypeSanitizer-aarch64 :: int-long.c' FAILED ********************
> Exit Code: 1
> 
> Command Output (stderr):
> --
> /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang  -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only   -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta   -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/int-long.c -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/int-long.c.tmp &&  /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/int-long.c.tmp >/home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/int-long.c.tmp.out 2>&1 # RUN: at line 1
> + /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/int-long.c -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/int-long.c.tmp
> ld: error: cannot open /home/b/sanitizer-aarch64-linux/build/build_default/lib/clang/21/lib/aarch64-unknown-linux-gnu/libclang_rt.tysan.a: No such file or directory
> clang: error: linker command failed with exit code 1 (use -v to see invocation)
> 
> --
> 
> ********************
> Testing:  0.. 10.. 20.. 30.. 40.. 50.. 60.. 70.. 
> FAIL: TypeSanitizer-aarch64 :: constexpr-subobject.cpp (4972 of 6144)
> ******************** TEST 'TypeSanitizer-aarch64 :: constexpr-subobject.cpp' FAILED ********************
> Exit Code: 1
> 
> Command Output (stderr):
> --
> /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang  -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only   -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta   -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/constexpr-subobject.cpp -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/constexpr-subobject.cpp.tmp &&  /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/constexpr-subobject.cpp.tmp >/home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/constexpr-subobject.cpp.tmp.out 2>&1 # RUN: at line 1
> + /home/b/sanitizer-aarch64-linux/build/build_default/./bin/clang -fsanitize=type -mno-omit-leaf-frame-pointer -fno-omit-frame-pointer -fno-optimize-sibling-calls -gline-tables-only -Wthread-safety -Wthread-safety-reference -Wthread-safety-beta -O0 /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/test/tysan/constexpr-subobject.cpp -o /home/b/sanitizer-aarch64-linux/build/build_default/runtimes/runtimes-bins/compiler-rt/test/tysan/AARCH64Config/Output/constexpr-subobject.cpp.tmp
> ld: error: cannot open /home/b/sanitizer-aarch64-linux/build/build_default/lib/clang/21/lib/aarch64-unknown-linux-gnu/libclang_rt.tysan.a: No such file or directory
> 
> ```
> 
> </details>

_Originally posted by @llvm-ci in https://github.com/llvm/llvm-project/issues/133466#issuecomment-2763349068_
            