### PR TITLE
[cpp23] Remove usage of std::aligned_union<> in llvm

### DIFF
--- a/compiler-rt/lib/orc/error.h
+++ b/compiler-rt/lib/orc/error.h
@@ -367,8 +367,8 @@ private:
   }
 
   union {
-    std::aligned_union_t<1, storage_type> TStorage;
-    std::aligned_union_t<1, error_type> ErrorStorage;
+    alignas(storage_type) char TStorage[sizeof(storage_type)];
+    alignas(error_type) char ErrorStorage[sizeof(error_type)];
   };
 
   bool HasError : 1;

--- a/llvm/include/llvm/ADT/TrieRawHashMap.h
+++ b/llvm/include/llvm/ADT/TrieRawHashMap.h
@@ -72,7 +72,7 @@ public:
 private:
   template <class T> struct AllocValueType {
     char Base[TrieContentBaseSize];
-    std::aligned_union_t<sizeof(T), T> Content;
+    alignas(T) char Content[sizeof(T)];
   };
 
 protected:


### PR DESCRIPTION
std::aligned_union<> is deprecated in C++23. See more details in the linked bug.

Bug: https://crbug.com/388068052