### PR TITLE
[clang][test] Improve unit tests for Fixed point AST matchers.

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -1564,6 +1564,9 @@ class FixedPointLiteral : public Expr, public APIntStorage {
   /// Returns an empty fixed-point literal.
   static FixedPointLiteral *Create(const ASTContext &C, EmptyShell Empty);
 
+  /// Returns an internal integer representation of the literal.
+  llvm::APInt getValue() const { return APIntStorage::getValue(); }
+
   SourceLocation getBeginLoc() const LLVM_READONLY { return Loc; }
   SourceLocation getEndLoc() const LLVM_READONLY { return Loc; }
 

--- a/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
@@ -1733,9 +1733,10 @@ public:
 template <typename T, typename ValueT>
 class ValueEqualsMatcher : public SingleNodeMatcherInterface<T> {
   static_assert(std::is_base_of<CharacterLiteral, T>::value ||
-                std::is_base_of<CXXBoolLiteralExpr, T>::value ||
-                std::is_base_of<FloatingLiteral, T>::value ||
-                std::is_base_of<IntegerLiteral, T>::value,
+                    std::is_base_of<CXXBoolLiteralExpr, T>::value ||
+                    std::is_base_of<FloatingLiteral, T>::value ||
+                    std::is_base_of<IntegerLiteral, T>::value ||
+                    std::is_base_of<FixedPointLiteral, T>::value,
                 "the node must have a getValue method");
 
 public:

--- a/clang/unittests/ASTMatchers/ASTMatchersNodeTest.cpp
+++ b/clang/unittests/ASTMatchers/ASTMatchersNodeTest.cpp
@@ -1017,6 +1017,67 @@ TEST_P(ASTMatchersTest, FloatLiteral) {
       notMatches("double i = 5.0;", floatLiteral(equals(llvm::APFloat(6.0)))));
 }
 
+TEST_P(ASTMatchersTest, FixedPointLiterals) {
+  StatementMatcher HasFixedPointLiteral = fixedPointLiteral();
+  EXPECT_TRUE(matchesWithFixedpoint("_Fract i = 0.25r;", HasFixedPointLiteral));
+  EXPECT_TRUE(
+      matchesWithFixedpoint("_Fract i = 0.25hr;", HasFixedPointLiteral));
+  EXPECT_TRUE(
+      matchesWithFixedpoint("_Fract i = 0.25uhr;", HasFixedPointLiteral));
+  EXPECT_TRUE(
+      matchesWithFixedpoint("_Fract i = 0.25ur;", HasFixedPointLiteral));
+  EXPECT_TRUE(
+      matchesWithFixedpoint("_Fract i = 0.25lr;", HasFixedPointLiteral));
+  EXPECT_TRUE(
+      matchesWithFixedpoint("_Fract i = 0.25ulr;", HasFixedPointLiteral));
+  EXPECT_TRUE(matchesWithFixedpoint("_Accum i = 1.25k;", HasFixedPointLiteral));
+  EXPECT_TRUE(
+      matchesWithFixedpoint("_Accum i = 1.25hk;", HasFixedPointLiteral));
+  EXPECT_TRUE(
+      matchesWithFixedpoint("_Accum i = 1.25uhk;", HasFixedPointLiteral));
+  EXPECT_TRUE(
+      matchesWithFixedpoint("_Accum i = 1.25uk;", HasFixedPointLiteral));
+  EXPECT_TRUE(
+      matchesWithFixedpoint("_Accum i = 1.25lk;", HasFixedPointLiteral));
+  EXPECT_TRUE(
+      matchesWithFixedpoint("_Accum i = 1.25ulk;", HasFixedPointLiteral));
+  EXPECT_TRUE(matchesWithFixedpoint("_Accum decexp1 = 1.575e1k;",
+                                    HasFixedPointLiteral));
+  EXPECT_TRUE(
+      matchesWithFixedpoint("_Accum hex = 0x1.25fp2k;", HasFixedPointLiteral));
+  EXPECT_TRUE(matchesWithFixedpoint("_Sat long _Fract i = 0.25r;",
+                                    HasFixedPointLiteral));
+  EXPECT_TRUE(matchesWithFixedpoint("_Sat short _Accum i = 256.0k;",
+                                    HasFixedPointLiteral));
+  EXPECT_TRUE(matchesWithFixedpoint(
+      "_Accum i = 256.0k;",
+      fixedPointLiteral(equals(llvm::APInt(32, 0x800000, true)))));
+  EXPECT_TRUE(matchesWithFixedpoint(
+      "_Fract i = 0.25ulr;",
+      fixedPointLiteral(equals(llvm::APInt(32, 0x40000000, false)))));
+  EXPECT_TRUE(matchesWithFixedpoint(
+      "_Fract i = 0.5hr;",
+      fixedPointLiteral(equals(llvm::APInt(8, 0x40, true)))));
+
+  EXPECT_TRUE(
+      notMatchesWithFixedpoint("short _Accum i = 2u;", HasFixedPointLiteral));
+  EXPECT_TRUE(
+      notMatchesWithFixedpoint("short _Accum i = 2;", HasFixedPointLiteral));
+  EXPECT_TRUE(
+      notMatchesWithFixedpoint("_Accum i = 1.25;", HasFixedPointLiteral));
+  EXPECT_TRUE(notMatchesWithFixedpoint("_Accum i = (double)(1.25 *  4.5i);",
+                                       HasFixedPointLiteral));
+  EXPECT_TRUE(notMatchesWithFixedpoint(
+      "_Accum i = 256.0k;",
+      fixedPointLiteral(equals(llvm::APInt(32, 0x800001, true)))));
+  EXPECT_TRUE(notMatchesWithFixedpoint(
+      "_Fract i = 0.25ulr;",
+      fixedPointLiteral(equals(llvm::APInt(32, 0x40000001, false)))));
+  EXPECT_TRUE(notMatchesWithFixedpoint(
+      "_Fract i = 0.5hr;",
+      fixedPointLiteral(equals(llvm::APInt(8, 0x41, true)))));
+}
+
 TEST_P(ASTMatchersTest, CXXNullPtrLiteralExpr) {
   if (!GetParam().isCXX11OrLater()) {
     return;

--- a/clang/unittests/ASTMatchers/ASTMatchersTest.h
+++ b/clang/unittests/ASTMatchers/ASTMatchersTest.h
@@ -290,6 +290,20 @@ testing::AssertionResult notMatchesWithOpenMP51(const Twine &Code,
 }
 
 template <typename T>
+testing::AssertionResult matchesWithFixedpoint(const std::string &Code,
+                                               const T &AMatcher) {
+  return matchesConditionally(Code, AMatcher, true, {"-ffixed-point"},
+                              FileContentMappings(), "input.c");
+}
+
+template <typename T>
+testing::AssertionResult notMatchesWithFixedpoint(const std::string &Code,
+                                                  const T &AMatcher) {
+  return matchesConditionally(Code, AMatcher, false, {"-ffixed-point"},
+                              FileContentMappings(), "input.c");
+}
+
+template <typename T>
 testing::AssertionResult matchAndVerifyResultConditionally(
     const Twine &Code, const T &AMatcher,
     std::unique_ptr<BoundNodesCallback> FindResultVerifier, bool ExpectResult,


### PR DESCRIPTION
We have AST matchers for fixed point float numbers since commits 789215dc0db174c9fdd273436fdd60d8289a9fc0 and
ff9120636e9c890b4db735d252d16b92091dde55. However in those commits the unit tests were not added. Amending the test suit by adding missing tests.