### PR TITLE
[RISCV] Don't allow mixing ABI and non-ABI register names when parsing register list.

### DIFF
--- a/llvm/test/MC/RISCV/rv32zcmp-invalid.s
+++ b/llvm/test/MC/RISCV/rv32zcmp-invalid.s
@@ -35,13 +35,16 @@ cm.pop {ra, t1}, -40
 cm.pop {ra, s0-t1}, -40
 
 # CHECK-ERROR: :[[@LINE+1]]:20: error: second contiguous registers pair of register list must start from 'x18'
-cm.pop {ra, x8-x9, x28}, -40
+cm.pop {x1, x8-x9, x28}, -40
 
 # CHECK-ERROR: :[[@LINE+1]]:24: error: invalid register
-cm.pop {ra, x8-x9, x18-x28}, -40
+cm.pop {x1, x8-x9, x18-x28}, -40
 
 # CHECK-ERROR: :[[@LINE+1]]:24: error: invalid register
-cm.pop {ra, x8-x9, x18-x17}, -40
+cm.pop {x1, x8-x9, x18-x17}, -40
 
 # CHECK-ERROR: :[[@LINE+1]]:16: error: invalid register
-cm.pop {ra, x8-f8, x18-x17}, -40
+cm.pop {x1, x8-f8, x18-x17}, -40
+
+# CHECK-ERROR: :[[@LINE+1]]:16: error: invalid register
+cm.pop {ra, s0-f8}, -40

--- a/llvm/test/MC/RISCV/rv64zcmp-invalid.s
+++ b/llvm/test/MC/RISCV/rv64zcmp-invalid.s
@@ -38,16 +38,16 @@ cm.pop {ra, t1}, -40
 cm.pop {ra, s0-t1}, -40
 
 # CHECK-ERROR: :[[@LINE+1]]:20: error: second contiguous registers pair of register list must start from 'x18'
-cm.pop {ra, x8-x9, x28}, -40
+cm.pop {x1, x8-x9, x28}, -40
 
 # CHECK-ERROR: :[[@LINE+1]]:24: error: invalid register
-cm.pop {ra, x8-x9, x18-x28}, -40
+cm.pop {x1, x8-x9, x18-x28}, -40
 
 # CHECK-ERROR: :[[@LINE+1]]:24: error: invalid register
-cm.pop {ra, x8-x9, x18-x17}, -40
+cm.pop {x1, x8-x9, x18-x17}, -40
 
 # CHECK-ERROR: :[[@LINE+1]]:16: error: invalid register
-cm.pop {ra, x8-f8, x18-x17}, -40
+cm.pop {x1, x8-f8, x18-x17}, -40
 
 # CHECK-ERROR: :[[@LINE+1]]:15: error: stack adjustment is invalid for this instruction and register list
 cm.pop {ra}, -x1
@@ -57,3 +57,30 @@ cm.push {ra}, x1
 
 # CHECK-ERROR: :[[@LINE+1]]:12: error: register list must end with '}'
 cm.push {x1-x9}, -32
+
+# CHECK-ERROR: :[[@LINE+1]]:13: error: invalid register
+cm.push {x1,s0}
+
+# CHECK-ERROR: :[[@LINE+1]]:13: error: invalid register
+cm.push {ra,x8}
+
+# CHECK-ERROR: :[[@LINE+1]]:16: error: invalid register
+cm.push {x1,x8-s1}
+
+# CHECK-ERROR: :[[@LINE+1]]:16: error: invalid register
+cm.push {ra,s0-x9}
+
+# CHECK-ERROR: :[[@LINE+1]]:16: error: invalid register
+cm.push {x1,x8-x18}
+
+# CHECK-ERROR: :[[@LINE+1]]:19: error: invalid register
+cm.push {x1,x8-x9,s2}
+
+# CHECK-ERROR: :[[@LINE+1]]:19: error: invalid register
+cm.push {ra,s0-s1,x18}
+
+# CHECK-ERROR: :[[@LINE+1]]:19: error: invalid register
+cm.push {ra,s0-s1,s2}
+
+# CHECK-ERROR: :[[@LINE+1]]:23: error: invalid register
+cm.push {x1,x8-x9,x18-s3}


### PR DESCRIPTION
This is the last parsing bug I currently know about. After this I'm going to start refactoring the code and writing better error messages using all the recently added invalid tests.