### PR TITLE
[mlir] fix references of attributes which are not defined earlier

### DIFF
--- a/mlir/utils/generate-test-checks.py
+++ b/mlir/utils/generate-test-checks.py
@@ -145,10 +145,9 @@ class AttributeNamer:
         return attribute_name
 
     # Get the saved substitution name for the given attribute name. If no name
-    # has been generated for the given attribute yet, the source attribute name
-    # itself is returned.
+    # has been generated for the given attribute yet, None is returned.
     def get_name(self, source_attribute_name):
-        return self.map[source_attribute_name] if source_attribute_name in self.map else '?'
+        return self.map.get(source_attribute_name)
 
 # Return the number of SSA results in a line of type
 #   %0, %1, ... = ...
@@ -227,9 +226,9 @@ def process_attribute_references(line, attribute_namer):
     components = ATTR_RE.split(line)
     for component in components:
         m = ATTR_RE.match(component)
-        if m:
-            output_line += '#[[' + attribute_namer.get_name(m.group(1)) + ']]'
-            output_line += component[len(m.group()):]
+        attribute_name = attribute_namer.get_name(m.group(1)) if m else None
+        if attribute_name:
+            output_line += f"#[[{attribute_name}]]{component[len(m.group()):]}"
         else:
             output_line += component
     return output_line


### PR DESCRIPTION
If an attribute is not defined earlier in the same file, but just referenced from its dialect directly, then currently not the correct check is being emited.

What would it emit for #toy.shape<[1, 2, 3]>:
Earlier:
// CHECK: #[['?']]<[1, 2, 3]>
Now:
// CHECK: #toy.shape<[1, 2, 3]>