### PR TITLE
[clang][modules] Dependency Scanning: Temporarily Turn Off Negative Directory Caching

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningFilesystem.cpp
@@ -241,6 +241,13 @@ DependencyScanningWorkerFilesystem::computeAndStoreResult(
   llvm::ErrorOr<llvm::vfs::Status> Stat =
       getUnderlyingFS().status(OriginalFilename);
   if (!Stat) {
+    // rdar://148027982
+    // Negative caching directories can cause build failures.
+    // FIXME: we should remove the check below once we know
+    // the build failures' root causes.
+    if (llvm::sys::path::extension(OriginalFilename).empty())
+      return Stat.getError();
+
     const auto &Entry =
         getOrEmplaceSharedEntryForFilename(FilenameForLookup, Stat.getError());
     return insertLocalEntryForFilename(FilenameForLookup, Entry);


### PR DESCRIPTION
55323ca6c8b9d21d85591f3499b299b62463321f implemented negative caching of directories. The implementation may be too aggressive in certain cases, and may lead to file not found errors even if the files exist on disk.

This PR temporarily turns off negative directory caching to fix the build failures. 

rdar://148027982