### PR TITLE
[Clang][Sema]:Fix musttail attribute on a function with not_tail_called attribute has no warning/error

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -327,7 +327,6 @@ Improvements to Clang's diagnostics
 
 - An error is now emitted when a ``musttail`` call is made to a function marked with the ``not_tail_called`` attribute. (#GH133509).
 
-
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -325,7 +325,7 @@ Improvements to Clang's diagnostics
 - Now correctly diagnose a tentative definition of an array with static
   storage duration in pedantic mode in C. (#GH50661)
 
-- The ``-err-musttail-mismatch`` error is emitted when a musttail call is made to a function marked with the not_tail_called attribute.(#133509).
+- An error is now emitted when a ``musttail`` call is made to a function marked with the ``not_tail_called`` attribute. (#GH133509).
 
 
 Improvements to Clang's time-trace

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -325,6 +325,9 @@ Improvements to Clang's diagnostics
 - Now correctly diagnose a tentative definition of an array with static
   storage duration in pedantic mode in C. (#GH50661)
 
+- The ``-err-musttail-mismatch`` error is emitted when a musttail call is made to a function marked with the not_tail_called attribute.(#133509).
+
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3161,7 +3161,7 @@ def err_musttail_member_mismatch : Error<
 def note_musttail_callee_defined_here : Note<"%0 declared here">;
 def note_tail_call_required : Note<"tail call required by %0 attribute here">;
 def err_musttail_mismatch : Error<
-  "cannot perform a tail call to function %select{| %1}0 because its signature "
+  "cannot perform a tail call to function%select{| %1}0 because its signature "
   "is incompatible with the calling function">;
 def note_musttail_mismatch : Note<
     "target function "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3170,6 +3170,8 @@ def note_musttail_mismatch : Note<
     "|has type mismatch at %ordinal3 parameter"
     "%diff{ (expected $ but has $)|}1,2"
     "|has different return type%diff{ ($ expected but has $)|}1,2}0">;
+def note_musttail_disabled_by_not_tail_called : Note<
+  "'not_tail_called' attribute here prevents being called as a tail call">;
 def err_musttail_callconv_mismatch : Error<
   "cannot perform a tail call to function%select{| %1}0 because it uses an "
   "incompatible calling convention">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3134,7 +3134,6 @@ def warn_function_attribute_ignored_in_stmt : Warning<
   "use '%0' on statements">,
   InGroup<IgnoredAttributes>;
 
-
 def err_musttail_needs_trivial_args : Error<
   "tail call requires that the return value, all parameters, and any "
   "temporaries created by the expression are trivially destructible">;
@@ -3162,7 +3161,7 @@ def err_musttail_member_mismatch : Error<
 def note_musttail_callee_defined_here : Note<"%0 declared here">;
 def note_tail_call_required : Note<"tail call required by %0 attribute here">;
 def err_musttail_mismatch : Error<
-  "cannot perform a tail call to function%select{| %1}0 because its signature "
+  "cannot perform a tail call to function %select{| %1}0 because its signature "
   "is incompatible with the calling function">;
 def note_musttail_mismatch : Note<
     "target function "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3171,7 +3171,7 @@ def note_musttail_mismatch : Note<
     "%diff{ (expected $ but has $)|}1,2"
     "|has different return type%diff{ ($ expected but has $)|}1,2}0">;
 def note_musttail_disabled_by_not_tail_called : Note<
-  "'not_tail_called' attribute here prevents being called as a tail call">;
+  "'not_tail_called' attribute prevents being called as a tail call">;
 def err_musttail_callconv_mismatch : Error<
   "cannot perform a tail call to function%select{| %1}0 because it uses an "
   "incompatible calling convention">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3134,9 +3134,7 @@ def warn_function_attribute_ignored_in_stmt : Warning<
   "use '%0' on statements">,
   InGroup<IgnoredAttributes>;
 
-def err_musttail_conflicts_with_not_tail_called : Error<
-  "%0 musttail conflicts with not tail called"
-  >;
+
 def err_musttail_needs_trivial_args : Error<
   "tail call requires that the return value, all parameters, and any "
   "temporaries created by the expression are trivially destructible">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12,61 +12,6 @@
 
 let Component = "Sema" in {
 let CategoryName = "Semantic Issue" in {
-// C++11 compatibility with C++98.
-defm nonclass_type_friend : CXX11Compat<"non-class friend type %0 is">;
-defm static_data_member_in_union : CXX11Compat<"static data member %0 in union is">;
-defm templ_default_in_function_templ : CXX11Compat<
-  "default template arguments for a function template are">;
-defm template_arg_extra_parens : CXX11Compat<
-  "parentheses around address non-type template argument are">;
-defm typename_outside_of_template : CXX11Compat<"'typename' outside of a template is">;
-
-// C++14 compatibility with C++11 and earlier.
-defm constexpr_type_definition : CXX14Compat<
-  "type definition in a constexpr %select{function|constructor}0 is">;
-defm constexpr_local_var : CXX14Compat<
-  "variable declaration in a constexpr %select{function|constructor}0 is">;
-defm constexpr_body_multiple_return : CXX14Compat<
-  "multiple return statements in constexpr function is">;
-defm variable_template : CXX14Compat<"variable templates are">;
-
-// C++17 compatibility with C++14 and earlier.
-defm decomp_decl : CXX17Compat<"decomposition declarations are">;
-defm inline_variable : CXX17Compat<"inline variables are">;
-
-// C++20 compatibility with C++17 and earlier.
-defm decomp_decl_spec : CXX20Compat<
-  "decomposition declaration declared "
-  "%plural{1:'%1'|:with '%1' specifiers}0 is">;
-defm constexpr_local_var_no_init : CXX20Compat<
-  "uninitialized variable in a constexpr %select{function|constructor}0 is">;
-defm constexpr_function_try_block : CXX20Compat<
-  "function try block in constexpr %select{function|constructor}0 is">;
-defm constexpr_union_ctor_no_init : CXX20Compat<
-  "constexpr union constructor that does not initialize any member is">;
-defm constexpr_ctor_missing_init : CXX20Compat<
-  "constexpr constructor that does not initialize all members is">;
-defm adl_only_template_id : CXX20Compat<
-  "use of function template name with no prior declaration in function call "
-  "with explicit template arguments is">;
-defm ctad_for_alias_templates
-    : CXX20Compat<"class template argument deduction for alias templates is">;
-
-// C++23 compatibility with C++20 and earlier.
-defm constexpr_static_var : CXX23Compat<
-  "definition of a %select{static|thread_local}1 variable "
-  "in a constexpr %select{function|constructor}0 "
-  "is">;
-
-// C++26 compatibility with C++23 and earlier.
-defm decomp_decl_cond : CXX26Compat<"structured binding declaration in a condition is">;
-
-// Compatibility warnings duplicated across multiple language versions.
-foreach std = [14, 20, 23] in {
-  defm cxx#std#_constexpr_body_invalid_stmt : CXXCompat<
-    "use of this statement in a constexpr %select{function|constructor}0 is", std>;
-}
-
 def note_previous_decl : Note<"%0 declared here">;
 def note_entity_declared_at : Note<"%0 declared here">;
 def note_callee_decl : Note<"%0 declared here">;
@@ -547,7 +492,7 @@ def warn_qual_return_type : Warning<
   InGroup<IgnoredQualifiers>, DefaultIgnore;
 def warn_qual_base_type : Warning<
   "'%0' qualifier%s1 on base class type %2 %plural{1:has|:have}1 no effect">,
-  InGroup<IgnoredBaseClassQualifiers>, DefaultIgnore;
+  InGroup<IgnoredQualifiers>, DefaultIgnore;
 
 def warn_deprecated_redundant_constexpr_static_def : Warning<
   "out-of-line definition of constexpr static data member is redundant "
@@ -578,9 +523,30 @@ def warn_modifying_shadowing_decl :
 // C++ decomposition declarations
 def err_decomp_decl_context : Error<
   "decomposition declaration not permitted in this context">;
+def warn_cxx14_compat_decomp_decl : Warning<
+  "decomposition declarations are incompatible with "
+  "C++ standards before C++17">, DefaultIgnore, InGroup<CXXPre17Compat>;
+def ext_decomp_decl : ExtWarn<
+  "decomposition declarations are a C++17 extension">, InGroup<CXX17>;
+def ext_decomp_decl_cond : ExtWarn<
+  "structured binding declaration in a condition is a C++2c extenstion">,
+  InGroup<CXX26>;
+def warn_cxx26_decomp_decl_cond : Warning<
+  "structured binding declaration in a condition is incompatible with "
+  "C++ standards before C++2c">,
+  InGroup<CXXPre26Compat>, DefaultIgnore;
 def err_decomp_decl_spec : Error<
   "decomposition declaration cannot be declared "
   "%plural{1:'%1'|:with '%1' specifiers}0">;
+def ext_decomp_decl_spec : ExtWarn<
+  "decomposition declaration declared "
+  "%plural{1:'%1'|:with '%1' specifiers}0 is a C++20 extension">,
+  InGroup<CXX20>;
+def warn_cxx17_compat_decomp_decl_spec : Warning<
+  "decomposition declaration declared "
+  "%plural{1:'%1'|:with '%1' specifiers}0 "
+  "is incompatible with C++ standards before C++20">,
+  InGroup<CXXPre20Compat>, DefaultIgnore;
 def err_decomp_decl_type : Error<
   "decomposition declaration cannot be declared with type %0; "
   "declared type must be 'auto' or reference to 'auto'">;
@@ -625,8 +591,6 @@ def err_decomp_decl_std_tuple_size_not_constant : Error<
   "is not a valid integral constant expression">;
 def note_in_binding_decl_init : Note<
   "in implicit initialization of binding declaration %0">;
-def err_arg_is_not_destructurable : Error<
-  "type %0 cannot be decomposed">;
 
 def err_std_type_trait_not_class_template : Error<
   "unsupported standard library implementation: "
@@ -1699,35 +1663,34 @@ def err_static_assert_requirement_failed : Error<
   "static assertion failed due to requirement '%0'%select{: %2|}1">;
 def note_expr_evaluates_to : Note<
   "expression evaluates to '%0 %1 %2'">;
-
-
-def subst_user_defined_msg : TextSubstitution<
-  "%select{the message|the expression}0 in "
-  "%select{a static assertion|this asm operand}0">;
-
-def err_user_defined_msg_invalid : Error<
-  "%sub{subst_user_defined_msg}0 must be a string literal or an "
+def err_static_assert_invalid_message : Error<
+  "the message in a static assertion must be a string literal or an "
   "object with 'data()' and 'size()' member functions">;
-def err_user_defined_msg_missing_member_function : Error<
-  "the %select{message|string}0 object in "
-  "%select{this static assertion|this asm operand}0 is missing %select{"
+def err_static_assert_missing_member_function : Error<
+  "the message object in this static assertion is missing %select{"
   "a 'size()' member function|"
   "a 'data()' member function|"
-  "'data()' and 'size()' member functions}1">;
-def err_user_defined_msg_invalid_mem_fn_ret_ty : Error<
-  "%sub{subst_user_defined_msg}0 must have a '%select{size|data}1()' member "
-  "function returning an object convertible to '%select{std::size_t|const char *}1'">;
-def warn_user_defined_msg_constexpr : Warning<
-  "%select{the message|the expression}0 in "
-  "%select{this static assertion|this asm operand}0 is not a constant expression">,
+  "'data()' and 'size()' member functions}0">;
+def err_static_assert_invalid_mem_fn_ret_ty : Error<
+  "the message in a static assertion must have a '%select{size|data}0()' member "
+  "function returning an object convertible to '%select{std::size_t|const char *}0'">;
+def warn_static_assert_message_constexpr : Warning<
+  "the message in this static assertion is not a "
+  "constant expression">,
   DefaultError, InGroup<DiagGroup<"invalid-static-assert-message">>;
-def err_user_defined_msg_constexpr : Error<
-  "%sub{subst_user_defined_msg}0 must be produced by a "
+def err_static_assert_message_constexpr : Error<
+  "the message in a static assertion must be produced by a "
   "constant expression">;
 
 def warn_consteval_if_always_true : Warning<
   "consteval if is always true in an %select{unevaluated|immediate}0 context">,
   InGroup<DiagGroup<"redundant-consteval-if">>;
+
+def ext_inline_variable : ExtWarn<
+  "inline variables are a C++17 extension">, InGroup<CXX17>;
+def warn_cxx14_compat_inline_variable : Warning<
+  "inline variables are incompatible with C++ standards before C++17">,
+  DefaultIgnore, InGroup<CXXPre17Compat>;
 
 def warn_inline_namespace_reopened_noninline : Warning<
   "inline namespace reopened as a non-inline namespace">,
@@ -1744,6 +1707,11 @@ def ext_enum_friend : ExtWarn<
   InGroup<DiagGroup<"friend-enum">>;
 def note_enum_friend : Note<
   "remove 'enum%select{| struct| class}0' to befriend an enum">;
+def ext_nonclass_type_friend : ExtWarn<
+  "non-class friend type %0 is a C++11 extension">, InGroup<CXX11>;
+def warn_cxx98_compat_nonclass_type_friend : Warning<
+  "non-class friend type %0 is incompatible with C++98">,
+  InGroup<CXX98Compat>, DefaultIgnore;
 def err_friend_is_member : Error<
   "friends cannot be members of the declaring class">;
 def warn_cxx98_compat_friend_is_member : Warning<
@@ -2175,6 +2143,11 @@ def select_tag_type_kind : TextSubstitution<
 def err_static_data_member_not_allowed_in_anon_struct : Error<
   "static data member %0 not allowed in anonymous "
   "%sub{select_tag_type_kind}1">;
+def ext_static_data_member_in_union : ExtWarn<
+  "static data member %0 in union is a C++11 extension">, InGroup<CXX11>;
+def warn_cxx98_compat_static_data_member_in_union : Warning<
+  "static data member %0 in union is incompatible with C++98">,
+  InGroup<CXX98Compat>, DefaultIgnore;
 def ext_union_member_of_reference_type : ExtWarn<
   "union member %0 has reference type %1, which is a Microsoft extension">,
   InGroup<MicrosoftUnionMemberReference>;
@@ -2733,9 +2706,6 @@ def warn_final_dtor_non_final_class : Warning<
   InGroup<FinalDtorNonFinalClass>;
 def note_final_dtor_non_final_class_silence : Note<
   "mark %0 as '%select{final|sealed}1' to silence this warning">;
-def warn_unnecessary_virtual_specifier : Warning<
-  "virtual method %0 is inside a 'final' class and can never be overridden">,
-  InGroup<WarnUnnecessaryVirtualSpecifier>, DefaultIgnore;
 
 // C++11 attributes
 def err_repeat_attribute : Error<"%0 attribute cannot be repeated">;
@@ -2922,17 +2892,63 @@ def err_constexpr_non_literal_param : Error<
   "not a literal type">;
 def err_constexpr_body_invalid_stmt : Error<
   "statement not allowed in %select{constexpr|consteval}1 %select{function|constructor}0">;
+def ext_constexpr_body_invalid_stmt : ExtWarn<
+  "use of this statement in a constexpr %select{function|constructor}0 "
+  "is a C++14 extension">, InGroup<CXX14>;
+def warn_cxx11_compat_constexpr_body_invalid_stmt : Warning<
+  "use of this statement in a constexpr %select{function|constructor}0 "
+  "is incompatible with C++ standards before C++14">,
+  InGroup<CXXPre14Compat>, DefaultIgnore;
+def ext_constexpr_body_invalid_stmt_cxx20 : ExtWarn<
+  "use of this statement in a constexpr %select{function|constructor}0 "
+  "is a C++20 extension">, InGroup<CXX20>;
+def warn_cxx17_compat_constexpr_body_invalid_stmt : Warning<
+  "use of this statement in a constexpr %select{function|constructor}0 "
+  "is incompatible with C++ standards before C++20">,
+  InGroup<CXXPre20Compat>, DefaultIgnore;
+def ext_constexpr_body_invalid_stmt_cxx23 : ExtWarn<
+  "use of this statement in a constexpr %select{function|constructor}0 "
+  "is a C++23 extension">, InGroup<CXX23>;
+def warn_cxx20_compat_constexpr_body_invalid_stmt : Warning<
+  "use of this statement in a constexpr %select{function|constructor}0 "
+  "is incompatible with C++ standards before C++23">,
+  InGroup<CXXPre23Compat>, DefaultIgnore;
+def ext_constexpr_type_definition : ExtWarn<
+  "type definition in a constexpr %select{function|constructor}0 "
+  "is a C++14 extension">, InGroup<CXX14>;
+def warn_cxx11_compat_constexpr_type_definition : Warning<
+  "type definition in a constexpr %select{function|constructor}0 "
+  "is incompatible with C++ standards before C++14">,
+  InGroup<CXXPre14Compat>, DefaultIgnore;
 def err_constexpr_vla : Error<
   "variably-modified type %0 cannot be used in a constexpr "
   "%select{function|constructor}1">;
+def ext_constexpr_local_var : ExtWarn<
+  "variable declaration in a constexpr %select{function|constructor}0 "
+  "is a C++14 extension">, InGroup<CXX14>;
+def warn_cxx11_compat_constexpr_local_var : Warning<
+  "variable declaration in a constexpr %select{function|constructor}0 "
+  "is incompatible with C++ standards before C++14">,
+  InGroup<CXXPre14Compat>, DefaultIgnore;
+def ext_constexpr_static_var : ExtWarn<
+  "definition of a %select{static|thread_local}1 variable "
+  "in a constexpr %select{function|constructor}0 "
+  "is a C++23 extension">, InGroup<CXX23>;
 def warn_cxx20_compat_constexpr_var : Warning<
-  "definition of a variable of non-literal type in a constexpr "
-  "%select{function|constructor}0 "
+  "definition of a %select{static variable|thread_local variable|variable "
+  "of non-literal type}1 in a constexpr %select{function|constructor}0 "
   "is incompatible with C++ standards before C++23">,
   InGroup<CXXPre23Compat>, DefaultIgnore;
 def err_constexpr_local_var_non_literal_type : Error<
   "variable of non-literal type %1 cannot be defined in a constexpr "
   "%select{function|constructor}0 before C++23">;
+def ext_constexpr_local_var_no_init : ExtWarn<
+  "uninitialized variable in a constexpr %select{function|constructor}0 "
+  "is a C++20 extension">, InGroup<CXX20>;
+def warn_cxx17_compat_constexpr_local_var_no_init : Warning<
+  "uninitialized variable in a constexpr %select{function|constructor}0 "
+  "is incompatible with C++ standards before C++20">,
+  InGroup<CXXPre20Compat>, DefaultIgnore;
 def ext_constexpr_function_never_constant_expr : ExtWarn<
   "%select{constexpr|consteval}1 %select{function|constructor}0 never produces a "
   "constant expression">, InGroup<DiagGroup<"invalid-constexpr">>, DefaultError;
@@ -2954,11 +2970,41 @@ def err_constexpr_return_missing_expr : Error<
 def warn_cxx11_compat_constexpr_body_no_return : Warning<
   "constexpr function with no return statements is incompatible with C++ "
   "standards before C++14">, InGroup<CXXPre14Compat>, DefaultIgnore;
+def ext_constexpr_body_multiple_return : ExtWarn<
+  "multiple return statements in constexpr function is a C++14 extension">,
+  InGroup<CXX14>;
+def warn_cxx11_compat_constexpr_body_multiple_return : Warning<
+  "multiple return statements in constexpr function "
+  "is incompatible with C++ standards before C++14">,
+  InGroup<CXXPre14Compat>, DefaultIgnore;
 def note_constexpr_body_previous_return : Note<
   "previous return statement is here">;
 def err_ms_constexpr_cannot_be_applied : Error<
   "attribute 'msvc::constexpr' cannot be applied to the %select{constexpr|consteval|virtual}0 function %1">;
 
+// C++20 function try blocks in constexpr
+def ext_constexpr_function_try_block_cxx20 : ExtWarn<
+  "function try block in constexpr %select{function|constructor}0 is "
+  "a C++20 extension">, InGroup<CXX20>;
+def warn_cxx17_compat_constexpr_function_try_block : Warning<
+  "function try block in constexpr %select{function|constructor}0 is "
+  "incompatible with C++ standards before C++20">,
+  InGroup<CXXPre20Compat>, DefaultIgnore;
+
+def ext_constexpr_union_ctor_no_init : ExtWarn<
+  "constexpr union constructor that does not initialize any member "
+  "is a C++20 extension">, InGroup<CXX20>;
+def warn_cxx17_compat_constexpr_union_ctor_no_init : Warning<
+  "constexpr union constructor that does not initialize any member "
+  "is incompatible with C++ standards before C++20">,
+  InGroup<CXXPre20Compat>, DefaultIgnore;
+def ext_constexpr_ctor_missing_init : ExtWarn<
+  "constexpr constructor that does not initialize all members "
+  "is a C++20 extension">, InGroup<CXX20>;
+def warn_cxx17_compat_constexpr_ctor_missing_init : Warning<
+  "constexpr constructor that does not initialize all members "
+  "is incompatible with C++ standards before C++20">,
+  InGroup<CXXPre20Compat>, DefaultIgnore;
 def note_constexpr_ctor_missing_init : Note<
   "member not initialized by constructor">;
 def note_non_literal_no_constexpr_ctors : Note<
@@ -3143,6 +3189,9 @@ def err_musttail_needs_call : Error<
 def err_musttail_needs_prototype : Error<
   "%0 attribute requires that both caller and callee functions have a "
   "prototype">;
+def err_musttail_conflicts_with_not_tail_called : Error<
+  "%0 musttail conflicts with not tail called"
+  >;
 def note_musttail_fix_non_prototype : Note<
   "add 'void' to the parameter list to turn an old-style K&R function "
   "declaration into a prototype">;
@@ -3195,10 +3244,6 @@ def err_attribute_wrong_number_arguments : Error<
 def err_attribute_wrong_number_arguments_for : Error <
   "%0 attribute references function %1, which %plural{0:takes no arguments|1:takes one argument|"
   ":takes exactly %2 arguments}2">;
-def err_callback_attribute_wrong_arg_count : Error<
-  "'callback' attribute references function of type %0 which expects %1 "
-  "%plural{1:argument|:arguments}1 but attribute specifies %2 parameter index "
-  "%plural{1:argument|:arguments}2">;
 def err_attribute_bounds_for_function : Error<
   "%0 attribute references parameter %1, but the function %2 has only %3 parameters">;
 def err_attribute_no_member_function : Error<
@@ -3555,10 +3600,6 @@ def err_conflicting_codeseg_attribute : Error<
   "conflicting code segment specifiers">;
 def warn_duplicate_codeseg_attribute : Warning<
   "duplicate code segment specifiers">, InGroup<Section>;
-
-def err_attribute_patchable_function_entry_invalid_section
-    : Error<"section argument to 'patchable_function_entry' attribute is not "
-            "valid for this target: %0">;
 
 def err_anonymous_property: Error<
   "anonymous property is not supported">;
@@ -5243,6 +5284,12 @@ def note_template_param_prev_default_arg_in_other_module : Note<
   "previous default template argument defined in module %0">;
 def err_template_param_default_arg_missing : Error<
   "template parameter missing a default argument">;
+def ext_template_parameter_default_in_function_template : ExtWarn<
+  "default template arguments for a function template are a C++11 extension">,
+  InGroup<CXX11>;
+def warn_cxx98_compat_template_parameter_default_in_function_template : Warning<
+  "default template arguments for a function template are incompatible with C++98">,
+  InGroup<CXX98Compat>, DefaultIgnore;
 def err_template_parameter_default_template_member : Error<
   "cannot add a default template argument to the definition of a member of a "
   "class template">;
@@ -5251,6 +5298,11 @@ def err_template_parameter_default_friend_template : Error<
 def err_template_template_parm_no_parms : Error<
   "template template parameter must have its own template parameters">;
 
+def ext_variable_template : ExtWarn<"variable templates are a C++14 extension">,
+  InGroup<CXX14>;
+def warn_cxx11_compat_variable_template : Warning<
+  "variable templates are incompatible with C++ standards before C++14">,
+  InGroup<CXXPre14Compat>, DefaultIgnore;
 def err_template_variable_noparams : Error<
   "extraneous 'template<>' in declaration of variable %0">;
 def err_template_member : Error<"non-static data member %0 cannot be declared as a template">;
@@ -5259,6 +5311,15 @@ def err_template_member_noparams : Error<
   "extraneous 'template<>' in declaration of member %0">;
 def err_template_tag_noparams : Error<
   "extraneous 'template<>' in declaration of %0 %1">;
+
+def warn_cxx17_compat_adl_only_template_id : Warning<
+  "use of function template name with no prior function template "
+  "declaration in function call with explicit template arguments "
+  "is incompatible with C++ standards before C++20">,
+  InGroup<CXXPre20Compat>, DefaultIgnore;
+def ext_adl_only_template_id : ExtWarn<
+  "use of function template name with no prior declaration in function call "
+  "with explicit template arguments is a C++20 extension">, InGroup<CXX20>;
 
 def warn_unqualified_call_to_std_cast_function : Warning<
   "unqualified call to '%0'">, InGroup<DiagGroup<"unqualified-std-cast-call">>;
@@ -5398,6 +5459,11 @@ def err_template_arg_not_pointer_to_member_form : Error<
   "non-type template argument is not a pointer to member constant">;
 def err_template_arg_invalid : Error<
   "non-type template argument '%0' is invalid">;
+def ext_template_arg_extra_parens : ExtWarn<
+  "address non-type template argument cannot be surrounded by parentheses">;
+def warn_cxx98_compat_template_arg_extra_parens : Warning<
+  "redundant parentheses surrounding address non-type template argument are "
+  "incompatible with C++98">, InGroup<CXX98Compat>, DefaultIgnore;
 def err_pointer_to_member_type : Error<
   "invalid use of pointer to member type after %select{.*|->*}0">;
 def err_pointer_to_member_call_drops_quals : Error<
@@ -5625,8 +5691,6 @@ def warn_func_template_missing : Warning<"instantiation of function %q0 "
   InGroup<UndefinedFuncTemplate>, DefaultIgnore;
 def note_forward_template_decl : Note<
   "forward declaration of template entity is here">;
-def note_unreachable_template_decl
-    : Note<"unreachable declaration of template entity is here">;
 def note_inst_declaration_hint : Note<"add an explicit instantiation "
   "declaration to suppress this warning if %q0 is explicitly instantiated in "
   "another translation unit">;
@@ -5812,6 +5876,11 @@ def err_typename_missing_template
 def ext_typename_missing
     : ExtWarn<"missing 'typename' prior to dependent type name %0">,
       InGroup<DiagGroup<"typename-missing">>;
+def ext_typename_outside_of_template : ExtWarn<
+  "'typename' occurs outside of a template">, InGroup<CXX11>;
+def warn_cxx98_compat_typename_outside_of_template : Warning<
+  "use of 'typename' outside of a template is incompatible with C++98">,
+  InGroup<CXX98Compat>, DefaultIgnore;
 def err_typename_refers_to_using_value_decl : Error<
   "typename specifier refers to a dependent using declaration for a value "
   "%0 in %1">;
@@ -6148,7 +6217,7 @@ def warn_possible_object_duplication_mutable : Warning<
   "it is mutable, has hidden visibility, and external linkage">,
   InGroup<UniqueObjectDuplication>, DefaultIgnore;
 def warn_possible_object_duplication_init : Warning<
-  "initialization of %0 may run twice when built into a shared library: "
+  "initializeation of %0 may run twice when built into a shared library: "
   "it has hidden visibility and external linkage">,
   InGroup<UniqueObjectDuplication>, DefaultIgnore;
 
@@ -6985,8 +7054,10 @@ def err_illegal_decl_mempointer_to_reference : Error<
   "'%0' declared as a member pointer to a reference of type %1">;
 def err_illegal_decl_mempointer_to_void : Error<
   "'%0' declared as a member pointer to void">;
-def err_illegal_decl_mempointer_in_nonclass
-    : Error<"%0 does not point into a class">;
+def err_illegal_decl_mempointer_in_nonclass : Error<
+  "'%0' does not point into a class">;
+def err_mempointer_in_nonclass_type : Error<
+  "member pointer refers into non-class type %0">;
 def err_reference_to_void : Error<"cannot form a reference to 'void'">;
 def err_nonfunction_block_type : Error<
   "block pointer to non-function type is invalid">;
@@ -7032,8 +7103,6 @@ def err_sizeof_alignof_typeof_bitfield : Error<
   "bit-field">;
 def err_alignof_member_of_incomplete_type : Error<
   "invalid application of 'alignof' to a field of a class still being defined">;
-def err_countof_arg_not_array_type : Error<
-  "'_Countof' requires an argument of array type; %0 invalid">;
 def err_vecstep_non_scalar_vector_type : Error<
   "'vec_step' requires built-in scalar or vector type, %0 invalid">;
 def err_offsetof_incomplete_type : Error<
@@ -7041,10 +7110,10 @@ def err_offsetof_incomplete_type : Error<
 def err_offsetof_record_type : Error<
   "offsetof requires struct, union, or class type, %0 invalid">;
 def err_offsetof_array_type : Error<"offsetof requires array type, %0 invalid">;
-def ext_offsetof_non_pod_type : ExtWarn<"'offsetof' on non-POD type %0">,
+def ext_offsetof_non_pod_type : ExtWarn<"offset of on non-POD type %0">,
   InGroup<InvalidOffsetof>;
 def ext_offsetof_non_standardlayout_type : ExtWarn<
-  "'offsetof' on non-standard-layout type %0">, InGroup<InvalidOffsetof>;
+  "offset of on non-standard-layout type %0">, InGroup<InvalidOffsetof>;
 def err_offsetof_bitfield : Error<"cannot compute offset of bit-field %0">;
 def err_offsetof_field_of_virtual_base : Error<
   "invalid application of 'offsetof' to a field of a virtual base">;
@@ -7564,13 +7633,9 @@ def warn_arith_conv_mixed_enum_types_cxx20 : Warning<
   "%sub{select_arith_conv_kind}0 "
   "different enumeration types%diff{ ($ and $)|}1,2 is deprecated">,
   InGroup<DeprecatedEnumEnumConversion>;
-
-def err_conv_mixed_enum_types: Error <
+def err_conv_mixed_enum_types_cxx26 : Error<
   "invalid %sub{select_arith_conv_kind}0 "
   "different enumeration types%diff{ ($ and $)|}1,2">;
-def warn_conv_mixed_enum_types_cxx26 : Warning <
-  err_conv_mixed_enum_types.Summary>,
-  InGroup<EnumEnumConversion>, DefaultError;
 
 def warn_arith_conv_mixed_anon_enum_types : Warning<
   warn_arith_conv_mixed_enum_types.Summary>,
@@ -8455,6 +8520,11 @@ let CategoryName = "Lambda Issue" in {
   def warn_cxx17_compat_lambda_def_ctor_assign : Warning<
     "%select{default construction|assignment}0 of lambda is incompatible with "
     "C++ standards before C++20">, InGroup<CXXPre20Compat>, DefaultIgnore;
+
+  // C++20 class template argument deduction for alias templates.
+  def warn_cxx17_compat_ctad_for_alias_templates : Warning<
+  "class template argument deduction for alias templates is incompatible with "
+  "C++ standards before C++20">, InGroup<CXXPre20Compat>, DefaultIgnore;
 }
 
 def err_return_in_captured_stmt : Error<
@@ -9448,9 +9518,6 @@ def warn_redefine_extname_not_applied : Warning<
 
 // inline asm.
 let CategoryName = "Inline Assembly Issue" in {
-  def err_asm_operand_empty_string : Error<
-     "cannot use an empty string literal in 'asm'">;
-
   def err_asm_pmf_through_constraint_not_permitted
     : Error<"cannot pass a pointer-to-member through register-constrained "
             "inline assembly parameter">;
@@ -10555,9 +10622,6 @@ def warn_second_arg_of_va_start_not_last_non_variadic_param : Warning<
   InGroup<Varargs>;
 def warn_c17_compat_ellipsis_only_parameter : Warning<
   "'...' as the only parameter of a function is incompatible with C standards "
-  "before C23">, DefaultIgnore, InGroup<CPre23Compat>;
-def warn_c17_compat_va_start_one_arg : Warning<
-  "passing only one argument to 'va_start' is incompatible with C standards "
   "before C23">, DefaultIgnore, InGroup<CPre23Compat>;
 def warn_va_start_type_is_undefined : Warning<
   "passing %select{an object that undergoes default argument promotion|"
@@ -12443,31 +12507,16 @@ def err_builtin_is_within_lifetime_invalid_arg : Error<
   "%select{non-|function }0pointer argument to '__builtin_is_within_lifetime' "
   "is not allowed">;
 
-// A multi-component builtin type diagnostic. The first component broadly
-// selects a scalar or container type (scalar, vector or matrix). The second
-// component selects integer types and the third component selects
-// floating-point types. Any component can be left empty.
-def err_builtin_invalid_arg_type: Error<
-  "%ordinal0 argument must be a "
-  // First component: scalar or container types
-  "%select{|scalar|vector|matrix|vector of|scalar or vector of}1"
-  // A comma after generic vector/matrix types if there are non-empty second
-  // and third components, to initiate a list.
-  "%plural{[2,3]:%plural{0:|:%plural{0:|:,}2}3|:}1"
-  // A space after a non-empty first component
-  "%plural{0:|: }1"
-  // Second component: integer-like types
-  "%select{|integer|signed integer|unsigned integer|'int'|"
-  "pointer to a valid matrix element}2"
-  // A space after a non-empty second component
-  "%plural{0:|: }2"
-  // An 'or' if non-empty second and third components are combined
-  "%plural{0:|:%plural{0:|:or }2}3"
-  // Third component: floating-point types
-  "%select{|floating-point}3"
-  // A space after a non-empty third component
-  "%plural{0:|: }3"
-  "%plural{[0,3]:type|:types}1 (was %4)">;
+def err_builtin_invalid_arg_type: Error <
+  "%ordinal0 argument must be "
+  "%select{a vector, integer or floating point type|a matrix|"
+  "a pointer to a valid matrix element type|"
+  "a signed integer or floating point type|a vector type|"
+  "a floating point type|"
+  "a vector of integers|"
+  "an unsigned integer|"
+  "an 'int'|"
+  "a vector of floating points}1 (was %2)">;
 
 def err_builtin_matrix_disabled: Error<
   "matrix types extension is disabled. Pass -fenable-matrix to enable it">;
@@ -13046,20 +13095,8 @@ def err_acc_magic_static_in_routine
 def err_acc_duplicate_bind
     : Error<"multiple 'routine' directives with 'bind' clauses are not "
             "permitted to refer to the same function">;
-def err_acc_duplicate_unnamed_bind
-    : Error<"OpenACC 'bind' clause on a declaration must bind to the same name "
-            "as previous bind clauses">;
-def warn_acc_confusing_routine_name
-    : Warning<"OpenACC 'routine' directive with a name refers to a function "
-              "with the same name as the function on the following line; this "
-              "may be unintended">,
-      InGroup<DiagGroup<"openacc-confusing-routine-name">>;
-def err_acc_decl_for_routine
-    : Error<"expected function or lambda declaration for 'routine' construct">;
-def err_acc_invalid_modifier
-    : Error<"OpenACC '%0' modifier not valid on '%1' clause">;
 
 // AMDGCN builtins diagnostics
-def err_amdgcn_load_lds_size_invalid_value : Error<"invalid size value">;
-def note_amdgcn_load_lds_size_valid_value : Note<"size must be %select{1, 2, or 4|1, 2, 4, 12 or 16}0">;
+def err_amdgcn_global_load_lds_size_invalid_value : Error<"invalid size value">;
+def note_amdgcn_global_load_lds_size_valid_value : Note<"size must be %select{1, 2, or 4|1, 2, 4, 12 or 16}0">;
 } // end of sema component.

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12,6 +12,61 @@
 
 let Component = "Sema" in {
 let CategoryName = "Semantic Issue" in {
+// C++11 compatibility with C++98.
+defm nonclass_type_friend : CXX11Compat<"non-class friend type %0 is">;
+defm static_data_member_in_union : CXX11Compat<"static data member %0 in union is">;
+defm templ_default_in_function_templ : CXX11Compat<
+  "default template arguments for a function template are">;
+defm template_arg_extra_parens : CXX11Compat<
+  "parentheses around address non-type template argument are">;
+defm typename_outside_of_template : CXX11Compat<"'typename' outside of a template is">;
+
+// C++14 compatibility with C++11 and earlier.
+defm constexpr_type_definition : CXX14Compat<
+  "type definition in a constexpr %select{function|constructor}0 is">;
+defm constexpr_local_var : CXX14Compat<
+  "variable declaration in a constexpr %select{function|constructor}0 is">;
+defm constexpr_body_multiple_return : CXX14Compat<
+  "multiple return statements in constexpr function is">;
+defm variable_template : CXX14Compat<"variable templates are">;
+
+// C++17 compatibility with C++14 and earlier.
+defm decomp_decl : CXX17Compat<"decomposition declarations are">;
+defm inline_variable : CXX17Compat<"inline variables are">;
+
+// C++20 compatibility with C++17 and earlier.
+defm decomp_decl_spec : CXX20Compat<
+  "decomposition declaration declared "
+  "%plural{1:'%1'|:with '%1' specifiers}0 is">;
+defm constexpr_local_var_no_init : CXX20Compat<
+  "uninitialized variable in a constexpr %select{function|constructor}0 is">;
+defm constexpr_function_try_block : CXX20Compat<
+  "function try block in constexpr %select{function|constructor}0 is">;
+defm constexpr_union_ctor_no_init : CXX20Compat<
+  "constexpr union constructor that does not initialize any member is">;
+defm constexpr_ctor_missing_init : CXX20Compat<
+  "constexpr constructor that does not initialize all members is">;
+defm adl_only_template_id : CXX20Compat<
+  "use of function template name with no prior declaration in function call "
+  "with explicit template arguments is">;
+defm ctad_for_alias_templates
+    : CXX20Compat<"class template argument deduction for alias templates is">;
+
+// C++23 compatibility with C++20 and earlier.
+defm constexpr_static_var : CXX23Compat<
+  "definition of a %select{static|thread_local}1 variable "
+  "in a constexpr %select{function|constructor}0 "
+  "is">;
+
+// C++26 compatibility with C++23 and earlier.
+defm decomp_decl_cond : CXX26Compat<"structured binding declaration in a condition is">;
+
+// Compatibility warnings duplicated across multiple language versions.
+foreach std = [14, 20, 23] in {
+  defm cxx#std#_constexpr_body_invalid_stmt : CXXCompat<
+    "use of this statement in a constexpr %select{function|constructor}0 is", std>;
+}
+
 def note_previous_decl : Note<"%0 declared here">;
 def note_entity_declared_at : Note<"%0 declared here">;
 def note_callee_decl : Note<"%0 declared here">;
@@ -492,7 +547,7 @@ def warn_qual_return_type : Warning<
   InGroup<IgnoredQualifiers>, DefaultIgnore;
 def warn_qual_base_type : Warning<
   "'%0' qualifier%s1 on base class type %2 %plural{1:has|:have}1 no effect">,
-  InGroup<IgnoredQualifiers>, DefaultIgnore;
+  InGroup<IgnoredBaseClassQualifiers>, DefaultIgnore;
 
 def warn_deprecated_redundant_constexpr_static_def : Warning<
   "out-of-line definition of constexpr static data member is redundant "
@@ -523,30 +578,9 @@ def warn_modifying_shadowing_decl :
 // C++ decomposition declarations
 def err_decomp_decl_context : Error<
   "decomposition declaration not permitted in this context">;
-def warn_cxx14_compat_decomp_decl : Warning<
-  "decomposition declarations are incompatible with "
-  "C++ standards before C++17">, DefaultIgnore, InGroup<CXXPre17Compat>;
-def ext_decomp_decl : ExtWarn<
-  "decomposition declarations are a C++17 extension">, InGroup<CXX17>;
-def ext_decomp_decl_cond : ExtWarn<
-  "structured binding declaration in a condition is a C++2c extenstion">,
-  InGroup<CXX26>;
-def warn_cxx26_decomp_decl_cond : Warning<
-  "structured binding declaration in a condition is incompatible with "
-  "C++ standards before C++2c">,
-  InGroup<CXXPre26Compat>, DefaultIgnore;
 def err_decomp_decl_spec : Error<
   "decomposition declaration cannot be declared "
   "%plural{1:'%1'|:with '%1' specifiers}0">;
-def ext_decomp_decl_spec : ExtWarn<
-  "decomposition declaration declared "
-  "%plural{1:'%1'|:with '%1' specifiers}0 is a C++20 extension">,
-  InGroup<CXX20>;
-def warn_cxx17_compat_decomp_decl_spec : Warning<
-  "decomposition declaration declared "
-  "%plural{1:'%1'|:with '%1' specifiers}0 "
-  "is incompatible with C++ standards before C++20">,
-  InGroup<CXXPre20Compat>, DefaultIgnore;
 def err_decomp_decl_type : Error<
   "decomposition declaration cannot be declared with type %0; "
   "declared type must be 'auto' or reference to 'auto'">;
@@ -591,6 +625,8 @@ def err_decomp_decl_std_tuple_size_not_constant : Error<
   "is not a valid integral constant expression">;
 def note_in_binding_decl_init : Note<
   "in implicit initialization of binding declaration %0">;
+def err_arg_is_not_destructurable : Error<
+  "type %0 cannot be decomposed">;
 
 def err_std_type_trait_not_class_template : Error<
   "unsupported standard library implementation: "
@@ -1663,34 +1699,35 @@ def err_static_assert_requirement_failed : Error<
   "static assertion failed due to requirement '%0'%select{: %2|}1">;
 def note_expr_evaluates_to : Note<
   "expression evaluates to '%0 %1 %2'">;
-def err_static_assert_invalid_message : Error<
-  "the message in a static assertion must be a string literal or an "
+
+
+def subst_user_defined_msg : TextSubstitution<
+  "%select{the message|the expression}0 in "
+  "%select{a static assertion|this asm operand}0">;
+
+def err_user_defined_msg_invalid : Error<
+  "%sub{subst_user_defined_msg}0 must be a string literal or an "
   "object with 'data()' and 'size()' member functions">;
-def err_static_assert_missing_member_function : Error<
-  "the message object in this static assertion is missing %select{"
+def err_user_defined_msg_missing_member_function : Error<
+  "the %select{message|string}0 object in "
+  "%select{this static assertion|this asm operand}0 is missing %select{"
   "a 'size()' member function|"
   "a 'data()' member function|"
-  "'data()' and 'size()' member functions}0">;
-def err_static_assert_invalid_mem_fn_ret_ty : Error<
-  "the message in a static assertion must have a '%select{size|data}0()' member "
-  "function returning an object convertible to '%select{std::size_t|const char *}0'">;
-def warn_static_assert_message_constexpr : Warning<
-  "the message in this static assertion is not a "
-  "constant expression">,
+  "'data()' and 'size()' member functions}1">;
+def err_user_defined_msg_invalid_mem_fn_ret_ty : Error<
+  "%sub{subst_user_defined_msg}0 must have a '%select{size|data}1()' member "
+  "function returning an object convertible to '%select{std::size_t|const char *}1'">;
+def warn_user_defined_msg_constexpr : Warning<
+  "%select{the message|the expression}0 in "
+  "%select{this static assertion|this asm operand}0 is not a constant expression">,
   DefaultError, InGroup<DiagGroup<"invalid-static-assert-message">>;
-def err_static_assert_message_constexpr : Error<
-  "the message in a static assertion must be produced by a "
+def err_user_defined_msg_constexpr : Error<
+  "%sub{subst_user_defined_msg}0 must be produced by a "
   "constant expression">;
 
 def warn_consteval_if_always_true : Warning<
   "consteval if is always true in an %select{unevaluated|immediate}0 context">,
   InGroup<DiagGroup<"redundant-consteval-if">>;
-
-def ext_inline_variable : ExtWarn<
-  "inline variables are a C++17 extension">, InGroup<CXX17>;
-def warn_cxx14_compat_inline_variable : Warning<
-  "inline variables are incompatible with C++ standards before C++17">,
-  DefaultIgnore, InGroup<CXXPre17Compat>;
 
 def warn_inline_namespace_reopened_noninline : Warning<
   "inline namespace reopened as a non-inline namespace">,
@@ -1707,11 +1744,6 @@ def ext_enum_friend : ExtWarn<
   InGroup<DiagGroup<"friend-enum">>;
 def note_enum_friend : Note<
   "remove 'enum%select{| struct| class}0' to befriend an enum">;
-def ext_nonclass_type_friend : ExtWarn<
-  "non-class friend type %0 is a C++11 extension">, InGroup<CXX11>;
-def warn_cxx98_compat_nonclass_type_friend : Warning<
-  "non-class friend type %0 is incompatible with C++98">,
-  InGroup<CXX98Compat>, DefaultIgnore;
 def err_friend_is_member : Error<
   "friends cannot be members of the declaring class">;
 def warn_cxx98_compat_friend_is_member : Warning<
@@ -2143,11 +2175,6 @@ def select_tag_type_kind : TextSubstitution<
 def err_static_data_member_not_allowed_in_anon_struct : Error<
   "static data member %0 not allowed in anonymous "
   "%sub{select_tag_type_kind}1">;
-def ext_static_data_member_in_union : ExtWarn<
-  "static data member %0 in union is a C++11 extension">, InGroup<CXX11>;
-def warn_cxx98_compat_static_data_member_in_union : Warning<
-  "static data member %0 in union is incompatible with C++98">,
-  InGroup<CXX98Compat>, DefaultIgnore;
 def ext_union_member_of_reference_type : ExtWarn<
   "union member %0 has reference type %1, which is a Microsoft extension">,
   InGroup<MicrosoftUnionMemberReference>;
@@ -2706,6 +2733,9 @@ def warn_final_dtor_non_final_class : Warning<
   InGroup<FinalDtorNonFinalClass>;
 def note_final_dtor_non_final_class_silence : Note<
   "mark %0 as '%select{final|sealed}1' to silence this warning">;
+def warn_unnecessary_virtual_specifier : Warning<
+  "virtual method %0 is inside a 'final' class and can never be overridden">,
+  InGroup<WarnUnnecessaryVirtualSpecifier>, DefaultIgnore;
 
 // C++11 attributes
 def err_repeat_attribute : Error<"%0 attribute cannot be repeated">;
@@ -2892,63 +2922,17 @@ def err_constexpr_non_literal_param : Error<
   "not a literal type">;
 def err_constexpr_body_invalid_stmt : Error<
   "statement not allowed in %select{constexpr|consteval}1 %select{function|constructor}0">;
-def ext_constexpr_body_invalid_stmt : ExtWarn<
-  "use of this statement in a constexpr %select{function|constructor}0 "
-  "is a C++14 extension">, InGroup<CXX14>;
-def warn_cxx11_compat_constexpr_body_invalid_stmt : Warning<
-  "use of this statement in a constexpr %select{function|constructor}0 "
-  "is incompatible with C++ standards before C++14">,
-  InGroup<CXXPre14Compat>, DefaultIgnore;
-def ext_constexpr_body_invalid_stmt_cxx20 : ExtWarn<
-  "use of this statement in a constexpr %select{function|constructor}0 "
-  "is a C++20 extension">, InGroup<CXX20>;
-def warn_cxx17_compat_constexpr_body_invalid_stmt : Warning<
-  "use of this statement in a constexpr %select{function|constructor}0 "
-  "is incompatible with C++ standards before C++20">,
-  InGroup<CXXPre20Compat>, DefaultIgnore;
-def ext_constexpr_body_invalid_stmt_cxx23 : ExtWarn<
-  "use of this statement in a constexpr %select{function|constructor}0 "
-  "is a C++23 extension">, InGroup<CXX23>;
-def warn_cxx20_compat_constexpr_body_invalid_stmt : Warning<
-  "use of this statement in a constexpr %select{function|constructor}0 "
-  "is incompatible with C++ standards before C++23">,
-  InGroup<CXXPre23Compat>, DefaultIgnore;
-def ext_constexpr_type_definition : ExtWarn<
-  "type definition in a constexpr %select{function|constructor}0 "
-  "is a C++14 extension">, InGroup<CXX14>;
-def warn_cxx11_compat_constexpr_type_definition : Warning<
-  "type definition in a constexpr %select{function|constructor}0 "
-  "is incompatible with C++ standards before C++14">,
-  InGroup<CXXPre14Compat>, DefaultIgnore;
 def err_constexpr_vla : Error<
   "variably-modified type %0 cannot be used in a constexpr "
   "%select{function|constructor}1">;
-def ext_constexpr_local_var : ExtWarn<
-  "variable declaration in a constexpr %select{function|constructor}0 "
-  "is a C++14 extension">, InGroup<CXX14>;
-def warn_cxx11_compat_constexpr_local_var : Warning<
-  "variable declaration in a constexpr %select{function|constructor}0 "
-  "is incompatible with C++ standards before C++14">,
-  InGroup<CXXPre14Compat>, DefaultIgnore;
-def ext_constexpr_static_var : ExtWarn<
-  "definition of a %select{static|thread_local}1 variable "
-  "in a constexpr %select{function|constructor}0 "
-  "is a C++23 extension">, InGroup<CXX23>;
 def warn_cxx20_compat_constexpr_var : Warning<
-  "definition of a %select{static variable|thread_local variable|variable "
-  "of non-literal type}1 in a constexpr %select{function|constructor}0 "
+  "definition of a variable of non-literal type in a constexpr "
+  "%select{function|constructor}0 "
   "is incompatible with C++ standards before C++23">,
   InGroup<CXXPre23Compat>, DefaultIgnore;
 def err_constexpr_local_var_non_literal_type : Error<
   "variable of non-literal type %1 cannot be defined in a constexpr "
   "%select{function|constructor}0 before C++23">;
-def ext_constexpr_local_var_no_init : ExtWarn<
-  "uninitialized variable in a constexpr %select{function|constructor}0 "
-  "is a C++20 extension">, InGroup<CXX20>;
-def warn_cxx17_compat_constexpr_local_var_no_init : Warning<
-  "uninitialized variable in a constexpr %select{function|constructor}0 "
-  "is incompatible with C++ standards before C++20">,
-  InGroup<CXXPre20Compat>, DefaultIgnore;
 def ext_constexpr_function_never_constant_expr : ExtWarn<
   "%select{constexpr|consteval}1 %select{function|constructor}0 never produces a "
   "constant expression">, InGroup<DiagGroup<"invalid-constexpr">>, DefaultError;
@@ -2970,41 +2954,11 @@ def err_constexpr_return_missing_expr : Error<
 def warn_cxx11_compat_constexpr_body_no_return : Warning<
   "constexpr function with no return statements is incompatible with C++ "
   "standards before C++14">, InGroup<CXXPre14Compat>, DefaultIgnore;
-def ext_constexpr_body_multiple_return : ExtWarn<
-  "multiple return statements in constexpr function is a C++14 extension">,
-  InGroup<CXX14>;
-def warn_cxx11_compat_constexpr_body_multiple_return : Warning<
-  "multiple return statements in constexpr function "
-  "is incompatible with C++ standards before C++14">,
-  InGroup<CXXPre14Compat>, DefaultIgnore;
 def note_constexpr_body_previous_return : Note<
   "previous return statement is here">;
 def err_ms_constexpr_cannot_be_applied : Error<
   "attribute 'msvc::constexpr' cannot be applied to the %select{constexpr|consteval|virtual}0 function %1">;
 
-// C++20 function try blocks in constexpr
-def ext_constexpr_function_try_block_cxx20 : ExtWarn<
-  "function try block in constexpr %select{function|constructor}0 is "
-  "a C++20 extension">, InGroup<CXX20>;
-def warn_cxx17_compat_constexpr_function_try_block : Warning<
-  "function try block in constexpr %select{function|constructor}0 is "
-  "incompatible with C++ standards before C++20">,
-  InGroup<CXXPre20Compat>, DefaultIgnore;
-
-def ext_constexpr_union_ctor_no_init : ExtWarn<
-  "constexpr union constructor that does not initialize any member "
-  "is a C++20 extension">, InGroup<CXX20>;
-def warn_cxx17_compat_constexpr_union_ctor_no_init : Warning<
-  "constexpr union constructor that does not initialize any member "
-  "is incompatible with C++ standards before C++20">,
-  InGroup<CXXPre20Compat>, DefaultIgnore;
-def ext_constexpr_ctor_missing_init : ExtWarn<
-  "constexpr constructor that does not initialize all members "
-  "is a C++20 extension">, InGroup<CXX20>;
-def warn_cxx17_compat_constexpr_ctor_missing_init : Warning<
-  "constexpr constructor that does not initialize all members "
-  "is incompatible with C++ standards before C++20">,
-  InGroup<CXXPre20Compat>, DefaultIgnore;
 def note_constexpr_ctor_missing_init : Note<
   "member not initialized by constructor">;
 def note_non_literal_no_constexpr_ctors : Note<
@@ -3180,6 +3134,9 @@ def warn_function_attribute_ignored_in_stmt : Warning<
   "use '%0' on statements">,
   InGroup<IgnoredAttributes>;
 
+def err_musttail_conflicts_with_not_tail_called : Error<
+  "%0 musttail conflicts with not tail called"
+  >;
 def err_musttail_needs_trivial_args : Error<
   "tail call requires that the return value, all parameters, and any "
   "temporaries created by the expression are trivially destructible">;
@@ -3189,9 +3146,6 @@ def err_musttail_needs_call : Error<
 def err_musttail_needs_prototype : Error<
   "%0 attribute requires that both caller and callee functions have a "
   "prototype">;
-def err_musttail_conflicts_with_not_tail_called : Error<
-  "%0 musttail conflicts with not tail called"
-  >;
 def note_musttail_fix_non_prototype : Note<
   "add 'void' to the parameter list to turn an old-style K&R function "
   "declaration into a prototype">;
@@ -3244,6 +3198,10 @@ def err_attribute_wrong_number_arguments : Error<
 def err_attribute_wrong_number_arguments_for : Error <
   "%0 attribute references function %1, which %plural{0:takes no arguments|1:takes one argument|"
   ":takes exactly %2 arguments}2">;
+def err_callback_attribute_wrong_arg_count : Error<
+  "'callback' attribute references function of type %0 which expects %1 "
+  "%plural{1:argument|:arguments}1 but attribute specifies %2 parameter index "
+  "%plural{1:argument|:arguments}2">;
 def err_attribute_bounds_for_function : Error<
   "%0 attribute references parameter %1, but the function %2 has only %3 parameters">;
 def err_attribute_no_member_function : Error<
@@ -3600,6 +3558,10 @@ def err_conflicting_codeseg_attribute : Error<
   "conflicting code segment specifiers">;
 def warn_duplicate_codeseg_attribute : Warning<
   "duplicate code segment specifiers">, InGroup<Section>;
+
+def err_attribute_patchable_function_entry_invalid_section
+    : Error<"section argument to 'patchable_function_entry' attribute is not "
+            "valid for this target: %0">;
 
 def err_anonymous_property: Error<
   "anonymous property is not supported">;
@@ -5284,12 +5246,6 @@ def note_template_param_prev_default_arg_in_other_module : Note<
   "previous default template argument defined in module %0">;
 def err_template_param_default_arg_missing : Error<
   "template parameter missing a default argument">;
-def ext_template_parameter_default_in_function_template : ExtWarn<
-  "default template arguments for a function template are a C++11 extension">,
-  InGroup<CXX11>;
-def warn_cxx98_compat_template_parameter_default_in_function_template : Warning<
-  "default template arguments for a function template are incompatible with C++98">,
-  InGroup<CXX98Compat>, DefaultIgnore;
 def err_template_parameter_default_template_member : Error<
   "cannot add a default template argument to the definition of a member of a "
   "class template">;
@@ -5298,11 +5254,6 @@ def err_template_parameter_default_friend_template : Error<
 def err_template_template_parm_no_parms : Error<
   "template template parameter must have its own template parameters">;
 
-def ext_variable_template : ExtWarn<"variable templates are a C++14 extension">,
-  InGroup<CXX14>;
-def warn_cxx11_compat_variable_template : Warning<
-  "variable templates are incompatible with C++ standards before C++14">,
-  InGroup<CXXPre14Compat>, DefaultIgnore;
 def err_template_variable_noparams : Error<
   "extraneous 'template<>' in declaration of variable %0">;
 def err_template_member : Error<"non-static data member %0 cannot be declared as a template">;
@@ -5311,15 +5262,6 @@ def err_template_member_noparams : Error<
   "extraneous 'template<>' in declaration of member %0">;
 def err_template_tag_noparams : Error<
   "extraneous 'template<>' in declaration of %0 %1">;
-
-def warn_cxx17_compat_adl_only_template_id : Warning<
-  "use of function template name with no prior function template "
-  "declaration in function call with explicit template arguments "
-  "is incompatible with C++ standards before C++20">,
-  InGroup<CXXPre20Compat>, DefaultIgnore;
-def ext_adl_only_template_id : ExtWarn<
-  "use of function template name with no prior declaration in function call "
-  "with explicit template arguments is a C++20 extension">, InGroup<CXX20>;
 
 def warn_unqualified_call_to_std_cast_function : Warning<
   "unqualified call to '%0'">, InGroup<DiagGroup<"unqualified-std-cast-call">>;
@@ -5459,11 +5401,6 @@ def err_template_arg_not_pointer_to_member_form : Error<
   "non-type template argument is not a pointer to member constant">;
 def err_template_arg_invalid : Error<
   "non-type template argument '%0' is invalid">;
-def ext_template_arg_extra_parens : ExtWarn<
-  "address non-type template argument cannot be surrounded by parentheses">;
-def warn_cxx98_compat_template_arg_extra_parens : Warning<
-  "redundant parentheses surrounding address non-type template argument are "
-  "incompatible with C++98">, InGroup<CXX98Compat>, DefaultIgnore;
 def err_pointer_to_member_type : Error<
   "invalid use of pointer to member type after %select{.*|->*}0">;
 def err_pointer_to_member_call_drops_quals : Error<
@@ -5691,6 +5628,8 @@ def warn_func_template_missing : Warning<"instantiation of function %q0 "
   InGroup<UndefinedFuncTemplate>, DefaultIgnore;
 def note_forward_template_decl : Note<
   "forward declaration of template entity is here">;
+def note_unreachable_template_decl
+    : Note<"unreachable declaration of template entity is here">;
 def note_inst_declaration_hint : Note<"add an explicit instantiation "
   "declaration to suppress this warning if %q0 is explicitly instantiated in "
   "another translation unit">;
@@ -5876,11 +5815,6 @@ def err_typename_missing_template
 def ext_typename_missing
     : ExtWarn<"missing 'typename' prior to dependent type name %0">,
       InGroup<DiagGroup<"typename-missing">>;
-def ext_typename_outside_of_template : ExtWarn<
-  "'typename' occurs outside of a template">, InGroup<CXX11>;
-def warn_cxx98_compat_typename_outside_of_template : Warning<
-  "use of 'typename' outside of a template is incompatible with C++98">,
-  InGroup<CXX98Compat>, DefaultIgnore;
 def err_typename_refers_to_using_value_decl : Error<
   "typename specifier refers to a dependent using declaration for a value "
   "%0 in %1">;
@@ -6217,7 +6151,7 @@ def warn_possible_object_duplication_mutable : Warning<
   "it is mutable, has hidden visibility, and external linkage">,
   InGroup<UniqueObjectDuplication>, DefaultIgnore;
 def warn_possible_object_duplication_init : Warning<
-  "initializeation of %0 may run twice when built into a shared library: "
+  "initialization of %0 may run twice when built into a shared library: "
   "it has hidden visibility and external linkage">,
   InGroup<UniqueObjectDuplication>, DefaultIgnore;
 
@@ -7054,10 +6988,8 @@ def err_illegal_decl_mempointer_to_reference : Error<
   "'%0' declared as a member pointer to a reference of type %1">;
 def err_illegal_decl_mempointer_to_void : Error<
   "'%0' declared as a member pointer to void">;
-def err_illegal_decl_mempointer_in_nonclass : Error<
-  "'%0' does not point into a class">;
-def err_mempointer_in_nonclass_type : Error<
-  "member pointer refers into non-class type %0">;
+def err_illegal_decl_mempointer_in_nonclass
+    : Error<"%0 does not point into a class">;
 def err_reference_to_void : Error<"cannot form a reference to 'void'">;
 def err_nonfunction_block_type : Error<
   "block pointer to non-function type is invalid">;
@@ -7103,6 +7035,8 @@ def err_sizeof_alignof_typeof_bitfield : Error<
   "bit-field">;
 def err_alignof_member_of_incomplete_type : Error<
   "invalid application of 'alignof' to a field of a class still being defined">;
+def err_countof_arg_not_array_type : Error<
+  "'_Countof' requires an argument of array type; %0 invalid">;
 def err_vecstep_non_scalar_vector_type : Error<
   "'vec_step' requires built-in scalar or vector type, %0 invalid">;
 def err_offsetof_incomplete_type : Error<
@@ -7110,10 +7044,10 @@ def err_offsetof_incomplete_type : Error<
 def err_offsetof_record_type : Error<
   "offsetof requires struct, union, or class type, %0 invalid">;
 def err_offsetof_array_type : Error<"offsetof requires array type, %0 invalid">;
-def ext_offsetof_non_pod_type : ExtWarn<"offset of on non-POD type %0">,
+def ext_offsetof_non_pod_type : ExtWarn<"'offsetof' on non-POD type %0">,
   InGroup<InvalidOffsetof>;
 def ext_offsetof_non_standardlayout_type : ExtWarn<
-  "offset of on non-standard-layout type %0">, InGroup<InvalidOffsetof>;
+  "'offsetof' on non-standard-layout type %0">, InGroup<InvalidOffsetof>;
 def err_offsetof_bitfield : Error<"cannot compute offset of bit-field %0">;
 def err_offsetof_field_of_virtual_base : Error<
   "invalid application of 'offsetof' to a field of a virtual base">;
@@ -7633,9 +7567,13 @@ def warn_arith_conv_mixed_enum_types_cxx20 : Warning<
   "%sub{select_arith_conv_kind}0 "
   "different enumeration types%diff{ ($ and $)|}1,2 is deprecated">,
   InGroup<DeprecatedEnumEnumConversion>;
-def err_conv_mixed_enum_types_cxx26 : Error<
+
+def err_conv_mixed_enum_types: Error <
   "invalid %sub{select_arith_conv_kind}0 "
   "different enumeration types%diff{ ($ and $)|}1,2">;
+def warn_conv_mixed_enum_types_cxx26 : Warning <
+  err_conv_mixed_enum_types.Summary>,
+  InGroup<EnumEnumConversion>, DefaultError;
 
 def warn_arith_conv_mixed_anon_enum_types : Warning<
   warn_arith_conv_mixed_enum_types.Summary>,
@@ -8520,11 +8458,6 @@ let CategoryName = "Lambda Issue" in {
   def warn_cxx17_compat_lambda_def_ctor_assign : Warning<
     "%select{default construction|assignment}0 of lambda is incompatible with "
     "C++ standards before C++20">, InGroup<CXXPre20Compat>, DefaultIgnore;
-
-  // C++20 class template argument deduction for alias templates.
-  def warn_cxx17_compat_ctad_for_alias_templates : Warning<
-  "class template argument deduction for alias templates is incompatible with "
-  "C++ standards before C++20">, InGroup<CXXPre20Compat>, DefaultIgnore;
 }
 
 def err_return_in_captured_stmt : Error<
@@ -9518,6 +9451,9 @@ def warn_redefine_extname_not_applied : Warning<
 
 // inline asm.
 let CategoryName = "Inline Assembly Issue" in {
+  def err_asm_operand_empty_string : Error<
+     "cannot use an empty string literal in 'asm'">;
+
   def err_asm_pmf_through_constraint_not_permitted
     : Error<"cannot pass a pointer-to-member through register-constrained "
             "inline assembly parameter">;
@@ -10622,6 +10558,9 @@ def warn_second_arg_of_va_start_not_last_non_variadic_param : Warning<
   InGroup<Varargs>;
 def warn_c17_compat_ellipsis_only_parameter : Warning<
   "'...' as the only parameter of a function is incompatible with C standards "
+  "before C23">, DefaultIgnore, InGroup<CPre23Compat>;
+def warn_c17_compat_va_start_one_arg : Warning<
+  "passing only one argument to 'va_start' is incompatible with C standards "
   "before C23">, DefaultIgnore, InGroup<CPre23Compat>;
 def warn_va_start_type_is_undefined : Warning<
   "passing %select{an object that undergoes default argument promotion|"
@@ -12507,16 +12446,31 @@ def err_builtin_is_within_lifetime_invalid_arg : Error<
   "%select{non-|function }0pointer argument to '__builtin_is_within_lifetime' "
   "is not allowed">;
 
-def err_builtin_invalid_arg_type: Error <
-  "%ordinal0 argument must be "
-  "%select{a vector, integer or floating point type|a matrix|"
-  "a pointer to a valid matrix element type|"
-  "a signed integer or floating point type|a vector type|"
-  "a floating point type|"
-  "a vector of integers|"
-  "an unsigned integer|"
-  "an 'int'|"
-  "a vector of floating points}1 (was %2)">;
+// A multi-component builtin type diagnostic. The first component broadly
+// selects a scalar or container type (scalar, vector or matrix). The second
+// component selects integer types and the third component selects
+// floating-point types. Any component can be left empty.
+def err_builtin_invalid_arg_type: Error<
+  "%ordinal0 argument must be a "
+  // First component: scalar or container types
+  "%select{|scalar|vector|matrix|vector of|scalar or vector of}1"
+  // A comma after generic vector/matrix types if there are non-empty second
+  // and third components, to initiate a list.
+  "%plural{[2,3]:%plural{0:|:%plural{0:|:,}2}3|:}1"
+  // A space after a non-empty first component
+  "%plural{0:|: }1"
+  // Second component: integer-like types
+  "%select{|integer|signed integer|unsigned integer|'int'|"
+  "pointer to a valid matrix element}2"
+  // A space after a non-empty second component
+  "%plural{0:|: }2"
+  // An 'or' if non-empty second and third components are combined
+  "%plural{0:|:%plural{0:|:or }2}3"
+  // Third component: floating-point types
+  "%select{|floating-point}3"
+  // A space after a non-empty third component
+  "%plural{0:|: }3"
+  "%plural{[0,3]:type|:types}1 (was %4)">;
 
 def err_builtin_matrix_disabled: Error<
   "matrix types extension is disabled. Pass -fenable-matrix to enable it">;
@@ -13095,8 +13049,20 @@ def err_acc_magic_static_in_routine
 def err_acc_duplicate_bind
     : Error<"multiple 'routine' directives with 'bind' clauses are not "
             "permitted to refer to the same function">;
+def err_acc_duplicate_unnamed_bind
+    : Error<"OpenACC 'bind' clause on a declaration must bind to the same name "
+            "as previous bind clauses">;
+def warn_acc_confusing_routine_name
+    : Warning<"OpenACC 'routine' directive with a name refers to a function "
+              "with the same name as the function on the following line; this "
+              "may be unintended">,
+      InGroup<DiagGroup<"openacc-confusing-routine-name">>;
+def err_acc_decl_for_routine
+    : Error<"expected function or lambda declaration for 'routine' construct">;
+def err_acc_invalid_modifier
+    : Error<"OpenACC '%0' modifier not valid on '%1' clause">;
 
 // AMDGCN builtins diagnostics
-def err_amdgcn_global_load_lds_size_invalid_value : Error<"invalid size value">;
-def note_amdgcn_global_load_lds_size_valid_value : Note<"size must be %select{1, 2, or 4|1, 2, 4, 12 or 16}0">;
+def err_amdgcn_load_lds_size_invalid_value : Error<"invalid size value">;
+def note_amdgcn_load_lds_size_valid_value : Note<"size must be %select{1, 2, or 4|1, 2, 4, 12 or 16}0">;
 } // end of sema component.

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -717,6 +717,14 @@ bool Sema::checkMustTailAttr(const Stmt *St, const Attr &MTA) {
     return false;
   }
 
+  if (const FunctionDecl *CalleeDecl = CE->getDirectCallee()) {
+    if (CalleeDecl->hasAttr<NotTailCalledAttr>()) {
+      Diag(St->getBeginLoc(), diag::err_musttail_conflicts_with_not_tail_called)
+          << &MTA;
+      return false;
+    }
+  }
+
   if (const auto *EWC = dyn_cast<ExprWithCleanups>(E)) {
     if (EWC->cleanupsHaveSideEffects()) {
       Diag(St->getBeginLoc(), diag::err_musttail_needs_trivial_args) << &MTA;

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -719,7 +719,8 @@ bool Sema::checkMustTailAttr(const Stmt *St, const Attr &MTA) {
 
   if (const FunctionDecl *CalleeDecl = CE->getDirectCallee();
       CalleeDecl && CalleeDecl->hasAttr<NotTailCalledAttr>()) {
-    Diag(St->getBeginLoc(), diag::err_musttail_mismatch) << true << CalleeDecl;
+    Diag(St->getBeginLoc(), diag::err_musttail_mismatch) << /*show-function-callee=*/true << CalleeDecl;
+    Diag(CalleeDecl->getLocation(), diag::note_musttail_disabled_by_not_tail_called) << CalleeDecl;
     return false;
   }
 

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -719,7 +719,7 @@ bool Sema::checkMustTailAttr(const Stmt *St, const Attr &MTA) {
 
   if (const FunctionDecl *CalleeDecl = CE->getDirectCallee();
       CalleeDecl && CalleeDecl->hasAttr<NotTailCalledAttr>()) {
-    Diag(St->getBeginLoc(), diag::err_musttail_mismatch) << CalleeDecl;
+    Diag(St->getBeginLoc(), diag::err_musttail_mismatch) << true << CalleeDecl;
     return false;
   }
 

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -719,7 +719,7 @@ bool Sema::checkMustTailAttr(const Stmt *St, const Attr &MTA) {
 
   if (const FunctionDecl *CalleeDecl = CE->getDirectCallee();
       CalleeDecl && CalleeDecl->hasAttr<NotTailCalledAttr>()) {
-    Diag(St->getBeginLoc(), diag::err_musttail_mismatch) << &MTA;
+    Diag(St->getBeginLoc(), diag::err_musttail_mismatch) << CalleeDecl;
     return false;
   }
 

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -718,10 +718,9 @@ bool Sema::checkMustTailAttr(const Stmt *St, const Attr &MTA) {
   }
 
   if (const FunctionDecl *CalleeDecl = CE->getDirectCallee();
-     CalleeDecl && CalleeDecl->hasAttr<NotTailCalledAttr>()) {
-      Diag(St->getBeginLoc(), diag::err_musttail_mismatch)
-      << &MTA;
-     return false;
+      CalleeDecl && CalleeDecl->hasAttr<NotTailCalledAttr>()) {
+    Diag(St->getBeginLoc(), diag::err_musttail_mismatch) << &MTA;
+    return false;
   }
 
   if (const auto *EWC = dyn_cast<ExprWithCleanups>(E)) {

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -720,7 +720,7 @@ bool Sema::checkMustTailAttr(const Stmt *St, const Attr &MTA) {
   if (const FunctionDecl *CalleeDecl = CE->getDirectCallee();
       CalleeDecl && CalleeDecl->hasAttr<NotTailCalledAttr>()) {
     Diag(St->getBeginLoc(), diag::err_musttail_mismatch) << /*show-function-callee=*/true << CalleeDecl;
-    Diag(CalleeDecl->getLocation(), diag::note_musttail_disabled_by_not_tail_called) << CalleeDecl;
+    Diag(CalleeDecl->getLocation(), diag::note_musttail_disabled_by_not_tail_called);
     return false;
   }
 

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -717,12 +717,11 @@ bool Sema::checkMustTailAttr(const Stmt *St, const Attr &MTA) {
     return false;
   }
 
-  if (const FunctionDecl *CalleeDecl = CE->getDirectCallee()) {
-    if (CalleeDecl->hasAttr<NotTailCalledAttr>()) {
-      Diag(St->getBeginLoc(), diag::err_musttail_conflicts_with_not_tail_called)
-          << &MTA;
-      return false;
-    }
+  if (const FunctionDecl *CalleeDecl = CE->getDirectCallee();
+     CalleeDecl && CalleeDecl->hasAttr<NotTailCalledAttr>()) {
+      Diag(St->getBeginLoc(), diag::err_musttail_mismatch)
+      << &MTA;
+     return false;
   }
 
   if (const auto *EWC = dyn_cast<ExprWithCleanups>(E)) {

--- a/clang/test/Sema/attr-musttail.cpp
+++ b/clang/test/Sema/attr-musttail.cpp
@@ -7,7 +7,7 @@ int __attribute__((not_tail_called)) foo1(int a) {
 
 int foo2(int a) {
     [[clang::musttail]] 
-    return foo1(a);  // expected-error{{cannot perform a tail call to function'foo1' because its signature is incompatible with the calling function}}
+    return foo1(a);  // expected-error {{cannot perform a tail call to function 'foo1' because its signature is incompatible with the calling function}}
 }
 
 int main() {

--- a/clang/test/Sema/attr-musttail.cpp
+++ b/clang/test/Sema/attr-musttail.cpp
@@ -7,10 +7,11 @@ int __attribute__((not_tail_called)) foo1(int a) {
 
 int foo2(int a) {
     [[clang::musttail]] 
-    return foo1(a);  // expected-error{{cannot perform a tail call to function'musttail' because its signature is incompatible with the calling function}}
+    return foo1(a);  // expected-error{{cannot perform a tail call to function 'musttail' because its signature is incompatible with the calling function}}
 }
 
 int main() {
     int result = foo2(10);      
     return 0;
 }
+

--- a/clang/test/Sema/attr-musttail.cpp
+++ b/clang/test/Sema/attr-musttail.cpp
@@ -1,13 +1,13 @@
 // RUN: %clang_cc1 -verify -fsyntax-only %s
 
-int __attribute__((not_tail_called)) foo1(int a) {
+int __attribute__((not_tail_called)) foo1(int a) {// expected-note {{'not_tail_called' attribute here prevents being called as a tail call}}
     return a + 1;  
 }
 
 
 int foo2(int a) {
     [[clang::musttail]] 
-    return foo1(a);  // expected-error {{cannot perform a tail call to function 'foo1' because its signature is incompatible with the calling function}}
+    return foo1(a);  // expected-error {{cannot perform a tail call to function 'foo1' because its signature is incompatible with the calling function}}    `note: 'not_tail_called' attribute here prevents being called as a tail call'
 }
 
 int main() {

--- a/clang/test/Sema/attr-musttail.cpp
+++ b/clang/test/Sema/attr-musttail.cpp
@@ -7,7 +7,7 @@ int __attribute__((not_tail_called)) foo1(int a) {
 
 int foo2(int a) {
     [[clang::musttail]] 
-    return foo1(a);  // expected-error{{cannot perform a tail call to function 'musttail' because its signature is incompatible with the calling function}}
+    return foo1(a);  // expected-error{{cannot perform a tail call to function'foo1' because its signature is incompatible with the calling function}}
 }
 
 int main() {

--- a/clang/test/Sema/attr-musttail.cpp
+++ b/clang/test/Sema/attr-musttail.cpp
@@ -1,13 +1,13 @@
 // RUN: %clang_cc1 -verify -fsyntax-only %s
 
-int __attribute__((not_tail_called)) foo1(int a) {// expected-note {{'not_tail_called' attribute here prevents being called as a tail call}}
+int __attribute__((not_tail_called)) foo1(int a) {// expected-note {{'not_tail_called' attribute prevents being called as a tail call}}
     return a + 1;  
 }
 
 
 int foo2(int a) {
     [[clang::musttail]] 
-    return foo1(a);  // expected-error {{cannot perform a tail call to function 'foo1' because its signature is incompatible with the calling function}}    `note: 'not_tail_called' attribute here prevents being called as a tail call'
+    return foo1(a);  // expected-error {{cannot perform a tail call to function 'foo1' because its signature is incompatible with the calling function}} 
 }
 
 int main() {

--- a/clang/test/Sema/attr-musttail.cpp
+++ b/clang/test/Sema/attr-musttail.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -verify -fsyntax-only %s
+
+int __attribute__((not_tail_called)) foo1(int a) {
+    return a + 1;  
+}
+
+
+int foo2(int a) {
+    [[clang::musttail]] 
+    return foo1(a);  // expected-error{{cannot perform a tail call to function'musttail' because its signature is incompatible with the calling function}}
+}
+
+int main() {
+    int result = foo2(10);      
+    return 0;
+}


### PR DESCRIPTION
The error is emitted when a musttail call is made to a function marked with the not_tail_called attribute.Closes #133509