### PR TITLE
Revert "[clang] [ARM] Explicitly enable NEON for Windows/Darwin targets (#122095)"

### DIFF
--- a/clang/lib/Driver/ToolChains/Arch/ARM.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/ARM.cpp
@@ -658,19 +658,11 @@ llvm::ARM::FPUKind arm::getARMTargetFeatures(const Driver &D,
         CPUArgFPUKind != llvm::ARM::FK_INVALID ? CPUArgFPUKind : ArchArgFPUKind;
     (void)llvm::ARM::getFPUFeatures(FPUKind, Features);
   } else {
-    bool Generic = true;
     if (!ForAS) {
       std::string CPU = arm::getARMTargetCPU(CPUName, ArchName, Triple);
-      if (CPU != "generic")
-        Generic = false;
       llvm::ARM::ArchKind ArchKind =
           arm::getLLVMArchKindForARM(CPU, ArchName, Triple);
       FPUKind = llvm::ARM::getDefaultFPU(CPU, ArchKind);
-      (void)llvm::ARM::getFPUFeatures(FPUKind, Features);
-    }
-    if (Generic && (Triple.isOSWindows() || Triple.isOSDarwin()) &&
-        getARMSubArchVersionNumber(Triple) >= 7) {
-      FPUKind = llvm::ARM::parseFPU("neon");
       (void)llvm::ARM::getFPUFeatures(FPUKind, Features);
     }
   }

--- a/clang/test/Driver/arm-mfpu.c
+++ b/clang/test/Driver/arm-mfpu.c
@@ -356,10 +356,8 @@
 // CHECK-HF-DAG: "-target-cpu" "arm1176jzf-s"
 
 // RUN: %clang -target armv7-apple-darwin -x assembler %s -### -c 2>&1 \
-// RUN:   | FileCheck --check-prefix=ASM-NEON %s
-// RUN: %clang -target armv7-windows -x assembler %s -### -c 2>&1 \
-// RUN:   | FileCheck --check-prefix=ASM-NEON %s
-// ASM-NEON: "-target-feature" "+neon"
+// RUN:   | FileCheck --check-prefix=ASM %s
+// ASM-NOT: -target-feature
 
 // RUN: %clang -target armv8-linux-gnueabi -mfloat-abi=soft -mfpu=none %s -### -c 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-SOFT-ABI-FP %s

--- a/clang/test/Preprocessor/arm-target-features.c
+++ b/clang/test/Preprocessor/arm-target-features.c
@@ -132,30 +132,6 @@
 // CHECK-V7VE-DEFAULT-ABI-SOFT: #define __ARM_ARCH_EXT_IDIV__ 1
 // CHECK-V7VE-DEFAULT-ABI-SOFT: #define __ARM_FP 0xc
 
-// RUN: %clang -target x86_64-apple-macosx10.10 -arch armv7 -x c -E -dM %s -o - | FileCheck -match-full-lines --check-prefix=CHECK-DARWIN-V7 %s
-// CHECK-DARWIN-V7: #define __ARMEL__ 1
-// CHECK-DARWIN-V7: #define __ARM_ARCH 7
-// CHECK-DARWIN-V7: #define __ARM_ARCH_7A__ 1
-// CHECK-DARWIN-V7-NOT: __ARM_FEATURE_CRC32
-// CHECK-DARWIN-V7-NOT: __ARM_FEATURE_NUMERIC_MAXMIN
-// CHECK-DARWIN-V7-NOT: __ARM_FEATURE_DIRECTED_ROUNDING
-// CHECK-DARWIN-V7: #define __ARM_FP 0xc
-// CHECK-DARWIN-V7: #define __ARM_NEON 1
-// CHECK-DARWIN-V7: #define __ARM_NEON_FP 0x4
-// CHECK-DARWIN-V7: #define __ARM_NEON__ 1
-
-// RUN: %clang -target armv7-windows -x c -E -dM %s -o - | FileCheck -match-full-lines --check-prefix=CHECK-WINDOWS-V7 %s
-// CHECK-WINDOWS-V7: #define __ARMEL__ 1
-// CHECK-WINDOWS-V7: #define __ARM_ARCH 7
-// CHECK-WINDOWS-V7: #define __ARM_ARCH_7A__ 1
-// CHECK-WINDOWS-V7-NOT: __ARM_FEATURE_CRC32
-// CHECK-WINDOWS-V7-NOT: __ARM_FEATURE_NUMERIC_MAXMIN
-// CHECK-WINDOWS-V7-NOT: __ARM_FEATURE_DIRECTED_ROUNDING
-// CHECK-WINDOWS-V7: #define __ARM_FP 0xe
-// CHECK-WINDOWS-V7: #define __ARM_NEON 1
-// CHECK-WINDOWS-V7: #define __ARM_NEON_FP 0x6
-// CHECK-WINDOWS-V7: #define __ARM_NEON__ 1
-
 // RUN: %clang -target x86_64-apple-macosx10.10 -arch armv7s -x c -E -dM %s -o - | FileCheck -match-full-lines --check-prefix=CHECK-V7S %s
 // CHECK-V7S: #define __ARMEL__ 1
 // CHECK-V7S: #define __ARM_ARCH 7
@@ -164,9 +140,6 @@
 // CHECK-V7S-NOT: __ARM_FEATURE_NUMERIC_MAXMIN
 // CHECK-V7S-NOT: __ARM_FEATURE_DIRECTED_ROUNDING
 // CHECK-V7S: #define __ARM_FP 0xe
-// CHECK-V7S: #define __ARM_NEON 1
-// CHECK-V7S: #define __ARM_NEON_FP 0x6
-// CHECK-V7S: #define __ARM_NEON__ 1
 
 // RUN: %clang -target arm-arm-none-eabi -march=armv7-m -mfloat-abi=soft -x c -E -dM %s | FileCheck -match-full-lines --check-prefix=CHECK-VFP-FP %s
 // RUN: %clang -target arm-arm-none-eabi -march=armv7-m -mfloat-abi=softfp -x c -E -dM %s | FileCheck -match-full-lines --check-prefix=CHECK-VFP-FP %s


### PR DESCRIPTION
This reverts commit 8fa0f0efce5fb81eb422e6d7eec74c66dafef4a3.

This change broke assembling for e.g. "armv7s-apple-darwin" triples, which should enable VFPv4 by default (and did that before this change), but after this change, only NEON/VFPv3 were available.

This is being fixed properly in latest git main as part of https://github.com/llvm/llvm-project/pull/130623 (possibly as a split out change), but any proper fix here seems to have too much potential surprises for an existing release branch.