### PR TITLE
[CMAKE][AMDGPU] fix build failure caused by PR #133619

### DIFF
--- a/clang/lib/CodeGen/TargetBuiltins/CMakeLists.txt
+++ b/clang/lib/CodeGen/TargetBuiltins/CMakeLists.txt
@@ -12,8 +12,3 @@ add_clang_library(clangCodeGenTargetBuiltins STATIC
   WebAssembly.cpp
   X86.cpp
 )
-
-target_link_libraries(clangCodeGenTargetBuiltins
-  PRIVATE
-  clangCodeGen
-)

--- a/clang/lib/CodeGen/Targets/CMakeLists.txt
+++ b/clang/lib/CodeGen/Targets/CMakeLists.txt
@@ -28,8 +28,3 @@ add_clang_library(clangCodeGenTargets STATIC
   X86.cpp
   XCore.cpp
 )
-
-target_link_libraries(clangCodeGenTargets
-  PRIVATE
-  clangCodeGen
-)


### PR DESCRIPTION
While clangCodeGenTargetBuiltins and clangCodeGenTargets are static libraries clangCodeGen is not and so this is creating a circular reference in the linux amdgpu-offload CIs on ubuntu and RHEL.

removing the circular reference doesn't break anything and looks to be a vestigial element of the origional PR.