### PR TITLE
[lld] Merge equivalent symbols found during ICF

### DIFF
--- a/lld/ELF/ICF.cpp
+++ b/lld/ELF/ICF.cpp
@@ -561,7 +561,7 @@ template <class ELFT> void ICF<ELFT>::run() {
 
   EquivalenceClasses<Symbol *> symbolEquivalence;
   // Merge sections by the equivalence class.
-  // Merge symbols identified as equivalent during ICF
+  // Merge symbols identified as equivalent during ICF.
   forEachClassRange(0, sections.size(), [&](size_t begin, size_t end) {
     if (end - begin == 1)
       return;

--- a/lld/ELF/ICF.cpp
+++ b/lld/ELF/ICF.cpp
@@ -602,7 +602,8 @@ template <class ELFT> void ICF<ELFT>::run() {
     fold(sym);
     auto it = symbolEquivalence.findLeader(sym);
     if (it != symbolEquivalence.member_end() && *it != sym) {
-      print() << "Redirecting " << sym->getName() << " to " << (*it)->getName();
+      print() << "redirecting '" << sym->getName() << "' in symtab to '"
+              << (*it)->getName() << "'";
       ctx.symtab->redirect(sym, *it);
     }
   }
@@ -612,8 +613,8 @@ template <class ELFT> void ICF<ELFT>::run() {
     for (Symbol *&sym : file->getMutableGlobalSymbols()) {
       auto it = symbolEquivalence.findLeader(sym);
       if (it != symbolEquivalence.member_end() && *it != sym) {
-        print() << "Redirecting " << sym->getName() << " to "
-                << (*it)->getName();
+        print() << "redirecting '" << sym->getName() << "' to '"
+                << (*it)->getName() << "'";
         sym = *it;
       }
     }

--- a/lld/ELF/ICF.cpp
+++ b/lld/ELF/ICF.cpp
@@ -333,6 +333,28 @@ bool ICF<ELFT>::equalsConstant(const InputSection *a, const InputSection *b) {
              : constantEq(a, ra.relas, b, rb.relas);
 }
 
+template <class RelTy>
+static SmallVector<Symbol *> getReloc(const InputSection *sec,
+                                      Relocs<RelTy> relocs) {
+  SmallVector<Symbol *> syms;
+  for (auto ri = relocs.begin(), re = relocs.end(); ri != re; ++ri) {
+    Symbol &sym = sec->file->getRelocTargetSym(*ri);
+    syms.push_back(&sym);
+  }
+  return syms;
+}
+
+template <class ELFT>
+static SmallVector<Symbol *> getRelocTargetSyms(const InputSection *sec) {
+  const RelsOrRelas<ELFT> rel = sec->template relsOrRelas<ELFT>();
+  if (rel.areRelocsCrel())
+    return getReloc(sec, rel.crels);
+  if (rel.areRelocsRel())
+    return getReloc(sec, rel.rels);
+
+  return getReloc(sec, rel.relas);
+}
+
 // Compare two lists of relocations. Returns true if all pairs of
 // relocations point to the same section in terms of ICF.
 template <class ELFT>
@@ -535,14 +557,35 @@ template <class ELFT> void ICF<ELFT>::run() {
   auto print = [&ctx = ctx]() -> ELFSyncStream {
     return {ctx, ctx.arg.printIcfSections ? DiagLevel::Msg : DiagLevel::None};
   };
+
+  DenseMap<Symbol *, Symbol *> symbolMap;
   // Merge sections by the equivalence class.
+  // Merge symbols identified as equivalent during ICF
   forEachClassRange(0, sections.size(), [&](size_t begin, size_t end) {
     if (end - begin == 1)
       return;
     print() << "selected section " << sections[begin];
+    SmallVector<Symbol *> syms = getRelocTargetSyms<ELFT>(sections[begin]);
     for (size_t i = begin + 1; i < end; ++i) {
       print() << "  removing identical section " << sections[i];
       sections[begin]->replace(sections[i]);
+      SmallVector<Symbol *> replacedSyms =
+          getRelocTargetSyms<ELFT>(sections[i]);
+      assert(syms.size() == replacedSyms.size() &&
+             "Should have same number of syms!");
+      for (size_t i = 0; i < syms.size(); i++) {
+        if (syms[i] == replacedSyms[i] || !syms[i]->isGlobal() ||
+            !replacedSyms[i]->isGlobal())
+          continue;
+        auto [it, inserted] =
+            symbolMap.insert(std::make_pair(replacedSyms[i], syms[i]));
+        print() << "  selected symbol: " << syms[i]->getName().data()
+                << "; replaced symbol: " << replacedSyms[i]->getName().data();
+        if (!inserted) {
+          print() << "    replacement already exists: "
+                  << it->getSecond()->getName().data();
+        }
+      }
 
       // At this point we know sections merged are fully identical and hence
       // we want to remove duplicate implicit dependencies such as link order
@@ -561,11 +604,17 @@ template <class ELFT> void ICF<ELFT>::run() {
           d->folded = true;
         }
   };
-  for (Symbol *sym : ctx.symtab->getSymbols())
+  for (Symbol *sym : ctx.symtab->getSymbols()) {
     fold(sym);
+    if (Symbol *s = symbolMap.lookup(sym))
+      ctx.symtab->redirect(sym, s);
+  }
   parallelForEach(ctx.objectFiles, [&](ELFFileBase *file) {
     for (Symbol *sym : file->getLocalSymbols())
       fold(sym);
+    for (Symbol *&sym : file->getMutableGlobalSymbols())
+      if (Symbol *s = symbolMap.lookup(sym))
+        sym = s;
   });
 
   // InputSectionDescription::sections is populated by processSectionCommands().

--- a/lld/ELF/SymbolTable.cpp
+++ b/lld/ELF/SymbolTable.cpp
@@ -32,7 +32,6 @@ using namespace lld::elf;
 void SymbolTable::redirect(Symbol *from, Symbol *to) {
   int &fromIdx = symMap[CachedHashStringRef(from->getName())];
   const int toIdx = symMap[CachedHashStringRef(to->getName())];
-
   fromIdx = toIdx;
 }
 

--- a/lld/ELF/SymbolTable.cpp
+++ b/lld/ELF/SymbolTable.cpp
@@ -29,6 +29,13 @@ using namespace llvm::ELF;
 using namespace lld;
 using namespace lld::elf;
 
+void SymbolTable::redirect(Symbol *from, Symbol *to) {
+  int &fromIdx = symMap[CachedHashStringRef(from->getName())];
+  const int toIdx = symMap[CachedHashStringRef(to->getName())];
+
+  fromIdx = toIdx;
+}
+
 void SymbolTable::wrap(Symbol *sym, Symbol *real, Symbol *wrap) {
   // Redirect __real_foo to the original foo and foo to the original __wrap_foo.
   int &idx1 = symMap[CachedHashStringRef(sym->getName())];

--- a/lld/ELF/SymbolTable.h
+++ b/lld/ELF/SymbolTable.h
@@ -41,6 +41,7 @@ public:
   SymbolTable(Ctx &ctx) : ctx(ctx) {}
   ArrayRef<Symbol *> getSymbols() const { return symVector; }
 
+  void redirect(Symbol *from, Symbol *to);
   void wrap(Symbol *sym, Symbol *real, Symbol *wrap);
 
   Symbol *insert(StringRef name);

--- a/lld/test/ELF/aarch64-got-merging-icf.s
+++ b/lld/test/ELF/aarch64-got-merging-icf.s
@@ -1,4 +1,5 @@
-// REQUIRES: aarch64
+## REQUIRES: aarch64
+## Check that symbols that ICF assumes to be the same get a single GOT entry
 
 # RUN: llvm-mc -filetype=obj -triple=aarch64 %s -o %t
 # RUN: llvm-mc -filetype=obj -crel -triple=aarch64 %s -o %tcrel

--- a/lld/test/ELF/aarch64-got-merging-icf.s
+++ b/lld/test/ELF/aarch64-got-merging-icf.s
@@ -1,13 +1,21 @@
 // REQUIRES: aarch64
 
 # RUN: llvm-mc -filetype=obj -triple=aarch64 %s -o %t
+# RUN: llvm-mc -filetype=obj -crel -triple=aarch64 %s -o %tcrel
 # RUN: ld.lld %t -o %t2 --icf=all
+# RUN: ld.lld %tcrel -o %tcrel2 --icf=all
+
 # RUN: llvm-objdump --section-headers %t2 | FileCheck %s --check-prefix=EXE
+# RUN: llvm-objdump --section-headers %tcrel2 | FileCheck %s --check-prefix=EXE
 
 # RUN: ld.lld -shared %t -o %t3 --icf=all
-# RUN: llvm-objdump --section-headers %t3 | FileCheck %s --check-prefix=DSO
+# RUN: ld.lld -shared %tcrel -o %tcrel3 --icf=all
 
-## All .rodata.* sections should merge into a single GOT entry
+# RUN: llvm-objdump --section-headers %t3 | FileCheck %s --check-prefix=DSO
+# RUN: llvm-objdump --section-headers %tcrel3 | FileCheck %s --check-prefix=DSO
+
+## All global g* symbols should merge into a single GOT entry while non-global
+## gets its own GOT entry.
 # EXE: {{.*}}.got 00000010{{.*}}
 
 ## When symbols are preemptible in DSO mode, GOT entries wouldn't be merged
@@ -50,7 +58,8 @@ bl f1_\index
 
 .endm
 
-# another set of sections merging: g1 <- g2
+## Another set of sections merging: g1 <- g2. Linker should be able to
+## resolve both g1 and g2 to g0 based on ICF on previous sections.
 
 .section .text.t1_0,"ax",@progbits
 t1_0:

--- a/lld/test/ELF/aarch64-got-merging-icf.s
+++ b/lld/test/ELF/aarch64-got-merging-icf.s
@@ -8,7 +8,7 @@
 # RUN: llvm-objdump --section-headers %t3 | FileCheck %s --check-prefix=DSO
 
 ## All .rodata.* sections should merge into a single GOT entry
-# EXE: {{.*}}.got 00000008{{.*}}
+# EXE: {{.*}}.got 00000010{{.*}}
 
 ## When symbols are preemptible in DSO mode, GOT entries wouldn't be merged
 # DSO: {{.*}}.got 00000020{{.*}}

--- a/lld/test/ELF/aarch64-got-merging-icf.s
+++ b/lld/test/ELF/aarch64-got-merging-icf.s
@@ -11,7 +11,7 @@
 # EXE: {{.*}}.got 00000010{{.*}}
 
 ## When symbols are preemptible in DSO mode, GOT entries wouldn't be merged
-# DSO: {{.*}}.got 00000020{{.*}}
+# DSO: {{.*}}.got 00000028{{.*}}
 
 .addrsig
 
@@ -50,6 +50,30 @@ bl f1_\index
 
 .endm
 
+# another set of sections merging: g1 <- g2
+
+.section .text.t1_0,"ax",@progbits
+t1_0:
+adrp x2, :got:g1
+mov x3, #1
+b t2_0
+
+.section .text.t2_0,"ax",@progbits
+t2_0:
+ldr x2, [x2, :got_lo12:g1]
+b callee
+
+.section .text.t1_1,"ax",@progbits
+t1_1:
+adrp x2, :got:g2
+mov x3, #2
+b t2_1
+
+.section .text.t2_1,"ax",@progbits
+t2_1:
+ldr x2, [x2, :got_lo12:g2]
+b callee
+
 .section .text._start,"ax",@progbits
 .globl _start
 _start:
@@ -57,4 +81,5 @@ _start:
 f 0 1
 f 1 1
 f 2 1
-f 3
+f 3 1
+f 4

--- a/lld/test/ELF/aarch64-got-merging-icf.s
+++ b/lld/test/ELF/aarch64-got-merging-icf.s
@@ -1,0 +1,68 @@
+// REQUIRES: aarch64
+
+# RUN: llvm-mc -filetype=obj -triple=aarch64 %s -o %t
+# RUN: ld.lld %t -o %t2 --icf=all
+# RUN: llvm-objdump --section-headers %t2 | FileCheck %s --check-prefix=EXE
+
+# RUN: ld.lld -shared %t -o %t3 --icf=all
+# RUN: llvm-objdump --section-headers %t3 | FileCheck %s --check-prefix=DSO
+
+## All .rodata.* sections should merge into a single GOT entry
+# EXE: {{.*}}.got 00000008{{.*}}
+
+## When symbols are preemptible in DSO mode, GOT entries wouldn't be merged
+# DSO: {{.*}}.got 00000020{{.*}}
+
+.addrsig
+
+callee:
+ret
+
+.section .rodata.dummy1,"a",@progbits
+sym1:
+.long 111
+.long 122
+.byte 123
+
+.section .rodata.dummy2,"a",@progbits
+sym2:
+.long 111
+.long 122
+sym3:
+.byte 123
+
+.macro f, index
+
+.section .text.f1_\index,"ax",@progbits
+f1_\index:
+adrp x0, :got:g\index
+mov x1, #\index
+b f2_\index
+
+.section .text.f2_\index,"ax",@progbits
+f2_\index:
+ldr x0, [x0, :got_lo12:g\index] 
+b callee
+
+.globl g\index
+.section .rodata.g\index,"a",@progbits
+g_\index:
+.long 111
+.long 122
+
+g\index:
+.byte 123
+
+.section .text._start,"ax",@progbits
+bl f1_\index
+
+.endm
+
+.section .text._start,"ax",@progbits
+.globl _start
+_start:
+
+f 0
+f 1
+f 2
+f 3

--- a/lld/test/ELF/aarch64-got-merging-icf.s
+++ b/lld/test/ELF/aarch64-got-merging-icf.s
@@ -18,20 +18,7 @@
 callee:
 ret
 
-.section .rodata.dummy1,"a",@progbits
-sym1:
-.long 111
-.long 122
-.byte 123
-
-.section .rodata.dummy2,"a",@progbits
-sym2:
-.long 111
-.long 122
-sym3:
-.byte 123
-
-.macro f, index
+.macro f, index, isglobal
 
 # (Kept unique) first instruction of the GOT code sequence
 .section .text.f1_\index,"ax",@progbits
@@ -47,7 +34,9 @@ ldr x0, [x0, :got_lo12:g\index]
 b callee
 
 # Folded
+.ifnb \isglobal
 .globl g\index
+.endif
 .section .rodata.g\index,"a",@progbits
 g_\index:
 .long 111
@@ -65,7 +54,7 @@ bl f1_\index
 .globl _start
 _start:
 
-f 0
-f 1
-f 2
+f 0 1
+f 1 1
+f 2 1
 f 3

--- a/lld/test/ELF/aarch64-got-merging-icf.s
+++ b/lld/test/ELF/aarch64-got-merging-icf.s
@@ -33,17 +33,20 @@ sym3:
 
 .macro f, index
 
+# (Kept unique) first instruction of the GOT code sequence
 .section .text.f1_\index,"ax",@progbits
 f1_\index:
 adrp x0, :got:g\index
 mov x1, #\index
 b f2_\index
 
+# Folded, second instruction of the GOT code sequence
 .section .text.f2_\index,"ax",@progbits
 f2_\index:
 ldr x0, [x0, :got_lo12:g\index] 
 b callee
 
+# Folded
 .globl g\index
 .section .rodata.g\index,"a",@progbits
 g_\index:

--- a/lld/test/ELF/icf-preemptible.s
+++ b/lld/test/ELF/icf-preemptible.s
@@ -11,16 +11,15 @@
 # EXE-NOT:  {{.}}
 # EXE:      selected section {{.*}}:(.text.g1)
 # EXE-NEXT:   removing identical section {{.*}}:(.text.g2)
-# EXE-NEXT:   selected symbol: f1; replaced symbol: f2
 # EXE-NEXT:   removing identical section {{.*}}:(.text.g3)
 # EXE-NEXT: selected section {{.*}}:(.text.f1)
 # EXE-NEXT:   removing identical section {{.*}}:(.text.f2)
 # EXE-NEXT: selected section {{.*}}:(.text.h1)
 # EXE-NEXT:   removing identical section {{.*}}:(.text.h2)
-# EXE-NEXT:   selected symbol: g1; replaced symbol: g2
 # EXE-NEXT:   removing identical section {{.*}}:(.text.h3)
-# EXE-NEXT:   selected symbol: g1; replaced symbol: g3
-# EXE-NOT:  {{.}}
+# EXE-NEXT: Redirecting f2 to f1
+# EXE-NEXT: Redirecting g2 to g1
+# EXE-NEXT: Redirecting g3 to g1
 
 ## Definitions are preemptible in a DSO. Only leaf functions can be folded.
 # DSO-NOT:  {{.}}

--- a/lld/test/ELF/icf-preemptible.s
+++ b/lld/test/ELF/icf-preemptible.s
@@ -11,12 +11,15 @@
 # EXE-NOT:  {{.}}
 # EXE:      selected section {{.*}}:(.text.g1)
 # EXE-NEXT:   removing identical section {{.*}}:(.text.g2)
+# EXE-NEXT:   selected symbol: f1; replaced symbol: f2
 # EXE-NEXT:   removing identical section {{.*}}:(.text.g3)
 # EXE-NEXT: selected section {{.*}}:(.text.f1)
 # EXE-NEXT:   removing identical section {{.*}}:(.text.f2)
 # EXE-NEXT: selected section {{.*}}:(.text.h1)
 # EXE-NEXT:   removing identical section {{.*}}:(.text.h2)
+# EXE-NEXT:   selected symbol: g1; replaced symbol: g2
 # EXE-NEXT:   removing identical section {{.*}}:(.text.h3)
+# EXE-NEXT:   selected symbol: g1; replaced symbol: g3
 # EXE-NOT:  {{.}}
 
 ## Definitions are preemptible in a DSO. Only leaf functions can be folded.

--- a/lld/test/ELF/icf-preemptible.s
+++ b/lld/test/ELF/icf-preemptible.s
@@ -17,9 +17,13 @@
 # EXE-NEXT: selected section {{.*}}:(.text.h1)
 # EXE-NEXT:   removing identical section {{.*}}:(.text.h2)
 # EXE-NEXT:   removing identical section {{.*}}:(.text.h3)
-# EXE-NEXT: Redirecting f2 to f1
-# EXE-NEXT: Redirecting g2 to g1
-# EXE-NEXT: Redirecting g3 to g1
+# EXE-NEXT: redirecting 'f2' in symtab to 'f1'
+# EXE-NEXT: redirecting 'g2' in symtab to 'g1'
+# EXE-NEXT: redirecting 'g3' in symtab to 'g1'
+# EXE-NEXT: redirecting 'f2' to 'f1'
+# EXE-NEXT: redirecting 'g2' to 'g1'
+# EXE-NEXT: redirecting 'g3' to 'g1'
+# EXE-NOT:  {{.}}
 
 ## Definitions are preemptible in a DSO. Only leaf functions can be folded.
 # DSO-NOT:  {{.}}


### PR DESCRIPTION
Fixes a correctness issue for AArch64 when ADRP and LDR instructions are outlined in separate sections and sections are fed to ICF for deduplication.

See test case (based on https://github.com/llvm/llvm-project/issues/129122) for details. All rodata.* sections are folded into a single section with ICF. This leads to all f2_* function sections getting folded into one (as their relocation target symbols g* belong to .rodata.g* sections that have already been folded into one). Since relocations still refer original g* symbols, we end up creating duplicate GOT entry for all such symbols. This PR addresses that by tracking such folded symbols and create one GOT entry for all such symbols.

Fixes https://github.com/llvm/llvm-project/issues/129122

Co-authored by: @jyknight 