### PR TITLE
unittests: ORC: Skip the ReOptimizeLayerTest for RISC-V

### DIFF
--- a/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp
@@ -55,6 +55,10 @@ protected:
     if (Triple.isPPC())
       GTEST_SKIP();
 
+    // RISC-V is not supported yet
+    if (Triple.isRISCV())
+      GTEST_SKIP();
+
     auto EPC = SelfExecutorProcessControl::Create();
     if (!EPC) {
       consumeError(EPC.takeError());


### PR DESCRIPTION
David Abdurachmanov reports[1] that we hit this error on P550 hardware:

    [...]
    /builddir/build/BUILD/llvm-20.1.1-build/llvm-project-20.1.1.src/llvm/unittests/ExecutionEngine/Orc/ReOptimizeLayerTest.cpp:140: Failure
    Value of: llvm::detail::TakeError(RM.takeError())
    Expected: succeeded
    Actual: failed (Architecture not supported) (of type llvm::detail::ErrorHolder)
    [...]

Tom Stellard noted[2] that he's seen this before on other architectures and suggested to skip it.

[1] https://src.fedoraproject.org/rpms/llvm/pull-request/408#comment-255547
[2] https://src.fedoraproject.org/rpms/llvm/pull-request/408#comment-255557