### PR TITLE
Revert "Replace bool operator== for VersionType in sanitizer_mac.h"

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_mac.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_mac.h
@@ -37,17 +37,15 @@ struct VersionBase {
 
   VersionBase(u16 major, u16 minor) : major(major), minor(minor) {}
 
+  bool operator==(const VersionType &other) const {
+    return major == other.major && minor == other.minor;
+  }
   bool operator>=(const VersionType &other) const {
     return major > other.major ||
            (major == other.major && minor >= other.minor);
   }
   bool operator<(const VersionType &other) const { return !(*this >= other); }
 };
-
-template <typename VersionType>
-bool operator==(const VersionType &self, const VersionType &other) {
-  return self.major == other.major && self.minor == other.minor;
-}
 
 struct MacosVersion : VersionBase<MacosVersion> {
   MacosVersion(u16 major, u16 minor) : VersionBase(major, minor) {}


### PR DESCRIPTION
Reverts llvm/llvm-project#135068 because it breaks building compiler-rt on Darwin. 

https://green.lab.llvm.org/job/clang-stage1-RA/
https://green.lab.llvm.org/job/llvm.org/view/LLDB/job/as-lldb-cmake/
https://green.lab.llvm.org/job/llvm.org/view/LLDB/job/lldb-cmake/