### PR TITLE
cuda clang: Clean up test dependency for CUDA surfaces

### DIFF
--- a/clang/test/CodeGen/include/cuda.h
+++ b/clang/test/CodeGen/include/cuda.h
@@ -1,5 +1,5 @@
 /* Minimal declarations for CUDA support.  Testing purposes only.
- * This should stay in sync with clang/test/CodeGen/include/cuda.h
+ * This should stay in sync with clang/test/Headers/Inputs/include/cuda.h
  */
 #pragma once
 

--- a/clang/test/CodeGen/nvptx-surface.cu
+++ b/clang/test/CodeGen/nvptx-surface.cu
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -triple nvptx-unknown-unknown -fcuda-is-device -O3 -o - %s -emit-llvm | FileCheck %s
 // RUN: %clang_cc1 -triple nvptx64-unknown-unknown -fcuda-is-device -O3 -o - %s -emit-llvm | FileCheck %s
-#include "../Headers/Inputs/include/cuda.h"
+#include "include/cuda.h"
 
 #include "__clang_cuda_texture_intrinsics.h"
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/132883 added support for cuda surfaces but reached into clang/test/Headers/ from clang/test/CodeGen/ to grab the minimal cuda.h.  Duplicate that file instead based on comments in the review, to fix remote test runs.