### PR TITLE
[RFC][BPF] Support Jump Table

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -663,7 +663,8 @@ public:
   MCSymbol *GetExternalSymbolSymbol(const Twine &Sym) const;
 
   /// Return the symbol for the specified jump table entry.
-  MCSymbol *GetJTISymbol(unsigned JTID, bool isLinkerPrivate = false) const;
+  virtual MCSymbol *GetJTISymbol(unsigned JTID,
+                                 bool isLinkerPrivate = false) const;
 
   /// Return the symbol for the specified jump table .set
   /// FIXME: privatize to AsmPrinter.

--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -663,8 +663,7 @@ public:
   MCSymbol *GetExternalSymbolSymbol(const Twine &Sym) const;
 
   /// Return the symbol for the specified jump table entry.
-  virtual MCSymbol *GetJTISymbol(unsigned JTID,
-                                 bool isLinkerPrivate = false) const;
+  MCSymbol *GetJTISymbol(unsigned JTID, bool isLinkerPrivate = false) const;
 
   /// Return the symbol for the specified jump table .set
   /// FIXME: privatize to AsmPrinter.

--- a/llvm/lib/Target/BPF/AsmParser/BPFAsmParser.cpp
+++ b/llvm/lib/Target/BPF/AsmParser/BPFAsmParser.cpp
@@ -234,6 +234,7 @@ public:
         .Case("callx", true)
         .Case("goto", true)
         .Case("gotol", true)
+        .Case("gotox", true)
         .Case("may_goto", true)
         .Case("*", true)
         .Case("exit", true)

--- a/llvm/lib/Target/BPF/BPFAsmPrinter.cpp
+++ b/llvm/lib/Target/BPF/BPFAsmPrinter.cpp
@@ -17,18 +17,24 @@
 #include "BTFDebug.h"
 #include "MCTargetDesc/BPFInstPrinter.h"
 #include "TargetInfo/BPFTargetInfo.h"
+#include "llvm/BinaryFormat/ELF.h"
 #include "llvm/CodeGen/AsmPrinter.h"
 #include "llvm/CodeGen/MachineConstantPool.h"
 #include "llvm/CodeGen/MachineInstr.h"
+#include "llvm/CodeGen/MachineJumpTableInfo.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/TargetLowering.h"
 #include "llvm/IR/Module.h"
 #include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSymbol.h"
+#include "llvm/MC/MCSymbolELF.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Target/TargetLoweringObjectFile.h"
 using namespace llvm;
 
 #define DEBUG_TYPE "asm-printer"
@@ -49,6 +55,9 @@ public:
                              const char *ExtraCode, raw_ostream &O) override;
 
   void emitInstruction(const MachineInstr *MI) override;
+  virtual MCSymbol *GetJTISymbol(unsigned JTID,
+                                 bool isLinkerPrivate = false) const override;
+  virtual void emitJumpTableInfo() override;
 
   static char ID;
 
@@ -148,6 +157,74 @@ void BPFAsmPrinter::emitInstruction(const MachineInstr *MI) {
     MCInstLowering.Lower(MI, TmpInst);
   }
   EmitToStreamer(*OutStreamer, TmpInst);
