### PR TITLE
[NFC][LLVM][PowerPC] Cleanup pass initialization for PowerPC

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCBoolRetToInt.cpp
+++ b/llvm/lib/Target/PowerPC/PPCBoolRetToInt.cpp
@@ -178,9 +178,7 @@ class PPCBoolRetToInt : public FunctionPass {
  public:
   static char ID;
 
-  PPCBoolRetToInt() : FunctionPass(ID) {
-    initializePPCBoolRetToIntPass(*PassRegistry::getPassRegistry());
-  }
+  PPCBoolRetToInt() : FunctionPass(ID) {}
 
   bool runOnFunction(Function &F) override {
     if (skipFunction(F))

--- a/llvm/lib/Target/PowerPC/PPCBranchCoalescing.cpp
+++ b/llvm/lib/Target/PowerPC/PPCBranchCoalescing.cpp
@@ -160,9 +160,7 @@ class PPCBranchCoalescing : public MachineFunctionPass {
 public:
   static char ID;
 
-  PPCBranchCoalescing() : MachineFunctionPass(ID) {
-    initializePPCBranchCoalescingPass(*PassRegistry::getPassRegistry());
-  }
+  PPCBranchCoalescing() : MachineFunctionPass(ID) {}
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.addRequired<MachineDominatorTreeWrapperPass>();

--- a/llvm/lib/Target/PowerPC/PPCBranchSelector.cpp
+++ b/llvm/lib/Target/PowerPC/PPCBranchSelector.cpp
@@ -37,9 +37,7 @@ STATISTIC(NumPrefixedAligned,
 namespace {
   struct PPCBSel : public MachineFunctionPass {
     static char ID;
-    PPCBSel() : MachineFunctionPass(ID) {
-      initializePPCBSelPass(*PassRegistry::getPassRegistry());
-    }
+    PPCBSel() : MachineFunctionPass(ID) {}
 
     // The sizes of the basic blocks in the function (the first
     // element of the pair); the second element of the pair is the amount of the

--- a/llvm/lib/Target/PowerPC/PPCCTRLoops.cpp
+++ b/llvm/lib/Target/PowerPC/PPCCTRLoops.cpp
@@ -57,9 +57,7 @@ class PPCCTRLoops : public MachineFunctionPass {
 public:
   static char ID;
 
-  PPCCTRLoops() : MachineFunctionPass(ID) {
-    initializePPCCTRLoopsPass(*PassRegistry::getPassRegistry());
-  }
+  PPCCTRLoops() : MachineFunctionPass(ID) {}
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.addRequired<MachineLoopInfoWrapperPass>();

--- a/llvm/lib/Target/PowerPC/PPCEarlyReturn.cpp
+++ b/llvm/lib/Target/PowerPC/PPCEarlyReturn.cpp
@@ -33,9 +33,7 @@ namespace {
   // branch-to-blr sequences.
   struct PPCEarlyReturn : public MachineFunctionPass {
     static char ID;
-    PPCEarlyReturn() : MachineFunctionPass(ID) {
-      initializePPCEarlyReturnPass(*PassRegistry::getPassRegistry());
-    }
+    PPCEarlyReturn() : MachineFunctionPass(ID) {}
 
     const TargetInstrInfo *TII;
 

--- a/llvm/lib/Target/PowerPC/PPCExpandAtomicPseudoInsts.cpp
+++ b/llvm/lib/Target/PowerPC/PPCExpandAtomicPseudoInsts.cpp
@@ -32,9 +32,7 @@ public:
   const PPCRegisterInfo *TRI;
   static char ID;
 
-  PPCExpandAtomicPseudo() : MachineFunctionPass(ID) {
-    initializePPCExpandAtomicPseudoPass(*PassRegistry::getPassRegistry());
-  }
+  PPCExpandAtomicPseudo() : MachineFunctionPass(ID) {}
 
   bool runOnMachineFunction(MachineFunction &MF) override;
 

--- a/llvm/lib/Target/PowerPC/PPCLoopInstrFormPrep.cpp
+++ b/llvm/lib/Target/PowerPC/PPCLoopInstrFormPrep.cpp
@@ -221,13 +221,7 @@ namespace {
   public:
     static char ID; // Pass ID, replacement for typeid
 
-    PPCLoopInstrFormPrep() : FunctionPass(ID) {
-      initializePPCLoopInstrFormPrepPass(*PassRegistry::getPassRegistry());
-    }
-
-    PPCLoopInstrFormPrep(PPCTargetMachine &TM) : FunctionPass(ID), TM(&TM) {
-      initializePPCLoopInstrFormPrepPass(*PassRegistry::getPassRegistry());
-    }
+    PPCLoopInstrFormPrep(PPCTargetMachine &TM) : FunctionPass(ID), TM(&TM) {}
 
     void getAnalysisUsage(AnalysisUsage &AU) const override {
       AU.addPreserved<DominatorTreeWrapperPass>();

--- a/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
+++ b/llvm/lib/Target/PowerPC/PPCMIPeephole.cpp
@@ -112,9 +112,7 @@ struct PPCMIPeephole : public MachineFunctionPass {
   MachineRegisterInfo *MRI;
   LiveVariables *LV;
 
-  PPCMIPeephole() : MachineFunctionPass(ID) {
-    initializePPCMIPeepholePass(*PassRegistry::getPassRegistry());
-  }
+  PPCMIPeephole() : MachineFunctionPass(ID) {}
 
 private:
   MachineDominatorTree *MDT;

--- a/llvm/lib/Target/PowerPC/PPCPreEmitPeephole.cpp
+++ b/llvm/lib/Target/PowerPC/PPCPreEmitPeephole.cpp
@@ -95,9 +95,7 @@ static bool hasPCRelativeForm(MachineInstr &Use) {
   class PPCPreEmitPeephole : public MachineFunctionPass {
   public:
     static char ID;
-    PPCPreEmitPeephole() : MachineFunctionPass(ID) {
-      initializePPCPreEmitPeepholePass(*PassRegistry::getPassRegistry());
-    }
+    PPCPreEmitPeephole() : MachineFunctionPass(ID) {}
 
     void getAnalysisUsage(AnalysisUsage &AU) const override {
       MachineFunctionPass::getAnalysisUsage(AU);

--- a/llvm/lib/Target/PowerPC/PPCReduceCRLogicals.cpp
+++ b/llvm/lib/Target/PowerPC/PPCReduceCRLogicals.cpp
@@ -104,6 +104,7 @@ static void addIncomingValuesToPHIs(MachineBasicBlock *Successor,
   }
 }
 
+namespace {
 struct BlockSplitInfo {
   MachineInstr *OrigBranch;
   MachineInstr *SplitBefore;
@@ -127,6 +128,7 @@ struct BlockSplitInfo {
     return true;
   }
 };
+} // end anonymous namespace
 
 /// Splits a MachineBasicBlock to branch before \p SplitBefore. The original
 /// branch is \p OrigBranch. The target of the new branch can either be the same
@@ -350,7 +352,6 @@ computeBranchTargetAndInversion(unsigned CROp, unsigned BROp, bool UsingDef1,
 namespace {
 
 class PPCReduceCRLogicals : public MachineFunctionPass {
-
 public:
   static char ID;
   struct CRLogicalOpInfo {
@@ -405,9 +406,7 @@ private:
   }
 
 public:
-  PPCReduceCRLogicals() : MachineFunctionPass(ID) {
-    initializePPCReduceCRLogicalsPass(*PassRegistry::getPassRegistry());
-  }
+  PPCReduceCRLogicals() : MachineFunctionPass(ID) {}
 
   MachineInstr *lookThroughCRCopy(unsigned Reg, unsigned &Subreg,
                                   MachineInstr *&CpDef);
@@ -431,6 +430,7 @@ public:
     MachineFunctionPass::getAnalysisUsage(AU);
   }
 };
+} // end anonymous namespace
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
 LLVM_DUMP_METHOD void PPCReduceCRLogicals::CRLogicalOpInfo::dump() {
@@ -725,8 +725,6 @@ void PPCReduceCRLogicals::collectCRLogicals() {
     }
   }
 }
-
-} // end anonymous namespace
 
 INITIALIZE_PASS_BEGIN(PPCReduceCRLogicals, DEBUG_TYPE,
                       "PowerPC Reduce CR logical Operation", false, false)

--- a/llvm/lib/Target/PowerPC/PPCTLSDynamicCall.cpp
+++ b/llvm/lib/Target/PowerPC/PPCTLSDynamicCall.cpp
@@ -38,9 +38,7 @@ using namespace llvm;
 namespace {
   struct PPCTLSDynamicCall : public MachineFunctionPass {
     static char ID;
-    PPCTLSDynamicCall() : MachineFunctionPass(ID) {
-      initializePPCTLSDynamicCallPass(*PassRegistry::getPassRegistry());
-    }
+    PPCTLSDynamicCall() : MachineFunctionPass(ID) {}
 
     const PPCInstrInfo *TII;
 

--- a/llvm/lib/Target/PowerPC/PPCTOCRegDeps.cpp
+++ b/llvm/lib/Target/PowerPC/PPCTOCRegDeps.cpp
@@ -80,11 +80,9 @@ namespace {
   // branch-to-blr sequences.
   struct PPCTOCRegDeps : public MachineFunctionPass {
     static char ID;
-    PPCTOCRegDeps() : MachineFunctionPass(ID) {
-      initializePPCTOCRegDepsPass(*PassRegistry::getPassRegistry());
-    }
+    PPCTOCRegDeps() : MachineFunctionPass(ID) {}
 
-protected:
+  protected:
     bool hasTOCLoReloc(const MachineInstr &MI) {
       if (MI.getOpcode() == PPC::LDtocL || MI.getOpcode() == PPC::ADDItocL8 ||
           MI.getOpcode() == PPC::LWZtocL)

--- a/llvm/lib/Target/PowerPC/PPCTargetMachine.cpp
+++ b/llvm/lib/Target/PowerPC/PPCTargetMachine.cpp
@@ -561,7 +561,6 @@ void PPCPassConfig::addMachineSSAOptimization() {
 
 void PPCPassConfig::addPreRegAlloc() {
   if (getOptLevel() != CodeGenOptLevel::None) {
-    initializePPCVSXFMAMutatePass(*PassRegistry::getPassRegistry());
     insertPass(VSXFMAMutateEarly ? &RegisterCoalescerID : &MachineSchedulerID,
                &PPCVSXFMAMutateID);
   }

--- a/llvm/lib/Target/PowerPC/PPCVSXCopy.cpp
+++ b/llvm/lib/Target/PowerPC/PPCVSXCopy.cpp
@@ -34,9 +34,7 @@ namespace {
   // copies into subregister copies with other restrictions.
   struct PPCVSXCopy : public MachineFunctionPass {
     static char ID;
-    PPCVSXCopy() : MachineFunctionPass(ID) {
-      initializePPCVSXCopyPass(*PassRegistry::getPassRegistry());
-    }
+    PPCVSXCopy() : MachineFunctionPass(ID) {}
 
     const TargetInstrInfo *TII;
 
@@ -151,7 +149,7 @@ public:
       MachineFunctionPass::getAnalysisUsage(AU);
     }
   };
-}
+  } // end anonymous namespace
 
 INITIALIZE_PASS(PPCVSXCopy, DEBUG_TYPE,
                 "PowerPC VSX Copy Legalization", false, false)

--- a/llvm/lib/Target/PowerPC/PPCVSXFMAMutate.cpp
+++ b/llvm/lib/Target/PowerPC/PPCVSXFMAMutate.cpp
@@ -55,9 +55,7 @@ namespace {
   // copies into subregister copies with other restrictions.
   struct PPCVSXFMAMutate : public MachineFunctionPass {
     static char ID;
-    PPCVSXFMAMutate() : MachineFunctionPass(ID) {
-      initializePPCVSXFMAMutatePass(*PassRegistry::getPassRegistry());
-    }
+    PPCVSXFMAMutate() : MachineFunctionPass(ID) {}
 
     LiveIntervals *LIS;
     const PPCInstrInfo *TII;

--- a/llvm/lib/Target/PowerPC/PPCVSXSwapRemoval.cpp
+++ b/llvm/lib/Target/PowerPC/PPCVSXSwapRemoval.cpp
@@ -110,9 +110,7 @@ struct PPCVSXSwapRemoval : public MachineFunctionPass {
   // Swap entries are represented by their VSEId fields.
   EquivalenceClasses<int> *EC;
 
-  PPCVSXSwapRemoval() : MachineFunctionPass(ID) {
-    initializePPCVSXSwapRemovalPass(*PassRegistry::getPassRegistry());
-  }
+  PPCVSXSwapRemoval() : MachineFunctionPass(ID) {}
 
 private:
   // Initialize data structures.
@@ -211,6 +209,7 @@ public:
     return Changed;
   }
 };
+} // end anonymous namespace
 
 // Initialize data structures for this pass.  In particular, clear the
 // swap vector and allocate the equivalence class mapping before
@@ -1060,8 +1059,6 @@ LLVM_DUMP_METHOD void PPCVSXSwapRemoval::dumpSwapVector() {
   dbgs() << "\n";
 }
 #endif
-
-} // end default namespace
 
 INITIALIZE_PASS_BEGIN(PPCVSXSwapRemoval, DEBUG_TYPE,
                       "PowerPC VSX Swap Removal", false, false)


### PR DESCRIPTION
- Remove calls to pass initialization from pass constructors.
- https://github.com/llvm/llvm-project/issues/111767