### PR TITLE
[NFC][clang-tidy] Remove {{^}} clauses in some tests (3/N)

### DIFF
--- a/clang-tools-extra/test/clang-tidy/checkers/abseil/string-find-startswith.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/abseil/string-find-startswith.cpp
@@ -29,67 +29,67 @@ std::string bar();
 void tests(std::string s, global_string s2, std::string_view sv) {
   s.find("a") == 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StartsWith instead of find() == 0 [abseil-string-find-startswith]
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StartsWith(s, "a");{{$}}
+  // CHECK-FIXES: absl::StartsWith(s, "a");
 
   s.find(s) == 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StartsWith
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StartsWith(s, s);{{$}}
+  // CHECK-FIXES: absl::StartsWith(s, s);
 
   s.find("aaa") != 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StartsWith
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StartsWith(s, "aaa");{{$}}
+  // CHECK-FIXES: !absl::StartsWith(s, "aaa");
 
   s.find(foo(foo(bar()))) != 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StartsWith
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StartsWith(s, foo(foo(bar())));{{$}}
+  // CHECK-FIXES: !absl::StartsWith(s, foo(foo(bar())));
 
   if (s.find("....") == 0) { /* do something */ }
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use absl::StartsWith
-  // CHECK-FIXES: {{^[[:space:]]*}}if (absl::StartsWith(s, "....")) { /* do something */ }{{$}}
+  // CHECK-FIXES: if (absl::StartsWith(s, "....")) { /* do something */ }
 
   0 != s.find("a");
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StartsWith
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StartsWith(s, "a");{{$}}
+  // CHECK-FIXES: !absl::StartsWith(s, "a");
 
   s2.find("a") == 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StartsWith
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StartsWith(s2, "a");{{$}}
+  // CHECK-FIXES: absl::StartsWith(s2, "a");
 
   s.rfind("a", 0) == 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StartsWith instead of rfind() == 0 [abseil-string-find-startswith]
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StartsWith(s, "a");{{$}}
+  // CHECK-FIXES: absl::StartsWith(s, "a");
 
   s.rfind(s, 0) == 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StartsWith
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StartsWith(s, s);{{$}}
+  // CHECK-FIXES: absl::StartsWith(s, s);
 
   s.rfind("aaa", 0) != 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StartsWith
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StartsWith(s, "aaa");{{$}}
+  // CHECK-FIXES: !absl::StartsWith(s, "aaa");
 
   s.rfind(foo(foo(bar())), 0) != 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StartsWith
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StartsWith(s, foo(foo(bar())));{{$}}
+  // CHECK-FIXES: !absl::StartsWith(s, foo(foo(bar())));
 
   if (s.rfind("....", 0) == 0) { /* do something */ }
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: use absl::StartsWith
-  // CHECK-FIXES: {{^[[:space:]]*}}if (absl::StartsWith(s, "....")) { /* do something */ }{{$}}
+  // CHECK-FIXES: if (absl::StartsWith(s, "....")) { /* do something */ }
 
   0 != s.rfind("a", 0);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StartsWith
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StartsWith(s, "a");{{$}}
+  // CHECK-FIXES: !absl::StartsWith(s, "a");
 
   s2.rfind("a", 0) == 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StartsWith
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StartsWith(s2, "a");{{$}}
+  // CHECK-FIXES: absl::StartsWith(s2, "a");
 
   sv.find("a") == 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use absl::StartsWith
-  // CHECK-FIXES: {{^[[:space:]]*}}absl::StartsWith(sv, "a");{{$}}
+  // CHECK-FIXES: absl::StartsWith(sv, "a");
 
   sv.rfind("a", 0) != 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use !absl::StartsWith
-  // CHECK-FIXES: {{^[[:space:]]*}}!absl::StartsWith(sv, "a");{{$}}
+  // CHECK-FIXES: !absl::StartsWith(sv, "a");
 
   // expressions that don't trigger the check are here.
   A_MACRO(s.find("a"), 0);

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/reserved-identifier-c.c
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/reserved-identifier-c.c
@@ -7,4 +7,4 @@ void f__o__o(void);
 void f_________oo(void);
 void __foo(void);
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: declaration uses identifier '__foo', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}void foo(void);{{$}}
+// CHECK-FIXES: void foo(void);

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/reserved-identifier.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/reserved-identifier.cpp
@@ -8,35 +8,35 @@
 
 #define _MACRO(m) int m = 0
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: declaration uses identifier '_MACRO', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}#define MACRO(m) int m = 0{{$}}
+// CHECK-FIXES: #define MACRO(m) int m = 0
 
 namespace _Ns {
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: declaration uses identifier '_Ns', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}namespace Ns {{{$}}
+// CHECK-FIXES: namespace Ns {
 
 class _Object {
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: declaration uses identifier '_Object', which is a reserved identifier [bugprone-reserved-identifier]
-  // CHECK-FIXES: {{^}}class Object {{{$}}
+  // CHECK-FIXES: class Object {
   int _Member;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: declaration uses identifier '_Member', which is a reserved identifier [bugprone-reserved-identifier]
-  // CHECK-FIXES: {{^}}  int Member;{{$}}
+  // CHECK-FIXES: int Member;
 };
 
 float _Global;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: declaration uses identifier '_Global', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}float Global;{{$}}
