### PR TITLE
[clang][index] Handle undefined function-like macros in single file parse mode

### DIFF
--- a/clang/test/Index/single-file-parse-undefined-function-like-macro.c
+++ b/clang/test/Index/single-file-parse-undefined-function-like-macro.c
@@ -1,0 +1,15 @@
+// RUN: split-file %s %t
+// RUN: c-index-test -single-file-parse %t/tu.c 2>&1 | FileCheck %t/tu.c
+
+//--- header.h
+#define FUNCTION_LIKE_MACRO() 1
+//--- tu.c
+#include "header.h"
+// CHECK-NOT: tu.c:[[@LINE+1]]:5: error: function-like macro 'FUNCTION_LIKE_MACRO' is not defined
+#if FUNCTION_LIKE_MACRO()
+// CHECK: tu.c:[[@LINE+1]]:5: FunctionDecl=then_fn
+int then_fn();
+#else
+// CHECK: tu.c:[[@LINE+1]]:5: FunctionDecl=else_fn
+int else_fn();
+#endif


### PR DESCRIPTION
The single file parse mode is supposed to enter both branches of an `#if` directive whenever the condition contains undefined identifiers. This patch adds support for undefined function-like macros, where we would previously emit an error that doesn't make sense from end-user perspective.

(I discovered this while working on a very similar feature that parses single module only and doesn't enter either `#if` branch when the condition contains undefined identifiers.)