### PR TITLE
[llvm] Build Windows release package with clang-cl if possible

### DIFF
--- a/llvm/utils/release/build_llvm_release.bat
+++ b/llvm/utils/release/build_llvm_release.bat
@@ -172,16 +172,16 @@ if "%force-msvc%" == "" (
   if errorlevel 0 (
     where /q lld-link
     if errorlevel 0 (
-	  set common_compiler_flags=%common_compiler_flags% -fuse-ld=lld
-	  
-	  set common_cmake_flags=%common_cmake_flags%^
-	    -DCMAKE_C_COMPILER=clang-cl.exe ^
-		-DCMAKE_CXX_COMPILER=clang-cl.exe ^
-		-DCMAKE_LINKER=lld-link.exe ^
-		-DLLVM_ENABLE_LLD=ON ^
+      set common_compiler_flags=%common_compiler_flags% -fuse-ld=lld
+      
+      set common_cmake_flags=%common_cmake_flags%^
+        -DCMAKE_C_COMPILER=clang-cl.exe ^
+        -DCMAKE_CXX_COMPILER=clang-cl.exe ^
+        -DCMAKE_LINKER=lld-link.exe ^
+        -DLLVM_ENABLE_LLD=ON ^
         -DCMAKE_C_FLAGS="%common_compiler_flags%" ^
         -DCMAKE_CXX_FLAGS="%common_compiler_flags%"
-	)
+    )
   )
 )
 

--- a/llvm/utils/release/build_llvm_release.bat
+++ b/llvm/utils/release/build_llvm_release.bat
@@ -7,7 +7,7 @@ goto begin
 echo Script for building the LLVM installer on Windows,
 echo used for the releases at https://github.com/llvm/llvm-project/releases
 echo.
-echo Usage: build_llvm_release.bat --version ^<version^> [--x86,--x64, --arm64] [--skip-checkout] [--local-python]
+echo Usage: build_llvm_release.bat --version ^<version^> [--x86,--x64, --arm64] [--skip-checkout] [--local-python] [--force-msvc]
 echo.
 echo Options:
 echo --version: [required] version to build
@@ -17,6 +17,7 @@ echo --x64: build and test x64 variant
 echo --arm64: build and test arm64 variant
 echo --skip-checkout: use local git checkout instead of downloading src.zip
 echo --local-python: use installed Python and does not try to use a specific version (3.10)
+echo --force-msvc: use MSVC compiler for stage0, even if clang-cl is present
 echo.
 echo Note: At least one variant to build is required.
 echo.
@@ -34,6 +35,7 @@ set x64=
 set arm64=
 set skip-checkout=
 set local-python=
+set force-msvc=
 call :parse_args %*
 
 if "%help%" NEQ "" goto usage
@@ -164,6 +166,24 @@ set common_cmake_flags=^
   -DCMAKE_CXX_FLAGS="%common_compiler_flags%" ^
   -DLLVM_ENABLE_RPMALLOC=ON ^
   -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;compiler-rt;lldb;openmp"
+
+if "%force-msvc%" == "" (
+  where /q clang-cl
+  if errorlevel 0 (
+    where /q lld-link
+    if errorlevel 0 (
+	  set common_compiler_flags=%common_compiler_flags% -fuse-ld=lld
+	  
+	  set common_cmake_flags=%common_cmake_flags%^
+	    -DCMAKE_C_COMPILER=clang-cl.exe ^
+		-DCMAKE_CXX_COMPILER=clang-cl.exe ^
+		-DCMAKE_LINKER=lld-link.exe ^
+		-DLLVM_ENABLE_LLD=ON ^
+        -DCMAKE_C_FLAGS="%common_compiler_flags%" ^
+        -DCMAKE_CXX_FLAGS="%common_compiler_flags%"
+	)
+  )
+)
 
 set cmake_profile_flags=""
 


### PR DESCRIPTION
If `clang-cl.exe` and `lld-link.exe` are installed in `%PATH%`, the Windows release build script will now use these by default, in place of MSVC. The reason for doing this is that MSVC still has, for the past year(s), a O(N^2) behavior when building certain LLVM source files, which leads to long build times (minutes per file). A report was filled here: https://developercommunity.visualstudio.com/t/ON2-in-SparseBitVectorBase-when-com/10657991

I also added a `--force-msvc` option to the script, to use MSVC even if clang-cl is installed.