### PR TITLE
[NFC][NVPTX] Use StringRef for Modifier arg in NVPTXInstPrinter

### DIFF
--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXInstPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXInstPrinter.cpp
@@ -95,10 +95,9 @@ void NVPTXInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
 }
 
 void NVPTXInstPrinter::printCvtMode(const MCInst *MI, int OpNum, raw_ostream &O,
-                                    const char *M) {
+                                    StringRef Modifier) {
   const MCOperand &MO = MI->getOperand(OpNum);
   int64_t Imm = MO.getImm();
-  llvm::StringRef Modifier(M);
 
   if (Modifier == "ftz") {
     // FTZ flag
@@ -155,10 +154,9 @@ void NVPTXInstPrinter::printCvtMode(const MCInst *MI, int OpNum, raw_ostream &O,
 }
 
 void NVPTXInstPrinter::printCmpMode(const MCInst *MI, int OpNum, raw_ostream &O,
-                                    const char *M) {
+                                    StringRef Modifier) {
   const MCOperand &MO = MI->getOperand(OpNum);
   int64_t Imm = MO.getImm();
-  llvm::StringRef Modifier(M);
 
   if (Modifier == "ftz") {
     // FTZ flag
@@ -229,8 +227,7 @@ void NVPTXInstPrinter::printCmpMode(const MCInst *MI, int OpNum, raw_ostream &O,
 }
 
 void NVPTXInstPrinter::printLdStCode(const MCInst *MI, int OpNum,
-                                     raw_ostream &O, const char *M) {
-  llvm::StringRef Modifier(M);
+                                     raw_ostream &O, StringRef Modifier) {
   const MCOperand &MO = MI->getOperand(OpNum);
   int Imm = (int)MO.getImm();
   if (Modifier == "sem") {
@@ -329,10 +326,9 @@ void NVPTXInstPrinter::printLdStCode(const MCInst *MI, int OpNum,
 }
 
 void NVPTXInstPrinter::printMmaCode(const MCInst *MI, int OpNum, raw_ostream &O,
-                                    const char *M) {
+                                    StringRef Modifier) {
   const MCOperand &MO = MI->getOperand(OpNum);
   int Imm = (int)MO.getImm();
-  llvm::StringRef Modifier(M);
   if (Modifier.empty() || Modifier == "version") {
     O << Imm; // Just print out PTX version
     return;
@@ -346,9 +342,8 @@ void NVPTXInstPrinter::printMmaCode(const MCInst *MI, int OpNum, raw_ostream &O,
 }
 
 void NVPTXInstPrinter::printMemOperand(const MCInst *MI, int OpNum,
-                                       raw_ostream &O, const char *M) {
+                                       raw_ostream &O, StringRef Modifier) {
   printOperand(MI, OpNum, O);
-  llvm::StringRef Modifier(M);
 
   if (Modifier == "add") {
     O << ", ";
@@ -363,7 +358,7 @@ void NVPTXInstPrinter::printMemOperand(const MCInst *MI, int OpNum,
 }
 
 void NVPTXInstPrinter::printOffseti32imm(const MCInst *MI, int OpNum,
-                                         raw_ostream &O, const char *Modifier) {
+                                         raw_ostream &O) {
   auto &Op = MI->getOperand(OpNum);
   assert(Op.isImm() && "Invalid operand");
   if (Op.getImm() != 0) {
@@ -373,13 +368,13 @@ void NVPTXInstPrinter::printOffseti32imm(const MCInst *MI, int OpNum,
 }
 
 void NVPTXInstPrinter::printHexu32imm(const MCInst *MI, int OpNum,
-                                      raw_ostream &O, const char *Modifier) {
+                                      raw_ostream &O) {
   int64_t Imm = MI->getOperand(OpNum).getImm();
   O << formatHex(Imm) << "U";
 }
 
 void NVPTXInstPrinter::printProtoIdent(const MCInst *MI, int OpNum,
-                                       raw_ostream &O, const char *Modifier) {
+                                       raw_ostream &O) {
   const MCOperand &Op = MI->getOperand(OpNum);
   assert(Op.isExpr() && "Call prototype is not an MCExpr?");
   const MCExpr *Expr = Op.getExpr();
@@ -388,7 +383,7 @@ void NVPTXInstPrinter::printProtoIdent(const MCInst *MI, int OpNum,
 }
 
 void NVPTXInstPrinter::printPrmtMode(const MCInst *MI, int OpNum,
-                                     raw_ostream &O, const char *Modifier) {
+                                     raw_ostream &O) {
   const MCOperand &MO = MI->getOperand(OpNum);
   int64_t Imm = MO.getImm();
 
@@ -419,10 +414,9 @@ void NVPTXInstPrinter::printPrmtMode(const MCInst *MI, int OpNum,
 }
 
 void NVPTXInstPrinter::printTmaReductionMode(const MCInst *MI, int OpNum,
-                                             raw_ostream &O,
-                                             const char *Modifier) {
+                                             raw_ostream &O) {
   const MCOperand &MO = MI->getOperand(OpNum);
-  using RedTy = llvm::nvvm::TMAReductionOp;
+  using RedTy = nvvm::TMAReductionOp;
 
   switch (static_cast<RedTy>(MO.getImm())) {
   case RedTy::ADD:

--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXInstPrinter.h
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXInstPrinter.h
@@ -37,25 +37,20 @@ public:
 
   void printOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O);
   void printCvtMode(const MCInst *MI, int OpNum, raw_ostream &O,
-                    const char *Modifier = nullptr);
+                    StringRef Modifier = {});
   void printCmpMode(const MCInst *MI, int OpNum, raw_ostream &O,
-                    const char *Modifier = nullptr);
-  void printLdStCode(const MCInst *MI, int OpNum,
-                     raw_ostream &O, const char *Modifier = nullptr);
+                    StringRef Modifier = {});
+  void printLdStCode(const MCInst *MI, int OpNum, raw_ostream &O,
+                     StringRef Modifier = {});
   void printMmaCode(const MCInst *MI, int OpNum, raw_ostream &O,
-                    const char *Modifier = nullptr);
-  void printMemOperand(const MCInst *MI, int OpNum,
-                       raw_ostream &O, const char *Modifier = nullptr);
-  void printOffseti32imm(const MCInst *MI, int OpNum, raw_ostream &O,
-                         const char *Modifier = nullptr);
-  void printHexu32imm(const MCInst *MI, int OpNum, raw_ostream &O,
-                      const char *Modifier = nullptr);
-  void printProtoIdent(const MCInst *MI, int OpNum,
-                       raw_ostream &O, const char *Modifier = nullptr);
-  void printPrmtMode(const MCInst *MI, int OpNum, raw_ostream &O,
-                     const char *Modifier = nullptr);
-  void printTmaReductionMode(const MCInst *MI, int OpNum, raw_ostream &O,
-                             const char *Modifier = nullptr);
+                    StringRef Modifier = {});
+  void printMemOperand(const MCInst *MI, int OpNum, raw_ostream &O,
+                       StringRef Modifier = {});
+  void printOffseti32imm(const MCInst *MI, int OpNum, raw_ostream &O);
+  void printHexu32imm(const MCInst *MI, int OpNum, raw_ostream &O);
+  void printProtoIdent(const MCInst *MI, int OpNum, raw_ostream &O);
+  void printPrmtMode(const MCInst *MI, int OpNum, raw_ostream &O);
+  void printTmaReductionMode(const MCInst *MI, int OpNum, raw_ostream &O);
 };
 
 }


### PR DESCRIPTION
- Use StringRef type for Modifier instead of const char *.
- Remove Modifier arg from functions that do not need them.