### PR TITLE
[flang] Defined SafeTempArrayCopyAttrInterface for array repacking.

### DIFF
--- a/flang/include/flang/Lower/ConvertVariable.h
+++ b/flang/include/flang/Lower/ConvertVariable.h
@@ -194,8 +194,8 @@ fir::ExtendedValue genPackArray(Fortran::lower::AbstractConverter &converter,
 /// to the given symbol, generate fir.unpack_array operation
 /// that reverts the effect of fir.pack_array.
 /// \p def is expected to be hlfir.declare operation.
-void genUnpackArray(fir::FirOpBuilder &builder, mlir::Location loc,
-                    fir::FortranVariableOpInterface def,
+void genUnpackArray(Fortran::lower::AbstractConverter &converter,
+                    mlir::Location loc, fir::FortranVariableOpInterface def,
                     const Fortran::semantics::Symbol &sym);
 
 } // namespace lower

--- a/flang/include/flang/Optimizer/Dialect/CMakeLists.txt
+++ b/flang/include/flang/Optimizer/Dialect/CMakeLists.txt
@@ -29,6 +29,11 @@ set(LLVM_TARGET_DEFINITIONS FirAliasTagOpInterface.td)
 mlir_tablegen(FirAliasTagOpInterface.h.inc -gen-op-interface-decls)
 mlir_tablegen(FirAliasTagOpInterface.cpp.inc -gen-op-interface-defs)
 
+set(LLVM_TARGET_DEFINITIONS SafeTempArrayCopyAttrInterface.td)
+mlir_tablegen(SafeTempArrayCopyAttrInterface.h.inc -gen-attr-interface-decls)
+mlir_tablegen(SafeTempArrayCopyAttrInterface.cpp.inc -gen-attr-interface-defs)
+add_public_tablegen_target(FIRSafeTempArrayCopyAttrInterfaceIncGen)
+
 set(LLVM_TARGET_DEFINITIONS CanonicalizationPatterns.td)
 mlir_tablegen(CanonicalizationPatterns.inc -gen-rewriters)
 add_public_tablegen_target(CanonicalizationPatternsIncGen)

--- a/flang/include/flang/Optimizer/Dialect/FIRAttr.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRAttr.h
@@ -164,4 +164,6 @@ void printFirAttribute(FIROpsDialect *dialect, mlir::Attribute attr,
 #define GET_ATTRDEF_CLASSES
 #include "flang/Optimizer/Dialect/FIRAttr.h.inc"
 
+#include "flang/Optimizer/Dialect/SafeTempArrayCopyAttrInterface.h"
+
 #endif // FORTRAN_OPTIMIZER_DIALECT_FIRATTR_H

--- a/flang/include/flang/Optimizer/Dialect/FIRAttr.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRAttr.td
@@ -178,4 +178,26 @@ def fir_PackArrayHeuristicsAttr
   let assemblyFormat = "`<` $value `>`";
 }
 
+def fir_OpenACCSafeTempArrayCopyAttr : fir_Attr<"OpenACCSafeTempArrayCopy"> {
+  let mnemonic = "acc_safe_temp_array_copy";
+  let description = [{
+    An attribute implementing SafeTempArrayCopyAttrInterface.
+    It specifies whether it is possible to dynamically check
+    if creating a temporary copy of a Fortran array is safe
+    in the context of OpenACC.
+    It also provides the methods to generate those dynamic checks.
+  }];
+}
+
+def fir_OpenMPSafeTempArrayCopyAttr : fir_Attr<"OpenMPSafeTempArrayCopy"> {
+  let mnemonic = "omp_safe_temp_array_copy";
+  let description = [{
+    An attribute implementing SafeTempArrayCopyAttrInterface.
+    It specifies whether it is possible to dynamically check
+    if creating a temporary copy of a Fortran array is safe
+    in the context of OpenMP.
+    It also provides the methods to generate those dynamic checks.
+  }];
+}
+
 #endif // FIR_DIALECT_FIR_ATTRS

--- a/flang/include/flang/Optimizer/Dialect/FIRDialect.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRDialect.h
@@ -44,6 +44,9 @@ void addFIRInlinerExtension(mlir::DialectRegistry &registry);
 // Register implementation of LLVMTranslationDialectInterface.
 void addFIRToLLVMIRExtension(mlir::DialectRegistry &registry);
 
+void registerFortranTempArrayCopyIsSafeExternalModels(
+    mlir::DialectRegistry &registry);
+
 } // namespace fir
 
 #endif // FORTRAN_OPTIMIZER_DIALECT_FIRDIALECT_H

