### PR TITLE
[NFC][MC] Use `StringRef` for Modifier in Inst/Asm Printers

### DIFF
--- a/llvm/lib/Target/BPF/MCTargetDesc/BPFInstPrinter.cpp
+++ b/llvm/lib/Target/BPF/MCTargetDesc/BPFInstPrinter.cpp
@@ -51,8 +51,7 @@ static void printExpr(const MCExpr *Expr, raw_ostream &O) {
 }
 
 void BPFInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
-                                  raw_ostream &O, const char *Modifier) {
-  assert((Modifier == nullptr || Modifier[0] == 0) && "No modifiers supported");
+                                  raw_ostream &O) {
   const MCOperand &Op = MI->getOperand(OpNo);
   if (Op.isReg()) {
     O << getRegisterName(Op.getReg());
@@ -64,8 +63,8 @@ void BPFInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
   }
 }
 
-void BPFInstPrinter::printMemOperand(const MCInst *MI, int OpNo, raw_ostream &O,
-                                     const char *Modifier) {
+void BPFInstPrinter::printMemOperand(const MCInst *MI, int OpNo,
+                                     raw_ostream &O) {
   const MCOperand &RegOp = MI->getOperand(OpNo);
   const MCOperand &OffsetOp = MI->getOperand(OpNo + 1);
 

--- a/llvm/lib/Target/BPF/MCTargetDesc/BPFInstPrinter.h
+++ b/llvm/lib/Target/BPF/MCTargetDesc/BPFInstPrinter.h
@@ -24,10 +24,8 @@ public:
 
   void printInst(const MCInst *MI, uint64_t Address, StringRef Annot,
                  const MCSubtargetInfo &STI, raw_ostream &O) override;
-  void printOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O,
-                    const char *Modifier = nullptr);
-  void printMemOperand(const MCInst *MI, int OpNo, raw_ostream &O,
-                       const char *Modifier = nullptr);
+  void printOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O);
+  void printMemOperand(const MCInst *MI, int OpNo, raw_ostream &O);
   void printImm64Operand(const MCInst *MI, unsigned OpNo, raw_ostream &O);
   void printBrTargetOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O);
 

--- a/llvm/lib/Target/CSKY/MCTargetDesc/CSKYInstPrinter.cpp
+++ b/llvm/lib/Target/CSKY/MCTargetDesc/CSKYInstPrinter.cpp
@@ -98,9 +98,7 @@ void CSKYInstPrinter::printFPRRegName(raw_ostream &O, unsigned RegNo) const {
 }
 
 void CSKYInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
