### PR TITLE
[libc++][CI] Improves updating Docker image.

### DIFF
--- a/libcxx/utils/ci/Dockerfile
+++ b/libcxx/utils/ci/Dockerfile
@@ -45,8 +45,10 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE AS builder-base
 
 # Changing this file causes a rebuild of the image in a GitHub action.
-# The date uses the ISO format YYYY-MM-DD.
-RUN echo "Last forced update executed on 2025-04-05."
+# However, it does not cause the CI runners to switch to that image
+# automatically, that must be done by updating the SHA in the Github workflow
+# file. The date uses the ISO format YYYY-MM-DD.
+RUN echo "Last forced update executed on 2025-04-28."
 
 # Make sure apt-get doesn't try to prompt for stuff like our time zone, etc.
 ENV DEBIAN_FRONTEND=noninteractive

--- a/libcxx/utils/ci/Dockerfile
+++ b/libcxx/utils/ci/Dockerfile
@@ -44,6 +44,10 @@
 ARG BASE_IMAGE
 FROM $BASE_IMAGE AS builder-base
 
+# Changing this file causes a rebuild of the image in a GitHub action.
+# The date uses the ISO format YYYY-MM-DD.
+RUN echo "Last forced update executed on 2025-04-05."
+
 # Make sure apt-get doesn't try to prompt for stuff like our time zone, etc.
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
This makes it easier to build a new Docker image in the CI. Since the new image is not used automatically it's safe to commit these changes directly to main. Then use a PR to test the new image.