### PR TITLE
[CI] Always upload queue/running count

### DIFF
--- a/.ci/metrics/metrics.py
+++ b/.ci/metrics/metrics.py
@@ -282,6 +282,13 @@ def github_get_metrics(
     queued_count = collections.Counter()
     running_count = collections.Counter()
 
+    # Initialize all the counters to 0 so we report 0 when no job is queued
+    # or running.
+    for wf_name, wf_metric_name in GITHUB_WORKFLOW_TO_TRACK.items():
+      for job_name, job_metric_name in GITHUB_JOB_TO_TRACK[wf_metric_name].items():
+        queued_count[wf_metric_name + "_" + job_metric_name] = 0
+        running_count[wf_metric_name + "_" + job_metric_name] = 0
+
     # The list of workflows this iteration will process.
     # MaxSize = GITHUB_WORKFLOWS_MAX_PROCESS_COUNT
     workflow_seen_as_completed = set()

--- a/.ci/metrics/metrics.py
+++ b/.ci/metrics/metrics.py
@@ -285,9 +285,9 @@ def github_get_metrics(
     # Initialize all the counters to 0 so we report 0 when no job is queued
     # or running.
     for wf_name, wf_metric_name in GITHUB_WORKFLOW_TO_TRACK.items():
-      for job_name, job_metric_name in GITHUB_JOB_TO_TRACK[wf_metric_name].items():
-        queued_count[wf_metric_name + "_" + job_metric_name] = 0
-        running_count[wf_metric_name + "_" + job_metric_name] = 0
+        for job_name, job_metric_name in GITHUB_JOB_TO_TRACK[wf_metric_name].items():
+            queued_count[wf_metric_name + "_" + job_metric_name] = 0
+            running_count[wf_metric_name + "_" + job_metric_name] = 0
 
     # The list of workflows this iteration will process.
     # MaxSize = GITHUB_WORKFLOWS_MAX_PROCESS_COUNT


### PR DESCRIPTION
Before this commit, we only pushed a queue/running count when the value was not zero. This makes building Grafana alerting a bit harder. Changing this to always upload a value for watched workflows.