### PR TITLE
[clang][CGObjC] Prefer PointerType::get with LLVMContext over Type (NFC)

### DIFF
--- a/clang/lib/CodeGen/CGObjCMac.cpp
+++ b/clang/lib/CodeGen/CGObjCMac.cpp
@@ -2011,7 +2011,7 @@ CodeGen::RValue CGObjCMac::GenerateMessageSendSuper(
                           CGF.Builder.CreateStructGEP(ObjCSuper, 0));
 
   // If this is a class message the metaclass is passed as the target.
-  llvm::Type *ClassTyPtr = llvm::PointerType::getUnqual(ObjCTypes.ClassTy);
+  llvm::Type *ClassTyPtr = llvm::PointerType::getUnqual(VMContext);
   llvm::Value *Target;
   if (IsClassMessage) {
     if (isCategoryImpl) {
@@ -5657,7 +5657,7 @@ ObjCCommonTypesHelper::ObjCCommonTypesHelper(CodeGen::CodeGenModule &cgm)
     IvarOffsetVarTy = LongTy;
 
   ObjectPtrTy = cast<llvm::PointerType>(Types.ConvertType(Ctx.getObjCIdType()));
-  PtrObjectPtrTy = llvm::PointerType::getUnqual(ObjectPtrTy);
+  PtrObjectPtrTy = llvm::PointerType::getUnqual(VMContext);
   SelectorPtrTy =
       cast<llvm::PointerType>(Types.ConvertType(Ctx.getObjCSelType()));
 
@@ -5688,7 +5688,7 @@ ObjCCommonTypesHelper::ObjCCommonTypesHelper(CodeGen::CodeGenModule &cgm)
   SuperPtrCTy = Ctx.getPointerType(SuperCTy);
 
   SuperTy = cast<llvm::StructType>(Types.ConvertType(SuperCTy));
-  SuperPtrTy = llvm::PointerType::getUnqual(SuperTy);
+  SuperPtrTy = llvm::PointerType::getUnqual(VMContext);
 
   // struct _prop_t {
   //   char *name;
@@ -5704,7 +5704,7 @@ ObjCCommonTypesHelper::ObjCCommonTypesHelper(CodeGen::CodeGenModule &cgm)
   PropertyListTy = llvm::StructType::create(
       "struct._prop_list_t", IntTy, IntTy, llvm::ArrayType::get(PropertyTy, 0));
   // struct _prop_list_t *
-  PropertyListPtrTy = llvm::PointerType::getUnqual(PropertyListTy);
+  PropertyListPtrTy = llvm::PointerType::getUnqual(VMContext);
 
   // struct _objc_method {
   //   SEL _cmd;
@@ -5716,7 +5716,7 @@ ObjCCommonTypesHelper::ObjCCommonTypesHelper(CodeGen::CodeGenModule &cgm)
 
   // struct _objc_cache *
   CacheTy = llvm::StructType::create(VMContext, "struct._objc_cache");
-  CachePtrTy = llvm::PointerType::getUnqual(CacheTy);
+  CachePtrTy = llvm::PointerType::getUnqual(VMContext);
 }
 
 ObjCTypesHelper::ObjCTypesHelper(CodeGen::CodeGenModule &cgm)
@@ -5737,8 +5737,7 @@ ObjCTypesHelper::ObjCTypesHelper(CodeGen::CodeGenModule &cgm)
                                llvm::ArrayType::get(MethodDescriptionTy, 0));
 
   // struct _objc_method_description_list *
-  MethodDescriptionListPtrTy =
-      llvm::PointerType::getUnqual(MethodDescriptionListTy);
+  MethodDescriptionListPtrTy = llvm::PointerType::getUnqual(VMContext);
 
   // Protocol description structures
 
@@ -5756,7 +5755,7 @@ ObjCTypesHelper::ObjCTypesHelper(CodeGen::CodeGenModule &cgm)
       PropertyListPtrTy);
 
   // struct _objc_protocol_extension *
-  ProtocolExtensionPtrTy = llvm::PointerType::getUnqual(ProtocolExtensionTy);
+  ProtocolExtensionPtrTy = llvm::PointerType::getUnqual(VMContext);
 
   // Handle construction of Protocol and ProtocolList types
 