+}
+
+MCSymbol *BPFAsmPrinter::GetJTISymbol(unsigned JTID,
+                                      bool isLinkerPrivate) const {
+  SmallString<60> Name;
+  raw_svector_ostream(Name)
+      << "BPF.JT." << MF->getFunctionNumber() << '.' << JTID;
+  MCSymbol *S = OutContext.getOrCreateSymbol(Name);
+  if (auto *ES = dyn_cast<MCSymbolELF>(S))
+    ES->setBinding(ELF::STB_GLOBAL);
+  return S;
+}
+
+void BPFAsmPrinter::emitJumpTableInfo() {
+  const MachineJumpTableInfo *MJTI = MF->getJumpTableInfo();
+  if (!MJTI)
+    return;
+
+  const std::vector<MachineJumpTableEntry> &JT = MJTI->getJumpTables();
+  if (JT.empty())
+    return;
+
+  const TargetLoweringObjectFile &TLOF = getObjFileLowering();
+  const Function &F = MF->getFunction();
+  MCSection *JTS = TLOF.getSectionForJumpTable(F, TM);
+  assert(MJTI->getEntryKind() == MachineJumpTableInfo::EK_LabelDifference32);
+  unsigned EntrySize = MJTI->getEntrySize(getDataLayout());
+  OutStreamer->switchSection(JTS);
+  for (unsigned JTI = 0; JTI < JT.size(); JTI++) {
+    ArrayRef<MachineBasicBlock *> JTBBs = JT[JTI].MBBs;
+    if (JTBBs.empty())
+      continue;
+
+    SmallPtrSet<const MachineBasicBlock *, 16> EmittedSets;
+    const TargetLowering *TLI = MF->getSubtarget().getTargetLowering();
+    const MCExpr *Base = TLI->getPICJumpTableRelocBaseExpr(MF, JTI, OutContext);
+    for (const MachineBasicBlock *MBB : JTBBs) {
+      if (!EmittedSets.insert(MBB).second)
+        continue;
+
+      // Offset from gotox to target basic block expressed in number
+      // of instructions, e.g.:
+      //
+      //   .L0_0_set_4 = ((LBB0_4 - .LBPF.JX.0.0) >> 3) - 1
+      const MCExpr *LHS = MCSymbolRefExpr::create(MBB->getSymbol(), OutContext);
+      OutStreamer->emitAssignment(
+          GetJTSetSymbol(JTI, MBB->getNumber()),
+          MCBinaryExpr::createSub(
+              MCBinaryExpr::createAShr(
+                  MCBinaryExpr::createSub(LHS, Base, OutContext),
+                  MCConstantExpr::create(3, OutContext), OutContext),
+              MCConstantExpr::create(1, OutContext), OutContext));
+    }
+    // BPF.JT.0.0:
+    //    .long   .L0_0_set_4
+    //    .long   .L0_0_set_2
+    //    ...
+    //    .size   BPF.JT.0.0, 128
+    MCSymbol *JTStart = GetJTISymbol(JTI);
+    OutStreamer->emitLabel(JTStart);
+    for (const MachineBasicBlock *MBB : JTBBs) {
+      MCSymbol *SetSymbol = GetJTSetSymbol(JTI, MBB->getNumber());
+      const MCExpr *V = MCSymbolRefExpr::create(SetSymbol, OutContext);
+      OutStreamer->emitValue(V, EntrySize);
+    }
+    const MCExpr *JTSize = MCConstantExpr::create(JTBBs.size() * 4, OutContext);
+    OutStreamer->emitELFSize(JTStart, JTSize);
+  }
 }
 
 char BPFAsmPrinter::ID = 0;

--- a/llvm/lib/Target/BPF/BPFAsmPrinter.h
+++ b/llvm/lib/Target/BPF/BPFAsmPrinter.h
@@ -1,0 +1,44 @@
+//===-- BPFFrameLowering.h - Define frame lowering for BPF -----*- C++ -*--===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_BPF_BPFASMPRINTER_H
+#define LLVM_LIB_TARGET_BPF_BPFASMPRINTER_H
+
+#include "BTFDebug.h"
+#include "llvm/CodeGen/AsmPrinter.h"
+
+namespace llvm {
+
+class BPFAsmPrinter : public AsmPrinter {
+public:
+  explicit BPFAsmPrinter(TargetMachine &TM,
+                         std::unique_ptr<MCStreamer> Streamer)
+      : AsmPrinter(TM, std::move(Streamer), ID), BTF(nullptr) {}
+
+  StringRef getPassName() const override { return "BPF Assembly Printer"; }
+  bool doInitialization(Module &M) override;
+  void printOperand(const MachineInstr *MI, int OpNum, raw_ostream &O);
+  bool PrintAsmOperand(const MachineInstr *MI, unsigned OpNo,
+                       const char *ExtraCode, raw_ostream &O) override;
+  bool PrintAsmMemoryOperand(const MachineInstr *MI, unsigned OpNum,
+                             const char *ExtraCode, raw_ostream &O) override;
+
+  void emitInstruction(const MachineInstr *MI) override;
+  MCSymbol *getJTPublicSymbol(unsigned JTI);
+  MCSymbol *getJXAnchorSymbol(unsigned JTI);
+  virtual void emitJumpTableInfo() override;
+
+  static char ID;
+
+private:
+  BTFDebug *BTF;
+};
+
+} // namespace llvm
+
+#endif /* LLVM_LIB_TARGET_BPF_BPFASMPRINTER_H */

--- a/llvm/lib/Target/BPF/BPFISelLowering.cpp
+++ b/llvm/lib/Target/BPF/BPFISelLowering.cpp
@@ -1092,20 +1092,6 @@ bool BPFTargetLowering::isLegalAddressingMode(const DataLayout &DL,
   return true;
 }
 
-MCSymbol *BPFTargetLowering::getJXAnchorSymbol(const MachineFunction *MF,
-                                               unsigned JTI) {
-  const MCAsmInfo *MAI = MF->getContext().getAsmInfo();
-  SmallString<60> Name;
-  raw_svector_ostream(Name) << MAI->getPrivateGlobalPrefix() << "BPF.JX."
-                            << MF->getFunctionNumber() << '.' << JTI;
-  return MF->getContext().getOrCreateSymbol(Name);
-}
-
 unsigned BPFTargetLowering::getJumpTableEncoding() const {
   return MachineJumpTableInfo::EK_LabelDifference32;
-}
-
-const MCExpr *BPFTargetLowering::getPICJumpTableRelocBaseExpr(
-    const MachineFunction *MF, unsigned JTI, MCContext &Ctx) const {
-  return MCSymbolRefExpr::create(getJXAnchorSymbol(MF, JTI), Ctx);
 }

