### PR TITLE
[MLIR][mlir-opt] move action debugger hook flag

### DIFF
--- a/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
+++ b/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
@@ -238,9 +238,6 @@ protected:
   /// Elide resources when generating bytecode.
   bool elideResourceDataFromBytecodeFlag = false;
 
-  /// Enable the Debugger action hook: Debugger can intercept MLIR Actions.
-  bool enableDebuggerActionHookFlag = false;
-
   /// IRDL file to register before processing the input.
   std::string irdlFileFlag = "";
 

--- a/mlir/lib/Debug/CLOptionsSetup.cpp
+++ b/mlir/lib/Debug/CLOptionsSetup.cpp
@@ -64,6 +64,11 @@ struct DebugConfigCLOptions : public DebugConfig {
           auto [file, line, col] = *locBreakpoint;
           locBreakpointManager.addBreakpoint(file, line, col);
         }));
+
+    static cl::opt<bool, /*ExternalStorage=*/true> enableDebuggerHook(
+        "mlir-enable-debugger-hook",
+        cl::desc("Enable Debugger hook for debugging MLIR Actions"),
+        cl::location(enableDebuggerActionHookFlag), cl::init(false));
   }
   tracing::FileLineColLocBreakpointManager locBreakpointManager;
 };

--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -126,11 +126,6 @@ struct MlirOptMainConfigCLOptions : public MlirOptMainConfig {
         "mlir-disable-diagnostic-notes", cl::desc("Disable diagnostic notes."),
         cl::location(disableDiagnosticNotesFlag), cl::init(false));
 
-    static cl::opt<bool, /*ExternalStorage=*/true> enableDebuggerHook(
-        "mlir-enable-debugger-hook",
-        cl::desc("Enable Debugger hook for debugging MLIR Actions"),
-        cl::location(enableDebuggerActionHookFlag), cl::init(false));
-
     static cl::opt<bool, /*ExternalStorage=*/true> explicitModule(
         "no-implicit-module",
         cl::desc("Disable implicit addition of a top-level module op during "

--- a/mlir/test/mlir-opt/debuggerhook.mlir
+++ b/mlir/test/mlir-opt/debuggerhook.mlir
@@ -1,0 +1,9 @@
+// Checks that the debugger hook is enabled when called with the CLI option.
+// RUN: mlir-opt %s --mlir-enable-debugger-hook --pass-pipeline="builtin.module(func.func(canonicalize))" --mlir-disable-threading 2>&1 | FileCheck %s
+
+func.func @foo() {
+    return
+}
+
+// CHECK: ExecutionContext registered on the context
+// CHECK-SAME:  (with Debugger hook)


### PR DESCRIPTION
Currently if a developer uses the flag `--mlir-enable-debugger-hook` the debugger hook is not actually enabled. It seems the DebugConfig and the MainMLIROptConfig are not connected.

To fix this we can move the `enableDebuggerHook` CL Option to the DebugConfigCLOptions struct so that it can get registered and enabled along with the other debugger flags. AFAICS there are no other uses of the flag so this should be safe.

This also adds a small LIT test to check that the hook is enabled by checking the std::cerr output for the log message.