### PR TITLE
Fix printing of  `mlirUniformQuantizedSubChannelTypeGetNumBlockSizes` in 32-bit machine.

### DIFF
--- a/mlir/test/CAPI/quant.c
+++ b/mlir/test/CAPI/quant.c
@@ -268,7 +268,7 @@ void testUniformSubChannelType(MlirContext ctx) {
           mlirTypeIsNull(illegalSubChannel));
 
   // CHECK: num dims: 2
-  fprintf(stderr, "num dims: %" PRId64 "\n",
+  fprintf(stderr, "num dims: %" PRIdPTR "\n",
           mlirUniformQuantizedSubChannelTypeGetNumBlockSizes(subChannel));
 
   // CHECK: axis-block-size-pair[0]: 0:1


### PR DESCRIPTION
Fixes the issue reported in https://github.com/llvm/llvm-project/pull/120172#issuecomment-2763212827

cc @mgorny 