### PR TITLE
Define pointer layout for AVR program address space

### DIFF
--- a/clang/lib/Basic/Targets/AVR.h
+++ b/clang/lib/Basic/Targets/AVR.h
@@ -57,7 +57,8 @@ public:
     Int16Type = SignedInt;
     Char32Type = UnsignedLong;
     SigAtomicType = SignedChar;
-    resetDataLayout("e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8");
+    resetDataLayout(
+        "e-P1-p0:16:8-p1:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8");
   }
 
   void getTargetDefines(const LangOptions &Opts,

--- a/llvm/lib/Target/AVR/AVRTargetMachine.cpp
+++ b/llvm/lib/Target/AVR/AVRTargetMachine.cpp
@@ -27,7 +27,7 @@
 namespace llvm {
 
 static const char *AVRDataLayout =
-    "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8";
+    "e-P1-p0:16:8-p1:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8";
 
 /// Processes a CPU name.
 static StringRef getCPU(StringRef CPU) {

--- a/llvm/test/CodeGen/AVR/block-address-is-in-progmem-space.ll
+++ b/llvm/test/CodeGen/AVR/block-address-is-in-progmem-space.ll
@@ -11,7 +11,7 @@
 ; This would cause a load of uninitialized memory, not even
 ; touching the program's machine code as otherwise desired.
 
-target datalayout = "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8"
+target datalayout = "e-P1-p0:16:8-p1:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8"
 
 ; CHECK-LABEL: load_with_no_forward_reference
 define i8 @load_with_no_forward_reference(i8 %a, i8 %b) {

--- a/llvm/test/CodeGen/AVR/shift-expand.ll
+++ b/llvm/test/CodeGen/AVR/shift-expand.ll
@@ -5,7 +5,7 @@
 ; amount to a loop. These loops avoid generating a (non-existing) builtin such
 ; as __ashlsi3.
 
-target datalayout = "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8"
+target datalayout = "e-P1-p0:16:8-p1:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8"
 target triple = "avr"
 
 define i16 @shl16(i16 %value, i16 %amount) addrspace(1) {

--- a/llvm/test/Transforms/ArgumentPromotion/nonzero-address-spaces.ll
+++ b/llvm/test/Transforms/ArgumentPromotion/nonzero-address-spaces.ll
@@ -4,7 +4,7 @@
 ; ArgumentPromotion should preserve the default function address space
 ; from the data layout.
 
-target datalayout = "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8"
+target datalayout = "e-P1-p0:16:8-p1:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8"
 
 @g = common global i32 0, align 4
 

--- a/llvm/test/Transforms/Attributor/ArgumentPromotion/nonzero-address-spaces.ll
+++ b/llvm/test/Transforms/Attributor/ArgumentPromotion/nonzero-address-spaces.ll
@@ -5,7 +5,7 @@
 ; ArgumentPromotion should preserve the default function address space
 ; from the data layout.
 
-target datalayout = "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8"
+target datalayout = "e-P1-p0:16:8-p1:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8"
 
 @g = common global i32 0, align 4
 

--- a/llvm/test/Transforms/DeadArgElim/nonzero-address-spaces.ll
+++ b/llvm/test/Transforms/DeadArgElim/nonzero-address-spaces.ll
@@ -3,7 +3,7 @@
 ; DeadArgumentElimination should respect the function address space
 ; in the data layout.
 
-target datalayout = "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8"
+target datalayout = "e-P1-p0:16:8-p1:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8"
 
 ; CHECK: define internal i32 @foo() addrspace(1)
 define internal i32 @foo(i32 %x) #0 {


### PR DESCRIPTION
AVR uses separate address spaces for data (0) and program (1) memory, however pointer layout is only defined for address space 0 in the data layout string.

The `p[n]` directive defines pointer layouts where `n` defaults to `0`. When pointer layout is unspecified it defaults to `p[n]:64:64:64`. ([data layout reference](https://llvm.org/docs/LangRef.html#data-layout))

AVR uses 16-bit pointers for both data and program memory (e.g. for function pointers): https://onlinedocs.microchip.com/oxy/GUID-BD1C16C8-7FA3-4D73-A4BE-241EE05EF592-en-US-7/GUID-5F57457F-3E41-400A-B56C-432188906974.html

> Function pointers are 2 bytes in size.