### PR TITLE
[alpha.webkit.ForwardDeclChecker] Recognize a forward declared template specialization

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ForwardDeclChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ForwardDeclChecker.cpp
@@ -125,8 +125,18 @@ public:
     if (!R) // Forward declaration of a Objective-C interface is safe.
       return false;
     auto Name = R->getName();
-    return !R->hasDefinition() && !RTC.isUnretained(QT) &&
-           !SystemTypes.contains(CanonicalType) &&
+    if (R->hasDefinition())
+      return false;
+    // Find a definition amongst template declarations.
+    if (auto *Specialization = dyn_cast<ClassTemplateSpecializationDecl>(R)) {
+      if (auto* S = Specialization->getSpecializedTemplate()) {
+        for (S = S->getMostRecentDecl(); S; S = S->getPreviousDecl()) {
+          if (S->isThisDeclarationADefinition())
+            return false;
+        }
+      }
+    }
+    return !RTC.isUnretained(QT) && !SystemTypes.contains(CanonicalType) &&
            !SystemTypes.contains(PointeeType) && !Name.starts_with("Opaque") &&
            Name != "_NSZone";
   }

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ForwardDeclChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ForwardDeclChecker.cpp
@@ -129,7 +129,7 @@ public:
       return false;
     // Find a definition amongst template declarations.
     if (auto *Specialization = dyn_cast<ClassTemplateSpecializationDecl>(R)) {
-      if (auto* S = Specialization->getSpecializedTemplate()) {
+      if (auto *S = Specialization->getSpecializedTemplate()) {
         for (S = S->getMostRecentDecl(); S; S = S->getPreviousDecl()) {
           if (S->isThisDeclarationADefinition())
             return false;

--- a/clang/test/Analysis/Checkers/WebKit/forward-decl-checker.mm
+++ b/clang/test/Analysis/Checkers/WebKit/forward-decl-checker.mm
@@ -138,3 +138,20 @@ JSStringRef opaque_ptr() {
 }
 
 @end
+
+namespace template_forward_declare {
+
+template<typename> class HashSet;
+
+template<typename T>
+using SingleThreadHashSet = HashSet<T>;
+
+template<typename> class HashSet { };
+
+struct Font { };
+
+struct ComplexTextController {
+    SingleThreadHashSet<const Font>* fallbackFonts { nullptr };
+};
+
+}


### PR DESCRIPTION
This PR fixes a bug that when a template specialization is declared with a forward declaration of a template, the checker fails to find its definition in the same translation unit and erroneously emit an unsafe forward declaration warning.