### PR TITLE
[libc][bazel] Remove a no-op libc_internal_target macro.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_build_rules.bzl
@@ -10,10 +10,6 @@ load(":libc_configure_options.bzl", "LIBC_CONFIGURE_OPTIONS")
 load(":libc_namespace.bzl", "LIBC_NAMESPACE")
 load(":platforms.bzl", "PLATFORM_CPU_X86_64")
 
-# TODO: Remove this helper function once all donwstream users are migrated.
-def libc_internal_target(name):
-    return name
-
 def libc_common_copts():
     root_label = Label(":libc")
     libc_include_path = paths.join(root_label.workspace_root, root_label.package)
@@ -84,10 +80,7 @@ def libc_function(name, **kwargs):
     # Builds "internal" library with a function, exposed as a C++ function in
     # the "LIBC_NAMESPACE" namespace. This allows us to test the function in the
     # presence of another libc.
-    _libc_library(
-        name = libc_internal_target(name),
-        **kwargs
-    )
+    _libc_library(name = name, **kwargs)
 
 LibcLibraryInfo = provider(
     "All source files and textual headers for building a particular library.",

--- a/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
@@ -12,26 +12,24 @@ They come in two flavors:
 When performing tests we make sure to always use the internal version.
 """
 
-load("//libc:libc_build_rules.bzl", "libc_common_copts", "libc_internal_target")
+load("//libc:libc_build_rules.bzl", "libc_common_copts")
 load("//libc:libc_configure_options.bzl", "LIBC_CONFIGURE_OPTIONS")
 
-def libc_test(name, srcs, libc_function_deps = [], copts = [], deps = [], local_defines = [], **kwargs):
+def libc_test(name, libc_function_deps = [], copts = [], deps = [], local_defines = [], **kwargs):
     """Add target for a libc test.
 
     Args:
       name: Test target name
-      srcs: List of sources for the test.
       libc_function_deps: List of libc_function targets used by this test.
       copts: The list of options to add to the C++ compilation command.
       deps: The list of other libraries to be linked in to the test target.
       local_defines: The list of target local_defines if any.
-      **kwargs: Attributes relevant for a libc_test. For example, name, srcs.
+      **kwargs: Attributes relevant for a cc_test.
     """
     native.cc_test(
         name = name,
-        srcs = srcs,
         local_defines = local_defines + LIBC_CONFIGURE_OPTIONS,
-        deps = [libc_internal_target(d) for d in libc_function_deps] + [
+        deps = [
             "//libc/test/UnitTest:LibcUnitTest",
             "//libc:__support_macros_config",
             "//libc:errno",
@@ -39,7 +37,7 @@ def libc_test(name, srcs, libc_function_deps = [], copts = [], deps = [], local_
             "//libc:func_free",
             "//libc:func_malloc",
             "//libc:func_realloc",
-        ] + deps,
+        ] + libc_function_deps + deps,
         copts = copts + libc_common_copts(),
         linkstatic = 1,
         **kwargs


### PR DESCRIPTION
This macro is a no-op after 90c001ac9e1d92a1a95d191d1640ab5337a937e5: libc_function macro now produce a "regular" cc_library target, without modifying its name, and this target is intended to only be used in tests.

Thus, libc_internal_target macro is no longer needed, and we can safely treat libc_function rules and libc_support_library rules identically for test purposes.

`libc_function_deps` attribute of a `libc_test` macro can also be cleaned up, but I plan to do this in a subsequent change.