### PR TITLE
[Mips] Implement MipsInstrInfo::getNop() operation

### DIFF
--- a/clang/test/CodeGen/Mips/unreachable.cpp
+++ b/clang/test/CodeGen/Mips/unreachable.cpp
@@ -1,0 +1,13 @@
+// REQUIRES: mips-registered-target
+// RUN: %clang_cc1 -triple mipsel-w64-windows-gnu -x c++ -mrelocation-model static -emit-obj %s -o - | llvm-objdump -a - | FileCheck %s
+// CHECK: file format coff-mips
+
+[[__noreturn__]] inline void g() {
+  __builtin_unreachable();
+}
+
+void f(int i)
+{
+  if (i == 0)
+    g();
+}

--- a/llvm/lib/Target/Mips/MipsInstrInfo.cpp
+++ b/llvm/lib/Target/Mips/MipsInstrInfo.cpp
@@ -87,6 +87,14 @@ MipsInstrInfo::GetMemOperand(MachineBasicBlock &MBB, int FI,
                                  MFI.getObjectAlign(FI));
 }
 
+MCInst MipsInstrInfo::getNop() const {
+  MCInst Nop;
+  // using Mips::NOP gives
+  // "fatal error: error in backend: Not supported instr: <MCInst 580>"
+  Nop.setOpcode(Mips::SSNOP);
+  return Nop;
+}
+
 //===----------------------------------------------------------------------===//
 // Branch Analysis
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/Mips/MipsInstrInfo.h
+++ b/llvm/lib/Target/Mips/MipsInstrInfo.h
@@ -59,6 +59,8 @@ public:
 
   static const MipsInstrInfo *create(MipsSubtarget &STI);
 
+  MCInst getNop() const override;
+
   /// Branch Analysis
   bool analyzeBranch(MachineBasicBlock &MBB, MachineBasicBlock *&TBB,
                      MachineBasicBlock *&FBB,


### PR DESCRIPTION
Previously, this was calling TargetInstrInfo::getNop(), which contains:
 llvm_unreachable("Not implemented");

Fixes #134913.