### PR TITLE
[llvm] revisions to export annotation macros to avoid compiler warnings

### DIFF
--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -199,15 +199,15 @@
 #define LLVM_ABI_EXPORT __declspec(dllexport)
 #elif defined(__ELF__) || defined(__MINGW32__) || defined(_AIX) ||             \
     defined(__MVS__)
-#define LLVM_ABI LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
-#define LLVM_TEMPLATE_ABI LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
+#define LLVM_ABI __attribute__((visibility("default")))
+#define LLVM_TEMPLATE_ABI __attribute__((visibility("default")))
 #define LLVM_EXPORT_TEMPLATE
-#define LLVM_ABI_EXPORT LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
+#define LLVM_ABI_EXPORT __attribute__((visibility("default")))
 #elif defined(__MACH__) || defined(__WASM__) || defined(__EMSCRIPTEN__)
-#define LLVM_ABI LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
+#define LLVM_ABI __attribute__((visibility("default")))
 #define LLVM_TEMPLATE_ABI
 #define LLVM_EXPORT_TEMPLATE
-#define LLVM_ABI_EXPORT LLVM_ATTRIBUTE_VISIBILITY_DEFAULT
+#define LLVM_ABI_EXPORT __attribute__((visibility("default")))
 #endif
 #else
 #define LLVM_ABI

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -199,9 +199,12 @@
 #define LLVM_ABI_EXPORT __declspec(dllexport)
 #elif (defined(__ELF__) || defined(__MINGW32__) || defined(_AIX) ||            \
     defined(__MVS__)) && __has_attribute(visibililty)
+// Use __attribute__((visibility(""))) syntax for visibility rather than
+// [[gnu::visibility("")]] because compilers are more permissive with its
+// placement.
 #define LLVM_ABI __attribute__((visibility("default")))
 #if defined(__GNUC__) && !defined(__clang__)
-// GCC produces warnings on visibility attributes applied to templates.
+// GCC produces warnings on visibility attributes applied to some templates.
 #define LLVM_TEMPLATE_ABI
 #else
 #define LLVM_TEMPLATE_ABI __attribute__((visibility("default")))

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -198,7 +198,8 @@
 #endif
 #define LLVM_ABI_EXPORT __declspec(dllexport)
 #elif (defined(__ELF__) || defined(__MINGW32__) || defined(_AIX) ||            \
-    defined(__MVS__)) && __has_attribute(visibililty)
+       defined(__MVS__)) &&                                                    \
+    __has_attribute(visibililty)
 // Use __attribute__((visibility(""))) syntax for visibility rather than
 // [[gnu::visibility("")]] because compilers are more permissive with its
 // placement.

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -197,8 +197,8 @@
 #define LLVM_EXPORT_TEMPLATE
 #endif
 #define LLVM_ABI_EXPORT __declspec(dllexport)
-#elif defined(__ELF__) || defined(__MINGW32__) || defined(_AIX) ||             \
-    defined(__MVS__)
+#elif (defined(__ELF__) || defined(__MINGW32__) || defined(_AIX) ||            \
+    defined(__MVS__)) && __has_attribute(visibililty)
 #define LLVM_ABI __attribute__((visibility("default")))
 #if defined(__GNUC__) && !defined(__clang__)
 // GCC produces warnings on visibility attributes applied to templates.
@@ -208,11 +208,17 @@
 #endif
 #define LLVM_EXPORT_TEMPLATE
 #define LLVM_ABI_EXPORT __attribute__((visibility("default")))
-#elif defined(__MACH__) || defined(__WASM__) || defined(__EMSCRIPTEN__)
+#elif (defined(__MACH__) || defined(__WASM__) || defined(__EMSCRIPTEN__)) &&   \
+    __has_attribute(visibility)
 #define LLVM_ABI __attribute__((visibility("default")))
 #define LLVM_TEMPLATE_ABI
 #define LLVM_EXPORT_TEMPLATE
 #define LLVM_ABI_EXPORT __attribute__((visibility("default")))
+#else
+#define LLVM_ABI
+#define LLVM_TEMPLATE_ABI
+#define LLVM_EXPORT_TEMPLATE
+#define LLVM_ABI_EXPORT
 #endif
 #else
 #define LLVM_ABI

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -200,7 +200,12 @@
 #elif defined(__ELF__) || defined(__MINGW32__) || defined(_AIX) ||             \
     defined(__MVS__)
 #define LLVM_ABI __attribute__((visibility("default")))
+#if defined(__GNUC__) && !defined(__clang__)
+// GCC produces warnings on visibility attributes applied to templates.
+#define LLVM_TEMPLATE_ABI
+#else
 #define LLVM_TEMPLATE_ABI __attribute__((visibility("default")))
+#endif
 #define LLVM_EXPORT_TEMPLATE
 #define LLVM_ABI_EXPORT __attribute__((visibility("default")))
 #elif defined(__MACH__) || defined(__WASM__) || defined(__EMSCRIPTEN__)


### PR DESCRIPTION
## Purpose
Revise the `LLVM_ABI` family of macros defined in `llvm/Support/Compiler.h` to eliminate GCC compiler warnings that appear when more of the codebase is annotated.

## Overview
This patch changes the annotation behavior in two ways:
1. Switches the macros to explicitly use the `__annotation__((visibility("default")))` syntax rather than rely on the pre-existing `LLVM_ATTRIBUTE_VISIBILITY_DEFAULT`. The `LLVM_ATTRIBUTE_VISIBILITY_DEFAULT` macro resolves to `[[gnu::visibility("default")]]` on most compiler versions, which is permitted in fewer locations (such as annotating `friend` function declarations) and produces warnings.
2. Defines `LLVM_TEMPLATE_ABI` to nothing when compiling with GCC. This avoids compiler warnings about redefined attributes on explicitly instantiated template types.

## Background
Additional context on the effort to annotate LLVM's public interface is in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307).

Without this change, compiling LLVM with GCC will produce `-Wattributes` warnings in a number of cases once more of the codebase has been annotated. Specifically:
```
warning: attribute ignored [-Wattributes] note: an attribute that appertains to a friend declaration that is not a definition is ignored
```
```
warning: type attributes ignored after type is already defined [-Wattributes]
```
Neither of these warnings are present when compiling with Clang.