### PR TITLE
[compiler-rt] Fix `addtf3_test.c` being skipped due to misplaced include

### DIFF
--- a/compiler-rt/test/builtins/Unit/addtf3_test.c
+++ b/compiler-rt/test/builtins/Unit/addtf3_test.c
@@ -4,13 +4,13 @@
 #include <fenv.h>
 #include <stdio.h>
 
+#include "fp_test.h"
+#include "int_lib.h"
+
 // The testcase currently assumes IEEE TF format, once that has been
 // fixed the defined(CRT_HAS_IEEE_TF) guard can be removed to enable it for
 // IBM 128 floats as well.
 #if defined(CRT_HAS_IEEE_TF)
-
-#  include "fp_test.h"
-#  include "int_lib.h"
 
 // Returns: a + b
 COMPILER_RT_ABI tf_float __addtf3(tf_float a, tf_float b);
@@ -62,7 +62,13 @@ int main() {
       defined(i386) || defined(__x86_64__) ||                                  \
       (defined(__loongarch__) && __loongarch_frlen != 0)
   // Rounding mode tests on supported architectures
-  const tf_float m = 1234.0L, n = 0.01L;
+  // Use explicit values because the binary representation of long double
+  // is platform dependent. Intended values:
+  // m = 1234.0L, n = 0.01L (where L is a literal for 128 bit long double)
+  const tf_float m =
+      fromRep128(UINT64_C(0x4009348000000000), UINT64_C(0x0000000000000000));
+  const tf_float n =
+      fromRep128(UINT64_C(0x3FF847AE147AE147), UINT64_C(0xAE147AE147AE147B));
 
   fesetround(FE_UPWARD);
   if (test__addtf3(m, n, UINT64_C(0x40093480a3d70a3d),


### PR DESCRIPTION
[compiler-rt] The test `addtf3_test.c` is currently guarded by `#if defined(CRT_HAS_IEEE_TF)`, a macro that is declared in `int_lib.h`. However, `int_lib.h` is included *after* the preprocessor check, which results in the macro not being defined in time and causes the test to always be skipped.

This patch moves the includes of `fp_test.h` and `int_lib.h` to the top of the file so that `CRT_HAS_IEEE_TF` is defined before it is checked.