### PR TITLE
[WIP] Adding Support for a unified ABI Lowering Library

### DIFF
--- a/llvm/examples/CMakeLists.txt
+++ b/llvm/examples/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(ABI)
 add_subdirectory(BrainF)
 add_subdirectory(Fibonacci)
 add_subdirectory(HowToUseJIT)

--- a/llvm/include/llvm/ABI/ABIInfo.h
+++ b/llvm/include/llvm/ABI/ABIInfo.h
@@ -1,0 +1,129 @@
+//===- ABIInfo.h - ABI Information -----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file defines the interfaces used by frontends to get ABI information.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_ABI_ABIINFO_H
+#define LLVM_ABI_ABIINFO_H
+
+#include "llvm/ABI/ABIType.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/IR/Type.h"
+#include "llvm/Support/ErrorHandling.h"
+#include <memory>
+#include <vector>
+
+namespace llvm {
+class LLVMContext;
+
+namespace abi {
+
+/// Argument or return value ABI classification
+enum class ABIArgKind {
+  Direct,   // Just yeets the value straight into registers
+  Indirect, // Passed indirectly via a hidden pointer
+  Ignore,   // exists in the source but ghosted at compile time
+  Expand,   // Expand into multiple arguments
+  Coerce    // Coerce to different type
+};
+
+/// Information about how to handle an argument or return value
+class ABIArgInfo {
+  ABIArgKind Kind;
+  const ABIType *CoerceToABIType; // Target ABI type for coercion
+  Type *CoerceToLLVMType;         // Corresponding LLVM type
+  unsigned DirectOffset;          // Offset for direct passing
+  bool CanBeFlattened;            // Whether the type can be flattened
+  bool InReg;                     // Whether to pass in registers
+
+  /// For Expand kind - holds component types
+  std::vector<ABIArgInfo> ExpandedArgs;
+
+public:
+  ABIArgInfo(ABIArgKind Kind, const ABIType *CoerceToABIType = nullptr,
+             Type *CoerceToLLVMType = nullptr, unsigned DirectOffset = 0,
+             bool CanBeFlattened = false, bool InReg = false)
+      : Kind(Kind), CoerceToABIType(CoerceToABIType),
+        CoerceToLLVMType(CoerceToLLVMType), DirectOffset(DirectOffset),
+        CanBeFlattened(CanBeFlattened), InReg(InReg) {}
+
+  // Factory methods
+  static ABIArgInfo getDirect(const ABIType *ABITy = nullptr,
+                              Type *LLVMTy = nullptr, unsigned Offset = 0,
+                              bool CanBeFlattened = false, bool InReg = false) {
+    return ABIArgInfo(ABIArgKind::Direct, ABITy, LLVMTy, Offset, CanBeFlattened,
+                      InReg);
+  }
+
+  static ABIArgInfo getIndirect(const ABIType *ABITy = nullptr,
+                                bool InReg = false) {
+    return ABIArgInfo(ABIArgKind::Indirect, ABITy, nullptr, 0, false, InReg);
+  }
+
+  static ABIArgInfo getIgnore() { return ABIArgInfo(ABIArgKind::Ignore); }
+
+  static ABIArgInfo getCoerce(const ABIType *ABITy, Type *LLVMTy = nullptr) {
+    return ABIArgInfo(ABIArgKind::Coerce, ABITy, LLVMTy);
+  }
+
+  static ABIArgInfo getExpand() { return ABIArgInfo(ABIArgKind::Expand); }
+
+  // Accessors
+  ABIArgKind getKind() const { return Kind; }
+  const ABIType *getCoerceToABIType() const { return CoerceToABIType; }
+  Type *getCoerceToLLVMType() const { return CoerceToLLVMType; }
+  unsigned getDirectOffset() const { return DirectOffset; }
+  bool canBeFlattened() const { return CanBeFlattened; }
+  bool getInReg() const { return InReg; }
+
+  void setCoerceToLLVMType(Type *T) { CoerceToLLVMType = T; }
+
+  // Predicates
+  bool isDirect() const { return Kind == ABIArgKind::Direct; }
+  bool isIndirect() const { return Kind == ABIArgKind::Indirect; }
+  bool isIgnore() const { return Kind == ABIArgKind::Ignore; }
+  bool isCoerce() const { return Kind == ABIArgKind::Coerce; }
+  bool isExpand() const { return Kind == ABIArgKind::Expand; }
+
+  // Expand kind management
+  void setExpandedArgs(ArrayRef<ABIArgInfo> Args) {
+    assert(Kind == ABIArgKind::Expand && "Not an expand kind");
+    ExpandedArgs.assign(Args.begin(), Args.end());
+  }
+
+  ArrayRef<ABIArgInfo> getExpandedArgs() const {
+    assert(Kind == ABIArgKind::Expand && "Not an expand kind");
+    return ExpandedArgs;
+  }
+};
+
+/// Base class for target-specific ABI information
+class ABIInfo {
+public:
+  virtual ~ABIInfo() = default;
+
+  /// Classify how a type should be passed as an argument
+  virtual ABIArgInfo classifyArgumentType(const ABIType *Ty) = 0;
+
+  /// Classify how a type should be returned
+  virtual ABIArgInfo classifyReturnType(const ABIType *Ty) = 0;
+
+  /// Convert an ABIType to the corresponding LLVM IR type
+  virtual Type *getLLVMType(const ABIType *Ty, LLVMContext &Context) = 0;
+};
+
+/// Create target-specific ABI information based on the target triple
+std::unique_ptr<ABIInfo> createABIInfo(StringRef TargetTriple);
+
+} // namespace abi
+} // namespace llvm
+
+#endif // LLVM_ABI_ABIINFO_H

