### PR TITLE
[lldb] Override Should{Select,Show} in StopReasonBreakpoint

### DIFF
--- a/lldb/source/Target/StopInfo.cpp
+++ b/lldb/source/Target/StopInfo.cpp
@@ -263,6 +263,10 @@ public:
     return bp_site_sp->GetSuggestedStackFrameIndex();
   }
 
+  bool ShouldShow() const override { return !m_was_all_internal; }
+
+  bool ShouldSelect() const override { return !m_was_all_internal; }
+
 protected:
   bool ShouldStop(Event *event_ptr) override {
     // This just reports the work done by PerformAction or the synchronous


### PR DESCRIPTION
This is necessary so that LLDB does not select (or show the stop reason for) a thread which stopped at an internal breakpoint.

Other than manual testing/inspection, which I've done, this does not seem to lend itself to API testing, as we cannot set internal breakpoints through the SBAPI.