### PR TITLE
[clang] [CodeGen] fix crash when Ty isDependentType in CodeGenFunction::EmitAutoVarAlloca

### DIFF
--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -1466,7 +1466,10 @@ CodeGenFunction::EmitAutoVarAlloca(const VarDecl &D) {
       (Ty.getAddressSpace() == LangAS::opencl_private && getLangOpts().OpenCL));
 
   AutoVarEmission emission(D);
-
+  
+  if (Ty->isDependentType())
+    return emission;
+  
   bool isEscapingByRef = D.isEscapingByref();
   emission.IsEscapingByRef = isEscapingByRef;
 


### PR DESCRIPTION
when Ty.isDependentType() is true, it will crash here:

I encountered it while compiling my own project, which may not be the right solution, but prevents crashes

```bash
Starting program: /home/MacroModel/llvm-debug-install/bin/clang-21 -c -Qunused-arguments -m64 -g -Wall -Wextra -Werror -O0 -std=c++26 -Ithird-parties/fast_io/include -Isrc -DUWVM_VERSION_X=2 -DUWVM_VERSION_Y=0 -DUWVM_VERSION_Z=0 -DUWVM_VERSION_S=0 -DUWVM_USE_DEFAULT_INT -DUWVM_USE_DEFAULT_JIT -DDEBUG -D_DEBUG -finput-charset=UTF-8 -fexec-charset=UTF-8 -Wno-braced-scalar-init -fno-rtti -fno-unwind-tables -march=native -fmodule-file=uwvm.crtmain=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.crtmain.pcm -fmodule-file=uwvm.crtmain:uwvm=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.crtmain-uwvm.pcm -fmodule-file=fast_io=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/fast_io.pcm -fmodule-file=utils.global=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/utils.global.pcm -fmodule-file=utils.global:tzset=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/utils.global-tzset.pcm -fmodule-file=uwvm.cmdline=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.cmdline.pcm -fmodule-file=uwvm.cmdline:params=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.cmdline-params.pcm -fmodule-file=utils.cmdline=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/utils.cmdline.pcm -fmodule-file=utils.cmdline:handle=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/utils.cmdline-handle.pcm -fmodule-file=fast_io_crypto=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/fast_io_crypto.pcm -fmodule-file=utils.cmdline:shortest_path=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/utils.cmdline-shortest_path.pcm -fmodule-file=uwvm.cmdline.params=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.cmdline.params.pcm -fmodule-file=uwvm.cmdline.params:help=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.cmdline.params-help.pcm -fmodule-file=uwvm.cmdline.params:mode=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.cmdline.params-mode.pcm -fmodule-file=utils.io=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/utils.io.pcm -fmodule-file=utils.io:io_device=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/utils.io-io_device.pcm -fmodule-file=uwvm.cmdline.params:run=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.cmdline.params-run.pcm -fmodule-file=uwvm.cmdline.params:test=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.cmdline.params-test.pcm -fmodule-file=uwvm.cmdline.params:version=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.cmdline.params-version.pcm -fmodule-file=uwvm.cmdline.params:wasm_abi=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.cmdline.params-wasm_abi.pcm -fmodule-file=uwvm.cmdline.params:wasm_binfmt=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.cmdline.params-wasm_binfmt.pcm -fmodule-file=uwvm.cmdline:parser=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.cmdline-parser.pcm -fmodule-file=uwvm.run=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.run.pcm -fmodule-file=uwvm.run:run=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.run-run.pcm -fmodule-file=parser.wasm.binfmt.base=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.binfmt.base.pcm -fmodule-file=parser.wasm.standard.wasm1.type=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1.type.pcm -fmodule-file=parser.wasm.standard.wasm1.type:modules=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1.type-modules.pcm -fmodule-file=parser.wasm.standard.wasm1.type:section_type=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1.type-section_type.pcm -fmodule-file=parser.wasm.standard.wasm1.type:value_binfmt=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1.type-value_binfmt.pcm -fmodule-file=parser.wasm.standard.wasm1.type:value_type=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1.type-value_type.pcm -fmodule-file=parser.wasm.concepts=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.concepts.pcm -fmodule-file=parser.wasm.concepts:operation=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.concepts-operation.pcm -fmodule-file=parser.wasm.concepts:root=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.concepts-root.pcm -fmodule-file=parser.wasm.standard=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.pcm -fmodule-file=parser.wasm.standard.wasm1=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1.pcm -fmodule-file=parser.wasm.standard.wasm1.features=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1.features.pcm -fmodule-file=parser.wasm.standard.wasm1.features:binfmt=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1.features-binfmt.pcm -fmodule-file=parser.wasm.binfmt.binfmt_ver1=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.binfmt.binfmt_ver1.pcm -fmodule-file=parser.wasm.binfmt.binfmt_ver1:def=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.binfmt.binfmt_ver1-def.pcm -fmodule-file=parser.wasm.binfmt.binfmt_ver1:section=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.binfmt.binfmt_ver1-section.pcm -fmodule-file=parser.wasm.standard.wasm1.section=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1.section.pcm -fmodule-file=parser.wasm.standard.wasm1.section:funcbody=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1.section-funcbody.pcm -fmodule-file=parser.wasm.standard.wasm1.section:section_type=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1.section-section_type.pcm -fmodule-file=parser.wasm.binfmt.binfmt_ver1:handler=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.binfmt.binfmt_ver1-handler.pcm -fmodule-file=parser.wasm.base=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.base.pcm -fmodule-file=parser.wasm.base:abi=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.base-abi.pcm -fmodule-file=parser.wasm.base:mode=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.base-mode.pcm -fmodule-file=parser.wasm.standard.wasm1.features:type_section=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1.features-type_section.pcm -fmodule-file=parser.wasm.standard.wasm1.opcode=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1.opcode.pcm -fmodule-file=parser.wasm.standard.wasm1.opcode:mvp=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1.opcode-mvp.pcm -fmodule-file=parser.wasm.standard.wasm1p1=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1p1.pcm -fmodule-file=parser.wasm.standard.wasm1p1.type=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1p1.type.pcm -fmodule-file=parser.wasm.standard.wasm1p1.type:value_binfmt=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1p1.type-value_binfmt.pcm -fmodule-file=parser.wasm.standard.wasm1p1.type:value_type=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm1p1.type-value_type.pcm -fmodule-file=parser.wasm.standard.wasm2=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm2.pcm -fmodule-file=parser.wasm.standard.wasm2_MultiMemory=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm2_MultiMemory.pcm -fmodule-file=parser.wasm.standard.wasm2_TailCalls=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm2_TailCalls.pcm -fmodule-file=parser.wasm.standard.wasm2_TailCalls_FunctionReference=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm2_TailCalls_FunctionReference.pcm -fmodule-file=parser.wasm.standard.wasm2_TailCalls_FunctionReference_GC=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm2_TailCalls_FunctionReference_GC.pcm -fmodule-file=parser.wasm.standard.wasm2_thread=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm2_thread.pcm -fmodule-file=parser.wasm.standard.wasm3=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/parser.wasm.standard.wasm3.pcm -fmodule-file=uwvm.wasm.feature=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.wasm.feature.pcm -fmodule-file=uwvm.wasm.storage=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.wasm.storage.pcm -fmodule-file=uwvm.wasm.storage:execut--Type <RET> for more, q to quit, c to continue without paging--
e_wasm=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.wasm.storage-execute_wasm.pcm -fmodule-file=uwvm.wasm.storage:import_dl=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.wasm.storage-import_dl.pcm -fmodule-file=uwvm.wasm.storage:import_wasm=build/.gens/uwvm/linux/x86_64/debug/rules/bmi/cache/modules/63f7f4c9/uwvm.wasm.storage-import_wasm.pcm -MMD -MF /tmp/.xmake1000/250414/_AC1C8187CC7643308A74DFE73F9DA760 -fdiagnostics-color=always -o build/.objs/uwvm/linux/x86_64/debug/src/uwvm/main.cpp.o src/uwvm/main.cpp

clang-21: /home/MacroModel/tool-chain/src/llvm-project/clang/lib/AST/Type.cpp:2412: bool clang::Type::isConstantSizeType() const: Assertion `!isDependentType() && "This doesn't make sense for dependent types"' failed.

