### PR TITLE
[lldb] Convert Breakpoint & Watchpoints structs to classes (NFC)

### DIFF
--- a/lldb/tools/lldb-dap/Breakpoint.cpp
+++ b/lldb/tools/lldb-dap/Breakpoint.cpp
@@ -19,11 +19,11 @@
 
 using namespace lldb_dap;
 
-void Breakpoint::SetCondition() { m_bp.SetCondition(condition.c_str()); }
+void Breakpoint::SetCondition() { m_bp.SetCondition(m_condition.c_str()); }
 
 void Breakpoint::SetHitCondition() {
   uint64_t hitCount = 0;
-  if (llvm::to_integer(hitCondition, hitCount))
+  if (llvm::to_integer(m_hit_condition, hitCount))
     m_bp.SetIgnoreCount(hitCount - 1);
 }
 
@@ -75,8 +75,8 @@ bool Breakpoint::MatchesName(const char *name) {
 
 void Breakpoint::SetBreakpoint() {
   m_bp.AddName(kDAPBreakpointLabel);
-  if (!condition.empty())
+  if (!m_condition.empty())
     SetCondition();
-  if (!hitCondition.empty())
+  if (!m_hit_condition.empty())
     SetHitCondition();
 }

--- a/lldb/tools/lldb-dap/Breakpoint.cpp
+++ b/lldb/tools/lldb-dap/Breakpoint.cpp
@@ -19,21 +19,21 @@
 
 using namespace lldb_dap;
 
-void Breakpoint::SetCondition() { bp.SetCondition(condition.c_str()); }
+void Breakpoint::SetCondition() { m_bp.SetCondition(condition.c_str()); }
 
 void Breakpoint::SetHitCondition() {
   uint64_t hitCount = 0;
   if (llvm::to_integer(hitCondition, hitCount))
-    bp.SetIgnoreCount(hitCount - 1);
+    m_bp.SetIgnoreCount(hitCount - 1);
 }
 
 void Breakpoint::CreateJsonObject(llvm::json::Object &object) {
   // Each breakpoint location is treated as a separate breakpoint for VS code.
   // They don't have the notion of a single breakpoint with multiple locations.
-  if (!bp.IsValid())
+  if (!m_bp.IsValid())
     return;
-  object.try_emplace("verified", bp.GetNumResolvedLocations() > 0);
-  object.try_emplace("id", bp.GetID());
+  object.try_emplace("verified", m_bp.GetNumResolvedLocations() > 0);
+  object.try_emplace("id", m_bp.GetID());
   // VS Code DAP doesn't currently allow one breakpoint to have multiple
   // locations so we just report the first one. If we report all locations
   // then the IDE starts showing the wrong line numbers and locations for
@@ -43,20 +43,20 @@ void Breakpoint::CreateJsonObject(llvm::json::Object &object) {
   // this as the breakpoint location since it will have a complete location
   // that is at least loaded in the current process.
   lldb::SBBreakpointLocation bp_loc;
-  const auto num_locs = bp.GetNumLocations();
+  const auto num_locs = m_bp.GetNumLocations();
   for (size_t i = 0; i < num_locs; ++i) {
-    bp_loc = bp.GetLocationAtIndex(i);
+    bp_loc = m_bp.GetLocationAtIndex(i);
     if (bp_loc.IsResolved())
       break;
   }
   // If not locations are resolved, use the first location.
   if (!bp_loc.IsResolved())
-    bp_loc = bp.GetLocationAtIndex(0);
+    bp_loc = m_bp.GetLocationAtIndex(0);
   auto bp_addr = bp_loc.GetAddress();
 
   if (bp_addr.IsValid()) {
     std::string formatted_addr =
-        "0x" + llvm::utohexstr(bp_addr.GetLoadAddress(bp.GetTarget()));
+        "0x" + llvm::utohexstr(bp_addr.GetLoadAddress(m_bp.GetTarget()));
     object.try_emplace("instructionReference", formatted_addr);
     auto line_entry = bp_addr.GetLineEntry();
     const auto line = line_entry.GetLine();
@@ -69,10 +69,12 @@ void Breakpoint::CreateJsonObject(llvm::json::Object &object) {
   }
 }
 
-bool Breakpoint::MatchesName(const char *name) { return bp.MatchesName(name); }
+bool Breakpoint::MatchesName(const char *name) {
+  return m_bp.MatchesName(name);
+}
 
 void Breakpoint::SetBreakpoint() {
-  bp.AddName(kDAPBreakpointLabel);
+  m_bp.AddName(kDAPBreakpointLabel);
   if (!condition.empty())
     SetCondition();
   if (!hitCondition.empty())

--- a/lldb/tools/lldb-dap/Breakpoint.h
+++ b/lldb/tools/lldb-dap/Breakpoint.h
@@ -15,12 +15,12 @@
 
 namespace lldb_dap {
 
-struct Breakpoint : public BreakpointBase {
-  // The LLDB breakpoint associated wit this source breakpoint
-  lldb::SBBreakpoint bp;
-
+class Breakpoint : public BreakpointBase {
+public:
   Breakpoint(DAP &d, const llvm::json::Object &obj) : BreakpointBase(d, obj) {}
-  Breakpoint(DAP &d, lldb::SBBreakpoint bp) : BreakpointBase(d), bp(bp) {}
+  Breakpoint(DAP &d, lldb::SBBreakpoint bp) : BreakpointBase(d), m_bp(bp) {}
+
+  lldb::break_id_t GetID() const { return m_bp.GetID(); }
 
   void SetCondition() override;
   void SetHitCondition() override;
@@ -28,6 +28,10 @@ struct Breakpoint : public BreakpointBase {
 
   bool MatchesName(const char *name);
   void SetBreakpoint();
+
+protected:
+  /// The LLDB breakpoint associated wit this source breakpoint.
+  lldb::SBBreakpoint m_bp;
 };
 } // namespace lldb_dap
 

--- a/lldb/tools/lldb-dap/BreakpointBase.cpp
+++ b/lldb/tools/lldb-dap/BreakpointBase.cpp
@@ -13,16 +13,18 @@
 using namespace lldb_dap;
 
 BreakpointBase::BreakpointBase(DAP &d, const llvm::json::Object &obj)
-    : dap(d), condition(std::string(GetString(obj, "condition").value_or(""))),
-      hitCondition(std::string(GetString(obj, "hitCondition").value_or(""))) {}
+    : m_dap(d),
+      m_condition(std::string(GetString(obj, "condition").value_or(""))),
+      m_hit_condition(
+          std::string(GetString(obj, "hitCondition").value_or(""))) {}
 
 void BreakpointBase::UpdateBreakpoint(const BreakpointBase &request_bp) {
-  if (condition != request_bp.condition) {
-    condition = request_bp.condition;
+  if (m_condition != request_bp.m_condition) {
+    m_condition = request_bp.m_condition;
     SetCondition();
   }
-  if (hitCondition != request_bp.hitCondition) {
-    hitCondition = request_bp.hitCondition;
+  if (m_hit_condition != request_bp.m_hit_condition) {
+    m_hit_condition = request_bp.m_hit_condition;
     SetHitCondition();
   }
 }

--- a/lldb/tools/lldb-dap/BreakpointBase.h
+++ b/lldb/tools/lldb-dap/BreakpointBase.h
@@ -17,7 +17,7 @@ namespace lldb_dap {
 
 class BreakpointBase {
 public:
-  explicit BreakpointBase(DAP &d) : dap(d) {}
+  explicit BreakpointBase(DAP &d) : m_dap(d) {}
   BreakpointBase(DAP &d, const llvm::json::Object &obj);
   virtual ~BreakpointBase() = default;
 
@@ -44,14 +44,14 @@ public:
 
 protected:
   /// Associated DAP session.
-  DAP &dap;
+  DAP &m_dap;
 
   /// An optional expression for conditional breakpoints.
-  std::string condition;
+  std::string m_condition;
 
   /// An optional expression that controls how many hits of the breakpoint are
   /// ignored. The backend is expected to interpret the expression as needed
-  std::string hitCondition;
+  std::string m_hit_condition;
 };
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/BreakpointBase.h
+++ b/lldb/tools/lldb-dap/BreakpointBase.h
@@ -15,16 +15,8 @@
 
 namespace lldb_dap {
 
-struct BreakpointBase {
-  // Associated DAP session.
-  DAP &dap;
-
-  // An optional expression for conditional breakpoints.
-  std::string condition;
-  // An optional expression that controls how many hits of the breakpoint are
-  // ignored. The backend is expected to interpret the expression as needed
-  std::string hitCondition;
-
+class BreakpointBase {
+public:
   explicit BreakpointBase(DAP &d) : dap(d) {}
   BreakpointBase(DAP &d, const llvm::json::Object &obj);
   virtual ~BreakpointBase() = default;
@@ -49,6 +41,17 @@ struct BreakpointBase {
   /// breakpoint in one of the DAP breakpoints that we should report changes
   /// for.
   static constexpr const char *kDAPBreakpointLabel = "dap";
+
+protected:
+  /// Associated DAP session.
+  DAP &dap;
+
+  /// An optional expression for conditional breakpoints.
+  std::string condition;
+
+  /// An optional expression that controls how many hits of the breakpoint are
+  /// ignored. The backend is expected to interpret the expression as needed
+  std::string hitCondition;
 };
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -162,7 +162,7 @@ void DAP::PopulateExceptionBreakpoints() {
   });
 }
 
-ExceptionBreakpoint *DAP::GetExceptionBreakpoint(const std::string &filter) {
+ExceptionBreakpoint *DAP::GetExceptionBreakpoint(llvm::StringRef filter) {
   // PopulateExceptionBreakpoints() is called after g_dap.debugger is created
   // in a request-initialize.
   //
@@ -181,7 +181,7 @@ ExceptionBreakpoint *DAP::GetExceptionBreakpoint(const std::string &filter) {
   PopulateExceptionBreakpoints();
 
   for (auto &bp : *exception_breakpoints) {
-    if (bp.filter == filter)
+    if (bp.GetFilter() == filter)
       return &bp;
   }
   return nullptr;
@@ -192,7 +192,7 @@ ExceptionBreakpoint *DAP::GetExceptionBreakpoint(const lldb::break_id_t bp_id) {
   PopulateExceptionBreakpoints();
 
   for (auto &bp : *exception_breakpoints) {
-    if (bp.bp.GetID() == bp_id)
+    if (bp.GetID() == bp_id)
       return &bp;
   }
   return nullptr;
@@ -1066,7 +1066,7 @@ void DAP::SetThreadFormat(llvm::StringRef format) {
 InstructionBreakpoint *
 DAP::GetInstructionBreakpoint(const lldb::break_id_t bp_id) {
   for (auto &bp : instruction_breakpoints) {
-    if (bp.second.bp.GetID() == bp_id)
+    if (bp.second.GetID() == bp_id)
       return &bp.second;
   }
   return nullptr;

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -236,7 +236,7 @@ struct DAP {
   void operator=(const DAP &rhs) = delete;
   /// @}
 
-  ExceptionBreakpoint *GetExceptionBreakpoint(const std::string &filter);
+  ExceptionBreakpoint *GetExceptionBreakpoint(llvm::StringRef filter);
   ExceptionBreakpoint *GetExceptionBreakpoint(const lldb::break_id_t bp_id);
 
   /// Redirect stdout and stderr fo the IDE's console output.

--- a/lldb/tools/lldb-dap/DAPForward.h
+++ b/lldb/tools/lldb-dap/DAPForward.h
@@ -12,16 +12,16 @@
 // IWYU pragma: begin_exports
 
 namespace lldb_dap {
-struct BreakpointBase;
-struct ExceptionBreakpoint;
-struct FunctionBreakpoint;
-struct SourceBreakpoint;
-struct Watchpoint;
-struct InstructionBreakpoint;
-struct DAP;
-class Log;
 class BaseRequestHandler;
+class BreakpointBase;
+class ExceptionBreakpoint;
+class FunctionBreakpoint;
+class InstructionBreakpoint;
+class Log;
 class ResponseHandler;
+class SourceBreakpoint;
+class Watchpoint;
+struct DAP;
 } // namespace lldb_dap
 
 namespace lldb {

--- a/lldb/tools/lldb-dap/ExceptionBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/ExceptionBreakpoint.cpp
@@ -14,20 +14,20 @@
 namespace lldb_dap {
 
 void ExceptionBreakpoint::SetBreakpoint() {
-  if (bp.IsValid())
+  if (m_bp.IsValid())
     return;
-  bool catch_value = filter.find("_catch") != std::string::npos;
-  bool throw_value = filter.find("_throw") != std::string::npos;
-  bp = dap.target.BreakpointCreateForException(language, catch_value,
-                                               throw_value);
-  bp.AddName(BreakpointBase::kDAPBreakpointLabel);
+  bool catch_value = m_filter.find("_catch") != std::string::npos;
+  bool throw_value = m_filter.find("_throw") != std::string::npos;
+  m_bp = m_dap.target.BreakpointCreateForException(m_language, catch_value,
+                                                   throw_value);
+  m_bp.AddName(BreakpointBase::kDAPBreakpointLabel);
 }
 
 void ExceptionBreakpoint::ClearBreakpoint() {
-  if (!bp.IsValid())
+  if (!m_bp.IsValid())
     return;
-  dap.target.BreakpointDelete(bp.GetID());
-  bp = lldb::SBBreakpoint();
+  m_dap.target.BreakpointDelete(m_bp.GetID());
+  m_bp = lldb::SBBreakpoint();
 }
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/ExceptionBreakpoint.h
+++ b/lldb/tools/lldb-dap/ExceptionBreakpoint.h
@@ -12,25 +12,35 @@
 #include "DAPForward.h"
 #include "lldb/API/SBBreakpoint.h"
 #include "lldb/lldb-enumerations.h"
+#include "llvm/ADT/StringRef.h"
 #include <string>
 #include <utility>
 
 namespace lldb_dap {
 
-struct ExceptionBreakpoint {
-  DAP &dap;
-  std::string filter;
-  std::string label;
-  lldb::LanguageType language;
-  bool default_value = false;
-  lldb::SBBreakpoint bp;
+class ExceptionBreakpoint {
+public:
   ExceptionBreakpoint(DAP &d, std::string f, std::string l,
                       lldb::LanguageType lang)
-      : dap(d), filter(std::move(f)), label(std::move(l)), language(lang),
-        bp() {}
+      : m_dap(d), m_filter(std::move(f)), m_label(std::move(l)),
+        m_language(lang), m_bp() {}
 
   void SetBreakpoint();
   void ClearBreakpoint();
+  void CreateJsonObject(llvm::json::Object &object);
+
+  lldb::break_id_t GetID() const { return m_bp.GetID(); }
+  llvm::StringRef GetFilter() const { return m_filter; }
+  llvm::StringRef GetLabel() const { return m_label; }
+
+  static constexpr bool kDefaultValue = false;
+
+protected:
+  DAP &m_dap;
+  std::string m_filter;
+  std::string m_label;
+  lldb::LanguageType m_language;
+  lldb::SBBreakpoint m_bp;
 };
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/ExceptionBreakpoint.h
+++ b/lldb/tools/lldb-dap/ExceptionBreakpoint.h
@@ -27,7 +27,6 @@ public:
 
   void SetBreakpoint();
   void ClearBreakpoint();
-  void CreateJsonObject(llvm::json::Object &object);
 
   lldb::break_id_t GetID() const { return m_bp.GetID(); }
   llvm::StringRef GetFilter() const { return m_filter; }

--- a/lldb/tools/lldb-dap/FunctionBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/FunctionBreakpoint.cpp
@@ -19,7 +19,7 @@ FunctionBreakpoint::FunctionBreakpoint(DAP &d, const llvm::json::Object &obj)
 void FunctionBreakpoint::SetBreakpoint() {
   if (m_function_name.empty())
     return;
-  m_bp = dap.target.BreakpointCreateByName(m_function_name.c_str());
+  m_bp = m_dap.target.BreakpointCreateByName(m_function_name.c_str());
   Breakpoint::SetBreakpoint();
 }
 

--- a/lldb/tools/lldb-dap/FunctionBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/FunctionBreakpoint.cpp
@@ -14,12 +14,12 @@ namespace lldb_dap {
 
 FunctionBreakpoint::FunctionBreakpoint(DAP &d, const llvm::json::Object &obj)
     : Breakpoint(d, obj),
-      functionName(std::string(GetString(obj, "name").value_or(""))) {}
+      m_function_name(std::string(GetString(obj, "name").value_or(""))) {}
 
 void FunctionBreakpoint::SetBreakpoint() {
-  if (functionName.empty())
+  if (m_function_name.empty())
     return;
-  bp = dap.target.BreakpointCreateByName(functionName.c_str());
+  m_bp = dap.target.BreakpointCreateByName(m_function_name.c_str());
   Breakpoint::SetBreakpoint();
 }
 

--- a/lldb/tools/lldb-dap/FunctionBreakpoint.h
+++ b/lldb/tools/lldb-dap/FunctionBreakpoint.h
@@ -14,13 +14,17 @@
 
 namespace lldb_dap {
 
-struct FunctionBreakpoint : public Breakpoint {
-  std::string functionName;
-
+class FunctionBreakpoint : public Breakpoint {
+public:
   FunctionBreakpoint(DAP &dap, const llvm::json::Object &obj);
 
-  // Set this breakpoint in LLDB as a new breakpoint
+  /// Set this breakpoint in LLDB as a new breakpoint.
   void SetBreakpoint();
+
+  llvm::StringRef GetFunctionName() const { return m_function_name; }
+
+protected:
+  std::string m_function_name;
 };
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Handler/ExceptionInfoRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/ExceptionInfoRequestHandler.cpp
@@ -125,8 +125,8 @@ void ExceptionInfoRequestHandler::operator()(
     else if (stopReason == lldb::eStopReasonBreakpoint) {
       ExceptionBreakpoint *exc_bp = dap.GetExceptionBPFromStopReason(thread);
       if (exc_bp) {
-        EmplaceSafeString(body, "exceptionId", exc_bp->filter);
-        EmplaceSafeString(body, "description", exc_bp->label);
+        EmplaceSafeString(body, "exceptionId", exc_bp->GetFilter());
+        EmplaceSafeString(body, "description", exc_bp->GetLabel());
       } else {
         body.try_emplace("exceptionId", "exception");
       }

--- a/lldb/tools/lldb-dap/Handler/SetBreakpointsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SetBreakpointsRequestHandler.cpp
@@ -143,7 +143,8 @@ void SetBreakpointsRequestHandler::operator()(
       const auto *bp_obj = bp.getAsObject();
       if (bp_obj) {
         SourceBreakpoint src_bp(dap, *bp_obj);
-        std::pair<uint32_t, uint32_t> bp_pos(src_bp.line, src_bp.column);
+        std::pair<uint32_t, uint32_t> bp_pos(src_bp.GetLine(),
+                                             src_bp.GetColumn());
         request_bps.try_emplace(bp_pos, src_bp);
         const auto [iv, inserted] =
             dap.source_breakpoints[path].try_emplace(bp_pos, src_bp);
@@ -153,7 +154,7 @@ void SetBreakpointsRequestHandler::operator()(
         else
           iv->getSecond().UpdateBreakpoint(src_bp);
         AppendBreakpoint(&iv->getSecond(), response_breakpoints, path,
-                         src_bp.line);
+                         src_bp.GetLine());
       }
     }
   }
@@ -167,7 +168,7 @@ void SetBreakpointsRequestHandler::operator()(
       auto request_pos = request_bps.find(old_bp.first);
       if (request_pos == request_bps.end()) {
         // This breakpoint no longer exists in this source file, delete it
-        dap.target.BreakpointDelete(old_bp.second.bp.GetID());
+        dap.target.BreakpointDelete(old_bp.second.GetID());
         old_src_bp_pos->second.erase(old_bp.first);
       }
     }

--- a/lldb/tools/lldb-dap/Handler/SetDataBreakpointsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SetDataBreakpointsRequestHandler.cpp
@@ -97,9 +97,9 @@ void SetDataBreakpointsRequestHandler::operator()(
   // backward.
   std::set<lldb::addr_t> addresses;
   for (auto iter = watchpoints.rbegin(); iter != watchpoints.rend(); ++iter) {
-    if (addresses.count(iter->addr) == 0) {
+    if (addresses.count(iter->GetAddress()) == 0) {
       iter->SetWatchpoint();
-      addresses.insert(iter->addr);
+      addresses.insert(iter->GetAddress());
     }
   }
   for (auto wp : watchpoints)

--- a/lldb/tools/lldb-dap/Handler/SetExceptionBreakpointsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SetExceptionBreakpointsRequestHandler.cpp
@@ -70,9 +70,9 @@ void SetExceptionBreakpointsRequestHandler::operator()(
   const auto *filters = arguments->getArray("filters");
   // Keep a list of any exception breakpoint filter names that weren't set
   // so we can clear any exception breakpoints if needed.
-  std::set<std::string> unset_filters;
+  std::set<llvm::StringRef> unset_filters;
   for (const auto &bp : *dap.exception_breakpoints)
-    unset_filters.insert(bp.filter);
+    unset_filters.insert(bp.GetFilter());
 
   for (const auto &value : *filters) {
     const auto filter = GetAsString(value);

--- a/lldb/tools/lldb-dap/Handler/SetFunctionBreakpointsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SetFunctionBreakpointsRequestHandler.cpp
@@ -110,15 +110,15 @@ void SetFunctionBreakpointsRequestHandler::operator()(
     if (!bp_obj)
       continue;
     FunctionBreakpoint fn_bp(dap, *bp_obj);
-    const auto [it, inserted] =
-        dap.function_breakpoints.try_emplace(fn_bp.functionName, dap, *bp_obj);
+    const auto [it, inserted] = dap.function_breakpoints.try_emplace(
+        fn_bp.GetFunctionName(), dap, *bp_obj);
     if (inserted)
       it->second.SetBreakpoint();
     else
       it->second.UpdateBreakpoint(fn_bp);
 
     AppendBreakpoint(&it->second, response_breakpoints);
-    seen.erase(fn_bp.functionName);
+    seen.erase(fn_bp.GetFunctionName());
   }
 
   // Remove any breakpoints that are no longer in our list
@@ -126,7 +126,7 @@ void SetFunctionBreakpointsRequestHandler::operator()(
     auto fn_bp = dap.function_breakpoints.find(name);
     if (fn_bp == dap.function_breakpoints.end())
       continue;
-    dap.target.BreakpointDelete(fn_bp->second.bp.GetID());
+    dap.target.BreakpointDelete(fn_bp->second.GetID());
     dap.function_breakpoints.erase(name);
   }
 

--- a/lldb/tools/lldb-dap/Handler/SetInstructionBreakpointsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SetInstructionBreakpointsRequestHandler.cpp
@@ -223,20 +223,20 @@ void SetInstructionBreakpointsRequestHandler::operator()(
     // Read instruction breakpoint request.
     InstructionBreakpoint inst_bp(dap, *bp_obj);
     const auto [iv, inserted] = dap.instruction_breakpoints.try_emplace(
-        inst_bp.instructionAddressReference, dap, *bp_obj);
+        inst_bp.GetInstructionAddressReference(), dap, *bp_obj);
     if (inserted)
       iv->second.SetBreakpoint();
     else
       iv->second.UpdateBreakpoint(inst_bp);
     AppendBreakpoint(&iv->second, response_breakpoints);
-    seen.erase(inst_bp.instructionAddressReference);
+    seen.erase(inst_bp.GetInstructionAddressReference());
   }
 
   for (const auto &addr : seen) {
     auto inst_bp = dap.instruction_breakpoints.find(addr);
     if (inst_bp == dap.instruction_breakpoints.end())
       continue;
-    dap.target.BreakpointDelete(inst_bp->second.bp.GetID());
+    dap.target.BreakpointDelete(inst_bp->second.GetID());
     dap.instruction_breakpoints.erase(addr);
   }
 

--- a/lldb/tools/lldb-dap/InstructionBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/InstructionBreakpoint.cpp
@@ -27,7 +27,8 @@ InstructionBreakpoint::InstructionBreakpoint(DAP &d,
 }
 
 void InstructionBreakpoint::SetBreakpoint() {
-  m_bp = dap.target.BreakpointCreateByAddress(m_instruction_address_reference);
+  m_bp =
+      m_dap.target.BreakpointCreateByAddress(m_instruction_address_reference);
   Breakpoint::SetBreakpoint();
 }
 

--- a/lldb/tools/lldb-dap/InstructionBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/InstructionBreakpoint.cpp
@@ -16,19 +16,18 @@
 
 namespace lldb_dap {
 
-// Instruction Breakpoint
 InstructionBreakpoint::InstructionBreakpoint(DAP &d,
                                              const llvm::json::Object &obj)
-    : Breakpoint(d, obj), instructionAddressReference(LLDB_INVALID_ADDRESS),
-      offset(GetInteger<int64_t>(obj, "offset").value_or(0)) {
+    : Breakpoint(d, obj), m_instruction_address_reference(LLDB_INVALID_ADDRESS),
+      m_offset(GetInteger<int64_t>(obj, "offset").value_or(0)) {
   GetString(obj, "instructionReference")
       .value_or("")
-      .getAsInteger(0, instructionAddressReference);
-  instructionAddressReference += offset;
+      .getAsInteger(0, m_instruction_address_reference);
+  m_instruction_address_reference += m_offset;
 }
 
 void InstructionBreakpoint::SetBreakpoint() {
-  bp = dap.target.BreakpointCreateByAddress(instructionAddressReference);
+  m_bp = dap.target.BreakpointCreateByAddress(m_instruction_address_reference);
   Breakpoint::SetBreakpoint();
 }
 

--- a/lldb/tools/lldb-dap/InstructionBreakpoint.h
+++ b/lldb/tools/lldb-dap/InstructionBreakpoint.h
@@ -17,16 +17,21 @@
 
 namespace lldb_dap {
 
-// Instruction Breakpoint
-struct InstructionBreakpoint : public Breakpoint {
-
-  lldb::addr_t instructionAddressReference;
-  int32_t offset;
-
+/// Instruction Breakpoint
+class InstructionBreakpoint : public Breakpoint {
+public:
   InstructionBreakpoint(DAP &d, const llvm::json::Object &obj);
 
-  // Set instruction breakpoint in LLDB as a new breakpoint
+  /// Set instruction breakpoint in LLDB as a new breakpoint.
   void SetBreakpoint();
+
+  lldb::addr_t GetInstructionAddressReference() const {
+    return m_instruction_address_reference;
+  }
+
+protected:
+  lldb::addr_t m_instruction_address_reference;
+  int32_t m_offset;
 };
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -560,9 +560,9 @@ llvm::json::Object CreateEventObject(const llvm::StringRef event_name) {
 protocol::ExceptionBreakpointsFilter
 CreateExceptionBreakpointFilter(const ExceptionBreakpoint &bp) {
   protocol::ExceptionBreakpointsFilter filter;
-  filter.filter = bp.filter;
-  filter.label = bp.label;
-  filter.defaultState = bp.default_value;
+  filter.filter = bp.GetFilter();
+  filter.label = bp.GetLabel();
+  filter.defaultState = ExceptionBreakpoint::kDefaultValue;
   return filter;
 }
 
@@ -940,7 +940,7 @@ llvm::json::Value CreateThreadStopped(DAP &dap, lldb::SBThread &thread,
     ExceptionBreakpoint *exc_bp = dap.GetExceptionBPFromStopReason(thread);
     if (exc_bp) {
       body.try_emplace("reason", "exception");
-      EmplaceSafeString(body, "description", exc_bp->label);
+      EmplaceSafeString(body, "description", exc_bp->GetLabel());
     } else {
       InstructionBreakpoint *inst_bp =
           dap.GetInstructionBPFromStopReason(thread);

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -34,8 +34,8 @@ SourceBreakpoint::SourceBreakpoint(DAP &dap, const llvm::json::Object &obj)
 
 void SourceBreakpoint::SetBreakpoint(const llvm::StringRef source_path) {
   lldb::SBFileSpecList module_list;
-  bp = dap.target.BreakpointCreateByLocation(source_path.str().c_str(), line,
-                                             column, 0, module_list);
+  m_bp = dap.target.BreakpointCreateByLocation(source_path.str().c_str(), line,
+                                               column, 0, module_list);
   if (!logMessage.empty())
     SetLogMessage();
   Breakpoint::SetBreakpoint();
@@ -288,7 +288,7 @@ void SourceBreakpoint::SetLogMessage() {
     }
   }
 
-  bp.SetCallback(BreakpointHitCallback, this);
+  m_bp.SetCallback(BreakpointHitCallback, this);
 }
 
 void SourceBreakpoint::NotifyLogMessageError(llvm::StringRef error) {

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -26,24 +26,24 @@ namespace lldb_dap {
 
 SourceBreakpoint::SourceBreakpoint(DAP &dap, const llvm::json::Object &obj)
     : Breakpoint(dap, obj),
-      logMessage(GetString(obj, "logMessage").value_or("").str()),
-      line(
+      m_log_message(GetString(obj, "logMessage").value_or("").str()),
+      m_line(
           GetInteger<uint64_t>(obj, "line").value_or(LLDB_INVALID_LINE_NUMBER)),
-      column(GetInteger<uint64_t>(obj, "column")
-                 .value_or(LLDB_INVALID_COLUMN_NUMBER)) {}
+      m_column(GetInteger<uint64_t>(obj, "column")
+                   .value_or(LLDB_INVALID_COLUMN_NUMBER)) {}
 
 void SourceBreakpoint::SetBreakpoint(const llvm::StringRef source_path) {
   lldb::SBFileSpecList module_list;
-  m_bp = dap.target.BreakpointCreateByLocation(source_path.str().c_str(), line,
-                                               column, 0, module_list);
-  if (!logMessage.empty())
+  m_bp = m_dap.target.BreakpointCreateByLocation(
+      source_path.str().c_str(), m_line, m_column, 0, module_list);
+  if (!m_log_message.empty())
     SetLogMessage();
   Breakpoint::SetBreakpoint();
 }
 
 void SourceBreakpoint::UpdateBreakpoint(const SourceBreakpoint &request_bp) {
-  if (logMessage != request_bp.logMessage) {
-    logMessage = request_bp.logMessage;
+  if (m_log_message != request_bp.m_log_message) {
+    m_log_message = request_bp.m_log_message;
     SetLogMessage();
   }
   BreakpointBase::UpdateBreakpoint(request_bp);
@@ -52,13 +52,13 @@ void SourceBreakpoint::UpdateBreakpoint(const SourceBreakpoint &request_bp) {
 lldb::SBError SourceBreakpoint::AppendLogMessagePart(llvm::StringRef part,
                                                      bool is_expr) {
   if (is_expr) {
-    logMessageParts.emplace_back(part, is_expr);
+    m_log_message_parts.emplace_back(part, is_expr);
   } else {
     std::string formatted;
     lldb::SBError error = FormatLogText(part, formatted);
     if (error.Fail())
       return error;
-    logMessageParts.emplace_back(formatted, is_expr);
+    m_log_message_parts.emplace_back(formatted, is_expr);
   }
   return lldb::SBError();
 }
@@ -195,7 +195,7 @@ lldb::SBError SourceBreakpoint::FormatLogText(llvm::StringRef text,
 // The function tries to parse logMessage into a list of LogMessageParts
 // for easy later access in BreakpointHitCallback.
 void SourceBreakpoint::SetLogMessage() {
-  logMessageParts.clear();
+  m_log_message_parts.clear();
 
   // Contains unmatched open curly braces indices.
   std::vector<int> unmatched_curly_braces;
@@ -209,10 +209,10 @@ void SourceBreakpoint::SetLogMessage() {
   // Part1 - parse matched_curly_braces_ranges.
   // locating all curly braced expression ranges in logMessage.
   // The algorithm takes care of nested and imbalanced curly braces.
-  for (size_t i = 0; i < logMessage.size(); ++i) {
-    if (logMessage[i] == '{') {
+  for (size_t i = 0; i < m_log_message.size(); ++i) {
+    if (m_log_message[i] == '{') {
       unmatched_curly_braces.push_back(i);
-    } else if (logMessage[i] == '}') {
+    } else if (m_log_message[i] == '}') {
       if (unmatched_curly_braces.empty())
         // Nothing to match.
         continue;
@@ -252,7 +252,7 @@ void SourceBreakpoint::SetLogMessage() {
     size_t raw_text_len = curly_braces_range.first - last_raw_text_start;
     if (raw_text_len > 0) {
       error = AppendLogMessagePart(
-          llvm::StringRef(logMessage.c_str() + last_raw_text_start,
+          llvm::StringRef(m_log_message.c_str() + last_raw_text_start,
                           raw_text_len),
           /*is_expr=*/false);
       if (error.Fail()) {
@@ -265,7 +265,7 @@ void SourceBreakpoint::SetLogMessage() {
     assert(curly_braces_range.second > curly_braces_range.first);
     size_t expr_len = curly_braces_range.second - curly_braces_range.first - 1;
     error = AppendLogMessagePart(
-        llvm::StringRef(logMessage.c_str() + curly_braces_range.first + 1,
+        llvm::StringRef(m_log_message.c_str() + curly_braces_range.first + 1,
                         expr_len),
         /*is_expr=*/true);
     if (error.Fail()) {
@@ -277,10 +277,10 @@ void SourceBreakpoint::SetLogMessage() {
   }
   // Trailing raw text after close curly brace.
   assert(last_raw_text_start >= 0);
-  if (logMessage.size() > (size_t)last_raw_text_start) {
+  if (m_log_message.size() > (size_t)last_raw_text_start) {
     error = AppendLogMessagePart(
-        llvm::StringRef(logMessage.c_str() + last_raw_text_start,
-                        logMessage.size() - last_raw_text_start),
+        llvm::StringRef(m_log_message.c_str() + last_raw_text_start,
+                        m_log_message.size() - last_raw_text_start),
         /*is_expr=*/false);
     if (error.Fail()) {
       NotifyLogMessageError(error.GetCString());
@@ -294,7 +294,7 @@ void SourceBreakpoint::SetLogMessage() {
 void SourceBreakpoint::NotifyLogMessageError(llvm::StringRef error) {
   std::string message = "Log message has error: ";
   message += error;
-  dap.SendOutput(OutputType::Console, message);
+  m_dap.SendOutput(OutputType::Console, message);
 }
 
 /*static*/
@@ -309,7 +309,7 @@ bool SourceBreakpoint::BreakpointHitCallback(
 
   std::string output;
   for (const SourceBreakpoint::LogMessagePart &messagePart :
-       bp->logMessageParts) {
+       bp->m_log_message_parts) {
     if (messagePart.is_expr) {
       // Try local frame variables first before fall back to expression
       // evaluation
@@ -320,7 +320,7 @@ bool SourceBreakpoint::BreakpointHitCallback(
       if (value.GetError().Fail())
         value = frame.EvaluateExpression(expr);
       output +=
-          VariableDescription(value, bp->dap.enable_auto_variable_summaries)
+          VariableDescription(value, bp->m_dap.enable_auto_variable_summaries)
               .display_value;
     } else {
       output += messagePart.text;
@@ -328,7 +328,7 @@ bool SourceBreakpoint::BreakpointHitCallback(
   }
   if (!output.empty() && output.back() != '\n')
     output.push_back('\n'); // Ensure log message has line break.
-  bp->dap.SendOutput(OutputType::Console, output.c_str());
+  bp->m_dap.SendOutput(OutputType::Console, output.c_str());
 
   // Do not stop.
   return false;

--- a/lldb/tools/lldb-dap/SourceBreakpoint.h
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.h
@@ -19,23 +19,8 @@
 
 namespace lldb_dap {
 
-struct SourceBreakpoint : public Breakpoint {
-  // logMessage part can be either a raw text or an expression.
-  struct LogMessagePart {
-    LogMessagePart(llvm::StringRef text, bool is_expr)
-        : text(text), is_expr(is_expr) {}
-    std::string text;
-    bool is_expr;
-  };
-  // If this attribute exists and is non-empty, the backend must not 'break'
-  // (stop) but log the message instead. Expressions within {} are
-  // interpolated.
-  std::string logMessage;
-  std::vector<LogMessagePart> logMessageParts;
-
-  uint32_t line;   ///< The source line of the breakpoint or logpoint
-  uint32_t column; ///< An optional source column of the breakpoint
-
+class SourceBreakpoint : public Breakpoint {
+public:
   SourceBreakpoint(DAP &d, const llvm::json::Object &obj);
 
   // Set this breakpoint in LLDB as a new breakpoint
@@ -52,14 +37,33 @@ struct SourceBreakpoint : public Breakpoint {
   static bool BreakpointHitCallback(void *baton, lldb::SBProcess &process,
                                     lldb::SBThread &thread,
                                     lldb::SBBreakpointLocation &location);
-};
 
-inline bool operator<(const SourceBreakpoint &lhs,
-                      const SourceBreakpoint &rhs) {
-  if (lhs.line == rhs.line)
-    return lhs.column < rhs.column;
-  return lhs.line < rhs.line;
-}
+  inline bool operator<(const SourceBreakpoint &rhs) {
+    if (line == rhs.line)
+      return column < rhs.column;
+    return line < rhs.line;
+  }
+
+  uint32_t GetLine() const { return line; }
+  uint32_t GetColumn() const { return column; }
+
+protected:
+  // logMessage part can be either a raw text or an expression.
+  struct LogMessagePart {
+    LogMessagePart(llvm::StringRef text, bool is_expr)
+        : text(text), is_expr(is_expr) {}
+    std::string text;
+    bool is_expr;
+  };
+  // If this attribute exists and is non-empty, the backend must not 'break'
+  // (stop) but log the message instead. Expressions within {} are
+  // interpolated.
+  std::string logMessage;
+  std::vector<LogMessagePart> logMessageParts;
+
+  uint32_t line;   ///< The source line of the breakpoint or logpoint
+  uint32_t column; ///< An optional source column of the breakpoint
+};
 
 } // namespace lldb_dap
 

--- a/lldb/tools/lldb-dap/SourceBreakpoint.h
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.h
@@ -39,13 +39,13 @@ public:
                                     lldb::SBBreakpointLocation &location);
 
   inline bool operator<(const SourceBreakpoint &rhs) {
-    if (line == rhs.line)
-      return column < rhs.column;
-    return line < rhs.line;
+    if (m_line == rhs.m_line)
+      return m_column < rhs.m_column;
+    return m_line < rhs.m_line;
   }
 
-  uint32_t GetLine() const { return line; }
-  uint32_t GetColumn() const { return column; }
+  uint32_t GetLine() const { return m_line; }
+  uint32_t GetColumn() const { return m_column; }
 
 protected:
   // logMessage part can be either a raw text or an expression.
@@ -58,11 +58,11 @@ protected:
   // If this attribute exists and is non-empty, the backend must not 'break'
   // (stop) but log the message instead. Expressions within {} are
   // interpolated.
-  std::string logMessage;
-  std::vector<LogMessagePart> logMessageParts;
+  std::string m_log_message;
+  std::vector<LogMessagePart> m_log_message_parts;
 
-  uint32_t line;   ///< The source line of the breakpoint or logpoint
-  uint32_t column; ///< An optional source column of the breakpoint
+  uint32_t m_line;   ///< The source line of the breakpoint or logpoint
+  uint32_t m_column; ///< An optional source column of the breakpoint
 };
 
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Watchpoint.cpp
+++ b/lldb/tools/lldb-dap/Watchpoint.cpp
@@ -23,33 +23,34 @@ Watchpoint::Watchpoint(DAP &d, const llvm::json::Object &obj)
   llvm::StringRef dataId = GetString(obj, "dataId").value_or("");
   std::string accessType = GetString(obj, "accessType").value_or("").str();
   auto [addr_str, size_str] = dataId.split('/');
-  llvm::to_integer(addr_str, addr, 16);
-  llvm::to_integer(size_str, size);
-  options.SetWatchpointTypeRead(accessType != "write");
+  llvm::to_integer(addr_str, m_addr, 16);
+  llvm::to_integer(size_str, m_size);
+  m_options.SetWatchpointTypeRead(accessType != "write");
   if (accessType != "read")
-    options.SetWatchpointTypeWrite(lldb::eWatchpointWriteTypeOnModify);
+    m_options.SetWatchpointTypeWrite(lldb::eWatchpointWriteTypeOnModify);
 }
 
-void Watchpoint::SetCondition() { wp.SetCondition(condition.c_str()); }
+void Watchpoint::SetCondition() { m_wp.SetCondition(condition.c_str()); }
 
 void Watchpoint::SetHitCondition() {
   uint64_t hitCount = 0;
   if (llvm::to_integer(hitCondition, hitCount))
-    wp.SetIgnoreCount(hitCount - 1);
+    m_wp.SetIgnoreCount(hitCount - 1);
 }
 
 void Watchpoint::CreateJsonObject(llvm::json::Object &object) {
-  if (!error.IsValid() || error.Fail()) {
+  if (!m_error.IsValid() || m_error.Fail()) {
     object.try_emplace("verified", false);
-    if (error.Fail())
-      EmplaceSafeString(object, "message", error.GetCString());
+    if (m_error.Fail())
+      EmplaceSafeString(object, "message", m_error.GetCString());
   } else {
     object.try_emplace("verified", true);
   }
 }
 
 void Watchpoint::SetWatchpoint() {
-  wp = dap.target.WatchpointCreateByAddress(addr, size, options, error);
+  m_wp =
+      dap.target.WatchpointCreateByAddress(m_addr, m_size, m_options, m_error);
   if (!condition.empty())
     SetCondition();
   if (!hitCondition.empty())

--- a/lldb/tools/lldb-dap/Watchpoint.cpp
+++ b/lldb/tools/lldb-dap/Watchpoint.cpp
@@ -30,11 +30,11 @@ Watchpoint::Watchpoint(DAP &d, const llvm::json::Object &obj)
     m_options.SetWatchpointTypeWrite(lldb::eWatchpointWriteTypeOnModify);
 }
 
-void Watchpoint::SetCondition() { m_wp.SetCondition(condition.c_str()); }
+void Watchpoint::SetCondition() { m_wp.SetCondition(m_condition.c_str()); }
 
 void Watchpoint::SetHitCondition() {
   uint64_t hitCount = 0;
-  if (llvm::to_integer(hitCondition, hitCount))
+  if (llvm::to_integer(m_hit_condition, hitCount))
     m_wp.SetIgnoreCount(hitCount - 1);
 }
 
@@ -49,11 +49,11 @@ void Watchpoint::CreateJsonObject(llvm::json::Object &object) {
 }
 
 void Watchpoint::SetWatchpoint() {
-  m_wp =
-      dap.target.WatchpointCreateByAddress(m_addr, m_size, m_options, m_error);
-  if (!condition.empty())
+  m_wp = m_dap.target.WatchpointCreateByAddress(m_addr, m_size, m_options,
+                                                m_error);
+  if (!m_condition.empty())
     SetCondition();
-  if (!hitCondition.empty())
+  if (!m_hit_condition.empty())
     SetHitCondition();
 }
 } // namespace lldb_dap

--- a/lldb/tools/lldb-dap/Watchpoint.h
+++ b/lldb/tools/lldb-dap/Watchpoint.h
@@ -19,22 +19,26 @@
 
 namespace lldb_dap {
 
-struct Watchpoint : public BreakpointBase {
-  lldb::addr_t addr;
-  size_t size;
-  lldb::SBWatchpointOptions options;
-  // The LLDB breakpoint associated wit this watchpoint.
-  lldb::SBWatchpoint wp;
-  lldb::SBError error;
-
+class Watchpoint : public BreakpointBase {
+public:
   Watchpoint(DAP &d, const llvm::json::Object &obj);
-  Watchpoint(DAP &d, lldb::SBWatchpoint wp) : BreakpointBase(d), wp(wp) {}
+  Watchpoint(DAP &d, lldb::SBWatchpoint wp) : BreakpointBase(d), m_wp(wp) {}
 
   void SetCondition() override;
   void SetHitCondition() override;
   void CreateJsonObject(llvm::json::Object &object) override;
 
   void SetWatchpoint();
+
+  lldb::addr_t GetAddress() const { return m_addr; }
+
+protected:
+  lldb::addr_t m_addr;
+  size_t m_size;
+  lldb::SBWatchpointOptions m_options;
+  /// The LLDB breakpoint associated wit this watchpoint.
+  lldb::SBWatchpoint m_wp;
+  lldb::SBError m_error;
 };
 } // namespace lldb_dap
 


### PR DESCRIPTION
Convert Breakpoint & Watchpoints structs to classes to provide proper access control. This is in preparation for adopting SBMutex to protect the underlying SBBreakpoint and SBWatchpoint.