### PR TITLE
[NVPTX] Cleanup ISel for selp.*

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
+++ b/llvm/lib/Target/NVPTX/NVPTXInstrInfo.td
@@ -725,62 +725,40 @@ def : Pat<(v2f16 (build_vector (f16 (fpround_oneuse f32:$lo)),
 // selp instructions that don't have any pattern matches; we explicitly use
 // them within this file.
 let hasSideEffects = false in {
-  multiclass SELP<string TypeStr, RegisterClass RC, Operand ImmCls> {
-    def rr : NVPTXInst<(outs RC:$dst),
-                       (ins RC:$a, RC:$b, Int1Regs:$p),
-                       !strconcat("selp.", TypeStr, " \t$dst, $a, $b, $p;"), []>;
-    def ri : NVPTXInst<(outs RC:$dst),
-                       (ins RC:$a, ImmCls:$b, Int1Regs:$p),
-                       !strconcat("selp.", TypeStr, " \t$dst, $a, $b, $p;"), []>;
-    def ir : NVPTXInst<(outs RC:$dst),
-                       (ins ImmCls:$a, RC:$b, Int1Regs:$p),
-                       !strconcat("selp.", TypeStr, " \t$dst, $a, $b, $p;"), []>;
-    def ii : NVPTXInst<(outs RC:$dst),
-                       (ins ImmCls:$a, ImmCls:$b, Int1Regs:$p),
-                       !strconcat("selp.", TypeStr, " \t$dst, $a, $b, $p;"), []>;
-  }
-
-  multiclass SELP_PATTERN<string TypeStr, ValueType T, RegisterClass RC,
-                          Operand ImmCls, SDNode ImmNode> {
+  multiclass SELP_PATTERN<string TypeStr, RegTyInfo t> {
+    defvar asm_str = "selp." # TypeStr # " \t$dst, $a, $b, $p;";
     def rr :
-      NVPTXInst<(outs RC:$dst),
-                (ins RC:$a, RC:$b, Int1Regs:$p),
-                !strconcat("selp.", TypeStr, " \t$dst, $a, $b, $p;"),
-                [(set T:$dst, (select i1:$p, T:$a, T:$b))]>;
+      NVPTXInst<(outs t.RC:$dst),
+                (ins t.RC:$a, t.RC:$b, Int1Regs:$p),
+                asm_str,
+                [(set t.Ty:$dst, (select i1:$p, t.Ty:$a, t.Ty:$b))]>;
     def ri :
-      NVPTXInst<(outs RC:$dst),
-                (ins RC:$a, ImmCls:$b, Int1Regs:$p),
-                !strconcat("selp.", TypeStr, " \t$dst, $a, $b, $p;"),
-                [(set T:$dst, (select i1:$p, T:$a, (T ImmNode:$b)))]>;
+      NVPTXInst<(outs t.RC:$dst),
+                (ins t.RC:$a, t.Imm:$b, Int1Regs:$p),
+                asm_str,
+                [(set t.Ty:$dst, (select i1:$p, t.Ty:$a, t.ImmNode:$b))]>;
     def ir :
-      NVPTXInst<(outs RC:$dst),
-                (ins ImmCls:$a, RC:$b, Int1Regs:$p),
-                !strconcat("selp.", TypeStr, " \t$dst, $a, $b, $p;"),
-                [(set T:$dst, (select i1:$p, ImmNode:$a, T:$b))]>;
+      NVPTXInst<(outs t.RC:$dst),
+                (ins t.Imm:$a, t.RC:$b, Int1Regs:$p),
+                asm_str,
+                [(set t.Ty:$dst, (select i1:$p, t.ImmNode:$a, t.Ty:$b))]>;
     def ii :
-      NVPTXInst<(outs RC:$dst),
-                (ins ImmCls:$a, ImmCls:$b, Int1Regs:$p),
-                !strconcat("selp.", TypeStr, " \t$dst, $a, $b, $p;"),
-                [(set T:$dst, (select i1:$p, ImmNode:$a, ImmNode:$b))]>;
+      NVPTXInst<(outs t.RC:$dst),
+                (ins t.Imm:$a, t.Imm:$b, Int1Regs:$p),
+                asm_str,
+                [(set t.Ty:$dst, (select i1:$p, t.ImmNode:$a, t.ImmNode:$b))]>;
   }
 }
 
 // Don't pattern match on selp.{s,u}{16,32,64} -- selp.b{16,32,64} is just as
 // good.
-defm SELP_b16 : SELP_PATTERN<"b16", i16, Int16Regs, i16imm, imm>;
-defm SELP_s16 : SELP<"s16", Int16Regs, i16imm>;
-defm SELP_u16 : SELP<"u16", Int16Regs, i16imm>;
-defm SELP_b32 : SELP_PATTERN<"b32", i32, Int32Regs, i32imm, imm>;
-defm SELP_s32 : SELP<"s32", Int32Regs, i32imm>;
-defm SELP_u32 : SELP<"u32", Int32Regs, i32imm>;
-defm SELP_b64 : SELP_PATTERN<"b64", i64, Int64Regs, i64imm, imm>;
-defm SELP_s64 : SELP<"s64", Int64Regs, i64imm>;
-defm SELP_u64 : SELP<"u64", Int64Regs, i64imm>;
-defm SELP_f16 : SELP_PATTERN<"b16", f16, Int16Regs, f16imm, fpimm>;
-defm SELP_bf16 : SELP_PATTERN<"b16", bf16, Int16Regs, bf16imm, fpimm>;
-
-defm SELP_f32 : SELP_PATTERN<"f32", f32, Float32Regs, f32imm, fpimm>;
-defm SELP_f64 : SELP_PATTERN<"f64", f64, Float64Regs, f64imm, fpimm>;
+defm SELP_b16  : SELP_PATTERN<"b16", I16RT>;
+defm SELP_b32  : SELP_PATTERN<"b32", I32RT>;
+defm SELP_b64  : SELP_PATTERN<"b64", I64RT>;
+defm SELP_f16  : SELP_PATTERN<"b16", F16RT>;
+defm SELP_bf16 : SELP_PATTERN<"b16", BF16RT>;
+defm SELP_f32  : SELP_PATTERN<"f32", F32RT>;
+defm SELP_f64  : SELP_PATTERN<"f64", F64RT>;
 
 // This does not work as tablegen fails to infer the type of 'imm'.
 // def v2f16imm : Operand<v2f16>;
@@ -2023,9 +2001,9 @@ def: Pat<(setne (i16 (and (trunc (bfe Int32Regs:$a, imm:$oa, 8)), 255)),
 
 // i1 compare -> i32
 def : Pat<(i32 (setne i1:$a, i1:$b)),
-          (SELP_u32ii -1, 0, (XORb1rr $a, $b))>;
+          (SELP_b32ii -1, 0, (XORb1rr $a, $b))>;
 def : Pat<(i32 (setne i1:$a, i1:$b)),
-          (SELP_u32ii 0, -1, (XORb1rr $a, $b))>;
+          (SELP_b32ii 0, -1, (XORb1rr $a, $b))>;
 
 
 
@@ -2690,7 +2668,7 @@ foreach ta = [v2f16, v2bf16, v2i16, v4i8, i32] in {
 
 // sint -> f16
 def : Pat<(f16 (sint_to_fp i1:$a)),
-          (CVT_f16_s32 (SELP_s32ii -1, 0, $a), CvtRN)>;
+          (CVT_f16_s32 (SELP_b32ii -1, 0, $a), CvtRN)>;
 def : Pat<(f16 (sint_to_fp Int16Regs:$a)),
           (CVT_f16_s16 $a, CvtRN)>;
 def : Pat<(f16 (sint_to_fp i32:$a)),
@@ -2700,7 +2678,7 @@ def : Pat<(f16 (sint_to_fp i64:$a)),
 
 // uint -> f16
 def : Pat<(f16 (uint_to_fp i1:$a)),
-          (CVT_f16_u32 (SELP_u32ii 1, 0, $a), CvtRN)>;
+          (CVT_f16_u32 (SELP_b32ii 1, 0, $a), CvtRN)>;
 def : Pat<(f16 (uint_to_fp Int16Regs:$a)),
           (CVT_f16_u16 $a, CvtRN)>;
 def : Pat<(f16 (uint_to_fp i32:$a)),
@@ -2710,7 +2688,7 @@ def : Pat<(f16 (uint_to_fp i64:$a)),
 
 // sint -> bf16
 def : Pat<(bf16 (sint_to_fp i1:$a)),
-          (CVT_bf16_s32 (SELP_u32ii 1, 0, $a), CvtRN)>, Requires<[hasPTX<78>, hasSM<90>]>;
+          (CVT_bf16_s32 (SELP_b32ii 1, 0, $a), CvtRN)>, Requires<[hasPTX<78>, hasSM<90>]>;
 def : Pat<(bf16 (sint_to_fp i16:$a)),
           (CVT_bf16_s16 $a, CvtRN)>, Requires<[hasPTX<78>, hasSM<90>]>;
 def : Pat<(bf16 (sint_to_fp i32:$a)),
@@ -2720,7 +2698,7 @@ def : Pat<(bf16 (sint_to_fp i64:$a)),
 
 // uint -> bf16
 def : Pat<(bf16 (uint_to_fp i1:$a)),
-          (CVT_bf16_u32 (SELP_u32ii 1, 0, $a), CvtRN)>, Requires<[hasPTX<78>, hasSM<90>]>;
+          (CVT_bf16_u32 (SELP_b32ii 1, 0, $a), CvtRN)>, Requires<[hasPTX<78>, hasSM<90>]>;
 def : Pat<(bf16 (uint_to_fp i16:$a)),
           (CVT_bf16_u16 $a, CvtRN)>, Requires<[hasPTX<78>, hasSM<90>]>;
 def : Pat<(bf16 (uint_to_fp i32:$a)),
@@ -2730,7 +2708,7 @@ def : Pat<(bf16 (uint_to_fp i64:$a)),
 
 // sint -> f32
 def : Pat<(f32 (sint_to_fp i1:$a)),
-          (CVT_f32_s32 (SELP_s32ii -1, 0, $a), CvtRN)>;
+          (CVT_f32_s32 (SELP_b32ii -1, 0, $a), CvtRN)>;
 def : Pat<(f32 (sint_to_fp i16:$a)),
           (CVT_f32_s16 $a, CvtRN)>;
 def : Pat<(f32 (sint_to_fp i32:$a)),
@@ -2740,7 +2718,7 @@ def : Pat<(f32 (sint_to_fp i64:$a)),
 
 // uint -> f32
 def : Pat<(f32 (uint_to_fp i1:$a)),
-          (CVT_f32_u32 (SELP_u32ii 1, 0, $a), CvtRN)>;
+          (CVT_f32_u32 (SELP_b32ii 1, 0, $a), CvtRN)>;
 def : Pat<(f32 (uint_to_fp i16:$a)),
           (CVT_f32_u16 $a, CvtRN)>;
 def : Pat<(f32 (uint_to_fp i32:$a)),
@@ -2750,7 +2728,7 @@ def : Pat<(f32 (uint_to_fp i64:$a)),
 
 // sint -> f64
 def : Pat<(f64 (sint_to_fp i1:$a)),
-          (CVT_f64_s32 (SELP_s32ii -1, 0, $a), CvtRN)>;
+          (CVT_f64_s32 (SELP_b32ii -1, 0, $a), CvtRN)>;
 def : Pat<(f64 (sint_to_fp i16:$a)),
           (CVT_f64_s16 $a, CvtRN)>;
 def : Pat<(f64 (sint_to_fp i32:$a)),
@@ -2760,7 +2738,7 @@ def : Pat<(f64 (sint_to_fp i64:$a)),
 
 // uint -> f64
 def : Pat<(f64 (uint_to_fp i1:$a)),
-          (CVT_f64_u32 (SELP_u32ii 1, 0, $a), CvtRN)>;
+          (CVT_f64_u32 (SELP_b32ii 1, 0, $a), CvtRN)>;
 def : Pat<(f64 (uint_to_fp i16:$a)),
           (CVT_f64_u16 $a, CvtRN)>;
 def : Pat<(f64 (uint_to_fp i32:$a)),
@@ -2862,27 +2840,27 @@ def : Pat<(i64 (fp_to_uint f64:$a)),
 
 // sext i1
 def : Pat<(i16 (sext i1:$a)),
-          (SELP_s16ii -1, 0, $a)>;
+          (SELP_b16ii -1, 0, $a)>;
 def : Pat<(i32 (sext i1:$a)),
-          (SELP_s32ii -1, 0, $a)>;
+          (SELP_b32ii -1, 0, $a)>;
 def : Pat<(i64 (sext i1:$a)),
-          (SELP_s64ii -1, 0, $a)>;
+          (SELP_b64ii -1, 0, $a)>;
 
 // zext i1
 def : Pat<(i16 (zext i1:$a)),
-          (SELP_u16ii 1, 0, $a)>;
+          (SELP_b16ii 1, 0, $a)>;
 def : Pat<(i32 (zext i1:$a)),
-          (SELP_u32ii 1, 0, $a)>;
+          (SELP_b32ii 1, 0, $a)>;
 def : Pat<(i64 (zext i1:$a)),
-          (SELP_u64ii 1, 0, $a)>;
+          (SELP_b64ii 1, 0, $a)>;
 
 // anyext i1
 def : Pat<(i16 (anyext i1:$a)),
-          (SELP_u16ii -1, 0, $a)>;
+          (SELP_b16ii -1, 0, $a)>;
 def : Pat<(i32 (anyext i1:$a)),
-          (SELP_u32ii -1, 0, $a)>;
+          (SELP_b32ii -1, 0, $a)>;
 def : Pat<(i64 (anyext i1:$a)),
-          (SELP_u64ii -1, 0, $a)>;
+          (SELP_b64ii -1, 0, $a)>;
 
 // sext i16
 def : Pat<(i32 (sext i16:$a)),

--- a/llvm/test/CodeGen/NVPTX/add-sub-128bit.ll
+++ b/llvm/test/CodeGen/NVPTX/add-sub-128bit.ll
@@ -9,7 +9,7 @@ define i128 @test_add(i128 %a, i128 %b) {
 ; NOCARRY:        add.s64
 ; NOCARRY-NEXT:   add.s64
 ; NOCARRY-NEXT:   setp.lt.u64
-; NOCARRY-NEXT:   selp.u64
+; NOCARRY-NEXT:   selp.b64
 ; NOCARRY-NEXT:   add.s64
 
 ; CARRY:          add.cc.s64
@@ -23,7 +23,7 @@ define i128 @test_add(i128 %a, i128 %b) {
 define i128 @test_sub(i128 %a, i128 %b) {
 ; NOCARRY:        sub.s64
 ; NOCARRY-NEXT:   setp.lt.u64
-; NOCARRY-NEXT:   selp.s64
+; NOCARRY-NEXT:   selp.b64
 ; NOCARRY-NEXT:   add.s64
 ; NOCARRY-NEXT:   sub.s64
 

--- a/llvm/test/CodeGen/NVPTX/bf16-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/bf16-instructions.ll
@@ -1124,7 +1124,7 @@ define bfloat @test_uitofp_i1(i1 %a) {
 ; SM70-NEXT:    ld.param.u8 %rs1, [test_uitofp_i1_param_0];
 ; SM70-NEXT:    and.b16 %rs2, %rs1, 1;
 ; SM70-NEXT:    setp.eq.b16 %p1, %rs2, 1;
-; SM70-NEXT:    selp.u32 %r1, 1, 0, %p1;
+; SM70-NEXT:    selp.b32 %r1, 1, 0, %p1;
 ; SM70-NEXT:    cvt.rn.f32.u32 %f1, %r1;
 ; SM70-NEXT:    mov.b32 %r2, %f1;
 ; SM70-NEXT:    bfe.u32 %r3, %r2, 16, 1;
@@ -1148,7 +1148,7 @@ define bfloat @test_uitofp_i1(i1 %a) {
 ; SM80-NEXT:    ld.param.u8 %rs1, [test_uitofp_i1_param_0];
 ; SM80-NEXT:    and.b16 %rs2, %rs1, 1;
 ; SM80-NEXT:    setp.eq.b16 %p1, %rs2, 1;
-; SM80-NEXT:    selp.u32 %r1, 1, 0, %p1;
+; SM80-NEXT:    selp.b32 %r1, 1, 0, %p1;
 ; SM80-NEXT:    cvt.rn.f32.u32 %f1, %r1;
 ; SM80-NEXT:    cvt.rn.bf16.f32 %rs3, %f1;
 ; SM80-NEXT:    st.param.b16 [func_retval0], %rs3;
@@ -1165,7 +1165,7 @@ define bfloat @test_uitofp_i1(i1 %a) {
 ; SM80-FTZ-NEXT:    ld.param.u8 %rs1, [test_uitofp_i1_param_0];
 ; SM80-FTZ-NEXT:    and.b16 %rs2, %rs1, 1;
 ; SM80-FTZ-NEXT:    setp.eq.b16 %p1, %rs2, 1;
-; SM80-FTZ-NEXT:    selp.u32 %r1, 1, 0, %p1;
+; SM80-FTZ-NEXT:    selp.b32 %r1, 1, 0, %p1;
 ; SM80-FTZ-NEXT:    cvt.rn.f32.u32 %f1, %r1;
 ; SM80-FTZ-NEXT:    cvt.rn.bf16.f32 %rs3, %f1;
 ; SM80-FTZ-NEXT:    st.param.b16 [func_retval0], %rs3;
@@ -1181,7 +1181,7 @@ define bfloat @test_uitofp_i1(i1 %a) {
 ; SM90-NEXT:    ld.param.u8 %rs1, [test_uitofp_i1_param_0];
 ; SM90-NEXT:    and.b16 %rs2, %rs1, 1;
 ; SM90-NEXT:    setp.eq.b16 %p1, %rs2, 1;
-; SM90-NEXT:    selp.u32 %r1, 1, 0, %p1;
+; SM90-NEXT:    selp.b32 %r1, 1, 0, %p1;
 ; SM90-NEXT:    cvt.rn.bf16.u32 %rs3, %r1;
 ; SM90-NEXT:    st.param.b16 [func_retval0], %rs3;
 ; SM90-NEXT:    ret;

--- a/llvm/test/CodeGen/NVPTX/compare-int.ll
+++ b/llvm/test/CodeGen/NVPTX/compare-int.ll
@@ -12,7 +12,7 @@
 
 define i64 @icmp_eq_i64(i64 %a, i64 %b) {
 ; CHECK: setp.eq.s64 %p[[P0:[0-9]+]], %rd{{[0-9]+}}, %rd{{[0-9]+}}
-; CHECK: selp.u64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp eq i64 %a, %b
   %ret = zext i1 %cmp to i64
@@ -21,7 +21,7 @@ define i64 @icmp_eq_i64(i64 %a, i64 %b) {
 
 define i64 @icmp_ne_i64(i64 %a, i64 %b) {
 ; CHECK: setp.ne.s64 %p[[P0:[0-9]+]], %rd{{[0-9]+}}, %rd{{[0-9]+}}
-; CHECK: selp.u64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp ne i64 %a, %b
   %ret = zext i1 %cmp to i64
@@ -30,7 +30,7 @@ define i64 @icmp_ne_i64(i64 %a, i64 %b) {
 
 define i64 @icmp_ugt_i64(i64 %a, i64 %b) {
 ; CHECK: setp.gt.u64 %p[[P0:[0-9]+]], %rd{{[0-9]+}}, %rd{{[0-9]+}}
-; CHECK: selp.u64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp ugt i64 %a, %b
   %ret = zext i1 %cmp to i64
@@ -39,7 +39,7 @@ define i64 @icmp_ugt_i64(i64 %a, i64 %b) {
 
 define i64 @icmp_uge_i64(i64 %a, i64 %b) {
 ; CHECK: setp.ge.u64 %p[[P0:[0-9]+]], %rd{{[0-9]+}}, %rd{{[0-9]+}}
-; CHECK: selp.u64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp uge i64 %a, %b
   %ret = zext i1 %cmp to i64
@@ -48,7 +48,7 @@ define i64 @icmp_uge_i64(i64 %a, i64 %b) {
 
 define i64 @icmp_ult_i64(i64 %a, i64 %b) {
 ; CHECK: setp.lt.u64 %p[[P0:[0-9]+]], %rd{{[0-9]+}}, %rd{{[0-9]+}}
-; CHECK: selp.u64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp ult i64 %a, %b
   %ret = zext i1 %cmp to i64
@@ -57,7 +57,7 @@ define i64 @icmp_ult_i64(i64 %a, i64 %b) {
 
 define i64 @icmp_ule_i64(i64 %a, i64 %b) {
 ; CHECK: setp.le.u64 %p[[P0:[0-9]+]], %rd{{[0-9]+}}, %rd{{[0-9]+}}
-; CHECK: selp.u64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp ule i64 %a, %b
   %ret = zext i1 %cmp to i64
@@ -66,7 +66,7 @@ define i64 @icmp_ule_i64(i64 %a, i64 %b) {
 
 define i64 @icmp_sgt_i64(i64 %a, i64 %b) {
 ; CHECK: setp.gt.s64 %p[[P0:[0-9]+]], %rd{{[0-9]+}}, %rd{{[0-9]+}}
-; CHECK: selp.u64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp sgt i64 %a, %b
   %ret = zext i1 %cmp to i64
@@ -75,7 +75,7 @@ define i64 @icmp_sgt_i64(i64 %a, i64 %b) {
 
 define i64 @icmp_sge_i64(i64 %a, i64 %b) {
 ; CHECK: setp.ge.s64 %p[[P0:[0-9]+]], %rd{{[0-9]+}}, %rd{{[0-9]+}}
-; CHECK: selp.u64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp sge i64 %a, %b
   %ret = zext i1 %cmp to i64
@@ -84,7 +84,7 @@ define i64 @icmp_sge_i64(i64 %a, i64 %b) {
 
 define i64 @icmp_slt_i64(i64 %a, i64 %b) {
 ; CHECK: setp.lt.s64 %p[[P0:[0-9]+]], %rd{{[0-9]+}}, %rd{{[0-9]+}}
-; CHECK: selp.u64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp slt i64 %a, %b
   %ret = zext i1 %cmp to i64
@@ -93,7 +93,7 @@ define i64 @icmp_slt_i64(i64 %a, i64 %b) {
 
 define i64 @icmp_sle_i64(i64 %a, i64 %b) {
 ; CHECK: setp.le.s64 %p[[P0:[0-9]+]], %rd{{[0-9]+}}, %rd{{[0-9]+}}
-; CHECK: selp.u64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b64 %rd{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp sle i64 %a, %b
   %ret = zext i1 %cmp to i64
@@ -104,7 +104,7 @@ define i64 @icmp_sle_i64(i64 %a, i64 %b) {
 
 define i32 @icmp_eq_i32(i32 %a, i32 %b) {
 ; CHECK: setp.eq.s32 %p[[P0:[0-9]+]], %r{{[0-9]+}}, %r{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp eq i32 %a, %b
   %ret = zext i1 %cmp to i32
@@ -113,7 +113,7 @@ define i32 @icmp_eq_i32(i32 %a, i32 %b) {
 
 define i32 @icmp_ne_i32(i32 %a, i32 %b) {
 ; CHECK: setp.ne.s32 %p[[P0:[0-9]+]], %r{{[0-9]+}}, %r{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp ne i32 %a, %b
   %ret = zext i1 %cmp to i32
@@ -122,7 +122,7 @@ define i32 @icmp_ne_i32(i32 %a, i32 %b) {
 
 define i32 @icmp_ugt_i32(i32 %a, i32 %b) {
 ; CHECK: setp.gt.u32 %p[[P0:[0-9]+]], %r{{[0-9]+}}, %r{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp ugt i32 %a, %b
   %ret = zext i1 %cmp to i32
@@ -131,7 +131,7 @@ define i32 @icmp_ugt_i32(i32 %a, i32 %b) {
 
 define i32 @icmp_uge_i32(i32 %a, i32 %b) {
 ; CHECK: setp.ge.u32 %p[[P0:[0-9]+]], %r{{[0-9]+}}, %r{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp uge i32 %a, %b
   %ret = zext i1 %cmp to i32
@@ -140,7 +140,7 @@ define i32 @icmp_uge_i32(i32 %a, i32 %b) {
 
 define i32 @icmp_ult_i32(i32 %a, i32 %b) {
 ; CHECK: setp.lt.u32 %p[[P0:[0-9]+]], %r{{[0-9]+}}, %r{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp ult i32 %a, %b
   %ret = zext i1 %cmp to i32
@@ -149,7 +149,7 @@ define i32 @icmp_ult_i32(i32 %a, i32 %b) {
 
 define i32 @icmp_ule_i32(i32 %a, i32 %b) {
 ; CHECK: setp.le.u32 %p[[P0:[0-9]+]], %r{{[0-9]+}}, %r{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp ule i32 %a, %b
   %ret = zext i1 %cmp to i32
@@ -158,7 +158,7 @@ define i32 @icmp_ule_i32(i32 %a, i32 %b) {
 
 define i32 @icmp_sgt_i32(i32 %a, i32 %b) {
 ; CHECK: setp.gt.s32 %p[[P0:[0-9]+]], %r{{[0-9]+}}, %r{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp sgt i32 %a, %b
   %ret = zext i1 %cmp to i32
@@ -167,7 +167,7 @@ define i32 @icmp_sgt_i32(i32 %a, i32 %b) {
 
 define i32 @icmp_sge_i32(i32 %a, i32 %b) {
 ; CHECK: setp.ge.s32 %p[[P0:[0-9]+]], %r{{[0-9]+}}, %r{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp sge i32 %a, %b
   %ret = zext i1 %cmp to i32
@@ -176,7 +176,7 @@ define i32 @icmp_sge_i32(i32 %a, i32 %b) {
 
 define i32 @icmp_slt_i32(i32 %a, i32 %b) {
 ; CHECK: setp.lt.s32 %p[[P0:[0-9]+]], %r{{[0-9]+}}, %r{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp slt i32 %a, %b
   %ret = zext i1 %cmp to i32
@@ -185,7 +185,7 @@ define i32 @icmp_slt_i32(i32 %a, i32 %b) {
 
 define i32 @icmp_sle_i32(i32 %a, i32 %b) {
 ; CHECK: setp.le.s32 %p[[P0:[0-9]+]], %r{{[0-9]+}}, %r{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp sle i32 %a, %b
   %ret = zext i1 %cmp to i32
@@ -197,7 +197,7 @@ define i32 @icmp_sle_i32(i32 %a, i32 %b) {
 
 define i16 @icmp_eq_i16(i16 %a, i16 %b) {
 ; CHECK: setp.eq.s16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp eq i16 %a, %b
   %ret = zext i1 %cmp to i16
@@ -206,7 +206,7 @@ define i16 @icmp_eq_i16(i16 %a, i16 %b) {
 
 define i16 @icmp_ne_i16(i16 %a, i16 %b) {
 ; CHECK: setp.ne.s16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp ne i16 %a, %b
   %ret = zext i1 %cmp to i16
@@ -215,7 +215,7 @@ define i16 @icmp_ne_i16(i16 %a, i16 %b) {
 
 define i16 @icmp_ugt_i16(i16 %a, i16 %b) {
 ; CHECK: setp.gt.u16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp ugt i16 %a, %b
   %ret = zext i1 %cmp to i16
@@ -224,7 +224,7 @@ define i16 @icmp_ugt_i16(i16 %a, i16 %b) {
 
 define i16 @icmp_uge_i16(i16 %a, i16 %b) {
 ; CHECK: setp.ge.u16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp uge i16 %a, %b
   %ret = zext i1 %cmp to i16
@@ -233,7 +233,7 @@ define i16 @icmp_uge_i16(i16 %a, i16 %b) {
 
 define i16 @icmp_ult_i16(i16 %a, i16 %b) {
 ; CHECK: setp.lt.u16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp ult i16 %a, %b
   %ret = zext i1 %cmp to i16
@@ -242,7 +242,7 @@ define i16 @icmp_ult_i16(i16 %a, i16 %b) {
 
 define i16 @icmp_ule_i16(i16 %a, i16 %b) {
 ; CHECK: setp.le.u16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp ule i16 %a, %b
   %ret = zext i1 %cmp to i16
@@ -251,7 +251,7 @@ define i16 @icmp_ule_i16(i16 %a, i16 %b) {
 
 define i16 @icmp_sgt_i16(i16 %a, i16 %b) {
 ; CHECK: setp.gt.s16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp sgt i16 %a, %b
   %ret = zext i1 %cmp to i16
@@ -260,7 +260,7 @@ define i16 @icmp_sgt_i16(i16 %a, i16 %b) {
 
 define i16 @icmp_sge_i16(i16 %a, i16 %b) {
 ; CHECK: setp.ge.s16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp sge i16 %a, %b
   %ret = zext i1 %cmp to i16
@@ -269,7 +269,7 @@ define i16 @icmp_sge_i16(i16 %a, i16 %b) {
 
 define i16 @icmp_slt_i16(i16 %a, i16 %b) {
 ; CHECK: setp.lt.s16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp slt i16 %a, %b
   %ret = zext i1 %cmp to i16
@@ -278,7 +278,7 @@ define i16 @icmp_slt_i16(i16 %a, i16 %b) {
 
 define i16 @icmp_sle_i16(i16 %a, i16 %b) {
 ; CHECK: setp.le.s16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp sle i16 %a, %b
   %ret = zext i1 %cmp to i16
@@ -291,7 +291,7 @@ define i16 @icmp_sle_i16(i16 %a, i16 %b) {
 define i8 @icmp_eq_i8(i8 %a, i8 %b) {
 ; Comparison happens in 16-bit
 ; CHECK: setp.eq.s16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp eq i8 %a, %b
   %ret = zext i1 %cmp to i8
@@ -301,7 +301,7 @@ define i8 @icmp_eq_i8(i8 %a, i8 %b) {
 define i8 @icmp_ne_i8(i8 %a, i8 %b) {
 ; Comparison happens in 16-bit
 ; CHECK: setp.ne.s16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp ne i8 %a, %b
   %ret = zext i1 %cmp to i8
@@ -311,7 +311,7 @@ define i8 @icmp_ne_i8(i8 %a, i8 %b) {
 define i8 @icmp_ugt_i8(i8 %a, i8 %b) {
 ; Comparison happens in 16-bit
 ; CHECK: setp.gt.u16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp ugt i8 %a, %b
   %ret = zext i1 %cmp to i8
@@ -321,7 +321,7 @@ define i8 @icmp_ugt_i8(i8 %a, i8 %b) {
 define i8 @icmp_uge_i8(i8 %a, i8 %b) {
 ; Comparison happens in 16-bit
 ; CHECK: setp.ge.u16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp uge i8 %a, %b
   %ret = zext i1 %cmp to i8
@@ -331,7 +331,7 @@ define i8 @icmp_uge_i8(i8 %a, i8 %b) {
 define i8 @icmp_ult_i8(i8 %a, i8 %b) {
 ; Comparison happens in 16-bit
 ; CHECK: setp.lt.u16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp ult i8 %a, %b
   %ret = zext i1 %cmp to i8
@@ -341,7 +341,7 @@ define i8 @icmp_ult_i8(i8 %a, i8 %b) {
 define i8 @icmp_ule_i8(i8 %a, i8 %b) {
 ; Comparison happens in 16-bit
 ; CHECK: setp.le.u16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp ule i8 %a, %b
   %ret = zext i1 %cmp to i8
@@ -351,7 +351,7 @@ define i8 @icmp_ule_i8(i8 %a, i8 %b) {
 define i8 @icmp_sgt_i8(i8 %a, i8 %b) {
 ; Comparison happens in 16-bit
 ; CHECK: setp.gt.s16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp sgt i8 %a, %b
   %ret = zext i1 %cmp to i8
@@ -361,7 +361,7 @@ define i8 @icmp_sgt_i8(i8 %a, i8 %b) {
 define i8 @icmp_sge_i8(i8 %a, i8 %b) {
 ; Comparison happens in 16-bit
 ; CHECK: setp.ge.s16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp sge i8 %a, %b
   %ret = zext i1 %cmp to i8
@@ -371,7 +371,7 @@ define i8 @icmp_sge_i8(i8 %a, i8 %b) {
 define i8 @icmp_slt_i8(i8 %a, i8 %b) {
 ; Comparison happens in 16-bit
 ; CHECK: setp.lt.s16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp slt i8 %a, %b
   %ret = zext i1 %cmp to i8
@@ -381,7 +381,7 @@ define i8 @icmp_slt_i8(i8 %a, i8 %b) {
 define i8 @icmp_sle_i8(i8 %a, i8 %b) {
 ; Comparison happens in 16-bit
 ; CHECK: setp.le.s16 %p[[P0:[0-9]+]], %rs{{[0-9]+}}, %rs{{[0-9]+}}
-; CHECK: selp.u32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
+; CHECK: selp.b32 %r{{[0-9]+}}, 1, 0, %p[[P0]]
 ; CHECK: ret
   %cmp = icmp sle i8 %a, %b
   %ret = zext i1 %cmp to i8

--- a/llvm/test/CodeGen/NVPTX/elect.ll
+++ b/llvm/test/CodeGen/NVPTX/elect.ll
@@ -17,7 +17,7 @@ define {i32, i1} @elect_sync(i32 %mask) {
 ; CHECK-NEXT:    ld.param.u32 %r1, [elect_sync_param_0];
 ; CHECK-NEXT:    elect.sync %r2|%p1, %r1;
 ; CHECK-NEXT:    st.param.b32 [func_retval0], %r2;
-; CHECK-NEXT:    selp.u16 %rs1, -1, 0, %p1;
+; CHECK-NEXT:    selp.b16 %rs1, -1, 0, %p1;
 ; CHECK-NEXT:    st.param.b8 [func_retval0+4], %rs1;
 ; CHECK-NEXT:    ret;
   %val = call {i32, i1} @llvm.nvvm.elect.sync(i32 %mask)
@@ -34,7 +34,7 @@ define {i32, i1} @elect_sync_imm() {
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    elect.sync %r1|%p1, -1;
 ; CHECK-NEXT:    st.param.b32 [func_retval0], %r1;
-; CHECK-NEXT:    selp.u16 %rs1, -1, 0, %p1;
+; CHECK-NEXT:    selp.b16 %rs1, -1, 0, %p1;
 ; CHECK-NEXT:    st.param.b8 [func_retval0+4], %rs1;
 ; CHECK-NEXT:    ret;
   %val = call {i32, i1} @llvm.nvvm.elect.sync(i32 u0xffffffff)
@@ -55,7 +55,7 @@ define {i32, i1} @elect_sync_twice(i32 %mask) {
 ; CHECK-NEXT:    elect.sync %r2|%p1, %r1;
 ; CHECK-NEXT:    elect.sync %r3|%p2, %r1;
 ; CHECK-NEXT:    st.param.b32 [func_retval0], %r2;
-; CHECK-NEXT:    selp.u16 %rs1, -1, 0, %p1;
+; CHECK-NEXT:    selp.b16 %rs1, -1, 0, %p1;
 ; CHECK-NEXT:    st.param.b8 [func_retval0+4], %rs1;
 ; CHECK-NEXT:    ret;
   %val = call {i32, i1} @llvm.nvvm.elect.sync(i32 %mask)

--- a/llvm/test/CodeGen/NVPTX/extractelement.ll
+++ b/llvm/test/CodeGen/NVPTX/extractelement.ll
@@ -41,7 +41,7 @@ define i1  @test_v2i8_load(ptr %a) {
 ; CHECK-NEXT:    or.b16 %rs5, %rs1, %rs2;
 ; CHECK-NEXT:    and.b16 %rs6, %rs5, 255;
 ; CHECK-NEXT:    setp.eq.s16 %p1, %rs6, 0;
-; CHECK-NEXT:    selp.u32 %r1, 1, 0, %p1;
+; CHECK-NEXT:    selp.b32 %r1, 1, 0, %p1;
 ; CHECK-NEXT:    st.param.b32 [func_retval0], %r1;
 ; CHECK-NEXT:    ret;
   %v = load <2 x i8>, ptr %a, align 4

--- a/llvm/test/CodeGen/NVPTX/f16-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/f16-instructions.ll
@@ -399,7 +399,7 @@ define half @test_select_cc_f16_f32(half %a, half %b, float %c, float %d) #0 {
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[AF:%f[0-9]+]], [[A]];
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[BF:%f[0-9]+]], [[B]];
 ; CHECK-NOF16: setp.neu.f32   [[PRED:%p[0-9]+]], [[AF]], [[BF]]
-; CHECK-NEXT: selp.u32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
+; CHECK-NEXT: selp.b32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
 ; CHECK-NEXT: st.param.b32    [func_retval0], [[R]];
 ; CHECK-NEXT: ret;
 define i1 @test_fcmp_une(half %a, half %b) #0 {
@@ -415,7 +415,7 @@ define i1 @test_fcmp_une(half %a, half %b) #0 {
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[AF:%f[0-9]+]], [[A]];
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[BF:%f[0-9]+]], [[B]];
 ; CHECK-NOF16: setp.equ.f32   [[PRED:%p[0-9]+]], [[AF]], [[BF]]
-; CHECK-NEXT: selp.u32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
+; CHECK-NEXT: selp.b32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
 ; CHECK-NEXT: st.param.b32    [func_retval0], [[R]];
 ; CHECK-NEXT: ret;
 define i1 @test_fcmp_ueq(half %a, half %b) #0 {
@@ -431,7 +431,7 @@ define i1 @test_fcmp_ueq(half %a, half %b) #0 {
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[AF:%f[0-9]+]], [[A]];
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[BF:%f[0-9]+]], [[B]];
 ; CHECK-NOF16: setp.gtu.f32   [[PRED:%p[0-9]+]], [[AF]], [[BF]]
-; CHECK-NEXT: selp.u32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
+; CHECK-NEXT: selp.b32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
 ; CHECK-NEXT: st.param.b32    [func_retval0], [[R]];
 ; CHECK-NEXT: ret;
 define i1 @test_fcmp_ugt(half %a, half %b) #0 {
@@ -447,7 +447,7 @@ define i1 @test_fcmp_ugt(half %a, half %b) #0 {
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[AF:%f[0-9]+]], [[A]];
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[BF:%f[0-9]+]], [[B]];
 ; CHECK-NOF16: setp.geu.f32   [[PRED:%p[0-9]+]], [[AF]], [[BF]]
-; CHECK-NEXT: selp.u32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
+; CHECK-NEXT: selp.b32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
 ; CHECK-NEXT: st.param.b32    [func_retval0], [[R]];
 ; CHECK-NEXT: ret;
 define i1 @test_fcmp_uge(half %a, half %b) #0 {
@@ -463,7 +463,7 @@ define i1 @test_fcmp_uge(half %a, half %b) #0 {
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[AF:%f[0-9]+]], [[A]];
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[BF:%f[0-9]+]], [[B]];
 ; CHECK-NOF16: setp.ltu.f32   [[PRED:%p[0-9]+]], [[AF]], [[BF]]
-; CHECK-NEXT: selp.u32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
+; CHECK-NEXT: selp.b32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
 ; CHECK-NEXT: st.param.b32    [func_retval0], [[R]];
 ; CHECK-NEXT: ret;
 define i1 @test_fcmp_ult(half %a, half %b) #0 {
@@ -479,7 +479,7 @@ define i1 @test_fcmp_ult(half %a, half %b) #0 {
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[AF:%f[0-9]+]], [[A]];
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[BF:%f[0-9]+]], [[B]];
 ; CHECK-NOF16: setp.leu.f32   [[PRED:%p[0-9]+]], [[AF]], [[BF]]
-; CHECK-NEXT: selp.u32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
+; CHECK-NEXT: selp.b32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
 ; CHECK-NEXT: st.param.b32    [func_retval0], [[R]];
 ; CHECK-NEXT: ret;
 define i1 @test_fcmp_ule(half %a, half %b) #0 {
@@ -496,7 +496,7 @@ define i1 @test_fcmp_ule(half %a, half %b) #0 {
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[AF:%f[0-9]+]], [[A]];
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[BF:%f[0-9]+]], [[B]];
 ; CHECK-NOF16: setp.nan.f32   [[PRED:%p[0-9]+]], [[AF]], [[BF]]
-; CHECK-NEXT: selp.u32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
+; CHECK-NEXT: selp.b32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
 ; CHECK-NEXT: st.param.b32    [func_retval0], [[R]];
 ; CHECK-NEXT: ret;
 define i1 @test_fcmp_uno(half %a, half %b) #0 {
@@ -512,7 +512,7 @@ define i1 @test_fcmp_uno(half %a, half %b) #0 {
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[AF:%f[0-9]+]], [[A]];
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[BF:%f[0-9]+]], [[B]];
 ; CHECK-NOF16: setp.ne.f32    [[PRED:%p[0-9]+]], [[AF]], [[BF]]
-; CHECK-NEXT: selp.u32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
+; CHECK-NEXT: selp.b32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
 ; CHECK-NEXT: st.param.b32    [func_retval0], [[R]];
 ; CHECK-NEXT: ret;
 define i1 @test_fcmp_one(half %a, half %b) #0 {
@@ -528,7 +528,7 @@ define i1 @test_fcmp_one(half %a, half %b) #0 {
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[AF:%f[0-9]+]], [[A]];
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[BF:%f[0-9]+]], [[B]];
 ; CHECK-NOF16: setp.eq.f32    [[PRED:%p[0-9]+]], [[AF]], [[BF]]
-; CHECK-NEXT: selp.u32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
+; CHECK-NEXT: selp.b32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
 ; CHECK-NEXT: st.param.b32    [func_retval0], [[R]];
 ; CHECK-NEXT: ret;
 define i1 @test_fcmp_oeq(half %a, half %b) #0 {
@@ -544,7 +544,7 @@ define i1 @test_fcmp_oeq(half %a, half %b) #0 {
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[AF:%f[0-9]+]], [[A]];
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[BF:%f[0-9]+]], [[B]];
 ; CHECK-NOF16: setp.gt.f32    [[PRED:%p[0-9]+]], [[AF]], [[BF]]
-; CHECK-NEXT: selp.u32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
+; CHECK-NEXT: selp.b32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
 ; CHECK-NEXT: st.param.b32    [func_retval0], [[R]];
 ; CHECK-NEXT: ret;
 define i1 @test_fcmp_ogt(half %a, half %b) #0 {
@@ -560,7 +560,7 @@ define i1 @test_fcmp_ogt(half %a, half %b) #0 {
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[AF:%f[0-9]+]], [[A]];
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[BF:%f[0-9]+]], [[B]];
 ; CHECK-NOF16: setp.ge.f32    [[PRED:%p[0-9]+]], [[AF]], [[BF]]
-; CHECK-NEXT: selp.u32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
+; CHECK-NEXT: selp.b32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
 ; CHECK-NEXT: st.param.b32    [func_retval0], [[R]];
 ; CHECK-NEXT: ret;
 define i1 @test_fcmp_oge(half %a, half %b) #0 {
@@ -576,7 +576,7 @@ define i1 @test_fcmp_oge(half %a, half %b) #0 {
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[AF:%f[0-9]+]], [[A]];
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[BF:%f[0-9]+]], [[B]];
 ; CHECK-NOF16: setp.lt.f32    [[PRED:%p[0-9]+]], [[AF]], [[BF]]
-; CHECK-NEXT: selp.u32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
+; CHECK-NEXT: selp.b32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
 ; CHECK-NEXT: st.param.b32    [func_retval0], [[R]];
 ; CHECK-NEXT: ret;
 define i1 @test_fcmp_olt(half %a, half %b) #0 {
@@ -592,7 +592,7 @@ define i1 @test_fcmp_olt(half %a, half %b) #0 {
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[AF:%f[0-9]+]], [[A]];
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[BF:%f[0-9]+]], [[B]];
 ; CHECK-NOF16: setp.le.f32    [[PRED:%p[0-9]+]], [[AF]], [[BF]]
-; CHECK-NEXT: selp.u32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
+; CHECK-NEXT: selp.b32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
 ; CHECK-NEXT: st.param.b32    [func_retval0], [[R]];
 ; CHECK-NEXT: ret;
 define i1 @test_fcmp_ole(half %a, half %b) #0 {
@@ -608,7 +608,7 @@ define i1 @test_fcmp_ole(half %a, half %b) #0 {
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[AF:%f[0-9]+]], [[A]];
 ; CHECK-NOF16-DAG: cvt.f32.f16 [[BF:%f[0-9]+]], [[B]];
 ; CHECK-NOF16: setp.num.f32   [[PRED:%p[0-9]+]], [[AF]], [[BF]]
-; CHECK-NEXT: selp.u32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
+; CHECK-NEXT: selp.b32        [[R:%r[0-9]+]], 1, 0, [[PRED]];
 ; CHECK-NEXT: st.param.b32    [func_retval0], [[R]];
 ; CHECK-NEXT: ret;
 define i1 @test_fcmp_ord(half %a, half %b) #0 {

--- a/llvm/test/CodeGen/NVPTX/f16x2-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/f16x2-instructions.ll
@@ -705,9 +705,9 @@ define <2 x i1> @test_fcmp_une(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-F16-NEXT:    ld.param.b32 %r2, [test_fcmp_une_param_1];
 ; CHECK-F16-NEXT:    ld.param.b32 %r1, [test_fcmp_une_param_0];
 ; CHECK-F16-NEXT:    setp.neu.f16x2 %p1|%p2, %r1, %r2;
-; CHECK-F16-NEXT:    selp.u16 %rs1, -1, 0, %p1;
+; CHECK-F16-NEXT:    selp.b16 %rs1, -1, 0, %p1;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0], %rs1;
-; CHECK-F16-NEXT:    selp.u16 %rs2, -1, 0, %p2;
+; CHECK-F16-NEXT:    selp.b16 %rs2, -1, 0, %p2;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0+1], %rs2;
 ; CHECK-F16-NEXT:    ret;
 ;
@@ -729,9 +729,9 @@ define <2 x i1> @test_fcmp_une(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f3, %rs1;
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f4, %rs3;
 ; CHECK-NOF16-NEXT:    setp.neu.f32 %p2, %f4, %f3;
-; CHECK-NOF16-NEXT:    selp.u16 %rs5, -1, 0, %p2;
+; CHECK-NOF16-NEXT:    selp.b16 %rs5, -1, 0, %p2;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0], %rs5;
-; CHECK-NOF16-NEXT:    selp.u16 %rs6, -1, 0, %p1;
+; CHECK-NOF16-NEXT:    selp.b16 %rs6, -1, 0, %p1;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0+1], %rs6;
 ; CHECK-NOF16-NEXT:    ret;
   %r = fcmp une <2 x half> %a, %b
@@ -749,9 +749,9 @@ define <2 x i1> @test_fcmp_ueq(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-F16-NEXT:    ld.param.b32 %r2, [test_fcmp_ueq_param_1];
 ; CHECK-F16-NEXT:    ld.param.b32 %r1, [test_fcmp_ueq_param_0];
 ; CHECK-F16-NEXT:    setp.equ.f16x2 %p1|%p2, %r1, %r2;
-; CHECK-F16-NEXT:    selp.u16 %rs1, -1, 0, %p1;
+; CHECK-F16-NEXT:    selp.b16 %rs1, -1, 0, %p1;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0], %rs1;
-; CHECK-F16-NEXT:    selp.u16 %rs2, -1, 0, %p2;
+; CHECK-F16-NEXT:    selp.b16 %rs2, -1, 0, %p2;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0+1], %rs2;
 ; CHECK-F16-NEXT:    ret;
 ;
@@ -773,9 +773,9 @@ define <2 x i1> @test_fcmp_ueq(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f3, %rs1;
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f4, %rs3;
 ; CHECK-NOF16-NEXT:    setp.equ.f32 %p2, %f4, %f3;
-; CHECK-NOF16-NEXT:    selp.u16 %rs5, -1, 0, %p2;
+; CHECK-NOF16-NEXT:    selp.b16 %rs5, -1, 0, %p2;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0], %rs5;
-; CHECK-NOF16-NEXT:    selp.u16 %rs6, -1, 0, %p1;
+; CHECK-NOF16-NEXT:    selp.b16 %rs6, -1, 0, %p1;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0+1], %rs6;
 ; CHECK-NOF16-NEXT:    ret;
   %r = fcmp ueq <2 x half> %a, %b
@@ -793,9 +793,9 @@ define <2 x i1> @test_fcmp_ugt(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-F16-NEXT:    ld.param.b32 %r2, [test_fcmp_ugt_param_1];
 ; CHECK-F16-NEXT:    ld.param.b32 %r1, [test_fcmp_ugt_param_0];
 ; CHECK-F16-NEXT:    setp.gtu.f16x2 %p1|%p2, %r1, %r2;
-; CHECK-F16-NEXT:    selp.u16 %rs1, -1, 0, %p1;
+; CHECK-F16-NEXT:    selp.b16 %rs1, -1, 0, %p1;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0], %rs1;
-; CHECK-F16-NEXT:    selp.u16 %rs2, -1, 0, %p2;
+; CHECK-F16-NEXT:    selp.b16 %rs2, -1, 0, %p2;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0+1], %rs2;
 ; CHECK-F16-NEXT:    ret;
 ;
@@ -817,9 +817,9 @@ define <2 x i1> @test_fcmp_ugt(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f3, %rs1;
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f4, %rs3;
 ; CHECK-NOF16-NEXT:    setp.gtu.f32 %p2, %f4, %f3;
-; CHECK-NOF16-NEXT:    selp.u16 %rs5, -1, 0, %p2;
+; CHECK-NOF16-NEXT:    selp.b16 %rs5, -1, 0, %p2;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0], %rs5;
-; CHECK-NOF16-NEXT:    selp.u16 %rs6, -1, 0, %p1;
+; CHECK-NOF16-NEXT:    selp.b16 %rs6, -1, 0, %p1;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0+1], %rs6;
 ; CHECK-NOF16-NEXT:    ret;
   %r = fcmp ugt <2 x half> %a, %b
@@ -837,9 +837,9 @@ define <2 x i1> @test_fcmp_uge(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-F16-NEXT:    ld.param.b32 %r2, [test_fcmp_uge_param_1];
 ; CHECK-F16-NEXT:    ld.param.b32 %r1, [test_fcmp_uge_param_0];
 ; CHECK-F16-NEXT:    setp.geu.f16x2 %p1|%p2, %r1, %r2;
-; CHECK-F16-NEXT:    selp.u16 %rs1, -1, 0, %p1;
+; CHECK-F16-NEXT:    selp.b16 %rs1, -1, 0, %p1;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0], %rs1;
-; CHECK-F16-NEXT:    selp.u16 %rs2, -1, 0, %p2;
+; CHECK-F16-NEXT:    selp.b16 %rs2, -1, 0, %p2;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0+1], %rs2;
 ; CHECK-F16-NEXT:    ret;
 ;
@@ -861,9 +861,9 @@ define <2 x i1> @test_fcmp_uge(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f3, %rs1;
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f4, %rs3;
 ; CHECK-NOF16-NEXT:    setp.geu.f32 %p2, %f4, %f3;
-; CHECK-NOF16-NEXT:    selp.u16 %rs5, -1, 0, %p2;
+; CHECK-NOF16-NEXT:    selp.b16 %rs5, -1, 0, %p2;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0], %rs5;
-; CHECK-NOF16-NEXT:    selp.u16 %rs6, -1, 0, %p1;
+; CHECK-NOF16-NEXT:    selp.b16 %rs6, -1, 0, %p1;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0+1], %rs6;
 ; CHECK-NOF16-NEXT:    ret;
   %r = fcmp uge <2 x half> %a, %b
@@ -881,9 +881,9 @@ define <2 x i1> @test_fcmp_ult(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-F16-NEXT:    ld.param.b32 %r2, [test_fcmp_ult_param_1];
 ; CHECK-F16-NEXT:    ld.param.b32 %r1, [test_fcmp_ult_param_0];
 ; CHECK-F16-NEXT:    setp.ltu.f16x2 %p1|%p2, %r1, %r2;
-; CHECK-F16-NEXT:    selp.u16 %rs1, -1, 0, %p1;
+; CHECK-F16-NEXT:    selp.b16 %rs1, -1, 0, %p1;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0], %rs1;
-; CHECK-F16-NEXT:    selp.u16 %rs2, -1, 0, %p2;
+; CHECK-F16-NEXT:    selp.b16 %rs2, -1, 0, %p2;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0+1], %rs2;
 ; CHECK-F16-NEXT:    ret;
 ;
@@ -905,9 +905,9 @@ define <2 x i1> @test_fcmp_ult(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f3, %rs1;
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f4, %rs3;
 ; CHECK-NOF16-NEXT:    setp.ltu.f32 %p2, %f4, %f3;
-; CHECK-NOF16-NEXT:    selp.u16 %rs5, -1, 0, %p2;
+; CHECK-NOF16-NEXT:    selp.b16 %rs5, -1, 0, %p2;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0], %rs5;
-; CHECK-NOF16-NEXT:    selp.u16 %rs6, -1, 0, %p1;
+; CHECK-NOF16-NEXT:    selp.b16 %rs6, -1, 0, %p1;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0+1], %rs6;
 ; CHECK-NOF16-NEXT:    ret;
   %r = fcmp ult <2 x half> %a, %b
@@ -925,9 +925,9 @@ define <2 x i1> @test_fcmp_ule(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-F16-NEXT:    ld.param.b32 %r2, [test_fcmp_ule_param_1];
 ; CHECK-F16-NEXT:    ld.param.b32 %r1, [test_fcmp_ule_param_0];
 ; CHECK-F16-NEXT:    setp.leu.f16x2 %p1|%p2, %r1, %r2;
-; CHECK-F16-NEXT:    selp.u16 %rs1, -1, 0, %p1;
+; CHECK-F16-NEXT:    selp.b16 %rs1, -1, 0, %p1;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0], %rs1;
-; CHECK-F16-NEXT:    selp.u16 %rs2, -1, 0, %p2;
+; CHECK-F16-NEXT:    selp.b16 %rs2, -1, 0, %p2;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0+1], %rs2;
 ; CHECK-F16-NEXT:    ret;
 ;
@@ -949,9 +949,9 @@ define <2 x i1> @test_fcmp_ule(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f3, %rs1;
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f4, %rs3;
 ; CHECK-NOF16-NEXT:    setp.leu.f32 %p2, %f4, %f3;
-; CHECK-NOF16-NEXT:    selp.u16 %rs5, -1, 0, %p2;
+; CHECK-NOF16-NEXT:    selp.b16 %rs5, -1, 0, %p2;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0], %rs5;
-; CHECK-NOF16-NEXT:    selp.u16 %rs6, -1, 0, %p1;
+; CHECK-NOF16-NEXT:    selp.b16 %rs6, -1, 0, %p1;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0+1], %rs6;
 ; CHECK-NOF16-NEXT:    ret;
   %r = fcmp ule <2 x half> %a, %b
@@ -970,9 +970,9 @@ define <2 x i1> @test_fcmp_uno(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-F16-NEXT:    ld.param.b32 %r2, [test_fcmp_uno_param_1];
 ; CHECK-F16-NEXT:    ld.param.b32 %r1, [test_fcmp_uno_param_0];
 ; CHECK-F16-NEXT:    setp.nan.f16x2 %p1|%p2, %r1, %r2;
-; CHECK-F16-NEXT:    selp.u16 %rs1, -1, 0, %p1;
+; CHECK-F16-NEXT:    selp.b16 %rs1, -1, 0, %p1;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0], %rs1;
-; CHECK-F16-NEXT:    selp.u16 %rs2, -1, 0, %p2;
+; CHECK-F16-NEXT:    selp.b16 %rs2, -1, 0, %p2;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0+1], %rs2;
 ; CHECK-F16-NEXT:    ret;
 ;
@@ -994,9 +994,9 @@ define <2 x i1> @test_fcmp_uno(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f3, %rs1;
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f4, %rs3;
 ; CHECK-NOF16-NEXT:    setp.nan.f32 %p2, %f4, %f3;
-; CHECK-NOF16-NEXT:    selp.u16 %rs5, -1, 0, %p2;
+; CHECK-NOF16-NEXT:    selp.b16 %rs5, -1, 0, %p2;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0], %rs5;
-; CHECK-NOF16-NEXT:    selp.u16 %rs6, -1, 0, %p1;
+; CHECK-NOF16-NEXT:    selp.b16 %rs6, -1, 0, %p1;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0+1], %rs6;
 ; CHECK-NOF16-NEXT:    ret;
   %r = fcmp uno <2 x half> %a, %b
@@ -1014,9 +1014,9 @@ define <2 x i1> @test_fcmp_one(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-F16-NEXT:    ld.param.b32 %r2, [test_fcmp_one_param_1];
 ; CHECK-F16-NEXT:    ld.param.b32 %r1, [test_fcmp_one_param_0];
 ; CHECK-F16-NEXT:    setp.ne.f16x2 %p1|%p2, %r1, %r2;
-; CHECK-F16-NEXT:    selp.u16 %rs1, -1, 0, %p1;
+; CHECK-F16-NEXT:    selp.b16 %rs1, -1, 0, %p1;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0], %rs1;
-; CHECK-F16-NEXT:    selp.u16 %rs2, -1, 0, %p2;
+; CHECK-F16-NEXT:    selp.b16 %rs2, -1, 0, %p2;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0+1], %rs2;
 ; CHECK-F16-NEXT:    ret;
 ;
@@ -1038,9 +1038,9 @@ define <2 x i1> @test_fcmp_one(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f3, %rs1;
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f4, %rs3;
 ; CHECK-NOF16-NEXT:    setp.ne.f32 %p2, %f4, %f3;
-; CHECK-NOF16-NEXT:    selp.u16 %rs5, -1, 0, %p2;
+; CHECK-NOF16-NEXT:    selp.b16 %rs5, -1, 0, %p2;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0], %rs5;
-; CHECK-NOF16-NEXT:    selp.u16 %rs6, -1, 0, %p1;
+; CHECK-NOF16-NEXT:    selp.b16 %rs6, -1, 0, %p1;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0+1], %rs6;
 ; CHECK-NOF16-NEXT:    ret;
   %r = fcmp one <2 x half> %a, %b
@@ -1058,9 +1058,9 @@ define <2 x i1> @test_fcmp_oeq(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-F16-NEXT:    ld.param.b32 %r2, [test_fcmp_oeq_param_1];
 ; CHECK-F16-NEXT:    ld.param.b32 %r1, [test_fcmp_oeq_param_0];
 ; CHECK-F16-NEXT:    setp.eq.f16x2 %p1|%p2, %r1, %r2;
-; CHECK-F16-NEXT:    selp.u16 %rs1, -1, 0, %p1;
+; CHECK-F16-NEXT:    selp.b16 %rs1, -1, 0, %p1;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0], %rs1;
-; CHECK-F16-NEXT:    selp.u16 %rs2, -1, 0, %p2;
+; CHECK-F16-NEXT:    selp.b16 %rs2, -1, 0, %p2;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0+1], %rs2;
 ; CHECK-F16-NEXT:    ret;
 ;
@@ -1082,9 +1082,9 @@ define <2 x i1> @test_fcmp_oeq(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f3, %rs1;
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f4, %rs3;
 ; CHECK-NOF16-NEXT:    setp.eq.f32 %p2, %f4, %f3;
-; CHECK-NOF16-NEXT:    selp.u16 %rs5, -1, 0, %p2;
+; CHECK-NOF16-NEXT:    selp.b16 %rs5, -1, 0, %p2;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0], %rs5;
-; CHECK-NOF16-NEXT:    selp.u16 %rs6, -1, 0, %p1;
+; CHECK-NOF16-NEXT:    selp.b16 %rs6, -1, 0, %p1;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0+1], %rs6;
 ; CHECK-NOF16-NEXT:    ret;
   %r = fcmp oeq <2 x half> %a, %b
@@ -1102,9 +1102,9 @@ define <2 x i1> @test_fcmp_ogt(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-F16-NEXT:    ld.param.b32 %r2, [test_fcmp_ogt_param_1];
 ; CHECK-F16-NEXT:    ld.param.b32 %r1, [test_fcmp_ogt_param_0];
 ; CHECK-F16-NEXT:    setp.gt.f16x2 %p1|%p2, %r1, %r2;
-; CHECK-F16-NEXT:    selp.u16 %rs1, -1, 0, %p1;
+; CHECK-F16-NEXT:    selp.b16 %rs1, -1, 0, %p1;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0], %rs1;
-; CHECK-F16-NEXT:    selp.u16 %rs2, -1, 0, %p2;
+; CHECK-F16-NEXT:    selp.b16 %rs2, -1, 0, %p2;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0+1], %rs2;
 ; CHECK-F16-NEXT:    ret;
 ;
@@ -1126,9 +1126,9 @@ define <2 x i1> @test_fcmp_ogt(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f3, %rs1;
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f4, %rs3;
 ; CHECK-NOF16-NEXT:    setp.gt.f32 %p2, %f4, %f3;
-; CHECK-NOF16-NEXT:    selp.u16 %rs5, -1, 0, %p2;
+; CHECK-NOF16-NEXT:    selp.b16 %rs5, -1, 0, %p2;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0], %rs5;
-; CHECK-NOF16-NEXT:    selp.u16 %rs6, -1, 0, %p1;
+; CHECK-NOF16-NEXT:    selp.b16 %rs6, -1, 0, %p1;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0+1], %rs6;
 ; CHECK-NOF16-NEXT:    ret;
   %r = fcmp ogt <2 x half> %a, %b
@@ -1146,9 +1146,9 @@ define <2 x i1> @test_fcmp_oge(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-F16-NEXT:    ld.param.b32 %r2, [test_fcmp_oge_param_1];
 ; CHECK-F16-NEXT:    ld.param.b32 %r1, [test_fcmp_oge_param_0];
 ; CHECK-F16-NEXT:    setp.ge.f16x2 %p1|%p2, %r1, %r2;
-; CHECK-F16-NEXT:    selp.u16 %rs1, -1, 0, %p1;
+; CHECK-F16-NEXT:    selp.b16 %rs1, -1, 0, %p1;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0], %rs1;
-; CHECK-F16-NEXT:    selp.u16 %rs2, -1, 0, %p2;
+; CHECK-F16-NEXT:    selp.b16 %rs2, -1, 0, %p2;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0+1], %rs2;
 ; CHECK-F16-NEXT:    ret;
 ;
@@ -1170,9 +1170,9 @@ define <2 x i1> @test_fcmp_oge(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f3, %rs1;
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f4, %rs3;
 ; CHECK-NOF16-NEXT:    setp.ge.f32 %p2, %f4, %f3;
-; CHECK-NOF16-NEXT:    selp.u16 %rs5, -1, 0, %p2;
+; CHECK-NOF16-NEXT:    selp.b16 %rs5, -1, 0, %p2;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0], %rs5;
-; CHECK-NOF16-NEXT:    selp.u16 %rs6, -1, 0, %p1;
+; CHECK-NOF16-NEXT:    selp.b16 %rs6, -1, 0, %p1;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0+1], %rs6;
 ; CHECK-NOF16-NEXT:    ret;
   %r = fcmp oge <2 x half> %a, %b
@@ -1190,9 +1190,9 @@ define <2 x i1> @test_fcmp_olt(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-F16-NEXT:    ld.param.b32 %r2, [test_fcmp_olt_param_1];
 ; CHECK-F16-NEXT:    ld.param.b32 %r1, [test_fcmp_olt_param_0];
 ; CHECK-F16-NEXT:    setp.lt.f16x2 %p1|%p2, %r1, %r2;
-; CHECK-F16-NEXT:    selp.u16 %rs1, -1, 0, %p1;
+; CHECK-F16-NEXT:    selp.b16 %rs1, -1, 0, %p1;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0], %rs1;
-; CHECK-F16-NEXT:    selp.u16 %rs2, -1, 0, %p2;
+; CHECK-F16-NEXT:    selp.b16 %rs2, -1, 0, %p2;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0+1], %rs2;
 ; CHECK-F16-NEXT:    ret;
 ;
@@ -1214,9 +1214,9 @@ define <2 x i1> @test_fcmp_olt(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f3, %rs1;
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f4, %rs3;
 ; CHECK-NOF16-NEXT:    setp.lt.f32 %p2, %f4, %f3;
-; CHECK-NOF16-NEXT:    selp.u16 %rs5, -1, 0, %p2;
+; CHECK-NOF16-NEXT:    selp.b16 %rs5, -1, 0, %p2;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0], %rs5;
-; CHECK-NOF16-NEXT:    selp.u16 %rs6, -1, 0, %p1;
+; CHECK-NOF16-NEXT:    selp.b16 %rs6, -1, 0, %p1;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0+1], %rs6;
 ; CHECK-NOF16-NEXT:    ret;
   %r = fcmp olt <2 x half> %a, %b
@@ -1234,9 +1234,9 @@ define <2 x i1> @test_fcmp_ole(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-F16-NEXT:    ld.param.b32 %r2, [test_fcmp_ole_param_1];
 ; CHECK-F16-NEXT:    ld.param.b32 %r1, [test_fcmp_ole_param_0];
 ; CHECK-F16-NEXT:    setp.le.f16x2 %p1|%p2, %r1, %r2;
-; CHECK-F16-NEXT:    selp.u16 %rs1, -1, 0, %p1;
+; CHECK-F16-NEXT:    selp.b16 %rs1, -1, 0, %p1;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0], %rs1;
-; CHECK-F16-NEXT:    selp.u16 %rs2, -1, 0, %p2;
+; CHECK-F16-NEXT:    selp.b16 %rs2, -1, 0, %p2;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0+1], %rs2;
 ; CHECK-F16-NEXT:    ret;
 ;
@@ -1258,9 +1258,9 @@ define <2 x i1> @test_fcmp_ole(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f3, %rs1;
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f4, %rs3;
 ; CHECK-NOF16-NEXT:    setp.le.f32 %p2, %f4, %f3;
-; CHECK-NOF16-NEXT:    selp.u16 %rs5, -1, 0, %p2;
+; CHECK-NOF16-NEXT:    selp.b16 %rs5, -1, 0, %p2;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0], %rs5;
-; CHECK-NOF16-NEXT:    selp.u16 %rs6, -1, 0, %p1;
+; CHECK-NOF16-NEXT:    selp.b16 %rs6, -1, 0, %p1;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0+1], %rs6;
 ; CHECK-NOF16-NEXT:    ret;
   %r = fcmp ole <2 x half> %a, %b
@@ -1278,9 +1278,9 @@ define <2 x i1> @test_fcmp_ord(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-F16-NEXT:    ld.param.b32 %r2, [test_fcmp_ord_param_1];
 ; CHECK-F16-NEXT:    ld.param.b32 %r1, [test_fcmp_ord_param_0];
 ; CHECK-F16-NEXT:    setp.num.f16x2 %p1|%p2, %r1, %r2;
-; CHECK-F16-NEXT:    selp.u16 %rs1, -1, 0, %p1;
+; CHECK-F16-NEXT:    selp.b16 %rs1, -1, 0, %p1;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0], %rs1;
-; CHECK-F16-NEXT:    selp.u16 %rs2, -1, 0, %p2;
+; CHECK-F16-NEXT:    selp.b16 %rs2, -1, 0, %p2;
 ; CHECK-F16-NEXT:    st.param.b8 [func_retval0+1], %rs2;
 ; CHECK-F16-NEXT:    ret;
 ;
@@ -1302,9 +1302,9 @@ define <2 x i1> @test_fcmp_ord(<2 x half> %a, <2 x half> %b) #0 {
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f3, %rs1;
 ; CHECK-NOF16-NEXT:    cvt.f32.f16 %f4, %rs3;
 ; CHECK-NOF16-NEXT:    setp.num.f32 %p2, %f4, %f3;
-; CHECK-NOF16-NEXT:    selp.u16 %rs5, -1, 0, %p2;
+; CHECK-NOF16-NEXT:    selp.b16 %rs5, -1, 0, %p2;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0], %rs5;
-; CHECK-NOF16-NEXT:    selp.u16 %rs6, -1, 0, %p1;
+; CHECK-NOF16-NEXT:    selp.b16 %rs6, -1, 0, %p1;
 ; CHECK-NOF16-NEXT:    st.param.b8 [func_retval0+1], %rs6;
 ; CHECK-NOF16-NEXT:    ret;
   %r = fcmp ord <2 x half> %a, %b

--- a/llvm/test/CodeGen/NVPTX/i1-int-to-fp.ll
+++ b/llvm/test/CodeGen/NVPTX/i1-int-to-fp.ll
@@ -3,7 +3,7 @@
 
 ; CHECK-LABEL: foo
 ; CHECK: setp.eq.b16 %[[P:p[0-9]+]], %{{.*}}, 1;
-; CHECK: selp.u32 %[[R:r[0-9]+]], 1, 0, %[[P]];
+; CHECK: selp.b32 %[[R:r[0-9]+]], 1, 0, %[[P]];
 ; CHECK: cvt.rn.f32.u32 %f{{.*}}, %[[R]]
 define float @foo(i1 %a) {
   %ret = uitofp i1 %a to float
@@ -12,7 +12,7 @@ define float @foo(i1 %a) {
 
 ; CHECK-LABEL: foo2
 ; CHECK: setp.eq.b16 %[[P:p[0-9]+]], %{{.*}}, 1;
-; CHECK: selp.s32 %[[R:r[0-9]+]], -1, 0, %[[P]];
+; CHECK: selp.b32 %[[R:r[0-9]+]], -1, 0, %[[P]];
 ; CHECK: cvt.rn.f32.s32 %f{{.*}}, %[[R]]
 define float @foo2(i1 %a) {
   %ret = sitofp i1 %a to float
@@ -21,7 +21,7 @@ define float @foo2(i1 %a) {
 
 ; CHECK-LABEL: foo3
 ; CHECK: setp.eq.b16 %[[P:p[0-9]+]], %{{.*}}, 1;
-; CHECK: selp.u32 %[[R:r[0-9]+]], 1, 0, %[[P]];
+; CHECK: selp.b32 %[[R:r[0-9]+]], 1, 0, %[[P]];
 ; CHECK: cvt.rn.f64.u32 %fd{{.*}}, %[[R]]
 define double @foo3(i1 %a) {
   %ret = uitofp i1 %a to double
@@ -30,7 +30,7 @@ define double @foo3(i1 %a) {
 
 ; CHECK-LABEL: foo4
 ; CHECK: setp.eq.b16 %[[P:p[0-9]+]], %{{.*}}, 1;
-; CHECK: selp.s32 %[[R:r[0-9]+]], -1, 0, %[[P]];
+; CHECK: selp.b32 %[[R:r[0-9]+]], -1, 0, %[[P]];
 ; CHECK: cvt.rn.f64.s32 %fd{{.*}}, %[[R]]
 define double @foo4(i1 %a) {
   %ret = sitofp i1 %a to double
@@ -39,7 +39,7 @@ define double @foo4(i1 %a) {
 
 ; CHECK-LABEL: foo5
 ; CHECK: setp.eq.b16 %[[P:p[0-9]+]], %{{.*}}, 1;
-; CHECK: selp.u32 %[[R:r[0-9]+]], 1, 0, %[[P]];
+; CHECK: selp.b32 %[[R:r[0-9]+]], 1, 0, %[[P]];
 ; CHECK: cvt.rn.f16.u32 %{{.*}}, %[[R]]
 define half @foo5(i1 %a) {
   %ret = uitofp i1 %a to half
@@ -48,7 +48,7 @@ define half @foo5(i1 %a) {
 
 ; CHECK-LABEL: foo6
 ; CHECK: setp.eq.b16 %[[P:p[0-9]+]], %{{.*}}, 1;
-; CHECK: selp.s32 %[[R:r[0-9]+]], -1, 0, %[[P]];
+; CHECK: selp.b32 %[[R:r[0-9]+]], -1, 0, %[[P]];
 ; CHECK: cvt.rn.f16.s32 %{{.*}}, %[[R]]
 define half @foo6(i1 %a) {
   %ret = sitofp i1 %a to half

--- a/llvm/test/CodeGen/NVPTX/i128.ll
+++ b/llvm/test/CodeGen/NVPTX/i128.ll
@@ -47,9 +47,9 @@ define i128 @srem_i128(i128 %lhs, i128 %rhs) {
 ; CHECK-NEXT:    subc.cc.s64 %rd67, %rd117, 0;
 ; CHECK-NEXT:    setp.eq.s64 %p8, %rd67, 0;
 ; CHECK-NEXT:    setp.ne.s64 %p9, %rd67, 0;
-; CHECK-NEXT:    selp.u32 %r5, -1, 0, %p9;
+; CHECK-NEXT:    selp.b32 %r5, -1, 0, %p9;
 ; CHECK-NEXT:    setp.gt.u64 %p10, %rd66, 127;
-; CHECK-NEXT:    selp.u32 %r6, -1, 0, %p10;
+; CHECK-NEXT:    selp.b32 %r6, -1, 0, %p10;
 ; CHECK-NEXT:    selp.b32 %r7, %r6, %r5, %p8;
 ; CHECK-NEXT:    and.b32 %r8, %r7, 1;
 ; CHECK-NEXT:    setp.eq.b32 %p11, %r8, 1;
@@ -180,9 +180,9 @@ define i128 @urem_i128(i128 %lhs, i128 %rhs) {
 ; CHECK-NEXT:    subc.cc.s64 %rd57, %rd103, 0;
 ; CHECK-NEXT:    setp.eq.s64 %p6, %rd57, 0;
 ; CHECK-NEXT:    setp.ne.s64 %p7, %rd57, 0;
-; CHECK-NEXT:    selp.u32 %r5, -1, 0, %p7;
+; CHECK-NEXT:    selp.b32 %r5, -1, 0, %p7;
 ; CHECK-NEXT:    setp.gt.u64 %p8, %rd56, 127;
-; CHECK-NEXT:    selp.u32 %r6, -1, 0, %p8;
+; CHECK-NEXT:    selp.b32 %r6, -1, 0, %p8;
 ; CHECK-NEXT:    selp.b32 %r7, %r6, %r5, %p6;
 ; CHECK-NEXT:    and.b32 %r8, %r7, 1;
 ; CHECK-NEXT:    setp.eq.b32 %p9, %r8, 1;
@@ -356,9 +356,9 @@ define i128 @sdiv_i128(i128 %lhs, i128 %rhs) {
 ; CHECK-NEXT:    subc.cc.s64 %rd68, %rd112, 0;
 ; CHECK-NEXT:    setp.eq.s64 %p8, %rd68, 0;
 ; CHECK-NEXT:    setp.ne.s64 %p9, %rd68, 0;
-; CHECK-NEXT:    selp.u32 %r5, -1, 0, %p9;
+; CHECK-NEXT:    selp.b32 %r5, -1, 0, %p9;
 ; CHECK-NEXT:    setp.gt.u64 %p10, %rd67, 127;
-; CHECK-NEXT:    selp.u32 %r6, -1, 0, %p10;
+; CHECK-NEXT:    selp.b32 %r6, -1, 0, %p10;
 ; CHECK-NEXT:    selp.b32 %r7, %r6, %r5, %p8;
 ; CHECK-NEXT:    and.b32 %r8, %r7, 1;
 ; CHECK-NEXT:    setp.eq.b32 %p11, %r8, 1;
@@ -483,9 +483,9 @@ define i128 @udiv_i128(i128 %lhs, i128 %rhs) {
 ; CHECK-NEXT:    subc.cc.s64 %rd57, %rd97, 0;
 ; CHECK-NEXT:    setp.eq.s64 %p6, %rd57, 0;
 ; CHECK-NEXT:    setp.ne.s64 %p7, %rd57, 0;
-; CHECK-NEXT:    selp.u32 %r5, -1, 0, %p7;
+; CHECK-NEXT:    selp.b32 %r5, -1, 0, %p7;
 ; CHECK-NEXT:    setp.gt.u64 %p8, %rd56, 127;
-; CHECK-NEXT:    selp.u32 %r6, -1, 0, %p8;
+; CHECK-NEXT:    selp.b32 %r6, -1, 0, %p8;
 ; CHECK-NEXT:    selp.b32 %r7, %r6, %r5, %p6;
 ; CHECK-NEXT:    and.b32 %r8, %r7, 1;
 ; CHECK-NEXT:    setp.eq.b32 %p9, %r8, 1;

--- a/llvm/test/CodeGen/NVPTX/i8x4-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/i8x4-instructions.ll
@@ -1451,11 +1451,11 @@ define void @test_sext_v4i1_to_v4i8(ptr %a, ptr %b, ptr %c) {
 ; CHECK-NEXT:    bfe.u32 %r9, %r2, 24, 8;
 ; CHECK-NEXT:    bfe.u32 %r10, %r1, 24, 8;
 ; CHECK-NEXT:    setp.hi.u32 %p4, %r10, %r9;
-; CHECK-NEXT:    selp.s32 %r11, -1, 0, %p4;
-; CHECK-NEXT:    selp.s32 %r12, -1, 0, %p3;
+; CHECK-NEXT:    selp.b32 %r11, -1, 0, %p4;
+; CHECK-NEXT:    selp.b32 %r12, -1, 0, %p3;
 ; CHECK-NEXT:    prmt.b32 %r13, %r12, %r11, 0x3340U;
-; CHECK-NEXT:    selp.s32 %r14, -1, 0, %p2;
-; CHECK-NEXT:    selp.s32 %r15, -1, 0, %p1;
+; CHECK-NEXT:    selp.b32 %r14, -1, 0, %p2;
+; CHECK-NEXT:    selp.b32 %r15, -1, 0, %p1;
 ; CHECK-NEXT:    prmt.b32 %r16, %r15, %r14, 0x3340U;
 ; CHECK-NEXT:    prmt.b32 %r17, %r16, %r13, 0x5410U;
 ; CHECK-NEXT:    st.u32 [%rd3], %r17;

--- a/llvm/test/CodeGen/NVPTX/sext-setcc.ll
+++ b/llvm/test/CodeGen/NVPTX/sext-setcc.ll
@@ -16,8 +16,8 @@ define <2 x i16> @sext_setcc_v2i1_to_v2i16(ptr %p) {
 ; CHECK-NEXT:    mov.b32 {%rs1, %rs2}, %r1;
 ; CHECK-NEXT:    setp.eq.s16 %p1, %rs1, 0;
 ; CHECK-NEXT:    setp.eq.s16 %p2, %rs2, 0;
-; CHECK-NEXT:    selp.s16 %rs3, -1, 0, %p2;
-; CHECK-NEXT:    selp.s16 %rs4, -1, 0, %p1;
+; CHECK-NEXT:    selp.b16 %rs3, -1, 0, %p2;
+; CHECK-NEXT:    selp.b16 %rs4, -1, 0, %p1;
 ; CHECK-NEXT:    mov.b32 %r2, {%rs4, %rs3};
 ; CHECK-NEXT:    st.param.b32 [func_retval0], %r2;
 ; CHECK-NEXT:    ret;
@@ -55,11 +55,11 @@ define <4 x i8> @sext_setcc_v4i1_to_v4i8(ptr %p) {
 ; CHECK-NEXT:    cvt.u16.u32 %rs7, %r5;
 ; CHECK-NEXT:    and.b16 %rs8, %rs7, 255;
 ; CHECK-NEXT:    setp.eq.s16 %p4, %rs8, 0;
-; CHECK-NEXT:    selp.s32 %r6, -1, 0, %p4;
-; CHECK-NEXT:    selp.s32 %r7, -1, 0, %p3;
+; CHECK-NEXT:    selp.b32 %r6, -1, 0, %p4;
+; CHECK-NEXT:    selp.b32 %r7, -1, 0, %p3;
 ; CHECK-NEXT:    prmt.b32 %r8, %r7, %r6, 0x3340U;
-; CHECK-NEXT:    selp.s32 %r9, -1, 0, %p2;
-; CHECK-NEXT:    selp.s32 %r10, -1, 0, %p1;
+; CHECK-NEXT:    selp.b32 %r9, -1, 0, %p2;
+; CHECK-NEXT:    selp.b32 %r10, -1, 0, %p1;
 ; CHECK-NEXT:    prmt.b32 %r11, %r10, %r9, 0x3340U;
 ; CHECK-NEXT:    prmt.b32 %r12, %r11, %r8, 0x5410U;
 ; CHECK-NEXT:    st.param.b32 [func_retval0], %r12;

--- a/llvm/test/CodeGen/NVPTX/tid-range.ll
+++ b/llvm/test/CodeGen/NVPTX/tid-range.ll
@@ -12,7 +12,7 @@ entry:
 
 ; CHECK-LABEL: test1(
 ; CHECK: setp.eq.s32  %p1, %r1, 1;
-; CHECK: selp.u32     %[[R:.+]], 1, 0, %p1;
+; CHECK: selp.b32     %[[R:.+]], 1, 0, %p1;
 ; CHECK: st.param.b32 [func_retval0], %[[R]];
 
 declare i32 @llvm.nvvm.read.ptx.sreg.tid.x()

--- a/llvm/test/CodeGen/NVPTX/vector-compare.ll
+++ b/llvm/test/CodeGen/NVPTX/vector-compare.ll
@@ -18,8 +18,8 @@ define void @foo(ptr %a, ptr %b, ptr %r1, ptr %r2) {
   %res = icmp slt <2 x i32> %aval, %bval
   %t1 = extractelement <2 x i1> %res, i32 0
   %t2 = extractelement <2 x i1> %res, i32 1
-; CHECK: selp.u32        %r{{[0-9]+}}, 1, 0
-; CHECK: selp.u32        %r{{[0-9]+}}, 1, 0
+; CHECK: selp.b32        %r{{[0-9]+}}, 1, 0
+; CHECK: selp.b32        %r{{[0-9]+}}, 1, 0
   %t1a = zext i1 %t1 to i32
   %t2a = zext i1 %t2 to i32
 ; CHECK: st.u32


### PR DESCRIPTION
This change uses the untyped variant of `selp.` in all integer cases to simplify the ISel TableGen logic. It is not expected to have any impact on the final SASS.