### PR TITLE
[Clang] [NFC] Tablegen component diags headers

### DIFF
--- a/clang/include/clang/Basic/CMakeLists.txt
+++ b/clang/include/clang/Basic/CMakeLists.txt
@@ -13,6 +13,11 @@ macro(clang_diag_gen component)
     -gen-clang-diags-compat-ids -clang-component=${component}
     SOURCE Diagnostic.td
     TARGET ClangDiagnostic${component}CompatIDs)
+
+  clang_tablegen(Diagnostic${component}Interface.inc
+    -gen-clang-diags-iface -clang-component=${component}
+    SOURCE Diagnostic.td
+    TARGET ClangDiagnostic${component}Interface)
 endmacro(clang_diag_gen)
 
 clang_diag_gen(Analysis)

--- a/clang/include/clang/Basic/DiagnosticAST.h
+++ b/clang/include/clang/Basic/DiagnosticAST.h
@@ -10,44 +10,6 @@
 #define LLVM_CLANG_BASIC_DIAGNOSTICAST_H
 
 #include "clang/Basic/Diagnostic.h"
-
-namespace clang {
-namespace diag {
-enum {
-#define DIAG(ENUM, FLAGS, DEFAULT_MAPPING, DESC, GROUP, SFINAE, NOWERROR,      \
-             SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY)            \
-  ENUM,
-#define ASTSTART
-#include "clang/Basic/DiagnosticASTKinds.inc"
-#undef DIAG
-  NUM_BUILTIN_AST_DIAGNOSTICS
-};
-
-#define DIAG_ENUM(ENUM_NAME)                                                   \
-  namespace ENUM_NAME {                                                        \
-  enum {
-#define DIAG_ENUM_ITEM(IDX, NAME) NAME = IDX,
-#define DIAG_ENUM_END()                                                        \
-  }                                                                            \
-  ;                                                                            \
-  }
-#include "clang/Basic/DiagnosticASTEnums.inc"
-#undef DIAG_ENUM_END
-#undef DIAG_ENUM_ITEM
-#undef DIAG_ENUM
-} // end namespace diag
-
-namespace diag_compat {
-#define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                  \
-  }                                                                            \
-  ;
-#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticASTCompatIDs.inc"
-#undef DIAG_COMPAT_ID
-#undef DIAG_COMPAT_IDS_BEGIN
-#undef DIAG_COMPAT_IDS_END
-} // end namespace diag_compat
-} // end namespace clang
+#include "clang/Basic/DiagnosticASTInterface.inc"
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICAST_H

--- a/clang/include/clang/Basic/DiagnosticAnalysis.h
+++ b/clang/include/clang/Basic/DiagnosticAnalysis.h
@@ -10,43 +10,6 @@
 #define LLVM_CLANG_BASIC_DIAGNOSTICANALYSIS_H
 
 #include "clang/Basic/Diagnostic.h"
-
-namespace clang {
-namespace diag {
-enum {
-#define DIAG(ENUM, FLAGS, DEFAULT_MAPPING, DESC, GROUP, SFINAE, NOWERROR,      \
-             SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY)            \
-  ENUM,
-#define ANALYSISSTART
-#include "clang/Basic/DiagnosticAnalysisKinds.inc"
-#undef DIAG
-  NUM_BUILTIN_ANALYSIS_DIAGNOSTICS
-};
-#define DIAG_ENUM(ENUM_NAME)                                                   \
-  namespace ENUM_NAME {                                                        \
-  enum {
-#define DIAG_ENUM_ITEM(IDX, NAME) NAME = IDX,
-#define DIAG_ENUM_END()                                                        \
-  }                                                                            \
-  ;                                                                            \
-  }
-#include "clang/Basic/DiagnosticAnalysisEnums.inc"
-#undef DIAG_ENUM_END
-#undef DIAG_ENUM_ITEM
-#undef DIAG_ENUM
-} // end namespace diag
-
-namespace diag_compat {
-#define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                  \
-  }                                                                            \
-  ;
-#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticAnalysisCompatIDs.inc"
-#undef DIAG_COMPAT_ID
-#undef DIAG_COMPAT_IDS_BEGIN
-#undef DIAG_COMPAT_IDS_END
-} // end namespace diag_compat
-} // end namespace clang
+#include "clang/Basic/DiagnosticAnalysisInterface.inc"
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICANALYSIS_H

