### PR TITLE
No longer diagnose __auto_type as the auto extension

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -315,6 +315,9 @@ Improvements to Clang's diagnostics
 
 - Split diagnosing base class qualifiers from the ``-Wignored-Qualifiers`` diagnostic group into a new ``-Wignored-base-class-qualifiers`` diagnostic group (which is grouped under ``-Wignored-qualifiers``). Fixes #GH131935.
 
+- ``-Wc++98-compat`` no longer diagnoses use of ``__auto_type`` or
+  ``decltype(auto)`` as though it was the extension for ``auto``. (#GH47900)
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -3376,13 +3376,18 @@ static QualType GetDeclSpecTypeForDeclarator(TypeProcessingState &state,
     } else if (Auto && D.getContext() != DeclaratorContext::LambdaExpr) {
       // If there was a trailing return type, we already got
       // warn_cxx98_compat_trailing_return_type in the parser.
-      SemaRef.Diag(AutoRange.getBegin(),
-                   D.getContext() == DeclaratorContext::LambdaExprParameter
-                       ? diag::warn_cxx11_compat_generic_lambda
-                   : IsDeducedReturnType
-                       ? diag::warn_cxx11_compat_deduced_return_type
-                       : diag::warn_cxx98_compat_auto_type_specifier)
-          << AutoRange;
+      // If there was a decltype(auto), we already got
+      // warn_cxx11_compat_decltype_auto_type_specifier.
+      unsigned DiagId = 0;
+      if (D.getContext() == DeclaratorContext::LambdaExprParameter)
+        DiagId = diag::warn_cxx11_compat_generic_lambda;
+      else if (IsDeducedReturnType)
+        DiagId = diag::warn_cxx11_compat_deduced_return_type;
+      else if (Auto->getKeyword() == AutoTypeKeyword::Auto)
+        DiagId = diag::warn_cxx98_compat_auto_type_specifier;
+
+      if (DiagId)
+        SemaRef.Diag(AutoRange.getBegin(), DiagId) << AutoRange;
     }
   }
 

--- a/clang/test/SemaCXX/cxx98-compat.cpp
+++ b/clang/test/SemaCXX/cxx98-compat.cpp
@@ -14,6 +14,16 @@ namespace std {
   };
 }
 
+void test_other_auto_spellings() {
+  __auto_type x = 0; // Ok
+  decltype(auto) y = 0; // expected-warning {{'decltype' type specifier is incompatible with C++98}}
+#ifndef CXX14COMPAT
+  // expected-warning@-2 {{'decltype(auto)' type specifier is a C++14 extension}}
+#else
+  // expected-warning@-4 {{'decltype(auto)' type specifier is incompatible with C++ standards before C++14}}
+#endif
+}
+
 template<typename ...T>  // expected-warning {{variadic templates are incompatible with C++98}}
 class Variadic1 {};
 


### PR DESCRIPTION
Given:

  __auto_type x = 12;
  decltype(auto) y = 12;

-Wc++98-compat would diagnose both x and y with:

'auto' type specifier is incompatible with C++98

This patch silences the diagnostic in those cases. decltype(auto) is still diagnosed with:

'decltype(auto)' type specifier is incompatible with C++ standards before C++14

as expected but no longer produces the extraneous diagnostic about use of 'auto'.

Fixes #47900