### PR TITLE
[MLIR][NFC] Retire let constructor for EmitC

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/EmitC/Transforms/Passes.h
@@ -14,12 +14,8 @@
 namespace mlir {
 namespace emitc {
 
-//===----------------------------------------------------------------------===//
-// Passes
-//===----------------------------------------------------------------------===//
-
-/// Creates an instance of the C-style expressions forming pass.
-std::unique_ptr<Pass> createFormExpressionsPass();
+#define GEN_PASS_DECL_FORMEXPRESSIONSPASS
+#include "mlir/Dialect/EmitC/Transforms/Passes.h.inc"
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/mlir/include/mlir/Dialect/EmitC/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/EmitC/Transforms/Passes.td
@@ -11,13 +11,12 @@
 
 include "mlir/Pass/PassBase.td"
 
-def FormExpressions : Pass<"form-expressions"> {
+def FormExpressionsPass : Pass<"form-expressions"> {
   let summary = "Form C-style expressions from C-operator ops";
   let description = [{
     The pass wraps emitc ops modelling C operators in emitc.expression ops and
     then folds single-use expressions into their users where possible.
   }];
-  let constructor = "mlir::emitc::createFormExpressionsPass()";
   let dependentDialects = ["emitc::EmitCDialect"];
 }
 

--- a/mlir/lib/Dialect/EmitC/Transforms/FormExpressions.cpp
+++ b/mlir/lib/Dialect/EmitC/Transforms/FormExpressions.cpp
@@ -18,7 +18,7 @@
 
 namespace mlir {
 namespace emitc {
-#define GEN_PASS_DEF_FORMEXPRESSIONS
+#define GEN_PASS_DEF_FORMEXPRESSIONSPASS
 #include "mlir/Dialect/EmitC/Transforms/Passes.h.inc"
 } // namespace emitc
 } // namespace mlir
@@ -28,7 +28,7 @@ using namespace emitc;
 
 namespace {
 struct FormExpressionsPass
-    : public emitc::impl::FormExpressionsBase<FormExpressionsPass> {
+    : public emitc::impl::FormExpressionsPassBase<FormExpressionsPass> {
   void runOnOperation() override {
     Operation *rootOp = getOperation();
     MLIRContext *context = rootOp->getContext();
@@ -56,7 +56,3 @@ struct FormExpressionsPass
   }
 };
 } // namespace
-
-std::unique_ptr<Pass> mlir::emitc::createFormExpressionsPass() {
-  return std::make_unique<FormExpressionsPass>();
-}


### PR DESCRIPTION
`let constructor` is legacy (do not use in tree!) since the tableGen
backend emits most of the glue logic to build a pass.