### PR TITLE
[Clang-tidy][NFC] Remove dead code detected by code sanitizer.

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/RedundantExpressionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/RedundantExpressionCheck.cpp
@@ -929,16 +929,6 @@ static bool areExprsSameMacroOrLiteral(const BinaryOperator *BinOp,
 
   const auto *LStrl = dyn_cast<StringLiteral>(Lhs);
   const auto *RStrl = dyn_cast<StringLiteral>(Rhs);
-  if (Lil && Ril) {
-    const llvm::StringRef L = Lexer::getSourceText(
-        CharSourceRange::getTokenRange(LStrl->getBeginLoc()), SM,
-        Context->getLangOpts(), 0);
-    const llvm::StringRef R = Lexer::getSourceText(
-        CharSourceRange::getTokenRange(RStrl->getBeginLoc()), SM,
-        Context->getLangOpts(), 0);
-    return L.compare(R) == 0;
-  }
-
   const auto *Lbl = dyn_cast<CXXBoolLiteralExpr>(Lhs);
   const auto *Rbl = dyn_cast<CXXBoolLiteralExpr>(Rhs);
   if (Lbl && Rbl)

--- a/clang-tools-extra/clang-tidy/misc/RedundantExpressionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/RedundantExpressionCheck.cpp
@@ -927,8 +927,6 @@ static bool areExprsSameMacroOrLiteral(const BinaryOperator *BinOp,
   if (Lil && Ril)
     return Lil->getValue() == Ril->getValue();
 
-  const auto *LStrl = dyn_cast<StringLiteral>(Lhs);
-  const auto *RStrl = dyn_cast<StringLiteral>(Rhs);
   const auto *Lbl = dyn_cast<CXXBoolLiteralExpr>(Lhs);
   const auto *Rbl = dyn_cast<CXXBoolLiteralExpr>(Rhs);
   if (Lbl && Rbl)


### PR DESCRIPTION
The code sanitizer is failing with this error: `Execution cannot reach this statement.`
The execution code path would early exit at line 928 if `(Lil && Ril) = true`.