### PR TITLE
Fix builds with macOS SDKs older than 10.13

### DIFF
--- a/libcxx/include/__cxx03/__mbstate_t.h
+++ b/libcxx/include/__cxx03/__mbstate_t.h
@@ -42,6 +42,7 @@
 #elif __has_include(<bits/types/mbstate_t.h>)
 #  include <bits/types/mbstate_t.h> // works on most Unixes
 #elif __has_include(<sys/_types/_mbstate_t.h>)
+#  include <machine/types.h>
 #  include <sys/_types/_mbstate_t.h> // works on Darwin
 #elif !defined(_LIBCPP_HAS_NO_WIDE_CHARACTERS) && __has_include_next(<wchar.h>)
 #  include_next <wchar.h> // fall back to the C standard provider of mbstate_t

--- a/libcxx/include/__mbstate_t.h
+++ b/libcxx/include/__mbstate_t.h
@@ -42,6 +42,7 @@
 #elif __has_include(<bits/types/mbstate_t.h>)
 #  include <bits/types/mbstate_t.h> // works on most Unixes
 #elif __has_include(<sys/_types/_mbstate_t.h>)
+#  include <machine/types.h>
 #  include <sys/_types/_mbstate_t.h> // works on Darwin
 #elif __has_include_next(<wchar.h>)
 #  include_next <wchar.h> // use the C standard provider of mbstate_t if present


### PR DESCRIPTION
`sys/_types/_mbstate_t.h` was added in the 10.9 SDK, but it didn't include `machine/types.h` for you until 10.13, this results in a funny situation where partial libc++ builds are possible with the 10.8 SDK and the 10.13 SDK but not 10.9-10.12, since you'll get an error about `__darwin_mbstate_t` not being defined (`sys/_types/_mbstate_t.h` just does `typedef __darwin_mbstate_t mbstate_t;`).  I know versions before 10.13 aren't officially supported, but it would be nice to keep supporting partial builds at least.