### PR TITLE
[LLD][ELF] Support OVERLAY NOCROSSREFS

### DIFF
--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -565,7 +565,6 @@ SmallVector<SectionCommand *, 0> ScriptParser::readOverlay() {
     addrExpr = readExpr();
     expect(":");
   }
-
   bool noCrossRefs = consume("NOCROSSREFS");
   Expr lmaExpr = consume("AT") ? readParenExpr() : Expr{};
   expect("{");

--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -566,16 +566,9 @@ SmallVector<SectionCommand *, 0> ScriptParser::readOverlay() {
     expect(":");
   }
 
-  Expr lmaExpr;
-  bool noCrossRefs = false;
-  while (auto tok = till("{")) {
-    if (tok == "AT")
-      lmaExpr = readParenExpr();
-    else if (tok == "NOCROSSREFS")
-      noCrossRefs = true;
-    else
-      setError("{ expected, but got " + tok);
-  }
+  bool noCrossRefs = consume("NOCROSSREFS");
+  Expr lmaExpr = consume("AT") ? readParenExpr() : Expr{};
+  expect("{");
 
   SmallVector<SectionCommand *, 0> v;
   OutputSection *prev = nullptr;

--- a/lld/docs/ReleaseNotes.rst
+++ b/lld/docs/ReleaseNotes.rst
@@ -39,6 +39,9 @@ ELF Improvements
   items that kept it live during garbage collection. This is inspired by the
   Mach-O LLD feature of the same name.
 
+* Linker script ``OVERLAY`` descriptions now support virtual memory regions
+  (e.g. ``>region``) and ``NOCROSSREFS``.
+
 Breaking changes
 ----------------
 

--- a/lld/test/ELF/linkerscript/nocrossrefs.test
+++ b/lld/test/ELF/linkerscript/nocrossrefs.test
@@ -28,6 +28,10 @@
 # RUN: not ld.lld a.o data.o -T 3.t 2>&1 | FileCheck %s --check-prefix=CHECK3 --implicit-check-not=error:
 # CHECK3:      error: a.o:(.nonalloc+0x0): prohibited cross reference from '.nonalloc' to '.text' in '.text'
 
+# RUN: not ld.lld a.o data.o -T overlay.t 2>&1 | FileCheck %s --check-prefix=OVERLAY --implicit-check-not=error:
+# OVERLAY: error: a.o:(.text.start+0x11): prohibited cross reference from '.text' to 'data' in '.data'
+# OVERLAY-NEXT: error: a.o:(.text.start+0x17): prohibited cross reference from '.text' to 'str1' in '.rodata'
+
 #--- 0.t
 ## Some cases that do not cause errors.
 abs = 42;
@@ -49,6 +53,17 @@ NOCROSSREFS(.text .text1 .text2 .data .rodata .data .nonalloc)
 #--- 3.t
 abs = 42;
 NOCROSSREFS_TO(.text .text .text1 .text2 .data .nonalloc)
+
+#--- overlay.t
+abs = 42;
+_edata = 43;
+SECTIONS {
+  OVERLAY : NOCROSSREFS {
+    .text { *(.text*) }
+    .data { *(.data*) }
+    .rodata { *(.rodata*) }
+  }
+}
 
 #--- err1.t
 NOCROSSREFS )

--- a/lld/test/ELF/linkerscript/overlay.test
+++ b/lld/test/ELF/linkerscript/overlay.test
@@ -134,13 +134,10 @@ SECTIONS {
 # UNCLOSED:     error: unclosed.lds:2: unexpected EOF
 # UNCLOSED-NOT: {{.}}
 
-#--- invalid-before-brace.lds
-SECTIONS {
-  OVERLAY 0x1000 : INVALID {
-  }
-}
+#--- at-nocrossrefs-order.lds
+SECTIONS { OVERLAY 0x1000 : AT(0x1234) NOCROSSREFS {} }
 
-# RUN: not ld.lld a.o -T invalid-before-brace.lds 2>&1 | FileCheck %s --check-prefix=INVALID-BEFORE-BRACE --strict-whitespace
-# INVALID-BEFORE-BRACE:{{.*}}error: invalid-before-brace.lds:2: { expected, but got INVALID
-# INVALID-BEFORE-BRACE-NEXT:>>>   OVERLAY 0x1000 : INVALID {
-# INVALID-BEFORE-BRACE-NEXT:>>>                    ^
+# RUN: not ld.lld a.o -T at-nocrossrefs-order.lds 2>&1 | FileCheck %s --check-prefix=AT-NOCROSSREFS-ORDER --strict-whitespace
+# AT-NOCROSSREFS-ORDER:{{.*}}error: at-nocrossrefs-order.lds:1: { expected, but got NOCROSSREFS
+# AT-NOCROSSREFS-ORDER-NEXT:>>> SECTIONS { OVERLAY 0x1000 : AT(0x1234) NOCROSSREFS {} }
+# AT-NOCROSSREFS-ORDER-NEXT:>>>                                        ^

--- a/lld/test/ELF/linkerscript/overlay.test
+++ b/lld/test/ELF/linkerscript/overlay.test
@@ -133,3 +133,14 @@ SECTIONS {
 # RUN: not ld.lld a.o -T unclosed.lds 2>&1 | FileCheck %s --check-prefix=UNCLOSED
 # UNCLOSED:     error: unclosed.lds:2: unexpected EOF
 # UNCLOSED-NOT: {{.}}
+
+#--- invalid-before-brace.lds
+SECTIONS {
+  OVERLAY 0x1000 : INVALID {
+  }
+}
+
+# RUN: not ld.lld a.o -T invalid-before-brace.lds 2>&1 | FileCheck %s --check-prefix=INVALID-BEFORE-BRACE --strict-whitespace
+# INVALID-BEFORE-BRACE:{{.*}}error: invalid-before-brace.lds:2: { expected, but got INVALID
+# INVALID-BEFORE-BRACE-NEXT:>>>   OVERLAY 0x1000 : INVALID {
+# INVALID-BEFORE-BRACE-NEXT:>>>                    ^


### PR DESCRIPTION
This allows NOCROSSREFS to be specified in OVERLAY linker script descriptions. This is a particularly useful part of the OVERLAY syntax, since it's very rarely possible for one overlay section to sensibly reference another.

Closes #128790