### PR TITLE
[EquivalenceClasses] Introduce erase member function

### DIFF
--- a/llvm/include/llvm/ADT/EquivalenceClasses.h
+++ b/llvm/include/llvm/ADT/EquivalenceClasses.h
@@ -222,7 +222,7 @@ public:
   }
 
   /// erase - Erase a value from the union/find set, return "true" if erase
-  /// succeeded.
+  /// succeeded, or "false" when the value was not found.
   bool erase(const ElemTy &V) {
     if (!TheMapping.contains(V))
       return false;
@@ -237,9 +237,9 @@ public:
       Next->Next = reinterpret_cast<const ECValue *>(
           reinterpret_cast<intptr_t>(Next->Next) | static_cast<intptr_t>(1));
 
-      const ECValue *newLeader = Next;
+      const ECValue *NewLeader = Next;
       while ((Next = Next->getNext())) {
-        Next->Leader = newLeader;
+        Next->Leader = NewLeader;
       }
     } else if (!Cur->isLeader()) {
       const ECValue *Leader = findLeader(V).Node;

--- a/llvm/include/llvm/ADT/EquivalenceClasses.h
+++ b/llvm/include/llvm/ADT/EquivalenceClasses.h
@@ -234,12 +234,14 @@ public:
     // all other elements in same class to be the successor element.
     if (Cur->isLeader() && Next) {
       Next->Leader = Cur->Leader;
-      Next->Next = (const ECValue *)((intptr_t)Next->Next | (intptr_t)1);
+      Next->Next = reinterpret_cast<const ECValue *>(
+          reinterpret_cast<intptr_t>(Next->Next) | static_cast<intptr_t>(1));
+
       const ECValue *newLeader = Next;
       while ((Next = Next->getNext())) {
         Next->Leader = newLeader;
       }
-    } else {
+    } else if (!Cur->isLeader()) {
       const ECValue *Leader = findLeader(V).Node;
       const ECValue *Pre = Leader;
       while (Pre->getNext() != Cur) {
@@ -254,8 +256,9 @@ public:
       } else {
         // If the current element is in the middle of class, then simply
         // connect the predecessor element and the successor element.
-        Pre->Next =
-            (const ECValue *)((intptr_t)Next | (intptr_t)Pre->isLeader());
+        Pre->Next = reinterpret_cast<const ECValue *>(
+            reinterpret_cast<intptr_t>(Next) |
+            static_cast<intptr_t>(Pre->isLeader()));
         Next->Leader = Pre;
       }
     }

--- a/llvm/include/llvm/ADT/EquivalenceClasses.h
+++ b/llvm/include/llvm/ADT/EquivalenceClasses.h
@@ -220,6 +220,40 @@ public:
     return *ECV;
   }
 
+  /// erase - Erase a value from the union/find set, return if erase succeed.
+  bool erase(const ElemTy &V) {
+    if (!TheMapping.contains(V)) return false;
+    const ECValue *cur = TheMapping[V];
+    const ECValue *next = cur->getNext();
+    if (cur->isLeader()) {
+      if (next) {
+        next->Leader = cur->Leader;
+        auto nn = next->Next;
+        next->Next = (const ECValue*)((intptr_t)nn | (intptr_t)1);
+      }
+    } else {
+      const ECValue *leader = findLeader(V).Node;
+      const ECValue *pre = leader;
+      while (pre->getNext() != cur) {
+        pre = pre->getNext();
+      }
+      if (!next) {
+        pre->Next = nullptr;
+        leader->Leader = pre;
+      } else {
+        pre->Next = (const ECValue*)((intptr_t)next | (intptr_t)pre->isLeader());
+        next->Leader = pre;
+      }
+    }
+    TheMapping.erase(V);
+    for (auto I = Members.begin(); I != Members.end(); I++) {
+      if (*I == cur) {
+        Members.erase(I);
+        break;
+      }
+    }
+    return true;
+  }
   /// findLeader - Given a value in the set, return a member iterator for the
   /// equivalence class it is in.  This does the path-compression part that
   /// makes union-find "union findy".  This returns an end iterator if the value
@@ -247,7 +281,9 @@ public:
     // Otherwise, this is a real union operation.  Set the end of the L1 list to
     // point to the L2 leader node.
     const ECValue &L1LV = *L1.Node, &L2LV = *L2.Node;
-    L1LV.getEndOfList()->setNext(&L2LV);
+    const ECValue *L1LastV = L1LV.getEndOfList();
+
+    L1LastV->setNext(&L2LV);
 
     // Update L1LV's end of list pointer.
     L1LV.Leader = L2LV.getEndOfList();
@@ -255,8 +291,8 @@ public:
     // Clear L2's leader flag:
     L2LV.Next = L2LV.getNext();
 
-    // L2's leader is now L1.
-    L2LV.Leader = &L1LV;
+    // L2's leader is now last value of L1.
+    L2LV.Leader = L1LastV;
     return L1;
   }
 

--- a/llvm/include/llvm/ADT/EquivalenceClasses.h
+++ b/llvm/include/llvm/ADT/EquivalenceClasses.h
@@ -265,7 +265,7 @@ public:
     // Update 'TheMapping' and 'Members'.
     assert(TheMapping.contains(V) && "Can't find input in TheMapping!");
     TheMapping.erase(V);
