### PR TITLE
[clang][Dependency Scanning] Adding an API to Diagnose Invalid Negative Stat Cache Entries

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningFilesystem.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningFilesystem.h
@@ -225,9 +225,8 @@ public:
   /// the path is added to InvalidPaths, indicating that the cache
   /// may have erroneously negatively cached it. The caller can then
   /// use InvalidPaths to issue diagnostics.
-  void diagnoseInvalidNegativeStatCachedPaths(
-      std::vector<std::string> &InvalidPaths,
-      llvm::vfs::FileSystem &UnderlyingFS) const;
+  std::vector<StringRef>
+  getInvalidNegativeStatCachedPaths(llvm::vfs::FileSystem &UnderlyingFS) const;
 
 private:
   std::unique_ptr<CacheShard[]> CacheShards;

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningFilesystem.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningFilesystem.h
@@ -220,13 +220,14 @@ public:
   CacheShard &getShardForFilename(StringRef Filename) const;
   CacheShard &getShardForUID(llvm::sys::fs::UniqueID UID) const;
 
-  /// Visits all cached entries and re-stat an entry using the UnderlyingFS if
-  /// it is negatively stat cached. If the re-stat succeeds, print diagnostics
-  /// information to OS indicating that negative stat caching has been
-  /// invalidated.
-  void
-  diagnoseNegativeStatCachedPaths(llvm::raw_ostream &OS,
-                                  llvm::vfs::FileSystem &UnderlyingFS) const;
+  /// Visits all cached entries and re-stat an entry using FS if
+  /// it is negatively stat cached. If re-stat succeeds on a path,
+  /// the path is added to InvalidPaths, indicating that the cache
+  /// may have erroneously negatively cached it. The caller can then
+  /// use InvalidPaths to issue diagnostics.
+  void diagnoseInvalidNegativeStatCachedPaths(
+      std::vector<std::string> &InvalidPaths,
+      llvm::vfs::FileSystem &UnderlyingFS) const;
 
 private:
   std::unique_ptr<CacheShard[]> CacheShards;

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningFilesystem.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningFilesystem.h
@@ -220,6 +220,14 @@ public:
   CacheShard &getShardForFilename(StringRef Filename) const;
   CacheShard &getShardForUID(llvm::sys::fs::UniqueID UID) const;
 
+  /// Visits all cached entries and re-stat an entry using the UnderlyingFS if
+  /// it is negatively stat cached. If the re-stat succeeds, print diagnostics
+  /// information to OS indicating that negative stat caching has been
+  /// invalidated.
+  void
+  diagnoseNegativeStatCachedPaths(llvm::raw_ostream &OS,
+                                  llvm::vfs::FileSystem &UnderlyingFS) const;
+
 private:
   std::unique_ptr<CacheShard[]> CacheShards;
   unsigned NumShards;

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningFilesystem.cpp
@@ -108,11 +108,11 @@ DependencyScanningFilesystemSharedCache::getShardForUID(
   return CacheShards[Hash % NumShards];
 }
 
-void DependencyScanningFilesystemSharedCache::
-    diagnoseInvalidNegativeStatCachedPaths(
-        std::vector<std::string> &InvalidPaths,
-        llvm::vfs::FileSystem &UnderlyingFS) const {
+std::vector<StringRef>
+DependencyScanningFilesystemSharedCache::getInvalidNegativeStatCachedPaths(
+    llvm::vfs::FileSystem &UnderlyingFS) const {
   // Iterate through all shards and look for cached stat errors.
+  std::vector<StringRef> InvalidPaths;
   for (unsigned i = 0; i < NumShards; i++) {
     const CacheShard &Shard = CacheShards[i];
     std::lock_guard<std::mutex> LockGuard(Shard.CacheLock);
@@ -132,6 +132,7 @@ void DependencyScanningFilesystemSharedCache::
       }
     }
   }
+  return InvalidPaths;
 }
 
 const CachedFileSystemEntry *

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningFilesystem.cpp
@@ -127,7 +127,7 @@ DependencyScanningFilesystemSharedCache::getInvalidNegativeStatCachedPaths(
           // of the file at Path first, and a a file at the path is created
           // later. The cache entry is not invalidated (as we have no good
           // way to do it now), which may lead to missing file build errors.
-          InvalidPaths.push_back(std::string(Path));
+          InvalidPaths.push_back(Path);
         }
       }
     }

