### PR TITLE
[clang] Constant-evaluate format strings as last resort

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -407,7 +407,7 @@ related warnings within the method body.
     example.c:6:17: warning: format specifies type 'char *' but the argument has type 'int' [-Wformat]
         6 |     printf(format, 123);
           |            ~~~~~~  ^~~
-    <scratch space>:1:4: note: format string resolved to a constant string
+    <scratch space>:1:4: note: format string computed from non-literal expression
         1 | "hello %s"
           |        ^~
           |        %d

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -382,8 +382,39 @@ related warnings within the method body.
   ``format_matches`` accepts an example valid format string as its third
   argument. For more information, see the Clang attributes documentation.
 
-- Format string checking now supports the compile-time evaluation of format
-  strings as a fallback mechanism.
+- Clang can now verify format strings that can be constant-folded even if they
+  do not resolve to a string literal. For instance, all of these can now be
+  verified:
+
+  .. code-block:: c++
+
+    const char format[] = {'h', 'e', 'l', 'l', 'o', ' ', '%', 's', 0};
+    printf(format, "world");
+    // no warning
+    
+    printf(format, 123);
+    // warning: format specifies type 'char *' but the argument has type 'int'
+
+    printf(("%"s + "i"s).c_str(), "world");
+    // warning: format specifies type 'int' but the argument has type 'char *'
+  
+  When the format expression does not evaluate to a string literal, Clang
+  points diagnostics into a pseudo-file called ``<scratch space>`` that contains
+  the format string literal as it evaluated, like so:
+
+  .. code-block:: text
+
+    example.c:6:17: warning: format specifies type 'char *' but the argument has type 'int' [-Wformat]
+        6 |     printf(format, 123);
+          |            ~~~~~~  ^~~
+    <scratch space>:1:4: note: format string resolved to a constant string
+        1 | "hello %s"
+          |        ^~
+          |        %d
+  
+  This may mean that format strings which were previously unverified (or which
+  triggered ``-Wformat-nonliteral``) are now verified by ``-Wformat`` and its
+  allies.
 
 - Introduced a new statement attribute ``[[clang::atomic]]`` that enables
   fine-grained control over atomic code generation on a per-statement basis.

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -382,6 +382,9 @@ related warnings within the method body.
   ``format_matches`` accepts an example valid format string as its third
   argument. For more information, see the Clang attributes documentation.
 
+- Format string checking now supports the compile-time evaluation of format
+  strings as a fallback mechanism.
+
 - Introduced a new statement attribute ``[[clang::atomic]]`` that enables
   fine-grained control over atomic code generation on a per-statement basis.
   Supported options include ``[no_]remote_memory``,

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -809,7 +809,8 @@ public:
   /// \c NullTerminated is supplied, it is set to whether there is at least one
   /// NUL character in the string.
   std::optional<StringEvalResult>
-  tryEvaluateString(ASTContext &Ctx, bool *NullTerminated = nullptr) const;
+  tryEvaluateString(ASTContext &Ctx, bool *NullTerminated = nullptr,
+                    bool InConstantContext = false) const;
 
   /// Enumeration used to describe the kind of Null pointer constant
   /// returned from \c isNullPointerConstant().

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -791,7 +791,14 @@ public:
                                  const Expr *PtrExpression, ASTContext &Ctx,
                                  EvalResult &Status) const;
 
-  /// If the current Expr can be evaluated to a pointer to a null-terminated
+  /// Fill \c Into with the first characters that can be constant-evaluated
+  /// from this \c Expr . When encountering a null character, stop and return
+  /// \c true (the null is not returned in \c Into ). Return \c false if
+  /// evaluation runs off the end of the constant-evaluated string before it
+  /// encounters a null character.
+  bool tryEvaluateString(ASTContext &Ctx, std::string &Into) const;
+
+  /// If the current \c Expr can be evaluated to a pointer to a null-terminated
   /// constant string, return the constant string (without the terminating
   /// null).
   std::optional<std::string> tryEvaluateString(ASTContext &Ctx) const;

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -791,17 +791,25 @@ public:
                                  const Expr *PtrExpression, ASTContext &Ctx,
                                  EvalResult &Status) const;
 
