### PR TITLE
[HLSL] Boolean in a RawBuffer should be i32 and Boolean vector in a RawBuffer should be <N x i32>

### DIFF
--- a/clang/lib/CodeGen/Targets/DirectX.cpp
+++ b/clang/lib/CodeGen/Targets/DirectX.cpp
@@ -52,7 +52,7 @@ llvm::Type *DirectXTargetCodeGenInfo::getHLSLType(
       return nullptr;
 
     // convert element type
-    llvm::Type *ElemType = CGM.getTypes().ConvertType(ContainedTy);
+    llvm::Type *ElemType = CGM.getTypes().ConvertTypeForMem(ContainedTy);
 
     llvm::StringRef TypeName =
         ResAttrs.RawBuffer ? "dx.RawBuffer" : "dx.TypedBuffer";

--- a/clang/test/CodeGenHLSL/builtins/AppendStructuredBuffer-elementtype.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/AppendStructuredBuffer-elementtype.hlsl
@@ -20,6 +20,8 @@ struct MyStruct {
 // DXIL: %"class.hlsl::AppendStructuredBuffer.11" = type { target("dx.RawBuffer", <3 x float>, 1, 0)
 // DXIL: %"class.hlsl::AppendStructuredBuffer.12" = type { target("dx.RawBuffer", %struct.MyStruct, 1, 0)
 // DXIL: %struct.MyStruct = type { <4 x float>, <2 x i32>, [8 x i8] }
+// DXIL: %"class.hlsl::AppendStructuredBuffer.13" = type { target("dx.RawBuffer", i32, 1, 0)
+// DXIL: %"class.hlsl::AppendStructuredBuffer.14" = type { target("dx.RawBuffer", <4 x i32>, 1, 0)
 
 AppendStructuredBuffer<int16_t> BufI16;
 AppendStructuredBuffer<uint16_t> BufU16;
@@ -41,6 +43,8 @@ AppendStructuredBuffer<float3> BufF32x3;
 // TODO: AppendStructuredBuffer<snorm double> BufSNormF64;
 // TODO: AppendStructuredBuffer<unorm double> BufUNormF64;
 AppendStructuredBuffer<MyStruct> BufMyStruct;
+AppendStructuredBuffer<bool> BufBool;
+AppendStructuredBuffer<bool4> BufBoolVec;
 
 [numthreads(1,1,1)]
 void main(int GI : SV_GroupIndex) {

--- a/clang/test/CodeGenHLSL/builtins/ConsumeStructuredBuffer-elementtype.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/ConsumeStructuredBuffer-elementtype.hlsl
@@ -20,6 +20,8 @@ struct MyStruct {
 // DXIL: %"class.hlsl::ConsumeStructuredBuffer.11" = type { target("dx.RawBuffer", <3 x float>, 1, 0)
 // DXIL: %"class.hlsl::ConsumeStructuredBuffer.12" = type { target("dx.RawBuffer", %struct.MyStruct, 1, 0)
 // DXIL: %struct.MyStruct = type { <4 x float>, <2 x i32>, [8 x i8] }
+// DXIL: %"class.hlsl::ConsumeStructuredBuffer.13" = type { target("dx.RawBuffer", i32, 1, 0)
+// DXIL: %"class.hlsl::ConsumeStructuredBuffer.14" = type { target("dx.RawBuffer", <4 x i32>, 1, 0)
 
 ConsumeStructuredBuffer<int16_t> BufI16;
 ConsumeStructuredBuffer<uint16_t> BufU16;
@@ -41,6 +43,8 @@ ConsumeStructuredBuffer<float3> BufF32x3;
 // TODO: ConsumeStructuredBuffer<snorm double> BufSNormF64;
 // TODO: ConsumeStructuredBuffer<unorm double> BufUNormF64;
 ConsumeStructuredBuffer<MyStruct> BufMyStruct;
+ConsumeStructuredBuffer<bool> BufBool;
+ConsumeStructuredBuffer<bool4> BufBoolVec;
 
 [numthreads(1,1,1)]
 void main(int GI : SV_GroupIndex) {

--- a/clang/test/CodeGenHLSL/builtins/RWStructuredBuffer-elementtype.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/RWStructuredBuffer-elementtype.hlsl
@@ -13,6 +13,8 @@
 // CHECK: %"class.hlsl::RWStructuredBuffer.9" = type { target("dx.RawBuffer", <3 x i32>, 1, 0) }
 // CHECK: %"class.hlsl::RWStructuredBuffer.10" = type { target("dx.RawBuffer", <2 x half>, 1, 0) }
 // CHECK: %"class.hlsl::RWStructuredBuffer.11" = type { target("dx.RawBuffer", <3 x float>, 1, 0) }
+// CHECK: %"class.hlsl::RWStructuredBuffer.12" = type { target("dx.RawBuffer", i32, 1, 0) }
+// CHECK: %"class.hlsl::RWStructuredBuffer.13" = type { target("dx.RawBuffer", <4 x i32>, 1, 0) }
 
 RWStructuredBuffer<int16_t> BufI16;
 RWStructuredBuffer<uint16_t> BufU16;
@@ -27,6 +29,8 @@ RWStructuredBuffer< vector<int16_t, 4> > BufI16x4;
 RWStructuredBuffer< vector<uint, 3> > BufU32x3;
 RWStructuredBuffer<half2> BufF16x2;
 RWStructuredBuffer<float3> BufF32x3;
+RWStructuredBuffer<bool> BufBool;
+RWStructuredBuffer<bool4> BufBoolVec;
 // TODO: RWStructuredBuffer<snorm half> BufSNormF16;
 // TODO: RWStructuredBuffer<unorm half> BufUNormF16;
 // TODO: RWStructuredBuffer<snorm float> BufSNormF32;
@@ -49,4 +53,6 @@ void main(int GI : SV_GroupIndex) {
   BufU32x3[GI] = 0;
   BufF16x2[GI] = 0;
   BufF32x3[GI] = 0;
+  BufBool[GI] = false;
+  BufBool[GI] = false;
 }

--- a/clang/test/CodeGenHLSL/builtins/StructuredBuffer-elementtype.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/StructuredBuffer-elementtype.hlsl
@@ -13,6 +13,8 @@
 // CHECK: %"class.hlsl::StructuredBuffer.9" = type { target("dx.RawBuffer", <3 x i32>, 0, 0) }
 // CHECK: %"class.hlsl::StructuredBuffer.10" = type { target("dx.RawBuffer", <2 x half>, 0, 0) }
 // CHECK: %"class.hlsl::StructuredBuffer.11" = type { target("dx.RawBuffer", <3 x float>, 0, 0) }
+// CHECK: %"class.hlsl::StructuredBuffer.12" = type { target("dx.RawBuffer", i32, 0, 0) }
+// CHECK: %"class.hlsl::StructuredBuffer.13" = type { target("dx.RawBuffer", <4 x i32>, 0, 0) }
 
 StructuredBuffer<int16_t> BufI16;
 StructuredBuffer<uint16_t> BufU16;
@@ -27,6 +29,8 @@ StructuredBuffer< vector<int16_t, 4> > BufI16x4;
 StructuredBuffer< vector<uint, 3> > BufU32x3;
 StructuredBuffer<half2> BufF16x2;
 StructuredBuffer<float3> BufF32x3;
+StructuredBuffer<bool> BufBool;
+StructuredBuffer<bool4> BufBoolVec;
 // TODO: StructuredBuffer<snorm half> BufSNormF16;
 // TODO: StructuredBuffer<unorm half> BufUNormF16;
 // TODO: StructuredBuffer<snorm float> BufSNormF32;
@@ -49,4 +53,6 @@ void main(int GI : SV_GroupIndex) {
   vector<int, 3> v11 = BufU32x3[GI];
   half2 v12 = BufF16x2[GI];
   float3 v13 = BufF32x3[GI];
+  bool v14 = BufBool[GI];
+  bool4 v15 = BufBoolVec[GI];
 }


### PR DESCRIPTION
Instead of converting the type in a RawBuffer to its HLSL type using 'ConvertType', use 'ConvertTypeForMem'.
ConvertTypeForMem handles booleans being i32 and boolean vectors being < N x i32 >.
Add tests to show booleans and boolean vectors in RawBuffers now have the correct type of i32, and <N x i32> respectively.
Closes #135635