### PR TITLE
[JITLink][NFC] Guard functions used only for debug for `XCOFFLinkGraphBuilder`

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/XCOFFLinkGraphBuilder.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/XCOFFLinkGraphBuilder.cpp
@@ -40,6 +40,7 @@ XCOFFLinkGraphBuilder::XCOFFLinkGraphBuilder(
           std::string(Obj.getFileName()), std::move(SSP), std::move(TT),
           std::move(Features), std::move(GetEdgeKindName))) {}
 
+#ifndef NDEBUG
 static llvm::StringRef getStorageClassString(XCOFF::StorageClass SC) {
   switch (SC) {
   case XCOFF::StorageClass::C_FILE:
@@ -144,6 +145,7 @@ static llvm::StringRef getStorageClassString(XCOFF::StorageClass SC) {
     return "C_TCSYM (Reserved)";
   }
 }
+#endif
 
 Error XCOFFLinkGraphBuilder::processSections() {
   LLVM_DEBUG(dbgs() << "  Creating graph sections...\n");
@@ -203,6 +205,7 @@ getXCOFFSymbolContainingSymbolRef(const object::XCOFFObjectFile &Obj,
   return object::XCOFFSymbolRef(DRI, &Obj);
 }
 
+#ifndef NDEBUG
 static void printSymbolEntry(raw_ostream &OS,
                              const object::XCOFFObjectFile &Obj,
                              const object::XCOFFSymbolRef &Sym) {
@@ -231,6 +234,7 @@ static void printSymbolEntry(raw_ostream &OS,
   }
   OS << "\n";
 }
+#endif
 
 Error XCOFFLinkGraphBuilder::processCsectsAndSymbols() {
   LLVM_DEBUG(dbgs() << "  Creating graph blocks and symbols...\n");


### PR DESCRIPTION
2 of the functions in `XCOFFGraphBuilder` are only for debugging. So we need to guard it to avoid warnings.