### PR TITLE
[OCaml] Make OCaml MetadataKind type consistent with C API

### DIFF
--- a/llvm/bindings/ocaml/debuginfo/llvm_debuginfo.ml
+++ b/llvm/bindings/ocaml/debuginfo/llvm_debuginfo.ml
@@ -144,6 +144,7 @@ module MetadataKind = struct
     | DIArgListMetadataKind
     | DIAssignIDMetadataKind
     | DISubrangeTypeMetadataKind
+    | DIFixedPointTypeMetadataKind
 end
 
 (** The amount of debug information to emit. *)

--- a/llvm/bindings/ocaml/debuginfo/llvm_debuginfo.mli
+++ b/llvm/bindings/ocaml/debuginfo/llvm_debuginfo.mli
@@ -148,6 +148,7 @@ module MetadataKind : sig
     | DIArgListMetadataKind
     | DIAssignIDMetadataKind
     | DISubrangeTypeMetadataKind
+    | DIFixedPointTypeMetadataKind
 end
 
 (** The amount of debug information to emit. *)

--- a/llvm/include/llvm-c/DebugInfo.h
+++ b/llvm/include/llvm-c/DebugInfo.h
@@ -173,7 +173,6 @@ enum {
   LLVMDISubrangeMetadataKind,
   LLVMDIEnumeratorMetadataKind,
   LLVMDIBasicTypeMetadataKind,
-  LLVMDIFixedPointTypeMetadataKind,
   LLVMDIDerivedTypeMetadataKind,
   LLVMDICompositeTypeMetadataKind,
   LLVMDISubroutineTypeMetadataKind,
@@ -199,6 +198,7 @@ enum {
   LLVMDIArgListMetadataKind,
   LLVMDIAssignIDMetadataKind,
   LLVMDISubrangeTypeMetadataKind,
+  LLVMDIFixedPointTypeMetadataKind,
 };
 typedef unsigned LLVMMetadataKind;
 

--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -212,6 +212,7 @@ if(TARGET ocaml_llvm)
           ocaml_llvm_analysis
           ocaml_llvm_bitreader
           ocaml_llvm_bitwriter
+          ocaml_llvm_debuginfo
           ocaml_llvm_executionengine
           ocaml_llvm_irreader
           ocaml_llvm_linker


### PR DESCRIPTION
Fixes breakage of OCaml API introduced by commit 6894734.