### PR TITLE
[Clang][Cmake] fix libtool duplicate member name warnings

### DIFF
--- a/clang/lib/CodeGen/CMakeLists.txt
+++ b/clang/lib/CodeGen/CMakeLists.txt
@@ -116,45 +116,8 @@ add_clang_library(clangCodeGen
   PatternInit.cpp
   SanitizerMetadata.cpp
   SwiftCallingConv.cpp
-  TargetBuiltins/ARM.cpp
-  TargetBuiltins/AMDGPU.cpp
-  TargetBuiltins/Hexagon.cpp
-  TargetBuiltins/NVPTX.cpp
-  TargetBuiltins/PPC.cpp
-  TargetBuiltins/RISCV.cpp
-  TargetBuiltins/SPIR.cpp
-  TargetBuiltins/SystemZ.cpp
-  TargetBuiltins/WebAssembly.cpp
-  TargetBuiltins/X86.cpp
   TargetInfo.cpp
-  Targets/AArch64.cpp
-  Targets/AMDGPU.cpp
-  Targets/ARC.cpp
-  Targets/ARM.cpp
-  Targets/AVR.cpp
-  Targets/BPF.cpp
-  Targets/CSKY.cpp
-  Targets/DirectX.cpp
-  Targets/Hexagon.cpp
-  Targets/Lanai.cpp
-  Targets/LoongArch.cpp
-  Targets/M68k.cpp
-  Targets/MSP430.cpp
-  Targets/Mips.cpp
-  Targets/NVPTX.cpp
-  Targets/PNaCl.cpp
-  Targets/PPC.cpp
-  Targets/RISCV.cpp
-  Targets/SPIR.cpp
-  Targets/Sparc.cpp
-  Targets/SystemZ.cpp
-  Targets/TCE.cpp
-  Targets/VE.cpp
-  Targets/WebAssembly.cpp
-  Targets/X86.cpp
-  Targets/XCore.cpp
   VarBypassDetector.cpp
-
   DEPENDS
   vt_gen
   intrinsics_gen
@@ -170,4 +133,16 @@ add_clang_library(clangCodeGen
   clangFrontend
   clangLex
   clangSerialization
+  clangCodeGenTargetBuiltins
+  clangCodeGenTargets
   )
+
+  target_include_directories(clangCodeGen
+    PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/TargetBuiltins
+    ${CMAKE_CURRENT_SOURCE_DIR}/Targets
+  )
+  
+  add_subdirectory(TargetBuiltins)
+  add_subdirectory(Targets)

--- a/clang/lib/CodeGen/TargetBuiltins/AMDGPU.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/AMDGPU.cpp
@@ -1,4 +1,4 @@
-//===------- AMDCPU.cpp - Emit LLVM Code for builtins ---------------------===//
+//===------- AMDGPU.cpp - Emit LLVM Code for builtins ---------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang/lib/CodeGen/TargetBuiltins/CMakeLists.txt
+++ b/clang/lib/CodeGen/TargetBuiltins/CMakeLists.txt
@@ -1,0 +1,19 @@
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+add_clang_library(clangCodeGenTargetBuiltins STATIC
+  ARM.cpp
+  AMDGPU.cpp
+  Hexagon.cpp
+  NVPTX.cpp
+  PPC.cpp
+  RISCV.cpp
+  SPIR.cpp
+  SystemZ.cpp
+  WebAssembly.cpp
+  X86.cpp
+)
+
+target_link_libraries(clangCodeGenTargetBuiltins
+  PRIVATE
+  clangCodeGen
+)

--- a/clang/lib/CodeGen/Targets/CMakeLists.txt
+++ b/clang/lib/CodeGen/Targets/CMakeLists.txt
@@ -1,0 +1,35 @@
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+add_clang_library(clangCodeGenTargets STATIC
+  AArch64.cpp
+  AMDGPU.cpp
+  ARC.cpp
+  ARM.cpp
+  AVR.cpp
+  BPF.cpp
+  CSKY.cpp
+  DirectX.cpp
+  Hexagon.cpp
+  Lanai.cpp
+  LoongArch.cpp
+  M68k.cpp
+  MSP430.cpp
+  Mips.cpp
+  NVPTX.cpp
+  PNaCl.cpp
+  PPC.cpp
+  RISCV.cpp
+  SPIR.cpp
+  Sparc.cpp
+  SystemZ.cpp
+  TCE.cpp
+  VE.cpp
+  WebAssembly.cpp
+  X86.cpp
+  XCore.cpp
+)
+
+target_link_libraries(clangCodeGenTargets
+  PRIVATE
+  clangCodeGen
+)


### PR DESCRIPTION
fixes #133199
 
PR #132252 Created a second file that shared `<TargetName>.cpp` in `clang/lib/CodeGen/CMakeLists.txt`

For example There were two `AMDGPU.cpp`'s one in `TargetBuiltins` and the other in `Targets`. Even though these were in different directories `libtool` warns that it might not distinguish them because they share the same base name.

There are two potential fixes. The easy fix is to rename one of them and keep one cmake file. That solution though doesn't future proof this problem in the event of a third `<TargetName>.cpp` and it seems teams want to just use the target name
https://github.com/llvm/llvm-project/pull/132252#issuecomment-2758178483.

The alternative fix is to seperate the cmake files into their own sub directories. I chose to create static libraries. It might of been possible to build an OBJECT, but I only saw examples of this in compiler-rt and test directories so assumed there was a reason it wasn't used.

