### PR TITLE
[flang] Fix Driver/do_concurrent_to_omp_cli.f90 test not to use runtime

### DIFF
--- a/flang/test/Driver/do_concurrent_to_omp_cli.f90
+++ b/flang/test/Driver/do_concurrent_to_omp_cli.f90
@@ -10,7 +10,7 @@
 ! BBC:      -fdo-concurrent-to-openmp=<string>
 ! BBC-SAME:   Try to map `do concurrent` loops to OpenMP [none|host|device] 
 
-! RUN: %flang -fdo-concurrent-to-openmp=host %s 2>&1 \
+! RUN: %flang -c -fdo-concurrent-to-openmp=host %s 2>&1 \
 ! RUN: | FileCheck %s --check-prefix=OPT
 
 ! OPT: warning: OpenMP is required for lowering `do concurrent` loops to OpenMP.


### PR DESCRIPTION
Fix Flang invocation in `Driver/do_concurrent_to_omp_cli.f90` test to run compilation step only, to fix testing when building with `-DFLANG_INCLUDE_RUNTIME=OFF`.  The test is only concerned with warning being emitted by the compiler, so there is no need to link the resulting executable.