### PR TITLE
[ThinLTO] Don't convert functions to declarations if `force-import-all` is enabled

### DIFF
--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -75,6 +75,8 @@ static cl::opt<bool>
 
 extern cl::opt<bool> CodeGenDataThinLTOTwoRounds;
 
+extern cl::opt<bool> ForceImportAll;
+
 namespace llvm {
 /// Enable global value internalization in LTO.
 cl::opt<bool> EnableLTOInternalization(
@@ -406,8 +408,11 @@ static void thinLTOResolvePrevailingGUID(
         Visibility = S->getVisibility();
     }
     // Alias and aliasee can't be turned into available_externally.
+    // When force-import-all is used, it indicates that object linking is not
+    // supported by the target. In this case, we can't change the linkage as
+    // well in case the global is converted to declaration.
     else if (!isa<AliasSummary>(S.get()) &&
-             !GlobalInvolvedWithAlias.count(S.get()))
+             !GlobalInvolvedWithAlias.count(S.get()) && !ForceImportAll)
       S->setLinkage(GlobalValue::AvailableExternallyLinkage);
 
     // For ELF, set visibility to the computed visibility from summaries. We

--- a/llvm/lib/Transforms/IPO/FunctionImport.cpp
+++ b/llvm/lib/Transforms/IPO/FunctionImport.cpp
@@ -71,6 +71,10 @@ STATISTIC(NumImportedModules, "Number of modules imported from");
 STATISTIC(NumDeadSymbols, "Number of dead stripped symbols in index");
 STATISTIC(NumLiveSymbols, "Number of live symbols in index");
 
+cl::opt<bool>
+    ForceImportAll("force-import-all", cl::init(false), cl::Hidden,
+                   cl::desc("Import functions with noinline attribute"));
+
 /// Limit on instruction count of imported functions.
 static cl::opt<unsigned> ImportInstrLimit(
     "import-instr-limit", cl::init(100), cl::Hidden, cl::value_desc("N"),
@@ -79,10 +83,6 @@ static cl::opt<unsigned> ImportInstrLimit(
 static cl::opt<int> ImportCutoff(
     "import-cutoff", cl::init(-1), cl::Hidden, cl::value_desc("N"),
     cl::desc("Only import first N functions if N>=0 (default -1)"));
-
-static cl::opt<bool>
-    ForceImportAll("force-import-all", cl::init(false), cl::Hidden,
-                   cl::desc("Import functions with noinline attribute"));
 
 static cl::opt<float>
     ImportInstrFactor("import-instr-evolution-factor", cl::init(0.7),

--- a/llvm/test/ThinLTO/AMDGPU/Inputs/in-f1.ll
+++ b/llvm/test/ThinLTO/AMDGPU/Inputs/in-f1.ll
@@ -1,0 +1,13 @@
+define void @f1(ptr %v) #0 {
+entry:
+  call void @weak_common(ptr %v)
+  ret void
+}
+
+define weak hidden void @weak_common(ptr %v) #0 {
+entry:
+  store i32 12345, ptr %v
+  ret void
+}
+
+attributes #0 = { noinline }

--- a/llvm/test/ThinLTO/AMDGPU/force-import-all.ll
+++ b/llvm/test/ThinLTO/AMDGPU/force-import-all.ll
@@ -1,0 +1,27 @@
+; RUN: opt -mtriple=amdgcn-amd-amdhsa -module-summary %s -o %t.main.bc
+; RUN: opt -mtriple=amdgcn-amd-amdhsa -module-summary %p/Inputs/in-f1.ll -o %t.in.bc
+; RUN: llvm-lto -thinlto-action=run -force-import-all %t.main.bc %t.in.bc --thinlto-save-temps=%t.2.
+; RUN: llvm-dis %t.2.0.3.imported.bc -o - | FileCheck --check-prefix=MOD1 %s
+; RUN: llvm-dis %t.2.1.3.imported.bc -o - | FileCheck --check-prefix=MOD2 %s
+
+define void @f0(ptr %p) #0 {
+entry:
+  call void @f1(ptr %p)
+  ret void
+}
+
+define weak hidden void @weak_common(ptr %v) #0 {
+entry:
+  store i32 12345, ptr %v
+  ret void
+}
+
+declare void @f1(ptr)
+
+attributes #0 = { noinline }
+
+; MOD1: define weak hidden void @weak_common
+; MOD1: define available_externally void @f1
+
+; MOD2: define void @f1
+; MOD2: define weak hidden void @weak_common

--- a/llvm/test/ThinLTO/AMDGPU/lit.local.cfg
+++ b/llvm/test/ThinLTO/AMDGPU/lit.local.cfg
@@ -1,0 +1,2 @@
+if not "AMDGPU" in config.root.targets:
+    config.unsupported = True


### PR DESCRIPTION
On one hand, we intend to force import all functions when the option is enabled.
On the other hand, we currently drop definitions of some functions and convert
them to declarations, which contradicts this intent.

With this PR, functions will no longer be converted to declarations when
`force-import-all` is enabled.