### PR TITLE
[clang] convergent attribute does not require "all threads"

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -1680,10 +1680,6 @@ translated into the LLVM ``convergent`` attribute, which indicates that the call
 instructions of a function with this attribute cannot be made control-dependent
 on any additional values.
 
-In languages designed for SPMD/SIMT programming model, e.g. OpenCL or CUDA,
-the call instructions of a function with this attribute must be executed by
-all work items or threads in a work group or sub group.
-
 This attribute is different from ``noduplicate`` because it allows duplicating
 function calls if it can be proved that the duplicated function calls are
 not made control-dependent on any additional values, e.g., unrolling a loop


### PR DESCRIPTION
The documentation for the `convergent` attribute claims that OpenCL and CUDA require "all threads" in a group to call the same convergent operation. This is true only for OpenCL, and in general, the `convergent` attribute is used in LLVM IR on operations that have no such constraint.