### PR TITLE
llvm-reduce: Use simpleSimplifyCFG in block reduction

### DIFF
--- a/llvm/test/tools/llvm-reduce/remove-bb-switch-default.ll
+++ b/llvm/test/tools/llvm-reduce/remove-bb-switch-default.ll
@@ -16,6 +16,7 @@
 ; RESULT0-NEXT: br i1 %arg0, label %bb1, label %bb2
 
 ; RESULT0: bb1:
+; RESULT0: %bb1.phi = phi i32 [ %bb.load, %bb ], [ %bb.load, %bb2 ], [ %bb.load, %bb2 ]
 ; RESULT0-NEXT: store i32 1, ptr null, align 4
 ; RESULT0-NEXT: ret void
 


### PR DESCRIPTION
Use the more targeted method of pruning newly dead blocks.