### PR TITLE
[DebugInfo][TailCallElim] Use ret DILocation for return value selects

### DIFF
--- a/llvm/lib/Transforms/Scalar/TailRecursionElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/TailRecursionElimination.cpp
@@ -725,6 +725,7 @@ bool TailRecursionEliminator::eliminateCall(CallInst *CI) {
       SelectInst *SI =
           SelectInst::Create(RetKnownPN, RetPN, Ret->getReturnValue(),
                              "current.ret.tr", Ret->getIterator());
+      SI->setDebugLoc(Ret->getDebugLoc());
       RetSelects.push_back(SI);
 
       RetPN->addIncoming(SI, BB);

--- a/llvm/test/Transforms/TailCallElim/debugloc.ll
+++ b/llvm/test/Transforms/TailCallElim/debugloc.ll
@@ -1,16 +1,18 @@
 ; RUN: opt < %s -passes=debugify,tailcallelim -S | FileCheck %s
 
-define void @foo() {
+define i32 @foo() {
 entry:
 ; CHECK-LABEL: entry:
 ; CHECK: br label %tailrecurse{{$}}
 
-  call void @foo()                            ;; line 1
-  ret void
+  %ret = call i32 @foo()                          ;; line 1
+  ret i32 0                                       ;; line 2
 
 ; CHECK-LABEL: tailrecurse:
-; CHECK: br label %tailrecurse, !dbg ![[DbgLoc:[0-9]+]]
+; CHECK: select i1 {{.+}}, !dbg ![[DbgLoc2:[0-9]+]]
+; CHECK: br label %tailrecurse, !dbg ![[DbgLoc1:[0-9]+]]
 }
 
 ;; Make sure tailrecurse has the call instruction's DL
-; CHECK: ![[DbgLoc]] = !DILocation(line: 1
+; CHECK: ![[DbgLoc1]] = !DILocation(line: 1
+; CHECK: ![[DbgLoc2]] = !DILocation(line: 2


### PR DESCRIPTION
In TailRecursionElimination we may insert a select before the return to choose the return value if necessary; this select is effectively part of the return statement, and so should use its DILocation.

Found using https://github.com/llvm/llvm-project/pull/107279.