### PR TITLE
[X86] Remove outdated comment

### DIFF
--- a/llvm/lib/Target/X86/X86.td
+++ b/llvm/lib/Target/X86/X86.td
@@ -371,8 +371,7 @@ def FeatureMOVRS   : SubtargetFeature<"movrs", "HasMOVRS", "true",
                            "Enable MOVRS", []>;
 
 // Ivy Bridge and newer processors have enhanced REP MOVSB and STOSB (aka
-// "string operations"). See "REP String Enhancement" in the Intel Software
-// Development Manual. This feature essentially means that REP MOVSB will copy
+// "string operations"). This feature essentially means that REP MOVSB will copy
 // using the largest available size instead of copying bytes one by one, making
 // it at least as fast as REPMOVS{W,D,Q}.
 def FeatureERMSB


### PR DESCRIPTION
A part of the comment is out of date -- the Intel SDM doesn't have a chapter (nor any string) named that way. We could update it, but I believe it's better to simply remove it -- it's hard to maintain, and I feel it's unnecessary.