### PR TITLE
[WebKit checkers] Treat Objective-C message send return value as safe

### DIFF
--- a/clang/test/Analysis/Checkers/WebKit/objc-mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/objc-mock-types.h
@@ -71,6 +71,7 @@ __attribute__((objc_root_class))
 + (Class) superclass;
 - (instancetype) init;
 - (instancetype)retain;
+- (instancetype)autorelease;
 - (void)release;
 - (BOOL)isKindOfClass:(Class)aClass;
 @end
@@ -220,6 +221,10 @@ template <typename T> struct RetainPtr {
   }
   operator PtrType() const { return t; }
   operator bool() const { return t; }
+
+#if !__has_feature(objc_arc)
+  PtrType autorelease() { [[clang::suppress]] return [t autorelease]; }
+#endif
 
 private:
   CFTypeRef toCFTypeRef(id ptr) { return (__bridge CFTypeRef)ptr; }

--- a/clang/test/Analysis/Checkers/WebKit/unretained-call-args-arc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-call-args-arc.mm
@@ -18,6 +18,7 @@ void foo() {
 
 @interface AnotherObj : NSObject
 - (void)foo:(SomeObj *)obj;
+- (SomeObj *)getSomeObj;
 @end
 
 @implementation AnotherObj
@@ -26,5 +27,13 @@ void foo() {
   [provide() doWork];
   CFArrayAppendValue(provide_cf(), nullptr);
   // expected-warning@-1{{Call argument for parameter 'theArray' is unretained and unsafe [alpha.webkit.UnretainedCallArgsChecker]}}
+}
+
+- (SomeObj *)getSomeObj {
+    return provide();
+}
+
+- (void)doWorkOnSomeObj {
+    [[self getSomeObj] doWork];
 }
 @end

--- a/clang/test/Analysis/Checkers/WebKit/unretained-call-args.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-call-args.mm
@@ -405,6 +405,7 @@ void idcf(CFTypeRef obj) {
 @interface TestObject : NSObject
 - (void)doWork:(NSString *)msg, ...;
 - (void)doWorkOnSelf;
+- (SomeObj *)getSomeObj;
 @end
 
 @implementation TestObject
@@ -419,6 +420,14 @@ void idcf(CFTypeRef obj) {
   // expected-warning@-1{{Call argument is unretained and unsafe}}
   // expected-warning@-2{{Call argument is unretained and unsafe}}
   [self doWork:@"hello", RetainPtr<SomeObj> { provide() }.get(), RetainPtr<CFMutableArrayRef> { provide_cf() }.get()];
+}
+
+- (SomeObj *)getSomeObj {
+    return RetainPtr<SomeObj *>(provide()).autorelease();
+}
+
+- (void)doWorkOnSomeObj {
+    [[self getSomeObj] doWork];
 }
 
 @end

--- a/clang/test/Analysis/Checkers/WebKit/unretained-local-vars.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-local-vars.mm
@@ -14,8 +14,9 @@ void bar(SomeObj *) {}
 } // namespace raw_ptr
 
 namespace pointer {
+SomeObj *provide();
 void foo_ref() {
-  SomeObj *bar = [[SomeObj alloc] init];
+  SomeObj *bar = provide();
   // expected-warning@-1{{Local variable 'bar' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
   [bar doWork];
 }
@@ -387,6 +388,7 @@ unsigned ccf(CFTypeRef obj) {
 } // ptr_conversion
 
 bool doMoreWorkOpaque(OtherObj*);
+SomeObj* provide();
 
 @implementation OtherObj
 - (instancetype)init {
@@ -396,5 +398,14 @@ bool doMoreWorkOpaque(OtherObj*);
 
 - (void)doMoreWork:(OtherObj *)other {
   doMoreWorkOpaque(other);
+}
+
+- (SomeObj*)getSomeObj {
+  return RetainPtr<SomeObj *>(provide()).autorelease();
+}
+
+- (void)storeSomeObj {
+  auto *obj = [self getSomeObj];
+  [obj doWork];
 }
 @end


### PR DESCRIPTION
Objective-C selectors are supposed to return autoreleased object. Treat these return values as safe.