### PR TITLE
Remove debugger pretty printers for llvm::Optional

### DIFF
--- a/llvm/utils/LLVMVisualizers/llvm.natvis
+++ b/llvm/utils/LLVMVisualizers/llvm.natvis
@@ -193,14 +193,6 @@ For later versions of Visual Studio, no setup is required.
     <DisplayString>{Data}</DisplayString>
   </Type>
 
-  <Type Name="llvm::Optional&lt;*&gt;">
-    <DisplayString Condition="!Storage.hasVal">None</DisplayString>
-    <DisplayString Condition="Storage.hasVal">{Storage.value}</DisplayString>
-    <Expand>
-      <Item Name="[underlying]" Condition="Storage.hasVal">Storage.value</Item>
-    </Expand>
-  </Type>
-
   <Type Name="llvm::Expected&lt;*&gt;">
     <DisplayString Condition="HasError">Error</DisplayString>
     <DisplayString Condition="!HasError">{*((storage_type *)TStorage.buffer)}</DisplayString>

--- a/llvm/utils/gdb-scripts/prettyprinters.py
+++ b/llvm/utils/gdb-scripts/prettyprinters.py
@@ -142,27 +142,6 @@ class ExpectedPrinter(Iterator):
         return "llvm::Expected{}".format(" is error" if self.val["HasError"] else "")
 
 
-class OptionalPrinter(Iterator):
-    """Print an llvm::Optional object."""
-
-    def __init__(self, val):
-        self.val = val
-
-    def __next__(self):
-        val = self.val
-        if val is None:
-            raise StopIteration
-        self.val = None
-        if not val["Storage"]["hasVal"]:
-            raise StopIteration
-        return ("value", val["Storage"]["val"])
-
-    def to_string(self):
-        return "llvm::Optional{}".format(
-            "" if self.val["Storage"]["hasVal"] else " is not initialized"
-        )
-
-
 class DenseMapPrinter:
     "Print a DenseMap"
 
@@ -543,7 +522,6 @@ pp.add_printer(
 )
 pp.add_printer("llvm::ArrayRef", "^llvm::(Mutable)?ArrayRef<.*>$", ArrayRefPrinter)
 pp.add_printer("llvm::Expected", "^llvm::Expected<.*>$", ExpectedPrinter)
-pp.add_printer("llvm::Optional", "^llvm::Optional<.*>$", OptionalPrinter)
 pp.add_printer("llvm::DenseMap", "^llvm::DenseMap<.*>$", DenseMapPrinter)
 pp.add_printer("llvm::StringMap", "^llvm::StringMap<.*>$", StringMapPrinter)
 pp.add_printer("llvm::Twine", "^llvm::Twine$", TwinePrinter)


### PR DESCRIPTION
Since 2916b99182752b1aece8cc4479d8d6a20b5e02da this is just an alias to std::optional, and by now it has been removed entirely.