### PR TITLE
[lldb] Remove unused UnwindPlan functions

### DIFF
--- a/lldb/include/lldb/Symbol/FuncUnwinders.h
+++ b/lldb/include/lldb/Symbol/FuncUnwinders.h
@@ -61,19 +61,6 @@ public:
     });
   }
 
-  // A function may have a Language Specific Data Area specified -- a block of
-  // data in
-  // the object file which is used in the processing of an exception throw /
-  // catch. If any of the UnwindPlans have the address of the LSDA region for
-  // this function, this will return it.
-  Address GetLSDAAddress(Target &target);
-
-  // A function may have a Personality Routine associated with it -- used in the
-  // processing of throwing an exception.  If any of the UnwindPlans have the
-  // address of the personality routine, this will return it.  Read the target-
-  // pointer at this address to get the personality function address.
-  Address GetPersonalityRoutinePtrAddress(Target &target);
-
   // The following methods to retrieve specific unwind plans should rarely be
   // used. Instead, clients should ask for the *behavior* they are looking for,
   // using one of the above UnwindPlan retrieval methods.

--- a/lldb/include/lldb/Symbol/UnwindPlan.h
+++ b/lldb/include/lldb/Symbol/UnwindPlan.h
@@ -536,21 +536,9 @@ public:
     m_plan_is_sourced_from_compiler = eLazyBoolCalculate;
     m_plan_is_valid_at_all_instruction_locations = eLazyBoolCalculate;
     m_plan_is_for_signal_trap = eLazyBoolCalculate;
-    m_lsda_address.Clear();
-    m_personality_func_addr.Clear();
   }
 
   const RegisterInfo *GetRegisterInfo(Thread *thread, uint32_t reg_num) const;
-
-  Address GetLSDAAddress() const { return m_lsda_address; }
-
-  void SetLSDAAddress(Address lsda_addr) { m_lsda_address = lsda_addr; }
-
-  Address GetPersonalityFunctionPtr() const { return m_personality_func_addr; }
-
-  void SetPersonalityFunctionPtr(Address presonality_func_ptr) {
-    m_personality_func_addr = presonality_func_ptr;
-  }
 
 private:
   std::vector<Row> m_row_list;
@@ -566,13 +554,6 @@ private:
   lldb_private::LazyBool m_plan_is_sourced_from_compiler;
   lldb_private::LazyBool m_plan_is_valid_at_all_instruction_locations;
   lldb_private::LazyBool m_plan_is_for_signal_trap;
-
-  Address m_lsda_address; // Where the language specific data area exists in the
-                          // module - used
-                          // in exception handling.
-  Address m_personality_func_addr; // The address of a pointer to the
-                                   // personality function - used in
-                                   // exception handling.
 };                                 // class UnwindPlan
 
 } // namespace lldb_private

