### PR TITLE
[Clang] Use "syncscope" instead of "synchscope". NFC.

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -6757,7 +6757,7 @@ public:
 /// and corresponding __opencl_atomic_* for OpenCL 2.0.
 /// All of these instructions take one primary pointer, at least one memory
 /// order. The instructions for which getScopeModel returns non-null value
-/// take one synch scope.
+/// take one sync scope.
 class AtomicExpr : public Expr {
 public:
   enum AtomicOp {

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9075,7 +9075,7 @@ def err_atomic_op_needs_atomic_int : Error<
 def warn_atomic_op_has_invalid_memory_order : Warning<
   "%select{|success |failure }0memory order argument to atomic operation is invalid">,
   InGroup<DiagGroup<"atomic-memory-ordering">>;
-def err_atomic_op_has_invalid_synch_scope : Error<
+def err_atomic_op_has_invalid_sync_scope : Error<
   "synchronization scope argument to atomic operation is invalid">;
 def warn_atomic_implicit_seq_cst : Warning<
   "implicit use of sequentially-consistent atomic may incur stronger memory barriers than necessary">,

--- a/clang/include/clang/Basic/SyncScope.h
+++ b/clang/include/clang/Basic/SyncScope.h
@@ -21,17 +21,17 @@
 
 namespace clang {
 
-/// Defines synch scope values used internally by clang.
+/// Defines sync scope values used internally by clang.
 ///
 /// The enum values start from 0 and are contiguous. They are mainly used for
-/// enumerating all supported synch scope values and mapping them to LLVM
-/// synch scopes. Their numerical values may be different from the corresponding
-/// synch scope enums used in source languages.
+/// enumerating all supported sync scope values and mapping them to LLVM
+/// sync scopes. Their numerical values may be different from the corresponding
+/// sync scope enums used in source languages.
 ///
-/// In atomic builtin and expressions, language-specific synch scope enums are
+/// In atomic builtin and expressions, language-specific sync scope enums are
 /// used. Currently only OpenCL memory scope enums are supported and assumed
 /// to be used by all languages. However, in the future, other languages may
-/// define their own set of synch scope enums. The language-specific synch scope
+/// define their own set of sync scope enums. The language-specific sync scope
 /// values are represented by class AtomicScopeModel and its derived classes.
 ///
 /// To add a new enum value:
@@ -88,31 +88,31 @@ inline llvm::StringRef getAsString(SyncScope S) {
   case SyncScope::OpenCLSubGroup:
     return "opencl_subgroup";
   }
-  llvm_unreachable("Invalid synch scope");
+  llvm_unreachable("Invalid sync scope");
 }
 
 /// Defines the kind of atomic scope models.
 enum class AtomicScopeModelKind { None, OpenCL, HIP, Generic };
 
-/// Defines the interface for synch scope model.
+/// Defines the interface for sync scope model.
 class AtomicScopeModel {
 public:
   virtual ~AtomicScopeModel() {}
-  /// Maps language specific synch scope values to internal
+  /// Maps language specific sync scope values to internal
   /// SyncScope enum.
   virtual SyncScope map(unsigned S) const = 0;
 
-  /// Check if the compile-time constant synch scope value
+  /// Check if the compile-time constant sync scope value
   /// is valid.
   virtual bool isValid(unsigned S) const = 0;
 
-  /// Get all possible synch scope values that might be
+  /// Get all possible sync scope values that might be
   /// encountered at runtime for the current language.
   virtual ArrayRef<unsigned> getRuntimeValues() const = 0;
 
   /// If atomic builtin function is called with invalid
-  /// synch scope value at runtime, it will fall back to a valid
-  /// synch scope value returned by this function.
+  /// sync scope value at runtime, it will fall back to a valid
+  /// sync scope value returned by this function.
   virtual unsigned getFallBackValue() const = 0;
 
   /// Create an atomic scope model by AtomicScopeModelKind.
@@ -120,7 +120,7 @@ public:
   static std::unique_ptr<AtomicScopeModel> create(AtomicScopeModelKind K);
 };
 
-/// Defines the synch scope model for OpenCL.
+/// Defines the sync scope model for OpenCL.
 class AtomicScopeOpenCLModel : public AtomicScopeModel {
 public:
   /// The enum values match the pre-defined macros
@@ -147,7 +147,7 @@ public:
     case SubGroup:
       return SyncScope::OpenCLSubGroup;
     }
-    llvm_unreachable("Invalid language synch scope value");
+    llvm_unreachable("Invalid language sync scope value");
   }
 
   bool isValid(unsigned S) const override {
@@ -156,7 +156,7 @@ public:
   }
 
   ArrayRef<unsigned> getRuntimeValues() const override {
-    static_assert(Last == SubGroup, "Does not include all synch scopes");
+    static_assert(Last == SubGroup, "Does not include all sync scopes");
     static const unsigned Scopes[] = {
         static_cast<unsigned>(WorkGroup), static_cast<unsigned>(Device),
         static_cast<unsigned>(AllSVMDevices), static_cast<unsigned>(SubGroup)};
@@ -168,7 +168,7 @@ public:
   }
 };
 
