### PR TITLE
[SPIR-V] Don't emit OpLifetime for Vulkan

### DIFF
--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/lifetime.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/lifetime.ll
@@ -1,16 +1,15 @@
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefixes=CHECK,CL
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefixes=CL
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefixes=CHECK,CL
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefixes=CL
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - | FileCheck %s --check-prefixes=CHECK,VK
-
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - | FileCheck %s --check-prefixes=VK
 ; FIXME(135165) Alignment capability emitted for Vulkan.
 ; FIXME: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - -filetype=obj | spirv-val %}
 
-; CHECK-DAG: %[[#Char:]] = OpTypeInt 8 0
-; CHECK-DAG: %[[#PtrChar:]] = OpTypePointer Function %[[#Char]]
+; CL-DAG: %[[#Char:]] = OpTypeInt 8 0
+; CL-DAG: %[[#PtrChar:]] = OpTypePointer Function %[[#Char]]
 
 %tprange = type { %tparray }
 %tparray = type { [2 x i64] }

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/lifetime.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/lifetime.ll
@@ -1,8 +1,13 @@
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefixes=CHECK,CL
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
-; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefixes=CHECK,CL
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - | FileCheck %s --check-prefixes=CHECK,VK
+
+; FIXME(135165) Alignment capability emitted for Vulkan.
+; FIXME: %if spirv-tools %{ llc -O0 -mtriple=spirv-unknown-vulkan1.3-compute %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-DAG: %[[#Char:]] = OpTypeInt 8 0
 ; CHECK-DAG: %[[#PtrChar:]] = OpTypePointer Function %[[#Char]]
@@ -10,15 +15,21 @@
 %tprange = type { %tparray }
 %tparray = type { [2 x i64] }
 
-; CHECK: OpFunction
-; CHECK: %[[#FooVar:]] = OpVariable
-; CHECK: %[[#Casted1:]] = OpBitcast %[[#PtrChar]] %[[#FooVar]]
-; CHECK: OpLifetimeStart %[[#Casted1]], 72
-; CHECK: OpCopyMemorySized
-; CHECK: OpBitcast
-; CHECK: OpInBoundsPtrAccessChain
-; CHECK: %[[#Casted2:]] = OpBitcast %[[#PtrChar]] %[[#FooVar]]
-; CHECK: OpLifetimeStop %[[#Casted2]], 72
+; CL:      OpFunction
+; CL:      %[[#FooVar:]] = OpVariable
+; CL-NEXT: %[[#Casted1:]] = OpBitcast %[[#PtrChar]] %[[#FooVar]]
+; CL-NEXT: OpLifetimeStart %[[#Casted1]], 72
+; CL-NEXT: OpCopyMemorySized
+; CL-NEXT: OpBitcast
+; CL-NEXT: OpInBoundsPtrAccessChain
+; CL-NEXT: %[[#Casted2:]] = OpBitcast %[[#PtrChar]] %[[#FooVar]]
+; CL-NEXT: OpLifetimeStop %[[#Casted2]], 72
+
+; VK:      OpFunction
+; VK:      %[[#FooVar:]] = OpVariable
+; VK-NEXT: OpCopyMemorySized
+; VK-NEXT: OpInBoundsAccessChain
+; VK-NEXT: OpReturn
 define spir_func void @foo(ptr noundef byval(%tprange) align 8 %_arg_UserRange) {
   %RoundedRangeKernel = alloca %tprange, align 8
   call void @llvm.lifetime.start.p0(i64 72, ptr nonnull %RoundedRangeKernel)
@@ -28,13 +39,19 @@ define spir_func void @foo(ptr noundef byval(%tprange) align 8 %_arg_UserRange) 
   ret void
 }
 
-; CHECK: OpFunction
-; CHECK: %[[#BarVar:]] = OpVariable
-; CHECK: OpLifetimeStart %[[#BarVar]], 0
-; CHECK: OpCopyMemorySized
-; CHECK: OpBitcast
-; CHECK: OpInBoundsPtrAccessChain
-; CHECK: OpLifetimeStop %[[#BarVar]], 0
+; CL: OpFunction
+; CL: %[[#BarVar:]] = OpVariable
+; CL-NEXT: OpLifetimeStart %[[#BarVar]], 0
+; CL-NEXT: OpCopyMemorySized
+; CL-NEXT: OpBitcast
+; CL-NEXT: OpInBoundsPtrAccessChain
+; CL-NEXT: OpLifetimeStop %[[#BarVar]], 0
+
+; VK:      OpFunction
+; VK:      %[[#BarVar:]] = OpVariable
+; VK-NEXT: OpCopyMemorySized
+; VK-NEXT: OpInBoundsAccessChain
+; VK-NEXT: OpReturn
 define spir_func void @bar(ptr noundef byval(%tprange) align 8 %_arg_UserRange) {
   %RoundedRangeKernel = alloca %tprange, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr nonnull %RoundedRangeKernel)
@@ -44,12 +61,18 @@ define spir_func void @bar(ptr noundef byval(%tprange) align 8 %_arg_UserRange) 
   ret void
 }
 
-; CHECK: OpFunction
-; CHECK: %[[#TestVar:]] = OpVariable
-; CHECK: OpLifetimeStart %[[#TestVar]], 1
-; CHECK: OpCopyMemorySized
-; CHECK: OpInBoundsPtrAccessChain
-; CHECK: OpLifetimeStop %[[#TestVar]], 1
+; CL: OpFunction
+; CL: %[[#TestVar:]] = OpVariable
+; CL-NEXT: OpLifetimeStart %[[#TestVar]], 1
+; CL-NEXT: OpCopyMemorySized
+; CL-NEXT: OpInBoundsPtrAccessChain
+; CL-NEXT: OpLifetimeStop %[[#TestVar]], 1
+
+; VK:      OpFunction
+; VK:      %[[#Test:]] = OpVariable
+; VK-NEXT: OpCopyMemorySized
+; VK-NEXT: OpInBoundsAccessChain
+; VK-NEXT: OpReturn
 define spir_func void @test(ptr noundef align 8 %_arg) {
   %var = alloca i8, align 8
   call void @llvm.lifetime.start.p0(i64 1, ptr nonnull %var)


### PR DESCRIPTION
Those instructions require the Kernel capability, which is not available when targeting Vulkan.