### PR TITLE
[docs][AMDGPU] Document amdgpu.buffer.oob.mode more, especially on fat pointers

### DIFF
--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -1352,7 +1352,7 @@ buffer fat pointers and buffer strided pointers) generally implement handling fo
 out of bounds (OOB) memory accesses, including those that are partially OOB,
 if the buffer resource resource has the required flags set. How ordinary
 ``load`` and ``store`` instructions are lowered to buffer operations is partly
-controlled by the ``amdgpu.buffer.oob.mode`` (see :ref:`_amdgpu_metadata`). If
+controlled by the ``amdgpu.buffer.oob.mode`` (see :ref:`amdgpu-module-flags`). If
 that flag is set to ``1`` (relaxed), no handling to improve the expected behavior
 of OOB accesses is performed, while if it is set to ``0`` (any) or ``2`` (strict),
 oerations may be spliit to ensure correctness under stronger models of how

--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -859,11 +859,14 @@ consumed by the AMDGPU backend during code generation.
          semantics. This is an alias of **strict** that is allowed to link
          with any other module. Code generation is identical to **strict**.
        - ``1``: **relaxed**. The backend may merge misaligned buffer
-         accesses for performance, even if that changes OOB behaviour.
+         accesses for performance, even if that changes OOB behaviour, and will
+         not split vector accesses that may produce unexpected OOB accesses.
        - ``2``: **strict**. The backend preserves per-byte OOB guarantees
          by preventing merging of misaligned buffer accesses that could
          straddle an OOB boundary (e.g. as required by Vulkan
-         ``robustBufferAccess2``).
+         ``robustBufferAccess2``) and by splitting vector accesses to buffer
+         fat pointers that may produce incorrect results under a robust buffer
+         access scheme. See `__amdgpu_fat_buffer_oob_handling` for details.
 
    * - ``amdgpu.tbuffer.oob.mode``
      - ``i32``
@@ -1338,6 +1341,46 @@ instruction with ``one-as`` sync scope is specified via
     ``singlethread-one-as`` Same as ``singlethread`` but only synchronizes with
                             other operations within the same address space.
     ======================= ===================================================
