### PR TITLE
[lldb-dap] Speed up TestDAP_Progress

### DIFF
--- a/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
+++ b/lldb/test/API/tools/lldb-dap/progress/Progress_emitter.py
@@ -88,11 +88,11 @@ class ProgressTesterCommand:
             progress = lldb.SBProgress(
                 "Progress tester", "Initial Detail", total, debugger
             )
-        # Check to see if total is set to None to indicate an indeterminate progress
-        # then default to 10 steps.
+        # Check to see if total is set to None to indicate an indeterminate
+        # progress then default to 3 steps.
         with progress:
             if total is None:
-                total = 10
+                total = 3
 
             for i in range(1, total):
                 if cmd_options.no_details:

--- a/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
+++ b/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
@@ -19,7 +19,6 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
         expected_not_in_message=None,
         only_verify_first_update=False,
     ):
-        self.dap_server.wait_for_event("progressEnd", 15)
         self.assertTrue(len(self.dap_server.progress_events) > 0)
         start_found = False
         update_found = False
@@ -45,20 +44,18 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
         self.assertTrue(start_found)
         self.assertTrue(update_found)
         self.assertTrue(end_found)
+        self.dap_server.progress_events.clear()
 
     @skipIfWindows
-    def test_output(self):
+    def test(self):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)
         progress_emitter = os.path.join(os.getcwd(), "Progress_emitter.py")
-        source = "main.cpp"
-        breakpoint_ids = self.set_source_breakpoints(
-            source, [line_number(source, "// break here")]
-        )
-        self.continue_to_breakpoints(breakpoint_ids)
         self.dap_server.request_evaluate(
             f"`command script import {progress_emitter}", context="repl"
         )
+
+        # Test details.
         self.dap_server.request_evaluate(
             "`test-progress --total 3 --seconds 1", context="repl"
         )
@@ -68,19 +65,7 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
             expected_not_in_message="Progress tester",
         )
 
-    @skipIfWindows
-    def test_output_nodetails(self):
-        program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program)
-        progress_emitter = os.path.join(os.getcwd(), "Progress_emitter.py")
-        source = "main.cpp"
-        breakpoint_ids = self.set_source_breakpoints(
-            source, [line_number(source, "// break here")]
-        )
-        self.continue_to_breakpoints(breakpoint_ids)
-        self.dap_server.request_evaluate(
-            f"`command script import {progress_emitter}", context="repl"
-        )
+        # Test no details.
         self.dap_server.request_evaluate(
             "`test-progress --total 3 --seconds 1 --no-details", context="repl"
         )
@@ -90,19 +75,7 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
             expected_message="Initial Detail",
         )
 
-    @skipIfWindows
-    def test_output_indeterminate(self):
-        program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program)
-        progress_emitter = os.path.join(os.getcwd(), "Progress_emitter.py")
-        source = "main.cpp"
-        breakpoint_ids = self.set_source_breakpoints(
-            source, [line_number(source, "// break here")]
-        )
-        self.continue_to_breakpoints(breakpoint_ids)
-        self.dap_server.request_evaluate(
-            f"`command script import {progress_emitter}", context="repl"
-        )
+        # Test details indeterminate.
         self.dap_server.request_evaluate("`test-progress --seconds 1", context="repl")
 
         self.verify_progress_events(
@@ -111,19 +84,7 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
             only_verify_first_update=True,
         )
 
-    @skipIfWindows
-    def test_output_nodetails_indeterminate(self):
-        program = self.getBuildArtifact("a.out")
-        self.build_and_launch(program)
-        progress_emitter = os.path.join(os.getcwd(), "Progress_emitter.py")
-        source = "main.cpp"
-        breakpoint_ids = self.set_source_breakpoints(
-            source, [line_number(source, "// break here")]
-        )
-        self.dap_server.request_evaluate(
-            f"`command script import {progress_emitter}", context="repl"
-        )
-
+        # Test no details indeterminate.
         self.dap_server.request_evaluate(
             "`test-progress --seconds 1 --no-details", context="repl"
         )


### PR DESCRIPTION
While trying to make progress on #133782, I noticed that TestDAP_Progress was taking 90 seconds to complete. This patch brings that down to 10 seocnds by making the following changes:

1. Don't call `wait_for_event` with a 15 second timeout. By the time we call this, all progress events have been emitted, which means that we're just sitting there until we hit the timeout.

2. Don't use 10 steps (= 10 seconds) for indeterminate progress. We have two indeterminate progress tests so that's 6 seconds instead of 20.

3. Don't launch the process over and over. Once we have a dap session, we can clear the progress vector and emit new progress events.