### PR TITLE
[AMDGPU] Print `workgroup_processor_mode` metadata field as a boolean

### DIFF
--- a/llvm/lib/BinaryFormat/AMDGPUMetadataVerifier.cpp
+++ b/llvm/lib/BinaryFormat/AMDGPUMetadataVerifier.cpp
@@ -262,7 +262,8 @@ bool MetadataVerifier::verifyKernel(msgpack::DocNode &Node) {
   if (!verifyScalarEntry(KernelMap, ".uses_dynamic_stack", false,
                          msgpack::Type::Boolean))
     return false;
-  if (!verifyIntegerEntry(KernelMap, ".workgroup_processor_mode", false))
+  if (!verifyScalarEntry(KernelMap, ".workgroup_processor_mode", false,
+                         msgpack::Type::Boolean))
     return false;
   if (!verifyIntegerEntry(KernelMap, ".kernarg_segment_align", true))
     return false;

--- a/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.cpp
@@ -510,7 +510,7 @@ MetadataStreamerMsgPackV4::getHSAKernelProps(const MachineFunction &MF,
 
   if (CodeObjectVersion >= AMDGPU::AMDHSA_COV5 && STM.supportsWGP())
     Kern[".workgroup_processor_mode"] =
-        Kern.getDocument()->getNode(ProgramInfo.WgpMode);
+        Kern.getDocument()->getNode((bool)ProgramInfo.WgpMode);
 
   // FIXME: The metadata treats the minimum as 16?
   Kern[".kernarg_segment_align"] =

--- a/llvm/test/CodeGen/AMDGPU/hsa-generic-target-features.ll
+++ b/llvm/test/CodeGen/AMDGPU/hsa-generic-target-features.ll
@@ -17,9 +17,9 @@
 ; Checks 10.1, 10.3 and 11 generic targets allow cumode/wave64.
 
 ; NOCU:    .amdhsa_workgroup_processor_mode 0
-; NOCU:    .workgroup_processor_mode: 0
+; NOCU:    .workgroup_processor_mode: false
 ; CU:      .amdhsa_workgroup_processor_mode 1
-; CU:      .workgroup_processor_mode: 1
+; CU:      .workgroup_processor_mode: true
 
 ; W64:      .amdhsa_wavefront_size32 0
 ; W32:      .amdhsa_wavefront_size32 1

--- a/llvm/test/CodeGen/AMDGPU/hsa-metadata-workgroup-processor-mode-v5.ll
+++ b/llvm/test/CodeGen/AMDGPU/hsa-metadata-workgroup-processor-mode-v5.ll
@@ -4,9 +4,9 @@
 ; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1100 < %s | FileCheck -check-prefix=GFX10-CU %s
 
 ; GFX10:    .amdhsa_workgroup_processor_mode 0
-; GFX10:    .workgroup_processor_mode: 0
+; GFX10:    .workgroup_processor_mode: false
 ; GFX10-CU: .amdhsa_workgroup_processor_mode 1
-; GFX10-CU: .workgroup_processor_mode: 1
+; GFX10-CU: .workgroup_processor_mode: true
 
 define amdgpu_kernel void @wavefrontsize() {
 entry:


### PR DESCRIPTION
The `workgroup_processor_mode` metadata field is a boolean according to the documentation. We currently serialize its value as "0" (false) or "1" (true) when these should be literal "false" or "true", in line with other boolean metadata fields. This fixes the AMDGPU metadata streamer and verifier to resolve this mismatch.

Fixes SWDEV-524612.