### PR TITLE
[DirectX] Implement UseNativeLowPrecision shader flag analysis

### DIFF
--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -287,6 +287,10 @@ void CGHLSLRuntime::finishCodeGen() {
   Triple T(M.getTargetTriple());
   if (T.getArch() == Triple::ArchType::dxil)
     addDxilValVersion(TargetOpts.DxilValidatorVersion, M);
+
+  // NativeHalfType corresponds to the -fnative-half-type clang option which is
+  // aliased by clang-dxc's -enable-16bit-types option. This option is used to
+  // set the UseNativeLowPrecision DXIL module flag in the DirectX backend
   if (LangOpts.NativeHalfType)
     M.setModuleFlag(llvm::Module::ModFlagBehavior::Error, "dx.nativelowprec",
                     1);

--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -288,7 +288,8 @@ void CGHLSLRuntime::finishCodeGen() {
   if (T.getArch() == Triple::ArchType::dxil)
     addDxilValVersion(TargetOpts.DxilValidatorVersion, M);
   if (LangOpts.NativeHalfType)
-    M.setModuleFlag(llvm::Module::ModFlagBehavior::Error, "dx.nativelowprec", 1);
+    M.setModuleFlag(llvm::Module::ModFlagBehavior::Error, "dx.nativelowprec",
+                    1);
 
   generateGlobalCtorDtorCalls();
 }

--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -282,10 +282,13 @@ void CGHLSLRuntime::addHLSLBufferLayoutType(const RecordType *StructType,
 
 void CGHLSLRuntime::finishCodeGen() {
   auto &TargetOpts = CGM.getTarget().getTargetOpts();
+  auto &LangOpts = CGM.getLangOpts();
   llvm::Module &M = CGM.getModule();
   Triple T(M.getTargetTriple());
   if (T.getArch() == Triple::ArchType::dxil)
     addDxilValVersion(TargetOpts.DxilValidatorVersion, M);
+  if (LangOpts.NativeHalfType)
+    M.setModuleFlag(llvm::Module::ModFlagBehavior::Error, "dx.nativelowprec", 1);
 
   generateGlobalCtorDtorCalls();
 }

--- a/clang/test/CodeGenHLSL/enable-16bit-types.hlsl
+++ b/clang/test/CodeGenHLSL/enable-16bit-types.hlsl
@@ -1,7 +1,5 @@
-// RUN: %clang_cc1 -fnative-half-type -finclude-default-header -triple dxil-pc-shadermodel6.3-library -emit-llvm -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=FLAG
-// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.3-library -emit-llvm -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=NOFLAG
-
-// NOTE: -enable-16bit-types is a DXCFlag that aliases -fnative-half-type
+// RUN: %clang_dxc -enable-16bit-types -T lib_6_3 -HV 202x %s | FileCheck %s --check-prefix=FLAG
+// RUN: %clang_dxc -T lib_6_3 -HV 202x %s | FileCheck %s --check-prefix=NOFLAG
 
 // FLAG-DAG: ![[NLP:.*]] = !{i32 1, !"dx.nativelowprec", i32 1}
 // FLAG-DAG: !llvm.module.flags = !{{{.*}}![[NLP]]{{.*}}}

--- a/clang/test/CodeGenHLSL/enable-16bit-types.hlsl
+++ b/clang/test/CodeGenHLSL/enable-16bit-types.hlsl
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -fnative-half-type -finclude-default-header -triple dxil-pc-shadermodel6.3-library -emit-llvm -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=FLAG
+// RUN: %clang_cc1 -finclude-default-header -triple dxil-pc-shadermodel6.3-library -emit-llvm -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=NOFLAG
+
+// NOTE: -enable-16bit-types is a DXCFlag that aliases -fnative-half-type
+
+// FLAG-DAG: ![[NLP:.*]] = !{i32 1, !"dx.nativelowprec", i32 1}
+// FLAG-DAG: !llvm.module.flags = !{{{.*}}![[NLP]]{{.*}}}
+
+// NOFLAG-NOT: dx.nativelowprec

--- a/clang/test/CodeGenHLSL/enable-16bit-types.hlsl
+++ b/clang/test/CodeGenHLSL/enable-16bit-types.hlsl
@@ -1,5 +1,5 @@
-// RUN: %clang_dxc -enable-16bit-types -T lib_6_3 -HV 202x %s | FileCheck %s --check-prefix=FLAG
-// RUN: %clang_dxc -T lib_6_3 -HV 202x %s | FileCheck %s --check-prefix=NOFLAG
+// RUN: %clang_dxc -enable-16bit-types -T lib_6_3 -HV 202x -Vd -Xclang -emit-llvm %s | FileCheck %s --check-prefix=FLAG
+// RUN: %clang_dxc -T lib_6_3 -HV 202x -Vd -Xclang -emit-llvm %s | FileCheck %s --check-prefix=NOFLAG
 
 // FLAG-DAG: ![[NLP:.*]] = !{i32 1, !"dx.nativelowprec", i32 1}
 // FLAG-DAG: !llvm.module.flags = !{{{.*}}![[NLP]]{{.*}}}

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -188,6 +188,12 @@ void ModuleShaderFlags::initialize(Module &M, DXILResourceTypeMap &DRTM,
         continue;
       }
 
+      // Set UseNativeLowPrecision using dx.nativelowprec module metadata
+      if (auto *NativeLowPrec = mdconst::extract_or_null<ConstantInt>(
+              M.getModuleFlag("dx.nativelowprec")))
+        if (NativeLowPrec->getValue() != 0)
+          SCCSF.UseNativeLowPrecision = true;
+
       ComputedShaderFlags CSF;
       for (const auto &BB : *F)
         for (const auto &I : BB)

--- a/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
+++ b/llvm/lib/Target/DirectX/DXILShaderFlags.cpp
@@ -191,7 +191,8 @@ void ModuleShaderFlags::initialize(Module &M, DXILResourceTypeMap &DRTM,
       // Set UseNativeLowPrecision using dx.nativelowprec module metadata
       if (auto *NativeLowPrec = mdconst::extract_or_null<ConstantInt>(
               M.getModuleFlag("dx.nativelowprec")))
-        if (NativeLowPrec->getValue() != 0)
+        if (MMDI.DXILVersion >= VersionTuple(1, 2) &&
+            NativeLowPrec->getValue() != 0)
           SCCSF.UseNativeLowPrecision = true;
 
       ComputedShaderFlags CSF;

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/low-precision.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/low-precision.ll
@@ -1,5 +1,4 @@
 ; RUN: opt -S --passes="print-dx-shader-flags" 2>&1 %s | FileCheck %s
-; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=DXC
 
 target triple = "dxil-pc-shadermodel6.7-library"
 
@@ -13,26 +12,19 @@ target triple = "dxil-pc-shadermodel6.7-library"
 ;CHECK-NEXT: ; Shader Flags for Module Functions
 
 ;CHECK-LABEL: ; Function add_i16 : 0x00000020
-define i16 @add_i16(i16 %a, i16 %b) #0 {
+define i16 @add_i16(i16 %a, i16 %b) {
   %sum = add i16 %a, %b
   ret i16 %sum
 }
 
 ;CHECK-LABEL: ; Function add_i32 : 0x00000000
-define i32 @add_i32(i32 %a, i32 %b) #0 {
+define i32 @add_i32(i32 %a, i32 %b) {
   %sum = add i32 %a, %b
   ret i32 %sum
 }
 
 ;CHECK-LABEL: ; Function add_half : 0x00000020
-define half @add_half(half %a, half %b) #0 {
+define half @add_half(half %a, half %b) {
   %sum = fadd half %a, %b
   ret half %sum
 }
-
-attributes #0 = { convergent norecurse nounwind "hlsl.export"}
-
-; DXC: - Name:            SFI0
-; DXC-NEXT:     Size:            8
-; DXC-NOT:     Flags:
-; DXC: ...

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/use-native-low-precision.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/use-native-low-precision.ll
@@ -1,0 +1,45 @@
+; RUN: opt -S --passes="print-dx-shader-flags" 2>&1 %s | FileCheck %s
+; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=DXC
+
+target triple = "dxil-pc-shadermodel6.7-library"
+
+;CHECK: ; Combined Shader Flags for Module
+;CHECK-NEXT: ; Shader Flags Value: 0x00800020
+;CHECK-NEXT: ;
+;CHECK-NEXT: ; Note: shader requires additional functionality:
+;CHECK-NEXT: ; Note: extra DXIL module flags:
+;CHECK-NEXT: ;       D3D11_1_SB_GLOBAL_FLAG_ENABLE_MINIMUM_PRECISION
+;CHECK-NEXT: ;       Native 16bit types enabled
+;CHECK-NEXT: ;
+;CHECK-NEXT: ; Shader Flags for Module Functions
+
+;CHECK-LABEL: ; Function add_i16 : 0x00800020
+define i16 @add_i16(i16 %a, i16 %b) #0 {
+  %sum = add i16 %a, %b
+  ret i16 %sum
+}
+
+; NOTE: The flag for native low precision is set for every function in the
+; module regardless of whether or not the function uses low precision data
+; types. This matches the behavior in DXC
+;CHECK-LABEL: ; Function add_i32 : 0x00800000
+define i32 @add_i32(i32 %a, i32 %b) #0 {
+  %sum = add i32 %a, %b
+  ret i32 %sum
+}
+
+;CHECK-LABEL: ; Function add_half : 0x00800020
+define half @add_half(half %a, half %b) #0 {
+  %sum = fadd half %a, %b
+  ret half %sum
+}
+
+attributes #0 = { convergent norecurse nounwind "hlsl.export" }
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"dx.nativelowprec", i32 1}
+
+; DXC: - Name:            SFI0
+; DXC-NEXT:     Size:            8
+; DXC-NOT:     Flags:
+; DXC: ...

