### PR TITLE
[llvm-extract] support unnamed bbs.

### DIFF
--- a/llvm/include/llvm/IR/Value.h
+++ b/llvm/include/llvm/IR/Value.h
@@ -290,9 +290,7 @@ public:
   /// \note It is an error to call V->takeName(V).
   void takeName(Value *V);
 
-#ifndef NDEBUG
   std::string getNameOrAsOperand() const;
-#endif
 
   /// Change all uses of this to point to a new Value.
   ///

--- a/llvm/lib/IR/Value.cpp
+++ b/llvm/lib/IR/Value.cpp
@@ -441,7 +441,6 @@ void Value::takeName(Value *V) {
     ST->reinsertValue(this);
 }
 
-#ifndef NDEBUG
 std::string Value::getNameOrAsOperand() const {
   if (!getName().empty())
     return std::string(getName());
@@ -451,7 +450,6 @@ std::string Value::getNameOrAsOperand() const {
   printAsOperand(OS, false);
   return OS.str();
 }
-#endif
 
 void Value::assertModuleIsMaterializedImpl() const {
 #ifndef NDEBUG

--- a/llvm/test/tools/llvm-extract/extract-unnamed-bb.ll
+++ b/llvm/test/tools/llvm-extract/extract-unnamed-bb.ll
@@ -1,0 +1,28 @@
+; RUN: llvm-extract -S --bb "_Z6kernelv.extracted:%5" < %s | FileCheck %s
+
+; CHECK: define dso_local void @_Z6kernelv.extracted.extracted(i64 %0, i64 %1) {
+
+; CHECK       2:
+; CHECK:        %3 = add nuw nsw i64 %0, 1
+; CHECK-NEXT:   %4 = sub nuw nsw i64 %3, %1
+; CHECK-NEXT:   br label %.exitStub
+
+define dso_local void @_Z6kernelv.extracted(i64 %0, ptr %.out) #0 {
+newFuncRoot:
+  br label %1
+
+1:
+  %2 = phi i64 [ 0, %newFuncRoot ], [ %3, %1 ]
+  %3 = add nuw nsw i64 %2, 1
+  %4 = icmp eq i64 %2, %3
+  br i1 %4, label %5, label %1
+
+5:
+  %6 = add nuw nsw i64 %0, 1
+  %7 = sub nuw nsw i64 %6, %3
+  br label %8
+
+8:
+  %9 = add nuw i64 %0, 2
+  ret void
+}

--- a/llvm/tools/llvm-extract/llvm-extract.cpp
+++ b/llvm/tools/llvm-extract/llvm-extract.cpp
@@ -90,10 +90,13 @@ static cl::list<std::string> ExtractBlocks(
         "Each pair will create a function.\n"
         "If multiple basic blocks are specified in one pair,\n"
         "the first block in the sequence should dominate the rest.\n"
+        "If an unnamed basic block is to be extracted,\n"
+        "'%' should be added before the basic block variable names.\n"
         "eg:\n"
         "  --bb=f:bb1;bb2 will extract one function with both bb1 and bb2;\n"
         "  --bb=f:bb1 --bb=f:bb2 will extract two functions, one with bb1, one "
-        "with bb2."),
+        "with bb2.\n"
+        "  --bb=f:%1 will extract one function with basic block 1;"),
     cl::value_desc("function:bb1[;bb2...]"), cl::cat(ExtractCat));
 
 // ExtractAlias - The alias to extract from the module.
@@ -356,7 +359,7 @@ int main(int argc, char **argv) {
         // The function has been materialized, so add its matching basic blocks
         // to the block extractor list, or fail if a name is not found.
         auto Res = llvm::find_if(*P.first, [&](const BasicBlock &BB) {
-          return BB.getName() == BBName;
+          return BB.getNameOrAsOperand() == BBName;
         });
         if (Res == P.first->end()) {
           errs() << argv[0] << ": function " << P.first->getName()


### PR DESCRIPTION
Dear developer:

I have recently working with LLVM IR and I want to isolate basic blocks using the command "llvm-extract". However, I found that the command option "llvm-extract --bb func_name:bb_name" will only function when dumping source code into IRs with options "-fno-discard-value-names". That is to say, the "llvm-extract" command cannot support unnamed basic blocks, which is a default output of the compiler. So, I made these changes and hope they will make LLVM better.

Best regards,