### PR TITLE
[lldb] Include the version in the lldbassert error message

### DIFF
--- a/lldb/source/Core/CMakeLists.txt
+++ b/lldb/source/Core/CMakeLists.txt
@@ -70,6 +70,7 @@ add_lldb_library(lldbCore
     lldbTarget
     lldbUtility
     lldbValueObject
+    lldbVersion
     lldbPluginCPlusPlusLanguage
     lldbPluginObjCLanguage
     ${LLDB_CURSES_LIBS}

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -1525,8 +1525,9 @@ bool Debugger::FormatDisassemblerAddress(const FormatEntity::Entry *format,
 void Debugger::AssertCallback(llvm::StringRef message,
                               llvm::StringRef backtrace,
                               llvm::StringRef prompt) {
-  Debugger::ReportError(
-      llvm::formatv("{0}\n{1}{2}", message, backtrace, prompt).str());
+  Debugger::ReportError(llvm::formatv("{0}\n{1}{2}\n{3}", message, backtrace,
+                                      GetVersion(), prompt)
+                            .str());
 }
 
 void Debugger::SetLoggingCallback(lldb::LogOutputCallback log_callback,

--- a/lldb/source/Utility/LLDBAssert.cpp
+++ b/lldb/source/Utility/LLDBAssert.cpp
@@ -54,8 +54,8 @@ void _lldb_assert(bool expression, const char *expr_text, const char *func,
                     expr_text, func, file, line)
           .str(),
       buffer,
-      "Please file a bug report against lldb reporting this failure log, and "
-      "as many details as possible");
+      "Please file a bug report against lldb and include the backtrace, the "
+      "version and as many details as possible.");
 }
 
 void SetLLDBAssertCallback(LLDBAssertCallback callback) {


### PR DESCRIPTION
Include the LLDB version in the lldbassert error message, and prompt users to include it in the bug report. The majority of users that bother filing a bug report just copy past the stack trace and often forget to include this important detail. By putting it after the backtrace and before the prompt, I'm hoping it'll get copy-pasted in.

rdar://146793016