### PR TITLE
[mlir][bazel] add alwayslink=True to mlir-runner utils

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -10330,6 +10330,7 @@ cc_library(
         ":mlir_float16_utils",
         "//llvm:Support",
     ],
+    alwayslink = True,
 )
 
 # Indirection to avoid 'libmlir_c_runner_utils.so' filename clash.
@@ -10359,6 +10360,7 @@ cc_library(
         ":mlir_c_runner_utils",
         ":mlir_float16_utils",
     ],
+    alwayslink = True,
 )
 
 # Indirection to avoid 'libmlir_runner_utils.so' filename clash.


### PR DESCRIPTION
MacOS platforms using mlir-runner in lit tests consistently hit the following error:

```
# .---command stderr------------
# | JIT session error: Symbols not found: [ __mlir_ciface_printMemrefI32 ]
# | Error: Failed to materialize symbols: { (main, { __mlir_printMemrefI32, ... }) }
# `-----------------------------
```

https://github.com/google/heir/issues/1521#issuecomment-2751303404 confirms the issue is fixed by using `alwayslink` on these two targets, and I confirmed on a separate Apple M1 (OSX version Sequoia 15.3.2.).

I'm not an expert on the mlir runner internals, but given the mlir-runner is purely for testing, and alwayslink at worst adds some overhead by not removing symbols, it seems low risk.