### PR TITLE
[lldb-dap] Add a -v/--version command line argument

### DIFF
--- a/lldb/test/Shell/DAP/TestHelp.test
+++ b/lldb/test/Shell/DAP/TestHelp.test
@@ -4,5 +4,5 @@
 # CHECK: --help
 # CHECK: -h
 # CHECK: --repl-mode
+# CHECK: --version
 # CHECK: --wait-for-debugger
-

--- a/lldb/test/Shell/DAP/TestVersion.test
+++ b/lldb/test/Shell/DAP/TestVersion.test
@@ -1,0 +1,3 @@
+# RUN: lldb-dap --version | FileCheck %s
+# CHECK: lldb-dap:
+# CHECK: liblldb:

--- a/lldb/tools/lldb-dap/Options.td
+++ b/lldb/tools/lldb-dap/Options.td
@@ -11,6 +11,12 @@ def: Flag<["-"], "h">,
   Alias<help>,
   HelpText<"Alias for --help">;
 
+def version: F<"version">,
+  HelpText<"Prints out the lldb-dap version.">;
+def: Flag<["-"], "v">,
+  Alias<version>,
+  HelpText<"Alias for --version">;
+
 def wait_for_debugger: F<"wait-for-debugger">,
   HelpText<"Pause the program at startup.">;
 def: Flag<["-"], "g">,

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -31,6 +31,7 @@
 #include "llvm/Option/ArgList.h"
 #include "llvm/Option/OptTable.h"
 #include "llvm/Option/Option.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/InitLLVM.h"
@@ -175,6 +176,12 @@ EXAMPLES:
 
     lldb-dap -g
 )___";
+}
+
+static void PrintVersion() {
+  llvm::outs() << "lldb-dap: ";
+  llvm::cl::PrintVersionMessage();
+  llvm::outs() << "liblldb: " << lldb::SBDebugger::GetVersionString() << '\n';
 }
 
 // If --launch-target is provided, this instance of lldb-dap becomes a
@@ -418,6 +425,11 @@ int main(int argc, char *argv[]) {
 
   if (input_args.hasArg(OPT_help)) {
     PrintHelp(T, llvm::sys::path::filename(argv[0]));
+    return EXIT_SUCCESS;
+  }
+
+  if (input_args.hasArg(OPT_version)) {
+    PrintVersion();
     return EXIT_SUCCESS;
   }
 


### PR DESCRIPTION
Add a -v/--version command line argument to print the version of both the lldb-dap binary and the liblldb it's linked against.

This is motivated by me trying to figure out which lldb-dap I had in my PATH.