### PR TITLE
[CIR] Handle NullStmt

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -57,6 +57,7 @@ mlir::LogicalResult CIRGenFunction::emitStmt(const Stmt *s,
 
   switch (s->getStmtClass()) {
   case Stmt::BreakStmtClass:
+  case Stmt::NullStmtClass:
   case Stmt::CompoundStmtClass:
   case Stmt::ContinueStmtClass:
   case Stmt::DeclStmtClass:
@@ -93,7 +94,6 @@ mlir::LogicalResult CIRGenFunction::emitStmt(const Stmt *s,
   case Stmt::SEHExceptStmtClass:
   case Stmt::SEHFinallyStmtClass:
   case Stmt::MSDependentExistsStmtClass:
-  case Stmt::NullStmtClass:
   case Stmt::LabelStmtClass:
   case Stmt::AttributedStmtClass:
   case Stmt::GotoStmtClass:
@@ -231,6 +231,11 @@ mlir::LogicalResult CIRGenFunction::emitSimpleStmt(const Stmt *s,
     break;
   case Stmt::ContinueStmtClass:
     return emitContinueStmt(cast<ContinueStmt>(*s));
+
+  // NullStmt doesn't need any handling, but we need to say we handled it.
+  case Stmt::NullStmtClass:
+    break;
+
   case Stmt::BreakStmtClass:
     return emitBreakStmt(cast<BreakStmt>(*s));
   case Stmt::ReturnStmtClass:

--- a/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenStmt.cpp
@@ -56,6 +56,12 @@ mlir::LogicalResult CIRGenFunction::emitStmt(const Stmt *s,
     return mlir::success();
 
   switch (s->getStmtClass()) {
+  case Stmt::NoStmtClass:
+  case Stmt::CXXCatchStmtClass:
+  case Stmt::SEHExceptStmtClass:
+  case Stmt::SEHFinallyStmtClass:
+  case Stmt::MSDependentExistsStmtClass:
+    llvm_unreachable("invalid statement class to emit generically");
   case Stmt::BreakStmtClass:
   case Stmt::NullStmtClass:
   case Stmt::CompoundStmtClass:
@@ -89,11 +95,6 @@ mlir::LogicalResult CIRGenFunction::emitStmt(const Stmt *s,
 
   case Stmt::OMPScopeDirectiveClass:
   case Stmt::OMPErrorDirectiveClass:
-  case Stmt::NoStmtClass:
-  case Stmt::CXXCatchStmtClass:
-  case Stmt::SEHExceptStmtClass:
-  case Stmt::SEHFinallyStmtClass:
-  case Stmt::MSDependentExistsStmtClass:
   case Stmt::LabelStmtClass:
   case Stmt::AttributedStmtClass:
   case Stmt::GotoStmtClass:

--- a/clang/test/CIR/CodeGen/basic.c
+++ b/clang/test/CIR/CodeGen/basic.c
@@ -105,3 +105,42 @@ void f4(void) {
 //      OGCG: define{{.*}} void @f4()
 // OGCG-NEXT: entry:
 // OGCG-NEXT:   ret void
+
+// Verify null statement as for-loop body.
+void f5(void) {
+  for (;;)
+    ;
+}
+
+//      CIR: cir.func @f5()
+// CIR-NEXT:   cir.scope {
+// CIR-NEXT:      cir.for : cond {
+// CIR-NEXT:        %0 = cir.const #true
+// CIR-NEXT:        cir.condition(%0)
+// CIR-NEXT:      } body {
+// CIR-NEXT:        cir.yield
+// CIR-NEXT:      } step {
+// CIR-NEXT:        cir.yield
+// CIR-NEXT:      }
+// CIR-NEXT:   }
+// CIR-NEXT:   cir.return
+// CIR-NEXT: }
+
+// LLVM: define void @f5()
+// LLVM:   br label %[[SCOPE:.*]]
+// LLVM: [[SCOPE]]:
+// LLVM:   br label %[[LOOP:.*]]
+// LLVM: [[LOOP]]:
+// LLVM:   br i1 true, label %[[LOOP_STEP:.*]], label %[[LOOP_EXIT:.*]]
+// LLVM: [[LOOP_STEP]]:
+// LLVM:   br label %[[LOOP_BODY:.*]]
+// LLVM: [[LOOP_BODY]]:
+// LLVM:   br label %[[LOOP]]
+// LLVM: [[LOOP_EXIT]]:
+// LLVM:   ret void
+
+// OGCG: define{{.*}} void @f5()
+// OGCG: entry:
+// OGCG:   br label %[[LOOP:.*]]
+// OGCG: [[LOOP]]:
+// OGCG:   br label %[[LOOP]]

--- a/clang/test/CIR/CodeGen/basic.c
+++ b/clang/test/CIR/CodeGen/basic.c
@@ -90,3 +90,18 @@ int f3(void) {
 // OGCG-NEXT:   store i32 3, ptr %[[I_PTR]], align 4
 // OGCG-NEXT:   %[[I:.*]] = load i32, ptr %[[I_PTR]], align 4
 // OGCG-NEXT:   ret i32 %[[I]]
+
+// Verify null statement handling.
+void f4(void) {
+  ;
+}
+
+//      CIR: cir.func @f4()
+// CIR-NEXT:   cir.return
+
+//      LLVM: define void @f4()
+// LLVM-NEXT:   ret void
+
+//      OGCG: define{{.*}} void @f4()
+// OGCG-NEXT: entry:
+// OGCG-NEXT:   ret void


### PR DESCRIPTION
The handling for NullStmt was going to an error saying the statement handling wasn't implemented. It doesn't need any implementation. It is sufficient for emitSimpleStmt to just return success for that statement class. This change does that.