### PR TITLE
[SCF] add debug label for MergeNestedParallelLoops pattern

### DIFF
--- a/mlir/lib/Dialect/SCF/IR/SCF.cpp
+++ b/mlir/lib/Dialect/SCF/IR/SCF.cpp
@@ -3143,6 +3143,8 @@ struct ParallelOpSingleOrZeroIterationDimsFolder
 struct MergeNestedParallelLoops : public OpRewritePattern<ParallelOp> {
   using OpRewritePattern<ParallelOp>::OpRewritePattern;
 
+  void initialize() { setDebugName("MergeNestedParallelLoops"); }
+
   LogicalResult matchAndRewrite(ParallelOp op,
                                 PatternRewriter &rewriter) const override {
     Block &outerBody = *op.getBody();
@@ -3202,9 +3204,9 @@ struct MergeNestedParallelLoops : public OpRewritePattern<ParallelOp> {
 
 void ParallelOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
-  results.add<ParallelOpSingleOrZeroIterationDimsFolder>(context);
-  results.addWithLabel<MergeNestedParallelLoops>({"MergeNestedParallelLoops"},
-                                                 context);
+  results
+      .add<ParallelOpSingleOrZeroIterationDimsFolder, MergeNestedParallelLoops>(
+          context);
 }
 
 /// Given the region at `index`, or the parent operation if `index` is None,

--- a/mlir/lib/Dialect/SCF/IR/SCF.cpp
+++ b/mlir/lib/Dialect/SCF/IR/SCF.cpp
@@ -3202,9 +3202,9 @@ struct MergeNestedParallelLoops : public OpRewritePattern<ParallelOp> {
 
 void ParallelOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
-  results
-      .add<ParallelOpSingleOrZeroIterationDimsFolder, MergeNestedParallelLoops>(
-          context);
+  results.add<ParallelOpSingleOrZeroIterationDimsFolder>(context);
+  results.addWithLabel<MergeNestedParallelLoops>({"MergeNestedParallelLoops"},
+                                                 context);
 }
 
 /// Given the region at `index`, or the parent operation if `index` is None,


### PR DESCRIPTION
Adding debug labels to rewrite patterns gives the canonicalizer the ability to disable specific patterns if undesired.

The motivation here is that since there is currently no way to handle attributes on ops that are changed when these patterns are applied, this at least provides a workaround.