### PR TITLE
[libc++] `flat_meow` transparent comparator string literals

### DIFF
--- a/libcxx/include/__flat_map/flat_multimap.h
+++ b/libcxx/include/__flat_map/flat_multimap.h
@@ -10,18 +10,16 @@
 #ifndef _LIBCPP___FLAT_MAP_FLAT_MULTIMAP_H
 #define _LIBCPP___FLAT_MAP_FLAT_MULTIMAP_H
 
+#include <__algorithm/equal_range.h>
 #include <__algorithm/lexicographical_compare_three_way.h>
+#include <__algorithm/lower_bound.h>
 #include <__algorithm/min.h>
 #include <__algorithm/ranges_equal.h>
-#include <__algorithm/ranges_equal_range.h>
 #include <__algorithm/ranges_inplace_merge.h>
 #include <__algorithm/ranges_is_sorted.h>
-#include <__algorithm/ranges_lower_bound.h>
-#include <__algorithm/ranges_partition_point.h>
 #include <__algorithm/ranges_sort.h>
-#include <__algorithm/ranges_unique.h>
-#include <__algorithm/ranges_upper_bound.h>
 #include <__algorithm/remove_if.h>
+#include <__algorithm/upper_bound.h>
 #include <__assert>
 #include <__compare/synth_three_way.h>
 #include <__concepts/convertible_to.h>
