### PR TITLE
[CMake] Only export the LLVM_LINK_LLVM_DYLIB setting if not yet set

### DIFF
--- a/llvm/cmake/modules/CMakeLists.txt
+++ b/llvm/cmake/modules/CMakeLists.txt
@@ -80,11 +80,6 @@ if (LLVM_BUILD_UTILS)
   endif()
 endif()
 
-if (LLVM_LINK_LLVM_DYLIB)
-  set(LLVM_CONFIG_LINK_LLVM_DYLIB
-      "set(LLVM_LINK_LLVM_DYLIB ${LLVM_LINK_LLVM_DYLIB})")
-endif()
-
 # We need to use the full path to the LLVM Exports file to make sure we get the
 # one from the build tree. This is due to our cmake files being split between
 # this source dir and the binary dir in the build tree configuration and the

--- a/llvm/cmake/modules/LLVMConfig.cmake.in
+++ b/llvm/cmake/modules/LLVMConfig.cmake.in
@@ -22,7 +22,11 @@ set(LLVM_COMMON_DEPENDS @LLVM_COMMON_DEPENDS@)
 
 set(LLVM_AVAILABLE_LIBS @LLVM_AVAILABLE_LIBS@)
 
-@LLVM_CONFIG_LINK_LLVM_DYLIB@
+# By only exporting the setting if it was not yet defined, out-of-tree
+# clients get the correct default, but may still choose if they can.
+if(@LLVM_LINK_LLVM_DYLIB@ AND NOT DEFINED LLVM_LINK_LLVM_DYLIB)
+  set(LLVM_LINK_LLVM_DYLIB @LLVM_LINK_LLVM_DYLIB@)
+endif()
 
 set(LLVM_DYLIB_COMPONENTS @LLVM_DYLIB_COMPONENTS@)
 


### PR DESCRIPTION
Follows up on these two commits:

  * 3b8b3c2a2cd3 [CMake] Export the LLVM_LINK_LLVM_DYLIB setting
  * 5fed24a39698 [CMake] Followup for r337366: Only export LLVM_LINK_LLVM_DYLIB if it's set to ON

Commit 3b8b3c2a2cd3 introduced the export of the `LLVM_LINK_LLVM_DYLIB` setting, so that clients can check whether the option of dynamic linking is available. However, it left no way for the client to actually set `LLVM_LINK_LLVM_DYLIB` themselves.

Commit 5fed24a39698 addressed the problem that out-of-tree clients lost the ability to link against the dylib, even if in-tree tools did not.

There is one remaining problem: if LLVM_LINK_LLVM_DYLIB is supported there is no way to configure clients to not link against llvm dynamically anymore. Naively, one would be able to do this for Clang e.g. with `-DLLVM_LINK_LLVM_DYLIB=OFF`.

This commit suggests to fix this problem by only setting the DYLIB option if it was not already set before.