### PR TITLE
[nvptx-arch] allowed load `nvcuda.dll` on Windows

### DIFF
--- a/clang/tools/offload-arch/NVPTXArch.cpp
+++ b/clang/tools/offload-arch/NVPTXArch.cpp
@@ -39,7 +39,11 @@ CUresult (*cuGetErrorString)(CUresult, const char **);
 CUresult (*cuDeviceGet)(CUdevice *, int);
 CUresult (*cuDeviceGetAttribute)(int *, CUdevice_attribute, CUdevice);
 
+#if defined(_WIN32)
+constexpr const char *DynamicCudaPath = "nvcuda.dll";
+#else
 constexpr const char *DynamicCudaPath = "libcuda.so.1";
+#endif
 
 llvm::Error loadCUDA() {
   std::string ErrMsg;


### PR DESCRIPTION
Make nvptx-arch work on windows