### PR TITLE
[mlir] Remove deprecated cast member functions

### DIFF
--- a/mlir/docs/DeclarativeRewrites.md
+++ b/mlir/docs/DeclarativeRewrites.md
@@ -704,8 +704,8 @@ For example, we can write
 def HasNoUseOf: Constraint<CPred<"$_self.use_empty()">, "has no use">;
 
 def HasSameElementType : Constraint<
-    CPred<"$0.cast<ShapedType>().getElementType() == "
-          "$1.cast<ShapedType>().getElementType()">,
+    CPred<"cast<ShapedType>($0).getElementType() == "
+          "cast<ShapedType>($1).getElementType()">,
     "has same element type">;
 
 def : Pattern<(TwoResultOp:$results $input),

--- a/mlir/docs/DefiningDialects/Operations.md
+++ b/mlir/docs/DefiningDialects/Operations.md
@@ -1397,7 +1397,7 @@ is used. They serve as "hooks" to the enclosing environment. This includes
     information of the current operation.
 *   `$_self` will be replaced with the entity this predicate is attached to.
     E.g., `BoolAttr` is an attribute constraint that wraps a
-    `CPred<"$_self.isa<BoolAttr>()">`. Then for `BoolAttr:$attr`,`$_self` will be
+    `CPred<"isa<BoolAttr>($_self)">`. Then for `BoolAttr:$attr`,`$_self` will be
     replaced by `$attr`. For type constraints, it's a little bit special since
     we want the constraints on each type definition reads naturally and we want
     to attach type constraints directly to an operand/result, `$_self` will be
@@ -1409,8 +1409,8 @@ to allow referencing operand/result `$-name`s; such `$-name`s can start with
 underscore.
 
 For example, to write an attribute `attr` is an `IntegerAttr`, in C++ you can
-just call `attr.isa<IntegerAttr>()`. The code can be wrapped in a `CPred` as
-`$_self.isa<IntegerAttr>()`, with `$_self` as the special placeholder to be
+just call `isa<IntegerAttr>(attr)`. The code can be wrapped in a `CPred` as
+`isa<IntegerAttr>($_self)`, with `$_self` as the special placeholder to be
 replaced by the current attribute `attr` at expansion time.
 
 For more complicated predicates, you can wrap it in a single `CPred`, or you can
@@ -1419,10 +1419,10 @@ that an attribute `attr` is a 32-bit or 64-bit integer, you can write it as
 
 ```tablegen
 And<[
-  CPred<"$_self.isa<IntegerAttr>()">,
+  CPred<"$isa<IntegerAttr>(_self)()">,
   Or<[
-    CPred<"$_self.cast<IntegerAttr>().getType().isInteger(32)">,
-    CPred<"$_self.cast<IntegerAttr>().getType().isInteger(64)">
+    CPred<"cast<IntegerAttr>($_self).getType().isInteger(32)">,
+    CPred<"cast<IntegerAttr>($_self).getType().isInteger(64)">
   ]>
 ]>
 ```

--- a/mlir/docs/DefiningDialects/_index.md
+++ b/mlir/docs/DefiningDialects/_index.md
@@ -43,7 +43,7 @@ extends to all of the MLIR constructs, including [Interfaces](../Interfaces.md) 
 
 ```tablegen
 // Include the definition of the necessary tablegen constructs for defining
-// our dialect. 
+// our dialect.
 include "mlir/IR/DialectBase.td"
 
 // Here is a simple definition of a dialect.
@@ -649,7 +649,7 @@ Type MyDialect::parseType(DialectAsmParser &parser) const {
             return dynType;
          return Type();
     }
-    
+
     ...
 }
 ```
@@ -669,7 +669,7 @@ It is also possible to cast a `Type` known to be defined at runtime to a
 `DynamicType`.
 
 ```c++
-auto dynType = type.cast<DynamicType>();
+auto dynType = cast<DynamicType>(type);
 auto typeDef = dynType.getTypeDef();
 auto args = dynType.getParams();
 ```
@@ -679,7 +679,7 @@ auto args = dynType.getParams();
 Similar to types defined at runtime, attributes defined at runtime can only have
 as argument a list of `Attribute`.
 
