### PR TITLE
[MLIR][NFC] Expose `computeProduct` function.

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/IR/AffineOps.h
+++ b/mlir/include/mlir/Dialect/Affine/IR/AffineOps.h
@@ -53,6 +53,11 @@ Region *getAffineScope(Operation *op);
 /// analysis scope.
 Region *getAffineAnalysisScope(Operation *op);
 
+/// Return the product of `terms`, creating an `affine.apply` if any of them are
+/// non-constant values. If any of `terms` is `nullptr`, return `nullptr`.
+OpFoldResult computeProduct(Location loc, OpBuilder &builder,
+                            ArrayRef<OpFoldResult> terms);
+
 /// AffineDmaStartOp starts a non-blocking DMA operation that transfers data
 /// from a source memref to a destination memref. The source and destination
 /// memref need not be of the same dimensionality, but need to have the same

--- a/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
+++ b/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
@@ -5081,10 +5081,8 @@ struct DropLinearizeUnitComponentsIfDisjointOrZero final
   }
 };
 
-/// Return the product of `terms`, creating an `affine.apply` if any of them are
-/// non-constant values. If any of `terms` is `nullptr`, return `nullptr`.
-static OpFoldResult computeProduct(Location loc, OpBuilder &builder,
-                                   ArrayRef<OpFoldResult> terms) {
+OpFoldResult computeProduct(Location loc, OpBuilder &builder,
+                            ArrayRef<OpFoldResult> terms) {
   int64_t nDynamic = 0;
   SmallVector<Value> dynamicPart;
   AffineExpr result = builder.getAffineConstantExpr(1);


### PR DESCRIPTION
Make it non-static, as its functionality is quite generic.