--- a/llvm/include/llvm/ABI/ABIType.h
+++ b/llvm/include/llvm/ABI/ABIType.h
@@ -1,0 +1,259 @@
+#ifndef LLVM_ABI_ABITYPE_H
+#define LLVM_ABI_ABITYPE_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Allocator.h"
+#include <cstdint>
+#include <vector>
+
+namespace llvm {
+namespace abi {
+
+enum class ABITypeKind {
+  Void,
+  Bool,
+  Char,
+  SChar,
+  UChar,
+  Short,
+  UShort,
+  Int,
+  UInt,
+  Long,
+  ULong,
+  LongLong,
+  ULongLong,
+  Float,
+  Double,
+  LongDouble,
+  Pointer,
+  Array,
+  Record,
+  Union
+};
+
+/// Base class for all types in the ABI type system
+class ABIType {
+  const ABITypeKind Kind;
+  unsigned Alignment;
+
+protected:
+  ABIType(ABITypeKind K, unsigned Align) : Kind(K), Alignment(Align) {}
+
+public:
+  ABITypeKind getKind() const { return Kind; }
+  unsigned getAlignment() const { return Alignment; }
+
+  // Support for LLVM RTTI
+  static bool classof(const ABIType *) { return true; }
+
+  virtual ~ABIType() = default;
+};
+
+class VoidType : public ABIType {
+public:
+  VoidType() : ABIType(ABITypeKind::Void, 0) {}
+
+  static bool classof(const ABIType *T) {
+    return T->getKind() == ABITypeKind::Void;
+  }
+};
+
+class ScalarType : public ABIType {
+  uint64_t Size;
+
+public:
+  ScalarType(ABITypeKind Kind, unsigned Align, uint64_t Size)
+      : ABIType(Kind, Align), Size(Size) {}
+
+  uint64_t getSize() const { return Size; }
+
+  static bool classof(const ABIType *T) {
+    return T->getKind() >= ABITypeKind::Bool &&
+           T->getKind() <= ABITypeKind::LongDouble;
+  }
+};
+
+class PointerType : public ABIType {
+  const ABIType *PointeeType;
+  uint64_t Size;
+
+public:
+  PointerType(const ABIType *Pointee, unsigned Align, uint64_t Size)
+      : ABIType(ABITypeKind::Pointer, Align), PointeeType(Pointee), Size(Size) {
+  }
+
+  const ABIType *getPointeeType() const { return PointeeType; }
+  uint64_t getSize() const { return Size; }
+
+  static bool classof(const ABIType *T) {
+    return T->getKind() == ABITypeKind::Pointer;
+  }
+};
+
+class ArrayType : public ABIType {
+  const ABIType *ElementType;
+  uint64_t NumElements;
+  uint64_t Size;
+
+public:
+  ArrayType(const ABIType *ElemType, uint64_t Count, unsigned Align,
+            uint64_t Size)
+      : ABIType(ABITypeKind::Array, Align), ElementType(ElemType),
+        NumElements(Count), Size(Size) {}
+
+  const ABIType *getElementType() const { return ElementType; }
+  uint64_t getNumElements() const { return NumElements; }
+  uint64_t getSize() const { return Size; }
+
+  static bool classof(const ABIType *T) {
+    return T->getKind() == ABITypeKind::Array;
+  }
+};
+
+struct RecordField {
+  StringRef Name;
+  const ABIType *Type;
+  uint64_t Offset;
+
+  RecordField(StringRef Name, const ABIType *Type, uint64_t Offset)
+      : Name(Name), Type(Type), Offset(Offset) {}
+};
+
+class RecordType : public ABIType {
+  std::vector<RecordField> Fields;
+  uint64_t Size;
+  bool Packed;
+
+public:
+  RecordType(ArrayRef<RecordField> Fields, unsigned Align, uint64_t Size,
+             bool Packed)
+      : ABIType(ABITypeKind::Record, Align),
+        Fields(Fields.begin(), Fields.end()), Size(Size), Packed(Packed) {}
+
+  ArrayRef<RecordField> getFields() const { return Fields; }
+  uint64_t getSize() const { return Size; }
+  bool isPacked() const { return Packed; }
+
+  static bool classof(const ABIType *T) {
+    return T->getKind() == ABITypeKind::Record;
+  }
+};
+
+class UnionType : public ABIType {
+  std::vector<RecordField> Fields;
+  uint64_t Size;
+
+public:
+  UnionType(ArrayRef<RecordField> Fields, unsigned Align, uint64_t Size)
+      : ABIType(ABITypeKind::Union, Align),
+        Fields(Fields.begin(), Fields.end()), Size(Size) {}
+
+  ArrayRef<RecordField> getFields() const { return Fields; }
+  uint64_t getSize() const { return Size; }
+
+  static bool classof(const ABIType *T) {
+    return T->getKind() == ABITypeKind::Union;
+  }
+};
+
+class ABITypeContext {
+  BumpPtrAllocator Allocator;
+  VoidType VoidTy;
+
+  ScalarType BoolTy;
+  ScalarType CharTy;
+  ScalarType SCharTy;
+  ScalarType UCharTy;
+  ScalarType ShortTy;
+  ScalarType UShortTy;
+  ScalarType IntTy;
+  ScalarType UIntTy;
+  ScalarType LongTy;
+  ScalarType ULongTy;
+  ScalarType LongLongTy;
+  ScalarType ULongLongTy;
+  ScalarType FloatTy;
+  ScalarType DoubleTy;
+  ScalarType LongDoubleTy;
+
+public:
+  ABITypeContext()
+      : VoidTy(),
+        // Initialize scalar types with target-independent defaults
+        // Real implementations would initialize these based on target info
+        BoolTy(ABITypeKind::Bool, 1, 1), CharTy(ABITypeKind::Char, 1, 1),
+        SCharTy(ABITypeKind::SChar, 1, 1), UCharTy(ABITypeKind::UChar, 1, 1),
+        ShortTy(ABITypeKind::Short, 2, 2), UShortTy(ABITypeKind::UShort, 2, 2),
+        IntTy(ABITypeKind::Int, 4, 4), UIntTy(ABITypeKind::UInt, 4, 4),
+        LongTy(ABITypeKind::Long, 8, 8), ULongTy(ABITypeKind::ULong, 8, 8),
+        LongLongTy(ABITypeKind::LongLong, 8, 8),
+        ULongLongTy(ABITypeKind::ULongLong, 8, 8),
+        FloatTy(ABITypeKind::Float, 4, 4), DoubleTy(ABITypeKind::Double, 8, 8),
+        LongDoubleTy(ABITypeKind::LongDouble, 16, 16) {}
+
+  const VoidType *getVoidType() { return &VoidTy; }
+  const ScalarType *getBoolType() { return &BoolTy; }
+  const ScalarType *getCharType() { return &CharTy; }
+  const ScalarType *getSCharType() { return &SCharTy; }
+  const ScalarType *getUCharType() { return &UCharTy; }
+  const ScalarType *getShortType() { return &ShortTy; }
+  const ScalarType *getUShortType() { return &UShortTy; }
+  const ScalarType *getIntType() { return &IntTy; }
+  const ScalarType *getUIntType() { return &UIntTy; }
+  const ScalarType *getLongType() { return &LongTy; }
+  const ScalarType *getULongType() { return &ULongTy; }
+  const ScalarType *getLongLongType() { return &LongLongTy; }
+  const ScalarType *getULongLongType() { return &ULongLongTy; }
+  const ScalarType *getFloatType() { return &FloatTy; }
+  const ScalarType *getDoubleType() { return &DoubleTy; }
+  const ScalarType *getLongDoubleType() { return &LongDoubleTy; }
+
+  const PointerType *getPointerType(const ABIType *Pointee, unsigned Align,
+                                    uint64_t Size) {
+    return new (Allocator) PointerType(Pointee, Align, Size);
+  }
+
+  const ArrayType *getArrayType(const ABIType *ElementType,
+                                uint64_t NumElements, unsigned Align,
+                                uint64_t Size) {
+    return new (Allocator) ArrayType(ElementType, NumElements, Align, Size);
+  }
+  const RecordType *getRecordType(ArrayRef<RecordField> Fields, unsigned Align,
+                                  uint64_t Size, bool Packed = false) {
+    // Take the allocator and make copy
+    SmallVector<RecordField, 8> FieldsCopy;
+    for (const auto &Field : Fields) {
+      StringRef Name;
+      if (!Field.Name.empty()) {
+        char *NameBuf = Allocator.Allocate<char>(Field.Name.size() + 1);
+        std::copy(Field.Name.begin(), Field.Name.end(), NameBuf);
+        NameBuf[Field.Name.size()] = '\0';
+        Name = StringRef(NameBuf, Field.Name.size());
+      }
+      FieldsCopy.emplace_back(Name, Field.Type, Field.Offset);
+    }
+    return new (Allocator) RecordType(FieldsCopy, Align, Size, Packed);
+  }
+  const UnionType *getUnionType(ArrayRef<RecordField> Fields, unsigned Align,
+                                uint64_t Size) {
+    // Make a copy with the allocator
+    SmallVector<RecordField, 8> FieldsCopy;
+    for (const auto &Field : Fields) {
+      StringRef Name;
+      if (!Field.Name.empty()) {
+        char *NameBuf = Allocator.Allocate<char>(Field.Name.size() + 1);
+        std::copy(Field.Name.begin(), Field.Name.end(), NameBuf);
+        NameBuf[Field.Name.size()] = '\0';
+        Name = StringRef(NameBuf, Field.Name.size());
+      }
+      FieldsCopy.emplace_back(Name, Field.Type, Field.Offset);
+    }
+    return new (Allocator) UnionType(FieldsCopy, Align, Size);
+  }
+};
+} // namespace abi
+} // namespace llvm
+
+#endif // LLVM_ABI_ABITYPE_H

