### PR TITLE
llvm-reduce: Increase operands-to-args test coverage

### DIFF
--- a/llvm/test/tools/llvm-reduce/operands-to-args.ll
+++ b/llvm/test/tools/llvm-reduce/operands-to-args.ll
@@ -1,6 +1,7 @@
-; RUN: llvm-reduce %s -o %t --abort-on-invalid-reduction --delta-passes=operands-to-args --test FileCheck --test-arg %s --test-arg --match-full-lines --test-arg --check-prefix=INTERESTING --test-arg --input-file
-; RUN: FileCheck %s --input-file %t --check-prefixes=REDUCED,INTERESTING
+; RUN: llvm-reduce %s -o %t --abort-on-invalid-reduction --delta-passes=operands-to-args --test FileCheck --test-arg %s --test-arg --check-prefix=INTERESTING --test-arg --input-file
+; RUN: FileCheck %s --input-file %t --check-prefix=REDUCED
 
+; INTERESTING-LABEL: define void @func(
 ; REDUCED-LABEL: define void @func(i32 %k, ptr %Local, ptr %Global) {
 
 ; Keep one reference to the original value.
@@ -18,9 +19,6 @@
 ; Do not add any arguments for %Keep and @GlobalKeep.
 ; INTERESTING: %[[KEEP:LocalKeep[0-9]*]] = add i32 %k, 21
 ; INTERESTING: store i32 %[[KEEP]], ptr @GlobalKeep, align 4
-
-; INTERESTING-LABEL: define void @func_caller() {
-; REDUCED:             call void @func(i32 21, ptr null, ptr null)
 
 
 @Global = global i32 42
@@ -47,7 +45,9 @@ entry:
   ret void
 }
 
-
+; INTERESTING-LABEL: define void @func_caller(
+; REDUCED-LABEL: define void @func_caller() {
+; REDUCED: call void @func(i32 21, ptr null, ptr null)
 define void @func_caller() {
 entry:
   call void @func(i32 21)
@@ -58,14 +58,61 @@ entry:
 ; Make sure to skip functions with non-direct call users
 declare void @e(ptr)
 
-; INTERESTING-LABEL: define void @g() {
+; INTERESTING-LABEL: define void @g(
+; REDUCED-LABEL: define void @g(ptr %f) {
+; REDUCED: call void @e(ptr %f)
 define void @g() {
   call void @e(ptr @f)
   ret void
 }
 
-; INTERESTING-LABEL: define void @f(ptr %a) {
+; INTERESTING-LABEL: define void @f(
+; REDUCED-LABEL: define void @f(ptr %a) {
+; REDUCED: %1 = load ptr, ptr %a, align 8
 define void @f(ptr %a) {
   %1 = load ptr, ptr %a
+  ret void
+}
+
+@gv_init_use = global [1 x ptr] [ptr @has_global_init_user]
+
+; INTERESTING-LABEL: define void @has_global_init_user(
+; REDUCED-LABEL: define void @has_global_init_user() {
+define void @has_global_init_user() {
+  %Local = alloca i32, align 4
+  store i32 42, ptr %Local, align 4
+  ret void
+}
+
+; INTERESTING-LABEL: define void @has_callee_and_arg_user(
+; REDUCED-LABEL: define void @has_callee_and_arg_user(ptr %orig.arg) {
+define void @has_callee_and_arg_user(ptr %orig.arg) {
+  %Local = alloca i32, align 4
+  store i32 42, ptr %Local, align 4
+  ret void
+}
+
+declare void @ptr_user(ptr)
+
+; INTERESTING-LABEL: define void @calls_and_passes_func(
+; REDUCED-LABEL: define void @calls_and_passes_func(ptr %has_callee_and_arg_user) {
+; REDUCED: call void @has_callee_and_arg_user(ptr %has_callee_and_arg_user)
+define void @calls_and_passes_func() {
+  call void @has_callee_and_arg_user(ptr @has_callee_and_arg_user)
+  ret void
+}
+
+; INTERESTING-LABEL: define void @has_wrong_callsite_type_user(
+; REDUCED-LABEL: define void @has_wrong_callsite_type_user(i32 %extra.arg, ptr %Local) {
+define void @has_wrong_callsite_type_user(i32 %extra.arg) {
+  %Local = alloca i32, align 4
+  store i32 42, ptr %Local, align 4
+  ret void
+}
+
+; INTERESTING-LABEL: define void @calls_wrong_func_type(
+; REDUCED: call void @has_wrong_callsite_type_user()
+define void @calls_wrong_func_type() {
+  call void @has_wrong_callsite_type_user()
   ret void
 }


### PR DESCRIPTION
This wasn't checking the output for all functions.
--match-full-lines is also particularly hazardous for the
interestingness checks for avoiding asserts and broken IR.

Also add tests for some of the filtered function user types.
This wasn't covered, and is overly conservative.