### PR TITLE
Update default value of LLVM_ENABLE_TELEMETRY in BUILD.gn to TRUE

### DIFF
--- a/llvm/utils/gn/secondary/llvm/include/llvm/Config/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/include/llvm/Config/BUILD.gn
@@ -292,7 +292,7 @@ write_cmake_config("llvm-config") {
   values = [
     "LLVM_BUILD_LLVM_DYLIB=",
     "LLVM_BUILD_SHARED_LIBS=",
-    "LLVM_ENABLE_TELEMETRY=",
+    "LLVM_ENABLE_TELEMETRY=1",
     "LLVM_DEFAULT_TARGET_TRIPLE=$llvm_target_triple",
     "LLVM_ENABLE_DUMP=",
     "LLVM_ENABLE_HTTPLIB=",


### PR DESCRIPTION
This is to be consistent with the default value in  llvm/CmakeList.txt.