### PR TITLE
[clang] Make tests write to /dev/null if output is not needed

### DIFF
--- a/clang/test/Driver/openacc-no-cir.c
+++ b/clang/test/Driver/openacc-no-cir.c
@@ -1,6 +1,6 @@
-// RUN: %clang -fopenacc -S %s 2>&1 | FileCheck %s -check-prefix=ERROR
-// RUN: %clang -fclangir -fopenacc -S %s 2>&1 | FileCheck %s --allow-empty -check-prefix=NOERROR
-// RUN: %clang -fopenacc -fclangir -S %s 2>&1 | FileCheck %s --allow-empty -check-prefix=NOERROR
+// RUN: %clang -fopenacc -S %s -o /dev/null 2>&1 | FileCheck %s -check-prefix=ERROR
+// RUN: %clang -fclangir -fopenacc -S %s -o /dev/null 2>&1 | FileCheck %s --allow-empty -check-prefix=NOERROR
+// RUN: %clang -fopenacc -fclangir -S %s -o /dev/null 2>&1 | FileCheck %s --allow-empty -check-prefix=NOERROR
 
 // ERROR: OpenACC directives will result in no runtime behavior; use -fclangir to enable runtime effect
 // NOERROR-NOT: OpenACC directives


### PR DESCRIPTION
We execute tests in read only environment which leads to test failure when tests try to write to the current directory. Either they should write to a temporary directory or not write if output is not needed.

Fallback from #134717