### PR TITLE
[NFC][LLVM][Hexagon] Cleanup pass initialization for Hexagon

### DIFF
--- a/llvm/lib/Target/Hexagon/Hexagon.h
+++ b/llvm/lib/Target/Hexagon/Hexagon.h
@@ -14,15 +14,104 @@
 #ifndef LLVM_LIB_TARGET_HEXAGON_HEXAGON_H
 #define LLVM_LIB_TARGET_HEXAGON_HEXAGON_H
 
+#include "llvm/Support/CodeGen.h"
+
 namespace llvm {
-  class HexagonTargetMachine;
-  class ImmutablePass;
-  class PassRegistry;
+class HexagonTargetMachine;
+class ImmutablePass;
+class PassRegistry;
+class FunctionPass;
+class Pass;
 
-  /// Creates a Hexagon-specific Target Transformation Info pass.
-  ImmutablePass *createHexagonTargetTransformInfoPass(const HexagonTargetMachine *TM);
+extern char &HexagonCopyHoistingID;
+extern char &HexagonExpandCondsetsID;
+extern char &HexagonTfrCleanupID;
+void initializeHexagonBitSimplifyPass(PassRegistry &);
+void initializeHexagonBranchRelaxationPass(PassRegistry &);
+void initializeHexagonCFGOptimizerPass(PassRegistry &);
+void initializeHexagonCommonGEPPass(PassRegistry &);
+void initializeHexagonCopyHoistingPass(PassRegistry &);
+void initializeHexagonConstExtendersPass(PassRegistry &);
+void initializeHexagonConstPropagationPass(PassRegistry &);
+void initializeHexagonCopyToCombinePass(PassRegistry &);
+void initializeHexagonDAGToDAGISelLegacyPass(PassRegistry &);
+void initializeHexagonEarlyIfConversionPass(PassRegistry &);
+void initializeHexagonExpandCondsetsPass(PassRegistry &);
+void initializeHexagonGenMemAbsolutePass(PassRegistry &);
+void initializeHexagonGenMuxPass(PassRegistry &);
+void initializeHexagonHardwareLoopsPass(PassRegistry &);
+void initializeHexagonLoopIdiomRecognizeLegacyPassPass(PassRegistry &);
+void initializeHexagonLoopAlignPass(PassRegistry &);
+void initializeHexagonLoopReschedulingPass(PassRegistry &);
+void initializeHexagonMaskPass(PassRegistry &);
+void initializeHexagonMergeActivateWeightPass(PassRegistry &);
+void initializeHexagonNewValueJumpPass(PassRegistry &);
+void initializeHexagonOptAddrModePass(PassRegistry &);
+void initializeHexagonPacketizerPass(PassRegistry &);
+void initializeHexagonRDFOptPass(PassRegistry &);
+void initializeHexagonSplitDoubleRegsPass(PassRegistry &);
+void initializeHexagonTfrCleanupPass(PassRegistry &);
+void initializeHexagonVExtractPass(PassRegistry &);
+void initializeHexagonVectorCombineLegacyPass(PassRegistry &);
+void initializeHexagonVectorLoopCarriedReuseLegacyPassPass(PassRegistry &);
+void initializeHexagonFixupHwLoopsPass(PassRegistry &);
+void initializeHexagonCallFrameInformationPass(PassRegistry &);
+void initializeHexagonGenExtractPass(PassRegistry &);
+void initializeHexagonGenInsertPass(PassRegistry &);
+void initializeHexagonGenPredicatePass(PassRegistry &);
+void initializeHexagonLoadWideningPass(PassRegistry &);
+void initializeHexagonStoreWideningPass(PassRegistry &);
+void initializeHexagonOptimizeSZextendsPass(PassRegistry &);
+void initializeHexagonPeepholePass(PassRegistry &);
+void initializeHexagonSplitConst32AndConst64Pass(PassRegistry &);
+void initializeHexagonVectorPrintPass(PassRegistry &);
 
-  void initializeHexagonDAGToDAGISelLegacyPass(PassRegistry &);
+Pass *createHexagonLoopIdiomPass();
+Pass *createHexagonVectorLoopCarriedReuseLegacyPass();
+
+/// Creates a Hexagon-specific Target Transformation Info pass.
+ImmutablePass *
+createHexagonTargetTransformInfoPass(const HexagonTargetMachine *TM);
+
+FunctionPass *createHexagonBitSimplify();
+FunctionPass *createHexagonBranchRelaxation();
+FunctionPass *createHexagonCallFrameInformation();
+FunctionPass *createHexagonCFGOptimizer();
+FunctionPass *createHexagonCommonGEP();
+FunctionPass *createHexagonConstExtenders();
+FunctionPass *createHexagonConstPropagationPass();
+FunctionPass *createHexagonCopyHoisting();
+FunctionPass *createHexagonCopyToCombine();
+FunctionPass *createHexagonEarlyIfConversion();
+FunctionPass *createHexagonFixupHwLoops();
+FunctionPass *createHexagonGenExtract();
+FunctionPass *createHexagonGenInsert();
+FunctionPass *createHexagonGenMemAbsolute();
+FunctionPass *createHexagonGenMux();
+FunctionPass *createHexagonGenPredicate();
+FunctionPass *createHexagonHardwareLoops();
+FunctionPass *createHexagonISelDag(HexagonTargetMachine &TM,
+                                   CodeGenOptLevel OptLevel);
+FunctionPass *createHexagonLoopAlign();
+FunctionPass *createHexagonLoopRescheduling();
+FunctionPass *createHexagonMask();
+FunctionPass *createHexagonMergeActivateWeight();
+FunctionPass *createHexagonNewValueJump();
+FunctionPass *createHexagonOptAddrMode();
+FunctionPass *createHexagonOptimizeSZextends();
+FunctionPass *createHexagonPacketizer(bool Minimal);
+FunctionPass *createHexagonPeephole();
+FunctionPass *createHexagonRDFOpt();
+FunctionPass *createHexagonSplitConst32AndConst64();
+FunctionPass *createHexagonSplitDoubleRegs();
+FunctionPass *createHexagonStoreWidening();
+FunctionPass *createHexagonLoadWidening();
+FunctionPass *createHexagonTfrCleanup();
+FunctionPass *createHexagonVectorCombineLegacyPass();
+FunctionPass *createHexagonVectorPrint();
+FunctionPass *createHexagonVExtract();
+FunctionPass *createHexagonExpandCondsets();
+
 } // end namespace llvm;
 
 #endif

