### PR TITLE
[AArch64] Add FPCR register usages to mop4 instructions

### DIFF
--- a/llvm/lib/Target/AArch64/SMEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SMEInstrFormats.td
@@ -5595,6 +5595,7 @@ class sme2_bf16_fp32_quarter_tile_outer_product<bit M, bit N, bit S, string mnem
   let Inst{1-0} = ZAda;
 
   let Constraints = "$ZAda = $_ZAda";
+  let Uses = [FPCR];
 }
 
 multiclass sme2_bfmop4as_widening<bit S, string mnemonic, string op> {
@@ -5758,6 +5759,7 @@ class sme2_fp16_quarter_tile_outer_product<bit M, bit N, bit S, string mnemonic,
   let Inst{0} = ZAda;
 
   let Constraints = "$ZAda = $_ZAda";
+  let Uses = [FPCR];
 }
 
 multiclass sme2_fmop4as_fp16_non_widening<bit S, string mnemonic, string op> {
@@ -5846,6 +5848,7 @@ class sme2_bf16_fp16_quarter_tile_outer_product<bit M, bit N, bit S, string mnem
   let Inst{0} = ZAda;
 
   let Constraints = "$ZAda = $_ZAda";
+  let Uses = [FPCR];
 }
 
 multiclass sme2_bfmop4as_non_widening<bit S, string mnemonic, string op> {
@@ -5899,6 +5902,7 @@ class sme2_fp32_quarter_tile_outer_product<bit M, bit N, bit S, string mnemonic,
   let Inst{1-0} = ZAda;
 
   let Constraints = "$ZAda = $_ZAda";
+  let Uses = [FPCR];
 }
 
 multiclass sme2_fmop4as_fp32_non_widening<bit S, string mnemonic, string op> {
@@ -5952,6 +5956,7 @@ class sme2_fp64_quarter_tile_outer_product<bit M, bit N, bit S, string mnemonic,
   let Inst{2-0} = ZAda;
 
   let Constraints = "$ZAda = $_ZAda";
+  let Uses = [FPCR];
 }
 
 multiclass sme2_fmop4as_fp64_non_widening<bit S, string mnemonic, string op> {
@@ -6005,6 +6010,7 @@ class sme2_fp16_fp32_quarter_tile_outer_product<bit M, bit N, bit S, string mnem
   let Inst{1-0} = ZAda;
 
   let Constraints = "$ZAda = $_ZAda";
+  let Uses = [FPCR];
 }
 
 multiclass sme2_fmop4as_fp16_fp32_widening<bit S, string mnemonic, string op> {


### PR DESCRIPTION
Ensure all floating mop4 instructions implicitly use FPCR