### PR TITLE
[Clang] Add non static data member initializer for BindingDecl member Decomp

### DIFF
--- a/clang/include/clang/AST/DeclCXX.h
+++ b/clang/include/clang/AST/DeclCXX.h
@@ -4166,7 +4166,7 @@ public:
 /// DecompositionDecl of type 'int (&)[3]'.
 class BindingDecl : public ValueDecl {
   /// The declaration that this binding binds to part of.
-  ValueDecl *Decomp;
+  ValueDecl *Decomp = nullptr;
   /// The binding represented by this declaration. References to this
   /// declaration are effectively equivalent to this expression (except
   /// that it is only evaluated once at the point of declaration of the


### PR DESCRIPTION
Static analysis flagged BindingDecl Decomp member as not being initialized during construction or by any other member function.

Fix is add a default initializer for it like the other member Binding.