### PR TITLE
Mark CXX module initializer with PACBTI attributes

### DIFF
--- a/clang/lib/CodeGen/CGDeclCXX.cpp
+++ b/clang/lib/CodeGen/CGDeclCXX.cpp
@@ -818,6 +818,12 @@ void CodeGenModule::EmitCXXModuleInitFunc(Module *Primary) {
     Fn->addFnAttr("device-init");
   }
 
+  if (getTarget().isBranchProtectionSupportedArch(
+          getTarget().getTargetOpts().CPU)) {
+    TargetInfo::BranchProtectionInfo BPI(getLangOpts());
+    getTargetCodeGenInfo().setBranchProtectionFnAttributes(BPI, (*Fn));
+  }
+
   // We are done with the inits.
   AllImports.clear();
   PrioritizedCXXGlobalInits.clear();

--- a/clang/lib/CodeGen/CGDeclCXX.cpp
+++ b/clang/lib/CodeGen/CGDeclCXX.cpp
@@ -447,6 +447,8 @@ llvm::Function *CodeGenModule::CreateGlobalInitOrCleanUpFunction(
 
   if (Linkage == llvm::GlobalVariable::InternalLinkage)
     SetInternalFunctionAttributes(GlobalDecl(), Fn, FI);
+  else
+    getTargetCodeGenInfo().setTargetAttributes(nullptr, Fn, *this);
 
   Fn->setCallingConv(getRuntimeCC());
 
@@ -793,7 +795,6 @@ void CodeGenModule::EmitCXXModuleInitFunc(Module *Primary) {
     }
     CodeGenFunction(*this).GenerateCXXGlobalInitFunc(Fn, ModuleInits,
                                                      GuardAddr);
-    getTargetCodeGenInfo().setTargetAttributes(nullptr, Fn, *this);
   }
 
   // We allow for the case that a module object is added to a linked binary

--- a/clang/lib/CodeGen/CGDeclCXX.cpp
+++ b/clang/lib/CodeGen/CGDeclCXX.cpp
@@ -447,8 +447,11 @@ llvm::Function *CodeGenModule::CreateGlobalInitOrCleanUpFunction(
 
   if (Linkage == llvm::GlobalVariable::InternalLinkage)
     SetInternalFunctionAttributes(GlobalDecl(), Fn, FI);
-  else
+  else {
+    SetLLVMFunctionAttributes(GlobalDecl(), FI, Fn, false);
+    SetLLVMFunctionAttributesForDefinition(nullptr, Fn);
     getTargetCodeGenInfo().setTargetAttributes(nullptr, Fn, *this);
+  }
 
   Fn->setCallingConv(getRuntimeCC());
 

--- a/clang/lib/CodeGen/CGDeclCXX.cpp
+++ b/clang/lib/CodeGen/CGDeclCXX.cpp
@@ -793,6 +793,7 @@ void CodeGenModule::EmitCXXModuleInitFunc(Module *Primary) {
     }
     CodeGenFunction(*this).GenerateCXXGlobalInitFunc(Fn, ModuleInits,
                                                      GuardAddr);
+    getTargetCodeGenInfo().setTargetAttributes(nullptr, Fn, *this);
   }
 
   // We allow for the case that a module object is added to a linked binary
@@ -816,12 +817,6 @@ void CodeGenModule::EmitCXXModuleInitFunc(Module *Primary) {
     else
       Fn->setCallingConv(llvm::CallingConv::AMDGPU_KERNEL);
     Fn->addFnAttr("device-init");
-  }
-
-  if (getTarget().isBranchProtectionSupportedArch(
-          getTarget().getTargetOpts().CPU)) {
-    TargetInfo::BranchProtectionInfo BPI(getLangOpts());
-    getTargetCodeGenInfo().setBranchProtectionFnAttributes(BPI, (*Fn));
   }
 
   // We are done with the inits.

