### PR TITLE
[AMDGPU] Update code object metadata for kernarg preload

### DIFF
--- a/llvm/include/llvm/Support/AMDGPUMetadata.h
+++ b/llvm/include/llvm/Support/AMDGPUMetadata.h
@@ -48,7 +48,7 @@ constexpr uint32_t VersionMinorV5 = 2;
 /// HSA metadata major version for code object V6.
 constexpr uint32_t VersionMajorV6 = 1;
 /// HSA metadata minor version for code object V6.
-constexpr uint32_t VersionMinorV6 = 2;
+constexpr uint32_t VersionMinorV6 = 3;
 
 /// Old HSA metadata beginning assembler directive for V2. This is only used for
 /// diagnostics now.

--- a/llvm/lib/Target/AMDGPU/AMDGPUArgumentUsageInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUArgumentUsageInfo.cpp
@@ -187,25 +187,25 @@ AMDGPUFunctionArgInfo::getPreloadDescriptorsForArgIdx(unsigned ArgIdx) const {
       Results.push_back(&KV.second);
   }
 
-  llvm::stable_sort(Results, [](const KernArgPreloadDescriptor *A,
-                                const KernArgPreloadDescriptor *B) {
+  stable_sort(Results, [](const KernArgPreloadDescriptor *A,
+                          const KernArgPreloadDescriptor *B) {
     return A->PartIdx < B->PartIdx;
   });
 
   return Results;
 }
 
-std::optional<const KernArgPreloadDescriptor *>
+const KernArgPreloadDescriptor *
 AMDGPUFunctionArgInfo::getHiddenArgPreloadDescriptor(HiddenArg HA) const {
   assert(HA < END_HIDDEN_ARGS);
 
   auto HiddenArgIt = PreloadHiddenArgsIndexMap.find(HA);
   if (HiddenArgIt == PreloadHiddenArgsIndexMap.end())
-    return std::nullopt;
+    return nullptr;
 
   auto KernArgIt = PreloadKernArgs.find(HiddenArgIt->second);
   if (KernArgIt == PreloadKernArgs.end())
-    return std::nullopt;
+    return nullptr;
 
   return &KernArgIt->second;
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPUArgumentUsageInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUArgumentUsageInfo.cpp
@@ -182,15 +182,11 @@ AMDGPUFunctionArgInfo AMDGPUFunctionArgInfo::fixedABILayout() {
 SmallVector<const KernArgPreloadDescriptor *, 4>
 AMDGPUFunctionArgInfo::getPreloadDescriptorsForArgIdx(unsigned ArgIdx) const {
   SmallVector<const KernArgPreloadDescriptor *, 4> Results;
-  for (const auto &KV : PreloadKernArgs) {
-    if (KV.second.OrigArgIdx == ArgIdx)
-      Results.push_back(&KV.second);
+  for (unsigned PartIdx = 0; PartIdx < PreloadKernArgs.size(); ++PartIdx) {
+    const auto &Desc = PreloadKernArgs[PartIdx];
+    if (Desc.OrigArgIdx == ArgIdx)
+      Results.push_back(&Desc);
   }
-
-  stable_sort(Results, [](const KernArgPreloadDescriptor *A,
-                          const KernArgPreloadDescriptor *B) {
-    return A->PartIdx < B->PartIdx;
-  });
 
   return Results;
 }
@@ -203,11 +199,9 @@ AMDGPUFunctionArgInfo::getHiddenArgPreloadDescriptor(HiddenArg HA) const {
   if (HiddenArgIt == PreloadHiddenArgsIndexMap.end())
     return nullptr;
 
-  auto KernArgIt = PreloadKernArgs.find(HiddenArgIt->second);
-  if (KernArgIt == PreloadKernArgs.end())
-    return nullptr;
-
-  return &KernArgIt->second;
+  const KernArgPreloadDescriptor &Desc = PreloadKernArgs[HiddenArgIt->second];
+  assert(Desc.IsValid && "Hidden argument preload descriptor not valid.");
+  return &Desc;
 }
 
 const AMDGPUFunctionArgInfo &

--- a/llvm/lib/Target/AMDGPU/AMDGPUArgumentUsageInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUArgumentUsageInfo.h
@@ -11,7 +11,10 @@
 
 #include "MCTargetDesc/AMDGPUMCTargetDesc.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/Analysis/ValueTracking.h"
 #include "llvm/CodeGen/Register.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Type.h"
 #include "llvm/Pass.h"
 
 namespace llvm {
@@ -95,10 +98,77 @@ inline raw_ostream &operator<<(raw_ostream &OS, const ArgDescriptor &Arg) {
   return OS;
 }
 
-struct KernArgPreloadDescriptor : public ArgDescriptor {
-  KernArgPreloadDescriptor() {}
-  SmallVector<MCRegister> Regs;
+namespace KernArgPreload {
+
+enum HiddenArg {
+  HIDDEN_BLOCK_COUNT_X,
+  HIDDEN_BLOCK_COUNT_Y,
+  HIDDEN_BLOCK_COUNT_Z,
+  HIDDEN_GROUP_SIZE_X,
+  HIDDEN_GROUP_SIZE_Y,
+  HIDDEN_GROUP_SIZE_Z,
+  HIDDEN_REMAINDER_X,
+  HIDDEN_REMAINDER_Y,
+  HIDDEN_REMAINDER_Z,
+  END_HIDDEN_ARGS
 };
+
+// Stores information about a specific hidden argument.
+struct HiddenArgInfo {
+  // Offset in bytes from the location in the kernearg segment pointed to by
+  // the implicitarg pointer.
+  uint8_t Offset;
+  // The size of the hidden argument in bytes.
+  uint8_t Size;
+  // The name of the hidden argument in the kernel signature.
+  const char *Name;
+};
+
+struct HiddenArgUtils {
+  static constexpr HiddenArgInfo HiddenArgs[END_HIDDEN_ARGS] = {
+      {0, 4, "_hidden_block_count_x"}, {4, 4, "_hidden_block_count_y"},
+      {8, 4, "_hidden_block_count_z"}, {12, 2, "_hidden_group_size_x"},
+      {14, 2, "_hidden_group_size_y"}, {16, 2, "_hidden_group_size_z"},
+      {18, 2, "_hidden_remainder_x"},  {20, 2, "_hidden_remainder_y"},
+      {22, 2, "_hidden_remainder_z"}};
+
+  static HiddenArg getHiddenArgFromOffset(unsigned Offset) {
+    for (unsigned I = 0; I < END_HIDDEN_ARGS; ++I)
+      if (HiddenArgs[I].Offset == Offset)
+        return static_cast<HiddenArg>(I);
+
+    return END_HIDDEN_ARGS;
+  }
+
+  static Type *getHiddenArgType(LLVMContext &Ctx, HiddenArg HA) {
+    if (HA < END_HIDDEN_ARGS)
+      return static_cast<Type *>(Type::getIntNTy(Ctx, HiddenArgs[HA].Size * 8));
+
+    llvm_unreachable("Unexpected hidden argument.");
+  }
+
+  static const char *getHiddenArgName(HiddenArg HA) {
+    if (HA < END_HIDDEN_ARGS) {
+      return HiddenArgs[HA].Name;
+    }
+    llvm_unreachable("Unexpected hidden argument.");
+  }
+};
+
+struct KernArgPreloadDescriptor {
+  // Id of the original argument in the IR kernel function argument list.
+  unsigned OrigArgIdx = 0;
+
+  // If this IR argument was split into multiple parts, this is the index of the
+  // part in the original argument.
+  unsigned PartIdx = 0;
+
+  // The registers that the argument is preloaded into. The argument may be
+  // split accross multilpe registers.
+  SmallVector<MCRegister, 2> Regs;
+};
+
+} // namespace KernArgPreload
 
 struct AMDGPUFunctionArgInfo {
   // clang-format off
@@ -161,7 +231,10 @@ struct AMDGPUFunctionArgInfo {
   ArgDescriptor WorkItemIDZ;
 
   // Map the index of preloaded kernel arguments to its descriptor.
-  SmallDenseMap<int, KernArgPreloadDescriptor> PreloadKernArgs{};
+  SmallDenseMap<int, KernArgPreload::KernArgPreloadDescriptor>
+      PreloadKernArgs{};
+  // Map hidden argument to the index of it's descriptor.
+  SmallDenseMap<KernArgPreload::HiddenArg, int> PreloadHiddenArgsIndexMap{};
   // The first user SGPR allocated for kernarg preloading.
   Register FirstKernArgPreloadReg;
 
@@ -169,6 +242,16 @@ struct AMDGPUFunctionArgInfo {
   getPreloadedValue(PreloadedValue Value) const;
 
   static AMDGPUFunctionArgInfo fixedABILayout();
+
+  // Returns preload argument descriptors for an IR argument index. Isel may
+  // split IR arguments into multiple parts, the return vector holds all parts
+  // associated with an IR argument in the kernel signature.
+  SmallVector<const KernArgPreload::KernArgPreloadDescriptor *, 4>
+  getPreloadDescriptorsForArgIdx(unsigned ArgIdx) const;
+
+  // Returns the hidden arguments `KernArgPreloadDescriptor` if it is preloaded.
+  std::optional<const KernArgPreload::KernArgPreloadDescriptor *>
+  getHiddenArgPreloadDescriptor(KernArgPreload::HiddenArg HA) const;
 };
 
 class AMDGPUArgumentUsageInfo : public ImmutablePass {

--- a/llvm/lib/Target/AMDGPU/AMDGPUArgumentUsageInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUArgumentUsageInfo.h
@@ -101,27 +101,27 @@ inline raw_ostream &operator<<(raw_ostream &OS, const ArgDescriptor &Arg) {
 namespace KernArgPreload {
 
 enum HiddenArg {
-  HIDDEN_BLOCK_COUNT_X,
-  HIDDEN_BLOCK_COUNT_Y,
-  HIDDEN_BLOCK_COUNT_Z,
-  HIDDEN_GROUP_SIZE_X,
-  HIDDEN_GROUP_SIZE_Y,
-  HIDDEN_GROUP_SIZE_Z,
-  HIDDEN_REMAINDER_X,
-  HIDDEN_REMAINDER_Y,
-  HIDDEN_REMAINDER_Z,
-  END_HIDDEN_ARGS
+  HIDDEN_BLOCK_COUNT_X = 0,
+  HIDDEN_BLOCK_COUNT_Y = 1,
+  HIDDEN_BLOCK_COUNT_Z = 2,
+  HIDDEN_GROUP_SIZE_X = 3,
+  HIDDEN_GROUP_SIZE_Y = 4,
+  HIDDEN_GROUP_SIZE_Z = 5,
+  HIDDEN_REMAINDER_X = 6,
+  HIDDEN_REMAINDER_Y = 7,
+  HIDDEN_REMAINDER_Z = 8,
+  END_HIDDEN_ARGS = 9
 };
 
 // Stores information about a specific hidden argument.
 struct HiddenArgInfo {
   // Offset in bytes from the location in the kernearg segment pointed to by
   // the implicitarg pointer.
-  uint8_t Offset;
+  uint8_t Offset = 0;
   // The size of the hidden argument in bytes.
-  uint8_t Size;
+  uint8_t Size = 0;
   // The name of the hidden argument in the kernel signature.
-  const char *Name;
+  const char *Name = nullptr;
 };
 
 struct HiddenArgUtils {

--- a/llvm/lib/Target/AMDGPU/AMDGPUArgumentUsageInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUArgumentUsageInfo.h
@@ -100,7 +100,7 @@ inline raw_ostream &operator<<(raw_ostream &OS, const ArgDescriptor &Arg) {
 
 namespace KernArgPreload {
 
-enum HiddenArg {
+enum HiddenArg : unsigned {
   HIDDEN_BLOCK_COUNT_X = 0,
   HIDDEN_BLOCK_COUNT_Y = 1,
   HIDDEN_BLOCK_COUNT_Z = 2,
@@ -110,7 +110,7 @@ enum HiddenArg {
   HIDDEN_REMAINDER_X = 6,
   HIDDEN_REMAINDER_Y = 7,
   HIDDEN_REMAINDER_Z = 8,
-  END_HIDDEN_ARGS = 9
+  END_HIDDEN_ARGS = HIDDEN_REMAINDER_Z + 1
 };
 
 // Stores information about a specific hidden argument.
@@ -165,7 +165,7 @@ struct KernArgPreloadDescriptor {
   unsigned PartIdx = 0;
 
   // The registers that the argument is preloaded into. The argument may be
-  // split accross multilpe registers.
+  // split across multiple registers.
   SmallVector<MCRegister, 2> Regs;
 };
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUArgumentUsageInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUArgumentUsageInfo.h
@@ -133,25 +133,26 @@ struct HiddenArgUtils {
       {22, 2, "_hidden_remainder_z"}};
 
   static HiddenArg getHiddenArgFromOffset(unsigned Offset) {
-    for (unsigned I = 0; I < END_HIDDEN_ARGS; ++I)
+    for (unsigned I = 0; I < END_HIDDEN_ARGS; ++I) {
       if (HiddenArgs[I].Offset == Offset)
         return static_cast<HiddenArg>(I);
+    }
 
     return END_HIDDEN_ARGS;
   }
 
   static Type *getHiddenArgType(LLVMContext &Ctx, HiddenArg HA) {
     if (HA < END_HIDDEN_ARGS)
-      return static_cast<Type *>(Type::getIntNTy(Ctx, HiddenArgs[HA].Size * 8));
+      return Type::getIntNTy(Ctx, HiddenArgs[HA].Size * 8);
 
-    llvm_unreachable("Unexpected hidden argument.");
+    llvm_unreachable("unexpected hidden argument");
   }
 
   static const char *getHiddenArgName(HiddenArg HA) {
-    if (HA < END_HIDDEN_ARGS) {
+    if (HA < END_HIDDEN_ARGS)
       return HiddenArgs[HA].Name;
-    }
-    llvm_unreachable("Unexpected hidden argument.");
+
+    llvm_unreachable("unexpected hidden argument");
   }
 };
 
@@ -250,7 +251,7 @@ struct AMDGPUFunctionArgInfo {
   getPreloadDescriptorsForArgIdx(unsigned ArgIdx) const;
 
   // Returns the hidden arguments `KernArgPreloadDescriptor` if it is preloaded.
-  std::optional<const KernArgPreload::KernArgPreloadDescriptor *>
+  const KernArgPreload::KernArgPreloadDescriptor *
   getHiddenArgPreloadDescriptor(KernArgPreload::HiddenArg HA) const;
 };
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUArgumentUsageInfo.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUArgumentUsageInfo.h
@@ -11,6 +11,7 @@
 
 #include "MCTargetDesc/AMDGPUMCTargetDesc.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/IndexedMap.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/CodeGen/Register.h"
 #include "llvm/IR/LLVMContext.h"
@@ -167,6 +168,8 @@ struct KernArgPreloadDescriptor {
   // The registers that the argument is preloaded into. The argument may be
   // split across multiple registers.
   SmallVector<MCRegister, 2> Regs;
+
+  bool IsValid = false;
 };
 
 } // namespace KernArgPreload
@@ -231,9 +234,15 @@ struct AMDGPUFunctionArgInfo {
   ArgDescriptor WorkItemIDY;
   ArgDescriptor WorkItemIDZ;
 
+  struct PreloadArgIndexFunctor {
+    using argument_type = unsigned;
+    unsigned operator()(unsigned Idx) const { return Idx; }
+  };
+
   // Map the index of preloaded kernel arguments to its descriptor.
-  SmallDenseMap<int, KernArgPreload::KernArgPreloadDescriptor>
-      PreloadKernArgs{};
+  IndexedMap<KernArgPreload::KernArgPreloadDescriptor, PreloadArgIndexFunctor>
+      PreloadKernArgs;
+
   // Map hidden argument to the index of it's descriptor.
   SmallDenseMap<KernArgPreload::HiddenArg, int> PreloadHiddenArgsIndexMap{};
   // The first user SGPR allocated for kernarg preloading.

--- a/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.cpp
@@ -793,7 +793,7 @@ void MetadataStreamerMsgPackV6::emitHiddenKernelArg(
       ArgInfo->getHiddenArgPreloadDescriptor(HiddenArg);
   if (PreloadDesc) {
     const SmallVectorImpl<MCRegister> &Regs = PreloadDesc->Regs;
-    for (const auto &Reg : Regs) {
+    for (const auto Reg : Regs) {
       if (!PreloadStr.empty())
         PreloadStr.push_back(' ');
       PreloadStr += AMDGPUInstPrinter::getRegisterName(Reg);
@@ -817,7 +817,7 @@ void MetadataStreamerMsgPackV6::emitKernelArg(const Argument &Arg,
       if (!PreloadRegisters.empty())
         PreloadRegisters.push_back(' ');
 
-      for (const auto &Reg : Desc->Regs) {
+      for (const auto Reg : Desc->Regs) {
         if (!PreloadRegisters.empty())
           PreloadRegisters.push_back(' ');
         PreloadRegisters += AMDGPUInstPrinter::getRegisterName(Reg);

--- a/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.h
@@ -162,6 +162,11 @@ protected:
                             msgpack::ArrayDocNode Args) override;
   void emitKernelAttrs(const AMDGPUTargetMachine &TM, const Function &Func,
                        msgpack::MapDocNode Kern) override;
+  virtual void emitHiddenKernelArg(
+      const DataLayout &DL, Type *ArgTy, Align Alignment, StringRef ArgName,
+      unsigned &Offset, msgpack::ArrayDocNode Args,
+      KernArgPreload::HiddenArg HiddenArg = KernArgPreload::END_HIDDEN_ARGS,
+      const AMDGPUFunctionArgInfo *ArgInfo = nullptr);
 
 public:
   MetadataStreamerMsgPackV5() = default;
@@ -171,18 +176,14 @@ public:
 class MetadataStreamerMsgPackV6 final : public MetadataStreamerMsgPackV5 {
 protected:
   void emitVersion() override;
-  void emitHiddenKernelArgs(const MachineFunction &MF, unsigned &Offset,
-                            msgpack::ArrayDocNode Args) override;
   void emitKernelArg(const Argument &Arg, unsigned &Offset,
                      msgpack::ArrayDocNode Args,
                      const MachineFunction &MF) override;
-
-  void emitHiddenKernelArgWithPreload(const DataLayout &DL, Type *ArgTy,
-                                      Align Alignment,
-                                      KernArgPreload::HiddenArg HiddenArg,
-                                      StringRef ArgName, unsigned &Offset,
-                                      msgpack::ArrayDocNode Args,
-                                      const AMDGPUFunctionArgInfo &ArgInfo);
+  void emitHiddenKernelArg(
+      const DataLayout &DL, Type *ArgTy, Align Alignment, StringRef ArgName,
+      unsigned &Offset, msgpack::ArrayDocNode Args,
+      KernArgPreload::HiddenArg HiddenArg = KernArgPreload::END_HIDDEN_ARGS,
+      const AMDGPUFunctionArgInfo *ArgInfo = nullptr) override;
 
 public:
   MetadataStreamerMsgPackV6() = default;

--- a/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.h
@@ -115,6 +115,11 @@ protected:
                      msgpack::ArrayDocNode Args,
                      const MachineFunction &MF) override;
 
+  void emitKernelArgCommon(const Argument &Arg, unsigned &Offset,
+                           msgpack::ArrayDocNode Args,
+                           const MachineFunction &MF,
+                           StringRef PreloadRegisters = {});
+
   void emitKernelArgImpl(const DataLayout &DL, Type *Ty, Align Alignment,
                          StringRef ValueKind, unsigned &Offset,
                          msgpack::ArrayDocNode Args,

--- a/llvm/lib/Target/AMDGPU/AMDGPULowerKernelArguments.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerKernelArguments.cpp
@@ -24,6 +24,7 @@
 #define DEBUG_TYPE "amdgpu-lower-kernel-arguments"
 
 using namespace llvm;
+using namespace llvm::KernArgPreload;
 
 namespace {
 

--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -48,6 +48,7 @@
 
 using namespace llvm;
 using namespace llvm::SDPatternMatch;
+using namespace llvm::KernArgPreload;
 
 #define DEBUG_TYPE "si-lower"
 
@@ -2680,6 +2681,18 @@ void SITargetLowering::allocateHSAUserSGPRs(CCState &CCInfo,
   // these from the dispatch pointer.
 }
 
+// Maps a hidden kernel argument to its preload index in
+// PreloadHiddenArgsIndexMap.
+static void mapHiddenArgToPreloadIndex(AMDGPUFunctionArgInfo &ArgInfo,
+                                       unsigned ArgOffset,
+                                       unsigned ImplicitArgOffset,
+                                       unsigned ArgIdx) {
+  auto [It, Inserted] = ArgInfo.PreloadHiddenArgsIndexMap.try_emplace(
+      HiddenArgUtils::getHiddenArgFromOffset(ArgOffset - ImplicitArgOffset));
+  assert(Inserted && "Preload hidden kernel argument allocated twice.");
+  It->second = ArgIdx;
+}
+
 // Allocate pre-loaded kernel arguemtns. Arguments to be preloading must be
 // sequential starting from the first argument.
 void SITargetLowering::allocatePreloadKernArgSGPRs(
@@ -2692,6 +2705,7 @@ void SITargetLowering::allocatePreloadKernArgSGPRs(
   bool InPreloadSequence = true;
   unsigned InIdx = 0;
   bool AlignedForImplictArgs = false;
+  unsigned ImplicitArgOffsetAdjustment = 0;
   unsigned ImplicitArgOffset = 0;
   for (auto &Arg : F.args()) {
     if (!InPreloadSequence || !Arg.hasInRegAttr())
@@ -2720,18 +2734,32 @@ void SITargetLowering::allocatePreloadKernArgSGPRs(
         if (!AlignedForImplictArgs) {
           ImplicitArgOffset =
               alignTo(LastExplicitArgOffset,
-                      Subtarget->getAlignmentForImplicitArgPtr()) -
-              LastExplicitArgOffset;
+                      Subtarget->getAlignmentForImplicitArgPtr());
+          ImplicitArgOffsetAdjustment =
+              ImplicitArgOffset - LastExplicitArgOffset;
           AlignedForImplictArgs = true;
         }
-        ArgOffset += ImplicitArgOffset;
+        ArgOffset += ImplicitArgOffsetAdjustment;
       }
 
       // Arg is preloaded into the previous SGPR.
       if (ArgLoc.getLocVT().getStoreSize() < 4 && Alignment < 4) {
         assert(InIdx >= 1 && "No previous SGPR");
-        Info.getArgInfo().PreloadKernArgs[InIdx].Regs.push_back(
-            Info.getArgInfo().PreloadKernArgs[InIdx - 1].Regs[0]);
+        auto [It, Inserted] =
+            Info.getArgInfo().PreloadKernArgs.try_emplace(InIdx);
+        assert(Inserted && "Preload kernel argument allocated twice.");
+        KernArgPreloadDescriptor &PreloadDesc = It->second;
+
+        const KernArgPreloadDescriptor &PrevDesc =
+            Info.getArgInfo().PreloadKernArgs[InIdx - 1];
+        PreloadDesc.Regs.push_back(PrevDesc.Regs[0]);
+
+        PreloadDesc.OrigArgIdx = Arg.getArgNo();
+        PreloadDesc.PartIdx = InIdx;
+        if (Arg.hasAttribute("amdgpu-hidden-argument"))
+          mapHiddenArgToPreloadIndex(Info.getArgInfo(), ArgOffset,
+                                     ImplicitArgOffset, InIdx);
+
         continue;
       }
 
@@ -2743,11 +2771,15 @@ void SITargetLowering::allocatePreloadKernArgSGPRs(
         break;
       }
 
+      if (Arg.hasAttribute("amdgpu-hidden-argument"))
+        mapHiddenArgToPreloadIndex(Info.getArgInfo(), ArgOffset,
+                                   ImplicitArgOffset, InIdx);
+
       // Preload this argument.
       const TargetRegisterClass *RC =
           TRI.getSGPRClassForBitWidth(NumAllocSGPRs * 32);
-      SmallVectorImpl<MCRegister> *PreloadRegs =
-          Info.addPreloadedKernArg(TRI, RC, NumAllocSGPRs, InIdx, PaddingSGPRs);
+      SmallVectorImpl<MCRegister> *PreloadRegs = Info.addPreloadedKernArg(
+          TRI, RC, NumAllocSGPRs, InIdx, Arg.getArgNo(), PaddingSGPRs);
 
       if (PreloadRegs->size() > 1)
         RC = &AMDGPU::SGPR_32RegClass;

--- a/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.cpp
@@ -276,9 +276,14 @@ Register SIMachineFunctionInfo::addLDSKernelId() {
 
 SmallVectorImpl<MCRegister> *SIMachineFunctionInfo::addPreloadedKernArg(
     const SIRegisterInfo &TRI, const TargetRegisterClass *RC,
-    unsigned AllocSizeDWord, int KernArgIdx, int PaddingSGPRs) {
-  auto [It, Inserted] = ArgInfo.PreloadKernArgs.try_emplace(KernArgIdx);
+    unsigned AllocSizeDWord, unsigned PartIdx, unsigned ArgIdx,
+    unsigned PaddingSGPRs) {
+  auto [It, Inserted] = ArgInfo.PreloadKernArgs.try_emplace(PartIdx);
   assert(Inserted && "Preload kernel argument allocated twice.");
+  KernArgPreload::KernArgPreloadDescriptor &PreloadDesc = It->second;
+  PreloadDesc.PartIdx = PartIdx;
+  PreloadDesc.OrigArgIdx = ArgIdx;
+
   NumUserSGPRs += PaddingSGPRs;
   // If the available register tuples are aligned with the kernarg to be
   // preloaded use that register, otherwise we need to use a set of SGPRs and
@@ -287,7 +292,7 @@ SmallVectorImpl<MCRegister> *SIMachineFunctionInfo::addPreloadedKernArg(
     ArgInfo.FirstKernArgPreloadReg = getNextUserSGPR();
   Register PreloadReg =
       TRI.getMatchingSuperReg(getNextUserSGPR(), AMDGPU::sub0, RC);
-  auto &Regs = It->second.Regs;
+  auto &Regs = PreloadDesc.Regs;
   if (PreloadReg &&
       (RC == &AMDGPU::SReg_32RegClass || RC == &AMDGPU::SReg_64RegClass)) {
     Regs.push_back(PreloadReg);

--- a/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.cpp
@@ -278,11 +278,13 @@ SmallVectorImpl<MCRegister> *SIMachineFunctionInfo::addPreloadedKernArg(
     const SIRegisterInfo &TRI, const TargetRegisterClass *RC,
     unsigned AllocSizeDWord, unsigned PartIdx, unsigned ArgIdx,
     unsigned PaddingSGPRs) {
-  auto [It, Inserted] = ArgInfo.PreloadKernArgs.try_emplace(PartIdx);
-  assert(Inserted && "Preload kernel argument allocated twice.");
-  KernArgPreload::KernArgPreloadDescriptor &PreloadDesc = It->second;
+  ArgInfo.PreloadKernArgs.grow(PartIdx);
+  KernArgPreload::KernArgPreloadDescriptor &PreloadDesc =
+      ArgInfo.PreloadKernArgs[PartIdx];
+  assert(!PreloadDesc.IsValid && "Preload kernel argument allocated twice.");
   PreloadDesc.PartIdx = PartIdx;
   PreloadDesc.OrigArgIdx = ArgIdx;
+  PreloadDesc.IsValid = true;
 
   NumUserSGPRs += PaddingSGPRs;
   // If the available register tuples are aligned with the kernarg to be

--- a/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIMachineFunctionInfo.h
@@ -854,8 +854,8 @@ public:
   Register addLDSKernelId();
   SmallVectorImpl<MCRegister> *
   addPreloadedKernArg(const SIRegisterInfo &TRI, const TargetRegisterClass *RC,
-                      unsigned AllocSizeDWord, int KernArgIdx,
-                      int PaddingSGPRs);
+                      unsigned AllocSizeDWord, unsigned PartIdx,
+                      unsigned ArgIdx, unsigned PaddingSGPRs);
 
   /// Increment user SGPRs used for padding the argument list only.
   Register addReservedUserSGPR() {

--- a/llvm/test/CodeGen/AMDGPU/hsa-metadata-preload-args-v6.ll
+++ b/llvm/test/CodeGen/AMDGPU/hsa-metadata-preload-args-v6.ll
@@ -1,0 +1,388 @@
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 -amdgpu-kernarg-preload-count=16 -filetype=obj -o - < %s | llvm-readelf --notes - | FileCheck --check-prefix=CHECK %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 -amdgpu-kernarg-preload-count=16 < %s | FileCheck --check-prefix=CHECK %s
+
+; CHECK:	amdhsa.kernels:
+; CHECK-NEXT:    - .agpr_count:     0
+; CHECK-NEXT:     .args:
+; CHECK-NEXT:       - .name:           in
+; CHECK-NEXT:         .offset:         0
+; CHECK-NEXT:         .preload_registers: s8
+; CHECK-NEXT:         .size:           4
+; CHECK-NEXT:         .value_kind:     by_value
+; CHECK-NEXT:       - .address_space:  global
+; CHECK-NEXT:         .name:           r
+; CHECK-NEXT:         .offset:         8
+; CHECK-NEXT:         .preload_registers: 's[10:11]'
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     global_buffer
+; CHECK-NEXT:       - .address_space:  global
+; CHECK-NEXT:         .name:           a
+; CHECK-NEXT:         .offset:         16
+; CHECK-NEXT:         .preload_registers: 's[12:13]'
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     global_buffer
+; CHECK-NEXT:       - .address_space:  global
+; CHECK-NEXT:         .name:           b
+; CHECK-NEXT:         .offset:         24
+; CHECK-NEXT:         .preload_registers: 's[14:15]'
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     global_buffer
+; CHECK-NEXT:       - .offset:         32
+; CHECK-NEXT:         .size:           4
+; CHECK-NEXT:         .value_kind:     hidden_block_count_x
+; CHECK-NEXT:       - .offset:         36
+; CHECK-NEXT:         .size:           4
+; CHECK-NEXT:         .value_kind:     hidden_block_count_y
+; CHECK-NEXT:       - .offset:         40
+; CHECK-NEXT:         .size:           4
+; CHECK-NEXT:         .value_kind:     hidden_block_count_z
+; CHECK-NEXT:       - .offset:         44
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_group_size_x
+; CHECK-NEXT:       - .offset:         46
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_group_size_y
+; CHECK-NEXT:       - .offset:         48
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_group_size_z
+; CHECK-NEXT:       - .offset:         50
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_remainder_x
+; CHECK-NEXT:       - .offset:         52
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_remainder_y
+; CHECK-NEXT:       - .offset:         54
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_remainder_z
+; CHECK-NEXT:       - .offset:         72
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_global_offset_x
+; CHECK-NEXT:       - .offset:         80
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_global_offset_y
+; CHECK-NEXT:       - .offset:         88
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_global_offset_z
+; CHECK-NEXT:       - .offset:         96
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_grid_dims
+; CHECK-NEXT:       - .offset:         104
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_printf_buffer
+; CHECK-NEXT:       - .offset:         112
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_hostcall_buffer
+; CHECK-NEXT:       - .offset:         120
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_multigrid_sync_arg
+; CHECK-NEXT:       - .offset:         128
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_heap_v1
+; CHECK-NEXT:       - .offset:         136
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_default_queue
+; CHECK-NEXT:       - .offset:         144
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_completion_action
+; CHECK-NEXT:       - .offset:         152
+; CHECK-NEXT:         .size:           4
+; CHECK-NEXT:         .value_kind:     hidden_dynamic_lds_size
+; CHECK-NEXT:       - .offset:         232
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_queue_ptr
+; CHECK-NEXT:   .group_segment_fixed_size: 0
+; CHECK-NEXT:   .kernarg_segment_align: 8
+; CHECK-NEXT:   .kernarg_segment_size: 288
+; CHECK-NEXT:   .max_flat_workgroup_size: 1024
+; CHECK-NEXT:   .name:           test_preload_v6
+; CHECK-NEXT:   .private_segment_fixed_size: 0
+; CHECK-NEXT:   .sgpr_count:     22
+; CHECK-NEXT:   .sgpr_spill_count: 0
+; CHECK-NEXT:   .symbol:         test_preload_v6.kd
+; CHECK-NEXT:   .uses_dynamic_stack: false
+; CHECK-NEXT:   .vgpr_count:     3
+; CHECK-NEXT:   .vgpr_spill_count: 0
+; CHECK-NEXT:   .wavefront_size: 64
+; CHECK-NEXT: - .agpr_count:     0
+; CHECK-NEXT:     .args:
+; CHECK-NEXT:       - .address_space:  global
+; CHECK-NEXT:         .name:           out
+; CHECK-NEXT:         .offset:         0
+; CHECK-NEXT:         .preload_registers: 's[2:3]'
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     global_buffer
+; CHECK-NEXT:       - .offset:         8
+; CHECK-NEXT:         .preload_registers: s4
+; CHECK-NEXT:         .size:           4
+; CHECK-NEXT:         .value_kind:     hidden_block_count_x
+; CHECK-NEXT:       - .offset:         12
+; CHECK-NEXT:         .preload_registers: s5
+; CHECK-NEXT:         .size:           4
+; CHECK-NEXT:         .value_kind:     hidden_block_count_y
+; CHECK-NEXT:       - .offset:         16
+; CHECK-NEXT:         .preload_registers: s6
+; CHECK-NEXT:         .size:           4
+; CHECK-NEXT:         .value_kind:     hidden_block_count_z
+; CHECK-NEXT:       - .offset:         20
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_group_size_x
+; CHECK-NEXT:       - .offset:         22
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_group_size_y
+; CHECK-NEXT:       - .offset:         24
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_group_size_z
+; CHECK-NEXT:       - .offset:         26
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_remainder_x
+; CHECK-NEXT:       - .offset:         28
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_remainder_y
+; CHECK-NEXT:       - .offset:         30
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_remainder_z
+; CHECK-NEXT:       - .offset:         48
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_global_offset_x
+; CHECK-NEXT:       - .offset:         56
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_global_offset_y
+; CHECK-NEXT:       - .offset:         64
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_global_offset_z
+; CHECK-NEXT:       - .offset:         72
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_grid_dims
+; CHECK-NEXT:       - .offset:         80
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_printf_buffer
+; CHECK-NEXT:   .group_segment_fixed_size: 0
+; CHECK-NEXT:   .kernarg_segment_align: 8
+; CHECK-NEXT:   .kernarg_segment_size: 264
+; CHECK-NEXT:   .max_flat_workgroup_size: 1024
+; CHECK-NEXT:   .name:           test_preload_v6_block_count_xyz
+; CHECK-NEXT:   .private_segment_fixed_size: 0
+; CHECK-NEXT:   .sgpr_count:     13
+; CHECK-NEXT:   .sgpr_spill_count: 0
+; CHECK-NEXT:   .symbol:         test_preload_v6_block_count_xyz.kd
+; CHECK-NEXT:   .uses_dynamic_stack: false
+; CHECK-NEXT:   .vgpr_count:     4
+; CHECK-NEXT:   .vgpr_spill_count: 0
+; CHECK-NEXT:   .wavefront_size: 64
+; CHECK-NEXT: - .agpr_count:     0
+; CHECK-NEXT:     .args:
+; CHECK-NEXT:       - .address_space:  global
+; CHECK-NEXT:         .name:           out
+; CHECK-NEXT:         .offset:         0
+; CHECK-NEXT:         .preload_registers: 's[2:3]'
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     global_buffer
+; CHECK-NEXT:       - .offset:         8
+; CHECK-NEXT:         .preload_registers: s4
+; CHECK-NEXT:         .size:           4
+; CHECK-NEXT:         .value_kind:     hidden_block_count_x
+; CHECK-NEXT:       - .offset:         12
+; CHECK-NEXT:         .preload_registers: s5
+; CHECK-NEXT:         .size:           4
+; CHECK-NEXT:         .value_kind:     hidden_block_count_y
+; CHECK-NEXT:       - .offset:         16
+; CHECK-NEXT:         .preload_registers: s6
+; CHECK-NEXT:         .size:           4
+; CHECK-NEXT:         .value_kind:     hidden_block_count_z
+; CHECK-NEXT:       - .offset:         20
+; CHECK-NEXT:         .preload_registers: s7
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_group_size_x
+; CHECK-NEXT:       - .offset:         22
+; CHECK-NEXT:         .preload_registers: s7
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_group_size_y
+; CHECK-NEXT:       - .offset:         24
+; CHECK-NEXT:         .preload_registers: s8
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_group_size_z
+; CHECK-NEXT:       - .offset:         26
+; CHECK-NEXT:         .preload_registers: s8
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_remainder_x
+; CHECK-NEXT:       - .offset:         28
+; CHECK-NEXT:         .preload_registers: s9
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_remainder_y
+; CHECK-NEXT:       - .offset:         30
+; CHECK-NEXT:         .preload_registers: s9
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_remainder_z
+; CHECK-NEXT:       - .offset:         48
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_global_offset_x
+; CHECK-NEXT:       - .offset:         56
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_global_offset_y
+; CHECK-NEXT:       - .offset:         64
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_global_offset_z
+; CHECK-NEXT:       - .offset:         72
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_grid_dims
+; CHECK-NEXT:       - .offset:         80
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_printf_buffer
+; CHECK-NEXT:   .group_segment_fixed_size: 0
+; CHECK-NEXT:   .kernarg_segment_align: 8
+; CHECK-NEXT:   .kernarg_segment_size: 264
+; CHECK-NEXT:   .max_flat_workgroup_size: 1024
+; CHECK-NEXT:   .name:           test_preload_v6_block_count_z_workgroup_size_z_remainder_z
+; CHECK-NEXT:   .private_segment_fixed_size: 0
+; CHECK-NEXT:   .sgpr_count:     16
+; CHECK-NEXT:   .sgpr_spill_count: 0
+; CHECK-NEXT:   .symbol:         test_preload_v6_block_count_z_workgroup_size_z_remainder_z.kd
+; CHECK-NEXT:   .uses_dynamic_stack: false
+; CHECK-NEXT:   .vgpr_count:     4
+; CHECK-NEXT:   .vgpr_spill_count: 0
+; CHECK-NEXT:   .wavefront_size: 64
+; CHECK-NEXT: - .agpr_count:     0
+; CHECK-NEXT:     .args:
+; CHECK-NEXT:       - .address_space:  global
+; CHECK-NEXT:         .name:           out
+; CHECK-NEXT:         .offset:         0
+; CHECK-NEXT:         .preload_registers: 's[2:3]'
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     global_buffer
+; CHECK-NEXT:       - .name:           arg0
+; CHECK-NEXT:         .offset:         8
+; CHECK-NEXT:         .preload_registers: s4
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     by_value
+; CHECK-NEXT:       - .name:           arg1
+; CHECK-NEXT:         .offset:         10
+; CHECK-NEXT:         .preload_registers: s4
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     by_value
+; CHECK-NEXT:       - .offset:         16
+; CHECK-NEXT:         .size:           4
+; CHECK-NEXT:         .value_kind:     hidden_block_count_x
+; CHECK-NEXT:       - .offset:         20
+; CHECK-NEXT:         .size:           4
+; CHECK-NEXT:         .value_kind:     hidden_block_count_y
+; CHECK-NEXT:       - .offset:         24
+; CHECK-NEXT:         .size:           4
+; CHECK-NEXT:         .value_kind:     hidden_block_count_z
+; CHECK-NEXT:       - .offset:         28
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_group_size_x
+; CHECK-NEXT:       - .offset:         30
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_group_size_y
+; CHECK-NEXT:       - .offset:         32
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_group_size_z
+; CHECK-NEXT:       - .offset:         34
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_remainder_x
+; CHECK-NEXT:       - .offset:         36
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_remainder_y
+; CHECK-NEXT:       - .offset:         38
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_remainder_z
+; CHECK-NEXT:       - .offset:         56
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_global_offset_x
+; CHECK-NEXT:       - .offset:         64
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_global_offset_y
+; CHECK-NEXT:       - .offset:         72
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_global_offset_z
+; CHECK-NEXT:       - .offset:         80
+; CHECK-NEXT:         .size:           2
+; CHECK-NEXT:         .value_kind:     hidden_grid_dims
+; CHECK-NEXT:       - .offset:         88
+; CHECK-NEXT:         .size:           8
+; CHECK-NEXT:         .value_kind:     hidden_printf_buffer
+; CHECK-NEXT:   .group_segment_fixed_size: 0
+; CHECK-NEXT:   .kernarg_segment_align: 8
+; CHECK-NEXT:   .kernarg_segment_size: 272
+; CHECK-NEXT:   .max_flat_workgroup_size: 1024
+; CHECK-NEXT:   .name:           test_prelaod_v6_ptr1_i16_i16
+; CHECK-NEXT:   .private_segment_fixed_size: 0
+; CHECK-NEXT:   .sgpr_count:     11
+; CHECK-NEXT:   .sgpr_spill_count: 0
+; CHECK-NEXT:   .symbol:         test_prelaod_v6_ptr1_i16_i16.kd
+; CHECK-NEXT:   .uses_dynamic_stack: false
+; CHECK-NEXT:   .vgpr_count:     2
+; CHECK-NEXT:   .vgpr_spill_count: 0
+; CHECK-NEXT:   .wavefront_size: 64
+; CHECK-NEXT: amdhsa.printf:
+; CHECK-NEXT:   - '1:1:4:%d\n'
+; CHECK-NEXT:   - '2:1:8:%g\n'
+; CHECK-NEXT: amdhsa.target:   amdgcn-amd-amdhsa--gfx942
+; CHECK-NEXT: amdhsa.version:
+; CHECK-NEXT:   - 1
+; CHECK-NEXT:   - 3
+
+@lds = external hidden addrspace(3) global [0 x i32], align 4
+
+define amdgpu_kernel void @test_preload_v6(
+    i32 inreg %in,
+    ptr addrspace(1) inreg %r,
+    ptr addrspace(1) inreg %a,
+    ptr addrspace(1) inreg %b) #0 {
+  %a.val = load half, ptr addrspace(1) %a
+  %b.val = load half, ptr addrspace(1) %b
+  %r.val = fadd half %a.val, %b.val
+  store half %r.val, ptr addrspace(1) %r
+  store i32 1234, ptr addrspacecast (ptr addrspace(3) @lds to ptr), align 4
+  ret void
+}
+
+define amdgpu_kernel void @test_preload_v6_block_count_xyz(ptr addrspace(1) inreg %out) #1 {
+  %imp_arg_ptr = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+  %gep_x = getelementptr i8, ptr addrspace(4) %imp_arg_ptr, i32 0
+  %load_x = load i32, ptr addrspace(4) %gep_x
+  %gep_y = getelementptr i8, ptr addrspace(4) %imp_arg_ptr, i32 4
+  %load_y = load i32, ptr addrspace(4) %gep_y
+  %gep_z = getelementptr i8, ptr addrspace(4) %imp_arg_ptr, i32 8
+  %load_z = load i32, ptr addrspace(4) %gep_z
+  %ins.0 =  insertelement <3 x i32> poison, i32 %load_x, i32 0
+  %ins.1 =  insertelement <3 x i32> %ins.0, i32 %load_y, i32 1
+  %ins.2 =  insertelement <3 x i32> %ins.1, i32 %load_z, i32 2
+  store <3 x i32> %ins.2, ptr addrspace(1) %out
+  ret void
+}
+
+define amdgpu_kernel void @test_preload_v6_block_count_z_workgroup_size_z_remainder_z(ptr addrspace(1) inreg %out) #1 {
+  %imp_arg_ptr = call ptr addrspace(4) @llvm.amdgcn.implicitarg.ptr()
+  %gep0 = getelementptr i8, ptr addrspace(4) %imp_arg_ptr, i32 8
+  %gep1 = getelementptr i8, ptr addrspace(4) %imp_arg_ptr, i32 16
+  %gep2 = getelementptr i8, ptr addrspace(4) %imp_arg_ptr, i32 22
+  %load0 = load i32, ptr addrspace(4) %gep0
+  %load1 = load i16, ptr addrspace(4) %gep1
+  %load2 = load i16, ptr addrspace(4) %gep2
+  %conv1 = zext i16 %load1 to i32
+  %conv2 = zext i16 %load2 to i32
+  %ins.0 =  insertelement <3 x i32> poison, i32 %load0, i32 0
+  %ins.1 =  insertelement <3 x i32> %ins.0, i32 %conv1, i32 1
+  %ins.2 =  insertelement <3 x i32> %ins.1, i32 %conv2, i32 2
+  store <3 x i32> %ins.2, ptr addrspace(1) %out
+  ret void
+}
+
+define amdgpu_kernel void @test_prelaod_v6_ptr1_i16_i16(ptr addrspace(1) inreg %out, i16 inreg %arg0, i16 inreg %arg1) #1 {
+  %ext = zext i16 %arg0 to i32
+  %ext1 = zext i16 %arg1 to i32
+  %add = add i32 %ext, %ext1
+  store i32 %add, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"amdhsa_code_object_version", i32 600}
+!llvm.printf.fmts = !{!1, !2}
+!1 = !{!"1:1:4:%d\5Cn"}
+!2 = !{!"2:1:8:%g\5Cn"}
+
+attributes #0 = { optnone noinline }
+attributes #1 = { "amdgpu-agpr-alloc"="0" "amdgpu-no-completion-action" "amdgpu-no-default-queue" "amdgpu-no-dispatch-id" "amdgpu-no-dispatch-ptr" "amdgpu-no-heap-ptr" "amdgpu-no-hostcall-ptr" "amdgpu-no-lds-kernel-id" "amdgpu-no-multigrid-sync-arg" "amdgpu-no-queue-ptr" "amdgpu-no-workgroup-id-x" "amdgpu-no-workgroup-id-y" "amdgpu-no-workgroup-id-z" "amdgpu-no-workitem-id-x" "amdgpu-no-workitem-id-y" "amdgpu-no-workitem-id-z" "uniform-work-group-size"="false" }

--- a/llvm/test/CodeGen/AMDGPU/hsa-metadata-preload-args-v6.ll
+++ b/llvm/test/CodeGen/AMDGPU/hsa-metadata-preload-args-v6.ll
@@ -314,6 +314,74 @@
 ; CHECK-NEXT:   .vgpr_count:     2
 ; CHECK-NEXT:   .vgpr_spill_count: 0
 ; CHECK-NEXT:   .wavefront_size: 64
+; CHECK-NEXT: - .agpr_count:     0
+; CHECK-NEXT:   .args:
+; CHECK-NEXT:    - .address_space:  global
+; CHECK-NEXT:      .name:           out
+; CHECK-NEXT:      .offset:         0
+; CHECK-NEXT:      .preload_registers: 's[2:3]'
+; CHECK-NEXT:      .size:           8
+; CHECK-NEXT:      .value_kind:     global_buffer
+; CHECK-NEXT:    - .name:           arg0
+; CHECK-NEXT:      .offset:         16
+; CHECK-NEXT:      .preload_registers: s6 s7 s8 s9
+; CHECK-NEXT:      .size:           16
+; CHECK-NEXT:      .value_kind:     by_value
+; CHECK-NEXT:    - .offset:         32
+; CHECK-NEXT:      .size:           4
+; CHECK-NEXT:      .value_kind:     hidden_block_count_x
+; CHECK-NEXT:    - .offset:         36
+; CHECK-NEXT:      .size:           4
+; CHECK-NEXT:      .value_kind:     hidden_block_count_y
+; CHECK-NEXT:    - .offset:         40
+; CHECK-NEXT:      .size:           4
+; CHECK-NEXT:      .value_kind:     hidden_block_count_z
+; CHECK-NEXT:    - .offset:         44
+; CHECK-NEXT:      .size:           2
+; CHECK-NEXT:      .value_kind:     hidden_group_size_x
+; CHECK-NEXT:    - .offset:         46
+; CHECK-NEXT:      .size:           2
+; CHECK-NEXT:      .value_kind:     hidden_group_size_y
+; CHECK-NEXT:    - .offset:         48
+; CHECK-NEXT:      .size:           2
+; CHECK-NEXT:      .value_kind:     hidden_group_size_z
+; CHECK-NEXT:    - .offset:         50
+; CHECK-NEXT:      .size:           2
+; CHECK-NEXT:      .value_kind:     hidden_remainder_x
+; CHECK-NEXT:    - .offset:         52
+; CHECK-NEXT:      .size:           2
+; CHECK-NEXT:      .value_kind:     hidden_remainder_y
+; CHECK-NEXT:    - .offset:         54
+; CHECK-NEXT:      .size:           2
+; CHECK-NEXT:      .value_kind:     hidden_remainder_z
+; CHECK-NEXT:    - .offset:         72
+; CHECK-NEXT:      .size:           8
+; CHECK-NEXT:      .value_kind:     hidden_global_offset_x
+; CHECK-NEXT:    - .offset:         80
+; CHECK-NEXT:      .size:           8
+; CHECK-NEXT:      .value_kind:     hidden_global_offset_y
+; CHECK-NEXT:    - .offset:         88
+; CHECK-NEXT:      .size:           8
+; CHECK-NEXT:      .value_kind:     hidden_global_offset_z
+; CHECK-NEXT:    - .offset:         96
+; CHECK-NEXT:      .size:           2
+; CHECK-NEXT:      .value_kind:     hidden_grid_dims
+; CHECK-NEXT:    - .offset:         104
+; CHECK-NEXT:      .size:           8
+; CHECK-NEXT:      .value_kind:     hidden_printf_buffer
+; CHECK-NEXT:  .group_segment_fixed_size: 0
+; CHECK-NEXT:  .kernarg_segment_align: 16
+; CHECK-NEXT:  .kernarg_segment_size: 288
+; CHECK-NEXT:  .max_flat_workgroup_size: 1024
+; CHECK-NEXT:  .name:           test_prelaod_v6_ptr1_v8i16
+; CHECK-NEXT:  .private_segment_fixed_size: 0
+; CHECK-NEXT:  .sgpr_count:     16
+; CHECK-NEXT:  .sgpr_spill_count: 0
+; CHECK-NEXT:  .symbol:         test_prelaod_v6_ptr1_v8i16.kd
+; CHECK-NEXT:  .uses_dynamic_stack: false
+; CHECK-NEXT:  .vgpr_count:     5
+; CHECK-NEXT:  .vgpr_spill_count: 0
+; CHECK-NEXT:  .wavefront_size: 64
 ; CHECK-NEXT: amdhsa.printf:
 ; CHECK-NEXT:   - '1:1:4:%d\n'
 ; CHECK-NEXT:   - '2:1:8:%g\n'
@@ -377,6 +445,10 @@ define amdgpu_kernel void @test_prelaod_v6_ptr1_i16_i16(ptr addrspace(1) inreg %
   ret void
 }
 
+define amdgpu_kernel void @test_prelaod_v6_ptr1_v8i16(ptr addrspace(1) inreg %out, <8 x i16> inreg %arg0) #1 {
+  store <8 x i16> %arg0, ptr addrspace(1) %out, align 4
+  ret void
+}
 
 !llvm.module.flags = !{!0}
 !0 = !{i32 1, !"amdhsa_code_object_version", i32 600}

--- a/llvm/test/CodeGen/AMDGPU/tid-mul-func-xnack-all-any.ll
+++ b/llvm/test/CodeGen/AMDGPU/tid-mul-func-xnack-all-any.ll
@@ -1,6 +1,6 @@
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM4 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM6 %s
 
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=4 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF4 %s
 ; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=5 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF5 %s
@@ -15,7 +15,8 @@
 ; ASM:  amdhsa.version:
 ; ASM:     - 1
 ; ASM4:    - 1
-; ASM56:   - 2
+; ASM5:   - 2
+; ASM6:   - 3
 
 ; ELF:      OS/ABI: AMDGPU_HSA (0x40)
 ; ELF4:      ABIVersion: 2

--- a/llvm/test/CodeGen/AMDGPU/tid-mul-func-xnack-all-not-supported.ll
+++ b/llvm/test/CodeGen/AMDGPU/tid-mul-func-xnack-all-not-supported.ll
@@ -1,6 +1,6 @@
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx700 | FileCheck --check-prefixes=ASM,ASM4 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx700 | FileCheck --check-prefixes=ASM,ASM56 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx700 | FileCheck --check-prefixes=ASM,ASM56 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx700 | FileCheck --check-prefixes=ASM,ASM5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx700 | FileCheck --check-prefixes=ASM,ASM6 %s
 
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx700 --amdhsa-code-object-version=4 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF4 %s
 ; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx700 --amdhsa-code-object-version=5 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF5 %s
@@ -15,7 +15,8 @@
 ; ASM:  amdhsa.version:
 ; ASM:     - 1
 ; ASM4:    - 1
-; ASM56:   - 2
+; ASM5:   - 2
+; ASM6:   - 3
 
 ; ELF:      OS/ABI: AMDGPU_HSA (0x40)
 ; ELF4:      ABIVersion: 2

--- a/llvm/test/CodeGen/AMDGPU/tid-mul-func-xnack-all-off.ll
+++ b/llvm/test/CodeGen/AMDGPU/tid-mul-func-xnack-all-off.ll
@@ -1,6 +1,6 @@
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM4 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM6 %s
 
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=4 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF4 %s
 ; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=5 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF5 %s
@@ -15,7 +15,8 @@
 ; ASM:  amdhsa.version:
 ; ASM:     - 1
 ; ASM4:    - 1
-; ASM56:   - 2
+; ASM5:   - 2
+; ASM6:   - 3
 
 ; ELF:      OS/ABI: AMDGPU_HSA (0x40)
 ; ELF4:      ABIVersion: 2

--- a/llvm/test/CodeGen/AMDGPU/tid-mul-func-xnack-all-on.ll
+++ b/llvm/test/CodeGen/AMDGPU/tid-mul-func-xnack-all-on.ll
@@ -1,6 +1,6 @@
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM4 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM6 %s
 
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=4 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF4 %s
 ; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=5 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF5 %s
@@ -15,7 +15,8 @@
 ; ASM:  amdhsa.version:
 ; ASM:     - 1
 ; ASM4:    - 1
-; ASM56:   - 2
+; ASM5:   - 2
+; ASM6:   - 3
 
 ; ELF:      OS/ABI: AMDGPU_HSA (0x40)
 ; ELF4:      ABIVersion: 2

--- a/llvm/test/CodeGen/AMDGPU/tid-mul-func-xnack-any-off-1.ll
+++ b/llvm/test/CodeGen/AMDGPU/tid-mul-func-xnack-any-off-1.ll
@@ -1,6 +1,6 @@
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM4 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM6 %s
 
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=4 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF4 %s
 ; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=5 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF5 %s
@@ -15,7 +15,8 @@
 ; ASM:  amdhsa.version:
 ; ASM:     - 1
 ; ASM4:    - 1
-; ASM56:   - 2
+; ASM5:   - 2
+; ASM6:   - 3
 
 ; ELF:      OS/ABI: AMDGPU_HSA (0x40)
 ; ELF4:      ABIVersion: 2

--- a/llvm/test/CodeGen/AMDGPU/tid-mul-func-xnack-any-off-2.ll
+++ b/llvm/test/CodeGen/AMDGPU/tid-mul-func-xnack-any-off-2.ll
@@ -1,6 +1,6 @@
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM4 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM6 %s
 
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=4 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF4 %s
 ; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=5 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF5 %s
@@ -15,7 +15,8 @@
 ; ASM:  amdhsa.version:
 ; ASM:     - 1
 ; ASM4:    - 1
-; ASM56:   - 2
+; ASM5:   - 2
+; ASM6:   - 3
 
 ; ELF:      OS/ABI: AMDGPU_HSA (0x40)
 ; ELF4:      ABIVersion: 2

--- a/llvm/test/CodeGen/AMDGPU/tid-mul-func-xnack-any-on-1.ll
+++ b/llvm/test/CodeGen/AMDGPU/tid-mul-func-xnack-any-on-1.ll
@@ -1,6 +1,6 @@
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM4 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM6 %s
 
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=4 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF4 %s
 ; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=5 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF5 %s
@@ -15,7 +15,8 @@
 ; ASM:  amdhsa.version:
 ; ASM:     - 1
 ; ASM4:    - 1
-; ASM56:   - 2
+; ASM5:   - 2
+; ASM6:   - 3
 
 ; ELF:      OS/ABI: AMDGPU_HSA (0x40)
 ; ELF4:      ABIVersion: 2

--- a/llvm/test/CodeGen/AMDGPU/tid-mul-func-xnack-any-on-2.ll
+++ b/llvm/test/CodeGen/AMDGPU/tid-mul-func-xnack-any-on-2.ll
@@ -1,6 +1,6 @@
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM4 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM6 %s
 
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=4 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF4 %s
 ; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=5 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF5 %s
@@ -15,7 +15,8 @@
 ; ASM:  amdhsa.version:
 ; ASM:     - 1
 ; ASM4:    - 1
-; ASM56:   - 2
+; ASM5:   - 2
+; ASM6:   - 3
 
 ; ELF:      OS/ABI: AMDGPU_HSA (0x40)
 ; ELF4:      ABIVersion: 2

--- a/llvm/test/CodeGen/AMDGPU/tid-one-func-xnack-not-supported.ll
+++ b/llvm/test/CodeGen/AMDGPU/tid-one-func-xnack-not-supported.ll
@@ -1,6 +1,6 @@
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx700 | FileCheck --check-prefixes=ASM,ASM4 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx700 | FileCheck --check-prefixes=ASM,ASM56 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx700 | FileCheck --check-prefixes=ASM,ASM56 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx700 | FileCheck --check-prefixes=ASM,ASM5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx700 | FileCheck --check-prefixes=ASM,ASM6 %s
 
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx700 --amdhsa-code-object-version=4 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF4 %s
 ; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx700 --amdhsa-code-object-version=5 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF5 %s
@@ -15,7 +15,8 @@
 ; ASM:  amdhsa.version:
 ; ASM:     - 1
 ; ASM4:    - 1
-; ASM56:   - 2
+; ASM5:   - 2
+; ASM6:   - 3
 
 ; ELF:      OS/ABI: AMDGPU_HSA (0x40)
 ; ELF4:      ABIVersion: 2

--- a/llvm/test/CodeGen/AMDGPU/tid-one-func-xnack-off.ll
+++ b/llvm/test/CodeGen/AMDGPU/tid-one-func-xnack-off.ll
@@ -1,6 +1,6 @@
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM4 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM6 %s
 
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=4 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF4 %s
 ; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=5 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF5 %s
@@ -15,7 +15,8 @@
 ; ASM:  amdhsa.version:
 ; ASM:     - 1
 ; ASM4:    - 1
-; ASM56:   - 2
+; ASM5:   - 2
+; ASM6:   - 3
 
 ; ELF:      OS/ABI: AMDGPU_HSA (0x40)
 ; ELF4:      ABIVersion: 2

--- a/llvm/test/CodeGen/AMDGPU/tid-one-func-xnack-on.ll
+++ b/llvm/test/CodeGen/AMDGPU/tid-one-func-xnack-on.ll
@@ -1,6 +1,6 @@
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM4 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
-; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM56 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM5 %s
+; RUN: sed 's/CODE_OBJECT_VERSION/600/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 | FileCheck --check-prefixes=ASM,ASM6 %s
 
 ; RUN: sed 's/CODE_OBJECT_VERSION/400/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=4 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF4 %s
 ; RUN: sed 's/CODE_OBJECT_VERSION/500/g' %s | llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 --amdhsa-code-object-version=5 --filetype=obj | llvm-readobj --file-headers - | FileCheck --check-prefixes=ELF,ELF5 %s
@@ -15,7 +15,8 @@
 ; ASM:  amdhsa.version:
 ; ASM:     - 1
 ; ASM4:    - 1
-; ASM56:   - 2
+; ASM5:   - 2
+; ASM6:   - 3
 
 ; ELF:      OS/ABI: AMDGPU_HSA (0x40)
 ; ELF4:      ABIVersion: 2


### PR DESCRIPTION
Tracks the registers that explicit and hidden arguments are preloaded to
with new code object metadata.

IR arguments may be split across multiple parts by isel, and SGPR tuple
alignment means that an argument may be spread across multiple
registers.

To support this, some of the utilities for hidden kernel arguments are
moved to `AMDGPUArgumentUsageInfo.h`. Additional bookkeeping is also
needed for tracking purposes.