### PR TITLE
llvm-reduce: Fix overly conservative operands-to-args user restriction

### DIFF
--- a/llvm/test/tools/llvm-reduce/operands-to-args.ll
+++ b/llvm/test/tools/llvm-reduce/operands-to-args.ll
@@ -77,7 +77,7 @@ define void @f(ptr %a) {
 @gv_init_use = global [1 x ptr] [ptr @has_global_init_user]
 
 ; INTERESTING-LABEL: define void @has_global_init_user(
-; REDUCED-LABEL: define void @has_global_init_user() {
+; REDUCED-LABEL: define void @has_global_init_user(ptr %Local) {
 define void @has_global_init_user() {
   %Local = alloca i32, align 4
   store i32 42, ptr %Local, align 4
@@ -85,7 +85,7 @@ define void @has_global_init_user() {
 }
 
 ; INTERESTING-LABEL: define void @has_callee_and_arg_user(
-; REDUCED-LABEL: define void @has_callee_and_arg_user(ptr %orig.arg) {
+; REDUCED-LABEL: define void @has_callee_and_arg_user(ptr %orig.arg, ptr %Local) {
 define void @has_callee_and_arg_user(ptr %orig.arg) {
   %Local = alloca i32, align 4
   store i32 42, ptr %Local, align 4
@@ -96,7 +96,7 @@ declare void @ptr_user(ptr)
 
 ; INTERESTING-LABEL: define void @calls_and_passes_func(
 ; REDUCED-LABEL: define void @calls_and_passes_func(ptr %has_callee_and_arg_user) {
-; REDUCED: call void @has_callee_and_arg_user(ptr %has_callee_and_arg_user)
+; REDUCED: call void @has_callee_and_arg_user(ptr %has_callee_and_arg_user, ptr null)
 define void @calls_and_passes_func() {
   call void @has_callee_and_arg_user(ptr @has_callee_and_arg_user)
   ret void

--- a/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp
@@ -19,12 +19,9 @@
 
 using namespace llvm;
 
-static bool canReplaceFunction(Function *F) {
-  return all_of(F->uses(), [](Use &Op) {
-    if (auto *CI = dyn_cast<CallBase>(Op.getUser()))
-      return &CI->getCalledOperandUse() == &Op;
-    return false;
-  });
+static bool canReplaceFunction(const Function &F) {
+  // TODO: Add controls to avoid ABI breaks (e.g. don't break main)
+  return true;
 }
 
 static bool canReduceUse(Use &Op) {
@@ -59,8 +56,9 @@ static bool canReduceUse(Use &Op) {
 static void replaceFunctionCalls(Function *OldF, Function *NewF) {
   SmallVector<CallBase *> Callers;
   for (Use &U : OldF->uses()) {
-    auto *CI = cast<CallBase>(U.getUser());
-    assert(&U == &CI->getCalledOperandUse());
+    auto *CI = dyn_cast<CallBase>(U.getUser());
+    if (!CI || !CI->isCallee(&U)) // RAUW can handle these fine.
+      continue;
 
     Function *CalledF = CI->getCalledFunction();
     if (CalledF == OldF) {
@@ -209,7 +207,7 @@ void llvm::reduceOperandsToArgsDeltaPass(Oracle &O, ReducerWorkItem &WorkItem) {
 
   SmallVector<Use *> OperandsToReduce;
   for (Function &F : make_early_inc_range(Program.functions())) {
-    if (!canReplaceFunction(&F))
+    if (!canReplaceFunction(F))
       continue;
     OperandsToReduce.clear();
     for (Instruction &I : instructions(&F)) {


### PR DESCRIPTION
I assume this was a leftover from typed pointers. It's easier to replace
the non-callee uses, they are just replacable pointer values.