### PR TITLE
[libc++][NFC] Inline _LIBCPP_FALLTHROUGH()

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -1129,9 +1129,6 @@ typedef __char32_t char32_t;
     __attribute__((__format__(archetype, format_string_index, first_format_arg_index)))
 #  define _LIBCPP_PACKED __attribute__((__packed__))
 
-// Use a function like macro to imply that it must be followed by a semicolon
-#  define _LIBCPP_FALLTHROUGH() [[fallthrough]]
-
 #  if __has_attribute(__no_sanitize__) && !defined(_LIBCPP_COMPILER_GCC)
 #    define _LIBCPP_NO_CFI __attribute__((__no_sanitize__("cfi")))
 #  else

--- a/libcxx/include/__functional/hash.h
+++ b/libcxx/include/__functional/hash.h
@@ -64,10 +64,10 @@ struct __murmur2_or_cityhash<_Size, 32> {
     switch (__len) {
     case 3:
       __h ^= static_cast<_Size>(__data[2] << 16);
-      _LIBCPP_FALLTHROUGH();
+      [[__fallthrough__]];
     case 2:
       __h ^= static_cast<_Size>(__data[1] << 8);
-      _LIBCPP_FALLTHROUGH();
+      [[__fallthrough__]];
     case 1:
       __h ^= __data[0];
       __h *= __m;

--- a/libcxx/include/locale
+++ b/libcxx/include/locale
@@ -2421,7 +2421,7 @@ bool money_get<_CharT, _InputIterator>::__do_get(
           return false;
         }
       }
-      _LIBCPP_FALLTHROUGH();
+      [[__fallthrough__]];
     case money_base::none:
       if (__p != 3) {
         while (__b != __e && __ct.is(ctype_base::space, *__b))

--- a/libcxx/include/regex
+++ b/libcxx/include/regex
@@ -3930,7 +3930,7 @@ _ForwardIterator basic_regex<_CharT, _Traits>::__parse_character_escape(
       if (__hd == -1)
         std::__throw_regex_error<regex_constants::error_escape>();
       __sum = 16 * __sum + static_cast<unsigned>(__hd);
-      _LIBCPP_FALLTHROUGH();
+      [[__fallthrough__]];
     case 'x':
       ++__first;
       if (__first == __last)

--- a/libcxx/src/filesystem/path_parser.h
+++ b/libcxx/src/filesystem/path_parser.h
@@ -90,7 +90,7 @@ public:
       if (TkEnd)
         return makeState(PS_InRootName, Start, TkEnd);
     }
-      _LIBCPP_FALLTHROUGH();
+      [[__fallthrough__]];
     case PS_InRootName: {
       PosPtr TkEnd = consumeAllSeparators(Start, End);
       if (TkEnd)


### PR DESCRIPTION
We have `[[fallthrough]]` available in all standards modes, so we can just inline it like other stanard attributes we use.
