### PR TITLE
[libc++] Updating release notes to include ranges::iota

### DIFF
--- a/libcxx/docs/ReleaseNotes/21.rst
+++ b/libcxx/docs/ReleaseNotes/21.rst
@@ -45,6 +45,7 @@ Implemented Papers
 - P2562R1: ``constexpr`` Stable Sorting (`Github <https://github.com/llvm/llvm-project/issues/105360>`__)
 - P1222R4: A Standard ``flat_set`` is partially implemented and ``flat_set`` is provided (`Github <https://github.com/llvm/llvm-project/issues/105193>`__)
 - P0472R3: Put std::monostate in <utility> (`Github <https://github.com/llvm/llvm-project/issues/127874>`__)
+- P2440R1: Implemented ``std::ranges::iota`` (`Github <https://github.com/llvm/llvm-project/pull/68494>`__)
 
 Improvements and New Features
 -----------------------------


### PR DESCRIPTION
# Summary

This PR is a follow up to #68494 and adds a bullet in the libc++ 21 release notes saying that `std::ranges::iota` is implemented and links to the GitHub PR. Thanks to @Zingam for catching that it should be in the release notes.