### PR TITLE
llvm-reduce: Reduce externally_initialized

### DIFF
--- a/llvm/test/tools/llvm-reduce/reduce-externally-initialized.ll
+++ b/llvm/test/tools/llvm-reduce/reduce-externally-initialized.ll
@@ -1,0 +1,11 @@
+; RUN: llvm-reduce -abort-on-invalid-reduction --delta-passes=global-values --test FileCheck --test-arg --check-prefix=INTERESTING --test-arg %s --test-arg --input-file %s -o %t.0
+; RUN: FileCheck --implicit-check-not=define --check-prefix=RESULT %s < %t.0
+
+; INTERESTING: @externally_initialized_keep = externally_initialized global i32 0
+; INTERESTING: @externally_initialized_drop
+
+; RESULT: @externally_initialized_keep = externally_initialized global i32 0, align 4
+; RESULT: @externally_initialized_drop = global i32 1, align 4
+@externally_initialized_keep = externally_initialized global i32 0, align 4
+@externally_initialized_drop = externally_initialized global i32 1, align 4
+

--- a/llvm/tools/llvm-reduce/deltas/ReduceGlobalValues.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceGlobalValues.cpp
@@ -64,5 +64,13 @@ void llvm::reduceGlobalValuesDeltaPass(Oracle &O, ReducerWorkItem &Program) {
       if (IsImplicitDSOLocal)
         GV.setDSOLocal(false);
     }
+
+    // TODO: Should this go in a separate reduction?
+    if (auto *GVar = dyn_cast<GlobalVariable>(&GV)) {
+      if (GVar->isExternallyInitialized() && !O.shouldKeep())
+        GVar->setExternallyInitialized(false);
+
+      // TODO: Reduce code model
+    }
   }
 }


### PR DESCRIPTION
Not sure this is the right place to put it. This is a property
of GlobalVariable, not GlobalValue. But the ReduceGlobalVars
reduction tries to delete the value entirely.