### PR TITLE
[Flang][Windows] Disable PCH on Windows for flangFrontend

### DIFF
--- a/flang/lib/Frontend/CMakeLists.txt
+++ b/flang/lib/Frontend/CMakeLists.txt
@@ -73,10 +73,16 @@ add_flang_library(flangFrontend
   clangDriver
 )
 
-target_precompile_headers(flangFrontend PRIVATE
-  [["flang/Parser/parsing.h"]]
-  [["flang/Parser/parse-tree.h"]]
-  [["flang/Parser/dump-parse-tree.h"]]
-  [["flang/Lower/PFTBuilder.h"]]
-  [["flang/Lower/Bridge.h"]]
-)
+# Precompiled Headers for flangFrontend
+# Only enable PCH on non-Windows platforms, as the current usage of
+# target_precompile_headers appears fragile during incremental builds
+# involving CMake regeneration specifically on Windows.
+if(NOT WIN32)
+  target_precompile_headers(flangFrontend PRIVATE
+    [["flang/Parser/parsing.h"]]
+    [["flang/Parser/parse-tree.h"]]
+    [["flang/Parser/dump-parse-tree.h"]]
+    [["flang/Lower/PFTBuilder.h"]]
+    [["flang/Lower/Bridge.h"]]
+  )
+endif()


### PR DESCRIPTION
This patch fixes PCH staleness errors (fatal error: ... mtime changed) for flangFrontend during incremental Windows builds.

The error occurs because the automatic CMake re-run during incremental builds updates the timestamp of the PCH source file (cmake_pch.cxx) relative to the existing PCH artifact (.ph). This happens even without direct modifications to the headers listed for precompilation.

Apparently, flangFrontend is the only known LLVM target which uses target_precompile_headers, and this mechanism fails to reliably force a PCH rebuild after the CMake re-run in this Windows environment.

This was observed on https://lab.llvm.org/staging/#/builders/206/builds/1835 with following log

