### PR TITLE
[flang] Fix `do concurrent` CLI test for PowerPC

### DIFF
--- a/flang/test/Driver/do_concurrent_to_omp_cli.f90
+++ b/flang/test/Driver/do_concurrent_to_omp_cli.f90
@@ -1,4 +1,4 @@
-! UNSUPPORTED: target=powerpc{{.*}}, system-windows
+! UNSUPPORTED: system-windows
 
 ! RUN: %flang --help | FileCheck %s --check-prefix=FLANG
 
@@ -10,7 +10,7 @@
 ! BBC:      -fdo-concurrent-to-openmp=<string>
 ! BBC-SAME:   Try to map `do concurrent` loops to OpenMP [none|host|device] 
 
-! RUN: %flang -fdo-concurrent-to-openmp=host %s 2>&1 \
+! RUN: %flang -c -fdo-concurrent-to-openmp=host %s 2>&1 \
 ! RUN: | FileCheck %s --check-prefix=OPT
 
 ! OPT: warning: OpenMP is required for lowering `do concurrent` loops to OpenMP.

--- a/flang/test/Driver/do_concurrent_to_omp_cli.f90
+++ b/flang/test/Driver/do_concurrent_to_omp_cli.f90
@@ -1,4 +1,4 @@
-! UNSUPPORTED: system-windows
+! UNSUPPORTED: target=powerpc{{.*}}, system-windows
 
 ! RUN: %flang --help | FileCheck %s --check-prefix=FLANG
 


### PR DESCRIPTION
One of the `do concurrent` tests crashes on PowerPC (see https://github.com/llvm/llvm-project/pull/126026#issuecomment-2775513679). This PR tries to fix the issue by adding the `-c` flag to the test to avoid linking.