### PR TITLE
[CodeGen] Use pimpl idiom for CVTables (NFC)

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -25,6 +25,7 @@
 #include "PatternInit.h"
 #include "TargetInfo.h"
 #include "clang/AST/OSLog.h"
+#include "clang/AST/RecordLayout.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Basic/TargetBuiltins.h"
 #include "clang/Basic/TargetInfo.h"

--- a/clang/lib/CodeGen/CGCXX.cpp
+++ b/clang/lib/CodeGen/CGCXX.cpp
@@ -13,6 +13,7 @@
 // We might split this into multiple files if it gets too unwieldy
 
 #include "CGCXXABI.h"
+#include "CGVTables.h"
 #include "CodeGenFunction.h"
 #include "CodeGenModule.h"
 #include "clang/AST/ASTContext.h"

--- a/clang/lib/CodeGen/CGCXXABI.cpp
+++ b/clang/lib/CodeGen/CGCXXABI.cpp
@@ -14,6 +14,7 @@
 #include "CGCXXABI.h"
 #include "CGCleanup.h"
 #include "clang/AST/Attr.h"
+#include "clang/AST/RecordLayout.h"
 
 using namespace clang;
 using namespace CodeGen;

--- a/clang/lib/CodeGen/CGCXXABI.h
+++ b/clang/lib/CodeGen/CGCXXABI.h
@@ -32,6 +32,7 @@ class CXXDestructorDecl;
 class CXXMethodDecl;
 class CXXRecordDecl;
 class MangleContext;
