### PR TITLE
[NFC][LLVM] Cleanup pass initialization for ARM/ARV/Lanai/X86/XCore

### DIFF
--- a/llvm/lib/Target/ARM/ARMFixCortexA57AES1742098Pass.cpp
+++ b/llvm/lib/Target/ARM/ARMFixCortexA57AES1742098Pass.cpp
@@ -70,9 +70,7 @@ namespace {
 class ARMFixCortexA57AES1742098 : public MachineFunctionPass {
 public:
   static char ID;
-  explicit ARMFixCortexA57AES1742098() : MachineFunctionPass(ID) {
-    initializeARMFixCortexA57AES1742098Pass(*PassRegistry::getPassRegistry());
-  }
+  explicit ARMFixCortexA57AES1742098() : MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &F) override;
 

--- a/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -34,9 +34,7 @@ class AVRExpandPseudo : public MachineFunctionPass {
 public:
   static char ID;
 
-  AVRExpandPseudo() : MachineFunctionPass(ID) {
-    initializeAVRExpandPseudoPass(*PassRegistry::getPassRegistry());
-  }
+  AVRExpandPseudo() : MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &MF) override;
 
@@ -2643,8 +2641,7 @@ bool AVRExpandPseudo::expandMI(Block &MBB, BlockIt MBBI) {
 
 INITIALIZE_PASS(AVRExpandPseudo, "avr-expand-pseudo", AVR_EXPAND_PSEUDO_NAME,
                 false, false)
-namespace llvm {
 
-FunctionPass *createAVRExpandPseudoPass() { return new AVRExpandPseudo(); }
-
-} // end of namespace llvm
+FunctionPass *llvm::createAVRExpandPseudoPass() {
+  return new AVRExpandPseudo();
+}

--- a/llvm/lib/Target/Lanai/Lanai.h
+++ b/llvm/lib/Target/Lanai/Lanai.h
@@ -38,6 +38,7 @@ FunctionPass *createLanaiMemAluCombinerPass();
 FunctionPass *createLanaiSetflagAluCombinerPass();
 
 void initializeLanaiDAGToDAGISelLegacyPass(PassRegistry &);
+void initializeLanaiMemAluCombinerPass(PassRegistry &);
 
 } // namespace llvm
 

--- a/llvm/lib/Target/Lanai/LanaiMemAluCombiner.cpp
+++ b/llvm/lib/Target/Lanai/LanaiMemAluCombiner.cpp
@@ -22,6 +22,7 @@
 // in the same machine basic block into one machine instruction.
 //===----------------------------------------------------------------------===//
 
+#include "Lanai.h"
 #include "LanaiAluCode.h"
 #include "LanaiTargetMachine.h"
 #include "llvm/ADT/Statistic.h"
@@ -44,10 +45,6 @@ static llvm::cl::opt<bool> DisableMemAluCombiner(
     llvm::cl::desc("Do not combine ALU and memory operators"),
     llvm::cl::Hidden);
 
-namespace llvm {
-void initializeLanaiMemAluCombinerPass(PassRegistry &);
-} // namespace llvm
-
 namespace {
 typedef MachineBasicBlock::iterator MbbIterator;
 typedef MachineFunction::iterator MfIterator;
@@ -55,9 +52,7 @@ typedef MachineFunction::iterator MfIterator;
 class LanaiMemAluCombiner : public MachineFunctionPass {
 public:
   static char ID;
-  explicit LanaiMemAluCombiner() : MachineFunctionPass(ID) {
-    initializeLanaiMemAluCombinerPass(*PassRegistry::getPassRegistry());
-  }
+  explicit LanaiMemAluCombiner() : MachineFunctionPass(ID) {}
 
   StringRef getPassName() const override {
     return "Lanai load / store optimization pass";

--- a/llvm/lib/Target/Lanai/LanaiTargetMachine.cpp
+++ b/llvm/lib/Target/Lanai/LanaiTargetMachine.cpp
@@ -26,16 +26,13 @@
 
 using namespace llvm;
 
-namespace llvm {
-void initializeLanaiMemAluCombinerPass(PassRegistry &);
-} // namespace llvm
-
 extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeLanaiTarget() {
   // Register the target.
   RegisterTargetMachine<LanaiTargetMachine> registered_target(
       getTheLanaiTarget());
   PassRegistry &PR = *PassRegistry::getPassRegistry();
   initializeLanaiDAGToDAGISelLegacyPass(PR);
+  initializeLanaiMemAluCombinerPass(PR);
 }
 
 static std::string computeDataLayout() {

--- a/llvm/lib/Target/X86/X86LowerAMXIntrinsics.cpp
+++ b/llvm/lib/Target/X86/X86LowerAMXIntrinsics.cpp
@@ -631,10 +631,7 @@ class X86LowerAMXIntrinsicsLegacyPass : public FunctionPass {
 public:
   static char ID;
 
-  X86LowerAMXIntrinsicsLegacyPass() : FunctionPass(ID) {
-    initializeX86LowerAMXIntrinsicsLegacyPassPass(
-        *PassRegistry::getPassRegistry());
-  }
+  X86LowerAMXIntrinsicsLegacyPass() : FunctionPass(ID) {}
 
   bool runOnFunction(Function &F) override {
     if (!X86ScalarizeAMX)

--- a/llvm/lib/Target/XCore/XCoreLowerThreadLocal.cpp
+++ b/llvm/lib/Target/XCore/XCoreLowerThreadLocal.cpp
@@ -41,9 +41,7 @@ namespace {
   struct XCoreLowerThreadLocal : public ModulePass {
     static char ID;
 
-    XCoreLowerThreadLocal() : ModulePass(ID) {
-      initializeXCoreLowerThreadLocalPass(*PassRegistry::getPassRegistry());
-    }
+    XCoreLowerThreadLocal() : ModulePass(ID) {}
 
     bool lowerGlobal(GlobalVariable *GV);
 

--- a/llvm/lib/Target/XCore/XCoreTargetMachine.cpp
+++ b/llvm/lib/Target/XCore/XCoreTargetMachine.cpp
@@ -106,6 +106,7 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeXCoreTarget() {
   RegisterTargetMachine<XCoreTargetMachine> X(getTheXCoreTarget());
   PassRegistry &PR = *PassRegistry::getPassRegistry();
   initializeXCoreDAGToDAGISelLegacyPass(PR);
+  initializeXCoreLowerThreadLocalPass(PR);
 }
 
 TargetTransformInfo


### PR DESCRIPTION
- Remove pass initialization from pass constructors.
- https://github.com/llvm/llvm-project/issues/111767