### PR TITLE
[flang][NFC] Split CG dialect and the passes.

### DIFF
--- a/flang/include/flang/Optimizer/CodeGen/CMakeLists.txt
+++ b/flang/include/flang/Optimizer/CodeGen/CMakeLists.txt
@@ -1,8 +1,3 @@
-set(LLVM_TARGET_DEFINITIONS CGOps.td)
-mlir_tablegen(CGOps.h.inc -gen-op-decls)
-mlir_tablegen(CGOps.cpp.inc -gen-op-defs)
-add_public_tablegen_target(CGOpsIncGen)
-
 set(LLVM_TARGET_DEFINITIONS CGPasses.td)
 mlir_tablegen(CGPasses.h.inc -gen-pass-decls -name OptCodeGen)
 add_public_tablegen_target(FIROptCodeGenPassIncGen)

--- a/flang/include/flang/Optimizer/Dialect/CMakeLists.txt
+++ b/flang/include/flang/Optimizer/Dialect/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(CUF)
+add_subdirectory(FIRCG)
 
 # This replicates part of the add_mlir_dialect cmake function from MLIR that
 # cannot be used her because it expects to be run inside MLIR directory which

--- a/flang/include/flang/Optimizer/Dialect/FIRCG/CGOps.h
+++ b/flang/include/flang/Optimizer/Dialect/FIRCG/CGOps.h
@@ -10,14 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef OPTIMIZER_CODEGEN_CGOPS_H
-#define OPTIMIZER_CODEGEN_CGOPS_H
+#ifndef OPTIMIZER_DIALECT_FIRCG_CGOPS_H
+#define OPTIMIZER_DIALECT_FIRCG_CGOPS_H
 
 #include "flang/Optimizer/Dialect/FIRAttr.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 
 #define GET_OP_CLASSES
-#include "flang/Optimizer/CodeGen/CGOps.h.inc"
+#include "flang/Optimizer/Dialect/FIRCG/CGOps.h.inc"
 
-#endif
+#endif // OPTIMIZER_DIALECT_FIRCG_CGOPS_H

--- a/flang/include/flang/Optimizer/Dialect/FIRCG/CGOps.td
+++ b/flang/include/flang/Optimizer/Dialect/FIRCG/CGOps.td
@@ -1,4 +1,4 @@
-//===-- CGOps.td - FIR operation definitions ---------------*- tablegen -*-===//
+//===-- CGOps.td - FIR CodeGen operation definitions -------*- tablegen -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -28,7 +28,7 @@ def fircg_Dialect : Dialect {
 // Base class for FIR CG operations.
 // All operations automatically get a prefix of "fircg.".
 class fircg_Op<string mnemonic, list<Trait> traits>
-  : Op<fircg_Dialect, mnemonic, traits>;
+    : Op<fircg_Dialect, mnemonic, traits>;
 
 // Extended embox operation.
 def fircg_XEmboxOp : fircg_Op<"ext_embox", [AttrSizedOperandSegments]> {
@@ -55,17 +55,12 @@ def fircg_XEmboxOp : fircg_Op<"ext_embox", [AttrSizedOperandSegments]> {
     The memref and shape arguments are mandatory. The rest are optional.
   }];
 
