### PR TITLE
[libc++] Remove _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS and _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS

### DIFF
--- a/libcxx/.clang-format
+++ b/libcxx/.clang-format
@@ -35,7 +35,6 @@ AttributeMacros: [
                   '_LIBCPP_DIAGNOSE_NULLPTR_IF',
                   '_LIBCPP_EXCLUDE_FROM_EXPLICIT_INSTANTIATION',
                   '_LIBCPP_EXPORTED_FROM_ABI',
-                  '_LIBCPP_EXTERN_TEMPLATE_TYPE_VIS',
                   '_LIBCPP_FALLTHROUGH',
                   '_LIBCPP_HIDDEN',
                   '_LIBCPP_HIDE_FROM_ABI_AFTER_V1',

--- a/libcxx/docs/DesignDocs/VisibilityMacros.rst
+++ b/libcxx/docs/DesignDocs/VisibilityMacros.rst
@@ -66,35 +66,6 @@ Visibility Macros
   ABI, we should create a new _LIBCPP_HIDE_FROM_ABI_AFTER_XXX macro, and we can
   use it to start removing symbols from the ABI after that stable version.
 
-**_LIBCPP_EXTERN_TEMPLATE_TYPE_VIS**
-  Mark the member functions, typeinfo, and vtable of the type named in
-  an extern template declaration as being exported by the libc++ library.
-  This attribute must be specified on all extern class template declarations.
-
-  This macro is used to export the member functions produced by the explicit
-  instantiation in the dylib.
-
-  **Windows Behavior**: `extern template` and `dllexport` are fundamentally
-  incompatible *on a class template* on Windows; the former suppresses
-  instantiation, while the latter forces it. Specifying both on the same
-  declaration makes the class template be instantiated, which is not desirable
-  inside headers. This macro therefore expands to `dllimport` outside of libc++
-  but nothing inside of it (rather than expanding to `dllexport`); instead, the
-  explicit instantiations themselves are marked as exported. Note that this
-  applies *only* to extern *class* templates. Extern *function* templates obey
-  regular import/export semantics, and applying `dllexport` directly to the
-  extern template declaration (i.e. using `_LIBCPP_FUNC_VIS`) is the correct
-  thing to do for them.
-
-**_LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS**
-  Mark the member functions, typeinfo, and vtable of an explicit instantiation
-  of a class template as being exported by the libc++ library. This attribute
-  must be specified on all class template explicit instantiations.
-
-  It is only necessary to mark the explicit instantiation itself (as opposed to
-  the extern template declaration) as exported on Windows, as discussed above.
-  On all other platforms, this macro has an empty definition.
-
 Links
 =====
 

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -57,10 +57,6 @@
 
 #  define __has_keyword(__x) !(__is_identifier(__x))
 
-#  ifndef __has_warning
-#    define __has_warning(...) 0
-#  endif
-
 #  if !defined(_LIBCPP_COMPILER_CLANG_BASED) && __cplusplus < 201103L
 #    error "libc++ only supports C++03 with Clang-based compilers. Please enable C++11"
 #  endif

--- a/libcxx/include/__configuration/attributes.h
+++ b/libcxx/include/__configuration/attributes.h
@@ -56,23 +56,12 @@
 #  endif
 
 #  if defined(_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS) || (defined(__MINGW32__) && !defined(_LIBCPP_BUILDING_LIBRARY))
-#    define _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS
-#    define _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS
 #    define _LIBCPP_OVERRIDABLE_FUNC_VIS
 #    define _LIBCPP_EXPORTED_FROM_ABI
 #  elif defined(_LIBCPP_BUILDING_LIBRARY)
-#    if defined(__MINGW32__)
-#      define _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __declspec(dllexport)
-#      define _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS
-#    else
-#      define _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS
-#      define _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS __declspec(dllexport)
-#    endif
 #    define _LIBCPP_OVERRIDABLE_FUNC_VIS __declspec(dllexport)
 #    define _LIBCPP_EXPORTED_FROM_ABI __declspec(dllexport)
 #  else
-#    define _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __declspec(dllimport)
-#    define _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS
 #    define _LIBCPP_OVERRIDABLE_FUNC_VIS
 #    define _LIBCPP_EXPORTED_FROM_ABI __declspec(dllimport)
 #  endif
@@ -92,8 +81,6 @@
 #  define _LIBCPP_HIDDEN _LIBCPP_VISIBILITY("hidden")
 #  define _LIBCPP_TEMPLATE_DATA_VIS _LIBCPP_VISIBILITY("default")
 #  define _LIBCPP_EXPORTED_FROM_ABI _LIBCPP_VISIBILITY("default")
-#  define _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS _LIBCPP_VISIBILITY("default")
-#  define _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS
 
 // TODO: Make this a proper customization point or remove the option to override it.
 #  ifndef _LIBCPP_OVERRIDABLE_FUNC_VIS

--- a/libcxx/include/__configuration/compiler.h
+++ b/libcxx/include/__configuration/compiler.h
@@ -46,6 +46,10 @@
 #    endif
 #  endif
 
+#  ifndef __has_warning
+#    define __has_warning(...) 0
+#  endif
+
 #endif
 
 #endif // _LIBCPP___CONFIGURATION_COMPILER_H

--- a/libcxx/include/__configuration/namespace.h
+++ b/libcxx/include/__configuration/namespace.h
@@ -12,11 +12,25 @@
 
 #include <__config_site>
 #include <__configuration/attributes.h>
+#include <__configuration/compiler.h>
 #include <__configuration/diagnostic_suppression.h>
+#include <__configuration/platform.h>
 #include <__configuration/utility.h>
 
 #ifndef _LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER
 #  pragma GCC system_header
+#endif
+
+#if __has_warning("-Wdllexport-explicit-instantiation")
+#  define _LIBCPP_CLANG_DIAGNOSTIC_IGNORE_DLLEXPORT                                                                    \
+    _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wdllexport-explicit-instantiation")
+// TODO(LLVM 24): Remove this fallback and assume that the warning exists
+#elif defined(_LIBCPP_OBJECT_FORMAT_COFF)
+#  define _LIBCPP_CLANG_DIAGNOSTIC_IGNORE_DLLEXPORT                                                                    \
+    _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wignored-attributes")                                                           \
+    _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wdllexport-explicit-instantiation-decl")
+#else
+#  define _LIBCPP_CLANG_DIAGNOSTIC_IGNORE_DLLEXPORT
 #endif
 
 // Clang modules take a significant compile time hit when pushing and popping diagnostics.
