### PR TITLE
[Flang][Windows] Fix test_errors.py by enforcing UTF-8 encoding

### DIFF
--- a/flang/test/Semantics/test_errors.py
+++ b/flang/test/Semantics/test_errors.py
@@ -17,7 +17,7 @@ from difflib import unified_diff
 
 cm.check_args(sys.argv)
 srcdir = cm.set_source(sys.argv[1])
-with open(srcdir, "r") as f:
+with open(srcdir, "r", encoding="utf-8") as f:
     src = f.readlines()
 actual = ""
 expect = ""
@@ -39,6 +39,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
             check=True,
             universal_newlines=True,
             cwd=tmpdir,
+            encoding="utf-8",
         )
     except subprocess.CalledProcessError as e:
         log = e.stderr


### PR DESCRIPTION
This patch fixes UnicodeDecodeError on Windows in test_errors.py. This issue was observed on the flang-arm64-windows-msvc buildbot. Semantics/OpenMP/interop-construct.f90 was crashing due to Python defaulting to the cp1252 codec on Windows.

I have fixed this by explicitly setting encoding="utf-8" when reading source files and invoking subprocess.run() in test_errors.py

flang-arm64-windows-msvc was running on stagging master which resulted in this issue not being fixed earlier.
https://lab.llvm.org/staging/#/builders/206