### PR TITLE
[RISCV] Add exhaustive diassember tests for c.slli64. NFC

### DIFF
--- a/llvm/test/MC/Disassembler/RISCV/c_slli.txt
+++ b/llvm/test/MC/Disassembler/RISCV/c_slli.txt
@@ -14,6 +14,8 @@
 # RUN:     -M no-aliases --show-encoding < %s 2>&1 | \
 # RUN:   FileCheck --check-prefix=NOHINTS %s
 
+0x02 0x00 # GOOD: c.slli64 zero
+0x02 0x00 # NOHINTS: invalid instruction encoding
 0x06 0x00 # GOOD: c.slli zero, 1
 0x06 0x00 # NOHINTS: invalid instruction encoding
 0x0A 0x00 # GOOD: c.slli zero, 2
@@ -172,6 +174,10 @@
 0x7E 0x10 # BAD32: invalid instruction encoding
 0x7E 0x10 # GOOD64: c.slli zero, 63
 0x7E 0x10 # NOHINTS: invalid instruction encoding
+# GOOD: c.slli64 ra
+# NOHINTS: invalid instruction encoding
+0x82 0x00
+0x86 0x00 # GOOD: c.slli ra, 1
 0x86 0x00 # GOOD: c.slli ra, 1
 0x8A 0x00 # GOOD: c.slli ra, 2
 0x8E 0x00 # GOOD: c.slli ra, 3
@@ -267,6 +273,9 @@
 0xFA 0x10 # GOOD64: c.slli ra, 62
 0xFE 0x10 # BAD32: invalid instruction encoding
 0xFE 0x10 # GOOD64: c.slli ra, 63
+# GOOD: c.slli64 sp
+# NOHINTS: invalid instruction encoding
+0x02 0x01
 0x06 0x01 # GOOD: c.slli sp, 1
 0x0A 0x01 # GOOD: c.slli sp, 2
 0x0E 0x01 # GOOD: c.slli sp, 3
@@ -362,6 +371,9 @@
 0x7A 0x11 # GOOD64: c.slli sp, 62
 0x7E 0x11 # BAD32: invalid instruction encoding
 0x7E 0x11 # GOOD64: c.slli sp, 63
+# GOOD: c.slli64 gp
+# NOHINTS: invalid instruction encoding
+0x82 0x01
 0x86 0x01 # GOOD: c.slli gp, 1
 0x8A 0x01 # GOOD: c.slli gp, 2
 0x8E 0x01 # GOOD: c.slli gp, 3
@@ -457,6 +469,9 @@
 0xFA 0x11 # GOOD64: c.slli gp, 62
 0xFE 0x11 # BAD32: invalid instruction encoding
 0xFE 0x11 # GOOD64: c.slli gp, 63
+# GOOD: c.slli64 tp
+# NOHINTS: invalid instruction encoding
+0x02 0x02
 0x06 0x02 # GOOD: c.slli tp, 1
 0x0A 0x02 # GOOD: c.slli tp, 2
 0x0E 0x02 # GOOD: c.slli tp, 3
@@ -552,6 +567,9 @@
 0x7A 0x12 # GOOD64: c.slli tp, 62
 0x7E 0x12 # BAD32: invalid instruction encoding
 0x7E 0x12 # GOOD64: c.slli tp, 63
+# GOOD: c.slli64 t0
+# NOHINTS: invalid instruction encoding
+0x82 0x02
 0x86 0x02 # GOOD: c.slli t0, 1
 0x8A 0x02 # GOOD: c.slli t0, 2
 0x8E 0x02 # GOOD: c.slli t0, 3
@@ -647,6 +665,9 @@
 0xFA 0x12 # GOOD64: c.slli t0, 62
 0xFE 0x12 # BAD32: invalid instruction encoding
 0xFE 0x12 # GOOD64: c.slli t0, 63
+# GOOD: c.slli64 t1
+# NOHINTS: invalid instruction encoding
+0x02 0x03
 0x06 0x03 # GOOD: c.slli t1, 1
 0x0A 0x03 # GOOD: c.slli t1, 2
 0x0E 0x03 # GOOD: c.slli t1, 3
@@ -742,6 +763,9 @@
 0x7A 0x13 # GOOD64: c.slli t1, 62
 0x7E 0x13 # BAD32: invalid instruction encoding
 0x7E 0x13 # GOOD64: c.slli t1, 63
+# GOOD: c.slli64 t2
+# NOHINTS: invalid instruction encoding
+0x82 0x03
 0x86 0x03 # GOOD: c.slli t2, 1
 0x8A 0x03 # GOOD: c.slli t2, 2
 0x8E 0x03 # GOOD: c.slli t2, 3