--- a/lldb/source/Symbol/CompactUnwindInfo.cpp
+++ b/lldb/source/Symbol/CompactUnwindInfo.cpp
@@ -741,9 +741,6 @@ bool CompactUnwindInfo::CreateUnwindPlan_x86_64(Target &target,
   unwind_plan.SetUnwindPlanForSignalTrap(eLazyBoolNo);
   unwind_plan.SetRegisterKind(eRegisterKindEHFrame);
 
-  unwind_plan.SetLSDAAddress(function_info.lsda_address);
-  unwind_plan.SetPersonalityFunctionPtr(function_info.personality_ptr_address);
-
   UnwindPlan::Row row;
 
   const int wordsize = 8;
@@ -1010,9 +1007,6 @@ bool CompactUnwindInfo::CreateUnwindPlan_i386(Target &target,
   unwind_plan.SetUnwindPlanValidAtAllInstructions(eLazyBoolNo);
   unwind_plan.SetUnwindPlanForSignalTrap(eLazyBoolNo);
   unwind_plan.SetRegisterKind(eRegisterKindEHFrame);
-
-  unwind_plan.SetLSDAAddress(function_info.lsda_address);
-  unwind_plan.SetPersonalityFunctionPtr(function_info.personality_ptr_address);
 
   UnwindPlan::Row row;
 
@@ -1306,9 +1300,6 @@ bool CompactUnwindInfo::CreateUnwindPlan_arm64(Target &target,
   unwind_plan.SetUnwindPlanForSignalTrap(eLazyBoolNo);
   unwind_plan.SetRegisterKind(eRegisterKindEHFrame);
 
-  unwind_plan.SetLSDAAddress(function_info.lsda_address);
-  unwind_plan.SetPersonalityFunctionPtr(function_info.personality_ptr_address);
-
   UnwindPlan::Row row;
 
   const int wordsize = 8;
@@ -1436,9 +1427,6 @@ bool CompactUnwindInfo::CreateUnwindPlan_armv7(Target &target,
   unwind_plan.SetUnwindPlanValidAtAllInstructions(eLazyBoolNo);
   unwind_plan.SetUnwindPlanForSignalTrap(eLazyBoolNo);
   unwind_plan.SetRegisterKind(eRegisterKindEHFrame);
-
-  unwind_plan.SetLSDAAddress(function_info.lsda_address);
-  unwind_plan.SetPersonalityFunctionPtr(function_info.personality_ptr_address);
 
   UnwindPlan::Row row;
 

--- a/lldb/source/Symbol/DWARFCallFrameInfo.cpp
+++ b/lldb/source/Symbol/DWARFCallFrameInfo.cpp
@@ -583,42 +583,12 @@ bool DWARFCallFrameInfo::FDEToUnwindPlan(dw_offset_t dwarf_offset,
                      m_objfile.GetSectionList());
   range.SetByteSize(range_len);
 
-  addr_t lsda_data_file_address = LLDB_INVALID_ADDRESS;
+  // Skip the LSDA, if present.
+  if (cie->augmentation[0] == 'z')
+    offset += (uint32_t)m_cfi_data.GetULEB128(&offset);
 
-  if (cie->augmentation[0] == 'z') {
-    uint32_t aug_data_len = (uint32_t)m_cfi_data.GetULEB128(&offset);
-    if (aug_data_len != 0 && cie->lsda_addr_encoding != DW_EH_PE_omit) {
-      lldb::offset_t saved_offset = offset;
-      lsda_data_file_address =
-          GetGNUEHPointer(m_cfi_data, &offset, cie->lsda_addr_encoding,
-                          pc_rel_addr, text_addr, data_addr);
-      if (offset - saved_offset != aug_data_len) {
-        // There is more in the augmentation region than we know how to process;
-        // don't read anything.
-        lsda_data_file_address = LLDB_INVALID_ADDRESS;
-      }
-      offset = saved_offset;
-    }
-    offset += aug_data_len;
-  }
   unwind_plan.SetUnwindPlanForSignalTrap(
     strchr(cie->augmentation, 'S') ? eLazyBoolYes : eLazyBoolNo);
-
-  Address lsda_data;
-  Address personality_function_ptr;
-
-  if (lsda_data_file_address != LLDB_INVALID_ADDRESS &&
-      cie->personality_loc != LLDB_INVALID_ADDRESS) {
-    m_objfile.GetModule()->ResolveFileAddress(lsda_data_file_address,
-                                              lsda_data);
-    m_objfile.GetModule()->ResolveFileAddress(cie->personality_loc,
-                                              personality_function_ptr);
-  }
-
-  if (lsda_data.IsValid() && personality_function_ptr.IsValid()) {
-    unwind_plan.SetLSDAAddress(lsda_data);
-    unwind_plan.SetPersonalityFunctionPtr(personality_function_ptr);
-  }
 
   uint32_t code_align = cie->code_align;
   int32_t data_align = cie->data_align;

--- a/lldb/source/Symbol/FuncUnwinders.cpp
+++ b/lldb/source/Symbol/FuncUnwinders.cpp
@@ -537,39 +537,3 @@ FuncUnwinders::GetUnwindAssemblyProfiler(Target &target) {
   }
   return assembly_profiler_sp;
 }
-
-Address FuncUnwinders::GetLSDAAddress(Target &target) {
-  Address lsda_addr;
-
-  std::shared_ptr<const UnwindPlan> unwind_plan_sp =
-      GetEHFrameUnwindPlan(target);
-  if (unwind_plan_sp.get() == nullptr) {
-    unwind_plan_sp = GetCompactUnwindUnwindPlan(target);
-  }
-  if (unwind_plan_sp.get() == nullptr) {
-    unwind_plan_sp = GetObjectFileUnwindPlan(target);
-  }
-  if (unwind_plan_sp.get() && unwind_plan_sp->GetLSDAAddress().IsValid()) {
-    lsda_addr = unwind_plan_sp->GetLSDAAddress();
-  }
-  return lsda_addr;
-}
-
-Address FuncUnwinders::GetPersonalityRoutinePtrAddress(Target &target) {
-  Address personality_addr;
-
-  std::shared_ptr<const UnwindPlan> unwind_plan_sp =
-      GetEHFrameUnwindPlan(target);
-  if (unwind_plan_sp.get() == nullptr) {
-    unwind_plan_sp = GetCompactUnwindUnwindPlan(target);
-  }
-  if (unwind_plan_sp.get() == nullptr) {
-    unwind_plan_sp = GetObjectFileUnwindPlan(target);
-  }
-  if (unwind_plan_sp.get() &&
-      unwind_plan_sp->GetPersonalityFunctionPtr().IsValid()) {
-    personality_addr = unwind_plan_sp->GetPersonalityFunctionPtr();
-  }
-
-  return personality_addr;
-}

--- a/lldb/source/Symbol/UnwindPlan.cpp
+++ b/lldb/source/Symbol/UnwindPlan.cpp
@@ -511,19 +511,6 @@ void UnwindPlan::Dump(Stream &s, Thread *thread, lldb::addr_t base_addr) const {
     s.Printf("This UnwindPlan originally sourced from %s\n",
              m_source_name.GetCString());
   }
-  if (m_lsda_address.IsValid() && m_personality_func_addr.IsValid()) {
-    TargetSP target_sp(thread->CalculateTarget());
-    addr_t lsda_load_addr = m_lsda_address.GetLoadAddress(target_sp.get());
-    addr_t personality_func_load_addr =
-        m_personality_func_addr.GetLoadAddress(target_sp.get());
-
-    if (lsda_load_addr != LLDB_INVALID_ADDRESS &&
-        personality_func_load_addr != LLDB_INVALID_ADDRESS) {
-      s.Printf("LSDA address 0x%" PRIx64
-               ", personality routine is at address 0x%" PRIx64 "\n",
-               lsda_load_addr, personality_func_load_addr);
-    }
-  }
   s.Printf("This UnwindPlan is sourced from the compiler: ");
   switch (m_plan_is_sourced_from_compiler) {
   case eLazyBoolYes:


### PR DESCRIPTION
`GetLSDAAddress` and `GetPersonalityRoutinePtrAddress` are unused and they create a bit of a problem for discontinuous functions, because the unwind plan for these consists of multiple eh_frame descriptors and (at least in theory) each of them could have a different value for these entities.

We could say we only support functions for which these are always the same, or create some sort of a Address2LSDA lookup map, but I think it's better to leave this question to someone who actually needs this.