--- a/flang/include/flang/Optimizer/Dialect/FIROps.h
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.h
@@ -14,6 +14,7 @@
 #include "flang/Optimizer/Dialect/FIRType.h"
 #include "flang/Optimizer/Dialect/FirAliasTagOpInterface.h"
 #include "flang/Optimizer/Dialect/FortranVariableInterface.h"
+#include "flang/Optimizer/Dialect/SafeTempArrayCopyAttrInterface.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMAttrs.h"

--- a/flang/include/flang/Optimizer/Dialect/FIROps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIROps.td
@@ -23,6 +23,7 @@ include "flang/Optimizer/Dialect/FIRTypes.td"
 include "flang/Optimizer/Dialect/FIRAttr.td"
 include "flang/Optimizer/Dialect/FortranVariableInterface.td"
 include "flang/Optimizer/Dialect/FirAliasTagOpInterface.td"
+include "flang/Optimizer/Dialect/SafeTempArrayCopyAttrInterface.td"
 include "mlir/IR/BuiltinAttributes.td"
 
 // Base class for FIR operations.
@@ -3378,6 +3379,14 @@ def fir_PackArrayOp
           that is eligible for repacking.
       - heuristics attribute specifies conditions when the array repacking
         may be optimized.
+      - is_safe is an optional non-empty array of SafeTempArrayCopyAttr
+        attributes. Each attribute implements SafeTempArrayCopyAttrInterface
+        that is used to generate a dynamic predicate value identifying
+        whether the creation of the temporary array copy is safe.
+        For example, if omp.fortran_safe_temp_array_copy attribute
+        is attached, its implementation may generate special code
+        to check if fir.pack_array may be executed by multiple
+        threads, and disallow repacking in this case.
   }];
 
   let arguments = (ins AnyBoxedArray:$array, UnitAttr:$stack,
@@ -3386,7 +3395,8 @@ def fir_PackArrayOp
       OptionalAttr<UI64Attr>:$min_stride,
       DefaultValuedAttr<fir_PackArrayHeuristicsAttr,
                         "::fir::PackArrayHeuristics::None">:$heuristics,
-      Variadic<AnyIntegerType>:$typeparams);
+      Variadic<AnyIntegerType>:$typeparams,
+      OptionalAttr<NonEmptySafeTempArrayCopyArrayAttr>:$is_safe);
 
   let results = (outs AnyBoxedArray:$result);
   let assemblyFormat = [{
@@ -3395,7 +3405,7 @@ def fir_PackArrayOp
     (`no_copy` $no_copy^)?
     (`constraints` custom<PackArrayConstraints>($max_size, $max_element_size, $min_stride)^)?
     (`heuristics` $heuristics^)?
-    (`typeparams` $typeparams^)?
+    (`typeparams` $typeparams^)? (`is_safe` $is_safe^)?
     attr-dict `:` functional-type(operands, results)
   }];
 
@@ -3420,15 +3430,26 @@ def fir_UnpackArrayOp
         was allocated.
       - no_copy attribute indicates that the temporary array
         is not copied into the original temporary array.
+      - is_safe is an optional non-empty array of SafeTempArrayCopyAttr
+        attributes. Each attribute implements SafeTempArrayCopyAttrInterface
+        that is used to generate extra code before any copy-out or
+        deallocation of the temporary happens.
+        For example, if acc.fortran_safe_temp_array_copy attribute
+        is attached, its implementation may generate special code
+        to check if the temporary has been transferred to OpenACC device
+        data environment, and issue a runtime error that the temporary
+        is present on the device while it is about to be deallocated
+        on the host.
   }];
 
   let arguments = (ins AnyBoxedArray:$temp, AnyBoxedArray:$original,
-      UnitAttr:$stack, UnitAttr:$no_copy);
+      UnitAttr:$stack, UnitAttr:$no_copy,
+      OptionalAttr<NonEmptySafeTempArrayCopyArrayAttr>:$is_safe);
 
   let assemblyFormat = [{
     $temp `to` $original
     (`stack` $stack^):(`heap`)?
-    (`no_copy` $no_copy^)?
+    (`no_copy` $no_copy^)? (`is_safe` $is_safe^)?
     attr-dict `:` type($original)
   }];
 

