### PR TITLE
[flang-rt] Update `test_flang` in CI to use `flang-rt` as one of the projects.

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -25,6 +25,7 @@ PROJECT_DEPENDENCIES = {
     "libc": {"clang", "lld"},
     "openmp": {"clang", "lld"},
     "flang": {"llvm", "clang"},
+    "flang-rt": {"flang"},
     "lldb": {"llvm", "clang"},
     "libclc": {"llvm", "clang"},
     "lld": {"llvm"},
@@ -51,6 +52,7 @@ DEPENDENTS_TO_TEST = {
     # TODO(issues/132795): LLDB should be enabled on clang changes.
     "clang": {"clang-tools-extra", "compiler-rt", "cross-project-tests"},
     "clang-tools-extra": {"libc"},
+    "flang": {"flang-rt"},
     "mlir": {"flang"},
 }
 
@@ -104,6 +106,7 @@ PROJECT_CHECK_TARGETS = {
     "bolt": "check-bolt",
     "lld": "check-lld",
     "flang": "check-flang",
+    "flang-rt": "check-flang",
     "libc": "check-libc",
     "lld": "check-lld",
     "lldb": "check-lldb",

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -140,7 +140,9 @@ class TestComputeProjects(unittest.TestCase):
         env_variables = compute_projects.get_env_variables(
             ["flang/CMakeLists.txt"], "Linux"
         )
-        self.assertEqual(env_variables["projects_to_build"], "clang;flang;llvm;flang-rt")
+        self.assertEqual(
+            env_variables["projects_to_build"], "clang;flang;llvm;flang-rt"
+        )
         self.assertEqual(env_variables["project_check_targets"], "check-flang")
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -140,7 +140,7 @@ class TestComputeProjects(unittest.TestCase):
         env_variables = compute_projects.get_env_variables(
             ["flang/CMakeLists.txt"], "Linux"
         )
-        self.assertEqual(env_variables["projects_to_build"], "clang;flang;llvm")
+        self.assertEqual(env_variables["projects_to_build"], "clang;flang;llvm;flang-rt")
         self.assertEqual(env_variables["project_check_targets"], "check-flang")
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")


### PR DESCRIPTION
The CI `test_flang` seems not being updated since `flang-rt` is separated from the `flang` build. 
This PR is to update `test_flang` to put `flang-rt` as one of the projects when testing flang, so it uses bootstrap build instead of part of the flang build, which we are moving away from. It is also consistent with the buildbots.
I am not familiar with the CI configuration, so this PR serves as an initiation for the update.