### PR TITLE
[ThinLTO] Properly support targets that require importing all external functions

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/FunctionImportUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/FunctionImportUtils.h
@@ -16,9 +16,12 @@
 
 #include "llvm/ADT/SetVector.h"
 #include "llvm/IR/ModuleSummaryIndex.h"
+#include "llvm/Support/CommandLine.h"
 
 namespace llvm {
 class Module;
+
+extern cl::opt<bool> ForceImportAll;
 
 /// Class to handle necessary GlobalValue changes required by ThinLTO
 /// function importing, including linkage changes and any necessary renaming.

--- a/llvm/test/Transforms/FunctionImport/adjustable_threshold.ll
+++ b/llvm/test/Transforms/FunctionImport/adjustable_threshold.ll
@@ -15,11 +15,11 @@
 ; RUN: opt -passes=function-import -summary-file %t3.thinlto.bc %t.bc \
 ; RUN:  -import-instr-limit=1 -force-import-all -S \
 ; RUN:  | FileCheck %s --check-prefix=IMPORTALL
-; IMPORTALL-DAG: define available_externally void @globalfunc1()
-; IMPORTALL-DAG: define available_externally void @trampoline()
-; IMPORTALL-DAG: define available_externally void @largefunction()
-; IMPORTALL-DAG: define available_externally hidden void @staticfunc2.llvm.0()
-; IMPORTALL-DAG: define available_externally void @globalfunc2()
+; IMPORTALL-DAG: define void @globalfunc1()
+; IMPORTALL-DAG: define void @trampoline()
+; IMPORTALL-DAG: define void @largefunction()
+; IMPORTALL-DAG: define hidden void @staticfunc2.llvm.0()
+; IMPORTALL-DAG: define void @globalfunc2()
 
 declare void @globalfunc1()
 declare void @globalfunc2()

--- a/llvm/test/Transforms/FunctionImport/noinline.ll
+++ b/llvm/test/Transforms/FunctionImport/noinline.ll
@@ -19,5 +19,5 @@ entry:
 }
 
 ; NOIMPORT: declare void @foo(ptr)
-; IMPORT: define available_externally void @foo
+; IMPORT: define void @foo
 declare void @foo(ptr) #1


### PR DESCRIPTION
`ForceImportAll` mostly works, but it uses `available_externally` linkage. For
targets that don't support object linking, like AMDGPU, this approach doesn't
work.

With this PR, all imported functions use "default" linkage. I'm not entirely
sure if that's the best approach, but for AMDGPU it's not really a problem since
we internalize everything at a later stage.