### PR TITLE
[MachineScheduler] Add more debug prints w.r.t hazards and pending SUnits

### DIFF
--- a/llvm/test/CodeGen/AArch64/misched-detail-resource-booking-01.mir
+++ b/llvm/test/CodeGen/AArch64/misched-detail-resource-booking-01.mir
@@ -297,6 +297,7 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @0c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @0c
+# CHECK-NEXT:   Move SU(0) into Available Q
 # CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
@@ -314,6 +315,7 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @0c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @0c
+# CHECK-NEXT:   Move SU(1) into Available Q
 # CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
@@ -331,6 +333,7 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @0c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @0c
+# CHECK-NEXT:   Move SU(2) into Available Q
 # CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
@@ -348,9 +351,13 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @0c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitFPALU[0] available @0c
+# CHECK-NEXT:   Move SU(4) into Available Q
+# CHECK-NEXT:   hazard: SU(12) ReadyCycle = 3 is later than CurrCycle = 0 on an unbuffered resource
+# CHECK-NEXT:   hazard: SU(11) ReadyCycle = 3 is later than CurrCycle = 0 on an unbuffered resource
 # CHECK-NEXT: Critical Path(GS-RR ): 14
 # CHECK-NEXT: ** ScheduleDAGMILive::schedule picking next node
 # CHECK-NEXT: Cycle: 3 BotQ.A
+# CHECK-NEXT: Checking pending node SU(12)
 # CHECK-NEXT:   Resource booking (@3c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
@@ -368,6 +375,8 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @3c
 # CHECK-NEXT:     Instance 1 available @3c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @3c
+# CHECK-NEXT:   Move SU(12) into Available Q
+# CHECK-NEXT: Checking pending node SU(11)
 # CHECK-NEXT:   Resource booking (@3c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
@@ -385,6 +394,7 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @3c
 # CHECK-NEXT:     Instance 1 available @3c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @3c
+# CHECK-NEXT:   Move SU(11) into Available Q
 # CHECK-NEXT: Queue BotQ.P:
 # CHECK-NEXT: Queue BotQ.A: 12 11
 # CHECK-NEXT:   Cand SU(12) FIRST
@@ -446,6 +456,7 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
+# CHECK-NEXT:   hazard: SU(10) ReadyCycle = 7 is later than CurrCycle = 3 on an unbuffered resource
 # CHECK-NEXT: ** ScheduleDAGMILive::schedule picking next node
 # CHECK-NEXT:   Resource booking (@3c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 3
@@ -523,8 +534,14 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
+# CHECK-NEXT:   hazard: SU(8) ReadyCycle = 7 is later than CurrCycle = 4 on an unbuffered resource
 # CHECK-NEXT: ** ScheduleDAGMILive::schedule picking next node
+# CHECK-NEXT: Checking pending node SU(10)
+# CHECK-NEXT:   hazard: SU(10) ReadyCycle = 7 is later than CurrCycle = 4 on an unbuffered resource
+# CHECK-NEXT: Checking pending node SU(8)
+# CHECK-NEXT:   hazard: SU(8) ReadyCycle = 7 is later than CurrCycle = 4 on an unbuffered resource
 # CHECK-NEXT: Cycle: 7 BotQ.A
+# CHECK-NEXT: Checking pending node SU(10)
 # CHECK-NEXT:   Resource booking (@7c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 3
 # CHECK-NEXT: CortexA55UnitALU(1) = 3
@@ -542,6 +559,8 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @7c
 # CHECK-NEXT:     Instance 1 available @7c
 # CHECK-NEXT:     selecting CortexA55UnitFPALU[0] available @7c
+# CHECK-NEXT:   Move SU(10) into Available Q
+# CHECK-NEXT: Checking pending node SU(8)
 # CHECK-NEXT:   Resource booking (@7c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 3
 # CHECK-NEXT: CortexA55UnitALU(1) = 3
@@ -559,6 +578,7 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @7c
 # CHECK-NEXT:     Instance 1 available @7c
 # CHECK-NEXT:     selecting CortexA55UnitFPALU[0] available @7c
+# CHECK-NEXT:   Move SU(8) into Available Q
 # CHECK-NEXT: Queue BotQ.P:
 # CHECK-NEXT: Queue BotQ.A: 10 8
 # CHECK-NEXT:   Cand SU(10) FIRST
@@ -621,7 +641,13 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
+# CHECK-NEXT:   hazard: SU(9) ReadyCycle = 9 is later than CurrCycle = 8 on an unbuffered resource
+# CHECK-NEXT:   hazard: SU(3) ReadyCycle = 11 is later than CurrCycle = 8 on an unbuffered resource
 # CHECK-NEXT: ** ScheduleDAGMILive::schedule picking next node
+# CHECK-NEXT: Checking pending node SU(9)
+# CHECK-NEXT:   hazard: SU(9) ReadyCycle = 9 is later than CurrCycle = 8 on an unbuffered resource
+# CHECK-NEXT: Checking pending node SU(3)
+# CHECK-NEXT:   hazard: SU(3) ReadyCycle = 11 is later than CurrCycle = 8 on an unbuffered resource
 # CHECK-NEXT:   Resource booking (@8c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 3
 # CHECK-NEXT: CortexA55UnitALU(1) = 3
@@ -699,7 +725,9 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
+# CHECK-NEXT:   hazard: SU(7) ReadyCycle = 10 is later than CurrCycle = 9 on an unbuffered resource
 # CHECK-NEXT: ** ScheduleDAGMILive::schedule picking next node
