### PR TITLE
[libc][bazel] Fold "libc_function_deps" into "deps" for libc_tests.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/test/libc_test_rules.bzl
@@ -15,14 +15,13 @@ When performing tests we make sure to always use the internal version.
 load("//libc:libc_build_rules.bzl", "libc_common_copts")
 load("//libc:libc_configure_options.bzl", "LIBC_CONFIGURE_OPTIONS")
 
-def libc_test(name, libc_function_deps = [], copts = [], deps = [], local_defines = [], **kwargs):
+def libc_test(name, copts = [], deps = [], local_defines = [], **kwargs):
     """Add target for a libc test.
 
     Args:
       name: Test target name
-      libc_function_deps: List of libc_function targets used by this test.
       copts: The list of options to add to the C++ compilation command.
-      deps: The list of other libraries to be linked in to the test target.
+      deps: The list of libc functions and libraries to be linked in.
       local_defines: The list of target local_defines if any.
       **kwargs: Attributes relevant for a cc_test.
     """
@@ -37,7 +36,7 @@ def libc_test(name, libc_function_deps = [], copts = [], deps = [], local_define
             "//libc:func_free",
             "//libc:func_malloc",
             "//libc:func_realloc",
-        ] + libc_function_deps + deps,
+        ] + deps,
         copts = copts + libc_common_copts(),
         linkstatic = 1,
         **kwargs

--- a/utils/bazel/llvm-project-overlay/libc/test/src/complex/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/complex/BUILD.bazel
@@ -7,8 +7,7 @@ load("//libc/test:libc_test_rules.bzl", "libc_test")
             "CImagTest.h",
             func_name + "_test.cpp",
         ],
-        libc_function_deps = ["//libc:func_name".replace("func_name", func_name)],
-        deps = [
+        deps = ["//libc:func_name".replace("func_name", func_name)] + [
             "//libc:hdr_math_macros",
             "//libc/test/UnitTest:fp_test_helpers",
         ],
@@ -29,8 +28,7 @@ load("//libc/test:libc_test_rules.bzl", "libc_test")
             "ConjTest.h",
             func_name + "_test.cpp",
         ],
-        libc_function_deps = ["//libc:func_name".replace("func_name", func_name)],
-        deps = [
+        deps = ["//libc:func_name".replace("func_name", func_name)] + [
             "//libc:hdr_math_macros",
             "//libc/test/UnitTest:fp_test_helpers",
         ],
@@ -51,8 +49,7 @@ load("//libc/test:libc_test_rules.bzl", "libc_test")
             "CprojTest.h",
             func_name + "_test.cpp",
         ],
-        libc_function_deps = ["//libc:func_name".replace("func_name", func_name)],
-        deps = [
+        deps = ["//libc:func_name".replace("func_name", func_name)] + [
             "//libc:hdr_math_macros",
             "//libc/test/UnitTest:fp_test_helpers",
         ] + (["//libc/utils/MPCWrapper:mpc_wrapper"] if func_name == "cprojf" else []),
@@ -73,8 +70,7 @@ load("//libc/test:libc_test_rules.bzl", "libc_test")
             "CRealTest.h",
             func_name + "_test.cpp",
         ],
