### PR TITLE
[NFC][libc++][test] Refactor new ftm generator tests.

### DIFF
--- a/libcxx/test/libcxx/feature_test_macro/ftm_metadata.sh.py
+++ b/libcxx/test/libcxx/feature_test_macro/ftm_metadata.sh.py
@@ -9,39 +9,48 @@
 # RUN: %{python} %s %{libcxx-dir}/utils %{libcxx-dir}/test/libcxx/feature_test_macro/test_data.json
 
 import sys
+import unittest
 
-sys.path.append(sys.argv[1])
+UTILS = sys.argv[1]
+TEST_DATA = sys.argv[2]
+del sys.argv[1:3]
+
+sys.path.append(UTILS)
 from generate_feature_test_macro_components import FeatureTestMacros, Metadata
 
 
-def test(output, expected):
-    assert output == expected, f"expected\n{expected}\n\noutput\n{output}"
+class Test(unittest.TestCase):
+    def setUp(self):
+        self.ftm = FeatureTestMacros(TEST_DATA)
+        self.maxDiff = None  # This causes the diff to be printed when the test fails
+
+    def test_implementation(self):
+        expected = {
+            "__cpp_lib_any": Metadata(
+                headers=["any"], test_suite_guard=None, libcxx_guard=None
+            ),
+            "__cpp_lib_barrier": Metadata(
+                headers=["barrier"],
+                test_suite_guard="!defined(_LIBCPP_VERSION) || (_LIBCPP_HAS_THREADS && _LIBCPP_AVAILABILITY_HAS_SYNC)",
+                libcxx_guard="_LIBCPP_HAS_THREADS && _LIBCPP_AVAILABILITY_HAS_SYNC",
+            ),
+            "__cpp_lib_format": Metadata(
+                headers=["format"], test_suite_guard=None, libcxx_guard=None
+            ),
+            "__cpp_lib_parallel_algorithm": Metadata(
+                headers=["algorithm", "numeric"],
+                test_suite_guard=None,
+                libcxx_guard=None,
+            ),
+            "__cpp_lib_variant": Metadata(
+                headers=["variant"], test_suite_guard=None, libcxx_guard=None
+            ),
+            "__cpp_lib_missing_FTM_in_older_standard": Metadata(
+                headers=[], test_suite_guard=None, libcxx_guard=None
+            ),
+        }
+        self.assertEqual(self.ftm.ftm_metadata, expected)
 
 
-ftm = FeatureTestMacros(sys.argv[2])
-
-test(
-    ftm.ftm_metadata,
-    {
-        "__cpp_lib_any": Metadata(
-            headers=["any"], test_suite_guard=None, libcxx_guard=None
-        ),
-        "__cpp_lib_barrier": Metadata(
-            headers=["barrier"],
-            test_suite_guard="!defined(_LIBCPP_VERSION) || (_LIBCPP_HAS_THREADS && _LIBCPP_AVAILABILITY_HAS_SYNC)",
-            libcxx_guard="_LIBCPP_HAS_THREADS && _LIBCPP_AVAILABILITY_HAS_SYNC",
-        ),
-        "__cpp_lib_format": Metadata(
-            headers=["format"], test_suite_guard=None, libcxx_guard=None
-        ),
-        "__cpp_lib_parallel_algorithm": Metadata(
-            headers=["algorithm", "numeric"], test_suite_guard=None, libcxx_guard=None
-        ),
-        "__cpp_lib_variant": Metadata(
-            headers=["variant"], test_suite_guard=None, libcxx_guard=None
-        ),
-        "__cpp_lib_missing_FTM_in_older_standard": Metadata(
-            headers=[], test_suite_guard=None, libcxx_guard=None
-        ),
-    },
-)
+if __name__ == "__main__":
+    unittest.main()

--- a/libcxx/test/libcxx/feature_test_macro/implemented_ftms.sh.py
+++ b/libcxx/test/libcxx/feature_test_macro/implemented_ftms.sh.py
@@ -9,51 +9,61 @@
 # RUN: %{python} %s %{libcxx-dir}/utils %{libcxx-dir}/test/libcxx/feature_test_macro/test_data.json
 
 import sys
