### PR TITLE
[Driver] Generalize the `addFortranRuntimeLibs` function in `PPCLinux.cpp` to all Linux platform.

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -3439,3 +3439,18 @@ void Generic_ELF::addClangTargetOptions(const ArgList &DriverArgs,
                           options::OPT_fno_use_init_array, true))
     CC1Args.push_back("-fno-use-init-array");
 }
+
+void Generic_ELF::addFortranRuntimeLibs(
+    const ArgList &Args, llvm::opt::ArgStringList &CmdArgs) const {
+  // Link static flang_rt.runtime.a or shared flang_rt.runtime.so
+  const char *Path;
+  if (getVFS().exists(Twine(Path = getCompilerRTArgString(
+                                Args, "runtime", ToolChain::FT_Static, true))))
+    CmdArgs.push_back(Path);
+  else if (getVFS().exists(
+               Twine(Path = getCompilerRTArgString(
+                         Args, "runtime", ToolChain::FT_Shared, true))))
+    CmdArgs.push_back(Path);
+  else
+    CmdArgs.push_back("-lflang_rt.runtime");
+}

--- a/clang/lib/Driver/ToolChains/Gnu.h
+++ b/clang/lib/Driver/ToolChains/Gnu.h
@@ -376,6 +376,8 @@ public:
   void addClangTargetOptions(const llvm::opt::ArgList &DriverArgs,
                              llvm::opt::ArgStringList &CC1Args,
                              Action::OffloadKind DeviceOffloadKind) const override;
+  void addFortranRuntimeLibs(const llvm::opt::ArgList &Args,
+                             llvm::opt::ArgStringList &CmdArgs) const override;
 
   virtual std::string getDynamicLinker(const llvm::opt::ArgList &Args) const {
     return {};

--- a/clang/lib/Driver/ToolChains/PPCLinux.cpp
+++ b/clang/lib/Driver/ToolChains/PPCLinux.cpp
@@ -102,18 +102,3 @@ bool PPCLinuxToolChain::SupportIEEEFloat128(
   return GlibcSupportsFloat128((Twine(D.DyldPrefix) + Linker).str()) &&
          !(D.CCCIsCXX() && HasUnsupportedCXXLib);
 }
-
-void PPCLinuxToolChain::addFortranRuntimeLibs(
-    const ArgList &Args, llvm::opt::ArgStringList &CmdArgs) const {
-  // Link static flang_rt.runtime.a or shared flang_rt.runtime.so
-  const char *Path;
-  if (getVFS().exists(Twine(Path = getCompilerRTArgString(
-                                Args, "runtime", ToolChain::FT_Static, true))))
-    CmdArgs.push_back(Path);
-  else if (getVFS().exists(
-               Twine(Path = getCompilerRTArgString(
-                         Args, "runtime", ToolChain::FT_Shared, true))))
-    CmdArgs.push_back(Path);
-  else
-    CmdArgs.push_back("-lflang_rt.runtime");
-}

--- a/clang/lib/Driver/ToolChains/PPCLinux.h
+++ b/clang/lib/Driver/ToolChains/PPCLinux.h
@@ -24,9 +24,6 @@ public:
   AddClangSystemIncludeArgs(const llvm::opt::ArgList &DriverArgs,
                             llvm::opt::ArgStringList &CC1Args) const override;
 
-  void addFortranRuntimeLibs(const llvm::opt::ArgList &Args,
-                             llvm::opt::ArgStringList &CmdArgs) const override;
-
 private:
   bool SupportIEEEFloat128(const Driver &D, const llvm::Triple &Triple,
                            const llvm::opt::ArgList &Args) const;


### PR DESCRIPTION
As suggested in PR #131041, this PR moves the code of `addFortranRuntimeLibs` from `PPCLinux.cpp` to `Gnu.cpp` to generalize it for all Linux platform.