### PR TITLE
[NFC][LLVM][AArch64] Cleanup pass initialization for AArch64

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64A53Fix835769.cpp
+++ b/llvm/lib/Target/AArch64/AArch64A53Fix835769.cpp
@@ -81,9 +81,7 @@ class AArch64A53Fix835769 : public MachineFunctionPass {
 
 public:
   static char ID;
-  explicit AArch64A53Fix835769() : MachineFunctionPass(ID) {
-    initializeAArch64A53Fix835769Pass(*PassRegistry::getPassRegistry());
-  }
+  explicit AArch64A53Fix835769() : MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &F) override;
 

--- a/llvm/lib/Target/AArch64/AArch64A57FPLoadBalancing.cpp
+++ b/llvm/lib/Target/AArch64/AArch64A57FPLoadBalancing.cpp
@@ -112,9 +112,7 @@ class AArch64A57FPLoadBalancing : public MachineFunctionPass {
 
 public:
   static char ID;
-  explicit AArch64A57FPLoadBalancing() : MachineFunctionPass(ID) {
-    initializeAArch64A57FPLoadBalancingPass(*PassRegistry::getPassRegistry());
-  }
+  explicit AArch64A57FPLoadBalancing() : MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &F) override;
 

--- a/llvm/lib/Target/AArch64/AArch64AdvSIMDScalarPass.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AdvSIMDScalarPass.cpp
@@ -82,9 +82,7 @@ private:
 
 public:
   static char ID; // Pass identification, replacement for typeid.
-  explicit AArch64AdvSIMDScalar() : MachineFunctionPass(ID) {
-    initializeAArch64AdvSIMDScalarPass(*PassRegistry::getPassRegistry());
-  }
+  explicit AArch64AdvSIMDScalar() : MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &F) override;
 

