### PR TITLE
[flang][runtime] Fix recently broken big-endian formatted integer input

### DIFF
--- a/flang-rt/lib/runtime/edit-input.cpp
+++ b/flang-rt/lib/runtime/edit-input.cpp
@@ -293,8 +293,8 @@ RT_API_ATTRS bool EditIntegerInput(IoStatementState &io, const DataEdit &edit,
 #if USING_NATIVE_INT128_T
     auto shft{static_cast<int>(sizeof value - kind)};
     if (!isHostLittleEndian && shft >= 0) {
-      auto l{value << shft};
-      std::memcpy(n, &l, kind);
+      auto shifted{value << (8 * shft)};
+      std::memcpy(n, &shifted, kind);
     } else {
       std::memcpy(n, &value, kind); // a blank field means zero
     }


### PR DESCRIPTION
My recent change to speed up formatted integer input has a bug on big-endian targets that has shown up on ppc64 AIX build bots. Fix.