### PR TITLE
[lldb-dap] fix inconsistent debugAdapterHostname argument name

### DIFF
--- a/lldb/tools/lldb-dap/src-ts/debug-adapter-factory.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-adapter-factory.ts
@@ -211,7 +211,7 @@ export class LLDBDapDescriptorFactory
     if (session.configuration.debugAdapterPort) {
       return new vscode.DebugAdapterServer(
         session.configuration.debugAdapterPort,
-        session.configuration.debugAdapterHost,
+        session.configuration.debugAdapterHostname,
       );
     }
 

--- a/lldb/tools/lldb-dap/src-ts/debug-configuration-provider.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-configuration-provider.ts
@@ -32,11 +32,11 @@ export class LLDBDapConfigurationProvider
   ): Promise<vscode.DebugConfiguration | null | undefined> {
     try {
       if (
-        "debugAdapterHost" in debugConfiguration &&
+        "debugAdapterHostname" in debugConfiguration &&
         !("debugAdapterPort" in debugConfiguration)
       ) {
         throw new ErrorWithNotification(
-          "A debugAdapterPort must be provided when debugAdapterHost is set. Please update your launch configuration.",
+          "A debugAdapterPort must be provided when debugAdapterHostname is set. Please update your launch configuration.",
           new ConfigureButton(),
         );
       }
@@ -83,7 +83,7 @@ export class LLDBDapConfigurationProvider
           // and list of arguments.
           delete debugConfiguration.debugAdapterExecutable;
           delete debugConfiguration.debugAdapterArgs;
-          debugConfiguration.debugAdapterHost = serverInfo.host;
+          debugConfiguration.debugAdapterHostname = serverInfo.host;
           debugConfiguration.debugAdapterPort = serverInfo.port;
         }
       }


### PR DESCRIPTION
the argument is written as `debugAdapterHostname` in package.json but used as `debugAdapterHost`