### PR TITLE
[mlir] Use `dyn_cast` instead of `cast` in MathToVCIX conversion

### DIFF
--- a/mlir/test/Conversion/MathToVCIX/math-to-vcix.mlir
+++ b/mlir/test/Conversion/MathToVCIX/math-to-vcix.mlir
@@ -191,3 +191,14 @@ func.func @log_fixed(%a: vector<8 x f32>, %rvl: i64) -> vector<8 x f32> {
   %res = math.log %a : vector<8 x f32>
   return %res : vector<8 x f32>
 }
+
+// -----
+
+// Ensure this case exit gracefully
+
+// CHECK-LABEL:   func.func @no_vector_type
+// CHECK:           math.cos
+func.func @no_vector_type(%arg0: f32) -> f32 {
+  %0 = math.cos %arg0 : f32
+  return %0 : f32
+}

--- a/mlir/test/lib/Conversion/MathToVCIX/TestMathToVCIXConversion.cpp
+++ b/mlir/test/lib/Conversion/MathToVCIX/TestMathToVCIXConversion.cpp
@@ -25,7 +25,7 @@ namespace {
 /// according to LLVM's encoding:
 /// https://lists.llvm.org/pipermail/llvm-dev/2020-October/145850.html
 static std::pair<unsigned, VectorType> legalizeVectorType(const Type &type) {
-  VectorType vt = cast<VectorType>(type);
+  VectorType vt = dyn_cast<VectorType>(type);
   // To simplify test pass, avoid multi-dimensional vectors.
   if (!vt || vt.getRank() != 1)
     return {0, nullptr};


### PR DESCRIPTION
Fixes #131093.