### PR TITLE
[DirectX] XFAIL test failing because of debuginfo changes

### DIFF
--- a/llvm/test/tools/dxil-dis/debug-info.ll
+++ b/llvm/test/tools/dxil-dis/debug-info.ll
@@ -1,4 +1,7 @@
 ; RUN: llc --filetype=obj %s -o  - -experimental-debuginfo-iterators=false | dxil-dis -o - | FileCheck %s
+; Note: LLVM has soft disabled experimental-debuginfo-iterators in commit 6a45fce
+; XFAIL: *
+
 target triple = "dxil-unknown-shadermodel6.7-library"
 target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128"
 


### PR DESCRIPTION
For more context see https://discourse.llvm.org/t/psa-ir-output-changing-from-debug-intrinsics-to-debug-records/79578

This change: https://github.com/llvm/llvm-project/commit/6a45fce90937f1c8671e609c4218818ce4491329
broke this test: https://github.com/llvm/llvm-project/blob/main/llvm/test/tools/dxil-dis/debug-info.ll
in our pipeline: https://github.com/llvm/llvm-project/actions/workflows/hlsl-matrix.yaml

LLVM is transitioning off of the llvm.dbg.value debug intrinsic in favor of the `#dbg_declare(..) format. see https://github.com/llvm/llvm-project/pull/133917/files

dxil-dis does not understand the new format and so work needs to be planned out to support this transition 

For now the fix is to XFAIL this test to unblock the pipeline.