### PR TITLE
[BUILD] Fix unicode build issue.

### DIFF
--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -232,7 +232,7 @@
 
 // Only enabled for clang:
 // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99587
-// GCC may produce "warning: ‘retain’ attribute ignored" (despite
+// GCC may produce "warning: 'retain' attribute ignored" (despite
 // __has_attribute(retain) being 1).
 #if defined(__clang__) && __has_attribute(retain)
 #define LLVM_ATTRIBUTE_RETAIN __attribute__((__retain__))


### PR DESCRIPTION
Fix unicode build fail issue:
```
C4819	The file contains a character that cannot be represented in the current code page (936). Save the file in Unicode format to prevent data loss	...\llvm-project\llvm\include\llvm\Support\Compiler.h
```