### PR TITLE
[lldb] Use the "reverse video" effect when colors are disabled.

### DIFF
--- a/lldb/source/Core/Statusline.cpp
+++ b/lldb/source/Core/Statusline.cpp
@@ -27,6 +27,7 @@
 #define ANSI_CLEAR_LINE ESCAPE "[2K"
 #define ANSI_SET_SCROLL_ROWS ESCAPE "[0;%ur"
 #define ANSI_TO_START_OF_ROW ESCAPE "[%u;0f"
+#define ANSI_REVERSE_VIDEO ESCAPE "[7m"
 #define ANSI_UP_ROWS ESCAPE "[%dA"
 
 using namespace lldb;
@@ -74,6 +75,12 @@ void Statusline::Draw(std::string str) {
   locked_stream << ANSI_SAVE_CURSOR;
   locked_stream.Printf(ANSI_TO_START_OF_ROW,
                        static_cast<unsigned>(m_terminal_height));
+
+  // Use "reverse video" to make sure the statusline has a background. Only do
+  // this when colors are disabled, and rely on the statusline format otherwise.
+  if (!m_debugger.GetUseColor())
+    locked_stream << ANSI_REVERSE_VIDEO;
+
   locked_stream << str;
   locked_stream << ANSI_NORMAL;
   locked_stream << ANSI_RESTORE_CURSOR;

--- a/lldb/test/API/functionalities/statusline/TestStatusline.py
+++ b/lldb/test/API/functionalities/statusline/TestStatusline.py
@@ -56,7 +56,6 @@ class TestStatusline(PExpectTest):
             "set set show-statusline false", ["\x1b[0;{}r".format(terminal_height)]
         )
 
-
     # PExpect uses many timeouts internally and doesn't play well
     # under ASAN on a loaded machine..
     @skipIfAsan

--- a/lldb/test/API/functionalities/statusline/TestStatusline.py
+++ b/lldb/test/API/functionalities/statusline/TestStatusline.py
@@ -55,3 +55,26 @@ class TestStatusline(PExpectTest):
         self.expect(
             "set set show-statusline false", ["\x1b[0;{}r".format(terminal_height)]
         )
+
+
+    # PExpect uses many timeouts internally and doesn't play well
+    # under ASAN on a loaded machine..
+    @skipIfAsan
+    def test_no_color(self):
+        """Basic test for the statusline with colors disabled."""
+        self.build()
+        self.launch(use_colors=False)
+        self.do_setup()
+
+        # Change the terminal dimensions.
+        terminal_height = 10
+        terminal_width = 60
+        self.child.setwinsize(terminal_height, terminal_width)
+
+        # Enable the statusline and check for the "reverse video" control character.
+        self.expect(
+            "set set show-statusline true",
+            [
+                "\x1b[7m",
+            ],
+        )


### PR DESCRIPTION
When you run lldb without colors (`-X`), the status line looks weird because it doesn't have a background. You end up with what appears to be floating text at the bottom of your terminal.

This patch changes the statusline to use the reverse video effect, even when colors are off. The effect doesn't introduce any new colors and just inverts the foreground and background color.

I considered an alternative approach which changes the behavior of the `-X` option, so that turning off colors doesn't prevent emitting non-color related control characters such as bold, underline, and reverse video. I decided to go with this more targeted fix as (1) nobody is asking for this more general change and (2) it introduces significant complexity to plumb this through using a setting and driver flag so that it can be disabled when running the tests.

Fixes #134112.