### PR TITLE
[ExecutionEngine] Use DenseMap::insert_range (NFC)

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/LinkGraphLinkingLayer.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/LinkGraphLinkingLayer.cpp
@@ -108,8 +108,7 @@ public:
         LookupContinuation->run(Result.takeError());
       else {
         AsyncLookupResult LR;
-        for (auto &KV : *Result)
-          LR[KV.first] = KV.second;
+        LR.insert_range(*Result);
         LookupContinuation->run(std::move(LR));
       }
     };


### PR DESCRIPTION
We can safely switch to insert_range here because LR starts out empty.
Also, *Result is a DenseMap, so we know that the keys are unique.
