### PR TITLE
[driver] return immediately in `addArchSpecificRPath` and `getArchSpecificLibPaths` on AIX

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1015,7 +1015,12 @@ ToolChain::path_list ToolChain::getArchSpecificLibPaths() const {
     Paths.push_back(std::string(Path));
   };
 
-  AddPath({getTriple().str()});
+  // For AIX, get the triple without the OS version.
+  if (Triple.isOSAIX()) {
+    const llvm::Triple &TripleWithoutVersion = getTripleWithoutOSVersion();
+    AddPath({TripleWithoutVersion.str()});
+  } else
+    AddPath({getTriple().str()});
   AddPath({getOSLibName(), llvm::Triple::getArchTypeName(getArch())});
   return Paths;
 }

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1015,12 +1015,7 @@ ToolChain::path_list ToolChain::getArchSpecificLibPaths() const {
     Paths.push_back(std::string(Path));
   };
 
-  // For AIX, get the triple without the OS version.
-  if (Triple.isOSAIX()) {
-    const llvm::Triple &TripleWithoutVersion = getTripleWithoutOSVersion();
-    AddPath({TripleWithoutVersion.str()});
-  } else
-    AddPath({getTriple().str()});
+  AddPath({getTriple().str()});
   AddPath({getOSLibName(), llvm::Triple::getArchTypeName(getArch())});
   return Paths;
 }

--- a/clang/lib/Driver/ToolChains/AIX.h
+++ b/clang/lib/Driver/ToolChains/AIX.h
@@ -98,6 +98,8 @@ public:
     return llvm::DebuggerKind::DBX;
   }
 
+  path_list getArchSpecificLibPaths() const override { return path_list(); };
+
 protected:
   Tool *buildAssembler() const override;
   Tool *buildLinker() const override;

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1252,6 +1252,9 @@ void tools::addArchSpecificRPath(const ToolChain &TC, const ArgList &Args,
                     options::OPT_fno_rtlib_add_rpath, false))
     return;
 
+  if (TC.getTriple().isOSAIX()) // AIX doesn't support -rpath option.
+    return;
+
   SmallVector<std::string> CandidateRPaths(TC.getArchSpecificLibPaths());
   if (const auto CandidateRPath = TC.getStdlibPath())
     CandidateRPaths.emplace_back(*CandidateRPath);

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1252,7 +1252,7 @@ void tools::addArchSpecificRPath(const ToolChain &TC, const ArgList &Args,
                     options::OPT_fno_rtlib_add_rpath, false))
     return;
 
-  if (TC.getTriple().isOSAIX()) // AIX doesn't support -rpath option.
+  if (TC.getTriple().isOSAIX()) // TODO: AIX doesn't support -rpath option.
     return;
 
   SmallVector<std::string> CandidateRPaths(TC.getArchSpecificLibPaths());

--- a/flang/test/Driver/flang-ld-powerpc.f90
+++ b/flang/test/Driver/flang-ld-powerpc.f90
@@ -23,6 +23,7 @@
 ! AIX64-LD-PER-TARGET-DEFAULT-SAME:     "[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}powerpc64-ibm-aix{{/|\\\\}}libflang_rt.runtime.a"
 ! AIX64-LD-PER-TARGET-DEFAULT-SAME:     "-lm"
 ! AIX64-LD-PER-TARGET-DEFAULT-SAME:     "-lpthread"
+! AIX64-LD-PER-TARGET-DEFAULT-NOT:      "-L/[[RESOURCE_DIR]]{{/|\\\\}}lib{{/|\\\\}}powerpc64-ibm-aix"
 
 
 ! Check powerpc64-ibm-aix 64-bit linking to static flang-rt by option 


### PR DESCRIPTION
`addArchSpecificRPath` should immediately return for AIX as AIX doesn't support `rpath` option.
`getArchSpecificLibPaths` should return as well as we don't want `-L/ArchSepcificLibPaths` sent to the linker on AIX.