### PR TITLE
[clang-tidy] treat unsigned char and signed char as char type by default in bugprone-unintended-char-ostream-output

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/UnintendedCharOstreamOutputCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/UnintendedCharOstreamOutputCheck.h
@@ -30,6 +30,7 @@ public:
   }
 
 private:
+  const std::vector<StringRef> AllowedTypes;
   const std::optional<StringRef> CastTypeName;
 };
 

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/unintended-char-ostream-output.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/unintended-char-ostream-output.rst
@@ -44,10 +44,12 @@ Options
 
 .. option:: AllowedTypes
 
-  A semicolon-separated list of type names that will be treated as ``char``
-  type. It only contains the non canonical type names without the alias of type
-  names. Explicit casting to these types or use the variable defined with these
-  types will be ignored.
+  A semicolon-separated list of type names that will be treated like the ``char``
+  type: the check will not report variables declared with with these types or
+  explicit cast expressions to these types. Note that this distinguishes type
+  aliases from the original type, so specifying e.g. ``unsigned char`` here
+  will not suppress reports about ``uint8_t`` even if it is defined as a
+  ``typedef`` alias for ``unsigned char``.
   Default is `unsigned char;signed char`.
 
 .. option:: CastTypeName

--- a/clang-tools-extra/docs/clang-tidy/checks/bugprone/unintended-char-ostream-output.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/bugprone/unintended-char-ostream-output.rst
@@ -42,6 +42,14 @@ Or cast to char to explicitly indicate that output should be a character.
 Options
 -------
 
+.. option:: AllowedTypes
+
+  A semicolon-separated list of type names that will be treated as ``char``
+  type. It only contains the non canonical type names without the alias of type
+  names. Explicit casting to these types or use the variable defined with these
+  types will be ignored.
+  Default is `unsigned char;signed char`.
+
 .. option:: CastTypeName
 
   When `CastTypeName` is specified, the fix-it will use `CastTypeName` as the

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/unintended-char-ostream-output-allowed-types.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/unintended-char-ostream-output-allowed-types.cpp
@@ -1,6 +1,6 @@
 // RUN: %check_clang_tidy %s bugprone-unintended-char-ostream-output %t -- \
 // RUN:   -config="{CheckOptions: \
-// RUN:             {bugprone-unintended-char-ostream-output.CastTypeName: \"unsigned char\"}}"
+// RUN:             {bugprone-unintended-char-ostream-output.AllowedTypes: \"\"}}"
 
 namespace std {
 
@@ -27,19 +27,14 @@ using ostream = basic_ostream<char>;
 
 } // namespace std
 