@@ -5779,9 +5778,9 @@ ObjCTypesHelper::ObjCTypesHelper(CodeGen::CodeGenModule &cgm)
                                "struct._objc_protocol_list");
 
   // struct _objc_protocol_list *
-  ProtocolListPtrTy = llvm::PointerType::getUnqual(ProtocolListTy);
+  ProtocolListPtrTy = llvm::PointerType::getUnqual(VMContext);
 
-  ProtocolPtrTy = llvm::PointerType::getUnqual(ProtocolTy);
+  ProtocolPtrTy = llvm::PointerType::getUnqual(VMContext);
 
   // Class description structures
 
@@ -5795,17 +5794,17 @@ ObjCTypesHelper::ObjCTypesHelper(CodeGen::CodeGenModule &cgm)
 
   // struct _objc_ivar_list *
   IvarListTy = llvm::StructType::create(VMContext, "struct._objc_ivar_list");
-  IvarListPtrTy = llvm::PointerType::getUnqual(IvarListTy);
+  IvarListPtrTy = llvm::PointerType::getUnqual(VMContext);
 
   // struct _objc_method_list *
   MethodListTy =
       llvm::StructType::create(VMContext, "struct._objc_method_list");
-  MethodListPtrTy = llvm::PointerType::getUnqual(MethodListTy);
+  MethodListPtrTy = llvm::PointerType::getUnqual(VMContext);
 
   // struct _objc_class_extension *
   ClassExtensionTy = llvm::StructType::create(
       "struct._objc_class_extension", IntTy, Int8PtrTy, PropertyListPtrTy);
-  ClassExtensionPtrTy = llvm::PointerType::getUnqual(ClassExtensionTy);
+  ClassExtensionPtrTy = llvm::PointerType::getUnqual(VMContext);
 
   // struct _objc_class {
   //   Class isa;
@@ -5828,7 +5827,7 @@ ObjCTypesHelper::ObjCTypesHelper(CodeGen::CodeGenModule &cgm)
        Int8PtrTy, ClassExtensionPtrTy},
       "struct._objc_class");
 
-  ClassPtrTy = llvm::PointerType::getUnqual(ClassTy);
+  ClassPtrTy = llvm::PointerType::getUnqual(VMContext);
 
   // struct _objc_category {
   //   char *category_name;
@@ -5857,7 +5856,7 @@ ObjCTypesHelper::ObjCTypesHelper(CodeGen::CodeGenModule &cgm)
   SymtabTy = llvm::StructType::create("struct._objc_symtab", LongTy,
                                       SelectorPtrTy, ShortTy, ShortTy,
                                       llvm::ArrayType::get(Int8PtrTy, 0));
-  SymtabPtrTy = llvm::PointerType::getUnqual(SymtabTy);
+  SymtabPtrTy = llvm::PointerType::getUnqual(VMContext);
 
   // struct _objc_module {
   //   long version;