-  /// Fill \c Into with the first characters that can be constant-evaluated
-  /// from this \c Expr . When encountering a null character, stop and return
-  /// \c true (the null is not returned in \c Into ). Return \c false if
-  /// evaluation runs off the end of the constant-evaluated string before it
-  /// encounters a null character.
-  bool tryEvaluateString(ASTContext &Ctx, std::string &Into) const;
+  class StringEvalResult {
+    std::string Storage;
+    const StringLiteral *SL;
+    uint64_t Offset;
 
-  /// If the current \c Expr can be evaluated to a pointer to a null-terminated
-  /// constant string, return the constant string (without the terminating
-  /// null).
-  std::optional<std::string> tryEvaluateString(ASTContext &Ctx) const;
+  public:
+    StringEvalResult(std::string Contents);
+    StringEvalResult(const StringLiteral *SL, uint64_t Offset);
+
+    llvm::StringRef getString() const;
+    bool getStringLiteral(const StringLiteral *&SL, uint64_t &Offset) const;
+  };
+
+  /// If the current \c Expr can be evaluated to a pointer to a constant string,
+  /// return the constant string. The string may not be NUL-terminated. If
+  /// \c NullTerminated is supplied, it is set to whether there is at least one
+  /// NUL character in the string.
+  std::optional<StringEvalResult>
+  tryEvaluateString(ASTContext &Ctx, bool *NullTerminated = nullptr) const;
 
   /// Enumeration used to describe the kind of Null pointer constant
   /// returned from \c isNullPointerConstant().

--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -791,26 +791,30 @@ public:
                                  const Expr *PtrExpression, ASTContext &Ctx,
                                  EvalResult &Status) const;
 
+  /// Represents the result of a string compile-time evaluation query. Can tell
+  /// whether the expression evaluated to a string literal, which is often
+  /// preferable if diagnostics are involved (since a string literal has
+  /// source location info), and whether the string was null-terminated.
   class StringEvalResult {
     std::string Storage;
     const StringLiteral *SL;
     uint64_t Offset;
+    bool HasNullTerminator;
 
   public:
-    StringEvalResult(std::string Contents);
-    StringEvalResult(const StringLiteral *SL, uint64_t Offset);
+    StringEvalResult(std::string Contents, bool HasNullTerminator);
+    StringEvalResult(const StringLiteral *SL, uint64_t Offset,
+                     bool HasNullTerminator);
 
     llvm::StringRef getString() const;
+    bool hasNullTerminator() const { return HasNullTerminator; }
     bool getStringLiteral(const StringLiteral *&SL, uint64_t &Offset) const;
   };
 
   /// If the current \c Expr can be evaluated to a pointer to a constant string,
-  /// return the constant string. The string may not be NUL-terminated. If
-  /// \c NullTerminated is supplied, it is set to whether there is at least one
-  /// NUL character in the string.
+  /// return the constant string. The string may not be NUL-terminated.
   std::optional<StringEvalResult>
-  tryEvaluateString(ASTContext &Ctx, bool *NullTerminated = nullptr,
-                    bool InConstantContext = false) const;
+  tryEvaluateString(ASTContext &Ctx, bool InConstantContext = false) const;
 
   /// Enumeration used to describe the kind of Null pointer constant
   /// returned from \c isNullPointerConstant().

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10355,7 +10355,7 @@ def warn_format_bool_as_character : Warning<
   InGroup<Format>;
 def note_format_string_defined : Note<"format string is defined here">;
 def note_format_string_evaluated_to : Note<
-  "format string resolved to a constant string">;
+  "format string computed from non-literal expression">;
 def note_format_fix_specifier : Note<"did you mean to use '%0'?">;
 def note_printf_c_str: Note<"did you mean to call the %0 method?">;
 def note_format_security_fixit: Note<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9268,7 +9268,7 @@ def err_expected_callable_argument : Error<
 def note_building_builtin_dump_struct_call : Note<
   "in call to printing function with arguments '(%0)' while dumping struct">;
 def err_builtin_verbose_trap_arg : Error<
