### PR TITLE
[RISCV] Extend redundant vrgather.vx peephole to vfmv.v.f

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -19716,10 +19716,15 @@ SDValue RISCVTargetLowering::PerformDAGCombine(SDNode *N,
     SDValue Src = N->getOperand(0);
     SDValue Passthru = N->getOperand(2);
     SDValue VL = N->getOperand(4);
-    // TODO: Handle fmv.v.f?
-    if (Src.getOpcode() == RISCVISD::VMV_V_X_VL && Passthru.isUndef() &&
-        VL == Src.getOperand(2))
-      return Src;
+    switch (Src.getOpcode()) {
+    default:
+      break;
+    case RISCVISD::VMV_V_X_VL:
+    case RISCVISD::VFMV_V_F_VL:
+      if (Passthru.isUndef() && VL == Src.getOperand(2))
+        return Src;
+      break;
+    }
     break;
   }
   }

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-fp.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-shuffle-fp.ll
@@ -69,11 +69,10 @@ define <4 x double> @shuffle_vf_v4f64(<4 x double> %x) {
 define <4 x float> @vfmerge_constant_v4f32(<4 x float> %x) {
 ; CHECK-LABEL: vfmerge_constant_v4f32:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    lui a0, 264704
-; CHECK-NEXT:    vsetivli zero, 4, e32, m1, ta, mu
+; CHECK-NEXT:    vsetivli zero, 4, e32, m1, ta, ma
 ; CHECK-NEXT:    vmv.v.i v0, 6
-; CHECK-NEXT:    vmv.v.x v9, a0
-; CHECK-NEXT:    vrgather.vi v8, v9, 1, v0.t
+; CHECK-NEXT:    lui a0, 264704
+; CHECK-NEXT:    vmerge.vxm v8, v8, a0, v0
 ; CHECK-NEXT:    ret
    %s = shufflevector <4 x float> %x, <4 x float> <float poison, float 5.0, float poison, float poison>, <4 x i32> <i32 0, i32 5, i32 5, i32 3>
    ret <4 x float> %s
@@ -86,9 +85,8 @@ define <4 x double> @vfmerge_constant_v4f64(<4 x double> %x) {
 ; CHECK-NEXT:    fld fa5, %lo(.LCPI6_0)(a0)
 ; CHECK-NEXT:    vsetivli zero, 1, e8, mf8, ta, ma
 ; CHECK-NEXT:    vmv.v.i v0, 6
-; CHECK-NEXT:    vsetivli zero, 4, e64, m2, ta, mu
-; CHECK-NEXT:    vfmv.v.f v10, fa5
-; CHECK-NEXT:    vrgather.vi v8, v10, 1, v0.t
+; CHECK-NEXT:    vsetivli zero, 4, e64, m2, ta, ma
+; CHECK-NEXT:    vfmerge.vfm v8, v8, fa5, v0
 ; CHECK-NEXT:    ret
    %s = shufflevector <4 x double> %x, <4 x double> <double poison, double 5.0, double poison, double poison>, <4 x i32> <i32 0, i32 5, i32 5, i32 3>
    ret <4 x double> %s


### PR DESCRIPTION
Extend the transform introduced in 336b290 to vfmv.v.f.  This is fairly trivial and would have been in the original commit except I hadn't written the FP tests yet.

If the vrgather.vi is preceeded by a vfmv.v.f which writes a superset of the lanes writen by the vrgather, and the vrgather has no passthru, then the vrgather has no semantic effect.