### PR TITLE
[LLDB] Fix warnings in DIL.

### DIFF
--- a/lldb/include/lldb/ValueObject/DILParser.h
+++ b/lldb/include/lldb/ValueObject/DILParser.h
@@ -50,7 +50,7 @@ public:
   }
 
   llvm::ArrayRef<DiagnosticDetail> GetDetails() const override {
-    return {m_detail};
+    return m_detail;
   }
 
   std::string message() const override { return m_detail.rendered; }
@@ -116,8 +116,10 @@ private:
 
   lldb::DynamicValueType m_use_dynamic;
   bool m_use_synthetic;
-  bool m_fragile_ivar;
-  bool m_check_ptr_vs_member;
+  // The following are not currently used, but will be used as more
+  // functionality is added to DIL.
+  bool m_fragile_ivar __attribute__((unused));
+  bool m_check_ptr_vs_member __attribute__((unused));
 }; // class DILParser
 
 } // namespace lldb_private::dil

--- a/lldb/include/lldb/ValueObject/DILParser.h
+++ b/lldb/include/lldb/ValueObject/DILParser.h
@@ -116,10 +116,6 @@ private:
 
   lldb::DynamicValueType m_use_dynamic;
   bool m_use_synthetic;
-  // The following are not currently used, but will be used as more
-  // functionality is added to DIL.
-  bool m_fragile_ivar __attribute__((unused));
-  bool m_check_ptr_vs_member __attribute__((unused));
 }; // class DILParser
 
 } // namespace lldb_private::dil

--- a/lldb/source/ValueObject/DILParser.cpp
+++ b/lldb/source/ValueObject/DILParser.cpp
@@ -66,8 +66,7 @@ DILParser::DILParser(llvm::StringRef dil_input_expr, DILLexer lexer,
                      llvm::Error &error)
     : m_ctx_scope(frame_sp), m_input_expr(dil_input_expr),
       m_dil_lexer(std::move(lexer)), m_error(error), m_use_dynamic(use_dynamic),
-      m_use_synthetic(use_synthetic), m_fragile_ivar(fragile_ivar),
-      m_check_ptr_vs_member(check_ptr_vs_member) {}
+      m_use_synthetic(use_synthetic) {}
 
 ASTNodeUP DILParser::Run() {
   ASTNodeUP expr = ParseExpression();


### PR DESCRIPTION
This fixes 3 warnings from compiling the DILParser:

DILParser.h:53:12: warning: returning address of local temporary object [-Wreturn-stack-address]

DILParser.h:119:8: warning: private field 'm_fragile_ivar' is not used [-Wunused-private-field]

DILParser.h:120:8: warning: private field 'm_check_ptr_vs_member' is not used [-Wunused-private-field]