### PR TITLE
[Github][CI] Upload artifacts directory for premerge workflow

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: Premerge Artifacts
-          path: artifacts/
+          path: artifacts/**
           retention-days: 5
 
   premerge-checks-windows:

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -65,6 +65,13 @@ jobs:
           export CXX=/opt/llvm/bin/clang++
 
           ./.ci/monolithic-linux.sh "${projects_to_build}" "${project_check_targets}" "${runtimes_to_build}" "${runtimes_check_targets}"
+            - name: "Upload artifact"
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Premerge Artifacts
+          path: artifacts/
+          retention-days: 5
 
   premerge-checks-windows:
     name: Windows Premerge Checks (Test Only - Please Ignore Results)

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -70,8 +70,9 @@ jobs:
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: Premerge Artifacts
-          path: artifacts/**
+          path: artifacts/
           retention-days: 5
+          include-hidden-files: 'true'
 
   premerge-checks-windows:
     name: Windows Premerge Checks (Test Only - Please Ignore Results)
@@ -120,6 +121,13 @@ jobs:
           set MAX_PARALLEL_LINK_JOBS=64
           call C:\\BuildTools\\Common7\\Tools\\VsDevCmd.bat -arch=amd64 -host_arch=amd64
           bash .ci/monolithic-windows.sh "${{ steps.vars.outputs.windows-projects }}" "${{ steps.vars.outputs.windows-check-targets }}"
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: Premerge Artifacts
+          path: artifacts/
+          retention-days: 5
+          include-hidden-files: 'true'
 
   premerge-check-macos:
     name: MacOS Premerge Checks

--- a/bolt/CMakeLists.txt
+++ b/bolt/CMakeLists.txt
@@ -1,3 +1,4 @@
+# testing
 cmake_minimum_required(VERSION 3.20.0)
 
 set(LLVM_SUBPROJECT_TITLE "BOLT")

--- a/bolt/CMakeLists.txt
+++ b/bolt/CMakeLists.txt
@@ -1,4 +1,3 @@
-# testing
 cmake_minimum_required(VERSION 3.20.0)
 
 set(LLVM_SUBPROJECT_TITLE "BOLT")


### PR DESCRIPTION
The premerge pipeline currently creates an artifacts directory with some
statistics that gets uploaded on the buildkite side for later
inspection. This patch adds support for this on the Github side by using
the upload artifacts action.
