### PR TITLE
[lldb][lldb-dap] explicitly set the expr as an alias for expression.

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1377,14 +1377,7 @@ bool CommandInterpreter::GetAliasFullName(llvm::StringRef cmd,
 }
 
 bool CommandInterpreter::AliasExists(llvm::StringRef cmd) const {
-  const bool exact_match = (m_alias_dict.find(cmd) != m_alias_dict.end());
-  if (exact_match)
-    return true;
-
-  StringList matches;
-  const int num_cmd_matches =
-      AddNamesMatchingPartialString(m_command_dict, cmd, matches);
-  return num_cmd_matches > 0;
+  return m_alias_dict.find(cmd) != m_alias_dict.end();
 }
 
 bool CommandInterpreter::UserCommandExists(llvm::StringRef cmd) const {

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -444,6 +444,7 @@ void CommandInterpreter::Initialize() {
   if (cmd_obj_sp) {
     // Ensure `e` runs `expression`.
     AddAlias("e", cmd_obj_sp);
+    AddAlias("expr", cmd_obj_sp);
     AddAlias("call", cmd_obj_sp, "--")->SetHelpLong("");
     CommandAlias *parray_alias =
         AddAlias("parray", cmd_obj_sp, "--element-count %1 --");
@@ -1376,7 +1377,9 @@ bool CommandInterpreter::GetAliasFullName(llvm::StringRef cmd,
 }
 
 bool CommandInterpreter::AliasExists(llvm::StringRef cmd) const {
-  return m_alias_dict.find(cmd) != m_alias_dict.end();
+  std::string alias_name;
+  return GetAliasFullName(cmd, alias_name);
+  // return m_alias_dict.find(cmd) != m_alias_dict.end();
 }
 
 bool CommandInterpreter::UserCommandExists(llvm::StringRef cmd) const {

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1377,9 +1377,14 @@ bool CommandInterpreter::GetAliasFullName(llvm::StringRef cmd,
 }
 
 bool CommandInterpreter::AliasExists(llvm::StringRef cmd) const {
-  std::string alias_name;
-  return GetAliasFullName(cmd, alias_name);
-  // return m_alias_dict.find(cmd) != m_alias_dict.end();
+  const bool exact_match = (m_alias_dict.find(cmd) != m_alias_dict.end());
+  if (exact_match)
+    return true;
+
+  StringList matches;
+  const int num_cmd_matches =
+      AddNamesMatchingPartialString(m_command_dict, cmd, matches);
+  return num_cmd_matches > 0;
 }
 
 bool CommandInterpreter::UserCommandExists(llvm::StringRef cmd) const {


### PR DESCRIPTION
dap console does not recognise `expr` as a command because it is not explicitly set.

It works fine in normal lldb because it is gotten from approximate match which is not available in the SBAPI