### PR TITLE
[libc++] Guard additional headers with _LIBCPP_HAS_LOCALIZATION (#131921)

### DIFF
--- a/libcxx/include/__configuration/platform.h
+++ b/libcxx/include/__configuration/platform.h
@@ -42,6 +42,13 @@
 #  endif
 #endif
 
+// This is required in order for _NEWLIB_VERSION to be defined in places where we use it.
+// TODO: We shouldn't be including arbitrarily-named headers from libc++ since this can break valid
+//       user code. Move code paths that need _NEWLIB_VERSION to another customization mechanism.
+#if __has_include(<picolibc.h>)
+#  include <picolibc.h>
+#endif
+
 #ifndef __BYTE_ORDER__
 #  error                                                                                                               \
       "Your compiler doesn't seem to define __BYTE_ORDER__, which is required by libc++ to know the endianness of your target platform"

--- a/libcxx/include/__locale
+++ b/libcxx/include/__locale
@@ -11,6 +11,9 @@
 #define _LIBCPP___LOCALE
 
 #include <__config>
+
+#if _LIBCPP_HAS_LOCALIZATION
+
 #include <__locale_dir/locale_base_api.h>
 #include <__memory/shared_count.h>
 #include <__mutex/once_flag.h>
@@ -24,18 +27,18 @@
 #include <string>
 
 // Some platforms require more includes than others. Keep the includes on all plaforms for now.
-#include <cstddef>
-#include <cstring>
+#  include <cstddef>
+#  include <cstring>
 
-#if _LIBCPP_HAS_WIDE_CHARACTERS
-#  include <cwchar>
-#else
-#  include <__std_mbstate_t.h>
-#endif
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    include <cwchar>
+#  else
+#    include <__std_mbstate_t.h>
+#  endif
 
-#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#  pragma GCC system_header
-#endif
+#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#    pragma GCC system_header
+#  endif
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -85,9 +88,9 @@ public:
   // locale operations:
   string name() const;
   bool operator==(const locale&) const;
-#if _LIBCPP_STD_VER <= 17
+#  if _LIBCPP_STD_VER <= 17
   _LIBCPP_HIDE_FROM_ABI bool operator!=(const locale& __y) const { return !(*this == __y); }
-#endif
+#  endif
   template <class _CharT, class _Traits, class _Allocator>
   _LIBCPP_METHOD_TEMPLATE_IMPLICIT_INSTANTIATION_VIS bool
   operator()(const basic_string<_CharT, _Traits, _Allocator>&, const basic_string<_CharT, _Traits, _Allocator>&) const;
@@ -237,9 +240,9 @@ long collate<_CharT>::do_hash(const char_type* __lo, const char_type* __hi) cons
 }
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS collate<char>;
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS collate<wchar_t>;
-#endif
+#  endif
 
 // template <class CharT> class collate_byname;
 
@@ -264,7 +267,7 @@ protected:
   string_type do_transform(const char_type* __lo, const char_type* __hi) const override;
 };
 
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI collate_byname<wchar_t> : public collate<wchar_t> {
   __locale::__locale_t __l_;
@@ -283,7 +286,7 @@ protected:
       const char_type* __lo1, const char_type* __hi1, const char_type* __lo2, const char_type* __hi2) const override;
   string_type do_transform(const char_type* __lo, const char_type* __hi) const override;
 };
-#endif
+#  endif
 
 template <class _CharT, class _Traits, class _Allocator>
 bool locale::operator()(const basic_string<_CharT, _Traits, _Allocator>& __x,
@@ -296,7 +299,7 @@ bool locale::operator()(const basic_string<_CharT, _Traits, _Allocator>& __x,
 
 class _LIBCPP_EXPORTED_FROM_ABI ctype_base {
 public:
-#if defined(_LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE)
+#  if defined(_LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE)
   typedef unsigned long mask;
   static const mask space  = 1 << 0;
   static const mask print  = 1 << 1;
@@ -308,14 +311,14 @@ public:
   static const mask punct  = 1 << 7;
   static const mask xdigit = 1 << 8;
   static const mask blank  = 1 << 9;
-#  if defined(__BIONIC__)
+#    if defined(__BIONIC__)
   // Historically this was a part of regex_traits rather than ctype_base. The
   // historical value of the constant is preserved for ABI compatibility.
   static const mask __regex_word = 0x8000;
-#  else
+#    else
   static const mask __regex_word = 1 << 10;
-#  endif // defined(__BIONIC__)
-#elif defined(__GLIBC__)
+#    endif // defined(__BIONIC__)
+#  elif defined(__GLIBC__)
   typedef unsigned short mask;
   static const mask space  = _ISspace;
   static const mask print  = _ISprint;
@@ -327,12 +330,12 @@ public:
   static const mask punct  = _ISpunct;
   static const mask xdigit = _ISxdigit;
   static const mask blank  = _ISblank;
-#  if defined(__mips__) || (BYTE_ORDER == BIG_ENDIAN)
+#    if defined(__mips__) || (BYTE_ORDER == BIG_ENDIAN)
   static const mask __regex_word = static_cast<mask>(_ISbit(15));
-#  else
+#    else
   static const mask __regex_word = 0x80;
-#  endif
-#elif defined(_LIBCPP_MSVCRT_LIKE)
+#    endif
+#  elif defined(_LIBCPP_MSVCRT_LIKE)
   typedef unsigned short mask;
   static const mask space        = _SPACE;
   static const mask print        = _BLANK | _PUNCT | _ALPHA | _DIGIT;
@@ -345,16 +348,16 @@ public:
   static const mask xdigit       = _HEX;
   static const mask blank        = _BLANK;
   static const mask __regex_word = 0x4000; // 0x8000 and 0x0100 and 0x00ff are used
-#  define _LIBCPP_CTYPE_MASK_IS_COMPOSITE_PRINT
-#  define _LIBCPP_CTYPE_MASK_IS_COMPOSITE_ALPHA
-#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__)
-#  ifdef __APPLE__
+#    define _LIBCPP_CTYPE_MASK_IS_COMPOSITE_PRINT
+#    define _LIBCPP_CTYPE_MASK_IS_COMPOSITE_ALPHA
+#  elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__)
+#    ifdef __APPLE__
   typedef uint32_t mask;
-#  elif defined(__FreeBSD__)
+#    elif defined(__FreeBSD__)
   typedef unsigned long mask;
-#  elif defined(__NetBSD__)
+#    elif defined(__NetBSD__)
   typedef unsigned short mask;
-#  endif
+#    endif
   static const mask space  = _CTYPE_S;
   static const mask print  = _CTYPE_R;
   static const mask cntrl  = _CTYPE_C;
@@ -365,16 +368,16 @@ public:
   static const mask punct  = _CTYPE_P;
   static const mask xdigit = _CTYPE_X;
 
-#  if defined(__NetBSD__)
+#    if defined(__NetBSD__)
   static const mask blank = _CTYPE_BL;
   // NetBSD defines classes up to 0x2000
   // see sys/ctype_bits.h, _CTYPE_Q
   static const mask __regex_word = 0x8000;
-#  else
+#    else
   static const mask blank        = _CTYPE_B;
   static const mask __regex_word = 0x80;
-#  endif
-#elif defined(_AIX)
+#    endif
+#  elif defined(_AIX)
   typedef unsigned int mask;
   static const mask space        = _ISSPACE;
   static const mask print        = _ISPRINT;
@@ -387,7 +390,7 @@ public:
   static const mask xdigit       = _ISXDIGIT;
   static const mask blank        = _ISBLANK;
   static const mask __regex_word = 0x8000;
-#elif defined(_NEWLIB_VERSION)
+#  elif defined(_NEWLIB_VERSION)
   // Same type as Newlib's _ctype_ array in newlib/libc/include/ctype.h.
   typedef char mask;
   // In case char is signed, static_cast is needed to avoid warning on
@@ -404,11 +407,11 @@ public:
   static const mask blank  = static_cast<mask>(_B);
   // mask is already fully saturated, use a different type in regex_type_traits.
   static const unsigned short __regex_word = 0x100;
-#  define _LIBCPP_CTYPE_MASK_IS_COMPOSITE_PRINT
-#  define _LIBCPP_CTYPE_MASK_IS_COMPOSITE_ALPHA
-#  define _LIBCPP_CTYPE_MASK_IS_COMPOSITE_XDIGIT
-#elif defined(__MVS__)
-#  if defined(__NATIVE_ASCII_F)
+#    define _LIBCPP_CTYPE_MASK_IS_COMPOSITE_PRINT
+#    define _LIBCPP_CTYPE_MASK_IS_COMPOSITE_ALPHA
+#    define _LIBCPP_CTYPE_MASK_IS_COMPOSITE_XDIGIT
+#  elif defined(__MVS__)
+#    if defined(__NATIVE_ASCII_F)
   typedef unsigned int mask;
   static const mask space  = _ISSPACE_A;
   static const mask print  = _ISPRINT_A;
@@ -420,7 +423,7 @@ public:
   static const mask punct  = _ISPUNCT_A;
   static const mask xdigit = _ISXDIGIT_A;
   static const mask blank  = _ISBLANK_A;
-#  else
+#    else
   typedef unsigned short mask;
   static const mask space  = __ISSPACE;
   static const mask print  = __ISPRINT;
@@ -432,11 +435,11 @@ public:
   static const mask punct  = __ISPUNCT;
   static const mask xdigit = __ISXDIGIT;
   static const mask blank  = __ISBLANK;
-#  endif
+#    endif
   static const mask __regex_word = 0x8000;
-#else
-#  error unknown rune table for this platform -- do you mean to define _LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE?
-#endif
+#  else
+#    error unknown rune table for this platform -- do you mean to define _LIBCPP_PROVIDES_DEFAULT_RUNE_TABLE?
+#  endif
   static const mask alnum = alpha | digit;
   static const mask graph = alnum | punct;
 
@@ -450,7 +453,7 @@ public:
 template <class _CharT>
 class _LIBCPP_TEMPLATE_VIS ctype;
 
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI ctype<wchar_t> : public locale::facet, public ctype_base {
 public:
@@ -515,7 +518,7 @@ protected:
   virtual const char_type*
   do_narrow(const char_type* __low, const char_type* __high, char __dfault, char* __dest) const;
 };
-#endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#  endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 inline _LIBCPP_HIDE_FROM_ABI bool __libcpp_isascii(int __c) { return (__c & ~0x7F) == 0; }
 
@@ -580,25 +583,25 @@ public:
 
   static locale::id id;
 
-#ifdef _CACHED_RUNES
+#  ifdef _CACHED_RUNES
   static const size_t table_size = _CACHED_RUNES;
-#else
+#  else
   static const size_t table_size = 256; // FIXME: Don't hardcode this.
-#endif
+#  endif
   _LIBCPP_HIDE_FROM_ABI const mask* table() const _NOEXCEPT { return __tab_; }
   static const mask* classic_table() _NOEXCEPT;
-#if defined(__GLIBC__) || defined(__EMSCRIPTEN__)
+#  if defined(__GLIBC__) || defined(__EMSCRIPTEN__)
   static const int* __classic_upper_table() _NOEXCEPT;
   static const int* __classic_lower_table() _NOEXCEPT;
-#endif
-#if defined(__NetBSD__)
+#  endif
+#  if defined(__NetBSD__)
   static const short* __classic_upper_table() _NOEXCEPT;
   static const short* __classic_lower_table() _NOEXCEPT;
-#endif
-#if defined(__MVS__)
+#  endif
+#  if defined(__MVS__)
   static const unsigned short* __classic_upper_table() _NOEXCEPT;
   static const unsigned short* __classic_lower_table() _NOEXCEPT;
-#endif
+#  endif
 
 protected:
   ~ctype() override;
@@ -633,7 +636,7 @@ protected:
   const char_type* do_tolower(char_type* __low, const char_type* __high) const override;
 };
 
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI ctype_byname<wchar_t> : public ctype<wchar_t> {
   __locale::__locale_t __l_;
@@ -658,7 +661,7 @@ protected:
   const char_type*
   do_narrow(const char_type* __low, const char_type* __high, char __dfault, char* __dest) const override;
 };
-#endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#  endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 template <class _CharT>
 inline _LIBCPP_HIDE_FROM_ABI bool isspace(_CharT __c, const locale& __loc) {
@@ -824,7 +827,7 @@ protected:
 
 // template <> class codecvt<wchar_t, char, mbstate_t>
 
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI codecvt<wchar_t, char, mbstate_t> : public locale::facet, public codecvt_base {
   __locale::__locale_t __l_;
@@ -903,7 +906,7 @@ protected:
   virtual int do_length(state_type&, const extern_type* __frm, const extern_type* __end, size_t __mx) const;
   virtual int do_max_length() const _NOEXCEPT;
 };
-#endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#  endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 // template <> class codecvt<char16_t, char, mbstate_t> // deprecated in C++20
 
@@ -985,7 +988,7 @@ protected:
   virtual int do_max_length() const _NOEXCEPT;
 };
 
-#if _LIBCPP_HAS_CHAR8_T
+#  if _LIBCPP_HAS_CHAR8_T
 
 // template <> class codecvt<char16_t, char8_t, mbstate_t> // C++20
 
@@ -1066,7 +1069,7 @@ protected:
   virtual int do_max_length() const _NOEXCEPT;
 };
 
-#endif
+#  endif
 
 // template <> class codecvt<char32_t, char, mbstate_t> // deprecated in C++20
 
@@ -1148,7 +1151,7 @@ protected:
   virtual int do_max_length() const _NOEXCEPT;
 };
 
