### PR TITLE
[CIR][NFC] Upstream LValueBaseInfo handling

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -108,11 +108,11 @@ struct MissingFeatures {
   static bool cgFPOptionsRAII() { return false; }
   static bool metaDataNode() { return false; }
   static bool fastMathFlags() { return false; }
-  static bool lvalueBaseInfo() { return false; }
   static bool alignCXXRecordDecl() { return false; }
   static bool setNonGC() { return false; }
   static bool incrementProfileCounter() { return false; }
   static bool insertBuiltinUnpredictable() { return false; }
+  static bool objCGC() { return false; }
 
   // Missing types
   static bool dataMemberType() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -146,7 +146,7 @@ void CIRGenFunction::emitAutoVarInit(
   // its removal/optimization to the CIR lowering.
   if (!constant || isa<CXXTemporaryObjectExpr>(init)) {
     initializeWhatIsTechnicallyUninitialized(addr);
-    LValue lv = LValue::makeAddr(addr, type);
+    LValue lv = makeAddrLValue(addr, type, AlignmentSource::Decl);
     emitExprAsInit(init, &d, lv);
     // In case lv has uses it means we indeed initialized something
     // out of it while trying to build the expression, mark it as such.
@@ -165,7 +165,7 @@ void CIRGenFunction::emitAutoVarInit(
   assert(typedConstant && "expected typed attribute");
   if (!emission.IsConstantAggregate) {
     // For simple scalar/complex initialization, store the value directly.
-    LValue lv = LValue::makeAddr(addr, type);
+    LValue lv = makeAddrLValue(addr, type);
     assert(init && "expected initializer");
     mlir::Location initLoc = getLoc(init->getSourceRange());
     // lv.setNonGC(true);

--- a/clang/lib/CIR/CodeGen/CIRGenExprAggregate.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprAggregate.cpp
@@ -130,7 +130,7 @@ void AggExprEmitter::emitArrayInit(Address destPtr, cir::ArrayType arrayTy,
     }
 
     const Address address = Address(element, cirElementType, elementAlign);
-    const LValue elementLV = LValue::makeAddr(address, elementType);
+    const LValue elementLV = cgf.makeAddrLValue(address, elementType);
     emitInitializationToLValue(args[i], elementLV);
   }
 
@@ -157,7 +157,7 @@ void AggExprEmitter::emitArrayInit(Address destPtr, cir::ArrayType arrayTy,
     const Address tmpAddr = cgf.createTempAlloca(
         cirElementPtrType, cgf.getPointerAlign(), loc, "arrayinit.temp",
         /*insertIntoFnEntryBlock=*/false);
-    LValue tmpLV = LValue::makeAddr(tmpAddr, elementPtrType);
+    LValue tmpLV = cgf.makeAddrLValue(tmpAddr, elementPtrType);
     cgf.emitStoreThroughLValue(RValue::get(element), tmpLV);
 
     // TODO(CIR): Replace this part later with cir::DoWhileOp
@@ -166,7 +166,7 @@ void AggExprEmitter::emitArrayInit(Address destPtr, cir::ArrayType arrayTy,
           builder.createLoad(loc, tmpAddr.getPointer());
 
       // Emit the actual filler expression.
-      const LValue elementLV = LValue::makeAddr(
+      const LValue elementLV = cgf.makeAddrLValue(
           Address(currentElement, cirElementType, elementAlign), elementType);
 
       if (arrayFiller)

--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -242,10 +242,21 @@ public:
   /// been signed, and the returned Address will have the pointer authentication
   /// information needed to authenticate the signed pointer.
   Address makeNaturalAddressForPointer(mlir::Value ptr, QualType t,
-                                       CharUnits alignment) {
+                                       CharUnits alignment,
+                                       bool forPointeeType = false,
+                                       LValueBaseInfo *baseInfo = nullptr) {
     if (alignment.isZero())
-      alignment = cgm.getNaturalTypeAlignment(t);
+      alignment = cgm.getNaturalTypeAlignment(t, baseInfo);
     return Address(ptr, convertTypeForMem(t), alignment);
+  }
+
+  LValue makeAddrLValue(Address addr, QualType ty,
+                        AlignmentSource source = AlignmentSource::Type) {
+    return makeAddrLValue(addr, ty, LValueBaseInfo(source));
+  }
+
+  LValue makeAddrLValue(Address addr, QualType ty, LValueBaseInfo baseInfo) {
+    return LValue::makeAddr(addr, ty, baseInfo);
   }
 
   cir::FuncOp generateCode(clang::GlobalDecl gd, cir::FuncOp fn,
@@ -523,7 +534,8 @@ public:
   /// into the address of a local variable.  In such a case, it's quite
   /// reasonable to just ignore the returned alignment when it isn't from an
   /// explicit source.
-  Address emitPointerWithAlignment(const clang::Expr *expr);
+  Address emitPointerWithAlignment(const clang::Expr *expr,
+                                   LValueBaseInfo *baseInfo);
 
   mlir::LogicalResult emitReturnStmt(const clang::ReturnStmt &s);
 

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -16,6 +16,7 @@
 #include "CIRGenBuilder.h"
 #include "CIRGenTypeCache.h"
 #include "CIRGenTypes.h"
+#include "CIRGenValue.h"
 
 #include "clang/AST/CharUnits.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
@@ -91,7 +92,8 @@ public:
 
   /// FIXME: this could likely be a common helper and not necessarily related
   /// with codegen.
-  clang::CharUnits getNaturalTypeAlignment(clang::QualType t);
+  clang::CharUnits getNaturalTypeAlignment(clang::QualType t,
+                                           LValueBaseInfo *baseInfo);
 
   void emitTopLevelDecl(clang::Decl *decl);
 


### PR DESCRIPTION
Previous implementations that used the cir::LValue class omitted hanling of the LValueBaseInfo class, which tracks information about the basis for the LValue's alignment. As more code was upstreamed from the incubator, we were accumulating technical debt by adding more places where this wasn't handled correctly. This change puts the interfaces in place to track this information.

The information being tracked isn't used yet, so no functional change is intended. The tracking is being added now because it will become more difficult to add it as more features are implemented.