### PR TITLE
[ctxprof] Use `isInSpecializedModule` as criteria for using contextual profile

### DIFF
--- a/llvm/lib/Transforms/IPO/ModuleInliner.cpp
+++ b/llvm/lib/Transforms/IPO/ModuleInliner.cpp
@@ -171,8 +171,8 @@ PreservedAnalyses ModuleInlinerPass::run(Module &M,
                      << setIsVerbose();
             });
           }
-        } else if (CtxProfPromoteAlwaysInline && !CtxProf.contexts().empty() &&
-                   CB->isIndirectCall()) {
+        } else if (CtxProfPromoteAlwaysInline &&
+                   CtxProf.isInSpecializedModule() && CB->isIndirectCall()) {
           CtxProfAnalysis::collectIndirectCallPromotionList(*CB, CtxProf,
                                                             ICPCandidates);
         }
@@ -260,7 +260,7 @@ PreservedAnalyses ModuleInlinerPass::run(Module &M,
           // iteration because the next iteration may not happen and we may
           // miss inlining it.
           // FIXME: enable for ctxprof.
-          if (CtxProf.contexts().empty())
+          if (CtxProf.isInSpecializedModule())
             if (tryPromoteCall(*ICB))
               NewCallee = ICB->getCalledFunction();
         }

--- a/llvm/lib/Transforms/Utils/InlineFunction.cpp
+++ b/llvm/lib/Transforms/Utils/InlineFunction.cpp
@@ -2356,7 +2356,7 @@ llvm::InlineResult llvm::InlineFunction(CallBase &CB, InlineFunctionInfo &IFI,
                                         AAResults *CalleeAAR,
                                         bool InsertLifetime,
                                         Function *ForwardVarArgsTo) {
-  if (CtxProf.contexts().empty())
+  if (!CtxProf.isInSpecializedModule())
     return InlineFunction(CB, IFI, MergeAttributes, CalleeAAR, InsertLifetime,
                           ForwardVarArgsTo);
 

--- a/llvm/test/Analysis/CtxProfAnalysis/handle-select.ll
+++ b/llvm/test/Analysis/CtxProfAnalysis/handle-select.ll
@@ -6,9 +6,9 @@
 ; RUN: split-file %s %t
 ; RUN: llvm-ctxprof-util fromYAML --input=%t/profile.yaml --output=%t/profile.ctxprofdata
 ;
-; RUN: opt -passes=ctx-instr-gen %t/example.ll -use-ctx-profile=%t/profile.ctxprofdata -S -o - | FileCheck %s --check-prefix=INSTR
-; RUN: opt -passes=ctx-instr-gen,module-inline %t/example.ll -use-ctx-profile=%t/profile.ctxprofdata -S -o - | FileCheck %s --check-prefix=POST-INL
-; RUN: opt -passes=ctx-instr-gen,module-inline,ctx-prof-flatten %t/example.ll -use-ctx-profile=%t/profile.ctxprofdata -S -o - | FileCheck %s --check-prefix=FLATTEN
+; RUN: opt -passes=ctx-instr-gen %t/1234.ll -use-ctx-profile=%t/profile.ctxprofdata -S -o - | FileCheck %s --check-prefix=INSTR
+; RUN: opt -passes=ctx-instr-gen,module-inline %t/1234.ll -use-ctx-profile=%t/profile.ctxprofdata -S -o - | FileCheck %s --check-prefix=POST-INL
+; RUN: opt -passes=ctx-instr-gen,module-inline,ctx-prof-flatten %t/1234.ll -use-ctx-profile=%t/profile.ctxprofdata -S -o - | FileCheck %s --check-prefix=FLATTEN
 
 ; INSTR-LABEL: yes:
 ; INSTR-NEXT:   call void @llvm.instrprof.increment(ptr @foo, i64 [[#]], i32 2, i32 1)
@@ -45,7 +45,7 @@
 ; entry count of that BB is 4.
 ; ![[SELPROF]] = !{!"branch_weights", i32 3, i32 1}
 
-;--- example.ll
+;--- 1234.ll
 define i32 @foo(i32 %t) !guid !0 {
   %test = icmp slt i32 %t, 0
   br i1 %test, label %yes, label %no

--- a/llvm/test/Analysis/CtxProfAnalysis/inline.ll
+++ b/llvm/test/Analysis/CtxProfAnalysis/inline.ll
@@ -3,7 +3,7 @@
 ; RUN: split-file %s %t
 ; RUN: llvm-ctxprof-util fromYAML --input=%t/profile.yaml --output=%t/profile.ctxprofdata
 
-; RUN: opt -passes='module-inline,print<ctx-prof-analysis>' -ctx-profile-printer-level=everything %t/module.ll -S \
+; RUN: opt -passes='module-inline,print<ctx-prof-analysis>' -ctx-profile-printer-level=everything %t/1000.ll -S \
 ; RUN:   -use-ctx-profile=%t/profile.ctxprofdata -ctx-profile-printer-level=yaml \
 ; RUN:   -o - 2> %t/profile-final.yaml | FileCheck %s
 ; RUN: diff %t/profile-final.yaml %t/expected.yaml
@@ -34,7 +34,7 @@
 
 ; Make sure the postlink thinlto pipeline is aware of ctxprof
 ; RUN: opt -passes='thinlto<O2>' -use-ctx-profile=%t/profile.ctxprofdata \
-; RUN:   %t/module.ll -S -o - | FileCheck %s --check-prefix=PIPELINE
+; RUN:   %t/1000.ll -S -o - | FileCheck %s --check-prefix=PIPELINE
 
 ; PIPELINE-LABEL: define i32 @entrypoint
 ; PIPELINE-SAME: !prof ![[ENTRYPOINT_COUNT:[0-9]+]]
@@ -50,7 +50,7 @@
 ; These are the weights of the un-inlined @a, where the counters were 8, 500 (8 for entry, 500 for loop)
 ; PIPELINE: ![[LOOP_BW_ORIG]] = !{!"branch_weights", i32 492, i32 8}
 
-;--- module.ll
+;--- 1000.ll
 define i32 @entrypoint(i32 %x) !guid !0 {
   call void @llvm.instrprof.increment(ptr @entrypoint, i64 0, i32 3, i32 0)
   %t = icmp eq i32 %x, 0


### PR DESCRIPTION
After #134340, the availability of contextual profile isn't in itself an indication of compiling the module containing all the functions covered by that profile.