### PR TITLE
[RISCV] Explicitly set FRM defs as non-dead to prevent their reordering with instructions that may use it

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -20970,6 +20970,13 @@ RISCVTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
 
 void RISCVTargetLowering::AdjustInstrPostInstrSelection(MachineInstr &MI,
                                                         SDNode *Node) const {
+  // If instruction defines FRM operand, conservatively set it as non-dead to
+  // express data dependency with FRM users and prevent incorrect instruction
+  // reordering.
+  if (auto *FRMDef = MI.findRegisterDefOperand(RISCV::FRM, /*TRI=*/nullptr)) {
+    FRMDef->setIsDead(false);
+    return;
+  }
   // Add FRM dependency to any instructions with dynamic rounding mode.
   int Idx = RISCV::getNamedOperandIdx(MI.getOpcode(), RISCV::OpName::frm);
   if (Idx < 0) {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -1941,9 +1941,11 @@ class SwapSysRegImm<SysReg SR, list<Register> Regs>
 }
 
 def ReadFRM : ReadSysReg<SysRegFRM, [FRM]>;
+let hasPostISelHook = 1 in {
 def WriteFRM : WriteSysReg<SysRegFRM, [FRM]>;
 def WriteFRMImm : WriteSysRegImm<SysRegFRM, [FRM]>;
 def SwapFRMImm : SwapSysRegImm<SysRegFRM, [FRM]>;
+}
 
 def WriteVXRMImm : WriteSysRegImm<SysRegVXRM, [VXRM]>;
 

--- a/llvm/test/CodeGen/RISCV/frm-write-in-loop.ll
+++ b/llvm/test/CodeGen/RISCV/frm-write-in-loop.ll
@@ -7,12 +7,12 @@ define double @foo(double %0, double %1, i64 %n) strictfp {
 ; CHECK-LABEL: foo:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    fmv.d.x fa5, zero
-; CHECK-NEXT:    fsrmi 3
-; CHECK-NEXT:    fsrmi 0
 ; CHECK-NEXT:  .LBB0_1: # %loop
 ; CHECK-NEXT:    # =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    fsrmi 3
 ; CHECK-NEXT:    fadd.d fa5, fa5, fa0
 ; CHECK-NEXT:    addi a0, a0, -1
+; CHECK-NEXT:    fsrmi 0
 ; CHECK-NEXT:    fadd.d fa5, fa5, fa1
 ; CHECK-NEXT:    beqz a0, .LBB0_1
 ; CHECK-NEXT:  # %bb.2: # %exit
@@ -53,12 +53,12 @@ define double @bar(double %0, double %1, i64 %n) strictfp {
 ; CHECK-NEXT:    fmv.d fs0, fa1
 ; CHECK-NEXT:    fmv.d fs1, fa0
 ; CHECK-NEXT:    fmv.d.x fa0, zero
-; CHECK-NEXT:    fsrmi 3
-; CHECK-NEXT:    fsrmi 0
 ; CHECK-NEXT:  .LBB1_1: # %loop
 ; CHECK-NEXT:    # =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    fsrmi 3
 ; CHECK-NEXT:    fmv.d fa1, fs1
 ; CHECK-NEXT:    call baz
+; CHECK-NEXT:    fsrmi 0
 ; CHECK-NEXT:    fmv.d fa1, fs0
 ; CHECK-NEXT:    call baz
 ; CHECK-NEXT:    addi s0, s0, -1


### PR DESCRIPTION
Fixes #135172. The proposed solution is to conservatively reset dead flag from all $frm defs in AdjustInstrPostInstrSelection (this is probably a bit hacky, so I'm open to the better ideas)