### PR TITLE
SimplifyLibCalls: Skip sincospi optimization for ConstantData

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
@@ -3002,6 +3002,9 @@ Value *LibCallSimplifier::optimizeSinCosPi(CallInst *CI, bool IsSin, IRBuilderBa
     return nullptr;
 
   Value *Arg = CI->getArgOperand(0);
+  if (isa<ConstantData>(Arg))
+    return nullptr;
+
   SmallVector<CallInst *, 1> SinCalls;
   SmallVector<CallInst *, 1> CosCalls;
   SmallVector<CallInst *, 1> SinCosCalls;

--- a/llvm/test/Transforms/InstCombine/sincospi.ll
+++ b/llvm/test/Transforms/InstCombine/sincospi.ll
@@ -90,18 +90,14 @@ define float @test_instbased_f32_other_user(ptr %ptr) {
 
 define float @test_constant_f32() {
 ; CHECK-FLOAT-IN-VEC-LABEL: @test_constant_f32(
-; CHECK-FLOAT-IN-VEC-NEXT:    [[SINCOSPI:%.*]] = call <2 x float> @__sincospif_stret(float 1.000000e+00)
-; CHECK-FLOAT-IN-VEC-NEXT:    [[SINPI:%.*]] = extractelement <2 x float> [[SINCOSPI]], i64 0
-; CHECK-FLOAT-IN-VEC-NEXT:    [[COSPI:%.*]] = extractelement <2 x float> [[SINCOSPI]], i64 1
-; CHECK-FLOAT-IN-VEC-NEXT:    [[COS:%.*]] = call float @__cospif(float 1.000000e+00) #[[ATTR0]]
+; CHECK-FLOAT-IN-VEC-NEXT:    [[SINPI:%.*]] = call float @__sinpif(float 1.000000e+00) #[[ATTR0]]
+; CHECK-FLOAT-IN-VEC-NEXT:    [[COSPI:%.*]] = call float @__cospif(float 1.000000e+00) #[[ATTR0]]
 ; CHECK-FLOAT-IN-VEC-NEXT:    [[RES:%.*]] = fadd float [[SINPI]], [[COSPI]]
 ; CHECK-FLOAT-IN-VEC-NEXT:    ret float [[RES]]
 ;
 ; CHECK-LABEL: @test_constant_f32(
-; CHECK-NEXT:    [[SINCOSPI:%.*]] = call { float, float } @__sincospif_stret(float 1.000000e+00)
-; CHECK-NEXT:    [[SINPI:%.*]] = extractvalue { float, float } [[SINCOSPI]], 0
-; CHECK-NEXT:    [[COSPI:%.*]] = extractvalue { float, float } [[SINCOSPI]], 1
-; CHECK-NEXT:    [[COS:%.*]] = call float @__cospif(float 1.000000e+00) #[[ATTR0]]
+; CHECK-NEXT:    [[SINPI:%.*]] = call float @__sinpif(float 1.000000e+00) #[[ATTR0]]
+; CHECK-NEXT:    [[COSPI:%.*]] = call float @__cospif(float 1.000000e+00) #[[ATTR0]]
 ; CHECK-NEXT:    [[RES:%.*]] = fadd float [[SINPI]], [[COSPI]]
 ; CHECK-NEXT:    ret float [[RES]]
 ;
@@ -172,18 +168,14 @@ define double @test_instbased_f64() {
 
 define double @test_constant_f64() {
 ; CHECK-FLOAT-IN-VEC-LABEL: @test_constant_f64(
-; CHECK-FLOAT-IN-VEC-NEXT:    [[SINCOSPI:%.*]] = call { double, double } @__sincospi_stret(double 1.000000e+00)
-; CHECK-FLOAT-IN-VEC-NEXT:    [[SINPI:%.*]] = extractvalue { double, double } [[SINCOSPI]], 0
-; CHECK-FLOAT-IN-VEC-NEXT:    [[COSPI:%.*]] = extractvalue { double, double } [[SINCOSPI]], 1
-; CHECK-FLOAT-IN-VEC-NEXT:    [[COS:%.*]] = call double @__cospi(double 1.000000e+00) #[[ATTR0]]
+; CHECK-FLOAT-IN-VEC-NEXT:    [[SINPI:%.*]] = call double @__sinpi(double 1.000000e+00) #[[ATTR0]]
+; CHECK-FLOAT-IN-VEC-NEXT:    [[COSPI:%.*]] = call double @__cospi(double 1.000000e+00) #[[ATTR0]]
 ; CHECK-FLOAT-IN-VEC-NEXT:    [[RES:%.*]] = fadd double [[SINPI]], [[COSPI]]
 ; CHECK-FLOAT-IN-VEC-NEXT:    ret double [[RES]]
 ;
 ; CHECK-LABEL: @test_constant_f64(
-; CHECK-NEXT:    [[SINCOSPI:%.*]] = call { double, double } @__sincospi_stret(double 1.000000e+00)
-; CHECK-NEXT:    [[SINPI:%.*]] = extractvalue { double, double } [[SINCOSPI]], 0
-; CHECK-NEXT:    [[COSPI:%.*]] = extractvalue { double, double } [[SINCOSPI]], 1
-; CHECK-NEXT:    [[COS:%.*]] = call double @__cospi(double 1.000000e+00) #[[ATTR0]]
+; CHECK-NEXT:    [[SINPI:%.*]] = call double @__sinpi(double 1.000000e+00) #[[ATTR0]]
+; CHECK-NEXT:    [[COSPI:%.*]] = call double @__cospi(double 1.000000e+00) #[[ATTR0]]
 ; CHECK-NEXT:    [[RES:%.*]] = fadd double [[SINPI]], [[COSPI]]
 ; CHECK-NEXT:    ret double [[RES]]
 ;


### PR DESCRIPTION
Avoids looking at the uselist, and it would probably be more
productive to constant fold this.