### PR TITLE
[libc++][NFC] Remove `public` from the type traits

### DIFF
--- a/libcxx/include/__type_traits/is_abstract.h
+++ b/libcxx/include/__type_traits/is_abstract.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_NO_SPECIALIZATIONS is_abstract : public integral_constant<bool, __is_abstract(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_abstract : integral_constant<bool, __is_abstract(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_aggregate.h
+++ b/libcxx/include/__type_traits/is_aggregate.h
@@ -21,7 +21,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 17
 
 template <class _Tp>
-struct _LIBCPP_NO_SPECIALIZATIONS is_aggregate : public integral_constant<bool, __is_aggregate(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_aggregate : integral_constant<bool, __is_aggregate(_Tp)> {};
 
 template <class _Tp>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_aggregate_v = __is_aggregate(_Tp);

--- a/libcxx/include/__type_traits/is_arithmetic.h
+++ b/libcxx/include/__type_traits/is_arithmetic.h
@@ -22,7 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_arithmetic
-    : public integral_constant<bool, is_integral<_Tp>::value || is_floating_point<_Tp>::value> {};
+    : integral_constant<bool, is_integral<_Tp>::value || is_floating_point<_Tp>::value> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_assignable.h
+++ b/libcxx/include/__type_traits/is_assignable.h
@@ -30,8 +30,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_assignable_v = __is_assignab
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_copy_assignable
-    : public integral_constant<bool,
-                               __is_assignable(__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<const _Tp>)> {};
+    : integral_constant<bool, __is_assignable(__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<const _Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -40,7 +39,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_copy_assignable_v = is_copy_
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_move_assignable
-    : public integral_constant<bool, __is_assignable(__add_lvalue_reference_t<_Tp>, __add_rvalue_reference_t<_Tp>)> {};
+    : integral_constant<bool, __is_assignable(__add_lvalue_reference_t<_Tp>, __add_rvalue_reference_t<_Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_base_of.h
+++ b/libcxx/include/__type_traits/is_base_of.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Bp, class _Dp>
-struct _LIBCPP_NO_SPECIALIZATIONS is_base_of : public integral_constant<bool, __is_base_of(_Bp, _Dp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_base_of : integral_constant<bool, __is_base_of(_Bp, _Dp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Bp, class _Dp>
@@ -30,8 +30,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_base_of_v = __is_base_of(_Bp
 #  if __has_builtin(__builtin_is_virtual_base_of)
 
 template <class _Base, class _Derived>
-struct _LIBCPP_NO_SPECIALIZATIONS is_virtual_base_of
-    : public bool_constant<__builtin_is_virtual_base_of(_Base, _Derived)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_virtual_base_of : bool_constant<__builtin_is_virtual_base_of(_Base, _Derived)> {};
 
 template <class _Base, class _Derived>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_virtual_base_of_v = __builtin_is_virtual_base_of(_Base, _Derived);

--- a/libcxx/include/__type_traits/is_class.h
+++ b/libcxx/include/__type_traits/is_class.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_NO_SPECIALIZATIONS is_class : public integral_constant<bool, __is_class(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_class : integral_constant<bool, __is_class(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_constructible.h
+++ b/libcxx/include/__type_traits/is_constructible.h
@@ -21,8 +21,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class... _Args>
-struct _LIBCPP_NO_SPECIALIZATIONS is_constructible : public integral_constant<bool, __is_constructible(_Tp, _Args...)> {
-};
+struct _LIBCPP_NO_SPECIALIZATIONS is_constructible : integral_constant<bool, __is_constructible(_Tp, _Args...)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp, class... _Args>
@@ -31,7 +30,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_constructible_v = __is_const
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_copy_constructible
-    : public integral_constant<bool, __is_constructible(_Tp, __add_lvalue_reference_t<const _Tp>)> {};
+    : integral_constant<bool, __is_constructible(_Tp, __add_lvalue_reference_t<const _Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -40,7 +39,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_copy_constructible_v = is_co
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_move_constructible
-    : public integral_constant<bool, __is_constructible(_Tp, __add_rvalue_reference_t<_Tp>)> {};
+    : integral_constant<bool, __is_constructible(_Tp, __add_rvalue_reference_t<_Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -48,7 +47,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_move_constructible_v = is_mo
 #endif
 
 template <class _Tp>
-struct _LIBCPP_NO_SPECIALIZATIONS is_default_constructible : public integral_constant<bool, __is_constructible(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_default_constructible : integral_constant<bool, __is_constructible(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_convertible.h
+++ b/libcxx/include/__type_traits/is_convertible.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _T1, class _T2>
-struct _LIBCPP_NO_SPECIALIZATIONS is_convertible : public integral_constant<bool, __is_convertible(_T1, _T2)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_convertible : integral_constant<bool, __is_convertible(_T1, _T2)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _From, class _To>

--- a/libcxx/include/__type_traits/is_core_convertible.h
+++ b/libcxx/include/__type_traits/is_core_convertible.h
@@ -24,11 +24,11 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 // and __is_core_convertible<immovable-type,immovable-type> is true in C++17 and later.
 
 template <class _Tp, class _Up, class = void>
-struct __is_core_convertible : public false_type {};
+struct __is_core_convertible : false_type {};
 
 template <class _Tp, class _Up>
 struct __is_core_convertible<_Tp, _Up, decltype(static_cast<void (*)(_Up)>(0)(static_cast<_Tp (*)()>(0)()))>
-    : public true_type {};
+    : true_type {};
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__type_traits/is_destructible.h
+++ b/libcxx/include/__type_traits/is_destructible.h
@@ -62,28 +62,28 @@ struct __destructible_imp;
 
 template <class _Tp>
 struct __destructible_imp<_Tp, false>
-    : public integral_constant<bool, __is_destructor_wellformed<__remove_all_extents_t<_Tp> >::value> {};
+    : integral_constant<bool, __is_destructor_wellformed<__remove_all_extents_t<_Tp> >::value> {};
 
 template <class _Tp>
-struct __destructible_imp<_Tp, true> : public true_type {};
+struct __destructible_imp<_Tp, true> : true_type {};
 
 template <class _Tp, bool>
 struct __destructible_false;
 
 template <class _Tp>
-struct __destructible_false<_Tp, false> : public __destructible_imp<_Tp, is_reference<_Tp>::value> {};
+struct __destructible_false<_Tp, false> : __destructible_imp<_Tp, is_reference<_Tp>::value> {};
 
 template <class _Tp>
-struct __destructible_false<_Tp, true> : public false_type {};
+struct __destructible_false<_Tp, true> : false_type {};
 
 template <class _Tp>
-struct is_destructible : public __destructible_false<_Tp, is_function<_Tp>::value> {};
+struct is_destructible : __destructible_false<_Tp, is_function<_Tp>::value> {};
 
 template <class _Tp>
-struct is_destructible<_Tp[]> : public false_type {};
+struct is_destructible<_Tp[]> : false_type {};
 
 template <>
-struct is_destructible<void> : public false_type {};
+struct is_destructible<void> : false_type {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_empty.h
+++ b/libcxx/include/__type_traits/is_empty.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_NO_SPECIALIZATIONS is_empty : public integral_constant<bool, __is_empty(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_empty : integral_constant<bool, __is_empty(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_enum.h
+++ b/libcxx/include/__type_traits/is_enum.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_NO_SPECIALIZATIONS is_enum : public integral_constant<bool, __is_enum(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_enum : integral_constant<bool, __is_enum(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_final.h
+++ b/libcxx/include/__type_traits/is_final.h
@@ -19,11 +19,11 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct __libcpp_is_final : public integral_constant<bool, __is_final(_Tp)> {};
+struct __libcpp_is_final : integral_constant<bool, __is_final(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 14
 template <class _Tp>
-struct _LIBCPP_NO_SPECIALIZATIONS is_final : public integral_constant<bool, __is_final(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_final : integral_constant<bool, __is_final(_Tp)> {};
 #endif
 
 #if _LIBCPP_STD_VER >= 17

--- a/libcxx/include/__type_traits/is_floating_point.h
+++ b/libcxx/include/__type_traits/is_floating_point.h
@@ -20,14 +20,14 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 // clang-format off
-template <class _Tp> struct __libcpp_is_floating_point              : public false_type {};
-template <>          struct __libcpp_is_floating_point<float>       : public true_type {};
-template <>          struct __libcpp_is_floating_point<double>      : public true_type {};
-template <>          struct __libcpp_is_floating_point<long double> : public true_type {};
+template <class _Tp> struct __libcpp_is_floating_point              : false_type {};
+template <>          struct __libcpp_is_floating_point<float>       : true_type {};
+template <>          struct __libcpp_is_floating_point<double>      : true_type {};
+template <>          struct __libcpp_is_floating_point<long double> : true_type {};
 // clang-format on
 
 template <class _Tp>
-struct _LIBCPP_NO_SPECIALIZATIONS is_floating_point : public __libcpp_is_floating_point<__remove_cv_t<_Tp> > {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_floating_point : __libcpp_is_floating_point<__remove_cv_t<_Tp> > {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_fundamental.h
+++ b/libcxx/include/__type_traits/is_fundamental.h
@@ -34,7 +34,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_fundamental_v = __is_fundame
 
 template <class _Tp>
 struct is_fundamental
-    : public integral_constant<bool, is_void<_Tp>::value || __is_null_pointer_v<_Tp> || is_arithmetic<_Tp>::value> {};
+    : integral_constant<bool, is_void<_Tp>::value || __is_null_pointer_v<_Tp> || is_arithmetic<_Tp>::value> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_implicit_lifetime.h
+++ b/libcxx/include/__type_traits/is_implicit_lifetime.h
@@ -22,7 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #  if __has_builtin(__builtin_is_implicit_lifetime)
 
 template <class _Tp>
-struct _LIBCPP_NO_SPECIALIZATIONS is_implicit_lifetime : public bool_constant<__builtin_is_implicit_lifetime(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_implicit_lifetime : bool_constant<__builtin_is_implicit_lifetime(_Tp)> {};
 
 template <class _Tp>
 _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_implicit_lifetime_v = __builtin_is_implicit_lifetime(_Tp);

--- a/libcxx/include/__type_traits/is_literal_type.h
+++ b/libcxx/include/__type_traits/is_literal_type.h
@@ -21,7 +21,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER <= 17 || defined(_LIBCPP_ENABLE_CXX20_REMOVED_TYPE_TRAITS)
 template <class _Tp>
 struct _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_NO_SPECIALIZATIONS is_literal_type
-    : public integral_constant<bool, __is_literal_type(_Tp)> {};
+    : integral_constant<bool, __is_literal_type(_Tp)> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_nothrow_assignable.h
+++ b/libcxx/include/__type_traits/is_nothrow_assignable.h
@@ -21,8 +21,8 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp, class _Arg>
-struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_assignable
-    : public integral_constant<bool, __is_nothrow_assignable(_Tp, _Arg)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_assignable : integral_constant<bool, __is_nothrow_assignable(_Tp, _Arg)> {
+};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp, class _Arg>
@@ -31,9 +31,8 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_nothrow_assignable_v = __is_
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_copy_assignable
-    : public integral_constant<
-          bool,
-          __is_nothrow_assignable(__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<const _Tp>)> {};
+    : integral_constant<bool,
+                        __is_nothrow_assignable(__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<const _Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -42,9 +41,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_nothrow_copy_assignable_v = 
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_move_assignable
-    : public integral_constant<bool,
-                               __is_nothrow_assignable(__add_lvalue_reference_t<_Tp>, __add_rvalue_reference_t<_Tp>)> {
-};
+    : integral_constant<bool, __is_nothrow_assignable(__add_lvalue_reference_t<_Tp>, __add_rvalue_reference_t<_Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_nothrow_constructible.h
+++ b/libcxx/include/__type_traits/is_nothrow_constructible.h
@@ -22,7 +22,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template < class _Tp, class... _Args>
 struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_constructible
-    : public integral_constant<bool, __is_nothrow_constructible(_Tp, _Args...)> {};
+    : integral_constant<bool, __is_nothrow_constructible(_Tp, _Args...)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp, class... _Args>
@@ -32,7 +32,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_nothrow_constructible_v =
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_copy_constructible
-    : public integral_constant< bool, __is_nothrow_constructible(_Tp, __add_lvalue_reference_t<const _Tp>)> {};
+    : integral_constant<bool, __is_nothrow_constructible(_Tp, __add_lvalue_reference_t<const _Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -42,7 +42,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_nothrow_copy_constructible_v
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_move_constructible
-    : public integral_constant<bool, __is_nothrow_constructible(_Tp, __add_rvalue_reference_t<_Tp>)> {};
+    : integral_constant<bool, __is_nothrow_constructible(_Tp, __add_rvalue_reference_t<_Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -52,7 +52,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_nothrow_move_constructible_v
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_nothrow_default_constructible
-    : public integral_constant<bool, __is_nothrow_constructible(_Tp)> {};
+    : integral_constant<bool, __is_nothrow_constructible(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_nothrow_destructible.h
+++ b/libcxx/include/__type_traits/is_nothrow_destructible.h
@@ -32,23 +32,22 @@ template <bool, class _Tp>
 struct __libcpp_is_nothrow_destructible;
 
 template <class _Tp>
-struct __libcpp_is_nothrow_destructible<false, _Tp> : public false_type {};
+struct __libcpp_is_nothrow_destructible<false, _Tp> : false_type {};
 
 template <class _Tp>
-struct __libcpp_is_nothrow_destructible<true, _Tp>
-    : public integral_constant<bool, noexcept(std::declval<_Tp>().~_Tp()) > {};
+struct __libcpp_is_nothrow_destructible<true, _Tp> : integral_constant<bool, noexcept(std::declval<_Tp>().~_Tp()) > {};
 
 template <class _Tp>
-struct is_nothrow_destructible : public __libcpp_is_nothrow_destructible<is_destructible<_Tp>::value, _Tp> {};
+struct is_nothrow_destructible : __libcpp_is_nothrow_destructible<is_destructible<_Tp>::value, _Tp> {};
 
 template <class _Tp, size_t _Ns>
-struct is_nothrow_destructible<_Tp[_Ns]> : public is_nothrow_destructible<_Tp> {};
+struct is_nothrow_destructible<_Tp[_Ns]> : is_nothrow_destructible<_Tp> {};
 
 template <class _Tp>
-struct is_nothrow_destructible<_Tp&> : public true_type {};
+struct is_nothrow_destructible<_Tp&> : true_type {};
 
 template <class _Tp>
-struct is_nothrow_destructible<_Tp&&> : public true_type {};
+struct is_nothrow_destructible<_Tp&&> : true_type {};
 
 #endif // __has_builtin(__is_nothrow_destructible)
 

--- a/libcxx/include/__type_traits/is_pod.h
+++ b/libcxx/include/__type_traits/is_pod.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_NO_SPECIALIZATIONS is_pod : public integral_constant<bool, __is_pod(_Tp)> {};
+struct _LIBCPP_DEPRECATED_IN_CXX20 _LIBCPP_NO_SPECIALIZATIONS is_pod : integral_constant<bool, __is_pod(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_pointer.h
+++ b/libcxx/include/__type_traits/is_pointer.h
@@ -32,9 +32,9 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_pointer_v = __is_pointer(_Tp
 #else // __has_builtin(__is_pointer)
 
 template <class _Tp>
-struct __libcpp_is_pointer : public false_type {};
+struct __libcpp_is_pointer : false_type {};
 template <class _Tp>
-struct __libcpp_is_pointer<_Tp*> : public true_type {};
+struct __libcpp_is_pointer<_Tp*> : true_type {};
 
 template <class _Tp>
 struct __libcpp_remove_objc_qualifiers {
@@ -50,7 +50,7 @@ template <class _Tp> struct __libcpp_remove_objc_qualifiers<_Tp __unsafe_unretai
 #  endif
 
 template <class _Tp>
-struct is_pointer : public __libcpp_is_pointer<typename __libcpp_remove_objc_qualifiers<__remove_cv_t<_Tp> >::type> {};
+struct is_pointer : __libcpp_is_pointer<typename __libcpp_remove_objc_qualifiers<__remove_cv_t<_Tp> >::type> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_polymorphic.h
+++ b/libcxx/include/__type_traits/is_polymorphic.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_NO_SPECIALIZATIONS is_polymorphic : public integral_constant<bool, __is_polymorphic(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_polymorphic : integral_constant<bool, __is_polymorphic(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_reference.h
+++ b/libcxx/include/__type_traits/is_reference.h
@@ -44,14 +44,14 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_rvalue_reference_v = __is_rv
 #else // __has_builtin(__is_lvalue_reference)
 
 template <class _Tp>
-struct is_lvalue_reference : public false_type {};
+struct is_lvalue_reference : false_type {};
 template <class _Tp>
-struct is_lvalue_reference<_Tp&> : public true_type {};
+struct is_lvalue_reference<_Tp&> : true_type {};
 
 template <class _Tp>
-struct is_rvalue_reference : public false_type {};
+struct is_rvalue_reference : false_type {};
 template <class _Tp>
-struct is_rvalue_reference<_Tp&&> : public true_type {};
+struct is_rvalue_reference<_Tp&&> : true_type {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_reference_wrapper.h
+++ b/libcxx/include/__type_traits/is_reference_wrapper.h
@@ -21,11 +21,11 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct __is_reference_wrapper_impl : public false_type {};
+struct __is_reference_wrapper_impl : false_type {};
 template <class _Tp>
-struct __is_reference_wrapper_impl<reference_wrapper<_Tp> > : public true_type {};
+struct __is_reference_wrapper_impl<reference_wrapper<_Tp> > : true_type {};
 template <class _Tp>
-struct __is_reference_wrapper : public __is_reference_wrapper_impl<__remove_cv_t<_Tp> > {};
+struct __is_reference_wrapper : __is_reference_wrapper_impl<__remove_cv_t<_Tp> > {};
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__type_traits/is_scalar.h
+++ b/libcxx/include/__type_traits/is_scalar.h
@@ -45,7 +45,7 @@ struct __is_block<_Rp (^)(_Args...)> : true_type {};
 // clang-format off
 template <class _Tp>
 struct is_scalar
-    : public integral_constant<
+    : integral_constant<
           bool, is_arithmetic<_Tp>::value ||
                 is_member_pointer<_Tp>::value ||
                 is_pointer<_Tp>::value ||
@@ -55,7 +55,7 @@ struct is_scalar
 // clang-format on
 
 template <>
-struct is_scalar<nullptr_t> : public true_type {};
+struct is_scalar<nullptr_t> : true_type {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_signed.h
+++ b/libcxx/include/__type_traits/is_signed.h
@@ -33,19 +33,19 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_signed_v = __is_signed(_Tp);
 #else // __has_builtin(__is_signed)
 
 template <class _Tp, bool = is_integral<_Tp>::value>
-struct __libcpp_is_signed_impl : public _BoolConstant<(_Tp(-1) < _Tp(0))> {};
+struct __libcpp_is_signed_impl : _BoolConstant<(_Tp(-1) < _Tp(0))> {};
 
 template <class _Tp>
-struct __libcpp_is_signed_impl<_Tp, false> : public true_type {}; // floating point
+struct __libcpp_is_signed_impl<_Tp, false> : true_type {}; // floating point
 
 template <class _Tp, bool = is_arithmetic<_Tp>::value>
-struct __libcpp_is_signed : public __libcpp_is_signed_impl<_Tp> {};
+struct __libcpp_is_signed : __libcpp_is_signed_impl<_Tp> {};
 
 template <class _Tp>
-struct __libcpp_is_signed<_Tp, false> : public false_type {};
+struct __libcpp_is_signed<_Tp, false> : false_type {};
 
 template <class _Tp>
-struct is_signed : public __libcpp_is_signed<_Tp> {};
+struct is_signed : __libcpp_is_signed<_Tp> {};
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_signed_integer.h
+++ b/libcxx/include/__type_traits/is_signed_integer.h
@@ -19,14 +19,14 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 // clang-format off
-template <class _Tp> struct __libcpp_is_signed_integer                   : public false_type {};
-template <>          struct __libcpp_is_signed_integer<signed char>      : public true_type {};
-template <>          struct __libcpp_is_signed_integer<signed short>     : public true_type {};
-template <>          struct __libcpp_is_signed_integer<signed int>       : public true_type {};
-template <>          struct __libcpp_is_signed_integer<signed long>      : public true_type {};
-template <>          struct __libcpp_is_signed_integer<signed long long> : public true_type {};
+template <class _Tp> struct __libcpp_is_signed_integer                   : false_type {};
+template <>          struct __libcpp_is_signed_integer<signed char>      : true_type {};
+template <>          struct __libcpp_is_signed_integer<signed short>     : true_type {};
+template <>          struct __libcpp_is_signed_integer<signed int>       : true_type {};
+template <>          struct __libcpp_is_signed_integer<signed long>      : true_type {};
+template <>          struct __libcpp_is_signed_integer<signed long long> : true_type {};
 #if _LIBCPP_HAS_INT128
-template <>          struct __libcpp_is_signed_integer<__int128_t>       : public true_type {};
+template <>          struct __libcpp_is_signed_integer<__int128_t>       : true_type {};
 #endif
 // clang-format on
 

--- a/libcxx/include/__type_traits/is_standard_layout.h
+++ b/libcxx/include/__type_traits/is_standard_layout.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_NO_SPECIALIZATIONS is_standard_layout : public integral_constant<bool, __is_standard_layout(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_standard_layout : integral_constant<bool, __is_standard_layout(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_trivial.h
+++ b/libcxx/include/__type_traits/is_trivial.h
@@ -21,7 +21,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct _LIBCPP_DEPRECATED_IN_CXX26_(
     "Consider using is_trivially_copyable<T>::value && is_trivially_default_constructible<T>::value instead.")
-    _LIBCPP_NO_SPECIALIZATIONS is_trivial : public integral_constant<bool, __is_trivial(_Tp)> {};
+    _LIBCPP_NO_SPECIALIZATIONS is_trivial : integral_constant<bool, __is_trivial(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_trivially_assignable.h
+++ b/libcxx/include/__type_traits/is_trivially_assignable.h
@@ -31,7 +31,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_trivially_assignable_v = __i
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_trivially_copy_assignable
-    : public integral_constant<
+    : integral_constant<
           bool,
           __is_trivially_assignable(__add_lvalue_reference_t<_Tp>, __add_lvalue_reference_t<const _Tp>)> {};
 
@@ -43,9 +43,8 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_trivially_copy_assignable_v 
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_trivially_move_assignable
-    : public integral_constant<
-          bool,
-          __is_trivially_assignable(__add_lvalue_reference_t<_Tp>, __add_rvalue_reference_t<_Tp>)> {};
+    : integral_constant<bool, __is_trivially_assignable(__add_lvalue_reference_t<_Tp>, __add_rvalue_reference_t<_Tp>)> {
+};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_trivially_constructible.h
+++ b/libcxx/include/__type_traits/is_trivially_constructible.h
@@ -32,7 +32,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_trivially_constructible_v =
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_trivially_copy_constructible
-    : public integral_constant<bool, __is_trivially_constructible(_Tp, __add_lvalue_reference_t<const _Tp>)> {};
+    : integral_constant<bool, __is_trivially_constructible(_Tp, __add_lvalue_reference_t<const _Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -42,7 +42,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_trivially_copy_constructible
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_trivially_move_constructible
-    : public integral_constant<bool, __is_trivially_constructible(_Tp, __add_rvalue_reference_t<_Tp>)> {};
+    : integral_constant<bool, __is_trivially_constructible(_Tp, __add_rvalue_reference_t<_Tp>)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>
@@ -52,7 +52,7 @@ _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_trivially_move_constructible
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_trivially_default_constructible
-    : public integral_constant<bool, __is_trivially_constructible(_Tp)> {};
+    : integral_constant<bool, __is_trivially_constructible(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_trivially_copyable.h
+++ b/libcxx/include/__type_traits/is_trivially_copyable.h
@@ -20,8 +20,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_NO_SPECIALIZATIONS is_trivially_copyable : public integral_constant<bool, __is_trivially_copyable(_Tp)> {
-};
+struct _LIBCPP_NO_SPECIALIZATIONS is_trivially_copyable : integral_constant<bool, __is_trivially_copyable(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_trivially_destructible.h
+++ b/libcxx/include/__type_traits/is_trivially_destructible.h
@@ -23,13 +23,13 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
 struct _LIBCPP_NO_SPECIALIZATIONS is_trivially_destructible
-    : public integral_constant<bool, __is_trivially_destructible(_Tp)> {};
+    : integral_constant<bool, __is_trivially_destructible(_Tp)> {};
 
 #elif __has_builtin(__has_trivial_destructor)
 
 template <class _Tp>
 struct is_trivially_destructible
-    : public integral_constant<bool, is_destructible<_Tp>::value&& __has_trivial_destructor(_Tp)> {};
+    : integral_constant<bool, is_destructible<_Tp>::value&& __has_trivial_destructor(_Tp)> {};
 
 #else
 

--- a/libcxx/include/__type_traits/is_union.h
+++ b/libcxx/include/__type_traits/is_union.h
@@ -19,7 +19,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-struct _LIBCPP_NO_SPECIALIZATIONS is_union : public integral_constant<bool, __is_union(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS is_union : integral_constant<bool, __is_union(_Tp)> {};
 
 #if _LIBCPP_STD_VER >= 17
 template <class _Tp>

--- a/libcxx/include/__type_traits/is_unsigned_integer.h
+++ b/libcxx/include/__type_traits/is_unsigned_integer.h
@@ -19,14 +19,14 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 // clang-format off
-template <class _Tp> struct __libcpp_is_unsigned_integer                     : public false_type {};
-template <>          struct __libcpp_is_unsigned_integer<unsigned char>      : public true_type {};
-template <>          struct __libcpp_is_unsigned_integer<unsigned short>     : public true_type {};
-template <>          struct __libcpp_is_unsigned_integer<unsigned int>       : public true_type {};
-template <>          struct __libcpp_is_unsigned_integer<unsigned long>      : public true_type {};
-template <>          struct __libcpp_is_unsigned_integer<unsigned long long> : public true_type {};
+template <class _Tp> struct __libcpp_is_unsigned_integer                     : false_type {};
+template <>          struct __libcpp_is_unsigned_integer<unsigned char>      : true_type {};
+template <>          struct __libcpp_is_unsigned_integer<unsigned short>     : true_type {};
+template <>          struct __libcpp_is_unsigned_integer<unsigned int>       : true_type {};
+template <>          struct __libcpp_is_unsigned_integer<unsigned long>      : true_type {};
+template <>          struct __libcpp_is_unsigned_integer<unsigned long long> : true_type {};
 #if _LIBCPP_HAS_INT128
-template <>          struct __libcpp_is_unsigned_integer<__uint128_t>        : public true_type {};
+template <>          struct __libcpp_is_unsigned_integer<__uint128_t>        : true_type {};
 #endif
 // clang-format on
 


### PR DESCRIPTION
The type traits are always `struct`s, so the `public` isn't necessary.
We're currently using `public` in some places, while we omit it in
others. This makes us consistent across the type traits.