+
+.. __amdgpu_fat_buffer_oob_handling:
+
+Buffer Fat Pointer out of bounds (OOB) handling
+-----------------------------------------------
+
+Instructions that load from or store to buffer resources (and thus, by extension
+buffer fat pointers and buffer strided pointers) generally implement handling for
+out of bounds (OOB) memory accesses, including those that are partially OOB,
+if the buffer resource resource has the required flags set. How ordinary
+``load`` and ``store`` instructions are lowered to buffer operations is partly
+controlled by the ``amdgpu.buffer.oob.mode`` (see `__amdgpu_metadata`). If
+that flag is set to ``1`` (relaxed), no handling to improve the expected behavior
+of OOB accesses is performed, while if it is set to ``0`` (any) or ``2`` (strict),
+oerations may be spliit to ensure correctness under stronger models of how
+out-of-bounds accesses should behave.
+
+When operating on more than 32 bits of data, the ``voffset`` used for the access
+will be range-checked for each 32-bit word independently. This check uses saturating
+arithmetic and interprets the offset as an unsigned value.
+
+The behavior described above conflicts with the ABI requirements of certain graphics
+APIs that require out of bounds accesses to be handled strictly so that accessed
+that begin out of bounds but then access in-bounds elements (such as loading a
+``<4 x i32>`` beginning at offset ``-4``) still load the three in-bounds integers
+(producing ``<0, v0, v1, v2>`` and not ``<0, 0, 0, 0>``. So, under strict OOB
+handling, such an access will be split into four ``i32`` accesses.
+
+Similarly, buffer fat pointers permit operating types such as ``<8 x i8>`` which
+must be accessed (and bounds-checked) 4 bytes at a time. Non-word-aligned
+accesses to such types from near the end of a buffer resource (such as starting
+a load of an ``<8 x i8>`` from an offset of ``6`` on an 8-byte buffer) will treat
+the initial two bytes to be loaded/stored as out of bounds, even though, under
+a strict interpretation of the bounds-checking semantics, they would be in bounds.
+Under strict OOB handling, such a load will be split into a sequence of ``<2 x i16>``
+loads.
+
+.. note::
+These transformations do not impact intrinsic calls (calling
+``llvm.amdgcn.raw.buffer.*.t`` directly.
 
 Target Types
 ------------

--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -866,7 +866,7 @@ consumed by the AMDGPU backend during code generation.
          straddle an OOB boundary (e.g. as required by Vulkan
          ``robustBufferAccess2``) and by splitting vector accesses to buffer
          fat pointers that may produce incorrect results under a robust buffer
-         access scheme. See :ref:`_amdgpu_fat_buffer_oob_handling` for details.
+         access scheme. See :ref:`amdgpu-fat-buffer-oob-handling` for details.
 
    * - ``amdgpu.tbuffer.oob.mode``
      - ``i32``
@@ -1342,7 +1342,7 @@ instruction with ``one-as`` sync scope is specified via
                             other operations within the same address space.
     ======================= ===================================================
 
-.. _amdgpu_fat_buffer_oob_handling:
+.. _amdgpu-fat-buffer-oob-handling:
 
 Buffer Fat Pointer out of bounds (OOB) handling
 -----------------------------------------------

--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -1367,7 +1367,9 @@ APIs that require out of bounds accesses to be handled strictly so that accessed
 that begin out of bounds but then access in-bounds elements (such as loading a
 ``<4 x i32>`` beginning at offset ``-4``) still load the three in-bounds integers
 (producing ``<0, v0, v1, v2>`` and not ``<0, 0, 0, 0>``. So, under strict OOB
-handling, such an access will be split into four ``i32`` accesses.
+handling, such an access will be split into four ``i32`` accesses. Note this this
+can only happen for underaligned loads - such wraparound isn't possible for
+loads thatare alligned to their natural size.
 
 Similarly, buffer fat pointers permit operating types such as ``<8 x i8>`` which
 must be accessed (and bounds-checked) 4 bytes at a time. Non-word-aligned

--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -1379,8 +1379,9 @@ Under strict OOB handling, such a load will be split into a sequence of ``<2 x i
 loads.
 
 .. note::
-These transformations do not impact intrinsic calls (calling
-``llvm.amdgcn.raw.buffer.*.t`` directly.
+
+  These transformations do not impact buffer intrinsic calls (calling
+  ``llvm.amdgcn.raw.buffer.*`` directly).
 
 Target Types
 ------------

--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -866,7 +866,7 @@ consumed by the AMDGPU backend during code generation.
          straddle an OOB boundary (e.g. as required by Vulkan
          ``robustBufferAccess2``) and by splitting vector accesses to buffer
          fat pointers that may produce incorrect results under a robust buffer
-         access scheme. See `__amdgpu_fat_buffer_oob_handling` for details.
+         access scheme. See :ref:`_amdgpu_fat_buffer_oob_handling` for details.
 
    * - ``amdgpu.tbuffer.oob.mode``
      - ``i32``
@@ -1342,7 +1342,7 @@ instruction with ``one-as`` sync scope is specified via
                             other operations within the same address space.
     ======================= ===================================================
 
-.. __amdgpu_fat_buffer_oob_handling:
+.. _amdgpu_fat_buffer_oob_handling:
 
 Buffer Fat Pointer out of bounds (OOB) handling
 -----------------------------------------------
@@ -1352,7 +1352,7 @@ buffer fat pointers and buffer strided pointers) generally implement handling fo
 out of bounds (OOB) memory accesses, including those that are partially OOB,
 if the buffer resource resource has the required flags set. How ordinary
 ``load`` and ``store`` instructions are lowered to buffer operations is partly
-controlled by the ``amdgpu.buffer.oob.mode`` (see `__amdgpu_metadata`). If
+controlled by the ``amdgpu.buffer.oob.mode`` (see :ref:`_amdgpu_metadata`). If
 that flag is set to ``1`` (relaxed), no handling to improve the expected behavior
 of OOB accesses is performed, while if it is set to ``0`` (any) or ``2`` (strict),
 oerations may be spliit to ensure correctness under stronger models of how

--- a/llvm/docs/AMDGPUUsage.rst
+++ b/llvm/docs/AMDGPUUsage.rst
@@ -1355,7 +1355,7 @@ if the buffer resource resource has the required flags set. How ordinary
 controlled by the ``amdgpu.buffer.oob.mode`` (see :ref:`amdgpu-module-flags`). If
 that flag is set to ``1`` (relaxed), no handling to improve the expected behavior
 of OOB accesses is performed, while if it is set to ``0`` (any) or ``2`` (strict),
-oerations may be spliit to ensure correctness under stronger models of how
+operations may be split to ensure correctness under stronger models of how
 out-of-bounds accesses should behave.
 
 When operating on more than 32 bits of data, the ``voffset`` used for the access
@@ -1369,9 +1369,9 @@ that begin out of bounds but then access in-bounds elements (such as loading a
 (producing ``<0, v0, v1, v2>`` and not ``<0, 0, 0, 0>``. So, under strict OOB
 handling, such an access will be split into four ``i32`` accesses. Note this this
 can only happen for underaligned loads - such wraparound isn't possible for
-loads thatare alligned to their natural size.
+loads that are alligned to their natural size.
 
-Similarly, buffer fat pointers permit operating types such as ``<8 x i8>`` which
+Similarly, buffer fat pointers permit operating on types such as ``<8 x i8>`` which
 must be accessed (and bounds-checked) 4 bytes at a time. Non-word-aligned
 accesses to such types from near the end of a buffer resource (such as starting
 a load of an ``<8 x i8>`` from an offset of ``6`` on an 8-byte buffer) will treat
@@ -1382,8 +1382,10 @@ loads.
 
 .. note::
 
-  These transformations do not impact buffer intrinsic calls (calling
-  ``llvm.amdgcn.raw.buffer.*`` directly).
+  No attempt will be made to shrink buffer intrinsic calls (calling
+  ``llvm.amdgcn.raw.ptr.buffer.*`` directly) in order to cause them to meet the
+  requirements of strict OOB mode. However, in strict OOB mode, those intrinsics
+  will not be combined in a way that would violate the guarantees of that mode.
 
 Target Types
 ------------


### PR DESCRIPTION
This commit expands the documentation of the amdgpu.buffer.oob.mode so that fat buffer pointer users are aware of the implications of the change.