### PR TITLE
[RISCV] Reuse existing tablegen classes for Zilsd/Zclsd. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
@@ -234,25 +234,25 @@ def uimm2_opcode : RISCVUImmOp<2> {
 
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 class CStackLoad<bits<3> funct3, string OpcodeStr,
-                 RegisterClass cls, DAGOperand opnd>
+                 DAGOperand cls, DAGOperand opnd>
     : RVInst16CI<funct3, 0b10, (outs cls:$rd), (ins SPMem:$rs1, opnd:$imm),
                  OpcodeStr, "$rd, ${imm}(${rs1})">;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 class CStackStore<bits<3> funct3, string OpcodeStr,
-                  RegisterClass cls, DAGOperand opnd>
+                  DAGOperand cls, DAGOperand opnd>
     : RVInst16CSS<funct3, 0b10, (outs), (ins cls:$rs2, SPMem:$rs1, opnd:$imm),
                   OpcodeStr, "$rs2, ${imm}(${rs1})">;
 
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
 class CLoad_ri<bits<3> funct3, string OpcodeStr,
-               RegisterClass cls, DAGOperand opnd>
+               DAGOperand cls, DAGOperand opnd>
     : RVInst16CL<funct3, 0b00, (outs cls:$rd), (ins GPRCMem:$rs1, opnd:$imm),
                  OpcodeStr, "$rd, ${imm}(${rs1})">;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 class CStore_rri<bits<3> funct3, string OpcodeStr,
-                 RegisterClass cls, DAGOperand opnd>
+                 DAGOperand cls, DAGOperand opnd>
     : RVInst16CS<funct3, 0b00, (outs), (ins cls:$rs2,GPRCMem:$rs1, opnd:$imm),
                  OpcodeStr, "$rs2, ${imm}(${rs1})">;
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZclsd.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZclsd.td
@@ -37,53 +37,29 @@ def GPRPairCRV32 : RegisterOperand<GPRPairC> {
   let ParserMatchClass = GPRPairCRV32Operand;
 }
 
-let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
-class PairCStackLoad<bits<3> funct3, string OpcodeStr,
-                     DAGOperand RC, DAGOperand opnd>
-    : RVInst16CI<funct3, 0b10, (outs RC:$rd), (ins SPMem:$rs1, opnd:$imm),
-                 OpcodeStr, "$rd, ${imm}(${rs1})">;
-
-let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
-class PairCStackStore<bits<3> funct3, string OpcodeStr,
-                      DAGOperand RC, DAGOperand opnd>
-    : RVInst16CSS<funct3, 0b10, (outs), (ins RC:$rs2, SPMem:$rs1, opnd:$imm),
-                  OpcodeStr, "$rs2, ${imm}(${rs1})">;
-
-let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
-class PairCLoad_ri<bits<3> funct3, string OpcodeStr,
-                  DAGOperand RC, DAGOperand opnd>
-    : RVInst16CL<funct3, 0b00, (outs RC:$rd), (ins GPRCMem:$rs1, opnd:$imm),
-                 OpcodeStr, "$rd, ${imm}(${rs1})">;
-
-let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
-class PairCStore_rri<bits<3> funct3, string OpcodeStr,
-                     DAGOperand RC, DAGOperand opnd>
-    : RVInst16CS<funct3, 0b00, (outs), (ins RC:$rs2,GPRCMem:$rs1, opnd:$imm),
-                 OpcodeStr, "$rs2, ${imm}(${rs1})">;
-
 //===----------------------------------------------------------------------===//
 // Instructions
 //===----------------------------------------------------------------------===//
 
 let Predicates = [HasStdExtZclsd, IsRV32], DecoderNamespace = "ZcOverlap" in {
-def C_LDSP_RV32 : PairCStackLoad<0b011, "c.ldsp", GPRPairNoX0RV32, uimm9_lsb000>,
+def C_LDSP_RV32 : CStackLoad<0b011, "c.ldsp", GPRPairNoX0RV32, uimm9_lsb000>,
                   Sched<[WriteLDD, ReadMemBase]> {
   let Inst{4-2} = imm{8-6};
 }
 
-def C_SDSP_RV32 : PairCStackStore<0b111, "c.sdsp", GPRPairRV32, uimm9_lsb000>,
+def C_SDSP_RV32 : CStackStore<0b111, "c.sdsp", GPRPairRV32, uimm9_lsb000>,
                   Sched<[WriteSTD, ReadStoreData, ReadMemBase]> {
   let Inst{9-7} = imm{8-6};
 }
 
-def C_LD_RV32 : PairCLoad_ri<0b011, "c.ld", GPRPairCRV32, uimm8_lsb000>,
+def C_LD_RV32 : CLoad_ri<0b011, "c.ld", GPRPairCRV32, uimm8_lsb000>,
                 Sched<[WriteLDD, ReadMemBase]> {
   bits<8> imm;
   let Inst{12-10} = imm{5-3};
   let Inst{6-5} = imm{7-6};
 }
 
-def C_SD_RV32 : PairCStore_rri<0b111, "c.sd", GPRPairCRV32, uimm8_lsb000>,
+def C_SD_RV32 : CStore_rri<0b111, "c.sd", GPRPairCRV32, uimm8_lsb000>,
                 Sched<[WriteSTD, ReadStoreData, ReadMemBase]> {
   bits<8> imm;
   let Inst{12-10} = imm{5-3};

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZilsd.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZilsd.td
@@ -15,26 +15,14 @@
 // Instruction Class Templates
 //===----------------------------------------------------------------------===//
 
-let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in
-class PairLoad_ri<string opcodestr, DAGOperand RC>
-    : RVInstI<0b011, OPC_LOAD, (outs RC:$rd), 
-              (ins GPRMem:$rs1, simm12:$imm12),
-              opcodestr, "${rd}, ${imm12}(${rs1})">;
-
-let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
-class PairStore_rri<string opcodestr, DAGOperand RC>
-    : RVInstS<0b011, OPC_STORE, (outs),
-              (ins RC:$rs2, GPRMem:$rs1, simm12:$imm12),
-              opcodestr, "${rs2}, ${imm12}(${rs1})">;
-
 //===----------------------------------------------------------------------===//
 // Instructions
 //===----------------------------------------------------------------------===//
 
 let Predicates = [HasStdExtZilsd, IsRV32], DecoderNamespace = "RV32Only" in {
-def LD_RV32 : PairLoad_ri<"ld", GPRPairRV32>, Sched<[WriteLDD, ReadMemBase]>;
-def SD_RV32 : PairStore_rri<"sd", GPRPairRV32>, Sched<[WriteSTD, ReadStoreData,
-                            ReadMemBase]>;
+def LD_RV32 : Load_ri<0b011, "ld", GPRPairRV32>, Sched<[WriteLDD, ReadMemBase]>;
+def SD_RV32 : Store_rri<0b011, "sd", GPRPairRV32>,
+              Sched<[WriteSTD, ReadStoreData, ReadMemBase]>;
 } // Predicates = [HasStdExtZilsd, IsRV32], DecoderNamespace = "RV32Only"
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
We don't need pair specific classes. We just need to pass the pair RegisterOperand to the existing classes we use for the base ISA and Zca. For Zclsd, we need to changes the classes to take DAGOperand instead of RegisterClass so we can pass a RegisterOperand.