### PR TITLE
[libc] Improve the state of the lint rules

### DIFF
--- a/libc/.clang-tidy
+++ b/libc/.clang-tidy
@@ -6,6 +6,8 @@ CheckOptions:
     value:           CamelCase
   - key:             readability-identifier-naming.StructCase
     value:           aNy_CasE
+  - key:             readability-identifier-naming.StructIgnoredRegexp
+    value:           "_?(_[A-Za-z0-9]+)*"
   - key:             readability-identifier-naming.MemberCase
     value:           lower_case
   - key:             readability-identifier-naming.MemberIgnoredRegexp
@@ -13,6 +15,10 @@ CheckOptions:
   - key:             readability-identifier-naming.VariableCase
     value:           lower_case
   - key:             readability-identifier-naming.VariableIgnoredRegexp
+    value:           "_?(_[A-Za-z0-9]+)*"
+  - key:             readability-identifier-naming.ParameterCase
+    value:           lower_case
+  - key:             readability-identifier-naming.ParameterIgnoredRegexp
     value:           "_?(_[A-Za-z0-9]+)*"
   - key:             readability-identifier-naming.FunctionCase
     value:           lower_case
@@ -26,6 +32,8 @@ CheckOptions:
     value:           UPPER_CASE
   - key:             readability-identifier-naming.ConstexprVariableCase
     value:           UPPER_CASE
+  - key:             readability-identifier-naming.ConstexprVariableIgnoredRegexp
+    value:           "is(_[A-Za-z0-9]+)*_v"
   - key:             readability-identifier-naming.ConstexprFunctionCase
     value:           lower_case
   - key:             readability-identifier-naming.GetConfigPerFile

--- a/libc/cmake/modules/LLVMLibCObjectRules.cmake
+++ b/libc/cmake/modules/LLVMLibCObjectRules.cmake
@@ -355,7 +355,7 @@ function(create_entrypoint_object fq_target_name)
       # Until this is fixed upstream, we use -fno-caret-diagnostics to surpress
       # these.
       COMMAND ${LLVM_LIBC_CLANG_TIDY}
-              "--extra-arg=-fno-caret-diagnostics" --quiet
+              "--extra-arg=-fno-caret-diagnostics" --quiet --fix
               # Path to directory containing compile_commands.json
               -p ${PROJECT_BINARY_DIR}
               ${ADD_ENTRYPOINT_OBJ_SRCS}

--- a/libc/include/.clang-tidy
+++ b/libc/include/.clang-tidy
@@ -1,0 +1,3 @@
+InheritParentConfig: false
+Checks: ''
+HeaderFilterRegex: '.*'

--- a/libc/src/.clang-tidy
+++ b/libc/src/.clang-tidy
@@ -4,4 +4,4 @@ HeaderFilterRegex: '.*'
 WarningsAsErrors: 'llvmlibc-*'
 CheckOptions:
   - key:             llvmlibc-restrict-system-libc-headers.Includes
-    value:           '-*, linux/*, asm/*.h, asm-generic/*.h'
+    value:           '-*, linux/*, asm/*.h, asm-generic/*.h. sys/syscall.h'


### PR DESCRIPTION
The goal of this change is to update the rules such that we can run the
linter and get a clean result. For testing purposes set
`-DLLVM_LIBC_ENABLE_LINTING=ON` and run `ninja -j 1 -k 0 libc-lint`, or
pick a single `__lint__` target, such as `ninja
libc.src.stdio.sprintf.__lint__`.

BEFORE MERGING:
remove --fix from the lint target
