### PR TITLE
[polly] Add distribution targets for headers/cmake

### DIFF
--- a/polly/CMakeLists.txt
+++ b/polly/CMakeLists.txt
@@ -100,16 +100,20 @@ include_directories(
 if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
   install(DIRECTORY include/
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    COMPONENT polly-headers
     FILES_MATCHING
     PATTERN "*.h"
     )
 
   install(DIRECTORY ${POLLY_BINARY_DIR}/include/
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    COMPONENT polly-headers
     FILES_MATCHING
     PATTERN "*.h"
     PATTERN "CMakeFiles" EXCLUDE
     )
+  add_llvm_install_targets(install-polly-headers
+    COMPONENT polly-headers)
 endif()
 
 # add_llvm_pass_plugin() already declares the option, but we need access to

--- a/polly/cmake/CMakeLists.txt
+++ b/polly/cmake/CMakeLists.txt
@@ -154,5 +154,8 @@ if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
     "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/PollyConfig.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/PollyConfigVersion.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${POLLY_EXPORTS_FILE_NAME}"
-    DESTINATION "${POLLY_INSTALL_PACKAGE_DIR}")
+    DESTINATION "${POLLY_INSTALL_PACKAGE_DIR}"
+    COMPONENT polly-cmake-exports)
+  add_llvm_install_targets(install-polly-cmake-exports
+    COMPONENT polly-cmake-exports)
 endif ()


### PR DESCRIPTION
This adds distribution targets to `polly-headers` and `polly-cmake-exports` so that they can be installed with `LLVM_DISTRIBUTION_COMPONENTS`.