### PR TITLE
[AutoUpgrade] Add Default Case to Avoid Path to Assertion (NFCI)

### DIFF
--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -4545,6 +4545,9 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
         Ret = Builder.CreateInsertVector(RetTy, Ret, V, Idx);
       }
       NewCall = dyn_cast<CallInst>(Ret);
+    } else {
+      DefaultCase();
+      return;
     }
     break;
   }
@@ -5015,11 +5018,9 @@ bool llvm::UpgradeDebugInfo(Module &M) {
     if (!BrokenDebugInfo)
       // Everything is ok.
       return false;
-    else {
-      // Diagnose malformed debug info.
-      DiagnosticInfoIgnoringInvalidDebugMetadata Diag(M);
-      M.getContext().diagnose(Diag);
-    }
+    // Diagnose malformed debug info.
+    DiagnosticInfoIgnoringInvalidDebugMetadata Diag(M);
+    M.getContext().diagnose(Diag);
   }
   bool Modified = StripDebugInfo(M);
   if (Modified && Version != DEBUG_METADATA_VERSION) {


### PR DESCRIPTION
We have been running Polyspace on the LLVM codebase and the following path to assertion was flagged.

    1 - Assignment to local pointer 'NewCall' - AutoUpgrade.cpp[4443, 13]
    2 - Entering switch case - AutoUpgrade.cpp[4516, 3]
    3 - Not entering if statement (if-condition false) - AutoUpgrade.cpp[4519, 5]
    4 - Not entering if statement (if-condition false) - AutoUpgrade.cpp[4523, 5]
    5 - Not entering if statement (if-condition false) - AutoUpgrade.cpp[4548, 12]
    6 - Assertion - AutoUpgrade.cpp[4896, 3]

This updated adds a Default Case to avoid the path and removes an unnecessary else after return.