### PR TITLE
[libclc] Fix unresolved reference to missing table

### DIFF
--- a/libclc/clc/include/clc/math/tables.h
+++ b/libclc/clc/include/clc/math/tables.h
@@ -78,7 +78,6 @@ CLC_TABLE_FUNCTION_DECL(float, exp_tbl_ep_tail);
 
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable
 
-TABLE_FUNCTION_DECL(double2, ln_tbl);
 CLC_TABLE_FUNCTION_DECL(double, ln_tbl_lo);
 CLC_TABLE_FUNCTION_DECL(double, ln_tbl_hi);
 CLC_TABLE_FUNCTION_DECL(double, atan_jby256_tbl_head);

--- a/libclc/clc/lib/generic/math/clc_log_base.h
+++ b/libclc/clc/lib/generic/math/clc_log_base.h
@@ -261,9 +261,8 @@ __clc_log(double x)
   int index = __clc_as_int2(ux).hi >> 13;
   index = ((0x80 | (index & 0x7e)) >> 1) + (index & 0x1);
 
-  double2 tv = USE_TABLE(ln_tbl, index - 64);
-  double z1 = tv.s0;
-  double q = tv.s1;
+  double z1 = USE_TABLE(ln_tbl_lo, index - 64);
+  double q = USE_TABLE(ln_tbl_hi, index - 64);
 
   double f1 = index * 0x1.0p-7;
   double f2 = f - f1;


### PR DESCRIPTION
Splitting the 'ln_tbl' into two in db98e292 wasn't done thoroughly enough as some references to the old table still remained. This commit fixes the unresolved references by updating to the new split table.