### PR TITLE
[offload] Fix finding amdgpu/nvptx-arch to generate tests

### DIFF
--- a/offload/cmake/Modules/LibomptargetGetDependencies.cmake
+++ b/offload/cmake/Modules/LibomptargetGetDependencies.cmake
@@ -51,7 +51,7 @@ if(TARGET nvptx-arch)
   get_property(LIBOMPTARGET_NVPTX_ARCH TARGET nvptx-arch PROPERTY LOCATION)
 else()
   find_program(LIBOMPTARGET_NVPTX_ARCH NAMES nvptx-arch
-               PATHS ${LLVM_TOOLS_BINARY_DIR}/bin)
+               PATHS ${LLVM_TOOLS_BINARY_DIR})
 endif()
 
 if(LIBOMPTARGET_NVPTX_ARCH)
@@ -75,7 +75,7 @@ if(TARGET amdgpu-arch)
   get_property(LIBOMPTARGET_AMDGPU_ARCH TARGET amdgpu-arch PROPERTY LOCATION)
 else()
   find_program(LIBOMPTARGET_AMDGPU_ARCH NAMES amdgpu-arch
-               PATHS ${LLVM_TOOLS_BINARY_DIR}/bin)
+               PATHS ${LLVM_TOOLS_BINARY_DIR})
 endif()
 
 if(LIBOMPTARGET_AMDGPU_ARCH)


### PR DESCRIPTION
PR #134713, which landed as 79cb6f05da37, causes this on my test systems:

```
-- Building AMDGPU plugin for dlopened libhsa
-- Not generating AMDGPU tests, no supported devices detected. Use 'LIBOMPTARGET_FORCE_AMDGPU_TESTS' to override.
-- Building CUDA plugin for dlopened libcuda
-- Not generating NVIDIA tests, no supported devices detected. Use 'LIBOMPTARGET_FORCE_NVIDIA_TESTS' to override.
```

The problem is it cannot locate amdgpu-arch and nvptx-arch.  This patch enables it to.

I suspect there is more cleanup to do here.  amdgpu-arch and nvptx-arch do not appear to exist as cmake targets anymore, but there is still cmake code here that looks for those targets.