### PR TITLE
[DebugInfo] Soft-disable the production of debug intrinsics

### DIFF
--- a/flang/test/Integration/debug-local-var-2.f90
+++ b/flang/test/Integration/debug-local-var-2.f90
@@ -1,4 +1,3 @@
-! RUN: %flang_fc1 -emit-llvm -debug-info-kind=standalone %s -mllvm --experimental-debuginfo-iterators=false -o - | FileCheck %s --check-prefixes=BOTH,INTRINSICS
 ! RUN: %flang_fc1 -emit-llvm -debug-info-kind=standalone %s -mllvm --experimental-debuginfo-iterators=true -o - | FileCheck %s --check-prefixes=BOTH,RECORDS
 ! RUN: %flang_fc1 -emit-llvm -debug-info-kind=line-tables-only %s -mllvm --experimental-debuginfo-iterators=false -o - | FileCheck --check-prefix=LINEONLY %s
 ! RUN: %flang_fc1 -emit-llvm -debug-info-kind=line-tables-only %s -mllvm --experimental-debuginfo-iterators=true -o - | FileCheck --check-prefix=LINEONLY %s
@@ -12,12 +11,6 @@
 ! BOTH-DAG: %[[AL13:.*]] = alloca i8
 ! BOTH-DAG: %[[AL12:.*]] = alloca i64
 ! BOTH-DAG: %[[AL11:.*]] = alloca i32
-! INTRINSICS-DAG: call void @llvm.dbg.declare(metadata ptr %[[AL11]], metadata ![[I4:.*]], metadata !DIExpression())
-! INTRINSICS-DAG: call void @llvm.dbg.declare(metadata ptr %[[AL12]], metadata ![[I8:.*]], metadata !DIExpression())
-! INTRINSICS-DAG: call void @llvm.dbg.declare(metadata ptr %[[AL13]], metadata ![[L1:.*]], metadata !DIExpression())
-! INTRINSICS-DAG: call void @llvm.dbg.declare(metadata ptr %[[AL14]], metadata ![[L4:.*]], metadata !DIExpression())
-! INTRINSICS-DAG: call void @llvm.dbg.declare(metadata ptr %[[AL15]], metadata ![[R4:.*]], metadata !DIExpression())
-! INTRINSICS-DAG: call void @llvm.dbg.declare(metadata ptr %[[AL16]], metadata ![[R8:.*]], metadata !DIExpression())
 ! RECORDS-DAG: #dbg_declare(ptr %[[AL11]], ![[I4:.*]], !DIExpression(), !{{.*}})
 ! RECORDS-DAG: #dbg_declare(ptr %[[AL12]], ![[I8:.*]], !DIExpression(), !{{.*}})
 ! RECORDS-DAG: #dbg_declare(ptr %[[AL13]], ![[L1:.*]], !DIExpression(), !{{.*}})
@@ -28,27 +21,19 @@
 
 ! BOTH-LABEL: define {{.*}}i64 @_QFPfn1
 ! BOTH-SAME: (ptr captures(none) %[[ARG1:.*]], ptr captures(none) %[[ARG2:.*]], ptr captures(none) %[[ARG3:.*]])
-! INTRINSICS-DAG: call void @llvm.dbg.declare(metadata ptr %[[ARG1]], metadata ![[A1:.*]], metadata !DIExpression())
-! INTRINSICS-DAG: call void @llvm.dbg.declare(metadata ptr %[[ARG2]], metadata ![[B1:.*]], metadata !DIExpression())
-! INTRINSICS-DAG: call void @llvm.dbg.declare(metadata ptr %[[ARG3]], metadata ![[C1:.*]], metadata !DIExpression())
 ! RECORDS-DAG: #dbg_declare(ptr %[[ARG1]], ![[A1:.*]], !DIExpression(), !{{.*}})
 ! RECORDS-DAG: #dbg_declare(ptr %[[ARG2]], ![[B1:.*]], !DIExpression(), !{{.*}})
 ! RECORDS-DAG: #dbg_declare(ptr %[[ARG3]], ![[C1:.*]], !DIExpression(), !{{.*}})
 ! BOTH-DAG: %[[AL2:.*]] = alloca i64
-! INTRINSICS-DAG: call void @llvm.dbg.declare(metadata ptr %[[AL2]], metadata ![[RES1:.*]], metadata !DIExpression())
 ! RECORDS-DAG: #dbg_declare(ptr %[[AL2]], ![[RES1:.*]], !DIExpression(), !{{.*}})
 ! BOTH-LABEL: }
 
 ! BOTH-LABEL: define {{.*}}i32 @_QFPfn2
 ! BOTH-SAME: (ptr captures(none) %[[FN2ARG1:.*]], ptr captures(none) %[[FN2ARG2:.*]], ptr captures(none) %[[FN2ARG3:.*]])
