### PR TITLE
[mlir][bazel] Allow `gentbl_cc_library(tbl_outs)` to be a dict.

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -128,10 +128,10 @@ gentbl_cc_library(
 
 gentbl_cc_library(
     name = "TensorEncodingIncGen",
-    tbl_outs = [
+    tbl_outs = {
         "include/mlir/IR/TensorEncInterfaces.h.inc": ["-gen-attr-interface-decls"],
         "include/mlir/IR/TensorEncInterfaces.cpp.inc": ["-gen-attr-interface-defs"],
-    ],
+    },
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/IR/TensorEncoding.td",
     deps = [":TensorOpsTdFiles"],

--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -129,14 +129,8 @@ gentbl_cc_library(
 gentbl_cc_library(
     name = "TensorEncodingIncGen",
     tbl_outs = [
-        (
-            ["-gen-attr-interface-decls"],
-            "include/mlir/IR/TensorEncInterfaces.h.inc",
-        ),
-        (
-            ["-gen-attr-interface-defs"],
-            "include/mlir/IR/TensorEncInterfaces.cpp.inc",
-        ),
+        "include/mlir/IR/TensorEncInterfaces.h.inc": ["-gen-attr-interface-decls"],
+        "include/mlir/IR/TensorEncInterfaces.cpp.inc": ["-gen-attr-interface-defs"],
     ],
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/IR/TensorEncoding.td",

--- a/utils/bazel/llvm-project-overlay/mlir/tblgen.bzl
+++ b/utils/bazel/llvm-project-overlay/mlir/tblgen.bzl
@@ -397,9 +397,9 @@ def gentbl_cc_library(
       name: The name of the generated cc_library rule for use in dependencies.
       tblgen: The binary used to produce the output.
       td_file: The primary table definitions file.
-      tbl_outs: A list of tuples ([opts], out), where each 'opts' is a list of
-        options passed to tblgen, each option being a string, and 'out' is the
-        corresponding output file produced.
+      tbl_outs: Either a dict {out: [opts]} or a list of tuples ([opts], out),
+        where each 'opts' is a list of options passed to tblgen, each option
+        being a string, and 'out' is the corresponding output file produced.
       td_srcs: See gentbl_rule.td_srcs
       includes: See gentbl_rule.includes
       deps: See gentbl_rule.deps
@@ -409,6 +409,8 @@ def gentbl_cc_library(
       **kwargs: Extra keyword arguments to pass to all generated rules.
     """
 
+    if type(tbl_outs) == type({}):
+        tbl_outs = [(v, k) for k, v in tbl_outs.items()]
     filegroup_name = name + "_filegroup"
     gentbl_filegroup(
         name = filegroup_name,


### PR DESCRIPTION
This makes the BUILD file shorter and more readable.
I will follow up with converting the other instances.