### PR TITLE
[clang] fix NestedNameSpecifier dependency calculation

### DIFF
--- a/clang/lib/AST/NestedNameSpecifier.cpp
+++ b/clang/lib/AST/NestedNameSpecifier.cpp
@@ -221,7 +221,8 @@ NestedNameSpecifierDependence NestedNameSpecifier::getDependence() const {
     NestedNameSpecifierDependence Dep =
         toNestedNameSpecifierDependendence(getAsType()->getDependence());
     if (NestedNameSpecifier *Prefix = getPrefix())
-      Dep |= Prefix->getDependence();
+      Dep |=
+          Prefix->getDependence() & ~NestedNameSpecifierDependence::Dependent;
     return Dep;
   }
   }

--- a/clang/lib/Sema/SemaCXXScopeSpec.cpp
+++ b/clang/lib/Sema/SemaCXXScopeSpec.cpp
@@ -31,8 +31,7 @@ static CXXRecordDecl *getCurrentInstantiationOf(QualType T,
   const Type *Ty = T->getCanonicalTypeInternal().getTypePtr();
   if (const RecordType *RecordTy = dyn_cast<RecordType>(Ty)) {
     CXXRecordDecl *Record = cast<CXXRecordDecl>(RecordTy->getDecl());
-    if (!Record->isDependentContext() ||
-        Record->isCurrentInstantiation(CurContext))
+    if (Record->isCurrentInstantiation(CurContext))
       return Record;
 
     return nullptr;

--- a/clang/test/SemaTemplate/dependent-names.cpp
+++ b/clang/test/SemaTemplate/dependent-names.cpp
@@ -467,3 +467,17 @@ namespace TransformDependentTemplates {
     void f(Arg<int>);
   };
 } // namespace TransformDependentTemplates
+
+namespace TransformNestedName {
+  enum class S { kA };
+
+  template <class T> struct N {
+    using State = S;
+    template <typename T::template X<State::kA> = 0>
+    void F();
+  };
+
+  template <class T>
+  template <typename T::template X<N<T>::State::kA>>
+  inline void N<T>::F() {}
+} // namespace TransformNestedName


### PR DESCRIPTION
A NestedNameSpecifier of TypeSpec kind can be non-dependent even if its prefix is dependent, when for example the prefix is an injected class type but the type itself is a simple alias to a non-dependent type.

This issue was a bit hard to observe because if it is an alias to a class type, then we (for some unknown reason) ignored that the NNS was dependent in the first place, which wouldn't happen with an enum type.

This could have been a workaround for previous dependency bugs, and is not relevant anymore for any of the test cases in the tree, so this patch also removes that.

The other kinds of dependencies are still relevant. If the prefix contains an unexpanded pack, then this NNS is still unexpanded, and likewise for errors.

This fixes a regression reported here: https://github.com/llvm/llvm-project/pull/133610#issuecomment-2787909829 which was introduced by https://github.com/llvm/llvm-project/pull/133610

There are no release notes since the regression was never released.