Program received signal SIGABRT, Aborted.
0x00007ffff79cce44 in ?? () from /usr/lib/libc.so.6
(gdb) bt
#0  0x00007ffff79cce44 in ?? () from /usr/lib/libc.so.6
#1  0x00007ffff7974a30 in raise () from /usr/lib/libc.so.6
#2  0x00007ffff795c4c3 in abort () from /usr/lib/libc.so.6
#3  0x00007ffff795c3df in ?? () from /usr/lib/libc.so.6
#4  0x00007ffff796cc67 in __assert_fail () from /usr/lib/libc.so.6
#5  0x0000555567334ae0 in clang::Type::isConstantSizeType (this=0x55556cd7deb0) at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/AST/Type.cpp:2412
#6  0x00005555623b4793 in clang::CodeGen::CodeGenFunction::EmitAutoVarAlloca (this=0x7ffffffeb140, D=...)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CGDecl.cpp:1498
#7  0x00005555623b0988 in clang::CodeGen::CodeGenFunction::EmitAutoVarDecl (this=0x7ffffffeb140, D=...)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CGDecl.cpp:1326
#8  0x00005555623b0077 in clang::CodeGen::CodeGenFunction::EmitVarDecl (this=0x7ffffffeb140, D=...) at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CGDecl.cpp:225
#9  0x00005555623b0141 in clang::CodeGen::CodeGenFunction::MaybeEmitDeferredVarDeclInit (this=0x7ffffffeb140, VD=0x55556cd7ea78)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CGDecl.cpp:2060
#10 0x00005555623afde2 in clang::CodeGen::CodeGenFunction::EmitDecl (this=0x7ffffffeb140, D=..., EvaluateConditionDecl=true)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CGDecl.cpp:168
#11 0x00005555621fd64a in clang::CodeGen::CodeGenFunction::EmitDeclStmt (this=0x7ffffffeb140, S=...) at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CGStmt.cpp:1674
#12 0x00005555621f59cf in clang::CodeGen::CodeGenFunction::EmitSimpleStmt (this=0x7ffffffeb140, S=0x55556cd7ea58, Attrs=...)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CGStmt.cpp:515
#13 0x00005555621f486b in clang::CodeGen::CodeGenFunction::EmitStmt (this=0x7ffffffeb140, S=0x55556cd7ea58, Attrs=...)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CGStmt.cpp:65
#14 0x00005555621fea73 in clang::CodeGen::CodeGenFunction::EmitCompoundStmtWithoutScope (this=0x7ffffffeb140, S=..., GetLast=false, AggSlot=...)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CGStmt.cpp:622
#15 0x00005555621cbd1f in clang::CodeGen::CodeGenFunction::EmitFunctionBody (this=0x7ffffffeb140, Body=0x55556cd7ebf0)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CodeGenFunction.cpp:1373
#16 0x00005555621ccea1 in clang::CodeGen::CodeGenFunction::GenerateCode (this=0x7ffffffeb140, GD=..., Fn=0x55556c98f698, FnInfo=...)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CodeGenFunction.cpp:1619
#17 0x0000555561fa96df in clang::CodeGen::CodeGenModule::EmitGlobalFunctionDefinition (this=0x55556866f590, GD=..., GV=0x55556c98f698)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CodeGenModule.cpp:6147
#18 0x0000555561fa00bc in clang::CodeGen::CodeGenModule::EmitGlobalDefinition (this=0x55556866f590, GD=..., GV=0x55556c98f698)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CodeGenModule.cpp:4261
#19 0x0000555561f944c4 in clang::CodeGen::CodeGenModule::EmitDeferred (this=0x55556866f590) at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CodeGenModule.cpp:3338
#20 0x0000555561f94500 in clang::CodeGen::CodeGenModule::EmitDeferred (this=0x55556866f590) at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CodeGenModule.cpp:3344
#21 0x0000555561f94500 in clang::CodeGen::CodeGenModule::EmitDeferred (this=0x55556866f590) at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CodeGenModule.cpp:3344
#22 0x0000555561f94500 in clang::CodeGen::CodeGenModule::EmitDeferred (this=0x55556866f590) at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CodeGenModule.cpp:3344
#23 0x0000555561f94500 in clang::CodeGen::CodeGenModule::EmitDeferred (this=0x55556866f590) at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CodeGenModule.cpp:3344
#24 0x0000555561f903ae in clang::CodeGen::CodeGenModule::Release (this=0x55556866f590) at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CodeGenModule.cpp:855
#25 0x000055556293ef6d in (anonymous namespace)::CodeGeneratorImpl::HandleTranslationUnit (this=0x555568629750, Ctx=...)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/ModuleBuilder.cpp:287
#26 0x000055556292e9ff in clang::BackendConsumer::HandleTranslationUnit (this=0x55556860a7c0, C=...)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CodeGenAction.cpp:241
#27 0x00005555653265cb in clang::ParseAST (S=..., PrintStats=false, SkipFunctionBodies=false) at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/Parse/ParseAST.cpp:184
#28 0x0000555563219387 in clang::ASTFrontendAction::ExecuteAction (this=0x55556860cc40) at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/Frontend/FrontendAction.cpp:1345
#29 0x0000555562932f6d in clang::CodeGenAction::ExecuteAction (this=0x55556860cc40) at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/CodeGen/CodeGenAction.cpp:1111
#30 0x0000555563218dd6 in clang::FrontendAction::Execute (this=0x55556860cc40) at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/Frontend/FrontendAction.cpp:1227
#31 0x000055556313d271 in clang::CompilerInstance::ExecuteAction (this=0x5555686069c0, Act=...)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/Frontend/CompilerInstance.cpp:1055
#32 0x00005555633e5bfa in clang::ExecuteCompilerInvocation (Clang=0x5555686069c0)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp:300
#33 0x000055555db1901e in cc1_main (Argv=..., Argv0=0x5555685eba20 "/home/MacroModel/llvm-debug-install/bin/clang-21",
    MainAddr=0x55555db0a730 <GetExecutablePath[abi:cxx11](char const*, bool)>) at /home/MacroModel/tool-chain/src/llvm-project/clang/tools/driver/cc1_main.cpp:294