--- a/clang/include/clang/Basic/DiagnosticComment.h
+++ b/clang/include/clang/Basic/DiagnosticComment.h
@@ -10,44 +10,6 @@
 #define LLVM_CLANG_BASIC_DIAGNOSTICCOMMENT_H
 
 #include "clang/Basic/Diagnostic.h"
-
-namespace clang {
-namespace diag {
-enum {
-#define DIAG(ENUM, FLAGS, DEFAULT_MAPPING, DESC, GROUP, SFINAE, NOWERROR,      \
-             SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY)            \
-  ENUM,
-#define COMMENTSTART
-#include "clang/Basic/DiagnosticCommentKinds.inc"
-#undef DIAG
-  NUM_BUILTIN_COMMENT_DIAGNOSTICS
-};
-
-#define DIAG_ENUM(ENUM_NAME)                                                   \
-  namespace ENUM_NAME {                                                        \
-  enum {
-#define DIAG_ENUM_ITEM(IDX, NAME) NAME = IDX,
-#define DIAG_ENUM_END()                                                        \
-  }                                                                            \
-  ;                                                                            \
-  }
-#include "clang/Basic/DiagnosticCommentEnums.inc"
-#undef DIAG_ENUM_END
-#undef DIAG_ENUM_ITEM
-#undef DIAG_ENUM
-} // end namespace diag
-
-namespace diag_compat {
-#define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                  \
-  }                                                                            \
-  ;
-#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticCommentCompatIDs.inc"
-#undef DIAG_COMPAT_ID
-#undef DIAG_COMPAT_IDS_BEGIN
-#undef DIAG_COMPAT_IDS_END
-} // end namespace diag_compat
-} // end namespace clang
+#include "clang/Basic/DiagnosticCommentInterface.inc"
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICCOMMENT_H

--- a/clang/include/clang/Basic/DiagnosticCrossTU.h
+++ b/clang/include/clang/Basic/DiagnosticCrossTU.h
@@ -10,44 +10,6 @@
 #define LLVM_CLANG_BASIC_DIAGNOSTICCROSSTU_H
 
 #include "clang/Basic/Diagnostic.h"
-
-namespace clang {
-namespace diag {
-enum {
-#define DIAG(ENUM, FLAGS, DEFAULT_MAPPING, DESC, GROUP, SFINAE, NOWERROR,      \
-             SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY)            \
-  ENUM,
-#define CROSSTUSTART
-#include "clang/Basic/DiagnosticCrossTUKinds.inc"
-#undef DIAG
-  NUM_BUILTIN_CROSSTU_DIAGNOSTICS
-};
-
-#define DIAG_ENUM(ENUM_NAME)                                                   \
-  namespace ENUM_NAME {                                                        \
-  enum {
-#define DIAG_ENUM_ITEM(IDX, NAME) NAME = IDX,
-#define DIAG_ENUM_END()                                                        \
-  }                                                                            \
-  ;                                                                            \
-  }
-#include "clang/Basic/DiagnosticCrossTUEnums.inc"
-#undef DIAG_ENUM_END
-#undef DIAG_ENUM_ITEM
-#undef DIAG_ENUM
-} // end namespace diag
-
-namespace diag_compat {
-#define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                  \
-  }                                                                            \
-  ;
-#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticCrossTUCompatIDs.inc"
-#undef DIAG_COMPAT_ID
-#undef DIAG_COMPAT_IDS_BEGIN
-#undef DIAG_COMPAT_IDS_END
-} // end namespace diag_compat
-} // end namespace clang
+#include "clang/Basic/DiagnosticCrossTUInterface.inc"
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICCROSSTU_H

