### PR TITLE
[LangRef] Clarify semantics for ``sdiv poison -1``

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -4917,6 +4917,8 @@ behavior. Notably this includes (but is not limited to):
    space).
 -  The divisor operand of a ``udiv``, ``sdiv``, ``urem`` or ``srem``
    instruction.
+-  The dividend operand of a ``sdiv`` or ``srem`` instruction when the divisor
+   is -1.
 -  The condition operand of a :ref:`br <i_br>` instruction.
 -  The callee operand of a :ref:`call <i_call>` or :ref:`invoke <i_invoke>`
    instruction.


### PR DESCRIPTION
Documents in the LangRef that ``sdiv poison -1`` triggers immediate undefined behavior.

Despite it being already documented in "immediate undefined behavior occurs if a poison value is used as an instruction operand that has any values that trigger undefined behavior", it is a corner case that is worth mentioning explicitly.