+# CHECK-NEXT: Checking pending node SU(9)
 # CHECK-NEXT:   Resource booking (@9c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 3
 # CHECK-NEXT: CortexA55UnitALU(1) = 3
@@ -717,6 +745,11 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @9c
 # CHECK-NEXT:     Instance 1 available @9c
 # CHECK-NEXT:     selecting CortexA55UnitFPALU[0] available @9c
+# CHECK-NEXT:   Move SU(9) into Available Q
+# CHECK-NEXT: Checking pending node SU(7)
+# CHECK-NEXT:   hazard: SU(7) ReadyCycle = 10 is later than CurrCycle = 9 on an unbuffered resource
+# CHECK-NEXT: Checking pending node SU(3)
+# CHECK-NEXT:   hazard: SU(3) ReadyCycle = 11 is later than CurrCycle = 9 on an unbuffered resource
 # CHECK-NEXT:   Resource booking (@9c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 3
 # CHECK-NEXT: CortexA55UnitALU(1) = 3
@@ -792,8 +825,10 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
+# CHECK-NEXT:   hazard: SU(5) ReadyCycle = 10 is later than CurrCycle = 9 on an unbuffered resource
 # CHECK-NEXT: ** ScheduleDAGMILive::schedule picking next node
 # CHECK-NEXT: Cycle: 10 BotQ.A
+# CHECK-NEXT: Checking pending node SU(7)
 # CHECK-NEXT:   Resource booking (@10c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 3
 # CHECK-NEXT: CortexA55UnitALU(1) = 3
@@ -811,6 +846,8 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @10c
 # CHECK-NEXT:     Instance 1 available @10c
 # CHECK-NEXT:     selecting CortexA55UnitFPALU[0] available @10c
+# CHECK-NEXT:   Move SU(7) into Available Q
+# CHECK-NEXT: Checking pending node SU(5)
 # CHECK-NEXT:   Resource booking (@10c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 3
 # CHECK-NEXT: CortexA55UnitALU(1) = 3
@@ -828,6 +865,9 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @11c
 # CHECK-NEXT:     Instance 1 available @10c
 # CHECK-NEXT:     selecting CortexA55UnitFPALU[1] available @10c
+# CHECK-NEXT:   Move SU(5) into Available Q
+# CHECK-NEXT: Checking pending node SU(3)
+# CHECK-NEXT:   hazard: SU(3) ReadyCycle = 11 is later than CurrCycle = 10 on an unbuffered resource
 # CHECK-NEXT: Queue BotQ.P: 3
 # CHECK-NEXT: Queue BotQ.A: 7 5
 # CHECK-NEXT:   Cand SU(7) FIRST
@@ -887,6 +927,7 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
+# CHECK-NEXT:   hazard: SU(6) ReadyCycle = 11 is later than CurrCycle = 10 on an unbuffered resource
 # CHECK-NEXT: ** ScheduleDAGMILive::schedule picking next node
 # CHECK-NEXT:   Resource booking (@10c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 3
@@ -966,7 +1007,9 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
+# CHECK-NEXT:   hazard: SU(0) ReadyCycle = 13 is later than CurrCycle = 11 on an unbuffered resource
 # CHECK-NEXT: ** ScheduleDAGMILive::schedule picking next node
+# CHECK-NEXT: Checking pending node SU(3)
 # CHECK-NEXT:   Resource booking (@11c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 3
 # CHECK-NEXT: CortexA55UnitALU(1) = 3
@@ -984,7 +1027,8 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @12c
 # CHECK-NEXT:     Instance 1 available @12c
 # CHECK-NEXT:     selecting CortexA55UnitFPALU[0] available @12c
-# CHECK-NEXT:   SU(3) CortexA55UnitFPALU[0]=12c
+# CHECK-NEXT:   hazard:  SU(3) CortexA55UnitFPALU[0]=12c, is later than CurrCycle = 11c
+# CHECK-NEXT: Checking pending node SU(6)
 # CHECK-NEXT:   Resource booking (@11c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 3
 # CHECK-NEXT: CortexA55UnitALU(1) = 3
@@ -1002,8 +1046,11 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @12c
 # CHECK-NEXT:     Instance 1 available @12c
 # CHECK-NEXT:     selecting CortexA55UnitFPALU[0] available @12c
-# CHECK-NEXT:   SU(6) CortexA55UnitFPALU[0]=12c
+# CHECK-NEXT:   hazard:  SU(6) CortexA55UnitFPALU[0]=12c, is later than CurrCycle = 11c
+# CHECK-NEXT: Checking pending node SU(0)
+# CHECK-NEXT:   hazard: SU(0) ReadyCycle = 13 is later than CurrCycle = 11 on an unbuffered resource
 # CHECK-NEXT: Cycle: 12 BotQ.A
+# CHECK-NEXT: Checking pending node SU(3)
 # CHECK-NEXT:   Resource booking (@12c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 3
 # CHECK-NEXT: CortexA55UnitALU(1) = 3
@@ -1021,6 +1068,10 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @12c
 # CHECK-NEXT:     Instance 1 available @12c
 # CHECK-NEXT:     selecting CortexA55UnitFPALU[0] available @12c
