### PR TITLE
[mlir][Transforms][NFC] Dialect Conversion: Replace after legalizing constants

### DIFF
--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -2109,9 +2109,6 @@ OperationLegalizer::legalizeWithFold(Operation *op,
   if (replacementValues.empty())
     return legalize(op, rewriter);
 
-  // Insert a replacement for 'op' with the folded replacement values.
-  rewriter.replaceOp(op, replacementValues);
-
   // Recursively legalize any new constant operations.
   for (unsigned i = curState.numRewrites, e = rewriterImpl.rewrites.size();
        i != e; ++i) {
@@ -2127,6 +2124,9 @@ OperationLegalizer::legalizeWithFold(Operation *op,
       return failure();
     }
   }
+
+  // Insert a replacement for 'op' with the folded replacement values.
+  rewriter.replaceOp(op, replacementValues);
 
   LLVM_DEBUG(logSuccess(rewriterImpl.logger, ""));
   return success();


### PR DESCRIPTION
When folding an op during a conversion, first try to legalize all generated constants, then replace the original operation. This is slightly more efficient because fewer rewrites must be rolled back in case a generated constant could not be legalized.

Note: This is in preparation of the One-Shot Dialect Conversion refactoring.