@@ -33,7 +47,8 @@
     _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++14-extensions")                                                               \
     _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++17-extensions")                                                               \
     _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++20-extensions")                                                               \
-    _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++23-extensions")
+    _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++23-extensions")                                                               \
+    _LIBCPP_CLANG_DIAGNOSTIC_IGNORE_DLLEXPORT
 #  define _LIBCPP_POP_EXTENSION_DIAGNOSTICS _LIBCPP_DIAGNOSTIC_POP
 #else
 #  define _LIBCPP_PUSH_EXTENSION_DIAGNOSTICS

--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -248,10 +248,10 @@ long collate<_CharT>::do_hash(const char_type* __lo, const char_type* __hi) cons
   return static_cast<long>(__h);
 }
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS collate<char>;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS collate<wchar_t>;
-#  endif
+extern template class _LIBCPP_EXPORTED_FROM_ABI collate<char>;
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
+extern template class _LIBCPP_EXPORTED_FROM_ABI collate<wchar_t>;
+#    endif
 
 // template <class CharT> class collate_byname;
 
@@ -1243,17 +1243,17 @@ template <class _InternT, class _ExternT, class _StateT>
 codecvt_byname<_InternT, _ExternT, _StateT>::~codecvt_byname() {}
 _LIBCPP_SUPPRESS_DEPRECATED_POP
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<char, char, mbstate_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI codecvt_byname<char, char, mbstate_t>;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<wchar_t, char, mbstate_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI codecvt_byname<wchar_t, char, mbstate_t>;
 #  endif
 extern template class _LIBCPP_DEPRECATED_IN_CXX20
