### PR TITLE
[lldb] Hoist UUID generation into the UUID class

### DIFF
--- a/lldb/include/lldb/Utility/UUID.h
+++ b/lldb/include/lldb/Utility/UUID.h
@@ -12,26 +12,28 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Endian.h"
+#include "llvm/Support/Error.h"
 #include <cstddef>
 #include <cstdint>
 #include <string>
+#include <sys/_types/_u_int32_t.h>
 
 namespace lldb_private {
 
-  class Stream;
+class Stream;
 
+/// Represents UUID's of various sizes.  In all cases, a uuid of all zeros is
+/// treated as an "Invalid UUID" marker, and the UUID created from such data
+/// will return false for IsValid.
 class UUID {
-  // Represents UUID's of various sizes.  In all cases, a uuid of all zeros is
-  // treated as an "Invalid UUID" marker, and the UUID created from such data
-  // will return false for IsValid.
 public:
   UUID() = default;
-  
-  /// Creates a uuid from the data pointed to by the bytes argument.
+
+  /// Create a uuid from the data pointed to by the bytes argument.
   UUID(llvm::ArrayRef<uint8_t> bytes) : m_bytes(bytes) {
     if (llvm::all_of(m_bytes, [](uint8_t b) { return b == 0; })) {
       Clear();
-   }
+    }
   }
 
   // Reference:
@@ -50,13 +52,12 @@ public:
   /// Create a UUID from CvRecordPdb70.
   UUID(CvRecordPdb70 debug_info);
 
-  /// Creates a UUID from the data pointed to by the bytes argument. 
+  /// Create a UUID from the data pointed to by the bytes argument.
   UUID(const void *bytes, uint32_t num_bytes) {
     if (!bytes)
       return;
-    *this 
-        = UUID(llvm::ArrayRef<uint8_t>(reinterpret_cast<const uint8_t *>(bytes), 
-               num_bytes));
+    *this = UUID(llvm::ArrayRef<uint8_t>(
+        reinterpret_cast<const uint8_t *>(bytes), num_bytes));
   }
 
   void Clear() { m_bytes.clear(); }
@@ -67,7 +68,7 @@ public:
 
   explicit operator bool() const { return IsValid(); }
   bool IsValid() const { return !m_bytes.empty(); }
-  
+
   std::string GetAsString(llvm::StringRef separator = "-") const;
 
   bool SetFromStringRef(llvm::StringRef str);
@@ -87,6 +88,9 @@ public:
   static llvm::StringRef
   DecodeUUIDBytesFromString(llvm::StringRef str,
                             llvm::SmallVectorImpl<uint8_t> &uuid_bytes);
+
+  /// Create a random UUID.
+  static llvm::Expected<UUID> Generate(uint32_t num_bytes = 16);
 
 private:
   // GNU ld generates 20-byte build-ids. Size chosen to avoid heap allocations

--- a/lldb/include/lldb/Utility/UUID.h
+++ b/lldb/include/lldb/Utility/UUID.h
@@ -16,7 +16,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <string>
-#include <sys/_types/_u_int32_t.h>
 
 namespace lldb_private {
 
@@ -90,7 +89,7 @@ public:
                             llvm::SmallVectorImpl<uint8_t> &uuid_bytes);
 
   /// Create a random UUID.
-  static llvm::Expected<UUID> Generate(uint32_t num_bytes = 16);
+  static UUID Generate(uint32_t num_bytes = 16);
 
 private:
   // GNU ld generates 20-byte build-ids. Size chosen to avoid heap allocations

--- a/lldb/source/Core/Telemetry.cpp
+++ b/lldb/source/Core/Telemetry.cpp
@@ -9,15 +9,18 @@
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/Telemetry.h"
 #include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
 #include "lldb/Utility/UUID.h"
 #include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-forward.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/Format.h"
 #include "llvm/Support/RandomNumberGenerator.h"
 #include "llvm/Telemetry/Telemetry.h"
 #include <chrono>
 #include <cstdlib>
+#include <ctime>
 #include <memory>
 #include <string>
 #include <utility>
@@ -37,18 +40,16 @@ static uint64_t ToNanosec(const SteadyTimePoint Point) {
 // This reduces the chances of getting the same UUID, even when the same
 // user runs the two copies of binary at the same time.
 static std::string MakeUUID() {
-  uint8_t random_bytes[16];
-  std::string randomString = "_";
-  if (auto ec = llvm::getRandomBytes(random_bytes, 16)) {
-    LLDB_LOG(GetLog(LLDBLog::Object),
-             "Failed to generate random bytes for UUID: {0}", ec.message());
-  } else {
-    randomString = UUID(random_bytes).GetAsString();
+  auto timestmap = std::chrono::steady_clock::now().time_since_epoch().count();
+
+  llvm::Expected<UUID> maybe_uuid = UUID::Generate();
+  if (!maybe_uuid) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Host), maybe_uuid.takeError(),
+                   "Failed to generate random bytes for UUID: {0}");
+    return llvm::formatv("{0}", timestmap);
   }
 
-  return llvm::formatv(
-      "{0}_{1}", randomString,
-      std::chrono::steady_clock::now().time_since_epoch().count());
+  return llvm::formatv("{0}_{1}", maybe_uuid->GetAsString(), timestmap);
 }
 
 void LLDBBaseTelemetryInfo::serialize(Serializer &serializer) const {

--- a/lldb/source/Core/Telemetry.cpp
+++ b/lldb/source/Core/Telemetry.cpp
@@ -41,15 +41,8 @@ static uint64_t ToNanosec(const SteadyTimePoint Point) {
 // user runs the two copies of binary at the same time.
 static std::string MakeUUID() {
   auto timestmap = std::chrono::steady_clock::now().time_since_epoch().count();
-
-  llvm::Expected<UUID> maybe_uuid = UUID::Generate();
-  if (!maybe_uuid) {
-    LLDB_LOG_ERROR(GetLog(LLDBLog::Host), maybe_uuid.takeError(),
-                   "Failed to generate random bytes for UUID: {0}");
-    return llvm::formatv("{0}", timestmap);
-  }
-
-  return llvm::formatv("{0}_{1}", maybe_uuid->GetAsString(), timestmap);
+  UUID uuid = UUID::Generate();
+  return llvm::formatv("{0}_{1}", uuid.GetAsString(), timestmap);
 }
 
 void LLDBBaseTelemetryInfo::serialize(Serializer &serializer) const {

--- a/lldb/source/Utility/UUID.cpp
+++ b/lldb/source/Utility/UUID.cpp
@@ -14,6 +14,7 @@
 #include "llvm/Support/RandomNumberGenerator.h"
 
 #include <cctype>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>

--- a/lldb/source/Utility/UUID.cpp
+++ b/lldb/source/Utility/UUID.cpp
@@ -15,10 +15,10 @@
 
 #include <cctype>
 #include <chrono>
+#include <climits>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <climits>
 #include <random>
 
 using namespace lldb_private;

--- a/lldb/source/Utility/UUID.cpp
+++ b/lldb/source/Utility/UUID.cpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <climits>
 #include <random>
 
 using namespace lldb_private;

--- a/lldb/source/Utility/UUID.cpp
+++ b/lldb/source/Utility/UUID.cpp
@@ -11,8 +11,10 @@
 #include "lldb/Utility/Stream.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/RandomNumberGenerator.h"
 
 #include <cctype>
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 
@@ -109,4 +111,11 @@ bool UUID::SetFromStringRef(llvm::StringRef str) {
 
   *this = UUID(bytes);
   return true;
+}
+
+llvm::Expected<UUID> UUID::Generate(uint32_t num_bytes) {
+  llvm::SmallVector<uint8_t, 20> bytes(num_bytes);
+  if (auto ec = llvm::getRandomBytes(bytes.data(), bytes.size()))
+    return llvm::errorCodeToError(ec);
+  return UUID(bytes);
 }

--- a/lldb/unittests/Utility/UUIDTest.cpp
+++ b/lldb/unittests/Utility/UUIDTest.cpp
@@ -88,11 +88,9 @@ TEST(UUIDTest, StringConverion) {
 }
 
 TEST(UUIDTest, Generate) {
-  llvm::Expected<UUID> u16 = UUID::Generate();
-  ASSERT_THAT_EXPECTED(u16, llvm::Succeeded());
-  EXPECT_EQ(u16->GetBytes().size(), 16UL);
+  UUID u16 = UUID::Generate();
+  EXPECT_EQ(u16.GetBytes().size(), 16UL);
 
-  llvm::Expected<UUID> u20 = UUID::Generate(20);
-  ASSERT_THAT_EXPECTED(u20, llvm::Succeeded());
-  EXPECT_EQ(u20->GetBytes().size(), 20UL);
+  UUID u20 = UUID::Generate(20);
+  EXPECT_EQ(u20.GetBytes().size(), 20UL);
 }

--- a/lldb/unittests/Utility/UUIDTest.cpp
+++ b/lldb/unittests/Utility/UUIDTest.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "gtest/gtest.h"
-
 #include "lldb/Utility/UUID.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
 
 using namespace lldb_private;
 
@@ -85,4 +85,14 @@ TEST(UUIDTest, StringConverion) {
             UUID("@ABCDEFGHIJKLMNO", 16).GetAsString());
   EXPECT_EQ("40414243-4445-4647-4849-4A4B4C4D4E4F-50515253",
             UUID("@ABCDEFGHIJKLMNOPQRS", 20).GetAsString());
+}
+
+TEST(UUIDTest, Generate) {
+  llvm::Expected<UUID> u16 = UUID::Generate();
+  ASSERT_THAT_EXPECTED(u16, llvm::Succeeded());
+  EXPECT_EQ(u16->GetBytes().size(), 16UL);
+
+  llvm::Expected<UUID> u20 = UUID::Generate(20);
+  ASSERT_THAT_EXPECTED(u20, llvm::Succeeded());
+  EXPECT_EQ(u20->GetBytes().size(), 20UL);
 }


### PR DESCRIPTION
Hoist UUID generation into the UUID class and add a trivial unit test. This also changes the telemetry code to drop the double underscore if we failed to generate a UUID and subsequently logs to the Host instead of Object log channel.