### PR TITLE
[AArch64] Replace 64-bit MADD with [SU]MADDL when possible

### DIFF
--- a/llvm/test/CodeGen/AArch64/aarch64-mull-masks.ll
+++ b/llvm/test/CodeGen/AArch64/aarch64-mull-masks.ll
@@ -12,7 +12,7 @@ define i64 @umull(i64 %x0, i64 %x1) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    mov w8, w0
 ; CHECK-GI-NEXT:    mov w9, w1
-; CHECK-GI-NEXT:    mul x0, x9, x8
+; CHECK-GI-NEXT:    umull x0, w9, w8
 ; CHECK-GI-NEXT:    ret
 entry:
   %and = and i64 %x0, 4294967295
@@ -31,7 +31,7 @@ define i64 @umull2(i64 %x, i32 %y) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    mov w8, w0
 ; CHECK-GI-NEXT:    mov w9, w1
-; CHECK-GI-NEXT:    mul x0, x8, x9
+; CHECK-GI-NEXT:    umull x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %and = and i64 %x, 4294967295
@@ -50,7 +50,7 @@ define i64 @umull2_commuted(i64 %x, i32 %y) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    mov w8, w0
 ; CHECK-GI-NEXT:    mov w9, w1
-; CHECK-GI-NEXT:    mul x0, x9, x8
+; CHECK-GI-NEXT:    umull x0, w9, w8
 ; CHECK-GI-NEXT:    ret
 entry:
   %and = and i64 %x, 4294967295
@@ -69,7 +69,7 @@ define i64 @smull(i64 %x0, i64 %x1) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    sxtw x8, w0
 ; CHECK-GI-NEXT:    sxtw x9, w1
-; CHECK-GI-NEXT:    mul x0, x9, x8
+; CHECK-GI-NEXT:    smull x0, w9, w8
 ; CHECK-GI-NEXT:    ret
 entry:
   %sext = shl i64 %x0, 32
