### PR TITLE
[alpha.webkit.ForwardDeclChecker] Ignore forward declared struct.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ForwardDeclChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ForwardDeclChecker.cpp
@@ -127,8 +127,8 @@ public:
     auto Name = R->getName();
     return !R->hasDefinition() && !RTC.isUnretained(QT) &&
            !SystemTypes.contains(CanonicalType) &&
-           !SystemTypes.contains(PointeeType) &&
-           !Name.starts_with("Opaque") && Name != "_NSZone";
+           !SystemTypes.contains(PointeeType) && !Name.starts_with("Opaque") &&
+           Name != "_NSZone";
   }
 
   void visitRecordDecl(const RecordDecl *RD, const Decl *DeclWithIssue) const {

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ForwardDeclChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ForwardDeclChecker.cpp
@@ -108,17 +108,16 @@ public:
     RTC.visitTypedef(TD);
     auto QT = TD->getUnderlyingType().getCanonicalType();
     if (BR->getSourceManager().isInSystemHeader(TD->getBeginLoc())) {
-      if (auto *Type = QT.getTypePtrOrNull(); Type && QT->isPointerType())
+      if (auto *Type = QT.getTypePtrOrNull())
         SystemTypes.insert(Type);
     }
   }
 
   bool isUnknownType(QualType QT) const {
-    auto *Type = QT.getTypePtrOrNull();
-    if (!Type)
-      return false;
     auto *CanonicalType = QT.getCanonicalType().getTypePtrOrNull();
-    auto PointeeQT = Type->getPointeeType();
+    if (!CanonicalType)
+      return false;
+    auto PointeeQT = CanonicalType->getPointeeType();
     auto *PointeeType = PointeeQT.getTypePtrOrNull();
     if (!PointeeType)
       return false;
@@ -128,6 +127,7 @@ public:
     auto Name = R->getName();
     return !R->hasDefinition() && !RTC.isUnretained(QT) &&
            !SystemTypes.contains(CanonicalType) &&
+           !SystemTypes.contains(PointeeType) &&
            !Name.starts_with("Opaque") && Name != "_NSZone";
   }
 

--- a/clang/test/Analysis/Checkers/WebKit/forward-decl-checker.mm
+++ b/clang/test/Analysis/Checkers/WebKit/forward-decl-checker.mm
@@ -25,6 +25,8 @@ class Obj;
 
 Obj* provide_obj_ptr();
 void receive_obj_ptr(Obj* p = nullptr);
+sqlite3* open_db();
+void close_db(sqlite3*);
 
 Obj* ptr(Obj* arg) {
   receive_obj_ptr(provide_obj_ptr());
@@ -34,6 +36,8 @@ Obj* ptr(Obj* arg) {
   receive_obj_ptr(arg);
   receive_obj_ptr(nullptr);
   receive_obj_ptr();
+  auto* db = open_db();
+  close_db(db);
   return obj;
 }
 

--- a/clang/test/Analysis/Checkers/WebKit/mock-system-header.h
+++ b/clang/test/Analysis/Checkers/WebKit/mock-system-header.h
@@ -16,6 +16,8 @@ struct MemberVariable {
     T* obj { nullptr };
 };
 
+typedef struct sqlite3 sqlite3;
+
 typedef unsigned char uint8_t;
 
 enum os_log_type_t : uint8_t {


### PR DESCRIPTION
There are some system libraries such as sqlite3 which forward declare a struct then use a pointer to that forward declared type in various APIs. Ignore these types ForwardDeclChecker like other pointer types.