### PR TITLE
[webkit.UncountedLambdaCapturesChecker] Treat a call to lambda function via a variable as safe.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/RawPtrRefLambdaCapturesChecker.cpp
@@ -263,8 +263,6 @@ public:
           return;
         DeclRefExprsToIgnore.insert(ArgRef);
         LambdasToIgnore.insert(L);
-        Checker->visitLambdaExpr(L, shouldCheckThis() && !hasProtectedThis(L),
-                                 ClsType, /* ignoreParamVarDecl */ true);
       }
 
       bool hasProtectedThis(LambdaExpr *L) {

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
@@ -374,10 +374,13 @@ void trivial_lambda() {
 
 bool call_lambda_var_decl() {
   RefCountable* ref_countable = make_obj();
-  auto lambda = [&]() -> bool {
+  auto lambda1 = [&]() -> bool {
     return ref_countable->next();
   };
-  return lambda();
+  auto lambda2 = [=]() -> bool {
+    return ref_countable->next();
+  };
+  return lambda1() && lambda2();
 }
 
 void lambda_with_args(RefCountable* obj) {

--- a/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/uncounted-lambda-captures.cpp
@@ -372,6 +372,14 @@ void trivial_lambda() {
   trivial_lambda();
 }
 
+bool call_lambda_var_decl() {
+  RefCountable* ref_countable = make_obj();
+  auto lambda = [&]() -> bool {
+    return ref_countable->next();
+  };
+  return lambda();
+}
+
 void lambda_with_args(RefCountable* obj) {
   auto trivial_lambda = [&](int v) {
     obj->method();


### PR DESCRIPTION
This PR makes the checker ignore a function call to lambda via a local variable.