### PR TITLE
[clang-tidy][NFC][doc] improve "options" sections of `misc-`, `cppcore-` and other checks

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/android/comparison-in-temp-failure-retry.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/android/comparison-in-temp-failure-retry.rst
@@ -41,3 +41,4 @@ Options
 .. option:: RetryMacros
 
    A comma-separated list of the names of retry macros to be checked.
+   Default is `TEMP_FAILURE_RETRY`.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/msc51-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/msc51-cpp.rst
@@ -37,4 +37,4 @@ Options
 .. option:: DisallowedSeedTypes
 
    A comma-separated list of the type names which are disallowed.
-   Default values are ``time_t``, ``std::time_t``.
+   Default value is `time_t,std::time_t`.

--- a/clang-tools-extra/docs/clang-tidy/checks/concurrency/mt-unsafe.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/concurrency/mt-unsafe.rst
@@ -32,6 +32,9 @@ Examples:
 
     sleep(1); // implementation may use SIGALRM
 
+Options
+-------
+
 .. option:: FunctionSet
 
   Specifies which functions in libc should be considered thread-safe,

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/no-malloc.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/no-malloc.rst
@@ -35,14 +35,14 @@ Options
 .. option:: Allocations
 
    Semicolon-separated list of fully qualified names of memory allocation functions.
-   Defaults to ``::malloc;::calloc``.
+   Defaults to `::malloc;::calloc`.
 
 .. option:: Deallocations
 
    Semicolon-separated list of fully qualified names of memory allocation functions.
-   Defaults to ``::free``.
+   Defaults to `::free`.
 
 .. option:: Reallocations
 
    Semicolon-separated list of fully qualified names of memory allocation functions.
-   Defaults to ``::realloc``.
+   Defaults to `::realloc`.

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/owning-memory.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/owning-memory.rst
@@ -95,14 +95,14 @@ Options
 
    Semicolon-separated list of fully qualified names of legacy functions that create
    resources but cannot introduce ``gsl::owner<>``.
-   Defaults to ``::malloc;::aligned_alloc;::realloc;::calloc;::fopen;::freopen;::tmpfile``.
+   Defaults to `::malloc;::aligned_alloc;::realloc;::calloc;::fopen;::freopen;::tmpfile`.
 
 
 .. option:: LegacyResourceConsumers
 
    Semicolon-separated list of fully qualified names of legacy functions expecting
    resource owners as pointer arguments but cannot introduce ``gsl::owner<>``.
-   Defaults to ``::free;::realloc;::freopen;::fclose``.
+   Defaults to `::free;::realloc;::freopen;::fclose`.
 
 
 Limitations

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-constant-array-index.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-bounds-constant-array-index.rst
@@ -21,6 +21,7 @@ Options
 
    The check can generate fixes after this option has been set to the name of
    the include file that contains ``gsl::at()``, e.g. `"gsl/gsl.h"`.
+   Default is an empty string.
 
 .. option:: IncludeStyle
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.rst
@@ -37,6 +37,7 @@ Options
 
    If set to `true`, the check will provide fix-its with literal initializers
    \( ``int i = 0;`` \) instead of curly braces \( ``int i{};`` \).
+   Default is `false`.
 
 This rule is part of the `Type safety (Type.6)
 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Pro-type-memberinit>`_

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/coroutine-hostile-raii.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/coroutine-hostile-raii.rst
@@ -79,5 +79,5 @@ Options
       }
 
     Eg: `my::safe::awaitable;other::awaitable`
-    The default value of this option is an empty string.
+    Default is an empty string.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/coroutine-hostile-raii.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/coroutine-hostile-raii.rst
@@ -45,7 +45,7 @@ Options
 
     A semicolon-separated list of qualified types which should not be allowed to
     persist across suspension points.
-    Eg: `my::lockable;a::b;::my::other::lockable;`
+    Eg: `my::lockable;a::b;::my::other::lockable`
     The default value of this option is `std::lock_guard;std::scoped_lock`.
 
 .. option:: AllowedAwaitablesList

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/coroutine-hostile-raii.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/coroutine-hostile-raii.rst
@@ -45,8 +45,8 @@ Options
 
     A semicolon-separated list of qualified types which should not be allowed to
     persist across suspension points.
