### PR TITLE
[libc++][NFC] Replace typedefs with using declarations in <vector>

### DIFF
--- a/libcxx/include/__vector/vector.h
+++ b/libcxx/include/__vector/vector.h
@@ -89,28 +89,28 @@ public:
   //
   // Types
   //
-  typedef vector __self;
-  typedef _Tp value_type;
-  typedef _Allocator allocator_type;
-  typedef allocator_traits<allocator_type> __alloc_traits;
-  typedef value_type& reference;
-  typedef const value_type& const_reference;
-  typedef typename __alloc_traits::size_type size_type;
-  typedef typename __alloc_traits::difference_type difference_type;
-  typedef typename __alloc_traits::pointer pointer;
-  typedef typename __alloc_traits::const_pointer const_pointer;
+  using __self _LIBCPP_NODEBUG         = vector;
+  using value_type                     = _Tp;
+  using allocator_type                 = _Allocator;
+  using __alloc_traits _LIBCPP_NODEBUG = allocator_traits<allocator_type>;
+  using reference                      = value_type&;
+  using const_reference                = const value_type&;
+  using size_type                      = typename __alloc_traits::size_type;
+  using difference_type                = typename __alloc_traits::difference_type;
+  using pointer                        = typename __alloc_traits::pointer;
+  using const_pointer                  = typename __alloc_traits::const_pointer;
 #ifdef _LIBCPP_ABI_BOUNDED_ITERATORS_IN_VECTOR
   // Users might provide custom allocators, and prior to C++20 we have no existing way to detect whether the allocator's
   // pointer type is contiguous (though it has to be by the Standard). Using the wrapper type ensures the iterator is
   // considered contiguous.
-  typedef __bounded_iter<__wrap_iter<pointer> > iterator;
-  typedef __bounded_iter<__wrap_iter<const_pointer> > const_iterator;
+  using iterator       = __bounded_iter<__wrap_iter<pointer> >;
+  using const_iterator = __bounded_iter<__wrap_iter<const_pointer> >;
 #else
-  typedef __wrap_iter<pointer> iterator;
-  typedef __wrap_iter<const_pointer> const_iterator;
+  using iterator       = __wrap_iter<pointer>;
+  using const_iterator = __wrap_iter<const_pointer>;
 #endif
-  typedef std::reverse_iterator<iterator> reverse_iterator;
-  typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+  using reverse_iterator       = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
   // A vector containers the following members which may be trivially relocatable:
   // - pointer: may be trivially relocatable, so it's checked

--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -77,36 +77,36 @@ struct __has_storage_type<vector<bool, _Allocator> > {
 template <class _Allocator>
 class vector<bool, _Allocator> {
 public:
-  typedef vector __self;
-  typedef bool value_type;
-  typedef _Allocator allocator_type;
-  typedef allocator_traits<allocator_type> __alloc_traits;
-  typedef typename __alloc_traits::size_type size_type;
-  typedef typename __alloc_traits::difference_type difference_type;
-  typedef size_type __storage_type;
-  typedef __bit_iterator<vector, false> pointer;
-  typedef __bit_iterator<vector, true> const_pointer;
-  typedef pointer iterator;
-  typedef const_pointer const_iterator;
-  typedef std::reverse_iterator<iterator> reverse_iterator;
-  typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+  using __self _LIBCPP_NODEBUG         = vector;
+  using value_type                     = bool;
+  using allocator_type                 = _Allocator;
+  using __alloc_traits _LIBCPP_NODEBUG = allocator_traits<allocator_type>;
+  using size_type                      = typename __alloc_traits::size_type;
+  using difference_type                = typename __alloc_traits::difference_type;
+  using __storage_type _LIBCPP_NODEBUG = size_type;
+  using pointer                        = __bit_iterator<vector, false>;
+  using const_pointer                  = __bit_iterator<vector, true>;
+  using iterator                       = pointer;
+  using const_iterator                 = const_pointer;
+  using reverse_iterator               = std::reverse_iterator<iterator>;
+  using const_reverse_iterator         = std::reverse_iterator<const_iterator>;
 
 private:
-  typedef __rebind_alloc<__alloc_traits, __storage_type> __storage_allocator;
-  typedef allocator_traits<__storage_allocator> __storage_traits;
-  typedef typename __storage_traits::pointer __storage_pointer;
-  typedef typename __storage_traits::const_pointer __const_storage_pointer;
+  using __storage_allocator _LIBCPP_NODEBUG     = __rebind_alloc<__alloc_traits, __storage_type>;
+  using __storage_traits _LIBCPP_NODEBUG        = allocator_traits<__storage_allocator>;
+  using __storage_pointer _LIBCPP_NODEBUG       = typename __storage_traits::pointer;
+  using __const_storage_pointer _LIBCPP_NODEBUG = typename __storage_traits::const_pointer;
 
   __storage_pointer __begin_;
   size_type __size_;
   _LIBCPP_COMPRESSED_PAIR(size_type, __cap_, __storage_allocator, __alloc_);
 
 public:
-  typedef __bit_reference<vector> reference;
+  using reference = __bit_reference<vector>;
 #ifdef _LIBCPP_ABI_BITSET_VECTOR_BOOL_CONST_SUBSCRIPT_RETURN_BOOL
   using const_reference = bool;
 #else
-  typedef __bit_const_reference<vector> const_reference;
+  using const_reference = __bit_const_reference<vector>;
 #endif
 
 private:


### PR DESCRIPTION
This brings the code base a bit closer to using `using` declarations everywhere.
