### PR TITLE
[clang-tidy] Use DenseMap::insert_range (NFC)

### DIFF
--- a/clang-tools-extra/clang-tidy/utils/ExprSequence.cpp
+++ b/clang-tools-extra/clang-tidy/utils/ExprSequence.cpp
@@ -84,9 +84,7 @@ getAllInitListForms(const InitListExpr *InitList) {
 ExprSequence::ExprSequence(const CFG *TheCFG, const Stmt *Root,
                            ASTContext *TheContext)
     : Context(TheContext), Root(Root) {
-  for (const auto &SyntheticStmt : TheCFG->synthetic_stmts()) {
-    SyntheticStmtSourceMap[SyntheticStmt.first] = SyntheticStmt.second;
-  }
+  SyntheticStmtSourceMap.insert_range(TheCFG->synthetic_stmts());
 }
 
 bool ExprSequence::inSequence(const Stmt *Before, const Stmt *After) const {


### PR DESCRIPTION
We can safely switch to insert_range here because
SyntheticStmtSourceMap starts out empty in the constructor.  Also
TheCFG->synthetic_stmts() comes from DenseMap, so we know that the
keys are unique.  That is, operator[] and insert are equivalent in
this particular case.
