### PR TITLE
[mlir][linalg][NFC] Update elementwise docs to match op name

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgStructuredOps.td
@@ -565,18 +565,18 @@ def ElementwiseOp : LinalgStructuredBase_Op<"elementwise", [
 
     Example:
 
-    Defining a unary linalg.elemwise with default indexing-map:
+    Defining a unary linalg.elementwise with default indexing-map:
     ```mlir
-    %exp = linalg.elemwise
-        kind=#linalg.elemwise_kind<exp>
+    %exp = linalg.elementwise
+        kind=#linalg.elementwise_kind<exp>
         ins(%x : tensor<4x16x8xf32>)
         outs(%y: tensor<4x16x8xf32>) -> tensor<4x16x8xf32>
     ```
 
-    Defining a binary linalg.elemwise with user-defined indexing-map:
+    Defining a binary linalg.elementwise with user-defined indexing-map:
     ```mlir
-    %add = linalg.elemwise
-        kind=#linalg.elemwise_kind<add>
+    %add = linalg.elementwise
+        kind=#linalg.elementwise_kind<add>
         indexing_maps = [#transpose, #broadcast, #identity]
         ins(%exp, %arg1 : tensor<4x16x8xf32>, tensor<4x16xf32>)
         outs(%arg2: tensor<4x8x16xf32>) -> tensor<4x8x16xf32>


### PR DESCRIPTION
Updates linalg.elementwise op description to replace older abbreviated mnemonic with its current form.