### PR TITLE
libclc: frexp: fix implementation regarding denormals

### DIFF
--- a/libclc/clc/lib/generic/math/clc_frexp.inc
+++ b/libclc/clc/lib/generic/math/clc_frexp.inc
@@ -26,7 +26,7 @@ __clc_frexp(__CLC_GENTYPE x, __CLC_ADDRESS_SPACE __CLC_INTN *ep) {
       (ai & (__CLC_INTN)MANTBITS_SP32);
 
   __CLC_INTN is_inf_nan_or_zero =
-      x == __CLC_FP_LIT(0.0) || __clc_isinf(x) || __clc_isnan(x);
+      ai == (__CLC_INTN)0 || __clc_isinf(x) || __clc_isnan(x);
   *ep = __clc_select(e, (__CLC_INTN)0, is_inf_nan_or_zero);
   return __clc_select(__CLC_AS_GENTYPE(i), x, is_inf_nan_or_zero);
 }


### PR DESCRIPTION
Devices not supporting denormals can compare them true against zero. It leads to result not matching the CTS expectation when either supporting or not denormals.

For example for 0x1.008p-140 we get {0x1.008p-140, 0} while the CTS expects {0x1.008p-1, -139} when supporting denormals, or {0, 0} when not supporting denormals (flushed to zero).

Ref #129871