### PR TITLE
[Clang][CodeGen][OpenCL] Add `-fno-delete-null-pointer-checks` to avoid UB. NFC.

### DIFF
--- a/clang/test/CodeGenOpenCL/spir32_target.cl
+++ b/clang/test/CodeGenOpenCL/spir32_target.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -triple "spir-unknown-unknown" -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 %s -triple "spir-unknown-unknown" -fno-delete-null-pointer-checks -emit-llvm -o - | FileCheck %s
 
 // CHECK: target triple = "spir-unknown-unknown"
 

--- a/clang/test/CodeGenOpenCL/spir64_target.cl
+++ b/clang/test/CodeGenOpenCL/spir64_target.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -triple "spir64-unknown-unknown" -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 %s -triple "spir64-unknown-unknown" -emit-llvm -fno-delete-null-pointer-checks -o - | FileCheck %s
 
 // CHECK: target triple = "spir64-unknown-unknown"
 

--- a/clang/test/CodeGenOpenCL/spirv_target.cl
+++ b/clang/test/CodeGenOpenCL/spirv_target.cl
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 %s -triple "spirv32-unknown-unknown" -verify -emit-llvm -o - | FileCheck %s -check-prefix=SPIRV32
-// RUN: %clang_cc1 %s -triple "spirv64-unknown-unknown" -verify -emit-llvm -o - | FileCheck %s -check-prefix=SPIRV64
+// RUN: %clang_cc1 %s -triple "spirv32-unknown-unknown" -fno-delete-null-pointer-checks -verify -emit-llvm -o - | FileCheck %s -check-prefix=SPIRV32
+// RUN: %clang_cc1 %s -triple "spirv64-unknown-unknown" -fno-delete-null-pointer-checks -verify -emit-llvm -o - | FileCheck %s -check-prefix=SPIRV64
 
 // SPIRV32: target triple = "spirv32-unknown-unknown"
 // SPIRV64: target triple = "spirv64-unknown-unknown"


### PR DESCRIPTION
Needed by https://github.com/llvm/llvm-project/pull/130742.
