### PR TITLE
[HLSL][RootSignature] Implement initial parsing of the descriptor table clause params

### DIFF
--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1835,5 +1835,6 @@ def err_hlsl_unexpected_end_of_params
     : Error<"expected %0 to denote end of parameters, or, another valid parameter of %1">;
 def err_hlsl_rootsig_repeat_param : Error<"specified the same parameter '%0' multiple times">;
 def err_hlsl_rootsig_missing_param : Error<"did not specify mandatory parameter '%0'">;
+def err_hlsl_number_literal_overflow : Error<"integer literal is too large to be represented as a 32-bit %select{signed |}0 integer type">;
 
 } // end of Parser diagnostics

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1830,8 +1830,10 @@ def err_hlsl_virtual_function
 def err_hlsl_virtual_inheritance
     : Error<"virtual inheritance is unsupported in HLSL">;
 
-// HLSL Root Siganture diagnostic messages
+// HLSL Root Signature Parser Diagnostics
 def err_hlsl_unexpected_end_of_params
     : Error<"expected %0 to denote end of parameters, or, another valid parameter of %1">;
+def err_hlsl_rootsig_repeat_param : Error<"specified the same parameter '%0' multiple times">;
+def err_hlsl_rootsig_missing_param : Error<"did not specify mandatory parameter '%0'">;
 
 } // end of Parser diagnostics

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -69,59 +69,13 @@ private:
   bool parseDescriptorTable();
   bool parseDescriptorTableClause();
 
