### PR TITLE
[mlir] fix IntegerRangeAnalysis::staticallyNonNegative

### DIFF
--- a/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
@@ -43,6 +43,9 @@ LogicalResult staticallyNonNegative(DataFlowSolver &solver, Value v) {
   if (!result || result->getValue().isUninitialized())
     return failure();
   const ConstantIntRanges &range = result->getValue().getValue();
+  if (!range.umin().getBitWidth() || !range.umax().getBitWidth() ||
+      !range.smin().getBitWidth() || !range.smax().getBitWidth())
+    return false;
   return success(range.smin().isNonNegative());
 }
 


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/133541, `ConstantIntRanges` can sometimes have 0-bitwidth APInt. This leads to 

```
llvm/include/llvm/ADT/APInt.h:1044: bool llvm::APInt::operator[](unsigned int) const: Assertion `bitPosition < getBitWidth() && "Bit position out of bounds!"' failed.
```

somewhere around here. This isn't a great fix (basically a band-aid) but I'm putting it up so we can centralize discussion of how to actually fix - possibly we might first revert https://github.com/llvm/llvm-project/pull/133541? Not sure.