### PR TITLE
[NFC][HLSL][RootSignature] Make the Lexer adhere to naming conventions

### DIFF
--- a/clang/include/clang/Lex/LexHLSLRootSignature.h
+++ b/clang/include/clang/Lex/LexHLSLRootSignature.h
@@ -61,13 +61,13 @@ public:
       : Buffer(Signature), SourceLoc(SourceLoc) {}
 
   /// Consumes and returns the next token.
-  RootSignatureToken ConsumeToken();
+  RootSignatureToken consumeToken();
 
   /// Returns the token that proceeds CurToken
-  RootSignatureToken PeekNextToken();
+  RootSignatureToken peekNextToken();
 
-  bool EndOfBuffer() {
-    AdvanceBuffer(Buffer.take_while(isspace).size());
+  bool isEndOfBuffer() {
+    advanceBuffer(Buffer.take_while(isspace).size());
     return Buffer.empty();
   }
 
@@ -82,11 +82,11 @@ private:
   clang::SourceLocation SourceLoc;
 
   /// Consumes the buffer and returns the lexed token.
-  RootSignatureToken LexToken();
+  RootSignatureToken lexToken();
 
   /// Advance the buffer by the specified number of characters.
   /// Updates the SourceLocation appropriately.
-  void AdvanceBuffer(unsigned NumCharacters = 1) {
+  void advanceBuffer(unsigned NumCharacters = 1) {
     Buffer = Buffer.drop_front(NumCharacters);
     SourceLoc = SourceLoc.getLocWithOffset(NumCharacters);
   }

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -70,7 +70,7 @@ private:
   bool parseDescriptorTableClause();
 
   /// Invoke the Lexer to consume a token and update CurToken with the result
-  void consumeNextToken() { CurToken = Lexer.ConsumeToken(); }
+  void consumeNextToken() { CurToken = Lexer.consumeToken(); }
 
   /// Return true if the next token one of the expected kinds
   bool peekExpectedToken(RootSignatureToken::Kind Expected);

--- a/clang/lib/Lex/LexHLSLRootSignature.cpp
+++ b/clang/lib/Lex/LexHLSLRootSignature.cpp
@@ -15,16 +15,16 @@ using TokenKind = RootSignatureToken::Kind;
 
 // Lexer Definitions
 
-static bool IsNumberChar(char C) {
+static bool isNumberChar(char C) {
   // TODO(#126565): extend for float support exponents
   return isdigit(C); // integer support
 }
 
-RootSignatureToken RootSignatureLexer::LexToken() {
+RootSignatureToken RootSignatureLexer::lexToken() {
   // Discard any leading whitespace
-  AdvanceBuffer(Buffer.take_while(isspace).size());
+  advanceBuffer(Buffer.take_while(isspace).size());
 
-  if (EndOfBuffer())
+  if (isEndOfBuffer())
     return RootSignatureToken(TokenKind::end_of_stream, SourceLoc);
 
   // Record where this token is in the text for usage in parser diagnostics
@@ -37,7 +37,7 @@ RootSignatureToken RootSignatureLexer::LexToken() {
 #define PUNCTUATOR(X, Y)                                                       \
   case Y: {                                                                    \
     Result.TokKind = TokenKind::pu_##X;                                        \
-    AdvanceBuffer();                                                           \
+    advanceBuffer();                                                           \
     return Result;                                                             \
   }
 #include "clang/Lex/HLSLRootSignatureTokenKinds.def"
@@ -48,8 +48,8 @@ RootSignatureToken RootSignatureLexer::LexToken() {
   // Integer literal
   if (isdigit(C)) {
     Result.TokKind = TokenKind::int_literal;
-    Result.NumSpelling = Buffer.take_while(IsNumberChar);
-    AdvanceBuffer(Result.NumSpelling.size());
+    Result.NumSpelling = Buffer.take_while(isNumberChar);
+    advanceBuffer(Result.NumSpelling.size());
     return Result;
   }
 
@@ -82,11 +82,11 @@ RootSignatureToken RootSignatureLexer::LexToken() {
       llvm_unreachable("Switch for an expected token was not provided");
     }
 
-    AdvanceBuffer();
+    advanceBuffer();
 
     // Lex the integer literal
-    Result.NumSpelling = Buffer.take_while(IsNumberChar);
-    AdvanceBuffer(Result.NumSpelling.size());
+    Result.NumSpelling = Buffer.take_while(isNumberChar);
+    advanceBuffer(Result.NumSpelling.size());
 
     return Result;
   }
@@ -103,26 +103,26 @@ RootSignatureToken RootSignatureLexer::LexToken() {
 
   // Then attempt to retreive a string from it
   Result.TokKind = Switch.Default(TokenKind::invalid);
-  AdvanceBuffer(TokSpelling.size());
+  advanceBuffer(TokSpelling.size());
   return Result;
 }
 
-RootSignatureToken RootSignatureLexer::ConsumeToken() {
+RootSignatureToken RootSignatureLexer::consumeToken() {
   // If we previously peeked then just return the previous value over
   if (NextToken && NextToken->TokKind != TokenKind::end_of_stream) {
     RootSignatureToken Result = *NextToken;
     NextToken = std::nullopt;
     return Result;
   }
-  return LexToken();
+  return lexToken();
 }
 
-RootSignatureToken RootSignatureLexer::PeekNextToken() {
+RootSignatureToken RootSignatureLexer::peekNextToken() {
   // Already peeked from the current token
   if (NextToken)
     return *NextToken;
 
-  NextToken = LexToken();
+  NextToken = lexToken();
   return *NextToken;
 }
 

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -125,7 +125,7 @@ bool RootSignatureParser::peekExpectedToken(TokenKind Expected) {
 }
 
 bool RootSignatureParser::peekExpectedToken(ArrayRef<TokenKind> AnyExpected) {
-  RootSignatureToken Result = Lexer.PeekNextToken();
+  RootSignatureToken Result = Lexer.peekNextToken();
   return llvm::is_contained(AnyExpected, Result.TokKind);
 }
 

--- a/clang/unittests/Lex/LexHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Lex/LexHLSLRootSignatureTest.cpp
@@ -19,7 +19,7 @@ class LexHLSLRootSignatureTest : public ::testing::Test {
 protected:
   LexHLSLRootSignatureTest() {}
 
-  void CheckTokens(hlsl::RootSignatureLexer &Lexer,
+  void checkTokens(hlsl::RootSignatureLexer &Lexer,
                    SmallVector<hlsl::RootSignatureToken> &Computed,
                    SmallVector<TokenKind> &Expected) {
     for (unsigned I = 0, E = Expected.size(); I != E; ++I) {
@@ -27,13 +27,13 @@ protected:
       if (Expected[I] == TokenKind::invalid ||
           Expected[I] == TokenKind::end_of_stream)
         continue;
-      hlsl::RootSignatureToken Result = Lexer.ConsumeToken();
+      hlsl::RootSignatureToken Result = Lexer.consumeToken();
       ASSERT_EQ(Result.TokKind, Expected[I]);
       Computed.push_back(Result);
     }
-    hlsl::RootSignatureToken EndOfStream = Lexer.ConsumeToken();
+    hlsl::RootSignatureToken EndOfStream = Lexer.consumeToken();
     ASSERT_EQ(EndOfStream.TokKind, TokenKind::end_of_stream);
-    ASSERT_TRUE(Lexer.EndOfBuffer());
+    ASSERT_TRUE(Lexer.isEndOfBuffer());
   }
 };
 
@@ -55,7 +55,7 @@ TEST_F(LexHLSLRootSignatureTest, ValidLexNumbersTest) {
       TokenKind::pu_plus,     TokenKind::int_literal, TokenKind::pu_plus,
       TokenKind::int_literal,
   };
-  CheckTokens(Lexer, Tokens, Expected);
+  checkTokens(Lexer, Tokens, Expected);
 
   // Sample negative: int component
   hlsl::RootSignatureToken IntToken = Tokens[1];
@@ -119,7 +119,7 @@ TEST_F(LexHLSLRootSignatureTest, ValidLexAllTokensTest) {
 #include "clang/Lex/HLSLRootSignatureTokenKinds.def"
   };
 
-  CheckTokens(Lexer, Tokens, Expected);
+  checkTokens(Lexer, Tokens, Expected);
 }
 
 TEST_F(LexHLSLRootSignatureTest, ValidCaseInsensitiveKeywordsTest) {
@@ -149,7 +149,7 @@ TEST_F(LexHLSLRootSignatureTest, ValidCaseInsensitiveKeywordsTest) {
       TokenKind::kw_offset,
   };
 
-  CheckTokens(Lexer, Tokens, Expected);
+  checkTokens(Lexer, Tokens, Expected);
 }
 
 TEST_F(LexHLSLRootSignatureTest, ValidLexPeekTest) {
@@ -161,26 +161,26 @@ TEST_F(LexHLSLRootSignatureTest, ValidLexPeekTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
 
   // Test basic peek
-  hlsl::RootSignatureToken Res = Lexer.PeekNextToken();
+  hlsl::RootSignatureToken Res = Lexer.peekNextToken();
   ASSERT_EQ(Res.TokKind, TokenKind::pu_r_paren);
 
   // Ensure it doesn't peek past one element
-  Res = Lexer.PeekNextToken();
+  Res = Lexer.peekNextToken();
   ASSERT_EQ(Res.TokKind, TokenKind::pu_r_paren);
 
-  Res = Lexer.ConsumeToken();
+  Res = Lexer.consumeToken();
   ASSERT_EQ(Res.TokKind, TokenKind::pu_r_paren);
 
   // Invoke after reseting the NextToken
-  Res = Lexer.PeekNextToken();
+  Res = Lexer.peekNextToken();
   ASSERT_EQ(Res.TokKind, TokenKind::int_literal);
 
   // Ensure we can still consume the second token
-  Res = Lexer.ConsumeToken();
+  Res = Lexer.consumeToken();
   ASSERT_EQ(Res.TokKind, TokenKind::int_literal);
 
   // Ensure end of stream token
-  Res = Lexer.PeekNextToken();
+  Res = Lexer.peekNextToken();
   ASSERT_EQ(Res.TokKind, TokenKind::end_of_stream);
 }
 


### PR DESCRIPTION
- when developing the RootSignatureLexer library, we are creating new files so we should set the standard to adhere to the coding conventions for function naming
- this was missed in the initial review but caught in the review of the parser pr [here](https://github.com/llvm/llvm-project/pull/133302#discussion_r2017632092)