### PR TITLE
Reland "Replace bool operator== for VersionType in sanitizer_mac.h"

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_mac.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_mac.h
@@ -37,15 +37,18 @@ struct VersionBase {
 
   VersionBase(u16 major, u16 minor) : major(major), minor(minor) {}
 
-  bool operator==(const VersionType &other) const {
-    return major == other.major && minor == other.minor;
-  }
   bool operator>=(const VersionType &other) const {
     return major > other.major ||
            (major == other.major && minor >= other.minor);
   }
   bool operator<(const VersionType &other) const { return !(*this >= other); }
 };
+
+template <typename VersionType>
+bool operator==(const VersionBase<VersionType> &self,
+                const VersionBase<VersionType> &other) {
+  return self.major == other.major && self.minor == other.minor;
+}
 
 struct MacosVersion : VersionBase<MacosVersion> {
   MacosVersion(u16 major, u16 minor) : VersionBase(major, minor) {}


### PR DESCRIPTION
Fixes error: ISO C++20 considers use of overloaded operator '==' (with operand types 'MacosVersion' and 'MacosVersion') to be ambiguous despite there being a unique best viable function [-Werror,-Wambiguous-reversed-operator].

This converts the comparison operator from a non-symmetric operator (const VersionBase<VersionType>& (as "this") and const VersionType &). into a symmetric operator

Relands #135068