### PR TITLE
[clang-tidy] Use --match-full-lines instead of --strict-whitespace in check_clang_tidy

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -91,6 +91,12 @@ Improvements to clang-query
 Improvements to clang-tidy
 --------------------------
 
+- Changed the :program:`check_clang_tidy.py` tool to use FileCheck's
+  ``--match-full-lines`` instead of ``strict-whitespace`` for ``CHECK-FIXES``
+  clauses. Added a ``--match-partial-fixes`` option to keep previous behavior on
+  specific tests. This may break tests for users with custom out-of-tree checks
+  who use :program:`check_clang_tidy.py` as-is.
+
 - Improved :program:`clang-tidy-diff.py` script. Add the `-warnings-as-errors`
   argument to treat warnings as errors.
 

--- a/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
+++ b/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
@@ -105,6 +105,7 @@ class CheckRunner:
         self.fixes = MessagePrefix("CHECK-FIXES")
         self.messages = MessagePrefix("CHECK-MESSAGES")
         self.notes = MessagePrefix("CHECK-NOTES")
+        self.match_partial_fixes = args.match_partial_fixes
 
         file_name_with_extension = self.assume_file_name or self.input_file_name
         _, extension = os.path.splitext(file_name_with_extension)
@@ -248,10 +249,14 @@ class CheckRunner:
             try_run(
                 [
                     "FileCheck",
-                    "-input-file=" + self.temp_file_name,
+                    "--input-file=" + self.temp_file_name,
                     self.input_file_name,
-                    "-check-prefixes=" + ",".join(self.fixes.prefixes),
-                    "-strict-whitespace",
+                    "--check-prefixes=" + ",".join(self.fixes.prefixes),
+                    (
+                        "--match-full-lines"
+                        if not self.match_partial_fixes
+                        else "--strict-whitespace"  # Keeping past behavior.
+                    ),
                 ]
             )
 
@@ -371,6 +376,11 @@ def parse_arguments() -> Tuple[argparse.Namespace, List[str]]:
         type=csv,
         default=["c++11-or-later"],
         help="Passed to clang. Special -or-later values are expanded.",
