### PR TITLE
[lldb-dap] Add progress events to the packet list

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -255,8 +255,6 @@ class DebugCommunication(object):
                 # and 'progressEnd' events. Keep these around in case test
                 # cases want to verify them.
                 self.progress_events.append(packet)
-                # No need to add 'progress' event packets to our packets list.
-                return keepGoing
 
         elif packet_type == "response":
             if packet["command"] == "disconnect":

--- a/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
+++ b/lldb/test/API/tools/lldb-dap/progress/TestDAP_Progress.py
@@ -19,6 +19,7 @@ class TestDAP_progress(lldbdap_testcase.DAPTestCaseBase):
         expected_not_in_message=None,
         only_verify_first_update=False,
     ):
+        self.dap_server.wait_for_event("progressEnd")
         self.assertTrue(len(self.dap_server.progress_events) > 0)
         start_found = False
         update_found = False


### PR DESCRIPTION
Before #134048, TestDAP_Progress relied on wait_for_event to block until
the progressEnd came in. However, progress events were not added to the
packet list, so this call would always time out. This PR makes it so
that packets are added to the packet list, and you can block on them.