### PR TITLE
[libclc] Move native_(exp10|powr|tan) to CLC library

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -266,20 +266,22 @@ set_source_files_properties(
   # CLC builtins
   ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/generic/math/clc_native_cos.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/generic/math/clc_native_divide.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/generic/math/clc_native_exp10.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/generic/math/clc_native_exp2.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/generic/math/clc_native_exp.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/generic/math/clc_native_log10.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/generic/math/clc_native_log2.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/generic/math/clc_native_log.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/generic/math/clc_native_powr.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/generic/math/clc_native_recip.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/generic/math/clc_native_rsqrt.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/generic/math/clc_native_sin.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/generic/math/clc_native_sqrt.cl
+  ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/generic/math/clc_native_tan.cl
   # Target-specific CLC builtins
   ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/amdgpu/math/clc_native_exp2.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/amdgpu/math/clc_native_exp.cl
   ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/amdgpu/math/clc_native_log10.cl
-  # Target-specific OpenCL builtins
   ${CMAKE_CURRENT_SOURCE_DIR}/clc/lib/r600/math/clc_native_rsqrt.cl
   # OpenCL builtins
   ${CMAKE_CURRENT_SOURCE_DIR}/generic/lib/math/native_cos.cl

--- a/libclc/clc/include/clc/math/clc_native_exp10.h
+++ b/libclc/clc/include/clc/math/clc_native_exp10.h
@@ -6,6 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE native_tan(__CLC_GENTYPE val) {
-  return native_sin(val) / native_cos(val);
-}
+#ifndef __CLC_MATH_CLC_NATIVE_EXP10_H__
+#define __CLC_MATH_CLC_NATIVE_EXP10_H__
+
+#define __FLOAT_ONLY
+#define __CLC_FUNCTION __clc_native_exp10
+#define __CLC_BODY <clc/shared/unary_decl.inc>
+
+#include <clc/math/gentype.inc>
+
+#undef __CLC_BODY
+#undef __CLC_FUNCTION
+#undef __FLOAT_ONLY
+
+#endif // __CLC_MATH_CLC_NATIVE_EXP10_H__

--- a/libclc/clc/include/clc/math/clc_native_powr.h
+++ b/libclc/clc/include/clc/math/clc_native_powr.h
@@ -6,8 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE native_powr(__CLC_GENTYPE x, __CLC_GENTYPE y) {
-  // x^y == 2^{log2 x^y} == 2^{y * log2 x}
-  // for x < 0 propagate nan created by log2
-  return native_exp2(y * native_log2(x));
-}
+#ifndef __CLC_MATH_CLC_NATIVE_POWR_H__
+#define __CLC_MATH_CLC_NATIVE_POWR_H__
+
+#define __FLOAT_ONLY
+#define __CLC_FUNCTION __clc_native_powr
+#define __CLC_BODY <clc/shared/binary_decl.inc>
+
+#include <clc/math/gentype.inc>
+
+#undef __CLC_BODY
+#undef __CLC_FUNCTION
+#undef __FLOAT_ONLY
+
+#endif // __CLC_MATH_CLC_NATIVE_POWR_H__

--- a/libclc/clc/include/clc/math/clc_native_tan.h
+++ b/libclc/clc/include/clc/math/clc_native_tan.h
@@ -6,10 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define __CLC_BODY <clc/shared/binary_decl.inc>
-#define __CLC_FUNCTION native_powr
+#ifndef __CLC_MATH_CLC_NATIVE_TAN_H__
+#define __CLC_MATH_CLC_NATIVE_TAN_H__
+
+#define __FLOAT_ONLY
+#define __CLC_FUNCTION __clc_native_tan
+#define __CLC_BODY <clc/shared/unary_decl.inc>
 
 #include <clc/math/gentype.inc>
 
 #undef __CLC_BODY
 #undef __CLC_FUNCTION
+#undef __FLOAT_ONLY
+
+#endif // __CLC_MATH_CLC_NATIVE_TAN_H__

--- a/libclc/clc/lib/generic/SOURCES
+++ b/libclc/clc/lib/generic/SOURCES
@@ -55,14 +55,17 @@ math/clc_nan.cl
 math/clc_native_cos.cl
 math/clc_native_divide.cl
 math/clc_native_exp.cl
+math/clc_native_exp10.cl
 math/clc_native_exp2.cl
 math/clc_native_log.cl
 math/clc_native_log10.cl
 math/clc_native_log2.cl
+math/clc_native_powr.cl
 math/clc_native_rsqrt.cl
 math/clc_native_recip.cl
 math/clc_native_sin.cl
 math/clc_native_sqrt.cl
+math/clc_native_tan.cl
 math/clc_nextafter.cl
 math/clc_pow.cl
 math/clc_pown.cl

--- a/libclc/clc/lib/generic/math/clc_native_exp10.cl
+++ b/libclc/clc/lib/generic/math/clc_native_exp10.cl
@@ -6,10 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define __CLC_BODY <clc/shared/binary_decl.inc>
-#define __CLC_FUNCTION native_powr
+#include <clc/float/definitions.h>
+#include <clc/internal/clc.h>
+#include <clc/math/clc_native_exp2.h>
+
+#define __FLOAT_ONLY
+#define __CLC_BODY <clc_native_exp10.inc>
 
 #include <clc/math/gentype.inc>
-
-#undef __CLC_BODY
-#undef __CLC_FUNCTION

--- a/libclc/clc/lib/generic/math/clc_native_exp10.inc
+++ b/libclc/clc/lib/generic/math/clc_native_exp10.inc
@@ -6,10 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define __CLC_BODY <clc/shared/binary_decl.inc>
-#define __CLC_FUNCTION native_powr
-
-#include <clc/math/gentype.inc>
-
-#undef __CLC_BODY
-#undef __CLC_FUNCTION
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_native_exp10(__CLC_GENTYPE val) {
+  return __clc_native_exp2(val * M_LOG210_F);
+}

--- a/libclc/clc/lib/generic/math/clc_native_powr.cl
+++ b/libclc/clc/lib/generic/math/clc_native_powr.cl
@@ -6,10 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define __CLC_BODY <clc/shared/binary_decl.inc>
-#define __CLC_FUNCTION native_powr
+#include <clc/internal/clc.h>
+#include <clc/math/clc_native_exp2.h>
+#include <clc/math/clc_native_log2.h>
+
+#define __FLOAT_ONLY
+#define __CLC_BODY <clc_native_powr.inc>
 
 #include <clc/math/gentype.inc>
-
-#undef __CLC_BODY
-#undef __CLC_FUNCTION

--- a/libclc/clc/lib/generic/math/clc_native_powr.inc
+++ b/libclc/clc/lib/generic/math/clc_native_powr.inc
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE native_exp10(__CLC_GENTYPE val) {
-  return native_exp2(val * M_LOG210_F);
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_native_powr(__CLC_GENTYPE x,
+                                                       __CLC_GENTYPE y) {
+  // x^y == 2^{log2 x^y} == 2^{y * log2 x}
+  // for x < 0 propagate nan created by log2
+  return __clc_native_exp2(y * __clc_native_log2(x));
 }

--- a/libclc/clc/lib/generic/math/clc_native_tan.cl
+++ b/libclc/clc/lib/generic/math/clc_native_tan.cl
@@ -6,10 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define __CLC_BODY <clc/shared/binary_decl.inc>
-#define __CLC_FUNCTION native_powr
+#include <clc/internal/clc.h>
+#include <clc/math/clc_native_cos.h>
+#include <clc/math/clc_native_sin.h>
+
+#define __FLOAT_ONLY
+#define __CLC_BODY <clc_native_tan.inc>
 
 #include <clc/math/gentype.inc>
-
-#undef __CLC_BODY
-#undef __CLC_FUNCTION

--- a/libclc/clc/lib/generic/math/clc_native_tan.inc
+++ b/libclc/clc/lib/generic/math/clc_native_tan.inc
@@ -6,10 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define __CLC_BODY <clc/shared/binary_decl.inc>
-#define __CLC_FUNCTION native_powr
-
-#include <clc/math/gentype.inc>
-
-#undef __CLC_BODY
-#undef __CLC_FUNCTION
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_native_tan(__CLC_GENTYPE val) {
+  return __clc_native_sin(val) / __clc_native_cos(val);
+}

--- a/libclc/generic/include/clc/math/native_divide.h
+++ b/libclc/generic/include/clc/math/native_divide.h
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define __CLC_BODY <clc/math/binary_decl_tt.inc>
+#define __CLC_BODY <clc/shared/binary_decl.inc>
 #define __CLC_FUNCTION native_divide
 
 #include <clc/math/gentype.inc>

--- a/libclc/generic/lib/math/native_exp10.cl
+++ b/libclc/generic/lib/math/native_exp10.cl
@@ -7,7 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/clc.h>
+#include <clc/math/clc_native_exp10.h>
 
-#define __CLC_BODY <native_exp10.inc>
 #define __FLOAT_ONLY
+#define FUNCTION native_exp10
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
 #include <clc/math/gentype.inc>

--- a/libclc/generic/lib/math/native_powr.cl
+++ b/libclc/generic/lib/math/native_powr.cl
@@ -7,7 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/clc.h>
+#include <clc/math/clc_native_powr.h>
 
-#define __CLC_BODY <native_powr.inc>
 #define __FLOAT_ONLY
+#define FUNCTION native_powr
+#define __CLC_BODY <clc/shared/binary_def.inc>
+
 #include <clc/math/gentype.inc>

--- a/libclc/generic/lib/math/native_tan.cl
+++ b/libclc/generic/lib/math/native_tan.cl
@@ -7,7 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/clc.h>
+#include <clc/math/clc_native_tan.h>
 
-#define __CLC_BODY <native_tan.inc>
 #define __FLOAT_ONLY
+#define FUNCTION native_tan
+#define __CLC_BODY <clc/shared/unary_def.inc>
+
 #include <clc/math/gentype.inc>


### PR DESCRIPTION
These are the three remaining native builtins not yet ported.

There are elementwise versions of exp10 and tan which correspond to the intrinsics, which may be preferable to the current versions which route through other native builtins. Those could be changed in a follow-up if desired.