> AILED: tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/CompilerInstance.cpp.obj 
ccache C:\Users\tcwg\scoop\apps\llvm-arm64\current\bin\clang-cl.exe  /nologo -TP -DCLANG_BUILD_STATIC -DFLANG_INCLUDE_TESTS=1 -DGTEST_HAS_RTTI=0 -DUNICODE -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_GLIBCXX_ASSERTIONS -D_HAS_EXCEPTIONS=0 -D_SCL_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/lib/Frontend -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/include -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/include -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/include -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/llvm/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/../mlir/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/mlir/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/clang/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/llvm/../clang/include /DWIN32 /D_WINDOWS   /Zc:inline /Zc:__cplusplus /Oi /Brepro /bigobj /permissive- -Werror=unguarded-availability-new /W4  -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported /Gw -Wno-deprecated-copy -Wno-string-conversion -Wno-ctad-maybe-unsupported /O2 /Ob2  -std:c++17 -MD  /EHs-c- /GR- -UNDEBUG /YuC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/cmake_pch.hxx /FpC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/./cmake_pch.cxx.pch /FIC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/cmake_pch.hxx /showIncludes /Fotools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/CompilerInstance.cpp.obj /Fdtools\flang\lib\Frontend\CMakeFiles\flangFrontend.dir\flangFrontend.pdb -c -- C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/lib/Frontend/CompilerInstance.cpp
fatal error: file 'C:\Users\tcwg\llvm-worker\flang-arm64-windows-msvc\build\tools\flang\lib\Frontend\CMakeFiles\flangFrontend.dir\cmake_pch.cxx' has been modified since the precompiled header 'C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/./cmake_pch.cxx.pch' was built: mtime changed (was 1744031958, now 1744046904)
note: please rebuild precompiled header 'C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/./cmake_pch.cxx.pch'
1 error generated.
3.556 [695/9/104] Building CXX object tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/CompilerInvocation.cpp.obj
FAILED: tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/CompilerInvocation.cpp.obj 
ccache C:\Users\tcwg\scoop\apps\llvm-arm64\current\bin\clang-cl.exe  /nologo -TP -DCLANG_BUILD_STATIC -DFLANG_INCLUDE_TESTS=1 -DGTEST_HAS_RTTI=0 -DUNICODE -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_GLIBCXX_ASSERTIONS -D_HAS_EXCEPTIONS=0 -D_SCL_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/lib/Frontend -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/include -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/include -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/include -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/llvm/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/../mlir/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/mlir/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/clang/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/llvm/../clang/include /DWIN32 /D_WINDOWS   /Zc:inline /Zc:__cplusplus /Oi /Brepro /bigobj /permissive- -Werror=unguarded-availability-new /W4  -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported /Gw -Wno-deprecated-copy -Wno-string-conversion -Wno-ctad-maybe-unsupported /O2 /Ob2  -std:c++17 -MD  /EHs-c- /GR- -UNDEBUG /YuC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/cmake_pch.hxx /FpC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/./cmake_pch.cxx.pch /FIC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/cmake_pch.hxx /showIncludes /Fotools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/CompilerInvocation.cpp.obj /Fdtools\flang\lib\Frontend\CMakeFiles\flangFrontend.dir\flangFrontend.pdb -c -- C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/lib/Frontend/CompilerInvocation.cpp
fatal error: file 'C:\Users\tcwg\llvm-worker\flang-arm64-windows-msvc\build\tools\flang\lib\Frontend\CMakeFiles\flangFrontend.dir\cmake_pch.cxx' has been modified since the precompiled header 'C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/./cmake_pch.cxx.pch' was built: mtime changed (was 1744031958, now 1744046904)
note: please rebuild precompiled header 'C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/./cmake_pch.cxx.pch'
1 error generated.
3.563 [695/8/105] Building CXX object tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/CodeGenOptions.cpp.obj
FAILED: tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/CodeGenOptions.cpp.obj 
ccache C:\Users\tcwg\scoop\apps\llvm-arm64\current\bin\clang-cl.exe  /nologo -TP -DCLANG_BUILD_STATIC -DFLANG_INCLUDE_TESTS=1 -DGTEST_HAS_RTTI=0 -DUNICODE -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_GLIBCXX_ASSERTIONS -D_HAS_EXCEPTIONS=0 -D_SCL_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/lib/Frontend -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/include -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/include -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/include -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/llvm/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/../mlir/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/mlir/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/clang/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/llvm/../clang/include /DWIN32 /D_WINDOWS   /Zc:inline /Zc:__cplusplus /Oi /Brepro /bigobj /permissive- -Werror=unguarded-availability-new /W4  -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported /Gw -Wno-deprecated-copy -Wno-string-conversion -Wno-ctad-maybe-unsupported /O2 /Ob2  -std:c++17 -MD  /EHs-c- /GR- -UNDEBUG /YuC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/cmake_pch.hxx /FpC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/./cmake_pch.cxx.pch /FIC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/cmake_pch.hxx /showIncludes /Fotools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/CodeGenOptions.cpp.obj /Fdtools\flang\lib\Frontend\CMakeFiles\flangFrontend.dir\flangFrontend.pdb -c -- C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/lib/Frontend/CodeGenOptions.cpp
fatal error: file 'C:\Users\tcwg\llvm-worker\flang-arm64-windows-msvc\build\tools\flang\lib\Frontend\CMakeFiles\flangFrontend.dir\cmake_pch.cxx' has been modified since the precompiled header 'C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/./cmake_pch.cxx.pch' was built: mtime changed (was 1744031958, now 1744046904)
note: please rebuild precompiled header 'C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/./cmake_pch.cxx.pch'
1 error generated.
3.571 [695/7/106] Building CXX object tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/FrontendAction.cpp.obj
FAILED: tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/FrontendAction.cpp.obj 
ccache C:\Users\tcwg\scoop\apps\llvm-arm64\current\bin\clang-cl.exe  /nologo -TP -DCLANG_BUILD_STATIC -DFLANG_INCLUDE_TESTS=1 -DGTEST_HAS_RTTI=0 -DUNICODE -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_GLIBCXX_ASSERTIONS -D_HAS_EXCEPTIONS=0 -D_SCL_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/lib/Frontend -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/include -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/include -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/include -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/llvm/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/../mlir/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/mlir/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/clang/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/llvm/../clang/include /DWIN32 /D_WINDOWS   /Zc:inline /Zc:__cplusplus /Oi /Brepro /bigobj /permissive- -Werror=unguarded-availability-new /W4  -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported /Gw -Wno-deprecated-copy -Wno-string-conversion -Wno-ctad-maybe-unsupported /O2 /Ob2  -std:c++17 -MD  /EHs-c- /GR- -UNDEBUG /YuC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/cmake_pch.hxx /FpC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/./cmake_pch.cxx.pch /FIC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/cmake_pch.hxx /showIncludes /Fotools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/FrontendAction.cpp.obj /Fdtools\flang\lib\Frontend\CMakeFiles\flangFrontend.dir\flangFrontend.pdb -c -- C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/lib/Frontend/FrontendAction.cpp
fatal error: file 'C:\Users\tcwg\llvm-worker\flang-arm64-windows-msvc\build\tools\flang\lib\Frontend\CMakeFiles\flangFrontend.dir\cmake_pch.cxx' has been modified since the precompiled header 'C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/./cmake_pch.cxx.pch' was built: mtime changed (was 1744031958, now 1744046904)
note: please rebuild precompiled header 'C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/./cmake_pch.cxx.pch'
1 error generated.
3.575 [695/6/107] Building CXX object tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/ParserActions.cpp.obj
FAILED: tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/ParserActions.cpp.obj 
ccache C:\Users\tcwg\scoop\apps\llvm-arm64\current\bin\clang-cl.exe  /nologo -TP -DCLANG_BUILD_STATIC -DFLANG_INCLUDE_TESTS=1 -DGTEST_HAS_RTTI=0 -DUNICODE -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_GLIBCXX_ASSERTIONS -D_HAS_EXCEPTIONS=0 -D_SCL_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/lib/Frontend -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/include -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/include -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/include -IC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/llvm/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/../mlir/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/mlir/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/clang/include -imsvcC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/llvm/../clang/include /DWIN32 /D_WINDOWS   /Zc:inline /Zc:__cplusplus /Oi /Brepro /bigobj /permissive- -Werror=unguarded-availability-new /W4  -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported /Gw -Wno-deprecated-copy -Wno-string-conversion -Wno-ctad-maybe-unsupported /O2 /Ob2  -std:c++17 -MD  /EHs-c- /GR- -UNDEBUG /YuC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/cmake_pch.hxx /FpC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/./cmake_pch.cxx.pch /FIC:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/cmake_pch.hxx /showIncludes /Fotools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/ParserActions.cpp.obj /Fdtools\flang\lib\Frontend\CMakeFiles\flangFrontend.dir\flangFrontend.pdb -c -- C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/llvm-project/flang/lib/Frontend/ParserActions.cpp
fatal error: file 'C:\Users\tcwg\llvm-worker\flang-arm64-windows-msvc\build\tools\flang\lib\Frontend\CMakeFiles\flangFrontend.dir\cmake_pch.cxx' has been modified since the precompiled header 'C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/./cmake_pch.cxx.pch' was built: mtime changed (was 1744031958, now 1744046904)
note: please rebuild precompiled header 'C:/Users/tcwg/llvm-worker/flang-arm64-windows-msvc/build/tools/flang/lib/Frontend/CMakeFiles/flangFrontend.dir/./cmake_pch.cxx.pch'
1 error generated.