### PR TITLE
[mlir][tosa] Remove Convolution Type Verifiers

### DIFF
--- a/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaOps.cpp
@@ -425,17 +425,7 @@ static LogicalResult verifyConvOpModes(T op) {
   if (auto quantType = llvm::dyn_cast<mlir::quant::QuantizedType>(resultEType))
     resultEType = quantType.getStorageType();
 
-  // check allowed input/result element types combinations
-  if ((inputEType.isInteger(8) && resultEType.isInteger(32)) ||
-      (inputEType.isInteger(16) && resultEType.isInteger(48)) ||
-      (isa<Float8E5M2Type>(inputEType) && resultEType.isF16()) ||
-      (isa<Float8E4M3FNType>(inputEType) && resultEType.isF16()) ||
-      (inputEType.isF16() && resultEType.isF16()) ||
-      (inputEType.isBF16() && resultEType.isBF16()) ||
-      (inputEType.isF32() && resultEType.isF32()))
-    return success();
-
-  return op.emitOpError("input/output element types are incompatible.");
+  return success();
 }
 
 // verify that inType and outType have same element types

--- a/mlir/test/Dialect/Tosa/invalid.mlir
+++ b/mlir/test/Dialect/Tosa/invalid.mlir
@@ -182,15 +182,6 @@ func.func @test_conv2d_quant_any_acc(%arg0: tensor<1x4x4x4x!quant.any<i8<-8:7>>>
 }
 
 // -----
-// CHECK-LABEL: conv2d_quant_any_result
-func.func @test_conv2d_quant_any_result(%arg0: tensor<1x4x4x4x!quant.any<i8<-8:7>>>, %arg1: tensor<8x1x1x4x!quant.any<i8<-8:7>>>, %arg2: tensor<8x!quant.any<i8<-8:7>>>) -> tensor<1x4x4x8x!quant.any<i8<-8:7>>> {
-  %zp = "tosa.const" () { values = dense<0> : tensor<1xi8> } : () -> tensor<1xi8>
-  // expected-error@+1 {{'tosa.conv2d' op input/output element types are incompatible}}
-  %0 = tosa.conv2d %arg0, %arg1, %arg2, %zp, %zp {acc_type = i32, dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, stride = array<i64: 1, 1>, local_bound = true} : (tensor<1x4x4x4x!quant.any<i8<-8:7>>>, tensor<8x1x1x4x!quant.any<i8<-8:7>>>, tensor<8x!quant.any<i8<-8:7>>>, tensor<1xi8>, tensor<1xi8>) -> tensor<1x4x4x8x!quant.any<i8<-8:7>>>
-  return %0 : tensor<1x4x4x8x!quant.any<i8<-8:7>>>
-}
-
-// -----
 
 func.func @test_concat(%arg0 : tensor<2x1xf32>, %arg1 : tensor<2x2xf32>) -> tensor<?x?xf32> {
   // expected-error@+1 {{'tosa.concat' op expect all operand shapes to have the same sizes on non-axis dimensions, but got 2 vs 1 at index 1 on operands 0 and 1}}


### PR DESCRIPTION
Remove the test in the convolution verifier that checks the input and output element types of convolution operations conform to the constraints imposed by the TOSA 1.0 specification.

These checks are too strict for users of the TOSA dialect who wish to allow more types than those allowed by the spec and provide compatibility issues with earlier TOSA implementation which allowed more type combinations.

Users who do wish to constrain the convolution types combination to only those allowed by the TOSA 1.0 spec should run the TOSA validation pass which already performs these checks.