--- a/llvm/lib/Target/BPF/BPFISelLowering.cpp
+++ b/llvm/lib/Target/BPF/BPFISelLowering.cpp
@@ -72,8 +72,10 @@ BPFTargetLowering::BPFTargetLowering(const TargetMachine &TM,
   setStackPointerRegisterToSaveRestore(BPF::R11);
 
   setOperationAction(ISD::BR_CC, MVT::i64, Custom);
-  setOperationAction(ISD::BR_JT, MVT::Other, Custom);
   setOperationAction(ISD::BRCOND, MVT::Other, Expand);
+  LegalizeAction IndirectBrAction = STI.hasGotox() ? Custom : Expand;
+  setOperationAction(ISD::BR_JT, MVT::Other, IndirectBrAction);
+  setOperationAction(ISD::BRIND, MVT::Other, IndirectBrAction);
 
   setOperationAction(ISD::TRAP, MVT::Other, Custom);
 

--- a/llvm/lib/Target/BPF/BPFISelLowering.h
+++ b/llvm/lib/Target/BPF/BPFISelLowering.h
@@ -71,27 +71,6 @@ public:
   // JX instruction location and target basic block label.
   virtual unsigned getJumpTableEncoding() const override;
 
-  // This is a label for JX instructions, used for jump table offsets
-  // computation, e.g.:
-  //
-  //   .LBPF.JX.0.0:                         <------- this is the anchor
-  //        .reloc 0, FK_SecRel_8, BPF.JT.0.0
-  //        gotox r1
-  //        ...
-  //   .section        .jumptables,"",@progbits
-  //   .L0_0_set_7 = ((LBB0_7-.LBPF.JX.0.0)>>3)-1
-  //   ...
-  //   BPF.JT.0.0:                           <------- JT definition
-  //        .long   .L0_0_set_7
-  //        ...
-  static MCSymbol *getJXAnchorSymbol(const MachineFunction *MF, unsigned JTI);
-
-  // Refers to a symbol returned by getJXAnchorSymbol(), used by
-  // AsmPrinter::emitJumpTableInfo() to define the .L0_0_set_7 etc above.
-  virtual const MCExpr *
-  getPICJumpTableRelocBaseExpr(const MachineFunction *MF, unsigned JTI,
-                               MCContext &Ctx) const override;
-
 private:
   // Control Instruction Selection Features
   bool HasAlu32;

--- a/llvm/lib/Target/BPF/BPFInstrInfo.cpp
+++ b/llvm/lib/Target/BPF/BPFInstrInfo.cpp
@@ -181,9 +181,10 @@ bool BPFInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
     if (!isUnpredicatedTerminator(*I))
       break;
 
-    // If a JX insn, we're done.
-    if (I->getOpcode() == BPF::JX)
-      break;
+    // From base method doc: ... returning true if it cannot be understood ...
+    // Indirect branch has multiple destinations and no true/false concepts.
+    if (I->isIndirectBranch())
+      return true;
 
     // A terminator that isn't a branch can't easily be handled
     // by this analysis.

--- a/llvm/lib/Target/BPF/BPFInstrInfo.cpp
+++ b/llvm/lib/Target/BPF/BPFInstrInfo.cpp
@@ -181,6 +181,10 @@ bool BPFInstrInfo::analyzeBranch(MachineBasicBlock &MBB,
     if (!isUnpredicatedTerminator(*I))
       break;
 
+    // If a JX insn, we're done.
+    if (I->getOpcode() == BPF::JX)
+      break;
+
     // A terminator that isn't a branch can't easily be handled
     // by this analysis.
     if (!I->isBranch())
@@ -258,4 +262,12 @@ unsigned BPFInstrInfo::removeBranch(MachineBasicBlock &MBB,
   }
 
   return Count;
+}
+
+int BPFInstrInfo::getJumpTableIndex(const MachineInstr &MI) const {
+  if (MI.getOpcode() != BPF::JX)
+    return -1;
+  const MachineOperand &MO = MI.getOperand(1);
+  assert(MO.isJTI() && "JX operand #0 should be isJTI");
+  return MO.getIndex();
 }

--- a/llvm/lib/Target/BPF/BPFInstrInfo.h
+++ b/llvm/lib/Target/BPF/BPFInstrInfo.h
@@ -58,6 +58,9 @@ public:
                         MachineBasicBlock *FBB, ArrayRef<MachineOperand> Cond,
                         const DebugLoc &DL,
                         int *BytesAdded = nullptr) const override;
+
+  int getJumpTableIndex(const MachineInstr &MI) const override;
+
 private:
   void expandMEMCPY(MachineBasicBlock::iterator) const;
 

