### PR TITLE
[clang] implement common-sugar for adjusted member-pointers

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -14135,7 +14135,6 @@ static QualType getCommonSugarTypeNode(ASTContext &Ctx, const Type *X,
     CANONICAL_TYPE(IncompleteArray)
     CANONICAL_TYPE(HLSLAttributedResource)
     CANONICAL_TYPE(LValueReference)
-    CANONICAL_TYPE(MemberPointer)
     CANONICAL_TYPE(ObjCInterface)
     CANONICAL_TYPE(ObjCObject)
     CANONICAL_TYPE(ObjCObjectPointer)
@@ -14312,6 +14311,15 @@ static QualType getCommonSugarTypeNode(ASTContext &Ctx, const Type *X,
     if (!CD)
       return QualType();
     return Ctx.getUsingType(CD, Ctx.getQualifiedType(Underlying));
+  }
+  case Type::MemberPointer: {
+    const auto *PX = cast<MemberPointerType>(X),
+               *PY = cast<MemberPointerType>(Y);
+    CXXRecordDecl *Cls = PX->getMostRecentCXXRecordDecl();
+    assert(Cls == PY->getMostRecentCXXRecordDecl());
+    return Ctx.getMemberPointerType(
+        ::getCommonPointeeType(Ctx, PX, PY),
+        ::getCommonQualifier(Ctx, PX, PY, /*IsSame=*/false), Cls);
   }
   case Type::CountAttributed: {
     const auto *DX = cast<CountAttributedType>(X),

--- a/clang/test/SemaCXX/sugar-common-types.cpp
+++ b/clang/test/SemaCXX/sugar-common-types.cpp
@@ -186,3 +186,19 @@ namespace arrays {
     // expected-error@-1 {{lvalue of type 'const volatile volatile B1[1]' (aka 'const volatile volatile int[1]')}}
   } // namespace balanced_qualifiers
 } // namespace arrays
+
+namespace member_pointers {
+  template <class T> struct W {
+    X1 a;
+    Y1 b;
+  };
+  struct W1 : W<X2> {};
+  struct W2 : W<Y2> {};
+
+  N t1 = 0 ? &W<X2>::a : &W<Y2>::b;
+  // expected-error@-1 {{rvalue of type 'B1 W<B2>::*'}}
+
+  // FIXME: adjusted MemberPointer does not preserve qualifier
+  N t3 = 0 ? &W1::a : &W2::b;
+  // expected-error@-1 {{rvalue of type 'B1 W<void>::*'}}
+} // namespace member_pointers


### PR DESCRIPTION
This implements a missing case for an adjusted member-pointer in getCommonSugaredType, when that was originally implemented here: https://github.com/llvm/llvm-project/pull/130537

This missing case could otherwise cause a crash, so this is a regression fix.

This should fix the crash reported here: https://github.com/llvm/llvm-project/pull/132401#issuecomment-2764331907

No release notes, since this regression and its underlying feature were never released.