+// CHECK-FIXES: float Global;
 
 void _Function() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: declaration uses identifier '_Function', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}void Function() {}{{$}}
+// CHECK-FIXES: void Function() {}
 
 using _Alias = int;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: declaration uses identifier '_Alias', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}using Alias = int;{{$}}
+// CHECK-FIXES: using Alias = int;
 
 template <typename _TemplateParam>
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: declaration uses identifier '_TemplateParam', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}template <typename TemplateParam>{{$}}
+// CHECK-FIXES: template <typename TemplateParam>
 struct S {};
 
 } // namespace _Ns
@@ -45,34 +45,34 @@ struct S {};
 
 #define __macro(m) int m = 0
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: declaration uses identifier '__macro', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}#define _macro(m) int m = 0{{$}}
+// CHECK-FIXES: #define _macro(m) int m = 0
 
 namespace __ns {
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: declaration uses identifier '__ns', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}namespace ns {{{$}}
+// CHECK-FIXES: namespace ns {
 class __object {
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: declaration uses identifier '__object', which is a reserved identifier [bugprone-reserved-identifier]
-  // CHECK-FIXES: {{^}}class _object {{{$}}
+  // CHECK-FIXES: class _object {
   int __member;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: declaration uses identifier '__member', which is a reserved identifier [bugprone-reserved-identifier]
-  // CHECK-FIXES: {{^}}  int _member;{{$}}
+  // CHECK-FIXES: int _member;
 };
 
 float __global;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: declaration uses identifier '__global', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}float _global;{{$}}
+// CHECK-FIXES: float _global;
 
 void __function() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: declaration uses identifier '__function', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}void _function() {}{{$}}
+// CHECK-FIXES: void _function() {}
 
 using __alias = int;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: declaration uses identifier '__alias', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}using _alias = int;{{$}}
+// CHECK-FIXES: using _alias = int;
 
 template <typename __templateParam>
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: declaration uses identifier '__templateParam', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}template <typename _templateParam>{{$}}
+// CHECK-FIXES: template <typename _templateParam>
 struct S {};
 
 } // namespace __ns
@@ -81,34 +81,34 @@ struct S {};
 
 #define macro___m(m) int m = 0
 // CHECK-MESSAGES: :[[@LINE-1]]:9: warning: declaration uses identifier 'macro___m', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}#define macro_m(m) int m = 0{{$}}
+// CHECK-FIXES: #define macro_m(m) int m = 0
 
 namespace ns___n {
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: declaration uses identifier 'ns___n', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}namespace ns_n {{{$}}
+// CHECK-FIXES: namespace ns_n {
 class object___o {
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: declaration uses identifier 'object___o', which is a reserved identifier [bugprone-reserved-identifier]
-  // CHECK-FIXES: {{^}}class object_o {{{$}}
+  // CHECK-FIXES: class object_o {
   int member___m;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: declaration uses identifier 'member___m', which is a reserved identifier [bugprone-reserved-identifier]
-  // CHECK-FIXES: {{^}}  int member_m;{{$}}
+  // CHECK-FIXES: int member_m;
 };
 
 float global___g;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: declaration uses identifier 'global___g', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}float global_g;{{$}}
+// CHECK-FIXES: float global_g;
 
 void function___f() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: declaration uses identifier 'function___f', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}void function_f() {}{{$}}
+// CHECK-FIXES: void function_f() {}
 
 using alias___a = int;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: declaration uses identifier 'alias___a', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}using alias_a = int;{{$}}
+// CHECK-FIXES: using alias_a = int;
 
 template <typename templateParam___t>
 // CHECK-MESSAGES: :[[@LINE-1]]:20: warning: declaration uses identifier 'templateParam___t', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}template <typename templateParam_t>{{$}}
