### PR TITLE
[OpenMP] [AIX] Add missing } in  openmp/runtime/src/z_Linux_util.cpp

### DIFF
--- a/openmp/runtime/src/z_Linux_util.cpp
+++ b/openmp/runtime/src/z_Linux_util.cpp
@@ -2520,6 +2520,7 @@ int __kmp_get_load_balance(int max) {
   glb_running_threads = running_threads;
 
   return running_threads;
+}
 #elif KMP_OS_HAIKU
 
 int __kmp_get_load_balance(int max) { return -1; }

--- a/openmp/runtime/src/z_Linux_util.cpp
+++ b/openmp/runtime/src/z_Linux_util.cpp
@@ -2521,6 +2521,7 @@ int __kmp_get_load_balance(int max) {
 
   return running_threads;
 }
+
 #elif KMP_OS_HAIKU
 
 int __kmp_get_load_balance(int max) { return -1; }


### PR DESCRIPTION
Changes from https://github.com/llvm/llvm-project/pull/133034 removed a `}` presumably accidentally that are causing failures in the AIX flang bot.