@@ -5892,7 +5891,7 @@ ObjCNonFragileABITypesHelper::ObjCNonFragileABITypesHelper(
       llvm::StructType::create("struct.__method_list_t", IntTy, IntTy,
                                llvm::ArrayType::get(MethodTy, 0));
   // struct method_list_t *
-  MethodListnfABIPtrTy = llvm::PointerType::getUnqual(MethodListnfABITy);
+  MethodListnfABIPtrTy = llvm::PointerType::getUnqual(VMContext);
 
   // struct _protocol_t {
   //   id isa;  // NULL
@@ -5918,7 +5917,7 @@ ObjCNonFragileABITypesHelper::ObjCNonFragileABITypesHelper(
       PropertyListPtrTy);
 
   // struct _protocol_t*
-  ProtocolnfABIPtrTy = llvm::PointerType::getUnqual(ProtocolnfABITy);
+  ProtocolnfABIPtrTy = llvm::PointerType::getUnqual(VMContext);
 
   // struct _protocol_list_t {
   //   long protocol_count;   // Note, this is 32/64 bit
@@ -5929,7 +5928,7 @@ ObjCNonFragileABITypesHelper::ObjCNonFragileABITypesHelper(
       "struct._objc_protocol_list");
 
   // struct _objc_protocol_list*
-  ProtocolListnfABIPtrTy = llvm::PointerType::getUnqual(ProtocolListnfABITy);
+  ProtocolListnfABIPtrTy = llvm::PointerType::getUnqual(VMContext);
 
   // struct _ivar_t {
   //   unsigned [long] int *offset;  // pointer to ivar offset location
@@ -5939,8 +5938,8 @@ ObjCNonFragileABITypesHelper::ObjCNonFragileABITypesHelper(
   //   uint32_t size;
   // }
   IvarnfABITy = llvm::StructType::create(
-      "struct._ivar_t", llvm::PointerType::getUnqual(IvarOffsetVarTy),
-      Int8PtrTy, Int8PtrTy, IntTy, IntTy);
+      "struct._ivar_t", llvm::PointerType::getUnqual(VMContext), Int8PtrTy,
+      Int8PtrTy, IntTy, IntTy);
 
   // struct _ivar_list_t {
   //   uint32 entsize;  // sizeof(struct _ivar_t)
@@ -5951,7 +5950,7 @@ ObjCNonFragileABITypesHelper::ObjCNonFragileABITypesHelper(
       llvm::StructType::create("struct._ivar_list_t", IntTy, IntTy,
                                llvm::ArrayType::get(IvarnfABITy, 0));
 
-  IvarListnfABIPtrTy = llvm::PointerType::getUnqual(IvarListnfABITy);
+  IvarListnfABIPtrTy = llvm::PointerType::getUnqual(VMContext);
 
   // struct _class_ro_t {
   //   uint32_t const flags;
@@ -5987,12 +5986,12 @@ ObjCNonFragileABITypesHelper::ObjCNonFragileABITypesHelper(
   ClassnfABITy = llvm::StructType::create(
       {llvm::PointerType::getUnqual(VMContext),
        llvm::PointerType::getUnqual(VMContext), CachePtrTy,
-       llvm::PointerType::getUnqual(ImpnfABITy),
-       llvm::PointerType::getUnqual(ClassRonfABITy)},
+       llvm::PointerType::getUnqual(VMContext),
+       llvm::PointerType::getUnqual(VMContext)},
       "struct._class_t");
 
   // LLVM for struct _class_t *
-  ClassnfABIPtrTy = llvm::PointerType::getUnqual(ClassnfABITy);
+  ClassnfABIPtrTy = llvm::PointerType::getUnqual(VMContext);
 
   // struct _category_t {
   //   const char * const name;
@@ -6036,7 +6035,7 @@ ObjCNonFragileABITypesHelper::ObjCNonFragileABITypesHelper(
   MessageRefTy = cast<llvm::StructType>(Types.ConvertType(MessageRefCTy));
 
   // MessageRefPtrTy - LLVM for struct _message_ref_t*
-  MessageRefPtrTy = llvm::PointerType::getUnqual(MessageRefTy);
+  MessageRefPtrTy = llvm::PointerType::getUnqual(VMContext);
 
   // SuperMessageRefTy - LLVM for:
   // struct _super_message_ref_t {
@@ -6047,7 +6046,7 @@ ObjCNonFragileABITypesHelper::ObjCNonFragileABITypesHelper(
                                                ImpnfABITy, SelectorPtrTy);
 
   // SuperMessageRefPtrTy - LLVM for struct _super_message_ref_t*
-  SuperMessageRefPtrTy = llvm::PointerType::getUnqual(SuperMessageRefTy);
+  SuperMessageRefPtrTy = llvm::PointerType::getUnqual(VMContext);
 
   // struct objc_typeinfo {
   //   const void** vtable; // objc_ehtype_vtable + 2
@@ -6055,9 +6054,9 @@ ObjCNonFragileABITypesHelper::ObjCNonFragileABITypesHelper(
   //   Class        cls;
   // };
   EHTypeTy = llvm::StructType::create("struct._objc_typeinfo",
-                                      llvm::PointerType::getUnqual(Int8PtrTy),
+                                      llvm::PointerType::getUnqual(VMContext),
                                       Int8PtrTy, ClassnfABIPtrTy);
-  EHTypePtrTy = llvm::PointerType::getUnqual(EHTypeTy);
+  EHTypePtrTy = llvm::PointerType::getUnqual(VMContext);
 }
 
 llvm::Function *CGObjCNonFragileABIMac::ModuleInitFunction() {


### PR DESCRIPTION
Part of #123569