### PR TITLE
Move relocation specifiers to AMDGPUMCExpr::Specifier

### DIFF
--- a/llvm/include/llvm/MC/MCExpr.h
+++ b/llvm/include/llvm/MC/MCExpr.h
@@ -218,14 +218,6 @@ public:
     VK_WASM_GOT_TLS,   // Wasm global index of TLS symbol.
     VK_WASM_FUNCINDEX, // Wasm function index.
 
-    VK_AMDGPU_GOTPCREL32_LO, // symbol@gotpcrel32@lo
-    VK_AMDGPU_GOTPCREL32_HI, // symbol@gotpcrel32@hi
-    VK_AMDGPU_REL32_LO,      // symbol@rel32@lo
-    VK_AMDGPU_REL32_HI,      // symbol@rel32@hi
-    VK_AMDGPU_REL64,         // symbol@rel64
-    VK_AMDGPU_ABS32_LO,      // symbol@abs32@lo
-    VK_AMDGPU_ABS32_HI,      // symbol@abs32@hi
-
     FirstTargetSpecifier,
   };
 

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUELFObjectWriter.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUELFObjectWriter.cpp
@@ -8,6 +8,7 @@
 
 #include "AMDGPUFixupKinds.h"
 #include "AMDGPUMCTargetDesc.h"
+#include "MCTargetDesc/AMDGPUMCExpr.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCELFObjectWriter.h"
 #include "llvm/MC/MCValue.h"
@@ -45,24 +46,24 @@ unsigned AMDGPUELFObjectWriter::getRelocType(MCContext &Ctx,
       return ELF::R_AMDGPU_ABS32_LO;
   }
 
