### PR TITLE
release/20.x: [clang][AST] Handle implicit first argument in CallExpr::getBeginLoc()

### DIFF
--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -1665,8 +1665,11 @@ SourceLocation CallExpr::getBeginLoc() const {
         Method && Method->isExplicitObjectMemberFunction()) {
       bool HasFirstArg = getNumArgs() > 0 && getArg(0);
       assert(HasFirstArg);
-      if (HasFirstArg)
-        return getArg(0)->getBeginLoc();
+      if (HasFirstArg) {
+        if (auto FirstArgLoc = getArg(0)->getBeginLoc(); FirstArgLoc.isValid()) {
+          return FirstArgLoc;
+        }
+      }
     }
   }
 

--- a/clang/test/SemaCXX/cxx2b-deducing-this.cpp
+++ b/clang/test/SemaCXX/cxx2b-deducing-this.cpp
@@ -1134,3 +1134,10 @@ struct S {
 static_assert((S{} << 11) == a);
 // expected-error@-1 {{use of undeclared identifier 'a'}}
 }
+
+namespace GH135522 {
+struct S {
+  auto f(this auto) -> S;
+  bool g() { return f(); } // expected-error {{no viable conversion from returned value of type 'S' to function return type 'bool'}}
+};
+}


### PR DESCRIPTION
Backport https://github.com/llvm/llvm-project/commit/289baf1f42c8b5773271b611cd235d4ab94bb4e8

Fixes https://github.com/llvm/llvm-project/issues/135922