### PR TITLE
[MLIR][SCF] Add support for vectorization hints in `scf-to-cf` lowering.

### DIFF
--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -984,7 +984,12 @@ def ReconcileUnrealizedCastsPass : Pass<"reconcile-unrealized-casts"> {
 def SCFToControlFlowPass : Pass<"convert-scf-to-cf"> {
   let summary = "Convert SCF dialect to ControlFlow dialect, replacing structured"
                 " control flow with a CFG";
-  let dependentDialects = ["cf::ControlFlowDialect"];
+  let dependentDialects = ["cf::ControlFlowDialect", "LLVM::LLVMDialect"];
+
+  let options = [Option<"enableVectorizeHits", "enable-vectorize-hits", "bool",
+                        /*default=*/"false",
+                        "Add vectorization hints when convert SCF parallel "
+                        "loop to ControlFlow dialect">];
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -986,7 +986,8 @@ def SCFToControlFlowPass : Pass<"convert-scf-to-cf"> {
                 " control flow with a CFG";
   let dependentDialects = ["cf::ControlFlowDialect", "LLVM::LLVMDialect"];
 
-  let options = [Option<"enableVectorizeHits", "enable-vectorize-hits", "bool",
+  let options = [Option<"enableVectorizeHints", "enable-vectorize-hints",
+                        "bool",
                         /*default=*/"false",
                         "Add vectorization hints when convert SCF parallel "
                         "loop to ControlFlow dialect">];

--- a/mlir/include/mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h
+++ b/mlir/include/mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h
@@ -20,7 +20,8 @@ class RewritePatternSet;
 
 /// Collect a set of patterns to convert SCF operations to CFG branch-based
 /// operations within the ControlFlow dialect.
-void populateSCFToControlFlowConversionPatterns(RewritePatternSet &patterns);
+void populateSCFToControlFlowConversionPatterns(
+    RewritePatternSet &patterns, bool enableVectorizeHits = false);
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h
+++ b/mlir/include/mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h
@@ -21,7 +21,7 @@ class RewritePatternSet;
 /// Collect a set of patterns to convert SCF operations to CFG branch-based
 /// operations within the ControlFlow dialect.
 void populateSCFToControlFlowConversionPatterns(
-    RewritePatternSet &patterns, bool enableVectorizeHits = false);
+    RewritePatternSet &patterns, bool enableVectorizeHints = false);
 
 } // namespace mlir
 

--- a/mlir/test/Conversion/SCFToControlFlow/convert-to-cfg.mlir
+++ b/mlir/test/Conversion/SCFToControlFlow/convert-to-cfg.mlir
@@ -1,5 +1,5 @@
 // RUN: mlir-opt -allow-unregistered-dialect -convert-scf-to-cf -split-input-file %s | FileCheck %s --check-prefixes=CHECK,NO-VEC
-// RUN: mlir-opt -allow-unregistered-dialect -convert-scf-to-cf="enable-vectorize-hits=true" \
+// RUN: mlir-opt -allow-unregistered-dialect -convert-scf-to-cf="enable-vectorize-hints=true" \
 // RUN:          -split-input-file %s | FileCheck %s --check-prefixes=CHECK,VEC
 
 // VEC: #loop_vectorize = #llvm.loop_vectorize<disable = false>


### PR DESCRIPTION
Add vectorization hints when convert SCF parallel loop to ControlFlow dialect, and provide an option to control it.