### PR TITLE
[X86][AMX] Add missing __inline__ for AMXCOMPLEX intrinsics, NFCI

### DIFF
--- a/clang/lib/Headers/amxcomplexintrin.h
+++ b/clang/lib/Headers/amxcomplexintrin.h
@@ -135,9 +135,8 @@ _tile_cmmrlfp16ps_internal(unsigned short m, unsigned short n, unsigned short k,
 ///    The 1st source tile. Max size is 1024 Bytes.
 /// \param src1
 ///    The 2nd source tile. Max size is 1024 Bytes.
-__DEFAULT_FN_ATTRS_COMPLEX
-static void __tile_cmmimfp16ps(__tile1024i *dst, __tile1024i src0,
-                               __tile1024i src1) {
+static __inline__ void __DEFAULT_FN_ATTRS_COMPLEX
+__tile_cmmimfp16ps(__tile1024i *dst, __tile1024i src0, __tile1024i src1) {
   dst->tile = _tile_cmmimfp16ps_internal(src0.row, src1.col, src0.col,
                                          dst->tile, src0.tile, src1.tile);
 }
@@ -158,9 +157,8 @@ static void __tile_cmmimfp16ps(__tile1024i *dst, __tile1024i src0,
 ///    The 1st source tile. Max size is 1024 Bytes.
 /// \param src1
 ///    The 2nd source tile. Max size is 1024 Bytes.
-__DEFAULT_FN_ATTRS_COMPLEX
-static void __tile_cmmrlfp16ps(__tile1024i *dst, __tile1024i src0,
-                               __tile1024i src1) {
+static __inline__ void __DEFAULT_FN_ATTRS_COMPLEX
+__tile_cmmrlfp16ps(__tile1024i *dst, __tile1024i src0, __tile1024i src1) {
   dst->tile = _tile_cmmrlfp16ps_internal(src0.row, src1.col, src0.col,
                                          dst->tile, src0.tile, src1.tile);
 }


### PR DESCRIPTION
Found by #64779.