### PR TITLE
AsmPrinter: Remove ELF's special lowerRelativeReference for unnamed_addr function; use lowerDSOLocalEquivalent in more cases

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
+++ b/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
@@ -125,10 +125,6 @@ public:
   lowerSymbolDifference(const MCSymbol *LHS, const MCSymbol *RHS,
                         int64_t Addend,
                         std::optional<int64_t> PCRelativeOffset) const;
-  const MCExpr *lowerRelativeReference(const GlobalValue *LHS,
-                                       const GlobalValue *RHS, int64_t Addend,
-                                       std::optional<int64_t> PCRelativeOffset,
-                                       const TargetMachine &TM) const override;
 
   const MCExpr *lowerDSOLocalEquivalent(const MCSymbol *LHS,
                                         const MCSymbol *RHS, int64_t Addend,

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -3496,10 +3496,12 @@ const MCExpr *AsmPrinter::lowerConstant(const Constant *CV,
           LHSGV, RHSGV, Addend, PCRelativeOffset, TM);
 
       // (ELF-specific) If the generic symbol difference does not apply, and
-      // LHS is a dso_local_equivalent of a dso_preemptable function,
-      // reference the PLT entry instead.
-      if (DSOEquiv && TM.getTargetTriple().isOSBinFormatELF() &&
-          !(LHSGV->isDSOLocal() || LHSGV->isImplicitDSOLocal()))
+      // LHS is a dso_local_equivalent of a function, reference the PLT entry
+      // instead. Note: A default visibility symbol is by default preemptible
+      // during linking, and should not be referenced with PC-relative
+      // relocations. Therefore, use a PLT relocation even if the function is
+      // dso_local.
+      if (DSOEquiv && TM.getTargetTriple().isOSBinFormatELF())
         Res = getObjFileLowering().lowerDSOLocalEquivalent(
             LHSSym, RHSSym, Addend, PCRelativeOffset, TM);
 

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -1233,24 +1233,6 @@ const MCExpr *TargetLoweringObjectFileELF::lowerSymbolDifference(
   return Res;
 }
 
-const MCExpr *TargetLoweringObjectFileELF::lowerRelativeReference(
-    const GlobalValue *LHS, const GlobalValue *RHS, int64_t Addend,
-    std::optional<int64_t> PCRelativeOffset, const TargetMachine &TM) const {
-  // We may only use a PLT-relative relocation to refer to unnamed_addr
-  // functions.
-  if (!LHS->hasGlobalUnnamedAddr() || !LHS->getValueType()->isFunctionTy())
-    return nullptr;
-
-  // Basic correctness checks.
-  if (LHS->getType()->getPointerAddressSpace() != 0 ||
-      RHS->getType()->getPointerAddressSpace() != 0 || LHS->isThreadLocal() ||
-      RHS->isThreadLocal())
-    return nullptr;
-
-  return lowerSymbolDifference(TM.getSymbol(LHS), TM.getSymbol(RHS), Addend,
-                               PCRelativeOffset);
-}
-
 // Reference the PLT entry of a function, optionally with a subtrahend (`RHS`).
 const MCExpr *TargetLoweringObjectFileELF::lowerDSOLocalEquivalent(
     const MCSymbol *LHS, const MCSymbol *RHS, int64_t Addend,

--- a/llvm/test/CodeGen/ARM/relative-reloc.ll
+++ b/llvm/test/CodeGen/ARM/relative-reloc.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=i686-unknown-linux -o - %s | FileCheck %s
+; RUN: llc -mtriple=armv7-unknown-linux -o - %s | FileCheck %s
 
 @vtable = constant [4 x i32] [i32 0,
     i32 sub (i32 ptrtoint (ptr @fn1 to i32), i32 ptrtoint (ptr getelementptr ([4 x i32], ptr @vtable, i32 0, i32 1) to i32)),
@@ -10,7 +10,8 @@ declare void @fn1() unnamed_addr
 declare void @fn2() unnamed_addr
 declare void @fn3()
 
+;; Create a PC-relative relocation that the linker might decline if the addend symbol is preemptible.
 ; CHECK: .long 0
-; CHECK-NEXT: .long fn1@PLT-vtable-4
-; CHECK-NEXT: .long fn2@PLT-vtable-4
+; CHECK-NEXT: .long fn1-vtable-4
+; CHECK-NEXT: .long fn2-vtable-4
 ; CHECK-NEXT: .long fn3-vtable-4

--- a/llvm/test/CodeGen/RISCV/dso_local_equivalent.ll
+++ b/llvm/test/CodeGen/RISCV/dso_local_equivalent.ll
@@ -26,9 +26,9 @@ declare void @extern_func()
 ; CHECK-NEXT:    .word   0                               # 0x0
 ; CHECK-NEXT:    .word   %pltpcrel(f0)
 ; CHECK-NEXT:    .word   %pltpcrel(f1+4)
-; CHECK-NEXT:    .word   f2-_ZTV1B-8
+; CHECK-NEXT:    .word   %pltpcrel(f2+8)
 ; CHECK-NEXT:    .word   %pltpcrel(f3+12)
-; CHECK-NEXT:    .word   f4-_ZTV1B-8
+; CHECK-NEXT:    .word   %pltpcrel(f4+16)
 ; CHECK-NEXT:    .size   _ZTV1B, 28
 declare void @f0()
 declare void @f1()

--- a/llvm/test/CodeGen/RISCV/relative-reloc.ll
+++ b/llvm/test/CodeGen/RISCV/relative-reloc.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=x86_64-unknown-linux -o - %s | FileCheck %s
+; RUN: llc -mtriple=riscv64 < %s | FileCheck %s
 
 @vtable = constant [5 x i32] [i32 0,
     i32 trunc (i64 sub (i64 ptrtoint (ptr @fn1 to i64), i64 ptrtoint (ptr getelementptr ([5 x i32], ptr @vtable, i32 0, i32 1) to i64)) to i32),
@@ -12,8 +12,11 @@ declare void @fn2() unnamed_addr
 declare void @fn3()
 @global4 = external unnamed_addr global i8
 
-; CHECK: .long 0
-; CHECK-NEXT: .long fn1@PLT-vtable-4
-; CHECK-NEXT: .long fn2@PLT-vtable-4
-; CHECK-NEXT: .long fn3-vtable-4
-; CHECK-NEXT: .long global4-vtable-4
+;; Create a PC-relative relocation that the linker might decline if the addend symbol is preemptible.
+; CHECK:      vtable:
+; CHECK-NEXT:         .word   0                               # 0x0
+; CHECK-NEXT:         .word   fn1-vtable-4
+; CHECK-NEXT:         .word   fn2-vtable-4
+; CHECK-NEXT:         .word   fn3-vtable-4
+; CHECK-NEXT:         .word   global4-vtable-4
+; CHECK-NEXT:         .size   vtable, 20

--- a/llvm/test/CodeGen/X86/dso_local_equivalent.ll
+++ b/llvm/test/CodeGen/X86/dso_local_equivalent.ll
@@ -207,11 +207,27 @@ define void @call_no_name_extern() {
 
 declare hidden void @0()
 declare void @1()
+declare void @forward_extern_func()
 
 ;; Note that we keep this at the very end because llc emits this after all the
 ;; functions.
-; CHECK: const:
-; CHECK:   .long   forward_extern_func@PLT
-@const = constant i32 trunc (i64 ptrtoint (ptr dso_local_equivalent @forward_extern_func to i64) to i32)
+; CHECK-LABEL: _ZTV1B:
+; CHECK:         .long   0
+; CHECK-NEXT:    .long   0
+; CHECK-NEXT:    .long   f0@PLT-_ZTV1B-8
+; CHECK-NEXT:    .long   f1@PLT-_ZTV1B-8
+; CHECK-NEXT:    .long   f2@PLT-_ZTV1B-8
 
-declare void @forward_extern_func()
+@_ZTV1B = dso_local constant { [5 x i32] } { [5 x i32] [
+  i32 0,
+  i32 0,
+  i32 trunc (i64 sub (i64 ptrtoint (ptr dso_local_equivalent @f0 to i64), i64 ptrtoint (ptr getelementptr inbounds ({ [7 x i32] }, ptr @_ZTV1B, i32 0, i32 0, i32 2) to i64)) to i32),
+  i32 trunc (i64 sub (i64 ptrtoint (ptr dso_local_equivalent @f1 to i64), i64 ptrtoint (ptr getelementptr inbounds ({ [7 x i32] }, ptr @_ZTV1B, i32 0, i32 0, i32 2) to i64)) to i32),
+  i32 trunc (i64 sub (i64 ptrtoint (ptr dso_local_equivalent @f2 to i64), i64 ptrtoint (ptr getelementptr inbounds ({ [7 x i32] }, ptr @_ZTV1B, i32 0, i32 0, i32 2) to i64)) to i32)
+] }
+
+declare void @f0()
+declare void @f1()
+define dso_local void @f2() {
+  ret void
+}

--- a/llvm/test/CodeGen/X86/relative-reloc-32.ll
+++ b/llvm/test/CodeGen/X86/relative-reloc-32.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=armv7-unknown-linux -o - %s | FileCheck %s
+; RUN: llc -mtriple=i686-unknown-linux -o - %s | FileCheck %s
 
 @vtable = constant [4 x i32] [i32 0,
     i32 sub (i32 ptrtoint (ptr @fn1 to i32), i32 ptrtoint (ptr getelementptr ([4 x i32], ptr @vtable, i32 0, i32 1) to i32)),
@@ -11,6 +11,6 @@ declare void @fn2() unnamed_addr
 declare void @fn3()
 
 ; CHECK: .long 0
-; CHECK-NEXT: .long fn1(prel31)-vtable-4
-; CHECK-NEXT: .long fn2(prel31)-vtable-4
+; CHECK-NEXT: .long fn1-vtable-4
+; CHECK-NEXT: .long fn2-vtable-4
 ; CHECK-NEXT: .long fn3-vtable-4

--- a/llvm/test/CodeGen/X86/relative-reloc-64.ll
+++ b/llvm/test/CodeGen/X86/relative-reloc-64.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=riscv64 < %s | FileCheck %s
+; RUN: llc -mtriple=x86_64-unknown-linux -o - %s | FileCheck %s
 
 @vtable = constant [5 x i32] [i32 0,
     i32 trunc (i64 sub (i64 ptrtoint (ptr @fn1 to i64), i64 ptrtoint (ptr getelementptr ([5 x i32], ptr @vtable, i32 0, i32 1) to i64)) to i32),
@@ -12,10 +12,9 @@ declare void @fn2() unnamed_addr
 declare void @fn3()
 @global4 = external unnamed_addr global i8
 
-; CHECK:      vtable:
-; CHECK-NEXT:         .word   0                               # 0x0
-; CHECK-NEXT:         .word   %pltpcrel(fn1)
-; CHECK-NEXT:         .word   %pltpcrel(fn2+4)
-; CHECK-NEXT:         .word   fn3-vtable-4
-; CHECK-NEXT:         .word   global4-vtable-4
-; CHECK-NEXT:         .size   vtable, 20
+;; Create a PC-relative relocation that the linker might decline if the addend symbol is preemptible.
+; CHECK: .long 0
+; CHECK-NEXT: .long fn1-vtable-4
+; CHECK-NEXT: .long fn2-vtable-4
+; CHECK-NEXT: .long fn3-vtable-4
+; CHECK-NEXT: .long global4-vtable-4

--- a/llvm/test/CodeGen/X86/relptr-rodata.ll
+++ b/llvm/test/CodeGen/X86/relptr-rodata.ll
@@ -24,7 +24,7 @@ target triple = "x86_64-unknown-linux-gnu"
 ; CHECK-NEXT: .globl obj
 ; CHECK:      obj:
 ; CHECK:      .long 0
-; CHECK:      .long hidden_func-obj-4
+; CHECK:      .long hidden_func@PLT-obj-4
 
 declare hidden void @hidden_func()
 


### PR DESCRIPTION
https://reviews.llvm.org/D17938 introduced lowerRelativeReference to
give ConstantExpr sub (A-B) special semantics in ELF: when `A` is an
`unnamed_addr` function, create a PLT-generating relocation. This was
intended for C++ relative vtables, but C++ relative vtable ended up
using DSOLocalEquivalent (lowerDSOLocalEquivalent).

This special treatment of `unnamed_addr` seems unusual.
Let's remove it. Only COFF needs an overload to generate a @IMGREL32
relocation specifier (llvm/test/MC/COFF/cross-section-relative.ll).