@@ -443,7 +441,7 @@ public:
              is_move_constructible_v<mapped_type>
   _LIBCPP_HIDE_FROM_ABI iterator emplace(_Args&&... __args) {
     std::pair<key_type, mapped_type> __pair(std::forward<_Args>(__args)...);
-    auto __key_it    = ranges::upper_bound(__containers_.keys, __pair.first, __compare_);
+    auto __key_it    = std::upper_bound(__containers_.keys.begin(), __containers_.keys.end(), __pair.first, __compare_);
     auto __mapped_it = __corresponding_mapped_it(*this, __key_it);
 
     return __flat_map_utils::__emplace_exact_pos(
@@ -473,7 +471,7 @@ public:
       //                   |
       //                  hint
       // We want to insert "2" after the last existing "2"
-      __key_iter    = ranges::upper_bound(__containers_.keys.begin(), __key_iter, __pair.first, __compare_);
+      __key_iter    = std::upper_bound(__containers_.keys.begin(), __key_iter, __pair.first, __compare_);
       __mapped_iter = __corresponding_mapped_it(*this, __key_iter);
     } else {
       _LIBCPP_ASSERT_INTERNAL(!__prev_larger && __next_smaller, "this means that the multimap is not sorted");
@@ -485,7 +483,7 @@ public:
       //  |
       // hint
       // We want to insert "2" before the first existing "2"
-      __key_iter    = ranges::lower_bound(__key_iter, __containers_.keys.end(), __pair.first, __compare_);
+      __key_iter    = std::lower_bound(__key_iter, __containers_.keys.end(), __pair.first, __compare_);
       __mapped_iter = __corresponding_mapped_it(*this, __key_iter);
     }
     return __flat_map_utils::__emplace_exact_pos(
@@ -804,7 +802,8 @@ private:
 
   template <class _Self, class _Kp>
   _LIBCPP_HIDE_FROM_ABI static auto __equal_range_impl(_Self&& __self, const _Kp& __key) {
-    auto [__key_first, __key_last] = ranges::equal_range(__self.__containers_.keys, __key, __self.__compare_);
+    auto [__key_first, __key_last] =
+        std::equal_range(__self.__containers_.keys.begin(), __self.__containers_.keys.end(), __key, __self.__compare_);
 
     using __iterator_type = ranges::iterator_t<decltype(__self)>;
     return std::make_pair(__iterator_type(__key_first, __corresponding_mapped_it(__self, __key_first)),
@@ -813,14 +812,16 @@ private:
 
   template <class _Res, class _Self, class _Kp>
   _LIBCPP_HIDE_FROM_ABI static _Res __lower_bound(_Self&& __self, _Kp& __x) {
-    auto __key_iter    = ranges::lower_bound(__self.__containers_.keys, __x, __self.__compare_);
+    auto __key_iter =
+        std::lower_bound(__self.__containers_.keys.begin(), __self.__containers_.keys.end(), __x, __self.__compare_);
     auto __mapped_iter = __corresponding_mapped_it(__self, __key_iter);
     return _Res(std::move(__key_iter), std::move(__mapped_iter));
   }
 
   template <class _Res, class _Self, class _Kp>
   _LIBCPP_HIDE_FROM_ABI static _Res __upper_bound(_Self&& __self, _Kp& __x) {
-    auto __key_iter    = ranges::upper_bound(__self.__containers_.keys, __x, __self.__compare_);
+    auto __key_iter =
+        std::upper_bound(__self.__containers_.keys.begin(), __self.__containers_.keys.end(), __x, __self.__compare_);
     auto __mapped_iter = __corresponding_mapped_it(__self, __key_iter);
     return _Res(std::move(__key_iter), std::move(__mapped_iter));
   }

--- a/libcxx/include/__flat_set/flat_set.h
+++ b/libcxx/include/__flat_set/flat_set.h
@@ -16,7 +16,6 @@
 #include <__algorithm/ranges_adjacent_find.h>
 #include <__algorithm/ranges_equal.h>
 #include <__algorithm/ranges_inplace_merge.h>
-#include <__algorithm/ranges_partition_point.h>
 #include <__algorithm/ranges_sort.h>
 #include <__algorithm/ranges_unique.h>
 #include <__algorithm/remove_if.h>

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.access/at_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.access/at_transparent.pass.cpp
@@ -106,6 +106,13 @@ int main(int, char**) {
     TEST_IGNORE_NODISCARD m.at(Transparent<int>{3});
     assert(transparent_used);
   }
+  {
+    // std::string and C string literal
+    using M = std::flat_map<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
+    int& x = m.at("alpha");
+    assert(x == 1);
+  }
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.access/at_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.access/at_transparent.pass.cpp
@@ -107,7 +107,7 @@ int main(int, char**) {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_map<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
     int& x = m.at("alpha");

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.access/index_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.access/index_transparent.pass.cpp
@@ -95,7 +95,7 @@ int main(int, char**) {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_map<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
     int& x = m["alpha"];

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.access/index_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.access/index_transparent.pass.cpp
@@ -95,6 +95,13 @@ int main(int, char**) {
     assert(transparent_used);
   }
   {
+    // std::string and C string literal
+    using M = std::flat_map<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
+    int& x = m["alpha"];
+    assert(x == 1);
+  }
+  {
     auto index_func = [](auto& m, auto key_arg, auto value_arg) {
       using FlatMap                             = std::decay_t<decltype(m)>;
       using Key                                 = typename FlatMap::key_type;

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/erase_key_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/erase_key_transparent.pass.cpp
@@ -140,7 +140,7 @@ int main(int, char**) {
     test_erase_exception_guarantee(erase_transparent);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_map<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
     auto n = m.erase("beta");

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/erase_key_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/erase_key_transparent.pass.cpp
@@ -139,6 +139,13 @@ int main(int, char**) {
     };
     test_erase_exception_guarantee(erase_transparent);
   }
+  {
+    // std::string and C string literal
+    using M = std::flat_map<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
+    auto n = m.erase("beta");
+    assert(n == 1);
+  }
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/insert_or_assign_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/insert_or_assign_transparent.pass.cpp
@@ -254,6 +254,18 @@ int main(int, char**) {
     };
     test_emplace_exception_guarantee(insert_or_assign_iter);
   }
+  {
+    // std::string and C string literal
+    using M = std::flat_map<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
+    auto [it, inserted] = m.insert_or_assign("alpha", 2);
+    assert(!inserted);
+    assert(it == m.begin());
+    assert(it->second == 2);
+    auto it2 = m.insert_or_assign(m.begin(), "beta2", 2);
+    assert(it2 == m.begin() + 2);
+    assert(it2->second == 2);
+  }
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/insert_or_assign_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/insert_or_assign_transparent.pass.cpp
@@ -255,7 +255,7 @@ int main(int, char**) {
     test_emplace_exception_guarantee(insert_or_assign_iter);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_map<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
     auto [it, inserted] = m.insert_or_assign("alpha", 2);

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/insert_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/insert_transparent.pass.cpp
@@ -164,7 +164,7 @@ int main(int, char**) {
     test_emplace_exception_guarantee(insert_func_iter);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_map<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
     auto [it, inserted] = m.insert({"alpha", 1});

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/insert_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/insert_transparent.pass.cpp
@@ -163,5 +163,15 @@ int main(int, char**) {
     };
     test_emplace_exception_guarantee(insert_func_iter);
   }
+  {
+    // std::string and C string literal
+    using M = std::flat_map<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
+    auto [it, inserted] = m.insert({"alpha", 1});
+    assert(!inserted);
+    assert(it == m.begin());
+    auto it2 = m.insert(m.begin(), {"beta2", 2});
+    assert(it2 == m.begin() + 2);
+  }
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/try_emplace_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/try_emplace_transparent.pass.cpp
@@ -161,7 +161,7 @@ int main(int, char**) {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_map<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
     auto [it1, inserted] = m.try_emplace("charlie", 4);

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/try_emplace_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.modifiers/try_emplace_transparent.pass.cpp
@@ -161,6 +161,17 @@ int main(int, char**) {
     assert(transparent_used);
   }
   {
+    // std::string and C string literal
+    using M = std::flat_map<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
+    auto [it1, inserted] = m.try_emplace("charlie", 4);
+    assert(it1 == m.begin() + 2);
+    assert(inserted);
+
+    auto it2 = m.try_emplace(m.begin(), "beta2", 2);
+    assert(it2 == m.begin() + 2);
+  }
+  {
     auto try_emplace = [](auto& m, auto key_arg, auto value_arg) {
       using M   = std::decay_t<decltype(m)>;
       using Key = typename M::key_type;

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/contains_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/contains_transparent.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <cassert>
 #include <flat_map>
+#include <functional>
 #include <string>
 #include <utility>
 #include <deque>
@@ -66,6 +67,13 @@ int main(int, char**) {
     auto b = m.contains(Transparent<int>{3});
     assert(b);
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_map<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
+    assert(m.contains("beta") == true);
+    assert(m.contains("charlie") == false);
   }
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/contains_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/contains_transparent.pass.cpp
@@ -69,7 +69,7 @@ int main(int, char**) {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_map<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
     assert(m.contains("beta") == true);

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/count_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/count_transparent.pass.cpp
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <deque>
 #include <flat_map>
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -66,6 +67,13 @@ int main(int, char**) {
     auto n = m.count(Transparent<int>{3});
     assert(n == 1);
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_map<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
+    assert(m.count("alpha") == 1);
+    assert(m.count("charlie") == 0);
   }
 
   return 0;

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/count_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/count_transparent.pass.cpp
@@ -69,7 +69,7 @@ int main(int, char**) {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_map<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
     assert(m.count("alpha") == 1);

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/equal_range_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/equal_range_transparent.pass.cpp
@@ -16,6 +16,7 @@
 #include <cassert>
 #include <deque>
 #include <flat_map>
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -94,6 +95,14 @@ int main(int, char**) {
     auto p = m.equal_range(Transparent<int>{3});
     assert(p.first != p.second);
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_map<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
+    auto [first, last] = m.equal_range("beta");
+    assert(first == m.begin() + 1);
+    assert(last == m.begin() + 2);
   }
 
   return 0;

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/equal_range_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/equal_range_transparent.pass.cpp
@@ -97,7 +97,7 @@ int main(int, char**) {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_map<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
     auto [first, last] = m.equal_range("beta");

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/find_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/find_transparent.pass.cpp
@@ -16,6 +16,7 @@
 #include <cassert>
 #include <deque>
 #include <flat_map>
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -82,6 +83,13 @@ int main(int, char**) {
     auto it = m.find(Transparent<int>{3});
     assert(it != m.end());
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_map<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
+    auto it = m.find("beta");
+    assert(it == m.begin() + 1);
   }
 
   return 0;

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/find_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/find_transparent.pass.cpp
@@ -85,7 +85,7 @@ int main(int, char**) {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_map<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
     auto it = m.find("beta");

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/lower_bound_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/lower_bound_transparent.pass.cpp
@@ -16,6 +16,7 @@
 #include <cassert>
 #include <deque>
 #include <flat_map>
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -89,6 +90,13 @@ int main(int, char**) {
     auto it = m.lower_bound(Transparent<int>{3});
     assert(it != m.end());
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_map<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
+    auto it = m.lower_bound("charlie");
+    assert(it == m.begin() + 2);
   }
 
   return 0;

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/lower_bound_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/lower_bound_transparent.pass.cpp
@@ -92,7 +92,7 @@ int main(int, char**) {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_map<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
     auto it = m.lower_bound("charlie");

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/upper_bound_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/upper_bound_transparent.pass.cpp
@@ -91,7 +91,7 @@ int main(int, char**) {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_map<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
     auto it = m.upper_bound("charlie");

--- a/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/upper_bound_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.map/flat.map.operations/upper_bound_transparent.pass.cpp
@@ -16,6 +16,7 @@
 #include <cassert>
 #include <deque>
 #include <flat_map>
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -88,6 +89,13 @@ int main(int, char**) {
     auto it = m.upper_bound(Transparent<int>{2});
     assert(it != m.end());
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_map<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"epsilon", 1}, {"eta", 3}, {"gamma", 3}};
+    auto it = m.upper_bound("charlie");
+    assert(it == m.begin() + 2);
   }
 
   return 0;

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/erase_key_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/erase_key_transparent.pass.cpp
@@ -156,6 +156,13 @@ int main(int, char**) {
     };
     test_erase_exception_guarantee(erase_transparent);
   }
+  {
+    // std::string and C string literal
+    using M = std::flat_multimap<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"beta", 1}, {"eta", 3}, {"gamma", 3}};
+    auto n = m.erase("beta");
+    assert(n == 2);
+  }
 
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/erase_key_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/erase_key_transparent.pass.cpp
@@ -157,7 +157,7 @@ int main(int, char**) {
     test_erase_exception_guarantee(erase_transparent);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_multimap<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"beta", 1}, {"eta", 3}, {"gamma", 3}};
     auto n = m.erase("beta");

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/insert_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/insert_transparent.pass.cpp
@@ -132,7 +132,7 @@ int main(int, char**) {
     test_emplace_exception_guarantee(insert_func_iter);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_multimap<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"beta", 1}, {"eta", 3}, {"gamma", 3}};
     auto it = m.insert({"beta", 1});

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/insert_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.modifiers/insert_transparent.pass.cpp
@@ -131,5 +131,14 @@ int main(int, char**) {
     };
     test_emplace_exception_guarantee(insert_func_iter);
   }
+  {
+    // std::string and C string literal
+    using M = std::flat_multimap<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"beta", 1}, {"eta", 3}, {"gamma", 3}};
+    auto it = m.insert({"beta", 1});
+    assert(it == m.begin() + 3);
+    auto it2 = m.insert(m.begin(), {"beta2", 2});
+    assert(it2 == m.begin() + 4);
+  }
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/contains_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/contains_transparent.pass.cpp
@@ -71,7 +71,7 @@ int main(int, char**) {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_multimap<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"beta", 1}, {"eta", 3}, {"gamma", 3}};
     assert(m.contains("beta") == true);

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/contains_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/contains_transparent.pass.cpp
@@ -16,6 +16,7 @@
 
 #include <cassert>
 #include <flat_map>
+#include <functional>
 #include <string>
 #include <utility>
 #include <deque>
@@ -68,6 +69,13 @@ int main(int, char**) {
     auto b = m.contains(Transparent<int>{3});
     assert(b);
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_multimap<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"beta", 1}, {"eta", 3}, {"gamma", 3}};
+    assert(m.contains("beta") == true);
+    assert(m.contains("charlie") == false);
   }
   return 0;
 }

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/count_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/count_transparent.pass.cpp
@@ -17,6 +17,7 @@
 #include <cassert>
 #include <deque>
 #include <flat_map>
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -77,6 +78,13 @@ int main(int, char**) {
     auto n = m.count(Transparent<int>{3});
     assert(n == 2);
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_multimap<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"beta", 1}, {"eta", 3}, {"gamma", 3}};
+    assert(m.count("beta") == 2);
+    assert(m.count("charlie") == 0);
   }
 
   return 0;

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/count_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/count_transparent.pass.cpp
@@ -80,7 +80,7 @@ int main(int, char**) {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_multimap<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"beta", 1}, {"eta", 3}, {"gamma", 3}};
     assert(m.count("beta") == 2);

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/equal_range_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/equal_range_transparent.pass.cpp
@@ -107,7 +107,7 @@ int main(int, char**) {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_multimap<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"beta", 1}, {"eta", 3}, {"gamma", 3}};
     auto [first, last] = m.equal_range("beta");

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/equal_range_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/equal_range_transparent.pass.cpp
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <deque>
 #include <flat_map>
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -104,6 +105,14 @@ int main(int, char**) {
     assert(p.first == m.begin() + 2);
     assert(p.second == m.end());
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_multimap<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"beta", 1}, {"eta", 3}, {"gamma", 3}};
+    auto [first, last] = m.equal_range("beta");
+    assert(first == m.begin() + 1);
+    assert(last == m.begin() + 3);
   }
 
   return 0;

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/find_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/find_transparent.pass.cpp
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <deque>
 #include <flat_map>
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -93,6 +94,13 @@ int main(int, char**) {
     auto it = m.find(Transparent<int>{3});
     assert(it != m.end());
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_multimap<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"beta", 1}, {"eta", 3}, {"gamma", 3}};
+    auto it = m.find("beta");
+    assert(it == m.begin() + 1);
   }
 
   return 0;

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/find_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/find_transparent.pass.cpp
@@ -96,7 +96,7 @@ int main(int, char**) {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_multimap<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"beta", 1}, {"eta", 3}, {"gamma", 3}};
     auto it = m.find("beta");

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/lower_bound_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/lower_bound_transparent.pass.cpp
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <deque>
 #include <flat_map>
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -101,6 +102,13 @@ int main(int, char**) {
     auto it = m.lower_bound(Transparent<int>{3});
     assert(it != m.end());
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_multimap<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"beta", 1}, {"eta", 3}, {"gamma", 3}};
+    auto it = m.lower_bound("charlie");
+    assert(it == m.begin() + 3);
   }
 
   return 0;

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/lower_bound_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/lower_bound_transparent.pass.cpp
@@ -104,7 +104,7 @@ int main(int, char**) {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_multimap<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"beta", 1}, {"eta", 3}, {"gamma", 3}};
     auto it = m.lower_bound("charlie");

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/upper_bound_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/upper_bound_transparent.pass.cpp
@@ -103,7 +103,7 @@ int main(int, char**) {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_multimap<std::string, int, std::less<>>;
     M m{{"alpha", 1}, {"beta", 2}, {"beta", 1}, {"eta", 3}, {"gamma", 3}};
     auto it = m.upper_bound("charlie");

--- a/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/upper_bound_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.multimap/flat.multimap.operations/upper_bound_transparent.pass.cpp
@@ -18,6 +18,7 @@
 #include <cassert>
 #include <deque>
 #include <flat_map>
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -100,6 +101,13 @@ int main(int, char**) {
     auto it = m.upper_bound(Transparent<int>{2});
     assert(it == m.begin() + 3);
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_multimap<std::string, int, std::less<>>;
+    M m{{"alpha", 1}, {"beta", 2}, {"beta", 1}, {"eta", 3}, {"gamma", 3}};
+    auto it = m.upper_bound("charlie");
+    assert(it == m.begin() + 3);
   }
 
   return 0;

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.modifiers/erase_key_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.modifiers/erase_key_transparent.pass.cpp
@@ -139,7 +139,7 @@ void test() {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_set<std::string, std::less<>>;
     M m{"alpha", "beta", "epsilon", "eta", "gamma"};
     auto n = m.erase("beta");

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.modifiers/erase_key_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.modifiers/erase_key_transparent.pass.cpp
@@ -138,6 +138,13 @@ void test() {
     assert(n == 1);
     assert(transparent_used);
   }
+  {
+    // std::string and C string literal
+    using M = std::flat_set<std::string, std::less<>>;
+    M m{"alpha", "beta", "epsilon", "eta", "gamma"};
+    auto n = m.erase("beta");
+    assert(n == 1);
+  }
 }
 
 void test_exception() {

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_transparent.pass.cpp
@@ -123,6 +123,14 @@ void test() {
     ASSERT_SAME_TYPE(decltype(m.insert(m.begin(), Evil())), M::iterator);
     ASSERT_SAME_TYPE(decltype(m.insert(m.begin(), m.end())), void);
   }
+  {
+    // std::string and C string literal
+    using M = std::flat_set<std::string, std::less<>>;
+    M m{"alpha", "beta", "epsilon", "eta", "gamma"};
+    auto [iter, inserted] = m.insert("beta");
+    assert(!inserted);
+    assert(iter == m.begin() + 1);
+  }
 }
 
 void test_exception() {

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.modifiers/insert_transparent.pass.cpp
@@ -124,7 +124,7 @@ void test() {
     ASSERT_SAME_TYPE(decltype(m.insert(m.begin(), m.end())), void);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_set<std::string, std::less<>>;
     M m{"alpha", "beta", "epsilon", "eta", "gamma"};
     auto [iter, inserted] = m.insert("beta");

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/contains_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/contains_transparent.pass.cpp
@@ -76,7 +76,7 @@ void test() {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_set<std::string, std::less<>>;
     M m{"alpha", "beta", "epsilon", "eta", "gamma"};
     assert(m.contains("beta"));

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/contains_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/contains_transparent.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <cassert>
 #include <flat_set>
+#include <functional>
 #include <string>
 #include <utility>
 #include <deque>
@@ -73,6 +74,13 @@ void test() {
     auto b = m.contains(Transparent<int>{3});
     assert(b);
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_set<std::string, std::less<>>;
+    M m{"alpha", "beta", "epsilon", "eta", "gamma"};
+    assert(m.contains("beta"));
+    assert(!m.contains("eta2"));
   }
 }
 

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/count_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/count_transparent.pass.cpp
@@ -75,7 +75,7 @@ void test() {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_set<std::string, std::less<>>;
     M m{"alpha", "beta", "epsilon", "eta", "gamma"};
     assert(m.count("beta") == 1);

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/count_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/count_transparent.pass.cpp
@@ -15,6 +15,7 @@
 #include <cassert>
 #include <deque>
 #include <flat_set>
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -72,6 +73,13 @@ void test() {
     auto n = m.count(Transparent<int>{3});
     assert(n == 1);
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_set<std::string, std::less<>>;
+    M m{"alpha", "beta", "epsilon", "eta", "gamma"};
+    assert(m.count("beta") == 1);
+    assert(m.count("eta2") == 0);
   }
 }
 

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/equal_range_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/equal_range_transparent.pass.cpp
@@ -16,6 +16,7 @@
 #include <cassert>
 #include <deque>
 #include <flat_set>
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -100,6 +101,14 @@ void test() {
     auto p = m.equal_range(Transparent<int>{3});
     assert(p.first != p.second);
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_set<std::string, std::less<>>;
+    M m{"alpha", "beta", "epsilon", "eta", "gamma"};
+    auto [first, last] = m.equal_range("beta");
+    assert(first == m.begin() + 1);
+    assert(last == m.begin() + 2);
   }
 }
 

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/equal_range_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/equal_range_transparent.pass.cpp
@@ -103,7 +103,7 @@ void test() {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_set<std::string, std::less<>>;
     M m{"alpha", "beta", "epsilon", "eta", "gamma"};
     auto [first, last] = m.equal_range("beta");

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/find_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/find_transparent.pass.cpp
@@ -93,7 +93,7 @@ void test() {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_set<std::string, std::less<>>;
     M m{"alpha", "beta", "epsilon", "eta", "gamma"};
     auto it = m.find("beta");

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/find_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/find_transparent.pass.cpp
@@ -16,6 +16,7 @@
 #include <cassert>
 #include <deque>
 #include <flat_set>
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -90,6 +91,15 @@ void test() {
     auto it = m.find(Transparent<int>{3});
     assert(it != m.end());
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_set<std::string, std::less<>>;
+    M m{"alpha", "beta", "epsilon", "eta", "gamma"};
+    auto it = m.find("beta");
+    assert(it == m.begin() + 1);
+    auto it2 = m.find("beta2");
+    assert(it2 == m.end());
   }
 }
 

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/lower_bound_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/lower_bound_transparent.pass.cpp
@@ -16,6 +16,7 @@
 #include <cassert>
 #include <deque>
 #include <flat_set>
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -96,6 +97,15 @@ void test() {
     auto it = m.lower_bound(Transparent<int>{3});
     assert(it != m.end());
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_set<std::string, std::less<>>;
+    M m{"alpha", "beta", "epsilon", "eta", "gamma"};
+    auto it = m.lower_bound("beta");
+    assert(it == m.begin() + 1);
+    auto it2 = m.lower_bound("beta2");
+    assert(it2 == m.begin() + 2);
   }
 }
 

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/lower_bound_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/lower_bound_transparent.pass.cpp
@@ -99,7 +99,7 @@ void test() {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_set<std::string, std::less<>>;
     M m{"alpha", "beta", "epsilon", "eta", "gamma"};
     auto it = m.lower_bound("beta");

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/upper_bound_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/upper_bound_transparent.pass.cpp
@@ -16,6 +16,7 @@
 #include <cassert>
 #include <deque>
 #include <flat_set>
+#include <functional>
 #include <string>
 #include <utility>
 
@@ -96,6 +97,15 @@ void test() {
     auto it = m.upper_bound(Transparent<int>{2});
     assert(it != m.end());
     assert(transparent_used);
+  }
+  {
+    // std::string and C string literal
+    using M = std::flat_set<std::string, std::less<>>;
+    M m{"alpha", "beta", "epsilon", "eta", "gamma"};
+    auto it = m.upper_bound("beta");
+    assert(it == m.begin() + 2);
+    auto it2 = m.upper_bound("beta2");
+    assert(it2 == m.begin() + 2);
   }
 }
 

--- a/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/upper_bound_transparent.pass.cpp
+++ b/libcxx/test/std/containers/container.adaptors/flat.set/flat.set.operations/upper_bound_transparent.pass.cpp
@@ -99,7 +99,7 @@ void test() {
     assert(transparent_used);
   }
   {
-    // std::string and C string literal
+    // LWG4239 std::string and C string literal
     using M = std::flat_set<std::string, std::less<>>;
     M m{"alpha", "beta", "epsilon", "eta", "gamma"};
     auto it = m.upper_bound("beta");


### PR DESCRIPTION
See discussion in https://cplusplus.github.io/LWG/issue4239

```cpp
std::flat_map<std::string, int, std::less<>> m;
m.try_emplace("abc", 5);  // hard error
```

The reason is that we specify in 23.6.8.7 [[flat.map.modifiers]](https://wg21.link/flat.map.modifiers) p21 the effect to be as if `ranges::upper_bound` is called.

`ranges::upper_bound` requires indirect_strict_weak_order, which requires the comparator to be invocable for all combinations. In this case, it requires

`const char (&)[4] < const char (&)[4]`
to be well-formed, which is no longer the case in C++26 after [P2865R6](https://wg21.link/P2865R6).

We should just use `std::upper_bound` instead.