### PR TITLE
[mlir][memref] Mark result memref as "strided"

### DIFF
--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -1372,7 +1372,7 @@ def MemRef_ReinterpretCastOp
                        DenseI64ArrayAttr:$static_offsets,
                        DenseI64ArrayAttr:$static_sizes,
                        DenseI64ArrayAttr:$static_strides);
-  let results = (outs AnyMemRef:$result);
+  let results = (outs AnyStridedMemRef:$result);
 
   let assemblyFormat = [{
     $source `to` `offset` `` `:`


### PR DESCRIPTION
We already check this in the verifier, but this makes it explicit in the Tablegen.
