### PR TITLE
[flang][openacc] Allow finalize clause on exit data more than once

### DIFF
--- a/flang/test/Lower/OpenACC/acc-exit-data.f90
+++ b/flang/test/Lower/OpenACC/acc-exit-data.f90
@@ -102,4 +102,9 @@ subroutine acc_exit_data
 !CHECK: acc.exit_data wait_devnum(%[[WAIT6]] : i32) wait(%[[WAIT4]], %[[WAIT5]] : i32, i32) dataOperands(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>)
 !CHECK: acc.delete accPtr(%[[DEVPTR]] : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
 
+  !$acc exit data delete(a) finalize
+!CHECK: acc.exit_data dataOperands(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) attributes {finalize}
+
+  !$acc exit data delete(a) finalize finalize
+!CHECK: acc.exit_data dataOperands(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) attributes {finalize}
 end subroutine acc_exit_data

--- a/flang/test/Semantics/OpenACC/acc-data.f90
+++ b/flang/test/Semantics/OpenACC/acc-data.f90
@@ -86,7 +86,7 @@ program openacc_data_validity
 
   !$acc exit data delete(aa) finalize
 
-  !ERROR: At most one FINALIZE clause can appear on the EXIT DATA directive
+  ! OK
   !$acc exit data delete(aa) finalize finalize
 
   !ERROR: Argument `cc` on the DETACH clause must be a variable or array with the POINTER or ALLOCATABLE attribute

--- a/llvm/include/llvm/Frontend/OpenACC/ACC.td
+++ b/llvm/include/llvm/Frontend/OpenACC/ACC.td
@@ -535,14 +535,10 @@ def ACC_EnterData : Directive<"enter data"> {
 
 // 2.14.7
 def ACC_ExitData : Directive<"exit data"> {
-  let allowedClauses = [
-    VersionedClause<ACCC_Wait>
-  ];
-  let allowedOnceClauses = [
-    VersionedClause<ACCC_Async>,
-    VersionedClause<ACCC_If>,
-    VersionedClause<ACCC_Finalize>
-  ];
+  let allowedClauses = [VersionedClause<ACCC_Finalize>,
+                        VersionedClause<ACCC_Wait>];
+  let allowedOnceClauses = [VersionedClause<ACCC_Async>,
+                            VersionedClause<ACCC_If>];
   let requiredClauses = [
     VersionedClause<ACCC_Copyout>,
     VersionedClause<ACCC_Delete>,


### PR DESCRIPTION
The spec has not strict restriction to allow a single `finalize` clause on the `exit data` directive. Allowing this clause multiple times does not change the semantic of it. This patch relax the rules in `ACC.td` since there is no restriction in the standard.

The OpenACC dialect represent the finalize clause with a UnitAttr so the attribute will be set if the is one or more `finalize` clause. 