### PR TITLE
[mlir] implement `-verify-diagnostics=only-expected`

### DIFF
--- a/mlir/examples/transform-opt/mlir-transform-opt.cpp
+++ b/mlir/examples/transform-opt/mlir-transform-opt.cpp
@@ -40,12 +40,14 @@ struct MlirTransformOptCLOptions {
 
   cl::opt<mlir::SourceMgrDiagnosticVerifierHandler::Level> verifyDiagnostics{
       "verify-diagnostics", llvm::cl::ValueOptional,
-      cl::desc("Check that emitted diagnostics match "
-               "expected-* lines on the corresponding line"),
+      cl::desc("Check that emitted diagnostics match expected-* lines on the "
+               "corresponding line"),
       cl::values(
           clEnumValN(
               mlir::SourceMgrDiagnosticVerifierHandler::Level::All, "all",
               "Check all diagnostics (expected, unexpected, near-misses)"),
+          // Implicit value: when passed with no arguments, e.g.
+          // `--verify-diagnostics` or `--verify-diagnostics=`.
           clEnumValN(
               mlir::SourceMgrDiagnosticVerifierHandler::Level::All, "",
               "Check all diagnostics (expected, unexpected, near-misses)"),

--- a/mlir/examples/transform-opt/mlir-transform-opt.cpp
+++ b/mlir/examples/transform-opt/mlir-transform-opt.cpp
@@ -268,7 +268,9 @@ static llvm::LogicalResult processPayloadBuffer(
   context.allowUnregisteredDialects(clOptions->allowUnregisteredDialects);
   mlir::ParserConfig config(&context);
   TransformSourceMgr sourceMgr(
-      /*verifyDiagnostics=*/clOptions->verifyDiagnostics);
+      /*verifyDiagnostics=*/clOptions->verifyDiagnostics.getNumOccurrences()
+          ? std::optional{clOptions->verifyDiagnostics.getValue()}
+          : std::nullopt);
 
   // Parse the input buffer that will be used as transform payload.
   mlir::OwningOpRef<mlir::Operation *> payloadRoot =

--- a/mlir/include/mlir/IR/Diagnostics.h
+++ b/mlir/include/mlir/IR/Diagnostics.h
@@ -626,12 +626,12 @@ struct SourceMgrDiagnosticVerifierHandlerImpl;
 /// corresponding line of the source file.
 class SourceMgrDiagnosticVerifierHandler : public SourceMgrDiagnosticHandler {
 public:
-  SourceMgrDiagnosticVerifierHandler(
-      llvm::SourceMgr &srcMgr, MLIRContext *ctx, raw_ostream &out,
-      bool verifyOnlyExpectedDiagnostics = false);
-  SourceMgrDiagnosticVerifierHandler(
-      llvm::SourceMgr &srcMgr, MLIRContext *ctx,
-      bool verifyOnlyExpectedDiagnostics = false);
+  enum class Level { None = 0, All, OnlyExpected };
+  SourceMgrDiagnosticVerifierHandler(llvm::SourceMgr &srcMgr, MLIRContext *ctx,
+                                     raw_ostream &out,
+                                     Level level = Level::All);
+  SourceMgrDiagnosticVerifierHandler(llvm::SourceMgr &srcMgr, MLIRContext *ctx,
+                                     Level level = Level::All);
   ~SourceMgrDiagnosticVerifierHandler();
 
   /// Returns the status of the handler and verifies that all expected
@@ -648,9 +648,7 @@ private:
 
   std::unique_ptr<detail::SourceMgrDiagnosticVerifierHandlerImpl> impl;
 
-  /// Set whether to check that emitted diagnostics match *only specified*
-  /// `expected-*` lines on the corresponding line.
-  bool verifyOnlyExpectedDiagnostics = false;
+  Level level = Level::All;
 };
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/IR/Diagnostics.h
+++ b/mlir/include/mlir/IR/Diagnostics.h
@@ -626,9 +626,12 @@ struct SourceMgrDiagnosticVerifierHandlerImpl;
 /// corresponding line of the source file.
 class SourceMgrDiagnosticVerifierHandler : public SourceMgrDiagnosticHandler {
 public:
-  SourceMgrDiagnosticVerifierHandler(llvm::SourceMgr &srcMgr, MLIRContext *ctx,
-                                     raw_ostream &out);
-  SourceMgrDiagnosticVerifierHandler(llvm::SourceMgr &srcMgr, MLIRContext *ctx);
+  SourceMgrDiagnosticVerifierHandler(
+      llvm::SourceMgr &srcMgr, MLIRContext *ctx, raw_ostream &out,
+      bool verifyOnlyExpectedDiagnostics = false);
+  SourceMgrDiagnosticVerifierHandler(
+      llvm::SourceMgr &srcMgr, MLIRContext *ctx,
+      bool verifyOnlyExpectedDiagnostics = false);
   ~SourceMgrDiagnosticVerifierHandler();
 
   /// Returns the status of the handler and verifies that all expected
@@ -644,6 +647,10 @@ private:
   void process(LocationAttr loc, StringRef msg, DiagnosticSeverity kind);
 
   std::unique_ptr<detail::SourceMgrDiagnosticVerifierHandlerImpl> impl;
+
+  /// Set whether to check that emitted diagnostics match *only specified*
+  /// `expected-*` lines on the corresponding line.
+  bool verifyOnlyExpectedDiagnostics = false;
 };
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/IR/Diagnostics.h
+++ b/mlir/include/mlir/IR/Diagnostics.h
@@ -647,8 +647,6 @@ private:
   void process(LocationAttr loc, StringRef msg, DiagnosticSeverity kind);
 
   std::unique_ptr<detail::SourceMgrDiagnosticVerifierHandlerImpl> impl;
-
-  Level level = Level::All;
 };
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
+++ b/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
@@ -185,20 +185,19 @@ public:
 
   /// Set whether to check that emitted diagnostics match `expected-*` lines on
   /// the corresponding line. This is meant for implementing diagnostic tests.
-  MlirOptMainConfig &verifyDiagnostics(bool verify) {
+  MlirOptMainConfig &
+  verifyDiagnostics(SourceMgrDiagnosticVerifierHandler::Level verify) {
     verifyDiagnosticsFlag = verify;
     return *this;
   }
-  bool shouldVerifyDiagnostics() const { return verifyDiagnosticsFlag; }
 
-  /// Set whether to check that emitted diagnostics match *only specified*
-  /// `expected-*` lines on the corresponding line.
-  MlirOptMainConfig &verifyOnlyExpectedDiagnostics(bool verify) {
-    verifyOnlyExpectedDiagnosticsFlag = verify;
-    return *this;
+  bool shouldVerifyDiagnostics() const {
+    return verifyDiagnosticsFlag !=
+           SourceMgrDiagnosticVerifierHandler::Level::None;
   }
-  bool shouldVerifyOnlyExpectedDiagnostics() const {
-    return verifyOnlyExpectedDiagnosticsFlag;
+
+  SourceMgrDiagnosticVerifierHandler::Level verifyDiagnosticsLevel() const {
+    return verifyDiagnosticsFlag;
   }
 
   /// Set whether to run the verifier after each transformation pass.
@@ -286,10 +285,8 @@ protected:
 
   /// Set whether to check that emitted diagnostics match `expected-*` lines on
   /// the corresponding line. This is meant for implementing diagnostic tests.
-  bool verifyDiagnosticsFlag = false;
-  /// Set whether to check that emitted diagnostics match *only specified*
-  /// `expected-*` lines on the corresponding line.
-  bool verifyOnlyExpectedDiagnosticsFlag = false;
+  SourceMgrDiagnosticVerifierHandler::Level verifyDiagnosticsFlag =
+      SourceMgrDiagnosticVerifierHandler::Level::None;
 
   /// Run the verifier after each transformation pass.
   bool verifyPassesFlag = true;

--- a/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
+++ b/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
@@ -191,6 +191,16 @@ public:
   }
   bool shouldVerifyDiagnostics() const { return verifyDiagnosticsFlag; }
 
+  /// Set whether to check that emitted diagnostics match *only specified*
+  /// `expected-*` lines on the corresponding line.
+  MlirOptMainConfig &verifyOnlyExpectedDiagnostics(bool verify) {
+    verifyOnlyExpectedDiagnosticsFlag = verify;
+    return *this;
+  }
+  bool shouldVerifyOnlyExpectedDiagnostics() const {
+    return verifyOnlyExpectedDiagnosticsFlag;
+  }
+
   /// Set whether to run the verifier after each transformation pass.
   MlirOptMainConfig &verifyPasses(bool verify) {
     verifyPassesFlag = verify;
@@ -277,6 +287,9 @@ protected:
   /// Set whether to check that emitted diagnostics match `expected-*` lines on
   /// the corresponding line. This is meant for implementing diagnostic tests.
   bool verifyDiagnosticsFlag = false;
+  /// Set whether to check that emitted diagnostics match *only specified*
+  /// `expected-*` lines on the corresponding line.
+  bool verifyOnlyExpectedDiagnosticsFlag = false;
 
   /// Run the verifier after each transformation pass.
   bool verifyPassesFlag = true;

--- a/mlir/lib/IR/Diagnostics.cpp
+++ b/mlir/lib/IR/Diagnostics.cpp
@@ -661,7 +661,9 @@ struct ExpectedDiag {
 };
 
 struct SourceMgrDiagnosticVerifierHandlerImpl {
-  SourceMgrDiagnosticVerifierHandlerImpl() : status(success()) {}
+  SourceMgrDiagnosticVerifierHandlerImpl(
+      SourceMgrDiagnosticVerifierHandler::Level level)
+      : status(success()), level(level) {}
 
   /// Returns the expected diagnostics for the given source file.
   std::optional<MutableArrayRef<ExpectedDiag>>
@@ -671,6 +673,10 @@ struct SourceMgrDiagnosticVerifierHandlerImpl {
   MutableArrayRef<ExpectedDiag>
   computeExpectedDiags(raw_ostream &os, llvm::SourceMgr &mgr,
                        const llvm::MemoryBuffer *buf);
+
+  SourceMgrDiagnosticVerifierHandler::Level getVerifyLevel() const {
+    return level;
+  }
 
   /// The current status of the verifier.
   LogicalResult status;
@@ -685,6 +691,10 @@ struct SourceMgrDiagnosticVerifierHandlerImpl {
   llvm::Regex expected =
       llvm::Regex("expected-(error|note|remark|warning)(-re)? "
                   "*(@([+-][0-9]+|above|below|unknown))? *{{(.*)}}$");
+
+  /// Verification level.
+  SourceMgrDiagnosticVerifierHandler::Level level =
+      SourceMgrDiagnosticVerifierHandler::Level::All;
 };
 } // namespace detail
 } // namespace mlir
@@ -805,7 +815,7 @@ SourceMgrDiagnosticVerifierHandlerImpl::computeExpectedDiags(
 SourceMgrDiagnosticVerifierHandler::SourceMgrDiagnosticVerifierHandler(
     llvm::SourceMgr &srcMgr, MLIRContext *ctx, raw_ostream &out, Level level)
     : SourceMgrDiagnosticHandler(srcMgr, ctx, out),
-      impl(new SourceMgrDiagnosticVerifierHandlerImpl()), level(level) {
+      impl(new SourceMgrDiagnosticVerifierHandlerImpl(level)) {
   // Compute the expected diagnostics for each of the current files in the
   // source manager.
   for (unsigned i = 0, e = mgr.getNumBuffers(); i != e; ++i)
@@ -898,7 +908,7 @@ void SourceMgrDiagnosticVerifierHandler::process(LocationAttr loc,
     }
   }
 
-  if (level == Level::OnlyExpected)
+  if (impl->getVerifyLevel() == Level::OnlyExpected)
     return;
 
   // Otherwise, emit an error for the near miss.

--- a/mlir/lib/IR/Diagnostics.cpp
+++ b/mlir/lib/IR/Diagnostics.cpp
@@ -803,9 +803,11 @@ SourceMgrDiagnosticVerifierHandlerImpl::computeExpectedDiags(
 }
 
 SourceMgrDiagnosticVerifierHandler::SourceMgrDiagnosticVerifierHandler(
-    llvm::SourceMgr &srcMgr, MLIRContext *ctx, raw_ostream &out)
+    llvm::SourceMgr &srcMgr, MLIRContext *ctx, raw_ostream &out,
+    bool verifyOnlyExpectedDiagnostics)
     : SourceMgrDiagnosticHandler(srcMgr, ctx, out),
-      impl(new SourceMgrDiagnosticVerifierHandlerImpl()) {
+      impl(new SourceMgrDiagnosticVerifierHandlerImpl()),
+      verifyOnlyExpectedDiagnostics(verifyOnlyExpectedDiagnostics) {
   // Compute the expected diagnostics for each of the current files in the
   // source manager.
   for (unsigned i = 0, e = mgr.getNumBuffers(); i != e; ++i)
@@ -823,8 +825,10 @@ SourceMgrDiagnosticVerifierHandler::SourceMgrDiagnosticVerifierHandler(
 }
 
 SourceMgrDiagnosticVerifierHandler::SourceMgrDiagnosticVerifierHandler(
-    llvm::SourceMgr &srcMgr, MLIRContext *ctx)
-    : SourceMgrDiagnosticVerifierHandler(srcMgr, ctx, llvm::errs()) {}
+    llvm::SourceMgr &srcMgr, MLIRContext *ctx,
+    bool verifyOnlyExpectedDiagnostics)
+    : SourceMgrDiagnosticVerifierHandler(srcMgr, ctx, llvm::errs(),
+                                         verifyOnlyExpectedDiagnostics) {}
 
 SourceMgrDiagnosticVerifierHandler::~SourceMgrDiagnosticVerifierHandler() {
   // Ensure that all expected diagnostics were handled.
@@ -897,6 +901,9 @@ void SourceMgrDiagnosticVerifierHandler::process(LocationAttr loc,
       nearMiss = &e;
     }
   }
+
+  if (verifyOnlyExpectedDiagnostics)
+    return;
 
   // Otherwise, emit an error for the near miss.
   if (nearMiss)

--- a/mlir/lib/IR/Diagnostics.cpp
+++ b/mlir/lib/IR/Diagnostics.cpp
@@ -803,11 +803,9 @@ SourceMgrDiagnosticVerifierHandlerImpl::computeExpectedDiags(
 }
 
 SourceMgrDiagnosticVerifierHandler::SourceMgrDiagnosticVerifierHandler(
-    llvm::SourceMgr &srcMgr, MLIRContext *ctx, raw_ostream &out,
-    bool verifyOnlyExpectedDiagnostics)
+    llvm::SourceMgr &srcMgr, MLIRContext *ctx, raw_ostream &out, Level level)
     : SourceMgrDiagnosticHandler(srcMgr, ctx, out),
-      impl(new SourceMgrDiagnosticVerifierHandlerImpl()),
-      verifyOnlyExpectedDiagnostics(verifyOnlyExpectedDiagnostics) {
+      impl(new SourceMgrDiagnosticVerifierHandlerImpl()), level(level) {
   // Compute the expected diagnostics for each of the current files in the
   // source manager.
   for (unsigned i = 0, e = mgr.getNumBuffers(); i != e; ++i)
@@ -825,10 +823,8 @@ SourceMgrDiagnosticVerifierHandler::SourceMgrDiagnosticVerifierHandler(
 }
 
 SourceMgrDiagnosticVerifierHandler::SourceMgrDiagnosticVerifierHandler(
-    llvm::SourceMgr &srcMgr, MLIRContext *ctx,
-    bool verifyOnlyExpectedDiagnostics)
-    : SourceMgrDiagnosticVerifierHandler(srcMgr, ctx, llvm::errs(),
-                                         verifyOnlyExpectedDiagnostics) {}
+    llvm::SourceMgr &srcMgr, MLIRContext *ctx, Level level)
+    : SourceMgrDiagnosticVerifierHandler(srcMgr, ctx, llvm::errs(), level) {}
 
 SourceMgrDiagnosticVerifierHandler::~SourceMgrDiagnosticVerifierHandler() {
   // Ensure that all expected diagnostics were handled.
@@ -902,7 +898,7 @@ void SourceMgrDiagnosticVerifierHandler::process(LocationAttr loc,
     }
   }
 
-  if (verifyOnlyExpectedDiagnostics)
+  if (level == Level::OnlyExpected)
     return;
 
   // Otherwise, emit an error for the near miss.

--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -167,8 +167,8 @@ struct MlirOptMainConfigCLOptions : public MlirOptMainConfig {
                    /*ExternalStorage=*/true>
         verifyDiagnostics{
             "verify-diagnostics", llvm::cl::ValueOptional,
-            cl::desc("Check that emitted diagnostics match "
-                     "expected-* lines on the corresponding line"),
+            cl::desc("Check that emitted diagnostics match expected-* lines on "
+                     "the corresponding line"),
             cl::location(verifyDiagnosticsFlag),
             cl::values(
                 clEnumValN(SourceMgrDiagnosticVerifierHandler::Level::All,

--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -168,6 +168,14 @@ struct MlirOptMainConfigCLOptions : public MlirOptMainConfig {
         cl::desc("Check that emitted diagnostics match "
                  "expected-* lines on the corresponding line"),
         cl::location(verifyDiagnosticsFlag), cl::init(false));
+    static cl::opt<bool, /*ExternalStorage=*/true>
+        verifyOnlyExpectedDiagnostics{
+            "verify-only-expected-diagnostics",
+            cl::desc("Check that emitted diagnostics match only specified "
+                     "expected-* "
+                     "lines "
+                     "on the corresponding line"),
+            cl::location(verifyOnlyExpectedDiagnosticsFlag), cl::init(false)};
 
     static cl::opt<bool, /*ExternalStorage=*/true> verifyPasses(
         "verify-each",
@@ -537,7 +545,8 @@ static LogicalResult processBuffer(raw_ostream &os,
     return performActions(os, sourceMgr, &context, config);
   }
 
-  SourceMgrDiagnosticVerifierHandler sourceMgrHandler(*sourceMgr, &context);
+  SourceMgrDiagnosticVerifierHandler sourceMgrHandler(
+      *sourceMgr, &context, config.shouldVerifyOnlyExpectedDiagnostics());
 
   // Do any processing requested by command line flags.  We don't care whether
   // these actions succeed or fail, we only care what diagnostics they produce

--- a/mlir/lib/Tools/mlir-translate/MlirTranslateMain.cpp
+++ b/mlir/lib/Tools/mlir-translate/MlirTranslateMain.cpp
@@ -58,7 +58,8 @@ LogicalResult mlir::mlirTranslateMain(int argc, char **argv,
 
   static llvm::cl::opt<bool> allowUnregisteredDialects(
       "allow-unregistered-dialect",
-      llvm::cl::desc("Allow operation with no registered dialects (discouraged: testing only!)"),
+      llvm::cl::desc("Allow operation with no registered dialects "
+                     "(discouraged: testing only!)"),
       llvm::cl::init(false));
 
   static llvm::cl::opt<std::string> inputSplitMarker{
@@ -77,6 +78,13 @@ LogicalResult mlir::mlirTranslateMain(int argc, char **argv,
       llvm::cl::desc("Check that emitted diagnostics match "
                      "expected-* lines on the corresponding line"),
       llvm::cl::init(false));
+  static llvm::cl::opt<bool> verifyOnlyExpectedDiagnostics{
+      "verify-only-expected-diagnostics",
+      llvm::cl::desc(
+          "Check that emitted diagnostics match only specified expected-* "
+          "lines "
+          "on the corresponding line"),
+      llvm::cl::init(false)};
 
   static llvm::cl::opt<bool> errorDiagnosticsOnly(
       "error-diagnostics-only",
@@ -158,8 +166,8 @@ LogicalResult mlir::mlirTranslateMain(int argc, char **argv,
         // translation failed (in most cases, it is expected to fail) and we do
         // not filter non-error diagnostics even if `errorDiagnosticsOnly` is
         // set. Instead, we check if the diagnostics were produced as expected.
-        SourceMgrDiagnosticVerifierHandler sourceMgrHandler(*sourceMgr,
-                                                            &context);
+        SourceMgrDiagnosticVerifierHandler sourceMgrHandler(
+            *sourceMgr, &context, verifyOnlyExpectedDiagnostics);
         (void)(*translationRequested)(sourceMgr, os, &context);
         result = sourceMgrHandler.verify();
       } else if (errorDiagnosticsOnly) {

--- a/mlir/lib/Tools/mlir-translate/MlirTranslateMain.cpp
+++ b/mlir/lib/Tools/mlir-translate/MlirTranslateMain.cpp
@@ -58,8 +58,7 @@ LogicalResult mlir::mlirTranslateMain(int argc, char **argv,
 
   static llvm::cl::opt<bool> allowUnregisteredDialects(
       "allow-unregistered-dialect",
-      llvm::cl::desc("Allow operation with no registered dialects "
-                     "(discouraged: testing only!)"),
+      llvm::cl::desc("Allow operation with no registered dialects (discouraged: testing only!)"),
       llvm::cl::init(false));
 
   static llvm::cl::opt<std::string> inputSplitMarker{
@@ -76,12 +75,14 @@ LogicalResult mlir::mlirTranslateMain(int argc, char **argv,
   static llvm::cl::opt<SourceMgrDiagnosticVerifierHandler::Level>
       verifyDiagnostics{
           "verify-diagnostics", llvm::cl::ValueOptional,
-          llvm::cl::desc("Check that emitted diagnostics match "
-                         "expected-* lines on the corresponding line"),
+          llvm::cl::desc("Check that emitted diagnostics match expected-* "
+                         "lines on the corresponding line"),
           llvm::cl::values(
               clEnumValN(
                   SourceMgrDiagnosticVerifierHandler::Level::All, "all",
                   "Check all diagnostics (expected, unexpected, near-misses)"),
+              // Implicit value: when passed with no arguments, e.g.
+              // `--verify-diagnostics` or `--verify-diagnostics=`.
               clEnumValN(
                   SourceMgrDiagnosticVerifierHandler::Level::All, "",
                   "Check all diagnostics (expected, unexpected, near-misses)"),
@@ -160,7 +161,7 @@ LogicalResult mlir::mlirTranslateMain(int argc, char **argv,
 
       MLIRContext context;
       context.allowUnregisteredDialects(allowUnregisteredDialects);
-      context.printOpOnDiagnostic(!bool(verifyDiagnostics.getNumOccurrences()));
+      context.printOpOnDiagnostic(verifyDiagnostics.getNumOccurrences() == 0);
       auto sourceMgr = std::make_shared<llvm::SourceMgr>();
       sourceMgr->AddNewSourceBuffer(std::move(ownedBuffer), SMLoc());
 

--- a/mlir/test/Pass/full_diagnostics.mlir
+++ b/mlir/test/Pass/full_diagnostics.mlir
@@ -1,4 +1,5 @@
 // RUN: mlir-opt %s -pass-pipeline='builtin.module(func.func(test-pass-failure{gen-diagnostics}))' -verify-diagnostics
+// RUN: mlir-opt %s -pass-pipeline='builtin.module(func.func(test-pass-failure{gen-diagnostics}))' -verify-diagnostics=all
 
 // Test that all errors are reported.
 // expected-error@below {{illegal operation}}

--- a/mlir/test/Pass/full_diagnostics_only_expected.mlir
+++ b/mlir/test/Pass/full_diagnostics_only_expected.mlir
@@ -1,0 +1,17 @@
+// RUN: mlir-opt %s -pass-pipeline='builtin.module(func.func(test-pass-failure{gen-diagnostics}))' -verify-diagnostics=only-expected
+
+// Test that only expected errors are reported.
+// reports {{illegal operation}} but unchecked
+func.func @TestAlwaysIllegalOperationPass1() {
+  return
+}
+
+// expected-error@+1 {{illegal operation}}
+func.func @TestAlwaysIllegalOperationPass2() {
+  return
+}
+
+// reports {{illegal operation}} but unchecked
+func.func @TestAlwaysIllegalOperationPass3() {
+  return
+}

--- a/mlir/test/mlir-translate/verify-only-expected.mlir
+++ b/mlir/test/mlir-translate/verify-only-expected.mlir
@@ -1,49 +1,24 @@
-// Note: borrowed/copied from mlir/test/Target/LLVMIR/arm-sme-invalid.mlir
-
 // Check that verify-diagnostics=only-expected passes with only one actual `expected-error`
-// RUN: mlir-translate %s -verify-diagnostics=only-expected -split-input-file -mlir-to-llvmir
+// RUN: mlir-translate %s --allow-unregistered-dialect -verify-diagnostics=only-expected -split-input-file -mlir-to-llvmir
 
-// Check that verify-diagnostics=all fails because we're missing three `expected-error`
-// RUN: not mlir-translate %s -verify-diagnostics=all -split-input-file -mlir-to-llvmir 2>&1 | FileCheck %s --check-prefix=CHECK-VERIFY-ALL
-// CHECK-VERIFY-ALL:      error: unexpected error: 'arm_sme.intr.write.horiz' op failed to verify that all of {predicate, vector} have same shape
-// CHECK-VERIFY-ALL-NEXT: "arm_sme.intr.write.horiz"
-// CHECK-VERIFY-ALL:      error: unexpected error: 'arm_sme.intr.read.horiz' op failed to verify that all of {vector, res} have same element type
-// CHECK-VERIFY-ALL-NEXT: %res = "arm_sme.intr.read.horiz"
-// CHECK-VERIFY-ALL:      error: unexpected error: 'arm_sme.intr.cntsb' op failed to verify that `res` is i64
-// CHECK-VERIFY-ALL-NEXT: %res = "arm_sme.intr.cntsb"
+// Check that verify-diagnostics=all fails because we're missing two `expected-error`
+// RUN: not mlir-translate %s --allow-unregistered-dialect -verify-diagnostics=all -split-input-file -mlir-to-llvmir 2>&1 | FileCheck %s --check-prefix=CHECK-VERIFY-ALL
+// CHECK-VERIFY-ALL: unexpected error: cannot be converted to LLVM IR: missing `LLVMTranslationDialectInterface` registration for dialect for op: simple.terminator1
+// CHECK-VERIFY-ALL: unexpected error: cannot be converted to LLVM IR: missing `LLVMTranslationDialectInterface` registration for dialect for op: simple.terminator3
 
-llvm.func @arm_sme_vector_to_tile_invalid_types(%tileslice : i32,
-                                                %nxv4i1 : vector<[4]xi1>,
-                                                %nxv16i8 : vector<[16]xi8>) {
-  "arm_sme.intr.write.horiz"(%tileslice, %nxv4i1, %nxv16i8) <{tile_id = 0 : i32}> :
-      (i32, vector<[4]xi1>, vector<[16]xi8>) -> ()
-  llvm.return
+llvm.func @trivial() {
+  "simple.terminator1"() : () -> ()
 }
 
 // -----
 
-llvm.func @arm_sme_tile_slice_to_vector_invalid_shapes(
-  %tileslice : i32, %nxv4i1 : vector<[4]xi1>, %nxv16i8 : vector<[16]xi8>
-) -> vector<[3]xf32> {
-  // expected-error @+1 {{failed to verify that all of {vector, predicate, res} have same shape}}
-  %res = "arm_sme.intr.read.horiz"(%nxv16i8, %nxv4i1, %tileslice) <{tile_id = 0 : i32}> :
-      (vector<[16]xi8>, vector<[4]xi1>, i32) -> vector<[3]xf32>
-  llvm.return %res : vector<[3]xf32>
+llvm.func @trivial() {
+  // expected-error @+1 {{cannot be converted to LLVM IR: missing `LLVMTranslationDialectInterface` registration for dialect for op: simple.terminator2}}
+  "simple.terminator2"() : () -> ()
 }
 
 // -----
 
-llvm.func @arm_sme_tile_slice_to_vector_invalid_element_types(
-  %tileslice : i32, %nxv4i1 : vector<[4]xi1>, %nxv4f32 : vector<[4]xf32>
-) -> vector<[3]xi32> {
-  %res = "arm_sme.intr.read.horiz"(%nxv4f32, %nxv4i1, %tileslice) <{tile_id = 0 : i32}> :
-      (vector<[4]xf32>, vector<[4]xi1>, i32) -> vector<[4]xi32>
-  llvm.return %res : vector<[4]xi32>
-}
-
-// -----
-
-llvm.func @arm_sme_streaming_vl_invalid_return_type() -> i32 {
-  %res = "arm_sme.intr.cntsb"() : () -> i32
-  llvm.return %res : i32
+llvm.func @trivial() {
+  "simple.terminator3"() : () -> ()
 }

--- a/mlir/test/mlir-translate/verify-only-expected.mlir
+++ b/mlir/test/mlir-translate/verify-only-expected.mlir
@@ -1,0 +1,49 @@
+// Note: borrowed/copied from mlir/test/Target/LLVMIR/arm-sme-invalid.mlir
+
+// Check that verify-diagnostics=only-expected passes with only one actual `expected-error`
+// RUN: mlir-translate %s -verify-diagnostics=only-expected -split-input-file -mlir-to-llvmir
+
+// Check that verify-diagnostics=all fails because we're missing three `expected-error`
+// RUN: not mlir-translate %s -verify-diagnostics=all -split-input-file -mlir-to-llvmir 2>&1 | FileCheck %s --check-prefix=CHECK-VERIFY-ALL
+// CHECK-VERIFY-ALL:      error: unexpected error: 'arm_sme.intr.write.horiz' op failed to verify that all of {predicate, vector} have same shape
+// CHECK-VERIFY-ALL-NEXT: "arm_sme.intr.write.horiz"
+// CHECK-VERIFY-ALL:      error: unexpected error: 'arm_sme.intr.read.horiz' op failed to verify that all of {vector, res} have same element type
+// CHECK-VERIFY-ALL-NEXT: %res = "arm_sme.intr.read.horiz"
+// CHECK-VERIFY-ALL:      error: unexpected error: 'arm_sme.intr.cntsb' op failed to verify that `res` is i64
+// CHECK-VERIFY-ALL-NEXT: %res = "arm_sme.intr.cntsb"
+
+llvm.func @arm_sme_vector_to_tile_invalid_types(%tileslice : i32,
+                                                %nxv4i1 : vector<[4]xi1>,
+                                                %nxv16i8 : vector<[16]xi8>) {
+  "arm_sme.intr.write.horiz"(%tileslice, %nxv4i1, %nxv16i8) <{tile_id = 0 : i32}> :
+      (i32, vector<[4]xi1>, vector<[16]xi8>) -> ()
+  llvm.return
+}
+
+// -----
+
+llvm.func @arm_sme_tile_slice_to_vector_invalid_shapes(
+  %tileslice : i32, %nxv4i1 : vector<[4]xi1>, %nxv16i8 : vector<[16]xi8>
+) -> vector<[3]xf32> {
+  // expected-error @+1 {{failed to verify that all of {vector, predicate, res} have same shape}}
+  %res = "arm_sme.intr.read.horiz"(%nxv16i8, %nxv4i1, %tileslice) <{tile_id = 0 : i32}> :
+      (vector<[16]xi8>, vector<[4]xi1>, i32) -> vector<[3]xf32>
+  llvm.return %res : vector<[3]xf32>
+}
+
+// -----
+
+llvm.func @arm_sme_tile_slice_to_vector_invalid_element_types(
+  %tileslice : i32, %nxv4i1 : vector<[4]xi1>, %nxv4f32 : vector<[4]xf32>
+) -> vector<[3]xi32> {
+  %res = "arm_sme.intr.read.horiz"(%nxv4f32, %nxv4i1, %tileslice) <{tile_id = 0 : i32}> :
+      (vector<[4]xf32>, vector<[4]xi1>, i32) -> vector<[4]xi32>
+  llvm.return %res : vector<[4]xi32>
+}
+
+// -----
+
+llvm.func @arm_sme_streaming_vl_invalid_return_type() -> i32 {
+  %res = "arm_sme.intr.cntsb"() : () -> i32
+  llvm.return %res : i32
+}


### PR DESCRIPTION
This PR implements `verify-diagnostics=only-expected` which is a "best effort" verification - i.e., `unexpected`s and `near-misses` will not be considered failures. The purpose is to enable narrowly scoped checking of verification remarks (just as we have for lit where only a subset of lines get `CHECK`ed).