### PR TITLE
[lldb-dap] Do not take ownership of stdin.

### DIFF
--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -571,9 +571,9 @@ int main(int argc, char *argv[]) {
   }
 
   lldb::IOObjectSP input = std::make_shared<NativeFile>(
-      fileno(stdin), File::eOpenOptionReadOnly, false);
+      fileno(stdin), File::eOpenOptionReadOnly, NativeFile::Unowned);
   lldb::IOObjectSP output = std::make_shared<NativeFile>(
-      stdout_fd, File::eOpenOptionWriteOnly, false);
+      stdout_fd, File::eOpenOptionWriteOnly, NativeFile::Unowned);
 
   constexpr llvm::StringLiteral client_name = "stdin/stdout";
   Transport transport(client_name, log.get(), input, output);

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -571,7 +571,7 @@ int main(int argc, char *argv[]) {
   }
 
   lldb::IOObjectSP input = std::make_shared<NativeFile>(
-      fileno(stdin), File::eOpenOptionReadOnly, true);
+      fileno(stdin), File::eOpenOptionReadOnly, false);
   lldb::IOObjectSP output = std::make_shared<NativeFile>(
       stdout_fd, File::eOpenOptionWriteOnly, false);
 


### PR DESCRIPTION
There isn't any benefit to taking ownership of stdin and it may cause issues if `Transport` is dealloced.