### PR TITLE
[gn] Use exec_script_allowlist in //llvm/utils/gn/.gn

### DIFF
--- a/llvm/utils/gn/.gn
+++ b/llvm/utils/gn/.gn
@@ -6,7 +6,7 @@ buildconfig = "//llvm/utils/gn/build/BUILDCONFIG.gn"
 
 # Disallow all calls to exec_script. We should be very conservative about
 # whitelisting things here.
-exec_script_whitelist = []
+exec_script_allowlist = []
 
 # Execute action() targets using Python 3.
 script_executable = "python3"

--- a/llvm/utils/gn/.gn
+++ b/llvm/utils/gn/.gn
@@ -11,7 +11,7 @@ assert(gn_version >= 2207,
 
 
 # Disallow all calls to exec_script. We should be very conservative about
-# whitelisting things here.
+# allowing things here.
 exec_script_allowlist = []
 
 # Execute action() targets using Python 3.

--- a/llvm/utils/gn/.gn
+++ b/llvm/utils/gn/.gn
@@ -4,12 +4,6 @@
 
 buildconfig = "//llvm/utils/gn/build/BUILDCONFIG.gn"
 
-# `exec_script_allowlist` was added in GN version 2207, so that's the minimum
-# version of GN we require.
-assert(gn_version >= 2207,
-       "Your GN is too old! Update it, perhaps by running llvm/utils/gn/get.py")
-
-
 # Disallow all calls to exec_script. We should be very conservative about
 # allowing things here.
 exec_script_allowlist = []

--- a/llvm/utils/gn/.gn
+++ b/llvm/utils/gn/.gn
@@ -4,6 +4,12 @@
 
 buildconfig = "//llvm/utils/gn/build/BUILDCONFIG.gn"
 
+# `exec_script_allowlist` was added in GN version 2207, so that's the minimum
+# version of GN we require.
+assert(gn_version >= 2207,
+       "Your GN is too old! Update it, perhaps by running llvm/utils/gn/get.py")
+
+
 # Disallow all calls to exec_script. We should be very conservative about
 # whitelisting things here.
 exec_script_allowlist = []

--- a/llvm/utils/gn/build/toolchain/BUILD.gn
+++ b/llvm/utils/gn/build/toolchain/BUILD.gn
@@ -71,23 +71,6 @@ template("unix_toolchain") {
       default_output_dir = "{{root_out_dir}}/lib"
     }
 
-    if (current_os == "ios" || current_os == "mac") {
-      # gn < 1693 (e214b5d35898) doesn't support |frameworks|, requiring
-      # frameworks to be listed in |libs|, but gn >= 1808 (3028c6a426a4) forbids
-      # frameworks from appearing in |libs|. This assertion provides a helpful
-      # cue to upgrade, and is much more user-friendly than the failure that
-      # occurs when an older gn encounters |frameworks|.
-      #
-      # gn_version doesn’t actually exist in gn < 1709 (52cb644a3fb4), and
-      # defined(gn_version) doesn't actually work as expected
-      # (https://crbug.com/gn/183), so 1709 is the true minimum enforced by
-      # this construct, and if gn_version is not available, this line will still
-      # be blamed, making the resolution somewhat discoverable.
-      assert(gn_version >= 1693,
-             "Your GN is too old! " +
-                 "Update it, perhaps by running llvm/utils/gn/get.py")
-    }
-
     # Make these apply to all tools below.
     lib_switch = "-l"
     lib_dir_switch = "-L"

--- a/llvm/utils/gn/secondary/BUILD.gn
+++ b/llvm/utils/gn/secondary/BUILD.gn
@@ -1,6 +1,11 @@
 import("//clang/lib/StaticAnalyzer/Frontend/enable.gni")
 import("//llvm/utils/gn/build/toolchain/compiler.gni")
 
+# `exec_script_allowlist` was added in GN version 2207, so that's the minimum
+# version of GN we require.
+assert(gn_version >= 2207,
+       "Your GN is too old! Update it, perhaps by running llvm/utils/gn/get.py")
+
 group("default") {
   deps = [
     "//clang-tools-extra/clangd/test",


### PR DESCRIPTION
Use exec_script_allowlist in //llvm/utils/gn/.gn

GN is moving to use exec_script_allowlist instead of exec_script_whitelist everywhere.

See crbug.com/389986807