### PR TITLE
[flang][test] fix sporadically failing test

### DIFF
--- a/flang/test/Transforms/DoConcurrent/loop_nest_test.f90
+++ b/flang/test/Transforms/DoConcurrent/loop_nest_test.f90
@@ -3,7 +3,7 @@
 ! REQUIRES: asserts
 
 ! RUN: %flang_fc1 -emit-hlfir  -fopenmp -fdo-concurrent-to-openmp=host \
-! RUN:   -mmlir -debug %s -o - 2> %t.log || true
+! RUN:   -mmlir -debug -mmlir -mlir-disable-threading %s -o - 2> %t.log || true
 
 ! RUN: FileCheck %s < %t.log
 


### PR DESCRIPTION
The test is checking output from MLIR debug prints. MLIR passes can be executed in parallel, for example a pass on func.func might schedule different func.func operations in different threads. This led to intermittent test failures where debug output from different threads became mixed up.

Fix by disabling mlir multithreading for this test.