### PR TITLE
[clang][SPIRV] Set program address space for Intel-flavored SPIR-V

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -683,6 +683,8 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
         return std::make_unique<SPIRV64AMDGCNTargetInfo>(Triple, Opts);
       return nullptr;
     }
+    if (Triple.getVendor() == llvm::Triple::Intel)
+      return std::make_unique<SPIRV64IntelTargetInfo>(Triple, Opts);
     return std::make_unique<SPIRV64TargetInfo>(Triple, Opts);
   }
   case llvm::Triple::wasm32:

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -469,6 +469,17 @@ public:
   bool hasInt128Type() const override { return TargetInfo::hasInt128Type(); }
 };
 
+class LLVM_LIBRARY_VISIBILITY SPIRV64IntelTargetInfo final
+    : public SPIRV64TargetInfo {
+public:
+  SPIRV64IntelTargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts)
+      : SPIRV64TargetInfo(Triple, Opts) {
+    assert(Triple.getVendor() == llvm::Triple::VendorType::Intel &&
+           "64-bit Intel SPIR-V target must use Intel vendor");
+    resetDataLayout("e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-"
+                    "v256:256-v512:512-v1024:1024-n8:16:32:64-G1-P4-A0");
+  }
+};
 } // namespace targets
 } // namespace clang
 #endif // LLVM_CLANG_LIB_BASIC_TARGETS_SPIR_H

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -477,7 +477,7 @@ public:
     assert(Triple.getVendor() == llvm::Triple::VendorType::Intel &&
            "64-bit Intel SPIR-V target must use Intel vendor");
     resetDataLayout("e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-"
-                    "v256:256-v512:512-v1024:1024-n8:16:32:64-G1-P4-A0");
+                    "v256:256-v512:512-v1024:1024-n8:16:32:64-G1-P9-A0");
   }
 };
 } // namespace targets

--- a/clang/test/CodeGenSPIRV/spirv-intel.c
+++ b/clang/test/CodeGenSPIRV/spirv-intel.c
@@ -1,9 +1,11 @@
-// RUN: %clang_cc1 -triple spirv64-intel %s -emit-llvm -o - | FileCheck -check-prefix=CHECK-WITH %s
-// RUN: %clang_cc1 -triple spirv32-intel %s -emit-llvm -o - | FileCheck -check-prefix=CHECK-WITH %s
+// RUN: %clang_cc1 -triple spirv64-intel %s -emit-llvm -o - | FileCheck -check-prefix=CHECK-WITH-64 %s
+// RUN: %clang_cc1 -triple spirv32-intel %s -emit-llvm -o - | FileCheck -check-prefix=CHECK-WITH-32 %s
 // RUN: %clang_cc1 -triple spir-intel %s -emit-llvm -o - | FileCheck -check-prefix=CHECK-WITHOUT %s
 // RUN: %clang_cc1 -triple spir64-intel %s -emit-llvm -o - | FileCheck -check-prefix=CHECK-WITHOUT %s
 
-// CHECK-WITH: spir_func void @foo(ptr addrspace(4) noundef %param) #0 {
+// CHECK-WITH-64: spir_func void @foo(ptr addrspace(4) noundef %param) addrspace(4) #0 {
+// CHECK-WITH-32: spir_func void @foo(ptr addrspace(4) noundef %param) #0 {
+
 // CHECK-WITHOUT: spir_func void @foo(ptr noundef %param) #0 {
 void foo(int *param) {
 }

--- a/clang/test/CodeGenSPIRV/spirv-intel.c
+++ b/clang/test/CodeGenSPIRV/spirv-intel.c
@@ -3,7 +3,7 @@
 // RUN: %clang_cc1 -triple spir-intel %s -emit-llvm -o - | FileCheck -check-prefix=CHECK-WITHOUT %s
 // RUN: %clang_cc1 -triple spir64-intel %s -emit-llvm -o - | FileCheck -check-prefix=CHECK-WITHOUT %s
 
