### PR TITLE
[MLIR][NFC] Retire let constructor for Tosa

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.h
@@ -41,13 +41,7 @@ void populateTosaConstantReduction(MLIRContext *ctx,
 
 void populateTosaTypeConversion(TypeConverter &converter);
 
-std::unique_ptr<Pass> createTosaLayerwiseConstantFoldPass();
-std::unique_ptr<Pass> createTosaLayerwiseConstantFoldPass(
-    const TosaLayerwiseConstantFoldPassOptions &options);
-std::unique_ptr<Pass> createTosaInferShapesPass();
-std::unique_ptr<Pass> createTosaMakeBroadcastablePass();
 std::unique_ptr<Pass> createTosaTestQuantUtilAPIPass();
-std::unique_ptr<Pass> createTosaOptionalDecompositions();
 
 #define GEN_PASS_REGISTRATION
 #include "mlir/Dialect/Tosa/Transforms/Passes.h.inc"

--- a/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
@@ -22,8 +22,6 @@ def TosaLayerwiseConstantFoldPass : Pass<"tosa-layerwise-constant-fold", "func::
     Pass that enables folding of full-layer operations on constant tensors.
   }];
 
-  let constructor = "createTosaLayerwiseConstantFoldPass()";
-
   let options = [
       Option<"aggressiveReduceConstant", "aggressive-reduce-constant", "bool",
              /*default=*/"false",
@@ -32,14 +30,13 @@ def TosaLayerwiseConstantFoldPass : Pass<"tosa-layerwise-constant-fold", "func::
    ];
 }
 
