### PR TITLE
[llvm][ELF][build attributes] Change StringRef to std::string for BuildAttributeSubSection::Name

### DIFF
--- a/llvm/include/llvm/Support/ELFAttributes.h
+++ b/llvm/include/llvm/Support/ELFAttributes.h
@@ -36,7 +36,7 @@ struct BuildAttributeItem {
       : Type(Ty), Tag(Tg), IntValue(IV), StringValue(std::move(SV)) {}
 };
 struct BuildAttributeSubSection {
-  StringRef Name;
+  std::string Name;
   unsigned IsOptional;
   unsigned ParameterType;
   SmallVector<BuildAttributeItem, 64> Content;


### PR DESCRIPTION
BuildAttributeSubSection::Name must be a std::string instead of StringRef because it may be assigned from non-persistent memory. StringRef is non-owning and unsafe in this context. This change ensures the subsection name owns its memory, preventing use-after-free or dangling references.

Context: Work in progress in PR #131990.