--- a/llvm/lib/Target/BPF/BPFInstrInfo.td
+++ b/llvm/lib/Target/BPF/BPFInstrInfo.td
@@ -31,6 +31,8 @@ def SDT_BPFMEMCPY       : SDTypeProfile<0, 4, [SDTCisVT<0, i64>,
                                                SDTCisVT<1, i64>,
                                                SDTCisVT<2, i64>,
                                                SDTCisVT<3, i64>]>;
+def SDT_BPFBrJt         : SDTypeProfile<0, 2, [SDTCisVT<0, i32>,    // jump table
+                                               SDTCisVT<1, i64>]>;  // index
 
 def BPFcall         : SDNode<"BPFISD::CALL", SDT_BPFCall,
                              [SDNPHasChain, SDNPOptInGlue, SDNPOutGlue,
@@ -49,6 +51,9 @@ def BPFWrapper      : SDNode<"BPFISD::Wrapper", SDT_BPFWrapper>;
 def BPFmemcpy       : SDNode<"BPFISD::MEMCPY", SDT_BPFMEMCPY,
                              [SDNPHasChain, SDNPInGlue, SDNPOutGlue,
                               SDNPMayStore, SDNPMayLoad]>;
+def BPFBrJt         : SDNode<"BPFISD::BPF_BR_JT", SDT_BPFBrJt,
+                             [SDNPHasChain]>;
+
 def BPFIsLittleEndian : Predicate<"Subtarget->isLittleEndian()">;
 def BPFIsBigEndian    : Predicate<"!Subtarget->isLittleEndian()">;
 def BPFHasALU32 : Predicate<"Subtarget->getHasAlu32()">;
@@ -183,6 +188,15 @@ class TYPE_LD_ST<bits<3> mode, bits<2> size,
   let Inst{60-59} = size;
 }
 
+// For indirect jump
+class TYPE_IND_JMP<bits<4> op, bits<1> srctype,
+                   dag outs, dag ins, string asmstr, list<dag> pattern>
+  : InstBPF<outs, ins, asmstr, pattern> {
+
+  let Inst{63-60} = op;
+  let Inst{59} = srctype;
+}
+
 // jump instructions
 class JMP_RR<BPFJumpOp Opc, string OpcodeStr, PatLeaf Cond>
     : TYPE_ALU_JMP<Opc.Value, BPF_X.Value,
@@ -213,6 +227,18 @@ class JMP_RI<BPFJumpOp Opc, string OpcodeStr, PatLeaf Cond>
   let Inst{51-48} = dst;
   let Inst{47-32} = BrDst;
   let Inst{31-0} = imm;
+  let BPFClass = BPF_JMP;
+}
+
+class JMP_IND<BPFJumpOp Opc, string OpcodeStr, list<dag> Pattern>
+    : TYPE_ALU_JMP<Opc.Value, BPF_X.Value,
+                   (outs),
+                   (ins GPR:$dst, i32imm:$jt),
+                   !strconcat(OpcodeStr, " $dst"),
+                   Pattern> {
+  bits<4> dst;
+
+  let Inst{51-48} = dst;
   let BPFClass = BPF_JMP;
 }
 
@@ -281,6 +307,10 @@ defm JSLT : J<BPF_JSLT, "s<", BPF_CC_LT, BPF_CC_LT_32>;
 defm JSLE : J<BPF_JSLE, "s<=", BPF_CC_LE, BPF_CC_LE_32>;
 defm JSET : J<BPF_JSET, "&", NoCond, NoCond>;
 def JCOND : JMP_JCOND<BPF_JCOND, "may_goto", []>;
+
+let isIndirectBranch = 1 in {
+  def JX : JMP_IND<BPF_JA, "gotox", [(BPFBrJt tjumptable:$jt, i64:$dst)]>;
+}
 }
 
 // ALU instructions

--- a/llvm/lib/Target/BPF/BPFInstrInfo.td
+++ b/llvm/lib/Target/BPF/BPFInstrInfo.td
@@ -308,7 +308,7 @@ defm JSLE : J<BPF_JSLE, "s<=", BPF_CC_LE, BPF_CC_LE_32>;
 defm JSET : J<BPF_JSET, "&", NoCond, NoCond>;
 def JCOND : JMP_JCOND<BPF_JCOND, "may_goto", []>;
 
-let isIndirectBranch = 1 in {
+let isIndirectBranch = 1, isBarrier = 1, isNotDuplicable = 1 in {
   def JX : JMP_IND<BPF_JA, "gotox", [(BPFBrJt tjumptable:$jt, i64:$dst)]>;
 }
 }

--- a/llvm/lib/Target/BPF/BPFMCInstLower.cpp
+++ b/llvm/lib/Target/BPF/BPFMCInstLower.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "BPFMCInstLower.h"
+#include "BPFAsmPrinter.h"
 #include "BPFISelLowering.h"
 #include "llvm/CodeGen/AsmPrinter.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
