### PR TITLE
[flang][openacc] Allow if_present multiple times on host_data and update

### DIFF
--- a/flang/test/Lower/OpenACC/acc-host-data.f90
+++ b/flang/test/Lower/OpenACC/acc-host-data.f90
@@ -24,6 +24,11 @@ subroutine acc_host_data()
 ! CHECK: acc.host_data dataOperands(%[[DA]] : !fir.ref<!fir.array<10xf32>>) {
 ! CHECK: } attributes {ifPresent}
 
+  !$acc host_data use_device(a) if_present if_present
+  !$acc end host_data
+! CHECK: acc.host_data dataOperands(%{{.*}} : !fir.ref<!fir.array<10xf32>>) {
+! CHECK: } attributes {ifPresent}
+
   !$acc host_data use_device(a) if(ifCondition)
   !$acc end host_data
 

--- a/flang/test/Lower/OpenACC/acc-update.f90
+++ b/flang/test/Lower/OpenACC/acc-update.f90
@@ -24,6 +24,9 @@ subroutine acc_update
 ! CHECK: acc.update dataOperands(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) attributes {ifPresent}{{$}}
 ! CHECK: acc.update_host accPtr(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>) to varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) {name = "a", structured = false}
 
+  !$acc update host(a) if_present if_present
+! CHECK: acc.update dataOperands(%{{.*}} : !fir.ref<!fir.array<10x10xf32>>) attributes {ifPresent}{{$}}
+
   !$acc update self(a)
 ! CHECK: %[[DEVPTR_A:.*]] = acc.getdeviceptr varPtr(%[[DECLA]]#0 : !fir.ref<!fir.array<10x10xf32>>) -> !fir.ref<!fir.array<10x10xf32>> {dataClause = #acc<data_clause acc_update_self>, name = "a", structured = false}
 ! CHECK: acc.update dataOperands(%[[DEVPTR_A]] : !fir.ref<!fir.array<10x10xf32>>){{$}}

--- a/flang/test/Semantics/OpenACC/acc-host-data.f90
+++ b/flang/test/Semantics/OpenACC/acc-host-data.f90
@@ -27,7 +27,7 @@ program openacc_host_data_validity
   !$acc host_data use_device(aa, bb) if_present
   !$acc end host_data
 
-  !ERROR: At most one IF_PRESENT clause can appear on the HOST_DATA directive
+  ! OK
   !$acc host_data use_device(aa, bb) if_present if_present
   !$acc end host_data
 

--- a/flang/test/Semantics/OpenACC/acc-update-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-update-validity.f90
@@ -58,7 +58,7 @@ program openacc_update_validity
   !ERROR: At most one IF clause can appear on the UPDATE directive
   !$acc update device(aa) if(.true.) if(ifCondition)
 
-  !ERROR: At most one IF_PRESENT clause can appear on the UPDATE directive
+  ! OK
   !$acc update device(bb) if_present if_present
 
   !ERROR: Clause IF is not allowed after clause DEVICE_TYPE on the UPDATE directive

--- a/llvm/include/llvm/Frontend/OpenACC/ACC.td
+++ b/llvm/include/llvm/Frontend/OpenACC/ACC.td
@@ -487,15 +487,11 @@ def ACC_Shutdown : Directive<"shutdown"> {
 
 // 2.14.4
 def ACC_Update : Directive<"update"> {
-  let allowedClauses = [
-    VersionedClause<ACCC_DeviceType>,
-    VersionedClause<ACCC_Wait>
-  ];
-  let allowedOnceClauses = [
-    VersionedClause<ACCC_Async>,
-    VersionedClause<ACCC_If>,
-    VersionedClause<ACCC_IfPresent>
-  ];
+  let allowedClauses = [VersionedClause<ACCC_DeviceType>,
+                        VersionedClause<ACCC_IfPresent>,
+                        VersionedClause<ACCC_Wait>];
+  let allowedOnceClauses = [VersionedClause<ACCC_Async>,
+                            VersionedClause<ACCC_If>];
   let requiredClauses = [
     VersionedClause<ACCC_Device>,
     VersionedClause<ACCC_Host>,
@@ -554,10 +550,8 @@ def ACC_ExitData : Directive<"exit data"> {
 
 // 2.8
 def ACC_HostData : Directive<"host_data"> {
-  let allowedOnceClauses = [
-    VersionedClause<ACCC_If>,
-    VersionedClause<ACCC_IfPresent>
-  ];
+  let allowedClauses = [VersionedClause<ACCC_IfPresent>];
+  let allowedOnceClauses = [VersionedClause<ACCC_If>];
   let requiredClauses = [
     VersionedClause<ACCC_UseDevice>
   ];


### PR DESCRIPTION
Similar to #135415.

The spec has not strict restriction to allow a single `if_present` clause on the host_data and update directives. Allowing this clause multiple times does not change the semantic of it. This patch relax the rules in ACC.td since there is no restriction in the standard.

The OpenACC dialect represents the `if_present` clause with a `UnitAttr` so the attribute will be set if the is one or more `if_present` clause.

