### PR TITLE
llvm-reduce: Use 80 dashes for section separator in status printing

### DIFF
--- a/llvm/tools/llvm-reduce/deltas/Delta.cpp
+++ b/llvm/tools/llvm-reduce/deltas/Delta.cpp
@@ -63,6 +63,10 @@ static cl::opt<unsigned> NumJobs(
 unsigned NumJobs = 1;
 #endif
 
+static StringLiteral SeparatorLine =
+    "--------------------------------------------------------------------------"
+    "------\n";
+
 /// Splits Chunks in half and prints them.
 /// If unable to split (when chunk size is 1) returns false.
 static bool increaseGranularity(std::vector<Chunk> &Chunks) {
@@ -223,7 +227,7 @@ void llvm::runDeltaPass(TestRunner &Test, const DeltaPass &Pass) {
   if (!Targets) {
     if (Verbose)
       errs() << "\nNothing to reduce\n";
-    errs() << "----------------------------\n";
+    errs() << SeparatorLine;
     return;
   }
 
@@ -359,5 +363,5 @@ void llvm::runDeltaPass(TestRunner &Test, const DeltaPass &Pass) {
   }
   if (Verbose)
     errs() << "Couldn't increase anymore.\n";
-  errs() << "----------------------------\n";
+  errs() << SeparatorLine;
 }


### PR DESCRIPTION
Previously it printed a shorter sequence of dashes, which were shorter
than most of the printed pass descriptions. It is much shorter than
the printed names after fea6b388055284f37852e615fbf5b40a3ba34249.
Make this look more consistent by filling a standard terminal width.