-  switch (Target.getAccessVariant()) {
+  switch (AMDGPUMCExpr::Specifier(Target.getAccessVariant())) {
   default:
     break;
-  case MCSymbolRefExpr::VK_GOTPCREL:
+  case AMDGPUMCExpr::S_GOTPCREL:
     return ELF::R_AMDGPU_GOTPCREL;
-  case MCSymbolRefExpr::VK_AMDGPU_GOTPCREL32_LO:
+  case AMDGPUMCExpr::S_GOTPCREL32_LO:
     return ELF::R_AMDGPU_GOTPCREL32_LO;
-  case MCSymbolRefExpr::VK_AMDGPU_GOTPCREL32_HI:
+  case AMDGPUMCExpr::S_GOTPCREL32_HI:
     return ELF::R_AMDGPU_GOTPCREL32_HI;
-  case MCSymbolRefExpr::VK_AMDGPU_REL32_LO:
+  case AMDGPUMCExpr::S_REL32_LO:
     return ELF::R_AMDGPU_REL32_LO;
-  case MCSymbolRefExpr::VK_AMDGPU_REL32_HI:
+  case AMDGPUMCExpr::S_REL32_HI:
     return ELF::R_AMDGPU_REL32_HI;
-  case MCSymbolRefExpr::VK_AMDGPU_REL64:
+  case AMDGPUMCExpr::S_REL64:
     return ELF::R_AMDGPU_REL64;
-  case MCSymbolRefExpr::VK_AMDGPU_ABS32_LO:
+  case AMDGPUMCExpr::S_ABS32_LO:
     return ELF::R_AMDGPU_ABS32_LO;
-  case MCSymbolRefExpr::VK_AMDGPU_ABS32_HI:
+  case AMDGPUMCExpr::S_ABS32_HI:
     return ELF::R_AMDGPU_ABS32_HI;
   }
 

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCAsmInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCAsmInfo.cpp
@@ -8,6 +8,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "AMDGPUMCAsmInfo.h"
+#include "MCTargetDesc/AMDGPUMCExpr.h"
 #include "MCTargetDesc/AMDGPUMCTargetDesc.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCSubtargetInfo.h"
@@ -16,14 +17,14 @@
 using namespace llvm;
 
 const MCAsmInfo::VariantKindDesc variantKindDescs[] = {
-    {MCSymbolRefExpr::VK_GOTPCREL, "gotpcrel"},
-    {MCSymbolRefExpr::VK_AMDGPU_GOTPCREL32_LO, "gotpcrel32@lo"},
-    {MCSymbolRefExpr::VK_AMDGPU_GOTPCREL32_HI, "gotpcrel32@hi"},
-    {MCSymbolRefExpr::VK_AMDGPU_REL32_LO, "rel32@lo"},
-    {MCSymbolRefExpr::VK_AMDGPU_REL32_HI, "rel32@hi"},
-    {MCSymbolRefExpr::VK_AMDGPU_REL64, "rel64"},
-    {MCSymbolRefExpr::VK_AMDGPU_ABS32_LO, "abs32@lo"},
-    {MCSymbolRefExpr::VK_AMDGPU_ABS32_HI, "abs32@hi"},
+    {AMDGPUMCExpr::S_GOTPCREL, "gotpcrel"},
+    {AMDGPUMCExpr::S_GOTPCREL32_LO, "gotpcrel32@lo"},
+    {AMDGPUMCExpr::S_GOTPCREL32_HI, "gotpcrel32@hi"},
+    {AMDGPUMCExpr::S_REL32_LO, "rel32@lo"},
+    {AMDGPUMCExpr::S_REL32_HI, "rel32@hi"},
+    {AMDGPUMCExpr::S_REL64, "rel64"},
+    {AMDGPUMCExpr::S_ABS32_LO, "abs32@lo"},
+    {AMDGPUMCExpr::S_ABS32_HI, "abs32@hi"},
 };
 
 AMDGPUMCAsmInfo::AMDGPUMCAsmInfo(const Triple &TT,

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCCodeEmitter.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCCodeEmitter.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "MCTargetDesc/AMDGPUFixupKinds.h"
+#include "MCTargetDesc/AMDGPUMCExpr.h"
 #include "MCTargetDesc/AMDGPUMCTargetDesc.h"
 #include "SIDefines.h"
 #include "Utils/AMDGPUBaseInfo.h"
@@ -546,9 +547,8 @@ static bool needsPCRel(const MCExpr *Expr) {
   switch (Expr->getKind()) {
   case MCExpr::SymbolRef: {
     auto *SE = cast<MCSymbolRefExpr>(Expr);
-    MCSymbolRefExpr::VariantKind Kind = SE->getKind();
-    return Kind != MCSymbolRefExpr::VK_AMDGPU_ABS32_LO &&
-           Kind != MCSymbolRefExpr::VK_AMDGPU_ABS32_HI;
+    auto Spec = AMDGPU::getSpecifier(SE);
+    return Spec != AMDGPUMCExpr::S_ABS32_LO && Spec != AMDGPUMCExpr::S_ABS32_HI;
   }
   case MCExpr::Binary: {
     auto *BE = cast<MCBinaryExpr>(Expr);

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCExpr.h
@@ -39,6 +39,19 @@ public:
     AGVK_Occupancy
   };
 
+  // Relocation specifiers.
+  enum Specifier {
+    S_None,
+    S_GOTPCREL,      // symbol@gotpcrel
+    S_GOTPCREL32_LO, // symbol@gotpcrel32@lo
+    S_GOTPCREL32_HI, // symbol@gotpcrel32@hi
+    S_REL32_LO,      // symbol@rel32@lo
+    S_REL32_HI,      // symbol@rel32@hi
+    S_REL64,         // symbol@rel64
+    S_ABS32_LO,      // symbol@abs32@lo
+    S_ABS32_HI,      // symbol@abs32@hi
+  };
+
 private:
   VariantKind Kind;
   MCContext &Ctx;
@@ -113,6 +126,9 @@ void printAMDGPUMCExpr(const MCExpr *Expr, raw_ostream &OS,
 
 const MCExpr *foldAMDGPUMCExpr(const MCExpr *Expr, MCContext &Ctx);
 
+static inline AMDGPUMCExpr::Specifier getSpecifier(const MCSymbolRefExpr *SRE) {
+  return AMDGPUMCExpr::Specifier(SRE->getKind());
+}
 } // end namespace AMDGPU
 } // end namespace llvm
 

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUTargetStreamer.cpp
@@ -1005,8 +1005,8 @@ void AMDGPUTargetELFStreamer::EmitAmdhsaKernelDescriptor(
   // It implies R_AMDGPU_REL64, but ends up being R_AMDGPU_ABS64.
   Streamer.emitValue(
       MCBinaryExpr::createSub(
-          MCSymbolRefExpr::create(KernelCodeSymbol,
-                                  MCSymbolRefExpr::VK_AMDGPU_REL64, Context),
+          MCSymbolRefExpr::create(KernelCodeSymbol, AMDGPUMCExpr::S_REL64,
+                                  Context),
           MCSymbolRefExpr::create(KernelDescriptorSymbol, Context), Context),
       sizeof(amdhsa::kernel_descriptor_t::kernel_code_entry_byte_offset));
   for (uint32_t i = 0; i < sizeof(amdhsa::kernel_descriptor_t::reserved1); ++i)

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/R600MCCodeEmitter.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/R600MCCodeEmitter.cpp
@@ -13,6 +13,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "MCTargetDesc/AMDGPUMCExpr.h"
 #include "MCTargetDesc/R600MCTargetDesc.h"
 #include "R600Defines.h"
 #include "llvm/MC/MCCodeEmitter.h"


### PR DESCRIPTION
Similar to previous migration done for all other ELF targets.
Switch from the confusing `VariantKind` to `Specifier`, which aligns
with Arm and IBM AIX's documentation.

Moving forward, relocation specifiers should be integrated into
AMDGPUMCExpr rather than MCSymbolRefExpr::SubclassData.

(Note: the term AMDGPUMCExpr::VariantKind is for expressions
without relocation specifiers:
https://github.com/llvm/llvm-project/pull/82022

It's up to AMDGPU maintainers to integrate these constants into Specifier.
)
