### PR TITLE
[llvm][IR] Treat memcmp and bcmp as libcalls

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.def
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.def
@@ -513,6 +513,8 @@ HANDLE_LIBCALL(UO_PPCF128, "__gcc_qunord")
 HANDLE_LIBCALL(MEMCPY, "memcpy")
 HANDLE_LIBCALL(MEMMOVE, "memmove")
 HANDLE_LIBCALL(MEMSET, "memset")
+HANDLE_LIBCALL(MEMCMP, "memcmp")
+HANDLE_LIBCALL(BCMP, "bcmp")
 // DSEPass can emit calloc if it finds a pair of malloc/memset
 HANDLE_LIBCALL(CALLOC, "calloc")
 HANDLE_LIBCALL(BZERO, nullptr)

--- a/llvm/test/LTO/Resolution/X86/bcmp-libcall.ll
+++ b/llvm/test/LTO/Resolution/X86/bcmp-libcall.ll
@@ -26,9 +26,8 @@ define i1 @foo(ptr %0, [2 x i32] %1) {
 ; CHECK: declare i32 @memcmp(ptr, ptr, i32)
 declare i32 @memcmp(ptr, ptr, i32)
 
-;; Ensure bcmp is removed from module. Follow up patches can address this.
-; CHECK-NOT: declare{{.*}}i32 @bcmp
-; CHECK-NOT: define{{.*}}i32 @bcmp
+;; Ensure bcmp is not removed from module.
+; CHECK: define{{.*}}i32 @bcmp
 define i32 @bcmp(ptr %0, ptr %1, i32 %2) {
   ret i32 0
 }


### PR DESCRIPTION
Since the backend may emit calls to these functions, they should be
treated like other libcalls. If we don't, then it is possible to
have their definitions removed during LTO because they are dead, only to
have a later transform introduce calls to them.

See https://discourse.llvm.org/t/rfc-addressing-deficiencies-in-llvm-s-lto-implementation/84999
for more information.