### PR TITLE
[alpha.webkit.UnretainedCallArgsChecker] Don't emit a warning for RetainPtr::operator=

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefCallArgsChecker.cpp
@@ -264,7 +264,7 @@ public:
         auto *callee = MemberOp->getDirectCallee();
         if (auto *calleeDecl = dyn_cast<CXXMethodDecl>(callee)) {
           if (const CXXRecordDecl *classDecl = calleeDecl->getParent()) {
-            if (isRefCounted(classDecl))
+            if (isSafePtr(classDecl))
               return true;
           }
         }

--- a/clang/test/Analysis/Checkers/WebKit/call-args-checked.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/call-args-checked.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UncountedCallArgsChecker -verify %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=alpha.webkit.UncheckedCallArgsChecker -verify %s
 
 #include "mock-types.h"
 
@@ -10,10 +10,10 @@ namespace call_args_unchecked_uncounted {
 
 static void foo() {
   someFunction(makeObj());
-  // expected-warning@-1{{Call argument is uncounted and unsafe [alpha.webkit.UncountedCallArgsChecker]}}
+  // expected-warning@-1{{Call argument is unchecked and unsafe [alpha.webkit.UncheckedCallArgsChecker]}}
 }
 
-} // namespace call_args_checked
+} // namespace call_args_unchecked_uncounted
 
 namespace call_args_checked {
 
@@ -35,12 +35,22 @@ static void baz() {
 namespace call_args_default {
 
 void someFunction(RefCountableAndCheckable* = makeObj());
-// expected-warning@-1{{Call argument is uncounted and unsafe [alpha.webkit.UncountedCallArgsChecker]}}
+// expected-warning@-1{{Call argument is unchecked and unsafe [alpha.webkit.UncheckedCallArgsChecker]}}
 void otherFunction(RefCountableAndCheckable* = makeObjChecked().ptr());
 
 void foo() {
   someFunction();
   otherFunction();
+}
+
+}
+
+namespace call_args_checked_assignment {
+
+CheckedObj* provide();
+void foo() {
+  CheckedPtr<CheckedObj> ptr;
+  ptr = provide();
 }
 
 }

--- a/clang/test/Analysis/Checkers/WebKit/mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/mock-types.h
@@ -249,7 +249,7 @@ public:
   T *get() const { return t; }
   T *operator->() const { return t; }
   T &operator*() const { return *t; }
-  CheckedPtr &operator=(T *) { return *this; }
+  CheckedPtr &operator=(T *);
   operator bool() const { return t; }
 };
 

--- a/clang/test/Analysis/Checkers/WebKit/objc-mock-types.h
+++ b/clang/test/Analysis/Checkers/WebKit/objc-mock-types.h
@@ -216,11 +216,7 @@ template <typename T> struct RetainPtr {
   PtrType get() const { return t; }
   PtrType operator->() const { return t; }
   T &operator*() const { return *t; }
-  RetainPtr &operator=(PtrType t) {
-    RetainPtr o(t);
-    swap(o);
-    return *this;
-  }
+  RetainPtr &operator=(PtrType t);
   PtrType leakRef()
   {
     PtrType s = t;

--- a/clang/test/Analysis/Checkers/WebKit/unretained-call-args.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-call-args.mm
@@ -271,6 +271,16 @@ namespace cxx_member_operator_call {
   }
 }
 
+namespace cxx_assignment_op {
+
+  SomeObj* provide();
+  void foo() {
+    RetainPtr<SomeObj> ptr;
+    ptr = provide();
+  }
+
+}
+
 namespace call_with_ptr_on_ref {
   RetainPtr<SomeObj> provideProtected();
   RetainPtr<CFMutableArrayRef> provideProtectedCF();


### PR DESCRIPTION
Generalize the check for operator= so that it works for RetainPtr and CheckedPtr instead of just RefPtr.