### PR TITLE
[lldb] Fix the incorrect reporting of dwarf5 .debug_names index time during partial indexing

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.h
@@ -89,7 +89,7 @@ public:
 
   virtual void Dump(Stream &s) = 0;
 
-  StatsDuration::Duration GetIndexTime() { return m_index_time; }
+  virtual StatsDuration::Duration GetIndexTime() { return m_index_time; }
 
   void ResetStatistics() { m_index_time.reset(); }
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.h
@@ -65,6 +65,10 @@ public:
   void GetFunctions(const RegularExpression &regex,
                     llvm::function_ref<bool(DWARFDIE die)> callback) override;
 
+  StatsDuration::Duration GetIndexTime() override {
+    return m_fallback.GetIndexTime();
+  }
+
   void Dump(Stream &s) override;
 
 private:


### PR DESCRIPTION
While using "statistics dump" command to check lldb index time, we noticed that it can sometimes report much smaller time than actually spent. Turns out this is a bug in `DebugNamesDWARFIndex::GetIndexTime()` which only reports base class's `m_index_time` when dwarf5 .debug_names is present. However, this is incorrect when the target has partial .debug_names (some compile units have .debug_names, some compile units are missing). This is very common when you are linking target that mixes code with dwarf5 .debug_names enabled and legacy code without .debug_names enabled (like 3rd party code compiled by GCC). In this scenario, lldb spends non-trivial amount of time using fallback `ManualDWARFIndex` to index the compile units without .debug_names. However, `DebugNamesDWARFIndex` is not reporting this index time.

This PR fixes the reporting time by getting its underlying fallback `ManualDWARFIndex` index time. 

With the fix the `totalDebugInfoIndexTime` is matching what observed from wall-time. 
```
{
  "memory": {
    "strings": {
      "bytesTotal": 8613420334,
      "bytesUnused": 738020587,
      "bytesUsed": 7875399747
    }
  },
  "targets": [
    {
      "dyldPluginName": "posix-dyld",
      "mismatchCoredumpModuleCount": -1,
      "sourceMapDeduceCount": 0,
      "sourceRealpathAttemptCount": 0,
      "sourceRealpathCompatibleCount": 0,
      "stopCount": 6,
      "summaryProviderStatistics": [],
      "totalSharedLibraryEventHitCount": 2
    }
  ],
  "totalDebugInfoByteSize": 15010170183,
  "totalDebugInfoEnabled": 1210,
  "totalDebugInfoIndexLoadedFromCache": 0,
  "totalDebugInfoIndexSavedToCache": 0,
  "totalDebugInfoIndexTime": 87.81044199999991,  <-------- about 87.8s
  "totalDebugInfoParseTime": 73.547295999999903,
  "totalModuleCount": 1214,
  "totalModuleCountHasDebugInfo": 1210,
  "totalModuleCountWithIncompleteTypes": 0,
  "totalModuleCountWithVariableErrors": 0,
  "totalSymbolTableIndexTime": 233.57413600000029,
  "totalSymbolTableParseTime": 207.17128999999997,
  "totalSymbolTableStripped": 0,
  "totalSymbolTablesLoadedFromCache": 0,
  "totalSymbolTablesSavedToCache": 0
}
```