### PR TITLE
[LLDB] Expose checking if the symbol file exists/is loaded via SBModule

### DIFF
--- a/lldb/include/lldb/API/SBModule.h
+++ b/lldb/include/lldb/API/SBModule.h
@@ -290,6 +290,9 @@ public:
   lldb::SBAddress GetObjectFileHeaderAddress() const;
   lldb::SBAddress GetObjectFileEntryPointAddress() const;
 
+  /// Get if the symbol file for this module is loaded.
+  bool IsDebugInfoLoaded() const;
+
   /// Get the number of global modules.
   static uint32_t GetNumberAllocatedModules();
 

--- a/lldb/source/API/SBModule.cpp
+++ b/lldb/source/API/SBModule.cpp
@@ -659,6 +659,18 @@ lldb::SBAddress SBModule::GetObjectFileEntryPointAddress() const {
   return sb_addr;
 }
 
+bool SBModule::IsDebugInfoLoaded() const {
+  LLDB_INSTRUMENT_VA(this);
+
+  ModuleSP module_sp(GetSP());
+  if (module_sp) {
+    SymbolFile *sym_file = module_sp->GetSymbolFile(/*create=*/false);
+    return sym_file && sym_file->GetLoadDebugInfoEnabled();
+  }
+
+  return false;
+}
+
 uint32_t SBModule::GetNumberAllocatedModules() {
   LLDB_INSTRUMENT();
 


### PR DESCRIPTION
The motivation for this patch is that in Statistics.cpp we [check to see if the module symfile is loaded](https://github.com/llvm/llvm-project/blob/990a086d9da0bc2fd53a6a4c95ecbbe23a297a83/lldb/source/Target/Statistics.cpp#L353C60-L353C75) to calculate how much debug info has been loaded. I have an external utility that only wants to look at the loaded debug info, which isn't exposed by the SBAPI.