--- a/flang/include/flang/Optimizer/Dialect/SafeTempArrayCopyAttrInterface.h
+++ b/flang/include/flang/Optimizer/Dialect/SafeTempArrayCopyAttrInterface.h
@@ -1,0 +1,27 @@
+//===- SafeTempArrayCopyAttrInterface.h -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_OPTIMIZER_DIALECT_SAFETEMPARRAYCOPYATTRINTERFACE_H
+#define FORTRAN_OPTIMIZER_DIALECT_SAFETEMPARRAYCOPYATTRINTERFACE_H
+
+#include "flang/Optimizer/Dialect/FIRAttr.h"
+#include "flang/Optimizer/Dialect/FIRType.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/OpDefinition.h"
+
+namespace fir {
+class FirOpBuilder;
+}
+
+#include "flang/Optimizer/Dialect/SafeTempArrayCopyAttrInterface.h.inc"
+
+#endif // FORTRAN_OPTIMIZER_DIALECT_SAFETEMPARRAYCOPYATTRINTERFACE_H

--- a/flang/include/flang/Optimizer/Dialect/SafeTempArrayCopyAttrInterface.td
+++ b/flang/include/flang/Optimizer/Dialect/SafeTempArrayCopyAttrInterface.td
@@ -1,0 +1,81 @@
+//===- SafeTempArrayCopyAttrInterface.td -------------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+/// \file
+/// This file defines SafeTempArrayCopyAttrInterface and a generic attribute
+/// SafeTempArrayCopyAttr promising the SafeTempArrayCopyAttrInterface.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_SAFETEMPARRAYCOPYATTRINTERFACE_TD
+#define FORTRAN_SAFETEMPARRAYCOPYATTRINTERFACE_TD
+
+include "mlir/IR/OpBase.td"
+
+def SafeTempArrayCopyAttrInterface
+    : AttrInterface<"SafeTempArrayCopyAttrInterface"> {
+  let cppNamespace = "::fir";
+  let description = [{
+    Interface for attributes defining whether creation of a temporary
+    copy of a Fortran array is safe and/or how to produce proper
+    dynamic checks to avoid it, if it is unsafe.
+  }];
+
+  let methods =
+      [StaticInterfaceMethod<
+           /*desc=*/[{
+        Returns true iff the usage of the temporary array copy
+        can be made safe applying some dynamic checks.
+      }],
+           /*retTy=*/"bool",
+           /*methodName=*/"isDynamicallySafe",
+           /*args=*/(ins)>,
+       StaticInterfaceMethod<
+           /*desc=*/[{
+        Generate FIR that produces an i1 Value indicating
+        whether the creation of the temporary array copy is safe.
+        \p array is a definition of the original array.
+        The implementation may assume that \p array is present
+        (though, it may be empty).
+      }],
+           /*retTy=*/"mlir::Value",
+           /*methodName=*/"genDynamicCheck",
+           /*args=*/
+           (ins "::mlir::Location":$loc, "::fir::FirOpBuilder &":$builder,
+               "::mlir::Value":$array)>,
+       StaticInterfaceMethod<
+           /*desc=*/[{
+        This method allows inserting any FIR right before the optional
+        copy-out (from \p temp to \p array) and the deallocation
+        of the temporary array (implying that the temporary copy was
+        actually created).
+      }],
+           /*retTy=*/"void",
+           /*methodName=*/"registerTempDeallocation",
+           /*args=*/
+           (ins "::mlir::Location":$loc, "::fir::FirOpBuilder &":$builder,
+               "::mlir::Value":$array, "::mlir::Value":$temp)>,
+  ];
+}
+
+def SafeTempArrayCopyAttr
+    : ConfinedAttr<
+          AnyAttr, [PromisedAttrInterface<SafeTempArrayCopyAttrInterface>]> {
+  let description = [{
+    Generic attribute implementing or promising
+    the `SafeTempArrayCopyAttrInterface` interface.
+  }];
+}
+
+def SafeTempArrayCopyArrayAttr
+    : TypedArrayAttrBase<SafeTempArrayCopyAttr,
+                         "array of SafeTempArrayCopyAttr attributes">;
+
+def NonEmptySafeTempArrayCopyArrayAttr
+    : ConfinedAttr<SafeTempArrayCopyArrayAttr, [ArrayMinCount<1>]>;
+
+#endif // FORTRAN_SAFETEMPARRAYCOPYATTRINTERFACE_TD

