### PR TITLE
[NFC][Clang] Don't check hardcode op num

### DIFF
--- a/clang/test/Modules/no-external-type-id.cppm
+++ b/clang/test/Modules/no-external-type-id.cppm
@@ -23,7 +23,7 @@ export module b;
 import a;
 export int b();
 
-// CHECK: <DECL_FUNCTION {{.*}} op8=4120
+// CHECK: <DECL_FUNCTION {{.*}} op8=[[#]]
 // CHECK: <TYPE_FUNCTION_PROTO
 
 //--- a.v1.cppm


### PR DESCRIPTION
The num will change for any downstream customization.
