### PR TITLE
[Clang] Fix unnecessary extra return block emmited during function epilog after musttail call

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -3897,6 +3897,13 @@ void CodeGenFunction::EmitFunctionEpilog(const CGFunctionInfo &FI,
     return;
   }
 
+  // If there is no valid insert point, we won't emit a return.
+  // The insert point could be null if we have already emitted a return
+  // (e.g. if musttail)
+  if (!HaveInsertPoint()) {
+    return;
+  }
+
   llvm::DebugLoc RetDbgLoc;
   llvm::Value *RV = nullptr;
   QualType RetTy = FI.getReturnType();
@@ -5990,7 +5997,6 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
     else
       Builder.CreateRet(CI);
     Builder.ClearInsertionPoint();
-    EnsureInsertPoint();
     return GetUndefRValue(RetTy);
   }
 

--- a/clang/lib/CodeGen/CGExprComplex.cpp
+++ b/clang/lib/CodeGen/CGExprComplex.cpp
@@ -1491,7 +1491,10 @@ void CodeGenFunction::EmitComplexExprIntoLValue(const Expr *E, LValue dest,
          "Invalid complex expression to emit");
   ComplexExprEmitter Emitter(*this);
   ComplexPairTy Val = Emitter.Visit(const_cast<Expr*>(E));
-  Emitter.EmitStoreOfComplex(Val, dest, isInit);
+  // The insert point may be empty if we have just emmited a 
+  // musttail call.
+  if (HaveInsertPoint())
+    Emitter.EmitStoreOfComplex(Val, dest, isInit);
 }
 
 /// EmitStoreOfComplex - Store a complex number into the specified l-value.

--- a/clang/lib/CodeGen/CGExprComplex.cpp
+++ b/clang/lib/CodeGen/CGExprComplex.cpp
@@ -1491,7 +1491,7 @@ void CodeGenFunction::EmitComplexExprIntoLValue(const Expr *E, LValue dest,
          "Invalid complex expression to emit");
   ComplexExprEmitter Emitter(*this);
   ComplexPairTy Val = Emitter.Visit(const_cast<Expr*>(E));
-  // The insert point may be empty if we have just emmited a 
+  // The insert point may be empty if we have just emmited a
   // musttail call.
   if (HaveInsertPoint())
     Emitter.EmitStoreOfComplex(Val, dest, isInit);


### PR DESCRIPTION
closes #104770.

We clear the insert point after musttail call, and check for this when generating the function epilog. 
We also check for a return point when emitting the return statement for a complex value