### PR TITLE
Mark the file opened by DeserializedDeclsSourceRangePrinter as a text file

### DIFF
--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -312,7 +312,7 @@ FrontendAction::CreateWrappedASTConsumer(CompilerInstance &CI,
     std::error_code ErrorCode;
     auto FileStream = std::make_unique<llvm::raw_fd_ostream>(
         DumpDeserializedDeclarationRangesPath, ErrorCode,
-        llvm::sys::fs::OF_None);
+        llvm::sys::fs::OF_TextWithCRLF);
     if (!ErrorCode) {
       Consumers.push_back(std::make_unique<DeserializedDeclsSourceRangePrinter>(
           CI.getSourceManager(), std::move(FileStream)));


### PR DESCRIPTION
This PR will fix the following lit failure seeing on z/OS and most likely on Windows:

`FAIL: Clang :: Frontend/dump-minimization-hints.cpp`

Without `OF_TextWithCRLF` flag, a file is treated as binary and is read improperly.