### PR TITLE
[libc++] Fix deployment targets that were incorrectly bumped

### DIFF
--- a/libcxx/include/__configuration/availability.h
+++ b/libcxx/include/__configuration/availability.h
@@ -171,10 +171,10 @@
     __attribute__((availability(driverkit, strict, introduced = 23.0)))
 
 // LLVM 15
-#  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 130400) ||   \
-      (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 160500) || \
-      (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 160500) ||         \
-      (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 90500) ||    \
+#  if (defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 130300) ||   \
+      (defined(__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ < 160300) || \
+      (defined(__ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_TV_OS_VERSION_MIN_REQUIRED__ < 160300) ||         \
+      (defined(__ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_WATCH_OS_VERSION_MIN_REQUIRED__ < 90300) ||    \
       (defined(__ENVIRONMENT_BRIDGE_OS_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_BRIDGE_OS_VERSION_MIN_REQUIRED__ < 70500) ||  \
       (defined(__ENVIRONMENT_DRIVERKIT_VERSION_MIN_REQUIRED__) && __ENVIRONMENT_DRIVERKIT_VERSION_MIN_REQUIRED__ < 220400)
 #    define _LIBCPP_INTRODUCED_IN_LLVM_15 0
@@ -182,10 +182,10 @@
 #    define _LIBCPP_INTRODUCED_IN_LLVM_15 1
 #  endif
 #  define _LIBCPP_INTRODUCED_IN_LLVM_15_ATTRIBUTE                                                                 \
-    __attribute__((availability(macos, strict, introduced = 13.4)))                                               \
-    __attribute__((availability(ios, strict, introduced = 16.5)))                                                 \
-    __attribute__((availability(tvos, strict, introduced = 16.5)))                                                \
-    __attribute__((availability(watchos, strict, introduced = 9.5)))                                              \
+    __attribute__((availability(macos, strict, introduced = 13.3)))                                               \
+    __attribute__((availability(ios, strict, introduced = 16.3)))                                                 \
+    __attribute__((availability(tvos, strict, introduced = 16.3)))                                                \
+    __attribute__((availability(watchos, strict, introduced = 9.3)))                                              \
     __attribute__((availability(bridgeos, strict, introduced = 7.5)))                                             \
     __attribute__((availability(driverkit, strict, introduced = 22.4)))
 


### PR DESCRIPTION
When I introduced the various `_LIBCPP_INTRODUCED_IN_LLVM_XY_ATTRIBUTE` macros in 182f5e9b2f03, I tried to correlate them to the right OS versions, but it seems that I made a few mistakes. This wasn't caught in the CI because we don't test back-deployment that far.

rdar://148405946