### PR TITLE
[AMDGPU][NPM] Add isRequired to passes missing it

### DIFF
--- a/llvm/include/llvm/Passes/CodeGenPassBuilder.h
+++ b/llvm/include/llvm/Passes/CodeGenPassBuilder.h
@@ -188,9 +188,6 @@ public:
 
 protected:
   template <typename PassT>
-  using has_required_t = decltype(std::declval<PassT &>().isRequired());
-
-  template <typename PassT>
   using is_module_pass_t = decltype(std::declval<PassT &>().run(
       std::declval<Module &>(), std::declval<ModuleAnalysisManager &>()));
 
@@ -220,10 +217,7 @@ protected:
       static_assert((is_detected<is_function_pass_t, PassT>::value ||
                      is_detected<is_module_pass_t, PassT>::value) &&
                     "Only module pass and function pass are supported.");
-      bool Required = false;
-      if constexpr (is_detected<has_required_t, PassT>::value)
-        Required = PassT::isRequired();
-      if (!PB.runBeforeAdding(Name) && !Required)
+      if (!PB.runBeforeAdding(Name))
         return;
 
       // Add Function Pass

--- a/llvm/lib/Target/AMDGPU/AMDGPU.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.h
@@ -89,6 +89,7 @@ public:
   SILowerI1CopiesPass() = default;
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 
 void initializeAMDGPUDAGToDAGISelLegacyPass(PassRegistry &);
@@ -353,6 +354,7 @@ class SIModeRegisterPass : public PassInfoMixin<SIModeRegisterPass> {
 public:
   SIModeRegisterPass() {}
   PreservedAnalyses run(MachineFunction &F, MachineFunctionAnalysisManager &AM);
+  static bool isRequired() { return true; }
 };
 
 class SIMemoryLegalizerPass : public PassInfoMixin<SIMemoryLegalizerPass> {
@@ -469,6 +471,7 @@ private:
 public:
   SIAnnotateControlFlowPass(const AMDGPUTargetMachine &TM) : TM(TM) {}
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  static bool isRequired() { return true; }
 };
 
 void initializeSIAnnotateControlFlowLegacyPass(PassRegistry &);

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.h
@@ -287,6 +287,7 @@ public:
 
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 
 class AMDGPUDAGToDAGISelLegacy : public SelectionDAGISelLegacy {

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -2113,7 +2113,8 @@ void AMDGPUCodeGenPassBuilder::addPreISel(AddIRPass &addPass) const {
 
   // FIXME: Why isn't this queried as required from AMDGPUISelDAGToDAG, and why
   // isn't this in addInstSelector?
-  addPass(RequireAnalysisPass<UniformityInfoAnalysis, Function>());
+  addPass(RequireAnalysisPass<UniformityInfoAnalysis, Function>(),
+          /*Force=*/true);
 }
 
 void AMDGPUCodeGenPassBuilder::addILPOpts(AddMachinePass &addPass) const {

--- a/llvm/lib/Target/AMDGPU/AMDGPUUnifyDivergentExitNodes.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUUnifyDivergentExitNodes.h
@@ -29,6 +29,7 @@ class AMDGPUUnifyDivergentExitNodesPass
     : public PassInfoMixin<AMDGPUUnifyDivergentExitNodesPass> {
 public:
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  static bool isRequired() { return true; }
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/AMDGPU/GCNNSAReassign.h
+++ b/llvm/lib/Target/AMDGPU/GCNNSAReassign.h
@@ -16,6 +16,7 @@ class GCNNSAReassignPass : public PassInfoMixin<GCNNSAReassignPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AMDGPU/GCNPreRALongBranchReg.h
+++ b/llvm/lib/Target/AMDGPU/GCNPreRALongBranchReg.h
@@ -17,6 +17,7 @@ class GCNPreRALongBranchRegPass
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AMDGPU/GCNRewritePartialRegUses.h
+++ b/llvm/lib/Target/AMDGPU/GCNRewritePartialRegUses.h
@@ -17,6 +17,7 @@ class GCNRewritePartialRegUsesPass
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.h
+++ b/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.h
@@ -18,6 +18,7 @@ public:
   SIFixSGPRCopiesPass() = default;
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/AMDGPU/SIFixVGPRCopies.h
+++ b/llvm/lib/Target/AMDGPU/SIFixVGPRCopies.h
@@ -16,6 +16,7 @@ class SIFixVGPRCopiesPass : public PassInfoMixin<SIFixVGPRCopiesPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AMDGPU/SILowerControlFlow.h
+++ b/llvm/lib/Target/AMDGPU/SILowerControlFlow.h
@@ -16,6 +16,7 @@ class SILowerControlFlowPass : public PassInfoMixin<SILowerControlFlowPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.h
+++ b/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.h
@@ -23,6 +23,7 @@ public:
         .set(MachineFunctionProperties::Property::IsSSA)
         .set(MachineFunctionProperties::Property::NoVRegs);
   }
+  static bool isRequired() { return true; }
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AMDGPU/SILowerWWMCopies.h
+++ b/llvm/lib/Target/AMDGPU/SILowerWWMCopies.h
@@ -16,6 +16,7 @@ class SILowerWWMCopiesPass : public PassInfoMixin<SILowerWWMCopiesPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AMDGPU/SIPreAllocateWWMRegs.h
+++ b/llvm/lib/Target/AMDGPU/SIPreAllocateWWMRegs.h
@@ -18,6 +18,7 @@ class SIPreAllocateWWMRegsPass
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/AMDGPU/SIWholeQuadMode.h
+++ b/llvm/lib/Target/AMDGPU/SIWholeQuadMode.h
@@ -21,6 +21,7 @@ public:
     return MachineFunctionProperties().set(
         MachineFunctionProperties::Property::IsSSA);
   }
+  static bool isRequired() { return true; }
 };
 } // namespace llvm
 

