### PR TITLE
[flang-rt][NFC] Work around CTK12.8 compilation failure.

### DIFF
--- a/flang-rt/lib/runtime/matmul-transpose.cpp
+++ b/flang-rt/lib/runtime/matmul-transpose.cpp
@@ -331,6 +331,7 @@ template <bool IS_ALLOCATING, TypeCategory XCAT, int XKIND, TypeCategory YCAT,
 struct MatmulTransposeHelper {
   using ResultDescriptor =
       std::conditional_t<IS_ALLOCATING, Descriptor, const Descriptor>;
+  using ResultTy = Fortran::common::optional<std::pair<TypeCategory, int>>;
   RT_API_ATTRS void operator()(ResultDescriptor &result, const Descriptor &x,
       const Descriptor &y, const char *sourceFile, int line) const {
     Terminator terminator{sourceFile, line};
@@ -339,7 +340,7 @@ struct MatmulTransposeHelper {
     RUNTIME_CHECK(terminator, xCatKind.has_value() && yCatKind.has_value());
     RUNTIME_CHECK(terminator, xCatKind->first == XCAT);
     RUNTIME_CHECK(terminator, yCatKind->first == YCAT);
-    if constexpr (constexpr auto resultType{
+    if constexpr (constexpr ResultTy resultType{
                       GetResultType(XCAT, XKIND, YCAT, YKIND)}) {
       return DoMatmulTranspose<IS_ALLOCATING, resultType->first,
           resultType->second, CppTypeFor<XCAT, XKIND>, CppTypeFor<YCAT, YKIND>>(

--- a/flang-rt/lib/runtime/matmul.cpp
+++ b/flang-rt/lib/runtime/matmul.cpp
@@ -424,6 +424,7 @@ static inline RT_API_ATTRS void DoMatmul(
 template <bool IS_ALLOCATING, TypeCategory XCAT, int XKIND, TypeCategory YCAT,
     int YKIND>
 struct MatmulHelper {
+  using ResultTy = Fortran::common::optional<std::pair<TypeCategory, int>>;
   using ResultDescriptor =
       std::conditional_t<IS_ALLOCATING, Descriptor, const Descriptor>;
   RT_API_ATTRS void operator()(ResultDescriptor &result, const Descriptor &x,
@@ -439,7 +440,7 @@ struct MatmulHelper {
                      xCatKind->first == TypeCategory::Unsigned) &&
                     (yCatKind->first == TypeCategory::Integer ||
                         yCatKind->first == TypeCategory::Unsigned))));
-    if constexpr (constexpr auto resultType{
+    if constexpr (constexpr ResultTy resultType{
                       GetResultType(XCAT, XKIND, YCAT, YKIND)}) {
       return DoMatmul<IS_ALLOCATING, resultType->first, resultType->second,
           CppTypeFor<XCAT, XKIND>, CppTypeFor<YCAT, YKIND>>(


### PR DESCRIPTION
It happened in https://lab.llvm.org/buildbot/#/builders/152/builds/1131
when the buildbot was switched from CTK12.3 to CTK12.8.
The logs are gone by now, so the above link is useless.

The error was:
error: ‘auto’ not permitted in template argument

This workaround helps, but I also reported the issue to NVCC devs.
