### PR TITLE
[C23] Fix failed assertions with invalid #embed parameters

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -170,6 +170,8 @@ C23 Feature Support
   scope.
 - Fixed a bug where you could not cast a null pointer constant to type
   ``nullptr_t``. Fixes #GH133644.
+- Fixed a failed assertion with an invalid parameter to the ``#embed``
+  directive. Fixes #GH126940.
 
 C11 Feature Support
 ^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -3897,7 +3897,9 @@ Preprocessor::LexEmbedParameters(Token &CurTok, bool ForHasEmbed) {
           return std::nullopt;
       }
       if (!ForHasEmbed) {
-        Diag(CurTok, diag::err_pp_unknown_parameter) << 1 << Parameter;
+        Diag(ParamStartLoc, diag::err_pp_unknown_parameter) << 1 << Parameter;
+        if (CurTok.isNot(tok::eod))
+          DiscardUntilEndOfDirective(CurTok);
         return std::nullopt;
       }
     }

--- a/clang/test/Preprocessor/embed_parameter_unrecognized.c
+++ b/clang/test/Preprocessor/embed_parameter_unrecognized.c
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 %s -std=c23 -E -verify
-// okay-no-diagnostics
 
 #embed __FILE__ unrecognized
 // expected-error@-1 {{unknown embed preprocessor parameter 'unrecognized'}}
@@ -7,3 +6,12 @@
 // expected-error@-1 {{unknown embed preprocessor parameter 'unrecognized::param'}}
 #embed __FILE__ unrecognized::param(with, args)
 // expected-error@-1 {{unknown embed preprocessor parameter 'unrecognized::param'}}
+
+// The first of these two cases was causing a failed assertion due to not being
+// at the end of the directive when we finished skipping past `bla`.
+#embed __FILE__ bla(2) limit(2) // expected-error {{unknown embed preprocessor parameter 'bla'}}
+#embed __FILE__ limit(2) bla(2) // expected-error {{unknown embed preprocessor parameter 'bla'}}
+
+// We intentionally only tell you about one invalid parameter at a time so that
+// we can skip over invalid token soup.
+#embed __FILE__ bla(2) limit(2) bork // expected-error {{unknown embed preprocessor parameter 'bla'}}


### PR DESCRIPTION
If the invalid parameter was not the last parameter given, we would fail to skip to the end of the directive and trip a failed assertion.

Fixes #126940