--- a/llvm/lib/Target/Hexagon/HexagonBitSimplify.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonBitSimplify.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "BitTracker.h"
+#include "Hexagon.h"
 #include "HexagonBitTracker.h"
 #include "HexagonInstrInfo.h"
 #include "HexagonRegisterInfo.h"
@@ -49,13 +50,6 @@ static unsigned CountBitSplit = 0;
 
 static cl::opt<unsigned> RegisterSetLimit("hexbit-registerset-limit",
   cl::Hidden, cl::init(1000));
-
-namespace llvm {
-
-  void initializeHexagonBitSimplifyPass(PassRegistry& Registry);
-  FunctionPass *createHexagonBitSimplify();
-
-} // end namespace llvm
 
 namespace {
 
@@ -2897,22 +2891,13 @@ bool HexagonBitSimplify::runOnMachineFunction(MachineFunction &MF) {
 //   r5:4 = memd(r0++#8)
 // }:endloop0
 
-namespace llvm {
-
-  FunctionPass *createHexagonLoopRescheduling();
-  void initializeHexagonLoopReschedulingPass(PassRegistry&);
-
-} // end namespace llvm
-
 namespace {
 
   class HexagonLoopRescheduling : public MachineFunctionPass {
   public:
     static char ID;
 
-    HexagonLoopRescheduling() : MachineFunctionPass(ID) {
-      initializeHexagonLoopReschedulingPass(*PassRegistry::getPassRegistry());
-    }
+    HexagonLoopRescheduling() : MachineFunctionPass(ID) {}
 
     bool runOnMachineFunction(MachineFunction &MF) override;
 
@@ -2957,8 +2942,8 @@ namespace {
 
 char HexagonLoopRescheduling::ID = 0;
 
-INITIALIZE_PASS(HexagonLoopRescheduling, "hexagon-loop-resched",
-  "Hexagon Loop Rescheduling", false, false)
+INITIALIZE_PASS(HexagonLoopRescheduling, "hexagon-loop-resched-pass",
+                "Hexagon Loop Rescheduling", false, false)
 
 HexagonLoopRescheduling::PhiInfo::PhiInfo(MachineInstr &P,
       MachineBasicBlock &B) {

--- a/llvm/lib/Target/Hexagon/HexagonBranchRelaxation.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonBranchRelaxation.cpp
@@ -37,22 +37,13 @@ static cl::opt<uint32_t>
     BranchRelaxSafetyBuffer("branch-relax-safety-buffer", cl::init(200),
                             cl::Hidden, cl::desc("safety buffer size"));
 
-namespace llvm {
-
-  FunctionPass *createHexagonBranchRelaxation();
-  void initializeHexagonBranchRelaxationPass(PassRegistry&);
-
-} // end namespace llvm
-
 namespace {
 
   struct HexagonBranchRelaxation : public MachineFunctionPass {
   public:
     static char ID;
 
-    HexagonBranchRelaxation() : MachineFunctionPass(ID) {
-      initializeHexagonBranchRelaxationPass(*PassRegistry::getPassRegistry());
-    }
+    HexagonBranchRelaxation() : MachineFunctionPass(ID) {}
 
     bool runOnMachineFunction(MachineFunction &MF) override;
 

--- a/llvm/lib/Target/Hexagon/HexagonCFGOptimizer.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonCFGOptimizer.cpp
@@ -24,13 +24,6 @@ using namespace llvm;
 
 #define DEBUG_TYPE "hexagon_cfg"
 
-namespace llvm {
-
-FunctionPass *createHexagonCFGOptimizer();
-void initializeHexagonCFGOptimizerPass(PassRegistry&);
-
-} // end namespace llvm
-
 namespace {
 
 class HexagonCFGOptimizer : public MachineFunctionPass {
@@ -41,9 +34,7 @@ private:
 public:
   static char ID;
 
-  HexagonCFGOptimizer() : MachineFunctionPass(ID) {
-    initializeHexagonCFGOptimizerPass(*PassRegistry::getPassRegistry());
-  }
+  HexagonCFGOptimizer() : MachineFunctionPass(ID) {}
 
   StringRef getPassName() const override { return "Hexagon CFG Optimizer"; }
   bool runOnMachineFunction(MachineFunction &Fn) override;

--- a/llvm/lib/Target/Hexagon/HexagonCommonGEP.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonCommonGEP.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "Hexagon.h"
+
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/GraphTraits.h"
@@ -58,12 +60,6 @@ static cl::opt<bool> OptEnableInv("commgep-inv", cl::init(true), cl::Hidden);
 static cl::opt<bool> OptEnableConst("commgep-const", cl::init(true),
                                     cl::Hidden);
 
-namespace llvm {
-
-  void initializeHexagonCommonGEPPass(PassRegistry&);
-
-} // end namespace llvm
-
 namespace {
 
   struct GepNode;
@@ -97,9 +93,7 @@ namespace {
   public:
     static char ID;
 
-    HexagonCommonGEP() : FunctionPass(ID) {
-      initializeHexagonCommonGEPPass(*PassRegistry::getPassRegistry());
-    }
+    HexagonCommonGEP() : FunctionPass(ID) {}
 
     bool runOnFunction(Function &F) override;
     StringRef getPassName() const override { return "Hexagon Common GEP"; }

--- a/llvm/lib/Target/Hexagon/HexagonConstExtenders.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonConstExtenders.cpp
@@ -37,11 +37,6 @@ static cl::opt<unsigned>
     ReplaceLimit("hexagon-cext-limit", cl::init(0), cl::Hidden,
                  cl::desc("Maximum number of replacements"));
 
-namespace llvm {
-  void initializeHexagonConstExtendersPass(PassRegistry&);
-  FunctionPass *createHexagonConstExtenders();
-}
-
 static int32_t adjustUp(int32_t V, uint8_t A, uint8_t O) {
   assert(isPowerOf2_32(A));
   int32_t U = (V & -A) + O;

--- a/llvm/lib/Target/Hexagon/HexagonConstPropagation.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonConstPropagation.cpp
@@ -1827,13 +1827,6 @@ bool MachineConstEvaluator::evaluateSplati(const APInt &A1, unsigned Bits,
 // ----------------------------------------------------------------------
 // Hexagon-specific code.
 
-namespace llvm {
-
-  FunctionPass *createHexagonConstPropagationPass();
-  void initializeHexagonConstPropagationPass(PassRegistry &Registry);
-
-} // end namespace llvm
-
 namespace {
 
   class HexagonConstEvaluator : public MachineConstEvaluator {

--- a/llvm/lib/Target/Hexagon/HexagonCopyHoisting.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonCopyHoisting.cpp
@@ -28,20 +28,13 @@ using namespace llvm;
 static cl::opt<std::string> CPHoistFn("cphoistfn", cl::Hidden, cl::desc(""),
                                       cl::init(""));
 
-namespace llvm {
-void initializeHexagonCopyHoistingPass(PassRegistry &Registry);
-FunctionPass *createHexagonCopyHoisting();
-} // namespace llvm
-
 namespace {
 
 class HexagonCopyHoisting : public MachineFunctionPass {
 
 public:
   static char ID;
-  HexagonCopyHoisting() : MachineFunctionPass(ID), MFN(nullptr), MRI(nullptr) {
-    initializeHexagonCopyHoistingPass(*PassRegistry::getPassRegistry());
-  }
+  HexagonCopyHoisting() : MachineFunctionPass(ID), MFN(nullptr), MRI(nullptr) {}
 
   StringRef getPassName() const override { return "Hexagon Copy Hoisting"; }
 

--- a/llvm/lib/Target/Hexagon/HexagonCopyToCombine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonCopyToCombine.cpp
@@ -48,12 +48,6 @@ MaxNumOfInstsBetweenNewValueStoreAndTFR("max-num-inst-between-tfr-and-nv-store",
                    cl::desc("Maximum distance between a tfr feeding a store we "
                             "consider the store still to be newifiable"));
 
-namespace llvm {
-  FunctionPass *createHexagonCopyToCombine();
-  void initializeHexagonCopyToCombinePass(PassRegistry&);
-}
-
-
 namespace {
 
 class HexagonCopyToCombine : public MachineFunctionPass  {

--- a/llvm/lib/Target/Hexagon/HexagonEarlyIfConv.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonEarlyIfConv.cpp
@@ -91,13 +91,6 @@
 
 using namespace llvm;
 
-namespace llvm {
-
-  FunctionPass *createHexagonEarlyIfConversion();
-  void initializeHexagonEarlyIfConversionPass(PassRegistry& Registry);
-
-} // end namespace llvm
-
 static cl::opt<bool> EnableHexagonBP("enable-hexagon-br-prob", cl::Hidden,
   cl::init(true), cl::desc("Enable branch probability info"));
 static cl::opt<unsigned> SizeLimit("eif-limit", cl::init(6), cl::Hidden,

--- a/llvm/lib/Target/Hexagon/HexagonExpandCondsets.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonExpandCondsets.cpp
@@ -85,6 +85,7 @@
 // however, is that finding the locations where the implicit uses need
 // to be added, and updating the live ranges will be more involved.
 
+#include "Hexagon.h"
 #include "HexagonInstrInfo.h"
 #include "HexagonRegisterInfo.h"
 #include "llvm/ADT/DenseMap.h"
@@ -128,13 +129,6 @@ static cl::opt<unsigned> OptTfrLimit("expand-condsets-tfr-limit",
 static cl::opt<unsigned> OptCoaLimit("expand-condsets-coa-limit",
   cl::init(~0U), cl::Hidden, cl::desc("Max number of segment coalescings"));
 
-namespace llvm {
-
-  void initializeHexagonExpandCondsetsPass(PassRegistry&);
-  FunctionPass *createHexagonExpandCondsets();
-
-} // end namespace llvm
-
 namespace {
 
   class HexagonExpandCondsets : public MachineFunctionPass {
@@ -146,7 +140,6 @@ namespace {
         CoaLimitActive = true, CoaLimit = OptCoaLimit;
       if (OptTfrLimit.getPosition())
         TfrLimitActive = true, TfrLimit = OptTfrLimit;
-      initializeHexagonExpandCondsetsPass(*PassRegistry::getPassRegistry());
     }
 
     StringRef getPassName() const override { return "Hexagon Expand Condsets"; }
@@ -245,12 +238,7 @@ namespace {
 } // end anonymous namespace
 
 char HexagonExpandCondsets::ID = 0;
-
-namespace llvm {
-
-  char &HexagonExpandCondsetsID = HexagonExpandCondsets::ID;
-
-} // end namespace llvm
+char &llvm::HexagonExpandCondsetsID = HexagonExpandCondsets::ID;
 
 INITIALIZE_PASS_BEGIN(HexagonExpandCondsets, "expand-condsets",
   "Hexagon Expand Condsets", false, false)

--- a/llvm/lib/Target/Hexagon/HexagonFixupHwLoops.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonFixupHwLoops.cpp
@@ -28,19 +28,12 @@ static cl::opt<unsigned> MaxLoopRange(
     "hexagon-loop-range", cl::Hidden, cl::init(200),
     cl::desc("Restrict range of loopN instructions (testing only)"));
 
-namespace llvm {
-  FunctionPass *createHexagonFixupHwLoops();
-  void initializeHexagonFixupHwLoopsPass(PassRegistry&);
-}
-
 namespace {
   struct HexagonFixupHwLoops : public MachineFunctionPass {
   public:
     static char ID;
 
-    HexagonFixupHwLoops() : MachineFunctionPass(ID) {
-      initializeHexagonFixupHwLoopsPass(*PassRegistry::getPassRegistry());
-    }
+    HexagonFixupHwLoops() : MachineFunctionPass(ID) {}
 
     bool runOnMachineFunction(MachineFunction &MF) override;
 

--- a/llvm/lib/Target/Hexagon/HexagonFrameLowering.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonFrameLowering.cpp
@@ -196,23 +196,13 @@ static cl::opt<unsigned> SpillOptMax("spill-opt-max", cl::Hidden,
 static unsigned SpillOptCount = 0;
 #endif
 
-namespace llvm {
-
-  void initializeHexagonCallFrameInformationPass(PassRegistry&);
-  FunctionPass *createHexagonCallFrameInformation();
-
-} // end namespace llvm
-
 namespace {
 
   class HexagonCallFrameInformation : public MachineFunctionPass {
   public:
     static char ID;
 
-    HexagonCallFrameInformation() : MachineFunctionPass(ID) {
-      PassRegistry &PR = *PassRegistry::getPassRegistry();
-      initializeHexagonCallFrameInformationPass(PR);
-    }
+    HexagonCallFrameInformation() : MachineFunctionPass(ID) {}
 
     bool runOnMachineFunction(MachineFunction &MF) override;
 

--- a/llvm/lib/Target/Hexagon/HexagonGenExtract.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonGenExtract.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "Hexagon.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/GraphTraits.h"
 #include "llvm/IR/BasicBlock.h"
@@ -46,22 +47,13 @@ static cl::opt<bool> NoSR0("extract-nosr0", cl::init(true), cl::Hidden,
 static cl::opt<bool> NeedAnd("extract-needand", cl::init(true), cl::Hidden,
   cl::desc("Require & in extract patterns"));
 
-namespace llvm {
-
-void initializeHexagonGenExtractPass(PassRegistry&);
-FunctionPass *createHexagonGenExtract();
-
-} // end namespace llvm
-
 namespace {
 
   class HexagonGenExtract : public FunctionPass {
   public:
     static char ID;
 
-    HexagonGenExtract() : FunctionPass(ID) {
-      initializeHexagonGenExtractPass(*PassRegistry::getPassRegistry());
-    }
+    HexagonGenExtract() : FunctionPass(ID) {}
 
     StringRef getPassName() const override {
       return "Hexagon generate \"extract\" instructions";

--- a/llvm/lib/Target/Hexagon/HexagonGenInsert.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonGenInsert.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "BitTracker.h"
+#include "Hexagon.h"
 #include "HexagonBitTracker.h"
 #include "HexagonInstrInfo.h"
 #include "HexagonRegisterInfo.h"
@@ -493,22 +494,13 @@ namespace {
 
 } // end anonymous namespace
 
-namespace llvm {
-
-  void initializeHexagonGenInsertPass(PassRegistry&);
-  FunctionPass *createHexagonGenInsert();
-
-} // end namespace llvm
-
 namespace {
 
   class HexagonGenInsert : public MachineFunctionPass {
   public:
     static char ID;
 
-    HexagonGenInsert() : MachineFunctionPass(ID) {
-      initializeHexagonGenInsertPass(*PassRegistry::getPassRegistry());
-    }
+    HexagonGenInsert() : MachineFunctionPass(ID) {}
 
     StringRef getPassName() const override {
       return "Hexagon generate \"insert\" instructions";

--- a/llvm/lib/Target/Hexagon/HexagonGenMemAbsolute.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonGenMemAbsolute.cpp
@@ -31,11 +31,6 @@ STATISTIC(HexagonNumLoadAbsConversions,
 STATISTIC(HexagonNumStoreAbsConversions,
           "Number of Store instructions converted to absolute-set form");
 
-namespace llvm {
-FunctionPass *createHexagonGenMemAbsolute();
-void initializeHexagonGenMemAbsolutePass(PassRegistry &Registry);
-} // namespace llvm
-
 namespace {
 
 class HexagonGenMemAbsolute : public MachineFunctionPass {
@@ -45,9 +40,7 @@ class HexagonGenMemAbsolute : public MachineFunctionPass {
 
 public:
   static char ID;
-  HexagonGenMemAbsolute() : MachineFunctionPass(ID), TII(0), MRI(0), TRI(0) {
-    initializeHexagonGenMemAbsolutePass(*PassRegistry::getPassRegistry());
-  }
+  HexagonGenMemAbsolute() : MachineFunctionPass(ID), TII(0), MRI(0), TRI(0) {}
 
   StringRef getPassName() const override {
     return "Hexagon Generate Load/Store Set Absolute Address Instruction";

--- a/llvm/lib/Target/Hexagon/HexagonGenMux.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonGenMux.cpp
@@ -19,6 +19,7 @@
 // the predicate register, they cannot use the .new form. In such cases it
 // is better to collapse them back to a single MUX instruction.
 
+#include "Hexagon.h"
 #include "HexagonInstrInfo.h"
 #include "HexagonRegisterInfo.h"
 #include "HexagonSubtarget.h"
@@ -47,13 +48,6 @@
 #define DEBUG_TYPE "hexmux"
 
 using namespace llvm;
-
-namespace llvm {
-
-  FunctionPass *createHexagonGenMux();
-  void initializeHexagonGenMuxPass(PassRegistry& Registry);
-
-} // end namespace llvm
 
 // Initialize this to 0 to always prefer generating mux by default.
 static cl::opt<unsigned> MinPredDist("hexagon-gen-mux-threshold", cl::Hidden,

--- a/llvm/lib/Target/Hexagon/HexagonGenPredicate.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonGenPredicate.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "Hexagon.h"
 #include "HexagonInstrInfo.h"
 #include "HexagonSubtarget.h"
 #include "llvm/ADT/SetVector.h"
@@ -36,13 +37,6 @@
 #define DEBUG_TYPE "gen-pred"
 
 using namespace llvm;
-
-namespace llvm {
-
-  void initializeHexagonGenPredicatePass(PassRegistry& Registry);
-  FunctionPass *createHexagonGenPredicate();
-
-} // end namespace llvm
 
 namespace {
 
@@ -84,9 +78,7 @@ namespace {
   public:
     static char ID;
 
-    HexagonGenPredicate() : MachineFunctionPass(ID) {
-      initializeHexagonGenPredicatePass(*PassRegistry::getPassRegistry());
-    }
+    HexagonGenPredicate() : MachineFunctionPass(ID) {}
 
     StringRef getPassName() const override {
       return "Hexagon generate predicate operations";
@@ -128,11 +120,11 @@ namespace {
 
 char HexagonGenPredicate::ID = 0;
 
-INITIALIZE_PASS_BEGIN(HexagonGenPredicate, "hexagon-gen-pred",
-  "Hexagon generate predicate operations", false, false)
+INITIALIZE_PASS_BEGIN(HexagonGenPredicate, "hexagon-gen-pred-pass",
+                      "Hexagon generate predicate operations", false, false)
 INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
-INITIALIZE_PASS_END(HexagonGenPredicate, "hexagon-gen-pred",
-  "Hexagon generate predicate operations", false, false)
+INITIALIZE_PASS_END(HexagonGenPredicate, "hexagon-gen-pred-pass",
+                    "Hexagon generate predicate operations", false, false)
 
 bool HexagonGenPredicate::isPredReg(Register R) {
   if (!R.isVirtual())

--- a/llvm/lib/Target/Hexagon/HexagonHardwareLoops.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonHardwareLoops.cpp
@@ -24,6 +24,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "Hexagon.h"
 #include "HexagonInstrInfo.h"
 #include "HexagonSubtarget.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -85,13 +86,6 @@ static cl::opt<bool> SpecPreheader("hwloop-spec-preheader", cl::Hidden,
                                             "instructions"));
 
 STATISTIC(NumHWLoops, "Number of loops converted to hardware loops");
-
-namespace llvm {
-
-  FunctionPass *createHexagonHardwareLoops();
-  void initializeHexagonHardwareLoopsPass(PassRegistry&);
-
-} // end namespace llvm
 
 namespace {
 

--- a/llvm/lib/Target/Hexagon/HexagonLoadStoreWidening.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonLoadStoreWidening.cpp
@@ -36,6 +36,7 @@
 
 //===---------------------------------------------------------------------===//
 
+#include "Hexagon.h"
 #include "HexagonInstrInfo.h"
 #include "HexagonRegisterInfo.h"
 #include "HexagonSubtarget.h"
@@ -71,15 +72,6 @@ using namespace llvm;
 static cl::opt<unsigned> MaxMBBSizeForLoadStoreWidening(
     "max-bb-size-for-load-store-widening", cl::Hidden, cl::init(1000),
     cl::desc("Limit block size to analyze in load/store widening pass"));
-
-namespace llvm {
-
-FunctionPass *createHexagonStoreWidening();
-FunctionPass *createHexagonLoadWidening();
-void initializeHexagonStoreWideningPass(PassRegistry &);
-void initializeHexagonLoadWideningPass(PassRegistry &);
-
-} // end namespace llvm
 
 namespace {
 
@@ -135,9 +127,7 @@ private:
 struct HexagonStoreWidening : public MachineFunctionPass {
   static char ID;
 
-  HexagonStoreWidening() : MachineFunctionPass(ID) {
-    initializeHexagonStoreWideningPass(*PassRegistry::getPassRegistry());
-  }
+  HexagonStoreWidening() : MachineFunctionPass(ID) {}
 
   StringRef getPassName() const override { return "Hexagon Store Widening"; }
 
@@ -164,9 +154,7 @@ struct HexagonStoreWidening : public MachineFunctionPass {
 struct HexagonLoadWidening : public MachineFunctionPass {
   static char ID;
 
-  HexagonLoadWidening() : MachineFunctionPass(ID) {
-    initializeHexagonLoadWideningPass(*PassRegistry::getPassRegistry());
-  }
+  HexagonLoadWidening() : MachineFunctionPass(ID) {}
 
   StringRef getPassName() const override { return "Hexagon Load Widening"; }
 

--- a/llvm/lib/Target/Hexagon/HexagonLoopAlign.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonLoopAlign.cpp
@@ -9,6 +9,7 @@
 // number of instructions, set the prefLoopAlignment to 32 bytes (5).
 //===----------------------------------------------------------------------===//
 
+#include "Hexagon.h"
 #include "HexagonTargetMachine.h"
 #include "llvm/CodeGen/MachineBlockFrequencyInfo.h"
 #include "llvm/CodeGen/MachineBranchProbabilityInfo.h"
@@ -51,11 +52,6 @@ static cl::opt<uint32_t>
     LoopEdgeThreshold("hexagon-loop-edge-threshold", cl::Hidden, cl::init(7500),
                       cl::desc("Set hexagon loop align edge threshold"));
 
-namespace llvm {
-FunctionPass *createHexagonLoopAlign();
-void initializeHexagonLoopAlignPass(PassRegistry &);
-} // namespace llvm
-
 namespace {
 
 class HexagonLoopAlign : public MachineFunctionPass {
@@ -65,9 +61,7 @@ class HexagonLoopAlign : public MachineFunctionPass {
 
 public:
   static char ID;
-  HexagonLoopAlign() : MachineFunctionPass(ID) {
-    initializeHexagonLoopAlignPass(*PassRegistry::getPassRegistry());
-  }
+  HexagonLoopAlign() : MachineFunctionPass(ID) {}
   bool shouldBalignLoop(MachineBasicBlock &BB, bool AboveThres);
   bool isSingleLoop(MachineBasicBlock &MBB);
   bool attemptToBalignSmallLoop(MachineFunction &MF, MachineBasicBlock &MBB);

--- a/llvm/lib/Target/Hexagon/HexagonLoopIdiomRecognition.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonLoopIdiomRecognition.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "HexagonLoopIdiomRecognition.h"
+#include "Hexagon.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SetVector.h"
@@ -108,14 +109,6 @@ static cl::opt<unsigned> SimplifyLimit("hlir-simplify-limit", cl::init(10000),
 static const char *HexagonVolatileMemcpyName
   = "hexagon_memcpy_forward_vp4cp4n2";
 
-
-namespace llvm {
-
-void initializeHexagonLoopIdiomRecognizeLegacyPassPass(PassRegistry &);
-Pass *createHexagonLoopIdiomPass();
-
-} // end namespace llvm
-
 namespace {
 
 class HexagonLoopIdiomRecognize {
@@ -151,10 +144,7 @@ class HexagonLoopIdiomRecognizeLegacyPass : public LoopPass {
 public:
   static char ID;
 
-  explicit HexagonLoopIdiomRecognizeLegacyPass() : LoopPass(ID) {
-    initializeHexagonLoopIdiomRecognizeLegacyPassPass(
-        *PassRegistry::getPassRegistry());
-  }
+  explicit HexagonLoopIdiomRecognizeLegacyPass() : LoopPass(ID) {}
 
   StringRef getPassName() const override {
     return "Recognize Hexagon-specific loop idioms";

--- a/llvm/lib/Target/Hexagon/HexagonMask.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonMask.cpp
@@ -8,8 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define DEBUG_TYPE "mask"
-
+#include "Hexagon.h"
 #include "HexagonSubtarget.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/CodeGen/MachineFunction.h"
@@ -20,19 +19,15 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Target/TargetMachine.h"
 
+#define DEBUG_TYPE "mask"
+
 using namespace llvm;
 
-namespace llvm {
-FunctionPass *createHexagonMask();
-void initializeHexagonMaskPass(PassRegistry &);
-
+namespace {
 class HexagonMask : public MachineFunctionPass {
 public:
   static char ID;
-  HexagonMask() : MachineFunctionPass(ID) {
-    PassRegistry &Registry = *PassRegistry::getPassRegistry();
-    initializeHexagonMaskPass(Registry);
-  }
+  HexagonMask() : MachineFunctionPass(ID) {}
 
   StringRef getPassName() const override {
     return "Hexagon replace const ext tfri with mask";
@@ -43,6 +38,7 @@ private:
   const HexagonInstrInfo *HII;
   void replaceConstExtTransferImmWithMask(MachineFunction &MF);
 };
+} // end anonymous namespace
 
 char HexagonMask::ID = 0;
 
@@ -93,8 +89,6 @@ bool HexagonMask::runOnMachineFunction(MachineFunction &MF) {
 
   return true;
 }
-
-} // namespace llvm
 
 //===----------------------------------------------------------------------===//
 //                         Public Constructor Functions

--- a/llvm/lib/Target/Hexagon/HexagonNewValueJump.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonNewValueJump.cpp
@@ -63,13 +63,6 @@ static cl::opt<int> DbgNVJCount("nvj-count", cl::init(-1), cl::Hidden,
 static cl::opt<bool> DisableNewValueJumps("disable-nvjump", cl::Hidden,
                                           cl::desc("Disable New Value Jumps"));
 
-namespace llvm {
-
-FunctionPass *createHexagonNewValueJump();
-void initializeHexagonNewValueJumpPass(PassRegistry&);
-
-} // end namespace llvm
-
 namespace {
 
   struct HexagonNewValueJump : public MachineFunctionPass {

--- a/llvm/lib/Target/Hexagon/HexagonOptAddrMode.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonOptAddrMode.cpp
@@ -9,6 +9,7 @@
 // load/store instructions.
 //===----------------------------------------------------------------------===//
 
+#include "Hexagon.h"
 #include "HexagonInstrInfo.h"
 #include "HexagonSubtarget.h"
 #include "MCTargetDesc/HexagonBaseInfo.h"
@@ -49,13 +50,6 @@ static cl::opt<int> CodeGrowthLimit("hexagon-amode-growth-limit",
   "optimization"));
 
 extern cl::opt<unsigned> RDFFuncBlockLimit;
-
-namespace llvm {
-
-  FunctionPass *createHexagonOptAddrMode();
-  void initializeHexagonOptAddrModePass(PassRegistry&);
-
-} // end namespace llvm
 
 namespace {
 

--- a/llvm/lib/Target/Hexagon/HexagonOptimizeSZextends.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonOptimizeSZextends.cpp
@@ -23,18 +23,11 @@
 
 using namespace llvm;
 
-namespace llvm {
-  FunctionPass *createHexagonOptimizeSZextends();
-  void initializeHexagonOptimizeSZextendsPass(PassRegistry&);
-}
-
 namespace {
   struct HexagonOptimizeSZextends : public FunctionPass {
   public:
     static char ID;
-    HexagonOptimizeSZextends() : FunctionPass(ID) {
-      initializeHexagonOptimizeSZextendsPass(*PassRegistry::getPassRegistry());
-    }
+    HexagonOptimizeSZextends() : FunctionPass(ID) {}
     bool runOnFunction(Function &F) override;
 
     StringRef getPassName() const override { return "Remove sign extends"; }

--- a/llvm/lib/Target/Hexagon/HexagonPeephole.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonPeephole.cpp
@@ -68,11 +68,6 @@ static cl::opt<bool>
                       cl::init(true),
                       cl::desc("Disable Optimization of extensions to i64."));
 
-namespace llvm {
-  FunctionPass *createHexagonPeephole();
-  void initializeHexagonPeepholePass(PassRegistry&);
-}
-
 namespace {
   struct HexagonPeephole : public MachineFunctionPass {
     const HexagonInstrInfo    *QII;
@@ -81,9 +76,7 @@ namespace {
 
   public:
     static char ID;
-    HexagonPeephole() : MachineFunctionPass(ID) {
-      initializeHexagonPeepholePass(*PassRegistry::getPassRegistry());
-    }
+    HexagonPeephole() : MachineFunctionPass(ID) {}
 
     bool runOnMachineFunction(MachineFunction &MF) override;
 

--- a/llvm/lib/Target/Hexagon/HexagonRDFOpt.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonRDFOpt.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "Hexagon.h"
 #include "HexagonInstrInfo.h"
 #include "HexagonSubtarget.h"
 #include "MCTargetDesc/HexagonBaseInfo.h"
@@ -37,13 +38,6 @@
 
 using namespace llvm;
 using namespace rdf;
-
-namespace llvm {
-
-  void initializeHexagonRDFOptPass(PassRegistry&);
-  FunctionPass *createHexagonRDFOpt();
-
-} // end namespace llvm
 
 static unsigned RDFCount = 0;
 

--- a/llvm/lib/Target/Hexagon/HexagonSplitConst32AndConst64.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonSplitConst32AndConst64.cpp
@@ -16,6 +16,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "Hexagon.h"
 #include "HexagonSubtarget.h"
 #include "HexagonTargetMachine.h"
 #include "HexagonTargetObjectFile.h"
@@ -29,19 +30,11 @@ using namespace llvm;
 
 #define DEBUG_TYPE "xfer"
 
-namespace llvm {
-  FunctionPass *createHexagonSplitConst32AndConst64();
-  void initializeHexagonSplitConst32AndConst64Pass(PassRegistry&);
-}
-
 namespace {
   class HexagonSplitConst32AndConst64 : public MachineFunctionPass {
   public:
     static char ID;
-    HexagonSplitConst32AndConst64() : MachineFunctionPass(ID) {
-      PassRegistry &R = *PassRegistry::getPassRegistry();
-      initializeHexagonSplitConst32AndConst64Pass(R);
-    }
+    HexagonSplitConst32AndConst64() : MachineFunctionPass(ID) {}
     StringRef getPassName() const override {
       return "Hexagon Split Const32s and Const64s";
     }

--- a/llvm/lib/Target/Hexagon/HexagonSplitDouble.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonSplitDouble.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "Hexagon.h"
 #include "HexagonInstrInfo.h"
 #include "HexagonRegisterInfo.h"
 #include "HexagonSubtarget.h"
@@ -43,13 +44,6 @@
 #define DEBUG_TYPE "hsdr"
 
 using namespace llvm;
-
-namespace llvm {
-
-  FunctionPass *createHexagonSplitDoubleRegs();
-  void initializeHexagonSplitDoubleRegsPass(PassRegistry&);
-
-} // end namespace llvm
 
 static cl::opt<int> MaxHSDR("max-hsdr", cl::Hidden, cl::init(-1),
     cl::desc("Maximum number of split partitions"));

--- a/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonTargetMachine.cpp
@@ -170,75 +170,6 @@ static MachineSchedRegistry
     SchedCustomRegistry("hexagon", "Run Hexagon's custom scheduler",
                         createVLIWMachineSched);
 
-namespace llvm {
-extern char &HexagonCopyHoistingID;
-extern char &HexagonExpandCondsetsID;
-extern char &HexagonTfrCleanupID;
-void initializeHexagonBitSimplifyPass(PassRegistry &);
-void initializeHexagonCopyHoistingPass(PassRegistry &);
-void initializeHexagonConstExtendersPass(PassRegistry &);
-void initializeHexagonConstPropagationPass(PassRegistry &);
-void initializeHexagonCopyToCombinePass(PassRegistry &);
-void initializeHexagonEarlyIfConversionPass(PassRegistry &);
-void initializeHexagonExpandCondsetsPass(PassRegistry &);
-void initializeHexagonGenMemAbsolutePass(PassRegistry &);
-void initializeHexagonGenMuxPass(PassRegistry &);
-void initializeHexagonHardwareLoopsPass(PassRegistry &);
-void initializeHexagonLoopIdiomRecognizeLegacyPassPass(PassRegistry &);
-void initializeHexagonLoopAlignPass(PassRegistry &);
-void initializeHexagonMaskPass(PassRegistry &);
-void initializeHexagonMergeActivateWeightPass(PassRegistry &);
-void initializeHexagonNewValueJumpPass(PassRegistry &);
-void initializeHexagonOptAddrModePass(PassRegistry &);
-void initializeHexagonPacketizerPass(PassRegistry &);
-void initializeHexagonRDFOptPass(PassRegistry &);
-void initializeHexagonSplitDoubleRegsPass(PassRegistry &);
-void initializeHexagonTfrCleanupPass(PassRegistry &);
-void initializeHexagonVExtractPass(PassRegistry &);
-void initializeHexagonVectorCombineLegacyPass(PassRegistry &);
-void initializeHexagonVectorLoopCarriedReuseLegacyPassPass(PassRegistry &);
-Pass *createHexagonLoopIdiomPass();
-Pass *createHexagonVectorLoopCarriedReuseLegacyPass();
-
-FunctionPass *createHexagonBitSimplify();
-FunctionPass *createHexagonBranchRelaxation();
-FunctionPass *createHexagonCallFrameInformation();
-FunctionPass *createHexagonCFGOptimizer();
-FunctionPass *createHexagonCommonGEP();
-FunctionPass *createHexagonConstExtenders();
-FunctionPass *createHexagonConstPropagationPass();
-FunctionPass *createHexagonCopyHoisting();
-FunctionPass *createHexagonCopyToCombine();
-FunctionPass *createHexagonEarlyIfConversion();
-FunctionPass *createHexagonFixupHwLoops();
-FunctionPass *createHexagonGenExtract();
-FunctionPass *createHexagonGenInsert();
-FunctionPass *createHexagonGenMemAbsolute();
-FunctionPass *createHexagonGenMux();
-FunctionPass *createHexagonGenPredicate();
-FunctionPass *createHexagonHardwareLoops();
-FunctionPass *createHexagonISelDag(HexagonTargetMachine &TM,
-                                   CodeGenOptLevel OptLevel);
-FunctionPass *createHexagonLoopAlign();
-FunctionPass *createHexagonLoopRescheduling();
-FunctionPass *createHexagonMask();
-FunctionPass *createHexagonMergeActivateWeight();
-FunctionPass *createHexagonNewValueJump();
-FunctionPass *createHexagonOptAddrMode();
-FunctionPass *createHexagonOptimizeSZextends();
-FunctionPass *createHexagonPacketizer(bool Minimal);
-FunctionPass *createHexagonPeephole();
-FunctionPass *createHexagonRDFOpt();
-FunctionPass *createHexagonSplitConst32AndConst64();
-FunctionPass *createHexagonSplitDoubleRegs();
-FunctionPass *createHexagonStoreWidening();
-FunctionPass *createHexagonLoadWidening();
-FunctionPass *createHexagonTfrCleanup();
-FunctionPass *createHexagonVectorCombineLegacyPass();
-FunctionPass *createHexagonVectorPrint();
-FunctionPass *createHexagonVExtract();
-} // namespace llvm
-
 static Reloc::Model getEffectiveRelocModel(std::optional<Reloc::Model> RM) {
   return RM.value_or(Reloc::Static);
 }
@@ -266,6 +197,26 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeHexagonTarget() {
   initializeHexagonVectorLoopCarriedReuseLegacyPassPass(PR);
   initializeHexagonVExtractPass(PR);
   initializeHexagonDAGToDAGISelLegacyPass(PR);
+  initializeHexagonLoopReschedulingPass(PR);
+  initializeHexagonBranchRelaxationPass(PR);
+  initializeHexagonCFGOptimizerPass(PR);
+  initializeHexagonCommonGEPPass(PR);
+  initializeHexagonCopyHoistingPass(PR);
+  initializeHexagonExpandCondsetsPass(PR);
+  initializeHexagonLoopAlignPass(PR);
+  initializeHexagonTfrCleanupPass(PR);
+  initializeHexagonFixupHwLoopsPass(PR);
+  initializeHexagonCallFrameInformationPass(PR);
+  initializeHexagonGenExtractPass(PR);
+  initializeHexagonGenInsertPass(PR);
+  initializeHexagonGenPredicatePass(PR);
+  initializeHexagonLoadWideningPass(PR);
+  initializeHexagonStoreWideningPass(PR);
+  initializeHexagonMaskPass(PR);
+  initializeHexagonOptimizeSZextendsPass(PR);
+  initializeHexagonPeepholePass(PR);
+  initializeHexagonSplitConst32AndConst64Pass(PR);
+  initializeHexagonVectorPrintPass(PR);
 }
 
 HexagonTargetMachine::HexagonTargetMachine(const Target &T, const Triple &TT,
@@ -287,10 +238,6 @@ HexagonTargetMachine::HexagonTargetMachine(const Target &T, const Triple &TT,
           (HexagonNoOpt ? CodeGenOptLevel::None : OL)),
       TLOF(std::make_unique<HexagonTargetObjectFile>()),
       Subtarget(Triple(TT), CPU, FS, *this) {
-  initializeHexagonCopyHoistingPass(*PassRegistry::getPassRegistry());
-  initializeHexagonExpandCondsetsPass(*PassRegistry::getPassRegistry());
-  initializeHexagonLoopAlignPass(*PassRegistry::getPassRegistry());
-  initializeHexagonTfrCleanupPass(*PassRegistry::getPassRegistry());
   initAsmInfo();
 }
 

--- a/llvm/lib/Target/Hexagon/HexagonTfrCleanup.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonTfrCleanup.cpp
@@ -25,7 +25,7 @@
 //    r0 = zxtb(r3)
 //  }
 
-#define DEBUG_TYPE "tfr-cleanup"
+#include "Hexagon.h"
 #include "HexagonTargetMachine.h"
 
 #include "llvm/CodeGen/LiveIntervals.h"
@@ -37,19 +37,13 @@
 
 using namespace llvm;
 
-namespace llvm {
-FunctionPass *createHexagonTfrCleanup();
-void initializeHexagonTfrCleanupPass(PassRegistry &);
-} // namespace llvm
+#define DEBUG_TYPE "tfr-cleanup"
 
 namespace {
 class HexagonTfrCleanup : public MachineFunctionPass {
 public:
   static char ID;
-  HexagonTfrCleanup() : MachineFunctionPass(ID), HII(0), TRI(0) {
-    PassRegistry &R = *PassRegistry::getPassRegistry();
-    initializeHexagonTfrCleanupPass(R);
-  }
+  HexagonTfrCleanup() : MachineFunctionPass(ID), HII(0), TRI(0) {}
   StringRef getPassName() const override { return "Hexagon TFR Cleanup"; }
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.setPreservesAll();

--- a/llvm/lib/Target/Hexagon/HexagonVExtract.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVExtract.cpp
@@ -31,11 +31,6 @@ static cl::opt<unsigned> VExtractThreshold(
     "hexagon-vextract-threshold", cl::Hidden, cl::init(1),
     cl::desc("Threshold for triggering vextract replacement"));
 
-namespace llvm {
-  void initializeHexagonVExtractPass(PassRegistry& Registry);
-  FunctionPass *createHexagonVExtract();
-}
-
 namespace {
   class HexagonVExtract : public MachineFunctionPass {
   public:

--- a/llvm/lib/Target/Hexagon/HexagonVLIWPacketizer.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVLIWPacketizer.cpp
@@ -77,13 +77,6 @@ static cl::opt<bool>
 
 extern cl::opt<bool> ScheduleInlineAsm;
 
-namespace llvm {
-
-FunctionPass *createHexagonPacketizer(bool Minimal);
-void initializeHexagonPacketizerPass(PassRegistry&);
-
-} // end namespace llvm
-
 namespace {
 
   class HexagonPacketizer : public MachineFunctionPass {

--- a/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVectorCombine.cpp
@@ -43,6 +43,7 @@
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Transforms/Utils/Local.h"
 
+#include "Hexagon.h"
 #include "HexagonSubtarget.h"
 #include "HexagonTargetMachine.h"
 
@@ -2930,11 +2931,6 @@ auto HexagonVectorCombine::getElementRange(IRBuilderBase &Builder, Value *Lo,
 }
 
 // Pass management.
-
-namespace llvm {
-void initializeHexagonVectorCombineLegacyPass(PassRegistry &);
-FunctionPass *createHexagonVectorCombineLegacyPass();
-} // namespace llvm
 
 namespace {
 class HexagonVectorCombineLegacy : public FunctionPass {

--- a/llvm/lib/Target/Hexagon/HexagonVectorLoopCarriedReuse.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVectorLoopCarriedReuse.cpp
@@ -14,6 +14,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "HexagonVectorLoopCarriedReuse.h"
+#include "Hexagon.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
@@ -54,13 +55,6 @@ static cl::opt<int> HexagonVLCRIterationLim(
     "hexagon-vlcr-iteration-lim", cl::Hidden,
     cl::desc("Maximum distance of loop carried dependences that are handled"),
     cl::init(2));
-
-namespace llvm {
-
-void initializeHexagonVectorLoopCarriedReuseLegacyPassPass(PassRegistry &);
-Pass *createHexagonVectorLoopCarriedReuseLegacyPass();
-
-} // end namespace llvm
 
 namespace {
 
@@ -162,10 +156,7 @@ namespace {
   public:
     static char ID;
 
-    explicit HexagonVectorLoopCarriedReuseLegacyPass() : LoopPass(ID) {
-      PassRegistry *PR = PassRegistry::getPassRegistry();
-      initializeHexagonVectorLoopCarriedReuseLegacyPassPass(*PR);
-    }
+    explicit HexagonVectorLoopCarriedReuseLegacyPass() : LoopPass(ID) {}
 
     StringRef getPassName() const override {
       return "Hexagon-specific loop carried reuse for HVX vectors";

--- a/llvm/lib/Target/Hexagon/HexagonVectorPrint.cpp
+++ b/llvm/lib/Target/Hexagon/HexagonVectorPrint.cpp
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "Hexagon.h"
 #include "HexagonInstrInfo.h"
 #include "HexagonSubtarget.h"
 #include "llvm/ADT/StringRef.h"
@@ -40,13 +41,6 @@ static cl::opt<bool>
     TraceHexVectorStoresOnly("trace-hex-vector-stores-only", cl::Hidden,
                              cl::desc("Enables tracing of vector stores"));
 
-namespace llvm {
-
-FunctionPass *createHexagonVectorPrint();
-void initializeHexagonVectorPrintPass(PassRegistry&);
-
-} // end namespace llvm
-
 namespace {
 
 class HexagonVectorPrint : public MachineFunctionPass {
@@ -57,9 +51,7 @@ class HexagonVectorPrint : public MachineFunctionPass {
 public:
   static char ID;
 
-  HexagonVectorPrint() : MachineFunctionPass(ID) {
-    initializeHexagonVectorPrintPass(*PassRegistry::getPassRegistry());
-  }
+  HexagonVectorPrint() : MachineFunctionPass(ID) {}
 
   StringRef getPassName() const override { return "Hexagon VectorPrint pass"; }
 


### PR DESCRIPTION
- Remove pass initialization calls from pass constructors.
- Move pass initialization and creation function declarations to Hexagon.h and remove them from individual .cpp files.
- Add calls for pass initialization in Hexagon target initialization.
- https://github.com/llvm/llvm-project/issues/111767