### PR TITLE
[NFC][LLVM][BPF] Cleanup pass initialization for BPF

### DIFF
--- a/llvm/lib/Target/BPF/BPFMIChecking.cpp
+++ b/llvm/lib/Target/BPF/BPFMIChecking.cpp
@@ -32,9 +32,7 @@ struct BPFMIPreEmitChecking : public MachineFunctionPass {
   MachineFunction *MF;
   const TargetRegisterInfo *TRI;
 
-  BPFMIPreEmitChecking() : MachineFunctionPass(ID) {
-    initializeBPFMIPreEmitCheckingPass(*PassRegistry::getPassRegistry());
-  }
+  BPFMIPreEmitChecking() : MachineFunctionPass(ID) {}
 
 private:
   // Initialize class variables.

--- a/llvm/lib/Target/BPF/BPFMIPeephole.cpp
+++ b/llvm/lib/Target/BPF/BPFMIPeephole.cpp
@@ -51,9 +51,7 @@ struct BPFMIPeephole : public MachineFunctionPass {
   MachineFunction *MF;
   MachineRegisterInfo *MRI;
 
-  BPFMIPeephole() : MachineFunctionPass(ID) {
-    initializeBPFMIPeepholePass(*PassRegistry::getPassRegistry());
-  }
+  BPFMIPeephole() : MachineFunctionPass(ID) {}
 
 private:
   // Initialize class variables.
@@ -311,9 +309,7 @@ struct BPFMIPreEmitPeephole : public MachineFunctionPass {
   const BPFInstrInfo *TII;
   bool SupportGotol;
 
-  BPFMIPreEmitPeephole() : MachineFunctionPass(ID) {
-    initializeBPFMIPreEmitPeepholePass(*PassRegistry::getPassRegistry());
-  }
+  BPFMIPreEmitPeephole() : MachineFunctionPass(ID) {}
 
 private:
   // Initialize class variables.

--- a/llvm/lib/Target/BPF/BPFMISimplifyPatchable.cpp
+++ b/llvm/lib/Target/BPF/BPFMISimplifyPatchable.cpp
@@ -50,9 +50,7 @@ struct BPFMISimplifyPatchable : public MachineFunctionPass {
   const BPFInstrInfo *TII;
   MachineFunction *MF;
 
-  BPFMISimplifyPatchable() : MachineFunctionPass(ID) {
-    initializeBPFMISimplifyPatchablePass(*PassRegistry::getPassRegistry());
-  }
+  BPFMISimplifyPatchable() : MachineFunctionPass(ID) {}
 
 private:
   std::set<MachineInstr *> SkipInsts;

--- a/llvm/lib/Target/BPF/BPFTargetMachine.cpp
+++ b/llvm/lib/Target/BPF/BPFTargetMachine.cpp
@@ -47,7 +47,10 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeBPFTarget() {
   initializeGlobalISel(PR);
   initializeBPFCheckAndAdjustIRPass(PR);
   initializeBPFMIPeepholePass(PR);
+  initializeBPFMIPreEmitPeepholePass(PR);
   initializeBPFDAGToDAGISelLegacyPass(PR);
+  initializeBPFMISimplifyPatchablePass(PR);
+  initializeBPFMIPreEmitCheckingPass(PR);
 }
 
 // DataLayout: little or big endian


### PR DESCRIPTION
- Remove calls to pass initialization from pass constructors and move them to target initialization.
- https://github.com/llvm/llvm-project/issues/111767