+    )
+    parser.add_argument(
+        "--match-partial-fixes",
+        action="store_true",
+        help="allow partial line matches for fixes",
     )
     return parser.parse_known_args()
 

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-addition.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-addition.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s abseil-duration-addition %t -- -- -I%S/Inputs
+// RUN: %check_clang_tidy --match-partial-fixes %s abseil-duration-addition %t -- -- -I%S/Inputs
 
 #include "absl/time/time.h"
 

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-comparison.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-comparison.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s abseil-duration-comparison %t -- -- -I%S/Inputs
+// RUN: %check_clang_tidy --match-partial-fixes %s abseil-duration-comparison %t -- -- -I%S/Inputs
 
 #include "absl/time/time.h"
 

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-conversion-cast.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-conversion-cast.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s abseil-duration-conversion-cast %t -- -- -I%S/Inputs
+// RUN: %check_clang_tidy --match-partial-fixes %s abseil-duration-conversion-cast %t -- -- -I%S/Inputs
 
 #include "absl/time/time.h"
 

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-factory-float.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-factory-float.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s abseil-duration-factory-float %t -- -- -I%S/Inputs
+// RUN: %check_clang_tidy --match-partial-fixes %s abseil-duration-factory-float %t -- -- -I%S/Inputs
 
 #include "absl/time/time.h"
 

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-factory-scale.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-factory-scale.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s abseil-duration-factory-scale %t -- -- -I%S/Inputs
+// RUN: %check_clang_tidy --match-partial-fixes %s abseil-duration-factory-scale %t -- -- -I%S/Inputs
 
 #include "absl/time/time.h"
 

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-subtraction.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-subtraction.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s abseil-duration-subtraction %t -- -- -I %S/Inputs
+// RUN: %check_clang_tidy --match-partial-fixes %s abseil-duration-subtraction %t -- -- -I %S/Inputs
 
 #include "absl/time/time.h"
 

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-unnecessary-conversion.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/duration-unnecessary-conversion.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c++11-or-later %s abseil-duration-unnecessary-conversion %t -- -- -I %S/Inputs
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++11-or-later %s abseil-duration-unnecessary-conversion %t -- -- -I %S/Inputs
 
 #include "absl/time/time.h"
 

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/redundant-strcat-calls.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/redundant-strcat-calls.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s abseil-redundant-strcat-calls %t -- -- -isystem %clang_tidy_headers
+// RUN: %check_clang_tidy --match-partial-fixes %s abseil-redundant-strcat-calls %t -- -- -isystem %clang_tidy_headers
 #include <string>
 
 namespace absl {

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/time-comparison.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/time-comparison.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s abseil-time-comparison %t -- -- -I%S/Inputs
+// RUN: %check_clang_tidy --match-partial-fixes %s abseil-time-comparison %t -- -- -I%S/Inputs
 
 #include "absl/time/time.h"
 

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/time-subtraction.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/time-subtraction.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c++11-or-later %s abseil-time-subtraction %t -- -- -I %S/Inputs
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++11-or-later %s abseil-time-subtraction %t -- -- -I %S/Inputs
 
 #include "absl/time/time.h"
 

--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/upgrade-duration-conversions.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/upgrade-duration-conversions.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c++11-or-later %s abseil-upgrade-duration-conversions %t -- -- -I%S/Inputs
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++11-or-later %s abseil-upgrade-duration-conversions %t -- -- -I%S/Inputs
 
 using int64_t = long long;
 

--- a/clang-tools-extra/test/clang-tidy/checkers/altera/struct-pack-align.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/altera/struct-pack-align.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s altera-struct-pack-align %t -- -header-filter=.*
+// RUN: %check_clang_tidy --match-partial-fixes %s altera-struct-pack-align %t -- -header-filter=.*
 
 // Struct needs both alignment and packing
 struct error {

--- a/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-memfd-create.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-memfd-create.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s android-cloexec-memfd-create %t
+// RUN: %check_clang_tidy --match-partial-fixes %s android-cloexec-memfd-create %t
 
 #define MFD_ALLOW_SEALING 1
 #define __O_CLOEXEC 3

--- a/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-open.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-open.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s android-cloexec-open %t
+// RUN: %check_clang_tidy --match-partial-fixes %s android-cloexec-open %t
 
 #define O_RDWR 1
 #define O_EXCL 2

--- a/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-socket.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/android/cloexec-socket.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s android-cloexec-socket %t
+// RUN: %check_clang_tidy --match-partial-fixes %s android-cloexec-socket %t
 
 #define SOCK_STREAM 1
 #define SOCK_DGRAM 2

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/incorrect-enable-shared-from-this.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/incorrect-enable-shared-from-this.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c++11-or-later %s bugprone-incorrect-enable-shared-from-this %t
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++11-or-later %s bugprone-incorrect-enable-shared-from-this %t
 
 // NOLINTBEGIN
 namespace std {

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/move-forwarding-reference.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/move-forwarding-reference.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c++14-or-later %s bugprone-move-forwarding-reference %t -- -- -fno-delayed-template-parsing
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++14-or-later %s bugprone-move-forwarding-reference %t -- -- -fno-delayed-template-parsing
 
 namespace std {
 template <typename> struct remove_reference;

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/not-null-terminated-result-in-initialization-strlen.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/not-null-terminated-result-in-initialization-strlen.c
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s bugprone-not-null-terminated-result %t -- \
+// RUN: %check_clang_tidy --match-partial-fixes %s bugprone-not-null-terminated-result %t -- \
 // RUN: -- -std=c11 -I %S/Inputs/not-null-terminated-result
 
 #include "not-null-terminated-result-c.h"

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/not-null-terminated-result-memcpy-safe-cxx.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/not-null-terminated-result-memcpy-safe-cxx.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s bugprone-not-null-terminated-result %t -- \
+// RUN: %check_clang_tidy --match-partial-fixes %s bugprone-not-null-terminated-result %t -- \
 // RUN: -- -std=c++11 -I %S/Inputs/not-null-terminated-result
 
 #include "not-null-terminated-result-cxx.h"

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/not-null-terminated-result-strlen.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/not-null-terminated-result-strlen.c
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s bugprone-not-null-terminated-result %t -- \
+// RUN: %check_clang_tidy --match-partial-fixes %s bugprone-not-null-terminated-result %t -- \
 // RUN: -- -std=c11 -I %S/Inputs/not-null-terminated-result
 
 // FIXME: Something wrong with the APInt un/signed conversion on Windows:

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/not-null-terminated-result-wcslen.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/not-null-terminated-result-wcslen.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s bugprone-not-null-terminated-result %t -- \
+// RUN: %check_clang_tidy --match-partial-fixes %s bugprone-not-null-terminated-result %t -- \
 // RUN: -- -std=c++11 -I %S/Inputs/not-null-terminated-result
 
 // FIXME: Something wrong with the APInt un/signed conversion on Windows:

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/posix-return.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/posix-return.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s bugprone-posix-return %t
+// RUN: %check_clang_tidy --match-partial-fixes %s bugprone-posix-return %t
 
 #define NULL nullptr
 #define ZERO 0

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/standalone-empty.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/standalone-empty.cpp
@@ -176,14 +176,14 @@ bool test_member_empty() {
     std::vector_with_clear<int> v;
     v.empty();
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'empty()'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  v.clear();{{$}}
+    // CHECK-FIXES: v.clear();
   }
 
   {
     std::vector_with_int_empty<int> v;
     v.empty();
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'empty()'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  v.clear();{{$}}
+    // CHECK-FIXES: v.clear();
   }
 
   {
@@ -214,14 +214,14 @@ bool test_member_empty() {
     absl::string_with_clear s;
     s.empty();
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'empty()'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  s.clear();{{$}}
+    // CHECK-FIXES: s.clear();
   }
 
   {
     absl::string_with_int_empty s;
     s.empty();
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'empty()'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  s.clear();{{$}}
+    // CHECK-FIXES: s.clear();
   }
 
   {
@@ -302,11 +302,11 @@ bool test_qualified_empty() {
     absl::string_with_clear v;
     std::empty(v);
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'std::empty'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  v.clear();{{$}}
+    // CHECK-FIXES: v.clear();
 
     absl::empty(v);
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'absl::empty'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  v.clear();{{$}}
+    // CHECK-FIXES: v.clear();
 
     test::empty(v);
     // no-warning
@@ -361,21 +361,21 @@ bool test_unqualified_empty() {
     std::vector_with_void_empty<int> v;
     empty(v);
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'std::empty'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  v.clear();{{$}}
+    // CHECK-FIXES: v.clear();
   }
 
   {
     std::vector_with_clear<int> v;
     empty(v);
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'std::empty'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  v.clear();{{$}}
+    // CHECK-FIXES: v.clear();
   }
 
   {
     std::vector_with_int_empty<int> v;
     empty(v);
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'std::empty'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  v.clear();{{$}}
+    // CHECK-FIXES: v.clear();
   }
 
   {
@@ -400,21 +400,21 @@ bool test_unqualified_empty() {
     absl::string_with_void_empty s;
     empty(s);
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'absl::empty'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  s.clear();{{$}}
+    // CHECK-FIXES: s.clear();
   }
 
   {
     absl::string_with_clear s;
     empty(s);
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'absl::empty'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  s.clear();{{$}}
+    // CHECK-FIXES: s.clear();
   }
 
   {
     absl::string_with_int_empty s;
     empty(s);
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'absl::empty'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  s.clear();{{$}}
+    // CHECK-FIXES: s.clear();
   }
 
   {
@@ -441,7 +441,7 @@ bool test_unqualified_empty() {
     using std::empty;
     empty(v);
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'std::empty'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  v.clear();{{$}}
+    // CHECK-FIXES: v.clear();
   }
 
   {
@@ -456,7 +456,7 @@ bool test_unqualified_empty() {
     using absl::empty;
     empty(s);
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'absl::empty'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  s.clear();{{$}}
+    // CHECK-FIXES: s.clear();
   }
 
   {
@@ -637,14 +637,14 @@ bool test_clear_in_base_class() {
     base::vector<int> v;
     v.empty();
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'empty()'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  v.clear();{{$}}
+    // CHECK-FIXES: v.clear();
   }
 
   {
     base::vector_non_dependent<int> v;
     v.empty();
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'empty()'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  v.clear();{{$}}
+    // CHECK-FIXES: v.clear();
   }
 
   {
@@ -663,14 +663,14 @@ bool test_clear_in_base_class() {
     base::vector<int> v;
     empty(v);
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'base::empty'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  v.clear();{{$}}
+    // CHECK-FIXES: v.clear();
   }
 
   {
     base::vector_non_dependent<int> v;
     empty(v);
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'base::empty'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  v.clear();{{$}}
+    // CHECK-FIXES: v.clear();
   }
 
   {
@@ -775,14 +775,14 @@ bool test_clear_with_qualifiers() {
     qualifiers::vector_with_volatile_clear<int> v;
     v.empty();
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'empty()'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  v.clear();{{$}}
+    // CHECK-FIXES: v.clear();
   }
 
   {
     volatile qualifiers::vector_with_volatile_clear<int> v;
     v.empty();
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'empty()'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  v.clear();{{$}}
+    // CHECK-FIXES: v.clear();
   }
 
   {
@@ -795,14 +795,14 @@ bool test_clear_with_qualifiers() {
     qualifiers::vector_with_volatile_clear<int> v;
     empty(v);
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'qualifiers::empty'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  v.clear();{{$}}
+    // CHECK-FIXES: v.clear();
   }
 
   {
     volatile qualifiers::vector_with_volatile_clear<int> v;
     empty(v);
     // CHECK-MESSAGES: :[[#@LINE-1]]:5: warning: ignoring the result of 'qualifiers::empty'; did you mean 'clear()'? [bugprone-standalone-empty]
-    // CHECK-FIXES: {{^  }}  v.clear();{{$}}
+    // CHECK-FIXES: v.clear();
   }
 
   {

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/stringview-nullptr.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/stringview-nullptr.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s bugprone-stringview-nullptr -std=c++17 %t
+// RUN: %check_clang_tidy --match-partial-fixes %s bugprone-stringview-nullptr -std=c++17 %t
 
 namespace std {
 

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/suspicious-string-compare.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/suspicious-string-compare.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s bugprone-suspicious-string-compare %t -- \
+// RUN: %check_clang_tidy --match-partial-fixes %s bugprone-suspicious-string-compare %t -- \
 // RUN: -config='{CheckOptions: \
 // RUN:  {bugprone-suspicious-string-compare.WarnOnImplicitComparison: true, \
 // RUN:   bugprone-suspicious-string-compare.WarnOnLogicalNotComparison: true}}' \

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/swapped-arguments.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/swapped-arguments.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s bugprone-swapped-arguments %t
+// RUN: %check_clang_tidy --match-partial-fixes %s bugprone-swapped-arguments %t
 
 void F(int, double);
 

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/prefer-member-initializer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/prefer-member-initializer.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cppcoreguidelines-prefer-member-initializer %t -- -- -fcxx-exceptions
+// RUN: %check_clang_tidy --match-partial-fixes %s cppcoreguidelines-prefer-member-initializer %t -- -- -fcxx-exceptions
 
 extern void __assert_fail (__const char *__assertion, __const char *__file,
     unsigned int __line, __const char *__function)

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-bounds-constant-array-index.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-bounds-constant-array-index.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cppcoreguidelines-pro-bounds-constant-array-index %t
+// RUN: %check_clang_tidy --match-partial-fixes %s cppcoreguidelines-pro-bounds-constant-array-index %t
 
 typedef __SIZE_TYPE__ size_t;
 

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-member-init-use-assignment.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-member-init-use-assignment.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cppcoreguidelines-pro-type-member-init %t -- -config="{CheckOptions: {cppcoreguidelines-pro-type-member-init.UseAssignment: true}}" -- -fsigned-char
+// RUN: %check_clang_tidy --match-partial-fixes %s cppcoreguidelines-pro-type-member-init %t -- -config="{CheckOptions: {cppcoreguidelines-pro-type-member-init.UseAssignment: true}}" -- -fsigned-char
 
 struct T {
   int i;

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-member-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/pro-type-member-init.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c++11,c++14,c++17 %s cppcoreguidelines-pro-type-member-init %t -- -- -fno-delayed-template-parsing
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++11,c++14,c++17 %s cppcoreguidelines-pro-type-member-init %t -- -- -fno-delayed-template-parsing
 // FIXME: Fix the checker to work in C++20 mode.
 
 struct PositiveFieldBeforeConstructor {

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/virtual-class-destructor.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/virtual-class-destructor.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cppcoreguidelines-virtual-class-destructor %t -- --fix-notes
+// RUN: %check_clang_tidy --match-partial-fixes %s cppcoreguidelines-virtual-class-destructor %t -- --fix-notes
 
 // CHECK-MESSAGES: :[[@LINE+4]]:8: warning: destructor of 'PrivateVirtualBaseStruct' is private and prevents using the type [cppcoreguidelines-virtual-class-destructor]
 // CHECK-MESSAGES: :[[@LINE+3]]:8: note: make it public and virtual

--- a/clang-tools-extra/test/clang-tidy/checkers/google/build-explicit-make-pair.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/build-explicit-make-pair.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s google-build-explicit-make-pair %t
+// RUN: %check_clang_tidy --match-partial-fixes %s google-build-explicit-make-pair %t
 
 namespace std {
 template <class T1, class T2>

--- a/clang-tools-extra/test/clang-tidy/checkers/google/objc-avoid-nsobject-new.m
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/objc-avoid-nsobject-new.m
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s google-objc-avoid-nsobject-new %t
+// RUN: %check_clang_tidy --match-partial-fixes %s google-objc-avoid-nsobject-new %t
 
 @interface NSObject
 + (instancetype)new;

--- a/clang-tools-extra/test/clang-tidy/checkers/google/upgrade-googletest-case.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/upgrade-googletest-case.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s google-upgrade-googletest-case %t -- -- -I%S/Inputs
+// RUN: %check_clang_tidy --match-partial-fixes %s google-upgrade-googletest-case %t -- -- -I%S/Inputs
 // RUN: %check_clang_tidy -check-suffix=NOSUITE %s google-upgrade-googletest-case %t -- -- -DNOSUITE -I%S/Inputs/gtest/nosuite
 
 #include "gtest/gtest.h"

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/prefer-isa-or-dyn-cast-in-conditionals.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/prefer-isa-or-dyn-cast-in-conditionals.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s llvm-prefer-isa-or-dyn-cast-in-conditionals %t
+// RUN: %check_clang_tidy --match-partial-fixes %s llvm-prefer-isa-or-dyn-cast-in-conditionals %t
 
 struct X;
 struct Y;

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/prefer-register-over-unsigned.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/prefer-register-over-unsigned.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s llvm-prefer-register-over-unsigned %t
+// RUN: %check_clang_tidy --match-partial-fixes %s llvm-prefer-register-over-unsigned %t
 
 namespace llvm {
 class Register {

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/prefer-register-over-unsigned2.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/prefer-register-over-unsigned2.cpp
@@ -14,12 +14,12 @@ using namespace llvm;
 void apply_1() {
   unsigned Reg = getReg();
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: variable 'Reg' declared as 'unsigned int'; use 'Register' instead [llvm-prefer-register-over-unsigned]
-  // CHECK-FIXES: apply_1()
+  // CHECK-FIXES: void apply_1() {
   // CHECK-FIXES-NEXT: Register Reg = getReg();
 }
 
 void done_1() {
   llvm::Register Reg = getReg();
-  // CHECK-FIXES: done_1()
+  // CHECK-FIXES: void done_1() {
   // CHECK-FIXES-NEXT: llvm::Register Reg = getReg();
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/prefer-register-over-unsigned3.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/prefer-register-over-unsigned3.cpp
@@ -12,14 +12,14 @@ Register getReg();
 
 void do_nothing_1() {
   unsigned Reg1 = getReg();
-  // CHECK-FIXES: do_nothing_1()
+  // CHECK-FIXES: void do_nothing_1() {
   // CHECK-FIXES-NEXT: unsigned Reg1 = getReg();
 }
 
 void do_nothing_2() {
   using namespace llvm;
   unsigned Reg2 = getReg();
-  // CHECK-FIXES: do_nothing_2()
+  // CHECK-FIXES: void do_nothing_2() {
   // CHECK-FIXES-NEXT: using namespace llvm;
   // CHECK-FIXES-NEXT: unsigned Reg2 = getReg();
 }
@@ -27,7 +27,7 @@ void do_nothing_2() {
 namespace llvm {
 void do_nothing_3() {
   unsigned Reg3 = getReg();
-  // CHECK-FIXES: do_nothing_3()
+  // CHECK-FIXES: void do_nothing_3() {
   // CHECK-FIXES-NEXT: unsigned Reg3 = getReg();
 }
 } // end namespace llvm

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/twine-local.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/twine-local.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s llvm-twine-local %t
+// RUN: %check_clang_tidy --match-partial-fixes %s llvm-twine-local %t
 
 namespace llvm {
 class Twine {

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-pointer-as-pointers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-pointer-as-pointers.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s misc-const-correctness %t \
+// RUN: %check_clang_tidy --match-partial-fixes %s misc-const-correctness %t \
 // RUN: -config='{CheckOptions: {\
 // RUN:   misc-const-correctness.AnalyzeValues: false,\
 // RUN:   misc-const-correctness.AnalyzeReferences: false,\

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-pointer-as-values.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-pointer-as-values.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s misc-const-correctness %t \
+// RUN: %check_clang_tidy --match-partial-fixes %s misc-const-correctness %t \
 // RUN: -config='{CheckOptions: \
 // RUN:  {misc-const-correctness.AnalyzeValues: true,\
 // RUN:   misc-const-correctness.WarnPointersAsValues: true,\

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-templates.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-templates.cpp
@@ -14,7 +14,7 @@ void type_dependent_variables() {
 
   int value_int = 42;
   // CHECK-MESSAGES:[[@LINE-1]]:3: warning: variable 'value_int' of type 'int' can be declared 'const'
-  // CHECK-FIXES: int const value_int
+  // CHECK-FIXES: int const value_int = 42;
 }
 void instantiate_template_cases() {
   type_dependent_variables<int>();

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-values-before-cxx23.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-values-before-cxx23.cpp
@@ -10,7 +10,7 @@
 double &non_const_ref_return() {
   double p_local0 = 0.0;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: variable 'p_local0' of type 'double' can be declared 'const'
-  // CHECK-FIXES: double const p_local0
+  // CHECK-FIXES: double const p_local0 = 0.0;
   double np_local0 = 42.42;
   return np_local0;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-values.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/const-correctness-values.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s misc-const-correctness %t -- \
+// RUN: %check_clang_tidy --match-partial-fixes %s misc-const-correctness %t -- \
 // RUN:   -config="{CheckOptions: {\
 // RUN:     misc-const-correctness.TransformValues: true, \
 // RUN:     misc-const-correctness.WarnPointersAsValues: false, \

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/definitions-in-headers.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/definitions-in-headers.hpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s misc-definitions-in-headers %t -- --fix-notes
+// RUN: %check_clang_tidy --match-partial-fixes %s misc-definitions-in-headers %t -- --fix-notes
 
 int f() {
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: function 'f' defined in a header file; function definitions in header files can lead to ODR violations [misc-definitions-in-headers]

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters.cpp
@@ -1,6 +1,6 @@
 // RUN: echo "static void staticFunctionHeader(int i) {;}" > %T/header.h
 // RUN: echo "static void staticFunctionHeader(int  /*i*/) {;}" > %T/header-fixed.h
-// RUN: %check_clang_tidy -std=c++11 %s misc-unused-parameters %t -- -header-filter='.*' -- -fno-delayed-template-parsing
+// RUN: %check_clang_tidy  --match-partial-fixes -std=c++11 %s misc-unused-parameters %t -- -header-filter='.*' -- -fno-delayed-template-parsing
 // RUN: diff %T/header.h %T/header-fixed.h
 // FIXME: Make the test work in all language modes.
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/avoid-bind.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/avoid-bind.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c++14-or-later %s modernize-avoid-bind %t
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++14-or-later %s modernize-avoid-bind %t
 
 namespace std {
 inline namespace impl {

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/concat-nested-namespaces.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/concat-nested-namespaces.cpp
@@ -1,9 +1,9 @@
 // RUN: cp %S/Inputs/concat-nested-namespaces/modernize-concat-nested-namespaces.h %T/modernize-concat-nested-namespaces.h
-// RUN: %check_clang_tidy -std=c++17 -check-suffix=NORMAL %s modernize-concat-nested-namespaces %t -- -header-filter=".*" -- -I %T
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++17 -check-suffix=NORMAL %s modernize-concat-nested-namespaces %t -- -header-filter=".*" -- -I %T
 // RUN: FileCheck -input-file=%T/modernize-concat-nested-namespaces.h %S/Inputs/concat-nested-namespaces/modernize-concat-nested-namespaces.h -check-prefix=CHECK-FIXES
 // Restore header file and re-run with c++20:
 // RUN: cp %S/Inputs/concat-nested-namespaces/modernize-concat-nested-namespaces.h %T/modernize-concat-nested-namespaces.h
-// RUN: %check_clang_tidy -std=c++20 -check-suffixes=NORMAL,CPP20 %s modernize-concat-nested-namespaces %t -- -header-filter=".*" -- -I %T
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++20 -check-suffixes=NORMAL,CPP20 %s modernize-concat-nested-namespaces %t -- -header-filter=".*" -- -I %T
 // RUN: FileCheck -input-file=%T/modernize-concat-nested-namespaces.h %S/Inputs/concat-nested-namespaces/modernize-concat-nested-namespaces.h -check-prefix=CHECK-FIXES
 
 #include "modernize-concat-nested-namespaces.h"

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-basic.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-basic.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s modernize-loop-convert %t -- -- -I %S/Inputs/loop-convert
+// RUN: %check_clang_tidy --match-partial-fixes %s modernize-loop-convert %t -- -- -I %S/Inputs/loop-convert
 
 #include "structures.h"
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-camelback.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-camelback.cpp
@@ -13,14 +13,14 @@ void naming() {
     printf("%d\n", arr[i]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead [modernize-loop-convert]
-  // CHECK-FIXES: for (int i : arr)
+  // CHECK-FIXES: for (int i : arr) {
   // CHECK-FIXES-NEXT: printf("%d\n", i);
 
   for (int i = 0; i < n; ++i) {
     printf("%d\n", nums[i]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int num : nums)
+  // CHECK-FIXES: for (int num : nums) {
   // CHECK-FIXES-NEXT: printf("%d\n", num);
 
   int num = 0;
@@ -28,6 +28,6 @@ void naming() {
     printf("%d\n", nums[i] + num);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int i : nums)
+  // CHECK-FIXES: for (int i : nums) {
   // CHECK-FIXES-NEXT: printf("%d\n", i + num);
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-const.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-const.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s modernize-loop-convert %t
+// RUN: %check_clang_tidy --match-partial-fixes %s modernize-loop-convert %t
 
 struct Str {
   Str() = default;

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-extra.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-extra.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s modernize-loop-convert %t -- -- -I %S/Inputs/loop-convert
+// RUN: %check_clang_tidy --match-partial-fixes %s modernize-loop-convert %t -- -- -I %S/Inputs/loop-convert
 
 #include "structures.h"
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-lowercase.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-lowercase.cpp
@@ -14,21 +14,21 @@ void naming() {
     printf("%d\n", arr[i]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead [modernize-loop-convert]
-  // CHECK-FIXES: for (int i : arr)
+  // CHECK-FIXES: for (int i : arr) {
   // CHECK-FIXES-NEXT: printf("%d\n", i);
 
   for (int i = 0; i < n; ++i) {
     printf("%d\n", nums[i]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int num : nums)
+  // CHECK-FIXES: for (int num : nums) {
   // CHECK-FIXES-NEXT: printf("%d\n", num);
 
   for (int i = 0; i < n; ++i) {
     printf("%d\n", nums_[i]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int num : nums_)
+  // CHECK-FIXES: for (int num : nums_) {
   // CHECK-FIXES-NEXT: printf("%d\n", num);
 
   int num = 0;
@@ -36,6 +36,6 @@ void naming() {
     printf("%d\n", nums[i] + num);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int i : nums)
+  // CHECK-FIXES: for (int i : nums) {
   // CHECK-FIXES-NEXT: printf("%d\n", i + num);
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-rewritten-binop.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-rewritten-binop.cpp
@@ -47,7 +47,7 @@ void rewritten() {
     (void)*It;
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & It : Oeo)
+  // CHECK-FIXES: for (int & It : Oeo) {
   // CHECK-FIXES-NEXT: (void)It;
 
   HasSpaceshipMem Hsm;
@@ -55,6 +55,6 @@ void rewritten() {
     (void)*It;
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int & It : Hsm)
+  // CHECK-FIXES: for (int & It : Hsm) {
   // CHECK-FIXES-NEXT: (void)It;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-uppercase.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/loop-convert-uppercase.cpp
@@ -14,21 +14,21 @@ void naming() {
     printf("%d\n", ARR[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead [modernize-loop-convert]
-  // CHECK-FIXES: for (int I : ARR)
+  // CHECK-FIXES: for (int I : ARR) {
   // CHECK-FIXES-NEXT: printf("%d\n", I);
 
   for (int I = 0; I < N; ++I) {
     printf("%d\n", NUMS[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int NUM : NUMS)
+  // CHECK-FIXES: for (int NUM : NUMS) {
   // CHECK-FIXES-NEXT: printf("%d\n", NUM);
 
   for (int I = 0; I < N; ++I) {
     printf("%d\n", NUMS_[I]);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int NUM : NUMS_)
+  // CHECK-FIXES: for (int NUM : NUMS_) {
   // CHECK-FIXES-NEXT: printf("%d\n", NUM);
 
   int NUM = 0;
@@ -36,6 +36,6 @@ void naming() {
     printf("%d\n", NUMS[I] + NUM);
   }
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: use range-based for loop instead
-  // CHECK-FIXES: for (int I : NUMS)
+  // CHECK-FIXES: for (int I : NUMS) {
   // CHECK-FIXES-NEXT: printf("%d\n", I + NUM);
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/make-shared.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/make-shared.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s modernize-make-shared %t -- -- -I %S/Inputs/smart-ptr
+// RUN: %check_clang_tidy --match-partial-fixes %s modernize-make-shared %t -- -- -I %S/Inputs/smart-ptr
 
 #include "shared_ptr.h"
 // CHECK-FIXES: #include <memory>

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/make-unique.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/make-unique.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c++14-or-later %s modernize-make-unique %t -- -- -I %S/Inputs/smart-ptr
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++14-or-later %s modernize-make-unique %t -- -- -I %S/Inputs/smart-ptr
 
 #include "unique_ptr.h"
 #include "initializer_list.h"

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/min-max-use-initializer-list.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/min-max-use-initializer-list.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s modernize-min-max-use-initializer-list %t
+// RUN: %check_clang_tidy --match-partial-fixes %s modernize-min-max-use-initializer-list %t
 
 // CHECK-FIXES: #include <algorithm>
 namespace utils {

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s modernize-pass-by-value %t -- -- -fno-delayed-template-parsing
+// RUN: %check_clang_tidy --match-partial-fixes %s modernize-pass-by-value %t -- -- -fno-delayed-template-parsing
 
 namespace {
 // POD types are trivially move constructible.

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/redundant-void-arg.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/redundant-void-arg.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s modernize-redundant-void-arg %t
+// RUN: %check_clang_tidy --match-partial-fixes %s modernize-redundant-void-arg %t
 
 #define NULL 0
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/replace-auto-ptr.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/replace-auto-ptr.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s modernize-replace-auto-ptr %t -- -- -I %S/Inputs/replace-auto-ptr
+// RUN: %check_clang_tidy --match-partial-fixes %s modernize-replace-auto-ptr %t -- -- -I %S/Inputs/replace-auto-ptr
 
 // CHECK-FIXES: #include <utility>
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/type-traits.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/type-traits.cpp
@@ -37,7 +37,7 @@ namespace ext {
 
 bool NoTemplate = std::is_const<bool>::value;
 // CHECK-MESSAGES-CXX17: :[[@LINE-1]]:19: warning: use c++17 style variable templates
-// CHECK-FIXES-CXX17: bool NoTemplate = std::is_const_v<bool>
+// CHECK-FIXES-CXX17: bool NoTemplate = std::is_const_v<bool>;
 
 template<typename T>
 constexpr bool InTemplate = std::is_const<T>::value;

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-cast-remove-stars.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-cast-remove-stars.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s modernize-use-auto %t -- \
+// RUN: %check_clang_tidy --match-partial-fixes %s modernize-use-auto %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-auto.RemoveStars: 'true' , modernize-use-auto.MinTypeNameLength: '0'}}" \
 // RUN:   -- -frtti
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-cast.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-cast.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s modernize-use-auto %t -- \
+// RUN: %check_clang_tidy --match-partial-fixes %s modernize-use-auto %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-auto.MinTypeNameLength: '0'}}" \
 // RUN:   -- -I %S/Inputs/use-auto -frtti
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-for-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-for-pointer.cpp
@@ -1,6 +1,6 @@
-// RUN: %check_clang_tidy -check-suffix=REMOVE %s modernize-use-auto %t -- \
+// RUN: %check_clang_tidy --match-partial-fixes -check-suffix=REMOVE %s modernize-use-auto %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-auto.RemoveStars: 'true', modernize-use-auto.MinTypeNameLength: '0'}}"
-// RUN: %check_clang_tidy %s modernize-use-auto %t -- \
+// RUN: %check_clang_tidy --match-partial-fixes %s modernize-use-auto %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-auto.RemoveStars: 'false', modernize-use-auto.MinTypeNameLength: '0'}}"
 
 void pointerToFunction() {

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-iterator.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-iterator.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c++11,c++14 %s modernize-use-auto %t -- -- -I %S/Inputs/use-auto
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++11,c++14 %s modernize-use-auto %t -- -- -I %S/Inputs/use-auto
 // FIXME: Fix the checker to work in C++17 mode.
 
 #include "containers.h"

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-min-type-name-length.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-auto-min-type-name-length.cpp
@@ -1,7 +1,7 @@
-// RUN: %check_clang_tidy -check-suffix=0-0 %s modernize-use-auto %t  -- -config="{CheckOptions: {modernize-use-auto.RemoveStars: false, modernize-use-auto.MinTypeNameLength: 0}}" -- -frtti
-// RUN: %check_clang_tidy -check-suffix=0-8 %s modernize-use-auto %t  -- -config="{CheckOptions: {modernize-use-auto.RemoveStars: false, modernize-use-auto.MinTypeNameLength: 8}}" -- -frtti
-// RUN: %check_clang_tidy -check-suffix=1-0 %s modernize-use-auto %t  -- -config="{CheckOptions: {modernize-use-auto.RemoveStars: true, modernize-use-auto.MinTypeNameLength: 0}}" -- -frtti
-// RUN: %check_clang_tidy -check-suffix=1-8 %s modernize-use-auto %t  -- -config="{CheckOptions: {modernize-use-auto.RemoveStars: true, modernize-use-auto.MinTypeNameLength: 8}}" -- -frtti
+// RUN: %check_clang_tidy --match-partial-fixes -check-suffix=0-0 %s modernize-use-auto %t -- -config="{CheckOptions: {modernize-use-auto.RemoveStars: false, modernize-use-auto.MinTypeNameLength: 0}}" -- -frtti
+// RUN: %check_clang_tidy --match-partial-fixes -check-suffix=0-8 %s modernize-use-auto %t -- -config="{CheckOptions: {modernize-use-auto.RemoveStars: false, modernize-use-auto.MinTypeNameLength: 8}}" -- -frtti
+// RUN: %check_clang_tidy --match-partial-fixes -check-suffix=1-0 %s modernize-use-auto %t -- -config="{CheckOptions: {modernize-use-auto.RemoveStars: true, modernize-use-auto.MinTypeNameLength: 0}}" -- -frtti
+// RUN: %check_clang_tidy --match-partial-fixes -check-suffix=1-8 %s modernize-use-auto %t -- -config="{CheckOptions: {modernize-use-auto.RemoveStars: true, modernize-use-auto.MinTypeNameLength: 8}}" -- -frtti
 
 template <class T> extern T foo();
 template <class T> struct P {  explicit P(T t) : t_(t) {}  T t_;};

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-equals-default-copy.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-equals-default-copy.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s modernize-use-equals-default %t -- \
+// RUN: %check_clang_tidy --match-partial-fixes %s modernize-use-equals-default %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-equals-default.IgnoreMacros: false}}" \
 // RUN:   -- -fno-delayed-template-parsing -fexceptions -Wno-error=return-type
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-equals-default.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-equals-default.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s modernize-use-equals-default %t -- -- -fno-delayed-template-parsing -fexceptions
+// RUN: %check_clang_tidy --match-partial-fixes %s modernize-use-equals-default %t -- -- -fno-delayed-template-parsing -fexceptions
 
 // Out of line definition.
 class OL {

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-integer-sign-comparison-qt.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-integer-sign-comparison-qt.cpp
@@ -1,6 +1,7 @@
-// CHECK-FIXES: #include <QtCore/q20utility.h>
-// RUN: %check_clang_tidy -std=c++17 %s modernize-use-integer-sign-comparison %t -- \
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++17 %s modernize-use-integer-sign-comparison %t -- \
 // RUN: -config="{CheckOptions: {modernize-use-integer-sign-comparison.EnableQtSupport: true}}"
+
+// CHECK-FIXES: #include <QtCore/q20utility.h>
 
 // The code that triggers the check
 #define MAX_MACRO(a, b) (a < b) ? b : a

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-integer-sign-comparison.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-integer-sign-comparison.cpp
@@ -1,5 +1,6 @@
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++20 %s modernize-use-integer-sign-comparison %t
+
 // CHECK-FIXES: #include <utility>
-// RUN: %check_clang_tidy -std=c++20 %s modernize-use-integer-sign-comparison %t
 
 // The code that triggers the check
 #define MAX_MACRO(a, b) (a < b) ? b : a

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-nullptr.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-nullptr.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s modernize-use-nullptr %t -- \
+// RUN: %check_clang_tidy --match-partial-fixes %s modernize-use-nullptr %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-nullptr.NullMacros: 'MY_NULL,NULL'}}"
 
 #define NULL 0

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s modernize-use-override,cppcoreguidelines-explicit-virtual-functions %t -- -- -fexceptions
+// RUN: %check_clang_tidy --match-partial-fixes %s modernize-use-override,cppcoreguidelines-explicit-virtual-functions %t -- -- -fexceptions
 
 #define ABSTRACT = 0
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-starts-ends-with.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-starts-ends-with.cpp
@@ -61,7 +61,7 @@ void test(std::string s, std::string_view sv, sub_string ss, sub_sub_string sss,
 
   if (s.find("....") == 0) { /* do something */ }
   // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use starts_with
-  // CHECK-FIXES: if (s.starts_with("...."))
+  // CHECK-FIXES: if (s.starts_with("....")) { /* do something */ }
 
   0 != s.find("a");
   // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use starts_with
@@ -85,7 +85,7 @@ void test(std::string s, std::string_view sv, sub_string ss, sub_sub_string sss,
 
   if (s.rfind("....", 0) == 0) { /* do something */ }
   // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use starts_with
-  // CHECK-FIXES: if (s.starts_with("...."))
+  // CHECK-FIXES: if (s.starts_with("....")) { /* do something */ }
 
   0 != s.rfind("a", 0);
   // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use starts_with
@@ -94,17 +94,17 @@ void test(std::string s, std::string_view sv, sub_string ss, sub_sub_string sss,
   #define FIND find
   s.FIND("a") == 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use starts_with
-  // CHECK-FIXES: s.starts_with("a")
+  // CHECK-FIXES: s.starts_with("a");
 
   #define PREFIX "a"
   s.find(PREFIX) == 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use starts_with
-  // CHECK-FIXES: s.starts_with(PREFIX)
+  // CHECK-FIXES: s.starts_with(PREFIX);
 
   #define ZERO 0
   s.find("a") == ZERO;
   // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use starts_with
-  // CHECK-FIXES: s.starts_with("a")
+  // CHECK-FIXES: s.starts_with("a");
 
   sv.find("a") == 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use starts_with
@@ -120,7 +120,7 @@ void test(std::string s, std::string_view sv, sub_string ss, sub_sub_string sss,
 
   sss.find("a") == 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use starts_with
-  // CHECK-FIXES: ss.starts_with("a");
+  // CHECK-FIXES: sss.starts_with("a");
 
   sl.find("a") == 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use starts_with
@@ -172,7 +172,7 @@ void test(std::string s, std::string_view sv, sub_string ss, sub_sub_string sss,
 
   0 != s.compare(0, sv.length(), sv);
   // CHECK-MESSAGES: :[[@LINE-1]]:{{[0-9]+}}: warning: use starts_with
-  // CHECK-FIXES: s.starts_with(sv);
+  // CHECK-FIXES: !s.starts_with(sv);
 
   #define LENGTH(x) (x).length()
   s.compare(0, LENGTH(s), s) == 0;

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-format-fmt.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-format-fmt.cpp
@@ -20,5 +20,5 @@ std::basic_string<Char> sprintf(const S& fmt, const T&... args);
 std::string fmt_sprintf_simple() {
   return fmt::sprintf("Hello %s %d", "world", 42);
   // CHECK-MESSAGES: [[@LINE-1]]:10: warning: use 'fmt::format' instead of 'sprintf' [modernize-use-std-format]
-  // CHECK-FIXES: fmt::format("Hello {} {}", "world", 42);
+  // CHECK-FIXES: return fmt::format("Hello {} {}", "world", 42);
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-format.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-format.cpp
@@ -1,10 +1,10 @@
-// RUN: %check_clang_tidy \
+// RUN: %check_clang_tidy --match-partial-fixes \
 // RUN:   -std=c++20 %s modernize-use-std-format %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-std-format.StrictMode: true}}" \
 // RUN:   -- -isystem %clang_tidy_headers \
 // RUN:      -DPRI_CMDLINE_MACRO="\"s\"" \
 // RUN:      -D__PRI_CMDLINE_MACRO="\"s\""
-// RUN: %check_clang_tidy \
+// RUN: %check_clang_tidy --match-partial-fixes \
 // RUN:   -std=c++20 %s modernize-use-std-format %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-std-format.StrictMode: false}}" \
 // RUN:   -- -isystem %clang_tidy_headers \

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-print.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-std-print.cpp
@@ -1,10 +1,10 @@
-// RUN: %check_clang_tidy -check-suffixes=,STRICT \
+// RUN: %check_clang_tidy --match-partial-fixes -check-suffixes=,STRICT \
 // RUN:   -std=c++23 %s modernize-use-std-print %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-std-print.StrictMode: true}}" \
 // RUN:   -- -isystem %clang_tidy_headers -fexceptions \
 // RUN:      -DPRI_CMDLINE_MACRO="\"s\"" \
 // RUN:      -D__PRI_CMDLINE_MACRO="\"s\""
-// RUN: %check_clang_tidy -check-suffixes=,NOTSTRICT \
+// RUN: %check_clang_tidy --match-partial-fixes -check-suffixes=,NOTSTRICT \
 // RUN:   -std=c++23 %s modernize-use-std-print %t -- \
 // RUN:   -config="{CheckOptions: {modernize-use-std-print.StrictMode: false}}" \
 // RUN:   -- -isystem %clang_tidy_headers -fexceptions \

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s modernize-use-using %t -- -- -fno-delayed-template-parsing -I %S/Inputs/use-using/
+// RUN: %check_clang_tidy --match-partial-fixes %s modernize-use-using %t -- -- -fno-delayed-template-parsing -I %S/Inputs/use-using/
 
 typedef int Type;
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use 'using' instead of 'typedef' [modernize-use-using]

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/faster-string-find.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/faster-string-find.cpp
@@ -92,11 +92,11 @@ void StringFind() {
   std::wstring WStr;
   WStr.find(L"n");
   // CHECK-MESSAGES: [[@LINE-1]]:13: warning: 'find' called with a string literal
-  // CHECK-FIXES: Str.find(L'n');
+  // CHECK-FIXES: WStr.find(L'n');
   // Even with unicode that fits in one wide char.
   WStr.find(L"\x3A9");
   // CHECK-MESSAGES: [[@LINE-1]]:13: warning: 'find' called with a string literal
-  // CHECK-FIXES: Str.find(L'\x3A9');
+  // CHECK-FIXES: WStr.find(L'\x3A9');
 
   // std::string_view and std::wstring_view should work.
   std::string_view StrView;

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/for-range-copy.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/for-range-copy.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s performance-for-range-copy %t -- -- -fno-delayed-template-parsing
+// RUN: %check_clang_tidy --match-partial-fixes %s performance-for-range-copy %t -- -- -fno-delayed-template-parsing
 
 namespace std {
 

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/noexcept-move-constructor-fix.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/noexcept-move-constructor-fix.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s performance-noexcept-move-constructor %t -- -- -fexceptions
+// RUN: %check_clang_tidy --match-partial-fixes %s performance-noexcept-move-constructor %t -- -- -fexceptions
 
 struct C_1 {
  ~C_1() {}

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-copy-initialization.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-copy-initialization.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c++17-or-later %s performance-unnecessary-copy-initialization %t
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++17-or-later %s performance-unnecessary-copy-initialization %t
 
 template <typename T>
 struct Iterator {

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-delayed.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param-delayed.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s performance-unnecessary-value-param %t -- -- -fdelayed-template-parsing
+// RUN: %check_clang_tidy --match-partial-fixes %s performance-unnecessary-value-param %t -- -- -fdelayed-template-parsing
 
 struct ExpensiveToCopyType {
   const ExpensiveToCopyType & constReference() const {

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s performance-unnecessary-value-param %t -- -- -fno-delayed-template-parsing
+// RUN: %check_clang_tidy --match-partial-fixes %s performance-unnecessary-value-param %t -- -- -fno-delayed-template-parsing
 
 // CHECK-FIXES: #include <utility>
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/braces-around-statements.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/braces-around-statements.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s readability-braces-around-statements %t
+// RUN: %check_clang_tidy --match-partial-fixes %s readability-braces-around-statements %t
 
 void do_something(const char *) {}
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/const-return-type.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/const-return-type.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c++14-or-later %s readability-const-return-type %t -- -- -Wno-error=return-type
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++14-or-later %s readability-const-return-type %t -- -- -Wno-error=return-type
 
 //  p# = positive test
 //  n# = negative test

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/container-size-empty.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/container-size-empty.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c++14-or-later %s readability-container-size-empty %t -- \
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++14-or-later %s readability-container-size-empty %t -- \
 // RUN: -config="{CheckOptions: {readability-container-size-empty.ExcludedComparisonTypes: '::std::array;::IgnoredDummyType'}}" \
 // RUN: -- -fno-delayed-template-parsing -isystem %clang_tidy_headers
 #include <string>

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.c
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s readability-implicit-bool-conversion %t -- -- -std=c23
+// RUN: %check_clang_tidy --match-partial-fixes %s readability-implicit-bool-conversion %t -- -- -std=c23
 // RUN: %check_clang_tidy -check-suffix=UPPER-CASE %s readability-implicit-bool-conversion %t -- \
 // RUN:     -config='{CheckOptions: { \
 // RUN:         readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix: true \

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/implicit-bool-conversion.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s readability-implicit-bool-conversion %t
+// RUN: %check_clang_tidy --match-partial-fixes %s readability-implicit-bool-conversion %t
 // RUN: %check_clang_tidy -check-suffix=UPPER-CASE %s readability-implicit-bool-conversion %t -- \
 // RUN:     -config='{CheckOptions: { \
 // RUN:         readability-implicit-bool-conversion.UseUpperCaseLiteralSuffix: true \

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/math-missing-parentheses.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/math-missing-parentheses.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s readability-math-missing-parentheses %t
+// RUN: %check_clang_tidy --match-partial-fixes %s readability-math-missing-parentheses %t
 
 #define MACRO_AND &
 #define MACRO_ADD +

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-members.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr-members.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s readability-simplify-boolean-expr %t
+// RUN: %check_clang_tidy --match-partial-fixes %s readability-simplify-boolean-expr %t
 
 class A {
 public:

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/simplify-boolean-expr.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s readability-simplify-boolean-expr %t
+// RUN: %check_clang_tidy --match-partial-fixes %s readability-simplify-boolean-expr %t
 
 bool a1 = false;
 

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/uppercase-literal-suffix-integer-custom-list.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/uppercase-literal-suffix-integer-custom-list.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s readability-uppercase-literal-suffix %t -- -config="{CheckOptions: {readability-uppercase-literal-suffix.NewSuffixes: 'L;uL'}}" -- -I %clang_tidy_headers
+// RUN: %check_clang_tidy --match-partial-fixes %s readability-uppercase-literal-suffix %t -- -config="{CheckOptions: {readability-uppercase-literal-suffix.NewSuffixes: 'L;uL'}}" -- -I %clang_tidy_headers
 // RUN: grep -Ev "// *[A-Z-]+:" %s > %t.cpp
 // RUN: clang-tidy %t.cpp -checks='-*,readability-uppercase-literal-suffix' -fix -config="{CheckOptions: {readability-uppercase-literal-suffix.NewSuffixes: 'L;uL'}}" -- -I %clang_tidy_headers
 // RUN: clang-tidy %t.cpp -checks='-*,readability-uppercase-literal-suffix' -warnings-as-errors='-*,readability-uppercase-literal-suffix' -config="{CheckOptions: {readability-uppercase-literal-suffix.NewSuffixes: 'L;uL'}}" -- -I %clang_tidy_headers

--- a/clang-tools-extra/test/clang-tidy/infrastructure/duplicate-conflicted-fixes-of-alias-checkers.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/duplicate-conflicted-fixes-of-alias-checkers.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cppcoreguidelines-pro-type-member-init,hicpp-member-init,modernize-use-emplace,hicpp-use-emplace %t -- \
+// RUN: %check_clang_tidy --match-partial-fixes %s cppcoreguidelines-pro-type-member-init,hicpp-member-init,modernize-use-emplace,hicpp-use-emplace %t -- \
 //// RUN:     -config='{CheckOptions: { \
 //// RUN:         cppcoreguidelines-pro-type-member-init.UseAssignment: true, \
 //// RUN:     }}'

--- a/clang-tools-extra/test/clang-tidy/infrastructure/duplicate-fixes-of-alias-checkers.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/duplicate-fixes-of-alias-checkers.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cppcoreguidelines-pro-type-member-init,hicpp-member-init,modernize-use-emplace,hicpp-use-emplace %t
+// RUN: %check_clang_tidy --match-partial-fixes %s cppcoreguidelines-pro-type-member-init,hicpp-member-init,modernize-use-emplace,hicpp-use-emplace %t
 
 namespace std {
 


### PR DESCRIPTION

See Discourse post here:
https://discourse.llvm.org/t/rfc-using-match-full-lines-in-clang-tidy-tests/85553

I've added `--match-partial-fixes` to all tests that were failing, unless I noticed the fix was quick and trivial. I'll do a second pass after this lands to update more tests.