-        libc_function_deps = ["//libc:func_name".replace("func_name", func_name)],
-        deps = [
+        deps = ["//libc:func_name".replace("func_name", func_name)] + [
             "//libc:hdr_math_macros",
             "//libc/test/UnitTest:fp_test_helpers",
         ],

--- a/utils/bazel/llvm-project-overlay/libc/test/src/fenv/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/fenv/BUILD.bazel
@@ -16,14 +16,12 @@ libc_test(
         "exception_status_test.cpp",
         "excepts.h",
     ],
-    libc_function_deps = [
+    deps = [
+        "//libc:__support_fputil_fenv_impl",
         "//libc:feclearexcept",
         "//libc:feraiseexcept",
         "//libc:fesetexcept",
         "//libc:fetestexcept",
-    ],
-    deps = [
-        "//libc:__support_fputil_fenv_impl",
         "//libc:hdr_fenv_macros",
         "//libc/test/UnitTest:fp_test_helpers",
     ],
@@ -35,11 +33,9 @@ libc_test(
         "excepts.h",
         "rounding_mode_test.cpp",
     ],
-    libc_function_deps = [
+    deps = [
         "//libc:fegetround",
         "//libc:fesetround",
-    ],
-    deps = [
         "//libc:hdr_fenv_macros",
         "//libc/test/UnitTest:fp_test_helpers",
     ],
@@ -51,16 +47,14 @@ libc_test(
         "enabled_exceptions_test.cpp",
         "excepts.h",
     ],
-    libc_function_deps = [
-        "//libc:feclearexcept",
-        "//libc:feraiseexcept",
-        "//libc:fetestexcept",
-    ],
     tags = ["nosan"],
     deps = [
         "//libc:__support_common",
         "//libc:__support_fputil_fenv_impl",
         "//libc:__support_macros_properties_architectures",
+        "//libc:feclearexcept",
+        "//libc:feraiseexcept",
+        "//libc:fetestexcept",
         "//libc:hdr_fenv_macros",
         "//libc/test/UnitTest:fp_test_helpers",
     ],
@@ -72,14 +66,12 @@ libc_test(
         "excepts.h",
         "feholdexcept_test.cpp",
     ],
-    libc_function_deps = [
-        "//libc:feholdexcept",
-    ],
     tags = ["nosan"],
     deps = [
         "//libc:__support_common",
         "//libc:__support_fputil_fenv_impl",
         "//libc:__support_macros_properties_architectures",
+        "//libc:feholdexcept",
         "//libc:hdr_fenv_macros",
         "//libc:types_fenv_t",
         "//libc/test/UnitTest:fp_test_helpers",
@@ -92,13 +84,11 @@ libc_test(
         "exception_flags_test.cpp",
         "excepts.h",
     ],
-    libc_function_deps = [
+    deps = [
+        "//libc:__support_fputil_fenv_impl",
         "//libc:fegetexceptflag",
         "//libc:fesetexceptflag",
         "//libc:fetestexceptflag",
-    ],
-    deps = [
-        "//libc:__support_fputil_fenv_impl",
         "//libc:hdr_fenv_macros",
         "//libc:types_fexcept_t",
         "//libc/test/UnitTest:fp_test_helpers",
@@ -111,11 +101,9 @@ libc_test(
         "excepts.h",
         "feclearexcept_test.cpp",
     ],
-    libc_function_deps = [
-        "//libc:feclearexcept",
-    ],
     deps = [
         "//libc:__support_fputil_fenv_impl",
+        "//libc:feclearexcept",
         "//libc:hdr_fenv_macros",
         "//libc/test/UnitTest:fp_test_helpers",
     ],
@@ -127,14 +115,12 @@ libc_test(
         "excepts.h",
         "feenableexcept_test.cpp",
     ],
-    libc_function_deps = [
-        "//libc:fedisableexcept",
-        "//libc:feenableexcept",
-        "//libc:fegetexcept",
-    ],
     deps = [
         "//libc:__support_common",
         "//libc:__support_macros_properties_architectures",
+        "//libc:fedisableexcept",
+        "//libc:feenableexcept",
+        "//libc:fegetexcept",
         "//libc:hdr_fenv_macros",
         "//libc/test/UnitTest:fp_test_helpers",
     ],
@@ -146,11 +132,9 @@ libc_test(
         "excepts.h",
         "feupdateenv_test.cpp",
     ],
-    libc_function_deps = [
-        "//libc:feupdateenv",
-    ],
     deps = [
         "//libc:__support_fputil_fenv_impl",
+        "//libc:feupdateenv",
         "//libc:hdr_fenv_macros",
         "//libc:types_fenv_t",
         "//libc/test/UnitTest:fp_test_helpers",
@@ -163,15 +147,13 @@ libc_test(
         "excepts.h",
         "getenv_and_setenv_test.cpp",
     ],
-    libc_function_deps = [
+    deps = [
+        "//libc:__support_fputil_fenv_impl",
+        "//libc:__support_macros_properties_os",
         "//libc:fegetenv",
         "//libc:fegetround",
         "//libc:fesetenv",
         "//libc:fesetround",
-    ],
-    deps = [
-        "//libc:__support_fputil_fenv_impl",
-        "//libc:__support_macros_properties_os",
         "//libc:hdr_fenv_macros",
         "//libc:types_fenv_t",
         "//libc/test/UnitTest:fp_test_helpers",

--- a/utils/bazel/llvm-project-overlay/libc/test/src/inttypes/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/inttypes/BUILD.bazel
@@ -13,7 +13,7 @@ licenses(["notice"])
 libc_test(
     name = "imaxabs_test",
     srcs = ["imaxabs_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:imaxabs",
     ],
 )
@@ -21,10 +21,8 @@ libc_test(
 libc_test(
     name = "imaxdiv_test",
     srcs = ["imaxdiv_test.cpp"],
-    libc_function_deps = [
-        "//libc:imaxdiv",
-    ],
     deps = [
+        "//libc:imaxdiv",
         "//libc/test/src/stdlib:div_test_helper",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/libc_math_test_rules.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/libc_math_test_rules.bzl
@@ -23,8 +23,7 @@ def math_test(name, hdrs = [], deps = [], **kwargs):
     libc_test(
         name = test_name,
         srcs = [test_name + ".cpp"] + hdrs,
-        libc_function_deps = ["//libc:func_name".replace("func_name", name)],
-        deps = [
+        deps = ["//libc:func_name".replace("func_name", name)] + [
             "//libc:__support_cpp_algorithm",
             "//libc:__support_cpp_bit",
             "//libc:__support_cpp_limits",

--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdbit/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdbit/BUILD.bazel
@@ -39,11 +39,12 @@ bit_prefix_list = [
     libc_test(
         name = bit_prefix + bit_suffix + "_test",
         srcs = [bit_prefix + bit_suffix + "_test.cpp"],
-        libc_function_deps = ["//libc:func_name".replace(
-            "func_name",
-            bit_prefix + bit_suffix,
-        )],
-        deps = ["//libc:__support_cpp_limits"],
+        deps = [
+            "//libc:func_name".replace(
+                "func_name",
+                bit_prefix + bit_suffix,
+            ),
+        ] + ["//libc:__support_cpp_limits"],
     )
     for bit_prefix in bit_prefix_list
     for bit_suffix in bit_suffix_list

--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdio/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdio/BUILD.bazel
@@ -13,8 +13,6 @@ licenses(["notice"])
 libc_test(
     name = "printf_parser_test",
     srcs = ["printf_core/parser_test.cpp"],
-    libc_function_deps = [
-    ],
     deps = [
         "//libc:__support_arg_list",
         "//libc:__support_cpp_bit",
@@ -28,8 +26,6 @@ libc_test(
 libc_test(
     name = "printf_writer_test",
     srcs = ["printf_core/writer_test.cpp"],
-    libc_function_deps = [
-    ],
     deps = [
         "//libc:__support_arg_list",
         "//libc:__support_cpp_string_view",
@@ -42,8 +38,6 @@ libc_test(
 libc_test(
     name = "printf_converter_test",
     srcs = ["printf_core/converter_test.cpp"],
-    libc_function_deps = [
-    ],
     deps = [
         "//libc:__support_arg_list",
         "//libc:__support_cpp_string_view",
@@ -56,11 +50,9 @@ libc_test(
 libc_test(
     name = "sprintf_test",
     srcs = ["sprintf_test.cpp"],
-    libc_function_deps = [
-        "//libc:sprintf",
-    ],
     deps = [
         "//libc:__support_fputil_fp_bits",
+        "//libc:sprintf",
         "//libc/test/UnitTest:fp_test_helpers",
     ],
 )
@@ -68,7 +60,7 @@ libc_test(
 libc_test(
     name = "snprintf_test",
     srcs = ["snprintf_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:snprintf",
     ],
 )
@@ -76,7 +68,7 @@ libc_test(
 libc_test(
     name = "printf_test",
     srcs = ["printf_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:printf",
     ],
 )
@@ -84,7 +76,7 @@ libc_test(
 libc_test(
     name = "fprintf_test",
     srcs = ["fprintf_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:fprintf",
     ],
 )
@@ -92,7 +84,7 @@ libc_test(
 libc_test(
     name = "vsprintf_test",
     srcs = ["vsprintf_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:vsprintf",
     ],
 )
@@ -100,7 +92,7 @@ libc_test(
 libc_test(
     name = "vsnprintf_test",
     srcs = ["vsnprintf_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:vsnprintf",
     ],
 )
@@ -108,7 +100,7 @@ libc_test(
 libc_test(
     name = "vprintf_test",
     srcs = ["vprintf_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:vprintf",
     ],
 )
@@ -116,7 +108,7 @@ libc_test(
 libc_test(
     name = "vfprintf_test",
     srcs = ["vfprintf_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:vfprintf",
     ],
 )
@@ -124,25 +116,23 @@ libc_test(
 libc_test(
     name = "remove_test",
     srcs = ["remove_test.cpp"],
-    libc_function_deps = [
-        "//libc:remove",
-        "//libc:open",
-        "//libc:mkdirat",
+    deps = [
         "//libc:access",
         "//libc:close",
+        "//libc:mkdirat",
+        "//libc:open",
+        "//libc:remove",
     ],
 )
 
 libc_test(
     name = "sscanf_test",
     srcs = ["sscanf_test.cpp"],
-    libc_function_deps = [
-        "//libc:sscanf",
-    ],
     deps = [
         "//libc:__support_cpp_limits",
         "//libc:__support_fputil_fp_bits",
         "//libc:hdr_stdio_macros",
+        "//libc:sscanf",
         "//libc/test/UnitTest:fp_test_helpers",
     ],
 )
@@ -150,16 +140,16 @@ libc_test(
 libc_test(
     name = "fscanf_test",
     srcs = ["fscanf_test.cpp"],
-    libc_function_deps = [
+    deps = [
+        "//libc:__support_cpp_string_view",
         "//libc:fscanf",
     ],
-    deps = ["//libc:__support_cpp_string_view"],
 )
 
 libc_test(
     name = "vsscanf_test",
     srcs = ["vsscanf_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:vsscanf",
     ],
 )
@@ -167,8 +157,8 @@ libc_test(
 libc_test(
     name = "vfscanf_test",
     srcs = ["vfscanf_test.cpp"],
-    libc_function_deps = [
+    deps = [
+        "//libc:__support_cpp_string_view",
         "//libc:vfscanf",
     ],
-    deps = ["//libc:__support_cpp_string_view"],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
@@ -13,19 +13,19 @@ licenses(["notice"])
 libc_test(
     name = "abs_test",
     srcs = ["abs_test.cpp"],
-    libc_function_deps = ["//libc:abs"],
+    deps = ["//libc:abs"],
 )
 
 libc_test(
     name = "labs_test",
     srcs = ["labs_test.cpp"],
-    libc_function_deps = ["//libc:labs"],
+    deps = ["//libc:labs"],
 )
 
 libc_test(
     name = "llabs_test",
     srcs = ["llabs_test.cpp"],
-    libc_function_deps = ["//libc:llabs"],
+    deps = ["//libc:llabs"],
 )
 
 libc_test_library(
@@ -37,9 +37,9 @@ libc_test_library(
 libc_test(
     name = "div_test",
     srcs = ["div_test.cpp"],
-    libc_function_deps = ["//libc:div"],
     deps = [
         ":div_test_helper",
+        "//libc:div",
         "//libc:types_div_t",
     ],
 )
@@ -47,9 +47,9 @@ libc_test(
 libc_test(
     name = "ldiv_test",
     srcs = ["ldiv_test.cpp"],
-    libc_function_deps = ["//libc:ldiv"],
     deps = [
         ":div_test_helper",
+        "//libc:ldiv",
         "//libc:types_ldiv_t",
     ],
 )
@@ -57,9 +57,9 @@ libc_test(
 libc_test(
     name = "lldiv_test",
     srcs = ["lldiv_test.cpp"],
-    libc_function_deps = ["//libc:lldiv"],
     deps = [
         ":div_test_helper",
+        "//libc:lldiv",
         "//libc:types_lldiv_t",
     ],
 )
@@ -77,36 +77,46 @@ libc_test_library(
 libc_test(
     name = "atoi_test",
     srcs = ["atoi_test.cpp"],
-    libc_function_deps = ["//libc:atoi"],
-    deps = [":atoi_test_helper"],
+    deps = [
+        ":atoi_test_helper",
+        "//libc:atoi",
+    ],
 )
 
 libc_test(
     name = "atol_test",
     srcs = ["atol_test.cpp"],
-    libc_function_deps = ["//libc:atol"],
-    deps = [":atoi_test_helper"],
+    deps = [
+        ":atoi_test_helper",
+        "//libc:atol",
+    ],
 )
 
 libc_test(
     name = "atoll_test",
     srcs = ["atoll_test.cpp"],
-    libc_function_deps = ["//libc:atoll"],
-    deps = [":atoi_test_helper"],
+    deps = [
+        ":atoi_test_helper",
+        "//libc:atoll",
+    ],
 )
 
 libc_test(
     name = "atof_test",
     srcs = ["atof_test.cpp"],
-    libc_function_deps = ["//libc:atof"],
-    deps = ["//libc:__support_fputil_fp_bits"],
+    deps = [
+        "//libc:__support_fputil_fp_bits",
+        "//libc:atof",
+    ],
 )
 
 libc_test(
     name = "bsearch_test",
     srcs = ["bsearch_test.cpp"],
-    libc_function_deps = ["//libc:bsearch"],
-    deps = ["//libc:types_size_t"],
+    deps = [
+        "//libc:bsearch",
+        "//libc:types_size_t",
+    ],
 )
 
 libc_test_library(
@@ -121,9 +131,9 @@ libc_test_library(
 libc_test(
     name = "quick_sort_test",
     srcs = ["quick_sort_test.cpp"],
-    libc_function_deps = ["//libc:qsort"],
     deps = [
         ":qsort_test_helper",
+        "//libc:qsort",
         "//libc:qsort_util",
         "//libc:types_size_t",
     ],
@@ -132,9 +142,9 @@ libc_test(
 libc_test(
     name = "heap_sort_test",
     srcs = ["heap_sort_test.cpp"],
-    libc_function_deps = ["//libc:qsort"],
     deps = [
         ":qsort_test_helper",
+        "//libc:qsort",
         "//libc:qsort_util",
         "//libc:types_size_t",
     ],
@@ -143,8 +153,10 @@ libc_test(
 libc_test(
     name = "qsort_r_test",
     srcs = ["qsort_r_test.cpp"],
-    libc_function_deps = ["//libc:qsort_r"],
-    deps = ["//libc:types_size_t"],
+    deps = [
+        "//libc:qsort_r",
+        "//libc:types_size_t",
+    ],
 )
 
 libc_test_library(
@@ -160,22 +172,28 @@ libc_test_library(
 libc_test(
     name = "strfromf_test",
     srcs = ["strfromf_test.cpp"],
-    libc_function_deps = ["//libc:strfromf"],
-    deps = [":strfrom_test_helper"],
+    deps = [
+        ":strfrom_test_helper",
+        "//libc:strfromf",
+    ],
 )
 
 libc_test(
     name = "strfromd_test",
     srcs = ["strfromd_test.cpp"],
-    libc_function_deps = ["//libc:strfromd"],
-    deps = [":strfrom_test_helper"],
+    deps = [
+        ":strfrom_test_helper",
+        "//libc:strfromd",
+    ],
 )
 
 libc_test(
     name = "strfroml_test",
     srcs = ["strfroml_test.cpp"],
-    libc_function_deps = ["//libc:strfroml"],
-    deps = [":strfrom_test_helper"],
+    deps = [
+        ":strfrom_test_helper",
+        "//libc:strfroml",
+    ],
 )
 
 libc_test_library(
@@ -194,37 +212,45 @@ libc_test_library(
 libc_test(
     name = "strtol_test",
     srcs = ["strtol_test.cpp"],
-    libc_function_deps = ["//libc:strtol"],
-    deps = [":strtol_test_helper"],
+    deps = [
+        ":strtol_test_helper",
+        "//libc:strtol",
+    ],
 )
 
 libc_test(
     name = "strtoll_test",
     srcs = ["strtoll_test.cpp"],
-    libc_function_deps = ["//libc:strtoll"],
-    deps = [":strtol_test_helper"],
+    deps = [
+        ":strtol_test_helper",
+        "//libc:strtoll",
+    ],
 )
 
 libc_test(
     name = "strtoul_test",
     srcs = ["strtoul_test.cpp"],
-    libc_function_deps = ["//libc:strtoul"],
-    deps = [":strtol_test_helper"],
+    deps = [
+        ":strtol_test_helper",
+        "//libc:strtoul",
+    ],
 )
 
 libc_test(
     name = "strtoull_test",
     srcs = ["strtoull_test.cpp"],
-    libc_function_deps = ["//libc:strtoull"],
-    deps = [":strtol_test_helper"],
+    deps = [
+        ":strtol_test_helper",
+        "//libc:strtoull",
+    ],
 )
 
 libc_test(
     name = "strtof_test",
     srcs = ["strtof_test.cpp"],
-    libc_function_deps = ["//libc:strtof"],
     deps = [
         "//libc:__support_fputil_fp_bits",
+        "//libc:strtof",
         "//libc/test/UnitTest:fp_test_helpers",
     ],
 )
@@ -232,9 +258,9 @@ libc_test(
 libc_test(
     name = "strtod_test",
     srcs = ["strtod_test.cpp"],
-    libc_function_deps = ["//libc:strtod"],
     deps = [
         "//libc:__support_fputil_fp_bits",
+        "//libc:strtod",
         "//libc/test/UnitTest:fp_test_helpers",
     ],
 )
@@ -242,9 +268,9 @@ libc_test(
 libc_test(
     name = "strtold_test",
     srcs = ["strtold_test.cpp"],
-    libc_function_deps = ["//libc:strtold"],
     deps = [
         "//libc:__support_fputil_fp_bits",
         "//libc:__support_uint128",
+        "//libc:strtold",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/string/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/string/BUILD.bazel
@@ -13,7 +13,7 @@ licenses(["notice"])
 libc_test(
     name = "strlen_test",
     srcs = ["strlen_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:strlen",
     ],
 )
@@ -21,7 +21,7 @@ libc_test(
 libc_test(
     name = "strcpy_test",
     srcs = ["strcpy_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:strcpy",
     ],
 )
@@ -29,7 +29,7 @@ libc_test(
 libc_test(
     name = "strcmp_test",
     srcs = ["strcmp_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:strcmp",
     ],
 )
@@ -37,7 +37,7 @@ libc_test(
 libc_test(
     name = "memchr_test",
     srcs = ["memchr_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:memchr",
     ],
 )
@@ -51,16 +51,16 @@ libc_test_library(
 libc_test(
     name = "strchr_test",
     srcs = ["strchr_test.cpp"],
-    libc_function_deps = [
+    deps = [
+        ":strchr_test_helper",
         "//libc:strchr",
     ],
-    deps = [":strchr_test_helper"],
 )
 
 libc_test(
     name = "strstr_test",
     srcs = ["strstr_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:strstr",
     ],
 )
@@ -68,7 +68,7 @@ libc_test(
 libc_test(
     name = "strnlen_test",
     srcs = ["strnlen_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:strnlen",
     ],
 )
@@ -76,7 +76,7 @@ libc_test(
 libc_test(
     name = "memrchr_test",
     srcs = ["memrchr_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:memrchr",
     ],
 )
@@ -84,16 +84,16 @@ libc_test(
 libc_test(
     name = "strrchr_test",
     srcs = ["strrchr_test.cpp"],
-    libc_function_deps = [
+    deps = [
+        ":strchr_test_helper",
         "//libc:strrchr",
     ],
-    deps = [":strchr_test_helper"],
 )
 
 libc_test(
     name = "strcspn_test",
     srcs = ["strcspn_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:strcspn",
     ],
 )
@@ -101,7 +101,7 @@ libc_test(
 libc_test(
     name = "strspn_test",
     srcs = ["strspn_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:strspn",
     ],
 )
@@ -109,7 +109,7 @@ libc_test(
 libc_test(
     name = "strtok_test",
     srcs = ["strtok_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:strtok",
     ],
 )
@@ -138,20 +138,18 @@ libc_test_library(
 libc_test(
     name = "memcpy_test",
     srcs = ["memcpy_test.cpp"],
-    libc_function_deps = [
-        "//libc:memcpy",
-    ],
     deps = [
         ":memory_check_utils",
         ":protected_pages",
         "//libc:__support_macros_properties_os",
+        "//libc:memcpy",
     ],
 )
 
 libc_test(
     name = "mempcpy_test",
     srcs = ["mempcpy_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:mempcpy",
     ],
 )
@@ -159,26 +157,22 @@ libc_test(
 libc_test(
     name = "memset_test",
     srcs = ["memset_test.cpp"],
-    libc_function_deps = [
-        "//libc:memset",
-    ],
     deps = [
         ":memory_check_utils",
         ":protected_pages",
         "//libc:__support_macros_properties_os",
+        "//libc:memset",
     ],
 )
 
 libc_test(
     name = "memmove_test",
     srcs = ["memmove_test.cpp"],
-    libc_function_deps = [
-        "//libc:memcmp",
-        "//libc:memmove",
-    ],
     deps = [
         ":memory_check_utils",
         "//libc:__support_cpp_span",
+        "//libc:memcmp",
+        "//libc:memmove",
         "//libc/test/UnitTest:memory_matcher",
     ],
 )
@@ -186,11 +180,9 @@ libc_test(
 libc_test(
     name = "memcmp_test",
     srcs = ["memcmp_test.cpp"],
-    libc_function_deps = [
-        "//libc:memcmp",
-    ],
     deps = [
         ":memory_check_utils",
+        "//libc:memcmp",
         "//libc/test/UnitTest:test_logger",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/strings/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/strings/BUILD.bazel
@@ -13,11 +13,9 @@ licenses(["notice"])
 libc_test(
     name = "bcopy_test",
     srcs = ["bcopy_test.cpp"],
-    libc_function_deps = [
-        "//libc:bcopy",
-    ],
     deps = [
         "//libc:__support_cpp_span",
+        "//libc:bcopy",
         "//libc/test/UnitTest:memory_matcher",
         "//libc/test/src/string:memory_check_utils",
     ],
@@ -26,10 +24,8 @@ libc_test(
 libc_test(
     name = "bcmp_test",
     srcs = ["bcmp_test.cpp"],
-    libc_function_deps = [
-        "//libc:bcmp",
-    ],
     deps = [
+        "//libc:bcmp",
         "//libc/test/UnitTest:test_logger",
         "//libc/test/src/string:memory_check_utils",
     ],
@@ -38,10 +34,8 @@ libc_test(
 libc_test(
     name = "bzero_test",
     srcs = ["bzero_test.cpp"],
-    libc_function_deps = [
-        "//libc:bzero",
-    ],
     deps = [
+        "//libc:bzero",
         "//libc/test/src/string:memory_check_utils",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/sys/epoll/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/sys/epoll/BUILD.bazel
@@ -13,11 +13,9 @@ licenses(["notice"])
 libc_test(
     name = "epoll_create_test",
     srcs = ["linux/epoll_create_test.cpp"],
-    libc_function_deps = [
-        "//libc:epoll_create",
-        "//libc:close",
-    ],
     deps = [
+        "//libc:close",
+        "//libc:epoll_create",
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
@@ -25,11 +23,9 @@ libc_test(
 libc_test(
     name = "epoll_create1_test",
     srcs = ["linux/epoll_create1_test.cpp"],
-    libc_function_deps = [
-        "//libc:epoll_create1",
-        "//libc:close",
-    ],
     deps = [
+        "//libc:close",
+        "//libc:epoll_create1",
         "//libc:hdr_sys_epoll_macros",
         "//libc/test/UnitTest:errno_test_helpers",
     ],
@@ -38,14 +34,12 @@ libc_test(
 libc_test(
     name = "epoll_ctl_test",
     srcs = ["linux/epoll_ctl_test.cpp"],
-    libc_function_deps = [
+    deps = [
+        "//libc:close",
         "//libc:epoll_create1",
         "//libc:epoll_ctl",
-        "//libc:pipe",
-        "//libc:close",
-    ],
-    deps = [
         "//libc:hdr_sys_epoll_macros",
+        "//libc:pipe",
         "//libc:types_struct_epoll_event",
         "//libc/test/UnitTest:errno_test_helpers",
     ],
@@ -54,15 +48,13 @@ libc_test(
 libc_test(
     name = "epoll_wait_test",
     srcs = ["linux/epoll_wait_test.cpp"],
-    libc_function_deps = [
-        "//libc:epoll_wait",
+    deps = [
+        "//libc:close",
         "//libc:epoll_create1",
         "//libc:epoll_ctl",
-        "//libc:pipe",
-        "//libc:close",
-    ],
-    deps = [
+        "//libc:epoll_wait",
         "//libc:hdr_sys_epoll_macros",
+        "//libc:pipe",
         "//libc:types_struct_epoll_event",
         "//libc/test/UnitTest:errno_test_helpers",
     ],
@@ -71,15 +63,13 @@ libc_test(
 libc_test(
     name = "epoll_pwait_test",
     srcs = ["linux/epoll_pwait_test.cpp"],
-    libc_function_deps = [
-        "//libc:epoll_pwait",
+    deps = [
+        "//libc:close",
         "//libc:epoll_create1",
         "//libc:epoll_ctl",
-        "//libc:pipe",
-        "//libc:close",
-    ],
-    deps = [
+        "//libc:epoll_pwait",
         "//libc:hdr_sys_epoll_macros",
+        "//libc:pipe",
         "//libc:types_struct_epoll_event",
         "//libc/test/UnitTest:errno_test_helpers",
     ],
@@ -88,15 +78,13 @@ libc_test(
 libc_test(
     name = "epoll_pwait2_test",
     srcs = ["linux/epoll_pwait2_test.cpp"],
-    libc_function_deps = [
-        "//libc:epoll_pwait2",
+    deps = [
+        "//libc:close",
         "//libc:epoll_create1",
         "//libc:epoll_ctl",
-        "//libc:pipe",
-        "//libc:close",
-    ],
-    deps = [
+        "//libc:epoll_pwait2",
         "//libc:hdr_sys_epoll_macros",
+        "//libc:pipe",
         "//libc:types_struct_epoll_event",
         "//libc:types_struct_timespec",
         "//libc/test/UnitTest:errno_test_helpers",

--- a/utils/bazel/llvm-project-overlay/libc/test/src/sys/socket/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/sys/socket/BUILD.bazel
@@ -13,11 +13,9 @@ licenses(["notice"])
 libc_test(
     name = "socket_test",
     srcs = ["linux/socket_test.cpp"],
-    libc_function_deps = [
-        "//libc:socket",
-        "//libc:close",
-    ],
     deps = [
+        "//libc:close",
+        "//libc:socket",
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
@@ -25,11 +23,9 @@ libc_test(
 libc_test(
     name = "socketpair_test",
     srcs = ["linux/socketpair_test.cpp"],
-    libc_function_deps = [
-        "//libc:socketpair",
-        "//libc:close",
-    ],
     deps = [
+        "//libc:close",
+        "//libc:socketpair",
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
@@ -37,13 +33,11 @@ libc_test(
 libc_test(
     name = "send_recv_test",
     srcs = ["linux/send_recv_test.cpp"],
-    libc_function_deps = [
-        "//libc:socketpair",
-        "//libc:send",
-        "//libc:recv",
-        "//libc:close",
-    ],
     deps = [
+        "//libc:close",
+        "//libc:recv",
+        "//libc:send",
+        "//libc:socketpair",
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
@@ -51,13 +45,11 @@ libc_test(
 libc_test(
     name = "sendto_recvfrom_test",
     srcs = ["linux/sendto_recvfrom_test.cpp"],
-    libc_function_deps = [
-        "//libc:socketpair",
-        "//libc:sendto",
-        "//libc:recvfrom",
-        "//libc:close",
-    ],
     deps = [
+        "//libc:close",
+        "//libc:recvfrom",
+        "//libc:sendto",
+        "//libc:socketpair",
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
@@ -65,13 +57,11 @@ libc_test(
 libc_test(
     name = "sendmsg_recvmsg_test",
     srcs = ["linux/sendmsg_recvmsg_test.cpp"],
-    libc_function_deps = [
-        "//libc:socketpair",
-        "//libc:sendmsg",
-        "//libc:recvmsg",
-        "//libc:close",
-    ],
     deps = [
+        "//libc:close",
+        "//libc:recvmsg",
+        "//libc:sendmsg",
+        "//libc:socketpair",
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/unistd/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/unistd/BUILD.bazel
@@ -13,13 +13,11 @@ licenses(["notice"])
 libc_test(
     name = "access_test",
     srcs = ["access_test.cpp"],
-    libc_function_deps = [
-        "//libc:open",
+    deps = [
         "//libc:access",
         "//libc:close",
+        "//libc:open",
         "//libc:unlink",
-    ],
-    deps = [
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
@@ -27,15 +25,13 @@ libc_test(
 libc_test(
     name = "dup_test",
     srcs = ["dup_test.cpp"],
-    libc_function_deps = [
-        "//libc:open",
+    deps = [
         "//libc:close",
         "//libc:dup",
+        "//libc:open",
         "//libc:read",
         "//libc:unlink",
         "//libc:write",
-    ],
-    deps = [
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
@@ -43,15 +39,13 @@ libc_test(
 libc_test(
     name = "dup2_test",
     srcs = ["dup2_test.cpp"],
-    libc_function_deps = [
-        "//libc:open",
+    deps = [
         "//libc:close",
         "//libc:dup2",
+        "//libc:open",
         "//libc:read",
         "//libc:unlink",
         "//libc:write",
-    ],
-    deps = [
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
@@ -59,15 +53,13 @@ libc_test(
 libc_test(
     name = "dup3_test",
     srcs = ["dup3_test.cpp"],
-    libc_function_deps = [
-        "//libc:open",
+    deps = [
         "//libc:close",
         "//libc:dup3",
+        "//libc:open",
         "//libc:read",
         "//libc:unlink",
         "//libc:write",
-    ],
-    deps = [
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
@@ -75,16 +67,14 @@ libc_test(
 libc_test(
     name = "ftruncate_test",
     srcs = ["ftruncate_test.cpp"],
-    libc_function_deps = [
-        "//libc:open",
-        "//libc:close",
-        "//libc:read",
-        "//libc:ftruncate",
-        "//libc:unlink",
-        "//libc:write",
-    ],
     deps = [
         "//libc:__support_cpp_string_view",
+        "//libc:close",
+        "//libc:ftruncate",
+        "//libc:open",
+        "//libc:read",
+        "//libc:unlink",
+        "//libc:write",
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
@@ -92,16 +82,14 @@ libc_test(
 libc_test(
     name = "pread_pwrite_test",
     srcs = ["pread_pwrite_test.cpp"],
-    libc_function_deps = [
-        "//libc:open",
+    deps = [
         "//libc:close",
         "//libc:fsync",
+        "//libc:open",
         "//libc:pread",
         "//libc:pwrite",
         "//libc:unlink",
         "//libc:write",
-    ],
-    deps = [
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
@@ -109,15 +97,13 @@ libc_test(
 libc_test(
     name = "read_write_test",
     srcs = ["read_write_test.cpp"],
-    libc_function_deps = [
-        "//libc:open",
+    deps = [
         "//libc:close",
         "//libc:fsync",
+        "//libc:open",
         "//libc:read",
-        "//libc:write",
         "//libc:remove",
-    ],
-    deps = [
+        "//libc:write",
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
@@ -125,13 +111,11 @@ libc_test(
 libc_test(
     name = "link_test",
     srcs = ["link_test.cpp"],
-    libc_function_deps = [
-        "//libc:open",
+    deps = [
         "//libc:close",
         "//libc:link",
+        "//libc:open",
         "//libc:unlink",
-    ],
-    deps = [
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
@@ -139,24 +123,20 @@ libc_test(
 libc_test(
     name = "swab_test",
     srcs = ["swab_test.cpp"],
-    libc_function_deps = [
-        "//libc:swab",
-    ],
     deps = [
         "//libc:string_utils",
+        "//libc:swab",
     ],
 )
 
 libc_test(
     name = "symlink_test",
     srcs = ["symlink_test.cpp"],
-    libc_function_deps = [
-        "//libc:open",
+    deps = [
         "//libc:close",
+        "//libc:open",
         "//libc:symlink",
         "//libc:unlink",
-    ],
-    deps = [
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
@@ -164,16 +144,14 @@ libc_test(
 libc_test(
     name = "truncate_test",
     srcs = ["truncate_test.cpp"],
-    libc_function_deps = [
-        "//libc:open",
+    deps = [
+        "//libc:__support_cpp_string_view",
         "//libc:close",
+        "//libc:open",
         "//libc:read",
         "//libc:truncate",
         "//libc:unlink",
         "//libc:write",
-    ],
-    deps = [
-        "//libc:__support_cpp_string_view",
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
@@ -181,12 +159,10 @@ libc_test(
 libc_test(
     name = "unlink_test",
     srcs = ["unlink_test.cpp"],
-    libc_function_deps = [
-        "//libc:open",
-        "//libc:close",
-        "//libc:unlink",
-    ],
     deps = [
+        "//libc:close",
+        "//libc:open",
+        "//libc:unlink",
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
@@ -194,7 +170,7 @@ libc_test(
 libc_test(
     name = "getppid_test",
     srcs = ["getppid_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:getppid",
     ],
 )
@@ -202,7 +178,7 @@ libc_test(
 libc_test(
     name = "getuid_test",
     srcs = ["getuid_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:getuid",
     ],
 )
@@ -210,12 +186,10 @@ libc_test(
 libc_test(
     name = "isatty_test",
     srcs = ["isatty_test.cpp"],
-    libc_function_deps = [
+    deps = [
+        "//libc:close",
         "//libc:isatty",
         "//libc:open",
-        "//libc:close",
-    ],
-    deps = [
         "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
@@ -223,7 +197,7 @@ libc_test(
 libc_test(
     name = "geteuid_test",
     srcs = ["geteuid_test.cpp"],
-    libc_function_deps = [
+    deps = [
         "//libc:geteuid",
     ],
 )
@@ -236,7 +210,7 @@ libc_test(
 # libc_test(
 #     name = "syscall_test",
 #     srcs = ["syscall_test.cpp"],
-#     libc_function_deps = [
+#     deps = [
 #         "//libc:syscall",
 #     ],
 # )
@@ -246,7 +220,7 @@ libc_test(
 # libc_test(
 #     name = "sysconf_test",
 #     srcs = ["sysconf_test.cpp"],
-#     libc_function_deps = [
+#     deps = [
 #         "//libc:sysconf",
 #     ],
 # )
@@ -256,12 +230,10 @@ libc_test(
 # libc_test(
 #     name = "getopt_test",
 #     srcs = ["getopt_test.cpp"],
-#     libc_function_deps = [
+#     deps = [
+#         "//libc:__support_cpp_array",
 #         "//libc:getopt",
 #         "//libc:fopencookie",
 #         "//libc:fflush",
-#     ],
-#     deps = [
-#         "//libc:__support_cpp_array",
 #     ],
 # )


### PR DESCRIPTION
libc_function_deps and deps are now identical, as we no longer need or have special treatment for libc_function targets. Merge these attributes passed to the libc_test macro, and fix all relevant libc_test macro invocations. This change is a no-op.

This concludes cleanup started in 9b13d345303d819bb83de7ebbeb826d704add0bc.