### PR TITLE
[flang][openacc] Relax constraint on OpenACC declare statement

### DIFF
--- a/flang/docs/OpenACC.md
+++ b/flang/docs/OpenACC.md
@@ -25,6 +25,8 @@ local:
   logical expression.
 * `!$acc routine` directive can be placed at the top level. 
 * `!$acc cache` directive accepts scalar variable.
+* The `!$acc declare` directive accepts assumed size array arguments for 
+  `deviceptr` and `present` clauses.
 
 ## Remarks about incompatibilities with other implementations
 * Array element references in the data clauses are equivalent to array sections

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -953,7 +953,14 @@ void AccAttributeVisitor::Post(
   const auto &clauseList = std::get<parser::AccClauseList>(x.t);
   for (const auto &clause : clauseList.v) {
     // Restriction - line 2414
-    DoNotAllowAssumedSizedArray(GetAccObjectList(clause));
+    // We assume the restriction is present because clauses that require
+    // moving data would require the size of the data to be present, but
+    // the deviceptr and present clauses do not require moving data and
+    // thus we permit them.
+    if (!std::holds_alternative<parser::AccClause::Deviceptr>(clause.u) &&
+        !std::holds_alternative<parser::AccClause::Present>(clause.u)) {
+      DoNotAllowAssumedSizedArray(GetAccObjectList(clause));
+    }
   }
 }
 

--- a/flang/test/Semantics/OpenACC/acc-declare-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-declare-validity.f90
@@ -62,8 +62,20 @@ contains
   subroutine sub2(cc)
     real(8), dimension(*) :: cc
     !ERROR: Assumed-size dummy arrays may not appear on the DECLARE directive
-    !$acc declare present(cc)
+    !$acc declare copyin(cc)
   end subroutine sub2
+
+  subroutine sub2e1(cc)
+    real(8), dimension(*) :: cc
+    !OK
+    !$acc declare present(cc)
+  end subroutine sub2e1
+
+  subroutine sub2e2(cc)
+    real(8), dimension(*) :: cc
+    !OK
+    !$acc declare deviceptr(cc)
+  end subroutine sub2e2
 
   subroutine sub3()
     real :: aa(100)


### PR DESCRIPTION
OpenACC declare statements are restricted from having having clauses that reference assumed size arrays. It should be the case that we can implement `deviceptr` and `present` clauses for assumed-size arrays. This is a first step towards relaxing this restriction.

Note running flang on the following example results in an error in lowering.
```
$ cat t.f90
subroutine vadd (a, b, c, n)
   real(8) :: a(*), b(*), c(*)
!$acc declare deviceptr(a, b, c)
!$acc parallel loop
   do i = 1,n
      c(i) = a(i) + b(i)
   enddo
end subroutine

$ flang -fopenacc -c t.f90
error: loc("/home/akuhlenschmi/work/p4/ta/tests/openacc/src/t.f90":3:7): expect declare attribute on variable in declare operation
error: Lowering to LLVM IR failed
error: loc("/home/akuhlenschmi/work/p4/ta/tests/openacc/src/t.f90":4:7): unsupported OpenACC operation: acc.private.recipe
error: loc("/home/akuhlenschmi/work/p4/ta/tests/openacc/src/t.f90":4:7): LLVM Translation failed for operation: acc.private.recipe
error: failed to create the LLVM module
```

I would like to to share this code, because others are currently working on the implementation of `deviceptr`, but it is obviously not running end-to-end. I think the cleanest approach to this would be to put this exception to the rule behind some feature flag, but I am not certain what the precedence for that is.