### PR TITLE
[lldb] Support negative function offsets in UnwindPlans

### DIFF
--- a/lldb/include/lldb/Symbol/UnwindPlan.h
+++ b/lldb/include/lldb/Symbol/UnwindPlan.h
@@ -356,11 +356,11 @@ public:
 
     void RemoveRegisterInfo(uint32_t reg_num);
 
-    lldb::addr_t GetOffset() const { return m_offset; }
+    int64_t GetOffset() const { return m_offset; }
 
-    void SetOffset(lldb::addr_t offset) { m_offset = offset; }
+    void SetOffset(int64_t offset) { m_offset = offset; }
 
-    void SlideOffset(lldb::addr_t offset) { m_offset += offset; }
+    void SlideOffset(int64_t offset) { m_offset += offset; }
 
     const FAValue &GetCFAValue() const { return m_cfa_value; }
     FAValue &GetCFAValue() { return m_cfa_value; }
@@ -420,7 +420,7 @@ public:
 
   protected:
     typedef std::map<uint32_t, AbstractRegisterLocation> collection;
-    lldb::addr_t m_offset = 0; // Offset into the function for this row
+    int64_t m_offset = 0; // Offset into the function for this row
 
     FAValue m_cfa_value;
     FAValue m_afa_value;
@@ -455,7 +455,7 @@ public:
   // practice, the UnwindPlan for a function with no known start address will be
   // the architectural default UnwindPlan which will only have one row.
   const UnwindPlan::Row *
-  GetRowForFunctionOffset(std::optional<int> offset) const;
+  GetRowForFunctionOffset(std::optional<int64_t> offset) const;
 
   lldb::RegisterKind GetRegisterKind() const { return m_register_kind; }
 

