### PR TITLE
[CI] monolithic-linux improvements

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -52,6 +52,9 @@ DEPENDENTS_TO_TEST = {
     "clang": {"clang-tools-extra", "compiler-rt", "cross-project-tests"},
     "clang-tools-extra": {"libc"},
     "mlir": {"flang"},
+    # Test everything if ci scripts are changed.
+    # FIXME: Figure out what is missing and add here.
+    ".ci": {"llvm", "clang", "lld", "lldb"},
 }
 
 DEPENDENT_RUNTIMES_TO_TEST = {"clang": {"libcxx", "libcxxabi", "libunwind"}}
@@ -130,12 +133,11 @@ def _add_dependencies(projects: Set[str]) -> Set[str]:
 def _compute_projects_to_test(modified_projects: Set[str], platform: str) -> Set[str]:
     projects_to_test = set()
     for modified_project in modified_projects:
-        # Skip all projects where we cannot run tests.
-        if modified_project not in PROJECT_CHECK_TARGETS:
-            continue
         if modified_project in RUNTIMES:
             continue
-        projects_to_test.add(modified_project)
+        # Skip all projects where we cannot run tests.
+        if modified_project in PROJECT_CHECK_TARGETS:
+            projects_to_test.add(modified_project)
         if modified_project not in DEPENDENTS_TO_TEST:
             continue
         for dependent_project in DEPENDENTS_TO_TEST[modified_project]:

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -188,6 +188,19 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")
 
