### PR TITLE
[X86][SSE] Don't emit SSE2 load instructions in SSE1-only mode

### DIFF
--- a/llvm/lib/Target/X86/X86FixupVectorConstants.cpp
+++ b/llvm/lib/Target/X86/X86FixupVectorConstants.cpp
@@ -333,6 +333,7 @@ bool X86FixupVectorConstantsPass::processInstruction(MachineFunction &MF,
                                                      MachineInstr &MI) {
   unsigned Opc = MI.getOpcode();
   MachineConstantPool *CP = MI.getParent()->getParent()->getConstantPool();
+  bool HasSSE2 = ST->hasSSE2();
   bool HasSSE41 = ST->hasSSE41();
   bool HasAVX2 = ST->hasAVX2();
   bool HasDQI = ST->hasDQI();
@@ -394,11 +395,13 @@ bool X86FixupVectorConstantsPass::processInstruction(MachineFunction &MF,
   case X86::MOVAPDrm:
   case X86::MOVAPSrm:
   case X86::MOVUPDrm:
-  case X86::MOVUPSrm:
+  case X86::MOVUPSrm: {
     // TODO: SSE3 MOVDDUP Handling
-    return FixupConstant({{X86::MOVSSrm, 1, 32, rebuildZeroUpperCst},
-                          {X86::MOVSDrm, 1, 64, rebuildZeroUpperCst}},
-                         128, 1);
+    FixupEntry Fixups[] = {
+        {X86::MOVSSrm, 1, 32, rebuildZeroUpperCst},
+        {HasSSE2 ? X86::MOVSDrm : 0, 1, 64, rebuildZeroUpperCst}};
+    return FixupConstant(Fixups, 128, 1);
+  }
   case X86::VMOVAPDrm:
   case X86::VMOVAPSrm:
   case X86::VMOVUPDrm:

--- a/llvm/test/CodeGen/X86/pr134607.ll
+++ b/llvm/test/CodeGen/X86/pr134607.ll
@@ -1,0 +1,20 @@
+; RUN: llc < %s -mtriple=i386-unknown-unknown -mattr=+sse -O3 | FileCheck %s --check-prefixes=X86
+; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=-sse2,+sse -O3 | FileCheck %s --check-prefixes=X64-SSE1
+; RUN: llc < %s -mtriple=x86_64-unknown-unknown -mattr=+sse2,+sse -O3 | FileCheck %s --check-prefixes=X64-SSE2
+
+define void @store_v2f32_constant(ptr %v) {
+; X86-LABEL: store_v2f32_constant:
+; X86:       # %bb.0:
+; X86-NEXT:    movl 4(%esp), %eax
+; X86-NEXT:    movaps {{\.?LCPI[0-9]+_[0-9]+}}, %xmm0
+
+; X64-SSE1-LABEL: store_v2f32_constant:
+; X64-SSE1:       # %bb.0:
+; X64-SSE1-NEXT:    movaps {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
+
+; X64-SSE2-LABEL: store_v2f32_constant:
+; X64-SSE2:       # %bb.0:
+; X64-SSE2-NEXT:    movsd {{\.?LCPI[0-9]+_[0-9]+}}(%rip), %xmm0
+  store <2 x float> <float 2.560000e+02, float 5.120000e+02>, ptr %v, align 4
+  ret void
+}


### PR DESCRIPTION
This fixes a regression I traced back to https://github.com/llvm/llvm-project/commit/8b43c1be23119c1024bed0a8ce392bc73727e2e2 / https://github.com/llvm/llvm-project/pull/79000

The regression caused an SSE2 instruction, `movsd`, to be emitted as a replacement for an SSE instruction, `movaps`  despite the target potentially not supporting this instruction, such as when building with clang using `-march=pentium3`.

The test was produced by reducing down an actual occurrence of the issue in production code. I'm not super familiar with tests for optimization passes, so it may be possible to improve this further and I'll happily do so if advised.

The problematic optimization is part of the LLVM 19 and 20 releases, is it possible to have this fix backported and if yes, what's the process for that?

Fixes #134607