### PR TITLE
Update LIBUNWIND_ENABLE_WERROR default value in BuildingLibunwind.rst

### DIFF
--- a/libunwind/docs/BuildingLibunwind.rst
+++ b/libunwind/docs/BuildingLibunwind.rst
@@ -91,7 +91,7 @@ libunwind specific options
 
 .. option:: LIBUNWIND_ENABLE_WERROR:BOOL
 
-  **Default**: ``ON``
+  **Default**: ``OFF``
 
   Compile with -Werror
 


### PR DESCRIPTION
Hey there,

It seems that `LIBUNWIND_ENABLE_WERROR` defaults to `OFF` according to [CMakeLists.txt](https://github.com/llvm/llvm-project/blob/main/libunwind/CMakeLists.txt#L43).

Thanks for your time!