### PR TITLE
[Bazel] Remove redundant gtest_main from codegen_tests, codegen_globalisel_tests, mi_tests

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/unittests/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/unittests/BUILD.bazel
@@ -174,7 +174,6 @@ cc_test(
         "//llvm:Target",
         "//llvm:TestingSupport",
         "//third-party/unittest:gtest",
-        "//third-party/unittest:gtest_main",
     ],
 )
 
@@ -203,7 +202,6 @@ cc_test(
         "//llvm:Support",
         "//llvm:Target",
         "//third-party/unittest:gtest",
-        "//third-party/unittest:gtest_main",
     ],
 )
 
@@ -501,7 +499,6 @@ cc_test(
         "//llvm:Support",
         "//llvm:Target",
         "//third-party/unittest:gtest",
-        "//third-party/unittest:gtest_main",
     ],
 )
 


### PR DESCRIPTION
 For codegen_tests, codegen_globalisel_tests and mi_tests, they already have their own `main` function defined, so there should be no need to add `gtest_main` dependency for the main function...

- codegen_tests: https://github.com/llvm/llvm-project/blob/main/llvm/unittests/CodeGen/TargetOptionsTest.cpp#L73
- codegen_globalisel_tests: https://github.com/llvm/llvm-project/blob/main/llvm/unittests/CodeGen/GlobalISel/PatternMatchTest.cpp#L978
- mi_tests: https://github.com/llvm/llvm-project/blob/main/llvm/unittests/MI/LiveIntervalTest.cpp#L933