### PR TITLE
llvm-reduce: Reduce global variable code model

### DIFF
--- a/llvm/include/llvm/IR/GlobalVariable.h
+++ b/llvm/include/llvm/IR/GlobalVariable.h
@@ -289,6 +289,10 @@ public:
   ///
   void setCodeModel(CodeModel::Model CM);
 
+  /// Remove the code model for this global.
+  ///
+  void clearCodeModel();
+
   // Methods for support type inquiry through isa, cast, and dyn_cast:
   static bool classof(const Value *V) {
     return V->getValueID() == Value::GlobalVariableVal;

--- a/llvm/lib/IR/Globals.cpp
+++ b/llvm/lib/IR/Globals.cpp
@@ -557,6 +557,15 @@ void GlobalVariable::setCodeModel(CodeModel::Model CM) {
   assert(getCodeModel() == CM && "Code model representation error!");
 }
 
+void GlobalVariable::clearCodeModel() {
+  unsigned CodeModelData = 0;
+  unsigned OldData = getGlobalValueSubClassData();
+  unsigned NewData = (OldData & ~(CodeModelMask << CodeModelShift)) |
+                     (CodeModelData << CodeModelShift);
+  setGlobalValueSubClassData(NewData);
+  assert(getCodeModel() == std::nullopt && "Code model representation error!");
+}
+
 //===----------------------------------------------------------------------===//
 // GlobalAlias Implementation
 //===----------------------------------------------------------------------===//

--- a/llvm/test/tools/llvm-reduce/reduce-code-model.ll
+++ b/llvm/test/tools/llvm-reduce/reduce-code-model.ll
@@ -1,0 +1,18 @@
+; RUN: llvm-reduce -abort-on-invalid-reduction --delta-passes=global-values --test FileCheck --test-arg --check-prefix=INTERESTING --test-arg %s --test-arg --input-file %s -o %t.0
+; RUN: FileCheck --implicit-check-not=define --check-prefix=RESULT %s < %t.0
+
+; INTERESTING: @code_model_large_keep = global i32 0, code_model "large", align 4
+; INTERESTING @code_model_large_drop = global i32 0
+
+; RESULT: @code_model_large_keep = global i32 0, code_model "large", align 4{{$}}
+; RESULT: @code_model_large_drop = global i32 0, align 4{{$}}
+@code_model_large_keep = global i32 0, code_model "large", align 4
+@code_model_large_drop = global i32 0, code_model "large", align 4
+
+; INTERESTING: @code_model_tiny_keep = global i32 0, code_model "tiny", align 4
+; INTERESTING @code_model_tiny_drop = global i32 0
+
+; RESULT: @code_model_tiny_keep = global i32 0, code_model "tiny", align 4{{$}}
+; RESULT: @code_model_tiny_drop = global i32 0, align 4{{$}}
+@code_model_tiny_keep = global i32 0, code_model "tiny", align 4
+@code_model_tiny_drop = global i32 0, code_model "tiny", align 4

--- a/llvm/tools/llvm-reduce/deltas/ReduceGlobalValues.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceGlobalValues.cpp
@@ -70,7 +70,8 @@ void llvm::reduceGlobalValuesDeltaPass(Oracle &O, ReducerWorkItem &Program) {
       if (GVar->isExternallyInitialized() && !O.shouldKeep())
         GVar->setExternallyInitialized(false);
 
-      // TODO: Reduce code model
+      if (GVar->getCodeModel() && !O.shouldKeep())
+        GVar->clearCodeModel();
     }
   }
 }


### PR DESCRIPTION
The current API doesn't have a way to unset it. The query returns
an optional, but the set doesn't. Alternatively I could switch the
set to also use optional.