+     def test_ci(self):
+        env_variables = compute_projects.get_env_variables(
+            [".ci/compute_projects.py"], "Linux"
+        )
+        self.assertEqual(env_variables["projects_to_build"],
+                         "clang;lld;llvm;lldb")
+        self.assertEqual(env_variables["project_check_targets"], "check-clang
+                         check-lld check-llvm check-lldb")
+        self.assertEqual(env_variables["runtimes_to_build"],
+                         "libcxx;libcxxabi;libunwind")
+        self.assertEqual(env_variables["runtimes_check_targets"], "check-cxx
+                         check-cxxabi check-unwind")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -18,7 +18,6 @@ set -o pipefail
 
 MONOREPO_ROOT="${MONOREPO_ROOT:="$(git rev-parse --show-toplevel)"}"
 BUILD_DIR="${BUILD_DIR:=${MONOREPO_ROOT}/build}"
-INSTALL_DIR="${BUILD_DIR}/install"
 rm -rf "${BUILD_DIR}"
 
 ccache --zero-stats
@@ -28,10 +27,14 @@ if [[ -n "${CLEAR_CACHE:-}" ]]; then
   ccache --clear
 fi
 
+mkdir -p artifacts/reproducers
+
+# Make sure any clang reproducers will end up as artifacts.
+export CLANG_CRASH_DIAGNOSTICS_DIR=`realpath artifacts/reproducers`
+
 function at-exit {
   retcode=$?
 
-  mkdir -p artifacts
   ccache --print-stats > artifacts/ccache_stats.txt
 
   # If building fails there will be no results files.
@@ -49,17 +52,28 @@ trap at-exit EXIT
 
 projects="${1}"
 targets="${2}"
+runtimes="${3}"
 
 lit_args="-v --xunit-xml-output ${BUILD_DIR}/test-results.xml --use-unique-output-file-name --timeout=1200 --time-tests"
 
 echo "--- cmake"
+
 export PIP_BREAK_SYSTEM_PACKAGES=1
 pip install -q -r "${MONOREPO_ROOT}"/mlir/python/requirements.txt
 pip install -q -r "${MONOREPO_ROOT}"/lldb/test/requirements.txt
 pip install -q -r "${MONOREPO_ROOT}"/.ci/requirements.txt
+
+# Set the system llvm-symbolizer as preferred.
+export LLVM_SYMBOLIZER_PATH=`which llvm-symbolizer`
+[[ ! -f "${LLVM_SYMBOLIZER_PATH}" ]] && echo "llvm-symbolizer not found!"
+
+# Set up all runtimes either way. libcxx is a dependency of LLDB.
+# If it ends up being unused, not much harm.
 cmake -S "${MONOREPO_ROOT}"/llvm -B "${BUILD_DIR}" \
       -D LLVM_ENABLE_PROJECTS="${projects}" \
+      -D LLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
       -G Ninja \
+      -D CMAKE_PREFIX_PATH="${HOME}/.local" \
       -D CMAKE_BUILD_TYPE=Release \
       -D LLVM_ENABLE_ASSERTIONS=ON \
       -D LLVM_BUILD_EXAMPLES=ON \
@@ -68,69 +82,47 @@ cmake -S "${MONOREPO_ROOT}"/llvm -B "${BUILD_DIR}" \
       -D LLVM_ENABLE_LLD=ON \
       -D CMAKE_CXX_FLAGS=-gmlt \
       -D LLVM_CCACHE_BUILD=ON \
+      -D LIBCXX_CXX_ABI=libcxxabi \
       -D MLIR_ENABLE_BINDINGS_PYTHON=ON \
-      -D CMAKE_INSTALL_PREFIX="${INSTALL_DIR}"
+      -D LLDB_ENABLE_PYTHON=ON \
+      -D LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS=ON
 
 echo "--- ninja"
+
 # Targets are not escaped as they are passed as separate arguments.
 ninja -C "${BUILD_DIR}" -k 0 ${targets}
 
-runtimes="${3}"
 runtime_targets="${4}"
 
-# Compiling runtimes with just-built Clang and running their tests
-# as an additional testing for Clang.
+# Run runtimes tests.
+# We don't need to do a clean separate build of runtimes, because runtimes
+# will be built against just built clang, and because LIBCXX_TEST_PARAMS
+# and LIBCXXABI_TEST_PARAMS only affect lit configuration, which successfully
+# propagates without a clean build. Other that those two variables, builds
+# are supposed to be the same.
 if [[ "${runtimes}" != "" ]]; then
   if [[ "${runtime_targets}" == "" ]]; then
     echo "Runtimes to build are specified, but targets are not."
     exit 1
   fi
 
-  echo "--- ninja install-clang"
-
-  ninja -C ${BUILD_DIR} install-clang install-clang-resource-headers
-
-  RUNTIMES_BUILD_DIR="${MONOREPO_ROOT}/build-runtimes"
-  INSTALL_DIR="${BUILD_DIR}/install"
-  mkdir -p ${RUNTIMES_BUILD_DIR}
-
   echo "--- cmake runtimes C++26"
 
-  rm -rf "${RUNTIMES_BUILD_DIR}"
-  cmake -S "${MONOREPO_ROOT}/runtimes" -B "${RUNTIMES_BUILD_DIR}" -GNinja \
-      -D CMAKE_C_COMPILER="${INSTALL_DIR}/bin/clang" \
-      -D CMAKE_CXX_COMPILER="${INSTALL_DIR}/bin/clang++" \
-      -D LLVM_ENABLE_RUNTIMES="${runtimes}" \
-      -D LIBCXX_CXX_ABI=libcxxabi \
-      -D CMAKE_BUILD_TYPE=RelWithDebInfo \
-      -D CMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
+  cmake -S "${MONOREPO_ROOT}"/llvm -B "${BUILD_DIR}" \
       -D LIBCXX_TEST_PARAMS="std=c++26" \
-      -D LIBCXXABI_TEST_PARAMS="std=c++26" \
-      -D LLVM_LIT_ARGS="${lit_args}"
+      -D LIBCXXABI_TEST_PARAMS="std=c++26"
 
   echo "--- ninja runtimes C++26"
 
-  ninja -vC "${RUNTIMES_BUILD_DIR}" ${runtime_targets}
+  ninja -vC "${BUILD_DIR}" ${runtime_targets}
 
   echo "--- cmake runtimes clang modules"
 
-  # We don't need to do a clean build of runtimes, because LIBCXX_TEST_PARAMS
-  # and LIBCXXABI_TEST_PARAMS only affect lit configuration, which successfully
-  # propagates without a clean build. Other that those two variables, builds
-  # are supposed to be the same.
-
-  cmake -S "${MONOREPO_ROOT}/runtimes" -B "${RUNTIMES_BUILD_DIR}" -GNinja \
-      -D CMAKE_C_COMPILER="${INSTALL_DIR}/bin/clang" \
-      -D CMAKE_CXX_COMPILER="${INSTALL_DIR}/bin/clang++" \
-      -D LLVM_ENABLE_RUNTIMES="${runtimes}" \
-      -D LIBCXX_CXX_ABI=libcxxabi \
-      -D CMAKE_BUILD_TYPE=RelWithDebInfo \
-      -D CMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
+  cmake -S "${MONOREPO_ROOT}"/llvm -B "${BUILD_DIR}" \
       -D LIBCXX_TEST_PARAMS="enable_modules=clang" \
-      -D LIBCXXABI_TEST_PARAMS="enable_modules=clang" \
-      -D LLVM_LIT_ARGS="${lit_args}"
+      -D LIBCXXABI_TEST_PARAMS="enable_modules=clang"
 
   echo "--- ninja runtimes clang modules"
 
-  ninja -vC "${RUNTIMES_BUILD_DIR}" ${runtime_targets}
+  ninja -vC "${BUILD_DIR}" ${runtime_targets}
 fi

--- a/lldb/test/requirements.txt
+++ b/lldb/test/requirements.txt
@@ -5,3 +5,5 @@ psutil>=5.9.4
 # See llvm.org/pr22274.
 pexpect>=4.9.0; sys_platform != 'win32'
 packaging
+# Required for python tests
+swig


### PR DESCRIPTION
Some improvements to monolithic-linux CI:

1) Add correct configuration and dependencies for LLDB testing which
   is actually relevant for clang changes.
2) Skip clang installation and separate configuration for runtimes.
   They will be built with the just built clang either way.
   This avoids building the runtimes twice when LLDB is also tested.
3) Make sure any generated clang reproducers end up as artifacts.
4) Set up llvm-symbolizer environment variable so that its preferred over
   any symbolizer just built, as it can be much slower when built for debugging.
5) Add all projects as dependencies of `.ci`, to make sure everything is
   tested when it changes.