-! INTRINSICS-DAG: call void @llvm.dbg.declare(metadata ptr %[[FN2ARG1]], metadata ![[A2:.*]], metadata !DIExpression())
-! INTRINSICS-DAG: call void @llvm.dbg.declare(metadata ptr %[[FN2ARG2]], metadata ![[B2:.*]], metadata !DIExpression())
-! INTRINSICS-DAG: call void @llvm.dbg.declare(metadata ptr %[[FN2ARG3]], metadata ![[C2:.*]], metadata !DIExpression())
 ! RECORDS-DAG: #dbg_declare(ptr %[[FN2ARG1]], ![[A2:.*]], !DIExpression(), !{{.*}})
 ! RECORDS-DAG: #dbg_declare(ptr %[[FN2ARG2]], ![[B2:.*]], !DIExpression(), !{{.*}})
 ! RECORDS-DAG: #dbg_declare(ptr %[[FN2ARG3]], ![[C2:.*]], !DIExpression(), !{{.*}})
 ! BOTH-DAG: %[[AL3:.*]] = alloca i32
-! INTRINSICS-DAG: call void @llvm.dbg.declare(metadata ptr %[[AL3]], metadata ![[RES2:.*]], metadata !DIExpression())
 ! RECORDS-DAG: #dbg_declare(ptr %[[AL3]], ![[RES2:.*]], !DIExpression(), !{{.*}})
 ! BOTH-LABEL: }
 

--- a/llvm/lib/IR/BasicBlock.cpp
+++ b/llvm/lib/IR/BasicBlock.cpp
@@ -30,11 +30,28 @@ using namespace llvm;
 #define DEBUG_TYPE "ir"
 STATISTIC(NumInstrRenumberings, "Number of renumberings across all blocks");
 
+// This cl-opt exists to control whether variable-location information is
+// produced using intrinsics, or whether DbgRecords are produced. However,
+// it's imminently being phased out, so give it a flag-name that is very
+// unlikely to be used anywhere.
+//
+// If you find yourself needing to use this flag for any period longer than
+// five minutes, please revert the patch making this change, and make contact
+// in this discourse post, where we can discuss any further transition work
+// that might be needed to remove debug intrinsics.
+//
+// https://discourse.llvm.org/t/psa-ir-output-changing-from-debug-intrinsics-to-debug-records/79578
 cl::opt<bool> UseNewDbgInfoFormat(
-    "experimental-debuginfo-iterators",
-    cl::desc("Enable communicating debuginfo positions through iterators, "
-             "eliminating intrinsics. Has no effect if "
-             "--preserve-input-debuginfo-format=true."),
+    "dont-pass-this-flag-please-experimental-debuginfo", cl::Hidden,
+    cl::init(true));
+
+// This cl-opt collects the --experimental-debuginfo-iterators flag and then
+// does nothing with it (because the it gets stored into an otherwise unused
+// cl-opt), so that we can disable debug-intrinsic production without
+// immediately modifying lots of tests. If your tests break because of this
+// change, please see the next comment up.
+static cl::opt<bool> DeliberatelyUnseenDbgInfoFlag(
+    "experimental-debuginfo-iterators", cl::Hidden,
     cl::init(true));
 
 DbgMarker *BasicBlock::createMarker(Instruction *I) {


### PR DESCRIPTION
The objective of this patch is to flush out anyone who's still using debug intrinsics by breaking their tests (see commit message below), and getting them to make contact. To the best of my knowledge, there's nothing left for us to do for eliminating debug intrinsics aside from this. We could also be hard-nosed and just start deleting stuff, but this'll give downstream folks a heads-up at least.

All the llvm-lit tests pass with this change. It's possible there are rarer mlir/flang tests that'll fail, I suspect the solution to those will be deleting coverage for what's about to be disabled anyway. In an ideal world, we can then move on to deleting spurious debug-info things!.

This patch depends on #133917, which is just squashing another output-variation flag.

~

This patch switches the --experimental-debuginfo-iterators flag to be stored to an otherwise unused cl-opt. This is a deliberate attempt to break downstream tests that are relying on the use of debug intrinsics, because they're imminently going away! If this commit breaks your tests, please just revert the commit upstream, and then make contact with us here:

https://discourse.llvm.org/t/psa-ir-output-changing-from-debug-intrinsics-to-debug-records/79578

So that we can work out whether there's any further transition work needed to support the move away from using debug intrinsics.