--- a/flang/include/flang/Optimizer/OpenMP/Support/RegisterOpenMPExtensions.h
+++ b/flang/include/flang/Optimizer/OpenMP/Support/RegisterOpenMPExtensions.h
@@ -1,4 +1,4 @@
-//===- RegisterOpenACCExtensions.h - OpenACC Extension Registration --===--===//
+//===- RegisterOpenMPExtensions.h - OpenMP Extension Registration -*- C++ -*-=//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,18 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef FLANG_OPTIMIZER_OPENACC_REGISTEROPENACCEXTENSIONS_H_
-#define FLANG_OPTIMIZER_OPENACC_REGISTEROPENACCEXTENSIONS_H_
+#ifndef FLANG_OPTIMIZER_OPENMP_SUPPORT_REGISTEROPENMPEXTENSIONS_H_
+#define FLANG_OPTIMIZER_OPENMP_SUPPORT_REGISTEROPENMPEXTENSIONS_H_
 
 namespace mlir {
 class DialectRegistry;
 } // namespace mlir
 
-namespace fir::acc {
+namespace fir::omp {
 
-void registerOpenACCExtensions(mlir::DialectRegistry &registry);
+void registerOpenMPExtensions(mlir::DialectRegistry &registry);
 
-/// Register external models for FIR attributes related to OpenACC.
+/// Register external models for FIR attributes related to OpenMP.
 void registerAttrsExtensions(mlir::DialectRegistry &registry);
 
 /// Register all dialects whose operations may be created
@@ -25,6 +25,6 @@ void registerAttrsExtensions(mlir::DialectRegistry &registry);
 void registerTransformationalAttrsDependentDialects(
     mlir::DialectRegistry &registry);
 
-} // namespace fir::acc
+} // namespace fir::omp
 
-#endif // FLANG_OPTIMIZER_OPENACC_REGISTEROPENACCEXTENSIONS_H_
+#endif // FLANG_OPTIMIZER_OPENMP_SUPPORT_REGISTEROPENMPEXTENSIONS_H_

--- a/flang/include/flang/Optimizer/Support/InitFIR.h
+++ b/flang/include/flang/Optimizer/Support/InitFIR.h
@@ -18,6 +18,7 @@
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/HLFIR/HLFIRDialect.h"
 #include "flang/Optimizer/OpenACC/RegisterOpenACCExtensions.h"
+#include "flang/Optimizer/OpenMP/Support/RegisterOpenMPExtensions.h"
 #include "mlir/Conversion/Passes.h"
 #include "mlir/Dialect/Affine/Passes.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"
