### PR TITLE
[fatlto] Add coroutine passes when using FatLTO with ThinLTO

### DIFF
--- a/clang/test/CodeGenCoroutines/pr134409.cpp
+++ b/clang/test/CodeGenCoroutines/pr134409.cpp
@@ -1,0 +1,43 @@
+// An end-to-end test to make sure coroutine passes are added for thinlto.
+
+// RUN: %clang_cc1 -std=c++23 -ffat-lto-objects -flto=thin -emit-llvm %s -O3 -o - \
+// RUN:  | FileCheck %s
+
+#include "Inputs/coroutine.h"
+
+class BasicCoroutine {
+public:
+    struct Promise {
+        BasicCoroutine get_return_object() { return BasicCoroutine {}; }
+
+        void unhandled_exception() noexcept { }
+
+        void return_void() noexcept { }
+
+        std::suspend_never initial_suspend() noexcept { return {}; }
+        std::suspend_never final_suspend() noexcept { return {}; }
+    };
+    using promise_type = Promise;
+};
+
+// COM: match the embedded module, so we don't match something in it by accident.
+// CHECK: @llvm.embedded.object = {{.*}}
+// CHECK: @llvm.compiler.used = {{.*}}
+
+BasicCoroutine coro() {
+// CHECK: define {{.*}} void @_Z4corov() {{.*}} {
+// CHECK-NEXT: entry:
+// CHECK-NEXT: ret void
+// CHECK-NEXT: }
+    co_return;
+}
+
+int main() {
+// CHECK: define {{.*}} i32 @main() {{.*}} {
+// CHECK-NEXT: entry:
+// CHECK-NEXT: tail call void @_Z4corov()
+// CHECK-NEXT: ret i32 0
+// CHECK-NEXT: }
+    coro();
+}
+

--- a/clang/test/CodeGenCoroutines/pr134409.cpp
+++ b/clang/test/CodeGenCoroutines/pr134409.cpp
@@ -1,6 +1,6 @@
 // An end-to-end test to make sure coroutine passes are added for thinlto.
-
-// RUN: %clang_cc1 -std=c++23 -ffat-lto-objects -flto=thin -emit-llvm %s -O3 -o - \
+// REQUIRES: x86-registered-target
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -std=c++23 -ffat-lto-objects -flto=thin -emit-llvm %s -O3 -o - \
 // RUN:  | FileCheck %s
 
 #include "Inputs/coroutine.h"


### PR DESCRIPTION
When coroutines are used w/ both -ffat-lto-objects and -flto=thin,
the coroutine passes are not added to the optimization pipelines.
Ensure they are added before ModuleOptimization to generate a
working ELF object.

Fixes #134409.