### PR TITLE
[NFC] Use the hasMinSize() instead of hasFnAttribute(Attribute::MinSize)

### DIFF
--- a/llvm/lib/Transforms/IPO/HotColdSplitting.cpp
+++ b/llvm/lib/Transforms/IPO/HotColdSplitting.cpp
@@ -199,7 +199,7 @@ static bool markFunctionCold(Function &F, bool UpdateEntryCount = false) {
     F.addFnAttr(Attribute::Cold);
     Changed = true;
   }
-  if (!F.hasFnAttribute(Attribute::MinSize)) {
+  if (!F.hasMinSize()) {
     F.addFnAttr(Attribute::MinSize);
     Changed = true;
   }

--- a/llvm/lib/Transforms/Scalar/JumpThreading.cpp
+++ b/llvm/lib/Transforms/Scalar/JumpThreading.cpp
@@ -303,7 +303,7 @@ bool JumpThreadingPass::runImpl(Function &F_, FunctionAnalysisManager *FAM_,
   // size.
   if (BBDuplicateThreshold.getNumOccurrences())
     BBDupThreshold = BBDuplicateThreshold;
-  else if (F->hasFnAttribute(Attribute::MinSize))
+  else if (F->hasMinSize())
     BBDupThreshold = 3;
   else
     BBDupThreshold = DefaultBBDupThreshold;


### PR DESCRIPTION
The other code all use the hasMinSize(), so I change the last two hasFnAttribute(Attribute::MinSize).