### PR TITLE
[libc++][docs] Confirm that P3136R1 Retiring niebloids is Complete

### DIFF
--- a/libcxx/docs/Status/Cxx2cPapers.csv
+++ b/libcxx/docs/Status/Cxx2cPapers.csv
@@ -76,7 +76,7 @@
 "`P2422R1 <https://wg21.link/P2422R1>`__","Remove ``nodiscard`` annotations from the standard library specification","2024-06 (St. Louis)","|Complete|","19","``nodiscard`` attributes were kept as a conforming extension"
 "`P2300R10 <https://wg21.link/P2300R10>`__","``std::execution``","2024-06 (St. Louis)","","",""
 "","","","","",""
-"`P3136R1 <https://wg21.link/P3136R1>`__","Retiring niebloids","2024-11 (Wrocław)","|Nothing To Do|","","libc++ has been implementing niebloids as customization point objects since they are initially added."
+"`P3136R1 <https://wg21.link/P3136R1>`__","Retiring niebloids","2024-11 (Wrocław)","|Complete|","14",""
 "`P3138R5 <https://wg21.link/P3138R5>`__","``views::cache_latest``","2024-11 (Wrocław)","","",""
 "`P3379R0 <https://wg21.link/P3379R0>`__","Constrain ``std::expected`` equality operators","2024-11 (Wrocław)","","",""
 "`P2862R1 <https://wg21.link/P2862R1>`__","``text_encoding::name()`` should never return null values","2024-11 (Wrocław)","","",""

--- a/libcxx/docs/Status/Cxx2cPapers.csv
+++ b/libcxx/docs/Status/Cxx2cPapers.csv
@@ -76,7 +76,7 @@
 "`P2422R1 <https://wg21.link/P2422R1>`__","Remove ``nodiscard`` annotations from the standard library specification","2024-06 (St. Louis)","|Complete|","19","``nodiscard`` attributes were kept as a conforming extension"
 "`P2300R10 <https://wg21.link/P2300R10>`__","``std::execution``","2024-06 (St. Louis)","","",""
 "","","","","",""
-"`P3136R1 <https://wg21.link/P3136R1>`__","Retiring niebloids","2024-11 (Wrocław)","","",""
+"`P3136R1 <https://wg21.link/P3136R1>`__","Retiring niebloids","2024-11 (Wrocław)","|Nothing To Do|","","libc++ has been implementing niebloids as customization point objects since they are initially added."
 "`P3138R5 <https://wg21.link/P3138R5>`__","``views::cache_latest``","2024-11 (Wrocław)","","",""
 "`P3379R0 <https://wg21.link/P3379R0>`__","Constrain ``std::expected`` equality operators","2024-11 (Wrocław)","","",""
 "`P2862R1 <https://wg21.link/P2862R1>`__","``text_encoding::name()`` should never return null values","2024-11 (Wrocław)","","",""

--- a/libcxx/test/std/algorithms/ranges_robust_against_omitting_invoke.pass.cpp
+++ b/libcxx/test/std/algorithms/ranges_robust_against_omitting_invoke.pass.cpp
@@ -35,7 +35,7 @@ struct Bar {
   Bar create() const { return Bar(); }
 };
 
-// Invokes both the (iterator, sentinel, ...) and the (range, ...) overloads of the given niebloid.
+// Invokes both the (iterator, sentinel, ...) and the (range, ...) overloads of the given algorithm function object.
 
 // (in, ...)
 template <class Func, std::ranges::range Input, class... Args>

--- a/libcxx/test/std/library/description/conventions/customization.point.object/niebloid.compile.pass.cpp
+++ b/libcxx/test/std/library/description/conventions/customization.point.object/niebloid.compile.pass.cpp
@@ -32,7 +32,7 @@
 //
 // As of P3136R1, niebloids (formally known as algorithm function objects) are required to be CPOs.
 //
-// libc++ always implements niebloids in the same way as CPOs;
+// libc++ implements niebloids in the same way as CPOs since LLVM 14;
 // therefore this file should stay in sync with ./cpo.compile.pass.cpp.
 
 template <class CPO, class... Args>

--- a/libcxx/test/std/library/description/conventions/customization.point.object/niebloid.compile.pass.cpp
+++ b/libcxx/test/std/library/description/conventions/customization.point.object/niebloid.compile.pass.cpp
@@ -9,6 +9,7 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // REQUIRES: stdlib=libc++
 
+// [alg.func.obj]
 // [algorithms.requirements]/2
 // [range.iter.ops.general]/2
 
@@ -24,12 +25,14 @@
 
 #include "test_macros.h"
 
-// Niebloids, unlike CPOs, are *not* required to be semiregular or even to have
-// a declared type at all; they are specified as "magic" overload sets whose
-// names are not found by argument-dependent lookup and which inhibit
-// argument-dependent lookup if they are found via a `using`-declaration.
+// Before P3136R1, niebloids were pedantically not CPOs, and they were *not* required to be semiregular or
+// even to have a declared type at all; they were specified as "magic" overload sets
+// whose names are not found by argument-dependent lookup and
+// which inhibit argument-dependent lookup if they are found via a `using`-declaration.
 //
-// libc++ implements them using the same function-object technique we use for CPOs;
+// As of P3136R1, niebloids (formally known as algorithm function objects) are required to be CPOs.
+//
+// libc++ always implements niebloids in the same way as CPOs;
 // therefore this file should stay in sync with ./cpo.compile.pass.cpp.
 
 template <class CPO, class... Args>


### PR DESCRIPTION
As libc++ has been implementing niebloids as CPOs since LLVM 14 due to https://reviews.llvm.org/D116570.

Also changes some comments in test files to use the formal term "algorithm function object".

Closes #118133.