### PR TITLE
[BOLT][JT] Fix emitting jump table entry size

### DIFF
--- a/bolt/include/bolt/Core/JumpTable.h
+++ b/bolt/include/bolt/Core/JumpTable.h
@@ -45,6 +45,12 @@ class JumpTable : public BinaryData {
   JumpTable(const JumpTable &) = delete;
   JumpTable &operator=(const JumpTable &) = delete;
 
+  /// Size of the entry used for storage.
+  size_t EntrySize;
+
+  /// Size of the entry size we will write (we may use a more compact layout)
+  size_t OutputEntrySize;
+
 public:
   enum JumpTableType : char {
     JTT_NORMAL,
@@ -57,11 +63,10 @@ public:
     uint64_t Count{0};
   };
 
-  /// Size of the entry used for storage.
-  size_t EntrySize;
+  size_t getEntrySize() const { return EntrySize; }
 
-  /// Size of the entry size we will write (we may use a more compact layout)
-  size_t OutputEntrySize;
+  size_t getOutputEntrySize() const { return OutputEntrySize; }
+  void setOutputEntrySize(size_t val) { OutputEntrySize = val; }
 
   /// The type of this jump table.
   JumpTableType Type;

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -743,7 +743,7 @@ void BinaryContext::populateJumpTables() {
     if (opts::StrictMode && JT->Type == JumpTable::JTT_PIC) {
       for (uint64_t Address = JT->getAddress();
            Address < JT->getAddress() + JT->getSize();
-           Address += JT->EntrySize) {
+           Address += JT->getEntrySize()) {
         DataPCRelocations.erase(DataPCRelocations.find(Address));
       }
     }
@@ -905,7 +905,7 @@ BinaryContext::duplicateJumpTable(BinaryFunction &Function, JumpTable *JT,
   (void)Found;
   MCSymbol *NewLabel = Ctx->createNamedTempSymbol("duplicatedJT");
   JumpTable *NewJT =
-      new JumpTable(*NewLabel, JT->getAddress(), JT->EntrySize, JT->Type,
+      new JumpTable(*NewLabel, JT->getAddress(), JT->getEntrySize(), JT->Type,
                     JumpTable::LabelMapType{{Offset, NewLabel}},
                     *getSectionForAddress(JT->getAddress()));
   NewJT->Parents = JT->Parents;

--- a/bolt/lib/Core/BinaryEmitter.cpp
+++ b/bolt/lib/Core/BinaryEmitter.cpp
@@ -807,7 +807,7 @@ void BinaryEmitter::emitJumpTable(const JumpTable &JT, MCSection *HotSection,
     LabelCounts[CurrentLabel] = CurrentLabelCount;
   } else {
     Streamer.switchSection(JT.Count > 0 ? HotSection : ColdSection);
-    Streamer.emitValueToAlignment(Align(JT.getEntrySize()));
+    Streamer.emitValueToAlignment(Align(JT.getOutputEntrySize()));
   }
   MCSymbol *JTLabel = nullptr;
   uint64_t Offset = 0;
@@ -826,7 +826,7 @@ void BinaryEmitter::emitJumpTable(const JumpTable &JT, MCSection *HotSection,
       const uint64_t JTCount = LabelCounts[JTLabel];
       LLVM_DEBUG(dbgs() << "BOLT-DEBUG: jump table count: " << JTCount << '\n');
       Streamer.switchSection(JTCount ? HotSection : ColdSection);
-      Streamer.emitValueToAlignment(Align(JT.EntrySize));
+      Streamer.emitValueToAlignment(Align(JT.getOutputEntrySize()));
     }
     // Emit all labels registered at the address of this jump table
     // to sync with our global symbol table.  We may have two labels
@@ -857,9 +857,9 @@ void BinaryEmitter::emitJumpTable(const JumpTable &JT, MCSection *HotSection,
           MCSymbolRefExpr::create(Entry, Streamer.getContext());
       const MCBinaryExpr *Value =
           MCBinaryExpr::createSub(E, JTExpr, Streamer.getContext());
-      Streamer.emitValue(Value, JT.getEntrySize());
+      Streamer.emitValue(Value, JT.getOutputEntrySize());
     }
-    Offset += JT.getEntrySize();
+    Offset += JT.getOutputEntrySize();
   }
 }
 

--- a/bolt/lib/Core/BinaryEmitter.cpp
+++ b/bolt/lib/Core/BinaryEmitter.cpp
@@ -796,7 +796,7 @@ void BinaryEmitter::emitJumpTable(const JumpTable &JT, MCSection *HotSection,
     MCSymbol *CurrentLabel = It->second;
     uint64_t CurrentLabelCount = 0;
     for (unsigned Index = 0; Index < JT.Entries.size(); ++Index) {
-      auto LI = JT.Labels.find(Index * JT.EntrySize);
+      auto LI = JT.Labels.find(Index * JT.getEntrySize());
       if (LI != JT.Labels.end()) {
         LabelCounts[CurrentLabel] = CurrentLabelCount;
         CurrentLabel = LI->second;
@@ -807,7 +807,7 @@ void BinaryEmitter::emitJumpTable(const JumpTable &JT, MCSection *HotSection,
     LabelCounts[CurrentLabel] = CurrentLabelCount;
   } else {
     Streamer.switchSection(JT.Count > 0 ? HotSection : ColdSection);
-    Streamer.emitValueToAlignment(Align(JT.EntrySize));
+    Streamer.emitValueToAlignment(Align(JT.getEntrySize()));
   }
   MCSymbol *JTLabel = nullptr;
   uint64_t Offset = 0;
@@ -849,7 +849,7 @@ void BinaryEmitter::emitJumpTable(const JumpTable &JT, MCSection *HotSection,
     }
   emitEntry:
     if (JT.Type == JumpTable::JTT_NORMAL) {
-      Streamer.emitSymbolValue(Entry, JT.OutputEntrySize);
+      Streamer.emitSymbolValue(Entry, JT.getOutputEntrySize());
     } else { // JTT_PIC
       const MCSymbolRefExpr *JTExpr =
           MCSymbolRefExpr::create(JTLabel, Streamer.getContext());
@@ -857,9 +857,9 @@ void BinaryEmitter::emitJumpTable(const JumpTable &JT, MCSection *HotSection,
           MCSymbolRefExpr::create(Entry, Streamer.getContext());
       const MCBinaryExpr *Value =
           MCBinaryExpr::createSub(E, JTExpr, Streamer.getContext());
-      Streamer.emitValue(Value, JT.EntrySize);
+      Streamer.emitValue(Value, JT.getEntrySize());
     }
-    Offset += JT.EntrySize;
+    Offset += JT.getEntrySize();
   }
 }
 

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1969,7 +1969,8 @@ void BinaryFunction::postProcessJumpTables() {
 
     uint64_t EntryOffset = JTAddress - JT->getAddress();
     while (EntryOffset < JT->getSize()) {
-      uint64_t EntryAddress = JT->EntriesAsAddress[EntryOffset / JT->EntrySize];
+      uint64_t EntryAddress =
+          JT->EntriesAsAddress[EntryOffset / JT->getEntrySize()];
       uint64_t TargetOffset = EntryAddress - getAddress();
       if (TargetOffset < getSize()) {
         TakenBranches.emplace_back(JTSiteOffset, TargetOffset);
@@ -1978,7 +1979,7 @@ void BinaryFunction::postProcessJumpTables() {
           registerReferencedOffset(TargetOffset);
       }
 
-      EntryOffset += JT->EntrySize;
+      EntryOffset += JT->getEntrySize();
 
       // A label at the next entry means the end of this jump table.
       if (JT->Labels.count(EntryOffset))

--- a/bolt/lib/Core/BinaryFunctionProfile.cpp
+++ b/bolt/lib/Core/BinaryFunctionProfile.cpp
@@ -173,7 +173,7 @@ void BinaryFunction::postProcessProfile() {
     if (JT->Counts.empty())
       JT->Counts.resize(JT->Entries.size());
     auto EI = JT->Entries.begin();
-    uint64_t Delta = (JTAddress - JT->getAddress()) / JT->EntrySize;
+    uint64_t Delta = (JTAddress - JT->getAddress()) / JT->getEntrySize();
     EI += Delta;
     while (EI != JT->Entries.end()) {
       const BinaryBasicBlock *TargetBB = getBasicBlockForLabel(*EI);
@@ -187,7 +187,7 @@ void BinaryFunction::postProcessProfile() {
       ++Delta;
       ++EI;
       // A label marks the start of another jump table.
-      if (JT->Labels.count(Delta * JT->EntrySize))
+      if (JT->Labels.count(Delta * JT->getEntrySize()))
         break;
     }
   }

--- a/bolt/lib/Passes/AsmDump.cpp
+++ b/bolt/lib/Passes/AsmDump.cpp
@@ -78,7 +78,7 @@ void dumpJumpTableSymbols(raw_ostream &OS, const JumpTable *JT, AsmPrinter &MAP,
   }
   OS << "\"" << JT->getName() << "\":\n";
   for (MCSymbol *JTEntry : JT->Entries)
-    MAP.OutStreamer->emitSymbolValue(JTEntry, JT->OutputEntrySize);
+    MAP.OutStreamer->emitSymbolValue(JTEntry, JT->getOutputEntrySize());
   OS << '\n';
 }
 

--- a/bolt/lib/Passes/IdenticalCodeFolding.cpp
+++ b/bolt/lib/Passes/IdenticalCodeFolding.cpp
@@ -84,7 +84,7 @@ static bool equalJumpTables(const JumpTable &JumpTableA,
                             const JumpTable &JumpTableB,
                             const BinaryFunction &FunctionA,
                             const BinaryFunction &FunctionB) {
-  if (JumpTableA.EntrySize != JumpTableB.EntrySize)
+  if (JumpTableA.getEntrySize() != JumpTableB.getEntrySize())
     return false;
 
   if (JumpTableA.Type != JumpTableB.Type)

--- a/bolt/lib/Passes/IndirectCallPromotion.cpp
+++ b/bolt/lib/Passes/IndirectCallPromotion.cpp
@@ -257,7 +257,7 @@ IndirectCallPromotion::getCallTargets(BinaryBasicBlock &BB,
         JT->Counts.empty() ? &DefaultJI : &JT->Counts[Range.first];
     const size_t JIAdj = JT->Counts.empty() ? 0 : 1;
     assert(JT->Type == JumpTable::JTT_PIC ||
-           JT->EntrySize == BC.AsmInfo->getCodePointerSize());
+           JT->getEntrySize() == BC.AsmInfo->getCodePointerSize());
     for (size_t I = Range.first; I < Range.second; ++I, JI += JIAdj) {
       MCSymbol *Entry = JT->Entries[I];
       const BinaryBasicBlock *ToBB = BF.getBasicBlockForLabel(Entry);
@@ -458,7 +458,7 @@ IndirectCallPromotion::maybeGetHotJumpTableTargets(BinaryBasicBlock &BB,
     if (!AccessInfo.MemoryObject && !AccessInfo.Offset)
       continue;
 
-    if (AccessInfo.Offset % JT->EntrySize != 0) // ignore bogus data
+    if (AccessInfo.Offset % JT->getEntrySize() != 0) // ignore bogus data
       return JumpTableInfoType();
 
     if (AccessInfo.MemoryObject) {
@@ -466,10 +466,10 @@ IndirectCallPromotion::maybeGetHotJumpTableTargets(BinaryBasicBlock &BB,
       if (!AccessInfo.MemoryObject->getName().starts_with(
               "JUMP_TABLE/" + Function.getOneName().str()))
         return JumpTableInfoType();
-      Index =
-          (AccessInfo.Offset - (ArrayStart - JT->getAddress())) / JT->EntrySize;
+      Index = (AccessInfo.Offset - (ArrayStart - JT->getAddress())) /
+              JT->getEntrySize();
     } else {
-      Index = (AccessInfo.Offset - ArrayStart) / JT->EntrySize;
+      Index = (AccessInfo.Offset - ArrayStart) / JT->getEntrySize();
     }
 
     // If Index is out of range it probably means the memory profiling data is

--- a/bolt/lib/Passes/JTFootprintReduction.cpp
+++ b/bolt/lib/Passes/JTFootprintReduction.cpp
@@ -119,7 +119,7 @@ void JTFootprintReduction::checkOpportunities(BinaryFunction &Function,
     TotalJTScore += CurScore;
     if (!BlacklistedJTs.count(JT)) {
       OptimizedScore += CurScore;
-      if (JT->EntrySize == 8)
+      if (JT->getEntrySize() == 8)
         BytesSaved += JT->getSize() >> 1;
     }
   }
@@ -161,7 +161,7 @@ bool JTFootprintReduction::tryOptimizeNonPIC(
                            MCOperand::createReg(Index), Offset, RegOp);
   BC.MIB->setJumpTable(NewFrag.back(), JTAddr, Index);
 
-  JumpTable->OutputEntrySize = 4;
+  JumpTable->setOutputEntrySize(4);
 
   BB.replaceInstruction(Inst, NewFrag.begin(), NewFrag.end());
   return true;
@@ -200,7 +200,7 @@ bool JTFootprintReduction::tryOptimizePIC(BinaryContext &BC,
                            MCOperand::createReg(Index), JumpTableRef, RegOp);
   BC.MIB->setJumpTable(NewFrag.back(), JTAddr, Index);
 
-  JumpTable->OutputEntrySize = 4;
+  JumpTable->setOutputEntrySize(4);
   // DePICify
   JumpTable->Type = JumpTable::JTT_NORMAL;
 


### PR DESCRIPTION
This patch adds getter & setter for jump table fields, also provide the fix for emit jump table functionality. 
For x86_64 jump table footprint reduction pass can decrease the size of entries, for AArch64 the size can be increase for instrumentation or after reorder basic blocks passes. We should emit JT with output entry size