-  let arguments = (ins
-    AnyReferenceLike:$memref,
-    Variadic<AnyIntegerType>:$shape,
-    Variadic<AnyIntegerType>:$shift,
-    Variadic<AnyIntegerType>:$slice,
-    Variadic<AnyCoordinateType>:$subcomponent,
-    Variadic<AnyIntegerType>:$substr,
-    Variadic<AnyIntegerType>:$lenParams,
-    Optional<fir_ClassType>:$sourceBox,
-    OptionalAttr<I32Attr>:$allocator_idx
-  );
+  let arguments = (ins AnyReferenceLike:$memref,
+      Variadic<AnyIntegerType>:$shape, Variadic<AnyIntegerType>:$shift,
+      Variadic<AnyIntegerType>:$slice,
+      Variadic<AnyCoordinateType>:$subcomponent,
+      Variadic<AnyIntegerType>:$substr, Variadic<AnyIntegerType>:$lenParams,
+      Optional<fir_ClassType>:$sourceBox, OptionalAttr<I32Attr>:$allocator_idx);
   let results = (outs BoxOrClassType);
 
   let assemblyFormat = [{
@@ -125,14 +120,10 @@ def fircg_XReboxOp : fircg_Op<"ext_rebox", [AttrSizedOperandSegments]> {
     There must not both be a shape and slice/subcomponent arguments
   }];
 
-  let arguments = (ins
-    BoxOrClassType:$box,
-    Variadic<AnyIntegerType>:$shape,
-    Variadic<AnyIntegerType>:$shift,
-    Variadic<AnyIntegerType>:$slice,
-    Variadic<AnyCoordinateType>:$subcomponent,
-    Variadic<AnyIntegerType>:$substr
-  );
+  let arguments = (ins BoxOrClassType:$box, Variadic<AnyIntegerType>:$shape,
+      Variadic<AnyIntegerType>:$shift, Variadic<AnyIntegerType>:$slice,
+      Variadic<AnyCoordinateType>:$subcomponent,
+      Variadic<AnyIntegerType>:$substr);
   let results = (outs BoxOrClassType);
 
   let assemblyFormat = [{
@@ -163,9 +154,9 @@ def fircg_XReboxOp : fircg_Op<"ext_rebox", [AttrSizedOperandSegments]> {
   }];
 }
 
-
 // Extended array coordinate operation.
-def fircg_XArrayCoorOp : fircg_Op<"ext_array_coor", [AttrSizedOperandSegments]> {
+def fircg_XArrayCoorOp
+    : fircg_Op<"ext_array_coor", [AttrSizedOperandSegments]> {
   let summary = "for internal conversion only";
 
   let description = [{
@@ -190,15 +181,11 @@ def fircg_XArrayCoorOp : fircg_Op<"ext_array_coor", [AttrSizedOperandSegments]> 
     omitted otherwise. The rest of the arguments are optional.
   }];
 
-  let arguments = (ins
-    AnyRefOrBox:$memref,
-    Variadic<AnyIntegerType>:$shape,
-    Variadic<AnyIntegerType>:$shift,
-    Variadic<AnyIntegerType>:$slice,
-    Variadic<AnyCoordinateType>:$subcomponent,
-    Variadic<AnyCoordinateType>:$indices,
-    Variadic<AnyIntegerType>:$lenParams
-  );
+  let arguments = (ins AnyRefOrBox:$memref, Variadic<AnyIntegerType>:$shape,
+      Variadic<AnyIntegerType>:$shift, Variadic<AnyIntegerType>:$slice,
+      Variadic<AnyCoordinateType>:$subcomponent,
+      Variadic<AnyCoordinateType>:$indices,
+      Variadic<AnyIntegerType>:$lenParams);
   let results = (outs fir_ReferenceType);
 
   let assemblyFormat = [{
@@ -239,14 +226,9 @@ def fircg_XDeclareOp : fircg_Op<"ext_declare", [AttrSizedOperandSegments]> {
     be converted to an extended DeclareOp.
   }];
 
-  let arguments = (ins
-    AnyRefOrBox:$memref,
-    Variadic<AnyIntegerType>:$shape,
-    Variadic<AnyIntegerType>:$shift,
-    Variadic<AnyIntegerType>:$typeparams,
-    Optional<fir_DummyScopeType>:$dummy_scope,
-    Builtin_StringAttr:$uniq_name
-  );
+  let arguments = (ins AnyRefOrBox:$memref, Variadic<AnyIntegerType>:$shape,
+      Variadic<AnyIntegerType>:$shift, Variadic<AnyIntegerType>:$typeparams,
+      Optional<fir_DummyScopeType>:$dummy_scope, Builtin_StringAttr:$uniq_name);
   let results = (outs AnyRefOrBox);
 
   let assemblyFormat = [{

--- a/flang/include/flang/Optimizer/Dialect/FIRCG/CMakeLists.txt
+++ b/flang/include/flang/Optimizer/Dialect/FIRCG/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(LLVM_TARGET_DEFINITIONS CGOps.td)
+mlir_tablegen(CGOps.h.inc -gen-op-decls)
+mlir_tablegen(CGOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(CGOpsIncGen)

--- a/flang/lib/Frontend/CMakeLists.txt
+++ b/flang/lib/Frontend/CMakeLists.txt
@@ -33,6 +33,7 @@ add_flang_library(flangFrontend
   FIRSupport
   FIRBuilder
   FIRCodeGen
+  FIRCodeGenDialect
   FIRTransforms
   HLFIRDialect
   HLFIRTransforms

--- a/flang/lib/Optimizer/CodeGen/CMakeLists.txt
+++ b/flang/lib/Optimizer/CodeGen/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_flang_library(FIRCodeGen
   BoxedProcedure.cpp
-  CGOps.cpp
   CodeGen.cpp
   CodeGenOpenMP.cpp
   FIROpPatterns.cpp
@@ -21,13 +20,12 @@ add_flang_library(FIRCodeGen
   CUFAttrs
   FIRAnalysis
   FIRBuilder
+  FIRCodeGenDialect
   FIRDialect
   FIRDialectSupport
   FIRSupport
 
   LINK_COMPONENTS
-  AsmParser
-  AsmPrinter
   Remarks
   TargetParser
 

--- a/flang/lib/Optimizer/CodeGen/CodeGen.cpp
+++ b/flang/lib/Optimizer/CodeGen/CodeGen.cpp
@@ -12,11 +12,11 @@
 
 #include "flang/Optimizer/CodeGen/CodeGen.h"
 
-#include "flang/Optimizer/CodeGen/CGOps.h"
 #include "flang/Optimizer/CodeGen/CodeGenOpenMP.h"
 #include "flang/Optimizer/CodeGen/FIROpPatterns.h"
 #include "flang/Optimizer/CodeGen/TypeConverter.h"
 #include "flang/Optimizer/Dialect/FIRAttr.h"
+#include "flang/Optimizer/Dialect/FIRCG/CGOps.h"
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FIRType.h"

--- a/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/PreCGRewrite.cpp
@@ -13,7 +13,7 @@
 #include "flang/Optimizer/CodeGen/CodeGen.h"
 
 #include "flang/Optimizer/Builder/Todo.h" // remove when TODO's are done
-#include "flang/Optimizer/CodeGen/CGOps.h"
+#include "flang/Optimizer/Dialect/FIRCG/CGOps.h"
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FIRType.h"

--- a/flang/lib/Optimizer/Dialect/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(Support)
 add_subdirectory(CUF)
+add_subdirectory(FIRCG)
 
 add_flang_library(FIRDialect
   FIRAttr.cpp

--- a/flang/lib/Optimizer/Dialect/FIRCG/CGOps.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRCG/CGOps.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "flang/Optimizer/CodeGen/CGOps.h"
+#include "flang/Optimizer/Dialect/FIRCG/CGOps.h"
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
@@ -20,7 +20,7 @@ fir::FIRCodeGenDialect::FIRCodeGenDialect(mlir::MLIRContext *ctx)
     : mlir::Dialect("fircg", ctx, mlir::TypeID::get<FIRCodeGenDialect>()) {
   addOperations<
 #define GET_OP_LIST
-#include "flang/Optimizer/CodeGen/CGOps.cpp.inc"
+#include "flang/Optimizer/Dialect/FIRCG/CGOps.cpp.inc"
       >();
 }
 
@@ -30,7 +30,7 @@ fir::FIRCodeGenDialect::~FIRCodeGenDialect() {
 }
 
 #define GET_OP_CLASSES
-#include "flang/Optimizer/CodeGen/CGOps.cpp.inc"
+#include "flang/Optimizer/Dialect/FIRCG/CGOps.cpp.inc"
 
 unsigned fir::cg::XEmboxOp::getOutRank() {
   if (getSlice().empty())

--- a/flang/lib/Optimizer/Dialect/FIRCG/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/FIRCG/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_flang_library(FIRCodeGenDialect
+  CGOps.cpp
+
+  DEPENDS
+  CGOpsIncGen
+
+  LINK_LIBS
+  FIRDialect
+  MLIRIR
+
+  LINK_COMPONENTS
+  AsmParser
+  AsmPrinter
+  )

--- a/flang/lib/Optimizer/OpenACC/CMakeLists.txt
+++ b/flang/lib/Optimizer/OpenACC/CMakeLists.txt
@@ -6,7 +6,6 @@ add_flang_library(FIROpenACCSupport
 
   DEPENDS
   FIRBuilder
-  FIRCodeGen
   FIRDialect
   FIRDialectSupport
   FIRSupport
@@ -14,7 +13,7 @@ add_flang_library(FIROpenACCSupport
 
   LINK_LIBS
   FIRBuilder
-  FIRCodeGen
+  FIRCodeGenDialect
   FIRDialect
   FIRDialectSupport
   FIRSupport

--- a/flang/lib/Optimizer/OpenACC/FIROpenACCTypeInterfaces.cpp
+++ b/flang/lib/Optimizer/OpenACC/FIROpenACCTypeInterfaces.cpp
@@ -15,7 +15,7 @@
 #include "flang/Optimizer/Builder/DirectivesCommon.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/HLFIRTools.h"
-#include "flang/Optimizer/CodeGen/CGOps.h"
+#include "flang/Optimizer/Dialect/FIRCG/CGOps.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FIROpsSupport.h"
 #include "flang/Optimizer/Dialect/FIRType.h"

--- a/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
+++ b/flang/lib/Optimizer/Transforms/AddDebugInfo.cpp
@@ -14,7 +14,7 @@
 #include "DebugTypeGenerator.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/Todo.h"
-#include "flang/Optimizer/CodeGen/CGOps.h"
+#include "flang/Optimizer/Dialect/FIRCG/CGOps.h"
 #include "flang/Optimizer/Dialect/FIRDialect.h"
 #include "flang/Optimizer/Dialect/FIROps.h"
 #include "flang/Optimizer/Dialect/FIROpsSupport.h"

--- a/flang/lib/Optimizer/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/Transforms/CMakeLists.txt
@@ -47,6 +47,7 @@ add_flang_library(FIRTransforms
   FIRAnalysis
   FIRBuilder
   FIRCodeGen
+  FIRCodeGenDialect
   FIRDialect
   FIRDialectSupport
   FIRSupport

--- a/flang/lib/Optimizer/Transforms/DebugTypeGenerator.h
+++ b/flang/lib/Optimizer/Transforms/DebugTypeGenerator.h
@@ -13,8 +13,8 @@
 #ifndef FORTRAN_OPTIMIZER_TRANSFORMS_DEBUGTYPEGENERATOR_H
 #define FORTRAN_OPTIMIZER_TRANSFORMS_DEBUGTYPEGENERATOR_H
 
-#include "flang/Optimizer/CodeGen/CGOps.h"
 #include "flang/Optimizer/CodeGen/TypeConverter.h"
+#include "flang/Optimizer/Dialect/FIRCG/CGOps.h"
 #include "flang/Optimizer/Dialect/FIRType.h"
 #include "flang/Optimizer/Dialect/Support/FIRContext.h"
 #include "flang/Optimizer/Dialect/Support/KindMapping.h"

--- a/flang/tools/fir-opt/CMakeLists.txt
+++ b/flang/tools/fir-opt/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(fir-opt PRIVATE
   FIRSupport
   FIRTransforms
   FIRCodeGen
+  FIRCodeGenDialect
   HLFIRDialect
   HLFIRTransforms
   FIROpenACCSupport

--- a/flang/tools/tco/CMakeLists.txt
+++ b/flang/tools/tco/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(tco PRIVATE
   CUFAttrs
   CUFDialect
   FIRCodeGen
+  FIRCodeGenDialect
   FIRDialect
   FIRDialectSupport
   FIRSupport

--- a/flang/unittests/Optimizer/CMakeLists.txt
+++ b/flang/unittests/Optimizer/CMakeLists.txt
@@ -8,7 +8,7 @@ set(LLVM_LINK_COMPONENTS
 set(LIBS
   CUFDialect
   FIRBuilder
-  FIRCodeGen
+  FIRCodeGenDialect
   FIRDialect
   FIRDialectSupport
   FIRSupport


### PR DESCRIPTION
I am making a CG pass to depend on `FIROpenACCSupport` in #134346.
This introduces a cyclic dependency between `FIROpenACCSupport`
and `FIRCodeGen`. This patch splits `FIRCodeGen` into
`FIRCodeGenDialect` (for FIR CG dialect definition) and `FIRCodeGen`
(for the CG passes).

Now, `FIROpenACCSupport` depends on `FIRCodeGenDialect`,
and `FIRCodeGen` depends on `FIROpenACCSupport`.
