### PR TITLE
[IR] Deprecate PointerType::get/getUnqual pointee type overload

### DIFF
--- a/llvm/include/llvm/IR/DerivedTypes.h
+++ b/llvm/include/llvm/IR/DerivedTypes.h
@@ -685,9 +685,8 @@ public:
 
   /// This constructs a pointer to an object of the specified type in a numbered
   /// address space.
-  LLVM_DEPRECATED("PointerType::get with pointee type is pending removal. Use "
-                  "Context overload.",
-                  "PointerType::get(LLVMContext, AS)")
+  [[deprecated("PointerType::get with pointee type is pending removal. Use "
+               "Context overload.")]]
   static PointerType *get(Type *ElementType, unsigned AddressSpace);
   /// This constructs an opaque pointer to an object in a numbered address
   /// space.
@@ -695,9 +694,8 @@ public:
 
   /// This constructs a pointer to an object of the specified type in the
   /// default address space (address space zero).
-  LLVM_DEPRECATED("PointerType::getUnqual with pointee type is pending "
-                  "removal. Use Context overload.",
-                  "PointerType::getUnqual(LLVMCOntext)")
+  [[deprecated("PointerType::getUnqual with pointee type is pending removal. "
+               "Use Context overload.")]]
   static PointerType *getUnqual(Type *ElementType) {
     return PointerType::get(ElementType, 0);
   }

--- a/llvm/include/llvm/IR/DerivedTypes.h
+++ b/llvm/include/llvm/IR/DerivedTypes.h
@@ -685,6 +685,9 @@ public:
 
   /// This constructs a pointer to an object of the specified type in a numbered
   /// address space.
+  LLVM_DEPRECATED("PointerType::get with pointee type is pending removal. Use "
+                  "Context overload.",
+                  "PointerType::get(LLVMContext, AS)")
   static PointerType *get(Type *ElementType, unsigned AddressSpace);
   /// This constructs an opaque pointer to an object in a numbered address
   /// space.
@@ -692,6 +695,9 @@ public:
 
   /// This constructs a pointer to an object of the specified type in the
   /// default address space (address space zero).
+  LLVM_DEPRECATED("PointerType::getUnqual with pointee type is pending "
+                  "removal. Use Context overload.",
+                  "PointerType::getUnqual(LLVMCOntext)")
   static PointerType *getUnqual(Type *ElementType) {
     return PointerType::get(ElementType, 0);
   }


### PR DESCRIPTION
Deprecates the methods and schedules them for removal in the future as
the overloads taking LLVMContext are preferred, as the pointee type
has no meaning in opaque pointers.

From what my clangd can tell, there are no usages left in the monorepo

Part of #123569