### PR TITLE
[HLSL] Don't invoke `dxv` from `clang-dxc` for text output

### DIFF
--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -309,6 +309,9 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
 }
 
 bool HLSLToolChain::requiresValidation(DerivedArgList &Args) const {
+  if (!Args.hasArg(options::OPT_dxc_Fo))
+    return false;
+
   if (Args.getLastArg(options::OPT_dxc_disable_validation))
     return false;
 

--- a/clang/test/Driver/HLSL/metal-converter.hlsl
+++ b/clang/test/Driver/HLSL/metal-converter.hlsl
@@ -1,11 +1,13 @@
-// RUN: %clang_dxc -T cs_6_0 %s -metal -Fo %t.mtl -### 2>&1 | FileCheck %s
-// RUN: %clang_dxc -T cs_6_0 %s -metal -Vd -Fo %t.mtl -### 2>&1 | FileCheck %s
-// CHECK: "{{.*}}metal-shaderconverter{{(.exe)?}}" "{{.*}}.obj" "-o" "{{.*}}.mtl"
+// RUN: echo "dxv" > %T/dxv && chmod 754 %T/dxv
+
+// RUN: env PATH="" %clang_dxc -T cs_6_0 %s -metal -Fo %t.mtl -### 2>&1 | FileCheck --check-prefix=NO_DXV %s
+// RUN: env PATH="" %clang_dxc -T cs_6_0 %s -metal -Vd -Fo %t.mtl -### 2>&1 | FileCheck --check-prefix=NO_DXV %s
+// RUN: env PATH="" %clang_dxc -T cs_6_0 %s --dxv-path=%T -metal -Vd -Fo %t.mtl -### 2>&1 | FileCheck --check-prefix=NO_DXV %s
+// NO_DXV: "{{.*}}metal-shaderconverter{{(.exe)?}}" "{{.*}}.obj" "-o" "{{.*}}.mtl"
 
 // RUN: %clang_dxc -T cs_6_0 %s -metal -### 2>&1 | FileCheck --check-prefix=NO_MTL %s
 // NO_MTL-NOT: metal-shaderconverter
 
-// RUN: echo "dxv" > %T/dxv && chmod 754 %T/dxv
 // RUN: %clang_dxc -T cs_6_0 %s --dxv-path=%T -metal -Fo %t.mtl -### 2>&1 | FileCheck --check-prefix=DXV %s
 // DXV: "{{.*}}dxv{{(.exe)?}}" "{{.*}}.obj" "-o" "{{.*}}.dxo"
 // DXV: "{{.*}}metal-shaderconverter{{(.exe)?}}" "{{.*}}.dxo" "-o" "{{.*}}.mtl"

--- a/clang/test/Driver/dxc_D.hlsl
+++ b/clang/test/Driver/dxc_D.hlsl
@@ -1,5 +1,4 @@
 // RUN: %clang_dxc -DTEST=2 -Tlib_6_7 -### %s 2>&1 | FileCheck %s
-// RUN: %clang_dxc -DTEST=2  -Tlib_6_7 %s | FileCheck %s --check-prefix=ERROR
 
 // Make sure -D send to cc1.
 // CHECK:"-D" "TEST=2"
@@ -9,5 +8,3 @@
 #elif TEST != 2
 #error "TEST defined to wrong value"
 #endif
-
-// ERROR-NOT: error:

--- a/clang/test/Driver/dxc_D.hlsl
+++ b/clang/test/Driver/dxc_D.hlsl
@@ -1,5 +1,5 @@
 // RUN: %clang_dxc -DTEST=2 -Tlib_6_7 -### %s 2>&1 | FileCheck %s
-// RUN: %clang_dxc -DTEST=2  -Tlib_6_7 %s -fcgl -Fo - | FileCheck %s --check-prefix=ERROR
+// RUN: %clang_dxc -DTEST=2  -Tlib_6_7 %s | FileCheck %s --check-prefix=ERROR
 
 // Make sure -D send to cc1.
 // CHECK:"-D" "TEST=2"

--- a/clang/test/Driver/dxc_dxv_path.hlsl
+++ b/clang/test/Driver/dxc_dxv_path.hlsl
@@ -1,10 +1,10 @@
-// RUN: %clang_dxc -I test -Tlib_6_3  -### %s 2>&1 | FileCheck %s
+// RUN: env PATH="" %clang_dxc -I test -Tlib_6_3 -Fo %T/a.dxo  -### %s 2>&1 | FileCheck %s
 
 // Make sure report warning.
 // CHECK:dxv not found
 
-// RUN: echo "dxv" > %T/dxv && chmod 754 %T/dxv && %clang_dxc --dxv-path=%T %s -Tlib_6_3 -### 2>&1 | FileCheck %s --check-prefix=DXV_PATH
-// DXV_PATH:dxv{{(.exe)?}}" "-" "-o" "{{.*}}.dxo"
+// RUN: echo "dxv" > %T/dxv && chmod 754 %T/dxv && %clang_dxc --dxv-path=%T %s -Tlib_6_3 -Fo %T/a.dxo -### 2>&1 | FileCheck %s --check-prefix=DXV_PATH
+// DXV_PATH:dxv{{(.exe)?}}" "{{.*}}.obj" "-o" "{{.*}}/a.dxo"
 
 // RUN: %clang_dxc -I test -Vd -Tlib_6_3  -### %s 2>&1 | FileCheck %s --check-prefix=VD
 // VD:"-cc1"{{.*}}"-triple" "dxilv1.3-unknown-shadermodel6.3-library"

--- a/clang/test/Driver/dxc_options.hlsl
+++ b/clang/test/Driver/dxc_options.hlsl
@@ -4,5 +4,4 @@
 // RUN: -fdiagnostics-color \
 // RUN: -fno-diagnostics-color \
 // RUN: -fdiagnostics-color=auto \
-// RUN: -Tlib_6_7 -Vd -fdriver-only -- %s 2>&1 |count 0
-
+// RUN: -Tlib_6_7 -fdriver-only -- %s 2>&1 |count 0

--- a/clang/test/Driver/hlsl-lang-targets.hlsl
+++ b/clang/test/Driver/hlsl-lang-targets.hlsl
@@ -2,10 +2,10 @@
 
 // Supported targets
 //
-// RUN: %clang -target dxil--shadermodel6.2-pixel %s -S -o /dev/null 2>&1 | FileCheck --check-prefix=CHECK-VALID %s
-// RUN: %clang -target dxil-unknown-shadermodel6.2-pixel %s -S -o /dev/null 2>&1 | FileCheck --check-prefix=CHECK-VALID %s
-// RUN: %clang -target dxil--shadermodel6.2-library %s -S -o /dev/null 2>&1 | FileCheck --check-prefix=CHECK-VALID %s
-// RUN: %clang -target dxil-unknown-shadermodel6.2-library %s -S -o /dev/null 2>&1 | FileCheck --check-prefix=CHECK-VALID %s
+// RUN: %clang -target dxil--shadermodel6.2-pixel %s -S -o /dev/null 2>&1 | FileCheck --allow-empty --check-prefix=CHECK-VALID %s
+// RUN: %clang -target dxil-unknown-shadermodel6.2-pixel %s -S -o /dev/null 2>&1 | FileCheck --allow-empty --check-prefix=CHECK-VALID %s
+// RUN: %clang -target dxil--shadermodel6.2-library %s -S -o /dev/null 2>&1 | FileCheck --allow-empty --check-prefix=CHECK-VALID %s
+// RUN: %clang -target dxil-unknown-shadermodel6.2-library %s -S -o /dev/null 2>&1 | FileCheck --allow-empty --check-prefix=CHECK-VALID %s
 
 // Empty shader model
 //


### PR DESCRIPTION
Running `clang-dxc` with textual output was emitting various spurious warnings (if `dxv` wasn't on your path) or errors (if it was). Avoid these by not attempting to run this tool when it doesn't make sense to do so.

Fixes #135874.