### PR TITLE
[NFC][clang-tidy] Remove {{^}} clauses in some tests (1/N)

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/performance/for-range-copy.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/for-range-copy.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s performance-for-range-copy %t -- -- -fno-delayed-template-parsing
+// RUN: %check_clang_tidy %s performance-for-range-copy %t -- -- -fno-delayed-template-parsing
 
 namespace std {
 
@@ -79,7 +79,7 @@ template <typename T>
 void uninstantiated() {
   for (const S S1 : View<Iterator<S>>()) {}
   // CHECK-MESSAGES: [[@LINE-1]]:16: warning: the loop variable's type is not a reference type; this creates a copy in each iteration; consider making this a reference [performance-for-range-copy]
-  // CHECK-FIXES: {{^}}  for (const S& S1 : View<Iterator<S>>()) {}
+  // CHECK-FIXES: for (const S& S1 : View<Iterator<S>>()) {}
 
   // Don't warn on dependent types.
   for (const T t1 : View<Iterator<T>>()) {
@@ -90,15 +90,15 @@ template <typename T>
 void instantiated() {
   for (const S S2 : View<Iterator<S>>()) {}
   // CHECK-MESSAGES: [[@LINE-1]]:16: warning: the loop variable's type is {{.*}}
-  // CHECK-FIXES: {{^}}  for (const S& S2 : View<Iterator<S>>()) {}
+  // CHECK-FIXES: for (const S& S2 : View<Iterator<S>>()) {}
 
   for (const auto [X, Y] : View<Iterator<Point>>()) {}
   // CHECK-MESSAGES: [[@LINE-1]]:19: warning: the loop variable's type is
-  // CHECK-FIXES: {{^}}  for (const auto& [X, Y] : View<Iterator<Point>>()) {}
+  // CHECK-FIXES: for (const auto& [X, Y] : View<Iterator<Point>>()) {}
 
   for (const T T2 : View<Iterator<T>>()) {}
   // CHECK-MESSAGES: [[@LINE-1]]:16: warning: the loop variable's type is {{.*}}
-  // CHECK-FIXES: {{^}}  for (const T& T2 : View<Iterator<T>>()) {}
+  // CHECK-FIXES: for (const T& T2 : View<Iterator<T>>()) {}
 }
 
 template <typename T>
@@ -311,10 +311,8 @@ View<Iterator<S>> createView(S) { return View<Iterator<S>>(); }
 
 void positiveValueIteratorUsedElseWhere() {
   for (const S SS : createView(*ValueReturningIterator<S>())) {
-    // CHECK-MESSAGES: [[@LINE-1]]:16: warning: the loop variable's type is not
-    // a reference type; this creates a copy in each iteration; consider making
-    // this a reference [performance-for-range-copy] CHECK-FIXES: for (const S&
-    // SS : createView(*ValueReturningIterator<S>())) {
+    // CHECK-MESSAGES: [[@LINE-1]]:16: warning: the loop variable's type is not a reference type; this creates a copy in each iteration; consider making this a reference [performance-for-range-copy]
+    // CHECK-FIXES: for (const S& SS : createView(*ValueReturningIterator<S>())) {
   }
 }
 

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/inefficient-algorithm.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/inefficient-algorithm.cpp
@@ -69,83 +69,83 @@ template <typename T> void f(const T &t) {
   std::set<int> s;
   find(s.begin(), s.end(), 46);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: this STL algorithm call should be
-  // CHECK-FIXES: {{^  }}s.find(46);{{$}}
+  // CHECK-FIXES: s.find(46);
 
   find(t.begin(), t.end(), 46);
-  // CHECK-FIXES: {{^  }}find(t.begin(), t.end(), 46);{{$}}
+  // CHECK-FIXES: find(t.begin(), t.end(), 46);
 }
 
 int main() {
   std::set<int> s;
   auto it = std::find(s.begin(), s.end(), 43);
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: this STL algorithm call should be replaced with a container method [performance-inefficient-algorithm]
-  // CHECK-FIXES: {{^  }}auto it = s.find(43);{{$}}
+  // CHECK-FIXES: auto it = s.find(43);
   auto c = count(s.begin(), s.end(), 43);
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: this STL algorithm call should be
-  // CHECK-FIXES: {{^  }}auto c = s.count(43);{{$}}
+  // CHECK-FIXES: auto c = s.count(43);
 
 #define SECOND(x, y, z) y
   SECOND(q,std::count(s.begin(), s.end(), 22),w);
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: this STL algorithm call should be
-  // CHECK-FIXES: {{^  }}SECOND(q,s.count(22),w);{{$}}
+  // CHECK-FIXES: SECOND(q,s.count(22),w);
 
   it = find_if(s.begin(), s.end(), [](int) { return false; });
 
   std::multiset<int> ms;
   find(ms.begin(), ms.end(), 46);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: this STL algorithm call should be
-  // CHECK-FIXES: {{^  }}ms.find(46);{{$}}
+  // CHECK-FIXES: ms.find(46);
 
   const std::multiset<int> &msref = ms;
   find(msref.begin(), msref.end(), 46);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: this STL algorithm call should be
-  // CHECK-FIXES: {{^  }}msref.find(46);{{$}}
+  // CHECK-FIXES: msref.find(46);
 
   std::multiset<int> *msptr = &ms;
   find(msptr->begin(), msptr->end(), 46);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: this STL algorithm call should be
-  // CHECK-FIXES: {{^  }}msptr->find(46);{{$}}
+  // CHECK-FIXES: msptr->find(46);
 
   it = std::find(s.begin(), s.end(), 43, std::greater<int>());
   // CHECK-MESSAGES: :[[@LINE-1]]:42: warning: different comparers used in the algorithm and the container [performance-inefficient-algorithm]
 
   FIND_IN_SET(s);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: this STL algorithm call should be
-  // CHECK-FIXES: {{^  }}FIND_IN_SET(s);{{$}}
+  // CHECK-FIXES: FIND_IN_SET(s);
 
   f(s);
 
   std::unordered_set<int> us;
   lower_bound(us.begin(), us.end(), 10);
-  // CHECK-FIXES: {{^  }}lower_bound(us.begin(), us.end(), 10);{{$}}
+  // CHECK-FIXES: lower_bound(us.begin(), us.end(), 10);
   find(us.begin(), us.end(), 10);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: this STL algorithm call should be
-  // CHECK-FIXES: {{^  }}us.find(10);{{$}}
+  // CHECK-FIXES: us.find(10);
 
   std::unordered_multiset<int> ums;
   find(ums.begin(), ums.end(), 10);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: this STL algorithm call should be
-  // CHECK-FIXES: {{^  }}ums.find(10);{{$}}
+  // CHECK-FIXES: ums.find(10);
 
   std::map<int, int> intmap;
   find(intmap.begin(), intmap.end(), 46);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: this STL algorithm call should be
-  // CHECK-FIXES: {{^  }}find(intmap.begin(), intmap.end(), 46);{{$}}
+  // CHECK-FIXES: find(intmap.begin(), intmap.end(), 46);
 
   std::multimap<int, int> intmmap;
   find(intmmap.begin(), intmmap.end(), 46);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: this STL algorithm call should be
-  // CHECK-FIXES: {{^  }}find(intmmap.begin(), intmmap.end(), 46);{{$}}
+  // CHECK-FIXES: find(intmmap.begin(), intmmap.end(), 46);
 
   std::unordered_map<int, int> umap;
   find(umap.begin(), umap.end(), 46);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: this STL algorithm call should be
-  // CHECK-FIXES: {{^  }}find(umap.begin(), umap.end(), 46);{{$}}
+  // CHECK-FIXES: find(umap.begin(), umap.end(), 46);
 
   std::unordered_multimap<int, int> ummap;
   find(ummap.begin(), ummap.end(), 46);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: this STL algorithm call should be
-  // CHECK-FIXES: {{^  }}find(ummap.begin(), ummap.end(), 46);{{$}}
+  // CHECK-FIXES: find(ummap.begin(), ummap.end(), 46);
 }
 
 struct Value {
@@ -162,5 +162,5 @@ struct Ordering {
 void g(std::set<Value, Ordering> container, int value) {
   lower_bound(container.begin(), container.end(), value, Ordering());
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: this STL algorithm call should be
-  // CHECK-FIXES: {{^  }}lower_bound(container.begin(), container.end(), value, Ordering());{{$}}
+  // CHECK-FIXES: lower_bound(container.begin(), container.end(), value, Ordering());
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/trivially-destructible.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/trivially-destructible.cpp
@@ -21,7 +21,7 @@ struct NotTriviallyDestructible1 : TriviallyDestructible2 {
 
 NotTriviallyDestructible1::~NotTriviallyDestructible1() = default; // to-be-removed
 // CHECK-MESSAGES: :[[@LINE-1]]:28: note: destructor definition is here
-// CHECK-FIXES: {{^}}// to-be-removed
+// CHECK-FIXES: // to-be-removed
 
 // Don't emit for class template with type-dependent fields.
 template <class T>
@@ -57,7 +57,7 @@ struct MaybeTriviallyDestructible1<T *> {
 template <class T>
 MaybeTriviallyDestructible1<T *>::~MaybeTriviallyDestructible1() noexcept = default; // to-be-removed
 // CHECK-MESSAGES: :[[@LINE-1]]:35: note: destructor definition is here
-// CHECK-FIXES: {{^}}// to-be-removed
+// CHECK-FIXES: // to-be-removed
 
 // Emit for explicit specializations.
 template <>
@@ -69,7 +69,7 @@ struct MaybeTriviallyDestructible1<double>: TriviallyDestructible1 {
 
 MaybeTriviallyDestructible1<double>::~MaybeTriviallyDestructible1() noexcept = default; // to-be-removed
 // CHECK-MESSAGES: :[[@LINE-1]]:38: note: destructor definition is here
-// CHECK-FIXES: {{^}}// to-be-removed
+// CHECK-FIXES: // to-be-removed
 
 struct NotTriviallyDestructible2 {
   virtual ~NotTriviallyDestructible2();

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/type-promotion-in-math-fn.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/type-promotion-in-math-fn.cpp
@@ -67,169 +67,169 @@ void check_all_fns() {
 
   acos(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'acos' promotes float to double [performance-type-promotion-in-math-fn]
-  // CHECK-FIXES: {{^}}  std::acos(a);{{$}}
+  // CHECK-FIXES: std::acos(a);
   acosh(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'acosh'
-  // CHECK-FIXES: {{^}}  std::acosh(a);{{$}}
+  // CHECK-FIXES: std::acosh(a);
   asin(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'asin'
-  // CHECK-FIXES: {{^}}  std::asin(a);{{$}}
+  // CHECK-FIXES: std::asin(a);
   asinh(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'asinh'
-  // CHECK-FIXES: {{^}}  std::asinh(a);{{$}}
+  // CHECK-FIXES: std::asinh(a);
   atan2(a, b);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'atan2'
-  // CHECK-FIXES: {{^}}  std::atan2(a, b);{{$}}
+  // CHECK-FIXES: std::atan2(a, b);
   atan(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'atan'
-  // CHECK-FIXES: {{^}}  std::atan(a);{{$}}
+  // CHECK-FIXES: std::atan(a);
   atanh(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'atanh'
-  // CHECK-FIXES: {{^}}  std::atanh(a);{{$}}
+  // CHECK-FIXES: std::atanh(a);
   cbrt(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'cbrt'
-  // CHECK-FIXES: {{^}}  std::cbrt(a);{{$}}
+  // CHECK-FIXES: std::cbrt(a);
   ceil(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'ceil'
-  // CHECK-FIXES: {{^}}  std::ceil(a);{{$}}
+  // CHECK-FIXES: std::ceil(a);
   copysign(a, b);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'copysign'
-  // CHECK-FIXES: {{^}}  std::copysign(a, b);{{$}}
+  // CHECK-FIXES: std::copysign(a, b);
   cos(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'cos'
-  // CHECK-FIXES: {{^}}  std::cos(a);{{$}}
+  // CHECK-FIXES: std::cos(a);
   cosh(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'cosh'
-  // CHECK-FIXES: {{^}}  std::cosh(a);{{$}}
+  // CHECK-FIXES: std::cosh(a);
   erf(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'erf'
-  // CHECK-FIXES: {{^}}  std::erf(a);{{$}}
+  // CHECK-FIXES: std::erf(a);
   erfc(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'erfc'
-  // CHECK-FIXES: {{^}}  std::erfc(a);{{$}}
+  // CHECK-FIXES: std::erfc(a);
   exp2(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'exp2'
-  // CHECK-FIXES: {{^}}  std::exp2(a);{{$}}
+  // CHECK-FIXES: std::exp2(a);
   exp(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'exp'
-  // CHECK-FIXES: {{^}}  std::exp(a);{{$}}
+  // CHECK-FIXES: std::exp(a);
   expm1(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'expm1'
-  // CHECK-FIXES: {{^}}  std::expm1(a);{{$}}
+  // CHECK-FIXES: std::expm1(a);
   fabs(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'fabs'
-  // CHECK-FIXES: {{^}}  std::fabs(a);{{$}}
+  // CHECK-FIXES: std::fabs(a);
   fdim(a, b);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'fdim'
-  // CHECK-FIXES: {{^}}  std::fdim(a, b);{{$}}
+  // CHECK-FIXES: std::fdim(a, b);
   floor(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'floor'
-  // CHECK-FIXES: {{^}}  std::floor(a);{{$}}
+  // CHECK-FIXES: std::floor(a);
   fma(a, b, c);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'fma'
-  // CHECK-FIXES: {{^}}  std::fma(a, b, c);{{$}}
+  // CHECK-FIXES: std::fma(a, b, c);
   fmax(a, b);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'fmax'
-  // CHECK-FIXES: {{^}}  std::fmax(a, b);{{$}}
+  // CHECK-FIXES: std::fmax(a, b);
   fmin(a, b);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'fmin'
-  // CHECK-FIXES: {{^}}  std::fmin(a, b);{{$}}
+  // CHECK-FIXES: std::fmin(a, b);
   fmod(a, b);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'fmod'
-  // CHECK-FIXES: {{^}}  std::fmod(a, b);{{$}}
+  // CHECK-FIXES: std::fmod(a, b);
   frexp(a, int_ptr);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'frexp'
-  // CHECK-FIXES: {{^}}  std::frexp(a, int_ptr);{{$}}
+  // CHECK-FIXES: std::frexp(a, int_ptr);
   hypot(a, b);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'hypot'
-  // CHECK-FIXES: {{^}}  std::hypot(a, b);{{$}}
+  // CHECK-FIXES: std::hypot(a, b);
   ilogb(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'ilogb'
-  // CHECK-FIXES: {{^}}  std::ilogb(a);{{$}}
+  // CHECK-FIXES: std::ilogb(a);
   ldexp(a, b);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'ldexp'
-  // CHECK-FIXES: {{^}}  std::ldexp(a, b);{{$}}
+  // CHECK-FIXES: std::ldexp(a, b);
   lgamma(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'lgamma'
-  // CHECK-FIXES: {{^}}  std::lgamma(a);{{$}}
+  // CHECK-FIXES: std::lgamma(a);
   llrint(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'llrint'
-  // CHECK-FIXES: {{^}}  std::llrint(a);{{$}}
+  // CHECK-FIXES: std::llrint(a);
   llround(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'llround'
-  // CHECK-FIXES: {{^}}  std::llround(a);{{$}}
+  // CHECK-FIXES: std::llround(a);
   log10(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'log10'
-  // CHECK-FIXES: {{^}}  std::log10(a);{{$}}
+  // CHECK-FIXES: std::log10(a);
   log1p(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'log1p'
-  // CHECK-FIXES: {{^}}  std::log1p(a);{{$}}
+  // CHECK-FIXES: std::log1p(a);
   log2(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'log2'
-  // CHECK-FIXES: {{^}}  std::log2(a);{{$}}
+  // CHECK-FIXES: std::log2(a);
   log(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'log'
-  // CHECK-FIXES: {{^}}  std::log(a);{{$}}
+  // CHECK-FIXES: std::log(a);
   logb(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'logb'
-  // CHECK-FIXES: {{^}}  std::logb(a);{{$}}
+  // CHECK-FIXES: std::logb(a);
   lrint(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'lrint'
-  // CHECK-FIXES: {{^}}  std::lrint(a);{{$}}
+  // CHECK-FIXES: std::lrint(a);
   lround(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'lround'
-  // CHECK-FIXES: {{^}}  std::lround(a);{{$}}
+  // CHECK-FIXES: std::lround(a);
   nearbyint(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'nearbyint'
-  // CHECK-FIXES: {{^}}  std::nearbyint(a);{{$}}
+  // CHECK-FIXES: std::nearbyint(a);
   nextafter(a, b);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'nextafter'
-  // CHECK-FIXES: {{^}}  std::nextafter(a, b);{{$}}
+  // CHECK-FIXES: std::nextafter(a, b);
   nexttoward(a, b);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'nexttoward'
-  // CHECK-FIXES: {{^}}  std::nexttoward(a, b);{{$}}
+  // CHECK-FIXES: std::nexttoward(a, b);
   pow(a, b);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'pow'
-  // CHECK-FIXES: {{^}}  std::pow(a, b);{{$}}
+  // CHECK-FIXES: std::pow(a, b);
   remainder(a, b);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'remainder'
-  // CHECK-FIXES: {{^}}  std::remainder(a, b);{{$}}
+  // CHECK-FIXES: std::remainder(a, b);
   remquo(a, b, int_ptr);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'remquo'
-  // CHECK-FIXES: {{^}}  std::remquo(a, b, int_ptr);{{$}}
+  // CHECK-FIXES: std::remquo(a, b, int_ptr);
   rint(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'rint'
-  // CHECK-FIXES: {{^}}  std::rint(a);{{$}}
+  // CHECK-FIXES: std::rint(a);
   round(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'round'
-  // CHECK-FIXES: {{^}}  std::round(a);{{$}}
+  // CHECK-FIXES: std::round(a);
   scalbln(a, l);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'scalbln'
-  // CHECK-FIXES: {{^}}  std::scalbln(a, l);{{$}}
+  // CHECK-FIXES: std::scalbln(a, l);
   scalbn(a, i);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'scalbn'
-  // CHECK-FIXES: {{^}}  std::scalbn(a, i);{{$}}
+  // CHECK-FIXES: std::scalbn(a, i);
   sin(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'sin'
-  // CHECK-FIXES: {{^}}  std::sin(a);{{$}}
+  // CHECK-FIXES: std::sin(a);
   sinh(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'sinh'
-  // CHECK-FIXES: {{^}}  std::sinh(a);{{$}}
+  // CHECK-FIXES: std::sinh(a);
   sqrt(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'sqrt'
-  // CHECK-FIXES: {{^}}  std::sqrt(a);{{$}}
+  // CHECK-FIXES: std::sqrt(a);
   tan(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'tan'
-  // CHECK-FIXES: {{^}}  std::tan(a);{{$}}
+  // CHECK-FIXES: std::tan(a);
   tanh(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'tanh'
-  // CHECK-FIXES: {{^}}  std::tanh(a);{{$}}
+  // CHECK-FIXES: std::tanh(a);
   tgamma(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'tgamma'
-  // CHECK-FIXES: {{^}}  std::tgamma(a);{{$}}
+  // CHECK-FIXES: std::tgamma(a);
   trunc(a);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'trunc'
-  // CHECK-FIXES: {{^}}  std::trunc(a);{{$}}
+  // CHECK-FIXES: std::trunc(a);
 }
 
 // nexttoward/nexttowardf are weird -- the second param is always long double.
@@ -237,16 +237,16 @@ void check_all_fns() {
 void check_nexttoward() {
   nexttoward(0.f, 0);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'nexttoward'
-  // CHECK-FIXES: {{^}}  std::nexttoward(0.f, 0);{{$}}
+  // CHECK-FIXES: std::nexttoward(0.f, 0);
   nexttoward(0.f, 0l);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'nexttoward'
-  // CHECK-FIXES: {{^}}  std::nexttoward(0.f, 0l);{{$}}
+  // CHECK-FIXES: std::nexttoward(0.f, 0l);
   nexttoward(0.f, 0.f);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'nexttoward'
-  // CHECK-FIXES: {{^}}  std::nexttoward(0.f, 0.f);{{$}}
+  // CHECK-FIXES: std::nexttoward(0.f, 0.f);
   nexttoward(0.f, 0.);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'nexttoward'
-  // CHECK-FIXES: {{^}}  std::nexttoward(0.f, 0.);{{$}}
+  // CHECK-FIXES: std::nexttoward(0.f, 0.);
 
   // No warnings for these.
   nexttoward(0., 0);
@@ -259,10 +259,10 @@ void check_nexttoward() {
 void check_scalbn() {
   scalbn(0.f, 0);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'scalbn'
-  // CHECK-FIXES: {{^}}  std::scalbn(0.f, 0);{{$}}
+  // CHECK-FIXES: std::scalbn(0.f, 0);
   scalbn(0.f, static_cast<char>(0));
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'scalbn'
-  // CHECK-FIXES: {{^}}  std::scalbn(0.f, static_cast<char>(0));{{$}}
+  // CHECK-FIXES: std::scalbn(0.f, static_cast<char>(0));
 
   // No warnings for these.
   scalbn(0., 0);
@@ -275,10 +275,10 @@ void check_scalbn() {
 void check_scalbln() {
   scalbln(0.f, 0);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'scalbln'
-  // CHECK-FIXES: {{^}}  std::scalbln(0.f, 0);{{$}}
+  // CHECK-FIXES: std::scalbln(0.f, 0);
   scalbln(0.f, 0l);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: call to 'scalbln'
-  // CHECK-FIXES: {{^}}  std::scalbln(0.f, 0l);{{$}}
+  // CHECK-FIXES: std::scalbln(0.f, 0l);
 
   // No warnings for these.
   scalbln(0., 0);

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/delete-null-pointer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/delete-null-pointer.cpp
@@ -10,7 +10,7 @@ struct Templ {
       delete mem;
     // CHECK-MESSAGES: :[[@LINE-2]]:5: warning: 'if' statement is unnecessary;
     // CHECK-FIXES: // t1
-    // CHECK-FIXES-NEXT: {{^    }}// t2
+    // CHECK-FIXES-NEXT: // t2
     // CHECK-FIXES-NEXT: delete mem;
   }
   T mem;
@@ -24,7 +24,7 @@ struct TemplPtr {
       delete mem;
     // CHECK-MESSAGES: :[[@LINE-2]]:5: warning: 'if' statement is unnecessary;
     // CHECK-FIXES: // t3
-    // CHECK-FIXES-NEXT: {{^    }}// t4
+    // CHECK-FIXES-NEXT: // t4
     // CHECK-FIXES-NEXT: delete mem;
   }
   T *mem;
@@ -45,7 +45,7 @@ struct NeverInstantiated {
       delete mem;
     // CHECK-MESSAGES: :[[@LINE-2]]:5: warning: 'if' statement is unnecessary;
     // CHECK-FIXES: // t1
-    // CHECK-FIXES-NEXT: {{^    }}// t2
+    // CHECK-FIXES-NEXT: // t2
     // CHECK-FIXES-NEXT: delete mem;
   }
   T mem;
@@ -59,7 +59,7 @@ struct NeverInstantiatedPtr {
       delete mem;
     // CHECK-MESSAGES: :[[@LINE-2]]:5: warning: 'if' statement is unnecessary;
     // CHECK-FIXES: // t3
-    // CHECK-FIXES-NEXT: {{^    }}// t4
+    // CHECK-FIXES-NEXT: // t4
     // CHECK-FIXES-NEXT: delete mem;
   }
   T *mem;
@@ -72,7 +72,7 @@ void f() {
   // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: 'if' statement is unnecessary; deleting null pointer has no effect [readability-delete-null-pointer]
 
   // CHECK-FIXES: int *ps = 0;
-  // CHECK-FIXES-NEXT: {{^  }}// #0
+  // CHECK-FIXES-NEXT: // #0
   // CHECK-FIXES-NEXT: delete ps;
 
   int *p = 0;
@@ -83,10 +83,10 @@ void f() {
   } // #3
   // CHECK-MESSAGES: :[[@LINE-3]]:3: warning: 'if' statement is unnecessary; deleting null pointer has no effect [readability-delete-null-pointer]
 
-  // CHECK-FIXES: {{^  }}// #1
-  // CHECK-FIXES-NEXT: {{^  }}// #2
+  // CHECK-FIXES: // #1
+  // CHECK-FIXES-NEXT: // #2
   // CHECK-FIXES-NEXT: delete p;
-  // CHECK-FIXES-NEXT: {{^  }}// #3
+  // CHECK-FIXES-NEXT: // #3
 
   int *p2 = new int[3];
   // #4
@@ -95,7 +95,7 @@ void f() {
   // CHECK-MESSAGES: :[[@LINE-2]]:3: warning: 'if' statement is unnecessary;
 
   // CHECK-FIXES: // #4
-  // CHECK-FIXES-NEXT: {{^  }}// #5
+  // CHECK-FIXES-NEXT: // #5
   // CHECK-FIXES-NEXT: delete[] p2;
 
   int *p3 = 0;
@@ -136,7 +136,7 @@ void f() {
       if (mp) // #6
         delete mp;
       // CHECK-MESSAGES: :[[@LINE-2]]:7: warning: 'if' statement is unnecessary; deleting null pointer has no effect [readability-delete-null-pointer]
-      // CHECK-FIXES: {{^      }}// #6
+      // CHECK-FIXES: // #6
       // CHECK-FIXES-NEXT: delete mp;
     }
     int *mp;

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/else-after-return-no-warn.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/else-after-return-no-warn.cpp
@@ -20,12 +20,12 @@ int lifeTimeExtensionTests(int a) {
     b++;
   }
   if (int b = a) { // comment-0
-    // CHECK-FIXES:      {{^}}  int b = a;
-    // CHECK-FIXES-NEXT: {{^}}if (b) { // comment-0
+    // CHECK-FIXES:      int b = a;
+    // CHECK-FIXES-NEXT: if (b) { // comment-0
     return a;
   } else { // comment-0
            // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: do not use 'else' after 'return'
-           // CHECK-FIXES: {{^}}  } // comment-0
+           // CHECK-FIXES: } // comment-0
     return b;
   }
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-hungarian-notation-lower-case-prefix.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-hungarian-notation-lower-case-prefix.cpp
@@ -11,164 +11,164 @@ class C_MyClass1 {
 public:
   static int ClassMemberCase;
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for class member 'ClassMemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  static int i_ClassMemberCase;
+  // CHECK-FIXES: static int i_ClassMemberCase;
 
   char const ConstantMemberCase = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for constant member 'ConstantMemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char const c_ConstantMemberCase = 0;
+  // CHECK-FIXES: char const c_ConstantMemberCase = 0;
 
   void MyFunc1(const int ConstantParameterCase);
   // CHECK-MESSAGES: :[[@LINE-1]]:26: warning: invalid case style for constant parameter 'ConstantParameterCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  void MyFunc1(const int i_ConstantParameterCase);
+  // CHECK-FIXES: void MyFunc1(const int i_ConstantParameterCase);
 
   void MyFunc2(const int* ConstantPointerParameterCase);
   // CHECK-MESSAGES: :[[@LINE-1]]:27: warning: invalid case style for pointer parameter 'ConstantPointerParameterCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  void MyFunc2(const int* pi_ConstantPointerParameterCase);
+  // CHECK-FIXES: void MyFunc2(const int* pi_ConstantPointerParameterCase);
 
   static constexpr int ConstexprVariableCase = 123;
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: invalid case style for constexpr variable 'ConstexprVariableCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  static constexpr int i_ConstexprVariableCase = 123;
+  // CHECK-FIXES: static constexpr int i_ConstexprVariableCase = 123;
 };
 
 const int GlobalConstantCase = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for global constant 'GlobalConstantCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const int i_GlobalConstantCase = 0;
+// CHECK-FIXES: const int i_GlobalConstantCase = 0;
 
 const int* GlobalConstantPointerCase = nullptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global pointer 'GlobalConstantPointerCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const int* pi_GlobalConstantPointerCase = nullptr;
+// CHECK-FIXES: const int* pi_GlobalConstantPointerCase = nullptr;
 
 int* GlobalPointerCase = nullptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global pointer 'GlobalPointerCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int* pi_GlobalPointerCase = nullptr;
+// CHECK-FIXES: int* pi_GlobalPointerCase = nullptr;
 
 int GlobalVariableCase = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'GlobalVariableCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int i_GlobalVariableCase = 0;
+// CHECK-FIXES: int i_GlobalVariableCase = 0;
 
 void Func1(){
   int const LocalConstantCase = 3;
   // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for local constant 'LocalConstantCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  int const i_LocalConstantCase = 3;
+  // CHECK-FIXES: int const i_LocalConstantCase = 3;
 
   unsigned const ConstantCase = 1;
   // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for local constant 'ConstantCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  unsigned const u_ConstantCase = 1;
+  // CHECK-FIXES: unsigned const u_ConstantCase = 1;
 
   int* const LocalConstantPointerCase = nullptr;
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for local constant pointer 'LocalConstantPointerCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  int* const pi_LocalConstantPointerCase = nullptr;
+  // CHECK-FIXES: int* const pi_LocalConstantPointerCase = nullptr;
 
   int *LocalPointerCase = nullptr;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for local pointer 'LocalPointerCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  int *pi_LocalPointerCase = nullptr;
+  // CHECK-FIXES: int *pi_LocalPointerCase = nullptr;
 
   int LocalVariableCase = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for local variable 'LocalVariableCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  int i_LocalVariableCase = 0;
+  // CHECK-FIXES: int i_LocalVariableCase = 0;
 }
 
 class C_MyClass2 {
   char MemberCase;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for private member 'MemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char c_MemberCase;
+  // CHECK-FIXES: char c_MemberCase;
 
   void Func1(int ParameterCase);
   // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for parameter 'ParameterCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  void Func1(int i_ParameterCase);
+  // CHECK-FIXES: void Func1(int i_ParameterCase);
 
   void Func2(const int ParameterCase);
   // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: invalid case style for constant parameter 'ParameterCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  void Func2(const int i_ParameterCase);
+  // CHECK-FIXES: void Func2(const int i_ParameterCase);
 
   void Func3(const int *PointerParameterCase);
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: invalid case style for pointer parameter 'PointerParameterCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  void Func3(const int *pi_PointerParameterCase);
+  // CHECK-FIXES: void Func3(const int *pi_PointerParameterCase);
 };
 
 class C_MyClass3 {
 private:
   char PrivateMemberCase;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for private member 'PrivateMemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char c_PrivateMemberCase;
+  // CHECK-FIXES: char c_PrivateMemberCase;
 
 protected:
   char ProtectedMemberCase;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for protected member 'ProtectedMemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char c_ProtectedMemberCase;
+  // CHECK-FIXES: char c_ProtectedMemberCase;
 
 public:
   char PublicMemberCase;
   // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for public member 'PublicMemberCase' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char c_PublicMemberCase;
+  // CHECK-FIXES: char c_PublicMemberCase;
 };
 
 static const int StaticConstantCase = 3;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for global constant 'StaticConstantCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}static const int i_StaticConstantCase = 3;
+// CHECK-FIXES: static const int i_StaticConstantCase = 3;
 
 static int StaticVariableCase = 3;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'StaticVariableCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}static int i_StaticVariableCase = 3;
+// CHECK-FIXES: static int i_StaticVariableCase = 3;
 
 struct MyStruct { int StructCase; };
 // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: invalid case style for public member 'StructCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}struct MyStruct { int i_StructCase; };
+// CHECK-FIXES: struct MyStruct { int i_StructCase; };
 
 struct shouldBeCamelCaseStruct { int i_Field; };
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for struct 'shouldBeCamelCaseStruct' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}struct ShouldBeCamelCaseStruct { int i_Field; };
+// CHECK-FIXES: struct ShouldBeCamelCaseStruct { int i_Field; };
 
 union MyUnion { int UnionCase; long l_UnionCase; };
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for union 'MyUnion' [readability-identifier-naming]
 // CHECK-MESSAGES: :[[@LINE-2]]:21: warning: invalid case style for public member 'UnionCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}union myUnion { int i_UnionCase; long l_UnionCase; };
+// CHECK-FIXES: union myUnion { int i_UnionCase; long l_UnionCase; };
 
 //===----------------------------------------------------------------------===//
 // C string
 //===----------------------------------------------------------------------===//
 const char *NamePtr = "Name";
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global pointer 'NamePtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const char *sz_NamePtr = "Name";
+// CHECK-FIXES: const char *sz_NamePtr = "Name";
 
 const char NameArray[] = "Name";
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global constant 'NameArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const char sz_NameArray[] = "Name";
+// CHECK-FIXES: const char sz_NameArray[] = "Name";
 
 const char *NamePtrArray[] = {"AA", "BB"};
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global variable 'NamePtrArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const char *psz_NamePtrArray[] = {"AA", "BB"};
+// CHECK-FIXES: const char *psz_NamePtrArray[] = {"AA", "BB"};
 
 const wchar_t *WideNamePtr = L"Name";
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global pointer 'WideNamePtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const wchar_t *wsz_WideNamePtr = L"Name";
+// CHECK-FIXES: const wchar_t *wsz_WideNamePtr = L"Name";
 
 const wchar_t WideNameArray[] = L"Name";
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for global constant 'WideNameArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const wchar_t wsz_WideNameArray[] = L"Name";
+// CHECK-FIXES: const wchar_t wsz_WideNameArray[] = L"Name";
 
 const wchar_t *WideNamePtrArray[] = {L"AA", L"BB"};
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global variable 'WideNamePtrArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const wchar_t *pwsz_WideNamePtrArray[] = {L"AA", L"BB"};
+// CHECK-FIXES: const wchar_t *pwsz_WideNamePtrArray[] = {L"AA", L"BB"};
 
 class C_MyClass4 {
 private:
   char *Name = "Text";
   // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for private member 'Name' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  char *sz_Name = "Text";
+  // CHECK-FIXES: char *sz_Name = "Text";
 
   const char *ConstName = "Text";
   // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for private member 'ConstName' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  const char *sz_ConstName = "Text";
+  // CHECK-FIXES: const char *sz_ConstName = "Text";
 
 public:
   const char* DuplicateString(const char* Input, size_t n_RequiredSize);
   // CHECK-MESSAGES: :[[@LINE-1]]:43: warning: invalid case style for pointer parameter 'Input' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  const char* DuplicateString(const char* sz_Input, size_t n_RequiredSize);
+  // CHECK-FIXES: const char* DuplicateString(const char* sz_Input, size_t n_RequiredSize);
 
   size_t UpdateText(const char* Buffer, size_t n_BufferSize);
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: invalid case style for pointer parameter 'Buffer' [readability-identifier-naming]
-  // CHECK-FIXES: {{^}}  size_t UpdateText(const char* sz_Buffer, size_t n_BufferSize);
+  // CHECK-FIXES: size_t UpdateText(const char* sz_Buffer, size_t n_BufferSize);
 };
 
 
@@ -177,123 +177,123 @@ public:
 //===----------------------------------------------------------------------===//
 DWORD MsDword = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsDword' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}DWORD dw_MsDword = 0;
+// CHECK-FIXES: DWORD dw_MsDword = 0;
 
 BYTE MsByte = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsByte' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}BYTE by_MsByte = 0;
+// CHECK-FIXES: BYTE by_MsByte = 0;
 
 WORD MsWord = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsWord' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}WORD w_MsWord = 0;
+// CHECK-FIXES: WORD w_MsWord = 0;
 
 BOOL MsBool = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsBool' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}BOOL b_MsBool = 0;
+// CHECK-FIXES: BOOL b_MsBool = 0;
 
 BOOLEAN MsBoolean = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsBoolean' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}BOOLEAN b_MsBoolean = 0;
+// CHECK-FIXES: BOOLEAN b_MsBoolean = 0;
 
 CHAR MsValueChar = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueChar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}CHAR c_MsValueChar = 0;
+// CHECK-FIXES: CHAR c_MsValueChar = 0;
 
 UCHAR MsValueUchar = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueUchar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UCHAR uc_MsValueUchar = 0;
+// CHECK-FIXES: UCHAR uc_MsValueUchar = 0;
 
 SHORT MsValueShort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueShort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}SHORT s_MsValueShort = 0;
+// CHECK-FIXES: SHORT s_MsValueShort = 0;
 
 USHORT MsValueUshort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'MsValueUshort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}USHORT us_MsValueUshort = 0;
+// CHECK-FIXES: USHORT us_MsValueUshort = 0;
 
 WORD MsValueWord = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueWord' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}WORD w_MsValueWord = 0;
+// CHECK-FIXES: WORD w_MsValueWord = 0;
 
 DWORD MsValueDword = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueDword' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}DWORD dw_MsValueDword = 0;
+// CHECK-FIXES: DWORD dw_MsValueDword = 0;
 
 DWORD32 MsValueDword32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsValueDword32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}DWORD32 dw32_MsValueDword32 = 0;
+// CHECK-FIXES: DWORD32 dw32_MsValueDword32 = 0;
 
 DWORD64 MsValueDword64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsValueDword64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}DWORD64 dw64_MsValueDword64 = 0;
+// CHECK-FIXES: DWORD64 dw64_MsValueDword64 = 0;
 
 LONG MsValueLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}LONG l_MsValueLong = 0;
+// CHECK-FIXES: LONG l_MsValueLong = 0;
 
 ULONG MsValueUlong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueUlong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ULONG ul_MsValueUlong = 0;
+// CHECK-FIXES: ULONG ul_MsValueUlong = 0;
 
 ULONG32 MsValueUlong32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsValueUlong32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ULONG32 ul32_MsValueUlong32 = 0;
+// CHECK-FIXES: ULONG32 ul32_MsValueUlong32 = 0;
 
 ULONG64 MsValueUlong64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'MsValueUlong64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ULONG64 ul64_MsValueUlong64 = 0;
+// CHECK-FIXES: ULONG64 ul64_MsValueUlong64 = 0;
 
 ULONGLONG MsValueUlongLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for global variable 'MsValueUlongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ULONGLONG ull_MsValueUlongLong = 0;
+// CHECK-FIXES: ULONGLONG ull_MsValueUlongLong = 0;
 
 HANDLE MsValueHandle = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global pointer 'MsValueHandle' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}HANDLE h_MsValueHandle = 0;
+// CHECK-FIXES: HANDLE h_MsValueHandle = 0;
 
 INT MsValueInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'MsValueInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT i_MsValueInt = 0;
+// CHECK-FIXES: INT i_MsValueInt = 0;
 
 INT8 MsValueInt8 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueInt8' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT8 i8_MsValueInt8 = 0;
+// CHECK-FIXES: INT8 i8_MsValueInt8 = 0;
 
 INT16 MsValueInt16 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueInt16' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT16 i16_MsValueInt16 = 0;
+// CHECK-FIXES: INT16 i16_MsValueInt16 = 0;
 
 INT32 MsValueInt32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueInt32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT32 i32_MsValueInt32 = 0;
+// CHECK-FIXES: INT32 i32_MsValueInt32 = 0;
 
 INT64 MsValueINt64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueINt64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INT64 i64_MsValueINt64 = 0;
+// CHECK-FIXES: INT64 i64_MsValueINt64 = 0;
 
 UINT MsValueUint = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'MsValueUint' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT ui_MsValueUint = 0;
+// CHECK-FIXES: UINT ui_MsValueUint = 0;
 
 UINT8 MsValueUint8 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'MsValueUint8' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT8 u8_MsValueUint8 = 0;
+// CHECK-FIXES: UINT8 u8_MsValueUint8 = 0;
 
 UINT16 MsValueUint16 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'MsValueUint16' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT16 u16_MsValueUint16 = 0;
+// CHECK-FIXES: UINT16 u16_MsValueUint16 = 0;
 
 UINT32 MsValueUint32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'MsValueUint32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT32 u32_MsValueUint32 = 0;
+// CHECK-FIXES: UINT32 u32_MsValueUint32 = 0;
 
 UINT64 MsValueUint64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'MsValueUint64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}UINT64 u64_MsValueUint64 = 0;
+// CHECK-FIXES: UINT64 u64_MsValueUint64 = 0;
 
 PVOID MsValuePvoid = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global pointer 'MsValuePvoid' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}PVOID p_MsValuePvoid = NULL;
+// CHECK-FIXES: PVOID p_MsValuePvoid = NULL;
 
 
 //===----------------------------------------------------------------------===//
@@ -301,19 +301,19 @@ PVOID MsValuePvoid = NULL;
 //===----------------------------------------------------------------------===//
 unsigned GlobalUnsignedArray[] = {1, 2, 3};
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'GlobalUnsignedArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned a_GlobalUnsignedArray[] = {1, 2, 3};
+// CHECK-FIXES: unsigned a_GlobalUnsignedArray[] = {1, 2, 3};
 
 int GlobalIntArray[] = {1, 2, 3};
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'GlobalIntArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int a_GlobalIntArray[] = {1, 2, 3};
+// CHECK-FIXES: int a_GlobalIntArray[] = {1, 2, 3};
 
 int DataInt[1] = {0};
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'DataInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int a_DataInt[1] = {0};
+// CHECK-FIXES: int a_DataInt[1] = {0};
 
 int DataArray[2] = {0};
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'DataArray' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int a_DataArray[2] = {0};
+// CHECK-FIXES: int a_DataArray[2] = {0};
 
 
 //===----------------------------------------------------------------------===//
@@ -321,56 +321,56 @@ int DataArray[2] = {0};
 //===----------------------------------------------------------------------===//
 int *DataIntPtr[1] = {0};
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'DataIntPtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int *pa_DataIntPtr[1] = {0};
+// CHECK-FIXES: int *pa_DataIntPtr[1] = {0};
 
 void *BufferPtr1;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global pointer 'BufferPtr1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void *p_BufferPtr1;
+// CHECK-FIXES: void *p_BufferPtr1;
 
 void **BufferPtr2;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global pointer 'BufferPtr2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void **pp_BufferPtr2;
+// CHECK-FIXES: void **pp_BufferPtr2;
 
 void **pBufferPtr3;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global pointer 'pBufferPtr3' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void **pp_BufferPtr3;
+// CHECK-FIXES: void **pp_BufferPtr3;
 
 int *pBufferPtr4;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global pointer 'pBufferPtr4' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int *pi_BufferPtr4;
+// CHECK-FIXES: int *pi_BufferPtr4;
 
 typedef void (*FUNC_PTR_HELLO)();
 FUNC_PTR_HELLO Hello = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global pointer 'Hello' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}FUNC_PTR_HELLO fn_Hello = NULL;
+// CHECK-FIXES: FUNC_PTR_HELLO fn_Hello = NULL;
 
 void *ValueVoidPtr = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global pointer 'ValueVoidPtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void *p_ValueVoidPtr = NULL;
+// CHECK-FIXES: void *p_ValueVoidPtr = NULL;
 
 ptrdiff_t PtrDiff = NULL;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for global variable 'PtrDiff' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}ptrdiff_t p_PtrDiff = NULL;
+// CHECK-FIXES: ptrdiff_t p_PtrDiff = NULL;
 
 int8_t *ValueI8Ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global pointer 'ValueI8Ptr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int8_t *pi8_ValueI8Ptr;
+// CHECK-FIXES: int8_t *pi8_ValueI8Ptr;
 
 uint8_t *ValueU8Ptr;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global pointer 'ValueU8Ptr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint8_t *pu8_ValueU8Ptr;
+// CHECK-FIXES: uint8_t *pu8_ValueU8Ptr;
 
 unsigned char *ValueUcPtr;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global pointer 'ValueUcPtr' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned char *puc_ValueUcPtr;
+// CHECK-FIXES: unsigned char *puc_ValueUcPtr;
 
 unsigned char **ValueUcPtr2;
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: invalid case style for global pointer 'ValueUcPtr2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned char **ppuc_ValueUcPtr2;
+// CHECK-FIXES: unsigned char **ppuc_ValueUcPtr2;
 
 void MyFunc2(void* Val){}
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: invalid case style for pointer parameter 'Val' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}void MyFunc2(void* p_Val){}
+// CHECK-FIXES: void MyFunc2(void* p_Val){}
 
 
 //===----------------------------------------------------------------------===//
@@ -379,16 +379,16 @@ void MyFunc2(void* Val){}
 int i_ValueIndex = 1;
 int &RefValueIndex = i_ValueIndex;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'RefValueIndex' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int &i_RefValueIndex = i_ValueIndex;
+// CHECK-FIXES: int &i_RefValueIndex = i_ValueIndex;
 
 const int &ConstRefValue = i_ValueIndex;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'ConstRefValue' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}const int &i_ConstRefValue = i_ValueIndex;
+// CHECK-FIXES: const int &i_ConstRefValue = i_ValueIndex;
 
 long long ll_ValueLongLong = 2;
 long long &RefValueLongLong = ll_ValueLongLong;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'RefValueLongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long long &ll_RefValueLongLong = ll_ValueLongLong;
+// CHECK-FIXES: long long &ll_RefValueLongLong = ll_ValueLongLong;
 
 
 //===----------------------------------------------------------------------===//
@@ -396,151 +396,151 @@ long long &RefValueLongLong = ll_ValueLongLong;
 //===----------------------------------------------------------------------===//
 int8_t ValueI8;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'ValueI8' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int8_t i8_ValueI8;
+// CHECK-FIXES: int8_t i8_ValueI8;
 
 int16_t ValueI16 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueI16' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int16_t i16_ValueI16 = 0;
+// CHECK-FIXES: int16_t i16_ValueI16 = 0;
 
 int32_t ValueI32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueI32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int32_t i32_ValueI32 = 0;
+// CHECK-FIXES: int32_t i32_ValueI32 = 0;
 
 int64_t ValueI64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueI64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int64_t i64_ValueI64 = 0;
+// CHECK-FIXES: int64_t i64_ValueI64 = 0;
 
 uint8_t ValueU8 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueU8' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint8_t u8_ValueU8 = 0;
+// CHECK-FIXES: uint8_t u8_ValueU8 = 0;
 
 uint16_t ValueU16 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueU16' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint16_t u16_ValueU16 = 0;
+// CHECK-FIXES: uint16_t u16_ValueU16 = 0;
 
 uint32_t ValueU32 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueU32' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint32_t u32_ValueU32 = 0;
+// CHECK-FIXES: uint32_t u32_ValueU32 = 0;
 
 uint64_t ValueU64 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueU64' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}uint64_t u64_ValueU64 = 0;
+// CHECK-FIXES: uint64_t u64_ValueU64 = 0;
 
 float ValueFloat = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'ValueFloat' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}float f_ValueFloat = 0;
+// CHECK-FIXES: float f_ValueFloat = 0;
 
 double ValueDouble = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'ValueDouble' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}double d_ValueDouble = 0;
+// CHECK-FIXES: double d_ValueDouble = 0;
 
 char ValueChar = 'c';
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'ValueChar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}char c_ValueChar = 'c';
+// CHECK-FIXES: char c_ValueChar = 'c';
 
 bool ValueBool = true;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'ValueBool' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}bool b_ValueBool = true;
+// CHECK-FIXES: bool b_ValueBool = true;
 
 int ValueInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'ValueInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int i_ValueInt = 0;
+// CHECK-FIXES: int i_ValueInt = 0;
 
 size_t ValueSize = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'ValueSize' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}size_t n_ValueSize = 0;
+// CHECK-FIXES: size_t n_ValueSize = 0;
 
 wchar_t ValueWchar = 'w';
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for global variable 'ValueWchar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}wchar_t wc_ValueWchar = 'w';
+// CHECK-FIXES: wchar_t wc_ValueWchar = 'w';
 
 short ValueShort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'ValueShort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}short s_ValueShort = 0;
+// CHECK-FIXES: short s_ValueShort = 0;
 
 unsigned ValueUnsigned = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueUnsigned' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned u_ValueUnsigned = 0;
+// CHECK-FIXES: unsigned u_ValueUnsigned = 0;
 
 signed ValueSigned = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:8: warning: invalid case style for global variable 'ValueSigned' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed s_ValueSigned = 0;
+// CHECK-FIXES: signed s_ValueSigned = 0;
 
 long ValueLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: invalid case style for global variable 'ValueLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long l_ValueLong = 0;
+// CHECK-FIXES: long l_ValueLong = 0;
 
 long long ValueLongLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: invalid case style for global variable 'ValueLongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long long ll_ValueLongLong = 0;
+// CHECK-FIXES: long long ll_ValueLongLong = 0;
 
 long long int ValueLongLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for global variable 'ValueLongLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long long int lli_ValueLongLongInt = 0;
+// CHECK-FIXES: long long int lli_ValueLongLongInt = 0;
 
 long double ValueLongDouble = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global variable 'ValueLongDouble' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long double ld_ValueLongDouble = 0;
+// CHECK-FIXES: long double ld_ValueLongDouble = 0;
 
 signed int ValueSignedInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'ValueSignedInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed int si_ValueSignedInt = 0;
+// CHECK-FIXES: signed int si_ValueSignedInt = 0;
 
 signed short ValueSignedShort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for global variable 'ValueSignedShort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed short ss_ValueSignedShort = 0;
+// CHECK-FIXES: signed short ss_ValueSignedShort = 0;
 
 signed short int ValueSignedShortInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for global variable 'ValueSignedShortInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed short int ssi_ValueSignedShortInt = 0;
+// CHECK-FIXES: signed short int ssi_ValueSignedShortInt = 0;
 
 signed long long ValueSignedLongLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for global variable 'ValueSignedLongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed long long sll_ValueSignedLongLong = 0;
+// CHECK-FIXES: signed long long sll_ValueSignedLongLong = 0;
 
 signed long int ValueSignedLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: invalid case style for global variable 'ValueSignedLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed long int sli_ValueSignedLongInt = 0;
+// CHECK-FIXES: signed long int sli_ValueSignedLongInt = 0;
 
 signed long ValueSignedLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:13: warning: invalid case style for global variable 'ValueSignedLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}signed long sl_ValueSignedLong = 0;
+// CHECK-FIXES: signed long sl_ValueSignedLong = 0;
 
 unsigned long long int ValueUnsignedLongLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:24: warning: invalid case style for global variable 'ValueUnsignedLongLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned long long int ulli_ValueUnsignedLongLongInt = 0;
+// CHECK-FIXES: unsigned long long int ulli_ValueUnsignedLongLongInt = 0;
 
 unsigned long long ValueUnsignedLongLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: invalid case style for global variable 'ValueUnsignedLongLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned long long ull_ValueUnsignedLongLong = 0;
+// CHECK-FIXES: unsigned long long ull_ValueUnsignedLongLong = 0;
 
 unsigned long int ValueUnsignedLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: invalid case style for global variable 'ValueUnsignedLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned long int uli_ValueUnsignedLongInt = 0;
+// CHECK-FIXES: unsigned long int uli_ValueUnsignedLongInt = 0;
 
 unsigned long ValueUnsignedLong = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for global variable 'ValueUnsignedLong' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned long ul_ValueUnsignedLong = 0;
+// CHECK-FIXES: unsigned long ul_ValueUnsignedLong = 0;
 
 unsigned short int ValueUnsignedShortInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: invalid case style for global variable 'ValueUnsignedShortInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned short int usi_ValueUnsignedShortInt = 0;
+// CHECK-FIXES: unsigned short int usi_ValueUnsignedShortInt = 0;
 
 unsigned short ValueUnsignedShort = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: invalid case style for global variable 'ValueUnsignedShort' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned short us_ValueUnsignedShort = 0;
+// CHECK-FIXES: unsigned short us_ValueUnsignedShort = 0;
 
 unsigned int ValueUnsignedInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for global variable 'ValueUnsignedInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned int ui_ValueUnsignedInt = 0;
+// CHECK-FIXES: unsigned int ui_ValueUnsignedInt = 0;
 
 unsigned char ValueUnsignedChar = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: invalid case style for global variable 'ValueUnsignedChar' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}unsigned char uc_ValueUnsignedChar = 0;
+// CHECK-FIXES: unsigned char uc_ValueUnsignedChar = 0;
 
 long int ValueLongInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: invalid case style for global variable 'ValueLongInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}long int li_ValueLongInt = 0;
+// CHECK-FIXES: long int li_ValueLongInt = 0;
 
 
 //===----------------------------------------------------------------------===//
@@ -548,25 +548,25 @@ long int ValueLongInt = 0;
 //===----------------------------------------------------------------------===//
 volatile int VolatileInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: invalid case style for global variable 'VolatileInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}volatile int i_VolatileInt = 0;
+// CHECK-FIXES: volatile int i_VolatileInt = 0;
 
 thread_local int ThreadLocalValueInt = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: invalid case style for global variable 'ThreadLocalValueInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}thread_local int i_ThreadLocalValueInt = 0;
+// CHECK-FIXES: thread_local int i_ThreadLocalValueInt = 0;
 
 extern int ExternValueInt;
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: invalid case style for global variable 'ExternValueInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}extern int i_ExternValueInt;
+// CHECK-FIXES: extern int i_ExternValueInt;
 
 struct DataBuffer {
     mutable size_t Size;
 };
 // CHECK-MESSAGES: :[[@LINE-2]]:20: warning: invalid case style for public member 'Size' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}    mutable size_t n_Size;
+// CHECK-FIXES: mutable size_t n_Size;
 
 static constexpr int const &ConstExprInt = 42;
 // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: invalid case style for constexpr variable 'ConstExprInt' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}static constexpr int const &i_ConstExprInt = 42;
+// CHECK-FIXES: static constexpr int const &i_ConstExprInt = 42;
 
 
 //===----------------------------------------------------------------------===//
@@ -575,7 +575,7 @@ static constexpr int const &ConstExprInt = 42;
 typedef int INDEX;
 INDEX iIndex = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for global variable 'iIndex' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}INDEX Index = 0;
+// CHECK-FIXES: INDEX Index = 0;
 
 
 //===----------------------------------------------------------------------===//
@@ -583,96 +583,96 @@ INDEX iIndex = 0;
 //===----------------------------------------------------------------------===//
 class ClassCase { int Func(); };
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'ClassCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}class C_ClassCase { int Func(); };
+// CHECK-FIXES: class C_ClassCase { int Func(); };
 
 class AbstractClassCase { virtual int Func() = 0; };
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for abstract class 'AbstractClassCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}class I_AbstractClassCase { virtual int Func() = 0; };
+// CHECK-FIXES: class I_AbstractClassCase { virtual int Func() = 0; };
 
 class AbstractClassCase1 { virtual int Func1() = 0; int Func2(); };
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for abstract class 'AbstractClassCase1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}class I_AbstractClassCase1 { virtual int Func1() = 0; int Func2(); };
+// CHECK-FIXES: class I_AbstractClassCase1 { virtual int Func1() = 0; int Func2(); };
 
 class ClassConstantCase { public: static const int i_ConstantCase; };
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: invalid case style for class 'ClassConstantCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}class C_ClassConstantCase { public: static const int i_ConstantCase; };
+// CHECK-FIXES: class C_ClassConstantCase { public: static const int i_ConstantCase; };
 
 //===----------------------------------------------------------------------===//
 // Other Cases
 //===----------------------------------------------------------------------===//
 int lower_case = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'lower_case' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int i_LowerCase = 0;
+// CHECK-FIXES: int i_LowerCase = 0;
 
 int lower_case1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'lower_case1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int i_LowerCase1 = 0;
+// CHECK-FIXES: int i_LowerCase1 = 0;
 
 int lower_case_2 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'lower_case_2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int i_LowerCase2 = 0;
+// CHECK-FIXES: int i_LowerCase2 = 0;
 
 int UPPER_CASE = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'UPPER_CASE' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int i_UpperCase = 0;
+// CHECK-FIXES: int i_UpperCase = 0;
 
 int UPPER_CASE_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'UPPER_CASE_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int i_UpperCase1 = 0;
+// CHECK-FIXES: int i_UpperCase1 = 0;
 
 int camelBack = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camelBack' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int i_CamelBack = 0;
+// CHECK-FIXES: int i_CamelBack = 0;
 
 int camelBack_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camelBack_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int i_CamelBack1 = 0;
+// CHECK-FIXES: int i_CamelBack1 = 0;
 
 int camelBack2 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camelBack2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int i_CamelBack2 = 0;
+// CHECK-FIXES: int i_CamelBack2 = 0;
 
 int CamelCase = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'CamelCase' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int i_CamelCase = 0;
+// CHECK-FIXES: int i_CamelCase = 0;
 
 int CamelCase_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'CamelCase_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int i_CamelCase1 = 0;
+// CHECK-FIXES: int i_CamelCase1 = 0;
 
 int CamelCase2 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'CamelCase2' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int i_CamelCase2 = 0;
+// CHECK-FIXES: int i_CamelCase2 = 0;
 
 int camel_Snake_Back = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camel_Snake_Back' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int i_CamelSnakeBack = 0;
+// CHECK-FIXES: int i_CamelSnakeBack = 0;
 
 int camel_Snake_Back_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'camel_Snake_Back_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int i_CamelSnakeBack1 = 0;
+// CHECK-FIXES: int i_CamelSnakeBack1 = 0;
 
 int Camel_Snake_Case = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'Camel_Snake_Case' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int i_CamelSnakeCase = 0;
+// CHECK-FIXES: int i_CamelSnakeCase = 0;
 
 int Camel_Snake_Case_1 = 0;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: invalid case style for global variable 'Camel_Snake_Case_1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}int i_CamelSnakeCase1 = 0;
+// CHECK-FIXES: int i_CamelSnakeCase1 = 0;
 
 //===----------------------------------------------------------------------===//
 // Enum
 //===----------------------------------------------------------------------===//
 enum REV_TYPE { RevValid };
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: invalid case style for enum constant 'RevValid' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}enum REV_TYPE { rt_RevValid };
+// CHECK-FIXES: enum REV_TYPE { rt_RevValid };
 
 enum EnumConstantCase { OneByte, TwoByte };
 // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: invalid case style for enum constant 'OneByte' [readability-identifier-naming]
 // CHECK-MESSAGES: :[[@LINE-2]]:34: warning: invalid case style for enum constant 'TwoByte' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}enum EnumConstantCase { ecc_OneByte, ecc_TwoByte };
+// CHECK-FIXES: enum EnumConstantCase { ecc_OneByte, ecc_TwoByte };
 
 enum class ScopedEnumConstantCase { Case1 };
 // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: invalid case style for scoped enum constant 'Case1' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}enum class ScopedEnumConstantCase { secc_Case1 };
+// CHECK-FIXES: enum class ScopedEnumConstantCase { secc_Case1 };
 // clang-format on

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-outofline.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-outofline.cpp
@@ -11,11 +11,11 @@ public:
     template <typename T>
     int someMethod();
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: invalid case style for method 'someMethod' [readability-identifier-naming]
-// CHECK-FIXES: {{^}}    int SomeMethod();
+// CHECK-FIXES: int SomeMethod();
 };
 template <typename T>
 int SomeClass::someMethod() {
-// CHECK-FIXES: {{^}}int SomeClass::SomeMethod() {
+// CHECK-FIXES: int SomeClass::SomeMethod() {
     return 5;
 }
 
@@ -24,7 +24,7 @@ int SomeClass::someMethod() {
 void someFunc() {
     Inner::SomeClass S;
     S.someMethod<int>();
-// CHECK-FIXES: {{^}}    S.SomeMethod<int>();
+// CHECK-FIXES: S.SomeMethod<int>();
 }
 
 } // namespace SomeNamespace

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/isolate-declaration-cxx17.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/isolate-declaration-cxx17.cpp
@@ -63,31 +63,31 @@ void modern() {
   auto autoInt1 = 3, autoInt2 = 4;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: auto autoInt1 = 3;
-  // CHECK-FIXES: {{^  }}auto autoInt2 = 4;
+  // CHECK-FIXES: auto autoInt2 = 4;
 
   decltype(int()) declnottouch = 4;
   decltype(int()) declint1 = 5, declint2 = 3;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: decltype(int()) declint1 = 5;
-  // CHECK-FIXES: {{^  }}decltype(int()) declint2 = 3;
+  // CHECK-FIXES: decltype(int()) declint2 = 3;
 
   std::vector<int> vectorA = {1, 2}, vectorB = {1, 2, 3}, vectorC({1, 1, 1});
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: std::vector<int> vectorA = {1, 2};
-  // CHECK-FIXES: {{^  }}std::vector<int> vectorB = {1, 2, 3};
-  // CHECK-FIXES: {{^  }}std::vector<int> vectorC({1, 1, 1});
+  // CHECK-FIXES: std::vector<int> vectorB = {1, 2, 3};
+  // CHECK-FIXES: std::vector<int> vectorC({1, 1, 1});
 
   using uType = int;
   uType utype1, utype2;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: uType utype1;
-  // CHECK-FIXES: {{^  }}uType utype2;
+  // CHECK-FIXES: uType utype2;
 
   Types::MyType mytype1, mytype2, mytype3 = 3;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: Types::MyType mytype1;
-  // CHECK-FIXES: {{^  }}Types::MyType mytype2;
-  // CHECK-FIXES: {{^  }}Types::MyType mytype3 = 3;
+  // CHECK-FIXES: Types::MyType mytype2;
+  // CHECK-FIXES: Types::MyType mytype3 = 3;
 
   {
     using namespace std::string_literals;
@@ -95,9 +95,9 @@ void modern() {
     std::vector<std::string> s{"foo"s, "bar"s}, t{"foo"s}, u, a({"hey", "you"}), bb = {"h", "a"};
     // CHECK-MESSAGES: [[@LINE-1]]:5: warning: multiple declarations in a single statement reduces readability
     // CHECK-FIXES: std::vector<std::string> s{"foo"s, "bar"s};
-    // CHECK-FIXES: {{^    }}std::vector<std::string> t{"foo"s};
-    // CHECK-FIXES: {{^    }}std::vector<std::string> u;
-    // CHECK-FIXES: {{^    }}std::vector<std::string> a({"hey", "you"});
-    // CHECK-FIXES: {{^    }}std::vector<std::string> bb = {"h", "a"};
+    // CHECK-FIXES: std::vector<std::string> t{"foo"s};
+    // CHECK-FIXES: std::vector<std::string> u;
+    // CHECK-FIXES: std::vector<std::string> a({"hey", "you"});
+    // CHECK-FIXES: std::vector<std::string> bb = {"h", "a"};
   }
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/isolate-declaration.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/isolate-declaration.c
@@ -6,7 +6,7 @@ void c_specific(void) {
   int j = sizeof(struct T { int i; }), k;
   // CHECK-MESSAGES: [[@LINE-1]]:3: warning: multiple declarations in a single statement reduces readability
   // CHECK-FIXES: int j = sizeof(struct T { int i; });
-  // CHECK-FIXES: {{^  }}int k;
+  // CHECK-FIXES: int k;
 
   void g(struct U { int i; } s);                // One decl
   void h(struct V { int i; } s), m(int i, ...); // Two decls

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-declaration-ignore-macros.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/redundant-declaration-ignore-macros.cpp
@@ -6,16 +6,16 @@
 extern int Xyz;
 extern int Xyz; // Xyz
 // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: redundant 'Xyz' declaration [readability-redundant-declaration]
-// CHECK-FIXES: {{^}}// Xyz{{$}}
+// CHECK-FIXES: // Xyz
 
 namespace macros {
 #define DECLARE(x) extern int x
 #define DEFINE(x) extern int x; int x = 42
 DECLARE(test);
 DEFINE(test);
-// CHECK-FIXES: {{^}}#define DECLARE(x) extern int x{{$}}
-// CHECK-FIXES: {{^}}#define DEFINE(x) extern int x; int x = 42{{$}}
-// CHECK-FIXES: {{^}}DECLARE(test);{{$}}
-// CHECK-FIXES: {{^}}DEFINE(test);{{$}}
+// CHECK-FIXES: #define DECLARE(x) extern int x
+// CHECK-FIXES: #define DEFINE(x) extern int x; int x = 42
+// CHECK-FIXES: DECLARE(test);
+// CHECK-FIXES: DEFINE(test);
 
 } // namespace macros


### PR DESCRIPTION

`check_clang_tidy` now matches full lines only, so `{{^}}` clauses are no longer necessary.

I am splitting those changes over multiple PRs to make review easier. Numbering them but the actual order doesn't matter.