+import unittest
 
-sys.path.append(sys.argv[1])
+UTILS = sys.argv[1]
+TEST_DATA = sys.argv[2]
+del sys.argv[1:3]
+
+sys.path.append(UTILS)
 from generate_feature_test_macro_components import FeatureTestMacros
 
 
-def test(output, expected):
-    assert output == expected, f"expected\n{expected}\n\noutput\n{output}"
+class Test(unittest.TestCase):
+    def setUp(self):
+        self.ftm = FeatureTestMacros(TEST_DATA)
+        self.maxDiff = None  # This causes the diff to be printed when the test fails
+
+    def test_implementation(self):
+
+        expected = {
+            "__cpp_lib_any": {
+                "c++17": "201606L",
+                "c++20": "201606L",
+                "c++23": "201606L",
+                "c++26": "201606L",
+            },
+            "__cpp_lib_barrier": {
+                "c++20": "201907L",
+                "c++23": "201907L",
+                "c++26": "299900L",
+            },
+            "__cpp_lib_format": {
+                "c++20": None,
+                "c++23": None,
+                "c++26": None,
+            },
+            "__cpp_lib_parallel_algorithm": {
+                "c++17": "201603L",
+                "c++20": "201603L",
+                "c++23": "201603L",
+                "c++26": "201603L",
+            },
+            "__cpp_lib_variant": {
+                "c++17": "202102L",
+                "c++20": "202102L",
+                "c++23": "202102L",
+                "c++26": "202102L",
+            },
+            "__cpp_lib_missing_FTM_in_older_standard": {
+                "c++17": None,
+                "c++20": None,
+                "c++26": None,
+            },
+        }
+
+        self.assertEqual(self.ftm.implemented_ftms, expected)
 
 
-ftm = FeatureTestMacros(sys.argv[2])
-test(
-    ftm.implemented_ftms,
-    {
-        "__cpp_lib_any": {
-            "c++17": "201606L",
-            "c++20": "201606L",
-            "c++23": "201606L",
-            "c++26": "201606L",
-        },
-        "__cpp_lib_barrier": {
-            "c++20": "201907L",
-            "c++23": "201907L",
-            "c++26": "299900L",
-        },
-        "__cpp_lib_format": {
-            "c++20": None,
-            "c++23": None,
-            "c++26": None,
-        },
-        "__cpp_lib_parallel_algorithm": {
-            "c++17": "201603L",
-            "c++20": "201603L",
-            "c++23": "201603L",
-            "c++26": "201603L",
-        },
-        "__cpp_lib_variant": {
-            "c++17": "202102L",
-            "c++20": "202102L",
-            "c++23": "202102L",
-            "c++26": "202102L",
-        },
-        "__cpp_lib_missing_FTM_in_older_standard": {
-            "c++17": None,
-            "c++20": None,
-            "c++26": None,
-        },
-    },
-)
+if __name__ == "__main__":
+    unittest.main()

--- a/libcxx/test/libcxx/feature_test_macro/standard_ftms.sh.py
+++ b/libcxx/test/libcxx/feature_test_macro/standard_ftms.sh.py
@@ -9,52 +9,61 @@
 # RUN: %{python} %s %{libcxx-dir}/utils %{libcxx-dir}/test/libcxx/feature_test_macro/test_data.json
 
 import sys
+import unittest
 
-sys.path.append(sys.argv[1])
+UTILS = sys.argv[1]
+TEST_DATA = sys.argv[2]
+del sys.argv[1:3]
+
+sys.path.append(UTILS)
 from generate_feature_test_macro_components import FeatureTestMacros
 
 