--- a/clang/include/clang/Basic/DiagnosticDriver.h
+++ b/clang/include/clang/Basic/DiagnosticDriver.h
@@ -10,44 +10,6 @@
 #define LLVM_CLANG_BASIC_DIAGNOSTICDRIVER_H
 
 #include "clang/Basic/Diagnostic.h"
-
-namespace clang {
-namespace diag {
-enum {
-#define DIAG(ENUM, FLAGS, DEFAULT_MAPPING, DESC, GROUP, SFINAE, NOWERROR,      \
-             SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY)            \
-  ENUM,
-#define DRIVERSTART
-#include "clang/Basic/DiagnosticDriverKinds.inc"
-#undef DIAG
-  NUM_BUILTIN_DRIVER_DIAGNOSTICS
-};
-
-#define DIAG_ENUM(ENUM_NAME)                                                   \
-  namespace ENUM_NAME {                                                        \
-  enum {
-#define DIAG_ENUM_ITEM(IDX, NAME) NAME = IDX,
-#define DIAG_ENUM_END()                                                        \
-  }                                                                            \
-  ;                                                                            \
-  }
-#include "clang/Basic/DiagnosticDriverEnums.inc"
-#undef DIAG_ENUM_END
-#undef DIAG_ENUM_ITEM
-#undef DIAG_ENUM
-} // end namespace diag
-
-namespace diag_compat {
-#define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                  \
-  }                                                                            \
-  ;
-#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticDriverCompatIDs.inc"
-#undef DIAG_COMPAT_ID
-#undef DIAG_COMPAT_IDS_BEGIN
-#undef DIAG_COMPAT_IDS_END
-} // end namespace diag_compat
-} // end namespace clang
+#include "clang/Basic/DiagnosticDriverInterface.inc"
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICDRIVER_H

--- a/clang/include/clang/Basic/DiagnosticFrontend.h
+++ b/clang/include/clang/Basic/DiagnosticFrontend.h
@@ -10,44 +10,6 @@
 #define LLVM_CLANG_BASIC_DIAGNOSTICFRONTEND_H
 
 #include "clang/Basic/Diagnostic.h"
-
-namespace clang {
-namespace diag {
-enum {
-#define DIAG(ENUM, FLAGS, DEFAULT_MAPPING, DESC, GROUP, SFINAE, NOWERROR,      \
-             SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY)            \
-  ENUM,
-#define FRONTENDSTART
-#include "clang/Basic/DiagnosticFrontendKinds.inc"
-#undef DIAG
-  NUM_BUILTIN_FRONTEND_DIAGNOSTICS
-};
-
-#define DIAG_ENUM(ENUM_NAME)                                                   \
-  namespace ENUM_NAME {                                                        \
-  enum {
-#define DIAG_ENUM_ITEM(IDX, NAME) NAME = IDX,
-#define DIAG_ENUM_END()                                                        \
-  }                                                                            \
-  ;                                                                            \
-  }
-#include "clang/Basic/DiagnosticFrontendEnums.inc"
-#undef DIAG_ENUM_END
-#undef DIAG_ENUM_ITEM
-#undef DIAG_ENUM
-} // end namespace diag
-
-namespace diag_compat {
-#define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                  \
-  }                                                                            \
-  ;
-#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticFrontendCompatIDs.inc"
-#undef DIAG_COMPAT_ID
-#undef DIAG_COMPAT_IDS_BEGIN
-#undef DIAG_COMPAT_IDS_END
-} // end namespace diag_compat
-} // end namespace clang
+#include "clang/Basic/DiagnosticFrontendInterface.inc"
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICFRONTEND_H

