### PR TITLE
[lldb/cmake] Normalize use of HAVE_LIBCOMPRESSION

### DIFF
--- a/lldb/include/lldb/Host/Config.h.cmake
+++ b/lldb/include/lldb/Host/Config.h.cmake
@@ -23,9 +23,7 @@
 
 #cmakedefine01 HAVE_NR_PROCESS_VM_READV
 
-#ifndef HAVE_LIBCOMPRESSION
-#cmakedefine HAVE_LIBCOMPRESSION
-#endif
+#cmakedefine01 HAVE_LIBCOMPRESSION
 
 #cmakedefine01 LLDB_ENABLE_POSIX
 

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
@@ -46,7 +46,7 @@
 #define DEBUGSERVER_BASENAME "lldb-server"
 #endif
 
-#if defined(HAVE_LIBCOMPRESSION)
+#if HAVE_LIBCOMPRESSION
 #include <compression.h>
 #endif
 
@@ -77,7 +77,7 @@ GDBRemoteCommunication::~GDBRemoteCommunication() {
     Disconnect();
   }
 
-#if defined(HAVE_LIBCOMPRESSION)
+#if HAVE_LIBCOMPRESSION
   if (m_decompression_scratch)
     free (m_decompression_scratch);
 #endif
@@ -514,7 +514,7 @@ bool GDBRemoteCommunication::DecompressPacket() {
     }
   }
 
-#if defined(HAVE_LIBCOMPRESSION)
+#if HAVE_LIBCOMPRESSION
   if (m_compression_type == CompressionType::ZlibDeflate ||
       m_compression_type == CompressionType::LZFSE ||
       m_compression_type == CompressionType::LZ4 ||

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.h
@@ -227,7 +227,7 @@ private:
   HostThread m_listen_thread;
   std::string m_listen_url;
 
-#if defined(HAVE_LIBCOMPRESSION)
+#if HAVE_LIBCOMPRESSION
   CompressionType m_decompression_scratch_type = CompressionType::None;
   void *m_decompression_scratch = nullptr;
 #endif

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -41,7 +41,7 @@
 #include "llvm/Config/llvm-config.h" // for LLVM_ENABLE_ZLIB
 #include "llvm/Support/JSON.h"
 
-#if defined(HAVE_LIBCOMPRESSION)
+#if HAVE_LIBCOMPRESSION
 #include <compression.h>
 #endif
 
@@ -1104,7 +1104,7 @@ void GDBRemoteCommunicationClient::MaybeEnableCompression(
   CompressionType avail_type = CompressionType::None;
   llvm::StringRef avail_name;
 
-#if defined(HAVE_LIBCOMPRESSION)
+#if HAVE_LIBCOMPRESSION
   if (avail_type == CompressionType::None) {
     for (auto compression : supported_compressions) {
       if (compression == "lzfse") {
@@ -1114,9 +1114,6 @@ void GDBRemoteCommunicationClient::MaybeEnableCompression(
       }
     }
   }
-#endif
-
-#if defined(HAVE_LIBCOMPRESSION)
   if (avail_type == CompressionType::None) {
     for (auto compression : supported_compressions) {
       if (compression == "zlib-deflate") {
@@ -1140,7 +1137,7 @@ void GDBRemoteCommunicationClient::MaybeEnableCompression(
   }
 #endif
 
-#if defined(HAVE_LIBCOMPRESSION)
+#if HAVE_LIBCOMPRESSION
   if (avail_type == CompressionType::None) {
     for (auto compression : supported_compressions) {
       if (compression == "lz4") {
@@ -1150,9 +1147,6 @@ void GDBRemoteCommunicationClient::MaybeEnableCompression(
       }
     }
   }
-#endif
-
-#if defined(HAVE_LIBCOMPRESSION)
   if (avail_type == CompressionType::None) {
     for (auto compression : supported_compressions) {
       if (compression == "lzma") {


### PR DESCRIPTION
I *think* this was the reason behind the failures in 2fd860c1f559c0b0be66cc000e38270a04d0a1a3: the clang include tool showed the Config.h headers as unused, and because the macro was referenced through an `#ifdef`, its removal didn't cause build failures.  Switching to `#cmakedefine01` + `#if` should make sure this does not happen again.

According to D48977, the `#ifndef`+`#cmakedefine` patterns is due to some files redefining the macro themselves. I no longer see any such files in the source tree (there also were no files like that in the source tree at the revision mentioned, but the macro *was* defined in the hand-maintained XCode project we had at the time).