### PR TITLE
[clang] WIP: Fix MemberPointer serialization non-determinism

### DIFF
--- a/clang/include/clang/AST/TypeProperties.td
+++ b/clang/include/clang/AST/TypeProperties.td
@@ -104,7 +104,8 @@ let Class = MemberPointerType in {
     let Read = [{ node->getQualifier() }];
   }
   def : Property<"Cls", DeclRef> {
-    let Read = [{ node->getMostRecentCXXRecordDecl() }];
+    let Read =
+        [{ node->isSugared() ? node->getMostRecentCXXRecordDecl()->getCanonicalDecl() : nullptr }];
   }
 
   def : Creator<[{


### PR DESCRIPTION
This fixes a problem originally reported here:
https://github.com/llvm/llvm-project/pull/132401#issuecomment-2795078260

This makes sure we only serialize the class declaration when its strictly needed, and canonicalizes it, so it doesn't change in ways that don't round trip.

There are no release notes, since this regression was never released.