### PR TITLE
[flang][cuda] Avoid triggering host array error in host device proc

### DIFF
--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -261,6 +261,9 @@ public:
           subp->cudaSubprogramAttrs().value_or(
               common::CUDASubprogramAttrs::Host) !=
               common::CUDASubprogramAttrs::Host) {
+        isHostDevice = subp->cudaSubprogramAttrs() &&
+            subp->cudaSubprogramAttrs() ==
+                common::CUDASubprogramAttrs::HostDevice;
         Check(body);
       }
     }
@@ -357,6 +360,8 @@ private:
   }
   template <typename A>
   void ErrorIfHostSymbol(const A &expr, parser::CharBlock source) {
+    if (isHostDevice)
+      return;
     if (const Symbol * hostArray{FindHostArray{}(expr)}) {
       context_.Say(source,
           "Host array '%s' cannot be present in device context"_err_en_US,
@@ -502,6 +507,7 @@ private:
   }
 
   SemanticsContext &context_;
+  bool isHostDevice{false};
 };
 
 void CUDAChecker::Enter(const parser::SubroutineSubprogram &x) {

--- a/flang/test/Semantics/cuf09.cuf
+++ b/flang/test/Semantics/cuf09.cuf
@@ -221,3 +221,10 @@ subroutine ieee_test
     ll(i) = ieee_is_finite(y(i)) ! allow ieee_arithmetic functions on the device.
   end do
 end subroutine
+
+attributes(host,device) subroutine do2(a,b,c,i)
+  integer a(*), b(*), c(*)
+  integer, value :: i  
+  c(i) = a(i) - b(i) ! ok. Should not error with Host array 
+                     ! cannot be present in device context
+end


### PR DESCRIPTION
we cannot enforce the detection of host arrays in device code when the procedure is host, device. Relax the check for those. 