### PR TITLE
[flang] Propagate fast-math flags in target-rewrite

### DIFF
--- a/flang/lib/Optimizer/CodeGen/TargetRewrite.cpp
+++ b/flang/lib/Optimizer/CodeGen/TargetRewrite.cpp
@@ -542,6 +542,7 @@ public:
             mlir::TypeRange{newInTypes}.drop_front(dropFront), newResTys));
         newCall = rewriter->create<fir::CallOp>(loc, newResTys, newOpers);
       }
+      newCall.setFastmathAttr(callOp.getFastmathAttr());
       // Always set ABI argument attributes on call operations, even when
       // direct, as required by
       // https://llvm.org/docs/LangRef.html#parameter-attributes.

--- a/flang/test/Fir/CUDA/cuda-target-rewrite.mlir
+++ b/flang/test/Fir/CUDA/cuda-target-rewrite.mlir
@@ -14,7 +14,7 @@ gpu.module @testmod {
 }
 
 // CHECK-LABEL: gpu.func @_QPvcpowdk
-// CHECK: %{{.*}} = fir.call @_FortranAzpowk(%{{.*}}, %{{.*}}, %{{.*}}) : (f64, f64, i64) -> tuple<f64, f64>
+// CHECK: %{{.*}} = fir.call @_FortranAzpowk(%{{.*}}, %{{.*}}, %{{.*}}) fastmath<contract> : (f64, f64, i64) -> tuple<f64, f64>
 // CHECK: func.func private @_FortranAzpowk(f64, f64, i64) -> tuple<f64, f64> attributes {fir.bindc_name = "_FortranAzpowk", fir.runtime}
 }
 

--- a/flang/test/Fir/target-rewrite-fmfs.fir
+++ b/flang/test/Fir/target-rewrite-fmfs.fir
@@ -1,0 +1,8 @@
+// RUN: fir-opt --target-rewrite %s | FileCheck %s
+
+// CHECK-LABEL: func.func @libm_preserves_fmfs
+func.func @libm_preserves_fmfs(%arg0 : complex<f32>) -> complex<f32> {
+  %0 = fir.call @csin(%arg0) fastmath<contract> : (complex<f32>) -> complex<f32>
+  // CHECK: fir.call @csin(%{{.+}}) fastmath<contract>
+  return %0 : complex<f32>
+}

--- a/flang/test/Fir/target-rewrite-selective.fir
+++ b/flang/test/Fir/target-rewrite-selective.fir
@@ -21,13 +21,13 @@
 //   r = test2(value)
 // end function
 
-// CMPLXOFF-DAG: fir.call @_QPtest1({{.*}}, {{.*}}, {{.*}}) : (!fir.ref<!fir.char<1,?>>, complex<f32>, i64) -> complex<f32>
-// CMPLXOFF-DAG: fir.call @_QPtest2({{.*}}, {{.*}}, {{.*}}) : (!fir.ref<!fir.char<1,10>>, index, complex<f32>) -> !fir.boxchar<1>
+// CMPLXOFF-DAG: fir.call @_QPtest1({{.*}}, {{.*}}, {{.*}}) fastmath<contract> : (!fir.ref<!fir.char<1,?>>, complex<f32>, i64) -> complex<f32>
+// CMPLXOFF-DAG: fir.call @_QPtest2({{.*}}, {{.*}}, {{.*}}) fastmath<contract> : (!fir.ref<!fir.char<1,10>>, index, complex<f32>) -> !fir.boxchar<1>
 // CMPLXOFF-DAG: func.func private @_QPtest1(!fir.ref<!fir.char<1,?>>, complex<f32>, i64) -> complex<f32>
 // CMPLXOFF-DAG: func.func private @_QPtest2(!fir.ref<!fir.char<1,10>>, index, complex<f32>) -> !fir.boxchar<1>
 
-// CHAROFF-DAG: fir.call @_QPtest1({{.*}}, {{.*}}) : (!fir.boxchar<1>, !fir.vector<2:f32>) -> !fir.vector<2:f32>
-// CHAROFF-DAG: fir.call @_QPtest2({{.*}}, {{.*}}, {{.*}}) : (!fir.ref<!fir.char<1,10>>, index, !fir.vector<2:f32>) -> !fir.boxchar<1>
+// CHAROFF-DAG: fir.call @_QPtest1({{.*}}, {{.*}}) fastmath<contract> : (!fir.boxchar<1>, !fir.vector<2:f32>) -> !fir.vector<2:f32>
+// CHAROFF-DAG: fir.call @_QPtest2({{.*}}, {{.*}}, {{.*}}) fastmath<contract> : (!fir.ref<!fir.char<1,10>>, index, !fir.vector<2:f32>) -> !fir.boxchar<1>
 // CHAROFF-DAG: func.func private @_QPtest1(!fir.boxchar<1>, !fir.vector<2:f32>) -> !fir.vector<2:f32>
 // CHAROFF-DAG: func.func private @_QPtest2(!fir.ref<!fir.char<1,10>>, index, !fir.vector<2:f32>) -> !fir.boxchar<1>
 


### PR DESCRIPTION
TargetRewritePass was dropping fast-math flags. Add the flags to the new call ops and update tests.