### PR TITLE
[MLIR][CAPI] add C API typedef to fix downstream C API usage

### DIFF
--- a/mlir/include/mlir-c/Dialect/Linalg.h
+++ b/mlir/include/mlir-c/Dialect/Linalg.h
@@ -24,19 +24,19 @@ mlirLinalgFillBuiltinNamedOpRegion(MlirOperation mlirOp);
 
 MLIR_CAPI_EXPORTED bool mlirLinalgIsAContractionOp(MlirOperation op);
 
-struct MlirLinalgContractionDimensions {
+typedef struct MlirLinalgContractionDimensions {
   MlirAttribute batch;
   MlirAttribute m;
   MlirAttribute n;
   MlirAttribute k;
-};
+} MlirLinalgContractionDimensions;
 
 MLIR_CAPI_EXPORTED MlirLinalgContractionDimensions
 mlirLinalgInferContractionDimensions(MlirOperation op);
 
 MLIR_CAPI_EXPORTED bool mlirLinalgIsAConvolutionOp(MlirOperation op);
 
-struct MlirLinalgConvolutionDimensions {
+typedef struct MlirLinalgConvolutionDimensions {
   MlirAttribute batch;
   MlirAttribute outputImage;
   MlirAttribute outputChannel;
@@ -45,7 +45,7 @@ struct MlirLinalgConvolutionDimensions {
   MlirAttribute depth;
   MlirAttribute strides;
   MlirAttribute dilations;
-};
+} MlirLinalgConvolutionDimensions;
 
 MLIR_CAPI_EXPORTED MlirLinalgConvolutionDimensions
 mlirLinalgInferConvolutionDimensions(MlirOperation op);


### PR DESCRIPTION
This PR is after #135253 and #134935 to fix the error reported by https://github.com/llvm/llvm-project/pull/135253#issuecomment-2796077024. This PR Adds typedef declarations for `MlirLinalgContractionDimensions` and `MlirLinalgConvolutionDimensions` in the C API to ensure compatibility with pure C code.

I confirm that this fix resolves the reported error based on my testing.