-Similarily to types, an attribute is defined at runtime using the class
+Similarly to types, an attribute is defined at runtime using the class
 `DynamicAttrDefinition`, which is created using the `DynamicAttrDefinition::get`
 functions. An attribute definition requires a name, the dialect that will
 register the attribute, and a parameter verifier. It can also define optionally
@@ -767,7 +767,7 @@ It is also possible to cast an `Attribute` known to be defined at runtime to a
 `DynamicAttr`.
 
 ```c++
-auto dynAttr = attr.cast<DynamicAttr>();
+auto dynAttr = cast<DynamicAttr>(attr);
 auto attrDef = dynAttr.getAttrDef();
 auto args = dynAttr.getParams();
 ```

--- a/mlir/docs/Diagnostics.md
+++ b/mlir/docs/Diagnostics.md
@@ -293,7 +293,7 @@ shown below:
 // function should not recurse into the child location. Recursion into nested
 // location is performed as necessary by the caller.
 auto shouldShowFn = [](Location loc) -> bool {
-  FileLineColLoc fileLoc = loc.dyn_cast<FileLineColLoc>();
+  FileLineColLoc fileLoc = dyn_cast<FileLineColLoc>(loc);
 
   // We don't perform any filtering on non-file locations.
   // Reminder: The caller will recurse into any necessary child locations.

--- a/mlir/docs/Interfaces.md
+++ b/mlir/docs/Interfaces.md
@@ -256,7 +256,7 @@ struct ExampleTypeInterfaceTraits {
   struct ExternalModel : public FallbackModel<ConcreteModel> {
     unsigned exampleInterfaceHook(Type type) const override {
       // Default implementation can be provided here.
-      return type.cast<ConcreteType>().callSomeTypeSpecificMethod();
+      return cast<ConcreteType>(type).callSomeTypeSpecificMethod();
     }
   };
 };

--- a/mlir/docs/PDLL.md
+++ b/mlir/docs/PDLL.md
@@ -139,8 +139,8 @@ def HasNoUseOf: Constraint<CPred<"$_self.use_empty()">, "has no use">;
 
 // Check if two values have a ShapedType with the same element type.
 def HasSameElementType : Constraint<
-    CPred<"$0.getType().cast<ShapedType>().getElementType() == "
-          "$1.getType().cast<ShapedType>().getElementType()">,
+    CPred<"cast<ShapedType>($0.getType()).getElementType() == "
+          "cast<ShapedType>($1.getType()).getElementType()">,
     "values have same element type">;
 
 def : Pattern<(TwoResultOp:$results $input),
@@ -161,8 +161,8 @@ Constraint HasNoUseOf(value: Value) [{
   return success(value.use_empty());
 }];
 Constraint HasSameElementType(value1: Value, value2: Value) [{
-  return success(value1.getType().cast<ShapedType>().getElementType() ==
-                 value2.getType().cast<ShapedType>().getElementType());
+  return success(cast<ShapedType>(value1.getType()).getElementType() ==
+                 cast<ShapedType>(value2.getType()).getElementType());
 }];
 
 Pattern {
@@ -1105,8 +1105,8 @@ static LogicalResult hasOneUseImpl(PatternRewriter &rewriter, Value value) {
 }
 static LogicalResult hasSameElementTypeImpl(PatternRewriter &rewriter,
                                             Value value1, Value Value2) {
-  return success(value1.getType().cast<ShapedType>().getElementType() ==
-                 value2.getType().cast<ShapedType>().getElementType());
+  return success(cast<ShapedType>(value1.getType()).getElementType() ==
+                 cast<ShapedType>(value2.getType()).getElementType());
 }
 
 void registerNativeConstraints(RewritePatternSet &patterns) {
@@ -1129,8 +1129,8 @@ Constraint HasOneUse(value: Value) [{
   return success(value.hasOneUse());
 }];
 Constraint HasSameElementType(value1: Value, value2: Value) [{
-  return success(value1.getType().cast<ShapedType>().getElementType() ==
-                 value2.getType().cast<ShapedType>().getElementType());
+  return success(cast<ShapedType>(value1.getType()).getElementType() ==
+                 cast<ShapedType>(value2.getType()).getElementType());
 }];
 
 Pattern {
@@ -1160,8 +1160,8 @@ LogicalResult HasOneUse(PatternRewriter &rewriter, Value value) {
   return success(value.hasOneUse());
 }
 LogicalResult HasSameElementType(Value value1, Value value2) {
-  return success(value1.getType().cast<ShapedType>().getElementType() ==
-                 value2.getType().cast<ShapedType>().getElementType());
+  return success(cast<ShapedType>(value1.getType()).getElementType() ==
+                 cast<ShapedType>(value2.getType()).getElementType());
 }
 ```
 

--- a/mlir/docs/Tutorials/QuickstartRewrites.md
+++ b/mlir/docs/Tutorials/QuickstartRewrites.md
@@ -132,7 +132,7 @@ static Value createTFLLeakyRelu(PatternRewriter &rewriter, Operation *op,
                                 Value operand, Attribute attr) {
   return rewriter.create<mlir::TFL::LeakyReluOp>(
       op->getLoc(), operands[0].getType(), /*arg=*/operands[0],
-      /*alpha=*/attrs[0].cast<FloatAttr>());
+      /*alpha=*/cast<FloatAttr>(attrs[0]));
 }
 ```
 

--- a/mlir/docs/Tutorials/Toy/Ch-5.md
+++ b/mlir/docs/Tutorials/Toy/Ch-5.md
@@ -75,8 +75,7 @@ void ToyToAffineLoweringPass::runOnOperation() {
   // only treat it as `legal` if its operands are legal.
   target.addIllegalDialect<ToyDialect>();
   target.addDynamicallyLegalOp<toy::PrintOp>([](toy::PrintOp op) {
-    return llvm::none_of(op->getOperandTypes(),
-                         [](Type type) { return type.isa<TensorType>(); });
+    return llvm::none_of(op->getOperandTypes(), llvm::IsaPred<TensorType>);
   });
   ...
 }

--- a/mlir/docs/Tutorials/Toy/Ch-7.md
+++ b/mlir/docs/Tutorials/Toy/Ch-7.md
@@ -203,7 +203,7 @@ within the Dialect. A simple example is shown below:
 // using StructType in a similar way to Tensor or MemRef. We use `DialectType`
 // to demarcate the StructType as belonging to the Toy dialect.
 def Toy_StructType :
-    DialectType<Toy_Dialect, CPred<"$_self.isa<StructType>()">,
+    DialectType<Toy_Dialect, CPred<"isa<StructType>($_self)">,
                 "Toy struct type">;
 
 // Provide a definition of the types that are used within the Toy dialect.
@@ -274,7 +274,7 @@ mlir::Type ToyDialect::parseType(mlir::DialectAsmParser &parser) const {
       return nullptr;
 
     // Check that the type is either a TensorType or another StructType.
-    if (!elementType.isa<mlir::TensorType, StructType>()) {
+    if (!isa<mlir::TensorType, StructType>(elementType)) {
       parser.emitError(typeLoc, "element type for a struct must either "
                                 "be a TensorType or a StructType, got: ")
           << elementType;
@@ -467,7 +467,7 @@ OpFoldResult StructConstantOp::fold(FoldAdaptor adaptor) {
 
 /// Fold simple struct access operations that access into a constant.
 OpFoldResult StructAccessOp::fold(FoldAdaptor adaptor) {
-  auto structAttr = adaptor.getInput().dyn_cast_or_null<mlir::ArrayAttr>();
+  auto structAttr = dyn_cast_or_null<mlir::ArrayAttr>(adaptor.getInput());
   if (!structAttr)
     return nullptr;
 
@@ -487,11 +487,11 @@ mlir::Operation *ToyDialect::materializeConstant(mlir::OpBuilder &builder,
                                                  mlir::Attribute value,
                                                  mlir::Type type,
                                                  mlir::Location loc) {
-  if (type.isa<StructType>())
+  if (isa<StructType>(type))
     return builder.create<StructConstantOp>(loc, type,
-                                            value.cast<mlir::ArrayAttr>());
+                                            cast<mlir::ArrayAttr>(value));
   return builder.create<ConstantOp>(loc, type,
-                                    value.cast<mlir::DenseElementsAttr>());
+                                    cast<mlir::DenseElementsAttr>(value));
 }
 ```
 

--- a/mlir/docs/Tutorials/UnderstandingTheIRStructure.md
+++ b/mlir/docs/Tutorials/UnderstandingTheIRStructure.md
@@ -236,7 +236,7 @@ some information about them:
     } else {
       // If there is no defining op, the Value is necessarily a Block
       // argument.
-      auto blockArg = operand.cast<BlockArgument>();
+      auto blockArg = cast<BlockArgument>(operand);
       llvm::outs() << "  - Operand produced by Block argument, number "
                    << blockArg.getArgNumber() << "\n";
     }

--- a/mlir/docs/Tutorials/transform/Ch4.md
+++ b/mlir/docs/Tutorials/transform/Ch4.md
@@ -355,7 +355,7 @@ mlir::transform::HasOperandSatisfyingOp::apply(
     transform::detail::prepareValueMappings(
         yieldedMappings, getBody().front().getTerminator()->getOperands(),
         state);
-    results.setParams(getPosition().cast<OpResult>(),
+    results.setParams(cast<OpResult>(getPosition()),
                       {rewriter.getI32IntegerAttr(operand.getOperandNumber())});
     for (auto &&[result, mapping] : llvm::zip(getResults(), yieldedMappings))
       results.setMappedValues(result, mapping);

--- a/mlir/examples/transform-opt/mlir-transform-opt.cpp
+++ b/mlir/examples/transform-opt/mlir-transform-opt.cpp
@@ -136,7 +136,7 @@ public:
   /// Verifies the captured "expected-*" diagnostics if required.
   llvm::LogicalResult verify() const {
     if (auto *ptr =
-            handler.dyn_cast<mlir::SourceMgrDiagnosticVerifierHandler *>()) {
+            dyn_cast<mlir::SourceMgrDiagnosticVerifierHandler *>(handler)) {
       return ptr->verify();
     }
     return mlir::success();
@@ -144,7 +144,7 @@ public:
 
   /// Destructs the object of the same type as allocated.
   ~DiagnosticHandlerWrapper() {
-    if (auto *ptr = handler.dyn_cast<mlir::SourceMgrDiagnosticHandler *>()) {
+    if (auto *ptr = dyn_cast<mlir::SourceMgrDiagnosticHandler *>(handler)) {
       delete ptr;
     } else {
       delete cast<mlir::SourceMgrDiagnosticVerifierHandler *>(handler);

--- a/mlir/include/mlir/IR/AffineExpr.h
+++ b/mlir/include/mlir/IR/AffineExpr.h
@@ -81,19 +81,6 @@ public:
 
   bool operator!() const { return expr == nullptr; }
 
-  template <typename U>
-  [[deprecated("Use llvm::isa<U>() instead")]] constexpr bool isa() const;
-
-  template <typename U>
-  [[deprecated("Use llvm::dyn_cast<U>() instead")]] U dyn_cast() const;
-
-  template <typename U>
-  [[deprecated("Use llvm::dyn_cast_or_null<U>() instead")]] U
-  dyn_cast_or_null() const;
-
-  template <typename U>
-  [[deprecated("Use llvm::cast<U>() instead")]] U cast() const;
-
   MLIRContext *getContext() const;
 
   /// Return the classification for this type.
@@ -287,30 +274,6 @@ AffineExpr getAffineExprFromFlatForm(ArrayRef<int64_t> flatExprs,
                                      MLIRContext *context);
 
 raw_ostream &operator<<(raw_ostream &os, AffineExpr expr);
-
-template <typename U>
-constexpr bool AffineExpr::isa() const {
-  if constexpr (std::is_same_v<U, AffineBinaryOpExpr>)
-    return getKind() <= AffineExprKind::LAST_AFFINE_BINARY_OP;
-  if constexpr (std::is_same_v<U, AffineDimExpr>)
-    return getKind() == AffineExprKind::DimId;
-  if constexpr (std::is_same_v<U, AffineSymbolExpr>)
-    return getKind() == AffineExprKind::SymbolId;
-  if constexpr (std::is_same_v<U, AffineConstantExpr>)
-    return getKind() == AffineExprKind::Constant;
-}
-template <typename U>
-U AffineExpr::dyn_cast() const {
-  return llvm::dyn_cast<U>(*this);
-}
-template <typename U>
-U AffineExpr::dyn_cast_or_null() const {
-  return llvm::dyn_cast_or_null<U>(*this);
-}
-template <typename U>
-U AffineExpr::cast() const {
-  return llvm::cast<U>(*this);
-}
 
 /// Simplify an affine expression by flattening and some amount of simple
 /// analysis. This has complexity linear in the number of nodes in 'expr'.

--- a/mlir/include/mlir/IR/Attributes.h
+++ b/mlir/include/mlir/IR/Attributes.h
@@ -47,24 +47,6 @@ public:
 
   bool operator!() const { return impl == nullptr; }
 
-  /// Casting utility functions. These are deprecated and will be removed,
-  /// please prefer using the `llvm` namespace variants instead.
-  template <typename... Tys>
-  [[deprecated("Use mlir::isa<U>() instead")]]
-  bool isa() const;
-  template <typename... Tys>
-  [[deprecated("Use mlir::isa_and_nonnull<U>() instead")]]
-  bool isa_and_nonnull() const;
-  template <typename U>
-  [[deprecated("Use mlir::dyn_cast<U>() instead")]]
-  U dyn_cast() const;
-  template <typename U>
-  [[deprecated("Use mlir::dyn_cast_or_null<U>() instead")]]
-  U dyn_cast_or_null() const;
-  template <typename U>
-  [[deprecated("Use mlir::cast<U>() instead")]]
-  U cast() const;
-
   /// Return a unique identifier for the concrete attribute type. This is used
   /// to support dynamic type casting.
   TypeID getTypeID() { return impl->getAbstractAttribute().getTypeID(); }
@@ -168,31 +150,6 @@ protected:
 inline raw_ostream &operator<<(raw_ostream &os, Attribute attr) {
   attr.print(os);
   return os;
-}
-
-template <typename... Tys>
-bool Attribute::isa() const {
-  return llvm::isa<Tys...>(*this);
-}
-
-template <typename... Tys>
-bool Attribute::isa_and_nonnull() const {
-  return llvm::isa_and_present<Tys...>(*this);
-}
-
-template <typename U>
-U Attribute::dyn_cast() const {
-  return llvm::dyn_cast<U>(*this);
-}
-
-template <typename U>
-U Attribute::dyn_cast_or_null() const {
-  return llvm::dyn_cast_if_present<U>(*this);
-}
-
-template <typename U>
-U Attribute::cast() const {
-  return llvm::cast<U>(*this);
 }
 
 inline ::llvm::hash_code hash_value(Attribute arg) {

--- a/mlir/include/mlir/IR/ExtensibleDialect.h
+++ b/mlir/include/mlir/IR/ExtensibleDialect.h
@@ -149,7 +149,7 @@ class IsDynamicAttr : public TraitBase<ConcreteType, IsDynamicAttr> {};
 /// A dynamic attribute instance. This is an attribute whose definition is
 /// defined at runtime.
 /// It is possible to check if an attribute is a dynamic attribute using
-/// `my_attr.isa<DynamicAttr>()`, and getting the attribute definition of a
+/// `isa<DynamicAttr>(myAttr)`, and getting the attribute definition of a
 /// dynamic attribute using the `DynamicAttr::getAttrDef` method.
 /// All dynamic attributes have the same storage, which is an array of
 /// attributes.
@@ -306,7 +306,7 @@ class IsDynamicType : public TypeTrait::TraitBase<ConcreteType, IsDynamicType> {
 /// A dynamic type instance. This is a type whose definition is defined at
 /// runtime.
 /// It is possible to check if a type is a dynamic type using
-/// `my_type.isa<DynamicType>()`, and getting the type definition of a dynamic
+/// `isa<DynamicType>(myType)`, and getting the type definition of a dynamic
 /// type using the `DynamicType::getTypeDef` method.
 /// All dynamic types have the same storage, which is an array of attributes.
 class DynamicType

--- a/mlir/include/mlir/IR/Location.h
+++ b/mlir/include/mlir/IR/Location.h
@@ -79,23 +79,6 @@ public:
   operator LocationAttr() const { return impl; }
   LocationAttr *operator->() const { return const_cast<LocationAttr *>(&impl); }
 
-  /// Type casting utilities on the underlying location.
-  template <typename U>
-  [[deprecated("Use mlir::isa<U>() instead")]]
-  bool isa() const {
-    return llvm::isa<U>(*this);
-  }
-  template <typename U>
-  [[deprecated("Use mlir::dyn_cast<U>() instead")]]
-  U dyn_cast() const {
-    return llvm::dyn_cast<U>(*this);
-  }
-  template <typename U>
-  [[deprecated("Use mlir::cast<U>() instead")]]
-  U cast() const {
-    return llvm::cast<U>(*this);
-  }
-
   /// Comparison operators.
   bool operator==(Location rhs) const { return impl == rhs.impl; }
   bool operator!=(Location rhs) const { return !(*this == rhs); }

--- a/mlir/include/mlir/IR/Types.h
+++ b/mlir/include/mlir/IR/Types.h
@@ -96,22 +96,6 @@ public:
 
   bool operator!() const { return impl == nullptr; }
 
-  template <typename... Tys>
-  [[deprecated("Use mlir::isa<U>() instead")]]
-  bool isa() const;
-  template <typename... Tys>
-  [[deprecated("Use mlir::isa_and_nonnull<U>() instead")]]
-  bool isa_and_nonnull() const;
-  template <typename U>
-  [[deprecated("Use mlir::dyn_cast<U>() instead")]]
-  U dyn_cast() const;
-  template <typename U>
-  [[deprecated("Use mlir::dyn_cast_or_null<U>() instead")]]
-  U dyn_cast_or_null() const;
-  template <typename U>
-  [[deprecated("Use mlir::cast<U>() instead")]]
-  U cast() const;
-
   /// Return a unique identifier for the concrete type. This is used to support
   /// dynamic type casting.
   TypeID getTypeID() { return impl->getAbstractType().getTypeID(); }
@@ -317,31 +301,6 @@ using IsMutable = detail::StorageUserTrait::IsMutable<ConcreteType>;
 // Make Type hashable.
 inline ::llvm::hash_code hash_value(Type arg) {
   return DenseMapInfo<const Type::ImplType *>::getHashValue(arg.impl);
-}
-
-template <typename... Tys>
-bool Type::isa() const {
-  return llvm::isa<Tys...>(*this);
-}
-
-template <typename... Tys>
-bool Type::isa_and_nonnull() const {
-  return llvm::isa_and_present<Tys...>(*this);
-}
-
-template <typename U>
-U Type::dyn_cast() const {
-  return llvm::dyn_cast<U>(*this);
-}
-
-template <typename U>
-U Type::dyn_cast_or_null() const {
-  return llvm::dyn_cast_or_null<U>(*this);
-}
-
-template <typename U>
-U Type::cast() const {
-  return llvm::cast<U>(*this);
 }
 
 } // namespace mlir

--- a/mlir/include/mlir/IR/Value.h
+++ b/mlir/include/mlir/IR/Value.h
@@ -97,30 +97,6 @@ class Value {
 public:
   constexpr Value(detail::ValueImpl *impl = nullptr) : impl(impl) {}
 
-  template <typename U>
-  [[deprecated("Use mlir::isa<U>() instead")]]
-  bool isa() const {
-    return llvm::isa<U>(*this);
-  }
-
-  template <typename U>
-  [[deprecated("Use mlir::dyn_cast<U>() instead")]]
-  U dyn_cast() const {
-    return llvm::dyn_cast<U>(*this);
-  }
-
-  template <typename U>
-  [[deprecated("Use mlir::dyn_cast_or_null<U>() instead")]]
-  U dyn_cast_or_null() const {
-    return llvm::dyn_cast_or_null<U>(*this);
-  }
-
-  template <typename U>
-  [[deprecated("Use mlir::cast<U>() instead")]]
-  U cast() const {
-    return llvm::cast<U>(*this);
-  }
-
   explicit operator bool() const { return impl; }
   bool operator==(const Value &other) const { return impl == other.impl; }
   bool operator!=(const Value &other) const { return !(*this == other); }

--- a/mlir/include/mlir/Tools/PDLL/AST/Types.h
+++ b/mlir/include/mlir/Tools/PDLL/AST/Types.h
@@ -62,35 +62,6 @@ public:
   bool operator!=(const Type &other) const { return !(*this == other); }
   explicit operator bool() const { return impl; }
 
-  /// Provide type casting support.
-  template <typename U>
-  [[deprecated("Use mlir::isa<U>() instead")]]
-  bool isa() const {
-    assert(impl && "isa<> used on a null type.");
-    return U::classof(*this);
-  }
-  template <typename U, typename V, typename... Others>
-  [[deprecated("Use mlir::isa<U>() instead")]]
-  bool isa() const {
-    return isa<U>() || isa<V, Others...>();
-  }
-  template <typename U>
-  [[deprecated("Use mlir::dyn_cast<U>() instead")]]
-  U dyn_cast() const {
-    return isa<U>() ? U(impl) : U(nullptr);
-  }
-  template <typename U>
-  [[deprecated("Use mlir::dyn_cast_or_null<U>() instead")]]
-  U dyn_cast_or_null() const {
-    return (impl && isa<U>()) ? U(impl) : U(nullptr);
-  }
-  template <typename U>
-  [[deprecated("Use mlir::cast<U>() instead")]]
-  U cast() const {
-    assert(isa<U>());
-    return U(impl);
-  }
-
   /// Return the internal storage instance of this type.
   Storage *getImpl() const { return impl; }
 

--- a/mlir/lib/Conversion/VectorToLLVM/ConvertVectorToLLVM.cpp
+++ b/mlir/lib/Conversion/VectorToLLVM/ConvertVectorToLLVM.cpp
@@ -113,7 +113,7 @@ static Value getIndexedPtrs(ConversionPatternRewriter &rewriter, Location loc,
 /// an LLVM constant op.
 static Value getAsLLVMValue(OpBuilder &builder, Location loc,
                             OpFoldResult foldResult) {
-  if (auto attr = foldResult.dyn_cast<Attribute>()) {
+  if (auto attr = dyn_cast<Attribute>(foldResult)) {
     auto intAttr = cast<IntegerAttr>(attr);
     return builder.create<LLVM::ConstantOp>(loc, intAttr).getResult();
   }

--- a/mlir/lib/Dialect/SparseTensor/Transforms/Utils/LoopEmitter.h
+++ b/mlir/lib/Dialect/SparseTensor/Transforms/Utils/LoopEmitter.h
@@ -104,7 +104,7 @@ public:
                           SynTensorBoundSetter synSetter = nullptr);
 
   /// Generates code to compute an affine expression whose variables are
-  /// `LoopId`s (i.e., `a.cast<AffineDimExpr>().getPosition()` is a valid
+  /// `LoopId`s (i.e., `cast<AffineDimExpr>(a).getPosition()` is a valid
   /// `LoopId`).
   Value genAffine(OpBuilder &builder, Location loc, AffineExpr a);
 

--- a/mlir/lib/Dialect/Transform/Transforms/TransformInterpreterUtils.cpp
+++ b/mlir/lib/Dialect/Transform/Transforms/TransformInterpreterUtils.cpp
@@ -210,7 +210,7 @@ LogicalResult transform::applyTransformNamedSequence(
            << "expected one payload to be bound to the first argument, got "
            << bindings.at(0).size();
   }
-  auto *payloadRoot = bindings.at(0).front().dyn_cast<Operation *>();
+  auto *payloadRoot = dyn_cast<Operation *>(bindings.at(0).front());
   if (!payloadRoot) {
     return transformRoot->emitError() << "expected the object bound to the "
                                          "first argument to be an operation";

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -341,7 +341,7 @@ SmallVector<Value> vector::getAsValues(OpBuilder &builder, Location loc,
   SmallVector<Value> values;
   llvm::transform(foldResults, std::back_inserter(values),
                   [&](OpFoldResult foldResult) {
-                    if (auto attr = foldResult.dyn_cast<Attribute>())
+                    if (auto attr = dyn_cast<Attribute>(foldResult))
                       return builder
                           .create<arith::ConstantIndexOp>(
                               loc, cast<IntegerAttr>(attr).getInt())
@@ -2970,7 +2970,7 @@ LogicalResult InsertOp::verify() {
     return emitOpError(
         "expected position attribute rank to match the dest vector rank");
   for (auto [idx, pos] : llvm::enumerate(position)) {
-    if (auto attr = pos.dyn_cast<Attribute>()) {
+    if (auto attr = dyn_cast<Attribute>(pos)) {
       int64_t constIdx = cast<IntegerAttr>(attr).getInt();
       if (!isValidPositiveIndexOrPoison(constIdx, kPoisonIndex,
                                         destVectorType.getDimSize(idx))) {

--- a/mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp
@@ -300,9 +300,9 @@ static Value dynamicallyExtractSubVector(OpBuilder &rewriter, Location loc,
 
   for (int i = 0; i < numElemsToExtract; ++i) {
     Value extractLoc =
-        (i == 0) ? offset.dyn_cast<Value>()
+        (i == 0) ? dyn_cast<Value>(offset)
                  : rewriter.create<arith::AddIOp>(
-                       loc, rewriter.getIndexType(), offset.dyn_cast<Value>(),
+                       loc, rewriter.getIndexType(), dyn_cast<Value>(offset),
                        rewriter.create<arith::ConstantIndexOp>(loc, i));
     auto extractOp = rewriter.create<vector::ExtractOp>(loc, src, extractLoc);
     dest = rewriter.create<vector::InsertOp>(loc, extractOp, dest, i);

--- a/mlir/lib/IR/AffineMap.cpp
+++ b/mlir/lib/IR/AffineMap.cpp
@@ -748,7 +748,7 @@ AffineMap mlir::foldAttributesIntoMap(Builder &b, AffineMap map,
   SmallVector<AffineExpr> dimReplacements, symReplacements;
   int64_t numDims = 0;
   for (int64_t i = 0; i < map.getNumDims(); ++i) {
-    if (auto attr = operands[i].dyn_cast<Attribute>()) {
+    if (auto attr = dyn_cast<Attribute>(operands[i])) {
       dimReplacements.push_back(
           b.getAffineConstantExpr(cast<IntegerAttr>(attr).getInt()));
     } else {
@@ -758,7 +758,7 @@ AffineMap mlir::foldAttributesIntoMap(Builder &b, AffineMap map,
   }
   int64_t numSymbols = 0;
   for (int64_t i = 0; i < map.getNumSymbols(); ++i) {
-    if (auto attr = operands[i + map.getNumDims()].dyn_cast<Attribute>()) {
+    if (auto attr = dyn_cast<Attribute>(operands[i + map.getNumDims()])) {
       symReplacements.push_back(
           b.getAffineConstantExpr(cast<IntegerAttr>(attr).getInt()));
     } else {

--- a/mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
+++ b/mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp
@@ -515,7 +515,7 @@ bool GreedyPatternRewriteDriver::processWorklist() {
         bool materializationSucceeded = true;
         for (auto [ofr, resultType] :
              llvm::zip_equal(foldResults, op->getResultTypes())) {
-          if (auto value = ofr.dyn_cast<Value>()) {
+          if (auto value = dyn_cast<Value>(ofr)) {
             assert(value.getType() == resultType &&
                    "folder produced value of incorrect type");
             replacements.push_back(value);

--- a/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
+++ b/mlir/tools/mlir-tblgen/OpDefinitionsGen.cpp
@@ -1802,7 +1802,7 @@ void OpEmitter::genPropertiesSupportForBytecode(
       writePropertiesMethod << tgfmt(writeBytecodeSegmentSizeLegacy, &fmtCtxt);
     }
     if (const auto *namedProperty =
-            attrOrProp.dyn_cast<const NamedProperty *>()) {
+            dyn_cast<const NamedProperty *>(attrOrProp)) {
       StringRef name = namedProperty->name;
       readPropertiesMethod << formatv(
           R"(

--- a/mlir/unittests/IR/SymbolTableTest.cpp
+++ b/mlir/unittests/IR/SymbolTableTest.cpp
@@ -49,8 +49,7 @@ protected:
     // Check that it got renamed.
     bool calleeFound = false;
     fooOp->walk([&](CallOpInterface callOp) {
-      StringAttr callee = callOp.getCallableForCallee()
-                              .dyn_cast<SymbolRefAttr>()
+      StringAttr callee = dyn_cast<SymbolRefAttr>(callOp.getCallableForCallee())
                               .getLeafReference();
       EXPECT_EQ(callee, "baz");
       calleeFound = true;


### PR DESCRIPTION
These have been deprecated for over two years now in favor of free functions.

See the relevant discourse thread:
https://discourse.llvm.org/t/preferred-casting-style-going-forward/68443 and the deprecation notice: https://mlir.llvm.org/deprecation/.