### PR TITLE
Revert "[cmake] Refactor clang unittest cmake"

### DIFF
--- a/clang/unittests/AST/ByteCode/CMakeLists.txt
+++ b/clang/unittests/AST/ByteCode/CMakeLists.txt
@@ -2,13 +2,19 @@ add_clang_unittest(InterpTests
   BitcastBuffer.cpp
   Descriptor.cpp
   toAPValue.cpp
-  CLANG_LIBS
+  )
+
+clang_target_link_libraries(InterpTests
+  PRIVATE
   clangAST
   clangASTMatchers
   clangBasic
   clangFrontend
   clangSerialization
   clangTooling
-  LINK_LIBS
-  clangTesting
   )
+
+  target_link_libraries(InterpTests
+  PRIVATE
+  clangTesting
+)

--- a/clang/unittests/AST/CMakeLists.txt
+++ b/clang/unittests/AST/CMakeLists.txt
@@ -1,3 +1,10 @@
+set(LLVM_LINK_COMPONENTS
+  FrontendOpenMP
+  Support
+  TargetParser
+  )
+
+
 add_subdirectory(ByteCode)
 
 add_clang_unittest(ASTTests
@@ -36,7 +43,10 @@ add_clang_unittest(ASTTests
   TemplateNameTest.cpp
   TypePrinterTest.cpp
   UnresolvedSetTest.cpp
-  CLANG_LIBS
+  )
+
+clang_target_link_libraries(ASTTests
+  PRIVATE
   clangAST
   clangASTMatchers
   clangBasic
@@ -44,12 +54,11 @@ add_clang_unittest(ASTTests
   clangLex
   clangSerialization
   clangTooling
-  LINK_LIBS
+  )
+
+target_link_libraries(ASTTests
+  PRIVATE
   clangTesting
   LLVMTestingAnnotations
   LLVMTestingSupport
-  LLVM_COMPONENTS
-  FrontendOpenMP
-  Support
-  TargetParser
-  )
+)

--- a/clang/unittests/ASTMatchers/CMakeLists.txt
+++ b/clang/unittests/ASTMatchers/CMakeLists.txt
@@ -1,23 +1,31 @@
+set(LLVM_LINK_COMPONENTS
+  FrontendOpenMP
+  Support
+  TargetParser
+  )
+
 add_clang_unittest(ASTMatchersTests
   ASTMatchersInternalTest.cpp
   ASTMatchersNodeTest.cpp
   ASTMatchersNarrowingTest.cpp
   ASTMatchersTraversalTest.cpp
   GtestMatchersTest.cpp
-  CLANG_LIBS
+  )
+
+clang_target_link_libraries(ASTMatchersTests
+  PRIVATE
   clangAST
   clangASTMatchers
   clangBasic
   clangFrontend
   clangSerialization
   clangTooling
-  LINK_LIBS
+  )
+
+target_link_libraries(ASTMatchersTests
+  PRIVATE
   clangTesting
   LLVMTestingSupport
-  LLVM_COMPONENTS
-  FrontendOpenMP
-  Support
-  TargetParser
-  )
+)
 
 add_subdirectory(Dynamic)

