### PR TITLE
[lldb][TypeSystemClang] Allow arrays to be dereferenced in C/C++.

### DIFF
--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -436,10 +436,7 @@ public:
   llvm::Expected<CompilerType>
   GetDereferencedType(ExecutionContext *exe_ctx, std::string &child_name,
                       uint32_t &child_byte_size, int32_t &child_byte_offset,
-                      uint32_t &child_bitfield_bit_size,
-                      uint32_t &child_bitfield_bit_offset,
-                      bool &child_is_base_class, ValueObject *valobj,
-                      uint64_t &language_flags) const;
+                      ValueObject *valobj, uint64_t &language_flags) const;
 
   llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       ExecutionContext *exe_ctx, size_t idx, bool transparent_pointers,

--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -433,14 +433,13 @@ public:
 
   CompilerDecl GetStaticFieldWithName(llvm::StringRef name) const;
 
-  llvm::Expected<CompilerType> GetDereferencedType(
-      ExecutionContext *exe_ctx, bool transparent_pointers,
-      bool omit_empty_base_classes, bool ignore_array_bounds,
-      std::string &child_name, uint32_t &child_byte_size,
-      int32_t &child_byte_offset, uint32_t &child_bitfield_bit_size,
-      uint32_t &child_bitfield_bit_offset, bool &child_is_base_class,
-      bool &child_is_deref_of_parent, ValueObject *valobj,
-      uint64_t &language_flags, bool &type_valid) const;
+  llvm::Expected<CompilerType>
+  GetDereferencedType(ExecutionContext *exe_ctx, std::string &child_name,
+                      uint32_t &child_byte_size, int32_t &child_byte_offset,
+                      uint32_t &child_bitfield_bit_size,
+                      uint32_t &child_bitfield_bit_offset,
+                      bool &child_is_base_class, ValueObject *valobj,
+                      uint64_t &language_flags, bool &type_valid) const;
 
   llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       ExecutionContext *exe_ctx, size_t idx, bool transparent_pointers,

--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -186,8 +186,6 @@ public:
   bool IsReferenceType(CompilerType *pointee_type = nullptr,
                        bool *is_rvalue = nullptr) const;
 
-  bool IsValidDereferenceType() const;
-
   bool ShouldTreatScalarValueAsAddress() const;
 
   bool IsScalarType() const;
@@ -434,6 +432,15 @@ public:
                                           uint32_t *bit_offset_ptr) const;
 
   CompilerDecl GetStaticFieldWithName(llvm::StringRef name) const;
+
+  llvm::Expected<CompilerType> GetDereferencedType(
+      ExecutionContext *exe_ctx, bool transparent_pointers,
+      bool omit_empty_base_classes, bool ignore_array_bounds,
+      std::string &child_name, uint32_t &child_byte_size,
+      int32_t &child_byte_offset, uint32_t &child_bitfield_bit_size,
+      uint32_t &child_bitfield_bit_offset, bool &child_is_base_class,
+      bool &child_is_deref_of_parent, ValueObject *valobj,
+      uint64_t &language_flags, bool &type_valid) const;
 
   llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       ExecutionContext *exe_ctx, size_t idx, bool transparent_pointers,

--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -439,7 +439,7 @@ public:
                       uint32_t &child_bitfield_bit_size,
                       uint32_t &child_bitfield_bit_offset,
                       bool &child_is_base_class, ValueObject *valobj,
-                      uint64_t &language_flags, bool &type_valid) const;
+                      uint64_t &language_flags) const;
 
   llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       ExecutionContext *exe_ctx, size_t idx, bool transparent_pointers,

--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -186,6 +186,8 @@ public:
   bool IsReferenceType(CompilerType *pointee_type = nullptr,
                        bool *is_rvalue = nullptr) const;
 
+  bool IsValidDereferenceType() const;
+
   bool ShouldTreatScalarValueAsAddress() const;
 
   bool IsScalarType() const;

--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -434,8 +434,8 @@ public:
   CompilerDecl GetStaticFieldWithName(llvm::StringRef name) const;
 
   llvm::Expected<CompilerType>
