### PR TITLE
[RISCV] Add symbol parsing support for Xqcilb long branch instructions

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -2156,17 +2156,17 @@ ParseStatus RISCVAsmParser::parsePseudoQCJumpSymbol(OperandVector &Operands) {
     return ParseStatus::NoMatch;
 
   std::string Identifier(getTok().getIdentifier());
-  SMLoc E = SMLoc::getFromPointer(S.getPointer() + Identifier.size());
+  SMLoc E = getTok().getEndLoc();
 
   if (getLexer().peekTok().is(AsmToken::At)) {
     Lex();
     Lex();
     SMLoc PLTLoc = getLoc();
     StringRef PLT;
+    E = getTok().getEndLoc();
     if (getParser().parseIdentifier(PLT) || PLT != "plt")
       return Error(PLTLoc,
                    "'@plt' is the only valid operand for this instruction");
-    E = SMLoc::getFromPointer(S.getPointer() + /*@plt*/ 4);
   } else {
     Lex();
   }

--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -202,6 +202,7 @@ class RISCVAsmParser : public MCTargetAsmParser {
   ParseStatus parseOperandWithSpecifier(OperandVector &Operands);
   ParseStatus parseBareSymbol(OperandVector &Operands);
   ParseStatus parseCallSymbol(OperandVector &Operands);
+  ParseStatus parsePseudoQCJumpSymbol(OperandVector &Operands);
   ParseStatus parsePseudoJumpSymbol(OperandVector &Operands);
   ParseStatus parseJALOffset(OperandVector &Operands);
   ParseStatus parseVTypeI(OperandVector &Operands);
@@ -588,6 +589,17 @@ public:
     RISCVMCExpr::Specifier VK = RISCVMCExpr::VK_None;
     return RISCVAsmParser::classifySymbolRef(getImm(), VK) &&
            (VK == RISCVMCExpr::VK_CALL || VK == RISCVMCExpr::VK_CALL_PLT);
+  }
+
+  bool isPseudoQCJumpSymbol() const {
+    int64_t Imm;
+    // Must be of 'immediate' type but not a constant.
+    if (!isImm() || evaluateConstantImm(getImm(), Imm))
+      return false;
+
+    RISCVMCExpr::Specifier VK = RISCVMCExpr::VK_None;
+    return RISCVAsmParser::classifySymbolRef(getImm(), VK) &&
+           VK == RISCVMCExpr::VK_QC_E_JUMP_PLT;
   }
 
   bool isPseudoJumpSymbol() const {
@@ -2128,6 +2140,34 @@ ParseStatus RISCVAsmParser::parseCallSymbol(OperandVector &Operands) {
 
   SMLoc E = SMLoc::getFromPointer(S.getPointer() + Identifier.size());
   RISCVMCExpr::Specifier Kind = RISCVMCExpr::VK_CALL_PLT;
+
+  MCSymbol *Sym = getContext().getOrCreateSymbol(Identifier);
+  Res = MCSymbolRefExpr::create(Sym, getContext());
+  Res = RISCVMCExpr::create(Res, Kind, getContext());
+  Operands.push_back(RISCVOperand::createImm(Res, S, E, isRV64()));
+  return ParseStatus::Success;
+}
+
+ParseStatus RISCVAsmParser::parsePseudoQCJumpSymbol(OperandVector &Operands) {
+  SMLoc S = getLoc();
+  const MCExpr *Res;
+
+  if (getLexer().getKind() != AsmToken::Identifier)
+    return ParseStatus::NoMatch;
+  std::string Identifier(getTok().getIdentifier());
+
+  if (getLexer().peekTok().is(AsmToken::At)) {
+    Lex();
+    Lex();
+    StringRef PLT;
+    if (getParser().parseIdentifier(PLT) || PLT != "plt")
+      return ParseStatus::Failure;
+  } else {
+    Lex();
+  }
+
+  SMLoc E = SMLoc::getFromPointer(S.getPointer() + Identifier.size());
+  RISCVMCExpr::Specifier Kind = RISCVMCExpr::VK_QC_E_JUMP_PLT;
 
   MCSymbol *Sym = getContext().getOrCreateSymbol(Identifier);
   Res = MCSymbolRefExpr::create(Sym, getContext());

--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -2154,19 +2154,23 @@ ParseStatus RISCVAsmParser::parsePseudoQCJumpSymbol(OperandVector &Operands) {
 
   if (getLexer().getKind() != AsmToken::Identifier)
     return ParseStatus::NoMatch;
+
   std::string Identifier(getTok().getIdentifier());
+  SMLoc E = SMLoc::getFromPointer(S.getPointer() + Identifier.size());
 
   if (getLexer().peekTok().is(AsmToken::At)) {
     Lex();
     Lex();
+    SMLoc PLTLoc = getLoc();
     StringRef PLT;
     if (getParser().parseIdentifier(PLT) || PLT != "plt")
-      return ParseStatus::Failure;
+      return Error(PLTLoc,
+                   "'@plt' is the only valid operand for this instruction");
+    E = SMLoc::getFromPointer(S.getPointer() + /*@plt*/ 4);
   } else {
     Lex();
   }
 
-  SMLoc E = SMLoc::getFromPointer(S.getPointer() + Identifier.size());
   RISCVMCExpr::Specifier Kind = RISCVMCExpr::VK_QC_E_JUMP_PLT;
 
   MCSymbol *Sym = getContext().getOrCreateSymbol(Identifier);

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFObjectWriter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVELFObjectWriter.cpp
@@ -119,6 +119,8 @@ unsigned RISCVELFObjectWriter::getRelocType(MCContext &Ctx,
       return ELF::R_RISCV_CALL_PLT;
     case RISCV::fixup_riscv_qc_e_branch:
       return ELF::R_RISCV_QC_E_BRANCH;
+    case RISCV::fixup_riscv_qc_e_jump_plt:
+      return ELF::R_RISCV_QC_E_JUMP_PLT;
     }
   }
 

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVFixupKinds.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVFixupKinds.h
@@ -84,6 +84,8 @@ enum Fixups {
   fixup_riscv_qc_e_32,
   // 20-bit fixup for symbol references in the 32-bit qc.li instruction
   fixup_riscv_qc_abs20_u,
+  // 32-bit fixup for symbol references in the 48-bit qc.j/qc.jal instructions
+  fixup_riscv_qc_e_jump_plt,
 
   // Used as a sentinel, must be the last
   fixup_riscv_invalid,

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCCodeEmitter.cpp
@@ -56,6 +56,10 @@ public:
                           SmallVectorImpl<MCFixup> &Fixups,
                           const MCSubtargetInfo &STI) const;
 
+  void expandQCJump(const MCInst &MI, SmallVectorImpl<char> &CB,
+                    SmallVectorImpl<MCFixup> &Fixups,
+                    const MCSubtargetInfo &STI) const;
+
   void expandTLSDESCCall(const MCInst &MI, SmallVectorImpl<char> &CB,
                          SmallVectorImpl<MCFixup> &Fixups,
                          const MCSubtargetInfo &STI) const;
@@ -167,6 +171,26 @@ void RISCVMCCodeEmitter::expandFunctionCall(const MCInst &MI,
     TmpInst = MCInstBuilder(RISCV::JALR).addReg(Ra).addReg(Ra).addImm(0);
   Binary = getBinaryCodeForInstr(TmpInst, Fixups, STI);
   support::endian::write(CB, Binary, llvm::endianness::little);
+}
+
+void RISCVMCCodeEmitter::expandQCJump(const MCInst &MI,
+                                      SmallVectorImpl<char> &CB,
+                                      SmallVectorImpl<MCFixup> &Fixups,
+                                      const MCSubtargetInfo &STI) const {
+  MCOperand Func = MI.getOperand(0);
+  assert(Func.isExpr() && "Expected expression");
+
+  auto Opcode =
+      (MI.getOpcode() == RISCV::PseudoQC_E_J) ? RISCV::QC_E_J : RISCV::QC_E_JAL;
+  MCInst Jump = MCInstBuilder(Opcode).addExpr(Func.getExpr());
+
+  uint64_t Bits = getBinaryCodeForInstr(Jump, Fixups, STI) & 0xffff'ffff'ffffu;
+  SmallVector<char, 8> Encoding;
+  support::endian::write(Encoding, Bits, llvm::endianness::little);
+  assert(Encoding[6] == 0 && Encoding[7] == 0 &&
+         "Unexpected encoding for 48-bit instruction");
+  Encoding.truncate(6);
+  CB.append(Encoding);
 }
 
 void RISCVMCCodeEmitter::expandTLSDESCCall(const MCInst &MI,
@@ -440,6 +464,11 @@ void RISCVMCCodeEmitter::encodeInstruction(const MCInst &MI,
     expandTLSDESCCall(MI, CB, Fixups, STI);
     MCNumEmitted += 1;
     return;
+  case RISCV::PseudoQC_E_J:
+  case RISCV::PseudoQC_E_JAL:
+    expandQCJump(MI, CB, Fixups, STI);
+    MCNumEmitted += 1;
+    return;
   }
 
   switch (Size) {
@@ -655,6 +684,9 @@ uint64_t RISCVMCCodeEmitter::getImmOpValue(const MCInst &MI, unsigned OpNo,
       break;
     case RISCVMCExpr::VK_QC_ABS20:
       FixupKind = RISCV::fixup_riscv_qc_abs20_u;
+      break;
+    case RISCVMCExpr::VK_QC_E_JUMP_PLT:
+      FixupKind = RISCV::fixup_riscv_qc_e_jump_plt;
       break;
     }
   } else if (Kind == MCExpr::SymbolRef || Kind == MCExpr::Binary) {

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCExpr.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCExpr.cpp
@@ -34,7 +34,8 @@ const RISCVMCExpr *RISCVMCExpr::create(const MCExpr *Expr, Specifier S,
 
 void RISCVMCExpr::printImpl(raw_ostream &OS, const MCAsmInfo *MAI) const {
   Specifier S = getSpecifier();
-  bool HasVariant = ((S != VK_None) && (S != VK_CALL) && (S != VK_CALL_PLT));
+  bool HasVariant = ((S != VK_None) && (S != VK_CALL) && (S != VK_CALL_PLT) &&
+                     (S != VK_QC_E_JUMP_PLT));
 
   if (HasVariant)
     OS << '%' << getSpecifierName(S) << '(';
@@ -167,6 +168,8 @@ StringRef RISCVMCExpr::getSpecifierName(Specifier S) {
     return "pltpcrel";
   case VK_QC_ABS20:
     return "qc.abs20";
+  case VK_QC_E_JUMP_PLT:
+    return "qc_e_jump_plt";
   }
   llvm_unreachable("Invalid ELF symbol kind");
 }

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCExpr.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCExpr.h
@@ -44,6 +44,7 @@ public:
     VK_TLSDESC_ADD_LO,
     VK_TLSDESC_CALL,
     VK_QC_ABS20,
+    VK_QC_E_JUMP_PLT
   };
 
 private:

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
@@ -153,6 +153,18 @@ def simm32_lsb0 : Operand<OtherVT> {
   let OperandType = "OPERAND_PCREL";
 }
 
+def PseudoQCJumpSymbol : AsmOperandClass {
+  let Name = "PseudoQCJumpSymbol";
+  let RenderMethod = "addImmOperands";
+  let DiagnosticType = "InvalidPseudoQCJumpSymbol";
+  let DiagnosticString = "operand must be a valid jump target";
+  let ParserMethod = "parsePseudoQCJumpSymbol";
+}
+
+def pseudo_qc_jump_symbol : Operand<XLenVT> {
+  let ParserMatchClass = PseudoQCJumpSymbol;
+}
+
 //===----------------------------------------------------------------------===//
 // Instruction Formats
 //===----------------------------------------------------------------------===//
@@ -708,7 +720,7 @@ class QCIRVInstEI<bits<3> funct3, bits<2> funct2, string opcodestr>
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class QCIRVInst48EJ<bits<2> func2, string opcodestr>
     : RVInst48<(outs), (ins simm32_lsb0:$imm31),
-               opcodestr, "$imm31", [], InstFormatOther> {
+               opcodestr, "$imm31", [], InstFormatQC_EJ> {
   bits<31> imm31;
 
   let Inst{47-32} = imm31{30-15};
@@ -1218,6 +1230,16 @@ def PseudoQC_E_SB : PseudoStore<"qc.e.sb">;
 def PseudoQC_E_SH : PseudoStore<"qc.e.sh">;
 def PseudoQC_E_SW : PseudoStore<"qc.e.sw">;
 } // Predicates = [HasVendorXqcilo, IsRV32]
+
+let isCall = 0, isBarrier = 1, isTerminator = 1,
+    isCodeGenOnly = 0, hasSideEffects = 0, mayStore = 0, mayLoad = 0 in
+def PseudoQC_E_J : Pseudo<(outs), (ins pseudo_qc_jump_symbol:$func), [],
+                          "qc.e.j", "$func">;
+
+let isCall = 1, Defs = [X1], isCodeGenOnly = 0, hasSideEffects = 0,
+    mayStore = 0, mayLoad = 0 in
+def PseudoQC_E_JAL: Pseudo<(outs), (ins pseudo_qc_jump_symbol:$func), [],
+                           "qc.e.jal", "$func">;
 
 //===----------------------------------------------------------------------===//
 // Code Gen Patterns

--- a/llvm/test/MC/RISCV/xqcilb-invalid.s
+++ b/llvm/test/MC/RISCV/xqcilb-invalid.s
@@ -22,3 +22,6 @@ qc.e.jal 2147483649
 
 # CHECK-MINUS: :[[@LINE+1]]:1: error: instruction requires the following: 'Xqcilb' (Qualcomm uC Long Branch Extension)
 qc.e.jal 2147483640
+
+# CHECK: :[[@LINE+1]]:12: error: '@plt' is the only valid operand for this instruction
+qc.e.j foo@rlt

--- a/llvm/test/MC/RISCV/xqcilb-relocations.s
+++ b/llvm/test/MC/RISCV/xqcilb-relocations.s
@@ -1,0 +1,59 @@
+# RUN: llvm-mc -triple riscv32 -mattr=+experimental-xqcilb %s -show-encoding \
+# RUN:     | FileCheck -check-prefix=INSTR -check-prefix=FIXUP %s
+# RUN: llvm-mc -filetype=obj -triple riscv32 -mattr=+experimental-xqcilb %s -o %t.o
+# RUN: llvm-readobj -r %t.o | FileCheck -check-prefix=RELOC %s
+
+# Check prefixes:
+# RELOC - Check the relocation in the object.
+# FIXUP - Check the fixup on the instruction.
+# INSTR - Check the instruction is handled properly by the ASMPrinter.
+
+.text
+
+qc.e.j foo
+# RELOC: R_RISCV_CUSTOM195 foo 0x0
+# INSTR: qc.e.j foo
+# FIXUP: fixup A - offset: 0, value: foo, kind: fixup_riscv_qc_e_jump_plt
+
+qc.e.j foo@plt
+# RELOC: R_RISCV_CUSTOM195 foo 0x0
+# INSTR: qc.e.j foo
+# FIXUP: fixup A - offset: 0, value: foo, kind: fixup_riscv_qc_e_jump_plt
+
+qc.e.jal foo@plt
+# RELOC: R_RISCV_CUSTOM195 foo 0x0
+# INSTR: qc.e.jal foo
+# FIXUP: fixup A - offset: 0, value: foo, kind: fixup_riscv_qc_e_jump_plt
+
+qc.e.jal foo
+# RELOC: R_RISCV_CUSTOM195 foo 0x0
+# INSTR: qc.e.jal foo
+# FIXUP: fixup A - offset: 0, value: foo, kind: fixup_riscv_qc_e_jump_plt
+
+# Check that a label in a different section is handled similar to an undefined symbol
+qc.e.j .bar
+# RELOC: R_RISCV_CUSTOM195 .bar 0x0
+# INSTR: qc.e.j .bar
+# FIXUP: fixup A - offset: 0, value: .bar, kind: fixup_riscv_qc_e_jump_plt
+
+qc.e.jal .bar
+# RELOC: R_RISCV_CUSTOM195 .bar 0x0
+# INSTR: qc.e.jal .bar
+# FIXUP: fixup A - offset: 0, value: .bar, kind: fixup_riscv_qc_e_jump_plt
+
+# Check that jumps to a defined symbol are handled correctly
+qc.e.j .L1
+# INSTR:qc.e.j .L1
+# FIXUP: fixup A - offset: 0, value: .L1, kind: fixup_riscv_qc_e_jump_plt
+
+qc.e.jal .L1
+# INSTR:qc.e.jal .L1
+# FIXUP: fixup A - offset: 0, value: .L1, kind: fixup_riscv_qc_e_jump_plt
+
+.L1:
+  ret
+
+.section .t2
+
+.bar:
+  ret


### PR DESCRIPTION
This patch adds support for parsing symbols in the Xqcilb long branch instructions. The instructions use the `R_RISCV_QC_E_JUMP_PLT` relocation and the `InstFormatQC_EJ` instruction format.

Vendor relocation support will be added in a later patch.
