### PR TITLE
[C11] Claim conformance to WG14 N1518

### DIFF
--- a/clang/test/C/C11/n1518.c
+++ b/clang/test/C/C11/n1518.c
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -verify=c11 -std=c11 %s
+// RUN: %clang_cc1 -verify=c23 -std=c23 %s
+
+/* WG14 N1518: Clang 15
+ * Recommendations for extended identifier characters for C and C++
+ *
+ * This paper effectively adopts UAX #31, which was later officially adopted
+ * for C23 via WG14 N2836 and supersedes N1518.
+ */
+
+// This file takes test cases from clang/test/C/C23/n2836_n2939.c.
+// This file contains Unicode characters; please do not "fix" them!
+
+// This was fine in C11, is now an error in C23.
+extern int ٢;  // c23-error {{character <U+0662> not allowed at the start of an identifier}} \
+                  c23-warning {{declaration does not declare anything}}
+
+// This was an error in C11 but is an extension in C23.
+extern int ∞;  // c11-error {{unexpected character <U+221E>}} \
+                  c11-warning {{declaration does not declare anything}} \
+                  c23-warning {{mathematical notation character <U+221E> in an identifier is a Clang extension}}

--- a/clang/test/C/C11/n1518.c
+++ b/clang/test/C/C11/n1518.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -verify=c11 -std=c11 %s
-// RUN: %clang_cc1 -verify=c23 -std=c23 %s
+// RUN: %clang_cc1 -verify=c11,both -std=c11 %s
+// RUN: %clang_cc1 -verify=c23,both -std=c23 %s
 
 /* WG14 N1518: Clang 15
  * Recommendations for extended identifier characters for C and C++
@@ -19,3 +19,6 @@ extern int ٢;  // c23-error {{character <U+0662> not allowed at the start of an
 extern int ∞;  // c11-error {{unexpected character <U+221E>}} \
                   c11-warning {{declaration does not declare anything}} \
                   c23-warning {{mathematical notation character <U+221E> in an identifier is a Clang extension}}
+
+int \u1DC0;  // both-error {{expected identifier or '('}}
+int e\u1DC0; // Ok

--- a/clang/www/c_status.html
+++ b/clang/www/c_status.html
@@ -1105,7 +1105,7 @@ conformance.</p>
     <tr>
       <td>Recommendations for extended identifier characters for C and C++</td>
       <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1518.htm">N1518</a></td>
-      <td class="unknown" align="center">Unknown</td>
+      <td class="full" align="center">Clang 15</td>
     </tr>
     <tr>
       <td>Atomic C1x/C++0x compatibility refinements (1st part only)</td>


### PR DESCRIPTION
This paper introduced ranges of valid start and continuation characters for identifiers. C23 made further changes to these sets.