--- a/clang/include/clang/Basic/DiagnosticIDs.h
+++ b/clang/include/clang/Basic/DiagnosticIDs.h
@@ -71,17 +71,6 @@ namespace clang {
     /// All of the diagnostics that can be emitted by the frontend.
     typedef unsigned kind;
 
-    // Get typedefs for common diagnostics.
-    enum {
-#define DIAG(ENUM, FLAGS, DEFAULT_MAPPING, DESC, GROUP, SFINAE, CATEGORY,      \
-             NOWERROR, SHOWINSYSHEADER, SHOWINSYSMACRO, DEFFERABLE)            \
-  ENUM,
-#define COMMONSTART
-#include "clang/Basic/DiagnosticCommonKinds.inc"
-      NUM_BUILTIN_COMMON_DIAGNOSTICS
-#undef DIAG
-    };
-
     /// Enum values that allow the client to map NOTEs, WARNINGs, and EXTENSIONs
     /// to either Ignore (nothing), Remark (emit a remark), Warning
     /// (emit a warning) or Error (emit as an error).  It allows clients to
@@ -103,20 +92,13 @@ namespace clang {
       Remark          ///< A diagnostic that indicates normal progress through
                       ///< compilation.
     };
-  }
+  } // end namespace diag
+} // end namespace clang
 
-  namespace diag_compat {
-#define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                \
-    }                                                                          \
-    ;
-#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticCommonCompatIDs.inc"
-#undef DIAG_COMPAT_ID
-#undef DIAG_COMPAT_IDS_BEGIN
-#undef DIAG_COMPAT_IDS_END
-  } // end namespace diag_compat
+// This has to be included *after* the DIAG_START_ enums above are defined.
+#include "clang/Basic/DiagnosticCommonInterface.inc"
 
+namespace clang {
 class DiagnosticMapping {
   LLVM_PREFERRED_TYPE(diag::Severity)
   unsigned Severity : 3;

--- a/clang/include/clang/Basic/DiagnosticInstallAPI.h
+++ b/clang/include/clang/Basic/DiagnosticInstallAPI.h
@@ -10,42 +10,6 @@
 #define LLVM_CLANG_BASIC_DIAGNOSTICINSTALLAPI_H
 
 #include "clang/Basic/Diagnostic.h"
-namespace clang {
-namespace diag {
-enum {
-#define DIAG(ENUM, FLAGS, DEFAULT_MAPPING, DESC, GROUP, SFINAE, NOWERROR,      \
-             SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY)            \
-  ENUM,
-#define INSTALLAPISTART
-#include "clang/Basic/DiagnosticInstallAPIKinds.inc"
-#undef DIAG
-  NUM_BUILTIN_INSTALLAPI_DIAGNOSTICS
-};
+#include "clang/Basic/DiagnosticInstallAPIInterface.inc"
 
-#define DIAG_ENUM(ENUM_NAME)                                                   \
-  namespace ENUM_NAME {                                                        \
-  enum {
-#define DIAG_ENUM_ITEM(IDX, NAME) NAME = IDX,
-#define DIAG_ENUM_END()                                                        \
-  }                                                                            \
-  ;                                                                            \
-  }
-#include "clang/Basic/DiagnosticInstallAPIEnums.inc"
-#undef DIAG_ENUM_END
-#undef DIAG_ENUM_ITEM
-#undef DIAG_ENUM
-} // namespace diag
-
-namespace diag_compat {
-#define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                  \
-  }                                                                            \
-  ;
-#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticInstallAPICompatIDs.inc"
-#undef DIAG_COMPAT_ID
-#undef DIAG_COMPAT_IDS_BEGIN
-#undef DIAG_COMPAT_IDS_END
-} // end namespace diag_compat
-} // namespace clang
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICINSTALLAPI_H

--- a/clang/include/clang/Basic/DiagnosticLex.h
+++ b/clang/include/clang/Basic/DiagnosticLex.h
@@ -10,43 +10,6 @@
 #define LLVM_CLANG_BASIC_DIAGNOSTICLEX_H
 
 #include "clang/Basic/Diagnostic.h"
