### PR TITLE
[RISCV] Improve error for using x18-x27 in a register list with RVE.

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
@@ -603,8 +603,8 @@ enum RLISTENCODE {
   INVALID_RLIST,
 };
 
-inline unsigned encodeRlist(MCRegister EndReg, bool IsRV32E = false) {
-  assert((!IsRV32E || EndReg <= RISCV::X9) && "Invalid Rlist for RV32E");
+inline unsigned encodeRlist(MCRegister EndReg, bool IsRVE = false) {
+  assert((!IsRVE || EndReg <= RISCV::X9) && "Invalid Rlist for RV32E");
   switch (EndReg) {
   case RISCV::X1:
     return RLISTENCODE::RA;

--- a/llvm/test/MC/RISCV/rv32e-xqccmp-invalid.s
+++ b/llvm/test/MC/RISCV/rv32e-xqccmp-invalid.s
@@ -14,8 +14,11 @@ qc.cm.push {ra,s0-s2}, -16
 # CHECK: :[[@LINE+1]]:21: error: invalid register
 qc.cm.popret {ra,s0-s2}, 16
 # CHECK-DIS: ba72 <unknown>
-# CHECK: :[[@LINE+1]]:21: error: register list must end with '}'
+# CHECK: :[[@LINE+1]]:23: error: invalid register
 qc.cm.pop {x1, x8-x9, x18}, 16
 # CHECK-DIS: b972 <unknown>
-# CHECK: :[[@LINE+1]]:24: error: register list must end with '}'
+# CHECK: :[[@LINE+1]]:26: error: invalid register
 qc.cm.pushfp {x1, x8-x9, x18}, -16
+# CHECK-DIS: b972 <unknown>
+# CHECK: :[[@LINE+1]]:22: error: invalid register
+qc.cm.pushfp {ra, s0-s2}, -16

--- a/llvm/test/MC/RISCV/rv32e-zcmp-invalid.s
+++ b/llvm/test/MC/RISCV/rv32e-zcmp-invalid.s
@@ -14,5 +14,8 @@ cm.push {ra,s0-s2}, -16
 # CHECK: :[[@LINE+1]]:18: error: invalid register
 cm.popret {ra,s0-s2}, 16
 # CHECK-DIS: ba72 <unknown>
-# CHECK: :[[@LINE+1]]:18: error: register list must end with '}'
+# CHECK: :[[@LINE+1]]:20: error: invalid register
 cm.pop {x1, x8-x9, x18}, 16
+# CHECK-DIS: ba72 <unknown>
+# CHECK: :[[@LINE+1]]:16: error: invalid register
+cm.pop {ra, s0-s2}, 16

--- a/llvm/test/MC/RISCV/rv64e-xqccmp-invalid.s
+++ b/llvm/test/MC/RISCV/rv64e-xqccmp-invalid.s
@@ -14,8 +14,11 @@ qc.cm.push {ra,s0-s2}, -32
 # CHECK: :[[@LINE+1]]:21: error: invalid register
 qc.cm.popret {ra,s0-s2}, 32
 # CHECK-DIS: ba72 <unknown>
-# CHECK: :[[@LINE+1]]:21: error: register list must end with '}'
+# CHECK: :[[@LINE+1]]:23: error: invalid register
 qc.cm.pop {x1, x8-x9, x18}, 32
 # CHECK-DIS: b972 <unknown>
-# CHECK: :[[@LINE+1]]:24: error: register list must end with '}'
+# CHECK: :[[@LINE+1]]:26: error: invalid register
 qc.cm.pushfp {x1, x8-x9, x18}, -32
+# CHECK-DIS: b972 <unknown>
+# CHECK: :[[@LINE+1]]:22: error: invalid register
+qc.cm.pushfp {ra, s0-s2}, -32

--- a/llvm/test/MC/RISCV/rv64e-zcmp-invalid.s
+++ b/llvm/test/MC/RISCV/rv64e-zcmp-invalid.s
@@ -14,5 +14,8 @@ cm.push {ra,s0-s2}, -32
 # CHECK: :[[@LINE+1]]:18: error: invalid register
 cm.popret {ra,s0-s2}, 32
 # CHECK-DIS: ba72 <unknown>
-# CHECK: :[[@LINE+1]]:18: error: register list must end with '}'
+# CHECK: :[[@LINE+1]]:20: error: invalid register
 cm.pop {x1, x8-x9, x18}, 32
+# CHECK-DIS: ba72 <unknown>
+# CHECK: :[[@LINE+1]]:16: error: invalid register
+cm.pop {ra, s0-s2}, 32


### PR DESCRIPTION
matchRegisterNameHelper returns MCRegister() for RVE so the first RVE check was dead.

For the second check, I've moved the RVE check from the comma parsing to the identifier parsing so the diagnostic points at the register. Note we're using matchRegisterName instead of matchRegisterNameHelper to avoid allowing ABI names so we don't get the RVE check that lives inside matchRegisterNameHelper.

The errors for RVE in general should probably say something other than "invalid register", but that's a problem throughout the assembler.