### PR TITLE
[RISCV] Allocate Feature Bits for Zilsd/Zclsd/Zcmp

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model/riscv.c
+++ b/compiler-rt/lib/builtins/cpu_model/riscv.c
@@ -128,6 +128,12 @@ struct {
 #define ZCMOP_BITMASK (1ULL << 6)
 #define ZAWRS_GROUPID 1
 #define ZAWRS_BITMASK (1ULL << 7)
+#define ZILSD_GROUPID 1
+#define ZILSD_BITMASK (1ULL << 8)
+#define ZCLSD_GROUPID 1
+#define ZCLSD_BITMASK (1ULL << 9)
+#define ZCMP_GROUPID 1
+#define ZCMP_BITMASK (1ULL << 10)
 
 #if defined(__linux__)
 

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -178,7 +178,8 @@ def NoHasStdExtZicfiss : Predicate<"!Subtarget->hasStdExtZicfiss()">;
 
 def FeatureStdExtZilsd
     : RISCVExtension<1, 0,
-                     "Load/Store Pair Instructions">;
+                     "Load/Store Pair Instructions">,
+      RISCVExtensionBitmask<1, 8>;
 def HasStdExtZilsd : Predicate<"Subtarget->hasStdExtZilsd()">,
                        AssemblerPredicate<(all_of FeatureStdExtZilsd),
                                           "'Zilsd' (Load/Store pair instructions)">;
@@ -411,7 +412,8 @@ def FeatureStdExtZcf
 def FeatureStdExtZclsd
     : RISCVExtension<1, 0,
                      "Compressed Load/Store Pair Instructions",
-                     [FeatureStdExtZilsd, FeatureStdExtZca]>;
+                     [FeatureStdExtZilsd, FeatureStdExtZca]>,
+      RISCVExtensionBitmask<1, 9>;
 def HasStdExtZclsd : Predicate<"Subtarget->hasStdExtZclsd()">,
                     AssemblerPredicate<(all_of FeatureStdExtZclsd),
                         "'Zclsd' (Compressed Load/Store pair instructions)">;
@@ -419,7 +421,8 @@ def HasStdExtZclsd : Predicate<"Subtarget->hasStdExtZclsd()">,
 def FeatureStdExtZcmp
     : RISCVExtension<1, 0,
                      "sequenced instructions for code-size reduction",
-                     [FeatureStdExtZca]>;
+                     [FeatureStdExtZca]>,
+      RISCVExtensionBitmask<1, 10>;
 def HasStdExtZcmp : Predicate<"Subtarget->hasStdExtZcmp() && !Subtarget->hasStdExtC()">,
                     AssemblerPredicate<(all_of FeatureStdExtZcmp),
                         "'Zcmp' (sequenced instructions for code-size reduction)">;


### PR DESCRIPTION
As proposed in https://github.com/riscv-non-isa/riscv-c-api-doc/pull/104

No real compiler-rt implementation, as these are not exposed by Linux.