### PR TITLE
[bazel] Fold "${Target}Analysis" targets into their respective CodeGen targets.

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -3371,6 +3371,8 @@ gentbl_cc_library(
         name = target["name"] + "CodeGen",
         srcs = glob(
             [
+                "lib/Target/" + target["name"] + "/Analysis/*.cpp",
+                "lib/Target/" + target["name"] + "/Analysis/*.h",
                 "lib/Target/" + target["name"] + "/GISel/*.cpp",
                 "lib/Target/" + target["name"] + "/GISel/*.h",
                 "lib/Target/" + target["name"] + "/*.cpp",
@@ -3406,7 +3408,6 @@ gentbl_cc_library(
             ":TransformUtils",
             ":Vectorize",
             ":config",
-            ":" + target["name"] + "Analysis",
             ":" + target["name"] + "CommonTableGen",
             ":" + target["name"] + "Info",
             ":" + target["name"] + "UtilsAndDesc",
@@ -3509,24 +3510,6 @@ gentbl_cc_library(
             ":" + target["name"] + "DisassemblerInternalHeaders",
             ":" + target["name"] + "Info",
             ":" + target["name"] + "UtilsAndDesc",
-        ],
-    )],
-    [cc_library(
-        name = target["name"] + "Analysis",
-        srcs = glob(
-            [
-                "lib/Target/" + target["name"] + "/Analysis/*.cpp",
-                "lib/Target/" + target["name"] + "/Analysis/*.h",
-            ],
-            allow_empty = True,
-        ),
-        copts = llvm_copts,
-        features = ["-layering_check"],
-        deps = [
-            ":Analysis",
-            ":Core",
-            ":Support",
-            ":TransformUtils",
         ],
     )],
 ] for target in llvm_target_lib_list]


### PR DESCRIPTION
After 3801bf6164f570a145e3ebd20cf9114782ae0329, SPIRVAnalysis needs to include SPIRV.h provided by SPIRVCodegen, but the CodeGen target already depends on Analysis, so that would cause a circular dependency.

Analysis is a subdirectory of CodeGen so it makes sense as a part of the main CodeGen target too.