### PR TITLE
[lldb-dap] Replace GetBreakpointLabel with kDAPBreakpointLabel constant (NFC)

### DIFF
--- a/lldb/tools/lldb-dap/Breakpoint.cpp
+++ b/lldb/tools/lldb-dap/Breakpoint.cpp
@@ -72,9 +72,7 @@ void Breakpoint::CreateJsonObject(llvm::json::Object &object) {
 bool Breakpoint::MatchesName(const char *name) { return bp.MatchesName(name); }
 
 void Breakpoint::SetBreakpoint() {
-  // See comments in BreakpointBase::GetBreakpointLabel() for details of why
-  // we add a label to our breakpoints.
-  bp.AddName(GetBreakpointLabel());
+  bp.AddName(kDAPBreakpointLabel);
   if (!condition.empty())
     SetCondition();
   if (!hitCondition.empty())

--- a/lldb/tools/lldb-dap/BreakpointBase.cpp
+++ b/lldb/tools/lldb-dap/BreakpointBase.cpp
@@ -26,19 +26,3 @@ void BreakpointBase::UpdateBreakpoint(const BreakpointBase &request_bp) {
     SetHitCondition();
   }
 }
-
-const char *BreakpointBase::GetBreakpointLabel() {
-  // Breakpoints in LLDB can have names added to them which are kind of like
-  // labels or categories. All breakpoints that are set through the IDE UI get
-  // sent through the various DAP set*Breakpoint packets, and these
-  // breakpoints will be labeled with this name so if breakpoint update events
-  // come in for breakpoints that the IDE doesn't know about, like if a
-  // breakpoint is set manually using the debugger console, we won't report any
-  // updates on them and confused the IDE. This function gets called by all of
-  // the breakpoint classes after they set breakpoints to mark a breakpoint as
-  // a UI breakpoint. We can later check a lldb::SBBreakpoint object that comes
-  // in via LLDB breakpoint changed events and check the breakpoint by calling
-  // "bool lldb::SBBreakpoint::MatchesName(const char *)" to check if a
-  // breakpoint in one of the UI breakpoints that we should report changes for.
-  return "dap";
-}

--- a/lldb/tools/lldb-dap/BreakpointBase.h
+++ b/lldb/tools/lldb-dap/BreakpointBase.h
@@ -10,6 +10,7 @@
 #define LLDB_TOOLS_LLDB_DAP_BREAKPOINTBASE_H
 
 #include "DAPForward.h"
+#include "llvm/ADT/StringRef.h"
 #include <string>
 
 namespace lldb_dap {
@@ -34,7 +35,20 @@ struct BreakpointBase {
 
   void UpdateBreakpoint(const BreakpointBase &request_bp);
 
-  static const char *GetBreakpointLabel();
+  /// Breakpoints in LLDB can have names added to them which are kind of like
+  /// labels or categories. All breakpoints that are set through DAP get sent
+  /// through the various DAP set*Breakpoint packets, and these breakpoints will
+  /// be labeled with this name so if breakpoint update events come in for
+  /// breakpoints that the client doesn't know about, like if a breakpoint is
+  /// set manually using the debugger console, we won't report any updates on
+  /// them and confused the client. This label gets added by all of the
+  /// breakpoint classes after they set breakpoints to mark a breakpoint as a
+  /// DAP breakpoint. We can later check a lldb::SBBreakpoint object that comes
+  /// in via LLDB breakpoint changed events and check the breakpoint by calling
+  /// "bool lldb::SBBreakpoint::MatchesName(const char *)" to check if a
+  /// breakpoint in one of the DAP breakpoints that we should report changes
+  /// for.
+  static constexpr const char *kDAPBreakpointLabel = "dap";
 };
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/ExceptionBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/ExceptionBreakpoint.cpp
@@ -20,9 +20,7 @@ void ExceptionBreakpoint::SetBreakpoint() {
   bool throw_value = filter.find("_throw") != std::string::npos;
   bp = dap.target.BreakpointCreateForException(language, catch_value,
                                                throw_value);
-  // See comments in BreakpointBase::GetBreakpointLabel() for details of why
-  // we add a label to our breakpoints.
-  bp.AddName(BreakpointBase::GetBreakpointLabel());
+  bp.AddName(BreakpointBase::kDAPBreakpointLabel);
 }
 
 void ExceptionBreakpoint::ClearBreakpoint() {

--- a/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/InitializeRequestHandler.cpp
@@ -197,13 +197,13 @@ static void EventThreadFunction(DAP &dap) {
           auto bp = Breakpoint(
               dap, lldb::SBBreakpoint::GetBreakpointFromEvent(event));
           // If the breakpoint was set through DAP, it will have the
-          // BreakpointBase::GetBreakpointLabel() label. Regardless
-          // of whether  locations were added, removed, or resolved, the
-          // breakpoint isn't going away and the reason is always "changed".
+          // BreakpointBase::kDAPBreakpointLabel. Regardless of whether
+          // locations were added, removed, or resolved, the breakpoint isn't
+          // going away and the reason is always "changed".
           if ((event_type & lldb::eBreakpointEventTypeLocationsAdded ||
                event_type & lldb::eBreakpointEventTypeLocationsRemoved ||
                event_type & lldb::eBreakpointEventTypeLocationsResolved) &&
-              bp.MatchesName(BreakpointBase::GetBreakpointLabel())) {
+              bp.MatchesName(BreakpointBase::kDAPBreakpointLabel)) {
             // As the DAP client already knows the path of this breakpoint, we
             // don't need to send it back as part of the "changed" event. This
             // avoids sending paths that should be source mapped. Note that


### PR DESCRIPTION
Replace GetBreakpointLabel with kDAPBreakpointLabel constant to avoid an unnecessary function call.