### PR TITLE
[libc] Fix incorrect unsigned comparison

### DIFF
--- a/libc/src/stdio/printf_core/float_dec_converter.h
+++ b/libc/src/stdio/printf_core/float_dec_converter.h
@@ -192,7 +192,7 @@ template <WriteMode write_mode> class FloatWriter {
         RET_IF_RESULT_NEGATIVE(writer->write({block_buffer, digits_to_write}));
       }
       RET_IF_RESULT_NEGATIVE(writer->write(DECIMAL_POINT));
-      if (buffered_digits - digits_to_write > 0) {
+      if (buffered_digits > digits_to_write) {
         // Write the digits after the decimal point.
         RET_IF_RESULT_NEGATIVE(
             writer->write({block_buffer + digits_to_write,
@@ -222,7 +222,7 @@ template <WriteMode write_mode> class FloatWriter {
         RET_IF_RESULT_NEGATIVE(writer->write(MAX_BLOCK_DIGIT, digits_to_write));
       }
       RET_IF_RESULT_NEGATIVE(writer->write(DECIMAL_POINT));
-      if ((BLOCK_SIZE * max_block_count) - digits_to_write > 0) {
+      if ((BLOCK_SIZE * max_block_count) > digits_to_write) {
         RET_IF_RESULT_NEGATIVE(writer->write(
             MAX_BLOCK_DIGIT, (BLOCK_SIZE * max_block_count) - digits_to_write));
       }

--- a/libc/src/stdio/printf_core/float_dec_converter.h
+++ b/libc/src/stdio/printf_core/float_dec_converter.h
@@ -186,11 +186,10 @@ template <WriteMode write_mode> class FloatWriter {
     if (total_digits_written < digits_before_decimal &&
         total_digits_written + buffered_digits >= digits_before_decimal &&
         has_decimal_point) {
+      // digits_to_write > 0 guaranteed by outer if
       size_t digits_to_write = digits_before_decimal - total_digits_written;
-      if (digits_to_write > 0) {
-        // Write the digits before the decimal point.
-        RET_IF_RESULT_NEGATIVE(writer->write({block_buffer, digits_to_write}));
-      }
+      // Write the digits before the decimal point.
+      RET_IF_RESULT_NEGATIVE(writer->write({block_buffer, digits_to_write}));
       RET_IF_RESULT_NEGATIVE(writer->write(DECIMAL_POINT));
       if (buffered_digits > digits_to_write) {
         // Write the digits after the decimal point.
@@ -217,10 +216,9 @@ template <WriteMode write_mode> class FloatWriter {
         total_digits_written + BLOCK_SIZE * max_block_count >=
             digits_before_decimal &&
         has_decimal_point) {
+      // digits_to_write > 0 guaranteed by outer if
       size_t digits_to_write = digits_before_decimal - total_digits_written;
-      if (digits_to_write > 0) {
-        RET_IF_RESULT_NEGATIVE(writer->write(MAX_BLOCK_DIGIT, digits_to_write));
-      }
+      RET_IF_RESULT_NEGATIVE(writer->write(MAX_BLOCK_DIGIT, digits_to_write));
       RET_IF_RESULT_NEGATIVE(writer->write(DECIMAL_POINT));
       if ((BLOCK_SIZE * max_block_count) > digits_to_write) {
         RET_IF_RESULT_NEGATIVE(writer->write(


### PR DESCRIPTION
There is a problem with such unsigned comparison pattern:
```
if(unsigned_a - unsigned_b > 0) { /* only NOT go here when unsigned_a==unsigned_b */ }
```
When `unsigned_a` < `unsigned_b`, the result will still be `>0` due to underflow.
This patch fixes two of the occurrences I found.
Also remove two redundant `if` where its condition is guaranteed by outer `if`.