### PR TITLE
[MLIR][NFC] Retire let constructor for MemRef

### DIFF
--- a/mlir/include/mlir/Dialect/MemRef/Transforms/Passes.h
+++ b/mlir/include/mlir/Dialect/MemRef/Transforms/Passes.h
@@ -37,45 +37,13 @@ class VectorDialect;
 } // namespace vector
 
 namespace memref {
+
 //===----------------------------------------------------------------------===//
 // Passes
 //===----------------------------------------------------------------------===//
 
 #define GEN_PASS_DECL
 #include "mlir/Dialect/MemRef/Transforms/Passes.h.inc"
-
-/// Creates an instance of the ExpandOps pass that legalizes memref dialect ops
-/// to be convertible to LLVM. For example, `memref.reshape` gets converted to
-/// `memref_reinterpret_cast`.
-std::unique_ptr<Pass> createExpandOpsPass();
-
-/// Creates an operation pass to fold memref aliasing ops into consumer
-/// load/store ops into `patterns`.
-std::unique_ptr<Pass> createFoldMemRefAliasOpsPass();
-
-/// Creates an interprocedural pass to normalize memrefs to have a trivial
-/// (identity) layout map.
-std::unique_ptr<OperationPass<ModuleOp>> createNormalizeMemRefsPass();
-
-/// Creates an operation pass to resolve `memref.dim` operations with values
-/// that are defined by operations that implement the
-/// `ReifyRankedShapedTypeOpInterface`, in terms of shapes of its input
-/// operands.
-std::unique_ptr<Pass> createResolveRankedShapeTypeResultDimsPass();
-
-/// Creates an operation pass to resolve `memref.dim` operations with values
-/// that are defined by operations that implement the
-/// `InferShapedTypeOpInterface` or the `ReifyRankedShapedTypeOpInterface`,
-/// in terms of shapes of its input operands.
-std::unique_ptr<Pass> createResolveShapedTypeResultDimsPass();
-
-/// Creates an operation pass to expand some memref operation into
-/// easier to reason about operations.
-std::unique_ptr<Pass> createExpandStridedMetadataPass();
-
-/// Creates an operation pass to expand `memref.realloc` operations into their
-/// components.
-std::unique_ptr<Pass> createExpandReallocPass(bool emitDeallocs = true);
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/mlir/include/mlir/Dialect/MemRef/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/MemRef/Transforms/Passes.td
@@ -11,18 +11,16 @@
 
 include "mlir/Pass/PassBase.td"
 
-def ExpandOps : Pass<"memref-expand"> {
+def ExpandOpsPass : Pass<"memref-expand"> {
   let summary = "Legalize memref operations to be convertible to LLVM.";
-  let constructor = "mlir::memref::createExpandOpsPass()";
 }
 
-def FoldMemRefAliasOps : Pass<"fold-memref-alias-ops"> {
+def FoldMemRefAliasOpsPass : Pass<"fold-memref-alias-ops"> {
   let summary = "Fold memref alias ops into consumer load/store ops";
   let description = [{
     The pass folds loading/storing from/to memref aliasing ops to loading/storing
     from/to the original memref.
   }];
-  let constructor = "mlir::memref::createFoldMemRefAliasOpsPass()";
   let dependentDialects = [
       "affine::AffineDialect", "memref::MemRefDialect", "vector::VectorDialect"
   ];
@@ -44,9 +42,9 @@ def MemRefEmulateWideInt : Pass<"memref-emulate-wide-int"> {
   let dependentDialects = ["vector::VectorDialect"];
 }
 
-def NormalizeMemRefs : Pass<"normalize-memrefs", "ModuleOp"> {
+def NormalizeMemRefsPass : Pass<"normalize-memrefs", "ModuleOp"> {
   let summary = "Normalize memrefs";
-   let description = [{
+  let description = [{
     This pass transforms memref types with a non-trivial
     [layout map](https://mlir.llvm.org/docs/Dialects/Builtin/#affine-map-layout)
     into memref types with an identity layout map, e.g. (i, j) -> (i, j). This
@@ -155,26 +153,23 @@ def NormalizeMemRefs : Pass<"normalize-memrefs", "ModuleOp"> {
   }
   ```
   }];
-  let constructor = "mlir::memref::createNormalizeMemRefsPass()";
   let dependentDialects = ["affine::AffineDialect"];
 }
 
-def ResolveRankedShapeTypeResultDims :
-    Pass<"resolve-ranked-shaped-type-result-dims"> {
+def ResolveRankedShapeTypeResultDimsPass
+    : Pass<"resolve-ranked-shaped-type-result-dims"> {
   let summary = "Resolve memref.dim of result values of ranked shape type";
   let description = [{
     The pass resolves memref.dim of result of operations that
     implement the `ReifyRankedShapedTypeOpInterface` in terms of
     shapes of its operands.
   }];
-  let constructor =
-      "mlir::memref::createResolveRankedShapeTypeResultDimsPass()";
   let dependentDialects = [
     "memref::MemRefDialect", "tensor::TensorDialect"
   ];
 }
 
-def ResolveShapedTypeResultDims : Pass<"resolve-shaped-type-result-dims"> {
+def ResolveShapedTypeResultDimsPass : Pass<"resolve-shaped-type-result-dims"> {
   let summary = "Resolve memref.dim of result values";
   let description = [{
     The pass resolves memref.dim of result of operations that
@@ -182,13 +177,12 @@ def ResolveShapedTypeResultDims : Pass<"resolve-shaped-type-result-dims"> {
     `ReifyRankedShapedTypeOpInterface` in terms of shapes of its
     operands.
   }];
-  let constructor = "mlir::memref::createResolveShapedTypeResultDimsPass()";
   let dependentDialects = [
     "affine::AffineDialect", "memref::MemRefDialect", "tensor::TensorDialect"
   ];
 }
 
-def ExpandStridedMetadata : Pass<"expand-strided-metadata"> {
+def ExpandStridedMetadataPass : Pass<"expand-strided-metadata"> {
   let summary = "Expand memref operations into easier to analyze constructs";
   let description = [{
     The pass expands memref operations that modify the metadata of a memref
@@ -205,13 +199,12 @@ def ExpandStridedMetadata : Pass<"expand-strided-metadata"> {
     - `memref.extract_strided_metadata`
     - `memref.subview`
   }];
-  let constructor = "mlir::memref::createExpandStridedMetadataPass()";
   let dependentDialects = [
       "affine::AffineDialect", "memref::MemRefDialect"
   ];
 }
 
-def ExpandRealloc : Pass<"expand-realloc"> {
+def ExpandReallocPass : Pass<"expand-realloc"> {
   let summary = "Expand memref.realloc operations into its components";
   let description = [{
     The `memref.realloc` operation performs a conditional allocation and copy to
@@ -243,11 +236,10 @@ def ExpandRealloc : Pass<"expand-realloc"> {
     }
     ```
   }];
-  let options = [
-    Option<"emitDeallocs", "emit-deallocs", "bool", /*default=*/"true",
-           "Emit deallocation operations for the original MemRef">,
+  let options = [Option<"emitDeallocs", "emit-deallocs", "bool",
+                        /*default=*/"true",
+                        "Emit deallocation operations for the original MemRef">,
   ];
-  let constructor = "mlir::memref::createExpandReallocPass()";
   let dependentDialects = [
       "arith::ArithDialect", "scf::SCFDialect", "memref::MemRefDialect"
   ];

--- a/mlir/lib/Dialect/Bufferization/Pipelines/BufferizationPipelines.cpp
+++ b/mlir/lib/Dialect/Bufferization/Pipelines/BufferizationPipelines.cpp
@@ -20,7 +20,9 @@
 
 void mlir::bufferization::buildBufferDeallocationPipeline(
     OpPassManager &pm, const BufferDeallocationPipelineOptions &options) {
-  pm.addPass(memref::createExpandReallocPass(/*emitDeallocs=*/false));
+  memref::ExpandReallocPassOptions expandAllocPassOptions{
+      /*emitDeallocs=*/false};
+  pm.addPass(memref::createExpandReallocPass(expandAllocPassOptions));
   pm.addPass(createCanonicalizerPass());
 
   OwnershipBasedBufferDeallocationPassOptions deallocationOptions{

--- a/mlir/lib/Dialect/MemRef/Transforms/ExpandOps.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/ExpandOps.cpp
@@ -24,7 +24,7 @@
 
 namespace mlir {
 namespace memref {
-#define GEN_PASS_DEF_EXPANDOPS
+#define GEN_PASS_DEF_EXPANDOPSPASS
 #include "mlir/Dialect/MemRef/Transforms/Passes.h.inc"
 } // namespace memref
 } // namespace mlir
@@ -130,7 +130,7 @@ public:
   }
 };
 
-struct ExpandOpsPass : public memref::impl::ExpandOpsBase<ExpandOpsPass> {
+struct ExpandOpsPass : public memref::impl::ExpandOpsPassBase<ExpandOpsPass> {
   void runOnOperation() override {
     MLIRContext &ctx = getContext();
 
@@ -160,8 +160,4 @@ struct ExpandOpsPass : public memref::impl::ExpandOpsBase<ExpandOpsPass> {
 void mlir::memref::populateExpandOpsPatterns(RewritePatternSet &patterns) {
   patterns.add<AtomicRMWOpConverter, MemRefReshapeOpConverter>(
       patterns.getContext());
-}
-
-std::unique_ptr<Pass> mlir::memref::createExpandOpsPass() {
-  return std::make_unique<ExpandOpsPass>();
 }

--- a/mlir/lib/Dialect/MemRef/Transforms/ExpandRealloc.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/ExpandRealloc.cpp
@@ -16,7 +16,7 @@
 
 namespace mlir {
 namespace memref {
-#define GEN_PASS_DEF_EXPANDREALLOC
+#define GEN_PASS_DEF_EXPANDREALLOCPASS
 #include "mlir/Dialect/MemRef/Transforms/Passes.h.inc"
 } // namespace memref
 } // namespace mlir
@@ -142,11 +142,9 @@ private:
 };
 
 struct ExpandReallocPass
-    : public memref::impl::ExpandReallocBase<ExpandReallocPass> {
-  ExpandReallocPass(bool emitDeallocs)
-      : memref::impl::ExpandReallocBase<ExpandReallocPass>() {
-    this->emitDeallocs.setValue(emitDeallocs);
-  }
+    : public memref::impl::ExpandReallocPassBase<ExpandReallocPass> {
+  using Base::Base;
+
   void runOnOperation() override {
     MLIRContext &ctx = getContext();
 
@@ -168,8 +166,4 @@ struct ExpandReallocPass
 void mlir::memref::populateExpandReallocPatterns(RewritePatternSet &patterns,
                                                  bool emitDeallocs) {
   patterns.add<ExpandReallocOpPattern>(patterns.getContext(), emitDeallocs);
-}
-
-std::unique_ptr<Pass> mlir::memref::createExpandReallocPass(bool emitDeallocs) {
-  return std::make_unique<ExpandReallocPass>(emitDeallocs);
 }

--- a/mlir/lib/Dialect/MemRef/Transforms/ExpandStridedMetadata.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/ExpandStridedMetadata.cpp
@@ -28,7 +28,7 @@
 
 namespace mlir {
 namespace memref {
-#define GEN_PASS_DEF_EXPANDSTRIDEDMETADATA
+#define GEN_PASS_DEF_EXPANDSTRIDEDMETADATAPASS
 #include "mlir/Dialect/MemRef/Transforms/Passes.h.inc"
 } // namespace memref
 } // namespace mlir
@@ -1213,7 +1213,7 @@ void memref::populateResolveExtractStridedMetadataPatterns(
 namespace {
 
 struct ExpandStridedMetadataPass final
-    : public memref::impl::ExpandStridedMetadataBase<
+    : public memref::impl::ExpandStridedMetadataPassBase<
           ExpandStridedMetadataPass> {
   void runOnOperation() override;
 };
@@ -1224,8 +1224,4 @@ void ExpandStridedMetadataPass::runOnOperation() {
   RewritePatternSet patterns(&getContext());
   memref::populateExpandStridedMetadataPatterns(patterns);
   (void)applyPatternsGreedily(getOperation(), std::move(patterns));
-}
-
-std::unique_ptr<Pass> memref::createExpandStridedMetadataPass() {
-  return std::make_unique<ExpandStridedMetadataPass>();
 }

--- a/mlir/lib/Dialect/MemRef/Transforms/FoldMemRefAliasOps.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/FoldMemRefAliasOps.cpp
@@ -35,7 +35,7 @@
 
 namespace mlir {
 namespace memref {
-#define GEN_PASS_DEF_FOLDMEMREFALIASOPS
+#define GEN_PASS_DEF_FOLDMEMREFALIASOPSPASS
 #include "mlir/Dialect/MemRef/Transforms/Passes.h.inc"
 } // namespace memref
 } // namespace mlir
@@ -848,7 +848,7 @@ void memref::populateFoldMemRefAliasOpPatterns(RewritePatternSet &patterns) {
 namespace {
 
 struct FoldMemRefAliasOpsPass final
-    : public memref::impl::FoldMemRefAliasOpsBase<FoldMemRefAliasOpsPass> {
+    : public memref::impl::FoldMemRefAliasOpsPassBase<FoldMemRefAliasOpsPass> {
   void runOnOperation() override;
 };
 
@@ -858,8 +858,4 @@ void FoldMemRefAliasOpsPass::runOnOperation() {
   RewritePatternSet patterns(&getContext());
   memref::populateFoldMemRefAliasOpPatterns(patterns);
   (void)applyPatternsGreedily(getOperation(), std::move(patterns));
-}
-
-std::unique_ptr<Pass> memref::createFoldMemRefAliasOpsPass() {
-  return std::make_unique<FoldMemRefAliasOpsPass>();
 }

--- a/mlir/lib/Dialect/MemRef/Transforms/NormalizeMemRefs.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/NormalizeMemRefs.cpp
@@ -21,7 +21,7 @@
 
 namespace mlir {
 namespace memref {
-#define GEN_PASS_DEF_NORMALIZEMEMREFS
+#define GEN_PASS_DEF_NORMALIZEMEMREFSPASS
 #include "mlir/Dialect/MemRef/Transforms/Passes.h.inc"
 } // namespace memref
 } // namespace mlir
@@ -40,7 +40,7 @@ namespace {
 /// to call a non-normalizable function, we treat that function as
 /// non-normalizable as well. We assume external functions to be normalizable.
 struct NormalizeMemRefs
-    : public memref::impl::NormalizeMemRefsBase<NormalizeMemRefs> {
+    : public memref::impl::NormalizeMemRefsPassBase<NormalizeMemRefs> {
   void runOnOperation() override;
   void normalizeFuncOpMemRefs(func::FuncOp funcOp, ModuleOp moduleOp);
   bool areMemRefsNormalizable(func::FuncOp funcOp);
@@ -52,11 +52,6 @@ struct NormalizeMemRefs
 };
 
 } // namespace
-
-std::unique_ptr<OperationPass<ModuleOp>>
-mlir::memref::createNormalizeMemRefsPass() {
-  return std::make_unique<NormalizeMemRefs>();
-}
 
 void NormalizeMemRefs::runOnOperation() {
   LLVM_DEBUG(llvm::dbgs() << "Normalizing Memrefs...\n");

--- a/mlir/lib/Dialect/MemRef/Transforms/ResolveShapedTypeResultDims.cpp
+++ b/mlir/lib/Dialect/MemRef/Transforms/ResolveShapedTypeResultDims.cpp
@@ -25,8 +25,8 @@
 
 namespace mlir {
 namespace memref {
-#define GEN_PASS_DEF_RESOLVERANKEDSHAPETYPERESULTDIMS
-#define GEN_PASS_DEF_RESOLVESHAPEDTYPERESULTDIMS
+#define GEN_PASS_DEF_RESOLVERANKEDSHAPETYPERESULTDIMSPASS
+#define GEN_PASS_DEF_RESOLVESHAPEDTYPERESULTDIMSPASS
 #include "mlir/Dialect/MemRef/Transforms/Passes.h.inc"
 } // namespace memref
 } // namespace mlir
@@ -164,13 +164,13 @@ struct IterArgsToInitArgs : public OpRewritePattern<tensor::DimOp> {
 
 namespace {
 struct ResolveRankedShapeTypeResultDimsPass final
-    : public memref::impl::ResolveRankedShapeTypeResultDimsBase<
+    : public memref::impl::ResolveRankedShapeTypeResultDimsPassBase<
           ResolveRankedShapeTypeResultDimsPass> {
   void runOnOperation() override;
 };
 
 struct ResolveShapedTypeResultDimsPass final
-    : public memref::impl::ResolveShapedTypeResultDimsBase<
+    : public memref::impl::ResolveShapedTypeResultDimsPassBase<
           ResolveShapedTypeResultDimsPass> {
   void runOnOperation() override;
 };
@@ -205,12 +205,4 @@ void ResolveShapedTypeResultDimsPass::runOnOperation() {
   memref::populateResolveShapedTypeResultDimsPatterns(patterns);
   if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
     return signalPassFailure();
-}
-
-std::unique_ptr<Pass> memref::createResolveShapedTypeResultDimsPass() {
-  return std::make_unique<ResolveShapedTypeResultDimsPass>();
-}
-
-std::unique_ptr<Pass> memref::createResolveRankedShapeTypeResultDimsPass() {
-  return std::make_unique<ResolveRankedShapeTypeResultDimsPass>();
 }

--- a/mlir/test/python/pass_manager.py
+++ b/mlir/test/python/pass_manager.py
@@ -130,7 +130,7 @@ def testInvalidNesting():
         try:
             pm = PassManager.parse("func.func(normalize-memrefs)")
         except ValueError as e:
-            # CHECK: ValueError exception: Can't add pass 'NormalizeMemRefs' restricted to 'builtin.module' on a PassManager intended to run on 'func.func', did you intend to nest?
+            # CHECK: ValueError exception: Can't add pass 'NormalizeMemRefsPass' restricted to 'builtin.module' on a PassManager intended to run on 'func.func', did you intend to nest?
             log("ValueError exception:", e)
         else:
             log("Exception not produced")


### PR DESCRIPTION
let constructor is legacy (do not use in tree!) since the tableGen
backend emits most of the glue logic to build a pass.

Note: The following constructor has been retired:

```cpp
std::unique_ptr<Pass> createExpandReallocPass(bool emitDeallocs = true);
```
    
To update your codebase, replace it with the new options-based API:
    
```cpp
memref::ExpandReallocPassOptions expandAllocPassOptions{
          /*emitDeallocs=*/false};
pm.addPass(memref::createExpandReallocPass(expandAllocPassOptions));
```