-def test(output, expected):
-    assert output == expected, f"expected\n{expected}\n\noutput\n{output}"
+class Test(unittest.TestCase):
+    def setUp(self):
+        self.ftm = FeatureTestMacros(TEST_DATA)
+        self.maxDiff = None  # This causes the diff to be printed when the test fails
+
+    def test_implementation(self):
+        expected = {
+            "__cpp_lib_any": {
+                "c++17": "201606L",
+                "c++20": "201606L",
+                "c++23": "201606L",
+                "c++26": "201606L",
+            },
+            "__cpp_lib_barrier": {
+                "c++20": "201907L",
+                "c++23": "201907L",
+                "c++26": "299900L",
+            },
+            "__cpp_lib_format": {
+                "c++20": "202110L",
+                "c++23": "202207L",
+                "c++26": "202311L",
+            },
+            "__cpp_lib_parallel_algorithm": {
+                "c++17": "201603L",
+                "c++20": "201603L",
+                "c++23": "201603L",
+                "c++26": "201603L",
+            },
+            "__cpp_lib_variant": {
+                "c++17": "202102L",
+                "c++20": "202106L",
+                "c++23": "202106L",
+                "c++26": "202306L",
+            },
+            "__cpp_lib_missing_FTM_in_older_standard": {
+                "c++17": "2017L",
+                "c++20": "2020L",
+                "c++23": "2020L",
+                "c++26": "2026L",
+            },
+        }
+
+        self.assertEqual(self.ftm.standard_ftms, expected)
 
 
-ftm = FeatureTestMacros(sys.argv[2])
-test(
-    ftm.standard_ftms,
-    {
-        "__cpp_lib_any": {
-            "c++17": "201606L",
-            "c++20": "201606L",
-            "c++23": "201606L",
-            "c++26": "201606L",
-        },
-        "__cpp_lib_barrier": {
-            "c++20": "201907L",
-            "c++23": "201907L",
-            "c++26": "299900L",
-        },
-        "__cpp_lib_format": {
-            "c++20": "202110L",
-            "c++23": "202207L",
-            "c++26": "202311L",
-        },
-        "__cpp_lib_parallel_algorithm": {
-            "c++17": "201603L",
-            "c++20": "201603L",
-            "c++23": "201603L",
-            "c++26": "201603L",
-        },
-        "__cpp_lib_variant": {
-            "c++17": "202102L",
-            "c++20": "202106L",
-            "c++23": "202106L",
-            "c++26": "202306L",
-        },
-        "__cpp_lib_missing_FTM_in_older_standard": {
-            "c++17": "2017L",
-            "c++20": "2020L",
-            "c++23": "2020L",
-            "c++26": "2026L",
-        },
-    },
-)
+if __name__ == "__main__":
+    unittest.main()

--- a/libcxx/test/libcxx/feature_test_macro/std_dialects.sh.py
+++ b/libcxx/test/libcxx/feature_test_macro/std_dialects.sh.py
@@ -9,22 +9,31 @@
 # RUN: %{python} %s %{libcxx-dir}/utils %{libcxx-dir}/test/libcxx/feature_test_macro/test_data.json
 
 import sys
+import unittest
 
-sys.path.append(sys.argv[1])
+UTILS = sys.argv[1]
+TEST_DATA = sys.argv[2]
+del sys.argv[1:3]
+
+sys.path.append(UTILS)
 from generate_feature_test_macro_components import FeatureTestMacros
 
 
-def test(output, expected):
-    assert output == expected, f"expected\n{expected}\n\noutput\n{output}"
+class Test(unittest.TestCase):
+    def setUp(self):
+        self.ftm = FeatureTestMacros(TEST_DATA)
+        self.maxDiff = None  # This causes the diff to be printed when the test fails
+
+    def test_implementation(self):
+        expected = [
+            "c++17",
+            "c++20",
+            "c++23",
+            "c++26",
+        ]
+
+        self.assertEqual(self.ftm.std_dialects, expected)
 
 
-ftm = FeatureTestMacros(sys.argv[2])
-test(
-    ftm.std_dialects,
-    [
-        "c++17",
-        "c++20",
-        "c++23",
-        "c++26",
-    ],
-)
+if __name__ == "__main__":
+    unittest.main()

