### PR TITLE
[SPIRV] Fix sanitizer-x86_64-linux-android/8085

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -82,10 +82,9 @@ storageClassRequiresExplictLayout(SPIRV::StorageClass::StorageClass SC) {
   case SPIRV::StorageClass::DeviceOnlyINTEL:
   case SPIRV::StorageClass::HostOnlyINTEL:
     return false;
-  default:
-    llvm_unreachable("Unknown storage class");
-    return false;
   }
+  llvm_unreachable("Unknown storage class");
+  return false;
 }
 
 SPIRVGlobalRegistry::SPIRVGlobalRegistry(unsigned PointerSize)


### PR DESCRIPTION
The build failed because the cases covered all possibilities, so the
default was not needed. I have removed the default case, and placed the
llvm_unreachable after the switch.

https://lab.llvm.org/buildbot/#/builders/186/builds/8085
