### PR TITLE
[alpha.webkit.NoUnretainedMemberChecker] Ignore system-header-defined ivar / property of a forward declared type

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
@@ -133,6 +133,8 @@ public:
 
   void visitIvarDecl(const ObjCContainerDecl *CD,
                      const ObjCIvarDecl *Ivar) const {
+    if (BR->getSourceManager().isInSystemHeader(Ivar->getLocation()))
+      return;
     auto QT = Ivar->getType();
     const Type *IvarType = QT.getTypePtrOrNull();
     if (!IvarType)
@@ -154,6 +156,8 @@ public:
 
   void visitObjCPropertyDecl(const ObjCContainerDecl *CD,
                              const ObjCPropertyDecl *PD) const {
+    if (BR->getSourceManager().isInSystemHeader(PD->getLocation()))
+      return;
     auto QT = PD->getType();
     const Type *PropType = QT.getTypePtrOrNull();
     if (!PropType)
@@ -241,6 +245,7 @@ public:
                                  BR->getSourceManager());
     auto Report = std::make_unique<BasicBugReport>(Bug, Os.str(), BSLoc);
     Report->addRange(Member->getSourceRange());
+    Report->setDeclWithIssue(ClassCXXRD);
     BR->emitReport(std::move(Report));
   }
 

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefMemberChecker.cpp
@@ -245,7 +245,6 @@ public:
                                  BR->getSourceManager());
     auto Report = std::make_unique<BasicBugReport>(Bug, Os.str(), BSLoc);
     Report->addRange(Member->getSourceRange());
-    Report->setDeclWithIssue(ClassCXXRD);
     BR->emitReport(std::move(Report));
   }
 

--- a/clang/test/Analysis/Checkers/WebKit/unretained-members.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-members.mm
@@ -1,5 +1,7 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.NoUnretainedMemberChecker -verify %s
 
+@class SystemObject;
+
 #include "objc-mock-types.h"
 #include "mock-system-header.h"
 


### PR DESCRIPTION
Prior to this PR, we were emitting warnings for Objective-C ivars and properties if the forward declaration of the type appeared first in a non-system header. This PR fixes the checker so tha we'd ignore ivars and properties defined for a forward declared type.