### PR TITLE
[mlir][llvm] Respect call noinline attr in inliner

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/LLVMIR/Transforms/InlinerInterfaceImpl.cpp
@@ -664,9 +664,14 @@ struct LLVMInlinerInterface : public DialectInlinerInterface {
 
   bool isLegalToInline(Operation *call, Operation *callable,
                        bool wouldBeCloned) const final {
-    if (!isa<LLVM::CallOp>(call)) {
+    auto callOp = dyn_cast<LLVM::CallOp>(call);
+    if (!callOp) {
       LLVM_DEBUG(llvm::dbgs() << "Cannot inline: call is not an '"
                               << LLVM::CallOp::getOperationName() << "' op\n");
+      return false;
+    }
+    if (callOp.getNoInline()) {
+      LLVM_DEBUG(llvm::dbgs() << "Cannot inline: call is marked no_inline\n");
       return false;
     }
     auto funcOp = dyn_cast<LLVM::LLVMFuncOp>(callable);

--- a/mlir/test/Dialect/LLVMIR/inlining.mlir
+++ b/mlir/test/Dialect/LLVMIR/inlining.mlir
@@ -95,7 +95,7 @@ llvm.func @foo() -> (i32) attributes { no_inline } {
   llvm.return %0 : i32
 }
 
-llvm.func @bar() -> (i32) attributes { no_inline } {
+llvm.func @bar() -> (i32) {
   %0 = llvm.mlir.constant(1 : i32) : i32
   llvm.return %0 : i32
 }
@@ -106,7 +106,7 @@ llvm.func @callee_with_multiple_blocks(%cond: i1) -> (i32) {
   %0 = llvm.call @foo() : () -> (i32)
   llvm.br ^bb3(%0: i32)
 ^bb2:
-  %1 = llvm.call @bar() : () -> (i32)
+  %1 = llvm.call @bar() { no_inline } : () -> (i32)
   llvm.br ^bb3(%1: i32)
 ^bb3(%arg: i32):
   llvm.return %arg : i32


### PR DESCRIPTION
This commit extends the LLVM dialect inliner interface to respect the call op's noinline attribute. This is a follow-up to https://github.com/llvm/llvm-project/pull/133726
which added the noinline attribute to the LLVM dialect call op.