-#if _LIBCPP_HAS_CHAR8_T
+#  if _LIBCPP_HAS_CHAR8_T
 
 // template <> class codecvt<char32_t, char8_t, mbstate_t> // C++20
 
@@ -1229,7 +1232,7 @@ protected:
   virtual int do_max_length() const _NOEXCEPT;
 };
 
-#endif
+#  endif
 
 // template <class _InternT, class _ExternT, class _StateT> class codecvt_byname
 
@@ -1251,17 +1254,17 @@ codecvt_byname<_InternT, _ExternT, _StateT>::~codecvt_byname() {}
 _LIBCPP_SUPPRESS_DEPRECATED_POP
 
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<char, char, mbstate_t>;
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<wchar_t, char, mbstate_t>;
-#endif
+#  endif
 extern template class _LIBCPP_DEPRECATED_IN_CXX20
 _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<char16_t, char, mbstate_t>; // deprecated in C++20
 extern template class _LIBCPP_DEPRECATED_IN_CXX20
 _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<char32_t, char, mbstate_t>; // deprecated in C++20
-#if _LIBCPP_HAS_CHAR8_T
+#  if _LIBCPP_HAS_CHAR8_T
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<char16_t, char8_t, mbstate_t>; // C++20
 extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS codecvt_byname<char32_t, char8_t, mbstate_t>; // C++20
-#endif
+#  endif
 
 template <size_t _Np>
 struct __narrow_to_utf8 {
@@ -1441,7 +1444,7 @@ protected:
   string __grouping_;
 };
 
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI numpunct<wchar_t> : public locale::facet {
 public:
@@ -1470,7 +1473,7 @@ protected:
   char_type __thousands_sep_;
   string __grouping_;
 };
-#endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#  endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 // template <class charT> class numpunct_byname
 
@@ -1493,7 +1496,7 @@ private:
   void __init(const char*);
 };
 
-#if _LIBCPP_HAS_WIDE_CHARACTERS
+#  if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 class _LIBCPP_EXPORTED_FROM_ABI numpunct_byname<wchar_t> : public numpunct<wchar_t> {
 public:
@@ -1509,8 +1512,10 @@ protected:
 private:
   void __init(const char*);
 };
-#endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#  endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 _LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP_HAS_LOCALIZATION
 
 #endif // _LIBCPP___LOCALE

--- a/libcxx/include/__locale_dir/locale_base_api.h
+++ b/libcxx/include/__locale_dir/locale_base_api.h
@@ -111,57 +111,59 @@
 //  int     __sscanf(const char*, __locale_t, const char*, ...);     // required by the headers
 // }
 
-#if defined(__APPLE__)
-#  include <__locale_dir/support/apple.h>
-#elif defined(__FreeBSD__)
-#  include <__locale_dir/support/freebsd.h>
-#elif defined(_LIBCPP_MSVCRT_LIKE)
-#  include <__locale_dir/support/windows.h>
-#elif defined(__Fuchsia__)
-#  include <__locale_dir/support/fuchsia.h>
-#else
+#if _LIBCPP_HAS_LOCALIZATION
+
+#  if defined(__APPLE__)
+#    include <__locale_dir/support/apple.h>
+#  elif defined(__FreeBSD__)
+#    include <__locale_dir/support/freebsd.h>
+#  elif defined(_LIBCPP_MSVCRT_LIKE)
+#    include <__locale_dir/support/windows.h>
+#  elif defined(__Fuchsia__)
+#    include <__locale_dir/support/fuchsia.h>
+#  else
 
 // TODO: This is a temporary definition to bridge between the old way we defined the locale base API
 //       (by providing global non-reserved names) and the new API. As we move individual platforms
 //       towards the new way of defining the locale base API, this should disappear since each platform
 //       will define those directly.
-#  if defined(_AIX) || defined(__MVS__)
-#    include <__locale_dir/locale_base_api/ibm.h>
-#  elif defined(__ANDROID__)
-#    include <__locale_dir/locale_base_api/android.h>
-#  elif defined(__OpenBSD__)
-#    include <__locale_dir/locale_base_api/openbsd.h>
-#  elif defined(__wasi__) || _LIBCPP_HAS_MUSL_LIBC
-#    include <__locale_dir/locale_base_api/musl.h>
-#  endif
+#    if defined(_AIX) || defined(__MVS__)
+#      include <__locale_dir/locale_base_api/ibm.h>
+#    elif defined(__ANDROID__)
+#      include <__locale_dir/locale_base_api/android.h>
+#    elif defined(__OpenBSD__)
+#      include <__locale_dir/locale_base_api/openbsd.h>
+#    elif defined(__wasi__) || _LIBCPP_HAS_MUSL_LIBC
+#      include <__locale_dir/locale_base_api/musl.h>
+#    endif
 
