### PR TITLE
[Clang][OpenCL] Fix wait_for_event argument address space with -fdeclare-opencl-builtins

### DIFF
--- a/clang/lib/Sema/OpenCLBuiltins.td
+++ b/clang/lib/Sema/OpenCLBuiltins.td
@@ -958,11 +958,23 @@ foreach name = ["async_work_group_strided_copy"] in {
   def : Builtin<name, [Event, PointerType<AGenTypeN, LocalAS>, PointerType<ConstType<AGenTypeN>, GlobalAS>, Size, Size, Event]>;
   def : Builtin<name, [Event, PointerType<AGenTypeN, GlobalAS>, PointerType<ConstType<AGenTypeN>, LocalAS>, Size, Size, Event]>;
 }
-foreach name = ["wait_group_events"] in {
-  def : Builtin<name, [Void, Int, PointerType<Event, GenericAS>]>;
-}
 foreach name = ["prefetch"] in {
   def : Builtin<name, [Void, PointerType<ConstType<AGenTypeN>, GlobalAS>, Size]>;
+}
+
+// The wait_group_events is declared with an argument of type event_t*.
+// The address-space of the pointer parameter is different if the generic address space is available.
+multiclass BuiltinWithDefaultPointerArg<AddressSpace AS> {
+  foreach name = ["wait_group_events"] in {
+    def : Builtin<name, [Void, Int, PointerType<Event, AS>]>;
+  }
+}
+
+let Extension = FuncExtOpenCLCNamedAddressSpaceBuiltins in {
+  defm : BuiltinWithDefaultPointerArg<PrivateAS>;
+}
+let Extension = FuncExtOpenCLCGenericAddressSpace in {
+  defm : BuiltinWithDefaultPointerArg<GenericAS>;
 }
 
 //--------------------------------------------------------------------

--- a/clang/test/CodeGenOpenCL/fdeclare-opencl-builtins.cl
+++ b/clang/test/CodeGenOpenCL/fdeclare-opencl-builtins.cl
@@ -48,6 +48,15 @@ void test_generic_optionality(float a, float *b) {
   float res = fract(a, b);
 }
 
+// Test that the correct builtin is called depending on the generic address
+// space feature availability. If not available, the __private version is called
+// CHECK-LABEL: @test_wait_group_events
+// CHECK-GAS: call spir_func void @_Z17wait_group_eventsiPU3AS49ocl_event
+// CHECK-NOGAS: call spir_func void @_Z17wait_group_eventsiP9ocl_event
+void test_wait_group_events(int i, event_t *e) {
+  wait_group_events(i, e);
+}
+
 // CHECK: attributes [[ATTR_CONST]] =
 // CHECK-SAME: memory(none)
 // CHECK: attributes [[ATTR_PURE]] =


### PR DESCRIPTION
The pointer argument for `wait_for_event(int, event_t*)` should take the default address space: generic if available, otherwise private.

Before this patch it would always be generic with `-fdeclare-opencl-builtins`. This was inconsistent with the behavior when opencl-c.h is included.