### PR TITLE
[readobj][ELF][AArch64] Handle misformed AArch64 build attribute section

### DIFF
--- a/llvm/lib/Support/ELFAttrParserExtended.cpp
+++ b/llvm/lib/Support/ELFAttrParserExtended.cpp
@@ -103,6 +103,8 @@ Error ELFExtendedAttrParser::parse(ArrayRef<uint8_t> Section,
 
   // Get format-version
   uint8_t FormatVersion = De.getU8(Cursor);
+  if (!Cursor)
+    return Cursor.takeError();
   if (ELFAttrs::Format_Version != FormatVersion)
     return createStringError(errc::invalid_argument,
                              "unrecognized format-version: 0x" +
@@ -110,6 +112,8 @@ Error ELFExtendedAttrParser::parse(ArrayRef<uint8_t> Section,
 
   while (!De.eof(Cursor)) {
     uint32_t ExtBASubsectionLength = De.getU32(Cursor);
+    if (!Cursor)
+      return Cursor.takeError();
     // Minimal valid Extended Build Attributes subsection header size is at
     // least 8: length(4) name(at least a single char + null) optionality(1) and
     // type(1)
@@ -120,9 +124,25 @@ Error ELFExtendedAttrParser::parse(ArrayRef<uint8_t> Section,
               utohexstr(Cursor.tell() - 4));
 
     StringRef VendorName = De.getCStrRef(Cursor);
+    if (!Cursor)
+      return Cursor.takeError();
     uint8_t IsOptional = De.getU8(Cursor);
+    if (!Cursor)
+      return Cursor.takeError();
+    if (!(0 == IsOptional || 1 == IsOptional))
+      return createStringError(
+          errc::invalid_argument,
+          "\ninvalid Optionality at offset " + utohexstr(Cursor.tell() - 4) +
+              ": " + utohexstr(IsOptional) + " (Options are 1|0)");
     StringRef IsOptionalStr = IsOptional ? "optional" : "required";
     uint8_t Type = De.getU8(Cursor);
+    if (!Cursor)
+      return Cursor.takeError();
+    if (!(0 == Type || 1 == Type))
+      return createStringError(errc::invalid_argument,
+                               "\ninvalid Type at offset " +
+                                   utohexstr(Cursor.tell() - 4) + ": " +
+                                   utohexstr(Type) + " (Options are 1|0)");
     StringRef TypeStr = Type ? "ntbs" : "uleb128";
 
     BuildAttributeSubSection BASubSection;
@@ -150,6 +170,8 @@ Error ELFExtendedAttrParser::parse(ArrayRef<uint8_t> Section,
            (OffsetInSection + ExtBASubsectionLength - BytesAllButAttributes)) {
 
       uint64_t Tag = De.getULEB128(Cursor);
+      if (!Cursor)
+        return Cursor.takeError();
 
       StringRef TagName = getTagName(VendorName, Tag);
 
@@ -157,10 +179,14 @@ Error ELFExtendedAttrParser::parse(ArrayRef<uint8_t> Section,
       std::string ValueStr = "";
       if (Type) { // type==1 --> ntbs
         ValueStr = De.getCStrRef(Cursor);
+        if (!Cursor)
+          return Cursor.takeError();
         if (Sw)
           Sw->printString("" != TagName ? TagName : utostr(Tag), ValueStr);
       } else { // type==0 --> uleb128
         ValueInt = De.getULEB128(Cursor);
+        if (!Cursor)
+          return Cursor.takeError();
         if (Sw)
           Sw->printNumber("" != TagName ? TagName : utostr(Tag), ValueInt);
       }

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-long.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-long.s
@@ -20,7 +20,8 @@
 # CHECK-NEXT:     Tag_Feature_GCS: 1
 # CHECK-NEXT: unable to dump attributes from the Unknown section with index 1: unable to decode LEB128 at offset 0x0000003d: malformed uleb128, extends past end
 
-
+# Indicated size is longer than actual size.
+# The size is indicated by the '99' in the sequence '...0101020199...' should be 23
 --- !ELF
 FileHeader:
   Class: ELFCLASS64

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-long.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-long.s
@@ -1,24 +1,7 @@
 # RUN: yaml2obj %s -o %t.o
 # RUN: not llvm-readobj --arch-specific %t.o %null 2>&1 | FileCheck %s
 
-# CHECK: BuildAttributes {
-# CHECK-NEXT: FormatVersion: 0x41
-# CHECK-NEXT: Section 1 {
-# CHECK-NEXT:   SectionLength: 25
-# CHECK-NEXT:   VendorName: aeabi_pauthabi Optionality: required Type: uleb128
-# CHECK-NEXT:   Attributes {
-# CHECK-NEXT:     Tag_PAuth_Platform: 1
-# CHECK-NEXT:     Tag_PAuth_Schema: 1
-# CHECK-NEXT:   }
-# CHECK-NEXT: }
-# CHECK-NEXT: Section 2 {
-# CHECK-NEXT:   SectionLength: 153
-# CHECK-NEXT:   VendorName: aeabi_feature_and_bits Optionality: optional Type: uleb128
-# CHECK-NEXT:   Attributes {
-# CHECK-NEXT:     Tag_Feature_BTI: 1
-# CHECK-NEXT:     Tag_Feature_PAC: 1
-# CHECK-NEXT:     Tag_Feature_GCS: 1
-# CHECK-NEXT: unable to dump attributes from the Unknown section with index 1: unable to decode LEB128 at offset 0x0000003d: malformed uleb128, extends past end
+# CHECK: unable to dump attributes from the Unknown section with index 1: invalid Extended Build Attributes subsection size at offset: 1A
 
 # Indicated size is longer than actual size.
 # The size is indicated by the '99' in the sequence '...0101020199...' should be 23

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-long.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-long.s
@@ -1,0 +1,40 @@
+# RUN: yaml2obj %s -o %t.o
+# RUN: not llvm-readobj --arch-specific %t.o /dev/null 2>&1 | FileCheck %s
+
+# CHECK: BuildAttributes {
+# CHECK-NEXT: FormatVersion: 0x41
+# CHECK-NEXT: Section 1 {
+# CHECK-NEXT:   SectionLength: 25
+# CHECK-NEXT:   VendorName: aeabi_pauthabi Optionality: required Type: uleb128
+# CHECK-NEXT:   Attributes {
+# CHECK-NEXT:     Tag_PAuth_Platform: 1
+# CHECK-NEXT:     Tag_PAuth_Schema: 1
+# CHECK-NEXT:   }
+# CHECK-NEXT: }
+# CHECK-NEXT: Section 2 {
+# CHECK-NEXT:   SectionLength: 153
+# CHECK-NEXT:   VendorName: aeabi_feature_and_bits Optionality: optional Type: uleb128
+# CHECK-NEXT:   Attributes {
+# CHECK-NEXT:     Tag_Feature_BTI: 1
+# CHECK-NEXT:     Tag_Feature_PAC: 1
+# CHECK-NEXT:     Tag_Feature_GCS: 1
+# CHECK-NEXT: unable to dump attributes from the Unknown section with index 1: unable to decode LEB128 at offset 0x0000003d: malformed uleb128, extends past end
+
+
+--- !ELF
+FileHeader:
+  Class: ELFCLASS64
+  Data: ELFDATA2LSB
+  OSABI: ELFOSABI_NONE
+  Type: ET_REL
+  Machine: EM_AARCH64
+  Entry: 0x0
+
+Sections:
+  - Name: .ARM.attributes
+    Type: 0x70000003  # SHT_LOPROC + 3
+    AddressAlign: 1
+    Offset: 0x40
+    Size: 0x3d
+    Content: "411900000061656162695f7061757468616269000000010102019900000061656162695f666561747572655f616e645f62697473000100000101010201"
+...

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-long.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-long.s
@@ -1,5 +1,5 @@
 # RUN: yaml2obj %s -o %t.o
-# RUN: not llvm-readobj --arch-specific %t.o 2>&1 | FileCheck %s
+# RUN: not llvm-readobj --arch-specific %t.o %null 2>&1 | FileCheck %s
 
 # CHECK: BuildAttributes {
 # CHECK-NEXT: FormatVersion: 0x41

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-long.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-long.s
@@ -1,5 +1,5 @@
 # RUN: yaml2obj %s -o %t.o
-# RUN: not llvm-readobj --arch-specific %t.o /dev/null 2>&1 | FileCheck %s
+# RUN: not llvm-readobj --arch-specific %t.o 2>&1 | FileCheck %s
 
 # CHECK: BuildAttributes {
 # CHECK-NEXT: FormatVersion: 0x41

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-long.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-long.s
@@ -1,5 +1,5 @@
 # RUN: yaml2obj %s -o %t.o
-# RUN: not llvm-readobj --arch-specific %t.o %null 2>&1 | FileCheck %s
+# RUN: not llvm-readobj --arch-specific %t.o 2>&1 | FileCheck %s
 
 # CHECK: BuildAttributes {
 # CHECK-NEXT: FormatVersion: 0x41

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-short.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-short.s
@@ -1,25 +1,7 @@
 # RUN: yaml2obj %s -o %t.o
 # RUN: not llvm-readobj --arch-specific %t.o %null 2>&1 | FileCheck %s
 
-# CHECK: BuildAttributes {
-# CHECK-NEXT: FormatVersion: 0x41
-# CHECK-NEXT: Section 1 {
-# CHECK-NEXT: SectionLength: 25
-# CHECK-NEXT: VendorName: aeabi_pauthabi Optionality: required Type: uleb128
-# CHECK-NEXT: Attributes {
-# CHECK-NEXT: Tag_PAuth_Platform: 1
-# CHECK-NEXT: Tag_PAuth_Schema: 1
-# CHECK-NEXT: }
-# CHECK-NEXT: }
-# CHECK-NEXT: Section 2 {
-# CHECK-NEXT: SectionLength: 32
-# CHECK-NEXT: VendorName: aeabi_feature_and_bits Optionality: optional Type: uleb128
-# CHECK-NEXT: Attributes {
-# CHECK-NEXT: Tag_Feature_BTI: 1
-# CHECK-NEXT: Tag_Feature_PAC: 1
-# CHECK-NEXT: }
-# CHECK-NEXT: }
-# CHECK-NEXT: unable to dump attributes from the Unknown section with index 1: invalid Extended Build Attributes subsection size at offset: 3B
+# CHECK: unable to dump attributes from the Unknown section with index 1: invalid Extended Build Attributes subsection size at offset: 3B
 
 # Indicated size is shorter than actual size.
 # The size is indicated by the '20' in the sequence '...0101020120...' should be 23

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-short.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-short.s
@@ -21,7 +21,8 @@
 # CHECK-NEXT: }
 # CHECK-NEXT: unable to dump attributes from the Unknown section with index 1: invalid Extended Build Attributes subsection size at offset: 3B
 
-
+# Indicated size is shorter than actual size.
+# The size is indicated by the '20' in the sequence '...0101020120...' should be 23
 --- !ELF
 FileHeader:
   Class: ELFCLASS64

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-short.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-short.s
@@ -1,0 +1,41 @@
+# RUN: yaml2obj %s -o %t.o
+# RUN: not llvm-readobj --arch-specific %t.o /dev/null 2>&1 | FileCheck %s
+
+# CHECK: BuildAttributes {
+# CHECK-NEXT: FormatVersion: 0x41
+# CHECK-NEXT: Section 1 {
+# CHECK-NEXT: SectionLength: 25
+# CHECK-NEXT: VendorName: aeabi_pauthabi Optionality: required Type: uleb128
+# CHECK-NEXT: Attributes {
+# CHECK-NEXT: Tag_PAuth_Platform: 1
+# CHECK-NEXT: Tag_PAuth_Schema: 1
+# CHECK-NEXT: }
+# CHECK-NEXT: }
+# CHECK-NEXT: Section 2 {
+# CHECK-NEXT: SectionLength: 32
+# CHECK-NEXT: VendorName: aeabi_feature_and_bits Optionality: optional Type: uleb128
+# CHECK-NEXT: Attributes {
+# CHECK-NEXT: Tag_Feature_BTI: 1
+# CHECK-NEXT: Tag_Feature_PAC: 1
+# CHECK-NEXT: }
+# CHECK-NEXT: }
+# CHECK-NEXT: unable to dump attributes from the Unknown section with index 1: invalid Extended Build Attributes subsection size at offset: 3B
+
+
+--- !ELF
+FileHeader:
+  Class: ELFCLASS64
+  Data: ELFDATA2LSB
+  OSABI: ELFOSABI_NONE
+  Type: ET_REL
+  Machine: EM_AARCH64
+  Entry: 0x0
+
+Sections:
+  - Name: .ARM.attributes
+    Type: 0x70000003  # SHT_LOPROC + 3
+    AddressAlign: 1
+    Offset: 0x40
+    Size: 0x41
+    Content: "411900000061656162695f7061757468616269000000010102012000000061656162695f666561747572655f616e645f6269747300010000010101020000"
+...

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-short.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-short.s
@@ -1,5 +1,5 @@
 # RUN: yaml2obj %s -o %t.o
-# RUN: not llvm-readobj --arch-specific %t.o 2>&1 | FileCheck %s
+# RUN: not llvm-readobj --arch-specific %t.o %null 2>&1 | FileCheck %s
 
 # CHECK: BuildAttributes {
 # CHECK-NEXT: FormatVersion: 0x41

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-short.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-short.s
@@ -1,5 +1,5 @@
 # RUN: yaml2obj %s -o %t.o
-# RUN: not llvm-readobj --arch-specific %t.o /dev/null 2>&1 | FileCheck %s
+# RUN: not llvm-readobj --arch-specific %t.o 2>&1 | FileCheck %s
 
 # CHECK: BuildAttributes {
 # CHECK-NEXT: FormatVersion: 0x41

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-short.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-short.s
@@ -1,5 +1,5 @@
 # RUN: yaml2obj %s -o %t.o
-# RUN: not llvm-readobj --arch-specific %t.o %null 2>&1 | FileCheck %s
+# RUN: not llvm-readobj --arch-specific %t.o 2>&1 | FileCheck %s
 
 # CHECK: BuildAttributes {
 # CHECK-NEXT: FormatVersion: 0x41

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-type.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-type.s
@@ -6,6 +6,8 @@
 # CHECK-NEXT: unable to dump attributes from the Unknown section with index 1: 
 # CHECK-NEXT: invalid Type at offset 12: 9 (Options are 1|0)
 
+# Type are not 0 or 1
+# Type is indicated by the '09' in the sequence '...69000109...' should be 00 or 01
 --- !ELF
 FileHeader:
   Class: ELFCLASS64

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-type.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-type.s
@@ -1,0 +1,25 @@
+# RUN: yaml2obj %s -o %t.o
+# RUN: not llvm-readobj --arch-specific %t.o /dev/null 2>&1 | FileCheck %s
+
+# CHECK: BuildAttributes {
+# CHECK-NEXT: FormatVersion: 0x41
+# CHECK-NEXT: unable to dump attributes from the Unknown section with index 1: 
+# CHECK-NEXT: invalid Type at offset 12: 9 (Options are 1|0)
+
+--- !ELF
+FileHeader:
+  Class: ELFCLASS64
+  Data: ELFDATA2LSB
+  OSABI: ELFOSABI_NONE
+  Type: ET_REL
+  Machine: EM_AARCH64
+  Entry: 0x0
+
+Sections:
+  - Name: .ARM.attributes
+    Type: 0x70000003  # SHT_LOPROC + 3
+    AddressAlign: 1
+    Offset: 0x40
+    Size: 0x3d
+    Content: "411900000061656162695f7061757468616269000109010102012300000061656162695f666561747572655f616e645f62697473000100000101010201"
+...

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-type.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-type.s
@@ -1,5 +1,5 @@
 # RUN: yaml2obj %s -o %t.o
-# RUN: not llvm-readobj --arch-specific %t.o 2>&1 | FileCheck %s
+# RUN: not llvm-readobj --arch-specific %t.o %null 2>&1 | FileCheck %s
 
 # CHECK: BuildAttributes {
 # CHECK-NEXT: FormatVersion: 0x41

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-type.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-type.s
@@ -1,5 +1,5 @@
 # RUN: yaml2obj %s -o %t.o
-# RUN: not llvm-readobj --arch-specific %t.o /dev/null 2>&1 | FileCheck %s
+# RUN: not llvm-readobj --arch-specific %t.o 2>&1 | FileCheck %s
 
 # CHECK: BuildAttributes {
 # CHECK-NEXT: FormatVersion: 0x41

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-type.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-type.s
@@ -1,5 +1,5 @@
 # RUN: yaml2obj %s -o %t.o
-# RUN: not llvm-readobj --arch-specific %t.o %null 2>&1 | FileCheck %s
+# RUN: not llvm-readobj --arch-specific %t.o 2>&1 | FileCheck %s
 
 # CHECK: BuildAttributes {
 # CHECK-NEXT: FormatVersion: 0x41

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-values.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-values.s
@@ -22,7 +22,8 @@
 # CHECK-NEXT:  }
 # CHECK-NEXT: unable to dump attributes from the Unknown section with index 1: invalid Extended Build Attributes subsection size at offset: 3D
 
-
+# ULEB values are overflowing.
+# Those are the trailing '000' in the sequence '...00010101020000' should be '...000101010201'
 --- !ELF
 FileHeader:
   Class: ELFCLASS64

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-values.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-values.s
@@ -1,26 +1,7 @@
 # RUN: yaml2obj %s -o %t.o
 # RUN: not llvm-readobj --arch-specific %t.o %null 2>&1 | FileCheck %s
 
-# CHECK: BuildAttributes {
-# CHECK-NEXT:  FormatVersion: 0x41
-# CHECK-NEXT:  Section 1 {
-# CHECK-NEXT:    SectionLength: 25
-# CHECK-NEXT:    VendorName: aeabi_pauthabi Optionality: required Type: uleb128
-# CHECK-NEXT:    Attributes {
-# CHECK-NEXT:      Tag_PAuth_Platform: 1
-# CHECK-NEXT:      Tag_PAuth_Schema: 1
-# CHECK-NEXT:    }
-# CHECK-NEXT:  }
-# CHECK-NEXT:  Section 2 {
-# CHECK-NEXT:    SectionLength: 35
-# CHECK-NEXT:    VendorName: aeabi_feature_and_bits Optionality: optional Type: uleb128
-# CHECK-NEXT:    Attributes {
-# CHECK-NEXT:      Tag_Feature_BTI: 1
-# CHECK-NEXT:      Tag_Feature_PAC: 1
-# CHECK-NEXT:      Tag_Feature_GCS: 0
-# CHECK-NEXT:    }
-# CHECK-NEXT:  }
-# CHECK-NEXT: unable to dump attributes from the Unknown section with index 1: invalid Extended Build Attributes subsection size at offset: 3D
+# CHECK: unable to dump attributes from the Unknown section with index 1: invalid Extended Build Attributes subsection size at offset: 3D
 
 # ULEB values are overflowing.
 # Those are the trailing '000' in the sequence '...00010101020000' should be '...000101010201'

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-values.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-values.s
@@ -1,5 +1,5 @@
 # RUN: yaml2obj %s -o %t.o
-# RUN: not llvm-readobj --arch-specific %t.o /dev/null 2>&1 | FileCheck %s
+# RUN: not llvm-readobj --arch-specific %t.o 2>&1 | FileCheck %s
 
 # CHECK: BuildAttributes {
 # CHECK-NEXT:  FormatVersion: 0x41

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-values.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-values.s
@@ -1,5 +1,5 @@
 # RUN: yaml2obj %s -o %t.o
-# RUN: not llvm-readobj --arch-specific %t.o %null 2>&1 | FileCheck %s
+# RUN: not llvm-readobj --arch-specific %t.o 2>&1 | FileCheck %s
 
 # CHECK: BuildAttributes {
 # CHECK-NEXT:  FormatVersion: 0x41

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-values.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-values.s
@@ -1,0 +1,42 @@
+# RUN: yaml2obj %s -o %t.o
+# RUN: not llvm-readobj --arch-specific %t.o /dev/null 2>&1 | FileCheck %s
+
+# CHECK: BuildAttributes {
+# CHECK-NEXT:  FormatVersion: 0x41
+# CHECK-NEXT:  Section 1 {
+# CHECK-NEXT:    SectionLength: 25
+# CHECK-NEXT:    VendorName: aeabi_pauthabi Optionality: required Type: uleb128
+# CHECK-NEXT:    Attributes {
+# CHECK-NEXT:      Tag_PAuth_Platform: 1
+# CHECK-NEXT:      Tag_PAuth_Schema: 1
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
+# CHECK-NEXT:  Section 2 {
+# CHECK-NEXT:    SectionLength: 35
+# CHECK-NEXT:    VendorName: aeabi_feature_and_bits Optionality: optional Type: uleb128
+# CHECK-NEXT:    Attributes {
+# CHECK-NEXT:      Tag_Feature_BTI: 1
+# CHECK-NEXT:      Tag_Feature_PAC: 1
+# CHECK-NEXT:      Tag_Feature_GCS: 0
+# CHECK-NEXT:    }
+# CHECK-NEXT:  }
+# CHECK-NEXT: unable to dump attributes from the Unknown section with index 1: invalid Extended Build Attributes subsection size at offset: 3D
+
+
+--- !ELF
+FileHeader:
+  Class: ELFCLASS64
+  Data: ELFDATA2LSB
+  OSABI: ELFOSABI_NONE
+  Type: ET_REL
+  Machine: EM_AARCH64
+  Entry: 0x0
+
+Sections:
+  - Name: .ARM.attributes
+    Type: 0x70000003  # SHT_LOPROC + 3
+    AddressAlign: 1
+    Offset: 0x40
+    Size: 0x41
+    Content: "411900000061656162695f7061757468616269000000010102012300000061656162695f666561747572655f616e645f6269747300010000010101020000"
+...

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-values.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-values.s
@@ -1,5 +1,5 @@
 # RUN: yaml2obj %s -o %t.o
-# RUN: not llvm-readobj --arch-specific %t.o 2>&1 | FileCheck %s
+# RUN: not llvm-readobj --arch-specific %t.o %null 2>&1 | FileCheck %s
 
 # CHECK: BuildAttributes {
 # CHECK-NEXT:  FormatVersion: 0x41

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-ver.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-ver.s
@@ -1,9 +1,7 @@
 # RUN: yaml2obj %s -o %t.o
 # RUN: not llvm-readobj --arch-specific %t.o %null 2>&1 | FileCheck %s
 
-# CHECK: BuildAttributes {
-# CHECK-NEXT:  FormatVersion: 0x37
-# CHECK-NEXT:  unable to dump attributes from the Unknown section with index 1: unrecognized format-version: 0x37
+# CHECK:  unable to dump attributes from the Unknown section with index 1: unrecognized format-version: 0x37
 
 # Version is 37 instead of 41, this is the first byte.
 --- !ELF

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-ver.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-ver.s
@@ -5,6 +5,7 @@
 # CHECK-NEXT:  FormatVersion: 0x37
 # CHECK-NEXT:  unable to dump attributes from the Unknown section with index 1: unrecognized format-version: 0x37
 
+# Version is 37 instead of 41, this is the first byte.
 --- !ELF
 FileHeader:
   Class: ELFCLASS64

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-ver.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-ver.s
@@ -1,0 +1,24 @@
+# RUN: yaml2obj %s -o %t.o
+# RUN: not llvm-readobj --arch-specific %t.o /dev/null 2>&1 | FileCheck %s
+
+# CHECK: BuildAttributes {
+# CHECK-NEXT:  FormatVersion: 0x37
+# CHECK-NEXT:  unable to dump attributes from the Unknown section with index 1: unrecognized format-version: 0x37
+
+--- !ELF
+FileHeader:
+  Class: ELFCLASS64
+  Data: ELFDATA2LSB
+  OSABI: ELFOSABI_NONE
+  Type: ET_REL
+  Machine: EM_AARCH64
+  Entry: 0x0
+
+Sections:
+  - Name: .ARM.attributes
+    Type: 0x70000003  # SHT_LOPROC + 3
+    AddressAlign: 1
+    Offset: 0x40
+    Size: 0x3d
+    Content: "371900000061656162695f7061757468616269000000010102012300000061656162695f666561747572655f616e645f62697473000100000101010201"
+...

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-ver.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-ver.s
@@ -1,5 +1,5 @@
 # RUN: yaml2obj %s -o %t.o
-# RUN: not llvm-readobj --arch-specific %t.o %null 2>&1 | FileCheck %s
+# RUN: not llvm-readobj --arch-specific %t.o 2>&1 | FileCheck %s
 
 # CHECK: BuildAttributes {
 # CHECK-NEXT:  FormatVersion: 0x37

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-ver.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-ver.s
@@ -1,5 +1,5 @@
 # RUN: yaml2obj %s -o %t.o
-# RUN: not llvm-readobj --arch-specific %t.o /dev/null 2>&1 | FileCheck %s
+# RUN: not llvm-readobj --arch-specific %t.o 2>&1 | FileCheck %s
 
 # CHECK: BuildAttributes {
 # CHECK-NEXT:  FormatVersion: 0x37

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-ver.s
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/build-attributes-melformed-ver.s
@@ -1,5 +1,5 @@
 # RUN: yaml2obj %s -o %t.o
-# RUN: not llvm-readobj --arch-specific %t.o 2>&1 | FileCheck %s
+# RUN: not llvm-readobj --arch-specific %t.o %null 2>&1 | FileCheck %s
 
 # CHECK: BuildAttributes {
 # CHECK-NEXT:  FormatVersion: 0x37


### PR DESCRIPTION
Report an error when the .ARM.attributes section for AArch64 is malformed or violates expected format.