### PR TITLE
Add generic sqrt root headers to libc sqrt specializations

### DIFF
--- a/libc/src/__support/FPUtil/aarch64/sqrt.h
+++ b/libc/src/__support/FPUtil/aarch64/sqrt.h
@@ -18,6 +18,8 @@
 #error "Invalid include"
 #endif
 
+#include "src/__support/FPUtil/generic/sqrt.h"
+
 namespace LIBC_NAMESPACE_DECL {
 namespace fputil {
 

--- a/libc/src/__support/FPUtil/arm/sqrt.h
+++ b/libc/src/__support/FPUtil/arm/sqrt.h
@@ -18,6 +18,8 @@
 #error "Invalid include"
 #endif
 
+#include "src/__support/FPUtil/generic/sqrt.h"
+
 namespace LIBC_NAMESPACE_DECL {
 namespace fputil {
 

--- a/libc/src/__support/FPUtil/riscv/sqrt.h
+++ b/libc/src/__support/FPUtil/riscv/sqrt.h
@@ -18,6 +18,8 @@
 #error "Invalid include"
 #endif
 
+#include "src/__support/FPUtil/generic/sqrt.h"
+
 namespace LIBC_NAMESPACE_DECL {
 namespace fputil {
 

--- a/libc/src/__support/FPUtil/x86_64/sqrt.h
+++ b/libc/src/__support/FPUtil/x86_64/sqrt.h
@@ -18,6 +18,8 @@
 #error "sqrtss / sqrtsd need SSE2"
 #endif
 
+#include "src/__support/FPUtil/generic/sqrt.h"
+
 namespace LIBC_NAMESPACE_DECL {
 namespace fputil {
 


### PR DESCRIPTION
This header is needed to provide the declaration for the sqrt template.  You can build without these in the CMake build, but not having this include in the architecture specific headers makes them not self contained.  