### PR TITLE
[MLIR][Affine] Fix signatures of normalize memref utilities

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/Utils.h
+++ b/mlir/include/mlir/Dialect/Affine/Utils.h
@@ -247,11 +247,11 @@ LogicalResult replaceAllMemRefUsesWith(Value oldMemRef, Value newMemRef,
 /// and updates all its indexing uses. Returns failure if any of its uses
 /// escape (while leaving the IR in a valid state).
 template <typename AllocLikeOp>
-LogicalResult normalizeMemRef(AllocLikeOp *op);
+LogicalResult normalizeMemRef(AllocLikeOp op);
 extern template LogicalResult
-normalizeMemRef<memref::AllocaOp>(memref::AllocaOp *op);
+normalizeMemRef<memref::AllocaOp>(memref::AllocaOp op);
 extern template LogicalResult
-normalizeMemRef<memref::AllocOp>(memref::AllocOp *op);
+normalizeMemRef<memref::AllocOp>(memref::AllocOp op);
 
 /// Normalizes `memrefType` so that the affine layout map of the memref is
 /// transformed to an identity map with a new shape being computed for the

--- a/mlir/lib/Dialect/MemRef/Transforms/NormalizeMemRefs.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/NormalizeMemRefs.cpp
@@ -356,12 +356,12 @@ void NormalizeMemRefs::normalizeFuncOpMemRefs(func::FuncOp funcOp,
   SmallVector<memref::AllocOp, 4> allocOps;
   funcOp.walk([&](memref::AllocOp op) { allocOps.push_back(op); });
   for (memref::AllocOp allocOp : allocOps)
-    (void)normalizeMemRef(&allocOp);
+    (void)normalizeMemRef(allocOp);
 
   SmallVector<memref::AllocaOp> allocaOps;
   funcOp.walk([&](memref::AllocaOp op) { allocaOps.push_back(op); });
   for (memref::AllocaOp allocaOp : allocaOps)
-    (void)normalizeMemRef(&allocaOp);
+    (void)normalizeMemRef(allocaOp);
 
   // We use this OpBuilder to create new memref layout later.
   OpBuilder b(funcOp);


### PR DESCRIPTION
These methods were passing derived op types by pointers, which deviates
from the style. While on this, fix obsolete comments on those methods.
