### PR TITLE
[clang][CGObjC] Remove unused ExternalProtocolPtrTy (NFC)

### DIFF
--- a/clang/lib/CodeGen/CGObjCMac.cpp
+++ b/clang/lib/CodeGen/CGObjCMac.cpp
@@ -184,25 +184,6 @@ public:
   /// SelectorPtrTy - LLVM type for selector handles (typeof(SEL))
   llvm::PointerType *SelectorPtrTy;
 
-private:
-  /// ProtocolPtrTy - LLVM type for external protocol handles
-  /// (typeof(Protocol))
-  llvm::Type *ExternalProtocolPtrTy;
-
-public:
-  llvm::Type *getExternalProtocolPtrTy() {
-    if (!ExternalProtocolPtrTy) {
-      // FIXME: It would be nice to unify this with the opaque type, so that the
-      // IR comes out a bit cleaner.
-      CodeGen::CodeGenTypes &Types = CGM.getTypes();
-      ASTContext &Ctx = CGM.getContext();
-      llvm::Type *T = Types.ConvertType(Ctx.getObjCProtoType());
-      ExternalProtocolPtrTy = llvm::PointerType::getUnqual(T);
-    }
-
-    return ExternalProtocolPtrTy;
-  }
-
   // SuperCTy - clang type for struct objc_super.
   QualType SuperCTy;
   // SuperPtrCTy - clang type for struct objc_super *.
@@ -5636,8 +5617,7 @@ CGObjCNonFragileABIMac::CGObjCNonFragileABIMac(CodeGen::CodeGenModule &cgm)
 /* *** */
 
 ObjCCommonTypesHelper::ObjCCommonTypesHelper(CodeGen::CodeGenModule &cgm)
-    : VMContext(cgm.getLLVMContext()), CGM(cgm),
-      ExternalProtocolPtrTy(nullptr) {
+    : VMContext(cgm.getLLVMContext()), CGM(cgm) {
   CodeGen::CodeGenTypes &Types = CGM.getTypes();
   ASTContext &Ctx = CGM.getContext();
   unsigned ProgramAS = CGM.getDataLayout().getProgramAddressSpace();


### PR DESCRIPTION
This function was previously used to get a type to the protocol that
was used to bitcast the initializer of GenerateProtocol. This bitcast
has later been removed (thanks to opaque pointers), but the member was
left behind.

History:

- 020de3254acc3 used ExternalProtocolPtrTy
- 34ee69b4ce662 removes the bitcast

Also technically part of #123569 