### PR TITLE
[bazel][mlir] Add missing dep for X86Vector

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -2273,7 +2273,7 @@ gentbl_cc_library(
     name = "X86VectorInterfacesIncGen",
     tbl_outs = {
         "include/mlir/Dialect/X86Vector/X86VectorInterfaces.h.inc": ["-gen-op-interface-decls"],
-        "include/mlir/Dialect/X86Vector/X86VectorInterfaces.h.inc": ["-gen-op-interface-defs"],
+        "include/mlir/Dialect/X86Vector/X86VectorInterfaces.cpp.inc": ["-gen-op-interface-defs"],
     },
     tblgen = ":mlir-tblgen",
     td_file = "include/mlir/Dialect/X86Vector/X86VectorInterfaces.td",

--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -2237,7 +2237,10 @@ gentbl_cc_library(
 
 td_library(
     name = "X86VectorTdFiles",
-    srcs = ["include/mlir/Dialect/X86Vector/X86Vector.td"],
+    srcs = [
+        "include/mlir/Dialect/X86Vector/X86Vector.td",
+        "include/mlir/Dialect/X86Vector/X86VectorInterfaces.td",
+    ],
     includes = ["include"],
     deps = [
         ":InferTypeOpInterfaceTdFiles",

--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -2269,6 +2269,17 @@ gentbl_cc_library(
     deps = [":X86VectorTdFiles"],
 )
 
+gentbl_cc_library(
+    name = "X86VectorInterfacesIncGen",
+    tbl_outs = {
+        "include/mlir/Dialect/X86Vector/X86VectorInterfaces.h.inc": ["-gen-op-interface-decls"],
+        "include/mlir/Dialect/X86Vector/X86VectorInterfaces.h.inc": ["-gen-op-interface-defs"],
+    },
+    tblgen = ":mlir-tblgen",
+    td_file = "include/mlir/Dialect/X86Vector/X86VectorInterfaces.td",
+    deps = [":X86VectorTdFiles"],
+)
+
 cc_library(
     name = "X86VectorDialect",
     srcs = ["lib/Dialect/X86Vector/IR/X86VectorDialect.cpp"],
@@ -2281,6 +2292,7 @@ cc_library(
         ":LLVMDialect",
         ":SideEffectInterfaces",
         ":X86VectorIncGen",
+        ":X86VectorInterfacesIncGen",
     ],
 )
 


### PR DESCRIPTION
Follow up fix to https://github.com/llvm/llvm-project/pull/133692