### PR TITLE
[VectorUtils] Add helper to get list of metadata to propagate (NFC).

### DIFF
--- a/llvm/lib/Analysis/VectorUtils.cpp
+++ b/llvm/lib/Analysis/VectorUtils.cpp
@@ -998,9 +998,9 @@ static void getMetadataToPropagate(
 
   // Remove any unsupported metadata kinds from Metadata.
   for (unsigned Idx = 0; Idx != Metadata.size();) {
-    if (is_contained(SupportedIDs, Metadata[Idx].first))
+    if (is_contained(SupportedIDs, Metadata[Idx].first)) {
       Idx++;
-    else {
+    } else {
       // Swap element to end and remove it.
       std::swap(Metadata[Idx], Metadata.back());
       Metadata.pop_back();

--- a/llvm/lib/Analysis/VectorUtils.cpp
+++ b/llvm/lib/Analysis/VectorUtils.cpp
@@ -990,7 +990,7 @@ static void getMetadataToPropagate(
     Instruction *Inst,
     SmallVectorImpl<std::pair<unsigned, MDNode *>> &Metadata) {
   Inst->getAllMetadataOtherThanDebugLoc(Metadata);
-  unsigned SupportedIDs[] = {
+  static const unsigned SupportedIDs[] = {
       LLVMContext::MD_tbaa,         LLVMContext::MD_alias_scope,
       LLVMContext::MD_noalias,      LLVMContext::MD_fpmath,
       LLVMContext::MD_nontemporal,  LLVMContext::MD_invariant_load,
@@ -999,7 +999,7 @@ static void getMetadataToPropagate(
   // Remove any unsupported metadata kinds from Metadata.
   for (unsigned Idx = 0; Idx != Metadata.size();) {
     if (is_contained(SupportedIDs, Metadata[Idx].first)) {
-      Idx++;
+      ++Idx;
     } else {
       // Swap element to end and remove it.
       std::swap(Metadata[Idx], Metadata.back());

--- a/llvm/lib/Analysis/VectorUtils.cpp
+++ b/llvm/lib/Analysis/VectorUtils.cpp
@@ -984,19 +984,38 @@ MDNode *llvm::intersectAccessGroups(const Instruction *Inst1,
   return MDNode::get(Ctx, Intersection);
 }
 
+/// Add metadata from \p Inst to \p Metadata, if it can be preserved after
+/// vectorization.
+static void getMetadataToPropagate(
+    Instruction *Inst,
+    SmallVectorImpl<std::pair<unsigned, MDNode *>> &Metadata) {
+  Inst->getAllMetadataOtherThanDebugLoc(Metadata);
+  unsigned SupportedIDs[] = {
+      LLVMContext::MD_tbaa,         LLVMContext::MD_alias_scope,
+      LLVMContext::MD_noalias,      LLVMContext::MD_fpmath,
+      LLVMContext::MD_nontemporal,  LLVMContext::MD_invariant_load,
+      LLVMContext::MD_access_group, LLVMContext::MD_mmra};
+
+  // Remove any unsupported metadata kinds from Metadata.
+  for (unsigned Idx = 0; Idx != Metadata.size();) {
+    if (is_contained(SupportedIDs, Metadata[Idx].first))
+      Idx++;
+    else {
+      // Swap element to end and remove it.
+      std::swap(Metadata[Idx], Metadata.back());
+      Metadata.pop_back();
+    }
+  }
+}
+
 /// \returns \p I after propagating metadata from \p VL.
 Instruction *llvm::propagateMetadata(Instruction *Inst, ArrayRef<Value *> VL) {
   if (VL.empty())
     return Inst;
-  Instruction *I0 = cast<Instruction>(VL[0]);
-  SmallVector<std::pair<unsigned, MDNode *>, 4> Metadata;
-  I0->getAllMetadataOtherThanDebugLoc(Metadata);
+  SmallVector<std::pair<unsigned, MDNode *>> Metadata;
+  getMetadataToPropagate(cast<Instruction>(VL[0]), Metadata);
 
-  for (auto Kind : {LLVMContext::MD_tbaa, LLVMContext::MD_alias_scope,
-                    LLVMContext::MD_noalias, LLVMContext::MD_fpmath,
-                    LLVMContext::MD_nontemporal, LLVMContext::MD_invariant_load,
-                    LLVMContext::MD_access_group, LLVMContext::MD_mmra}) {
-    MDNode *MD = I0->getMetadata(Kind);
+  for (auto &[Kind, MD] : Metadata) {
     for (int J = 1, E = VL.size(); MD && J != E; ++J) {
       const Instruction *IJ = cast<Instruction>(VL[J]);
       MDNode *IMD = IJ->getMetadata(Kind);


### PR DESCRIPTION
Split off the logic to filter out metadata that should not be propagated to a helper that populates a list with metadata kinds that should be preserved.

The current version just uses is_contained on an array to check if a metadata kind is supported. Given that most instructions will only have a small number of metadata kinds to start with, this shouldn't be worse than iterating over all kinds once and querying the instruction for individual metadata kinds, which involves quite a bit of indirection.

I plan ot use this utility in a follow-up patch in other places as well.