### PR TITLE
[driver] Generalize the code that adds the path of libflang_rt.runtime.a.

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6880,6 +6880,13 @@ let Flags = [TargetSpecific] in {
 defm android_pad_segment : BooleanFFlag<"android-pad-segment">, Group<f_Group>;
 } // let Flags = [TargetSpecific]
 
+def shared_libflangrt : Flag<["-"], "shared-libflangrt">,
+  HelpText<"Dynamically link the shared flang-rt">, Group<Link_Group>,
+  Visibility<[FlangOption]>, Flags<[NoArgumentUnused]>;
+def static_libflangrt : Flag<["-"], "static-libflangrt">, 
+  HelpText<"Statically link the static flang-rt">, Group<Link_Group>,
+  Visibility<[FlangOption]>, Flags<[NoArgumentUnused]>;
+
 //===----------------------------------------------------------------------===//
 // FLangOption + NoXarchOption
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6881,10 +6881,10 @@ defm android_pad_segment : BooleanFFlag<"android-pad-segment">, Group<f_Group>;
 } // let Flags = [TargetSpecific]
 
 def shared_libflangrt : Flag<["-"], "shared-libflangrt">,
-  HelpText<"Dynamically link the shared flang-rt">, Group<Link_Group>,
+  HelpText<"Link the flang-rt shared library">, Group<Link_Group>,
   Visibility<[FlangOption]>, Flags<[NoArgumentUnused]>;
 def static_libflangrt : Flag<["-"], "static-libflangrt">, 
-  HelpText<"Statically link the static flang-rt">, Group<Link_Group>,
+  HelpText<"Link the flang-rt static library">, Group<Link_Group>,
   Visibility<[FlangOption]>, Flags<[NoArgumentUnused]>;
 
 //===----------------------------------------------------------------------===//

--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -521,6 +521,10 @@ public:
   addFortranRuntimeLibraryPath(const llvm::opt::ArgList &Args,
                                llvm::opt::ArgStringList &CmdArgs) const;
 
