### PR TITLE
clang_EvalResult_getAsCXString impl

### DIFF
--- a/clang/include/clang-c/CXString.h
+++ b/clang/include/clang-c/CXString.h
@@ -16,6 +16,7 @@
 
 #include "clang-c/ExternC.h"
 #include "clang-c/Platform.h"
+#include <stddef.h>
 
 LLVM_CLANG_C_EXTERN_C_BEGIN
 
@@ -44,6 +45,11 @@ typedef struct {
   unsigned Count;
 } CXStringSet;
 
+typedef struct {
+  const char *string;
+  size_t length;
+} CStringInfo;
+
 /**
  * Retrieve the character data associated with the given string.
  *
@@ -52,6 +58,15 @@ typedef struct {
  * to `std::string::c_str()`.
  */
 CINDEX_LINKAGE const char *clang_getCString(CXString string);
+
+/**
+ * Retrieve the character data associated with the given string and its length.
+ *
+ * The returned lenght might be bigger than strlen(.string) if the string
+ * contains nul bytes. This function has the same requirements and guarantees as
+ * clang_getCString.
+ */
+CINDEX_LINKAGE CStringInfo clang_getCStringInfo(CXString string);
 
 /**
  * Free the given string.
@@ -70,4 +85,3 @@ CINDEX_LINKAGE void clang_disposeStringSet(CXStringSet *set);
 LLVM_CLANG_C_EXTERN_C_END
 
 #endif
-

--- a/clang/include/clang-c/CXString.h
+++ b/clang/include/clang-c/CXString.h
@@ -14,8 +14,6 @@
 #ifndef LLVM_CLANG_C_CXSTRING_H
 #define LLVM_CLANG_C_CXSTRING_H
 
-#include <stddef.h>
-
 #include "clang-c/ExternC.h"
 #include "clang-c/Platform.h"
 #include <stddef.h>

--- a/clang/include/clang-c/CXString.h
+++ b/clang/include/clang-c/CXString.h
@@ -14,6 +14,8 @@
 #ifndef LLVM_CLANG_C_CXSTRING_H
 #define LLVM_CLANG_C_CXSTRING_H
 
+#include <stddef.h>
+
 #include "clang-c/ExternC.h"
 #include "clang-c/Platform.h"
 #include <stddef.h>

--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -6062,12 +6062,21 @@ clang_EvalResult_getAsUnsigned(CXEvalResult E);
 CINDEX_LINKAGE double clang_EvalResult_getAsDouble(CXEvalResult E);
 
 /**
- * Returns the evaluation result as a constant string if the
- * kind is other than Int or float. User must not free this pointer,
- * instead call clang_EvalResult_dispose on the CXEvalResult returned
- * by clang_Cursor_Evaluate.
+ * This function behaves the same as clang_EvalResult_getAsCXString, with 2
+ * exceptions:
+ * - the string literal will be truncated if a nul byte is found in the string.
+ * For this reason clang_EvalResult_getAsCXString is recommended.
+ * - the caller must not free this pointer; instead call
+ * clang_EvalResult_dispose on the CXEvalResult returned by
+ * clang_Cursor_Evaluate.
  */
 CINDEX_LINKAGE const char *clang_EvalResult_getAsStr(CXEvalResult E);
+/**
+ * Returns the evaluation result as a CXString if the
+ * kind is other than Int or float. This might include zero bytes.
+ * The caller is responsible for freeing the CXString using clang_disposeString.
+ */
+CINDEX_LINKAGE CXString clang_EvalResult_getAsCXString(CXEvalResult E);
 
 /**
  * Disposes the created Eval memory.

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -4565,6 +4565,7 @@ static StringLiteral *getCFSTR_value(CallExpr *callExpr) {
   return S;
 }
 
+namespace {
 struct ExprEvalResult {
   CXEvalResultKind EvalType;
   union {
@@ -4581,6 +4582,7 @@ struct ExprEvalResult {
     }
   }
 };
+} // end namespace
 
 void clang_EvalResult_dispose(CXEvalResult E) {
   delete static_cast<ExprEvalResult *>(E);
@@ -4640,7 +4642,8 @@ CXString clang_EvalResult_getAsCXString(CXEvalResult E) {
   if (!E) {
     return cxstring::createNull();
   }
-  auto data = clang_getCStringInfo(((ExprEvalResult *)E)->EvalData.stringVal);
+  auto data = clang_getCStringInfo(
+      static_cast<ExprEvalResult *>(E)->EvalData.stringVal);
   return cxstring::createDup(StringRef(data.string, data.length));
 }
 

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -455,6 +455,8 @@ LLVM_21 {
     clang_Cursor_getGCCAssemblyNumClobbers;
     clang_Cursor_getGCCAssemblyClobber;
     clang_Cursor_isGCCAssemblyVolatile;
+    clang_getCStringInfo;
+    clang_EvalResult_getAsCXString;
 };
 
 # Example of how to add a new symbol version entry.  If you do add a new symbol


### PR DESCRIPTION
Tries to implement #69749.

From Discord:
`
In terms of how to solve it... I'm hoping we can extend CXString to be length-aware and then add an interface that returns a CXString object instead. Perhaps clang_EvalResult_getAsCXString() with a comment explaining that getAsStr() is only valid for null-terminated strings?
`


There's some questions I have:

1. Is `size_t` appropriate here? I see some functions using `unsigned`, and some using `size_t`.
2. On this new flow to get a string literal, there's at least 2 allocations of the string from the 2 `cxstring::createDup`, one when evaluating the result, and one when returning it. Is this ok/can it be done better?
3. Is returning a "null" `CXString` on error a good idea?

There's probably more things that I did wrong, so I'm hoping for a review.