-                                   const MCSubtargetInfo &STI, raw_ostream &O,
-                                   const char *Modifier) {
-  assert((Modifier == 0 || Modifier[0] == 0) && "No modifiers supported");
+                                   const MCSubtargetInfo &STI, raw_ostream &O) {
   const MCOperand &MO = MI->getOperand(OpNo);
 
   if (MO.isReg()) {

--- a/llvm/lib/Target/CSKY/MCTargetDesc/CSKYInstPrinter.h
+++ b/llvm/lib/Target/CSKY/MCTargetDesc/CSKYInstPrinter.h
@@ -34,7 +34,7 @@ public:
   void printRegName(raw_ostream &O, MCRegister Reg) override;
 
   void printOperand(const MCInst *MI, unsigned OpNo, const MCSubtargetInfo &STI,
-                    raw_ostream &O, const char *Modifier = nullptr);
+                    raw_ostream &O);
 
   void printFPRRegName(raw_ostream &O, unsigned RegNo) const;
 

--- a/llvm/lib/Target/Lanai/MCTargetDesc/LanaiInstPrinter.cpp
+++ b/llvm/lib/Target/Lanai/MCTargetDesc/LanaiInstPrinter.cpp
@@ -144,8 +144,7 @@ void LanaiInstPrinter::printInst(const MCInst *MI, uint64_t Address,
 }
 
 void LanaiInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
-                                    raw_ostream &OS, const char *Modifier) {
-  assert((Modifier == nullptr || Modifier[0] == 0) && "No modifiers supported");
+                                    raw_ostream &OS) {
   const MCOperand &Op = MI->getOperand(OpNo);
   if (Op.isReg())
     OS << "%" << getRegisterName(Op.getReg());
@@ -232,8 +231,7 @@ static void printMemoryImmediateOffset(const MCAsmInfo &MAI,
 }
 
 void LanaiInstPrinter::printMemRiOperand(const MCInst *MI, int OpNo,
-                                         raw_ostream &OS,
-                                         const char * /*Modifier*/) {
+                                         raw_ostream &OS) {
   const MCOperand &RegOp = MI->getOperand(OpNo);
   const MCOperand &OffsetOp = MI->getOperand(OpNo + 1);
   const MCOperand &AluOp = MI->getOperand(OpNo + 2);
@@ -247,8 +245,7 @@ void LanaiInstPrinter::printMemRiOperand(const MCInst *MI, int OpNo,
 }
 
 void LanaiInstPrinter::printMemRrOperand(const MCInst *MI, int OpNo,
-                                         raw_ostream &OS,
-                                         const char * /*Modifier*/) {
+                                         raw_ostream &OS) {
   const MCOperand &RegOp = MI->getOperand(OpNo);
   const MCOperand &OffsetOp = MI->getOperand(OpNo + 1);
   const MCOperand &AluOp = MI->getOperand(OpNo + 2);
@@ -268,8 +265,7 @@ void LanaiInstPrinter::printMemRrOperand(const MCInst *MI, int OpNo,
 }
 
 void LanaiInstPrinter::printMemSplsOperand(const MCInst *MI, int OpNo,
-                                           raw_ostream &OS,
-                                           const char * /*Modifier*/) {
+                                           raw_ostream &OS) {
   const MCOperand &RegOp = MI->getOperand(OpNo);
   const MCOperand &OffsetOp = MI->getOperand(OpNo + 1);
   const MCOperand &AluOp = MI->getOperand(OpNo + 2);

--- a/llvm/lib/Target/Lanai/MCTargetDesc/LanaiInstPrinter.h
+++ b/llvm/lib/Target/Lanai/MCTargetDesc/LanaiInstPrinter.h
@@ -26,15 +26,11 @@ public:
 
   void printInst(const MCInst *MI, uint64_t Address, StringRef Annot,
                  const MCSubtargetInfo &STI, raw_ostream &O) override;
-  void printOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O,
-                    const char *Modifier = nullptr);
+  void printOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O);
   void printPredicateOperand(const MCInst *MI, unsigned OpNum, raw_ostream &O);
-  void printMemRiOperand(const MCInst *MI, int OpNo, raw_ostream &O,
-                         const char *Modifier = nullptr);
-  void printMemRrOperand(const MCInst *MI, int OpNo, raw_ostream &O,
-                         const char *Modifier = nullptr);
-  void printMemSplsOperand(const MCInst *MI, int OpNo, raw_ostream &O,
-                           const char *Modifier = nullptr);
+  void printMemRiOperand(const MCInst *MI, int OpNo, raw_ostream &O);
+  void printMemRrOperand(const MCInst *MI, int OpNo, raw_ostream &O);
+  void printMemSplsOperand(const MCInst *MI, int OpNo, raw_ostream &O);
   void printCCOperand(const MCInst *MI, int OpNo, raw_ostream &O);
   void printHi16ImmOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O);
   void printHi16AndImmOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O);

--- a/llvm/lib/Target/MSP430/MCTargetDesc/MSP430InstPrinter.cpp
+++ b/llvm/lib/Target/MSP430/MCTargetDesc/MSP430InstPrinter.cpp
@@ -53,8 +53,7 @@ void MSP430InstPrinter::printPCRelImmOperand(const MCInst *MI, unsigned OpNo,
 }
 
 void MSP430InstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
