### PR TITLE
lld: Target-specific section-folding logic for ICF

### DIFF
--- a/lld/ELF/Target.h
+++ b/lld/ELF/Target.h
@@ -102,6 +102,9 @@ public:
   virtual void applyJumpInstrMod(uint8_t *loc, JumpModType type,
                                  JumpModType val) const {}
 
+  // Used by ICF to determine if section full of @relocs can be folded safely with another
+  virtual bool canFoldSection(const SmallVector<Relocation> &relocs) const { return true; }
+
   virtual ~TargetInfo();
 
   // This deletes a jump insn at the end of the section if it is a fall thru to

--- a/lld/test/ELF/aarch64-icf-unpaired.s
+++ b/lld/test/ELF/aarch64-icf-unpaired.s
@@ -1,0 +1,48 @@
+// REQUIRES: aarch64
+
+# RUN: llvm-mc -filetype=obj -triple=aarch64 %s -o %t
+# RUN: ld.lld %t -o %t2 --icf=all --print-icf-sections | FileCheck %s
+
+# CHECK-NOT: selected section {{.*}}(.text.f2_0)
+# CHECK-NOT:   removing identical section {{.*}}(.text.f2_1)
+# CHECK-NOT:   removing identical section {{.*}}(.text.f2_2)
+
+.addrsig
+
+callee:
+ret
+
+.macro f, index
+
+.section .text.f1_\index,"ax",@progbits
+f1_\index:
+adrp x0, :got:g\index
+mov x1, #\index
+b f2_\index
+
+.section .text.f2_\index,"ax",@progbits
+f2_\index:
+ldr x0, [x0, :got_lo12:g\index] 
+b callee
+
+.globl g\index
+.section .rodata.g\index,"a",@progbits
+g_\index:
+.long 111
+.long 122
+
+g\index:
+.byte 123
+
+.section .text._start,"ax",@progbits
+bl f1_\index
+
+.endm
+
+.section .text._start,"ax",@progbits
+.globl _start
+_start:
+
+f 0
+f 1
+f 2


### PR DESCRIPTION
This is needed for AArch64 when we try to fold two sections with unpaired ADRP/LDR relocations in them.