#34 0x000055555db0bdee in ExecuteCC1Tool (ArgV=..., ToolContext=...) at /home/MacroModel/tool-chain/src/llvm-project/clang/tools/driver/driver.cpp:218
#35 0x000055555db0c860 in clang_main(int, char**, llvm::ToolContext const&)::$_0::operator()(llvm::SmallVectorImpl<char const*>&) const (this=0x7fffffff6bd8, ArgV=...)
--Type <RET> for more, q to quit, c to continue without paging--
    at /home/MacroModel/tool-chain/src/llvm-project/clang/tools/driver/driver.cpp:364
#36 0x000055555db0c82d in llvm::function_ref<int(llvm::SmallVectorImpl<char const*>&)>::callback_fn<clang_main(int, char**, llvm::ToolContext const&)::$_0> (callable=140737488317400,
    params=...) at /home/MacroModel/tool-chain/src/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:46
#37 0x0000555562fb18d1 in llvm::function_ref<int(llvm::SmallVectorImpl<char const*>&)>::operator() (this=0x7fffffff7050, params=...)
    at /home/MacroModel/tool-chain/src/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:69
#38 0x0000555562faeb78 in clang::driver::CC1Command::Execute(llvm::ArrayRef<std::optional<llvm::StringRef> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, bool*) const::$_0::operator()() const (this=0x7fffffff6118) at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/Driver/Job.cpp:435
#39 0x0000555562faeb45 in llvm::function_ref<void()>::callback_fn<clang::driver::CC1Command::Execute(llvm::ArrayRef<std::optional<llvm::StringRef> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*, bool*) const::$_0> (callable=140737488314648)
    at /home/MacroModel/tool-chain/src/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:46
