### PR TITLE
[flang] Rework preprocessor fix for replacement in kind suffixes

### DIFF
--- a/flang/test/Preprocessing/bug518.F
+++ b/flang/test/Preprocessing/bug518.F
@@ -1,0 +1,5 @@
+! RUN: %flang -fc1 -fdebug-unparse %s 2>&1 | FileCheck %s
+! CHECK: k=1_4
+                        k=                                            1_99999999
+     &4
+      end


### PR DESCRIPTION
Recent work to better handle macro replacement in literal constant kind suffixes isn't handling fixed form well, leading to a crash in Fujitsu test 0113/0113_0073.F.  The look-ahead needs to be done with the higher-level prescanner functions that skip over fixed form comment fields after column 72.  Rework.