-  GetDereferencedType(ExecutionContext *exe_ctx, std::string &child_name,
-                      uint32_t &child_byte_size, int32_t &child_byte_offset,
+  GetDereferencedType(ExecutionContext *exe_ctx, std::string &deref_name,
+                      uint32_t &deref_byte_size, int32_t &deref_byte_offset,
                       ValueObject *valobj, uint64_t &language_flags) const;
 
   llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -364,12 +364,11 @@ public:
     return CompilerDecl();
   }
 
-  virtual llvm::Expected<CompilerType> GetDereferencedType(
-      lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
-      std::string &child_name, uint32_t &child_byte_size,
-      int32_t &child_byte_offset, uint32_t &child_bitfield_bit_size,
-      uint32_t &child_bitfield_bit_offset, bool &child_is_base_class,
-      ValueObject *valobj, uint64_t &language_flags) = 0;
+  virtual llvm::Expected<CompilerType>
+  GetDereferencedType(lldb::opaque_compiler_type_t type,
+                      ExecutionContext *exe_ctx, std::string &child_name,
+                      uint32_t &child_byte_size, int32_t &child_byte_offset,
+                      ValueObject *valobj, uint64_t &language_flags) = 0;
 
   virtual llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -366,8 +366,8 @@ public:
 
   virtual llvm::Expected<CompilerType>
   GetDereferencedType(lldb::opaque_compiler_type_t type,
-                      ExecutionContext *exe_ctx, std::string &child_name,
-                      uint32_t &child_byte_size, int32_t &child_byte_offset,
+                      ExecutionContext *exe_ctx, std::string &deref_name,
+                      uint32_t &deref_byte_size, int32_t &deref_byte_offset,
                       ValueObject *valobj, uint64_t &language_flags) = 0;
 
   virtual llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -366,11 +366,9 @@ public:
 
   virtual llvm::Expected<CompilerType> GetDereferencedType(
       lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
-      bool transparent_pointers, bool omit_empty_base_classes,
-      bool ignore_array_bounds, std::string &child_name,
-      uint32_t &child_byte_size, int32_t &child_byte_offset,
-      uint32_t &child_bitfield_bit_size, uint32_t &child_bitfield_bit_offset,
-      bool &child_is_base_class, bool &child_is_deref_of_parent,
+      std::string &child_name, uint32_t &child_byte_size,
+      int32_t &child_byte_offset, uint32_t &child_bitfield_bit_size,
+      uint32_t &child_bitfield_bit_offset, bool &child_is_base_class,
       ValueObject *valobj, uint64_t &language_flags, bool &type_valid) = 0;
 
   virtual llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -364,6 +364,15 @@ public:
     return CompilerDecl();
   }
 
+  virtual llvm::Expected<CompilerType> GetDereferencedType(
+      lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
+      bool transparent_pointers, bool omit_empty_base_classes,
+      bool ignore_array_bounds, std::string &child_name,
+      uint32_t &child_byte_size, int32_t &child_byte_offset,
+      uint32_t &child_bitfield_bit_size, uint32_t &child_bitfield_bit_offset,
+      bool &child_is_base_class, bool &child_is_deref_of_parent,
+      ValueObject *valobj, uint64_t &language_flags, bool &type_valid) = 0;
+
   virtual llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
       bool transparent_pointers, bool omit_empty_base_classes,
@@ -488,8 +497,6 @@ public:
 
   virtual bool IsReferenceType(lldb::opaque_compiler_type_t type,
                                CompilerType *pointee_type, bool *is_rvalue) = 0;
-
-  virtual bool IsValidDereferenceType(lldb::opaque_compiler_type_t type) = 0;
 
   virtual bool
   ShouldTreatScalarValueAsAddress(lldb::opaque_compiler_type_t type) {

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -369,7 +369,7 @@ public:
       std::string &child_name, uint32_t &child_byte_size,
       int32_t &child_byte_offset, uint32_t &child_bitfield_bit_size,
       uint32_t &child_bitfield_bit_offset, bool &child_is_base_class,
-      ValueObject *valobj, uint64_t &language_flags, bool &type_valid) = 0;
+      ValueObject *valobj, uint64_t &language_flags) = 0;
 
   virtual llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -489,6 +489,8 @@ public:
   virtual bool IsReferenceType(lldb::opaque_compiler_type_t type,
                                CompilerType *pointee_type, bool *is_rvalue) = 0;
 