-    auto I = llvm::find(Members, Cur);
+    auto I = find(Members, Cur);
     assert(I != Members.end() && "Can't find input in members!");
     Members.erase(I);
     return true;

--- a/llvm/include/llvm/ADT/EquivalenceClasses.h
+++ b/llvm/include/llvm/ADT/EquivalenceClasses.h
@@ -16,8 +16,8 @@
 #define LLVM_ADT_EQUIVALENCECLASSES_H
 
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Allocator.h"
 #include <cassert>

--- a/llvm/include/llvm/ADT/EquivalenceClasses.h
+++ b/llvm/include/llvm/ADT/EquivalenceClasses.h
@@ -228,18 +228,16 @@ public:
       return false;
     const ECValue *Cur = TheMapping[V];
     const ECValue *Next = Cur->getNext();
-    if (Cur->isLeader()) {
-      // If the current element is the leader and has a successor element,
-      // update the successor element's 'Leader' field to be the last element,
-      // set the successor element's stolen bit, and set the 'Leader' field of
-      // all other elements in same class to be the successor element.
-      if (Next) {
-        Next->Leader = Cur->Leader;
-        Next->Next = (const ECValue *)((intptr_t)Next->Next | (intptr_t)1);
-        const ECValue *newLeader = Next;
-        while ((Next = Next->getNext())) {
-          Next->Leader = newLeader;
-        }
+    // If the current element is the leader and has a successor element,
+    // update the successor element's 'Leader' field to be the last element,
+    // set the successor element's stolen bit, and set the 'Leader' field of
+    // all other elements in same class to be the successor element.
+    if (Cur->isLeader() && Next) {
+      Next->Leader = Cur->Leader;
+      Next->Next = (const ECValue *)((intptr_t)Next->Next | (intptr_t)1);
+      const ECValue *newLeader = Next;
+      while ((Next = Next->getNext())) {
+        Next->Leader = newLeader;
       }
     } else {
       const ECValue *Leader = findLeader(V).Node;

--- a/llvm/unittests/ADT/EquivalenceClassesTest.cpp
+++ b/llvm/unittests/ADT/EquivalenceClassesTest.cpp
@@ -59,6 +59,55 @@ TEST(EquivalenceClassesTest, SimpleMerge2) {
       EXPECT_TRUE(EqClasses.isEquivalent(i, j));
 }
 
+TEST(EquivalenceClassesTest, SimpleErase1) {
+  EquivalenceClasses<int> EqClasses;
+  // Check that erase head success.
+  // After erase A from (A, B ,C, D), <B, C, D> belong to one set.
+  EqClasses.unionSets(0, 1);
+  EqClasses.unionSets(2, 3);
+  EqClasses.unionSets(0, 2);
+  EXPECT_TRUE(EqClasses.erase(0));
+  for (int i = 1; i < 4; ++i)
+    for (int j = 1; j < 4; ++j)
+      EXPECT_TRUE(EqClasses.isEquivalent(i, j));
+}
+
+TEST(EquivalenceClassesTest, SimpleErase2) {
+  EquivalenceClasses<int> EqClasses;
+  // Check that erase tail success.
+  // After erase D from (A, B ,C, D), <A, B, C> belong to one set.
+  EqClasses.unionSets(0, 1);
+  EqClasses.unionSets(2, 3);
+  EqClasses.unionSets(0, 2);
+  EXPECT_TRUE(EqClasses.erase(3));
+  for (int i = 0; i < 3; ++i)
+    for (int j = 0; j < 3; ++j)
+      EXPECT_TRUE(EqClasses.isEquivalent(i, j));
+}
+
+TEST(EquivalenceClassesTest, SimpleErase3) {
+  EquivalenceClasses<int> EqClasses;
+  // Check that erase a value in the middle success.
+  // After erase B from (A, B ,C, D), <A, C, D> belong to one set.
+  EqClasses.unionSets(0, 1);
+  EqClasses.unionSets(2, 3);
+  EqClasses.unionSets(0, 2);
+  EXPECT_TRUE(EqClasses.erase(1));
+  for (int i = 0; i < 3; ++i)
+    for (int j = 0; j < 3; ++j)
+      EXPECT_TRUE(EqClasses.isEquivalent(i, j) ^ ((i == 1) ^ (j == 1)));
+}
+
+TEST(EquivalenceClassesTest, SimpleErase4) {
+  EquivalenceClasses<int> EqClasses;
+  // Check that erase a single class success.
+  EqClasses.insert(0);
+  EXPECT_TRUE(EqClasses.getNumClasses() == 1);
+  EXPECT_TRUE(EqClasses.erase(0));
+  EXPECT_TRUE(EqClasses.getNumClasses() == 0);
+  EXPECT_FALSE(EqClasses.erase(1));
+}
+
 TEST(EquivalenceClassesTest, TwoSets) {
   EquivalenceClasses<int> EqClasses;
   // Form sets of odd and even numbers, check that we split them into these


### PR DESCRIPTION
Introduce 'erase(const ElemTy &V)' member function to allow the deletion of a certain value from EquivClasses. This is essential for certain scenarios that require modifying the contents of EquivClasses.