### PR TITLE
llvm-reduce: Add target-features-attr reduction

### DIFF
--- a/llvm/test/tools/llvm-reduce/reduce-target-features-attr.ll
+++ b/llvm/test/tools/llvm-reduce/reduce-target-features-attr.ll
@@ -1,0 +1,72 @@
+; RUN: llvm-reduce --abort-on-invalid-reduction --delta-passes=target-features-attr --test FileCheck --test-arg -enable-var-scope --test-arg --check-prefixes=INTERESTING,CHECK --test-arg %s --test-arg --input-file %s -o %t
+; RUN: FileCheck -check-prefixes=RESULT,CHECK %s < %t
+
+; CHECK: @keep_none_from_one() [[$KEEP_NONE_FROM_ONE:#[0-9]+]]
+define void @keep_none_from_one() #0 {
+  ret void
+}
+
+; CHECK: @keep_one_from_one() [[$KEEP_ONE_FROM_ONE:#[0-9]+]]
+define void @keep_one_from_one() #1 {
+  ret void
+}
+
+; CHECK: @keep_first_from_two() [[$KEEP_FIRST_FROM_TWO:#[0-9]+]]
+define void @keep_first_from_two() #2 {
+  ret void
+}
+
+; CHECK: @keep_second_from_two() [[$KEEP_SECOND_FROM_TWO:#[0-9]+]]
+define void @keep_second_from_two() #3 {
+  ret void
+}
+
+; CHECK: @keep_all_of_two() [[$KEEP_ALL_OF_TWO:#[0-9]+]]
+define void @keep_all_of_two() #4 {
+  ret void
+}
+
+; CHECK: @drop_empty_element() [[$DROP_EMPTY_ELEMENT:#[0-9]+]]
+define void @drop_empty_element() #5 {
+  ret void
+}
+
+; CHECK: @keep_second_from_three() [[$KEEP_SECOND_FROM_THREE:#[0-9]+]]
+define void @keep_second_from_three() #6 {
+  ret void
+}
+
+; RESULT: define void @no_target_features() {
+define void @no_target_features() {
+  ret void
+}
+
+; IR verifier should probably reject this
+; RESULT: define void @no_target_features_value() {
+define void @no_target_features_value() #7 {
+  ret void
+}
+
+attributes #0 = { "target-features"="+foo" "unique-attr-0" }
+attributes #1 = { "target-features"="+foo" "unique-attr-1" }
+attributes #2 = { "target-features"="+first,+second" "unique-attr-2" }
+attributes #3 = { "target-features"="+first,+second" "unique-attr-3" }
+attributes #4 = { "target-features"="+first,+second" "unique-attr-4" }
+attributes #5 = { "target-features"="+dead,,+beef" "unique-attr-5" }
+attributes #6 = { "target-features"="+a,+b,+c" "unique-attr-6" }
+attributes #7 = { "target-features" }
+
+; INTERESTING-DAG: [[$KEEP_ONE_FROM_ONE]] = { "target-features"="+foo"
+; INTERESTING-DAG: [[$KEEP_FIRST_FROM_TWO]] = { "target-features"="{{.*}}+first
+; INTERESTING-DAG: [[$KEEP_SECOND_FROM_TWO]] = { "target-features"="{{.*}}+second
+; INTERESTING-DAG: [[$KEEP_ALL_OF_TWO]] = { "target-features"="{{.*}}+first,+second
+; INTERESTING-DAG: [[$DROP_EMPTY_ELEMENT]] = { "target-features"="{{.*}}+dead{{.*}}+beef
+; INTERESTING-DAG: [[$KEEP_SECOND_FROM_THREE]] = { "target-features"="{{.*}}+b
+
+
+; RESULT-DAG: attributes [[$KEEP_NONE_FROM_ONE]] = { "unique-attr-0" }
+; RESULT-DAG: [[$KEEP_FIRST_FROM_TWO]] = { "target-features"="+first" "unique-attr-2" }
+; RESULT-DAG: [[$KEEP_SECOND_FROM_TWO]] = { "target-features"="+second" "unique-attr-3" }
+; RESULT-DAG: [[$KEEP_ALL_OF_TWO]] = { "target-features"="+first,+second" "unique-attr-4" }
+; RESULT-DAG: [[$DROP_EMPTY_ELEMENT]] = { "target-features"="+dead,+beef" "unique-attr-5" }
+; RESULT-DAG: [[$KEEP_SECOND_FROM_THREE]] = { "target-features"="+b" "unique-attr-6" }

--- a/llvm/tools/llvm-reduce/CMakeLists.txt
+++ b/llvm/tools/llvm-reduce/CMakeLists.txt
@@ -58,6 +58,7 @@ add_llvm_tool(llvm-reduce
   deltas/ReduceRegisterMasks.cpp
   deltas/ReduceRegisterDefs.cpp
   deltas/ReduceRegisterUses.cpp
+  deltas/ReduceTargetFeaturesAttr.cpp
   deltas/ReduceUsingSimplifyCFG.cpp
   deltas/RunIRPasses.cpp
   deltas/SimplifyInstructions.cpp

--- a/llvm/tools/llvm-reduce/DeltaManager.cpp
+++ b/llvm/tools/llvm-reduce/DeltaManager.cpp
@@ -45,6 +45,7 @@
 #include "deltas/ReduceRegisterMasks.h"
 #include "deltas/ReduceRegisterUses.h"
 #include "deltas/ReduceSpecialGlobals.h"
+#include "deltas/ReduceTargetFeaturesAttr.h"
 #include "deltas/ReduceUsingSimplifyCFG.h"
 #include "deltas/ReduceVirtualRegisters.h"
 #include "deltas/RunIRPasses.h"

--- a/llvm/tools/llvm-reduce/DeltaPasses.def
+++ b/llvm/tools/llvm-reduce/DeltaPasses.def
@@ -45,6 +45,7 @@ DELTA_PASS_IR("operands-to-args", reduceOperandsToArgsDeltaPass, "Converting ope
 DELTA_PASS_IR("operands-skip", reduceOperandsSkipDeltaPass, "Reducing operands by skipping over instructions")
 DELTA_PASS_IR("operand-bundles", reduceOperandBundesDeltaPass, "Reducing Operand Bundles")
 DELTA_PASS_IR("attributes", reduceAttributesDeltaPass, "Reducing Attributes")
+DELTA_PASS_IR("target-features-attr", reduceTargetFeaturesAttrDeltaPass, "Reducing target-features")
 DELTA_PASS_IR("module-data", reduceModuleDataDeltaPass, "Reducing Module Data")
 DELTA_PASS_IR("opcodes", reduceOpcodesDeltaPass, "Reducing Opcodes")
 DELTA_PASS_IR("volatile", reduceVolatileInstructionsDeltaPass, "Reducing Volatile Instructions")

--- a/llvm/tools/llvm-reduce/deltas/ReduceTargetFeaturesAttr.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceTargetFeaturesAttr.cpp
@@ -1,0 +1,56 @@
+//===- ReduceTargetFeaturesAttr.cpp - Specialized Delta Pass --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Attempt to remove individual elements of the "target-features" attribute on
+// functions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "ReduceTargetFeaturesAttr.h"
+
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/IR/Function.h"
+
+// TODO: We could maybe do better if we did a semantic parse of the attributes
+// through MCSubtargetInfo. Features can be flipped on and off in the string,
+// some are implied by target-cpu and can't be meaningfully re-added.
+void llvm::reduceTargetFeaturesAttrDeltaPass(Oracle &O,
+                                             ReducerWorkItem &WorkItem) {
+  Module &M = WorkItem.getModule();
+  SmallString<256> NewValueString;
+  SmallVector<StringRef, 32> SplitFeatures;
+
+  for (Function &F : M) {
+    Attribute TargetFeaturesAttr = F.getFnAttribute("target-features");
+    if (!TargetFeaturesAttr.isValid())
+      continue;
+
+    StringRef TargetFeatures = TargetFeaturesAttr.getValueAsString();
+    TargetFeatures.split(SplitFeatures, ',', /*MaxSplit=*/-1,
+                         /*KeepEmpty=*/false);
+
+    ListSeparator LS(",");
+
+    {
+      raw_svector_ostream OS(NewValueString);
+      for (StringRef Feature : SplitFeatures) {
+        if (O.shouldKeep())
+          OS << LS << Feature;
+      }
+    }
+
+    if (NewValueString.empty())
+      F.removeFnAttr("target-features");
+    else
+      F.addFnAttr("target-features", NewValueString);
+
+    SplitFeatures.clear();
+    NewValueString.clear();
+  }
+}

--- a/llvm/tools/llvm-reduce/deltas/ReduceTargetFeaturesAttr.h
+++ b/llvm/tools/llvm-reduce/deltas/ReduceTargetFeaturesAttr.h
@@ -1,0 +1,23 @@
+//===- ReduceTargetFeaturesAttr.h - Specialized Delta Pass ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a function which calls the Generic Delta pass in order
+// to reduce uninteresting attributes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TOOLS_LLVM_REDUCE_DELTAS_REDUCETARGETFEATURESATTR_H
+#define LLVM_TOOLS_LLVM_REDUCE_DELTAS_REDUCETARGETFEATURESATTR_H
+
+#include "Delta.h"
+
+namespace llvm {
+void reduceTargetFeaturesAttrDeltaPass(Oracle &O, ReducerWorkItem &WorkItem);
+} // namespace llvm
+
+#endif

--- a/llvm/utils/gn/secondary/llvm/tools/llvm-reduce/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/tools/llvm-reduce/BUILD.gn
@@ -47,6 +47,7 @@ executable("llvm-reduce") {
     "deltas/ReduceRegisterDefs.cpp",
     "deltas/ReduceRegisterMasks.cpp",
     "deltas/ReduceRegisterUses.cpp",
+    "deltas/ReduceTargetFeaturesAttr.cpp",
     "deltas/ReduceSpecialGlobals.cpp",
     "deltas/ReduceUsingSimplifyCFG.cpp",
     "deltas/ReduceVirtualRegisters.cpp",


### PR DESCRIPTION
Try to reduce individual subtarget features in the "target-features"
attribute. This attempts a textual removal of the fields in the string,
not a semantic removal. Typically there's a lot of redundant feature spam
in the feature list implied by the target-cpu (which I really wish clang
would stop emitting). If we could parse these out, we could easily drop
the fields without testing anything.