### PR TITLE
[clang][bytecode] Classify function pointers as PT_Ptr

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -463,6 +463,8 @@ bool Compiler<Emitter>::VisitCastExpr(const CastExpr *CE) {
 
       if (!this->visit(SubExpr))
         return false;
+      if (CE->getType()->isFunctionPointerType())
+        return true;
       if (FromT == PT_Ptr)
         return this->emitPtrPtrCast(SubExprTy->isVoidPointerType(), CE);
       return true;
@@ -4921,10 +4923,10 @@ bool Compiler<Emitter>::VisitCallExpr(const CallExpr *E) {
   } else if (!FuncDecl) {
     const Expr *Callee = E->getCallee();
     CalleeOffset =
-        this->allocateLocalPrimitive(Callee, PT_FnPtr, /*IsConst=*/true);
+        this->allocateLocalPrimitive(Callee, PT_Ptr, /*IsConst=*/true);
     if (!this->visit(Callee))
       return false;
-    if (!this->emitSetLocal(PT_FnPtr, *CalleeOffset, E))
+    if (!this->emitSetLocal(PT_Ptr, *CalleeOffset, E))
       return false;
   }
 
@@ -5011,7 +5013,7 @@ bool Compiler<Emitter>::VisitCallExpr(const CallExpr *E) {
       if (!this->emitGetMemberPtrDecl(E))
         return false;
     } else {
-      if (!this->emitGetLocal(PT_FnPtr, *CalleeOffset, E))
+      if (!this->emitGetLocal(PT_Ptr, *CalleeOffset, E))
         return false;
     }
     if (!this->emitCallPtr(ArgSize, E, E))

--- a/clang/lib/AST/ByteCode/Context.cpp
+++ b/clang/lib/AST/ByteCode/Context.cpp
@@ -189,7 +189,7 @@ std::optional<PrimType> Context::classify(QualType T) const {
 
   if (T->isFunctionPointerType() || T->isFunctionReferenceType() ||
       T->isFunctionType() || T->isBlockPointerType())
-    return PT_FnPtr;
+    return PT_Ptr;
 
   if (T->isPointerOrReferenceType() || T->isObjCObjectPointerType())
     return PT_Ptr;

--- a/clang/lib/AST/ByteCode/Context.h
+++ b/clang/lib/AST/ByteCode/Context.h
@@ -78,11 +78,8 @@ public:
   /// Classifies an expression.
   std::optional<PrimType> classify(const Expr *E) const {
     assert(E);
-    if (E->isGLValue()) {
-      if (E->getType()->isFunctionType())
-        return PT_FnPtr;
+    if (E->isGLValue())
       return PT_Ptr;
-    }
 
     return classify(E->getType());
   }

--- a/clang/lib/AST/ByteCode/EvalEmitter.cpp
+++ b/clang/lib/AST/ByteCode/EvalEmitter.cpp
@@ -169,6 +169,11 @@ template <> bool EvalEmitter::emitRet<PT_Ptr>(const SourceInfo &Info) {
 
   const Pointer &Ptr = S.Stk.pop<Pointer>();
 
+  if (Ptr.isFunctionPointer()) {
+    EvalResult.setValue(Ptr.toAPValue(Ctx.getASTContext()));
+    return true;
+  }
+
   if (!EvalResult.checkReturnValue(S, Ctx, Ptr, Info))
     return false;
   if (CheckFullyInitialized && !EvalResult.checkFullyInitialized(S, Ptr))

--- a/clang/lib/AST/ByteCode/Pointer.h
+++ b/clang/lib/AST/ByteCode/Pointer.h
@@ -525,6 +525,8 @@ public:
   }
 
   bool isWeak() const {
+    if (isFunctionPointer())
+      return asFunctionPointer().isWeak();
     if (!isBlockPointer())
       return false;
 

--- a/clang/test/AST/ByteCode/pointer-to-fnptr.cpp
+++ b/clang/test/AST/ByteCode/pointer-to-fnptr.cpp
@@ -1,0 +1,29 @@
+// RUN: %clang_cc1 -triple x86_64-linux -emit-llvm -o - %s                                         | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-linux -emit-llvm -o - %s -fexperimental-new-constant-interpreter | FileCheck %s
+
+template<typename T>
+struct Wrapper {
+  T *Val;
+
+  template<typename _Up>
+  constexpr Wrapper(_Up&& __u) {
+    T& __f = static_cast<_Up&&>(__u);
+    Val = &__f;
+  }
+  constexpr T& get() const { return *Val; }
+};
+
+void f(){}
+int main() {
+  auto W = Wrapper<decltype(f)>(f);
+
+  if (&W.get() != &f)
+    __builtin_abort();
+}
+
+/// We used to convert do the pointer->fnptr conversion
+/// by doing an integer conversion in between, which caused the
+/// %0 line to be:
+/// store ptr inttoptr (i64 138574454870464 to ptr), ptr %__f, align 8
+// CHECK: @_ZN7WrapperIFvvEEC2IRS0_EEOT_
+// CHECK: %0 = load ptr, ptr %__u.addr

--- a/clang/unittests/AST/ByteCode/toAPValue.cpp
+++ b/clang/unittests/AST/ByteCode/toAPValue.cpp
@@ -135,7 +135,7 @@ TEST(ToAPValue, FunctionPointers) {
 
   {
     const Pointer &GP = getGlobalPtr("func");
-    const FunctionPointer &FP = GP.deref<FunctionPointer>();
+    const Pointer &FP = GP.deref<Pointer>();
     ASSERT_FALSE(FP.isZero());
     APValue A = FP.toAPValue(ASTCtx);
     ASSERT_TRUE(A.hasValue());
@@ -193,7 +193,7 @@ TEST(ToAPValue, FunctionPointersC) {
     const ValueDecl *D = getDecl("func");
     const Pointer &GP = getGlobalPtr("func");
     ASSERT_TRUE(GP.isLive());
-    const FunctionPointer &FP = GP.deref<FunctionPointer>();
+    const Pointer &FP = GP.deref<Pointer>();
     ASSERT_FALSE(FP.isZero());
     APValue A = FP.toAPValue(ASTCtx);
     ASSERT_TRUE(A.hasValue());


### PR DESCRIPTION
The Pointer class already has the capability to be a function pointer, but we still classifed function pointers as PT_FnPtr/FunctionPointer. This means when converting from a Pointer to a FunctionPointer, we lost the information of what the original Pointer pointed to.