### PR TITLE
[Test][Darwin] Disable test on watchos due to memory restraints

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/mmap_limit_mb.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/mmap_limit_mb.cpp
@@ -1,5 +1,8 @@
 // Test the mmap_limit_mb flag.
 //
+// Unstable on watchOS devices under memory pressure.
+// UNSUPPORTED: watchos
+//
 // RUN: %clangxx_asan -O2 %s -o %t
 // RUN: %run %t 20 16
 // RUN: %run %t 30 1000000


### PR DESCRIPTION
Because of the nature of this test (mmap stress-test) it tests too large of memory allocations to be stable on watchos. WatchOS has memory limits that can lead to the termination of this process before it reaches the limit set by the flag. Typical only on devices that are under heavy load. disable on watchOS.

rdar://147222346