-// CHECK-WITH-64: spir_func void @foo(ptr addrspace(4) noundef %param) addrspace(4) #0 {
+// CHECK-WITH-64: spir_func void @foo(ptr addrspace(4) noundef %param) addrspace(9) #0 {
 // CHECK-WITH-32: spir_func void @foo(ptr addrspace(4) noundef %param) #0 {
 
 // CHECK-WITHOUT: spir_func void @foo(ptr noundef %param) #0 {

--- a/clang/test/OpenMP/spirv_variant_match.cpp
+++ b/clang/test/OpenMP/spirv_variant_match.cpp
@@ -35,7 +35,7 @@ int foo() { return 1; }
 
 // CHECK-DAG: define{{.*}} @{{"_Z[0-9]+foo\$ompvariant\$.*"}}()
 
-// CHECK-DAG: call spir_func noundef i32 @{{"_Z[0-9]+foo\$ompvariant\$.*"}}()
+// CHECK-DAG: call spir_func noundef addrspace(4) i32 @{{"_Z[0-9]+foo\$ompvariant\$.*"}}()
 
 int main() {
   int res;

--- a/clang/test/OpenMP/spirv_variant_match.cpp
+++ b/clang/test/OpenMP/spirv_variant_match.cpp
@@ -35,7 +35,7 @@ int foo() { return 1; }
 
 // CHECK-DAG: define{{.*}} @{{"_Z[0-9]+foo\$ompvariant\$.*"}}()
 
-// CHECK-DAG: call spir_func noundef addrspace(4) i32 @{{"_Z[0-9]+foo\$ompvariant\$.*"}}()
+// CHECK-DAG: call spir_func noundef addrspace(9) i32 @{{"_Z[0-9]+foo\$ompvariant\$.*"}}()
 
 int main() {
   int res;

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
@@ -90,6 +90,10 @@ SPIRVSubtarget::SPIRVSubtarget(const Triple &TT, const std::string &CPU,
   else
     Env = Unknown;
 
+  // Set the default extensions based on the target triple.
+  if (TargetTriple.getVendor() == Triple::Intel)
+    Extensions.insert(SPIRV::Extension::SPV_INTEL_function_pointers);
+
   // The order of initialization is important.
   initAvailableExtensions(Extensions);
   initAvailableExtInstSets();

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -77,6 +77,9 @@ static std::string computeDataLayout(const Triple &TT) {
       TT.getOS() == Triple::OSType::AMDHSA)
     return "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-"
            "v512:512-v1024:1024-n32:64-S32-G1-P4-A0";
+  if (TT.getVendor() == Triple::VendorType::Intel)
+    return "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-"
+           "v512:512-v1024:1024-n8:16:32:64-G1-P4-A0";
   return "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-"
          "v512:512-v1024:1024-n8:16:32:64-G1";
 }

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -79,7 +79,7 @@ static std::string computeDataLayout(const Triple &TT) {
            "v512:512-v1024:1024-n32:64-S32-G1-P4-A0";
   if (TT.getVendor() == Triple::VendorType::Intel)
     return "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-"
-           "v512:512-v1024:1024-n8:16:32:64-G1-P4-A0";
+           "v512:512-v1024:1024-n8:16:32:64-G1-P9-A0";
   return "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-"
          "v512:512-v1024:1024-n8:16:32:64-G1";
 }


### PR DESCRIPTION
Technically, SPIR-V should use addrspace(4) for generic pointers.

We already set the default AS in TargetInfo to 4, but that's not enough for all cases. Also set the program address space to 4 to fix the remaining cases. AMD already does this for their SPIR-V target, do it for Intel's SPIR-V target.

I need this for OpenMP offloading to SPIR-V. There are a couple of places I need to change in the OMP FE to check the program AS, I'll do that in a follow-up PR.