### PR TITLE
[libc++] Enable sized deallocation when building operator new shims on Apple

### DIFF
--- a/libcxx/utils/ci/apple-install-libcxx.sh
+++ b/libcxx/utils/ci/apple-install-libcxx.sh
@@ -119,7 +119,9 @@ for arch in ${architectures}; do
     step "Building shims to make libc++ compatible with the system libc++ on Apple platforms when running the tests"
     shims_library="${build_dir}/${arch}/apple-system-shims.a"
     # Note that this doesn't need to match the Standard version used to build the rest of the library.
-    xcrun clang++ -c -std=c++2b -target ${target} "${llvm_root}/libcxxabi/src/vendor/apple/shims.cpp" -static -o "${shims_library}"
+    # Also note that we explicitly enable sized deallocation when building the shims to ensure that we provide as
+    # many symbols as possible.
+    xcrun clang++ -c -std=c++2b -fsized-deallocation -target ${target} "${llvm_root}/libcxxabi/src/vendor/apple/shims.cpp" -static -o "${shims_library}"
 
     step "Building libc++.dylib and libc++abi.dylib for architecture ${arch}"
     xcrun cmake -S "${llvm_root}/runtimes" \


### PR DESCRIPTION
This ensures that we are able to build the shims on compilers that enable sized deallocation by default and those that don't, regardless.