### PR TITLE
Reapply "[cmake] Refactor clang unittest cmake"

### DIFF
--- a/clang/unittests/AST/ByteCode/CMakeLists.txt
+++ b/clang/unittests/AST/ByteCode/CMakeLists.txt
@@ -2,19 +2,17 @@ add_clang_unittest(InterpTests
   BitcastBuffer.cpp
   Descriptor.cpp
   toAPValue.cpp
-  )
-
-clang_target_link_libraries(InterpTests
-  PRIVATE
+  CLANG_LIBS
   clangAST
   clangASTMatchers
   clangBasic
   clangFrontend
   clangSerialization
   clangTooling
-  )
-
-  target_link_libraries(InterpTests
-  PRIVATE
+  LINK_LIBS
   clangTesting
-)
+  LLVM_COMPONENTS
+  FrontendOpenMP
+  Support
+  TargetParser
+  )

--- a/clang/unittests/AST/CMakeLists.txt
+++ b/clang/unittests/AST/CMakeLists.txt
@@ -1,10 +1,3 @@
-set(LLVM_LINK_COMPONENTS
-  FrontendOpenMP
-  Support
-  TargetParser
-  )
-
-
 add_subdirectory(ByteCode)
 
 add_clang_unittest(ASTTests
@@ -43,10 +36,7 @@ add_clang_unittest(ASTTests
   TemplateNameTest.cpp
   TypePrinterTest.cpp
   UnresolvedSetTest.cpp
-  )
-
-clang_target_link_libraries(ASTTests
-  PRIVATE
+  CLANG_LIBS
   clangAST
   clangASTMatchers
   clangBasic
@@ -54,11 +44,12 @@ clang_target_link_libraries(ASTTests
   clangLex
   clangSerialization
   clangTooling
-  )
-
-target_link_libraries(ASTTests
-  PRIVATE
+  LINK_LIBS
   clangTesting
   LLVMTestingAnnotations
   LLVMTestingSupport
-)
+  LLVM_COMPONENTS
+  FrontendOpenMP
+  Support
+  TargetParser
+  )

--- a/clang/unittests/ASTMatchers/CMakeLists.txt
+++ b/clang/unittests/ASTMatchers/CMakeLists.txt
@@ -1,31 +1,23 @@
-set(LLVM_LINK_COMPONENTS
-  FrontendOpenMP
-  Support
-  TargetParser
-  )
-
 add_clang_unittest(ASTMatchersTests
   ASTMatchersInternalTest.cpp
   ASTMatchersNodeTest.cpp
   ASTMatchersNarrowingTest.cpp
   ASTMatchersTraversalTest.cpp
   GtestMatchersTest.cpp
-  )
-
-clang_target_link_libraries(ASTMatchersTests
-  PRIVATE
+  CLANG_LIBS
   clangAST
   clangASTMatchers
   clangBasic
   clangFrontend
   clangSerialization
   clangTooling
-  )
-
-target_link_libraries(ASTMatchersTests
-  PRIVATE
+  LINK_LIBS
   clangTesting
   LLVMTestingSupport
-)
+  LLVM_COMPONENTS
+  FrontendOpenMP
+  Support
+  TargetParser
+  )
 
 add_subdirectory(Dynamic)

