### PR TITLE
[offload] Add early exit on plugin deinit when offloading is disabled

### DIFF
--- a/offload/libomptarget/PluginManager.cpp
+++ b/offload/libomptarget/PluginManager.cpp
@@ -51,6 +51,11 @@ void PluginManager::init() {
 
 void PluginManager::deinit() {
   TIMESCOPE();
+  if (OffloadPolicy::isOffloadDisabled()) {
+    DP("Offload is disabled. Skipping plugin deinitialization\n");
+    return;
+  }
+
   DP("Unloading RTLs...\n");
 
   for (auto &Plugin : Plugins) {


### PR DESCRIPTION
Add early exit during plugin de-init
 - when OffloadPolicy::isOffloadDisabled
 - e.g.: `OMP_TARGET_OFFLOAD=DISABLED`

See also: https://github.com/llvm/llvm-project/pull/133470