### PR TITLE
[flang] Don't insert spaces in -E output after line continuation

### DIFF
--- a/flang/test/Preprocessing/bug134986.F90
+++ b/flang/test/Preprocessing/bug134986.F90
@@ -1,0 +1,5 @@
+! RUN: %flang -E %s 2>&1 | FileCheck %s
+! CHECK: print *, "HELLO "//" WORLD"
+print *, "HELLO "/&
+                       &/" WORLD"
+end


### PR DESCRIPTION
See test case.  When Fortran line continuation has been used, don't insert spaces in -E formatted output to put things into the right column, as this can break up a token.

Fixes https://github.com/llvm/llvm-project/issues/134986.