### PR TITLE
[KeyInstr][Clang] While stmt atom

### DIFF
--- a/clang/test/DebugInfo/KeyInstructions/while.c
+++ b/clang/test/DebugInfo/KeyInstructions/while.c
@@ -1,0 +1,34 @@
+// RUN: %clang -gkey-instructions -x c++ -std=c++17 %s -gmlt -S -emit-llvm -o - \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+// RUN: %clang -gkey-instructions -x c %s -gmlt -S -emit-llvm -o -  \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+// Perennial quesiton: should the `dec` be in its own source atom or not
+// (currently it is).
+
+// We've made the cmp and br separate source atoms for now, to match existing
+// behaviour in this case:
+// 1. while (
+// 2.   int i = --End
+// 3.   ) {
+// 4.   useValue(i);
+// 5. }
+// Without Key Instructions we go: 2, 1[, 4, 2, 1]+
+// Without separating cmp and br with Key Instructions we'd get:
+// 1[, 4, 1]+. If we made the cmp higher precedence than the
+// br and had them in the same group, we could get:
+// 2, [4, 2]+ which might be nicer. FIXME: do that later.
+
+void a(int A) {
+// CHECK: %dec = add nsw i32 %0, -1, !dbg [[G1R2:!.*]]
+// CHECK: store i32 %dec, ptr %A.addr{{.*}}, !dbg [[G1R1:!.*]]
+// CHECK: %tobool = icmp ne i32 %dec, 0, !dbg [[G2R1:!.*]]
+// CHECK: br i1 %tobool, label %while.body, label %while.end, !dbg [[G3R1:!.*]]
+    while (--A) { };
+}
+
+// CHECK: [[G1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)

--- a/clang/test/DebugInfo/KeyInstructions/while.c
+++ b/clang/test/DebugInfo/KeyInstructions/while.c
@@ -1,7 +1,7 @@
-// RUN: %clang -gkey-instructions -x c++ -std=c++17 %s -gmlt -S -emit-llvm -o - \
+// RUN: %clang_cc1 -gkey-instructions -x c++ -std=c++17 %s -debug-info-kind=line-tables-only -emit-llvm -o - \
 // RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
 
-// RUN: %clang -gkey-instructions -x c %s -gmlt -S -emit-llvm -o -  \
+// RUN: %clang_cc1 -gkey-instructions -x c %s -debug-info-kind=line-tables-only -emit-llvm -o -  \
 // RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
 
 // Perennial quesiton: should the `dec` be in its own source atom or not

--- a/clang/test/DebugInfo/KeyInstructions/while.c
+++ b/clang/test/DebugInfo/KeyInstructions/while.c
@@ -4,7 +4,7 @@
 // RUN: %clang_cc1 -gkey-instructions -x c %s -debug-info-kind=line-tables-only -emit-llvm -o -  \
 // RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
 
-// Perennial quesiton: should the `dec` be in its own source atom or not
+// Perennial question: should the `dec` be in its own source atom or not
 // (currently it is).
 
 // We've made the cmp and br separate source atoms for now, to match existing


### PR DESCRIPTION
See test comment for possible future improvement.

This patch is part of a stack that teaches Clang to generate Key Instructions
metadata for C and C++.

The Key Instructions project is introduced, including a "quick summary" section
at the top which adds context for this PR, here:
https://discourse.llvm.org/t/rfc-improving-is-stmt-placement-for-better-interactive-debugging/82668

The feature is only functional in LLVM if LLVM is built with CMake flag
LLVM_EXPERIMENTAL_KEY_INSTRUCTIONs. Eventually that flag will be removed.

The Clang-side work is demoed here:
https://github.com/llvm/llvm-project/pull/130943