### PR TITLE
[clang-tidy] Avoid diagnosing std::array initializations for modernize-use-designated-initializers

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseDesignatedInitializersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseDesignatedInitializersCheck.cpp
@@ -121,8 +121,9 @@ void UseDesignatedInitializersCheck::registerMatchers(MatchFinder *Finder) {
       hasAnyBase(hasType(cxxRecordDecl(has(fieldDecl()))));
   Finder->addMatcher(
       initListExpr(
-          hasType(cxxRecordDecl(RestrictToPODTypes ? isPOD() : isAggregate(),
-                                unless(HasBaseWithFields))
+          hasType(cxxRecordDecl(
+                      RestrictToPODTypes ? isPOD() : isAggregate(),
+                      unless(anyOf(HasBaseWithFields, hasName("::std::array"))))
                       .bind("type")),
           IgnoreSingleElementAggregates ? hasMoreThanOneElement() : anything(),
           unless(isFullyDesignated()))

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -182,6 +182,10 @@ Changes in existing checks
   ``constexpr`` and ``static``` values on member initialization and by detecting
   explicit casting of built-in types within member list initialization.
 
+- Improved :doc:`modernize-use-designated-initializers
+  <clang-tidy/checks/modernize/use-designated-initializers>` check by avoiding
+  diagnosing designated initializers for ``std::array`` initializations.
+
 - Improved :doc:`modernize-use-ranges
   <clang-tidy/checks/modernize/use-ranges>` check by updating suppress 
   warnings logic for ``nullptr`` in ``std::find``.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/use-designated-initializers.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/use-designated-initializers.rst
@@ -54,6 +54,9 @@ Options
 
     The value `false` specifies that even initializers for aggregate types with
     only a single element should be checked. The default value is `true`.
+    ``std::array`` initializations are always excluded, as the type is a
+    standard library abstraction and not intended to be initialized with
+    designated initializers.
 
 .. option:: RestrictToPODTypes
 

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-designated-initializers.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-designated-initializers.cpp
@@ -209,3 +209,18 @@ struct S15{
   S15(S14& d):d{d}{}
   S14& d;
 };
+
+//Issue #133715
+namespace std {
+  template<typename T, unsigned int N>
+  struct array {
+    T __elems[N];
+  };
+    template<typename T, typename... U>
+    array(T, U...) -> array<T, 1 + sizeof...(U)>;
+}
+
+std::array a{1,2,3};
+std::array<int,2> b{10, 11};
+using array = std::array<int, 2>;
+array c{10, 11};


### PR DESCRIPTION
**Edit:**
I suggest we avoid diagnosing initializers for  `std::array` type. The fixit provided is incorrect as observed in **#133715.** The only workaround would require C99-style array designators which don’t really align with the purpose of this check. This would also generate extra compiler warnings. 

Fixes #133715