### PR TITLE
[doc][CoC] Update committee members list

### DIFF
--- a/llvm/docs/CodeOfConduct.rst
+++ b/llvm/docs/CodeOfConduct.rst
@@ -159,13 +159,13 @@ following
 
 The current committee members are:
 
-* Kit Barton (kbarton\@llvm.org)
+* Aaron Ballman (aaron.ballman\@llvm.org)
 * Kristof Beyls (kristof.beyls\@llvm.org)
-* Stella Stamenova (sstamenova\@llvm.org)
 * David Blaikie (dblaikie\@llvm.org)
-* Mike Edwards (medwards\@llvm.org)
+* Jonas Devlieghere (jonas.devlieghere\@llvm.org)
 * Cyndy Ishida (cishida\@llvm.org)
 * Tanya Lattner (tanyalattner\@llvm.org)
+* Stella Stamenova (sstamenova\@llvm.org)
 
 
 Transparency Reports


### PR DESCRIPTION
The list of Code of Conduct committee member names was out of date. This updates it, and orders them alphabetically by last name.