### PR TITLE
Add commands to list/enable/disable plugins

### DIFF
--- a/lldb/include/lldb/Core/PluginManager.h
+++ b/lldb/include/lldb/Core/PluginManager.h
@@ -544,6 +544,12 @@ public:
   static InstrumentationRuntimeCreateInstance
   GetInstrumentationRuntimeCreateCallbackAtIndex(uint32_t idx);
 
+  static std::vector<RegisteredPluginInfo>
+  GetInstrumentationRuntimePluginInfo();
+
+  static bool SetInstrumentationRuntimePluginEnabled(llvm::StringRef name,
+                                                     bool enabled);
+
   // TypeSystem
   static bool RegisterPlugin(llvm::StringRef name, llvm::StringRef description,
                              TypeSystemCreateInstance create_callback,

--- a/lldb/include/lldb/Core/PluginManager.h
+++ b/lldb/include/lldb/Core/PluginManager.h
@@ -105,7 +105,7 @@ public:
   // If pattern is given it will be used to filter the plugins that are
   // are returned. The pattern filters the plugin names using the
   // PluginManager::MatchPluginName() function.
-  static llvm::json::Object GetJSON(llvm::StringRef pattern);
+  static llvm::json::Object GetJSON(llvm::StringRef pattern = "");
 
   // Return true if the pattern matches the plugin name.
   //
@@ -115,7 +115,7 @@ public:
   //
   // An empty pattern matches all plugins.
   static bool MatchPluginName(llvm::StringRef pattern,
-                              const PluginNamespace &ns,
+                              const PluginNamespace &plugin_ns,
                               const RegisteredPluginInfo &plugin);
 
   // ABI

--- a/lldb/include/lldb/Core/PluginManager.h
+++ b/lldb/include/lldb/Core/PluginManager.h
@@ -20,6 +20,7 @@
 #include "lldb/lldb-private-interfaces.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/JSON.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -81,7 +82,41 @@ public:
 
   static void Terminate();
 
+  // Support for enabling and disabling plugins.
+
+  // Return the plugins that can be enabled or disabled by the user.
   static llvm::ArrayRef<PluginNamespace> GetPluginNamespaces();
+
+  // Generate a json object that describes the plugins that are available.
+  // This is a json representation of the plugin info returned by
+  // GetPluginNamespaces().
+  //
+  //    {
+  //       <plugin-namespace>: [
+  //           {
+  //               "enabled": <bool>,
+  //               "name": <plugin-name>,
+  //           },
+  //           ...
+  //       ],
+  //       ...
+  //    }
+  //
+  // If pattern is given it will be used to filter the plugins that are
+  // are returned. The pattern filters the plugin names using the
+  // PluginManager::MatchPluginName() function.
+  static llvm::json::Object GetJSON(llvm::StringRef pattern);
+
+  // Return true if the pattern matches the plugin name.
+  //
+  // The pattern matches the name if it is exactly equal to the namespace name
+  // or if it is equal to the qualified name, which is the namespace name
+  // followed by a dot and the plugin name (e.g. "system-runtime.foo").
+  //
+  // An empty pattern matches all plugins.
+  static bool MatchPluginName(llvm::StringRef pattern,
+                              const PluginNamespace &ns,
+                              const RegisteredPluginInfo &plugin);
 
   // ABI
   static bool RegisterPlugin(llvm::StringRef name, llvm::StringRef description,

--- a/lldb/include/lldb/Core/PluginManager.h
+++ b/lldb/include/lldb/Core/PluginManager.h
@@ -62,8 +62,8 @@ struct RegisteredPluginInfo {
 // and ObjectFile plugins.
 //
 // The namespace name is used a prefix when matching plugin names. For example,
-// if we have an "elf" plugin in the "object-file" namespace then we will
-// match a plugin name pattern against the "object-file.elf" name.
+// if we have an "macosx" plugin in the "system-runtime" namespace then we will
+// match a plugin name pattern against the "system-runtime.macosx" name.
 //
 // The plugin namespace here is used so we can operate on all the plugins
 // of a given type so it is easy to enable or disable them as a group.

--- a/lldb/include/lldb/Interpreter/CommandOptionArgumentTable.h
+++ b/lldb/include/lldb/Interpreter/CommandOptionArgumentTable.h
@@ -314,6 +314,7 @@ static constexpr CommandObject::ArgumentTableEntry g_argument_table[] = {
     { lldb::eArgTypeModule, "module", lldb::CompletionType::eModuleCompletion, {}, { nullptr, false }, "The name of a module loaded into the current target." },
     { lldb::eArgTypeCPUName, "cpu-name", lldb::CompletionType::eNoCompletion, {}, { nullptr, false }, "The name of a CPU." },
     { lldb::eArgTypeCPUFeatures, "cpu-features", lldb::CompletionType::eNoCompletion, {}, { nullptr, false }, "The CPU feature string." },
+    { lldb::eArgTypeManagedPlugin, "managed-plugin", lldb::CompletionType::eNoCompletion, {}, { nullptr, false }, "Plugins managed by the PluginManager" },
     // clang-format on
 };
 

--- a/lldb/include/lldb/Target/Statistics.h
+++ b/lldb/include/lldb/Target/Statistics.h
@@ -174,12 +174,21 @@ public:
     return !GetSummaryOnly();
   }
 
+  void SetIncludePlugins(bool value) { m_include_plugins = value; }
+  bool GetIncludePlugins() const {
+    if (m_include_plugins.has_value())
+      return m_include_plugins.value();
+    // Default to true in both default mode and summary mode.
+    return true;
+  }
+
 private:
   std::optional<bool> m_summary_only;
   std::optional<bool> m_load_all_debug_info;
   std::optional<bool> m_include_targets;
   std::optional<bool> m_include_modules;
   std::optional<bool> m_include_transcript;
+  std::optional<bool> m_include_plugins;
 };
 
 /// A class that represents statistics about a TypeSummaryProviders invocations

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -663,6 +663,7 @@ enum CommandArgumentType {
   eArgTypeModule,
   eArgTypeCPUName,
   eArgTypeCPUFeatures,
+  eArgTypeManagedPlugin,
   eArgTypeLastArg // Always keep this entry as the last entry in this
                   // enumeration!!
 };

--- a/lldb/source/Commands/CommandObjectPlugin.cpp
+++ b/lldb/source/Commands/CommandObjectPlugin.cpp
@@ -7,8 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "CommandObjectPlugin.h"
+#include "lldb/Core/PluginManager.h"
+#include "lldb/Host/OptionParser.h"
 #include "lldb/Interpreter/CommandInterpreter.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
+#include "llvm/Support/GlobPattern.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -46,12 +49,344 @@ protected:
   }
 };
 
