### PR TITLE
[lldb-dap] Fixing a race during disconnect.

### DIFF
--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -921,7 +921,7 @@ llvm::Error DAP::Loop() {
     StopEventHandlers();
   });
 
-  while (!disconnecting) {
+  while (!disconnecting || !m_queue.empty()) {
     std::unique_lock<std::mutex> lock(m_queue_mutex);
     m_queue_cv.wait(lock, [&] { return disconnecting || !m_queue.empty(); });
 


### PR DESCRIPTION
While attempting to disconnect the DAP transport reader thread is setting
`disconnecting` as soon as it sees a [disconnect request](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Disconnect).

However, if it is processing another request when this disconnect arrives the `DAP::Loop` handler may exit the loop without replying to the disconnect request.

There has been some instability on the CI jobs due to this race, for example https://lab.llvm.org/buildbot/#/builders/59/builds/16076

To address this, ensure we only return from `DAP::Loop` once we've emptied the queue.