### PR TITLE
[clang-doc][NFC] Use destructuring in Mapper.cpp

### DIFF
--- a/clang-tools-extra/clang-doc/Mapper.cpp
+++ b/clang-tools-extra/clang-doc/Mapper.cpp
@@ -59,18 +59,18 @@ bool MapASTVisitor::mapDecl(const T *D, bool IsDefinition) {
   bool IsFileInRootDir;
   llvm::SmallString<128> File =
       getFile(D, D->getASTContext(), CDCtx.SourceRoot, IsFileInRootDir);
-  auto I = serialize::emitInfo(D, getComment(D, D->getASTContext()),
-                               getLine(D, D->getASTContext()), File,
-                               IsFileInRootDir, CDCtx.PublicOnly);
+  auto [Child, Parent] = serialize::emitInfo(
+      D, getComment(D, D->getASTContext()), getLine(D, D->getASTContext()),
+      File, IsFileInRootDir, CDCtx.PublicOnly);
 
-  // A null in place of I indicates that the serializer is skipping this decl
-  // for some reason (e.g. we're only reporting public decls).
-  if (I.first)
-    CDCtx.ECtx->reportResult(llvm::toHex(llvm::toStringRef(I.first->USR)),
-                             serialize::serialize(I.first));
-  if (I.second)
-    CDCtx.ECtx->reportResult(llvm::toHex(llvm::toStringRef(I.second->USR)),
-                             serialize::serialize(I.second));
+  // A null in place of a valid Info indicates that the serializer is skipping
+  // this decl for some reason (e.g. we're only reporting public decls).
+  if (Child)
+    CDCtx.ECtx->reportResult(llvm::toHex(llvm::toStringRef(Child->USR)),
+                             serialize::serialize(Child));
+  if (Parent)
+    CDCtx.ECtx->reportResult(llvm::toHex(llvm::toStringRef(Parent->USR)),
+                             serialize::serialize(Parent));
   return true;
 }
 


### PR DESCRIPTION
Destructuring makes the intent a bit clearer over first/second.