### PR TITLE
[KeyInstr][Clang] Agg init atom

### DIFF
--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -1227,6 +1227,7 @@ void CodeGenFunction::emitStoresForConstant(const VarDecl &D, Address Loc,
     }
     auto *I = Builder.CreateMemSet(
         Loc, llvm::ConstantInt::get(CGM.Int8Ty, Value), SizeVal, isVolatile);
+    addInstToCurrentSourceAtom(I, nullptr);
     if (IsAutoInit)
       I->addAnnotationMetadata("auto-init");
     return;

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -1189,6 +1189,7 @@ void CodeGenFunction::emitStoresForConstant(const VarDecl &D, Address Loc,
                           Ty->isPtrOrPtrVectorTy() || Ty->isFPOrFPVectorTy();
   if (canDoSingleStore) {
     auto *I = Builder.CreateStore(constant, Loc, isVolatile);
+    addInstToCurrentSourceAtom(I, nullptr);
     if (IsAutoInit)
       I->addAnnotationMetadata("auto-init");
     return;

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -945,6 +945,7 @@ void CodeGenFunction::emitStoresForInitAfterBZero(llvm::Constant *Init,
       isa<llvm::ConstantVector>(Init) || isa<llvm::BlockAddress>(Init) ||
       isa<llvm::ConstantExpr>(Init)) {
     auto *I = Builder.CreateStore(Init, Loc, isVolatile);
+    addInstToCurrentSourceAtom(I, nullptr);
     if (IsAutoInit)
       I->addAnnotationMetadata("auto-init");
     return;
@@ -1200,6 +1201,8 @@ void CodeGenFunction::emitStoresForConstant(const VarDecl &D, Address Loc,
   if (shouldUseBZeroPlusStoresToInitialize(constant, ConstantSize)) {
     auto *I = Builder.CreateMemSet(Loc, llvm::ConstantInt::get(CGM.Int8Ty, 0),
                                    SizeVal, isVolatile);
+    addInstToCurrentSourceAtom(I, nullptr);
+
     if (IsAutoInit)
       I->addAnnotationMetadata("auto-init");
 

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -1270,6 +1270,8 @@ void CodeGenFunction::emitStoresForConstant(const VarDecl &D, Address Loc,
                            createUnnamedGlobalForMemcpyFrom(
                                CGM, D, Builder, constant, Loc.getAlignment()),
                            SizeVal, isVolatile);
+  addInstToCurrentSourceAtom(I, nullptr);
+
   if (IsAutoInit)
     I->addAnnotationMetadata("auto-init");
 }

--- a/clang/test/DebugInfo/KeyInstructions/init-agg.cpp
+++ b/clang/test/DebugInfo/KeyInstructions/init-agg.cpp
@@ -1,5 +1,5 @@
 
-// RUN: %clang -gkey-instructions %s -gmlt -gno-column-info -S -emit-llvm -o - \
+// RUN: %clang -gkey-instructions %s -gmlt -gno-column-info -S -emit-llvm -o - -ftrivial-auto-var-init=pattern \
 // RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
 
 // The implicit-check-not is important; we don't want the GEPs created for the
@@ -26,6 +26,9 @@ void a() {
 
 // CHECK: call void @llvm.memset{{.*}}, !dbg [[G4R1:!.*]]
     char arr[] = { 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, };
+
+// CHECK: store i8 -86, ptr %uninit{{.*}}, !dbg [[G5R1:!.*]], !annotation
+    char uninit; // -ftrivial-auto-var-init=pattern
 }
 
 // CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
@@ -33,3 +36,4 @@ void a() {
 // CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
 // CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
 // CHECK: [[G4R1]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 1)
+// CHECK: [[G5R1]] = !DILocation({{.*}}, atomGroup: 5, atomRank: 1)

--- a/clang/test/DebugInfo/KeyInstructions/init-agg.cpp
+++ b/clang/test/DebugInfo/KeyInstructions/init-agg.cpp
@@ -1,22 +1,32 @@
 
-// RUN: %clang -gkey-instructions %s -gmlt -S -emit-llvm -o - \
+// RUN: %clang -gkey-instructions %s -gmlt -gno-column-info -S -emit-llvm -o - \
 // RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
 
 // The implicit-check-not is important; we don't want the GEPs created for the
 // store locations to be included in the atom group.
 
 int g;
+char gc;
 void a() {
 // CHECK: _Z1av()
 // CHECK: call void @llvm.memcpy{{.*}}, !dbg [[G1R1:!.*]]
     int A[] = { 1, 2, 3 };
+
 // CHECK: store i32 1, ptr %{{.*}}, !dbg [[G2R1:!.*]]
 // CHECK: store i32 2, ptr %{{.*}}, !dbg [[G2R1]]
 // CHECK: %0 = load i32, ptr @g{{.*}}, !dbg [[G2R2:!.*]]
 // CHECK: store i32 %0, ptr %{{.*}}, !dbg [[G2R1]]
     int B[] = { 1, 2, g };
+
+// CHECK: call void @llvm.memset{{.*}}, !dbg [[G3R1:!.*]]
+// CHECK: store i8 97{{.*}}, !dbg [[G3R1]]
+// CHECK: store i8 98{{.*}}, !dbg [[G3R1]]
+// CHECK: store i8 99{{.*}}, !dbg [[G3R1]]
+// CHECK: store i8 100{{.*}}, !dbg [[G3R1]]
+    char big[65536] = { 'a', 'b', 'c', 'd' };
 }
 
 // CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
 // CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
 // CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
+// CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)

--- a/clang/test/DebugInfo/KeyInstructions/init-agg.cpp
+++ b/clang/test/DebugInfo/KeyInstructions/init-agg.cpp
@@ -1,0 +1,22 @@
+
+// RUN: %clang -gkey-instructions %s -gmlt -S -emit-llvm -o - \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+// The implicit-check-not is important; we don't want the GEPs created for the
+// store locations to be included in the atom group.
+
+int g;
+void a() {
+// CHECK: _Z1av()
+// CHECK: call void @llvm.memcpy{{.*}}, !dbg [[G1R1:!.*]]
+    int A[] = { 1, 2, 3 };
+// CHECK: store i32 1, ptr %{{.*}}, !dbg [[G2R1:!.*]]
+// CHECK: store i32 2, ptr %{{.*}}, !dbg [[G2R1]]
+// CHECK: %0 = load i32, ptr @g{{.*}}, !dbg [[G2R2:!.*]]
+// CHECK: store i32 %0, ptr %{{.*}}, !dbg [[G2R1]]
+    int B[] = { 1, 2, g };
+}
+
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)

--- a/clang/test/DebugInfo/KeyInstructions/init-agg.cpp
+++ b/clang/test/DebugInfo/KeyInstructions/init-agg.cpp
@@ -6,7 +6,6 @@
 // store locations to be included in the atom group.
 
 int g;
-char gc;
 void a() {
 // CHECK: _Z1av()
 // CHECK: call void @llvm.memcpy{{.*}}, !dbg [[G1R1:!.*]]
@@ -24,9 +23,13 @@ void a() {
 // CHECK: store i8 99{{.*}}, !dbg [[G3R1]]
 // CHECK: store i8 100{{.*}}, !dbg [[G3R1]]
     char big[65536] = { 'a', 'b', 'c', 'd' };
+
+// CHECK: call void @llvm.memset{{.*}}, !dbg [[G4R1:!.*]]
+    char arr[] = { 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, };
 }
 
 // CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
 // CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
 // CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
 // CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
+// CHECK: [[G4R1]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 1)

--- a/clang/test/DebugInfo/KeyInstructions/init-agg.cpp
+++ b/clang/test/DebugInfo/KeyInstructions/init-agg.cpp
@@ -11,25 +11,27 @@ void a() {
 // CHECK: call void @llvm.memcpy{{.*}}%A, {{.*}}@__const._Z1av.A{{.*}}, !dbg [[G1R1:!.*]]
     int A[] = { 1, 2, 3 };
 
-// CHECK: call void @llvm.memcpy{{.*}}%B, {{.*}}@__const._Z1av.B{{.*}}, !dbg [[G2R1:!.*]]
-// CHECK: store i32 1, ptr %{{.*}}, !dbg [[G2R1:!.*]]
-// CHECK: store i32 2, ptr %{{.*}}, !dbg [[G2R1]]
-// CHECK: %0 = load i32, ptr @g{{.*}}, !dbg [[G2R2:!.*]]
-// CHECK: store i32 %0, ptr %{{.*}}, !dbg [[G2R1]]
+// CHECK:      call void @llvm.memcpy{{.*}}%B, {{.*}}@__const._Z1av.B{{.*}}, !dbg [[G2R1:!.*]]
+// CHECK-NEXT: store i32 1, ptr %B{{.*}}, !dbg [[G2R1:!.*]]
+// CHECK-NEXT: %arrayinit.element = getelementptr {{.*}}, ptr %B, i64 1, !dbg [[B_LINE:!.*]]
+// CHECK-NEXT: store i32 2, ptr %arrayinit.element{{.*}}, !dbg [[G2R1]]
+// CHECK-NEXT: %arrayinit.element1 = getelementptr {{.*}}, ptr %B, i64 2, !dbg [[B_LINE]]
+// CHECK-NEXT: %0 = load i32, ptr @g{{.*}}, !dbg [[G2R2:!.*]]
+// CHECK-NEXT: store i32 %0, ptr %arrayinit.element1{{.*}}, !dbg [[G2R1]]
     int B[] = { 1, 2, g };
 
-// CHECK:      call void @llvm.memset{{.*}}, !dbg [[G3R1:!.*]]
-// CHECK-NEXT: %1 = getelementptr {{.*}}, ptr %big, i32 0, i32 0, !dbg [[LINE30:!.*]]
+// CHECK:      call void @llvm.memset{{.*}}%big{{.*}} !dbg [[G3R1:!.*]]
+// CHECK-NEXT: %1 = getelementptr {{.*}}, ptr %big, i32 0, i32 0, !dbg [[big_LINE:!.*]]
 // CHECK-NEXT: store i8 97, ptr %1{{.*}}, !dbg [[G3R1]]
-// CHECK-NEXT: %2 = getelementptr {{.*}}, ptr %big, i32 0, i32 1, !dbg [[LINE30]]
-// CHECK-NEXT: store i8 98, ptr %2{{.*}} !dbg [[G3R1]]
-// CHECK-NEXT: %3 = getelementptr {{.*}}, ptr %big, i32 0, i32 2, !dbg [[LINE30]]
-// CHECK-NEXT: store i8 99, ptr %3{{.*}} !dbg [[G3R1]]
-// CHECK-NEXT: %4 = getelementptr {{.*}}, ptr %big, i32 0, i32 3, !dbg [[LINE30]]
+// CHECK-NEXT: %2 = getelementptr {{.*}}, ptr %big, i32 0, i32 1, !dbg [[big_LINE]]
+// CHECK-NEXT: store i8 98, ptr %2{{.*}}, !dbg [[G3R1]]
+// CHECK-NEXT: %3 = getelementptr {{.*}}, ptr %big, i32 0, i32 2, !dbg [[big_LINE]]
+// CHECK-NEXT: store i8 99, ptr %3{{.*}}, !dbg [[G3R1]]
+// CHECK-NEXT: %4 = getelementptr {{.*}}, ptr %big, i32 0, i32 3, !dbg [[big_LINE]]
 // CHECK: store i8 100, ptr %4{{.*}} !dbg [[G3R1]]
     char big[65536] = { 'a', 'b', 'c', 'd' };
 
-// CHECK: call void @llvm.memset{{.*}}, !dbg [[G4R1:!.*]]
+// CHECK: call void @llvm.memset{{.*}}%arr{{.*}}, !dbg [[G4R1:!.*]]
     char arr[] = { 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, };
 
 // CHECK: store i8 -86, ptr %uninit{{.*}}, !dbg [[G5R1:!.*]], !annotation
@@ -38,8 +40,9 @@ void a() {
 
 // CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
 // CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[B_LINE]] = !DILocation(line: 21, scope: ![[#]])
 // CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
 // CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
-// CHECK: [[LINE30]] = !DILocation(line: 30, scope: ![[#]])
+// CHECK: [[big_LINE]] = !DILocation(line: 32, scope: ![[#]])
 // CHECK: [[G4R1]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 1)
 // CHECK: [[G5R1]] = !DILocation({{.*}}, atomGroup: 5, atomRank: 1)

--- a/clang/test/DebugInfo/KeyInstructions/init-agg.cpp
+++ b/clang/test/DebugInfo/KeyInstructions/init-agg.cpp
@@ -8,20 +8,25 @@
 int g;
 void a() {
 // CHECK: _Z1av()
-// CHECK: call void @llvm.memcpy{{.*}}, !dbg [[G1R1:!.*]]
+// CHECK: call void @llvm.memcpy{{.*}}%A, {{.*}}@__const._Z1av.A{{.*}}, !dbg [[G1R1:!.*]]
     int A[] = { 1, 2, 3 };
 
+// CHECK: call void @llvm.memcpy{{.*}}%B, {{.*}}@__const._Z1av.B{{.*}}, !dbg [[G2R1:!.*]]
 // CHECK: store i32 1, ptr %{{.*}}, !dbg [[G2R1:!.*]]
 // CHECK: store i32 2, ptr %{{.*}}, !dbg [[G2R1]]
 // CHECK: %0 = load i32, ptr @g{{.*}}, !dbg [[G2R2:!.*]]
 // CHECK: store i32 %0, ptr %{{.*}}, !dbg [[G2R1]]
     int B[] = { 1, 2, g };
 
-// CHECK: call void @llvm.memset{{.*}}, !dbg [[G3R1:!.*]]
-// CHECK: store i8 97{{.*}}, !dbg [[G3R1]]
-// CHECK: store i8 98{{.*}}, !dbg [[G3R1]]
-// CHECK: store i8 99{{.*}}, !dbg [[G3R1]]
-// CHECK: store i8 100{{.*}}, !dbg [[G3R1]]
+// CHECK:      call void @llvm.memset{{.*}}, !dbg [[G3R1:!.*]]
+// CHECK-NEXT: %1 = getelementptr {{.*}}, ptr %big, i32 0, i32 0, !dbg [[LINE30:!.*]]
+// CHECK-NEXT: store i8 97, ptr %1{{.*}}, !dbg [[G3R1]]
+// CHECK-NEXT: %2 = getelementptr {{.*}}, ptr %big, i32 0, i32 1, !dbg [[LINE30]]
+// CHECK-NEXT: store i8 98, ptr %2{{.*}} !dbg [[G3R1]]
+// CHECK-NEXT: %3 = getelementptr {{.*}}, ptr %big, i32 0, i32 2, !dbg [[LINE30]]
+// CHECK-NEXT: store i8 99, ptr %3{{.*}} !dbg [[G3R1]]
+// CHECK-NEXT: %4 = getelementptr {{.*}}, ptr %big, i32 0, i32 3, !dbg [[LINE30]]
+// CHECK: store i8 100, ptr %4{{.*}} !dbg [[G3R1]]
     char big[65536] = { 'a', 'b', 'c', 'd' };
 
 // CHECK: call void @llvm.memset{{.*}}, !dbg [[G4R1:!.*]]
@@ -35,5 +40,6 @@ void a() {
 // CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
 // CHECK: [[G2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
 // CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
+// CHECK: [[LINE30]] = !DILocation(line: 30, scope: ![[#]])
 // CHECK: [[G4R1]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 1)
 // CHECK: [[G5R1]] = !DILocation({{.*}}, atomGroup: 5, atomRank: 1)

--- a/clang/test/DebugInfo/KeyInstructions/init-agg.cpp
+++ b/clang/test/DebugInfo/KeyInstructions/init-agg.cpp
@@ -1,5 +1,5 @@
 
-// RUN: %clang -gkey-instructions %s -gmlt -gno-column-info -S -emit-llvm -o - -ftrivial-auto-var-init=pattern \
+// RUN: %clang_cc1 -gkey-instructions %s -debug-info-kind=line-tables-only -gno-column-info -emit-llvm -o - -ftrivial-auto-var-init=pattern \
 // RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
 
 // The implicit-check-not is important; we don't want the GEPs created for the


### PR DESCRIPTION
[KeyInstr][Clang] Agg init atom

This patch is part of a stack that teaches Clang to generate Key Instructions
metadata for C and C++.

The Key Instructions project is introduced, including a "quick summary" section
at the top which adds context for this PR, here:
https://discourse.llvm.org/t/rfc-improving-is-stmt-placement-for-better-interactive-debugging/82668

The feature is only functional in LLVM if LLVM is built with CMake flag
LLVM_EXPERIMENTAL_KEY_INSTRUCTIONs. Eventually that flag will be removed.

The Clang-side work is demoed here:
https://github.com/llvm/llvm-project/pull/130943

shouldUseBZeroPlusStoresToInitialize

[KeyInstr] init-agg pattern

[KeyInstr][Clang] Init pattern atom