### PR TITLE
[Clang][CodeGen][UBSan] Remove redundant `EmitCheckValue` calls. NFCI

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -1972,7 +1972,7 @@ bool CodeGenFunction::EmitScalarRangeCheck(llvm::Value *Value, QualType Ty,
   SanitizerKind::SanitizerOrdinal Kind =
       NeedsEnumCheck ? SanitizerKind::SO_Enum : SanitizerKind::SO_Bool;
   EmitCheck(std::make_pair(Check, Kind), SanitizerHandler::LoadInvalidValue,
-            StaticArgs, EmitCheckValue(Value));
+            StaticArgs, Value);
   return true;
 }
 

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -3197,9 +3197,7 @@ void CodeGenFunction::emitAlignmentAssumptionCheck(
     llvm::Constant *StaticData[] = {EmitCheckSourceLocation(Loc),
                                     EmitCheckSourceLocation(SecondaryLoc),
                                     EmitCheckTypeDescriptor(Ty)};
-    llvm::Value *DynamicData[] = {EmitCheckValue(Ptr),
-                                  EmitCheckValue(Alignment),
-                                  EmitCheckValue(OffsetValue)};
+    llvm::Value *DynamicData[] = {Ptr, Alignment, OffsetValue};
     EmitCheck({std::make_pair(TheCheck, SanitizerKind::SO_Alignment)},
               SanitizerHandler::AlignmentAssumption, StaticData, DynamicData);
   }

