### PR TITLE
[RISCV] Just reporting an error shouldn't generate a crash diagnostic

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.cpp
@@ -53,10 +53,10 @@ namespace RISCV {
 
 // Report an error but don't ask the user to report a bug.
 [[noreturn]] static void reportError(const char *Reason) {
-  report_fatal_error(Reason, false);
+  report_fatal_error(Reason, /*gen_crash_diag=*/false);
 }
 [[noreturn]] static void reportError(Error Err) {
-  report_fatal_error(std::move(Err), false);
+  report_fatal_error(std::move(Err), /*gen_crash_diag=*/false);
 }
 
 namespace RISCVABI {

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.cpp
@@ -51,7 +51,7 @@ namespace RISCV {
 #include "RISCVGenSearchableTables.inc"
 } // namespace RISCV
 
-// Report an error but don't perform ask the user to report a bug.
+// Report an error but don't ask the user to report a bug.
 [[noreturn]] static void reportError(const char *Reason) {
   report_fatal_error(Reason, false);
 }

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.cpp
@@ -51,6 +51,14 @@ namespace RISCV {
 #include "RISCVGenSearchableTables.inc"
 } // namespace RISCV
 
+// Report an error but don't perform ask the user to report a bug.
+[[noreturn]] static void reportError(const char *Reason) {
+  report_fatal_error(Reason, false);
+}
+[[noreturn]] static void reportError(Error Err) {
+  report_fatal_error(std::move(Err), false);
+}
+
 namespace RISCVABI {
 ABI computeTargetABI(const Triple &TT, const FeatureBitset &FeatureBits,
                      StringRef ABIName) {
@@ -87,7 +95,7 @@ ABI computeTargetABI(const Triple &TT, const FeatureBitset &FeatureBits,
   if ((TargetABI == RISCVABI::ABI::ABI_ILP32E ||
        (TargetABI == ABI_Unknown && IsRVE && !IsRV64)) &&
       FeatureBits[RISCV::FeatureStdExtD])
-    report_fatal_error("ILP32E cannot be used with the D ISA extension");
+    reportError("ILP32E cannot be used with the D ISA extension");
 
   if (TargetABI != ABI_Unknown)
     return TargetABI;
@@ -95,7 +103,7 @@ ABI computeTargetABI(const Triple &TT, const FeatureBitset &FeatureBits,
   // If no explicit ABI is given, try to compute the default ABI.
   auto ISAInfo = RISCVFeatures::parseFeatureBits(IsRV64, FeatureBits);
   if (!ISAInfo)
-    report_fatal_error(ISAInfo.takeError());
+    reportError(ISAInfo.takeError());
   return getTargetABI((*ISAInfo)->computeDefaultABI());
 }
 
@@ -127,12 +135,12 @@ namespace RISCVFeatures {
 
 void validate(const Triple &TT, const FeatureBitset &FeatureBits) {
   if (TT.isArch64Bit() && !FeatureBits[RISCV::Feature64Bit])
-    report_fatal_error("RV64 target requires an RV64 CPU");
+    reportError("RV64 target requires an RV64 CPU");
   if (!TT.isArch64Bit() && !FeatureBits[RISCV::Feature32Bit])
-    report_fatal_error("RV32 target requires an RV32 CPU");
+    reportError("RV32 target requires an RV32 CPU");
   if (FeatureBits[RISCV::Feature32Bit] &&
       FeatureBits[RISCV::Feature64Bit])
-    report_fatal_error("RV32 and RV64 can't be combined");
+    reportError("RV32 and RV64 can't be combined");
 }
 
 llvm::Expected<std::unique_ptr<RISCVISAInfo>>

--- a/llvm/test/MC/RISCV/target-abi-invalid.s
+++ b/llvm/test/MC/RISCV/target-abi-invalid.s
@@ -30,7 +30,7 @@
 # RUN:   | FileCheck -check-prefix=RV32E-LP64 %s
 # RUN: llvm-mc -triple=riscv32 -mattr=+e,+f -target-abi lp64f < %s 2>&1 \
 # RUN:   | FileCheck -check-prefix=RV32EF-LP64F %s
-# RUN: not --crash llvm-mc -triple=riscv32 -mattr=+e,+d -target-abi lp64f < %s 2>&1 \
+# RUN: not llvm-mc -triple=riscv32 -mattr=+e,+d -target-abi lp64f < %s 2>&1 \
 # RUN:   | FileCheck -check-prefix=RV32EFD-LP64D %s
 # RUN: llvm-mc -triple=riscv32 -mattr=+e -target-abi lp64e %s 2>&1 \
 # RUN:   | FileCheck -check-prefix=RV32E-LP64E %s
@@ -70,9 +70,9 @@
 # RUN:   | FileCheck -check-prefix=RV32EF-ILP32F %s
 # RUN: llvm-mc -triple=riscv32 -mattr=+e,+f -target-abi ilp32f < %s 2>&1 \
 # RUN:   | FileCheck -check-prefix=RV32EF-ILP32F %s
-# RUN: not --crash llvm-mc -triple=riscv32 -mattr=+e,+d -target-abi ilp32f < %s 2>&1 \
+# RUN: not llvm-mc -triple=riscv32 -mattr=+e,+d -target-abi ilp32f < %s 2>&1 \
 # RUN:   | FileCheck -check-prefix=RV32EFD-ILP32F %s
-# RUN: not --crash llvm-mc -triple=riscv32 -mattr=+e,+d -target-abi ilp32d < %s 2>&1 \
+# RUN: not llvm-mc -triple=riscv32 -mattr=+e,+d -target-abi ilp32d < %s 2>&1 \
 # RUN:   | FileCheck -check-prefix=RV32EFD-ILP32D %s
 
 # RV32E-ILP32: Only the ilp32e ABI is supported for RV32E (ignoring target-abi)


### PR DESCRIPTION
Wanting to examine some of generated code, I tried MCA with the command:
~~~bash
llvm-mca -mtriple=riscv32-unknown-unknown -mcpu=rocket -iterations=300 core_list_join.s
~~~
I was greeted with the following error message:
~~~
LLVM ERROR: RV32 target requires an RV32 CPU
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
Stack dump:
…
~~~
On beginning to investigate the “bug”, I discovered that the code was simply attempting to report a user error. It used report_fatal_error() to do so but with the “bool GenCrashDiag” argument enabled (the default). This tiny change adds a wrapper function which calls report_fatal_error() as before but with GenCrashDiag disabled.