+# CHECK-NEXT:   Move SU(3) into Available Q
+# CHECK-NEXT: Checking pending node SU(0)
+# CHECK-NEXT:   hazard: SU(0) ReadyCycle = 13 is later than CurrCycle = 12 on an unbuffered resource
+# CHECK-NEXT: Checking pending node SU(6)
 # CHECK-NEXT:   Resource booking (@12c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 3
 # CHECK-NEXT: CortexA55UnitALU(1) = 3
@@ -1038,6 +1089,7 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @12c
 # CHECK-NEXT:     Instance 1 available @12c
 # CHECK-NEXT:     selecting CortexA55UnitFPALU[0] available @12c
+# CHECK-NEXT:   Move SU(6) into Available Q
 # CHECK-NEXT: Queue BotQ.P: 0
 # CHECK-NEXT: Queue BotQ.A: 3 6
 # CHECK-NEXT:   Cand SU(3) FIRST
@@ -1101,7 +1153,10 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
+# CHECK-NEXT:   hazard: SU(4) ReadyCycle = 16 is later than CurrCycle = 13 on an unbuffered resource
+# CHECK-NEXT:   hazard: SU(1) ReadyCycle = 15 is later than CurrCycle = 13 on an unbuffered resource
 # CHECK-NEXT: ** ScheduleDAGMILive::schedule picking next node
+# CHECK-NEXT: Checking pending node SU(0)
 # CHECK-NEXT:   Resource booking (@13c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 3
 # CHECK-NEXT: CortexA55UnitALU(1) = 3
@@ -1119,6 +1174,11 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @13c
 # CHECK-NEXT:     Instance 1 available @13c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @13c
+# CHECK-NEXT:   Move SU(0) into Available Q
+# CHECK-NEXT: Checking pending node SU(1)
+# CHECK-NEXT:   hazard: SU(1) ReadyCycle = 15 is later than CurrCycle = 13 on an unbuffered resource
+# CHECK-NEXT: Checking pending node SU(4)
+# CHECK-NEXT:   hazard: SU(4) ReadyCycle = 16 is later than CurrCycle = 13 on an unbuffered resource
 # CHECK-NEXT:   Resource booking (@13c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 3
 # CHECK-NEXT: CortexA55UnitALU(1) = 3
@@ -1215,7 +1275,14 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
+# CHECK-NEXT:   hazard: SU(2) ReadyCycle = 16 is later than CurrCycle = 14 on an unbuffered resource
 # CHECK-NEXT: ** ScheduleDAGMILive::schedule picking next node
+# CHECK-NEXT: Checking pending node SU(1)
+# CHECK-NEXT:   hazard: SU(1) ReadyCycle = 15 is later than CurrCycle = 14 on an unbuffered resource
+# CHECK-NEXT: Checking pending node SU(4)
+# CHECK-NEXT:   hazard: SU(4) ReadyCycle = 16 is later than CurrCycle = 14 on an unbuffered resource
+# CHECK-NEXT: Checking pending node SU(2)
+# CHECK-NEXT:   hazard: SU(2) ReadyCycle = 16 is later than CurrCycle = 14 on an unbuffered resource
 # CHECK-NEXT:   Resource booking (@14c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 3
 # CHECK-NEXT: CortexA55UnitALU(1) = 3
@@ -1293,6 +1360,7 @@ body:             |
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
 # CHECK-NEXT: ** ScheduleDAGMILive::schedule picking next node
 # CHECK-NEXT: Cycle: 15 BotQ.A
+# CHECK-NEXT: Checking pending node SU(1)
 # CHECK-NEXT:   Resource booking (@15c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 14
 # CHECK-NEXT: CortexA55UnitALU(1) = 3
@@ -1310,6 +1378,11 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @15c
 # CHECK-NEXT:     Instance 1 available @15c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @15c
+# CHECK-NEXT:   Move SU(1) into Available Q
+# CHECK-NEXT: Checking pending node SU(2)
+# CHECK-NEXT:   hazard: SU(2) ReadyCycle = 16 is later than CurrCycle = 15 on an unbuffered resource
+# CHECK-NEXT: Checking pending node SU(4)
+# CHECK-NEXT:   hazard: SU(4) ReadyCycle = 16 is later than CurrCycle = 15 on an unbuffered resource
 # CHECK-NEXT: Queue BotQ.P: 2 4
 # CHECK-NEXT: Queue BotQ.A: 1
 # CHECK-NEXT: Scheduling SU(1) %1:fpr128 = COPY $q1
@@ -1369,6 +1442,7 @@ body:             |
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
 # CHECK-NEXT: ** ScheduleDAGMILive::schedule picking next node
 # CHECK-NEXT: Cycle: 16 BotQ.A
+# CHECK-NEXT: Checking pending node SU(2)
 # CHECK-NEXT:   Resource booking (@16c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 15
 # CHECK-NEXT: CortexA55UnitALU(1) = 3
@@ -1386,6 +1460,8 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @16c
 # CHECK-NEXT:     Instance 1 available @16c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @16c
+# CHECK-NEXT:   Move SU(2) into Available Q
+# CHECK-NEXT: Checking pending node SU(4)
 # CHECK-NEXT:   Resource booking (@16c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 15
 # CHECK-NEXT: CortexA55UnitALU(1) = 3
@@ -1403,6 +1479,7 @@ body:             |
 # CHECK-NEXT:     Instance 0 available @16c
 # CHECK-NEXT:     Instance 1 available @16c
 # CHECK-NEXT:     selecting CortexA55UnitFPALU[0] available @16c
