### PR TITLE
[RemoveDI][Polly] Migrate to adapt to the new DebugRecord format in more areas

### DIFF
--- a/polly/include/polly/Support/ScopHelper.h
+++ b/polly/include/polly/Support/ScopHelper.h
@@ -402,7 +402,7 @@ llvm::Value *expandCodeFor(Scop &S, llvm::ScalarEvolution &SE,
                            llvm::Function *GenFn, llvm::ScalarEvolution &GenSE,
                            const llvm::DataLayout &DL, const char *Name,
                            const llvm::SCEV *E, llvm::Type *Ty,
-                           llvm::Instruction *IP, ValueMapT *VMap,
+                           llvm::BasicBlock::iterator IP, ValueMapT *VMap,
                            LoopToScevMapT *LoopMap, llvm::BasicBlock *RTCBB);
 
 /// Return the condition for the terminator @p TI.

--- a/polly/lib/CodeGen/BlockGenerators.cpp
+++ b/polly/lib/CodeGen/BlockGenerators.cpp
@@ -1384,7 +1384,7 @@ void RegionGenerator::copyPHIInstruction(ScopStmt &Stmt, PHINode *PHI,
   unsigned NumIncoming = PHI->getNumIncomingValues();
   PHINode *PHICopy =
       Builder.CreatePHI(PHI->getType(), NumIncoming, "polly." + PHI->getName());
-  PHICopy->moveBeforePreserving(PHICopy->getParent()->getFirstNonPHIIt());
+  PHICopy->moveBefore(PHICopy->getParent()->getFirstNonPHIIt());
   BBMap[PHI] = PHICopy;
 
   for (BasicBlock *IncomingBB : PHI->blocks())

--- a/polly/lib/CodeGen/BlockGenerators.cpp
+++ b/polly/lib/CodeGen/BlockGenerators.cpp
@@ -87,7 +87,7 @@ Value *BlockGenerator::trySynthesizeNewValue(ScopStmt &Stmt, Value *Old,
          "Only instructions can be insert points for SCEVExpander");
   Value *Expanded = expandCodeFor(
       S, SE, Builder.GetInsertBlock()->getParent(), *GenSE, DL, "polly", Scev,
-      Old->getType(), &*IP, &VTV, &LTS, StartBlock->getSinglePredecessor());
+      Old->getType(), IP, &VTV, &LTS, StartBlock->getSinglePredecessor());
 
   BBMap[Old] = Expanded;
   return Expanded;
@@ -411,7 +411,7 @@ void BlockGenerator::copyStmt(ScopStmt &Stmt, LoopToScevMapT &LTS,
 
 BasicBlock *BlockGenerator::splitBB(BasicBlock *BB) {
   BasicBlock *CopyBB = SplitBlock(Builder.GetInsertBlock(),
-                                  &*Builder.GetInsertPoint(), GenDT, GenLI);
+                                  Builder.GetInsertPoint(), GenDT, GenLI);
   CopyBB->setName("polly.stmt." + BB->getName());
   return CopyBB;
 }
