### PR TITLE
[mlir] Add support for broader range of input files in generate-test-checks.py

### DIFF
--- a/mlir/utils/generate-test-checks.py
+++ b/mlir/utils/generate-test-checks.py
@@ -236,7 +236,8 @@ def process_attribute_references(line, attribute_namer):
 # Pre-process a line of input to remove any character sequences that will be
 # problematic with FileCheck.
 def preprocess_line(line):
-    # If input line has `{{` i.e. in a StrAttr with serialized proto.
+    # Replace any `{{` with escaped replacements. `{{` corresponds to regex
+    # checks in FileCheck.
     output_line = line.replace("{{", "{{\\{\\{}}")
 
     # Replace any double brackets, '[[' with escaped replacements. '[['

--- a/mlir/utils/generate-test-checks.py
+++ b/mlir/utils/generate-test-checks.py
@@ -236,9 +236,12 @@ def process_attribute_references(line, attribute_namer):
 # Pre-process a line of input to remove any character sequences that will be
 # problematic with FileCheck.
 def preprocess_line(line):
+    # If input line has `{{` i.e. in a StrAttr with serialized proto.
+    output_line = line.replace("{{", "{{\\{\\{}}")
+
     # Replace any double brackets, '[[' with escaped replacements. '[['
     # corresponds to variable names in FileCheck.
-    output_line = line.replace("[[", "{{\\[\\[}}")
+    output_line = output_line.replace("[[", "{{\\[\\[}}")
 
     # Replace any single brackets that are followed by an SSA identifier, the
     # identifier will be replace by a variable; Creating the same situation as
@@ -325,6 +328,11 @@ def main():
     # Process lines
     for input_line in input_lines:
         if not input_line:
+            continue
+
+        # When using `--starts_from_scope=0` to capture module lines, the file
+        # split needs to be skipped, otherwise a `CHECK: // -----` is inserted.
+        if input_line.startswith("// -----"):
             continue
 
         # Check if this is an attribute definition and process it


### PR DESCRIPTION
A few additions:

- Lines with `{{`: These can show up if serializing non-MLIR info into string attrs `my.attr = {{proto}, {...}}`. String escape the opening `{{`, given that check lines are generated this has no effect on `{{.*}}` etc in generated lines.
- File split line: Normally these are skipped because of their indent level, but if using `--starts_from_scope=0` to generate checks for the `module {...} {` line, and since MLIR opt tools emit file split lines by default, some `CHECK: // -----` lines were emit.
- (edit removed this, fixed by https://github.com/llvm/llvm-project/pull/134364) AttrAliases: I'm not sure if I'm missing something for the attribute parser to work correctly, but I was getting many `#[[?]]` for all dialect attrs. Only use the attr aliasing if there's a match.