### PR TITLE
Revert "[flang] Use precompiled parsing headers"

### DIFF
--- a/flang/lib/Frontend/CMakeLists.txt
+++ b/flang/lib/Frontend/CMakeLists.txt
@@ -72,11 +72,3 @@ add_flang_library(flangFrontend
   clangBasic
   clangDriver
 )
-
-target_precompile_headers(flangFrontend PRIVATE
-  [["flang/Parser/parsing.h"]]
-  [["flang/Parser/parse-tree.h"]]
-  [["flang/Parser/dump-parse-tree.h"]]
-  [["flang/Lower/PFTBuilder.h"]]
-  [["flang/Lower/Bridge.h"]]
-)


### PR DESCRIPTION
Reverts llvm/llvm-project#130600

Reverting on account of Windows issues with ccache, will bring back along with #131137 once those are resolved.