### PR TITLE
[NFC] Use cast instead of dyn_cast for Src and Dst vec types in VecCombine folding

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -2050,10 +2050,8 @@ bool VectorCombine::foldShuffleOfSelects(Instruction &I) {
        (SI0FOp->getFastMathFlags() != SI1FOp->getFastMathFlags())))
     return false;
 
-  auto *SrcVecTy = dyn_cast<FixedVectorType>(T1->getType());
-  auto *DstVecTy = dyn_cast<FixedVectorType>(I.getType());
-  assert(SrcVecTy && DstVecTy &&
-         "Expected shuffle/select vector types to be defined");
+  auto *SrcVecTy = cast<FixedVectorType>(T1->getType());
+  auto *DstVecTy = cast<FixedVectorType>(I.getType());
 
   auto SK = TargetTransformInfo::SK_PermuteTwoSrc;
   auto SelOp = Instruction::Select;

--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -2052,6 +2052,9 @@ bool VectorCombine::foldShuffleOfSelects(Instruction &I) {
 
   auto *SrcVecTy = dyn_cast<FixedVectorType>(T1->getType());
   auto *DstVecTy = dyn_cast<FixedVectorType>(I.getType());
+  assert(SrcVecTy && DstVecTy &&
+         "Expected shuffle/select vector types to be defined");
+
   auto SK = TargetTransformInfo::SK_PermuteTwoSrc;
   auto SelOp = Instruction::Select;
   InstructionCost OldCost = TTI.getCmpSelInstrCost(

--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -2052,7 +2052,6 @@ bool VectorCombine::foldShuffleOfSelects(Instruction &I) {
 
   auto *SrcVecTy = cast<FixedVectorType>(T1->getType());
   auto *DstVecTy = cast<FixedVectorType>(I.getType());
-
   auto SK = TargetTransformInfo::SK_PermuteTwoSrc;
   auto SelOp = Instruction::Select;
   InstructionCost OldCost = TTI.getCmpSelInstrCost(


### PR DESCRIPTION
SrcVecTy and DstVecTy are used without a null check, and originate from a dyn_cast. This patch adjusts this to use a fixed cast, since it is not checked for null before use otherwise, but is semantically guaranteed from previous checks.