#40 0x0000555560825479 in llvm::function_ref<void()>::operator() (this=0x7fffffff60d8) at /home/MacroModel/tool-chain/src/llvm-project/llvm/include/llvm/ADT/STLFunctionalExtras.h:69
#41 0x0000555561aaccaf in llvm::CrashRecoveryContext::RunSafely (this=0x7fffffff6158, Fn=...)
    at /home/MacroModel/tool-chain/src/llvm-project/llvm/lib/Support/CrashRecoveryContext.cpp:426
#42 0x0000555562fae6e3 in clang::driver::CC1Command::Execute (this=0x55556858f6e0, Redirects=..., ErrMsg=0x7fffffff6668, ExecutionFailed=0x7fffffff6667)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/Driver/Job.cpp:435
#43 0x0000555562f49d82 in clang::driver::Compilation::ExecuteCommand (this=0x5555685fe120, C=..., FailingCommand=@0x7fffffff6788: 0x0, LogOnly=false)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/Driver/Compilation.cpp:196
#44 0x0000555562f49f5c in clang::driver::Compilation::ExecuteJobs (this=0x5555685fe120, Jobs=..., FailingCommands=..., LogOnly=false)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/Driver/Compilation.cpp:251
#45 0x0000555562f65821 in clang::driver::Driver::ExecuteCompilation (this=0x7fffffff6cb0, C=..., FailingCommands=...)
    at /home/MacroModel/tool-chain/src/llvm-project/clang/lib/Driver/Driver.cpp:2220
#46 0x000055555db0b907 in clang_main (Argc=99, Argv=0x7fffffffbb28, ToolContext=...) at /home/MacroModel/tool-chain/src/llvm-project/clang/tools/driver/driver.cpp:402
#47 0x000055555db3df85 in main (argc=99, argv=0x7fffffffbb28) at /home/MacroModel/tool-chain/build/llvm/tools/clang/tools/driver/clang-driver.cpp:17
```