### PR TITLE
[sanitizer_common] Fix building with NetBSD 10.99.12 or newer

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux_libcdep.cpp
@@ -29,7 +29,13 @@
 #  include "sanitizer_solaris.h"
 
 #  if SANITIZER_NETBSD
-#    define _RTLD_SOURCE  // for __lwp_gettcb_fast() / __lwp_getprivate_fast()
+#    // for __lwp_gettcb_fast() / __lwp_getprivate_fast()
+#    include <sys/param.h>
+#    if defined(__NetBSD_Version__) && (__NetBSD_Version__ >= 1099001200)
+#      include <machine/lwp_private.h>
+#    else
+#      define _RTLD_SOURCE
+#    endif
 #  endif
 
 #  include <dlfcn.h>  // for dlsym()


### PR DESCRIPTION
https://github.com/NetBSD/src/commit/16543c49052c820334cffc5c69b2afde18f02458

__lwp_getprivate_fast() was moved to a new arch-specific header file.

Closes: #125566