### PR TITLE
[libc++][NFC] Remove _LIBCPP_DISABLE_EXTENSION_WARNINGS

### DIFF
--- a/libcxx/.clang-format
+++ b/libcxx/.clang-format
@@ -30,7 +30,6 @@ AttributeMacros: [
                   '_LIBCPP_DEPRECATED_IN_CXX20',
                   '_LIBCPP_DEPRECATED_IN_CXX23',
                   '_LIBCPP_DEPRECATED',
-                  '_LIBCPP_DISABLE_EXTENSION_WARNING',
                   '_LIBCPP_EXCLUDE_FROM_EXPLICIT_INSTANTIATION',
                   '_LIBCPP_EXPORTED_FROM_ABI',
                   '_LIBCPP_EXTERN_TEMPLATE_TYPE_VIS',

--- a/libcxx/include/__atomic/support/c11.h
+++ b/libcxx/include/__atomic/support/c11.h
@@ -35,7 +35,7 @@ struct __cxx_atomic_base_impl {
   }
 #endif // _LIBCPP_CXX03_LANG
   _LIBCPP_CONSTEXPR explicit __cxx_atomic_base_impl(_Tp __value) _NOEXCEPT : __a_value(__value) {}
-  _LIBCPP_DISABLE_EXTENSION_WARNING _Atomic(_Tp) __a_value;
+  _Atomic(_Tp) __a_value;
 };
 
 #define __cxx_atomic_is_lock_free(__s) __c11_atomic_is_lock_free(__s)

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -352,8 +352,6 @@ typedef __char32_t char32_t;
 
 #  define _LIBCPP_ALWAYS_INLINE __attribute__((__always_inline__))
 
-#  define _LIBCPP_DISABLE_EXTENSION_WARNING __extension__
-
 #  if defined(_LIBCPP_OBJECT_FORMAT_COFF)
 
 #    ifdef _DLL


### PR DESCRIPTION
We only use `_LIBCPP_DISABLE_EXTENSION_WARNINGS` in a single place while we use extensions all over the place. The warnings are already disabled, since libc++'s headers are system headers, so this shouldn't be in any way observable by users.
