### PR TITLE
[libclc]: clspv: add a dummy implememtation for mul_hi

### DIFF
--- a/libclc/clc/lib/clspv/SOURCES
+++ b/libclc/clc/lib/clspv/SOURCES
@@ -1,1 +1,2 @@
 math/clc_sw_fma.cl
+integer/clc_mul_hi.cl

--- a/libclc/clc/lib/clspv/integer/clc_mul_hi.cl
+++ b/libclc/clc/lib/clspv/integer/clc_mul_hi.cl
@@ -1,0 +1,5 @@
+/*
+Opt-out of libclc mul_hi implementation for clspv.
+clspv has an internal implementation that does not required using a bigger data size.
+That implementation is based on OpMulExtended which is SPIR-V specific, thus it cannot be written in OpenCL-C.
+*/


### PR DESCRIPTION
clspv uses a better implementation that is not using a bigger side when not available.
Add a dummy implementation for mul_hi to avoid to override the implementation of clspv with the one in libclc.