--- a/lldb/source/Plugins/UnwindAssembly/x86/x86AssemblyInspectionEngine.cpp
+++ b/lldb/source/Plugins/UnwindAssembly/x86/x86AssemblyInspectionEngine.cpp
@@ -1390,11 +1390,12 @@ bool x86AssemblyInspectionEngine::AugmentUnwindPlanFromCallSite(
 
     // If we already have one row for this instruction, we can continue.
     while (row_id < unwind_plan.GetRowCount() &&
-           unwind_plan.GetRowAtIndex(row_id)->GetOffset() <= offset) {
+           unwind_plan.GetRowAtIndex(row_id)->GetOffset() <=
+               static_cast<int64_t>(offset)) {
       row_id++;
     }
     const UnwindPlan::Row *original_row = unwind_plan.GetRowAtIndex(row_id - 1);
-    if (original_row->GetOffset() == offset) {
+    if (original_row->GetOffset() == static_cast<int64_t>(offset)) {
       row = *original_row;
       continue;
     }

--- a/lldb/source/Symbol/DWARFCallFrameInfo.cpp
+++ b/lldb/source/Symbol/DWARFCallFrameInfo.cpp
@@ -765,7 +765,7 @@ bool DWARFCallFrameInfo::FDEToUnwindPlan(dw_offset_t dwarf_offset,
                      __FUNCTION__, dwarf_offset, startaddr.GetFileAddress());
             break;
           }
-          lldb::addr_t offset = row.GetOffset();
+          int64_t offset = row.GetOffset();
           row = std::move(stack.back());
           stack.pop_back();
           row.SetOffset(offset);

--- a/lldb/source/Symbol/UnwindPlan.cpp
+++ b/lldb/source/Symbol/UnwindPlan.cpp
@@ -398,10 +398,10 @@ void UnwindPlan::AppendRow(Row row) {
 }
 
 struct RowLess {
-  bool operator()(addr_t a, const UnwindPlan::Row &b) const {
+  bool operator()(int64_t a, const UnwindPlan::Row &b) const {
     return a < b.GetOffset();
   }
-  bool operator()(const UnwindPlan::Row &a, addr_t b) const {
+  bool operator()(const UnwindPlan::Row &a, int64_t b) const {
     return a.GetOffset() < b;
   }
 };
@@ -418,7 +418,7 @@ void UnwindPlan::InsertRow(Row row, bool replace_existing) {
 }
 
 const UnwindPlan::Row *
-UnwindPlan::GetRowForFunctionOffset(std::optional<int> offset) const {
+UnwindPlan::GetRowForFunctionOffset(std::optional<int64_t> offset) const {
   auto it = offset ? llvm::upper_bound(m_row_list, *offset, RowLess())
                    : m_row_list.end();
   if (it == m_row_list.begin())

--- a/lldb/unittests/Symbol/UnwindPlanTest.cpp
+++ b/lldb/unittests/Symbol/UnwindPlanTest.cpp
@@ -24,6 +24,7 @@ static UnwindPlan::Row make_simple_row(addr_t offset, uint64_t cfa_value) {
 TEST(UnwindPlan, InsertRow) {
   UnwindPlan::Row row1 = make_simple_row(0, 42);
   UnwindPlan::Row row2 = make_simple_row(0, 47);
+  UnwindPlan::Row row3 = make_simple_row(-1, 4242);
 
   UnwindPlan plan(eRegisterKindGeneric);
   plan.InsertRow(row1);
@@ -34,6 +35,10 @@ TEST(UnwindPlan, InsertRow) {
 
   plan.InsertRow(row2, /*replace_existing=*/true);
   EXPECT_THAT(plan.GetRowForFunctionOffset(0), testing::Pointee(row2));
+
+  EXPECT_THAT(plan.GetRowForFunctionOffset(-1), nullptr);
+  plan.InsertRow(row3);
+  EXPECT_THAT(plan.GetRowForFunctionOffset(-1), testing::Pointee(row3));
 }
 
 TEST(UnwindPlan, GetRowForFunctionOffset) {

--- a/lldb/unittests/UnwindAssembly/ARM64/TestArm64InstEmulation.cpp
+++ b/lldb/unittests/UnwindAssembly/ARM64/TestArm64InstEmulation.cpp
@@ -90,7 +90,7 @@ TEST_F(TestArm64InstEmulation, TestSimpleDarwinFunction) {
 
   // CFA=sp +0 => fp= <same> lr= <same>
   row = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_EQ(0, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(0, row->GetCFAValue().GetOffset());
@@ -103,7 +103,7 @@ TEST_F(TestArm64InstEmulation, TestSimpleDarwinFunction) {
 
   // CFA=sp+16 => fp=[CFA-16] lr=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_EQ(4, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -118,7 +118,7 @@ TEST_F(TestArm64InstEmulation, TestSimpleDarwinFunction) {
 
   // CFA=fp+16 => fp=[CFA-16] lr=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(8);
-  EXPECT_EQ(8ull, row->GetOffset());
+  EXPECT_EQ(8, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -133,7 +133,7 @@ TEST_F(TestArm64InstEmulation, TestSimpleDarwinFunction) {
 
   // CFA=sp+16 => fp=[CFA-16] lr=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(16);
-  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_EQ(16, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -148,7 +148,7 @@ TEST_F(TestArm64InstEmulation, TestSimpleDarwinFunction) {
 
   // CFA=sp +0 => fp= <same> lr= <same>
   row = unwind_plan.GetRowForFunctionOffset(20);
-  EXPECT_EQ(20ull, row->GetOffset());
+  EXPECT_EQ(20, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(0, row->GetCFAValue().GetOffset());
@@ -219,14 +219,14 @@ TEST_F(TestArm64InstEmulation, TestMediumDarwinFunction) {
 
   // 0: CFA=sp +0 =>
   row = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_EQ(0, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
   // 4: CFA=sp+48 => x21=[CFA-40] x22=[CFA-48]
   row = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_EQ(4, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
   EXPECT_EQ(48, row->GetCFAValue().GetOffset());
 
@@ -240,7 +240,7 @@ TEST_F(TestArm64InstEmulation, TestMediumDarwinFunction) {
 
   // 8: CFA=sp+48 => x19=[CFA-24] x20=[CFA-32] x21=[CFA-40] x22=[CFA-48]
   row = unwind_plan.GetRowForFunctionOffset(8);
-  EXPECT_EQ(8ull, row->GetOffset());
+  EXPECT_EQ(8, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
   EXPECT_EQ(48, row->GetCFAValue().GetOffset());
 
@@ -255,7 +255,7 @@ TEST_F(TestArm64InstEmulation, TestMediumDarwinFunction) {
   // 12: CFA=sp+48 => x19=[CFA-24] x20=[CFA-32] x21=[CFA-40] x22=[CFA-48]
   // fp=[CFA-16] lr=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(12);
-  EXPECT_EQ(12ull, row->GetOffset());
+  EXPECT_EQ(12, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
   EXPECT_EQ(48, row->GetCFAValue().GetOffset());
 
@@ -270,7 +270,7 @@ TEST_F(TestArm64InstEmulation, TestMediumDarwinFunction) {
   // 16: CFA=fp+16 => x19=[CFA-24] x20=[CFA-32] x21=[CFA-40] x22=[CFA-48]
   // fp=[CFA-16] lr=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(16);
-  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_EQ(16, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -278,7 +278,7 @@ TEST_F(TestArm64InstEmulation, TestMediumDarwinFunction) {
   // 28: CFA=sp+48 => x19=[CFA-24] x20=[CFA-32] x21=[CFA-40] x22=[CFA-48]
   // fp=[CFA-16] lr=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(28);
-  EXPECT_EQ(28ull, row->GetOffset());
+  EXPECT_EQ(28, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(48, row->GetCFAValue().GetOffset());
@@ -286,7 +286,7 @@ TEST_F(TestArm64InstEmulation, TestMediumDarwinFunction) {
   // 32: CFA=sp+48 => x19=[CFA-24] x20=[CFA-32] x21=[CFA-40] x22=[CFA-48] fp=
   // <same> lr= <same>
   row = unwind_plan.GetRowForFunctionOffset(32);
-  EXPECT_EQ(32ull, row->GetOffset());
+  EXPECT_EQ(32, row->GetOffset());
 
   // I'd prefer if these restored registers were cleared entirely instead of set
   // to IsSame...
@@ -299,7 +299,7 @@ TEST_F(TestArm64InstEmulation, TestMediumDarwinFunction) {
   // 36: CFA=sp+48 => x19= <same> x20= <same> x21=[CFA-40] x22=[CFA-48] fp=
   // <same> lr= <same>
   row = unwind_plan.GetRowForFunctionOffset(36);
-  EXPECT_EQ(36ull, row->GetOffset());
+  EXPECT_EQ(36, row->GetOffset());
 
   EXPECT_TRUE(row->GetRegisterInfo(gpr_x19_arm64, regloc));
   EXPECT_TRUE(regloc.IsSame());
@@ -310,7 +310,7 @@ TEST_F(TestArm64InstEmulation, TestMediumDarwinFunction) {
   // 40: CFA=sp +0 => x19= <same> x20= <same> x21= <same> x22= <same> fp= <same>
   // lr= <same>
   row = unwind_plan.GetRowForFunctionOffset(40);
-  EXPECT_EQ(40ull, row->GetOffset());
+  EXPECT_EQ(40, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(0, row->GetCFAValue().GetOffset());
@@ -373,7 +373,7 @@ TEST_F(TestArm64InstEmulation, TestFramelessThreeEpilogueFunction) {
 
   // 0: CFA=sp +0 =>
   row = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_EQ(0, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(0, row->GetCFAValue().GetOffset());
@@ -503,7 +503,7 @@ TEST_F(TestArm64InstEmulation, TestRegisterSavedTwice) {
       sample_range, data, sizeof(data), unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(36);
-  EXPECT_EQ(28ull, row->GetOffset());
+  EXPECT_EQ(28, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -513,7 +513,7 @@ TEST_F(TestArm64InstEmulation, TestRegisterSavedTwice) {
   EXPECT_EQ(-32, regloc.GetOffset());
 
   row = unwind_plan.GetRowForFunctionOffset(40);
-  EXPECT_EQ(28ull, row->GetOffset());
+  EXPECT_EQ(28, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -619,7 +619,7 @@ TEST_F(TestArm64InstEmulation, TestRegisterDoubleSpills) {
   //  d8=[CFA-40] d9=[CFA-48] d10=[CFA-56] d11=[CFA-64] d12=[CFA-72]
   //  d13=[CFA-80] d14=[CFA-88] d15=[CFA-96]
   row = unwind_plan.GetRowForFunctionOffset(28);
-  EXPECT_EQ(28ull, row->GetOffset());
+  EXPECT_EQ(28, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -658,7 +658,7 @@ TEST_F(TestArm64InstEmulation, TestRegisterDoubleSpills) {
 
   //  60: CFA=sp +0 =>
   row = unwind_plan.GetRowForFunctionOffset(60);
-  EXPECT_EQ(60ull, row->GetOffset());
+  EXPECT_EQ(60, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(0, row->GetCFAValue().GetOffset());
@@ -765,14 +765,14 @@ TEST_F(TestArm64InstEmulation, TestCFARegisterTrackedAcrossJumps) {
 
   // Confirm CFA at mid-func epilogue 'ret' is $sp+0
   row = unwind_plan.GetRowForFunctionOffset(40);
-  EXPECT_EQ(40ull, row->GetOffset());
+  EXPECT_EQ(40, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
   // After the 'ret', confirm we're back to the correct CFA of $fp+16
   row = unwind_plan.GetRowForFunctionOffset(44);
-  EXPECT_EQ(44ull, row->GetOffset());
+  EXPECT_EQ(44, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -780,7 +780,7 @@ TEST_F(TestArm64InstEmulation, TestCFARegisterTrackedAcrossJumps) {
   // Confirm that we have no additional UnwindPlan rows before the 
   // real epilogue -- we still get the Row at offset 44.
   row = unwind_plan.GetRowForFunctionOffset(60);
-  EXPECT_EQ(44ull, row->GetOffset());
+  EXPECT_EQ(44, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -788,7 +788,7 @@ TEST_F(TestArm64InstEmulation, TestCFARegisterTrackedAcrossJumps) {
   // And in the epilogue, confirm that we start by switching back to 
   // defining the CFA in terms of $sp.
   row = unwind_plan.GetRowForFunctionOffset(64);
-  EXPECT_EQ(64ull, row->GetOffset());
+  EXPECT_EQ(64, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(32, row->GetCFAValue().GetOffset());
@@ -845,14 +845,14 @@ TEST_F(TestArm64InstEmulation, TestCFAResetToSP) {
 
   // Confirm CFA before epilogue instructions is in terms of $fp
   row = unwind_plan.GetRowForFunctionOffset(12);
-  EXPECT_EQ(12ull, row->GetOffset());
+  EXPECT_EQ(12, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_fp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
 
   // Confirm that after restoring $fp to caller's value, CFA is now in
   // terms of $sp
   row = unwind_plan.GetRowForFunctionOffset(16);
-  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_EQ(16, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_arm64);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
 }

--- a/lldb/unittests/UnwindAssembly/PPC64/TestPPC64InstEmulation.cpp
+++ b/lldb/unittests/UnwindAssembly/PPC64/TestPPC64InstEmulation.cpp
@@ -97,14 +97,14 @@ TEST_F(TestPPC64InstEmulation, TestSimpleFunction) {
 
   // 0: CFA=sp+0
   row = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_EQ(0, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
   // 1: CFA=sp+0 => fp=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(16);
-  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_EQ(16, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(0, row->GetCFAValue().GetOffset());
@@ -115,7 +115,7 @@ TEST_F(TestPPC64InstEmulation, TestSimpleFunction) {
 
   // 2: CFA=sp+0 => fp=[CFA-8] lr=[CFA+16]
   row = unwind_plan.GetRowForFunctionOffset(20);
-  EXPECT_EQ(20ull, row->GetOffset());
+  EXPECT_EQ(20, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(0, row->GetCFAValue().GetOffset());
@@ -126,7 +126,7 @@ TEST_F(TestPPC64InstEmulation, TestSimpleFunction) {
 
   // 3: CFA=sp+112 => fp=[CFA-8] lr=[CFA+16]
   row = unwind_plan.GetRowForFunctionOffset(24);
-  EXPECT_EQ(24ull, row->GetOffset());
+  EXPECT_EQ(24, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(112, row->GetCFAValue().GetOffset());
@@ -141,7 +141,7 @@ TEST_F(TestPPC64InstEmulation, TestSimpleFunction) {
 
   // 4: CFA=r31+112 => fp=[CFA-8] lr=[CFA+16]
   row = unwind_plan.GetRowForFunctionOffset(28);
-  EXPECT_EQ(28ull, row->GetOffset());
+  EXPECT_EQ(28, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r31_ppc64le);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(112, row->GetCFAValue().GetOffset());
@@ -156,7 +156,7 @@ TEST_F(TestPPC64InstEmulation, TestSimpleFunction) {
 
   // 5: CFA=sp+0 => fp=[CFA-8] lr=[CFA+16]
   row = unwind_plan.GetRowForFunctionOffset(40);
-  EXPECT_EQ(40ull, row->GetOffset());
+  EXPECT_EQ(40, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(0, row->GetCFAValue().GetOffset());
@@ -209,14 +209,14 @@ TEST_F(TestPPC64InstEmulation, TestMediumFunction) {
 
   // 0: CFA=sp+0
   row = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_EQ(0, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
   // 1: CFA=sp+0 => fp=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(8);
-  EXPECT_EQ(8ull, row->GetOffset());
+  EXPECT_EQ(8, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(0, row->GetCFAValue().GetOffset());
@@ -227,7 +227,7 @@ TEST_F(TestPPC64InstEmulation, TestMediumFunction) {
 
   // 2: CFA=sp+0 => fp=[CFA-8] lr=[CFA+16]
   row = unwind_plan.GetRowForFunctionOffset(12);
-  EXPECT_EQ(12ull, row->GetOffset());
+  EXPECT_EQ(12, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(0, row->GetCFAValue().GetOffset());
@@ -238,20 +238,20 @@ TEST_F(TestPPC64InstEmulation, TestMediumFunction) {
 
   // 3: CFA=r30
   row = unwind_plan.GetRowForFunctionOffset(16);
-  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_EQ(16, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r30_ppc64le);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
   row = unwind_plan.GetRowForFunctionOffset(32);
-  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_EQ(16, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r30_ppc64le);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(0, row->GetCFAValue().GetOffset());
 
   // 4: CFA=sp+0
   row = unwind_plan.GetRowForFunctionOffset(36);
-  EXPECT_EQ(36ull, row->GetOffset());
+  EXPECT_EQ(36, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_r1_ppc64le);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(0, row->GetCFAValue().GetOffset());

--- a/lldb/unittests/UnwindAssembly/x86/Testx86AssemblyInspectionEngine.cpp
+++ b/lldb/unittests/UnwindAssembly/x86/Testx86AssemblyInspectionEngine.cpp
@@ -172,7 +172,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimple64bitFrameFunction) {
 
   // 0: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
   const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_EQ(0, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -183,7 +183,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimple64bitFrameFunction) {
 
   // 1: CFA=rsp+16 => rbp=[CFA-16] rsp=CFA+0 rip=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_EQ(1, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -194,7 +194,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimple64bitFrameFunction) {
 
   // 4: CFA=rbp+16 => rbp=[CFA-16] rsp=CFA+0 rip=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_EQ(4, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -205,7 +205,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimple64bitFrameFunction) {
 
   // 7: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(7);
-  EXPECT_EQ(7ull, row->GetOffset());
+  EXPECT_EQ(7, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -248,7 +248,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimple32bitFrameFunction) {
 
   // offset 0 -- pushl %ebp
   const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_EQ(0, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(4, row->GetCFAValue().GetOffset());
@@ -259,7 +259,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimple32bitFrameFunction) {
 
   // 1: CFA=esp +8 => ebp=[CFA-8] esp=CFA+0 eip=[CFA-4]
   row = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_EQ(1, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -270,7 +270,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimple32bitFrameFunction) {
 
   // 3: CFA=ebp +8 => ebp=[CFA-8] esp=CFA+0 eip=[CFA-4]
   row = unwind_plan.GetRowForFunctionOffset(3);
-  EXPECT_EQ(3ull, row->GetOffset());
+  EXPECT_EQ(3, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_ebp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -281,7 +281,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimple32bitFrameFunction) {
 
   // 6: CFA=esp +4 => esp=CFA+0 eip=[CFA-4]
   row = unwind_plan.GetRowForFunctionOffset(6);
-  EXPECT_EQ(6ull, row->GetOffset());
+  EXPECT_EQ(6, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(4, row->GetCFAValue().GetOffset());
@@ -389,7 +389,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Test64bitFramelessBigStackFrame) {
 
   const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(17);
 
-  EXPECT_EQ(17ull, row->GetOffset());
+  EXPECT_EQ(17, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(14496, row->GetCFAValue().GetOffset());
@@ -427,7 +427,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Test64bitFramelessBigStackFrame) {
 
   row = unwind_plan.GetRowForFunctionOffset(34);
 
-  EXPECT_EQ(34ull, row->GetOffset());
+  EXPECT_EQ(34, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -658,7 +658,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32bitFramelessBigStackFrame) {
   // CFA=esp+14464 => ebx=[CFA-12] edi=[CFA-16] esi=[CFA-20] ebp=[CFA-8]
   // esp=CFA+0 eip=[CFA-4]
   row = unwind_plan.GetRowForFunctionOffset(10);
-  EXPECT_EQ(10ull, row->GetOffset());
+  EXPECT_EQ(10, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(14464, row->GetCFAValue().GetOffset());
@@ -666,13 +666,13 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32bitFramelessBigStackFrame) {
   // 15: CFA=esp+14468 => ebx=[CFA-12] edi=[CFA-16] esi=[CFA-20] ebp=[CFA-8]
   // esp=CFA+0 eip=[CFA-4]
   row = unwind_plan.GetRowForFunctionOffset(15);
-  EXPECT_EQ(15ull, row->GetOffset());
+  EXPECT_EQ(15, row->GetOffset());
   EXPECT_EQ(14468, row->GetCFAValue().GetOffset());
 
   // 16: CFA=esp+14464 => ebx=[CFA-12] edi=[CFA-16] esi=[CFA-20] ebp=[CFA-8]
   // esp=CFA+0 eip=[CFA-4]
   row = unwind_plan.GetRowForFunctionOffset(16);
-  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_EQ(16, row->GetOffset());
   EXPECT_EQ(14464, row->GetCFAValue().GetOffset());
 
   // Check that the row for offset 16 has the registers saved that we expect
@@ -703,7 +703,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32bitFramelessBigStackFrame) {
   // 23: CFA=esp+14472 => ebx=[CFA-12] edi=[CFA-16] esi=[CFA-20] ebp=[CFA-8]
   // esp=CFA+0 eip=[CFA-4]
   row = unwind_plan.GetRowForFunctionOffset(23);
-  EXPECT_EQ(23ull, row->GetOffset());
+  EXPECT_EQ(23, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(14472, row->GetCFAValue().GetOffset());
@@ -711,26 +711,26 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32bitFramelessBigStackFrame) {
   // 24: CFA=esp+14476 => ebx=[CFA-12] edi=[CFA-16] esi=[CFA-20] ebp=[CFA-8]
   // esp=CFA+0 eip=[CFA-4]
   row = unwind_plan.GetRowForFunctionOffset(24);
-  EXPECT_EQ(24ull, row->GetOffset());
+  EXPECT_EQ(24, row->GetOffset());
   EXPECT_EQ(14476, row->GetCFAValue().GetOffset());
 
   // 28: CFA=esp+14480 => ebx=[CFA-12] edi=[CFA-16] esi=[CFA-20] ebp=[CFA-8]
   // esp=CFA+0 eip=[CFA-4]
   row = unwind_plan.GetRowForFunctionOffset(28);
-  EXPECT_EQ(28ull, row->GetOffset());
+  EXPECT_EQ(28, row->GetOffset());
   EXPECT_EQ(14480, row->GetCFAValue().GetOffset());
 
   // 36: CFA=esp+14464 => ebx=[CFA-12] edi=[CFA-16] esi=[CFA-20] ebp=[CFA-8]
   // esp=CFA+0 eip=[CFA-4]
   row = unwind_plan.GetRowForFunctionOffset(36);
-  EXPECT_EQ(36ull, row->GetOffset());
+  EXPECT_EQ(36, row->GetOffset());
   EXPECT_EQ(14464, row->GetCFAValue().GetOffset());
 
   // Check that the epilogue gets us back to the original unwind state
 
   //  47: CFA=esp +4 => esp=CFA+0 eip=[CFA-4]
   row = unwind_plan.GetRowForFunctionOffset(47);
-  EXPECT_EQ(47ull, row->GetOffset());
+  EXPECT_EQ(47, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(4, row->GetCFAValue().GetOffset());
@@ -809,7 +809,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Test64bitFramelessSmallStackFrame) {
 
   const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(13);
 
-  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_EQ(1, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -841,7 +841,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Test64bitFramelessSmallStackFrame) {
 
   row = unwind_plan.GetRowForFunctionOffset(22);
 
-  EXPECT_EQ(22ull, row->GetOffset());
+  EXPECT_EQ(22, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -918,7 +918,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32bitFramelessSmallStackFrame) {
 
   const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(3);
 
-  EXPECT_EQ(3ull, row->GetOffset());
+  EXPECT_EQ(3, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -927,7 +927,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32bitFramelessSmallStackFrame) {
   // 8: CFA=esp+20 => esp=CFA+0 eip=[CFA-4]
 
   row = unwind_plan.GetRowForFunctionOffset(8);
-  EXPECT_EQ(8ull, row->GetOffset());
+  EXPECT_EQ(8, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(20, row->GetCFAValue().GetOffset());
@@ -936,7 +936,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32bitFramelessSmallStackFrame) {
   // row[3]:    9: CFA=esp+16 => esp=CFA+0 eip=[CFA-4]
 
   row = unwind_plan.GetRowForFunctionOffset(9);
-  EXPECT_EQ(9ull, row->GetOffset());
+  EXPECT_EQ(9, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -955,7 +955,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32bitFramelessSmallStackFrame) {
   //  34: CFA=esp +4 => esp=CFA+0 eip=[CFA-4]
 
   row = unwind_plan.GetRowForFunctionOffset(34);
-  EXPECT_EQ(34ull, row->GetOffset());
+  EXPECT_EQ(34, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(4, row->GetCFAValue().GetOffset());
@@ -979,7 +979,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushRBP) {
 
   row = unwind_plan.GetRowForFunctionOffset(1);
 
-  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_EQ(1, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -994,7 +994,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushRBP) {
 
   row = unwind_plan.GetRowForFunctionOffset(1);
 
-  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_EQ(1, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1022,13 +1022,13 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushImm) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(5);
-  EXPECT_EQ(5ull, row->GetOffset());
+  EXPECT_EQ(5, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
   row = unwind_plan.GetRowForFunctionOffset(7);
-  EXPECT_EQ(7ull, row->GetOffset());
+  EXPECT_EQ(7, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(24, row->GetCFAValue().GetOffset());
@@ -1038,13 +1038,13 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushImm) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(5);
-  EXPECT_EQ(5ull, row->GetOffset());
+  EXPECT_EQ(5, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
   row = unwind_plan.GetRowForFunctionOffset(7);
-  EXPECT_EQ(7ull, row->GetOffset());
+  EXPECT_EQ(7, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(12, row->GetCFAValue().GetOffset());
@@ -1072,7 +1072,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPush0) {
   row = unwind_plan.GetRowForFunctionOffset(2);
 
   // We're verifying that no row was created for the 'pushq $0'
-  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_EQ(0, row->GetOffset());
 
   std::unique_ptr<x86AssemblyInspectionEngine> engine32 = Geti386Inspector();
   EXPECT_TRUE(engine32->GetNonCallSiteUnwindPlanFromAssembly(
@@ -1081,7 +1081,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPush0) {
   row = unwind_plan.GetRowForFunctionOffset(2);
 
   // We're verifying that no row was created for the 'pushq $0'
-  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_EQ(0, row->GetOffset());
 }
 
 TEST_F(Testx86AssemblyInspectionEngine, TestPushExtended) {
@@ -1104,7 +1104,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushExtended) {
 
   row = unwind_plan.GetRowForFunctionOffset(4);
 
-  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_EQ(4, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -1114,19 +1114,19 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushExtended) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_EQ(4, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
   row = unwind_plan.GetRowForFunctionOffset(10);
-  EXPECT_EQ(10ull, row->GetOffset());
+  EXPECT_EQ(10, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(12, row->GetCFAValue().GetOffset());
 
   row = unwind_plan.GetRowForFunctionOffset(12);
-  EXPECT_EQ(12ull, row->GetOffset());
+  EXPECT_EQ(12, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -1150,7 +1150,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushR15) {
 
   row = unwind_plan.GetRowForFunctionOffset(2);
 
-  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_EQ(2, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -1178,7 +1178,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushR14) {
 
   row = unwind_plan.GetRowForFunctionOffset(2);
 
-  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_EQ(2, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -1206,7 +1206,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushR13) {
 
   row = unwind_plan.GetRowForFunctionOffset(2);
 
-  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_EQ(2, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -1234,7 +1234,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushR12) {
 
   row = unwind_plan.GetRowForFunctionOffset(2);
 
-  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_EQ(2, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -1262,7 +1262,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushRBX) {
 
   row = unwind_plan.GetRowForFunctionOffset(1);
 
-  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_EQ(1, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -1293,7 +1293,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushEAX) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_EQ(1, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1322,7 +1322,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushECX) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_EQ(1, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1351,7 +1351,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushEDX) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_EQ(1, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1377,7 +1377,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushEBX) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_EQ(1, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1405,7 +1405,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushEBP) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_EQ(1, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1433,7 +1433,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushRBPWithREX) {
 
   row = unwind_plan.GetRowForFunctionOffset(2);
 
-  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_EQ(2, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -1461,7 +1461,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushESI) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_EQ(1, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1489,7 +1489,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPushEDI) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_EQ(1, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1517,7 +1517,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestMovRSPtoRBP) {
 
   row = unwind_plan.GetRowForFunctionOffset(3);
 
-  EXPECT_EQ(3ull, row->GetOffset());
+  EXPECT_EQ(3, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1533,7 +1533,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestMovRSPtoRBP) {
       data64_2, sizeof(data64_2), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(3);
-  EXPECT_EQ(3ull, row->GetOffset());
+  EXPECT_EQ(3, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1549,7 +1549,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestMovRSPtoRBP) {
       data32_1, sizeof(data32_1), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_EQ(2, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_ebp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1565,7 +1565,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestMovRSPtoRBP) {
       data32_2, sizeof(data32_2), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_EQ(2, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_ebp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1589,7 +1589,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSubRSP) {
       data1, sizeof(data1), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(7);
-  EXPECT_EQ(7ull, row->GetOffset());
+  EXPECT_EQ(7, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(264, row->GetCFAValue().GetOffset());
@@ -1605,7 +1605,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSubRSP) {
       data2, sizeof(data2), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_EQ(4, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(24, row->GetCFAValue().GetOffset());
@@ -1629,7 +1629,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSubESP) {
       data1, sizeof(data1), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(6);
-  EXPECT_EQ(6ull, row->GetOffset());
+  EXPECT_EQ(6, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(260, row->GetCFAValue().GetOffset());
@@ -1645,7 +1645,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSubESP) {
       data2, sizeof(data2), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(3);
-  EXPECT_EQ(3ull, row->GetOffset());
+  EXPECT_EQ(3, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(20, row->GetCFAValue().GetOffset());
@@ -1669,7 +1669,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestAddRSP) {
       data1, sizeof(data1), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(7);
-  EXPECT_EQ(7ull, row->GetOffset());
+  EXPECT_EQ(7, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8 - 256, row->GetCFAValue().GetOffset());
@@ -1685,7 +1685,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestAddRSP) {
       data2, sizeof(data2), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_EQ(4, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8 - 16, row->GetCFAValue().GetOffset());
@@ -1709,7 +1709,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestAddESP) {
       data1, sizeof(data1), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(6);
-  EXPECT_EQ(6ull, row->GetOffset());
+  EXPECT_EQ(6, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(4 - 256, row->GetCFAValue().GetOffset());
@@ -1725,7 +1725,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestAddESP) {
       data2, sizeof(data2), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(3);
-  EXPECT_EQ(3ull, row->GetOffset());
+  EXPECT_EQ(3, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(4 - 16, row->GetCFAValue().GetOffset());
@@ -1749,7 +1749,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestLEA_RSP_Pattern) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_EQ(0, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1774,7 +1774,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopRBX) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_EQ(2, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1800,7 +1800,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopRBP) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_EQ(2, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1826,7 +1826,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopR12) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_EQ(4, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1852,7 +1852,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopR13) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_EQ(4, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1878,7 +1878,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopR14) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_EQ(4, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1904,7 +1904,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopR15) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_EQ(4, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -1930,7 +1930,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopEBX) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_EQ(2, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(4, row->GetCFAValue().GetOffset());
@@ -1956,7 +1956,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopEBP) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_EQ(2, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(4, row->GetCFAValue().GetOffset());
@@ -1982,7 +1982,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopRBPWithREX) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_EQ(4, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -2008,7 +2008,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopESI) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_EQ(2, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(4, row->GetCFAValue().GetOffset());
@@ -2034,7 +2034,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestPopEDI) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_EQ(2, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(4, row->GetCFAValue().GetOffset());
@@ -2069,13 +2069,13 @@ TEST_F(Testx86AssemblyInspectionEngine, Testi386IgnoredRegisters) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_EQ(4, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(20, row->GetCFAValue().GetOffset());
 
   row = unwind_plan.GetRowForFunctionOffset(7);
-  EXPECT_EQ(7ull, row->GetOffset());
+  EXPECT_EQ(7, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -2101,7 +2101,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestLEAVE) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_EQ(2, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -2111,7 +2111,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestLEAVE) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_EQ(2, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(4, row->GetCFAValue().GetOffset());
@@ -2140,7 +2140,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestCALLNextInsn) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(5);
-  EXPECT_EQ(5ull, row->GetOffset());
+  EXPECT_EQ(5, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -2169,7 +2169,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSpillRegToStackViaMOVx86_64) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(19);
-  EXPECT_EQ(19ull, row->GetOffset());
+  EXPECT_EQ(19, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 
@@ -2207,7 +2207,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSpillRegToStackViaMOVi386) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(12);
-  EXPECT_EQ(12ull, row->GetOffset());
+  EXPECT_EQ(12, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
@@ -2280,22 +2280,22 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSpArithx86_64Augmented) {
   // Before we touch the stack pointer, we should still refer to the
   // row from after the prologue.
   const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(5);
-  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_EQ(4, row->GetOffset());
 
   // Check the first stack pointer update.
   row = unwind_plan.GetRowForFunctionOffset(12);
-  EXPECT_EQ(12ull, row->GetOffset());
+  EXPECT_EQ(12, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_EQ(152, row->GetCFAValue().GetOffset());
 
   // After the nop, we should still refer to the same row.
   row = unwind_plan.GetRowForFunctionOffset(13);
-  EXPECT_EQ(12ull, row->GetOffset());
+  EXPECT_EQ(12, row->GetOffset());
 
   // Check that the second stack pointer update is reflected in the
   // unwind plan.
   row = unwind_plan.GetRowForFunctionOffset(20);
-  EXPECT_EQ(20ull, row->GetOffset());
+  EXPECT_EQ(20, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
 }
@@ -2354,7 +2354,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimplex86_64Augmented) {
       data, sizeof(data), sample_range, unwind_plan, reg_ctx_sp));
 
   const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(6);
-  EXPECT_EQ(6ull, row->GetOffset());
+  EXPECT_EQ(6, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
 
@@ -2421,7 +2421,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestSimplei386ugmented) {
       data, sizeof(data), sample_range, unwind_plan, reg_ctx_sp));
 
   const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(5);
-  EXPECT_EQ(5ull, row->GetOffset());
+  EXPECT_EQ(5, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
   EXPECT_EQ(4, row->GetCFAValue().GetOffset());
 
@@ -2458,7 +2458,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32BitOnlyInstruction) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(2ull, row->GetOffset());
+  EXPECT_EQ(2, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -2473,7 +2473,7 @@ TEST_F(Testx86AssemblyInspectionEngine, Test32BitOnlyInstruction) {
       data, sizeof(data), sample_range, unwind_plan));
 
   row = unwind_plan.GetRowForFunctionOffset(2);
-  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_EQ(0, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -2683,7 +2683,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestReturnDetect) {
 
   //  0: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
   const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(0);
-  EXPECT_EQ(0ull, row->GetOffset());
+  EXPECT_EQ(0, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -2694,7 +2694,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestReturnDetect) {
 
   //  1: CFA=rsp+16 => rbp=[CFA-16] rsp=CFA+0 rip=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(1);
-  EXPECT_EQ(1ull, row->GetOffset());
+  EXPECT_EQ(1, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -2705,7 +2705,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestReturnDetect) {
 
   //  4: CFA=rbp+16 => rbp=[CFA-16] rsp=CFA+0 rip=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(4);
-  EXPECT_EQ(4ull, row->GetOffset());
+  EXPECT_EQ(4, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -2716,7 +2716,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestReturnDetect) {
 
   //  7: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(7);
-  EXPECT_EQ(7ull, row->GetOffset());
+  EXPECT_EQ(7, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -2727,7 +2727,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestReturnDetect) {
 
   //  8: CFA=rbp+16 => rbp=[CFA-16] rsp=CFA+0 rip=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(8);
-  EXPECT_EQ(8ull, row->GetOffset());
+  EXPECT_EQ(8, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -2738,7 +2738,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestReturnDetect) {
 
   // 11: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(11);
-  EXPECT_EQ(11ull, row->GetOffset());
+  EXPECT_EQ(11, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -2749,7 +2749,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestReturnDetect) {
 
   // 12: CFA=rbp+16 => rbp=[CFA-16] rsp=CFA+0 rip=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(12);
-  EXPECT_EQ(12ull, row->GetOffset());
+  EXPECT_EQ(12, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -2760,7 +2760,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestReturnDetect) {
 
   // 15: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(15);
-  EXPECT_EQ(15ull, row->GetOffset());
+  EXPECT_EQ(15, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -2771,7 +2771,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestReturnDetect) {
 
   // 18: CFA=rbp+16 => rbp=[CFA-16] rsp=CFA+0 rip=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(18);
-  EXPECT_EQ(18ull, row->GetOffset());
+  EXPECT_EQ(18, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -2782,7 +2782,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestReturnDetect) {
 
   // 21: CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(21);
-  EXPECT_EQ(21ull, row->GetOffset());
+  EXPECT_EQ(21, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(8, row->GetCFAValue().GetOffset());
@@ -2793,7 +2793,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestReturnDetect) {
 
   // 24: CFA=rbp+16 => rbp=[CFA-16] rsp=CFA+0 rip=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(24);
-  EXPECT_EQ(24ull, row->GetOffset());
+  EXPECT_EQ(24, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(16, row->GetCFAValue().GetOffset());
@@ -2849,7 +2849,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestDisassemblyMidFunctionEpilogues) {
   // Check that we've unwound the stack after the first mid-function epilogue
   // row:   CFA=esp +4 => esp=CFA+0 eip=[CFA-4]
   const UnwindPlan::Row *row = unwind_plan.GetRowForFunctionOffset(16);
-  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_EQ(16, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(wordsize, row->GetCFAValue().GetOffset());
@@ -2858,7 +2858,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestDisassemblyMidFunctionEpilogues) {
   // unwind instructions after a jmpq *%eax
   // row:   CFA=ebp +8 => esp=CFA+0 eip=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(18);
-  EXPECT_EQ(18ull, row->GetOffset());
+  EXPECT_EQ(18, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_ebp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(wordsize * 2, row->GetCFAValue().GetOffset());
@@ -2867,7 +2867,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestDisassemblyMidFunctionEpilogues) {
   // unwind instructions after a mid-function retq
   // row:   CFA=ebp +8 => esp=CFA+0 eip=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(28);
-  EXPECT_EQ(28ull, row->GetOffset());
+  EXPECT_EQ(28, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_ebp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(wordsize * 2, row->GetCFAValue().GetOffset());
@@ -2876,7 +2876,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestDisassemblyMidFunctionEpilogues) {
   // the stack frame has been unwound
   // row:   CFA=esp +4 => esp=CFA+0 eip=[CFA-4]
   row = unwind_plan.GetRowForFunctionOffset(34);
-  EXPECT_EQ(34ull, row->GetOffset());
+  EXPECT_EQ(34, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_esp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(wordsize, row->GetCFAValue().GetOffset());
@@ -2890,7 +2890,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestDisassemblyMidFunctionEpilogues) {
   // Check that we've unwound the stack after the first mid-function epilogue
   // row:   CFA=rsp +8 => rsp=CFA+0 rip=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(16);
-  EXPECT_EQ(16ull, row->GetOffset());
+  EXPECT_EQ(16, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(wordsize, row->GetCFAValue().GetOffset());
@@ -2899,7 +2899,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestDisassemblyMidFunctionEpilogues) {
   // unwind instructions after a jmpq *%eax
   // row:   CFA=rbp+16 => rsp=CFA+0 rip=[CFA-16]
   row = unwind_plan.GetRowForFunctionOffset(18);
-  EXPECT_EQ(18ull, row->GetOffset());
+  EXPECT_EQ(18, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(wordsize * 2, row->GetCFAValue().GetOffset());
@@ -2908,7 +2908,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestDisassemblyMidFunctionEpilogues) {
   // unwind instructions after a mid-function retq
   // row:   CFA=rbp+16 => rsp=CFA+0 rip=[CFA-16]
   row = unwind_plan.GetRowForFunctionOffset(28);
-  EXPECT_EQ(28ull, row->GetOffset());
+  EXPECT_EQ(28, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rbp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(wordsize * 2, row->GetCFAValue().GetOffset());
@@ -2917,7 +2917,7 @@ TEST_F(Testx86AssemblyInspectionEngine, TestDisassemblyMidFunctionEpilogues) {
   // the stack frame has been unwound
   // row:   CFA=rsp +8 => esp=CFA+0 rip=[CFA-8]
   row = unwind_plan.GetRowForFunctionOffset(34);
-  EXPECT_EQ(34ull, row->GetOffset());
+  EXPECT_EQ(34, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == k_rsp);
   EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
   EXPECT_EQ(wordsize, row->GetCFAValue().GetOffset());


### PR DESCRIPTION
These are needed for functions whose entry point is not their lowest address.