### PR TITLE
[flang] Improve OpenACC SELF clause parser

### DIFF
--- a/flang/lib/Parser/openacc-parsers.cpp
+++ b/flang/lib/Parser/openacc-parsers.cpp
@@ -126,8 +126,13 @@ TYPE_PARSER(construct<AccDefaultClause>(
 // SELF clause is either a simple optional condition for compute construct
 // or a synonym of the HOST clause for the update directive 2.14.4 holding
 // an object list.
-TYPE_PARSER(construct<AccSelfClause>(Parser<AccObjectList>{}) ||
-    construct<AccSelfClause>(scalarLogicalExpr))
+TYPE_PARSER(
+    construct<AccSelfClause>(Parser<AccObjectList>{}) / lookAhead(")"_tok) ||
+    construct<AccSelfClause>(scalarLogicalExpr / lookAhead(")"_tok)) ||
+    construct<AccSelfClause>(
+        recovery(fail<std::optional<ScalarLogicalExpr>>(
+                     "logical expression or object list expected"_err_en_US),
+            SkipTo<')'>{} >> pure<std::optional<ScalarLogicalExpr>>())))
 
 // Modifier for copyin, copyout, cache and create
 TYPE_PARSER(construct<AccDataModifier>(

--- a/flang/test/Semantics/OpenACC/bug135810-1.f90
+++ b/flang/test/Semantics/OpenACC/bug135810-1.f90
@@ -1,0 +1,14 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenacc
+integer function square(x, y)
+    implicit none
+    integer, intent(in) :: x, y
+    !$acc parallel self(x * 2 > x) ! ok
+    !$acc end parallel
+!ERROR: Must have LOGICAL type, but is INTEGER(4)
+    !$acc parallel self(x * 2)
+    !$acc end parallel
+!ERROR: SELF clause on the PARALLEL directive only accepts optional scalar logical expression
+    !$acc parallel self(x, y)
+    !$acc end parallel
+    square = x * x
+end function square

--- a/flang/test/Semantics/OpenACC/bug135810-2.f90
+++ b/flang/test/Semantics/OpenACC/bug135810-2.f90
@@ -1,0 +1,12 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenacc
+integer function square(x)
+    implicit none
+    integer, intent(in) :: x
+!ERROR: logical expression or object list expected
+    !$acc parallel self(,)
+    !$acc end parallel
+!ERROR: logical expression or object list expected
+    !$acc parallel self(.true., )
+    !$acc end parallel
+    square = x * x
+end function square


### PR DESCRIPTION
The current parser can fail on "self(x * 2)" by recognizing just "x" as a one-element list of object names and then failing at a higher level because it never reached the right parenthesis. Add lookahead checks and error recovery.

Fixes https://github.com/llvm/llvm-project/issues/135810.