@@ -837,6 +861,9 @@
 0xFA 0x13 # GOOD64: c.slli t2, 62
 0xFE 0x13 # BAD32: invalid instruction encoding
 0xFE 0x13 # GOOD64: c.slli t2, 63
+# GOOD: c.slli64 s0
+# NOHINTS: invalid instruction encoding
+0x02 0x04
 0x06 0x04 # GOOD: c.slli s0, 1
 0x0A 0x04 # GOOD: c.slli s0, 2
 0x0E 0x04 # GOOD: c.slli s0, 3
@@ -932,6 +959,9 @@
 0x7A 0x14 # GOOD64: c.slli s0, 62
 0x7E 0x14 # BAD32: invalid instruction encoding
 0x7E 0x14 # GOOD64: c.slli s0, 63
+# GOOD: c.slli64 s1
+# NOHINTS: invalid instruction encoding
+0x82 0x04
 0x86 0x04 # GOOD: c.slli s1, 1
 0x8A 0x04 # GOOD: c.slli s1, 2
 0x8E 0x04 # GOOD: c.slli s1, 3
@@ -1027,6 +1057,9 @@
 0xFA 0x14 # GOOD64: c.slli s1, 62
 0xFE 0x14 # BAD32: invalid instruction encoding
 0xFE 0x14 # GOOD64: c.slli s1, 63
+# GOOD: c.slli64 a0
+# NOHINTS: invalid instruction encoding
+0x02 0x05
 0x06 0x05 # GOOD: c.slli a0, 1
 0x0A 0x05 # GOOD: c.slli a0, 2
 0x0E 0x05 # GOOD: c.slli a0, 3
@@ -1122,6 +1155,9 @@
 0x7A 0x15 # GOOD64: c.slli a0, 62
 0x7E 0x15 # BAD32: invalid instruction encoding
 0x7E 0x15 # GOOD64: c.slli a0, 63
+# GOOD: c.slli64 a1
+# NOHINTS: invalid instruction encoding
+0x82 0x05
 0x86 0x05 # GOOD: c.slli a1, 1
 0x8A 0x05 # GOOD: c.slli a1, 2
 0x8E 0x05 # GOOD: c.slli a1, 3
@@ -1217,6 +1253,9 @@
 0xFA 0x15 # GOOD64: c.slli a1, 62
 0xFE 0x15 # BAD32: invalid instruction encoding
 0xFE 0x15 # GOOD64: c.slli a1, 63
+# GOOD: c.slli64 a2
+# NOHINTS: invalid instruction encoding
+0x02 0x06
 0x06 0x06 # GOOD: c.slli a2, 1
 0x0A 0x06 # GOOD: c.slli a2, 2
 0x0E 0x06 # GOOD: c.slli a2, 3
@@ -1312,6 +1351,9 @@
 0x7A 0x16 # GOOD64: c.slli a2, 62
 0x7E 0x16 # BAD32: invalid instruction encoding
 0x7E 0x16 # GOOD64: c.slli a2, 63
+# GOOD: c.slli64 a3
+# NOHINTS: invalid instruction encoding
+0x82 0x06
 0x86 0x06 # GOOD: c.slli a3, 1
 0x8A 0x06 # GOOD: c.slli a3, 2
 0x8E 0x06 # GOOD: c.slli a3, 3
@@ -1407,6 +1449,9 @@
 0xFA 0x16 # GOOD64: c.slli a3, 62
 0xFE 0x16 # BAD32: invalid instruction encoding
 0xFE 0x16 # GOOD64: c.slli a3, 63
+# GOOD: c.slli64 a4
+# NOHINTS: invalid instruction encoding
+0x02 0x07
 0x06 0x07 # GOOD: c.slli a4, 1
 0x0A 0x07 # GOOD: c.slli a4, 2
 0x0E 0x07 # GOOD: c.slli a4, 3
@@ -1502,6 +1547,9 @@
 0x7A 0x17 # GOOD64: c.slli a4, 62
 0x7E 0x17 # BAD32: invalid instruction encoding
 0x7E 0x17 # GOOD64: c.slli a4, 63
+# GOOD: c.slli64 a5
+# NOHINTS: invalid instruction encoding
+0x82 0x07
 0x86 0x07 # GOOD: c.slli a5, 1
 0x8A 0x07 # GOOD: c.slli a5, 2
 0x8E 0x07 # GOOD: c.slli a5, 3
