### PR TITLE
[lldb][nfc] Add customization flags for ThreadPlanStepOut

### DIFF
--- a/lldb/include/lldb/Target/ThreadPlanShouldStopHere.h
+++ b/lldb/include/lldb/Target/ThreadPlanShouldStopHere.h
@@ -60,7 +60,9 @@ public:
     eAvoidInlines = (1 << 0),
     eStepInAvoidNoDebug = (1 << 1),
     eStepOutAvoidNoDebug = (1 << 2),
-    eStepOutPastThunks = (1 << 3)
+    eStepOutPastThunks = (1 << 3),
+    eStepOutPastHiddenFunctions = (1 << 4),
+    eStepOutPastArtificialFunctions = (1 << 5),
   };
 
   // Constructors and Destructors

--- a/lldb/include/lldb/Target/ThreadPlanStepOut.h
+++ b/lldb/include/lldb/Target/ThreadPlanStepOut.h
@@ -17,12 +17,12 @@ namespace lldb_private {
 
 class ThreadPlanStepOut : public ThreadPlan, public ThreadPlanShouldStopHere {
 public:
-  ThreadPlanStepOut(Thread &thread, SymbolContext *addr_context,
-                    bool first_insn, bool stop_others, Vote report_stop_vote,
-                    Vote report_run_vote, uint32_t frame_idx,
-                    LazyBool step_out_avoids_code_without_debug_info,
-                    bool continue_to_next_branch = false,
-                    bool gather_return_value = true);
+  ThreadPlanStepOut(
+      Thread &thread, SymbolContext *addr_context, bool first_insn,
+      bool stop_others, Vote report_stop_vote, Vote report_run_vote,
+      uint32_t frame_idx, LazyBool step_out_avoids_code_without_debug_info,
+      bool continue_to_next_branch = false, bool gather_return_value = true,
+      lldb_private::Flags flags = ThreadPlanStepOut::s_default_flag_values);
 
   ~ThreadPlanStepOut() override;
 
@@ -86,6 +86,10 @@ private:
   // from step in.
 
   void CalculateReturnValue();
+
+  /// Computes the target frame this plan should step out to.
+  lldb::StackFrameSP ComputeTargetFrame(Thread &thread,
+                                        uint32_t start_frame_idx, Flags flags);
 
   ThreadPlanStepOut(const ThreadPlanStepOut &) = delete;
   const ThreadPlanStepOut &operator=(const ThreadPlanStepOut &) = delete;


### PR DESCRIPTION
ThreadPlanStepOut always skips over Hidden/Artificial frames when computing its destination frame, without providing any customization of this behavior. This is problematic for some plans like StepThrough, which may need to step out of a frame _without_ stepping out of a Hidden/Artificial frame. Any first step towards fixing this requires the ability to customize ThreadPlanStepOut, which is what this NFC patch addresses.

Since the computation of which frames to skip is done by the constructor, this patch adds a Flags parameter to
`ThreadPlanStepOut::ThreadPlanStepOut`.