-  /// Parameter arguments (eg. `bReg`, `space`, ...) can be specified in any
-  /// order and only exactly once. `ParsedParamState` provides a common
-  /// stateful structure to facilitate a common abstraction over collecting
-  /// parameters. By having a common return type we can follow clang's pattern
-  /// of first parsing out the values and then validating when we construct
-  /// the corresponding in-memory RootElements.
-  struct ParsedParamState {
-    // Parameter state to hold the parsed values. The value is only guarentted
-    // to be correct if one of its keyword bits is set in `Seen`.
-    // Eg) if any of the seen bits for `bReg, tReg, uReg, sReg` are set, then
-    // Register will have an initialized value
-    llvm::hlsl::rootsig::Register Register;
-    uint32_t Space;
-
-    // Seen retains whether or not the corresponding keyword has been
-    // seen
-    uint32_t Seen = 0u;
-
-    // Valid keywords for the different parameter types and its corresponding
-    // parsed value
-    ArrayRef<RootSignatureToken::Kind> Keywords;
-
-    // Context of which RootElement is retained to dispatch on the correct
-    // parse method.
-    // Eg) If we encounter kw_flags, it will depend on Context
-    // we are parsing to determine which `parse*Flags` method to call
-    RootSignatureToken::Kind Context;
-
-    // Retain start of params for reporting diagnostics
-    SourceLocation StartLoc;
-
-    // Must provide the starting context of the parameters
-    ParsedParamState(ArrayRef<RootSignatureToken::Kind> Keywords,
-                     RootSignatureToken::Kind Context, SourceLocation StartLoc)
-        : Keywords(Keywords), Context(Context), StartLoc(StartLoc) {}
-
-    // Helper functions to interact with Seen
-    size_t getKeywordIdx(RootSignatureToken::Kind Keyword);
-    bool checkAndSetSeen(RootSignatureToken::Kind Keyword);
-    bool checkAndClearSeen(RootSignatureToken::Kind Keyword);
+  struct ParsedParams {
+    std::optional<llvm::hlsl::rootsig::Register> Register;
+    std::optional<uint32_t> Space;
   };
-
-  /// Root signature parameters follow the form of `keyword` `=` `value`, or,
-  /// are a register. Given a keyword and the context of which `RootElement`
-  /// type we are parsing, we can dispatch onto the correct parseMethod to
-  /// parse a value into the `ParsedParamState`.
-  ///
-  /// This function implements the dispatch onto the correct parse method.
-  bool parseParam(ParsedParamState &Params);
-
-  /// Parses out a `ParsedParamState` for the caller to use for construction
+  /// Parses out a `ParsedParams` for the caller to use for construction
   /// of the in-memory representation of a Root Element.
-  bool parseParams(ParsedParamState &Params);
+  bool parseDescriptorTableClauseParams(ParsedParams &Params, RootSignatureToken::Kind RegType);
 
   /// Parameter parse methods corresponding to a ParamType
   bool parseUIntParam(uint32_t &X);

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -40,26 +40,31 @@ public:
 private:
   DiagnosticsEngine &getDiags() { return PP.getDiagnostics(); }
 
-  // All private Parse.* methods follow a similar pattern:
+  // All private parse.* methods follow a similar pattern:
   //   - Each method will start with an assert to denote what the CurToken is
   // expected to be and will parse from that token forward
   //
   //   - Therefore, it is the callers responsibility to ensure that you are
   // at the correct CurToken. This should be done with the pattern of:
   //
-  //  if (TryConsumeExpectedToken(RootSignatureToken::Kind))
-  //    if (Parse.*())
-  //      return true;
+  //  if (tryConsumeExpectedToken(RootSignatureToken::Kind)) {
+  //    auto ParsedObject = parse.*();
+  //    if (!ParsedObject.has_value())
+  //      return std::nullopt;
+  //    ...
+  // }
   //
   // or,
   //
-  //  if (ConsumeExpectedToken(RootSignatureToken::Kind, ...))
-  //    return true;
-  //  if (Parse.*())
-  //    return true;
+  //  if (consumeExpectedToken(RootSignatureToken::Kind, ...))
+  //    return std::nullopt;
+  //  auto ParsedObject = parse.*();
+  //  if (!ParsedObject.has_value())
+  //    return std::nullopt;
+  //  ...
   //
-  //   - All methods return true if a parsing error is encountered. It is the
-  // callers responsibility to propogate this error up, or deal with it
+  //   - All methods return std::nullopt if a parsing error is encountered. It
+  // is the callers responsibility to propogate this error up, or deal with it
   // otherwise
   //
   //   - An error will be raised if the proceeding tokens are not what is
@@ -69,21 +74,22 @@ private:
   bool parseDescriptorTable();
   bool parseDescriptorTableClause();
 
-  struct ParsedParams {
+  /// Parameter arguments (eg. `bReg`, `space`, ...) can be specified in any
+  /// order and only exactly once. `ParsedClauseParams` denotes the current
+  /// state of parsed params
+  struct ParsedClauseParams {
     std::optional<llvm::hlsl::rootsig::Register> Register;
     std::optional<uint32_t> Space;
   };
-  /// Parses out a `ParsedParams` for the caller to use for construction
-  /// of the in-memory representation of a Root Element.
-  bool parseDescriptorTableClauseParams(ParsedParams &Params, RootSignatureToken::Kind RegType);
+  std::optional<ParsedClauseParams>
+  parseDescriptorTableClauseParams(RootSignatureToken::Kind RegType);
 
-  /// Parameter parse methods corresponding to a ParamType
-  bool parseUIntParam(uint32_t &X);
-  bool parseRegister(llvm::hlsl::rootsig::Register &Reg);
+  std::optional<uint32_t> parseUIntParam();
+  std::optional<llvm::hlsl::rootsig::Register> parseRegister();
 
   /// Use NumericLiteralParser to convert CurToken.NumSpelling into a unsigned
   /// 32-bit integer
-  bool handleUIntLiteral(uint32_t &X);
+  std::optional<uint32_t> handleUIntLiteral();
 
   /// Invoke the Lexer to consume a token and update CurToken with the result
   void consumeNextToken() { CurToken = Lexer.ConsumeToken(); }

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -69,8 +69,8 @@ private:
   bool parseDescriptorTable();
   bool parseDescriptorTableClause();
 
-  /// Each unique ParamType will have a custom parse method defined that we can
-  /// use to invoke the parameters.
+  /// Each unique ParamType will have a custom parse method defined that can be
+  /// invoked to set a value to the referenced paramtype.
   ///
   /// This function will switch on the ParamType using std::visit and dispatch
   /// onto the corresponding parse method
@@ -86,7 +86,7 @@ private:
   ///    TokenKind::kw_space, &Clause.Space
   ///  };
   ///  SmallDenseSet<TokenKind> Mandatory = {
-  ///    TokenKind::kw_numDescriptors
+  ///    TokenKind::bReg
   ///  };
   ///
   /// We can read it is as:

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -101,6 +101,14 @@ private:
       llvm::SmallDenseMap<TokenKind, llvm::hlsl::rootsig::ParamType> &Params,
       llvm::SmallDenseSet<TokenKind> &Mandatory);
 
+  /// Parameter parse methods corresponding to a ParamType
+  bool parseUIntParam(uint32_t *X);
+  bool parseRegister(llvm::hlsl::rootsig::Register *Reg);
+
+  /// Use NumericLiteralParser to convert CurToken.NumSpelling into a unsigned
+  /// 32-bit integer
+  bool handleUIntLiteral(uint32_t *X);
+
   /// Invoke the Lexer to consume a token and update CurToken with the result
   void consumeNextToken() { CurToken = Lexer.ConsumeToken(); }
 

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -69,6 +69,38 @@ private:
   bool parseDescriptorTable();
   bool parseDescriptorTableClause();
 
+  /// Each unique ParamType will have a custom parse method defined that we can
+  /// use to invoke the parameters.
+  ///
+  /// This function will switch on the ParamType using std::visit and dispatch
+  /// onto the corresponding parse method
+  bool parseParam(llvm::hlsl::rootsig::ParamType Ref);
+
+  /// Parameter arguments (eg. `bReg`, `space`, ...) can be specified in any
+  /// order, exactly once, and only a subset are mandatory. This function acts
+  /// as the infastructure to do so in a declarative way.
+  ///
+  /// For the example:
+  ///  SmallDenseMap<TokenKind, ParamType> Params = {
+  ///    TokenKind::bReg, &Clause.Register,
+  ///    TokenKind::kw_space, &Clause.Space
+  ///  };
+  ///  SmallDenseSet<TokenKind> Mandatory = {
+  ///    TokenKind::kw_numDescriptors
+  ///  };
+  ///
+  /// We can read it is as:
+  ///
+  /// when 'b0' is encountered, invoke the parse method for the type
+  ///   of &Clause.Register (Register *) and update the parameter
+  /// when 'space' is encountered, invoke a parse method for the type
+  ///   of &Clause.Space (uint32_t *) and update the parameter
+  ///
+  /// and 'bReg' must be specified
+  bool parseParams(
+      llvm::SmallDenseMap<TokenKind, llvm::hlsl::rootsig::ParamType> &Params,
+      llvm::SmallDenseSet<TokenKind> &Mandatory);
+
   /// Invoke the Lexer to consume a token and update CurToken with the result
   void consumeNextToken() { CurToken = Lexer.ConsumeToken(); }
 

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -97,9 +97,9 @@ private:
   ///   of &Clause.Space (uint32_t *) and update the parameter
   ///
   /// and 'bReg' must be specified
-  bool parseParams(
-      llvm::SmallDenseMap<RootSignatureToken::Kind, llvm::hlsl::rootsig::ParamType> &Params,
-      llvm::SmallDenseSet<RootSignatureToken::Kind> &Mandatory);
+  bool parseParams(llvm::SmallDenseMap<RootSignatureToken::Kind,
+                                       llvm::hlsl::rootsig::ParamType> &Params,
+                   llvm::SmallDenseSet<RootSignatureToken::Kind> &Mandatory);
 
   /// Parameter parse methods corresponding to a ParamType
   bool parseUIntParam(uint32_t *X);

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -81,12 +81,12 @@ private:
   /// as the infastructure to do so in a declarative way.
   ///
   /// For the example:
-  ///  SmallDenseMap<TokenKind, ParamType> Params = {
-  ///    TokenKind::bReg, &Clause.Register,
-  ///    TokenKind::kw_space, &Clause.Space
+  ///  SmallDenseMap<RootSignatureToken::Kind, ParamType> Params = {
+  ///    RootSignatureToken::Kind::bReg, &Clause.Register,
+  ///    RootSignatureToken::Kind::kw_space, &Clause.Space
   ///  };
-  ///  SmallDenseSet<TokenKind> Mandatory = {
-  ///    TokenKind::bReg
+  ///  SmallDenseSet<RootSignatureToken::Kind> Mandatory = {
+  ///    RootSignatureToken::Kind::bReg
   ///  };
   ///
   /// We can read it is as:
@@ -98,8 +98,8 @@ private:
   ///
   /// and 'bReg' must be specified
   bool parseParams(
-      llvm::SmallDenseMap<TokenKind, llvm::hlsl::rootsig::ParamType> &Params,
-      llvm::SmallDenseSet<TokenKind> &Mandatory);
+      llvm::SmallDenseMap<RootSignatureToken::Kind, llvm::hlsl::rootsig::ParamType> &Params,
+      llvm::SmallDenseSet<RootSignatureToken::Kind> &Mandatory);
 
   /// Parameter parse methods corresponding to a ParamType
   bool parseUIntParam(uint32_t *X);

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -210,6 +210,8 @@ bool RootSignatureParser::parseRegister(Register *Register) {
       "Expects to only be invoked starting at given keyword");
 
   switch (CurToken.Kind) {
+  default:
+    llvm_unreachable("Switch for consumed token was not provided");
   case TokenKind::bReg:
     Register->ViewType = RegisterType::BReg;
     break;
@@ -222,8 +224,6 @@ bool RootSignatureParser::parseRegister(Register *Register) {
   case TokenKind::sReg:
     Register->ViewType = RegisterType::SReg;
     break;
-  default:
-    break; // Unreachable given Try + assert pattern
   }
 
   if (handleUIntLiteral(&Register->Number))

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -138,12 +138,15 @@ bool RootSignatureParser::parseDescriptorTableClause() {
 }
 
 // Helper struct defined to use the overloaded notation of std::visit.
-template <class... Ts> struct ParseMethods : Ts... { using Ts::operator()...; };
-template <class... Ts> ParseMethods(Ts...) -> ParseMethods<Ts...>;
+template <class... Ts> struct ParseParamTypeMethods : Ts... {
+  using Ts::operator()...;
+};
+template <class... Ts>
+ParseParamTypeMethods(Ts...) -> ParseParamTypeMethods<Ts...>;
 
 bool RootSignatureParser::parseParam(ParamType Ref) {
   return std::visit(
-      ParseMethods{
+      ParseParamTypeMethods{
           [this](Register *X) -> bool { return parseRegister(X); },
           [this](uint32_t *X) -> bool {
             return consumeExpectedToken(TokenKind::pu_equal,

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -43,12 +43,11 @@ bool RootSignatureParser::parse() {
       break;
   }
 
-  if (!tryConsumeExpectedToken(TokenKind::end_of_stream)) {
-    getDiags().Report(CurToken.TokLoc, diag::err_hlsl_unexpected_end_of_params)
-        << /*expected=*/TokenKind::end_of_stream
-        << /*param of=*/TokenKind::kw_RootSignature;
+  if (consumeExpectedToken(TokenKind::end_of_stream,
+                           diag::err_hlsl_unexpected_end_of_params,
+                           /*param of=*/TokenKind::kw_RootSignature))
     return true;
-  }
+
   return false;
 }
 
@@ -74,12 +73,10 @@ bool RootSignatureParser::parseDescriptorTable() {
       break;
   }
 
-  if (!tryConsumeExpectedToken(TokenKind::pu_r_paren)) {
-    getDiags().Report(CurToken.TokLoc, diag::err_hlsl_unexpected_end_of_params)
-        << /*expected=*/TokenKind::pu_r_paren
-        << /*param of=*/TokenKind::kw_DescriptorTable;
+  if (consumeExpectedToken(TokenKind::pu_r_paren,
+                           diag::err_hlsl_unexpected_end_of_params,
+                           /*param of=*/TokenKind::kw_DescriptorTable))
     return true;
-  }
 
   Elements.push_back(Table);
   return false;
@@ -132,7 +129,7 @@ bool RootSignatureParser::parseDescriptorTableClause() {
     return true;
 
   if (consumeExpectedToken(TokenKind::pu_r_paren, diag::err_hlsl_unexpected_end_of_params,
-                           ParamKind))
+                           /*param of=*/ParamKind))
     return true;
 
   Elements.push_back(Clause);
@@ -279,6 +276,7 @@ bool RootSignatureParser::consumeExpectedToken(TokenKind Expected,
   case diag::err_expected:
     DB << Expected;
     break;
+  case diag::err_hlsl_unexpected_end_of_params:
   case diag::err_expected_either:
   case diag::err_expected_after:
     DB << Expected << Context;

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -147,7 +147,7 @@ bool RootSignatureParser::parseParam(ParamType Ref) {
           [this](uint32_t *X) -> bool {
             return consumeExpectedToken(TokenKind::pu_equal,
                                         diag::err_expected_after,
-                                        CurToken.Kind) ||
+                                        CurToken.TokKind) ||
                    parseUIntParam(X);
           },
       },
@@ -167,14 +167,14 @@ bool RootSignatureParser::parseParams(
   llvm::SmallDenseSet<TokenKind> Seen;
 
   while (tryConsumeExpectedToken(Keywords)) {
-    if (Seen.contains(CurToken.Kind)) {
+    if (Seen.contains(CurToken.TokKind)) {
       getDiags().Report(CurToken.TokLoc, diag::err_hlsl_rootsig_repeat_param)
-          << CurToken.Kind;
+          << CurToken.TokKind;
       return true;
     }
-    Seen.insert(CurToken.Kind);
+    Seen.insert(CurToken.TokKind);
 
-    if (parseParam(Params[CurToken.Kind]))
+    if (parseParam(Params[CurToken.TokKind]))
       return true;
 
     if (!tryConsumeExpectedToken(TokenKind::pu_comma))
@@ -195,21 +195,21 @@ bool RootSignatureParser::parseParams(
 }
 
 bool RootSignatureParser::parseUIntParam(uint32_t *X) {
-  assert(CurToken.Kind == TokenKind::pu_equal &&
+  assert(CurToken.TokKind == TokenKind::pu_equal &&
          "Expects to only be invoked starting at given keyword");
   tryConsumeExpectedToken(TokenKind::pu_plus);
   return consumeExpectedToken(TokenKind::int_literal, diag::err_expected_after,
-                              CurToken.Kind) ||
+                              CurToken.TokKind) ||
          handleUIntLiteral(X);
 }
 
 bool RootSignatureParser::parseRegister(Register *Register) {
   assert(
-      (CurToken.Kind == TokenKind::bReg || CurToken.Kind == TokenKind::tReg ||
-       CurToken.Kind == TokenKind::uReg || CurToken.Kind == TokenKind::sReg) &&
+      (CurToken.TokKind == TokenKind::bReg || CurToken.TokKind == TokenKind::tReg ||
+       CurToken.TokKind == TokenKind::uReg || CurToken.TokKind == TokenKind::sReg) &&
       "Expects to only be invoked starting at given keyword");
 
-  switch (CurToken.Kind) {
+  switch (CurToken.TokKind) {
   default:
     llvm_unreachable("Switch for consumed token was not provided");
   case TokenKind::bReg:

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -128,7 +128,8 @@ bool RootSignatureParser::parseDescriptorTableClause() {
   if (parseParams(Params, Mandatory))
     return true;
 
-  if (consumeExpectedToken(TokenKind::pu_r_paren, diag::err_hlsl_unexpected_end_of_params,
+  if (consumeExpectedToken(TokenKind::pu_r_paren,
+                           diag::err_hlsl_unexpected_end_of_params,
                            /*param of=*/ParamKind))
     return true;
 
@@ -204,10 +205,11 @@ bool RootSignatureParser::parseUIntParam(uint32_t *X) {
 }
 
 bool RootSignatureParser::parseRegister(Register *Register) {
-  assert(
-      (CurToken.TokKind == TokenKind::bReg || CurToken.TokKind == TokenKind::tReg ||
-       CurToken.TokKind == TokenKind::uReg || CurToken.TokKind == TokenKind::sReg) &&
-      "Expects to only be invoked starting at given keyword");
+  assert((CurToken.TokKind == TokenKind::bReg ||
+          CurToken.TokKind == TokenKind::tReg ||
+          CurToken.TokKind == TokenKind::uReg ||
+          CurToken.TokKind == TokenKind::sReg) &&
+         "Expects to only be invoked starting at given keyword");
 
   switch (CurToken.TokKind) {
   default:

--- a/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
@@ -130,10 +130,10 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseEmptyTest) {
 TEST_F(ParseHLSLRootSignatureTest, ValidParseDTClausesTest) {
   const llvm::StringLiteral Source = R"cc(
     DescriptorTable(
-      CBV(),
-      SRV(),
-      Sampler(),
-      UAV()
+      CBV(b0),
+      SRV(space = 3, t42),
+      Sampler(s987, space = +2),
+      UAV(u4294967294)
     ),
     DescriptorTable()
   )cc";
@@ -155,18 +155,34 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseDTClausesTest) {
   RootElement Elem = Elements[0];
   ASSERT_TRUE(std::holds_alternative<DescriptorTableClause>(Elem));
   ASSERT_EQ(std::get<DescriptorTableClause>(Elem).Type, ClauseType::CBuffer);
+  ASSERT_EQ(std::get<DescriptorTableClause>(Elem).Register.ViewType,
+            RegisterType::BReg);
+  ASSERT_EQ(std::get<DescriptorTableClause>(Elem).Register.Number, 0u);
+  ASSERT_EQ(std::get<DescriptorTableClause>(Elem).Space, 0u);
 
   Elem = Elements[1];
   ASSERT_TRUE(std::holds_alternative<DescriptorTableClause>(Elem));
   ASSERT_EQ(std::get<DescriptorTableClause>(Elem).Type, ClauseType::SRV);
+  ASSERT_EQ(std::get<DescriptorTableClause>(Elem).Register.ViewType,
+            RegisterType::TReg);
+  ASSERT_EQ(std::get<DescriptorTableClause>(Elem).Register.Number, 42u);
+  ASSERT_EQ(std::get<DescriptorTableClause>(Elem).Space, 3u);
 
   Elem = Elements[2];
   ASSERT_TRUE(std::holds_alternative<DescriptorTableClause>(Elem));
   ASSERT_EQ(std::get<DescriptorTableClause>(Elem).Type, ClauseType::Sampler);
+  ASSERT_EQ(std::get<DescriptorTableClause>(Elem).Register.ViewType,
+            RegisterType::SReg);
+  ASSERT_EQ(std::get<DescriptorTableClause>(Elem).Register.Number, 987u);
+  ASSERT_EQ(std::get<DescriptorTableClause>(Elem).Space, 2u);
 
   Elem = Elements[3];
   ASSERT_TRUE(std::holds_alternative<DescriptorTableClause>(Elem));
   ASSERT_EQ(std::get<DescriptorTableClause>(Elem).Type, ClauseType::UAV);
+  ASSERT_EQ(std::get<DescriptorTableClause>(Elem).Register.ViewType,
+            RegisterType::UReg);
+  ASSERT_EQ(std::get<DescriptorTableClause>(Elem).Register.Number, 4294967294u);
+  ASSERT_EQ(std::get<DescriptorTableClause>(Elem).Space, 0u);
 
   Elem = Elements[4];
   ASSERT_TRUE(std::holds_alternative<DescriptorTable>(Elem));
@@ -176,6 +192,32 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseDTClausesTest) {
   Elem = Elements[5];
   ASSERT_TRUE(std::holds_alternative<DescriptorTable>(Elem));
   ASSERT_EQ(std::get<DescriptorTable>(Elem).NumClauses, 0u);
+
+  ASSERT_TRUE(Consumer->isSatisfied());
+}
+
+TEST_F(ParseHLSLRootSignatureTest, ValidTrailingCommaTest) {
+  // This test will checks we can handling trailing commas ','
+  const llvm::StringLiteral Source = R"cc(
+    DescriptorTable(
+      CBV(b0, ),
+      SRV(t42),
+    )
+  )cc";
+
+  TrivialModuleLoader ModLoader;
+  auto PP = createPP(Source, ModLoader);
+  auto TokLoc = SourceLocation();
+
+  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  SmallVector<RootElement> Elements;
+  hlsl::RootSignatureParser Parser(Elements, Lexer, *PP);
+
+  // Test no diagnostics produced
+  Consumer->setNoDiag();
+
+  ASSERT_FALSE(Parser.parse());
+
   ASSERT_TRUE(Consumer->isSatisfied());
 }
 
@@ -237,6 +279,102 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidParseUnexpectedEndOfStreamTest) {
 
   // Test correct diagnostic produced - end of stream
   Consumer->setExpected(diag::err_expected_after);
+
+  ASSERT_TRUE(Parser.parse());
+
+  ASSERT_TRUE(Consumer->isSatisfied());
+}
+
+TEST_F(ParseHLSLRootSignatureTest, InvalidMissingParameterTest) {
+  // This test will check that the parsing fails due a mandatory
+  // parameter (register) not being specified
+  const llvm::StringLiteral Source = R"cc(
+    DescriptorTable(
+      CBV()
+    )
+  )cc";
+
+  TrivialModuleLoader ModLoader;
+  auto PP = createPP(Source, ModLoader);
+  auto TokLoc = SourceLocation();
+
+  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  SmallVector<RootElement> Elements;
+  hlsl::RootSignatureParser Parser(Elements, Lexer, *PP);
+
+  // Test correct diagnostic produced
+  Consumer->setExpected(diag::err_hlsl_rootsig_missing_param);
+  ASSERT_TRUE(Parser.parse());
+
+  ASSERT_TRUE(Consumer->isSatisfied());
+}
+
+TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedMandatoryParameterTest) {
+  // This test will check that the parsing fails due the same mandatory
+  // parameter being specified multiple times
+  const llvm::StringLiteral Source = R"cc(
+    DescriptorTable(
+      CBV(b32, b84)
+    )
+  )cc";
+
+  TrivialModuleLoader ModLoader;
+  auto PP = createPP(Source, ModLoader);
+  auto TokLoc = SourceLocation();
+
+  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  SmallVector<RootElement> Elements;
+  hlsl::RootSignatureParser Parser(Elements, Lexer, *PP);
+
+  // Test correct diagnostic produced
+  Consumer->setExpected(diag::err_hlsl_rootsig_repeat_param);
+  ASSERT_TRUE(Parser.parse());
+
+  ASSERT_TRUE(Consumer->isSatisfied());
+}
+
+TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedOptionalParameterTest) {
+  // This test will check that the parsing fails due the same optional
+  // parameter being specified multiple times
+  const llvm::StringLiteral Source = R"cc(
+    DescriptorTable(
+      CBV(space = 2, space = 0)
+    )
+  )cc";
+
+  TrivialModuleLoader ModLoader;
+  auto PP = createPP(Source, ModLoader);
+  auto TokLoc = SourceLocation();
+
+  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  SmallVector<RootElement> Elements;
+  hlsl::RootSignatureParser Parser(Elements, Lexer, *PP);
+
+  // Test correct diagnostic produced
+  Consumer->setExpected(diag::err_hlsl_rootsig_repeat_param);
+  ASSERT_TRUE(Parser.parse());
+
+  ASSERT_TRUE(Consumer->isSatisfied());
+}
+
+TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedNumberTest) {
+  // This test will check that the lexing fails due to an integer overflow
+  const llvm::StringLiteral Source = R"cc(
+    DescriptorTable(
+      CBV(b4294967296)
+    )
+  )cc";
+
+  TrivialModuleLoader ModLoader;
+  auto PP = createPP(Source, ModLoader);
+  auto TokLoc = SourceLocation();
+
+  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  SmallVector<RootElement> Elements;
+  hlsl::RootSignatureParser Parser(Elements, Lexer, *PP);
+
+  // Test correct diagnostic produced
+  Consumer->setExpected(diag::err_hlsl_number_literal_overflow);
   ASSERT_TRUE(Parser.parse());
 
   ASSERT_TRUE(Consumer->isSatisfied());

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -46,12 +46,6 @@ struct DescriptorTableClause {
 // Models RootElement : DescriptorTable | DescriptorTableClause
 using RootElement = std::variant<DescriptorTable, DescriptorTableClause>;
 
-// ParamType is used as an 'any' type that will reference to a parameter in
-// RootElement. Each variant of ParamType is expected to have a Parse method
-// defined that will be dispatched on when we are attempting to parse a
-// parameter
-using ParamType = std::variant<uint32_t *, Register *>;
-
 } // namespace rootsig
 } // namespace hlsl
 } // namespace llvm

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -23,6 +23,13 @@ namespace rootsig {
 
 // Definitions of the in-memory data layout structures
 
+// Models the different registers: bReg | tReg | uReg | sReg
+enum class RegisterType { BReg, TReg, UReg, SReg };
+struct Register {
+  RegisterType ViewType;
+  uint32_t Number;
+};
+
 // Models the end of a descriptor table and stores its visibility
 struct DescriptorTable {
   uint32_t NumClauses = 0; // The number of clauses in the table
@@ -32,6 +39,8 @@ struct DescriptorTable {
 using ClauseType = llvm::dxil::ResourceClass;
 struct DescriptorTableClause {
   ClauseType Type;
+  Register Register;
+  uint32_t Space = 0;
 };
 
 // Models RootElement : DescriptorTable | DescriptorTableClause
@@ -41,7 +50,7 @@ using RootElement = std::variant<DescriptorTable, DescriptorTableClause>;
 // RootElement. Each variant of ParamType is expected to have a Parse method
 // defined that will be dispatched on when we are attempting to parse a
 // parameter
-using ParamType = std::variant<std::monostate>;
+using ParamType = std::variant<uint32_t *, Register *>;
 
 } // namespace rootsig
 } // namespace hlsl

--- a/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLRootSignature.h
@@ -37,6 +37,12 @@ struct DescriptorTableClause {
 // Models RootElement : DescriptorTable | DescriptorTableClause
 using RootElement = std::variant<DescriptorTable, DescriptorTableClause>;
 
+// ParamType is used as an 'any' type that will reference to a parameter in
+// RootElement. Each variant of ParamType is expected to have a Parse method
+// defined that will be dispatched on when we are attempting to parse a
+// parameter
+using ParamType = std::variant<std::monostate>;
+
 } // namespace rootsig
 } // namespace hlsl
 } // namespace llvm


### PR DESCRIPTION
- Defines `ParseDescriptorTableClauseParams` to establish the pattern of how we will parse parameters in root signatures. Namely, to use recursive descent parsing in a way that follows closely to the EBNF notation definition in the root signature spec.

- Implements parsing of two param types: `UInt32` and `Register` to demonstrate the parsing implementation and allow for unit testing

- Changes the calling convention to use `std::optional` return values instead of boolean error returns and parameters by reference

Part two of implementing: https://github.com/llvm/llvm-project/issues/126569