### PR TITLE
[WebAssembly] Represent trap instructions as `poison`

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyLowerRefTypesIntPtrConv.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyLowerRefTypesIntPtrConv.cpp
@@ -68,8 +68,7 @@ bool WebAssemblyLowerRefTypesIntPtrConv::runOnFunction(Function &F) {
         !(ITP && WebAssembly::isWebAssemblyReferenceType(ITP->getDestTy())))
       continue;
 
-    UndefValue *U = UndefValue::get(I->getType());
-    I->replaceAllUsesWith(U);
+    I->replaceAllUsesWith(PoisonValue::get(I->getType()));
 
     Function *TrapIntrin =
         Intrinsic::getOrInsertDeclaration(F.getParent(), Intrinsic::debugtrap);


### PR DESCRIPTION
The WebAssemblyLowerRefTypesIntPtrConv pass currently uses `undef` to represent trap instructions. These can instead be represented by the `poison` value.