### PR TITLE
[lldb] Support programmatically setting the statusline format (NFC)

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -307,6 +307,7 @@ public:
   bool GetShowStatusline() const;
 
   const FormatEntity::Entry *GetStatuslineFormat() const;
+  bool SetStatuslineFormat(const FormatEntity::Entry &format);
 
   llvm::StringRef GetShowProgressAnsiPrefix() const;
 

--- a/lldb/include/lldb/Interpreter/OptionValue.h
+++ b/lldb/include/lldb/Interpreter/OptionValue.h
@@ -72,7 +72,7 @@ public:
   virtual ~OptionValue() = default;
 
   OptionValue(const OptionValue &other);
-  
+
   OptionValue& operator=(const OptionValue &other);
 
   // Subclasses should override these functions
@@ -330,6 +330,10 @@ public:
 
   bool SetValueAs(ArchSpec v) { return SetArchSpecValue(v); }
 
+  bool SetValueAs(const FormatEntity::Entry &v) {
+    return SetFormatEntityValue(v);
+  }
+
   template <typename T, std::enable_if_t<std::is_enum_v<T>, bool> = true>
   bool SetValueAs(T t) {
     return SetEnumerationValue(t);
@@ -387,8 +391,10 @@ private:
   bool SetUUIDValue(const UUID &uuid);
 
   const FormatEntity::Entry *GetFormatEntity() const;
+  bool SetFormatEntityValue(const FormatEntity::Entry &entry);
+
   const RegularExpression *GetRegexValue() const;
-  
+
   mutable std::mutex m_mutex;
 };
 

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -484,6 +484,11 @@ const FormatEntity::Entry *Debugger::GetStatuslineFormat() const {
   return GetPropertyAtIndexAs<const FormatEntity::Entry *>(idx);
 }
 
+bool Debugger::SetStatuslineFormat(const FormatEntity::Entry &format) {
+  constexpr uint32_t idx = ePropertyStatuslineFormat;
+  return SetPropertyAtIndex(idx, format);
+}
+
 bool Debugger::GetUseAutosuggestion() const {
   const uint32_t idx = ePropertyShowAutosuggestion;
   return GetPropertyAtIndexAs<bool>(

--- a/lldb/source/Interpreter/OptionValue.cpp
+++ b/lldb/source/Interpreter/OptionValue.cpp
@@ -474,6 +474,15 @@ bool OptionValue::SetArchSpecValue(ArchSpec arch_spec) {
   return false;
 }
 
+bool OptionValue::SetFormatEntityValue(const FormatEntity::Entry &entry) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (OptionValueFormatEntity *option_value = GetAsFormatEntity()) {
+    option_value->SetCurrentValue(entry);
+    return true;
+  }
+  return false;
+}
+
 const char *OptionValue::GetBuiltinTypeAsCString(Type t) {
   switch (t) {
   case eTypeInvalid:

--- a/lldb/unittests/Core/CMakeLists.txt
+++ b/lldb/unittests/Core/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 add_lldb_unittest(LLDBCoreTests
+  DebuggerTest.cpp
   CommunicationTest.cpp
   DiagnosticEventTest.cpp
   DumpDataExtractorTest.cpp

--- a/lldb/unittests/Core/DebuggerTest.cpp
+++ b/lldb/unittests/Core/DebuggerTest.cpp
@@ -1,0 +1,52 @@
+//===-- DebuggerTest.cpp --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Core/Debugger.h"
+#include "Plugins/Platform/MacOSX/PlatformMacOSX.h"
+#include "Plugins/Platform/MacOSX/PlatformRemoteMacOSX.h"
+#include "TestingSupport/TestUtilities.h"
+#include "lldb/Host/FileSystem.h"
+#include "lldb/Host/HostInfo.h"
+#include "gtest/gtest.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+namespace {
+class DebuggerTest : public ::testing::Test {
+public:
+  void SetUp() override {
+    FileSystem::Initialize();
+    HostInfo::Initialize();
+    PlatformMacOSX::Initialize();
+    std::call_once(TestUtilities::g_debugger_initialize_flag,
+                   []() { Debugger::Initialize(nullptr); });
+    ArchSpec arch("x86_64-apple-macosx-");
+    Platform::SetHostPlatform(
+        PlatformRemoteMacOSX::CreateInstance(true, &arch));
+  }
+  void TearDown() override {
+    PlatformMacOSX::Terminate();
+    HostInfo::Terminate();
+    FileSystem::Terminate();
+  }
+};
+} // namespace
+
+TEST_F(DebuggerTest, TestSettings) {
+  DebuggerSP debugger_sp = Debugger::CreateInstance();
+
+  EXPECT_TRUE(debugger_sp->SetUseColor(true));
+  EXPECT_TRUE(debugger_sp->GetUseColor());
+
+  FormatEntity::Entry format("foo");
+  EXPECT_TRUE(debugger_sp->SetStatuslineFormat(format));
+  EXPECT_EQ(debugger_sp->GetStatuslineFormat()->string, "foo");
+
+  Debugger::Destroy(debugger_sp);
+}


### PR DESCRIPTION
Support programmatically setting the statusline format. I want to use this API downstream, to change the statusline format for the Swift REPL.