+namespace {
+#define LLDB_OPTIONS_plugin_list
+#include "CommandOptions.inc"
+
+// These option definitions are shared by the plugin list/enable/disable
+// commands.
+class PluginListCommandOptions : public Options {
+public:
+  PluginListCommandOptions() = default;
+
+  ~PluginListCommandOptions() override = default;
+
+  Status SetOptionValue(uint32_t option_idx, llvm::StringRef option_arg,
+                        ExecutionContext *execution_context) override {
+    Status error;
+    const int short_option = m_getopt_table[option_idx].val;
+
+    switch (short_option) {
+    case 'x':
+      m_exact_name_match = true;
+      break;
+    default:
+      llvm_unreachable("Unimplemented option");
+    }
+
+    return error;
+  }
+
+  void OptionParsingStarting(ExecutionContext *execution_context) override {
+    m_exact_name_match = false;
+  }
+
+  llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
+    return llvm::ArrayRef(g_plugin_list_options);
+  }
+
+  // Instance variables to hold the values for command options.
+  bool m_exact_name_match = false;
+};
+
+// Define some data structures to describe known plugin "namespaces".
+// The PluginManager is organized into a series of static functions
+// that operate on different types of plugin. For example SystemRuntime
+// and ObjectFile plugins.
+//
+// The namespace name is used a prefix when matching plugin names. For example,
+// if we have an "elf" plugin in the "object-file" namespace then we will
+// match a plugin name pattern against the "object-file.elf" name.
+//
+// The plugin namespace here is used so we can operate on all the plugins
+// of a given type so it is easy to enable or disable them as a group.
+using GetPluginInfo = std::function<std::vector<RegisteredPluginInfo>()>;
+using SetPluginEnabled = std::function<bool(llvm::StringRef, bool)>;
+struct PluginNamespace {
+  llvm::StringRef name;
+  GetPluginInfo get_info;
+  SetPluginEnabled set_enabled;
+};
+
+// Currently supported set of plugin namespaces. This will be expanded
+// over time.
+PluginNamespace PluginNamespaces[] = {
+    {"system-runtime", PluginManager::GetSystemRuntimePluginInfo,
+     PluginManager::SetSystemRuntimePluginEnabled}};
+
+// Helper function to perform an action on each matching plugin.
+// The action callback is given the containing namespace along with plugin info
+// for each matching plugin.
+static int ActOnMatchingPlugins(
+    llvm::GlobPattern pattern,
+    std::function<void(const PluginNamespace &plugin_namespace,
+                       const std::vector<RegisteredPluginInfo> &plugin_info)>
+        action) {
+  int num_matching = 0;
+
+  for (const PluginNamespace &plugin_namespace : PluginNamespaces) {
+    std::vector<RegisteredPluginInfo> all_plugins = plugin_namespace.get_info();
+    std::vector<RegisteredPluginInfo> matching_plugins;
+    for (const RegisteredPluginInfo &plugin_info : all_plugins) {
+      std::string qualified_name =
+          (plugin_namespace.name + "." + plugin_info.name).str();
+      if (pattern.match(qualified_name)) {
+        matching_plugins.push_back(plugin_info);
+      }
+    }
+
+    if (!matching_plugins.empty()) {
+      num_matching += matching_plugins.size();
+      action(plugin_namespace, matching_plugins);
+    }
+  }
+
+  return num_matching;
+}
+
+// Return a string in glob syntax for matching plugins.
+static std::string GetPluginNamePatternString(llvm::StringRef user_input,
+                                              bool add_default_glob) {
+  std::string pattern_str;
+  if (user_input.empty())
+    pattern_str = "*";
+  else
+    pattern_str = user_input;
+
+  if (add_default_glob && pattern_str != "*") {
+    pattern_str = "*" + pattern_str + "*";
+  }
+
+  return pattern_str;
+}
+
+// Attempts to create a glob pattern for a plugin name based on plugin command
+// input. Writes an error message to the `result` object if the glob cannot be
+// created successfully.
+//
+// The `glob_storage` is used to hold the string data for the glob pattern. The
+// llvm::GlobPattern only contains pointers into the string data so we need a
+// stable location that can outlive the glob pattern itself.
+std::optional<llvm::GlobPattern>
+TryCreatePluginPattern(const char *plugin_command_name, const Args &command,
+                       const PluginListCommandOptions &options,
+                       CommandReturnObject &result, std::string &glob_storage) {
+  size_t argc = command.GetArgumentCount();
+  if (argc > 1) {
+    result.AppendErrorWithFormat("'%s' requires one argument",
+                                 plugin_command_name);
+    return {};
+  }
+
+  llvm::StringRef user_pattern;
+  if (argc == 1) {
+    user_pattern = command[0].ref();
+  }
+
+  glob_storage =
+      GetPluginNamePatternString(user_pattern, !options.m_exact_name_match);
+
+  auto glob_pattern = llvm::GlobPattern::create(glob_storage);
+
+  if (auto error = glob_pattern.takeError()) {
+    std::string error_message =
+        (llvm::Twine("Invalid plugin glob pattern: '") + glob_storage +
+         "': " + llvm::toString(std::move(error)))
+            .str();
+    result.AppendError(error_message);
+    return {};
+  }
+
+  return *glob_pattern;
+}
+
+// Call the "SetEnable" function for each matching plugins.
+// Used to share the majority of the code between the enable
+// and disable commands.
+int SetEnableOnMatchingPlugins(const llvm::GlobPattern &pattern,
+                               CommandReturnObject &result, bool enabled) {
+  return ActOnMatchingPlugins(
+      pattern, [&](const PluginNamespace &plugin_namespace,
+                   const std::vector<RegisteredPluginInfo> &plugins) {
+        result.AppendMessage(plugin_namespace.name);
+        for (const auto &plugin : plugins) {
+          if (!plugin_namespace.set_enabled(plugin.name, enabled)) {
+            result.AppendErrorWithFormat("failed to enable plugin %s.%s",
+                                         plugin_namespace.name.data(),
+                                         plugin.name.data());
+            continue;
+          }
+
+          result.AppendMessageWithFormat(
+              "  %s %-30s %s\n", enabled ? "[+]" : "[-]", plugin.name.data(),
+              plugin.description.data());
+        }
+      });
+}
+} // namespace
+
+class CommandObjectPluginList : public CommandObjectParsed {
+public:
+  CommandObjectPluginList(CommandInterpreter &interpreter)
+      : CommandObjectParsed(interpreter, "plugin list",
+                            "Report info about registered LLDB plugins.",
+                            nullptr) {
+    AddSimpleArgumentList(eArgTypePlugin);
+    SetHelpLong(R"(
+Display information about registered plugins.
+The plugin information is formatted as shown below
+
+    <plugin-namespace>
+      [+] <plugin-name>                  Plugin #1 description
+      [-] <plugin-name>                  Plugin #2 description
+
+An enabled plugin is marked with [+] and a disabled plugin is marked with [-].
+
+Selecting plugins
+------------------
+plugin list [<plugin-namespace>.][<plugin-name>]
+
+Plugin names are specified using glob patterns. The pattern will be matched
+against the plugins fully qualified name, which is composed of the namespace,
+followed by a '.', followed by the plugin name.
+
+When no arguments are given the plugin selection string is the wildcard '*'.
+By default wildcards are added around the input to enable searching by
+substring. You can prevent these implicit wild cards by using the
+-x flag.
+
+Examples
+-----------------
+List all plugins in the system-runtime namespace
+
+  (lldb) plugin list system-runtime.*
+
+List all plugins containing the string foo
+
+  (lldb) plugin list foo
+
+This is equivalent to
+
+  (lldb) plugin list *foo*
+
+List only a plugin matching a fully qualified name exactly
+
+  (lldb) plugin list -x system-runtime.foo
+)");
+  }
+
+  ~CommandObjectPluginList() override = default;
+
+  Options *GetOptions() override { return &m_options; }
+
+protected:
+  void DoExecute(Args &command, CommandReturnObject &result) override {
+    std::string glob_storage;
+    std::optional<llvm::GlobPattern> plugin_glob = TryCreatePluginPattern(
+        "plugin list", command, m_options, result, glob_storage);
+
+    if (!plugin_glob) {
+      assert(!result.Succeeded());
+      return;
+    }
+
+    int num_matching = ActOnMatchingPlugins(
+        *plugin_glob, [&](const PluginNamespace &plugin_namespace,
+                          const std::vector<RegisteredPluginInfo> &plugins) {
+          result.AppendMessage(plugin_namespace.name);
+          for (auto &plugin : plugins) {
+            result.AppendMessageWithFormat(
+                "  %s %-30s %s\n", plugin.enabled ? "[+]" : "[-]",
+                plugin.name.data(), plugin.description.data());
+          }
+        });
+
+    if (num_matching == 0) {
+      result.AppendErrorWithFormat("Found no matching plugins");
+    }
+  }
+
+  PluginListCommandOptions m_options;
+};
+
+class CommandObjectPluginEnable : public CommandObjectParsed {
+public:
+  CommandObjectPluginEnable(CommandInterpreter &interpreter)
+      : CommandObjectParsed(interpreter, "plugin enable",
+                            "Enable registered LLDB plugins.", nullptr) {
+    AddSimpleArgumentList(eArgTypePlugin);
+  }
+
+  ~CommandObjectPluginEnable() override = default;
+
+  Options *GetOptions() override { return &m_options; }
+
+protected:
+  void DoExecute(Args &command, CommandReturnObject &result) override {
+    std::string glob_storage;
+    std::optional<llvm::GlobPattern> plugin_glob = TryCreatePluginPattern(
+        "plugin enable", command, m_options, result, glob_storage);
+
+    if (!plugin_glob) {
+      assert(!result.Succeeded());
+      return;
+    }
+
+    int num_matching = SetEnableOnMatchingPlugins(*plugin_glob, result, true);
+
+    if (num_matching == 0) {
+      result.AppendErrorWithFormat("Found no matching plugins to enable");
+    }
+  }
+
+  PluginListCommandOptions m_options;
+};
+
+class CommandObjectPluginDisable : public CommandObjectParsed {
+public:
+  CommandObjectPluginDisable(CommandInterpreter &interpreter)
+      : CommandObjectParsed(interpreter, "plugin disable",
+                            "Disable registered LLDB plugins.", nullptr) {
+    AddSimpleArgumentList(eArgTypePlugin);
+  }
+
+  ~CommandObjectPluginDisable() override = default;
+
+  Options *GetOptions() override { return &m_options; }
+
+protected:
+  void DoExecute(Args &command, CommandReturnObject &result) override {
+    std::string glob_storage;
+    std::optional<llvm::GlobPattern> plugin_glob = TryCreatePluginPattern(
+        "plugin disable", command, m_options, result, glob_storage);
+
+    if (!plugin_glob) {
+      assert(!result.Succeeded());
+      return;
+    }
+
+    int num_matching = SetEnableOnMatchingPlugins(*plugin_glob, result, false);
+
+    if (num_matching == 0) {
+      result.AppendErrorWithFormat("Found no matching plugins to disable");
+    }
+  }
+
+  PluginListCommandOptions m_options;
+};
+
 CommandObjectPlugin::CommandObjectPlugin(CommandInterpreter &interpreter)
     : CommandObjectMultiword(interpreter, "plugin",
                              "Commands for managing LLDB plugins.",
                              "plugin <subcommand> [<subcommand-options>]") {
   LoadSubCommand("load",
                  CommandObjectSP(new CommandObjectPluginLoad(interpreter)));
+  LoadSubCommand("list",
+                 CommandObjectSP(new CommandObjectPluginList(interpreter)));
+  LoadSubCommand("enable",
+                 CommandObjectSP(new CommandObjectPluginEnable(interpreter)));
+  LoadSubCommand("disable",
+                 CommandObjectSP(new CommandObjectPluginDisable(interpreter)));
 }
 
 CommandObjectPlugin::~CommandObjectPlugin() = default;