--- a/clang/unittests/Tooling/DependencyScanning/DependencyScanningFilesystemTest.cpp
+++ b/clang/unittests/Tooling/DependencyScanning/DependencyScanningFilesystemTest.cpp
@@ -196,10 +196,9 @@ TEST(DependencyScanningFilesystem, DiagnoseStaleStatFailures) {
   // DepFS's eyes.
   EXPECT_EQ(Path1Exists, false);
 
-  std::vector<std::string> InvalidPaths;
-  SharedCache.diagnoseInvalidNegativeStatCachedPaths(InvalidPaths,
-                                                     *InMemoryFS.get());
+  std::vector<llvm::StringRef> InvalidPaths =
+      SharedCache.getInvalidNegativeStatCachedPaths(*InMemoryFS.get());
 
   EXPECT_EQ(InvalidPaths.size(), 1u);
-  ASSERT_STREQ("/path1", InvalidPaths[0].c_str());
+  ASSERT_STREQ("/path1", InvalidPaths[0].str().c_str());
 }

--- a/clang/unittests/Tooling/DependencyScanning/DependencyScanningFilesystemTest.cpp
+++ b/clang/unittests/Tooling/DependencyScanning/DependencyScanningFilesystemTest.cpp
@@ -196,13 +196,10 @@ TEST(DependencyScanningFilesystem, DiagnoseStaleStatFailures) {
   // DepFS's eyes.
   EXPECT_EQ(Path1Exists, false);
 
-  std::string Diags;
-  llvm::raw_string_ostream DiagsStream(Diags);
-  SharedCache.diagnoseNegativeStatCachedPaths(DiagsStream, *InMemoryFS.get());
+  std::vector<std::string> InvalidPaths;
+  SharedCache.diagnoseInvalidNegativeStatCachedPaths(InvalidPaths,
+                                                     *InMemoryFS.get());
 
-  ASSERT_STREQ(
-      "The following paths did not exist when they were first searched, but "
-      "files they point to were created later:\n\t/path1\nFiles missing at the "
-      "paths above may have caused build errors.\n",
-      Diags.c_str());
+  EXPECT_EQ(InvalidPaths.size(), 1u);
+  ASSERT_STREQ("/path1", InvalidPaths[0].c_str());
 }

--- a/clang/unittests/Tooling/DependencyScanning/DependencyScanningFilesystemTest.cpp
+++ b/clang/unittests/Tooling/DependencyScanning/DependencyScanningFilesystemTest.cpp
@@ -182,7 +182,6 @@ TEST(DependencyScanningFilesystem, CacheStatFailures) {
 TEST(DependencyScanningFilesystem, DiagnoseStaleStatFailures) {
   auto InMemoryFS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
   InMemoryFS->setCurrentWorkingDirectory("/");
-  InMemoryFS->addFile("/dir", 0, llvm::MemoryBuffer::getMemBuffer(""));
 
   DependencyScanningFilesystemSharedCache SharedCache;
   DependencyScanningWorkerFilesystem DepFS(SharedCache, InMemoryFS);
@@ -202,7 +201,8 @@ TEST(DependencyScanningFilesystem, DiagnoseStaleStatFailures) {
   SharedCache.diagnoseNegativeStatCachedPaths(DiagsStream, *InMemoryFS.get());
 
   ASSERT_STREQ(
-      "/path1 did not exist when it was first searched but was created later. "
-      "This may have led to a build failure due to missing files.\n",
+      "The following paths did not exist when they were first searched, but "
+      "files they point to were created later:\n\t/path1\nFiles missing at the "
+      "paths above may have caused build errors.\n",
       Diags.c_str());
 }


### PR DESCRIPTION
We have had numerous situations where the negatively stat cached paths are invalidated during the build, and such invalidations lead to build errors. 

This PR adds an API to diagnose such cases. `DependencyScanningFilesystemSharedCache::diagnoseNegativeStatCachedPaths` allows users of the cache to ask the cache to examine all negatively stat cached paths, and re-stat the paths using the passed-in file system. If any re-stat succeeds, the API emits diagnostics. 

rdar://149147920