### PR TITLE
[flang] Fix fixed-form continuations of !$ OpenMP conditional lines

### DIFF
--- a/flang/test/Parser/continuation-in-conditional-compilation.f
+++ b/flang/test/Parser/continuation-in-conditional-compilation.f
@@ -5,6 +5,12 @@
       k01=1+
 !$   &  1
 
+! CHECK: !$    k02=23
+! CHECK: !$   &4
+!$    k02=2
+     +3
+!$   +4
+
 ! CHECK: !$omp parallel private(k01)
 !$omp parallel
 !$omp+ private(k01)

--- a/flang/test/Parser/unmatched-parens.f90
+++ b/flang/test/Parser/unmatched-parens.f90
@@ -1,4 +1,4 @@
-! RUN: not %flang_fc1 -E %s 2>&1 | FileCheck %s
+! RUN: not %flang_fc1 -fdebug-unparse %s 2>&1 | FileCheck %s
 do i = 1,10
   ! CHECK: Unmatched '('
   if (i != 0) then

--- a/flang/test/Preprocessing/implicit-contin3.F90
+++ b/flang/test/Preprocessing/implicit-contin3.F90
@@ -1,4 +1,4 @@
-! RUN: not %flang -E %s 2>&1 | FileCheck %s
+! RUN: not %flang_fc1 -fdebug-unparse %s 2>&1 | FileCheck %s
 ! Test implicit continuation for possible function-like macro calls only
 #define flm(x) x
 call notamacro(3


### PR DESCRIPTION
I broke fixed-form line continuation (without !$) for OpenMP !$ conditional compilation lines.  Fix it.