+// CHECK-FIXES: template <typename templateParam_t>
 struct S {};
 
 } // namespace ns___n
@@ -121,55 +121,55 @@ struct S {};
 
 namespace _ns {
 // CHECK-MESSAGES: :[[@LINE-1]]:11: warning: declaration uses identifier '_ns', which is reserved in the global namespace [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}namespace ns {{{$}}
+// CHECK-FIXES: namespace ns {
 int _i;
 // no warning
 } // namespace _ns
 class _object {
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: declaration uses identifier '_object', which is reserved in the global namespace [bugprone-reserved-identifier]
-  // CHECK-FIXES: {{^}}class object {{{$}}
+  // CHECK-FIXES: class object {
   int _member;
   // no warning
 };
 float _global;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: declaration uses identifier '_global', which is reserved in the global namespace [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}float global;{{$}}
+// CHECK-FIXES: float global;
 void _function() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: declaration uses identifier '_function', which is reserved in the global namespace [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}void function() {}{{$}}
+// CHECK-FIXES: void function() {}
 using _alias = int;
 // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: declaration uses identifier '_alias', which is reserved in the global namespace [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}using alias = int;{{$}}
+// CHECK-FIXES: using alias = int;
 template <typename _templateParam> // no warning, template params are not in the global namespace
 struct S {};
 
 void _float() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: declaration uses identifier '_float', which is reserved in the global namespace; cannot be fixed because 'float' would conflict with a keyword [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}void _float() {}{{$}}
+// CHECK-FIXES: void _float() {}
 
 #define SOME_MACRO
 int SOME__MACRO;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: declaration uses identifier 'SOME__MACRO', which is a reserved identifier; cannot be fixed because 'SOME_MACRO' would conflict with a macro definition [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}int SOME__MACRO;{{$}}
+// CHECK-FIXES: int SOME__MACRO;
 
 void _TWO__PROBLEMS() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: declaration uses identifier '_TWO__PROBLEMS', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}void TWO_PROBLEMS() {}{{$}}
+// CHECK-FIXES: void TWO_PROBLEMS() {}
 void _two__problems() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:6: warning: declaration uses identifier '_two__problems', which is a reserved identifier [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}void two_problems() {}{{$}}
+// CHECK-FIXES: void two_problems() {}
 
 int __;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: declaration uses identifier '__', which is a reserved identifier; cannot be fixed automatically [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}int __;{{$}}
+// CHECK-FIXES: int __;
 
 int _________;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: declaration uses identifier '_________', which is a reserved identifier; cannot be fixed automatically [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}int _________;{{$}}
+// CHECK-FIXES: int _________;
 
 int _;
 // CHECK-MESSAGES: :[[@LINE-1]]:5: warning: declaration uses identifier '_', which is reserved in the global namespace; cannot be fixed automatically [bugprone-reserved-identifier]
-// CHECK-FIXES: {{^}}int _;{{$}}
+// CHECK-FIXES: int _;
 
 // This should not trigger a warning
 // https://github.com/llvm/llvm-project/issues/52895

