### PR TITLE
[Tooling] Handle AttributedType in getFullyQualifiedType

### DIFF
--- a/clang/lib/AST/QualTypeNames.cpp
+++ b/clang/lib/AST/QualTypeNames.cpp
@@ -417,7 +417,7 @@ QualType getFullyQualifiedType(QualType QT, const ASTContext &Ctx,
     return QT;
   }
 
-  // Handle types that have attributes attached such as `unique_ptr<int> _Nonnull`.
+  // Handle types with attributes such as `unique_ptr<int> _Nonnull`.
   if (auto *AT = dyn_cast<AttributedType>(QT.getTypePtr())) {
     QualType NewModified =
         getFullyQualifiedType(AT->getModifiedType(), Ctx, WithGlobalNsPrefix);

--- a/clang/lib/AST/QualTypeNames.cpp
+++ b/clang/lib/AST/QualTypeNames.cpp
@@ -417,6 +417,15 @@ QualType getFullyQualifiedType(QualType QT, const ASTContext &Ctx,
     return QT;
   }
 
+  // Handle types that have attributes attached such as `unique_ptr<int> _Nonnull`.
+  if (auto *AT = dyn_cast<AttributedType>(QT.getTypePtr())) {
+    QualType NewModified =
+        getFullyQualifiedType(AT->getModifiedType(), Ctx, WithGlobalNsPrefix);
+    QualType NewEquivalent =
+        getFullyQualifiedType(AT->getEquivalentType(), Ctx, WithGlobalNsPrefix);
+    return Ctx.getAttributedType(AT->getAttrKind(), NewModified, NewEquivalent);
+  }
+
   // Remove the part of the type related to the type being a template
   // parameter (we won't report it as part of the 'type name' and it
   // is actually make the code below to be more complex (to handle

--- a/clang/lib/AST/QualTypeNames.cpp
+++ b/clang/lib/AST/QualTypeNames.cpp
@@ -10,6 +10,7 @@
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/DeclarationName.h"
 #include "clang/AST/Mangle.h"
+#include "clang/AST/Type.h"
 
 namespace clang {
 
@@ -423,7 +424,10 @@ QualType getFullyQualifiedType(QualType QT, const ASTContext &Ctx,
         getFullyQualifiedType(AT->getModifiedType(), Ctx, WithGlobalNsPrefix);
     QualType NewEquivalent =
         getFullyQualifiedType(AT->getEquivalentType(), Ctx, WithGlobalNsPrefix);
-    return Ctx.getAttributedType(AT->getAttrKind(), NewModified, NewEquivalent);
+    Qualifiers Qualifiers = QT.getLocalQualifiers();
+    return Ctx.getQualifiedType(
+        Ctx.getAttributedType(AT->getAttrKind(), NewModified, NewEquivalent),
+        Qualifiers);
   }
 
   // Remove the part of the type related to the type being a template

--- a/clang/unittests/Tooling/QualTypeNamesTest.cpp
+++ b/clang/unittests/Tooling/QualTypeNamesTest.cpp
@@ -297,4 +297,21 @@ TEST(QualTypeNameTest, ConstUsing) {
                         using ::A::S;
                         void foo(const S& param1, const S param2);)");
 }
+
+TEST(QualTypeNameTest, NullableAttributesWithGlobalNs) {
+  TypeNameVisitor Visitor;
+  Visitor.WithGlobalNsPrefix = true;
+  Visitor.ExpectedQualTypeNames["param1"] = "::std::unique_ptr<int> _Nullable";
+  Visitor.ExpectedQualTypeNames["param2"] = "::std::unique_ptr<int> _Nonnull";
+  Visitor.ExpectedQualTypeNames["param3"] =
+      "::std::unique_ptr< ::std::unique_ptr<int> _Nullable> _Nonnull";
+  Visitor.runOver(R"(namespace std {
+                        template<class T> class unique_ptr {};
+                     }
+                     void foo(
+                      std::unique_ptr<int> _Nullable param1,
+                      _Nonnull std::unique_ptr<int> param2,
+                      std::unique_ptr<std::unique_ptr<int> _Nullable> _Nonnull param3);
+                     )");
+}
 }  // end anonymous namespace

--- a/clang/unittests/Tooling/QualTypeNamesTest.cpp
+++ b/clang/unittests/Tooling/QualTypeNamesTest.cpp
@@ -305,13 +305,23 @@ TEST(QualTypeNameTest, NullableAttributesWithGlobalNs) {
   Visitor.ExpectedQualTypeNames["param2"] = "::std::unique_ptr<int> _Nonnull";
   Visitor.ExpectedQualTypeNames["param3"] =
       "::std::unique_ptr< ::std::unique_ptr<int> _Nullable> _Nonnull";
+  Visitor.ExpectedQualTypeNames["param4"] =
+      "::std::unique_ptr<int>  _Nullable const *";
+  Visitor.ExpectedQualTypeNames["param5"] =
+      "::std::unique_ptr<int>  _Nullable const *";
+  Visitor.ExpectedQualTypeNames["param6"] =
+      "::std::unique_ptr<int>  _Nullable const *";
   Visitor.runOver(R"(namespace std {
                         template<class T> class unique_ptr {};
                      }
                      void foo(
                       std::unique_ptr<int> _Nullable param1,
                       _Nonnull std::unique_ptr<int> param2,
-                      std::unique_ptr<std::unique_ptr<int> _Nullable> _Nonnull param3);
+                      std::unique_ptr<std::unique_ptr<int> _Nullable> _Nonnull param3,
+                      const std::unique_ptr<int> _Nullable *param4,
+                      _Nullable std::unique_ptr<int> const *param5,
+                      std::unique_ptr<int> _Nullable const *param6
+                      );
                      )");
 }
 }  // end anonymous namespace


### PR DESCRIPTION
Before this change the code used to add extra qualifiers, e.g.
`std::unique_ptr<int> _Nonnull` became `::std::std::unique_ptr<int> _Nonnull`
when adding a global namespace qualifier was requested.