### PR TITLE
[Clang][AMDGPU] Enable `avail-extern-to-local` for ThinLTO in HIP

### DIFF
--- a/clang/lib/Driver/ToolChains/HIPAMD.cpp
+++ b/clang/lib/Driver/ToolChains/HIPAMD.cpp
@@ -103,8 +103,10 @@ void AMDGCN::Linker::constructLldCommand(Compilation &C, const JobAction &JA,
   // ToDo: Remove this option after AMDGPU backend supports ISA-level linking.
   // Since AMDGPU backend currently does not support ISA-level linking, all
   // called functions need to be imported.
-  if (IsThinLTO)
+  if (IsThinLTO) {
     LldArgs.push_back(Args.MakeArgString("-plugin-opt=-force-import-all"));
+    LldArgs.push_back(Args.MakeArgString("-plugin-opt=-avail-extern-to-local"));
+  }
 
   for (const Arg *A : Args.filtered(options::OPT_mllvm)) {
     LldArgs.push_back(

--- a/clang/test/Driver/hip-thinlto.hip
+++ b/clang/test/Driver/hip-thinlto.hip
@@ -1,0 +1,8 @@
+// RUN: %clang -foffload-lto=thin -nogpulib -nogpuinc %s -### 2>&1 | FileCheck %s
+
+// CHECK: -plugin-opt=thinlto
+// CHECK-SAME: -plugin-opt=-force-import-all
+// CHECK-SAME: -plugin-opt=-avail-extern-to-local
+int main(int, char *[]) {
+  return 0;
+}


### PR DESCRIPTION
In HIP, the Clang driver already sets `force-import-all` when ThinLTO is
enabled. As a result, all imported functions get the `available_externally`
linkage. However, these functions are later removed by the
`EliminateAvailableExternallyPass`, effectively undoing the forced import and
eventually leading to link errors.

The `EliminateAvailableExternallyPass` provides an option to convert
`available_externally` functions into local functions, renaming them to avoid
conflicts. This behavior is exactly what we need for HIP. This PR enables that
option (`avail-extern-to-local`) alongside `force-import-all` when ThinLTO is
used.

With this change, ThinLTO almost works correctly on AMDGPU. The only remaining
issue is an undefined reference to `__assert_fail`, but that falls outside the
scope of this PR.