+# CHECK-NEXT:   Move SU(4) into Available Q
 # CHECK-NEXT: Queue BotQ.P:
 # CHECK-NEXT: Queue BotQ.A: 2 4
 # CHECK-NEXT:   Cand SU(2) FIRST
@@ -1546,33 +1623,33 @@ body:             |
 # CHECK-NEXT:  * Schedule table (BottomUp):
 # CHECK-NEXT:   i: issue
 # CHECK-NEXT:   x: resource booked
-# CHECK-NEXT: Cycle              | 17 | 16 | 15 | 14 | 13 | 12 | 11 | 10 | 9  | 8  | 7  | 6  | 5  | 4  | 3  |
-# CHECK-NEXT: SU(2)              | i  |    |    |    |    |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT:   CortexA55UnitALU | x  |    |    |    |    |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT: SU(4)              |    | i  |    |    |    |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT: CortexA55UnitFPALU |    | x  | x  |    |    |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT: SU(1)              |    |    | i  |    |    |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT:   CortexA55UnitALU |    |    | x  |    |    |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT: SU(0)              |    |    |    | i  |    |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT:   CortexA55UnitALU |    |    |    | x  |    |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT: SU(3)              |    |    |    |    | i  |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT: CortexA55UnitFPALU |    |    |    |    | x  | x  |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT: SU(6)              |    |    |    |    |    | i  |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT: CortexA55UnitFPALU |    |    |    |    |    | x  | x  |    |    |    |    |    |    |    |    |
-# CHECK-NEXT: SU(5)              |    |    |    |    |    |    |    | i  |    |    |    |    |    |    |    |
-# CHECK-NEXT: CortexA55UnitFPALU |    |    |    |    |    |    |    | x  | x  |    |    |    |    |    |    |
-# CHECK-NEXT: SU(7)              |    |    |    |    |    |    |    | i  |    |    |    |    |    |    |    |
-# CHECK-NEXT: CortexA55UnitFPALU |    |    |    |    |    |    |    | x  |    |    |    |    |    |    |    |
-# CHECK-NEXT: SU(9)              |    |    |    |    |    |    |    |    | i  |    |    |    |    |    |    |
-# CHECK-NEXT: CortexA55UnitFPALU |    |    |    |    |    |    |    |    | x  |    |    |    |    |    |    |
-# CHECK-NEXT: SU(8)              |    |    |    |    |    |    |    |    |    | i  |    |    |    |    |    |
-# CHECK-NEXT: CortexA55UnitFPALU |    |    |    |    |    |    |    |    |    | x  | x  |    |    |    |    |
-# CHECK-NEXT: SU(10)             |    |    |    |    |    |    |    |    |    |    | i  |    |    |    |    |
-# CHECK-NEXT: CortexA55UnitFPALU |    |    |    |    |    |    |    |    |    |    | x  | x  |    |    |    |
-# CHECK-NEXT: SU(11)             |    |    |    |    |    |    |    |    |    |    |    |    |    |    | i  |
-# CHECK-NEXT:   CortexA55UnitALU |    |    |    |    |    |    |    |    |    |    |    |    |    |    | x  |
-# CHECK-NEXT: SU(12)             |    |    |    |    |    |    |    |    |    |    |    |    |    |    | i  |
-# CHECK-NEXT:   CortexA55UnitALU |    |    |    |    |    |    |    |    |    |    |    |    |    |    | x  |
+# CHECK-NEXT: Cycle                | 17 | 16 | 15 | 14 | 13 | 12 | 11 | 10 | 9  | 8  | 7  | 6  | 5  | 4  | 3  |
+# CHECK-NEXT: SU(2)                | i  |    |    |    |    |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT:     CortexA55UnitALU | x  |    |    |    |    |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT: SU(4)                |    | i  |    |    |    |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT:   CortexA55UnitFPALU |    | x  | x  |    |    |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT: SU(1)                |    |    | i  |    |    |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT:     CortexA55UnitALU |    |    | x  |    |    |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT: SU(0)                |    |    |    | i  |    |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT:     CortexA55UnitALU |    |    |    | x  |    |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT: SU(3)                |    |    |    |    | i  |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT:   CortexA55UnitFPALU |    |    |    |    | x  | x  |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT: SU(6)                |    |    |    |    |    | i  |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT:   CortexA55UnitFPALU |    |    |    |    |    | x  | x  |    |    |    |    |    |    |    |    |
+# CHECK-NEXT: SU(5)                |    |    |    |    |    |    |    | i  |    |    |    |    |    |    |    |
+# CHECK-NEXT:   CortexA55UnitFPALU |    |    |    |    |    |    |    | x  | x  |    |    |    |    |    |    |
+# CHECK-NEXT: SU(7)                |    |    |    |    |    |    |    | i  |    |    |    |    |    |    |    |
+# CHECK-NEXT:   CortexA55UnitFPALU |    |    |    |    |    |    |    | x  |    |    |    |    |    |    |    |
+# CHECK-NEXT: SU(9)                |    |    |    |    |    |    |    |    | i  |    |    |    |    |    |    |
+# CHECK-NEXT:   CortexA55UnitFPALU |    |    |    |    |    |    |    |    | x  |    |    |    |    |    |    |
+# CHECK-NEXT: SU(8)                |    |    |    |    |    |    |    |    |    | i  |    |    |    |    |    |
+# CHECK-NEXT:   CortexA55UnitFPALU |    |    |    |    |    |    |    |    |    | x  | x  |    |    |    |    |
+# CHECK-NEXT: SU(10)               |    |    |    |    |    |    |    |    |    |    | i  |    |    |    |    |
+# CHECK-NEXT:   CortexA55UnitFPALU |    |    |    |    |    |    |    |    |    |    | x  | x  |    |    |    |
+# CHECK-NEXT: SU(11)               |    |    |    |    |    |    |    |    |    |    |    |    |    |    | i  |
+# CHECK-NEXT:     CortexA55UnitALU |    |    |    |    |    |    |    |    |    |    |    |    |    |    | x  |
+# CHECK-NEXT: SU(12)               |    |    |    |    |    |    |    |    |    |    |    |    |    |    | i  |
+# CHECK-NEXT:     CortexA55UnitALU |    |    |    |    |    |    |    |    |    |    |    |    |    |    | x  |
 # CHECK-NEXT: SU(2) [TopReadyCycle = 0, BottomReadyCycle = 17]:   %0:fpr128 = COPY $q0
 # CHECK-NEXT: SU(4) [TopReadyCycle = 0, BottomReadyCycle = 16]:   %6:fpr128 = MOVIv2d_ns 17
 # CHECK-NEXT: SU(1) [TopReadyCycle = 0, BottomReadyCycle = 15]:   %1:fpr128 = COPY $q1