-                                     raw_ostream &O, const char *Modifier) {
-  assert((Modifier == nullptr || Modifier[0] == 0) && "No modifiers supported");
+                                     raw_ostream &O) {
   const MCOperand &Op = MI->getOperand(OpNo);
   if (Op.isReg()) {
     O << getRegisterName(Op.getReg());
@@ -68,8 +67,7 @@ void MSP430InstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
 }
 
 void MSP430InstPrinter::printSrcMemOperand(const MCInst *MI, unsigned OpNo,
-                                           raw_ostream &O,
-                                           const char *Modifier) {
+                                           raw_ostream &O) {
   const MCOperand &Base = MI->getOperand(OpNo);
   const MCOperand &Disp = MI->getOperand(OpNo+1);
 

--- a/llvm/lib/Target/MSP430/MCTargetDesc/MSP430InstPrinter.h
+++ b/llvm/lib/Target/MSP430/MCTargetDesc/MSP430InstPrinter.h
@@ -38,11 +38,9 @@ namespace llvm {
     static const char *getRegisterName(MCRegister Reg);
 
   private:
-    void printOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O,
-                      const char *Modifier = nullptr);
+    void printOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O);
     void printPCRelImmOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O);
-    void printSrcMemOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O,
-                            const char *Modifier = nullptr);
+    void printSrcMemOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O);
     void printIndRegOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O);
     void printPostIndRegOperand(const MCInst *MI, unsigned OpNo,
                                 raw_ostream &O);

--- a/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
+++ b/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
@@ -714,9 +714,8 @@ printMemOperandEA(const MachineInstr *MI, int opNum, raw_ostream &O) {
   printOperand(MI, opNum+1, O);
 }
 