-    Eg: ``my::lockable; a::b;::my::other::lockable;``
-    The default value of this option is `"std::lock_guard;std::scoped_lock"`.
+    Eg: `my::lockable;a::b;::my::other::lockable;`
+    The default value of this option is `std::lock_guard;std::scoped_lock`.
 
 .. option:: AllowedAwaitablesList
 
@@ -78,6 +78,6 @@ Options
         co_await wait();
       }
 
-    Eg: ``my::safe::awaitable;other::awaitable``
-    The default value of this option is empty string `""`.
+    Eg: `my::safe::awaitable;other::awaitable`
+    The default value of this option is an empty string.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/include-cleaner.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/include-cleaner.rst
@@ -31,8 +31,8 @@ Options
 
    A semicolon-separated list of regexes to disable insertion/removal of header
    files that match this regex as a suffix.  E.g., `foo/.*` disables
-   insertion/removal for all headers under the directory `foo`. By default, no 
-   headers will be ignored.
+   insertion/removal for all headers under the directory `foo`. Default is an
+   empty string, no headers will be ignored.
 
 .. option:: DeduplicateFindings
 

--- a/clang-tools-extra/docs/clang-tidy/checks/misc/non-private-member-variables-in-classes.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc/non-private-member-variables-in-classes.rst
@@ -17,10 +17,11 @@ Options
 
 .. option:: IgnoreClassesWithAllMemberVariablesBeingPublic
 
-   Allows to completely ignore classes if **all** the member variables in that
-   class a declared with a ``public`` access specifier.
+   When `true`, allows to completely ignore classes if **all** the member
+   variables in that class declared with a ``public`` access specifier.
+   Default is `false`.
 
 .. option:: IgnorePublicMemberVariables
 
-   Allows to ignore (not diagnose) **all** the member variables declared with
-   a ``public`` access specifier.
+   When `true`, allows to ignore (not diagnose) **all** the member variables
+   declared with a ``public`` access specifier. Default is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/container-data-pointer.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/container-data-pointer.rst
@@ -18,4 +18,4 @@ Options
 .. option:: IgnoredContainers
 
    Semicolon-separated list of containers regexp for which this check won't be
-   enforced. Default is `empty`.
+   enforced. Default is an empty string.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/container-size-empty.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/container-size-empty.rst
@@ -25,6 +25,9 @@ The check issues warning if a container has ``empty()`` and ``size()`` or
 
 `size_type` can be any kind of integer type.
 
+Options
+-------
+
 .. option:: ExcludedComparisonTypes
 
     A semicolon-separated list of class names for which the check will ignore

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/inconsistent-declaration-parameter-name.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/inconsistent-declaration-parameter-name.rst
@@ -52,6 +52,9 @@ In the case of multiple redeclarations or function template specializations,
 a warning is issued for every redeclaration or specialization inconsistent with
 the definition or the first declaration seen in a translation unit.
 
+Options
+-------
+
 .. option:: IgnoreMacros
 
    If this option is set to `true` (default is `true`), the check will not warn

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-inline-specifier.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-inline-specifier.rst
@@ -29,4 +29,4 @@ Options
 .. option:: StrictMode
 
    If set to `true`, the check will also flag functions and variables that
-   already have internal linkage as redundant.
+   already have internal linkage as redundant. Default is `false`.

--- a/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-smartptr-get.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/readability/redundant-smartptr-get.rst
@@ -14,6 +14,8 @@ Examples:
   *ptr->get()  ==>  **ptr
   if (ptr.get() == nullptr) ... => if (ptr == nullptr) ...
 
+Options
+-------
 
 .. option:: IgnoreMacros
 


### PR DESCRIPTION
Improved "options" sections of various checks:

1. Added Options keyword to be a delimiter between "body" and "options" parts of docs
2. Added default values where were absent.
3. Changed double-tick to single-tick in default values.