### PR TITLE
[clang] fix DependentTemplateSpecializationType transform

### DIFF
--- a/clang/test/SemaTemplate/dependent-names.cpp
+++ b/clang/test/SemaTemplate/dependent-names.cpp
@@ -458,3 +458,12 @@ namespace PR37680 {
   };
   int f(b<a> ba) { return ba.add<0>(); }
 }
+
+namespace TransformDependentTemplates {
+  template <class T> struct Test1 {
+    template <class T2>
+      using Arg = typename T::template Arg<T2>;
+    void f(Arg<void>);
+    void f(Arg<int>);
+  };
+} // namespace TransformDependentTemplates


### PR DESCRIPTION
This changes the transform for DTST so it rebuilds the node if any of the template arguments changed.

This fixes a regression reported here: https://github.com/llvm/llvm-project/pull/133610#issuecomment-2784576267 which was introduced by https://github.com/llvm/llvm-project/pull/133610

There are no release notes since the regression was never released.