### PR TITLE
Revert "[CMake] Fix using precompiled headers with ccache"

### DIFF
--- a/flang/CMakeLists.txt
+++ b/flang/CMakeLists.txt
@@ -452,10 +452,6 @@ if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-semantic-interposition")
   endif()
 
-  # GCC requires this flag in order for precompiled headers to work with ccache
-  if (CMAKE_CXX_COMPILER_ID MATCHES GCC AND NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpch-preprocess")
-  endif()
 endif()
 
 # Clang on Darwin enables non-POSIX extensions by default, which allows the
@@ -464,11 +460,6 @@ endif()
 # Set _POSIX_C_SOURCE to avoid including these extensions.
 if (APPLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_POSIX_C_SOURCE=200809")
-endif()
-
-# Clang requires this flag in order for precompiled headers to work with ccache
-if (CMAKE_CXX_COMPILER_ID MATCHES Clang AND NOT CMAKE_DISABLE_PRECOMPILE_HEADERS)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -fno-pch-timestamp")
 endif()
 
 list(REMOVE_DUPLICATES CMAKE_CXX_FLAGS)

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -271,43 +271,30 @@ set(LLVM_CCACHE_BUILD OFF CACHE BOOL "Set to ON for a ccache enabled build")
 if(LLVM_CCACHE_BUILD)
   find_program(CCACHE_PROGRAM ccache)
   if(CCACHE_PROGRAM)
-    # ccache --version example output: "ccache version 4.9.1\n(..)"
-    execute_process(COMMAND ${CCACHE_PROGRAM} --version OUTPUT_VARIABLE CCACHE_VERSION_STR)
-    string(REGEX MATCH "[0-9]+\.[0-9]+\.?[0-9]*" CCACHE_VERSION "${CCACHE_VERSION_STR}")
-
     set(LLVM_CCACHE_MAXSIZE "" CACHE STRING "Size of ccache")
     set(LLVM_CCACHE_DIR "" CACHE STRING "Directory to keep ccached data")
+    set(LLVM_CCACHE_PARAMS "CCACHE_CPP2=yes CCACHE_HASHDIR=yes"
+        CACHE STRING "Parameters to pass through to ccache")
 
-    # ccache only supports passing options on the command line from version 4.8.0
-    # use a workaround with ad-hoc environment variables for older versions
-    if (CCACHE_VERSION VERSION_LESS "4.8.0")
-      set(LLVM_CCACHE_PARAMS "CCACHE_CPP2=yes;CCACHE_HASHDIR=yes;CCACHE_SLOPPINESS=pch_defines,time_macros"
-          CACHE STRING "Parameters to pass through to ccache")
-
-      set(launcher_params ${LLVM_CCACHE_PARAMS})
-      if (CCACHE_MAXSIZE)
-        set(launcher_params "CCACHE_MAXSIZE=${CCACHE_MAXSIZE};${launcher_params}")
+    if(NOT CMAKE_SYSTEM_NAME MATCHES "Windows")
+      set(CCACHE_PROGRAM "${LLVM_CCACHE_PARAMS} ${CCACHE_PROGRAM}")
+      if (LLVM_CCACHE_MAXSIZE)
+        set(CCACHE_PROGRAM "CCACHE_MAXSIZE=${LLVM_CCACHE_MAXSIZE} ${CCACHE_PROGRAM}")
       endif()
-      if (CCACHE_DIR)
-        set(launcher_params "CCACHE_DIR=${CCACHE_DIR};${launcher_params}")
+      if (LLVM_CCACHE_DIR)
+        set(CCACHE_PROGRAM "CCACHE_DIR=${LLVM_CCACHE_DIR} ${CCACHE_PROGRAM}")
       endif()
-      set(launcher "${launcher_params};${CCACHE_PROGRAM}")
+      set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_PROGRAM})
     else()
-      set(LLVM_CCACHE_PARAMS "run_second_cpp=true;hash_dir=true;sloppiness=pch_defines,time_macros"
-          CACHE STRING "Parameters to pass through to ccache")
-
-      set(launcher_params ${LLVM_CCACHE_PARAMS})
-      if (CCACHE_MAXSIZE)
-        set(launcher_params "max_size=${CCACHE_MAXSIZE};${launcher_params}")
+      if(LLVM_CCACHE_MAXSIZE OR LLVM_CCACHE_DIR OR
+         NOT LLVM_CCACHE_PARAMS MATCHES "CCACHE_CPP2=yes CCACHE_HASHDIR=yes")
+        message(FATAL_ERROR "Ccache configuration through CMake is not supported on Windows. Please use environment variables.")
       endif()
-      if (CCACHE_DIR)
-        set(launcher_params "cache_dir=${CCACHE_DIR};${launcher_params}")
-      endif()
-      set(launcher "${CCACHE_PROGRAM};${launcher_params}")
+      # RULE_LAUNCH_COMPILE should work with Ninja but currently has issues
+      # with cmd.exe and some MSVC tools other than cl.exe
+      set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
+      set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
     endif()
-
-    set(CMAKE_C_COMPILER_LAUNCHER ${launcher})
-    set(CMAKE_CXX_COMPILER_LAUNCHER ${launcher})
   else()
     message(FATAL_ERROR "Unable to find the program ccache. Set LLVM_CCACHE_BUILD to OFF")
   endif()


### PR DESCRIPTION
Reverts llvm/llvm-project#131397

Reverting for now on account of build bot failures on certain platforms.