### PR TITLE
[flang][openacc] Allow open acc routines from other modules.

### DIFF
--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -358,9 +358,6 @@ public:
   /// functions in order to be in sync).
   virtual mlir::SymbolTable *getMLIRSymbolTable() = 0;
 
-  virtual Fortran::lower::AccRoutineInfoMappingList &
-  getAccDelayedRoutines() = 0;
-
 private:
   /// Options controlling lowering behavior.
   const Fortran::lower::LoweringOptions &loweringOptions;

--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -14,7 +14,6 @@
 #define FORTRAN_LOWER_ABSTRACTCONVERTER_H
 
 #include "flang/Lower/LoweringOptions.h"
-#include "flang/Lower/OpenACC.h"
 #include "flang/Lower/PFTDefs.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Dialect/FIRAttr.h"

--- a/flang/include/flang/Lower/AbstractConverter.h
+++ b/flang/include/flang/Lower/AbstractConverter.h
@@ -14,6 +14,7 @@
 #define FORTRAN_LOWER_ABSTRACTCONVERTER_H
 
 #include "flang/Lower/LoweringOptions.h"
+#include "flang/Lower/OpenACC.h"
 #include "flang/Lower/PFTDefs.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
 #include "flang/Optimizer/Dialect/FIRAttr.h"
@@ -356,6 +357,9 @@ public:
   /// always be provided to the builder helper creating globals and
   /// functions in order to be in sync).
   virtual mlir::SymbolTable *getMLIRSymbolTable() = 0;
+
+  virtual Fortran::lower::AccRoutineInfoMappingList &
+  getAccDelayedRoutines() = 0;
 
 private:
   /// Options controlling lowering behavior.

--- a/flang/include/flang/Lower/OpenACC.h
+++ b/flang/include/flang/Lower/OpenACC.h
@@ -24,7 +24,7 @@ class StringRef;
 namespace mlir {
 namespace func {
 class FuncOp;
-}
+} // namespace func
 class Location;
 class Type;
 class ModuleOp;