-  "argument to __builtin_verbose_trap must %select{be a pointer to a constant NUL-terminated string|not contain $}0">;
+  "argument to '__builtin_verbose_trap' must %select{be a pointer to a constant null-terminated string|not contain $}0">;
 
 def err_atomic_load_store_uses_lib : Error<
   "atomic %select{load|store}0 requires runtime support that is not "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -9268,7 +9268,7 @@ def err_expected_callable_argument : Error<
 def note_building_builtin_dump_struct_call : Note<
   "in call to printing function with arguments '(%0)' while dumping struct">;
 def err_builtin_verbose_trap_arg : Error<
-  "argument to __builtin_verbose_trap must %select{be a pointer to a constant string|not contain $}0">;
+  "argument to __builtin_verbose_trap must %select{be a pointer to a constant NUL-terminated string|not contain $}0">;
 
 def err_atomic_load_store_uses_lib : Error<
   "atomic %select{load|store}0 requires runtime support that is not "

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10354,6 +10354,8 @@ def warn_format_bool_as_character : Warning<
   "using '%0' format specifier, but argument has boolean value">,
   InGroup<Format>;
 def note_format_string_defined : Note<"format string is defined here">;
+def note_format_string_evaluated_to : Note<
+  "format string was constant-evaluated">;
 def note_format_fix_specifier : Note<"did you mean to use '%0'?">;
 def note_printf_c_str: Note<"did you mean to call the %0 method?">;
 def note_format_security_fixit: Note<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10355,7 +10355,7 @@ def warn_format_bool_as_character : Warning<
   InGroup<Format>;
 def note_format_string_defined : Note<"format string is defined here">;
 def note_format_string_evaluated_to : Note<
-  "format string was constant-evaluated">;
+  "format string resolved to a constant string">;
 def note_format_fix_specifier : Note<"did you mean to use '%0'?">;
 def note_printf_c_str: Note<"did you mean to call the %0 method?">;
 def note_format_security_fixit: Note<

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -17981,14 +17981,17 @@ static bool EvaluateStringAsLValue(EvalInfo &Info, const Expr *E,
       String.addArray(Info, E, CAT);
     else
       String.addUnsizedArray(Info, E, CharTy);
-  } else if (Ty->hasPointerRepresentation()) {
+    return true;
+  }
+
+  if (Ty->hasPointerRepresentation()) {
     if (!EvaluatePointer(E, String, Info))
       return false;
     CharTy = Ty->getPointeeType();
-  } else {
-    return false;
+    return true;
   }
