### PR TITLE
[clang] Fix elaborated keyword canonicalization

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseConstraintsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseConstraintsCheck.cpp
@@ -54,8 +54,10 @@ static std::optional<TemplateSpecializationTypeLoc>
 matchEnableIfSpecializationImplTypename(TypeLoc TheType) {
   if (const auto Dep = TheType.getAs<DependentNameTypeLoc>()) {
     const IdentifierInfo *Identifier = Dep.getTypePtr()->getIdentifier();
+    ElaboratedTypeKeyword Keyword = Dep.getTypePtr()->getKeyword();
     if (!Identifier || Identifier->getName() != "type" ||
-        Dep.getTypePtr()->getKeyword() != ElaboratedTypeKeyword::Typename) {
+        (Keyword != ElaboratedTypeKeyword::Typename &&
+         Keyword != ElaboratedTypeKeyword::None)) {
       return std::nullopt;
     }
     TheType = Dep.getQualifierLoc().getTypeLoc();
@@ -108,8 +110,10 @@ matchEnableIfSpecializationImplTrait(TypeLoc TheType) {
 
     if (const auto *AliasedType =
             dyn_cast<DependentNameType>(Specialization->getAliasedType())) {
+      ElaboratedTypeKeyword Keyword = AliasedType->getKeyword();
       if (AliasedType->getIdentifier()->getName() != "type" ||
-          AliasedType->getKeyword() != ElaboratedTypeKeyword::Typename) {
+          (Keyword != ElaboratedTypeKeyword::Typename &&
+           Keyword != ElaboratedTypeKeyword::None)) {
         return std::nullopt;
       }
     } else {

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -476,6 +476,10 @@ Bug Fixes to C++ Support
 - Fixes matching of nested template template parameters. (#GH130362)
 - Correctly diagnoses template template paramters which have a pack parameter
   not in the last position.
+- Disallow overloading on struct vs class on dependent types, which is IFNDR, as
+  this makes the problem diagnosable.
+- Improved preservation of the presence or abscence of typename specifier when
+  printing types in diagnostics.
 - Clang now correctly parses ``if constexpr`` expressions in immediate function context. (#GH123524)
 - Fixed an assertion failure affecting code that uses C++23 "deducing this". (#GH130272)
 - Clang now properly instantiates destructors for initialized members within non-delegating constructors. (#GH93251)

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -2839,13 +2839,15 @@ public:
   template <typename T> const T *getAs() const;
 
   /// Look through sugar for an instance of TemplateSpecializationType which
-  /// is not a type alias.
+  /// is not a type alias, or null if there is no such type.
+  /// This is used when you want as-written template arguments or the template
+  /// name for a class template specialization.
   const TemplateSpecializationType *
   getAsNonAliasTemplateSpecializationType() const;
 
   const TemplateSpecializationType *
   castAsNonAliasTemplateSpecializationType() const {
-    auto TST = getAsNonAliasTemplateSpecializationType();
+    const auto *TST = getAsNonAliasTemplateSpecializationType();
     assert(TST && "not a TemplateSpecializationType");
     return TST;
   }

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -2838,6 +2838,18 @@ public:
   /// immediately following this class.
   template <typename T> const T *getAs() const;
 
+  /// Look through sugar for an instance of TemplateSpecializationType which
+  /// is not a type alias.
+  const TemplateSpecializationType *
+  getAsNonAliasTemplateSpecializationType() const;
+
+  const TemplateSpecializationType *
+  castAsNonAliasTemplateSpecializationType() const {
+    auto TST = getAsNonAliasTemplateSpecializationType();
+    assert(TST && "not a TemplateSpecializationType");
+    return TST;
+  }
+
   /// Member-template getAsAdjusted<specific type>. Look through specific kinds
   /// of sugar (parens, attributes, etc) for an instance of \<specific type>.
   /// This is used when you need to walk over sugar nodes that represent some

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -1940,13 +1940,10 @@ TagDecl *Type::getAsTagDecl() const {
 
 const TemplateSpecializationType *
 Type::getAsNonAliasTemplateSpecializationType() const {
-  for (const auto *T = this; /**/; /**/) {
-    const TemplateSpecializationType *TST =
-        T->getAs<TemplateSpecializationType>();
-    if (!TST || !TST->isTypeAlias())
-      return TST;
-    T = TST->desugar().getTypePtr();
-  }
+  const auto *TST = getAs<TemplateSpecializationType>();
+  while (TST && TST->isTypeAlias())
+    TST = TST->desugar()->getAs<TemplateSpecializationType>();
+  return TST;
 }
 
 bool Type::hasAttr(attr::Kind AK) const {

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -1938,6 +1938,17 @@ TagDecl *Type::getAsTagDecl() const {
   return nullptr;
 }
 
+const TemplateSpecializationType *
+Type::getAsNonAliasTemplateSpecializationType() const {
+  for (const auto *T = this; /**/; /**/) {
+    const TemplateSpecializationType *TST =
+        T->getAs<TemplateSpecializationType>();
+    if (!TST || !TST->isTypeAlias())
+      return TST;
+    T = TST->desugar().getTypePtr();
+  }
+}
+
 bool Type::hasAttr(attr::Kind AK) const {
   const Type *Cur = this;
   while (const auto *AT = Cur->getAs<AttributedType>()) {

--- a/clang/lib/AST/TypeLoc.cpp
+++ b/clang/lib/AST/TypeLoc.cpp
@@ -546,37 +546,47 @@ void UnaryTransformTypeLoc::initializeLocal(ASTContext &Context,
         Context.getTrivialTypeSourceInfo(getTypePtr()->getBaseType(), Loc));
 }
 
+template <class TL>
+static void initializeElaboratedKeyword(TL T, SourceLocation Loc) {
+  T.setElaboratedKeywordLoc(T.getTypePtr()->getKeyword() !=
+                                    ElaboratedTypeKeyword::None
+                                ? Loc
+                                : SourceLocation());
+}
+
+static NestedNameSpecifierLoc
+initializeQualifier(ASTContext &Context, NestedNameSpecifier *Qualifier,
+                    SourceLocation Loc) {
+  if (!Qualifier)
+    return NestedNameSpecifierLoc();
+  NestedNameSpecifierLocBuilder Builder;
+  Builder.MakeTrivial(Context, Qualifier, Loc);
+  return Builder.getWithLocInContext(Context);
+}
+
 void ElaboratedTypeLoc::initializeLocal(ASTContext &Context,
                                         SourceLocation Loc) {
   if (isEmpty())
     return;
-  setElaboratedKeywordLoc(Loc);
-  NestedNameSpecifierLocBuilder Builder;
-  Builder.MakeTrivial(Context, getTypePtr()->getQualifier(), Loc);
-  setQualifierLoc(Builder.getWithLocInContext(Context));
+  initializeElaboratedKeyword(*this, Loc);
+  setQualifierLoc(
+      initializeQualifier(Context, getTypePtr()->getQualifier(), Loc));
 }
 
 void DependentNameTypeLoc::initializeLocal(ASTContext &Context,
                                            SourceLocation Loc) {
-  setElaboratedKeywordLoc(Loc);
-  NestedNameSpecifierLocBuilder Builder;
-  Builder.MakeTrivial(Context, getTypePtr()->getQualifier(), Loc);
-  setQualifierLoc(Builder.getWithLocInContext(Context));
+  initializeElaboratedKeyword(*this, Loc);
+  setQualifierLoc(
+      initializeQualifier(Context, getTypePtr()->getQualifier(), Loc));
   setNameLoc(Loc);
 }
 
 void
 DependentTemplateSpecializationTypeLoc::initializeLocal(ASTContext &Context,
                                                         SourceLocation Loc) {
-  setElaboratedKeywordLoc(Loc);
-  if (NestedNameSpecifier *Qualifier =
-          getTypePtr()->getDependentTemplateName().getQualifier()) {
-    NestedNameSpecifierLocBuilder Builder;
-    Builder.MakeTrivial(Context, Qualifier, Loc);
-    setQualifierLoc(Builder.getWithLocInContext(Context));
-  } else {
-    setQualifierLoc(NestedNameSpecifierLoc());
-  }
+  initializeElaboratedKeyword(*this, Loc);
+  setQualifierLoc(initializeQualifier(
+      Context, getTypePtr()->getDependentTemplateName().getQualifier(), Loc));
   setTemplateKeywordLoc(Loc);
   setTemplateNameLoc(Loc);
   setLAngleLoc(Loc);

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -247,15 +247,15 @@ static ParsedType recoverFromTypeInKnownDependentBase(Sema &S,
     return nullptr;
 
   // We found some types in dependent base classes.  Recover as if the user
-  // wrote 'typename MyClass::II' instead of 'II'.  We'll fully resolve the
-  // lookup during template instantiation.
+  // wrote 'MyClass::II' instead of 'II', and this implicit typename was
+  // allowed.  We'll fully resolve the lookup during template instantiation.
   S.Diag(NameLoc, diag::ext_found_in_dependent_base) << &II;
 
   ASTContext &Context = S.Context;
   auto *NNS = NestedNameSpecifier::Create(
       Context, nullptr, cast<Type>(Context.getRecordType(RD)));
   QualType T =
-      Context.getDependentNameType(ElaboratedTypeKeyword::Typename, NNS, &II);
+      Context.getDependentNameType(ElaboratedTypeKeyword::None, NNS, &II);
 
   CXXScopeSpec SS;
   SS.MakeTrivial(Context, NNS, SourceRange(NameLoc));

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -9897,7 +9897,7 @@ QualType Sema::DeduceTemplateSpecializationFromInitializer(
 
   auto TemplateName = DeducedTST->getTemplateName();
   if (TemplateName.isDependent())
-    return SubstAutoTypeDependent(TSInfo->getType());
+    return SubstAutoTypeSourceInfoDependent(TSInfo)->getType();
 
   // We can only perform deduction for class templates or alias templates.
   auto *Template =
@@ -9942,7 +9942,7 @@ QualType Sema::DeduceTemplateSpecializationFromInitializer(
     Diag(TSInfo->getTypeLoc().getBeginLoc(),
          diag::warn_cxx14_compat_class_template_argument_deduction)
         << TSInfo->getTypeLoc().getSourceRange() << 0;
-    return SubstAutoTypeDependent(TSInfo->getType());
+    return SubstAutoTypeSourceInfoDependent(TSInfo)->getType();
   }
 
   // FIXME: Perform "exact type" matching first, per CWG discussion?
@@ -10253,7 +10253,8 @@ QualType Sema::DeduceTemplateSpecializationFromInitializer(
   //  The placeholder is replaced by the return type of the function selected
   //  by overload resolution for class template deduction.
   QualType DeducedType =
-      SubstAutoType(TSInfo->getType(), Best->Function->getReturnType());
+      SubstAutoTypeSourceInfo(TSInfo, Best->Function->getReturnType())
+          ->getType();
   Diag(TSInfo->getTypeLoc().getBeginLoc(),
        diag::warn_cxx14_compat_class_template_argument_deduction)
       << TSInfo->getTypeLoc().getSourceRange() << 1 << DeducedType;

--- a/clang/test/Analysis/anonymous-decls.cpp
+++ b/clang/test/Analysis/anonymous-decls.cpp
@@ -74,13 +74,13 @@ int main() {
 // CHECK-NEXT:   4: * [B3.3] (OperatorCall)
 // CHECK-NEXT:   5: auto &;
 // CHECK-NEXT:   6: get<0UL>
-// CHECK-NEXT:   7: [B3.6] (ImplicitCastExpr, FunctionToPointerDecay, typename tuple_element<0L, pair<int, int> >::type (*)(pair<int, int> &))
+// CHECK-NEXT:   7: [B3.6] (ImplicitCastExpr, FunctionToPointerDecay, tuple_element<0L, pair<int, int> >::type (*)(pair<int, int> &))
 // CHECK-NEXT:   8: decomposition-a-b
 // CHECK-NEXT:   9: [B3.7]([B3.8])
 // CHECK-NEXT:  10: [B3.9]
 // CHECK-NEXT:  11: std::tuple_element<0, std::pair<int, int>>::type a = get<0UL>(decomposition-a-b);
 // CHECK-NEXT:  12: get<1UL>
-// CHECK-NEXT:  13: [B3.12] (ImplicitCastExpr, FunctionToPointerDecay, typename tuple_element<1L, pair<int, int> >::type (*)(pair<int, int> &))
+// CHECK-NEXT:  13: [B3.12] (ImplicitCastExpr, FunctionToPointerDecay, tuple_element<1L, pair<int, int> >::type (*)(pair<int, int> &))
 // CHECK-NEXT:  14: decomposition-a-b
 // CHECK-NEXT:  15: [B3.13]([B3.14])
 // CHECK-NEXT:  16: [B3.15]

--- a/clang/test/CXX/drs/cwg23xx.cpp
+++ b/clang/test/CXX/drs/cwg23xx.cpp
@@ -91,7 +91,7 @@ struct Y {};
 struct Z : W,
   X, check_derived_from<Z, X>, // #cwg2310-X
   check_derived_from<Z, Y>, Y  // #cwg2310-Y
-{  
+{
   // FIXME: It was properly rejected before, but we're crashing since Clang 11 in C++11 and C++14 modes.
   //        See https://github.com/llvm/llvm-project/issues/59920
 #if __cplusplus >= 201703L
@@ -188,7 +188,7 @@ struct InitListCtor {
 
 std::initializer_list<InitListCtor> i;
 auto j = std::initializer_list<InitListCtor>{ i };
-// since-cxx17-error@-1 {{conversion function from 'std::initializer_list<InitListCtor>' to 'const cwg2311::InitListCtor' invokes a deleted function}}
+// since-cxx17-error@-1 {{conversion function from 'std::initializer_list<InitListCtor>' to 'const InitListCtor' invokes a deleted function}}
 //   since-cxx17-note@#cwg2311-InitListCtor {{'InitListCtor' has been explicitly marked deleted here}}
 #endif
 } // namespace cwg2311

--- a/clang/test/SemaTemplate/dependent-template-recover.cpp
+++ b/clang/test/SemaTemplate/dependent-template-recover.cpp
@@ -146,9 +146,9 @@ namespace templ_spec {
 
     // FIXME: Why error recovery for the non-typename case is so bad?
     A<T::template X<int>> t3; // expected-error {{did you forget 'typename'}}
-    // expected-error@-1 {{'A<typename T::X>' (aka 'void')}}
+    // expected-error@-1 {{'A<T::X>' (aka 'void')}}
 
     A<T::X<int>> t4; // expected-error {{use 'template' keyword}} expected-error {{did you forget 'typename'}}
-    // expected-error@-1 {{'A<typename T::X>' (aka 'void')}}
+    // expected-error@-1 {{'A<T::X>' (aka 'void')}}
   };
 } // namespace templ_spec

--- a/clang/test/SemaTemplate/elaborated-type-specifier.cpp
+++ b/clang/test/SemaTemplate/elaborated-type-specifier.cpp
@@ -10,7 +10,7 @@ namespace PR6915 {
   struct D1 {
     enum X { value };
   };
-  struct D2 { 
+  struct D2 {
     class X { }; // expected-note{{previous use is here}}
   };
   struct D3 { };
@@ -25,12 +25,12 @@ struct DeclOrDef {
   enum T::foo; // expected-error{{nested name specifier for a declaration cannot depend on a template parameter}}
                // expected-error@-1{{forward declaration of enum cannot have a nested name specifier}}
   enum T::bar { // expected-error{{nested name specifier for a declaration cannot depend on a template parameter}}
-    value 
+    value
   };
 };
 
 namespace PR6649 {
-  template <typename T> struct foo { 
+  template <typename T> struct foo {
     class T::bar;  // expected-error{{nested name specifier for a declaration cannot depend on a template parameter}}
                    // expected-error@-1{{forward declaration of class cannot have a nested name specifier}}
     class T::bar { int x; }; // expected-error{{nested name specifier for a declaration cannot depend on a template parameter}}
@@ -40,3 +40,60 @@ namespace PR6649 {
 namespace rdar8568507 {
   template <class T> struct A *makeA(T t);
 }
+
+namespace canon {
+  template <class T> void t1(struct T::X) {}
+  // expected-note@-1 {{previous definition is here}}
+  template <class T> void t1(class T::X) {}
+  // expected-error@-1 {{redefinition of 't1'}}
+
+  template <class T> void t2(struct T::template X<int>) {}
+  // expected-note@-1 {{previous definition is here}}
+  template <class T> void t2(class T::template X<int>) {}
+  // expected-error@-1 {{redefinition of 't2'}}
+
+  template <class T> constexpr int t3(typename T::X* = 0) { return 0; } // #canon-t3-0
+  template <class T> constexpr int t3(struct   T::X* = 0) { return 1; } // #canon-t3-1
+  template <class T> constexpr int t3(union    T::X* = 0) { return 2; } // #canon-t3-2
+  template <class T> constexpr int t3(enum     T::X* = 0) { return 3; } // #canon-t3-3
+
+  struct A { using X = int; };
+  static_assert(t3<A>() == 0);
+
+  struct B { struct X {}; };
+  static_assert(t3<B>() == 1);
+  // expected-error@-1 {{call to 't3' is ambiguous}}
+  // expected-note@#canon-t3-0 {{candidate function}}
+  // expected-note@#canon-t3-1 {{candidate function}}
+
+  struct C { union X {}; };
+  static_assert(t3<C>() == 2);
+  // expected-error@-1 {{call to 't3' is ambiguous}}
+  // expected-note@#canon-t3-0 {{candidate function}}
+  // expected-note@#canon-t3-2 {{candidate function}}
+
+  struct D { enum X {}; };
+  static_assert(t3<D>() == 3);
+  // expected-error@-1 {{call to 't3' is ambiguous}}
+  // expected-note@#canon-t3-0 {{candidate function}}
+  // expected-note@#canon-t3-3 {{candidate function}}
+
+  template <class T> constexpr int t4(typename T::template X<int>* = 0) { return 0; }
+  // expected-note@-1 3{{candidate function}}
+  template <class T> constexpr int t4(struct   T::template X<int>* = 0) { return 1; }
+  // expected-note@-1 3{{candidate function}}
+  template <class T> constexpr int t4(union    T::template X<int>* = 0) { return 2; }
+  // expected-note@-1 3{{candidate function}}
+
+  // FIXME: This should work.
+  struct E { template <class T> using X = T; };
+  static_assert(t4<E>() == 0); // expected-error {{call to 't4' is ambiguous}}
+
+  // FIXME: Should not match the union overload.
+  struct F { template <class> struct X {}; };
+  static_assert(t4<F>() == 1); // expected-error {{call to 't4' is ambiguous}}
+
+  // FIXME: Should not match the struct overload.
+  struct G { template <class> union X {}; };
+  static_assert(t4<G>() == 2); // expected-error {{call to 't4' is ambiguous}}
+} // namespace canon

--- a/clang/test/SemaTemplate/typename-specifier-3.cpp
+++ b/clang/test/SemaTemplate/typename-specifier-3.cpp
@@ -75,3 +75,21 @@ namespace PR12884_fixed {
 
   A<int>::C::x a; // ok
 }
+
+namespace preserve_keyword {
+  template <class T> struct A {
+    using type = T;
+  };
+
+  template <class T> using B = A<T>::type*; // precxx17-warning {{missing 'typename'}}
+  void *t1 = *B<int>(); // expected-error {{lvalue of type 'A<int>::type' (aka 'int')}}
+
+  template <class T> using C = typename A<T>::type*;
+  void *t2 = *C<int>(); // expected-error {{lvalue of type 'typename A<int>::type' (aka 'int')}}
+
+  using D = A<int>::type*;
+  void *t3 = *D(); // expected-error {{lvalue of type 'A<int>::type' (aka 'int')}}
+
+  using D = typename A<int>::type*;
+  void *t4 = *D(); // expected-error {{lvalue of type 'typename A<int>::type' (aka 'int')}}
+} // namespace preserve_keyword


### PR DESCRIPTION
This patches makes the rules for canonicalization of the elaborated keyword uniform
between DependentNameType and DependentTemplateSpecializationType.

`class` and `struct` keywords are functionally equivalent,
so relying on their equivalence was IFNDR.
This changes it so we treat them as equivalent,
as at least that disallows overloading, which is diagnosable.

This patch also considers a few drive by fixes to preservation
of the presence / absence of the typename keyword, and improves
a few assertions in that area.

Also improves preservation of sugar on initializer_list deduction
in order to avoid a few changes in diagnostics.