### PR TITLE
[BOLT] Support relative vtable

### DIFF
--- a/bolt/lib/Core/Relocation.cpp
+++ b/bolt/lib/Core/Relocation.cpp
@@ -96,6 +96,7 @@ static bool isSupportedAArch64(uint32_t Type) {
   case ELF::R_AARCH64_MOVW_UABS_G2:
   case ELF::R_AARCH64_MOVW_UABS_G2_NC:
   case ELF::R_AARCH64_MOVW_UABS_G3:
+  case ELF::R_AARCH64_PLT32:
     return true;
   }
 }
@@ -202,6 +203,7 @@ static size_t getSizeForTypeAArch64(uint32_t Type) {
   case ELF::R_AARCH64_MOVW_UABS_G2_NC:
   case ELF::R_AARCH64_MOVW_UABS_G3:
   case ELF::R_AARCH64_ABS32:
+  case ELF::R_AARCH64_PLT32:
     return 4;
   case ELF::R_AARCH64_ABS64:
   case ELF::R_AARCH64_PREL64:
@@ -354,6 +356,7 @@ static uint64_t extractValueAArch64(uint32_t Type, uint64_t Contents,
   case ELF::R_AARCH64_PREL16:
     return static_cast<int64_t>(PC) + SignExtend64<16>(Contents & 0xffff);
   case ELF::R_AARCH64_PREL32:
+  case ELF::R_AARCH64_PLT32:
     return static_cast<int64_t>(PC) + SignExtend64<32>(Contents & 0xffffffff);
   case ELF::R_AARCH64_PREL64:
     return static_cast<int64_t>(PC) + Contents;
@@ -676,6 +679,7 @@ static bool isPCRelativeAArch64(uint32_t Type) {
   case ELF::R_AARCH64_PREL16:
   case ELF::R_AARCH64_PREL32:
   case ELF::R_AARCH64_PREL64:
+  case ELF::R_AARCH64_PLT32:
     return true;
   }
 }

--- a/bolt/test/runtime/relative-vftable.cpp
+++ b/bolt/test/runtime/relative-vftable.cpp
@@ -1,0 +1,57 @@
+// Test bolt instrumentation is able to handle relative virtual function table,
+// i.e., when code is compiled with `-fexperimental-relative-c++-abi-vtables`.
+
+// REQUIRES: system-linux,bolt-runtime
+
+// RUN: split-file %s %t
+// RUN: %clang -fuse-ld=lld -o %t/main.so %t/tt.cpp %t/main.cpp -Wl,-q \
+// RUN:     -fno-rtti -fexperimental-relative-c++-abi-vtables
+// RUN: %t/main.so | FileCheck %s
+
+// CHECK: derived_foo
+// CHECK-NEXT: derived_bar
+// CHECK-NEXT: derived_goo
+
+// RUN: llvm-bolt --instrument %t/main.so -o %t/main.instr.so
+// RUN: %t/main.instr.so | FileCheck %s
+
+;--- tt.h
+#include <stdio.h>
+
+class Base {
+public:
+  virtual void foo();
+  virtual void bar();
+  virtual void goo();
+};
+
+class Derived : public Base {
+public:
+  virtual void foo() override;
+  virtual void bar() override;
+  virtual void goo() override;
+};
+
+;--- tt.cpp
+#include "tt.h"
+void Derived::goo() { printf("derived_goo\n"); }
+
+;--- main.cpp
+#include "tt.h"
+// #pragma clang optimize off
+
+void Base::foo() { printf("base_foo\n"); }
+void Base::bar() { printf("base_bar\n"); }
+void Base::goo() { printf("base_goo\n"); }
+
+void Derived::foo() { printf("derived_foo\n"); }
+void Derived::bar() { printf("derived_bar\n"); }
+
+int main() {
+  Derived D;
+  Base *ptr = &D;
+  ptr->foo();
+  ptr->bar();
+  ptr->goo();
+  return 0;
+}

--- a/bolt/test/runtime/relative-vftable.cpp
+++ b/bolt/test/runtime/relative-vftable.cpp
@@ -12,8 +12,8 @@
 // CHECK-NEXT: derived_bar
 // CHECK-NEXT: derived_goo
 
-// RUN: llvm-bolt --instrument %t/main.so -o %t/main.instr.so
-// RUN: %t/main.instr.so | FileCheck %s
+// RUN: llvm-bolt %t/main.so -o %t/main.bolted.so --trap-old-code
+// RUN: %t/main.bolted.so | FileCheck %s
 
 ;--- tt.h
 #include <stdio.h>
@@ -38,7 +38,7 @@ void Derived::goo() { printf("derived_goo\n"); }
 
 ;--- main.cpp
 #include "tt.h"
-// #pragma clang optimize off
+#pragma clang optimize off
 
 void Base::foo() { printf("base_foo\n"); }
 void Base::bar() { printf("base_bar\n"); }

--- a/bolt/test/runtime/relative-vftable.cpp
+++ b/bolt/test/runtime/relative-vftable.cpp
@@ -1,7 +1,7 @@
-// Test bolt instrumentation is able to handle relative virtual function table,
-// i.e., when code is compiled with `-fexperimental-relative-c++-abi-vtables`.
+// Test BOLT is able to handle relative virtual function table, i.e., when
+// code is compiled with `-fexperimental-relative-c++-abi-vtables`.
 
-// REQUIRES: system-linux,bolt-runtime
+// REQUIRES: system-linux
 
 // RUN: split-file %s %t
 // RUN: %clang -fuse-ld=lld -o %t/main.so %t/tt.cpp %t/main.cpp -Wl,-q \


### PR DESCRIPTION
To handle relative vftable, which is enabled with clang option
`-fexperimental-relative-c++-abi-vtables`, we look for PC relative
relocations whose fixup locations fall in vtable address ranges.
For such relocations, actual target is just virtual function itself,
and the addend is to record the distance between vtable slot for
target virtual function and the first virtual function slot in vtable,
which is to match generated code that calls virtual function. So
we can skip the logic of handling "function + offset" and directly
save such relocations for future fixup after new layout is known.