--- a/llvm/test/CodeGen/AArch64/misched-detail-resource-booking-01.mir
+++ b/llvm/test/CodeGen/AArch64/misched-detail-resource-booking-01.mir
@@ -1623,33 +1623,33 @@ body:             |
 # CHECK-NEXT:  * Schedule table (BottomUp):
 # CHECK-NEXT:   i: issue
 # CHECK-NEXT:   x: resource booked
-# CHECK-NEXT: Cycle                | 17 | 16 | 15 | 14 | 13 | 12 | 11 | 10 | 9  | 8  | 7  | 6  | 5  | 4  | 3  |
-# CHECK-NEXT: SU(2)                | i  |    |    |    |    |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT:     CortexA55UnitALU | x  |    |    |    |    |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT: SU(4)                |    | i  |    |    |    |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT:   CortexA55UnitFPALU |    | x  | x  |    |    |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT: SU(1)                |    |    | i  |    |    |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT:     CortexA55UnitALU |    |    | x  |    |    |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT: SU(0)                |    |    |    | i  |    |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT:     CortexA55UnitALU |    |    |    | x  |    |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT: SU(3)                |    |    |    |    | i  |    |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT:   CortexA55UnitFPALU |    |    |    |    | x  | x  |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT: SU(6)                |    |    |    |    |    | i  |    |    |    |    |    |    |    |    |    |
-# CHECK-NEXT:   CortexA55UnitFPALU |    |    |    |    |    | x  | x  |    |    |    |    |    |    |    |    |
-# CHECK-NEXT: SU(5)                |    |    |    |    |    |    |    | i  |    |    |    |    |    |    |    |
-# CHECK-NEXT:   CortexA55UnitFPALU |    |    |    |    |    |    |    | x  | x  |    |    |    |    |    |    |
-# CHECK-NEXT: SU(7)                |    |    |    |    |    |    |    | i  |    |    |    |    |    |    |    |
-# CHECK-NEXT:   CortexA55UnitFPALU |    |    |    |    |    |    |    | x  |    |    |    |    |    |    |    |
-# CHECK-NEXT: SU(9)                |    |    |    |    |    |    |    |    | i  |    |    |    |    |    |    |
-# CHECK-NEXT:   CortexA55UnitFPALU |    |    |    |    |    |    |    |    | x  |    |    |    |    |    |    |
-# CHECK-NEXT: SU(8)                |    |    |    |    |    |    |    |    |    | i  |    |    |    |    |    |
-# CHECK-NEXT:   CortexA55UnitFPALU |    |    |    |    |    |    |    |    |    | x  | x  |    |    |    |    |
-# CHECK-NEXT: SU(10)               |    |    |    |    |    |    |    |    |    |    | i  |    |    |    |    |
-# CHECK-NEXT:   CortexA55UnitFPALU |    |    |    |    |    |    |    |    |    |    | x  | x  |    |    |    |
-# CHECK-NEXT: SU(11)               |    |    |    |    |    |    |    |    |    |    |    |    |    |    | i  |
-# CHECK-NEXT:     CortexA55UnitALU |    |    |    |    |    |    |    |    |    |    |    |    |    |    | x  |
-# CHECK-NEXT: SU(12)               |    |    |    |    |    |    |    |    |    |    |    |    |    |    | i  |
-# CHECK-NEXT:     CortexA55UnitALU |    |    |    |    |    |    |    |    |    |    |    |    |    |    | x  |
+# CHECK-NEXT: Cycle              | 17 | 16 | 15 | 14 | 13 | 12 | 11 | 10 | 9  | 8  | 7  | 6  | 5  | 4  | 3  |
+# CHECK-NEXT: SU(2)              | i  |    |    |    |    |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT:   CortexA55UnitALU | x  |    |    |    |    |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT: SU(4)              |    | i  |    |    |    |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT: CortexA55UnitFPALU |    | x  | x  |    |    |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT: SU(1)              |    |    | i  |    |    |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT:   CortexA55UnitALU |    |    | x  |    |    |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT: SU(0)              |    |    |    | i  |    |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT:   CortexA55UnitALU |    |    |    | x  |    |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT: SU(3)              |    |    |    |    | i  |    |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT: CortexA55UnitFPALU |    |    |    |    | x  | x  |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT: SU(6)              |    |    |    |    |    | i  |    |    |    |    |    |    |    |    |    |
+# CHECK-NEXT: CortexA55UnitFPALU |    |    |    |    |    | x  | x  |    |    |    |    |    |    |    |    |
+# CHECK-NEXT: SU(5)              |    |    |    |    |    |    |    | i  |    |    |    |    |    |    |    |
+# CHECK-NEXT: CortexA55UnitFPALU |    |    |    |    |    |    |    | x  | x  |    |    |    |    |    |    |
+# CHECK-NEXT: SU(7)              |    |    |    |    |    |    |    | i  |    |    |    |    |    |    |    |
+# CHECK-NEXT: CortexA55UnitFPALU |    |    |    |    |    |    |    | x  |    |    |    |    |    |    |    |
+# CHECK-NEXT: SU(9)              |    |    |    |    |    |    |    |    | i  |    |    |    |    |    |    |
+# CHECK-NEXT: CortexA55UnitFPALU |    |    |    |    |    |    |    |    | x  |    |    |    |    |    |    |
+# CHECK-NEXT: SU(8)              |    |    |    |    |    |    |    |    |    | i  |    |    |    |    |    |
+# CHECK-NEXT: CortexA55UnitFPALU |    |    |    |    |    |    |    |    |    | x  | x  |    |    |    |    |
+# CHECK-NEXT: SU(10)             |    |    |    |    |    |    |    |    |    |    | i  |    |    |    |    |
+# CHECK-NEXT: CortexA55UnitFPALU |    |    |    |    |    |    |    |    |    |    | x  | x  |    |    |    |
+# CHECK-NEXT: SU(11)             |    |    |    |    |    |    |    |    |    |    |    |    |    |    | i  |
+# CHECK-NEXT:   CortexA55UnitALU |    |    |    |    |    |    |    |    |    |    |    |    |    |    | x  |
+# CHECK-NEXT: SU(12)             |    |    |    |    |    |    |    |    |    |    |    |    |    |    | i  |
+# CHECK-NEXT:   CortexA55UnitALU |    |    |    |    |    |    |    |    |    |    |    |    |    |    | x  |
 # CHECK-NEXT: SU(2) [TopReadyCycle = 0, BottomReadyCycle = 17]:   %0:fpr128 = COPY $q0
 # CHECK-NEXT: SU(4) [TopReadyCycle = 0, BottomReadyCycle = 16]:   %6:fpr128 = MOVIv2d_ns 17
 # CHECK-NEXT: SU(1) [TopReadyCycle = 0, BottomReadyCycle = 15]:   %1:fpr128 = COPY $q1

