### PR TITLE
[MLIR][NFC] Retire let constructor for Reducer

### DIFF
--- a/mlir/include/mlir/Reducer/Passes.h
+++ b/mlir/include/mlir/Reducer/Passes.h
@@ -15,10 +15,6 @@ namespace mlir {
 #define GEN_PASS_DECL
 #include "mlir/Reducer/Passes.h.inc"
 
-std::unique_ptr<Pass> createReductionTreePass();
-
-std::unique_ptr<Pass> createOptReductionPass();
-
 /// Generate the code for registering reducer passes.
 #define GEN_PASS_REGISTRATION
 #include "mlir/Reducer/Passes.h.inc"

--- a/mlir/include/mlir/Reducer/Passes.td
+++ b/mlir/include/mlir/Reducer/Passes.td
@@ -24,10 +24,8 @@ def CommonReductionPassOptions {
   ];
 }
 
-def ReductionTree : Pass<"reduction-tree"> {
+def ReductionTreePass : Pass<"reduction-tree"> {
   let summary = "Reduce the input with reduction-tree algorithm";
-
-  let constructor = "mlir::createReductionTreePass()";
 
   let options = [
     Option<"traversalModeId", "traversal-mode", "unsigned",
@@ -36,10 +34,8 @@ def ReductionTree : Pass<"reduction-tree"> {
   ] # CommonReductionPassOptions.options;
 }
 
-def OptReduction : Pass<"opt-reduction-pass", "ModuleOp"> {
+def OptReductionPass : Pass<"opt-reduction-pass", "ModuleOp"> {
   let summary = "A wrapper pass that reduces the file with optimization passes";
-
-  let constructor = "mlir::createOptReductionPass()";
 
   let options = [
     Option<"optPass", "opt-pass", "std::string", /* default */"",

--- a/mlir/lib/Reducer/OptReductionPass.cpp
+++ b/mlir/lib/Reducer/OptReductionPass.cpp
@@ -19,7 +19,7 @@
 #include "llvm/Support/Debug.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_OPTREDUCTION
+#define GEN_PASS_DEF_OPTREDUCTIONPASS
 #include "mlir/Reducer/Passes.h.inc"
 } // namespace mlir
 
@@ -29,8 +29,10 @@ using namespace mlir;
 
 namespace {
 
-class OptReductionPass : public impl::OptReductionBase<OptReductionPass> {
+class OptReductionPass : public impl::OptReductionPassBase<OptReductionPass> {
 public:
+  using Base::Base;
+
   /// Runs the pass instance in the pass pipeline.
   void runOnOperation() override;
 };
@@ -85,8 +87,4 @@ void OptReductionPass::runOnOperation() {
   moduleVariant->destroy();
 
   LLVM_DEBUG(llvm::dbgs() << "Pass Complete\n\n");
-}
-
-std::unique_ptr<Pass> mlir::createOptReductionPass() {
-  return std::make_unique<OptReductionPass>();
 }

--- a/mlir/lib/Reducer/OptReductionPass.cpp
+++ b/mlir/lib/Reducer/OptReductionPass.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Reducer/Passes.h"
 #include "mlir/Reducer/Tester.h"
+
 #include "llvm/Support/Debug.h"
 
 namespace mlir {

--- a/mlir/lib/Reducer/ReductionTreePass.cpp
+++ b/mlir/lib/Reducer/ReductionTreePass.cpp
@@ -29,7 +29,7 @@
 #include "llvm/Support/ManagedStatic.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_REDUCTIONTREE
+#define GEN_PASS_DEF_REDUCTIONTREEPASS
 #include "mlir/Reducer/Passes.h.inc"
 } // namespace mlir
 
@@ -191,10 +191,10 @@ public:
 /// This class defines the Reduction Tree Pass. It provides a framework to
 /// to implement a reduction pass using a tree structure to keep track of the
 /// generated reduced variants.
-class ReductionTreePass : public impl::ReductionTreeBase<ReductionTreePass> {
+class ReductionTreePass
+    : public impl::ReductionTreePassBase<ReductionTreePass> {
 public:
-  ReductionTreePass() = default;
-  ReductionTreePass(const ReductionTreePass &pass) = default;
+  using Base::Base;
 
   LogicalResult initialize(MLIRContext *context) override;
 
@@ -255,8 +255,4 @@ LogicalResult ReductionTreePass::reduceOp(ModuleOp module, Region &region) {
   default:
     return module.emitError() << "unsupported traversal mode detected";
   }
-}
-
-std::unique_ptr<Pass> mlir::createReductionTreePass() {
-  return std::make_unique<ReductionTreePass>();
 }


### PR DESCRIPTION
let constructor is legacy (do not use in tree!) since the tableGen
backend emits most of the glue logic to build a pass.