### PR TITLE
[TableGen] Accurately calculate where the source variable ops start in PseudoLoweringEmitter::emitLoweringEmitter.

### DIFF
--- a/llvm/utils/TableGen/PseudoLoweringEmitter.cpp
+++ b/llvm/utils/TableGen/PseudoLoweringEmitter.cpp
@@ -247,9 +247,9 @@ void PseudoLoweringEmitter::emitLoweringEmitter(raw_ostream &o) {
       // FIXME: Instruction operands with defaults values (predicates and cc_out
       //        in ARM, for example shouldn't need explicit values in the
       //        expansion DAG.
-      unsigned MIOpNo = 0;
       for (const auto &DestOperand : Dest.Operands) {
         o << "    // Operand: " << DestOperand.Name << "\n";
+        unsigned MIOpNo = DestOperand.MIOperandNo;
         for (unsigned i = 0, e = DestOperand.MINumOperands; i != e; ++i) {
           switch (Expansion.OperandMap[MIOpNo + i].Kind) {
           case OpData::Operand:
@@ -277,12 +277,13 @@ void PseudoLoweringEmitter::emitLoweringEmitter(raw_ostream &o) {
           }
           }
         }
-        MIOpNo += DestOperand.MINumOperands;
       }
       if (Dest.Operands.isVariadic) {
-        MIOpNo = Source.Operands.size() + 1;
+        unsigned LastOpNo = 0;
+        for (const auto &Op : Source.Operands)
+          LastOpNo += Op.MINumOperands;
         o << "    // variable_ops\n";
-        o << "    for (unsigned i = " << MIOpNo
+        o << "    for (unsigned i = " << LastOpNo
           << ", e = MI->getNumOperands(); i != e; ++i)\n"
           << "      if (lowerOperand(MI->getOperand(i), MCOp))\n"
           << "        Inst.addOperand(MCOp);\n";


### PR DESCRIPTION
The code was using the number of source operands plus one. The plus one seems to be an ARM specific value accounting for one of the source operands having 2 sub operands. No other target in tree uses PseudoLowering with variadic instructions so this worked.

This patch replaces it with a proper count of the number of sub operands of all operands. While there I update the loop to use MIOperandNo so we don't need to count up the sub operands as we go.