### PR TITLE
[libc++] Removes the _LIBCPP_VERBOSE_ABORT_NOT_NOEXCEPT macro.

### DIFF
--- a/libcxx/docs/ReleaseNotes/21.rst
+++ b/libcxx/docs/ReleaseNotes/21.rst
@@ -70,6 +70,9 @@ Deprecations and Removals
 
 - ``std::is_trivial`` and ``std::is_trivial_v`` are deprecated in C++26 and later.
 
+- The ``_LIBCPP_VERBOSE_ABORT_NOT_NOEXCEPT`` has been removed, making ``std::__libcpp_verbose_abort``
+  unconditionally ``noexcept``.
+
 Potentially breaking changes
 ----------------------------
 
@@ -90,9 +93,6 @@ LLVM 21
 
   If you are using C++03 in your project, you should consider moving to a newer version of the Standard to get the most
   out of libc++.
-
-- The ``_LIBCPP_VERBOSE_ABORT_NOT_NOEXCEPT`` macro will be removed in LLVM 21, making ``std::__libcpp_verbose_abort``
-  unconditionally ``noexcept``.
 
 - Non-conforming extension ``packaged_task::result_type`` will be removed in LLVM 21.
 

--- a/libcxx/include/__verbose_abort
+++ b/libcxx/include/__verbose_abort
@@ -18,16 +18,10 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#if defined(_LIBCPP_VERBOSE_ABORT_NOT_NOEXCEPT)
-#  define _LIBCPP_VERBOSE_ABORT_NOEXCEPT
-#else
-#  define _LIBCPP_VERBOSE_ABORT_NOEXCEPT _NOEXCEPT
-#endif
-
 // This function should never be called directly from the code -- it should only be called through
 // the _LIBCPP_VERBOSE_ABORT macro.
 [[__noreturn__]] _LIBCPP_AVAILABILITY_VERBOSE_ABORT _LIBCPP_OVERRIDABLE_FUNC_VIS _LIBCPP_ATTRIBUTE_FORMAT(
-    __printf__, 1, 2) void __libcpp_verbose_abort(const char* __format, ...) _LIBCPP_VERBOSE_ABORT_NOEXCEPT;
+    __printf__, 1, 2) void __libcpp_verbose_abort(const char* __format, ...) _NOEXCEPT;
 
 // _LIBCPP_VERBOSE_ABORT(format, args...)
 //

--- a/libcxx/src/verbose_abort.cpp
+++ b/libcxx/src/verbose_abort.cpp
@@ -23,7 +23,7 @@ extern "C" void android_set_abort_message(const char* msg);
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-_LIBCPP_WEAK void __libcpp_verbose_abort(char const* format, ...) _LIBCPP_VERBOSE_ABORT_NOEXCEPT {
+_LIBCPP_WEAK void __libcpp_verbose_abort(char const* format, ...) noexcept {
   // Write message to stderr. We do this before formatting into a
   // buffer so that we still get some information out if that fails.
   {


### PR DESCRIPTION
This makes __libcpp_verbose_abort unconditionally noexcept. This was planned for the upcomming release.