### PR TITLE
Reapply "[lldb] Return *const* UnwindPlan pointers from FuncUnwinders "

### DIFF
--- a/lldb/include/lldb/Symbol/FuncUnwinders.h
+++ b/lldb/include/lldb/Symbol/FuncUnwinders.h
@@ -36,18 +36,19 @@ public:
 
   ~FuncUnwinders();
 
-  lldb::UnwindPlanSP GetUnwindPlanAtCallSite(Target &target, Thread &thread);
+  std::shared_ptr<const UnwindPlan> GetUnwindPlanAtCallSite(Target &target,
+                                                            Thread &thread);
 
-  lldb::UnwindPlanSP GetUnwindPlanAtNonCallSite(Target &target,
-                                                lldb_private::Thread &thread);
+  std::shared_ptr<const UnwindPlan>
+  GetUnwindPlanAtNonCallSite(Target &target, lldb_private::Thread &thread);
 
-  lldb::UnwindPlanSP GetUnwindPlanFastUnwind(Target &target,
-                                             lldb_private::Thread &thread);
+  std::shared_ptr<const UnwindPlan>
+  GetUnwindPlanFastUnwind(Target &target, lldb_private::Thread &thread);
 
-  lldb::UnwindPlanSP
+  std::shared_ptr<const UnwindPlan>
   GetUnwindPlanArchitectureDefault(lldb_private::Thread &thread);
 
-  lldb::UnwindPlanSP
+  std::shared_ptr<const UnwindPlan>
   GetUnwindPlanArchitectureDefaultAtFunctionEntry(lldb_private::Thread &thread);
 
   Address &GetFirstNonPrologueInsn(Target &target);
@@ -77,32 +78,34 @@ public:
   // used. Instead, clients should ask for the *behavior* they are looking for,
   // using one of the above UnwindPlan retrieval methods.
 
-  lldb::UnwindPlanSP GetAssemblyUnwindPlan(Target &target, Thread &thread);
+  std::shared_ptr<const UnwindPlan> GetAssemblyUnwindPlan(Target &target,
+                                                          Thread &thread);
 
-  lldb::UnwindPlanSP GetObjectFileUnwindPlan(Target &target);
+  std::shared_ptr<const UnwindPlan> GetObjectFileUnwindPlan(Target &target);
 
-  lldb::UnwindPlanSP GetObjectFileAugmentedUnwindPlan(Target &target,
-                                                      Thread &thread);
+  std::shared_ptr<const UnwindPlan>
+  GetObjectFileAugmentedUnwindPlan(Target &target, Thread &thread);
 
-  lldb::UnwindPlanSP GetEHFrameUnwindPlan(Target &target);
+  std::shared_ptr<const UnwindPlan> GetEHFrameUnwindPlan(Target &target);
 
-  lldb::UnwindPlanSP GetEHFrameAugmentedUnwindPlan(Target &target,
-                                                   Thread &thread);
+  std::shared_ptr<const UnwindPlan>
+  GetEHFrameAugmentedUnwindPlan(Target &target, Thread &thread);
 
-  lldb::UnwindPlanSP GetDebugFrameUnwindPlan(Target &target);
+  std::shared_ptr<const UnwindPlan> GetDebugFrameUnwindPlan(Target &target);
 
-  lldb::UnwindPlanSP GetDebugFrameAugmentedUnwindPlan(Target &target,
-                                                      Thread &thread);
+  std::shared_ptr<const UnwindPlan>
+  GetDebugFrameAugmentedUnwindPlan(Target &target, Thread &thread);
 
-  lldb::UnwindPlanSP GetCompactUnwindUnwindPlan(Target &target);
+  std::shared_ptr<const UnwindPlan> GetCompactUnwindUnwindPlan(Target &target);
 
-  lldb::UnwindPlanSP GetArmUnwindUnwindPlan(Target &target);
+  std::shared_ptr<const UnwindPlan> GetArmUnwindUnwindPlan(Target &target);
 
-  lldb::UnwindPlanSP GetSymbolFileUnwindPlan(Thread &thread);
+  std::shared_ptr<const UnwindPlan> GetSymbolFileUnwindPlan(Thread &thread);
 
-  lldb::UnwindPlanSP GetArchDefaultUnwindPlan(Thread &thread);
+  std::shared_ptr<const UnwindPlan> GetArchDefaultUnwindPlan(Thread &thread);
 
-  lldb::UnwindPlanSP GetArchDefaultAtFuncEntryUnwindPlan(Thread &thread);
+  std::shared_ptr<const UnwindPlan>
+  GetArchDefaultAtFuncEntryUnwindPlan(Thread &thread);
 
 private:
   lldb::UnwindAssemblySP GetUnwindAssemblyProfiler(Target &target);
@@ -113,7 +116,8 @@ private:
   // unwind rule for the pc, and LazyBoolCalculate if it was unable to
   // determine this for some reason.
   lldb_private::LazyBool CompareUnwindPlansForIdenticalInitialPCLocation(
-      Thread &thread, const lldb::UnwindPlanSP &a, const lldb::UnwindPlanSP &b);
+      Thread &thread, const std::shared_ptr<const UnwindPlan> &a,
+      const std::shared_ptr<const UnwindPlan> &b);
 
   UnwindTable &m_unwind_table;
 
@@ -129,22 +133,22 @@ private:
 
   std::recursive_mutex m_mutex;
 
-  lldb::UnwindPlanSP m_unwind_plan_assembly_sp;
-  lldb::UnwindPlanSP m_unwind_plan_object_file_sp;
-  lldb::UnwindPlanSP m_unwind_plan_eh_frame_sp;
-  lldb::UnwindPlanSP m_unwind_plan_debug_frame_sp;
+  std::shared_ptr<const UnwindPlan> m_unwind_plan_assembly_sp;
+  std::shared_ptr<const UnwindPlan> m_unwind_plan_object_file_sp;
+  std::shared_ptr<const UnwindPlan> m_unwind_plan_eh_frame_sp;
+  std::shared_ptr<const UnwindPlan> m_unwind_plan_debug_frame_sp;
 
   // augmented by assembly inspection so it's valid everywhere
