### PR TITLE
[libc++] Fix disabling of extension warnings in C++20 and later

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -538,9 +538,9 @@ typedef __char32_t char32_t;
 #  endif
 
 // Clang modules take a significant compile time hit when pushing and popping diagnostics.
-// Since all the headers are marked as system headers in the modulemap, we can simply disable this
-// pushing and popping when building with clang modules.
-#  if !__has_feature(modules)
+// Since all the headers are marked as system headers unless _LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER is defined, we can
+// simply disable this pushing and popping when _LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER isn't defined.
+#  ifdef _LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER
 #    define _LIBCPP_PUSH_EXTENSION_DIAGNOSTICS                                                                         \
       _LIBCPP_DIAGNOSTIC_PUSH                                                                                          \
       _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++11-extensions")                                                           \


### PR DESCRIPTION
`__has_feature(modules)` is always true in C++20 and later. Instead of using that, just disable extension warnings if they're not ignored through the system header machinery anyways.
