### PR TITLE
[Github] Bump workflows depending on CI container to ubuntu 24.04

### DIFF
--- a/.github/workflows/ci-post-commit-analyzer.yml
+++ b/.github/workflows/ci-post-commit-analyzer.yml
@@ -34,9 +34,9 @@ jobs:
     if: >-
       github.repository_owner == 'llvm' &&
       github.event.action != 'closed'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
-      image: 'ghcr.io/llvm/ci-ubuntu-22.04:latest'
+      image: 'ghcr.io/llvm/ci-ubuntu-24.04:latest'
     env:
       LLVM_VERSION: 18
     steps:

--- a/.github/workflows/libclang-python-tests.yml
+++ b/.github/workflows/libclang-python-tests.yml
@@ -37,5 +37,5 @@ jobs:
       projects: clang
       # There is an issue running on "windows-2019".
       # See https://github.com/llvm/llvm-project/issues/76601#issuecomment-1873049082.
-      os_list: '["ubuntu-22.04"]'
+      os_list: '["ubuntu-24.04"]'
       python_version: ${{ matrix.python-version }}

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -39,12 +39,7 @@ on:
         type: string
         # Use windows-2019 due to:
         # https://developercommunity.visualstudio.com/t/Prev-Issue---with-__assume-isnan-/1597317
-        # Use ubuntu-22.04 rather than ubuntu-24.04 to match the ubuntu
-        # version in the CI container. Without this, setup-python tries
-        # to install a python version linked against a newer version of glibc.
-        # TODO(boomanaiden154): Bump the Ubuntu version once the version in the
-        # container is bumped.
-        default: '["ubuntu-22.04", "windows-2019", "macOS-13"]'
+        default: '["ubuntu-24.04", "windows-2019", "macOS-13"]'
 
       python_version:
         required: false
@@ -64,7 +59,7 @@ jobs:
     name: Lit Tests
     runs-on: ${{ matrix.os }}
     container:
-      image: ${{(startsWith(matrix.os, 'ubuntu') && 'ghcr.io/llvm/ci-ubuntu-22.04:latest') || null}}
+      image: ${{(startsWith(matrix.os, 'ubuntu') && 'ghcr.io/llvm/ci-ubuntu-24.04:latest') || null}}
       volumes:
         - /mnt/:/mnt/
     strategy:

--- a/.github/workflows/spirv-tests.yml
+++ b/.github/workflows/spirv-tests.yml
@@ -26,4 +26,4 @@ jobs:
       build_target: check-llvm-codegen-spirv
       projects:
       extra_cmake_args: '-DLLVM_TARGETS_TO_BUILD="SPIRV" -DLLVM_INCLUDE_SPIRV_TOOLS_TESTS=ON'
-      os_list: '["ubuntu-22.04"]'
+      os_list: '["ubuntu-24.04"]'


### PR DESCRIPTION
This patch bumps workflows depending upon the Linux CI container to ubuntu 24.04. The 22.04 container is no longer being built as it was recently bumped to 24.04, so this patch moves all of these workflows over to the new container to keep them updated and ensure they are using an actually maintained version of the container image.