### PR TITLE
[Arm] Add more -mtp=cp15 tests

### DIFF
--- a/clang/test/Driver/arm-thread-pointer.c
+++ b/clang/test/Driver/arm-thread-pointer.c
@@ -1,93 +1,93 @@
-// Test of the AArch32 values of -mtp=, checking that each one maps to
-// the right target features.
+// This file tests the -mtp=<mode> functionality in Clang’s ARM driver.
+// It verifies:
+//
+//   1. ARMv7 targets: explicit hardware modes, explicit soft mode, and auto mode.
+//   2. M Profile variants: explicit hardware mode should fail and auto mode defaults to soft.
+//   3. ARMv6 variants: explicit hardware modes on ARMv6K/KZ work, but auto mode falls back to soft when Thumb2 is missing.
+//   4. ARMv5 variants: explicit hardware mode is rejected and auto mode defaults to soft.
+//   5. Miscellaneous error cases (e.g. empty -mtp value).
+//
+//===----------------------------------------------------------------------===//
 
-// RUN: %clang --target=armv7-linux -mtp=cp15 -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARMv7_THREAD_POINTER-HARD %s
-// ARMv7_THREAD_POINTER-HARD: "-target-feature" "+read-tp-tpidruro"
+//===----------------------------------------------------------------------===//
+// 1. ARMv7 Targets
+//===----------------------------------------------------------------------===//
 
-// RUN: %clang --target=armv7-linux -mtp=tpidruro -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARMv7_THREAD_POINTER-HARD %s
-// RUN: %clang --target=armv7-linux -mtp=tpidrurw -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARMv7_THREAD_POINTER-TPIDRURW %s
-// ARMv7_THREAD_POINTER-TPIDRURW: "-target-feature" "+read-tp-tpidrurw"
-// RUN: %clang --target=armv7-linux -mtp=tpidrprw -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARMv7_THREAD_POINTER-TPIDRPRW %s
-// ARMv7_THREAD_POINTER-TPIDRPRW: "-target-feature" "+read-tp-tpidrprw"
+// Test explicit hardware mode using "tpidrprw" on an ARMv7 target.
+// RUN: %clang --target=armv7-linux -mtp=tpidrprw -### -S %s 2>&1 | FileCheck -check-prefix=ARMv7_TPIDRPRW %s
+// ARMv7_TPIDRPRW: "-target-feature" "+read-tp-tpidrprw"
 
-// RUN: %clang --target=armv6k-linux -mtp=cp15 -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARM_THREAD_POINTER-HARD %s
-// ARM_THREAD_POINTER-HARD: "-target-feature" "+read-tp-tpidruro"
+// Test explicit hardware mode using "tpidrurw" on an ARMv7 target.
+// RUN: %clang --target=armv7-linux -mtp=tpidrurw -### -S %s 2>&1 | FileCheck -check-prefix=ARMv7_TPIDRURW %s
+// ARMv7_TPIDRURW: "-target-feature" "+read-tp-tpidrurw"
 
-// RUN: %clang --target=armv6k-linux -mtp=auto -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARM_THREAD_POINTER_AUTO %s
-// ARM_THREAD_POINTER_AUTO-NOT: "-target-feature" "+read-tp-tpidruro"
+// Test explicit hardware mode using "tpidruro" on an ARMv7 target.
+// RUN: %clang --target=armv7-linux -mtp=tpidruro -### -S %s 2>&1 | FileCheck -check-prefix=ARMv7_TPIDRURO %s
+// ARMv7_TPIDRURO: "-target-feature" "+read-tp-tpidruro"
 
-// RUN: %clang --target=thumbv6k-apple-darwin -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=THUMBv6_THREAD_POINTER_NO_AUTO %s
-// THUMBv6_THREAD_POINTER_NO_AUTO-NOT: "-target-feature" "+read-tp-tpidruro"
+// Test explicit "soft" mode on an ARMv7 target (forces software mode).
+// RUN: %clang --target=armv7-linux -mtp=soft -### -S %s 2>&1 | FileCheck -check-prefix=ARM_Soft %s
+// ARM_Soft-NOT: "-target-feature" "+read-tp-"
 
