### PR TITLE
[nfc] Add doc comment for `canReturn` in Analysis/CFG.h

### DIFF
--- a/llvm/include/llvm/Analysis/CFG.h
+++ b/llvm/include/llvm/Analysis/CFG.h
@@ -174,7 +174,10 @@ bool containsIrreducibleCFG(RPOTraversalT &RPOTraversal, const LoopInfoT &LI) {
 
   return false;
 }
+
+/// Return true if there is at least a path through which F can return, false if
+/// there is no such path.
 bool canReturn(const Function &F);
-} // End llvm namespace
+} // namespace llvm
 
 #endif


### PR DESCRIPTION
Also drive-by fix of the // namespace comment.