### PR TITLE
[BOLT] Gadget scanner: refactor issue reporting

### DIFF
--- a/bolt/include/bolt/Passes/PAuthGadgetScanner.h
+++ b/bolt/include/bolt/Passes/PAuthGadgetScanner.h
@@ -204,9 +204,10 @@ namespace PAuthGadgetScanner {
 // * an analysis (SrcSafetyAnalysis at now, DstSafetyAnalysis will be added
 //   later to support the detection of authentication oracles) computes register
 //   state for each instruction in the function.
-// * each instruction is checked to be a gadget of some kind, taking the
-//   computed state into account. If a gadget is found, its kind and location
-//   are stored into a subclass of Diagnostic wrapped into BriefReport<ReqT>.
+// * for each instruction, it is checked whether it is a gadget of some kind,
+//   taking the computed state into account. If a gadget is found, its kind
+//   and location are stored into a subclass of Diagnostic wrapped into
+//   PartialReport<ReqT>.
 // * if any issue is to be reported for the function, the same analysis is
 //   re-run to collect extra information to provide to the user. Which extra
 //   information can be requested depends on the particular analysis (for
@@ -216,7 +217,7 @@ namespace PAuthGadgetScanner {
 //
 // Here, the subclasses of Diagnostic store the pieces of information which
 // are kept unchanged since they are collected on the first run of the analysis.
-// BriefReport<T>::RequestedDetails, on the other hand, is replaced with
+// PartialReport<T>::RequestedDetails, on the other hand, is replaced with
 // FinalReport::Details computed by the second run of the analysis.
 
 /// Description of a gadget kind that can be detected. Intended to be
@@ -265,7 +266,7 @@ struct GenericDiagnostic : public Diagnostic {
                               const BinaryContext &BC) const override;
 };
 
-/// An information about an issue collected on the slower, detailed,
+/// Extra information about an issue collected on the slower, detailed,
 /// run of the analysis.
 class ExtraInfo {
 public:
@@ -288,9 +289,9 @@ public:
 /// A half-baked report produced on the first run of the analysis. An extra,
 /// analysis-specific information may be requested to be collected on the
 /// second run.
-template <typename T> struct BriefReport {
-  BriefReport(std::shared_ptr<Diagnostic> Issue,
-              const std::optional<T> RequestedDetails)
+template <typename T> struct PartialReport {
+  PartialReport(std::shared_ptr<Diagnostic> Issue,
+                const std::optional<T> RequestedDetails)
       : Issue(Issue), RequestedDetails(RequestedDetails) {}
 
   std::shared_ptr<Diagnostic> Issue;
@@ -320,12 +321,12 @@ class FunctionAnalysisContext {
 
   bool PacRetGadgetsOnly;
 
-  void findUnsafeUses(SmallVector<BriefReport<MCPhysReg>> &Reports);
-  void augmentUnsafeUseReports(ArrayRef<BriefReport<MCPhysReg>> Reports);
+  void findUnsafeUses(SmallVector<PartialReport<MCPhysReg>> &Reports);
+  void augmentUnsafeUseReports(ArrayRef<PartialReport<MCPhysReg>> Reports);
 
   /// Process the reports which do not have to be augmented, and remove them
   /// from Reports.
-  void handleSimpleReports(SmallVector<BriefReport<MCPhysReg>> &Reports);
+  void handleSimpleReports(SmallVector<PartialReport<MCPhysReg>> &Reports);
 
 public:
   FunctionAnalysisContext(BinaryFunction &BF,

--- a/bolt/include/bolt/Passes/PAuthGadgetScanner.h
+++ b/bolt/include/bolt/Passes/PAuthGadgetScanner.h
@@ -253,8 +253,7 @@ class ClobberingInfo : public ExtraInfo {
   SmallVector<MCInstReference> ClobberingInstrs;
 
 public:
-  ClobberingInfo(const ArrayRef<MCInstReference> Instrs)
-      : ClobberingInstrs(Instrs) {}
+  ClobberingInfo(ArrayRef<MCInstReference> Instrs) : ClobberingInstrs(Instrs) {}
 
   void print(raw_ostream &OS, const MCInstReference Location) const override;
 };
@@ -298,7 +297,7 @@ class FunctionAnalysis {
   bool PacRetGadgetsOnly;
 
   void findUnsafeUses(SmallVector<BriefReport<MCPhysReg>> &Reports);
-  void augmentUnsafeUseReports(const ArrayRef<BriefReport<MCPhysReg>> Reports);
+  void augmentUnsafeUseReports(ArrayRef<BriefReport<MCPhysReg>> Reports);
 
   /// Process the reports which do not have to be augmented, and remove them
   /// from Reports.

--- a/bolt/include/bolt/Passes/PAuthGadgetScanner.h
+++ b/bolt/include/bolt/Passes/PAuthGadgetScanner.h
@@ -300,6 +300,10 @@ class FunctionAnalysis {
   void findUnsafeUses(SmallVector<BriefReport<MCPhysReg>> &Reports);
   void augmentUnsafeUseReports(const ArrayRef<BriefReport<MCPhysReg>> Reports);
 
+  /// Process the reports which do not have to be augmented, and remove them
+  /// from Reports.
+  void handleSimpleReports(SmallVector<BriefReport<MCPhysReg>> &Reports);
+
 public:
   FunctionAnalysis(BinaryFunction &BF, MCPlusBuilder::AllocatorIdTy AllocatorId,
                    bool PacRetGadgetsOnly)

--- a/bolt/lib/Passes/PAuthGadgetScanner.cpp
+++ b/bolt/lib/Passes/PAuthGadgetScanner.cpp
@@ -517,18 +517,13 @@ protected:
 public:
   std::vector<MCInstReference>
   getLastClobberingInsts(const MCInst &Inst, BinaryFunction &BF,
-                         ArrayRef<MCPhysReg> UsedDirtyRegs) const {
-    if (RegsToTrackInstsFor.empty())
+                         std::optional<MCPhysReg> ClobberedReg) const {
+    if (!ClobberedReg || RegsToTrackInstsFor.empty())
       return {};
     const SrcState &S = getStateBefore(Inst);
-    // Due to aliasing registers, multiple registers may have been tracked.
-    std::set<const MCInst *> LastWritingInsts;
-    for (MCPhysReg TrackedReg : UsedDirtyRegs) {
-      for (const MCInst *Inst : lastWritingInsts(S, TrackedReg))
-        LastWritingInsts.insert(Inst);
-    }
+
     std::vector<MCInstReference> Result;
-    for (const MCInst *Inst : LastWritingInsts) {
+    for (const MCInst *Inst : lastWritingInsts(S, *ClobberedReg)) {
       MCInstReference Ref = MCInstReference::get(Inst, BF);
       assert(Ref && "Expected Inst to be found");
       Result.push_back(Ref);
@@ -720,16 +715,30 @@ SrcSafetyAnalysis::create(BinaryFunction &BF,
                                                        RegsToTrackInstsFor);
 }
 
-static std::shared_ptr<Report>
+static BriefReport<MCPhysReg> make_generic_report(MCInstReference Location,
+                                                  StringRef Text) {
+  auto Report = std::make_shared<GenericReport>(Location, Text);
+  return BriefReport<MCPhysReg>(Report, std::nullopt);
+}
+
+template <typename T>
+static BriefReport<T> make_report(const GadgetKind &Kind,
+                                  MCInstReference Location,
+                                  T RequestedDetails) {
+  auto Report = std::make_shared<GadgetReport>(Kind, Location);
+  return BriefReport<T>(Report, RequestedDetails);
+}
+
+static std::optional<BriefReport<MCPhysReg>>
 shouldReportReturnGadget(const BinaryContext &BC, const MCInstReference &Inst,
                          const SrcState &S) {
   static const GadgetKind RetKind("non-protected ret found");
   if (!BC.MIB->isReturn(Inst))
-    return nullptr;
+    return std::nullopt;
 
   ErrorOr<MCPhysReg> MaybeRetReg = BC.MIB->getRegUsedAsRetDest(Inst);
   if (MaybeRetReg.getError()) {
-    return std::make_shared<GenericReport>(
+    return make_generic_report(
         Inst, "Warning: pac-ret analysis could not analyze this return "
               "instruction");
   }
@@ -740,26 +749,26 @@ shouldReportReturnGadget(const BinaryContext &BC, const MCInstReference &Inst,
     traceReg(BC, "Authenticated reg", BC.MIB->getAuthenticatedReg(Inst));
   });
   if (BC.MIB->isAuthenticationOfReg(Inst, RetReg))
-    return nullptr;
+    return std::nullopt;
   LLVM_DEBUG({ traceRegMask(BC, "SafeToDerefRegs", S.SafeToDerefRegs); });
   if (S.SafeToDerefRegs[RetReg])
-    return nullptr;
+    return std::nullopt;
 
-  return std::make_shared<GadgetReport>(RetKind, Inst, RetReg);
+  return make_report(RetKind, Inst, RetReg);
 }
 
-static std::shared_ptr<Report>
+static std::optional<BriefReport<MCPhysReg>>
 shouldReportCallGadget(const BinaryContext &BC, const MCInstReference &Inst,
                        const SrcState &S) {
   static const GadgetKind CallKind("non-protected call found");
   if (!BC.MIB->isIndirectCall(Inst) && !BC.MIB->isIndirectBranch(Inst))
-    return nullptr;
+    return std::nullopt;
 
   bool IsAuthenticated = false;
   MCPhysReg DestReg =
       BC.MIB->getRegUsedAsIndirectBranchDest(Inst, IsAuthenticated);
   if (IsAuthenticated)
-    return nullptr;
+    return std::nullopt;
 
   assert(DestReg != BC.MIB->getNoRegister());
   LLVM_DEBUG({
@@ -768,19 +777,19 @@ shouldReportCallGadget(const BinaryContext &BC, const MCInstReference &Inst,
     traceRegMask(BC, "SafeToDerefRegs", S.SafeToDerefRegs);
   });
   if (S.SafeToDerefRegs[DestReg])
-    return nullptr;
+    return std::nullopt;
 
-  return std::make_shared<GadgetReport>(CallKind, Inst, DestReg);
+  return make_report(CallKind, Inst, DestReg);
 }
 
-static std::shared_ptr<Report>
+static std::optional<BriefReport<MCPhysReg>>
 shouldReportSigningOracle(const BinaryContext &BC, const MCInstReference &Inst,
                           const SrcState &S) {
   static const GadgetKind SigningOracleKind("signing oracle found");
 
   MCPhysReg SignedReg = BC.MIB->getSignedReg(Inst);
   if (SignedReg == BC.MIB->getNoRegister())
-    return nullptr;
+    return std::nullopt;
 
   LLVM_DEBUG({
     traceInst(BC, "Found sign inst", Inst);
@@ -788,9 +797,9 @@ shouldReportSigningOracle(const BinaryContext &BC, const MCInstReference &Inst,
     traceRegMask(BC, "TrustedRegs", S.TrustedRegs);
   });
   if (S.TrustedRegs[SignedReg])
-    return nullptr;
+    return std::nullopt;
 
-  return std::make_shared<GadgetReport>(SigningOracleKind, Inst, SignedReg);
+  return make_report(SigningOracleKind, Inst, SignedReg);
 }
 
 template <typename T> static void iterateOverInstrs(BinaryFunction &BF, T Fn) {
@@ -804,11 +813,18 @@ template <typename T> static void iterateOverInstrs(BinaryFunction &BF, T Fn) {
   }
 }
 
-FunctionAnalysisResult
-Analysis::findGadgets(BinaryFunction &BF,
-                      MCPlusBuilder::AllocatorIdTy AllocatorId) {
-  FunctionAnalysisResult Result;
+static SmallVector<MCPhysReg>
+collectRegsToTrack(const ArrayRef<BriefReport<MCPhysReg>> Reports) {
+  SmallSet<MCPhysReg, 4> RegsToTrack;
+  for (auto Report : Reports)
+    if (Report.RequestedDetails)
+      RegsToTrack.insert(*Report.RequestedDetails);
 
+  return SmallVector<MCPhysReg>(RegsToTrack.begin(), RegsToTrack.end());
+}
+
+void FunctionAnalysis::findUnsafeUses(
+    SmallVector<BriefReport<MCPhysReg>> &Reports) {
   auto Analysis = SrcSafetyAnalysis::create(BF, AllocatorId, {});
   LLVM_DEBUG({ dbgs() << "Running src register safety analysis...\n"; });
   Analysis->run();
@@ -817,45 +833,35 @@ Analysis::findGadgets(BinaryFunction &BF,
     BF.dump();
   });
 
-  BinaryContext &BC = BF.getBinaryContext();
   iterateOverInstrs(BF, [&](MCInstReference Inst) {
     const SrcState &S = Analysis->getStateBefore(Inst);
 
     // If non-empty state was never propagated from the entry basic block
     // to Inst, assume it to be unreachable and report a warning.
     if (S.empty()) {
-      Result.Diagnostics.push_back(std::make_shared<GenericReport>(
-          Inst, "Warning: unreachable instruction found"));
+      Reports.push_back(
+          make_generic_report(Inst, "Warning: unreachable instruction found"));
       return;
     }
 
     if (auto Report = shouldReportReturnGadget(BC, Inst, S))
-      Result.Diagnostics.push_back(Report);
+      Reports.push_back(*Report);
 
     if (PacRetGadgetsOnly)
       return;
 
     if (auto Report = shouldReportCallGadget(BC, Inst, S))
-      Result.Diagnostics.push_back(Report);
+      Reports.push_back(*Report);
     if (auto Report = shouldReportSigningOracle(BC, Inst, S))
-      Result.Diagnostics.push_back(Report);
+      Reports.push_back(*Report);
   });
-  return Result;
 }
 
-void Analysis::computeDetailedInfo(BinaryFunction &BF,
-                                   MCPlusBuilder::AllocatorIdTy AllocatorId,
-                                   FunctionAnalysisResult &Result) {
-  BinaryContext &BC = BF.getBinaryContext();
-
-  // Collect the affected registers across all gadgets found in this function.
-  SmallSet<MCPhysReg, 4> RegsToTrack;
-  for (auto Report : Result.Diagnostics)
-    RegsToTrack.insert_range(Report->getAffectedRegisters());
-  std::vector<MCPhysReg> RegsToTrackVec(RegsToTrack.begin(), RegsToTrack.end());
-
+void FunctionAnalysis::augmentUnsafeUseReports(
+    const ArrayRef<BriefReport<MCPhysReg>> Reports) {
+  SmallVector<MCPhysReg> RegsToTrack = collectRegsToTrack(Reports);
   // Re-compute the analysis with register tracking.
-  auto Analysis = SrcSafetyAnalysis::create(BF, AllocatorId, RegsToTrackVec);
+  auto Analysis = SrcSafetyAnalysis::create(BF, AllocatorId, RegsToTrack);
   LLVM_DEBUG(
       { dbgs() << "\nRunning detailed src register safety analysis...\n"; });
   Analysis->run();
@@ -865,32 +871,37 @@ void Analysis::computeDetailedInfo(BinaryFunction &BF,
   });
 
   // Augment gadget reports.
-  for (auto Report : Result.Diagnostics) {
-    LLVM_DEBUG(
-        { traceInst(BC, "Attaching clobbering info to", Report->Location); });
-    (void)BC;
-    Report->setOverwritingInstrs(Analysis->getLastClobberingInsts(
-        Report->Location, BF, Report->getAffectedRegisters()));
+  for (auto Report : Reports) {
+    MCInstReference Location = Report.Issue->Location;
+    LLVM_DEBUG({ traceInst(BC, "Attaching clobbering info to", Location); });
+    auto DetailedInfo =
+        std::make_shared<ClobberingInfo>(Analysis->getLastClobberingInsts(
+            Location, BF, Report.RequestedDetails));
+    Result.Diagnostics.emplace_back(Report.Issue, DetailedInfo);
   }
+}
+
+void FunctionAnalysis::run() {
+  LLVM_DEBUG({
+    dbgs() << "Analyzing function " << BF.getPrintName()
+           << ", AllocatorId = " << AllocatorId << "\n";
+    BF.dump();
+  });
+
+  SmallVector<BriefReport<MCPhysReg>> UnsafeUses;
+  findUnsafeUses(UnsafeUses);
+  if (!UnsafeUses.empty())
+    augmentUnsafeUseReports(UnsafeUses);
 }
 
 void Analysis::runOnFunction(BinaryFunction &BF,
                              MCPlusBuilder::AllocatorIdTy AllocatorId) {
-  LLVM_DEBUG({
-    dbgs() << "Analyzing in function " << BF.getPrintName() << ", AllocatorId "
-           << AllocatorId << "\n";
-    BF.dump();
-  });
+  FunctionAnalysis FA(BF, AllocatorId, PacRetGadgetsOnly);
+  FA.run();
 
-  FunctionAnalysisResult FAR = findGadgets(BF, AllocatorId);
+  const FunctionAnalysisResult &FAR = FA.getResult();
   if (FAR.Diagnostics.empty())
     return;
-
-  // Redo the analysis, but now also track which instructions last wrote
-  // to any of the registers in RetRegsWithGadgets, so that better
-  // diagnostics can be produced.
-
-  computeDetailedInfo(BF, AllocatorId, FAR);
 
   // `runOnFunction` is typically getting called from multiple threads in
   // parallel. Therefore, use a lock to avoid data races when storing the
@@ -918,16 +929,14 @@ static void printBB(const BinaryContext &BC, const BinaryBasicBlock *BB,
   }
 }
 
-static void reportFoundGadgetInSingleBBSingleOverwInst(
-    raw_ostream &OS, const BinaryContext &BC, const MCInstReference OverwInst,
+static void reportFoundGadgetInSingleBBSingleRelatedInst(
+    raw_ostream &OS, const BinaryContext &BC, const MCInstReference RelatedInst,
     const MCInstReference Location) {
   BinaryBasicBlock *BB = Location.getBasicBlock();
-  assert(OverwInst.ParentKind == MCInstReference::BasicBlockParent);
+  assert(RelatedInst.ParentKind == MCInstReference::BasicBlockParent);
   assert(Location.ParentKind == MCInstReference::BasicBlockParent);
-  MCInstInBBReference OverwInstBB = OverwInst.U.BBRef;
-  if (BB == OverwInstBB.BB) {
-    // overwriting inst and ret instruction are in the same basic block.
-    assert(OverwInstBB.BBIndex < Location.U.BBRef.BBIndex);
+  MCInstInBBReference RelatedInstBB = RelatedInst.U.BBRef;
+  if (BB == RelatedInstBB.BB) {
     OS << "  This happens in the following basic block:\n";
     printBB(BC, BB);
   }
@@ -950,29 +959,40 @@ void Report::printBasicInfo(raw_ostream &OS, const BinaryContext &BC,
 void GadgetReport::generateReport(raw_ostream &OS,
                                   const BinaryContext &BC) const {
   printBasicInfo(OS, BC, Kind.getDescription());
+}
 
-  BinaryFunction *BF = Location.getFunction();
-  OS << "  The " << OverwritingInstrs.size()
-     << " instructions that write to the affected registers after any "
-        "authentication are:\n";
+static void printRelatedInstrs(raw_ostream &OS, const MCInstReference Location,
+                               const ArrayRef<MCInstReference> RelatedInstrs) {
+  const BinaryFunction &BF = *Location.getFunction();
+  const BinaryContext &BC = BF.getBinaryContext();
+
   // Sort by address to ensure output is deterministic.
-  SmallVector<MCInstReference> OI = OverwritingInstrs;
-  llvm::sort(OI, [](const MCInstReference &A, const MCInstReference &B) {
+  SmallVector<MCInstReference> RI(RelatedInstrs);
+  llvm::sort(RI, [](const MCInstReference &A, const MCInstReference &B) {
     return A.getAddress() < B.getAddress();
   });
-  for (unsigned I = 0; I < OI.size(); ++I) {
-    MCInstReference InstRef = OI[I];
+  for (unsigned I = 0; I < RI.size(); ++I) {
+    MCInstReference InstRef = RI[I];
     OS << "  " << (I + 1) << ". ";
-    BC.printInstruction(OS, InstRef, InstRef.getAddress(), BF);
+    BC.printInstruction(OS, InstRef, InstRef.getAddress(), &BF);
   };
-  if (OverwritingInstrs.size() == 1) {
-    const MCInstReference OverwInst = OverwritingInstrs[0];
+  if (RelatedInstrs.size() == 1) {
+    const MCInstReference RelatedInst = RelatedInstrs[0];
     // Printing the details for the MCInstReference::FunctionParent case
     // is not implemented not to overcomplicate the code, as most functions
     // are expected to have CFG information.
-    if (OverwInst.ParentKind == MCInstReference::BasicBlockParent)
-      reportFoundGadgetInSingleBBSingleOverwInst(OS, BC, OverwInst, Location);
+    if (RelatedInst.ParentKind == MCInstReference::BasicBlockParent)
+      reportFoundGadgetInSingleBBSingleRelatedInst(OS, BC, RelatedInst,
+                                                   Location);
   }
+}
+
+void ClobberingInfo::print(raw_ostream &OS,
+                           const MCInstReference Location) const {
+  OS << "  The " << ClobberingInstrs.size()
+     << " instructions that write to the affected registers after any "
+        "authentication are:\n";
+  printRelatedInstrs(OS, Location, ClobberingInstrs);
 }
 
 void GenericReport::generateReport(raw_ostream &OS,
@@ -994,11 +1014,15 @@ Error Analysis::runOnFunctions(BinaryContext &BC) {
       BC, ParallelUtilities::SchedulingPolicy::SP_INST_LINEAR, WorkFun,
       SkipFunc, "PAuthGadgetScanner");
 
-  for (BinaryFunction *BF : BC.getAllBinaryFunctions())
-    if (AnalysisResults.count(BF) > 0) {
-      for (const std::shared_ptr<Report> &R : AnalysisResults[BF].Diagnostics)
-        R->generateReport(outs(), BC);
+  for (BinaryFunction *BF : BC.getAllBinaryFunctions()) {
+    if (!AnalysisResults.count(BF))
+      continue;
+    for (const DetailedReport &R : AnalysisResults[BF].Diagnostics) {
+      R.Issue->generateReport(outs(), BC);
+      if (R.Details)
+        R.Details->print(outs(), R.Issue->Location);
     }
+  }
   return Error::success();
 }
 

--- a/bolt/lib/Passes/PAuthGadgetScanner.cpp
+++ b/bolt/lib/Passes/PAuthGadgetScanner.cpp
@@ -812,7 +812,7 @@ template <typename T> static void iterateOverInstrs(BinaryFunction &BF, T Fn) {
 }
 
 static SmallVector<MCPhysReg>
-collectRegsToTrack(const ArrayRef<BriefReport<MCPhysReg>> Reports) {
+collectRegsToTrack(ArrayRef<BriefReport<MCPhysReg>> Reports) {
   SmallSet<MCPhysReg, 4> RegsToTrack;
   for (auto Report : Reports)
     if (Report.RequestedDetails)
@@ -856,7 +856,7 @@ void FunctionAnalysis::findUnsafeUses(
 }
 
 void FunctionAnalysis::augmentUnsafeUseReports(
-    const ArrayRef<BriefReport<MCPhysReg>> Reports) {
+    ArrayRef<BriefReport<MCPhysReg>> Reports) {
   SmallVector<MCPhysReg> RegsToTrack = collectRegsToTrack(Reports);
   // Re-compute the analysis with register tracking.
   auto Analysis = SrcSafetyAnalysis::create(BF, AllocatorId, RegsToTrack);
@@ -974,7 +974,7 @@ void GadgetReport::generateReport(raw_ostream &OS,
 }
 
 static void printRelatedInstrs(raw_ostream &OS, const MCInstReference Location,
-                               const ArrayRef<MCInstReference> RelatedInstrs) {
+                               ArrayRef<MCInstReference> RelatedInstrs) {
   const BinaryFunction &BF = *Location.getFunction();
   const BinaryContext &BC = BF.getBinaryContext();
 

--- a/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pacret-autiasp.s
@@ -217,6 +217,7 @@ f_callclobbered_calleesaved:
 f_unreachable_instruction:
 // CHECK-LABEL: GS-PAUTH: Warning: unreachable instruction found in function f_unreachable_instruction, basic block {{[0-9a-zA-Z.]+}}, at address
 // CHECK-NEXT:    The instruction is     {{[0-9a-f]+}}:       add     x0, x1, x2
+// CHECK-NOT:   instructions that write to the affected registers after any authentication are:
         b       1f
         add     x0, x1, x2
 1:

--- a/bolt/test/binary-analysis/AArch64/gs-pauth-debug-output.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pauth-debug-output.s
@@ -24,7 +24,7 @@ simple:
         ret
         .size simple, .-simple
 
-// CHECK-LABEL:Analyzing in function simple, AllocatorId 1
+// CHECK-LABEL:Analyzing function simple, AllocatorId = 1
 // CHECK-NEXT: Binary Function "simple"  {
 // CHECK-NEXT:   Number      : 1
 // CHECK-NEXT:   State       : CFG constructed
@@ -129,7 +129,7 @@ clobber:
         ret
         .size clobber, .-clobber
 
-// CHECK-LABEL:Analyzing in function clobber, AllocatorId 1
+// CHECK-LABEL:Analyzing function clobber, AllocatorId = 1
 // ...
 // CHECK:      Running src register safety analysis...
 // CHECK-NEXT:   SrcSafetyAnalysis::ComputeNext(   mov     w30, #0x0, src-state<SafeToDerefRegs: LR W30 W30_HI , TrustedRegs: LR W30 W30_HI , Insts: >)
@@ -174,7 +174,7 @@ nocfg:
         ret
         .size nocfg, .-nocfg
 
-// CHECK-LABEL:Analyzing in function nocfg, AllocatorId 1
+// CHECK-LABEL:Analyzing function nocfg, AllocatorId = 1
 // CHECK-NEXT: Binary Function "nocfg"  {
 // CHECK-NEXT:   Number      : 3
 // CHECK-NEXT:   State       : disassembled
@@ -254,7 +254,7 @@ nocfg:
 // CHECK-EMPTY:
 // CHECK-NEXT:   Attaching clobbering info to:     00000000:   ret # Offset: 8 # CFGUnawareSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, TrustedRegs: BitVector, Insts: [0]()>
 
-// CHECK-LABEL:Analyzing in function main, AllocatorId 1
+// CHECK-LABEL:Analyzing function main, AllocatorId = 1
         .globl  main
         .type   main,@function
 main:


### PR DESCRIPTION
Remove `getAffectedRegisters` and `setOverwritingInstrs` methods from the base `Report` class. Instead, rename the `Report` class to `Diagnostic` and make it always represent the brief version of the report, which is kept unchanged since initially found. Throughout its life-cycle, an instance of `Diagnostic` is first wrapped into `PartialReport<ReqT>` together with an optional request for extra details. Then, on the second run of the analysis, it is re-wrapped into `FinalReport` together with the requested detailed information.