@@ -1597,6 +1645,9 @@
 0xFA 0x17 # GOOD64: c.slli a5, 62
 0xFE 0x17 # BAD32: invalid instruction encoding
 0xFE 0x17 # GOOD64: c.slli a5, 63
+# GOOD: c.slli64 a6
+# NOHINTS: invalid instruction encoding
+0x02 0x08
 0x06 0x08 # GOOD: c.slli a6, 1
 0x0A 0x08 # GOOD: c.slli a6, 2
 0x0E 0x08 # GOOD: c.slli a6, 3
@@ -1692,6 +1743,9 @@
 0x7A 0x18 # GOOD64: c.slli a6, 62
 0x7E 0x18 # BAD32: invalid instruction encoding
 0x7E 0x18 # GOOD64: c.slli a6, 63
+# GOOD: c.slli64 a7
+# NOHINTS: invalid instruction encoding
+0x82 0x08
 0x86 0x08 # GOOD: c.slli a7, 1
 0x8A 0x08 # GOOD: c.slli a7, 2
 0x8E 0x08 # GOOD: c.slli a7, 3
@@ -1787,6 +1841,9 @@
 0xFA 0x18 # GOOD64: c.slli a7, 62
 0xFE 0x18 # BAD32: invalid instruction encoding
 0xFE 0x18 # GOOD64: c.slli a7, 63
+# GOOD: c.slli64 s2
+# NOHINTS: invalid instruction encoding
+0x02 0x09
 0x06 0x09 # GOOD: c.slli s2, 1
 0x0A 0x09 # GOOD: c.slli s2, 2
 0x0E 0x09 # GOOD: c.slli s2, 3
@@ -1882,6 +1939,9 @@
 0x7A 0x19 # GOOD64: c.slli s2, 62
 0x7E 0x19 # BAD32: invalid instruction encoding
 0x7E 0x19 # GOOD64: c.slli s2, 63
+# GOOD: c.slli64 s3
+# NOHINTS: invalid instruction encoding
+0x82 0x09
 0x86 0x09 # GOOD: c.slli s3, 1
 0x8A 0x09 # GOOD: c.slli s3, 2
 0x8E 0x09 # GOOD: c.slli s3, 3
@@ -1977,6 +2037,9 @@
 0xFA 0x19 # GOOD64: c.slli s3, 62
 0xFE 0x19 # BAD32: invalid instruction encoding
 0xFE 0x19 # GOOD64: c.slli s3, 63
+# GOOD: c.slli64 s4
+# NOHINTS: invalid instruction encoding
+0x02 0x0A
 0x06 0x0A # GOOD: c.slli s4, 1
 0x0A 0x0A # GOOD: c.slli s4, 2
 0x0E 0x0A # GOOD: c.slli s4, 3
@@ -2072,6 +2135,9 @@
 0x7A 0x1A # GOOD64: c.slli s4, 62
 0x7E 0x1A # BAD32: invalid instruction encoding
 0x7E 0x1A # GOOD64: c.slli s4, 63
+# GOOD: c.slli64 s5
+# NOHINTS: invalid instruction encoding
+0x82 0x0A
 0x86 0x0A # GOOD: c.slli s5, 1
 0x8A 0x0A # GOOD: c.slli s5, 2
 0x8E 0x0A # GOOD: c.slli s5, 3
@@ -2167,6 +2233,9 @@
 0xFA 0x1A # GOOD64: c.slli s5, 62
 0xFE 0x1A # BAD32: invalid instruction encoding
 0xFE 0x1A # GOOD64: c.slli s5, 63
+# GOOD: c.slli64 s6
+# NOHINTS: invalid instruction encoding
+0x02 0x0B
 0x06 0x0B # GOOD: c.slli s6, 1
 0x0A 0x0B # GOOD: c.slli s6, 2
 0x0E 0x0B # GOOD: c.slli s6, 3
@@ -2262,6 +2331,9 @@
 0x7A 0x1B # GOOD64: c.slli s6, 62
 0x7E 0x1B # BAD32: invalid instruction encoding
 0x7E 0x1B # GOOD64: c.slli s6, 63
+# GOOD: c.slli64 s7
+# NOHINTS: invalid instruction encoding
+0x82 0x0B
 0x86 0x0B # GOOD: c.slli s7, 1
 0x8A 0x0B # GOOD: c.slli s7, 2
 0x8E 0x0B # GOOD: c.slli s7, 3
