### PR TITLE
[clang] Extract `CompilerInstance` creation out of `compileModuleImpl()`

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1466,7 +1466,7 @@ static bool compileModuleAndReadASTImpl(CompilerInstance &ImportingInstance,
                                         Module *Module,
                                         StringRef ModuleFileName) {
   auto Instance = createCompilerInstanceForModuleCompile(
-      ImportingInstance, ImportLoc, Module, ModuleFileName);
+      ImportingInstance, ModuleNameLoc, Module, ModuleFileName);
 
   if (!compileModule(ImportingInstance, ModuleNameLoc,
                      Module->getTopLevelModuleName(), ModuleFileName,

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1297,7 +1297,7 @@ static bool compileModule(CompilerInstance &ImportingInstance,
     << ModuleName;
 
   // Propagate the statistics to the parent FileManager.
-  if (ImportingInstance.getFrontendOpts().ModulesShareFileManager)
+  if (!ImportingInstance.getFrontendOpts().ModulesShareFileManager)
     ImportingInstance.getFileManager().AddStats(Instance.getFileManager());
 
   if (Crashed) {


### PR DESCRIPTION
This PR extracts the creation of `CompilerInstance` for compiling an implicitly-discovered module out of `compileModuleImpl()` into its own separate function and passes it into `compileModuleImpl()` from the outside. This makes the instance creation logic reusable (useful for my experiments) and also simplifies the API, removing the `PreBuildStep` and `PostBuildStep` hooks from `compileModuleImpl()`.