### PR TITLE
[BasicAA] Treat IntToPtr(Argument) similarly to Argument in relation to function-local objects.

### DIFF
--- a/llvm/test/Analysis/BasicAA/noalias-inttoptr.ll
+++ b/llvm/test/Analysis/BasicAA/noalias-inttoptr.ll
@@ -24,10 +24,10 @@ define void @test2(i64 %Q_as_int) {
   ret void
 }
 
-; Verify that escaped noalias parameter may alias inttoptr
+; Verify that escaped noalias parameter are no alias inttoptr
 define void @test3(ptr noalias %P, i64 %Q_as_int) {
   ; CHECK-LABEL: Function: test3:
-  ; CHECK: MayAlias:	i8* %P, i8* %Q
+  ; CHECK: NoAlias:	i8* %P, i8* %Q
   call void @escape(ptr %P)
   %Q = inttoptr i64 %Q_as_int to ptr
   store i8 0, ptr %P
@@ -35,10 +35,10 @@ define void @test3(ptr noalias %P, i64 %Q_as_int) {
   ret void
 }
 
-; Verify that escaped alloca may alias inttoptr
+; Verify that escaped alloca are noalias inttoptr
 define void @test4(i64 %Q_as_int) {
   ; CHECK-LABEL: Function: test4:
-  ; CHECK: MayAlias:	i8* %P, i8* %Q
+  ; CHECK: NoAlias:	i8* %P, i8* %Q
   %P = alloca i8
   call void @escape(ptr %P)
   %Q = inttoptr i64 %Q_as_int to ptr
@@ -55,6 +55,18 @@ define void @test5(i64 %Q_as_int) {
   ; CHECK: MayAlias:	i8* %Q, i8* @G
   %Q = inttoptr i64 %Q_as_int to ptr
   store i8 0, ptr @G
+  store i8 1, ptr %Q
+  ret void
+}
+
+; Verify that extractvalue of a coerced argument are noalias a function local object
+define void @test6([2 x i64] %Q.coerce) {
+  ; CHECK-LABEL: Function: test6:
+  ; CHECK: NoAlias:	i8* %P, i8* %Q
+  %P = alloca i8
+  %Q_as_int = extractvalue [2 x i64] %Q.coerce, 1
+  %Q = inttoptr i64 %Q_as_int to ptr
+  store i8 0, ptr %P
   store i8 1, ptr %Q
   ret void
 }


### PR DESCRIPTION
Given a IntToPtr or an argument, or of an extract from an argument (that can come up from coerced call parameter), it cannot alias with an object that is function local. My understanding is that essentially from dataflow alone we can prove noalias, not requiring any provenance or whether the pointer escapes via the inttoptr. That is true even for noalias arguments if my reading of D101541 and the Pointer Aliasing Rules is correct, but I am really not an expert.

See https://reviews.llvm.org/D101541 for the last time this came up in the altered test cases.