@@ -2357,6 +2429,9 @@
 0xFA 0x1B # GOOD64: c.slli s7, 62
 0xFE 0x1B # BAD32: invalid instruction encoding
 0xFE 0x1B # GOOD64: c.slli s7, 63
+# GOOD: c.slli64 s8
+# NOHINTS: invalid instruction encoding
+0x02 0x0C
 0x06 0x0C # GOOD: c.slli s8, 1
 0x0A 0x0C # GOOD: c.slli s8, 2
 0x0E 0x0C # GOOD: c.slli s8, 3
@@ -2452,6 +2527,9 @@
 0x7A 0x1C # GOOD64: c.slli s8, 62
 0x7E 0x1C # BAD32: invalid instruction encoding
 0x7E 0x1C # GOOD64: c.slli s8, 63
+# GOOD: c.slli64 s9
+# NOHINTS: invalid instruction encoding
+0x82 0x0C
 0x86 0x0C # GOOD: c.slli s9, 1
 0x8A 0x0C # GOOD: c.slli s9, 2
 0x8E 0x0C # GOOD: c.slli s9, 3
@@ -2547,6 +2625,9 @@
 0xFA 0x1C # GOOD64: c.slli s9, 62
 0xFE 0x1C # BAD32: invalid instruction encoding
 0xFE 0x1C # GOOD64: c.slli s9, 63
+# GOOD: c.slli64 s10
+# NOHINTS: invalid instruction encoding
+0x02 0x0D
 0x06 0x0D # GOOD: c.slli s10, 1
 0x0A 0x0D # GOOD: c.slli s10, 2
 0x0E 0x0D # GOOD: c.slli s10, 3
@@ -2642,6 +2723,9 @@
 0x7A 0x1D # GOOD64: c.slli s10, 62
 0x7E 0x1D # BAD32: invalid instruction encoding
 0x7E 0x1D # GOOD64: c.slli s10, 63
+# GOOD: c.slli64 s11
+# NOHINTS: invalid instruction encoding
+0x82 0x0D
 0x86 0x0D # GOOD: c.slli s11, 1
 0x8A 0x0D # GOOD: c.slli s11, 2
 0x8E 0x0D # GOOD: c.slli s11, 3
@@ -2737,6 +2821,9 @@
 0xFA 0x1D # GOOD64: c.slli s11, 62
 0xFE 0x1D # BAD32: invalid instruction encoding
 0xFE 0x1D # GOOD64: c.slli s11, 63
+# GOOD: c.slli64 t3
+# NOHINTS: invalid instruction encoding
+0x02 0x0E
 0x06 0x0E # GOOD: c.slli t3, 1
 0x0A 0x0E # GOOD: c.slli t3, 2
 0x0E 0x0E # GOOD: c.slli t3, 3
@@ -2832,6 +2919,9 @@
 0x7A 0x1E # GOOD64: c.slli t3, 62
 0x7E 0x1E # BAD32: invalid instruction encoding
 0x7E 0x1E # GOOD64: c.slli t3, 63
+# GOOD: c.slli64 t4
+# NOHINTS: invalid instruction encoding
+0x82 0x0E
 0x86 0x0E # GOOD: c.slli t4, 1
 0x8A 0x0E # GOOD: c.slli t4, 2
 0x8E 0x0E # GOOD: c.slli t4, 3
@@ -2927,6 +3017,9 @@
 0xFA 0x1E # GOOD64: c.slli t4, 62
 0xFE 0x1E # BAD32: invalid instruction encoding
 0xFE 0x1E # GOOD64: c.slli t4, 63
+# GOOD: c.slli64 t5
+# NOHINTS: invalid instruction encoding
+0x02 0x0F
 0x06 0x0F # GOOD: c.slli t5, 1
 0x0A 0x0F # GOOD: c.slli t5, 2
 0x0E 0x0F # GOOD: c.slli t5, 3
@@ -3022,6 +3115,9 @@
 0x7A 0x1F # GOOD64: c.slli t5, 62
 0x7E 0x1F # BAD32: invalid instruction encoding
 0x7E 0x1F # GOOD64: c.slli t5, 63
+# GOOD: c.slli64 t6
+# NOHINTS: invalid instruction encoding
+0x82 0x0F
 0x86 0x0F # GOOD: c.slli t6, 1
 0x8A 0x0F # GOOD: c.slli t6, 2
 0x8E 0x0F # GOOD: c.slli t6, 3


### PR DESCRIPTION
The c.slli encoding with a shift of 0 is c.slli64 for RV128 and a hint for RV32 and RV64. Add a test for this encoding to the exhaustive c.slli test.