### PR TITLE
[Clang][BPF] Add tests for btf_type_tag c2x-style attributes

### DIFF
--- a/clang/test/CodeGen/attr-btf_type_tag-similar-type.c
+++ b/clang/test/CodeGen/attr-btf_type_tag-similar-type.c
@@ -1,8 +1,21 @@
 // RUN: %clang_cc1 -triple %itanium_abi_triple -debug-info-kind=limited -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple %itanium_abi_triple -DDOUBLE_BRACKET_ATTRS=1 -debug-info-kind=limited -emit-llvm -o - %s | FileCheck %s
+
+#if DOUBLE_BRACKET_ATTRS
+#define __tag1 [[clang::btf_type_tag("tag1")]]
+#define __tag2 [[clang::btf_type_tag("tag2")]]
+#define __tag3 [[clang::btf_type_tag("tag3")]]
+#define __tag4 [[clang::btf_type_tag("tag4")]]
+#else
+#define __tag1 __attribute__((btf_type_tag("tag1")))
+#define __tag2 __attribute__((btf_type_tag("tag2")))
+#define __tag3 __attribute__((btf_type_tag("tag3")))
+#define __tag4 __attribute__((btf_type_tag("tag4")))
+#endif
 
 struct map_value {
-        int __attribute__((btf_type_tag("tag1"))) __attribute__((btf_type_tag("tag3"))) *a;
-        int __attribute__((btf_type_tag("tag2"))) __attribute__((btf_type_tag("tag4"))) *b;
+        int __tag1 __tag3 *a;
+        int __tag2 __tag4 *b;
 };
 
 struct map_value *func(void);

--- a/clang/test/CodeGen/attr-btf_type_tag-typedef-field.c
+++ b/clang/test/CodeGen/attr-btf_type_tag-typedef-field.c
@@ -1,7 +1,13 @@
 // RUN: %clang_cc1 -triple %itanium_abi_triple -debug-info-kind=limited -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple %itanium_abi_triple -DDOUBLE_BRACKET_ATTRS=1 -debug-info-kind=limited -emit-llvm -o - %s | FileCheck %s
 
+#if DOUBLE_BRACKET_ATTRS
+#define __tag1 [[clang::btf_type_tag("tag1")]]
+#define __tag2 [[clang::btf_type_tag("tag2")]]
+#else
 #define __tag1 __attribute__((btf_type_tag("tag1")))
 #define __tag2 __attribute__((btf_type_tag("tag2")))
+#endif
 
 typedef void __fn_t(int);
 typedef __fn_t __tag1 __tag2 *__fn2_t;
@@ -31,5 +37,5 @@ int *foo1(struct t *a1) {
 // CHECK: ![[L28]] = !DISubroutineType(types: ![[L29:[0-9]+]])
 // CHECK: ![[L29]] = !{null, ![[L4]]}
 // CHECK: ![[L30]] = !{![[L21]], ![[L23]]}
-// CHECK: ![[L31]] = !DIDerivedType(tag: DW_TAG_member, name: "c", scope: ![[#]], file: ![[#]], line: [[#]]1, baseType: ![[L32:[0-9]+]]
+// CHECK: ![[L31]] = !DIDerivedType(tag: DW_TAG_member, name: "c", scope: ![[#]], file: ![[#]], line: [[#]], baseType: ![[L32:[0-9]+]]
 // CHECK: ![[L32]] = !DIBasicType(name: "long", size: [[#]], encoding: DW_ATE_signed)


### PR DESCRIPTION
For btf_type_tag implementation, in order to have the same results with clang (__attribute__((btf_type_tag("...")))), gcc intends to use c2x syntax '[[...]]'. Clang also supports similar c2x syntax. Currently, the clang selftest contains the following five tests:
```
  attr-btf_type_tag-func.c
  attr-btf_type_tag-similar-type.c
  attr-btf_type_tag-var.c
  attr-btf_type_tag-func-ptr.c
  attr-btf_type_tag-typedef-field.c
```

Tests attr-btf_type_tag-func.c and attr-btf_type_tag-var.c already have c2x syntax test.

Test attr-btf_type_tag-func-ptr.c does not support c2x syntax when '__attribute__((...))' is replaced with with '[[...]]'. This should not be an issue since we do not have use cases for function pointer yet.

This patch added '[[...]]' syntax for
```
  attr-btf_type_tag-similar-type.c
  attr-btf_type_tag-typedef-field.c
```