### PR TITLE
[Clang] [Sema] Document invariant in Sema::AddOverloadCandidate

### DIFF
--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -7189,6 +7189,7 @@ void Sema::AddOverloadCandidate(
     }
   }
 
+  assert(PO != OverloadCandidateParamOrder::Reversed || Args.size() == 2);
   // Determine the implicit conversion sequences for each of the
   // arguments.
   for (unsigned ArgIdx = 0; ArgIdx < Args.size(); ++ArgIdx) {


### PR DESCRIPTION
Static analysis flagged 1 - ArgIdx in Sema::AddOverloadCandidate for its potential to overflow.

Turns out this is intentional since when PO ==
OverloadCandidateParamOrder::Reversed Args.size() is always two, so this will never overflow.

We document using an assert.

Fixes: https://github.com/llvm/llvm-project/issues/135086