### PR TITLE
[NFC][LLVM][Mips] Cleanup pass initialization for Mips

### DIFF
--- a/llvm/lib/Target/Mips/MipsBranchExpansion.cpp
+++ b/llvm/lib/Target/Mips/MipsBranchExpansion.cpp
@@ -135,9 +135,8 @@ class MipsBranchExpansion : public MachineFunctionPass {
 public:
   static char ID;
 
-  MipsBranchExpansion() : MachineFunctionPass(ID), ABI(MipsABIInfo::Unknown()) {
-    initializeMipsBranchExpansionPass(*PassRegistry::getPassRegistry());
-  }
+  MipsBranchExpansion()
+      : MachineFunctionPass(ID), ABI(MipsABIInfo::Unknown()) {}
 
   StringRef getPassName() const override {
     return "Mips Branch Expansion Pass";

--- a/llvm/lib/Target/Mips/MipsDelaySlotFiller.cpp
+++ b/llvm/lib/Target/Mips/MipsDelaySlotFiller.cpp
@@ -208,9 +208,7 @@ namespace {
 
   class MipsDelaySlotFiller : public MachineFunctionPass {
   public:
-    MipsDelaySlotFiller() : MachineFunctionPass(ID) {
-      initializeMipsDelaySlotFillerPass(*PassRegistry::getPassRegistry());
-    }
+    MipsDelaySlotFiller() : MachineFunctionPass(ID) {}
 
     StringRef getPassName() const override { return "Mips Delay Slot Filler"; }
 

--- a/llvm/lib/Target/Mips/MipsMulMulBugPass.cpp
+++ b/llvm/lib/Target/Mips/MipsMulMulBugPass.cpp
@@ -35,9 +35,7 @@ namespace {
 
 class MipsMulMulBugFix : public MachineFunctionPass {
 public:
-  MipsMulMulBugFix() : MachineFunctionPass(ID) {
-    initializeMipsMulMulBugFixPass(*PassRegistry::getPassRegistry());
-  }
+  MipsMulMulBugFix() : MachineFunctionPass(ID) {}
 
   StringRef getPassName() const override { return "Mips VR4300 mulmul bugfix"; }
 

--- a/llvm/lib/Target/Mips/MipsPostLegalizerCombiner.cpp
+++ b/llvm/lib/Target/Mips/MipsPostLegalizerCombiner.cpp
@@ -117,8 +117,6 @@ void MipsPostLegalizerCombiner::getAnalysisUsage(AnalysisUsage &AU) const {
 
 MipsPostLegalizerCombiner::MipsPostLegalizerCombiner(bool IsOptNone)
     : MachineFunctionPass(ID), IsOptNone(IsOptNone) {
-  initializeMipsPostLegalizerCombinerPass(*PassRegistry::getPassRegistry());
-
   if (!RuleConfig.parseCommandLineOption())
     report_fatal_error("Invalid rule identifier");
 }
@@ -157,8 +155,6 @@ INITIALIZE_PASS_END(MipsPostLegalizerCombiner, DEBUG_TYPE,
                     "Combine Mips machine instrs after legalization", false,
                     false)
 
-namespace llvm {
-FunctionPass *createMipsPostLegalizeCombiner(bool IsOptNone) {
+FunctionPass *llvm::createMipsPostLegalizeCombiner(bool IsOptNone) {
   return new MipsPostLegalizerCombiner(IsOptNone);
 }
-} // end namespace llvm

--- a/llvm/lib/Target/Mips/MipsPreLegalizerCombiner.cpp
+++ b/llvm/lib/Target/Mips/MipsPreLegalizerCombiner.cpp
@@ -56,7 +56,6 @@ public:
   }
 
   bool tryCombineAll(MachineInstr &MI) const override {
-
     switch (MI.getOpcode()) {
     default:
       return false;
@@ -110,9 +109,8 @@ void MipsPreLegalizerCombiner::getAnalysisUsage(AnalysisUsage &AU) const {
   MachineFunctionPass::getAnalysisUsage(AU);
 }
 
-MipsPreLegalizerCombiner::MipsPreLegalizerCombiner() : MachineFunctionPass(ID) {
-  initializeMipsPreLegalizerCombinerPass(*PassRegistry::getPassRegistry());
-}
+MipsPreLegalizerCombiner::MipsPreLegalizerCombiner()
+    : MachineFunctionPass(ID) {}
 
 bool MipsPreLegalizerCombiner::runOnMachineFunction(MachineFunction &MF) {
   if (MF.getProperties().hasProperty(
@@ -141,8 +139,6 @@ INITIALIZE_PASS_END(MipsPreLegalizerCombiner, DEBUG_TYPE,
                     "Combine Mips machine instrs before legalization", false,
                     false)
 
-namespace llvm {
-FunctionPass *createMipsPreLegalizeCombiner() {
+FunctionPass *llvm::createMipsPreLegalizeCombiner() {
   return new MipsPreLegalizerCombiner();
 }
-} // end namespace llvm


### PR DESCRIPTION
- Remove calls to pass initialization from pass constructors.
- https://github.com/llvm/llvm-project/issues/111767