### PR TITLE
llvm-reduce: Change exit code for uninteresting inputs

### DIFF
--- a/llvm/docs/CommandGuide/llvm-reduce.rst
+++ b/llvm/docs/CommandGuide/llvm-reduce.rst
@@ -108,8 +108,9 @@ GENERIC OPTIONS
 EXIT STATUS
 ------------
 
-:program:`llvm-reduce` returns 0 under normal operation. It returns a non-zero
-exit code if there were any errors.
+:program:`llvm-reduce` returns 0 under normal operation. It returns a
+non-zero exit code if there were any errors. Returns 2 if the
+interestingness test reported the initial input was not interesting.
 
 EXAMPLE
 -------

--- a/llvm/tools/llvm-reduce/llvm-reduce.cpp
+++ b/llvm/tools/llvm-reduce/llvm-reduce.cpp
@@ -203,7 +203,7 @@ int main(int Argc, char **Argv) {
   // interestingness checks.
   if (!Tester.getProgram().isReduced(Tester)) {
     errs() << "\nInput isn't interesting! Verify interesting-ness test\n";
-    return 1;
+    return 2;
   }
 
   // Try to reduce code


### PR DESCRIPTION
This makes it easier to reduce llvm-reduce with llvm-reduce to filter
cases where the input reduced too much.

Not sure if it's possible to test the exit code in lit.