--- a/lldb/source/Commands/CommandObjectPlugin.cpp
+++ b/lldb/source/Commands/CommandObjectPlugin.cpp
@@ -274,17 +274,22 @@ public:
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     size_t argc = command.GetArgumentCount();
-    if (argc != 1) {
-      result.AppendError("'plugin enable' requires one argument");
+    if (argc == 0) {
+      result.AppendError("'plugin enable' requires one or more arguments");
       return;
     }
-    llvm::StringRef pattern = command[0].ref();
     result.SetStatus(eReturnStatusSuccessFinishResult);
 
-    int num_matching = SetEnableOnMatchingPlugins(pattern, result, true);
+    for (size_t i = 0; i < argc; ++i)
+    {
+      llvm::StringRef pattern = command[i].ref();
+      int num_matching = SetEnableOnMatchingPlugins(pattern, result, true);
 
-    if (num_matching == 0)
-      result.AppendErrorWithFormat("Found no matching plugins to enable");
+      if (num_matching == 0) {
+        result.AppendErrorWithFormat("Found no matching plugins to enable for pattern '%s'",pattern.data());
+        break;
+      }
+    }
   }
 };
 

--- a/lldb/source/Commands/CommandObjectPlugin.cpp
+++ b/lldb/source/Commands/CommandObjectPlugin.cpp
@@ -248,7 +248,7 @@ protected:
       result.AppendError("'plugin enable' requires one argument");
       return;
     }
-    llvm::StringRef pattern = argc ? command[0].ref() : "";
+    llvm::StringRef pattern = command[0].ref();
     result.SetStatus(eReturnStatusSuccessFinishResult);
 
     int num_matching = SetEnableOnMatchingPlugins(pattern, result, true);
@@ -275,7 +275,7 @@ protected:
       result.AppendError("'plugin disable' requires one argument");
       return;
     }
-    llvm::StringRef pattern = argc ? command[0].ref() : "";
+    llvm::StringRef pattern = command[0].ref();
     result.SetStatus(eReturnStatusSuccessFinishResult);
 
     int num_matching = SetEnableOnMatchingPlugins(pattern, result, false);

--- a/lldb/source/Commands/CommandObjectPlugin.cpp
+++ b/lldb/source/Commands/CommandObjectPlugin.cpp
@@ -297,7 +297,7 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    DoPluginEnableDisable(command, result, true);
+    DoPluginEnableDisable(command, result, /*enable=*/true);
   }
 };
 
@@ -313,7 +313,7 @@ public:
 
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
-    DoPluginEnableDisable(command, result, false);
+    DoPluginEnableDisable(command, result, /*enable=*/false);
   }
 };
 

--- a/lldb/source/Commands/CommandObjectPlugin.cpp
+++ b/lldb/source/Commands/CommandObjectPlugin.cpp
@@ -165,6 +165,7 @@ protected:
       return;
     }
     llvm::StringRef pattern = argc ? command[0].ref() : "";
+    result.SetStatus(eReturnStatusSuccessFinishResult);
 
     int num_matching = ActOnMatchingPlugins(
         pattern, [&](const PluginNamespace &plugin_namespace,
@@ -177,9 +178,8 @@ protected:
           }
         });
 
-    if (num_matching == 0) {
+    if (num_matching == 0)
       result.AppendErrorWithFormat("Found no matching plugins");
-    }
   }
 };
 
@@ -201,12 +201,12 @@ protected:
       return;
     }
     llvm::StringRef pattern = argc ? command[0].ref() : "";
+    result.SetStatus(eReturnStatusSuccessFinishResult);
 
     int num_matching = SetEnableOnMatchingPlugins(pattern, result, true);
 
-    if (num_matching == 0) {
+    if (num_matching == 0)
       result.AppendErrorWithFormat("Found no matching plugins to enable");
-    }
   }
 };
 
@@ -228,6 +228,7 @@ protected:
       return;
     }
     llvm::StringRef pattern = argc ? command[0].ref() : "";
+    result.SetStatus(eReturnStatusSuccessFinishResult);
 
     int num_matching = SetEnableOnMatchingPlugins(pattern, result, false);
 

