### PR TITLE
[libc++] Add missing release note for LLVM 20 about zip_view

### DIFF
--- a/libcxx/docs/ReleaseNotes/20.rst
+++ b/libcxx/docs/ReleaseNotes/20.rst
@@ -162,6 +162,12 @@ Deprecations and Removals
 
 - Non-conforming extension ``packaged_task::result_type`` is deprecated. It will be removed in LLVM 21.
 
+- The changes for ``ranges::zip_view`` from `P2165R4 <https://wg21.link/P2165R4>`_ have been implemented. This can
+  lead to code assuming that ``zip_view`` produces ``std::pair`` to stop compiling now that it produces ``std::tuple``.
+  The cases are rare since ``tuple`` and ``pair`` are compatible for the most part, but this can lead to code that
+  was previously accepted now being rejected. This is necessary for libc++ to be conforming, so we don't provide any
+  way to opt-out of that behavior.
+
 Upcoming Deprecations and Removals
 ----------------------------------
 
@@ -205,3 +211,8 @@ ABI Affecting Changes
 
 - The localization support base API has been reimplemented, leading to different functions being exported from the
   libc++ built library on Windows and Windows-like platforms.
+
+- The changes for ``ranges::zip_view`` from `P2165R4 <https://wg21.link/P2165R4>`_ have been implemented. This changes
+  the element type of ``zip_view`` from a ``std::pair`` to a ``std::tuple`` in some cases. This is technically an ABI
+  break, however since ``zip_view`` is generally not an ABI sensitive type, we don't expect users to encounter any
+  issues and we don't provide a way to change this behavior, which would make libc++ non-conforming.


### PR DESCRIPTION
We should have had a release note in LLVM 20 about implementing P2165R4 since that is technically an ABI and API break for zip_view. We don't expect anyone to actually hit the ABI issue, but we've come across some (fairly small) breakage due to the API change, so this should at least be mentioned in the release notes.