### PR TITLE
[clang][ReleaseNotes] Fix code block not rendering

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -334,6 +334,7 @@ Improvements to Clang's diagnostics
 - Fixed an assertion when referencing an out-of-bounds parameter via a function
   attribute whose argument list refers to parameters by index and the function
   is variadic. e.g.,
+
   .. code-block:: c
 
     __attribute__ ((__format_arg__(2))) void test (int i, ...) { }


### PR DESCRIPTION
Bullet lists require a blank line between paragraphs therefore the `.. code-block::` directive only renders correctly if preceded by a blank line.