### PR TITLE
[MLIR][AMDGPU] Bump to COV6

### DIFF
--- a/mlir/include/mlir/Dialect/GPU/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/GPU/Transforms/Passes.td
@@ -186,7 +186,7 @@ def GpuROCDLAttachTarget: Pass<"rocdl-attach-target", ""> {
            /*default=*/"\"\"",
            "Target features.">,
     Option<"abiVersion", "abi", "std::string",
-           /*default=*/"\"500\"",
+           /*default=*/"\"600\"",
            "ABI version.">,
     Option<"optLevel", "O", "unsigned",
            /*default=*/"2",

--- a/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/ROCDLOps.td
@@ -680,7 +680,7 @@ def ROCDL_V2BF16Type : FixedVectorOfLengthAndType<[2], [BF16]>,
                         BuildableType<"::mlir::VectorType::get("
                           "{2},$_builder.getBF16Type())">;
 
-// TODO: The word and byte selectors are immarg in LLVM 
+// TODO: The word and byte selectors are immarg in LLVM
 // update to be attributes in MLIR
 //===---------------------------------------------------------------------===//
 // 16-bit float intrinsics
@@ -1129,7 +1129,7 @@ def ROCDL_TargetAttr :
     StringRefParameter<"Target chip features.", "\"\"">:$features,
     // Also update the default builder below and rocdl-attach-target in
     // Dialect/GPU/Transforms/Passes.td .
-    StringRefParameter<"ABI version.", "\"500\"">:$abi,
+    StringRefParameter<"ABI version.", "\"600\"">:$abi,
     OptionalParameter<"DictionaryAttr", "Target specific flags.">:$flags,
     OptionalParameter<"ArrayAttr", "Files to link to the LLVM module.">:$link
   );
@@ -1141,7 +1141,7 @@ def ROCDL_TargetAttr :
                      CArg<"StringRef", "\"amdgcn-amd-amdhsa\"">:$triple,
                      CArg<"StringRef", "\"gfx900\"">:$chip,
                      CArg<"StringRef", "\"\"">:$features,
-                     CArg<"StringRef", "\"500\"">:$abiVersion,
+                     CArg<"StringRef", "\"600\"">:$abiVersion,
                      CArg<"DictionaryAttr", "nullptr">:$targetFlags,
                      CArg<"ArrayAttr", "nullptr">:$linkFiles), [{
       return Base::get($_ctxt, optLevel, triple, chip, features, abiVersion,

--- a/mlir/lib/Dialect/LLVMIR/IR/ROCDLDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/ROCDLDialect.cpp
@@ -234,8 +234,8 @@ ROCDLTargetAttr::verify(function_ref<InFlightDiagnostic()> emitError,
     emitError() << "The target chip cannot be empty.";
     return failure();
   }
-  if (abiVersion != "400" && abiVersion != "500") {
-    emitError() << "Invalid ABI version, it must be either `400` or `500`.";
+  if (abiVersion != "400" && abiVersion != "500" && abiVersion != "600") {
+    emitError() << "Invalid ABI version, it must be `400`, `500` or '600'.";
     return failure();
   }
   if (files && !llvm::all_of(files, [](::mlir::Attribute attr) {

--- a/mlir/lib/Target/LLVM/ROCDL/Target.cpp
+++ b/mlir/lib/Target/LLVM/ROCDL/Target.cpp
@@ -248,7 +248,8 @@ void SerializeGPUModuleBase::addControlVariables(
     controlVariable->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Local);
   };
 
-  int abi = 500;
+  // Note that COV6 requires ROCm 6.3+.
+  int abi = 600;
   abiVer.getAsInteger(0, abi);
   module.addModuleFlag(llvm::Module::Error, "amdhsa_code_object_version", abi);
   // Return if no device libraries are required.

--- a/mlir/test/Dialect/LLVMIR/rocdl.mlir
+++ b/mlir/test/Dialect/LLVMIR/rocdl.mlir
@@ -765,8 +765,8 @@ llvm.func @rocdl_8bit_floats(%source: i32, %source_half: f16, %source_bfloat: bf
 // CHECK: rocdl.cvt.f32.fp8
 // CHECK: rocdl.cvt.scalef32.f32.bf8
 // CHECK: rocdl.cvt.scalef32.f32.fp8
-// CHECK: rocdl.cvt.scalef32.pk.f16.bf8 
-// CHECK: rocdl.cvt.scalef32.pk.f16.fp8 
+// CHECK: rocdl.cvt.scalef32.pk.f16.bf8
+// CHECK: rocdl.cvt.scalef32.pk.f16.fp8
 // CHECK: rocdl.cvt.scalef32.pk.bf16.bf8
 // CHECK: rocdl.cvt.scalef32.pk.bf16.fp8
 // CHECK: rocdl.cvt.scalef32.f16.fp8
@@ -899,4 +899,7 @@ gpu.module @module_1 [#rocdl.target<O = 1, chip = "gfx900", abi = "500", link = 
 }
 
 gpu.module @module_2 [#rocdl.target<chip = "gfx900">, #rocdl.target<chip = "gfx90a">] {
+}
+
+gpu.module @module_3 [#rocdl.target<O = 1, chip = "gfx900", abi = "600", link = ["my_device_lib.bc"], flags = {fast, daz, unsafe_math}>] {
 }

--- a/mlir/unittests/Target/LLVM/SerializeROCDLTarget.cpp
+++ b/mlir/unittests/Target/LLVM/SerializeROCDLTarget.cpp
@@ -125,7 +125,7 @@ TEST_F(MLIRTargetLLVMROCDL,
         serializer.serializeToObject(gpuModule, options);
     // Check that the serializer was successful.
     EXPECT_TRUE(StringRef(object->data(), object->size())
-                    .contains(".amdhsa_code_object_version 5"));
+                    .contains(".amdhsa_code_object_version 6"));
   }
 }
 


### PR DESCRIPTION
We already bump to COV6 by default in the front-end and backend. This PR is for MLIR.

Note that COV6 requires ROCm 6.3+.