### PR TITLE
[flang] Preserve compiler directives in -E output

### DIFF
--- a/flang/lib/Parser/parsing.cpp
+++ b/flang/lib/Parser/parsing.cpp
@@ -79,16 +79,24 @@ const SourceFile *Parsing::Prescan(const std::string &path, Options options) {
       .set_expandIncludeLines(!options.prescanAndReformat ||
           options.expandIncludeLinesInPreprocessedOutput)
       .AddCompilerDirectiveSentinel("dir$");
-  if (options.features.IsEnabled(LanguageFeature::OpenACC)) {
+  bool noneOfTheAbove{!options.features.IsEnabled(LanguageFeature::OpenACC) &&
+      !options.features.IsEnabled(LanguageFeature::OpenMP) &&
+      !options.features.IsEnabled(LanguageFeature::CUDA)};
+  if (options.features.IsEnabled(LanguageFeature::OpenACC) ||
+      (options.prescanAndReformat && noneOfTheAbove)) {
     prescanner.AddCompilerDirectiveSentinel("$acc");
   }
-  if (options.features.IsEnabled(LanguageFeature::OpenMP)) {
+  if (options.features.IsEnabled(LanguageFeature::OpenMP) ||
+      (options.prescanAndReformat && noneOfTheAbove)) {
     prescanner.AddCompilerDirectiveSentinel("$omp");
     prescanner.AddCompilerDirectiveSentinel("$"); // OMP conditional line
   }
-  if (options.features.IsEnabled(LanguageFeature::CUDA)) {
+  if (options.features.IsEnabled(LanguageFeature::CUDA) ||
+      (options.prescanAndReformat && noneOfTheAbove)) {
     prescanner.AddCompilerDirectiveSentinel("$cuf");
     prescanner.AddCompilerDirectiveSentinel("@cuf");
+  }
+  if (options.features.IsEnabled(LanguageFeature::CUDA)) {
     preprocessor_.Define("_CUDA", "1");
   }
   ProvenanceRange range{allSources.AddIncludedFile(
@@ -119,11 +127,13 @@ void Parsing::EmitPreprocessedSource(
   int sourceLine{0};
   int column{1};
   bool inDirective{false};
+  bool ompConditionalLine{false};
   bool inContinuation{false};
   bool lineWasBlankBefore{true};
   const AllSources &allSources{allCooked().allSources()};
-  // All directives that flang support are known to have a length of 3 chars
-  constexpr int directiveNameLength{3};
+  // All directives that flang supports are known to have a length of 4 chars,
+  // except for OpenMP conditional compilation lines (!$).
+  constexpr int directiveNameLength{4};
   // We need to know the current directive in order to provide correct
   // continuation for the directive
   std::string directive;
@@ -133,6 +143,7 @@ void Parsing::EmitPreprocessedSource(
       out << '\n'; // TODO: DOS CR-LF line ending if necessary
       column = 1;
       inDirective = false;
+      ompConditionalLine = false;
       inContinuation = false;
       lineWasBlankBefore = true;
       ++sourceLine;
@@ -153,16 +164,21 @@ void Parsing::EmitPreprocessedSource(
         return ch;
       }};
 
+      bool inDirectiveSentinel{false};
       if (ch == '!' && lineWasBlankBefore) {
         // Other comment markers (C, *, D) in original fixed form source
         // input card column 1 will have been deleted or normalized to !,
         // which signifies a comment (directive) in both source forms.
         inDirective = true;
-      }
-      bool inDirectiveSentinel{
-          inDirective && directive.size() < directiveNameLength};
-      if (inDirectiveSentinel && IsLetter(ch)) {
-        directive += getOriginalChar(ch);
+        inDirectiveSentinel = true;
+      } else if (inDirective && !ompConditionalLine &&
+          directive.size() < directiveNameLength) {
+        if (IsLetter(ch) || ch == '$' || ch == '@') {
+          directive += getOriginalChar(ch);
+          inDirectiveSentinel = true;
+        } else if (directive == "$"s) {
+          ompConditionalLine = true;
+        }
       }
 
       std::optional<SourcePosition> position{provenance
@@ -199,9 +215,16 @@ void Parsing::EmitPreprocessedSource(
         // column limit override option.
         // OpenMP and OpenACC directives' continuations should have the
         // corresponding sentinel at the next line.
-        const auto continuation{
-            inDirective ? "&\n!$" + directive + "&" : "&\n     &"s};
-        out << continuation;
+        out << "&\n";
+        if (inDirective) {
+          if (ompConditionalLine) {
+            out << "!$   &";
+          } else {
+            out << '!' << directive << '&';
+          }
+        } else {
+          out << "     &";
+        }
         column = 7; // start of fixed form source field
         ++sourceLine;
         inContinuation = true;
@@ -212,11 +235,20 @@ void Parsing::EmitPreprocessedSource(
           out << ' ';
         }
       }
-      if (!inContinuation && !inDirectiveSentinel && position &&
-          position->column <= 72 && ch != ' ') {
-        // Preserve original indentation
-        for (; column < position->column; ++column) {
-          out << ' ';
+      if (ch != ' ') {
+        if (ompConditionalLine) {
+          // Only digits can stay in the label field
+          if (!(ch >= '0' && ch <= '9')) {
+            for (; column < 7; ++column) {
+              out << ' ';
+            }
+          }
+        } else if (!inContinuation && !inDirectiveSentinel && position &&
+            position->column <= 72) {
+          // Preserve original indentation
+          for (; column < position->column; ++column) {
+            out << ' ';
+          }
         }
       }
       out << getOriginalChar(ch);

--- a/flang/lib/Parser/token-sequence.cpp
+++ b/flang/lib/Parser/token-sequence.cpp
@@ -318,6 +318,7 @@ llvm::raw_ostream &TokenSequence::Dump(llvm::raw_ostream &o) const {
     o << '[' << j << "] @ " << start_[j] << " '" << TokenAt(j).ToString()
       << "'\n";
   }
+  provenances_.Dump(o << "provenances_:\n");
   return o;
 }
 

--- a/flang/test/Parser/OpenMP/compiler-directive-continuation.f90
+++ b/flang/test/Parser/OpenMP/compiler-directive-continuation.f90
@@ -1,12 +1,18 @@
-! RUN: %flang_fc1 -fopenmp -E %s 2>&1 | FileCheck %s --check-prefix=CHECK-OMP
-! RUN: %flang_fc1 -E %s 2>&1 | FileCheck %s 
+! RUN: %flang_fc1 -E %s 2>&1 | FileCheck %s --strict-whitespace --check-prefix=CHECK-E
+! RUN: %flang_fc1 -fopenmp -fdebug-unparse %s 2>&1 | FileCheck %s --check-prefix=CHECK-OMP
+! RUN: %flang_fc1 -fdebug-unparse %s 2>&1 | FileCheck %s --check-prefix=CHECK-NO-OMP
 
-
-! Test in mixed way, i.e., combination of Fortran free source form 
+! Test in mixed way, i.e., combination of Fortran free source form
 ! and free source form with conditional compilation sentinel.
 ! CHECK-LABEL: subroutine mixed_form1()
-! CHECK-OMP: i = 1 +100+ 1000+ 10 + 1 +1000000000 + 1000000
-! CHECK: i = 1 + 10 + 10000 + 1000000
+! CHECK-E:{{^}}      i = 1 &
+! CHECK-E:{{^}}!$    +100&
+! CHECK-E:{{^}}!$    &+ 1000&
+! CHECK-E:{{^}}      &+ 10 + 1&
+! CHECK-E:{{^}}!$    & +100000&
+! CHECK-E:{{^}}      &0000 + 1000000
+! CHECK-OMP: i=1001001112_4
+! CHECK-NO-OMP: i=1010011_4
 subroutine mixed_form1()
    i = 1 &
   !$+100&
@@ -14,13 +20,13 @@ subroutine mixed_form1()
    &+ 10 + 1&
   !$& +100000&
    &0000 + 1000000
-end subroutine	
-
+end subroutine
 
 ! Testing continuation lines in only Fortran Free form Source
 ! CHECK-LABEL: subroutine mixed_form2()
-! CHECK-OMP: i = 1 +10 +100 + 1000 + 10000
-! CHECK: i = 1 +10 +100 + 1000 + 10000
+! CHECK-E:{{^}}      i = 1 +10 +100 + 1000 + 10000
+! CHECK-OMP: i=11111_4
+! CHECK-NO-OMP: i=11111_4
 subroutine mixed_form2()
    i = 1 &
    +10 &
@@ -29,16 +35,21 @@ subroutine mixed_form2()
    + 10000
 end subroutine
 
-
 ! Testing continuation line in only free source form conditional compilation sentinel.
 ! CHECK-LABEL: subroutine mixed_form3()
-! CHECK-OMP: i=0
-! CHECK-OMP: i = 1 +10 +100+1000
+! CHECK-E:{{^}}!$    i=0
+! CHECK-E:{{^}}!$    i = 1 &
+! CHECK-E:{{^}}!$    & +10 &
+! CHECK-E:{{^}}!$    &+100&
+! CHECK-E:{{^}}!$    +1000
+! CHECK-OMP: i=0_4
+! CHECK-OMP: i=1111_4
+! CHECK-NO-OMP-NOT: i=0_4
 subroutine mixed_form3()
    !$ i=0
    !$ i = 1 &
    !$ & +10 &
    !$&+100&
-   !$ +1000 
+   !$ +1000
 end subroutine
 

--- a/flang/test/Parser/OpenMP/sentinels.f
+++ b/flang/test/Parser/OpenMP/sentinels.f
@@ -1,4 +1,4 @@
-! RUN: %flang_fc1 -fopenmp -E %s | FileCheck %s
+! RUN: %flang_fc1 -E %s | FileCheck %s
 ! CHECK:      program main
 ! CHECK:       interface
 ! CHECK:        subroutine sub(a, b)
@@ -60,13 +60,13 @@ c$ x &         , "comment"
 c$  +&         , "comment"
 
 ! Test valid chars in initial and continuation lines.
-! CHECK:      "msg2"
-! CHECK-SAME: "msg3"
+! CHECK: !$ 20 PRINT *, "msg2"
+! CHECK: !$ & , "msg3"
 c$ 20 PRINT *, "msg2"
 c$   &         , "msg3"
 
-! CHECK:      "msg4"
-! CHECK-SAME: "msg5"
+! CHECK: !$ PRINT *, "msg4",
+! CHECK: !$ & "msg5"
 c$   0PRINT *, "msg4",
 c$   +         "msg5"
       end

--- a/flang/test/Parser/continuation-in-conditional-compilation.f
+++ b/flang/test/Parser/continuation-in-conditional-compilation.f
@@ -1,6 +1,7 @@
-! RUN: %flang_fc1 -fopenmp -fopenacc -E %s 2>&1 | FileCheck %s
+! RUN: %flang_fc1 -E %s 2>&1 | FileCheck %s
       program main
-! CHECK: k01=1+ 1
+! CHECK:       k01=1+
+! CHECK: !$   & 1
       k01=1+
 !$   &  1
 

--- a/flang/test/Preprocessing/bug126459.F90
+++ b/flang/test/Preprocessing/bug126459.F90
@@ -1,5 +1,5 @@
-! RUN: %flang -E -fopenmp %s 2>&1 | FileCheck %s
-!CHECK: NDIR=0
+! RUN: %flang_fc1 -fdebug-unparse -fopenmp %s 2>&1 | FileCheck %s
+!CHECK: ndir=0
 #define BLANKMACRO
-BLANKMACRO !$ NDIR=0
+BLANKMACRO !$ ndir=0
 end

--- a/flang/test/Preprocessing/line-in-contin.F90
+++ b/flang/test/Preprocessing/line-in-contin.F90
@@ -1,4 +1,4 @@
-! RUN: %flang_fc1 -fopenmp -E %s 2>&1 | FileCheck %s
+! RUN: %flang_fc1 -E %s 2>&1 | FileCheck %s
 ! CHECK: call foo(0.)
 ! CHECK: call foo(1.)
 ! CHECK: call foo(2.)

--- a/flang/test/Preprocessing/pp132.f90
+++ b/flang/test/Preprocessing/pp132.f90
@@ -1,8 +1,10 @@
-! RUN: %flang -E -fopenmp -fopenacc %s 2>&1 | FileCheck --strict-whitespace %s
+! RUN: %flang -E %s 2>&1 | FileCheck --strict-whitespace %s
 ! CHECK:       {{^}}!$OMP   parallel default(shared) private(super_very_long_name_for_the_va&
 ! CHECK-NEXT:  {{^}}!$OMP&riable)
+! CHECK:       {{^}}!$omp   end parallel
 ! CHECK:       {{^}}!$acc   data copyin(super_very_long_name_for_the_variable, another_super&
 ! CHECK-NEXT:  {{^}}!$acc&_wordy_variable_to_test)
+! CHECK:       {{^}}!$acc   end data
 ! CHECK:       {{^}}!$OMP          something something
 ! Test correct continuations in compiler directives and left-alignment of sentinels
 subroutine foo

--- a/flang/test/Preprocessing/preprocessed-dirs.F90
+++ b/flang/test/Preprocessing/preprocessed-dirs.F90
@@ -1,4 +1,4 @@
-! RUN: %flang_fc1 -E -fopenacc %s 2>&1 | FileCheck %s
+! RUN: %flang_fc1 -E %s 2>&1 | FileCheck %s
 !CHECK: subroutine r4(x) Z real :: x Z !$acc routine Z print *, x Z end
 #define SUB(s, t) subroutine s(x) Z\
   t :: x Z\


### PR DESCRIPTION
No longer require -fopenmp or -fopenacc with -E, unless specific version number options are also required for predefined macros. This means that most source can be preprocessed with -E and then later compiled with -fopenmp, -fopenacc, or neither.

This means that OpenMP conditional compilation lines (!$) are also passed through to -E output.  The tricky part of this patch was dealing with the fact that those conditional lines can also contain regular Fortran line continuation, and that now has to be deferred when !$ lines are interspersed.