### PR TITLE
[X86] When expanding LCMPXCHG16B_SAVE_RBX, substitute RBX in base

### DIFF
--- a/llvm/lib/Target/X86/X86ExpandPseudo.cpp
+++ b/llvm/lib/Target/X86/X86ExpandPseudo.cpp
@@ -439,8 +439,18 @@ bool X86ExpandPseudo::expandMI(MachineBasicBlock &MBB,
     TII->copyPhysReg(MBB, MBBI, DL, X86::RBX, InArg.getReg(), false);
     // Create the actual instruction.
     MachineInstr *NewInstr = BuildMI(MBB, MBBI, DL, TII->get(X86::LCMPXCHG16B));
-    // Copy the operands related to the address.
-    for (unsigned Idx = 1; Idx < 6; ++Idx)
+    // Copy the operands related to the address. If we access a frame variable,
+    // we need to replace the RBX base with SaveRbx, as RBX has another value.
+    const MachineOperand &Base = MBBI->getOperand(1);
+    if (Base.getReg() == X86::RBX || Base.getReg() == X86::EBX)
+      NewInstr->addOperand(MachineOperand::CreateReg(
+          Base.getReg() == X86::RBX
+              ? SaveRbx
+              : Register(TRI->getSubReg(SaveRbx, X86::sub_32bit)),
+          /*IsDef=*/false));
+    else
+      NewInstr->addOperand(Base);
+    for (unsigned Idx = 1 + 1; Idx < 1 + X86::AddrNumOperands; ++Idx)
       NewInstr->addOperand(MBBI->getOperand(Idx));
     // Finally, restore the value of RBX.
     TII->copyPhysReg(MBB, MBBI, DL, X86::RBX, SaveRbx,


### PR DESCRIPTION
The pseudo-instruction LCMPXCHG16B_SAVE_RBX is used when RBX serves as frame base pointer. At a very late stage it is then translated into a regular LCMPXCHG16B, preceded by copying the actual argument into RBX, and followed by restoring the register to the base pointer.

However, in case the `cmpxchg` operates on a local variable, RBX might also be used as a base for the memory operand in frame finalization, and we've overwritten RBX with the input operand for `cmpxchg16b`. So we have to rewrite the memory operand base to use the saved value of RBX.

Fixes #119959.