### PR TITLE
[libcxxabi] Fix the long double demangling for PowerPC

### DIFF
--- a/libcxxabi/src/demangle/ItaniumDemangle.h
+++ b/libcxxabi/src/demangle/ItaniumDemangle.h
@@ -5741,7 +5741,7 @@ struct FloatData<double>
 template <>
 struct FloatData<long double>
 {
-#if __LDBL_MANT_DIG__ == 113
+#if __LDBL_MANT_DIG__ == 113 || __LDBL_MANT_DIG__ == 106
   static const size_t mangled_size = 32;
 #elif __LDBL_MANT_DIG__ == 53 || defined(_MSC_VER)
   // MSVC doesn't define __LDBL_MANT_DIG__, but it has long double equal to


### PR DESCRIPTION
PowerPC uses a slightly different type of floats for their 128 bit long doubles, as "double-double", with __LDBL_MANT_DIG__ == 106 rather than __LDBL_MANT_DIG__ == 113 for IEEE 128 bit floats.

This fixes compiling libcxxabi for PowerPC after
3b70715c13876c51542ebfe2e3f4ee908f6785cb.