--- a/llvm/test/CodeGen/DirectX/ShaderFlags/use-native-low-precision.ll
+++ b/llvm/test/CodeGen/DirectX/ShaderFlags/use-native-low-precision.ll
@@ -1,5 +1,4 @@
 ; RUN: opt -S --passes="print-dx-shader-flags" 2>&1 %s | FileCheck %s
-; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=DXC
 
 target triple = "dxil-pc-shadermodel6.7-library"
 
@@ -14,32 +13,25 @@ target triple = "dxil-pc-shadermodel6.7-library"
 ;CHECK-NEXT: ; Shader Flags for Module Functions
 
 ;CHECK-LABEL: ; Function add_i16 : 0x00800020
-define i16 @add_i16(i16 %a, i16 %b) #0 {
+define i16 @add_i16(i16 %a, i16 %b) {
   %sum = add i16 %a, %b
   ret i16 %sum
 }
 
-; NOTE: The flag for native low precision is set for every function in the
-; module regardless of whether or not the function uses low precision data
-; types. This matches the behavior in DXC
+; NOTE: The flag for native low precision (0x80000) is set for every function
+; in the module regardless of whether or not the function uses low precision
+; data types (flag 0x20). This matches the behavior in DXC
 ;CHECK-LABEL: ; Function add_i32 : 0x00800000
