### PR TITLE
[VPlan][NFCI] Small code quality fixes in VPlanHCFGBuilder

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanSLP.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanSLP.h
@@ -48,6 +48,8 @@ class VPInterleavedAccessInfo {
 
 public:
   VPInterleavedAccessInfo(VPlan &Plan, InterleavedAccessInfo &IAI);
+  VPInterleavedAccessInfo(const VPInterleavedAccessInfo &) = delete;
+  VPInterleavedAccessInfo &operator=(const VPInterleavedAccessInfo &) = delete;
 
   ~VPInterleavedAccessInfo() {
     // Avoid releasing a pointer twice.

--- a/llvm/lib/Transforms/Vectorize/VPlanSLP.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanSLP.h
@@ -48,8 +48,6 @@ class VPInterleavedAccessInfo {
 
 public:
   VPInterleavedAccessInfo(VPlan &Plan, InterleavedAccessInfo &IAI);
-  VPInterleavedAccessInfo(const VPInterleavedAccessInfo &) = delete;
-  VPInterleavedAccessInfo &operator=(const VPInterleavedAccessInfo &) = delete;
 
   ~VPInterleavedAccessInfo() {
     // Avoid releasing a pointer twice.


### PR DESCRIPTION
Addresses some code quality issues found during an internal code review. Specifically, fixing two instances where null dereferences were technically possible in VPlanHCFGBuilder.cpp, even if not in practice.