--- a/llvm/test/CodeGen/AArch64/misched-detail-resource-booking-02.mir
+++ b/llvm/test/CodeGen/AArch64/misched-detail-resource-booking-02.mir
@@ -25,17 +25,17 @@ body:             |
     
 # CHECK-LABEL: Before MISched:
 # CHECK-NEXT: # Machine code for function f: IsSSA, NoPHIs, TracksLiveness, NoVRegs
-# CHECK-EMPTY: 
+# CHECK-EMPTY:
 # CHECK-NEXT: bb.0:
 # CHECK-NEXT:   liveins: $x0, $x1, $x2
 # CHECK-NEXT:   $x3 = ADDXrr $x0, $x0
 # CHECK-NEXT:   $x4 = ADDXrr $x1, $x1
 # CHECK-NEXT:   $x5 = ADDXrr $x2, $x2
-# CHECK-EMPTY: 
+# CHECK-EMPTY:
 # CHECK-NEXT: # End machine code for function f.
-# CHECK-EMPTY: 
+# CHECK-EMPTY:
 # CHECK-NEXT: ********** MI Scheduling **********
-# CHECK-NEXT: f:%bb.0 
+# CHECK-NEXT: f:%bb.0
 # CHECK-NEXT:   From: $x3 = ADDXrr $x0, $x0
 # CHECK-NEXT:     To: End
 # CHECK-NEXT:  RegionInstrs: 3
@@ -67,7 +67,7 @@ body:             |
 # CHECK-NEXT:   Depth              : 0
 # CHECK-NEXT:   Height             : 0
 # CHECK-NEXT:   Single Issue       : false;
-# CHECK-NEXT:   Resource booking (@0c): 
+# CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -80,11 +80,12 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@0c): 
+# CHECK-NEXT:   getNextResourceCycle (@0c):
 # CHECK-NEXT:     Instance 0 available @0c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @0c
-# CHECK-NEXT:   Resource booking (@0c): 
+# CHECK-NEXT:   Move SU(0) into Available Q
+# CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -97,11 +98,12 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@0c): 
+# CHECK-NEXT:   getNextResourceCycle (@0c):
 # CHECK-NEXT:     Instance 0 available @0c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @0c
-# CHECK-NEXT:   Resource booking (@0c): 
+# CHECK-NEXT:   Move SU(1) into Available Q
+# CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -114,11 +116,12 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@0c): 
+# CHECK-NEXT:   getNextResourceCycle (@0c):
 # CHECK-NEXT:     Instance 0 available @0c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @0c