-  lldb::UnwindPlanSP m_unwind_plan_object_file_augmented_sp;
-  lldb::UnwindPlanSP m_unwind_plan_eh_frame_augmented_sp;
-  lldb::UnwindPlanSP m_unwind_plan_debug_frame_augmented_sp;
+  std::shared_ptr<const UnwindPlan> m_unwind_plan_object_file_augmented_sp;
+  std::shared_ptr<const UnwindPlan> m_unwind_plan_eh_frame_augmented_sp;
+  std::shared_ptr<const UnwindPlan> m_unwind_plan_debug_frame_augmented_sp;
 
-  std::vector<lldb::UnwindPlanSP> m_unwind_plan_compact_unwind;
-  lldb::UnwindPlanSP m_unwind_plan_arm_unwind_sp;
-  lldb::UnwindPlanSP m_unwind_plan_symbol_file_sp;
-  lldb::UnwindPlanSP m_unwind_plan_fast_sp;
-  lldb::UnwindPlanSP m_unwind_plan_arch_default_sp;
-  lldb::UnwindPlanSP m_unwind_plan_arch_default_at_func_entry_sp;
+  std::vector<std::shared_ptr<const UnwindPlan>> m_unwind_plan_compact_unwind;
+  std::shared_ptr<const UnwindPlan> m_unwind_plan_arm_unwind_sp;
+  std::shared_ptr<const UnwindPlan> m_unwind_plan_symbol_file_sp;
+  std::shared_ptr<const UnwindPlan> m_unwind_plan_fast_sp;
+  std::shared_ptr<const UnwindPlan> m_unwind_plan_arch_default_sp;
+  std::shared_ptr<const UnwindPlan> m_unwind_plan_arch_default_at_func_entry_sp;
 
   // Fetching the UnwindPlans can be expensive - if we've already attempted to
   // get one & failed, don't try again.

--- a/lldb/include/lldb/Symbol/UnwindPlan.h
+++ b/lldb/include/lldb/Symbol/UnwindPlan.h
@@ -482,7 +482,7 @@ public:
     m_return_addr_register = regnum;
   }
 
-  uint32_t GetReturnAddressRegister() { return m_return_addr_register; }
+  uint32_t GetReturnAddressRegister() const { return m_return_addr_register; }
 
   uint32_t GetInitialCFARegister() const {
     if (m_row_list.empty())
@@ -497,7 +497,7 @@ public:
     m_plan_valid_ranges = std::move(ranges);
   }
 
-  bool PlanValidAtAddress(Address addr);
+  bool PlanValidAtAddress(Address addr) const;
 
   bool IsValidRowIndex(uint32_t idx) const;
 

--- a/lldb/include/lldb/Target/RegisterContextUnwind.h
+++ b/lldb/include/lldb/Target/RegisterContextUnwind.h
@@ -127,7 +127,8 @@ private:
 
   /// Check if the given unwind plan indicates a signal trap handler, and
   /// update frame type and symbol context if so.
-  void PropagateTrapHandlerFlagFromUnwindPlan(lldb::UnwindPlanSP unwind_plan);
+  void PropagateTrapHandlerFlagFromUnwindPlan(
+      std::shared_ptr<const UnwindPlan> unwind_plan);
 
   // Provide a location for where THIS function saved the CALLER's register
   // value
@@ -194,16 +195,17 @@ private:
                         const UnwindPlan::Row::FAValue &fa,
                         lldb::addr_t &address);
 
-  lldb::UnwindPlanSP GetFastUnwindPlanForFrame();
+  std::shared_ptr<const UnwindPlan> GetFastUnwindPlanForFrame();
 
