### PR TITLE
[Flang][OpenMP] Initial defaultmap implementation

### DIFF
--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -4149,8 +4149,8 @@ struct OmpDefaultClause {
 //    PRESENT                                       // since 5.1
 struct OmpDefaultmapClause {
   TUPLE_CLASS_BOILERPLATE(OmpDefaultmapClause);
-  ENUM_CLASS(
-      ImplicitBehavior, Alloc, To, From, Tofrom, Firstprivate, None, Default)
+  ENUM_CLASS(ImplicitBehavior, Alloc, To, From, Tofrom, Firstprivate, None,
+      Default, Present)
   MODIFIER_BOILERPLATE(OmpVariableCategory);
   std::tuple<ImplicitBehavior, MODIFIERS()> t;
 };

--- a/flang/lib/Lower/OpenMP/ClauseProcessor.h
+++ b/flang/lib/Lower/OpenMP/ClauseProcessor.h
@@ -32,6 +32,10 @@ namespace Fortran {
 namespace lower {
 namespace omp {
 
+// Container type for tracking user specified Defaultmaps for a target region
+using DefaultMapsTy = std::map<clause::Defaultmap::VariableCategory,
+                               clause::Defaultmap::ImplicitBehavior>;
+
 /// Class that handles the processing of OpenMP clauses.
 ///
 /// Its `process<ClauseName>()` methods perform MLIR code generation for their
@@ -110,6 +114,8 @@ public:
   bool processCopyin() const;
   bool processCopyprivate(mlir::Location currentLocation,
                           mlir::omp::CopyprivateClauseOps &result) const;
+  bool processDefaultMap(lower::StatementContext &stmtCtx,
+                         DefaultMapsTy &result) const;
   bool processDepend(lower::SymMap &symMap, lower::StatementContext &stmtCtx,
                      mlir::omp::DependClauseOps &result) const;
   bool

--- a/flang/lib/Lower/OpenMP/Clauses.cpp
+++ b/flang/lib/Lower/OpenMP/Clauses.cpp
@@ -612,7 +612,7 @@ Defaultmap make(const parser::OmpClause::Defaultmap &inp,
       MS(Firstprivate, Firstprivate)
       MS(None,         None)
       MS(Default,      Default)
-      // MS(, Present)  missing-in-parser
+      MS(Present,      Present)
       // clang-format on
   );
 

--- a/flang/lib/Parser/openmp-parsers.cpp
+++ b/flang/lib/Parser/openmp-parsers.cpp
@@ -705,7 +705,7 @@ TYPE_PARSER(construct<OmpMapClause>(
 // [OpenMP 5.0]
 // 2.19.7.2 defaultmap(implicit-behavior[:variable-category])
 //  implicit-behavior -> ALLOC | TO | FROM | TOFROM | FIRSRTPRIVATE | NONE |
-//  DEFAULT
+//  DEFAULT | PRESENT
 //  variable-category -> ALL | SCALAR | AGGREGATE | ALLOCATABLE | POINTER
 TYPE_PARSER(construct<OmpDefaultmapClause>(
     construct<OmpDefaultmapClause::ImplicitBehavior>(
@@ -716,7 +716,8 @@ TYPE_PARSER(construct<OmpDefaultmapClause>(
         "FIRSTPRIVATE" >>
             pure(OmpDefaultmapClause::ImplicitBehavior::Firstprivate) ||
         "NONE" >> pure(OmpDefaultmapClause::ImplicitBehavior::None) ||
-        "DEFAULT" >> pure(OmpDefaultmapClause::ImplicitBehavior::Default)),
+        "DEFAULT" >> pure(OmpDefaultmapClause::ImplicitBehavior::Default) ||
+        "PRESENT" >> pure(OmpDefaultmapClause::ImplicitBehavior::Present)),
     maybe(":" >> nonemptyList(Parser<OmpDefaultmapClause::Modifier>{}))))
 
 TYPE_PARSER(construct<OmpScheduleClause::Kind>(

--- a/flang/test/Lower/OpenMP/Todo/defaultmap-clause-firstprivate.f90
+++ b/flang/test/Lower/OpenMP/Todo/defaultmap-clause-firstprivate.f90
@@ -1,0 +1,11 @@
+!RUN: %not_todo_cmd bbc -emit-hlfir -fopenmp -fopenmp-version=51 -o - %s 2>&1 | FileCheck %s
+!RUN: %not_todo_cmd %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=51 -o - %s 2>&1 | FileCheck %s
+
+subroutine f00
+    implicit none
+    integer :: i
+    !CHECK: not yet implemented: Firstprivate and None are currently unsupported defaultmap behaviour
+    !$omp target defaultmap(firstprivate)
+      i = 10
+    !$omp end target
+  end

--- a/flang/test/Lower/OpenMP/Todo/defaultmap-clause-none.f90
+++ b/flang/test/Lower/OpenMP/Todo/defaultmap-clause-none.f90
@@ -1,0 +1,11 @@
+!RUN: %not_todo_cmd bbc -emit-hlfir -fopenmp -fopenmp-version=51 -o - %s 2>&1 | FileCheck %s
+!RUN: %not_todo_cmd %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=51 -o - %s 2>&1 | FileCheck %s
+
+subroutine f00
+  implicit none
+  integer :: i
+  !CHECK: not yet implemented: Firstprivate and None are currently unsupported defaultmap behaviour
+  !$omp target defaultmap(none)
+    i = 10
+  !$omp end target
+end

--- a/flang/test/Lower/OpenMP/Todo/defaultmap-clause.f90
+++ b/flang/test/Lower/OpenMP/Todo/defaultmap-clause.f90
@@ -1,8 +1,0 @@
-!RUN: %not_todo_cmd bbc -emit-hlfir -fopenmp -fopenmp-version=45 -o - %s 2>&1 | FileCheck %s
-!RUN: %not_todo_cmd %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=45 -o - %s 2>&1 | FileCheck %s
-
-!CHECK: not yet implemented: DEFAULTMAP clause is not implemented yet
-subroutine f00
-  !$omp target defaultmap(tofrom:scalar)
-  !$omp end target
-end

--- a/flang/test/Lower/OpenMP/defaultmap.f90
+++ b/flang/test/Lower/OpenMP/defaultmap.f90
@@ -1,0 +1,105 @@
+!RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=52 %s -o - | FileCheck %s
+
+subroutine defaultmap_allocatable_present()
+    implicit none
+    integer, dimension(:), allocatable :: arr
+
+! CHECK: %[[MAP_1:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, i32) map_clauses(implicit, present, exit_release_or_enter_alloc) capture(ByRef) var_ptr_ptr({{.*}}) bounds({{.*}}) -> !fir.llvm_ptr<!fir.ref<!fir.array<?xi32>>> {name = ""}
+! CHECK: %[[MAP_2:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.box<!fir.heap<!fir.array<?xi32>>>) map_clauses(implicit, to) capture(ByRef) members({{.*}}) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {name = "arr"}
+!$omp target defaultmap(present: allocatable)
+    arr(1) = 10
+!$omp end target
+
+    return
+end subroutine
+
+subroutine defaultmap_scalar_tofrom()
+    implicit none
+    integer :: scalar_int
+
+! CHECK: %[[MAP:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<i32>, i32) map_clauses(implicit, tofrom) capture(ByRef) -> !fir.ref<i32> {name = "scalar_int"}
+   !$omp target defaultmap(tofrom: scalar)
+        scalar_int = 20
+   !$omp end target
+
+    return
+end subroutine
+
+subroutine defaultmap_all_default()
+    implicit none
+    integer, dimension(:), allocatable :: arr
+    integer :: aggregate(16)
+    integer :: scalar_int
+
+! CHECK: %[[MAP_1:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<i32>, i32) map_clauses(implicit, exit_release_or_enter_alloc) capture(ByCopy) -> !fir.ref<i32> {name = "scalar_int"}
+! CHECK: %[[MAP_2:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, i32) map_clauses(implicit, tofrom) capture(ByRef) var_ptr_ptr({{.*}}) bounds({{.*}}) -> !fir.llvm_ptr<!fir.ref<!fir.array<?xi32>>> {name = ""}
+! CHECK: %[[MAP_3:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.box<!fir.heap<!fir.array<?xi32>>>) map_clauses(implicit, to) capture(ByRef) members({{.*}}) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {name = "arr"}
+! CHECK: %[[MAP_4:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.array<16xi32>>, !fir.array<16xi32>) map_clauses(implicit, tofrom) capture(ByRef) bounds({{.*}}) -> !fir.ref<!fir.array<16xi32>> {name = "aggregate"}
+
+   !$omp target defaultmap(default: all)
+        scalar_int = 20
+        arr(1) = scalar_int + aggregate(1)
+   !$omp end target
+
+    return
+end subroutine
+
+subroutine defaultmap_pointer_to()
+    implicit none
+    integer, dimension(:), pointer :: arr_ptr(:)
+    integer :: scalar_int
+
+! CHECK: %[[MAP_1:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>, i32) map_clauses(implicit, to) capture(ByRef) var_ptr_ptr({{.*}}) bounds({{.*}}) -> !fir.llvm_ptr<!fir.ref<!fir.array<?xi32>>> {name = ""}
+! CHECK: %[[MAP_2:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>, !fir.box<!fir.ptr<!fir.array<?xi32>>>) map_clauses(implicit, to) capture(ByRef) members({{.*}}) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>> {name = "arr_ptr"}
+! CHECK: %[[MAP_3:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<i32>, i32) map_clauses(implicit, exit_release_or_enter_alloc) capture(ByCopy) -> !fir.ref<i32> {name = "scalar_int"}
+    !$omp target defaultmap(to: pointer)
+        arr_ptr(1) = scalar_int + 20
+    !$omp end target
+
+    return
+end subroutine
+
+subroutine defaultmap_scalar_from()
+    implicit none
+    integer :: scalar_test
+
+! CHECK:%[[MAP:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<i32>, i32) map_clauses(implicit, from) capture(ByRef) -> !fir.ref<i32> {name = "scalar_test"}
+    !$omp target defaultmap(from: scalar)
+        scalar_test = 20
+    !$omp end target
+
+    return
+end subroutine
+
+subroutine defaultmap_aggregate_to()
+    implicit none
+    integer :: aggregate_arr(16)
+    integer :: scalar_test
+
+! CHECK: %[[MAP_1:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<i32>, i32) map_clauses(tofrom) capture(ByRef) -> !fir.ref<i32> {name = "scalar_test"}
+! CHECK: %[[MAP_2:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.array<16xi32>>, !fir.array<16xi32>) map_clauses(implicit, to) capture(ByRef) bounds({{.*}}) -> !fir.ref<!fir.array<16xi32>> {name = "aggregate_arr"}
+    !$omp target map(tofrom: scalar_test) defaultmap(to: aggregate)
+        aggregate_arr(1) = 1
+        scalar_test = 1
+    !$omp end target
+
+    return
+end subroutine
+
+subroutine defaultmap_dtype_aggregate_to()
+    implicit none
+    type :: dtype
+        integer(4) :: array_i(10)
+        integer(4) :: k
+    end type dtype
+
+    type(dtype) :: aggregate_type
+
+! CHECK: %[[MAP:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.type<_QFdefaultmap_dtype_aggregate_toTdtype{array_i:!fir.array<10xi32>,k:i32}>>, !fir.type<_QFdefaultmap_dtype_aggregate_toTdtype{array_i:!fir.array<10xi32>,k:i32}>) map_clauses(implicit, to) capture(ByRef) -> !fir.ref<!fir.type<_QFdefaultmap_dtype_aggregate_toTdtype{array_i:!fir.array<10xi32>,k:i32}>> {name = "aggregate_type"}
+    !$omp target defaultmap(to: aggregate)
+        aggregate_type%k = 40
+        aggregate_type%array_i(1) = 50
+    !$omp end target
+
+    return
+end subroutine

--- a/flang/test/Parser/OpenMP/defaultmap-clause.f90
+++ b/flang/test/Parser/OpenMP/defaultmap-clause.f90
@@ -82,3 +82,19 @@ end
 !PARSE-TREE: | OmpClauseList -> OmpClause -> Defaultmap -> OmpDefaultmapClause
 !PARSE-TREE: | | ImplicitBehavior = Tofrom
 !PARSE-TREE: | | Modifier -> OmpVariableCategory -> Value  = Scalar
+
+subroutine f05
+  !$omp target defaultmap(present: scalar)
+  !$omp end target
+end
+
+!UNPARSE: SUBROUTINE f05
+!UNPARSE: !$OMP TARGET  DEFAULTMAP(PRESENT:SCALAR)
+!UNPARSE: !$OMP END TARGET
+!UNPARSE: END SUBROUTINE
+
+!PARSE-TREE: OmpBeginBlockDirective
+!PARSE-TREE: | OmpBlockDirective -> llvm::omp::Directive = target
+!PARSE-TREE: | OmpClauseList -> OmpClause -> Defaultmap -> OmpDefaultmapClause
+!PARSE-TREE: | | ImplicitBehavior = Present
+!PARSE-TREE: | | Modifier -> OmpVariableCategory -> Value  = Scalar

--- a/offload/test/offloading/fortran/target-defaultmap-present.f90
+++ b/offload/test/offloading/fortran/target-defaultmap-present.f90
@@ -1,0 +1,34 @@
+! This checks that the basic functionality of setting the implicit mapping
+! behaviour of a target region to present incurs the present behaviour for
+! the implicit map capture.
+! REQUIRES: flang, amdgpu
+! RUN: %libomptarget-compile-fortran-generic
+! RUN: %libomptarget-run-fail-generic 2>&1 \
+! RUN: | %fcheck-generic
+
+! NOTE: This should intentionally fatal error in omptarget as it's not
+! present, as is intended.
+subroutine target_data_not_present()
+    implicit none
+    double precision, dimension(:), allocatable :: arr
+    integer, parameter :: N = 16
+    integer :: i
+
+    allocate(arr(N))
+
+!$omp target defaultmap(present: allocatable)
+    do i = 1,N
+        arr(i) = 42.0d0
+    end do
+!$omp end target
+
+    deallocate(arr)
+    return
+end subroutine
+
+program map_present
+    implicit none
+    call target_data_not_present()
+end program
+
+!CHECK: omptarget message: device mapping required by 'present' map type modifier does not exist for host address{{.*}}

--- a/offload/test/offloading/fortran/target-defaultmap.f90
+++ b/offload/test/offloading/fortran/target-defaultmap.f90
@@ -1,0 +1,166 @@
+! Offloading test checking the use of the depend clause on the target construct
+! REQUIRES: flang, amdgcn-amd-amdhsa
+! UNSUPPORTED: nvptx64-nvidia-cuda
+! UNSUPPORTED: nvptx64-nvidia-cuda-LTO
+! UNSUPPORTED: aarch64-unknown-linux-gnu
+! UNSUPPORTED: aarch64-unknown-linux-gnu-LTO
+! UNSUPPORTED: x86_64-unknown-linux-gnu
+! UNSUPPORTED: x86_64-unknown-linux-gnu-LTO
+
+! RUN: %libomptarget-compile-fortran-run-and-check-generic
+subroutine defaultmap_allocatable_present()
+    implicit none
+    integer, dimension(:), allocatable :: arr
+    integer :: N = 16
+    integer :: i
+
+    allocate(arr(N))
+
+!$omp target enter data map(to: arr)
+
+!$omp target defaultmap(present: allocatable)
+    do i = 1,N
+        arr(i) = N + 40
+    end do
+!$omp end target
+
+!$omp target exit data map(from: arr)
+
+    print *, arr
+    deallocate(arr)
+
+    return
+end subroutine
+
+subroutine defaultmap_scalar_tofrom()
+    implicit none
+    integer :: scalar_int
+    scalar_int = 10
+
+   !$omp target defaultmap(tofrom: scalar)
+        scalar_int = 20
+   !$omp end target
+
+    print *, scalar_int
+    return
+end subroutine
+
+subroutine defaultmap_all_default()
+    implicit none
+    integer, dimension(:), allocatable :: arr
+    integer :: aggregate(16)
+    integer :: N = 16
+    integer :: i, scalar_int
+
+    allocate(arr(N))
+
+    scalar_int = 10
+    aggregate = scalar_int
+
+   !$omp target defaultmap(default: all)
+        scalar_int = 20
+        do i = 1,N
+            arr(i) = scalar_int + aggregate(i)
+        end do
+   !$omp end target
+
+    print *, scalar_int
+    print *, arr
+
+    deallocate(arr)
+    return
+end subroutine
+
+subroutine defaultmap_pointer_to()
+    implicit none
+    integer, dimension(:), pointer :: arr_ptr(:)
+    integer :: scalar_int, i
+    allocate(arr_ptr(10))
+    arr_ptr = 10
+    scalar_int = 20
+
+    !$omp target defaultmap(to: pointer)
+        do i = 1,10
+            arr_ptr(i) = scalar_int + 20
+        end do
+    !$omp end target
+
+    print *, arr_ptr
+    deallocate(arr_ptr)
+    return
+end subroutine
+
+subroutine defaultmap_scalar_from()
+    implicit none
+    integer :: scalar_test
+    scalar_test = 10
+    !$omp target defaultmap(from: scalar)
+        scalar_test = 20
+    !$omp end target
+
+    print *, scalar_test
+    return
+end subroutine
+
+subroutine defaultmap_aggregate_to()
+    implicit none
+    integer :: aggregate_arr(16)
+    integer :: i, scalar_test = 0
+    aggregate_arr = 0
+    !$omp target map(tofrom: scalar_test) defaultmap(to: aggregate)
+        do i = 1,16
+            aggregate_arr(i) = i
+            scalar_test = scalar_test + aggregate_arr(i)
+        enddo
+    !$omp end target
+
+    print *, scalar_test
+    print *, aggregate_arr
+    return
+end subroutine
+
+subroutine defaultmap_dtype_aggregate_to()
+    implicit none
+    type :: dtype
+        real(4) :: i
+        real(4) :: j
+        integer(4) :: array_i(10)
+        integer(4) :: k
+        integer(4) :: array_j(10)
+    end type dtype
+
+    type(dtype) :: aggregate_type
+
+    aggregate_type%k = 20
+    aggregate_type%array_i = 30
+
+    !$omp target defaultmap(to: aggregate)
+        aggregate_type%k = 40
+        aggregate_type%array_i(1) = 50
+    !$omp end target
+
+    print *, aggregate_type%k
+    print *, aggregate_type%array_i(1)
+    return
+end subroutine
+
+program map_present
+    implicit none
+! CHECK: 56 56 56 56 56 56 56 56 56 56 56 56 56 56 56 56
+    call defaultmap_allocatable_present()
+! CHECK: 20
+    call defaultmap_scalar_tofrom()
+! CHECK: 10
+! CHECK: 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30 30
+    call defaultmap_all_default()
+! CHECK: 10 10 10 10 10 10 10 10 10 10
+    call defaultmap_pointer_to()
+! CHECK: 20
+    call defaultmap_scalar_from()
+! CHECK: 136
+! CHECK: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+    call defaultmap_aggregate_to()
+! CHECK: 20
+! CHECK: 30
+    call defaultmap_dtype_aggregate_to()
+end program


### PR DESCRIPTION
This aims to implement most of the initial arguments for defaultmap aside from firstprivate and none, and some of the more recent OpenMP 6 additions which will come in subsequent updates (with the OpenMP 6 variants needing parsing/semantic support first).