### PR TITLE
[CIR] Generate the nsw flag correctly for unary ops

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -702,10 +702,14 @@ def UnaryOp : CIR_Op<"unary", [Pure, SameOperandsAndResultType]> {
   }];
 
   let results = (outs CIR_AnyType:$result);
-  let arguments = (ins Arg<UnaryOpKind, "unary op kind">:$kind, Arg<CIR_AnyType>:$input);
+  let arguments = (ins Arg<UnaryOpKind, "unary op kind">:$kind,
+                   Arg<CIR_AnyType>:$input,
+                   UnitAttr:$no_signed_wrap);
 
   let assemblyFormat = [{
-      `(` $kind `,` $input `)` `:` type($input) `,` type($result) attr-dict
+      `(` $kind `,` $input `)`
+      (`nsw` $no_signed_wrap^)?
+      `:` type($input) `,` type($result) attr-dict 
   }];
 
   let hasVerifier = 1;

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -695,9 +695,12 @@ def UnaryOp : CIR_Op<"unary", [Pure, SameOperandsAndResultType]> {
     It requires one input operand and has one result, both types
     should be the same.
 
+    If the `nsw` (no signed wrap) attribute is present, the result is poison if
+    signed overflow occurs.
+
     ```mlir
     %7 = cir.unary(inc, %1) : i32 -> i32
-    %8 = cir.unary(dec, %2) : i32 -> i32
+    %8 = cir.unary(dec, %2) nsw : i32 -> i32
     ```
   }];
 
@@ -868,9 +871,21 @@ def BinOp : CIR_Op<"binop", [Pure,
     It requires two input operands and has one result, all types
     should be the same.
 
+    If the `nsw` (no signed wrap) or `nuw` (no unsigned wrap) attributes are
+    present, the result is poison if signed or unsigned overflow occurs
+    (respectively).
+
+    If the `sat` (saturated) attribute is present, the result is clamped to
+    the maximum value representatable by the type if it would otherwise
+    exceed that value and is clamped to the minimum representable value if
+    it would otherwise be below that value.
+
     ```mlir
-    %7 = cir.binop(add, %1, %2) : !s32i
-    %7 = cir.binop(mul, %1, %2) : !u8i
+    %5 = cir.binop(add, %1, %2) : !s32i
+    %6 = cir.binop(mul, %1, %2) : !u8i
+    %7 = cir.binop(add, %1, %2) nsw : !s32i
+    %8 = cir.binop(add, %3, %4) nuw : !u32i
+    %9 = cir.binop(add, %1, %2) sat : !s32i
     ```
   }];
 

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -76,7 +76,6 @@ struct MissingFeatures {
   static bool opScopeCleanupRegion() { return false; }
 
   // Unary operator handling
-  static bool opUnarySignedOverflow() { return false; }
   static bool opUnaryPromotionType() { return false; }
 
   // Clang early optimizations or things defered to LLVM lowering.

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -860,14 +860,8 @@ mlir::LogicalResult CIRToLLVMUnaryOpLowering::matchAndRewrite(
   // Integer unary operations: + - ~ ++ --
   if (mlir::isa<cir::IntType>(elementType)) {
     mlir::LLVM::IntegerOverflowFlags maybeNSW =
-        mlir::LLVM::IntegerOverflowFlags::none;
-    if (mlir::dyn_cast<cir::IntType>(elementType).isSigned()) {
-      assert(!cir::MissingFeatures::opUnarySignedOverflow());
-      // TODO: For now, assume signed overflow is undefined. We'll need to add
-      // an attribute to the unary op to control this.
-      maybeNSW = mlir::LLVM::IntegerOverflowFlags::nsw;
-    }
-
+        op.getNoSignedWrap() ? mlir::LLVM::IntegerOverflowFlags::nsw
+                             : mlir::LLVM::IntegerOverflowFlags::none;
     switch (op.getKind()) {
     case cir::UnaryOpKind::Inc: {
       assert(!isVector && "++ not allowed on vector types");

--- a/clang/test/CIR/IR/unary.cir
+++ b/clang/test/CIR/IR/unary.cir
@@ -1,0 +1,50 @@
+// RUN: cir-opt %s | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+!s64i = !cir.int<s, 64>
+!u32i = !cir.int<u, 32>
+!u64i = !cir.int<u, 64>
+
+module {
+  cir.func @test_unary_unsigned() {
+    %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["a"] {alignment = 4 : i64}
+    %1 = cir.load %0 : !cir.ptr<!u32i>, !u32i
+    %2 = cir.unary(plus, %1) : !u32i, !u32i
+    %3 = cir.unary(minus, %1) : !u32i, !u32i
+    %4 = cir.unary(not, %1) : !u32i, !u32i
+    %5 = cir.unary(inc, %1) : !u32i, !u32i
+    %6 = cir.unary(dec, %1) : !u32i, !u32i
+    cir.return
+  }
+// CHECK: cir.func @test_unary_unsigned() {
+// CHECK:   %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["a"] {alignment = 4 : i64}
+// CHECK:   %1 = cir.load %0 : !cir.ptr<!u32i>, !u32i
+// CHECK:   %2 = cir.unary(plus, %1) : !u32i, !u32i
+// CHECK:   %3 = cir.unary(minus, %1) : !u32i, !u32i
+// CHECK:   %4 = cir.unary(not, %1) : !u32i, !u32i
+// CHECK:   %5 = cir.unary(inc, %1) : !u32i, !u32i
+// CHECK:   %6 = cir.unary(dec, %1) : !u32i, !u32i
+// CHECK:   cir.return
+// CHECK: }
+
+  cir.func @test_unary_signed() {
+    %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["a"] {alignment = 4 : i64}
+    %1 = cir.load %0 : !cir.ptr<!s32i>, !s32i
+    %2 = cir.unary(plus, %1) : !s32i, !s32i
+    %3 = cir.unary(minus, %1) nsw : !s32i, !s32i
+    %4 = cir.unary(not, %1) : !s32i, !s32i
+    %5 = cir.unary(inc, %1) nsw : !s32i, !s32i
+    %6 = cir.unary(dec, %1) nsw : !s32i, !s32i
+    cir.return
+  }
+// CHECK: cir.func @test_unary_signed() {
+// CHECK:   %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["a"] {alignment = 4 : i64}
+// CHECK:   %1 = cir.load %0 : !cir.ptr<!s32i>, !s32i
+// CHECK:   %2 = cir.unary(plus, %1) : !s32i, !s32i
+// CHECK:   %3 = cir.unary(minus, %1) nsw : !s32i, !s32i
+// CHECK:   %4 = cir.unary(not, %1) : !s32i, !s32i
+// CHECK:   %5 = cir.unary(inc, %1) nsw : !s32i, !s32i
+// CHECK:   %6 = cir.unary(dec, %1) nsw : !s32i, !s32i
+// CHECK:   cir.return
+// CHECK: }
+}


### PR DESCRIPTION
A previous checkin used a workaround to generate the nsw flag where needed for unary ops. This change upstreams a subsequent change that was made in the incubator to generate the flag correctly.