### PR TITLE
[libc++] Adds is_implemented function for new ftm generator.

### DIFF
--- a/libcxx/test/libcxx/feature_test_macro/implemented_ftms.sh.py
+++ b/libcxx/test/libcxx/feature_test_macro/implemented_ftms.sh.py
@@ -38,11 +38,7 @@ class Test(unittest.TestCase):
                 "c++23": "201907L",
                 "c++26": "299900L",
             },
-            "__cpp_lib_format": {
-                "c++20": None,
-                "c++23": None,
-                "c++26": None,
-            },
+            "__cpp_lib_format": {},
             "__cpp_lib_parallel_algorithm": {
                 "c++17": "201603L",
                 "c++20": "201603L",
@@ -55,11 +51,7 @@ class Test(unittest.TestCase):
                 "c++23": "202102L",
                 "c++26": "202102L",
             },
-            "__cpp_lib_missing_FTM_in_older_standard": {
-                "c++17": None,
-                "c++20": None,
-                "c++26": None,
-            },
+            "__cpp_lib_missing_FTM_in_older_standard": {},
         }
 
         self.assertEqual(self.ftm.implemented_ftms, expected)

--- a/libcxx/test/libcxx/feature_test_macro/is_implemented.sh.py
+++ b/libcxx/test/libcxx/feature_test_macro/is_implemented.sh.py
@@ -1,0 +1,39 @@
+# ===----------------------------------------------------------------------===##
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ===----------------------------------------------------------------------===##
+
+# RUN: %{python} %s %{libcxx-dir}/utils %{libcxx-dir}/test/libcxx/feature_test_macro/test_data.json
+
+import sys
+import unittest
+
+UTILS = sys.argv[1]
+TEST_DATA = sys.argv[2]
+del sys.argv[1:3]
+
+sys.path.append(UTILS)
+from generate_feature_test_macro_components import FeatureTestMacros, Metadata
+
+
+class Test(unittest.TestCase):
+    def setUp(self):
+        self.ftm = FeatureTestMacros(TEST_DATA)
+        self.maxDiff = None  # This causes the diff to be printed when the test fails
+
+    def test_implementation(self):
+        # FTM not available in C++14.
+        self.assertEqual(self.ftm.is_implemented("__cpp_lib_any", "c++14"), False)
+        self.assertEqual(self.ftm.is_implemented("__cpp_lib_any", "c++17"), True)
+
+        self.assertEqual(self.ftm.is_implemented("__cpp_lib_format", "c++20"), False)
+
+        # FTM C++20 202106L, libc++ has 202102L
+        self.assertEqual(self.ftm.is_implemented("__cpp_lib_variant", "c++20"), False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/libcxx/utils/generate_feature_test_macro_components.py
+++ b/libcxx/utils/generate_feature_test_macro_components.py
@@ -2211,10 +2211,8 @@ class FeatureTestMacros:
         """Has the FTM `ftm` been implemented in the dialect `std`?"""
 
         # When a paper for C++20 has not been implemented in libc++, then there will be no
-        # FTM entry in implemented_ftms for C++23 and later.
-        #
-        # Typically standard_ftms is not used with invalid values in the code, but
-        # guard just in case.
+        # FTM entry in implemented_ftms for C++23 and later. Similarly, a paper like <format>
+        # has no entry in standard_ftms for e.g. C++11.
         if not std in self.implemented_ftms[ftm].keys() or not std in self.standard_ftms[ftm].keys():
             return False
 

--- a/libcxx/utils/generate_feature_test_macro_components.py
+++ b/libcxx/utils/generate_feature_test_macro_components.py
@@ -2010,7 +2010,8 @@ def get_ftms(
                         else:
                             break
 
-                entry[std] = last
+                if last:
+                    entry[std] = last
         result[feature["name"]] = entry
 
     return result
@@ -2206,6 +2207,20 @@ class FeatureTestMacros:
 
         return get_ftms(self.__data, self.std_dialects, True)
 
+    def is_implemented(self, ftm: Ftm, std: Std) -> bool:
+        """Has the FTM `ftm` been implemented in the dialect `std`?"""
+
+        # When a paper for C++20 has not been implemented in libc++, then there will be no
+        # FTM entry in implemented_ftms for C++23 and later.
+        #
+        # Typically standard_ftms is not used with invalid values in the code, but
+        # guard just in case.
+        if not std in self.implemented_ftms[ftm].keys() or not std in self.standard_ftms[ftm].keys():
+            return False
+
+        return self.implemented_ftms[ftm][std] == self.standard_ftms[ftm][std]
+
+
     @functools.cached_property
     def ftm_metadata(self) -> Dict[Ftm, Metadata]:
         """Returns the metadata of the FTMs defined in the Standard.
@@ -2239,7 +2254,7 @@ class FeatureTestMacros:
                     continue
                 last_value = value
 
-                implemented = self.implemented_ftms[ftm][std] == self.standard_ftms[ftm][std]
+                implemented = self.is_implemented(ftm, std)
                 entry = VersionHeader(
                     value,
                     implemented,


### PR DESCRIPTION
At the moment the ftm macro for __cpp_lib_to_chars will have the following values:

standard_ftms: {
    "c++17": "201611L",
    "c++20": "201611L",
    "c++23": "201611L",
    "c++26": "201611L",
}

implemented_ftms: {
    "c++17": None,
}

This is an issue with the test whether the FTM is implemented it does:
  self.implemented_ftms[ftm][std] == self.standard_ftms[ftm][std]
This will fail in C++20 since implemented_ftms[ftm] does not have the key c++20. This adds a new helper function and removes the None entries when a FTM is not implemented.