### PR TITLE
[CI] Exclude gn changes from running premerge

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -200,6 +200,11 @@ def _get_modified_projects(modified_files: list[str]) -> Set[str]:
         # documentation builds.
         if len(path_parts) > 2 and path_parts[1] == "docs":
             continue
+        # Exclude files for the gn build. We do not test it within premerge
+        # and changes occur often enough that they otherwise take up
+        # capacity.
+        if len(path_parts) > 3 and path_parts[:3] == ("llvm", "utils", "gn"):
+            continue
         modified_projects.add(pathlib.Path(modified_file).parts[0])
     return modified_projects
 

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -179,6 +179,15 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")
 
+    def test_exclude_gn(self):
+        env_variables = compute_projects.get_env_variables(
+            ["llvm/utils/gn/build/BUILD.gn"], "Linux"
+        )
+        self.assertEqual(env_variables["projects_to_build"], "")
+        self.assertEqual(env_variables["project_check_targets"], "")
+        self.assertEqual(env_variables["runtimes_to_build"], "")
+        self.assertEqual(env_variables["runtimes_check_targets"], "")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
These changes are mostly pushed by the gnsyncbot directly to main and thus don't go through a PR, but we still test on main to see if main is broken. Given these touch llvm/, they end up burning a decent amount of testing time for no real benefit, so I think it makes sense to exclude them from premerge testing explicitly.