### PR TITLE
[CI] Fix Monolithic Linux Build in Ubuntu 24.04

### DIFF
--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -53,9 +53,9 @@ targets="${2}"
 lit_args="-v --xunit-xml-output ${BUILD_DIR}/test-results.xml --use-unique-output-file-name --timeout=1200 --time-tests"
 
 echo "--- cmake"
-pip install -q -r "${MONOREPO_ROOT}"/mlir/python/requirements.txt
-pip install -q -r "${MONOREPO_ROOT}"/lldb/test/requirements.txt
-pip install -q -r "${MONOREPO_ROOT}"/.ci/requirements.txt
+pip install --break-system-packages -q -r "${MONOREPO_ROOT}"/mlir/python/requirements.txt
+pip install --break-system-packages -q -r "${MONOREPO_ROOT}"/lldb/test/requirements.txt
+pip install --break-system-packages -q -r "${MONOREPO_ROOT}"/.ci/requirements.txt
 cmake -S "${MONOREPO_ROOT}"/llvm -B "${BUILD_DIR}" \
       -D LLVM_ENABLE_PROJECTS="${projects}" \
       -G Ninja \


### PR DESCRIPTION
This patch fixes the monolithic linux build in Ubuntu 24.04. Newer versions of debian/ubuntu pass a warning when installing packages at the system level using pip as it interferes with system package manager installed python packages. We do not use any system package manager installed python packages, so we just ignore the warning (that is an error without passing the flag) by passing the --break-system-packages flag.