-# CHECK-NEXT:   Resource booking (@0c): 
+# CHECK-NEXT:   Move SU(2) into Available Q
+# CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -131,11 +134,12 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@0c): 
+# CHECK-NEXT:   getNextResourceCycle (@0c):
 # CHECK-NEXT:     Instance 0 available @0c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @0c
-# CHECK-NEXT:   Resource booking (@0c): 
+# CHECK-NEXT:   Move SU(2) into Available Q
+# CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -148,11 +152,12 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@0c): 
+# CHECK-NEXT:   getNextResourceCycle (@0c):
 # CHECK-NEXT:     Instance 0 available @0c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @0c
-# CHECK-NEXT:   Resource booking (@0c): 
+# CHECK-NEXT:   Move SU(1) into Available Q
+# CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -165,13 +170,14 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@0c): 
+# CHECK-NEXT:   getNextResourceCycle (@0c):
 # CHECK-NEXT:     Instance 0 available @0c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @0c
+# CHECK-NEXT:   Move SU(0) into Available Q
 # CHECK-NEXT: Critical Path(GS-RR ): 0
 # CHECK-NEXT: ** ScheduleDAGMILive::schedule picking next node
-# CHECK-NEXT:   Resource booking (@0c): 
+# CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -184,11 +190,11 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@0c): 
+# CHECK-NEXT:   getNextResourceCycle (@0c):
 # CHECK-NEXT:     Instance 0 available @0c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @0c
-# CHECK-NEXT:   Resource booking (@0c): 
+# CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -201,11 +207,11 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@0c): 
+# CHECK-NEXT:   getNextResourceCycle (@0c):
 # CHECK-NEXT:     Instance 0 available @0c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @0c
-# CHECK-NEXT:   Resource booking (@0c): 
+# CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -218,18 +224,18 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@0c): 
+# CHECK-NEXT:   getNextResourceCycle (@0c):
 # CHECK-NEXT:     Instance 0 available @0c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @0c
-# CHECK-NEXT: Queue BotQ.P: 
-# CHECK-NEXT: Queue BotQ.A: 2 1 0 
-# CHECK-NEXT:   Cand SU(2) FIRST                              
-# CHECK-NEXT: Pick Bot FIRST     
+# CHECK-NEXT: Queue BotQ.P:
+# CHECK-NEXT: Queue BotQ.A: 2 1 0
+# CHECK-NEXT:   Cand SU(2) FIRST
+# CHECK-NEXT: Pick Bot FIRST
 # CHECK-NEXT: Scheduling SU(2) $x5 = ADDXrr $x2, $x2
 # CHECK-NEXT:   Ready @0c
 # CHECK-NEXT:   CortexA55UnitALU +1x1u
-# CHECK-NEXT:   Resource booking (@0c): 
+# CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -242,11 +248,11 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@0c): 
+# CHECK-NEXT:   getNextResourceCycle (@0c):
 # CHECK-NEXT:     Instance 0 available @0c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @0c
-# CHECK-NEXT:   Resource booking (@0c): 
+# CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -259,7 +265,7 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@0c): 
+# CHECK-NEXT:   getNextResourceCycle (@0c):
 # CHECK-NEXT:     Instance 0 available @0c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @0c
@@ -282,7 +288,7 @@ body:             |
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
 # CHECK-NEXT: ** ScheduleDAGMILive::schedule picking next node
-# CHECK-NEXT:   Resource booking (@0c): 
+# CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 0
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -295,11 +301,11 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@0c): 
+# CHECK-NEXT:   getNextResourceCycle (@0c):
 # CHECK-NEXT:     Instance 0 available @1c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[1] available @0c
-# CHECK-NEXT:   Resource booking (@0c): 
+# CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 0
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -312,19 +318,19 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@0c): 
+# CHECK-NEXT:   getNextResourceCycle (@0c):
 # CHECK-NEXT:     Instance 0 available @1c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[1] available @0c
-# CHECK-NEXT: Queue BotQ.P: 
-# CHECK-NEXT: Queue BotQ.A: 0 1 
-# CHECK-NEXT:   Cand SU(0) FIRST                              
-# CHECK-NEXT:   Cand SU(1) ORDER                              
-# CHECK-NEXT: Pick Bot ORDER     
+# CHECK-NEXT: Queue BotQ.P:
+# CHECK-NEXT: Queue BotQ.A: 0 1
+# CHECK-NEXT:   Cand SU(0) FIRST
+# CHECK-NEXT:   Cand SU(1) ORDER
+# CHECK-NEXT: Pick Bot ORDER
 # CHECK-NEXT: Scheduling SU(1) $x4 = ADDXrr $x1, $x1
 # CHECK-NEXT:   Ready @0c
 # CHECK-NEXT:   CortexA55UnitALU +1x1u
-# CHECK-NEXT:   Resource booking (@0c): 
+# CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 0
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -337,11 +343,11 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@0c): 
+# CHECK-NEXT:   getNextResourceCycle (@0c):
 # CHECK-NEXT:     Instance 0 available @1c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[1] available @0c
-# CHECK-NEXT:   Resource booking (@0c): 
+# CHECK-NEXT:   Resource booking (@0c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 0
 # CHECK-NEXT: CortexA55UnitALU(1) = 4294967295
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -354,7 +360,7 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@0c): 
+# CHECK-NEXT:   getNextResourceCycle (@0c):
 # CHECK-NEXT:     Instance 0 available @1c
 # CHECK-NEXT:     Instance 1 available @0c
 # CHECK-NEXT:     selecting CortexA55UnitALU[1] available @0c
