### PR TITLE
[win/arm64] Enable tail call with inreg arguments when possible

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -8712,6 +8712,8 @@ bool AArch64TargetLowering::isEligibleForTailCallOptimization(
       unsigned ArgNum = i - CallerF.arg_begin();
       if (!CLI.CB || CLI.CB->arg_size() <= ArgNum ||
           !CLI.CB->getParamAttr(ArgNum, Attribute::InReg).isValid() ||
+          !i->hasStructRetAttr() ||
+          !CLI.CB->getParamAttr(ArgNum, Attribute::StructRet).isValid() ||
           CLI.CB->getArgOperand(ArgNum) != i) {
         return false;
       }

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -8709,12 +8709,13 @@ bool AArch64TargetLowering::isEligibleForTailCallOptimization(
     // also has that attribute on the same argument, and the same value is
     // passed.
     if (i->hasInRegAttr()) {
-      unsigned ArgNum = i - CallerF.arg_begin();
-      if (!CLI.CB || CLI.CB->arg_size() <= ArgNum ||
-          !CLI.CB->getParamAttr(ArgNum, Attribute::InReg).isValid() ||
-          !i->hasStructRetAttr() ||
-          !CLI.CB->getParamAttr(ArgNum, Attribute::StructRet).isValid() ||
-          CLI.CB->getArgOperand(ArgNum) != i) {
+      unsigned ArgIdx = i - CallerF.arg_begin();
+      if (!CLI.CB || CLI.CB->arg_size() <= ArgIdx)
+        return false;
+      AttributeSet Attrs = CLI.CB->getParamAttributes(ArgIdx);
+      if (!Attrs.hasAttribute(Attribute::InReg) ||
+          !Attrs.hasAttribute(Attribute::StructRet) || !i->hasStructRetAttr() ||
+          CLI.CB->getArgOperand(ArgIdx) != i) {
         return false;
       }
     }

--- a/llvm/test/CodeGen/AArch64/arm64-windows-tailcall.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-windows-tailcall.ll
@@ -32,7 +32,7 @@ define void @inreg_caller_1(ptr %a, ptr inreg sret(%class.C) %b) {
 }
 
 define void @inreg_caller_2(ptr %a, ptr inreg sret(%class.C) %b) {
-; The inreg attribute and value lines up between caller and callee, so it can
+; The inreg attribute and value line up between caller and callee, so it can
 ; be tail called.
 ; CHECK-LABEL: inreg_caller_2
 ; CHECK: b inreg_callee

--- a/llvm/test/CodeGen/AArch64/arm64-windows-tailcall.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-windows-tailcall.ll
@@ -16,3 +16,27 @@ entry:
 }
 
 declare dso_local void @"?foo"(ptr dereferenceable(4))
+
+
+declare void @inreg_callee(ptr, ptr inreg sret(%class.C))
+
+define void @inreg_caller_1(ptr %a, ptr inreg sret(%class.C) %b) {
+; A different value is passed to the inreg parameter, so tail call is not possible.
+; CHECK-LABEL: inreg_caller_1
+; CHECK: mov x19, x1
+; CHECK: bl inreg_callee
+; CHECK: mov x0, x19
+
+  tail call void @inreg_callee(ptr %b, ptr inreg sret(%class.C) %a)
+  ret void
+}
+
+define void @inreg_caller_2(ptr %a, ptr inreg sret(%class.C) %b) {
+; The inreg attribute and value lines up between caller and callee, so it can
+; be tail called.
+; CHECK-LABEL: inreg_caller_2
+; CHECK: b inreg_callee
+
+  tail call void @inreg_callee(ptr %a, ptr inreg sret(%class.C) %b)
+  ret void
+}


### PR DESCRIPTION
Tail calls were disabled from callers with inreg parameters in 5dc8aeb with a fixme to check if the callee also takes an inreg parameter.

The issue is that inreg parameters (which are passed in x0 or x1 for free and member functions respectively) are supposed to be returned (in x0) at the end of the function. In case of a tail call, that means the callee needs to return the same value as the caller would.

We can check for that case, and it's not as niche as it sounds, as that's how Clang will lower one function with an sret return value calling another, such as:

```
struct T { int x; };
struct S {
    T foo();
    T bar();
};
T S::foo() { return bar(); } // foo's sret argument will get passed directly to bar
```

Fixes #133098