### PR TITLE
[lld-macho] Fix code section ordering in output binary

### DIFF
--- a/lld/test/MachO/arm64-objc-stubs.s
+++ b/lld/test/MachO/arm64-objc-stubs.s
@@ -1,22 +1,23 @@
 # REQUIRES: aarch64
 
 # RUN: llvm-mc -filetype=obj -triple=arm64-apple-darwin %s -o %t.o
-# RUN: %lld -arch arm64 -lSystem -o %t.out %t.o
+# RUN: %lld -arch arm64 -lSystem -o %t.out %t.o -U _external_func
 # RUN: llvm-otool -vs __TEXT __objc_stubs %t.out | FileCheck %s
-# RUN: %lld -arch arm64 -lSystem -o %t.out %t.o -dead_strip
+# RUN: %lld -arch arm64 -lSystem -o %t.out %t.o -dead_strip -U _external_func
 # RUN: llvm-otool -vs __TEXT __objc_stubs %t.out | FileCheck %s
-# RUN: %lld -arch arm64 -lSystem -o %t.out %t.o -objc_stubs_fast
+# RUN: %lld -arch arm64 -lSystem -o %t.out %t.o -objc_stubs_fast -U _external_func
 # RUN: llvm-otool -vs __TEXT __objc_stubs %t.out | FileCheck %s
 # RUN: llvm-otool -l %t.out | FileCheck %s --check-prefix=FASTALIGN
-# RUN: %lld -arch arm64 -lSystem -o %t.out %t.o -objc_stubs_small
+# RUN: %lld -arch arm64 -lSystem -o %t.out %t.o -objc_stubs_small -U _external_func
 # RUN: llvm-otool -vs __TEXT __objc_stubs  %t.out | FileCheck %s --check-prefix=SMALL
 # RUN: llvm-otool -l %t.out | FileCheck %s --check-prefix=SMALLALIGN
+# RUN: llvm-objdump --section-headers %t.out | FileCheck %s --check-prefix=SECTIONS
 
 # CHECK: Contents of (__TEXT,__objc_stubs) section
 
 # CHECK-NEXT: _objc_msgSend$foo:
 # CHECK-NEXT: adrp    x1, 8 ; 0x100008000
-# CHECK-NEXT: ldr     x1, [x1, #0x10]
+# CHECK-NEXT: ldr     x1, [x1, #0x18]
 # CHECK-NEXT: adrp    x16, 4 ; 0x100004000
 # CHECK-NEXT: ldr     x16, [x16]
 # CHECK-NEXT: br      x16
@@ -26,7 +27,7 @@
 
 # CHECK-NEXT: _objc_msgSend$length:
 # CHECK-NEXT: adrp    x1, 8 ; 0x100008000
-# CHECK-NEXT: ldr     x1, [x1, #0x18]
+# CHECK-NEXT: ldr     x1, [x1, #0x20]
 # CHECK-NEXT: adrp    x16, 4 ; 0x100004000
 # CHECK-NEXT: ldr     x16, [x16]
 # CHECK-NEXT: br      x16
@@ -44,13 +45,13 @@
 # FASTALIGN-NEXT:     align 2^5 (32)
 
 # SMALL: _objc_msgSend$foo:
-# SMALL-NEXT: adrp    x1, 4 ; 0x100004000
-# SMALL-NEXT: ldr     x1, [x1, #0x10]
+# SMALL-NEXT: adrp    x1, 8 ; 0x100008000
+# SMALL-NEXT: ldr     x1, [x1, #0x18]
 # SMALL-NEXT: b
 
 # SMALL-NEXT: _objc_msgSend$length:
-# SMALL-NEXT: adrp    x1, 4 ; 0x100004000
-# SMALL-NEXT: ldr     x1, [x1, #0x18]
+# SMALL-NEXT: adrp    x1, 8 ; 0x100008000
+# SMALL-NEXT: ldr     x1, [x1, #0x20]
 # SMALL-NEXT: b
 
 # SMALLALIGN:       sectname __objc_stubs
@@ -59,6 +60,12 @@
 # SMALLALIGN-NEXT:      size
 # SMALLALIGN-NEXT:    offset
 # SMALLALIGN-NEXT:     align 2^2 (4)
+
+## Check correct section ordering
+# SECTIONS: Sections:
+# SECTIONS: __text
+# SECTIONS: __stubs
+# SECTIONS: __objc_stubs
 
 .section  __TEXT,__objc_methname,cstring_literals
 lselref1:
@@ -81,4 +88,5 @@ _main:
   bl  _objc_msgSend$length
   bl  _objc_msgSend$foo
   bl  _objc_msgSend$foo
+  bl  _external_func
   ret


### PR DESCRIPTION
In `OutputSegment.cpp`, we need to ensure a specific order for certain sections. The current sorting logic incorrectly prioritizes code sections over explicitly defined section orders. This is problematic because the `__objc_stubs` section is both a code section *and* has a specific ordering requirement. The current logic would incorrectly prioritize its code section status, causing it to be sorted *before* the `__stubs` section. This incorrect ordering breaks the branch extension algorithm, ultimately leading to linker failures due to relocation errors.

We also modify the `lld/test/MachO/arm64-objc-stubs.s` test to ensure correct section ordering.