### PR TITLE
Add EliminateNewDuplicatePHINodes function.

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/Local.h
+++ b/llvm/include/llvm/Transforms/Utils/Local.h
@@ -175,6 +175,22 @@ bool EliminateDuplicatePHINodes(BasicBlock *BB);
 bool EliminateDuplicatePHINodes(BasicBlock *BB,
                                 SmallPtrSetImpl<PHINode *> &ToRemove);
 
+/// Check for and eliminate duplicate PHI nodes in the block. This function is
+/// specifically designed for scenarios where new PHI nodes are inserted into
+/// the beginning of the block, such when SSAUpdaterBulk::RewriteAllUses. It
+/// compares the newly inserted PHI nodes against the existing ones and if a
+/// new PHI node is found to be a duplicate of an existing one, the new node is
+/// removed. Existing PHI nodes are left unmodified, even if they are
+/// duplicates. New nodes are also deleted if they are duplicates of each other.
+/// Similar to EliminateDuplicatePHINodes, this function assumes a consistent
+/// order for all incoming values across PHI nodes in the block. FirstExistingPN
+/// Points to the first existing PHI node in the block. Newly inserted PHI nodes
+/// should not reference one another. However, they may reference themselves or
+/// existing PHI nodes, and existing PHI nodes may reference the newly inserted
+/// PHI nodes.
+bool EliminateNewDuplicatePHINodes(BasicBlock *BB,
+                                   BasicBlock::phi_iterator FirstExistingPN);
+
 /// This function is used to do simplification of a CFG.  For example, it
 /// adjusts branches to branches to eliminate the extra hop, it eliminates
 /// unreachable basic blocks, and does other peephole optimization of the CFG.


### PR DESCRIPTION
While integrating PHI deduplication into SSAUpdaterBulk, an attempt was made
to utilize EliminateDuplicatePHINodes, but it revealed some drawbacks:

1. It removes all duplicate PHI nodes within a block.
2. It retains the first occurrence among duplicates, which would replace
   an existing PHI with the new one.
3. It restarts the process after each duplicate removal.

When adding new PHI nodes, points 2 and especially 1 are not expected - for
example, it may be redundant to deduplicate existing PHIs. Point 3 can be
addressed by leveraging the fact that new PHIs do not reference each other.

While it might be possible to extend EliminateDuplicatePHINodes with this
functionality, I opted to implement separate routines for clarity. For the same
reason, I omitted the ToRemove argument.

Though it might be overkill, I decided to implement two versions of the
routine, similar to EliminateDuplicatePHINodes - N^2 and hash-based - to
compare performance on blocks with a small number of PHIs and ensure that
both versions agree on the resulting order of PHIs while remaining simple
in implementation.

Output for perfomance test on AMD EPYC 7702, 2183 MHz:
```
[ RUN      ] Local.RaceEliminateNewDuplicatePHINodes
Num phis: 2  H: 170  N2: 17  Diff: 153  Ratio: 10.000
Num phis: 3  H: 196  N2: 28  Diff: 168  Ratio: 7.000
Num phis: 4  H: 219  N2: 42  Diff: 177  Ratio: 5.214
Num phis: 5  H: 243  N2: 56  Diff: 187  Ratio: 4.339
Num phis: 6  H: 274  N2: 84  Diff: 190  Ratio: 3.262
Num phis: 7  H: 312  N2: 114  Diff: 198  Ratio: 2.737
Num phis: 8  H: 350  N2: 146  Diff: 204  Ratio: 2.397
Num phis: 9  H: 368  N2: 170  Diff: 198  Ratio: 2.165
Num phis: 10  H: 399  N2: 211  Diff: 188  Ratio: 1.891
Num phis: 11  H: 431  N2: 240  Diff: 191  Ratio: 1.796
Num phis: 12  H: 457  N2: 289  Diff: 168  Ratio: 1.581
Num phis: 13  H: 478  N2: 319  Diff: 159  Ratio: 1.498
Num phis: 14  H: 510  N2: 376  Diff: 134  Ratio: 1.356
Num phis: 15  H: 552  N2: 412  Diff: 140  Ratio: 1.340
Num phis: 16  H: 581  N2: 495  Diff: 86  Ratio: 1.174
Num phis: 17  H: 606  N2: 535  Diff: 71  Ratio: 1.133
Num phis: 18  H: 650  N2: 626  Diff: 24  Ratio: 1.038
Num phis: 19  H: 674  N2: 671  Diff: 3  Ratio: 1.004
Num phis: 20  H: 703  N2: 767  Diff: -64  Ratio: 0.917
Num phis: 21  H: 727  N2: 816  Diff: -89  Ratio: 0.891
Num phis: 22  H: 754  N2: 1052  Diff: -298  Ratio: 0.717
Num phis: 23  H: 779  N2: 1114  Diff: -335  Ratio: 0.699
Num phis: 24  H: 814  N2: 1216  Diff: -402  Ratio: 0.669
Num phis: 25  H: 833  N2: 1280  Diff: -447  Ratio: 0.651
Num phis: 26  H: 843  N2: 1418  Diff: -575  Ratio: 0.594
Num phis: 27  H: 864  N2: 1487  Diff: -623  Ratio: 0.581
Num phis: 28  H: 894  N2: 1640  Diff: -746  Ratio: 0.545
Num phis: 29  H: 936  N2: 1712  Diff: -776  Ratio: 0.547
Num phis: 30  H: 988  N2: 1863  Diff: -875  Ratio: 0.530
Num phis: 31  H: 1003  N2: 1940  Diff: -937  Ratio: 0.517
Num phis: 32  H: 1050  N2: 2100  Diff: -1050  Ratio: 0.500
Num phis: 33  H: 1071  N2: 2183  Diff: -1112  Ratio: 0.491`
...
```