### PR TITLE
[clang-doc] Pre-commit tests for static members and functions

### DIFF
--- a/clang-tools-extra/test/clang-doc/Inputs/basic-project/include/Calculator.h
+++ b/clang-tools-extra/test/clang-doc/Inputs/basic-project/include/Calculator.h
@@ -43,4 +43,25 @@ public:
      * @throw std::invalid_argument if b is zero.
      */
     double divide(int a, int b);
+
+    /**
+     * @brief Performs the mod operation on integers.
+     *
+     * @param a First integer.
+     * @param b Second integer.
+     * @return The result of a % b.
+     */
+    static int mod(int a, int b) {
+      return a % b;
+    }
+
+    /**
+     * @brief A static value.
+     */
+    static constexpr int static_val = 10;
+
+    /**
+     * @brief Holds a public value.
+     */
+    int public_val = -1;
 };

--- a/clang-tools-extra/test/clang-doc/Inputs/basic-project/src/Calculator.cpp
+++ b/clang-tools-extra/test/clang-doc/Inputs/basic-project/src/Calculator.cpp
@@ -15,3 +15,4 @@ int Calculator::multiply(int a, int b) {
 double Calculator::divide(int a, int b) {
   return static_cast<double>(a) / b;
 }
+

--- a/clang-tools-extra/test/clang-doc/basic-project.test
+++ b/clang-tools-extra/test/clang-doc/basic-project.test
@@ -192,12 +192,12 @@
 //      HTML-CALC: <p>if b is zero.</p>
 
 //      HTML-CALC: <p>public int mod(int a, int b)</p>
-//   CALC-NO-REPOSITORY: Defined at line 20 of file .{{.}}src{{.}}Calculator.cpp
+//   CALC-NO-REPOSITORY: Defined at line 54 of file .{{.}}include{{.}}Calculator.h
 //      CALC-REPOSITORY: Defined at line 
-// CALC-REPOSITORY-NEXT: <a href="https://repository.com/./src/Calculator.cpp#20">20</a>
-//     CALC-LINE-PREFIX: <a href="https://repository.com/./src/Calculator.cpp#L20">20</a>
+// CALC-REPOSITORY-NEXT: <a href="https://repository.com/./include/Calculator.h#54">54</a>
+//     CALC-LINE-PREFIX: <a href="https://repository.com/./include/Calculator.h#L54">54</a>
 // CALC-REPOSITORY-NEXT: of file 
-// CALC-REPOSITORY-NEXT: <a href="https://repository.com/./src/Calculator.cpp">Calculator.cpp</a>
+// CALC-REPOSITORY-NEXT: <a href="https://repository.com/./include/Calculator.h">Calculator.h</a>
 //      HTML-CALC: <div>brief</div>
 //      HTML-CALC: <p> Performs the mod operation on integers.</p>
 //      HTML-CALC: <div>return</div>

--- a/clang-tools-extra/test/clang-doc/basic-project.test
+++ b/clang-tools-extra/test/clang-doc/basic-project.test
@@ -324,6 +324,8 @@
 // MD-CALC: *Defined at .{{[\/]}}include{{[\/]}}Calculator.h#8*
 // MD-CALC: **brief** A simple calculator class.
 // MD-CALC:  Provides basic arithmetic operations.
+// MD-CALC: ## Members
+// MD-CALC: public int public_val
 // MD-CALC: ## Functions
 // MD-CALC: ### add
 // MD-CALC: *public int add(int a, int b)*
@@ -354,6 +356,13 @@
 // MD-CALC: **b** Second integer.
 // MD-CALC: **return** double The result of a / b.
 // MD-CALC: **throw**if b is zero.
+// MD-CALC: ### mod
+// MD-CALC: *public int mod(int a, int b)*
+// MD-CALC: *Defined at ./include{{[\/]}}Calculator.h#54*
+// MD-CALC: **brief** Performs the mod operation on integers.
+// MD-CALC: **a** First integer.
+// MD-CALC: **b** Second integer.
+// MD-CALC: **return** The result of a % b.
 
 // MD-CIRCLE: # class Circle
 // MD-CIRCLE: *Defined at .{{[\/]}}include{{[\/]}}Circle.h#10*

--- a/clang-tools-extra/test/clang-doc/basic-project.test
+++ b/clang-tools-extra/test/clang-doc/basic-project.test
@@ -129,6 +129,12 @@
 //      HTML-CALC: <div>brief</div>
 //      HTML-CALC: <p> A simple calculator class.</p>
 //      HTML-CALC: <p> Provides basic arithmetic operations.</p>
+
+//      HTML-CALC: <h2 id="Members">Members</h2>
+//      HTML-CALC: <div>brief</div>
+//      HTML-CALC: <p> Holds a public value.</p>
+//      HTML-CALC: <div>public int public_val</div>
+
 //      HTML-CALC: <h2 id="Functions">Functions</h2>
 //      HTML-CALC: <h3 id="{{([0-9A-F]{40})}}">add</h3>
 //      HTML-CALC: <p>public int add(int a, int b)</p>
@@ -184,6 +190,18 @@
 //      HTML-CALC: <p> double The result of a / b.</p>
 //      HTML-CALC: <div>throw</div>
 //      HTML-CALC: <p>if b is zero.</p>
+
+//      HTML-CALC: <p>public int mod(int a, int b)</p>
+//   CALC-NO-REPOSITORY: Defined at line 20 of file .{{.}}src{{.}}Calculator.cpp
+//      CALC-REPOSITORY: Defined at line 
+// CALC-REPOSITORY-NEXT: <a href="https://repository.com/./src/Calculator.cpp#20">20</a>
+//     CALC-LINE-PREFIX: <a href="https://repository.com/./src/Calculator.cpp#L20">20</a>
+// CALC-REPOSITORY-NEXT: of file 
+// CALC-REPOSITORY-NEXT: <a href="https://repository.com/./src/Calculator.cpp">Calculator.cpp</a>
+//      HTML-CALC: <div>brief</div>
+//      HTML-CALC: <p> Performs the mod operation on integers.</p>
+//      HTML-CALC: <div>return</div>
+//      HTML-CALC: <p> The result of a % b.</p>
 
 //      HTML-RECTANGLE: <h1>class Rectangle</h1>
 // RECTANGLE-NO-REPOSITORY: <p>Defined at line 10 of file .{{.}}include{{.}}Rectangle.h</p>


### PR DESCRIPTION
Issue #59813 mentions that static members are not included in
the documentation generated by clang-doc. This patch adds
some basic testing for that property, with the current incorrect
behavior. Follow up patches will address the missing documentation.