### PR TITLE
[HLSL][OpenCL] Strip addrspace from implicit cast diags

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -11360,6 +11360,14 @@ static void AnalyzeAssignment(Sema &S, BinaryOperator *E) {
 static void DiagnoseImpCast(Sema &S, Expr *E, QualType SourceType, QualType T,
                             SourceLocation CContext, unsigned diag,
                             bool pruneControlFlow = false) {
+  // For languages like HLSL and OpenCL, implicit conversion diagnostics listing
+  // address space annotations isn't really useful. The warnings aren't because
+  // you're converting a `private int` to `unsigned int`, it is because you're
+  // conerting `int` to `unsigned int`.
+  if (SourceType.hasAddressSpace())
+    SourceType = S.getASTContext().removeAddrSpaceQualType(SourceType);
+  if (T.hasAddressSpace())
+    T = S.getASTContext().removeAddrSpaceQualType(T);
   if (pruneControlFlow) {
     S.DiagRuntimeBehavior(E->getExprLoc(), E,
                           S.PDiag(diag)

--- a/clang/test/SemaHLSL/Language/ImpCastAddrSpace.hlsl
+++ b/clang/test/SemaHLSL/Language/ImpCastAddrSpace.hlsl
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -finclude-default-header -Wconversion -fnative-half-type %s -verify
+
+static double D = 2.0;
+static int I = D; // expected-warning{{implicit conversion turns floating-point number into integer: 'double' to 'int'}}
+groupshared float F = I; // expected-warning{{implicit conversion from 'int' to 'float' may lose precision}}
+
+export void fn() {
+  half d = I; // expected-warning{{implicit conversion from 'int' to 'half' may lose precision}}
+  int i = D; // expected-warning{{implicit conversion turns floating-point number into integer: 'double' to 'int'}}
+  int j = F; // expected-warning{{implicit conversion turns floating-point number into integer: 'float' to 'int'}}
+  int k = d; // expected-warning{{implicit conversion turns floating-point number into integer: 'half' to 'int'}}
+}

--- a/clang/test/SemaOpenCL/cl20-device-side-enqueue.cl
+++ b/clang/test/SemaOpenCL/cl20-device-side-enqueue.cl
@@ -97,7 +97,7 @@ kernel void enqueue_kernel_tests(void) {
                  },
                  c, 1024L);
 #ifdef WCONV
-// expected-warning-re@-2{{implicit conversion changes signedness: '__private char' to 'unsigned {{int|long}}'}}
+// expected-warning-re@-2{{implicit conversion changes signedness: 'char' to 'unsigned {{int|long}}'}}
 #endif
 #define UINT_MAX 4294967295
 


### PR DESCRIPTION
The address space of a source value for an implicit cast isn't really relevant when emitting conversion warnings. Since the lvalue->rvalue cast effectively removes the address space they don't factor in, but they do create visual noise in the diagnostics.

This is a small quality-of-life fixup to get in as HLSL adopts more address space annotations.