### PR TITLE
[lldb] Fix use-after-free in SBMutexTest

### DIFF
--- a/lldb/unittests/API/SBMutexTest.cpp
+++ b/lldb/unittests/API/SBMutexTest.cpp
@@ -32,10 +32,9 @@ protected:
 
 TEST_F(SBMutexTest, LockTest) {
   lldb::SBTarget target = debugger.GetDummyTarget();
-
+  std::atomic<bool> locked = false;
   std::future<void> f;
   {
-    std::atomic<bool> locked = false;
     lldb::SBMutex lock = target.GetAPIMutex();
     std::lock_guard<lldb::SBMutex> lock_guard(lock);
     ASSERT_FALSE(locked.exchange(true));


### PR DESCRIPTION
The `locked` variable can be accessed from the asynchronous thread until the call to f.wait() completes. However, the variable is scoped in a lexical block that ends before that, leading to a use-after-free.