-using uint8_t = unsigned char;
-using int8_t = signed char;
-
 void origin_ostream(std::ostream &os) {
-  uint8_t unsigned_value = 9;
+  unsigned char unsigned_value = 9;
   os << unsigned_value;
-  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'uint8_t' (aka 'unsigned char') passed to 'operator<<' outputs as character instead of integer
-  // CHECK-FIXES: os << static_cast<unsigned char>(unsigned_value);
+  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'unsigned char' passed to 'operator<<' outputs as character instead of integer
 
-  int8_t signed_value = 9;
+  signed char signed_value = 9;
   os << signed_value;
-  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'int8_t' (aka 'signed char') passed to 'operator<<' outputs as character instead of integer
-  // CHECK-FIXES: os << static_cast<unsigned char>(signed_value);
+  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'signed char' passed to 'operator<<' outputs as character instead of integer
 
   char char_value = 9;
   os << char_value;

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/unintended-char-ostream-output.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/unintended-char-ostream-output.cpp
@@ -27,41 +27,56 @@ using ostream = basic_ostream<char>;
 
 class A : public std::ostream {};
 
+using uint8_t = unsigned char;
+using int8_t = signed char;
+
 void origin_ostream(std::ostream &os) {
-  unsigned char unsigned_value = 9;
+  uint8_t unsigned_value = 9;
   os << unsigned_value;
-  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'unsigned char' passed to 'operator<<' outputs as character instead of integer
+  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'uint8_t' (aka 'unsigned char') passed to 'operator<<' outputs as character instead of integer
   // CHECK-FIXES: os << static_cast<unsigned int>(unsigned_value);
 
-  signed char signed_value = 9;
+  int8_t signed_value = 9;
   os << signed_value;
-  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'signed char' passed to 'operator<<' outputs as character instead of integer
+  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'int8_t' (aka 'signed char') passed to 'operator<<' outputs as character instead of integer
   // CHECK-FIXES: os << static_cast<int>(signed_value);
 
   char char_value = 9;
   os << char_value;
+  unsigned char unsigned_char_value = 9;
+  os << unsigned_char_value;
+  signed char signed_char_value = 9;
+  os << signed_char_value;
+}
+
+void explicit_cast_to_char_type(std::ostream &os) {
+  enum V : uint8_t {};
+  V e{};
+  os << static_cast<unsigned char>(e);
+  os << (unsigned char)(e);
+  os << (static_cast<unsigned char>(e));
 }
 
 void based_on_ostream(A &os) {
-  unsigned char unsigned_value = 9;
+  uint8_t unsigned_value = 9;
   os << unsigned_value;
-  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'unsigned char' passed to 'operator<<' outputs as character instead of integer
+  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'uint8_t' (aka 'unsigned char') passed to 'operator<<' outputs as character instead of integer
   // CHECK-FIXES: os << static_cast<unsigned int>(unsigned_value);
 
-  signed char signed_value = 9;
+  int8_t signed_value = 9;
   os << signed_value;
-  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'signed char' passed to 'operator<<' outputs as character instead of integer
+  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'int8_t' (aka 'signed char') passed to 'operator<<' outputs as character instead of integer
   // CHECK-FIXES: os << static_cast<int>(signed_value);
 
   char char_value = 9;
   os << char_value;
 }
 
-void other_ostream_template_parameters(std::basic_ostream<unsigned char> &os) {
-  unsigned char unsigned_value = 9;
+void other_ostream_template_parameters(std::basic_ostream<uint8_t> &os) {
+  uint8_t unsigned_value = 9;
   os << unsigned_value;
 
-  signed char signed_value = 9;
+  int8_t signed_value = 9;
   os << signed_value;
 
   char char_value = 9;
@@ -70,23 +85,22 @@ void other_ostream_template_parameters(std::basic_ostream<unsigned char> &os) {
 
 template <class T> class B : public std::ostream {};
 void template_based_on_ostream(B<int> &os) {
-  unsigned char unsigned_value = 9;
+  uint8_t unsigned_value = 9;
   os << unsigned_value;
-  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'unsigned char' passed to 'operator<<' outputs as character instead of integer
+  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'uint8_t' (aka 'unsigned char') passed to 'operator<<' outputs as character instead of integer
   // CHECK-FIXES: os << static_cast<unsigned int>(unsigned_value);
 }
 
 template<class T> void template_fn_1(T &os) {
-  unsigned char unsigned_value = 9;
+  uint8_t unsigned_value = 9;
   os << unsigned_value;
-  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'unsigned char' passed to 'operator<<' outputs as character instead of integer
+  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'uint8_t' (aka 'unsigned char') passed to 'operator<<' outputs as character instead of integer
   // CHECK-FIXES: os << static_cast<unsigned int>(unsigned_value);
 }
 template<class T> void template_fn_2(std::ostream &os) {
   T unsigned_value = 9;
   os << unsigned_value;
-  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'unsigned char' passed to 'operator<<' outputs as character instead of integer
-  // CHECK-FIXES: os << static_cast<unsigned int>(unsigned_value);
+  // It should be detected as well. But we cannot get the sugared type name for SubstTemplateTypeParmType.
 }
 template<class T> void template_fn_3(std::ostream &os) {
   T unsigned_value = 9;
@@ -95,24 +109,8 @@ template<class T> void template_fn_3(std::ostream &os) {
 void call_template_fn() {
   A a{};
   template_fn_1(a);
-  template_fn_2<unsigned char>(a);
+  template_fn_2<uint8_t>(a);
   template_fn_3<char>(a);
-}
-
-using U8 = unsigned char;
-void alias_unsigned_char(std::ostream &os) {
-  U8 v = 9;
-  os << v;
-  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'U8' (aka 'unsigned char') passed to 'operator<<' outputs as character instead of integer
-  // CHECK-FIXES: os << static_cast<unsigned int>(v);
-}
-
-using I8 = signed char;
-void alias_signed_char(std::ostream &os) {
-  I8 v = 9;
-  os << v;
-  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'I8' (aka 'signed char') passed to 'operator<<' outputs as character instead of integer
-  // CHECK-FIXES: os << static_cast<int>(v);
 }
 
 using C8 = char;
@@ -124,8 +122,8 @@ void alias_char(std::ostream &os) {
 
 #define MACRO_VARIANT_NAME a
 void macro_variant_name(std::ostream &os) {
-  unsigned char MACRO_VARIANT_NAME = 9;
+  uint8_t MACRO_VARIANT_NAME = 9;
   os << MACRO_VARIANT_NAME;
-  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'unsigned char' passed to 'operator<<' outputs as character instead of integer
+  // CHECK-MESSAGES: [[@LINE-1]]:6: warning: 'uint8_t' (aka 'unsigned char') passed to 'operator<<' outputs as character instead of integer
   // CHECK-FIXES: os << static_cast<unsigned int>(MACRO_VARIANT_NAME);
 }


### PR DESCRIPTION
Add `AllowedTypes` options to support custom defined char like type.
treat `unsigned char` and `signed char` as char like type by default.
The allowed types only effect when the var decl or explicit cast to this
non-canonical type names.

Fixed: #133425