### PR TITLE
[WebAssembly] Add a missing `break` statement

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -1109,6 +1109,7 @@ void WebAssemblyTargetLowering::computeKnownBitsForTargetNode(
       break;
     }
     }
+    break;
   }
 
   // For 128-bit addition if the upper bits are all zero then it's known that


### PR DESCRIPTION
This fixes an issue introduced in #132430 where a `break;` statement was accidentally missing causing unintended fall-through.