@@ -34,7 +34,7 @@ class Value;
 
 namespace fir {
 class FirOpBuilder;
-}
+} // namespace fir
 
 namespace Fortran {
 namespace evaluate {

--- a/flang/include/flang/Lower/OpenACC.h
+++ b/flang/include/flang/Lower/OpenACC.h
@@ -38,7 +38,7 @@ class FirOpBuilder;
 
 namespace Fortran {
 namespace evaluate {
-class ProcedureDesignator;
+struct ProcedureDesignator;
 } // namespace evaluate
 
 namespace parser {

--- a/flang/include/flang/Lower/OpenACC.h
+++ b/flang/include/flang/Lower/OpenACC.h
@@ -72,9 +72,6 @@ static constexpr llvm::StringRef declarePostDeallocSuffix =
 
 static constexpr llvm::StringRef privatizationRecipePrefix = "privatization";
 
-bool needsOpenACCRoutineConstruct(
-    const Fortran::evaluate::ProcedureDesignator *);
-
 mlir::Value genOpenACCConstruct(AbstractConverter &,
                                 Fortran::semantics::SemanticsContext &,
                                 pft::Evaluation &,

--- a/flang/include/flang/Lower/OpenACC.h
+++ b/flang/include/flang/Lower/OpenACC.h
@@ -37,11 +37,16 @@ class FirOpBuilder;
 }
 
 namespace Fortran {
+namespace evaluate {
+class ProcedureDesignator;
+} // namespace evaluate
+
 namespace parser {
 struct AccClauseList;
 struct OpenACCConstruct;
 struct OpenACCDeclarativeConstruct;
 struct OpenACCRoutineConstruct;
+struct ProcedureDesignator;
 } // namespace parser
 
 namespace semantics {
@@ -70,6 +75,8 @@ static constexpr llvm::StringRef declarePostDeallocSuffix =
     "_acc_declare_update_desc_post_dealloc";
 
 static constexpr llvm::StringRef privatizationRecipePrefix = "privatization";
+
+bool needsOpenACCRoutineConstruct(const Fortran::evaluate::ProcedureDesignator *);
 
 mlir::Value genOpenACCConstruct(AbstractConverter &,
                                 Fortran::semantics::SemanticsContext &,

--- a/flang/include/flang/Lower/OpenACC.h
+++ b/flang/include/flang/Lower/OpenACC.h
@@ -46,7 +46,6 @@ struct AccClauseList;
 struct OpenACCConstruct;
 struct OpenACCDeclarativeConstruct;
 struct OpenACCRoutineConstruct;
-struct ProcedureDesignator;
 } // namespace parser
 
 namespace semantics {

--- a/flang/include/flang/Lower/OpenACC.h
+++ b/flang/include/flang/Lower/OpenACC.h
@@ -63,9 +63,6 @@ namespace pft {
 struct Evaluation;
 } // namespace pft
 
-using AccRoutineInfoMappingList =
-    llvm::SmallVector<std::pair<std::string, mlir::SymbolRefAttr>>;
-
 static constexpr llvm::StringRef declarePostAllocSuffix =
     "_acc_declare_update_desc_post_alloc";
 static constexpr llvm::StringRef declarePreDeallocSuffix =
@@ -82,21 +79,12 @@ mlir::Value genOpenACCConstruct(AbstractConverter &,
                                 Fortran::semantics::SemanticsContext &,
                                 pft::Evaluation &,
                                 const parser::OpenACCConstruct &);
-void genOpenACCDeclarativeConstruct(AbstractConverter &,
-                                    Fortran::semantics::SemanticsContext &,
-                                    StatementContext &,
-                                    const parser::OpenACCDeclarativeConstruct &,
-                                    AccRoutineInfoMappingList &);
-void genOpenACCRoutineConstruct(AbstractConverter &,
-                                Fortran::semantics::SemanticsContext &,
-                                mlir::ModuleOp,
-                                const parser::OpenACCRoutineConstruct &);
+void genOpenACCDeclarativeConstruct(
+    AbstractConverter &, Fortran::semantics::SemanticsContext &,
+    StatementContext &, const parser::OpenACCDeclarativeConstruct &);
 void genOpenACCRoutineConstruct(
     AbstractConverter &, mlir::ModuleOp, mlir::func::FuncOp,
     const std::vector<Fortran::semantics::OpenACCRoutineInfo> &);
-
-void finalizeOpenACCRoutineAttachment(mlir::ModuleOp,
-                                      AccRoutineInfoMappingList &);
 
 /// Get a acc.private.recipe op for the given type or create it if it does not
 /// exist yet.

--- a/flang/include/flang/Lower/OpenACC.h
+++ b/flang/include/flang/Lower/OpenACC.h
@@ -76,7 +76,8 @@ static constexpr llvm::StringRef declarePostDeallocSuffix =
 
 static constexpr llvm::StringRef privatizationRecipePrefix = "privatization";
 
-bool needsOpenACCRoutineConstruct(const Fortran::evaluate::ProcedureDesignator *);
+bool needsOpenACCRoutineConstruct(
+    const Fortran::evaluate::ProcedureDesignator *);
 
 mlir::Value genOpenACCConstruct(AbstractConverter &,
                                 Fortran::semantics::SemanticsContext &,

--- a/flang/include/flang/Lower/OpenACC.h
+++ b/flang/include/flang/Lower/OpenACC.h
@@ -22,6 +22,9 @@ class StringRef;
 } // namespace llvm
 
 namespace mlir {
+namespace func {
+class FuncOp;
+}
 class Location;
 class Type;
 class ModuleOp;
@@ -42,6 +45,7 @@ struct OpenACCRoutineConstruct;
 } // namespace parser
 
 namespace semantics {
+class OpenACCRoutineInfo;
 class SemanticsContext;
 class Symbol;
 } // namespace semantics
@@ -79,8 +83,10 @@ void genOpenACCDeclarativeConstruct(AbstractConverter &,
 void genOpenACCRoutineConstruct(AbstractConverter &,
                                 Fortran::semantics::SemanticsContext &,
                                 mlir::ModuleOp,
-                                const parser::OpenACCRoutineConstruct &,
-                                AccRoutineInfoMappingList &);
+                                const parser::OpenACCRoutineConstruct &);
+void genOpenACCRoutineConstruct(
+    AbstractConverter &, mlir::ModuleOp, mlir::func::FuncOp,
+    const std::vector<Fortran::semantics::OpenACCRoutineInfo> &);
 
 void finalizeOpenACCRoutineAttachment(mlir::ModuleOp,
                                       AccRoutineInfoMappingList &);

--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -142,7 +142,11 @@ public:
   const std::string *bindName() const {
     return bindName_ ? &*bindName_ : nullptr;
   }
-  void set_bindName(std::string &&name) { bindName_ = std::move(name); }
+  bool bindNameIsInternal() const {return bindNameIsInternal_;}
+  void set_bindName(std::string &&name, bool isInternal=false) { 
+    bindName_ = std::move(name); 
+    bindNameIsInternal_ = isInternal;
+  }
 
   Fortran::common::OpenACCDeviceType dType() const { return deviceType_; }
 
@@ -153,6 +157,7 @@ private:
   bool isGang_{false};
   unsigned gangDim_{0};
   std::optional<std::string> bindName_;
+  bool bindNameIsInternal_{false};
   Fortran::common::OpenACCDeviceType deviceType_{
       Fortran::common::OpenACCDeviceType::None};
 };

--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -128,7 +128,8 @@ private:
 // Device type specific OpenACC routine information
 class OpenACCRoutineDeviceTypeInfo {
 public:
-  OpenACCRoutineDeviceTypeInfo(Fortran::common::OpenACCDeviceType dType)
+  explicit OpenACCRoutineDeviceTypeInfo(
+      Fortran::common::OpenACCDeviceType dType)
       : deviceType_{dType} {}
   bool isSeq() const { return isSeq_; }
   void set_isSeq(bool value = true) { isSeq_ = value; }
@@ -161,6 +162,8 @@ private:
   bool isWorker_{false};
   bool isGang_{false};
   unsigned gangDim_{0};
+  // bind("name") -> std::string
+  // bind(sym) -> SymbolRef (requires namemangling in lowering)
   std::optional<std::variant<std::string, SymbolRef>> bindName_;
   Fortran::common::OpenACCDeviceType deviceType_{
       Fortran::common::OpenACCDeviceType::None};

--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -143,7 +143,8 @@ public:
   const std::variant<std::string, SymbolRef> *bindName() const {
     return bindName_.has_value() ? &*bindName_ : nullptr;
   }
-  const std::optional<std::variant<std::string, SymbolRef>> &bindNameOpt() const {
+  const std::optional<std::variant<std::string, SymbolRef>> &
+  bindNameOpt() const {
     return bindName_;
   }
   void set_bindName(std::string &&name) { bindName_.emplace(std::move(name)); }
@@ -153,6 +154,7 @@ public:
 
   friend llvm::raw_ostream &operator<<(
       llvm::raw_ostream &, const OpenACCRoutineDeviceTypeInfo &);
+
 private:
   bool isSeq_{false};
   bool isVector_{false};

--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -127,6 +127,8 @@ private:
 // Device type specific OpenACC routine information
 class OpenACCRoutineDeviceTypeInfo {
 public:
+  OpenACCRoutineDeviceTypeInfo(Fortran::common::OpenACCDeviceType dType)
+      : deviceType_{dType} {}
   bool isSeq() const { return isSeq_; }
   void set_isSeq(bool value = true) { isSeq_ = value; }
   bool isVector() const { return isVector_; }
@@ -141,9 +143,7 @@ public:
     return bindName_ ? &*bindName_ : nullptr;
   }
   void set_bindName(std::string &&name) { bindName_ = std::move(name); }
-  void set_dType(Fortran::common::OpenACCDeviceType dType) {
-    deviceType_ = dType;
-  }
+
   Fortran::common::OpenACCDeviceType dType() const { return deviceType_; }
 
 private:
@@ -162,13 +162,24 @@ private:
 // in as objects in the OpenACCRoutineDeviceTypeInfo list.
 class OpenACCRoutineInfo : public OpenACCRoutineDeviceTypeInfo {
 public:
+  OpenACCRoutineInfo()
+      : OpenACCRoutineDeviceTypeInfo(Fortran::common::OpenACCDeviceType::None) {
+  }
   bool isNohost() const { return isNohost_; }
   void set_isNohost(bool value = true) { isNohost_ = value; }
-  std::list<OpenACCRoutineDeviceTypeInfo> &deviceTypeInfos() {
+  const std::list<OpenACCRoutineDeviceTypeInfo> &deviceTypeInfos() const {
     return deviceTypeInfos_;
   }
-  void add_deviceTypeInfo(OpenACCRoutineDeviceTypeInfo &info) {
-    deviceTypeInfos_.push_back(info);
+
+  OpenACCRoutineDeviceTypeInfo &add_deviceTypeInfo(
+      Fortran::common::OpenACCDeviceType type) {
+    return add_deviceTypeInfo(OpenACCRoutineDeviceTypeInfo(type));
+  }
+
+  OpenACCRoutineDeviceTypeInfo &add_deviceTypeInfo(
+      OpenACCRoutineDeviceTypeInfo &&info) {
+    deviceTypeInfos_.push_back(std::move(info));
+    return deviceTypeInfos_.back();
   }
 
 private:

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -5883,7 +5883,7 @@ private:
   /// Helper to generate GlobalOps when the builder is not positioned in any
   /// region block. This is required because the FirOpBuilder assumes it is
   /// always positioned inside a region block when creating globals, the easiest
-  /// way to comply is to create a dummy function and to throw it away 
+  /// way to comply is to create a dummy function and to throw it away
   /// afterwards.
   void createGlobalOutsideOfFunctionLowering(
       const std::function<void()> &createGlobals) {

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -465,8 +465,8 @@ public:
   /// Declare a function.
   void declareFunction(Fortran::lower::pft::FunctionLikeUnit &funit) {
     setCurrentPosition(funit.getStartingSourceLoc());
-    builder = new fir::FirOpBuilder(
-        bridge.getModule(), bridge.getKindMap(), &mlirSymbolTable);
+    builder = new fir::FirOpBuilder(bridge.getModule(), bridge.getKindMap(),
+                                    &mlirSymbolTable);
     for (int entryIndex = 0, last = funit.entryPointList.size();
          entryIndex < last; ++entryIndex) {
       funit.setActiveEntry(entryIndex);
@@ -1031,9 +1031,9 @@ public:
     return bridge.getSemanticsContext().FindScope(currentPosition);
   }
 
-  fir::FirOpBuilder &getFirOpBuilder() override final { 
+  fir::FirOpBuilder &getFirOpBuilder() override final {
     CHECK(builder && "builder is not set before calling getFirOpBuilder");
-    return *builder; 
+    return *builder;
   }
 
   mlir::ModuleOp getModuleOp() override final { return bridge.getModule(); }
@@ -5616,10 +5616,10 @@ private:
     LLVM_DEBUG(llvm::dbgs() << "\n[bridge - startNewFunction]";
                if (auto *sym = scope.symbol()) llvm::dbgs() << " " << *sym;
                llvm::dbgs() << "\n");
-    // I don't think setting the builder is necessary here, because callee 
+    // I don't think setting the builder is necessary here, because callee
     // always looks up the FuncOp from the module. If there was a function that
     // was not declared yet. This call to callee will cause an assertion
-    //failure.
+    // failure.
     Fortran::lower::CalleeInterface callee(funit, *this);
     mlir::func::FuncOp func = callee.addEntryBlockAndMapArguments();
     builder =

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -5897,7 +5897,8 @@ private:
   /// Helper to generate GlobalOps when the builder is not positioned in any
   /// region block. This is required because the FirOpBuilder assumes it is
   /// always positioned inside a region block when creating globals, the easiest
-  /// way comply is to create a dummy function and to throw it away afterwards.
+  /// way to comply is to create a dummy function and to throw it away 
+  /// afterwards.
   void createGlobalOutsideOfFunctionLowering(
       const std::function<void()> &createGlobals) {
     // FIXME: get rid of the bogus function context and instantiate the

--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -443,7 +443,7 @@ public:
                     bridge.getModule(), bridge.getKindMap(), &mlirSymbolTable);
                 Fortran::lower::genOpenACCRoutineConstruct(
                     *this, bridge.getSemanticsContext(), bridge.getModule(),
-                    d.routine, accRoutineInfos);
+                    d.routine);
                 builder = nullptr;
               },
           },
@@ -4285,6 +4285,11 @@ private:
       return Fortran::lower::convertExprToMutableBox(loc, *this, expr,
                                                      localSymbols);
     return Fortran::lower::createMutableBox(loc, *this, expr, localSymbols);
+  }
+
+  Fortran::lower::AccRoutineInfoMappingList &
+  getAccDelayedRoutines() override final {
+    return accRoutineInfos;
   }
 
   // Create the [newRank] array with the lower bounds to be passed to the

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -21,7 +21,6 @@
 #include "flang/Optimizer/Dialect/FIROpsSupport.h"
 #include "flang/Optimizer/Support/InternalNames.h"
 #include "flang/Optimizer/Support/Utils.h"
-#include "flang/Parser/parse-tree.h"
 #include "flang/Semantics/symbol.h"
 #include "flang/Semantics/tools.h"
 #include "flang/Support/Fortran.h"

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -1701,7 +1701,6 @@ public:
       fir::emitFatalError(converter.getCurrentLocation(),
                           "SignatureBuilder should only be used once");
     declare();
-
     interfaceDetermined = true;
     return getFuncOp();
   }

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -10,6 +10,7 @@
 #include "flang/Evaluate/fold.h"
 #include "flang/Lower/Bridge.h"
 #include "flang/Lower/Mangler.h"
+#include "flang/Lower/OpenACC.h"
 #include "flang/Lower/PFTBuilder.h"
 #include "flang/Lower/StatementContext.h"
 #include "flang/Lower/Support/Utils.h"
@@ -20,6 +21,7 @@
 #include "flang/Optimizer/Dialect/FIROpsSupport.h"
 #include "flang/Optimizer/Support/InternalNames.h"
 #include "flang/Optimizer/Support/Utils.h"
+#include "flang/Parser/parse-tree.h"
 #include "flang/Semantics/symbol.h"
 #include "flang/Semantics/tools.h"
 #include "flang/Support/Fortran.h"
@@ -715,6 +717,14 @@ void Fortran::lower::CallInterface<T>::declare() {
           func.setArgAttrs(placeHolder.index(), placeHolder.value().attributes);
 
       setCUDAAttributes(func, side().getProcedureSymbol(), characteristic);
+      
+      if (const Fortran::semantics::Symbol *sym = side().getProcedureSymbol()) {
+        if (const auto &info{sym->GetUltimate().detailsIf<Fortran::semantics::SubprogramDetails>()}) {
+          if (!info->openACCRoutineInfos().empty()) {
+            genOpenACCRoutineConstruct(converter, module, func, info->openACCRoutineInfos());
+          }
+        }
+      }
     }
   }
 }
@@ -1688,17 +1698,8 @@ public:
       fir::emitFatalError(converter.getCurrentLocation(),
                           "SignatureBuilder should only be used once");
     declare();
+
     interfaceDetermined = true;
-    if (procDesignator && procDesignator->GetInterfaceSymbol() &&
-        procDesignator->GetInterfaceSymbol()
-            ->has<Fortran::semantics::SubprogramDetails>()) {
-      auto info = procDesignator->GetInterfaceSymbol()
-                      ->get<Fortran::semantics::SubprogramDetails>();
-      if (!info.openACCRoutineInfos().empty()) {
-        genOpenACCRoutineConstruct(converter, converter.getModuleOp(),
-                                   getFuncOp(), info.openACCRoutineInfos());
-      }
-    }
     return getFuncOp();
   }
 

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -717,11 +717,14 @@ void Fortran::lower::CallInterface<T>::declare() {
           func.setArgAttrs(placeHolder.index(), placeHolder.value().attributes);
 
       setCUDAAttributes(func, side().getProcedureSymbol(), characteristic);
-      
+
       if (const Fortran::semantics::Symbol *sym = side().getProcedureSymbol()) {
-        if (const auto &info{sym->GetUltimate().detailsIf<Fortran::semantics::SubprogramDetails>()}) {
+        if (const auto &info{
+                sym->GetUltimate()
+                    .detailsIf<Fortran::semantics::SubprogramDetails>()}) {
           if (!info->openACCRoutineInfos().empty()) {
-            genOpenACCRoutineConstruct(converter, module, func, info->openACCRoutineInfos());
+            genOpenACCRoutineConstruct(converter, module, func,
+                                       info->openACCRoutineInfos());
           }
         }
       }

--- a/flang/lib/Lower/CallInterface.cpp
+++ b/flang/lib/Lower/CallInterface.cpp
@@ -1689,6 +1689,16 @@ public:
                           "SignatureBuilder should only be used once");
     declare();
     interfaceDetermined = true;
+    if (procDesignator && procDesignator->GetInterfaceSymbol() &&
+        procDesignator->GetInterfaceSymbol()
+            ->has<Fortran::semantics::SubprogramDetails>()) {
+      auto info = procDesignator->GetInterfaceSymbol()
+                      ->get<Fortran::semantics::SubprogramDetails>();
+      if (!info.openACCRoutineInfos().empty()) {
+        genOpenACCRoutineConstruct(converter, converter.getModuleOp(),
+                                   getFuncOp(), info.openACCRoutineInfos());
+      }
+    }
     return getFuncOp();
   }
 

--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -32,13 +32,13 @@
 #include "flang/Semantics/expression.h"
 #include "flang/Semantics/scope.h"
 #include "flang/Semantics/tools.h"
-#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
-#include "mlir/Support/LLVM.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Frontend/OpenACC/ACC.h.inc"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
-#include <mlir/IR/MLIRContext.h>
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Support/LLVM.h"
 
 #define DEBUG_TYPE "flang-lower-openacc"
 

--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -1394,7 +1394,9 @@ Scope *ModFileReader::Read(SourceName name, std::optional<bool> isIntrinsic,
   parser::Options options;
   options.isModuleFile = true;
   options.features.Enable(common::LanguageFeature::BackslashEscapes);
-  options.features.Enable(common::LanguageFeature::OpenACC);
+  if (context_.languageFeatures().IsEnabled(common::LanguageFeature::OpenACC)) {
+    options.features.Enable(common::LanguageFeature::OpenACC);
+  }
   options.features.Enable(common::LanguageFeature::OpenMP);
   options.features.Enable(common::LanguageFeature::CUDA);
   if (!isIntrinsic.value_or(false) && !notAModule) {

--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -24,6 +24,7 @@
 #include <fstream>
 #include <set>
 #include <string_view>
+#include <variant>
 #include <vector>
 
 namespace Fortran::semantics {
@@ -638,8 +639,14 @@ static void PutOpenACCDeviceTypeRoutineInfo(
   if (info.isWorker()) {
     os << " worker";
   }
-  if (info.bindName()) {
-    os << " bind(" << *info.bindName() << ")";
+  if (const std::variant<std::string, SymbolRef> *bindName{info.bindName()}) {
+    os << " bind(";
+    if (std::holds_alternative<std::string>(*bindName)) {
+      os << "\"" << std::get<std::string>(*bindName) << "\"";
+    } else {
+      os << std::get<SymbolRef>(*bindName)->name();
+    }
+    os << ")";
   }
 }
 

--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -1387,6 +1387,7 @@ Scope *ModFileReader::Read(SourceName name, std::optional<bool> isIntrinsic,
   parser::Options options;
   options.isModuleFile = true;
   options.features.Enable(common::LanguageFeature::BackslashEscapes);
+  options.features.Enable(common::LanguageFeature::OpenACC);
   options.features.Enable(common::LanguageFeature::OpenMP);
   options.features.Enable(common::LanguageFeature::CUDA);
   if (!isIntrinsic.value_or(false) && !notAModule) {

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1088,7 +1088,7 @@ void AccAttributeVisitor::AddRoutineInfoToSymbol(
           if (Symbol * sym{ResolveFctName(*name)}) {
             Symbol &ultimate{sym->GetUltimate()};
             for (auto &device : currentDevices) {
-              device->set_bindName(SymbolRef(ultimate));
+              device->set_bindName(SymbolRef{ultimate});
             }
           } else {
             context_.Say((*name).source,

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1077,10 +1077,12 @@ void AccAttributeVisitor::AddRoutineInfoToSymbol(
       } else if (const auto *bindClause =
                      std::get_if<Fortran::parser::AccClause::Bind>(&clause.u)) {
         std::string bindName = "";
+        bool isInternal = false;
         if (const auto *name =
                 std::get_if<Fortran::parser::Name>(&bindClause->v.u)) {
           if (Symbol *sym = ResolveFctName(*name)) {
             bindName = sym->name().ToString();
+            isInternal = true;
           } else {
             context_.Say((*name).source,
                 "No function or subroutine declared for '%s'"_err_en_US,
@@ -1100,12 +1102,14 @@ void AccAttributeVisitor::AddRoutineInfoToSymbol(
         if (!bindName.empty()) {
           // Fixme: do we need to ensure there there is only one device?
           for (auto &device : currentDevices) {
-            device->set_bindName(std::string(bindName));
+            device->set_bindName(std::string(bindName), isInternal);
           }
         }
       }
     }
     symbol.get<SubprogramDetails>().add_openACCRoutineInfo(info);
+  } else {
+    llvm::errs() << "Couldnot add routine info to symbol: " << symbol.name() << "\n";
   }
 }
 

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1036,65 +1036,75 @@ void AccAttributeVisitor::AddRoutineInfoToSymbol(
     Fortran::semantics::OpenACCRoutineInfo info;
     std::vector<OpenACCRoutineDeviceTypeInfo *> currentDevices;
     currentDevices.push_back(&info);
-    const auto &clauses = std::get<Fortran::parser::AccClauseList>(x.t);
+    const auto &clauses{std::get<Fortran::parser::AccClauseList>(x.t)};
     for (const Fortran::parser::AccClause &clause : clauses.v) {
-      if (const auto *dTypeClause =
-              std::get_if<Fortran::parser::AccClause::DeviceType>(&clause.u)) {
+      if (const auto *dTypeClause{
+              std::get_if<Fortran::parser::AccClause::DeviceType>(&clause.u)}) {
         currentDevices.clear();
-        for (const auto &deviceTypeExpr : dTypeClause->v.v)
+        for (const auto &deviceTypeExpr : dTypeClause->v.v) {
           currentDevices.push_back(&info.add_deviceTypeInfo(deviceTypeExpr.v));
+        }
       } else if (std::get_if<Fortran::parser::AccClause::Nohost>(&clause.u)) {
         info.set_isNohost();
       } else if (std::get_if<Fortran::parser::AccClause::Seq>(&clause.u)) {
-        for (auto &device : currentDevices)
+        for (auto &device : currentDevices) {
           device->set_isSeq();
+        }
       } else if (std::get_if<Fortran::parser::AccClause::Vector>(&clause.u)) {
-        for (auto &device : currentDevices)
+        for (auto &device : currentDevices) {
           device->set_isVector();
+        }
       } else if (std::get_if<Fortran::parser::AccClause::Worker>(&clause.u)) {
-        for (auto &device : currentDevices)
+        for (auto &device : currentDevices) {
           device->set_isWorker();
-      } else if (const auto *gangClause =
-                     std::get_if<Fortran::parser::AccClause::Gang>(&clause.u)) {
-        for (auto &device : currentDevices)
+        }
+      } else if (const auto *gangClause{
+                     std::get_if<Fortran::parser::AccClause::Gang>(
+                         &clause.u)}) {
+        for (auto &device : currentDevices) {
           device->set_isGang();
+        }
         if (gangClause->v) {
           const Fortran::parser::AccGangArgList &x = *gangClause->v;
           int numArgs{0};
           for (const Fortran::parser::AccGangArg &gangArg : x.v) {
             CHECK(numArgs <= 1 && "expecting 0 or 1 gang dim args");
-            if (const auto *dim =
-                    std::get_if<Fortran::parser::AccGangArg::Dim>(&gangArg.u)) {
+            if (const auto *dim{std::get_if<Fortran::parser::AccGangArg::Dim>(
+                    &gangArg.u)}) {
               if (const auto v{EvaluateInt64(context_, dim->v)}) {
-                for (auto &device : currentDevices)
+                for (auto &device : currentDevices) {
                   device->set_gangDim(*v);
+                }
               }
             }
             numArgs++;
           }
         }
-      } else if (const auto *bindClause =
-                     std::get_if<Fortran::parser::AccClause::Bind>(&clause.u)) {
-        if (const auto *name =
-                std::get_if<Fortran::parser::Name>(&bindClause->v.u)) {
-          if (Symbol *sym = ResolveFctName(*name)) {
+      } else if (const auto *bindClause{
+                     std::get_if<Fortran::parser::AccClause::Bind>(
+                         &clause.u)}) {
+        if (const auto *name{
+                std::get_if<Fortran::parser::Name>(&bindClause->v.u)}) {
+          if (Symbol * sym{ResolveFctName(*name)}) {
             Symbol &ultimate{sym->GetUltimate()};
-            for (auto &device : currentDevices)
+            for (auto &device : currentDevices) {
               device->set_bindName(SymbolRef(ultimate));
+            }
           } else {
             context_.Say((*name).source,
                 "No function or subroutine declared for '%s'"_err_en_US,
                 (*name).source);
           }
-        } else if (const auto charExpr =
+        } else if (const auto charExpr{
                        std::get_if<Fortran::parser::ScalarDefaultCharExpr>(
-                           &bindClause->v.u)) {
-          auto *charConst =
+                           &bindClause->v.u)}) {
+          auto *charConst{
               Fortran::parser::Unwrap<Fortran::parser::CharLiteralConstant>(
-                  *charExpr);
+                  *charExpr)};
           std::string str{std::get<std::string>(charConst->t)};
-          for (auto &device : currentDevices)
+          for (auto &device : currentDevices) {
             device->set_bindName(std::string(str));
+          }
         }
       }
     }
@@ -3030,4 +3040,6 @@ void OmpAttributeVisitor::IssueNonConformanceWarning(
   context_.Warn(common::UsageWarning::OpenMPUsage, source, "%s"_warn_en_US,
       warnStrOS.str());
 }
+} // namespace Fortran::semantics
+
 } // namespace Fortran::semantics

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -3041,5 +3041,3 @@ void OmpAttributeVisitor::IssueNonConformanceWarning(
       warnStrOS.str());
 }
 } // namespace Fortran::semantics
-
-} // namespace Fortran::semantics

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1041,9 +1041,8 @@ void AccAttributeVisitor::AddRoutineInfoToSymbol(
       if (const auto *dTypeClause =
               std::get_if<Fortran::parser::AccClause::DeviceType>(&clause.u)) {
         currentDevices.clear();
-        for (const auto &deviceTypeExpr : dTypeClause->v.v) {
+        for (const auto &deviceTypeExpr : dTypeClause->v.v)
           currentDevices.push_back(&info.add_deviceTypeInfo(deviceTypeExpr.v));
-        }
       } else if (std::get_if<Fortran::parser::AccClause::Nohost>(&clause.u)) {
         info.set_isNohost();
       } else if (std::get_if<Fortran::parser::AccClause::Seq>(&clause.u)) {
@@ -1080,9 +1079,8 @@ void AccAttributeVisitor::AddRoutineInfoToSymbol(
                 std::get_if<Fortran::parser::Name>(&bindClause->v.u)) {
           if (Symbol *sym = ResolveFctName(*name)) {
             Symbol &ultimate{sym->GetUltimate()};
-            for (auto &device : currentDevices) {
+            for (auto &device : currentDevices)
               device->set_bindName(SymbolRef(ultimate));
-            }
           } else {
             context_.Say((*name).source,
                 "No function or subroutine declared for '%s'"_err_en_US,
@@ -1095,16 +1093,12 @@ void AccAttributeVisitor::AddRoutineInfoToSymbol(
               Fortran::parser::Unwrap<Fortran::parser::CharLiteralConstant>(
                   *charExpr);
           std::string str{std::get<std::string>(charConst->t)};
-          for (auto &device : currentDevices) {
+          for (auto &device : currentDevices)
             device->set_bindName(std::string(str));
-          }
         }
       }
     }
     symbol.get<SubprogramDetails>().add_openACCRoutineInfo(info);
-  } else {
-    llvm::errs() << "Couldnot add routine info to symbol: " << symbol.name()
-                 << "\n";
   }
 }
 

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1103,7 +1103,8 @@ void AccAttributeVisitor::AddRoutineInfoToSymbol(
     }
     symbol.get<SubprogramDetails>().add_openACCRoutineInfo(info);
   } else {
-    llvm::errs() << "Couldnot add routine info to symbol: " << symbol.name() << "\n";
+    llvm::errs() << "Couldnot add routine info to symbol: " << symbol.name()
+                 << "\n";
   }
 }
 

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1034,61 +1034,53 @@ void AccAttributeVisitor::AddRoutineInfoToSymbol(
     Symbol &symbol, const parser::OpenACCRoutineConstruct &x) {
   if (symbol.has<SubprogramDetails>()) {
     Fortran::semantics::OpenACCRoutineInfo info;
+    std::vector<OpenACCRoutineDeviceTypeInfo *> currentDevices;
+    currentDevices.push_back(&info);
     const auto &clauses = std::get<Fortran::parser::AccClauseList>(x.t);
     for (const Fortran::parser::AccClause &clause : clauses.v) {
-      if (std::get_if<Fortran::parser::AccClause::Seq>(&clause.u)) {
-        if (info.deviceTypeInfos().empty()) {
-          info.set_isSeq();
-        } else {
-          info.deviceTypeInfos().back().set_isSeq();
-        }
-      } else if (const auto *gangClause =
-                     std::get_if<Fortran::parser::AccClause::Gang>(&clause.u)) {
-        if (info.deviceTypeInfos().empty()) {
-          info.set_isGang();
-        } else {
-          info.deviceTypeInfos().back().set_isGang();
-        }
-        if (gangClause->v) {
-          const Fortran::parser::AccGangArgList &x = *gangClause->v;
-          for (const Fortran::parser::AccGangArg &gangArg : x.v) {
-            if (const auto *dim =
-                    std::get_if<Fortran::parser::AccGangArg::Dim>(&gangArg.u)) {
-              if (const auto v{EvaluateInt64(context_, dim->v)}) {
-                if (info.deviceTypeInfos().empty()) {
-                  info.set_gangDim(*v);
-                } else {
-                  info.deviceTypeInfos().back().set_gangDim(*v);
-                }
-              }
-            }
-          }
-        }
-      } else if (std::get_if<Fortran::parser::AccClause::Vector>(&clause.u)) {
-        if (info.deviceTypeInfos().empty()) {
-          info.set_isVector();
-        } else {
-          info.deviceTypeInfos().back().set_isVector();
-        }
-      } else if (std::get_if<Fortran::parser::AccClause::Worker>(&clause.u)) {
-        if (info.deviceTypeInfos().empty()) {
-          info.set_isWorker();
-        } else {
-          info.deviceTypeInfos().back().set_isWorker();
+      if (const auto *dTypeClause =
+              std::get_if<Fortran::parser::AccClause::DeviceType>(&clause.u)) {
+        currentDevices.clear();
+        for (const auto &deviceTypeExpr : dTypeClause->v.v) {
+          currentDevices.push_back(&info.add_deviceTypeInfo(deviceTypeExpr.v));
         }
       } else if (std::get_if<Fortran::parser::AccClause::Nohost>(&clause.u)) {
         info.set_isNohost();
+      } else if (std::get_if<Fortran::parser::AccClause::Seq>(&clause.u)) {
+        for (auto &device : currentDevices)
+          device->set_isSeq();
+      } else if (std::get_if<Fortran::parser::AccClause::Vector>(&clause.u)) {
+        for (auto &device : currentDevices)
+          device->set_isVector();
+      } else if (std::get_if<Fortran::parser::AccClause::Worker>(&clause.u)) {
+        for (auto &device : currentDevices)
+          device->set_isWorker();
+      } else if (const auto *gangClause =
+                     std::get_if<Fortran::parser::AccClause::Gang>(&clause.u)) {
+        for (auto &device : currentDevices)
+          device->set_isGang();
+        if (gangClause->v) {
+          const Fortran::parser::AccGangArgList &x = *gangClause->v;
+          int numArgs{0};
+          for (const Fortran::parser::AccGangArg &gangArg : x.v) {
+            CHECK(numArgs <= 1 && "expecting 0 or 1 gang dim args");
+            if (const auto *dim =
+                    std::get_if<Fortran::parser::AccGangArg::Dim>(&gangArg.u)) {
+              if (const auto v{EvaluateInt64(context_, dim->v)}) {
+                for (auto &device : currentDevices)
+                  device->set_gangDim(*v);
+              }
+            }
+            numArgs++;
+          }
+        }
       } else if (const auto *bindClause =
                      std::get_if<Fortran::parser::AccClause::Bind>(&clause.u)) {
+        std::string bindName = "";
         if (const auto *name =
                 std::get_if<Fortran::parser::Name>(&bindClause->v.u)) {
           if (Symbol *sym = ResolveFctName(*name)) {
-            if (info.deviceTypeInfos().empty()) {
-              info.set_bindName(sym->name().ToString());
-            } else {
-              info.deviceTypeInfos().back().set_bindName(
-                  sym->name().ToString());
-            }
+            bindName = sym->name().ToString();
           } else {
             context_.Say((*name).source,
                 "No function or subroutine declared for '%s'"_err_en_US,
@@ -1101,21 +1093,16 @@ void AccAttributeVisitor::AddRoutineInfoToSymbol(
               Fortran::parser::Unwrap<Fortran::parser::CharLiteralConstant>(
                   *charExpr);
           std::string str{std::get<std::string>(charConst->t)};
-          std::stringstream bindName;
-          bindName << "\"" << str << "\"";
-          if (info.deviceTypeInfos().empty()) {
-            info.set_bindName(bindName.str());
-          } else {
-            info.deviceTypeInfos().back().set_bindName(bindName.str());
+          std::stringstream bindNameStream;
+          bindNameStream << "\"" << str << "\"";
+          bindName = bindNameStream.str();
+        }
+        if (!bindName.empty()) {
+          // Fixme: do we need to ensure there there is only one device?
+          for (auto &device : currentDevices) {
+            device->set_bindName(std::string(bindName));
           }
         }
-      } else if (const auto *dType =
-                     std::get_if<Fortran::parser::AccClause::DeviceType>(
-                         &clause.u)) {
-        const parser::AccDeviceTypeExprList &deviceTypeExprList = dType->v;
-        OpenACCRoutineDeviceTypeInfo dtypeInfo;
-        dtypeInfo.set_dType(deviceTypeExprList.v.front().v);
-        info.add_deviceTypeInfo(dtypeInfo);
       }
     }
     symbol.get<SubprogramDetails>().add_openACCRoutineInfo(info);

--- a/flang/lib/Semantics/symbol.cpp
+++ b/flang/lib/Semantics/symbol.cpp
@@ -146,7 +146,7 @@ llvm::raw_ostream &operator<<(
   }
   if (!x.openACCRoutineInfos_.empty()) {
     os << " openACCRoutineInfos:";
-    for (const auto x : x.openACCRoutineInfos_) {
+    for (const auto &x : x.openACCRoutineInfos_) {
       os << x;
     }
   }

--- a/flang/lib/Semantics/symbol.cpp
+++ b/flang/lib/Semantics/symbol.cpp
@@ -144,6 +144,52 @@ llvm::raw_ostream &operator<<(
       os << ' ' << x;
     }
   }
+  if (!x.openACCRoutineInfos_.empty()) {
+    os << " openACCRoutineInfos:";
+    for (const auto x : x.openACCRoutineInfos_) {
+      os << x;
+    }
+  }
+  return os;
+}
+
+llvm::raw_ostream &operator<<(
+    llvm::raw_ostream &os, const OpenACCRoutineDeviceTypeInfo &x) {
+  if (x.dType() != common::OpenACCDeviceType::None) {
+    os << " deviceType(" << common::EnumToString(x.dType()) << ')';
+  }
+  if (x.isSeq()) {
+    os << " seq";
+  }
+  if (x.isVector()) {
+    os << " vector";
+  }
+  if (x.isWorker()) {
+    os << " worker";
+  }
+  if (x.isGang()) {
+    os << " gang(" << x.gangDim() << ')';
+  }
+  if (const auto *bindName{x.bindName()}) {
+    if (const auto &symbol{std::get_if<std::string>(bindName)}) {
+      os << " bindName(\"" << *symbol << "\")";
+    } else {
+      const SymbolRef s{std::get<SymbolRef>(*bindName)};
+      os << " bindName(" << s->name() << ")";
+    }
+  }
+  return os;
+}
+
+llvm::raw_ostream &operator<<(
+    llvm::raw_ostream &os, const OpenACCRoutineInfo &x) {
+  if (x.isNohost()) {
+    os << " nohost";
+  }
+  os << static_cast<const OpenACCRoutineDeviceTypeInfo &>(x);
+  for (const auto &d : x.deviceTypeInfos_) {
+    os << d;
+  }
   return os;
 }
 

--- a/flang/test/Lower/OpenACC/acc-module-definition.f90
+++ b/flang/test/Lower/OpenACC/acc-module-definition.f90
@@ -1,0 +1,17 @@
+! RUN: rm -fr %t && mkdir -p %t && cd %t
+! RUN: bbc -fopenacc -emit-fir %s
+! RUN: cat mod1.mod | FileCheck %s
+
+!CHECK-LABEL: module mod1
+module mod1
+    contains
+      !CHECK subroutine callee(aa)
+      subroutine callee(aa)
+      !CHECK: !$acc routine seq
+      !$acc routine seq
+        integer :: aa
+        aa = 1
+      end subroutine
+      !CHECK: end
+      !CHECK: end
+end module

--- a/flang/test/Lower/OpenACC/acc-routine-named.f90
+++ b/flang/test/Lower/OpenACC/acc-routine-named.f90
@@ -4,8 +4,8 @@
 
 module acc_routines
 
-! CHECK: acc.routine @acc_routine_1 func(@_QMacc_routinesPacc2)
-! CHECK: acc.routine @acc_routine_0 func(@_QMacc_routinesPacc1) seq
+! CHECK: acc.routine @[[r0:.*]] func(@_QMacc_routinesPacc2)
+! CHECK: acc.routine @[[r1:.*]] func(@_QMacc_routinesPacc1) seq
 
 !$acc routine(acc1) seq
 
@@ -14,12 +14,14 @@ contains
   subroutine acc1()
   end subroutine
 
-! CHECK-LABEL: func.func @_QMacc_routinesPacc1() attributes {acc.routine_info = #acc.routine_info<[@acc_routine_0]>}
+! CHECK-LABEL: func.func @_QMacc_routinesPacc1() 
+! CHECK-SAME:attributes {acc.routine_info = #acc.routine_info<[@[[r1]]]>}
 
   subroutine acc2()
     !$acc routine(acc2)
   end subroutine
 
-! CHECK-LABEL: func.func @_QMacc_routinesPacc2() attributes {acc.routine_info = #acc.routine_info<[@acc_routine_1]>}
+! CHECK-LABEL: func.func @_QMacc_routinesPacc2()
+! CHECK-SAME:attributes {acc.routine_info = #acc.routine_info<[@[[r0]]]>}
 
 end module

--- a/flang/test/Lower/OpenACC/acc-routine-use-module.f90
+++ b/flang/test/Lower/OpenACC/acc-routine-use-module.f90
@@ -1,0 +1,23 @@
+! RUN: rm -fr %t && mkdir -p %t && cd %t
+! RUN: bbc -emit-fir %S/acc-module-definition.f90
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+! This test module is based off of flang/test/Lower/use_module.f90
+! The first runs ensures the module file is generated.
+
+module use_mod1
+  use mod1
+  contains
+    !CHECK: func.func @_QMuse_mod1Pcaller
+    !CHECK-SAME {
+    subroutine caller(aa)
+      integer :: aa
+      !$acc serial
+      !CHECK: fir.call @_QMmod1Pcallee
+      call callee(aa)
+      !$acc end serial
+    end subroutine
+    !CHECK: }
+    !CHECK: acc.routine @acc_routine_0 func(@_QMmod1Pcallee) seq
+    !CHECK: func.func private @_QMmod1Pcallee(!fir.ref<i32>) attributes {acc.routine_info = #acc.routine_info<[@acc_routine_0]>}
+end module

--- a/flang/test/Lower/OpenACC/acc-routine-use-module.f90
+++ b/flang/test/Lower/OpenACC/acc-routine-use-module.f90
@@ -1,6 +1,6 @@
 ! RUN: rm -fr %t && mkdir -p %t && cd %t
-! RUN: bbc -emit-fir %S/acc-module-definition.f90
-! RUN: bbc -emit-fir %s -o - | FileCheck %s
+! RUN: bbc -fopenacc -emit-fir %S/acc-module-definition.f90
+! RUN: bbc -fopenacc -emit-fir %s -o - | FileCheck %s
 
 ! This test module is based off of flang/test/Lower/use_module.f90
 ! The first runs ensures the module file is generated.
@@ -8,6 +8,7 @@
 module use_mod1
   use mod1
   contains
+    !CHECK: acc.routine @acc_routine_0 func(@_QMmod1Pcallee) seq
     !CHECK: func.func @_QMuse_mod1Pcaller
     !CHECK-SAME {
     subroutine caller(aa)
@@ -18,6 +19,5 @@ module use_mod1
       !$acc end serial
     end subroutine
     !CHECK: }
-    !CHECK: acc.routine @acc_routine_0 func(@_QMmod1Pcallee) seq
     !CHECK: func.func private @_QMmod1Pcallee(!fir.ref<i32>) attributes {acc.routine_info = #acc.routine_info<[@acc_routine_0]>}
 end module

--- a/flang/test/Lower/OpenACC/acc-routine.f90
+++ b/flang/test/Lower/OpenACC/acc-routine.f90
@@ -2,69 +2,77 @@
 
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
 
-! CHECK: acc.routine @acc_routine_17 func(@_QPacc_routine19) bind("_QPacc_routine17" [#acc.device_type<host>], "_QPacc_routine17" [#acc.device_type<default>], "_QPacc_routine16" [#acc.device_type<multicore>])
-! CHECK: acc.routine @acc_routine_16 func(@_QPacc_routine18) bind("_QPacc_routine17" [#acc.device_type<host>], "_QPacc_routine16" [#acc.device_type<multicore>])
-! CHECK: acc.routine @acc_routine_15 func(@_QPacc_routine17) worker ([#acc.device_type<host>]) vector ([#acc.device_type<multicore>])
-! CHECK: acc.routine @acc_routine_14 func(@_QPacc_routine16) gang([#acc.device_type<nvidia>]) seq ([#acc.device_type<host>])
-! CHECK: acc.routine @acc_routine_10 func(@_QPacc_routine11) seq
-! CHECK: acc.routine @acc_routine_9 func(@_QPacc_routine10) seq
-! CHECK: acc.routine @acc_routine_8 func(@_QPacc_routine9) bind("_QPacc_routine9a")
-! CHECK: acc.routine @acc_routine_7 func(@_QPacc_routine8) bind("routine8_")
-! CHECK: acc.routine @acc_routine_6 func(@_QPacc_routine7) gang(dim: 1 : i64)
-! CHECK: acc.routine @acc_routine_5 func(@_QPacc_routine6) nohost
-! CHECK: acc.routine @acc_routine_4 func(@_QPacc_routine5) worker
-! CHECK: acc.routine @acc_routine_3 func(@_QPacc_routine4) vector
-! CHECK: acc.routine @acc_routine_2 func(@_QPacc_routine3) gang
-! CHECK: acc.routine @acc_routine_1 func(@_QPacc_routine2) seq
-! CHECK: acc.routine @acc_routine_0 func(@_QPacc_routine1)
+! CHECK: acc.routine @[[r14:.*]] func(@_QPacc_routine19) bind("_QPacc_routine17" [#acc.device_type<host>], "_QPacc_routine17" [#acc.device_type<default>], "_QPacc_routine16" [#acc.device_type<multicore>])
+! CHECK: acc.routine @[[r13:.*]] func(@_QPacc_routine18) bind("_QPacc_routine17" [#acc.device_type<host>], "_QPacc_routine16" [#acc.device_type<multicore>])
+! CHECK: acc.routine @[[r12:.*]] func(@_QPacc_routine17) worker ([#acc.device_type<host>]) vector ([#acc.device_type<multicore>])
+! CHECK: acc.routine @[[r11:.*]] func(@_QPacc_routine16) gang([#acc.device_type<nvidia>]) seq ([#acc.device_type<host>])
+! CHECK: acc.routine @[[r10:.*]] func(@_QPacc_routine11) seq
+! CHECK: acc.routine @[[r09:.*]] func(@_QPacc_routine10) seq
+! CHECK: acc.routine @[[r08:.*]] func(@_QPacc_routine9) bind("_QPacc_routine9a")
+! CHECK: acc.routine @[[r07:.*]] func(@_QPacc_routine8) bind("routine8_")
+! CHECK: acc.routine @[[r06:.*]] func(@_QPacc_routine7) gang(dim: 1 : i64)
+! CHECK: acc.routine @[[r05:.*]] func(@_QPacc_routine6) nohost
+! CHECK: acc.routine @[[r04:.*]] func(@_QPacc_routine5) worker
+! CHECK: acc.routine @[[r03:.*]] func(@_QPacc_routine4) vector
+! CHECK: acc.routine @[[r02:.*]] func(@_QPacc_routine3) gang
+! CHECK: acc.routine @[[r01:.*]] func(@_QPacc_routine2) seq
+! CHECK: acc.routine @[[r00:.*]] func(@_QPacc_routine1)
 
 subroutine acc_routine1()
   !$acc routine
 end subroutine
 
-! CHECK-LABEL: func.func @_QPacc_routine1() attributes {acc.routine_info = #acc.routine_info<[@acc_routine_0]>}
+! CHECK-LABEL: func.func @_QPacc_routine1()
+! CHECK-SAME: attributes {acc.routine_info = #acc.routine_info<[@[[r00]]]>}
 
 subroutine acc_routine2()
   !$acc routine seq
 end subroutine
 
-! CHECK-LABEL: func.func @_QPacc_routine2() attributes {acc.routine_info = #acc.routine_info<[@acc_routine_1]>}
+! CHECK-LABEL: func.func @_QPacc_routine2()
+! CHECK-SAME: attributes {acc.routine_info = #acc.routine_info<[@[[r01]]]>}
 
 subroutine acc_routine3()
   !$acc routine gang
 end subroutine
 
-! CHECK-LABEL: func.func @_QPacc_routine3() attributes {acc.routine_info = #acc.routine_info<[@acc_routine_2]>}
+! CHECK-LABEL: func.func @_QPacc_routine3()
+! CHECK-SAME: attributes {acc.routine_info = #acc.routine_info<[@[[r02]]]>}
 
 subroutine acc_routine4()
   !$acc routine vector
 end subroutine
 
-! CHECK-LABEL: func.func @_QPacc_routine4() attributes {acc.routine_info = #acc.routine_info<[@acc_routine_3]>}
+! CHECK-LABEL: func.func @_QPacc_routine4()
+! CHECK-SAME: attributes {acc.routine_info = #acc.routine_info<[@[[r03]]]>}
 
 subroutine acc_routine5()
   !$acc routine worker
 end subroutine
 
-! CHECK-LABEL: func.func @_QPacc_routine5() attributes {acc.routine_info = #acc.routine_info<[@acc_routine_4]>}
+! CHECK-LABEL: func.func @_QPacc_routine5()
+! CHECK-SAME: attributes {acc.routine_info = #acc.routine_info<[@[[r04]]]>}
 
 subroutine acc_routine6()
   !$acc routine nohost
 end subroutine
 
-! CHECK-LABEL: func.func @_QPacc_routine6() attributes {acc.routine_info = #acc.routine_info<[@acc_routine_5]>}
+! CHECK-LABEL: func.func @_QPacc_routine6()
+! CHECK-SAME: attributes {acc.routine_info = #acc.routine_info<[@[[r05]]]>}
 
 subroutine acc_routine7()
   !$acc routine gang(dim:1)
 end subroutine
 
-! CHECK-LABEL: func.func @_QPacc_routine7() attributes {acc.routine_info = #acc.routine_info<[@acc_routine_6]>}
+! CHECK-LABEL: func.func @_QPacc_routine7()
+! CHECK-SAME: attributes {acc.routine_info = #acc.routine_info<[@[[r06]]]>}
 
 subroutine acc_routine8()
   !$acc routine bind("routine8_")
 end subroutine
 
-! CHECK-LABEL: func.func @_QPacc_routine8() attributes {acc.routine_info = #acc.routine_info<[@acc_routine_7]>}
+! CHECK-LABEL: func.func @_QPacc_routine8()
+! CHECK-SAME: attributes {acc.routine_info = #acc.routine_info<[@[[r07]]]>}
 
 subroutine acc_routine9a()
 end subroutine
@@ -73,20 +81,23 @@ subroutine acc_routine9()
   !$acc routine bind(acc_routine9a)
 end subroutine
 
-! CHECK-LABEL: func.func @_QPacc_routine9() attributes {acc.routine_info = #acc.routine_info<[@acc_routine_8]>}
+! CHECK-LABEL: func.func @_QPacc_routine9()
+! CHECK-SAME: attributes {acc.routine_info = #acc.routine_info<[@[[r08]]]>}
 
 function acc_routine10()
   !$acc routine(acc_routine10) seq
 end function
 
-! CHECK-LABEL: func.func @_QPacc_routine10() -> f32 attributes {acc.routine_info = #acc.routine_info<[@acc_routine_9]>}
+! CHECK-LABEL: func.func @_QPacc_routine10() -> f32
+! CHECK-SAME: attributes {acc.routine_info = #acc.routine_info<[@[[r09]]]>}
 
 subroutine acc_routine11(a)
   real :: a
   !$acc routine(acc_routine11) seq
 end subroutine
 
-! CHECK-LABEL: func.func @_QPacc_routine11(%arg0: !fir.ref<f32> {fir.bindc_name = "a"}) attributes {acc.routine_info = #acc.routine_info<[@acc_routine_10]>}
+! CHECK-LABEL: func.func @_QPacc_routine11(%arg0: !fir.ref<f32> {fir.bindc_name = "a"})
+! CHECK-SAME: attributes {acc.routine_info = #acc.routine_info<[@[[r10]]]>}
 
 subroutine acc_routine12()
 


### PR DESCRIPTION
OpenACC routines annotations in separate compilation units currently get ignored, which leads to errors in compilation. There are two reason for currently ignoring open acc routine information and this PR is addressing both.
- The module file reader doesn't read back in openacc directives from module files.
  - Simple fix in `flang/lib/Semantics/mod-file.cpp`
- The lowering to HLFIR doesn't generate routine directives for symbols imported from other modules that are openacc routines.
  - This is the majority of this diff, and is address by the changes that start in `flang/lib/Lower/CallInterface.cpp`. 