-
-namespace clang {
-namespace diag {
-enum {
-#define DIAG(ENUM, FLAGS, DEFAULT_MAPPING, DESC, GROUP, SFINAE, NOWERROR,      \
-             SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY)            \
-  ENUM,
-#define LEXSTART
-#include "clang/Basic/DiagnosticLexKinds.inc"
-#undef DIAG
-  NUM_BUILTIN_LEX_DIAGNOSTICS
-};
-#define DIAG_ENUM(ENUM_NAME)                                                   \
-  namespace ENUM_NAME {                                                        \
-  enum {
-#define DIAG_ENUM_ITEM(IDX, NAME) NAME = IDX,
-#define DIAG_ENUM_END()                                                        \
-  }                                                                            \
-  ;                                                                            \
-  }
-#include "clang/Basic/DiagnosticLexEnums.inc"
-#undef DIAG_ENUM_END
-#undef DIAG_ENUM_ITEM
-#undef DIAG_ENUM
-} // end namespace diag
-
-namespace diag_compat {
-#define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                  \
-  }                                                                            \
-  ;
-#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticLexCompatIDs.inc"
-#undef DIAG_COMPAT_ID
-#undef DIAG_COMPAT_IDS_BEGIN
-#undef DIAG_COMPAT_IDS_END
-} // end namespace diag_compat
-} // end namespace clang
+#include "clang/Basic/DiagnosticLexInterface.inc"
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICLEX_H

--- a/clang/include/clang/Basic/DiagnosticParse.h
+++ b/clang/include/clang/Basic/DiagnosticParse.h
@@ -10,44 +10,6 @@
 #define LLVM_CLANG_BASIC_DIAGNOSTICPARSE_H
 
 #include "clang/Basic/Diagnostic.h"
-
-namespace clang {
-namespace diag {
-enum {
-#define DIAG(ENUM, FLAGS, DEFAULT_MAPPING, DESC, GROUP, SFINAE, NOWERROR,      \
-             SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY)            \
-  ENUM,
-#define PARSESTART
-#include "clang/Basic/DiagnosticParseKinds.inc"
-#undef DIAG
-  NUM_BUILTIN_PARSE_DIAGNOSTICS
-};
-
-#define DIAG_ENUM(ENUM_NAME)                                                   \
-  namespace ENUM_NAME {                                                        \
-  enum {
-#define DIAG_ENUM_ITEM(IDX, NAME) NAME = IDX,
-#define DIAG_ENUM_END()                                                        \
-  }                                                                            \
-  ;                                                                            \
-  }
-#include "clang/Basic/DiagnosticParseEnums.inc"
-#undef DIAG_ENUM_END
-#undef DIAG_ENUM_ITEM
-#undef DIAG_ENUM
-} // end namespace diag
-
-namespace diag_compat {
-#define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                  \
-  }                                                                            \
-  ;
-#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticParseCompatIDs.inc"
-#undef DIAG_COMPAT_ID
-#undef DIAG_COMPAT_IDS_BEGIN
-#undef DIAG_COMPAT_IDS_END
-} // end namespace diag_compat
-} // end namespace clang
+#include "clang/Basic/DiagnosticParseInterface.inc"
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICPARSE_H

--- a/clang/include/clang/Basic/DiagnosticRefactoring.h
+++ b/clang/include/clang/Basic/DiagnosticRefactoring.h
@@ -10,44 +10,6 @@
 #define LLVM_CLANG_BASIC_DIAGNOSTICREFACTORING_H
 
 #include "clang/Basic/Diagnostic.h"
-
-namespace clang {
-namespace diag {
-enum {
-#define DIAG(ENUM, FLAGS, DEFAULT_MAPPING, DESC, GROUP, SFINAE, NOWERROR,      \
-             SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY)            \
-  ENUM,
-#define REFACTORINGSTART
-#include "clang/Basic/DiagnosticRefactoringKinds.inc"
-#undef DIAG
-  NUM_BUILTIN_REFACTORING_DIAGNOSTICS
-};
-
-#define DIAG_ENUM(ENUM_NAME)                                                   \
-  namespace ENUM_NAME {                                                        \
-  enum {
-#define DIAG_ENUM_ITEM(IDX, NAME) NAME = IDX,
-#define DIAG_ENUM_END()                                                        \
-  }                                                                            \
-  ;                                                                            \
-  }
-#include "clang/Basic/DiagnosticRefactoringEnums.inc"
-#undef DIAG_ENUM_END
-#undef DIAG_ENUM_ITEM
-#undef DIAG_ENUM
-} // end namespace diag
-
-namespace diag_compat {
-#define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                  \
-  }                                                                            \
-  ;
-#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticRefactoringCompatIDs.inc"
-#undef DIAG_COMPAT_ID
-#undef DIAG_COMPAT_IDS_BEGIN
-#undef DIAG_COMPAT_IDS_END
-} // end namespace diag_compat
-} // end namespace clang
+#include "clang/Basic/DiagnosticRefactoringInterface.inc"
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICREFACTORING_H

