### PR TITLE
[LLD][COFF] Swap the meaning of symtab and hybridSymtab in hybrid images

### DIFF
--- a/lld/COFF/COFFLinkerContext.h
+++ b/lld/COFF/COFFLinkerContext.h
@@ -32,7 +32,7 @@ public:
   SymbolTable symtab;
   COFFOptTable optTable;
 
-  // A hybrid ARM64EC symbol table on ARM64X target.
+  // A native ARM64 symbol table on ARM64X target.
   std::optional<SymbolTable> hybridSymtab;
 
   // Pointer to the ARM64EC symbol table: either symtab for an ARM64EC target or
@@ -41,16 +41,17 @@ public:
 
   // Returns the appropriate symbol table for the specified machine type.
   SymbolTable &getSymtab(llvm::COFF::MachineTypes machine) {
-    if (hybridSymtab && (machine == ARM64EC || machine == AMD64))
+    if (hybridSymtab && machine == ARM64)
       return *hybridSymtab;
     return symtab;
   }
 
   // Invoke the specified callback for each symbol table.
   void forEachSymtab(std::function<void(SymbolTable &symtab)> f) {
-    f(symtab);
+    // If present, process the native symbol table first.
     if (hybridSymtab)
       f(*hybridSymtab);
+    f(symtab);
   }
 
   std::vector<ObjFile *> objFileInstances;

--- a/lld/COFF/Chunks.cpp
+++ b/lld/COFF/Chunks.cpp
@@ -570,14 +570,14 @@ void SectionChunk::getBaserels(std::vector<Baserel> *res) {
   // to match the value in the EC load config, which is expected to be
   // a relocatable pointer to the __chpe_metadata symbol.
   COFFLinkerContext &ctx = file->symtab.ctx;
-  if (ctx.hybridSymtab && ctx.symtab.loadConfigSym &&
-      ctx.symtab.loadConfigSym->getChunk() == this &&
-      ctx.hybridSymtab->loadConfigSym &&
-      ctx.symtab.loadConfigSize >=
+  if (ctx.hybridSymtab && ctx.hybridSymtab->loadConfigSym &&
+      ctx.hybridSymtab->loadConfigSym->getChunk() == this &&
+      ctx.symtab.loadConfigSym &&
+      ctx.hybridSymtab->loadConfigSize >=
           offsetof(coff_load_configuration64, CHPEMetadataPointer) +
               sizeof(coff_load_configuration64::CHPEMetadataPointer))
     res->emplace_back(
-        ctx.symtab.loadConfigSym->getRVA() +
+        ctx.hybridSymtab->loadConfigSym->getRVA() +
             offsetof(coff_load_configuration64, CHPEMetadataPointer),
         IMAGE_REL_BASED_DIR64);
 }

--- a/lld/COFF/InputFiles.cpp
+++ b/lld/COFF/InputFiles.cpp
@@ -139,6 +139,7 @@ void ArchiveFile::parse() {
       // Read both EC and native symbols on ARM64X.
       if (!ctx.hybridSymtab)
         return;
+      archiveSymtab = &*ctx.hybridSymtab;
     } else if (ctx.hybridSymtab) {
       // If the ECSYMBOLS section is missing in the archive, the archive could
       // be either a native-only ARM64 or x86_64 archive. Check the machine type

--- a/lld/test/COFF/arm64x-map.s
+++ b/lld/test/COFF/arm64x-map.s
@@ -1,0 +1,60 @@
+// REQUIRES: aarch64
+// RUN: split-file %s %t.dir && cd %t.dir
+
+// RUN: llvm-mc -filetype=obj -triple=aarch64-windows arm64-data-sym.s -o arm64-data-sym.obj
+// RUN: llvm-mc -filetype=obj -triple=arm64ec-windows arm64ec-data-sym.s -o arm64ec-data-sym.obj
+// RUN: lld-link -machine:arm64x -dll -out:out.dll -map -mapinfo:exports arm64-data-sym.obj arm64ec-data-sym.obj
+// RUN: FileCheck %s < out.map
+
+// CHECK:      Start         Length     Name                   Class
+// CHECK-NEXT: 0001:00000000 00001004H .text                   CODE
+// CHECK-NEXT: 0004:00000000 00000008H .data                   DATA
+// CHECK-NEXT: 0004:00000008 00000000H .bss                    DATA
+// CHECK-EMPTY:
+// CHECK-NEXT:  Address         Publics by Value              Rva+Base               Lib:Object
+// CHECK-EMPTY:
+// CHECK-NEXT: 0001:00000000       _DllMainCRTStartup         0000000180001000     arm64-data-sym.obj
+// CHECK-NEXT: 0001:00001000       _DllMainCRTStartup         0000000180002000     arm64ec-data-sym.obj
+// CHECK-NEXT: 0004:00000000       arm64_data_sym             0000000180005000     arm64-data-sym.obj
+// CHECK-NEXT: 0004:00000004       arm64ec_data_sym           0000000180005004     arm64ec-data-sym.obj
+// CHECK-EMPTY:
+// CHECK-NEXT: entry point at         0002:00000000
+// CHECK-EMPTY:
+// CHECK-NEXT: Static symbols
+// CHECK-EMPTY:
+// CHECK-EMPTY:
+// CHECK-NEXT: Exports
+// CHECK-EMPTY:
+// CHECK-NEXT:  ordinal    name
+// CHECK-EMPTY:
+// CHECK-NEXT:        1    arm64ec_data_sym
+
+#--- arm64ec-data-sym.s
+        .text
+        .globl _DllMainCRTStartup
+_DllMainCRTStartup:
+        ret
+
+        .data
+        .globl arm64ec_data_sym
+        .p2align 2, 0x0
+arm64ec_data_sym:
+        .word 0x02020202
+
+        .section .drectve
+        .ascii "-export:arm64ec_data_sym,DATA"
+
+#--- arm64-data-sym.s
+        .text
+        .globl _DllMainCRTStartup
+_DllMainCRTStartup:
+        ret
+
+        .data
+        .globl arm64_data_sym
+        .p2align 2, 0x0
+arm64_data_sym:
+        .word 0x01010101
+
+        .section .drectve
+        .ascii "-export:arm64_data_sym,DATA"


### PR DESCRIPTION
Originally, the intent behind symtab was to represent the symbol table seen in the PE header (without applying ARM64X relocations). However, in most cases outside of `writeHeader()`, the code references either both symbol tables or only the EC one, for example, `mainSymtab` in `linkerMain()` maps to `hybridSymtab` on ARM64X.

MSVC's link.exe allows pure ARM64EC images to include native ARM64 files. This patch prepares LLD to support the same, which will require `hybridSymtab` to be available even for ARM64EC. At that point, `writeHeader()` will need to use the EC symbol table, and the original reasoning for keeping it in `hybridSymtab` no longer applies.

Given this, it seems cleaner to treat the EC symbol table as the “main” one, assigning it to `symtab`, and use `hybridSymtab` for the native symbol table instead. Since `writeHeader()` will need to be conditional anyway, this change simplifies the rest of the code by allowing other parts to consistently treat `ctx.symtab` as the main symbol table.

As a further simplification, this also allows us to eliminate `symtabEC` and use `symtab` directly; I’ll submit that as a separate PR.

The map file now uses the EC symbol table for printed entry points and exports, matching MSVC behavior.