-  return true;
+
+  return false;
 }
 
 static const StringLiteral *StringLValueIsLiteral(EvalInfo &Info,

--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -726,12 +726,13 @@ static bool hasUnsafeFormatOrSArg(const CallExpr *Call, const Expr *&UnsafeArg,
   const Expr *Fmt = Call->getArg(FmtArgIdx);
 
   if (auto *SL = dyn_cast<clang::StringLiteral>(Fmt->IgnoreParenImpCasts())) {
+    std::optional<Expr::StringEvalResult> SER;
     StringRef FmtStr;
 
     if (SL->getCharByteWidth() == 1)
       FmtStr = SL->getString();
-    else if (auto EvaledFmtStr = SL->tryEvaluateString(Ctx))
-      FmtStr = *EvaledFmtStr;
+    else if ((SER = SL->tryEvaluateString(Ctx)))
+      FmtStr = SER->getString();
     else
       goto CHECK_UNSAFE_PTR;
 

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -3477,8 +3477,9 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     llvm::DILocation *TrapLocation = Builder.getCurrentDebugLocation();
     if (getDebugInfo()) {
       TrapLocation = getDebugInfo()->CreateTrapFailureMessageFor(
-          TrapLocation, *E->getArg(0)->tryEvaluateString(getContext()),
-          *E->getArg(1)->tryEvaluateString(getContext()));
+          TrapLocation,
+          E->getArg(0)->tryEvaluateString(getContext())->getString(),
+          E->getArg(1)->tryEvaluateString(getContext())->getString());
     }
     ApplyDebugLocation ApplyTrapDI(*this, TrapLocation);
     // Currently no attempt is made to prevent traps from being merged.

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -6074,8 +6074,7 @@ class FormatStringFinder {
                      ArrayRef<const Expr *> Args,
                      llvm::SmallBitVector &CheckedVarArgs,
                      UncoveredArgHandler &UncoveredArg,
-                     Sema::FormatArgumentPassingKind APK,
-                     FormatStringType Type,
+                     Sema::FormatArgumentPassingKind APK, FormatStringType Type,
                      VariadicCallType CallType, unsigned format_idx,
                      unsigned firstDataArg, bool InFunctionCall)
       : S(S), ReferenceFormatString(ReferenceFormatString), Args(Args),

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -6492,7 +6492,7 @@ EvaluateStringAndCreateLiteral(Sema &S, const Expr *E, const StringLiteral *&SL,
   if (SER->getStringLiteral(SL, Offset))
     return SLCER_Evaluated;
 
-  // Otherwise, lop that string into a scratch buffer, create a string literal
+  // Otherwise, plop that string into a scratch buffer, create a string literal
   // and then go with that.
   std::unique_ptr<llvm::MemoryBuffer> MemBuf;
   {

--- a/clang/test/Sema/format-strings.c
+++ b/clang/test/Sema/format-strings.c
@@ -1,12 +1,8 @@
+// #scratch_space
 // RUN: %clang_cc1 -fblocks -fsyntax-only -verify -Wformat-nonliteral -isystem %S/Inputs %s
 // RUN: %clang_cc1 -fblocks -fsyntax-only -verify -Wformat-nonliteral -isystem %S/Inputs -fno-signed-char %s
 // RUN: %clang_cc1 -fblocks -fsyntax-only -verify -Wformat-nonliteral -isystem %S/Inputs -triple=x86_64-unknown-fuchsia %s
 // RUN: %clang_cc1 -fblocks -fsyntax-only -verify -Wformat-nonliteral -isystem %S/Inputs -triple=x86_64-linux-android %s
-
-// expected-note@-5{{format string computed from non-literal expression}}
-// ^^^ there will be a <scratch space> SourceLocation caused by the
-// test_consteval_init_array test, that -verify treats as if it showed up at
-// line 1 of this file.
 
 #include <stdarg.h>
 #include <stddef.h>
@@ -913,4 +909,5 @@ void test_consteval_init_array(void) {
   const char buf[] = {'%', 55 * 2 + 5, '\n', 0};
   printf(buf, "hello"); // no-warning
   printf(buf, 123); // expected-warning{{format specifies type 'char *' but the argument has type 'int'}}
+  // expected-note@#scratch_space {{format string computed from non-literal expression}}
 }

--- a/clang/test/Sema/format-strings.c
+++ b/clang/test/Sema/format-strings.c
@@ -3,7 +3,7 @@
 // RUN: %clang_cc1 -fblocks -fsyntax-only -verify -Wformat-nonliteral -isystem %S/Inputs -triple=x86_64-unknown-fuchsia %s
 // RUN: %clang_cc1 -fblocks -fsyntax-only -verify -Wformat-nonliteral -isystem %S/Inputs -triple=x86_64-linux-android %s
 
-// expected-note@-5{{format string was constant-evaluated}}
+// expected-note@-5{{format string computed from non-literal expression}}
 // ^^^ there will be a <scratch space> SourceLocation caused by the
 // test_consteval_init_array test, that -verify treats as if it showed up at
 // line 1 of this file.

--- a/clang/test/SemaCXX/format-strings.cpp
+++ b/clang/test/SemaCXX/format-strings.cpp
@@ -310,24 +310,29 @@ void test_constexpr_string() {
 #endif
 
 #if __cplusplus >= 202300L
-constexpr const char *consteval_str() {
+constexpr const char *consteval_d() {
   if consteval {
-    return "%s";
+    return "%s"; // expected-note 3{{format string is defined here}}
   } else {
-    return "%d"; // expected-note 2{{format string is defined here}}
+    return "%d"; // expected-note{{format string is defined here}}
   }
 }
 
-constexpr const char *consteval_str_global = consteval_str();
+constexpr const char *consteval_s = consteval_d();
+constinit const char *const consteval_s2 = consteval_d();
 
 void test_consteval_str() {
-  printf(consteval_str(), 789); // no-warning
-  printf(consteval_str(), "hello"); // expected-warning {{format specifies type 'int' but the argument has type 'const char *'}}
+  printf(consteval_d(), 789); // no-warning
+  printf(consteval_d(), "hello"); // expected-warning {{format specifies type 'int' but the argument has type 'const char *'}}
 
-#if 0
-  // TODO: incorrect result
-  printf(consteval_str_global, 1234); // expected-warning {{format specifies type 'const char *' but the argument has type 'int'}}
-  printf(consteval_str_global, "hello"); // no-warning
-#endif
+  printf(consteval_s, 1234); // expected-warning {{format specifies type 'char *' but the argument has type 'int'}}
+  printf(consteval_s, "hello"); // no-warning
+
+  printf(consteval_s2, 1234); // expected-warning {{format specifies type 'char *' but the argument has type 'int'}}
+  printf(consteval_s2, "hello"); // no-warning
+
+  constexpr const char *consteval_s3 = consteval_d();
+  printf(consteval_s3, 1234); // expected-warning {{format specifies type 'char *' but the argument has type 'int'}}
+  printf(consteval_s3, "hello"); // no-warning
 }
 #endif

--- a/clang/test/SemaCXX/format-strings.cpp
+++ b/clang/test/SemaCXX/format-strings.cpp
@@ -4,7 +4,7 @@
 // RUN: %clang_cc1 -fsyntax-only -verify -Wformat-nonliteral -Wformat-non-iso -Wformat-pedantic -fblocks -std=c++20 %s
 
 #if __cplusplus >= 202000l
-// expected-note@-6{{format string was constant-evaluated}}
+// expected-note@-6{{format string computed from non-literal expression}}
 // ^^^ there will be a <scratch space> SourceLocation caused by the
 // test_constexpr_string test, that -verify treats as if it showed up at
 // line 1 of this file.

--- a/clang/test/SemaCXX/format-strings.cpp
+++ b/clang/test/SemaCXX/format-strings.cpp
@@ -324,7 +324,10 @@ void test_consteval_str() {
   printf(consteval_str(), 789); // no-warning
   printf(consteval_str(), "hello"); // expected-warning {{format specifies type 'int' but the argument has type 'const char *'}}
 
-  printf(consteval_str_global, 1234); // no-warning
-  printf(consteval_str_global, "hello"); // expected-warning {{format specifies type 'int' but the argument has type 'const char *'}}
+#if 0
+  // TODO: incorrect result
+  printf(consteval_str_global, 1234); // expected-warning {{format specifies type 'const char *' but the argument has type 'int'}}
+  printf(consteval_str_global, "hello"); // no-warning
+#endif
 }
 #endif

--- a/clang/test/SemaCXX/verbose-trap.cpp
+++ b/clang/test/SemaCXX/verbose-trap.cpp
@@ -15,6 +15,9 @@ char const constMsg3[] = "hello";
 
 template <const char * const category, const char * const reason>
 void f(const char * arg) {
+  const char buf[] = {'a', 'b', 'c'};
+  const char buf_nt1[] = {'a', 'b', 'c', 0};
+  const char buf_nt2[] = {'a', 'b', 0, 'c'};
   __builtin_verbose_trap("cat1", "Arbitrary string literals can be used!");
   __builtin_verbose_trap(" cat1 ", "Argument_must_not_be_null");
   __builtin_verbose_trap("cat" "egory1", "hello" "world");
@@ -24,9 +27,12 @@ void f(const char * arg) {
   __builtin_verbose_trap(); // expected-error {{too few arguments}}
   __builtin_verbose_trap(""); // expected-error {{too few arguments}}
   __builtin_verbose_trap("", "", ""); // expected-error {{too many arguments}}
-  __builtin_verbose_trap("", 0); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant string}}
+  __builtin_verbose_trap("", 0); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant NUL-terminated string}}
   __builtin_verbose_trap(1, ""); // expected-error {{cannot initialize a parameter of type 'const char *' with an rvalue of type 'int'}}
-  __builtin_verbose_trap(arg, ""); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant string}}
+  __builtin_verbose_trap(arg, ""); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant NUL-terminated string}}
+  __builtin_verbose_trap(buf, ""); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant NUL-terminated string}}
+  __builtin_verbose_trap(buf_nt1, "");
+  __builtin_verbose_trap(buf_nt2, "");
   __builtin_verbose_trap("cat$1", "hel$lo"); // expected-error 2 {{argument to __builtin_verbose_trap must not contain $}}
   __builtin_verbose_trap(category, reason);
   __builtin_verbose_trap(u8"cat1", u8"hello");