-_LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<char16_t, char, mbstate_t>; // deprecated in C++20
+_LIBCPP_EXPORTED_FROM_ABI codecvt_byname<char16_t, char, mbstate_t>; // deprecated in C++20
 extern template class _LIBCPP_DEPRECATED_IN_CXX20
-_LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<char32_t, char, mbstate_t>; // deprecated in C++20
+_LIBCPP_EXPORTED_FROM_ABI codecvt_byname<char32_t, char, mbstate_t>; // deprecated in C++20
 #  if _LIBCPP_HAS_CHAR8_T
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<char16_t, char8_t, mbstate_t>; // C++20
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<char32_t, char8_t, mbstate_t>; // C++20
+extern template class _LIBCPP_EXPORTED_FROM_ABI codecvt_byname<char16_t, char8_t, mbstate_t>; // C++20
+extern template class _LIBCPP_EXPORTED_FROM_ABI codecvt_byname<char32_t, char8_t, mbstate_t>; // C++20
 #  endif
 
 template <size_t _Np>

--- a/libcxx/include/__locale_dir/messages.h
+++ b/libcxx/include/__locale_dir/messages.h
@@ -113,9 +113,9 @@ void messages<_CharT>::do_close(catalog __c) const {
 #  endif // _LIBCPP_HAS_CATOPEN
 }
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS messages<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI messages<char>;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS messages<wchar_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI messages<wchar_t>;
 #  endif
 
 template <class _CharT>
@@ -132,9 +132,9 @@ protected:
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL ~messages_byname() override {}
 };
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS messages_byname<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI messages_byname<char>;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS messages_byname<wchar_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI messages_byname<wchar_t>;
 #  endif
 
 _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS

--- a/libcxx/include/__locale_dir/money.h
+++ b/libcxx/include/__locale_dir/money.h
@@ -95,11 +95,11 @@ locale::id moneypunct<_CharT, _International>::id;
 template <class _CharT, bool _International>
 const bool moneypunct<_CharT, _International>::intl;
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct<char, false>;
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct<char, true>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI moneypunct<char, false>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI moneypunct<char, true>;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct<wchar_t, false>;
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct<wchar_t, true>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI moneypunct<wchar_t, false>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI moneypunct<wchar_t, true>;
 #  endif
 
 // moneypunct_byname
@@ -152,16 +152,16 @@ template <>
 _LIBCPP_EXPORTED_FROM_ABI void moneypunct_byname<char, false>::init(const char*);
 template <>
 _LIBCPP_EXPORTED_FROM_ABI void moneypunct_byname<char, true>::init(const char*);
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct_byname<char, false>;
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct_byname<char, true>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI moneypunct_byname<char, false>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI moneypunct_byname<char, true>;
 
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 _LIBCPP_EXPORTED_FROM_ABI void moneypunct_byname<wchar_t, false>::init(const char*);
 template <>
 _LIBCPP_EXPORTED_FROM_ABI void moneypunct_byname<wchar_t, true>::init(const char*);
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct_byname<wchar_t, false>;
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS moneypunct_byname<wchar_t, true>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI moneypunct_byname<wchar_t, false>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI moneypunct_byname<wchar_t, true>;
 #  endif
 
 // money_get
@@ -222,9 +222,9 @@ void __money_get<_CharT>::__gather_info(
   }
 }
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __money_get<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI __money_get<char>;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __money_get<wchar_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI __money_get<wchar_t>;
 #  endif
 
 template <class _CharT, class _InputIterator = istreambuf_iterator<_CharT> >
@@ -536,9 +536,9 @@ _InputIterator money_get<_CharT, _InputIterator>::do_get(
   return __b;
 }
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS money_get<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI money_get<char>;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS money_get<wchar_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI money_get<wchar_t>;
 #  endif
 
 // money_put
@@ -714,9 +714,9 @@ void __money_put<_CharT>::__format(
     __mi = __mb;
 }
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __money_put<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI __money_put<char>;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __money_put<wchar_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI __money_put<wchar_t>;
 #  endif
 
 template <class _CharT, class _OutputIterator = ostreambuf_iterator<_CharT> >
