### PR TITLE
[InstCombine] Do not combine shuffle+bitcast if the bitcast is eliminable.

### DIFF
--- a/llvm/test/Transforms/InstCombine/shufflevec-bitcast.ll
+++ b/llvm/test/Transforms/InstCombine/shufflevec-bitcast.ll
@@ -240,9 +240,8 @@ define <3 x i4> @shuf_bitcast_wrong_size(<2 x i8> %v, i8 %x) {
 
 define <16 x i8> @shuf_bitcast_chain(<8 x i32> %v) {
 ; CHECK-LABEL: @shuf_bitcast_chain(
-; CHECK-NEXT:    [[S_BC:%.*]] = bitcast <8 x i32> [[V:%.*]] to <2 x i128>
-; CHECK-NEXT:    [[S_EXTRACT:%.*]] = extractelement <2 x i128> [[S_BC]], i64 0
-; CHECK-NEXT:    [[C:%.*]] = bitcast i128 [[S_EXTRACT]] to <16 x i8>
+; CHECK-NEXT:    [[S:%.*]] = shufflevector <8 x i32> [[V:%.*]], <8 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT:    [[C:%.*]] = bitcast <4 x i32> [[S]] to <16 x i8>
 ; CHECK-NEXT:    ret <16 x i8> [[C]]
 ;
   %s = shufflevector <8 x i32> %v, <8 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
@@ -257,12 +256,9 @@ define <16 x i8> @shuf_bitcast_chain(<8 x i32> %v) {
 
 define <4 x i32> @shuf_bitcast_chain_2(<8 x i32> %v) {
 ; CHECK-LABEL: @shuf_bitcast_chain_2(
-; CHECK-NEXT:    [[S0_BC:%.*]] = bitcast <8 x i32> [[V:%.*]] to <2 x i128>
-; CHECK-NEXT:    [[S0_EXTRACT:%.*]] = extractelement <2 x i128> [[S0_BC]], i64 0
-; CHECK-NEXT:    [[S1_BC:%.*]] = bitcast <8 x i32> [[V]] to <2 x i128>
-; CHECK-NEXT:    [[S1_EXTRACT:%.*]] = extractelement <2 x i128> [[S1_BC]], i64 1
-; CHECK-NEXT:    [[R1:%.*]] = or i128 [[S0_EXTRACT]], [[S1_EXTRACT]]
-; CHECK-NEXT:    [[R:%.*]] = bitcast i128 [[R1]] to <4 x i32>
+; CHECK-NEXT:    [[S0:%.*]] = shufflevector <8 x i32> [[V:%.*]], <8 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT:    [[S1:%.*]] = shufflevector <8 x i32> [[V]], <8 x i32> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+; CHECK-NEXT:    [[R:%.*]] = or <4 x i32> [[S0]], [[S1]]
 ; CHECK-NEXT:    ret <4 x i32> [[R]]
 ;
   %s0 = shufflevector <8 x i32> %v, <8 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>

--- a/llvm/test/Transforms/InstCombine/shufflevec-bitcast.ll
+++ b/llvm/test/Transforms/InstCombine/shufflevec-bitcast.ll
@@ -240,8 +240,9 @@ define <3 x i4> @shuf_bitcast_wrong_size(<2 x i8> %v, i8 %x) {
 
 define <16 x i8> @shuf_bitcast_chain(<8 x i32> %v) {
 ; CHECK-LABEL: @shuf_bitcast_chain(
-; CHECK-NEXT:    [[S:%.*]] = shufflevector <8 x i32> [[V:%.*]], <8 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
-; CHECK-NEXT:    [[C:%.*]] = bitcast <4 x i32> [[S]] to <16 x i8>
+; CHECK-NEXT:    [[S_BC:%.*]] = bitcast <8 x i32> [[V:%.*]] to <2 x i128>
+; CHECK-NEXT:    [[S_EXTRACT:%.*]] = extractelement <2 x i128> [[S_BC]], i64 0
+; CHECK-NEXT:    [[C:%.*]] = bitcast i128 [[S_EXTRACT]] to <16 x i8>
 ; CHECK-NEXT:    ret <16 x i8> [[C]]
 ;
   %s = shufflevector <8 x i32> %v, <8 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
@@ -249,4 +250,27 @@ define <16 x i8> @shuf_bitcast_chain(<8 x i32> %v) {
   %b = bitcast <2 x i64> %a to i128
   %c = bitcast i128 %b to <16 x i8>
   ret <16 x i8> %c
+}
+
+; Same as above, but showing why it's not feasable to implement the reverse
+; fold in VectorCombine (see #136998).
+
+define <4 x i32> @shuf_bitcast_chain_2(<8 x i32> %v) {
+; CHECK-LABEL: @shuf_bitcast_chain_2(
+; CHECK-NEXT:    [[S0_BC:%.*]] = bitcast <8 x i32> [[V:%.*]] to <2 x i128>
+; CHECK-NEXT:    [[S0_EXTRACT:%.*]] = extractelement <2 x i128> [[S0_BC]], i64 0
+; CHECK-NEXT:    [[S1_BC:%.*]] = bitcast <8 x i32> [[V]] to <2 x i128>
+; CHECK-NEXT:    [[S1_EXTRACT:%.*]] = extractelement <2 x i128> [[S1_BC]], i64 1
+; CHECK-NEXT:    [[R1:%.*]] = or i128 [[S0_EXTRACT]], [[S1_EXTRACT]]
+; CHECK-NEXT:    [[R:%.*]] = bitcast i128 [[R1]] to <4 x i32>
+; CHECK-NEXT:    ret <4 x i32> [[R]]
+;
+  %s0 = shufflevector <8 x i32> %v, <8 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %s1 = shufflevector <8 x i32> %v, <8 x i32> poison, <4 x i32> <i32 4, i32 5, i32 6, i32 7>
+  %b0 = bitcast <4 x i32> %s0 to i128
+  %b1 = bitcast <4 x i32> %s1 to i128
+  %c0 = bitcast i128 %b0 to <4 x i32>
+  %c1 = bitcast i128 %b1 to <4 x i32>
+  %r = or <4 x i32> %c0, %c1
+  ret <4 x i32> %r
 }

--- a/llvm/test/Transforms/InstCombine/shufflevec-bitcast.ll
+++ b/llvm/test/Transforms/InstCombine/shufflevec-bitcast.ll
@@ -240,9 +240,8 @@ define <3 x i4> @shuf_bitcast_wrong_size(<2 x i8> %v, i8 %x) {
 
 define <16 x i8> @shuf_bitcast_chain(<8 x i32> %v) {
 ; CHECK-LABEL: @shuf_bitcast_chain(
-; CHECK-NEXT:    [[S_BC:%.*]] = bitcast <8 x i32> [[V:%.*]] to <2 x i128>
-; CHECK-NEXT:    [[S_EXTRACT:%.*]] = extractelement <2 x i128> [[S_BC]], i64 0
-; CHECK-NEXT:    [[C:%.*]] = bitcast i128 [[S_EXTRACT]] to <16 x i8>
+; CHECK-NEXT:    [[S:%.*]] = shufflevector <8 x i32> [[V:%.*]], <8 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+; CHECK-NEXT:    [[C:%.*]] = bitcast <4 x i32> [[S]] to <16 x i8>
 ; CHECK-NEXT:    ret <16 x i8> [[C]]
 ;
   %s = shufflevector <8 x i32> %v, <8 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>

--- a/llvm/test/Transforms/InstCombine/shufflevec-bitcast.ll
+++ b/llvm/test/Transforms/InstCombine/shufflevec-bitcast.ll
@@ -235,3 +235,19 @@ define <3 x i4> @shuf_bitcast_wrong_size(<2 x i8> %v, i8 %x) {
   %r = shufflevector <4 x i4> %b, <4 x i4> undef, <3 x i32> <i32 0, i32 1, i32 2>
   ret <3 x i4> %r
 }
+
+; Negative test - chain of bitcasts.
+
+define <16 x i8> @shuf_bitcast_chain(<8 x i32> %v) {
+; CHECK-LABEL: @shuf_bitcast_chain(
+; CHECK-NEXT:    [[S_BC:%.*]] = bitcast <8 x i32> [[V:%.*]] to <2 x i128>
+; CHECK-NEXT:    [[S_EXTRACT:%.*]] = extractelement <2 x i128> [[S_BC]], i64 0
+; CHECK-NEXT:    [[C:%.*]] = bitcast i128 [[S_EXTRACT]] to <16 x i8>
+; CHECK-NEXT:    ret <16 x i8> [[C]]
+;
+  %s = shufflevector <8 x i32> %v, <8 x i32> poison, <4 x i32> <i32 0, i32 1, i32 2, i32 3>
+  %a = bitcast <4 x i32> %s to <2 x i64>
+  %b = bitcast <2 x i64> %a to i128
+  %c = bitcast i128 %b to <16 x i8>
+  ret <16 x i8> %c
+}


### PR DESCRIPTION
If we are attempting to combine shuffle+bitcast but the bitcast is
pairable with a subsequent bitcast, we should not fold the shuffle as
doing so can block further simplifications.

The motivation for this is a long standing regression affecting SIMDe on
AArch64 introduced indirectly by the AlwaysInliner (1a2e77cf). Some
reproducers:
* https://godbolt.org/z/53qx18s6M
* https://godbolt.org/z/o5e43h5M7
