### PR TITLE
[LLD][COFF] Remove no longer needed symtabEC from COFFLinkerContext (NFC)

### DIFF
--- a/lld/COFF/COFFLinkerContext.h
+++ b/lld/COFF/COFFLinkerContext.h
@@ -35,10 +35,6 @@ public:
   // A native ARM64 symbol table on ARM64X target.
   std::optional<SymbolTable> hybridSymtab;
 
-  // Pointer to the ARM64EC symbol table: either symtab for an ARM64EC target or
-  // hybridSymtab for an ARM64X target.
-  SymbolTable *symtabEC = nullptr;
-
   // Returns the appropriate symbol table for the specified machine type.
   SymbolTable &getSymtab(llvm::COFF::MachineTypes machine) {
     if (hybridSymtab && machine == ARM64)

--- a/lld/COFF/DLL.cpp
+++ b/lld/COFF/DLL.cpp
@@ -848,7 +848,7 @@ void IdataContents::create(COFFLinkerContext &ctx) {
                                         : make<NullChunk>(ctx));
     addresses.push_back(addressesTerminator ? addressesTerminator
                                             : make<NullChunk>(ctx));
-    if (ctx.symtabEC) {
+    if (ctx.symtab.isEC()) {
       auxIat.push_back(make<NullChunk>(ctx));
       auxIatCopy.push_back(make<NullChunk>(ctx));
     }
@@ -998,7 +998,7 @@ void DelayLoadContents::create() {
       // Terminate with null values.
       addresses.push_back(make<NullChunk>(ctx, 8));
       names.push_back(make<NullChunk>(ctx, 8));
-      if (ctx.symtabEC) {
+      if (ctx.symtab.isEC()) {
         auxIat.push_back(make<NullChunk>(ctx, 8));
         auxIatCopy.push_back(make<NullChunk>(ctx, 8));
       }

--- a/lld/COFF/InputFiles.cpp
+++ b/lld/COFF/InputFiles.cpp
@@ -129,12 +129,12 @@ void ArchiveFile::parse() {
   file = CHECK(Archive::create(mb), this);
 
   // Try to read symbols from ECSYMBOLS section on ARM64EC.
-  if (ctx.symtabEC) {
+  if (ctx.symtab.isEC()) {
     iterator_range<Archive::symbol_iterator> symbols =
         CHECK(file->ec_symbols(), this);
     if (!symbols.empty()) {
       for (const Archive::Symbol &sym : symbols)
-        ctx.symtabEC->addLazyArchive(this, sym);
+        ctx.symtab.addLazyArchive(this, sym);
 
       // Read both EC and native symbols on ARM64X.
       if (!ctx.hybridSymtab)


### PR DESCRIPTION
With #135093, we may just use `symtab` instead.