@@ -67,6 +68,7 @@ inline void addFIRExtensions(mlir::DialectRegistry &registry,
   addFIRToLLVMIRExtension(registry);
   cuf::registerCUFDialectTranslation(registry);
   fir::acc::registerOpenACCExtensions(registry);
+  fir::omp::registerOpenMPExtensions(registry);
 }
 
 inline void loadNonCodegenDialects(mlir::MLIRContext &context) {

--- a/flang/lib/Frontend/CMakeLists.txt
+++ b/flang/lib/Frontend/CMakeLists.txt
@@ -39,6 +39,7 @@ add_flang_library(flangFrontend
   HLFIRTransforms
   flangPasses
   FIROpenACCSupport
+  FIROpenMPSupport
   FlangOpenMPTransforms
 
   LINK_COMPONENTS

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -203,6 +203,7 @@ bool CodeGenAction::beginSourceFileAction() {
   fir::support::registerLLVMTranslation(*mlirCtx);
   mlir::DialectRegistry registry;
   fir::acc::registerOpenACCExtensions(registry);
+  fir::omp::registerOpenMPExtensions(registry);
   mlirCtx->appendDialectRegistry(registry);
 
   const llvm::TargetMachine &targetMachine = ci.getTargetMachine();

--- a/flang/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/flang/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -23,6 +23,8 @@ add_flang_library(FIRCodeGen
   FIRCodeGenDialect
   FIRDialect
   FIRDialectSupport
+  FIROpenACCSupport
+  FIROpenMPSupport
   FIRSupport
 
   LINK_COMPONENTS

--- a/flang/lib/Optimizer/Dialect/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/CMakeLists.txt
@@ -10,10 +10,12 @@ add_flang_library(FIRDialect
   FirAliasTagOpInterface.cpp
   FortranVariableInterface.cpp
   Inliner.cpp
+  SafeTempArrayCopyAttrInterface.cpp
 
   DEPENDS
   CanonicalizationPatternsIncGen
   FIROpsIncGen
+  FIRSafeTempArrayCopyAttrInterfaceIncGen
   CUFAttrsIncGen
   intrinsics_gen
 

--- a/flang/lib/Optimizer/Dialect/FIRAttr.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRAttr.cpp
@@ -296,9 +296,9 @@ void fir::printFirAttribute(FIROpsDialect *dialect, mlir::Attribute attr,
 //===----------------------------------------------------------------------===//
 
 void FIROpsDialect::registerAttributes() {
-  addAttributes<ClosedIntervalAttr, ExactTypeAttr,
-                FortranProcedureFlagsEnumAttr, FortranVariableFlagsAttr,
-                LowerBoundAttr, PointIntervalAttr, RealAttr, ReduceAttr,
-                SubclassAttr, UpperBoundAttr, LocationKindAttr,
-                LocationKindArrayAttr, PackArrayHeuristicsAttr>();
+  addAttributes<ClosedIntervalAttr, ExactTypeAttr, LowerBoundAttr,
+                PointIntervalAttr, RealAttr, SubclassAttr, UpperBoundAttr,
+#define GET_ATTRDEF_LIST
+#include "flang/Optimizer/Dialect/FIRAttr.cpp.inc"
+                >();
 }

--- a/flang/lib/Optimizer/Dialect/SafeTempArrayCopyAttrInterface.cpp
+++ b/flang/lib/Optimizer/Dialect/SafeTempArrayCopyAttrInterface.cpp
@@ -1,0 +1,15 @@
+//===-- SafeTempArrayCopyAttrInterface.cpp --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Coding style: https://mlir.llvm.org/getting_started/DeveloperGuide/
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/Dialect/SafeTempArrayCopyAttrInterface.h"
+
+#include "flang/Optimizer/Dialect/SafeTempArrayCopyAttrInterface.cpp.inc"

--- a/flang/lib/Optimizer/OpenACC/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenACC/CMakeLists.txt
@@ -1,6 +1,7 @@
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 add_flang_library(FIROpenACCSupport
+  FIROpenACCAttributes.cpp
   FIROpenACCTypeInterfaces.cpp
   RegisterOpenACCExtensions.cpp
 

--- a/flang/lib/Optimizer/OpenACC/FIROpenACCAttributes.cpp
+++ b/flang/lib/Optimizer/OpenACC/FIROpenACCAttributes.cpp
@@ -1,0 +1,67 @@
+//===-- FIROpenACCAttributes.cpp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+/// \file
+/// This file implements attribute interfaces that are promised by FIR
+/// dialect attributes related to OpenACC.
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/Builder/FIRBuilder.h"
+#include "flang/Optimizer/Builder/Todo.h"
+#include "flang/Optimizer/Dialect/FIRAttr.h"
+#include "flang/Optimizer/Dialect/FIRDialect.h"
+#include "mlir/Dialect/OpenACC/OpenACC.h"
+
+namespace fir::acc {
+class FortranSafeTempArrayCopyAttrImpl
+    : public fir::SafeTempArrayCopyAttrInterface::FallbackModel<
+          FortranSafeTempArrayCopyAttrImpl> {
+public:
+  // SafeTempArrayCopyAttrInterface interface methods.
+  static bool isDynamicallySafe() { return false; }
+  static mlir::Value genDynamicCheck(mlir::Location loc,
+                                     fir::FirOpBuilder &builder,
+                                     mlir::Value array) {
+    TODO(loc, "fir::acc::FortranSafeTempArrayCopyAttrImpl::genDynamicCheck()");
+    return nullptr;
+  }
+  static void registerTempDeallocation(mlir::Location loc,
+                                       fir::FirOpBuilder &builder,
+                                       mlir::Value array, mlir::Value temp) {
+    TODO(loc, "fir::acc::FortranSafeTempArrayCopyAttrImpl::"
+              "registerTempDeallocation()");
+  }
+
+  // Extra helper methods.
+
+  /// Attach the implementation to fir::OpenACCSafeTempArrayCopyAttr.
+  static void registerExternalModel(mlir::DialectRegistry &registry);
+
+  /// If the methods above create any new operations, this method
+  /// must register all the corresponding dialect.
+  static void getDependentDialects(mlir::DialectRegistry &registry) {}
+};
+
+void FortranSafeTempArrayCopyAttrImpl::registerExternalModel(
+    mlir::DialectRegistry &registry) {
+  registry.addExtension(
+      +[](mlir::MLIRContext *ctx, fir::FIROpsDialect *dialect) {
+        fir::OpenACCSafeTempArrayCopyAttr::attachInterface<
+            FortranSafeTempArrayCopyAttrImpl>(*ctx);
+      });
+}
+
+void registerAttrsExtensions(mlir::DialectRegistry &registry) {
+  FortranSafeTempArrayCopyAttrImpl::registerExternalModel(registry);
+}
+
+void registerTransformationalAttrsDependentDialects(
+    mlir::DialectRegistry &registry) {
+  FortranSafeTempArrayCopyAttrImpl::getDependentDialects(registry);
+}
+
+} // namespace fir::acc

--- a/flang/lib/Optimizer/OpenACC/RegisterOpenACCExtensions.cpp
+++ b/flang/lib/Optimizer/OpenACC/RegisterOpenACCExtensions.cpp
@@ -32,6 +32,7 @@ void registerOpenACCExtensions(mlir::DialectRegistry &registry) {
     fir::LLVMPointerType::attachInterface<
         OpenACCPointerLikeModel<fir::LLVMPointerType>>(*ctx);
   });
+  registerAttrsExtensions(registry);
 }
 
 } // namespace fir::acc

--- a/flang/lib/Optimizer/OpenMP/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenMP/CMakeLists.txt
@@ -35,3 +35,5 @@ add_flang_library(FlangOpenMPTransforms
   MLIRTransformUtils
   ${dialect_libs}
 )
+
+add_subdirectory(Support)

--- a/flang/lib/Optimizer/OpenMP/Support/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenMP/Support/CMakeLists.txt
@@ -1,0 +1,20 @@
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+
+add_flang_library(FIROpenMPSupport
+  FIROpenMPAttributes.cpp
+  RegisterOpenMPExtensions.cpp
+
+  DEPENDS
+  FIRBuilder
+  FIRDialect
+
+  LINK_LIBS
+  FIRBuilder
+  FIRDialect
+
+  MLIR_DEPS
+  MLIROpenMPDialect
+
+  MLIR_LIBS
+  MLIROpenMPDialect
+)

--- a/flang/lib/Optimizer/OpenMP/Support/FIROpenMPAttributes.cpp
+++ b/flang/lib/Optimizer/OpenMP/Support/FIROpenMPAttributes.cpp
@@ -1,0 +1,69 @@
+//===-- FIROpenMPAttributes.cpp -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+/// \file
+/// This file implements attribute interfaces that are promised by FIR
+/// dialect attributes related to OpenMP.
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/Builder/FIRBuilder.h"
+#include "flang/Optimizer/Builder/Todo.h"
+#include "flang/Optimizer/Dialect/FIRAttr.h"
+#include "flang/Optimizer/Dialect/FIRDialect.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+
+namespace fir::omp {
+class FortranSafeTempArrayCopyAttrImpl
+    : public fir::SafeTempArrayCopyAttrInterface::FallbackModel<
+          FortranSafeTempArrayCopyAttrImpl> {
+public:
+  // SafeTempArrayCopyAttrInterface interface methods.
+  static bool isDynamicallySafe() { return false; }
+
+  static mlir::Value genDynamicCheck(mlir::Location loc,
+                                     fir::FirOpBuilder &builder,
+                                     mlir::Value array) {
+    TODO(loc, "fir::omp::FortranSafeTempArrayCopyAttrImpl::genDynamicCheck()");
+    return nullptr;
+  }
+
+  static void registerTempDeallocation(mlir::Location loc,
+                                       fir::FirOpBuilder &builder,
+                                       mlir::Value array, mlir::Value temp) {
+    TODO(loc, "fir::omp::FortranSafeTempArrayCopyAttrImpl::"
+              "registerTempDeallocation()");
+  }
+
+  // Extra helper methods.
+
+  /// Attach the implementation to fir::OpenMPSafeTempArrayCopyAttr.
+  static void registerExternalModel(mlir::DialectRegistry &registry);
+
+  /// If the methods above create any new operations, this method
+  /// must register all the corresponding dialect.
+  static void getDependentDialects(mlir::DialectRegistry &registry) {}
+};
+
+void FortranSafeTempArrayCopyAttrImpl::registerExternalModel(
+    mlir::DialectRegistry &registry) {
+  registry.addExtension(
+      +[](mlir::MLIRContext *ctx, fir::FIROpsDialect *dialect) {
+        fir::OpenMPSafeTempArrayCopyAttr::attachInterface<
+            FortranSafeTempArrayCopyAttrImpl>(*ctx);
+      });
+}
+
+void registerAttrsExtensions(mlir::DialectRegistry &registry) {
+  FortranSafeTempArrayCopyAttrImpl::registerExternalModel(registry);
+}
+
+void registerTransformationalAttrsDependentDialects(
+    mlir::DialectRegistry &registry) {
+  FortranSafeTempArrayCopyAttrImpl::getDependentDialects(registry);
+}
+
+} // namespace fir::omp

--- a/flang/lib/Optimizer/OpenMP/Support/RegisterOpenMPExtensions.cpp
+++ b/flang/lib/Optimizer/OpenMP/Support/RegisterOpenMPExtensions.cpp
@@ -1,0 +1,20 @@
+//===-- RegisterOpenMPExtensions.cpp --------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Registration for OpenMP extensions as applied to FIR dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Optimizer/OpenMP/Support/RegisterOpenMPExtensions.h"
+
+namespace fir::omp {
+void registerOpenMPExtensions(mlir::DialectRegistry &registry) {
+  registerAttrsExtensions(registry);
+}
+
+} // namespace fir::omp

--- a/flang/test/Lower/repack-arrays-safe.f90
+++ b/flang/test/Lower/repack-arrays-safe.f90
@@ -1,0 +1,17 @@
+! Test that fir.acc_safe_temp_array_copy and fir.omp_safe_temp_array_copy
+! are properly attached to fir.[un]pack_array by the lowering.
+
+! RUN: bbc -emit-hlfir -fopenacc -frepack-arrays %s -o - | FileCheck --check-prefixes=ALL,ACC %s
+! RUN: bbc -emit-hlfir -fopenmp -frepack-arrays %s -o - | FileCheck --check-prefixes=ALL,OMP %s
+! RUN: bbc -emit-hlfir -fopenacc -fopenmp -frepack-arrays %s -o - | FileCheck --check-prefixes=ALL,ACCOMP %s
+
+subroutine test(x)
+  real :: x(:)
+end subroutine test
+! ALL-LABEL:   func.func @_QPtest(
+! ACC:           %[[VAL_2:.*]] = fir.pack_array{{.*}}is_safe [#fir.acc_safe_temp_array_copy]
+! ACC:           fir.unpack_array{{.*}}is_safe [#fir.acc_safe_temp_array_copy]
+! OMP:           %[[VAL_2:.*]] = fir.pack_array{{.*}}is_safe [#fir.omp_safe_temp_array_copy]
+! OMP:           fir.unpack_array{{.*}}is_safe [#fir.omp_safe_temp_array_copy]
+! ACCOMP:           %[[VAL_2:.*]] = fir.pack_array{{.*}}is_safe [#fir.acc_safe_temp_array_copy, #fir.omp_safe_temp_array_copy]
+! ACCOMP:           fir.unpack_array{{.*}}is_safe [#fir.acc_safe_temp_array_copy, #fir.omp_safe_temp_array_copy]

--- a/flang/test/Transforms/lower-repack-arrays-openacc.fir
+++ b/flang/test/Transforms/lower-repack-arrays-openacc.fir
@@ -1,0 +1,17 @@
+// RUN: fir-opt --lower-repack-arrays %s | FileCheck %s
+
+// Test the current implementation of #fir.acc_safe_temp_array_copy attribute.
+// It results in removal of fir.[un]pack_array operations.
+func.func @_QPtest(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x"}) {
+  %0 = fir.dummy_scope : !fir.dscope
+  %1 = fir.pack_array %arg0 heap whole is_safe [#fir.acc_safe_temp_array_copy] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>>
+  %2 = fir.declare %1 dummy_scope %0 {uniq_name = "_QFtestEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> !fir.box<!fir.array<?xf32>>
+  fir.unpack_array %1 to %arg0 heap is_safe [#fir.acc_safe_temp_array_copy] : !fir.box<!fir.array<?xf32>>
+  return
+}
+// CHECK-LABEL:   func.func @_QPtest(
+// CHECK-SAME:                       %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x"}) {
+// CHECK-NEXT:      %[[VAL_1:.*]] = fir.dummy_scope : !fir.dscope
+// CHECK-NEXT:      %[[VAL_2:.*]] = fir.declare %[[VAL_0]] dummy_scope %[[VAL_1]] {uniq_name = "_QFtestEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> !fir.box<!fir.array<?xf32>>
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/flang/test/Transforms/lower-repack-arrays-openmp.fir
+++ b/flang/test/Transforms/lower-repack-arrays-openmp.fir
@@ -1,0 +1,17 @@
+// RUN: fir-opt --lower-repack-arrays %s | FileCheck %s
+
+// Test the current implementation of #fir.omp_safe_temp_array_copy attribute.
+// It results in removal of fir.[un]pack_array operations.
+func.func @_QPtest(%arg0: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x"}) {
+  %0 = fir.dummy_scope : !fir.dscope
+  %1 = fir.pack_array %arg0 heap whole is_safe [#fir.omp_safe_temp_array_copy] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<!fir.array<?xf32>>
+  %2 = fir.declare %1 dummy_scope %0 {uniq_name = "_QFtestEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> !fir.box<!fir.array<?xf32>>
+  fir.unpack_array %1 to %arg0 heap is_safe [#fir.omp_safe_temp_array_copy] : !fir.box<!fir.array<?xf32>>
+  return
+}
+// CHECK-LABEL:   func.func @_QPtest(
+// CHECK-SAME:                       %[[VAL_0:[0-9]+|[a-zA-Z$._-][a-zA-Z0-9$._-]*]]: !fir.box<!fir.array<?xf32>> {fir.bindc_name = "x"}) {
+// CHECK-NEXT:      %[[VAL_1:.*]] = fir.dummy_scope : !fir.dscope
+// CHECK-NEXT:      %[[VAL_2:.*]] = fir.declare %[[VAL_0]] dummy_scope %[[VAL_1]] {uniq_name = "_QFtestEx"} : (!fir.box<!fir.array<?xf32>>, !fir.dscope) -> !fir.box<!fir.array<?xf32>>
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/flang/tools/bbc/CMakeLists.txt
+++ b/flang/tools/bbc/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(bbc PRIVATE
   FIRDialect
   FIRDialectSupport
   FIROpenACCSupport
+  FIROpenMPSupport
   FIRSupport
   FIRTransforms
   FIRBuilder

--- a/flang/tools/fir-lsp-server/CMakeLists.txt
+++ b/flang/tools/fir-lsp-server/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(fir-lsp-server PRIVATE
   CUFDialect
   FIRDialect
   FIROpenACCSupport
+  FIROpenMPSupport
   HLFIRDialect)
 
 mlir_target_link_libraries(fir-lsp-server PRIVATE

--- a/flang/tools/fir-opt/CMakeLists.txt
+++ b/flang/tools/fir-opt/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(fir-opt PRIVATE
   HLFIRDialect
   HLFIRTransforms
   FIROpenACCSupport
+  FIROpenMPSupport
   FlangOpenMPTransforms
   FIRAnalysis
   ${test_libs}

--- a/flang/tools/tco/CMakeLists.txt
+++ b/flang/tools/tco/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(tco PRIVATE
   HLFIRTransforms
   flangPasses
   FIROpenACCSupport
+  FIROpenMPSupport
   FlangOpenMPTransforms
   FortranSupport
 )


### PR DESCRIPTION
This patch defines `fir::SafeTempArrayCopyAttrInterface` and the corresponding
OpenACC/OpenMP related attributes in FIR dialect. The actual implementations
are just placeholders right now, and array repacking becomes a no-op
if `-fopenacc/-fopenmp` is used for the compilation.