### PR TITLE
[mlir][vector] Fix deprecation warning for `.isa`. NFC.

### DIFF
--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -5348,7 +5348,7 @@ public:
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(GatherOp op,
                                 PatternRewriter &rewriter) const override {
-    if (!op.getBase().getType().isa<MemRefType>())
+    if (!isa<MemRefType>(op.getBase().getType()))
       return rewriter.notifyMatchFailure(op, "base must be of memref type");
 
     if (failed(isZeroBasedContiguousSeq(op.getIndexVec())))


### PR DESCRIPTION
This was introduced in: https://github.com/llvm/llvm-project/pull/135371