### PR TITLE
[X86][Test] Reorder PassMgrF and OS.

### DIFF
--- a/llvm/unittests/CodeGen/X86MCInstLowerTest.cpp
+++ b/llvm/unittests/CodeGen/X86MCInstLowerTest.cpp
@@ -151,9 +151,10 @@ TEST_F(X86MCInstLowerTest, moExternalSymbol_MCSYMBOL) {
   MachineModuleInfoWrapperPass *MMIWP =
       new MachineModuleInfoWrapperPass(TM.get(), &*MCFoo);
 
-  legacy::PassManager PassMgrF;
   SmallString<1024> Buf;
   llvm::raw_svector_ostream OS(Buf);
+  legacy::PassManager PassMgrF;
+
   AsmPrinter *Printer =
       addPassesToEmitFile(PassMgrF, OS, CodeGenFileType::AssemblyFile, MMIWP);
   PassMgrF.run(*M);


### PR DESCRIPTION
Reordering `OS` and `PassMgrF` should fix the asan failure that's caused by OS being destroyed before `PassMgrF` deletes the AsmPrinter.

As shown in[ this asan run ](https://lab.llvm.org/buildbot/#/builders/52/builds/7340/steps/12/logs/stdio)

```
  This frame has 15 object(s):
    [32, 48) 'PassMgrF' (line 154)
    [64, 1112) 'Buf' (line 155)
    [1248, 1304) 'OS' (line 156) <== Memory access at offset 1280 is inside this variable
```
which indicates an ordering problem. 

This should help to fix all the sanitizer failures caused by the test `X86MCInstLowerTest.cpp` that's introduced by [this PR](https://github.com/llvm/llvm-project/pull/133352#issuecomment-2780173791).