### PR TITLE
[ARM][MC] Add support for Armv8.1-M Mainline to '.arch' asm directive

### DIFF
--- a/llvm/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
+++ b/llvm/lib/Target/ARM/MCTargetDesc/ARMELFStreamer.cpp
@@ -911,6 +911,7 @@ void ARMTargetELFStreamer::emitArchDefaultAttributes() {
 
   case ARM::ArchKind::ARMV8MBaseline:
   case ARM::ArchKind::ARMV8MMainline:
+  case ARM::ArchKind::ARMV8_1MMainline:
     S.setAttributeItem(THUMB_ISA_use, AllowThumbDerived, false);
     S.setAttributeItem(CPU_arch_profile, MicroControllerProfile, false);
     break;

--- a/llvm/test/MC/ARM/directive-arch-armv8.1-m.s
+++ b/llvm/test/MC/ARM/directive-arch-armv8.1-m.s
@@ -1,0 +1,33 @@
+@ Test the .arch directive for armv8.1-m.main
+
+@ This test case will check the default .ARM.attributes value for the
+@ armv8.1-m.main architecture.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype asm %s \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ASM
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - | FileCheck %s -check-prefix CHECK-ATTR
+
+	.syntax	unified
+	.arch	armv8.1-m.main
+
+@ CHECK-ASM: 	.arch	armv8.1-m.main
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: CPU_name
+@ CHECK-ATTR:     Value: 8.1-M.Mainline
+@ CHECK-ATTR:   }
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: CPU_arch
+@ CHECK-ATTR:     Description: ARM v8.1-M Mainline
+@ CHECK-ATTR:   }
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: CPU_arch_profile
+@ CHECK-ATTR:     Description: Microcontroller
+@ CHECK-ATTR:   }
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: THUMB_ISA_use
+@ CHECK-ATTR:     Description: Permitted
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }

--- a/llvm/test/MC/ARM/directive-arch-armv8.1m.s
+++ b/llvm/test/MC/ARM/directive-arch-armv8.1m.s
@@ -1,0 +1,33 @@
+@ Test the .arch directive for armv8.1-m.main
+
+@ This test case will check the default .ARM.attributes value for the
+@ armv8.1-m.main architecture when using the armv8.1m.main alias.
+
+@ RUN: llvm-mc -triple arm-eabi -filetype asm %s \
+@ RUN:   | FileCheck %s -check-prefix CHECK-ASM
+@ RUN: llvm-mc -triple arm-eabi -filetype obj %s \
+@ RUN:   | llvm-readobj --arch-specific - | FileCheck %s -check-prefix CHECK-ATTR
+
+	.syntax	unified
+	.arch	armv8.1m.main
+
+@ CHECK-ASM: 	.arch	armv8.1-m.main
+
+@ CHECK-ATTR: FileAttributes {
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: CPU_name
+@ CHECK-ATTR:     Value: 8.1-M.Mainline
+@ CHECK-ATTR:   }
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: CPU_arch
+@ CHECK-ATTR:     Description: ARM v8.1-M Mainline
+@ CHECK-ATTR:   }
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: CPU_arch_profile
+@ CHECK-ATTR:     Description: Microcontroller
+@ CHECK-ATTR:   }
+@ CHECK-ATTR:   Attribute {
+@ CHECK-ATTR:     TagName: THUMB_ISA_use
+@ CHECK-ATTR:     Description: Permitted
+@ CHECK-ATTR:   }
+@ CHECK-ATTR: }


### PR DESCRIPTION
Armv8.1-M Mainline architecture is supported by Clang's driver & LLVM's ARM backend, but MC would report an 'Unknown Arch: armv8.1-m.main' error when processing '.arch armv8.1-m.main' assembler directives.