### PR TITLE
[clang][driver] Suppress gnu-line-marker when saving temps

### DIFF
--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "clang/Basic/DiagnosticLex.h"
 #include "clang/Basic/HLSLRuntime.h"
 #include "clang/Basic/MacroBuilder.h"
 #include "clang/Basic/SourceManager.h"
@@ -1644,4 +1645,11 @@ void clang::InitializePreprocessor(Preprocessor &PP,
 
   // Copy PredefinedBuffer into the Preprocessor.
   PP.setPredefines(std::move(PredefineBuffer));
+
+  // Match gcc behavior regarding gnu-line-directive diagnostics, assuming that
+  // '-x <*>-cpp-output' is analogous to '-fpreprocessed'.
+  if (FEOpts.DashX.isPreprocessed()) {
+    PP.getDiagnostics().setSeverity(diag::ext_pp_gnu_line_directive,
+                                    diag::Severity::Ignored, SourceLocation());
+  }
 }

--- a/clang/test/Preprocessor/line-directive-suppressed.c
+++ b/clang/test/Preprocessor/line-directive-suppressed.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -std=c99 -fsyntax-only -pedantic %s 2>&1 | grep 'warning: this style of line directive is a GNU extension'
+
+// RUN: %clang_cc1 -std=c99 -fsyntax-only -pedantic -x c-cpp-output %s 2>&1 | not grep warning
+// RUN: cp %s %t.i
+// RUN: %clang_cc1 -std=c99 -fsyntax-only -pedantic %t.i 2>&1 | not grep warning
+
+# 0 "zero"
+# 1 "one" 1
+# 2 "two" 1 3 4

--- a/clang/test/Preprocessor/line-directive-suppressed.c
+++ b/clang/test/Preprocessor/line-directive-suppressed.c
@@ -1,9 +1,16 @@
-// RUN: %clang_cc1 -std=c99 -fsyntax-only -pedantic %s 2>&1 | grep 'warning: this style of line directive is a GNU extension'
+// RUN: %clang_cc1 -std=c99 -fsyntax-only -pedantic %s 2>&1 | FileCheck %s
 
-// RUN: %clang_cc1 -std=c99 -fsyntax-only -pedantic -x c-cpp-output %s 2>&1 | not grep warning
 // RUN: cp %s %t.i
-// RUN: %clang_cc1 -std=c99 -fsyntax-only -pedantic %t.i 2>&1 | not grep warning
+// RUN: %clang_cc1 -std=c99 -fsyntax-only -pedantic %t.i 2>&1 | FileCheck %s --check-prefix=NO-WARNING --allow-empty
+// RUN: %clang_cc1 -std=c99 -fsyntax-only -pedantic -x cpp-output %s 2>&1 | FileCheck %s --check-prefix=NO-WARNING --allow-empty
 
 # 0 "zero"
+// CHECK: line-directive-suppressed.c:[[@LINE-1]]:5: warning: {{.*}} [-Wgnu-line-marker]
+
 # 1 "one" 1
+// CHECK: zero:2:5: warning: {{.*}} [-Wgnu-line-marker]
+
 # 2 "two" 1 3 4
+// CHECK: one:3:5: warning: {{.*}} [-Wgnu-line-marker]
+
+// NO-WARNING-NOT: warning:


### PR DESCRIPTION
When passing `-save-temps` to clang, the generated preprocessed output uses gnu line markers. This unexpectedly triggers gnu-line-marker warnings when used with `-Weverything` or `-pedantic`. Even worse, compilation fails if `-Werror` is used.

This change suppresses gnu-line-marker warnings when invoking clang with input from a preprocessor job and the user has not otherwise explictly specified `-Wgnu-line-marker` somewhere on the command line. Note that this does apply to user provided preprocessed files.

fixes #63802