### PR TITLE
[clang-format] Recognize TableGen paste operator on separate line

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -949,6 +949,8 @@ private:
       HashTok->setType(TT_Unknown);
       if (!parseTableGenValue(ParseNameMode))
         return false;
+      if (!CurrentToken)
+        return true;
     }
     // In name mode, '{' is regarded as the end of the value.
     // See TGParser::ParseValue in TGParser.cpp

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -4860,7 +4860,8 @@ void UnwrappedLineParser::readToken(int LevelDifference) {
       assert(Next); // There is an EOF token at the end.
       if ((Style.isVerilog() && !Keywords.isVerilogPPDirective(*Next)) ||
           (Style.isTableGen() &&
-           !Next->isOneOf(tok::pp_define, tok::pp_ifdef, tok::pp_ifndef))) {
+           !Next->isOneOf(tok::kw_else, tok::pp_define, tok::pp_ifdef,
+                          tok::pp_ifndef, tok::pp_endif))) {
         break;
       }
       distributeComments(Comments, FormatTok);

--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -4856,8 +4856,7 @@ void UnwrappedLineParser::readToken(int LevelDifference) {
            FirstNonCommentOnLine) {
       // In Verilog, the backtick is used for macro invocations. In TableGen,
       // the single hash is used for the paste operator.
-      const FormatToken *Next = Tokens->peekNextToken();
-      assert(Next); // There is an EOF token at the end.
+      const auto *Next = Tokens->peekNextToken();
       if ((Style.isVerilog() && !Keywords.isVerilogPPDirective(*Next)) ||
           (Style.isTableGen() &&
            !Next->isOneOf(tok::kw_else, tok::pp_define, tok::pp_ifdef,

--- a/clang/unittests/Format/FormatTestTableGen.cpp
+++ b/clang/unittests/Format/FormatTestTableGen.cpp
@@ -218,6 +218,12 @@ TEST_F(FormatTestTableGen, PasteOperator) {
                "  string Z = [\"Traring\", \"Paste\", \"Traring\", \"Paste\",\n"
                "              \"Traring\", \"Paste\"]#;\n"
                "}");
+  verifyFormat("def x#x {}", "def x\n"
+                             "#x {}");
+  verifyFormat("def x#x {}", "def x\n"
+                             "#\n"
+                             "x {}");
+  verifyFormat("def x#x");
 }
 
 TEST_F(FormatTestTableGen, ClassDefinition) {

--- a/clang/unittests/Format/FormatTestTableGen.cpp
+++ b/clang/unittests/Format/FormatTestTableGen.cpp
@@ -218,6 +218,7 @@ TEST_F(FormatTestTableGen, PasteOperator) {
                "  string Z = [\"Traring\", \"Paste\", \"Traring\", \"Paste\",\n"
                "              \"Traring\", \"Paste\"]#;\n"
                "}");
+
   verifyFormat("def x#x {}", "def x\n"
                              "#x {}");
   verifyFormat("def x#x {}", "def x\n"

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -2832,6 +2832,23 @@ TEST_F(TokenAnnotatorTest, UnderstandTableGenTokens) {
   Tokens = Annotate("!cond");
   EXPECT_TOKEN(Tokens[0], tok::identifier, TT_TableGenCondOperator);
 
+  // The paste operator should not be treated as a preprocessor directive even
+  // if it is on a separate line.
+  Tokens = Annotate("def x\n"
+                    "#embed {}");
+  ASSERT_EQ(Tokens.size(), 7u) << Tokens;
+  EXPECT_TOKEN(Tokens[1], tok::identifier, TT_StartOfName);
+  EXPECT_TOKEN(Tokens[2], tok::hash, TT_Unknown);
+  EXPECT_EQ(Tokens[1]->Next, Tokens[2]);
+  Tokens = Annotate("def x\n"
+                    "#define x\n"
+                    "#embed {}");
+  ASSERT_EQ(Tokens.size(), 10u) << Tokens;
+  EXPECT_TOKEN(Tokens[1], tok::identifier, TT_StartOfName);
+  EXPECT_TOKEN(Tokens[2], tok::hash, TT_Unknown);
+  EXPECT_TOKEN(Tokens[5], tok::hash, TT_Unknown);
+  EXPECT_EQ(Tokens[1]->Next, Tokens[5]);
+
   auto AnnotateValue = [this, &Style](StringRef Code) {
     // Values are annotated only in specific context.
     auto Result = annotate(("def X { let V = " + Code + "; }").str(), Style);

--- a/clang/unittests/Format/TokenAnnotatorTest.cpp
+++ b/clang/unittests/Format/TokenAnnotatorTest.cpp
@@ -2838,16 +2838,21 @@ TEST_F(TokenAnnotatorTest, UnderstandTableGenTokens) {
                     "#embed {}");
   ASSERT_EQ(Tokens.size(), 7u) << Tokens;
   EXPECT_TOKEN(Tokens[1], tok::identifier, TT_StartOfName);
-  EXPECT_TOKEN(Tokens[2], tok::hash, TT_Unknown);
   EXPECT_EQ(Tokens[1]->Next, Tokens[2]);
   Tokens = Annotate("def x\n"
                     "#define x\n"
                     "#embed {}");
   ASSERT_EQ(Tokens.size(), 10u) << Tokens;
   EXPECT_TOKEN(Tokens[1], tok::identifier, TT_StartOfName);
-  EXPECT_TOKEN(Tokens[2], tok::hash, TT_Unknown);
-  EXPECT_TOKEN(Tokens[5], tok::hash, TT_Unknown);
   EXPECT_EQ(Tokens[1]->Next, Tokens[5]);
+  Tokens = Annotate("def x\n"
+                    "#ifdef x\n"
+                    "#else\n"
+                    "#endif\n"
+                    "#embed {}");
+  ASSERT_EQ(Tokens.size(), 14u) << Tokens;
+  EXPECT_TOKEN(Tokens[1], tok::identifier, TT_StartOfName);
+  EXPECT_EQ(Tokens[1]->Next, Tokens[9]);
 
   auto AnnotateValue = [this, &Style](StringRef Code) {
     // Values are annotated only in specific context.


### PR DESCRIPTION
Formatting this piece of code made the program crash.

```
class TypedVecListRegOperand<RegisterClass Reg, int lanes, string eltsize>
    : RegisterOperand<Reg, "printTypedVectorList<" # lanes # ", '"
                                                   # eltsize # "'>">;
```

The line starting with the `#` was treated as a separate preprocessor directive line.  Then the code dereferenced a null pointer when it tried to continue parsing the first line that did not end in a semicolon.

Now the 2 problems are fixed.