### PR TITLE
[libc] Add dthorn as maintainer for allocator on baremetal

### DIFF
--- a/libc/Maintainers.rst
+++ b/libc/Maintainers.rst
@@ -22,6 +22,11 @@ Baremetal
 | Petr Hosek
 | phosek\@google.com (email), `petrhosek <https://github.com/petrhosek>`_ (github)
 
+Baremetal (Allocator)
+---------
+| Daniel Thornburgh
+| dthorn\@google.com (email), `mysterymath <https://github.com/mysterymath>`_ (github)
+
 Fixed Point
 -----------
 | Leonard Chan

--- a/libc/Maintainers.rst
+++ b/libc/Maintainers.rst
@@ -23,7 +23,7 @@ Baremetal
 | phosek\@google.com (email), `petrhosek <https://github.com/petrhosek>`_ (github)
 
 Baremetal (Allocator)
----------
+---------------------
 | Daniel Thornburgh
 | dthorn\@google.com (email), `mysterymath <https://github.com/mysterymath>`_ (github)
 


### PR DESCRIPTION
This was on request from other maintainers, given that I've been de-facto acting as maintainer of the baremetal allocator stuff.

Let me know if this is too fine-grained to track.