-  lldb::UnwindPlanSP GetFullUnwindPlanForFrame();
+  std::shared_ptr<const UnwindPlan> GetFullUnwindPlanForFrame();
 
   void UnwindLogMsg(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 
   void UnwindLogMsgVerbose(const char *fmt, ...)
       __attribute__((format(printf, 2, 3)));
 
-  bool IsUnwindPlanValidForCurrentPC(lldb::UnwindPlanSP unwind_plan_sp);
+  bool IsUnwindPlanValidForCurrentPC(
+      std::shared_ptr<const UnwindPlan> unwind_plan_sp);
 
   lldb::addr_t GetReturnAddressHint(int32_t plan_offset);
 
@@ -215,9 +217,9 @@ private:
   // i.e. where THIS frame saved them
   ///
 
-  lldb::UnwindPlanSP m_fast_unwind_plan_sp; // may be NULL
-  lldb::UnwindPlanSP m_full_unwind_plan_sp;
-  lldb::UnwindPlanSP m_fallback_unwind_plan_sp; // may be NULL
+  std::shared_ptr<const UnwindPlan> m_fast_unwind_plan_sp; // may be NULL
+  std::shared_ptr<const UnwindPlan> m_full_unwind_plan_sp;
+  std::shared_ptr<const UnwindPlan> m_fallback_unwind_plan_sp; // may be NULL
 
   bool m_all_registers_available; // Can we retrieve all regs or just
                                   // nonvolatile regs?

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -3641,77 +3641,70 @@ protected:
 
       result.GetOutputStream().Printf("\n");
 
-      UnwindPlanSP non_callsite_unwind_plan =
-          func_unwinders_sp->GetUnwindPlanAtNonCallSite(*target, *thread);
-      if (non_callsite_unwind_plan) {
+      if (std::shared_ptr<const UnwindPlan> plan_sp =
+              func_unwinders_sp->GetUnwindPlanAtNonCallSite(*target, *thread)) {
         result.GetOutputStream().Printf(
             "Asynchronous (not restricted to call-sites) UnwindPlan is '%s'\n",
-            non_callsite_unwind_plan->GetSourceName().AsCString());
+            plan_sp->GetSourceName().AsCString());
       }
-      UnwindPlanSP callsite_unwind_plan =
-          func_unwinders_sp->GetUnwindPlanAtCallSite(*target, *thread);
-      if (callsite_unwind_plan) {
+      if (std::shared_ptr<const UnwindPlan> plan_sp =
+              func_unwinders_sp->GetUnwindPlanAtCallSite(*target, *thread)) {
         result.GetOutputStream().Printf(
             "Synchronous (restricted to call-sites) UnwindPlan is '%s'\n",
-            callsite_unwind_plan->GetSourceName().AsCString());
+            plan_sp->GetSourceName().AsCString());
       }
-      UnwindPlanSP fast_unwind_plan =
-          func_unwinders_sp->GetUnwindPlanFastUnwind(*target, *thread);
-      if (fast_unwind_plan) {
-        result.GetOutputStream().Printf(
-            "Fast UnwindPlan is '%s'\n",
-            fast_unwind_plan->GetSourceName().AsCString());
+      if (std::shared_ptr<const UnwindPlan> plan_sp =
+              func_unwinders_sp->GetUnwindPlanFastUnwind(*target, *thread)) {
+        result.GetOutputStream().Printf("Fast UnwindPlan is '%s'\n",
+                                        plan_sp->GetSourceName().AsCString());
       }
 
       result.GetOutputStream().Printf("\n");
 
-      UnwindPlanSP assembly_sp =
-          func_unwinders_sp->GetAssemblyUnwindPlan(*target, *thread);
-      if (assembly_sp) {
+      if (std::shared_ptr<const UnwindPlan> plan_sp =
+              func_unwinders_sp->GetAssemblyUnwindPlan(*target, *thread)) {
         result.GetOutputStream().Printf(
             "Assembly language inspection UnwindPlan:\n");
-        assembly_sp->Dump(result.GetOutputStream(), thread.get(),
-                          LLDB_INVALID_ADDRESS);
+        plan_sp->Dump(result.GetOutputStream(), thread.get(),
+                      LLDB_INVALID_ADDRESS);
         result.GetOutputStream().Printf("\n");
       }
 
-      UnwindPlanSP of_unwind_sp =
-          func_unwinders_sp->GetObjectFileUnwindPlan(*target);
-      if (of_unwind_sp) {
+      if (std::shared_ptr<const UnwindPlan> plan_sp =
+              func_unwinders_sp->GetObjectFileUnwindPlan(*target)) {
         result.GetOutputStream().Printf("object file UnwindPlan:\n");
-        of_unwind_sp->Dump(result.GetOutputStream(), thread.get(),
-                           LLDB_INVALID_ADDRESS);
+        plan_sp->Dump(result.GetOutputStream(), thread.get(),
+                      LLDB_INVALID_ADDRESS);
         result.GetOutputStream().Printf("\n");
       }
 
-      UnwindPlanSP of_unwind_augmented_sp =
-          func_unwinders_sp->GetObjectFileAugmentedUnwindPlan(*target, *thread);
-      if (of_unwind_augmented_sp) {
+      if (std::shared_ptr<const UnwindPlan> plan_sp =
+              func_unwinders_sp->GetObjectFileAugmentedUnwindPlan(*target,
+                                                                  *thread)) {
         result.GetOutputStream().Printf("object file augmented UnwindPlan:\n");
-        of_unwind_augmented_sp->Dump(result.GetOutputStream(), thread.get(),
-                                     LLDB_INVALID_ADDRESS);
+        plan_sp->Dump(result.GetOutputStream(), thread.get(),
+                      LLDB_INVALID_ADDRESS);
         result.GetOutputStream().Printf("\n");
       }
 
-      UnwindPlanSP ehframe_sp =
-          func_unwinders_sp->GetEHFrameUnwindPlan(*target);
-      if (ehframe_sp) {
+      if (std::shared_ptr<const UnwindPlan> plan_sp =
+              func_unwinders_sp->GetEHFrameUnwindPlan(*target)) {
         result.GetOutputStream().Printf("eh_frame UnwindPlan:\n");
-        ehframe_sp->Dump(result.GetOutputStream(), thread.get(),
-                         LLDB_INVALID_ADDRESS);
+        plan_sp->Dump(result.GetOutputStream(), thread.get(),
+                      LLDB_INVALID_ADDRESS);
         result.GetOutputStream().Printf("\n");
       }
 
-      UnwindPlanSP ehframe_augmented_sp =
-          func_unwinders_sp->GetEHFrameAugmentedUnwindPlan(*target, *thread);
-      if (ehframe_augmented_sp) {
+      if (std::shared_ptr<const UnwindPlan> plan_sp =
+              func_unwinders_sp->GetEHFrameAugmentedUnwindPlan(*target,
+                                                               *thread)) {
         result.GetOutputStream().Printf("eh_frame augmented UnwindPlan:\n");
-        ehframe_augmented_sp->Dump(result.GetOutputStream(), thread.get(),
-                                   LLDB_INVALID_ADDRESS);
+        plan_sp->Dump(result.GetOutputStream(), thread.get(),
+                      LLDB_INVALID_ADDRESS);
         result.GetOutputStream().Printf("\n");
       }
 
-      if (UnwindPlanSP plan_sp =
+      if (std::shared_ptr<const UnwindPlan> plan_sp =
               func_unwinders_sp->GetDebugFrameUnwindPlan(*target)) {
         result.GetOutputStream().Printf("debug_frame UnwindPlan:\n");
         plan_sp->Dump(result.GetOutputStream(), thread.get(),
@@ -3719,7 +3712,7 @@ protected:
         result.GetOutputStream().Printf("\n");
       }
 
-      if (UnwindPlanSP plan_sp =
+      if (std::shared_ptr<const UnwindPlan> plan_sp =
               func_unwinders_sp->GetDebugFrameAugmentedUnwindPlan(*target,
                                                                   *thread)) {
         result.GetOutputStream().Printf("debug_frame augmented UnwindPlan:\n");
@@ -3728,36 +3721,35 @@ protected:
         result.GetOutputStream().Printf("\n");
       }
 
-      UnwindPlanSP arm_unwind_sp =
-          func_unwinders_sp->GetArmUnwindUnwindPlan(*target);
-      if (arm_unwind_sp) {
+      if (std::shared_ptr<const UnwindPlan> plan_sp =
+              func_unwinders_sp->GetArmUnwindUnwindPlan(*target)) {
         result.GetOutputStream().Printf("ARM.exidx unwind UnwindPlan:\n");
-        arm_unwind_sp->Dump(result.GetOutputStream(), thread.get(),
-                            LLDB_INVALID_ADDRESS);
+        plan_sp->Dump(result.GetOutputStream(), thread.get(),
+                      LLDB_INVALID_ADDRESS);
         result.GetOutputStream().Printf("\n");
       }
 
-      if (UnwindPlanSP symfile_plan_sp =
+      if (std::shared_ptr<const UnwindPlan> plan_sp =
               func_unwinders_sp->GetSymbolFileUnwindPlan(*thread)) {
         result.GetOutputStream().Printf("Symbol file UnwindPlan:\n");
-        symfile_plan_sp->Dump(result.GetOutputStream(), thread.get(),
-                              LLDB_INVALID_ADDRESS);
+        plan_sp->Dump(result.GetOutputStream(), thread.get(),
+                      LLDB_INVALID_ADDRESS);
         result.GetOutputStream().Printf("\n");
       }
 
-      UnwindPlanSP compact_unwind_sp =
-          func_unwinders_sp->GetCompactUnwindUnwindPlan(*target);
-      if (compact_unwind_sp) {
+      if (std::shared_ptr<const UnwindPlan> plan_sp =
+              func_unwinders_sp->GetCompactUnwindUnwindPlan(*target)) {
         result.GetOutputStream().Printf("Compact unwind UnwindPlan:\n");
-        compact_unwind_sp->Dump(result.GetOutputStream(), thread.get(),
-                                LLDB_INVALID_ADDRESS);
+        plan_sp->Dump(result.GetOutputStream(), thread.get(),
+                      LLDB_INVALID_ADDRESS);
         result.GetOutputStream().Printf("\n");
       }
 
-      if (fast_unwind_plan) {
+      if (std::shared_ptr<const UnwindPlan> plan_sp =
+              func_unwinders_sp->GetUnwindPlanFastUnwind(*target, *thread)) {
         result.GetOutputStream().Printf("Fast UnwindPlan:\n");
-        fast_unwind_plan->Dump(result.GetOutputStream(), thread.get(),
-                               LLDB_INVALID_ADDRESS);
+        plan_sp->Dump(result.GetOutputStream(), thread.get(),
+                      LLDB_INVALID_ADDRESS);
         result.GetOutputStream().Printf("\n");
       }
 

--- a/lldb/source/Symbol/FuncUnwinders.cpp
+++ b/lldb/source/Symbol/FuncUnwinders.cpp
@@ -71,40 +71,47 @@ FuncUnwinders::FuncUnwinders(UnwindTable &unwind_table, Address addr,
 
 FuncUnwinders::~FuncUnwinders() = default;
 
-UnwindPlanSP FuncUnwinders::GetUnwindPlanAtCallSite(Target &target,
-                                                    Thread &thread) {
+std::shared_ptr<const UnwindPlan>
+FuncUnwinders::GetUnwindPlanAtCallSite(Target &target, Thread &thread) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
 
-  if (UnwindPlanSP plan_sp = GetObjectFileUnwindPlan(target))
+  if (std::shared_ptr<const UnwindPlan> plan_sp =
+          GetObjectFileUnwindPlan(target))
     return plan_sp;
-  if (UnwindPlanSP plan_sp = GetSymbolFileUnwindPlan(thread))
+  if (std::shared_ptr<const UnwindPlan> plan_sp =
+          GetSymbolFileUnwindPlan(thread))
     return plan_sp;
-  if (UnwindPlanSP plan_sp = GetDebugFrameUnwindPlan(target))
+  if (std::shared_ptr<const UnwindPlan> plan_sp =
+          GetDebugFrameUnwindPlan(target))
     return plan_sp;
-  if (UnwindPlanSP plan_sp = GetEHFrameUnwindPlan(target))
+  if (std::shared_ptr<const UnwindPlan> plan_sp = GetEHFrameUnwindPlan(target))
     return plan_sp;
-  if (UnwindPlanSP plan_sp = GetCompactUnwindUnwindPlan(target))
+  if (std::shared_ptr<const UnwindPlan> plan_sp =
+          GetCompactUnwindUnwindPlan(target))
     return plan_sp;
-  if (UnwindPlanSP plan_sp = GetArmUnwindUnwindPlan(target))
+  if (std::shared_ptr<const UnwindPlan> plan_sp =
+          GetArmUnwindUnwindPlan(target))
     return plan_sp;
 
   return nullptr;
 }
 
-UnwindPlanSP FuncUnwinders::GetCompactUnwindUnwindPlan(Target &target) {
+std::shared_ptr<const UnwindPlan>
+FuncUnwinders::GetCompactUnwindUnwindPlan(Target &target) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   if (m_unwind_plan_compact_unwind.size() > 0)
     return m_unwind_plan_compact_unwind[0]; // FIXME support multiple compact
                                             // unwind plans for one func
   if (m_tried_unwind_plan_compact_unwind)
-    return UnwindPlanSP();
+    return nullptr;
 
   m_tried_unwind_plan_compact_unwind = true;
   if (m_range.GetBaseAddress().IsValid()) {
     Address current_pc(m_range.GetBaseAddress());
     CompactUnwindInfo *compact_unwind = m_unwind_table.GetCompactUnwindInfo();
     if (compact_unwind) {
-      UnwindPlanSP unwind_plan_sp(new UnwindPlan(lldb::eRegisterKindGeneric));
+      auto unwind_plan_sp =
+          std::make_shared<UnwindPlan>(lldb::eRegisterKindGeneric);
       if (compact_unwind->GetUnwindPlan(target, current_pc, *unwind_plan_sp)) {
         m_unwind_plan_compact_unwind.push_back(unwind_plan_sp);
         return m_unwind_plan_compact_unwind[0]; // FIXME support multiple
@@ -113,10 +120,11 @@ UnwindPlanSP FuncUnwinders::GetCompactUnwindUnwindPlan(Target &target) {
       }
     }
   }
-  return UnwindPlanSP();
+  return nullptr;
 }
 
-lldb::UnwindPlanSP FuncUnwinders::GetObjectFileUnwindPlan(Target &target) {
+std::shared_ptr<const UnwindPlan>
+FuncUnwinders::GetObjectFileUnwindPlan(Target &target) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   if (m_unwind_plan_object_file_sp.get() ||
       m_tried_unwind_plan_object_file)
@@ -126,17 +134,16 @@ lldb::UnwindPlanSP FuncUnwinders::GetObjectFileUnwindPlan(Target &target) {
   if (m_range.GetBaseAddress().IsValid()) {
     CallFrameInfo *object_file_frame = m_unwind_table.GetObjectFileUnwindInfo();
     if (object_file_frame) {
-      m_unwind_plan_object_file_sp =
-          std::make_shared<UnwindPlan>(lldb::eRegisterKindGeneric);
-      if (!object_file_frame->GetUnwindPlan(m_range,
-                                            *m_unwind_plan_object_file_sp))
-        m_unwind_plan_object_file_sp.reset();
+      auto plan_sp = std::make_shared<UnwindPlan>(lldb::eRegisterKindGeneric);
+      if (object_file_frame->GetUnwindPlan(m_range, *plan_sp))
+        m_unwind_plan_object_file_sp = std::move(plan_sp);
     }
   }
   return m_unwind_plan_object_file_sp;
 }
 
-UnwindPlanSP FuncUnwinders::GetEHFrameUnwindPlan(Target &target) {
+std::shared_ptr<const UnwindPlan>
+FuncUnwinders::GetEHFrameUnwindPlan(Target &target) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   if (m_unwind_plan_eh_frame_sp.get() || m_tried_unwind_plan_eh_frame)
     return m_unwind_plan_eh_frame_sp;
@@ -145,16 +152,16 @@ UnwindPlanSP FuncUnwinders::GetEHFrameUnwindPlan(Target &target) {
   if (m_range.GetBaseAddress().IsValid()) {
     DWARFCallFrameInfo *eh_frame = m_unwind_table.GetEHFrameInfo();
     if (eh_frame) {
-      m_unwind_plan_eh_frame_sp =
-          std::make_shared<UnwindPlan>(lldb::eRegisterKindGeneric);
-      if (!eh_frame->GetUnwindPlan(m_range, *m_unwind_plan_eh_frame_sp))
-        m_unwind_plan_eh_frame_sp.reset();
+      auto plan_sp = std::make_shared<UnwindPlan>(lldb::eRegisterKindGeneric);
+      if (eh_frame->GetUnwindPlan(m_range, *plan_sp))
+        m_unwind_plan_eh_frame_sp = std::move(plan_sp);
     }
   }
   return m_unwind_plan_eh_frame_sp;
 }
 
-UnwindPlanSP FuncUnwinders::GetDebugFrameUnwindPlan(Target &target) {
+std::shared_ptr<const UnwindPlan>
+FuncUnwinders::GetDebugFrameUnwindPlan(Target &target) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   if (m_unwind_plan_debug_frame_sp || m_tried_unwind_plan_debug_frame)
     return m_unwind_plan_debug_frame_sp;
@@ -163,16 +170,16 @@ UnwindPlanSP FuncUnwinders::GetDebugFrameUnwindPlan(Target &target) {
   if (m_range.GetBaseAddress().IsValid()) {
     DWARFCallFrameInfo *debug_frame = m_unwind_table.GetDebugFrameInfo();
     if (debug_frame) {
-      m_unwind_plan_debug_frame_sp =
-          std::make_shared<UnwindPlan>(lldb::eRegisterKindGeneric);
-      if (!debug_frame->GetUnwindPlan(m_range, *m_unwind_plan_debug_frame_sp))
-        m_unwind_plan_debug_frame_sp.reset();
+      auto plan_sp = std::make_shared<UnwindPlan>(lldb::eRegisterKindGeneric);
+      if (debug_frame->GetUnwindPlan(m_range, *plan_sp))
+        m_unwind_plan_debug_frame_sp = std::move(plan_sp);
     }
   }
   return m_unwind_plan_debug_frame_sp;
 }
 
-UnwindPlanSP FuncUnwinders::GetArmUnwindUnwindPlan(Target &target) {
+std::shared_ptr<const UnwindPlan>
+FuncUnwinders::GetArmUnwindUnwindPlan(Target &target) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   if (m_unwind_plan_arm_unwind_sp.get() || m_tried_unwind_plan_arm_unwind)
     return m_unwind_plan_arm_unwind_sp;
@@ -182,11 +189,9 @@ UnwindPlanSP FuncUnwinders::GetArmUnwindUnwindPlan(Target &target) {
     Address current_pc(m_range.GetBaseAddress());
     ArmUnwindInfo *arm_unwind_info = m_unwind_table.GetArmUnwindInfo();
     if (arm_unwind_info) {
-      m_unwind_plan_arm_unwind_sp =
-          std::make_shared<UnwindPlan>(lldb::eRegisterKindGeneric);
-      if (!arm_unwind_info->GetUnwindPlan(target, current_pc,
-                                          *m_unwind_plan_arm_unwind_sp))
-        m_unwind_plan_arm_unwind_sp.reset();
+      auto plan_sp = std::make_shared<UnwindPlan>(lldb::eRegisterKindGeneric);
+      if (arm_unwind_info->GetUnwindPlan(target, current_pc, *plan_sp))
+        m_unwind_plan_arm_unwind_sp = std::move(plan_sp);
     }
   }
   return m_unwind_plan_arm_unwind_sp;
@@ -210,7 +215,8 @@ private:
 };
 } // namespace
 
-UnwindPlanSP FuncUnwinders::GetSymbolFileUnwindPlan(Thread &thread) {
+std::shared_ptr<const UnwindPlan>
+FuncUnwinders::GetSymbolFileUnwindPlan(Thread &thread) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   if (m_unwind_plan_symbol_file_sp.get() || m_tried_unwind_plan_symbol_file)
     return m_unwind_plan_symbol_file_sp;
@@ -224,9 +230,9 @@ UnwindPlanSP FuncUnwinders::GetSymbolFileUnwindPlan(Thread &thread) {
   return m_unwind_plan_symbol_file_sp;
 }
 
-UnwindPlanSP
+std::shared_ptr<const UnwindPlan>
 FuncUnwinders::GetObjectFileAugmentedUnwindPlan(Target &target,
-                                                     Thread &thread) {
+                                                Thread &thread) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   if (m_unwind_plan_object_file_augmented_sp.get() ||
       m_tried_unwind_plan_object_file_augmented)
@@ -234,30 +240,27 @@ FuncUnwinders::GetObjectFileAugmentedUnwindPlan(Target &target,
 
   m_tried_unwind_plan_object_file_augmented = true;
 
-  UnwindPlanSP object_file_unwind_plan = GetObjectFileUnwindPlan(target);
+  std::shared_ptr<const UnwindPlan> object_file_unwind_plan =
+      GetObjectFileUnwindPlan(target);
   if (!object_file_unwind_plan)
     return m_unwind_plan_object_file_augmented_sp;
-
-  m_unwind_plan_object_file_augmented_sp =
-      std::make_shared<UnwindPlan>(*object_file_unwind_plan);
 
   // Augment the instructions with epilogue descriptions if necessary
   // so the UnwindPlan can be used at any instruction in the function.
 
   UnwindAssemblySP assembly_profiler_sp(GetUnwindAssemblyProfiler(target));
   if (assembly_profiler_sp) {
-    if (!assembly_profiler_sp->AugmentUnwindPlanFromCallSite(
-            m_range, thread, *m_unwind_plan_object_file_augmented_sp)) {
-      m_unwind_plan_object_file_augmented_sp.reset();
-    }
-  } else {
-    m_unwind_plan_object_file_augmented_sp.reset();
+    auto plan_sp = std::make_shared<UnwindPlan>(*object_file_unwind_plan);
+
+    if (assembly_profiler_sp->AugmentUnwindPlanFromCallSite(m_range, thread,
+                                                            *plan_sp))
+      m_unwind_plan_object_file_augmented_sp = std::move(plan_sp);
   }
   return m_unwind_plan_object_file_augmented_sp;
 }
 
-UnwindPlanSP FuncUnwinders::GetEHFrameAugmentedUnwindPlan(Target &target,
-                                                          Thread &thread) {
+std::shared_ptr<const UnwindPlan>
+FuncUnwinders::GetEHFrameAugmentedUnwindPlan(Target &target, Thread &thread) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   if (m_unwind_plan_eh_frame_augmented_sp.get() ||
       m_tried_unwind_plan_eh_frame_augmented)
@@ -275,30 +278,27 @@ UnwindPlanSP FuncUnwinders::GetEHFrameAugmentedUnwindPlan(Target &target,
 
   m_tried_unwind_plan_eh_frame_augmented = true;
 
-  UnwindPlanSP eh_frame_plan = GetEHFrameUnwindPlan(target);
+  std::shared_ptr<const UnwindPlan> eh_frame_plan =
+      GetEHFrameUnwindPlan(target);
   if (!eh_frame_plan)
     return m_unwind_plan_eh_frame_augmented_sp;
-
-  m_unwind_plan_eh_frame_augmented_sp =
-      std::make_shared<UnwindPlan>(*eh_frame_plan);
 
   // Augment the eh_frame instructions with epilogue descriptions if necessary
   // so the UnwindPlan can be used at any instruction in the function.
 
   UnwindAssemblySP assembly_profiler_sp(GetUnwindAssemblyProfiler(target));
   if (assembly_profiler_sp) {
-    if (!assembly_profiler_sp->AugmentUnwindPlanFromCallSite(
-            m_range, thread, *m_unwind_plan_eh_frame_augmented_sp)) {
-      m_unwind_plan_eh_frame_augmented_sp.reset();
-    }
-  } else {
-    m_unwind_plan_eh_frame_augmented_sp.reset();
+    auto plan_sp = std::make_shared<UnwindPlan>(*eh_frame_plan);
+    if (assembly_profiler_sp->AugmentUnwindPlanFromCallSite(m_range, thread,
+                                                            *plan_sp))
+      m_unwind_plan_eh_frame_augmented_sp = std::move(plan_sp);
   }
   return m_unwind_plan_eh_frame_augmented_sp;
 }
 
-UnwindPlanSP FuncUnwinders::GetDebugFrameAugmentedUnwindPlan(Target &target,
-                                                             Thread &thread) {
+std::shared_ptr<const UnwindPlan>
+FuncUnwinders::GetDebugFrameAugmentedUnwindPlan(Target &target,
+                                                Thread &thread) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   if (m_unwind_plan_debug_frame_augmented_sp.get() ||
       m_tried_unwind_plan_debug_frame_augmented)
@@ -316,12 +316,10 @@ UnwindPlanSP FuncUnwinders::GetDebugFrameAugmentedUnwindPlan(Target &target,
 
   m_tried_unwind_plan_debug_frame_augmented = true;
 
-  UnwindPlanSP debug_frame_plan = GetDebugFrameUnwindPlan(target);
+  std::shared_ptr<const UnwindPlan> debug_frame_plan =
+      GetDebugFrameUnwindPlan(target);
   if (!debug_frame_plan)
     return m_unwind_plan_debug_frame_augmented_sp;
-
-  m_unwind_plan_debug_frame_augmented_sp =
-      std::make_shared<UnwindPlan>(*debug_frame_plan);
 
   // Augment the debug_frame instructions with epilogue descriptions if
   // necessary so the UnwindPlan can be used at any instruction in the
@@ -329,17 +327,17 @@ UnwindPlanSP FuncUnwinders::GetDebugFrameAugmentedUnwindPlan(Target &target,
 
   UnwindAssemblySP assembly_profiler_sp(GetUnwindAssemblyProfiler(target));
   if (assembly_profiler_sp) {
-    if (!assembly_profiler_sp->AugmentUnwindPlanFromCallSite(
-            m_range, thread, *m_unwind_plan_debug_frame_augmented_sp)) {
-      m_unwind_plan_debug_frame_augmented_sp.reset();
-    }
-  } else
-    m_unwind_plan_debug_frame_augmented_sp.reset();
+    auto plan_sp = std::make_shared<UnwindPlan>(*debug_frame_plan);
+
+    if (assembly_profiler_sp->AugmentUnwindPlanFromCallSite(m_range, thread,
+                                                            *plan_sp))
+      m_unwind_plan_debug_frame_augmented_sp = std::move(plan_sp);
+  }
   return m_unwind_plan_debug_frame_augmented_sp;
 }
 
-UnwindPlanSP FuncUnwinders::GetAssemblyUnwindPlan(Target &target,
-                                                  Thread &thread) {
+std::shared_ptr<const UnwindPlan>
+FuncUnwinders::GetAssemblyUnwindPlan(Target &target, Thread &thread) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   if (m_unwind_plan_assembly_sp.get() || m_tried_unwind_plan_assembly ||
       !m_unwind_table.GetAllowAssemblyEmulationUnwindPlans()) {
@@ -360,12 +358,10 @@ UnwindPlanSP FuncUnwinders::GetAssemblyUnwindPlan(Target &target,
 
   UnwindAssemblySP assembly_profiler_sp(GetUnwindAssemblyProfiler(target));
   if (assembly_profiler_sp) {
-    m_unwind_plan_assembly_sp =
-        std::make_shared<UnwindPlan>(lldb::eRegisterKindGeneric);
-    if (!assembly_profiler_sp->GetNonCallSiteUnwindPlanFromAssembly(
-            range, thread, *m_unwind_plan_assembly_sp)) {
-      m_unwind_plan_assembly_sp.reset();
-    }
+    auto plan_sp = std::make_shared<UnwindPlan>(lldb::eRegisterKindGeneric);
+    if (assembly_profiler_sp->GetNonCallSiteUnwindPlanFromAssembly(
+            range, thread, *plan_sp))
+      m_unwind_plan_assembly_sp = std::move(plan_sp);
   }
   return m_unwind_plan_assembly_sp;
 }
@@ -374,7 +370,8 @@ UnwindPlanSP FuncUnwinders::GetAssemblyUnwindPlan(Target &target,
 // If they have the same way of getting the pc value (e.g. "CFA - 8" + "CFA is
 // sp"), then it will return LazyBoolTrue.
 LazyBool FuncUnwinders::CompareUnwindPlansForIdenticalInitialPCLocation(
-    Thread &thread, const UnwindPlanSP &a, const UnwindPlanSP &b) {
+    Thread &thread, const std::shared_ptr<const UnwindPlan> &a,
+    const std::shared_ptr<const UnwindPlan> &b) {
   LazyBool plans_are_identical = eLazyBoolCalculate;
 
   RegisterNumber pc_reg(thread, eRegisterKindGeneric, LLDB_REGNUM_GENERIC_PC);
@@ -404,17 +401,19 @@ LazyBool FuncUnwinders::CompareUnwindPlansForIdenticalInitialPCLocation(
   return plans_are_identical;
 }
 
-UnwindPlanSP FuncUnwinders::GetUnwindPlanAtNonCallSite(Target &target,
-                                                       Thread &thread) {
-  UnwindPlanSP eh_frame_sp = GetEHFrameUnwindPlan(target);
+std::shared_ptr<const UnwindPlan>
+FuncUnwinders::GetUnwindPlanAtNonCallSite(Target &target, Thread &thread) {
+  std::shared_ptr<const UnwindPlan> eh_frame_sp = GetEHFrameUnwindPlan(target);
   if (!eh_frame_sp)
     eh_frame_sp = GetDebugFrameUnwindPlan(target);
   if (!eh_frame_sp)
     eh_frame_sp = GetObjectFileUnwindPlan(target);
-  UnwindPlanSP arch_default_at_entry_sp =
+  std::shared_ptr<const UnwindPlan> arch_default_at_entry_sp =
       GetUnwindPlanArchitectureDefaultAtFunctionEntry(thread);
-  UnwindPlanSP arch_default_sp = GetUnwindPlanArchitectureDefault(thread);
-  UnwindPlanSP assembly_sp = GetAssemblyUnwindPlan(target, thread);
+  std::shared_ptr<const UnwindPlan> arch_default_sp =
+      GetUnwindPlanArchitectureDefault(thread);
+  std::shared_ptr<const UnwindPlan> assembly_sp =
+      GetAssemblyUnwindPlan(target, thread);
 
   // This point of this code is to detect when a function is using a non-
   // standard ABI, and the eh_frame correctly describes that alternate ABI.
@@ -443,20 +442,24 @@ UnwindPlanSP FuncUnwinders::GetUnwindPlanAtNonCallSite(Target &target,
     return eh_frame_sp;
   }
 
-  if (UnwindPlanSP plan_sp = GetSymbolFileUnwindPlan(thread))
+  if (std::shared_ptr<const UnwindPlan> plan_sp =
+          GetSymbolFileUnwindPlan(thread))
     return plan_sp;
-  if (UnwindPlanSP plan_sp = GetDebugFrameAugmentedUnwindPlan(target, thread))
+  if (std::shared_ptr<const UnwindPlan> plan_sp =
+          GetDebugFrameAugmentedUnwindPlan(target, thread))
     return plan_sp;
-  if (UnwindPlanSP plan_sp = GetEHFrameAugmentedUnwindPlan(target, thread))
+  if (std::shared_ptr<const UnwindPlan> plan_sp =
+          GetEHFrameAugmentedUnwindPlan(target, thread))
     return plan_sp;
-  if (UnwindPlanSP plan_sp = GetObjectFileAugmentedUnwindPlan(target, thread))
+  if (std::shared_ptr<const UnwindPlan> plan_sp =
+          GetObjectFileAugmentedUnwindPlan(target, thread))
     return plan_sp;
 
   return assembly_sp;
 }
 
-UnwindPlanSP FuncUnwinders::GetUnwindPlanFastUnwind(Target &target,
-                                                    Thread &thread) {
+std::shared_ptr<const UnwindPlan>
+FuncUnwinders::GetUnwindPlanFastUnwind(Target &target, Thread &thread) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   if (m_unwind_plan_fast_sp.get() || m_tried_unwind_fast)
     return m_unwind_plan_fast_sp;
@@ -465,17 +468,15 @@ UnwindPlanSP FuncUnwinders::GetUnwindPlanFastUnwind(Target &target,
 
   UnwindAssemblySP assembly_profiler_sp(GetUnwindAssemblyProfiler(target));
   if (assembly_profiler_sp) {
-    m_unwind_plan_fast_sp =
-        std::make_shared<UnwindPlan>(lldb::eRegisterKindGeneric);
-    if (!assembly_profiler_sp->GetFastUnwindPlan(m_range, thread,
-                                                 *m_unwind_plan_fast_sp)) {
-      m_unwind_plan_fast_sp.reset();
-    }
+    auto plan_sp = std::make_shared<UnwindPlan>(lldb::eRegisterKindGeneric);
+    if (assembly_profiler_sp->GetFastUnwindPlan(m_range, thread, *plan_sp))
+      m_unwind_plan_fast_sp = std::move(plan_sp);
   }
   return m_unwind_plan_fast_sp;
 }
 
-UnwindPlanSP FuncUnwinders::GetUnwindPlanArchitectureDefault(Thread &thread) {
+std::shared_ptr<const UnwindPlan>
+FuncUnwinders::GetUnwindPlanArchitectureDefault(Thread &thread) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   if (m_unwind_plan_arch_default_sp.get() || m_tried_unwind_arch_default)
     return m_unwind_plan_arch_default_sp;
@@ -491,7 +492,7 @@ UnwindPlanSP FuncUnwinders::GetUnwindPlanArchitectureDefault(Thread &thread) {
   return m_unwind_plan_arch_default_sp;
 }
 
-UnwindPlanSP
+std::shared_ptr<const UnwindPlan>
 FuncUnwinders::GetUnwindPlanArchitectureDefaultAtFunctionEntry(Thread &thread) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   if (m_unwind_plan_arch_default_at_func_entry_sp.get() ||
@@ -540,7 +541,8 @@ FuncUnwinders::GetUnwindAssemblyProfiler(Target &target) {
 Address FuncUnwinders::GetLSDAAddress(Target &target) {
   Address lsda_addr;
 
-  UnwindPlanSP unwind_plan_sp = GetEHFrameUnwindPlan(target);
+  std::shared_ptr<const UnwindPlan> unwind_plan_sp =
+      GetEHFrameUnwindPlan(target);
   if (unwind_plan_sp.get() == nullptr) {
     unwind_plan_sp = GetCompactUnwindUnwindPlan(target);
   }
@@ -556,7 +558,8 @@ Address FuncUnwinders::GetLSDAAddress(Target &target) {
 Address FuncUnwinders::GetPersonalityRoutinePtrAddress(Target &target) {
   Address personality_addr;
 
-  UnwindPlanSP unwind_plan_sp = GetEHFrameUnwindPlan(target);
+  std::shared_ptr<const UnwindPlan> unwind_plan_sp =
+      GetEHFrameUnwindPlan(target);
   if (unwind_plan_sp.get() == nullptr) {
     unwind_plan_sp = GetCompactUnwindUnwindPlan(target);
   }

--- a/lldb/source/Symbol/UnwindPlan.cpp
+++ b/lldb/source/Symbol/UnwindPlan.cpp
@@ -451,7 +451,7 @@ const UnwindPlan::Row *UnwindPlan::GetLastRow() const {
   return m_row_list.back().get();
 }
 
-bool UnwindPlan::PlanValidAtAddress(Address addr) {
+bool UnwindPlan::PlanValidAtAddress(Address addr) const {
   // If this UnwindPlan has no rows, it is an invalid UnwindPlan.
   if (GetRowCount() == 0) {
     Log *log = GetLog(LLDBLog::Unwind);


### PR DESCRIPTION
This reverts commit 094904303d50e0ab14bc5f2586a602f79af95953, reapplying d7afafdbc464e65c56a0a1d77bad426aa7538306 (#133247).

The failure ought to be fixed by
0509932bb6a291ba11253f30c465ab3ad164ae08.