@@ -379,7 +385,7 @@ body:             |
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
 # CHECK-NEXT: ** ScheduleDAGMILive::schedule picking next node
-# CHECK-NEXT:   Resource booking (@1c): 
+# CHECK-NEXT:   Resource booking (@1c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 0
 # CHECK-NEXT: CortexA55UnitALU(1) = 0
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -392,16 +398,16 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@1c): 
+# CHECK-NEXT:   getNextResourceCycle (@1c):
 # CHECK-NEXT:     Instance 0 available @1c
 # CHECK-NEXT:     Instance 1 available @1c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @1c
-# CHECK-NEXT: Queue BotQ.P: 
-# CHECK-NEXT: Queue BotQ.A: 0 
+# CHECK-NEXT: Queue BotQ.P:
+# CHECK-NEXT: Queue BotQ.A: 0
 # CHECK-NEXT: Scheduling SU(0) $x3 = ADDXrr $x0, $x0
 # CHECK-NEXT:   Ready @1c
 # CHECK-NEXT:   CortexA55UnitALU +1x1u
-# CHECK-NEXT:   Resource booking (@1c): 
+# CHECK-NEXT:   Resource booking (@1c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 0
 # CHECK-NEXT: CortexA55UnitALU(1) = 0
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -414,11 +420,11 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@1c): 
+# CHECK-NEXT:   getNextResourceCycle (@1c):
 # CHECK-NEXT:     Instance 0 available @1c
 # CHECK-NEXT:     Instance 1 available @1c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @1c
-# CHECK-NEXT:   Resource booking (@1c): 
+# CHECK-NEXT:   Resource booking (@1c):
 # CHECK-NEXT: CortexA55UnitALU(0) = 0
 # CHECK-NEXT: CortexA55UnitALU(1) = 0
 # CHECK-NEXT: CortexA55UnitB(0) = 4294967295
@@ -431,7 +437,7 @@ body:             |
 # CHECK-NEXT: CortexA55UnitLd(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitMAC(0) = 4294967295
 # CHECK-NEXT: CortexA55UnitSt(0) = 4294967295
-# CHECK-NEXT:   getNextResourceCycle (@1c): 
+# CHECK-NEXT:   getNextResourceCycle (@1c):
 # CHECK-NEXT:     Instance 0 available @1c
 # CHECK-NEXT:     Instance 1 available @1c
 # CHECK-NEXT:     selecting CortexA55UnitALU[0] available @1c
@@ -460,15 +466,15 @@ body:             |
 # CHECK-NEXT:   x: resource booked
 # CHECK-NEXT: Cycle              | 1 | 0 |
 # CHECK-NEXT: SU(0)              | i |   |
-# CHECK-NEXT:   CortexA55UnitALU | x |   | 
+# CHECK-NEXT:   CortexA55UnitALU | x |   |
 # CHECK-NEXT: SU(1)              |   | i |
-# CHECK-NEXT:   CortexA55UnitALU |   | x | 
+# CHECK-NEXT:   CortexA55UnitALU |   | x |
 # CHECK-NEXT: SU(2)              |   | i |
-# CHECK-NEXT:   CortexA55UnitALU |   | x | 
+# CHECK-NEXT:   CortexA55UnitALU |   | x |
 # CHECK-NEXT: SU(0) [TopReadyCycle = 0, BottomReadyCycle = 1]:   $x3 = ADDXrr $x0, $x0
 # CHECK-NEXT: SU(1) [TopReadyCycle = 0, BottomReadyCycle = 0]:   $x4 = ADDXrr $x1, $x1
 # CHECK-NEXT: SU(2) [TopReadyCycle = 0, BottomReadyCycle = 0]:   $x5 = ADDXrr $x2, $x2
-# CHECK-EMPTY: 
+# CHECK-EMPTY:
 # CHECK-NEXT: ********** INTERVALS **********
 # CHECK-NEXT: W0 [0B,16r:0) 0@0B-phi
 # CHECK-NEXT: W1 [0B,32r:0) 0@0B-phi
@@ -479,11 +485,11 @@ body:             |
 # CHECK-NEXT: RegMasks:
 # CHECK-NEXT: ********** MACHINEINSTRS **********
 # CHECK-NEXT: # Machine code for function f: IsSSA, NoPHIs, TracksLiveness, NoVRegs
-# CHECK-EMPTY: 
+# CHECK-EMPTY:
 # CHECK-NEXT: 0B	bb.0:
 # CHECK-NEXT: 	  liveins: $x0, $x1, $x2
 # CHECK-NEXT: 16B	  $x3 = ADDXrr $x0, $x0
 # CHECK-NEXT: 32B	  $x4 = ADDXrr $x1, $x1
 # CHECK-NEXT: 48B	  $x5 = ADDXrr $x2, $x2
-# CHECK-EMPTY: 
+# CHECK-EMPTY:
 # CHECK-NEXT: # End machine code for function f.


### PR DESCRIPTION
While we already have some detailed debug messages on the candidate selection process -- which selects a SUnit from the Available queue, we didn't say much about why a SUnit was _not_ moved from Pending queue to Available queue in the first place, which is just as important as why we scheduled a node IMHO.  Therefore, I added some debug prints for this very purpose.

I decide to print these extra messages by default (instead of being guarded by command line like `-misched-detail-resource-booking`) because we have been printing some of the hazard remarks, so I thought we might as well print these new messages -- which are mostly about hazard -- by default.