+  virtual bool IsValidDereferenceType(lldb::opaque_compiler_type_t type) = 0;
+
   virtual bool
   ShouldTreatScalarValueAsAddress(lldb::opaque_compiler_type_t type) {
     return IsPointerOrReferenceType(type, nullptr);

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -6189,9 +6189,9 @@ llvm::Expected<CompilerType> TypeSystemClang::GetDereferencedType(
     std::string &child_name, uint32_t &child_byte_size,
     int32_t &child_byte_offset, uint32_t &child_bitfield_bit_size,
     uint32_t &child_bitfield_bit_offset, bool &child_is_base_class,
-    ValueObject *valobj, uint64_t &language_flags, bool &type_valid) {
-  type_valid = IsPointerOrReferenceType(type, nullptr) ||
-               IsArrayType(type, nullptr, nullptr, nullptr);
+    ValueObject *valobj, uint64_t &language_flags) {
+  bool type_valid = IsPointerOrReferenceType(type, nullptr) ||
+                    IsArrayType(type, nullptr, nullptr, nullptr);
   if (!type_valid)
     return llvm::createStringError("not a pointer, reference or array type");
   bool child_is_deref_of_parent;

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -3443,13 +3443,6 @@ bool TypeSystemClang::IsReferenceType(lldb::opaque_compiler_type_t type,
   return false;
 }
 
-bool TypeSystemClang::IsValidDereferenceType(
-    lldb::opaque_compiler_type_t type) {
-  CompilerType compiler_type = GetType(clang::QualType::getFromOpaquePtr(type));
-  return compiler_type.IsPointerOrReferenceType() ||
-         compiler_type.IsArrayType();
-}
-
 bool TypeSystemClang::IsFloatingPointType(lldb::opaque_compiler_type_t type,
                                           uint32_t &count, bool &is_complex) {
   if (type) {
@@ -6189,6 +6182,25 @@ uint32_t TypeSystemClang::GetNumPointeeChildren(clang::QualType type) {
     break;
   }
   return 0;
+}
+
+llvm::Expected<CompilerType> TypeSystemClang::GetDereferencedType(
+    lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
+    bool transparent_pointers, bool omit_empty_base_classes,
+    bool ignore_array_bounds, std::string &child_name,
+    uint32_t &child_byte_size, int32_t &child_byte_offset,
+    uint32_t &child_bitfield_bit_size, uint32_t &child_bitfield_bit_offset,
+    bool &child_is_base_class, bool &child_is_deref_of_parent,
+    ValueObject *valobj, uint64_t &language_flags, bool &type_valid) {
+  type_valid = IsPointerOrReferenceType(type, nullptr) ||
+               IsArrayType(type, nullptr, nullptr, nullptr);
+  if (!type_valid)
+    return CompilerType();
+  return GetChildCompilerTypeAtIndex(
+      type, exe_ctx, 0, transparent_pointers, omit_empty_base_classes,
+      ignore_array_bounds, child_name, child_byte_size, child_byte_offset,
+      child_bitfield_bit_size, child_bitfield_bit_offset, child_is_base_class,
+      child_is_deref_of_parent, valobj, language_flags);
 }
 
 llvm::Expected<CompilerType> TypeSystemClang::GetChildCompilerTypeAtIndex(

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -3443,6 +3443,13 @@ bool TypeSystemClang::IsReferenceType(lldb::opaque_compiler_type_t type,
   return false;
 }
 
+bool TypeSystemClang::IsValidDereferenceType(
+    lldb::opaque_compiler_type_t type) {
+  CompilerType compiler_type = GetType(clang::QualType::getFromOpaquePtr(type));
+  return compiler_type.IsPointerOrReferenceType() ||
+         compiler_type.IsArrayType();
+}
+
 bool TypeSystemClang::IsFloatingPointType(lldb::opaque_compiler_type_t type,
                                           uint32_t &count, bool &is_complex) {
   if (type) {
@@ -6548,6 +6555,8 @@ llvm::Expected<CompilerType> TypeSystemClang::GetChildCompilerTypeAtIndex(
             return size_or_err.takeError();
           child_byte_size = *size_or_err;
           child_byte_offset = (int32_t)idx * (int32_t)child_byte_size;
+          if (idx == 0)
+            child_is_deref_of_parent = true;
           return element_type;
         }
       }

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -6186,8 +6186,8 @@ uint32_t TypeSystemClang::GetNumPointeeChildren(clang::QualType type) {
 
 llvm::Expected<CompilerType> TypeSystemClang::GetDereferencedType(
     lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
-    std::string &child_name, uint32_t &child_byte_size,
-    int32_t &child_byte_offset, ValueObject *valobj, uint64_t &language_flags) {
+    std::string &deref_name, uint32_t &deref_byte_size,
+    int32_t &deref_byte_offset, ValueObject *valobj, uint64_t &language_flags) {
   bool type_valid = IsPointerOrReferenceType(type, nullptr) ||
                     IsArrayType(type, nullptr, nullptr, nullptr);
   if (!type_valid)
@@ -6197,8 +6197,8 @@ llvm::Expected<CompilerType> TypeSystemClang::GetDereferencedType(
   bool child_is_base_class;
   bool child_is_deref_of_parent;
   return GetChildCompilerTypeAtIndex(
-      type, exe_ctx, 0, false, true, false, child_name, child_byte_size,
-      child_byte_offset, child_bitfield_bit_size, child_bitfield_bit_offset,
+      type, exe_ctx, 0, false, true, false, deref_name, deref_byte_size,
+      deref_byte_offset, child_bitfield_bit_size, child_bitfield_bit_offset,
       child_is_base_class, child_is_deref_of_parent, valobj, language_flags);
 }
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -6187,13 +6187,14 @@ uint32_t TypeSystemClang::GetNumPointeeChildren(clang::QualType type) {
 llvm::Expected<CompilerType> TypeSystemClang::GetDereferencedType(
     lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
     std::string &child_name, uint32_t &child_byte_size,
-    int32_t &child_byte_offset, uint32_t &child_bitfield_bit_size,
-    uint32_t &child_bitfield_bit_offset, bool &child_is_base_class,
-    ValueObject *valobj, uint64_t &language_flags) {
+    int32_t &child_byte_offset, ValueObject *valobj, uint64_t &language_flags) {
   bool type_valid = IsPointerOrReferenceType(type, nullptr) ||
                     IsArrayType(type, nullptr, nullptr, nullptr);
   if (!type_valid)
     return llvm::createStringError("not a pointer, reference or array type");
+  uint32_t child_bitfield_bit_size = 0;
+  uint32_t child_bitfield_bit_offset = 0;
+  bool child_is_base_class;
   bool child_is_deref_of_parent;
   return GetChildCompilerTypeAtIndex(
       type, exe_ctx, 0, false, true, false, child_name, child_byte_size,

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -889,12 +889,11 @@ public:
 
   static uint32_t GetNumPointeeChildren(clang::QualType type);
 
-  llvm::Expected<CompilerType> GetDereferencedType(
-      lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
-      std::string &child_name, uint32_t &child_byte_size,
-      int32_t &child_byte_offset, uint32_t &child_bitfield_bit_size,
-      uint32_t &child_bitfield_bit_offset, bool &child_is_base_class,
-      ValueObject *valobj, uint64_t &language_flags) override;
+  llvm::Expected<CompilerType>
+  GetDereferencedType(lldb::opaque_compiler_type_t type,
+                      ExecutionContext *exe_ctx, std::string &child_name,
+                      uint32_t &child_byte_size, int32_t &child_byte_offset,
+                      ValueObject *valobj, uint64_t &language_flags) override;
 
   llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -891,8 +891,8 @@ public:
 
   llvm::Expected<CompilerType>
   GetDereferencedType(lldb::opaque_compiler_type_t type,
-                      ExecutionContext *exe_ctx, std::string &child_name,
-                      uint32_t &child_byte_size, int32_t &child_byte_offset,
+                      ExecutionContext *exe_ctx, std::string &deref_name,
+                      uint32_t &deref_byte_size, int32_t &deref_byte_offset,
                       ValueObject *valobj, uint64_t &language_flags) override;
 
   llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -716,8 +716,6 @@ public:
   bool IsReferenceType(lldb::opaque_compiler_type_t type,
                        CompilerType *pointee_type, bool *is_rvalue) override;
 
-  bool IsValidDereferenceType(lldb::opaque_compiler_type_t type) override;
-
   bool IsScalarType(lldb::opaque_compiler_type_t type) override;
 
   bool IsTypedefType(lldb::opaque_compiler_type_t type) override;
@@ -890,6 +888,15 @@ public:
                                       llvm::StringRef name) override;
 
   static uint32_t GetNumPointeeChildren(clang::QualType type);
+
+  llvm::Expected<CompilerType> GetDereferencedType(
+      lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
+      bool transparent_pointers, bool omit_empty_base_classes,
+      bool ignore_array_bounds, std::string &child_name,
+      uint32_t &child_byte_size, int32_t &child_byte_offset,
+      uint32_t &child_bitfield_bit_size, uint32_t &child_bitfield_bit_offset,
+      bool &child_is_base_class, bool &child_is_deref_of_parent,
+      ValueObject *valobj, uint64_t &language_flags, bool &type_valid) override;
 
   llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -894,7 +894,7 @@ public:
       std::string &child_name, uint32_t &child_byte_size,
       int32_t &child_byte_offset, uint32_t &child_bitfield_bit_size,
       uint32_t &child_bitfield_bit_offset, bool &child_is_base_class,
-      ValueObject *valobj, uint64_t &language_flags, bool &type_valid) override;
+      ValueObject *valobj, uint64_t &language_flags) override;
 
   llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -716,6 +716,8 @@ public:
   bool IsReferenceType(lldb::opaque_compiler_type_t type,
                        CompilerType *pointee_type, bool *is_rvalue) override;
 
+  bool IsValidDereferenceType(lldb::opaque_compiler_type_t type) override;
+
   bool IsScalarType(lldb::opaque_compiler_type_t type) override;
 
   bool IsTypedefType(lldb::opaque_compiler_type_t type) override;

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -891,11 +891,9 @@ public:
 
   llvm::Expected<CompilerType> GetDereferencedType(
       lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx,
-      bool transparent_pointers, bool omit_empty_base_classes,
-      bool ignore_array_bounds, std::string &child_name,
-      uint32_t &child_byte_size, int32_t &child_byte_offset,
-      uint32_t &child_bitfield_bit_size, uint32_t &child_bitfield_bit_offset,
-      bool &child_is_base_class, bool &child_is_deref_of_parent,
+      std::string &child_name, uint32_t &child_byte_size,
+      int32_t &child_byte_offset, uint32_t &child_bitfield_bit_size,
+      uint32_t &child_bitfield_bit_offset, bool &child_is_base_class,
       ValueObject *valobj, uint64_t &language_flags, bool &type_valid) override;
 
   llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -897,14 +897,14 @@ llvm::Expected<CompilerType> CompilerType::GetDereferencedType(
     ExecutionContext *exe_ctx, std::string &child_name,
     uint32_t &child_byte_size, int32_t &child_byte_offset,
     uint32_t &child_bitfield_bit_size, uint32_t &child_bitfield_bit_offset,
-    bool &child_is_base_class, ValueObject *valobj, uint64_t &language_flags,
-    bool &type_valid) const {
+    bool &child_is_base_class, ValueObject *valobj,
+    uint64_t &language_flags) const {
   if (IsValid())
     if (auto type_system_sp = GetTypeSystem())
       return type_system_sp->GetDereferencedType(
           m_type, exe_ctx, child_name, child_byte_size, child_byte_offset,
           child_bitfield_bit_size, child_bitfield_bit_offset,
-          child_is_base_class, valobj, language_flags, type_valid);
+          child_is_base_class, valobj, language_flags);
   return CompilerType();
 }
 

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -895,16 +895,13 @@ CompilerDecl CompilerType::GetStaticFieldWithName(llvm::StringRef name) const {
 
 llvm::Expected<CompilerType> CompilerType::GetDereferencedType(
     ExecutionContext *exe_ctx, std::string &child_name,
-    uint32_t &child_byte_size, int32_t &child_byte_offset,
-    uint32_t &child_bitfield_bit_size, uint32_t &child_bitfield_bit_offset,
-    bool &child_is_base_class, ValueObject *valobj,
+    uint32_t &child_byte_size, int32_t &child_byte_offset, ValueObject *valobj,
     uint64_t &language_flags) const {
   if (IsValid())
     if (auto type_system_sp = GetTypeSystem())
       return type_system_sp->GetDereferencedType(
           m_type, exe_ctx, child_name, child_byte_size, child_byte_offset,
-          child_bitfield_bit_size, child_bitfield_bit_offset,
-          child_is_base_class, valobj, language_flags);
+          valobj, language_flags);
   return CompilerType();
 }
 

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -233,13 +233,6 @@ bool CompilerType::IsReferenceType(CompilerType *pointee_type,
   return false;
 }
 
-bool CompilerType::IsValidDereferenceType() const {
-  if (IsValid())
-    if (auto type_system_sp = GetTypeSystem())
-      return type_system_sp->IsValidDereferenceType(m_type);
-  return false;
-}
-
 bool CompilerType::ShouldTreatScalarValueAsAddress() const {
   if (IsValid())
     if (auto type_system_sp = GetTypeSystem())
@@ -898,6 +891,25 @@ CompilerDecl CompilerType::GetStaticFieldWithName(llvm::StringRef name) const {
   if (IsValid())
     return GetTypeSystem()->GetStaticFieldWithName(m_type, name);
   return CompilerDecl();
+}
+
+llvm::Expected<CompilerType> CompilerType::GetDereferencedType(
+    ExecutionContext *exe_ctx, bool transparent_pointers,
+    bool omit_empty_base_classes, bool ignore_array_bounds,
+    std::string &child_name, uint32_t &child_byte_size,
+    int32_t &child_byte_offset, uint32_t &child_bitfield_bit_size,
+    uint32_t &child_bitfield_bit_offset, bool &child_is_base_class,
+    bool &child_is_deref_of_parent, ValueObject *valobj,
+    uint64_t &language_flags, bool &type_valid) const {
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->GetDereferencedType(
+          m_type, exe_ctx, transparent_pointers, omit_empty_base_classes,
+          ignore_array_bounds, child_name, child_byte_size, child_byte_offset,
+          child_bitfield_bit_size, child_bitfield_bit_offset,
+          child_is_base_class, child_is_deref_of_parent, valobj, language_flags,
+          type_valid);
+  return CompilerType();
 }
 
 llvm::Expected<CompilerType> CompilerType::GetChildCompilerTypeAtIndex(

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -894,21 +894,17 @@ CompilerDecl CompilerType::GetStaticFieldWithName(llvm::StringRef name) const {
 }
 
 llvm::Expected<CompilerType> CompilerType::GetDereferencedType(
-    ExecutionContext *exe_ctx, bool transparent_pointers,
-    bool omit_empty_base_classes, bool ignore_array_bounds,
-    std::string &child_name, uint32_t &child_byte_size,
-    int32_t &child_byte_offset, uint32_t &child_bitfield_bit_size,
-    uint32_t &child_bitfield_bit_offset, bool &child_is_base_class,
-    bool &child_is_deref_of_parent, ValueObject *valobj,
-    uint64_t &language_flags, bool &type_valid) const {
+    ExecutionContext *exe_ctx, std::string &child_name,
+    uint32_t &child_byte_size, int32_t &child_byte_offset,
+    uint32_t &child_bitfield_bit_size, uint32_t &child_bitfield_bit_offset,
+    bool &child_is_base_class, ValueObject *valobj, uint64_t &language_flags,
+    bool &type_valid) const {
   if (IsValid())
     if (auto type_system_sp = GetTypeSystem())
       return type_system_sp->GetDereferencedType(
-          m_type, exe_ctx, transparent_pointers, omit_empty_base_classes,
-          ignore_array_bounds, child_name, child_byte_size, child_byte_offset,
+          m_type, exe_ctx, child_name, child_byte_size, child_byte_offset,
           child_bitfield_bit_size, child_bitfield_bit_offset,
-          child_is_base_class, child_is_deref_of_parent, valobj, language_flags,
-          type_valid);
+          child_is_base_class, valobj, language_flags, type_valid);
   return CompilerType();
 }
 

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -233,6 +233,13 @@ bool CompilerType::IsReferenceType(CompilerType *pointee_type,
   return false;
 }
 
+bool CompilerType::IsValidDereferenceType() const {
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsValidDereferenceType(m_type);
+  return false;
+}
+
 bool CompilerType::ShouldTreatScalarValueAsAddress() const {
   if (IsValid())
     if (auto type_system_sp = GetTypeSystem())

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -894,13 +894,13 @@ CompilerDecl CompilerType::GetStaticFieldWithName(llvm::StringRef name) const {
 }
 
 llvm::Expected<CompilerType> CompilerType::GetDereferencedType(
-    ExecutionContext *exe_ctx, std::string &child_name,
-    uint32_t &child_byte_size, int32_t &child_byte_offset, ValueObject *valobj,
+    ExecutionContext *exe_ctx, std::string &deref_name,
+    uint32_t &deref_byte_size, int32_t &deref_byte_offset, ValueObject *valobj,
     uint64_t &language_flags) const {
   if (IsValid())
     if (auto type_system_sp = GetTypeSystem())
       return type_system_sp->GetDereferencedType(
-          m_type, exe_ctx, child_name, child_byte_size, child_byte_offset,
+          m_type, exe_ctx, deref_name, deref_byte_size, deref_byte_offset,
           valobj, language_flags);
   return CompilerType();
 }

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -2794,56 +2794,56 @@ ValueObjectSP ValueObject::Dereference(Status &error) {
   if (m_deref_valobj)
     return m_deref_valobj->GetSP();
 
-  std::string child_name_str;
-  uint32_t child_byte_size = 0;
-  int32_t child_byte_offset = 0;
+  std::string deref_name_str;
+  uint32_t deref_byte_size = 0;
+  int32_t deref_byte_offset = 0;
   CompilerType compiler_type = GetCompilerType();
   uint64_t language_flags = 0;
 
   ExecutionContext exe_ctx(GetExecutionContextRef());
 
-  CompilerType child_compiler_type;
-  auto child_compiler_type_or_err = compiler_type.GetDereferencedType(
-      &exe_ctx, child_name_str, child_byte_size, child_byte_offset, this,
+  CompilerType deref_compiler_type;
+  auto deref_compiler_type_or_err = compiler_type.GetDereferencedType(
+      &exe_ctx, deref_name_str, deref_byte_size, deref_byte_offset, this,
       language_flags);
 
   std::string deref_error;
-  if (child_compiler_type_or_err) {
-    child_compiler_type = *child_compiler_type_or_err;
-    if (child_compiler_type && child_byte_size) {
-      ConstString child_name;
-      if (!child_name_str.empty())
-        child_name.SetCString(child_name_str.c_str());
+  if (deref_compiler_type_or_err) {
+    deref_compiler_type = *deref_compiler_type_or_err;
+    if (deref_compiler_type && deref_byte_size) {
+      ConstString deref_name;
+      if (!deref_name_str.empty())
+        deref_name.SetCString(deref_name_str.c_str());
 
       m_deref_valobj =
-          new ValueObjectChild(*this, child_compiler_type, child_name,
-                               child_byte_size, child_byte_offset, 0, 0, false,
+          new ValueObjectChild(*this, deref_compiler_type, deref_name,
+                               deref_byte_size, deref_byte_offset, 0, 0, false,
                                true, eAddressTypeInvalid, language_flags);
     }
 
-    // In case of incomplete child compiler type, use the pointee type and try
+    // In case of incomplete deref compiler type, use the pointee type and try
     // to recreate a new ValueObjectChild using it.
     if (!m_deref_valobj) {
       // FIXME(#59012): C++ stdlib formatters break with incomplete types (e.g.
       // `std::vector<int> &`). Remove ObjC restriction once that's resolved.
       if (Language::LanguageIsObjC(GetPreferredDisplayLanguage()) &&
           HasSyntheticValue()) {
-        child_compiler_type = compiler_type.GetPointeeType();
+        deref_compiler_type = compiler_type.GetPointeeType();
 
-        if (child_compiler_type) {
-          ConstString child_name;
-          if (!child_name_str.empty())
-            child_name.SetCString(child_name_str.c_str());
+        if (deref_compiler_type) {
+          ConstString deref_name;
+          if (!deref_name_str.empty())
+            deref_name.SetCString(deref_name_str.c_str());
 
           m_deref_valobj = new ValueObjectChild(
-              *this, child_compiler_type, child_name, child_byte_size,
-              child_byte_offset, 0, 0, false, true, eAddressTypeInvalid,
+              *this, deref_compiler_type, deref_name, deref_byte_size,
+              deref_byte_offset, 0, 0, false, true, eAddressTypeInvalid,
               language_flags);
         }
       }
     }
   } else {
-    deref_error = llvm::toString(child_compiler_type_or_err.takeError());
+    deref_error = llvm::toString(deref_compiler_type_or_err.takeError());
     LLDB_LOG(GetLog(LLDBLog::Types), "could not find child: {0}", deref_error);
     if (IsSynthetic()) {
       m_deref_valobj = GetChildMemberWithName("$$dereference$$").get();

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -2794,8 +2794,9 @@ ValueObjectSP ValueObject::Dereference(Status &error) {
   if (m_deref_valobj)
     return m_deref_valobj->GetSP();
 
-  const bool is_pointer_or_reference_type = IsPointerOrReferenceType();
-  if (is_pointer_or_reference_type) {
+  const bool is_valid_dereference_type =
+      GetCompilerType().IsValidDereferenceType();
+  if (is_valid_dereference_type) {
     bool omit_empty_base_classes = true;
     bool ignore_array_bounds = false;
 
@@ -2871,7 +2872,7 @@ ValueObjectSP ValueObject::Dereference(Status &error) {
     StreamString strm;
     GetExpressionPath(strm);
 
-    if (is_pointer_or_reference_type)
+    if (is_valid_dereference_type)
       error = Status::FromErrorStringWithFormat(
           "dereference failed: (%s) %s",
           GetTypeName().AsCString("<invalid type>"), strm.GetData());

--- a/lldb/test/API/commands/frame/var-dil/basics/PointerArithmetic/TestFrameVarDILPointerArithmetic.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/PointerArithmetic/TestFrameVarDILPointerArithmetic.py
@@ -33,11 +33,7 @@ class TestFrameVarDILGlobalVariableLookup(TestBase):
         self.expect_var_path("*offset_pref", True, type="int *")
         self.expect_var_path("**pp_int0", value="0")
         self.expect_var_path("&**pp_int0", type="int *")
-        self.expect(
-            "frame var '*array'",
-            error=True,
-            substrs=["not a pointer or reference type"],
-        )
+        self.expect_var_path("*array", value="0")
         self.expect(
             "frame var '&*p_null'",
             error=True,

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/optional/TestDataFormatterGenericOptional.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/optional/TestDataFormatterGenericOptional.py
@@ -88,7 +88,7 @@ class GenericOptionalDataFormatterTestCase(TestBase):
         self.expect(
             "frame variable *number_not_engaged",
             error=True,
-            substrs=["not a pointer or reference type"],
+            substrs=["dereference failed: not a"],
         )
 
     @add_test_categories(["libc++"])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/optional/TestDataFormatterGenericOptional.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/optional/TestDataFormatterGenericOptional.py
@@ -88,7 +88,7 @@ class GenericOptionalDataFormatterTestCase(TestBase):
         self.expect(
             "frame variable *number_not_engaged",
             error=True,
-            substrs=["dereference failed: not a"],
+            substrs=["dereference failed: not a pointer, reference or array type"],
         )
 
     @add_test_categories(["libc++"])


### PR DESCRIPTION
Add a function `GetDereferencedType` to `CompilerType` and allow `TypeSystemClang` to dereference arrays.