### PR TITLE
[lldb][lldb-dap] Respect x86 disassembly flavor setting

### DIFF
--- a/lldb/source/Commands/CommandObjectDisassemble.cpp
+++ b/lldb/source/Commands/CommandObjectDisassemble.cpp
@@ -190,7 +190,7 @@ void CommandObjectDisassemble::CommandOptions::OptionParsingStarting(
     // architecture.  For now GetDisassemblyFlavor is really only valid for x86
     // (and for the llvm assembler plugin, but I'm papering over that since that
     // is the only disassembler plugin we have...
-    // this logic is also duplicated in `Handler/DisassembleRequestHandler`
+    // This logic is duplicated in `Handler/DisassembleRequestHandler`.
     if (target->GetArchitecture().GetTriple().getArch() == llvm::Triple::x86 ||
         target->GetArchitecture().GetTriple().getArch() ==
             llvm::Triple::x86_64) {

--- a/lldb/source/Commands/CommandObjectDisassemble.cpp
+++ b/lldb/source/Commands/CommandObjectDisassemble.cpp
@@ -190,6 +190,7 @@ void CommandObjectDisassemble::CommandOptions::OptionParsingStarting(
     // architecture.  For now GetDisassemblyFlavor is really only valid for x86
     // (and for the llvm assembler plugin, but I'm papering over that since that
     // is the only disassembler plugin we have...
+    // this logic is also duplicated in `Handler/DisassembleRequestHandler`
     if (target->GetArchitecture().GetTriple().getArch() == llvm::Triple::x86 ||
         target->GetArchitecture().GetTriple().getArch() ==
             llvm::Triple::x86_64) {

--- a/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
@@ -119,8 +119,7 @@ void DisassembleRequestHandler::operator()(
 
   std::string flavor_string;
   const auto target_triple = llvm::StringRef(dap.target.GetTriple());
-  // this handles both 32 and 64bit x86 architecture.
-  // this logic is also duplicated in
+  // This handles both 32 and 64bit x86 architecture. The logic is duplicated in
   // `CommandObjectDisassemble::CommandOptions::OptionParsingStarting`
   if (target_triple.starts_with("x86")) {
     const lldb::SBStructuredData flavor =

--- a/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
@@ -117,7 +117,7 @@ void DisassembleRequestHandler::operator()(
   const auto inst_count =
       GetInteger<int64_t>(arguments, "instructionCount").value_or(0);
 
-  std::string flavor_string{};
+  std::string flavor_string;
   const auto target_triple = llvm::StringRef(dap.target.GetTriple());
   // this handles both 32 and 64bit x86 architecture.
   // this logic is also duplicated in

--- a/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
@@ -119,7 +119,10 @@ void DisassembleRequestHandler::operator()(
 
   std::string flavor_string{};
   const auto target_triple = llvm::StringRef(dap.target.GetTriple());
-  if (target_triple.starts_with("x86_64") || target_triple.starts_with("x86")) {
+  // this handles both 32 and 64bit x86 architecture.
+  // this logic is also duplicated in
+  // `CommandObjectDisassemble::CommandOptions::OptionParsingStarting`
+  if (target_triple.starts_with("x86")) {
     const lldb::SBStructuredData flavor =
         dap.debugger.GetSetting("target.x86-disassembly-flavor");
 

--- a/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/DisassembleRequestHandler.cpp
@@ -116,7 +116,22 @@ void DisassembleRequestHandler::operator()(
 
   const auto inst_count =
       GetInteger<int64_t>(arguments, "instructionCount").value_or(0);
-  lldb::SBInstructionList insts = dap.target.ReadInstructions(addr, inst_count);
+
+  std::string flavor_string{};
+  const auto target_triple = llvm::StringRef(dap.target.GetTriple());
+  if (target_triple.starts_with("x86_64") || target_triple.starts_with("x86")) {
+    const lldb::SBStructuredData flavor =
+        dap.debugger.GetSetting("target.x86-disassembly-flavor");
+
+    const size_t str_length = flavor.GetStringValue(nullptr, 0);
+    if (str_length != 0) {
+      flavor_string.resize(str_length + 1);
+      flavor.GetStringValue(flavor_string.data(), flavor_string.length());
+    }
+  }
+
+  lldb::SBInstructionList insts =
+      dap.target.ReadInstructions(addr, inst_count, flavor_string.c_str());
 
   if (!insts.IsValid()) {
     response["success"] = false;


### PR DESCRIPTION
Ensure the disassembly respects the "target.x86-disassembly-flavor" setting for x86 and x86_64 targets.

Depends on #134626