--- a/clang/include/clang/Basic/DiagnosticSema.h
+++ b/clang/include/clang/Basic/DiagnosticSema.h
@@ -10,45 +10,6 @@
 #define LLVM_CLANG_BASIC_DIAGNOSTICSEMA_H
 
 #include "clang/Basic/Diagnostic.h"
-
-namespace clang {
-namespace diag {
-enum {
-#define DIAG(ENUM, FLAGS, DEFAULT_MAPPING, DESC, GROUP, SFINAE, NOWERROR,      \
-             SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY)            \
-  ENUM,
-#define SEMASTART
-#include "clang/Basic/DiagnosticSemaKinds.inc"
-#undef DIAG
-  NUM_BUILTIN_SEMA_DIAGNOSTICS
-};
-
-#define DIAG_ENUM(ENUM_NAME)                                                   \
-  namespace ENUM_NAME {                                                        \
-  enum {
-#define DIAG_ENUM_ITEM(IDX, NAME) NAME = IDX,
-#define DIAG_ENUM_END()                                                        \
-  }                                                                            \
-  ;                                                                            \
-  }
-#include "clang/Basic/DiagnosticSemaEnums.inc"
-#undef DIAG_ENUM_END
-#undef DIAG_ENUM_ITEM
-#undef DIAG_ENUM
-
-} // end namespace diag
-
-namespace diag_compat {
-#define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                  \
-  }                                                                            \
-  ;
-#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticSemaCompatIDs.inc"
-#undef DIAG_COMPAT_ID
-#undef DIAG_COMPAT_IDS_BEGIN
-#undef DIAG_COMPAT_IDS_END
-} // end namespace diag_compat
-} // end namespace clang
+#include "clang/Basic/DiagnosticSemaInterface.inc"
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICSEMA_H

--- a/clang/include/clang/Basic/DiagnosticSerialization.h
+++ b/clang/include/clang/Basic/DiagnosticSerialization.h
@@ -10,44 +10,6 @@
 #define LLVM_CLANG_BASIC_DIAGNOSTICSERIALIZATION_H
 
 #include "clang/Basic/Diagnostic.h"
-
-namespace clang {
-namespace diag {
-enum {
-#define DIAG(ENUM, FLAGS, DEFAULT_MAPPING, DESC, GROUP, SFINAE, NOWERROR,      \
-             SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY)            \
-  ENUM,
-#define SERIALIZATIONSTART
-#include "clang/Basic/DiagnosticSerializationKinds.inc"
-#undef DIAG
-  NUM_BUILTIN_SERIALIZATION_DIAGNOSTICS
-};
-
-#define DIAG_ENUM(ENUM_NAME)                                                   \
-  namespace ENUM_NAME {                                                        \
-  enum {
-#define DIAG_ENUM_ITEM(IDX, NAME) NAME = IDX,
-#define DIAG_ENUM_END()                                                        \
-  }                                                                            \
-  ;                                                                            \
-  }
-#include "clang/Basic/DiagnosticSerializationEnums.inc"
-#undef DIAG_ENUM_END
-#undef DIAG_ENUM_ITEM
-#undef DIAG_ENUM
-} // end namespace diag
-
-namespace diag_compat {
-#define DIAG_COMPAT_IDS_BEGIN() enum {
-#define DIAG_COMPAT_IDS_END()                                                  \
-  }                                                                            \
-  ;
-#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/DiagnosticSerializationCompatIDs.inc"
-#undef DIAG_COMPAT_ID
-#undef DIAG_COMPAT_IDS_BEGIN
-#undef DIAG_COMPAT_IDS_END
-} // end namespace diag_compat
-} // end namespace clang
+#include "clang/Basic/DiagnosticSerializationInterface.inc"
 
 #endif // LLVM_CLANG_BASIC_DIAGNOSTICSERIALIZATION_H

