### PR TITLE
[lldb] Fix use-color settings not persistent

### DIFF
--- a/lldb/include/lldb/Core/IOHandler.h
+++ b/lldb/include/lldb/Core/IOHandler.h
@@ -101,7 +101,7 @@ public:
   }
 
   virtual bool SetUseColor(bool use_color) {
-    // Use color isn't mandatory
+    // Color support isn't mandatory.
     return false;
   };
 

--- a/lldb/include/lldb/Core/IOHandler.h
+++ b/lldb/include/lldb/Core/IOHandler.h
@@ -99,6 +99,12 @@ public:
     // Prompt support isn't mandatory
     return false;
   }
+
+  virtual bool SetUseColor(bool use_color) {
+    // Use color isn't mandatory
+    return false;
+  };
+
   bool SetPrompt(const char *) = delete;
 
   virtual llvm::StringRef GetControlSequence(char ch) { return {}; }
@@ -374,6 +380,8 @@ public:
 
   bool SetPrompt(llvm::StringRef prompt) override;
   bool SetPrompt(const char *prompt) = delete;
+
+  bool SetUseColor(bool use_color) override;
 
   const char *GetContinuationPrompt();
 

--- a/lldb/include/lldb/Host/Editline.h
+++ b/lldb/include/lldb/Host/Editline.h
@@ -168,6 +168,9 @@ public:
   DisplayCompletions(Editline &editline,
                      llvm::ArrayRef<CompletionResult::Completion> results);
 
+  /// Sets if editline should use color.
+  void UseColor(bool use_color);
+
   /// Sets a string to be used as a prompt, or combined with a line number to
   /// form a prompt.
   void SetPrompt(const char *prompt);
@@ -223,21 +226,29 @@ public:
   void SetPromptAnsiPrefix(std::string prefix) {
     if (m_color)
       m_prompt_ansi_prefix = std::move(prefix);
+    else
+      m_prompt_ansi_prefix.clear();
   }
 
   void SetPromptAnsiSuffix(std::string suffix) {
     if (m_color)
       m_prompt_ansi_suffix = std::move(suffix);
+    else
+      m_prompt_ansi_suffix.clear();
   }
 
   void SetSuggestionAnsiPrefix(std::string prefix) {
     if (m_color)
       m_suggestion_ansi_prefix = std::move(prefix);
+    else
+      m_suggestion_ansi_prefix.clear();
   }
 
   void SetSuggestionAnsiSuffix(std::string suffix) {
     if (m_color)
       m_suggestion_ansi_suffix = std::move(suffix);
+    else
+      m_suggestion_ansi_suffix.clear();
   }
 
   /// Prompts for and reads a single line of user input.

--- a/lldb/include/lldb/Interpreter/CommandInterpreter.h
+++ b/lldb/include/lldb/Interpreter/CommandInterpreter.h
@@ -476,6 +476,8 @@ public:
 
   void UpdatePrompt(llvm::StringRef prompt);
 
