### PR TITLE
[CUDA][Windows] detect installation via CUDA_PATH environment variable

### DIFF
--- a/clang/lib/Driver/ToolChains/Cuda.cpp
+++ b/clang/lib/Driver/ToolChains/Cuda.cpp
@@ -158,6 +158,11 @@ CudaInstallationDetector::CudaInstallationDetector(
     Candidates.emplace_back(
         Args.getLastArgValue(clang::driver::options::OPT_cuda_path_EQ).str());
   } else if (HostTriple.isOSWindows()) {
+    if (std::optional<std::string> CudaPath =
+            llvm::sys::Process::GetEnv("CUDA_PATH")) {
+      if (!CudaPath->empty())
+        Candidates.emplace_back(std::move(*CudaPath));
+    }
     for (const char *Ver : Versions)
       Candidates.emplace_back(
           D.SysRoot + "/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v" +


### PR DESCRIPTION
On Windows platforms, this patch enables detection of the CUDA installation directory by checking the CUDA_PATH environment variable.