### PR TITLE
[CIR][NFC] Fix an unused variable warning

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -35,7 +35,7 @@ Address CIRGenFunction::emitPointerWithAlignment(const Expr *expr) {
 
   // Casts:
   if (auto const *ce = dyn_cast<CastExpr>(expr)) {
-    if (auto const *ece = dyn_cast<ExplicitCastExpr>(ce)) {
+    if (isa<ExplicitCastExpr>(ce)) {
       cgm.errorNYI(expr->getSourceRange(),
                    "emitPointerWithAlignment: explicit cast");
       return Address::invalid();


### PR DESCRIPTION
This fixes a warning where a variable assigned in a 'if' statement wasn't referenced again.