### PR TITLE
[CIR] Fix warnings, again!

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.h
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.h
@@ -164,7 +164,7 @@ public:
   /// An abstract representation of regular/ObjC call/message targets.
   class AbstractCallee {
     /// The function declaration of the callee.
-    const clang::Decl *calleeDecl;
+    [[maybe_unused]] const clang::Decl *calleeDecl;
 
   public:
     AbstractCallee() : calleeDecl(nullptr) {}

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -262,6 +262,7 @@ CIRGenModule::getOrCreateCIRGlobal(StringRef mangledName, mlir::Type ty,
   }
 
   errorNYI(d->getSourceRange(), "reference of undeclared global");
+  return {};
 }
 
 cir::GlobalOp


### PR DESCRIPTION
The calleeDecl var will be used in the near future, so I left it. At least for clang, the [[maybe_unused]] attribute takes care of the warnings related to that variable. The other warning was a simple lack of return after errorNYI.