### PR TITLE
[RISCV] Add missing bitmask for some extensions

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -154,7 +154,8 @@ def FeatureStdExtZihpm
     : RISCVExtension<2, 0, "Hardware Performance Counters",
                      [FeatureStdExtZicsr]>;
 
-def FeatureStdExtZimop : RISCVExtension<1, 0, "May-Be-Operations">;
+def FeatureStdExtZimop : RISCVExtension<1, 0, "May-Be-Operations">,
+                         RISCVExtensionBitmask<1, 1>;
 def HasStdExtZimop : Predicate<"Subtarget->hasStdExtZimop()">,
                      AssemblerPredicate<(all_of FeatureStdExtZimop),
                                         "'Zimop' (May-Be-Operations)">;
@@ -262,7 +263,8 @@ def HasStdExtZalasr : Predicate<"Subtarget->hasStdExtZalasr()">,
 def FeatureStdExtZama16b
     : RISCVExtension<1, 0, "Atomic 16-byte misaligned loads, stores and AMOs">;
 
-def FeatureStdExtZawrs : RISCVExtension<1, 0, "Wait on Reservation Set">;
+def FeatureStdExtZawrs : RISCVExtension<1, 0, "Wait on Reservation Set">,
+                         RISCVExtensionBitmask<1, 7>;
 def HasStdExtZawrs : Predicate<"Subtarget->hasStdExtZawrs()">,
                      AssemblerPredicate<(all_of FeatureStdExtZawrs),
                                         "'Zawrs' (Wait on Reservation Set)">;
@@ -368,7 +370,8 @@ def HasRVCHints : Predicate<"Subtarget->enableRVCHintInstrs()">,
 def FeatureStdExtZca
     : RISCVExtension<1, 0,
                      "part of the C extension, excluding compressed "
-                     "floating point loads/stores">;
+                     "floating point loads/stores">,
+      RISCVExtensionBitmask<1, 2>;
 
 def FeatureStdExtC
     : RISCVExtension<2, 0, "Compressed Instructions", [FeatureStdExtZca]>,
@@ -387,7 +390,8 @@ def HasStdExtCOrZca
 
 def FeatureStdExtZcb
     : RISCVExtension<1, 0, "Compressed basic bit manipulation instructions",
-                     [FeatureStdExtZca]>;
+                     [FeatureStdExtZca]>,
+      RISCVExtensionBitmask<1, 3>;
 def HasStdExtZcb : Predicate<"Subtarget->hasStdExtZcb()">,
                    AssemblerPredicate<(all_of FeatureStdExtZcb),
                        "'Zcb' (Compressed basic bit manipulation instructions)">;
@@ -395,7 +399,8 @@ def HasStdExtZcb : Predicate<"Subtarget->hasStdExtZcb()">,
 def FeatureStdExtZcd
     : RISCVExtension<1, 0,
                      "Compressed Double-Precision Floating-Point Instructions",
-                     [FeatureStdExtD, FeatureStdExtZca]>;
+                     [FeatureStdExtD, FeatureStdExtZca]>,
+      RISCVExtensionBitmask<1, 4>;
 
 def HasStdExtCOrZcd
     : Predicate<"Subtarget->hasStdExtCOrZcd()">,
@@ -406,7 +411,8 @@ def HasStdExtCOrZcd
 def FeatureStdExtZcf
     : RISCVExtension<1, 0,
                      "Compressed Single-Precision Floating-Point Instructions",
-                     [FeatureStdExtF, FeatureStdExtZca]>;
+                     [FeatureStdExtF, FeatureStdExtZca]>,
+      RISCVExtensionBitmask<1, 5>;
 
 def FeatureStdExtZclsd
     : RISCVExtension<1, 0,
@@ -447,7 +453,8 @@ def HasStdExtCOrZcfOrZce
 
 def FeatureStdExtZcmop
     : RISCVExtension<1, 0, "Compressed May-Be-Operations",
-                     [FeatureStdExtZca]>;
+                     [FeatureStdExtZca]>,
+      RISCVExtensionBitmask<1, 6>;
 def HasStdExtZcmop : Predicate<"Subtarget->hasStdExtZcmop()">,
                      AssemblerPredicate<(all_of FeatureStdExtZcmop),
                          "'Zcmop' (Compressed May-Be-Operations)">;
@@ -628,32 +635,37 @@ def FeatureStdExtZve32x
     : RISCVExtension<1, 0,
                      "Vector Extensions for Embedded Processors "
                      "with maximal 32 EEW",
-                     [FeatureStdExtZicsr, FeatureStdExtZvl32b]>;
+                     [FeatureStdExtZicsr, FeatureStdExtZvl32b]>,
+      RISCVExtensionBitmask<0, 60>;
 
 
 def FeatureStdExtZve32f
     : RISCVExtension<1, 0,
                      "Vector Extensions for Embedded Processors "
                      "with maximal 32 EEW and F extension",
-                     [FeatureStdExtZve32x, FeatureStdExtF]>;
+                     [FeatureStdExtZve32x, FeatureStdExtF]>,
+      RISCVExtensionBitmask<0, 61>;
 
 def FeatureStdExtZve64x
     : RISCVExtension<1, 0,
                      "Vector Extensions for Embedded Processors "
                      "with maximal 64 EEW",
-                     [FeatureStdExtZve32x, FeatureStdExtZvl64b]>;
+                     [FeatureStdExtZve32x, FeatureStdExtZvl64b]>,
+      RISCVExtensionBitmask<0, 62>;
 
 def FeatureStdExtZve64f
     : RISCVExtension<1, 0,
                      "Vector Extensions for Embedded Processors "
                      "with maximal 64 EEW and F extension",
-                     [FeatureStdExtZve32f, FeatureStdExtZve64x]>;
+                     [FeatureStdExtZve32f, FeatureStdExtZve64x]>,
+      RISCVExtensionBitmask<0, 63>;
 
 def FeatureStdExtZve64d
     : RISCVExtension<1, 0,
                      "Vector Extensions for Embedded Processors "
                      "with maximal 64 EEW, F and D extension",
-                     [FeatureStdExtZve64f, FeatureStdExtD]>;
+                     [FeatureStdExtZve64f, FeatureStdExtD]>,
+      RISCVExtensionBitmask<1, 0>;
 
 def FeatureStdExtV
     : RISCVExtension<1, 0,

--- a/llvm/utils/TableGen/Basic/RISCVTargetDefEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/RISCVTargetDefEmitter.cpp
@@ -224,7 +224,12 @@ static void emitRISCVExtensionBitmask(const RecordKeeper &RK, raw_ostream &OS) {
   std::vector<const Record *> Extensions =
       RK.getAllDerivedDefinitionsIfDefined("RISCVExtensionBitmask");
   llvm::sort(Extensions, [](const Record *Rec1, const Record *Rec2) {
-    return getExtensionName(Rec1) < getExtensionName(Rec2);
+    unsigned GroupID1 = Rec1->getValueAsInt("GroupID");
+    unsigned GroupID2 = Rec2->getValueAsInt("GroupID");
+    if (GroupID1 != GroupID2)
+      return GroupID1 < GroupID2;
+
+    return Rec1->getValueAsInt("BitPos") < Rec2->getValueAsInt("BitPos");
   });
 
 #ifndef NDEBUG


### PR DESCRIPTION
According to: https://github.com/riscv-non-isa/riscv-c-api-doc/blob/main/src/c-api.adoc#extension-bitmask-definitions

And we sort the bitmask by group id and then bit position.