@@ -622,7 +622,7 @@ void BlockGenerator::generateConditionalExecution(
 
   // Generate the conditional block.
   DomTreeUpdater DTU(GenDT, DomTreeUpdater::UpdateStrategy::Eager);
-  SplitBlockAndInsertIfThen(Cond, &*Builder.GetInsertPoint(), false, nullptr,
+  SplitBlockAndInsertIfThen(Cond, Builder.GetInsertPoint(), false, nullptr,
                             &DTU, GenLI);
   BranchInst *Branch = cast<BranchInst>(HeadBlock->getTerminator());
   BasicBlock *ThenBlock = Branch->getSuccessor(0);
@@ -1069,8 +1069,8 @@ void RegionGenerator::copyStmt(ScopStmt &Stmt, LoopToScevMapT &LTS,
   // Create a dedicated entry for the region where we can reload all demoted
   // inputs.
   BasicBlock *EntryBB = R->getEntry();
-  BasicBlock *EntryBBCopy = SplitBlock(
-      Builder.GetInsertBlock(), &*Builder.GetInsertPoint(), GenDT, GenLI);
+  BasicBlock *EntryBBCopy = SplitBlock(Builder.GetInsertBlock(),
+                                       Builder.GetInsertPoint(), GenDT, GenLI);
   EntryBBCopy->setName("polly.stmt." + EntryBB->getName() + ".entry");
   Builder.SetInsertPoint(&EntryBBCopy->front());
 
@@ -1136,7 +1136,7 @@ void RegionGenerator::copyStmt(ScopStmt &Stmt, LoopToScevMapT &LTS,
 
   // Now create a new dedicated region exit block and add it to the region map.
   BasicBlock *ExitBBCopy = SplitBlock(Builder.GetInsertBlock(),
-                                      &*Builder.GetInsertPoint(), GenDT, GenLI);
+                                      Builder.GetInsertPoint(), GenDT, GenLI);
   ExitBBCopy->setName("polly.stmt." + R->getExit()->getName() + ".exit");
   StartBlockMap[R->getExit()] = ExitBBCopy;
   EndBlockMap[R->getExit()] = ExitBBCopy;
@@ -1384,7 +1384,7 @@ void RegionGenerator::copyPHIInstruction(ScopStmt &Stmt, PHINode *PHI,
   unsigned NumIncoming = PHI->getNumIncomingValues();
   PHINode *PHICopy =
       Builder.CreatePHI(PHI->getType(), NumIncoming, "polly." + PHI->getName());
-  PHICopy->moveBefore(PHICopy->getParent()->getFirstNonPHIIt());
+  PHICopy->moveBeforePreserving(PHICopy->getParent()->getFirstNonPHIIt());
   BBMap[PHI] = PHICopy;
 
   for (BasicBlock *IncomingBB : PHI->blocks())

--- a/polly/lib/CodeGen/IslExprBuilder.cpp
+++ b/polly/lib/CodeGen/IslExprBuilder.cpp
@@ -324,7 +324,7 @@ IslExprBuilder::createAccessAddress(__isl_take isl_ast_expr *Expr) {
     // needed. But GlobalMap may contain SCoP-invariant vars.
     Value *DimSize = expandCodeFor(
         S, SE, Builder.GetInsertBlock()->getParent(), *GenSE, DL, "polly",
-        DimSCEV, DimSCEV->getType(), &*Builder.GetInsertPoint(), &GlobalMap,
+        DimSCEV, DimSCEV->getType(), Builder.GetInsertPoint(), &GlobalMap,
         /*LoopMap*/ nullptr, StartBlock->getSinglePredecessor());
 
     Type *Ty = getWidestType(DimSize->getType(), IndexOp->getType());
@@ -613,7 +613,7 @@ IslExprBuilder::createOpBooleanConditional(__isl_take isl_ast_expr *Expr) {
 
   auto InsertBB = Builder.GetInsertBlock();
   auto InsertPoint = Builder.GetInsertPoint();
-  auto NextBB = SplitBlock(InsertBB, &*InsertPoint, GenDT, GenLI);
+  auto NextBB = SplitBlock(InsertBB, InsertPoint, GenDT, GenLI);
   BasicBlock *CondBB = BasicBlock::Create(Context, "polly.cond", F);
   GenLI->changeLoopFor(CondBB, GenLI->getLoopFor(InsertBB));
   GenDT->addNewBlock(CondBB, InsertBB);

--- a/polly/lib/CodeGen/IslNodeBuilder.cpp
+++ b/polly/lib/CodeGen/IslNodeBuilder.cpp
@@ -505,8 +505,8 @@ void IslNodeBuilder::createForParallel(__isl_take isl_ast_node *For) {
   // The preamble of parallel code interacts different than normal code with
   // e.g., scalar initialization. Therefore, we ensure the parallel code is
   // separated from the last basic block.
-  BasicBlock *ParBB = SplitBlock(Builder.GetInsertBlock(),
-                                 &*Builder.GetInsertPoint(), &DT, &LI);
+  BasicBlock *ParBB =
+      SplitBlock(Builder.GetInsertBlock(), Builder.GetInsertPoint(), &DT, &LI);
   ParBB->setName("polly.parallel.for");
   Builder.SetInsertPoint(&ParBB->front());
 
@@ -711,9 +711,9 @@ void IslNodeBuilder::createIf(__isl_take isl_ast_node *If) {
   LLVMContext &Context = F->getContext();
 
   BasicBlock *CondBB = SplitBlock(Builder.GetInsertBlock(),
-                                  &*Builder.GetInsertPoint(), GenDT, GenLI);
+                                  Builder.GetInsertPoint(), GenDT, GenLI);
   CondBB->setName("polly.cond");
-  BasicBlock *MergeBB = SplitBlock(CondBB, &CondBB->front(), GenDT, GenLI);
+  BasicBlock *MergeBB = SplitBlock(CondBB, CondBB->begin(), GenDT, GenLI);
   MergeBB->setName("polly.merge");
   BasicBlock *ThenBB = BasicBlock::Create(Context, "polly.then", F);
   BasicBlock *ElseBB = BasicBlock::Create(Context, "polly.else", F);
@@ -1111,10 +1111,10 @@ Value *IslNodeBuilder::preloadInvariantLoad(const MemoryAccess &MA,
     Cond = Builder.CreateIsNotNull(Cond);
 
   BasicBlock *CondBB = SplitBlock(Builder.GetInsertBlock(),
-                                  &*Builder.GetInsertPoint(), GenDT, GenLI);
+                                  Builder.GetInsertPoint(), GenDT, GenLI);
   CondBB->setName("polly.preload.cond");
 
-  BasicBlock *MergeBB = SplitBlock(CondBB, &CondBB->front(), GenDT, GenLI);
+  BasicBlock *MergeBB = SplitBlock(CondBB, CondBB->begin(), GenDT, GenLI);
   MergeBB->setName("polly.preload.merge");
 
   Function *F = Builder.GetInsertBlock()->getParent();
@@ -1349,7 +1349,7 @@ bool IslNodeBuilder::preloadInvariantLoads() {
     return true;
 
   BasicBlock *PreLoadBB = SplitBlock(Builder.GetInsertBlock(),
-                                     &*Builder.GetInsertPoint(), GenDT, GenLI);
+                                     Builder.GetInsertPoint(), GenDT, GenLI);
   PreLoadBB->setName("polly.preload.begin");
   Builder.SetInsertPoint(&PreLoadBB->front());
 
@@ -1397,7 +1397,7 @@ Value *IslNodeBuilder::generateSCEV(const SCEV *Expr) {
   /// insert location remains valid.
   assert(Builder.GetInsertBlock()->end() != Builder.GetInsertPoint() &&
          "Insert location points after last valid instruction");
-  Instruction *InsertLocation = &*Builder.GetInsertPoint();
+  BasicBlock::iterator InsertLocation = Builder.GetInsertPoint();
 
   return expandCodeFor(S, SE, Builder.GetInsertBlock()->getParent(), *GenSE, DL,
                        "polly", Expr, Expr->getType(), InsertLocation,

--- a/polly/lib/CodeGen/LoopGenerators.cpp
+++ b/polly/lib/CodeGen/LoopGenerators.cpp
@@ -128,7 +128,7 @@ Value *polly::createLoop(Value *LB, Value *UB, Value *Stride,
     Annotator->pushLoop(NewLoop, Parallel);
 
   // ExitBB
-  ExitBB = SplitBlock(BeforeBB, &*Builder.GetInsertPoint(), &DT, &LI);
+  ExitBB = SplitBlock(BeforeBB, Builder.GetInsertPoint(), &DT, &LI);
   ExitBB->setName("polly.loop_exit");
 
   // BeforeBB

--- a/polly/lib/Support/ScopHelper.cpp
+++ b/polly/lib/Support/ScopHelper.cpp
@@ -165,10 +165,10 @@ void polly::simplifyRegion(Region *R, DominatorTree *DT, LoopInfo *LI,
 // Split the block into two successive blocks.
 //
 // Like llvm::SplitBlock, but also preserves RegionInfo
-static BasicBlock *splitBlock(BasicBlock *Old, Instruction *SplitPt,
+static BasicBlock *splitBlock(BasicBlock *Old, BasicBlock::iterator SplitPt,
                               DominatorTree *DT, llvm::LoopInfo *LI,
                               RegionInfo *RI) {
-  assert(Old && SplitPt);
+  assert(Old);
 
   // Before:
   //
@@ -203,7 +203,7 @@ void polly::splitEntryBlockForAlloca(BasicBlock *EntryBlock, DominatorTree *DT,
     ++I;
 
   // splitBlock updates DT, LI and RI.
-  splitBlock(EntryBlock, &*I, DT, LI, RI);
+  splitBlock(EntryBlock, I, DT, LI, RI);
 }
 
 void polly::splitEntryBlockForAlloca(BasicBlock *EntryBlock, Pass *P) {
@@ -261,8 +261,8 @@ struct ScopExpander final : SCEVVisitor<ScopExpander, const SCEV *> {
         VMap(VMap), LoopMap(LoopMap), RTCBB(RTCBB), GenSE(GenSE), GenFn(GenFn) {
   }
 
-  Value *expandCodeFor(const SCEV *E, Type *Ty, Instruction *IP) {
-    assert(isInGenRegion(IP) &&
+  Value *expandCodeFor(const SCEV *E, Type *Ty, BasicBlock::iterator IP) {
+    assert(isInGenRegion(&*IP) &&
            "ScopExpander assumes to be applied to generated code region");
     const SCEV *GenE = visit(E);
     return Expander.expandCodeFor(GenE, Ty, IP);
@@ -305,7 +305,7 @@ private:
   bool isInGenRegion(Instruction *Inst) { return !isInOrigRegion(Inst); }
 
   const SCEV *visitGenericInst(const SCEVUnknown *E, Instruction *Inst,
-                               Instruction *IP) {
+                               BasicBlock::iterator IP) {
     if (!Inst || isInGenRegion(Inst))
       return E;
 
@@ -321,7 +321,7 @@ private:
     }
 
     InstClone->setName(Name + Inst->getName());
-    InstClone->insertBefore(IP->getIterator());
+    InstClone->insertBefore(IP);
     return GenSE.getSCEV(InstClone);
   }
 
@@ -341,19 +341,19 @@ private:
     }
 
     Instruction *Inst = dyn_cast<Instruction>(E->getValue());
-    Instruction *IP;
+    BasicBlock::iterator IP;
     if (Inst && isInGenRegion(Inst))
-      IP = Inst;
+      IP = Inst->getIterator();
     else if (R.getEntry()->getParent() != GenFn) {
       // RTCBB is in the original function, but we are generating for a
       // subfunction so we cannot emit to RTCBB. Usually, we land here only
       // because E->getValue() is not an instruction but a global or constant
       // which do not need to emit anything.
-      IP = GenFn->getEntryBlock().getTerminator();
+      IP = GenFn->getEntryBlock().getTerminator()->getIterator();
     } else if (Inst && RTCBB->getParent() == Inst->getFunction())
-      IP = RTCBB->getTerminator();
+      IP = RTCBB->getTerminator()->getIterator();
     else
-      IP = RTCBB->getParent()->getEntryBlock().getTerminator();
+      IP = RTCBB->getParent()->getEntryBlock().getTerminator()->getIterator();
 
     if (!Inst || (Inst->getOpcode() != Instruction::SRem &&
                   Inst->getOpcode() != Instruction::SDiv))
@@ -368,9 +368,8 @@ private:
     Value *LHS = expandCodeFor(LHSScev, E->getType(), IP);
     Value *RHS = expandCodeFor(RHSScev, E->getType(), IP);
 
-    Inst =
-        BinaryOperator::Create((Instruction::BinaryOps)Inst->getOpcode(), LHS,
-                               RHS, Inst->getName() + Name, IP->getIterator());
+    Inst = BinaryOperator::Create((Instruction::BinaryOps)Inst->getOpcode(),
+                                  LHS, RHS, Inst->getName() + Name, IP);
     return GenSE.getSCEV(Inst);
   }
 
@@ -465,7 +464,7 @@ private:
 Value *polly::expandCodeFor(Scop &S, llvm::ScalarEvolution &SE,
                             llvm::Function *GenFn, ScalarEvolution &GenSE,
                             const DataLayout &DL, const char *Name,
-                            const SCEV *E, Type *Ty, Instruction *IP,
+                            const SCEV *E, Type *Ty, BasicBlock::iterator IP,
                             ValueMapT *VMap, LoopToScevMapT *LoopMap,
                             BasicBlock *RTCBB) {
   ScopExpander Expander(S.getRegion(), SE, GenFn, GenSE, DL, Name, VMap,


### PR DESCRIPTION
Some of the changes in the patch include:

	1. Using iterators instead of instruction pointers when applicable.
	2. Modifying Polly functions to accept iterators instead of inst pointers.
	3. Updating API usages such as use begin instead of front.