--- a/clang/unittests/ASTMatchers/Dynamic/CMakeLists.txt
+++ b/clang/unittests/ASTMatchers/Dynamic/CMakeLists.txt
@@ -1,8 +1,16 @@
+set(LLVM_LINK_COMPONENTS
+  FrontendOpenMP
+  Support
+  )
+
 add_clang_unittest(DynamicASTMatchersTests
   VariantValueTest.cpp
   ParserTest.cpp
   RegistryTest.cpp
-  CLANG_LIBS
+  )
+
+clang_target_link_libraries(DynamicASTMatchersTests
+  PRIVATE
   clangAST
   clangASTMatchers
   clangBasic
@@ -10,9 +18,9 @@ add_clang_unittest(DynamicASTMatchersTests
   clangFrontend
   clangSerialization
   clangTooling
-  LINK_LIBS
+  )
+
+target_link_libraries(DynamicASTMatchersTests
+  PRIVATE
   clangTesting
-  LLVM_COMPONENTS
-  FrontendOpenMP
-  Support
   )

--- a/clang/unittests/Analysis/CMakeLists.txt
+++ b/clang/unittests/Analysis/CMakeLists.txt
@@ -1,3 +1,8 @@
+set(LLVM_LINK_COMPONENTS
+  FrontendOpenMP
+  Support
+  )
+
 add_clang_unittest(ClangAnalysisTests
   CFGDominatorTree.cpp
   CFGTest.cpp
@@ -6,7 +11,10 @@ add_clang_unittest(ClangAnalysisTests
   IntervalPartitionTest.cpp
   MacroExpansionContextTest.cpp
   UnsafeBufferUsageTest.cpp
-  CLANG_LIBS
+  )
+
+clang_target_link_libraries(ClangAnalysisTests
+  PRIVATE
   clangAST
   clangASTMatchers
   clangAnalysis
@@ -15,12 +23,12 @@ add_clang_unittest(ClangAnalysisTests
   clangLex
   clangSerialization
   clangTooling
-  LINK_LIBS
+  )
+
+target_link_libraries(ClangAnalysisTests
+  PRIVATE
   clangTesting
   LLVMTestingSupport
-  LLVM_COMPONENTS
-  FrontendOpenMP
-  Support
   )
 
 add_subdirectory(FlowSensitive)

--- a/clang/unittests/Analysis/FlowSensitive/CMakeLists.txt
+++ b/clang/unittests/Analysis/FlowSensitive/CMakeLists.txt
@@ -1,3 +1,8 @@
+set(LLVM_LINK_COMPONENTS
+  FrontendOpenMP
+  Support
+  )
+
 add_clang_unittest(ClangAnalysisFlowSensitiveTests
   ArenaTest.cpp
   ASTOpsTest.cpp
@@ -25,7 +30,10 @@ add_clang_unittest(ClangAnalysisFlowSensitiveTests
   UncheckedOptionalAccessModelTest.cpp
   ValueTest.cpp
   WatchedLiteralsSolverTest.cpp
-  CLANG_LIBS
+  )
+
+clang_target_link_libraries(ClangAnalysisFlowSensitiveTests
+  PRIVATE
   clangAST
   clangASTMatchers
   clangAnalysis
@@ -36,11 +44,11 @@ add_clang_unittest(ClangAnalysisFlowSensitiveTests
   clangLex
   clangSerialization
   clangTooling
-  LINK_LIBS
+  )
+
+target_link_libraries(ClangAnalysisFlowSensitiveTests
+  PRIVATE
   clangTesting
   LLVMTestingAnnotations
   LLVMTestingSupport
-  LLVM_COMPONENTS
-  FrontendOpenMP
-  Support
   )

--- a/clang/unittests/Basic/CMakeLists.txt
+++ b/clang/unittests/Basic/CMakeLists.txt
@@ -1,3 +1,7 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  )
+
 add_clang_unittest(BasicTests
   CharInfoTest.cpp
   DarwinSDKInfoTest.cpp
@@ -8,11 +12,15 @@ add_clang_unittest(BasicTests
   SanitizersTest.cpp
   SarifTest.cpp
   SourceManagerTest.cpp
-  CLANG_LIBS
+  )
+
+clang_target_link_libraries(BasicTests
+  PRIVATE
   clangBasic
   clangLex
-  LINK_LIBS
-  LLVMTestingSupport
-  LLVM_COMPONENTS
-  Support
   )
+
+target_link_libraries(BasicTests
+  PRIVATE
+  LLVMTestingSupport
+)

--- a/clang/unittests/CMakeLists.txt
+++ b/clang/unittests/CMakeLists.txt
@@ -15,36 +15,12 @@ if(CLANG_BUILT_STANDALONE)
   endif()
 endif()
 
-# add_clang_unittest(test_name file1.cpp file2.cpp)
+# add_clang_unittest(test_dirname file1.cpp file2.cpp)
 #
 # Will compile the list of files together and link against the clang
-# Produces a binary named 'basename(test_name)'.
-function(add_clang_unittest test_name)
-  cmake_parse_arguments(ARG
-    ""
-    ""
-    "CLANG_LIBS;LINK_LIBS;LLVM_COMPONENTS"
-    ${ARGN})
-
-  if (NOT ${test_name} MATCHES "Tests$")
-    message(FATAL_ERROR "Unit test name must end with 'Tests' for lit to find it.")
-  endif()
-
-  # LLVM_COMPONENTS is for LLVM_LINK_COMPONENTS deps, and must be before
-  # add_unittest.
-  list(APPEND LLVM_LINK_COMPONENTS ${ARG_LLVM_COMPONENTS})
-
-  add_unittest(ClangUnitTests ${test_name} ${ARG_UNPARSED_ARGUMENTS})
-
-  # Clang libs either come from the entire dylib, or individual libraries.
-  if (CLANG_LINK_CLANG_DYLIB)
-    list(APPEND ARG_LINK_LIBS clang-cpp)
-  else()
-    list(APPEND ARG_LINK_LIBS ${ARG_CLANG_LIBS})
-  endif()
-
-  # LINK_LIBS is for normal library dependencies.
-  target_link_libraries(${test_name} PRIVATE ${ARG_LINK_LIBS})
+# Produces a binary named 'basename(test_dirname)'.
+function(add_clang_unittest test_dirname)
+  add_unittest(ClangUnitTests ${test_dirname} ${ARGN})
 endfunction()
 
 add_subdirectory(Basic)

--- a/clang/unittests/CodeGen/CMakeLists.txt
+++ b/clang/unittests/CodeGen/CMakeLists.txt
@@ -1,9 +1,18 @@
+set(LLVM_LINK_COMPONENTS
+  Core
+  Support
+  TargetParser
+  )
+
 add_clang_unittest(ClangCodeGenTests
   BufferSourceTest.cpp
   CodeGenExternalTest.cpp
   TBAAMetadataTest.cpp
   CheckTargetFeaturesTest.cpp
-  CLANG_LIBS
+  )
+
+clang_target_link_libraries(ClangCodeGenTests
+  PRIVATE
   clangAST
   clangBasic
   clangCodeGen
@@ -11,8 +20,4 @@ add_clang_unittest(ClangCodeGenTests
   clangLex
   clangParse
   clangSerialization
-  LLVM_COMPONENTS
-  Core
-  Support
-  TargetParser
   )

--- a/clang/unittests/CrossTU/CMakeLists.txt
+++ b/clang/unittests/CrossTU/CMakeLists.txt
@@ -1,12 +1,18 @@
+set(LLVM_LINK_COMPONENTS
+  ${LLVM_TARGETS_TO_BUILD}
+  Support
+  )
+
 add_clang_unittest(CrossTUTests
   CrossTranslationUnitTest.cpp
-  CLANG_LIBS
+  )
+
+clang_target_link_libraries(CrossTUTests
+  PRIVATE
   clangAST
   clangBasic
   clangCrossTU
   clangFrontend
   clangSerialization
   clangTooling
-  LLVM_COMPONENTS
-  Support
   )

--- a/clang/unittests/DirectoryWatcher/CMakeLists.txt
+++ b/clang/unittests/DirectoryWatcher/CMakeLists.txt
@@ -1,12 +1,17 @@
 if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME STREQUAL Windows)
 
+  set(LLVM_LINK_COMPONENTS
+    Support
+    )
+
   add_clang_unittest(DirectoryWatcherTests
     DirectoryWatcherTest.cpp
-    LINK_LIBS
+    )
+
+  target_link_libraries(DirectoryWatcherTests
+    PRIVATE
     LLVMTestingSupport
     clangDirectoryWatcher
-    LLVM_COMPONENTS
-    Support
     )
 
 endif()

--- a/clang/unittests/Driver/CMakeLists.txt
+++ b/clang/unittests/Driver/CMakeLists.txt
@@ -1,3 +1,11 @@
+set(LLVM_LINK_COMPONENTS
+  ${LLVM_TARGETS_TO_BUILD}
+  MC
+  Option
+  Support
+  TargetParser
+  )
+
 add_clang_unittest(ClangDriverTests
   DistroTest.cpp
   DXCModeTest.cpp
@@ -7,15 +15,12 @@ add_clang_unittest(ClangDriverTests
   MultilibBuilderTest.cpp
   MultilibTest.cpp
   SanitizerArgsTest.cpp
-  CLANG_LIBS
+  )
+
+clang_target_link_libraries(ClangDriverTests
+  PRIVATE
   clangDriver
   clangBasic
   clangFrontend # For TextDiagnosticPrinter.
   clangSerialization
-  LLVM_COMPONENTS
-  ${LLVM_TARGETS_TO_BUILD}
-  MC
-  Option
-  Support
-  TargetParser
   )

--- a/clang/unittests/Format/CMakeLists.txt
+++ b/clang/unittests/Format/CMakeLists.txt
@@ -1,3 +1,7 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  )
+
 add_clang_unittest(FormatTests
   BracesInserterTest.cpp
   BracesRemoverTest.cpp
@@ -32,11 +36,12 @@ add_clang_unittest(FormatTests
   SortIncludesTest.cpp
   UsingDeclarationsSorterTest.cpp
   TokenAnnotatorTest.cpp
-  CLANG_LIBS
+  )
+
+clang_target_link_libraries(FormatTests
+  PRIVATE
   clangBasic
   clangFormat
   clangRewrite
   clangToolingCore
-  LLVM_COMPONENTS
-  Support
   )

--- a/clang/unittests/Frontend/CMakeLists.txt
+++ b/clang/unittests/Frontend/CMakeLists.txt
@@ -1,3 +1,8 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  TargetParser
+  )
+
 add_clang_unittest(FrontendTests
   ASTUnitTest.cpp
   CompilerInvocationTest.cpp
@@ -12,7 +17,9 @@ add_clang_unittest(FrontendTests
   OutputStreamTest.cpp
   TextDiagnosticTest.cpp
   UtilsTest.cpp
-  CLANG_LIBS
+  )
+clang_target_link_libraries(FrontendTests
+  PRIVATE
   clangAST
   clangBasic
   clangFrontend
@@ -22,7 +29,4 @@ add_clang_unittest(FrontendTests
   clangFrontendTool
   clangSerialization
   clangTooling
-  LLVM_COMPONENTS
-  Support
-  TargetParser
   )

--- a/clang/unittests/Index/CMakeLists.txt
+++ b/clang/unittests/Index/CMakeLists.txt
@@ -1,6 +1,14 @@
+set(LLVM_LINK_COMPONENTS
+  ${LLVM_TARGETS_TO_BUILD}
+  Support
+  )
+
 add_clang_unittest(IndexTests
   IndexTests.cpp
-  CLANG_LIBS
+  )
+
+clang_target_link_libraries(IndexTests
+  PRIVATE
   clangAST
   clangBasic
   clangFrontend
@@ -8,7 +16,4 @@ add_clang_unittest(IndexTests
   clangLex
   clangSerialization
   clangTooling
-  LLVM_COMPONENTS
-  ${LLVM_TARGETS_TO_BUILD}
-  Support
   )

--- a/clang/unittests/InstallAPI/CMakeLists.txt
+++ b/clang/unittests/InstallAPI/CMakeLists.txt
@@ -1,8 +1,11 @@
 add_clang_unittest(InstallAPITests
   HeaderFileTest.cpp
   FileListTest.cpp
-  CLANG_LIBS
-  clangInstallAPI 
-  LINK_LIBS
-  LLVMTestingSupport
   )
+
+clang_target_link_libraries(InstallAPITests
+  PRIVATE
+  clangInstallAPI 
+  )
+
+target_link_libraries(InstallAPITests PRIVATE LLVMTestingSupport)

--- a/clang/unittests/Interpreter/CMakeLists.txt
+++ b/clang/unittests/Interpreter/CMakeLists.txt
@@ -1,3 +1,12 @@
+set(LLVM_LINK_COMPONENTS
+  ${LLVM_TARGETS_TO_BUILD}
+  Core
+  MC
+  OrcJIT
+  Support
+  TargetParser
+  )
+
 add_clang_unittest(ClangReplInterpreterTests
   IncrementalCompilerBuilderTest.cpp
   IncrementalProcessingTest.cpp
@@ -6,24 +15,16 @@ add_clang_unittest(ClangReplInterpreterTests
   CodeCompletionTest.cpp
 
   EXPORT_SYMBOLS
+  )
+  
+target_link_libraries(ClangReplInterpreterTests PUBLIC LLVMTestingSupport)
 
-  CLANG_LIBS
+clang_target_link_libraries(ClangReplInterpreterTests PRIVATE
   clangAST
   clangBasic
   clangInterpreter
   clangFrontend
   clangSema
-
-  LINK_LIBS
-  LLVMTestingSupport
-
-  LLVM_COMPONENTS
-  ${LLVM_TARGETS_TO_BUILD}
-  Core
-  MC
-  OrcJIT
-  Support
-  TargetParser
   )
 
 # Exceptions on Windows are not yet supported.

--- a/clang/unittests/Interpreter/ExceptionTests/CMakeLists.txt
+++ b/clang/unittests/Interpreter/ExceptionTests/CMakeLists.txt
@@ -3,22 +3,24 @@
 set(LLVM_REQUIRES_EH ON)
 set(LLVM_REQUIRES_RTTI ON)
 
-add_clang_unittest(ClangReplInterpreterExceptionTests
-  InterpreterExceptionTest.cpp
-  EXPORT_SYMBOLS
-
-  CLANG_LIBS
-  clangAST
-  clangBasic
-  clangInterpreter
-  clangFrontend
-
-  LLVM_COMPONENTS
+set(LLVM_LINK_COMPONENTS
   ${LLVM_TARGETS_TO_BUILD}
   Core
   OrcJIT
   Support
   )
 
+add_clang_unittest(ClangReplInterpreterExceptionTests
+  InterpreterExceptionTest.cpp
+
+  EXPORT_SYMBOLS
+  )
+
 llvm_update_compile_flags(ClangReplInterpreterExceptionTests)
+target_link_libraries(ClangReplInterpreterExceptionTests PUBLIC
+  clangAST
+  clangBasic
+  clangInterpreter
+  clangFrontend
+  )
 add_dependencies(ClangReplInterpreterExceptionTests clang-resource-headers)

--- a/clang/unittests/Lex/CMakeLists.txt
+++ b/clang/unittests/Lex/CMakeLists.txt
@@ -1,3 +1,7 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  )
+
 add_clang_unittest(LexTests
   DependencyDirectivesScannerTest.cpp
   HeaderMapTest.cpp
@@ -9,15 +13,19 @@ add_clang_unittest(LexTests
   PPConditionalDirectiveRecordTest.cpp
   PPDependencyDirectivesTest.cpp
   PPMemoryAllocationsTest.cpp
-  CLANG_LIBS
+  )
+
+clang_target_link_libraries(LexTests
+  PRIVATE
   clangAST
   clangBasic
   clangLex
   clangParse
   clangSema
-  LINK_LIBS
+  )
+
+target_link_libraries(LexTests
+  PRIVATE
   LLVMTestingAnnotations
   LLVMTestingSupport
-  LLVM_COMPONENTS
-  Support
   )

--- a/clang/unittests/Rewrite/CMakeLists.txt
+++ b/clang/unittests/Rewrite/CMakeLists.txt
@@ -1,10 +1,14 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  )
+
 add_clang_unittest(RewriteTests
   RewriterTest.cpp
-  CLANG_LIBS
+  )
+clang_target_link_libraries(RewriteTests
+  PRIVATE
   clangFrontend
   clangRewrite
   clangSerialization
   clangTooling
-  LLVM_COMPONENTS
-  Support
   )

--- a/clang/unittests/Sema/CMakeLists.txt
+++ b/clang/unittests/Sema/CMakeLists.txt
@@ -1,3 +1,8 @@
+set(LLVM_LINK_COMPONENTS
+  FrontendOpenMP
+  Support
+  )
+
 add_clang_unittest(SemaTests
   ExternalSemaSourceTest.cpp
   CodeCompleteTest.cpp
@@ -5,7 +10,10 @@ add_clang_unittest(SemaTests
   GslOwnerPointerInference.cpp
   SemaLookupTest.cpp
   SemaNoloadLookupTest.cpp
-  CLANG_LIBS
+  )
+
+clang_target_link_libraries(SemaTests
+  PRIVATE
   clangAST
   clangASTMatchers
   clangBasic
@@ -14,11 +22,11 @@ add_clang_unittest(SemaTests
   clangSema
   clangSerialization
   clangTooling
-  LINK_LIBS
+  )
+
+target_link_libraries(SemaTests
+  PRIVATE
   LLVMTestingAnnotations
   LLVMTestingSupport
   clangTesting
-  LLVM_COMPONENTS
-  FrontendOpenMP
-  Support
   )

--- a/clang/unittests/Serialization/CMakeLists.txt
+++ b/clang/unittests/Serialization/CMakeLists.txt
@@ -1,3 +1,10 @@
+set(LLVM_LINK_COMPONENTS
+  BitReader
+  BitstreamReader
+  FrontendOpenMP
+  Support
+  )
+
 add_clang_unittest(SerializationTests
   ForceCheckFileInputTest.cpp
   InMemoryModuleCacheTest.cpp
@@ -7,7 +14,10 @@ add_clang_unittest(SerializationTests
   LoadSpecLazilyTest.cpp
   SourceLocationEncodingTest.cpp
   VarDeclConstantInitTest.cpp
-  CLANG_LIBS
+  )
+
+clang_target_link_libraries(SerializationTests
+  PRIVATE
   clangAST
   clangBasic
   clangFrontend
@@ -16,9 +26,4 @@ add_clang_unittest(SerializationTests
   clangSerialization
   clangTooling
   clangASTMatchers
-  LLVM_COMPONENTS
-  BitReader
-  BitstreamReader
-  FrontendOpenMP
-  Support
   )

--- a/clang/unittests/StaticAnalyzer/CMakeLists.txt
+++ b/clang/unittests/StaticAnalyzer/CMakeLists.txt
@@ -1,3 +1,8 @@
+set(LLVM_LINK_COMPONENTS
+  FrontendOpenMP
+  Support
+  )
+
 add_clang_unittest(StaticAnalysisTests
   AnalyzerOptionsTest.cpp
   APSIntTypeTest.cpp
@@ -20,7 +25,10 @@ add_clang_unittest(StaticAnalysisTests
   SValTest.cpp
   TestReturnValueUnderConstruction.cpp
   Z3CrosscheckOracleTest.cpp
-  CLANG_LIBS
+  )
+
+clang_target_link_libraries(StaticAnalysisTests
+  PRIVATE
   clangBasic
   clangAnalysis
   clangAST
@@ -31,9 +39,9 @@ add_clang_unittest(StaticAnalysisTests
   clangStaticAnalyzerCore
   clangStaticAnalyzerFrontend
   clangTooling
-  LINK_LIBS
+  )
+
+target_link_libraries(StaticAnalysisTests
+  PRIVATE
   clangTesting
-  LLVM_COMPONENTS
-  FrontendOpenMP
-  Support
   )

--- a/clang/unittests/Support/CMakeLists.txt
+++ b/clang/unittests/Support/CMakeLists.txt
@@ -1,10 +1,15 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  )
+
 add_clang_unittest(ClangSupportTests
   TimeProfilerTest.cpp
-  CLANG_LIBS
+  )
+
+clang_target_link_libraries(ClangSupportTests
+  PRIVATE
   clangAST
   clangBasic
   clangFrontend
   clangSerialization
-  LLVM_COMPONENTS
-  Support
   )

--- a/clang/unittests/Tooling/CMakeLists.txt
+++ b/clang/unittests/Tooling/CMakeLists.txt
@@ -1,3 +1,13 @@
+set(LLVM_LINK_COMPONENTS
+  ${LLVM_TARGETS_TO_BUILD}
+  MC
+  Option
+  FrontendOpenMP
+  Support
+  TargetParser
+  )
+
+
 add_clang_unittest(ToolingTests
   ASTSelectionTest.cpp
   CastExprTest.cpp
@@ -59,8 +69,10 @@ add_clang_unittest(ToolingTests
   StencilTest.cpp
   ToolingTest.cpp
   TransformerTest.cpp
+  )
 
-  CLANG_LIBS
+clang_target_link_libraries(ToolingTests
+  PRIVATE
   clangAST
   clangASTMatchers
   clangBasic
@@ -77,19 +89,13 @@ add_clang_unittest(ToolingTests
   clangToolingInclusionsStdlib
   clangToolingRefactoring
   clangTransformer
+  )
 
-  LINK_LIBS
+target_link_libraries(ToolingTests
+  PRIVATE
   LLVMTestingAnnotations
   LLVMTestingSupport
   clangTesting
-
-  LLVM_COMPONENTS
-  ${LLVM_TARGETS_TO_BUILD}
-  MC
-  Option
-  FrontendOpenMP
-  Support
-  TargetParser
-  )
+)
 
 add_subdirectory(Syntax)

--- a/clang/unittests/Tooling/Syntax/CMakeLists.txt
+++ b/clang/unittests/Tooling/Syntax/CMakeLists.txt
@@ -1,3 +1,7 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  )
+
 add_clang_unittest(SyntaxTests
   TreeTestBase.cpp
   BuildTreeTest.cpp
@@ -5,8 +9,10 @@ add_clang_unittest(SyntaxTests
   SynthesisTest.cpp
   TreeTest.cpp
   TokensTest.cpp
+)
 
-  CLANG_LIBS
+clang_target_link_libraries(SyntaxTests
+  PRIVATE
   clangAST
   clangBasic
   clangFrontend
@@ -15,12 +21,11 @@ add_clang_unittest(SyntaxTests
   clangTooling
   clangToolingCore
   clangToolingSyntax
+  )
 
-  LINK_LIBS
+target_link_libraries(SyntaxTests
+  PRIVATE
   clangTesting
   LLVMTestingAnnotations
   LLVMTestingSupport
-
-  LLVM_COMPONENTS
-  Support
 )

--- a/clang/unittests/libclang/CMakeLists.txt
+++ b/clang/unittests/libclang/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_clang_unittest(libclangTests
   LibclangTest.cpp
-  LINK_LIBS
+  )
+
+target_link_libraries(libclangTests
+  PRIVATE
   libclang
   )
 

--- a/clang/unittests/libclang/CrashTests/CMakeLists.txt
+++ b/clang/unittests/libclang/CrashTests/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_clang_unittest(libclangCrashTests
   LibclangCrashTest.cpp
-  LINK_LIBS
+  )
+
+target_link_libraries(libclangCrashTests
+  PRIVATE
   libclang
   )


### PR DESCRIPTION
Reverts llvm/llvm-project#133545

This change is breaking several buildbots as well as developer's builds.  Reverting to allow people to make progress.