### PR TITLE
[KeyInstr][Clang] Member initalization atom

### DIFF
--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -1338,6 +1338,7 @@ void CodeGenFunction::EmitCtorPrologue(const CXXConstructorDecl *CD,
     assert(!Member->isBaseInitializer());
     assert(Member->isAnyMemberInitializer() &&
            "Delegating initializer on non-delegating constructor");
+    ApplyAtomGroup Grp(getDebugInfo());
     CM.addMemberInitializer(Member);
   }
   CM.finish();

--- a/clang/test/DebugInfo/KeyInstructions/init-member.cpp
+++ b/clang/test/DebugInfo/KeyInstructions/init-member.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang -gkey-instructions %s -gmlt -S -emit-llvm -o - \
+// RUN: | FileCheck %s
+
+struct B {
+  float y;
+};
+
+class Cls {
+  public:
+    int x = 1;
+    B b = {5.f};
+};
+
+void fun() {
+  Cls c;
+}
+
+// CHECK: store i32 1, ptr %x{{.*}}, !dbg [[G1R1:!.*]]
+// CHECK: store float 5.000000e+00, ptr %y{{.*}}, !dbg [[G2R1:!.*]]
+
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)

--- a/clang/test/DebugInfo/KeyInstructions/init-member.cpp
+++ b/clang/test/DebugInfo/KeyInstructions/init-member.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang -gkey-instructions %s -gmlt -S -emit-llvm -o - \
+// RUN: %clang_cc1 -gkey-instructions %s -debug-info-kind=line-tables-only -emit-llvm -o - \
 // RUN: | FileCheck %s
 
 struct B {


### PR DESCRIPTION
This patch is part of a stack that teaches Clang to generate Key Instructions
metadata for C and C++.

The Key Instructions project is introduced, including a "quick summary" section
at the top which adds context for this PR, here:
https://discourse.llvm.org/t/rfc-improving-is-stmt-placement-for-better-interactive-debugging/82668

The feature is only functional in LLVM if LLVM is built with CMake flag
LLVM_EXPERIMENTAL_KEY_INSTRUCTIONs. Eventually that flag will be removed.

The Clang-side work is demoed here:
https://github.com/llvm/llvm-project/pull/130943