### PR TITLE
Add back include for AutoConvert.h as it's needed for z/OS

### DIFF
--- a/clang/lib/Basic/SourceManager.cpp
+++ b/clang/lib/Basic/SourceManager.cpp
@@ -24,6 +24,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/AutoConvert.h"
 #include "llvm/Support/Capacity.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"


### PR DESCRIPTION
The commit https://github.com/llvm/llvm-project/commit/a1935fd3809772c06f9a09fa151181642ae92b20 removed an include that is needed when building on z/OS.  