@@ -860,9 +860,9 @@ _OutputIterator money_put<_CharT, _OutputIterator>::do_put(
   return std::__pad_and_output(__s, __mb, __mi, __me, __iob, __fl);
 }
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS money_put<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI money_put<char>;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS money_put<wchar_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI money_put<wchar_t>;
 #  endif
 
 _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS

--- a/libcxx/include/__locale_dir/num.h
+++ b/libcxx/include/__locale_dir/num.h
@@ -198,9 +198,9 @@ int __num_get<_CharT>::__stage2_float_loop(
   return 0;
 }
 
-extern template struct _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __num_get<char>;
+extern template struct _LIBCPP_EXPORTED_FROM_ABI __num_get<char>;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template struct _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __num_get<wchar_t>;
+extern template struct _LIBCPP_EXPORTED_FROM_ABI __num_get<wchar_t>;
 #  endif
 
 template <class _Tp>
@@ -631,9 +631,9 @@ _InputIterator num_get<_CharT, _InputIterator>::do_get(
   return __res;
 }
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS num_get<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI num_get<char>;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS num_get<wchar_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI num_get<wchar_t>;
 #  endif
 
 struct _LIBCPP_EXPORTED_FROM_ABI __num_put_base {
@@ -756,9 +756,9 @@ void __num_put<_CharT>::__widen_and_group_float(
     __op = __ob + (__np - __nb);
 }
 
-extern template struct _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __num_put<char>;
+extern template struct _LIBCPP_EXPORTED_FROM_ABI __num_put<char>;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template struct _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS __num_put<wchar_t>;
+extern template struct _LIBCPP_EXPORTED_FROM_ABI __num_put<wchar_t>;
 #  endif
 
 template <class _CharT, class _OutputIterator = ostreambuf_iterator<_CharT> >
@@ -1004,9 +1004,9 @@ num_put<_CharT, _OutputIterator>::do_put(iter_type __s, ios_base& __iob, char_ty
   return __res;
 }
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS num_put<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI num_put<char>;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS num_put<wchar_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI num_put<wchar_t>;
 #  endif
 
 _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS

--- a/libcxx/include/__locale_dir/time.h
+++ b/libcxx/include/__locale_dir/time.h
@@ -555,9 +555,9 @@ _InputIterator time_get<_CharT, _InputIterator>::do_get(
   return __b;
 }
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_get<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI time_get<char>;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_get<wchar_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI time_get<wchar_t>;
 #  endif
 
 class _LIBCPP_EXPORTED_FROM_ABI __time_get {
@@ -644,9 +644,9 @@ private:
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL const string_type& __X() const override { return this->__X_; }
 };
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_get_byname<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI time_get_byname<char>;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_get_byname<wchar_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI time_get_byname<wchar_t>;
 #  endif
 
 class _LIBCPP_EXPORTED_FROM_ABI __time_put {
@@ -733,9 +733,9 @@ _OutputIterator time_put<_CharT, _OutputIterator>::do_put(
   return std::copy(__nb, __ne, __s);
 }
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_put<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI time_put<char>;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_put<wchar_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI time_put<wchar_t>;
 #  endif
 
 template <class _CharT, class _OutputIterator = ostreambuf_iterator<_CharT> >
@@ -751,9 +751,9 @@ protected:
   _LIBCPP_HIDE_FROM_ABI_VIRTUAL ~time_put_byname() override {}
 };
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_put_byname<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI time_put_byname<char>;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS time_put_byname<wchar_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI time_put_byname<wchar_t>;
 #  endif
 
 _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS

--- a/libcxx/include/__ostream/basic_ostream.h
+++ b/libcxx/include/__ostream/basic_ostream.h
@@ -668,9 +668,9 @@ basic_ostream<char, _Traits>& operator<<(basic_ostream<char, _Traits>&, const ch
 
 #  endif // _LIBCPP_STD_VER >= 20
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_ostream<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI basic_ostream<char>;
 #  if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_ostream<wchar_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI basic_ostream<wchar_t>;
 #  endif
 
 _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -1612,9 +1612,9 @@ inline void basic_fstream<_CharT, _Traits>::close() {
 }
 
 #    if _LIBCPP_AVAILABILITY_HAS_ADDITIONAL_IOSTREAM_EXPLICIT_INSTANTIATIONS_1
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_ifstream<char>;
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_ofstream<char>;
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_filebuf<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI basic_ifstream<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI basic_ofstream<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI basic_filebuf<char>;
 #    endif
 
 _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS

--- a/libcxx/include/ios
+++ b/libcxx/include/ios
@@ -753,10 +753,10 @@ inline _LIBCPP_HIDE_FROM_ABI void basic_ios<_CharT, _Traits>::set_rdbuf(basic_st
   ios_base::set_rdbuf(__sb);
 }
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_ios<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI basic_ios<char>;
 
 #    if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_ios<wchar_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI basic_ios<wchar_t>;
 #    endif
 
 _LIBCPP_HIDE_FROM_ABI inline ios_base& boolalpha(ios_base& __str) {

--- a/libcxx/include/istream
+++ b/libcxx/include/istream
@@ -1400,11 +1400,11 @@ operator>>(basic_istream<_CharT, _Traits>& __is, bitset<_Size>& __x) {
   return __is;
 }
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_istream<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI basic_istream<char>;
 #    if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_istream<wchar_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI basic_istream<wchar_t>;
 #    endif
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_iostream<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI basic_iostream<char>;
 
 _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS
 _LIBCPP_END_NAMESPACE_STD

--- a/libcxx/include/sstream
+++ b/libcxx/include/sstream
@@ -1283,10 +1283,10 @@ swap(basic_stringstream<_CharT, _Traits, _Allocator>& __x, basic_stringstream<_C
 }
 
 #    if _LIBCPP_AVAILABILITY_HAS_ADDITIONAL_IOSTREAM_EXPLICIT_INSTANTIATIONS_1
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_stringbuf<char>;
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_stringstream<char>;
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_ostringstream<char>;
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_istringstream<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI basic_stringbuf<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI basic_stringstream<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI basic_ostringstream<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI basic_istringstream<char>;
 #    endif
 
 _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS

--- a/libcxx/include/streambuf
+++ b/libcxx/include/streambuf
@@ -425,10 +425,10 @@ private:
   getline(basic_istream<_CharT2, _Traits2>&, basic_string<_CharT2, _Traits2, _Allocator>&, _CharT2);
 };
 
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_streambuf<char>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI basic_streambuf<char>;
 
 #    if _LIBCPP_HAS_WIDE_CHARACTERS
-extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_streambuf<wchar_t>;
+extern template class _LIBCPP_EXPORTED_FROM_ABI basic_streambuf<wchar_t>;
 #    endif
 
 _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS

--- a/libcxx/src/ios.instantiations.cpp
+++ b/libcxx/src/ios.instantiations.cpp
@@ -17,30 +17,30 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 // Original explicit instantiations provided in the library
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ios<char>;
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_streambuf<char>;
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_istream<char>;
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ostream<char>;
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_iostream<char>;
+template class _LIBCPP_EXPORTED_FROM_ABI basic_ios<char>;
+template class _LIBCPP_EXPORTED_FROM_ABI basic_streambuf<char>;
+template class _LIBCPP_EXPORTED_FROM_ABI basic_istream<char>;
+template class _LIBCPP_EXPORTED_FROM_ABI basic_ostream<char>;
+template class _LIBCPP_EXPORTED_FROM_ABI basic_iostream<char>;
 
 #if _LIBCPP_HAS_WIDE_CHARACTERS
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ios<wchar_t>;
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_streambuf<wchar_t>;
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_istream<wchar_t>;
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ostream<wchar_t>;
+template class _LIBCPP_EXPORTED_FROM_ABI basic_ios<wchar_t>;
+template class _LIBCPP_EXPORTED_FROM_ABI basic_streambuf<wchar_t>;
+template class _LIBCPP_EXPORTED_FROM_ABI basic_istream<wchar_t>;
+template class _LIBCPP_EXPORTED_FROM_ABI basic_ostream<wchar_t>;
 #endif
 
 // Additional instantiations added later. Whether programs rely on these being
 // available is protected by _LIBCPP_AVAILABILITY_HAS_ADDITIONAL_IOSTREAM_EXPLICIT_INSTANTIATIONS_1.
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_stringbuf<char>;
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_stringstream<char>;
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ostringstream<char>;
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_istringstream<char>;
+template class _LIBCPP_EXPORTED_FROM_ABI basic_stringbuf<char>;
+template class _LIBCPP_EXPORTED_FROM_ABI basic_stringstream<char>;
+template class _LIBCPP_EXPORTED_FROM_ABI basic_ostringstream<char>;
+template class _LIBCPP_EXPORTED_FROM_ABI basic_istringstream<char>;
 
 #if _LIBCPP_HAS_FILESYSTEM
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ifstream<char>;
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_ofstream<char>;
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS basic_filebuf<char>;
+template class _LIBCPP_EXPORTED_FROM_ABI basic_ifstream<char>;
+template class _LIBCPP_EXPORTED_FROM_ABI basic_ofstream<char>;
+template class _LIBCPP_EXPORTED_FROM_ABI basic_filebuf<char>;
 #endif
 
 // Add more here if needed...

--- a/libcxx/src/locale.cpp
+++ b/libcxx/src/locale.cpp
@@ -5589,71 +5589,71 @@ int __num_get<_CharT>::__stage2_int_loop(
   return 0;
 }
 
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS collate<char>;
-_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS collate<wchar_t>;)
+template class _LIBCPP_EXPORTED_FROM_ABI collate<char>;
+_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_EXPORTED_FROM_ABI collate<wchar_t>;)
 
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS num_get<char>;
-_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS num_get<wchar_t>;)
+template class _LIBCPP_EXPORTED_FROM_ABI num_get<char>;
+_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_EXPORTED_FROM_ABI num_get<wchar_t>;)
 
