### PR TITLE
include telemetry session-id in diagnostic msg when enabled

### DIFF
--- a/lldb/include/lldb/Core/Telemetry.h
+++ b/lldb/include/lldb/Core/Telemetry.h
@@ -219,6 +219,8 @@ public:
 
   virtual llvm::StringRef GetInstanceName() const = 0;
 
+  llvm::StringRef GetSessionId() const;
+
   static TelemetryManager *GetInstance();
 
 protected:

--- a/lldb/source/Core/Telemetry.cpp
+++ b/lldb/source/Core/Telemetry.cpp
@@ -112,6 +112,8 @@ llvm::Error TelemetryManager::preDispatch(TelemetryInfo *entry) {
   return llvm::Error::success();
 }
 
+llvm::StringRef TelemetryManager::GetSessionid() const { return m_id; }
+
 class NoOpTelemetryManager : public TelemetryManager {
 public:
   llvm::Error preDispatch(llvm::telemetry::TelemetryInfo *entry) override {

--- a/lldb/source/Utility/Diagnostics.cpp
+++ b/lldb/source/Utility/Diagnostics.cpp
@@ -70,6 +70,9 @@ bool Diagnostics::Dump(raw_ostream &stream) {
 bool Diagnostics::Dump(raw_ostream &stream, const FileSpec &dir) {
   stream << "LLDB diagnostics will be written to " << dir.GetPath() << "\n";
   stream << "Please include the directory content when filing a bug report\n";
+  TelemetryManager *manager = TelemetryManager::GetInstance();
+  if (manager->GetConfig()->EnableTelemetry)
+    stream << "Telemetry-SessionId: " << manager->GetSessionid() << "\n";
 
   if (Error error = Create(dir)) {
     stream << toString(std::move(error)) << '\n';


### PR DESCRIPTION
If LLDB crashes, it's often helpful to know what the user was doing up to the point of the crash. Reporting the session-id helps us look up the relevant logs.

(Given Telemetry is disabled upstream, this change should mostly be a no-op change)

P.S: One option I'd considered was making this a vendor-specific code but since the diagnostic reporting code is pretty simple at the moment, I'm not sure it'd be worth turning it into a complex plugin system.