### PR TITLE
reland [clang-doc][NFC] refactor out file helpers

### DIFF
--- a/clang-tools-extra/clang-doc/CMakeLists.txt
+++ b/clang-tools-extra/clang-doc/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LLVM_LINK_COMPONENTS
   BitstreamReader
   FrontendOpenMP
   )
+add_subdirectory(support)
 
 add_clang_library(clangDoc STATIC
   BitcodeReader.cpp
@@ -23,6 +24,7 @@ add_clang_library(clangDoc STATIC
 
 clang_target_link_libraries(clangDoc
   PRIVATE
+  clangDocSupport        
   clangAnalysis
   clangAST
   clangASTMatchers

--- a/clang-tools-extra/clang-doc/CMakeLists.txt
+++ b/clang-tools-extra/clang-doc/CMakeLists.txt
@@ -24,7 +24,6 @@ add_clang_library(clangDoc STATIC
 
 clang_target_link_libraries(clangDoc
   PRIVATE
-  clangDocSupport        
   clangAnalysis
   clangAST
   clangASTMatchers
@@ -34,6 +33,11 @@ clang_target_link_libraries(clangDoc
   clangLex
   clangTooling
   clangToolingCore
+  )
+
+target_link_libraries(clangDoc
+  PRIVATE
+  clangDocSupport      
   )
 
 add_subdirectory(tool)

--- a/clang-tools-extra/clang-doc/HTMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLGenerator.cpp
@@ -8,6 +8,7 @@
 
 #include "Generators.h"
 #include "Representation.h"
+#include "support/File.h"
 #include "clang/Basic/Version.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
@@ -1143,23 +1144,6 @@ static llvm::Error genIndex(const ClangDocContext &CDCtx) {
 
   F.render(IndexOS);
 
-  return llvm::Error::success();
-}
-
-static llvm::Error copyFile(StringRef FilePath, StringRef OutDirectory) {
-  llvm::SmallString<128> PathWrite;
-  llvm::sys::path::native(OutDirectory, PathWrite);
-  llvm::sys::path::append(PathWrite, llvm::sys::path::filename(FilePath));
-  llvm::SmallString<128> PathRead;
-  llvm::sys::path::native(FilePath, PathRead);
-  std::error_code OK;
-  std::error_code FileErr = llvm::sys::fs::copy_file(PathRead, PathWrite);
-  if (FileErr != OK) {
-    return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                   "error creating file " +
-                                       llvm::sys::path::filename(FilePath) +
-                                       ": " + FileErr.message() + "\n");
-  }
   return llvm::Error::success();
 }
 

--- a/clang-tools-extra/clang-doc/HTMLGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLGenerator.cpp
@@ -252,47 +252,6 @@ static void appendVector(std::vector<Derived> &&New,
   std::move(New.begin(), New.end(), std::back_inserter(Original));
 }
 
-// Compute the relative path from an Origin directory to a Destination directory
-static SmallString<128> computeRelativePath(StringRef Destination,
-                                            StringRef Origin) {
-  // If Origin is empty, the relative path to the Destination is its complete
-  // path.
-  if (Origin.empty())
-    return Destination;
-
-  // The relative path is an empty path if both directories are the same.
-  if (Destination == Origin)
-    return {};
-
-  // These iterators iterate through each of their parent directories
-  llvm::sys::path::const_iterator FileI = llvm::sys::path::begin(Destination);
-  llvm::sys::path::const_iterator FileE = llvm::sys::path::end(Destination);
-  llvm::sys::path::const_iterator DirI = llvm::sys::path::begin(Origin);
-  llvm::sys::path::const_iterator DirE = llvm::sys::path::end(Origin);
-  // Advance both iterators until the paths differ. Example:
-  //    Destination = A/B/C/D
-  //    Origin      = A/B/E/F
-  // FileI will point to C and DirI to E. The directories behind them is the
-  // directory they share (A/B).
-  while (FileI != FileE && DirI != DirE && *FileI == *DirI) {
-    ++FileI;
-    ++DirI;
-  }
-  SmallString<128> Result; // This will hold the resulting path.
-  // Result has to go up one directory for each of the remaining directories in
-  // Origin
-  while (DirI != DirE) {
-    llvm::sys::path::append(Result, "..");
-    ++DirI;
-  }
-  // Result has to append each of the remaining directories in Destination
-  while (FileI != FileE) {
-    llvm::sys::path::append(Result, *FileI);
-    ++FileI;
-  }
-  return Result;
-}
-
 // HTML generation
 
 static std::vector<std::unique_ptr<TagNode>>

--- a/clang-tools-extra/clang-doc/support/CMakeLists.txt
+++ b/clang-tools-extra/clang-doc/support/CMakeLists.txt
@@ -1,0 +1,9 @@
+# clang-doc/support contains support libraries that do not depend
+# on clang either programmatically or conceptually.
+set(LLVM_LINK_COMPONENTS
+  Support
+  )
+
+add_clang_library(clangDocSupport STATIC
+  File.cpp
+  )

--- a/clang-tools-extra/clang-doc/support/File.cpp
+++ b/clang-tools-extra/clang-doc/support/File.cpp
@@ -1,4 +1,4 @@
-//===-- FileHelpersClangDoc.cpp - File Helpers -------------------*- C++-*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang-tools-extra/clang-doc/support/File.cpp
+++ b/clang-tools-extra/clang-doc/support/File.cpp
@@ -1,0 +1,74 @@
+//===-- FileHelpersClangDoc.cpp - File Helpers -------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include "File.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+
+namespace clang {
+namespace doc {
+
+llvm::Error
+copyFile(llvm::StringRef FilePath, llvm::StringRef OutDirectory) {
+  llvm::SmallString<128> PathWrite;
+  llvm::sys::path::native(OutDirectory, PathWrite);
+  llvm::sys::path::append(PathWrite, llvm::sys::path::filename(FilePath));
+  llvm::SmallString<128> PathRead;
+  llvm::sys::path::native(FilePath, PathRead);
+  std::error_code FileErr = llvm::sys::fs::copy_file(PathRead, PathWrite);
+  if (FileErr) {
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "error creating file " +
+                                       llvm::sys::path::filename(FilePath) +
+                                       ": " + FileErr.message() + "\n");
+  }
+  return llvm::Error::success();
+}
+
+
+llvm::SmallString<128> computeRelativePath(llvm::StringRef Destination,
+                                           llvm::StringRef Origin) {
+  // If Origin is empty, the relative path to the Destination is its complete
+  // path.
+  if (Origin.empty())
+    return Destination;
+  
+  // The relative path is an empty path if both directories are the same.
+  if (Destination == Origin)
+    return {};
+
+  // These iterators iterate through each of their parent directories
+  llvm::sys::path::const_iterator FileI = llvm::sys::path::begin(Destination);
+  llvm::sys::path::const_iterator FileE = llvm::sys::path::end(Destination);
+  llvm::sys::path::const_iterator DirI = llvm::sys::path::begin(Origin);
+  llvm::sys::path::const_iterator DirE = llvm::sys::path::end(Origin);
+  // Advance both iterators until the paths differ. Example:
+  //    Destination = A/B/C/D
+  //    Origin      = A/B/E/F
+  // FileI will point to C and DirI to E. The directories behind them is the
+  // directory they share (A/B).
+  while (FileI != FileE && DirI != DirE && *FileI == *DirI) {
+    ++FileI;
+    ++DirI;
+  }
+  llvm::SmallString<128> Result; // This will hold the resulting path.
+  // Result has to go up one directory for each of the remaining directories in
+  // Origin
+  while (DirI != DirE) {
+    llvm::sys::path::append(Result, "..");
+    ++DirI;
+  }
+  // Result has to append each of the remaining directories in Destination
+  while (FileI != FileE) {
+    llvm::sys::path::append(Result, *FileI);
+    ++FileI;
+  }
+  return Result;
+}
+
+} // namespace doc
+} // namespace clang

--- a/clang-tools-extra/clang-doc/support/File.cpp
+++ b/clang-tools-extra/clang-doc/support/File.cpp
@@ -28,9 +28,8 @@ llvm::Error copyFile(llvm::StringRef FilePath, llvm::StringRef OutDirectory) {
   return llvm::Error::success();
 }
 
-
-llvm::SmallString<128> 
-computeRelativePath(llvm::StringRef Destination, llvm::StringRef Origin) {
+llvm::SmallString<128> computeRelativePath(llvm::StringRef Destination,
+                                           llvm::StringRef Origin) {
   // If Origin is empty, the relative path to the Destination is its complete
   // path.
   if (Origin.empty())

--- a/clang-tools-extra/clang-doc/support/File.cpp
+++ b/clang-tools-extra/clang-doc/support/File.cpp
@@ -12,8 +12,7 @@
 namespace clang {
 namespace doc {
 
-llvm::Error
-copyFile(llvm::StringRef FilePath, llvm::StringRef OutDirectory) {
+llvm::Error copyFile(llvm::StringRef FilePath, llvm::StringRef OutDirectory) {
   llvm::SmallString<128> PathWrite;
   llvm::sys::path::native(OutDirectory, PathWrite);
   llvm::sys::path::append(PathWrite, llvm::sys::path::filename(FilePath));
@@ -30,13 +29,13 @@ copyFile(llvm::StringRef FilePath, llvm::StringRef OutDirectory) {
 }
 
 
-llvm::SmallString<128> computeRelativePath(llvm::StringRef Destination,
-                                           llvm::StringRef Origin) {
+llvm::SmallString<128> 
+computeRelativePath(llvm::StringRef Destination, llvm::StringRef Origin) {
   // If Origin is empty, the relative path to the Destination is its complete
   // path.
   if (Origin.empty())
     return Destination;
-  
+
   // The relative path is an empty path if both directories are the same.
   if (Destination == Origin)
     return {};

--- a/clang-tools-extra/clang-doc/support/File.h
+++ b/clang-tools-extra/clang-doc/support/File.h
@@ -14,11 +14,10 @@
 namespace clang {
 namespace doc {
 
-llvm::Error 
-copyFile(llvm::StringRef FilePath, llvm::StringRef OutDirectory);
+llvm::Error copyFile(llvm::StringRef FilePath, llvm::StringRef OutDirectory);
 
-llvm::SmallString<128> 
-computeRelativePath(llvm::StringRef Destination,llvm::StringRef Origin);
+llvm::SmallString<128> computeRelativePath(llvm::StringRef Destination,
+                                           llvm::StringRef Origin);
 
 } // namespace doc
 } // namespace clang

--- a/clang-tools-extra/clang-doc/support/File.h
+++ b/clang-tools-extra/clang-doc/support/File.h
@@ -1,12 +1,12 @@
-//===-- File.h --- File Helpers -------------------*- C++-*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_FILEHELPER_H
-#define LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_FILEHELPER_H
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_FILE_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_FILE_H
 
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Error.h"
@@ -22,4 +22,4 @@ llvm::SmallString<128> computeRelativePath(llvm::StringRef Destination,
 } // namespace doc
 } // namespace clang
 
-#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_FILEHELPER_H
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_FILE_H

--- a/clang-tools-extra/clang-doc/support/File.h
+++ b/clang-tools-extra/clang-doc/support/File.h
@@ -1,0 +1,26 @@
+//===-- File.h --- File Helpers -------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_FILEHELPER_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_FILEHELPER_H
+
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/Error.h"
+
+namespace clang {
+namespace doc {
+
+llvm::Error 
+copyFile(llvm::StringRef FilePath, llvm::StringRef OutDirectory);
+
+llvm::SmallString<128> 
+computeRelativePath(llvm::StringRef Destination,llvm::StringRef Origin);
+
+} // namespace doc
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_FILEHELPER_H


### PR DESCRIPTION
Split from https://github.com/llvm/llvm-project/pull/133161

refactor the code to extract file helpers used in HTML generators for use in other generators for clang-doc

This patch fixes the error where compiling with -DLLVM_LINK_LLVM_DYLIB=ON broke the buildbot