### PR TITLE
[lldb][nfc] Remove redundant check in if statement

### DIFF
--- a/lldb/source/Target/ThreadPlanStepInRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepInRange.cpp
@@ -370,7 +370,7 @@ bool ThreadPlanStepInRange::DefaultShouldStopHereCallback(
   if (!should_stop_here)
     return false;
 
-  if (should_stop_here && current_plan->GetKind() == eKindStepInRange &&
+  if (current_plan->GetKind() == eKindStepInRange &&
       operation == eFrameCompareYounger) {
     ThreadPlanStepInRange *step_in_range_plan =
         static_cast<ThreadPlanStepInRange *>(current_plan);


### PR DESCRIPTION
We already check this boolean in the `if` statement two lines above.