### PR TITLE
[libc++] Move more attributes to the C++11 syntax

### DIFF
--- a/libcxx/include/__algorithm/simd_utils.h
+++ b/libcxx/include/__algorithm/simd_utils.h
@@ -126,7 +126,7 @@ template <class _Tp, size_t _Np>
   using __mask_vec = __simd_vector<bool, _Np>;
 
   // This has MSan disabled du to https://github.com/llvm/llvm-project/issues/85876
-  auto __impl = [&]<class _MaskT>(_MaskT) _LIBCPP_NO_SANITIZE("memory") noexcept {
+  auto __impl = [&]<class _MaskT> _LIBCPP_NO_SANITIZE("memory") (_MaskT) noexcept {
 #  if defined(_LIBCPP_BIG_ENDIAN)
     return std::min<size_t>(
         _Np, std::__countl_zero(__builtin_bit_cast(_MaskT, __builtin_convertvector(__vec, __mask_vec))));

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -303,8 +303,8 @@ _LIBCPP_HARDENING_MODE_DEBUG
 #  else
 
 #    define _LIBCPP_ALIGNOF(_Tp) _Alignof(_Tp)
-#    define _ALIGNAS_TYPE(x) __attribute__((__aligned__(_LIBCPP_ALIGNOF(x))))
-#    define _ALIGNAS(x) __attribute__((__aligned__(x)))
+#    define _ALIGNAS_TYPE(x) [[__gnu__::__aligned__(_LIBCPP_ALIGNOF(x))]]
+#    define _ALIGNAS(x) [[__gnu__::__aligned__(x)]]
 #    define nullptr __nullptr
 #    define _NOEXCEPT throw()
 #    define _NOEXCEPT_(...)
@@ -431,7 +431,7 @@ typedef __char32_t char32_t;
 
 #  endif // defined(_LIBCPP_OBJECT_FORMAT_COFF)
 
-#  if __has_attribute(exclude_from_explicit_instantiation)
+#  if __has_cpp_attribute(_Clang::__exclude_from_explicit_instantiation__)
 #    define _LIBCPP_EXCLUDE_FROM_EXPLICIT_INSTANTIATION __attribute__((__exclude_from_explicit_instantiation__))
 #  else
 // Try to approximate the effect of exclude_from_explicit_instantiation
@@ -817,7 +817,7 @@ typedef __char32_t char32_t;
 #  endif
 
 #  ifndef _LIBCPP_WEAK
-#    define _LIBCPP_WEAK __attribute__((__weak__))
+#    define _LIBCPP_WEAK [[__gnu__::__weak__]]
 #  endif
 
 // Thread API
@@ -969,14 +969,14 @@ typedef __char32_t char32_t;
 #  if _LIBCPP_STD_VER >= 20
 #    define _LIBCPP_CONSTINIT constinit
 #  elif __has_attribute(__require_constant_initialization__)
-#    define _LIBCPP_CONSTINIT __attribute__((__require_constant_initialization__))
+#    define _LIBCPP_CONSTINIT [[_Clang::__require_constant_initialization__]]
 #  else
 #    define _LIBCPP_CONSTINIT
 #  endif
 
 #  if defined(__CUDACC__) || defined(__CUDA_ARCH__) || defined(__CUDA_LIBDEVICE__)
 // The CUDA SDK contains an unfortunate definition for the __noinline__ macro,
-// which breaks the regular __attribute__((__noinline__)) syntax. Therefore,
+// which breaks the regular [[__gnu__::__noinline__]] syntax. Therefore,
 // when compiling for CUDA we use the non-underscored version of the noinline
 // attribute.
 //
@@ -984,9 +984,9 @@ typedef __char32_t char32_t;
 // this issue properly in the SDK headers.
 //
 // See https://github.com/llvm/llvm-project/pull/73838 for more details.
-#    define _LIBCPP_NOINLINE __attribute__((noinline))
+#    define _LIBCPP_NOINLINE [[__gnu__::noinline]]
 #  elif __has_attribute(__noinline__)
-#    define _LIBCPP_NOINLINE __attribute__((__noinline__))
+#    define _LIBCPP_NOINLINE [[__gnu__::__noinline__]]
 #  else
 #    define _LIBCPP_NOINLINE
 #  endif
@@ -1131,19 +1131,19 @@ typedef __char32_t char32_t;
 
 // Optional attributes - these are useful for a better QoI, but not required to be available
 
-#  define _LIBCPP_NOALIAS __attribute__((__malloc__))
+#  define _LIBCPP_NOALIAS [[__gnu__::__malloc__]]
 #  define _LIBCPP_NODEBUG [[__gnu__::__nodebug__]]
 #  define _LIBCPP_NO_SANITIZE(...) __attribute__((__no_sanitize__(__VA_ARGS__)))
-#  define _LIBCPP_INIT_PRIORITY_MAX __attribute__((__init_priority__(100)))
+#  define _LIBCPP_INIT_PRIORITY_MAX [[__gnu__::__init_priority__(100)]]
 #  define _LIBCPP_ATTRIBUTE_FORMAT(archetype, format_string_index, first_format_arg_index)                             \
     __attribute__((__format__(archetype, format_string_index, first_format_arg_index)))
-#  define _LIBCPP_PACKED __attribute__((__packed__))
+#  define _LIBCPP_PACKED [[__gnu__::__packed__]]
 
 // Use a function like macro to imply that it must be followed by a semicolon
 #  define _LIBCPP_FALLTHROUGH() [[fallthrough]]
 
-#  if __has_attribute(__no_sanitize__) && !defined(_LIBCPP_COMPILER_GCC)
-#    define _LIBCPP_NO_CFI __attribute__((__no_sanitize__("cfi")))
+#  if __has_cpp_attribute(_Clang::__no_sanitize__)
+#    define _LIBCPP_NO_CFI [[_Clang::__no_sanitize__("cfi")]]
 #  else
 #    define _LIBCPP_NO_CFI
 #  endif
@@ -1204,8 +1204,8 @@ typedef __char32_t char32_t;
 #  endif
 
 // Allow for build-time disabling of unsigned integer sanitization
-#  if __has_attribute(no_sanitize) && !defined(_LIBCPP_COMPILER_GCC)
-#    define _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK __attribute__((__no_sanitize__("unsigned-integer-overflow")))
+#  if __has_cpp_attribute(_Clang::__no_sanitize__)
+#    define _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK [[_Clang::__no_sanitize__("unsigned-integer-overflow")]]
 #  else
 #    define _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK
 #  endif

--- a/libcxx/include/__functional/function.h
+++ b/libcxx/include/__functional/function.h
@@ -349,7 +349,7 @@ class __value_func<_Rp(_ArgTypes...)> {
   typedef __base<_Rp(_ArgTypes...)> __func;
   __func* __f_;
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_CFI static __func* __as_base(void* __p) { return reinterpret_cast<__func*>(__p); }
+  _LIBCPP_NO_CFI _LIBCPP_HIDE_FROM_ABI static __func* __as_base(void* __p) { return reinterpret_cast<__func*>(__p); }
 
 public:
   _LIBCPP_HIDE_FROM_ABI __value_func() _NOEXCEPT : __f_(nullptr) {}

--- a/libcxx/include/__functional/hash.h
+++ b/libcxx/include/__functional/hash.h
@@ -46,7 +46,7 @@ struct __murmur2_or_cityhash;
 
 template <class _Size>
 struct __murmur2_or_cityhash<_Size, 32> {
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK _Size
+  _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK _LIBCPP_HIDE_FROM_ABI _Size
   operator()(const void* __key, _Size __len) const {
     // murmur2
     const _Size __m             = 0x5bd1e995;
@@ -82,7 +82,7 @@ struct __murmur2_or_cityhash<_Size, 32> {
 template <class _Size>
 struct __murmur2_or_cityhash<_Size, 64> {
   // cityhash64
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK _Size
+  _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK _LIBCPP_HIDE_FROM_ABI _Size
   operator()(const void* __key, _Size __len) const {
     const char* __s = static_cast<const char*>(__key);
     if (__len <= 32) {
@@ -140,7 +140,7 @@ private:
 
   _LIBCPP_HIDE_FROM_ABI static _Size __shift_mix(_Size __val) { return __val ^ (__val >> 47); }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK static _Size __hash_len_16(_Size __u, _Size __v) {
+  _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK _LIBCPP_HIDE_FROM_ABI static _Size __hash_len_16(_Size __u, _Size __v) {
     const _Size __mul = 0x9ddfea08eb382d69ULL;
     _Size __a         = (__u ^ __v) * __mul;
     __a ^= (__a >> 47);
@@ -150,7 +150,7 @@ private:
     return __b;
   }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK static _Size
+  _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK _LIBCPP_HIDE_FROM_ABI static _Size
   __hash_len_0_to_16(const char* __s, _Size __len) {
     if (__len > 8) {
       const _Size __a = std::__loadword<_Size>(__s);
@@ -177,7 +177,7 @@ private:
     return __k2;
   }
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK static _Size
+  _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK _LIBCPP_HIDE_FROM_ABI static _Size
   __hash_len_17_to_32(const char* __s, _Size __len) {
     const _Size __a = std::__loadword<_Size>(__s) * __k1;
     const _Size __b = std::__loadword<_Size>(__s + 8);
@@ -189,7 +189,7 @@ private:
 
   // Return a 16-byte hash for 48 bytes.  Quick and dirty.
   // Callers do best to use "random-looking" values for a and b.
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK static pair<_Size, _Size>
+  _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK _LIBCPP_HIDE_FROM_ABI static pair<_Size, _Size>
   __weak_hash_len_32_with_seeds(_Size __w, _Size __x, _Size __y, _Size __z, _Size __a, _Size __b) {
     __a += __w;
     __b             = __rotate(__b + __a + __z, 21);
@@ -201,7 +201,7 @@ private:
   }
 
   // Return a 16-byte hash for s[0] ... s[31], a, and b.  Quick and dirty.
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK static pair<_Size, _Size>
+  _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK _LIBCPP_HIDE_FROM_ABI static pair<_Size, _Size>
   __weak_hash_len_32_with_seeds(const char* __s, _Size __a, _Size __b) {
     return __weak_hash_len_32_with_seeds(
         std::__loadword<_Size>(__s),
@@ -213,7 +213,7 @@ private:
   }
 
   // Return an 8-byte hash for 33 to 64 bytes.
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK static _Size
+  _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK _LIBCPP_HIDE_FROM_ABI static _Size
   __hash_len_33_to_64(const char* __s, size_t __len) {
     _Size __z = std::__loadword<_Size>(__s + 24);
     _Size __a = std::__loadword<_Size>(__s) + (__len + std::__loadword<_Size>(__s + __len - 16)) * __k0;

--- a/libcxx/include/__hash_table
+++ b/libcxx/include/__hash_table
@@ -1707,7 +1707,7 @@ _LIBCPP_HIDE_FROM_ABI void __hash_table<_Tp, _Hash, _Equal, _Alloc>::__node_hand
 
 template <class _Tp, class _Hash, class _Equal, class _Alloc>
 template <bool _UniqueKeys>
-void __hash_table<_Tp, _Hash, _Equal, _Alloc>::__rehash(size_type __n) _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK {
+_LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK void __hash_table<_Tp, _Hash, _Equal, _Alloc>::__rehash(size_type __n) {
   if (__n == 1)
     __n = 2;
   else if (__n & (__n - 1))

--- a/libcxx/include/__memory/addressof.h
+++ b/libcxx/include/__memory/addressof.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-inline _LIBCPP_CONSTEXPR_SINCE_CXX17 _LIBCPP_NO_CFI _LIBCPP_HIDE_FROM_ABI _Tp* addressof(_Tp& __x) _NOEXCEPT {
+_LIBCPP_NO_CFI inline _LIBCPP_CONSTEXPR_SINCE_CXX17 _LIBCPP_HIDE_FROM_ABI _Tp* addressof(_Tp& __x) _NOEXCEPT {
   return __builtin_addressof(__x);
 }
 

--- a/libcxx/include/__memory/shared_ptr.h
+++ b/libcxx/include/__memory/shared_ptr.h
@@ -208,7 +208,7 @@ private:
       return std::addressof(reinterpret_cast<_Data*>(__buffer_)->__alloc_);
     }
 
-    _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_CFI __value_type* __get_elem() _NOEXCEPT {
+    _LIBCPP_NO_CFI _LIBCPP_HIDE_FROM_ABI __value_type* __get_elem() _NOEXCEPT {
       return std::addressof(reinterpret_cast<_Data*>(__buffer_)->__elem_);
     }
   };

--- a/libcxx/include/__memory/temp_value.h
+++ b/libcxx/include/__memory/temp_value.h
@@ -45,7 +45,7 @@ struct __temp_value {
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 _Tp& get() { return *__addr(); }
 
   template <class... _Args>
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_CFI _LIBCPP_CONSTEXPR_SINCE_CXX20 __temp_value(_Alloc& __alloc, _Args&&... __args)
+  _LIBCPP_NO_CFI _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 __temp_value(_Alloc& __alloc, _Args&&... __args)
       : __a(__alloc) {
     _Traits::construct(__a, __addr(), std::forward<_Args>(__args)...);
   }

--- a/libcxx/include/__memory/unique_temporary_buffer.h
+++ b/libcxx/include/__memory/unique_temporary_buffer.h
@@ -48,7 +48,7 @@ template <class _Tp>
 using __unique_temporary_buffer _LIBCPP_NODEBUG = unique_ptr<_Tp, __temporary_buffer_deleter<_Tp> >;
 
 template <class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_CFI _LIBCPP_CONSTEXPR_SINCE_CXX23 __unique_temporary_buffer<_Tp>
+_LIBCPP_NO_CFI inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX23 __unique_temporary_buffer<_Tp>
 __allocate_unique_temporary_buffer(ptrdiff_t __count) {
   using __deleter_type       = __temporary_buffer_deleter<_Tp>;
   using __unique_buffer_type = __unique_temporary_buffer<_Tp>;

--- a/libcxx/include/__new/allocate.h
+++ b/libcxx/include/__new/allocate.h
@@ -50,7 +50,7 @@ _LIBCPP_HIDE_FROM_ABI void __libcpp_operator_delete(_Args... __args) _NOEXCEPT {
 }
 
 template <class _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_CFI _Tp*
+_LIBCPP_NO_CFI inline _LIBCPP_HIDE_FROM_ABI _Tp*
 __libcpp_allocate(__element_count __n, size_t __align = _LIBCPP_ALIGNOF(_Tp)) {
   size_t __size = static_cast<size_t>(__n) * sizeof(_Tp);
 #if _LIBCPP_HAS_ALIGNED_ALLOCATION

--- a/libcxx/include/__new/global_new_delete.h
+++ b/libcxx/include/__new/global_new_delete.h
@@ -35,8 +35,8 @@
 #  include <new.h>
 #else
 [[__nodiscard__]] _LIBCPP_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz) _THROW_BAD_ALLOC;
-[[__nodiscard__]] _LIBCPP_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz, const std::nothrow_t&) _NOEXCEPT
-    _LIBCPP_NOALIAS;
+[[__nodiscard__]] _LIBCPP_NOALIAS _LIBCPP_OVERRIDABLE_FUNC_VIS void*
+operator new(std::size_t __sz, const std::nothrow_t&) _NOEXCEPT;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete(void* __p) _NOEXCEPT;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete(void* __p, const std::nothrow_t&) _NOEXCEPT;
 #  if _LIBCPP_HAS_SIZED_DEALLOCATION
@@ -44,8 +44,8 @@ _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete(void* __p, std::size_t __sz) _
 #  endif
 
 [[__nodiscard__]] _LIBCPP_OVERRIDABLE_FUNC_VIS void* operator new[](std::size_t __sz) _THROW_BAD_ALLOC;
-[[__nodiscard__]] _LIBCPP_OVERRIDABLE_FUNC_VIS void* operator new[](std::size_t __sz, const std::nothrow_t&) _NOEXCEPT
-    _LIBCPP_NOALIAS;
+[[__nodiscard__]] _LIBCPP_NOALIAS _LIBCPP_OVERRIDABLE_FUNC_VIS void*
+operator new[](std::size_t __sz, const std::nothrow_t&) _NOEXCEPT;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p) _NOEXCEPT;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p, const std::nothrow_t&) _NOEXCEPT;
 #  if _LIBCPP_HAS_SIZED_DEALLOCATION
@@ -54,8 +54,8 @@ _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p, std::size_t __sz)
 
 #  if _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION
 [[__nodiscard__]] _LIBCPP_OVERRIDABLE_FUNC_VIS void* operator new(std::size_t __sz, std::align_val_t) _THROW_BAD_ALLOC;
-[[__nodiscard__]] _LIBCPP_OVERRIDABLE_FUNC_VIS void*
-operator new(std::size_t __sz, std::align_val_t, const std::nothrow_t&) _NOEXCEPT _LIBCPP_NOALIAS;
+[[__nodiscard__]] _LIBCPP_NOALIAS _LIBCPP_OVERRIDABLE_FUNC_VIS void*
+operator new(std::size_t __sz, std::align_val_t, const std::nothrow_t&) _NOEXCEPT;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete(void* __p, std::align_val_t) _NOEXCEPT;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete(void* __p, std::align_val_t, const std::nothrow_t&) _NOEXCEPT;
 #    if _LIBCPP_HAS_SIZED_DEALLOCATION
@@ -64,8 +64,8 @@ _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete(void* __p, std::size_t __sz, s
 
 [[__nodiscard__]] _LIBCPP_OVERRIDABLE_FUNC_VIS void*
 operator new[](std::size_t __sz, std::align_val_t) _THROW_BAD_ALLOC;
-[[__nodiscard__]] _LIBCPP_OVERRIDABLE_FUNC_VIS void*
-operator new[](std::size_t __sz, std::align_val_t, const std::nothrow_t&) _NOEXCEPT _LIBCPP_NOALIAS;
+[[__nodiscard__]] _LIBCPP_NOALIAS _LIBCPP_OVERRIDABLE_FUNC_VIS void*
+operator new[](std::size_t __sz, std::align_val_t, const std::nothrow_t&) _NOEXCEPT;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p, std::align_val_t) _NOEXCEPT;
 _LIBCPP_OVERRIDABLE_FUNC_VIS void operator delete[](void* __p, std::align_val_t, const std::nothrow_t&) _NOEXCEPT;
 #    if _LIBCPP_HAS_SIZED_DEALLOCATION

--- a/libcxx/include/__numeric/midpoint.h
+++ b/libcxx/include/__numeric/midpoint.h
@@ -35,8 +35,9 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 20
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI constexpr enable_if_t<is_integral_v<_Tp> && !is_same_v<bool, _Tp> && !is_null_pointer_v<_Tp>, _Tp>
-midpoint(_Tp __a, _Tp __b) noexcept _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK {
+_LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK
+    _LIBCPP_HIDE_FROM_ABI constexpr enable_if_t<is_integral_v<_Tp> && !is_same_v<bool, _Tp> && !is_null_pointer_v<_Tp>,
+                                                _Tp> midpoint(_Tp __a, _Tp __b) noexcept {
   using _Up                = make_unsigned_t<_Tp>;
   constexpr _Up __bitshift = numeric_limits<_Up>::digits - 1;
 

--- a/libcxx/include/__random/mersenne_twister_engine.h
+++ b/libcxx/include/__random/mersenne_twister_engine.h
@@ -324,8 +324,9 @@ template <class _UIntType,
           _UIntType __c,
           size_t __l,
           _UIntType __f>
-void mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::seed(
-    result_type __sd) _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK { // __w >= 2
+_LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK void
+mersenne_twister_engine<_UIntType, __w, __n, __m, __r, __a, __u, __d, __s, __b, __t, __c, __l, __f>::seed(
+    result_type __sd) { // __w >= 2
   __x_[0] = __sd & _Max;
   for (size_t __i = 1; __i < __n; ++__i)
     __x_[__i] = (__f * (__x_[__i - 1] ^ __rshift<__w - 2>(__x_[__i - 1])) + __i) & _Max;

--- a/libcxx/include/__random/uniform_int_distribution.h
+++ b/libcxx/include/__random/uniform_int_distribution.h
@@ -207,8 +207,8 @@ public:
 
 template <class _IntType>
 template <class _URNG>
-typename uniform_int_distribution<_IntType>::result_type uniform_int_distribution<_IntType>::operator()(
-    _URNG& __g, const param_type& __p) _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK {
+_LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK typename uniform_int_distribution<_IntType>::result_type
+uniform_int_distribution<_IntType>::operator()(_URNG& __g, const param_type& __p) {
   static_assert(__libcpp_random_is_valid_urng<_URNG>::value, "");
   typedef __conditional_t<sizeof(result_type) <= sizeof(uint32_t), uint32_t, __make_unsigned_t<result_type> > _UIntType;
   const _UIntType __rp = _UIntType(__p.b()) - _UIntType(__p.a()) + _UIntType(1);

--- a/libcxx/include/__utility/is_pointer_in_range.h
+++ b/libcxx/include/__utility/is_pointer_in_range.h
@@ -33,7 +33,7 @@ struct __is_less_than_comparable<_Tp, _Up, __void_t<decltype(std::declval<_Tp>()
 };
 
 template <class _Tp, class _Up, __enable_if_t<__is_less_than_comparable<const _Tp*, const _Up*>::value, int> = 0>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_SANITIZE("address") bool
+_LIBCPP_NO_SANITIZE("address") _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
 __is_pointer_in_range(const _Tp* __begin, const _Tp* __end, const _Up* __ptr) {
   _LIBCPP_ASSERT_VALID_INPUT_RANGE(std::__is_valid_range(__begin, __end), "[__begin, __end) is not a valid range");
 
@@ -48,7 +48,7 @@ __is_pointer_in_range(const _Tp* __begin, const _Tp* __end, const _Up* __ptr) {
 }
 
 template <class _Tp, class _Up, __enable_if_t<!__is_less_than_comparable<const _Tp*, const _Up*>::value, int> = 0>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_SANITIZE("address") bool
+_LIBCPP_NO_SANITIZE("address") _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
 __is_pointer_in_range(const _Tp* __begin, const _Tp* __end, const _Up* __ptr) {
   if (__libcpp_is_constant_evaluated())
     return false;

--- a/libcxx/include/__utility/is_valid_range.h
+++ b/libcxx/include/__utility/is_valid_range.h
@@ -20,7 +20,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-_LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_SANITIZE("address") bool
+_LIBCPP_NO_SANITIZE("address") _LIBCPP_CONSTEXPR_SINCE_CXX14 _LIBCPP_HIDE_FROM_ABI bool
 __is_valid_range(const _Tp* __first, const _Tp* __last) {
   if (__libcpp_is_constant_evaluated()) {
     // If this is not a constant during constant evaluation, that is because __first and __last are not

--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -808,7 +808,7 @@ private:
   _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void __move_assign_alloc(vector&, false_type) _NOEXCEPT {}
 
   template <class _Ptr = pointer, __enable_if_t<is_pointer<_Ptr>::value, int> = 0>
-  static _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_CFI pointer
+  _LIBCPP_NO_CFI static _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI pointer
   __add_alignment_assumption(_Ptr __p) _NOEXCEPT {
     if (!__libcpp_is_constant_evaluated()) {
       return static_cast<pointer>(__builtin_assume_aligned(__p, _LIBCPP_ALIGNOF(decltype(*__p))));
@@ -817,7 +817,7 @@ private:
   }
 
   template <class _Ptr = pointer, __enable_if_t<!is_pointer<_Ptr>::value, int> = 0>
-  static _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_CFI pointer
+  _LIBCPP_NO_CFI static _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI pointer
   __add_alignment_assumption(_Ptr __p) _NOEXCEPT {
     return __p;
   }

--- a/libcxx/include/future
+++ b/libcxx/include/future
@@ -1465,7 +1465,7 @@ template <class _Rp, class... _ArgTypes>
 class __packaged_task_function<_Rp(_ArgTypes...)> {
   typedef __packaged_task_base<_Rp(_ArgTypes...)> __base;
 
-  _LIBCPP_HIDE_FROM_ABI _LIBCPP_NO_CFI __base* __get_buf() { return (__base*)&__buf_; }
+  _LIBCPP_NO_CFI _LIBCPP_HIDE_FROM_ABI __base* __get_buf() { return (__base*)&__buf_; }
 
   _LIBCPP_SUPPRESS_DEPRECATED_PUSH
   typename aligned_storage<3 * sizeof(void*)>::type __buf_;

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -2238,7 +2238,7 @@ private:
   // to call the __init() functions as those are marked as inline which may
   // result in over-aggressive inlining by the compiler, where our aim is
   // to only inline the fast path code directly in the ctor.
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_NOINLINE void __init_copy_ctor_external(const value_type* __s, size_type __sz);
+  _LIBCPP_NOINLINE _LIBCPP_CONSTEXPR_SINCE_CXX20 void __init_copy_ctor_external(const value_type* __s, size_type __sz);
 
   template <class _InputIterator, __enable_if_t<__has_exactly_input_iterator_category<_InputIterator>::value, int> = 0>
   inline _LIBCPP_CONSTEXPR_SINCE_CXX20 void __init(_InputIterator __first, _InputIterator __last);
@@ -2284,7 +2284,7 @@ private:
   // have proof that the input does not alias the current instance.
   // For example, operator=(basic_string) performs a 'self' check.
   template <bool __is_short>
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_NOINLINE basic_string& __assign_no_alias(const value_type* __s, size_type __n);
+  _LIBCPP_NOINLINE _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& __assign_no_alias(const value_type* __s, size_type __n);
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __erase_to_end(size_type __pos) {
     _LIBCPP_ASSERT_INTERNAL(__pos <= capacity(), "Trying to erase at position outside the strings capacity!");
@@ -2293,7 +2293,7 @@ private:
 
   // __erase_external_with_move is invoked for erase() invocations where
   // `n ~= npos`, likely requiring memory moves on the string data.
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_NOINLINE void __erase_external_with_move(size_type __pos, size_type __n);
+  _LIBCPP_NOINLINE _LIBCPP_CONSTEXPR_SINCE_CXX20 void __erase_external_with_move(size_type __pos, size_type __n);
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __copy_assign_alloc(const basic_string& __str) {
     __copy_assign_alloc(
@@ -2356,8 +2356,8 @@ private:
 
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 void __move_assign_alloc(basic_string&, false_type) _NOEXCEPT {}
 
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_NOINLINE basic_string& __assign_external(const value_type* __s);
-  _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_NOINLINE basic_string& __assign_external(const value_type* __s, size_type __n);
+  _LIBCPP_NOINLINE _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& __assign_external(const value_type* __s);
+  _LIBCPP_NOINLINE _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& __assign_external(const value_type* __s, size_type __n);
 
   // Assigns the value in __s, guaranteed to be __n < __min_cap in length.
   inline _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string& __assign_short(const value_type* __s, size_type __n) {
@@ -2492,7 +2492,7 @@ basic_string<_CharT, _Traits, _Allocator>::__init(const value_type* __s, size_ty
 }
 
 template <class _CharT, class _Traits, class _Allocator>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_NOINLINE void
+_LIBCPP_NOINLINE _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 basic_string<_CharT, _Traits, _Allocator>::__init_copy_ctor_external(const value_type* __s, size_type __sz) {
   if (__libcpp_is_constant_evaluated())
     __rep_ = __rep();
@@ -2709,7 +2709,7 @@ basic_string<_CharT, _Traits, _Allocator>::__grow_by_without_replace(
 
 template <class _CharT, class _Traits, class _Allocator>
 template <bool __is_short>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_NOINLINE basic_string<_CharT, _Traits, _Allocator>&
+_LIBCPP_NOINLINE _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<_CharT, _Traits, _Allocator>&
 basic_string<_CharT, _Traits, _Allocator>::__assign_no_alias(const value_type* __s, size_type __n) {
   const auto __cap  = __is_short ? static_cast<size_type>(__min_cap) : __get_long_cap();
   const auto __size = __is_short ? __get_short_size() : __get_long_size();
@@ -2735,7 +2735,7 @@ basic_string<_CharT, _Traits, _Allocator>::__assign_no_alias(const value_type* _
 }
 
 template <class _CharT, class _Traits, class _Allocator>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_NOINLINE basic_string<_CharT, _Traits, _Allocator>&
+_LIBCPP_NOINLINE _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<_CharT, _Traits, _Allocator>&
 basic_string<_CharT, _Traits, _Allocator>::__assign_external(const value_type* __s, size_type __n) {
   const auto __cap  = capacity();
   const auto __size = size();
@@ -2961,7 +2961,7 @@ basic_string<_CharT, _Traits, _Allocator>::assign(const _Tp& __t, size_type __po
 }
 
 template <class _CharT, class _Traits, class _Allocator>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_NOINLINE basic_string<_CharT, _Traits, _Allocator>&
+_LIBCPP_NOINLINE _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<_CharT, _Traits, _Allocator>&
 basic_string<_CharT, _Traits, _Allocator>::__assign_external(const value_type* __s) {
   return __assign_external(__s, traits_type::length(__s));
 }
@@ -3260,10 +3260,9 @@ basic_string<_CharT, _Traits, _Allocator>::insert(const_iterator __pos, value_ty
 // replace
 
 template <class _CharT, class _Traits, class _Allocator>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<_CharT, _Traits, _Allocator>&
+_LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK _LIBCPP_CONSTEXPR_SINCE_CXX20 basic_string<_CharT, _Traits, _Allocator>&
 basic_string<_CharT, _Traits, _Allocator>::replace(
-    size_type __pos, size_type __n1, const value_type* __s, size_type __n2)
-    _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK {
+    size_type __pos, size_type __n1, const value_type* __s, size_type __n2) {
   _LIBCPP_ASSERT_NON_NULL(__n2 == 0 || __s != nullptr, "string::replace received nullptr");
   size_type __sz = size();
   if (__pos > __sz)
@@ -3376,7 +3375,7 @@ basic_string<_CharT, _Traits, _Allocator>::replace(size_type __pos, size_type __
 // 'externally instantiated' erase() implementation, called when __n != npos.
 // Does not check __pos against size()
 template <class _CharT, class _Traits, class _Allocator>
-_LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_NOINLINE void
+_LIBCPP_NOINLINE _LIBCPP_CONSTEXPR_SINCE_CXX20 void
 basic_string<_CharT, _Traits, _Allocator>::__erase_external_with_move(size_type __pos, size_type __n) {
   if (__n) {
     size_type __sz     = size();


### PR DESCRIPTION
This moves most attributes to the C++11 syntax. Some annotations have to be moved around, since the C++11 syntax is a lot stricter on where attributes can be put.
