### PR TITLE
[LLVM][Demangle] Fix MS Demangler to be stricter about wide string literals

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -70,6 +70,8 @@ Changes to LLVM infrastructure
 
 * Removed support for target intrinsics being defined in the target directories
   themselves (i.e., the `TargetIntrinsicInfo` class).
+* Fix Microsoft demanling of string literals to be stricter
+  ([Fixes 129970](https://github.com/llvm/llvm-project/issues/129970))
 
 Changes to building LLVM
 ------------------------

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -70,8 +70,8 @@ Changes to LLVM infrastructure
 
 * Removed support for target intrinsics being defined in the target directories
   themselves (i.e., the `TargetIntrinsicInfo` class).
-* Fix Microsoft demanling of string literals to be stricter
-  ([Fixes 129970](https://github.com/llvm/llvm-project/issues/129970))
+* Fix Microsoft demangling of string literals to be stricter
+  (#GH129970))
 
 Changes to building LLVM
 ------------------------

--- a/llvm/lib/Demangle/MicrosoftDemangle.cpp
+++ b/llvm/lib/Demangle/MicrosoftDemangle.cpp
@@ -1374,6 +1374,11 @@ Demangler::demangleStringLiteral(std::string_view &MangledName) {
       Result->IsTruncated = true;
 
     while (!consumeFront(MangledName, '@')) {
+      // For a wide string StringByteSize has to have an even length.
+      if (StringByteSize % 2 != 0)
+        goto StringLiteralError;
+      if (StringByteSize == 0)
+        goto StringLiteralError;
       if (MangledName.size() < 2)
         goto StringLiteralError;
       wchar_t W = demangleWcharLiteral(MangledName);

--- a/llvm/test/Demangle/invalid-manglings.test
+++ b/llvm/test/Demangle/invalid-manglings.test
@@ -379,3 +379,27 @@
 ; CHECK-EMPTY:
 ; CHECK-NEXT: .?AUBase@@@8
 ; CHECK-NEXT: error: Invalid mangled name
+
+; Begin GH129970
+
+??_C@_12EEHFKJGG@?$AAt?$AAe?$AAx@
+; CHECK-EMPTY:
+; CHECK-NEXT: ??_C@_12EEHFKJGG@?$AAt?$AAe?$AAx@
+; CHECK-NEXT: error: Invalid mangled name
+
+??_C@_16EEHFKJGG@?$AAt?$AAe?$AAx@
+; CHECK-EMPTY:
+; CHECK-NEXT: ??_C@_16EEHFKJGG@?$AAt?$AAe?$AAx@
+; CHECK-NEXT: error: Invalid mangled name
+
+??_C@_18EEHFKJGG@?$AAt?$AAe?$AAx@
+; CHECK-EMPTY:
+; CHECK-NEXT: ??_C@_18EEHFKJGG@?$AAt?$AAe?$AAx@
+; CHECK-NEXT: error: Invalid mangled name
+
+??_C@_15EEHFKJGG@?$AAt?$AAe?$AAx?$AAx@
+; CHECK-EMPTY:
+; CHECK-NEXT: ??_C@_15EEHFKJGG@?$AAt?$AAe?$AAx?$AAx@
+; CHECK-NEXT: error: Invalid mangled name
+
+; End GH129970


### PR DESCRIPTION
Static analysis detected that Demangler::demangleStringLiteral had a potential overflow if not checking StringByteSize properly.

Added check to ensure that for wide string it is always even and that there were the byte count did not mismatch the actual size of the literal.

Fixes: https://github.com/llvm/llvm-project/issues/129970