--- a/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
+++ b/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
@@ -1570,6 +1570,10 @@ void clang::EmitClangDiagsInterface(llvm::raw_ostream &OS,
   if (Component.empty())
     PrintFatalError("'-gen-clang-diags-iface' requires a component name");
 
+  std::string ComponentUpper = StringRef(Component).upper();
+  const char *Comp = Component.c_str();
+  const char *Upper = ComponentUpper.c_str();
+
   OS << llvm::format(R"c++(
 namespace clang {
 namespace diag {
@@ -1577,10 +1581,10 @@ enum {
 #define DIAG(ENUM, FLAGS, DEFAULT_MAPPING, DESC, GROUP, SFINAE, NOWERROR,      \
              SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY)            \
   ENUM,
-#define %2$sSTART
-#include "clang/Basic/Diagnostic%1$sKinds.inc"
+#define %sSTART
+#include "clang/Basic/Diagnostic%sKinds.inc"
 #undef DIAG
-  NUM_BUILTIN_%2$s_DIAGNOSTICS
+  NUM_BUILTIN_%s_DIAGNOSTICS
 };
 
 #define DIAG_ENUM(ENUM_NAME)                                                   \
@@ -1591,7 +1595,7 @@ enum {
   }                                                                            \
   ;                                                                            \
   }
-#include "clang/Basic/Diagnostic%1$sEnums.inc"
+#include "clang/Basic/Diagnostic%sEnums.inc"
 #undef DIAG_ENUM_END
 #undef DIAG_ENUM_ITEM
 #undef DIAG_ENUM
@@ -1603,14 +1607,14 @@ namespace diag_compat {
   }                                                                            \
   ;
 #define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
-#include "clang/Basic/Diagnostic%1$sCompatIDs.inc"
+#include "clang/Basic/Diagnostic%sCompatIDs.inc"
 #undef DIAG_COMPAT_ID
 #undef DIAG_COMPAT_IDS_BEGIN
 #undef DIAG_COMPAT_IDS_END
 } // end namespace diag_compat
 } // end namespace clang
 )c++",
-                     Component.c_str(), StringRef(Component).upper().c_str());
+                     Upper, Comp, Upper, Comp, Comp);
 }
 
 /// ClangDiagsEnumsEmitter - The top-level class emits .def files containing

--- a/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
+++ b/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
@@ -20,6 +20,7 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/Format.h"
 #include "llvm/TableGen/Error.h"
 #include "llvm/TableGen/Record.h"
 #include "llvm/TableGen/StringToOffsetTable.h"
