### PR TITLE
[DirectX] Fix build break caused by bitcode writer changes

### DIFF
--- a/llvm/lib/Target/DirectX/DXILWriter/DXILBitcodeWriter.cpp
+++ b/llvm/lib/Target/DirectX/DXILWriter/DXILBitcodeWriter.cpp
@@ -237,6 +237,11 @@ private:
                          SmallVectorImpl<uint64_t> &Record, unsigned Abbrev);
   void writeDIBasicType(const DIBasicType *N, SmallVectorImpl<uint64_t> &Record,
                         unsigned Abbrev);
+  void writeDIFixedPointType(const DIFixedPointType *N,
+                             SmallVectorImpl<uint64_t> &Record,
+                             unsigned Abbrev) {
+    llvm_unreachable("DXIL cannot contain DIFixedPointType Nodes");
+  }
   void writeDIStringType(const DIStringType *N,
                          SmallVectorImpl<uint64_t> &Record, unsigned Abbrev) {
     llvm_unreachable("DXIL cannot contain DIStringType Nodes");


### PR DESCRIPTION
commit: https://github.com/llvm/llvm-project/commit/68947342b75cc71f3ac9041d11db086d8d074336 added a new `writeDIFixedPointType` function.
 However, `DIFixedPointType` is not supported in DXIL so we need to add a fail fast case for this to fix the build.

this change fixes a build break introduced by https://github.com/llvm/llvm-project/pull/129596