### PR TITLE
[CI] Reduce false positives in undef checker

### DIFF
--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -391,7 +391,9 @@ You can test this locally with the following command:
             else:
                 undef_regex = r"UndefValue::get"
             # search for additions of undef
-            if re.search(r"^[+](?!\s*#\s*).*(" + undef_regex + r")", file, re.MULTILINE):
+            if re.search(
+                r"^[+](?!\s*#\s*).*(" + undef_regex + r")", file, re.MULTILINE
+            ):
                 files.append(filename)
 
         if not files:

--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -376,14 +376,23 @@ You can test this locally with the following command:
         sys.stdout.write(proc.stderr)
         stdout = proc.stdout
 
+        if not stdout:
+            return None
+
         files = []
+
         # Split the diff so we have one array entry per file.
         # Each file is prefixed like:
         # diff --git a/file b/file
         for file in re.split("^diff --git ", stdout, 0, re.MULTILINE):
+            filename = re.match("a/([^ ]+)", file.splitlines()[0])[1]
+            if filename.endswith(".ll"):
+                undef_regex = r"\bundef\b"
+            else:
+                undef_regex = r"UndefValue::get"
             # search for additions of undef
-            if re.search(r"^[+](?!\s*#\s*).*(\bundef\b|UndefValue::get)", file, re.MULTILINE):
-                files.append(re.match("a/([^ ]+)", file.splitlines()[0])[1])
+            if re.search(r"^[+](?!\s*#\s*).*(" + undef_regex + r")", file, re.MULTILINE):
+                files.append(filename)
 
         if not files:
             return None


### PR DESCRIPTION
Only check for diffs containing "undef" in .ll files, this prevents comments like `// We should not have undef values...` triggering the undef checker bot.