-void MipsAsmPrinter::
-printFCCOperand(const MachineInstr *MI, int opNum, raw_ostream &O,
-                const char *Modifier) {
+void MipsAsmPrinter::printFCCOperand(const MachineInstr *MI, int opNum,
+                                     raw_ostream &O) {
   const MachineOperand &MO = MI->getOperand(opNum);
   O << Mips::MipsFCCToString((Mips::CondCode)MO.getImm());
 }

--- a/llvm/lib/Target/Mips/MipsAsmPrinter.h
+++ b/llvm/lib/Target/Mips/MipsAsmPrinter.h
@@ -152,8 +152,7 @@ public:
   void printOperand(const MachineInstr *MI, int opNum, raw_ostream &O);
   void printMemOperand(const MachineInstr *MI, int opNum, raw_ostream &O);
   void printMemOperandEA(const MachineInstr *MI, int opNum, raw_ostream &O);
-  void printFCCOperand(const MachineInstr *MI, int opNum, raw_ostream &O,
-                       const char *Modifier = nullptr);
+  void printFCCOperand(const MachineInstr *MI, int opNum, raw_ostream &O);
   void printRegisterList(const MachineInstr *MI, int opNum, raw_ostream &O);
   void emitStartOfAsmFile(Module &M) override;
   void emitEndOfAsmFile(Module &M) override;

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCInstPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCInstPrinter.cpp
@@ -218,11 +218,10 @@ void PPCInstPrinter::printInst(const MCInst *MI, uint64_t Address,
 
 void PPCInstPrinter::printPredicateOperand(const MCInst *MI, unsigned OpNo,
                                            const MCSubtargetInfo &STI,
-                                           raw_ostream &O,
-                                           const char *Modifier) {
+                                           raw_ostream &O, StringRef Modifier) {
   unsigned Code = MI->getOperand(OpNo).getImm();
 
-  if (StringRef(Modifier) == "cc") {
+  if (Modifier == "cc") {
     switch ((PPC::Predicate)Code) {
     case PPC::PRED_LT_MINUS:
     case PPC::PRED_LT_PLUS:
@@ -271,7 +270,7 @@ void PPCInstPrinter::printPredicateOperand(const MCInst *MI, unsigned OpNo,
     llvm_unreachable("Invalid predicate code");
   }
 
-  if (StringRef(Modifier) == "pm") {
+  if (Modifier == "pm") {
     switch ((PPC::Predicate)Code) {
     case PPC::PRED_LT:
     case PPC::PRED_LE:
@@ -309,7 +308,7 @@ void PPCInstPrinter::printPredicateOperand(const MCInst *MI, unsigned OpNo,
     llvm_unreachable("Invalid predicate code");
   }
 
-  assert(StringRef(Modifier) == "reg" &&
+  assert(Modifier == "reg" &&
          "Need to specify 'cc', 'pm' or 'reg' as predicate op modifier!");
   printOperand(MI, OpNo + 1, STI, O);
 }

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCInstPrinter.h
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCInstPrinter.h
@@ -52,7 +52,7 @@ public:
                     raw_ostream &O);
   void printPredicateOperand(const MCInst *MI, unsigned OpNo,
                              const MCSubtargetInfo &STI, raw_ostream &O,
-                             const char *Modifier = nullptr);
+                             StringRef Modifier = {});
   void printATBitsAsHint(const MCInst *MI, unsigned OpNo,
                          const MCSubtargetInfo &STI, raw_ostream &O);
 

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.cpp
@@ -78,9 +78,8 @@ void RISCVInstPrinter::printRegName(raw_ostream &O, MCRegister Reg) {
 }
 
 void RISCVInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
-                                    const MCSubtargetInfo &STI, raw_ostream &O,
-                                    const char *Modifier) {
-  assert((Modifier == nullptr || Modifier[0] == 0) && "No modifiers supported");
+                                    const MCSubtargetInfo &STI,
+                                    raw_ostream &O) {
   const MCOperand &MO = MI->getOperand(OpNo);
 
   if (MO.isReg()) {

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVInstPrinter.h
@@ -31,7 +31,7 @@ public:
   void printRegName(raw_ostream &O, MCRegister Reg) override;
 
   void printOperand(const MCInst *MI, unsigned OpNo, const MCSubtargetInfo &STI,
-                    raw_ostream &O, const char *Modifier = nullptr);
+                    raw_ostream &O);
   void printBranchOperand(const MCInst *MI, uint64_t Address, unsigned OpNo,
                           const MCSubtargetInfo &STI, raw_ostream &O);
   void printCSRSystemRegister(const MCInst *MI, unsigned OpNo,

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
@@ -359,8 +359,7 @@ static void printExpr(const MCExpr *Expr, raw_ostream &O) {
 }
 
 void SPIRVInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
-                                    raw_ostream &O, const char *Modifier) {
-  assert((Modifier == 0 || Modifier[0] == 0) && "No modifiers supported");
+                                    raw_ostream &O) {
   if (OpNo < MI->getNumOperands()) {
     const MCOperand &Op = MI->getOperand(OpNo);
     if (Op.isReg())

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.h
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.h
@@ -28,8 +28,7 @@ public:
 
   void printInst(const MCInst *MI, uint64_t Address, StringRef Annot,
                  const MCSubtargetInfo &STI, raw_ostream &OS) override;
-  void printOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O,
-                    const char *Modifier = nullptr);
+  void printOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O);
 
   void printStringImm(const MCInst *MI, unsigned OpNo, raw_ostream &O);
 

--- a/llvm/lib/Target/VE/MCTargetDesc/VEInstPrinter.cpp
+++ b/llvm/lib/Target/VE/MCTargetDesc/VEInstPrinter.cpp
@@ -66,15 +66,7 @@ void VEInstPrinter::printOperand(const MCInst *MI, int OpNum,
 
 void VEInstPrinter::printMemASXOperand(const MCInst *MI, int OpNum,
                                        const MCSubtargetInfo &STI,
-                                       raw_ostream &O, const char *Modifier) {
-  // If this is an ADD operand, emit it like normal operands.
-  if (Modifier && !strcmp(Modifier, "arith")) {
-    printOperand(MI, OpNum, STI, O);
-    O << ", ";
-    printOperand(MI, OpNum + 1, STI, O);
-    return;
-  }
-
+                                       raw_ostream &O) {
   if (MI->getOperand(OpNum + 2).isImm() &&
       MI->getOperand(OpNum + 2).getImm() == 0) {
     // don't print "+0"
@@ -110,15 +102,7 @@ void VEInstPrinter::printMemASXOperand(const MCInst *MI, int OpNum,
 
 void VEInstPrinter::printMemASOperandASX(const MCInst *MI, int OpNum,
                                          const MCSubtargetInfo &STI,
-                                         raw_ostream &O, const char *Modifier) {
-  // If this is an ADD operand, emit it like normal operands.
-  if (Modifier && !strcmp(Modifier, "arith")) {
-    printOperand(MI, OpNum, STI, O);
-    O << ", ";
-    printOperand(MI, OpNum + 1, STI, O);
-    return;
-  }
-
+                                         raw_ostream &O) {
   if (MI->getOperand(OpNum + 1).isImm() &&
       MI->getOperand(OpNum + 1).getImm() == 0) {
     // don't print "+0"
@@ -141,15 +125,7 @@ void VEInstPrinter::printMemASOperandASX(const MCInst *MI, int OpNum,
 
 void VEInstPrinter::printMemASOperandRRM(const MCInst *MI, int OpNum,
                                          const MCSubtargetInfo &STI,
-                                         raw_ostream &O, const char *Modifier) {
-  // If this is an ADD operand, emit it like normal operands.
-  if (Modifier && !strcmp(Modifier, "arith")) {
-    printOperand(MI, OpNum, STI, O);
-    O << ", ";
-    printOperand(MI, OpNum + 1, STI, O);
-    return;
-  }
-
+                                         raw_ostream &O) {
   if (MI->getOperand(OpNum + 1).isImm() &&
       MI->getOperand(OpNum + 1).getImm() == 0) {
     // don't print "+0"
@@ -172,15 +148,7 @@ void VEInstPrinter::printMemASOperandRRM(const MCInst *MI, int OpNum,
 
 void VEInstPrinter::printMemASOperandHM(const MCInst *MI, int OpNum,
                                         const MCSubtargetInfo &STI,
-                                        raw_ostream &O, const char *Modifier) {
-  // If this is an ADD operand, emit it like normal operands.
-  if (Modifier && !strcmp(Modifier, "arith")) {
-    printOperand(MI, OpNum, STI, O);
-    O << ", ";
-    printOperand(MI, OpNum + 1, STI, O);
-    return;
-  }
-
+                                        raw_ostream &O) {
   if (MI->getOperand(OpNum + 1).isImm() &&
       MI->getOperand(OpNum + 1).getImm() == 0) {
     // don't print "+0"

--- a/llvm/lib/Target/VE/MCTargetDesc/VEInstPrinter.h
+++ b/llvm/lib/Target/VE/MCTargetDesc/VEInstPrinter.h
@@ -41,17 +41,13 @@ public:
   void printOperand(const MCInst *MI, int OpNum, const MCSubtargetInfo &STI,
                     raw_ostream &OS);
   void printMemASXOperand(const MCInst *MI, int OpNum,
-                          const MCSubtargetInfo &STI, raw_ostream &OS,
-                          const char *Modifier = nullptr);
+                          const MCSubtargetInfo &STI, raw_ostream &OS);
   void printMemASOperandASX(const MCInst *MI, int OpNum,
-                            const MCSubtargetInfo &STI, raw_ostream &OS,
-                            const char *Modifier = nullptr);
+                            const MCSubtargetInfo &STI, raw_ostream &OS);
   void printMemASOperandRRM(const MCInst *MI, int OpNum,
-                            const MCSubtargetInfo &STI, raw_ostream &OS,
-                            const char *Modifier = nullptr);
+                            const MCSubtargetInfo &STI, raw_ostream &OS);
   void printMemASOperandHM(const MCInst *MI, int OpNum,
-                           const MCSubtargetInfo &STI, raw_ostream &OS,
-                           const char *Modifier = nullptr);
+                           const MCSubtargetInfo &STI, raw_ostream &OS);
   void printMImmOperand(const MCInst *MI, int OpNum, const MCSubtargetInfo &STI,
                         raw_ostream &OS);
   void printCCOperand(const MCInst *MI, int OpNum, const MCSubtargetInfo &STI,

--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -362,17 +362,18 @@ void X86AsmPrinter::PrintOperand(const MachineInstr *MI, unsigned OpNo,
 /// deferring to PrintOperand() if no modifier was supplied or if operand is not
 /// a register.
 void X86AsmPrinter::PrintModifiedOperand(const MachineInstr *MI, unsigned OpNo,
-                                         raw_ostream &O, const char *Modifier) {
+                                         raw_ostream &O, StringRef Modifier) {
   const MachineOperand &MO = MI->getOperand(OpNo);
-  if (!Modifier || !MO.isReg())
+  if (Modifier.empty() || !MO.isReg())
     return PrintOperand(MI, OpNo, O);
   if (MI->getInlineAsmDialect() == InlineAsm::AD_ATT)
     O << '%';
   Register Reg = MO.getReg();
-  if (strncmp(Modifier, "subreg", strlen("subreg")) == 0) {
-    unsigned Size = (strcmp(Modifier+6,"64") == 0) ? 64 :
-        (strcmp(Modifier+6,"32") == 0) ? 32 :
-        (strcmp(Modifier+6,"16") == 0) ? 16 : 8;
+  if (Modifier.consume_front("subreg")) {
+    unsigned Size = (Modifier == "64")   ? 64
+                    : (Modifier == "32") ? 32
+                    : (Modifier == "16") ? 16
+                                         : 8;
     Reg = getX86SubSuperRegister(Reg, Size);
   }
   O << X86ATTInstPrinter::getRegisterName(Reg);
@@ -400,15 +401,14 @@ void X86AsmPrinter::PrintPCRelImm(const MachineInstr *MI, unsigned OpNo,
 }
 
 void X86AsmPrinter::PrintLeaMemReference(const MachineInstr *MI, unsigned OpNo,
-                                         raw_ostream &O, const char *Modifier) {
+                                         raw_ostream &O, StringRef Modifier) {
   const MachineOperand &BaseReg = MI->getOperand(OpNo + X86::AddrBaseReg);
   const MachineOperand &IndexReg = MI->getOperand(OpNo + X86::AddrIndexReg);
   const MachineOperand &DispSpec = MI->getOperand(OpNo + X86::AddrDisp);
 
   // If we really don't want to print out (rip), don't.
   bool HasBaseReg = BaseReg.getReg() != 0;
-  if (HasBaseReg && Modifier && !strcmp(Modifier, "no-rip") &&
-      BaseReg.getReg() == X86::RIP)
+  if (HasBaseReg && Modifier == "no-rip" && BaseReg.getReg() == X86::RIP)
     HasBaseReg = false;
 
   // HasParenPart - True if we will print out the () part of the mem ref.
@@ -429,7 +429,7 @@ void X86AsmPrinter::PrintLeaMemReference(const MachineInstr *MI, unsigned OpNo,
     break;
   }
 
-  if (Modifier && strcmp(Modifier, "H") == 0)
+  if (Modifier == "H")
     O << "+8";
 
   if (HasParenPart) {
@@ -483,7 +483,7 @@ void X86AsmPrinter::emitBasicBlockEnd(const MachineBasicBlock &MBB) {
 }
 
 void X86AsmPrinter::PrintMemReference(const MachineInstr *MI, unsigned OpNo,
-                                      raw_ostream &O, const char *Modifier) {
+                                      raw_ostream &O, StringRef Modifier) {
   assert(isMem(*MI, OpNo) && "Invalid memory reference!");
   const MachineOperand &Segment = MI->getOperand(OpNo + X86::AddrSegmentReg);
   if (Segment.getReg()) {
@@ -493,10 +493,9 @@ void X86AsmPrinter::PrintMemReference(const MachineInstr *MI, unsigned OpNo,
   PrintLeaMemReference(MI, OpNo, O, Modifier);
 }
 
-
 void X86AsmPrinter::PrintIntelMemReference(const MachineInstr *MI,
                                            unsigned OpNo, raw_ostream &O,
-                                           const char *Modifier) {
+                                           StringRef Modifier) {
   const MachineOperand &BaseReg = MI->getOperand(OpNo + X86::AddrBaseReg);
   unsigned ScaleVal = MI->getOperand(OpNo + X86::AddrScaleAmt).getImm();
   const MachineOperand &IndexReg = MI->getOperand(OpNo + X86::AddrIndexReg);
@@ -505,13 +504,11 @@ void X86AsmPrinter::PrintIntelMemReference(const MachineInstr *MI,
 
   // If we really don't want to print out (rip), don't.
   bool HasBaseReg = BaseReg.getReg() != 0;
-  if (HasBaseReg && Modifier && !strcmp(Modifier, "no-rip") &&
-      BaseReg.getReg() == X86::RIP)
+  if (HasBaseReg && Modifier == "no-rip" && BaseReg.getReg() == X86::RIP)
     HasBaseReg = false;
 
   // If we really just want to print out displacement.
-  if (Modifier && (DispSpec.isGlobal() || DispSpec.isSymbol()) &&
-      !strcmp(Modifier, "disp-only")) {
+  if ((DispSpec.isGlobal() || DispSpec.isSymbol()) && Modifier == "disp-only") {
     HasBaseReg = false;
   }
 
@@ -863,9 +860,9 @@ bool X86AsmPrinter::PrintAsmMemoryOperand(const MachineInstr *MI, unsigned OpNo,
     }
   }
   if (MI->getInlineAsmDialect() == InlineAsm::AD_Intel) {
-    PrintIntelMemReference(MI, OpNo, O, nullptr);
+    PrintIntelMemReference(MI, OpNo, O);
   } else {
-    PrintMemReference(MI, OpNo, O, nullptr);
+    PrintMemReference(MI, OpNo, O);
   }
   return false;
 }

--- a/llvm/lib/Target/X86/X86AsmPrinter.h
+++ b/llvm/lib/Target/X86/X86AsmPrinter.h
@@ -112,14 +112,14 @@ class LLVM_LIBRARY_VISIBILITY X86AsmPrinter : public AsmPrinter {
   void PrintSymbolOperand(const MachineOperand &MO, raw_ostream &O) override;
   void PrintOperand(const MachineInstr *MI, unsigned OpNo, raw_ostream &O);
   void PrintModifiedOperand(const MachineInstr *MI, unsigned OpNo,
-                            raw_ostream &O, const char *Modifier);
+                            raw_ostream &O, StringRef Modifier = {});
   void PrintPCRelImm(const MachineInstr *MI, unsigned OpNo, raw_ostream &O);
   void PrintLeaMemReference(const MachineInstr *MI, unsigned OpNo,
-                            raw_ostream &O, const char *Modifier);
+                            raw_ostream &O, StringRef Modifier = {});
   void PrintMemReference(const MachineInstr *MI, unsigned OpNo, raw_ostream &O,
-                         const char *Modifier);
+                         StringRef Modifier = {});
   void PrintIntelMemReference(const MachineInstr *MI, unsigned OpNo,
-                              raw_ostream &O, const char *Modifier);
+                              raw_ostream &O, StringRef Modifier = {});
   const MCSubtargetInfo *getIFuncMCSubtargetInfo() const override;
   void emitMachOIFuncStubBody(Module &M, const GlobalIFunc &GI,
                               MCSymbol *LazyPointer) override;


### PR DESCRIPTION
- Change various Inst/Asm Printer functions to use a StringRef for the Modifier parameter (instead of a const char *).
- This simplifies various string comparisons used within these functions.
- Remove these params for print functions that do not use them.