### PR TITLE
[TableGen] Emit `llvm::is_contained` for `CheckOpcode` predicate

### DIFF
--- a/llvm/test/TableGen/MacroFusion.td
+++ b/llvm/test/TableGen/MacroFusion.td
@@ -34,7 +34,7 @@ let Namespace = "Test" in {
 def Inst0 : TestInst<0>;
 def Inst1 : TestInst<1>;
 let isCommutable = true in
-def Inst2 : TestInst<1>;
+def Inst2 : TestInst<2>;
 
 def BothFusionPredicate: BothFusionPredicateWithMCInstPredicate<CheckRegOperand<0, X0>>;
 def TestBothFusionPredicate: Fusion<"test-both-fusion-predicate", "HasBothFusionPredicate",

--- a/llvm/test/TableGen/MacroFusion.td
+++ b/llvm/test/TableGen/MacroFusion.td
@@ -34,7 +34,7 @@ let Namespace = "Test" in {
 def Inst0 : TestInst<0>;
 def Inst1 : TestInst<1>;
 let isCommutable = true in
-def Inst2 : TestInst<2>;
+def Inst2 : TestInst<1>;
 
 def BothFusionPredicate: BothFusionPredicateWithMCInstPredicate<CheckRegOperand<0, X0>>;
 def TestBothFusionPredicate: Fusion<"test-both-fusion-predicate", "HasBothFusionPredicate",
@@ -42,7 +42,7 @@ def TestBothFusionPredicate: Fusion<"test-both-fusion-predicate", "HasBothFusion
                                     [BothFusionPredicate]>;
 
 def TestFusion: SimpleFusion<"test-fusion", "HasTestFusion", "Test Fusion",
-                             CheckOpcode<[Inst0]>,
+                             CheckOpcode<[Inst0, Inst1]>,
                              CheckAll<[
                                CheckOpcode<[Inst1]>,
                                CheckRegOperand<0, X0>
@@ -162,7 +162,7 @@ def TestSingleFusion: SingleFusion<"test-single-fusion", "HasTestSingleFusion",
 // CHECK-PREDICATOR-NEXT:      return true;
 // CHECK-PREDICATOR-NEXT:    {
 // CHECK-PREDICATOR-NEXT:      const MachineInstr *MI = FirstMI;
-// CHECK-PREDICATOR-NEXT:      if (( MI->getOpcode() != Test::Inst0 ))
+// CHECK-PREDICATOR-NEXT:      if (!llvm::is_contained({Test::Inst0, Test::Inst1}, MI->getOpcode()))
 // CHECK-PREDICATOR-NEXT:        return false;
 // CHECK-PREDICATOR-NEXT:    }
 // CHECK-PREDICATOR-NEXT:    if (!SecondMI.getOperand(0).getReg().isVirtual()) {

--- a/llvm/utils/TableGen/Common/PredicateExpander.cpp
+++ b/llvm/utils/TableGen/Common/PredicateExpander.cpp
@@ -152,13 +152,13 @@ void PredicateExpander::expandCheckOpcode(raw_ostream &OS,
   }
 
   if (shouldNegate())
-    OS << "!";
+    OS << '!';
   OS << "llvm::is_contained(";
   ListSeparator Sep;
-  OS << "{";
+  OS << '{';
   for (const Record *Inst : Opcodes)
     OS << Sep << Inst->getValueAsString("Namespace") << "::" << Inst->getName();
-  OS << "}";
+  OS << '}';
   OS << ", MI" << (isByRef() ? "." : "->") << "getOpcode())";
 }
 

--- a/llvm/utils/TableGen/Common/PredicateExpander.cpp
+++ b/llvm/utils/TableGen/Common/PredicateExpander.cpp
@@ -143,7 +143,6 @@ void PredicateExpander::expandCheckOpcode(raw_ostream &OS, const Record *Inst) {
 void PredicateExpander::expandCheckOpcode(raw_ostream &OS,
                                           ArrayRef<const Record *> Opcodes) {
   assert(!Opcodes.empty() && "Expected at least one opcode to check!");
-  bool First = true;
 
   if (Opcodes.size() == 1) {
     OS << "( ";
@@ -152,19 +151,15 @@ void PredicateExpander::expandCheckOpcode(raw_ostream &OS,
     return;
   }
 
-  OS << '(';
-  ++Indent;
-  for (const Record *Rec : Opcodes) {
-    OS << '\n' << Indent;
-    if (!First)
-      OS << (shouldNegate() ? "&& " : "|| ");
-
-    expandCheckOpcode(OS, Rec);
-    First = false;
-  }
-
-  --Indent;
-  OS << '\n' << Indent << ')';
+  if (shouldNegate())
+    OS << "!";
+  OS << "llvm::is_contained(";
+  ListSeparator Sep;
+  OS << "{";
+  for (const Record *Inst : Opcodes)
+    OS << Sep << Inst->getValueAsString("Namespace") << "::" << Inst->getName();
+  OS << "}";
+  OS << ", MI" << (isByRef() ? "." : "->") << "getOpcode())";
 }
 
 void PredicateExpander::expandCheckPseudo(raw_ostream &OS,


### PR DESCRIPTION
When the list is large, using `llvm::is_contained` is of higher
performance than a sequence of comparisons. When the list is small,
the `llvm::is_contained` can be inlined and unrolled, which has the
same effect as using a sequence of comparisons.

And the generated code is more readable.