### PR TITLE
[lldb] Fix intel trace plugin tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/intelpt/intelpt_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/intelpt/intelpt_testcase.py
@@ -18,6 +18,13 @@ def testSBAPIAndCommands(func):
     return wrapper
 
 
+def skipIfCpuDoesNotSupportIntelPT(func):
+    """Skip tests if the system does not support tracing."""
+
+    supported = os.path.exists("/sys/bus/event_source/devices/intel_pt/type")
+    return unittest.skipIf(not supported, "intel-pt tracing is unsupported")(func)
+
+
 # Class that should be used by all python Intel PT tests.
 #
 # It has a handy check that skips the test if the intel-pt plugin is not enabled.

--- a/lldb/packages/Python/lldbsuite/test/tools/intelpt/intelpt_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/intelpt/intelpt_testcase.py
@@ -18,7 +18,7 @@ def testSBAPIAndCommands(func):
     return wrapper
 
 
-def skipIfCpuDoesNotSupportIntelPT(func):
+def skipIfNoIntelPT(func):
     """Skip tests if the system does not support tracing."""
 
     supported = os.path.exists("/sys/bus/event_source/devices/intel_pt/type")

--- a/lldb/source/Target/ProcessTrace.cpp
+++ b/lldb/source/Target/ProcessTrace.cpp
@@ -36,7 +36,8 @@ ProcessSP ProcessTrace::CreateInstance(TargetSP target_sp,
                                        bool can_connect) {
   if (can_connect)
     return nullptr;
-  return std::make_shared<ProcessTrace>(target_sp, listener_sp, *crash_file);
+  return std::make_shared<ProcessTrace>(target_sp, listener_sp,
+                                        crash_file ? *crash_file : FileSpec());
 }
 
 bool ProcessTrace::CanDebug(TargetSP target_sp, bool plugin_specified_by_name) {

--- a/lldb/test/API/commands/trace/TestTraceDumpFunctionCalls.py
+++ b/lldb/test/API/commands/trace/TestTraceDumpFunctionCalls.py
@@ -133,7 +133,7 @@ m.out`bar() + 30 at multi_thread.cpp:19:3 to 20:6  [5, 61831]
             ],
         )
 
-    @skipIfCpuDoesNotSupportIntelPT
+    @skipIfNoIntelPT
     def testInlineFunctionCalls(self):
         self.expect(
             "file " + os.path.join(self.getSourceDir(), "inline-function", "a.out")
@@ -195,7 +195,7 @@ a.out`main + 25 at inline.cpp:16:14 to 16:14  [28, 28]"""
             ],
         )
 
-    @skipIfCpuDoesNotSupportIntelPT
+    @skipIfNoIntelPT
     def testIncompleteInlineFunctionCalls(self):
         self.expect(
             "file " + os.path.join(self.getSourceDir(), "inline-function", "a.out")

--- a/lldb/test/API/commands/trace/TestTraceDumpFunctionCalls.py
+++ b/lldb/test/API/commands/trace/TestTraceDumpFunctionCalls.py
@@ -133,6 +133,7 @@ m.out`bar() + 30 at multi_thread.cpp:19:3 to 20:6  [5, 61831]
             ],
         )
 
+    @skipIfCpuDoesNotSupportIntelPT
     def testInlineFunctionCalls(self):
         self.expect(
             "file " + os.path.join(self.getSourceDir(), "inline-function", "a.out")
@@ -194,6 +195,7 @@ a.out`main + 25 at inline.cpp:16:14 to 16:14  [28, 28]"""
             ],
         )
 
+    @skipIfCpuDoesNotSupportIntelPT
     def testIncompleteInlineFunctionCalls(self):
         self.expect(
             "file " + os.path.join(self.getSourceDir(), "inline-function", "a.out")

--- a/lldb/test/API/commands/trace/TestTraceEvents.py
+++ b/lldb/test/API/commands/trace/TestTraceEvents.py
@@ -45,7 +45,7 @@ class TestTraceEvents(TraceIntelPTTestCaseBase):
             ],
         )
 
-    @skipIfCpuDoesNotSupportIntelPT
+    @skipIfNoIntelPT
     @testSBAPIAndCommands
     def testPauseEvents(self):
         """

--- a/lldb/test/API/commands/trace/TestTraceEvents.py
+++ b/lldb/test/API/commands/trace/TestTraceEvents.py
@@ -45,6 +45,7 @@ class TestTraceEvents(TraceIntelPTTestCaseBase):
             ],
         )
 
+    @skipIfCpuDoesNotSupportIntelPT
     @testSBAPIAndCommands
     def testPauseEvents(self):
         """

