### PR TITLE
[Sema] Handle AttributedType in template deduction with derived-to-base conversions

### DIFF
--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -4446,7 +4446,7 @@ static bool AdjustFunctionParmAndArgTypesForDeduction(
   //       transformed A can be a pointer to a derived class pointed to by
   //       the deduced A.
   if (isSimpleTemplateIdType(ParamType) ||
-      (isa<PointerType>(ParamType) &&
+      (ParamType->getAs<PointerType>() &&
        isSimpleTemplateIdType(
            ParamType->castAs<PointerType>()->getPointeeType())))
     TDF |= TDF_DerivedClass;

--- a/clang/test/Sema/nullability-and-template-deduction.cpp
+++ b/clang/test/Sema/nullability-and-template-deduction.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -fsyntax-only %s -verify
+// expected-no-diagnostics
+
+template <class T> struct Base {};
+template <class T> struct Derived : Base<T> {};
+
+template <class T> void foo(Base<T> *_Nonnull);
+
+template <class T> void bar(Base<T> *);
+
+
+void test() {
+    Derived<int> d;
+    foo(&d);
+    bar(&d);
+}


### PR DESCRIPTION
Fix #134356.

We accidentally skipped checking derived-to-base conversions because deduction did not strip sugar in the relevant code. This caused deduction failures when a parameter type had an attribute.