### PR TITLE
[libclang/C++] Fix clang_File_isEqual for in-memory files

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -557,6 +557,8 @@ clang-format
 
 libclang
 --------
+- Fixed a bug in ``clang_File_isEqual`` that sometimes led to different 
+  in-memory files to be considered as equal.
 - Added ``clang_visitCXXMethods``, which allows visiting the methods
   of a class.
 

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -5170,7 +5170,7 @@ int clang_File_isEqual(CXFile file1, CXFile file2) {
 
   FileEntryRef FEnt1 = *cxfile::getFileEntryRef(file1);
   FileEntryRef FEnt2 = *cxfile::getFileEntryRef(file2);
-  return FEnt1.getUniqueID() == FEnt2.getUniqueID();
+  return FEnt1 == FEnt2;
 }
 
 CXString clang_File_tryGetRealPathName(CXFile SFile) {

--- a/clang/unittests/libclang/LibclangTest.cpp
+++ b/clang/unittests/libclang/LibclangTest.cpp
@@ -1410,3 +1410,52 @@ TEST_F(LibclangRewriteTest, RewriteRemove) {
   ASSERT_EQ(clang_CXRewriter_overwriteChangedFiles(Rew), 0);
   EXPECT_EQ(getFileContent(Filename), "int () { return 0; }");
 }
+
+TEST_F(LibclangParseTest, FileEqual) {
+  std::string AInc = "a.inc", BInc = "b.inc", Main = "main.cpp";
+  WriteFile(Main, "int a[] = {\n"
+                  "    #include \"a.inc\"\n"
+                  "};\n"
+                  "int b[] = {\n"
+                  "    #include \"b.inc\"\n"
+                  "};");
+  WriteFile(AInc, "1,2,3");
+  WriteFile(BInc, "1,2,3");
+
+  ClangTU = clang_parseTranslationUnit(Index, Main.c_str(), nullptr, 0, nullptr,
+                                       0, TUFlags);
+
+  CXFile AFile = clang_getFile(ClangTU, AInc.c_str()),
+         AFile2 = clang_getFile(ClangTU, AInc.c_str()),
+         BFile = clang_getFile(ClangTU, BInc.c_str()),
+         MainFile = clang_getFile(ClangTU, Main.c_str());
+
+  ASSERT_FALSE(clang_File_isEqual(MainFile, AFile));
+  ASSERT_FALSE(clang_File_isEqual(AFile, BFile));
+  ASSERT_TRUE(clang_File_isEqual(AFile, AFile2));
+}
+
+TEST_F(LibclangParseTest, FileEqualInMemory) {
+  std::string AInc = "a.inc", BInc = "b.inc", Main = "main.cpp";
+  MapUnsavedFile(Main, "int a[] = {\n"
+                       "    #include \"a.inc\"\n"
+                       "};\n"
+                       "int b[] = {\n"
+                       "    #include \"b.inc\"\n"
+                       "};");
+  MapUnsavedFile(AInc, "1,2,3");
+  MapUnsavedFile(BInc, "1,2,3");
+
+  ClangTU = clang_parseTranslationUnit(Index, UnsavedFiles[0].Filename, nullptr,
+                                       0, &UnsavedFiles.front(),
+                                       UnsavedFiles.size(), TUFlags);
+
+  CXFile AFile = clang_getFile(ClangTU, UnsavedFiles[1].Filename),
+         AFile2 = clang_getFile(ClangTU, UnsavedFiles[1].Filename),
+         BFile = clang_getFile(ClangTU, UnsavedFiles[2].Filename),
+         MainFile = clang_getFile(ClangTU, UnsavedFiles[0].Filename);
+
+  ASSERT_FALSE(clang_File_isEqual(MainFile, AFile));
+  ASSERT_FALSE(clang_File_isEqual(AFile, BFile));
+  ASSERT_TRUE(clang_File_isEqual(AFile, AFile2));
+}


### PR DESCRIPTION
Add tests for `clang_File_isEqual` (on-disk and in-memory)