### PR TITLE
[clang][modules] Determine if the SDK supports builtin modules independent of the target

### DIFF
--- a/clang/include/clang/Basic/DarwinSDKInfo.h
+++ b/clang/include/clang/Basic/DarwinSDKInfo.h
@@ -143,15 +143,18 @@ public:
 
   DarwinSDKInfo(
       VersionTuple Version, VersionTuple MaximumDeploymentTarget,
+      llvm::Triple::OSType OS,
       llvm::DenseMap<OSEnvPair::StorageType,
                      std::optional<RelatedTargetVersionMapping>>
           VersionMappings =
               llvm::DenseMap<OSEnvPair::StorageType,
                              std::optional<RelatedTargetVersionMapping>>())
       : Version(Version), MaximumDeploymentTarget(MaximumDeploymentTarget),
-        VersionMappings(std::move(VersionMappings)) {}
+        OS(OS), VersionMappings(std::move(VersionMappings)) {}
 
   const llvm::VersionTuple &getVersion() const { return Version; }
+
+  const llvm::Triple::OSType &getOS() const { return OS; }
 
   // Returns the optional, target-specific version mapping that maps from one
   // target to another target.
@@ -177,6 +180,7 @@ public:
 private:
   VersionTuple Version;
   VersionTuple MaximumDeploymentTarget;
+  llvm::Triple::OSType OS;
   // Need to wrap the value in an optional here as the value has to be default
   // constructible, and std::unique_ptr doesn't like DarwinSDKInfo being
   // Optional as Optional is trying to copy it in emplace.

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1886,7 +1886,8 @@ struct DarwinPlatform {
     assert(IsValid && "invalid SDK version");
     return DarwinSDKInfo(
         Version,
-        /*MaximumDeploymentTarget=*/VersionTuple(Version.getMajor(), 0, 99));
+        /*MaximumDeploymentTarget=*/VersionTuple(Version.getMajor(), 0, 99),
+        getOSFromPlatform(Platform));
   }
 
 private:
@@ -1913,6 +1914,23 @@ private:
       return DarwinPlatformKind::DriverKit;
     default:
       llvm_unreachable("Unable to infer Darwin variant");
+    }
+  }
+
+  static llvm::Triple::OSType getOSFromPlatform(DarwinPlatformKind Platform) {
+    switch (Platform) {
+    case DarwinPlatformKind::MacOS:
+      return llvm::Triple::MacOSX;
+    case DarwinPlatformKind::IPhoneOS:
+      return llvm::Triple::IOS;
+    case DarwinPlatformKind::TvOS:
+      return llvm::Triple::TvOS;
+    case DarwinPlatformKind::WatchOS:
+      return llvm::Triple::WatchOS;
+    case DarwinPlatformKind::DriverKit:
+      return llvm::Triple::DriverKit;
+    case DarwinPlatformKind::XROS:
+      return llvm::Triple::XROS;
     }
   }
 
@@ -2966,20 +2984,8 @@ bool Darwin::isAlignedAllocationUnavailable() const {
   return TargetVersion < alignedAllocMinVersion(OS);
 }
 