--- a/lldb/source/Commands/CommandObjectPlugin.cpp
+++ b/lldb/source/Commands/CommandObjectPlugin.cpp
@@ -62,22 +62,12 @@ static int ActOnMatchingPlugins(
 
   for (const PluginNamespace &plugin_namespace :
        PluginManager::GetPluginNamespaces()) {
-    const bool match_namespace =
-        pattern.empty() || pattern == plugin_namespace.name;
 
     std::vector<RegisteredPluginInfo> matching_plugins;
     for (const RegisteredPluginInfo &plugin_info :
          plugin_namespace.get_info()) {
-
-      // If we match the namespace, we can skip the plugin name check.
-      bool match_qualified_name = false;
-      if (!match_namespace) {
-        std::string qualified_name =
-            (plugin_namespace.name + "." + plugin_info.name).str();
-        match_qualified_name = pattern == qualified_name;
-      }
-
-      if (match_namespace || match_qualified_name)
+      if (PluginManager::MatchPluginName(pattern, plugin_namespace,
+                                         plugin_info))
         matching_plugins.push_back(plugin_info);
     }
 

--- a/lldb/source/Commands/CommandObjectPlugin.cpp
+++ b/lldb/source/Commands/CommandObjectPlugin.cpp
@@ -151,7 +151,7 @@ protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     size_t argc = command.GetArgumentCount();
     if (argc > 1) {
-      result.AppendError("'plugin load' requires one argument");
+      result.AppendError("'plugin list' requires zero or one arguments");
       return;
     }
     llvm::StringRef pattern = argc ? command[0].ref() : "";
@@ -186,7 +186,7 @@ public:
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     size_t argc = command.GetArgumentCount();
-    if (argc > 1) {
+    if (argc != 1) {
       result.AppendError("'plugin enable' requires one argument");
       return;
     }
@@ -213,7 +213,7 @@ public:
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     size_t argc = command.GetArgumentCount();
-    if (argc > 1) {
+    if (argc != 1) {
       result.AppendError("'plugin disable' requires one argument");
       return;
     }

--- a/lldb/source/Commands/CommandObjectPlugin.cpp
+++ b/lldb/source/Commands/CommandObjectPlugin.cpp
@@ -201,7 +201,7 @@ public:
     AddSimpleArgumentList(eArgTypePlugin);
     SetHelpLong(R"(
 Display information about registered plugins.
-The plugin information is formatted as shown below
+The plugin information is formatted as shown below:
 
     <plugin-namespace>
       [+] <plugin-name>                  Plugin #1 description

--- a/lldb/source/Commands/CommandObjectPlugin.cpp
+++ b/lldb/source/Commands/CommandObjectPlugin.cpp
@@ -89,31 +89,6 @@ public:
   bool m_exact_name_match = false;
 };
 
-// Define some data structures to describe known plugin "namespaces".
-// The PluginManager is organized into a series of static functions
-// that operate on different types of plugin. For example SystemRuntime
-// and ObjectFile plugins.
-//
-// The namespace name is used a prefix when matching plugin names. For example,
-// if we have an "elf" plugin in the "object-file" namespace then we will
-// match a plugin name pattern against the "object-file.elf" name.
-//
-// The plugin namespace here is used so we can operate on all the plugins
-// of a given type so it is easy to enable or disable them as a group.
-using GetPluginInfo = std::function<std::vector<RegisteredPluginInfo>()>;
-using SetPluginEnabled = std::function<bool(llvm::StringRef, bool)>;
-struct PluginNamespace {
-  llvm::StringRef name;
-  GetPluginInfo get_info;
-  SetPluginEnabled set_enabled;
-};
-
-// Currently supported set of plugin namespaces. This will be expanded
-// over time.
-PluginNamespace PluginNamespaces[] = {
-    {"system-runtime", PluginManager::GetSystemRuntimePluginInfo,
-     PluginManager::SetSystemRuntimePluginEnabled}};
-
 // Helper function to perform an action on each matching plugin.
 // The action callback is given the containing namespace along with plugin info
 // for each matching plugin.
@@ -124,7 +99,8 @@ static int ActOnMatchingPlugins(
         action) {
   int num_matching = 0;
 
-  for (const PluginNamespace &plugin_namespace : PluginNamespaces) {
+  for (const PluginNamespace &plugin_namespace :
+       PluginManager::GetPluginNamespaces()) {
     std::vector<RegisteredPluginInfo> matching_plugins;
     for (const RegisteredPluginInfo &plugin_info :
          plugin_namespace.get_info()) {

--- a/lldb/source/Commands/CommandObjectPlugin.cpp
+++ b/lldb/source/Commands/CommandObjectPlugin.cpp
@@ -126,7 +126,8 @@ static int ActOnMatchingPlugins(
 
   for (const PluginNamespace &plugin_namespace : PluginNamespaces) {
     std::vector<RegisteredPluginInfo> matching_plugins;
-    for (const RegisteredPluginInfo &plugin_info : plugin_namespace.get_info()) {
+    for (const RegisteredPluginInfo &plugin_info :
+         plugin_namespace.get_info()) {
       std::string qualified_name =
           (plugin_namespace.name + "." + plugin_info.name).str();
       if (pattern.match(qualified_name))

--- a/lldb/source/Commands/CommandObjectPlugin.cpp
+++ b/lldb/source/Commands/CommandObjectPlugin.cpp
@@ -125,14 +125,12 @@ static int ActOnMatchingPlugins(
   int num_matching = 0;
 
   for (const PluginNamespace &plugin_namespace : PluginNamespaces) {
-    std::vector<RegisteredPluginInfo> all_plugins = plugin_namespace.get_info();
     std::vector<RegisteredPluginInfo> matching_plugins;
-    for (const RegisteredPluginInfo &plugin_info : all_plugins) {
+    for (const RegisteredPluginInfo &plugin_info : plugin_namespace.get_info()) {
       std::string qualified_name =
           (plugin_namespace.name + "." + plugin_info.name).str();
-      if (pattern.match(qualified_name)) {
+      if (pattern.match(qualified_name))
         matching_plugins.push_back(plugin_info);
-      }
     }
 
     if (!matching_plugins.empty()) {
@@ -147,15 +145,10 @@ static int ActOnMatchingPlugins(
 // Return a string in glob syntax for matching plugins.
 static std::string GetPluginNamePatternString(llvm::StringRef user_input,
                                               bool add_default_glob) {
-  std::string pattern_str;
-  if (user_input.empty())
-    pattern_str = "*";
-  else
-    pattern_str = user_input;
+  std::string pattern_str = user_input.empty() ? "*" : user_input;
 
-  if (add_default_glob && pattern_str != "*") {
+  if (add_default_glob && pattern_str != "*") 
     pattern_str = "*" + pattern_str + "*";
-  }
 
   return pattern_str;
 }
@@ -178,10 +171,7 @@ TryCreatePluginPattern(const char *plugin_command_name, const Args &command,
     return {};
   }
 
-  llvm::StringRef user_pattern;
-  if (argc == 1) {
-    user_pattern = command[0].ref();
-  }
+  llvm::StringRef user_pattern = argc == 1 ? command[0].ref() : "";
 
   glob_storage =
       GetPluginNamePatternString(user_pattern, !options.m_exact_name_match);
@@ -255,8 +245,7 @@ By default wildcards are added around the input to enable searching by
 substring. You can prevent these implicit wild cards by using the
 -x flag.
 
-Examples
------------------
+Examples:
 List all plugins in the system-runtime namespace
 
   (lldb) plugin list system-runtime.*
@@ -367,9 +356,8 @@ protected:
 
     int num_matching = SetEnableOnMatchingPlugins(*plugin_glob, result, false);
 
-    if (num_matching == 0) {
+    if (num_matching == 0) 
       result.AppendErrorWithFormat("Found no matching plugins to disable");
-    }
   }
 
   PluginListCommandOptions m_options;

--- a/lldb/source/Commands/CommandObjectPlugin.cpp
+++ b/lldb/source/Commands/CommandObjectPlugin.cpp
@@ -145,9 +145,9 @@ static int ActOnMatchingPlugins(
 // Return a string in glob syntax for matching plugins.
 static std::string GetPluginNamePatternString(llvm::StringRef user_input,
                                               bool add_default_glob) {
-  std::string pattern_str = user_input.empty() ? "*" : user_input;
+  std::string pattern_str = user_input.empty() ? "*" : user_input.str();
 
-  if (add_default_glob && pattern_str != "*") 
+  if (add_default_glob && pattern_str != "*")
     pattern_str = "*" + pattern_str + "*";
 
   return pattern_str;
@@ -232,9 +232,9 @@ The plugin information is formatted as shown below
 
 An enabled plugin is marked with [+] and a disabled plugin is marked with [-].
 
-Selecting plugins
-------------------
-plugin list [<plugin-namespace>.][<plugin-name>]
+Plugins can be listed by namespace and name with:
+
+  plugin list [<plugin-namespace>.][<plugin-name>]
 
 Plugin names are specified using glob patterns. The pattern will be matched
 against the plugins fully qualified name, which is composed of the namespace,
@@ -356,7 +356,7 @@ protected:
 
     int num_matching = SetEnableOnMatchingPlugins(*plugin_glob, result, false);
 
-    if (num_matching == 0) 
+    if (num_matching == 0)
       result.AppendErrorWithFormat("Found no matching plugins to disable");
   }
 

--- a/lldb/source/Commands/CommandObjectSettings.cpp
+++ b/lldb/source/Commands/CommandObjectSettings.cpp
@@ -15,6 +15,7 @@
 #include "lldb/Interpreter/CommandInterpreter.h"
 #include "lldb/Interpreter/CommandOptionArgumentTable.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
+#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Interpreter/OptionValueProperties.h"
 
 using namespace lldb;

--- a/lldb/source/Commands/CommandObjectSettings.cpp
+++ b/lldb/source/Commands/CommandObjectSettings.cpp
@@ -15,7 +15,6 @@
 #include "lldb/Interpreter/CommandInterpreter.h"
 #include "lldb/Interpreter/CommandOptionArgumentTable.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
-#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Interpreter/OptionValueProperties.h"
 
 using namespace lldb;

--- a/lldb/source/Commands/CommandObjectStats.cpp
+++ b/lldb/source/Commands/CommandObjectStats.cpp
@@ -103,6 +103,13 @@ class CommandObjectStatsDump : public CommandObjectParsed {
         else
           error = Status::FromError(bool_or_error.takeError());
         break;
+      case 'p':
+        if (llvm::Expected<bool> bool_or_error =
+                OptionArgParser::ToBoolean("--plugins", option_arg))
+          m_stats_options.SetIncludePlugins(*bool_or_error);
+        else
+          error = Status::FromError(bool_or_error.takeError());
+        break;
       default:
         llvm_unreachable("Unimplemented option");
       }

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -683,6 +683,11 @@ let Command = "platform shell" in {
     Desc<"Shell interpreter path. This is the binary used to run the command.">;
 }
 
+let Command = "plugin list" in {
+  def plugin_info_exact : Option<"exact", "x">,
+                          Desc<"Do not add implicit * glob around plugin name">;
+}
+
 let Command = "process launch" in {
   def process_launch_stop_at_entry : Option<"stop-at-entry", "s">,
     Desc<"Stop at the entry point of the program when launching a process.">;

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -1467,5 +1467,9 @@ let Command = "statistics dump" in {
     "scripts executed during a debug session. "
     "Defaults to true, unless the '--summary' mode is enabled, in which case "
     "this is turned off unless specified.">;
+  def statistics_dump_plugins: Option<"plugins", "p">, Group<1>,
+    Arg<"Boolean">,
+    Desc<"Dump statistics for known plugins including name, order, and enabled "
+    "state. Defaults to true for both summary and default mode.">;
 
 }

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -1472,6 +1472,6 @@ let Command = "statistics dump" in {
         Group<1>,
         Arg<"Boolean">,
         Desc<"Dump statistics for known plugins including name, order, and "
-             "enabled "
-             "state. Defaults to true for both summary and default mode.">;
+             "enabled state. Defaults to true for both summary and default "
+             "mode.">;
 }

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -683,11 +683,6 @@ let Command = "platform shell" in {
     Desc<"Shell interpreter path. This is the binary used to run the command.">;
 }
 
-let Command = "plugin list" in {
-  def plugin_info_exact : Option<"exact", "x">,
-                          Desc<"Do not add implicit * glob around plugin name">;
-}
-
 let Command = "process launch" in {
   def process_launch_stop_at_entry : Option<"stop-at-entry", "s">,
     Desc<"Stop at the entry point of the program when launching a process.">;

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -1467,9 +1467,11 @@ let Command = "statistics dump" in {
     "scripts executed during a debug session. "
     "Defaults to true, unless the '--summary' mode is enabled, in which case "
     "this is turned off unless specified.">;
-  def statistics_dump_plugins: Option<"plugins", "p">, Group<1>,
-    Arg<"Boolean">,
-    Desc<"Dump statistics for known plugins including name, order, and enabled "
-    "state. Defaults to true for both summary and default mode.">;
-
+  def statistics_dump_plugins
+      : Option<"plugins", "p">,
+        Group<1>,
+        Arg<"Boolean">,
+        Desc<"Dump statistics for known plugins including name, order, and "
+             "enabled "
+             "state. Defaults to true for both summary and default mode.">;
 }

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -683,6 +683,11 @@ let Command = "platform shell" in {
     Desc<"Shell interpreter path. This is the binary used to run the command.">;
 }
 
+let Command = "plugin list" in {
+  def plugin_list_json : Option<"json", "j">,
+                         Desc<"Output the plugin list in json format.">;
+}
+
 let Command = "process launch" in {
   def process_launch_stop_at_entry : Option<"stop-at-entry", "s">,
     Desc<"Stop at the entry point of the program when launching a process.">;

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -186,7 +186,10 @@ llvm::ArrayRef<PluginNamespace> PluginManager::GetPluginNamespaces() {
   // over time.
   static PluginNamespace PluginNamespaces[] = {
       {"system-runtime", PluginManager::GetSystemRuntimePluginInfo,
-       PluginManager::SetSystemRuntimePluginEnabled}};
+       PluginManager::SetSystemRuntimePluginEnabled},
+      {"instrumentation-runtime",
+       PluginManager::GetInstrumentationRuntimePluginInfo,
+       PluginManager::SetInstrumentationRuntimePluginEnabled}};
 
   return PluginNamespaces;
 }
@@ -1544,6 +1547,16 @@ PluginManager::GetInstrumentationRuntimeGetTypeCallbackAtIndex(uint32_t idx) {
 InstrumentationRuntimeCreateInstance
 PluginManager::GetInstrumentationRuntimeCreateCallbackAtIndex(uint32_t idx) {
   return GetInstrumentationRuntimeInstances().GetCallbackAtIndex(idx);
+}
+
+std::vector<RegisteredPluginInfo>
+PluginManager::GetInstrumentationRuntimePluginInfo() {
+  return GetInstrumentationRuntimeInstances().GetPluginInfoForAllInstances();
+}
+
+bool PluginManager::SetInstrumentationRuntimePluginEnabled(llvm::StringRef name,
+                                                           bool enable) {
+  return GetInstrumentationRuntimeInstances().SetInstanceEnabled(name, enable);
 }
 
 #pragma mark TypeSystem

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -191,6 +191,22 @@ llvm::ArrayRef<PluginNamespace> PluginManager::GetPluginNamespaces() {
   return PluginNamespaces;
 }
 
+bool PluginManager::MatchPluginName(llvm::StringRef pattern,
+                                    const PluginNamespace &ns,
+                                    const RegisteredPluginInfo &plugin_info) {
+  // The empty pattern matches all plugins.
+  if (pattern.empty())
+    return true;
+
+  // Check if the pattern matches the namespace.
+  if (pattern == ns.name)
+    return true;
+
+  // Check if the pattern matches the qualified name.
+  std::string qualified_name = (ns.name + "." + plugin_info.name).str();
+  return pattern == qualified_name;
+}
+
 template <typename Callback> struct PluginInstance {
   typedef Callback CallbackType;
 

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -191,19 +191,40 @@ llvm::ArrayRef<PluginNamespace> PluginManager::GetPluginNamespaces() {
   return PluginNamespaces;
 }
 
+llvm::json::Object PluginManager::GetJSON(llvm::StringRef pattern) {
+  llvm::json::Object plugin_stats;
+
+  for (const PluginNamespace &plugin_ns : GetPluginNamespaces()) {
+    llvm::json::Array namespace_stats;
+
+    for (const RegisteredPluginInfo &plugin : plugin_ns.get_info()) {
+      if (MatchPluginName(pattern, plugin_ns, plugin)) {
+        llvm::json::Object plugin_json;
+        plugin_json.try_emplace("name", plugin.name);
+        plugin_json.try_emplace("enabled", plugin.enabled);
+        namespace_stats.emplace_back(std::move(plugin_json));
+      }
+    }
+    if (!namespace_stats.empty())
+      plugin_stats.try_emplace(plugin_ns.name, std::move(namespace_stats));
+  }
+
+  return plugin_stats;
+}
+
 bool PluginManager::MatchPluginName(llvm::StringRef pattern,
-                                    const PluginNamespace &ns,
+                                    const PluginNamespace &plugin_ns,
                                     const RegisteredPluginInfo &plugin_info) {
   // The empty pattern matches all plugins.
   if (pattern.empty())
     return true;
 
   // Check if the pattern matches the namespace.
-  if (pattern == ns.name)
+  if (pattern == plugin_ns.name)
     return true;
 
   // Check if the pattern matches the qualified name.
-  std::string qualified_name = (ns.name + "." + plugin_info.name).str();
+  std::string qualified_name = (plugin_ns.name + "." + plugin_info.name).str();
   return pattern == qualified_name;
 }
 

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -181,6 +181,16 @@ void PluginManager::Terminate() {
   plugin_map.clear();
 }
 
+llvm::ArrayRef<PluginNamespace> PluginManager::GetPluginNamespaces() {
+  // Currently supported set of plugin namespaces. This will be expanded
+  // over time.
+  static PluginNamespace PluginNamespaces[] = {
+      {"system-runtime", PluginManager::GetSystemRuntimePluginInfo,
+       PluginManager::SetSystemRuntimePluginEnabled}};
+
+  return PluginNamespaces;
+}
+
 template <typename Callback> struct PluginInstance {
   typedef Callback CallbackType;
 

--- a/lldb/source/Target/Statistics.cpp
+++ b/lldb/source/Target/Statistics.cpp
@@ -468,7 +468,8 @@ llvm::json::Value DebuggerStats::ReportStatistics(
 
   if (include_plugins) {
     json::Object plugin_stats;
-    for (const PluginNamespace &plugin_ns : PluginManager::GetPluginNamespaces()) {
+    for (const PluginNamespace &plugin_ns :
+         PluginManager::GetPluginNamespaces()) {
       json::Array namespace_stats;
 
       for (const RegisteredPluginInfo &plugin : plugin_ns.get_info()) {

--- a/lldb/source/Target/Statistics.cpp
+++ b/lldb/source/Target/Statistics.cpp
@@ -467,21 +467,7 @@ llvm::json::Value DebuggerStats::ReportStatistics(
   }
 
   if (include_plugins) {
-    json::Object plugin_stats;
-    for (const PluginNamespace &plugin_ns :
-         PluginManager::GetPluginNamespaces()) {
-      json::Array namespace_stats;
-
-      for (const RegisteredPluginInfo &plugin : plugin_ns.get_info()) {
-        json::Object plugin_json;
-        plugin_json.try_emplace("name", plugin.name);
-        plugin_json.try_emplace("enabled", plugin.enabled);
-
-        namespace_stats.emplace_back(std::move(plugin_json));
-      }
-      plugin_stats.try_emplace(plugin_ns.name, std::move(namespace_stats));
-    }
-    global_stats.try_emplace("plugins", std::move(plugin_stats));
+    global_stats.try_emplace("plugins", PluginManager::GetJSON());
   }
 
   return std::move(global_stats);

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -1022,3 +1022,89 @@ class TestCase(TestBase):
         all_targets_stats = self.get_stats("--all-targets")
         self.assertIsNotNone(self.find_module_in_metrics(main_exe, all_targets_stats))
         self.assertIsNotNone(self.find_module_in_metrics(second_exe, all_targets_stats))
+
+    # Return some level of the plugin stats hierarchy.
+    # Will return either the top-level node, the namespace node, or a specific
+    # plugin node based on requested values.
+    #
+    # If any of the requested keys are not found in the stats then return None.
+    #
+    # Plugin stats look like this:
+    #
+    # "plugins": {
+    #     "system-runtime": [
+    #         {
+    #             "enabled": true,
+    #             "name": "systemruntime-macosx"
+    #         }
+    #     ]
+    # },
+    def get_plugin_stats(self, debugger_stats, plugin_namespace=None, plugin_name=None):
+        # Get top level plugin stats.
+        if "plugins" not in debugger_stats:
+            return None
+        plugins = debugger_stats["plugins"]
+        if not plugin_namespace:
+            return plugins
+
+        # Plugin namespace stats.
+        if plugin_namespace not in plugins:
+            return None
+        plugins_for_namespace = plugins[plugin_namespace]
+        if not plugin_name:
+            return plugins_for_namespace
+
+        # Specific plugin stats.
+        for plugin in debugger_stats["plugins"][plugin_namespace]:
+            if plugin["name"] == plugin_name:
+                return plugin
+        return None
+
+    def test_plugin_stats(self):
+        """
+        Test "statistics dump" contains plugin info.
+        """
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+        target = self.createTestTarget(file_path=exe)
+        debugger_stats = self.get_stats()
+
+        # Verify that the statistics dump contains the plugin information.
+        plugins = self.get_plugin_stats(debugger_stats)
+        self.assertIsNotNone(plugins)
+
+        # Check for a known plugin namespace that should be in the stats.
+        system_runtime_plugins = self.get_plugin_stats(debugger_stats, "system-runtime")
+        self.assertIsNotNone(system_runtime_plugins)
+
+        # Validate the keys exists for the bottom-level plugin stats.
+        plugin_keys_exist = [
+            "name",
+            "enabled",
+        ]
+        for plugin in system_runtime_plugins:
+            self.verify_keys(
+                plugin, 'debugger_stats["plugins"]["system-runtime"]', plugin_keys_exist
+            )
+
+        # Check for a known plugin that is enabled by default.
+        system_runtime_macosx_plugin = self.get_plugin_stats(
+            debugger_stats, "system-runtime", "systemruntime-macosx"
+        )
+        self.assertIsNotNone(system_runtime_macosx_plugin)
+        self.assertTrue(system_runtime_macosx_plugin["enabled"])
+
+        # Now disable the plugin and check the stats again.
+        # The stats should show the plugin is disabled.
+        self.runCmd("plugin disable system-runtime.systemruntime-macosx")
+        debugger_stats = self.get_stats()
+        system_runtime_macosx_plugin = self.get_plugin_stats(
+            debugger_stats, "system-runtime", "systemruntime-macosx"
+        )
+        self.assertIsNotNone(system_runtime_macosx_plugin)
+        self.assertFalse(system_runtime_macosx_plugin["enabled"])
+
+        # Plugins should not show up in the stats when disabled with an option.
+        debugger_stats = self.get_stats("--plugins false")
+        plugins = self.get_plugin_stats(debugger_stats)
+        self.assertIsNone(plugins)

--- a/lldb/test/Shell/Commands/command-plugin-enable+disable.test
+++ b/lldb/test/Shell/Commands/command-plugin-enable+disable.test
@@ -1,0 +1,53 @@
+# This test validates the plugin enable and disable commands.
+# Currently it works only for system-runtime plugins and we only have one
+# system runtime plugin so testing is a bit limited.
+#
+# Note that commands that return errors will stop running a script, so we
+# have new RUN lines for any command that is expected to return an error.
+
+# RUN: %lldb -s %s -o exit 2>&1 | FileCheck %s
+
+# Test plugin list shows the default state which is expected to be enabled.
+plugin list
+# CHECK-LABEL: plugin list
+# CHECK: system-runtime
+# CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
+
+# Test plugin disable disables a plugin.
+plugin disable systemruntime-macosx
+# CHECK-LABEL: plugin disable systemruntime-macosx
+# CHECK: system-runtime
+# CHECK:  [-] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
+
+# Make sure plugin list shows it disabled as well.
+plugin list
+# CHECK: system-runtime
+# CHECK:  [-] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
+
+# Test plugin enable re-enables a plugin.
+plugin enable systemruntime-macosx
+# CHECK-LABEL: plugin enable systemruntime-macosx
+# CHECK: system-runtime
+# CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
+
+# Make sure plugin list shows it enabled as well.
+plugin list
+# CHECK: system-runtime
+# CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
+
+# Test plugin disable with wildcard works.
+plugin disable system*
+# CHECK-LABEL: plugin disable system*
+# CHECK: system-runtime
+# CHECK:  [-] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
+
+# Test plugin enable with wildcard works.
+plugin enable system*
+# CHECK-LABEL: plugin enable system*
+# CHECK: system-runtime
+# CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
+
+# Test plugin enable/disable for unknown plugin returns an error.
+# RUN: %lldb -o "plugin enable some-plugin-that-does-not-exist" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
+# RUN: %lldb -o "plugin disable some-plugin-that-does-not-exist" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
+# ERROR_PLUGIN_NOT_FOUND: error: Found no matching plugins

--- a/lldb/test/Shell/Commands/command-plugin-enable+disable.test
+++ b/lldb/test/Shell/Commands/command-plugin-enable+disable.test
@@ -57,15 +57,24 @@ plugin disable instrumentation-runtime
 # CHECK: instrumentation-runtime
 # CHECK:  [-] AddressSanitizer
 
+# Test plugin enable with multiple arguments.
+plugin enable system-runtime instrumentation-runtime
+# CHECK-LABEL: plugin enable system-runtime instrumentation-runtime
+CHECK: system-runtime
+CHECK:   [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries.
+CHECK: instrumentation-runtime
+CHECK:   [+] AddressSanitizer               AddressSanitizer instrumentation runtime plugin.
+
+
 # Test plugin enable/disable for unknown plugin returns an error.
 # RUN: %lldb -o "plugin enable some-plugin-that-does-not-exist" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
 # RUN: %lldb -o "plugin disable some-plugin-that-does-not-exist" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
+# RUN: %lldb -o "plugin enable system-runtime some-plugin-that-does-not-exist" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
 # ERROR_PLUGIN_NOT_FOUND: error: Found no matching plugins
 
 # Test plugin enable/disable requires a plugin name.
 # RUN: %lldb -o "plugin enable" 2>&1 | FileCheck %s --check-prefix=ERROR_ARGUMENTS_ENABLE
-# RUN: %lldb -o "plugin enable a b c" 2>&1 | FileCheck %s --check-prefix=ERROR_ARGUMENTS_ENABLE
-# ERROR_ARGUMENTS_ENABLE: error: 'plugin enable' requires one argument
+# ERROR_ARGUMENTS_ENABLE: error: 'plugin enable' requires one or more arguments
 
 # RUN: %lldb -o "plugin disable" 2>&1 | FileCheck %s --check-prefix=ERROR_ARGUMENTS_DISABLE
 # RUN: %lldb -o "plugin disable a b c" 2>&1 | FileCheck %s --check-prefix=ERROR_ARGUMENTS_DISABLE

--- a/lldb/test/Shell/Commands/command-plugin-enable+disable.test
+++ b/lldb/test/Shell/Commands/command-plugin-enable+disable.test
@@ -47,6 +47,16 @@ plugin enable system-runtime
 # CHECK: system-runtime
 # CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
 
+# Test plugin enable/disable for instrumentation plugin works.
+plugin enable instrumentation-runtime
+# CHECK-LABEL: plugin enable instrumentation-runtime
+# CHECK: instrumentation-runtime
+# CHECK:  [+] AddressSanitizer
+plugin disable instrumentation-runtime
+# CHECK-LABEL: plugin disable instrumentation-runtime
+# CHECK: instrumentation-runtime
+# CHECK:  [-] AddressSanitizer
+
 # Test plugin enable/disable for unknown plugin returns an error.
 # RUN: %lldb -o "plugin enable some-plugin-that-does-not-exist" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
 # RUN: %lldb -o "plugin disable some-plugin-that-does-not-exist" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND

--- a/lldb/test/Shell/Commands/command-plugin-enable+disable.test
+++ b/lldb/test/Shell/Commands/command-plugin-enable+disable.test
@@ -60,11 +60,18 @@ plugin disable instrumentation-runtime
 # Test plugin enable with multiple arguments.
 plugin enable system-runtime instrumentation-runtime
 # CHECK-LABEL: plugin enable system-runtime instrumentation-runtime
-CHECK: system-runtime
-CHECK:   [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries.
-CHECK: instrumentation-runtime
-CHECK:   [+] AddressSanitizer               AddressSanitizer instrumentation runtime plugin.
+# CHECK: system-runtime
+# CHECK:   [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries.
+# CHECK: instrumentation-runtime
+# CHECK:   [+] AddressSanitizer               AddressSanitizer instrumentation runtime plugin.
 
+# Test plugin disable with multiple arguments.
+plugin disable system-runtime instrumentation-runtime
+# CHECK-LABEL: plugin disable system-runtime instrumentation-runtime
+# CHECK: system-runtime
+# CHECK:   [-] systemruntime-macosx           System runtime plugin for Mac OS X native libraries.
+# CHECK: instrumentation-runtime
+# CHECK:   [-] AddressSanitizer               AddressSanitizer instrumentation runtime plugin.
 
 # Test plugin enable/disable for unknown plugin returns an error.
 # RUN: %lldb -o "plugin enable some-plugin-that-does-not-exist" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
@@ -77,5 +84,4 @@ CHECK:   [+] AddressSanitizer               AddressSanitizer instrumentation run
 # ERROR_ARGUMENTS_ENABLE: error: 'plugin enable' requires one or more arguments
 
 # RUN: %lldb -o "plugin disable" 2>&1 | FileCheck %s --check-prefix=ERROR_ARGUMENTS_DISABLE
-# RUN: %lldb -o "plugin disable a b c" 2>&1 | FileCheck %s --check-prefix=ERROR_ARGUMENTS_DISABLE
-# ERROR_ARGUMENTS_DISABLE: error: 'plugin disable' requires one argument
+# ERROR_ARGUMENTS_DISABLE: error: 'plugin disable' requires one or more arguments

--- a/lldb/test/Shell/Commands/command-plugin-enable+disable.test
+++ b/lldb/test/Shell/Commands/command-plugin-enable+disable.test
@@ -51,3 +51,12 @@ plugin enable system-runtime
 # RUN: %lldb -o "plugin enable some-plugin-that-does-not-exist" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
 # RUN: %lldb -o "plugin disable some-plugin-that-does-not-exist" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
 # ERROR_PLUGIN_NOT_FOUND: error: Found no matching plugins
+
+# Test plugin enable/disable requires a plugin name.
+# RUN: %lldb -o "plugin enable" 2>&1 | FileCheck %s --check-prefix=ERROR_ARGUMENTS_ENABLE
+# RUN: %lldb -o "plugin enable a b c" 2>&1 | FileCheck %s --check-prefix=ERROR_ARGUMENTS_ENABLE
+# ERROR_ARGUMENTS_ENABLE: error: 'plugin enable' requires one argument
+
+# RUN: %lldb -o "plugin disable" 2>&1 | FileCheck %s --check-prefix=ERROR_ARGUMENTS_DISABLE
+# RUN: %lldb -o "plugin disable a b c" 2>&1 | FileCheck %s --check-prefix=ERROR_ARGUMENTS_DISABLE
+# ERROR_ARGUMENTS_DISABLE: error: 'plugin disable' requires one argument

--- a/lldb/test/Shell/Commands/command-plugin-enable+disable.test
+++ b/lldb/test/Shell/Commands/command-plugin-enable+disable.test
@@ -14,8 +14,8 @@ plugin list
 # CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
 
 # Test plugin disable disables a plugin.
-plugin disable systemruntime-macosx
-# CHECK-LABEL: plugin disable systemruntime-macosx
+plugin disable system-runtime.systemruntime-macosx
+# CHECK-LABEL: plugin disable system-runtime.systemruntime-macosx
 # CHECK: system-runtime
 # CHECK:  [-] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
 
@@ -25,8 +25,8 @@ plugin list
 # CHECK:  [-] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
 
 # Test plugin enable re-enables a plugin.
-plugin enable systemruntime-macosx
-# CHECK-LABEL: plugin enable systemruntime-macosx
+plugin enable system-runtime.systemruntime-macosx
+# CHECK-LABEL: plugin enable system-runtime.systemruntime-macosx
 # CHECK: system-runtime
 # CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
 
@@ -35,15 +35,15 @@ plugin list
 # CHECK: system-runtime
 # CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
 
-# Test plugin disable with wildcard works.
-plugin disable system*
-# CHECK-LABEL: plugin disable system*
+# Test plugin disable with namespace works.
+plugin disable system-runtime
+# CHECK-LABEL: plugin disable system-runtime
 # CHECK: system-runtime
 # CHECK:  [-] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
 
-# Test plugin enable with wildcard works.
-plugin enable system*
-# CHECK-LABEL: plugin enable system*
+# Test plugin enable with namespace works.
+plugin enable system-runtime
+# CHECK-LABEL: plugin enable system-runtime
 # CHECK: system-runtime
 # CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
 

--- a/lldb/test/Shell/Commands/command-plugin-list.test
+++ b/lldb/test/Shell/Commands/command-plugin-list.test
@@ -1,0 +1,51 @@
+# This test validates the plugin list command.
+# Currently it works only for system-runtime plugins and we only have one
+# system runtime plugin so testing is a bit limited.
+#
+# Note that commands that return errors will stop running a script, so we
+# have new RUN lines for any command that is expected to return an error.
+
+# RUN: %lldb -s %s -o exit 2>&1 | FileCheck %s
+
+# Test plugin list without an argument will list all plugins.
+plugin list
+# CHECK-LABEL: plugin list
+# CHECK: system-runtime
+# CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
+
+# Test plugin list with an argument will match a plugin name by substring.
+plugin list macosx
+# CHECK-LABEL: plugin list macosx
+# CHECK: system-runtime
+# CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
+
+# Test plugin exact list works with fully qualified name.
+plugin list -x system-runtime.systemruntime-macosx
+# CHECK-LABEL: plugin list -x system-runtime.systemruntime-macosx
+# CHECK: system-runtime
+# CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
+
+# Test plugin glob list works with fully qualified name.
+plugin list system-runtime.systemruntime-macosx
+# CHECK-LABEL: plugin list system-runtime.systemruntime-macosx
+# CHECK: system-runtime
+# CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
+
+# Test plugin exact list still allows glob patterns.
+plugin list -x system*
+# CHECK-LABEL: plugin list -x system*
+# CHECK: system-runtime
+# CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
+
+# Test plugin glob list still allows glob patterns.
+plugin list system-runtime.*
+# CHECK-LABEL: plugin list system-runtime.*
+# CHECK: system-runtime
+# CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
+
+# Test plugin list can disable implicit glob patterns.
+# RUN: %lldb -o "plugin list -x macosx" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
+
+# Test plugin list for unknown plugin returns an error.
+# RUN: %lldb -o "plugin list some-plugin-that-does-not-exist" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
+# ERROR_PLUGIN_NOT_FOUND: error: Found no matching plugins

--- a/lldb/test/Shell/Commands/command-plugin-list.test
+++ b/lldb/test/Shell/Commands/command-plugin-list.test
@@ -31,8 +31,8 @@ plugin list --json
 # CHECK: {
 # CHECK:  "system-runtime": [
 # CHECK:    {
-# CHECK:      "enabled": true,
-# CHECK:      "name": "systemruntime-macosx"
+# CHECK-DAG:  "enabled": true,
+# CHECK-DAG:  "name": "systemruntime-macosx"
 # CHECK:    }
 # CHECK:  ]
 # CHECK: }

--- a/lldb/test/Shell/Commands/command-plugin-list.test
+++ b/lldb/test/Shell/Commands/command-plugin-list.test
@@ -12,6 +12,8 @@ plugin list
 # CHECK-LABEL: plugin list
 # CHECK: system-runtime
 # CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
+# CHECK: instrumentation-runtime
+# CHECK:  [+] AddressSanitizer               AddressSanitizer instrumentation runtime plugin.
 
 # Test plugin list works with fully qualified name.
 plugin list system-runtime.systemruntime-macosx
@@ -29,13 +31,22 @@ plugin list system-runtime
 plugin list --json
 # CHECK-LABEL plugin list --json
 # CHECK: {
+# CHECK-DAG:  "system-runtime":
+# CHECK-DAG:  "instrumentation-runtime":
+# CHECK: }
+
+# Test json output for plugin list with a namespace
+plugin list system-runtime --json
+# CHECK-LABEL plugin list --json
+# CHECK: {
 # CHECK:  "system-runtime": [
 # CHECK:    {
-# CHECK-DAG:  "enabled": true,
+# CHECK-DAG:  "enabled": true
 # CHECK-DAG:  "name": "systemruntime-macosx"
 # CHECK:    }
 # CHECK:  ]
 # CHECK: }
+
 
 # Test plugin list does not match a plugin name by substring.
 # RUN: %lldb -o "plugin list macosx" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND

--- a/lldb/test/Shell/Commands/command-plugin-list.test
+++ b/lldb/test/Shell/Commands/command-plugin-list.test
@@ -27,12 +27,20 @@ plugin list system-runtime
 # CHECK: system-runtime
 # CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
 
+# Test plugin list on multiple args works.
+plugin list system-runtime instrumentation-runtime.AddressSanitizer
+# CHECK-LABEL: plugin list system-runtime instrumentation-runtime.AddressSanitizer
+# CHECK: system-runtime
+# CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
+# CHECK: instrumentation-runtime
+# CHECK:  [+] AddressSanitizer               AddressSanitizer instrumentation runtime plugin.
+
 # Test json output for plugin list.
 plugin list --json
 # CHECK-LABEL plugin list --json
 # CHECK: {
-# CHECK-DAG:  "system-runtime":
 # CHECK-DAG:  "instrumentation-runtime":
+# CHECK-DAG:  "system-runtime":
 # CHECK: }
 
 # Test json output for plugin list with a namespace
@@ -47,6 +55,15 @@ plugin list system-runtime --json
 # CHECK:  ]
 # CHECK: }
 
+# Test json output for listing multiple plugins
+plugin list --json system-runtime instrumentation-runtime.AddressSanitizer
+# CHECK-LABEL plugin list --json system-runtime instrumentation-runtime.AddressSanitizer
+# CHECK: {
+# CHECK-DAG:  "instrumentation-runtime":
+# CHECK-DAG:    "name": "AddressSanitizer"
+# CHECK-DAG:  "system-runtime":
+# CHECK: }
+
 
 # Test plugin list does not match a plugin name by substring.
 # RUN: %lldb -o "plugin list macosx" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
@@ -54,10 +71,12 @@ plugin list system-runtime --json
 # Test plugin list does not match a plugin namespace by substring.
 # RUN: %lldb -o "plugin list system-runtime." 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
 
+# Test plugin list returns an error for unknown second argument
+# RUN: %lldb -o "plugin list system-runtime foo" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
+
+# Test plugin list returns an error for unknown second argument
+# RUN: %lldb -o "plugin list --json system-runtime foo" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
+
 # Test plugin list for unknown plugin returns an error.
 # RUN: %lldb -o "plugin list some-plugin-that-does-not-exist" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
 # ERROR_PLUGIN_NOT_FOUND: error: Found no matching plugins
-
-# Test plugin list fails on multiple arguments.
-# RUN: %lldb -o "plugin list a b c" 2>&1 | FileCheck %s --check-prefix=ERROR_ARGUMENTS
-# ERROR_ARGUMENTS: error: 'plugin list' requires zero or one arguments

--- a/lldb/test/Shell/Commands/command-plugin-list.test
+++ b/lldb/test/Shell/Commands/command-plugin-list.test
@@ -34,3 +34,7 @@ plugin list system-runtime
 # Test plugin list for unknown plugin returns an error.
 # RUN: %lldb -o "plugin list some-plugin-that-does-not-exist" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
 # ERROR_PLUGIN_NOT_FOUND: error: Found no matching plugins
+
+# Test plugin list fails on multiple arguments.
+# RUN: %lldb -o "plugin list a b c" 2>&1 | FileCheck %s --check-prefix=ERROR_ARGUMENTS
+# ERROR_ARGUMENTS: error: 'plugin list' requires zero or one arguments

--- a/lldb/test/Shell/Commands/command-plugin-list.test
+++ b/lldb/test/Shell/Commands/command-plugin-list.test
@@ -25,6 +25,18 @@ plugin list system-runtime
 # CHECK: system-runtime
 # CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
 
+# Test json output for plugin list.
+plugin list --json
+# CHECK-LABEL plugin list --json
+# CHECK: {
+# CHECK:  "system-runtime": [
+# CHECK:    {
+# CHECK:      "enabled": true,
+# CHECK:      "name": "systemruntime-macosx"
+# CHECK:    }
+# CHECK:  ]
+# CHECK: }
+
 # Test plugin list does not match a plugin name by substring.
 # RUN: %lldb -o "plugin list macosx" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
 

--- a/lldb/test/Shell/Commands/command-plugin-list.test
+++ b/lldb/test/Shell/Commands/command-plugin-list.test
@@ -13,38 +13,23 @@ plugin list
 # CHECK: system-runtime
 # CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
 
-# Test plugin list with an argument will match a plugin name by substring.
-plugin list macosx
-# CHECK-LABEL: plugin list macosx
-# CHECK: system-runtime
-# CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
-
-# Test plugin exact list works with fully qualified name.
-plugin list -x system-runtime.systemruntime-macosx
-# CHECK-LABEL: plugin list -x system-runtime.systemruntime-macosx
-# CHECK: system-runtime
-# CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
-
-# Test plugin glob list works with fully qualified name.
+# Test plugin list works with fully qualified name.
 plugin list system-runtime.systemruntime-macosx
 # CHECK-LABEL: plugin list system-runtime.systemruntime-macosx
 # CHECK: system-runtime
 # CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
 
-# Test plugin exact list still allows glob patterns.
-plugin list -x system*
-# CHECK-LABEL: plugin list -x system*
+# Test plugin list on plugin namespace works.
+plugin list system-runtime
+# CHECK-LABEL: plugin list system-runtime
 # CHECK: system-runtime
 # CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
 
-# Test plugin glob list still allows glob patterns.
-plugin list system-runtime.*
-# CHECK-LABEL: plugin list system-runtime.*
-# CHECK: system-runtime
-# CHECK:  [+] systemruntime-macosx           System runtime plugin for Mac OS X native libraries
+# Test plugin list does not match a plugin name by substring.
+# RUN: %lldb -o "plugin list macosx" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
 
-# Test plugin list can disable implicit glob patterns.
-# RUN: %lldb -o "plugin list -x macosx" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
+# Test plugin list does not match a plugin namespace by substring.
+# RUN: %lldb -o "plugin list system-runtime." 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND
 
 # Test plugin list for unknown plugin returns an error.
 # RUN: %lldb -o "plugin list some-plugin-that-does-not-exist" 2>&1 | FileCheck %s --check-prefix=ERROR_PLUGIN_NOT_FOUND

--- a/lldb/unittests/Core/PluginManagerTest.cpp
+++ b/lldb/unittests/Core/PluginManagerTest.cpp
@@ -426,7 +426,7 @@ TEST_F(PluginManagerTest, JsonFormat) {
 
   // We should have a "system-runtime" array in the top-level object.
   llvm::json::Array *maybe_array = obj.getArray("system-runtime");
-  ASSERT_TRUE(maybe_array!= nullptr);
+  ASSERT_TRUE(maybe_array != nullptr);
   auto &array = *maybe_array;
   ASSERT_EQ(array.size(), 3u);
 
@@ -460,7 +460,8 @@ TEST_F(PluginManagerTest, JsonFormat) {
   ASSERT_TRUE(array[1].getAsObject()->getString("name") == "c");
 
   // Filtering the JSON output should only include the matching plugins.
-  array = *PluginManager::GetJSON("system-runtime.c").getArray("system-runtime");
+  array =
+      *PluginManager::GetJSON("system-runtime.c").getArray("system-runtime");
   ASSERT_EQ(array.size(), 1u);
   ASSERT_TRUE(array[0].getAsObject()->getString("name") == "c");
 

--- a/lldb/unittests/Core/PluginManagerTest.cpp
+++ b/lldb/unittests/Core/PluginManagerTest.cpp
@@ -379,3 +379,25 @@ TEST_F(PluginManagerTest, UnRegisterSystemRuntimePluginChangesOrder) {
   ASSERT_EQ(PluginManager::GetSystemRuntimeCreateCallbackAtIndex(2),
             CreateSystemRuntimePluginB);
 }
+
+TEST_F(PluginManagerTest, MatchPluginName) {
+  PluginNamespace Foo{"foo", nullptr, nullptr};
+  RegisteredPluginInfo Bar{"bar", "bar plugin ", true};
+  RegisteredPluginInfo Baz{"baz", "baz plugin ", true};
+
+  // Empty pattern matches everything.
+  ASSERT_TRUE(PluginManager::MatchPluginName("", Foo, Bar));
+
+  // Plugin namespace matches all plugins in that namespace.
+  ASSERT_TRUE(PluginManager::MatchPluginName("foo", Foo, Bar));
+  ASSERT_TRUE(PluginManager::MatchPluginName("foo", Foo, Baz));
+
+  // Fully qualified plugin name matches only that plugin.
+  ASSERT_TRUE(PluginManager::MatchPluginName("foo.bar", Foo, Bar));
+  ASSERT_FALSE(PluginManager::MatchPluginName("foo.baz", Foo, Bar));
+
+  // Prefix match should not match.
+  ASSERT_FALSE(PluginManager::MatchPluginName("f", Foo, Bar));
+  ASSERT_FALSE(PluginManager::MatchPluginName("foo.", Foo, Bar));
+  ASSERT_FALSE(PluginManager::MatchPluginName("foo.ba", Foo, Bar));
+}


### PR DESCRIPTION
This commit adds three new commands for managing plugins. The `list` command will show which plugins are currently registered and their enabled state. The `enable` and `disable` commands can be used to enable or disable plugins.

A disabled plugin will not show up to the PluginManager when it iterates over available plugins of a particular type.

The purpose of these commands is to provide more visibility into registered plugins and allow users to disable plugins for experimental perf reasons.

There are a few limitations to the current implementation

  1. Only SystemRuntime and InstrumentationRuntime plugins are currently supported. We can easily extend the existing implementation to support more types. The scope was limited to these plugins to keep the PR size manageable.
  2. Only "statically" know plugin types are supported (i.e. those managed by the PluginManager and not from `plugin load`). It is possibly we could support dynamic plugins as well, but I have not looked into it yet.