### PR TITLE
[RISCV] Validate the end of register ranges in Zcmp register lists.

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -2616,7 +2616,8 @@ ParseStatus RISCVAsmParser::parseRegListCommon(OperandVector &Operands,
     StringRef EndName = getLexer().getTok().getIdentifier();
     // FIXME: the register mapping and checks of EABI is wrong
     RegEnd = matchRegisterNameHelper(EndName);
-    if (!RegEnd)
+    if (!(RegEnd == RISCV::X9 ||
+          (RegEnd >= RISCV::X18 && RegEnd <= RISCV::X27)))
       return Error(getLoc(), "invalid register");
     if (IsEABI && RegEnd != RISCV::X9)
       return Error(getLoc(), "contiguous register list of EABI can only be "
@@ -2649,7 +2650,7 @@ ParseStatus RISCVAsmParser::parseRegListCommon(OperandVector &Operands,
           return Error(getLoc(), "invalid register");
         EndName = getLexer().getTok().getIdentifier();
         RegEnd = MatchRegisterName(EndName);
-        if (!RegEnd)
+        if (!(RegEnd >= RISCV::X19 && RegEnd <= RISCV::X27))
           return Error(getLoc(), "invalid register");
         getLexer().Lex();
       }

--- a/llvm/test/MC/RISCV/rv32zcmp-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zcmp-invalid.s
@@ -25,5 +25,23 @@ cm.pop {ra, s0-s1}, -32
 # CHECK-ERROR: error: stack adjustment for register list must be a multiple of 16 bytes in the range [-64, -16]
 cm.push {ra}, -8
 
-# CHECK-ERROR: error: stack adjustment for register list must be a multiple of 16 bytes in the range [16, 64]
-cm.pop {ra, s0-s1}, -40
+# CHECK-ERROR: :[[@LINE+1]]:9: error: register list must start from 'ra' or 'x1'
+cm.pop {s0}, -40
+
+# CHECK-ERROR: :[[@LINE+1]]:13: error: continuous register list must start from 's0' or 'x8'
+cm.pop {ra, t1}, -40
+
+# CHECK-ERROR: :[[@LINE+1]]:16: error: invalid register
+cm.pop {ra, s0-t1}, -40
+
+# CHECK-ERROR: :[[@LINE+1]]:20: error: second contiguous registers pair of register list must start from 'x18'
+cm.pop {ra, x8-x9, x28}, -40
+
+# CHECK-ERROR: :[[@LINE+1]]:24: error: invalid register
+cm.pop {ra, x8-x9, x18-x28}, -40
+
+# CHECK-ERROR: :[[@LINE+1]]:24: error: invalid register
+cm.pop {ra, x8-x9, x18-x17}, -40
+
+# CHECK-ERROR: :[[@LINE+1]]:16: error: invalid register
+cm.pop {ra, x8-f8, x18-x17}, -40

--- a/llvm/test/MC/RISCV/rv64zcmp-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zcmp-invalid.s
@@ -27,3 +27,24 @@ cm.push {ra}, -15
 
 # CHECK-ERROR: error: stack adjustment for register list must be a multiple of 16 bytes in the range [32, 80]
 cm.pop {ra, s0-s1}, -33
+
+# CHECK-ERROR: :[[@LINE+1]]:9: error: register list must start from 'ra' or 'x1'
+cm.pop {s0}, -40
+
+# CHECK-ERROR: :[[@LINE+1]]:13: error: continuous register list must start from 's0' or 'x8'
+cm.pop {ra, t1}, -40
+
+# CHECK-ERROR: :[[@LINE+1]]:16: error: invalid register
+cm.pop {ra, s0-t1}, -40
+
+# CHECK-ERROR: :[[@LINE+1]]:20: error: second contiguous registers pair of register list must start from 'x18'
+cm.pop {ra, x8-x9, x28}, -40
+
+# CHECK-ERROR: :[[@LINE+1]]:24: error: invalid register
+cm.pop {ra, x8-x9, x18-x28}, -40
+
+# CHECK-ERROR: :[[@LINE+1]]:24: error: invalid register
+cm.pop {ra, x8-x9, x18-x17}, -40
+
+# CHECK-ERROR: :[[@LINE+1]]:16: error: invalid register
+cm.pop {ra, x8-f8, x18-x17}, -40


### PR DESCRIPTION
We were only checking that the last register was a register, not that it was a legal register for a register list. This caused the encoder function to hit an llvm_unreachable.

The error messages are not good, but this only one of multiple things that need to be fixed in this function. I'll focus on error messages later once I have the other issues fixed.