-static bool sdkSupportsBuiltinModules(
-    const Darwin::DarwinPlatformKind &TargetPlatform,
-    const Darwin::DarwinEnvironmentKind &TargetEnvironment,
-    const std::optional<DarwinSDKInfo> &SDKInfo) {
-  if (TargetEnvironment == Darwin::NativeEnvironment ||
-      TargetEnvironment == Darwin::Simulator ||
-      TargetEnvironment == Darwin::MacCatalyst) {
-    // Standard xnu/Mach/Darwin based environments
-    // depend on the SDK version.
-  } else {
-    // All other environments support builtin modules from the start.
-    return true;
-  }
-
+static bool
+sdkSupportsBuiltinModules(const std::optional<DarwinSDKInfo> &SDKInfo) {
   if (!SDKInfo)
     // If there is no SDK info, assume this is building against a
     // pre-SDK version of macOS (i.e. before Mac OS X 10.4). Those
@@ -2990,26 +2996,18 @@ static bool sdkSupportsBuiltinModules(
     return false;
 
   VersionTuple SDKVersion = SDKInfo->getVersion();
-  switch (TargetPlatform) {
+  switch (SDKInfo->getOS()) {
   // Existing SDKs added support for builtin modules in the fall
   // 2024 major releases.
-  case Darwin::MacOS:
+  case llvm::Triple::MacOSX:
     return SDKVersion >= VersionTuple(15U);
-  case Darwin::IPhoneOS:
-    switch (TargetEnvironment) {
-    case Darwin::MacCatalyst:
-      // Mac Catalyst uses `-target arm64-apple-ios18.0-macabi` so the platform
-      // is iOS, but it builds with the macOS SDK, so it's the macOS SDK version
-      // that's relevant.
-      return SDKVersion >= VersionTuple(15U);
-    default:
-      return SDKVersion >= VersionTuple(18U);
-    }
-  case Darwin::TvOS:
+  case llvm::Triple::IOS:
     return SDKVersion >= VersionTuple(18U);
-  case Darwin::WatchOS:
+  case llvm::Triple::TvOS:
+    return SDKVersion >= VersionTuple(18U);
+  case llvm::Triple::WatchOS:
     return SDKVersion >= VersionTuple(11U);
-  case Darwin::XROS:
+  case llvm::Triple::XROS:
     return SDKVersion >= VersionTuple(2U);
 
   // New SDKs support builtin modules from the start.
@@ -3138,7 +3136,7 @@ void Darwin::addClangTargetOptions(
   // i.e. when the builtin stdint.h is in the Darwin module too, the cycle
   // goes away. Note that -fbuiltin-headers-in-system-modules does nothing
   // to fix the same problem with C++ headers, and is generally fragile.
-  if (!sdkSupportsBuiltinModules(TargetPlatform, TargetEnvironment, SDKInfo))
+  if (!sdkSupportsBuiltinModules(SDKInfo))
     CC1Args.push_back("-fbuiltin-headers-in-system-modules");
 
   if (!DriverArgs.hasArgNoClaim(options::OPT_fdefine_target_os_macros,

--- a/clang/test/Driver/Inputs/DriverKit23.0.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/DriverKit23.0.sdk/SDKSettings.json
@@ -1,1 +1,1 @@
-{"Version":"23.0", "MaximumDeploymentTarget": "23.0.99"}
+{"Version":"23.0", "CanonicalName": "driverkit23.0", "MaximumDeploymentTarget": "23.0.99"}

--- a/clang/test/Driver/Inputs/MacOSX10.14.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/MacOSX10.14.sdk/SDKSettings.json
@@ -1,1 +1,1 @@
-{"Version":"10.14", "MaximumDeploymentTarget": "10.14.99"}
+{"Version":"10.14", "CanonicalName": "macosx10.14", "MaximumDeploymentTarget": "10.14.99"}

--- a/clang/test/Driver/Inputs/MacOSX10.15.versioned.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/MacOSX10.15.versioned.sdk/SDKSettings.json
@@ -1,5 +1,6 @@
 {
   "Version":"10.15",
+  "CanonicalName": "macosx10.15",
   "MaximumDeploymentTarget": "10.15.99",
   "VersionMap" : {
       "macOS_iOSMac" : {

--- a/clang/test/Driver/Inputs/MacOSX15.0.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/MacOSX15.0.sdk/SDKSettings.json
@@ -1,1 +1,1 @@
-{"Version":"15.0", "MaximumDeploymentTarget": "15.0.99"}
+{"Version":"15.0", "CanonicalName": "macosx15.0", "MaximumDeploymentTarget": "15.0.99"}

--- a/clang/test/Driver/Inputs/MacOSX15.1.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/MacOSX15.1.sdk/SDKSettings.json
@@ -1,1 +1,1 @@
-{"Version":"15.1", "MaximumDeploymentTarget": "15.1.99"}
+{"Version":"15.1", "CanonicalName": "macosx15.1", "MaximumDeploymentTarget": "15.1.99"}

--- a/clang/test/Driver/Inputs/WatchOS6.0.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/WatchOS6.0.sdk/SDKSettings.json
@@ -1,1 +1,1 @@
-{"Version":"6.0.0", "MaximumDeploymentTarget": "6.0.99"}
+{"Version":"6.0", "CanonicalName": "watchos6.0", "MaximumDeploymentTarget": "6.0.99"}

--- a/clang/test/Driver/Inputs/iPhoneOS13.0.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/iPhoneOS13.0.sdk/SDKSettings.json
@@ -1,1 +1,1 @@
-{"Version":"13.0", "MaximumDeploymentTarget": "13.0.99"}
+{"Version":"13.0", "CanonicalName": "iphoneos13.0", "MaximumDeploymentTarget": "13.0.99"}

--- a/clang/test/Driver/darwin-ld-platform-version-watchos.c
+++ b/clang/test/Driver/darwin-ld-platform-version-watchos.c
@@ -18,5 +18,5 @@
 // RUN:   | FileCheck --check-prefix=SIMUL %s
 
 // LINKER-OLD: "-watchos_version_min" "5.2.0"
-// LINKER-NEW: "-platform_version" "watchos" "5.2.0" "6.0.0"
-// SIMUL: "-platform_version" "watchos-simulator" "6.0.0" "6.0.0"
+// LINKER-NEW: "-platform_version" "watchos" "5.2.0" "6.0"
+// SIMUL: "-platform_version" "watchos-simulator" "6.0.0" "6.0"

--- a/clang/test/InstallAPI/Inputs/MacOSX13.0.sdk/SDKSettings.json
+++ b/clang/test/InstallAPI/Inputs/MacOSX13.0.sdk/SDKSettings.json
@@ -1,6 +1,7 @@
 {
   "DefaultVariant": "macos", "DisplayName": "macOS 13",
   "Version": "13.0",
+  "CanonicalName": "macosx13.0",
   "MaximumDeploymentTarget": "13.0.99",
   "PropertyConditionFallbackNames": [], "VersionMap": {
     "iOSMac_macOS": {

--- a/clang/test/Sema/Inputs/AppleTVOS15.0.sdk/SDKSettings.json
+++ b/clang/test/Sema/Inputs/AppleTVOS15.0.sdk/SDKSettings.json
@@ -1,6 +1,7 @@
 {
   "DisplayName": "tvOS 15.0",
   "Version": "15.0",
+  "CanonicalName": "appletvos15.0",
   "MaximumDeploymentTarget": "15.0.99",
   "PropertyConditionFallbackNames": [],
   "VersionMap": {

--- a/clang/test/Sema/Inputs/MacOSX11.0.sdk/SDKSettings.json
+++ b/clang/test/Sema/Inputs/MacOSX11.0.sdk/SDKSettings.json
@@ -1,6 +1,7 @@
 {
   "DefaultVariant": "macos", "DisplayName": "macOS 11",
   "Version": "11.0",
+  "CanonicalName": "macosx11.0",
   "MaximumDeploymentTarget": "11.0.99",
   "PropertyConditionFallbackNames": [], "VersionMap": {
     "iOSMac_macOS": {

--- a/clang/test/Sema/Inputs/WatchOS7.0.sdk/SDKSettings.json
+++ b/clang/test/Sema/Inputs/WatchOS7.0.sdk/SDKSettings.json
@@ -1,6 +1,7 @@
 {
   "DisplayName": "watchOS 7.0",
   "Version": "7.0",
+  "CanonicalName": "watchos7.0",
   "MaximumDeploymentTarget": "7.0.99",
   "PropertyConditionFallbackNames": [],
   "VersionMap": {


### PR DESCRIPTION
Whether the SDK supports builtin modules is a property of the SDK itself, and really has nothing to do with the target. This was already worked around for Mac Catalyst, but there are some other more esoteric non-obvious target-to-sdk mappings that aren't handled. Have the SDK parse its OS out of CanonicalName and use that instead of the target to determine if builtin modules are supported.