--- a/clang-tools-extra/test/clang-tidy/checkers/google/readability-casting.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/google/readability-casting.cpp
@@ -16,16 +16,16 @@ void f(int a, double b, const char *cpc, const void *cpv, X *pX) {
   Typedef1 t1;
   (Typedef2)t1;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: C-style casts are discouraged; use static_cast (if needed, the cast may be redundant) [google-readability-casting]
-  // CHECK-FIXES: {{^}}  static_cast<Typedef2>(t1);
+  // CHECK-FIXES: static_cast<Typedef2>(t1);
   (const char*)t1;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: {{.*}}; use static_cast (if needed
-  // CHECK-FIXES: {{^}}  static_cast<const char*>(t1);
+  // CHECK-FIXES: static_cast<const char*>(t1);
   (Typedef1)cpc;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: {{.*}}; use static_cast (if needed
-  // CHECK-FIXES: {{^}}  static_cast<Typedef1>(cpc);
+  // CHECK-FIXES: static_cast<Typedef1>(cpc);
   (Typedef1)t1;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: redundant cast to the same type
-  // CHECK-FIXES: {{^}}  t1;
+  // CHECK-FIXES: t1;
 
   char *pc = (char*)cpc;
   // CHECK-MESSAGES: :[[@LINE-1]]:14: warning: C-style casts are discouraged; use const_cast [google-readability-casting]
@@ -33,15 +33,15 @@ void f(int a, double b, const char *cpc, const void *cpv, X *pX) {
   typedef char Char;
   Char *pChar = (Char*)pc;
   // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: {{.*}}; use static_cast (if needed
-  // CHECK-FIXES: {{^}}  Char *pChar = static_cast<Char*>(pc);
+  // CHECK-FIXES: Char *pChar = static_cast<Char*>(pc);
 
   (Char)*cpc;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: {{.*}}; use static_cast (if needed
-  // CHECK-FIXES: {{^}}  static_cast<Char>(*cpc);
+  // CHECK-FIXES: static_cast<Char>(*cpc);
 
   (char)*pChar;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: {{.*}}; use static_cast (if needed
-  // CHECK-FIXES: {{^}}  static_cast<char>(*pChar);
+  // CHECK-FIXES: static_cast<char>(*pChar);
 
   (const char*)cpv;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: {{.*}}; use static_cast [
@@ -124,24 +124,24 @@ void f(int a, double b, const char *cpc, const void *cpv, X *pX) {
 
   e = (Enum)Enum1;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: redundant cast to the same type
-  // CHECK-FIXES: {{^}}  e = Enum1;
+  // CHECK-FIXES: e = Enum1;
 
   e = (Enum)e;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: redundant cast to the same type
-  // CHECK-FIXES: {{^}}  e = e;
+  // CHECK-FIXES: e = e;
 
   e = (Enum)           e;
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: redundant cast to the same type
-  // CHECK-FIXES: {{^}}  e = e;
+  // CHECK-FIXES: e = e;
 
   e = (Enum)           (e);
   // CHECK-MESSAGES: :[[@LINE-1]]:7: warning: redundant cast to the same type
-  // CHECK-FIXES: {{^}}  e = (e);
+  // CHECK-FIXES: e = (e);
 
   static const int kZero = 0;
   (int)kZero;
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: redundant cast to the same type
-  // CHECK-FIXES: {{^}}  kZero;
+  // CHECK-FIXES: kZero;
 
   int b2 = static_cast<double>(b);
   int b3 = b;

--- a/clang-tools-extra/test/clang-tidy/checkers/llvm/qualified-auto.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/llvm/qualified-auto.cpp
@@ -10,10 +10,10 @@ const int *getCIntPtr();
 void foo() {
   auto NakedPtr = getIntPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'auto NakedPtr' can be declared as 'auto *NakedPtr'
-  // CHECK-FIXES: {{^}}  auto *NakedPtr = getIntPtr();
+  // CHECK-FIXES: auto *NakedPtr = getIntPtr();
   auto NakedConstPtr = getCIntPtr();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: 'auto NakedConstPtr' can be declared as 'const auto *NakedConstPtr'
-  // CHECK-FIXES: {{^}}  const auto *NakedConstPtr = getCIntPtr();
+  // CHECK-FIXES: const auto *NakedConstPtr = getCIntPtr();
   auto *Ptr = getIntPtr();
   auto *ConstPtr = getCIntPtr();
   auto &NakedRef = *getIntPtr();

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/static-assert.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/static-assert.cpp
@@ -40,24 +40,24 @@ constexpr int Y = 1;
 void referenceConstexprVariable() {
   assert(Y > 0);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() that could be replaced by static_assert() [misc-static-assert]
-  // CHECK-FIXES-CXX11: {{^  }}static_assert(Y > 0, "");
-  // CHECK-FIXES-CXX17: {{^  }}static_assert(Y > 0);
+  // CHECK-FIXES-CXX11: static_assert(Y > 0, "");
+  // CHECK-FIXES-CXX17: static_assert(Y > 0);
 }
 
 void useInSizeOf() {
   char a = 0;
   assert(sizeof(a) == 1U);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() that could be replaced by static_assert() [misc-static-assert]
-  // CHECK-FIXES-CXX11: {{^  }}static_assert(sizeof(a) == 1U, "");
-  // CHECK-FIXES-CXX17: {{^  }}static_assert(sizeof(a) == 1U);
+  // CHECK-FIXES-CXX11: static_assert(sizeof(a) == 1U, "");
+  // CHECK-FIXES-CXX17: static_assert(sizeof(a) == 1U);
 }
 
 void useInDecltype() {
   char a = 0;
   assert(static_cast<decltype(a)>(256) == 0);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() that could be replaced by static_assert() [misc-static-assert]
-  // CHECK-FIXES-CXX11: {{^  }}static_assert(static_cast<decltype(a)>(256) == 0, "");
-  // CHECK-FIXES-CXX17: {{^  }}static_assert(static_cast<decltype(a)>(256) == 0);
+  // CHECK-FIXES-CXX11: static_assert(static_cast<decltype(a)>(256) == 0, "");
+  // CHECK-FIXES-CXX17: static_assert(static_cast<decltype(a)>(256) == 0);
 }
 
 }
@@ -80,11 +80,11 @@ public:
 template <class T> void doSomething(T t) {
   assert(myfunc(1, 2));
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() that could be replaced by static_assert() [misc-static-assert]
-  // CHECK-FIXES-CXX11: {{^  }}static_assert(myfunc(1, 2), "");
-  // CHECK-FIXES-CXX17: {{^  }}static_assert(myfunc(1, 2));
+  // CHECK-FIXES-CXX11: static_assert(myfunc(1, 2), "");
+  // CHECK-FIXES-CXX17: static_assert(myfunc(1, 2));
 
   assert(t.method());
-  // CHECK-FIXES: {{^  }}assert(t.method());
+  // CHECK-FIXES: assert(t.method());
 
   assert(sizeof(T) == 123);
 }
@@ -92,16 +92,16 @@ template <class T> void doSomething(T t) {
 int main() {
   my_macro();
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() that could be
-  // CHECK-FIXES: {{^  }}my_macro();
+  // CHECK-FIXES: my_macro();
 
   assert(myfunc(1, 2) && (3 == 4));
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() that could be
-  // CHECK-FIXES-CXX11: {{^  }}static_assert(myfunc(1, 2) && (3 == 4), "");
-  // CHECK-FIXES-CXX17: {{^  }}static_assert(myfunc(1, 2) && (3 == 4));
+  // CHECK-FIXES-CXX11: static_assert(myfunc(1, 2) && (3 == 4), "");
+  // CHECK-FIXES-CXX17: static_assert(myfunc(1, 2) && (3 == 4));
 
   int x = 1;
   assert(x == 0);
-  // CHECK-FIXES: {{^  }}assert(x == 0);
+  // CHECK-FIXES: assert(x == 0);
 
   A a;
   B b;
@@ -110,55 +110,55 @@ int main() {
   doSomething<B>(b);
 
   assert(false);
-  // CHECK-FIXES: {{^  }}assert(false);
+  // CHECK-FIXES: assert(false);
 
   assert(False);
-  // CHECK-FIXES: {{^  }}assert(False);
+  // CHECK-FIXES: assert(False);
   assert(FALSE);
-  // CHECK-FIXES: {{^  }}assert(FALSE);
+  // CHECK-FIXES: assert(FALSE);
 
   assert(ZERO_MACRO);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() that could be
-  // CHECK-FIXES-CXX11: {{^  }}static_assert(ZERO_MACRO, "");
-  // CHECK-FIXES-CXX17: {{^  }}static_assert(ZERO_MACRO);
+  // CHECK-FIXES-CXX11: static_assert(ZERO_MACRO, "");
+  // CHECK-FIXES-CXX17: static_assert(ZERO_MACRO);
 
   assert(!"Don't report me!");
-  // CHECK-FIXES: {{^  }}assert(!"Don't report me!");
+  // CHECK-FIXES: assert(!"Don't report me!");
 
   assert(0 && "Don't report me!");
-  // CHECK-FIXES: {{^  }}assert(0 && "Don't report me!");
+  // CHECK-FIXES: assert(0 && "Don't report me!");
 
   assert(false && "Don't report me!");
-  // CHECK-FIXES: {{^  }}assert(false && "Don't report me!");
+  // CHECK-FIXES: assert(false && "Don't report me!");
 
 #define NULL ((void*)0)
   assert(NULL && "Don't report me!");
-  // CHECK-FIXES: {{^  }}assert(NULL && "Don't report me!");
+  // CHECK-FIXES: assert(NULL && "Don't report me!");
 
   assert(NULL == "Don't report me!");
-  // CHECK-FIXES: {{^  }}assert(NULL == "Don't report me!");
+  // CHECK-FIXES: assert(NULL == "Don't report me!");
 
   assert("Don't report me!" == NULL);
-  // CHECK-FIXES: {{^  }}assert("Don't report me!" == NULL);
+  // CHECK-FIXES: assert("Don't report me!" == NULL);
 
   assert(0 == "Don't report me!");
-  // CHECK-FIXES: {{^  }}assert(0 == "Don't report me!");
+  // CHECK-FIXES: assert(0 == "Don't report me!");
 
 #define NULL ((unsigned int)0)
   assert(NULL && "Report me!");
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() that could be
-  // CHECK-FIXES: {{^  }}static_assert(NULL , "Report me!");
+  // CHECK-FIXES: static_assert(NULL , "Report me!");
 
 #define NULL __null
   assert(__null == "Don't report me!");
-  // CHECK-FIXES: {{^  }}assert(__null == "Don't report me!");
+  // CHECK-FIXES: assert(__null == "Don't report me!");
   assert(NULL == "Don't report me!");
-  // CHECK-FIXES: {{^  }}assert(NULL == "Don't report me!");
+  // CHECK-FIXES: assert(NULL == "Don't report me!");
 #undef NULL
 
   assert(ZERO_MACRO && "Report me!");
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() that could be
-  // CHECK-FIXES: {{^  }}static_assert(ZERO_MACRO , "Report me!");
+  // CHECK-FIXES: static_assert(ZERO_MACRO , "Report me!");
 
   assert(0);
 
@@ -171,19 +171,19 @@ int main() {
 
   assert(10==5 && "Report me!");
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() that could be
-  // CHECK-FIXES: {{^  }}static_assert(10==5 , "Report me!");
+  // CHECK-FIXES: static_assert(10==5 , "Report me!");
 
   assert(strlen("12345") == 5);
-  // CHECK-FIXES: {{^  }}assert(strlen("12345") == 5);
+  // CHECK-FIXES: assert(strlen("12345") == 5);
 
 #define assert(e) (__builtin_expect(!(e), 0) ? print (#e, __FILE__, __LINE__) : (void)0)
   assert(false);
-  // CHECK-FIXES: {{^  }}assert(false);
+  // CHECK-FIXES: assert(false);
 
   assert(10 == 5 + 5);
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: found assert() that could be
-  // CHECK-FIXES-CXX11: {{^  }}static_assert(10 == 5 + 5, "");
-  // CHECK-FIXES-CXX17: {{^  }}static_assert(10 == 5 + 5);
+  // CHECK-FIXES-CXX11: static_assert(10 == 5 + 5, "");
+  // CHECK-FIXES-CXX17: static_assert(10 == 5 + 5);
 #undef assert
 
   return 0;

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/make-unique-macros.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/make-unique-macros.cpp
@@ -7,19 +7,19 @@
 class Foo {};
 class Bar {};
 #define DEFINE(...) __VA_ARGS__
-// CHECK-FIXES: {{^}}#define DEFINE(...) __VA_ARGS__{{$}}
+// CHECK-FIXES: #define DEFINE(...) __VA_ARGS__
 template<typename T>
 void g2(std::unique_ptr<Foo> *t) {
   DEFINE(
-  // CHECK-FIXES: {{^ *}}DEFINE({{$}}
+  // CHECK-FIXES: DEFINE(
       auto p = std::unique_ptr<Foo>(new Foo);
       // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: use std::make_unique instead
-      // CHECK-FIXES: {{^ *}}auto p = std::unique_ptr<Foo>(new Foo);{{$}}
+      // CHECK-FIXES: auto p = std::unique_ptr<Foo>(new Foo);
       t->reset(new Foo);
       // CHECK-MESSAGES: :[[@LINE-1]]:10: warning: use std::make_unique instead
-      // CHECK-FIXES: {{^ *}}t->reset(new Foo);{{$}}
+      // CHECK-FIXES: t->reset(new Foo);
       );
-      // CHECK-FIXES: {{^ *}});{{$}}
+      // CHECK-FIXES: );
 }
 void macro() {
   std::unique_ptr<Foo> *t;

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/unary-static-assert.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/unary-static-assert.cpp
@@ -6,11 +6,11 @@
 void f_textless(int a) {
   static_assert(sizeof(a) <= 10, "");
   // CHECK-MESSAGES: :[[@LINE-1]]:3: warning: use unary 'static_assert' when the string literal is an empty string [modernize-unary-static-assert]
-  // CHECK-FIXES: {{^}}  static_assert(sizeof(a) <= 10 );{{$}}
+  // CHECK-FIXES: static_assert(sizeof(a) <= 10 );
   FOO
-  // CHECK-FIXES: {{^}}  FOO{{$}}
+  // CHECK-FIXES: FOO
   static_assert(sizeof(a) <= 17, MSG);
-  // CHECK-FIXES: {{^}}  static_assert(sizeof(a) <= 17, MSG);{{$}}
+  // CHECK-FIXES: static_assert(sizeof(a) <= 17, MSG);
 }
 
 void f_with_tex(int a) {

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-bool-literals-ignore-macros.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-bool-literals-ignore-macros.cpp
@@ -5,41 +5,41 @@
 
 bool IntToTrue = 1;
 // CHECK-MESSAGES: :[[@LINE-1]]:18: warning: converting integer literal to bool, use bool literal instead [modernize-use-bool-literals]
-// CHECK-FIXES: {{^}}bool IntToTrue = true;{{$}}
+// CHECK-FIXES: bool IntToTrue = true;
 
 bool IntToFalse(0);
 // CHECK-MESSAGES: :[[@LINE-1]]:17: warning: converting integer literal to bool
-// CHECK-FIXES: {{^}}bool IntToFalse(false);{{$}}
+// CHECK-FIXES: bool IntToFalse(false);
 
 bool LongLongToTrue{0x1LL};
 // CHECK-MESSAGES: :[[@LINE-1]]:21: warning: converting integer literal to bool
-// CHECK-FIXES: {{^}}bool LongLongToTrue{true};{{$}}
+// CHECK-FIXES: bool LongLongToTrue{true};
 
 bool ExplicitCStyleIntToFalse = (bool)0;
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: converting integer literal to bool
-// CHECK-FIXES: {{^}}bool ExplicitCStyleIntToFalse = false;{{$}}
+// CHECK-FIXES: bool ExplicitCStyleIntToFalse = false;
 
 bool ExplicitFunctionalIntToFalse = bool(0);
 // CHECK-MESSAGES: :[[@LINE-1]]:37: warning: converting integer literal to bool
-// CHECK-FIXES: {{^}}bool ExplicitFunctionalIntToFalse = false;{{$}}
+// CHECK-FIXES: bool ExplicitFunctionalIntToFalse = false;
 
 bool ExplicitStaticIntToFalse = static_cast<bool>(0);
 // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: converting integer literal to bool
-// CHECK-FIXES: {{^}}bool ExplicitStaticIntToFalse = false;{{$}}
+// CHECK-FIXES: bool ExplicitStaticIntToFalse = false;
 
 #define TRUE_MACRO 1
-// CHECK-FIXES: {{^}}#define TRUE_MACRO 1{{$}}
+// CHECK-FIXES: #define TRUE_MACRO 1
 
 bool MacroIntToTrue = TRUE_MACRO;
-// CHECK-FIXES: {{^}}bool MacroIntToTrue = TRUE_MACRO;{{$}}
+// CHECK-FIXES: bool MacroIntToTrue = TRUE_MACRO;
 
 #define FALSE_MACRO bool(0)
-// CHECK-FIXES: {{^}}#define FALSE_MACRO bool(0){{$}}
+// CHECK-FIXES: #define FALSE_MACRO bool(0)
 
 bool TrueBool = true; // OK
 
 bool FalseBool = bool(FALSE_MACRO);
-// CHECK-FIXES: {{^}}bool FalseBool = bool(FALSE_MACRO);{{$}}
+// CHECK-FIXES: bool FalseBool = bool(FALSE_MACRO);
 
 void boolFunction(bool bar) {
 
@@ -50,56 +50,56 @@ char Character = 0; // OK
 unsigned long long LongInteger = 1; // OK
 
 #define MACRO_DEPENDENT_CAST(x) static_cast<bool>(x)
-// CHECK-FIXES: {{^}}#define MACRO_DEPENDENT_CAST(x) static_cast<bool>(x){{$}}
+// CHECK-FIXES: #define MACRO_DEPENDENT_CAST(x) static_cast<bool>(x)
 
 bool MacroDependentBool = MACRO_DEPENDENT_CAST(0);
-// CHECK-FIXES: {{^}}bool MacroDependentBool = MACRO_DEPENDENT_CAST(0);{{$}}
+// CHECK-FIXES: bool MacroDependentBool = MACRO_DEPENDENT_CAST(0);
 
 bool ManyMacrosDependent = MACRO_DEPENDENT_CAST(FALSE_MACRO);
-// CHECK-FIXES: {{^}}bool ManyMacrosDependent = MACRO_DEPENDENT_CAST(FALSE_MACRO);{{$}}
+// CHECK-FIXES: bool ManyMacrosDependent = MACRO_DEPENDENT_CAST(FALSE_MACRO);
 
 class FooClass {
   public:
   FooClass() : JustBool(0) {}
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}FooClass() : JustBool(false) {}{{$}}
+  // CHECK-FIXES: FooClass() : JustBool(false) {}
   FooClass(int) : JustBool{0} {}
   // CHECK-MESSAGES: :[[@LINE-1]]:28: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}FooClass(int) : JustBool{false} {}{{$}}
+  // CHECK-FIXES: FooClass(int) : JustBool{false} {}
   private:
   bool JustBool;
   bool BoolWithBraces{0};
   // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}bool BoolWithBraces{false};{{$}}
+  // CHECK-FIXES: bool BoolWithBraces{false};
   bool BoolFromInt = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:22: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}bool BoolFromInt = false;{{$}}
+  // CHECK-FIXES: bool BoolFromInt = false;
   bool SimpleBool = true; // OK
 };
 
 template<typename type>
 void templateFunction(type) {
   type TemplateType = 0;
-  // CHECK-FIXES: {{^ *}}type TemplateType = 0;{{$}}
+  // CHECK-FIXES: type TemplateType = 0;
 }
 
 template<int c>
 void valueDependentTemplateFunction() {
   bool Boolean = c;
-  // CHECK-FIXES: {{^ *}}bool Boolean = c;{{$}}
+  // CHECK-FIXES: bool Boolean = c;
 }
 
 template<typename type>
 void anotherTemplateFunction(type) {
   bool JustBool = 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:19: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}bool JustBool = false;{{$}}
+  // CHECK-FIXES: bool JustBool = false;
 }
 
 int main() {
   boolFunction(1);
   // CHECK-MESSAGES: :[[@LINE-1]]:16: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}boolFunction(true);{{$}}
+  // CHECK-FIXES: boolFunction(true);
 
   boolFunction(false);
 
@@ -113,7 +113,7 @@ int main() {
 
   IntToTrue = 1;
   // CHECK-MESSAGES: :[[@LINE-1]]:15: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}IntToTrue = true;{{$}}
+  // CHECK-FIXES: IntToTrue = true;
 }
 
 static int Value = 1;
@@ -122,7 +122,7 @@ bool Function1() {
   bool Result = Value == 1 ? 1 : 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: converting integer literal to bool
   // CHECK-MESSAGES: :[[@LINE-2]]:34: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}bool Result = Value == 1 ? true : false;{{$}}
+  // CHECK-FIXES: bool Result = Value == 1 ? true : false;
   return Result;
 }
 
@@ -130,18 +130,18 @@ bool Function2() {
   return Value == 1 ? 1 : 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:23: warning: converting integer literal to bool
   // CHECK-MESSAGES: :[[@LINE-2]]:27: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}return Value == 1 ? true : false;{{$}}
+  // CHECK-FIXES: return Value == 1 ? true : false;
 }
 
 void foo() {
   bool Result;
   Result = Value == 1 ? true : 0;
   // CHECK-MESSAGES: :[[@LINE-1]]:32: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}Result = Value == 1 ? true : false;{{$}}
+  // CHECK-FIXES: Result = Value == 1 ? true : false;
   Result = Value == 1 ? false : bool(0);
   // CHECK-MESSAGES: :[[@LINE-1]]:33: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}Result = Value == 1 ? false : false;{{$}}
+  // CHECK-FIXES: Result = Value == 1 ? false : false;
   Result = Value == 1 ? (bool)0 : false;
   // CHECK-MESSAGES: :[[@LINE-1]]:25: warning: converting integer literal to bool
-  // CHECK-FIXES: {{^ *}}Result = Value == 1 ? false : false;{{$}}
+  // CHECK-FIXES: Result = Value == 1 ? false : false;
 }

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-cxx98.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-override-cxx98.cpp
@@ -9,11 +9,11 @@ struct Base {
 struct SimpleCases : public Base {
 public:
   virtual ~SimpleCases();
-  // CHECK-FIXES: {{^}}  virtual ~SimpleCases();
+  // CHECK-FIXES: virtual ~SimpleCases();
 
   void a();
-  // CHECK-FIXES: {{^}}  void a();
+  // CHECK-FIXES: void a();
 
   virtual void b();
-  // CHECK-FIXES: {{^}}  virtual void b();
+  // CHECK-FIXES: virtual void b();
 };


### PR DESCRIPTION

`check_clang_tidy` now matches full lines only, so `{{^}}` clauses are no longer necessary.

I am splitting those changes over multiple PRs to make review easier. Numbering them but the actual order doesn't matter.
