### PR TITLE
[WebAssembly] Align bulk-memory thresholds

### DIFF
--- a/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyISelLowering.cpp
@@ -394,6 +394,17 @@ WebAssemblyTargetLowering::WebAssemblyTargetLowering(
   // is equivalent to a simple branch. This reduces code size for wasm, and we
   // defer possible jump table optimizations to the VM.
   setMinimumJumpTableEntries(2);
+
+  // Align bulk memory usage when optimizing for size or otherwise. As well as
+  // reducing code size, prefering high-level primitives can make it easier for
+  // runtimes to make optimisations, especially when explicit bounds checking is
+  // employed.
+  if (Subtarget->hasBulkMemory()) {
+    MaxStoresPerMemset = MaxStoresPerMemsetOptSize;
+    MaxStoresPerMemcpy = MaxStoresPerMemcpyOptSize;
+    MaxStoresPerMemmove = MaxStoresPerMemmoveOptSize;
+    MaxLoadsPerMemcmp = MaxLoadsPerMemcmpOptSize;
+  }
 }
 
 MVT WebAssemblyTargetLowering::getPointerTy(const DataLayout &DL,

--- a/llvm/test/CodeGen/WebAssembly/bulk-memory.ll
+++ b/llvm/test/CodeGen/WebAssembly/bulk-memory.ll
@@ -29,6 +29,27 @@ define void @memcpy_i8(ptr %dest, ptr %src, i8 zeroext %len) {
   ret void
 }
 
+; CHECK-LABEL: memcpy_i8_fixed_32
+; CHECK: i64.load
+; CHECK: i64.store
+; CHECK: i64.load
+; CHECK: i64.store
+; CHECK: i64.load
+; CHECK: i64.store
+; CHECK: i64.load
+; CHECK: i64.store
+define void @memcpy_i8_fixed_32(ptr %dest, ptr %src) {
+  call void @llvm.memcpy.p0.p0.i8(ptr %dest, ptr %src, i8 32, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memcpy_i8_fixed_36
+; BULK-MEM: memory.copy
+define void @memcpy_i8_fixed_36(ptr %dest, ptr %src) {
+  call void @llvm.memcpy.p0.p0.i8(ptr %dest, ptr %src, i8 36, i1 0)
+  ret void
+}
+
 ; CHECK-LABEL: memmove_i8:
 ; NO-BULK-MEM-NOT: memory.copy
 ; BULK-MEM-NEXT: .functype memmove_i8 (i32, i32, i32) -> ()
@@ -41,6 +62,27 @@ define void @memcpy_i8(ptr %dest, ptr %src, i8 zeroext %len) {
 ; BULK-MEM-NEXT: return
 define void @memmove_i8(ptr %dest, ptr %src, i8 zeroext %len) {
   call void @llvm.memmove.p0.p0.i8(ptr %dest, ptr %src, i8 %len, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memmove_i8_fixed_32
+; CHECK: i64.load
+; CHECK: i64.load
+; CHECK: i64.load
+; CHECK: i64.load
+; CHECK: i64.store
+; CHECK: i64.store
+; CHECK: i64.store
+; CHECK: i64.store
+define void @memmove_i8_fixed_32(ptr %dest, ptr %src) {
+  call void @llvm.memmove.p0.p0.i8(ptr %dest, ptr %src, i8 32, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memmove_i8_fixed_36
+; BULK-MEM: memory.copy
+define void @memmove_i8_fixed_36(ptr %dest, ptr %src) {
+  call void @llvm.memmove.p0.p0.i8(ptr %dest, ptr %src, i8 36, i1 0)
   ret void
 }
 
@@ -59,6 +101,23 @@ define void @memset_i8(ptr %dest, i8 %val, i8 zeroext %len) {
   ret void
 }
 
+; CHECK-LABEL: memset_i8_fixed_32
+; CHECK: i64.store
+; CHECK: i64.store
+; CHECK: i64.store
+; CHECK: i64.store
+define void @memset_i8_fixed_32(ptr %dest, i8 %val) {
+  call void @llvm.memset.p0.i8(ptr %dest, i8 %val, i8 32, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memset_i8_fixed_36
+; BULK-MEM: memory.fill
+define void @memset_i8_fixed_36(ptr %dest, i8 %val) {
+  call void @llvm.memset.p0.i8(ptr %dest, i8 %val, i8 36, i1 0)
+  ret void
+}
+
 ; CHECK-LABEL: memcpy_i32:
 ; NO-BULK-MEM-NOT: memory.copy
 ; BULK-MEM-NEXT: .functype memcpy_i32 (i32, i32, i32) -> ()
@@ -71,6 +130,27 @@ define void @memset_i8(ptr %dest, i8 %val, i8 zeroext %len) {
 ; BULK-MEM-NEXT: return
 define void @memcpy_i32(ptr %dest, ptr %src, i32 %len) {
   call void @llvm.memcpy.p0.p0.i32(ptr %dest, ptr %src, i32 %len, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memcpy_i32_fixed_32
+; CHECK: i64.load
+; CHECK: i64.store
+; CHECK: i64.load
+; CHECK: i64.store
+; CHECK: i64.load
+; CHECK: i64.store
+; CHECK: i64.load
+; CHECK: i64.store
+define void @memcpy_i32_fixed_32(ptr %dest, ptr %src) {
+  call void @llvm.memcpy.p0.p0.i32(ptr %dest, ptr %src, i32 32, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memcpy_i32_fixed_36
+; BULK-MEM: memory.copy
+define void @memcpy_i32_fixed_36(ptr %dest, ptr %src) {
+  call void @llvm.memcpy.p0.p0.i32(ptr %dest, ptr %src, i32 36, i1 0)
   ret void
 }
 
@@ -89,6 +169,27 @@ define void @memmove_i32(ptr %dest, ptr %src, i32 %len) {
   ret void
 }
 
+; CHECK-LABEL: memmove_i32_fixed_32
+; CHECK: i64.load
+; CHECK: i64.load
+; CHECK: i64.load
+; CHECK: i64.load
+; CHECK: i64.store
+; CHECK: i64.store
+; CHECK: i64.store
+; CHECK: i64.store
+define void @memmove_i32_fixed_32(ptr %dest, ptr %src) {
+  call void @llvm.memmove.p0.p0.i32(ptr %dest, ptr %src, i32 32, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memmove_i32_fixed_36
+; BULK-MEM: memory.copy
+define void @memmove_i32_fixed_36(ptr %dest, ptr %src) {
+  call void @llvm.memmove.p0.p0.i32(ptr %dest, ptr %src, i32 36, i1 0)
+  ret void
+}
+
 ; CHECK-LABEL: memset_i32:
 ; NO-BULK-MEM-NOT: memory.fill
 ; BULK-MEM-NEXT: .functype memset_i32 (i32, i32, i32) -> ()
@@ -101,6 +202,23 @@ define void @memmove_i32(ptr %dest, ptr %src, i32 %len) {
 ; BULK-MEM-NEXT: return
 define void @memset_i32(ptr %dest, i8 %val, i32 %len) {
   call void @llvm.memset.p0.i32(ptr %dest, i8 %val, i32 %len, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memset_i32_fixed_32
+; CHECK: i64.store
+; CHECK: i64.store
+; CHECK: i64.store
+; CHECK: i64.store
+define void @memset_i32_fixed_32(ptr %dest, i8 %val) {
+  call void @llvm.memset.p0.i32(ptr %dest, i8 %val, i32 32, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memset_i32_fixed_36
+; BULK-MEM: memory.fill
+define void @memset_i32_fixed_36(ptr %dest, i8 %val) {
+  call void @llvm.memset.p0.i32(ptr %dest, i8 %val, i32 36, i1 0)
   ret void
 }
 

--- a/llvm/test/CodeGen/WebAssembly/bulk-memory64.ll
+++ b/llvm/test/CodeGen/WebAssembly/bulk-memory64.ll
@@ -31,6 +31,27 @@ define void @memcpy_i8(ptr %dest, ptr %src, i8 zeroext %len) {
   ret void
 }
 
+; CHECK-LABEL: memcpy_i8_fixed_32
+; CHECK: i64.load
+; CHECK: i64.store
+; CHECK: i64.load
+; CHECK: i64.store
+; CHECK: i64.load
+; CHECK: i64.store
+; CHECK: i64.load
+; CHECK: i64.store
+define void @memcpy_i8_fixed_32(ptr %dest, ptr %src) {
+  call void @llvm.memcpy.p0.p0.i8(ptr %dest, ptr %src, i8 32, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memcpy_i8_fixed_36
+; BULK-MEM: memory.copy
+define void @memcpy_i8_fixed_36(ptr %dest, ptr %src) {
+  call void @llvm.memcpy.p0.p0.i8(ptr %dest, ptr %src, i8 36, i1 0)
+  ret void
+}
+
 ; CHECK-LABEL: memmove_i8:
 ; NO-BULK-MEM-NOT: memory.copy
 ; BULK-MEM-NEXT: .functype memmove_i8 (i64, i64, i32) -> ()
@@ -45,6 +66,27 @@ define void @memcpy_i8(ptr %dest, ptr %src, i8 zeroext %len) {
 ; BULK-MEM-NEXT: return
 define void @memmove_i8(ptr %dest, ptr %src, i8 zeroext %len) {
   call void @llvm.memmove.p0.p0.i8(ptr %dest, ptr %src, i8 %len, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memmove_i8_fixed_32
+; CHECK: i64.load
+; CHECK: i64.load
+; CHECK: i64.load
+; CHECK: i64.load
+; CHECK: i64.store
+; CHECK: i64.store
+; CHECK: i64.store
+; CHECK: i64.store
+define void @memmove_i8_fixed_32(ptr %dest, ptr %src) {
+  call void @llvm.memmove.p0.p0.i8(ptr %dest, ptr %src, i8 32, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memmove_i8_fixed_36
+; BULK-MEM: memory.copy
+define void @memmove_i8_fixed_36(ptr %dest, ptr %src) {
+  call void @llvm.memmove.p0.p0.i8(ptr %dest, ptr %src, i8 36, i1 0)
   ret void
 }
 
@@ -65,6 +107,23 @@ define void @memset_i8(ptr %dest, i8 %val, i8 zeroext %len) {
   ret void
 }
 
+; CHECK-LABEL: memset_i8_fixed_32
+; CHECK: i64.store
+; CHECK: i64.store
+; CHECK: i64.store
+; CHECK: i64.store
+define void @memset_i8_fixed_32(ptr %dest, i8 %val) {
+  call void @llvm.memset.p0.i8(ptr %dest, i8 %val, i8 32, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memset_i8_fixed_36
+; BULK-MEM: memory.fill
+define void @memset_i8_fixed_36(ptr %dest, i8 %val) {
+  call void @llvm.memset.p0.i8(ptr %dest, i8 %val, i8 36, i1 0)
+  ret void
+}
+
 ; CHECK-LABEL: memcpy_i32:
 ; NO-BULK-MEM-NOT: memory.copy
 ; BULK-MEM-NEXT: .functype memcpy_i32 (i64, i64, i64) -> ()
@@ -77,6 +136,27 @@ define void @memset_i8(ptr %dest, i8 %val, i8 zeroext %len) {
 ; BULK-MEM-NEXT: return
 define void @memcpy_i32(ptr %dest, ptr %src, i64 %len) {
   call void @llvm.memcpy.p0.p0.i64(ptr %dest, ptr %src, i64 %len, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memcpy_i32_fixed_32
+; CHECK: i64.load
+; CHECK: i64.store
+; CHECK: i64.load
+; CHECK: i64.store
+; CHECK: i64.load
+; CHECK: i64.store
+; CHECK: i64.load
+; CHECK: i64.store
+define void @memcpy_i32_fixed_32(ptr %dest, ptr %src) {
+  call void @llvm.memcpy.p0.p0.i32(ptr %dest, ptr %src, i32 32, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memcpy_i32_fixed_36
+; BULK-MEM: memory.copy
+define void @memcpy_i32_fixed_36(ptr %dest, ptr %src) {
+  call void @llvm.memcpy.p0.p0.i32(ptr %dest, ptr %src, i32 36, i1 0)
   ret void
 }
 
@@ -95,6 +175,27 @@ define void @memmove_i32(ptr %dest, ptr %src, i64 %len) {
   ret void
 }
 
+; CHECK-LABEL: memmove_i32_fixed_32
+; CHECK: i64.load
+; CHECK: i64.load
+; CHECK: i64.load
+; CHECK: i64.load
+; CHECK: i64.store
+; CHECK: i64.store
+; CHECK: i64.store
+; CHECK: i64.store
+define void @memmove_i32_fixed_32(ptr %dest, ptr %src) {
+  call void @llvm.memmove.p0.p0.i32(ptr %dest, ptr %src, i32 32, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memmove_i32_fixed_36
+; BULK-MEM: memory.copy
+define void @memmove_i32_fixed_36(ptr %dest, ptr %src) {
+  call void @llvm.memmove.p0.p0.i32(ptr %dest, ptr %src, i32 36, i1 0)
+  ret void
+}
+
 ; CHECK-LABEL: memset_i32:
 ; NO-BULK-MEM-NOT: memory.fill
 ; BULK-MEM-NEXT: .functype memset_i32 (i64, i32, i64) -> ()
@@ -107,6 +208,23 @@ define void @memmove_i32(ptr %dest, ptr %src, i64 %len) {
 ; BULK-MEM-NEXT: return
 define void @memset_i32(ptr %dest, i8 %val, i64 %len) {
   call void @llvm.memset.p0.i64(ptr %dest, i8 %val, i64 %len, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memset_i32_fixed_32
+; CHECK: i64.store
+; CHECK: i64.store
+; CHECK: i64.store
+; CHECK: i64.store
+define void @memset_i32_fixed_32(ptr %dest, i8 %val) {
+  call void @llvm.memset.p0.i32(ptr %dest, i8 %val, i32 32, i1 0)
+  ret void
+}
+
+; CHECK-LABEL: memset_i32_fixed_36
+; BULK-MEM: memory.fill
+define void @memset_i32_fixed_36(ptr %dest, i8 %val) {
+  call void @llvm.memset.p0.i32(ptr %dest, i8 %val, i32 36, i1 0)
   ret void
 }
 


### PR DESCRIPTION
Use the same thresholds for memcpy/move/set when optimizing for size or otherwise. The high-level nature of the memory instructions can allow runtimes to optimize them more readily.