@@ -1560,6 +1561,56 @@ void clang::EmitClangDiagsCompatIDs(const llvm::RecordKeeper &Records,
 
   if (!PrevComponent.empty())
     OS << "DIAG_COMPAT_IDS_END()\n";
+}
+
+/// ClangDiagsIntefaceEmitter - Emit the diagnostics interface header for
+/// a Clang component.
+void clang::EmitClangDiagsInterface(llvm::raw_ostream &OS,
+                                    const std::string &Component) {
+  if (Component.empty())
+    PrintFatalError("'-gen-clang-diags-iface' requires a component name");
+
+  OS << llvm::format(R"c++(
+namespace clang {
+namespace diag {
+enum {
+#define DIAG(ENUM, FLAGS, DEFAULT_MAPPING, DESC, GROUP, SFINAE, NOWERROR,      \
+             SHOWINSYSHEADER, SHOWINSYSMACRO, DEFERRABLE, CATEGORY)            \
+  ENUM,
+#define %2$sSTART
+#include "clang/Basic/Diagnostic%1$sKinds.inc"
+#undef DIAG
+  NUM_BUILTIN_%2$s_DIAGNOSTICS
+};
+
+#define DIAG_ENUM(ENUM_NAME)                                                   \
+  namespace ENUM_NAME {                                                        \
+  enum {
+#define DIAG_ENUM_ITEM(IDX, NAME) NAME = IDX,
+#define DIAG_ENUM_END()                                                        \
+  }                                                                            \
+  ;                                                                            \
+  }
+#include "clang/Basic/Diagnostic%1$sEnums.inc"
+#undef DIAG_ENUM_END
+#undef DIAG_ENUM_ITEM
+#undef DIAG_ENUM
+} // end namespace diag
+
+namespace diag_compat {
+#define DIAG_COMPAT_IDS_BEGIN() enum {
+#define DIAG_COMPAT_IDS_END()                                                  \
+  }                                                                            \
+  ;
+#define DIAG_COMPAT_ID(IDX, NAME, ...) NAME = IDX,
+#include "clang/Basic/Diagnostic%1$sCompatIDs.inc"
+#undef DIAG_COMPAT_ID
+#undef DIAG_COMPAT_IDS_BEGIN
+#undef DIAG_COMPAT_IDS_END
+} // end namespace diag_compat
+} // end namespace clang
+)c++",
+                     Component.c_str(), StringRef(Component).upper().c_str());
 }
 
 /// ClangDiagsEnumsEmitter - The top-level class emits .def files containing

--- a/clang/utils/TableGen/TableGen.cpp
+++ b/clang/utils/TableGen/TableGen.cpp
@@ -53,6 +53,7 @@ enum ActionType {
   GenClangDiagsEnums,
   GenClangDiagGroups,
   GenClangDiagsIndexName,
+  GenClangDiagsInterface,
   GenClangCommentNodes,
   GenClangDeclNodes,
   GenClangStmtNodes,
@@ -187,6 +188,8 @@ cl::opt<ActionType> Action(
                    "Generate Clang diagnostic groups"),
         clEnumValN(GenClangDiagsIndexName, "gen-clang-diags-index-name",
                    "Generate Clang diagnostic name index"),
+        clEnumValN(GenClangDiagsInterface, "gen-clang-diags-iface",
+                   "Generate Clang diagnostic interface headers"),
         clEnumValN(GenClangBasicReader, "gen-clang-basic-reader",
                    "Generate Clang BasicReader classes"),
         clEnumValN(GenClangBasicWriter, "gen-clang-basic-writer",
@@ -416,6 +419,9 @@ bool ClangTableGenMain(raw_ostream &OS, const RecordKeeper &Records) {
     break;
   case GenClangDiagsIndexName:
     EmitClangDiagsIndexName(Records, OS);
+    break;
+  case GenClangDiagsInterface:
+    EmitClangDiagsInterface(OS, ClangComponent);
     break;
   case GenClangCommentNodes:
     EmitClangASTNodes(Records, OS, CommentNodeClassName, "");

--- a/clang/utils/TableGen/TableGenBackends.h
+++ b/clang/utils/TableGen/TableGenBackends.h
@@ -102,6 +102,8 @@ void EmitClangDiagGroups(const llvm::RecordKeeper &Records,
                          llvm::raw_ostream &OS);
 void EmitClangDiagsIndexName(const llvm::RecordKeeper &Records,
                              llvm::raw_ostream &OS);
+void EmitClangDiagsInterface(llvm::raw_ostream &OS,
+                             const std::string &Component);
 
 void EmitClangSACheckers(const llvm::RecordKeeper &Records,
                          llvm::raw_ostream &OS);


### PR DESCRIPTION
The component diagnostic headers (i.e. `DiagnosticAST.h` and friends) all follow the same format, and there’s enough of them (and in them) to where updating all of them has become rather tedious (at least it was for me while working on #132348), so this patch instead generates all of them (or rather their contents) via Tablegen.

Also, it seems that `%enum_select` currently wouldn’t work in `DiagnosticCommonKinds.td` because the infrastructure for that was missing from `DiagnosticIDs.h`; this patch should fix that as well.