### PR TITLE
[clang] Check `std::initializer_list` more strictly

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2591,13 +2591,13 @@ def err_implied_std_initializer_list_not_found : Error<
   "cannot deduce type of initializer list because std::initializer_list was "
   "not found; include <initializer_list>">;
 def err_malformed_std_initializer_list
-    : Error<"std::initializer_list %select{"
-            "must have exactly one template parameter|"
-            "cannot have associated constraints|"
-            "must have a type template parameter|"
-            "cannot have default template arguments|"
-            "cannot be a variadic template|"
-            "must be a class template}0">;
+    : Error<"std::initializer_list %enum_select<MalformedStdInitializerList>{"
+            "%TooManyParams{must have exactly one template parameter}|"
+            "%Constrained{cannot have associated constraints}|"
+            "%BadParamKind{must have a type template parameter}|"
+            "%DefaultArg{cannot have default template arguments}|"
+            "%ParamPack{cannot be a variadic template}|"
+            "%BadEntityKind{must be a class template}}0">;
 def err_auto_init_list_from_c : Error<
   "cannot use %select{'auto'|<ERROR>|'__auto_type'}0 with "
   "%select{initializer list|array}1 in C">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2590,8 +2590,14 @@ def err_auto_non_deduced_not_alone : Error<
 def err_implied_std_initializer_list_not_found : Error<
   "cannot deduce type of initializer list because std::initializer_list was "
   "not found; include <initializer_list>">;
-def err_malformed_std_initializer_list : Error<
-  "std::initializer_list must be a class template with a single type parameter">;
+def err_malformed_std_initializer_list
+    : Error<"std::initializer_list %select{"
+            "must have exactly one template parameter|"
+            "cannot have associated constraints|"
+            "must have a type template parameter|"
+            "cannot have default template arguments|"
+            "cannot be a variadic template|"
+            "must be a class template}0">;
 def err_auto_init_list_from_c : Error<
   "cannot use %select{'auto'|<ERROR>|'__auto_type'}0 with "
   "%select{initializer list|array}1 in C">;

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -12078,6 +12078,7 @@ NamespaceDecl *Sema::getOrCreateStdNamespace() {
 /// \returns true if any issues were found.
 static bool CheckStdInitializerList(Sema &S, const ClassTemplateDecl *Template,
                                     bool Diagnose) {
+  assert(Template && "Template can't be null");
   const TemplateParameterList *Params = Template->getTemplateParameters();
   int ErrorKind = -1;
 

--- a/clang/test/SemaCXX/invalid-std-initializer-list.cpp
+++ b/clang/test/SemaCXX/invalid-std-initializer-list.cpp
@@ -1,0 +1,77 @@
+// RUN: %clang_cc1 %s -verify=expected,type-param -std=c++23 -DTYPE_PARAM
+// RUN: %clang_cc1 %s -verify=expected,others -std=c++23 -DCONSTANT_PARAM
+// RUN: %clang_cc1 %s -verify=expected,others -std=c++23 -DTYPE_TEMPLATE_PARAM
+// RUN: %clang_cc1 %s -verify=expected,others -std=c++23 -DDEFAULT_ARG
+// RUN: %clang_cc1 %s -verify=expected,others -std=c++23 -DMULTIPLE_PARAMS
+// RUN: %clang_cc1 %s -verify=expected,others -std=c++23 -DPARAM_PACK
+// RUN: %clang_cc1 %s -verify=expected,others -std=c++23 -DCONSTRAINED_PARAM
+// RUN: %clang_cc1 %s -verify=expected,others -std=c++23 -DREQUIRES_CLAUSE
+// RUN: %clang_cc1 %s -verify=expected,others -std=c++23 -DNONCLASS_TEMPLATE
+// RUN: %clang_cc1 %s -verify=expected,others -std=c++23 -DNONTEMPLATE
+
+namespace std {
+
+#ifdef TYPE_PARAM
+template<class> class initializer_list;
+// expected-note@-1 2 {{template is declared here}}
+#elifdef CONSTANT_PARAM
+template<int> class initializer_list;
+// expected-error@-1 2 {{std::initializer_list must have a type template parameter}}
+#elifdef TYPE_TEMPLATE_PARAM
+template<template<class> class> class initializer_list;
+// expected-error@-1 2 {{std::initializer_list must have a type template parameter}}
+#elifdef DEFAULT_ARG
+template<class = int> class initializer_list;
+// expected-error@-1 2 {{std::initializer_list cannot have default template arguments}}
+#elifdef MULTIPLE_PARAMS
+template<class, class> class initializer_list;
+// expected-error@-1 2 {{std::initializer_list must have exactly one template parameter}}
+#elifdef PARAM_PACK
+template<class...> class initializer_list;
+// expected-error@-1 2 {{std::initializer_list cannot be a variadic template}}
+#elifdef CONSTRAINED_PARAM
+template<class> concept C = true;
+template<C> class initializer_list;
+// expected-error@-1 2 {{std::initializer_list cannot have associated constraints}}
+#elifdef REQUIRES_CLAUSE
+template<class> requires true class initializer_list;
+// expected-error@-1 2 {{std::initializer_list cannot have associated constraints}}
+#elifdef NONCLASS_TEMPLATE
+template<class> class IL;
+template<class T> using initializer_list = IL<T>;
+// expected-error@-1 2 {{std::initializer_list must be a class template}}
+#elifdef NONTEMPLATE
+class initializer_list;
+// expected-error@-1 2 {{std::initializer_list must be a class template}}
+#else
+#error Unexpected test kind
+#endif
+
+}
+
+struct Test { // expected-note 2 {{candidate constructor}}
+#ifdef CONSTANT_PARAM
+    Test(std::initializer_list<1>); // expected-note {{candidate constructor}}
+#elifdef TYPE_TEMPLATE_PARAM
+    template<class> using A = double;
+    Test(std::initializer_list<A>); // expected-note {{candidate constructor}}
+#elifdef MULTIPLE_PARAMS
+    Test(std::initializer_list<double, double>); // expected-note {{candidate constructor}}
+#elifdef NONTEMPLATE
+    Test(std::initializer_list); // expected-note {{candidate constructor}}
+#else
+    Test(std::initializer_list<double>); // expected-note {{candidate constructor}}
+#endif
+};
+Test test {1.2, 3.4}; // expected-error {{no matching constructor}}
+
+auto x = {1};
+// type-param-error@-1 {{implicit instantiation of undefined template}}
+// others-note@-2 {{used here}}
+
+void f() {
+    for(int x : {1, 2});
+    // type-param-error@-1 {{implicit instantiation of undefined template}}
+    // type-param-error@-2 {{invalid range expression}}
+    // others-note@-3 {{used here}}
+}


### PR DESCRIPTION
Require `std::initializer_list` to be a class template with a template-head equivalent to `template<class>` and no default arguments.