### PR TITLE
[clang][index] Skip over `#include UNDEF_IDENT` in single-file-parse mode

### DIFF
--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2073,6 +2073,15 @@ void Preprocessor::HandleIncludeDirective(SourceLocation HashLoc,
     return;
 
   if (FilenameTok.isNot(tok::header_name)) {
+    if (FilenameTok.is(tok::identifier) && PPOpts.SingleFileParseMode) {
+      // If we saw #include IDENTIFIER and lexing didn't turn in into a header
+      // name, it was undefined. In 'single-file-parse' mode, just skip the
+      // directive without emitting diagnostics - the identifier might be
+      // normally defined in previously-skipped include directive.
+      DiscardUntilEndOfDirective();
+      return;
+    }
+
     Diag(FilenameTok.getLocation(), diag::err_pp_expects_filename);
     if (FilenameTok.isNot(tok::eod))
       DiscardUntilEndOfDirective();

--- a/clang/test/Index/single-file-parse-include-macro.c
+++ b/clang/test/Index/single-file-parse-include-macro.c
@@ -1,0 +1,10 @@
+// RUN: split-file %s %t
+// RUN: c-index-test -single-file-parse %t/tu.c 2>&1 | FileCheck --allow-empty %t/tu.c
+
+//--- header1.h
+#define HEADER2_H "header2.h"
+//--- header2.h
+//--- tu.c
+#include "header1.h"
+// CHECK-NOT: tu.c:[[@LINE+1]]:10: error: expected "FILENAME" or <FILENAME>
+#include HEADER2_H


### PR DESCRIPTION
In the 'single-file-parse' mode, seeing `#include UNDEFINED_IDENTIFIER` should not be treated as an error. The identifier might be defined in a header that we decided to skip, resulting in a nonsensical diagnostic from the user point of view.