### PR TITLE
[libclc] only check filename part of the source for avoiding duplication

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -466,16 +466,22 @@ function(libclc_configure_lib_source LIB_FILE_LIST)
   ## Add the generated convert files here to prevent adding the ones listed in
   ## SOURCES
   set( rel_files ${${LIB_FILE_LIST}} ) # Source directory input files, relative to the root dir
-  set( objects ${${LIB_FILE_LIST}} )   # A "set" of already-added input files
+  # A "set" of already-added input files
+  set( objects )
+  foreach( f ${${LIB_FILE_LIST}} )
+    get_filename_component( name ${f} NAME )
+    list( APPEND objects ${name} )
+  endforeach()
 
   foreach( l ${source_list} )
     file( READ ${l} file_list )
     string( REPLACE "\n" ";" file_list ${file_list} )
     get_filename_component( dir ${l} DIRECTORY )
     foreach( f ${file_list} )
+      get_filename_component( name ${f} NAME )
       # Only add each file once, so that targets can 'specialize' builtins
-      if( NOT ${f} IN_LIST objects )
-        list( APPEND objects ${f} )
+      if( NOT ${name} IN_LIST objects )
+        list( APPEND objects ${name} )
         list( APPEND rel_files ${dir}/${f} )
       endif()
     endforeach()


### PR DESCRIPTION
llvm-diff shows this PR has no changes to amdgcn--amdhsa.bc.

Motivation is that in our downstream the same category of target built-ins, e.g. math, are organized in several different folders. For example, in target SOURCES we have math-common/cos.cl, while in generic SOURCES it is math/cos.cl. Based on current check rule that compares both folder name and base filename, target math-common/cos.cl won't override math/cos.cl when collecting source files from SOURCES files in cmake function libclc_configure_lib_source.

With this PR, we allow folder name to be different in the process.

A notable change of this PR is that two entries in SOURCES with the same base filename must not implements the same built-in.