-// RUN: not %clang --target=thumbv6k-apple-darwin -mtp=cp15 -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=THUMBv6_THREAD_POINTER_NO_HARD %s
-// THUMBv6_THREAD_POINTER_NO_HARD: unsupported option '-mtp=' for target 'thumbv6k-apple-darwin'
+// Test auto mode on an ARMv7 target (hardware support and Thumb2 yield HW mode).
+// RUN: %clang --target=armv7-linux -mtp=auto -### -S %s 2>&1 | FileCheck -check-prefix=ARMv7_Auto %s
+// Default mode is implicitly -mtp=auto
+// RUN: %clang --target=armv7-linux -### -S %s 2>&1 | FileCheck -check-prefix=ARMv7_Auto %s
+// ARMv7_Auto: "-target-feature" "+read-tp-tpidruro"
 
-// RUN: not %clang --target=thumbv6t2-linux -mtp=cp15 -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARM_THREAD_POINTER_NO_HARD %s
-// ARM_THREAD_POINTER_NO_HARD: hardware TLS register is not supported for the armv6t2 sub-architecture
+//===----------------------------------------------------------------------===//
+// 2. M Profile Variants (e.g. thumbv6t2)
+//===----------------------------------------------------------------------===//
 
-// RUN: %clang --target=armv5t-linux -mtp=cp15 -x assembler -### %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARMv5_THREAD_POINTER_ASSEMBLER %s
-// ARMv5_THREAD_POINTER_ASSEMBLER-NOT: hardware TLS register is not supported for the armv5 sub-architecture
+// Test explicit hardware mode on a M Profile target: thumbv6t2 does not support CP15.
+// RUN: not %clang --target=thumbv6t2-linux -mtp=cp15 -### -S %s 2>&1 | FileCheck -check-prefix=Thumbv6t2_Error %s
+// Thumbv6t2_Error: error: hardware TLS register is not supported for the armv6t2 sub-architecture
 
-// RUN: not %clang --target=armv6-linux -mthumb -mtp=cp15 -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=THUMBv6_THREAD_POINTER_UNSUPP %s
-// RUN: not %clang --target=thumbv6-linux -mthumb -mtp=cp15 -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=THUMBv6_THREAD_POINTER_UNSUPP %s
-// THUMBv6_THREAD_POINTER_UNSUPP: hardware TLS register is not supported for the thumbv6 sub-architecture
+// Test auto mode on a M Profile target: should default to soft mode.
+// RUN: %clang --target=thumbv6t2-linux -mtp=auto -### -S %s 2>&1 | FileCheck -check-prefix=Thumbv6t2_Auto %s
+// Thumbv6t2_Auto-NOT: "-target-feature" "+read-tp-"
 
-// RUN: %clang --target=armv7-linux -mtp=soft -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARMv7_THREAD_POINTER_SOFT %s
-// ARMv7_THREAD_POINTER_SOFT-NOT: "-target-feature" "+read-tp-tpidruro"
 
-// RUN: %clang --target=armv7-linux -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARMv7_THREAD_POINTER_NON %s
-// ARMv7_THREAD_POINTER_NON: "-target-feature" "+read-tp-tpidruro"
+//===----------------------------------------------------------------------===//
+// 3. ARMv6 Variants
+//===----------------------------------------------------------------------===//
 
-// RUN: %clang --target=armv7-linux -mtp=auto -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARMv7_THREAD_POINTER_Auto %s
-// ARMv7_THREAD_POINTER_Auto: "-target-feature" "+read-tp-tpidruro"
+// Test explicit hardware mode using "cp15" on an ARMv6K and ARMv6KZ targets.
+// RUN: %clang --target=armv6k-linux -mtp=cp15 -### -S %s 2>&1 | FileCheck -check-prefix=ARMv6k_Cp15 %s
+// RUN: %clang --target=armv6kz-linux -mtp=cp15 -### -S %s 2>&1 | FileCheck -check-prefix=ARMv6k_Cp15 %s
+// ARMv6k_Cp15: "-target-feature" "+read-tp-tpidruro"
 
-// RUN: %clang --target=armv7-linux -mtp=cp15 -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARMv7_THREAD_POINTER_HARD %s
-// ARMv7_THREAD_POINTER_HARD: "-target-feature" "+read-tp-tpidruro"
 