-template struct _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS __num_get<char>;
-_LIBCPP_IF_WIDE_CHARACTERS(template struct _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS __num_get<wchar_t>;)
+template struct _LIBCPP_EXPORTED_FROM_ABI __num_get<char>;
+_LIBCPP_IF_WIDE_CHARACTERS(template struct _LIBCPP_EXPORTED_FROM_ABI __num_get<wchar_t>;)
 
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS num_put<char>;
-_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS num_put<wchar_t>;)
+template class _LIBCPP_EXPORTED_FROM_ABI num_put<char>;
+_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_EXPORTED_FROM_ABI num_put<wchar_t>;)
 
-template struct _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS __num_put<char>;
-_LIBCPP_IF_WIDE_CHARACTERS(template struct _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS __num_put<wchar_t>;)
+template struct _LIBCPP_EXPORTED_FROM_ABI __num_put<char>;
+_LIBCPP_IF_WIDE_CHARACTERS(template struct _LIBCPP_EXPORTED_FROM_ABI __num_put<wchar_t>;)
 
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS time_get<char>;
-_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS time_get<wchar_t>;)
+template class _LIBCPP_EXPORTED_FROM_ABI time_get<char>;
+_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_EXPORTED_FROM_ABI time_get<wchar_t>;)
 
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS time_get_byname<char>;
-_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS time_get_byname<wchar_t>;)
+template class _LIBCPP_EXPORTED_FROM_ABI time_get_byname<char>;
+_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_EXPORTED_FROM_ABI time_get_byname<wchar_t>;)
 
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS time_put<char>;
-_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS time_put<wchar_t>;)
+template class _LIBCPP_EXPORTED_FROM_ABI time_put<char>;
+_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_EXPORTED_FROM_ABI time_put<wchar_t>;)
 
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS time_put_byname<char>;
-_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS time_put_byname<wchar_t>;)
+template class _LIBCPP_EXPORTED_FROM_ABI time_put_byname<char>;
+_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_EXPORTED_FROM_ABI time_put_byname<wchar_t>;)
 
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS moneypunct<char, false>;
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS moneypunct<char, true>;
-_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS moneypunct<wchar_t, false>;)
-_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS moneypunct<wchar_t, true>;)
+template class _LIBCPP_EXPORTED_FROM_ABI moneypunct<char, false>;
+template class _LIBCPP_EXPORTED_FROM_ABI moneypunct<char, true>;
+_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_EXPORTED_FROM_ABI moneypunct<wchar_t, false>;)
+_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_EXPORTED_FROM_ABI moneypunct<wchar_t, true>;)
 
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS moneypunct_byname<char, false>;
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS moneypunct_byname<char, true>;
-_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS moneypunct_byname<wchar_t, false>;)
-_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS moneypunct_byname<wchar_t, true>;)
+template class _LIBCPP_EXPORTED_FROM_ABI moneypunct_byname<char, false>;
+template class _LIBCPP_EXPORTED_FROM_ABI moneypunct_byname<char, true>;
+_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_EXPORTED_FROM_ABI moneypunct_byname<wchar_t, false>;)
+_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_EXPORTED_FROM_ABI moneypunct_byname<wchar_t, true>;)
 
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS money_get<char>;
-_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS money_get<wchar_t>;)
+template class _LIBCPP_EXPORTED_FROM_ABI money_get<char>;
+_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_EXPORTED_FROM_ABI money_get<wchar_t>;)
 
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS __money_get<char>;
-_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS __money_get<wchar_t>;)
+template class _LIBCPP_EXPORTED_FROM_ABI __money_get<char>;
+_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_EXPORTED_FROM_ABI __money_get<wchar_t>;)
 
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS money_put<char>;
-_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS money_put<wchar_t>;)
+template class _LIBCPP_EXPORTED_FROM_ABI money_put<char>;
+_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_EXPORTED_FROM_ABI money_put<wchar_t>;)
 
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS __money_put<char>;
-_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS __money_put<wchar_t>;)
+template class _LIBCPP_EXPORTED_FROM_ABI __money_put<char>;
+_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_EXPORTED_FROM_ABI __money_put<wchar_t>;)
 
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS messages<char>;
-_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS messages<wchar_t>;)
+template class _LIBCPP_EXPORTED_FROM_ABI messages<char>;
+_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_EXPORTED_FROM_ABI messages<wchar_t>;)
 
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS messages_byname<char>;
-_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS messages_byname<wchar_t>;)
+template class _LIBCPP_EXPORTED_FROM_ABI messages_byname<char>;
+_LIBCPP_IF_WIDE_CHARACTERS(template class _LIBCPP_EXPORTED_FROM_ABI messages_byname<wchar_t>;)
 
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS codecvt_byname<char, char, mbstate_t>;
+template class _LIBCPP_EXPORTED_FROM_ABI codecvt_byname<char, char, mbstate_t>;
 _LIBCPP_IF_WIDE_CHARACTERS(
-    template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS codecvt_byname<wchar_t, char, mbstate_t>;)
-template class _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS
+    template class _LIBCPP_EXPORTED_FROM_ABI codecvt_byname<wchar_t, char, mbstate_t>;)
+template class _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_EXPORTED_FROM_ABI
     codecvt_byname<char16_t, char, mbstate_t>;
