### PR TITLE
[CodeGen][LLVM] Fix MachineOperand::print crash when TII is nullptr.

### DIFF
--- a/llvm/lib/CodeGen/MachineOperand.cpp
+++ b/llvm/lib/CodeGen/MachineOperand.cpp
@@ -1232,13 +1232,17 @@ void MachineMemOperand::print(raw_ostream &OS, ModuleSlotTracker &MST,
           OS, cast<ExternalSymbolPseudoSourceValue>(PVal)->getSymbol());
       break;
     default: {
-      const MIRFormatter *Formatter = TII->getMIRFormatter();
       // FIXME: This is not necessarily the correct MIR serialization format for
       // a custom pseudo source value, but at least it allows
       // MIR printing to work on a target with custom pseudo source
       // values.
       OS << "custom \"";
-      Formatter->printCustomPseudoSourceValue(OS, MST, *PVal);
+      if (TII) {
+        const MIRFormatter *Formatter = TII->getMIRFormatter();
+        Formatter->printCustomPseudoSourceValue(OS, MST, *PVal);
+      } else {
+        PVal->printCustom(OS);
+      }
       OS << '\"';
       break;
     }


### PR DESCRIPTION
This crash will caused if run this testcase:
  llvm/test/CodeGen/AMDGPU/llvm.amdgcn.ds.gws.barrier-fastregalloc.ll

When build the SDNode, precisely build the SDNode for this ir:
```ir
  call void @llvm.amdgcn.ds.gws.barrier(i32 %val, i32 0)
```
If want call the dump function of the new SDNode in the gdb environment like this:
```gdb
  p N->dump()
```
The llvm will crash.

All of these is because calling ```dump()``` will cause the calling```MachineMemOperand::print()``` 
with the argument value for the```TII``` is nullptr. 
And the llvm/lib/CodeGen/MachineOperand.cpp#L1235 is a derefrence of TII.