### PR TITLE
[clang][bytecode] Give typeinfo APValues an LValuePath

### DIFF
--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -167,7 +167,8 @@ APValue Pointer::toAPValue(const ASTContext &ASTCtx) const {
     return APValue(
         APValue::LValueBase::getTypeInfo(
             TypeInfo, QualType(PointeeStorage.Typeid.TypeInfoType, 0)),
-        CharUnits::Zero(), APValue::NoLValuePath{});
+        CharUnits::Zero(), {},
+        /*OnePastTheEnd=*/false, /*IsNull=*/false);
   }
 
   // Build the lvalue base from the block.


### PR DESCRIPTION
That's what the current interpreter does as well.