-def TosaInferShapes : Pass<"tosa-infer-shapes", "func::FuncOp"> {
+def TosaInferShapesPass : Pass<"tosa-infer-shapes", "func::FuncOp"> {
   let summary = "Propagate shapes across TOSA operations";
   let description = [{
     Pass that uses operand types and propagates shapes to TOSA operations.
     This includes legalizing rankless and dynamic shapes towards static.
   }];
 
-  let constructor = "createTosaInferShapesPass()";
   let dependentDialects = [
     "func::FuncDialect",
     "tensor::TensorDialect",
@@ -47,7 +44,8 @@ def TosaInferShapes : Pass<"tosa-infer-shapes", "func::FuncOp"> {
   ];
 }
 
-def TosaMakeBroadcastable : Pass<"tosa-make-broadcastable", "func::FuncOp"> {
+def TosaMakeBroadcastablePass
+    : Pass<"tosa-make-broadcastable", "func::FuncOp"> {
   let summary = "TOSA rank Reshape to enable Broadcasting";
   let description = [{
     Pass that enables broadcast by making all input arrays have the same
@@ -56,19 +54,15 @@ def TosaMakeBroadcastable : Pass<"tosa-make-broadcastable", "func::FuncOp"> {
     approach similar to step 1 of Numpy 4-step broadcasting:
     https://numpy.org/doc/stable/reference/ufuncs.html#broadcasting
   }];
-
-  let constructor = "createTosaMakeBroadcastablePass()";
 }
 
-def TosaOptionalDecompositions
-  : Pass<"tosa-optional-decompositions", "func::FuncOp"> {
+def TosaOptionalDecompositionsPass
+    : Pass<"tosa-optional-decompositions", "func::FuncOp"> {
   let summary = "Applies Tosa operations optional decompositions";
   let description = [{
     Pass to apply the Tosa operations decompositions
     exposed as populate functions in include/mlir/Dialect/Tosa/Transforms/Passes.h
   }];
-
-  let constructor = "tosa::createTosaOptionalDecompositions()";
 }
 
 def TosaLevelType : I32EnumAttr<"TosaLevelEnum", "Tosa level",

--- a/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgPass.cpp
+++ b/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgPass.cpp
@@ -85,7 +85,8 @@ void mlir::tosa::addTosaToLinalgPasses(
     std::optional<tosa::TosaValidationOptions> validationOptions) {
   // Optional decompositions are designed to benefit linalg.
   if (!options.disableTosaDecompositions)
-    pm.addNestedPass<func::FuncOp>(tosa::createTosaOptionalDecompositions());
+    pm.addNestedPass<func::FuncOp>(
+        tosa::createTosaOptionalDecompositionsPass());
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
 
   pm.addNestedPass<func::FuncOp>(tosa::createTosaInferShapesPass());

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaInferShapes.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaInferShapes.cpp
@@ -25,7 +25,7 @@
 
 namespace mlir {
 namespace tosa {
-#define GEN_PASS_DEF_TOSAINFERSHAPES
+#define GEN_PASS_DEF_TOSAINFERSHAPESPASS
 #include "mlir/Dialect/Tosa/Transforms/Passes.h.inc"
 } // namespace tosa
 } // namespace mlir
@@ -333,7 +333,7 @@ void validateSameOperandsAndResultRankTrait(Region &region) {
 /// Pass that performs shape propagation across TOSA operations. This includes
 /// migrating to within the regions of if/while operations.
 struct TosaInferShapes
-    : public tosa::impl::TosaInferShapesBase<TosaInferShapes> {
+    : public tosa::impl::TosaInferShapesPassBase<TosaInferShapes> {
 public:
   void runOnOperation() override {
     func::FuncOp func = getOperation();
@@ -345,7 +345,3 @@ public:
   }
 };
 } // namespace
-
-std::unique_ptr<Pass> mlir::tosa::createTosaInferShapesPass() {
-  return std::make_unique<TosaInferShapes>();
-}

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaLayerwiseConstantFoldPass.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaLayerwiseConstantFoldPass.cpp
@@ -45,9 +45,7 @@ void populateTosaOpsCanonicalizationPatterns(MLIRContext *ctx,
 struct TosaLayerwiseConstantFoldPass
     : public tosa::impl::TosaLayerwiseConstantFoldPassBase<
           TosaLayerwiseConstantFoldPass> {
-  TosaLayerwiseConstantFoldPass(
-      const TosaLayerwiseConstantFoldPassOptions &options)
-      : TosaLayerwiseConstantFoldPassBase(options) {}
+  using Base::Base;
 
   void runOnOperation() override {
     auto *ctx = &getContext();
@@ -66,13 +64,3 @@ struct TosaLayerwiseConstantFoldPass
 };
 
 } // namespace
-
-std::unique_ptr<Pass> mlir::tosa::createTosaLayerwiseConstantFoldPass() {
-  return std::make_unique<TosaLayerwiseConstantFoldPass>(
-      TosaLayerwiseConstantFoldPassOptions{false});
-}
-
-std::unique_ptr<Pass> mlir::tosa::createTosaLayerwiseConstantFoldPass(
-    const TosaLayerwiseConstantFoldPassOptions &options) {
-  return std::make_unique<TosaLayerwiseConstantFoldPass>(options);
-}

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaMakeBroadcastable.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaMakeBroadcastable.cpp
@@ -21,7 +21,7 @@
 
 namespace mlir {
 namespace tosa {
-#define GEN_PASS_DEF_TOSAMAKEBROADCASTABLE
+#define GEN_PASS_DEF_TOSAMAKEBROADCASTABLEPASS
 #include "mlir/Dialect/Tosa/Transforms/Passes.h.inc"
 } // namespace tosa
 } // namespace mlir
@@ -219,7 +219,7 @@ namespace {
 /// Pass that enables broadcast by making all input arrays have the same
 /// number of dimensions. Insert RESHAPE operations to lower rank operand
 struct TosaMakeBroadcastable
-    : public tosa::impl::TosaMakeBroadcastableBase<TosaMakeBroadcastable> {
+    : public tosa::impl::TosaMakeBroadcastablePassBase<TosaMakeBroadcastable> {
 public:
   void runOnOperation() override {
     auto func = getOperation();
@@ -250,7 +250,3 @@ public:
   }
 };
 } // namespace
-
-std::unique_ptr<Pass> mlir::tosa::createTosaMakeBroadcastablePass() {
-  return std::make_unique<TosaMakeBroadcastable>();
-}

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaOptionalDecompositions.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaOptionalDecompositions.cpp
@@ -21,7 +21,7 @@
 
 namespace mlir {
 namespace tosa {
-#define GEN_PASS_DEF_TOSAOPTIONALDECOMPOSITIONS
+#define GEN_PASS_DEF_TOSAOPTIONALDECOMPOSITIONSPASS
 #include "mlir/Dialect/Tosa/Transforms/Passes.h.inc"
 } // namespace tosa
 } // namespace mlir
@@ -31,7 +31,7 @@ using namespace mlir;
 namespace {
 
 struct TosaOptionalDecompositions
-    : public tosa::impl::TosaOptionalDecompositionsBase<
+    : public tosa::impl::TosaOptionalDecompositionsPassBase<
           TosaOptionalDecompositions> {
   void runOnOperation() override {
     auto *ctx = &getContext();
@@ -47,7 +47,3 @@ struct TosaOptionalDecompositions
 };
 
 } // namespace
-
-std::unique_ptr<Pass> mlir::tosa::createTosaOptionalDecompositions() {
-  return std::make_unique<TosaOptionalDecompositions>();
-}


### PR DESCRIPTION
`let constructor` is legacy (do not use in tree!) since the tableGen
backend emits most of the glue logic to build a pass.