### PR TITLE
[flang][openacc] Allow multiple device_type clauses on init and shutdown

### DIFF
--- a/flang/test/Lower/OpenACC/acc-init.f90
+++ b/flang/test/Lower/OpenACC/acc-init.f90
@@ -35,4 +35,7 @@ subroutine acc_init
    !$acc init device_type(nvidia)
 !CHECK: acc.init attributes {device_types = [#acc.device_type<nvidia>]}
 
+  !$acc init device_type(host) device_type(multicore)
+!CHECK: acc.init attributes {device_types = [#acc.device_type<host>, #acc.device_type<multicore>]}
+
 end subroutine acc_init

--- a/flang/test/Lower/OpenACC/acc-shutdown.f90
+++ b/flang/test/Lower/OpenACC/acc-shutdown.f90
@@ -25,4 +25,7 @@ subroutine acc_shutdown
 !CHECK: [[DEVNUM:%.*]] = arith.constant 1 : i32
 !CHECK: acc.shutdown device_num([[DEVNUM]] : i32) attributes {device_types = [#acc.device_type<default>, #acc.device_type<nvidia>]} 
 
+  !$acc shutdown device_type(default) device_type(nvidia)
+!CHECK: acc.shutdown attributes {device_types = [#acc.device_type<default>, #acc.device_type<nvidia>]} 
+
 end subroutine acc_shutdown

--- a/flang/test/Semantics/OpenACC/acc-init-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-init-validity.f90
@@ -93,7 +93,7 @@ program openacc_init_validity
   !ERROR: At most one DEVICE_NUM clause can appear on the INIT directive
   !$acc init device_num(1) device_num(i)
 
-  !ERROR: At most one DEVICE_TYPE clause can appear on the INIT directive
+  ! OK
   !$acc init device_type(nvidia) device_type(default, *)
 
   !ERROR: Must have LOGICAL or INTEGER type

--- a/flang/test/Semantics/OpenACC/acc-shutdown-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-shutdown-validity.f90
@@ -90,7 +90,7 @@ program openacc_shutdown_validity
   !ERROR: At most one DEVICE_NUM clause can appear on the SHUTDOWN directive
   !$acc shutdown device_num(1) device_num(i)
 
-  !ERROR: At most one DEVICE_TYPE clause can appear on the SHUTDOWN directive
+  ! OK
   !$acc shutdown device_type(*) device_type(host, default)
 
 end program openacc_shutdown_validity

--- a/llvm/include/llvm/Frontend/OpenACC/ACC.td
+++ b/llvm/include/llvm/Frontend/OpenACC/ACC.td
@@ -432,11 +432,9 @@ def ACC_Cache : Directive<"cache"> {
 
 // 2.14.1
 def ACC_Init : Directive<"init"> {
-  let allowedOnceClauses = [
-    VersionedClause<ACCC_DeviceNum>,
-    VersionedClause<ACCC_DeviceType>,
-    VersionedClause<ACCC_If>
-  ];
+  let allowedOnceClauses = [VersionedClause<ACCC_DeviceNum>,
+                            VersionedClause<ACCC_If>];
+  let allowedClauses = [VersionedClause<ACCC_DeviceType>];
   let association = AS_None;
   let category = CA_Executable;
 }
@@ -480,11 +478,9 @@ def ACC_Set : Directive<"set"> {
 
 // 2.14.2
 def ACC_Shutdown : Directive<"shutdown"> {
-  let allowedOnceClauses = [
-    VersionedClause<ACCC_DeviceNum>,
-    VersionedClause<ACCC_DeviceType>,
-    VersionedClause<ACCC_If>
-  ];
+  let allowedOnceClauses = [VersionedClause<ACCC_DeviceNum>,
+                            VersionedClause<ACCC_If>];
+  let allowedClauses = [VersionedClause<ACCC_DeviceType>];
   let association = AS_None;
   let category = CA_Executable;
 }


### PR DESCRIPTION
Relax the restriction for init and shutdown directives for device_type clause. The clause can be allowed multiple times. 