### PR TITLE
llvm-reduce: Remove unsupported from bitcode uselistorder test

### DIFF
--- a/llvm/test/tools/llvm-reduce/bitcode-uselistorder.ll
+++ b/llvm/test/tools/llvm-reduce/bitcode-uselistorder.ll
@@ -1,6 +1,3 @@
-; Sometimes fails with an assert on many targets.
-; UNSUPPORTED: target={{.*}}
-
 ; RUN: llvm-as -o %t.bc %s
 
 ; RUN: llvm-reduce -j=1 --abort-on-invalid-reduction \


### PR DESCRIPTION
This was disabled due to flakiness but I'm currently unable to reproduce.

I'm nervous the original issue still exists. However, I downgraded the tripped
assert in 8c18c25b1b22ea710edb40a4f167a6a8bfe6ff9d to a warning since the same
assert can trigger for illegitimate reasons.

Fixes #64157