@@ -91,7 +91,7 @@ define i64 @smull2(i64 %x, i32 %y) {
 ; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
 ; CHECK-GI-NEXT:    sxtw x8, w0
 ; CHECK-GI-NEXT:    sxtw x9, w1
-; CHECK-GI-NEXT:    mul x0, x8, x9
+; CHECK-GI-NEXT:    smull x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %shl = shl i64 %x, 32
@@ -112,7 +112,7 @@ define i64 @smull2_commuted(i64 %x, i32 %y) {
 ; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
 ; CHECK-GI-NEXT:    sxtw x8, w0
 ; CHECK-GI-NEXT:    sxtw x9, w1
-; CHECK-GI-NEXT:    mul x0, x9, x8
+; CHECK-GI-NEXT:    smull x0, w9, w8
 ; CHECK-GI-NEXT:    ret
 entry:
   %shl = shl i64 %x, 32
@@ -123,21 +123,13 @@ entry:
 }
 
 define i64 @smull_ldrsb_b(ptr %x0, i8 %x1) {
-; CHECK-SD-LABEL: smull_ldrsb_b:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsb x8, [x0]
-; CHECK-SD-NEXT:    sxtb x9, w1
-; CHECK-SD-NEXT:    smull x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smull_ldrsb_b:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsb x8, [x0]
-; CHECK-GI-NEXT:    sxtb x9, w1
-; CHECK-GI-NEXT:    mul x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smull_ldrsb_b:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsb x8, [x0]
+; CHECK-NEXT:    sxtb x9, w1
+; CHECK-NEXT:    smull x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
   %sext = sext i8 %ext64 to i64
@@ -147,21 +139,13 @@ entry:
 }
 
 define i64 @smull_ldrsb_b_commuted(ptr %x0, i8 %x1) {
-; CHECK-SD-LABEL: smull_ldrsb_b_commuted:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsb x8, [x0]
-; CHECK-SD-NEXT:    sxtb x9, w1
-; CHECK-SD-NEXT:    smull x0, w9, w8
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smull_ldrsb_b_commuted:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsb x8, [x0]
-; CHECK-GI-NEXT:    sxtb x9, w1
-; CHECK-GI-NEXT:    mul x0, x9, x8
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smull_ldrsb_b_commuted:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsb x8, [x0]
+; CHECK-NEXT:    sxtb x9, w1
+; CHECK-NEXT:    smull x0, w9, w8
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
   %sext = sext i8 %ext64 to i64
@@ -171,21 +155,13 @@ entry:
 }
 
 define i64 @smull_ldrsb_h(ptr %x0, i16 %x1) {
-; CHECK-SD-LABEL: smull_ldrsb_h:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsb x8, [x0]
-; CHECK-SD-NEXT:    sxth x9, w1
-; CHECK-SD-NEXT:    smull x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smull_ldrsb_h:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsb x8, [x0]
-; CHECK-GI-NEXT:    sxth x9, w1
-; CHECK-GI-NEXT:    mul x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smull_ldrsb_h:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsb x8, [x0]
+; CHECK-NEXT:    sxth x9, w1
+; CHECK-NEXT:    smull x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
   %sext = sext i8 %ext64 to i64
@@ -206,7 +182,7 @@ define i64 @smull_ldrsb_w(ptr %x0, i32 %x1) {
 ; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
 ; CHECK-GI-NEXT:    ldrsb x8, [x0]
 ; CHECK-GI-NEXT:    sxtw x9, w1
-; CHECK-GI-NEXT:    mul x0, x8, x9
+; CHECK-GI-NEXT:    smull x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
@@ -217,21 +193,13 @@ entry:
 }
 
 define i64 @smull_ldrsh_b(ptr %x0, i8 %x1) {
-; CHECK-SD-LABEL: smull_ldrsh_b:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsh x8, [x0]
-; CHECK-SD-NEXT:    sxtb x9, w1
-; CHECK-SD-NEXT:    smull x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smull_ldrsh_b:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsh x8, [x0]
-; CHECK-GI-NEXT:    sxtb x9, w1
-; CHECK-GI-NEXT:    mul x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smull_ldrsh_b:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsh x8, [x0]
+; CHECK-NEXT:    sxtb x9, w1
+; CHECK-NEXT:    smull x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i16, ptr %x0
   %sext = sext i16 %ext64 to i64
@@ -241,21 +209,13 @@ entry:
 }
 
 define i64 @smull_ldrsh_h(ptr %x0, i16 %x1) {
-; CHECK-SD-LABEL: smull_ldrsh_h:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsh x8, [x0]
-; CHECK-SD-NEXT:    sxth x9, w1
-; CHECK-SD-NEXT:    smull x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smull_ldrsh_h:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsh x8, [x0]
-; CHECK-GI-NEXT:    sxth x9, w1
-; CHECK-GI-NEXT:    mul x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smull_ldrsh_h:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsh x8, [x0]
+; CHECK-NEXT:    sxth x9, w1
+; CHECK-NEXT:    smull x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i16, ptr %x0
   %sext = sext i16 %ext64 to i64
@@ -265,21 +225,13 @@ entry:
 }
 
 define i64 @smull_ldrsh_h_commuted(ptr %x0, i16 %x1) {
-; CHECK-SD-LABEL: smull_ldrsh_h_commuted:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsh x8, [x0]
-; CHECK-SD-NEXT:    sxth x9, w1
-; CHECK-SD-NEXT:    smull x0, w9, w8
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smull_ldrsh_h_commuted:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsh x8, [x0]
-; CHECK-GI-NEXT:    sxth x9, w1
-; CHECK-GI-NEXT:    mul x0, x9, x8
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smull_ldrsh_h_commuted:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsh x8, [x0]
+; CHECK-NEXT:    sxth x9, w1
+; CHECK-NEXT:    smull x0, w9, w8
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i16, ptr %x0
   %sext = sext i16 %ext64 to i64
@@ -300,7 +252,7 @@ define i64 @smull_ldrsh_w(ptr %x0, i32 %x1) {
 ; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
 ; CHECK-GI-NEXT:    ldrsh x8, [x0]
 ; CHECK-GI-NEXT:    sxtw x9, w1
-; CHECK-GI-NEXT:    mul x0, x8, x9
+; CHECK-GI-NEXT:    smull x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i16, ptr %x0
@@ -311,21 +263,13 @@ entry:
 }
 
 define i64 @smull_ldrsw_b(ptr %x0, i8 %x1) {
-; CHECK-SD-LABEL: smull_ldrsw_b:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsw x8, [x0]
-; CHECK-SD-NEXT:    sxtb x9, w1
-; CHECK-SD-NEXT:    smull x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smull_ldrsw_b:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsw x8, [x0]
-; CHECK-GI-NEXT:    sxtb x9, w1
-; CHECK-GI-NEXT:    mul x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smull_ldrsw_b:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsw x8, [x0]
+; CHECK-NEXT:    sxtb x9, w1
+; CHECK-NEXT:    smull x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
   %sext = sext i32 %ext64 to i64
@@ -335,21 +279,13 @@ entry:
 }
 
 define i64 @smull_ldrsw_h(ptr %x0, i16 %x1) {
-; CHECK-SD-LABEL: smull_ldrsw_h:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsw x8, [x0]
-; CHECK-SD-NEXT:    sxth x9, w1
-; CHECK-SD-NEXT:    smull x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smull_ldrsw_h:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsw x8, [x0]
-; CHECK-GI-NEXT:    sxth x9, w1
-; CHECK-GI-NEXT:    mul x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smull_ldrsw_h:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsw x8, [x0]
+; CHECK-NEXT:    sxth x9, w1
+; CHECK-NEXT:    smull x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
   %sext = sext i32 %ext64 to i64
@@ -370,7 +306,7 @@ define i64 @smull_ldrsw_w(ptr %x0, i32 %x1) {
 ; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
 ; CHECK-GI-NEXT:    ldrsw x8, [x0]
 ; CHECK-GI-NEXT:    sxtw x9, w1
-; CHECK-GI-NEXT:    mul x0, x8, x9
+; CHECK-GI-NEXT:    smull x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
@@ -392,7 +328,7 @@ define i64 @smull_ldrsw_w_commuted(ptr %x0, i32 %x1) {
 ; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
 ; CHECK-GI-NEXT:    ldrsw x8, [x0]
 ; CHECK-GI-NEXT:    sxtw x9, w1
-; CHECK-GI-NEXT:    mul x0, x9, x8
+; CHECK-GI-NEXT:    smull x0, w9, w8
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
@@ -418,7 +354,7 @@ define i64 @smull_sext_bb(i8 %x0, i8 %x1) {
 ; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
 ; CHECK-GI-NEXT:    sxtb x8, w0
 ; CHECK-GI-NEXT:    sxtb x9, w1
-; CHECK-GI-NEXT:    mul x0, x8, x9
+; CHECK-GI-NEXT:    smull x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %sext = sext i8 %x0 to i64
@@ -438,7 +374,7 @@ define i64 @smull_ldrsw_shift(ptr %x0, i64 %x1) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldrsw x8, [x0]
 ; CHECK-GI-NEXT:    sxtw x9, w1
-; CHECK-GI-NEXT:    mul x0, x8, x9
+; CHECK-GI-NEXT:    smull x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
@@ -465,21 +401,13 @@ entry:
 }
 
 define i64 @smull_ldrsw_zexth(ptr %x0, i16 %x1) {
-; CHECK-SD-LABEL: smull_ldrsw_zexth:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldrsw x8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xffff
-; CHECK-SD-NEXT:    smull x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smull_ldrsw_zexth:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldrsw x8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xffff
-; CHECK-GI-NEXT:    mul x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smull_ldrsw_zexth:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldrsw x8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xffff
+; CHECK-NEXT:    smull x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
   %sext = sext i32 %ext64 to i64
@@ -489,21 +417,13 @@ entry:
 }
 
 define i64 @smull_ldrsw_zextb(ptr %x0, i8 %x1) {
-; CHECK-SD-LABEL: smull_ldrsw_zextb:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldrsw x8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xff
-; CHECK-SD-NEXT:    smull x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smull_ldrsw_zextb:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldrsw x8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xff
-; CHECK-GI-NEXT:    mul x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smull_ldrsw_zextb:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldrsw x8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xff
+; CHECK-NEXT:    smull x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
   %sext = sext i32 %ext64 to i64
@@ -513,21 +433,13 @@ entry:
 }
 
 define i64 @smull_ldrsw_zextb_commuted(ptr %x0, i8 %x1) {
-; CHECK-SD-LABEL: smull_ldrsw_zextb_commuted:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldrsw x8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xff
-; CHECK-SD-NEXT:    smull x0, w9, w8
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smull_ldrsw_zextb_commuted:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldrsw x8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xff
-; CHECK-GI-NEXT:    mul x0, x9, x8
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smull_ldrsw_zextb_commuted:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldrsw x8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xff
+; CHECK-NEXT:    smull x0, w9, w8
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
   %sext = sext i32 %ext64 to i64
@@ -537,21 +449,13 @@ entry:
 }
 
 define i64 @smaddl_ldrsb_h(ptr %x0, i16 %x1, i64 %x2) {
-; CHECK-SD-LABEL: smaddl_ldrsb_h:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsb x8, [x0]
-; CHECK-SD-NEXT:    sxth x9, w1
-; CHECK-SD-NEXT:    smaddl x0, w8, w9, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smaddl_ldrsb_h:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsb x8, [x0]
-; CHECK-GI-NEXT:    sxth x9, w1
-; CHECK-GI-NEXT:    madd x0, x8, x9, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smaddl_ldrsb_h:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsb x8, [x0]
+; CHECK-NEXT:    sxth x9, w1
+; CHECK-NEXT:    smaddl x0, w8, w9, x2
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
   %sext = sext i8 %ext64 to i64
@@ -562,21 +466,13 @@ entry:
 }
 
 define i64 @smaddl_ldrsb_h_commuted(ptr %x0, i16 %x1, i64 %x2) {
-; CHECK-SD-LABEL: smaddl_ldrsb_h_commuted:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsb x8, [x0]
-; CHECK-SD-NEXT:    sxth x9, w1
-; CHECK-SD-NEXT:    smaddl x0, w9, w8, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smaddl_ldrsb_h_commuted:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsb x8, [x0]
-; CHECK-GI-NEXT:    sxth x9, w1
-; CHECK-GI-NEXT:    madd x0, x9, x8, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smaddl_ldrsb_h_commuted:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsb x8, [x0]
+; CHECK-NEXT:    sxth x9, w1
+; CHECK-NEXT:    smaddl x0, w9, w8, x2
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
   %sext = sext i8 %ext64 to i64
@@ -598,7 +494,7 @@ define i64 @smaddl_ldrsh_w(ptr %x0, i32 %x1, i64 %x2) {
 ; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
 ; CHECK-GI-NEXT:    ldrsh x8, [x0]
 ; CHECK-GI-NEXT:    sxtw x9, w1
-; CHECK-GI-NEXT:    madd x0, x8, x9, x2
+; CHECK-GI-NEXT:    smaddl x0, w8, w9, x2
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i16, ptr %x0
@@ -621,7 +517,7 @@ define i64 @smaddl_ldrsh_w_commuted(ptr %x0, i32 %x1, i64 %x2) {
 ; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
 ; CHECK-GI-NEXT:    ldrsh x8, [x0]
 ; CHECK-GI-NEXT:    sxtw x9, w1
-; CHECK-GI-NEXT:    madd x0, x9, x8, x2
+; CHECK-GI-NEXT:    smaddl x0, w9, w8, x2
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i16, ptr %x0
@@ -633,21 +529,13 @@ entry:
 }
 
 define i64 @smaddl_ldrsw_b(ptr %x0, i8 %x1, i64 %x2) {
-; CHECK-SD-LABEL: smaddl_ldrsw_b:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsw x8, [x0]
-; CHECK-SD-NEXT:    sxtb x9, w1
-; CHECK-SD-NEXT:    smaddl x0, w8, w9, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smaddl_ldrsw_b:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsw x8, [x0]
-; CHECK-GI-NEXT:    sxtb x9, w1
-; CHECK-GI-NEXT:    madd x0, x8, x9, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smaddl_ldrsw_b:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsw x8, [x0]
+; CHECK-NEXT:    sxtb x9, w1
+; CHECK-NEXT:    smaddl x0, w8, w9, x2
+; CHECK-NEXT:    ret
   %ext64 = load i32, ptr %x0
   %sext = sext i32 %ext64 to i64
   %sext2 = sext i8 %x1 to i64
@@ -657,21 +545,13 @@ define i64 @smaddl_ldrsw_b(ptr %x0, i8 %x1, i64 %x2) {
 }
 
 define i64 @smaddl_ldrsw_b_commuted(ptr %x0, i8 %x1, i64 %x2) {
-; CHECK-SD-LABEL: smaddl_ldrsw_b_commuted:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsw x8, [x0]
-; CHECK-SD-NEXT:    sxtb x9, w1
-; CHECK-SD-NEXT:    smaddl x0, w9, w8, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smaddl_ldrsw_b_commuted:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsw x8, [x0]
-; CHECK-GI-NEXT:    sxtb x9, w1
-; CHECK-GI-NEXT:    madd x0, x9, x8, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smaddl_ldrsw_b_commuted:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsw x8, [x0]
+; CHECK-NEXT:    sxtb x9, w1
+; CHECK-NEXT:    smaddl x0, w9, w8, x2
+; CHECK-NEXT:    ret
   %ext64 = load i32, ptr %x0
   %sext = sext i32 %ext64 to i64
   %sext2 = sext i8 %x1 to i64
@@ -681,19 +561,12 @@ define i64 @smaddl_ldrsw_b_commuted(ptr %x0, i8 %x1, i64 %x2) {
 }
 
 define i64 @smaddl_ldrsw_ldrsw(ptr %x0, ptr %x1, i64 %x2) {
-; CHECK-SD-LABEL: smaddl_ldrsw_ldrsw:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldrsw x8, [x0]
-; CHECK-SD-NEXT:    ldrsw x9, [x1]
-; CHECK-SD-NEXT:    smaddl x0, w8, w9, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smaddl_ldrsw_ldrsw:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldrsw x8, [x0]
-; CHECK-GI-NEXT:    ldrsw x9, [x1]
-; CHECK-GI-NEXT:    madd x0, x8, x9, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smaddl_ldrsw_ldrsw:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldrsw x8, [x0]
+; CHECK-NEXT:    ldrsw x9, [x1]
+; CHECK-NEXT:    smaddl x0, w8, w9, x2
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
   %ext64_2 = load i32, ptr %x1
@@ -720,7 +593,7 @@ define i64 @smaddl_sext_hh(i16 %x0, i16 %x1, i64 %x2) {
 ; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
 ; CHECK-GI-NEXT:    sxth x8, w0
 ; CHECK-GI-NEXT:    sxth x9, w1
-; CHECK-GI-NEXT:    madd x0, x8, x9, x2
+; CHECK-GI-NEXT:    smaddl x0, w8, w9, x2
 ; CHECK-GI-NEXT:    ret
 entry:
   %sext = sext i16 %x0 to i64
@@ -741,7 +614,7 @@ define i64 @smaddl_ldrsw_shift(ptr %x0, i64 %x1, i64 %x2) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldrsw x8, [x0]
 ; CHECK-GI-NEXT:    sxtw x9, w1
-; CHECK-GI-NEXT:    madd x0, x8, x9, x2
+; CHECK-GI-NEXT:    smaddl x0, w8, w9, x2
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
@@ -754,21 +627,13 @@ entry:
 }
 
 define i64 @smaddl_ldrsw_zextb(ptr %x0, i8 %x1, i64 %x2) {
-; CHECK-SD-LABEL: smaddl_ldrsw_zextb:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldrsw x8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xff
-; CHECK-SD-NEXT:    smaddl x0, w8, w9, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smaddl_ldrsw_zextb:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldrsw x8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xff
-; CHECK-GI-NEXT:    madd x0, x8, x9, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smaddl_ldrsw_zextb:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldrsw x8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xff
+; CHECK-NEXT:    smaddl x0, w8, w9, x2
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
   %sext = sext i32 %ext64 to i64
@@ -779,21 +644,13 @@ entry:
 }
 
 define i64 @smnegl_ldrsb_h(ptr %x0, i16 %x1) {
-; CHECK-SD-LABEL: smnegl_ldrsb_h:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsb x8, [x0]
-; CHECK-SD-NEXT:    sxth x9, w1
-; CHECK-SD-NEXT:    smnegl x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smnegl_ldrsb_h:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsb x8, [x0]
-; CHECK-GI-NEXT:    sxth x9, w1
-; CHECK-GI-NEXT:    mneg x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smnegl_ldrsb_h:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsb x8, [x0]
+; CHECK-NEXT:    sxth x9, w1
+; CHECK-NEXT:    smnegl x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
   %sext = sext i8 %ext64 to i64
@@ -804,21 +661,13 @@ entry:
 }
 
 define i64 @smnegl_ldrsb_h_commuted(ptr %x0, i16 %x1) {
-; CHECK-SD-LABEL: smnegl_ldrsb_h_commuted:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsb x8, [x0]
-; CHECK-SD-NEXT:    sxth x9, w1
-; CHECK-SD-NEXT:    smnegl x0, w9, w8
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smnegl_ldrsb_h_commuted:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsb x8, [x0]
-; CHECK-GI-NEXT:    sxth x9, w1
-; CHECK-GI-NEXT:    mneg x0, x9, x8
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smnegl_ldrsb_h_commuted:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsb x8, [x0]
+; CHECK-NEXT:    sxth x9, w1
+; CHECK-NEXT:    smnegl x0, w9, w8
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
   %sext = sext i8 %ext64 to i64
@@ -840,7 +689,7 @@ define i64 @smnegl_ldrsh_w(ptr %x0, i32 %x1) {
 ; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
 ; CHECK-GI-NEXT:    ldrsh x8, [x0]
 ; CHECK-GI-NEXT:    sxtw x9, w1
-; CHECK-GI-NEXT:    mneg x0, x8, x9
+; CHECK-GI-NEXT:    smnegl x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i16, ptr %x0
@@ -863,7 +712,7 @@ define i64 @smnegl_ldrsh_w_commuted(ptr %x0, i32 %x1) {
 ; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
 ; CHECK-GI-NEXT:    ldrsh x8, [x0]
 ; CHECK-GI-NEXT:    sxtw x9, w1
-; CHECK-GI-NEXT:    mneg x0, x9, x8
+; CHECK-GI-NEXT:    smnegl x0, w9, w8
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i16, ptr %x0
@@ -875,21 +724,13 @@ entry:
 }
 
 define i64 @smnegl_ldrsw_b(ptr %x0, i8 %x1) {
-; CHECK-SD-LABEL: smnegl_ldrsw_b:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsw x8, [x0]
-; CHECK-SD-NEXT:    sxtb x9, w1
-; CHECK-SD-NEXT:    smnegl x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smnegl_ldrsw_b:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsw x8, [x0]
-; CHECK-GI-NEXT:    sxtb x9, w1
-; CHECK-GI-NEXT:    mneg x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smnegl_ldrsw_b:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsw x8, [x0]
+; CHECK-NEXT:    sxtb x9, w1
+; CHECK-NEXT:    smnegl x0, w8, w9
+; CHECK-NEXT:    ret
   %ext64 = load i32, ptr %x0
   %sext = sext i32 %ext64 to i64
   %sext2 = sext i8 %x1 to i64
@@ -899,21 +740,13 @@ define i64 @smnegl_ldrsw_b(ptr %x0, i8 %x1) {
 }
 
 define i64 @smnegl_ldrsw_b_commuted(ptr %x0, i8 %x1) {
-; CHECK-SD-LABEL: smnegl_ldrsw_b_commuted:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsw x8, [x0]
-; CHECK-SD-NEXT:    sxtb x9, w1
-; CHECK-SD-NEXT:    smnegl x0, w9, w8
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smnegl_ldrsw_b_commuted:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsw x8, [x0]
-; CHECK-GI-NEXT:    sxtb x9, w1
-; CHECK-GI-NEXT:    mneg x0, x9, x8
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smnegl_ldrsw_b_commuted:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsw x8, [x0]
+; CHECK-NEXT:    sxtb x9, w1
+; CHECK-NEXT:    smnegl x0, w9, w8
+; CHECK-NEXT:    ret
   %ext64 = load i32, ptr %x0
   %sext = sext i32 %ext64 to i64
   %sext2 = sext i8 %x1 to i64
@@ -923,19 +756,12 @@ define i64 @smnegl_ldrsw_b_commuted(ptr %x0, i8 %x1) {
 }
 
 define i64 @smnegl_ldrsw_ldrsw(ptr %x0, ptr %x1) {
-; CHECK-SD-LABEL: smnegl_ldrsw_ldrsw:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldrsw x8, [x0]
-; CHECK-SD-NEXT:    ldrsw x9, [x1]
-; CHECK-SD-NEXT:    smnegl x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smnegl_ldrsw_ldrsw:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldrsw x8, [x0]
-; CHECK-GI-NEXT:    ldrsw x9, [x1]
-; CHECK-GI-NEXT:    mneg x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smnegl_ldrsw_ldrsw:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldrsw x8, [x0]
+; CHECK-NEXT:    ldrsw x9, [x1]
+; CHECK-NEXT:    smnegl x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
   %ext64_2 = load i32, ptr %x1
@@ -962,7 +788,7 @@ define i64 @smnegl_sext_hh(i16 %x0, i16 %x1) {
 ; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
 ; CHECK-GI-NEXT:    sxth x8, w0
 ; CHECK-GI-NEXT:    sxth x9, w1
-; CHECK-GI-NEXT:    mneg x0, x8, x9
+; CHECK-GI-NEXT:    smnegl x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %sext = sext i16 %x0 to i64
@@ -983,7 +809,7 @@ define i64 @smnegl_ldrsw_shift(ptr %x0, i64 %x1) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldrsw x8, [x0]
 ; CHECK-GI-NEXT:    sxtw x9, w1
-; CHECK-GI-NEXT:    mneg x0, x8, x9
+; CHECK-GI-NEXT:    smnegl x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
@@ -996,21 +822,13 @@ entry:
 }
 
 define i64 @smnegl_ldrsw_zextb(ptr %x0, i8 %x1) {
-; CHECK-SD-LABEL: smnegl_ldrsw_zextb:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldrsw x8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xff
-; CHECK-SD-NEXT:    smnegl x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smnegl_ldrsw_zextb:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldrsw x8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xff
-; CHECK-GI-NEXT:    mneg x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smnegl_ldrsw_zextb:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldrsw x8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xff
+; CHECK-NEXT:    smnegl x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
   %sext = sext i32 %ext64 to i64
@@ -1021,21 +839,13 @@ entry:
 }
 
 define i64 @smsubl_ldrsb_h(ptr %x0, i16 %x1, i64 %x2) {
-; CHECK-SD-LABEL: smsubl_ldrsb_h:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsb x8, [x0]
-; CHECK-SD-NEXT:    sxth x9, w1
-; CHECK-SD-NEXT:    smsubl x0, w8, w9, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smsubl_ldrsb_h:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsb x8, [x0]
-; CHECK-GI-NEXT:    sxth x9, w1
-; CHECK-GI-NEXT:    msub x0, x8, x9, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smsubl_ldrsb_h:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsb x8, [x0]
+; CHECK-NEXT:    sxth x9, w1
+; CHECK-NEXT:    smsubl x0, w8, w9, x2
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
   %sext = sext i8 %ext64 to i64
@@ -1046,21 +856,13 @@ entry:
 }
 
 define i64 @smsubl_ldrsb_h_commuted(ptr %x0, i16 %x1, i64 %x2) {
-; CHECK-SD-LABEL: smsubl_ldrsb_h_commuted:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsb x8, [x0]
-; CHECK-SD-NEXT:    sxth x9, w1
-; CHECK-SD-NEXT:    smsubl x0, w9, w8, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smsubl_ldrsb_h_commuted:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsb x8, [x0]
-; CHECK-GI-NEXT:    sxth x9, w1
-; CHECK-GI-NEXT:    msub x0, x9, x8, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smsubl_ldrsb_h_commuted:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsb x8, [x0]
+; CHECK-NEXT:    sxth x9, w1
+; CHECK-NEXT:    smsubl x0, w9, w8, x2
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
   %sext = sext i8 %ext64 to i64
@@ -1082,7 +884,7 @@ define i64 @smsubl_ldrsh_w(ptr %x0, i32 %x1, i64 %x2) {
 ; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
 ; CHECK-GI-NEXT:    ldrsh x8, [x0]
 ; CHECK-GI-NEXT:    sxtw x9, w1
-; CHECK-GI-NEXT:    msub x0, x8, x9, x2
+; CHECK-GI-NEXT:    smsubl x0, w8, w9, x2
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i16, ptr %x0
@@ -1105,7 +907,7 @@ define i64 @smsubl_ldrsh_w_commuted(ptr %x0, i32 %x1, i64 %x2) {
 ; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
 ; CHECK-GI-NEXT:    ldrsh x8, [x0]
 ; CHECK-GI-NEXT:    sxtw x9, w1
-; CHECK-GI-NEXT:    msub x0, x9, x8, x2
+; CHECK-GI-NEXT:    smsubl x0, w9, w8, x2
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i16, ptr %x0
@@ -1117,21 +919,13 @@ entry:
 }
 
 define i64 @smsubl_ldrsw_b(ptr %x0, i8 %x1, i64 %x2) {
-; CHECK-SD-LABEL: smsubl_ldrsw_b:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsw x8, [x0]
-; CHECK-SD-NEXT:    sxtb x9, w1
-; CHECK-SD-NEXT:    smsubl x0, w8, w9, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smsubl_ldrsw_b:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsw x8, [x0]
-; CHECK-GI-NEXT:    sxtb x9, w1
-; CHECK-GI-NEXT:    msub x0, x8, x9, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smsubl_ldrsw_b:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsw x8, [x0]
+; CHECK-NEXT:    sxtb x9, w1
+; CHECK-NEXT:    smsubl x0, w8, w9, x2
+; CHECK-NEXT:    ret
   %ext64 = load i32, ptr %x0
   %sext = sext i32 %ext64 to i64
   %sext2 = sext i8 %x1 to i64
@@ -1141,21 +935,13 @@ define i64 @smsubl_ldrsw_b(ptr %x0, i8 %x1, i64 %x2) {
 }
 
 define i64 @smsubl_ldrsw_b_commuted(ptr %x0, i8 %x1, i64 %x2) {
-; CHECK-SD-LABEL: smsubl_ldrsw_b_commuted:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    ldrsw x8, [x0]
-; CHECK-SD-NEXT:    sxtb x9, w1
-; CHECK-SD-NEXT:    smsubl x0, w9, w8, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smsubl_ldrsw_b_commuted:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    ldrsw x8, [x0]
-; CHECK-GI-NEXT:    sxtb x9, w1
-; CHECK-GI-NEXT:    msub x0, x9, x8, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smsubl_ldrsw_b_commuted:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    ldrsw x8, [x0]
+; CHECK-NEXT:    sxtb x9, w1
+; CHECK-NEXT:    smsubl x0, w9, w8, x2
+; CHECK-NEXT:    ret
   %ext64 = load i32, ptr %x0
   %sext = sext i32 %ext64 to i64
   %sext2 = sext i8 %x1 to i64
@@ -1165,19 +951,12 @@ define i64 @smsubl_ldrsw_b_commuted(ptr %x0, i8 %x1, i64 %x2) {
 }
 
 define i64 @smsubl_ldrsw_ldrsw(ptr %x0, ptr %x1, i64 %x2) {
-; CHECK-SD-LABEL: smsubl_ldrsw_ldrsw:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldrsw x8, [x0]
-; CHECK-SD-NEXT:    ldrsw x9, [x1]
-; CHECK-SD-NEXT:    smsubl x0, w8, w9, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smsubl_ldrsw_ldrsw:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldrsw x8, [x0]
-; CHECK-GI-NEXT:    ldrsw x9, [x1]
-; CHECK-GI-NEXT:    msub x0, x8, x9, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smsubl_ldrsw_ldrsw:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldrsw x8, [x0]
+; CHECK-NEXT:    ldrsw x9, [x1]
+; CHECK-NEXT:    smsubl x0, w8, w9, x2
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
   %ext64_2 = load i32, ptr %x1
@@ -1204,7 +983,7 @@ define i64 @smsubl_sext_hh(i16 %x0, i16 %x1, i64 %x2) {
 ; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
 ; CHECK-GI-NEXT:    sxth x8, w0
 ; CHECK-GI-NEXT:    sxth x9, w1
-; CHECK-GI-NEXT:    msub x0, x8, x9, x2
+; CHECK-GI-NEXT:    smsubl x0, w8, w9, x2
 ; CHECK-GI-NEXT:    ret
 entry:
   %sext = sext i16 %x0 to i64
@@ -1225,7 +1004,7 @@ define i64 @smsubl_ldrsw_shift(ptr %x0, i64 %x1, i64 %x2) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldrsw x8, [x0]
 ; CHECK-GI-NEXT:    sxtw x9, w1
-; CHECK-GI-NEXT:    msub x0, x8, x9, x2
+; CHECK-GI-NEXT:    smsubl x0, w8, w9, x2
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
@@ -1238,21 +1017,13 @@ entry:
 }
 
 define i64 @smsubl_ldrsw_zextb(ptr %x0, i8 %x1, i64 %x2) {
-; CHECK-SD-LABEL: smsubl_ldrsw_zextb:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldrsw x8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xff
-; CHECK-SD-NEXT:    smsubl x0, w8, w9, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smsubl_ldrsw_zextb:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldrsw x8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xff
-; CHECK-GI-NEXT:    msub x0, x8, x9, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smsubl_ldrsw_zextb:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldrsw x8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xff
+; CHECK-NEXT:    smsubl x0, w8, w9, x2
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
   %sext = sext i32 %ext64 to i64
@@ -1289,7 +1060,7 @@ define i64 @smull_sext_ashr32(i32 %a, i64 %b) nounwind {
 ; CHECK-GI-NEXT:    // kill: def $w0 killed $w0 def $x0
 ; CHECK-GI-NEXT:    sxtw x8, w0
 ; CHECK-GI-NEXT:    asr x9, x1, #32
-; CHECK-GI-NEXT:    mul x0, x8, x9
+; CHECK-GI-NEXT:    smull x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %tmp1 = sext i32 %a to i64
@@ -1314,19 +1085,12 @@ entry:
 }
 
 define i64 @smull_ashr32_both(i64 %a, i64 %b) nounwind {
-; CHECK-SD-LABEL: smull_ashr32_both:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    asr x8, x0, #32
-; CHECK-SD-NEXT:    asr x9, x1, #32
-; CHECK-SD-NEXT:    smull x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: smull_ashr32_both:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    asr x8, x0, #32
-; CHECK-GI-NEXT:    asr x9, x1, #32
-; CHECK-GI-NEXT:    mul x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: smull_ashr32_both:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    asr x8, x0, #32
+; CHECK-NEXT:    asr x9, x1, #32
+; CHECK-NEXT:    smull x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %tmp1 = ashr i64 %a, 32
   %c = ashr i64 %b, 32
@@ -1335,21 +1099,13 @@ entry:
 }
 
 define i64 @umull_ldrb_h(ptr %x0, i16 %x1) {
-; CHECK-SD-LABEL: umull_ldrb_h:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldrb w8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xffff
-; CHECK-SD-NEXT:    umull x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: umull_ldrb_h:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldrb w8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xffff
-; CHECK-GI-NEXT:    mul x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: umull_ldrb_h:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldrb w8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xffff
+; CHECK-NEXT:    umull x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
   %zext = zext i8 %ext64 to i64
@@ -1359,21 +1115,13 @@ entry:
 }
 
 define i64 @umull_ldrb_h_commuted(ptr %x0, i16 %x1) {
-; CHECK-SD-LABEL: umull_ldrb_h_commuted:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldrb w8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xffff
-; CHECK-SD-NEXT:    umull x0, w9, w8
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: umull_ldrb_h_commuted:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldrb w8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xffff
-; CHECK-GI-NEXT:    mul x0, x9, x8
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: umull_ldrb_h_commuted:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldrb w8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xffff
+; CHECK-NEXT:    umull x0, w9, w8
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
   %zext = zext i8 %ext64 to i64
@@ -1393,7 +1141,7 @@ define i64 @umull_ldrh_w(ptr %x0, i32 %x1) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldrh w8, [x0]
 ; CHECK-GI-NEXT:    mov w9, w1
-; CHECK-GI-NEXT:    mul x0, x8, x9
+; CHECK-GI-NEXT:    umull x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i16, ptr %x0
@@ -1404,21 +1152,13 @@ entry:
 }
 
 define i64 @umull_ldr_b(ptr %x0, i8 %x1) {
-; CHECK-SD-LABEL: umull_ldr_b:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldr w8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xff
-; CHECK-SD-NEXT:    umull x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: umull_ldr_b:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldr w8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xff
-; CHECK-GI-NEXT:    mul x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: umull_ldr_b:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldr w8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xff
+; CHECK-NEXT:    umull x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
   %zext = zext i32 %ext64 to i64
@@ -1438,7 +1178,7 @@ define i64 @umull_ldr2_w(ptr %x0, i32 %x1) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldr w8, [x0]
 ; CHECK-GI-NEXT:    mov w9, w1
-; CHECK-GI-NEXT:    mul x0, x8, x9
+; CHECK-GI-NEXT:    umull x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i64, ptr %x0
@@ -1449,19 +1189,12 @@ entry:
 }
 
 define i64 @umull_ldr2_ldr2(ptr %x0, ptr %x1) {
-; CHECK-SD-LABEL: umull_ldr2_ldr2:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldr w8, [x0]
-; CHECK-SD-NEXT:    ldr w9, [x1]
-; CHECK-SD-NEXT:    umull x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: umull_ldr2_ldr2:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldr w8, [x0]
-; CHECK-GI-NEXT:    ldr w9, [x1]
-; CHECK-GI-NEXT:    mul x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: umull_ldr2_ldr2:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldr w8, [x0]
+; CHECK-NEXT:    ldr w9, [x1]
+; CHECK-NEXT:    umull x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i64, ptr %x0
   %and = and i64 %ext64, 4294967295
@@ -1482,7 +1215,7 @@ define i64 @umull_ldr2_d(ptr %x0, i64 %x1) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldr w8, [x0]
 ; CHECK-GI-NEXT:    mov w9, w1
-; CHECK-GI-NEXT:    mul x0, x8, x9
+; CHECK-GI-NEXT:    umull x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i64, ptr %x0
@@ -1493,21 +1226,13 @@ entry:
 }
 
 define i64 @umaddl_ldrb_h(ptr %x0, i16 %x1, i64 %x2) {
-; CHECK-SD-LABEL: umaddl_ldrb_h:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldrb w8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xffff
-; CHECK-SD-NEXT:    umaddl x0, w8, w9, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: umaddl_ldrb_h:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldrb w8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xffff
-; CHECK-GI-NEXT:    madd x0, x8, x9, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: umaddl_ldrb_h:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldrb w8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xffff
+; CHECK-NEXT:    umaddl x0, w8, w9, x2
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
   %zext = zext i8 %ext64 to i64
@@ -1518,21 +1243,13 @@ entry:
 }
 
 define i64 @umaddl_ldrb_h_commuted(ptr %x0, i16 %x1, i64 %x2) {
-; CHECK-SD-LABEL: umaddl_ldrb_h_commuted:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldrb w8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xffff
-; CHECK-SD-NEXT:    umaddl x0, w9, w8, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: umaddl_ldrb_h_commuted:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldrb w8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xffff
-; CHECK-GI-NEXT:    madd x0, x9, x8, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: umaddl_ldrb_h_commuted:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldrb w8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xffff
+; CHECK-NEXT:    umaddl x0, w9, w8, x2
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
   %zext = zext i8 %ext64 to i64
@@ -1553,7 +1270,7 @@ define i64 @umaddl_ldrh_w(ptr %x0, i32 %x1, i64 %x2) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldrh w8, [x0]
 ; CHECK-GI-NEXT:    mov w9, w1
-; CHECK-GI-NEXT:    madd x0, x8, x9, x2
+; CHECK-GI-NEXT:    umaddl x0, w8, w9, x2
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i16, ptr %x0
@@ -1565,21 +1282,13 @@ entry:
 }
 
 define i64 @umaddl_ldr_b(ptr %x0, i8 %x1, i64 %x2) {
-; CHECK-SD-LABEL: umaddl_ldr_b:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldr w8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xff
-; CHECK-SD-NEXT:    umaddl x0, w8, w9, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: umaddl_ldr_b:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldr w8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xff
-; CHECK-GI-NEXT:    madd x0, x8, x9, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: umaddl_ldr_b:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldr w8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xff
+; CHECK-NEXT:    umaddl x0, w8, w9, x2
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
   %zext = zext i32 %ext64 to i64
@@ -1600,7 +1309,7 @@ define i64 @umaddl_ldr2_w(ptr %x0, i32 %x1, i64 %x2) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldr w8, [x0]
 ; CHECK-GI-NEXT:    mov w9, w1
-; CHECK-GI-NEXT:    madd x0, x8, x9, x2
+; CHECK-GI-NEXT:    umaddl x0, w8, w9, x2
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i64, ptr %x0
@@ -1612,19 +1321,12 @@ entry:
 }
 
 define i64 @umaddl_ldr2_ldr2(ptr %x0, ptr %x1, i64 %x2) {
-; CHECK-SD-LABEL: umaddl_ldr2_ldr2:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldr w8, [x0]
-; CHECK-SD-NEXT:    ldr w9, [x1]
-; CHECK-SD-NEXT:    umaddl x0, w8, w9, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: umaddl_ldr2_ldr2:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldr w8, [x0]
-; CHECK-GI-NEXT:    ldr w9, [x1]
-; CHECK-GI-NEXT:    madd x0, x8, x9, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: umaddl_ldr2_ldr2:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldr w8, [x0]
+; CHECK-NEXT:    ldr w9, [x1]
+; CHECK-NEXT:    umaddl x0, w8, w9, x2
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i64, ptr %x0
   %and = and i64 %ext64, 4294967295
@@ -1646,7 +1348,7 @@ define i64 @umaddl_ldr2_d(ptr %x0, i64 %x1, i64 %x2) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldr w8, [x0]
 ; CHECK-GI-NEXT:    mov w9, w1
-; CHECK-GI-NEXT:    madd x0, x8, x9, x2
+; CHECK-GI-NEXT:    umaddl x0, w8, w9, x2
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i64, ptr %x0
@@ -1658,21 +1360,13 @@ entry:
 }
 
 define i64 @umnegl_ldrb_h(ptr %x0, i16 %x1) {
-; CHECK-SD-LABEL: umnegl_ldrb_h:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldrb w8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xffff
-; CHECK-SD-NEXT:    umnegl x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: umnegl_ldrb_h:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldrb w8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xffff
-; CHECK-GI-NEXT:    mneg x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: umnegl_ldrb_h:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldrb w8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xffff
+; CHECK-NEXT:    umnegl x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
   %zext = zext i8 %ext64 to i64
@@ -1683,21 +1377,13 @@ entry:
 }
 
 define i64 @umnegl_ldrb_h_commuted(ptr %x0, i16 %x1) {
-; CHECK-SD-LABEL: umnegl_ldrb_h_commuted:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldrb w8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xffff
-; CHECK-SD-NEXT:    umnegl x0, w9, w8
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: umnegl_ldrb_h_commuted:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldrb w8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xffff
-; CHECK-GI-NEXT:    mneg x0, x9, x8
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: umnegl_ldrb_h_commuted:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldrb w8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xffff
+; CHECK-NEXT:    umnegl x0, w9, w8
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
   %zext = zext i8 %ext64 to i64
@@ -1718,7 +1404,7 @@ define i64 @umnegl_ldrh_w(ptr %x0, i32 %x1) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldrh w8, [x0]
 ; CHECK-GI-NEXT:    mov w9, w1
-; CHECK-GI-NEXT:    mneg x0, x8, x9
+; CHECK-GI-NEXT:    umnegl x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i16, ptr %x0
@@ -1730,21 +1416,13 @@ entry:
 }
 
 define i64 @umnegl_ldr_b(ptr %x0, i8 %x1) {
-; CHECK-SD-LABEL: umnegl_ldr_b:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldr w8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xff
-; CHECK-SD-NEXT:    umnegl x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: umnegl_ldr_b:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldr w8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xff
-; CHECK-GI-NEXT:    mneg x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: umnegl_ldr_b:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldr w8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xff
+; CHECK-NEXT:    umnegl x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
   %zext = zext i32 %ext64 to i64
@@ -1765,7 +1443,7 @@ define i64 @umnegl_ldr2_w(ptr %x0, i32 %x1) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldr w8, [x0]
 ; CHECK-GI-NEXT:    mov w9, w1
-; CHECK-GI-NEXT:    mneg x0, x8, x9
+; CHECK-GI-NEXT:    umnegl x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i64, ptr %x0
@@ -1777,19 +1455,12 @@ entry:
 }
 
 define i64 @umnegl_ldr2_ldr2(ptr %x0, ptr %x1) {
-; CHECK-SD-LABEL: umnegl_ldr2_ldr2:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldr w8, [x0]
-; CHECK-SD-NEXT:    ldr w9, [x1]
-; CHECK-SD-NEXT:    umnegl x0, w8, w9
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: umnegl_ldr2_ldr2:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldr w8, [x0]
-; CHECK-GI-NEXT:    ldr w9, [x1]
-; CHECK-GI-NEXT:    mneg x0, x8, x9
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: umnegl_ldr2_ldr2:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldr w8, [x0]
+; CHECK-NEXT:    ldr w9, [x1]
+; CHECK-NEXT:    umnegl x0, w8, w9
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i64, ptr %x0
   %and = and i64 %ext64, 4294967295
@@ -1811,7 +1482,7 @@ define i64 @umnegl_ldr2_d(ptr %x0, i64 %x1) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldr w8, [x0]
 ; CHECK-GI-NEXT:    mov w9, w1
-; CHECK-GI-NEXT:    mneg x0, x8, x9
+; CHECK-GI-NEXT:    umnegl x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i64, ptr %x0
@@ -1823,21 +1494,13 @@ entry:
 }
 
 define i64 @umsubl_ldrb_h(ptr %x0, i16 %x1, i64 %x2) {
-; CHECK-SD-LABEL: umsubl_ldrb_h:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldrb w8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xffff
-; CHECK-SD-NEXT:    umsubl x0, w8, w9, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: umsubl_ldrb_h:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldrb w8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xffff
-; CHECK-GI-NEXT:    msub x0, x8, x9, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: umsubl_ldrb_h:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldrb w8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xffff
+; CHECK-NEXT:    umsubl x0, w8, w9, x2
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
   %zext = zext i8 %ext64 to i64
@@ -1848,21 +1511,13 @@ entry:
 }
 
 define i64 @umsubl_ldrb_h_commuted(ptr %x0, i16 %x1, i64 %x2) {
-; CHECK-SD-LABEL: umsubl_ldrb_h_commuted:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldrb w8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xffff
-; CHECK-SD-NEXT:    umsubl x0, w9, w8, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: umsubl_ldrb_h_commuted:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldrb w8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xffff
-; CHECK-GI-NEXT:    msub x0, x9, x8, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: umsubl_ldrb_h_commuted:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldrb w8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xffff
+; CHECK-NEXT:    umsubl x0, w9, w8, x2
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i8, ptr %x0
   %zext = zext i8 %ext64 to i64
@@ -1883,7 +1538,7 @@ define i64 @umsubl_ldrh_w(ptr %x0, i32 %x1, i64 %x2) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldrh w8, [x0]
 ; CHECK-GI-NEXT:    mov w9, w1
-; CHECK-GI-NEXT:    msub x0, x8, x9, x2
+; CHECK-GI-NEXT:    umsubl x0, w8, w9, x2
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i16, ptr %x0
@@ -1895,21 +1550,13 @@ entry:
 }
 
 define i64 @umsubl_ldr_b(ptr %x0, i8 %x1, i64 %x2) {
-; CHECK-SD-LABEL: umsubl_ldr_b:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldr w8, [x0]
-; CHECK-SD-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-SD-NEXT:    and x9, x1, #0xff
-; CHECK-SD-NEXT:    umsubl x0, w8, w9, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: umsubl_ldr_b:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldr w8, [x0]
-; CHECK-GI-NEXT:    // kill: def $w1 killed $w1 def $x1
-; CHECK-GI-NEXT:    and x9, x1, #0xff
-; CHECK-GI-NEXT:    msub x0, x8, x9, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: umsubl_ldr_b:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldr w8, [x0]
+; CHECK-NEXT:    // kill: def $w1 killed $w1 def $x1
+; CHECK-NEXT:    and x9, x1, #0xff
+; CHECK-NEXT:    umsubl x0, w8, w9, x2
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i32, ptr %x0
   %zext = zext i32 %ext64 to i64
@@ -1930,7 +1577,7 @@ define i64 @umsubl_ldr2_w(ptr %x0, i32 %x1, i64 %x2) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldr w8, [x0]
 ; CHECK-GI-NEXT:    mov w9, w1
-; CHECK-GI-NEXT:    msub x0, x8, x9, x2
+; CHECK-GI-NEXT:    umsubl x0, w8, w9, x2
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i64, ptr %x0
@@ -1942,19 +1589,12 @@ entry:
 }
 
 define i64 @umsubl_ldr2_ldr2(ptr %x0, ptr %x1, i64 %x2) {
-; CHECK-SD-LABEL: umsubl_ldr2_ldr2:
-; CHECK-SD:       // %bb.0: // %entry
-; CHECK-SD-NEXT:    ldr w8, [x0]
-; CHECK-SD-NEXT:    ldr w9, [x1]
-; CHECK-SD-NEXT:    umsubl x0, w8, w9, x2
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: umsubl_ldr2_ldr2:
-; CHECK-GI:       // %bb.0: // %entry
-; CHECK-GI-NEXT:    ldr w8, [x0]
-; CHECK-GI-NEXT:    ldr w9, [x1]
-; CHECK-GI-NEXT:    msub x0, x8, x9, x2
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: umsubl_ldr2_ldr2:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldr w8, [x0]
+; CHECK-NEXT:    ldr w9, [x1]
+; CHECK-NEXT:    umsubl x0, w8, w9, x2
+; CHECK-NEXT:    ret
 entry:
   %ext64 = load i64, ptr %x0
   %and = and i64 %ext64, 4294967295
@@ -1976,7 +1616,7 @@ define i64 @umsubl_ldr2_d(ptr %x0, i64 %x1, i64 %x2) {
 ; CHECK-GI:       // %bb.0: // %entry
 ; CHECK-GI-NEXT:    ldr w8, [x0]
 ; CHECK-GI-NEXT:    mov w9, w1
-; CHECK-GI-NEXT:    msub x0, x8, x9, x2
+; CHECK-GI-NEXT:    umsubl x0, w8, w9, x2
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i64, ptr %x0
@@ -2000,7 +1640,7 @@ define i64 @umull_ldr2_w_cc1(ptr %x0, i32 %x1) {
 ; CHECK-GI-NEXT:    ldr x8, [x0]
 ; CHECK-GI-NEXT:    mov w9, w1
 ; CHECK-GI-NEXT:    and x8, x8, #0x7fffffff
-; CHECK-GI-NEXT:    mul x0, x8, x9
+; CHECK-GI-NEXT:    umull x0, w8, w9
 ; CHECK-GI-NEXT:    ret
 entry:
   %ext64 = load i64, ptr %x0
@@ -2052,7 +1692,7 @@ define i64 @umull_and_lshr(i64 %x) {
 ; CHECK-GI:       // %bb.0:
 ; CHECK-GI-NEXT:    lsr x8, x0, #32
 ; CHECK-GI-NEXT:    mov w9, w0
-; CHECK-GI-NEXT:    mul x0, x9, x8
+; CHECK-GI-NEXT:    umull x0, w9, w8
 ; CHECK-GI-NEXT:    ret
     %lo = and i64 %x, u0xffffffff
     %hi = lshr i64 %x, 32
@@ -2070,7 +1710,7 @@ define i64 @umull_and_and(i64 %x, i64 %y) {
 ; CHECK-GI:       // %bb.0:
 ; CHECK-GI-NEXT:    mov w8, w0
 ; CHECK-GI-NEXT:    mov w9, w1
-; CHECK-GI-NEXT:    mul x0, x8, x9
+; CHECK-GI-NEXT:    umull x0, w8, w9
 ; CHECK-GI-NEXT:    ret
     %lo = and i64 %x, u0xffffffff
     %hi = and i64 %y, u0xffffffff
@@ -2089,7 +1729,7 @@ define i64 @umaddl_and_lshr(i64 %x, i64 %a) {
 ; CHECK-GI:       // %bb.0:
 ; CHECK-GI-NEXT:    lsr x8, x0, #32
 ; CHECK-GI-NEXT:    mov w9, w0
-; CHECK-GI-NEXT:    madd x0, x9, x8, x1
+; CHECK-GI-NEXT:    umaddl x0, w9, w8, x1
 ; CHECK-GI-NEXT:    ret
     %lo = and i64 %x, u0xffffffff
     %hi = lshr i64 %x, 32
@@ -2108,7 +1748,7 @@ define i64 @umaddl_and_and(i64 %x, i64 %y, i64 %a) {
 ; CHECK-GI:       // %bb.0:
 ; CHECK-GI-NEXT:    mov w8, w0
 ; CHECK-GI-NEXT:    mov w9, w1
-; CHECK-GI-NEXT:    madd x0, x8, x9, x2
+; CHECK-GI-NEXT:    umaddl x0, w8, w9, x2
 ; CHECK-GI-NEXT:    ret
     %lo = and i64 %x, u0xffffffff
     %hi = and i64 %y, u0xffffffff

--- a/llvm/test/CodeGen/AArch64/arm64-extract-insert-varidx.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-extract-insert-varidx.ll
@@ -186,7 +186,7 @@ define <2 x i16> @test_varidx_extract_v4s16(<4 x i16> %x, i32 %idx) {
 ; CHECK-GISEL-NEXT:    and x9, x9, #0x3
 ; CHECK-GISEL-NEXT:    // kill: def $d0 killed $d0 def $q0
 ; CHECK-GISEL-NEXT:    str d0, [sp, #8]
-; CHECK-GISEL-NEXT:    madd x8, x9, x8, x10
+; CHECK-GISEL-NEXT:    umaddl x8, w9, w8, x10
 ; CHECK-GISEL-NEXT:    umov w9, v0.h[1]
 ; CHECK-GISEL-NEXT:    ld1 { v0.h }[0], [x8]
 ; CHECK-GISEL-NEXT:    mov v0.s[1], w9

--- a/llvm/test/CodeGen/AArch64/fast-isel-gep.ll
+++ b/llvm/test/CodeGen/AArch64/fast-isel-gep.ll
@@ -56,7 +56,7 @@ define ptr @test_array5(ptr %a, i32 %i) {
 ; CHECK-NEXT:    ; kill: def $w1 killed $w1 def $x1
 ; CHECK-NEXT:    sxtw x8, w1
 ; CHECK-NEXT:    mov x9, #4 ; =0x4
-; CHECK-NEXT:    madd x0, x8, x9, x0
+; CHECK-NEXT:    smaddl x0, w8, w9, x0
 ; CHECK-NEXT:    ret
   %1 = getelementptr inbounds i32, ptr %a, i32 %i
   ret ptr %1

--- a/llvm/test/CodeGen/AArch64/insertextract.ll
+++ b/llvm/test/CodeGen/AArch64/insertextract.ll
@@ -630,7 +630,7 @@ define <8 x i8> @insert_v8i8_c(<8 x i8> %a, i8 %b, i32 %c) {
 ; CHECK-GI-NEXT:    mov w8, #1 // =0x1
 ; CHECK-GI-NEXT:    str d0, [sp, #8]
 ; CHECK-GI-NEXT:    and x9, x9, #0x7
-; CHECK-GI-NEXT:    mul x8, x9, x8
+; CHECK-GI-NEXT:    umull x8, w9, w8
 ; CHECK-GI-NEXT:    add x9, sp, #8
 ; CHECK-GI-NEXT:    strb w0, [x9, x8]
 ; CHECK-GI-NEXT:    ldr d0, [sp, #8]
@@ -682,7 +682,7 @@ define <16 x i8> @insert_v16i8_c(<16 x i8> %a, i8 %b, i32 %c) {
 ; CHECK-GI-NEXT:    mov w8, #1 // =0x1
 ; CHECK-GI-NEXT:    str q0, [sp]
 ; CHECK-GI-NEXT:    and x9, x9, #0xf
-; CHECK-GI-NEXT:    mul x8, x9, x8
+; CHECK-GI-NEXT:    umull x8, w9, w8
 ; CHECK-GI-NEXT:    mov x9, sp
 ; CHECK-GI-NEXT:    strb w0, [x9, x8]
 ; CHECK-GI-NEXT:    ldr q0, [sp], #16

--- a/llvm/test/CodeGen/AArch64/madd-32bit.mir
+++ b/llvm/test/CodeGen/AArch64/madd-32bit.mir
@@ -1,0 +1,53 @@
+# RUN: llc -mtriple=aarch64-none-linux-gnu -run-pass aarch64-mi-peephole-opt -verify-machineinstrs -o - %s | FileCheck %s
+---
+# CHECK-LABEL: name: test_zext
+# CHECK: UMADDLrrr
+name: test_zext
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $x0, $x1
+
+    %0:gpr64common = COPY $x1
+    %1:gpr64common = ANDXri %0, 4127
+    %2:gpr32 = MOVi32imm 10129
+    %3:gpr64 = SUBREG_TO_REG 0, %2:gpr32, %subreg.sub_32
+    %4:gpr64 = nuw nsw MADDXrrr %1:gpr64common, %3:gpr64, $xzr
+    RET_ReallyLR implicit $x0
+
+...
+---
+# CHECK-LABEL: name: test_sext
+# CHECK: SMADDLrrr
+name: test_sext
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $x0, $x1
+
+    %0:gpr64common = COPY $x1
+    %1:gpr64common = SBFMXri %0, 0, 31
+    %2:gpr64 = MOVi64imm 56
+    %3:gpr64 = nuw nsw MADDXrrr %1:gpr64common, %2:gpr64, $xzr
+    RET_ReallyLR implicit $x0
+
+...
+---
+# CHECK-LABEL: name: test_csel
+# CHECK: SMADDLrrr
+name: test_csel
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $x0, $x1
+
+    %0:gpr64common = COPY $x1
+    %1:gpr64common = SBFMXri %0, 0, 31
+    %2:gpr64 = SUBSXrr %0:gpr64common, %1:gpr64common, implicit-def $nzcv
+    %3:gpr64 = MOVi64imm 56
+    %4:gpr64common = CSELXr %1:gpr64common, %3:gpr64, 0, implicit $nzcv
+    %5:gpr64 = MOVi64imm 56
+    %6:gpr64 = nuw nsw MADDXrrr %4:gpr64common, %5:gpr64, $xzr
+    RET_ReallyLR implicit $x0
+
+...


### PR DESCRIPTION
This PR adds MIR peephole optimization to convert 64-bit MADDs to [SU]MADDLs where possible. This is already done at ISel stage via patterns but they have limited visibility and do not work if operands are in different blocks (which may happen in case of LICM, conditional statements, etc.).

Patch works for all patterns which I've seen in real code but please let me know if something isn't covered.

Patch was tested via LLVM's `ninja check` and llvm-test-suite (tested via QEMU simulation `-DTEST_SUITE_USER_MODE_EMULATION=ON -DTEST_SUITE_RUN_UNDER='qemu-aarch64 -L /usr/aarch64-linux-gnu'`). Please let me know if more testing is needed.

For llvm-test-suite benchmarks (`-DTEST_SUITE_BENCHMARKING_ONLY=ON`) this resulted in replacement of 7.8% of 64-bit MADDs:
```
$ find llvm-test-suite/build-benchmarking-ref -name \*.o | xargs -n1 aarch64-linux-gnu-objdump -d | grep '\<madd\>.*x' | wc -l
3110

$ find llvm-test-suite/build-benchmarking-new -name \*.o | xargs -n1 aarch64-linux-gnu-objdump -d | grep '\<madd\>.*x' | wc -l
2886
```

Joint work of Yuri Gribov and Mikhail Semenov (@mermen).