--- a/clang/test/SemaCXX/verbose-trap.cpp
+++ b/clang/test/SemaCXX/verbose-trap.cpp
@@ -27,13 +27,13 @@ void f(const char * arg) {
   __builtin_verbose_trap(); // expected-error {{too few arguments}}
   __builtin_verbose_trap(""); // expected-error {{too few arguments}}
   __builtin_verbose_trap("", "", ""); // expected-error {{too many arguments}}
-  __builtin_verbose_trap("", 0); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant NUL-terminated string}}
+  __builtin_verbose_trap("", 0); // expected-error {{argument to '__builtin_verbose_trap' must be a pointer to a constant null-terminated string}}
   __builtin_verbose_trap(1, ""); // expected-error {{cannot initialize a parameter of type 'const char *' with an rvalue of type 'int'}}
-  __builtin_verbose_trap(arg, ""); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant NUL-terminated string}}
-  __builtin_verbose_trap(buf, ""); // expected-error {{argument to __builtin_verbose_trap must be a pointer to a constant NUL-terminated string}}
+  __builtin_verbose_trap(arg, ""); // expected-error {{argument to '__builtin_verbose_trap' must be a pointer to a constant null-terminated string}}
+  __builtin_verbose_trap(buf, ""); // expected-error {{argument to '__builtin_verbose_trap' must be a pointer to a constant null-terminated string}}
   __builtin_verbose_trap(buf_nt1, "");
   __builtin_verbose_trap(buf_nt2, "");
-  __builtin_verbose_trap("cat$1", "hel$lo"); // expected-error 2 {{argument to __builtin_verbose_trap must not contain $}}
+  __builtin_verbose_trap("cat$1", "hel$lo"); // expected-error 2 {{argument to '__builtin_verbose_trap' must not contain $}}
   __builtin_verbose_trap(category, reason);
   __builtin_verbose_trap(u8"cat1", u8"hello");
 #if __cplusplus >= 202002L


### PR DESCRIPTION
I [asked on the forums](https://discourse.llvm.org/t/should-attribute-format-checking-try-to-const-evaluate-strings/85854/4) and people were generally supportive of the idea, so:

Clang's -Wformat checker can see through an inconsistent set of operations. We can fall back to the recently-updated constant string evaluation infrastructure when Clang's initial evaluation fails for a second chance at figuring out what the format string is intended to be. This enables analyzing format strings that were built at compile-time with std::string and other constexpr-capable types in C++, as long as all pieces are also constexpr-visible, and a number of other patterns.

As a side effect, it also enables `tryEvaluateString` on char arrays (rather than only char pointers).

Radar-ID: rdar://99940060