### PR TITLE
[Coroutines] Create C++ noop coroutine with default function attributes

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
@@ -130,9 +130,10 @@ void Lowerer::lowerCoroNoop(IntrinsicInst *II) {
         StructType::create({FnPtrTy, FnPtrTy}, "NoopCoro.Frame");
 
     // Create a Noop function that does nothing.
-    Function *NoopFn =
-        Function::Create(FnTy, GlobalValue::LinkageTypes::PrivateLinkage,
-                         "__NoopCoro_ResumeDestroy", &M);
+    Function *NoopFn = Function::createWithDefaultAttr(
+        FnTy, GlobalValue::LinkageTypes::PrivateLinkage,
+        M.getDataLayout().getProgramAddressSpace(), "__NoopCoro_ResumeDestroy",
+        &M);
     NoopFn->setCallingConv(CallingConv::Fast);
     buildDebugInfoForNoopResumeDestroyFunc(NoopFn);
     auto *Entry = BasicBlock::Create(C, "entry", NoopFn);

--- a/llvm/test/Transforms/Coroutines/coro-noop-pacbti.ll
+++ b/llvm/test/Transforms/Coroutines/coro-noop-pacbti.ll
@@ -1,0 +1,23 @@
+
+; RUN: opt < %s -S -passes=coro-early | FileCheck %s
+
+; CHECK:      define private fastcc void @__NoopCoro_ResumeDestroy(ptr %0) #1 {
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }
+
+; CHECK:      attributes #1 = { "branch-target-enforcement" "sign-return-address"="all" "sign-return-address-key"="a_key" }
+
+define ptr @noop() {
+entry:
+  %n = call ptr @llvm.coro.noop()
+  ret ptr %n
+}
+
+declare ptr @llvm.coro.noop()
+
+!llvm.module.flags = !{!0, !1, !2}
+
+!0 = !{i32 8, !"branch-target-enforcement", i32 1}
+!1 = !{i32 8, !"sign-return-address", i32 1}
+!2 = !{i32 8, !"sign-return-address-all", i32 1}


### PR DESCRIPTION
This change makes the C++ noop coroutine to be built with attributes based on the module flags. Among other things, this adds function attributes related to the Pointer Authentication and Branch Target Enforcement module flags, which are set by command-line options.

Before this patch, C++ programs built with either PAC-RET or BTI that had the noop coroutine emitted could have a runtime error because this function wasn't compatible with the rest of the program.