@@ -57,9 +58,8 @@ MCOperand BPFMCInstLower::LowerJTIOperand(const MachineInstr &MI,
   //        gotox r1
   assert((MI.getOpcode() == BPF::JX) &&
          "Jump Table Index operands are expected only for JX instructions");
-  const MachineFunction *MF = MI.getMF();
-  Printer.OutStreamer->emitLabel(BPFTargetLowering::getJXAnchorSymbol(MF, JTI));
-  MCSymbol *JT = Printer.GetJTISymbol(JTI);
+  Printer.OutStreamer->emitLabel(Printer.getJXAnchorSymbol(JTI));
+  MCSymbol *JT = Printer.getJTPublicSymbol(JTI);
   const MCExpr *Zero = MCConstantExpr::create(0, Ctx);
   Printer.OutStreamer->emitRelocDirective(*Zero, "FK_SecRel_8",
                                           MCSymbolRefExpr::create(JT, Ctx), {},

--- a/llvm/lib/Target/BPF/BPFMCInstLower.h
+++ b/llvm/lib/Target/BPF/BPFMCInstLower.h
@@ -12,7 +12,7 @@
 #include "llvm/Support/Compiler.h"
 
 namespace llvm {
-class AsmPrinter;
+class BPFAsmPrinter;
 class MCContext;
 class MCInst;
 class MCOperand;
@@ -24,10 +24,10 @@ class MachineOperand;
 class LLVM_LIBRARY_VISIBILITY BPFMCInstLower {
   MCContext &Ctx;
 
-  AsmPrinter &Printer;
+  BPFAsmPrinter &Printer;
 
 public:
-  BPFMCInstLower(MCContext &ctx, AsmPrinter &printer)
+  BPFMCInstLower(MCContext &ctx, BPFAsmPrinter &printer)
       : Ctx(ctx), Printer(printer) {}
   void Lower(const MachineInstr *MI, MCInst &OutMI) const;
 

--- a/llvm/lib/Target/BPF/BPFMCInstLower.h
+++ b/llvm/lib/Target/BPF/BPFMCInstLower.h
@@ -32,6 +32,8 @@ public:
   void Lower(const MachineInstr *MI, MCInst &OutMI) const;
 
   MCOperand LowerSymbolOperand(const MachineOperand &MO, MCSymbol *Sym) const;
+  MCOperand LowerJTIOperand(const MachineInstr &MI, const MachineOperand &MO,
+                            int JTI) const;
 
   MCSymbol *GetGlobalAddressSymbol(const MachineOperand &MO) const;
   MCSymbol *GetExternalSymbolSymbol(const MachineOperand &MO) const;

--- a/llvm/lib/Target/BPF/BPFSubtarget.cpp
+++ b/llvm/lib/Target/BPF/BPFSubtarget.cpp
@@ -43,6 +43,8 @@ static cl::opt<bool>
 static cl::opt<bool> Disable_load_acq_store_rel(
     "disable-load-acq-store-rel", cl::Hidden, cl::init(false),
     cl::desc("Disable load-acquire and store-release insns"));
+static cl::opt<bool> Disable_gotox("disable-gotox", cl::Hidden, cl::init(false),
+                                   cl::desc("Disable gotox insn"));
 
 void BPFSubtarget::anchor() {}
 
@@ -66,6 +68,7 @@ void BPFSubtarget::initializeEnvironment() {
   HasGotol = false;
   HasStoreImm = false;
   HasLoadAcqStoreRel = false;
+  HasGotox = false;
 }
 
 void BPFSubtarget::initSubtargetFeatures(StringRef CPU, StringRef FS) {
@@ -96,6 +99,7 @@ void BPFSubtarget::initSubtargetFeatures(StringRef CPU, StringRef FS) {
     HasGotol = !Disable_gotol;
     HasStoreImm = !Disable_StoreImm;
     HasLoadAcqStoreRel = !Disable_load_acq_store_rel;
+    HasGotox = !Disable_gotox;
     return;
   }
 }

--- a/llvm/lib/Target/BPF/BPFSubtarget.h
+++ b/llvm/lib/Target/BPF/BPFSubtarget.h
@@ -65,7 +65,7 @@ protected:
 
   // whether cpu v4 insns are enabled.
   bool HasLdsx, HasMovsx, HasBswap, HasSdivSmod, HasGotol, HasStoreImm,
-      HasLoadAcqStoreRel;
+      HasLoadAcqStoreRel, HasGotox;
 
   std::unique_ptr<CallLowering> CallLoweringInfo;
   std::unique_ptr<InstructionSelector> InstSelector;
@@ -94,6 +94,7 @@ public:
   bool hasGotol() const { return HasGotol; }
   bool hasStoreImm() const { return HasStoreImm; }
   bool hasLoadAcqStoreRel() const { return HasLoadAcqStoreRel; }
+  bool hasGotox() const { return HasGotox; }
 
   bool isLittleEndian() const { return IsLittleEndian; }
 

--- a/llvm/lib/Target/BPF/BPFTargetLoweringObjectFile.cpp
+++ b/llvm/lib/Target/BPF/BPFTargetLoweringObjectFile.cpp
@@ -1,0 +1,19 @@
+//===------------------ BPFTargetLoweringObjectFile.cpp -------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "BPFTargetLoweringObjectFile.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCSectionELF.h"
+
+using namespace llvm;
+
+MCSection *BPFTargetLoweringObjectFileELF::getSectionForJumpTable(
+    const Function &F, const TargetMachine &TM,
+    const MachineJumpTableEntry *JTE) const {
+  return getContext().getELFSection(".jumptables", ELF::SHT_PROGBITS, 0);
+}

--- a/llvm/lib/Target/BPF/BPFTargetLoweringObjectFile.h
+++ b/llvm/lib/Target/BPF/BPFTargetLoweringObjectFile.h
@@ -1,0 +1,25 @@
+//===============-  BPFTargetLoweringObjectFile.h  -*- C++ -*-================//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_BPF_BPFTARGETLOWERINGOBJECTFILE
+#define LLVM_LIB_TARGET_BPF_BPFTARGETLOWERINGOBJECTFILE
+
+#include "llvm/CodeGen/TargetLoweringObjectFileImpl.h"
+#include "llvm/Target/TargetLoweringObjectFile.h"
+
+namespace llvm {
+class BPFTargetLoweringObjectFileELF : public TargetLoweringObjectFileELF {
+
+public:
+  virtual MCSection *
+  getSectionForJumpTable(const Function &F, const TargetMachine &TM,
+                         const MachineJumpTableEntry *JTE) const override;
+};
+} // namespace llvm
+
+#endif // LLVM_LIB_TARGET_BPF_BPFTARGETLOWERINGOBJECTFILE

--- a/llvm/lib/Target/BPF/BPFTargetMachine.cpp
+++ b/llvm/lib/Target/BPF/BPFTargetMachine.cpp
@@ -12,6 +12,7 @@
 
 #include "BPFTargetMachine.h"
 #include "BPF.h"
+#include "BPFTargetLoweringObjectFile.h"
 #include "BPFTargetTransformInfo.h"
 #include "MCTargetDesc/BPFMCAsmInfo.h"
 #include "TargetInfo/BPFTargetInfo.h"
@@ -80,7 +81,7 @@ BPFTargetMachine::BPFTargetMachine(const Target &T, const Triple &TT,
     : CodeGenTargetMachineImpl(T, computeDataLayout(TT), TT, CPU, FS, Options,
                                getEffectiveRelocModel(RM),
                                getEffectiveCodeModel(CM, CodeModel::Small), OL),
-      TLOF(std::make_unique<TargetLoweringObjectFileELF>()),
+      TLOF(std::make_unique<BPFTargetLoweringObjectFileELF>()),
       Subtarget(TT, std::string(CPU), std::string(FS), *this) {
   if (!DisableCheckUnreachable) {
     this->Options.TrapUnreachable = true;

--- a/llvm/lib/Target/BPF/CMakeLists.txt
+++ b/llvm/lib/Target/BPF/CMakeLists.txt
@@ -37,6 +37,7 @@ add_llvm_target(BPFCodeGen
   BPFRegisterInfo.cpp
   BPFSelectionDAGInfo.cpp
   BPFSubtarget.cpp
+  BPFTargetLoweringObjectFile.cpp
   BPFTargetMachine.cpp
   BPFMIPeephole.cpp
   BPFMIChecking.cpp

--- a/llvm/lib/Target/BPF/MCTargetDesc/BPFAsmBackend.cpp
+++ b/llvm/lib/Target/BPF/MCTargetDesc/BPFAsmBackend.cpp
@@ -34,6 +34,7 @@ public:
   createObjectTargetWriter() const override;
 
   MCFixupKindInfo getFixupKindInfo(MCFixupKind Kind) const override;
+  std::optional<MCFixupKind> getFixupKind(StringRef Name) const override;
 
   bool writeNopData(raw_ostream &OS, uint64_t Count,
                     const MCSubtargetInfo *STI) const override;
@@ -52,6 +53,18 @@ MCFixupKindInfo BPFAsmBackend::getFixupKindInfo(MCFixupKind Kind) const {
   assert(unsigned(Kind - FirstTargetFixupKind) < BPF::NumTargetFixupKinds &&
          "Invalid kind!");
   return Infos[Kind - FirstTargetFixupKind];
+}
+
+std::optional<MCFixupKind> BPFAsmBackend::getFixupKind(StringRef Name) const {
+  if (Name == "FK_SecRel_8")
+    return FK_SecRel_8;
+  if (Name == "FK_BPF_PCRel_4")
+    return BPF::FK_BPF_PCRel_4;
+  if (Name == "FK_Data_8")
+    return FK_Data_8;
+  if (Name == "FK_Data_4")
+    return FK_Data_4;
+  return std::nullopt;
 }
 
 bool BPFAsmBackend::writeNopData(raw_ostream &OS, uint64_t Count,

--- a/llvm/test/CodeGen/BPF/jump-table-multi.ll
+++ b/llvm/test/CodeGen/BPF/jump-table-multi.ll
@@ -1,0 +1,78 @@
+; RUN: llc -O2 -bpf-min-jump-table-entries=1 -mtriple=bpfel -mcpu=v4 < %s | FileCheck %s
+
+; Check that two jump tables of different size are generated
+
+define i64 @foo(i64 %v1, i64 %v2) {
+; CHECK:      .LBPF.JX.0.0:
+; CHECK-NEXT:        .reloc 0, FK_SecRel_8, BPF.JT.0.0
+; CHECK-NEXT:        gotox r1
+
+; CHECK:      .LBPF.JX.0.1:
+; CHECK-NEXT:        .reloc 0, FK_SecRel_8, BPF.JT.0.1
+; CHECK-NEXT:        gotox r2
+
+; CHECK:        .section        .jumptables,"",@progbits
+
+; CHECK-NEXT: [[m1:.*]] = (({{.*}}-.LBPF.JX.0.0)>>3)-1
+; CHECK-NEXT: [[m2:.*]] = (({{.*}}-.LBPF.JX.0.0)>>3)-1
+; CHECK-NEXT: BPF.JT.0.0:
+; CHECK-NEXT:         .long   [[m1]]
+; CHECK-NEXT:         .long   [[m2]]
+; CHECK-NEXT:         .size   BPF.JT.0.0, 8
+
+; CHECK-NEXT: [[m1:.*]] = (({{.*}}-.LBPF.JX.0.1)>>3)-1
+; CHECK-NEXT: [[m2:.*]] = (({{.*}}-.LBPF.JX.0.1)>>3)-1
+; CHECK-NEXT: [[m3:.*]] = (({{.*}}-.LBPF.JX.0.1)>>3)-1
+; CHECK-NEXT: BPF.JT.0.1:
+; CHECK-NEXT:         .long [[m1]]
+; CHECK-NEXT:         .long [[m2]]
+; CHECK-NEXT:         .long [[m3]]
+; CHECK-NEXT:         .size BPF.JT.0.1, 12
+
+entry:
+  switch i64 %v1, label %sw.default [
+    i64 0, label %sw.bb1
+    i64 1, label %sw.bb2
+  ]
+
+sw.bb1:
+  br label %sw.epilog
+
+sw.bb2:
+  br label %sw.epilog
+
+sw.default:
+  br label %sw.epilog
+
+sw.epilog:
+  %ret = phi i64 [ 42, %sw.default ], [ 3, %sw.bb1 ], [ 5, %sw.bb2 ]
+  switch i64 %v2, label %sw.default.1 [
+    i64 0, label %sw.bb1.1
+    i64 1, label %sw.bb2.1
+    i64 2, label %sw.bb3.1
+  ]
+
+sw.bb1.1:
+  br label %sw.epilog.1
+
+sw.bb2.1:
+  br label %sw.epilog.1
+
+sw.bb3.1:
+  br label %sw.epilog.1
+
+sw.default.1:
+  br label %sw.epilog.1
+
+sw.epilog.1:
+  %ret.1 = phi i64 [ 42, %sw.default.1 ], [ 3, %sw.bb1.1 ], [ 5, %sw.bb2.1 ], [ 7, %sw.bb3.1 ]
+  %ret.2 = add i64 %ret, %ret.1
+  ret i64 %ret.2
+}
+
+!llvm.module.flags = !{!0, !1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"frame-pointer", i32 2}
+!2 = !{!"clang some version"}

--- a/llvm/test/CodeGen/BPF/jump-table-simple.ll
+++ b/llvm/test/CodeGen/BPF/jump-table-simple.ll
@@ -1,0 +1,86 @@
+; Checks generated using command:
+;
+;    llvm/utils/update_test_body.py llvm/test/CodeGen/BPF/jump-table-simple.ll
+;
+; RUN: rm -rf %t && split-file %s %t && cd %t
+; RUN: llc -O2 -bpf-min-jump-table-entries=1 -mtriple=bpfel -mcpu=v4 < test.ll | FileCheck %s
+;
+; Check general program structure generated for a jump table
+
+.ifdef GEN
+;--- test.ll
+define i64 @foo(i64 %v) {
+entry:
+  switch i64 %v, label %sw.default [
+    i64 0, label %sw.epilog
+    i64 1, label %sw.bb1
+    i64 2, label %sw.bb1
+    i64 3, label %sw.bb2
+  ]
+
+sw.bb1:
+  br label %sw.epilog
+
+sw.bb2:
+  br label %sw.epilog
+
+sw.default:
+  br label %sw.epilog
+
+sw.epilog:
+  %ret = phi i64 [ 42, %sw.default ], [ 3, %sw.bb1 ], [ 5, %sw.bb2 ], [ 7, %entry ]
+  ret i64 %ret
+}
+
+!llvm.module.flags = !{!0, !1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"frame-pointer", i32 2}
+!2 = !{!"clang some version"}
+
+;--- gen
+echo ""
+echo "; Generated checks follow"
+echo ";"
+llc -O2 -bpf-min-jump-table-entries=1 -mtriple=bpfel -mcpu=v4 < test.ll \
+  | awk '/# -- End function/ {p=0} /@function/ {p=1} p {print "; CHECK" ": " $0}'
+.endif
+
+; Generated checks follow
+;
+; CHECK: 	.type	foo,@function
+; CHECK: foo:                                    # @foo
+; CHECK: 	.cfi_startproc
+; CHECK: # %bb.0:                                # %entry
+; CHECK: 	if r1 > 3 goto LBB0_5
+; CHECK: # %bb.1:                                # %entry
+; CHECK: .LBPF.JX.0.0:
+; CHECK: 	.reloc 0, FK_SecRel_8, BPF.JT.0.0
+; CHECK: 	gotox r1
+; CHECK: LBB0_3:                                 # %sw.bb1
+; CHECK: 	r0 = 3
+; CHECK: 	goto LBB0_6
+; CHECK: LBB0_2:
+; CHECK: 	r0 = 7
+; CHECK: 	goto LBB0_6
+; CHECK: LBB0_4:                                 # %sw.bb2
+; CHECK: 	r0 = 5
+; CHECK: 	goto LBB0_6
+; CHECK: LBB0_5:                                 # %sw.default
+; CHECK: 	r0 = 42
+; CHECK: LBB0_6:                                 # %sw.epilog
+; CHECK: 	exit
+; CHECK: .Lfunc_end0:
+; CHECK: 	.size	foo, .Lfunc_end0-foo
+; CHECK: 	.cfi_endproc
+; CHECK: 	.section	.jumptables,"",@progbits
+; CHECK: .L0_0_set_2 = ((LBB0_2-.LBPF.JX.0.0)>>3)-1
+; CHECK: .L0_0_set_3 = ((LBB0_3-.LBPF.JX.0.0)>>3)-1
+; CHECK: .L0_0_set_4 = ((LBB0_4-.LBPF.JX.0.0)>>3)-1
+; CHECK: BPF.JT.0.0:
+; CHECK: 	.long	.L0_0_set_2
+; CHECK: 	.long	.L0_0_set_3
+; CHECK: 	.long	.L0_0_set_3
+; CHECK: 	.long	.L0_0_set_4
+; CHECK: 	.size	BPF.JT.0.0, 16


### PR DESCRIPTION
NOTE: We probably need cpu v5 or other flags to enable this feature. We can add it later when necessary.
```
- Generate all jump tables in a single section named .jumptables.
- Represent each jump table as a symbol:
  - value points to an offset within .jumptables;
  - size encodes jump table size in bytes.
- Indirect jump is a gotox instruction:
  - dst register is an index within the table;
  - accompanied by a R_BPF_64_64 relocation pointing to a jump table
    symbol.

clang -S:

  .LJTI0_0:
          .reloc 0, FK_SecRel_8, .BPF.JT.0.0
          gotox r1
          goto LBB0_2
  LBB0_4:
          ...

          .section        .jumptables,"",@progbits
  .L0_0_set_4 = ((LBB0_4-.LBPF.JX.0.0)>>3)-1
  .L0_0_set_2 = ((LBB0_2-.LBPF.JX.0.0)>>3)-1
  ...
  .BPF.JT.0.0:
          .long   .L0_0_set_4
          .long   .L0_0_set_2
          ...

llvm-readelf -r --sections --symbols:

  Section Headers:
    [Nr] Name              Type            Address          Off    Size   ES Flg Lk Inf Al
    ...
    [ 4] .jumptables       PROGBITS        0000000000000000 000118 000100 00      0   0  1
    ...

  Relocation section '.rel.text' at offset 0x2a8 contains 2 entries:
      Offset             Info             Type               Symbol's Value  Symbol's Name
  0000000000000010  0000000300000001 R_BPF_64_64            0000000000000000 .BPF.JT.0.0
  ...

  Symbol table '.symtab' contains 6 entries:
     Num:    Value          Size Type    Bind   Vis       Ndx Name
       ...
       2: 0000000000000000   112 FUNC    GLOBAL DEFAULT     2 foo
       3: 0000000000000000   128 NOTYPE  GLOBAL DEFAULT     4 .BPF.JT.0.0
       ...

llvm-objdump -Sdr:

  0000000000000000 <foo>:
       ...
       2:       gotox r1
                0000000000000010:  R_BPF_64_64  .BPF.JT.0.0
```

An option `-bpf-min-jump-table-entries` is implemented to control the minimum
number of entries to use a jump table on BPF. The default value 4, but it
can be changed with the following clang option
```
  clang ... -mllvm -bpf-min-jump-table-entries=6
```
where the number of jump table cases needs to be >= 6 in order to
use jump table.