### PR TITLE
Implement a simple e2e test for PFP.

### DIFF
--- a/compiler-rt/test/CMakeLists.txt
+++ b/compiler-rt/test/CMakeLists.txt
@@ -106,6 +106,9 @@ if(COMPILER_RT_CAN_EXECUTE_TESTS)
   # ShadowCallStack does not yet provide a runtime with compiler-rt, the tests
   # include their own minimal runtime
   add_subdirectory(shadowcallstack)
+  # PointerFieldProtection does not yet provide a runtime with compiler-rt, the tests
+  # include their own minimal runtime
+  add_subdirectory(pfp)
 endif()
 
 # Now that we've traversed all the directories and know all the lit testsuites,

--- a/compiler-rt/test/pfp/CMakeLists.txt
+++ b/compiler-rt/test/pfp/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(PFP_TESTSUITES)
+set(PFP_TEST_DEPS
+  ${SANITIZER_COMMON_LIT_TEST_DEPS}
+  lld
+  clang)
+
+set(PFP_TEST_ARCH ${X86_64} ${ARM64})
+
+configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+  ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg.py)
+
+list(APPEND PFP_TESTSUITES ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME})
+
+add_lit_testsuite(check-pfp "Running the PointerFieldProtection tests"
+  ${PFP_TESTSUITES}
+  DEPENDS ${PFP_TEST_DEPS})
+

--- a/compiler-rt/test/pfp/lit.cfg.py
+++ b/compiler-rt/test/pfp/lit.cfg.py
@@ -1,0 +1,35 @@
+# -*- Python -*-
+
+import os
+
+from lit.llvm import llvm_config
+from lit.llvm.subst import ToolSubst, FindTool
+
+# Setup config name.
+config.name = "pfp" + config.name_suffix
+
+# Default test suffixes.
+config.suffixes = [".c", ".cpp"]
+
+if config.host_os not in ["Linux"]:
+    config.unsupported = True
+
+# Setup source root.
+config.test_source_root = os.path.dirname(__file__)
+# Setup default compiler flags used with -fsanitize=memory option.
+clang_cflags = [config.target_cflags] + config.debug_info_flags
+clang_cxxflags = config.cxx_mode_flags + clang_cflags
+clang_pfp_tagged_common_cflags = clang_cflags + [
+    "-fexperimental-pointer-field-protection=tagged"
+]
+
+
+clang_pfp_cxxflags = config.cxx_mode_flags + clang_pfp_tagged_common_cflags
+
+
+def build_invocation(compile_flags):
+    return " " + " ".join([config.clang] + compile_flags) + " "
+
+
+config.substitutions.append(("%clangxx ", build_invocation(clang_cxxflags)))
+config.substitutions.append(("%clangxx_pfp ", build_invocation(clang_pfp_cxxflags)))

--- a/compiler-rt/test/pfp/lit.site.cfg.py.in
+++ b/compiler-rt/test/pfp/lit.site.cfg.py.in
@@ -1,0 +1,13 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+# Tool-specific config options.
+config.name_suffix = "@PFP_TEST_CONFIG_SUFFIX@"
+config.target_cflags = "@PFP_TEST_TARGET_CFLAGS@"
+config.target_arch = "@PFP_TEST_TARGET_ARCH@"
+
+
+# Load common config for all compiler-rt lit tests.
+lit_config.load_config(config, "@COMPILER_RT_BINARY_DIR@/test/lit.common.configured")
+
+# Load tool-specific config that would do the real work.
+lit_config.load_config(config, "@CMAKE_CURRENT_SOURCE_DIR@/lit.cfg.py")

--- a/compiler-rt/test/pfp/use-after-free-fixed.cpp
+++ b/compiler-rt/test/pfp/use-after-free-fixed.cpp
@@ -1,0 +1,43 @@
+// RUN: %clangxx_pfp %s -o %t1
+// RUN: %run %t1 2>&1
+// RUN: %clangxx %s -o %t2
+// RUN: %run %t2 2>&1
+
+#include <iostream>
+
+// Struct1.ptr and Struct2.ptr have different locks.
+struct Struct1 {
+  int *ptr;
+  Struct1() : num(1), ptr(&num) {}
+
+private:
+  int num;
+};
+
+struct Struct2 {
+  int *ptr;
+  Struct2() : num(2), ptr(&num) {}
+
+private:
+  int num;
+};
+
+Struct1 *new_object1() {
+  Struct1 *ptr = new Struct1;
+  return ptr;
+}
+
+Struct2 *new_object2() {
+  Struct2 *ptr = new Struct2;
+  return ptr;
+}
+
+int main() {
+  Struct1 *obj1 = new_object1();
+  Struct2 *obj2 = new_object2();
+  std::cout << "Struct2: " << *(obj2->ptr) << "\n";
+  std::cout << "Struct1: " << *(obj1->ptr) << "\n";
+  delete obj1;
+  delete obj2;
+  return 0;
+}

--- a/compiler-rt/test/pfp/use-after-free.cpp
+++ b/compiler-rt/test/pfp/use-after-free.cpp
@@ -1,0 +1,45 @@
+// RUN: %clangxx_pfp %s -o %t1
+// RUN: %expect_crash %run %t1 2>&1
+// RUN: %clangxx %s -o %t2
+// RUN: %run %t2 2>&1
+
+#include <iostream>
+
+// Struct1.ptr and Struct2.ptr have different locks.
+struct Struct1 {
+  int *ptr;
+  Struct1() : num(1), ptr(&num) {}
+
+private:
+  int num;
+};
+
+struct Struct2 {
+  int *ptr;
+  Struct2() : num(2), ptr(&num) {}
+
+private:
+  int num;
+};
+
+Struct1 *new_object1() {
+  Struct1 *ptr = new Struct1;
+  return ptr;
+}
+
+Struct2 *new_object2() {
+  Struct2 *ptr = new Struct2;
+  return ptr;
+}
+
+int main() {
+  Struct1 *obj1 = new_object1();
+  delete obj1;
+  // obj1's memory will be reused.
+  Struct2 *obj2 = new_object2();
+  std::cout << "Struct2: " << *(obj2->ptr) << "\n";
+  // Uses a wrong lock. The Program should crash when "-fexperimental-pointer-field-protection=tagged".
+  std::cout << "Struct1: " << *(obj1->ptr) << "\n";
+  delete obj2;
+  return 0;
+}


### PR DESCRIPTION
The program in this test contains a Use-After-Free (UAF) bug and is expected to crash when it is compiled with the `-fexperimental-pointer-field-protection=tagged` option.
