### PR TITLE
[flang][OpenMP][NFC] Don't use special chars in error messages

### DIFF
--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -5762,7 +5762,7 @@ void OmpStructureChecker::Enter(const parser::OpenMPInteropConstruct &x) {
               const auto *objectSymbol{name->symbol};
               if (llvm::is_contained(objectSymbolList, objectSymbol)) {
                 context_.Say(GetContext().directiveSource,
-                    "Each interop-var may be speciﬁed for at most one action-clause of each INTEROP construct."_err_en_US);
+                    "Each interop-var may be specified for at most one action-clause of each INTEROP construct."_err_en_US);
               } else {
                 objectSymbolList.insert(objectSymbol);
               }
@@ -5777,7 +5777,7 @@ void OmpStructureChecker::Enter(const parser::OpenMPInteropConstruct &x) {
               const auto *objectSymbol{name->symbol};
               if (llvm::is_contained(objectSymbolList, objectSymbol)) {
                 context_.Say(GetContext().directiveSource,
-                    "Each interop-var may be speciﬁed for at most one action-clause of each INTEROP construct."_err_en_US);
+                    "Each interop-var may be specified for at most one action-clause of each INTEROP construct."_err_en_US);
               } else {
                 objectSymbolList.insert(objectSymbol);
               }
@@ -5789,7 +5789,7 @@ void OmpStructureChecker::Enter(const parser::OpenMPInteropConstruct &x) {
               const auto *objectSymbol{name->symbol};
               if (llvm::is_contained(objectSymbolList, objectSymbol)) {
                 context_.Say(GetContext().directiveSource,
-                    "Each interop-var may be speciﬁed for at most one action-clause of each INTEROP construct."_err_en_US);
+                    "Each interop-var may be specified for at most one action-clause of each INTEROP construct."_err_en_US);
               } else {
                 objectSymbolList.insert(objectSymbol);
               }
@@ -5800,7 +5800,7 @@ void OmpStructureChecker::Enter(const parser::OpenMPInteropConstruct &x) {
   }
   if (targetCount > 1 || targetSyncCount > 1) {
     context_.Say(GetContext().directiveSource,
-        "Each interop-type may be speciﬁed at most once."_err_en_US);
+        "Each interop-type may be specified at most once."_err_en_US);
   }
   if (isDependClauseOccured && !targetSyncCount) {
     context_.Say(GetContext().directiveSource,

--- a/flang/test/Semantics/OpenMP/interop-construct.f90
+++ b/flang/test/Semantics/OpenMP/interop-construct.f90
@@ -8,7 +8,7 @@
 SUBROUTINE test_interop_01()
   USE omp_lib
   INTEGER(OMP_INTEROP_KIND) :: obj
-  !ERROR: Each interop-var may be speciﬁed for at most one action-clause of each INTEROP construct.
+  !ERROR: Each interop-var may be specified for at most one action-clause of each INTEROP construct.
   !$OMP INTEROP INIT(TARGETSYNC,TARGET: obj) USE(obj)
   PRINT *, 'pass'
 END SUBROUTINE test_interop_01
@@ -16,7 +16,7 @@ END SUBROUTINE test_interop_01
 SUBROUTINE test_interop_02()
   USE omp_lib
   INTEGER(OMP_INTEROP_KIND) :: obj
-  !ERROR: Each interop-type may be speciﬁed at most once.
+  !ERROR: Each interop-type may be specified at most once.
   !$OMP INTEROP INIT(TARGETSYNC,TARGET,TARGETSYNC: obj)
   PRINT *, 'pass'
 END SUBROUTINE test_interop_02


### PR DESCRIPTION
Some error messages were using a special char for `fi`, in the
word `specified`, probably due to a typo.

This caused an error on Windows: #134625
