### PR TITLE
Save unregistered attrs after type conversion.

### DIFF
--- a/mlir/lib/Dialect/Func/Transforms/FuncConversions.cpp
+++ b/mlir/lib/Dialect/Func/Transforms/FuncConversions.cpp
@@ -49,6 +49,7 @@ struct CallOpSignatureConversion : public OpConversionPattern<CallOp> {
     auto newCallOp = rewriter.create<CallOp>(
         callOp.getLoc(), callOp.getCallee(), convertedResults,
         flattenValues(adaptor.getOperands()));
+    newCallOp->setAttrs(callOp->getAttrs());
     SmallVector<ValueRange> replacements;
     size_t offset = 0;
     for (int i = 0, e = callOp->getNumResults(); i < e; ++i) {


### PR DESCRIPTION
In [Shardy](https://github.com/openxla/shardy), we rely on unregistered attrs being preserved between conversion of different dialects. At one point, we convert between StableHLO and MHLO. When this occurs, we have a `CallOp` with type `stablehlo.token` that is converted to `mhlo.token`. When this occurs, we lose attributes due to this pattern not preserving them. This change makes sure they are preserved.