### PR TITLE
[KeyInstr][Clang] For stmt atom

### DIFF
--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -1370,8 +1370,8 @@ void CodeGenFunction::EmitForStmt(const ForStmt &S,
     // match existing loop stepping behaviour. FIXME: We could have the branch
     // as the backup location for the condition, which would probably be a
     // better experience (no jumping to the brace).
-    if (auto *I = dyn_cast<llvm::Instruction>(BoolCondVal))
-      addInstToNewSourceAtom(I, nullptr);
+    if (auto *CondI = dyn_cast<llvm::Instruction>(BoolCondVal))
+      addInstToNewSourceAtom(CondI, nullptr);
     addInstToNewSourceAtom(I, nullptr);
 
     if (ExitBlock != LoopExit.getBlock()) {

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -1396,6 +1396,8 @@ void CodeGenFunction::EmitForStmt(const ForStmt &S,
     EmitStmt(S.getBody());
   }
 
+  // The last block in the loop's body (which unconditionally branches to the
+  // `inc` block if there is one).
   auto *FinalBodyBB = Builder.GetInsertBlock();
 
   // If there is an increment, emit it next.

--- a/clang/test/DebugInfo/KeyInstructions/for.c
+++ b/clang/test/DebugInfo/KeyInstructions/for.c
@@ -1,0 +1,37 @@
+// RUN: %clang -gkey-instructions -x c++ %s -gmlt -S -emit-llvm -o - \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+// RUN: %clang -gkey-instructions -x c %s -gmlt -S -emit-llvm -o -  \
+// RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
+
+// Perennial quesiton: should the inc be its own source atom or not
+// (currently it is).
+
+// FIXME: See do.c and while.c regarding cmp and cond br groups.
+
+void a(int A) {
+// CHECK: entry:
+// CHECK: store i32 0, ptr %i{{.*}}, !dbg [[G1R1:!.*]]
+// CHECK: for.cond:
+// CHECK: %cmp = icmp slt i32 %0, %1, !dbg [[G2R1:!.*]]
+// CHECK: br i1 %cmp, label %for.body, label %for.end, !dbg [[G3R1:!.*]]
+
+// FIXME: Added uncond br group here which is useful for O0, which we're
+// no longer targeting. With optimisations loop rotate puts the condition
+// into for.inc and simplifycfg smooshes that and for.body together, so
+// it's not clear whether it adds any value.
+// CHECK: for.body:
+// CHECK: br label %for.inc, !dbg [[G5R1:!.*]]
+
+// CHECK: for.inc:
+// CHECK: %inc = add{{.*}}, !dbg [[G4R2:!.*]]
+// CHECK: store i32 %inc, ptr %i{{.*}}, !dbg [[G4R1:!.*]]
+    for (int i = 0; i < A; ++i) { }
+}
+
+// CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
+// CHECK: [[G5R1]] = !DILocation({{.*}}, atomGroup: 5, atomRank: 1)
+// CHECK: [[G4R2]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 2)
+// CHECK: [[G4R1]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 1)

--- a/clang/test/DebugInfo/KeyInstructions/for.c
+++ b/clang/test/DebugInfo/KeyInstructions/for.c
@@ -81,6 +81,18 @@ void c(int A) {
   }
 }
 
+void d() {
+// - Check the `for` keyword gets an atom group.
+// CHECK: entry:
+// CHECK-NEXT: br label %for.cond
+
+// CHECK: for.cond:
+// CHECK: br label %for.cond, !dbg [[dG1R1:!.*]], !llvm.loop
+  for ( ; ; )
+  {
+  }
+}
+
 // CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
 // CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
 // CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
@@ -102,3 +114,5 @@ void c(int A) {
 // CHECK: [[cG3R1]] = !DILocation(line: 81,{{.*}} atomGroup: 3, atomRank: 1)
 // CHECK: [[cG2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
 // CHECK: [[cG2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+
+// CHECK: [[dG1R1]] = !DILocation(line: 91, column: 3, scope: ![[#]], atomGroup: 1, atomRank: 1)

--- a/clang/test/DebugInfo/KeyInstructions/for.c
+++ b/clang/test/DebugInfo/KeyInstructions/for.c
@@ -20,17 +20,18 @@ void a(int A) {
 // O0. Since we're no longer targeting O0 we should reevaluate whether this
 // adds any value.
 // CHECK: for.body:
-// CHECK: br label %for.inc, !dbg [[G5R1:!.*]]
+// CHECK-NEXT: br label %for.inc, !dbg [[G5R1:!.*]]
 
 // CHECK: for.inc:
 // CHECK: %inc = add{{.*}}, !dbg [[G4R2:!.*]]
 // CHECK: store i32 %inc, ptr %i{{.*}}, !dbg [[G4R1:!.*]]
-    for (int i = 0; i < A; ++i) { }
+  for (int i = 0; i < A; ++i) {
+  }
 }
 
 // CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
 // CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
 // CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
-// CHECK: [[G5R1]] = !DILocation({{.*}}, atomGroup: 5, atomRank: 1)
+// CHECK: [[G5R1]] = !DILocation(line: 29,{{.*}} atomGroup: 5, atomRank: 1)
 // CHECK: [[G4R2]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 2)
 // CHECK: [[G4R1]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 1)

--- a/clang/test/DebugInfo/KeyInstructions/for.c
+++ b/clang/test/DebugInfo/KeyInstructions/for.c
@@ -1,7 +1,7 @@
-// RUN: %clang -gkey-instructions -x c++ %s -gmlt -S -emit-llvm -o - \
+// RUN: %clang_cc1 -gkey-instructions -x c++ %s -debug-info-kind=line-tables-only -emit-llvm -o - \
 // RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
 
-// RUN: %clang -gkey-instructions -x c %s -gmlt -S -emit-llvm -o -  \
+// RUN: %clang_cc1 -gkey-instructions -x c %s -debug-info-kind=line-tables-only -emit-llvm -o -  \
 // RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
 
 // Perennial quesiton: should the inc be its own source atom or not

--- a/clang/test/DebugInfo/KeyInstructions/for.c
+++ b/clang/test/DebugInfo/KeyInstructions/for.c
@@ -4,10 +4,10 @@
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -gkey-instructions -x c %s -debug-info-kind=line-tables-only -emit-llvm -o -  \
 // RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
 
-// Perennial quesiton: should the inc be its own source atom or not
+// Perennial question: should the inc be its own source atom or not
 // (currently it is).
 
-// FIXME: See do.c and while.c regarding cmp and cond br groups.
+// TODO: See do.c and while.c regarding cmp and cond br groups.
 
 void a(int A) {
 // CHECK: entry:
@@ -16,10 +16,9 @@ void a(int A) {
 // CHECK: %cmp = icmp slt i32 %0, %1, !dbg [[G2R1:!.*]]
 // CHECK: br i1 %cmp, label %for.body, label %for.end, !dbg [[G3R1:!.*]]
 
-// FIXME: Added uncond br group here which is useful for O0, which we're
-// no longer targeting. With optimisations loop rotate puts the condition
-// into for.inc and simplifycfg smooshes that and for.body together, so
-// it's not clear whether it adds any value.
+// TODO: The unconditional br is given an atom group here which is useful for
+// O0. Since we're no longer targeting O0 we should reevaluate whether this
+// adds any value.
 // CHECK: for.body:
 // CHECK: br label %for.inc, !dbg [[G5R1:!.*]]
 

--- a/clang/test/DebugInfo/KeyInstructions/for.c
+++ b/clang/test/DebugInfo/KeyInstructions/for.c
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -gkey-instructions -x c++ %s -debug-info-kind=line-tables-only -emit-llvm -o - \
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -gkey-instructions -x c++ %s -debug-info-kind=line-tables-only -emit-llvm -o - \
 // RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
 
-// RUN: %clang_cc1 -gkey-instructions -x c %s -debug-info-kind=line-tables-only -emit-llvm -o -  \
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -gkey-instructions -x c %s -debug-info-kind=line-tables-only -emit-llvm -o -  \
 // RUN: | FileCheck %s --implicit-check-not atomGroup --implicit-check-not atomRank
 
 // Perennial quesiton: should the inc be its own source atom or not

--- a/clang/test/DebugInfo/KeyInstructions/for.c
+++ b/clang/test/DebugInfo/KeyInstructions/for.c
@@ -29,9 +29,76 @@ void a(int A) {
   }
 }
 
+void b(int A) {
+// CHECK: entry:
+// CHECK: store i32 0, ptr %i{{.*}}, !dbg [[bG1R1:!.*]]
+// CHECK: for.cond:
+// CHECK: %cmp = icmp slt i32 %0, %1, !dbg [[bG2R1:!.*]]
+// CHECK: br i1 %cmp, label %for.body, label %for.end, !dbg [[bG3R1:!.*]]
+
+// CHECK: for.body:
+// CHECK-NEXT: %2 = load i32, ptr %A.addr
+// - If stmt atom:
+// CHECK-NEXT: %cmp1 = icmp sgt i32 %2, 1, !dbg [[bG4R2:!.*]]
+// CHECK-NEXT: br i1 %cmp1, label %if.then, label %if.end, !dbg [[bG4R1:!.*]]
+// CHECK: if.then:
+// CHECK-NEXT: br label %if.end
+
+// - For closing brace.
+// CHECK: if.end:
+// CHECK-NEXT: br label %for.inc, !dbg [[bG6R1:!.*]]
+
+// CHECK: for.inc:
+// CHECK: %inc = add{{.*}}, !dbg [[bG5R2:!.*]]
+// CHECK: store i32 %inc, ptr %i{{.*}}, !dbg [[bG5R1:!.*]]
+  for (int i = 0; i < A; ++i) {
+    if (A > 1)
+      ;
+  }
+}
+
+void c(int A) {
+// CHECK: entry:
+// CHECK: for.cond:
+// CHECK-NEXT: %0 = load i32, ptr %A.addr
+// - If stmt atom:
+// CHECK-NEXT: %cmp = icmp sgt i32 %0, 1, !dbg [[cG1R2:!.*]]
+// CHECK-NEXT: br i1 %cmp, label %if.then, label %if.end, !dbg [[cG1R1:!.*]]
+// CHECK: if.then:
+// CHECK-NEXT: br label %if.end
+
+// - For closing brace.
+// CHECK: if.end:
+// CHECK-NEXT: br label %for.inc, !dbg [[cG3R1:!.*]]
+
+// CHECK: for.inc:
+// CHECK-NEXT: %1 = load i32, ptr %A.addr
+// CHECK-NEXT: %inc = add{{.*}}, !dbg [[cG2R2:!.*]]
+// CHECK-NEXT: store i32 %inc, ptr %A.addr{{.*}}, !dbg [[cG2R1:!.*]]
+  for (; /*no cond*/ ; ++A) {
+    if (A > 1)
+      ;
+  }
+}
+
 // CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
 // CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
 // CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
 // CHECK: [[G5R1]] = !DILocation(line: 29,{{.*}} atomGroup: 5, atomRank: 1)
 // CHECK: [[G4R2]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 2)
 // CHECK: [[G4R1]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 1)
+
+// CHECK: [[bG1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[bG2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[bG3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
+// CHECK: [[bG4R2]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 2)
+// CHECK: [[bG4R1]] = !DILocation({{.*}}, atomGroup: 4, atomRank: 1)
+// CHECK: [[bG6R1]] = !DILocation(line: 57,{{.*}} atomGroup: 6, atomRank: 1)
+// CHECK: [[bG5R2]] = !DILocation({{.*}}, atomGroup: 5, atomRank: 2)
+// CHECK: [[bG5R1]] = !DILocation({{.*}}, atomGroup: 5, atomRank: 1)
+
+// CHECK: [[cG1R2]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 2)
+// CHECK: [[cG1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[cG3R1]] = !DILocation(line: 81,{{.*}} atomGroup: 3, atomRank: 1)
+// CHECK: [[cG2R2]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 2)
+// CHECK: [[cG2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)

--- a/clang/test/DebugInfo/KeyInstructions/for.c
+++ b/clang/test/DebugInfo/KeyInstructions/for.c
@@ -93,6 +93,27 @@ void d() {
   }
 }
 
+int x, i;
+void ee();
+void e() {
+// - Check we assign an atom group to `for.body`s `br`, even without braces.
+// - TODO: Investigate whether this is needed.
+// CHECK: entry:
+
+// CHECK: for.cond:
+// CHECK-NEXT: %0 = load i32, ptr @i
+// CHECK-NEXT: %cmp = icmp slt i32 %0, 3, !dbg [[eG1R1:!.*]]
+// CHECK-NEXT: br i1 %cmp, label %for.body, label %for.end, !dbg [[eG2R1:!.*]]
+
+// CHECK: for.body:
+// CHECK-NEXT: %1 = load i32, ptr @i{{.*}}, !dbg [[eG3R2:!.*]]
+// CHECK-NEXT: store i32 %1, ptr @x{{.*}}, !dbg [[eG3R1:!.*]]
+// CHECK-NEXT: br label %for.inc, !dbg [[eG4R1:!.*]]
+  for (; i < 3; ee())
+    x = i;
+}
+
+
 // CHECK: [[G1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
 // CHECK: [[G2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
 // CHECK: [[G3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
@@ -116,3 +137,9 @@ void d() {
 // CHECK: [[cG2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
 
 // CHECK: [[dG1R1]] = !DILocation(line: 91, column: 3, scope: ![[#]], atomGroup: 1, atomRank: 1)
+
+// CHECK: [[eG1R1]] = !DILocation({{.*}}, atomGroup: 1, atomRank: 1)
+// CHECK: [[eG2R1]] = !DILocation({{.*}}, atomGroup: 2, atomRank: 1)
+// CHECK: [[eG3R2]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 2)
+// CHECK: [[eG3R1]] = !DILocation({{.*}}, atomGroup: 3, atomRank: 1)
+// CHECK: [[eG4R1]] = !DILocation(line: 113, column: 5, scope: ![[#]], atomGroup: 4, atomRank: 1)


### PR DESCRIPTION
This patch is part of a stack that teaches Clang to generate Key Instructions
metadata for C and C++.

The Key Instructions project is introduced, including a "quick summary" section
at the top which adds context for this PR, here:
https://discourse.llvm.org/t/rfc-improving-is-stmt-placement-for-better-interactive-debugging/82668

The feature is only functional in LLVM if LLVM is built with CMake flag
LLVM_EXPERIMENTAL_KEY_INSTRUCTIONs. Eventually that flag will be removed.

The Clang-side work is demoed here:
https://github.com/llvm/llvm-project/pull/130943