### PR TITLE
[libc] Stop depending on .cpp files libcxx_shared_headers library.

### DIFF
--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -165,7 +165,7 @@ add_header_library(
   DEPENDS
     .ctype_utils
     .str_to_num_result
-    libc.src.errno.errno
+    libc.hdr.errno_macros
     libc.src.__support.CPP.limits
     libc.src.__support.CPP.type_traits
     libc.src.__support.common
@@ -217,6 +217,7 @@ add_header_library(
     .str_to_integer
     .str_to_num_result
     .uint128
+    libc.hdr.errno_macros
     libc.src.__support.common
     libc.src.__support.CPP.bit
     libc.src.__support.CPP.limits
@@ -226,7 +227,6 @@ add_header_library(
     libc.src.__support.macros.config
     libc.src.__support.macros.null_check
     libc.src.__support.macros.optimization
-    libc.src.errno.errno
 )
 
 add_header_library(

--- a/libc/src/__support/libc_assert.h
+++ b/libc/src/__support/libc_assert.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_LIBC_ASSERT_H
 #define LLVM_LIBC_SRC___SUPPORT_LIBC_ASSERT_H
 
-#include "src/__support/macros/config.h"
 #if defined(LIBC_COPT_USE_C_ASSERT) || !defined(LIBC_FULL_BUILD)
 
 // The build is configured to just use the public <assert.h> API
@@ -25,6 +24,7 @@
 #include "src/__support/OSUtil/io.h"
 #include "src/__support/integer_to_string.h"
 #include "src/__support/macros/attributes.h"   // For LIBC_INLINE
+#include "src/__support/macros/config.h"
 #include "src/__support/macros/optimization.h" // For LIBC_UNLIKELY
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/__support/str_to_float.h
+++ b/libc/src/__support/str_to_float.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_STR_TO_FLOAT_H
 #define LLVM_LIBC_SRC___SUPPORT_STR_TO_FLOAT_H
 
+#include "hdr/errno_macros.h" // For ERANGE
 #include "src/__support/CPP/bit.h"
 #include "src/__support/CPP/limits.h"
 #include "src/__support/CPP/optional.h"
@@ -31,7 +32,6 @@
 #include "src/__support/str_to_integer.h"
 #include "src/__support/str_to_num_result.h"
 #include "src/__support/uint128.h"
-#include "src/errno/libc_errno.h" // For ERANGE
 
 #include <stdint.h>
 

--- a/libc/src/__support/str_to_integer.h
+++ b/libc/src/__support/str_to_integer.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_STR_TO_INTEGER_H
 #define LLVM_LIBC_SRC___SUPPORT_STR_TO_INTEGER_H
 
+#include "hdr/errno_macros.h" // For ERANGE
 #include "src/__support/CPP/limits.h"
 #include "src/__support/CPP/type_traits.h"
 #include "src/__support/CPP/type_traits/make_unsigned.h"
@@ -24,7 +25,6 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/str_to_num_result.h"
 #include "src/__support/uint128.h"
-#include "src/errno/libc_errno.h" // For ERANGE
 
 namespace LIBC_NAMESPACE_DECL {
 namespace internal {

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -841,12 +841,6 @@ libc_support_library(
 libc_support_library(
     name = "__support_libc_assert",
     hdrs = ["src/__support/libc_assert.h"],
-    deps = [
-        ":__support_integer_to_string",
-        ":__support_macros_attributes",
-        ":__support_osutil_exit",
-        ":__support_osutil_io",
-    ],
 )
 
 libc_support_library(
@@ -868,7 +862,7 @@ libc_support_library(
         ":__support_ctype_utils",
         ":__support_str_to_num_result",
         ":__support_uint128",
-        ":errno",
+        ":hdr_errno_macros",
     ],
 )
 
@@ -892,7 +886,7 @@ libc_support_library(
         ":__support_str_to_integer",
         ":__support_str_to_num_result",
         ":__support_uint128",
-        ":errno",
+        ":hdr_errno_macros",
     ],
 )
 
@@ -1590,21 +1584,6 @@ libc_support_library(
 
 ########################## externally shared targets ###########################
 
-# TODO: Remove this once downstream users are migrated to libcxx_shared_headers.
-libc_support_library(
-    name = "libc_external_common",
-    hdrs = glob(
-        ["shared/*.h"],
-        exclude = ["shared/rpc_server.h"],
-    ),
-    deps = [
-        ":__support_common",
-        ":__support_fputil_fp_bits",
-        ":__support_str_to_float",
-        ":__support_str_to_integer",
-    ],
-)
-
 libc_header_library(
     name = "libcxx_shared_headers",
     hdrs = [
@@ -1911,6 +1890,7 @@ libc_support_library(
         ":__support_fputil_fma",
         ":__support_fputil_multiply_add",
         ":__support_fputil_polyeval",
+        ":__support_integer_literals",
     ],
 )
 


### PR DESCRIPTION
Fix two instances of libcxx_shared_headers depending on .cpp files (in Bazel build):

* Don't depend on exit syscall in LIBC_ASSERT implementation. This dependency is not used, since LIBC_ASSERT always uses system <assert.h> in the overlay mode, which is the only mode supported by Bazel.
* Don't depend on libc_errno in str-to-float and str-to-integer conversions. We only need the ERANGE value, which can be obtained from the proxy header instead.