### PR TITLE
llvm-reduce: Reduce with early return of arguments

### DIFF
--- a/llvm/test/tools/llvm-reduce/reduce-values-to-return-args.ll
+++ b/llvm/test/tools/llvm-reduce/reduce-values-to-return-args.ll
@@ -1,26 +1,27 @@
 ; RUN: llvm-reduce --abort-on-invalid-reduction --delta-passes=arguments-to-return --test FileCheck --test-arg --check-prefixes=INTERESTING --test-arg %s --test-arg --input-file %s -o %t
 ; RUN: FileCheck --check-prefixes=RESULT %s < %t
 
+@gv = global i32 0
 
-; INTERESTING-LABEL: @move_entry_block_use_argument_to_return(i32 %arg, ptr %ptr) {
-; INTERESTING: %arg
+; INTERESTING-LABEL: @move_entry_block_use_argument_to_return(i32 %arg) {
+; INTERESTING: i32 %arg
 
 ; RESULT-LABEL: define i32 @move_entry_block_use_argument_to_return(
 ; RESULT-NEXT: ret i32 %arg
 ; RESULT-NEXT: }
-define void @move_entry_block_use_argument_to_return(i32 %arg, ptr %ptr) {
-  store i32 %arg, ptr %ptr
+define void @move_entry_block_use_argument_to_return(i32 %arg) {
+  store i32 %arg, ptr @gv
   ret void
 }
 
-; INTERESTING-LABEL: @move_entry_block_use_argument_to_return_existing_ret(i32 %arg, ptr %ptr) {
+; INTERESTING-LABEL: @move_entry_block_use_argument_to_return_existing_ret(i32 %arg) {
 ; INTERESTING: %arg
 
 ; RESULT-LABEL: define i32 @move_entry_block_use_argument_to_return_existing_ret(
 ; RESULT-NEXT: ret i32 %arg
 ; RESULT-NEXT: }
-define i32 @move_entry_block_use_argument_to_return_existing_ret(i32 %arg, ptr %ptr) {
-  store i32 %arg, ptr %ptr
+define i32 @move_entry_block_use_argument_to_return_existing_ret(i32 %arg) {
+  store i32 %arg, ptr @gv
   ret i32 0
 }
 
@@ -44,6 +45,17 @@ bb1:
   br i1 %cond1, label %bb0, label %bb2
 
 bb2:
+  ret void
+}
+
+; INTERESTING-LABEL: define {{.*}} @keep_first_arg(i32 %arg0, ptr %arg1) {
+; INTERESTING: %arg0
+
+; RESULT-LABEL: define i32 @keep_first_arg(
+; RESULT-NEXT: ret i32 %arg0
+; RESULT-NEXT: }
+define void @keep_first_arg(i32 %arg0, ptr %arg1) {
+  store i32 %arg0, ptr %arg1
   ret void
 }
 

--- a/llvm/test/tools/llvm-reduce/reduce-values-to-return-args.ll
+++ b/llvm/test/tools/llvm-reduce/reduce-values-to-return-args.ll
@@ -1,0 +1,77 @@
+; RUN: llvm-reduce --abort-on-invalid-reduction --delta-passes=arguments-to-return --test FileCheck --test-arg --check-prefixes=INTERESTING --test-arg %s --test-arg --input-file %s -o %t
+; RUN: FileCheck --check-prefixes=RESULT %s < %t
+
+
+; INTERESTING-LABEL: @move_entry_block_use_argument_to_return(i32 %arg, ptr %ptr) {
+; INTERESTING: %arg
+
+; RESULT-LABEL: define i32 @move_entry_block_use_argument_to_return(
+; RESULT-NEXT: ret i32 %arg
+; RESULT-NEXT: }
+define void @move_entry_block_use_argument_to_return(i32 %arg, ptr %ptr) {
+  store i32 %arg, ptr %ptr
+  ret void
+}
+
+; INTERESTING-LABEL: @move_entry_block_use_argument_to_return_existing_ret(i32 %arg, ptr %ptr) {
+; INTERESTING: %arg
+
+; RESULT-LABEL: define i32 @move_entry_block_use_argument_to_return_existing_ret(
+; RESULT-NEXT: ret i32 %arg
+; RESULT-NEXT: }
+define i32 @move_entry_block_use_argument_to_return_existing_ret(i32 %arg, ptr %ptr) {
+  store i32 %arg, ptr %ptr
+  ret i32 0
+}
+
+; INTERESTING-LABEL: @move_phi_block_use_argument_to_return(i32 %arg, ptr %ptr0, ptr %ptr1, i1 %cond0, i1 %cond1) {
+; INTERESTING: %arg
+
+; RESULT-LABEL: define i32 @move_phi_block_use_argument_to_return(
+; RESULT-NEXT: entry:
+; RESULT-NEXT: ret i32 %arg
+define void @move_phi_block_use_argument_to_return(i32 %arg, ptr %ptr0, ptr %ptr1, i1 %cond0, i1 %cond1) {
+entry:
+  br i1 %cond0, label %bb0, label %bb1
+
+bb0:
+  %phi = phi i32 [ %arg, %entry ], [ 123, %bb1 ]
+  store i32 %arg, ptr %ptr0
+  store i32 %phi, ptr %ptr1
+  br label %bb1
+
+bb1:
+  br i1 %cond1, label %bb0, label %bb2
+
+bb2:
+  ret void
+}
+
+; INTERESTING-LABEL: define {{.*}} @keep_second_arg(i32 %arg0, ptr %arg1) {
+; INTERESTING: %arg1
+
+; RESULT-LABEL: define ptr @keep_second_arg(
+; RESULT-NEXT: ret ptr %arg1
+; RESULT-NEXT: }
+define void @keep_second_arg(i32 %arg0, ptr %arg1) {
+  store i32 %arg0, ptr %arg1
+  ret void
+}
+
+; INTERESTING-LABEL: @multi_void_return_arg(i1 %arg0, ptr %arg1, i32 %arg2) {
+; INTERESTING: i32 %arg2
+
+; RESULT-LABEL: define i32 @multi_void_return_arg(i1 %arg0, ptr %arg1, i32 %arg2) {
+; RESULT-NEXT: entry:
+; RESULT-NEXT: ret i32 %arg2
+define void @multi_void_return_arg(i1 %arg0, ptr %arg1, i32 %arg2) {
+entry:
+  br i1 %arg0, label %bb0, label %bb1
+
+bb0:
+  store i32 %arg2, ptr %arg1
+  ret void
+
+bb1:
+  ret void
+}

--- a/llvm/tools/llvm-reduce/DeltaPasses.def
+++ b/llvm/tools/llvm-reduce/DeltaPasses.def
@@ -49,7 +49,11 @@ DELTA_PASS_IR("attributes", reduceAttributesDeltaPass, "Reducing Attributes")
 DELTA_PASS_IR("target-features-attr", reduceTargetFeaturesAttrDeltaPass, "Reducing target-features")
 DELTA_PASS_IR("module-data", reduceModuleDataDeltaPass, "Reducing Module Data")
 DELTA_PASS_IR("opcodes", reduceOpcodesDeltaPass, "Reducing Opcodes")
-DELTA_PASS_IR("instructions-to-return", reduceInstructionsToReturnDeltaPass, "Early return of instructions")
+
+DELTA_PASS_IR("arguments-to-return", reduceArgumentsToReturnDeltaPass,
+              "Converting arguments to function return value")
+DELTA_PASS_IR("instructions-to-return", reduceInstructionsToReturnDeltaPass,
+              "Early return of instructions")
 DELTA_PASS_IR("volatile", reduceVolatileInstructionsDeltaPass, "Reducing Volatile Instructions")
 DELTA_PASS_IR("atomic-ordering", reduceAtomicOrderingDeltaPass, "Reducing Atomic Ordering")
 DELTA_PASS_IR("syncscopes", reduceAtomicSyncScopesDeltaPass, "Reducing Atomic Sync Scopes")

--- a/llvm/tools/llvm-reduce/deltas/ReduceValuesToReturn.h
+++ b/llvm/tools/llvm-reduce/deltas/ReduceValuesToReturn.h
@@ -12,6 +12,7 @@
 #include "Delta.h"
 
 namespace llvm {
+void reduceArgumentsToReturnDeltaPass(Oracle &O, ReducerWorkItem &WorkItem);
 void reduceInstructionsToReturnDeltaPass(Oracle &O, ReducerWorkItem &WorkItem);
 } // namespace llvm
 


### PR DESCRIPTION
Extend the instruction -> return reduction with one that inserts
return of function arguments. Not sure how useful this really is. This
has more freedom since we could insert the return anywhere in the function,
but this just inserts the return in the entry block.