--- a/clang/test/CodeGen/catch-alignment-assumption-array.c
+++ b/clang/test/CodeGen/catch-alignment-assumption-array.c
@@ -16,9 +16,9 @@ void *caller(void) {
   // CHECK-SANITIZE-NEXT:               %[[PTRINT:.*]] = ptrtoint ptr %[[ARRAYDECAY]] to i64
   // CHECK-SANITIZE-NEXT:               %[[MASKEDPTR:.*]] = and i64 %[[PTRINT]], 0
   // CHECK-SANITIZE-NEXT:               %[[MASKCOND:.*]] = icmp eq i64 %[[MASKEDPTR]], 0
-  // CHECK-SANITIZE-NEXT:               %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[ARRAYDECAY]] to i64, !nosanitize
   // CHECK-SANITIZE-NEXT:               br i1 %[[MASKCOND]], label %[[CONT:.*]], label %[[HANDLER_ALIGNMENT_ASSUMPTION:[^,]+]],{{.*}} !nosanitize
   // CHECK-SANITIZE:                  [[HANDLER_ALIGNMENT_ASSUMPTION]]:
+  // CHECK-SANITIZE-ANYRECOVER-NEXT:    %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[ARRAYDECAY]] to i64, !nosanitize
   // CHECK-SANITIZE-NORECOVER-NEXT:     call void @__ubsan_handle_alignment_assumption_abort(ptr @[[ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 1, i64 0){{.*}}, !nosanitize
   // CHECK-SANITIZE-RECOVER-NEXT:       call void @__ubsan_handle_alignment_assumption(ptr @[[ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 1, i64 0){{.*}}, !nosanitize
   // CHECK-SANITIZE-TRAP-NEXT:          call void @llvm.ubsantrap(i8 23){{.*}}, !nosanitize

--- a/clang/test/CodeGen/catch-alignment-assumption-attribute-align_value-on-lvalue.cpp
+++ b/clang/test/CodeGen/catch-alignment-assumption-attribute-align_value-on-lvalue.cpp
@@ -24,9 +24,9 @@ char **load_from_ac_struct(struct ac_struct *x) {
   // CHECK-SANITIZE-NEXT:               %[[PTRINT:.*]] = ptrtoint ptr %[[A]] to i64
   // CHECK-SANITIZE-NEXT:               %[[MASKEDPTR:.*]] = and i64 %[[PTRINT]], 4294967295
   // CHECK-SANITIZE-NEXT:               %[[MASKCOND:.*]] = icmp eq i64 %[[MASKEDPTR]], 0
-  // CHECK-SANITIZE-NEXT:               %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[A]] to i64, !nosanitize
   // CHECK-SANITIZE-NEXT:               br i1 %[[MASKCOND]], label %[[CONT:.*]], label %[[HANDLER_ALIGNMENT_ASSUMPTION:[^,]+]],{{.*}} !nosanitize
   // CHECK-SANITIZE:                  [[HANDLER_ALIGNMENT_ASSUMPTION]]:
+  // CHECK-SANITIZE-ANYRECOVER-NEXT:    %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[A]] to i64, !nosanitize
   // CHECK-SANITIZE-NORECOVER-NEXT:     call void @__ubsan_handle_alignment_assumption_abort(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 4294967296, i64 0){{.*}}, !nosanitize
   // CHECK-SANITIZE-RECOVER-NEXT:       call void @__ubsan_handle_alignment_assumption(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 4294967296, i64 0){{.*}}, !nosanitize
   // CHECK-SANITIZE-TRAP-NEXT:          call void @llvm.ubsantrap(i8 23){{.*}}, !nosanitize

--- a/clang/test/CodeGen/catch-alignment-assumption-attribute-align_value-on-paramvar.cpp
+++ b/clang/test/CodeGen/catch-alignment-assumption-attribute-align_value-on-paramvar.cpp
@@ -16,9 +16,9 @@ char **passthrough(__attribute__((align_value(0x100000000))) char **x) {
   // CHECK-SANITIZE-NEXT:               %[[PTRINT:.*]] = ptrtoint ptr %[[X_RELOADED]] to i64
   // CHECK-SANITIZE-NEXT:               %[[MASKEDPTR:.*]] = and i64 %[[PTRINT]], 4294967295
   // CHECK-SANITIZE-NEXT:               %[[MASKCOND:.*]] = icmp eq i64 %[[MASKEDPTR]], 0
-  // CHECK-SANITIZE-NEXT:               %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[X_RELOADED]] to i64, !nosanitize
   // CHECK-SANITIZE-NEXT:               br i1 %[[MASKCOND]], label %[[CONT:.*]], label %[[HANDLER_ALIGNMENT_ASSUMPTION:[^,]+]],{{.*}} !nosanitize
   // CHECK-SANITIZE:                  [[HANDLER_ALIGNMENT_ASSUMPTION]]:
+  // CHECK-SANITIZE-ANYRECOVER-NEXT:    %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[X_RELOADED]] to i64, !nosanitize
   // CHECK-SANITIZE-NORECOVER-NEXT:     call void @__ubsan_handle_alignment_assumption_abort(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 4294967296, i64 0){{.*}}, !nosanitize
   // CHECK-SANITIZE-RECOVER-NEXT:       call void @__ubsan_handle_alignment_assumption(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 4294967296, i64 0){{.*}}, !nosanitize
   // CHECK-SANITIZE-TRAP-NEXT:          call void @llvm.ubsantrap(i8 23){{.*}}, !nosanitize

--- a/clang/test/CodeGen/catch-alignment-assumption-attribute-alloc_align-on-function-variable.cpp
+++ b/clang/test/CodeGen/catch-alignment-assumption-attribute-alloc_align-on-function-variable.cpp
@@ -34,11 +34,11 @@ passthrough(char **x, unsigned long alignment) {
 // CHECK-SANITIZE-NORECOVER-NEXT:    [[TMP2:%.*]] = sub i64 [[TMP1]], 1
 // CHECK-SANITIZE-NORECOVER-NEXT:    [[MASKEDPTR:%.*]] = and i64 [[PTRINT]], [[TMP2]]
 // CHECK-SANITIZE-NORECOVER-NEXT:    [[MASKCOND:%.*]] = icmp eq i64 [[MASKEDPTR]], 0
-// CHECK-SANITIZE-NORECOVER-NEXT:    [[TMP3:%.*]] = ptrtoint ptr [[CALL]] to i64, !nosanitize !2
-// CHECK-SANITIZE-NORECOVER-NEXT:    br i1 [[MASKCOND]], label [[CONT:%.*]], label [[HANDLER_ALIGNMENT_ASSUMPTION:%.*]], !prof [[PROF3:![0-9]+]], !nosanitize !2
+// CHECK-SANITIZE-NORECOVER-NEXT:    br i1 [[MASKCOND]], label [[CONT:%.*]], label [[HANDLER_ALIGNMENT_ASSUMPTION:%.*]], !prof [[PROF2:![0-9]+]], !nosanitize [[META3:![0-9]+]]
 // CHECK-SANITIZE-NORECOVER:       handler.alignment_assumption:
-// CHECK-SANITIZE-NORECOVER-NEXT:    call void @__ubsan_handle_alignment_assumption_abort(ptr @[[GLOB1:[0-9]+]], i64 [[TMP3]], i64 [[TMP1]], i64 0) #[[ATTR3:[0-9]+]], !nosanitize !2
-// CHECK-SANITIZE-NORECOVER-NEXT:    unreachable, !nosanitize !2
+// CHECK-SANITIZE-NORECOVER-NEXT:    [[TMP3:%.*]] = ptrtoint ptr [[CALL]] to i64, !nosanitize [[META3]]
+// CHECK-SANITIZE-NORECOVER-NEXT:    call void @__ubsan_handle_alignment_assumption_abort(ptr @[[GLOB1:[0-9]+]], i64 [[TMP3]], i64 [[TMP1]], i64 0) #[[ATTR3:[0-9]+]], !nosanitize [[META3]]
+// CHECK-SANITIZE-NORECOVER-NEXT:    unreachable, !nosanitize [[META3]]
 // CHECK-SANITIZE-NORECOVER:       cont:
 // CHECK-SANITIZE-NORECOVER-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[CALL]], i64 [[TMP1]]) ]
 // CHECK-SANITIZE-NORECOVER-NEXT:    ret ptr [[CALL]]
@@ -57,11 +57,11 @@ passthrough(char **x, unsigned long alignment) {
 // CHECK-SANITIZE-RECOVER-NEXT:    [[TMP2:%.*]] = sub i64 [[TMP1]], 1
 // CHECK-SANITIZE-RECOVER-NEXT:    [[MASKEDPTR:%.*]] = and i64 [[PTRINT]], [[TMP2]]
 // CHECK-SANITIZE-RECOVER-NEXT:    [[MASKCOND:%.*]] = icmp eq i64 [[MASKEDPTR]], 0
-// CHECK-SANITIZE-RECOVER-NEXT:    [[TMP3:%.*]] = ptrtoint ptr [[CALL]] to i64, !nosanitize !2
-// CHECK-SANITIZE-RECOVER-NEXT:    br i1 [[MASKCOND]], label [[CONT:%.*]], label [[HANDLER_ALIGNMENT_ASSUMPTION:%.*]], !prof [[PROF3:![0-9]+]], !nosanitize !2
+// CHECK-SANITIZE-RECOVER-NEXT:    br i1 [[MASKCOND]], label [[CONT:%.*]], label [[HANDLER_ALIGNMENT_ASSUMPTION:%.*]], !prof [[PROF2:![0-9]+]], !nosanitize [[META3:![0-9]+]]
 // CHECK-SANITIZE-RECOVER:       handler.alignment_assumption:
-// CHECK-SANITIZE-RECOVER-NEXT:    call void @__ubsan_handle_alignment_assumption(ptr @[[GLOB1:[0-9]+]], i64 [[TMP3]], i64 [[TMP1]], i64 0) #[[ATTR3:[0-9]+]], !nosanitize !2
-// CHECK-SANITIZE-RECOVER-NEXT:    br label [[CONT]], !nosanitize !2
+// CHECK-SANITIZE-RECOVER-NEXT:    [[TMP3:%.*]] = ptrtoint ptr [[CALL]] to i64, !nosanitize [[META3]]
+// CHECK-SANITIZE-RECOVER-NEXT:    call void @__ubsan_handle_alignment_assumption(ptr @[[GLOB1:[0-9]+]], i64 [[TMP3]], i64 [[TMP1]], i64 0) #[[ATTR3:[0-9]+]], !nosanitize [[META3]]
+// CHECK-SANITIZE-RECOVER-NEXT:    br label [[CONT]], !nosanitize [[META3]]
 // CHECK-SANITIZE-RECOVER:       cont:
 // CHECK-SANITIZE-RECOVER-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[CALL]], i64 [[TMP1]]) ]
 // CHECK-SANITIZE-RECOVER-NEXT:    ret ptr [[CALL]]
@@ -80,11 +80,10 @@ passthrough(char **x, unsigned long alignment) {
 // CHECK-SANITIZE-TRAP-NEXT:    [[TMP2:%.*]] = sub i64 [[TMP1]], 1
 // CHECK-SANITIZE-TRAP-NEXT:    [[MASKEDPTR:%.*]] = and i64 [[PTRINT]], [[TMP2]]
 // CHECK-SANITIZE-TRAP-NEXT:    [[MASKCOND:%.*]] = icmp eq i64 [[MASKEDPTR]], 0
-// CHECK-SANITIZE-TRAP-NEXT:    [[TMP3:%.*]] = ptrtoint ptr [[CALL]] to i64, !nosanitize !2
-// CHECK-SANITIZE-TRAP-NEXT:    br i1 [[MASKCOND]], label [[CONT:%.*]], label [[TRAP:%.*]], !nosanitize !2
+// CHECK-SANITIZE-TRAP-NEXT:    br i1 [[MASKCOND]], label [[CONT:%.*]], label [[TRAP:%.*]], !nosanitize [[META3:![0-9]+]]
 // CHECK-SANITIZE-TRAP:       trap:
-// CHECK-SANITIZE-TRAP-NEXT:    call void @llvm.ubsantrap(i8 23) #[[ATTR3:[0-9]+]], !nosanitize !2
-// CHECK-SANITIZE-TRAP-NEXT:    unreachable, !nosanitize !2
+// CHECK-SANITIZE-TRAP-NEXT:    call void @llvm.ubsantrap(i8 23) #[[ATTR3:[0-9]+]], !nosanitize [[META3]]
+// CHECK-SANITIZE-TRAP-NEXT:    unreachable, !nosanitize [[META3]]
 // CHECK-SANITIZE-TRAP:       cont:
 // CHECK-SANITIZE-TRAP-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[CALL]], i64 [[TMP1]]) ]
 // CHECK-SANITIZE-TRAP-NEXT:    ret ptr [[CALL]]

--- a/clang/test/CodeGen/catch-alignment-assumption-attribute-alloc_align-on-function.cpp
+++ b/clang/test/CodeGen/catch-alignment-assumption-attribute-alloc_align-on-function.cpp
@@ -39,11 +39,11 @@ passthrough(char **x, unsigned long alignment) {
 // CHECK-SANITIZE-NORECOVER-NEXT:    [[PTRINT:%.*]] = ptrtoint ptr [[CALL]] to i64
 // CHECK-SANITIZE-NORECOVER-NEXT:    [[MASKEDPTR:%.*]] = and i64 [[PTRINT]], 127
 // CHECK-SANITIZE-NORECOVER-NEXT:    [[MASKCOND:%.*]] = icmp eq i64 [[MASKEDPTR]], 0
-// CHECK-SANITIZE-NORECOVER-NEXT:    [[TMP1:%.*]] = ptrtoint ptr [[CALL]] to i64, !nosanitize !2
-// CHECK-SANITIZE-NORECOVER-NEXT:    br i1 [[MASKCOND]], label [[CONT:%.*]], label [[HANDLER_ALIGNMENT_ASSUMPTION:%.*]], !prof [[PROF3:![0-9]+]], !nosanitize !2
+// CHECK-SANITIZE-NORECOVER-NEXT:    br i1 [[MASKCOND]], label [[CONT:%.*]], label [[HANDLER_ALIGNMENT_ASSUMPTION:%.*]], !prof [[PROF2:![0-9]+]], !nosanitize [[META3:![0-9]+]]
 // CHECK-SANITIZE-NORECOVER:       handler.alignment_assumption:
-// CHECK-SANITIZE-NORECOVER-NEXT:    call void @__ubsan_handle_alignment_assumption_abort(ptr @[[GLOB1:[0-9]+]], i64 [[TMP1]], i64 128, i64 0) #[[ATTR3:[0-9]+]], !nosanitize !2
-// CHECK-SANITIZE-NORECOVER-NEXT:    unreachable, !nosanitize !2
+// CHECK-SANITIZE-NORECOVER-NEXT:    [[TMP1:%.*]] = ptrtoint ptr [[CALL]] to i64, !nosanitize [[META3]]
+// CHECK-SANITIZE-NORECOVER-NEXT:    call void @__ubsan_handle_alignment_assumption_abort(ptr @[[GLOB1:[0-9]+]], i64 [[TMP1]], i64 128, i64 0) #[[ATTR3:[0-9]+]], !nosanitize [[META3]]
+// CHECK-SANITIZE-NORECOVER-NEXT:    unreachable, !nosanitize [[META3]]
 // CHECK-SANITIZE-NORECOVER:       cont:
 // CHECK-SANITIZE-NORECOVER-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[CALL]], i64 128) ]
 // CHECK-SANITIZE-NORECOVER-NEXT:    ret ptr [[CALL]]
@@ -58,11 +58,11 @@ passthrough(char **x, unsigned long alignment) {
 // CHECK-SANITIZE-RECOVER-NEXT:    [[PTRINT:%.*]] = ptrtoint ptr [[CALL]] to i64
 // CHECK-SANITIZE-RECOVER-NEXT:    [[MASKEDPTR:%.*]] = and i64 [[PTRINT]], 127
 // CHECK-SANITIZE-RECOVER-NEXT:    [[MASKCOND:%.*]] = icmp eq i64 [[MASKEDPTR]], 0
-// CHECK-SANITIZE-RECOVER-NEXT:    [[TMP1:%.*]] = ptrtoint ptr [[CALL]] to i64, !nosanitize !2
-// CHECK-SANITIZE-RECOVER-NEXT:    br i1 [[MASKCOND]], label [[CONT:%.*]], label [[HANDLER_ALIGNMENT_ASSUMPTION:%.*]], !prof [[PROF3:![0-9]+]], !nosanitize !2
+// CHECK-SANITIZE-RECOVER-NEXT:    br i1 [[MASKCOND]], label [[CONT:%.*]], label [[HANDLER_ALIGNMENT_ASSUMPTION:%.*]], !prof [[PROF2:![0-9]+]], !nosanitize [[META3:![0-9]+]]
 // CHECK-SANITIZE-RECOVER:       handler.alignment_assumption:
-// CHECK-SANITIZE-RECOVER-NEXT:    call void @__ubsan_handle_alignment_assumption(ptr @[[GLOB1:[0-9]+]], i64 [[TMP1]], i64 128, i64 0) #[[ATTR3:[0-9]+]], !nosanitize !2
-// CHECK-SANITIZE-RECOVER-NEXT:    br label [[CONT]], !nosanitize !2
+// CHECK-SANITIZE-RECOVER-NEXT:    [[TMP1:%.*]] = ptrtoint ptr [[CALL]] to i64, !nosanitize [[META3]]
+// CHECK-SANITIZE-RECOVER-NEXT:    call void @__ubsan_handle_alignment_assumption(ptr @[[GLOB1:[0-9]+]], i64 [[TMP1]], i64 128, i64 0) #[[ATTR3:[0-9]+]], !nosanitize [[META3]]
+// CHECK-SANITIZE-RECOVER-NEXT:    br label [[CONT]], !nosanitize [[META3]]
 // CHECK-SANITIZE-RECOVER:       cont:
 // CHECK-SANITIZE-RECOVER-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[CALL]], i64 128) ]
 // CHECK-SANITIZE-RECOVER-NEXT:    ret ptr [[CALL]]
@@ -77,11 +77,10 @@ passthrough(char **x, unsigned long alignment) {
 // CHECK-SANITIZE-TRAP-NEXT:    [[PTRINT:%.*]] = ptrtoint ptr [[CALL]] to i64
 // CHECK-SANITIZE-TRAP-NEXT:    [[MASKEDPTR:%.*]] = and i64 [[PTRINT]], 127
 // CHECK-SANITIZE-TRAP-NEXT:    [[MASKCOND:%.*]] = icmp eq i64 [[MASKEDPTR]], 0
-// CHECK-SANITIZE-TRAP-NEXT:    [[TMP1:%.*]] = ptrtoint ptr [[CALL]] to i64, !nosanitize !2
-// CHECK-SANITIZE-TRAP-NEXT:    br i1 [[MASKCOND]], label [[CONT:%.*]], label [[TRAP:%.*]], !nosanitize !2
+// CHECK-SANITIZE-TRAP-NEXT:    br i1 [[MASKCOND]], label [[CONT:%.*]], label [[TRAP:%.*]], !prof [[PROF2:![0-9]+]], !nosanitize [[META3:![0-9]+]]
 // CHECK-SANITIZE-TRAP:       trap:
-// CHECK-SANITIZE-TRAP-NEXT:    call void @llvm.ubsantrap(i8 23) #[[ATTR3:[0-9]+]], !nosanitize !2
-// CHECK-SANITIZE-TRAP-NEXT:    unreachable, !nosanitize !2
+// CHECK-SANITIZE-TRAP-NEXT:    call void @llvm.ubsantrap(i8 23) #[[ATTR3:[0-9]+]], !nosanitize [[META3]]
+// CHECK-SANITIZE-TRAP-NEXT:    unreachable, !nosanitize [[META3]]
 // CHECK-SANITIZE-TRAP:       cont:
 // CHECK-SANITIZE-TRAP-NEXT:    call void @llvm.assume(i1 true) [ "align"(ptr [[CALL]], i64 128) ]
 // CHECK-SANITIZE-TRAP-NEXT:    ret ptr [[CALL]]

--- a/clang/test/CodeGen/catch-alignment-assumption-attribute-assume_aligned-on-function-two-params.cpp
+++ b/clang/test/CodeGen/catch-alignment-assumption-attribute-assume_aligned-on-function-two-params.cpp
@@ -28,9 +28,9 @@ char **caller(char **x) {
   // CHECK-SANITIZE-NEXT:               %[[OFFSETPTR:.*]] = sub i64 %[[PTRINT]], 42
   // CHECK-SANITIZE-NEXT:               %[[MASKEDPTR:.*]] = and i64 %[[OFFSETPTR]], 4294967295
   // CHECK-SANITIZE-NEXT:               %[[MASKCOND:.*]] = icmp eq i64 %[[MASKEDPTR]], 0
-  // CHECK-SANITIZE-NEXT:               %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[X_RETURNED]] to i64, !nosanitize
   // CHECK-SANITIZE-NEXT:               br i1 %[[MASKCOND]], label %[[CONT:.*]], label %[[HANDLER_ALIGNMENT_ASSUMPTION:[^,]+]],{{.*}} !nosanitize
   // CHECK-SANITIZE:                  [[HANDLER_ALIGNMENT_ASSUMPTION]]:
+  // CHECK-SANITIZE-ANYRECOVER-NEXT:               %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[X_RETURNED]] to i64, !nosanitize
   // CHECK-SANITIZE-NORECOVER-NEXT:     call void @__ubsan_handle_alignment_assumption_abort(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 4294967296, i64 42){{.*}}, !nosanitize
   // CHECK-SANITIZE-RECOVER-NEXT:       call void @__ubsan_handle_alignment_assumption(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 4294967296, i64 42){{.*}}, !nosanitize
   // CHECK-SANITIZE-TRAP-NEXT:          call void @llvm.ubsantrap(i8 23){{.*}}, !nosanitize

--- a/clang/test/CodeGen/catch-alignment-assumption-attribute-assume_aligned-on-function.cpp
+++ b/clang/test/CodeGen/catch-alignment-assumption-attribute-assume_aligned-on-function.cpp
@@ -28,9 +28,9 @@ char **caller(char **x) {
   // CHECK-SANITIZE-NEXT:               %[[PTRINT:.*]] = ptrtoint ptr %[[X_RETURNED]] to i64
   // CHECK-SANITIZE-NEXT:               %[[MASKEDPTR:.*]] = and i64 %[[PTRINT]], 127
   // CHECK-SANITIZE-NEXT:               %[[MASKCOND:.*]] = icmp eq i64 %[[MASKEDPTR]], 0
-  // CHECK-SANITIZE-NEXT:               %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[X_RETURNED]] to i64, !nosanitize
   // CHECK-SANITIZE-NEXT:               br i1 %[[MASKCOND]], label %[[CONT:.*]], label %[[HANDLER_ALIGNMENT_ASSUMPTION:[^,]+]],{{.*}} !nosanitize
   // CHECK-SANITIZE:                  [[HANDLER_ALIGNMENT_ASSUMPTION]]:
+  // CHECK-SANITIZE-ANYRECOVER-NEXT:    %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[X_RETURNED]] to i64, !nosanitize
   // CHECK-SANITIZE-NORECOVER-NEXT:     call void @__ubsan_handle_alignment_assumption_abort(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 128, i64 0){{.*}}, !nosanitize
   // CHECK-SANITIZE-RECOVER-NEXT:       call void @__ubsan_handle_alignment_assumption(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 128, i64 0){{.*}}, !nosanitize
   // CHECK-SANITIZE-TRAP-NEXT:          call void @llvm.ubsantrap(i8 23){{.*}}, !nosanitize

--- a/clang/test/CodeGen/catch-alignment-assumption-builtin_assume_aligned-polymorphism.cpp
+++ b/clang/test/CodeGen/catch-alignment-assumption-builtin_assume_aligned-polymorphism.cpp
@@ -42,9 +42,9 @@ void *f(C *c) {
   // CHECK-SANITIZE-NEXT:                 %[[PTRINT:.*]] = ptrtoint ptr %[[CAST_RESULT]] to i64
   // CHECK-SANITIZE-NEXT:                 %[[MASKEDPTR:.*]] = and i64 %[[PTRINT]], 7
   // CHECK-SANITIZE-NEXT:                 %[[MASKCOND:.*]] = icmp eq i64 %[[MASKEDPTR]], 0
-  // CHECK-SANITIZE-NEXT:                 %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[CAST_RESULT]] to i64, !nosanitize
   // CHECK-SANITIZE-NEXT:                 br i1 %[[MASKCOND]], label %[[CONT1:.*]], label %[[HANDLER_ALIGNMENT_ASSUMPTION:[^,]+]],{{.*}} !nosanitize
   // CHECK-SANITIZE:                    [[HANDLER_ALIGNMENT_ASSUMPTION]]:
+  // CHECK-SANITIZE-ANYRECOVER-NEXT:      %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[CAST_RESULT]] to i64, !nosanitize
   // CHECK-SANITIZE-NORECOVER-NEXT:       call void @__ubsan_handle_alignment_assumption_abort(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 8, i64 0){{.*}}, !nosanitize
   // CHECK-SANITIZE-RECOVER-NEXT:         call void @__ubsan_handle_alignment_assumption(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 8, i64 0){{.*}}, !nosanitize
   // CHECK-SANITIZE-TRAP-NEXT:            call void @llvm.ubsantrap(i8 23){{.*}}, !nosanitize

--- a/clang/test/CodeGen/catch-alignment-assumption-builtin_assume_aligned-three-params-variable.cpp
+++ b/clang/test/CodeGen/catch-alignment-assumption-builtin_assume_aligned-three-params-variable.cpp
@@ -19,9 +19,9 @@ void *caller(char **x, unsigned long offset) {
   // CHECK-SANITIZE-NEXT:               %[[OFFSETPTR:.*]] = sub i64 %[[PTRINT]], %[[OFFSET_RELOADED]]
   // CHECK-SANITIZE-NEXT:               %[[MASKEDPTR:.*]] = and i64 %[[OFFSETPTR]], 4294967295
   // CHECK-SANITIZE-NEXT:               %[[MASKCOND:.*]] = icmp eq i64 %[[MASKEDPTR]], 0
-  // CHECK-SANITIZE-NEXT:               %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[X_RELOADED]] to i64, !nosanitize
   // CHECK-SANITIZE-NEXT:               br i1 %[[MASKCOND]], label %[[CONT:.*]], label %[[HANDLER_ALIGNMENT_ASSUMPTION:[^,]+]],{{.*}} !nosanitize
   // CHECK-SANITIZE:                  [[HANDLER_ALIGNMENT_ASSUMPTION]]:
+  // CHECK-SANITIZE-ANYRECOVER-NEXT:    %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[X_RELOADED]] to i64, !nosanitize
   // CHECK-SANITIZE-NORECOVER-NEXT:     call void @__ubsan_handle_alignment_assumption_abort(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 4294967296, i64 %[[OFFSET_RELOADED]]){{.*}}, !nosanitize
   // CHECK-SANITIZE-RECOVER-NEXT:       call void @__ubsan_handle_alignment_assumption(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 4294967296, i64 %[[OFFSET_RELOADED]]){{.*}}, !nosanitize
   // CHECK-SANITIZE-TRAP-NEXT:          call void @llvm.ubsantrap(i8 23){{.*}}, !nosanitize

--- a/clang/test/CodeGen/catch-alignment-assumption-builtin_assume_aligned-three-params.cpp
+++ b/clang/test/CodeGen/catch-alignment-assumption-builtin_assume_aligned-three-params.cpp
@@ -16,9 +16,9 @@ void *caller(char **x) {
   // CHECK-SANITIZE-NEXT:               %[[OFFSETPTR:.*]] = sub i64 %[[PTRINT]], 42
   // CHECK-SANITIZE-NEXT:               %[[MASKEDPTR:.*]] = and i64 %[[OFFSETPTR]], 4294967295
   // CHECK-SANITIZE-NEXT:               %[[MASKCOND:.*]] = icmp eq i64 %[[MASKEDPTR]], 0
-  // CHECK-SANITIZE-NEXT:               %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[X_RELOADED]] to i64, !nosanitize
   // CHECK-SANITIZE-NEXT:               br i1 %[[MASKCOND]], label %[[CONT:.*]], label %[[HANDLER_ALIGNMENT_ASSUMPTION:[^,]+]],{{.*}} !nosanitize
   // CHECK-SANITIZE:                  [[HANDLER_ALIGNMENT_ASSUMPTION]]:
+  // CHECK-SANITIZE-ANYRECOVER-NEXT:    %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[X_RELOADED]] to i64, !nosanitize
   // CHECK-SANITIZE-NORECOVER-NEXT:     call void @__ubsan_handle_alignment_assumption_abort(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 4294967296, i64 42){{.*}}, !nosanitize
   // CHECK-SANITIZE-RECOVER-NEXT:       call void @__ubsan_handle_alignment_assumption(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 4294967296, i64 42){{.*}}, !nosanitize
   // CHECK-SANITIZE-TRAP-NEXT:          call void @llvm.ubsantrap(i8 23){{.*}}, !nosanitize

--- a/clang/test/CodeGen/catch-alignment-assumption-builtin_assume_aligned-two-params.cpp
+++ b/clang/test/CodeGen/catch-alignment-assumption-builtin_assume_aligned-two-params.cpp
@@ -15,9 +15,9 @@ void *caller(char **x) {
   // CHECK-SANITIZE-NEXT:               %[[PTRINT:.*]] = ptrtoint ptr %[[X_RELOADED]] to i64
   // CHECK-SANITIZE-NEXT:               %[[MASKEDPTR:.*]] = and i64 %[[PTRINT]], 4294967295
   // CHECK-SANITIZE-NEXT:               %[[MASKCOND:.*]] = icmp eq i64 %[[MASKEDPTR]], 0
-  // CHECK-SANITIZE-NEXT:               %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[X_RELOADED]] to i64, !nosanitize
   // CHECK-SANITIZE-NEXT:               br i1 %[[MASKCOND]], label %[[CONT:.*]], label %[[HANDLER_ALIGNMENT_ASSUMPTION:[^,]+]],{{.*}} !nosanitize
   // CHECK-SANITIZE:                  [[HANDLER_ALIGNMENT_ASSUMPTION]]:
+  // CHECK-SANITIZE-ANYRECOVER-NEXT:    %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[X_RELOADED]] to i64, !nosanitize
   // CHECK-SANITIZE-NORECOVER-NEXT:     call void @__ubsan_handle_alignment_assumption_abort(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 4294967296, i64 0){{.*}}, !nosanitize
   // CHECK-SANITIZE-RECOVER-NEXT:       call void @__ubsan_handle_alignment_assumption(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 4294967296, i64 0){{.*}}, !nosanitize
   // CHECK-SANITIZE-TRAP-NEXT:          call void @llvm.ubsantrap(i8 23){{.*}}, !nosanitize

--- a/clang/test/CodeGen/catch-alignment-assumption-openmp.cpp
+++ b/clang/test/CodeGen/catch-alignment-assumption-openmp.cpp
@@ -15,9 +15,9 @@ void func(char *data) {
   // CHECK-SANITIZE-NEXT:   %[[PTRINT:.*]] = ptrtoint ptr %[[DATA_RELOADED]] to i64
   // CHECK-SANITIZE-NEXT:   %[[MASKEDPTR:.*]] = and i64 %[[PTRINT]], 4294967295
   // CHECK-SANITIZE-NEXT:   %[[MASKCOND:.*]] = icmp eq i64 %[[MASKEDPTR]], 0
-  // CHECK-SANITIZE-NEXT:               %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[DATA_RELOADED]] to i64, !nosanitize
   // CHECK-SANITIZE-NEXT:               br i1 %[[MASKCOND]], label %[[CONT:.*]], label %[[HANDLER_ALIGNMENT_ASSUMPTION:[^,]+]],{{.*}} !nosanitize
   // CHECK-SANITIZE:                  [[HANDLER_ALIGNMENT_ASSUMPTION]]:
+  // CHECK-SANITIZE-ANYRECOVER-NEXT:    %[[PTRINT_DUP:.*]] = ptrtoint ptr %[[DATA_RELOADED]] to i64, !nosanitize
   // CHECK-SANITIZE-NORECOVER-NEXT:     call void @__ubsan_handle_alignment_assumption_abort(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 4294967296, i64 0){{.*}}, !nosanitize
   // CHECK-SANITIZE-RECOVER-NEXT:       call void @__ubsan_handle_alignment_assumption(ptr @[[LINE_100_ALIGNMENT_ASSUMPTION]], i64 %[[PTRINT_DUP]], i64 4294967296, i64 0){{.*}}, !nosanitize
   // CHECK-SANITIZE-TRAP-NEXT:          call void @llvm.ubsantrap(i8 23){{.*}}, !nosanitize


### PR DESCRIPTION
`EmitCheckValue` is called inside `EmitCheck`:
https://github.com/llvm/llvm-project/blob/b122956390a6877536927c2b073a0b99f8b9704f/clang/lib/CodeGen/CGExpr.cpp#L3739
The outside calls are redundant because `EmitCheckValue(EmitCheckValue(V))` always returns `EmitCheckValue(V)`.

Required by https://github.com/llvm/llvm-project/pull/135135.
