### PR TITLE
[RISCV] Don't allow '-' after 'ra' in Zcmp/Xqccmp register list.

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -2612,46 +2612,46 @@ ParseStatus RISCVAsmParser::parseRegListCommon(OperandVector &Operands,
       return Error(getLoc(),
                    "continuous register list must start from 's0' or 'x8'");
     getLexer().Lex(); // eat reg
-  }
 
-  // parse case like -s1
-  if (parseOptionalToken(AsmToken::Minus)) {
-    StringRef EndName = getLexer().getTok().getIdentifier();
-    // FIXME: the register mapping and checks of RVE is wrong
-    RegEnd = matchRegisterNameHelper(EndName);
-    if (!(RegEnd == RISCV::X9 ||
-          (RegEnd >= RISCV::X18 && RegEnd <= RISCV::X27)))
-      return Error(getLoc(), "invalid register");
-    getLexer().Lex();
-  }
-
-  // parse extra part like ', x18[-x20]' for XRegList
-  if (parseOptionalToken(AsmToken::Comma)) {
-    if (RegEnd != RISCV::X9)
-      return Error(
-          getLoc(),
-          "first contiguous registers pair of register list must be 'x8-x9'");
-
-    // parse ', x18' for extra part
-    if (getLexer().isNot(AsmToken::Identifier) || IsRVE)
-      return Error(getLoc(), "invalid register");
-    StringRef EndName = getLexer().getTok().getIdentifier();
-    RegEnd = MatchRegisterName(EndName);
-    if (RegEnd != RISCV::X18)
-      return Error(getLoc(),
-                   "second contiguous registers pair of register list "
-                   "must start from 'x18'");
-    getLexer().Lex();
-
-    // parse '-x20' for extra part
+    // parse case like -s1
     if (parseOptionalToken(AsmToken::Minus)) {
-      if (getLexer().isNot(AsmToken::Identifier) || IsRVE)
-        return Error(getLoc(), "invalid register");
-      EndName = getLexer().getTok().getIdentifier();
-      RegEnd = MatchRegisterName(EndName);
-      if (!(RegEnd >= RISCV::X19 && RegEnd <= RISCV::X27))
+      StringRef EndName = getLexer().getTok().getIdentifier();
+      // FIXME: the register mapping and checks of RVE is wrong
+      RegEnd = matchRegisterNameHelper(EndName);
+      if (!(RegEnd == RISCV::X9 ||
+            (RegEnd >= RISCV::X18 && RegEnd <= RISCV::X27)))
         return Error(getLoc(), "invalid register");
       getLexer().Lex();
+    }
+
+    // parse extra part like ', x18[-x20]' for XRegList
+    if (parseOptionalToken(AsmToken::Comma)) {
+      if (RegEnd != RISCV::X9)
+        return Error(
+            getLoc(),
+            "first contiguous registers pair of register list must be 'x8-x9'");
+
+      // parse ', x18' for extra part
+      if (getLexer().isNot(AsmToken::Identifier) || IsRVE)
+        return Error(getLoc(), "invalid register");
+      StringRef EndName = getLexer().getTok().getIdentifier();
+      RegEnd = MatchRegisterName(EndName);
+      if (RegEnd != RISCV::X18)
+        return Error(getLoc(),
+                     "second contiguous registers pair of register list "
+                     "must start from 'x18'");
+      getLexer().Lex();
+
+      // parse '-x20' for extra part
+      if (parseOptionalToken(AsmToken::Minus)) {
+        if (getLexer().isNot(AsmToken::Identifier) || IsRVE)
+          return Error(getLoc(), "invalid register");
+        EndName = getLexer().getTok().getIdentifier();
+        RegEnd = MatchRegisterName(EndName);
+        if (!(RegEnd >= RISCV::X19 && RegEnd <= RISCV::X27))
+          return Error(getLoc(), "invalid register");
+        getLexer().Lex();
+      }
     }
   }
 

--- a/llvm/test/MC/RISCV/rv64zcmp-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zcmp-invalid.s
@@ -54,3 +54,6 @@ cm.pop {ra}, -x1
 
 # CHECK-ERROR: :[[@LINE+1]]:15: error: stack adjustment is invalid for this instruction and register list
 cm.push {ra}, x1
+
+# CHECK-ERROR: :[[@LINE+1]]:12: error: register list must end with '}'
+cm.push {x1-x9}, -32


### PR DESCRIPTION
Move the parsing of minus under the check that we parsed a comma. Unfortunately, this leads to a poor error, but I still have more known issues in this code and may end up with an overall restructuring and want to think about wording.