### PR TITLE
Stop using __attribute__((retain)) in GCC builds

### DIFF
--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -230,15 +230,12 @@
 #define LLVM_ATTRIBUTE_USED
 #endif
 
-#if __has_attribute(retain)
-#if defined(__clang__) || !defined(__GNUC__)
-#define LLVM_ATTRIBUTE_RETAIN __attribute__((__retain__))
-#else
+// Only enabled for clang:
 // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99587
 // GCC may produce "warning: ‘retain’ attribute ignored" (despite
 // __has_attribute(retain) being 1).
-#define LLVM_ATTRIBUTE_RETAIN
-#endif
+#if defined(__clang__) && __has_attribute(retain)
+#define LLVM_ATTRIBUTE_RETAIN __attribute__((__retain__))
 #else
 #define LLVM_ATTRIBUTE_RETAIN
 #endif

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -231,7 +231,14 @@
 #endif
 
 #if __has_attribute(retain)
+#if defined(__clang__) || !defined(__GNUC__)
 #define LLVM_ATTRIBUTE_RETAIN __attribute__((__retain__))
+#else
+// See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99587
+// GCC may produce "warning: ‘retain’ attribute ignored" (despite
+// __has_attribute(retain) being 1).
+#define LLVM_ATTRIBUTE_RETAIN
+#endif
 #else
 #define LLVM_ATTRIBUTE_RETAIN
 #endif


### PR DESCRIPTION
GCC sometimes produces warnings about `__attribute__((retain))` despite `__has_attribute(retain)` being 1. See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99587

The amount of users who benefit from the attribute is probably very small compared to the amount of `-Werror` enabled builds or the desire to keep `-Wattributes` enabled in the LLVM build. So for now drop usage of the `retain` attribute in GCC builds.