+  /// Add the path for libflang_rt.runtime.a
+  void addFlangRTLibPath(const llvm::opt::ArgList &Args,
+                         llvm::opt::ArgStringList &CmdArgs) const;
+
   const char *getCompilerRTArgString(const llvm::opt::ArgList &Args,
                                      StringRef Component,
                                      FileType Type = ToolChain::FT_Static,

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -861,8 +861,7 @@ void ToolChain::addFlangRTLibPath(const ArgList &Args,
     CmdArgs.push_back(
         getCompilerRTArgString(Args, "runtime", ToolChain::FT_Static, true));
   else {
-    CmdArgs.push_back(
-        getCompilerRTArgString(Args, "runtime", ToolChain::FT_Shared, true));
+    CmdArgs.push_back("-lflang_rt.runtime");
     addArchSpecificRPath(*this, Args, CmdArgs);
   }
 }

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -856,12 +856,13 @@ void ToolChain::addFlangRTLibPath(const ArgList &Args,
   if (getVFS().exists(Twine(Path = getCompilerRTArgString(
                                 Args, "runtime", ToolChain::FT_Static, true))))
     CmdArgs.push_back(Path);
-  else if (getVFS().exists(
-               Twine(Path = getCompilerRTArgString(
-                         Args, "runtime", ToolChain::FT_Shared, true))))
-    CmdArgs.push_back(Path);
   else {
-    CmdArgs.push_back("-lflang_rt.runtime");
+    if (getVFS().exists(
+            Twine(Path = getCompilerRTArgString(Args, "runtime",
+                                                ToolChain::FT_Shared, true))))
+      CmdArgs.push_back(Path);
+    else
+      CmdArgs.push_back("-lflang_rt.runtime");
     addArchSpecificRPath(*this, Args, CmdArgs);
   }
 }

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -854,8 +854,8 @@ void ToolChain::addFortranRuntimeLibraryPath(const llvm::opt::ArgList &Args,
 
 void ToolChain::addFlangRTLibPath(const ArgList &Args,
                                   llvm::opt::ArgStringList &CmdArgs) const {
-  // Link static flang_rt.runtime.a or shared flang_rt.runtime.so
-  // On AIX, default to static flang-rt
+  // Link static flang_rt.runtime.a or shared flang_rt.runtime.so.
+  // On AIX, default to static flang-rt.
   if (Args.hasFlag(options::OPT_static_libflangrt,
                    options::OPT_shared_libflangrt, getTriple().isOSAIX()))
     CmdArgs.push_back(

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -744,10 +744,12 @@ std::string ToolChain::buildCompilerRTBasename(const llvm::opt::ArgList &Args,
     Suffix = IsITANMSVCWindows ? ".lib" : ".a";
     break;
   case ToolChain::FT_Shared:
-    Suffix = TT.isOSWindows()
-                 ? (TT.isWindowsGNUEnvironment() ? ".dll.a" : ".lib")
-             : TT.isOSAIX() ? ".a"
-                            : ".so";
+    if (TT.isOSWindows())
+      Suffix = TT.isWindowsGNUEnvironment() ? ".dll.a" : ".lib";
+    else if (TT.isOSAIX())
+      Suffix = ".a";
+    else
+      Suffix = ".so";
     break;
   }
 

--- a/clang/lib/Driver/ToolChains/AIX.cpp
+++ b/clang/lib/Driver/ToolChains/AIX.cpp
@@ -608,14 +608,6 @@ void AIX::addProfileRTLibs(const llvm::opt::ArgList &Args,
   ToolChain::addProfileRTLibs(Args, CmdArgs);
 }
 
-void AIX::addFortranRuntimeLibs(const ArgList &Args,
-                                llvm::opt::ArgStringList &CmdArgs) const {
-  // Link flang_rt.runtime.a. On AIX, the static and shared library are all
-  // named .a
-  CmdArgs.push_back(
-      getCompilerRTArgString(Args, "runtime", ToolChain::FT_Static, true));
-}
-
 ToolChain::CXXStdlibType AIX::GetDefaultCXXStdlibType() const {
   return ToolChain::CST_Libcxx;
 }

--- a/clang/lib/Driver/ToolChains/AIX.h
+++ b/clang/lib/Driver/ToolChains/AIX.h
@@ -87,9 +87,6 @@ public:
   void addProfileRTLibs(const llvm::opt::ArgList &Args,
                         llvm::opt::ArgStringList &CmdArgs) const override;
 
-  void addFortranRuntimeLibs(const llvm::opt::ArgList &Args,
-                             llvm::opt::ArgStringList &CmdArgs) const override;
-
   CXXStdlibType GetDefaultCXXStdlibType() const override;
 
   RuntimeLibType GetDefaultRuntimeLibType() const override;

--- a/clang/lib/Driver/ToolChains/PPCLinux.cpp
+++ b/clang/lib/Driver/ToolChains/PPCLinux.cpp
@@ -12,7 +12,6 @@
 #include "clang/Driver/Options.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
-#include "llvm/Support/VirtualFileSystem.h"
 
 using namespace clang::driver;
 using namespace clang::driver::toolchains;
@@ -101,19 +100,4 @@ bool PPCLinuxToolChain::SupportIEEEFloat128(
   std::string Linker = Linux::getDynamicLinker(Args);
   return GlibcSupportsFloat128((Twine(D.DyldPrefix) + Linker).str()) &&
          !(D.CCCIsCXX() && HasUnsupportedCXXLib);
-}
-
-void PPCLinuxToolChain::addFortranRuntimeLibs(
-    const ArgList &Args, llvm::opt::ArgStringList &CmdArgs) const {
-  // Link static flang_rt.runtime.a or shared flang_rt.runtime.so
-  const char *Path;
-  if (getVFS().exists(Twine(Path = getCompilerRTArgString(
-                                Args, "runtime", ToolChain::FT_Static, true))))
-    CmdArgs.push_back(Path);
-  else if (getVFS().exists(
-               Twine(Path = getCompilerRTArgString(
-                         Args, "runtime", ToolChain::FT_Shared, true))))
-    CmdArgs.push_back(Path);
-  else
-    CmdArgs.push_back("-lflang_rt.runtime");
 }

--- a/clang/lib/Driver/ToolChains/PPCLinux.h
+++ b/clang/lib/Driver/ToolChains/PPCLinux.h
@@ -24,9 +24,6 @@ public:
   AddClangSystemIncludeArgs(const llvm::opt::ArgList &DriverArgs,
                             llvm::opt::ArgStringList &CC1Args) const override;
 
-  void addFortranRuntimeLibs(const llvm::opt::ArgList &Args,
-                             llvm::opt::ArgStringList &CmdArgs) const override;
-
 private:
   bool SupportIEEEFloat128(const Driver &D, const llvm::Triple &Triple,
                            const llvm::opt::ArgList &Args) const;

--- a/flang/test/Driver/flang-ld-powerpc.f90
+++ b/flang/test/Driver/flang-ld-powerpc.f90
@@ -56,7 +56,7 @@
 ! AIX64-LD-PER-TARGET-SHARED-SAME:     "-b64"
 ! AIX64-LD-PER-TARGET-SHARED-SAME:     "-bpT:0x100000000" "-bpD:0x110000000"
 ! AIX64-LD-PER-TARGET-SHARED-SAME:     "-lc"
-! AIX64-LD-PER-TARGET-SHARED-SAME:     "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}powerpc64-ibm-aix{{/|\\\\}}libflang_rt.runtime.a"
+! AIX64-LD-PER-TARGET-SHARED-SAME:     "-lflang_rt.runtime"
 ! AIX64-LD-PER-TARGET-SHARED-SAME:     "-lm"
 ! AIX64-LD-PER-TARGET-SHARED-SAME:     "-lpthread"
 
@@ -71,7 +71,7 @@
 ! LOP64-LD-PER-TARGET-DEFAULT-SAME:     "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 ! LOP64-LD-PER-TARGET-DEFAULT:     "{{.*}}ld{{(.exe)?}}"
 ! LOP64-LD-PER-TARGET-DEFAULT-NOT: "-bnso"
-! LOP64-LD-PER-TARGET-DEFAULT-SAME:     "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}powerpc64le-unknown-linux-gnu{{/|\\\\}}libflang_rt.runtime.so"
+! LOP64-LD-PER-TARGET-DEFAULT-SAME:     "-lflang_rt.runtime"
 ! LOP64-LD-PER-TARGET-DEFAULT-SAME:     "-lm"
 ! LOP64-LD-PER-TARGET-DEFAULT-SAME:     "-lc"
 
@@ -100,7 +100,7 @@
 ! LOP64-LD-PER-TARGET-SHARED:     "-fc1" "-triple" "powerpc64le-unknown-linux-gnu"
 ! LOP64-LD-PER-TARGET-SHARED-SAME:     "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 ! LOP64-LD-PER-TARGET-SHARED:     "{{.*}}ld{{(.exe)?}}"
-! AIX64-LD-PER-TARGET-NOT: "-bnso"
-! LOP64-LD-PER-TARGET-SHARED-SAME:     "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}powerpc64le-unknown-linux-gnu{{/|\\\\}}libflang_rt.runtime.so"
+! LOP64-LD-PER-TARGET-SHARED-NOT: "-bnso"
+! LOP64-LD-PER-TARGET-SHARED-SAME:     "-lflang_rt.runtime"
 ! LOP64-LD-PER-TARGET-SHARED-SAME:     "-lm"
 ! LOP64-LD-PER-TARGET-SHARED-SAME:     "-lc"

--- a/flang/test/Driver/flang-ld-powerpc.f90
+++ b/flang/test/Driver/flang-ld-powerpc.f90
@@ -7,35 +7,106 @@
 !! LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=ON, use 
 !! resource_dir_with_per_target_subdir as inputs.
 
-! Check powerpc64-ibm-aix 64-bit linking to static flang-rt
+! Check powerpc64-ibm-aix 64-bit linking to static flang-rt by default
 ! RUN: %flang %s -### 2>&1 \
 ! RUN:        --target=powerpc64-ibm-aix \
 ! RUN:        -resource-dir=%S/../../../clang/test/Driver/Inputs/resource_dir_with_per_target_subdir \
-! RUN:   | FileCheck %s --check-prefix=AIX64-LD-PER-TARGET
+! RUN:   | FileCheck %s --check-prefix=AIX64-LD-PER-TARGET-DEFAULT
 
-! AIX64-LD-PER-TARGET-NOT: warning:
-! AIX64-LD-PER-TARGET:     "-fc1" "-triple" "powerpc64-ibm-aix"
-! AIX64-LD-PER-TARGET-SAME:     "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-! AIX64-LD-PER-TARGET:     "{{.*}}ld{{(.exe)?}}"
-! AIX64-LD-PER-TARGET-NOT: "-bnso"
-! AIX64-LD-PER-TARGET-SAME:     "-b64"
-! AIX64-LD-PER-TARGET-SAME:     "-bpT:0x100000000" "-bpD:0x110000000"
-! AIX64-LD-PER-TARGET-SAME:     "-lc"
-! AIX64-LD-PER-TARGET-SAME:     "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}powerpc64-ibm-aix{{/|\\\\}}libflang_rt.runtime.a"
-! AIX64-LD-PER-TARGET-SAME:     "-lm"
-! AIX64-LD-PER-TARGET-SAME:     "-lpthread"
+! AIX64-LD-PER-TARGET-DEFAULT-NOT: warning:
+! AIX64-LD-PER-TARGET-DEFAULT:     "-fc1" "-triple" "powerpc64-ibm-aix"
+! AIX64-LD-PER-TARGET-DEFAULT-SAME:     "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+! AIX64-LD-PER-TARGET-DEFAULT:     "{{.*}}ld{{(.exe)?}}"
+! AIX64-LD-PER-TARGET-DEFAULT-NOT: "-bnso"
+! AIX64-LD-PER-TARGET-DEFAULT-SAME:     "-b64"
+! AIX64-LD-PER-TARGET-DEFAULT-SAME:     "-bpT:0x100000000" "-bpD:0x110000000"
+! AIX64-LD-PER-TARGET-DEFAULT-SAME:     "-lc"
+! AIX64-LD-PER-TARGET-DEFAULT-SAME:     "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}powerpc64-ibm-aix{{/|\\\\}}libflang_rt.runtime.a"
+! AIX64-LD-PER-TARGET-DEFAULT-SAME:     "-lm"
+! AIX64-LD-PER-TARGET-DEFAULT-SAME:     "-lpthread"
 
-! Check powerpc64le-unknown-linux-gnu 64-bit linking to static flang-rt
+
+! Check powerpc64-ibm-aix 64-bit linking to static flang-rt by option 
+! RUN: %flang -static-libflangrt %s -### 2>&1 \
+! RUN:        --target=powerpc64-ibm-aix \
+! RUN:        -resource-dir=%S/../../../clang/test/Driver/Inputs/resource_dir_with_per_target_subdir \
+! RUN:   | FileCheck %s --check-prefix=AIX64-LD-PER-TARGET-STATIC
+
+! AIX64-LD-PER-TARGET-STATIC-NOT: warning:
+! AIX64-LD-PER-TARGET-STATIC:     "-fc1" "-triple" "powerpc64-ibm-aix"
+! AIX64-LD-PER-TARGET-STATIC-SAME:     "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+! AIX64-LD-PER-TARGET-STATIC:     "{{.*}}ld{{(.exe)?}}"
+! AIX64-LD-PER-TARGET-STATIC-NOT: "-bnso"
+! AIX64-LD-PER-TARGET-STATIC-SAME:     "-b64"
+! AIX64-LD-PER-TARGET-STATIC-SAME:     "-bpT:0x100000000" "-bpD:0x110000000"
+! AIX64-LD-PER-TARGET-STATIC-SAME:     "-lc"
+! AIX64-LD-PER-TARGET-STATIC-SAME:     "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}powerpc64-ibm-aix{{/|\\\\}}libflang_rt.runtime.a"
+! AIX64-LD-PER-TARGET-STATIC-SAME:     "-lm"
+! AIX64-LD-PER-TARGET-STATIC-SAME:     "-lpthread"
+
+
+! Check powerpc64-ibm-aix 64-bit linking to shared flang-rt by option 
+! RUN: %flang -shared-libflangrt %s -### 2>&1 \
+! RUN:        --target=powerpc64-ibm-aix \
+! RUN:        -resource-dir=%S/../../../clang/test/Driver/Inputs/resource_dir_with_per_target_subdir \
+! RUN:   | FileCheck %s --check-prefix=AIX64-LD-PER-TARGET-SHARED
+
+! AIX64-LD-PER-TARGET-SHARED-NOT: warning:
+! AIX64-LD-PER-TARGET-SHARED:     "-fc1" "-triple" "powerpc64-ibm-aix"
+! AIX64-LD-PER-TARGET-SHARED-SAME:     "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+! AIX64-LD-PER-TARGET-SHARED:     "{{.*}}ld{{(.exe)?}}"
+! AIX64-LD-PER-TARGET-SHARED-NOT: "-bnso"
+! AIX64-LD-PER-TARGET-SHARED-SAME:     "-b64"
+! AIX64-LD-PER-TARGET-SHARED-SAME:     "-bpT:0x100000000" "-bpD:0x110000000"
+! AIX64-LD-PER-TARGET-SHARED-SAME:     "-lc"
+! AIX64-LD-PER-TARGET-SHARED-SAME:     "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}powerpc64-ibm-aix{{/|\\\\}}libflang_rt.runtime.a"
+! AIX64-LD-PER-TARGET-SHARED-SAME:     "-lm"
+! AIX64-LD-PER-TARGET-SHARED-SAME:     "-lpthread"
+
+
+! Check powerpc64le-unknown-linux-gnu 64-bit linking to shared flang-rt by default
 ! RUN: %flang %s -### 2>&1 \
 ! RUN:        --target=powerpc64le-unknown-linux-gnu \
 ! RUN:        -resource-dir=%S/../../../clang/test/Driver/Inputs/resource_dir_with_per_target_subdir \
-! RUN:   | FileCheck %s --check-prefixes=LOP64-LD-PER-TARGET
+! RUN:   | FileCheck %s --check-prefixes=LOP64-LD-PER-TARGET-DEFAULT
 
-! LOP64-LD-PER-TARGET-NOT: warning:
-! LOP64-LD-PER-TARGET:     "-fc1" "-triple" "powerpc64le-unknown-linux-gnu"
-! LOP64-LD-PER-TARGET-SAME:     "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
-! LOP64-LD-PER-TARGET:     "{{.*}}ld{{(.exe)?}}"
-! LOP64-LD-PER-TARGET-NOT: "-bnso"
-! LOP64-LD-PER-TARGET-SAME:     "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}powerpc64le-unknown-linux-gnu{{/|\\\\}}libflang_rt.runtime.a"
-! LOP64-LD-PER-TARGET-SAME:     "-lm"
-! LOP64-LD-PER-TARGET-SAME:     "-lc"
+! LOP64-LD-PER-TARGET-DEFAULT-NOT: warning:
+! LOP64-LD-PER-TARGET-DEFAULT:     "-fc1" "-triple" "powerpc64le-unknown-linux-gnu"
+! LOP64-LD-PER-TARGET-DEFAULT-SAME:     "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+! LOP64-LD-PER-TARGET-DEFAULT:     "{{.*}}ld{{(.exe)?}}"
+! LOP64-LD-PER-TARGET-DEFAULT-NOT: "-bnso"
+! LOP64-LD-PER-TARGET-DEFAULT-SAME:     "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}powerpc64le-unknown-linux-gnu{{/|\\\\}}libflang_rt.runtime.so"
+! LOP64-LD-PER-TARGET-DEFAULT-SAME:     "-lm"
+! LOP64-LD-PER-TARGET-DEFAULT-SAME:     "-lc"
+
+
+! Check powerpc64le-unknown-linux-gnu 64-bit linking to static flang-rt
+! RUN: %flang -static-libflangrt %s -### 2>&1 \
+! RUN:        --target=powerpc64le-unknown-linux-gnu \
+! RUN:        -resource-dir=%S/../../../clang/test/Driver/Inputs/resource_dir_with_per_target_subdir \
+! RUN:   | FileCheck %s --check-prefixes=LOP64-LD-PER-TARGET-STATIC
+
+! LOP64-LD-PER-TARGET-STATIC-NOT: warning:
+! LOP64-LD-PER-TARGET-STATIC:     "-fc1" "-triple" "powerpc64le-unknown-linux-gnu"
+! LOP64-LD-PER-TARGET-STATIC-SAME:     "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+! LOP64-LD-PER-TARGET-STATIC:     "{{.*}}ld{{(.exe)?}}"
+! LOP64-LD-PER-TARGET-STATIC-NOT: "-bnso"
+! LOP64-LD-PER-TARGET-STATIC-SAME:     "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}powerpc64le-unknown-linux-gnu{{/|\\\\}}libflang_rt.runtime.a"
+! LOP64-LD-PER-TARGET-STATIC-SAME:     "-lm"
+! LOP64-LD-PER-TARGET-STATIC-SAME:     "-lc"
+
+
+! Check powerpc64le-unknown-linux-gnu 64-bit linking to shared flang-rt
+! RUN: %flang -shared-libflangrt %s -### 2>&1 \
+! RUN:        --target=powerpc64le-unknown-linux-gnu \
+! RUN:        -resource-dir=%S/../../../clang/test/Driver/Inputs/resource_dir_with_per_target_subdir \
+! RUN:   | FileCheck %s --check-prefixes=LOP64-LD-PER-TARGET-SHARED
+
+! LOP64-LD-PER-TARGET-SHARED-NOT: warning:
+! LOP64-LD-PER-TARGET-SHARED:     "-fc1" "-triple" "powerpc64le-unknown-linux-gnu"
+! LOP64-LD-PER-TARGET-SHARED-SAME:     "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
+! LOP64-LD-PER-TARGET-SHARED:     "{{.*}}ld{{(.exe)?}}"
+! AIX64-LD-PER-TARGET-NOT: "-bnso"
+! LOP64-LD-PER-TARGET-SHARED-SAME:     "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}powerpc64le-unknown-linux-gnu{{/|\\\\}}libflang_rt.runtime.so"
+! LOP64-LD-PER-TARGET-SHARED-SAME:     "-lm"
+! LOP64-LD-PER-TARGET-SHARED-SAME:     "-lc"

--- a/flang/test/Driver/flang-ld-powerpc.f90
+++ b/flang/test/Driver/flang-ld-powerpc.f90
@@ -8,12 +8,11 @@
 !! resource_dir_with_per_target_subdir as inputs.
 
 ! Check powerpc64-ibm-aix 64-bit linking to static flang-rt by default
-! RUN: %flang %s -### 2>&1 \
+! RUN: %flang -Werror %s -### 2>&1 \
 ! RUN:        --target=powerpc64-ibm-aix \
 ! RUN:        -resource-dir=%S/../../../clang/test/Driver/Inputs/resource_dir_with_per_target_subdir \
 ! RUN:   | FileCheck %s --check-prefix=AIX64-LD-PER-TARGET-DEFAULT
 
-! AIX64-LD-PER-TARGET-DEFAULT-NOT: warning:
 ! AIX64-LD-PER-TARGET-DEFAULT:     "-fc1" "-triple" "powerpc64-ibm-aix"
 ! AIX64-LD-PER-TARGET-DEFAULT-SAME:     "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 ! AIX64-LD-PER-TARGET-DEFAULT:     "{{.*}}ld{{(.exe)?}}"
@@ -27,12 +26,11 @@
 
 
 ! Check powerpc64-ibm-aix 64-bit linking to static flang-rt by option 
-! RUN: %flang -static-libflangrt %s -### 2>&1 \
+! RUN: %flang -static-libflangrt -Werror %s -### 2>&1 \
 ! RUN:        --target=powerpc64-ibm-aix \
 ! RUN:        -resource-dir=%S/../../../clang/test/Driver/Inputs/resource_dir_with_per_target_subdir \
 ! RUN:   | FileCheck %s --check-prefix=AIX64-LD-PER-TARGET-STATIC
 
-! AIX64-LD-PER-TARGET-STATIC-NOT: warning:
 ! AIX64-LD-PER-TARGET-STATIC:     "-fc1" "-triple" "powerpc64-ibm-aix"
 ! AIX64-LD-PER-TARGET-STATIC-SAME:     "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 ! AIX64-LD-PER-TARGET-STATIC:     "{{.*}}ld{{(.exe)?}}"
@@ -46,12 +44,11 @@
 
 
 ! Check powerpc64-ibm-aix 64-bit linking to shared flang-rt by option 
-! RUN: %flang -shared-libflangrt %s -### 2>&1 \
+! RUN: %flang -shared-libflangrt -Werror %s -### 2>&1 \
 ! RUN:        --target=powerpc64-ibm-aix \
 ! RUN:        -resource-dir=%S/../../../clang/test/Driver/Inputs/resource_dir_with_per_target_subdir \
 ! RUN:   | FileCheck %s --check-prefix=AIX64-LD-PER-TARGET-SHARED
 
-! AIX64-LD-PER-TARGET-SHARED-NOT: warning:
 ! AIX64-LD-PER-TARGET-SHARED:     "-fc1" "-triple" "powerpc64-ibm-aix"
 ! AIX64-LD-PER-TARGET-SHARED-SAME:     "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 ! AIX64-LD-PER-TARGET-SHARED:     "{{.*}}ld{{(.exe)?}}"
@@ -65,12 +62,11 @@
 
 
 ! Check powerpc64le-unknown-linux-gnu 64-bit linking to shared flang-rt by default
-! RUN: %flang %s -### 2>&1 \
+! RUN: %flang -Werror %s -### 2>&1 \
 ! RUN:        --target=powerpc64le-unknown-linux-gnu \
 ! RUN:        -resource-dir=%S/../../../clang/test/Driver/Inputs/resource_dir_with_per_target_subdir \
 ! RUN:   | FileCheck %s --check-prefixes=LOP64-LD-PER-TARGET-DEFAULT
 
-! LOP64-LD-PER-TARGET-DEFAULT-NOT: warning:
 ! LOP64-LD-PER-TARGET-DEFAULT:     "-fc1" "-triple" "powerpc64le-unknown-linux-gnu"
 ! LOP64-LD-PER-TARGET-DEFAULT-SAME:     "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 ! LOP64-LD-PER-TARGET-DEFAULT:     "{{.*}}ld{{(.exe)?}}"
@@ -80,13 +76,12 @@
 ! LOP64-LD-PER-TARGET-DEFAULT-SAME:     "-lc"
 
 
-! Check powerpc64le-unknown-linux-gnu 64-bit linking to static flang-rt
-! RUN: %flang -static-libflangrt %s -### 2>&1 \
+! Check powerpc64le-unknown-linux-gnu 64-bit linking to static flang-rt by option
+! RUN: %flang -static-libflangrt -Werror %s -### 2>&1 \
 ! RUN:        --target=powerpc64le-unknown-linux-gnu \
 ! RUN:        -resource-dir=%S/../../../clang/test/Driver/Inputs/resource_dir_with_per_target_subdir \
 ! RUN:   | FileCheck %s --check-prefixes=LOP64-LD-PER-TARGET-STATIC
 
-! LOP64-LD-PER-TARGET-STATIC-NOT: warning:
 ! LOP64-LD-PER-TARGET-STATIC:     "-fc1" "-triple" "powerpc64le-unknown-linux-gnu"
 ! LOP64-LD-PER-TARGET-STATIC-SAME:     "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 ! LOP64-LD-PER-TARGET-STATIC:     "{{.*}}ld{{(.exe)?}}"
@@ -96,13 +91,12 @@
 ! LOP64-LD-PER-TARGET-STATIC-SAME:     "-lc"
 
 
-! Check powerpc64le-unknown-linux-gnu 64-bit linking to shared flang-rt
-! RUN: %flang -shared-libflangrt %s -### 2>&1 \
+! Check powerpc64le-unknown-linux-gnu 64-bit linking to shared flang-rt by option
+! RUN: %flang -shared-libflangrt -Werror %s -### 2>&1 \
 ! RUN:        --target=powerpc64le-unknown-linux-gnu \
 ! RUN:        -resource-dir=%S/../../../clang/test/Driver/Inputs/resource_dir_with_per_target_subdir \
 ! RUN:   | FileCheck %s --check-prefixes=LOP64-LD-PER-TARGET-SHARED
 
-! LOP64-LD-PER-TARGET-SHARED-NOT: warning:
 ! LOP64-LD-PER-TARGET-SHARED:     "-fc1" "-triple" "powerpc64le-unknown-linux-gnu"
 ! LOP64-LD-PER-TARGET-SHARED-SAME:     "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
 ! LOP64-LD-PER-TARGET-SHARED:     "{{.*}}ld{{(.exe)?}}"

--- a/flang/test/Driver/linker-flags.f90
+++ b/flang/test/Driver/linker-flags.f90
@@ -44,8 +44,7 @@
 ! SOLARIS-F128NONE-NOT: flang_rt.quadmath
 ! UNIX-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
 ! SOLARIS-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "-z" "ignore" "-lquadmath" "-z" "record"
-! UNIX-SAME:   "{{.*}}{{\\|/}}libflang_rt.runtime.so"
-! UNIX-SAME:   "-lm"
+! UNIX-SAME: "-lflang_rt.runtime" "-lm" 
 ! COMPILER-RT: "{{.*}}{{\\|/}}libclang_rt.builtins.a"
 ! UNIX-STATIC-FLANGRT:   "{{.*}}{{\\|/}}libflang_rt.runtime.a"
 
@@ -53,7 +52,7 @@
 ! BSD-SAME: "[[object_file]]"
 ! BSD-F128NONE-NOT: flang_rt.quadmath
 ! BSD-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
-! BSD-SAME: "{{.*}}{{\\|/}}libflang_rt.runtime.so"
+! BSD-SAME: -lflang_rt.runtime
 ! BSD-SAME: "-lexecinfo"
 ! BSD-STATIC-FLANGRT: "{{.*}}{{\\|/}}libflang_rt.runtime.a"
 
@@ -61,21 +60,21 @@
 ! DARWIN-SAME: "[[object_file]]"
 ! DARWIN-F128NONE-NOT: libflang_rt.quadmath
 ! DARWIN-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
-! DARWIN-SAME: "{{.*}}{{\\|/}}libclang_rt.runtime_osx_dynamic.dylib"
+! DARWIN-SAME: -lflang_rt.runtime
 ! DARWIN-STATIC-FLANGRT: "{{.*}}{{\\|/}}libclang_rt.runtime_osx.a"
 
 ! HAIKU-LABEL:  "{{.*}}ld{{(\.exe)?}}"
 ! HAIKU-SAME: "[[object_file]]"
 ! HAIKU-F128NONE-NOT: libflang_rt.quadmath
 ! HAIKU-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
-! HAIKU-SAME: "{{.*}}{{\\|/}}libflang_rt.runtime.so"
+! HAIKU-SAME: -lflang_rt.runtime
 ! HAIKU-STATIC-FLANGRT: "{{.*}}{{\\|/}}libflang_rt.runtime.a"
 
 ! MINGW-LABEL:  "{{.*}}ld{{(\.exe)?}}"
 ! MINGW-SAME: "[[object_file]]"
 ! MINGW-F128NONE-NOT: libflang_rt.quadmath
 ! MINGW-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
-! MINGW-SAME: "{{.*}}{{\\|/}}libflang_rt.runtime.dll.a"
+! MINGW-SAME: -lflang_rt.runtime
 ! MINGW-STATIC-FLANGRT: "{{.*}}{{\\|/}}libflang_rt.runtime.a"
 
 ! NOTE: This also matches lld-link (when CLANG_DEFAULT_LINKER=lld) and

--- a/flang/test/Driver/linker-flags.f90
+++ b/flang/test/Driver/linker-flags.f90
@@ -44,7 +44,7 @@
 ! SOLARIS-F128NONE-NOT: flang_rt.quadmath
 ! UNIX-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
 ! SOLARIS-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "-z" "ignore" "-lquadmath" "-z" "record"
-! UNIX-SAME: "-lflang_rt.runtime" "-lm" 
+! UNIX-SAME: "-lflang_rt.runtime" "-lm"
 ! COMPILER-RT: "{{.*}}{{\\|/}}libclang_rt.builtins.a"
 ! UNIX-STATIC-FLANGRT:   "{{.*}}{{\\|/}}libflang_rt.runtime.a"
 
@@ -53,7 +53,7 @@
 ! BSD-F128NONE-NOT: flang_rt.quadmath
 ! BSD-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
 ! BSD-SAME: -lflang_rt.runtime
-! BSD-SAME: "-lexecinfo"
+! BSD-SAME: -lexecinfo
 ! BSD-STATIC-FLANGRT: "{{.*}}{{\\|/}}libflang_rt.runtime.a"
 
 ! DARWIN-LABEL:  "{{.*}}ld{{(\.exe)?}}"
@@ -67,7 +67,7 @@
 ! HAIKU-SAME: "[[object_file]]"
 ! HAIKU-F128NONE-NOT: libflang_rt.quadmath
 ! HAIKU-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
-! HAIKU-SAME: -lflang_rt.runtime
+! HAIKU-SAME: "-lflang_rt.runtime"
 ! HAIKU-STATIC-FLANGRT: "{{.*}}{{\\|/}}libflang_rt.runtime.a"
 
 ! MINGW-LABEL:  "{{.*}}ld{{(\.exe)?}}"

--- a/flang/test/Driver/linker-flags.f90
+++ b/flang/test/Driver/linker-flags.f90
@@ -33,33 +33,34 @@
 ! SOLARIS-F128NONE-NOT: flang_rt.quadmath
 ! UNIX-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
 ! SOLARIS-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "-z" "ignore" "-lquadmath" "-z" "record"
-! UNIX-SAME: "-lflang_rt.runtime" "-lm"
+! UNIX-SAME:   "{{.*}}{{\\|/}}libflang_rt.runtime.so"
+! UNIX-SAME:   "-lm"
 ! COMPILER-RT: "{{.*}}{{\\|/}}libclang_rt.builtins.a"
 
 ! BSD-LABEL:  "{{.*}}ld{{(\.exe)?}}"
 ! BSD-SAME: "[[object_file]]"
 ! BSD-F128NONE-NOT: flang_rt.quadmath
 ! BSD-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
-! BSD-SAME: -lflang_rt.runtime
-! BSD-SAME: -lexecinfo
+! BSD-SAME: "{{.*}}{{\\|/}}libflang_rt.runtime.so"
+! BSD-SAME: "-lexecinfo"
 
 ! DARWIN-LABEL:  "{{.*}}ld{{(\.exe)?}}"
 ! DARWIN-SAME: "[[object_file]]"
 ! DARWIN-F128NONE-NOT: libflang_rt.quadmath
 ! DARWIN-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
-! DARWIN-SAME: -lflang_rt.runtime
+! DARWIN-SAME: "{{.*}}{{\\|/}}libclang_rt.runtime_osx_dynamic.dylib"
 
 ! HAIKU-LABEL:  "{{.*}}ld{{(\.exe)?}}"
 ! HAIKU-SAME: "[[object_file]]"
 ! HAIKU-F128NONE-NOT: libflang_rt.quadmath
 ! HAIKU-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
-! HAIKU-SAME: "-lflang_rt.runtime"
+! HAIKU-SAME: "{{.*}}{{\\|/}}libflang_rt.runtime.so"
 
 ! MINGW-LABEL:  "{{.*}}ld{{(\.exe)?}}"
 ! MINGW-SAME: "[[object_file]]"
 ! MINGW-F128NONE-NOT: libflang_rt.quadmath
 ! MINGW-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
-! MINGW-SAME: -lflang_rt.runtime
+! MINGW-SAME: "{{.*}}{{\\|/}}libflang_rt.runtime.dll.a"
 
 ! NOTE: This also matches lld-link (when CLANG_DEFAULT_LINKER=lld) and
 !       any .exe suffix that is added when resolving to the full path of

--- a/flang/test/Driver/linker-flags.f90
+++ b/flang/test/Driver/linker-flags.f90
@@ -2,7 +2,7 @@
 ! invocation. These libraries are added on top of other standard runtime
 ! libraries that the Clang driver will include.
 
-! RUN: %flang -### --target=ppc64le-linux-gnu %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,UNIX,UNIX-F128NONE
+! RUN: %flang -### --target=ppc64le-linux-gnu %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,UNIX,UNIX-F128%f128-lib
 ! RUN: %flang -### --target=aarch64-apple-darwin %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,DARWIN,DARWIN-F128%f128-lib
 ! RUN: %flang -### --target=sparc-sun-solaris2.11 %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,UNIX,SOLARIS-F128%f128-lib
 ! RUN: %flang -### --target=x86_64-unknown-freebsd %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,BSD,BSD-F128%f128-lib

--- a/flang/test/Driver/linker-flags.f90
+++ b/flang/test/Driver/linker-flags.f90
@@ -3,20 +3,31 @@
 ! libraries that the Clang driver will include.
 
 ! RUN: %flang -### --target=ppc64le-linux-gnu %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,UNIX,UNIX-F128%f128-lib
-! RUN: %flang -### --target=aarch64-apple-darwin %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,DARWIN,DARWIN-F128%f128-lib
 ! RUN: %flang -### --target=sparc-sun-solaris2.11 %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,UNIX,SOLARIS-F128%f128-lib
 ! RUN: %flang -### --target=x86_64-unknown-freebsd %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,BSD,BSD-F128%f128-lib
 ! RUN: %flang -### --target=x86_64-unknown-netbsd %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,BSD,BSD-F128%f128-lib
 ! RUN: %flang -### --target=x86_64-unknown-openbsd %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,BSD,BSD-F128%f128-lib
 ! RUN: %flang -### --target=x86_64-unknown-dragonfly %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,BSD,BSD-F128%f128-lib
+! RUN: %flang -### --target=aarch64-apple-darwin %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,DARWIN,DARWIN-F128%f128-lib
 ! RUN: %flang -### --target=x86_64-unknown-haiku %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,HAIKU,HAIKU-F128%f128-lib
 ! RUN: %flang -### --target=x86_64-windows-gnu %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,MINGW,MINGW-F128%f128-lib
+
 ! RUN: %flang -### -rtlib=compiler-rt --target=aarch64-linux-gnu %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,UNIX,COMPILER-RT
 
 ! NOTE: Clang's driver library, clangDriver, usually adds 'oldnames' on Windows,
 !       but it is not needed when compiling Fortran code and they might bring in
 !       additional dependencies. Make sure its not added.
 ! RUN: %flang -### --target=aarch64-windows-msvc -fuse-ld= %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,MSVC --implicit-check-not oldnames
+
+! RUN: %flang -### --target=ppc64le-linux-gnu -static-libflangrt %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=UNIX-STATIC-FLANGRT
+! RUN: %flang -### --target=sparc-sun-solaris2.11 -static-libflangrt %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=UNIX-STATIC-FLANGRT
+! RUN: %flang -### --target=x86_64-unknown-freebsd -static-libflangrt %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=BSD-STATIC-FLANGRT
+! RUN: %flang -### --target=x86_64-unknown-netbsd -static-libflangrt %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=BSD-STATIC-FLANGRT
+! RUN: %flang -### --target=x86_64-unknown-openbsd -static-libflangrt %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=BSD-STATIC-FLANGRT
+! RUN: %flang -### --target=x86_64-unknown-dragonfly -static-libflangrt %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=CHECK,BSD-STATIC-FLANGRT
+! RUN: %flang -### --target=aarch64-apple-darwin -static-libflangrt %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=DARWIN-STATIC-FLANGRT
+! RUN: %flang -### --target=x86_64-unknown-haiku -static-libflangrt %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=HAIKU-STATIC-FLANGRT
+! RUN: %flang -### --target=x86_64-windows-gnu -static-libflangrt %S/Inputs/hello.f90 2>&1 | FileCheck %s --check-prefixes=MINGW-STATIC-FLANGRT
 
 ! Compiler invocation to generate the object file
 ! CHECK-LABEL: {{.*}} "-emit-obj"
@@ -36,6 +47,7 @@
 ! UNIX-SAME:   "{{.*}}{{\\|/}}libflang_rt.runtime.so"
 ! UNIX-SAME:   "-lm"
 ! COMPILER-RT: "{{.*}}{{\\|/}}libclang_rt.builtins.a"
+! UNIX-STATIC-FLANGRT:   "{{.*}}{{\\|/}}libflang_rt.runtime.a"
 
 ! BSD-LABEL:  "{{.*}}ld{{(\.exe)?}}"
 ! BSD-SAME: "[[object_file]]"
@@ -43,24 +55,28 @@
 ! BSD-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
 ! BSD-SAME: "{{.*}}{{\\|/}}libflang_rt.runtime.so"
 ! BSD-SAME: "-lexecinfo"
+! BSD-STATIC-FLANGRT: "{{.*}}{{\\|/}}libflang_rt.runtime.a"
 
 ! DARWIN-LABEL:  "{{.*}}ld{{(\.exe)?}}"
 ! DARWIN-SAME: "[[object_file]]"
 ! DARWIN-F128NONE-NOT: libflang_rt.quadmath
 ! DARWIN-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
 ! DARWIN-SAME: "{{.*}}{{\\|/}}libclang_rt.runtime_osx_dynamic.dylib"
+! DARWIN-STATIC-FLANGRT: "{{.*}}{{\\|/}}libclang_rt.runtime_osx.a"
 
 ! HAIKU-LABEL:  "{{.*}}ld{{(\.exe)?}}"
 ! HAIKU-SAME: "[[object_file]]"
 ! HAIKU-F128NONE-NOT: libflang_rt.quadmath
 ! HAIKU-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
 ! HAIKU-SAME: "{{.*}}{{\\|/}}libflang_rt.runtime.so"
+! HAIKU-STATIC-FLANGRT: "{{.*}}{{\\|/}}libflang_rt.runtime.a"
 
 ! MINGW-LABEL:  "{{.*}}ld{{(\.exe)?}}"
 ! MINGW-SAME: "[[object_file]]"
 ! MINGW-F128NONE-NOT: libflang_rt.quadmath
 ! MINGW-F128LIBQUADMATH-SAME: "-lflang_rt.quadmath" "--as-needed" "-lquadmath" "--no-as-needed"
 ! MINGW-SAME: "{{.*}}{{\\|/}}libflang_rt.runtime.dll.a"
+! MINGW-STATIC-FLANGRT: "{{.*}}{{\\|/}}libflang_rt.runtime.a"
 
 ! NOTE: This also matches lld-link (when CLANG_DEFAULT_LINKER=lld) and
 !       any .exe suffix that is added when resolving to the full path of


### PR DESCRIPTION
The PR is to generalize the re-use of the `compilerRT` code of adding the path of `libflang_rt.runtime.a (so)` from AIX and LoP only to all platforms via a new function `addFlangRTLibPath`.

It also added `-static-libflangrt` and `-shared-libflangrt` compiler options to allow users choosing which `flang-rt` to link to. It defaults to shared `flang-rt`, which is consistent with the linker behavior, except on AIX, it defaults to static.

Also,  PR #134320 exposed an issue in PR #131041 that the the overriding `addFortranRuntimeLibs` is missing the link to `libquadmath`. This PR also fixed that and restored the test case that PR #131041 broke.