### PR TITLE
[IfConversion] Fix duplicate successor error after if-converter.

### DIFF
--- a/llvm/lib/CodeGen/IfConversion.cpp
+++ b/llvm/lib/CodeGen/IfConversion.cpp
@@ -2200,7 +2200,9 @@ void IfConverter::CopyAndPredicateBlock(BBInfo &ToBBI, BBInfo &FromBBI,
       // Fallthrough edge can't be transferred.
       if (Succ == FallThrough)
         continue;
-      ToBBI.BB->addSuccessor(Succ);
+
+      if (!ToBBI.BB->isSuccessor(Succ))
+        ToBBI.BB->addSuccessor(Succ);
     }
   }
 


### PR DESCRIPTION
Bug is detected for `Simple` case when `FalseBB` is a successor of both blocks `BB` and `TrueBB`.

It is a mistake to add `FalseBB` as successor of `BB` after copy-and-merging of `TrueBB` into `BB`. `MachineVerifier` reports an error on duplicate successors and predecessors in this case.

Approximate CFG to trigger the bug:

```
    BB
   |  \       /
   |   \     /
   |    TrueBB
   |   /     \
   |  /       \
  FalseBB      ...
```

It is important that branch in `TrueBB` is **not analyzable**.

Bug is triggered on the custom out-of-tree backend. Unfortunately, I'm not familiar good enough with other backends to write a good .mir test for this with not analyzable branch. Sorry for that. But fix seems too trivial.