-// RUN: %clang --target=armv7m-linux -mtp=auto -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARMv7m_THREAD_POINTER_Auto %s
-// ARMv7m_THREAD_POINTER_Auto-NOT: "-target-feature" "+read-tp-tpidruro"
+// Test auto mode on ARMv6K and ARMv6KZ targets: defaults to soft mode due to missing Thumb2 encoding.
+// RUN: %clang --target=armv6k-linux -mtp=auto -### -S %s 2>&1 | FileCheck -check-prefix=ARMv6k_Auto %s
+// RUN: %clang --target=armv6kz-linux -mtp=auto -### -S %s 2>&1 | FileCheck -check-prefix=ARMv6k_Auto %s
+// ARMv6k_Auto-NOT: "-target-feature" "+read-tp-"
 
-// RUN: not %clang --target=armv7m-linux -mtp=cp15 -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARMv7m_THREAD_POINTER_HARD %s
-// ARMv7m_THREAD_POINTER_HARD: hardware TLS register is not supported for the thumbv7m sub-architecture
 
-// RUN: %clang --target=armv5t-linux -mtp=auto -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARMv5t_THREAD_POINTER_Auto %s
-// ARMv5t_THREAD_POINTER_Auto-NOT: "-target-feature" "+read-tp-tpidruro"
+//===----------------------------------------------------------------------===//
+// 4. ARMv5 Variants
+//===----------------------------------------------------------------------===//
 
-// RUN: %clang --target=armv6k-linux -mtp=cp15 -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARMv6k_THREAD_POINTER_Auto %s
-// ARMv6k_THREAD_POINTER_Auto: "-target-feature" "+read-tp-tpidruro"
+// Test explicit hardware mode on an ARMv5T target: hardware TP is not supported.
+// RUN: not %clang --target=armv5t-linux -mtp=cp15 -### -S %s 2>&1 | FileCheck -check-prefix=ARMv5t_Error %s
+// ARMv5t_Error: error: hardware TLS register is not supported for the armv5 sub-architecture
 
-// RUN: not %clang --target=armv6t2-linux -mtp=cp15 -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARMv6t2_THREAD_POINTER_HARD %s
-// ARMv6t2_THREAD_POINTER_HARD: hardware TLS register is not supported for the armv6t2 sub-architecture
+// Test auto mode on an ARMv5T target: should default to soft mode.
+// RUN: %clang --target=armv5t-linux -mtp=auto -### -S %s 2>&1 | FileCheck -check-prefix=ARMv5t_Auto %s
+// ARMv5t_Auto-NOT: "-target-feature" "+read-tp-"
 
-// RUN: %clang --target=armv6t2-linux -mtp=auto -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARMV6t2_THREAD_POINTER_AUTO %s
-// ARMV6t2_THREAD_POINTER_AUTO-NOT: "-target-feature" "+read-tp-tpidruro"
+//===----------------------------------------------------------------------===//
+// 5. Miscellaneous Tests
+//===----------------------------------------------------------------------===//
 
-// RUN: %clang --target=armv6kz-linux -mtp=cp15 -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARMv6kz_THREAD_POINTER_HARD %s
-// ARMv6kz_THREAD_POINTER_HARD: "-target-feature" "+read-tp-tpidruro"
+// Test empty -mtp value on an ARMv7 target: should produce a missing argument error.
+// RUN: not %clang --target=armv7-linux -mtp= -### -S %s 2>&1 | FileCheck -check-prefix=Empty_MTP %s
+// Empty_MTP: error: {{.*}}missing
 
-// RUN: %clang --target=armv6kz-linux -mtp=auto -### -S %s 2>&1 | \
-// RUN: FileCheck -check-prefix=ARMV6KZ_THREAD_POINTER_AUTO %s
-// ARMV6KZ_THREAD_POINTER_AUTO-NOT: "-target-feature" "+read-tp-tpidruro"
+// Test explicit hardware mode in assembler mode on an unsupporting target does not fail with error
+// RUN: %clang --target=thumbv6t2-linux -mtp=cp15 -x assembler -### %s 2>&1 | FileCheck -check-prefix=Thumbv6t2_Asm %s
+// Thumbv6t2_Asm-NOT: "-target-feature" "+read-tp-"
+
+// A dummy main is provided to form a valid translation unit.
+int main(void) { return 0; }
+


### PR DESCRIPTION
This patch systematically covers all -mtp=cp15 behaviour options for better code coverage.