+  void UpdateUseColor(bool use_color);
+
   bool Confirm(llvm::StringRef message, bool default_answer);
 
   void LoadCommandDictionary();

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -237,16 +237,16 @@ Status Debugger::SetPropertyValue(const ExecutionContext *exe_ctx,
           CommandInterpreter::eBroadcastBitResetPrompt, bytes.release());
       GetCommandInterpreter().BroadcastEvent(prompt_change_event_sp);
     } else if (property_path == g_debugger_properties[ePropertyUseColor].name) {
-      // use-color changed. Ping the prompt so it can reset the ansi terminal
-      // codes.
-      SetPrompt(GetPrompt());
+      // use-color changed. set use-color, this also pings the prompt so it can
+      // reset the ansi terminal codes.
+      SetUseColor(GetUseColor());
     } else if (property_path ==
                    g_debugger_properties[ePropertyPromptAnsiPrefix].name ||
                property_path ==
                    g_debugger_properties[ePropertyPromptAnsiSuffix].name) {
-      // Prompt colors changed. Ping the prompt so it can reset the ansi
-      // terminal codes.
-      SetPrompt(GetPrompt());
+      // Prompt color changed. set use-color, this also pings the prompt so it
+      // can reset the ansi terminal codes.
+      SetUseColor(GetUseColor());
     } else if (property_path ==
                g_debugger_properties[ePropertyShowStatusline].name) {
       // Statusline setting changed. If we have a statusline instance, update it
@@ -455,6 +455,8 @@ bool Debugger::GetUseColor() const {
 bool Debugger::SetUseColor(bool b) {
   const uint32_t idx = ePropertyUseColor;
   bool ret = SetPropertyAtIndex(idx, b);
+
+  GetCommandInterpreter().UpdateUseColor(b);
   SetPrompt(GetPrompt());
   return ret;
 }

--- a/lldb/source/Core/IOHandler.cpp
+++ b/lldb/source/Core/IOHandler.cpp
@@ -476,6 +476,21 @@ bool IOHandlerEditline::SetPrompt(llvm::StringRef prompt) {
   return true;
 }
 
+bool IOHandlerEditline::SetUseColor(bool use_color) {
+  m_color = use_color;
+
+#if LLDB_ENABLE_LIBEDIT
+  if (m_editline_up) {
+    m_editline_up->UseColor(use_color);
+    m_editline_up->SetSuggestionAnsiPrefix(ansi::FormatAnsiTerminalCodes(
+        m_debugger.GetAutosuggestionAnsiPrefix()));
+    m_editline_up->SetSuggestionAnsiSuffix(ansi::FormatAnsiTerminalCodes(
+        m_debugger.GetAutosuggestionAnsiSuffix()));
+  }
+#endif
+  return true;
+}
+
 const char *IOHandlerEditline::GetContinuationPrompt() {
   return (m_continuation_prompt.empty() ? nullptr
                                         : m_continuation_prompt.c_str());

--- a/lldb/source/Host/common/Editline.cpp
+++ b/lldb/source/Host/common/Editline.cpp
@@ -1114,6 +1114,8 @@ void Editline::DisplayCompletions(
   }
 }
 
+void Editline::UseColor(bool use_color) { m_color = use_color; }
+
 unsigned char Editline::TabCommand(int ch) {
   if (!m_completion_callback)
     return CC_ERROR;

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -2236,10 +2236,15 @@ CommandInterpreter::GetAutoSuggestionForCommand(llvm::StringRef line) {
 void CommandInterpreter::UpdatePrompt(llvm::StringRef new_prompt) {
   EventSP prompt_change_event_sp(
       new Event(eBroadcastBitResetPrompt, new EventDataBytes(new_prompt)));
-  ;
+
   BroadcastEvent(prompt_change_event_sp);
   if (m_command_io_handler_sp)
     m_command_io_handler_sp->SetPrompt(new_prompt);
+}
+
+void CommandInterpreter::UpdateUseColor(bool use_color) {
+  if (m_command_io_handler_sp)
+    m_command_io_handler_sp->SetUseColor(use_color);
 }
 
 bool CommandInterpreter::Confirm(llvm::StringRef message, bool default_answer) {

--- a/lldb/test/API/terminal/TestEditline.py
+++ b/lldb/test/API/terminal/TestEditline.py
@@ -95,3 +95,26 @@ class EditlineTest(PExpectTest):
         self.child.send("foo")
         # Check that there are no escape codes.
         self.child.expect(re.escape("\n(lldb) foo"))
+
+    @skipIfAsan
+    @skipIfEditlineSupportMissing
+    def test_enable_and_disable_color(self):
+        """Test that when we change the color during debugging it applies the changes"""
+        # launch with colors enabled.
+        self.launch(use_colors=True)
+        self.child.send('settings set prompt-ansi-prefix "${ansi.fg.red}"\n')
+        self.child.expect(re.escape("\x1b[31m(lldb) \x1b[0m\x1b[8G"))
+
+        # set use color to false.
+        self.child.send("settings set use-color false\n")
+
+        # check that there is no color.
+        self.child.send("foo\n")
+        self.child.expect(re.escape("(lldb) foo"))
+
+        # set use-color to true
+        self.child.send("settings set use-color true\n")
+
+        # check that there is colors;
+        self.child.send("foo")
+        self.child.expect(re.escape("\x1b[31m(lldb) \x1b[0m\x1b[8Gfoo"))


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/22981


Do you think it is necessary for the`SetUseColor` to return a bool for the interface