### PR TITLE
[lldb-dap] Make the DAP server resilient against broken pipes

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -1174,8 +1174,10 @@ class DebugCommunication(object):
         return self.send_recv(command_dict)
 
     def terminate(self):
-        self.send.close()
-        # self.recv.close()
+        try:
+            self.send.close()
+        except BrokenPipeError:
+            pass
 
     def request_setInstructionBreakpoints(self, memory_reference=[]):
         breakpoints = []


### PR DESCRIPTION
This makes the DAP test server resilient against broken pipes. I'm not sure what is causing the broken pipe, but IIRC this isn't the first time we've seen an issues related to that. I worry about sweeping it under the rug, but on the other hand having the test suite hangup isn't great either.

Based this on https://bugs.python.org/issue21619:

> The best way to clean up a subprocess that I have come up with to
> close the pipe(s) and call wait() in two separate steps, such as:

```
try:
    proc.stdin.close()
except BrokenPipeError:
    pass
proc.wait()
```

Fixes #133782 (or rather: works around it)