### PR TITLE
[flang][preprocessor] Further macro replacement of continued identifiers

### DIFF
--- a/flang/test/Preprocessing/pp047.F
+++ b/flang/test/Preprocessing/pp047.F
@@ -1,0 +1,25 @@
+! RUN: %flang -E %s 2>&1 | FileCheck %s
+#define FOO BAR
+#define FO BA
+#define OO AR
+! CHECK: print *,BAR, 1
+      print *,
+     +FOO
+     +, 1
+      print *,
+! CHECK: print *,FAR, 2
+     +F
+     +OO
+     +, 2
+! CHECK: print *,BAO, 3
+      print *,
+     +FO
+     +O
+     +, 3
+! CHECK: print *,BAR, 4
+      print *,
+     +F
+     +O
+     +O
+     +, 4
+      end

--- a/flang/test/Preprocessing/pp135.F90
+++ b/flang/test/Preprocessing/pp135.F90
@@ -1,0 +1,25 @@
+! RUN: %flang -E %s 2>&1 | FileCheck %s
+#define FOO BAR
+#define FO BA
+#define OO AR
+! CHECK: print *, BAR, 1
+print *, &
+  &FOO&
+  &, 1
+! CHECK: print *, FAR, 2
+print *, &
+  &F&
+  &OO&
+  &, 2
+! CHECK: print *, BAO, 3
+print *, &
+  &FO&
+  &O&
+  &, 3
+! CHECK: print *, BAR, 4
+print *, &
+  &F&
+  &O&
+  &O&
+  &, 4
+end


### PR DESCRIPTION
The preprocessor can perform macro replacement within identifiers when they are split up with Fortran line continuation, but is failing to do macro replacement on a continued identifier when none of its parts are replaced.