### PR TITLE
[mlir][bugfix] Fix erroneous condition in `getEffectsOnResource`

### DIFF
--- a/mlir/include/mlir/Interfaces/SideEffectInterfaceBase.td
+++ b/mlir/include/mlir/Interfaces/SideEffectInterfaceBase.td
@@ -140,7 +140,7 @@ class EffectOpInterfaceBase<string name, string baseEffect>
               }] # baseEffect # [{>> & effects) {
       getEffects(effects);
       ::llvm::erase_if(effects, [&](auto &it) {
-        return it.getResource() != resource;
+        return it.getResource()->getResourceID() != resource->getResourceID();
       });
     }
   }];


### PR DESCRIPTION
This patch corrects an invalid condition in `getEffectsOnResource` used
to identify relevant "resources":

```cpp
return it.getResource() != resource;
```

The current implementation assumes that only one instance of each
resource will exist, so comparing raw pointers is both safe and
sufficient. This assumption stems from constructs like:

```cpp
static DerivedResource *get() {
  static DerivedResource instance;
  return &instance;
}
```
i.e., resource instances returned via static singleton methods.

However, as discussed in
 * https://github.com/llvm/llvm-project/issues/129216,

this assumption breaks in practice — notably on macOS (Apple Silicon)
when built with:

* `-DBUILD_SHARED_LIBS=On`.

In such cases, multiple instances of the same logical resource may exist
across shared library boundaries, leading to incorrect behavior and
causing failures in tests like:

* test/Dialect/Transform/check-use-after-free.mlir

This patch replaces the pointer comparison with a comparison based on
resource identity:

```cpp
return it.getResource()->getResourceID() != resource->getResourceID();
```
This approach aligns better with the intent of `getEffectsOnResource`,
which is to:

```cpp
/// Collect all of the effect instances that operate on the provided
/// resource (...)
```

Fixes #129216