-template class _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS
+template class _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_EXPORTED_FROM_ABI
     codecvt_byname<char32_t, char, mbstate_t>;
 #if _LIBCPP_HAS_CHAR8_T
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS codecvt_byname<char16_t, char8_t, mbstate_t>;
-template class _LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS codecvt_byname<char32_t, char8_t, mbstate_t>;
+template class _LIBCPP_EXPORTED_FROM_ABI codecvt_byname<char16_t, char8_t, mbstate_t>;
+template class _LIBCPP_EXPORTED_FROM_ABI codecvt_byname<char32_t, char8_t, mbstate_t>;
 #endif
 
 _LIBCPP_END_EXPLICIT_ABI_ANNOTATIONS


### PR DESCRIPTION
MinGW and Win32 disagree on where the `__declspec(dllexport)` should be placed on extern template instantiations. However, there doesn't fundamentally seem to be a problem with putting the annotation in both places. This patch replaces `_LIBCPP_EXTERN_TEMPLATE_TYPE_VIS` and `_LIBCPP_CLASS_TEMPLATE_INSTANTIATION_VIS` with `_LIBCPP_EXPORTED_FROM_ABI`, simplifying our visibility annotations. `_LIBCPP_EXPORTED_FROM_ABI` has to be added both to the extern template delcaration and definition unfortunately, making it not 100% consistent with how functions have to be annotated. However, Clang will warn if that's not done correctly.
