### PR TITLE
[flang][OpenMP] Use function symbol on DECLARE TARGET

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2517,8 +2517,8 @@ void OmpAttributeVisitor::ResolveOmpObject(
                 if (ompFlag == Symbol::Flag::OmpDeclareTarget) {
                   if (symbol->IsFuncResult()) {
                     if (Symbol * func{currScope().symbol()}) {
-                      assert(func->IsSubprogram() &&
-                          "Expecting function scope");
+                      assert(
+                          func->IsSubprogram() && "Expecting function scope");
                       func->set(ompFlag);
                       name->symbol = func;
                     }

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2514,6 +2514,16 @@ void OmpAttributeVisitor::ResolveOmpObject(
                         name->ToString());
                   }
                 }
+                if (ompFlag == Symbol::Flag::OmpDeclareTarget) {
+                  if (symbol->IsFuncResult()) {
+                    if (Scope *container{&currScope()}) {
+                      if (Symbol *func{container->symbol()}) {
+                        func->set(ompFlag);
+                        name->symbol = func;
+                      }
+                    }
+                  }
+                }
                 if (GetContext().directive ==
                     llvm::omp::Directive::OMPD_target_data) {
                   checkExclusivelists(symbol, Symbol::Flag::OmpUseDevicePtr,

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2517,8 +2517,7 @@ void OmpAttributeVisitor::ResolveOmpObject(
                 if (ompFlag == Symbol::Flag::OmpDeclareTarget) {
                   if (symbol->IsFuncResult()) {
                     if (Symbol * func{currScope().symbol()}) {
-                      assert(
-                          func->IsSubprogram() && "Expecting function scope");
+                      CHECK(func->IsSubprogram());
                       func->set(ompFlag);
                       name->symbol = func;
                     }

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2516,11 +2516,11 @@ void OmpAttributeVisitor::ResolveOmpObject(
                 }
                 if (ompFlag == Symbol::Flag::OmpDeclareTarget) {
                   if (symbol->IsFuncResult()) {
-                    if (Scope * container{&currScope()}) {
-                      if (Symbol * func{container->symbol()}) {
-                        func->set(ompFlag);
-                        name->symbol = func;
-                      }
+                    if (Symbol * func{currScope().symbol()}) {
+                      assert(func->IsSubprogram() &&
+                          "Expecting function scope");
+                      func->set(ompFlag);
+                      name->symbol = func;
                     }
                   }
                 }

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -2516,8 +2516,8 @@ void OmpAttributeVisitor::ResolveOmpObject(
                 }
                 if (ompFlag == Symbol::Flag::OmpDeclareTarget) {
                   if (symbol->IsFuncResult()) {
-                    if (Scope *container{&currScope()}) {
-                      if (Symbol *func{container->symbol()}) {
+                    if (Scope * container{&currScope()}) {
+                      if (Symbol * func{container->symbol()}) {
                         func->set(ompFlag);
                         name->symbol = func;
                       }

--- a/flang/lib/Semantics/unparse-with-symbols.cpp
+++ b/flang/lib/Semantics/unparse-with-symbols.cpp
@@ -61,6 +61,14 @@ public:
     currStmt_ = std::nullopt;
   }
 
+  bool Pre(const parser::OpenMPDeclareTargetConstruct &x) {
+    currStmt_ = x.source;
+    return true;
+  }
+  void Post(const parser::OpenMPDeclareTargetConstruct &) {
+    currStmt_ = std::nullopt;
+  }
+
 private:
   std::optional<SourceName> currStmt_; // current statement we are processing
   std::multimap<const char *, const Symbol *> symbols_; // location to symbol

--- a/flang/test/Lower/OpenMP/declare-target-func-and-subr.f90
+++ b/flang/test/Lower/OpenMP/declare-target-func-and-subr.f90
@@ -85,6 +85,13 @@ FUNCTION FUNC_DEFAULT_EXTENDEDLIST() RESULT(I)
     I = 1
 END FUNCTION FUNC_DEFAULT_EXTENDEDLIST
 
+! ALL-LABEL: func.func @_QPfunc_name_as_result()
+! ALL-SAME: {{.*}}attributes {omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (to)>{{.*}}
+FUNCTION FUNC_NAME_AS_RESULT()
+!$omp declare target(FUNC_NAME_AS_RESULT)
+  FUNC_NAME_AS_RESULT = 1.0
+END FUNCTION FUNC_NAME_AS_RESULT
+
 !! -----
 
 ! Check specification valid forms of declare target with subroutines 

--- a/flang/test/Semantics/OpenMP/declare-target-function-name-with-symbols.f90
+++ b/flang/test/Semantics/OpenMP/declare-target-function-name-with-symbols.f90
@@ -1,0 +1,34 @@
+!RUN: %flang_fc1 -fdebug-unparse-with-symbols -fopenmp %s 2>&1 | FileCheck %s
+
+! This used to crash.
+
+module test
+  contains
+  function ex(a, b, c)
+    !$omp declare target(ex)
+    integer :: a, b, c
+    ex = a + b + c
+  end function ex
+end module test
+
+!CHECK: !DEF: /test Module
+!CHECK: module test
+!CHECK: contains
+!CHECK:  !DEF: /test/ex PUBLIC (Function, OmpDeclareTarget) Subprogram REAL(4)
+!CHECK:  !DEF: /test/ex/a ObjectEntity INTEGER(4)
+!CHECK:  !DEF: /test/ex/b ObjectEntity INTEGER(4)
+!CHECK:  !DEF: /test/ex/c ObjectEntity INTEGER(4)
+!CHECK:  function ex(a, b, c)
+!CHECK: !$omp declare target (ex)
+!CHECK:   !REF: /test/ex/a
+!CHECK:   !REF: /test/ex/b
+!CHECK:   !REF: /test/ex/c
+!CHECK:   integer a, b, c
+!CHECK:   !DEF: /test/ex/ex (Implicit, OmpDeclareTarget) ObjectEntity REAL(4)
+!CHECK:   !REF: /test/ex/a
+!CHECK:   !REF: /test/ex/b
+!CHECK:   !REF: /test/ex/c
+!CHECK:   ex = a+b+c
+!CHECK:  end function ex
+!CHECK: end module test
+


### PR DESCRIPTION
Consider:
```
function foo()
  !$omp declare target(foo) ! This `foo` was a function-result symbol
  ...
end
```
When resolving symbols, for this case use the symbol corresponding to the function instead of the symbol corresponding to the function result.

Currently, this will result in an error:
```
error: A variable that appears in a DECLARE TARGET directive must be declared in the scope of a module or have the SAVE attribute, either explicitly or implicitly
```
