### PR TITLE
[BOLT] Be less strict about Remember-Restore CFI mismatches in input binary

### DIFF
--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -453,7 +453,7 @@ private:
   /// Annotate each basic block entry with its current CFI state. This is
   /// run right after the construction of CFG while basic blocks are in their
   /// original order.
-  void annotateCFIState();
+  bool annotateCFIState();
 
   /// Associate DW_CFA_GNU_args_size info with invoke instructions
   /// (call instructions with non-empty landing pad).

--- a/bolt/lib/Passes/ADRRelaxationPass.cpp
+++ b/bolt/lib/Passes/ADRRelaxationPass.cpp
@@ -36,7 +36,7 @@ namespace bolt {
 static bool PassFailed = false;
 
 void ADRRelaxationPass::runOnFunction(BinaryFunction &BF) {
-  if (PassFailed)
+  if (PassFailed || BF.isIgnored())
     return;
 
   BinaryContext &BC = BF.getBinaryContext();

--- a/bolt/lib/Passes/Aligner.cpp
+++ b/bolt/lib/Passes/Aligner.cpp
@@ -62,6 +62,8 @@ namespace bolt {
 // Align function to the specified byte-boundary (typically, 64) offsetting
 // the fuction by not more than the corresponding value
 static void alignMaxBytes(BinaryFunction &Function) {
+  if (Function.isIgnored())
+    return;
   Function.setAlignment(opts::AlignFunctions);
   Function.setMaxAlignmentBytes(opts::AlignFunctionsMaxBytes);
   Function.setMaxColdAlignmentBytes(opts::AlignFunctionsMaxBytes);
@@ -73,6 +75,9 @@ static void alignMaxBytes(BinaryFunction &Function) {
 // -- the specified number of bytes
 static void alignCompact(BinaryFunction &Function,
                          const MCCodeEmitter *Emitter) {
+
+  if (Function.isIgnored())
+    return;
   const BinaryContext &BC = Function.getBinaryContext();
   size_t HotSize = 0;
   size_t ColdSize = 0;
@@ -97,7 +102,8 @@ static void alignCompact(BinaryFunction &Function,
 
 void AlignerPass::alignBlocks(BinaryFunction &Function,
                               const MCCodeEmitter *Emitter) {
-  if (!Function.hasValidProfile() || !Function.isSimple())
+  if (Function.isIgnored() || !Function.hasValidProfile() ||
+      !Function.isSimple())
     return;
 
   const BinaryContext &BC = Function.getBinaryContext();

--- a/bolt/lib/Passes/BinaryPasses.cpp
+++ b/bolt/lib/Passes/BinaryPasses.cpp
@@ -1810,10 +1810,14 @@ Error PrintProgramStats::runOnFunctions(BinaryContext &BC) {
 }
 
 Error InstructionLowering::runOnFunctions(BinaryContext &BC) {
-  for (auto &BFI : BC.getBinaryFunctions())
-    for (BinaryBasicBlock &BB : BFI.second)
+  for (auto &BFI : BC.getBinaryFunctions()) {
+    BinaryFunction &BF = BFI.second;
+    if (BF.isIgnored())
+      continue;
+    for (BinaryBasicBlock &BB : BF)
       for (MCInst &Instruction : BB)
         BC.MIB->lowerTailCall(Instruction);
+  }
   return Error::success();
 }
 
@@ -2029,6 +2033,8 @@ Error SpecializeMemcpy1::runOnFunctions(BinaryContext &BC) {
 }
 
 void RemoveNops::runOnFunction(BinaryFunction &BF) {
+  if (BF.isIgnored())
+    return;
   const BinaryContext &BC = BF.getBinaryContext();
   for (BinaryBasicBlock &BB : BF) {
     for (int64_t I = BB.size() - 1; I >= 0; --I) {

--- a/bolt/lib/Passes/FixRelaxationPass.cpp
+++ b/bolt/lib/Passes/FixRelaxationPass.cpp
@@ -24,6 +24,8 @@ namespace bolt {
 // target of ADD is another symbol. When found change ADRP symbol reference to
 // the ADDs one.
 void FixRelaxations::runOnFunction(BinaryFunction &BF) {
+  if (BF.isIgnored())
+    return;
   BinaryContext &BC = BF.getBinaryContext();
   for (BinaryBasicBlock &BB : BF) {
     for (auto II = BB.begin(); II != BB.end(); ++II) {

--- a/bolt/lib/Passes/Instrumentation.cpp
+++ b/bolt/lib/Passes/Instrumentation.cpp
@@ -368,7 +368,7 @@ bool Instrumentation::instrumentOneTarget(
 
 void Instrumentation::instrumentFunction(BinaryFunction &Function,
                                          MCPlusBuilder::AllocatorIdTy AllocId) {
-  if (Function.hasUnknownControlFlow())
+  if (Function.hasUnknownControlFlow() || Function.isIgnored())
     return;
 
   BinaryContext &BC = Function.getBinaryContext();

--- a/bolt/lib/Passes/LongJmp.cpp
+++ b/bolt/lib/Passes/LongJmp.cpp
@@ -557,6 +557,10 @@ Error LongJmpPass::relax(BinaryFunction &Func, bool &Modified) {
   const BinaryContext &BC = Func.getBinaryContext();
 
   assert(BC.isAArch64() && "Unsupported arch");
+
+  if (Func.isIgnored())
+    return Error::success();
+
   constexpr int InsnSize = 4; // AArch64
   std::vector<std::pair<BinaryBasicBlock *, std::unique_ptr<BinaryBasicBlock>>>
       Insertions;

--- a/bolt/lib/Passes/MCF.cpp
+++ b/bolt/lib/Passes/MCF.cpp
@@ -435,6 +435,8 @@ void equalizeBBCounts(DataflowInfoManager &Info, BinaryFunction &BF) {
 }
 
 void EstimateEdgeCounts::runOnFunction(BinaryFunction &BF) {
+  if (BF.isIgnored())
+    return;
   EdgeWeightMap PredEdgeWeights;
   EdgeWeightMap SuccEdgeWeights;
   if (!opts::IterativeGuess) {

--- a/bolt/lib/Passes/ValidateInternalCalls.cpp
+++ b/bolt/lib/Passes/ValidateInternalCalls.cpp
@@ -306,6 +306,8 @@ Error ValidateInternalCalls::runOnFunctions(BinaryContext &BC) {
   std::set<BinaryFunction *> NeedsValidation;
   for (auto &BFI : BC.getBinaryFunctions()) {
     BinaryFunction &Function = BFI.second;
+    if (Function.isIgnored())
+      continue;
     for (BinaryBasicBlock &BB : Function) {
       for (MCInst &Inst : BB) {
         if (getInternalCallTarget(Function, Inst)) {

--- a/bolt/lib/Passes/VeneerElimination.cpp
+++ b/bolt/lib/Passes/VeneerElimination.cpp
@@ -40,10 +40,7 @@ Error VeneerElimination::runOnFunctions(BinaryContext &BC) {
   std::unordered_map<const MCSymbol *, const MCSymbol *> VeneerDestinations;
   uint64_t NumEliminatedVeneers = 0;
   for (BinaryFunction &BF : llvm::make_second_range(BC.getBinaryFunctions())) {
-    if (!isPossibleVeneer(BF))
-      continue;
-
-    if (BF.isIgnored())
+    if (BF.isIgnored() || !isPossibleVeneer(BF))
       continue;
 
     MCInst &FirstInstruction = *(BF.begin()->begin());
@@ -84,6 +81,8 @@ Error VeneerElimination::runOnFunctions(BinaryContext &BC) {
 
   uint64_t VeneerCallers = 0;
   for (BinaryFunction &BF : llvm::make_second_range(BC.getBinaryFunctions())) {
+    if (BF.isIgnored())
+      continue;
     for (BinaryBasicBlock &BB : BF) {
       for (MCInst &Instr : BB) {
         if (!BC.MIB->isCall(Instr) || BC.MIB->isIndirectCall(Instr))

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -3503,6 +3503,9 @@ void RewriteInstance::postProcessFunctions() {
     if (Function.empty())
       continue;
 
+    if (Function.isIgnored())
+      continue;
+
     Function.postProcessCFG();
 
     if (opts::PrintAll || opts::PrintCFG)


### PR DESCRIPTION
## Problem
There are several open issues related to `annotateCFIState` failing, because of incorrect Remember-Restore CFI sequences in the input binary
- https://github.com/llvm/llvm-project/issues/133501
- https://github.com/llvm/llvm-project/issues/131790
- https://github.com/llvm/llvm-project/issues/124157
- https://github.com/llvm/llvm-project/issues/61971

There is a stack in `annotateCFIState` to which we push the state, when encountering a `RememberState` CFI, and popping from it, when encountering a `RestoreState` CFI.
There are two assertion that can fail: one is trying to pop from an empty stack, the other is at the end of the function, where we check if the stack is empty at the end.

It has previously been realized that some compilers can generate incorrect code, and [one of these assertions were converted into a warning](https://github.com/llvm/llvm-project/commit/f83a89c1b1ce78cfac1de1c72a03b234d2a844b6#diff-ca39122670f58da421af7031c33576d77078d2b81f48aa9baccd945724edb891) and this is already in main. However, the other is still an assertion, causing many users to not be able to run BOLT on certain binaries.

## Workaround
I believe we can relax the other check similarly. In this patch, I convert `annotateCFIState` from returning a `void` to `bool`, and if BOLT cannot process the CFIs correctly, I mark the function `Ignored`. After this, we need to check if the function `isIgnored` in several passes.
This way, the function with incorrect CFIs is not optimized, but the rest of the input binary is.

I am not entirely convinced that the issue is only with codegen (so the input binary), and not partly in BOLT. Because of this, I view my patch as a workaround, instead of a proper solution. 

Feel free to use the patch!