### PR TITLE
[flang] Temporary include variant.h in enum-class.h.

### DIFF
--- a/flang/include/flang/Common/enum-class.h
+++ b/flang/include/flang/Common/enum-class.h
@@ -17,6 +17,7 @@
 #ifndef FORTRAN_COMMON_ENUM_CLASS_H_
 #define FORTRAN_COMMON_ENUM_CLASS_H_
 
+#include "flang/Common/variant.h"
 #include <array>
 #include <string>
 


### PR DESCRIPTION
I am having problems building Fortran runtime for CUDA
after #134164. I need more time to investigate it,
but in the meantime including variant.h (or any header
that eventually includes a libcudacxx header) resolves
the issue.
