### PR TITLE
[flang] Fix linking to libMLIR

### DIFF
--- a/flang/lib/Optimizer/Dialect/FIRCG/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/FIRCG/CMakeLists.txt
@@ -7,10 +7,10 @@ add_flang_library(FIRCodeGenDialect
   LINK_LIBS
   FIRDialect
 
-  MLIR_LIBS
-  MLIRIR
-
   LINK_COMPONENTS
   AsmParser
   AsmPrinter
+
+  MLIR_LIBS
+  MLIRIR
   )

--- a/flang/lib/Optimizer/Dialect/FIRCG/CMakeLists.txt
+++ b/flang/lib/Optimizer/Dialect/FIRCG/CMakeLists.txt
@@ -6,6 +6,8 @@ add_flang_library(FIRCodeGenDialect
 
   LINK_LIBS
   FIRDialect
+
+  MLIR_LIBS
   MLIRIR
 
   LINK_COMPONENTS


### PR DESCRIPTION
Fix regression to MLIR dylib support introduced in #135240. Without the fix, the build with no static libraries fails:

```
FAILED: bin/fir-opt 
: && /usr/lib/ccache/bin/x86_64-pc-linux-gnu-g++ -O2 -pipe -march=native -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-maybe-uninitialized -Wno-nonnull -Wno-class-memaccess -Wno-redundant-move -Wno-pessimizing-move -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wsuggest-override -Wno-comment -Wno-misleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -Wno-deprecated-copy -Wno-ctad-maybe-unsupported -fno-strict-aliasing -fno-semantic-interposition -Wl,-O1 -Wl,--as-needed -Wl,-z,pack-relative-relocs    -Wl,-rpath-link,/var/tmp/portage/llvm-core/flang-21.0.0.9999/work/flang_build/lib  -Wl,--gc-sections  -Wl,--dependency-file=tools/fir-opt/CMakeFiles/fir-opt.dir/link.d tools/fir-opt/CMakeFiles/fir-opt.dir/fir-opt.cpp.o -o bin/fir-opt -L/usr/lib/llvm/21/lib64 -Wl,-rpath,"\$ORIGIN/../lib64:/usr/lib/llvm/21/lib64:"  lib/libCUFAttrs.a  lib/libCUFDialect.a  lib/libFIRDialect.a  lib/libFIRSupport.a  lib/libFIRTransforms.a  lib/libFIRCodeGen.a  lib/libFIRCodeGenDialect.a  lib/libHLFIRDialect.a  lib/libHLFIRTransforms.a  lib/libFIROpenACCSupport.a  lib/libFIROpenMPSupport.a  lib/libFlangOpenMPTransforms.a  lib/libFIRAnalysis.a  lib/libFIRTransforms.a  lib/libFIRCodeGen.a  lib/libFIROpenACCSupport.a  lib/libFIRCodeGenDialect.a  -lMLIRIR  lib/libFIROpenMPSupport.a  lib/libFIRAnalysis.a  lib/libFIRBuilder.a  lib/libCUFDialect.a  lib/libFIRSupport.a  lib/libHLFIRDialect.a  lib/libFIRDialect.a  lib/libCUFAttrs.a  lib/libFIRDialectSupport.a  lib/libFortranEvaluate.a  lib/libFortranDecimal.a  lib/libFortranParser.a  lib/libFortranSupport.a  /usr/lib/llvm/21/lib64/libMLIR.so.21.0gitfa4ac19f  /usr/lib/llvm/21/lib64/libclang-cpp.so.21.0gitfa4ac19f  /usr/lib/llvm/21/lib64/libLLVM.so.21.0gitfa4ac19f  -lquadmath && :
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lMLIRIR: No such file or directory
collect2: error: ld returned 1 exit status
```