### PR TITLE
libclc: clspv: fma: remove fp16 implementation

### DIFF
--- a/libclc/clspv/lib/math/fma.cl
+++ b/libclc/clspv/lib/math/fma.cl
@@ -12,13 +12,3 @@
 
 _CLC_DEFINE_TERNARY_BUILTIN(float, fma, __clc_sw_fma, float, float, float)
 
-#ifdef cl_khr_fp16
-
-#pragma OPENCL EXTENSION cl_khr_fp16 : enable
-
-_CLC_DEF _CLC_OVERLOAD half fma(half a, half b, half c) {
-  return (half)mad((float)a, (float)b, (float)c);
-}
-_CLC_TERNARY_VECTORIZE(_CLC_DEF _CLC_OVERLOAD, half, fma, half, half, half)
-
-#endif


### PR DESCRIPTION
clspv is already handling generation of fp16. This implementation is preventing clspv from making the best choice to use an emulation on top of fp32-fma, or the native fp16-fma, depending on the command-line arguments.