### PR TITLE
Fix to the libc BUILD.bazel file after changing atan_utils.h deps.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -1881,7 +1881,6 @@ libc_support_library(
     name = "inv_trigf_utils",
     srcs = ["src/math/generic/inv_trigf_utils.cpp"],
     hdrs = [
-        "src/math/generic/atan_utils.h",
         "src/math/generic/inv_trigf_utils.h",
     ],
     deps = [


### PR DESCRIPTION
Additional fix for libc BUILD.bazel after commit 8741412 (#133980)

This seems to match libc/src/math/generic/CMakeLists.txt.