### PR TITLE
[DirectX] Scalarize the dx.saturate intrinsic

### DIFF
--- a/llvm/lib/Target/DirectX/DirectXTargetTransformInfo.cpp
+++ b/llvm/lib/Target/DirectX/DirectXTargetTransformInfo.cpp
@@ -44,6 +44,7 @@ bool DirectXTTIImpl::isTargetIntrinsicTriviallyScalarizable(
   case Intrinsic::dx_firstbituhigh:
   case Intrinsic::dx_frac:
   case Intrinsic::dx_rsqrt:
+  case Intrinsic::dx_saturate:
   case Intrinsic::dx_splitdouble:
   case Intrinsic::dx_wave_readlane:
   case Intrinsic::dx_wave_reduce_max:

--- a/llvm/test/CodeGen/DirectX/saturate.ll
+++ b/llvm/test/CodeGen/DirectX/saturate.ll
@@ -1,4 +1,4 @@
-; RUN: opt -S -dxil-op-lower -mtriple=dxil-pc-shadermodel6.3-library %s | FileCheck %s
+; RUN: opt -S -scalarizer -dxil-op-lower -mtriple=dxil-pc-shadermodel6.3-library %s | FileCheck %s
 ; Make sure the intrinsic dx.saturate is to appropriate DXIL op for half/float/double data types.
 
 ; CHECK-LABEL: test_saturate_half
@@ -28,9 +28,35 @@ entry:
   ret double %hlsl.saturate
 }
 
+; CHECK-LABEL: test_saturate_half4
+define noundef <4 x half> @test_saturate_half4(<4 x half> noundef %p0) {
+entry:
+  ; CHECK: call half @dx.op.unary.f16(i32 7, half
+  ; CHECK: call half @dx.op.unary.f16(i32 7, half
+  ; CHECK: call half @dx.op.unary.f16(i32 7, half
+  ; CHECK: call half @dx.op.unary.f16(i32 7, half
+  %hlsl.saturate = call <4 x half> @llvm.dx.saturate.v4f16(<4 x half> %p0)
+  ret <4 x half> %hlsl.saturate
+}
+
+; CHECK-LABEL: test_saturate_float3
+define noundef <3 x float> @test_saturate_float3(<3 x float> noundef %p0) {
+entry:
+  ; CHECK: call float @dx.op.unary.f32(i32 7, float
+  ; CHECK: call float @dx.op.unary.f32(i32 7, float
+  ; CHECK: call float @dx.op.unary.f32(i32 7, float
+  %hlsl.saturate = call <3 x float> @llvm.dx.saturate.v3f32(<3 x float> %p0)
+  ret <3 x float> %hlsl.saturate
+}
+
+; CHECK-LABEL: test_saturate_double2
+define noundef <2 x double> @test_saturate_double2(<2 x double> noundef %p0) {
+entry:
+  ; CHECK: call double @dx.op.unary.f64(i32 7, double
+  ; CHECK: call double @dx.op.unary.f64(i32 7, double
+  %hlsl.saturate = call <2 x double> @llvm.dx.saturate.v4f64(<2 x double> %p0)
+  ret <2 x double> %hlsl.saturate
+}
+
+
 ; CHECK: attributes #[[#ATTR]] = {{{.*}} memory(none) {{.*}}}
-
-declare half @llvm.dx.saturate.f16(half)
-declare float @llvm.dx.saturate.f32(float)
-declare double @llvm.dx.saturate.f64(double)
-


### PR DESCRIPTION
The DXIL Saturate op only takes scalars.

Fixes #134378.