### PR TITLE
[docs][SandboxIR] Fix cross-reference to sandbox vectorizer

### DIFF
--- a/llvm/docs/SandboxIR.md
+++ b/llvm/docs/SandboxIR.md
@@ -106,4 +106,4 @@ Please note that after a call to `revert()` or `accept()` tracking will stop.
 To start tracking again, the user needs to call `save()`.
 
 # Users of Sandbox IR
-- [The Sandbox Vectorizer](sandbox-vectorizer)
+- [The Sandbox Vectorizer](project:SandboxVectorizer.md)

--- a/llvm/docs/Vectorizers.rst
+++ b/llvm/docs/Vectorizers.rst
@@ -480,8 +480,6 @@ through clang using the command line flag:
 
    $ clang -fno-slp-vectorize file.c
 
-.. _sandbox-vectorizer:
-
 The Sandbox Vectorizer
 ======================
 .. toctree::


### PR DESCRIPTION
The cross-reference used to point to a label in the auto-vectorization document.