--- a/lldb/test/API/commands/trace/TestTraceSave.py
+++ b/lldb/test/API/commands/trace/TestTraceSave.py
@@ -43,7 +43,7 @@ class TestTraceSave(TraceIntelPTTestCaseBase):
             "trace save", substrs=["error: Process is not being traced"], error=True
         )
 
-    @skipIfCpuDoesNotSupportIntelPT
+    @skipIfNoIntelPT
     def testSaveToInvalidDir(self):
         self.expect(
             "target create "
@@ -166,7 +166,7 @@ class TestTraceSave(TraceIntelPTTestCaseBase):
                     copied_cpu = find(lambda cor: cor["id"] == cpu["id"], copy["cpus"])
                     self.assertIsNotNone(copied_cpu)
 
-    @skipIfCpuDoesNotSupportIntelPT
+    @skipIfNoIntelPT
     def testSaveTrace(self):
         self.expect(
             "target create "

--- a/lldb/test/API/commands/trace/TestTraceSave.py
+++ b/lldb/test/API/commands/trace/TestTraceSave.py
@@ -43,6 +43,7 @@ class TestTraceSave(TraceIntelPTTestCaseBase):
             "trace save", substrs=["error: Process is not being traced"], error=True
         )
 
+    @skipIfCpuDoesNotSupportIntelPT
     def testSaveToInvalidDir(self):
         self.expect(
             "target create "
@@ -165,6 +166,7 @@ class TestTraceSave(TraceIntelPTTestCaseBase):
                     copied_cpu = find(lambda cor: cor["id"] == cpu["id"], copy["cpus"])
                     self.assertIsNotNone(copied_cpu)
 
+    @skipIfCpuDoesNotSupportIntelPT
     def testSaveTrace(self):
         self.expect(
             "target create "

--- a/lldb/test/API/commands/trace/TestTraceStartStop.py
+++ b/lldb/test/API/commands/trace/TestTraceStartStop.py
@@ -5,7 +5,7 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test.decorators import *
 
 
-@skipIfCpuDoesNotSupportIntelPT
+@skipIfNoIntelPT
 class TestTraceStartStop(TraceIntelPTTestCaseBase):
     def expectGenericHelpMessageForStartCommand(self):
         self.expect(

--- a/lldb/test/API/commands/trace/TestTraceStartStop.py
+++ b/lldb/test/API/commands/trace/TestTraceStartStop.py
@@ -5,6 +5,7 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test.decorators import *
 
 
+@skipIfCpuDoesNotSupportIntelPT
 class TestTraceStartStop(TraceIntelPTTestCaseBase):
     def expectGenericHelpMessageForStartCommand(self):
         self.expect(

--- a/lldb/test/API/commands/trace/TestTraceTSC.py
+++ b/lldb/test/API/commands/trace/TestTraceTSC.py
@@ -5,7 +5,7 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test.decorators import *
 
 
-@skipIfCpuDoesNotSupportIntelPT
+@skipIfNoIntelPT
 class TestTraceTimestampCounters(TraceIntelPTTestCaseBase):
     @testSBAPIAndCommands
     @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))

--- a/lldb/test/API/commands/trace/TestTraceTSC.py
+++ b/lldb/test/API/commands/trace/TestTraceTSC.py
@@ -5,6 +5,7 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test.decorators import *
 
 
+@skipIfCpuDoesNotSupportIntelPT
 class TestTraceTimestampCounters(TraceIntelPTTestCaseBase):
     @testSBAPIAndCommands
     @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))

--- a/lldb/test/API/commands/trace/multiple-threads/TestTraceStartStopMultipleThreads.py
+++ b/lldb/test/API/commands/trace/multiple-threads/TestTraceStartStopMultipleThreads.py
@@ -6,6 +6,7 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test.decorators import *
 
 
+@skipIfCpuDoesNotSupportIntelPT
 class TestTraceStartStopMultipleThreads(TraceIntelPTTestCaseBase):
     @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
     @testSBAPIAndCommands

--- a/lldb/test/API/commands/trace/multiple-threads/TestTraceStartStopMultipleThreads.py
+++ b/lldb/test/API/commands/trace/multiple-threads/TestTraceStartStopMultipleThreads.py
@@ -6,7 +6,7 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test.decorators import *
 
 
-@skipIfCpuDoesNotSupportIntelPT
+@skipIfNoIntelPT
 class TestTraceStartStopMultipleThreads(TraceIntelPTTestCaseBase):
     @skipIf(oslist=no_match(["linux"]), archs=no_match(["i386", "x86_64"]))
     @testSBAPIAndCommands

--- a/lldb/unittests/Process/CMakeLists.txt
+++ b/lldb/unittests/Process/CMakeLists.txt
@@ -7,8 +7,9 @@ endif()
 add_subdirectory(Utility)
 add_subdirectory(minidump)
 
-add_lldb_unittest(ProcessEventDataTests
+add_lldb_unittest(ProcessTests
   ProcessEventDataTest.cpp
+  ProcessTraceTest.cpp
 
   LINK_LIBS
       lldbCore
@@ -18,5 +19,6 @@ add_lldb_unittest(ProcessEventDataTests
       lldbUtility
       lldbUtilityHelpers
       lldbInterpreter
+      lldbPluginPlatformLinux
       lldbPluginPlatformMacOSX
   )

--- a/lldb/unittests/Process/ProcessTraceTest.cpp
+++ b/lldb/unittests/Process/ProcessTraceTest.cpp
@@ -1,0 +1,63 @@
+//===-- ProcessEventDataTest.cpp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Target/ProcessTrace.h"
+#include "Plugins/Platform/Linux/PlatformLinux.h"
+#include "lldb/Core/Debugger.h"
+#include "lldb/Host/HostInfo.h"
+#include "gtest/gtest.h"
+
+using namespace lldb_private;
+using namespace lldb;
+using namespace platform_linux;
+
+// This is needed for the tests that create a trace process.
+class ProcessTraceTest : public ::testing::Test {
+public:
+  void SetUp() override {
+    ProcessTrace::Initialize();
+    FileSystem::Initialize();
+    HostInfo::Initialize();
+    PlatformLinux::Initialize();
+  }
+  void TearDown() override {
+    PlatformLinux::Initialize();
+    HostInfo::Terminate();
+    FileSystem::Terminate();
+    ProcessTrace::Terminate();
+  }
+};
+
+TargetSP CreateTarget(DebuggerSP &debugger_sp, const ArchSpec &arch) {
+  PlatformSP platform_sp;
+  TargetSP target_sp;
+  debugger_sp->GetTargetList().CreateTarget(
+      *debugger_sp, "", arch, eLoadDependentsNo, platform_sp, target_sp);
+  return target_sp;
+}
+
+// Test that we can create a process trace with a nullptr core file.
+TEST_F(ProcessTraceTest, ConstructorWithNullptrCoreFile) {
+  ArchSpec arch("i386-pc-linux");
+
+  Platform::SetHostPlatform(PlatformLinux::CreateInstance(true, &arch));
+  ASSERT_NE(Platform::GetHostPlatform(), nullptr);
+
+  DebuggerSP debugger_sp = Debugger::CreateInstance();
+  ASSERT_TRUE(debugger_sp);
+
+  TargetSP target_sp = CreateTarget(debugger_sp, arch);
+  ASSERT_TRUE(target_sp);
+
+  ProcessSP process_sp = target_sp->CreateProcess(
+      /*listener*/ nullptr, "trace",
+      /*crash_file*/ nullptr,
+      /*can_connect*/ false);
+
+  ASSERT_NE(process_sp, nullptr);
+}


### PR DESCRIPTION
The tests for the
[intel-pt](https://github.com/llvm/llvm-project/blob/348374028970c956f2e49ab7553b495d7408ccd9/lldb/docs/use/intel_pt.rst) trace plugin were failing for multiple reasons.

On machines where tracing is supported many of the tests were crashing because of a nullptr dereference. It looks like the `core_file` parameter in `ProcessTrace::CreateInstance` was once ignored, but was changed to always being dereferenced. This caused the tests to fail even when tracing was supported.

On machines where tracing is not supported we would still run tests that attempt to take a trace. These would obviously fail because the required hardware is not present. Note that some of the tests simply read serialized json as trace files which does not require any special hardware.

This PR fixes these two issues by guarding the pointer dereference and then skipping unsupported tests on machines. With these changes the trace tests pass on both types of machines.

We also add a new unit test to validate that a process can be created with a nullptr core_file through the generic process trace plugin path.