--- a/llvm/test/tools/llc/new-pm/pipeline.mir
+++ b/llvm/test/tools/llc/new-pm/pipeline.mir
@@ -1,8 +1,10 @@
 # RUN: llc -mtriple=x86_64-pc-linux-gnu -x mir -passes=no-op-machine-function --print-pipeline-passes -filetype=null < %s | FileCheck %s --match-full-lines
 # RUN: llc -mtriple=x86_64-pc-linux-gnu -x mir -passes='require<machine-dom-tree>,print<machine-dom-tree>' -print-pipeline-passes < %s | FileCheck --check-prefix=ANALYSIS %s
+# RUN: llc -mtriple=x86_64-pc-linux-gnu -x mir -enable-new-pm -stop-before=greedy -O3 -filetype=null --print-pipeline-passes < %s | FileCheck %s --check-prefix=CHECK-REQ
 
 # CHECK: function(machine-function(no-op-machine-function)),PrintMIRPreparePass,function(machine-function(verify,print))
 
+# CHECK-REQ-NOT: greedy
 # ANALYSIS: require<machine-dom-tree>,print<machine-dom-tree>
 
 ---

--- a/llvm/test/tools/llc/new-pm/start-stop.ll
+++ b/llvm/test/tools/llc/new-pm/start-stop.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -mtriple=x86_64-pc-linux-gnu -enable-new-pm -print-pipeline-passes -start-before=mergeicmps -stop-after=gc-lowering -filetype=null %s | FileCheck --match-full-lines %s --check-prefix=NULL
 ; RUN: llc -mtriple=x86_64-pc-linux-gnu -enable-new-pm -print-pipeline-passes -start-before=mergeicmps -stop-after=gc-lowering -o /dev/null %s | FileCheck --match-full-lines %s --check-prefix=OBJ
 
-; NULL: require<MachineModuleAnalysis>,require<profile-summary>,require<collector-metadata>,function(verify,loop-mssa(loop-reduce),mergeicmps,expand-memcmp,gc-lowering,ee-instrument<post-inline>,verify)
-; OBJ: require<MachineModuleAnalysis>,require<profile-summary>,require<collector-metadata>,function(verify,loop-mssa(loop-reduce),mergeicmps,expand-memcmp,gc-lowering,ee-instrument<post-inline>,verify),PrintMIRPreparePass,function(machine-function(print),invalidate<machine-function-info>)
+; NULL: require<MachineModuleAnalysis>,require<profile-summary>,require<collector-metadata>,function(verify,mergeicmps,expand-memcmp,gc-lowering,verify)
+; OBJ: require<MachineModuleAnalysis>,require<profile-summary>,require<collector-metadata>,function(verify,mergeicmps,expand-memcmp,gc-lowering,verify),PrintMIRPreparePass,function(machine-function(print),invalidate<machine-function-info>)


### PR DESCRIPTION
Now that the `skipFunction` check is done automatically in OptNone instrumentation, we have to add this method to passes that should not be skipped.