--- a/clang/lib/CodeGen/Targets/AArch64.cpp
+++ b/clang/lib/CodeGen/Targets/AArch64.cpp
@@ -136,13 +136,15 @@ public:
 
   void setTargetAttributes(const Decl *D, llvm::GlobalValue *GV,
                            CodeGen::CodeGenModule &CGM) const override {
-    const FunctionDecl *FD = dyn_cast_or_null<FunctionDecl>(D);
-    if (!FD)
+    auto *Fn = dyn_cast<llvm::Function>(GV);
+    if (!Fn)
       return;
 
+    const auto *FD = dyn_cast_or_null<FunctionDecl>(D);
     TargetInfo::BranchProtectionInfo BPI(CGM.getLangOpts());
 
-    if (const auto *TA = FD->getAttr<TargetAttr>()) {
+    if (FD && FD->hasAttr<TargetAttr>()) {
+      const auto *TA = FD->getAttr<TargetAttr>();
       ParsedTargetAttr Attr =
           CGM.getTarget().parseTargetAttr(TA->getFeaturesStr());
       if (!Attr.BranchProtection.empty()) {
@@ -152,7 +154,6 @@ public:
         assert(Error.empty());
       }
     }
-    auto *Fn = cast<llvm::Function>(GV);
     setBranchProtectionFnAttributes(BPI, *Fn);
   }
 

--- a/clang/lib/CodeGen/Targets/ARM.cpp
+++ b/clang/lib/CodeGen/Targets/ARM.cpp
@@ -134,8 +134,6 @@ public:
 
   void setTargetAttributes(const Decl *D, llvm::GlobalValue *GV,
                            CodeGen::CodeGenModule &CGM) const override {
-    if (GV->isDeclaration())
-      return;
     auto *Fn = dyn_cast<llvm::Function>(GV);
     if (!Fn)
       return;

--- a/clang/lib/CodeGen/Targets/ARM.cpp
+++ b/clang/lib/CodeGen/Targets/ARM.cpp
@@ -136,12 +136,13 @@ public:
                            CodeGen::CodeGenModule &CGM) const override {
     if (GV->isDeclaration())
       return;
-    const FunctionDecl *FD = dyn_cast_or_null<FunctionDecl>(D);
-    if (!FD)
+    auto *Fn = dyn_cast<llvm::Function>(GV);
+    if (!Fn)
       return;
-    auto *Fn = cast<llvm::Function>(GV);
+    const auto *FD = dyn_cast_or_null<FunctionDecl>(D);
 
-    if (const auto *TA = FD->getAttr<TargetAttr>()) {
+    if (FD && FD->hasAttr<TargetAttr>()) {
+      const auto *TA = FD->getAttr<TargetAttr>();
       ParsedTargetAttr Attr =
           CGM.getTarget().parseTargetAttr(TA->getFeaturesStr());
       if (!Attr.BranchProtection.empty()) {
@@ -174,10 +175,10 @@ public:
       setBranchProtectionFnAttributes(BPI, (*Fn));
     }
 
-    const ARMInterruptAttr *Attr = FD->getAttr<ARMInterruptAttr>();
-    if (!Attr)
+    if (!FD || !FD->hasAttr<ARMInterruptAttr>())
       return;
 
+    const ARMInterruptAttr *Attr = FD->getAttr<ARMInterruptAttr>();
     const char *Kind;
     switch (Attr->getInterrupt()) {
     case ARMInterruptAttr::Generic: Kind = ""; break;

--- a/clang/test/CodeGenCXX/cxx20-module-initializer-pacbti.cpp
+++ b/clang/test/CodeGenCXX/cxx20-module-initializer-pacbti.cpp
@@ -1,0 +1,32 @@
+// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -emit-module-interface -target-feature +pacbti -mbranch-target-enforce -std=c++20 %s -o %t.pcm
+// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -std=c++20 %t.pcm -emit-llvm -o - | \
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-BTI %s
+
+// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -emit-module-interface -target-feature +pacbti -msign-return-address=non-leaf -std=c++20 %s -o %t.pcm
+// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -std=c++20 %t.pcm -emit-llvm -o - | \
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC %s
+
+// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -emit-module-interface -target-feature +pacbti -msign-return-address=all -std=c++20 %s -o %t.pcm
+// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -std=c++20 %t.pcm -emit-llvm -o - | \
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-ALL %s
+
+// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -emit-module-interface -target-feature +pacbti -msign-return-address=non-leaf -mbranch-target-enforce -std=c++20 %s -o %t.pcm
+// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -std=c++20 %t.pcm -emit-llvm -o - | \
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-BTI %s
+
+// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -emit-module-interface -target-feature +pacbti -msign-return-address=all -mbranch-target-enforce -std=c++20 %s -o %t.pcm
+// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -std=c++20 %t.pcm -emit-llvm -o - | \
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-BTI-ALL %s
+
+// CHECK: define void @_ZGIW3foo() #0
+// CHECK-BTI: attributes #0 = { nounwind "branch-target-enforcement" }
+// CHECK-PAC: attributes #0 = { nounwind "sign-return-address"="non-leaf" "sign-return-address-key"="a_key" }
+// CHECK-PAC-ALL: attributes #0 = { nounwind "sign-return-address"="all" "sign-return-address-key"="a_key" }
+// CHECK-PAC-BTI: attributes #0 = { nounwind "branch-target-enforcement" "sign-return-address"="non-leaf" "sign-return-address-key"="a_key" }
+// CHECK-PAC-BTI-ALL: attributes #0 = { nounwind "branch-target-enforcement" "sign-return-address"="all" "sign-return-address-key"="a_key" }
+
+module;
+
+export module foo;
+
+export void func();

--- a/clang/test/CodeGenCXX/cxx20-module-initializer-pacbti.cpp
+++ b/clang/test/CodeGenCXX/cxx20-module-initializer-pacbti.cpp
@@ -18,12 +18,52 @@
 // RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -std=c++20 %t.pcm -emit-llvm -o - | \
 // RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-BTI-ALL %s
 
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -mbranch-target-enforce -std=c++20 %s -o %t.pcm
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-BTI %s
+
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -msign-return-address=non-leaf -std=c++20 %s -o %t.pcm
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC %s
+
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -msign-return-address=non-leaf -msign-return-address-key=b_key -std=c++20 %s -o %t.pcm
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-BKEY %s
+
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -msign-return-address=all -std=c++20 %s -o %t.pcm
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-ALL %s
+
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -msign-return-address=all -msign-return-address-key=b_key -std=c++20 %s -o %t.pcm
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-ALL-BKEY %s
+
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -msign-return-address=non-leaf -mbranch-target-enforce -std=c++20 %s -o %t.pcm
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-BTI %s
+
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -msign-return-address=non-leaf -msign-return-address-key=b_key -mbranch-target-enforce -std=c++20 %s -o %t.pcm
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-BKEY-BTI %s
+
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -msign-return-address=all -mbranch-target-enforce -std=c++20 %s -o %t.pcm
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-BTI-ALL %s
+
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -msign-return-address=all -msign-return-address-key=b_key -mbranch-target-enforce -std=c++20 %s -o %t.pcm
+// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-BKEY-BTI-ALL %s
+
 // CHECK: define void @_ZGIW3foo() #0
 // CHECK-BTI: attributes #0 = { nounwind "branch-target-enforcement" }
 // CHECK-PAC: attributes #0 = { nounwind "sign-return-address"="non-leaf" "sign-return-address-key"="a_key" }
+// CHECK-PAC-BKEY: attributes #0 = { nounwind "sign-return-address"="non-leaf" "sign-return-address-key"="b_key" }
 // CHECK-PAC-ALL: attributes #0 = { nounwind "sign-return-address"="all" "sign-return-address-key"="a_key" }
+// CHECK-PAC-ALL-BKEY: attributes #0 = { nounwind "sign-return-address"="all" "sign-return-address-key"="b_key" }
 // CHECK-PAC-BTI: attributes #0 = { nounwind "branch-target-enforcement" "sign-return-address"="non-leaf" "sign-return-address-key"="a_key" }
+// CHECK-PAC-BKEY-BTI: attributes #0 = { nounwind "branch-target-enforcement" "sign-return-address"="non-leaf" "sign-return-address-key"="b_key" }
 // CHECK-PAC-BTI-ALL: attributes #0 = { nounwind "branch-target-enforcement" "sign-return-address"="all" "sign-return-address-key"="a_key" }
+// CHECK-PAC-BKEY-BTI-ALL: attributes #0 = { nounwind "branch-target-enforcement" "sign-return-address"="all" "sign-return-address-key"="b_key" }
 
 module;
 

--- a/clang/test/CodeGenCXX/cxx20-module-initializer-pacbti.cpp
+++ b/clang/test/CodeGenCXX/cxx20-module-initializer-pacbti.cpp
@@ -1,69 +1,14 @@
-// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -emit-module-interface -target-feature +pacbti -mbranch-target-enforce -std=c++20 %s -o %t.pcm
-// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -std=c++20 %t.pcm -emit-llvm -o - | \
-// RUN: FileCheck --check-prefixes=CHECK,CHECK-BTI %s
-
-// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -emit-module-interface -target-feature +pacbti -msign-return-address=non-leaf -std=c++20 %s -o %t.pcm
-// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -std=c++20 %t.pcm -emit-llvm -o - | \
-// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC %s
-
-// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -emit-module-interface -target-feature +pacbti -msign-return-address=all -std=c++20 %s -o %t.pcm
-// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -std=c++20 %t.pcm -emit-llvm -o - | \
-// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-ALL %s
-
-// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -emit-module-interface -target-feature +pacbti -msign-return-address=non-leaf -mbranch-target-enforce -std=c++20 %s -o %t.pcm
-// RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -std=c++20 %t.pcm -emit-llvm -o - | \
-// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-BTI %s
-
 // RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -emit-module-interface -target-feature +pacbti -msign-return-address=all -mbranch-target-enforce -std=c++20 %s -o %t.pcm
 // RUN: %clang_cc1 -triple thumbv8.1m.main-unknown-none-eabi -std=c++20 %t.pcm -emit-llvm -o - | \
-// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-BTI-ALL %s
-
-// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -mbranch-target-enforce -std=c++20 %s -o %t.pcm
-// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
-// RUN: FileCheck --check-prefixes=CHECK,CHECK-BTI %s
-
-// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -msign-return-address=non-leaf -std=c++20 %s -o %t.pcm
-// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
-// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC %s
-
-// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -msign-return-address=non-leaf -msign-return-address-key=b_key -std=c++20 %s -o %t.pcm
-// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
-// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-BKEY %s
-
-// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -msign-return-address=all -std=c++20 %s -o %t.pcm
-// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
-// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-ALL %s
-
-// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -msign-return-address=all -msign-return-address-key=b_key -std=c++20 %s -o %t.pcm
-// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
-// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-ALL-BKEY %s
-
-// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -msign-return-address=non-leaf -mbranch-target-enforce -std=c++20 %s -o %t.pcm
-// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
-// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-BTI %s
-
-// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -msign-return-address=non-leaf -msign-return-address-key=b_key -mbranch-target-enforce -std=c++20 %s -o %t.pcm
-// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
-// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-BKEY-BTI %s
-
-// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -msign-return-address=all -mbranch-target-enforce -std=c++20 %s -o %t.pcm
-// RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
-// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-BTI-ALL %s
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-ARM %s
 
 // RUN: %clang_cc1 -triple aarch64-unknown-none-elf -emit-module-interface -target-feature +pacbti -msign-return-address=all -msign-return-address-key=b_key -mbranch-target-enforce -std=c++20 %s -o %t.pcm
 // RUN: %clang_cc1 -triple aarch64-unknown-none-elf -std=c++20 %t.pcm -emit-llvm -o - | \
-// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-BKEY-BTI-ALL %s
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-PAC-AARCH64 %s
 
 // CHECK: define void @_ZGIW3foo() #0
-// CHECK-BTI: attributes #0 = { nounwind "branch-target-enforcement" }
-// CHECK-PAC: attributes #0 = { nounwind "sign-return-address"="non-leaf" "sign-return-address-key"="a_key" }
-// CHECK-PAC-BKEY: attributes #0 = { nounwind "sign-return-address"="non-leaf" "sign-return-address-key"="b_key" }
-// CHECK-PAC-ALL: attributes #0 = { nounwind "sign-return-address"="all" "sign-return-address-key"="a_key" }
-// CHECK-PAC-ALL-BKEY: attributes #0 = { nounwind "sign-return-address"="all" "sign-return-address-key"="b_key" }
-// CHECK-PAC-BTI: attributes #0 = { nounwind "branch-target-enforcement" "sign-return-address"="non-leaf" "sign-return-address-key"="a_key" }
-// CHECK-PAC-BKEY-BTI: attributes #0 = { nounwind "branch-target-enforcement" "sign-return-address"="non-leaf" "sign-return-address-key"="b_key" }
-// CHECK-PAC-BTI-ALL: attributes #0 = { nounwind "branch-target-enforcement" "sign-return-address"="all" "sign-return-address-key"="a_key" }
-// CHECK-PAC-BKEY-BTI-ALL: attributes #0 = { nounwind "branch-target-enforcement" "sign-return-address"="all" "sign-return-address-key"="b_key" }
+// CHECK-PAC-ARM: attributes #0 = { noinline nounwind "branch-target-enforcement" "no-trapping-math"="true" "sign-return-address"="all" "sign-return-address-key"="a_key" "stack-protector-buffer-size"="8" "target-features"="+armv8.1-m.main,+pacbti,+thumb-mode" }
+// CHECK-PAC-AARCH64: attributes #0 = { noinline nounwind "branch-target-enforcement" "no-trapping-math"="true" "sign-return-address"="all" "sign-return-address-key"="b_key" "stack-protector-buffer-size"="8" "target-features"="+pacbti" }
 
 module;
 


### PR DESCRIPTION
The CXX module initializer function, which is called at program startup, needs to be tagged with Pointer Authentication and Branch Target Identification marks whenever relevant.

Before this patch, in CPUs set up for PACBTI execution, the function wasn't protected with return address signing and no BTI instruction was inserted at the start of it, thus leading to an execution fault.

This patch fixes the issue by marking the function with the function attributes related to PAC and BTI if relevant.