### PR TITLE
[MLIR] Fix build after #131492

### DIFF
--- a/mlir/lib/Target/SMTLIB/CMakeLists.txt
+++ b/mlir/lib/Target/SMTLIB/CMakeLists.txt
@@ -10,4 +10,5 @@ add_mlir_translation_library(MLIRExportSMTLIB
   MLIRFuncDialect
   MLIRIR
   MLIRTranslateLib
+  MLIRArithDialect
 )


### PR DESCRIPTION
After #131492 is appears that linking MLIRAritDialect was missing.