--- a/llvm/lib/Target/AArch64/AArch64Arm64ECCallLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Arm64ECCallLowering.cpp
@@ -63,9 +63,7 @@ struct ThunkArgInfo {
 class AArch64Arm64ECCallLowering : public ModulePass {
 public:
   static char ID;
-  AArch64Arm64ECCallLowering() : ModulePass(ID) {
-    initializeAArch64Arm64ECCallLoweringPass(*PassRegistry::getPassRegistry());
-  }
+  AArch64Arm64ECCallLowering() : ModulePass(ID) {}
 
   Function *buildExitThunk(FunctionType *FnTy, AttributeList Attrs);
   Function *buildEntryThunk(Function *F);

--- a/llvm/lib/Target/AArch64/AArch64CompressJumpTables.cpp
+++ b/llvm/lib/Target/AArch64/AArch64CompressJumpTables.cpp
@@ -47,9 +47,7 @@ class AArch64CompressJumpTables : public MachineFunctionPass {
 
 public:
   static char ID;
-  AArch64CompressJumpTables() : MachineFunctionPass(ID) {
-    initializeAArch64CompressJumpTablesPass(*PassRegistry::getPassRegistry());
-  }
+  AArch64CompressJumpTables() : MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &MF) override;
 

--- a/llvm/lib/Target/AArch64/AArch64CondBrTuning.cpp
+++ b/llvm/lib/Target/AArch64/AArch64CondBrTuning.cpp
@@ -52,9 +52,7 @@ class AArch64CondBrTuning : public MachineFunctionPass {
 
 public:
   static char ID;
-  AArch64CondBrTuning() : MachineFunctionPass(ID) {
-    initializeAArch64CondBrTuningPass(*PassRegistry::getPassRegistry());
-  }
+  AArch64CondBrTuning() : MachineFunctionPass(ID) {}
   void getAnalysisUsage(AnalysisUsage &AU) const override;
   bool runOnMachineFunction(MachineFunction &MF) override;
   StringRef getPassName() const override { return AARCH64_CONDBR_TUNING_NAME; }

--- a/llvm/lib/Target/AArch64/AArch64ConditionOptimizer.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ConditionOptimizer.cpp
@@ -103,9 +103,7 @@ public:
 
   static char ID;
 
-  AArch64ConditionOptimizer() : MachineFunctionPass(ID) {
-    initializeAArch64ConditionOptimizerPass(*PassRegistry::getPassRegistry());
-  }
+  AArch64ConditionOptimizer() : MachineFunctionPass(ID) {}
 
   void getAnalysisUsage(AnalysisUsage &AU) const override;
   MachineInstr *findSuitableCompare(MachineBasicBlock *MBB);

--- a/llvm/lib/Target/AArch64/AArch64ConditionalCompares.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ConditionalCompares.cpp
@@ -771,9 +771,7 @@ class AArch64ConditionalCompares : public MachineFunctionPass {
 
 public:
   static char ID;
-  AArch64ConditionalCompares() : MachineFunctionPass(ID) {
-    initializeAArch64ConditionalComparesPass(*PassRegistry::getPassRegistry());
-  }
+  AArch64ConditionalCompares() : MachineFunctionPass(ID) {}
   void getAnalysisUsage(AnalysisUsage &AU) const override;
   bool runOnMachineFunction(MachineFunction &MF) override;
   StringRef getPassName() const override {

--- a/llvm/lib/Target/AArch64/AArch64DeadRegisterDefinitionsPass.cpp
+++ b/llvm/lib/Target/AArch64/AArch64DeadRegisterDefinitionsPass.cpp
@@ -40,10 +40,7 @@ private:
   void processMachineBasicBlock(MachineBasicBlock &MBB);
 public:
   static char ID; // Pass identification, replacement for typeid.
-  AArch64DeadRegisterDefinitions() : MachineFunctionPass(ID) {
-    initializeAArch64DeadRegisterDefinitionsPass(
-        *PassRegistry::getPassRegistry());
-  }
+  AArch64DeadRegisterDefinitions() : MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &F) override;
 

--- a/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
@@ -50,9 +50,7 @@ public:
 
   static char ID;
 
-  AArch64ExpandPseudo() : MachineFunctionPass(ID) {
-    initializeAArch64ExpandPseudoPass(*PassRegistry::getPassRegistry());
-  }
+  AArch64ExpandPseudo() : MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &Fn) override;
 

--- a/llvm/lib/Target/AArch64/AArch64LoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/AArch64/AArch64LoadStoreOptimizer.cpp
@@ -124,9 +124,7 @@ using LdStPairFlags = struct LdStPairFlags {
 struct AArch64LoadStoreOpt : public MachineFunctionPass {
   static char ID;
 
-  AArch64LoadStoreOpt() : MachineFunctionPass(ID) {
-    initializeAArch64LoadStoreOptPass(*PassRegistry::getPassRegistry());
-  }
+  AArch64LoadStoreOpt() : MachineFunctionPass(ID) {}
 
   AliasAnalysis *AA;
   const AArch64InstrInfo *TII;

--- a/llvm/lib/Target/AArch64/AArch64LowerHomogeneousPrologEpilog.cpp
+++ b/llvm/lib/Target/AArch64/AArch64LowerHomogeneousPrologEpilog.cpp
@@ -73,10 +73,7 @@ class AArch64LowerHomogeneousPrologEpilog : public ModulePass {
 public:
   static char ID;
 
-  AArch64LowerHomogeneousPrologEpilog() : ModulePass(ID) {
-    initializeAArch64LowerHomogeneousPrologEpilogPass(
-        *PassRegistry::getPassRegistry());
-  }
+  AArch64LowerHomogeneousPrologEpilog() : ModulePass(ID) {}
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.addRequired<MachineModuleInfoWrapperPass>();
     AU.addPreserved<MachineModuleInfoWrapperPass>();

--- a/llvm/lib/Target/AArch64/AArch64MIPeepholeOpt.cpp
+++ b/llvm/lib/Target/AArch64/AArch64MIPeepholeOpt.cpp
@@ -84,9 +84,7 @@ namespace {
 struct AArch64MIPeepholeOpt : public MachineFunctionPass {
   static char ID;
 
-  AArch64MIPeepholeOpt() : MachineFunctionPass(ID) {
-    initializeAArch64MIPeepholeOptPass(*PassRegistry::getPassRegistry());
-  }
+  AArch64MIPeepholeOpt() : MachineFunctionPass(ID) {}
 
   const AArch64InstrInfo *TII;
   const AArch64RegisterInfo *TRI;

--- a/llvm/lib/Target/AArch64/AArch64PostCoalescerPass.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PostCoalescerPass.cpp
@@ -21,9 +21,7 @@ namespace {
 struct AArch64PostCoalescer : public MachineFunctionPass {
   static char ID;
 
-  AArch64PostCoalescer() : MachineFunctionPass(ID) {
-    initializeAArch64PostCoalescerPass(*PassRegistry::getPassRegistry());
-  }
+  AArch64PostCoalescer() : MachineFunctionPass(ID) {}
 
   LiveIntervals *LIS;
   MachineRegisterInfo *MRI;

--- a/llvm/lib/Target/AArch64/AArch64PromoteConstant.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PromoteConstant.cpp
@@ -108,9 +108,7 @@ public:
 
   static char ID;
 
-  AArch64PromoteConstant() : ModulePass(ID) {
-    initializeAArch64PromoteConstantPass(*PassRegistry::getPassRegistry());
-  }
+  AArch64PromoteConstant() : ModulePass(ID) {}
 
   StringRef getPassName() const override { return "AArch64 Promote Constant"; }
 

--- a/llvm/lib/Target/AArch64/AArch64RedundantCopyElimination.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RedundantCopyElimination.cpp
@@ -78,10 +78,7 @@ class AArch64RedundantCopyElimination : public MachineFunctionPass {
 
 public:
   static char ID;
-  AArch64RedundantCopyElimination() : MachineFunctionPass(ID) {
-    initializeAArch64RedundantCopyEliminationPass(
-        *PassRegistry::getPassRegistry());
-  }
+  AArch64RedundantCopyElimination() : MachineFunctionPass(ID) {}
 
   struct RegImm {
     MCPhysReg Reg;

--- a/llvm/lib/Target/AArch64/AArch64SIMDInstrOpt.cpp
+++ b/llvm/lib/Target/AArch64/AArch64SIMDInstrOpt.cpp
@@ -150,9 +150,7 @@ struct AArch64SIMDInstrOpt : public MachineFunctionPass {
   // The maximum of N is curently 10 and it is for ST4 case.
   static const unsigned MaxNumRepl = 10;
 
-  AArch64SIMDInstrOpt() : MachineFunctionPass(ID) {
-    initializeAArch64SIMDInstrOptPass(*PassRegistry::getPassRegistry());
-  }
+  AArch64SIMDInstrOpt() : MachineFunctionPass(ID) {}
 
   /// Based only on latency of instructions, determine if it is cost efficient
   /// to replace the instruction InstDesc by the instructions stored in the

--- a/llvm/lib/Target/AArch64/AArch64SpeculationHardening.cpp
+++ b/llvm/lib/Target/AArch64/AArch64SpeculationHardening.cpp
@@ -126,9 +126,7 @@ public:
 
   static char ID;
 
-  AArch64SpeculationHardening() : MachineFunctionPass(ID) {
-    initializeAArch64SpeculationHardeningPass(*PassRegistry::getPassRegistry());
-  }
+  AArch64SpeculationHardening() : MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &Fn) override;
 

--- a/llvm/lib/Target/AArch64/AArch64StackTagging.cpp
+++ b/llvm/lib/Target/AArch64/AArch64StackTagging.cpp
@@ -309,9 +309,7 @@ public:
       : FunctionPass(ID),
         MergeInit(ClMergeInit.getNumOccurrences() ? ClMergeInit : !IsOptNone),
         UseStackSafety(ClUseStackSafety.getNumOccurrences() ? ClUseStackSafety
-                                                            : !IsOptNone) {
-    initializeAArch64StackTaggingPass(*PassRegistry::getPassRegistry());
-  }
+                                                            : !IsOptNone) {}
 
   void tagAlloca(AllocaInst *AI, Instruction *InsertBefore, Value *Ptr,
                  uint64_t Size);

--- a/llvm/lib/Target/AArch64/AArch64StackTaggingPreRA.cpp
+++ b/llvm/lib/Target/AArch64/AArch64StackTaggingPreRA.cpp
@@ -62,9 +62,7 @@ class AArch64StackTaggingPreRA : public MachineFunctionPass {
 
 public:
   static char ID;
-  AArch64StackTaggingPreRA() : MachineFunctionPass(ID) {
-    initializeAArch64StackTaggingPreRAPass(*PassRegistry::getPassRegistry());
-  }
+  AArch64StackTaggingPreRA() : MachineFunctionPass(ID) {}
 
   bool mayUseUncheckedLoadStore();
   void uncheckUsesOf(unsigned TaggedReg, int FI);

--- a/llvm/lib/Target/AArch64/AArch64StorePairSuppress.cpp
+++ b/llvm/lib/Target/AArch64/AArch64StorePairSuppress.cpp
@@ -38,9 +38,7 @@ class AArch64StorePairSuppress : public MachineFunctionPass {
 
 public:
   static char ID;
-  AArch64StorePairSuppress() : MachineFunctionPass(ID) {
-    initializeAArch64StorePairSuppressPass(*PassRegistry::getPassRegistry());
-  }
+  AArch64StorePairSuppress() : MachineFunctionPass(ID) {}
 
   StringRef getPassName() const override { return STPSUPPRESS_PASS_NAME; }
 

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -230,45 +230,46 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeAArch64Target() {
   RegisterTargetMachine<AArch64leTargetMachine> Z(getTheARM64Target());
   RegisterTargetMachine<AArch64leTargetMachine> W(getTheARM64_32Target());
   RegisterTargetMachine<AArch64leTargetMachine> V(getTheAArch64_32Target());
-  auto PR = PassRegistry::getPassRegistry();
-  initializeGlobalISel(*PR);
-  initializeAArch64A53Fix835769Pass(*PR);
-  initializeAArch64A57FPLoadBalancingPass(*PR);
-  initializeAArch64AdvSIMDScalarPass(*PR);
-  initializeAArch64BranchTargetsPass(*PR);
-  initializeAArch64CollectLOHPass(*PR);
-  initializeAArch64CompressJumpTablesPass(*PR);
-  initializeAArch64ConditionalComparesPass(*PR);
-  initializeAArch64ConditionOptimizerPass(*PR);
-  initializeAArch64DeadRegisterDefinitionsPass(*PR);
-  initializeAArch64ExpandPseudoPass(*PR);
-  initializeAArch64LoadStoreOptPass(*PR);
-  initializeAArch64MIPeepholeOptPass(*PR);
-  initializeAArch64SIMDInstrOptPass(*PR);
-  initializeAArch64O0PreLegalizerCombinerPass(*PR);
-  initializeAArch64PreLegalizerCombinerPass(*PR);
-  initializeAArch64PointerAuthPass(*PR);
-  initializeAArch64PostCoalescerPass(*PR);
-  initializeAArch64PostLegalizerCombinerPass(*PR);
-  initializeAArch64PostLegalizerLoweringPass(*PR);
-  initializeAArch64PostSelectOptimizePass(*PR);
-  initializeAArch64PromoteConstantPass(*PR);
-  initializeAArch64RedundantCopyEliminationPass(*PR);
-  initializeAArch64StorePairSuppressPass(*PR);
-  initializeFalkorHWPFFixPass(*PR);
-  initializeFalkorMarkStridedAccessesLegacyPass(*PR);
-  initializeLDTLSCleanupPass(*PR);
-  initializeKCFIPass(*PR);
-  initializeSMEABIPass(*PR);
-  initializeSMEPeepholeOptPass(*PR);
-  initializeSVEIntrinsicOptsPass(*PR);
-  initializeAArch64SpeculationHardeningPass(*PR);
-  initializeAArch64SLSHardeningPass(*PR);
-  initializeAArch64StackTaggingPass(*PR);
-  initializeAArch64StackTaggingPreRAPass(*PR);
-  initializeAArch64LowerHomogeneousPrologEpilogPass(*PR);
-  initializeAArch64DAGToDAGISelLegacyPass(*PR);
-  initializeAArch64CondBrTuningPass(*PR);
+  auto &PR = *PassRegistry::getPassRegistry();
+  initializeGlobalISel(PR);
+  initializeAArch64A53Fix835769Pass(PR);
+  initializeAArch64A57FPLoadBalancingPass(PR);
+  initializeAArch64AdvSIMDScalarPass(PR);
+  initializeAArch64BranchTargetsPass(PR);
+  initializeAArch64CollectLOHPass(PR);
+  initializeAArch64CompressJumpTablesPass(PR);
+  initializeAArch64ConditionalComparesPass(PR);
+  initializeAArch64ConditionOptimizerPass(PR);
+  initializeAArch64DeadRegisterDefinitionsPass(PR);
+  initializeAArch64ExpandPseudoPass(PR);
+  initializeAArch64LoadStoreOptPass(PR);
+  initializeAArch64MIPeepholeOptPass(PR);
+  initializeAArch64SIMDInstrOptPass(PR);
+  initializeAArch64O0PreLegalizerCombinerPass(PR);
+  initializeAArch64PreLegalizerCombinerPass(PR);
+  initializeAArch64PointerAuthPass(PR);
+  initializeAArch64PostCoalescerPass(PR);
+  initializeAArch64PostLegalizerCombinerPass(PR);
+  initializeAArch64PostLegalizerLoweringPass(PR);
+  initializeAArch64PostSelectOptimizePass(PR);
+  initializeAArch64PromoteConstantPass(PR);
+  initializeAArch64RedundantCopyEliminationPass(PR);
+  initializeAArch64StorePairSuppressPass(PR);
+  initializeFalkorHWPFFixPass(PR);
+  initializeFalkorMarkStridedAccessesLegacyPass(PR);
+  initializeLDTLSCleanupPass(PR);
+  initializeKCFIPass(PR);
+  initializeSMEABIPass(PR);
+  initializeSMEPeepholeOptPass(PR);
+  initializeSVEIntrinsicOptsPass(PR);
+  initializeAArch64SpeculationHardeningPass(PR);
+  initializeAArch64SLSHardeningPass(PR);
+  initializeAArch64StackTaggingPass(PR);
+  initializeAArch64StackTaggingPreRAPass(PR);
+  initializeAArch64LowerHomogeneousPrologEpilogPass(PR);
+  initializeAArch64DAGToDAGISelLegacyPass(PR);
+  initializeAArch64CondBrTuningPass(PR);
+  initializeAArch64Arm64ECCallLoweringPass(PR);
 }
 
 void AArch64TargetMachine::reset() { SubtargetMap.clear(); }
@@ -333,8 +334,9 @@ getEffectiveAArch64CodeModel(const Triple &TT,
         *CM != CodeModel::Large) {
       report_fatal_error(
           "Only small, tiny and large code models are allowed on AArch64");
-    } else if (*CM == CodeModel::Tiny && !TT.isOSBinFormatELF())
+    } else if (*CM == CodeModel::Tiny && !TT.isOSBinFormatELF()) {
       report_fatal_error("tiny code model is only supported on ELF");
+    }
     return *CM;
   }
   // The default MCJIT memory managers make no guarantees about where they can

--- a/llvm/lib/Target/AArch64/GISel/AArch64O0PreLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64O0PreLegalizerCombiner.cpp
@@ -142,8 +142,6 @@ void AArch64O0PreLegalizerCombiner::getAnalysisUsage(AnalysisUsage &AU) const {
 
 AArch64O0PreLegalizerCombiner::AArch64O0PreLegalizerCombiner()
     : MachineFunctionPass(ID) {
-  initializeAArch64O0PreLegalizerCombinerPass(*PassRegistry::getPassRegistry());
-
   if (!RuleConfig.parseCommandLineOption())
     report_fatal_error("Invalid rule identifier");
 }

--- a/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerCombiner.cpp
@@ -533,8 +533,6 @@ void AArch64PostLegalizerCombiner::getAnalysisUsage(AnalysisUsage &AU) const {
 
 AArch64PostLegalizerCombiner::AArch64PostLegalizerCombiner(bool IsOptNone)
     : MachineFunctionPass(ID), IsOptNone(IsOptNone) {
-  initializeAArch64PostLegalizerCombinerPass(*PassRegistry::getPassRegistry());
-
   if (!RuleConfig.parseCommandLineOption())
     report_fatal_error("Invalid rule identifier");
 }

--- a/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PostLegalizerLowering.cpp
@@ -1322,8 +1322,6 @@ void AArch64PostLegalizerLowering::getAnalysisUsage(AnalysisUsage &AU) const {
 
 AArch64PostLegalizerLowering::AArch64PostLegalizerLowering()
     : MachineFunctionPass(ID) {
-  initializeAArch64PostLegalizerLoweringPass(*PassRegistry::getPassRegistry());
-
   if (!RuleConfig.parseCommandLineOption())
     report_fatal_error("Invalid rule identifier");
 }

--- a/llvm/lib/Target/AArch64/GISel/AArch64PostSelectOptimize.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PostSelectOptimize.cpp
@@ -33,7 +33,7 @@ class AArch64PostSelectOptimize : public MachineFunctionPass {
 public:
   static char ID;
 
-  AArch64PostSelectOptimize();
+  AArch64PostSelectOptimize() : MachineFunctionPass(ID) {}
 
   StringRef getPassName() const override {
     return "AArch64 Post Select Optimizer";
@@ -57,11 +57,6 @@ void AArch64PostSelectOptimize::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.setPreservesCFG();
   getSelectionDAGFallbackAnalysisUsage(AU);
   MachineFunctionPass::getAnalysisUsage(AU);
-}
-
-AArch64PostSelectOptimize::AArch64PostSelectOptimize()
-    : MachineFunctionPass(ID) {
-  initializeAArch64PostSelectOptimizePass(*PassRegistry::getPassRegistry());
 }
 
 unsigned getNonFlagSettingVariant(unsigned Opc) {

--- a/llvm/lib/Target/AArch64/GISel/AArch64PreLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PreLegalizerCombiner.cpp
@@ -831,8 +831,6 @@ void AArch64PreLegalizerCombiner::getAnalysisUsage(AnalysisUsage &AU) const {
 
 AArch64PreLegalizerCombiner::AArch64PreLegalizerCombiner()
     : MachineFunctionPass(ID) {
-  initializeAArch64PreLegalizerCombinerPass(*PassRegistry::getPassRegistry());
-
   if (!RuleConfig.parseCommandLineOption())
     report_fatal_error("Invalid rule identifier");
 }


### PR DESCRIPTION
- Remove calls to pass initialization from pass constructors.
- https://github.com/llvm/llvm-project/issues/111767