### PR TITLE
[NFC][SPIRV] Misc code cleanup in SPIRV Target

### DIFF
--- a/llvm/lib/Target/SPIRV/Analysis/SPIRVConvergenceRegionAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/Analysis/SPIRVConvergenceRegionAnalysis.cpp
@@ -1,4 +1,4 @@
-//===- ConvergenceRegionAnalysis.h -----------------------------*- C++ -*--===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -24,6 +24,7 @@
 #define DEBUG_TYPE "spirv-convergence-region-analysis"
 
 using namespace llvm;
+using namespace SPIRV;
 
 namespace llvm {
 void initializeSPIRVConvergenceRegionAnalysisWrapperPassPass(PassRegistry &);
@@ -39,8 +40,6 @@ INITIALIZE_PASS_END(SPIRVConvergenceRegionAnalysisWrapperPass,
                     "convergence-region", "SPIRV convergence regions analysis",
                     true, true)
 
-namespace llvm {
-namespace SPIRV {
 namespace {
 
 template <typename BasicBlockType, typename IntrinsicInstType>
@@ -74,12 +73,13 @@ getConvergenceTokenInternal(BasicBlockType *BB) {
 
   return std::nullopt;
 }
+} // anonymous namespace
 
 // Given a ConvergenceRegion tree with |Start| as its root, finds the smallest
 // region |Entry| belongs to. If |Entry| does not belong to the region defined
 // by |Start|, this function returns |nullptr|.
-ConvergenceRegion *findParentRegion(ConvergenceRegion *Start,
-                                    BasicBlock *Entry) {
+static ConvergenceRegion *findParentRegion(ConvergenceRegion *Start,
+                                           BasicBlock *Entry) {
   ConvergenceRegion *Candidate = nullptr;
   ConvergenceRegion *NextCandidate = Start;
 
@@ -102,13 +102,13 @@ ConvergenceRegion *findParentRegion(ConvergenceRegion *Start,
   return Candidate;
 }
 
-} // anonymous namespace
-
-std::optional<IntrinsicInst *> getConvergenceToken(BasicBlock *BB) {
+std::optional<IntrinsicInst *>
+llvm::SPIRV::getConvergenceToken(BasicBlock *BB) {
   return getConvergenceTokenInternal<BasicBlock, IntrinsicInst>(BB);
 }
 
-std::optional<const IntrinsicInst *> getConvergenceToken(const BasicBlock *BB) {
+std::optional<const IntrinsicInst *>
+llvm::SPIRV::getConvergenceToken(const BasicBlock *BB) {
   return getConvergenceTokenInternal<const BasicBlock, const IntrinsicInst>(BB);
 }
 
@@ -187,8 +187,8 @@ void ConvergenceRegion::dump(const unsigned IndentSize) const {
   dbgs() << Indent << "}\n";
 }
 
+namespace {
 class ConvergenceRegionAnalyzer {
-
 public:
   ConvergenceRegionAnalyzer(Function &F, DominatorTree &DT, LoopInfo &LI)
       : DT(DT), LI(LI), F(F) {}
@@ -305,14 +305,14 @@ private:
   LoopInfo &LI;
   Function &F;
 };
+} // anonymous namespace
 
-ConvergenceRegionInfo getConvergenceRegions(Function &F, DominatorTree &DT,
-                                            LoopInfo &LI) {
+ConvergenceRegionInfo llvm::SPIRV::getConvergenceRegions(Function &F,
+                                                         DominatorTree &DT,
+                                                         LoopInfo &LI) {
   ConvergenceRegionAnalyzer Analyzer(F, DT, LI);
   return Analyzer.analyze();
 }
-
-} // namespace SPIRV
 
 char SPIRVConvergenceRegionAnalysisWrapperPass::ID = 0;
 
@@ -339,5 +339,3 @@ SPIRVConvergenceRegionAnalysis::run(Function &F, FunctionAnalysisManager &AM) {
 }
 
 AnalysisKey SPIRVConvergenceRegionAnalysis::Key;
-
-} // namespace llvm

--- a/llvm/lib/Target/SPIRV/Analysis/SPIRVConvergenceRegionAnalysis.h
+++ b/llvm/lib/Target/SPIRV/Analysis/SPIRVConvergenceRegionAnalysis.h
@@ -19,12 +19,11 @@
 #include "llvm/Analysis/CFG.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/IR/Dominators.h"
-#include "llvm/IR/IntrinsicInst.h"
-#include <iostream>
 #include <optional>
 #include <unordered_set>
 
 namespace llvm {
+class IntrinsicInst;
 class SPIRVSubtarget;
 class MachineFunction;
 class MachineModuleInfo;

--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -3048,7 +3048,7 @@ static SPIRVType *getInlineSpirvType(const TargetExtType *ExtensionType,
   auto Opcode = ExtensionType->getIntParameter(0);
 
   SmallVector<MCOperand> Operands;
-  for (llvm::Type *Param : ExtensionType->type_params()) {
+  for (Type *Param : ExtensionType->type_params()) {
     if (const TargetExtType *ParamEType = dyn_cast<TargetExtType>(Param)) {
       if (ParamEType->getName() == "spirv.IntegralConstant") {
         assert(ParamEType->getNumTypeParameters() == 1 &&

--- a/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
@@ -94,10 +94,10 @@ static const std::map<std::string, SPIRV::Extension::Extension, std::less<>>
         {"SPV_INTEL_fp_max_error",
          SPIRV::Extension::Extension::SPV_INTEL_fp_max_error}};
 
-bool SPIRVExtensionsParser::parse(cl::Option &O, llvm::StringRef ArgName,
-                                  llvm::StringRef ArgValue,
+bool SPIRVExtensionsParser::parse(cl::Option &O, StringRef ArgName,
+                                  StringRef ArgValue,
                                   std::set<SPIRV::Extension::Extension> &Vals) {
-  llvm::SmallVector<llvm::StringRef, 10> Tokens;
+  SmallVector<StringRef, 10> Tokens;
   ArgValue.split(Tokens, ",", -1, false);
   std::sort(Tokens.begin(), Tokens.end());
 
@@ -114,7 +114,7 @@ bool SPIRVExtensionsParser::parse(cl::Option &O, llvm::StringRef ArgName,
     if (Token.empty() || (!Token.starts_with("+") && !Token.starts_with("-")))
       return O.error("Invalid extension list format: " + Token.str());
 
-    llvm::StringRef ExtensionName = Token.substr(1);
+    StringRef ExtensionName = Token.substr(1);
     auto NameValuePair = SPIRVExtensionMap.find(ExtensionName);
 
     if (NameValuePair == SPIRVExtensionMap.end())
@@ -137,7 +137,7 @@ bool SPIRVExtensionsParser::parse(cl::Option &O, llvm::StringRef ArgName,
   return false;
 }
 
-llvm::StringRef SPIRVExtensionsParser::checkExtensions(
+StringRef SPIRVExtensionsParser::checkExtensions(
     const std::vector<std::string> &ExtNames,
     std::set<SPIRV::Extension::Extension> &AllowedExtensions) {
   for (const auto &Ext : ExtNames) {

--- a/llvm/lib/Target/SPIRV/SPIRVCommandLine.h
+++ b/llvm/lib/Target/SPIRV/SPIRVCommandLine.h
@@ -39,7 +39,7 @@ public:
   ///
   /// \return Returns a reference to the unknown SPIR-V extension name from the
   /// list if present, or an empty StringRef on success.
-  static llvm::StringRef
+  static StringRef
   checkExtensions(const std::vector<std::string> &ExtNames,
                   std::set<SPIRV::Extension::Extension> &AllowedExtensions);
 };

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -293,8 +293,7 @@ static void setInsertPointAfterDef(IRBuilder<> &B, Instruction *I) {
 }
 
 static bool requireAssignType(Instruction *I) {
-  IntrinsicInst *Intr = dyn_cast<IntrinsicInst>(I);
-  if (Intr) {
+  if (const auto *Intr = dyn_cast<IntrinsicInst>(I)) {
     switch (Intr->getIntrinsicID()) {
     case Intrinsic::invariant_start:
     case Intrinsic::invariant_end:
@@ -725,7 +724,7 @@ Type *SPIRVEmitIntrinsics::deduceNestedTypeHelper(
   if (!Visited.insert(U).second)
     return OrigTy;
 
-  if (dyn_cast<StructType>(OrigTy)) {
+  if (isa<StructType>(OrigTy)) {
     SmallVector<Type *> Tys;
     bool Change = false;
     for (unsigned i = 0; i < U->getNumOperands(); ++i) {

--- a/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitNonSemanticDI.cpp
@@ -27,7 +27,9 @@
 
 #define DEBUG_TYPE "spirv-nonsemantic-debug-info"
 
-namespace llvm {
+using namespace llvm;
+
+namespace {
 struct SPIRVEmitNonSemanticDI : public MachineFunctionPass {
   static char ID;
   SPIRVTargetMachine *TM;
@@ -40,9 +42,7 @@ private:
   bool IsGlobalDIEmitted = false;
   bool emitGlobalDI(MachineFunction &MF);
 };
-} // namespace llvm
-
-using namespace llvm;
+} // anonymous namespace
 
 INITIALIZE_PASS(SPIRVEmitNonSemanticDI, DEBUG_TYPE,
                 "SPIRV NonSemantic.Shader.DebugInfo.100 emitter", false, false)

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -32,13 +32,10 @@
 
 using namespace llvm;
 
-namespace {
-
-bool allowEmitFakeUse(const Value *Arg) {
+static bool allowEmitFakeUse(const Value *Arg) {
   if (isSpvIntrinsic(Arg))
     return false;
-  if (dyn_cast<AtomicCmpXchgInst>(Arg) || dyn_cast<InsertValueInst>(Arg) ||
-      dyn_cast<UndefValue>(Arg))
+  if (isa<AtomicCmpXchgInst, InsertValueInst, UndefValue>(Arg))
     return false;
   if (const auto *LI = dyn_cast<LoadInst>(Arg))
     if (LI->getType()->isAggregateType())
@@ -46,7 +43,7 @@ bool allowEmitFakeUse(const Value *Arg) {
   return true;
 }
 
-inline unsigned typeToAddressSpace(const Type *Ty) {
+static unsigned typeToAddressSpace(const Type *Ty) {
   if (auto PType = dyn_cast<TypedPointerType>(Ty))
     return PType->getAddressSpace();
   if (auto PType = dyn_cast<PointerType>(Ty))
@@ -56,8 +53,6 @@ inline unsigned typeToAddressSpace(const Type *Ty) {
     return ExtTy->getIntParameter(0);
   report_fatal_error("Unable to convert LLVM type to SPIRVType", true);
 }
-
-} // anonymous namespace
 
 SPIRVGlobalRegistry::SPIRVGlobalRegistry(unsigned PointerSize)
     : PointerSize(PointerSize), Bound(0) {}

--- a/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVStructurizer.cpp
@@ -38,27 +38,21 @@
 using namespace llvm;
 using namespace SPIRV;
 
-namespace llvm {
-
-void initializeSPIRVStructurizerPass(PassRegistry &);
-
-namespace {
-
 using BlockSet = std::unordered_set<BasicBlock *>;
 using Edge = std::pair<BasicBlock *, BasicBlock *>;
 
 // Helper function to do a partial order visit from the block |Start|, calling
 // |Op| on each visited node.
-void partialOrderVisit(BasicBlock &Start,
-                       std::function<bool(BasicBlock *)> Op) {
+static void partialOrderVisit(BasicBlock &Start,
+                              std::function<bool(BasicBlock *)> Op) {
   PartialOrderingVisitor V(*Start.getParent());
   V.partialOrderVisit(Start, Op);
 }
 
 // Returns the exact convergence region in the tree defined by `Node` for which
 // `BB` is the header, nullptr otherwise.
-const ConvergenceRegion *getRegionForHeader(const ConvergenceRegion *Node,
-                                            BasicBlock *BB) {
+static const ConvergenceRegion *
+getRegionForHeader(const ConvergenceRegion *Node, BasicBlock *BB) {
   if (Node->Entry == BB)
     return Node;
 
@@ -72,7 +66,7 @@ const ConvergenceRegion *getRegionForHeader(const ConvergenceRegion *Node,
 
 // Returns the single BasicBlock exiting the convergence region `CR`,
 // nullptr if no such exit exists.
-BasicBlock *getExitFor(const ConvergenceRegion *CR) {
+static BasicBlock *getExitFor(const ConvergenceRegion *CR) {
   std::unordered_set<BasicBlock *> ExitTargets;
   for (BasicBlock *Exit : CR->Exits) {
     for (BasicBlock *Successor : successors(Exit)) {
@@ -90,7 +84,7 @@ BasicBlock *getExitFor(const ConvergenceRegion *CR) {
 
 // Returns the merge block designated by I if I is a merge instruction, nullptr
 // otherwise.
-BasicBlock *getDesignatedMergeBlock(Instruction *I) {
+static BasicBlock *getDesignatedMergeBlock(Instruction *I) {
   IntrinsicInst *II = dyn_cast_or_null<IntrinsicInst>(I);
   if (II == nullptr)
     return nullptr;
@@ -105,7 +99,7 @@ BasicBlock *getDesignatedMergeBlock(Instruction *I) {
 
 // Returns the continue block designated by I if I is an OpLoopMerge, nullptr
 // otherwise.
-BasicBlock *getDesignatedContinueBlock(Instruction *I) {
+static BasicBlock *getDesignatedContinueBlock(Instruction *I) {
   IntrinsicInst *II = dyn_cast_or_null<IntrinsicInst>(I);
   if (II == nullptr)
     return nullptr;
@@ -119,7 +113,7 @@ BasicBlock *getDesignatedContinueBlock(Instruction *I) {
 
 // Returns true if Header has one merge instruction which designated Merge as
 // merge block.
-bool isDefinedAsSelectionMergeBy(BasicBlock &Header, BasicBlock &Merge) {
+static bool isDefinedAsSelectionMergeBy(BasicBlock &Header, BasicBlock &Merge) {
   for (auto &I : Header) {
     BasicBlock *MB = getDesignatedMergeBlock(&I);
     if (MB == &Merge)
@@ -129,7 +123,7 @@ bool isDefinedAsSelectionMergeBy(BasicBlock &Header, BasicBlock &Merge) {
 }
 
 // Returns true if the BB has one OpLoopMerge instruction.
-bool hasLoopMergeInstruction(BasicBlock &BB) {
+static bool hasLoopMergeInstruction(BasicBlock &BB) {
   for (auto &I : BB)
     if (getDesignatedContinueBlock(&I))
       return true;
@@ -138,13 +132,13 @@ bool hasLoopMergeInstruction(BasicBlock &BB) {
 
 // Returns true is I is an OpSelectionMerge or OpLoopMerge instruction, false
 // otherwise.
-bool isMergeInstruction(Instruction *I) {
+static bool isMergeInstruction(Instruction *I) {
   return getDesignatedMergeBlock(I) != nullptr;
 }
 
 // Returns all blocks in F having at least one OpLoopMerge or OpSelectionMerge
 // instruction.
-SmallPtrSet<BasicBlock *, 2> getHeaderBlocks(Function &F) {
+static SmallPtrSet<BasicBlock *, 2> getHeaderBlocks(Function &F) {
   SmallPtrSet<BasicBlock *, 2> Output;
   for (BasicBlock &BB : F) {
     for (Instruction &I : BB) {
@@ -157,7 +151,7 @@ SmallPtrSet<BasicBlock *, 2> getHeaderBlocks(Function &F) {
 
 // Returns all basic blocks in |F| referenced by at least 1
 // OpSelectionMerge/OpLoopMerge instruction.
-SmallPtrSet<BasicBlock *, 2> getMergeBlocks(Function &F) {
+static SmallPtrSet<BasicBlock *, 2> getMergeBlocks(Function &F) {
   SmallPtrSet<BasicBlock *, 2> Output;
   for (BasicBlock &BB : F) {
     for (Instruction &I : BB) {
@@ -172,7 +166,7 @@ SmallPtrSet<BasicBlock *, 2> getMergeBlocks(Function &F) {
 // Return all the merge instructions contained in BB.
 // Note: the SPIR-V spec doesn't allow a single BB to contain more than 1 merge
 // instruction, but this can happen while we structurize the CFG.
-std::vector<Instruction *> getMergeInstructions(BasicBlock &BB) {
+static std::vector<Instruction *> getMergeInstructions(BasicBlock &BB) {
   std::vector<Instruction *> Output;
   for (Instruction &I : BB)
     if (isMergeInstruction(&I))
@@ -182,7 +176,7 @@ std::vector<Instruction *> getMergeInstructions(BasicBlock &BB) {
 
 // Returns all basic blocks in |F| referenced as continue target by at least 1
 // OpLoopMerge instruction.
-SmallPtrSet<BasicBlock *, 2> getContinueBlocks(Function &F) {
+static SmallPtrSet<BasicBlock *, 2> getContinueBlocks(Function &F) {
   SmallPtrSet<BasicBlock *, 2> Output;
   for (BasicBlock &BB : F) {
     for (Instruction &I : BB) {
@@ -196,7 +190,7 @@ SmallPtrSet<BasicBlock *, 2> getContinueBlocks(Function &F) {
 
 // Do a preorder traversal of the CFG starting from the BB |Start|.
 // point. Calls |op| on each basic block encountered during the traversal.
-void visit(BasicBlock &Start, std::function<bool(BasicBlock *)> op) {
+static void visit(BasicBlock &Start, std::function<bool(BasicBlock *)> op) {
   std::stack<BasicBlock *> ToVisit;
   SmallPtrSet<BasicBlock *, 8> Seen;
 
@@ -221,8 +215,8 @@ void visit(BasicBlock &Start, std::function<bool(BasicBlock *)> op) {
 // Replaces the conditional and unconditional branch targets of |BB| by
 // |NewTarget| if the target was |OldTarget|. This function also makes sure the
 // associated merge instruction gets updated accordingly.
-void replaceIfBranchTargets(BasicBlock *BB, BasicBlock *OldTarget,
-                            BasicBlock *NewTarget) {
+static void replaceIfBranchTargets(BasicBlock *BB, BasicBlock *OldTarget,
+                                   BasicBlock *NewTarget) {
   auto *BI = cast<BranchInst>(BB->getTerminator());
 
   // 1. Replace all matching successors.
@@ -268,8 +262,8 @@ void replaceIfBranchTargets(BasicBlock *BB, BasicBlock *OldTarget,
 // was |OldTarget|. This function also fixes the associated merge instruction.
 // Note: this function does not simplify branching instructions, it only updates
 // targets. See also: simplifyBranches.
-void replaceBranchTargets(BasicBlock *BB, BasicBlock *OldTarget,
-                          BasicBlock *NewTarget) {
+static void replaceBranchTargets(BasicBlock *BB, BasicBlock *OldTarget,
+                                 BasicBlock *NewTarget) {
   auto *T = BB->getTerminator();
   if (isa<ReturnInst>(T))
     return;
@@ -288,12 +282,10 @@ void replaceBranchTargets(BasicBlock *BB, BasicBlock *OldTarget,
   assert(false && "Unhandled terminator type.");
 }
 
-} // anonymous namespace
-
+namespace {
 // Given a reducible CFG, produces a structurized CFG in the SPIR-V sense,
 // adding merge instructions when required.
 class SPIRVStructurizer : public FunctionPass {
-
   struct DivergentConstruct;
   // Represents a list of condition/loops/switch constructs.
   // See SPIR-V 2.11.2. Structured Control-flow Constructs for the list of
@@ -504,8 +496,7 @@ class SPIRVStructurizer : public FunctionPass {
         replaceBranchTargets(Src, Dst, NewExit);
       }
 
-      llvm::Value *Load =
-          ExitBuilder.CreateLoad(ExitBuilder.getInt32Ty(), Variable);
+      Value *Load = ExitBuilder.CreateLoad(ExitBuilder.getInt32Ty(), Variable);
 
       // If we can avoid an OpSwitch, generate an OpBranch. Reason is some
       // OpBranch are allowed to exist without a new OpSelectionMerge if one of
@@ -595,9 +586,7 @@ class SPIRVStructurizer : public FunctionPass {
       // adding an unreachable merge block.
       if (Merge == nullptr) {
         BranchInst *Br = cast<BranchInst>(BB.getTerminator());
-        assert(Br &&
-               "This assumes the branch is not a switch. Maybe that's wrong?");
-        assert(cast<BranchInst>(BB.getTerminator())->isUnconditional());
+        assert(Br->isUnconditional());
 
         Merge = CreateUnreachable(F);
         Builder.SetInsertPoint(Br);
@@ -614,7 +603,7 @@ class SPIRVStructurizer : public FunctionPass {
       SmallVector<unsigned, 1> LoopControlImms =
           getSpirvLoopControlOperandsFromLoopMetadata(L);
       for (unsigned Imm : LoopControlImms)
-        Args.emplace_back(llvm::ConstantInt::get(Builder.getInt32Ty(), Imm));
+        Args.emplace_back(ConstantInt::get(Builder.getInt32Ty(), Imm));
       Builder.CreateIntrinsic(Intrinsic::spv_loop_merge, {Args});
       Modified = true;
     }
@@ -1127,9 +1116,7 @@ class SPIRVStructurizer : public FunctionPass {
 public:
   static char ID;
 
-  SPIRVStructurizer() : FunctionPass(ID) {
-    initializeSPIRVStructurizerPass(*PassRegistry::getPassRegistry());
-  };
+  SPIRVStructurizer() : FunctionPass(ID) {}
 
   virtual bool runOnFunction(Function &F) override {
     bool Modified = false;
@@ -1211,23 +1198,21 @@ public:
 
     MDNode *MDNode = BBTerminatorInst->getMetadata("hlsl.controlflow.hint");
 
-    ConstantInt *BranchHint = llvm::ConstantInt::get(Builder->getInt32Ty(), 0);
+    ConstantInt *BranchHint = ConstantInt::get(Builder->getInt32Ty(), 0);
 
     if (MDNode) {
       assert(MDNode->getNumOperands() == 2 &&
              "invalid metadata hlsl.controlflow.hint");
       BranchHint = mdconst::extract<ConstantInt>(MDNode->getOperand(1));
-
-      assert(BranchHint && "invalid metadata value for hlsl.controlflow.hint");
     }
 
-    llvm::SmallVector<llvm::Value *, 2> Args = {MergeAddress, BranchHint};
+    SmallVector<Value *, 2> Args = {MergeAddress, BranchHint};
 
     Builder->CreateIntrinsic(Intrinsic::spv_selection_merge,
-                             {MergeAddress->getType()}, {Args});
+                             {MergeAddress->getType()}, Args);
   }
 };
-} // namespace llvm
+} // anonymous namespace
 
 char SPIRVStructurizer::ID = 0;
 

--- a/llvm/lib/Target/SPIRV/SPIRVStructurizerWrapper.h
+++ b/llvm/lib/Target/SPIRV/SPIRVStructurizerWrapper.h
@@ -11,8 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIB_TARGET_DIRECTX_SPIRVSTRUCTURIZER_H
-#define LLVM_LIB_TARGET_DIRECTX_SPIRVSTRUCTURIZER_H
+#ifndef LLVM_LIB_TARGET_SPIRV_SPIRVSTRUCTURIZER_H
+#define LLVM_LIB_TARGET_SPIRV_SPIRVSTRUCTURIZER_H
 
 #include "llvm/IR/PassManager.h"
 
@@ -26,4 +26,4 @@ public:
 
 } // namespace llvm
 
-#endif // LLVM_LIB_TARGET_DIRECTX_SPIRVSTRUCTURIZER_H
+#endif // LLVM_LIB_TARGET_SPIRV_SPIRVSTRUCTURIZER_H

--- a/llvm/unittests/Target/SPIRV/SPIRVConvergenceRegionAnalysisTests.cpp
+++ b/llvm/unittests/Target/SPIRV/SPIRVConvergenceRegionAnalysisTests.cpp
@@ -11,6 +11,7 @@
 #include "llvm/Analysis/PostDominators.h"
 #include "llvm/AsmParser/Parser.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"


### PR DESCRIPTION
- Use static instead of anonymous namespace for file local functions.
- Enclose file-local classes in anonymous namespace.
- Eliminate `llvm::` qualifier when file has `using namespace llvm`.
- Eliminate namespace surrounding entire code in SPIRVConvergenceRegionAnalysis.cpp file.
- Eliminate call to `initializeSPIRVStructurizerPass` from the pass constructor (https://github.com/llvm/llvm-project/issues/111767)