### PR TITLE
[Clang][MicrosoftMangle] Implement mangling for ConstantMatrixType

### DIFF
--- a/clang/lib/AST/MicrosoftMangle.cpp
+++ b/clang/lib/AST/MicrosoftMangle.cpp
@@ -3526,7 +3526,22 @@ void MicrosoftCXXNameMangler::mangleType(const DependentSizedExtVectorType *T,
 
 void MicrosoftCXXNameMangler::mangleType(const ConstantMatrixType *T,
                                          Qualifiers quals, SourceRange Range) {
-  Error(Range.getBegin(), "matrix type") << Range;
+  QualType EltTy = T->getElementType();
+  const BuiltinType *ET = EltTy->getAs<BuiltinType>();
+
+  llvm::SmallString<64> TemplateMangling;
+  llvm::raw_svector_ostream Stream(TemplateMangling);
+  MicrosoftCXXNameMangler Extra(Context, Stream);
+
+  Stream << "?$";
+
+  Extra.mangleSourceName("__matrix");
+  Extra.mangleType(EltTy, Range, QMM_Escape);
+
+  Extra.mangleIntegerLiteral(llvm::APSInt::getUnsigned(T->getNumRows()));
+  Extra.mangleIntegerLiteral(llvm::APSInt::getUnsigned(T->getNumColumns()));
+
+  mangleArtificialTagType(TagTypeKind::Struct, TemplateMangling, {"__clang"});
 }
 
 void MicrosoftCXXNameMangler::mangleType(const DependentSizedMatrixType *T,

--- a/clang/test/CodeGenCXX/mangle-ms-matrix.cpp
+++ b/clang/test/CodeGenCXX/mangle-ms-matrix.cpp
@@ -1,0 +1,57 @@
+// RUN: %clang_cc1 -fenable-matrix -fms-extensions -fcxx-exceptions -ffreestanding -target-feature +avx -emit-llvm %s -o - -triple=i686-pc-win32 | FileCheck %s
+// RUN: %clang_cc1 -fenable-matrix -fms-extensions -fcxx-exceptions -ffreestanding -target-feature +avx -emit-llvm %s -o - -triple=i686-pc-win32 -fexperimental-new-constant-interpreter | FileCheck %s
+
+typedef float __attribute__((matrix_type(4, 4))) m4x4f;
+typedef float __attribute__((matrix_type(2, 2))) m2x2f;
+
+typedef int __attribute__((matrix_type(4, 4))) m4x4i;
+typedef int __attribute__((matrix_type(2, 2))) m2x2i;
+
+void thow(int i) {
+  switch (i) {
+    case 0: throw m4x4f();
+    // CHECK: ??_R0U?$__matrix@M$03$03@__clang@@@8
+    // CHECK: _CT??_R0U?$__matrix@M$03$03@__clang@@@864
+    // CHECK: _CTA1U?$__matrix@M$03$03@__clang@@
+    // CHECK: _TI1U?$__matrix@M$03$03@__clang@@
+    case 1: throw m2x2f();
+    // CHECK: ??_R0U?$__matrix@M$01$01@__clang@@@8
+    // CHECK: _CT??_R0U?$__matrix@M$01$01@__clang@@@816
+    // CHECK: _CTA1U?$__matrix@M$01$01@__clang@@
+    // CHECK: _TI1U?$__matrix@M$01$01@__clang@@
+    case 2: throw m4x4i();
+    // CHECK: ??_R0U?$__matrix@H$03$03@__clang@@@8
+    // CHECK: _CT??_R0U?$__matrix@H$03$03@__clang@@@864
+    // CHECK: _CTA1U?$__matrix@H$03$03@__clang@@
+    // CHECK: _TI1U?$__matrix@H$03$03@__clang@@
+    case 3: throw m2x2i();
+    // CHECK: ??_R0U?$__matrix@H$01$01@__clang@@@8
+    // CHECK: _CT??_R0U?$__matrix@H$01$01@__clang@@@816
+    // CHECK: _CTA1U?$__matrix@H$01$01@__clang@@
+    // CHECK: _TI1U?$__matrix@H$01$01@__clang@@
+  }
+}
+
+void foo44f(m4x4f) {}
+// CHECK: define dso_local void @"?foo44f@@YAXU?$__matrix@M$03$03@__clang@@@Z"
+
+m4x4f rfoo44f() { return m4x4f(); }
+// CHECK: define dso_local noundef <16 x float> @"?rfoo44f@@YAU?$__matrix@M$03$03@__clang@@XZ"
+
+void foo22f(m2x2f) {}
+// CHECK: define dso_local void @"?foo22f@@YAXU?$__matrix@M$01$01@__clang@@@Z"
+
+m2x2f rfoo22f() { return m2x2f(); }
+// CHECK: define dso_local noundef <4 x float> @"?rfoo22f@@YAU?$__matrix@M$01$01@__clang@@XZ"
+
+void foo44i(m4x4i) {}
+// CHECK: define dso_local void @"?foo44i@@YAXU?$__matrix@H$03$03@__clang@@@Z"
+
+m4x4i rfoo44i() { return m4x4i(); }
+// CHECK: define dso_local noundef <16 x i32> @"?rfoo44i@@YAU?$__matrix@H$03$03@__clang@@XZ"
+
+void foo22i(m2x2i) {}
+// CHECK: define dso_local void @"?foo22i@@YAXU?$__matrix@H$01$01@__clang@@@Z"
+
+m2x2i rfoo22i() { return m2x2i(); }
+// CHECK: define dso_local noundef <4 x i32> @"?rfoo22i@@YAU?$__matrix@H$01$01@__clang@@XZ"


### PR DESCRIPTION
This pull request implements mangling for ConstantMatrixType, allowing matrices to be used on Windows.

Related issues: #53158, #127127

This example code:
```cpp
#include <typeinfo>
#include <stdio.h>

typedef float Matrix4 __attribute__((matrix_type(4, 4)));

int main()
{
  printf("%s\n", typeid(Matrix4).name());
}
```
Outputs this:
```
struct __clang::__matrix<float,4,4>
```

Apologies if I did something wrong, this is my first time doing this 😅.