+struct ReturnAdjustment;
 
 namespace CodeGen {
 class CGCallee;

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -26,6 +26,7 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
+#include "clang/AST/RecordLayout.h"
 #include "clang/Basic/CodeGenOptions.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/CodeGen/CGFunctionInfo.h"

--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -15,6 +15,7 @@
 #include "CGCXXABI.h"
 #include "CGDebugInfo.h"
 #include "CGRecordLayout.h"
+#include "CGVTables.h"
 #include "CodeGenFunction.h"
 #include "TargetInfo.h"
 #include "clang/AST/Attr.h"

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -15,6 +15,7 @@
 #include "CGCXXABI.h"
 #include "CGObjCRuntime.h"
 #include "CGRecordLayout.h"
+#include "CGVTables.h"
 #include "CodeGenFunction.h"
 #include "CodeGenModule.h"
 #include "ConstantEmitter.h"

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -28,6 +28,7 @@
 #include "clang/AST/Attr.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/NSAPI.h"
+#include "clang/AST/RecordLayout.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Basic/Builtins.h"
 #include "clang/Basic/CodeGenOptions.h"

--- a/clang/lib/CodeGen/CGExprAgg.cpp
+++ b/clang/lib/CodeGen/CGExprAgg.cpp
@@ -24,6 +24,7 @@
 #include "clang/AST/Attr.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclTemplate.h"
+#include "clang/AST/RecordLayout.h"
 #include "clang/AST/StmtVisitor.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"

--- a/clang/lib/CodeGen/CGExprCXX.cpp
+++ b/clang/lib/CodeGen/CGExprCXX.cpp
@@ -17,6 +17,7 @@
 #include "CodeGenFunction.h"
 #include "ConstantEmitter.h"
 #include "TargetInfo.h"
+#include "clang/AST/RecordLayout.h"
 #include "clang/Basic/CodeGenOptions.h"
 #include "clang/CodeGen/CGFunctionInfo.h"
 #include "llvm/IR/Intrinsics.h"

--- a/clang/lib/CodeGen/CGNonTrivialStruct.cpp
+++ b/clang/lib/CodeGen/CGNonTrivialStruct.cpp
@@ -15,6 +15,7 @@
 #include "CodeGenFunction.h"
 #include "CodeGenModule.h"
 #include "clang/AST/NonTrivialTypeVisitor.h"
+#include "clang/AST/RecordLayout.h"
 #include "clang/CodeGen/CodeGenABITypes.h"
 #include "llvm/Support/ScopedPrinter.h"
 #include <array>

--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -22,6 +22,7 @@
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/OpenMPClause.h"
+#include "clang/AST/RecordLayout.h"
 #include "clang/AST/StmtOpenMP.h"
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Basic/OpenMPKinds.h"

--- a/clang/lib/CodeGen/CGStmtOpenMP.cpp
+++ b/clang/lib/CodeGen/CGStmtOpenMP.cpp
@@ -20,6 +20,7 @@
 #include "clang/AST/Attr.h"
 #include "clang/AST/DeclOpenMP.h"
 #include "clang/AST/OpenMPClause.h"
+#include "clang/AST/RecordLayout.h"
 #include "clang/AST/Stmt.h"
 #include "clang/AST/StmtOpenMP.h"
 #include "clang/AST/StmtVisitor.h"

--- a/clang/lib/CodeGen/CGVTT.cpp
+++ b/clang/lib/CodeGen/CGVTT.cpp
@@ -10,8 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "CodeGenModule.h"
 #include "CGCXXABI.h"
+#include "CGVTables.h"
+#include "CodeGenModule.h"
 #include "clang/AST/RecordLayout.h"
 #include "clang/AST/VTTBuilder.h"
 using namespace clang;

--- a/clang/lib/CodeGen/CGVTables.cpp
+++ b/clang/lib/CodeGen/CGVTables.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "CGVTables.h"
 #include "CGCXXABI.h"
 #include "CGDebugInfo.h"
 #include "CodeGenFunction.h"
@@ -1190,7 +1191,7 @@ CodeGenModule::getVTableLinkage(const CXXRecordDecl *RD) {
 /// functions).  For weak vtables, CodeGen tracks when they are needed and
 /// emits them as-needed.
 void CodeGenModule::EmitVTable(CXXRecordDecl *theClass) {
-  VTables.GenerateClassData(theClass);
+  VTables->GenerateClassData(theClass);
 }
 
 void
@@ -1275,7 +1276,7 @@ void CodeGenModule::EmitDeferredVTables() {
 
   for (const CXXRecordDecl *RD : DeferredVTables)
     if (shouldEmitVTableAtEndOfTranslationUnit(*this, RD))
-      VTables.GenerateClassData(RD);
+      VTables->GenerateClassData(RD);
     else if (shouldOpportunisticallyEmitVTables())
       OpportunisticVTables.push_back(RD);
 
@@ -1416,4 +1417,16 @@ void CodeGenModule::EmitVTableTypeMetadata(const CXXRecordDecl *RD,
     if (TypeVis != llvm::GlobalObject::VCallVisibilityPublic)
       VTable->setVCallVisibilityMetadata(TypeVis);
   }
+}
+
+ItaniumVTableContext &CodeGenModule::getItaniumVTableContext() {
+  return VTables->getItaniumVTableContext();
+}
+
+const ItaniumVTableContext &CodeGenModule::getItaniumVTableContext() const {
+  return VTables->getItaniumVTableContext();
+}
+
+MicrosoftVTableContext &CodeGenModule::getMicrosoftVTableContext() {
+  return VTables->getMicrosoftVTableContext();
 }

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -20,6 +20,7 @@
 #include "CodeGenPGO.h"
 #include "EHScopeStack.h"
 #include "VarBypassDetector.h"
+#include "clang/AST/BaseSubobject.h"
 #include "clang/AST/CharUnits.h"
 #include "clang/AST/CurrentSourceLocExprScope.h"
 #include "clang/AST/ExprCXX.h"

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -22,6 +22,7 @@
 #include "CGOpenCLRuntime.h"
 #include "CGOpenMPRuntime.h"
 #include "CGOpenMPRuntimeGPU.h"
+#include "CGVTables.h"
 #include "CodeGenFunction.h"
 #include "CodeGenPGO.h"
 #include "ConstantEmitter.h"
@@ -341,7 +342,8 @@ CodeGenModule::CodeGenModule(ASTContext &C,
     : Context(C), LangOpts(C.getLangOpts()), FS(FS), HeaderSearchOpts(HSO),
       PreprocessorOpts(PPO), CodeGenOpts(CGO), TheModule(M), Diags(diags),
       Target(C.getTargetInfo()), ABI(createCXXABI(*this)),
-      VMContext(M.getContext()), VTables(*this), StackHandler(diags),
+      VMContext(M.getContext()),
+      VTables(std::make_unique<CodeGenVTables>(*this)), StackHandler(diags),
       SanitizerMD(new SanitizerMetadata(*this)),
       AtomicOpts(Target.getAtomicOpts()) {
 
@@ -3357,7 +3359,7 @@ void CodeGenModule::EmitVTablesOpportunistically() {
     assert(getVTables().isVTableExternal(RD) &&
            "This queue should only contain external vtables");
     if (getCXXABI().canSpeculativelyEmitVTable(RD))
-      VTables.GenerateClassData(RD);
+      VTables->GenerateClassData(RD);
   }
   OpportunisticVTables.clear();
 }

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -13,7 +13,6 @@
 #ifndef LLVM_CLANG_LIB_CODEGEN_CODEGENMODULE_H
 #define LLVM_CLANG_LIB_CODEGEN_CODEGENMODULE_H
 
-#include "CGVTables.h"
 #include "CodeGenTypeCache.h"
 #include "CodeGenTypes.h"
 #include "SanitizerMetadata.h"
@@ -22,6 +21,7 @@
 #include "clang/AST/DeclOpenMP.h"
 #include "clang/AST/GlobalDecl.h"
 #include "clang/AST/Mangle.h"
+#include "clang/AST/TypeOrdering.h"
 #include "clang/Basic/ABI.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Basic/NoSanitizeList.h"
@@ -61,6 +61,7 @@ class ASTContext;
 class AtomicType;
 class FunctionDecl;
 class IdentifierInfo;
+class ItaniumVTableContext;
 class ObjCImplementationDecl;
 class ObjCEncodeExpr;
 class BlockExpr;
@@ -69,10 +70,12 @@ class Decl;
 class Expr;
 class Stmt;
 class StringLiteral;
+class MicrosoftVTableContext;
 class NamedDecl;
 class PointerAuthSchema;
 class ValueDecl;
 class VarDecl;
+class VTableLayout;
 class LangOptions;
 class CodeGenOptions;
 class HeaderSearchOptions;
@@ -87,6 +90,7 @@ namespace CodeGen {
 
 class CodeGenFunction;
 class CodeGenTBAA;
+class CodeGenVTables;
 class CGCXXABI;
 class CGDebugInfo;
 class CGObjCRuntime;
@@ -368,7 +372,7 @@ private:
   std::unique_ptr<CodeGenTypes> Types;
 
   /// Holds information about C++ vtables.
-  CodeGenVTables VTables;
+  std::unique_ptr<CodeGenVTables> VTables;
 
   std::unique_ptr<CGObjCRuntime> ObjCRuntime;
   std::unique_ptr<CGOpenCLRuntime> OpenCLRuntime;
@@ -845,19 +849,11 @@ public:
 
   CodeGenTypes &getTypes() { return *Types; }
 
-  CodeGenVTables &getVTables() { return VTables; }
+  CodeGenVTables &getVTables() { return *VTables; }
 
-  ItaniumVTableContext &getItaniumVTableContext() {
-    return VTables.getItaniumVTableContext();
-  }
-
-  const ItaniumVTableContext &getItaniumVTableContext() const {
-    return VTables.getItaniumVTableContext();
-  }
-
-  MicrosoftVTableContext &getMicrosoftVTableContext() {
-    return VTables.getMicrosoftVTableContext();
-  }
+  ItaniumVTableContext &getItaniumVTableContext();
+  const ItaniumVTableContext &getItaniumVTableContext() const;
+  MicrosoftVTableContext &getMicrosoftVTableContext();
 
   CtorList &getGlobalCtors() { return GlobalCtors; }
   CtorList &getGlobalDtors() { return GlobalDtors; }

--- a/clang/lib/CodeGen/SwiftCallingConv.cpp
+++ b/clang/lib/CodeGen/SwiftCallingConv.cpp
@@ -14,6 +14,7 @@
 #include "ABIInfo.h"
 #include "CodeGenModule.h"
 #include "TargetInfo.h"
+#include "clang/AST/RecordLayout.h"
 #include "clang/Basic/TargetInfo.h"
 
 using namespace clang;

--- a/clang/lib/CodeGen/Targets/ARM.cpp
+++ b/clang/lib/CodeGen/Targets/ARM.cpp
@@ -8,6 +8,7 @@
 
 #include "ABIInfoImpl.h"
 #include "TargetInfo.h"
+#include "clang/AST/RecordLayout.h"
 
 using namespace clang;
 using namespace clang::CodeGen;

--- a/clang/lib/CodeGen/Targets/LoongArch.cpp
+++ b/clang/lib/CodeGen/Targets/LoongArch.cpp
@@ -8,6 +8,7 @@
 
 #include "ABIInfoImpl.h"
 #include "TargetInfo.h"
+#include "clang/AST/RecordLayout.h"
 
 using namespace clang;
 using namespace clang::CodeGen;

--- a/clang/lib/CodeGen/Targets/Mips.cpp
+++ b/clang/lib/CodeGen/Targets/Mips.cpp
@@ -8,6 +8,7 @@
 
 #include "ABIInfoImpl.h"
 #include "TargetInfo.h"
+#include "clang/AST/RecordLayout.h"
 
 using namespace clang;
 using namespace clang::CodeGen;

--- a/clang/lib/CodeGen/Targets/RISCV.cpp
+++ b/clang/lib/CodeGen/Targets/RISCV.cpp
@@ -8,6 +8,7 @@
 
 #include "ABIInfoImpl.h"
 #include "TargetInfo.h"
+#include "clang/AST/RecordLayout.h"
 #include "llvm/TargetParser/RISCVTargetParser.h"
 
 using namespace clang;

--- a/clang/lib/CodeGen/Targets/X86.cpp
+++ b/clang/lib/CodeGen/Targets/X86.cpp
@@ -8,6 +8,7 @@
 
 #include "ABIInfoImpl.h"
 #include "TargetInfo.h"
+#include "clang/AST/RecordLayout.h"
 #include "clang/Basic/DiagnosticFrontend.h"
 #include "llvm/ADT/SmallBitVector.h"
 


### PR DESCRIPTION
Avoid pulling in the CVTables.h header in CodeGenModules.h by putting the member behind a unique_ptr.

This had less impact than I was hoping, with only a 0.15% reduction in build time for clang. Apparently the expensive parts of CGVTables.h still get included via other pathways.