### PR TITLE
[flang][runtime] Formatted input optimizations

### DIFF
--- a/flang-rt/include/flang-rt/runtime/io-stmt.h
+++ b/flang-rt/include/flang-rt/runtime/io-stmt.h
@@ -130,8 +130,81 @@ public:
   }
 
   // Vacant after the end of the current record
-  RT_API_ATTRS Fortran::common::optional<char32_t> GetCurrentChar(
+  RT_API_ATTRS Fortran::common::optional<char32_t> GetCurrentCharSlow(
       std::size_t &byteCount);
+
+  // For faster formatted input editing, this structure can be built by
+  // GetUpcomingFastAsciiField() and used to save significant time in
+  // GetCurrentChar, NextInField() and other input utilities when the input
+  // is buffered, does not require UTF-8 conversion, and comprises only
+  // single byte characters.
+  class FastAsciiField {
+  public:
+    RT_API_ATTRS FastAsciiField(ConnectionState &connection)
+        : connection_{connection} {}
+    RT_API_ATTRS FastAsciiField(
+        ConnectionState &connection, const char *start, std::size_t bytes)
+        : connection_{connection}, at_{start}, limit_{start + bytes} {
+      CheckForAsterisk();
+    }
+    RT_API_ATTRS ConnectionState &connection() { return connection_; }
+    RT_API_ATTRS std::size_t got() const { return got_; }
+
+    RT_API_ATTRS bool MustUseSlowPath() const { return at_ == nullptr; }
+
+    RT_API_ATTRS Fortran::common::optional<char32_t> Next() const {
+      if (at_ && at_ < limit_) {
+        return *at_;
+      } else {
+        return std::nullopt;
+      }
+    }
+    RT_API_ATTRS void NextRecord(IoStatementState &io) {
+      if (at_) {
+        if (std::size_t bytes{io.GetNextInputBytes(at_)}) {
+          limit_ = at_ + bytes;
+          CheckForAsterisk();
+        } else {
+          at_ = limit_ = nullptr;
+        }
+      }
+    }
+    RT_API_ATTRS void Advance(int gotten, std::size_t bytes) {
+      if (at_ && at_ < limit_) {
+        ++at_;
+        got_ += gotten;
+      }
+      connection_.HandleRelativePosition(bytes);
+    }
+    RT_API_ATTRS bool MightHaveAsterisk() const { return !at_ || hasAsterisk_; }
+
+  private:
+    RT_API_ATTRS void CheckForAsterisk() {
+      hasAsterisk_ =
+          at_ && at_ < limit_ && std::memchr(at_, '*', limit_ - at_) != nullptr;
+    }
+
+    ConnectionState &connection_;
+    const char *at_{nullptr};
+    const char *limit_{nullptr};
+    std::size_t got_{0}; // for READ(..., SIZE=)
+    bool hasAsterisk_{false};
+  };
+
+  RT_API_ATTRS FastAsciiField GetUpcomingFastAsciiField();
+
+  RT_API_ATTRS Fortran::common::optional<char32_t> GetCurrentChar(
+      std::size_t &byteCount, FastAsciiField *field = nullptr) {
+    if (field) {
+      if (auto ch{field->Next()}) {
+        byteCount = ch ? 1 : 0;
+        return ch;
+      } else if (!field->MustUseSlowPath()) {
+        return std::nullopt;
+      }
+    }
+    return GetCurrentCharSlow(byteCount);
+  }
 
   // The result of CueUpInput() and the "remaining" arguments to SkipSpaces()
   // and NextInField() are always in units of bytes, not characters; the
@@ -139,11 +212,12 @@ public:
 
   // For fixed-width fields, return the number of remaining bytes.
   // Skip over leading blanks.
-  RT_API_ATTRS Fortran::common::optional<int> CueUpInput(const DataEdit &edit) {
+  RT_API_ATTRS Fortran::common::optional<int> CueUpInput(
+      const DataEdit &edit, FastAsciiField *fastField = nullptr) {
     Fortran::common::optional<int> remaining;
     if (edit.IsListDirected()) {
       std::size_t byteCount{0};
-      GetNextNonBlank(byteCount);
+      GetNextNonBlank(byteCount, fastField);
     } else {
       if (edit.width.value_or(0) > 0) {
         remaining = *edit.width;
@@ -152,16 +226,17 @@ public:
           *remaining *= bytesPerChar;
         }
       }
-      SkipSpaces(remaining);
+      SkipSpaces(remaining, fastField);
     }
     return remaining;
   }
 
   RT_API_ATTRS Fortran::common::optional<char32_t> SkipSpaces(
-      Fortran::common::optional<int> &remaining) {
+      Fortran::common::optional<int> &remaining,
+      FastAsciiField *fastField = nullptr) {
     while (!remaining || *remaining > 0) {
       std::size_t byteCount{0};
-      if (auto ch{GetCurrentChar(byteCount)}) {
+      if (auto ch{GetCurrentChar(byteCount, fastField)}) {
         if (*ch != ' ' && *ch != '\t') {
           return ch;
         }
@@ -172,7 +247,11 @@ public:
           GotChar(byteCount);
           *remaining -= byteCount;
         }
-        HandleRelativePosition(byteCount);
+        if (fastField) {
+          fastField->Advance(0, byteCount);
+        } else {
+          HandleRelativePosition(byteCount);
+        }
       } else {
         break;
       }
@@ -183,25 +262,35 @@ public:
   // Acquires the next input character, respecting any applicable field width
   // or separator character.
   RT_API_ATTRS Fortran::common::optional<char32_t> NextInField(
-      Fortran::common::optional<int> &remaining, const DataEdit &);
+      Fortran::common::optional<int> &remaining, const DataEdit &,
+      FastAsciiField *field = nullptr);
 
   // Detect and signal any end-of-record condition after input.
   // Returns true if at EOR and remaining input should be padded with blanks.
-  RT_API_ATTRS bool CheckForEndOfRecord(std::size_t afterReading);
+  RT_API_ATTRS bool CheckForEndOfRecord(
+      std::size_t afterReading, const ConnectionState &);
 
   // Skips spaces, advances records, and ignores NAMELIST comments
   RT_API_ATTRS Fortran::common::optional<char32_t> GetNextNonBlank(
-      std::size_t &byteCount) {
-    auto ch{GetCurrentChar(byteCount)};
+      std::size_t &byteCount, FastAsciiField *fastField = nullptr) {
+    auto ch{GetCurrentChar(byteCount, fastField)};
     bool inNamelist{mutableModes().inNamelist};
     while (!ch || *ch == ' ' || *ch == '\t' || *ch == '\n' ||
         (inNamelist && *ch == '!')) {
       if (ch && (*ch == ' ' || *ch == '\t' || *ch == '\n')) {
-        HandleRelativePosition(byteCount);
-      } else if (!AdvanceRecord()) {
+        if (fastField) {
+          fastField->Advance(0, byteCount);
+        } else {
+          HandleRelativePosition(byteCount);
+        }
+      } else if (AdvanceRecord()) {
+        if (fastField) {
+          fastField->NextRecord(*this);
+        }
+      } else {
         return Fortran::common::nullopt;
       }
-      ch = GetCurrentChar(byteCount);
+      ch = GetCurrentChar(byteCount, fastField);
     }
     return ch;
   }

--- a/flang-rt/lib/runtime/connection.cpp
+++ b/flang-rt/lib/runtime/connection.cpp
@@ -9,36 +9,9 @@
 #include "flang-rt/runtime/connection.h"
 #include "flang-rt/runtime/environment.h"
 #include "flang-rt/runtime/io-stmt.h"
-#include <algorithm>
 
 namespace Fortran::runtime::io {
 RT_OFFLOAD_API_GROUP_BEGIN
-
-RT_API_ATTRS std::size_t ConnectionState::RemainingSpaceInRecord() const {
-  auto recl{recordLength.value_or(openRecl.value_or(
-      executionEnvironment.listDirectedOutputLineLengthLimit))};
-  return positionInRecord >= recl ? 0 : recl - positionInRecord;
-}
-
-RT_API_ATTRS bool ConnectionState::NeedAdvance(std::size_t width) const {
-  return positionInRecord > 0 && width > RemainingSpaceInRecord();
-}
-
-RT_API_ATTRS bool ConnectionState::IsAtEOF() const {
-  return endfileRecordNumber && currentRecordNumber >= *endfileRecordNumber;
-}
-
-RT_API_ATTRS bool ConnectionState::IsAfterEndfile() const {
-  return endfileRecordNumber && currentRecordNumber > *endfileRecordNumber;
-}
-
-RT_API_ATTRS void ConnectionState::HandleAbsolutePosition(std::int64_t n) {
-  positionInRecord = std::max(n, std::int64_t{0}) + leftTabLimit.value_or(0);
-}
-
-RT_API_ATTRS void ConnectionState::HandleRelativePosition(std::int64_t n) {
-  positionInRecord = std::max(leftTabLimit.value_or(0), positionInRecord + n);
-}
 
 SavedPosition::SavedPosition(IoStatementState &io) : io_{io} {
   ConnectionState &conn{io_.GetConnectionState()};

--- a/flang-rt/lib/runtime/io-api.cpp
+++ b/flang-rt/lib/runtime/io-api.cpp
@@ -1057,14 +1057,15 @@ bool IODEF(InputDescriptor)(Cookie cookie, const Descriptor &descriptor) {
 }
 
 bool IODEF(InputInteger)(Cookie cookie, std::int64_t &n, int kind) {
-  if (!cookie->CheckFormattedStmtType<Direction::Input>("InputInteger")) {
-    return false;
+  IoStatementState &io{*cookie};
+  if (io.BeginReadingRecord()) {
+    if (auto edit{io.GetNextDataEdit()}) {
+      return edit->descriptor == DataEdit::ListDirectedNullValue ||
+          EditIntegerInput(io, *edit, reinterpret_cast<void *>(&n), kind,
+              /*isSigned=*/true);
+    }
   }
-  StaticDescriptor<0> staticDescriptor;
-  Descriptor &descriptor{staticDescriptor.descriptor()};
-  descriptor.Establish(
-      TypeCategory::Integer, kind, reinterpret_cast<void *>(&n), 0);
-  return descr::DescriptorIO<Direction::Input>(*cookie, descriptor);
+  return false;
 }
 
 bool IODEF(InputReal32)(Cookie cookie, float &x) {

--- a/flang-rt/lib/runtime/io-stmt.cpp
+++ b/flang-rt/lib/runtime/io-stmt.cpp
@@ -596,7 +596,7 @@ ExternalFileUnit *IoStatementState::GetExternalFileUnit() const {
       [](auto &x) { return x.get().GetExternalFileUnit(); }, u_);
 }
 
-Fortran::common::optional<char32_t> IoStatementState::GetCurrentChar(
+Fortran::common::optional<char32_t> IoStatementState::GetCurrentCharSlow(
     std::size_t &byteCount) {
   const char *p{nullptr};
   std::size_t bytes{GetNextInputBytes(p)};
@@ -628,12 +628,24 @@ Fortran::common::optional<char32_t> IoStatementState::GetCurrentChar(
   }
 }
 
+IoStatementState::FastAsciiField IoStatementState::GetUpcomingFastAsciiField() {
+  ConnectionState &connection{GetConnectionState()};
+  if (!connection.isUTF8 && connection.internalIoCharKind <= 1) {
+    const char *p{nullptr};
+    if (std::size_t bytes{GetNextInputBytes(p)}) {
+      return FastAsciiField(connection, p, bytes);
+    }
+  }
+  return FastAsciiField(connection);
+}
+
 Fortran::common::optional<char32_t> IoStatementState::NextInField(
-    Fortran::common::optional<int> &remaining, const DataEdit &edit) {
+    Fortran::common::optional<int> &remaining, const DataEdit &edit,
+    FastAsciiField *field) {
   std::size_t byteCount{0};
   if (!remaining) { // Stream, list-directed, NAMELIST, &c.
-    if (auto next{GetCurrentChar(byteCount)}) {
-      if (edit.width.value_or(0) == 0) {
+    if (auto next{GetCurrentChar(byteCount, field)}) {
+      if ((*next < '0' || *next == ';') && edit.width.value_or(0) == 0) {
         // list-directed, NAMELIST, I0 &c., or width-free I/G:
         // check for separator character
         switch (*next) {
@@ -667,21 +679,30 @@ Fortran::common::optional<char32_t> IoStatementState::NextInField(
           break;
         }
       }
-      HandleRelativePosition(byteCount);
-      GotChar(byteCount);
+      if (field) {
+        field->Advance(1, byteCount);
+      } else {
+        HandleRelativePosition(byteCount);
+        GotChar(byteCount);
+      }
       return next;
     }
   } else if (*remaining > 0) {
-    if (auto next{GetCurrentChar(byteCount)}) {
+    if (auto next{GetCurrentChar(byteCount, field)}) {
       if (byteCount > static_cast<std::size_t>(*remaining)) {
         return Fortran::common::nullopt;
       }
       *remaining -= byteCount;
-      HandleRelativePosition(byteCount);
-      GotChar(byteCount);
+      if (field) {
+        field->Advance(1, byteCount);
+      } else {
+        HandleRelativePosition(byteCount);
+        GotChar(byteCount);
+      }
       return next;
     }
-    if (CheckForEndOfRecord(0)) { // do padding
+    if (CheckForEndOfRecord(0,
+            field ? field->connection() : GetConnectionState())) { // do padding
       --*remaining;
       return Fortran::common::optional<char32_t>{' '};
     }
@@ -689,8 +710,8 @@ Fortran::common::optional<char32_t> IoStatementState::NextInField(
   return Fortran::common::nullopt;
 }
 
-bool IoStatementState::CheckForEndOfRecord(std::size_t afterReading) {
-  const ConnectionState &connection{GetConnectionState()};
+bool IoStatementState::CheckForEndOfRecord(
+    std::size_t afterReading, const ConnectionState &connection) {
   if (!connection.IsAtEOF()) {
     if (auto length{connection.EffectiveRecordLength()}) {
       if (connection.positionInRecord +
@@ -799,7 +820,6 @@ Fortran::common::optional<DataEdit>
 ListDirectedStatementState<Direction::Input>::GetNextDataEdit(
     IoStatementState &io, int maxRepeat) {
   // N.B. list-directed transfers cannot be nonadvancing (C1221)
-  ConnectionState &connection{io.GetConnectionState()};
   DataEdit edit;
   edit.descriptor = DataEdit::ListDirected;
   edit.repeat = 1; // may be overridden below
@@ -840,14 +860,15 @@ ListDirectedStatementState<Direction::Input>::GetNextDataEdit(
     imaginaryPart_ = true;
     edit.descriptor = DataEdit::ListDirectedImaginaryPart;
   }
-  auto ch{io.GetNextNonBlank(byteCount)};
+  auto fastField{io.GetUpcomingFastAsciiField()};
+  auto ch{io.GetNextNonBlank(byteCount, &fastField)};
   if (ch && *ch == comma && eatComma_) {
     // Consume comma & whitespace after previous item.
     // This includes the comma between real and imaginary components
     // in list-directed/NAMELIST complex input.
     // (When DECIMAL='COMMA', the comma is actually a semicolon.)
-    io.HandleRelativePosition(byteCount);
-    ch = io.GetNextNonBlank(byteCount);
+    fastField.Advance(0, byteCount);
+    ch = io.GetNextNonBlank(byteCount, &fastField);
   }
   eatComma_ = true;
   if (!ch) {
@@ -865,8 +886,9 @@ ListDirectedStatementState<Direction::Input>::GetNextDataEdit(
   if (imaginaryPart_) { // can't repeat components
     return edit;
   }
-  if (*ch >= '0' && *ch <= '9') { // look for "r*" repetition count
-    auto start{connection.positionInRecord};
+  if (*ch >= '0' && *ch <= '9' && fastField.MightHaveAsterisk()) {
+    // look for "r*" repetition count
+    auto start{fastField.connection().positionInRecord};
     int r{0};
     do {
       static auto constexpr clamp{(std::numeric_limits<int>::max() - '9') / 10};
@@ -875,12 +897,12 @@ ListDirectedStatementState<Direction::Input>::GetNextDataEdit(
         break;
       }
       r = 10 * r + (*ch - '0');
-      io.HandleRelativePosition(byteCount);
-      ch = io.GetCurrentChar(byteCount);
+      fastField.Advance(0, byteCount);
+      ch = io.GetCurrentChar(byteCount, &fastField);
     } while (ch && *ch >= '0' && *ch <= '9');
     if (r > 0 && ch && *ch == '*') { // subtle: r must be nonzero
-      io.HandleRelativePosition(byteCount);
-      ch = io.GetCurrentChar(byteCount);
+      fastField.Advance(0, byteCount);
+      ch = io.GetCurrentChar(byteCount, &fastField);
       if (ch && *ch == '/') { // r*/
         hitSlash_ = true;
         edit.descriptor = DataEdit::ListDirectedNullValue;
@@ -895,12 +917,12 @@ ListDirectedStatementState<Direction::Input>::GetNextDataEdit(
         repeatPosition_.emplace(io);
       }
     } else { // not a repetition count, just an integer value; rewind
-      connection.positionInRecord = start;
+      fastField.connection().positionInRecord = start;
     }
   }
   if (!imaginaryPart_ && ch && *ch == '(') {
     realPart_ = true;
-    io.HandleRelativePosition(byteCount);
+    fastField.connection().HandleRelativePosition(byteCount);
     edit.descriptor = DataEdit::ListDirectedRealPart;
   }
   return edit;

--- a/flang/include/flang/Common/uint128.h
+++ b/flang/include/flang/Common/uint128.h
@@ -278,9 +278,11 @@ using SignedInt128 = Int128<true>;
 
 #if !AVOID_NATIVE_UINT128_T && (defined __GNUC__ || defined __clang__) && \
     defined __SIZEOF_INT128__
+#define USING_NATIVE_INT128_T 1
 using uint128_t = __uint128_t;
 using int128_t = __int128_t;
 #else
+#undef USING_NATIVE_INT128_T
 using uint128_t = UnsignedInt128;
 using int128_t = SignedInt128;
 #endif


### PR DESCRIPTION
Make some minor tweaks (inlining, caching) to the formatting input path to improve integer input in a SPEC code.  (None of the I/O library has been tuned yet for performance, and there are some easy optimizations for common cases.)  Input integer values are now calculated with native C/C++ 128-bit integers.

A benchmark that only reads about 5M lines of three integer values each speeds up from over 8 seconds to under 3 in my environment with these changeds.

If this works out, the code here can be used to optimize the formatted input paths for real and character data, too.

Fixes https://github.com/llvm/llvm-project/issues/134026.