--- a/llvm/lib/ABI/ABIInfo.cpp
+++ b/llvm/lib/ABI/ABIInfo.cpp
@@ -1,0 +1,18 @@
+//===- ABIInfo.cpp - ABI Info Interface -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the ABIInfo interface.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ABI/ABIInfo.h"
+
+using namespace llvm;
+using namespace llvm::abi;
+
+// TODO: Target Specific Implementations....

--- a/llvm/lib/ABI/BPFABIInfo.cpp
+++ b/llvm/lib/ABI/BPFABIInfo.cpp
@@ -1,0 +1,142 @@
+#include "llvm/ABI/ABIInfo.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Type.h"
+
+/*using namespace llvm;*/
+
+namespace {
+
+class BPFABIInfo final : public llvm::abi::ABIInfo {
+public:
+  BPFABIInfo() {}
+
+  llvm::abi::ABIArgInfo
+  classifyArgumentType(const llvm::abi::ABIType *Ty) override;
+  llvm::abi::ABIArgInfo
+  classifyReturnType(const llvm::abi::ABIType *Ty) override;
+  llvm::Type *getLLVMType(const llvm::abi::ABIType *Ty,
+                          llvm::LLVMContext &Context) override;
+
+private:
+  llvm::abi::ABIArgInfo classifyType(const llvm::abi::ABIType *Ty,
+                                     bool IsReturn);
+  bool shouldPassIndirect(const llvm::abi::ABIType *Ty, bool IsReturn);
+};
+
+bool BPFABIInfo::shouldPassIndirect(const llvm::abi::ABIType *Ty,
+                                    bool IsReturn) {
+  if (llvm::isa<llvm::abi::RecordType>(Ty) ||
+      llvm::isa<llvm::abi::UnionType>(Ty))
+    return true;
+
+  if (llvm::isa<llvm::abi::ArrayType>(Ty))
+    return true;
+
+  if (const auto *ST = llvm::dyn_cast<llvm::abi::ScalarType>(Ty)) {
+    uint64_t Size = ST->getSize();
+    return Size > 8;
+  }
+
+  return false;
+}
+
+llvm::abi::ABIArgInfo BPFABIInfo::classifyType(const llvm::abi::ABIType *Ty,
+                                               bool IsReturn) {
+  if (Ty->getKind() == llvm::abi::ABITypeKind::Void)
+    return llvm::abi::ABIArgInfo::getIgnore();
+
+  if (shouldPassIndirect(Ty, IsReturn))
+    return llvm::abi::ABIArgInfo::getIndirect(Ty);
+
+  return llvm::abi::ABIArgInfo::getDirect();
+}
+
+llvm::abi::ABIArgInfo
+BPFABIInfo::classifyArgumentType(const llvm::abi::ABIType *Ty) {
+  return classifyType(Ty, /*IsReturn=*/false);
+}
+
+llvm::abi::ABIArgInfo
+BPFABIInfo::classifyReturnType(const llvm::abi::ABIType *Ty) {
+  return classifyType(Ty, /*IsReturn=*/true);
+}
+
+llvm::Type *BPFABIInfo::getLLVMType(const llvm::abi::ABIType *Ty,
+                                    llvm::LLVMContext &Context) {
+  switch (Ty->getKind()) {
+  case llvm::abi::ABITypeKind::Void:
+    return llvm::Type::getVoidTy(Context);
+  case llvm::abi::ABITypeKind::Bool:
+    return llvm::Type::getInt1Ty(Context);
+  case llvm::abi::ABITypeKind::Char:
+  case llvm::abi::ABITypeKind::SChar:
+  case llvm::abi::ABITypeKind::UChar:
+    return llvm::Type::getInt8Ty(Context);
+  case llvm::abi::ABITypeKind::Short:
+  case llvm::abi::ABITypeKind::UShort:
+    return llvm::Type::getInt16Ty(Context);
+  case llvm::abi::ABITypeKind::Int:
+  case llvm::abi::ABITypeKind::UInt:
+    return llvm::Type::getInt32Ty(Context);
+  case llvm::abi::ABITypeKind::Long:
+  case llvm::abi::ABITypeKind::ULong:
+  case llvm::abi::ABITypeKind::LongLong:
+  case llvm::abi::ABITypeKind::ULongLong:
+    return llvm::Type::getInt64Ty(Context);
+  case llvm::abi::ABITypeKind::Float:
+    return llvm::Type::getFloatTy(Context);
+  case llvm::abi::ABITypeKind::Double:
+    return llvm::Type::getDoubleTy(Context);
+  case llvm::abi::ABITypeKind::LongDouble:
+    return llvm::Type::getFP128Ty(Context);
+  case llvm::abi::ABITypeKind::Pointer: {
+    const llvm::abi::PointerType *PT = llvm::cast<llvm::abi::PointerType>(Ty);
+    return llvm::PointerType::get(getLLVMType(PT->getPointeeType(), Context),
+                                  0);
+  }
+  case llvm::abi::ABITypeKind::Array: {
+    const llvm::abi::ArrayType *AT = llvm::cast<llvm::abi::ArrayType>(Ty);
+    return llvm::ArrayType::get(getLLVMType(AT->getElementType(), Context),
+                                AT->getNumElements());
+  }
+  case llvm::abi::ABITypeKind::Record: {
+    const llvm::abi::RecordType *RT = llvm::cast<llvm::abi::RecordType>(Ty);
+    llvm::SmallVector<llvm::Type *, 8> Elements;
+    for (const llvm::abi::RecordField &Field : RT->getFields()) {
+      llvm::Type *FieldTy = getLLVMType(Field.Type, Context);
+      Elements.push_back(FieldTy);
+    }
+    return llvm::StructType::get(Context, Elements, RT->isPacked());
+  }
+  case llvm::abi::ABITypeKind::Union: {
+    const llvm::abi::UnionType *UT = llvm::cast<llvm::abi::UnionType>(Ty);
+    llvm::Type *LargestType = nullptr;
+
+    for (const llvm::abi::RecordField &Field : UT->getFields()) {
+      llvm::Type *FieldTy = getLLVMType(Field.Type, Context);
+      if (!LargestType ||
+          (FieldTy->isStructTy() && !LargestType->isStructTy()) ||
+          (FieldTy->isArrayTy() && !LargestType->isArrayTy())) {
+        LargestType = FieldTy;
+      }
+    }
+
+    if (!LargestType)
+      return llvm::StructType::get(Context);
+
+    return llvm::StructType::get(Context, LargestType);
+  }
+  }
+  llvm_unreachable("Unknown ABIType kind");
+}
+
+} // end anonymous namespace
+
+std::unique_ptr<llvm::abi::ABIInfo>
+llvm::abi::createABIInfo(StringRef TargetTriple) {
+  if (TargetTriple.starts_with("bpf"))
+    return std::make_unique<BPFABIInfo>();
+
+  llvm_unreachable("Unsupported target triple");
+}

