### PR TITLE
[mlir][NVVM] Fix default label unreachable warning in `getVoteSyncIntrinsicId`

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.cpp
@@ -131,9 +131,8 @@ static llvm::Intrinsic::ID getVoteSyncIntrinsicId(NVVM::VoteSyncKind kind) {
     return llvm::Intrinsic::nvvm_vote_ballot_sync;
   case NVVM::VoteSyncKind::uni:
     return llvm::Intrinsic::nvvm_vote_uni_sync;
-  default:
-    llvm_unreachable("unsupported vote kind");
   }
+  llvm_unreachable("unsupported vote kind");
 }
 
 /// Return the intrinsic ID associated with ldmatrix for the given paramters.


### PR DESCRIPTION
Fixes the following warning after the changes in https://github.com/llvm/llvm-project/pull/134309:

```
llvm-project/mlir/lib/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.cpp:134:3: warning: default label in switch which covers all enumeration values [-Wcovered-switch-default]
  default:
  ^
1 warning generated.
```