-define i32 @add_i32(i32 %a, i32 %b) #0 {
+define i32 @add_i32(i32 %a, i32 %b) {
   %sum = add i32 %a, %b
   ret i32 %sum
 }
 
 ;CHECK-LABEL: ; Function add_half : 0x00800020
-define half @add_half(half %a, half %b) #0 {
+define half @add_half(half %a, half %b) {
   %sum = fadd half %a, %b
   ret half %sum
 }
 
-attributes #0 = { convergent norecurse nounwind "hlsl.export" }
-
 !llvm.module.flags = !{!0}
 !0 = !{i32 1, !"dx.nativelowprec", i32 1}
-
-; DXC: - Name:            SFI0
-; DXC-NEXT:     Size:            8
-; DXC-NOT:     Flags:
-; DXC: ...


### PR DESCRIPTION
Fixes #112267 

Implement the shader flag analysis to set the UseNativeLowPrecision DXIL module flag.

The flag is only able to be set when the command-line flag `-enable-16bit-types` is passed to clang-dxc, or equivalently `-fnative-half-type` is passed to clang.
When the command-line flag is passed, a module metadata flag called "dx.nativelowprec" is set to 1.
The DXILShaderFlags shader flags analysis checks that the module metadata flag "dx.nativelowprec" is set to 1 and the DXIL Version is 1.2 or greater before setting the UseNativeLowPrecision DXIL module flag.