-#  include <__locale_dir/locale_base_api/bsd_locale_fallbacks.h>
+#    include <__locale_dir/locale_base_api/bsd_locale_fallbacks.h>
 
-#  include <__cstddef/size_t.h>
-#  include <__utility/forward.h>
-#  include <ctype.h>
-#  include <string.h>
-#  include <time.h>
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
-#    include <wctype.h>
-#  endif
+#    include <__cstddef/size_t.h>
+#    include <__utility/forward.h>
+#    include <ctype.h>
+#    include <string.h>
+#    include <time.h>
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
+#      include <wctype.h>
+#    endif
 _LIBCPP_BEGIN_NAMESPACE_STD
 namespace __locale {
 //
 // Locale management
 //
-#  define _LIBCPP_COLLATE_MASK LC_COLLATE_MASK
-#  define _LIBCPP_CTYPE_MASK LC_CTYPE_MASK
-#  define _LIBCPP_MONETARY_MASK LC_MONETARY_MASK
-#  define _LIBCPP_NUMERIC_MASK LC_NUMERIC_MASK
-#  define _LIBCPP_TIME_MASK LC_TIME_MASK
-#  define _LIBCPP_MESSAGES_MASK LC_MESSAGES_MASK
-#  define _LIBCPP_ALL_MASK LC_ALL_MASK
-#  define _LIBCPP_LC_ALL LC_ALL
+#    define _LIBCPP_COLLATE_MASK LC_COLLATE_MASK
+#    define _LIBCPP_CTYPE_MASK LC_CTYPE_MASK
+#    define _LIBCPP_MONETARY_MASK LC_MONETARY_MASK
+#    define _LIBCPP_NUMERIC_MASK LC_NUMERIC_MASK
+#    define _LIBCPP_TIME_MASK LC_TIME_MASK
+#    define _LIBCPP_MESSAGES_MASK LC_MESSAGES_MASK
+#    define _LIBCPP_ALL_MASK LC_ALL_MASK
+#    define _LIBCPP_LC_ALL LC_ALL
 
 using __locale_t _LIBCPP_NODEBUG = locale_t;
 
-#  if defined(_LIBCPP_BUILDING_LIBRARY)
+#    if defined(_LIBCPP_BUILDING_LIBRARY)
 using __lconv_t _LIBCPP_NODEBUG = lconv;
 
 inline _LIBCPP_HIDE_FROM_ABI __locale_t __newlocale(int __category_mask, const char* __name, __locale_t __loc) {
@@ -175,7 +177,7 @@ inline _LIBCPP_HIDE_FROM_ABI char* __setlocale(int __category, char const* __loc
 inline _LIBCPP_HIDE_FROM_ABI void __freelocale(__locale_t __loc) { freelocale(__loc); }
 
 inline _LIBCPP_HIDE_FROM_ABI __lconv_t* __localeconv(__locale_t& __loc) { return __libcpp_localeconv_l(__loc); }
-#  endif // _LIBCPP_BUILDING_LIBRARY
+#    endif // _LIBCPP_BUILDING_LIBRARY
 
 //
 // Strtonum functions
@@ -204,15 +206,15 @@ __strtoull(const char* __nptr, char** __endptr, int __base, __locale_t __loc) {
 //
 // Character manipulation functions
 //
-#  if defined(_LIBCPP_BUILDING_LIBRARY)
+#    if defined(_LIBCPP_BUILDING_LIBRARY)
 inline _LIBCPP_HIDE_FROM_ABI int __islower(int __ch, __locale_t __loc) { return islower_l(__ch, __loc); }
 inline _LIBCPP_HIDE_FROM_ABI int __isupper(int __ch, __locale_t __loc) { return isupper_l(__ch, __loc); }
-#  endif
+#    endif
 
 inline _LIBCPP_HIDE_FROM_ABI int __isdigit(int __ch, __locale_t __loc) { return isdigit_l(__ch, __loc); }
 inline _LIBCPP_HIDE_FROM_ABI int __isxdigit(int __ch, __locale_t __loc) { return isxdigit_l(__ch, __loc); }
 
-#  if defined(_LIBCPP_BUILDING_LIBRARY)
+#    if defined(_LIBCPP_BUILDING_LIBRARY)
 inline _LIBCPP_HIDE_FROM_ABI int __strcoll(const char* __s1, const char* __s2, __locale_t __loc) {
   return strcoll_l(__s1, __s2, __loc);
 }
@@ -222,7 +224,7 @@ inline _LIBCPP_HIDE_FROM_ABI size_t __strxfrm(char* __dest, const char* __src, s
 inline _LIBCPP_HIDE_FROM_ABI int __toupper(int __ch, __locale_t __loc) { return toupper_l(__ch, __loc); }
 inline _LIBCPP_HIDE_FROM_ABI int __tolower(int __ch, __locale_t __loc) { return tolower_l(__ch, __loc); }
 
-#    if _LIBCPP_HAS_WIDE_CHARACTERS
+#      if _LIBCPP_HAS_WIDE_CHARACTERS
 inline _LIBCPP_HIDE_FROM_ABI int __wcscoll(const wchar_t* __s1, const wchar_t* __s2, __locale_t __loc) {
   return wcscoll_l(__s1, __s2, __loc);
 }
@@ -244,7 +246,7 @@ inline _LIBCPP_HIDE_FROM_ABI int __iswpunct(wint_t __ch, __locale_t __loc) { ret
 inline _LIBCPP_HIDE_FROM_ABI int __iswxdigit(wint_t __ch, __locale_t __loc) { return iswxdigit_l(__ch, __loc); }
 inline _LIBCPP_HIDE_FROM_ABI wint_t __towupper(wint_t __ch, __locale_t __loc) { return towupper_l(__ch, __loc); }
 inline _LIBCPP_HIDE_FROM_ABI wint_t __towlower(wint_t __ch, __locale_t __loc) { return towlower_l(__ch, __loc); }
-#    endif
+#      endif
 
 inline _LIBCPP_HIDE_FROM_ABI size_t
 __strftime(char* __s, size_t __max, const char* __format, const tm* __tm, __locale_t __loc) {
@@ -257,7 +259,7 @@ __strftime(char* __s, size_t __max, const char* __format, const tm* __tm, __loca
 inline _LIBCPP_HIDE_FROM_ABI decltype(__libcpp_mb_cur_max_l(__locale_t())) __mb_len_max(__locale_t __loc) {
   return __libcpp_mb_cur_max_l(__loc);
 }
-#    if _LIBCPP_HAS_WIDE_CHARACTERS
+#      if _LIBCPP_HAS_WIDE_CHARACTERS
 inline _LIBCPP_HIDE_FROM_ABI wint_t __btowc(int __ch, __locale_t __loc) { return __libcpp_btowc_l(__ch, __loc); }
 inline _LIBCPP_HIDE_FROM_ABI int __wctob(wint_t __ch, __locale_t __loc) { return __libcpp_wctob_l(__ch, __loc); }
 inline _LIBCPP_HIDE_FROM_ABI size_t
@@ -285,17 +287,17 @@ inline _LIBCPP_HIDE_FROM_ABI size_t
 __mbsrtowcs(wchar_t* __dest, const char** __src, size_t __len, mbstate_t* __ps, __locale_t __loc) {
   return __libcpp_mbsrtowcs_l(__dest, __src, __len, __ps, __loc);
 }
-#    endif // _LIBCPP_HAS_WIDE_CHARACTERS
-#  endif   // _LIBCPP_BUILDING_LIBRARY
+#      endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#    endif   // _LIBCPP_BUILDING_LIBRARY
 
 _LIBCPP_DIAGNOSTIC_PUSH
 _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wgcc-compat")
 _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wformat-nonliteral") // GCC doesn't support [[gnu::format]] on variadic templates
-#  ifdef _LIBCPP_COMPILER_CLANG_BASED
-#    define _LIBCPP_VARIADIC_ATTRIBUTE_FORMAT(...) _LIBCPP_ATTRIBUTE_FORMAT(__VA_ARGS__)
-#  else
-#    define _LIBCPP_VARIADIC_ATTRIBUTE_FORMAT(...) /* nothing */
-#  endif
+#    ifdef _LIBCPP_COMPILER_CLANG_BASED
+#      define _LIBCPP_VARIADIC_ATTRIBUTE_FORMAT(...) _LIBCPP_ATTRIBUTE_FORMAT(__VA_ARGS__)
+#    else
+#      define _LIBCPP_VARIADIC_ATTRIBUTE_FORMAT(...) /* nothing */
+#    endif
 
 template <class... _Args>
 _LIBCPP_HIDE_FROM_ABI _LIBCPP_VARIADIC_ATTRIBUTE_FORMAT(__printf__, 4, 5) int __snprintf(
@@ -313,11 +315,13 @@ _LIBCPP_HIDE_FROM_ABI _LIBCPP_VARIADIC_ATTRIBUTE_FORMAT(__scanf__, 3, 4) int __s
   return std::__libcpp_sscanf_l(__s, __loc, __format, std::forward<_Args>(__args)...);
 }
 _LIBCPP_DIAGNOSTIC_POP
-#  undef _LIBCPP_VARIADIC_ATTRIBUTE_FORMAT
+#    undef _LIBCPP_VARIADIC_ATTRIBUTE_FORMAT
 
 } // namespace __locale
 _LIBCPP_END_NAMESPACE_STD
 
-#endif // Compatibility definition of locale base APIs
+#  endif // Compatibility definition of locale base APIs
+
+#endif // _LIBCPP_HAS_LOCALIZATION
 
 #endif // _LIBCPP___LOCALE_DIR_LOCALE_BASE_API_H

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -189,34 +189,35 @@ typedef basic_fstream<wchar_t> wfstream;
 #if __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)
 #  include <__cxx03/fstream>
 #else
-#  include <__algorithm/max.h>
-#  include <__assert>
 #  include <__config>
-#  include <__filesystem/path.h>
-#  include <__fwd/fstream.h>
-#  include <__locale>
-#  include <__memory/addressof.h>
-#  include <__memory/unique_ptr.h>
-#  include <__ostream/basic_ostream.h>
-#  include <__type_traits/enable_if.h>
-#  include <__type_traits/is_same.h>
-#  include <__utility/move.h>
-#  include <__utility/swap.h>
-#  include <__utility/unreachable.h>
-#  include <cstdio>
-#  include <istream>
-#  include <streambuf>
-#  include <typeinfo>
-#  include <version>
-
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
-
-_LIBCPP_PUSH_MACROS
-#  include <__undef_macros>
 
 #  if _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
+
+#    include <__algorithm/max.h>
+#    include <__assert>
+#    include <__filesystem/path.h>
+#    include <__fwd/fstream.h>
+#    include <__locale>
+#    include <__memory/addressof.h>
+#    include <__memory/unique_ptr.h>
+#    include <__ostream/basic_ostream.h>
+#    include <__type_traits/enable_if.h>
+#    include <__type_traits/is_same.h>
+#    include <__utility/move.h>
+#    include <__utility/swap.h>
+#    include <__utility/unreachable.h>
+#    include <cstdio>
+#    include <istream>
+#    include <streambuf>
+#    include <typeinfo>
+#    include <version>
+
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
+
+_LIBCPP_PUSH_MACROS
+#    include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -1570,9 +1571,9 @@ extern template class _LIBCPP_EXTERN_TEMPLATE_TYPE_VIS basic_filebuf<char>;
 
 _LIBCPP_END_NAMESPACE_STD
 
-#  endif // _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
-
 _LIBCPP_POP_MACROS
+
+#  endif // _LIBCPP_HAS_FILESYSTEM && _LIBCPP_HAS_LOCALIZATION
 
 #  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #    include <atomic>

--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -792,48 +792,50 @@ typedef regex_token_iterator<wstring::const_iterator> wsregex_token_iterator;
 #if __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)
 #  include <__cxx03/regex>
 #else
-#  include <__algorithm/find.h>
-#  include <__algorithm/search.h>
-#  include <__assert>
 #  include <__config>
-#  include <__iterator/back_insert_iterator.h>
-#  include <__iterator/default_sentinel.h>
-#  include <__iterator/wrap_iter.h>
-#  include <__locale>
-#  include <__memory/shared_ptr.h>
-#  include <__memory_resource/polymorphic_allocator.h>
-#  include <__type_traits/is_swappable.h>
-#  include <__utility/move.h>
-#  include <__utility/pair.h>
-#  include <__utility/swap.h>
-#  include <__verbose_abort>
-#  include <deque>
-#  include <stdexcept>
-#  include <string>
-#  include <vector>
-#  include <version>
+
+#  if _LIBCPP_HAS_LOCALIZATION
+
+#    include <__algorithm/find.h>
+#    include <__algorithm/search.h>
+#    include <__iterator/back_insert_iterator.h>
+#    include <__iterator/default_sentinel.h>
+#    include <__iterator/wrap_iter.h>
+#    include <__locale>
+#    include <__memory/shared_ptr.h>
+#    include <__memory_resource/polymorphic_allocator.h>
+#    include <__type_traits/is_swappable.h>
+#    include <__utility/move.h>
+#    include <__utility/pair.h>
+#    include <__utility/swap.h>
+#    include <__verbose_abort>
+#    include <deque>
+#    include <stdexcept>
+#    include <string>
+#    include <vector>
+#    include <version>
 
 // standard-mandated includes
 
 // [iterator.range]
-#  include <__iterator/access.h>
-#  include <__iterator/data.h>
-#  include <__iterator/empty.h>
-#  include <__iterator/reverse_access.h>
-#  include <__iterator/size.h>
+#    include <__iterator/access.h>
+#    include <__iterator/data.h>
+#    include <__iterator/empty.h>
+#    include <__iterator/reverse_access.h>
+#    include <__iterator/size.h>
 
 // [re.syn]
-#  include <compare>
-#  include <initializer_list>
+#    include <compare>
+#    include <initializer_list>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
 
 _LIBCPP_PUSH_MACROS
-#  include <__undef_macros>
+#    include <__undef_macros>
 
-#  define _LIBCPP_REGEX_COMPLEXITY_FACTOR 4096
+#    define _LIBCPP_REGEX_COMPLEXITY_FACTOR 4096
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
@@ -846,11 +848,11 @@ enum syntax_option_type {
   nosubs   = 1 << 1,
   optimize = 1 << 2,
   collate  = 1 << 3,
-#  ifdef _LIBCPP_ABI_REGEX_CONSTANTS_NONZERO
+#    ifdef _LIBCPP_ABI_REGEX_CONSTANTS_NONZERO
   ECMAScript = 1 << 9,
-#  else
+#    else
   ECMAScript = 0,
-#  endif
+#    endif
   basic    = 1 << 4,
   extended = 1 << 5,
   awk      = 1 << 6,
@@ -861,11 +863,11 @@ enum syntax_option_type {
 };
 
 _LIBCPP_HIDE_FROM_ABI inline _LIBCPP_CONSTEXPR syntax_option_type __get_grammar(syntax_option_type __g) {
-#  ifdef _LIBCPP_ABI_REGEX_CONSTANTS_NONZERO
+#    ifdef _LIBCPP_ABI_REGEX_CONSTANTS_NONZERO
   return static_cast<syntax_option_type>(__g & 0x3F0);
-#  else
+#    else
   return static_cast<syntax_option_type>(__g & 0x1F0);
-#  endif
+#    endif
 }
 
 inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR syntax_option_type operator~(syntax_option_type __x) {
@@ -987,11 +989,11 @@ public:
 
 template <regex_constants::error_type _Ev>
 [[__noreturn__]] inline _LIBCPP_HIDE_FROM_ABI void __throw_regex_error() {
-#  if _LIBCPP_HAS_EXCEPTIONS
+#    if _LIBCPP_HAS_EXCEPTIONS
   throw regex_error(_Ev);
-#  else
+#    else
   _LIBCPP_VERBOSE_ABORT("regex_error was thrown in -fno-exceptions mode");
-#  endif
+#    endif
 }
 
 template <class _CharT>
@@ -1000,7 +1002,7 @@ public:
   typedef _CharT char_type;
   typedef basic_string<char_type> string_type;
   typedef locale locale_type;
-#  if defined(__BIONIC__) || defined(_NEWLIB_VERSION)
+#    if defined(__BIONIC__) || defined(_NEWLIB_VERSION)
   // Originally bionic's ctype_base used its own ctype masks because the
   // builtin ctype implementation wasn't in libc++ yet. Bionic's ctype mask
   // was only 8 bits wide and already saturated, so it used a wider type here
@@ -1015,9 +1017,9 @@ public:
   // often used for space constrained environments, so it makes sense not to
   // duplicate the ctype table.
   typedef uint16_t char_class_type;
-#  else
+#    else
   typedef ctype_base::mask char_class_type;
-#  endif
+#    endif
 
   static const char_class_type __regex_word = ctype_base::__regex_word;
 
@@ -1057,30 +1059,30 @@ private:
 
   template <class _ForwardIterator>
   string_type __transform_primary(_ForwardIterator __f, _ForwardIterator __l, char) const;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
   template <class _ForwardIterator>
   string_type __transform_primary(_ForwardIterator __f, _ForwardIterator __l, wchar_t) const;
-#  endif
+#    endif
   template <class _ForwardIterator>
   string_type __lookup_collatename(_ForwardIterator __f, _ForwardIterator __l, char) const;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
   template <class _ForwardIterator>
   string_type __lookup_collatename(_ForwardIterator __f, _ForwardIterator __l, wchar_t) const;
-#  endif
+#    endif
   template <class _ForwardIterator>
   char_class_type __lookup_classname(_ForwardIterator __f, _ForwardIterator __l, bool __icase, char) const;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
   template <class _ForwardIterator>
   char_class_type __lookup_classname(_ForwardIterator __f, _ForwardIterator __l, bool __icase, wchar_t) const;
-#  endif
+#    endif
 
   static int __regex_traits_value(unsigned char __ch, int __radix);
   _LIBCPP_HIDE_FROM_ABI int __regex_traits_value(char __ch, int __radix) const {
     return __regex_traits_value(static_cast<unsigned char>(__ch), __radix);
   }
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
   _LIBCPP_HIDE_FROM_ABI int __regex_traits_value(wchar_t __ch, int __radix) const;
-#  endif
+#    endif
 };
 
 template <class _CharT>
@@ -1139,7 +1141,7 @@ regex_traits<_CharT>::__transform_primary(_ForwardIterator __f, _ForwardIterator
   return __d;
 }
 
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 template <class _CharT>
 template <class _ForwardIterator>
 typename regex_traits<_CharT>::string_type
@@ -1158,7 +1160,7 @@ regex_traits<_CharT>::__transform_primary(_ForwardIterator __f, _ForwardIterator
   }
   return __d;
 }
-#  endif
+#    endif
 
 // lookup_collatename is very FreeBSD-specific
 
@@ -1183,7 +1185,7 @@ regex_traits<_CharT>::__lookup_collatename(_ForwardIterator __f, _ForwardIterato
   return __r;
 }
 
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 template <class _CharT>
 template <class _ForwardIterator>
 typename regex_traits<_CharT>::string_type
@@ -1211,7 +1213,7 @@ regex_traits<_CharT>::__lookup_collatename(_ForwardIterator __f, _ForwardIterato
   }
   return __r;
 }
-#  endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#    endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 // lookup_classname
 
@@ -1226,7 +1228,7 @@ regex_traits<_CharT>::__lookup_classname(_ForwardIterator __f, _ForwardIterator 
   return std::__get_classname(__s.c_str(), __icase);
 }
 
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 template <class _CharT>
 template <class _ForwardIterator>
 typename regex_traits<_CharT>::char_class_type
@@ -1242,7 +1244,7 @@ regex_traits<_CharT>::__lookup_classname(_ForwardIterator __f, _ForwardIterator 
   }
   return __get_classname(__n.c_str(), __icase);
 }
-#  endif // _LIBCPP_HAS_WIDE_CHARACTERS
+#    endif // _LIBCPP_HAS_WIDE_CHARACTERS
 
 template <class _CharT>
 bool regex_traits<_CharT>::isctype(char_type __c, char_class_type __m) const {
@@ -1253,28 +1255,28 @@ bool regex_traits<_CharT>::isctype(char_type __c, char_class_type __m) const {
 
 inline _LIBCPP_HIDE_FROM_ABI bool __is_07(unsigned char __c) {
   return (__c & 0xF8u) ==
-#  if defined(__MVS__) && !defined(__NATIVE_ASCII_F)
+#    if defined(__MVS__) && !defined(__NATIVE_ASCII_F)
          0xF0;
-#  else
+#    else
          0x30;
-#  endif
+#    endif
 }
 
 inline _LIBCPP_HIDE_FROM_ABI bool __is_89(unsigned char __c) {
   return (__c & 0xFEu) ==
-#  if defined(__MVS__) && !defined(__NATIVE_ASCII_F)
+#    if defined(__MVS__) && !defined(__NATIVE_ASCII_F)
          0xF8;
-#  else
+#    else
          0x38;
-#  endif
+#    endif
 }
 
 inline _LIBCPP_HIDE_FROM_ABI unsigned char __to_lower(unsigned char __c) {
-#  if defined(__MVS__) && !defined(__NATIVE_ASCII_F)
+#    if defined(__MVS__) && !defined(__NATIVE_ASCII_F)
   return __c & 0xBF;
-#  else
+#    else
   return __c | 0x20;
-#  endif
+#    endif
 }
 
 template <class _CharT>
@@ -1293,12 +1295,12 @@ int regex_traits<_CharT>::__regex_traits_value(unsigned char __ch, int __radix) 
   return -1;
 }
 
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 template <class _CharT>
 inline int regex_traits<_CharT>::__regex_traits_value(wchar_t __ch, int __radix) const {
   return __regex_traits_value(static_cast<unsigned char>(__ct_->narrow(__ch, char_type())), __radix);
 }
-#  endif
+#    endif
 
 template <class _CharT>
 class __node;
@@ -1941,10 +1943,10 @@ public:
 
 template <>
 _LIBCPP_EXPORTED_FROM_ABI void __match_any_but_newline<char>::__exec(__state&) const;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 template <>
 _LIBCPP_EXPORTED_FROM_ABI void __match_any_but_newline<wchar_t>::__exec(__state&) const;
-#  endif
+#    endif
 
 // __match_char
 
@@ -2265,13 +2267,13 @@ template <class _CharT, class _Traits = regex_traits<_CharT> >
 class _LIBCPP_TEMPLATE_VIS basic_regex;
 
 typedef basic_regex<char> regex;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 typedef basic_regex<wchar_t> wregex;
-#  endif
+#    endif
 
 template <class _CharT, class _Traits>
-class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(regex)
-    _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wregex)) basic_regex {
+class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(regex) _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wregex))
+    basic_regex {
 public:
   // types:
   typedef _CharT value_type;
@@ -2338,21 +2340,21 @@ public:
       : __flags_(__f), __marked_count_(0), __loop_count_(0), __open_count_(0), __end_(nullptr) {
     __init(__first, __last);
   }
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI basic_regex(initializer_list<value_type> __il, flag_type __f = regex_constants::ECMAScript)
       : __flags_(__f), __marked_count_(0), __loop_count_(0), __open_count_(0), __end_(nullptr) {
     __init(__il.begin(), __il.end());
   }
-#  endif // _LIBCPP_CXX03_LANG
+#    endif // _LIBCPP_CXX03_LANG
 
   //    ~basic_regex() = default;
 
   //     basic_regex& operator=(const basic_regex&) = default;
   //     basic_regex& operator=(basic_regex&&) = default;
   _LIBCPP_HIDE_FROM_ABI basic_regex& operator=(const value_type* __p) { return assign(__p); }
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI basic_regex& operator=(initializer_list<value_type> __il) { return assign(__il); }
-#  endif // _LIBCPP_CXX03_LANG
+#    endif // _LIBCPP_CXX03_LANG
   template <class _ST, class _SA>
   _LIBCPP_HIDE_FROM_ABI basic_regex& operator=(const basic_string<value_type, _ST, _SA>& __p) {
     return assign(__p);
@@ -2360,9 +2362,9 @@ public:
 
   // assign:
   _LIBCPP_HIDE_FROM_ABI basic_regex& assign(const basic_regex& __that) { return *this = __that; }
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI basic_regex& assign(basic_regex&& __that) _NOEXCEPT { return *this = std::move(__that); }
-#  endif
+#    endif
   _LIBCPP_HIDE_FROM_ABI basic_regex& assign(const value_type* __p, flag_type __f = regex_constants::ECMAScript) {
     return assign(__p, __p + __traits_.length(__p), __f);
   }
@@ -2399,14 +2401,14 @@ public:
     return assign(basic_regex(__first, __last, __f));
   }
 
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
 
   _LIBCPP_HIDE_FROM_ABI basic_regex&
   assign(initializer_list<value_type> __il, flag_type __f = regex_constants::ECMAScript) {
     return assign(__il.begin(), __il.end(), __f);
   }
 
-#  endif // _LIBCPP_CXX03_LANG
+#    endif // _LIBCPP_CXX03_LANG
 
   // const operations:
   _LIBCPP_HIDE_FROM_ABI unsigned mark_count() const { return __marked_count_; }
@@ -2647,11 +2649,11 @@ private:
   friend class __lookahead;
 };
 
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
 template <class _ForwardIterator, __enable_if_t<__has_forward_iterator_category<_ForwardIterator>::value, int> = 0>
 basic_regex(_ForwardIterator, _ForwardIterator, regex_constants::syntax_option_type = regex_constants::ECMAScript)
     -> basic_regex<typename iterator_traits<_ForwardIterator>::value_type>;
-#  endif
+#    endif
 
 template <class _CharT, class _Traits>
 const regex_constants::syntax_option_type basic_regex<_CharT, _Traits>::icase;
@@ -4184,10 +4186,10 @@ void basic_regex<_CharT, _Traits>::__push_lookahead(const basic_regex& __exp, bo
 
 typedef sub_match<const char*> csub_match;
 typedef sub_match<string::const_iterator> ssub_match;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 typedef sub_match<const wchar_t*> wcsub_match;
 typedef sub_match<wstring::const_iterator> wssub_match;
-#  endif
+#    endif
 
 template <class _BidirectionalIterator>
 class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(csub_match)
@@ -4227,7 +4229,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool operator==(const sub_match<_BiIter>& __x, cons
   return __x.compare(__y) == 0;
 }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 template <class _BiIter>
 using __sub_match_cat _LIBCPP_NODEBUG =
     compare_three_way_result_t<basic_string<typename iterator_traits<_BiIter>::value_type>>;
@@ -4236,7 +4238,7 @@ template <class _BiIter>
 _LIBCPP_HIDE_FROM_ABI auto operator<=>(const sub_match<_BiIter>& __x, const sub_match<_BiIter>& __y) {
   return static_cast<__sub_match_cat<_BiIter>>(__x.compare(__y) <=> 0);
 }
-#  else  // _LIBCPP_STD_VER >= 20
+#    else  // _LIBCPP_STD_VER >= 20
 template <class _BiIter>
 inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const sub_match<_BiIter>& __x, const sub_match<_BiIter>& __y) {
   return !(__x == __y);
@@ -4303,7 +4305,7 @@ operator<=(const basic_string<typename iterator_traits<_BiIter>::value_type, _ST
            const sub_match<_BiIter>& __y) {
   return !(__y < __x);
 }
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
 template <class _BiIter, class _ST, class _SA>
 inline _LIBCPP_HIDE_FROM_ABI bool
@@ -4312,7 +4314,7 @@ operator==(const sub_match<_BiIter>& __x,
   return __x.compare(typename sub_match<_BiIter>::string_type(__y.data(), __y.size())) == 0;
 }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 template <class _BiIter, class _ST, class _SA>
 _LIBCPP_HIDE_FROM_ABI auto
 operator<=>(const sub_match<_BiIter>& __x,
@@ -4320,7 +4322,7 @@ operator<=>(const sub_match<_BiIter>& __x,
   return static_cast<__sub_match_cat<_BiIter>>(
       __x.compare(typename sub_match<_BiIter>::string_type(__y.data(), __y.size())) <=> 0);
 }
-#  else  // _LIBCPP_STD_VER >= 20
+#    else  // _LIBCPP_STD_VER >= 20
 template <class _BiIter, class _ST, class _SA>
 inline _LIBCPP_HIDE_FROM_ABI bool
 operator!=(const sub_match<_BiIter>& __x,
@@ -4391,7 +4393,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool
 operator<=(typename iterator_traits<_BiIter>::value_type const* __x, const sub_match<_BiIter>& __y) {
   return !(__y < __x);
 }
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
 template <class _BiIter>
 inline _LIBCPP_HIDE_FROM_ABI bool
@@ -4399,13 +4401,13 @@ operator==(const sub_match<_BiIter>& __x, typename iterator_traits<_BiIter>::val
   return __x.compare(__y) == 0;
 }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 template <class _BiIter>
 _LIBCPP_HIDE_FROM_ABI auto
 operator<=>(const sub_match<_BiIter>& __x, typename iterator_traits<_BiIter>::value_type const* __y) {
   return static_cast<__sub_match_cat<_BiIter>>(__x.compare(__y) <=> 0);
 }
-#  else  // _LIBCPP_STD_VER >= 20
+#    else  // _LIBCPP_STD_VER >= 20
 template <class _BiIter>
 inline _LIBCPP_HIDE_FROM_ABI bool
 operator!=(const sub_match<_BiIter>& __x, typename iterator_traits<_BiIter>::value_type const* __y) {
@@ -4473,7 +4475,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool
 operator<=(typename iterator_traits<_BiIter>::value_type const& __x, const sub_match<_BiIter>& __y) {
   return !(__y < __x);
 }
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
 template <class _BiIter>
 inline _LIBCPP_HIDE_FROM_ABI bool
@@ -4482,14 +4484,14 @@ operator==(const sub_match<_BiIter>& __x, typename iterator_traits<_BiIter>::val
   return __x.compare(string_type(1, __y)) == 0;
 }
 
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
 template <class _BiIter>
 _LIBCPP_HIDE_FROM_ABI auto
 operator<=>(const sub_match<_BiIter>& __x, typename iterator_traits<_BiIter>::value_type const& __y) {
   using string_type = basic_string<typename iterator_traits<_BiIter>::value_type>;
   return static_cast<__sub_match_cat<_BiIter>>(__x.compare(string_type(1, __y)) <=> 0);
 }
-#  else  // _LIBCPP_STD_VER >= 20
+#    else  // _LIBCPP_STD_VER >= 20
 template <class _BiIter>
 inline _LIBCPP_HIDE_FROM_ABI bool
 operator!=(const sub_match<_BiIter>& __x, typename iterator_traits<_BiIter>::value_type const& __y) {
@@ -4520,7 +4522,7 @@ inline _LIBCPP_HIDE_FROM_ABI bool
 operator<=(const sub_match<_BiIter>& __x, typename iterator_traits<_BiIter>::value_type const& __y) {
   return !(__y < __x);
 }
-#  endif // _LIBCPP_STD_VER >= 20
+#    endif // _LIBCPP_STD_VER >= 20
 
 template <class _CharT, class _ST, class _BiIter>
 inline _LIBCPP_HIDE_FROM_ABI basic_ostream<_CharT, _ST>&
@@ -4530,10 +4532,10 @@ operator<<(basic_ostream<_CharT, _ST>& __os, const sub_match<_BiIter>& __m) {
 
 typedef match_results<const char*> cmatch;
 typedef match_results<string::const_iterator> smatch;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 typedef match_results<const wchar_t*> wcmatch;
 typedef match_results<wstring::const_iterator> wsmatch;
-#  endif
+#    endif
 
 template <class _BidirectionalIterator, class _Allocator>
 class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(cmatch) _LIBCPP_IF_WIDE_CHARACTERS(_LIBCPP_PREFERRED_NAME(wcmatch))
@@ -4563,12 +4565,12 @@ public:
   typedef basic_string<char_type> string_type;
 
   // construct/copy/destroy:
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
   match_results() : match_results(allocator_type()) {}
   explicit match_results(const allocator_type& __a);
-#  else
+#    else
   explicit match_results(const allocator_type& __a = allocator_type());
-#  endif
+#    endif
 
   //    match_results(const match_results&) = default;
   //    match_results& operator=(const match_results&) = default;
@@ -4818,13 +4820,13 @@ _LIBCPP_HIDE_FROM_ABI bool operator==(const match_results<_BidirectionalIterator
   return __x.__matches_ == __y.__matches_ && __x.__prefix_ == __y.__prefix_ && __x.__suffix_ == __y.__suffix_;
 }
 
-#  if _LIBCPP_STD_VER < 20
+#    if _LIBCPP_STD_VER < 20
 template <class _BidirectionalIterator, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI bool operator!=(const match_results<_BidirectionalIterator, _Allocator>& __x,
                                              const match_results<_BidirectionalIterator, _Allocator>& __y) {
   return !(__x == __y);
 }
-#  endif
+#    endif
 
 template <class _BidirectionalIterator, class _Allocator>
 inline _LIBCPP_HIDE_FROM_ABI void
@@ -5236,13 +5238,13 @@ regex_search(const basic_string<_CharT, _ST, _SA>& __s,
   return __r;
 }
 
-#  if _LIBCPP_STD_VER >= 14
+#    if _LIBCPP_STD_VER >= 14
 template <class _ST, class _SA, class _Ap, class _Cp, class _Tp>
 bool regex_search(const basic_string<_Cp, _ST, _SA>&& __s,
                   match_results<typename basic_string<_Cp, _ST, _SA>::const_iterator, _Ap>&,
                   const basic_regex<_Cp, _Tp>& __e,
                   regex_constants::match_flag_type __flags = regex_constants::match_default) = delete;
-#  endif
+#    endif
 
 // regex_match
 
@@ -5291,14 +5293,14 @@ regex_match(const basic_string<_CharT, _ST, _SA>& __s,
   return std::regex_match(__s.begin(), __s.end(), __m, __e, __flags);
 }
 
-#  if _LIBCPP_STD_VER >= 14
+#    if _LIBCPP_STD_VER >= 14
 template <class _ST, class _SA, class _Allocator, class _CharT, class _Traits>
 inline _LIBCPP_HIDE_FROM_ABI bool
 regex_match(const basic_string<_CharT, _ST, _SA>&& __s,
             match_results<typename basic_string<_CharT, _ST, _SA>::const_iterator, _Allocator>& __m,
             const basic_regex<_CharT, _Traits>& __e,
             regex_constants::match_flag_type __flags = regex_constants::match_default) = delete;
-#  endif
+#    endif
 
 template <class _CharT, class _Traits>
 inline _LIBCPP_HIDE_FROM_ABI bool
@@ -5325,10 +5327,10 @@ class _LIBCPP_TEMPLATE_VIS regex_iterator;
 
 typedef regex_iterator<const char*> cregex_iterator;
 typedef regex_iterator<string::const_iterator> sregex_iterator;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 typedef regex_iterator<const wchar_t*> wcregex_iterator;
 typedef regex_iterator<wstring::const_iterator> wsregex_iterator;
-#  endif
+#    endif
 
 template <class _BidirectionalIterator, class _CharT, class _Traits>
 class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(cregex_iterator)
@@ -5341,9 +5343,9 @@ public:
   typedef const value_type* pointer;
   typedef const value_type& reference;
   typedef forward_iterator_tag iterator_category;
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   typedef input_iterator_tag iterator_concept;
-#  endif
+#    endif
 
 private:
   _BidirectionalIterator __begin_;
@@ -5358,20 +5360,20 @@ public:
                  _BidirectionalIterator __b,
                  const regex_type& __re,
                  regex_constants::match_flag_type __m = regex_constants::match_default);
-#  if _LIBCPP_STD_VER >= 14
+#    if _LIBCPP_STD_VER >= 14
   regex_iterator(_BidirectionalIterator __a,
                  _BidirectionalIterator __b,
                  const regex_type&& __re,
                  regex_constants::match_flag_type __m = regex_constants::match_default) = delete;
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI bool operator==(const regex_iterator& __x) const;
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI bool operator==(default_sentinel_t) const { return *this == regex_iterator(); }
-#  endif
-#  if _LIBCPP_STD_VER < 20
+#    endif
+#    if _LIBCPP_STD_VER < 20
   _LIBCPP_HIDE_FROM_ABI bool operator!=(const regex_iterator& __x) const { return !(*this == __x); }
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI reference operator*() const { return __match_; }
   _LIBCPP_HIDE_FROM_ABI pointer operator->() const { return std::addressof(__match_); }
@@ -5455,10 +5457,10 @@ class _LIBCPP_TEMPLATE_VIS regex_token_iterator;
 
 typedef regex_token_iterator<const char*> cregex_token_iterator;
 typedef regex_token_iterator<string::const_iterator> sregex_token_iterator;
-#  if _LIBCPP_HAS_WIDE_CHARACTERS
+#    if _LIBCPP_HAS_WIDE_CHARACTERS
 typedef regex_token_iterator<const wchar_t*> wcregex_token_iterator;
 typedef regex_token_iterator<wstring::const_iterator> wsregex_token_iterator;
-#  endif
+#    endif
 
 template <class _BidirectionalIterator, class _CharT, class _Traits>
 class _LIBCPP_TEMPLATE_VIS _LIBCPP_PREFERRED_NAME(cregex_token_iterator)
@@ -5472,9 +5474,9 @@ public:
   typedef const value_type* pointer;
   typedef const value_type& reference;
   typedef forward_iterator_tag iterator_category;
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   typedef input_iterator_tag iterator_concept;
-#  endif
+#    endif
 
 private:
   typedef regex_iterator<_BidirectionalIterator, _CharT, _Traits> _Position;
@@ -5492,67 +5494,67 @@ public:
                        const regex_type& __re,
                        int __submatch                       = 0,
                        regex_constants::match_flag_type __m = regex_constants::match_default);
-#  if _LIBCPP_STD_VER >= 14
+#    if _LIBCPP_STD_VER >= 14
   regex_token_iterator(_BidirectionalIterator __a,
                        _BidirectionalIterator __b,
                        const regex_type&& __re,
                        int __submatch                       = 0,
                        regex_constants::match_flag_type __m = regex_constants::match_default) = delete;
-#  endif
+#    endif
 
   regex_token_iterator(_BidirectionalIterator __a,
                        _BidirectionalIterator __b,
                        const regex_type& __re,
                        const vector<int>& __submatches,
                        regex_constants::match_flag_type __m = regex_constants::match_default);
-#  if _LIBCPP_STD_VER >= 14
-  regex_token_iterator(_BidirectionalIterator __a,
-                       _BidirectionalIterator __b,
-                       const regex_type&& __re,
-                       const vector<int>& __submatches,
-                       regex_constants::match_flag_type __m = regex_constants::match_default) = delete;
-#  endif
-
-#  ifndef _LIBCPP_CXX03_LANG
-  regex_token_iterator(_BidirectionalIterator __a,
-                       _BidirectionalIterator __b,
-                       const regex_type& __re,
-                       initializer_list<int> __submatches,
-                       regex_constants::match_flag_type __m = regex_constants::match_default);
-
 #    if _LIBCPP_STD_VER >= 14
   regex_token_iterator(_BidirectionalIterator __a,
                        _BidirectionalIterator __b,
                        const regex_type&& __re,
-                       initializer_list<int> __submatches,
+                       const vector<int>& __submatches,
                        regex_constants::match_flag_type __m = regex_constants::match_default) = delete;
 #    endif
-#  endif // _LIBCPP_CXX03_LANG
+
+#    ifndef _LIBCPP_CXX03_LANG
+  regex_token_iterator(_BidirectionalIterator __a,
+                       _BidirectionalIterator __b,
+                       const regex_type& __re,
+                       initializer_list<int> __submatches,
+                       regex_constants::match_flag_type __m = regex_constants::match_default);
+
+#      if _LIBCPP_STD_VER >= 14
+  regex_token_iterator(_BidirectionalIterator __a,
+                       _BidirectionalIterator __b,
+                       const regex_type&& __re,
+                       initializer_list<int> __submatches,
+                       regex_constants::match_flag_type __m = regex_constants::match_default) = delete;
+#      endif
+#    endif // _LIBCPP_CXX03_LANG
   template <size_t _Np>
   regex_token_iterator(_BidirectionalIterator __a,
                        _BidirectionalIterator __b,
                        const regex_type& __re,
                        const int (&__submatches)[_Np],
                        regex_constants::match_flag_type __m = regex_constants::match_default);
-#  if _LIBCPP_STD_VER >= 14
+#    if _LIBCPP_STD_VER >= 14
   template <size_t _Np>
   regex_token_iterator(_BidirectionalIterator __a,
                        _BidirectionalIterator __b,
                        const regex_type&& __re,
                        const int (&__submatches)[_Np],
                        regex_constants::match_flag_type __m = regex_constants::match_default) = delete;
-#  endif
+#    endif
 
   regex_token_iterator(const regex_token_iterator&);
   regex_token_iterator& operator=(const regex_token_iterator&);
 
   _LIBCPP_HIDE_FROM_ABI bool operator==(const regex_token_iterator& __x) const;
-#  if _LIBCPP_STD_VER >= 20
+#    if _LIBCPP_STD_VER >= 20
   _LIBCPP_HIDE_FROM_ABI bool operator==(default_sentinel_t) const { return *this == regex_token_iterator(); }
-#  endif
-#  if _LIBCPP_STD_VER < 20
+#    endif
+#    if _LIBCPP_STD_VER < 20
   _LIBCPP_HIDE_FROM_ABI bool operator!=(const regex_token_iterator& __x) const { return !(*this == __x); }
-#  endif
+#    endif
 
   _LIBCPP_HIDE_FROM_ABI const value_type& operator*() const { return *__result_; }
   _LIBCPP_HIDE_FROM_ABI const value_type* operator->() const { return __result_; }
@@ -5614,7 +5616,7 @@ regex_token_iterator<_BidirectionalIterator, _CharT, _Traits>::regex_token_itera
   __init(__a, __b);
 }
 
-#  ifndef _LIBCPP_CXX03_LANG
+#    ifndef _LIBCPP_CXX03_LANG
 
 template <class _BidirectionalIterator, class _CharT, class _Traits>
 regex_token_iterator<_BidirectionalIterator, _CharT, _Traits>::regex_token_iterator(
@@ -5627,7 +5629,7 @@ regex_token_iterator<_BidirectionalIterator, _CharT, _Traits>::regex_token_itera
   __init(__a, __b);
 }
 
-#  endif // _LIBCPP_CXX03_LANG
+#    endif // _LIBCPP_CXX03_LANG
 
 template <class _BidirectionalIterator, class _CharT, class _Traits>
 template <size_t _Np>
@@ -5802,7 +5804,7 @@ regex_replace(const _CharT* __s,
 
 _LIBCPP_END_NAMESPACE_STD
 
-#  if _LIBCPP_STD_VER >= 17
+#    if _LIBCPP_STD_VER >= 17
 _LIBCPP_BEGIN_NAMESPACE_STD
 namespace pmr {
 template <class _BidirT>
@@ -5812,15 +5814,17 @@ using match_results _LIBCPP_AVAILABILITY_PMR =
 using cmatch _LIBCPP_AVAILABILITY_PMR = match_results<const char*>;
 using smatch _LIBCPP_AVAILABILITY_PMR = match_results<std::pmr::string::const_iterator>;
 
-#    if _LIBCPP_HAS_WIDE_CHARACTERS
+#      if _LIBCPP_HAS_WIDE_CHARACTERS
 using wcmatch _LIBCPP_AVAILABILITY_PMR = match_results<const wchar_t*>;
 using wsmatch _LIBCPP_AVAILABILITY_PMR = match_results<std::pmr::wstring::const_iterator>;
-#    endif
+#      endif
 } // namespace pmr
 _LIBCPP_END_NAMESPACE_STD
-#  endif
+#    endif
 
 _LIBCPP_POP_MACROS
+
+#  endif // _LIBCPP_HAS_LOCALIZATION
 
 #  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #    include <atomic>

--- a/libcxx/include/strstream
+++ b/libcxx/include/strstream
@@ -133,30 +133,33 @@ private:
 #  include <__cxx03/strstream>
 #else
 #  include <__config>
-#  include <__ostream/basic_ostream.h>
-#  include <istream>
-#  include <streambuf>
-#  include <version>
 
-#  if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
-#    pragma GCC system_header
-#  endif
+#  if _LIBCPP_HAS_LOCALIZATION
 
-#  if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_STRSTREAM) || defined(_LIBCPP_BUILDING_LIBRARY)
+#    include <__ostream/basic_ostream.h>
+#    include <istream>
+#    include <streambuf>
+#    include <version>
+
+#    if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#      pragma GCC system_header
+#    endif
+
+#    if _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_STRSTREAM) || defined(_LIBCPP_BUILDING_LIBRARY)
 
 _LIBCPP_PUSH_MACROS
-#    include <__undef_macros>
+#      include <__undef_macros>
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 class _LIBCPP_DEPRECATED _LIBCPP_EXPORTED_FROM_ABI strstreambuf : public streambuf {
 public:
-#    ifndef _LIBCPP_CXX03_LANG
+#      ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI strstreambuf() : strstreambuf(0) {}
   explicit strstreambuf(streamsize __alsize);
-#    else
+#      else
   explicit strstreambuf(streamsize __alsize = 0);
-#    endif
+#      endif
   strstreambuf(void* (*__palloc)(size_t), void (*__pfree)(void*));
   strstreambuf(char* __gnext, streamsize __n, char* __pbeg = nullptr);
   strstreambuf(const char* __gnext, streamsize __n);
@@ -166,10 +169,10 @@ public:
   strstreambuf(unsigned char* __gnext, streamsize __n, unsigned char* __pbeg = nullptr);
   strstreambuf(const unsigned char* __gnext, streamsize __n);
 
-#    ifndef _LIBCPP_CXX03_LANG
+#      ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI strstreambuf(strstreambuf&& __rhs);
   _LIBCPP_HIDE_FROM_ABI strstreambuf& operator=(strstreambuf&& __rhs);
-#    endif // _LIBCPP_CXX03_LANG
+#      endif // _LIBCPP_CXX03_LANG
 
   ~strstreambuf() override;
 
@@ -203,7 +206,7 @@ private:
   void __init(char* __gnext, streamsize __n, char* __pbeg);
 };
 
-#    ifndef _LIBCPP_CXX03_LANG
+#      ifndef _LIBCPP_CXX03_LANG
 
 inline _LIBCPP_HIDE_FROM_ABI strstreambuf::strstreambuf(strstreambuf&& __rhs)
     : streambuf(__rhs),
@@ -232,7 +235,7 @@ inline _LIBCPP_HIDE_FROM_ABI strstreambuf& strstreambuf::operator=(strstreambuf&
   return *this;
 }
 
-#    endif // _LIBCPP_CXX03_LANG
+#      endif // _LIBCPP_CXX03_LANG
 
 class _LIBCPP_DEPRECATED _LIBCPP_EXPORTED_FROM_ABI istrstream : public istream {
 public:
@@ -241,7 +244,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI istrstream(const char* __s, streamsize __n) : istream(&__sb_), __sb_(__s, __n) {}
   _LIBCPP_HIDE_FROM_ABI istrstream(char* __s, streamsize __n) : istream(&__sb_), __sb_(__s, __n) {}
 
-#    ifndef _LIBCPP_CXX03_LANG
+#      ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI istrstream(istrstream&& __rhs) // extension
       : istream(std::move(static_cast<istream&>(__rhs))), __sb_(std::move(__rhs.__sb_)) {
     istream::set_rdbuf(&__sb_);
@@ -252,7 +255,7 @@ public:
     istream::operator=(std::move(__rhs));
     return *this;
   }
-#    endif // _LIBCPP_CXX03_LANG
+#      endif // _LIBCPP_CXX03_LANG
 
   ~istrstream() override;
 
@@ -274,7 +277,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI ostrstream(char* __s, int __n, ios_base::openmode __mode = ios_base::out)
       : ostream(&__sb_), __sb_(__s, __n, __s + (__mode & ios::app ? std::strlen(__s) : 0)) {}
 
-#    ifndef _LIBCPP_CXX03_LANG
+#      ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI ostrstream(ostrstream&& __rhs) // extension
       : ostream(std::move(static_cast<ostream&>(__rhs))), __sb_(std::move(__rhs.__sb_)) {
     ostream::set_rdbuf(&__sb_);
@@ -285,7 +288,7 @@ public:
     ostream::operator=(std::move(__rhs));
     return *this;
   }
-#    endif // _LIBCPP_CXX03_LANG
+#      endif // _LIBCPP_CXX03_LANG
 
   ~ostrstream() override;
 
@@ -316,7 +319,7 @@ public:
   _LIBCPP_HIDE_FROM_ABI strstream(char* __s, int __n, ios_base::openmode __mode = ios_base::in | ios_base::out)
       : iostream(&__sb_), __sb_(__s, __n, __s + (__mode & ios::app ? std::strlen(__s) : 0)) {}
 
-#    ifndef _LIBCPP_CXX03_LANG
+#      ifndef _LIBCPP_CXX03_LANG
   _LIBCPP_HIDE_FROM_ABI strstream(strstream&& __rhs) // extension
       : iostream(std::move(static_cast<iostream&>(__rhs))), __sb_(std::move(__rhs.__sb_)) {
     iostream::set_rdbuf(&__sb_);
@@ -327,7 +330,7 @@ public:
     iostream::operator=(std::move(__rhs));
     return *this;
   }
-#    endif // _LIBCPP_CXX03_LANG
+#      endif // _LIBCPP_CXX03_LANG
 
   ~strstream() override;
 
@@ -350,7 +353,11 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
-#  endif // _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_STRSTREAM) || defined(_LIBCPP_BUILDING_LIBRARY)
-#endif   // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)
+#    endif // _LIBCPP_STD_VER < 26 || defined(_LIBCPP_ENABLE_CXX26_REMOVED_STRSTREAM) ||
+           // defined(_LIBCPP_BUILDING_LIBRARY)
+
+#  endif // _LIBCPP_HAS_LOCALIZATION
+
+#endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)
 
 #endif // _LIBCPP_STRSTREAM

--- a/libcxx/test/configs/armv7m-picolibc-libc++.cfg.in
+++ b/libcxx/test/configs/armv7m-picolibc-libc++.cfg.in
@@ -11,10 +11,6 @@ config.substitutions.append(('%{compile_flags}',
     # "large atomic operation may incur significant performance penalty; the
     # access size (4 bytes) exceeds the max lock-free size (0 bytes)"
     ' -Wno-atomic-alignment'
-
-    # Various libc++ headers check for the definition of _NEWLIB_VERSION
-    # which for picolibc is defined in picolibc.h.
-    ' -include picolibc.h'
 ))
 config.substitutions.append(('%{link_flags}',
     '-nostdlib -nostdlib++ -L %{lib-dir} -lc++ -lc++abi'

--- a/libcxx/test/libcxx/system_reserved_names.gen.py
+++ b/libcxx/test/libcxx/system_reserved_names.gen.py
@@ -11,6 +11,7 @@
 # provided macros (in other words, ensure that we push/pop correctly everywhere).
 
 # RUN: %{python} %s %{libcxx-dir}/utils
+# END.
 
 import sys
 
@@ -27,6 +28,11 @@ for header in public_headers:
 //--- {header}.compile.pass.cpp
 {lit_header_restrictions.get(header, '')}
 {lit_header_undeprecations.get(header, '')}
+
+// UNSUPPORTED: FROZEN-CXX03-HEADERS-FIXME
+
+// This is required to detect the platform we're building for below.
+#include <__config>
 
 #define SYSTEM_RESERVED_NAME This name should not be used in libc++
 


### PR DESCRIPTION
There were some remaining headers that were not guarded with _LIBCPP_HAS_LOCALIZATION, leading to errors when trying to use modules on platforms that don't support localization (since all the headers get pulled in when building the 'std' module). This patch brings these headers in line with what we do for every other header that depends on localization.

This patch also requires including <picolibc.h> from <__configuration/platform.h> in order to define _NEWLIB_VERSION. In the long term, we should use a better approach for doing that, such as defining a macro in the __config_site header.

(cherry picked from commit 4090910a695efcba4b484e9f8ad2b564e9a4e7ed)