### PR TITLE
[clang][bytecode] Return Invalid() on non-constexpr builtins

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -2102,7 +2102,7 @@ static bool interp__builtin_memchr(InterpState &S, CodePtr OpPC,
 bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const Function *F,
                       const CallExpr *Call, uint32_t BuiltinID) {
   if (!S.getASTContext().BuiltinInfo.isConstantEvaluated(BuiltinID))
-    return false;
+    return Invalid(S, OpPC);
 
   const InterpFrame *Frame = S.Current;
 

--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -1545,3 +1545,12 @@ namespace WMemChr {
   constexpr bool c = !wcschr(L"hello", L'h'); // both-error {{constant expression}} \
                                               // both-note {{non-constexpr function 'wcschr' cannot be used in a constant expression}}
 }
+
+namespace Invalid {
+  constexpr int test() { // both-error {{never produces a constant expression}}
+    __builtin_abort(); // both-note 2{{subexpression not valid in a constant expression}}
+    return 0;
+  }
+  static_assert(test() == 0); // both-error {{not an integral constant expression}} \
+                              // both-note {{in call to}}
+}


### PR DESCRIPTION
So the diagnostic output matches with the current interpreter