--- a/clang/unittests/ASTMatchers/Dynamic/CMakeLists.txt
+++ b/clang/unittests/ASTMatchers/Dynamic/CMakeLists.txt
@@ -1,16 +1,8 @@
-set(LLVM_LINK_COMPONENTS
-  FrontendOpenMP
-  Support
-  )
-
 add_clang_unittest(DynamicASTMatchersTests
   VariantValueTest.cpp
   ParserTest.cpp
   RegistryTest.cpp
-  )
-
-clang_target_link_libraries(DynamicASTMatchersTests
-  PRIVATE
+  CLANG_LIBS
   clangAST
   clangASTMatchers
   clangBasic
@@ -18,9 +10,9 @@ clang_target_link_libraries(DynamicASTMatchersTests
   clangFrontend
   clangSerialization
   clangTooling
-  )
-
-target_link_libraries(DynamicASTMatchersTests
-  PRIVATE
+  LINK_LIBS
   clangTesting
+  LLVM_COMPONENTS
+  FrontendOpenMP
+  Support
   )

--- a/clang/unittests/Analysis/CMakeLists.txt
+++ b/clang/unittests/Analysis/CMakeLists.txt
@@ -1,8 +1,3 @@
-set(LLVM_LINK_COMPONENTS
-  FrontendOpenMP
-  Support
-  )
-
 add_clang_unittest(ClangAnalysisTests
   CFGDominatorTree.cpp
   CFGTest.cpp
@@ -11,10 +6,7 @@ add_clang_unittest(ClangAnalysisTests
   IntervalPartitionTest.cpp
   MacroExpansionContextTest.cpp
   UnsafeBufferUsageTest.cpp
-  )
-
-clang_target_link_libraries(ClangAnalysisTests
-  PRIVATE
+  CLANG_LIBS
   clangAST
   clangASTMatchers
   clangAnalysis
@@ -23,12 +15,12 @@ clang_target_link_libraries(ClangAnalysisTests
   clangLex
   clangSerialization
   clangTooling
-  )
-
-target_link_libraries(ClangAnalysisTests
-  PRIVATE
+  LINK_LIBS
   clangTesting
   LLVMTestingSupport
+  LLVM_COMPONENTS
+  FrontendOpenMP
+  Support
   )
 
 add_subdirectory(FlowSensitive)

--- a/clang/unittests/Analysis/FlowSensitive/CMakeLists.txt
+++ b/clang/unittests/Analysis/FlowSensitive/CMakeLists.txt
@@ -1,8 +1,3 @@
-set(LLVM_LINK_COMPONENTS
-  FrontendOpenMP
-  Support
-  )
-
 add_clang_unittest(ClangAnalysisFlowSensitiveTests
   ArenaTest.cpp
   ASTOpsTest.cpp
@@ -30,10 +25,7 @@ add_clang_unittest(ClangAnalysisFlowSensitiveTests
   UncheckedOptionalAccessModelTest.cpp
   ValueTest.cpp
   WatchedLiteralsSolverTest.cpp
-  )
-
-clang_target_link_libraries(ClangAnalysisFlowSensitiveTests
-  PRIVATE
+  CLANG_LIBS
   clangAST
   clangASTMatchers
   clangAnalysis
@@ -44,11 +36,11 @@ clang_target_link_libraries(ClangAnalysisFlowSensitiveTests
   clangLex
   clangSerialization
   clangTooling
-  )
-
-target_link_libraries(ClangAnalysisFlowSensitiveTests
-  PRIVATE
+  LINK_LIBS
   clangTesting
   LLVMTestingAnnotations
   LLVMTestingSupport
+  LLVM_COMPONENTS
+  FrontendOpenMP
+  Support
   )

--- a/clang/unittests/Basic/CMakeLists.txt
+++ b/clang/unittests/Basic/CMakeLists.txt
@@ -1,7 +1,3 @@
-set(LLVM_LINK_COMPONENTS
-  Support
-  )
-
 add_clang_unittest(BasicTests
   CharInfoTest.cpp
   DarwinSDKInfoTest.cpp
@@ -12,15 +8,11 @@ add_clang_unittest(BasicTests
   SanitizersTest.cpp
   SarifTest.cpp
   SourceManagerTest.cpp
-  )
-
-clang_target_link_libraries(BasicTests
-  PRIVATE
+  CLANG_LIBS
   clangBasic
   clangLex
-  )
-
-target_link_libraries(BasicTests
-  PRIVATE
+  LINK_LIBS
   LLVMTestingSupport
-)
+  LLVM_COMPONENTS
+  Support
+  )

--- a/clang/unittests/CMakeLists.txt
+++ b/clang/unittests/CMakeLists.txt
@@ -15,12 +15,36 @@ if(CLANG_BUILT_STANDALONE)
   endif()
 endif()
 
-# add_clang_unittest(test_dirname file1.cpp file2.cpp)
+# add_clang_unittest(test_name file1.cpp file2.cpp)
 #
 # Will compile the list of files together and link against the clang
-# Produces a binary named 'basename(test_dirname)'.
-function(add_clang_unittest test_dirname)
-  add_unittest(ClangUnitTests ${test_dirname} ${ARGN})
+# Produces a binary named 'basename(test_name)'.
+function(add_clang_unittest test_name)
+  cmake_parse_arguments(ARG
+    ""
+    ""
+    "CLANG_LIBS;LINK_LIBS;LLVM_COMPONENTS"
+    ${ARGN})
+
+  if (NOT ${test_name} MATCHES "Tests$")
+    message(FATAL_ERROR "Unit test name must end with 'Tests' for lit to find it.")
+  endif()
+
+  # LLVM_COMPONENTS is for LLVM_LINK_COMPONENTS deps, and must be before
+  # add_unittest.
+  list(APPEND LLVM_LINK_COMPONENTS ${ARG_LLVM_COMPONENTS})
+
+  add_unittest(ClangUnitTests ${test_name} ${ARG_UNPARSED_ARGUMENTS})
+
+  # Clang libs either come from the entire dylib, or individual libraries.
+  if (CLANG_LINK_CLANG_DYLIB)
+    list(APPEND ARG_LINK_LIBS clang-cpp)
+  else()
+    list(APPEND ARG_LINK_LIBS ${ARG_CLANG_LIBS})
+  endif()
+
+  # LINK_LIBS is for normal library dependencies.
+  target_link_libraries(${test_name} PRIVATE ${ARG_LINK_LIBS})
 endfunction()
 
 add_subdirectory(Basic)

--- a/clang/unittests/CodeGen/CMakeLists.txt
+++ b/clang/unittests/CodeGen/CMakeLists.txt
@@ -1,18 +1,9 @@
-set(LLVM_LINK_COMPONENTS
-  Core
-  Support
-  TargetParser
-  )
-
 add_clang_unittest(ClangCodeGenTests
   BufferSourceTest.cpp
   CodeGenExternalTest.cpp
   TBAAMetadataTest.cpp
   CheckTargetFeaturesTest.cpp
-  )
-
-clang_target_link_libraries(ClangCodeGenTests
-  PRIVATE
+  CLANG_LIBS
   clangAST
   clangBasic
   clangCodeGen
@@ -20,4 +11,8 @@ clang_target_link_libraries(ClangCodeGenTests
   clangLex
   clangParse
   clangSerialization
+  LLVM_COMPONENTS
+  Core
+  Support
+  TargetParser
   )

--- a/clang/unittests/CrossTU/CMakeLists.txt
+++ b/clang/unittests/CrossTU/CMakeLists.txt
@@ -1,18 +1,12 @@
-set(LLVM_LINK_COMPONENTS
-  ${LLVM_TARGETS_TO_BUILD}
-  Support
-  )
-
 add_clang_unittest(CrossTUTests
   CrossTranslationUnitTest.cpp
-  )
-
-clang_target_link_libraries(CrossTUTests
-  PRIVATE
+  CLANG_LIBS
   clangAST
   clangBasic
   clangCrossTU
   clangFrontend
   clangSerialization
   clangTooling
+  LLVM_COMPONENTS
+  Support
   )

--- a/clang/unittests/DirectoryWatcher/CMakeLists.txt
+++ b/clang/unittests/DirectoryWatcher/CMakeLists.txt
@@ -1,17 +1,12 @@
 if(APPLE OR CMAKE_SYSTEM_NAME MATCHES "Linux" OR CMAKE_SYSTEM_NAME STREQUAL Windows)
 
-  set(LLVM_LINK_COMPONENTS
-    Support
-    )
-
   add_clang_unittest(DirectoryWatcherTests
     DirectoryWatcherTest.cpp
-    )
-
-  target_link_libraries(DirectoryWatcherTests
-    PRIVATE
+    LINK_LIBS
     LLVMTestingSupport
     clangDirectoryWatcher
+    LLVM_COMPONENTS
+    Support
     )
 
 endif()

--- a/clang/unittests/Driver/CMakeLists.txt
+++ b/clang/unittests/Driver/CMakeLists.txt
@@ -1,11 +1,3 @@
-set(LLVM_LINK_COMPONENTS
-  ${LLVM_TARGETS_TO_BUILD}
-  MC
-  Option
-  Support
-  TargetParser
-  )
-
 add_clang_unittest(ClangDriverTests
   DistroTest.cpp
   DXCModeTest.cpp
@@ -15,12 +7,15 @@ add_clang_unittest(ClangDriverTests
   MultilibBuilderTest.cpp
   MultilibTest.cpp
   SanitizerArgsTest.cpp
-  )
-
-clang_target_link_libraries(ClangDriverTests
-  PRIVATE
+  CLANG_LIBS
   clangDriver
   clangBasic
   clangFrontend # For TextDiagnosticPrinter.
   clangSerialization
+  LLVM_COMPONENTS
+  ${LLVM_TARGETS_TO_BUILD}
+  MC
+  Option
+  Support
+  TargetParser
   )

--- a/clang/unittests/Format/CMakeLists.txt
+++ b/clang/unittests/Format/CMakeLists.txt
@@ -1,7 +1,3 @@
-set(LLVM_LINK_COMPONENTS
-  Support
-  )
-
 add_clang_unittest(FormatTests
   BracesInserterTest.cpp
   BracesRemoverTest.cpp
@@ -36,12 +32,11 @@ add_clang_unittest(FormatTests
   SortIncludesTest.cpp
   UsingDeclarationsSorterTest.cpp
   TokenAnnotatorTest.cpp
-  )
-
-clang_target_link_libraries(FormatTests
-  PRIVATE
+  CLANG_LIBS
   clangBasic
   clangFormat
   clangRewrite
   clangToolingCore
+  LLVM_COMPONENTS
+  Support
   )

--- a/clang/unittests/Frontend/CMakeLists.txt
+++ b/clang/unittests/Frontend/CMakeLists.txt
@@ -1,8 +1,3 @@
-set(LLVM_LINK_COMPONENTS
-  Support
-  TargetParser
-  )
-
 add_clang_unittest(FrontendTests
   ASTUnitTest.cpp
   CompilerInvocationTest.cpp
@@ -17,9 +12,7 @@ add_clang_unittest(FrontendTests
   OutputStreamTest.cpp
   TextDiagnosticTest.cpp
   UtilsTest.cpp
-  )
-clang_target_link_libraries(FrontendTests
-  PRIVATE
+  CLANG_LIBS
   clangAST
   clangBasic
   clangFrontend
@@ -29,4 +22,7 @@ clang_target_link_libraries(FrontendTests
   clangFrontendTool
   clangSerialization
   clangTooling
+  LLVM_COMPONENTS
+  Support
+  TargetParser
   )

--- a/clang/unittests/Index/CMakeLists.txt
+++ b/clang/unittests/Index/CMakeLists.txt
@@ -1,14 +1,6 @@
-set(LLVM_LINK_COMPONENTS
-  ${LLVM_TARGETS_TO_BUILD}
-  Support
-  )
-
 add_clang_unittest(IndexTests
   IndexTests.cpp
-  )
-
-clang_target_link_libraries(IndexTests
-  PRIVATE
+  CLANG_LIBS
   clangAST
   clangBasic
   clangFrontend
@@ -16,4 +8,7 @@ clang_target_link_libraries(IndexTests
   clangLex
   clangSerialization
   clangTooling
+  LLVM_COMPONENTS
+  ${LLVM_TARGETS_TO_BUILD}
+  Support
   )

--- a/clang/unittests/InstallAPI/CMakeLists.txt
+++ b/clang/unittests/InstallAPI/CMakeLists.txt
@@ -1,11 +1,8 @@
 add_clang_unittest(InstallAPITests
   HeaderFileTest.cpp
   FileListTest.cpp
-  )
-
-clang_target_link_libraries(InstallAPITests
-  PRIVATE
+  CLANG_LIBS
   clangInstallAPI 
+  LINK_LIBS
+  LLVMTestingSupport
   )
-
-target_link_libraries(InstallAPITests PRIVATE LLVMTestingSupport)

--- a/clang/unittests/Interpreter/CMakeLists.txt
+++ b/clang/unittests/Interpreter/CMakeLists.txt
@@ -1,12 +1,3 @@
-set(LLVM_LINK_COMPONENTS
-  ${LLVM_TARGETS_TO_BUILD}
-  Core
-  MC
-  OrcJIT
-  Support
-  TargetParser
-  )
-
 add_clang_unittest(ClangReplInterpreterTests
   IncrementalCompilerBuilderTest.cpp
   IncrementalProcessingTest.cpp
@@ -15,16 +6,24 @@ add_clang_unittest(ClangReplInterpreterTests
   CodeCompletionTest.cpp
 
   EXPORT_SYMBOLS
-  )
-  
-target_link_libraries(ClangReplInterpreterTests PUBLIC LLVMTestingSupport)
 
-clang_target_link_libraries(ClangReplInterpreterTests PRIVATE
+  CLANG_LIBS
   clangAST
   clangBasic
   clangInterpreter
   clangFrontend
   clangSema
+
+  LINK_LIBS
+  LLVMTestingSupport
+
+  LLVM_COMPONENTS
+  ${LLVM_TARGETS_TO_BUILD}
+  Core
+  MC
+  OrcJIT
+  Support
+  TargetParser
   )
 
 # Exceptions on Windows are not yet supported.

--- a/clang/unittests/Interpreter/ExceptionTests/CMakeLists.txt
+++ b/clang/unittests/Interpreter/ExceptionTests/CMakeLists.txt
@@ -3,24 +3,22 @@
 set(LLVM_REQUIRES_EH ON)
 set(LLVM_REQUIRES_RTTI ON)
 
-set(LLVM_LINK_COMPONENTS
+add_clang_unittest(ClangReplInterpreterExceptionTests
+  InterpreterExceptionTest.cpp
+  EXPORT_SYMBOLS
+
+  CLANG_LIBS
+  clangAST
+  clangBasic
+  clangInterpreter
+  clangFrontend
+
+  LLVM_COMPONENTS
   ${LLVM_TARGETS_TO_BUILD}
   Core
   OrcJIT
   Support
   )
 
-add_clang_unittest(ClangReplInterpreterExceptionTests
-  InterpreterExceptionTest.cpp
-
-  EXPORT_SYMBOLS
-  )
-
 llvm_update_compile_flags(ClangReplInterpreterExceptionTests)
-target_link_libraries(ClangReplInterpreterExceptionTests PUBLIC
-  clangAST
-  clangBasic
-  clangInterpreter
-  clangFrontend
-  )
 add_dependencies(ClangReplInterpreterExceptionTests clang-resource-headers)

--- a/clang/unittests/Lex/CMakeLists.txt
+++ b/clang/unittests/Lex/CMakeLists.txt
@@ -1,7 +1,3 @@
-set(LLVM_LINK_COMPONENTS
-  Support
-  )
-
 add_clang_unittest(LexTests
   DependencyDirectivesScannerTest.cpp
   HeaderMapTest.cpp
@@ -13,19 +9,15 @@ add_clang_unittest(LexTests
   PPConditionalDirectiveRecordTest.cpp
   PPDependencyDirectivesTest.cpp
   PPMemoryAllocationsTest.cpp
-  )
-
-clang_target_link_libraries(LexTests
-  PRIVATE
+  CLANG_LIBS
   clangAST
   clangBasic
   clangLex
   clangParse
   clangSema
-  )
-
-target_link_libraries(LexTests
-  PRIVATE
+  LINK_LIBS
   LLVMTestingAnnotations
   LLVMTestingSupport
+  LLVM_COMPONENTS
+  Support
   )

--- a/clang/unittests/Rewrite/CMakeLists.txt
+++ b/clang/unittests/Rewrite/CMakeLists.txt
@@ -1,14 +1,10 @@
-set(LLVM_LINK_COMPONENTS
-  Support
-  )
-
 add_clang_unittest(RewriteTests
   RewriterTest.cpp
-  )
-clang_target_link_libraries(RewriteTests
-  PRIVATE
+  CLANG_LIBS
   clangFrontend
   clangRewrite
   clangSerialization
   clangTooling
+  LLVM_COMPONENTS
+  Support
   )

--- a/clang/unittests/Sema/CMakeLists.txt
+++ b/clang/unittests/Sema/CMakeLists.txt
@@ -1,8 +1,3 @@
-set(LLVM_LINK_COMPONENTS
-  FrontendOpenMP
-  Support
-  )
-
 add_clang_unittest(SemaTests
   ExternalSemaSourceTest.cpp
   CodeCompleteTest.cpp
@@ -10,10 +5,7 @@ add_clang_unittest(SemaTests
   GslOwnerPointerInference.cpp
   SemaLookupTest.cpp
   SemaNoloadLookupTest.cpp
-  )
-
-clang_target_link_libraries(SemaTests
-  PRIVATE
+  CLANG_LIBS
   clangAST
   clangASTMatchers
   clangBasic
@@ -22,11 +14,11 @@ clang_target_link_libraries(SemaTests
   clangSema
   clangSerialization
   clangTooling
-  )
-
-target_link_libraries(SemaTests
-  PRIVATE
+  LINK_LIBS
   LLVMTestingAnnotations
   LLVMTestingSupport
   clangTesting
+  LLVM_COMPONENTS
+  FrontendOpenMP
+  Support
   )

--- a/clang/unittests/Serialization/CMakeLists.txt
+++ b/clang/unittests/Serialization/CMakeLists.txt
@@ -1,10 +1,3 @@
-set(LLVM_LINK_COMPONENTS
-  BitReader
-  BitstreamReader
-  FrontendOpenMP
-  Support
-  )
-
 add_clang_unittest(SerializationTests
   ForceCheckFileInputTest.cpp
   InMemoryModuleCacheTest.cpp
@@ -14,10 +7,7 @@ add_clang_unittest(SerializationTests
   LoadSpecLazilyTest.cpp
   SourceLocationEncodingTest.cpp
   VarDeclConstantInitTest.cpp
-  )
-
-clang_target_link_libraries(SerializationTests
-  PRIVATE
+  CLANG_LIBS
   clangAST
   clangBasic
   clangFrontend
@@ -26,4 +16,9 @@ clang_target_link_libraries(SerializationTests
   clangSerialization
   clangTooling
   clangASTMatchers
+  LLVM_COMPONENTS
+  BitReader
+  BitstreamReader
+  FrontendOpenMP
+  Support
   )

--- a/clang/unittests/StaticAnalyzer/CMakeLists.txt
+++ b/clang/unittests/StaticAnalyzer/CMakeLists.txt
@@ -1,8 +1,3 @@
-set(LLVM_LINK_COMPONENTS
-  FrontendOpenMP
-  Support
-  )
-
 add_clang_unittest(StaticAnalysisTests
   AnalyzerOptionsTest.cpp
   APSIntTypeTest.cpp
@@ -25,10 +20,7 @@ add_clang_unittest(StaticAnalysisTests
   SValTest.cpp
   TestReturnValueUnderConstruction.cpp
   Z3CrosscheckOracleTest.cpp
-  )
-
-clang_target_link_libraries(StaticAnalysisTests
-  PRIVATE
+  CLANG_LIBS
   clangBasic
   clangAnalysis
   clangAST
@@ -39,9 +31,9 @@ clang_target_link_libraries(StaticAnalysisTests
   clangStaticAnalyzerCore
   clangStaticAnalyzerFrontend
   clangTooling
-  )
-
-target_link_libraries(StaticAnalysisTests
-  PRIVATE
+  LINK_LIBS
   clangTesting
+  LLVM_COMPONENTS
+  FrontendOpenMP
+  Support
   )

--- a/clang/unittests/Support/CMakeLists.txt
+++ b/clang/unittests/Support/CMakeLists.txt
@@ -1,15 +1,10 @@
-set(LLVM_LINK_COMPONENTS
-  Support
-  )
-
 add_clang_unittest(ClangSupportTests
   TimeProfilerTest.cpp
-  )
-
-clang_target_link_libraries(ClangSupportTests
-  PRIVATE
+  CLANG_LIBS
   clangAST
   clangBasic
   clangFrontend
   clangSerialization
+  LLVM_COMPONENTS
+  Support
   )

--- a/clang/unittests/Tooling/CMakeLists.txt
+++ b/clang/unittests/Tooling/CMakeLists.txt
@@ -1,13 +1,3 @@
-set(LLVM_LINK_COMPONENTS
-  ${LLVM_TARGETS_TO_BUILD}
-  MC
-  Option
-  FrontendOpenMP
-  Support
-  TargetParser
-  )
-
-
 add_clang_unittest(ToolingTests
   ASTSelectionTest.cpp
   CastExprTest.cpp
@@ -69,10 +59,8 @@ add_clang_unittest(ToolingTests
   StencilTest.cpp
   ToolingTest.cpp
   TransformerTest.cpp
-  )
 
-clang_target_link_libraries(ToolingTests
-  PRIVATE
+  CLANG_LIBS
   clangAST
   clangASTMatchers
   clangBasic
@@ -89,13 +77,19 @@ clang_target_link_libraries(ToolingTests
   clangToolingInclusionsStdlib
   clangToolingRefactoring
   clangTransformer
-  )
 
-target_link_libraries(ToolingTests
-  PRIVATE
+  LINK_LIBS
   LLVMTestingAnnotations
   LLVMTestingSupport
   clangTesting
-)
+
+  LLVM_COMPONENTS
+  ${LLVM_TARGETS_TO_BUILD}
+  MC
+  Option
+  FrontendOpenMP
+  Support
+  TargetParser
+  )
 
 add_subdirectory(Syntax)

--- a/clang/unittests/Tooling/Syntax/CMakeLists.txt
+++ b/clang/unittests/Tooling/Syntax/CMakeLists.txt
@@ -1,7 +1,3 @@
-set(LLVM_LINK_COMPONENTS
-  Support
-  )
-
 add_clang_unittest(SyntaxTests
   TreeTestBase.cpp
   BuildTreeTest.cpp
@@ -9,10 +5,8 @@ add_clang_unittest(SyntaxTests
   SynthesisTest.cpp
   TreeTest.cpp
   TokensTest.cpp
-)
 
-clang_target_link_libraries(SyntaxTests
-  PRIVATE
+  CLANG_LIBS
   clangAST
   clangBasic
   clangFrontend
@@ -21,11 +15,12 @@ clang_target_link_libraries(SyntaxTests
   clangTooling
   clangToolingCore
   clangToolingSyntax
-  )
 
-target_link_libraries(SyntaxTests
-  PRIVATE
+  LINK_LIBS
   clangTesting
   LLVMTestingAnnotations
   LLVMTestingSupport
+
+  LLVM_COMPONENTS
+  Support
 )

--- a/clang/unittests/libclang/CMakeLists.txt
+++ b/clang/unittests/libclang/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_clang_unittest(libclangTests
   LibclangTest.cpp
-  )
-
-target_link_libraries(libclangTests
-  PRIVATE
+  LINK_LIBS
   libclang
   )
 

--- a/clang/unittests/libclang/CrashTests/CMakeLists.txt
+++ b/clang/unittests/libclang/CrashTests/CMakeLists.txt
@@ -1,8 +1,5 @@
 add_clang_unittest(libclangCrashTests
   LibclangCrashTest.cpp
-  )
-
-target_link_libraries(libclangCrashTests
-  PRIVATE
+  LINK_LIBS
   libclang
   )


### PR DESCRIPTION
This reapplies 5ffd9bdb50b57 (#133545) with fixes.

The BUILD_SHARED_LIBS=ON build was fixed by adding missing LLVM
dependencies to the InterpTests binary in
unittests/AST/ByteCode/CMakeLists.txt .
