### PR TITLE
[clang][depscan] Centralize logic for populating StableDirs, NFC

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
@@ -282,7 +282,8 @@ public:
                      CompilerInstance &ScanInstance, DependencyConsumer &C,
                      DependencyActionController &Controller,
                      CompilerInvocation OriginalCI,
-                     const PrebuiltModulesAttrsMap PrebuiltModulesASTMap);
+                     const PrebuiltModulesAttrsMap PrebuiltModulesASTMap,
+                     const ArrayRef<StringRef> StableDirs);
 
   void attachToPreprocessor(Preprocessor &PP) override;
   void attachToASTReader(ASTReader &R) override;
@@ -305,6 +306,9 @@ private:
   /// Mapping from prebuilt AST filepaths to their attributes referenced during
   /// dependency collecting.
   const PrebuiltModulesAttrsMap PrebuiltModulesASTMap;
+  /// Directory paths known to be stable through an active development and build
+  /// cycle.
+  const ArrayRef<StringRef> StableDirs;
   /// Path to the main source file.
   std::string MainFile;
   /// Hash identifying the compilation conditions of the current TU.

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -100,7 +100,7 @@ public:
                          PrebuiltModulesAttrsMap &PrebuiltModulesASTMap,
                          const HeaderSearchOptions &HSOpts,
                          const LangOptions &LangOpts, DiagnosticsEngine &Diags,
-                         const llvm::SmallVector<StringRef> &StableDirs)
+                         const ArrayRef<StringRef> StableDirs)
       : PrebuiltModuleFiles(PrebuiltModuleFiles),
         NewModuleFiles(NewModuleFiles),
         PrebuiltModulesASTMap(PrebuiltModulesASTMap), ExistingHSOpts(HSOpts),
@@ -199,7 +199,7 @@ private:
   const LangOptions &ExistingLangOpts;
   DiagnosticsEngine &Diags;
   std::string CurrentFile;
-  const llvm::SmallVector<StringRef> &StableDirs;
+  const ArrayRef<StringRef> StableDirs;
 };
 
 /// Visit the given prebuilt module and collect all of the modules it
@@ -208,16 +208,8 @@ static bool visitPrebuiltModule(StringRef PrebuiltModuleFilename,
                                 CompilerInstance &CI,
                                 PrebuiltModuleFilesT &ModuleFiles,
                                 PrebuiltModulesAttrsMap &PrebuiltModulesASTMap,
-                                DiagnosticsEngine &Diags) {
-
-  // Gather the set of stable directories to use as transitive dependencies are
-  // discovered.
-  llvm::SmallVector<StringRef> StableDirs;
-  std::string SysrootToUse(CI.getHeaderSearchOpts().Sysroot);
-  if (!SysrootToUse.empty() &&
-      (llvm::sys::path::root_directory(SysrootToUse) != SysrootToUse))
-    StableDirs = {SysrootToUse, CI.getHeaderSearchOpts().ResourceDir};
-
+                                DiagnosticsEngine &Diags,
+                                const ArrayRef<StringRef> StableDirs) {
   // List of module files to be processed.
   llvm::SmallVector<std::string> Worklist;
 
@@ -448,6 +440,15 @@ public:
     auto *FileMgr = ScanInstance.createFileManager(FS);
     ScanInstance.createSourceManager(*FileMgr);
 
+    // Create a collection of stable directories derived from the ScanInstance
+    // for determining whether module dependencies would fully resolve from
+    // those directories.
+    llvm::SmallVector<StringRef> StableDirs;
+    const StringRef Sysroot = ScanInstance.getHeaderSearchOpts().Sysroot;
+    if (!Sysroot.empty() &&
+        (llvm::sys::path::root_directory(Sysroot) != Sysroot))
+      StableDirs = {Sysroot, ScanInstance.getHeaderSearchOpts().ResourceDir};
+
     // Store a mapping of prebuilt module files and their properties like header
     // search options. This will prevent the implicit build to create duplicate
     // modules and will force reuse of the existing prebuilt module files
@@ -459,7 +460,7 @@ public:
               ScanInstance.getPreprocessorOpts().ImplicitPCHInclude,
               ScanInstance,
               ScanInstance.getHeaderSearchOpts().PrebuiltModuleFiles,
-              PrebuiltModulesASTMap, ScanInstance.getDiagnostics()))
+              PrebuiltModulesASTMap, ScanInstance.getDiagnostics(), StableDirs))
         return false;
 
     // Create the dependency collector that will collect the produced
@@ -489,7 +490,7 @@ public:
     case ScanningOutputFormat::Full:
       MDC = std::make_shared<ModuleDepCollector>(
           Service, std::move(Opts), ScanInstance, Consumer, Controller,
-          OriginalInvocation, std::move(PrebuiltModulesASTMap));
+          OriginalInvocation, std::move(PrebuiltModulesASTMap), StableDirs);
       ScanInstance.addDependencyCollector(MDC);
       break;
     }


### PR DESCRIPTION
Pass a reference to `StableDirs` when creating ModuleDepCollector. This avoids needing to create one from the same ScanInstance for each call to `handleTopLevelModule` & reduces the amount of potential downstream changes needed for handling StableDirs.