### PR TITLE
[lldb-dap] Swapping to not use FLAG_ENUM and just defining typed enums.

### DIFF
--- a/lldb/tools/lldb-dap/Protocol/ProtocolBase.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolBase.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "Protocol/ProtocolBase.h"
-#include "lldb/lldb-enumerations.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -32,8 +31,11 @@ static bool mapRaw(const json::Value &Params, StringLiteral Prop,
 
 namespace lldb_dap::protocol {
 
-FLAGS_ENUM(MessageType){eMessageTypeRequest, eMessageTypeResponse,
-                        eMessageTypeEvent};
+enum MessageType : unsigned {
+  eMessageTypeRequest,
+  eMessageTypeResponse,
+  eMessageTypeEvent
+};
 
 bool fromJSON(const json::Value &Params, MessageType &M, json::Path P) {
   auto rawType = Params.getAsString();

--- a/lldb/tools/lldb-dap/Protocol/ProtocolBase.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolBase.h
@@ -20,7 +20,6 @@
 #ifndef LLDB_TOOLS_LLDB_DAP_PROTOCOL_H
 #define LLDB_TOOLS_LLDB_DAP_PROTOCOL_H
 
-#include "lldb/lldb-enumerations.h"
 #include "llvm/Support/JSON.h"
 #include <cstdint>
 #include <optional>
@@ -65,11 +64,11 @@ struct Event {
 llvm::json::Value toJSON(const Event &);
 bool fromJSON(const llvm::json::Value &, Event &, llvm::json::Path);
 
-FLAGS_ENUM(ResponseMessage){
-    /// The request was cancelled
-    eResponseMessageCancelled,
-    /// The request may be retried once the adapter is in a 'stopped' state
-    eResponseMessageNotStopped,
+enum ResponseMessage : unsigned {
+  /// The request was cancelled
+  eResponseMessageCancelled,
+  /// The request may be retried once the adapter is in a 'stopped' state
+  eResponseMessageNotStopped,
 };
 
 /// Response for a request.

--- a/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolRequests.h
@@ -22,7 +22,6 @@
 
 #include "Protocol/ProtocolBase.h"
 #include "Protocol/ProtocolTypes.h"
-#include "lldb/lldb-enumerations.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/JSON.h"
 #include <cstdint>
@@ -57,26 +56,26 @@ bool fromJSON(const llvm::json::Value &, DisconnectArguments &,
 using DisconnectResponse = VoidResponse;
 
 /// Features supported by DAP clients.
-FLAGS_ENUM(ClientFeature){
-    eClientFeatureVariableType,
-    eClientFeatureVariablePaging,
-    eClientFeatureRunInTerminalRequest,
-    eClientFeatureMemoryReferences,
-    eClientFeatureProgressReporting,
-    eClientFeatureInvalidatedEvent,
-    eClientFeatureMemoryEvent,
-    /// Client supports the `argsCanBeInterpretedByShell` attribute on the
-    /// `runInTerminal` request.
-    eClientFeatureArgsCanBeInterpretedByShell,
-    eClientFeatureStartDebuggingRequest,
-    /// The client will interpret ANSI escape sequences in the display of
-    /// `OutputEvent.output` and `Variable.value` fields when
-    /// `Capabilities.supportsANSIStyling` is also enabled.
-    eClientFeatureANSIStyling,
+enum ClientFeature : unsigned {
+  eClientFeatureVariableType,
+  eClientFeatureVariablePaging,
+  eClientFeatureRunInTerminalRequest,
+  eClientFeatureMemoryReferences,
+  eClientFeatureProgressReporting,
+  eClientFeatureInvalidatedEvent,
+  eClientFeatureMemoryEvent,
+  /// Client supports the `argsCanBeInterpretedByShell` attribute on the
+  /// `runInTerminal` request.
+  eClientFeatureArgsCanBeInterpretedByShell,
+  eClientFeatureStartDebuggingRequest,
+  /// The client will interpret ANSI escape sequences in the display of
+  /// `OutputEvent.output` and `Variable.value` fields when
+  /// `Capabilities.supportsANSIStyling` is also enabled.
+  eClientFeatureANSIStyling,
 };
 
 /// Format of paths reported by the debug adapter.
-FLAGS_ENUM(PathFormat){ePatFormatPath, ePathFormatURI};
+enum PathFormat : unsigned { ePatFormatPath, ePathFormatURI };
 
 /// Arguments for `initialize` request.
 struct InitializeRequestArguments {

--- a/lldb/tools/lldb-dap/Protocol/ProtocolTypes.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolTypes.h
@@ -20,7 +20,6 @@
 #ifndef LLDB_TOOLS_LLDB_DAP_PROTOCOL_PROTOCOL_TYPES_H
 #define LLDB_TOOLS_LLDB_DAP_PROTOCOL_PROTOCOL_TYPES_H
 
-#include "lldb/lldb-enumerations.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/JSON.h"
 #include <cstdint>
@@ -57,8 +56,12 @@ struct ExceptionBreakpointsFilter {
 };
 llvm::json::Value toJSON(const ExceptionBreakpointsFilter &);
 
-FLAGS_ENUM(ColumnType){eColumnTypeString, eColumnTypeNumber, eColumnTypeBoolean,
-                       eColumnTypeTimestamp};
+enum ColumnType : unsigned {
+  eColumnTypeString,
+  eColumnTypeNumber,
+  eColumnTypeBoolean,
+  eColumnTypeTimestamp
+};
 
 /// A ColumnDescriptor specifies what module attribute to show in a column of
 /// the modules view, how to format it, and what the column’s label should be.
@@ -87,23 +90,27 @@ llvm::json::Value toJSON(const ColumnDescriptor &);
 
 /// Names of checksum algorithms that may be supported by a debug adapter.
 /// Values: ‘MD5’, ‘SHA1’, ‘SHA256’, ‘timestamp’.
-FLAGS_ENUM(ChecksumAlgorithm){eChecksumAlgorithmMD5, eChecksumAlgorithmSHA1,
-                              eChecksumAlgorithmSHA256,
-                              eChecksumAlgorithmTimestamp};
+enum ChecksumAlgorithm : unsigned {
+  eChecksumAlgorithmMD5,
+  eChecksumAlgorithmSHA1,
+  eChecksumAlgorithmSHA256,
+  eChecksumAlgorithmTimestamp
+};
 llvm::json::Value toJSON(const ChecksumAlgorithm &);
 
 /// Describes one or more type of breakpoint a BreakpointMode applies to. This
 /// is a non-exhaustive enumeration and may expand as future breakpoint types
 /// are added.
-FLAGS_ENUM(BreakpointModeApplicability){
-    /// In `SourceBreakpoint`'s.
-    eBreakpointModeApplicabilitySource,
-    /// In exception breakpoints applied in the `ExceptionFilterOptions`.
-    eBreakpointModeApplicabilityException,
-    /// In data breakpoints requested in the `DataBreakpointInfo` request.
-    eBreakpointModeApplicabilityData,
-    /// In `InstructionBreakpoint`'s.
-    eBreakpointModeApplicabilityInstruction};
+enum BreakpointModeApplicability : unsigned {
+  /// In `SourceBreakpoint`'s.
+  eBreakpointModeApplicabilitySource,
+  /// In exception breakpoints applied in the `ExceptionFilterOptions`.
+  eBreakpointModeApplicabilityException,
+  /// In data breakpoints requested in the `DataBreakpointInfo` request.
+  eBreakpointModeApplicabilityData,
+  /// In `InstructionBreakpoint`'s.
+  eBreakpointModeApplicabilityInstruction
+};
 llvm::json::Value toJSON(const BreakpointModeApplicability &);
 
 /// A `BreakpointMode` is provided as a option when setting breakpoints on
@@ -126,101 +133,101 @@ struct BreakpointMode {
 llvm::json::Value toJSON(const BreakpointMode &);
 
 /// Debug Adapter Features flags supported by lldb-dap.
-FLAGS_ENUM(AdapterFeature){
-    /// The debug adapter supports ANSI escape sequences in styling of
-    /// `OutputEvent.output` and `Variable.value` fields.
-    eAdapterFeatureANSIStyling,
-    /// The debug adapter supports the `breakpointLocations` request.
-    eAdapterFeatureBreakpointLocationsRequest,
-    /// The debug adapter supports the `cancel` request.
-    eAdapterFeatureCancelRequest,
-    /// The debug adapter supports the `clipboard` context value in the
-    /// `evaluate` request.
-    eAdapterFeatureClipboardContext,
-    /// The debug adapter supports the `completions` request.
-    eAdapterFeatureCompletionsRequest,
-    /// The debug adapter supports conditional breakpoints.
-    eAdapterFeatureConditionalBreakpoints,
-    /// The debug adapter supports the `configurationDone` request.
-    eAdapterFeatureConfigurationDoneRequest,
-    /// The debug adapter supports the `asAddress` and `bytes` fields in the
-    /// `dataBreakpointInfo` request.
-    eAdapterFeatureDataBreakpointBytes,
-    /// The debug adapter supports data breakpoints.
-    eAdapterFeatureDataBreakpoints,
-    /// The debug adapter supports the delayed loading of parts of the stack,
-    /// which requires that both the `startFrame` and `levels` arguments and the
-    /// `totalFrames` result of the `stackTrace` request are supported.
-    eAdapterFeatureDelayedStackTraceLoading,
-    /// The debug adapter supports the `disassemble` request.
-    eAdapterFeatureDisassembleRequest,
-    /// The debug adapter supports a (side effect free) `evaluate` request for
-    /// data hovers.
-    eAdapterFeatureEvaluateForHovers,
-    /// The debug adapter supports `filterOptions` as an argument on the
-    /// `setExceptionBreakpoints` request.
-    eAdapterFeatureExceptionFilterOptions,
-    /// The debug adapter supports the `exceptionInfo` request.
-    eAdapterFeatureExceptionInfoRequest,
-    /// The debug adapter supports `exceptionOptions` on the
-    /// `setExceptionBreakpoints` request.
-    eAdapterFeatureExceptionOptions,
-    /// The debug adapter supports function breakpoints.
-    eAdapterFeatureFunctionBreakpoints,
-    /// The debug adapter supports the `gotoTargets` request.
-    eAdapterFeatureGotoTargetsRequest,
-    /// The debug adapter supports breakpoints that break execution after a
-    /// specified number of hits.
-    eAdapterFeatureHitConditionalBreakpoints,
-    /// The debug adapter supports adding breakpoints based on instruction
-    /// references.
-    eAdapterFeatureInstructionBreakpoints,
-    /// The debug adapter supports the `loadedSources` request.
-    eAdapterFeatureLoadedSourcesRequest,
-    /// The debug adapter supports log points by interpreting the `logMessage`
-    /// attribute of the `SourceBreakpoint`.
-    eAdapterFeatureLogPoints,
-    /// The debug adapter supports the `modules` request.
-    eAdapterFeatureModulesRequest,
-    /// The debug adapter supports the `readMemory` request.
-    eAdapterFeatureReadMemoryRequest,
-    /// The debug adapter supports restarting a frame.
-    eAdapterFeatureRestartFrame,
-    /// The debug adapter supports the `restart` request. In this case a client
-    /// should not implement `restart` by terminating and relaunching the
-    /// adapter but by calling the `restart` request.
-    eAdapterFeatureRestartRequest,
-    /// The debug adapter supports the `setExpression` request.
-    eAdapterFeatureSetExpression,
-    /// The debug adapter supports setting a variable to a value.
-    eAdapterFeatureSetVariable,
-    /// The debug adapter supports the `singleThread` property on the execution
-    /// requests (`continue`, `next`, `stepIn`, `stepOut`, `reverseContinue`,
-    /// `stepBack`).
-    eAdapterFeatureSingleThreadExecutionRequests,
-    /// The debug adapter supports stepping back via the `stepBack` and
-    /// `reverseContinue` requests.
-    eAdapterFeatureStepBack,
-    /// The debug adapter supports the `stepInTargets` request.
-    eAdapterFeatureStepInTargetsRequest,
-    /// The debug adapter supports stepping granularities (argument
-    /// `granularity`) for the stepping requests.
-    eAdapterFeatureSteppingGranularity,
-    /// The debug adapter supports the `terminate` request.
-    eAdapterFeatureTerminateRequest,
-    /// The debug adapter supports the `terminateThreads` request.
-    eAdapterFeatureTerminateThreadsRequest,
-    /// The debug adapter supports the `suspendDebuggee` attribute on the
-    /// `disconnect` request.
-    eAdapterFeatureSuspendDebuggee,
-    /// The debug adapter supports a `format` attribute on the `stackTrace`,
-    /// `variables`, and `evaluate` requests.
-    eAdapterFeatureValueFormattingOptions,
-    /// The debug adapter supports the `writeMemory` request.
-    eAdapterFeatureWriteMemoryRequest,
-    /// The debug adapter supports the `terminateDebuggee` attribute on the
-    /// `disconnect` request.
-    eAdapterFeatureTerminateDebuggee,
+enum AdapterFeature : unsigned {
+  /// The debug adapter supports ANSI escape sequences in styling of
+  /// `OutputEvent.output` and `Variable.value` fields.
+  eAdapterFeatureANSIStyling,
+  /// The debug adapter supports the `breakpointLocations` request.
+  eAdapterFeatureBreakpointLocationsRequest,
+  /// The debug adapter supports the `cancel` request.
+  eAdapterFeatureCancelRequest,
+  /// The debug adapter supports the `clipboard` context value in the
+  /// `evaluate` request.
+  eAdapterFeatureClipboardContext,
+  /// The debug adapter supports the `completions` request.
+  eAdapterFeatureCompletionsRequest,
+  /// The debug adapter supports conditional breakpoints.
+  eAdapterFeatureConditionalBreakpoints,
+  /// The debug adapter supports the `configurationDone` request.
+  eAdapterFeatureConfigurationDoneRequest,
+  /// The debug adapter supports the `asAddress` and `bytes` fields in the
+  /// `dataBreakpointInfo` request.
+  eAdapterFeatureDataBreakpointBytes,
+  /// The debug adapter supports data breakpoints.
+  eAdapterFeatureDataBreakpoints,
+  /// The debug adapter supports the delayed loading of parts of the stack,
+  /// which requires that both the `startFrame` and `levels` arguments and the
+  /// `totalFrames` result of the `stackTrace` request are supported.
+  eAdapterFeatureDelayedStackTraceLoading,
+  /// The debug adapter supports the `disassemble` request.
+  eAdapterFeatureDisassembleRequest,
+  /// The debug adapter supports a (side effect free) `evaluate` request for
+  /// data hovers.
+  eAdapterFeatureEvaluateForHovers,
+  /// The debug adapter supports `filterOptions` as an argument on the
+  /// `setExceptionBreakpoints` request.
+  eAdapterFeatureExceptionFilterOptions,
+  /// The debug adapter supports the `exceptionInfo` request.
+  eAdapterFeatureExceptionInfoRequest,
+  /// The debug adapter supports `exceptionOptions` on the
+  /// `setExceptionBreakpoints` request.
+  eAdapterFeatureExceptionOptions,
+  /// The debug adapter supports function breakpoints.
+  eAdapterFeatureFunctionBreakpoints,
+  /// The debug adapter supports the `gotoTargets` request.
+  eAdapterFeatureGotoTargetsRequest,
+  /// The debug adapter supports breakpoints that break execution after a
+  /// specified number of hits.
+  eAdapterFeatureHitConditionalBreakpoints,
+  /// The debug adapter supports adding breakpoints based on instruction
+  /// references.
+  eAdapterFeatureInstructionBreakpoints,
+  /// The debug adapter supports the `loadedSources` request.
+  eAdapterFeatureLoadedSourcesRequest,
+  /// The debug adapter supports log points by interpreting the `logMessage`
+  /// attribute of the `SourceBreakpoint`.
+  eAdapterFeatureLogPoints,
+  /// The debug adapter supports the `modules` request.
+  eAdapterFeatureModulesRequest,
+  /// The debug adapter supports the `readMemory` request.
+  eAdapterFeatureReadMemoryRequest,
+  /// The debug adapter supports restarting a frame.
+  eAdapterFeatureRestartFrame,
+  /// The debug adapter supports the `restart` request. In this case a client
+  /// should not implement `restart` by terminating and relaunching the
+  /// adapter but by calling the `restart` request.
+  eAdapterFeatureRestartRequest,
+  /// The debug adapter supports the `setExpression` request.
+  eAdapterFeatureSetExpression,
+  /// The debug adapter supports setting a variable to a value.
+  eAdapterFeatureSetVariable,
+  /// The debug adapter supports the `singleThread` property on the execution
+  /// requests (`continue`, `next`, `stepIn`, `stepOut`, `reverseContinue`,
+  /// `stepBack`).
+  eAdapterFeatureSingleThreadExecutionRequests,
+  /// The debug adapter supports stepping back via the `stepBack` and
+  /// `reverseContinue` requests.
+  eAdapterFeatureStepBack,
+  /// The debug adapter supports the `stepInTargets` request.
+  eAdapterFeatureStepInTargetsRequest,
+  /// The debug adapter supports stepping granularities (argument
+  /// `granularity`) for the stepping requests.
+  eAdapterFeatureSteppingGranularity,
+  /// The debug adapter supports the `terminate` request.
+  eAdapterFeatureTerminateRequest,
+  /// The debug adapter supports the `terminateThreads` request.
+  eAdapterFeatureTerminateThreadsRequest,
+  /// The debug adapter supports the `suspendDebuggee` attribute on the
+  /// `disconnect` request.
+  eAdapterFeatureSuspendDebuggee,
+  /// The debug adapter supports a `format` attribute on the `stackTrace`,
+  /// `variables`, and `evaluate` requests.
+  eAdapterFeatureValueFormattingOptions,
+  /// The debug adapter supports the `writeMemory` request.
+  eAdapterFeatureWriteMemoryRequest,
+  /// The debug adapter supports the `terminateDebuggee` attribute on the
+  /// `disconnect` request.
+  eAdapterFeatureTerminateDebuggee,
 };
 
 /// Information about the capabilities of a debug adapter.
@@ -261,10 +268,10 @@ struct Capabilities {
 };
 llvm::json::Value toJSON(const Capabilities &);
 
-FLAGS_ENUM(PresentationHint){
-    ePresentationHintNormal,
-    ePresentationHintEmphasize,
-    ePresentationHintDeemphasize,
+enum PresentationHint : unsigned {
+  ePresentationHintNormal,
+  ePresentationHintEmphasize,
+  ePresentationHintDeemphasize,
 };
 
 /// A `Source` is a descriptor for source code. It is returned from the debug


### PR DESCRIPTION
Small tweak to the previous patch to make the enums in `lldb_dap::protocol` typed to work with types like `llvm::DenseSet` found by ubsan.