-/// Defines the synch scope model for HIP.
+/// Defines the sync scope model for HIP.
 class AtomicScopeHIPModel : public AtomicScopeModel {
 public:
   /// The enum values match the pre-defined macros
@@ -198,7 +198,7 @@ public:
     case System:
       return SyncScope::HIPSystem;
     }
-    llvm_unreachable("Invalid language synch scope value");
+    llvm_unreachable("Invalid language sync scope value");
   }
 
   bool isValid(unsigned S) const override {
@@ -207,7 +207,7 @@ public:
   }
 
   ArrayRef<unsigned> getRuntimeValues() const override {
-    static_assert(Last == System, "Does not include all synch scopes");
+    static_assert(Last == System, "Does not include all sync scopes");
     static const unsigned Scopes[] = {
         static_cast<unsigned>(SingleThread), static_cast<unsigned>(Wavefront),
         static_cast<unsigned>(Workgroup), static_cast<unsigned>(Agent),

--- a/clang/lib/CodeGen/CGAtomic.cpp
+++ b/clang/lib/CodeGen/CGAtomic.cpp
@@ -781,8 +781,8 @@ static void EmitAtomicOp(CodeGenFunction &CGF, AtomicExpr *Expr, Address Dest,
                          llvm::Value *Scope) {
   auto ScopeModel = Expr->getScopeModel();
 
-  // LLVM atomic instructions always have synch scope. If clang atomic
-  // expression has no scope operand, use default LLVM synch scope.
+  // LLVM atomic instructions always have sync scope. If clang atomic
+  // expression has no scope operand, use default LLVM sync scope.
   if (!ScopeModel) {
     llvm::SyncScope::ID SS;
     if (CGF.getLangOpts().OpenCL)
@@ -821,8 +821,8 @@ static void EmitAtomicOp(CodeGenFunction &CGF, AtomicExpr *Expr, Address Dest,
       CGF.createBasicBlock("atomic.scope.continue", CGF.CurFn);
 
   auto *SC = Builder.CreateIntCast(Scope, Builder.getInt32Ty(), false);
-  // If unsupported synch scope is encountered at run time, assume a fallback
-  // synch scope value.
+  // If unsupported sync scope is encountered at run time, assume a fallback
+  // sync scope value.
   auto FallBack = ScopeModel->getFallBackValue();
   llvm::SwitchInst *SI = Builder.CreateSwitch(SC, BB[FallBack]);
   for (auto S : Scopes) {

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -4229,7 +4229,7 @@ ExprResult Sema::BuildAtomicExpr(SourceRange CallRange, SourceRange ExprRange,
     if (std::optional<llvm::APSInt> Result =
             Scope->getIntegerConstantExpr(Context)) {
       if (!ScopeModel->isValid(Result->getZExtValue()))
-        Diag(Scope->getBeginLoc(), diag::err_atomic_op_has_invalid_synch_scope)
+        Diag(Scope->getBeginLoc(), diag::err_atomic_op_has_invalid_sync_scope)
             << Scope->getSourceRange();
     }
     SubExprs.push_back(Scope);

--- a/clang/test/SemaOpenCL/atomic-ops.cl
+++ b/clang/test/SemaOpenCL/atomic-ops.cl
@@ -159,7 +159,7 @@ void memory_checks(atomic_int *Ap, int *p, int val) {
   (void)__opencl_atomic_compare_exchange_weak(Ap, p, val, memory_order_seq_cst, memory_order_relaxed, memory_scope_work_group);
 }
 
-void synchscope_checks(atomic_int *Ap, int scope) {
+void syncscope_checks(atomic_int *Ap, int scope) {
   (void)__opencl_atomic_load(Ap, memory_order_relaxed, memory_scope_work_item); // expected-error{{synchronization scope argument to atomic operation is invalid}}
   (void)__opencl_atomic_load(Ap, memory_order_relaxed, memory_scope_work_group);
   (void)__opencl_atomic_load(Ap, memory_order_relaxed, memory_scope_device);


### PR DESCRIPTION
This matches the spelling of the keyword in LLVM IR.
