### PR TITLE
llvm-reduce: Do not delete convergencectrl in operand-bundles

### DIFF
--- a/llvm/test/tools/llvm-reduce/remove-operand-bundles-convergencectrl.ll
+++ b/llvm/test/tools/llvm-reduce/remove-operand-bundles-convergencectrl.ll
@@ -1,0 +1,36 @@
+; Check that invalid reductions aren't introduced by deleting
+; convergencectrl bundles in convergent functions
+;
+; RUN: llvm-reduce --abort-on-invalid-reduction --delta-passes=operand-bundles --test FileCheck --test-arg --check-prefixes=CHECK,INTERESTING --test-arg %s --test-arg --input-file %s -o %t
+; RUN: FileCheck --check-prefixes=CHECK,RESULT %s < %t
+
+; CHECK-LABEL: define float @convergentctrl_one_interesting(
+; INTERESTING: %interesting = call float @convergent.extern.func(
+; RESULT: %entry.token = call token @llvm.experimental.convergence.entry()
+; RESULT: %interesting = call float @convergent.extern.func(float %x) [ "convergencectrl"(token %entry.token) ]
+; RESULT: %boring = call float @convergent.extern.func(float %x) [ "convergencectrl"(token %entry.token) ]
+define float @convergentctrl_one_interesting(float %x, float %y) #0 {
+  %entry.token = call token @llvm.experimental.convergence.entry()
+  %interesting = call float @convergent.extern.func(float %x) [ "convergencectrl"(token %entry.token) ]
+  %boring = call float @convergent.extern.func(float %x) [ "convergencectrl"(token %entry.token) ]
+  %add = fadd float %interesting, %boring
+  ret float %add
+}
+
+; In theory we could remove the bundle here, since all convergencectrl
+; in the function will be removed.
+
+; CHECK-LABEL: define float @convergentctrl_can_remove_all(
+; RESULT: %entry.token = call token @llvm.experimental.convergence.entry()
+; RESULT: %val = call float @convergent.extern.func(float %x) [ "convergencectrl"(token %entry.token) ]
+define float @convergentctrl_can_remove_all(float %x, float %y) #0 {
+  %entry.token = call token @llvm.experimental.convergence.entry()
+  %val = call float @convergent.extern.func(float %x) [ "convergencectrl"(token %entry.token) ]
+  ret float %val
+}
+
+declare float @convergent.extern.func(float) #0
+declare token @llvm.experimental.convergence.entry() #1
+
+attributes #0 = { convergent }
+attributes #1 = { convergent nocallback nofree nosync nounwind willreturn memory(none) }

--- a/llvm/tools/llvm-reduce/deltas/ReduceOperandBundles.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperandBundles.cpp
@@ -32,6 +32,13 @@ using namespace llvm;
 
 namespace {
 
+/// Return true if stripping the bundle from a call will result in invalid IR.
+static bool shouldKeepBundleTag(uint32_t BundleTagID) {
+  // In convergent functions using convergencectrl bundles, all convergent calls
+  // must use the convergence bundles so don't try to remove them.
+  return BundleTagID == LLVMContext::OB_convergencectrl;
+}
+
 /// Given ChunksToKeep, produce a map of calls and indexes of operand bundles
 /// to be preserved for each call.
 class OperandBundleRemapper : public InstVisitor<OperandBundleRemapper> {
@@ -53,9 +60,12 @@ public:
     OperandBundlesToKeepIndexes.reserve(Call.getNumOperandBundles());
 
     // Enumerate every operand bundle on this call.
-    for (unsigned BundleIndex : seq(Call.getNumOperandBundles()))
-      if (O.shouldKeep()) // Should we keep this one?
+    for (unsigned BundleIndex : seq(Call.getNumOperandBundles())) {
+      if (shouldKeepBundleTag(
+              Call.getOperandBundleAt(BundleIndex).getTagID()) ||
+          O.shouldKeep()) // Should we keep this one?
         OperandBundlesToKeepIndexes.emplace_back(BundleIndex);
+    }
   }
 };
 


### PR DESCRIPTION
The IR verifier will fail if there are any convergent calls without
a convergencectrl bundle, if there are any convergencectrl bundles.

With the current verifier rules, we would need to drop all the instances
of convergencectrl in the function as a set, and strip all the convergence
token intrinsics. As such, I think it would be more appropriate to have a
separate convergence reduction pass.