### PR TITLE
[clang][test][NFC] Use -fdriver-only over /dev/null

### DIFF
--- a/clang/test/Driver/openacc-no-cir.c
+++ b/clang/test/Driver/openacc-no-cir.c
@@ -1,6 +1,6 @@
-// RUN: %clang -fopenacc -S %s -o /dev/null 2>&1 | FileCheck %s -check-prefix=ERROR
-// RUN: %clang -fclangir -fopenacc -S %s -o /dev/null 2>&1 | FileCheck %s --allow-empty -check-prefix=NOERROR
-// RUN: %clang -fopenacc -fclangir -S %s -o /dev/null 2>&1 | FileCheck %s --allow-empty -check-prefix=NOERROR
+// RUN: %clang -fopenacc -S %s -o -fdriver-only 2>&1 | FileCheck %s -check-prefix=ERROR
+// RUN: %clang -fclangir -fopenacc -S %s -fdriver-only 2>&1 | FileCheck %s --allow-empty -check-prefix=NOERROR
+// RUN: %clang -fopenacc -fclangir -S %s -fdriver-only 2>&1 | FileCheck %s --allow-empty -check-prefix=NOERROR
 
 // ERROR: OpenACC directives will result in no runtime behavior; use -fclangir to enable runtime effect
 // NOERROR-NOT: OpenACC directives


### PR DESCRIPTION
Tests should avoid using platform dependent behavior, like /dev/null
when possible. -fdriver-only should stop clang even earlier, and avoid
any non-diagnostic output.