### PR TITLE
[Clang][DirectX] Always use Diagnostic Printer

### DIFF
--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -605,13 +605,11 @@ void BackendConsumer::UnsupportedDiagHandler(
 
   // Context will be nullptr for IR input files, we will construct the diag
   // message from llvm::DiagnosticInfoUnsupported.
-  if (Context != nullptr) {
+  if (Context != nullptr)
     Loc = getBestLocationFromDebugLoc(D, BadDebugInfo, Filename, Line, Column);
-    MsgStream << D.getMessage();
-  } else {
-    DiagnosticPrinterRawOStream DP(MsgStream);
-    D.print(DP);
-  }
+
+  DiagnosticPrinterRawOStream DP(MsgStream);
+  D.print(DP);
 
   auto DiagType = D.getSeverity() == llvm::DS_Error
                       ? diag::err_fe_backend_unsupported

--- a/clang/test/CodeGenDirectX/unsupported_reduc_mul.hlsl
+++ b/clang/test/CodeGenDirectX/unsupported_reduc_mul.hlsl
@@ -1,4 +1,4 @@
-// RUN: not %clang_dxc -T lib_6_3 %s 2>&1 | FileCheck %s
+// RUN: %if clang-dxc %{not %clang_dxc -T lib_6_3 %s 2>&1 | FileCheck %s %}
 
 // CHECK: error: <unknown>:0:0: in function llvm.vector.reduce.mul.v4i32 i32 (<4 x i32>): Unsupported intrinsic for DXIL lowering
 

--- a/clang/test/CodeGenDirectX/unsupported_reduc_mul.hlsl
+++ b/clang/test/CodeGenDirectX/unsupported_reduc_mul.hlsl
@@ -1,0 +1,7 @@
+// RUN: not %clang_dxc -T lib_6_3 %s 2>&1 | FileCheck %s
+
+// CHECK: error: <unknown>:0:0: in function llvm.vector.reduce.mul.v4i32 i32 (<4 x i32>): Unsupported intrinsic for DXIL lowering
+
+export int vecReduceMulTest(int4 vec) {
+    return __builtin_reduce_mul(vec);
+}

--- a/clang/test/Sema/builtin-amdgcn-fence-failure.cpp
+++ b/clang/test/Sema/builtin-amdgcn-fence-failure.cpp
@@ -2,7 +2,6 @@
 // RUN: not %clang_cc1 %s -o - -S -triple=amdgcn-amd-amdhsa 2>&1 | FileCheck %s
 
 void test_amdgcn_fence_failure() {
-
-  // CHECK: error: Unsupported atomic synchronization scope
+  // CHECK: error: <unknown>:0:0: in function _Z25test_amdgcn_fence_failurev void (): Unsupported atomic synchronization scope
   __builtin_amdgcn_fence(__ATOMIC_SEQ_CST, "foobar");
 }


### PR DESCRIPTION
fixes #135654

In #128613 we added safe guards to prevent the lowering of just any intrinsic in the backend. We used `DiagnosticInfoUnsupported` to do this.

What we found was when using `opt` the diagnostic printer was called but when using clang the diagnostic message was called.

Printing message in the clang version means we miss valuable debugging information like function name and function type when LLVMContext was only needed to call `getBestLocationFromDebugLoc`.