### PR TITLE
[flang][preprocessor] Directive continuation must skip empty macros

### DIFF
--- a/flang/lib/Parser/prescan.cpp
+++ b/flang/lib/Parser/prescan.cpp
@@ -1325,7 +1325,7 @@ const char *Prescanner::FreeFormContinuationLine(bool ampersand) {
   if (p >= limit_) {
     return nullptr;
   }
-  p = SkipWhiteSpace(p);
+  p = SkipWhiteSpaceIncludingEmptyMacros(p);
   if (*p == '!') {
     ++p;
     if (InCompilerDirective()) {

--- a/flang/test/Preprocessing/directive-contin-with-pp.F90
+++ b/flang/test/Preprocessing/directive-contin-with-pp.F90
@@ -8,6 +8,7 @@
 #define COMMENT !
 #define OMP_START !$omp
 #define OMP_CONT !$omp&
+#define EMPTY
 
 module m
  contains
@@ -50,6 +51,11 @@ OMP_CONT do &
 OMP_CONT reduction(+:x)
     do j3 = 1, n
     end do
+
+EMPTY !$omp parallel &
+EMPTY !$omp do
+    do j4 = 1, n
+    end do
   end
 
 COMMENT &
@@ -78,6 +84,9 @@ end module
 !CHECK:   END DO
 !CHECK: !$OMP PARALLEL DO  REDUCTION(+: x)
 !CHECK:   DO j3=1_4,n
+!CHECK:   END DO
+!CHECK: !$OMP PARALLEL DO
+!CHECK:   DO j4=1_4,n
 !CHECK:   END DO
 !CHECK:  END SUBROUTINE
 !CHECK:  SUBROUTINE s2


### PR DESCRIPTION
When a compiler directive continuation line starts with keyword macro names that have empty expansions, skip them.