--- a/llvm/lib/ABI/CMakeLists.txt
+++ b/llvm/lib/ABI/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_llvm_component_library(LLVMABI
+  ABIInfo.cpp
+  BPFABIInfo.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${LLVM_MAIN_INCLUDE_DIR}/llvm/ABI
+
+  DEPENDS
+  intrinsics_gen
+
+  LINK_COMPONENTS
+  Core
+  Support
+  )

--- a/llvm/lib/CMakeLists.txt
+++ b/llvm/lib/CMakeLists.txt
@@ -3,6 +3,7 @@ include(LLVM-Build)
 # `Demangle', `Support' and `TableGen' libraries are added on the top-level
 # CMakeLists.txt
 
+add_subdirectory(ABI)
 add_subdirectory(IR)
 add_subdirectory(FuzzMutate)
 add_subdirectory(FileCheck)


### PR DESCRIPTION
There has been discourse around moving ABI lowering functionality from within clang into LLVM so that every LLVM frontend would not need to rewrite hundreds of lines of clang code again.

While the final library would probably look a lot different and would need support for mainstream ABIs like SysV, I've just taken the liberty to implement a minimal BPF ABI lowering system.

## TODO

- [ ] UnitTests
- [ ] Examples
- [ ] Clang Integration
- [ ] Performance Impact(?)