### PR TITLE
Support '-fmodule-file-home-is-cwd' for C++ modules.

### DIFF
--- a/clang/test/Modules/relocatable-modules.cpp
+++ b/clang/test/Modules/relocatable-modules.cpp
@@ -1,0 +1,54 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+// RUN: cd %t
+
+// RUN: %clang_cc1 -std=c++20 -emit-header-unit -xc++-user-header hu-01.h \
+// RUN:   -fmodule-name=hu-01 -o hu-01.pcm
+
+// RUN: %clang_cc1 -std=c++20 -emit-header-unit -xc++-user-header hu-02.h \
+// RUN:  -Wno-experimental-header-units -fmodule-file=hu-01.pcm -o hu-02-abs.pcm
+
+// RUN: %clang_cc1 -std=c++20 -emit-header-unit -xc++-user-header hu-02.h \
+// RUN:  -Wno-experimental-header-units -fmodule-file=hu-01.pcm -o hu-02-rel.pcm \
+// RUN:  -fmodule-file-home-is-cwd
+
+// RUN: %clang -module-file-info hu-02-abs.pcm | FileCheck %s --check-prefix=IMPORT-ABS -DPREFIX=%t
+// IMPORT-ABS: Imports module 'hu-01': [[PREFIX]]{{/|\\}}hu-01.pcm
+
+// RUN: %clang -module-file-info hu-02-rel.pcm | FileCheck %s --check-prefix=IMPORT-REL
+// IMPORT-REL: Imports module 'hu-01': hu-01.pcm
+
+// RUN: llvm-bcanalyzer --dump --disable-histogram %t/hu-02-abs.pcm \
+// RUN:   | FileCheck %s --check-prefix=INPUT-ABS -DPREFIX=%t
+// INPUT-ABS: <INPUT_FILE {{.*}}/> blob data = '[[PREFIX]]{{/|\\}}hu-02.h'
+
+// RUN: llvm-bcanalyzer --dump --disable-histogram %t/hu-02-rel.pcm \
+// RUN:   | FileCheck %s --check-prefix=INPUT-REL
+// INPUT-REL: <INPUT_FILE {{.*}}/> blob data = 'hu-02.h'
+
+//--- hu-01.h
+inline void f() {}
+
+//--- hu-02.h
+import "hu-01.h";
+
+inline void g() {
+  f();
+}
+
+// RUN: %clang_cc1 -std=c++20 -emit-module-interface %t/a.cppm -o %t/a-abs.pcm
+
+// RUN: %clang_cc1 -std=c++20 -emit-module-interface %t/a.cppm -o %t/a-rel.pcm \
+// RUN:   -fmodule-file-home-is-cwd
+
+// RUN: llvm-bcanalyzer --dump --disable-histogram %t/a-abs.pcm \
+// RUN:   | FileCheck %s --check-prefix=M-INPUT-ABS -DPREFIX=%t
+// M-INPUT-ABS: <INPUT_FILE {{.*}}/> blob data = '[[PREFIX]]{{/|\\}}a.cppm'
+
+// RUN: llvm-bcanalyzer --dump --disable-histogram %t/a-rel.pcm \
+// RUN:   | FileCheck %s --check-prefix=M-INPUT-REL
+// M-INPUT-REL: <INPUT_FILE {{.*}}/> blob data = 'a.cppm'
+
+//--- a.cppm
+export module a;


### PR DESCRIPTION
`-fmodule-file-home-is-cwd` was added in https://github.com/llvm/llvm-project/commit/646e502de0d854cb3ecaca90ab52bebfe59a40cd to support relocatable PCMs for ObjC and Clang modules. This PR extends the functionality to allow C++ modules to be relocatable.

C++ named modules today do not directly write the imported PCM's path (presumably because we know we have to be able to discover the location of the PCM through one of the `-fmodule-file=<name>=<pcm>` flags). However, the `INPUT_FILE` fields of the PCM still contains absolute paths of the input files. @ChuanqiXu9 mentioned that there's been a discussion of `-fmodules-embed-all-files` in https://github.com/llvm/llvm-project/issues/72383 that would embed the input files into the PCM itself. My understanding is that this effectively ignores the absolute paths of the input files in the PCM. Without `-fmodules-embed-all-files` though, the input files remain absolute paths today, which can cause unnecessary cache misses in distributed builds.

My actual use case is for C++ header units. It has the same problem of absolute path input files, but has the additional problem that header units **do** directly write the imported PCM's absolute path. Since header units technically are anonymous and cannot rely on `-fmodule-file=<name>=<pcm>` to discover the location of the PCM, it doesn't seem like it's feasible for header units to simply omit this like named modules do... but I'm not certain about this.

The proposed fix here is to extend `-fmodule-file-home-is-cwd` which already exists, such that
- header units can store relative paths of the imported PCMs, and
- relative paths of input files can be stored for both header units and named modules