--- a/libcxx/test/libcxx/feature_test_macro/version_header.sh.py
+++ b/libcxx/test/libcxx/feature_test_macro/version_header.sh.py
@@ -9,19 +9,23 @@
 # RUN: %{python} %s %{libcxx-dir}/utils %{libcxx-dir}/test/libcxx/feature_test_macro/test_data.json
 
 import sys
+import unittest
 
-sys.path.append(sys.argv[1])
+UTILS = sys.argv[1]
+TEST_DATA = sys.argv[2]
+del sys.argv[1:3]
+
+sys.path.append(UTILS)
 from generate_feature_test_macro_components import FeatureTestMacros
 
 
-def test(output, expected):
-    assert output == expected, f"expected\n{expected}\n\noutput\n{output}"
+class Test(unittest.TestCase):
+    def setUp(self):
+        self.ftm = FeatureTestMacros(TEST_DATA)
+        self.maxDiff = None  # This causes the diff to be printed when the test fails
 
-
-ftm = FeatureTestMacros(sys.argv[2])
-test(
-    ftm.version_header,
-    """// -*- C++ -*-
+    def test_implementeation(self):
+        expected = """// -*- C++ -*-
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -70,5 +74,9 @@ test(
 #endif // _LIBCPP_STD_VER >= 26
 
 #endif // _LIBCPP_VERSIONH
-""",
-)
+"""
+        self.assertEqual(self.ftm.version_header, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/libcxx/test/libcxx/feature_test_macro/version_header_implementation.sh.py
+++ b/libcxx/test/libcxx/feature_test_macro/version_header_implementation.sh.py
@@ -18,10 +18,11 @@ del sys.argv[1:3]
 sys.path.append(UTILS)
 from generate_feature_test_macro_components import FeatureTestMacros, VersionHeader
 
+
 class Test(unittest.TestCase):
     def setUp(self):
         self.ftm = FeatureTestMacros(TEST_DATA)
-        self.maxDiff = None # This causes the diff to be printed when the test fails
+        self.maxDiff = None  # This causes the diff to be printed when the test fails
 
     def test_implementation(self):
         expected = {
@@ -51,11 +52,11 @@ class Test(unittest.TestCase):
                     ),
                 },
                 {
-                    "__cpp_lib_missing_FTM_in_older_standard" : VersionHeader(
-                        value = "2017L",
-                        implemented = False,
-                        need_undef = False,
-                        condition = None,
+                    "__cpp_lib_missing_FTM_in_older_standard": VersionHeader(
+                        value="2017L",
+                        implemented=False,
+                        need_undef=False,
+                        condition=None,
                     ),
                 },
             ],
@@ -85,11 +86,11 @@ class Test(unittest.TestCase):
                     ),
                 },
                 {
-                    "__cpp_lib_missing_FTM_in_older_standard" : VersionHeader(
-                        value = "2020L",
-                        implemented = False,
-                        need_undef = False,
-                        condition = None,
+                    "__cpp_lib_missing_FTM_in_older_standard": VersionHeader(
+                        value="2020L",
+                        implemented=False,
+                        need_undef=False,
+                        condition=None,
                     ),
                 },
             ],
@@ -129,11 +130,11 @@ class Test(unittest.TestCase):
                     ),
                 },
                 {
-                    "__cpp_lib_missing_FTM_in_older_standard" : VersionHeader(
-                        value = "2026L",
-                        implemented = False,
-                        need_undef = False,
-                        condition = None,
+                    "__cpp_lib_missing_FTM_in_older_standard": VersionHeader(
+                        value="2026L",
+                        implemented=False,
+                        need_undef=False,
+                        condition=None,
                     ),
                 },
             ],
@@ -141,5 +142,6 @@ class Test(unittest.TestCase):
 
         self.assertEqual(self.ftm.version_header_implementation, expected)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This uses the python unit test framework instead of just asserts. This improves the diagnostics when a test fails.