### PR TITLE
[NFC][clang-tidy] Remove {{^}} clauses in some tests (2/N)

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/misplaced-operator-in-strlen-in-alloc.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/misplaced-operator-in-strlen-in-alloc.c
@@ -19,43 +19,43 @@ size_t wcsnlen_s(const wchar_t *, size_t);
 void bad_malloc(char *name) {
   char *new_name = (char *)malloc(strlen(name + 1));
   // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: addition operator is applied to the argument of strlen
-  // CHECK-FIXES: {{^  char \*new_name = \(char \*\)malloc\(}}strlen(name) + 1{{\);$}}
+  // CHECK-FIXES: char *new_name = (char *)malloc(strlen(name) + 1);
   new_name = (char *)malloc(strnlen(name + 1, 10));
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: addition operator is applied to the argument of strnlen
-  // CHECK-FIXES: {{^  new_name = \(char \*\)malloc\(}}strnlen(name, 10) + 1{{\);$}}
+  // CHECK-FIXES: new_name = (char *)malloc(strnlen(name, 10) + 1);
   new_name = (char *)malloc(strnlen_s(name + 1, 10));
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: addition operator is applied to the argument of strnlen_s
-  // CHECK-FIXES: {{^  new_name = \(char \*\)malloc\(}}strnlen_s(name, 10) + 1{{\);$}}
+  // CHECK-FIXES: new_name = (char *)malloc(strnlen_s(name, 10) + 1);
 }
 
 void bad_malloc_wide(wchar_t *name) {
   wchar_t *new_name = (wchar_t *)malloc(wcslen(name + 1));
   // CHECK-MESSAGES: :[[@LINE-1]]:34: warning: addition operator is applied to the argument of wcslen
-  // CHECK-FIXES: {{^  wchar_t \*new_name = \(wchar_t \*\)malloc\(}}wcslen(name) + 1{{\);$}}
+  // CHECK-FIXES: wchar_t *new_name = (wchar_t *)malloc(wcslen(name) + 1);
   new_name = (wchar_t *)malloc(wcsnlen(name + 1, 10));
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: addition operator is applied to the argument of wcsnlen
-  // CHECK-FIXES: {{^  new_name = \(wchar_t \*\)malloc\(}}wcsnlen(name, 10) + 1{{\);$}}
+  // CHECK-FIXES: new_name = (wchar_t *)malloc(wcsnlen(name, 10) + 1);
   new_name = (wchar_t *)malloc(wcsnlen_s(name + 1, 10));
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: addition operator is applied to the argument of wcsnlen_s
-  // CHECK-FIXES: {{^  new_name = \(wchar_t \*\)malloc\(}}wcsnlen_s(name, 10) + 1{{\);$}}
+  // CHECK-FIXES: new_name = (wchar_t *)malloc(wcsnlen_s(name, 10) + 1);
 }
 
 void bad_alloca(char *name) {
   char *new_name = (char *)alloca(strlen(name + 1));
   // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: addition operator is applied to the argument of strlen
-  // CHECK-FIXES: {{^  char \*new_name = \(char \*\)alloca\(}}strlen(name) + 1{{\);$}}
+  // CHECK-FIXES: char *new_name = (char *)alloca(strlen(name) + 1);
 }
 
 void bad_calloc(char *name) {
   char *new_names = (char *)calloc(2, strlen(name + 1));
   // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: addition operator is applied to the argument of strlen
-  // CHECK-FIXES: {{^  char \*new_names = \(char \*\)calloc\(2, }}strlen(name) + 1{{\);$}}
+  // CHECK-FIXES: char *new_names = (char *)calloc(2, strlen(name) + 1);
 }
 
 void bad_realloc(char *old_name, char *name) {
   char *new_name = (char *)realloc(old_name, strlen(name + 1));
   // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: addition operator is applied to the argument of strlen
-  // CHECK-FIXES: {{^  char \*new_name = \(char \*\)realloc\(old_name, }}strlen(name) + 1{{\);$}}
+  // CHECK-FIXES: char *new_name = (char *)realloc(old_name, strlen(name) + 1);
 }
 
 void intentional1(char *name) {
@@ -81,5 +81,5 @@ void (*(*const alloc_ptr)(size_t)) = malloc;
 void bad_indirect_alloc(char *name) {
   char *new_name = (char *)alloc_ptr(strlen(name + 1));
   // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: addition operator is applied to the argument of strlen
-  // CHECK-FIXES: {{^  char \*new_name = \(char \*\)alloc_ptr\(}}strlen(name) + 1{{\);$}}
+  // CHECK-FIXES: char *new_name = (char *)alloc_ptr(strlen(name) + 1);
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/google/explicit-constructor.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/explicit-constructor.cpp
@@ -44,20 +44,20 @@ struct A {
 
   explicit A(const A& a) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: copy constructor should not be declared explicit [google-explicit-constructor]
-  // CHECK-FIXES: {{^  }}A(const A& a) {}
+  // CHECK-FIXES: A(const A& a) {}
 
   A(int x1);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: single-argument constructors must be marked explicit to avoid unintentional implicit conversions [google-explicit-constructor]
-  // CHECK-FIXES: {{^  }}explicit A(int x1);
+  // CHECK-FIXES: explicit A(int x1);
 
   A(double x2, double y = 3.14) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: constructors that are callable with a single argument must be marked explicit to avoid unintentional implicit conversions [google-explicit-constructor]
-  // CHECK-FIXES: {{^  }}explicit A(double x2, double y = 3.14) {}
+  // CHECK-FIXES: explicit A(double x2, double y = 3.14) {}
 
   template <typename... T>
   A(T&&... args);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: constructors that are callable with a single argument
-  // CHECK-FIXES: {{^  }}explicit A(T&&... args);
+  // CHECK-FIXES: explicit A(T&&... args);
 };
 
 inline A::A(int x1) {}
@@ -69,23 +69,23 @@ struct B {
 
   operator bool() const { return true; }
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'operator bool' must be marked explicit to avoid unintentional implicit conversions [google-explicit-constructor]
-  // CHECK-FIXES: {{^  }}explicit operator bool() const { return true; }
+  // CHECK-FIXES: explicit operator bool() const { return true; }
 
   operator double() const;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'operator double' must be marked explicit to avoid unintentional implicit conversions [google-explicit-constructor]
-  // CHECK-FIXES: {{^  }}explicit operator double() const;
+  // CHECK-FIXES: explicit operator double() const;
 
   explicit B(::std::initializer_list<double> list4) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: initializer-list constructor should not be declared explicit [google-explicit-constructor]
-  // CHECK-FIXES: {{^  }}B(::std::initializer_list<double> list4) {}
+  // CHECK-FIXES: B(::std::initializer_list<double> list4) {}
 
   explicit B(const ::std::initializer_list<char> &list5) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: initializer-list constructor
-  // CHECK-FIXES: {{^  }}B(const ::std::initializer_list<char> &list5) {}
+  // CHECK-FIXES: B(const ::std::initializer_list<char> &list5) {}
 
   explicit B(::std::initializer_list<char> &&list6) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: initializer-list constructor
-  // CHECK-FIXES: {{^  }}B(::std::initializer_list<char> &&list6) {}
+  // CHECK-FIXES: B(::std::initializer_list<char> &&list6) {}
 };
 
 inline B::operator double() const { return 0.0; }
@@ -110,7 +110,7 @@ struct C2 {
 
   explicit C2(initializer_list<double> list4) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: initializer-list constructor
-  // CHECK-FIXES: {{^  }}C2(initializer_list<double> list4) {}
+  // CHECK-FIXES: C2(initializer_list<double> list4) {}
 };
 
 template <typename T>
@@ -132,11 +132,11 @@ template <typename T>
 struct E {
   E(T *pt) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: single-argument constructors
-  // CHECK-FIXES: {{^  }}explicit E(T *pt) {}
+  // CHECK-FIXES: explicit E(T *pt) {}
   template <typename U>
   E(U *pu) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: single-argument constructors
-  // CHECK-FIXES: {{^  }}explicit E(U *pu) {}
+  // CHECK-FIXES: explicit E(U *pu) {}
 
   explicit E(T t) {}
   template <typename U>
@@ -156,14 +156,14 @@ template<typename T>
 struct G {
   operator bool() const;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'operator bool' must be marked
-  // CHECK-FIXES: {{^}}  explicit operator bool() const;
+  // CHECK-FIXES: explicit operator bool() const;
   operator F<T>() const;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'operator F<type-parameter-0-0>' must be marked
-  // CHECK-FIXES: {{^}}  explicit operator F<T>() const;
+  // CHECK-FIXES: explicit operator F<T>() const;
   template<typename U>
   operator F<U>*() const;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'operator F<type-parameter-1-0> *' must be marked
-  // CHECK-FIXES: {{^}}  explicit operator F<U>*() const;
+  // CHECK-FIXES: explicit operator F<U>*() const;
 };
 
 void f2() {

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/definitions-in-headers.hpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/definitions-in-headers.hpp
@@ -203,4 +203,4 @@ constexpr bool f13<void, int> = false;
 
 int main() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: function 'main' defined in a header file;
-// CHECK-FIXES: {{^}}int main() {
+// CHECK-FIXES: int main() {}

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/static-assert.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/static-assert.c
@@ -13,15 +13,15 @@ void abort(void) {}
 void f(void) {
   int x = 1;
   assert(x == 0);
-  // CHECK-FIXES: {{^  }}assert(x == 0);
+  // CHECK-FIXES: assert(x == 0);
 
   #define static_assert(x, msg) _Static_assert(x, msg)
   assert(11 == 5 + 6);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() that could be
-  // CHECK-FIXES: {{^  }}static_assert(11 == 5 + 6, "");
+  // CHECK-FIXES: static_assert(11 == 5 + 6, "");
   #undef static_assert
 
   assert(10 == 5 + 5);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() that could be
-  // CHECK-FIXES: {{^  }}static_assert(10 == 5 + 5, "");
+  // CHECK-FIXES: static_assert(10 == 5 + 5, "");
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-alias-decls.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-alias-decls.cpp
@@ -6,7 +6,7 @@ class C {};
 
 namespace unused_alias = ::my_namespace; // eol-comments aren't removed (yet)
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: namespace alias decl 'unused_alias' is unused
-// CHECK-FIXES: {{^}}// eol-comments aren't removed (yet)
+// CHECK-FIXES: // eol-comments aren't removed (yet)
 
 namespace used_alias = ::my_namespace;
 void f() { used_alias::C c; }

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-using-decls.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-using-decls.cpp
@@ -82,13 +82,13 @@ T ff() { T t; return t; }
 using n::A; // A
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: using decl 'A' is unused
 // CHECK-MESSAGES: :[[@LINE-2]]:10: note: remove the using
-// CHECK-FIXES: {{^}}// A
+// CHECK-FIXES: // A
 using n::B;
 using n::C;
 using n::D;
 using n::E; // E
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: using decl 'E' is unused
-// CHECK-FIXES: {{^}}// E
+// CHECK-FIXES: // E
 using n::F;
 using n::G;
 using n::H;
@@ -103,10 +103,10 @@ using n::UsedFunc;
 using n::UsedTemplateFunc;
 using n::UnusedInstance; // UnusedInstance
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: using decl 'UnusedInstance' is unused
-// CHECK-FIXES: {{^}}// UnusedInstance
+// CHECK-FIXES: // UnusedInstance
 using n::UnusedFunc; // UnusedFunc
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: using decl 'UnusedFunc' is unused
-// CHECK-FIXES: {{^}}// UnusedFunc
+// CHECK-FIXES: // UnusedFunc
 using n::operator""_w;
 using n::cout;
 using n::endl;
@@ -120,7 +120,7 @@ template <typename T> void Callee() {
 
 using n::OverloadFunc; // OverloadFunc
 // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: using decl 'OverloadFunc' is unused
-// CHECK-FIXES: {{^}}// OverloadFunc
+// CHECK-FIXES: // OverloadFunc
 
 #define DEFINE_INT(name)        \
   namespace INT {               \

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/raw-string-literal-delimiter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/raw-string-literal-delimiter.cpp
@@ -2,8 +2,8 @@
 
 char const *const ContainsSentinel{"who\\ops)\""};
 // CHECK-MESSAGES: :[[@LINE-1]]:36: warning: {{.*}} can be written as a raw string literal
-// CHECK-FIXES: {{^}}char const *const ContainsSentinel{R"str(who\ops)")str"};{{$}}
+// CHECK-FIXES: char const *const ContainsSentinel{R"str(who\ops)")str"};
 
 //char const *const ContainsDelim{"whoops)\")lit\""};
 // CHECK-XMESSAGES: :[[@LINE-1]]:33: warning: {{.*}} can be written as a raw string literal
-// CHECK-XFIXES: {{^}}char const *const ContainsDelim{R"lit1(whoops)")lit")lit1"};{{$}}
+// CHECK-XFIXES: char const *const ContainsDelim{R"lit1(whoops)")lit")lit1"};

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/raw-string-literal-replace-shorter.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/raw-string-literal-replace-shorter.cpp
@@ -6,8 +6,8 @@ char const *const NeedDelimiter("\":)\"");
 
 char const *const ManyQuotes("quotes:\'\'\'\'");
 // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: {{.*}} can be written as a raw string literal
-// CHECK-FIXES: {{^}}char const *const ManyQuotes(R"(quotes:'''')");{{$}}
+// CHECK-FIXES: char const *const ManyQuotes(R"(quotes:'''')");
 
 char const *const LongOctal("\042\072\051\042");
 // CHECK-MESSAGES: :[[@LINE-1]]:29: warning: {{.*}} can be written as a raw string literal
-// CHECK-FIXES: {{^}}char const *const LongOctal(R"lit(":)")lit");{{$}}
+// CHECK-FIXES: char const *const LongOctal(R"lit(":)")lit");

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/shrink-to-fit.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/shrink-to-fit.cpp
@@ -9,17 +9,17 @@ void f() {
 
   std::vector<int>(v).swap(v);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: the shrink_to_fit method should be used to reduce the capacity of a shrinkable container [modernize-shrink-to-fit]
-  // CHECK-FIXES: {{^  }}v.shrink_to_fit();{{$}}
+  // CHECK-FIXES: v.shrink_to_fit();
 
   std::vector<int> &vref = v;
   std::vector<int>(vref).swap(vref);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: the shrink_to_fit method should
-  // CHECK-FIXES: {{^  }}vref.shrink_to_fit();{{$}}
+  // CHECK-FIXES: vref.shrink_to_fit();
 
   std::vector<int> *vptr = &v;
   std::vector<int>(*vptr).swap(*vptr);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: the shrink_to_fit method should
-  // CHECK-FIXES: {{^  }}vptr->shrink_to_fit();{{$}}
+  // CHECK-FIXES: vptr->shrink_to_fit();
 }
 
 struct X {
@@ -27,12 +27,12 @@ struct X {
   void f() {
     std::vector<int>(v).swap(v);
     // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: the shrink_to_fit method should
-    // CHECK-FIXES: {{^    }}v.shrink_to_fit();{{$}}
+    // CHECK-FIXES: v.shrink_to_fit();
 
     std::vector<int> *vptr = &v;
     std::vector<int>(*vptr).swap(*vptr);
     // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: the shrink_to_fit method should
-    // CHECK-FIXES: {{^    }}vptr->shrink_to_fit();{{$}}
+    // CHECK-FIXES: vptr->shrink_to_fit();
   }
 };
 
@@ -40,22 +40,22 @@ template <typename T> void g() {
   std::vector<int> v;
   std::vector<int>(v).swap(v);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: the shrink_to_fit method should
-  // CHECK-FIXES: {{^  }}v.shrink_to_fit();{{$}}
+  // CHECK-FIXES: v.shrink_to_fit();
 
   std::vector<T> v2;
   std::vector<T>(v2).swap(v2);
-  // CHECK-FIXES: {{^  }}std::vector<T>(v2).swap(v2);{{$}}
+  // CHECK-FIXES: std::vector<T>(v2).swap(v2);
 }
 
 template <typename T> void g2() {
   std::vector<int> v;
   std::vector<int>(v).swap(v);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: the shrink_to_fit method should
-  // CHECK-FIXES: {{^  }}v.shrink_to_fit();{{$}}
+  // CHECK-FIXES: v.shrink_to_fit();
 
   T v3;
   T(v3).swap(v3);
-  // CHECK-FIXES: {{^  }}T(v3).swap(v3);{{$}}
+  // CHECK-FIXES: T(v3).swap(v3);
 }
 
 #define COPY_AND_SWAP_INT_VEC(x) std::vector<int>(x).swap(x)
@@ -69,7 +69,7 @@ void h() {
   std::vector<int> v;
   COPY_AND_SWAP_INT_VEC(v);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: the shrink_to_fit method should
-  // CHECK-FIXES: {{^  }}COPY_AND_SWAP_INT_VEC(v);{{$}}
+  // CHECK-FIXES: COPY_AND_SWAP_INT_VEC(v);
 }
 
 void PR38315() {
@@ -77,11 +77,11 @@ void PR38315() {
   Vector v;
   Vector(v).swap(v);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: the shrink_to_fit method should
-  // CHECK-FIXES: {{^  }}v.shrink_to_fit();{{$}}
+  // CHECK-FIXES: v.shrink_to_fit();
 
   using Vector2 = std::vector<int>;
   Vector2 v2;
   Vector2(v2).swap(v2);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: the shrink_to_fit method should
-  // CHECK-FIXES: {{^  }}v2.shrink_to_fit();{{$}}
+  // CHECK-FIXES: v2.shrink_to_fit();
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-transparent-functors.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-transparent-functors.cpp
@@ -75,18 +75,18 @@ int main() {
   using std::less;
   std::set<int, std::less<int>> s;
   // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: prefer transparent functors 'less<>' [modernize-use-transparent-functors]
-  // CHECK-FIXES: {{^}}  std::set<int, std::less<>> s;{{$}}
+  // CHECK-FIXES: std::set<int, std::less<>> s;
   set<int, std::less<int>> s2;
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: prefer transparent functors
-  // CHECK-FIXES: {{^}}  set<int, std::less<>> s2;{{$}}
+  // CHECK-FIXES: set<int, std::less<>> s2;
   set<int, less<int>> s3;
   // CHECK-MESSAGES: :[[@LINE-1]]:12: warning: prefer transparent functors
-  // CHECK-FIXES: {{^}}  set<int, less<>> s3;{{$}}
+  // CHECK-FIXES: set<int, less<>> s3;
   std::set<int, std::less<>> s4;
   std::set<char *, std::less<std::string>> s5;
   std::set<set<int, less<int>>, std::less<>> s6;
   // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: prefer transparent functors
-  // CHECK-FIXES: {{^}}  std::set<set<int, less<>>, std::less<>> s6;{{$}}
+  // CHECK-FIXES: std::set<set<int, less<>>, std::less<>> s6;
   std::iterator begin, end;
   sort(begin, end, std::less<int>());
   // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: prefer transparent functors
@@ -96,7 +96,7 @@ int main() {
   std::find_if(begin, end, std::logical_not<>());
   using my_set = std::set<int, std::less<int>>;
   // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: prefer transparent functors
-  // CHECK-FIXES: {{^}}  using my_set = std::set<int, std::less<>>;{{$}}
+  // CHECK-FIXES: using my_set = std::set<int, std::less<>>;
   using my_set2 = std::set<char*, std::less<std::string>>;
   using my_less = std::less<std::string>;
   find_if(begin, end, my_less());

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-using.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy --match-partial-fixes %s modernize-use-using %t -- -- -fno-delayed-template-parsing -I %S/Inputs/use-using/
+// RUN: %check_clang_tidy %s modernize-use-using %t -- -- -fno-delayed-template-parsing -I %S/Inputs/use-using/
 
 typedef int Type;
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use 'using' instead of 'typedef' [modernize-use-using]
@@ -265,7 +265,7 @@ class Variadic {};
 
 typedef Variadic<Variadic<int, bool, Q<T{0 < 0}.b> >, S<(0 < 0), Variadic<Q<b[0 < 0]> > > > Variadic_t;
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use 'using' instead of 'typedef'
-// CHECK-FIXES: using Variadic_t = Variadic<Variadic<int, bool, Q<T{0 < 0}.b> >, S<(0 < 0), Variadic<Q<b[0 < 0]> > > >
+// CHECK-FIXES: using Variadic_t = Variadic<Variadic<int, bool, Q<T{0 < 0}.b> >, S<(0 < 0), Variadic<Q<b[0 < 0]> > > >;
 
 typedef Variadic<Variadic<int, bool, Q<T{0 < 0}.b> >, S<(0 < 0), Variadic<Q<b[0 < 0]> > > > Variadic_t, *Variadic_p;
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use 'using' instead of 'typedef'
@@ -319,8 +319,8 @@ typedef void (*ISSUE_65055_1)(int);
 typedef bool (*ISSUE_65055_2)(int);
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use 'using' instead of 'typedef'
 // CHECK-MESSAGES: :[[@LINE-2]]:1: warning: use 'using' instead of 'typedef'
-// CHECK-FIXES: {{^}}using ISSUE_65055_1 = void (*)(int);{{$}}
-// CHECK-FIXES: {{^}}using ISSUE_65055_2 = bool (*)(int);{{$}}
+// CHECK-FIXES: using ISSUE_65055_1 = void (*)(int);
+// CHECK-FIXES: using ISSUE_65055_2 = bool (*)(int);
 
 typedef class ISSUE_67529_1 *ISSUE_67529;
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use 'using' instead of 'typedef'


### PR DESCRIPTION

`check_clang_tidy` now matches full lines only, so `{{^}}` clauses are no longer necessary.

I am splitting those changes over multiple PRs to make review easier. Numbering them but the actual order doesn't matter.
