### PR TITLE
[IR] Avoid call to deprecated PointerType::get (NFC)

### DIFF
--- a/llvm/include/llvm/IR/DerivedTypes.h
+++ b/llvm/include/llvm/IR/DerivedTypes.h
@@ -697,7 +697,10 @@ public:
   [[deprecated("PointerType::getUnqual with pointee type is pending removal. "
                "Use Context overload.")]]
   static PointerType *getUnqual(Type *ElementType) {
-    return PointerType::get(ElementType, 0);
+    assert(ElementType && "Can't get a pointer to <null> type!");
+    assert(isValidElementType(ElementType) &&
+           "Invalid type for pointer element!");
+    return PointerType::getUnqual(ElementType->getContext());
   }
 
   /// This constructs an opaque pointer to an object in the


### PR DESCRIPTION
Should keep MSVC quiet as noticed by @rksimon in #134517.

Assertions have been copied over from PointerType::get in order to not silently change invariants with this call.
