### PR TITLE
[clang][bytecode][NFC] Remove PT_FnPtr

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -4057,7 +4057,7 @@ template <class Emitter> bool Compiler<Emitter>::visitBool(const Expr *E) {
     return true;
 
   // Convert pointers to bool.
-  if (T == PT_Ptr || T == PT_FnPtr) {
+  if (T == PT_Ptr) {
     if (!this->emitNull(*T, 0, nullptr, E))
       return false;
     return this->emitNE(*T, E);
@@ -4103,8 +4103,6 @@ bool Compiler<Emitter>::visitZeroInitializer(PrimType T, QualType QT,
   case PT_Ptr:
     return this->emitNullPtr(Ctx.getASTContext().getTargetNullPointerValue(QT),
                              nullptr, E);
-  case PT_FnPtr:
-    return this->emitNullFnPtr(0, nullptr, E);
   case PT_MemberPtr:
     return this->emitNullMemberPtr(0, nullptr, E);
   case PT_Float:
@@ -4255,7 +4253,6 @@ bool Compiler<Emitter>::emitConst(T Value, PrimType Ty, const Expr *E) {
   case PT_Bool:
     return this->emitConstBool(Value, E);
   case PT_Ptr:
-  case PT_FnPtr:
   case PT_MemberPtr:
   case PT_Float:
   case PT_IntAP:
@@ -4956,7 +4953,7 @@ bool Compiler<Emitter>::VisitCallExpr(const CallExpr *E) {
     // If we know the callee already, check the known parametrs for nullability.
     if (FuncDecl && NonNullArgs[ArgIndex]) {
       PrimType ArgT = classify(Arg).value_or(PT_Ptr);
-      if (ArgT == PT_Ptr || ArgT == PT_FnPtr) {
+      if (ArgT == PT_Ptr) {
         if (!this->emitCheckNonNullArg(ArgT, Arg))
           return false;
       }
@@ -5997,7 +5994,7 @@ bool Compiler<Emitter>::VisitUnaryOperator(const UnaryOperator *E) {
     if (!this->visit(SubExpr))
       return false;
 
-    if (T == PT_Ptr || T == PT_FnPtr) {
+    if (T == PT_Ptr) {
       if (!this->emitIncPtr(E))
         return false;
 
@@ -6021,7 +6018,7 @@ bool Compiler<Emitter>::VisitUnaryOperator(const UnaryOperator *E) {
     if (!this->visit(SubExpr))
       return false;
 
-    if (T == PT_Ptr || T == PT_FnPtr) {
+    if (T == PT_Ptr) {
       if (!this->emitDecPtr(E))
         return false;
 
@@ -6045,7 +6042,7 @@ bool Compiler<Emitter>::VisitUnaryOperator(const UnaryOperator *E) {
     if (!this->visit(SubExpr))
       return false;
 
-    if (T == PT_Ptr || T == PT_FnPtr) {
+    if (T == PT_Ptr) {
       if (!this->emitLoadPtr(E))
         return false;
       if (!this->emitConstUint8(1, E))
@@ -6088,7 +6085,7 @@ bool Compiler<Emitter>::VisitUnaryOperator(const UnaryOperator *E) {
     if (!this->visit(SubExpr))
       return false;
 
-    if (T == PT_Ptr || T == PT_FnPtr) {
+    if (T == PT_Ptr) {
       if (!this->emitLoadPtr(E))
         return false;
       if (!this->emitConstUint8(1, E))

--- a/clang/lib/AST/ByteCode/Disasm.cpp
+++ b/clang/lib/AST/ByteCode/Disasm.cpp
@@ -256,8 +256,6 @@ static const char *primTypeToString(PrimType T) {
     return "Float";
   case PT_Ptr:
     return "Ptr";
-  case PT_FnPtr:
-    return "FnPtr";
   case PT_MemberPtr:
     return "MemberPtr";
   case PT_FixedPoint:

--- a/clang/lib/AST/ByteCode/EvalEmitter.cpp
+++ b/clang/lib/AST/ByteCode/EvalEmitter.cpp
@@ -142,10 +142,6 @@ bool EvalEmitter::speculate(const CallExpr *E, const LabelTy &EndLabel) {
   if (T == PT_Ptr) {
     const auto &Ptr = S.Stk.pop<Pointer>();
     return this->emitBool(CheckBCPResult(S, Ptr), E);
-  } else if (T == PT_FnPtr) {
-    S.Stk.discard<FunctionPointer>();
-    // Never accepted
-    return this->emitBool(false, E);
   }
 
   // Otherwise, this is fine!
@@ -208,14 +204,6 @@ template <> bool EvalEmitter::emitRet<PT_Ptr>(const SourceInfo &Info) {
     EvalResult.setValue(Ptr.toAPValue(Ctx.getASTContext()));
   }
 
-  return true;
-}
-template <> bool EvalEmitter::emitRet<PT_FnPtr>(const SourceInfo &Info) {
-  if (!isActive())
-    return true;
-
-  // Function pointers cannot be converted to rvalues.
-  EvalResult.setFunctionPointer(S.Stk.pop<FunctionPointer>());
   return true;
 }
 

--- a/clang/lib/AST/ByteCode/FunctionPointer.cpp
+++ b/clang/lib/AST/ByteCode/FunctionPointer.cpp
@@ -16,27 +16,22 @@ APValue FunctionPointer::toAPValue(const ASTContext &) const {
     return APValue(static_cast<Expr *>(nullptr), CharUnits::Zero(), {},
                    /*OnePastTheEnd=*/false, /*IsNull=*/true);
 
-  if (!Valid)
-    return APValue(static_cast<Expr *>(nullptr),
-                   CharUnits::fromQuantity(getIntegerRepresentation()), {},
-                   /*OnePastTheEnd=*/false, /*IsNull=*/false);
-
   if (Func->getDecl())
-    return APValue(Func->getDecl(), CharUnits::fromQuantity(Offset), {},
+    return APValue(Func->getDecl(), CharUnits::fromQuantity(0), {},
                    /*OnePastTheEnd=*/false, /*IsNull=*/false);
-  return APValue(Func->getExpr(), CharUnits::fromQuantity(Offset), {},
+  return APValue(Func->getExpr(), CharUnits::fromQuantity(0), {},
                  /*OnePastTheEnd=*/false, /*IsNull=*/false);
 }
 
 void FunctionPointer::print(llvm::raw_ostream &OS) const {
   OS << "FnPtr(";
-  if (Func && Valid)
+  if (Func)
     OS << Func->getName();
   else if (Func)
     OS << reinterpret_cast<uintptr_t>(Func);
   else
     OS << "nullptr";
-  OS << ") + " << Offset;
+  OS << ")";
 }
 
 } // namespace interp

--- a/clang/lib/AST/ByteCode/FunctionPointer.h
+++ b/clang/lib/AST/ByteCode/FunctionPointer.h
@@ -20,24 +20,15 @@ namespace interp {
 class FunctionPointer final {
 private:
   const Function *Func;
-  uint64_t Offset;
-  bool Valid;
 
 public:
   FunctionPointer() = default;
-  FunctionPointer(const Function *Func, uint64_t Offset = 0)
-      : Func(Func), Offset(Offset), Valid(true) {}
-
-  FunctionPointer(uintptr_t IntVal, const Descriptor *Desc = nullptr)
-      : Func(reinterpret_cast<const Function *>(IntVal)), Offset(0),
-        Valid(false) {}
+  FunctionPointer(const Function *Func) : Func(Func) {}
 
   const Function *getFunction() const { return Func; }
-  uint64_t getOffset() const { return Offset; }
   bool isZero() const { return !Func; }
-  bool isValid() const { return Valid; }
   bool isWeak() const {
-    if (!Func || !Valid || !Func->getDecl())
+    if (!Func || !Func->getDecl())
       return false;
 
     return Func->getDecl()->isWeak();
@@ -56,19 +47,7 @@ public:
   uint64_t getIntegerRepresentation() const {
     return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(Func));
   }
-
-  ComparisonCategoryResult compare(const FunctionPointer &RHS) const {
-    if (Func == RHS.Func && Offset == RHS.Offset)
-      return ComparisonCategoryResult::Equal;
-    return ComparisonCategoryResult::Unordered;
-  }
 };
-
-inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS,
-                                     FunctionPointer FP) {
-  FP.print(OS);
-  return OS;
-}
 
 } // namespace interp
 } // namespace clang

--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -130,7 +130,6 @@ static bool retPrimValue(InterpState &S, CodePtr OpPC,
     return Ret<X>(S, OpPC);
   switch (*T) {
     RET_CASE(PT_Ptr);
-    RET_CASE(PT_FnPtr);
     RET_CASE(PT_Float);
     RET_CASE(PT_Bool);
     RET_CASE(PT_Sint8);
@@ -766,10 +765,7 @@ static bool interp__builtin_addressof(InterpState &S, CodePtr OpPC,
   assert(Call->getArg(0)->isLValue());
   PrimType PtrT = S.getContext().classify(Call->getArg(0)).value_or(PT_Ptr);
 
-  if (PtrT == PT_FnPtr) {
-    const FunctionPointer &Arg = S.Stk.peek<FunctionPointer>();
-    S.Stk.push<FunctionPointer>(Arg);
-  } else if (PtrT == PT_Ptr) {
+  if (PtrT == PT_Ptr) {
     const Pointer &Arg = S.Stk.peek<Pointer>();
     S.Stk.push<Pointer>(Arg);
   } else {

--- a/clang/lib/AST/ByteCode/InterpStack.h
+++ b/clang/lib/AST/ByteCode/InterpStack.h
@@ -183,8 +183,6 @@ private:
       return PT_Uint64;
     else if constexpr (std::is_same_v<T, Floating>)
       return PT_Float;
-    else if constexpr (std::is_same_v<T, FunctionPointer>)
-      return PT_FnPtr;
     else if constexpr (std::is_same_v<T, IntegralAP<true>>)
       return PT_IntAP;
     else if constexpr (std::is_same_v<T, IntegralAP<false>>)

--- a/clang/lib/AST/ByteCode/Opcodes.td
+++ b/clang/lib/AST/ByteCode/Opcodes.td
@@ -29,7 +29,6 @@ def IntAP : Type;
 def IntAPS : Type;
 def Float : Type;
 def Ptr : Type;
-def FnPtr : Type;
 def MemberPtr : Type;
 def FixedPoint : Type;
 
@@ -106,9 +105,7 @@ def AluTypeClass : TypeClass {
   let Types = !listconcat(IntegerTypeClass.Types, [Bool], [FixedPoint]);
 }
 
-def PtrTypeClass : TypeClass {
-  let Types = [Ptr, FnPtr, MemberPtr];
-}
+def PtrTypeClass : TypeClass { let Types = [Ptr, MemberPtr]; }
 
 def NonPtrTypeClass : TypeClass {
   let Types = !listconcat(IntegerTypeClass.Types, [Bool], [Float], [FixedPoint]);
@@ -119,7 +116,7 @@ def AllTypeClass : TypeClass {
 }
 
 def ComparableTypeClass : TypeClass {
-  let Types = !listconcat(AluTypeClass.Types, [Ptr], [Float], [FnPtr]);
+  let Types = !listconcat(AluTypeClass.Types, [Ptr], [Float]);
 }
 
 class SingletonTypeClass<Type Ty> : TypeClass {

--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -155,10 +155,10 @@ APValue Pointer::toAPValue(const ASTContext &ASTCtx) const {
   if (isFunctionPointer()) {
     const FunctionPointer &FP = asFunctionPointer();
     if (const FunctionDecl *FD = FP.getFunction()->getDecl())
-      return APValue(FD, CharUnits::fromQuantity(FP.getOffset() + Offset), {},
+      return APValue(FD, CharUnits::fromQuantity(Offset), {},
                      /*OnePastTheEnd=*/false, /*IsNull=*/false);
-    return APValue(FP.getFunction()->getExpr(),
-                   CharUnits::fromQuantity(FP.getOffset() + Offset), {},
+    return APValue(FP.getFunction()->getExpr(), CharUnits::fromQuantity(Offset),
+                   {},
                    /*OnePastTheEnd=*/false, /*IsNull=*/false);
   }
 

--- a/clang/lib/AST/ByteCode/PrimType.h
+++ b/clang/lib/AST/ByteCode/PrimType.h
@@ -46,12 +46,11 @@ enum PrimType : unsigned {
   PT_FixedPoint = 11,
   PT_Float = 12,
   PT_Ptr = 13,
-  PT_FnPtr = 14,
-  PT_MemberPtr = 15,
+  PT_MemberPtr = 14,
 };
 
 inline constexpr bool isPtrType(PrimType T) {
-  return T == PT_Ptr || T == PT_FnPtr || T == PT_MemberPtr;
+  return T == PT_Ptr || T == PT_MemberPtr;
 }
 
 enum class CastKind : uint8_t {
@@ -114,9 +113,6 @@ template <> struct PrimConv<PT_Bool> {
 template <> struct PrimConv<PT_Ptr> {
   using T = Pointer;
 };
-template <> struct PrimConv<PT_FnPtr> {
-  using T = FunctionPointer;
-};
 template <> struct PrimConv<PT_MemberPtr> {
   using T = MemberPointer;
 };
@@ -166,7 +162,6 @@ static inline bool aligned(const void *P) {
       TYPE_SWITCH_CASE(PT_Float, B)                                            \
       TYPE_SWITCH_CASE(PT_Bool, B)                                             \
       TYPE_SWITCH_CASE(PT_Ptr, B)                                              \
-      TYPE_SWITCH_CASE(PT_FnPtr, B)                                            \
       TYPE_SWITCH_CASE(PT_MemberPtr, B)                                        \
       TYPE_SWITCH_CASE(PT_FixedPoint, B)                                       \
     }                                                                          \


### PR DESCRIPTION
We don't need this anymore since we don't return it from classify() anymore.