### PR TITLE
Reland "Symbolize line zero as if no source info is available (#124846)"

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFContext.cpp
@@ -1870,7 +1870,7 @@ DWARFContext::getInliningInfoForAddress(object::SectionedAddress Address,
           LineTable->getFileLineInfoForAddress(
               {Address.Address, Address.SectionIndex}, Spec.ApproximateLine,
               CU->getCompilationDir(), Spec.FLIKind, Frame);
-      } else {
+      } else if (CallLine != 0) {
         // Otherwise, use call file, call line and call column from
         // previous DIE in inlined chain.
         if (LineTable)

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
@@ -1539,7 +1539,8 @@ bool DWARFDebugLine::LineTable::getFileLineInfoForAddress(
     return false;
   // Take file number and line/column from the row.
   const auto &Row = Rows[RowIndex];
-  if (!getFileNameByIndex(Row.File, CompDir, Kind, Result.FileName))
+  if (Row.Line == 0 ||
+      !getFileNameByIndex(Row.File, CompDir, Kind, Result.FileName))
     return false;
   Result.Line = Row.Line;
   Result.Column = Row.Column;

--- a/llvm/test/tools/llvm-symbolizer/skip-line-zero.s
+++ b/llvm/test/tools/llvm-symbolizer/skip-line-zero.s
@@ -20,13 +20,13 @@
 ## Check that without '--skip-line-zero', line zero is displayed for a line-table entry which has no source correspondence.
 # RUN: llvm-symbolizer --obj=%t.o -f=none 0x16d4 | FileCheck --strict-whitespace --match-full-lines --check-prefix=DISABLE %s
 
-# DISABLE:main.c:0:0
+# DISABLE:??:0:0
 
 ## Check that the '--skip-line-zero' does not cross sequence boundaries.
 ## If it fails to find in the current sequence then line zero is returned for the queried address.
 # RUN: llvm-symbolizer --obj=%t.o -f=none --skip-line-zero 0x16c0 | FileCheck --strict-whitespace --match-full-lines --check-prefix=FAIL-ACROSS-SEQ %s
 
-# FAIL-ACROSS-SEQ:main.c:0:0
+# FAIL-ACROSS-SEQ:??:0:0
 
 ## Check that with '--skip-line-zero', the last non-zero line in the current sequence is displayed.
 # RUN: llvm-symbolizer --obj=%t.o -f=none --skip-line-zero 0x1717 | FileCheck --strict-whitespace --match-full-lines --check-prefix=WITHIN-SEQ %s

--- a/llvm/test/tools/llvm-symbolizer/sym-verbose.test
+++ b/llvm/test/tools/llvm-symbolizer/sym-verbose.test
@@ -50,13 +50,12 @@ CHECK-NEXT: Column: 0
 
 CHECK: 0x4005ad
 CHECK-NEXT: foo
-CHECK-NEXT: Filename: /tmp{{[\\/]}}discrim.c
+CHECK-NEXT: Filename: ??
 CHECK-NEXT: Function start filename: /tmp{{[\\/]}}discrim.c
 CHECK-NEXT: Function start line: 4
 CHECK-NEXT: Function start address: 0x400590
 CHECK-NEXT: Line: 0
-CHECK-NEXT: Column: 30
-CHECK-NEXT: Discriminator: 4
+CHECK-NEXT: Column: 0
 CHECK-NEXT: main
 CHECK-NEXT: Filename: /tmp{{[\\/]}}discrim.c
 CHECK-NEXT: Function start filename: /tmp{{[\\/]}}discrim.c

--- a/offload/test/sanitizer/kernel_crash_many.c
+++ b/offload/test/sanitizer/kernel_crash_many.c
@@ -37,36 +37,36 @@ int main(void) {
 // CHECK: Kernel 1: {{.*}} (__omp_offloading_{{.*}}_main_l22)
 // CHECK:     launchKernel
 // NDEBG:     main
-// DEBUG:     main {{.*}}kernel_crash_many.c:
+// DEBUG:     main {{.*}}kernel_crash_many.c
 //
 // CHECK: Kernel 2: {{.*}} (__omp_offloading_{{.*}}_main_l22)
 // CHECK:     launchKernel
 // NDEBG:     main
-// DEBUG:     main {{.*}}kernel_crash_many.c:
+// DEBUG:     main {{.*}}kernel_crash_many.c
 //
 // CHECK: Kernel 3: {{.*}} (__omp_offloading_{{.*}}_main_l22)
 // CHECK:     launchKernel
 // NDEBG:     main
-// DEBUG:     main {{.*}}kernel_crash_many.c:
+// DEBUG:     main {{.*}}kernel_crash_many.c
 //
 // CHECK: Kernel 4: {{.*}} (__omp_offloading_{{.*}}_main_l22)
 // CHECK:     launchKernel
 // NDEBG:     main
-// DEBUG:     main {{.*}}kernel_crash_many.c:
+// DEBUG:     main {{.*}}kernel_crash_many.c
 //
 // CHECK: Kernel 5: {{.*}} (__omp_offloading_{{.*}}_main_l22)
 // CHECK:     launchKernel
 // NDEBG:     main
-// DEBUG:     main {{.*}}kernel_crash_many.c:
+// DEBUG:     main {{.*}}kernel_crash_many.c
 //
 // CHECK: Kernel 6: {{.*}} (__omp_offloading_{{.*}}_main_l22)
 // CHECK:     launchKernel
 // NDEBG:     main
-// DEBUG:     main {{.*}}kernel_crash_many.c:
+// DEBUG:     main {{.*}}kernel_crash_many.c
 //
 // CHECK: Kernel 7: {{.*}} (__omp_offloading_{{.*}}_main_l22)
 // CHECK:     launchKernel
 // NDEBG:     main
-// DEBUG:     main {{.*}}kernel_crash_many.c:
+// DEBUG:     main {{.*}}kernel_crash_many.c
 //
 // CHECK-NOT: Kernel {{[[0-9]]+}}:

--- a/offload/test/sanitizer/kernel_trap.c
+++ b/offload/test/sanitizer/kernel_trap.c
@@ -39,5 +39,4 @@ int main(void) {
 // CHECK: OFFLOAD ERROR: Kernel 'omp target in main @ 30 (__omp_offloading_{{.*}}_main_l30)'
 // CHECK: OFFLOAD ERROR: execution interrupted by hardware trap instruction
 // TRACE:     launchKernel
-// TRACE:     main
 // clang-format on

--- a/offload/test/sanitizer/kernel_trap.cpp
+++ b/offload/test/sanitizer/kernel_trap.cpp
@@ -47,6 +47,6 @@ int main(void) {
 // TRACE:     launchKernel
 // NDEBG:     cxx_function_name<S>(int, S*)
 // NDEBG:     main
-// DEBUG:     cxx_function_name<S>(int, S*) {{.*}}kernel_trap.cpp:
-// DEBUG:     main {{.*}}kernel_trap.cpp:
+// DEBUG:     cxx_function_name<S>(int, S*) {{.*}}kernel_trap.cpp
+// DEBUG:     main {{.*}}kernel_trap.cpp
 // clang-format on

--- a/offload/test/sanitizer/kernel_trap_many.c
+++ b/offload/test/sanitizer/kernel_trap_many.c
@@ -32,4 +32,4 @@ int main(void) {
 // TRACE: OFFLOAD ERROR: execution interrupted by hardware trap instruction
 // TRACE:     launchKernel
 // NDEBG:     main
-// DEBUG:     main {{.*}}kernel_trap_many.c:
+// DEBUG:     main {{.*}}kernel_trap_many.c


### PR DESCRIPTION
This land commits 23aca2f88dd5d2447e69496c89c3ed42a56f9c31 and 1b15a89a23c631a8e2d096dad4afe456970572c0. https://github.com/llvm/llvm-project/pull/128619 makes symbolizer to always use debug info when available so we can reland this chagnge.