### PR TITLE
[CodeGen] Fix new-delete-type-mismatch in ~CodeGenTypes()

### DIFF
--- a/clang/lib/CodeGen/CodeGenTypes.cpp
+++ b/clang/lib/CodeGen/CodeGenTypes.cpp
@@ -41,7 +41,7 @@ CodeGenTypes::CodeGenTypes(CodeGenModule &cgm)
 CodeGenTypes::~CodeGenTypes() {
   for (llvm::FoldingSet<CGFunctionInfo>::iterator
        I = FunctionInfos.begin(), E = FunctionInfos.end(); I != E; )
-    delete &*I++;
+    operator delete(&*I++);
 }
 
 CGCXXABI &CodeGenTypes::getCXXABI() const { return getCGM().getCXXABI(); }

--- a/clang/lib/CodeGen/CodeGenTypes.cpp
+++ b/clang/lib/CodeGen/CodeGenTypes.cpp
@@ -40,8 +40,10 @@ CodeGenTypes::CodeGenTypes(CodeGenModule &cgm)
 
 CodeGenTypes::~CodeGenTypes() {
   for (llvm::FoldingSet<CGFunctionInfo>::iterator
-       I = FunctionInfos.begin(), E = FunctionInfos.end(); I != E; )
+       I = FunctionInfos.begin(), E = FunctionInfos.end(); I != E; ) {
+    I->~CGFunctionInfo();
     operator delete(&*I++);
+  }
 }
 
 CGCXXABI &CodeGenTypes::getCXXABI() const { return getCGM().getCXXABI(); }


### PR DESCRIPTION
It is undefined behavior to use `delete` expression on something which was not created with corresponding `new` expression. Switching to explicit global `operator delete()` call to match with `operator new()` call at `CGFunctionInfo::create()`.

This issue is raised by Chromium ClusterFuzz, with ASan enabled. https://crbug.com/410141973