### PR TITLE
[llvm] annotate interfaces in llvm/Support for DLL export

### DIFF
--- a/llvm/include/llvm/Support/AArch64AttributeParser.h
+++ b/llvm/include/llvm/Support/AArch64AttributeParser.h
@@ -9,13 +9,14 @@
 #ifndef LLVM_SUPPORT_AARCH64ATTRIBUTEPARSER_H
 #define LLVM_SUPPORT_AARCH64ATTRIBUTEPARSER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ELFAttrParserExtended.h"
 #include "llvm/Support/ELFAttributes.h"
 
 namespace llvm {
 
 class AArch64AttributeParser : public ELFExtendedAttrParser {
-  static std::vector<SubsectionAndTagToTagName> &returnTagsNamesMap();
+  LLVM_ABI static std::vector<SubsectionAndTagToTagName> &returnTagsNamesMap();
 
 public:
   AArch64AttributeParser(ScopedPrinter *Sw)

--- a/llvm/include/llvm/Support/AMDGPUMetadata.h
+++ b/llvm/include/llvm/Support/AMDGPUMetadata.h
@@ -15,8 +15,8 @@
 #ifndef LLVM_SUPPORT_AMDGPUMETADATA_H
 #define LLVM_SUPPORT_AMDGPUMETADATA_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <string>
 #include <system_error>

--- a/llvm/include/llvm/Support/AMDGPUMetadata.h
+++ b/llvm/include/llvm/Support/AMDGPUMetadata.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_SUPPORT_AMDGPUMETADATA_H
 #define LLVM_SUPPORT_AMDGPUMETADATA_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include <cstdint>
 #include <string>
@@ -447,10 +448,10 @@ struct Metadata final {
 };
 
 /// Converts \p String to \p HSAMetadata.
-std::error_code fromString(StringRef String, Metadata &HSAMetadata);
+LLVM_ABI std::error_code fromString(StringRef String, Metadata &HSAMetadata);
 
 /// Converts \p HSAMetadata to \p String.
-std::error_code toString(Metadata HSAMetadata, std::string &String);
+LLVM_ABI std::error_code toString(Metadata HSAMetadata, std::string &String);
 
 //===----------------------------------------------------------------------===//
 // HSA metadata for v3 code object.

--- a/llvm/include/llvm/Support/ARMAttributeParser.h
+++ b/llvm/include/llvm/Support/ARMAttributeParser.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_ARMATTRIBUTEPARSER_H
 #define LLVM_SUPPORT_ARMATTRIBUTEPARSER_H
 
+#include "llvm/Support/Compiler.h"
 #include "ARMBuildAttributes.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/ELFAttrParserCompact.h"
@@ -18,7 +19,7 @@ namespace llvm {
 
 class ScopedPrinter;
 
-class ARMAttributeParser : public ELFCompactAttrParser {
+class LLVM_ABI ARMAttributeParser : public ELFCompactAttrParser {
   struct DisplayHandler {
     ARMBuildAttrs::AttrType attribute;
     Error (ARMAttributeParser::*routine)(ARMBuildAttrs::AttrType);

--- a/llvm/include/llvm/Support/ARMAttributeParser.h
+++ b/llvm/include/llvm/Support/ARMAttributeParser.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_SUPPORT_ARMATTRIBUTEPARSER_H
 #define LLVM_SUPPORT_ARMATTRIBUTEPARSER_H
 
-#include "llvm/Support/Compiler.h"
 #include "ARMBuildAttributes.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ELFAttrParserCompact.h"
 #include "llvm/Support/Error.h"
 

--- a/llvm/include/llvm/Support/ARMBuildAttributes.h
+++ b/llvm/include/llvm/Support/ARMBuildAttributes.h
@@ -18,12 +18,13 @@
 #ifndef LLVM_SUPPORT_ARMBUILDATTRIBUTES_H
 #define LLVM_SUPPORT_ARMBUILDATTRIBUTES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ELFAttributes.h"
 
 namespace llvm {
 namespace ARMBuildAttrs {
 
-const TagNameMap &getARMAttributeTags();
+LLVM_ABI const TagNameMap &getARMAttributeTags();
 
 enum SpecialAttr {
   // This is for the .cpu asm attr. It translates into one or more

--- a/llvm/include/llvm/Support/ARMWinEH.h
+++ b/llvm/include/llvm/Support/ARMWinEH.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_SUPPORT_ARMWINEH_H
 #define LLVM_SUPPORT_ARMWINEH_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 
 namespace llvm {
@@ -206,8 +206,8 @@ inline uint16_t StackAdjustment(const RuntimeFunction &RF) {
 
 /// SavedRegisterMask - Utility function to calculate the set of saved general
 /// purpose (r0-r15) and VFP (d0-d31) registers.
-LLVM_ABI std::pair<uint16_t, uint32_t> SavedRegisterMask(const RuntimeFunction &RF,
-                                                bool Prologue = true);
+LLVM_ABI std::pair<uint16_t, uint32_t>
+SavedRegisterMask(const RuntimeFunction &RF, bool Prologue = true);
 
 /// RuntimeFunctionARM64 - An entry in the table of procedure data (.pdata)
 ///

--- a/llvm/include/llvm/Support/ARMWinEH.h
+++ b/llvm/include/llvm/Support/ARMWinEH.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_ARMWINEH_H
 #define LLVM_SUPPORT_ARMWINEH_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Endian.h"
 
@@ -205,7 +206,7 @@ inline uint16_t StackAdjustment(const RuntimeFunction &RF) {
 
 /// SavedRegisterMask - Utility function to calculate the set of saved general
 /// purpose (r0-r15) and VFP (d0-d31) registers.
-std::pair<uint16_t, uint32_t> SavedRegisterMask(const RuntimeFunction &RF,
+LLVM_ABI std::pair<uint16_t, uint32_t> SavedRegisterMask(const RuntimeFunction &RF,
                                                 bool Prologue = true);
 
 /// RuntimeFunctionARM64 - An entry in the table of procedure data (.pdata)

--- a/llvm/include/llvm/Support/Allocator.h
+++ b/llvm/include/llvm/Support/Allocator.h
@@ -36,7 +36,7 @@ namespace detail {
 
 // We call out to an external function to actually print the message as the
 // printing code uses Allocator.h in its implementation.
-void printBumpPtrAllocatorStats(unsigned NumSlabs, size_t BytesAllocated,
+LLVM_ABI void printBumpPtrAllocatorStats(unsigned NumSlabs, size_t BytesAllocated,
                                 size_t TotalMemory);
 
 } // end namespace detail

--- a/llvm/include/llvm/Support/Allocator.h
+++ b/llvm/include/llvm/Support/Allocator.h
@@ -36,8 +36,9 @@ namespace detail {
 
 // We call out to an external function to actually print the message as the
 // printing code uses Allocator.h in its implementation.
-LLVM_ABI void printBumpPtrAllocatorStats(unsigned NumSlabs, size_t BytesAllocated,
-                                size_t TotalMemory);
+LLVM_ABI void printBumpPtrAllocatorStats(unsigned NumSlabs,
+                                         size_t BytesAllocated,
+                                         size_t TotalMemory);
 
 } // end namespace detail
 

--- a/llvm/include/llvm/Support/BalancedPartitioning.h
+++ b/llvm/include/llvm/Support/BalancedPartitioning.h
@@ -39,6 +39,7 @@
 #ifndef LLVM_SUPPORT_BALANCED_PARTITIONING_H
 #define LLVM_SUPPORT_BALANCED_PARTITIONING_H
 
+#include "llvm/Support/Compiler.h"
 #include "raw_ostream.h"
 #include "llvm/ADT/ArrayRef.h"
 
@@ -67,7 +68,7 @@ public:
   /// The ID of this node
   IDT Id;
 
-  void dump(raw_ostream &OS) const;
+  LLVM_ABI void dump(raw_ostream &OS) const;
 
 protected:
   /// The list of utility nodes associated with this node
@@ -99,10 +100,10 @@ struct BalancedPartitioningConfig {
 
 class BalancedPartitioning {
 public:
-  BalancedPartitioning(const BalancedPartitioningConfig &Config);
+  LLVM_ABI BalancedPartitioning(const BalancedPartitioningConfig &Config);
 
   /// Run recursive graph partitioning that optimizes a given objective.
-  void run(std::vector<BPFunctionNode> &Nodes) const;
+  LLVM_ABI void run(std::vector<BPFunctionNode> &Nodes) const;
 
 private:
   struct UtilitySignature;
@@ -127,7 +128,7 @@ private:
     /// Blocking wait for all threads to complete. Unlike ThreadPool, it is
     /// acceptable for other threads to add more tasks while blocking on this
     /// call.
-    void wait();
+    LLVM_ABI void wait();
     BPThreadPool(ThreadPoolInterface &TheThreadPool)
         : TheThreadPool(TheThreadPool) {}
   };
@@ -192,7 +193,7 @@ private:
 
 protected:
   /// Compute the move gain for uniform log-gap cost
-  static float moveGain(const BPFunctionNode &N, bool FromLeftToRight,
+  LLVM_ABI static float moveGain(const BPFunctionNode &N, bool FromLeftToRight,
                         const SignaturesT &Signatures);
   friend class BalancedPartitioningTest_MoveGain_Test;
 };

--- a/llvm/include/llvm/Support/BalancedPartitioning.h
+++ b/llvm/include/llvm/Support/BalancedPartitioning.h
@@ -39,9 +39,9 @@
 #ifndef LLVM_SUPPORT_BALANCED_PARTITIONING_H
 #define LLVM_SUPPORT_BALANCED_PARTITIONING_H
 
-#include "llvm/Support/Compiler.h"
 #include "raw_ostream.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Compiler.h"
 
 #include <atomic>
 #include <condition_variable>
@@ -194,7 +194,7 @@ private:
 protected:
   /// Compute the move gain for uniform log-gap cost
   LLVM_ABI static float moveGain(const BPFunctionNode &N, bool FromLeftToRight,
-                        const SignaturesT &Signatures);
+                                 const SignaturesT &Signatures);
   friend class BalancedPartitioningTest_MoveGain_Test;
 };
 

--- a/llvm/include/llvm/Support/Base64.h
+++ b/llvm/include/llvm/Support/Base64.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_BASE64_H
 #define LLVM_SUPPORT_BASE64_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
 #include <string>
@@ -54,7 +55,7 @@ template <class InputBytes> std::string encodeBase64(InputBytes const &Bytes) {
   return Buffer;
 }
 
-llvm::Error decodeBase64(llvm::StringRef Input, std::vector<char> &Output);
+LLVM_ABI llvm::Error decodeBase64(llvm::StringRef Input, std::vector<char> &Output);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/Support/Base64.h
+++ b/llvm/include/llvm/Support/Base64.h
@@ -55,7 +55,8 @@ template <class InputBytes> std::string encodeBase64(InputBytes const &Bytes) {
   return Buffer;
 }
 
-LLVM_ABI llvm::Error decodeBase64(llvm::StringRef Input, std::vector<char> &Output);
+LLVM_ABI llvm::Error decodeBase64(llvm::StringRef Input,
+                                  std::vector<char> &Output);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/Support/BinaryStreamError.h
+++ b/llvm/include/llvm/Support/BinaryStreamError.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_BINARYSTREAMERROR_H
 #define LLVM_SUPPORT_BINARYSTREAMERROR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 
@@ -24,7 +25,7 @@ enum class stream_error_code {
 };
 
 /// Base class for errors originating when parsing raw PDB files
-class BinaryStreamError : public ErrorInfo<BinaryStreamError> {
+class LLVM_ABI BinaryStreamError : public ErrorInfo<BinaryStreamError> {
 public:
   static char ID;
   explicit BinaryStreamError(stream_error_code C);

--- a/llvm/include/llvm/Support/BinaryStreamError.h
+++ b/llvm/include/llvm/Support/BinaryStreamError.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_SUPPORT_BINARYSTREAMERROR_H
 #define LLVM_SUPPORT_BINARYSTREAMERROR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 #include <string>

--- a/llvm/include/llvm/Support/BinaryStreamReader.h
+++ b/llvm/include/llvm/Support/BinaryStreamReader.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_SUPPORT_BINARYSTREAMREADER_H
 #define LLVM_SUPPORT_BINARYSTREAMREADER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Alignment.h"
 #include "llvm/Support/BinaryStreamArray.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
@@ -32,7 +32,8 @@ public:
   BinaryStreamReader() = default;
   LLVM_ABI explicit BinaryStreamReader(BinaryStreamRef Ref);
   LLVM_ABI explicit BinaryStreamReader(BinaryStream &Stream);
-  LLVM_ABI explicit BinaryStreamReader(ArrayRef<uint8_t> Data, llvm::endianness Endian);
+  LLVM_ABI explicit BinaryStreamReader(ArrayRef<uint8_t> Data,
+                                       llvm::endianness Endian);
   LLVM_ABI explicit BinaryStreamReader(StringRef Data, llvm::endianness Endian);
 
   BinaryStreamReader(const BinaryStreamReader &Other) = default;

--- a/llvm/include/llvm/Support/BinaryStreamReader.h
+++ b/llvm/include/llvm/Support/BinaryStreamReader.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_BINARYSTREAMREADER_H
 #define LLVM_SUPPORT_BINARYSTREAMREADER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Alignment.h"
@@ -29,10 +30,10 @@ namespace llvm {
 class BinaryStreamReader {
 public:
   BinaryStreamReader() = default;
-  explicit BinaryStreamReader(BinaryStreamRef Ref);
-  explicit BinaryStreamReader(BinaryStream &Stream);
-  explicit BinaryStreamReader(ArrayRef<uint8_t> Data, llvm::endianness Endian);
-  explicit BinaryStreamReader(StringRef Data, llvm::endianness Endian);
+  LLVM_ABI explicit BinaryStreamReader(BinaryStreamRef Ref);
+  LLVM_ABI explicit BinaryStreamReader(BinaryStream &Stream);
+  LLVM_ABI explicit BinaryStreamReader(ArrayRef<uint8_t> Data, llvm::endianness Endian);
+  LLVM_ABI explicit BinaryStreamReader(StringRef Data, llvm::endianness Endian);
 
   BinaryStreamReader(const BinaryStreamReader &Other) = default;
 
@@ -46,7 +47,7 @@ public:
   ///
   /// \returns a success error code if the data was successfully read, otherwise
   /// returns an appropriate error code.
-  Error readLongestContiguousChunk(ArrayRef<uint8_t> &Buffer);
+  LLVM_ABI Error readLongestContiguousChunk(ArrayRef<uint8_t> &Buffer);
 
   /// Read \p Size bytes from the underlying stream at the current offset and
   /// and set \p Buffer to the resulting data slice.  Whether a copy occurs
@@ -55,7 +56,7 @@ public:
   ///
   /// \returns a success error code if the data was successfully read, otherwise
   /// returns an appropriate error code.
-  Error readBytes(ArrayRef<uint8_t> &Buffer, uint32_t Size);
+  LLVM_ABI Error readBytes(ArrayRef<uint8_t> &Buffer, uint32_t Size);
 
   /// Read an integer of the specified endianness into \p Dest and update the
   /// stream's offset.  The data is always copied from the stream's underlying
@@ -91,13 +92,13 @@ public:
   ///
   /// \returns a success error code if the data was successfully read, otherwise
   /// returns an appropriate error code.
-  Error readULEB128(uint64_t &Dest);
+  LLVM_ABI Error readULEB128(uint64_t &Dest);
 
   /// Read a signed LEB128 encoded value.
   ///
   /// \returns a success error code if the data was successfully read, otherwise
   /// returns an appropriate error code.
-  Error readSLEB128(int64_t &Dest);
+  LLVM_ABI Error readSLEB128(int64_t &Dest);
 
   /// Read a null terminated string from \p Dest.  Whether a copy occurs depends
   /// on the implementation of the underlying stream.  Updates the stream's
@@ -105,14 +106,14 @@ public:
   ///
   /// \returns a success error code if the data was successfully read, otherwise
   /// returns an appropriate error code.
-  Error readCString(StringRef &Dest);
+  LLVM_ABI Error readCString(StringRef &Dest);
 
   /// Similar to readCString, however read a null-terminated UTF16 string
   /// instead.
   ///
   /// \returns a success error code if the data was successfully read, otherwise
   /// returns an appropriate error code.
-  Error readWideString(ArrayRef<UTF16> &Dest);
+  LLVM_ABI Error readWideString(ArrayRef<UTF16> &Dest);
 
   /// Read a \p Length byte string into \p Dest.  Whether a copy occurs depends
   /// on the implementation of the underlying stream.  Updates the stream's
@@ -120,7 +121,7 @@ public:
   ///
   /// \returns a success error code if the data was successfully read, otherwise
   /// returns an appropriate error code.
-  Error readFixedString(StringRef &Dest, uint32_t Length);
+  LLVM_ABI Error readFixedString(StringRef &Dest, uint32_t Length);
 
   /// Read the entire remainder of the underlying stream into \p Ref.  This is
   /// equivalent to calling getUnderlyingStream().slice(Offset).  Updates the
@@ -128,7 +129,7 @@ public:
   ///
   /// \returns a success error code if the data was successfully read, otherwise
   /// returns an appropriate error code.
-  Error readStreamRef(BinaryStreamRef &Ref);
+  LLVM_ABI Error readStreamRef(BinaryStreamRef &Ref);
 
   /// Read \p Length bytes from the underlying stream into \p Ref.  This is
   /// equivalent to calling getUnderlyingStream().slice(Offset, Length).
@@ -137,7 +138,7 @@ public:
   ///
   /// \returns a success error code if the data was successfully read, otherwise
   /// returns an appropriate error code.
-  Error readStreamRef(BinaryStreamRef &Ref, uint32_t Length);
+  LLVM_ABI Error readStreamRef(BinaryStreamRef &Ref, uint32_t Length);
 
   /// Read \p Length bytes from the underlying stream into \p Ref.  This is
   /// equivalent to calling getUnderlyingStream().slice(Offset, Length).
@@ -146,7 +147,7 @@ public:
   ///
   /// \returns a success error code if the data was successfully read, otherwise
   /// returns an appropriate error code.
-  Error readSubstream(BinarySubstreamRef &Ref, uint32_t Length);
+  LLVM_ABI Error readSubstream(BinarySubstreamRef &Ref, uint32_t Length);
 
   /// Get a pointer to an object of type T from the underlying stream, as if by
   /// memcpy, and store the result into \p Dest.  It is up to the caller to
@@ -251,17 +252,17 @@ public:
   ///
   /// \returns a success error code if at least \p Amount bytes remain in the
   /// stream, otherwise returns an appropriate error code.
-  Error skip(uint64_t Amount);
+  LLVM_ABI Error skip(uint64_t Amount);
 
   /// Examine the next byte of the underlying stream without advancing the
   /// stream's offset.  If the stream is empty the behavior is undefined.
   ///
   /// \returns the next byte in the stream.
-  uint8_t peek() const;
+  LLVM_ABI uint8_t peek() const;
 
-  Error padToAlignment(uint32_t Align);
+  LLVM_ABI Error padToAlignment(uint32_t Align);
 
-  std::pair<BinaryStreamReader, BinaryStreamReader>
+  LLVM_ABI std::pair<BinaryStreamReader, BinaryStreamReader>
   split(uint64_t Offset) const;
 
 private:

--- a/llvm/include/llvm/Support/BinaryStreamRef.h
+++ b/llvm/include/llvm/Support/BinaryStreamRef.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_BINARYSTREAMREF_H
 #define LLVM_SUPPORT_BINARYSTREAMREF_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/BinaryStream.h"
 #include "llvm/Support/BinaryStreamError.h"
@@ -160,11 +161,11 @@ class BinaryStreamRef
 
 public:
   BinaryStreamRef() = default;
-  BinaryStreamRef(BinaryStream &Stream);
-  BinaryStreamRef(BinaryStream &Stream, uint64_t Offset,
+  LLVM_ABI BinaryStreamRef(BinaryStream &Stream);
+  LLVM_ABI BinaryStreamRef(BinaryStream &Stream, uint64_t Offset,
                   std::optional<uint64_t> Length);
-  explicit BinaryStreamRef(ArrayRef<uint8_t> Data, llvm::endianness Endian);
-  explicit BinaryStreamRef(StringRef Data, llvm::endianness Endian);
+  LLVM_ABI explicit BinaryStreamRef(ArrayRef<uint8_t> Data, llvm::endianness Endian);
+  LLVM_ABI explicit BinaryStreamRef(StringRef Data, llvm::endianness Endian);
 
   BinaryStreamRef(const BinaryStreamRef &Other) = default;
   BinaryStreamRef &operator=(const BinaryStreamRef &Other) = default;
@@ -181,7 +182,7 @@ public:
   /// \returns a success error code if the entire range of data is within the
   /// bounds of this BinaryStreamRef's view and the implementation could read
   /// the data, and an appropriate error code otherwise.
-  Error readBytes(uint64_t Offset, uint64_t Size,
+  LLVM_ABI Error readBytes(uint64_t Offset, uint64_t Size,
                   ArrayRef<uint8_t> &Buffer) const;
 
   /// Given an Offset into this BinaryStreamRef, return a reference to the
@@ -189,7 +190,7 @@ public:
   ///
   /// \returns a success error code if implementation could read the data,
   /// and an appropriate error code otherwise.
-  Error readLongestContiguousChunk(uint64_t Offset,
+  LLVM_ABI Error readLongestContiguousChunk(uint64_t Offset,
                                    ArrayRef<uint8_t> &Buffer) const;
 };
 
@@ -233,10 +234,10 @@ class WritableBinaryStreamRef
 
 public:
   WritableBinaryStreamRef() = default;
-  WritableBinaryStreamRef(WritableBinaryStream &Stream);
-  WritableBinaryStreamRef(WritableBinaryStream &Stream, uint64_t Offset,
+  LLVM_ABI WritableBinaryStreamRef(WritableBinaryStream &Stream);
+  LLVM_ABI WritableBinaryStreamRef(WritableBinaryStream &Stream, uint64_t Offset,
                           std::optional<uint64_t> Length);
-  explicit WritableBinaryStreamRef(MutableArrayRef<uint8_t> Data,
+  LLVM_ABI explicit WritableBinaryStreamRef(MutableArrayRef<uint8_t> Data,
                                    llvm::endianness Endian);
   WritableBinaryStreamRef(const WritableBinaryStreamRef &Other) = default;
   WritableBinaryStreamRef &
@@ -255,13 +256,13 @@ public:
   /// \returns a success error code if the data could fit within the underlying
   /// stream at the specified location and the implementation could write the
   /// data, and an appropriate error code otherwise.
-  Error writeBytes(uint64_t Offset, ArrayRef<uint8_t> Data) const;
+  LLVM_ABI Error writeBytes(uint64_t Offset, ArrayRef<uint8_t> Data) const;
 
   /// Conver this WritableBinaryStreamRef to a read-only BinaryStreamRef.
-  operator BinaryStreamRef() const;
+  LLVM_ABI operator BinaryStreamRef() const;
 
   /// For buffered streams, commits changes to the backing store.
-  Error commit();
+  LLVM_ABI Error commit();
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Support/BinaryStreamRef.h
+++ b/llvm/include/llvm/Support/BinaryStreamRef.h
@@ -9,10 +9,10 @@
 #ifndef LLVM_SUPPORT_BINARYSTREAMREF_H
 #define LLVM_SUPPORT_BINARYSTREAMREF_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/BinaryStream.h"
 #include "llvm/Support/BinaryStreamError.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
 #include <memory>
@@ -163,8 +163,9 @@ public:
   BinaryStreamRef() = default;
   LLVM_ABI BinaryStreamRef(BinaryStream &Stream);
   LLVM_ABI BinaryStreamRef(BinaryStream &Stream, uint64_t Offset,
-                  std::optional<uint64_t> Length);
-  LLVM_ABI explicit BinaryStreamRef(ArrayRef<uint8_t> Data, llvm::endianness Endian);
+                           std::optional<uint64_t> Length);
+  LLVM_ABI explicit BinaryStreamRef(ArrayRef<uint8_t> Data,
+                                    llvm::endianness Endian);
   LLVM_ABI explicit BinaryStreamRef(StringRef Data, llvm::endianness Endian);
 
   BinaryStreamRef(const BinaryStreamRef &Other) = default;
@@ -183,7 +184,7 @@ public:
   /// bounds of this BinaryStreamRef's view and the implementation could read
   /// the data, and an appropriate error code otherwise.
   LLVM_ABI Error readBytes(uint64_t Offset, uint64_t Size,
-                  ArrayRef<uint8_t> &Buffer) const;
+                           ArrayRef<uint8_t> &Buffer) const;
 
   /// Given an Offset into this BinaryStreamRef, return a reference to the
   /// largest buffer the stream could support without necessitating a copy.
@@ -191,7 +192,7 @@ public:
   /// \returns a success error code if implementation could read the data,
   /// and an appropriate error code otherwise.
   LLVM_ABI Error readLongestContiguousChunk(uint64_t Offset,
-                                   ArrayRef<uint8_t> &Buffer) const;
+                                            ArrayRef<uint8_t> &Buffer) const;
 };
 
 struct BinarySubstreamRef {
@@ -235,10 +236,11 @@ class WritableBinaryStreamRef
 public:
   WritableBinaryStreamRef() = default;
   LLVM_ABI WritableBinaryStreamRef(WritableBinaryStream &Stream);
-  LLVM_ABI WritableBinaryStreamRef(WritableBinaryStream &Stream, uint64_t Offset,
-                          std::optional<uint64_t> Length);
+  LLVM_ABI WritableBinaryStreamRef(WritableBinaryStream &Stream,
+                                   uint64_t Offset,
+                                   std::optional<uint64_t> Length);
   LLVM_ABI explicit WritableBinaryStreamRef(MutableArrayRef<uint8_t> Data,
-                                   llvm::endianness Endian);
+                                            llvm::endianness Endian);
   WritableBinaryStreamRef(const WritableBinaryStreamRef &Other) = default;
   WritableBinaryStreamRef &
   operator=(const WritableBinaryStreamRef &Other) = default;

--- a/llvm/include/llvm/Support/BinaryStreamWriter.h
+++ b/llvm/include/llvm/Support/BinaryStreamWriter.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_BINARYSTREAMWRITER_H
 #define LLVM_SUPPORT_BINARYSTREAMWRITER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/BinaryStreamArray.h"
@@ -30,9 +31,9 @@ namespace llvm {
 class BinaryStreamWriter {
 public:
   BinaryStreamWriter() = default;
-  explicit BinaryStreamWriter(WritableBinaryStreamRef Ref);
-  explicit BinaryStreamWriter(WritableBinaryStream &Stream);
-  explicit BinaryStreamWriter(MutableArrayRef<uint8_t> Data,
+  LLVM_ABI explicit BinaryStreamWriter(WritableBinaryStreamRef Ref);
+  LLVM_ABI explicit BinaryStreamWriter(WritableBinaryStream &Stream);
+  LLVM_ABI explicit BinaryStreamWriter(MutableArrayRef<uint8_t> Data,
                               llvm::endianness Endian);
 
   BinaryStreamWriter(const BinaryStreamWriter &Other) = default;
@@ -47,7 +48,7 @@ public:
   ///
   /// \returns a success error code if the data was successfully written,
   /// otherwise returns an appropriate error code.
-  Error writeBytes(ArrayRef<uint8_t> Buffer);
+  LLVM_ABI Error writeBytes(ArrayRef<uint8_t> Buffer);
 
   /// Write the integer \p Value to the underlying stream in the
   /// specified endianness.  On success, updates the offset so that
@@ -77,14 +78,14 @@ public:
   ///
   /// \returns a success error code if the data was successfully written,
   /// otherwise returns an appropriate error code.
-  Error writeULEB128(uint64_t Value);
+  LLVM_ABI Error writeULEB128(uint64_t Value);
 
   /// Write the unsigned integer Value to the underlying stream using ULEB128
   /// encoding.
   ///
   /// \returns a success error code if the data was successfully written,
   /// otherwise returns an appropriate error code.
-  Error writeSLEB128(int64_t Value);
+  LLVM_ABI Error writeSLEB128(int64_t Value);
 
   /// Write the string \p Str to the underlying stream followed by a null
   /// terminator.  On success, updates the offset so that subsequent writes
@@ -93,7 +94,7 @@ public:
   ///
   /// \returns a success error code if the data was successfully written,
   /// otherwise returns an appropriate error code.
-  Error writeCString(StringRef Str);
+  LLVM_ABI Error writeCString(StringRef Str);
 
   /// Write the string \p Str to the underlying stream without a null
   /// terminator.  On success, updates the offset so that subsequent writes
@@ -101,7 +102,7 @@ public:
   ///
   /// \returns a success error code if the data was successfully written,
   /// otherwise returns an appropriate error code.
-  Error writeFixedString(StringRef Str);
+  LLVM_ABI Error writeFixedString(StringRef Str);
 
   /// Efficiently reads all data from \p Ref, and writes it to this stream.
   /// This operation will not invoke any copies of the source data, regardless
@@ -109,7 +110,7 @@ public:
   ///
   /// \returns a success error code if the data was successfully written,
   /// otherwise returns an appropriate error code.
-  Error writeStreamRef(BinaryStreamRef Ref);
+  LLVM_ABI Error writeStreamRef(BinaryStreamRef Ref);
 
   /// Efficiently reads \p Size bytes from \p Ref, and writes it to this stream.
   /// This operation will not invoke any copies of the source data, regardless
@@ -117,7 +118,7 @@ public:
   ///
   /// \returns a success error code if the data was successfully written,
   /// otherwise returns an appropriate error code.
-  Error writeStreamRef(BinaryStreamRef Ref, uint64_t Size);
+  LLVM_ABI Error writeStreamRef(BinaryStreamRef Ref, uint64_t Size);
 
   /// Writes the object \p Obj to the underlying stream, as if by using memcpy.
   /// It is up to the caller to ensure that type of \p Obj can be safely copied
@@ -171,13 +172,13 @@ public:
   }
 
   /// Splits the Writer into two Writers at a given offset.
-  std::pair<BinaryStreamWriter, BinaryStreamWriter> split(uint64_t Off) const;
+  LLVM_ABI std::pair<BinaryStreamWriter, BinaryStreamWriter> split(uint64_t Off) const;
 
   void setOffset(uint64_t Off) { Offset = Off; }
   uint64_t getOffset() const { return Offset; }
   uint64_t getLength() const { return Stream.getLength(); }
   uint64_t bytesRemaining() const { return getLength() - getOffset(); }
-  Error padToAlignment(uint32_t Align);
+  LLVM_ABI Error padToAlignment(uint32_t Align);
 
 protected:
   WritableBinaryStreamRef Stream;

--- a/llvm/include/llvm/Support/BinaryStreamWriter.h
+++ b/llvm/include/llvm/Support/BinaryStreamWriter.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_SUPPORT_BINARYSTREAMWRITER_H
 #define LLVM_SUPPORT_BINARYSTREAMWRITER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/BinaryStreamArray.h"
 #include "llvm/Support/BinaryStreamError.h"
 #include "llvm/Support/BinaryStreamRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
@@ -34,7 +34,7 @@ public:
   LLVM_ABI explicit BinaryStreamWriter(WritableBinaryStreamRef Ref);
   LLVM_ABI explicit BinaryStreamWriter(WritableBinaryStream &Stream);
   LLVM_ABI explicit BinaryStreamWriter(MutableArrayRef<uint8_t> Data,
-                              llvm::endianness Endian);
+                                       llvm::endianness Endian);
 
   BinaryStreamWriter(const BinaryStreamWriter &Other) = default;
 
@@ -172,7 +172,8 @@ public:
   }
 
   /// Splits the Writer into two Writers at a given offset.
-  LLVM_ABI std::pair<BinaryStreamWriter, BinaryStreamWriter> split(uint64_t Off) const;
+  LLVM_ABI std::pair<BinaryStreamWriter, BinaryStreamWriter>
+  split(uint64_t Off) const;
 
   void setOffset(uint64_t Off) { Offset = Off; }
   uint64_t getOffset() const { return Offset; }

--- a/llvm/include/llvm/Support/BlockFrequency.h
+++ b/llvm/include/llvm/Support/BlockFrequency.h
@@ -122,7 +122,7 @@ public:
 };
 
 LLVM_ABI void printRelativeBlockFreq(raw_ostream &OS, BlockFrequency EntryFreq,
-                            BlockFrequency Freq);
+                                     BlockFrequency Freq);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/Support/BlockFrequency.h
+++ b/llvm/include/llvm/Support/BlockFrequency.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_BLOCKFREQUENCY_H
 #define LLVM_SUPPORT_BLOCKFREQUENCY_H
 
+#include "llvm/Support/Compiler.h"
 #include <cassert>
 #include <cstdint>
 #include <optional>
@@ -39,13 +40,13 @@ public:
 
   /// Multiplies with a branch probability. The computation will never
   /// overflow.
-  BlockFrequency &operator*=(BranchProbability Prob);
-  BlockFrequency operator*(BranchProbability Prob) const;
+  LLVM_ABI BlockFrequency &operator*=(BranchProbability Prob);
+  LLVM_ABI BlockFrequency operator*(BranchProbability Prob) const;
 
   /// Divide by a non-zero branch probability using saturating
   /// arithmetic.
-  BlockFrequency &operator/=(BranchProbability Prob);
-  BlockFrequency operator/(BranchProbability Prob) const;
+  LLVM_ABI BlockFrequency &operator/=(BranchProbability Prob);
+  LLVM_ABI BlockFrequency operator/(BranchProbability Prob) const;
 
   /// Adds another block frequency using saturating arithmetic.
   BlockFrequency &operator+=(BlockFrequency Freq) {
@@ -80,7 +81,7 @@ public:
   }
 
   /// Multiplies frequency with `Factor`. Returns `nullopt` in case of overflow.
-  std::optional<BlockFrequency> mul(uint64_t Factor) const;
+  LLVM_ABI std::optional<BlockFrequency> mul(uint64_t Factor) const;
 
   /// Shift block frequency to the right by count digits saturating to 1.
   BlockFrequency &operator>>=(const unsigned count) {
@@ -120,7 +121,7 @@ public:
   }
 };
 
-void printRelativeBlockFreq(raw_ostream &OS, BlockFrequency EntryFreq,
+LLVM_ABI void printRelativeBlockFreq(raw_ostream &OS, BlockFrequency EntryFreq,
                             BlockFrequency Freq);
 
 } // namespace llvm

--- a/llvm/include/llvm/Support/BranchProbability.h
+++ b/llvm/include/llvm/Support/BranchProbability.h
@@ -56,7 +56,7 @@ public:
   static BranchProbability getRaw(uint32_t N) { return BranchProbability(N); }
   // Create a BranchProbability object from 64-bit integers.
   LLVM_ABI static BranchProbability getBranchProbability(uint64_t Numerator,
-                                                uint64_t Denominator);
+                                                         uint64_t Denominator);
 
   // Normalize given probabilties so that the sum of them becomes approximate
   // one.

--- a/llvm/include/llvm/Support/BranchProbability.h
+++ b/llvm/include/llvm/Support/BranchProbability.h
@@ -14,6 +14,7 @@
 #define LLVM_SUPPORT_BRANCHPROBABILITY_H
 
 #include "llvm/ADT/ADL.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 #include <algorithm>
 #include <cassert>
@@ -42,7 +43,7 @@ class BranchProbability {
 
 public:
   BranchProbability() : N(UnknownN) {}
-  BranchProbability(uint32_t Numerator, uint32_t Denominator);
+  LLVM_ABI BranchProbability(uint32_t Numerator, uint32_t Denominator);
 
   bool isZero() const { return N == 0; }
   bool isUnknown() const { return N == UnknownN; }
@@ -54,7 +55,7 @@ public:
   // as denominator.
   static BranchProbability getRaw(uint32_t N) { return BranchProbability(N); }
   // Create a BranchProbability object from 64-bit integers.
-  static BranchProbability getBranchProbability(uint64_t Numerator,
+  LLVM_ABI static BranchProbability getBranchProbability(uint64_t Numerator,
                                                 uint64_t Denominator);
 
   // Normalize given probabilties so that the sum of them becomes approximate
@@ -74,9 +75,9 @@ public:
   // Return (1 - Probability).
   BranchProbability getCompl() const { return BranchProbability(D - N); }
 
-  raw_ostream &print(raw_ostream &OS) const;
+  LLVM_ABI raw_ostream &print(raw_ostream &OS) const;
 
-  void dump() const;
+  LLVM_ABI void dump() const;
 
   /// Scale a large integer.
   ///
@@ -84,7 +85,7 @@ public:
   /// result.
   ///
   /// \return \c Num times \c this.
-  uint64_t scale(uint64_t Num) const;
+  LLVM_ABI uint64_t scale(uint64_t Num) const;
 
   /// Scale a large integer by the inverse.
   ///
@@ -92,7 +93,7 @@ public:
   /// Returns the floor of the result.
   ///
   /// \return \c Num divided by \c this.
-  uint64_t scaleByInverse(uint64_t Num) const;
+  LLVM_ABI uint64_t scaleByInverse(uint64_t Num) const;
 
   BranchProbability &operator+=(BranchProbability RHS) {
     assert(N != UnknownN && RHS.N != UnknownN &&

--- a/llvm/include/llvm/Support/BuryPointer.h
+++ b/llvm/include/llvm/Support/BuryPointer.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_BURYPOINTER_H
 #define LLVM_SUPPORT_BURYPOINTER_H
 
+#include "llvm/Support/Compiler.h"
 #include <memory>
 
 namespace llvm {
@@ -19,7 +20,7 @@ namespace llvm {
 // the memory is not misdiagnosed as an unintentional leak by leak detection
 // tools (this is achieved by preserving pointers to the object in a globally
 // visible array).
-void BuryPointer(const void *Ptr);
+LLVM_ABI void BuryPointer(const void *Ptr);
 template <typename T> void BuryPointer(std::unique_ptr<T> Ptr) {
   BuryPointer(Ptr.release());
 }

--- a/llvm/include/llvm/Support/COM.h
+++ b/llvm/include/llvm/Support/COM.h
@@ -14,6 +14,8 @@
 #ifndef LLVM_SUPPORT_COM_H
 #define LLVM_SUPPORT_COM_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 namespace sys {
 

--- a/llvm/include/llvm/Support/COM.h
+++ b/llvm/include/llvm/Support/COM.h
@@ -21,9 +21,9 @@ enum class COMThreadingMode { SingleThreaded, MultiThreaded };
 
 class InitializeCOMRAII {
 public:
-  explicit InitializeCOMRAII(COMThreadingMode Threading,
+  LLVM_ABI explicit InitializeCOMRAII(COMThreadingMode Threading,
                              bool SpeedOverMemory = false);
-  ~InitializeCOMRAII();
+  LLVM_ABI ~InitializeCOMRAII();
 
 private:
   InitializeCOMRAII(const InitializeCOMRAII &) = delete;

--- a/llvm/include/llvm/Support/COM.h
+++ b/llvm/include/llvm/Support/COM.h
@@ -22,7 +22,7 @@ enum class COMThreadingMode { SingleThreaded, MultiThreaded };
 class InitializeCOMRAII {
 public:
   LLVM_ABI explicit InitializeCOMRAII(COMThreadingMode Threading,
-                             bool SpeedOverMemory = false);
+                                      bool SpeedOverMemory = false);
   LLVM_ABI ~InitializeCOMRAII();
 
 private:

--- a/llvm/include/llvm/Support/CRC.h
+++ b/llvm/include/llvm/Support/CRC.h
@@ -13,17 +13,18 @@
 #ifndef LLVM_SUPPORT_CRC_H
 #define LLVM_SUPPORT_CRC_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 
 namespace llvm {
 template <typename T> class ArrayRef;
 
 // Compute the CRC-32 of Data.
-uint32_t crc32(ArrayRef<uint8_t> Data);
+LLVM_ABI uint32_t crc32(ArrayRef<uint8_t> Data);
 
 // Compute the running CRC-32 of Data, with CRC being the previous value of the
 // checksum.
-uint32_t crc32(uint32_t CRC, ArrayRef<uint8_t> Data);
+LLVM_ABI uint32_t crc32(uint32_t CRC, ArrayRef<uint8_t> Data);
 
 // Class for computing the JamCRC.
 //
@@ -47,7 +48,7 @@ public:
   JamCRC(uint32_t Init = 0xFFFFFFFFU) : CRC(Init) {}
 
   // Update the CRC calculation with Data.
-  void update(ArrayRef<uint8_t> Data);
+  LLVM_ABI void update(ArrayRef<uint8_t> Data);
 
   uint32_t getCRC() const { return CRC; }
 

--- a/llvm/include/llvm/Support/CSKYAttributeParser.h
+++ b/llvm/include/llvm/Support/CSKYAttributeParser.h
@@ -9,11 +9,12 @@
 #ifndef LLVM_SUPPORT_CSKYATTRIBUTEPARSER_H
 #define LLVM_SUPPORT_CSKYATTRIBUTEPARSER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/CSKYAttributes.h"
 #include "llvm/Support/ELFAttrParserCompact.h"
 
 namespace llvm {
-class CSKYAttributeParser : public ELFCompactAttrParser {
+class LLVM_ABI CSKYAttributeParser : public ELFCompactAttrParser {
   struct DisplayHandler {
     CSKYAttrs::AttrType attribute;
     Error (CSKYAttributeParser::*routine)(unsigned);

--- a/llvm/include/llvm/Support/CSKYAttributeParser.h
+++ b/llvm/include/llvm/Support/CSKYAttributeParser.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_SUPPORT_CSKYATTRIBUTEPARSER_H
 #define LLVM_SUPPORT_CSKYATTRIBUTEPARSER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/Support/CSKYAttributes.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ELFAttrParserCompact.h"
 
 namespace llvm {

--- a/llvm/include/llvm/Support/CSKYAttributes.h
+++ b/llvm/include/llvm/Support/CSKYAttributes.h
@@ -12,12 +12,13 @@
 #ifndef LLVM_SUPPORT_CSKYATTRIBUTES_H
 #define LLVM_SUPPORT_CSKYATTRIBUTES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ELFAttributes.h"
 
 namespace llvm {
 namespace CSKYAttrs {
 
-const TagNameMap &getCSKYAttributeTags();
+LLVM_ABI const TagNameMap &getCSKYAttributeTags();
 
 enum AttrType {
   CSKY_ARCH_NAME = 4,

--- a/llvm/include/llvm/Support/CachePruning.h
+++ b/llvm/include/llvm/Support/CachePruning.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_CACHEPRUNING_H
 #define LLVM_SUPPORT_CACHEPRUNING_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include <chrono>
 #include <optional>
@@ -66,7 +67,7 @@ struct CachePruningPolicy {
 /// For example: "prune_interval=30s:prune_after=24h:cache_size=50%"
 /// which means a pruning interval of 30 seconds, expiration time of 24 hours
 /// and maximum cache size of 50% of available disk space.
-Expected<CachePruningPolicy> parseCachePruningPolicy(StringRef PolicyStr);
+LLVM_ABI Expected<CachePruningPolicy> parseCachePruningPolicy(StringRef PolicyStr);
 
 /// Peform pruning using the supplied policy, returns true if pruning
 /// occurred, i.e. if Policy.Interval was expired.
@@ -79,7 +80,7 @@ Expected<CachePruningPolicy> parseCachePruningPolicy(StringRef PolicyStr);
 /// As a safeguard against data loss if the user specifies the wrong directory
 /// as their cache directory, this function will ignore files not matching the
 /// pattern "llvmcache-*".
-bool pruneCache(StringRef Path, CachePruningPolicy Policy,
+LLVM_ABI bool pruneCache(StringRef Path, CachePruningPolicy Policy,
                 const std::vector<std::unique_ptr<MemoryBuffer>> &Files = {});
 } // namespace llvm
 

--- a/llvm/include/llvm/Support/CachePruning.h
+++ b/llvm/include/llvm/Support/CachePruning.h
@@ -67,7 +67,8 @@ struct CachePruningPolicy {
 /// For example: "prune_interval=30s:prune_after=24h:cache_size=50%"
 /// which means a pruning interval of 30 seconds, expiration time of 24 hours
 /// and maximum cache size of 50% of available disk space.
-LLVM_ABI Expected<CachePruningPolicy> parseCachePruningPolicy(StringRef PolicyStr);
+LLVM_ABI Expected<CachePruningPolicy>
+parseCachePruningPolicy(StringRef PolicyStr);
 
 /// Peform pruning using the supplied policy, returns true if pruning
 /// occurred, i.e. if Policy.Interval was expired.
@@ -80,8 +81,9 @@ LLVM_ABI Expected<CachePruningPolicy> parseCachePruningPolicy(StringRef PolicySt
 /// As a safeguard against data loss if the user specifies the wrong directory
 /// as their cache directory, this function will ignore files not matching the
 /// pattern "llvmcache-*".
-LLVM_ABI bool pruneCache(StringRef Path, CachePruningPolicy Policy,
-                const std::vector<std::unique_ptr<MemoryBuffer>> &Files = {});
+LLVM_ABI bool
+pruneCache(StringRef Path, CachePruningPolicy Policy,
+           const std::vector<std::unique_ptr<MemoryBuffer>> &Files = {});
 } // namespace llvm
 
 #endif

--- a/llvm/include/llvm/Support/Caching.h
+++ b/llvm/include/llvm/Support/Caching.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_SUPPORT_CACHING_H
 #define LLVM_SUPPORT_CACHING_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -113,7 +114,7 @@ using AddBufferFn = std::function<void(unsigned Task, const Twine &ModuleName,
 /// done lazily the first time a file is added.  The cache name appears in error
 /// messages for errors during caching. The temporary file prefix is used in the
 /// temporary file naming scheme used when writing files atomically.
-Expected<FileCache> localCache(
+LLVM_ABI Expected<FileCache> localCache(
     const Twine &CacheNameRef, const Twine &TempFilePrefixRef,
     const Twine &CacheDirectoryPathRef,
     AddBufferFn AddBuffer = [](size_t Task, const Twine &ModuleName,

--- a/llvm/include/llvm/Support/Chrono.h
+++ b/llvm/include/llvm/Support/Chrono.h
@@ -91,24 +91,36 @@ LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, sys::UtcTime<> TP);
 template <>
 struct format_provider<sys::TimePoint<>> {
   LLVM_ABI static void format(const sys::TimePoint<> &TP, llvm::raw_ostream &OS,
-                     StringRef Style);
+                              StringRef Style);
 };
 
 template <> struct format_provider<sys::UtcTime<std::chrono::seconds>> {
   LLVM_ABI static void format(const sys::UtcTime<std::chrono::seconds> &TP,
-                     llvm::raw_ostream &OS, StringRef Style);
+                              llvm::raw_ostream &OS, StringRef Style);
 };
 
 namespace detail {
 template <typename Period> struct unit { static const char value[]; };
 template <typename Period> const char unit<Period>::value[] = "";
 
-template <> struct unit<std::ratio<3600>> { LLVM_ABI static const char value[]; };
-template <> struct unit<std::ratio<60>> { LLVM_ABI static const char value[]; };
-template <> struct unit<std::ratio<1>> { LLVM_ABI static const char value[]; };
-template <> struct unit<std::milli> { LLVM_ABI static const char value[]; };
-template <> struct unit<std::micro> { LLVM_ABI static const char value[]; };
-template <> struct unit<std::nano> { LLVM_ABI static const char value[]; };
+template <> struct unit<std::ratio<3600>> {
+  LLVM_ABI static const char value[];
+};
+template <> struct unit<std::ratio<60>> {
+  LLVM_ABI static const char value[];
+};
+template <> struct unit<std::ratio<1>> {
+  LLVM_ABI static const char value[];
+};
+template <> struct unit<std::milli> {
+  LLVM_ABI static const char value[];
+};
+template <> struct unit<std::micro> {
+  LLVM_ABI static const char value[];
+};
+template <> struct unit<std::nano> {
+  LLVM_ABI static const char value[];
+};
 } // namespace detail
 
 /// Implementation of format_provider<T> for duration types.

--- a/llvm/include/llvm/Support/Chrono.h
+++ b/llvm/include/llvm/Support/Chrono.h
@@ -77,8 +77,8 @@ toTimePoint(std::time_t T, uint32_t nsec) {
 
 } // namespace sys
 
-raw_ostream &operator<<(raw_ostream &OS, sys::TimePoint<> TP);
-raw_ostream &operator<<(raw_ostream &OS, sys::UtcTime<> TP);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, sys::TimePoint<> TP);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, sys::UtcTime<> TP);
 
 /// Format provider for TimePoint<>
 ///
@@ -90,12 +90,12 @@ raw_ostream &operator<<(raw_ostream &OS, sys::UtcTime<> TP);
 /// If no options are given, the default format is "%Y-%m-%d %H:%M:%S.%N".
 template <>
 struct format_provider<sys::TimePoint<>> {
-  static void format(const sys::TimePoint<> &TP, llvm::raw_ostream &OS,
+  LLVM_ABI static void format(const sys::TimePoint<> &TP, llvm::raw_ostream &OS,
                      StringRef Style);
 };
 
 template <> struct format_provider<sys::UtcTime<std::chrono::seconds>> {
-  static void format(const sys::UtcTime<std::chrono::seconds> &TP,
+  LLVM_ABI static void format(const sys::UtcTime<std::chrono::seconds> &TP,
                      llvm::raw_ostream &OS, StringRef Style);
 };
 
@@ -103,12 +103,12 @@ namespace detail {
 template <typename Period> struct unit { static const char value[]; };
 template <typename Period> const char unit<Period>::value[] = "";
 
-template <> struct unit<std::ratio<3600>> { static const char value[]; };
-template <> struct unit<std::ratio<60>> { static const char value[]; };
-template <> struct unit<std::ratio<1>> { static const char value[]; };
-template <> struct unit<std::milli> { static const char value[]; };
-template <> struct unit<std::micro> { static const char value[]; };
-template <> struct unit<std::nano> { static const char value[]; };
+template <> struct unit<std::ratio<3600>> { LLVM_ABI static const char value[]; };
+template <> struct unit<std::ratio<60>> { LLVM_ABI static const char value[]; };
+template <> struct unit<std::ratio<1>> { LLVM_ABI static const char value[]; };
+template <> struct unit<std::milli> { LLVM_ABI static const char value[]; };
+template <> struct unit<std::micro> { LLVM_ABI static const char value[]; };
+template <> struct unit<std::nano> { LLVM_ABI static const char value[]; };
 } // namespace detail
 
 /// Implementation of format_provider<T> for duration types.

--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -19,7 +19,6 @@
 #ifndef LLVM_SUPPORT_COMMANDLINE_H
 #define LLVM_SUPPORT_COMMANDLINE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -28,6 +27,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/ADT/iterator_range.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/StringSaver.h"
 #include "llvm/Support/raw_ostream.h"
@@ -67,10 +67,10 @@ namespace cl {
 // that give precedence to earlier occurrences, you will need to extend this
 // function to support it correctly.
 LLVM_ABI bool ParseCommandLineOptions(int argc, const char *const *argv,
-                             StringRef Overview = "",
-                             raw_ostream *Errs = nullptr,
-                             const char *EnvVar = nullptr,
-                             bool LongOptionsUseDoubleDash = false);
+                                      StringRef Overview = "",
+                                      raw_ostream *Errs = nullptr,
+                                      const char *EnvVar = nullptr,
+                                      bool LongOptionsUseDoubleDash = false);
 
 // Function pointer type for printing version information.
 using VersionPrinterTy = std::function<void(raw_ostream &)>;
@@ -891,7 +891,8 @@ public:
 //--------------------------------------------------
 // Super class of parsers to provide boilerplate code
 //
-class LLVM_ABI basic_parser_impl { // non-template implementation of basic_parser<t>
+class LLVM_ABI
+    basic_parser_impl { // non-template implementation of basic_parser<t>
 public:
   basic_parser_impl(Option &) {}
 
@@ -969,7 +970,8 @@ public:
 
 extern template class basic_parser<boolOrDefault>;
 
-template <> class LLVM_ABI parser<boolOrDefault> : public basic_parser<boolOrDefault> {
+template <>
+class LLVM_ABI parser<boolOrDefault> : public basic_parser<boolOrDefault> {
 public:
   parser(Option &O) : basic_parser(O) {}
 
@@ -1079,7 +1081,8 @@ public:
 extern template class basic_parser<unsigned long>;
 
 template <>
-class LLVM_ABI parser<unsigned long> final : public basic_parser<unsigned long> {
+class LLVM_ABI parser<unsigned long> final
+    : public basic_parser<unsigned long> {
 public:
   parser(Option &O) : basic_parser(O) {}
 
@@ -1101,7 +1104,8 @@ public:
 extern template class basic_parser<unsigned long long>;
 
 template <>
-class LLVM_ABI parser<unsigned long long> : public basic_parser<unsigned long long> {
+class LLVM_ABI parser<unsigned long long>
+    : public basic_parser<unsigned long long> {
 public:
   parser(Option &O) : basic_parser(O) {}
 
@@ -1165,7 +1169,8 @@ public:
 
 extern template class basic_parser<std::string>;
 
-template <> class LLVM_ABI parser<std::string> : public basic_parser<std::string> {
+template <>
+class LLVM_ABI parser<std::string> : public basic_parser<std::string> {
 public:
   parser(Option &O) : basic_parser(O) {}
 
@@ -2075,8 +2080,8 @@ getRegisteredSubcommands();
 /// lines and end of the response file to be marked with a nullptr string.
 /// \param [out] NewArgv All parsed strings are appended to NewArgv.
 LLVM_ABI void TokenizeGNUCommandLine(StringRef Source, StringSaver &Saver,
-                            SmallVectorImpl<const char *> &NewArgv,
-                            bool MarkEOLs = false);
+                                     SmallVectorImpl<const char *> &NewArgv,
+                                     bool MarkEOLs = false);
 
 /// Tokenizes a string of Windows command line arguments, which may contain
 /// quotes and escaped quotes.
@@ -2093,15 +2098,16 @@ LLVM_ABI void TokenizeGNUCommandLine(StringRef Source, StringSaver &Saver,
 /// lines and end of the response file to be marked with a nullptr string.
 /// \param [out] NewArgv All parsed strings are appended to NewArgv.
 LLVM_ABI void TokenizeWindowsCommandLine(StringRef Source, StringSaver &Saver,
-                                SmallVectorImpl<const char *> &NewArgv,
-                                bool MarkEOLs = false);
+                                         SmallVectorImpl<const char *> &NewArgv,
+                                         bool MarkEOLs = false);
 
 /// Tokenizes a Windows command line while attempting to avoid copies. If no
 /// quoting or escaping was used, this produces substrings of the original
 /// string. If a token requires unquoting, it will be allocated with the
 /// StringSaver.
-LLVM_ABI void TokenizeWindowsCommandLineNoCopy(StringRef Source, StringSaver &Saver,
-                                      SmallVectorImpl<StringRef> &NewArgv);
+LLVM_ABI void
+TokenizeWindowsCommandLineNoCopy(StringRef Source, StringSaver &Saver,
+                                 SmallVectorImpl<StringRef> &NewArgv);
 
 /// Tokenizes a Windows full command line, including command name at the start.
 ///
@@ -2116,9 +2122,10 @@ LLVM_ABI void TokenizeWindowsCommandLineNoCopy(StringRef Source, StringSaver &Sa
 /// if you set MarkEOLs = true, then the first word of every line will be
 /// parsed using the special rules for command names, making this function
 /// suitable for parsing a file full of commands to execute.
-LLVM_ABI void TokenizeWindowsCommandLineFull(StringRef Source, StringSaver &Saver,
-                                    SmallVectorImpl<const char *> &NewArgv,
-                                    bool MarkEOLs = false);
+LLVM_ABI void
+TokenizeWindowsCommandLineFull(StringRef Source, StringSaver &Saver,
+                               SmallVectorImpl<const char *> &NewArgv,
+                               bool MarkEOLs = false);
 
 /// String tokenization function type.  Should be compatible with either
 /// Windows or Unix command line tokenizers.
@@ -2136,8 +2143,8 @@ using TokenizerCallback = void (*)(StringRef Source, StringSaver &Saver,
 /// It works like TokenizeGNUCommandLine with ability to skip comment lines.
 ///
 LLVM_ABI void tokenizeConfigFile(StringRef Source, StringSaver &Saver,
-                        SmallVectorImpl<const char *> &NewArgv,
-                        bool MarkEOLs = false);
+                                 SmallVectorImpl<const char *> &NewArgv,
+                                 bool MarkEOLs = false);
 
 /// Contains options that control response file expansion.
 class ExpansionContext {
@@ -2208,7 +2215,8 @@ public:
   /// If the specified file name contains a directory separator, it is searched
   /// for by its absolute path. Otherwise looks for file sequentially in
   /// directories specified by SearchDirs field.
-  LLVM_ABI bool findConfigFile(StringRef FileName, SmallVectorImpl<char> &FilePath);
+  LLVM_ABI bool findConfigFile(StringRef FileName,
+                               SmallVectorImpl<char> &FilePath);
 
   /// Reads command line options from the given configuration file.
   ///
@@ -2220,7 +2228,8 @@ public:
   /// commands resolving file names in them relative to the directory where
   /// CfgFilename resides. It also expands "<CFGDIR>" to the base path of the
   /// current config file.
-  LLVM_ABI Error readConfigFile(StringRef CfgFile, SmallVectorImpl<const char *> &Argv);
+  LLVM_ABI Error readConfigFile(StringRef CfgFile,
+                                SmallVectorImpl<const char *> &Argv);
 
   /// Expands constructs "@file" in the provided array of arguments recursively.
   LLVM_ABI Error expandResponseFiles(SmallVectorImpl<const char *> &Argv);
@@ -2230,21 +2239,23 @@ public:
 /// environment variable EnvVar and command line options, then expands
 /// response files recursively.
 /// \return true if all @files were expanded successfully or there were none.
-LLVM_ABI bool expandResponseFiles(int Argc, const char *const *Argv, const char *EnvVar,
-                         SmallVectorImpl<const char *> &NewArgv);
+LLVM_ABI bool expandResponseFiles(int Argc, const char *const *Argv,
+                                  const char *EnvVar,
+                                  SmallVectorImpl<const char *> &NewArgv);
 
 /// A convenience helper which supports the typical use case of expansion
 /// function call.
-LLVM_ABI bool ExpandResponseFiles(StringSaver &Saver, TokenizerCallback Tokenizer,
-                         SmallVectorImpl<const char *> &Argv);
+LLVM_ABI bool ExpandResponseFiles(StringSaver &Saver,
+                                  TokenizerCallback Tokenizer,
+                                  SmallVectorImpl<const char *> &Argv);
 
 /// A convenience helper which concatenates the options specified by the
 /// environment variable EnvVar and command line options, then expands response
 /// files recursively. The tokenizer is a predefined GNU or Windows one.
 /// \return true if all @files were expanded successfully or there were none.
-LLVM_ABI bool expandResponseFiles(int Argc, const char *const *Argv, const char *EnvVar,
-                         StringSaver &Saver,
-                         SmallVectorImpl<const char *> &NewArgv);
+LLVM_ABI bool expandResponseFiles(int Argc, const char *const *Argv,
+                                  const char *EnvVar, StringSaver &Saver,
+                                  SmallVectorImpl<const char *> &NewArgv);
 
 /// Mark all options not part of this category as cl::ReallyHidden.
 ///
@@ -2254,7 +2265,7 @@ LLVM_ABI bool expandResponseFiles(int Argc, const char *const *Argv, const char 
 /// not specific to the tool. This function allows a tool to specify a single
 /// option category to display in the -help output.
 LLVM_ABI void HideUnrelatedOptions(cl::OptionCategory &Category,
-                          SubCommand &Sub = SubCommand::getTopLevel());
+                                   SubCommand &Sub = SubCommand::getTopLevel());
 
 /// Mark all options not part of the categories as cl::ReallyHidden.
 ///
@@ -2263,8 +2274,9 @@ LLVM_ABI void HideUnrelatedOptions(cl::OptionCategory &Category,
 /// Some tools (like clang-format) like to be able to hide all options that are
 /// not specific to the tool. This function allows a tool to specify a single
 /// option category to display in the -help output.
-LLVM_ABI void HideUnrelatedOptions(ArrayRef<const cl::OptionCategory *> Categories,
-                          SubCommand &Sub = SubCommand::getTopLevel());
+LLVM_ABI void
+HideUnrelatedOptions(ArrayRef<const cl::OptionCategory *> Categories,
+                     SubCommand &Sub = SubCommand::getTopLevel());
 
 /// Reset all command line options to a state that looks as if they have
 /// never appeared on the command line.  This is useful for being able to parse

--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -941,7 +941,7 @@ public:
 
 //--------------------------------------------------
 
-extern template class basic_parser<bool>;
+extern template class LLVM_TEMPLATE_ABI basic_parser<bool>;
 
 template <> class LLVM_ABI parser<bool> : public basic_parser<bool> {
 public:
@@ -968,7 +968,7 @@ public:
 
 //--------------------------------------------------
 
-extern template class basic_parser<boolOrDefault>;
+extern template class LLVM_TEMPLATE_ABI basic_parser<boolOrDefault>;
 
 template <>
 class LLVM_ABI parser<boolOrDefault> : public basic_parser<boolOrDefault> {
@@ -994,7 +994,7 @@ public:
 
 //--------------------------------------------------
 
-extern template class basic_parser<int>;
+extern template class LLVM_TEMPLATE_ABI basic_parser<int>;
 
 template <> class LLVM_ABI parser<int> : public basic_parser<int> {
 public:
@@ -1015,7 +1015,7 @@ public:
 
 //--------------------------------------------------
 
-extern template class basic_parser<long>;
+extern template class LLVM_TEMPLATE_ABI basic_parser<long>;
 
 template <> class LLVM_ABI parser<long> final : public basic_parser<long> {
 public:
@@ -1036,7 +1036,7 @@ public:
 
 //--------------------------------------------------
 
-extern template class basic_parser<long long>;
+extern template class LLVM_TEMPLATE_ABI basic_parser<long long>;
 
 template <> class LLVM_ABI parser<long long> : public basic_parser<long long> {
 public:
@@ -1057,7 +1057,7 @@ public:
 
 //--------------------------------------------------
 
-extern template class basic_parser<unsigned>;
+extern template class LLVM_TEMPLATE_ABI basic_parser<unsigned>;
 
 template <> class LLVM_ABI parser<unsigned> : public basic_parser<unsigned> {
 public:
@@ -1078,7 +1078,7 @@ public:
 
 //--------------------------------------------------
 
-extern template class basic_parser<unsigned long>;
+extern template class LLVM_TEMPLATE_ABI basic_parser<unsigned long>;
 
 template <>
 class LLVM_ABI parser<unsigned long> final
@@ -1101,7 +1101,7 @@ public:
 
 //--------------------------------------------------
 
-extern template class basic_parser<unsigned long long>;
+extern template class LLVM_TEMPLATE_ABI basic_parser<unsigned long long>;
 
 template <>
 class LLVM_ABI parser<unsigned long long>
@@ -1125,7 +1125,7 @@ public:
 
 //--------------------------------------------------
 
-extern template class basic_parser<double>;
+extern template class LLVM_TEMPLATE_ABI basic_parser<double>;
 
 template <> class LLVM_ABI parser<double> : public basic_parser<double> {
 public:
@@ -1146,7 +1146,7 @@ public:
 
 //--------------------------------------------------
 
-extern template class basic_parser<float>;
+extern template class LLVM_TEMPLATE_ABI basic_parser<float>;
 
 template <> class LLVM_ABI parser<float> : public basic_parser<float> {
 public:
@@ -1167,7 +1167,7 @@ public:
 
 //--------------------------------------------------
 
-extern template class basic_parser<std::string>;
+extern template class LLVM_TEMPLATE_ABI basic_parser<std::string>;
 
 template <>
 class LLVM_ABI parser<std::string> : public basic_parser<std::string> {
@@ -1192,7 +1192,7 @@ public:
 
 //--------------------------------------------------
 
-extern template class basic_parser<char>;
+extern template class LLVM_TEMPLATE_ABI basic_parser<char>;
 
 template <> class LLVM_ABI parser<char> : public basic_parser<char> {
 public:

--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -19,6 +19,7 @@
 #ifndef LLVM_SUPPORT_COMMANDLINE_H
 #define LLVM_SUPPORT_COMMANDLINE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -65,7 +66,7 @@ namespace cl {
 // that give precedence to later occurrences.  If your program supports options
 // that give precedence to earlier occurrences, you will need to extend this
 // function to support it correctly.
-bool ParseCommandLineOptions(int argc, const char *const *argv,
+LLVM_ABI bool ParseCommandLineOptions(int argc, const char *const *argv,
                              StringRef Overview = "",
                              raw_ostream *Errs = nullptr,
                              const char *EnvVar = nullptr,
@@ -78,20 +79,20 @@ using VersionPrinterTy = std::function<void(raw_ostream &)>;
 /// Override the default (LLVM specific) version printer used to print out the
 /// version when --version is given on the command line. This allows other
 /// systems using the CommandLine utilities to print their own version string.
-void SetVersionPrinter(VersionPrinterTy func);
+LLVM_ABI void SetVersionPrinter(VersionPrinterTy func);
 
 ///===---------------------------------------------------------------------===//
 /// Add an extra printer to use in addition to the default one. This can be
 /// called multiple times, and each time it adds a new function to the list
 /// which will be called after the basic LLVM version printing is complete.
 /// Each can then add additional information specific to the tool.
-void AddExtraVersionPrinter(VersionPrinterTy func);
+LLVM_ABI void AddExtraVersionPrinter(VersionPrinterTy func);
 
 // Print option values.
 // With -print-options print the difference between option values and defaults.
 // With -print-all-options print all option values.
 // (Currently not perfect, but best-effort.)
-void PrintOptionValues();
+LLVM_ABI void PrintOptionValues();
 
 // Forward declaration - AddLiteralOption needs to be up here to make gcc happy.
 class Option;
@@ -103,7 +104,7 @@ class Option;
 ///
 /// Literal options are used by some parsers to register special option values.
 /// This is how the PassNameParser registers pass names for opt.
-void AddLiteralOption(Option &O, StringRef Name);
+LLVM_ABI void AddLiteralOption(Option &O, StringRef Name);
 
 //===----------------------------------------------------------------------===//
 // Flags permitted to be passed to command line arguments
@@ -181,7 +182,7 @@ private:
   StringRef const Name;
   StringRef const Description;
 
-  void registerCategory();
+  LLVM_ABI void registerCategory();
 
 public:
   OptionCategory(StringRef const Name,
@@ -195,7 +196,7 @@ public:
 };
 
 // The general Option Category (used as default category).
-OptionCategory &getGeneralCategory();
+LLVM_ABI OptionCategory &getGeneralCategory();
 
 //===----------------------------------------------------------------------===//
 //
@@ -205,8 +206,8 @@ private:
   StringRef Description;
 
 protected:
-  void registerSubCommand();
-  void unregisterSubCommand();
+  LLVM_ABI void registerSubCommand();
+  LLVM_ABI void unregisterSubCommand();
 
 public:
   SubCommand(StringRef Name, StringRef Description = "")
@@ -216,15 +217,15 @@ public:
   SubCommand() = default;
 
   // Get the special subcommand representing no subcommand.
-  static SubCommand &getTopLevel();
+  LLVM_ABI static SubCommand &getTopLevel();
 
   // Get the special subcommand that can be used to put an option into all
   // subcommands.
-  static SubCommand &getAll();
+  LLVM_ABI static SubCommand &getAll();
 
-  void reset();
+  LLVM_ABI void reset();
 
-  explicit operator bool() const;
+  LLVM_ABI explicit operator bool() const;
 
   StringRef getName() const { return Name; }
   StringRef getDescription() const { return Description; }
@@ -247,7 +248,7 @@ public:
 
 //===----------------------------------------------------------------------===//
 //
-class Option {
+class LLVM_ABI Option {
   friend class alias;
 
   // Overriden by subclasses to handle the value passed into an argument. Should
@@ -529,7 +530,7 @@ callback(F CB) {
 //===----------------------------------------------------------------------===//
 
 // Support value comparison outside the template.
-struct GenericOptionValue {
+struct LLVM_ABI GenericOptionValue {
   virtual bool compare(const GenericOptionValue &V) const = 0;
 
 protected:
@@ -636,7 +637,7 @@ struct OptionValue final
 // Other safe-to-copy-by-value common option types.
 enum boolOrDefault { BOU_UNSET, BOU_TRUE, BOU_FALSE };
 template <>
-struct OptionValue<cl::boolOrDefault> final
+struct LLVM_ABI OptionValue<cl::boolOrDefault> final
     : OptionValueCopy<cl::boolOrDefault> {
   using WrapperType = cl::boolOrDefault;
 
@@ -654,7 +655,7 @@ private:
 };
 
 template <>
-struct OptionValue<std::string> final : OptionValueCopy<std::string> {
+struct LLVM_ABI OptionValue<std::string> final : OptionValueCopy<std::string> {
   using WrapperType = StringRef;
 
   OptionValue() = default;
@@ -724,7 +725,7 @@ template <typename... OptsTy> ValuesClass values(OptsTy... Options) {
 // every instance of the generic parser.  This also allows us to put stuff into
 // CommandLine.cpp
 //
-class generic_parser_base {
+class LLVM_ABI generic_parser_base {
 protected:
   class GenericOptionInfo {
   public:
@@ -890,7 +891,7 @@ public:
 //--------------------------------------------------
 // Super class of parsers to provide boilerplate code
 //
-class basic_parser_impl { // non-template implementation of basic_parser<t>
+class LLVM_ABI basic_parser_impl { // non-template implementation of basic_parser<t>
 public:
   basic_parser_impl(Option &) {}
 
@@ -941,7 +942,7 @@ public:
 
 extern template class basic_parser<bool>;
 
-template <> class parser<bool> : public basic_parser<bool> {
+template <> class LLVM_ABI parser<bool> : public basic_parser<bool> {
 public:
   parser(Option &O) : basic_parser(O) {}
 
@@ -968,7 +969,7 @@ public:
 
 extern template class basic_parser<boolOrDefault>;
 
-template <> class parser<boolOrDefault> : public basic_parser<boolOrDefault> {
+template <> class LLVM_ABI parser<boolOrDefault> : public basic_parser<boolOrDefault> {
 public:
   parser(Option &O) : basic_parser(O) {}
 
@@ -993,7 +994,7 @@ public:
 
 extern template class basic_parser<int>;
 
-template <> class parser<int> : public basic_parser<int> {
+template <> class LLVM_ABI parser<int> : public basic_parser<int> {
 public:
   parser(Option &O) : basic_parser(O) {}
 
@@ -1014,7 +1015,7 @@ public:
 
 extern template class basic_parser<long>;
 
-template <> class parser<long> final : public basic_parser<long> {
+template <> class LLVM_ABI parser<long> final : public basic_parser<long> {
 public:
   parser(Option &O) : basic_parser(O) {}
 
@@ -1035,7 +1036,7 @@ public:
 
 extern template class basic_parser<long long>;
 
-template <> class parser<long long> : public basic_parser<long long> {
+template <> class LLVM_ABI parser<long long> : public basic_parser<long long> {
 public:
   parser(Option &O) : basic_parser(O) {}
 
@@ -1056,7 +1057,7 @@ public:
 
 extern template class basic_parser<unsigned>;
 
-template <> class parser<unsigned> : public basic_parser<unsigned> {
+template <> class LLVM_ABI parser<unsigned> : public basic_parser<unsigned> {
 public:
   parser(Option &O) : basic_parser(O) {}
 
@@ -1078,7 +1079,7 @@ public:
 extern template class basic_parser<unsigned long>;
 
 template <>
-class parser<unsigned long> final : public basic_parser<unsigned long> {
+class LLVM_ABI parser<unsigned long> final : public basic_parser<unsigned long> {
 public:
   parser(Option &O) : basic_parser(O) {}
 
@@ -1100,7 +1101,7 @@ public:
 extern template class basic_parser<unsigned long long>;
 
 template <>
-class parser<unsigned long long> : public basic_parser<unsigned long long> {
+class LLVM_ABI parser<unsigned long long> : public basic_parser<unsigned long long> {
 public:
   parser(Option &O) : basic_parser(O) {}
 
@@ -1122,7 +1123,7 @@ public:
 
 extern template class basic_parser<double>;
 
-template <> class parser<double> : public basic_parser<double> {
+template <> class LLVM_ABI parser<double> : public basic_parser<double> {
 public:
   parser(Option &O) : basic_parser(O) {}
 
@@ -1143,7 +1144,7 @@ public:
 
 extern template class basic_parser<float>;
 
-template <> class parser<float> : public basic_parser<float> {
+template <> class LLVM_ABI parser<float> : public basic_parser<float> {
 public:
   parser(Option &O) : basic_parser(O) {}
 
@@ -1164,7 +1165,7 @@ public:
 
 extern template class basic_parser<std::string>;
 
-template <> class parser<std::string> : public basic_parser<std::string> {
+template <> class LLVM_ABI parser<std::string> : public basic_parser<std::string> {
 public:
   parser(Option &O) : basic_parser(O) {}
 
@@ -1188,7 +1189,7 @@ public:
 
 extern template class basic_parser<char>;
 
-template <> class parser<char> : public basic_parser<char> {
+template <> class LLVM_ABI parser<char> : public basic_parser<char> {
 public:
   parser(Option &O) : basic_parser(O) {}
 
@@ -1906,7 +1907,7 @@ public:
 // Aliased command line option (alias this name to a preexisting name)
 //
 
-class alias : public Option {
+class LLVM_ABI alias : public Option {
   Option *AliasFor;
 
   bool handleOccurrence(unsigned pos, StringRef /*ArgName*/,
@@ -1979,27 +1980,27 @@ struct aliasopt {
 struct extrahelp {
   StringRef morehelp;
 
-  explicit extrahelp(StringRef help);
+  LLVM_ABI explicit extrahelp(StringRef help);
 };
 
-void PrintVersionMessage();
+LLVM_ABI void PrintVersionMessage();
 
 /// This function just prints the help message, exactly the same way as if the
 /// -help or -help-hidden option had been given on the command line.
 ///
 /// \param Hidden if true will print hidden options
 /// \param Categorized if true print options in categories
-void PrintHelpMessage(bool Hidden = false, bool Categorized = false);
+LLVM_ABI void PrintHelpMessage(bool Hidden = false, bool Categorized = false);
 
 /// An array of optional enabled settings in the LLVM build configuration,
 /// which may be of interest to compiler developers. For example, includes
 /// "+assertions" if assertions are enabled. Used by printBuildConfig.
-ArrayRef<StringRef> getCompilerBuildConfig();
+LLVM_ABI ArrayRef<StringRef> getCompilerBuildConfig();
 
 /// Prints the compiler build configuration.
 /// Designed for compiler developers, not compiler end-users.
 /// Intended to be used in --version output when enabled.
-void printBuildConfig(raw_ostream &OS);
+LLVM_ABI void printBuildConfig(raw_ostream &OS);
 
 //===----------------------------------------------------------------------===//
 // Public interface for accessing registered options.
@@ -2032,7 +2033,7 @@ void printBuildConfig(raw_ostream &OS);
 /// Hopefully this API can be deprecated soon. Any situation where options need
 /// to be modified by tools or libraries should be handled by sane APIs rather
 /// than just handing around a global list.
-StringMap<Option *> &
+LLVM_ABI StringMap<Option *> &
 getRegisteredOptions(SubCommand &Sub = SubCommand::getTopLevel());
 
 /// Use this to get all registered SubCommands from the provided parser.
@@ -2054,7 +2055,7 @@ getRegisteredOptions(SubCommand &Sub = SubCommand::getTopLevel());
 ///
 /// This interface is useful for defining subcommands in libraries and
 /// the dispatch from a single point (like in the main function).
-iterator_range<typename SmallPtrSet<SubCommand *, 4>::iterator>
+LLVM_ABI iterator_range<typename SmallPtrSet<SubCommand *, 4>::iterator>
 getRegisteredSubcommands();
 
 //===----------------------------------------------------------------------===//
@@ -2073,7 +2074,7 @@ getRegisteredSubcommands();
 /// \param [in] MarkEOLs true if tokenizing a response file and you want end of
 /// lines and end of the response file to be marked with a nullptr string.
 /// \param [out] NewArgv All parsed strings are appended to NewArgv.
-void TokenizeGNUCommandLine(StringRef Source, StringSaver &Saver,
+LLVM_ABI void TokenizeGNUCommandLine(StringRef Source, StringSaver &Saver,
                             SmallVectorImpl<const char *> &NewArgv,
                             bool MarkEOLs = false);
 
@@ -2091,7 +2092,7 @@ void TokenizeGNUCommandLine(StringRef Source, StringSaver &Saver,
 /// \param [in] MarkEOLs true if tokenizing a response file and you want end of
 /// lines and end of the response file to be marked with a nullptr string.
 /// \param [out] NewArgv All parsed strings are appended to NewArgv.
-void TokenizeWindowsCommandLine(StringRef Source, StringSaver &Saver,
+LLVM_ABI void TokenizeWindowsCommandLine(StringRef Source, StringSaver &Saver,
                                 SmallVectorImpl<const char *> &NewArgv,
                                 bool MarkEOLs = false);
 
@@ -2099,7 +2100,7 @@ void TokenizeWindowsCommandLine(StringRef Source, StringSaver &Saver,
 /// quoting or escaping was used, this produces substrings of the original
 /// string. If a token requires unquoting, it will be allocated with the
 /// StringSaver.
-void TokenizeWindowsCommandLineNoCopy(StringRef Source, StringSaver &Saver,
+LLVM_ABI void TokenizeWindowsCommandLineNoCopy(StringRef Source, StringSaver &Saver,
                                       SmallVectorImpl<StringRef> &NewArgv);
 
 /// Tokenizes a Windows full command line, including command name at the start.
@@ -2115,7 +2116,7 @@ void TokenizeWindowsCommandLineNoCopy(StringRef Source, StringSaver &Saver,
 /// if you set MarkEOLs = true, then the first word of every line will be
 /// parsed using the special rules for command names, making this function
 /// suitable for parsing a file full of commands to execute.
-void TokenizeWindowsCommandLineFull(StringRef Source, StringSaver &Saver,
+LLVM_ABI void TokenizeWindowsCommandLineFull(StringRef Source, StringSaver &Saver,
                                     SmallVectorImpl<const char *> &NewArgv,
                                     bool MarkEOLs = false);
 
@@ -2134,7 +2135,7 @@ using TokenizerCallback = void (*)(StringRef Source, StringSaver &Saver,
 ///
 /// It works like TokenizeGNUCommandLine with ability to skip comment lines.
 ///
-void tokenizeConfigFile(StringRef Source, StringSaver &Saver,
+LLVM_ABI void tokenizeConfigFile(StringRef Source, StringSaver &Saver,
                         SmallVectorImpl<const char *> &NewArgv,
                         bool MarkEOLs = false);
 
@@ -2171,7 +2172,7 @@ class ExpansionContext {
                                  SmallVectorImpl<const char *> &NewArgv);
 
 public:
-  ExpansionContext(BumpPtrAllocator &A, TokenizerCallback T);
+  LLVM_ABI ExpansionContext(BumpPtrAllocator &A, TokenizerCallback T);
 
   ExpansionContext &setMarkEOLs(bool X) {
     MarkEOLs = X;
@@ -2207,7 +2208,7 @@ public:
   /// If the specified file name contains a directory separator, it is searched
   /// for by its absolute path. Otherwise looks for file sequentially in
   /// directories specified by SearchDirs field.
-  bool findConfigFile(StringRef FileName, SmallVectorImpl<char> &FilePath);
+  LLVM_ABI bool findConfigFile(StringRef FileName, SmallVectorImpl<char> &FilePath);
 
   /// Reads command line options from the given configuration file.
   ///
@@ -2219,29 +2220,29 @@ public:
   /// commands resolving file names in them relative to the directory where
   /// CfgFilename resides. It also expands "<CFGDIR>" to the base path of the
   /// current config file.
-  Error readConfigFile(StringRef CfgFile, SmallVectorImpl<const char *> &Argv);
+  LLVM_ABI Error readConfigFile(StringRef CfgFile, SmallVectorImpl<const char *> &Argv);
 
   /// Expands constructs "@file" in the provided array of arguments recursively.
-  Error expandResponseFiles(SmallVectorImpl<const char *> &Argv);
+  LLVM_ABI Error expandResponseFiles(SmallVectorImpl<const char *> &Argv);
 };
 
 /// A convenience helper which concatenates the options specified by the
 /// environment variable EnvVar and command line options, then expands
 /// response files recursively.
 /// \return true if all @files were expanded successfully or there were none.
-bool expandResponseFiles(int Argc, const char *const *Argv, const char *EnvVar,
+LLVM_ABI bool expandResponseFiles(int Argc, const char *const *Argv, const char *EnvVar,
                          SmallVectorImpl<const char *> &NewArgv);
 
 /// A convenience helper which supports the typical use case of expansion
 /// function call.
-bool ExpandResponseFiles(StringSaver &Saver, TokenizerCallback Tokenizer,
+LLVM_ABI bool ExpandResponseFiles(StringSaver &Saver, TokenizerCallback Tokenizer,
                          SmallVectorImpl<const char *> &Argv);
 
 /// A convenience helper which concatenates the options specified by the
 /// environment variable EnvVar and command line options, then expands response
 /// files recursively. The tokenizer is a predefined GNU or Windows one.
 /// \return true if all @files were expanded successfully or there were none.
-bool expandResponseFiles(int Argc, const char *const *Argv, const char *EnvVar,
+LLVM_ABI bool expandResponseFiles(int Argc, const char *const *Argv, const char *EnvVar,
                          StringSaver &Saver,
                          SmallVectorImpl<const char *> &NewArgv);
 
@@ -2252,7 +2253,7 @@ bool expandResponseFiles(int Argc, const char *const *Argv, const char *EnvVar,
 /// Some tools (like clang-format) like to be able to hide all options that are
 /// not specific to the tool. This function allows a tool to specify a single
 /// option category to display in the -help output.
-void HideUnrelatedOptions(cl::OptionCategory &Category,
+LLVM_ABI void HideUnrelatedOptions(cl::OptionCategory &Category,
                           SubCommand &Sub = SubCommand::getTopLevel());
 
 /// Mark all options not part of the categories as cl::ReallyHidden.
@@ -2262,22 +2263,22 @@ void HideUnrelatedOptions(cl::OptionCategory &Category,
 /// Some tools (like clang-format) like to be able to hide all options that are
 /// not specific to the tool. This function allows a tool to specify a single
 /// option category to display in the -help output.
-void HideUnrelatedOptions(ArrayRef<const cl::OptionCategory *> Categories,
+LLVM_ABI void HideUnrelatedOptions(ArrayRef<const cl::OptionCategory *> Categories,
                           SubCommand &Sub = SubCommand::getTopLevel());
 
 /// Reset all command line options to a state that looks as if they have
 /// never appeared on the command line.  This is useful for being able to parse
 /// a command line multiple times (especially useful for writing tests).
-void ResetAllOptionOccurrences();
+LLVM_ABI void ResetAllOptionOccurrences();
 
 /// Reset the command line parser back to its initial state.  This
 /// removes
 /// all options, categories, and subcommands and returns the parser to a state
 /// where no options are supported.
-void ResetCommandLineParser();
+LLVM_ABI void ResetCommandLineParser();
 
 /// Parses `Arg` into the option handler `Handler`.
-bool ProvidePositionalOption(Option *Handler, StringRef Arg, int i);
+LLVM_ABI bool ProvidePositionalOption(Option *Handler, StringRef Arg, int i);
 
 } // end namespace cl
 

--- a/llvm/include/llvm/Support/Compression.h
+++ b/llvm/include/llvm/Support/Compression.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_COMPRESSION_H
 #define LLVM_SUPPORT_COMPRESSION_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/DataTypes.h"
 
@@ -38,16 +39,16 @@ constexpr int BestSpeedCompression = 1;
 constexpr int DefaultCompression = 6;
 constexpr int BestSizeCompression = 9;
 
-bool isAvailable();
+LLVM_ABI bool isAvailable();
 
-void compress(ArrayRef<uint8_t> Input,
+LLVM_ABI void compress(ArrayRef<uint8_t> Input,
               SmallVectorImpl<uint8_t> &CompressedBuffer,
               int Level = DefaultCompression);
 
-Error decompress(ArrayRef<uint8_t> Input, uint8_t *Output,
+LLVM_ABI Error decompress(ArrayRef<uint8_t> Input, uint8_t *Output,
                  size_t &UncompressedSize);
 
-Error decompress(ArrayRef<uint8_t> Input, SmallVectorImpl<uint8_t> &Output,
+LLVM_ABI Error decompress(ArrayRef<uint8_t> Input, SmallVectorImpl<uint8_t> &Output,
                  size_t UncompressedSize);
 
 } // End of namespace zlib
@@ -59,16 +60,16 @@ constexpr int BestSpeedCompression = 1;
 constexpr int DefaultCompression = 5;
 constexpr int BestSizeCompression = 12;
 
-bool isAvailable();
+LLVM_ABI bool isAvailable();
 
-void compress(ArrayRef<uint8_t> Input,
+LLVM_ABI void compress(ArrayRef<uint8_t> Input,
               SmallVectorImpl<uint8_t> &CompressedBuffer,
               int Level = DefaultCompression, bool EnableLdm = false);
 
-Error decompress(ArrayRef<uint8_t> Input, uint8_t *Output,
+LLVM_ABI Error decompress(ArrayRef<uint8_t> Input, uint8_t *Output,
                  size_t &UncompressedSize);
 
-Error decompress(ArrayRef<uint8_t> Input, SmallVectorImpl<uint8_t> &Output,
+LLVM_ABI Error decompress(ArrayRef<uint8_t> Input, SmallVectorImpl<uint8_t> &Output,
                  size_t UncompressedSize);
 
 } // End of namespace zstd
@@ -109,19 +110,19 @@ struct Params {
 // Return nullptr if LLVM was built with support (LLVM_ENABLE_ZLIB,
 // LLVM_ENABLE_ZSTD) for the specified compression format; otherwise
 // return a string literal describing the reason.
-const char *getReasonIfUnsupported(Format F);
+LLVM_ABI const char *getReasonIfUnsupported(Format F);
 
 // Compress Input with the specified format P.Format. If Level is -1, use
 // *::DefaultCompression for the format.
-void compress(Params P, ArrayRef<uint8_t> Input,
+LLVM_ABI void compress(Params P, ArrayRef<uint8_t> Input,
               SmallVectorImpl<uint8_t> &Output);
 
 // Decompress Input. The uncompressed size must be available.
-Error decompress(DebugCompressionType T, ArrayRef<uint8_t> Input,
+LLVM_ABI Error decompress(DebugCompressionType T, ArrayRef<uint8_t> Input,
                  uint8_t *Output, size_t UncompressedSize);
-Error decompress(Format F, ArrayRef<uint8_t> Input,
+LLVM_ABI Error decompress(Format F, ArrayRef<uint8_t> Input,
                  SmallVectorImpl<uint8_t> &Output, size_t UncompressedSize);
-Error decompress(DebugCompressionType T, ArrayRef<uint8_t> Input,
+LLVM_ABI Error decompress(DebugCompressionType T, ArrayRef<uint8_t> Input,
                  SmallVectorImpl<uint8_t> &Output, size_t UncompressedSize);
 
 } // End of namespace compression

--- a/llvm/include/llvm/Support/Compression.h
+++ b/llvm/include/llvm/Support/Compression.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_SUPPORT_COMPRESSION_H
 #define LLVM_SUPPORT_COMPRESSION_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 
 namespace llvm {
@@ -42,14 +42,15 @@ constexpr int BestSizeCompression = 9;
 LLVM_ABI bool isAvailable();
 
 LLVM_ABI void compress(ArrayRef<uint8_t> Input,
-              SmallVectorImpl<uint8_t> &CompressedBuffer,
-              int Level = DefaultCompression);
+                       SmallVectorImpl<uint8_t> &CompressedBuffer,
+                       int Level = DefaultCompression);
 
 LLVM_ABI Error decompress(ArrayRef<uint8_t> Input, uint8_t *Output,
-                 size_t &UncompressedSize);
+                          size_t &UncompressedSize);
 
-LLVM_ABI Error decompress(ArrayRef<uint8_t> Input, SmallVectorImpl<uint8_t> &Output,
-                 size_t UncompressedSize);
+LLVM_ABI Error decompress(ArrayRef<uint8_t> Input,
+                          SmallVectorImpl<uint8_t> &Output,
+                          size_t UncompressedSize);
 
 } // End of namespace zlib
 
@@ -63,14 +64,15 @@ constexpr int BestSizeCompression = 12;
 LLVM_ABI bool isAvailable();
 
 LLVM_ABI void compress(ArrayRef<uint8_t> Input,
-              SmallVectorImpl<uint8_t> &CompressedBuffer,
-              int Level = DefaultCompression, bool EnableLdm = false);
+                       SmallVectorImpl<uint8_t> &CompressedBuffer,
+                       int Level = DefaultCompression, bool EnableLdm = false);
 
 LLVM_ABI Error decompress(ArrayRef<uint8_t> Input, uint8_t *Output,
-                 size_t &UncompressedSize);
+                          size_t &UncompressedSize);
 
-LLVM_ABI Error decompress(ArrayRef<uint8_t> Input, SmallVectorImpl<uint8_t> &Output,
-                 size_t UncompressedSize);
+LLVM_ABI Error decompress(ArrayRef<uint8_t> Input,
+                          SmallVectorImpl<uint8_t> &Output,
+                          size_t UncompressedSize);
 
 } // End of namespace zstd
 
@@ -115,15 +117,17 @@ LLVM_ABI const char *getReasonIfUnsupported(Format F);
 // Compress Input with the specified format P.Format. If Level is -1, use
 // *::DefaultCompression for the format.
 LLVM_ABI void compress(Params P, ArrayRef<uint8_t> Input,
-              SmallVectorImpl<uint8_t> &Output);
+                       SmallVectorImpl<uint8_t> &Output);
 
 // Decompress Input. The uncompressed size must be available.
 LLVM_ABI Error decompress(DebugCompressionType T, ArrayRef<uint8_t> Input,
-                 uint8_t *Output, size_t UncompressedSize);
+                          uint8_t *Output, size_t UncompressedSize);
 LLVM_ABI Error decompress(Format F, ArrayRef<uint8_t> Input,
-                 SmallVectorImpl<uint8_t> &Output, size_t UncompressedSize);
+                          SmallVectorImpl<uint8_t> &Output,
+                          size_t UncompressedSize);
 LLVM_ABI Error decompress(DebugCompressionType T, ArrayRef<uint8_t> Input,
-                 SmallVectorImpl<uint8_t> &Output, size_t UncompressedSize);
+                          SmallVectorImpl<uint8_t> &Output,
+                          size_t UncompressedSize);
 
 } // End of namespace compression
 

--- a/llvm/include/llvm/Support/ConvertEBCDIC.h
+++ b/llvm/include/llvm/Support/ConvertEBCDIC.h
@@ -13,16 +13,17 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include <system_error>
 
 namespace llvm {
 namespace ConverterEBCDIC {
-std::error_code convertToEBCDIC(StringRef Source,
+LLVM_ABI std::error_code convertToEBCDIC(StringRef Source,
                                 SmallVectorImpl<char> &Result);
 
-void convertToUTF8(StringRef Source, SmallVectorImpl<char> &Result);
+LLVM_ABI void convertToUTF8(StringRef Source, SmallVectorImpl<char> &Result);
 
 } // namespace ConverterEBCDIC
 } // namespace llvm

--- a/llvm/include/llvm/Support/ConvertEBCDIC.h
+++ b/llvm/include/llvm/Support/ConvertEBCDIC.h
@@ -13,15 +13,15 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include <system_error>
 
 namespace llvm {
 namespace ConverterEBCDIC {
 LLVM_ABI std::error_code convertToEBCDIC(StringRef Source,
-                                SmallVectorImpl<char> &Result);
+                                         SmallVectorImpl<char> &Result);
 
 LLVM_ABI void convertToUTF8(StringRef Source, SmallVectorImpl<char> &Result);
 

--- a/llvm/include/llvm/Support/ConvertUTF.h
+++ b/llvm/include/llvm/Support/ConvertUTF.h
@@ -105,6 +105,7 @@
 #ifndef LLVM_SUPPORT_CONVERTUTF_H
 #define LLVM_SUPPORT_CONVERTUTF_H
 
+#include "llvm/Support/Compiler.h"
 #include <cstddef>
 #include <string>
 
@@ -157,7 +158,7 @@ typedef enum {
   lenientConversion
 } ConversionFlags;
 
-ConversionResult ConvertUTF8toUTF16 (
+LLVM_ABI ConversionResult ConvertUTF8toUTF16 (
   const UTF8** sourceStart, const UTF8* sourceEnd,
   UTF16** targetStart, UTF16* targetEnd, ConversionFlags flags);
 
@@ -165,7 +166,7 @@ ConversionResult ConvertUTF8toUTF16 (
  * Convert a partial UTF8 sequence to UTF32.  If the sequence ends in an
  * incomplete code unit sequence, returns \c sourceExhausted.
  */
-ConversionResult ConvertUTF8toUTF32Partial(
+LLVM_ABI ConversionResult ConvertUTF8toUTF32Partial(
   const UTF8** sourceStart, const UTF8* sourceEnd,
   UTF32** targetStart, UTF32* targetEnd, ConversionFlags flags);
 
@@ -173,33 +174,33 @@ ConversionResult ConvertUTF8toUTF32Partial(
  * Convert a partial UTF8 sequence to UTF32.  If the sequence ends in an
  * incomplete code unit sequence, returns \c sourceIllegal.
  */
-ConversionResult ConvertUTF8toUTF32(
+LLVM_ABI ConversionResult ConvertUTF8toUTF32(
   const UTF8** sourceStart, const UTF8* sourceEnd,
   UTF32** targetStart, UTF32* targetEnd, ConversionFlags flags);
 
-ConversionResult ConvertUTF16toUTF8 (
+LLVM_ABI ConversionResult ConvertUTF16toUTF8 (
   const UTF16** sourceStart, const UTF16* sourceEnd,
   UTF8** targetStart, UTF8* targetEnd, ConversionFlags flags);
 
-ConversionResult ConvertUTF32toUTF8 (
+LLVM_ABI ConversionResult ConvertUTF32toUTF8 (
   const UTF32** sourceStart, const UTF32* sourceEnd,
   UTF8** targetStart, UTF8* targetEnd, ConversionFlags flags);
 
-ConversionResult ConvertUTF16toUTF32 (
+LLVM_ABI ConversionResult ConvertUTF16toUTF32 (
   const UTF16** sourceStart, const UTF16* sourceEnd,
   UTF32** targetStart, UTF32* targetEnd, ConversionFlags flags);
 
-ConversionResult ConvertUTF32toUTF16 (
+LLVM_ABI ConversionResult ConvertUTF32toUTF16 (
   const UTF32** sourceStart, const UTF32* sourceEnd,
   UTF16** targetStart, UTF16* targetEnd, ConversionFlags flags);
 
-Boolean isLegalUTF8Sequence(const UTF8 *source, const UTF8 *sourceEnd);
+LLVM_ABI Boolean isLegalUTF8Sequence(const UTF8 *source, const UTF8 *sourceEnd);
 
-Boolean isLegalUTF8String(const UTF8 **source, const UTF8 *sourceEnd);
+LLVM_ABI Boolean isLegalUTF8String(const UTF8 **source, const UTF8 *sourceEnd);
 
-unsigned getUTF8SequenceSize(const UTF8 *source, const UTF8 *sourceEnd);
+LLVM_ABI unsigned getUTF8SequenceSize(const UTF8 *source, const UTF8 *sourceEnd);
 
-unsigned getNumBytesForUTF8(UTF8 firstByte);
+LLVM_ABI unsigned getNumBytesForUTF8(UTF8 firstByte);
 
 /*************************************************************************/
 /* Below are LLVM-specific wrappers of the functions above. */
@@ -217,26 +218,26 @@ class StringRef;
  * the first character which could not be converted.
  * \return true on success.
  */
-bool ConvertUTF8toWide(unsigned WideCharWidth, llvm::StringRef Source,
+LLVM_ABI bool ConvertUTF8toWide(unsigned WideCharWidth, llvm::StringRef Source,
                        char *&ResultPtr, const UTF8 *&ErrorPtr);
 
 /**
 * Converts a UTF-8 StringRef to a std::wstring.
 * \return true on success.
 */
-bool ConvertUTF8toWide(llvm::StringRef Source, std::wstring &Result);
+LLVM_ABI bool ConvertUTF8toWide(llvm::StringRef Source, std::wstring &Result);
 
 /**
 * Converts a UTF-8 C-string to a std::wstring.
 * \return true on success.
 */
-bool ConvertUTF8toWide(const char *Source, std::wstring &Result);
+LLVM_ABI bool ConvertUTF8toWide(const char *Source, std::wstring &Result);
 
 /**
 * Converts a std::wstring to a UTF-8 encoded std::string.
 * \return true on success.
 */
-bool convertWideToUTF8(const std::wstring &Source, std::string &Result);
+LLVM_ABI bool convertWideToUTF8(const std::wstring &Source, std::string &Result);
 
 
 /**
@@ -249,7 +250,7 @@ bool convertWideToUTF8(const std::wstring &Source, std::string &Result);
  *
  * \returns true on success.
  */
-bool ConvertCodePointToUTF8(unsigned Source, char *&ResultPtr);
+LLVM_ABI bool ConvertCodePointToUTF8(unsigned Source, char *&ResultPtr);
 
 /**
  * Convert the first UTF8 sequence in the given source buffer to a UTF32
@@ -282,7 +283,7 @@ inline ConversionResult convertUTF8Sequence(const UTF8 **source,
  * Returns true if a blob of text starts with a UTF-16 big or little endian byte
  * order mark.
  */
-bool hasUTF16ByteOrderMark(ArrayRef<char> SrcBytes);
+LLVM_ABI bool hasUTF16ByteOrderMark(ArrayRef<char> SrcBytes);
 
 /**
  * Converts a stream of raw bytes assumed to be UTF16 into a UTF8 std::string.
@@ -291,7 +292,7 @@ bool hasUTF16ByteOrderMark(ArrayRef<char> SrcBytes);
  * \param [out] Out Converted UTF-8 is stored here on success.
  * \returns true on success
  */
-bool convertUTF16ToUTF8String(ArrayRef<char> SrcBytes, std::string &Out);
+LLVM_ABI bool convertUTF16ToUTF8String(ArrayRef<char> SrcBytes, std::string &Out);
 
 /**
 * Converts a UTF16 string into a UTF8 std::string.
@@ -300,7 +301,7 @@ bool convertUTF16ToUTF8String(ArrayRef<char> SrcBytes, std::string &Out);
 * \param [out] Out Converted UTF-8 is stored here on success.
 * \returns true on success
 */
-bool convertUTF16ToUTF8String(ArrayRef<UTF16> Src, std::string &Out);
+LLVM_ABI bool convertUTF16ToUTF8String(ArrayRef<UTF16> Src, std::string &Out);
 
 /**
  * Converts a stream of raw bytes assumed to be UTF32 into a UTF8 std::string.
@@ -309,7 +310,7 @@ bool convertUTF16ToUTF8String(ArrayRef<UTF16> Src, std::string &Out);
  * \param [out] Out Converted UTF-8 is stored here on success.
  * \returns true on success
  */
-bool convertUTF32ToUTF8String(ArrayRef<char> SrcBytes, std::string &Out);
+LLVM_ABI bool convertUTF32ToUTF8String(ArrayRef<char> SrcBytes, std::string &Out);
 
 /**
  * Converts a UTF32 string into a UTF8 std::string.
@@ -318,14 +319,14 @@ bool convertUTF32ToUTF8String(ArrayRef<char> SrcBytes, std::string &Out);
  * \param [out] Out Converted UTF-8 is stored here on success.
  * \returns true on success
  */
-bool convertUTF32ToUTF8String(ArrayRef<UTF32> Src, std::string &Out);
+LLVM_ABI bool convertUTF32ToUTF8String(ArrayRef<UTF32> Src, std::string &Out);
 
 /**
  * Converts a UTF-8 string into a UTF-16 string with native endianness.
  *
  * \returns true on success
  */
-bool convertUTF8ToUTF16String(StringRef SrcUTF8,
+LLVM_ABI bool convertUTF8ToUTF16String(StringRef SrcUTF8,
                               SmallVectorImpl<UTF16> &DstUTF16);
 
 #if defined(_WIN32)

--- a/llvm/include/llvm/Support/ConvertUTF.h
+++ b/llvm/include/llvm/Support/ConvertUTF.h
@@ -158,47 +158,62 @@ typedef enum {
   lenientConversion
 } ConversionFlags;
 
-LLVM_ABI ConversionResult ConvertUTF8toUTF16 (
-  const UTF8** sourceStart, const UTF8* sourceEnd,
-  UTF16** targetStart, UTF16* targetEnd, ConversionFlags flags);
+LLVM_ABI ConversionResult ConvertUTF8toUTF16(const UTF8 **sourceStart,
+                                             const UTF8 *sourceEnd,
+                                             UTF16 **targetStart,
+                                             UTF16 *targetEnd,
+                                             ConversionFlags flags);
 
 /**
  * Convert a partial UTF8 sequence to UTF32.  If the sequence ends in an
  * incomplete code unit sequence, returns \c sourceExhausted.
  */
-LLVM_ABI ConversionResult ConvertUTF8toUTF32Partial(
-  const UTF8** sourceStart, const UTF8* sourceEnd,
-  UTF32** targetStart, UTF32* targetEnd, ConversionFlags flags);
+LLVM_ABI ConversionResult ConvertUTF8toUTF32Partial(const UTF8 **sourceStart,
+                                                    const UTF8 *sourceEnd,
+                                                    UTF32 **targetStart,
+                                                    UTF32 *targetEnd,
+                                                    ConversionFlags flags);
 
 /**
  * Convert a partial UTF8 sequence to UTF32.  If the sequence ends in an
  * incomplete code unit sequence, returns \c sourceIllegal.
  */
-LLVM_ABI ConversionResult ConvertUTF8toUTF32(
-  const UTF8** sourceStart, const UTF8* sourceEnd,
-  UTF32** targetStart, UTF32* targetEnd, ConversionFlags flags);
+LLVM_ABI ConversionResult ConvertUTF8toUTF32(const UTF8 **sourceStart,
+                                             const UTF8 *sourceEnd,
+                                             UTF32 **targetStart,
+                                             UTF32 *targetEnd,
+                                             ConversionFlags flags);
 
-LLVM_ABI ConversionResult ConvertUTF16toUTF8 (
-  const UTF16** sourceStart, const UTF16* sourceEnd,
-  UTF8** targetStart, UTF8* targetEnd, ConversionFlags flags);
+LLVM_ABI ConversionResult ConvertUTF16toUTF8(const UTF16 **sourceStart,
+                                             const UTF16 *sourceEnd,
+                                             UTF8 **targetStart,
+                                             UTF8 *targetEnd,
+                                             ConversionFlags flags);
 
-LLVM_ABI ConversionResult ConvertUTF32toUTF8 (
-  const UTF32** sourceStart, const UTF32* sourceEnd,
-  UTF8** targetStart, UTF8* targetEnd, ConversionFlags flags);
+LLVM_ABI ConversionResult ConvertUTF32toUTF8(const UTF32 **sourceStart,
+                                             const UTF32 *sourceEnd,
+                                             UTF8 **targetStart,
+                                             UTF8 *targetEnd,
+                                             ConversionFlags flags);
 
-LLVM_ABI ConversionResult ConvertUTF16toUTF32 (
-  const UTF16** sourceStart, const UTF16* sourceEnd,
-  UTF32** targetStart, UTF32* targetEnd, ConversionFlags flags);
+LLVM_ABI ConversionResult ConvertUTF16toUTF32(const UTF16 **sourceStart,
+                                              const UTF16 *sourceEnd,
+                                              UTF32 **targetStart,
+                                              UTF32 *targetEnd,
+                                              ConversionFlags flags);
 
-LLVM_ABI ConversionResult ConvertUTF32toUTF16 (
-  const UTF32** sourceStart, const UTF32* sourceEnd,
-  UTF16** targetStart, UTF16* targetEnd, ConversionFlags flags);
+LLVM_ABI ConversionResult ConvertUTF32toUTF16(const UTF32 **sourceStart,
+                                              const UTF32 *sourceEnd,
+                                              UTF16 **targetStart,
+                                              UTF16 *targetEnd,
+                                              ConversionFlags flags);
 
 LLVM_ABI Boolean isLegalUTF8Sequence(const UTF8 *source, const UTF8 *sourceEnd);
 
 LLVM_ABI Boolean isLegalUTF8String(const UTF8 **source, const UTF8 *sourceEnd);
 
-LLVM_ABI unsigned getUTF8SequenceSize(const UTF8 *source, const UTF8 *sourceEnd);
+LLVM_ABI unsigned getUTF8SequenceSize(const UTF8 *source,
+                                      const UTF8 *sourceEnd);
 
 LLVM_ABI unsigned getNumBytesForUTF8(UTF8 firstByte);
 
@@ -219,7 +234,7 @@ class StringRef;
  * \return true on success.
  */
 LLVM_ABI bool ConvertUTF8toWide(unsigned WideCharWidth, llvm::StringRef Source,
-                       char *&ResultPtr, const UTF8 *&ErrorPtr);
+                                char *&ResultPtr, const UTF8 *&ErrorPtr);
 
 /**
 * Converts a UTF-8 StringRef to a std::wstring.
@@ -237,8 +252,8 @@ LLVM_ABI bool ConvertUTF8toWide(const char *Source, std::wstring &Result);
 * Converts a std::wstring to a UTF-8 encoded std::string.
 * \return true on success.
 */
-LLVM_ABI bool convertWideToUTF8(const std::wstring &Source, std::string &Result);
-
+LLVM_ABI bool convertWideToUTF8(const std::wstring &Source,
+                                std::string &Result);
 
 /**
  * Convert an Unicode code point to UTF8 sequence.
@@ -292,7 +307,8 @@ LLVM_ABI bool hasUTF16ByteOrderMark(ArrayRef<char> SrcBytes);
  * \param [out] Out Converted UTF-8 is stored here on success.
  * \returns true on success
  */
-LLVM_ABI bool convertUTF16ToUTF8String(ArrayRef<char> SrcBytes, std::string &Out);
+LLVM_ABI bool convertUTF16ToUTF8String(ArrayRef<char> SrcBytes,
+                                       std::string &Out);
 
 /**
 * Converts a UTF16 string into a UTF8 std::string.
@@ -310,7 +326,8 @@ LLVM_ABI bool convertUTF16ToUTF8String(ArrayRef<UTF16> Src, std::string &Out);
  * \param [out] Out Converted UTF-8 is stored here on success.
  * \returns true on success
  */
-LLVM_ABI bool convertUTF32ToUTF8String(ArrayRef<char> SrcBytes, std::string &Out);
+LLVM_ABI bool convertUTF32ToUTF8String(ArrayRef<char> SrcBytes,
+                                       std::string &Out);
 
 /**
  * Converts a UTF32 string into a UTF8 std::string.
@@ -327,7 +344,7 @@ LLVM_ABI bool convertUTF32ToUTF8String(ArrayRef<UTF32> Src, std::string &Out);
  * \returns true on success
  */
 LLVM_ABI bool convertUTF8ToUTF16String(StringRef SrcUTF8,
-                              SmallVectorImpl<UTF16> &DstUTF16);
+                                       SmallVectorImpl<UTF16> &DstUTF16);
 
 #if defined(_WIN32)
 namespace sys {

--- a/llvm/include/llvm/Support/ConvertUTF.h
+++ b/llvm/include/llvm/Support/ConvertUTF.h
@@ -349,14 +349,16 @@ LLVM_ABI bool convertUTF8ToUTF16String(StringRef SrcUTF8,
 #if defined(_WIN32)
 namespace sys {
 namespace windows {
-std::error_code UTF8ToUTF16(StringRef utf8, SmallVectorImpl<wchar_t> &utf16);
+LLVM_ABI std::error_code UTF8ToUTF16(StringRef utf8,
+                                     SmallVectorImpl<wchar_t> &utf16);
 /// Convert to UTF16 from the current code page used in the system
-std::error_code CurCPToUTF16(StringRef utf8, SmallVectorImpl<wchar_t> &utf16);
-std::error_code UTF16ToUTF8(const wchar_t *utf16, size_t utf16_len,
-                            SmallVectorImpl<char> &utf8);
+LLVM_ABI std::error_code CurCPToUTF16(StringRef utf8,
+                                      SmallVectorImpl<wchar_t> &utf16);
+LLVM_ABI std::error_code UTF16ToUTF8(const wchar_t *utf16, size_t utf16_len,
+                                     SmallVectorImpl<char> &utf8);
 /// Convert from UTF16 to the current code page used in the system
-std::error_code UTF16ToCurCP(const wchar_t *utf16, size_t utf16_len,
-                             SmallVectorImpl<char> &utf8);
+LLVM_ABI std::error_code UTF16ToCurCP(const wchar_t *utf16, size_t utf16_len,
+                                      SmallVectorImpl<char> &utf8);
 } // namespace windows
 } // namespace sys
 #endif

--- a/llvm/include/llvm/Support/CrashRecoveryContext.h
+++ b/llvm/include/llvm/Support/CrashRecoveryContext.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_CRASHRECOVERYCONTEXT_H
 #define LLVM_SUPPORT_CRASHRECOVERYCONTEXT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 
 namespace llvm {
@@ -48,28 +49,28 @@ class CrashRecoveryContext {
   CrashRecoveryContextCleanup *head = nullptr;
 
 public:
-  CrashRecoveryContext();
-  ~CrashRecoveryContext();
+  LLVM_ABI CrashRecoveryContext();
+  LLVM_ABI ~CrashRecoveryContext();
 
   /// Register cleanup handler, which is used when the recovery context is
   /// finished.
   /// The recovery context owns the handler.
-  void registerCleanup(CrashRecoveryContextCleanup *cleanup);
+  LLVM_ABI void registerCleanup(CrashRecoveryContextCleanup *cleanup);
 
-  void unregisterCleanup(CrashRecoveryContextCleanup *cleanup);
+  LLVM_ABI void unregisterCleanup(CrashRecoveryContextCleanup *cleanup);
 
   /// Enable crash recovery.
-  static void Enable();
+  LLVM_ABI static void Enable();
 
   /// Disable crash recovery.
-  static void Disable();
+  LLVM_ABI static void Disable();
 
   /// Return the active context, if the code is currently executing in a
   /// thread which is in a protected context.
-  static CrashRecoveryContext *GetCurrent();
+  LLVM_ABI static CrashRecoveryContext *GetCurrent();
 
   /// Return true if the current thread is recovering from a crash.
-  static bool isRecoveringFromCrash();
+  LLVM_ABI static bool isRecoveringFromCrash();
 
   /// Execute the provided callback function (with the given arguments) in
   /// a protected context.
@@ -78,7 +79,7 @@ public:
   /// function crashed (or HandleCrash was called explicitly). Clients should
   /// make as little assumptions as possible about the program state when
   /// RunSafely has returned false.
-  bool RunSafely(function_ref<void()> Fn);
+  LLVM_ABI bool RunSafely(function_ref<void()> Fn);
   bool RunSafely(void (*Fn)(void*), void *UserData) {
     return RunSafely([&]() { Fn(UserData); });
   }
@@ -91,25 +92,25 @@ public:
   ///
   /// On Darwin, if PRIO_DARWIN_BG is set on the calling thread, it will be
   /// propagated to the new thread as well.
-  bool RunSafelyOnThread(function_ref<void()>, unsigned RequestedStackSize = 0);
+  LLVM_ABI bool RunSafelyOnThread(function_ref<void()>, unsigned RequestedStackSize = 0);
   bool RunSafelyOnThread(void (*Fn)(void*), void *UserData,
                          unsigned RequestedStackSize = 0) {
     return RunSafelyOnThread([&]() { Fn(UserData); }, RequestedStackSize);
   }
 
-  bool RunSafelyOnNewStack(function_ref<void()>,
+  LLVM_ABI bool RunSafelyOnNewStack(function_ref<void()>,
                            unsigned RequestedStackSize = 0);
 
   /// Explicitly trigger a crash recovery in the current process, and
   /// return failure from RunSafely(). This function does not return.
-  [[noreturn]] void HandleExit(int RetCode);
+  [[noreturn]] LLVM_ABI void HandleExit(int RetCode);
 
   /// Return true if RetCode indicates that a signal or an exception occurred.
-  static bool isCrash(int RetCode);
+  LLVM_ABI static bool isCrash(int RetCode);
 
   /// Throw again a signal or an exception, after it was catched once by a
   /// CrashRecoveryContext.
-  static bool throwIfCrash(int RetCode);
+  LLVM_ABI static bool throwIfCrash(int RetCode);
 
   /// In case of a crash, this is the crash identifier.
   int RetCode = 0;
@@ -127,7 +128,7 @@ public:
 ///
 /// Cleanup handlers are stored in a double list, which is owned and managed by
 /// a crash recovery context.
-class CrashRecoveryContextCleanup {
+class LLVM_ABI CrashRecoveryContextCleanup {
 protected:
   CrashRecoveryContext *context = nullptr;
   CrashRecoveryContextCleanup(CrashRecoveryContext *context)

--- a/llvm/include/llvm/Support/CrashRecoveryContext.h
+++ b/llvm/include/llvm/Support/CrashRecoveryContext.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_SUPPORT_CRASHRECOVERYCONTEXT_H
 #define LLVM_SUPPORT_CRASHRECOVERYCONTEXT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 class CrashRecoveryContextCleanup;
@@ -92,14 +92,15 @@ public:
   ///
   /// On Darwin, if PRIO_DARWIN_BG is set on the calling thread, it will be
   /// propagated to the new thread as well.
-  LLVM_ABI bool RunSafelyOnThread(function_ref<void()>, unsigned RequestedStackSize = 0);
+  LLVM_ABI bool RunSafelyOnThread(function_ref<void()>,
+                                  unsigned RequestedStackSize = 0);
   bool RunSafelyOnThread(void (*Fn)(void*), void *UserData,
                          unsigned RequestedStackSize = 0) {
     return RunSafelyOnThread([&]() { Fn(UserData); }, RequestedStackSize);
   }
 
   LLVM_ABI bool RunSafelyOnNewStack(function_ref<void()>,
-                           unsigned RequestedStackSize = 0);
+                                    unsigned RequestedStackSize = 0);
 
   /// Explicitly trigger a crash recovery in the current process, and
   /// return failure from RunSafely(). This function does not return.

--- a/llvm/include/llvm/Support/DJB.h
+++ b/llvm/include/llvm/Support/DJB.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_DJB_H
 #define LLVM_SUPPORT_DJB_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace llvm {
@@ -26,7 +27,7 @@ inline uint32_t djbHash(StringRef Buffer, uint32_t H = 5381) {
 
 /// Computes the Bernstein hash after folding the input according to the Dwarf 5
 /// standard case folding rules.
-uint32_t caseFoldingDjbHash(StringRef Buffer, uint32_t H = 5381);
+LLVM_ABI uint32_t caseFoldingDjbHash(StringRef Buffer, uint32_t H = 5381);
 } // namespace llvm
 
 #endif // LLVM_SUPPORT_DJB_H

--- a/llvm/include/llvm/Support/DJB.h
+++ b/llvm/include/llvm/Support/DJB.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_SUPPORT_DJB_H
 #define LLVM_SUPPORT_DJB_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/Support/DataExtractor.h
+++ b/llvm/include/llvm/Support/DataExtractor.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_DATAEXTRACTOR_H
 #define LLVM_SUPPORT_DATAEXTRACTOR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/Error.h"
@@ -161,7 +162,7 @@ public:
   ///     pointed to by \a offset_ptr is out of bounds, or if the
   ///     offset plus the length of the C string is out of bounds,
   ///     a default-initialized StringRef will be returned.
-  StringRef getCStrRef(uint64_t *OffsetPtr, Error *Err = nullptr) const;
+  LLVM_ABI StringRef getCStrRef(uint64_t *OffsetPtr, Error *Err = nullptr) const;
 
   /// Extract a C string (as a StringRef) from the location given by the cursor.
   /// In case of an extraction error, or if the cursor is already in an error
@@ -200,7 +201,7 @@ public:
   ///     pointed to by \a OffsetPtr is out of bounds, or if the
   ///     offset plus the length of the C string is out of bounds,
   ///     a default-initialized StringRef will be returned.
-  StringRef getFixedLengthString(uint64_t *OffsetPtr,
+  LLVM_ABI StringRef getFixedLengthString(uint64_t *OffsetPtr,
       uint64_t Length, StringRef TrimChars = {"\0", 1}) const;
 
   /// Extract a fixed number of bytes from the specified offset.
@@ -230,7 +231,7 @@ public:
   ///     A StringRef for the extracted bytes. If the offset pointed to by
   ///     \a OffsetPtr is out of bounds, or if the offset plus the length
   ///     is out of bounds, a default-initialized StringRef will be returned.
-  StringRef getBytes(uint64_t *OffsetPtr, uint64_t Length,
+  LLVM_ABI StringRef getBytes(uint64_t *OffsetPtr, uint64_t Length,
                      Error *Err = nullptr) const;
 
   /// Extract a fixed number of bytes from the location given by the cursor. In
@@ -270,7 +271,7 @@ public:
   /// @return
   ///     The unsigned integer value that was extracted, or zero on
   ///     failure.
-  uint64_t getUnsigned(uint64_t *offset_ptr, uint32_t byte_size,
+  LLVM_ABI uint64_t getUnsigned(uint64_t *offset_ptr, uint32_t byte_size,
                        Error *Err = nullptr) const;
 
   /// Extract an unsigned integer of the given size from the location given by
@@ -303,7 +304,7 @@ public:
   /// @return
   ///     The sign extended signed integer value that was extracted,
   ///     or zero on failure.
-  int64_t getSigned(uint64_t *offset_ptr, uint32_t size) const;
+  LLVM_ABI int64_t getSigned(uint64_t *offset_ptr, uint32_t size) const;
 
   //------------------------------------------------------------------
   /// Extract an pointer from \a *offset_ptr.
@@ -351,7 +352,7 @@ public:
   ///
   /// @return
   ///     The extracted uint8_t value.
-  uint8_t getU8(uint64_t *offset_ptr, Error *Err = nullptr) const;
+  LLVM_ABI uint8_t getU8(uint64_t *offset_ptr, Error *Err = nullptr) const;
 
   /// Extract a single uint8_t value from the location given by the cursor. In
   /// case of an extraction error, or if the cursor is already in an error
@@ -381,13 +382,13 @@ public:
   /// @return
   ///     \a dst if all values were properly extracted and copied,
   ///     NULL otherise.
-  uint8_t *getU8(uint64_t *offset_ptr, uint8_t *dst, uint32_t count) const;
+  LLVM_ABI uint8_t *getU8(uint64_t *offset_ptr, uint8_t *dst, uint32_t count) const;
 
   /// Extract \a Count uint8_t values from the location given by the cursor and
   /// store them into the destination buffer. In case of an extraction error, or
   /// if the cursor is already in an error state, a nullptr is returned and the
   /// destination buffer is left unchanged.
-  uint8_t *getU8(Cursor &C, uint8_t *Dst, uint32_t Count) const;
+  LLVM_ABI uint8_t *getU8(Cursor &C, uint8_t *Dst, uint32_t Count) const;
 
   /// Extract \a Count uint8_t values from the location given by the cursor and
   /// store them into the destination vector. The vector is resized to fit the
@@ -425,7 +426,7 @@ public:
   /// @return
   ///     The extracted uint16_t value.
   //------------------------------------------------------------------
-  uint16_t getU16(uint64_t *offset_ptr, Error *Err = nullptr) const;
+  LLVM_ABI uint16_t getU16(uint64_t *offset_ptr, Error *Err = nullptr) const;
 
   /// Extract a single uint16_t value from the location given by the cursor. In
   /// case of an extraction error, or if the cursor is already in an error
@@ -455,7 +456,7 @@ public:
   /// @return
   ///     \a dst if all values were properly extracted and copied,
   ///     NULL otherise.
-  uint16_t *getU16(uint64_t *offset_ptr, uint16_t *dst, uint32_t count) const;
+  LLVM_ABI uint16_t *getU16(uint64_t *offset_ptr, uint16_t *dst, uint32_t count) const;
 
   /// Extract a 24-bit unsigned value from \a *offset_ptr and return it
   /// in a uint32_t.
@@ -478,7 +479,7 @@ public:
   ///
   /// @return
   ///     The extracted 24-bit value represented in a uint32_t.
-  uint32_t getU24(uint64_t *OffsetPtr, Error *Err = nullptr) const;
+  LLVM_ABI uint32_t getU24(uint64_t *OffsetPtr, Error *Err = nullptr) const;
 
   /// Extract a single 24-bit unsigned value from the location given by the
   /// cursor. In case of an extraction error, or if the cursor is already in an
@@ -505,7 +506,7 @@ public:
   ///
   /// @return
   ///     The extracted uint32_t value.
-  uint32_t getU32(uint64_t *offset_ptr, Error *Err = nullptr) const;
+  LLVM_ABI uint32_t getU32(uint64_t *offset_ptr, Error *Err = nullptr) const;
 
   /// Extract a single uint32_t value from the location given by the cursor. In
   /// case of an extraction error, or if the cursor is already in an error
@@ -535,7 +536,7 @@ public:
   /// @return
   ///     \a dst if all values were properly extracted and copied,
   ///     NULL otherise.
-  uint32_t *getU32(uint64_t *offset_ptr, uint32_t *dst, uint32_t count) const;
+  LLVM_ABI uint32_t *getU32(uint64_t *offset_ptr, uint32_t *dst, uint32_t count) const;
 
   /// Extract a uint64_t value from \a *offset_ptr.
   ///
@@ -557,7 +558,7 @@ public:
   ///
   /// @return
   ///     The extracted uint64_t value.
-  uint64_t getU64(uint64_t *offset_ptr, Error *Err = nullptr) const;
+  LLVM_ABI uint64_t getU64(uint64_t *offset_ptr, Error *Err = nullptr) const;
 
   /// Extract a single uint64_t value from the location given by the cursor. In
   /// case of an extraction error, or if the cursor is already in an error
@@ -587,7 +588,7 @@ public:
   /// @return
   ///     \a dst if all values were properly extracted and copied,
   ///     NULL otherise.
-  uint64_t *getU64(uint64_t *offset_ptr, uint64_t *dst, uint32_t count) const;
+  LLVM_ABI uint64_t *getU64(uint64_t *offset_ptr, uint64_t *dst, uint32_t count) const;
 
   /// Extract a signed LEB128 value from \a *offset_ptr.
   ///
@@ -611,7 +612,7 @@ public:
   ///
   /// @return
   ///     The extracted signed integer value.
-  int64_t getSLEB128(uint64_t *OffsetPtr, Error *Err = nullptr) const;
+  LLVM_ABI int64_t getSLEB128(uint64_t *OffsetPtr, Error *Err = nullptr) const;
 
   /// Extract an signed LEB128 value from the location given by the cursor.
   /// In case of an extraction error, or if the cursor is already in an error
@@ -640,7 +641,7 @@ public:
   ///
   /// @return
   ///     The extracted unsigned integer value.
-  uint64_t getULEB128(uint64_t *offset_ptr, llvm::Error *Err = nullptr) const;
+  LLVM_ABI uint64_t getULEB128(uint64_t *offset_ptr, llvm::Error *Err = nullptr) const;
 
   /// Extract an unsigned LEB128 value from the location given by the cursor.
   /// In case of an extraction error, or if the cursor is already in an error
@@ -649,7 +650,7 @@ public:
 
   /// Advance the Cursor position by the given number of bytes. No-op if the
   /// cursor is in an error state.
-  void skip(Cursor &C, uint64_t Length) const;
+  LLVM_ABI void skip(Cursor &C, uint64_t Length) const;
 
   /// Return true iff the cursor is at the end of the buffer, regardless of the
   /// error state of the cursor. The only way both eof and error states can be

--- a/llvm/include/llvm/Support/DataExtractor.h
+++ b/llvm/include/llvm/Support/DataExtractor.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_SUPPORT_DATAEXTRACTOR_H
 #define LLVM_SUPPORT_DATAEXTRACTOR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/Error.h"
 
@@ -162,7 +162,8 @@ public:
   ///     pointed to by \a offset_ptr is out of bounds, or if the
   ///     offset plus the length of the C string is out of bounds,
   ///     a default-initialized StringRef will be returned.
-  LLVM_ABI StringRef getCStrRef(uint64_t *OffsetPtr, Error *Err = nullptr) const;
+  LLVM_ABI StringRef getCStrRef(uint64_t *OffsetPtr,
+                                Error *Err = nullptr) const;
 
   /// Extract a C string (as a StringRef) from the location given by the cursor.
   /// In case of an extraction error, or if the cursor is already in an error
@@ -201,8 +202,9 @@ public:
   ///     pointed to by \a OffsetPtr is out of bounds, or if the
   ///     offset plus the length of the C string is out of bounds,
   ///     a default-initialized StringRef will be returned.
-  LLVM_ABI StringRef getFixedLengthString(uint64_t *OffsetPtr,
-      uint64_t Length, StringRef TrimChars = {"\0", 1}) const;
+  LLVM_ABI StringRef getFixedLengthString(uint64_t *OffsetPtr, uint64_t Length,
+                                          StringRef TrimChars = {"\0",
+                                                                 1}) const;
 
   /// Extract a fixed number of bytes from the specified offset.
   ///
@@ -232,7 +234,7 @@ public:
   ///     \a OffsetPtr is out of bounds, or if the offset plus the length
   ///     is out of bounds, a default-initialized StringRef will be returned.
   LLVM_ABI StringRef getBytes(uint64_t *OffsetPtr, uint64_t Length,
-                     Error *Err = nullptr) const;
+                              Error *Err = nullptr) const;
 
   /// Extract a fixed number of bytes from the location given by the cursor. In
   /// case of an extraction error, or if the cursor is already in an error
@@ -272,7 +274,7 @@ public:
   ///     The unsigned integer value that was extracted, or zero on
   ///     failure.
   LLVM_ABI uint64_t getUnsigned(uint64_t *offset_ptr, uint32_t byte_size,
-                       Error *Err = nullptr) const;
+                                Error *Err = nullptr) const;
 
   /// Extract an unsigned integer of the given size from the location given by
   /// the cursor. In case of an extraction error, or if the cursor is already in
@@ -382,7 +384,8 @@ public:
   /// @return
   ///     \a dst if all values were properly extracted and copied,
   ///     NULL otherise.
-  LLVM_ABI uint8_t *getU8(uint64_t *offset_ptr, uint8_t *dst, uint32_t count) const;
+  LLVM_ABI uint8_t *getU8(uint64_t *offset_ptr, uint8_t *dst,
+                          uint32_t count) const;
 
   /// Extract \a Count uint8_t values from the location given by the cursor and
   /// store them into the destination buffer. In case of an extraction error, or
@@ -456,7 +459,8 @@ public:
   /// @return
   ///     \a dst if all values were properly extracted and copied,
   ///     NULL otherise.
-  LLVM_ABI uint16_t *getU16(uint64_t *offset_ptr, uint16_t *dst, uint32_t count) const;
+  LLVM_ABI uint16_t *getU16(uint64_t *offset_ptr, uint16_t *dst,
+                            uint32_t count) const;
 
   /// Extract a 24-bit unsigned value from \a *offset_ptr and return it
   /// in a uint32_t.
@@ -536,7 +540,8 @@ public:
   /// @return
   ///     \a dst if all values were properly extracted and copied,
   ///     NULL otherise.
-  LLVM_ABI uint32_t *getU32(uint64_t *offset_ptr, uint32_t *dst, uint32_t count) const;
+  LLVM_ABI uint32_t *getU32(uint64_t *offset_ptr, uint32_t *dst,
+                            uint32_t count) const;
 
   /// Extract a uint64_t value from \a *offset_ptr.
   ///
@@ -588,7 +593,8 @@ public:
   /// @return
   ///     \a dst if all values were properly extracted and copied,
   ///     NULL otherise.
-  LLVM_ABI uint64_t *getU64(uint64_t *offset_ptr, uint64_t *dst, uint32_t count) const;
+  LLVM_ABI uint64_t *getU64(uint64_t *offset_ptr, uint64_t *dst,
+                            uint32_t count) const;
 
   /// Extract a signed LEB128 value from \a *offset_ptr.
   ///
@@ -641,7 +647,8 @@ public:
   ///
   /// @return
   ///     The extracted unsigned integer value.
-  LLVM_ABI uint64_t getULEB128(uint64_t *offset_ptr, llvm::Error *Err = nullptr) const;
+  LLVM_ABI uint64_t getULEB128(uint64_t *offset_ptr,
+                               llvm::Error *Err = nullptr) const;
 
   /// Extract an unsigned LEB128 value from the location given by the cursor.
   /// In case of an extraction error, or if the cursor is already in an error

--- a/llvm/include/llvm/Support/Debug.h
+++ b/llvm/include/llvm/Support/Debug.h
@@ -28,6 +28,8 @@
 #ifndef LLVM_SUPPORT_DEBUG_H
 #define LLVM_SUPPORT_DEBUG_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 
 class raw_ostream;

--- a/llvm/include/llvm/Support/Debug.h
+++ b/llvm/include/llvm/Support/Debug.h
@@ -81,7 +81,7 @@ void setCurrentDebugTypes(const char **Types, unsigned Count);
 /// is specified.  This should probably not be referenced directly, instead, use
 /// the DEBUG macro below.
 ///
-extern bool DebugFlag;
+LLVM_ABI extern bool DebugFlag;
 
 /// EnableDebugBuffering - This defaults to false.  If true, the debug
 /// stream will install signal handlers to dump any buffered debug
@@ -89,12 +89,12 @@ extern bool DebugFlag;
 /// to install signal handlers if they are certain there will be no
 /// conflict.
 ///
-extern bool EnableDebugBuffering;
+LLVM_ABI extern bool EnableDebugBuffering;
 
 /// dbgs() - This returns a reference to a raw_ostream for debugging
 /// messages.  If debugging is disabled it returns errs().  Use it
 /// like: dbgs() << "foo" << "bar";
-raw_ostream &dbgs();
+LLVM_ABI raw_ostream &dbgs();
 
 // DEBUG macro - This macro should be used by passes to emit debug information.
 // If the '-debug' option is specified on the commandline, and if this is a

--- a/llvm/include/llvm/Support/DebugCounter.h
+++ b/llvm/include/llvm/Support/DebugCounter.h
@@ -42,6 +42,7 @@
 #ifndef LLVM_SUPPORT_DEBUGCOUNTER_H
 #define LLVM_SUPPORT_DEBUGCOUNTER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringRef.h"
@@ -58,21 +59,21 @@ public:
   struct Chunk {
     int64_t Begin;
     int64_t End;
-    void print(llvm::raw_ostream &OS);
+    LLVM_ABI void print(llvm::raw_ostream &OS);
     bool contains(int64_t Idx) { return Idx >= Begin && Idx <= End; }
   };
 
-  static void printChunks(raw_ostream &OS, ArrayRef<Chunk>);
+  LLVM_ABI static void printChunks(raw_ostream &OS, ArrayRef<Chunk>);
 
   /// Return true on parsing error and print the error message on the
   /// llvm::errs()
-  static bool parseChunks(StringRef Str, SmallVector<Chunk> &Res);
+  LLVM_ABI static bool parseChunks(StringRef Str, SmallVector<Chunk> &Res);
 
   /// Returns a reference to the singleton instance.
-  static DebugCounter &instance();
+  LLVM_ABI static DebugCounter &instance();
 
   // Used by the command line option parser to push a new value it parsed.
-  void push_back(const std::string &);
+  LLVM_ABI void push_back(const std::string &);
 
   // Register a counter with the specified name.
   //
@@ -82,7 +83,7 @@ public:
   static unsigned registerCounter(StringRef Name, StringRef Desc) {
     return instance().addCounter(std::string(Name), std::string(Desc));
   }
-  static bool shouldExecuteImpl(unsigned CounterName);
+  LLVM_ABI static bool shouldExecuteImpl(unsigned CounterName);
 
   inline static bool shouldExecute(unsigned CounterName) {
     if (!isCountingEnabled())
@@ -119,9 +120,9 @@ public:
   }
 
   // Dump or print the current counter set into llvm::dbgs().
-  LLVM_DUMP_METHOD void dump() const;
+  LLVM_ABI LLVM_DUMP_METHOD void dump() const;
 
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 
   // Get the counter ID for a given named counter, or return 0 if none is found.
   unsigned getCounterId(const std::string &Name) const {

--- a/llvm/include/llvm/Support/DebugCounter.h
+++ b/llvm/include/llvm/Support/DebugCounter.h
@@ -42,11 +42,11 @@
 #ifndef LLVM_SUPPORT_DEBUGCOUNTER_H
 #define LLVM_SUPPORT_DEBUGCOUNTER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/UniqueVector.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include <string>
 

--- a/llvm/include/llvm/Support/DivisionByConstantInfo.h
+++ b/llvm/include/llvm/Support/DivisionByConstantInfo.h
@@ -13,20 +13,21 @@
 #ifndef LLVM_SUPPORT_DIVISIONBYCONSTANTINFO_H
 #define LLVM_SUPPORT_DIVISIONBYCONSTANTINFO_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APInt.h"
 
 namespace llvm {
 
 /// Magic data for optimising signed division by a constant.
 struct SignedDivisionByConstantInfo {
-  static SignedDivisionByConstantInfo get(const APInt &D);
+  LLVM_ABI static SignedDivisionByConstantInfo get(const APInt &D);
   APInt Magic;          ///< magic number
   unsigned ShiftAmount; ///< shift amount
 };
 
 /// Magic data for optimising unsigned division by a constant.
 struct UnsignedDivisionByConstantInfo {
-  static UnsignedDivisionByConstantInfo
+  LLVM_ABI static UnsignedDivisionByConstantInfo
   get(const APInt &D, unsigned LeadingZeros = 0,
       bool AllowEvenDivisorOptimization = true);
   APInt Magic;          ///< magic number

--- a/llvm/include/llvm/Support/DivisionByConstantInfo.h
+++ b/llvm/include/llvm/Support/DivisionByConstantInfo.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_SUPPORT_DIVISIONBYCONSTANTINFO_H
 #define LLVM_SUPPORT_DIVISIONBYCONSTANTINFO_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/Support/DynamicLibrary.h
+++ b/llvm/include/llvm/Support/DynamicLibrary.h
@@ -35,7 +35,7 @@ class DynamicLibrary {
   // Placeholder whose address represents an invalid library.
   // We use this instead of NULL or a pointer-int pair because the OS library
   // might define 0 or 1 to be "special" handles, such as "search all".
-  static char Invalid;
+  LLVM_ABI static char Invalid;
 
   // Opaque data used to interface with OS-specific dynamic library handling.
   void *Data;

--- a/llvm/include/llvm/Support/DynamicLibrary.h
+++ b/llvm/include/llvm/Support/DynamicLibrary.h
@@ -68,16 +68,16 @@ public:
   ///
   /// It is safe to call this function multiple times for the same library.
   /// Open a dynamic library permanently.
-  LLVM_ABI static DynamicLibrary getPermanentLibrary(const char *filename,
-                                            std::string *errMsg = nullptr);
+  LLVM_ABI static DynamicLibrary
+  getPermanentLibrary(const char *filename, std::string *errMsg = nullptr);
 
   /// Registers an externally loaded library. The library will be unloaded
   /// when the program terminates.
   ///
   /// It is safe to call this function multiple times for the same library,
   /// though ownership is only taken if there was no error.
-  LLVM_ABI static DynamicLibrary addPermanentLibrary(void *handle,
-                                            std::string *errMsg = nullptr);
+  LLVM_ABI static DynamicLibrary
+  addPermanentLibrary(void *handle, std::string *errMsg = nullptr);
 
   /// This function permanently loads the dynamic library at the given path.
   /// Use this instead of getPermanentLibrary() when you won't need to get
@@ -100,7 +100,7 @@ public:
   ///
   /// It is safe to call this function multiple times for the same library.
   LLVM_ABI static DynamicLibrary getLibrary(const char *FileName,
-                                   std::string *Err = nullptr);
+                                            std::string *Err = nullptr);
 
   /// This function closes the dynamic library at the given path, using the
   /// library close operation of the host operating system, and there is no

--- a/llvm/include/llvm/Support/DynamicLibrary.h
+++ b/llvm/include/llvm/Support/DynamicLibrary.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_DYNAMICLIBRARY_H
 #define LLVM_SUPPORT_DYNAMICLIBRARY_H
 
+#include "llvm/Support/Compiler.h"
 #include <string>
 
 namespace llvm {
@@ -54,7 +55,7 @@ public:
   /// Use isValid() to distinguish these cases if it is important.
   /// Note that this will \e not search symbols explicitly registered by
   /// AddSymbol().
-  void *getAddressOfSymbol(const char *symbolName);
+  LLVM_ABI void *getAddressOfSymbol(const char *symbolName);
 
   /// This function permanently loads the dynamic library at the given path
   /// using the library load operation from the host operating system. The
@@ -67,7 +68,7 @@ public:
   ///
   /// It is safe to call this function multiple times for the same library.
   /// Open a dynamic library permanently.
-  static DynamicLibrary getPermanentLibrary(const char *filename,
+  LLVM_ABI static DynamicLibrary getPermanentLibrary(const char *filename,
                                             std::string *errMsg = nullptr);
 
   /// Registers an externally loaded library. The library will be unloaded
@@ -75,7 +76,7 @@ public:
   ///
   /// It is safe to call this function multiple times for the same library,
   /// though ownership is only taken if there was no error.
-  static DynamicLibrary addPermanentLibrary(void *handle,
+  LLVM_ABI static DynamicLibrary addPermanentLibrary(void *handle,
                                             std::string *errMsg = nullptr);
 
   /// This function permanently loads the dynamic library at the given path.
@@ -98,7 +99,7 @@ public:
   /// library fails to load.
   ///
   /// It is safe to call this function multiple times for the same library.
-  static DynamicLibrary getLibrary(const char *FileName,
+  LLVM_ABI static DynamicLibrary getLibrary(const char *FileName,
                                    std::string *Err = nullptr);
 
   /// This function closes the dynamic library at the given path, using the
@@ -107,7 +108,7 @@ public:
   ///
   /// This function should be called only if the library was loaded using the
   /// getLibrary() function.
-  static void closeLibrary(DynamicLibrary &Lib);
+  LLVM_ABI static void closeLibrary(DynamicLibrary &Lib);
 
   enum SearchOrdering {
     /// SO_Linker - Search as a call to dlsym(dlopen(NULL)) would when
@@ -123,7 +124,7 @@ public:
     /// The default bahaviour is to search loaded libraries in reverse.
     SO_LoadOrder = 4
   };
-  static SearchOrdering SearchOrder; // = SO_Linker
+  LLVM_ABI static SearchOrdering SearchOrder; // = SO_Linker
 
   /// This function will search through all previously loaded dynamic
   /// libraries for the symbol \p symbolName. If it is found, the address of
@@ -132,7 +133,7 @@ public:
   /// as explicitly registered symbols (AddSymbol()).
   /// @throws std::string on error.
   /// Search through libraries for address of a symbol
-  static void *SearchForAddressOfSymbol(const char *symbolName);
+  LLVM_ABI static void *SearchForAddressOfSymbol(const char *symbolName);
 
   /// Convenience function for C++ophiles.
   static void *SearchForAddressOfSymbol(const std::string &symbolName) {
@@ -143,7 +144,7 @@ public:
   /// value \p symbolValue.  These symbols are searched before any
   /// libraries.
   /// Add searchable symbol/value pair.
-  static void AddSymbol(StringRef symbolName, void *symbolValue);
+  LLVM_ABI static void AddSymbol(StringRef symbolName, void *symbolValue);
 
   class HandleSet;
 };

--- a/llvm/include/llvm/Support/ELFAttrParserCompact.h
+++ b/llvm/include/llvm/Support/ELFAttrParserCompact.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_SUPPORT_ELFCOMPACTATTRPARSER_H
 #define LLVM_SUPPORT_ELFCOMPACTATTRPARSER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/ELFAttributeParser.h"
 #include "llvm/Support/ELFAttributes.h"

--- a/llvm/include/llvm/Support/ELFAttrParserCompact.h
+++ b/llvm/include/llvm/Support/ELFAttrParserCompact.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_ELFCOMPACTATTRPARSER_H
 #define LLVM_SUPPORT_ELFCOMPACTATTRPARSER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/ELFAttributeParser.h"
@@ -22,7 +23,7 @@ namespace llvm {
 class StringRef;
 class ScopedPrinter;
 
-class ELFCompactAttrParser : public ELFAttributeParser {
+class LLVM_ABI ELFCompactAttrParser : public ELFAttributeParser {
   StringRef vendor;
   std::unordered_map<unsigned, unsigned> attributes;
   std::unordered_map<unsigned, StringRef> attributesStr;

--- a/llvm/include/llvm/Support/ELFAttrParserExtended.h
+++ b/llvm/include/llvm/Support/ELFAttrParserExtended.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_ELFEXTENDEDATTRPARSER_H
 #define LLVM_SUPPORT_ELFEXTENDEDATTRPARSER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/ELFAttributeParser.h"
@@ -21,7 +22,7 @@ namespace llvm {
 class StringRef;
 class ScopedPrinter;
 
-class ELFExtendedAttrParser : public ELFAttributeParser {
+class LLVM_ABI ELFExtendedAttrParser : public ELFAttributeParser {
 protected:
   ScopedPrinter *Sw;
   DataExtractor De{ArrayRef<uint8_t>{}, true, 0};

--- a/llvm/include/llvm/Support/ELFAttrParserExtended.h
+++ b/llvm/include/llvm/Support/ELFAttrParserExtended.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_SUPPORT_ELFEXTENDEDATTRPARSER_H
 #define LLVM_SUPPORT_ELFEXTENDEDATTRPARSER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataExtractor.h"
 #include "llvm/Support/ELFAttributeParser.h"
 #include "llvm/Support/ELFAttributes.h"

--- a/llvm/include/llvm/Support/ELFAttributes.h
+++ b/llvm/include/llvm/Support/ELFAttributes.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_ELFATTRIBUTES_H
 #define LLVM_SUPPORT_ELFATTRIBUTES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include <optional>
@@ -55,9 +56,9 @@ namespace ELFAttrs {
 
 enum AttrType : unsigned { File = 1, Section = 2, Symbol = 3 };
 
-StringRef attrTypeAsString(unsigned attr, TagNameMap tagNameMap,
+LLVM_ABI StringRef attrTypeAsString(unsigned attr, TagNameMap tagNameMap,
                            bool hasTagPrefix = true);
-std::optional<unsigned> attrTypeFromString(StringRef tag, TagNameMap tagNameMap);
+LLVM_ABI std::optional<unsigned> attrTypeFromString(StringRef tag, TagNameMap tagNameMap);
 
 // Magic numbers for ELF attributes.
 enum AttrMagic { Format_Version = 0x41 };

--- a/llvm/include/llvm/Support/ELFAttributes.h
+++ b/llvm/include/llvm/Support/ELFAttributes.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_SUPPORT_ELFATTRIBUTES_H
 #define LLVM_SUPPORT_ELFATTRIBUTES_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include <optional>
 
 namespace llvm {
@@ -57,8 +57,9 @@ namespace ELFAttrs {
 enum AttrType : unsigned { File = 1, Section = 2, Symbol = 3 };
 
 LLVM_ABI StringRef attrTypeAsString(unsigned attr, TagNameMap tagNameMap,
-                           bool hasTagPrefix = true);
-LLVM_ABI std::optional<unsigned> attrTypeFromString(StringRef tag, TagNameMap tagNameMap);
+                                    bool hasTagPrefix = true);
+LLVM_ABI std::optional<unsigned> attrTypeFromString(StringRef tag,
+                                                    TagNameMap tagNameMap);
 
 // Magic numbers for ELF attributes.
 enum AttrMagic { Format_Version = 0x41 };

--- a/llvm/include/llvm/Support/Errno.h
+++ b/llvm/include/llvm/Support/Errno.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_ERRNO_H
 #define LLVM_SUPPORT_ERRNO_H
 
+#include "llvm/Support/Compiler.h"
 #include <cerrno>
 #include <string>
 
@@ -23,10 +24,10 @@ namespace sys {
 /// thread-safe variant of strerror() is available.  Be sure to call this
 /// immediately after the function that set errno, or errno may have been
 /// overwritten by an intervening call.
-std::string StrError();
+LLVM_ABI std::string StrError();
 
 /// Like the no-argument version above, but uses \p errnum instead of errno.
-std::string StrError(int errnum);
+LLVM_ABI std::string StrError(int errnum);
 
 template <typename FailT, typename Fun, typename... Args>
 inline decltype(auto) RetryAfterSignal(const FailT &Fail, const Fun &F,

--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -737,7 +737,8 @@ private:
 
 /// @deprecated Use reportFatalInternalError() or reportFatalUsageError()
 /// instead.
-[[noreturn]] LLVM_ABI void report_fatal_error(Error Err, bool gen_crash_diag = true);
+[[noreturn]] LLVM_ABI void report_fatal_error(Error Err,
+                                              bool gen_crash_diag = true);
 
 /// Report a fatal error that indicates a bug in LLVM.
 /// See ErrorHandling.h for details.
@@ -1055,7 +1056,8 @@ Expected<T> handleExpected(Expected<T> ValOrErr, RecoveryFtor &&RecoveryPath,
 /// This is useful in the base level of your program to allow clean termination
 /// (allowing clean deallocation of resources, etc.), while reporting error
 /// information to the user.
-LLVM_ABI void logAllUnhandledErrors(Error E, raw_ostream &OS, Twine ErrorBanner = {});
+LLVM_ABI void logAllUnhandledErrors(Error E, raw_ostream &OS,
+                                    Twine ErrorBanner = {});
 
 /// Write all error messages (if any) in E to a string. The newline character
 /// is used to separate error messages.

--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -262,7 +262,7 @@ private:
   // of debug prints can cause the function to be too large for inlining.  So
   // it's important that we define this function out of line so that it can't be
   // inlined.
-  [[noreturn]] void fatalUncheckedError() const;
+  [[noreturn]] LLVM_ABI void fatalUncheckedError() const;
 #endif
 
   void assertIsChecked() {
@@ -401,6 +401,10 @@ private:
     Payloads.push_back(std::move(Payload1));
     Payloads.push_back(std::move(Payload2));
   }
+
+  // Explicitly non-copyable.
+  ErrorList(ErrorList const &) = delete;
+  ErrorList &operator=(ErrorList const &) = delete;
 
   static Error join(Error E1, Error E2) {
     if (!E1)
@@ -1185,7 +1189,7 @@ private:
 /// (or Expected) and you want to call code that still returns
 /// std::error_codes.
 class LLVM_ABI ECError : public ErrorInfo<ECError> {
-  friend Error errorCodeToError(std::error_code);
+  LLVM_ABI_FRIEND friend Error errorCodeToError(std::error_code);
 
   void anchor() override;
 

--- a/llvm/include/llvm/Support/Error.h
+++ b/llvm/include/llvm/Support/Error.h
@@ -41,7 +41,7 @@ class ErrorSuccess;
 
 /// Base class for error info classes. Do not extend this directly: Extend
 /// the ErrorInfo template subclass instead.
-class ErrorInfoBase {
+class LLVM_ABI ErrorInfoBase {
 public:
   virtual ~ErrorInfoBase() = default;
 
@@ -366,7 +366,7 @@ public:
 
 /// Special ErrorInfo subclass representing a list of ErrorInfos.
 /// Instances of this class are constructed by joinError.
-class ErrorList final : public ErrorInfo<ErrorList> {
+class LLVM_ABI ErrorList final : public ErrorInfo<ErrorList> {
   // handleErrors needs to be able to iterate the payload list of an
   // ErrorList.
   template <typename... HandlerTs>
@@ -737,14 +737,14 @@ private:
 
 /// @deprecated Use reportFatalInternalError() or reportFatalUsageError()
 /// instead.
-[[noreturn]] void report_fatal_error(Error Err, bool gen_crash_diag = true);
+[[noreturn]] LLVM_ABI void report_fatal_error(Error Err, bool gen_crash_diag = true);
 
 /// Report a fatal error that indicates a bug in LLVM.
 /// See ErrorHandling.h for details.
-[[noreturn]] void reportFatalInternalError(Error Err);
+[[noreturn]] LLVM_ABI void reportFatalInternalError(Error Err);
 /// Report a fatal error that does not indicate a bug in LLVM.
 /// See ErrorHandling.h for details.
-[[noreturn]] void reportFatalUsageError(Error Err);
+[[noreturn]] LLVM_ABI void reportFatalUsageError(Error Err);
 
 /// Report a fatal error if Err is a failure value.
 ///
@@ -1055,15 +1055,15 @@ Expected<T> handleExpected(Expected<T> ValOrErr, RecoveryFtor &&RecoveryPath,
 /// This is useful in the base level of your program to allow clean termination
 /// (allowing clean deallocation of resources, etc.), while reporting error
 /// information to the user.
-void logAllUnhandledErrors(Error E, raw_ostream &OS, Twine ErrorBanner = {});
+LLVM_ABI void logAllUnhandledErrors(Error E, raw_ostream &OS, Twine ErrorBanner = {});
 
 /// Write all error messages (if any) in E to a string. The newline character
 /// is used to separate error messages.
-std::string toString(Error E);
+LLVM_ABI std::string toString(Error E);
 
 /// Like toString(), but does not consume the error. This can be used to print
 /// a warning while retaining the original error object.
-std::string toStringWithoutConsuming(const Error &E);
+LLVM_ABI std::string toStringWithoutConsuming(const Error &E);
 
 /// Consume a Error without doing anything. This method should be used
 /// only where an error can be considered a reasonable and expected return
@@ -1182,7 +1182,7 @@ private:
 /// This is useful if you're writing an interface that returns a Error
 /// (or Expected) and you want to call code that still returns
 /// std::error_codes.
-class ECError : public ErrorInfo<ECError> {
+class LLVM_ABI ECError : public ErrorInfo<ECError> {
   friend Error errorCodeToError(std::error_code);
 
   void anchor() override;
@@ -1208,16 +1208,16 @@ protected:
 /// sensible conversion to std::error_code is available, as attempts to convert
 /// to/from this error will result in a fatal error. (i.e. it is a programmatic
 /// error to try to convert such a value).
-std::error_code inconvertibleErrorCode();
+LLVM_ABI std::error_code inconvertibleErrorCode();
 
 /// Helper for converting an std::error_code to a Error.
-Error errorCodeToError(std::error_code EC);
+LLVM_ABI Error errorCodeToError(std::error_code EC);
 
 /// Helper for converting an ECError to a std::error_code.
 ///
 /// This method requires that Err be Error() or an ECError, otherwise it
 /// will trigger a call to abort().
-std::error_code errorToErrorCode(Error Err);
+LLVM_ABI std::error_code errorToErrorCode(Error Err);
 
 /// Helper to get errno as an std::error_code.
 ///
@@ -1271,7 +1271,7 @@ template <typename T> ErrorOr<T> expectedToErrorOr(Expected<T> &&E) {
 ///   }
 ///   @endcode
 ///
-class StringError : public ErrorInfo<StringError> {
+class LLVM_ABI StringError : public ErrorInfo<StringError> {
 public:
   static char ID;
 
@@ -1301,7 +1301,7 @@ inline Error createStringError(std::error_code EC, char const *Fmt,
   return make_error<StringError>(Buffer, EC);
 }
 
-Error createStringError(std::string &&Msg, std::error_code EC);
+LLVM_ABI Error createStringError(std::string &&Msg, std::error_code EC);
 
 inline Error createStringError(std::error_code EC, const char *S) {
   return createStringError(std::string(S), EC);
@@ -1331,7 +1331,7 @@ inline Error createStringError(std::errc EC, char const *Fmt,
 ///
 /// In some cases, an error needs to live along a 'source' name, in order to
 /// show more detailed information to the user.
-class FileError final : public ErrorInfo<FileError> {
+class LLVM_ABI FileError final : public ErrorInfo<FileError> {
 
   friend Error createFileError(const Twine &, Error);
   friend Error createFileError(const Twine &, size_t, Error);

--- a/llvm/include/llvm/Support/ErrorHandling.h
+++ b/llvm/include/llvm/Support/ErrorHandling.h
@@ -41,7 +41,7 @@ typedef void (*fatal_error_handler_t)(void *user_data, const char *reason,
 /// \param user_data - An argument which will be passed to the install error
 /// handler.
 LLVM_ABI void install_fatal_error_handler(fatal_error_handler_t handler,
-                                 void *user_data = nullptr);
+                                          void *user_data = nullptr);
 
 /// Restores default error handling behaviour.
 LLVM_ABI void remove_fatal_error_handler();
@@ -61,11 +61,11 @@ struct ScopedFatalErrorHandler {
 /// @deprecated Use reportFatalInternalError() or reportFatalUsageError()
 /// instead.
 [[noreturn]] LLVM_ABI void report_fatal_error(const char *reason,
-                                     bool gen_crash_diag = true);
+                                              bool gen_crash_diag = true);
 [[noreturn]] LLVM_ABI void report_fatal_error(StringRef reason,
-                                     bool gen_crash_diag = true);
+                                              bool gen_crash_diag = true);
 [[noreturn]] LLVM_ABI void report_fatal_error(const Twine &reason,
-                                     bool gen_crash_diag = true);
+                                              bool gen_crash_diag = true);
 
 /// Report a fatal error that likely indicates a bug in LLVM. It serves a
 /// similar purpose as an assertion, but is always enabled, regardless of the
@@ -113,7 +113,7 @@ struct ScopedFatalErrorHandler {
 /// \param user_data - An argument which will be passed to the installed error
 /// handler.
 LLVM_ABI void install_bad_alloc_error_handler(fatal_error_handler_t handler,
-                                     void *user_data = nullptr);
+                                              void *user_data = nullptr);
 
 /// Restores default bad alloc error handling behavior.
 LLVM_ABI void remove_bad_alloc_error_handler();
@@ -133,14 +133,14 @@ LLVM_ABI void install_out_of_memory_new_handler();
 /// if LLVM is compiled with exception support. Otherwise prints the error
 /// to standard error and calls abort().
 [[noreturn]] LLVM_ABI void report_bad_alloc_error(const char *Reason,
-                                         bool GenCrashDiag = true);
+                                                  bool GenCrashDiag = true);
 
 /// This function calls abort(), and prints the optional message to stderr.
 /// Use the llvm_unreachable macro (that adds location info), instead of
 /// calling this function directly.
 [[noreturn]] LLVM_ABI void llvm_unreachable_internal(const char *msg = nullptr,
-                                            const char *file = nullptr,
-                                            unsigned line = 0);
+                                                     const char *file = nullptr,
+                                                     unsigned line = 0);
 } // namespace llvm
 
 /// Marks that the current location is not supposed to be reachable.

--- a/llvm/include/llvm/Support/ErrorHandling.h
+++ b/llvm/include/llvm/Support/ErrorHandling.h
@@ -40,11 +40,11 @@ typedef void (*fatal_error_handler_t)(void *user_data, const char *reason,
 ///
 /// \param user_data - An argument which will be passed to the install error
 /// handler.
-void install_fatal_error_handler(fatal_error_handler_t handler,
+LLVM_ABI void install_fatal_error_handler(fatal_error_handler_t handler,
                                  void *user_data = nullptr);
 
 /// Restores default error handling behaviour.
-void remove_fatal_error_handler();
+LLVM_ABI void remove_fatal_error_handler();
 
 /// ScopedFatalErrorHandler - This is a simple helper class which just
 /// calls install_fatal_error_handler in its constructor and
@@ -60,11 +60,11 @@ struct ScopedFatalErrorHandler {
 
 /// @deprecated Use reportFatalInternalError() or reportFatalUsageError()
 /// instead.
-[[noreturn]] void report_fatal_error(const char *reason,
+[[noreturn]] LLVM_ABI void report_fatal_error(const char *reason,
                                      bool gen_crash_diag = true);
-[[noreturn]] void report_fatal_error(StringRef reason,
+[[noreturn]] LLVM_ABI void report_fatal_error(StringRef reason,
                                      bool gen_crash_diag = true);
-[[noreturn]] void report_fatal_error(const Twine &reason,
+[[noreturn]] LLVM_ABI void report_fatal_error(const Twine &reason,
                                      bool gen_crash_diag = true);
 
 /// Report a fatal error that likely indicates a bug in LLVM. It serves a
@@ -74,9 +74,9 @@ struct ScopedFatalErrorHandler {
 /// This will call installed error handlers (or print the message by default)
 /// and then abort. This will produce a crash trace and *will* ask users to
 /// report an LLVM bug.
-[[noreturn]] void reportFatalInternalError(const char *reason);
-[[noreturn]] void reportFatalInternalError(StringRef reason);
-[[noreturn]] void reportFatalInternalError(const Twine &reason);
+[[noreturn]] LLVM_ABI void reportFatalInternalError(const char *reason);
+[[noreturn]] LLVM_ABI void reportFatalInternalError(StringRef reason);
+[[noreturn]] LLVM_ABI void reportFatalInternalError(const Twine &reason);
 
 /// Report a fatal error that does not indicate a bug in LLVM.
 ///
@@ -92,9 +92,9 @@ struct ScopedFatalErrorHandler {
 /// This will call installed error handlers (or print the message by default)
 /// and then exit with code 1. It will not produce a crash trace and will
 /// *not* ask users to report an LLVM bug.
-[[noreturn]] void reportFatalUsageError(const char *reason);
-[[noreturn]] void reportFatalUsageError(StringRef reason);
-[[noreturn]] void reportFatalUsageError(const Twine &reason);
+[[noreturn]] LLVM_ABI void reportFatalUsageError(const char *reason);
+[[noreturn]] LLVM_ABI void reportFatalUsageError(StringRef reason);
+[[noreturn]] LLVM_ABI void reportFatalUsageError(const Twine &reason);
 
 /// Installs a new bad alloc error handler that should be used whenever a
 /// bad alloc error, e.g. failing malloc/calloc, is encountered by LLVM.
@@ -112,13 +112,13 @@ struct ScopedFatalErrorHandler {
 ///
 /// \param user_data - An argument which will be passed to the installed error
 /// handler.
-void install_bad_alloc_error_handler(fatal_error_handler_t handler,
+LLVM_ABI void install_bad_alloc_error_handler(fatal_error_handler_t handler,
                                      void *user_data = nullptr);
 
 /// Restores default bad alloc error handling behavior.
-void remove_bad_alloc_error_handler();
+LLVM_ABI void remove_bad_alloc_error_handler();
 
-void install_out_of_memory_new_handler();
+LLVM_ABI void install_out_of_memory_new_handler();
 
 /// Reports a bad alloc error, calling any user defined bad alloc
 /// error handler. In contrast to the generic 'report_fatal_error'
@@ -132,13 +132,13 @@ void install_out_of_memory_new_handler();
 /// If no error handler is installed (default), throws a bad_alloc exception
 /// if LLVM is compiled with exception support. Otherwise prints the error
 /// to standard error and calls abort().
-[[noreturn]] void report_bad_alloc_error(const char *Reason,
+[[noreturn]] LLVM_ABI void report_bad_alloc_error(const char *Reason,
                                          bool GenCrashDiag = true);
 
 /// This function calls abort(), and prints the optional message to stderr.
 /// Use the llvm_unreachable macro (that adds location info), instead of
 /// calling this function directly.
-[[noreturn]] void llvm_unreachable_internal(const char *msg = nullptr,
+[[noreturn]] LLVM_ABI void llvm_unreachable_internal(const char *msg = nullptr,
                                             const char *file = nullptr,
                                             unsigned line = 0);
 } // namespace llvm

--- a/llvm/include/llvm/Support/ExponentialBackoff.h
+++ b/llvm/include/llvm/Support/ExponentialBackoff.h
@@ -12,6 +12,7 @@
 #ifndef LLVM_EXPONENTIALBACKOFF_H
 #define LLVM_EXPONENTIALBACKOFF_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Error.h"
 #include <chrono>
@@ -50,7 +51,7 @@ public:
   /// Blocks while waiting for the next attempt.
   /// \returns true if you should try again, false if the timeout has been
   /// reached.
-  bool waitForNextAttempt();
+  LLVM_ABI bool waitForNextAttempt();
 
 private:
   duration MinWait;

--- a/llvm/include/llvm/Support/ExponentialBackoff.h
+++ b/llvm/include/llvm/Support/ExponentialBackoff.h
@@ -12,8 +12,8 @@
 #ifndef LLVM_EXPONENTIALBACKOFF_H
 #define LLVM_EXPONENTIALBACKOFF_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <chrono>
 #include <random>

--- a/llvm/include/llvm/Support/ExtensibleRTTI.h
+++ b/llvm/include/llvm/Support/ExtensibleRTTI.h
@@ -60,6 +60,8 @@
 #ifndef LLVM_SUPPORT_EXTENSIBLERTTI_H
 #define LLVM_SUPPORT_EXTENSIBLERTTI_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 
 /// Base class for the extensible RTTI hierarchy.

--- a/llvm/include/llvm/Support/ExtensibleRTTI.h
+++ b/llvm/include/llvm/Support/ExtensibleRTTI.h
@@ -66,7 +66,7 @@ namespace llvm {
 ///
 /// This class defines virtual methods, dynamicClassID and isA, that enable
 /// type comparisons.
-class RTTIRoot {
+class LLVM_ABI RTTIRoot {
 public:
   virtual ~RTTIRoot() = default;
 

--- a/llvm/include/llvm/Support/FileCollector.h
+++ b/llvm/include/llvm/Support/FileCollector.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_FILECOLLECTOR_H
 #define LLVM_SUPPORT_FILECOLLECTOR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/VirtualFileSystem.h"
@@ -19,7 +20,7 @@ namespace llvm {
 class FileCollectorFileSystem;
 class Twine;
 
-class FileCollectorBase {
+class LLVM_ABI FileCollectorBase {
 public:
   FileCollectorBase();
   virtual ~FileCollectorBase();
@@ -66,7 +67,7 @@ protected:
 ///
 /// In order to preserve the relative topology of files we use their real paths
 /// as relative paths inside of the Root.
-class FileCollector : public FileCollectorBase {
+class LLVM_ABI FileCollector : public FileCollectorBase {
 public:
   /// Helper utility that encapsulates the logic for canonicalizing a virtual
   /// path and a path to copy from.
@@ -78,7 +79,7 @@ public:
     };
 
     /// Canonicalize a pair of virtual and real paths.
-    PathStorage canonicalize(StringRef SrcPath);
+    LLVM_ABI PathStorage canonicalize(StringRef SrcPath);
 
   private:
     /// Replace with a (mostly) real path, or don't modify. Resolves symlinks

--- a/llvm/include/llvm/Support/FileCollector.h
+++ b/llvm/include/llvm/Support/FileCollector.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_SUPPORT_FILECOLLECTOR_H
 #define LLVM_SUPPORT_FILECOLLECTOR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include <mutex>
 #include <string>

--- a/llvm/include/llvm/Support/FileOutputBuffer.h
+++ b/llvm/include/llvm/Support/FileOutputBuffer.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_FILEOUTPUTBUFFER_H
 #define LLVM_SUPPORT_FILEOUTPUTBUFFER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/Error.h"
@@ -45,7 +46,7 @@ public:
   /// Otherwise, the file shrinks or grows as necessary based on the value of
   /// \p Size.  It is an error to specify F_modify and Size=-1 if \p FilePath
   /// does not exist.
-  static Expected<std::unique_ptr<FileOutputBuffer>>
+  LLVM_ABI static Expected<std::unique_ptr<FileOutputBuffer>>
   create(StringRef FilePath, size_t Size, unsigned Flags = 0);
 
   /// Returns a pointer to the start of the buffer.

--- a/llvm/include/llvm/Support/FileOutputBuffer.h
+++ b/llvm/include/llvm/Support/FileOutputBuffer.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_SUPPORT_FILEOUTPUTBUFFER_H
 #define LLVM_SUPPORT_FILEOUTPUTBUFFER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/Error.h"
 

--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -26,6 +26,7 @@
 #ifndef LLVM_SUPPORT_FILESYSTEM_H
 #define LLVM_SUPPORT_FILESYSTEM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
@@ -55,7 +56,7 @@ using file_t = void *;
 using file_t = int;
 #endif
 
-extern const file_t kInvalidFile;
+LLVM_ABI extern const file_t kInvalidFile;
 
 /// An enumeration for the file system's view of the type.
 enum class file_type {
@@ -183,7 +184,7 @@ public:
   ///
   /// Also see comments on \c getLastModificationTime() related to the precision
   /// of the returned value.
-  TimePoint<> getLastAccessedTime() const;
+  LLVM_ABI TimePoint<> getLastAccessedTime() const;
 
   /// The file modification time as reported from the underlying file system.
   ///
@@ -192,7 +193,7 @@ public:
   /// There is no guarantee for what kind of resolution you can expect, the
   /// resolution can differ across platforms and even across mountpoints on the
   /// same machine.
-  TimePoint<> getLastModificationTime() const;
+  LLVM_ABI TimePoint<> getLastModificationTime() const;
 
   #if defined(LLVM_ON_UNIX)
   uint32_t getUser() const { return fs_st_uid; }
@@ -257,8 +258,8 @@ public:
         PathHash(PathHash) {}
   #endif
 
-  UniqueID getUniqueID() const;
-  uint32_t getLinkCount() const;
+  LLVM_ABI UniqueID getUniqueID() const;
+  LLVM_ABI uint32_t getLinkCount() const;
 };
 
 /// @}
@@ -274,7 +275,7 @@ public:
 /// relative/../path => <current-directory>/relative/../path
 ///
 /// @param path A path that is modified to be an absolute path.
-void make_absolute(const Twine &current_directory, SmallVectorImpl<char> &path);
+LLVM_ABI void make_absolute(const Twine &current_directory, SmallVectorImpl<char> &path);
 
 /// Make \a path an absolute path.
 ///
@@ -287,7 +288,7 @@ void make_absolute(const Twine &current_directory, SmallVectorImpl<char> &path);
 /// @param path A path that is modified to be an absolute path.
 /// @returns errc::success if \a path has been made absolute, otherwise a
 ///          platform-specific error_code.
-std::error_code make_absolute(SmallVectorImpl<char> &path);
+LLVM_ABI std::error_code make_absolute(SmallVectorImpl<char> &path);
 
 /// Create all the non-existent directories in path.
 ///
@@ -295,7 +296,7 @@ std::error_code make_absolute(SmallVectorImpl<char> &path);
 /// @returns errc::success if is_directory(path), otherwise a platform
 ///          specific error_code. If IgnoreExisting is false, also returns
 ///          error if the directory already existed.
-std::error_code create_directories(const Twine &path,
+LLVM_ABI std::error_code create_directories(const Twine &path,
                                    bool IgnoreExisting = true,
                                    perms Perms = owner_all | group_all);
 
@@ -305,7 +306,7 @@ std::error_code create_directories(const Twine &path,
 /// @returns errc::success if is_directory(path), otherwise a platform
 ///          specific error_code. If IgnoreExisting is false, also returns
 ///          error if the directory already existed.
-std::error_code create_directory(const Twine &path, bool IgnoreExisting = true,
+LLVM_ABI std::error_code create_directory(const Twine &path, bool IgnoreExisting = true,
                                  perms Perms = owner_all | group_all);
 
 /// Create a link from \a from to \a to.
@@ -319,7 +320,7 @@ std::error_code create_directory(const Twine &path, bool IgnoreExisting = true,
 /// @param from The path to hard link from. This is created.
 /// @returns errc::success if the link was created, otherwise a platform
 /// specific error_code.
-std::error_code create_link(const Twine &to, const Twine &from);
+LLVM_ABI std::error_code create_link(const Twine &to, const Twine &from);
 
 /// Create a hard link from \a from to \a to, or return an error.
 ///
@@ -327,7 +328,7 @@ std::error_code create_link(const Twine &to, const Twine &from);
 /// @param from The path to hard link from. This is created.
 /// @returns errc::success if the link was created, otherwise a platform
 /// specific error_code.
-std::error_code create_hard_link(const Twine &to, const Twine &from);
+LLVM_ABI std::error_code create_hard_link(const Twine &to, const Twine &from);
 
 /// Collapse all . and .. patterns, resolve all symlinks, and optionally
 ///        expand ~ expressions to the user's home directory.
@@ -336,28 +337,28 @@ std::error_code create_hard_link(const Twine &to, const Twine &from);
 /// @param output The location to store the resolved path.
 /// @param expand_tilde If true, resolves ~ expressions to the user's home
 ///                     directory.
-std::error_code real_path(const Twine &path, SmallVectorImpl<char> &output,
+LLVM_ABI std::error_code real_path(const Twine &path, SmallVectorImpl<char> &output,
                           bool expand_tilde = false);
 
 /// Expands ~ expressions to the user's home directory. On Unix ~user
 /// directories are resolved as well.
 ///
 /// @param path The path to resolve.
-void expand_tilde(const Twine &path, SmallVectorImpl<char> &output);
+LLVM_ABI void expand_tilde(const Twine &path, SmallVectorImpl<char> &output);
 
 /// Get the current path.
 ///
 /// @param result Holds the current path on return.
 /// @returns errc::success if the current path has been stored in result,
 ///          otherwise a platform-specific error_code.
-std::error_code current_path(SmallVectorImpl<char> &result);
+LLVM_ABI std::error_code current_path(SmallVectorImpl<char> &result);
 
 /// Set the current path.
 ///
 /// @param path The path to set.
 /// @returns errc::success if the current path was successfully set,
 ///          otherwise a platform-specific error_code.
-std::error_code set_current_path(const Twine &path);
+LLVM_ABI std::error_code set_current_path(const Twine &path);
 
 /// Remove path. Equivalent to POSIX remove().
 ///
@@ -365,14 +366,14 @@ std::error_code set_current_path(const Twine &path);
 /// @returns errc::success if path has been removed or didn't exist, otherwise a
 ///          platform-specific error code. If IgnoreNonExisting is false, also
 ///          returns error if the file didn't exist.
-std::error_code remove(const Twine &path, bool IgnoreNonExisting = true);
+LLVM_ABI std::error_code remove(const Twine &path, bool IgnoreNonExisting = true);
 
 /// Recursively delete a directory.
 ///
 /// @param path Input path.
 /// @returns errc::success if path has been removed or didn't exist, otherwise a
 ///          platform-specific error code.
-std::error_code remove_directories(const Twine &path, bool IgnoreErrors = true);
+LLVM_ABI std::error_code remove_directories(const Twine &path, bool IgnoreErrors = true);
 
 /// Rename \a from to \a to.
 ///
@@ -382,19 +383,19 @@ std::error_code remove_directories(const Twine &path, bool IgnoreErrors = true);
 ///
 /// @param from The path to rename from.
 /// @param to The path to rename to. This is created.
-std::error_code rename(const Twine &from, const Twine &to);
+LLVM_ABI std::error_code rename(const Twine &from, const Twine &to);
 
 /// Copy the contents of \a From to \a To.
 ///
 /// @param From The path to copy from.
 /// @param To The path to copy to. This is created.
-std::error_code copy_file(const Twine &From, const Twine &To);
+LLVM_ABI std::error_code copy_file(const Twine &From, const Twine &To);
 
 /// Copy the contents of \a From to \a To.
 ///
 /// @param From The path to copy from.
 /// @param ToFD The open file descriptor of the destination file.
-std::error_code copy_file(const Twine &From, int ToFD);
+LLVM_ABI std::error_code copy_file(const Twine &From, int ToFD);
 
 /// Resize path to size. File is resized as if by POSIX truncate().
 ///
@@ -402,7 +403,7 @@ std::error_code copy_file(const Twine &From, int ToFD);
 /// @param Size Size to resize to.
 /// @returns errc::success if \a path has been resized to \a size, otherwise a
 ///          platform-specific error_code.
-std::error_code resize_file(int FD, uint64_t Size);
+LLVM_ABI std::error_code resize_file(int FD, uint64_t Size);
 
 /// Resize \p FD to \p Size before mapping \a mapped_file_region::readwrite. On
 /// non-Windows, this calls \a resize_file(). On Windows, this is a no-op,
@@ -424,10 +425,10 @@ inline std::error_code resize_file_before_mapping_readwrite(int FD,
 /// @param FD Input file descriptor.
 /// @returns An MD5Result with the hash computed, if successful, otherwise a
 ///          std::error_code.
-ErrorOr<MD5::MD5Result> md5_contents(int FD);
+LLVM_ABI ErrorOr<MD5::MD5Result> md5_contents(int FD);
 
 /// Version of compute_md5 that doesn't require an open file descriptor.
-ErrorOr<MD5::MD5Result> md5_contents(const Twine &Path);
+LLVM_ABI ErrorOr<MD5::MD5Result> md5_contents(const Twine &Path);
 
 /// @}
 /// @name Physical Observers
@@ -438,7 +439,7 @@ ErrorOr<MD5::MD5Result> md5_contents(const Twine &Path);
 /// @param status A basic_file_status previously returned from stat.
 /// @returns True if the file represented by status exists, false if it does
 ///          not.
-bool exists(const basic_file_status &status);
+LLVM_ABI bool exists(const basic_file_status &status);
 
 enum class AccessMode { Exist, Write, Execute };
 
@@ -447,7 +448,7 @@ enum class AccessMode { Exist, Write, Execute };
 /// @param Path Input path.
 /// @returns errc::success if the path can be accessed, otherwise a
 ///          platform-specific error_code.
-std::error_code access(const Twine &Path, AccessMode Mode);
+LLVM_ABI std::error_code access(const Twine &Path, AccessMode Mode);
 
 /// Does file exist?
 ///
@@ -461,7 +462,7 @@ inline bool exists(const Twine &Path) {
 ///
 /// @param Path Input path.
 /// @returns True if we can execute it, false otherwise.
-bool can_execute(const Twine &Path);
+LLVM_ABI bool can_execute(const Twine &Path);
 
 /// Can we write this file?
 ///
@@ -480,7 +481,7 @@ inline bool can_write(const Twine &Path) {
 ///
 /// @returns True if A and B both represent the same file system entity, false
 ///          otherwise.
-bool equivalent(file_status A, file_status B);
+LLVM_ABI bool equivalent(file_status A, file_status B);
 
 /// Do paths represent the same thing?
 ///
@@ -492,7 +493,7 @@ bool equivalent(file_status A, file_status B);
 ///               inode (or equivalent).
 /// @returns errc::success if result has been successfully set, otherwise a
 ///          platform-specific error_code.
-std::error_code equivalent(const Twine &A, const Twine &B, bool &result);
+LLVM_ABI std::error_code equivalent(const Twine &A, const Twine &B, bool &result);
 
 /// Simpler version of equivalent for clients that don't need to
 ///        differentiate between an error and false.
@@ -508,10 +509,10 @@ inline bool equivalent(const Twine &A, const Twine &B) {
 ///               false if it is not.
 /// @returns errc::success if result has been successfully set, otherwise a
 ///          platform specific error_code.
-std::error_code is_local(const Twine &path, bool &result);
+LLVM_ABI std::error_code is_local(const Twine &path, bool &result);
 
 /// Version of is_local accepting an open file descriptor.
-std::error_code is_local(int FD, bool &result);
+LLVM_ABI std::error_code is_local(int FD, bool &result);
 
 /// Simpler version of is_local for clients that don't need to
 ///        differentiate between an error and false.
@@ -533,13 +534,13 @@ inline bool is_local(int FD) {
 /// @param Follow For symbolic links, indicates whether to return the file type
 ///               of the link itself, or of the target.
 /// @returns A value from the file_type enumeration indicating the type of file.
-file_type get_file_type(const Twine &Path, bool Follow = true);
+LLVM_ABI file_type get_file_type(const Twine &Path, bool Follow = true);
 
 /// Does status represent a directory?
 ///
 /// @param status A basic_file_status previously returned from status.
 /// @returns status.type() == file_type::directory_file.
-bool is_directory(const basic_file_status &status);
+LLVM_ABI bool is_directory(const basic_file_status &status);
 
 /// Is path a directory?
 ///
@@ -548,7 +549,7 @@ bool is_directory(const basic_file_status &status);
 ///               symlinks, false if it is not. Undefined otherwise.
 /// @returns errc::success if result has been successfully set, otherwise a
 ///          platform-specific error_code.
-std::error_code is_directory(const Twine &path, bool &result);
+LLVM_ABI std::error_code is_directory(const Twine &path, bool &result);
 
 /// Simpler version of is_directory for clients that don't need to
 ///        differentiate between an error and false.
@@ -561,7 +562,7 @@ inline bool is_directory(const Twine &Path) {
 ///
 /// @param status A basic_file_status previously returned from status.
 /// @returns status_known(status) && status.type() == file_type::regular_file.
-bool is_regular_file(const basic_file_status &status);
+LLVM_ABI bool is_regular_file(const basic_file_status &status);
 
 /// Is path a regular file?
 ///
@@ -570,7 +571,7 @@ bool is_regular_file(const basic_file_status &status);
 ///               symlinks), false if it is not. Undefined otherwise.
 /// @returns errc::success if result has been successfully set, otherwise a
 ///          platform-specific error_code.
-std::error_code is_regular_file(const Twine &path, bool &result);
+LLVM_ABI std::error_code is_regular_file(const Twine &path, bool &result);
 
 /// Simpler version of is_regular_file for clients that don't need to
 ///        differentiate between an error and false.
@@ -585,7 +586,7 @@ inline bool is_regular_file(const Twine &Path) {
 ///
 /// @param status A basic_file_status previously returned from status.
 /// @returns status_known(status) && status.type() == file_type::symlink_file.
-bool is_symlink_file(const basic_file_status &status);
+LLVM_ABI bool is_symlink_file(const basic_file_status &status);
 
 /// Is path a symlink file?
 ///
@@ -594,7 +595,7 @@ bool is_symlink_file(const basic_file_status &status);
 ///               Undefined otherwise.
 /// @returns errc::success if result has been successfully set, otherwise a
 ///          platform-specific error_code.
-std::error_code is_symlink_file(const Twine &path, bool &result);
+LLVM_ABI std::error_code is_symlink_file(const Twine &path, bool &result);
 
 /// Simpler version of is_symlink_file for clients that don't need to
 ///        differentiate between an error and false.
@@ -610,7 +611,7 @@ inline bool is_symlink_file(const Twine &Path) {
 ///
 /// @param status A basic_file_status previously returned from status.
 /// @returns exists(s) && !is_regular_file(s) && !is_directory(s)
-bool is_other(const basic_file_status &status);
+LLVM_ABI bool is_other(const basic_file_status &status);
 
 /// Is path something that exists but is not a directory,
 ///        regular file, or symlink?
@@ -620,7 +621,7 @@ bool is_other(const basic_file_status &status);
 ///               file, or a symlink, false if it does not. Undefined otherwise.
 /// @returns errc::success if result has been successfully set, otherwise a
 ///          platform-specific error_code.
-std::error_code is_other(const Twine &path, bool &result);
+LLVM_ABI std::error_code is_other(const Twine &path, bool &result);
 
 /// Get file status as if by POSIX stat().
 ///
@@ -630,11 +631,11 @@ std::error_code is_other(const Twine &path, bool &result);
 ///               statted.
 /// @returns errc::success if result has been successfully set, otherwise a
 ///          platform-specific error_code.
-std::error_code status(const Twine &path, file_status &result,
+LLVM_ABI std::error_code status(const Twine &path, file_status &result,
                        bool follow = true);
 
 /// A version for when a file descriptor is already available.
-std::error_code status(int FD, file_status &Result);
+LLVM_ABI std::error_code status(int FD, file_status &Result);
 
 #ifdef _WIN32
 /// A version for when a file descriptor is already available.
@@ -647,7 +648,7 @@ std::error_code status(file_t FD, file_status &Result);
 /// @note There is no umask on Windows. This function returns 0 always
 ///       on Windows. This function does not return an error_code because
 ///       umask(2) never fails. It is not thread safe.
-unsigned getUmask();
+LLVM_ABI unsigned getUmask();
 
 /// Set file permissions.
 ///
@@ -658,12 +659,12 @@ unsigned getUmask();
 /// @note On Windows, all permissions except *_write are ignored. Using any of
 ///       owner_write, group_write, or all_write will make the file writable.
 ///       Otherwise, the file will be marked as read-only.
-std::error_code setPermissions(const Twine &Path, perms Permissions);
+LLVM_ABI std::error_code setPermissions(const Twine &Path, perms Permissions);
 
 /// Vesion of setPermissions accepting a file descriptor.
 /// TODO Delete the path based overload once we implement the FD based overload
 /// on Windows.
-std::error_code setPermissions(int FD, perms Permissions);
+LLVM_ABI std::error_code setPermissions(int FD, perms Permissions);
 
 /// Get file permissions.
 ///
@@ -673,7 +674,7 @@ std::error_code setPermissions(int FD, perms Permissions);
 /// @note On Windows, if the file does not have the FILE_ATTRIBUTE_READONLY
 ///       attribute, all_all will be returned. Otherwise, all_read | all_exe
 ///       will be returned.
-ErrorOr<perms> getPermissions(const Twine &Path);
+LLVM_ABI ErrorOr<perms> getPermissions(const Twine &Path);
 
 /// Get file size.
 ///
@@ -695,7 +696,7 @@ inline std::error_code file_size(const Twine &Path, uint64_t &Result) {
 /// @returns errc::success if the file times were successfully set, otherwise a
 ///          platform-specific error_code or errc::function_not_supported on
 ///          platforms where the functionality isn't available.
-std::error_code setLastAccessAndModificationTime(int FD, TimePoint<> AccessTime,
+LLVM_ABI std::error_code setLastAccessAndModificationTime(int FD, TimePoint<> AccessTime,
                                                  TimePoint<> ModificationTime);
 
 /// Simpler version that sets both file modification and access time to the same
@@ -709,7 +710,7 @@ inline std::error_code setLastAccessAndModificationTime(int FD,
 ///
 /// @param s Input file status.
 /// @returns True if status() != status_error.
-bool status_known(const basic_file_status &s);
+LLVM_ABI bool status_known(const basic_file_status &s);
 
 /// Is status available?
 ///
@@ -717,7 +718,7 @@ bool status_known(const basic_file_status &s);
 /// @param result Set to true if status() != status_error.
 /// @returns errc::success if result has been successfully set, otherwise a
 ///          platform-specific error_code.
-std::error_code status_known(const Twine &path, bool &result);
+LLVM_ABI std::error_code status_known(const Twine &path, bool &result);
 
 enum CreationDisposition : unsigned {
   /// CD_CreateAlways - When opening a file:
@@ -796,7 +797,7 @@ enum OpenFlags : unsigned {
 /// @param Model Name to base unique path off of.
 /// @param ResultPath Set to the file's path.
 /// @param MakeAbsolute Whether to use the system temp directory.
-void createUniquePath(const Twine &Model, SmallVectorImpl<char> &ResultPath,
+LLVM_ABI void createUniquePath(const Twine &Model, SmallVectorImpl<char> &ResultPath,
                       bool MakeAbsolute);
 
 /// Create a uniquely named file.
@@ -822,14 +823,14 @@ void createUniquePath(const Twine &Model, SmallVectorImpl<char> &ResultPath,
 /// @param Mode Set to the opened file's permissions.
 /// @returns errc::success if Result{FD,Path} have been successfully set,
 ///          otherwise a platform-specific error_code.
-std::error_code createUniqueFile(const Twine &Model, int &ResultFD,
+LLVM_ABI std::error_code createUniqueFile(const Twine &Model, int &ResultFD,
                                  SmallVectorImpl<char> &ResultPath,
                                  OpenFlags Flags = OF_None,
                                  unsigned Mode = all_read | all_write);
 
 /// Simpler version for clients that don't want an open file. An empty
 /// file will still be created.
-std::error_code createUniqueFile(const Twine &Model,
+LLVM_ABI std::error_code createUniqueFile(const Twine &Model,
                                  SmallVectorImpl<char> &ResultPath,
                                  unsigned Mode = all_read | all_write);
 
@@ -847,11 +848,11 @@ class TempFile {
 public:
   /// This creates a temporary file with createUniqueFile and schedules it for
   /// deletion with sys::RemoveFileOnSignal.
-  static Expected<TempFile> create(const Twine &Model,
+  LLVM_ABI static Expected<TempFile> create(const Twine &Model,
                                    unsigned Mode = all_read | all_write,
                                    OpenFlags ExtraFlags = OF_None);
-  TempFile(TempFile &&Other);
-  TempFile &operator=(TempFile &&Other);
+  LLVM_ABI TempFile(TempFile &&Other);
+  LLVM_ABI TempFile &operator=(TempFile &&Other);
 
   // Name of the temporary file.
   std::string TmpName;
@@ -865,16 +866,16 @@ public:
 #endif
 
   // Keep this with the given name.
-  Error keep(const Twine &Name);
+  LLVM_ABI Error keep(const Twine &Name);
 
   // Keep this with the temporary name.
-  Error keep();
+  LLVM_ABI Error keep();
 
   // Delete the file.
-  Error discard();
+  LLVM_ABI Error discard();
 
   // This checks that keep or delete was called.
-  ~TempFile();
+  LLVM_ABI ~TempFile();
 };
 
 /// Create a file in the system temporary directory.
@@ -885,18 +886,18 @@ public:
 ///
 /// This should be used for things like a temporary .s that is removed after
 /// running the assembler.
-std::error_code createTemporaryFile(const Twine &Prefix, StringRef Suffix,
+LLVM_ABI std::error_code createTemporaryFile(const Twine &Prefix, StringRef Suffix,
                                     int &ResultFD,
                                     SmallVectorImpl<char> &ResultPath,
                                     OpenFlags Flags = OF_None);
 
 /// Simpler version for clients that don't want an open file. An empty
 /// file will still be created.
-std::error_code createTemporaryFile(const Twine &Prefix, StringRef Suffix,
+LLVM_ABI std::error_code createTemporaryFile(const Twine &Prefix, StringRef Suffix,
                                     SmallVectorImpl<char> &ResultPath,
                                     OpenFlags Flags = OF_None);
 
-std::error_code createUniqueDirectory(const Twine &Prefix,
+LLVM_ABI std::error_code createUniqueDirectory(const Twine &Prefix,
                                       SmallVectorImpl<char> &ResultPath);
 
 /// Get a unique name, not currently exisiting in the filesystem. Subject
@@ -906,7 +907,7 @@ std::error_code createUniqueDirectory(const Twine &Prefix,
 /// checks if it exists. This function is subject to race conditions, if you
 /// want to use the returned name to actually create a file, use
 /// createUniqueFile instead.
-std::error_code getPotentiallyUniqueFileName(const Twine &Model,
+LLVM_ABI std::error_code getPotentiallyUniqueFileName(const Twine &Model,
                                              SmallVectorImpl<char> &ResultPath);
 
 /// Get a unique temporary file name, not currently exisiting in the
@@ -917,7 +918,7 @@ std::error_code getPotentiallyUniqueFileName(const Twine &Model,
 /// checks if it exists. This function is subject to race conditions, if you
 /// want to use the returned name to actually create a file, use
 /// createTemporaryFile instead.
-std::error_code
+LLVM_ABI std::error_code
 getPotentiallyUniqueTempFileName(const Twine &Prefix, StringRef Suffix,
                                  SmallVectorImpl<char> &ResultPath);
 
@@ -955,7 +956,7 @@ inline FileAccess &operator|=(FileAccess &A, FileAccess B) {
 /// @param Mode The access permissions of the file, represented in octal.
 /// @returns errc::success if \a Name has been opened, otherwise a
 ///          platform-specific error_code.
-std::error_code openFile(const Twine &Name, int &ResultFD,
+LLVM_ABI std::error_code openFile(const Twine &Name, int &ResultFD,
                          CreationDisposition Disp, FileAccess Access,
                          OpenFlags Flags, unsigned Mode = 0666);
 
@@ -973,7 +974,7 @@ std::error_code openFile(const Twine &Name, int &ResultFD,
 /// @param Mode The access permissions of the file, represented in octal.
 /// @returns errc::success if \a Name has been opened, otherwise a
 ///          platform-specific error_code.
-Expected<file_t> openNativeFile(const Twine &Name, CreationDisposition Disp,
+LLVM_ABI Expected<file_t> openNativeFile(const Twine &Name, CreationDisposition Disp,
                                 FileAccess Access, OpenFlags Flags,
                                 unsigned Mode = 0666);
 
@@ -988,15 +989,15 @@ inline file_t convertFDToNativeFile(int FD) { return FD; }
 
 /// Return an open handle to standard in. On Unix, this is typically FD 0.
 /// Returns kInvalidFile when the stream is closed.
-file_t getStdinHandle();
+LLVM_ABI file_t getStdinHandle();
 
 /// Return an open handle to standard out. On Unix, this is typically FD 1.
 /// Returns kInvalidFile when the stream is closed.
-file_t getStdoutHandle();
+LLVM_ABI file_t getStdoutHandle();
 
 /// Return an open handle to standard error. On Unix, this is typically FD 2.
 /// Returns kInvalidFile when the stream is closed.
-file_t getStderrHandle();
+LLVM_ABI file_t getStderrHandle();
 
 /// Reads \p Buf.size() bytes from \p FileHandle into \p Buf. Returns the number
 /// of bytes actually read. On Unix, this is equivalent to `return ::read(FD,
@@ -1005,7 +1006,7 @@ file_t getStderrHandle();
 /// @param FileHandle File to read from.
 /// @param Buf Buffer to read into.
 /// @returns The number of bytes read, or error.
-Expected<size_t> readNativeFile(file_t FileHandle, MutableArrayRef<char> Buf);
+LLVM_ABI Expected<size_t> readNativeFile(file_t FileHandle, MutableArrayRef<char> Buf);
 
 /// Default chunk size for \a readNativeFileToEOF().
 enum : size_t { DefaultReadChunkSize = 4 * 4096 };
@@ -1023,7 +1024,7 @@ enum : size_t { DefaultReadChunkSize = 4 * 4096 };
 /// \param Buffer Where to put the file content.
 /// \param ChunkSize Size of chunks.
 /// \returns The error if EOF was not found.
-Error readNativeFileToEOF(file_t FileHandle, SmallVectorImpl<char> &Buffer,
+LLVM_ABI Error readNativeFileToEOF(file_t FileHandle, SmallVectorImpl<char> &Buffer,
                           ssize_t ChunkSize = DefaultReadChunkSize);
 
 /// Reads \p Buf.size() bytes from \p FileHandle at offset \p Offset into \p
@@ -1035,7 +1036,7 @@ Error readNativeFileToEOF(file_t FileHandle, SmallVectorImpl<char> &Buffer,
 /// @param Buf Buffer to read into.
 /// @param Offset Offset into the file at which the read should occur.
 /// @returns The number of bytes read, or error.
-Expected<size_t> readNativeFileSlice(file_t FileHandle,
+LLVM_ABI Expected<size_t> readNativeFileSlice(file_t FileHandle,
                                      MutableArrayRef<char> Buf,
                                      uint64_t Offset);
 
@@ -1137,7 +1138,7 @@ inline Expected<file_t> openNativeFileForReadWrite(const Twine &Name,
 ///                 location.
 /// @returns errc::success if \a Name has been opened, otherwise a
 ///          platform-specific error_code.
-std::error_code openFileForRead(const Twine &Name, int &ResultFD,
+LLVM_ABI std::error_code openFileForRead(const Twine &Name, int &ResultFD,
                                 OpenFlags Flags = OF_None,
                                 SmallVectorImpl<char> *RealPath = nullptr);
 
@@ -1153,7 +1154,7 @@ std::error_code openFileForRead(const Twine &Name, int &ResultFD,
 ///                 location.
 /// @returns a platform-specific file descriptor if \a Name has been opened,
 ///          otherwise an error object.
-Expected<file_t>
+LLVM_ABI Expected<file_t>
 openNativeFileForRead(const Twine &Name, OpenFlags Flags = OF_None,
                       SmallVectorImpl<char> *RealPath = nullptr);
 
@@ -1178,21 +1179,21 @@ openNativeFileForRead(const Twine &Name, OpenFlags Flags = OF_None,
 /// context, as it may not prevent other threads in the same process from
 /// obtaining a lock on the same file, even if they are using a different file
 /// descriptor.
-std::error_code
+LLVM_ABI std::error_code
 tryLockFile(int FD,
             std::chrono::milliseconds Timeout = std::chrono::milliseconds(0));
 
 /// Lock the file.
 ///
 /// This function acts as @ref tryLockFile but it waits infinitely.
-std::error_code lockFile(int FD);
+LLVM_ABI std::error_code lockFile(int FD);
 
 /// Unlock the file.
 ///
 /// @param FD The descriptor representing the file to unlock.
 /// @returns errc::success if lock is successfully released or platform-specific
 /// error_code otherwise.
-std::error_code unlockFile(int FD);
+LLVM_ABI std::error_code unlockFile(int FD);
 
 /// @brief Close the file object.  This should be used instead of ::close for
 /// portability. On error, the caller should assume the file is closed, as is
@@ -1203,7 +1204,7 @@ std::error_code unlockFile(int FD);
 ///
 /// @returns An error code if closing the file failed. Typically, an error here
 /// means that the filesystem may have failed to perform some buffered writes.
-std::error_code closeFile(file_t &F);
+LLVM_ABI std::error_code closeFile(file_t &F);
 
 #ifdef LLVM_ON_UNIX
 /// @brief Change ownership of a file.
@@ -1212,7 +1213,7 @@ std::error_code closeFile(file_t &F);
 /// @param Group The group of the file to change to.
 /// @returns errc::success if successfully updated file ownership, otherwise an
 ///          error code is returned.
-std::error_code changeFileOwnership(int FD, uint32_t Owner, uint32_t Group);
+LLVM_ABI std::error_code changeFileOwnership(int FD, uint32_t Owner, uint32_t Group);
 #endif
 
 /// RAII class that facilitates file locking.
@@ -1244,7 +1245,7 @@ public:
   }
 };
 
-std::error_code getUniqueID(const Twine Path, UniqueID &Result);
+LLVM_ABI std::error_code getUniqueID(const Twine Path, UniqueID &Result);
 
 /// Get disk space usage information.
 ///
@@ -1255,7 +1256,7 @@ std::error_code getUniqueID(const Twine Path, UniqueID &Result);
 /// @returns a space_info structure filled with the capacity, free, and
 /// available space on the device \a Path is on. A platform specific error_code
 /// is returned on error.
-ErrorOr<space_info> disk_space(const Twine &Path);
+LLVM_ABI ErrorOr<space_info> disk_space(const Twine &Path);
 
 /// This class represents a memory mapped file. It is based on
 /// boost::iostreams::mapped_file.
@@ -1308,7 +1309,7 @@ public:
   mapped_file_region &operator=(const mapped_file_region &) = delete;
 
   /// \param fd An open file descriptor to map. Does not take ownership of fd.
-  mapped_file_region(sys::fs::file_t fd, mapmode mode, size_t length, uint64_t offset,
+  LLVM_ABI mapped_file_region(sys::fs::file_t fd, mapmode mode, size_t length, uint64_t offset,
                      std::error_code &ec);
 
   ~mapped_file_region() { unmapImpl(); }
@@ -1323,21 +1324,21 @@ public:
   }
   void dontNeed() { dontNeedImpl(); }
 
-  size_t size() const;
-  char *data() const;
+  LLVM_ABI size_t size() const;
+  LLVM_ABI char *data() const;
 
   /// Get a const view of the data. Modifying this memory has undefined
   /// behavior.
-  const char *const_data() const;
+  LLVM_ABI const char *const_data() const;
 
   /// \returns The minimum alignment offset must be.
-  static int alignment();
+  LLVM_ABI static int alignment();
 };
 
 /// Return the path to the main executable, given the value of argv[0] from
 /// program startup and the address of main itself. In extremis, this function
 /// may fail and return an empty path.
-std::string getMainExecutable(const char *argv0, void *MainExecAddr);
+LLVM_ABI std::string getMainExecutable(const char *argv0, void *MainExecAddr);
 
 /// @}
 /// @name Iterators
@@ -1364,14 +1365,14 @@ public:
 
   directory_entry() = default;
 
-  void replace_filename(const Twine &Filename, file_type Type,
+  LLVM_ABI void replace_filename(const Twine &Filename, file_type Type,
                         basic_file_status Status = basic_file_status());
 
   const std::string &path() const { return Path; }
   // Get basic information about entry file (a subset of fs::status()).
   // On most platforms this is a stat() call.
   // On windows the information was already retrieved from the directory.
-  ErrorOr<basic_file_status> status() const;
+  LLVM_ABI ErrorOr<basic_file_status> status() const;
   // Get the type of this file.
   // On most platforms (Linux/Mac/Windows/BSD), this was already retrieved.
   // On some platforms (e.g. Solaris) this is a stat() call.
@@ -1384,19 +1385,19 @@ public:
 
   bool operator==(const directory_entry& RHS) const { return Path == RHS.Path; }
   bool operator!=(const directory_entry& RHS) const { return !(*this == RHS); }
-  bool operator< (const directory_entry& RHS) const;
-  bool operator<=(const directory_entry& RHS) const;
-  bool operator> (const directory_entry& RHS) const;
-  bool operator>=(const directory_entry& RHS) const;
+  LLVM_ABI bool operator< (const directory_entry& RHS) const;
+  LLVM_ABI bool operator<=(const directory_entry& RHS) const;
+  LLVM_ABI bool operator> (const directory_entry& RHS) const;
+  LLVM_ABI bool operator>=(const directory_entry& RHS) const;
 };
 
 namespace detail {
 
   struct DirIterState;
 
-  std::error_code directory_iterator_construct(DirIterState &, StringRef, bool);
-  std::error_code directory_iterator_increment(DirIterState &);
-  std::error_code directory_iterator_destruct(DirIterState &);
+  LLVM_ABI std::error_code directory_iterator_construct(DirIterState &, StringRef, bool);
+  LLVM_ABI std::error_code directory_iterator_increment(DirIterState &);
+  LLVM_ABI std::error_code directory_iterator_destruct(DirIterState &);
 
   /// Keeps state for the directory_iterator.
   struct DirIterState {

--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -26,12 +26,12 @@
 #ifndef LLVM_SUPPORT_FILESYSTEM_H
 #define LLVM_SUPPORT_FILESYSTEM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/Chrono.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/ErrorOr.h"
@@ -195,11 +195,11 @@ public:
   /// same machine.
   LLVM_ABI TimePoint<> getLastModificationTime() const;
 
-  #if defined(LLVM_ON_UNIX)
+#if defined(LLVM_ON_UNIX)
   uint32_t getUser() const { return fs_st_uid; }
   uint32_t getGroup() const { return fs_st_gid; }
   uint64_t getSize() const { return fs_st_size; }
-  #elif defined (_WIN32)
+#elif defined(_WIN32)
   uint32_t getUser() const {
     return 9999; // Not applicable to Windows, so...
   }
@@ -211,7 +211,7 @@ public:
   uint64_t getSize() const {
     return (uint64_t(FileSizeHigh) << 32) + FileSizeLow;
   }
-  #endif
+#endif
 
   // setters
   void type(file_type v) { Type = v; }
@@ -275,7 +275,8 @@ public:
 /// relative/../path => <current-directory>/relative/../path
 ///
 /// @param path A path that is modified to be an absolute path.
-LLVM_ABI void make_absolute(const Twine &current_directory, SmallVectorImpl<char> &path);
+LLVM_ABI void make_absolute(const Twine &current_directory,
+                            SmallVectorImpl<char> &path);
 
 /// Make \a path an absolute path.
 ///
@@ -296,9 +297,9 @@ LLVM_ABI std::error_code make_absolute(SmallVectorImpl<char> &path);
 /// @returns errc::success if is_directory(path), otherwise a platform
 ///          specific error_code. If IgnoreExisting is false, also returns
 ///          error if the directory already existed.
-LLVM_ABI std::error_code create_directories(const Twine &path,
-                                   bool IgnoreExisting = true,
-                                   perms Perms = owner_all | group_all);
+LLVM_ABI std::error_code
+create_directories(const Twine &path, bool IgnoreExisting = true,
+                   perms Perms = owner_all | group_all);
 
 /// Create the directory in path.
 ///
@@ -306,8 +307,9 @@ LLVM_ABI std::error_code create_directories(const Twine &path,
 /// @returns errc::success if is_directory(path), otherwise a platform
 ///          specific error_code. If IgnoreExisting is false, also returns
 ///          error if the directory already existed.
-LLVM_ABI std::error_code create_directory(const Twine &path, bool IgnoreExisting = true,
-                                 perms Perms = owner_all | group_all);
+LLVM_ABI std::error_code create_directory(const Twine &path,
+                                          bool IgnoreExisting = true,
+                                          perms Perms = owner_all | group_all);
 
 /// Create a link from \a from to \a to.
 ///
@@ -337,8 +339,9 @@ LLVM_ABI std::error_code create_hard_link(const Twine &to, const Twine &from);
 /// @param output The location to store the resolved path.
 /// @param expand_tilde If true, resolves ~ expressions to the user's home
 ///                     directory.
-LLVM_ABI std::error_code real_path(const Twine &path, SmallVectorImpl<char> &output,
-                          bool expand_tilde = false);
+LLVM_ABI std::error_code real_path(const Twine &path,
+                                   SmallVectorImpl<char> &output,
+                                   bool expand_tilde = false);
 
 /// Expands ~ expressions to the user's home directory. On Unix ~user
 /// directories are resolved as well.
@@ -366,14 +369,16 @@ LLVM_ABI std::error_code set_current_path(const Twine &path);
 /// @returns errc::success if path has been removed or didn't exist, otherwise a
 ///          platform-specific error code. If IgnoreNonExisting is false, also
 ///          returns error if the file didn't exist.
-LLVM_ABI std::error_code remove(const Twine &path, bool IgnoreNonExisting = true);
+LLVM_ABI std::error_code remove(const Twine &path,
+                                bool IgnoreNonExisting = true);
 
 /// Recursively delete a directory.
 ///
 /// @param path Input path.
 /// @returns errc::success if path has been removed or didn't exist, otherwise a
 ///          platform-specific error code.
-LLVM_ABI std::error_code remove_directories(const Twine &path, bool IgnoreErrors = true);
+LLVM_ABI std::error_code remove_directories(const Twine &path,
+                                            bool IgnoreErrors = true);
 
 /// Rename \a from to \a to.
 ///
@@ -493,7 +498,8 @@ LLVM_ABI bool equivalent(file_status A, file_status B);
 ///               inode (or equivalent).
 /// @returns errc::success if result has been successfully set, otherwise a
 ///          platform-specific error_code.
-LLVM_ABI std::error_code equivalent(const Twine &A, const Twine &B, bool &result);
+LLVM_ABI std::error_code equivalent(const Twine &A, const Twine &B,
+                                    bool &result);
 
 /// Simpler version of equivalent for clients that don't need to
 ///        differentiate between an error and false.
@@ -632,7 +638,7 @@ LLVM_ABI std::error_code is_other(const Twine &path, bool &result);
 /// @returns errc::success if result has been successfully set, otherwise a
 ///          platform-specific error_code.
 LLVM_ABI std::error_code status(const Twine &path, file_status &result,
-                       bool follow = true);
+                                bool follow = true);
 
 /// A version for when a file descriptor is already available.
 LLVM_ABI std::error_code status(int FD, file_status &Result);
@@ -696,8 +702,9 @@ inline std::error_code file_size(const Twine &Path, uint64_t &Result) {
 /// @returns errc::success if the file times were successfully set, otherwise a
 ///          platform-specific error_code or errc::function_not_supported on
 ///          platforms where the functionality isn't available.
-LLVM_ABI std::error_code setLastAccessAndModificationTime(int FD, TimePoint<> AccessTime,
-                                                 TimePoint<> ModificationTime);
+LLVM_ABI std::error_code
+setLastAccessAndModificationTime(int FD, TimePoint<> AccessTime,
+                                 TimePoint<> ModificationTime);
 
 /// Simpler version that sets both file modification and access time to the same
 /// time.
@@ -797,8 +804,9 @@ enum OpenFlags : unsigned {
 /// @param Model Name to base unique path off of.
 /// @param ResultPath Set to the file's path.
 /// @param MakeAbsolute Whether to use the system temp directory.
-LLVM_ABI void createUniquePath(const Twine &Model, SmallVectorImpl<char> &ResultPath,
-                      bool MakeAbsolute);
+LLVM_ABI void createUniquePath(const Twine &Model,
+                               SmallVectorImpl<char> &ResultPath,
+                               bool MakeAbsolute);
 
 /// Create a uniquely named file.
 ///
@@ -824,15 +832,15 @@ LLVM_ABI void createUniquePath(const Twine &Model, SmallVectorImpl<char> &Result
 /// @returns errc::success if Result{FD,Path} have been successfully set,
 ///          otherwise a platform-specific error_code.
 LLVM_ABI std::error_code createUniqueFile(const Twine &Model, int &ResultFD,
-                                 SmallVectorImpl<char> &ResultPath,
-                                 OpenFlags Flags = OF_None,
-                                 unsigned Mode = all_read | all_write);
+                                          SmallVectorImpl<char> &ResultPath,
+                                          OpenFlags Flags = OF_None,
+                                          unsigned Mode = all_read | all_write);
 
 /// Simpler version for clients that don't want an open file. An empty
 /// file will still be created.
 LLVM_ABI std::error_code createUniqueFile(const Twine &Model,
-                                 SmallVectorImpl<char> &ResultPath,
-                                 unsigned Mode = all_read | all_write);
+                                          SmallVectorImpl<char> &ResultPath,
+                                          unsigned Mode = all_read | all_write);
 
 /// Represents a temporary file.
 ///
@@ -848,9 +856,9 @@ class TempFile {
 public:
   /// This creates a temporary file with createUniqueFile and schedules it for
   /// deletion with sys::RemoveFileOnSignal.
-  LLVM_ABI static Expected<TempFile> create(const Twine &Model,
-                                   unsigned Mode = all_read | all_write,
-                                   OpenFlags ExtraFlags = OF_None);
+  LLVM_ABI static Expected<TempFile>
+  create(const Twine &Model, unsigned Mode = all_read | all_write,
+         OpenFlags ExtraFlags = OF_None);
   LLVM_ABI TempFile(TempFile &&Other);
   LLVM_ABI TempFile &operator=(TempFile &&Other);
 
@@ -886,19 +894,20 @@ public:
 ///
 /// This should be used for things like a temporary .s that is removed after
 /// running the assembler.
-LLVM_ABI std::error_code createTemporaryFile(const Twine &Prefix, StringRef Suffix,
-                                    int &ResultFD,
-                                    SmallVectorImpl<char> &ResultPath,
-                                    OpenFlags Flags = OF_None);
+LLVM_ABI std::error_code createTemporaryFile(const Twine &Prefix,
+                                             StringRef Suffix, int &ResultFD,
+                                             SmallVectorImpl<char> &ResultPath,
+                                             OpenFlags Flags = OF_None);
 
 /// Simpler version for clients that don't want an open file. An empty
 /// file will still be created.
-LLVM_ABI std::error_code createTemporaryFile(const Twine &Prefix, StringRef Suffix,
-                                    SmallVectorImpl<char> &ResultPath,
-                                    OpenFlags Flags = OF_None);
+LLVM_ABI std::error_code createTemporaryFile(const Twine &Prefix,
+                                             StringRef Suffix,
+                                             SmallVectorImpl<char> &ResultPath,
+                                             OpenFlags Flags = OF_None);
 
-LLVM_ABI std::error_code createUniqueDirectory(const Twine &Prefix,
-                                      SmallVectorImpl<char> &ResultPath);
+LLVM_ABI std::error_code
+createUniqueDirectory(const Twine &Prefix, SmallVectorImpl<char> &ResultPath);
 
 /// Get a unique name, not currently exisiting in the filesystem. Subject
 /// to race conditions, prefer to use createUniqueFile instead.
@@ -907,8 +916,9 @@ LLVM_ABI std::error_code createUniqueDirectory(const Twine &Prefix,
 /// checks if it exists. This function is subject to race conditions, if you
 /// want to use the returned name to actually create a file, use
 /// createUniqueFile instead.
-LLVM_ABI std::error_code getPotentiallyUniqueFileName(const Twine &Model,
-                                             SmallVectorImpl<char> &ResultPath);
+LLVM_ABI std::error_code
+getPotentiallyUniqueFileName(const Twine &Model,
+                             SmallVectorImpl<char> &ResultPath);
 
 /// Get a unique temporary file name, not currently exisiting in the
 /// filesystem. Subject to race conditions, prefer to use createTemporaryFile
@@ -957,8 +967,8 @@ inline FileAccess &operator|=(FileAccess &A, FileAccess B) {
 /// @returns errc::success if \a Name has been opened, otherwise a
 ///          platform-specific error_code.
 LLVM_ABI std::error_code openFile(const Twine &Name, int &ResultFD,
-                         CreationDisposition Disp, FileAccess Access,
-                         OpenFlags Flags, unsigned Mode = 0666);
+                                  CreationDisposition Disp, FileAccess Access,
+                                  OpenFlags Flags, unsigned Mode = 0666);
 
 /// @brief Opens a file with the specified creation disposition, access mode,
 /// and flags and returns a platform-specific file object.
@@ -974,9 +984,10 @@ LLVM_ABI std::error_code openFile(const Twine &Name, int &ResultFD,
 /// @param Mode The access permissions of the file, represented in octal.
 /// @returns errc::success if \a Name has been opened, otherwise a
 ///          platform-specific error_code.
-LLVM_ABI Expected<file_t> openNativeFile(const Twine &Name, CreationDisposition Disp,
-                                FileAccess Access, OpenFlags Flags,
-                                unsigned Mode = 0666);
+LLVM_ABI Expected<file_t> openNativeFile(const Twine &Name,
+                                         CreationDisposition Disp,
+                                         FileAccess Access, OpenFlags Flags,
+                                         unsigned Mode = 0666);
 
 /// Converts from a Posix file descriptor number to a native file handle.
 /// On Windows, this retreives the underlying handle. On non-Windows, this is a
@@ -1006,7 +1017,8 @@ LLVM_ABI file_t getStderrHandle();
 /// @param FileHandle File to read from.
 /// @param Buf Buffer to read into.
 /// @returns The number of bytes read, or error.
-LLVM_ABI Expected<size_t> readNativeFile(file_t FileHandle, MutableArrayRef<char> Buf);
+LLVM_ABI Expected<size_t> readNativeFile(file_t FileHandle,
+                                         MutableArrayRef<char> Buf);
 
 /// Default chunk size for \a readNativeFileToEOF().
 enum : size_t { DefaultReadChunkSize = 4 * 4096 };
@@ -1024,8 +1036,9 @@ enum : size_t { DefaultReadChunkSize = 4 * 4096 };
 /// \param Buffer Where to put the file content.
 /// \param ChunkSize Size of chunks.
 /// \returns The error if EOF was not found.
-LLVM_ABI Error readNativeFileToEOF(file_t FileHandle, SmallVectorImpl<char> &Buffer,
-                          ssize_t ChunkSize = DefaultReadChunkSize);
+LLVM_ABI Error readNativeFileToEOF(file_t FileHandle,
+                                   SmallVectorImpl<char> &Buffer,
+                                   ssize_t ChunkSize = DefaultReadChunkSize);
 
 /// Reads \p Buf.size() bytes from \p FileHandle at offset \p Offset into \p
 /// Buf. If 'pread' is available, this will use that, otherwise it will use
@@ -1037,8 +1050,8 @@ LLVM_ABI Error readNativeFileToEOF(file_t FileHandle, SmallVectorImpl<char> &Buf
 /// @param Offset Offset into the file at which the read should occur.
 /// @returns The number of bytes read, or error.
 LLVM_ABI Expected<size_t> readNativeFileSlice(file_t FileHandle,
-                                     MutableArrayRef<char> Buf,
-                                     uint64_t Offset);
+                                              MutableArrayRef<char> Buf,
+                                              uint64_t Offset);
 
 /// @brief Opens the file with the given name in a write-only or read-write
 /// mode, returning its open file descriptor. If the file does not exist, it
@@ -1138,9 +1151,9 @@ inline Expected<file_t> openNativeFileForReadWrite(const Twine &Name,
 ///                 location.
 /// @returns errc::success if \a Name has been opened, otherwise a
 ///          platform-specific error_code.
-LLVM_ABI std::error_code openFileForRead(const Twine &Name, int &ResultFD,
-                                OpenFlags Flags = OF_None,
-                                SmallVectorImpl<char> *RealPath = nullptr);
+LLVM_ABI std::error_code
+openFileForRead(const Twine &Name, int &ResultFD, OpenFlags Flags = OF_None,
+                SmallVectorImpl<char> *RealPath = nullptr);
 
 /// @brief Opens the file with the given name in a read-only mode, returning
 /// its open file descriptor.
@@ -1213,7 +1226,8 @@ LLVM_ABI std::error_code closeFile(file_t &F);
 /// @param Group The group of the file to change to.
 /// @returns errc::success if successfully updated file ownership, otherwise an
 ///          error code is returned.
-LLVM_ABI std::error_code changeFileOwnership(int FD, uint32_t Owner, uint32_t Group);
+LLVM_ABI std::error_code changeFileOwnership(int FD, uint32_t Owner,
+                                             uint32_t Group);
 #endif
 
 /// RAII class that facilitates file locking.
@@ -1309,8 +1323,8 @@ public:
   mapped_file_region &operator=(const mapped_file_region &) = delete;
 
   /// \param fd An open file descriptor to map. Does not take ownership of fd.
-  LLVM_ABI mapped_file_region(sys::fs::file_t fd, mapmode mode, size_t length, uint64_t offset,
-                     std::error_code &ec);
+  LLVM_ABI mapped_file_region(sys::fs::file_t fd, mapmode mode, size_t length,
+                              uint64_t offset, std::error_code &ec);
 
   ~mapped_file_region() { unmapImpl(); }
 
@@ -1365,8 +1379,9 @@ public:
 
   directory_entry() = default;
 
-  LLVM_ABI void replace_filename(const Twine &Filename, file_type Type,
-                        basic_file_status Status = basic_file_status());
+  LLVM_ABI void
+  replace_filename(const Twine &Filename, file_type Type,
+                   basic_file_status Status = basic_file_status());
 
   const std::string &path() const { return Path; }
   // Get basic information about entry file (a subset of fs::status()).
@@ -1385,17 +1400,18 @@ public:
 
   bool operator==(const directory_entry& RHS) const { return Path == RHS.Path; }
   bool operator!=(const directory_entry& RHS) const { return !(*this == RHS); }
-  LLVM_ABI bool operator< (const directory_entry& RHS) const;
-  LLVM_ABI bool operator<=(const directory_entry& RHS) const;
-  LLVM_ABI bool operator> (const directory_entry& RHS) const;
-  LLVM_ABI bool operator>=(const directory_entry& RHS) const;
+  LLVM_ABI bool operator<(const directory_entry &RHS) const;
+  LLVM_ABI bool operator<=(const directory_entry &RHS) const;
+  LLVM_ABI bool operator>(const directory_entry &RHS) const;
+  LLVM_ABI bool operator>=(const directory_entry &RHS) const;
 };
 
 namespace detail {
 
   struct DirIterState;
 
-  LLVM_ABI std::error_code directory_iterator_construct(DirIterState &, StringRef, bool);
+  LLVM_ABI std::error_code directory_iterator_construct(DirIterState &,
+                                                        StringRef, bool);
   LLVM_ABI std::error_code directory_iterator_increment(DirIterState &);
   LLVM_ABI std::error_code directory_iterator_destruct(DirIterState &);
 

--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -220,17 +220,17 @@ public:
 
 /// Represents the result of a call to sys::fs::status().
 class file_status : public basic_file_status {
-  friend bool equivalent(file_status A, file_status B);
+  LLVM_ABI_FRIEND friend bool equivalent(file_status A, file_status B);
 
-  #if defined(LLVM_ON_UNIX)
+#if defined(LLVM_ON_UNIX)
   dev_t fs_st_dev = 0;
   nlink_t fs_st_nlinks = 0;
   ino_t fs_st_ino = 0;
-  #elif defined (_WIN32)
+#elif defined(_WIN32)
   uint32_t NumLinks = 0;
   uint32_t VolumeSerialNumber = 0;
   uint64_t PathHash = 0;
-  #endif
+#endif
 
 public:
   file_status() = default;
@@ -645,7 +645,7 @@ LLVM_ABI std::error_code status(int FD, file_status &Result);
 
 #ifdef _WIN32
 /// A version for when a file descriptor is already available.
-std::error_code status(file_t FD, file_status &Result);
+LLVM_ABI std::error_code status(file_t FD, file_status &Result);
 #endif
 
 /// Get file creation mode mask of the process.
@@ -851,7 +851,7 @@ LLVM_ABI std::error_code createUniqueFile(const Twine &Model,
 /// properly handle errors in a destructor.
 class TempFile {
   bool Done = false;
-  TempFile(StringRef Name, int FD);
+  LLVM_ABI TempFile(StringRef Name, int FD);
 
 public:
   /// This creates a temporary file with createUniqueFile and schedules it for
@@ -992,7 +992,7 @@ LLVM_ABI Expected<file_t> openNativeFile(const Twine &Name,
 /// Converts from a Posix file descriptor number to a native file handle.
 /// On Windows, this retreives the underlying handle. On non-Windows, this is a
 /// no-op.
-file_t convertFDToNativeFile(int FD);
+LLVM_ABI file_t convertFDToNativeFile(int FD);
 
 #ifndef _WIN32
 inline file_t convertFDToNativeFile(int FD) { return FD; }
@@ -1305,10 +1305,11 @@ private:
     Moved.copyFrom(mapped_file_region());
   }
 
-  void unmapImpl();
-  void dontNeedImpl();
+  LLVM_ABI void unmapImpl();
+  LLVM_ABI void dontNeedImpl();
 
-  std::error_code init(sys::fs::file_t FD, uint64_t Offset, mapmode Mode);
+  LLVM_ABI std::error_code init(sys::fs::file_t FD, uint64_t Offset,
+                                mapmode Mode);
 
 public:
   mapped_file_region() = default;

--- a/llvm/include/llvm/Support/FileUtilities.h
+++ b/llvm/include/llvm/Support/FileUtilities.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_FILEUTILITIES_H
 #define LLVM_SUPPORT_FILEUTILITIES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
@@ -29,7 +30,7 @@ namespace llvm {
 /// option, it will set the string to an error message if an error occurs, or
 /// if the files are different.
 ///
-int DiffFilesWithTolerance(StringRef FileA, StringRef FileB, double AbsTol,
+LLVM_ABI int DiffFilesWithTolerance(StringRef FileA, StringRef FileB, double AbsTol,
                            double RelTol, std::string *Error = nullptr);
 
 /// FileRemover - This class is a simple object meant to be stack allocated.
@@ -79,12 +80,12 @@ public:
 /// permissions and dates to the output file.
 class FilePermissionsApplier {
 public:
-  static Expected<FilePermissionsApplier> create(StringRef InputFilename);
+  LLVM_ABI static Expected<FilePermissionsApplier> create(StringRef InputFilename);
 
   /// Apply stored permissions to the \p OutputFilename.
   /// Copy LastAccess and ModificationTime if \p CopyDates is true.
   /// Overwrite stored permissions if \p OverwritePermissions is specified.
-  Error
+  LLVM_ABI Error
   apply(StringRef OutputFilename, bool CopyDates = false,
         std::optional<sys::fs::perms> OverwritePermissions = std::nullopt);
 

--- a/llvm/include/llvm/Support/FileUtilities.h
+++ b/llvm/include/llvm/Support/FileUtilities.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_SUPPORT_FILEUTILITIES_H
 #define LLVM_SUPPORT_FILEUTILITIES_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 
@@ -30,8 +30,9 @@ namespace llvm {
 /// option, it will set the string to an error message if an error occurs, or
 /// if the files are different.
 ///
-LLVM_ABI int DiffFilesWithTolerance(StringRef FileA, StringRef FileB, double AbsTol,
-                           double RelTol, std::string *Error = nullptr);
+LLVM_ABI int DiffFilesWithTolerance(StringRef FileA, StringRef FileB,
+                                    double AbsTol, double RelTol,
+                                    std::string *Error = nullptr);
 
 /// FileRemover - This class is a simple object meant to be stack allocated.
 /// If an exception is thrown from a region, the object removes the filename
@@ -80,7 +81,8 @@ public:
 /// permissions and dates to the output file.
 class FilePermissionsApplier {
 public:
-  LLVM_ABI static Expected<FilePermissionsApplier> create(StringRef InputFilename);
+  LLVM_ABI static Expected<FilePermissionsApplier>
+  create(StringRef InputFilename);
 
   /// Apply stored permissions to the \p OutputFilename.
   /// Copy LastAccess and ModificationTime if \p CopyDates is true.

--- a/llvm/include/llvm/Support/Format.h
+++ b/llvm/include/llvm/Support/Format.h
@@ -22,6 +22,7 @@
 #ifndef LLVM_SUPPORT_FORMAT_H
 #define LLVM_SUPPORT_FORMAT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
@@ -36,7 +37,7 @@ namespace llvm {
 
 /// This is a helper class used for handling formatted output.  It is the
 /// abstract base class of a templated derived class.
-class format_object_base {
+class LLVM_ABI format_object_base {
 protected:
   const char *Fmt;
   ~format_object_base() = default; // Disallow polymorphic deletion.

--- a/llvm/include/llvm/Support/Format.h
+++ b/llvm/include/llvm/Support/Format.h
@@ -22,10 +22,10 @@
 #ifndef LLVM_SUPPORT_FORMAT_H
 #define LLVM_SUPPORT_FORMAT_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 #include <cassert>
 #include <cstdio>

--- a/llvm/include/llvm/Support/FormatVariadic.h
+++ b/llvm/include/llvm/Support/FormatVariadic.h
@@ -25,6 +25,7 @@
 #ifndef LLVM_SUPPORT_FORMATVARIADIC_H
 #define LLVM_SUPPORT_FORMATVARIADIC_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
@@ -97,7 +98,7 @@ public:
   }
 
   // Parse and optionally validate format string (in debug builds).
-  static SmallVector<ReplacementItem, 2>
+  LLVM_ABI static SmallVector<ReplacementItem, 2>
   parseFormatString(StringRef Fmt, size_t NumArgs, bool Validate);
 
   std::string str() const {

--- a/llvm/include/llvm/Support/FormatVariadic.h
+++ b/llvm/include/llvm/Support/FormatVariadic.h
@@ -25,12 +25,12 @@
 #ifndef LLVM_SUPPORT_FORMATVARIADIC_H
 #define LLVM_SUPPORT_FORMATVARIADIC_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/FormatCommon.h"
 #include "llvm/Support/FormatProviders.h"
 #include "llvm/Support/FormatVariadicDetails.h"

--- a/llvm/include/llvm/Support/FormatVariadicDetails.h
+++ b/llvm/include/llvm/Support/FormatVariadicDetails.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_FORMATVARIADICDETAILS_H
 #define LLVM_SUPPORT_FORMATVARIADICDETAILS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/raw_ostream.h"
@@ -21,7 +22,7 @@ class Error;
 
 namespace support {
 namespace detail {
-class format_adapter {
+class LLVM_ABI format_adapter {
   virtual void anchor();
 
 protected:

--- a/llvm/include/llvm/Support/FormatVariadicDetails.h
+++ b/llvm/include/llvm/Support/FormatVariadicDetails.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_SUPPORT_FORMATVARIADICDETAILS_H
 #define LLVM_SUPPORT_FORMATVARIADICDETAILS_H
 
-#include "llvm/Support/Compiler.h"
-#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <type_traits>

--- a/llvm/include/llvm/Support/FormattedStream.h
+++ b/llvm/include/llvm/Support/FormattedStream.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_SUPPORT_FORMATTEDSTREAM_H
 #define LLVM_SUPPORT_FORMATTEDSTREAM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 #include <utility>
 

--- a/llvm/include/llvm/Support/FormattedStream.h
+++ b/llvm/include/llvm/Support/FormattedStream.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_FORMATTEDSTREAM_H
 #define LLVM_SUPPORT_FORMATTEDSTREAM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/raw_ostream.h"
 #include <utility>
@@ -27,7 +28,7 @@ namespace llvm {
 /// doesn't attempt to handle everything Unicode can do (combining characters,
 /// right-to-left markers, etc), but should cover the cases likely to appear in
 /// source code or diagnostic messages.
-class formatted_raw_ostream : public raw_ostream {
+class LLVM_ABI formatted_raw_ostream : public raw_ostream {
   /// TheStream - The real stream we output to. We set it to be
   /// unbuffered, since we're already doing our own buffering.
   ///
@@ -206,15 +207,15 @@ private:
 
 /// fouts() - This returns a reference to a formatted_raw_ostream for
 /// standard output.  Use it like: fouts() << "foo" << "bar";
-formatted_raw_ostream &fouts();
+LLVM_ABI formatted_raw_ostream &fouts();
 
 /// ferrs() - This returns a reference to a formatted_raw_ostream for
 /// standard error.  Use it like: ferrs() << "foo" << "bar";
-formatted_raw_ostream &ferrs();
+LLVM_ABI formatted_raw_ostream &ferrs();
 
 /// fdbgs() - This returns a reference to a formatted_raw_ostream for
 /// debug output.  Use it like: fdbgs() << "foo" << "bar";
-formatted_raw_ostream &fdbgs();
+LLVM_ABI formatted_raw_ostream &fdbgs();
 
 } // end llvm namespace
 

--- a/llvm/include/llvm/Support/GlobPattern.h
+++ b/llvm/include/llvm/Support/GlobPattern.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_GLOBPATTERN_H
 #define LLVM_SUPPORT_GLOBPATTERN_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -54,10 +55,10 @@ public:
   /// \param MaxSubPatterns if provided limit the number of allowed subpatterns
   ///                       created from expanding braces otherwise disable
   ///                       brace expansion
-  static Expected<GlobPattern>
+  LLVM_ABI static Expected<GlobPattern>
   create(StringRef Pat, std::optional<size_t> MaxSubPatterns = {});
   /// \returns \p true if \p S matches this glob pattern
-  bool match(StringRef S) const;
+  LLVM_ABI bool match(StringRef S) const;
 
   // Returns true for glob pattern "*". Can be used to avoid expensive
   // preparation/acquisition of the input for match().
@@ -74,9 +75,9 @@ private:
 
   struct SubGlobPattern {
     /// \param Pat the pattern to match against
-    static Expected<SubGlobPattern> create(StringRef Pat);
+    LLVM_ABI static Expected<SubGlobPattern> create(StringRef Pat);
     /// \returns \p true if \p S matches this glob pattern
-    bool match(StringRef S) const;
+    LLVM_ABI bool match(StringRef S) const;
     StringRef getPat() const { return StringRef(Pat.data(), Pat.size()); }
 
     // Brackets with their end position and matched bytes.

--- a/llvm/include/llvm/Support/GlobPattern.h
+++ b/llvm/include/llvm/Support/GlobPattern.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_SUPPORT_GLOBPATTERN_H
 #define LLVM_SUPPORT_GLOBPATTERN_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <optional>
 

--- a/llvm/include/llvm/Support/GraphWriter.h
+++ b/llvm/include/llvm/Support/GraphWriter.h
@@ -22,6 +22,7 @@
 #ifndef LLVM_SUPPORT_GRAPHWRITER_H
 #define LLVM_SUPPORT_GRAPHWRITER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/GraphTraits.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
@@ -37,11 +38,11 @@ namespace llvm {
 
 namespace DOT {  // Private functions...
 
-std::string EscapeString(const std::string &Label);
+LLVM_ABI std::string EscapeString(const std::string &Label);
 
 /// Get a color string for this node number. Simply round-robin selects
 /// from a reasonable number of colors.
-StringRef getColorString(unsigned NodeNumber);
+LLVM_ABI StringRef getColorString(unsigned NodeNumber);
 
 } // end namespace DOT
 
@@ -57,7 +58,7 @@ enum Name {
 
 } // end namespace GraphProgram
 
-bool DisplayGraph(StringRef Filename, bool wait = true,
+LLVM_ABI bool DisplayGraph(StringRef Filename, bool wait = true,
                   GraphProgram::Name program = GraphProgram::DOT);
 
 template<typename GraphType>
@@ -368,7 +369,7 @@ raw_ostream &WriteGraph(raw_ostream &O, const GraphType &G,
   return O;
 }
 
-std::string createGraphFilename(const Twine &Name, int &FD);
+LLVM_ABI std::string createGraphFilename(const Twine &Name, int &FD);
 
 /// Writes graph into a provided @c Filename.
 /// If @c Filename is empty, generates a random one.

--- a/llvm/include/llvm/Support/GraphWriter.h
+++ b/llvm/include/llvm/Support/GraphWriter.h
@@ -22,10 +22,10 @@
 #ifndef LLVM_SUPPORT_GRAPHWRITER_H
 #define LLVM_SUPPORT_GRAPHWRITER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/GraphTraits.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DOTGraphTraits.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"
@@ -59,7 +59,7 @@ enum Name {
 } // end namespace GraphProgram
 
 LLVM_ABI bool DisplayGraph(StringRef Filename, bool wait = true,
-                  GraphProgram::Name program = GraphProgram::DOT);
+                           GraphProgram::Name program = GraphProgram::DOT);
 
 template<typename GraphType>
 class GraphWriter {

--- a/llvm/include/llvm/Support/HexagonAttributeParser.h
+++ b/llvm/include/llvm/Support/HexagonAttributeParser.h
@@ -9,11 +9,12 @@
 #ifndef LLVM_SUPPORT_HEXAGONATTRIBUTEPARSER_H
 #define LLVM_SUPPORT_HEXAGONATTRIBUTEPARSER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ELFAttrParserCompact.h"
 #include "llvm/Support/HexagonAttributes.h"
 
 namespace llvm {
-class HexagonAttributeParser : public ELFCompactAttrParser {
+class LLVM_ABI HexagonAttributeParser : public ELFCompactAttrParser {
   struct DisplayHandler {
     HexagonAttrs::AttrType Attribute;
     Error (HexagonAttributeParser::*Routine)(unsigned);

--- a/llvm/include/llvm/Support/HexagonAttributes.h
+++ b/llvm/include/llvm/Support/HexagonAttributes.h
@@ -9,12 +9,13 @@
 #ifndef LLVM_SUPPORT_HEXAGONATTRIBUTES_H
 #define LLVM_SUPPORT_HEXAGONATTRIBUTES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ELFAttributes.h"
 
 namespace llvm {
 namespace HexagonAttrs {
 
-const TagNameMap &getHexagonAttributeTags();
+LLVM_ABI const TagNameMap &getHexagonAttributeTags();
 
 enum AttrType : unsigned {
   ARCH = 4,

--- a/llvm/include/llvm/Support/InitLLVM.h
+++ b/llvm/include/llvm/Support/InitLLVM.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_SUPPORT_INITLLVM_H
 #define LLVM_SUPPORT_INITLLVM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include <optional>
 
@@ -36,7 +36,7 @@ namespace llvm {
 class InitLLVM {
 public:
   LLVM_ABI InitLLVM(int &Argc, const char **&Argv,
-           bool InstallPipeSignalExitHandler = true);
+                    bool InstallPipeSignalExitHandler = true);
   InitLLVM(int &Argc, char **&Argv, bool InstallPipeSignalExitHandler = true)
       : InitLLVM(Argc, const_cast<const char **&>(Argv),
                  InstallPipeSignalExitHandler) {}

--- a/llvm/include/llvm/Support/InitLLVM.h
+++ b/llvm/include/llvm/Support/InitLLVM.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_INITLLVM_H
 #define LLVM_SUPPORT_INITLLVM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/PrettyStackTrace.h"
@@ -34,13 +35,13 @@
 namespace llvm {
 class InitLLVM {
 public:
-  InitLLVM(int &Argc, const char **&Argv,
+  LLVM_ABI InitLLVM(int &Argc, const char **&Argv,
            bool InstallPipeSignalExitHandler = true);
   InitLLVM(int &Argc, char **&Argv, bool InstallPipeSignalExitHandler = true)
       : InitLLVM(Argc, const_cast<const char **&>(Argv),
                  InstallPipeSignalExitHandler) {}
 
-  ~InitLLVM();
+  LLVM_ABI ~InitLLVM();
 
 private:
   BumpPtrAllocator Alloc;

--- a/llvm/include/llvm/Support/InstructionCost.h
+++ b/llvm/include/llvm/Support/InstructionCost.h
@@ -18,6 +18,7 @@
 #ifndef LLVM_SUPPORT_INSTRUCTIONCOST_H
 #define LLVM_SUPPORT_INSTRUCTIONCOST_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MathExtras.h"
 #include <limits>
 #include <tuple>
@@ -234,7 +235,7 @@ public:
     return *this >= RHS2;
   }
 
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 
   template <class Function>
   auto map(const Function &F) const -> InstructionCost {

--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -655,7 +655,8 @@ inline bool Object::erase(StringRef K) {
   return M.erase(ObjectKey(K));
 }
 
-LLVM_ABI std::vector<const Object::value_type *> sortedElements(const Object &O);
+LLVM_ABI std::vector<const Object::value_type *>
+sortedElements(const Object &O);
 
 /// A "cursor" marking a position within a Value.
 /// The Value is a tree, and this is the path from the root to the current node.
@@ -1112,7 +1113,8 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const Value &V) {
 /// The default style is basic/compact formatting, like operator<<.
 /// A format string like formatv("{0:2}", Value) pretty-prints with indent 2.
 template <> struct format_provider<llvm::json::Value> {
-  LLVM_ABI static void format(const llvm::json::Value &, raw_ostream &, StringRef);
+  LLVM_ABI static void format(const llvm::json::Value &, raw_ostream &,
+                              StringRef);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -481,12 +481,12 @@ public:
 #endif // !NDEBUG || LLVM_ENABLE_DUMP
 
 private:
-  void destroy();
-  void copyFrom(const Value &M);
+  LLVM_ABI void destroy();
+  LLVM_ABI void copyFrom(const Value &M);
   // We allow moving from *const* Values, by marking all members as mutable!
   // This hack is needed to support initializer-list syntax efficiently.
   // (std::initializer_list<T> is a container of const T).
-  void moveFrom(const Value &&M);
+  LLVM_ABI void moveFrom(const Value &&M);
   friend class Array;
   friend class Object;
 
@@ -531,7 +531,7 @@ private:
                                       llvm::StringRef, std::string, json::Array,
                                       json::Object>
       Union;
-  friend bool operator==(const Value &, const Value &);
+  LLVM_ABI_FRIEND friend bool operator==(const Value &, const Value &);
 };
 
 LLVM_ABI bool operator==(const Value &, const Value &);
@@ -713,7 +713,7 @@ class Path::Root {
   llvm::StringLiteral ErrorMessage;
   std::vector<Path::Segment> ErrorPath; // Only valid in error state. Reversed.
 
-  friend void Path::report(llvm::StringLiteral Message);
+  LLVM_ABI_FRIEND friend void Path::report(llvm::StringLiteral Message);
 
 public:
   Root(llvm::StringRef Name = "") : Name(Name), ErrorMessage("") {}
@@ -1079,9 +1079,9 @@ private:
     attributeEnd();
   }
 
-  void valueBegin();
-  void flushComment();
-  void newline();
+  LLVM_ABI void valueBegin();
+  LLVM_ABI void flushComment();
+  LLVM_ABI void newline();
 
   enum Context {
     Singleton, // Top level, or object attribute.

--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -82,11 +82,11 @@ constexpr bool is_uint_64_bit_v =
 
 /// Returns true if \p S is valid UTF-8, which is required for use as JSON.
 /// If it returns false, \p Offset is set to a byte offset near the first error.
-bool isUTF8(llvm::StringRef S, size_t *ErrOffset = nullptr);
+LLVM_ABI bool isUTF8(llvm::StringRef S, size_t *ErrOffset = nullptr);
 /// Replaces invalid UTF-8 sequences in \p S with the replacement character
 /// (U+FFFD). The returned string is valid UTF-8.
 /// This is much slower than isUTF8, so test that first.
-std::string fixUTF8(llvm::StringRef S);
+LLVM_ABI std::string fixUTF8(llvm::StringRef S);
 
 class Array;
 class ObjectKey;
@@ -136,25 +136,25 @@ public:
   iterator find(StringRef K) { return M.find_as(K); }
   const_iterator find(StringRef K) const { return M.find_as(K); }
   // operator[] acts as if Value was default-constructible as null.
-  Value &operator[](const ObjectKey &K);
-  Value &operator[](ObjectKey &&K);
+  LLVM_ABI Value &operator[](const ObjectKey &K);
+  LLVM_ABI Value &operator[](ObjectKey &&K);
   // Look up a property, returning nullptr if it doesn't exist.
-  Value *get(StringRef K);
-  const Value *get(StringRef K) const;
+  LLVM_ABI Value *get(StringRef K);
+  LLVM_ABI const Value *get(StringRef K) const;
   // Typed accessors return std::nullopt/nullptr if
   //   - the property doesn't exist
   //   - or it has the wrong type
-  std::optional<std::nullptr_t> getNull(StringRef K) const;
-  std::optional<bool> getBoolean(StringRef K) const;
-  std::optional<double> getNumber(StringRef K) const;
-  std::optional<int64_t> getInteger(StringRef K) const;
-  std::optional<llvm::StringRef> getString(StringRef K) const;
-  const json::Object *getObject(StringRef K) const;
-  json::Object *getObject(StringRef K);
-  const json::Array *getArray(StringRef K) const;
-  json::Array *getArray(StringRef K);
+  LLVM_ABI std::optional<std::nullptr_t> getNull(StringRef K) const;
+  LLVM_ABI std::optional<bool> getBoolean(StringRef K) const;
+  LLVM_ABI std::optional<double> getNumber(StringRef K) const;
+  LLVM_ABI std::optional<int64_t> getInteger(StringRef K) const;
+  LLVM_ABI std::optional<llvm::StringRef> getString(StringRef K) const;
+  LLVM_ABI const json::Object *getObject(StringRef K) const;
+  LLVM_ABI json::Object *getObject(StringRef K);
+  LLVM_ABI const json::Array *getArray(StringRef K) const;
+  LLVM_ABI json::Array *getArray(StringRef K);
 };
-bool operator==(const Object &LHS, const Object &RHS);
+LLVM_ABI bool operator==(const Object &LHS, const Object &RHS);
 inline bool operator!=(const Object &LHS, const Object &RHS) {
   return !(LHS == RHS);
 }
@@ -170,7 +170,7 @@ public:
   using const_iterator = std::vector<Value>::const_iterator;
 
   Array() = default;
-  explicit Array(std::initializer_list<Value> Elements);
+  LLVM_ABI explicit Array(std::initializer_list<Value> Elements);
   template <typename Collection> explicit Array(const Collection &C) {
     for (const auto &V : C)
       emplace_back(V);
@@ -301,7 +301,7 @@ public:
   // It would be nice to have Value() be null. But that would make {} null too.
   Value(const Value &M) { copyFrom(M); }
   Value(Value &&M) { moveFrom(std::move(M)); }
-  Value(std::initializer_list<Value> Elements);
+  LLVM_ABI Value(std::initializer_list<Value> Elements);
   Value(json::Array &&Elements) : Type(T_Array) {
     create<json::Array>(std::move(Elements));
   }
@@ -472,7 +472,7 @@ public:
     return LLVM_LIKELY(Type == T_Array) ? &as<json::Array>() : nullptr;
   }
 
-  void print(llvm::raw_ostream &OS) const;
+  LLVM_ABI void print(llvm::raw_ostream &OS) const;
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   LLVM_DUMP_METHOD void dump() const {
     print(llvm::dbgs());
@@ -534,7 +534,7 @@ private:
   friend bool operator==(const Value &, const Value &);
 };
 
-bool operator==(const Value &, const Value &);
+LLVM_ABI bool operator==(const Value &, const Value &);
 inline bool operator!=(const Value &L, const Value &R) { return !(L == R); }
 
 // Array Methods
@@ -655,7 +655,7 @@ inline bool Object::erase(StringRef K) {
   return M.erase(ObjectKey(K));
 }
 
-std::vector<const Object::value_type *> sortedElements(const Object &O);
+LLVM_ABI std::vector<const Object::value_type *> sortedElements(const Object &O);
 
 /// A "cursor" marking a position within a Value.
 /// The Value is a tree, and this is the path from the root to the current node.
@@ -667,7 +667,7 @@ public:
   /// Records that the value at the current path is invalid.
   /// Message is e.g. "expected number" and becomes part of the final error.
   /// This overwrites any previously written error message in the root.
-  void report(llvm::StringLiteral Message);
+  LLVM_ABI void report(llvm::StringLiteral Message);
 
   /// The root may be treated as a Path.
   Path(Root &R) : Parent(nullptr), Seg(&R) {}
@@ -723,7 +723,7 @@ public:
   Root &operator=(const Root &) = delete;
 
   /// Returns the last error reported, or else a generic error.
-  Error getError() const;
+  LLVM_ABI Error getError() const;
   /// Print the root value with the error shown inline as a comment.
   /// Unrelated parts of the value are elided for brevity, e.g.
   ///   {
@@ -731,7 +731,7 @@ public:
   ///      "name": /* expected string */ null,
   ///      "properties": { ... }
   ///   }
-  void printErrorContext(const Value &, llvm::raw_ostream &) const;
+  LLVM_ABI void printErrorContext(const Value &, llvm::raw_ostream &) const;
 };
 
 // Standard deserializers are provided for primitive types.
@@ -906,14 +906,14 @@ private:
 /// Parses the provided JSON source, or returns a ParseError.
 /// The returned Value is self-contained and owns its strings (they do not refer
 /// to the original source).
-llvm::Expected<Value> parse(llvm::StringRef JSON);
+LLVM_ABI llvm::Expected<Value> parse(llvm::StringRef JSON);
 
 class ParseError : public llvm::ErrorInfo<ParseError> {
   const char *Msg;
   unsigned Line, Column, Offset;
 
 public:
-  static char ID;
+  LLVM_ABI static char ID;
   ParseError(const char *Msg, unsigned Line, unsigned Column, unsigned Offset)
       : Msg(Msg), Line(Line), Column(Column), Offset(Offset) {}
   void log(llvm::raw_ostream &OS) const override {
@@ -1014,7 +1014,7 @@ class OStream {
   // or in an array (any number of times).
 
   /// Emit a self-contained value (number, string, vector<string> etc).
-  void value(const Value &V);
+  LLVM_ABI void value(const Value &V);
   /// Emit an array whose elements are emitted in the provided Block.
   void array(Block Contents) {
     arrayBegin();
@@ -1041,7 +1041,7 @@ class OStream {
   /// Emit a JavaScript comment associated with the next printed value.
   /// The string must be valid until the next attribute or value is emitted.
   /// Comments are not part of standard JSON, and many parsers reject them!
-  void comment(llvm::StringRef);
+  LLVM_ABI void comment(llvm::StringRef);
 
   // High level functions to output object attributes.
   // Valid only within an object (any number of times).
@@ -1062,14 +1062,14 @@ class OStream {
   // Low-level begin/end functions to output arrays, objects, and attributes.
   // Must be correctly paired. Allowed contexts are as above.
 
-  void arrayBegin();
-  void arrayEnd();
-  void objectBegin();
-  void objectEnd();
-  void attributeBegin(llvm::StringRef Key);
-  void attributeEnd();
-  raw_ostream &rawValueBegin();
-  void rawValueEnd();
+  LLVM_ABI void arrayBegin();
+  LLVM_ABI void arrayEnd();
+  LLVM_ABI void objectBegin();
+  LLVM_ABI void objectEnd();
+  LLVM_ABI void attributeBegin(llvm::StringRef Key);
+  LLVM_ABI void attributeEnd();
+  LLVM_ABI raw_ostream &rawValueBegin();
+  LLVM_ABI void rawValueEnd();
 
 private:
   void attributeImpl(llvm::StringRef Key, Block Contents) {
@@ -1112,7 +1112,7 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const Value &V) {
 /// The default style is basic/compact formatting, like operator<<.
 /// A format string like formatv("{0:2}", Value) pretty-prints with indent 2.
 template <> struct format_provider<llvm::json::Value> {
-  static void format(const llvm::json::Value &, raw_ostream &, StringRef);
+  LLVM_ABI static void format(const llvm::json::Value &, raw_ostream &, StringRef);
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Support/KnownBits.h
+++ b/llvm/include/llvm/Support/KnownBits.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_KNOWNBITS_H
 #define LLVM_SUPPORT_KNOWNBITS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APInt.h"
 #include <optional>
 
@@ -205,7 +206,7 @@ public:
 
   /// Return known bits for a in-register sign extension of the value we're
   /// tracking.
-  KnownBits sextInReg(unsigned SrcBitWidth) const;
+  LLVM_ABI KnownBits sextInReg(unsigned SrcBitWidth) const;
 
   /// Insert the bits from a smaller known bits starting at bitPosition.
   void insertBits(const KnownBits &SubBits, unsigned BitPosition) {
@@ -228,7 +229,7 @@ public:
 
   /// Return KnownBits based on this, but updated given that the underlying
   /// value is known to be greater than or equal to Val.
-  KnownBits makeGE(const APInt &Val) const;
+  LLVM_ABI KnownBits makeGE(const APInt &Val) const;
 
   /// Returns the minimum number of trailing zero bits.
   unsigned countMinTrailingZeros() const { return Zero.countr_one(); }
@@ -320,16 +321,16 @@ public:
   }
 
   /// Compute known bits resulting from adding LHS, RHS and a 1-bit Carry.
-  static KnownBits computeForAddCarry(
+  LLVM_ABI static KnownBits computeForAddCarry(
       const KnownBits &LHS, const KnownBits &RHS, const KnownBits &Carry);
 
   /// Compute known bits resulting from adding LHS and RHS.
-  static KnownBits computeForAddSub(bool Add, bool NSW, bool NUW,
+  LLVM_ABI static KnownBits computeForAddSub(bool Add, bool NSW, bool NUW,
                                     const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute known bits results from subtracting RHS from LHS with 1-bit
   /// Borrow.
-  static KnownBits computeForSubBorrow(const KnownBits &LHS, KnownBits RHS,
+  LLVM_ABI static KnownBits computeForSubBorrow(const KnownBits &LHS, KnownBits RHS,
                                        const KnownBits &Borrow);
 
   /// Compute knownbits resulting from addition of LHS and RHS.
@@ -345,128 +346,128 @@ public:
   }
 
   /// Compute knownbits resulting from llvm.sadd.sat(LHS, RHS)
-  static KnownBits sadd_sat(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits sadd_sat(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute knownbits resulting from llvm.uadd.sat(LHS, RHS)
-  static KnownBits uadd_sat(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits uadd_sat(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute knownbits resulting from llvm.ssub.sat(LHS, RHS)
-  static KnownBits ssub_sat(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits ssub_sat(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute knownbits resulting from llvm.usub.sat(LHS, RHS)
-  static KnownBits usub_sat(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits usub_sat(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute knownbits resulting from APIntOps::avgFloorS
-  static KnownBits avgFloorS(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits avgFloorS(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute knownbits resulting from APIntOps::avgFloorU
-  static KnownBits avgFloorU(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits avgFloorU(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute knownbits resulting from APIntOps::avgCeilS
-  static KnownBits avgCeilS(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits avgCeilS(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute knownbits resulting from APIntOps::avgCeilU
-  static KnownBits avgCeilU(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits avgCeilU(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute known bits resulting from multiplying LHS and RHS.
-  static KnownBits mul(const KnownBits &LHS, const KnownBits &RHS,
+  LLVM_ABI static KnownBits mul(const KnownBits &LHS, const KnownBits &RHS,
                        bool NoUndefSelfMultiply = false);
 
   /// Compute known bits from sign-extended multiply-hi.
-  static KnownBits mulhs(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits mulhs(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute known bits from zero-extended multiply-hi.
-  static KnownBits mulhu(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits mulhu(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute known bits for sdiv(LHS, RHS).
-  static KnownBits sdiv(const KnownBits &LHS, const KnownBits &RHS,
+  LLVM_ABI static KnownBits sdiv(const KnownBits &LHS, const KnownBits &RHS,
                         bool Exact = false);
 
   /// Compute known bits for udiv(LHS, RHS).
-  static KnownBits udiv(const KnownBits &LHS, const KnownBits &RHS,
+  LLVM_ABI static KnownBits udiv(const KnownBits &LHS, const KnownBits &RHS,
                         bool Exact = false);
 
   /// Compute known bits for urem(LHS, RHS).
-  static KnownBits urem(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits urem(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute known bits for srem(LHS, RHS).
-  static KnownBits srem(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits srem(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute known bits for umax(LHS, RHS).
-  static KnownBits umax(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits umax(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute known bits for umin(LHS, RHS).
-  static KnownBits umin(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits umin(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute known bits for smax(LHS, RHS).
-  static KnownBits smax(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits smax(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute known bits for smin(LHS, RHS).
-  static KnownBits smin(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits smin(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute known bits for abdu(LHS, RHS).
-  static KnownBits abdu(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits abdu(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Compute known bits for abds(LHS, RHS).
-  static KnownBits abds(KnownBits LHS, KnownBits RHS);
+  LLVM_ABI static KnownBits abds(KnownBits LHS, KnownBits RHS);
 
   /// Compute known bits for shl(LHS, RHS).
   /// NOTE: RHS (shift amount) bitwidth doesn't need to be the same as LHS.
-  static KnownBits shl(const KnownBits &LHS, const KnownBits &RHS,
+  LLVM_ABI static KnownBits shl(const KnownBits &LHS, const KnownBits &RHS,
                        bool NUW = false, bool NSW = false,
                        bool ShAmtNonZero = false);
 
   /// Compute known bits for lshr(LHS, RHS).
   /// NOTE: RHS (shift amount) bitwidth doesn't need to be the same as LHS.
-  static KnownBits lshr(const KnownBits &LHS, const KnownBits &RHS,
+  LLVM_ABI static KnownBits lshr(const KnownBits &LHS, const KnownBits &RHS,
                         bool ShAmtNonZero = false, bool Exact = false);
 
   /// Compute known bits for ashr(LHS, RHS).
   /// NOTE: RHS (shift amount) bitwidth doesn't need to be the same as LHS.
-  static KnownBits ashr(const KnownBits &LHS, const KnownBits &RHS,
+  LLVM_ABI static KnownBits ashr(const KnownBits &LHS, const KnownBits &RHS,
                         bool ShAmtNonZero = false, bool Exact = false);
 
   /// Determine if these known bits always give the same ICMP_EQ result.
-  static std::optional<bool> eq(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> eq(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_NE result.
-  static std::optional<bool> ne(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> ne(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_UGT result.
-  static std::optional<bool> ugt(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> ugt(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_UGE result.
-  static std::optional<bool> uge(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> uge(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_ULT result.
-  static std::optional<bool> ult(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> ult(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_ULE result.
-  static std::optional<bool> ule(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> ule(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_SGT result.
-  static std::optional<bool> sgt(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> sgt(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_SGE result.
-  static std::optional<bool> sge(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> sge(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_SLT result.
-  static std::optional<bool> slt(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> slt(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_SLE result.
-  static std::optional<bool> sle(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> sle(const KnownBits &LHS, const KnownBits &RHS);
 
   /// Update known bits based on ANDing with RHS.
-  KnownBits &operator&=(const KnownBits &RHS);
+  LLVM_ABI KnownBits &operator&=(const KnownBits &RHS);
 
   /// Update known bits based on ORing with RHS.
-  KnownBits &operator|=(const KnownBits &RHS);
+  LLVM_ABI KnownBits &operator|=(const KnownBits &RHS);
 
   /// Update known bits based on XORing with RHS.
-  KnownBits &operator^=(const KnownBits &RHS);
+  LLVM_ABI KnownBits &operator^=(const KnownBits &RHS);
 
   /// Compute known bits for the absolute value.
-  KnownBits abs(bool IntMinIsPoison = false) const;
+  LLVM_ABI KnownBits abs(bool IntMinIsPoison = false) const;
 
   KnownBits byteSwap() const {
     return KnownBits(Zero.byteSwap(), One.byteSwap());
@@ -478,11 +479,11 @@ public:
 
   /// Compute known bits for X & -X, which has only the lowest bit set of X set.
   /// The name comes from the X86 BMI instruction
-  KnownBits blsi() const;
+  LLVM_ABI KnownBits blsi() const;
 
   /// Compute known bits for X ^ (X - 1), which has all bits up to and including
   /// the lowest set bit of X set. The name comes from the X86 BMI instruction.
-  KnownBits blsmsk() const;
+  LLVM_ABI KnownBits blsmsk() const;
 
   bool operator==(const KnownBits &Other) const {
     return Zero == Other.Zero && One == Other.One;
@@ -490,8 +491,8 @@ public:
 
   bool operator!=(const KnownBits &Other) const { return !(*this == Other); }
 
-  void print(raw_ostream &OS) const;
-  void dump() const;
+  LLVM_ABI void print(raw_ostream &OS) const;
+  LLVM_ABI void dump() const;
 
 private:
   // Internal helper for getting the initial KnownBits for an `srem` or `urem`

--- a/llvm/include/llvm/Support/KnownBits.h
+++ b/llvm/include/llvm/Support/KnownBits.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_SUPPORT_KNOWNBITS_H
 #define LLVM_SUPPORT_KNOWNBITS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/Support/Compiler.h"
 #include <optional>
 
 namespace llvm {
@@ -321,17 +321,20 @@ public:
   }
 
   /// Compute known bits resulting from adding LHS, RHS and a 1-bit Carry.
-  LLVM_ABI static KnownBits computeForAddCarry(
-      const KnownBits &LHS, const KnownBits &RHS, const KnownBits &Carry);
+  LLVM_ABI static KnownBits computeForAddCarry(const KnownBits &LHS,
+                                               const KnownBits &RHS,
+                                               const KnownBits &Carry);
 
   /// Compute known bits resulting from adding LHS and RHS.
   LLVM_ABI static KnownBits computeForAddSub(bool Add, bool NSW, bool NUW,
-                                    const KnownBits &LHS, const KnownBits &RHS);
+                                             const KnownBits &LHS,
+                                             const KnownBits &RHS);
 
   /// Compute known bits results from subtracting RHS from LHS with 1-bit
   /// Borrow.
-  LLVM_ABI static KnownBits computeForSubBorrow(const KnownBits &LHS, KnownBits RHS,
-                                       const KnownBits &Borrow);
+  LLVM_ABI static KnownBits computeForSubBorrow(const KnownBits &LHS,
+                                                KnownBits RHS,
+                                                const KnownBits &Borrow);
 
   /// Compute knownbits resulting from addition of LHS and RHS.
   static KnownBits add(const KnownBits &LHS, const KnownBits &RHS,
@@ -346,32 +349,40 @@ public:
   }
 
   /// Compute knownbits resulting from llvm.sadd.sat(LHS, RHS)
-  LLVM_ABI static KnownBits sadd_sat(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits sadd_sat(const KnownBits &LHS,
+                                     const KnownBits &RHS);
 
   /// Compute knownbits resulting from llvm.uadd.sat(LHS, RHS)
-  LLVM_ABI static KnownBits uadd_sat(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits uadd_sat(const KnownBits &LHS,
+                                     const KnownBits &RHS);
 
   /// Compute knownbits resulting from llvm.ssub.sat(LHS, RHS)
-  LLVM_ABI static KnownBits ssub_sat(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits ssub_sat(const KnownBits &LHS,
+                                     const KnownBits &RHS);
 
   /// Compute knownbits resulting from llvm.usub.sat(LHS, RHS)
-  LLVM_ABI static KnownBits usub_sat(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits usub_sat(const KnownBits &LHS,
+                                     const KnownBits &RHS);
 
   /// Compute knownbits resulting from APIntOps::avgFloorS
-  LLVM_ABI static KnownBits avgFloorS(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits avgFloorS(const KnownBits &LHS,
+                                      const KnownBits &RHS);
 
   /// Compute knownbits resulting from APIntOps::avgFloorU
-  LLVM_ABI static KnownBits avgFloorU(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits avgFloorU(const KnownBits &LHS,
+                                      const KnownBits &RHS);
 
   /// Compute knownbits resulting from APIntOps::avgCeilS
-  LLVM_ABI static KnownBits avgCeilS(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits avgCeilS(const KnownBits &LHS,
+                                     const KnownBits &RHS);
 
   /// Compute knownbits resulting from APIntOps::avgCeilU
-  LLVM_ABI static KnownBits avgCeilU(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static KnownBits avgCeilU(const KnownBits &LHS,
+                                     const KnownBits &RHS);
 
   /// Compute known bits resulting from multiplying LHS and RHS.
   LLVM_ABI static KnownBits mul(const KnownBits &LHS, const KnownBits &RHS,
-                       bool NoUndefSelfMultiply = false);
+                                bool NoUndefSelfMultiply = false);
 
   /// Compute known bits from sign-extended multiply-hi.
   LLVM_ABI static KnownBits mulhs(const KnownBits &LHS, const KnownBits &RHS);
@@ -381,11 +392,11 @@ public:
 
   /// Compute known bits for sdiv(LHS, RHS).
   LLVM_ABI static KnownBits sdiv(const KnownBits &LHS, const KnownBits &RHS,
-                        bool Exact = false);
+                                 bool Exact = false);
 
   /// Compute known bits for udiv(LHS, RHS).
   LLVM_ABI static KnownBits udiv(const KnownBits &LHS, const KnownBits &RHS,
-                        bool Exact = false);
+                                 bool Exact = false);
 
   /// Compute known bits for urem(LHS, RHS).
   LLVM_ABI static KnownBits urem(const KnownBits &LHS, const KnownBits &RHS);
@@ -414,48 +425,58 @@ public:
   /// Compute known bits for shl(LHS, RHS).
   /// NOTE: RHS (shift amount) bitwidth doesn't need to be the same as LHS.
   LLVM_ABI static KnownBits shl(const KnownBits &LHS, const KnownBits &RHS,
-                       bool NUW = false, bool NSW = false,
-                       bool ShAmtNonZero = false);
+                                bool NUW = false, bool NSW = false,
+                                bool ShAmtNonZero = false);
 
   /// Compute known bits for lshr(LHS, RHS).
   /// NOTE: RHS (shift amount) bitwidth doesn't need to be the same as LHS.
   LLVM_ABI static KnownBits lshr(const KnownBits &LHS, const KnownBits &RHS,
-                        bool ShAmtNonZero = false, bool Exact = false);
+                                 bool ShAmtNonZero = false, bool Exact = false);
 
   /// Compute known bits for ashr(LHS, RHS).
   /// NOTE: RHS (shift amount) bitwidth doesn't need to be the same as LHS.
   LLVM_ABI static KnownBits ashr(const KnownBits &LHS, const KnownBits &RHS,
-                        bool ShAmtNonZero = false, bool Exact = false);
+                                 bool ShAmtNonZero = false, bool Exact = false);
 
   /// Determine if these known bits always give the same ICMP_EQ result.
-  LLVM_ABI static std::optional<bool> eq(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> eq(const KnownBits &LHS,
+                                         const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_NE result.
-  LLVM_ABI static std::optional<bool> ne(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> ne(const KnownBits &LHS,
+                                         const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_UGT result.
-  LLVM_ABI static std::optional<bool> ugt(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> ugt(const KnownBits &LHS,
+                                          const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_UGE result.
-  LLVM_ABI static std::optional<bool> uge(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> uge(const KnownBits &LHS,
+                                          const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_ULT result.
-  LLVM_ABI static std::optional<bool> ult(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> ult(const KnownBits &LHS,
+                                          const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_ULE result.
-  LLVM_ABI static std::optional<bool> ule(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> ule(const KnownBits &LHS,
+                                          const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_SGT result.
-  LLVM_ABI static std::optional<bool> sgt(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> sgt(const KnownBits &LHS,
+                                          const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_SGE result.
-  LLVM_ABI static std::optional<bool> sge(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> sge(const KnownBits &LHS,
+                                          const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_SLT result.
-  LLVM_ABI static std::optional<bool> slt(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> slt(const KnownBits &LHS,
+                                          const KnownBits &RHS);
 
   /// Determine if these known bits always give the same ICMP_SLE result.
-  LLVM_ABI static std::optional<bool> sle(const KnownBits &LHS, const KnownBits &RHS);
+  LLVM_ABI static std::optional<bool> sle(const KnownBits &LHS,
+                                          const KnownBits &RHS);
 
   /// Update known bits based on ANDing with RHS.
   LLVM_ABI KnownBits &operator&=(const KnownBits &RHS);

--- a/llvm/include/llvm/Support/LEB128.h
+++ b/llvm/include/llvm/Support/LEB128.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_LEB128_H
 #define LLVM_SUPPORT_LEB128_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace llvm {
@@ -221,10 +222,10 @@ inline uint64_t decodeULEB128AndIncUnsafe(const uint8_t *&p) {
 }
 
 /// Utility function to get the size of the ULEB128-encoded value.
-extern unsigned getULEB128Size(uint64_t Value);
+LLVM_ABI extern unsigned getULEB128Size(uint64_t Value);
 
 /// Utility function to get the size of the SLEB128-encoded value.
-extern unsigned getSLEB128Size(int64_t Value);
+LLVM_ABI extern unsigned getSLEB128Size(int64_t Value);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/Support/LineIterator.h
+++ b/llvm/include/llvm/Support/LineIterator.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_SUPPORT_LINEITERATOR_H
 #define LLVM_SUPPORT_LINEITERATOR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include <iterator>
@@ -50,12 +50,14 @@ public:
   line_iterator() = default;
 
   /// Construct a new iterator around an unowned memory buffer.
-  LLVM_ABI explicit line_iterator(const MemoryBufferRef &Buffer, bool SkipBlanks = true,
-                         char CommentMarker = '\0');
+  LLVM_ABI explicit line_iterator(const MemoryBufferRef &Buffer,
+                                  bool SkipBlanks = true,
+                                  char CommentMarker = '\0');
 
   /// Construct a new iterator around some memory buffer.
-  LLVM_ABI explicit line_iterator(const MemoryBuffer &Buffer, bool SkipBlanks = true,
-                         char CommentMarker = '\0');
+  LLVM_ABI explicit line_iterator(const MemoryBuffer &Buffer,
+                                  bool SkipBlanks = true,
+                                  char CommentMarker = '\0');
 
   /// Return true if we've reached EOF or are an "end" iterator.
   bool is_at_eof() const { return !Buffer; }

--- a/llvm/include/llvm/Support/LineIterator.h
+++ b/llvm/include/llvm/Support/LineIterator.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_LINEITERATOR_H
 #define LLVM_SUPPORT_LINEITERATOR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/MemoryBufferRef.h"
@@ -49,11 +50,11 @@ public:
   line_iterator() = default;
 
   /// Construct a new iterator around an unowned memory buffer.
-  explicit line_iterator(const MemoryBufferRef &Buffer, bool SkipBlanks = true,
+  LLVM_ABI explicit line_iterator(const MemoryBufferRef &Buffer, bool SkipBlanks = true,
                          char CommentMarker = '\0');
 
   /// Construct a new iterator around some memory buffer.
-  explicit line_iterator(const MemoryBuffer &Buffer, bool SkipBlanks = true,
+  LLVM_ABI explicit line_iterator(const MemoryBuffer &Buffer, bool SkipBlanks = true,
                          char CommentMarker = '\0');
 
   /// Return true if we've reached EOF or are an "end" iterator.
@@ -91,7 +92,7 @@ public:
 
 private:
   /// Advance the iterator to the next line.
-  void advance();
+  LLVM_ABI void advance();
 };
 }
 

--- a/llvm/include/llvm/Support/Locale.h
+++ b/llvm/include/llvm/Support/Locale.h
@@ -1,6 +1,8 @@
 #ifndef LLVM_SUPPORT_LOCALE_H
 #define LLVM_SUPPORT_LOCALE_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 class StringRef;
 

--- a/llvm/include/llvm/Support/Locale.h
+++ b/llvm/include/llvm/Support/Locale.h
@@ -9,7 +9,6 @@ namespace locale {
 
 LLVM_ABI int columnWidth(StringRef s);
 LLVM_ABI bool isPrint(int c);
-
 }
 }
 }

--- a/llvm/include/llvm/Support/Locale.h
+++ b/llvm/include/llvm/Support/Locale.h
@@ -7,8 +7,8 @@ class StringRef;
 namespace sys {
 namespace locale {
 
-int columnWidth(StringRef s);
-bool isPrint(int c);
+LLVM_ABI int columnWidth(StringRef s);
+LLVM_ABI bool isPrint(int c);
 
 }
 }

--- a/llvm/include/llvm/Support/LockFileManager.h
+++ b/llvm/include/llvm/Support/LockFileManager.h
@@ -8,10 +8,10 @@
 #ifndef LLVM_SUPPORT_LOCKFILEMANAGER_H
 #define LLVM_SUPPORT_LOCKFILEMANAGER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/AdvisoryLock.h"
+#include "llvm/Support/Compiler.h"
 #include <optional>
 #include <string>
 #include <variant>

--- a/llvm/include/llvm/Support/LockFileManager.h
+++ b/llvm/include/llvm/Support/LockFileManager.h
@@ -8,6 +8,7 @@
 #ifndef LLVM_SUPPORT_LOCKFILEMANAGER_H
 #define LLVM_SUPPORT_LOCKFILEMANAGER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/AdvisoryLock.h"
@@ -23,7 +24,7 @@ namespace llvm {
 /// atomicity of the file system to ensure that only a single process can create
 /// that ".lock" file. When the lock file is removed, the owning process has
 /// finished the operation.
-class LockFileManager : public AdvisoryLock {
+class LLVM_ABI LockFileManager : public AdvisoryLock {
   SmallString<128> FileName;
   SmallString<128> LockFileName;
   SmallString<128> UniqueLockFileName;

--- a/llvm/include/llvm/Support/MD5.h
+++ b/llvm/include/llvm/Support/MD5.h
@@ -104,7 +104,7 @@ private:
     MD5_u32plus block[16];
   } InternalState;
 
-  const uint8_t *body(ArrayRef<uint8_t> Data);
+  LLVM_ABI const uint8_t *body(ArrayRef<uint8_t> Data);
 };
 
 /// Helper to compute and return lower 64 bits of the given string's MD5 hash.

--- a/llvm/include/llvm/Support/MD5.h
+++ b/llvm/include/llvm/Support/MD5.h
@@ -28,6 +28,7 @@
 #ifndef LLVM_SUPPORT_MD5_H
 #define LLVM_SUPPORT_MD5_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Endian.h"
 #include <array>
@@ -41,7 +42,7 @@ template <typename T> class ArrayRef;
 class MD5 {
 public:
   struct MD5Result : public std::array<uint8_t, 16> {
-    SmallString<32> digest() const;
+    LLVM_ABI SmallString<32> digest() const;
 
     uint64_t low() const {
       // Our MD5 implementation returns the result in little endian, so the low
@@ -60,31 +61,31 @@ public:
     }
   };
 
-  MD5();
+  LLVM_ABI MD5();
 
   /// Updates the hash for the byte stream provided.
-  void update(ArrayRef<uint8_t> Data);
+  LLVM_ABI void update(ArrayRef<uint8_t> Data);
 
   /// Updates the hash for the StringRef provided.
-  void update(StringRef Str);
+  LLVM_ABI void update(StringRef Str);
 
   /// Finishes off the hash and puts the result in result.
-  void final(MD5Result &Result);
+  LLVM_ABI void final(MD5Result &Result);
 
   /// Finishes off the hash, and returns the 16-byte hash data.
-  MD5Result final();
+  LLVM_ABI MD5Result final();
 
   /// Finishes off the hash, and returns the 16-byte hash data.
   /// This is suitable for getting the MD5 at any time without invalidating the
   /// internal state, so that more calls can be made into `update`.
-  MD5Result result();
+  LLVM_ABI MD5Result result();
 
   /// Translates the bytes in \p Res to a hex string that is
   /// deposited into \p Str. The result will be of length 32.
-  static void stringifyResult(MD5Result &Result, SmallVectorImpl<char> &Str);
+  LLVM_ABI static void stringifyResult(MD5Result &Result, SmallVectorImpl<char> &Str);
 
   /// Computes the hash for a given bytes.
-  static MD5Result hash(ArrayRef<uint8_t> Data);
+  LLVM_ABI static MD5Result hash(ArrayRef<uint8_t> Data);
 
 private:
   // Any 32-bit or wider unsigned integer data type will do.

--- a/llvm/include/llvm/Support/MD5.h
+++ b/llvm/include/llvm/Support/MD5.h
@@ -28,8 +28,8 @@
 #ifndef LLVM_SUPPORT_MD5_H
 #define LLVM_SUPPORT_MD5_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include <array>
 #include <cstdint>
@@ -82,7 +82,8 @@ public:
 
   /// Translates the bytes in \p Res to a hex string that is
   /// deposited into \p Str. The result will be of length 32.
-  LLVM_ABI static void stringifyResult(MD5Result &Result, SmallVectorImpl<char> &Str);
+  LLVM_ABI static void stringifyResult(MD5Result &Result,
+                                       SmallVectorImpl<char> &Str);
 
   /// Computes the hash for a given bytes.
   LLVM_ABI static MD5Result hash(ArrayRef<uint8_t> Data);

--- a/llvm/include/llvm/Support/MSP430AttributeParser.h
+++ b/llvm/include/llvm/Support/MSP430AttributeParser.h
@@ -14,11 +14,12 @@
 #ifndef LLVM_SUPPORT_MSP430ATTRIBUTEPARSER_H
 #define LLVM_SUPPORT_MSP430ATTRIBUTEPARSER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ELFAttrParserCompact.h"
 #include "llvm/Support/MSP430Attributes.h"
 
 namespace llvm {
-class MSP430AttributeParser : public ELFCompactAttrParser {
+class LLVM_ABI MSP430AttributeParser : public ELFCompactAttrParser {
   struct DisplayHandler {
     MSP430Attrs::AttrType Attribute;
     Error (MSP430AttributeParser::*Routine)(MSP430Attrs::AttrType);

--- a/llvm/include/llvm/Support/MSP430Attributes.h
+++ b/llvm/include/llvm/Support/MSP430Attributes.h
@@ -18,12 +18,13 @@
 #ifndef LLVM_SUPPORT_MSP430ATTRIBUTES_H
 #define LLVM_SUPPORT_MSP430ATTRIBUTES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ELFAttributes.h"
 
 namespace llvm {
 namespace MSP430Attrs {
 
-const TagNameMap &getMSP430AttributeTags();
+LLVM_ABI const TagNameMap &getMSP430AttributeTags();
 
 enum AttrType : unsigned {
   // Attribute types in ELF/.MSP430.attributes.

--- a/llvm/include/llvm/Support/ManagedStatic.h
+++ b/llvm/include/llvm/Support/ManagedStatic.h
@@ -61,7 +61,8 @@ protected:
   mutable const ManagedStaticBase *Next;
 #endif
 
-  LLVM_ABI void RegisterManagedStatic(void *(*creator)(), void (*deleter)(void*)) const;
+  LLVM_ABI void RegisterManagedStatic(void *(*creator)(),
+                                      void (*deleter)(void *)) const;
 
 public:
 #ifdef LLVM_USE_CONSTEXPR_CTOR

--- a/llvm/include/llvm/Support/ManagedStatic.h
+++ b/llvm/include/llvm/Support/ManagedStatic.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_MANAGEDSTATIC_H
 #define LLVM_SUPPORT_MANAGEDSTATIC_H
 
+#include "llvm/Support/Compiler.h"
 #include <atomic>
 #include <cstddef>
 
@@ -60,7 +61,7 @@ protected:
   mutable const ManagedStaticBase *Next;
 #endif
 
-  void RegisterManagedStatic(void *(*creator)(), void (*deleter)(void*)) const;
+  LLVM_ABI void RegisterManagedStatic(void *(*creator)(), void (*deleter)(void*)) const;
 
 public:
 #ifdef LLVM_USE_CONSTEXPR_CTOR
@@ -70,7 +71,7 @@ public:
   /// isConstructed - Return true if this object has not been created yet.
   bool isConstructed() const { return Ptr != nullptr; }
 
-  void destroy() const;
+  LLVM_ABI void destroy() const;
 };
 
 /// ManagedStatic - This transparently changes the behavior of global statics to
@@ -111,7 +112,7 @@ public:
 };
 
 /// llvm_shutdown - Deallocate and destroy all ManagedStatic variables.
-void llvm_shutdown();
+LLVM_ABI void llvm_shutdown();
 
 /// llvm_shutdown_obj - This is a simple helper class that calls
 /// llvm_shutdown() when it is destroyed.

--- a/llvm/include/llvm/Support/MathExtras.h
+++ b/llvm/include/llvm/Support/MathExtras.h
@@ -703,7 +703,7 @@ SaturatingMultiplyAdd(T X, T Y, T A, bool *ResultOverflowed = nullptr) {
 }
 
 /// Use this rather than HUGE_VALF; the latter causes warnings on MSVC.
-extern const float huge_valf;
+LLVM_ABI extern const float huge_valf;
 
 /// Add two signed integers, computing the two's complement truncated result,
 /// returning true if overflow occurred.

--- a/llvm/include/llvm/Support/MemAlloc.h
+++ b/llvm/include/llvm/Support/MemAlloc.h
@@ -71,7 +71,7 @@ LLVM_ATTRIBUTE_RETURNS_NONNULL inline void *safe_realloc(void *Ptr, size_t Sz) {
 /// like posix_memalign due to portability. It is mostly intended to allow
 /// compatibility with platforms that, after aligned allocation was added, use
 /// reduced default alignment.
-LLVM_ATTRIBUTE_RETURNS_NONNULL LLVM_ATTRIBUTE_RETURNS_NOALIAS void *
+LLVM_ABI LLVM_ATTRIBUTE_RETURNS_NONNULL LLVM_ATTRIBUTE_RETURNS_NOALIAS void *
 allocate_buffer(size_t Size, size_t Alignment);
 
 /// Deallocate a buffer of memory with the given size and alignment.
@@ -81,7 +81,7 @@ allocate_buffer(size_t Size, size_t Alignment);
 ///
 /// The pointer must have been allocated with the corresponding new operator,
 /// most likely using the above helper.
-void deallocate_buffer(void *Ptr, size_t Size, size_t Alignment);
+LLVM_ABI void deallocate_buffer(void *Ptr, size_t Size, size_t Alignment);
 
 } // namespace llvm
 #endif

--- a/llvm/include/llvm/Support/Memory.h
+++ b/llvm/include/llvm/Support/Memory.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_MEMORY_H
 #define LLVM_SUPPORT_MEMORY_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 #include <system_error>
 #include <utility>
@@ -95,7 +96,7 @@ namespace sys {
     /// otherwise a null MemoryBlock is with \p EC describing the error.
     ///
     /// Allocate mapped memory.
-    static MemoryBlock allocateMappedMemory(size_t NumBytes,
+    LLVM_ABI static MemoryBlock allocateMappedMemory(size_t NumBytes,
                                             const MemoryBlock *const NearBlock,
                                             unsigned Flags,
                                             std::error_code &EC);
@@ -109,7 +110,7 @@ namespace sys {
     /// describing the failure if an error occurred.
     ///
     /// Release mapped memory.
-    static std::error_code releaseMappedMemory(MemoryBlock &Block);
+    LLVM_ABI static std::error_code releaseMappedMemory(MemoryBlock &Block);
 
     /// This method sets the protection flags for a block of memory to the
     /// state specified by /p Flags.  The behavior is not specified if the
@@ -125,13 +126,13 @@ namespace sys {
     /// describing the failure if an error occurred.
     ///
     /// Set memory protection state.
-    static std::error_code protectMappedMemory(const MemoryBlock &Block,
+    LLVM_ABI static std::error_code protectMappedMemory(const MemoryBlock &Block,
                                                unsigned Flags);
 
     /// InvalidateInstructionCache - Before the JIT can run a block of code
     /// that has been emitted it must invalidate the instruction cache on some
     /// platforms.
-    static void InvalidateInstructionCache(const void *Addr, size_t Len);
+    LLVM_ABI static void InvalidateInstructionCache(const void *Addr, size_t Len);
   };
 
   /// Owning version of MemoryBlock.

--- a/llvm/include/llvm/Support/Memory.h
+++ b/llvm/include/llvm/Support/Memory.h
@@ -96,10 +96,9 @@ namespace sys {
     /// otherwise a null MemoryBlock is with \p EC describing the error.
     ///
     /// Allocate mapped memory.
-    LLVM_ABI static MemoryBlock allocateMappedMemory(size_t NumBytes,
-                                            const MemoryBlock *const NearBlock,
-                                            unsigned Flags,
-                                            std::error_code &EC);
+    LLVM_ABI static MemoryBlock
+    allocateMappedMemory(size_t NumBytes, const MemoryBlock *const NearBlock,
+                         unsigned Flags, std::error_code &EC);
 
     /// This method releases a block of memory that was allocated with the
     /// allocateMappedMemory method. It should not be used to release any
@@ -126,13 +125,14 @@ namespace sys {
     /// describing the failure if an error occurred.
     ///
     /// Set memory protection state.
-    LLVM_ABI static std::error_code protectMappedMemory(const MemoryBlock &Block,
-                                               unsigned Flags);
+    LLVM_ABI static std::error_code
+    protectMappedMemory(const MemoryBlock &Block, unsigned Flags);
 
     /// InvalidateInstructionCache - Before the JIT can run a block of code
     /// that has been emitted it must invalidate the instruction cache on some
     /// platforms.
-    LLVM_ABI static void InvalidateInstructionCache(const void *Addr, size_t Len);
+    LLVM_ABI static void InvalidateInstructionCache(const void *Addr,
+                                                    size_t Len);
   };
 
   /// Owning version of MemoryBlock.

--- a/llvm/include/llvm/Support/MemoryBuffer.h
+++ b/llvm/include/llvm/Support/MemoryBuffer.h
@@ -13,13 +13,13 @@
 #ifndef LLVM_SUPPORT_MEMORYBUFFER_H
 #define LLVM_SUPPORT_MEMORYBUFFER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm-c/Types.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/Alignment.h"
 #include "llvm/Support/CBindingWrapping.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/MemoryBufferRef.h"
 #include <cstddef>

--- a/llvm/include/llvm/Support/MemoryBuffer.h
+++ b/llvm/include/llvm/Support/MemoryBuffer.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_MEMORYBUFFER_H
 #define LLVM_SUPPORT_MEMORYBUFFER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm-c/Types.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
@@ -48,7 +49,7 @@ using file_t = int;
 /// be more efficient for clients which are reading all the data to stop
 /// reading when they encounter a '\0' than to continually check the file
 /// position to see if it has reached the end of the file.
-class MemoryBuffer {
+class LLVM_ABI MemoryBuffer {
   const char *BufferStart; // Start of the buffer.
   const char *BufferEnd;   // End of the buffer.
 
@@ -199,12 +200,12 @@ public:
     return {getBufferStart(), getBufferEnd()};
   }
 
-  static ErrorOr<std::unique_ptr<WritableMemoryBuffer>>
+  LLVM_ABI static ErrorOr<std::unique_ptr<WritableMemoryBuffer>>
   getFile(const Twine &Filename, bool IsVolatile = false,
           std::optional<Align> Alignment = std::nullopt);
 
   /// Map a subrange of the specified file as a WritableMemoryBuffer.
-  static ErrorOr<std::unique_ptr<WritableMemoryBuffer>>
+  LLVM_ABI static ErrorOr<std::unique_ptr<WritableMemoryBuffer>>
   getFileSlice(const Twine &Filename, uint64_t MapSize, uint64_t Offset,
                bool IsVolatile = false,
                std::optional<Align> Alignment = std::nullopt);
@@ -215,14 +216,14 @@ public:
   ///
   /// \param Alignment Set to indicate that the buffer should be aligned to at
   /// least the specified alignment.
-  static std::unique_ptr<WritableMemoryBuffer>
+  LLVM_ABI static std::unique_ptr<WritableMemoryBuffer>
   getNewUninitMemBuffer(size_t Size, const Twine &BufferName = "",
                         std::optional<Align> Alignment = std::nullopt);
 
   /// Allocate a new zero-initialized MemoryBuffer of the specified size. Note
   /// that the caller need not initialize the memory allocated by this method.
   /// The memory is owned by the MemoryBuffer object.
-  static std::unique_ptr<WritableMemoryBuffer>
+  LLVM_ABI static std::unique_ptr<WritableMemoryBuffer>
   getNewMemBuffer(size_t Size, const Twine &BufferName = "");
 
 private:
@@ -263,11 +264,11 @@ public:
     return {getBufferStart(), getBufferEnd()};
   }
 
-  static ErrorOr<std::unique_ptr<WriteThroughMemoryBuffer>>
+  LLVM_ABI static ErrorOr<std::unique_ptr<WriteThroughMemoryBuffer>>
   getFile(const Twine &Filename, int64_t FileSize = -1);
 
   /// Map a subrange of the specified file as a ReadWriteMemoryBuffer.
-  static ErrorOr<std::unique_ptr<WriteThroughMemoryBuffer>>
+  LLVM_ABI static ErrorOr<std::unique_ptr<WriteThroughMemoryBuffer>>
   getFileSlice(const Twine &Filename, uint64_t MapSize, uint64_t Offset);
 
 private:

--- a/llvm/include/llvm/Support/MemoryBufferRef.h
+++ b/llvm/include/llvm/Support/MemoryBufferRef.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_MEMORYBUFFERREF_H
 #define LLVM_SUPPORT_MEMORYBUFFERREF_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace llvm {
@@ -25,7 +26,7 @@ class MemoryBufferRef {
 
 public:
   MemoryBufferRef() = default;
-  MemoryBufferRef(const MemoryBuffer &Buffer);
+  LLVM_ABI MemoryBufferRef(const MemoryBuffer &Buffer);
   MemoryBufferRef(StringRef Buffer, StringRef Identifier)
       : Buffer(Buffer), Identifier(Identifier) {}
 

--- a/llvm/include/llvm/Support/MemoryBufferRef.h
+++ b/llvm/include/llvm/Support/MemoryBufferRef.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_SUPPORT_MEMORYBUFFERREF_H
 #define LLVM_SUPPORT_MEMORYBUFFERREF_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/Support/ModRef.h
+++ b/llvm/include/llvm/Support/ModRef.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_MODREF_H
 #define LLVM_SUPPORT_MODREF_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/Sequence.h"
 #include "llvm/Support/raw_ostream.h"
@@ -53,7 +54,7 @@ enum class ModRefInfo : uint8_t {
 }
 
 /// Debug print ModRefInfo.
-raw_ostream &operator<<(raw_ostream &OS, ModRefInfo MR);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, ModRefInfo MR);
 
 /// The locations at which a function might access memory.
 enum class IRMemLocation {
@@ -295,7 +296,7 @@ public:
 using MemoryEffects = MemoryEffectsBase<IRMemLocation>;
 
 /// Debug print MemoryEffects.
-raw_ostream &operator<<(raw_ostream &OS, MemoryEffects RMRB);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, MemoryEffects RMRB);
 
 // Legacy alias.
 using FunctionModRefBehavior = MemoryEffects;
@@ -344,7 +345,7 @@ inline bool capturesAll(CaptureComponents CC) {
   return CC == CaptureComponents::All;
 }
 
-raw_ostream &operator<<(raw_ostream &OS, CaptureComponents CC);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, CaptureComponents CC);
 
 /// Represents which components of the pointer may be captured in which
 /// location. This represents the captures(...) attribute in IR.
@@ -433,7 +434,7 @@ public:
   }
 };
 
-raw_ostream &operator<<(raw_ostream &OS, CaptureInfo Info);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, CaptureInfo Info);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/Support/ModRef.h
+++ b/llvm/include/llvm/Support/ModRef.h
@@ -14,9 +14,9 @@
 #ifndef LLVM_SUPPORT_MODREF_H
 #define LLVM_SUPPORT_MODREF_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/ADT/Sequence.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace llvm {

--- a/llvm/include/llvm/Support/Mustache.h
+++ b/llvm/include/llvm/Support/Mustache.h
@@ -69,6 +69,7 @@
 #ifndef LLVM_SUPPORT_MUSTACHE
 #define LLVM_SUPPORT_MUSTACHE
 
+#include "llvm/Support/Compiler.h"
 #include "Error.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Allocator.h"
@@ -89,32 +90,32 @@ using AstPtr = std::unique_ptr<ASTNode>;
 // and Lambdas that are registered with it.
 class Template {
 public:
-  Template(StringRef TemplateStr);
+  LLVM_ABI Template(StringRef TemplateStr);
 
   Template(const Template &) = delete;
 
   Template &operator=(const Template &) = delete;
 
-  Template(Template &&Other) noexcept;
+  LLVM_ABI Template(Template &&Other) noexcept;
 
   // Define this in the cpp file to  work around ASTNode being an incomplete
   // type.
-  ~Template();
+  LLVM_ABI ~Template();
 
-  Template &operator=(Template &&Other) noexcept;
+  LLVM_ABI Template &operator=(Template &&Other) noexcept;
 
-  void render(const llvm::json::Value &Data, llvm::raw_ostream &OS);
+  LLVM_ABI void render(const llvm::json::Value &Data, llvm::raw_ostream &OS);
 
-  void registerPartial(std::string Name, std::string Partial);
+  LLVM_ABI void registerPartial(std::string Name, std::string Partial);
 
-  void registerLambda(std::string Name, Lambda Lambda);
+  LLVM_ABI void registerLambda(std::string Name, Lambda Lambda);
 
-  void registerLambda(std::string Name, SectionLambda Lambda);
+  LLVM_ABI void registerLambda(std::string Name, SectionLambda Lambda);
 
   // By default the Mustache Spec Specifies that HTML special characters
   // should be escaped. This function allows the user to specify which
   // characters should be escaped.
-  void overrideEscapeCharacters(DenseMap<char, std::string> Escapes);
+  LLVM_ABI void overrideEscapeCharacters(DenseMap<char, std::string> Escapes);
 
 private:
   StringMap<AstPtr> Partials;

--- a/llvm/include/llvm/Support/Mustache.h
+++ b/llvm/include/llvm/Support/Mustache.h
@@ -69,10 +69,10 @@
 #ifndef LLVM_SUPPORT_MUSTACHE
 #define LLVM_SUPPORT_MUSTACHE
 
-#include "llvm/Support/Compiler.h"
 #include "Error.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/StringSaver.h"
 #include <functional>

--- a/llvm/include/llvm/Support/NativeFormatting.h
+++ b/llvm/include/llvm/Support/NativeFormatting.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_NATIVEFORMATTING_H
 #define LLVM_SUPPORT_NATIVEFORMATTING_H
 
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <optional>
 
@@ -21,25 +22,25 @@ enum class IntegerStyle {
 };
 enum class HexPrintStyle { Upper, Lower, PrefixUpper, PrefixLower };
 
-size_t getDefaultPrecision(FloatStyle Style);
+LLVM_ABI size_t getDefaultPrecision(FloatStyle Style);
 
-bool isPrefixedHexStyle(HexPrintStyle S);
+LLVM_ABI bool isPrefixedHexStyle(HexPrintStyle S);
 
-void write_integer(raw_ostream &S, unsigned int N, size_t MinDigits,
+LLVM_ABI void write_integer(raw_ostream &S, unsigned int N, size_t MinDigits,
                    IntegerStyle Style);
-void write_integer(raw_ostream &S, int N, size_t MinDigits, IntegerStyle Style);
-void write_integer(raw_ostream &S, unsigned long N, size_t MinDigits,
+LLVM_ABI void write_integer(raw_ostream &S, int N, size_t MinDigits, IntegerStyle Style);
+LLVM_ABI void write_integer(raw_ostream &S, unsigned long N, size_t MinDigits,
                    IntegerStyle Style);
-void write_integer(raw_ostream &S, long N, size_t MinDigits,
+LLVM_ABI void write_integer(raw_ostream &S, long N, size_t MinDigits,
                    IntegerStyle Style);
-void write_integer(raw_ostream &S, unsigned long long N, size_t MinDigits,
+LLVM_ABI void write_integer(raw_ostream &S, unsigned long long N, size_t MinDigits,
                    IntegerStyle Style);
-void write_integer(raw_ostream &S, long long N, size_t MinDigits,
+LLVM_ABI void write_integer(raw_ostream &S, long long N, size_t MinDigits,
                    IntegerStyle Style);
 
-void write_hex(raw_ostream &S, uint64_t N, HexPrintStyle Style,
+LLVM_ABI void write_hex(raw_ostream &S, uint64_t N, HexPrintStyle Style,
                std::optional<size_t> Width = std::nullopt);
-void write_double(raw_ostream &S, double D, FloatStyle Style,
+LLVM_ABI void write_double(raw_ostream &S, double D, FloatStyle Style,
                   std::optional<size_t> Precision = std::nullopt);
 }
 

--- a/llvm/include/llvm/Support/NativeFormatting.h
+++ b/llvm/include/llvm/Support/NativeFormatting.h
@@ -27,21 +27,22 @@ LLVM_ABI size_t getDefaultPrecision(FloatStyle Style);
 LLVM_ABI bool isPrefixedHexStyle(HexPrintStyle S);
 
 LLVM_ABI void write_integer(raw_ostream &S, unsigned int N, size_t MinDigits,
-                   IntegerStyle Style);
-LLVM_ABI void write_integer(raw_ostream &S, int N, size_t MinDigits, IntegerStyle Style);
+                            IntegerStyle Style);
+LLVM_ABI void write_integer(raw_ostream &S, int N, size_t MinDigits,
+                            IntegerStyle Style);
 LLVM_ABI void write_integer(raw_ostream &S, unsigned long N, size_t MinDigits,
-                   IntegerStyle Style);
+                            IntegerStyle Style);
 LLVM_ABI void write_integer(raw_ostream &S, long N, size_t MinDigits,
-                   IntegerStyle Style);
-LLVM_ABI void write_integer(raw_ostream &S, unsigned long long N, size_t MinDigits,
-                   IntegerStyle Style);
+                            IntegerStyle Style);
+LLVM_ABI void write_integer(raw_ostream &S, unsigned long long N,
+                            size_t MinDigits, IntegerStyle Style);
 LLVM_ABI void write_integer(raw_ostream &S, long long N, size_t MinDigits,
-                   IntegerStyle Style);
+                            IntegerStyle Style);
 
 LLVM_ABI void write_hex(raw_ostream &S, uint64_t N, HexPrintStyle Style,
-               std::optional<size_t> Width = std::nullopt);
+                        std::optional<size_t> Width = std::nullopt);
 LLVM_ABI void write_double(raw_ostream &S, double D, FloatStyle Style,
-                  std::optional<size_t> Precision = std::nullopt);
+                           std::optional<size_t> Precision = std::nullopt);
 }
 
 #endif

--- a/llvm/include/llvm/Support/OptimizedStructLayout.h
+++ b/llvm/include/llvm/Support/OptimizedStructLayout.h
@@ -35,6 +35,7 @@
 #ifndef LLVM_SUPPORT_OPTIMIZEDSTRUCTLAYOUT_H
 #define LLVM_SUPPORT_OPTIMIZEDSTRUCTLAYOUT_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Alignment.h"
 #include "llvm/ADT/ArrayRef.h"
 #include <utility>
@@ -135,7 +136,7 @@ struct OptimizedStructLayoutField {
 /// The return value is the total size of the struct and its required
 /// alignment.  Note that the total size is not rounded up to a multiple
 /// of the required alignment; clients which require this can do so easily.
-std::pair<uint64_t, Align> performOptimizedStructLayout(
+LLVM_ABI std::pair<uint64_t, Align> performOptimizedStructLayout(
                         MutableArrayRef<OptimizedStructLayoutField> Fields);
 
 } // namespace llvm

--- a/llvm/include/llvm/Support/OptimizedStructLayout.h
+++ b/llvm/include/llvm/Support/OptimizedStructLayout.h
@@ -35,9 +35,9 @@
 #ifndef LLVM_SUPPORT_OPTIMIZEDSTRUCTLAYOUT_H
 #define LLVM_SUPPORT_OPTIMIZEDSTRUCTLAYOUT_H
 
-#include "llvm/Support/Compiler.h"
-#include "llvm/Support/Alignment.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/Alignment.h"
+#include "llvm/Support/Compiler.h"
 #include <utility>
 
 namespace llvm {
@@ -137,7 +137,7 @@ struct OptimizedStructLayoutField {
 /// alignment.  Note that the total size is not rounded up to a multiple
 /// of the required alignment; clients which require this can do so easily.
 LLVM_ABI std::pair<uint64_t, Align> performOptimizedStructLayout(
-                        MutableArrayRef<OptimizedStructLayoutField> Fields);
+    MutableArrayRef<OptimizedStructLayoutField> Fields);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/Support/PGOOptions.h
+++ b/llvm/include/llvm/Support/PGOOptions.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_PGOOPTIONS_H
 #define LLVM_SUPPORT_PGOOPTIONS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/Support/Error.h"
 
@@ -28,7 +29,7 @@ struct PGOOptions {
   enum PGOAction { NoAction, IRInstr, IRUse, SampleUse };
   enum CSPGOAction { NoCSAction, CSIRInstr, CSIRUse };
   enum class ColdFuncOpt { Default, OptSize, MinSize, OptNone };
-  PGOOptions(std::string ProfileFile, std::string CSProfileGenFile,
+  LLVM_ABI PGOOptions(std::string ProfileFile, std::string CSProfileGenFile,
              std::string ProfileRemappingFile, std::string MemoryProfile,
              IntrusiveRefCntPtr<vfs::FileSystem> FS,
              PGOAction Action = NoAction, CSPGOAction CSAction = NoCSAction,
@@ -36,9 +37,9 @@ struct PGOOptions {
              bool DebugInfoForProfiling = false,
              bool PseudoProbeForProfiling = false,
              bool AtomicCounterUpdate = false);
-  PGOOptions(const PGOOptions &);
-  ~PGOOptions();
-  PGOOptions &operator=(const PGOOptions &);
+  LLVM_ABI PGOOptions(const PGOOptions &);
+  LLVM_ABI ~PGOOptions();
+  LLVM_ABI PGOOptions &operator=(const PGOOptions &);
 
   std::string ProfileFile;
   std::string CSProfileGenFile;

--- a/llvm/include/llvm/Support/PGOOptions.h
+++ b/llvm/include/llvm/Support/PGOOptions.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_SUPPORT_PGOOPTIONS_H
 #define LLVM_SUPPORT_PGOOPTIONS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -30,13 +30,15 @@ struct PGOOptions {
   enum CSPGOAction { NoCSAction, CSIRInstr, CSIRUse };
   enum class ColdFuncOpt { Default, OptSize, MinSize, OptNone };
   LLVM_ABI PGOOptions(std::string ProfileFile, std::string CSProfileGenFile,
-             std::string ProfileRemappingFile, std::string MemoryProfile,
-             IntrusiveRefCntPtr<vfs::FileSystem> FS,
-             PGOAction Action = NoAction, CSPGOAction CSAction = NoCSAction,
-             ColdFuncOpt ColdType = ColdFuncOpt::Default,
-             bool DebugInfoForProfiling = false,
-             bool PseudoProbeForProfiling = false,
-             bool AtomicCounterUpdate = false);
+                      std::string ProfileRemappingFile,
+                      std::string MemoryProfile,
+                      IntrusiveRefCntPtr<vfs::FileSystem> FS,
+                      PGOAction Action = NoAction,
+                      CSPGOAction CSAction = NoCSAction,
+                      ColdFuncOpt ColdType = ColdFuncOpt::Default,
+                      bool DebugInfoForProfiling = false,
+                      bool PseudoProbeForProfiling = false,
+                      bool AtomicCounterUpdate = false);
   LLVM_ABI PGOOptions(const PGOOptions &);
   LLVM_ABI ~PGOOptions();
   LLVM_ABI PGOOptions &operator=(const PGOOptions &);

--- a/llvm/include/llvm/Support/Parallel.h
+++ b/llvm/include/llvm/Support/Parallel.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_SUPPORT_PARALLEL_H
 #define LLVM_SUPPORT_PARALLEL_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Config/llvm-config.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/Threading.h"
@@ -226,7 +226,8 @@ void parallelSort(RandomAccessIterator Start, RandomAccessIterator End,
   llvm::sort(Start, End, Comp);
 }
 
-LLVM_ABI void parallelFor(size_t Begin, size_t End, function_ref<void(size_t)> Fn);
+LLVM_ABI void parallelFor(size_t Begin, size_t End,
+                          function_ref<void(size_t)> Fn);
 
 template <class IterTy, class FuncTy>
 void parallelForEach(IterTy Begin, IterTy End, FuncTy Fn) {

--- a/llvm/include/llvm/Support/Parallel.h
+++ b/llvm/include/llvm/Support/Parallel.h
@@ -42,7 +42,7 @@ LLVM_ABI extern ThreadPoolStrategy strategy;
 #ifdef _WIN32
 // Direct access to thread_local variables from a different DLL isn't
 // possible with Windows Native TLS.
-unsigned getThreadIndex();
+LLVM_ABI unsigned getThreadIndex();
 #else
 // Don't access this directly, use the getThreadIndex wrapper.
 LLVM_ABI extern thread_local unsigned threadIndex;

--- a/llvm/include/llvm/Support/Parallel.h
+++ b/llvm/include/llvm/Support/Parallel.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_PARALLEL_H
 #define LLVM_SUPPORT_PARALLEL_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/Error.h"
@@ -27,7 +28,7 @@ namespace parallel {
 // Strategy for the default executor used by the parallel routines provided by
 // this file. It defaults to using all hardware threads and should be
 // initialized before the first use of parallel routines.
-extern ThreadPoolStrategy strategy;
+LLVM_ABI extern ThreadPoolStrategy strategy;
 
 #if LLVM_ENABLE_THREADS
 #define GET_THREAD_INDEX_IMPL                                                  \
@@ -44,12 +45,12 @@ extern ThreadPoolStrategy strategy;
 unsigned getThreadIndex();
 #else
 // Don't access this directly, use the getThreadIndex wrapper.
-extern thread_local unsigned threadIndex;
+LLVM_ABI extern thread_local unsigned threadIndex;
 
 inline unsigned getThreadIndex() { GET_THREAD_INDEX_IMPL; }
 #endif
 
-size_t getThreadCount();
+LLVM_ABI size_t getThreadCount();
 #else
 inline unsigned getThreadIndex() { return 0; }
 inline size_t getThreadCount() { return 1; }
@@ -91,13 +92,13 @@ class TaskGroup {
   bool Parallel;
 
 public:
-  TaskGroup();
-  ~TaskGroup();
+  LLVM_ABI TaskGroup();
+  LLVM_ABI ~TaskGroup();
 
   // Spawn a task, but does not wait for it to finish.
   // Tasks marked with \p Sequential will be executed
   // exactly in the order which they were spawned.
-  void spawn(std::function<void()> f);
+  LLVM_ABI void spawn(std::function<void()> f);
 
   void sync() const { L.sync(); }
 
@@ -225,7 +226,7 @@ void parallelSort(RandomAccessIterator Start, RandomAccessIterator End,
   llvm::sort(Start, End, Comp);
 }
 
-void parallelFor(size_t Begin, size_t End, function_ref<void(size_t)> Fn);
+LLVM_ABI void parallelFor(size_t Begin, size_t End, function_ref<void(size_t)> Fn);
 
 template <class IterTy, class FuncTy>
 void parallelForEach(IterTy Begin, IterTy End, FuncTy Fn) {

--- a/llvm/include/llvm/Support/Path.h
+++ b/llvm/include/llvm/Support/Path.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_SUPPORT_PATH_H
 #define LLVM_SUPPORT_PATH_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/ADT/iterator.h"
 #include "llvm/Support/DataTypes.h"
@@ -84,11 +85,11 @@ class const_iterator
 
 public:
   reference operator*() const { return Component; }
-  const_iterator &operator++();    // preincrement
-  bool operator==(const const_iterator &RHS) const;
+  LLVM_ABI const_iterator &operator++();    // preincrement
+  LLVM_ABI bool operator==(const const_iterator &RHS) const;
 
   /// Difference in bytes between this and RHS.
-  ptrdiff_t operator-(const const_iterator &RHS) const;
+  LLVM_ABI ptrdiff_t operator-(const const_iterator &RHS) const;
 };
 
 /// Reverse path iterator.
@@ -109,34 +110,34 @@ class reverse_iterator
 
 public:
   reference operator*() const { return Component; }
-  reverse_iterator &operator++();    // preincrement
-  bool operator==(const reverse_iterator &RHS) const;
+  LLVM_ABI reverse_iterator &operator++();    // preincrement
+  LLVM_ABI bool operator==(const reverse_iterator &RHS) const;
 
   /// Difference in bytes between this and RHS.
-  ptrdiff_t operator-(const reverse_iterator &RHS) const;
+  LLVM_ABI ptrdiff_t operator-(const reverse_iterator &RHS) const;
 };
 
 /// Get begin iterator over \a path.
 /// @param path Input path.
 /// @returns Iterator initialized with the first component of \a path.
-const_iterator begin(StringRef path LLVM_LIFETIME_BOUND,
+LLVM_ABI const_iterator begin(StringRef path LLVM_LIFETIME_BOUND,
                      Style style = Style::native);
 
 /// Get end iterator over \a path.
 /// @param path Input path.
 /// @returns Iterator initialized to the end of \a path.
-const_iterator end(StringRef path LLVM_LIFETIME_BOUND);
+LLVM_ABI const_iterator end(StringRef path LLVM_LIFETIME_BOUND);
 
 /// Get reverse begin iterator over \a path.
 /// @param path Input path.
 /// @returns Iterator initialized with the first reverse component of \a path.
-reverse_iterator rbegin(StringRef path LLVM_LIFETIME_BOUND,
+LLVM_ABI reverse_iterator rbegin(StringRef path LLVM_LIFETIME_BOUND,
                         Style style = Style::native);
 
 /// Get reverse end iterator over \a path.
 /// @param path Input path.
 /// @returns Iterator initialized to the reverse end of \a path.
-reverse_iterator rend(StringRef path LLVM_LIFETIME_BOUND);
+LLVM_ABI reverse_iterator rend(StringRef path LLVM_LIFETIME_BOUND);
 
 /// @}
 /// @name Lexical Modifiers
@@ -154,7 +155,7 @@ reverse_iterator rend(StringRef path LLVM_LIFETIME_BOUND);
 /// @endcode
 ///
 /// @param path A path that is modified to not have a file component.
-void remove_filename(SmallVectorImpl<char> &path, Style style = Style::native);
+LLVM_ABI void remove_filename(SmallVectorImpl<char> &path, Style style = Style::native);
 
 /// Replace the file extension of \a path with \a extension.
 ///
@@ -168,7 +169,7 @@ void remove_filename(SmallVectorImpl<char> &path, Style style = Style::native);
 /// @param extension The extension to be added. It may be empty. It may also
 ///                  optionally start with a '.', if it does not, one will be
 ///                  prepended.
-void replace_extension(SmallVectorImpl<char> &path, const Twine &extension,
+LLVM_ABI void replace_extension(SmallVectorImpl<char> &path, const Twine &extension,
                        Style style = Style::native);
 
 /// Replace matching path prefix with another path.
@@ -193,7 +194,7 @@ void replace_extension(SmallVectorImpl<char> &path, const Twine &extension,
 /// @param style The style used to match the prefix. Exact match using
 /// Posix style, case/separator insensitive match for Windows style.
 /// @result true if \a Path begins with OldPrefix
-bool replace_path_prefix(SmallVectorImpl<char> &Path, StringRef OldPrefix,
+LLVM_ABI bool replace_path_prefix(SmallVectorImpl<char> &Path, StringRef OldPrefix,
                          StringRef NewPrefix,
                          Style style = Style::native);
 
@@ -201,7 +202,7 @@ bool replace_path_prefix(SmallVectorImpl<char> &Path, StringRef OldPrefix,
 ///
 /// @param path Input path.
 /// @result The cleaned-up \a path.
-StringRef remove_leading_dotslash(StringRef path LLVM_LIFETIME_BOUND,
+LLVM_ABI StringRef remove_leading_dotslash(StringRef path LLVM_LIFETIME_BOUND,
                                   Style style = Style::native);
 
 /// In-place remove any './' and optionally '../' components from a path.
@@ -210,7 +211,7 @@ StringRef remove_leading_dotslash(StringRef path LLVM_LIFETIME_BOUND,
 /// @param remove_dot_dot specify if '../' (except for leading "../") should be
 /// removed
 /// @result True if path was changed
-bool remove_dots(SmallVectorImpl<char> &path, bool remove_dot_dot = false,
+LLVM_ABI bool remove_dots(SmallVectorImpl<char> &path, bool remove_dot_dot = false,
                  Style style = Style::native);
 
 /// Append to path.
@@ -223,12 +224,12 @@ bool remove_dots(SmallVectorImpl<char> &path, bool remove_dot_dot = false,
 ///
 /// @param path Set to \a path + \a component.
 /// @param a The component to be appended to \a path.
-void append(SmallVectorImpl<char> &path, const Twine &a,
+LLVM_ABI void append(SmallVectorImpl<char> &path, const Twine &a,
                                          const Twine &b = "",
                                          const Twine &c = "",
                                          const Twine &d = "");
 
-void append(SmallVectorImpl<char> &path, Style style, const Twine &a,
+LLVM_ABI void append(SmallVectorImpl<char> &path, Style style, const Twine &a,
             const Twine &b = "", const Twine &c = "", const Twine &d = "");
 
 /// Append to path.
@@ -242,7 +243,7 @@ void append(SmallVectorImpl<char> &path, Style style, const Twine &a,
 /// @param path Set to \a path + [\a begin, \a end).
 /// @param begin Start of components to append.
 /// @param end One past the end of components to append.
-void append(SmallVectorImpl<char> &path, const_iterator begin,
+LLVM_ABI void append(SmallVectorImpl<char> &path, const_iterator begin,
             const_iterator end, Style style = Style::native);
 
 /// @}
@@ -255,7 +256,7 @@ void append(SmallVectorImpl<char> &path, const_iterator begin,
 ///
 /// @param path A path that is transformed to native format.
 /// @param result Holds the result of the transformation.
-void native(const Twine &path, SmallVectorImpl<char> &result,
+LLVM_ABI void native(const Twine &path, SmallVectorImpl<char> &result,
             Style style = Style::native);
 
 /// Convert path to the native form in place. This is used to give paths to
@@ -263,7 +264,7 @@ void native(const Twine &path, SmallVectorImpl<char> &result,
 /// on Windows all '/' are converted to '\'.
 ///
 /// @param path A path that is transformed to native format.
-void native(SmallVectorImpl<char> &path, Style style = Style::native);
+LLVM_ABI void native(SmallVectorImpl<char> &path, Style style = Style::native);
 
 /// For Windows path styles, convert path to use the preferred path separators.
 /// For other styles, do nothing.
@@ -282,7 +283,7 @@ inline void make_preferred(SmallVectorImpl<char> &path,
 /// @result The result of replacing backslashes with forward slashes if Windows.
 /// On Unix, this function is a no-op because backslashes are valid path
 /// chracters.
-std::string convert_to_slash(StringRef path, Style style = Style::native);
+LLVM_ABI std::string convert_to_slash(StringRef path, Style style = Style::native);
 
 /// @}
 /// @name Lexical Observers
@@ -298,7 +299,7 @@ std::string convert_to_slash(StringRef path, Style style = Style::native);
 ///
 /// @param path Input path.
 /// @result The root name of \a path if it has one, otherwise "".
-StringRef root_name(StringRef path LLVM_LIFETIME_BOUND,
+LLVM_ABI StringRef root_name(StringRef path LLVM_LIFETIME_BOUND,
                     Style style = Style::native);
 
 /// Get root directory.
@@ -312,7 +313,7 @@ StringRef root_name(StringRef path LLVM_LIFETIME_BOUND,
 /// @param path Input path.
 /// @result The root directory of \a path if it has one, otherwise
 ///               "".
-StringRef root_directory(StringRef path LLVM_LIFETIME_BOUND,
+LLVM_ABI StringRef root_directory(StringRef path LLVM_LIFETIME_BOUND,
                          Style style = Style::native);
 
 /// Get root path.
@@ -321,7 +322,7 @@ StringRef root_directory(StringRef path LLVM_LIFETIME_BOUND,
 ///
 /// @param path Input path.
 /// @result The root path of \a path if it has one, otherwise "".
-StringRef root_path(StringRef path LLVM_LIFETIME_BOUND,
+LLVM_ABI StringRef root_path(StringRef path LLVM_LIFETIME_BOUND,
                     Style style = Style::native);
 
 /// Get relative path.
@@ -334,7 +335,7 @@ StringRef root_path(StringRef path LLVM_LIFETIME_BOUND,
 ///
 /// @param path Input path.
 /// @result The path starting after root_path if one exists, otherwise "".
-StringRef relative_path(StringRef path LLVM_LIFETIME_BOUND,
+LLVM_ABI StringRef relative_path(StringRef path LLVM_LIFETIME_BOUND,
                         Style style = Style::native);
 
 /// Get parent path.
@@ -347,7 +348,7 @@ StringRef relative_path(StringRef path LLVM_LIFETIME_BOUND,
 ///
 /// @param path Input path.
 /// @result The parent path of \a path if one exists, otherwise "".
-StringRef parent_path(StringRef path LLVM_LIFETIME_BOUND,
+LLVM_ABI StringRef parent_path(StringRef path LLVM_LIFETIME_BOUND,
                       Style style = Style::native);
 
 /// Get filename.
@@ -362,7 +363,7 @@ StringRef parent_path(StringRef path LLVM_LIFETIME_BOUND,
 /// @param path Input path.
 /// @result The filename part of \a path. This is defined as the last component
 ///         of \a path. Similar to the POSIX "basename" utility.
-StringRef filename(StringRef path LLVM_LIFETIME_BOUND,
+LLVM_ABI StringRef filename(StringRef path LLVM_LIFETIME_BOUND,
                    Style style = Style::native);
 
 /// Get stem.
@@ -381,7 +382,7 @@ StringRef filename(StringRef path LLVM_LIFETIME_BOUND,
 ///
 /// @param path Input path.
 /// @result The stem of \a path.
-StringRef stem(StringRef path LLVM_LIFETIME_BOUND, Style style = Style::native);
+LLVM_ABI StringRef stem(StringRef path LLVM_LIFETIME_BOUND, Style style = Style::native);
 
 /// Get extension.
 ///
@@ -397,19 +398,19 @@ StringRef stem(StringRef path LLVM_LIFETIME_BOUND, Style style = Style::native);
 ///
 /// @param path Input path.
 /// @result The extension of \a path.
-StringRef extension(StringRef path LLVM_LIFETIME_BOUND,
+LLVM_ABI StringRef extension(StringRef path LLVM_LIFETIME_BOUND,
                     Style style = Style::native);
 
 /// Check whether the given char is a path separator on the host OS.
 ///
 /// @param value a character
 /// @result true if \a value is a path separator character on the host OS
-bool is_separator(char value, Style style = Style::native);
+LLVM_ABI bool is_separator(char value, Style style = Style::native);
 
 /// Return the preferred separator for this platform.
 ///
 /// @result StringRef of the preferred separator, null-terminated.
-StringRef get_separator(Style style = Style::native);
+LLVM_ABI StringRef get_separator(Style style = Style::native);
 
 /// Get the typical temporary directory for the system, e.g.,
 /// "/var/tmp" or "C:/TEMP"
@@ -420,27 +421,27 @@ StringRef get_separator(Style style = Style::native);
 /// (e.g., TEMP on Windows, TMPDIR on *nix) to specify a temporary directory.
 ///
 /// @param result Holds the resulting path name.
-void system_temp_directory(bool erasedOnReboot, SmallVectorImpl<char> &result);
+LLVM_ABI void system_temp_directory(bool erasedOnReboot, SmallVectorImpl<char> &result);
 
 /// Get the user's home directory.
 ///
 /// @param result Holds the resulting path name.
 /// @result True if a home directory is set, false otherwise.
-bool home_directory(SmallVectorImpl<char> &result);
+LLVM_ABI bool home_directory(SmallVectorImpl<char> &result);
 
 /// Get the directory where packages should read user-specific configurations.
 /// e.g. $XDG_CONFIG_HOME.
 ///
 /// @param result Holds the resulting path name.
 /// @result True if the appropriate path was determined, it need not exist.
-bool user_config_directory(SmallVectorImpl<char> &result);
+LLVM_ABI bool user_config_directory(SmallVectorImpl<char> &result);
 
 /// Get the directory where installed packages should put their
 /// machine-local cache, e.g. $XDG_CACHE_HOME.
 ///
 /// @param result Holds the resulting path name.
 /// @result True if the appropriate path was determined, it need not exist.
-bool cache_directory(SmallVectorImpl<char> &result);
+LLVM_ABI bool cache_directory(SmallVectorImpl<char> &result);
 
 /// Has root name?
 ///
@@ -448,7 +449,7 @@ bool cache_directory(SmallVectorImpl<char> &result);
 ///
 /// @param path Input path.
 /// @result True if the path has a root name, false otherwise.
-bool has_root_name(const Twine &path, Style style = Style::native);
+LLVM_ABI bool has_root_name(const Twine &path, Style style = Style::native);
 
 /// Has root directory?
 ///
@@ -456,7 +457,7 @@ bool has_root_name(const Twine &path, Style style = Style::native);
 ///
 /// @param path Input path.
 /// @result True if the path has a root directory, false otherwise.
-bool has_root_directory(const Twine &path, Style style = Style::native);
+LLVM_ABI bool has_root_directory(const Twine &path, Style style = Style::native);
 
 /// Has root path?
 ///
@@ -464,7 +465,7 @@ bool has_root_directory(const Twine &path, Style style = Style::native);
 ///
 /// @param path Input path.
 /// @result True if the path has a root path, false otherwise.
-bool has_root_path(const Twine &path, Style style = Style::native);
+LLVM_ABI bool has_root_path(const Twine &path, Style style = Style::native);
 
 /// Has relative path?
 ///
@@ -472,7 +473,7 @@ bool has_root_path(const Twine &path, Style style = Style::native);
 ///
 /// @param path Input path.
 /// @result True if the path has a relative path, false otherwise.
-bool has_relative_path(const Twine &path, Style style = Style::native);
+LLVM_ABI bool has_relative_path(const Twine &path, Style style = Style::native);
 
 /// Has parent path?
 ///
@@ -480,7 +481,7 @@ bool has_relative_path(const Twine &path, Style style = Style::native);
 ///
 /// @param path Input path.
 /// @result True if the path has a parent path, false otherwise.
-bool has_parent_path(const Twine &path, Style style = Style::native);
+LLVM_ABI bool has_parent_path(const Twine &path, Style style = Style::native);
 
 /// Has filename?
 ///
@@ -488,7 +489,7 @@ bool has_parent_path(const Twine &path, Style style = Style::native);
 ///
 /// @param path Input path.
 /// @result True if the path has a filename, false otherwise.
-bool has_filename(const Twine &path, Style style = Style::native);
+LLVM_ABI bool has_filename(const Twine &path, Style style = Style::native);
 
 /// Has stem?
 ///
@@ -496,7 +497,7 @@ bool has_filename(const Twine &path, Style style = Style::native);
 ///
 /// @param path Input path.
 /// @result True if the path has a stem, false otherwise.
-bool has_stem(const Twine &path, Style style = Style::native);
+LLVM_ABI bool has_stem(const Twine &path, Style style = Style::native);
 
 /// Has extension?
 ///
@@ -504,7 +505,7 @@ bool has_stem(const Twine &path, Style style = Style::native);
 ///
 /// @param path Input path.
 /// @result True if the path has a extension, false otherwise.
-bool has_extension(const Twine &path, Style style = Style::native);
+LLVM_ABI bool has_extension(const Twine &path, Style style = Style::native);
 
 /// Is path absolute?
 ///
@@ -523,7 +524,7 @@ bool has_extension(const Twine &path, Style style = Style::native);
 ///
 /// @param path Input path.
 /// @result True if the path is absolute, false if it is not.
-bool is_absolute(const Twine &path, Style style = Style::native);
+LLVM_ABI bool is_absolute(const Twine &path, Style style = Style::native);
 
 /// Is path absolute using GNU rules?
 ///
@@ -548,13 +549,13 @@ bool is_absolute(const Twine &path, Style style = Style::native);
 /// means to derive the style from the host.
 /// @result True if the path is absolute following GNU rules, false if it is
 /// not.
-bool is_absolute_gnu(const Twine &path, Style style = Style::native);
+LLVM_ABI bool is_absolute_gnu(const Twine &path, Style style = Style::native);
 
 /// Is path relative?
 ///
 /// @param path Input path.
 /// @result True if the path is relative, false if it is not.
-bool is_relative(const Twine &path, Style style = Style::native);
+LLVM_ABI bool is_relative(const Twine &path, Style style = Style::native);
 
 } // end namespace path
 } // end namespace sys

--- a/llvm/include/llvm/Support/Path.h
+++ b/llvm/include/llvm/Support/Path.h
@@ -80,8 +80,8 @@ class const_iterator
   Style S = Style::native; ///< The path style to use.
 
   // An end iterator has Position = Path.size() + 1.
-  friend const_iterator begin(StringRef path, Style style);
-  friend const_iterator end(StringRef path);
+  LLVM_ABI_FRIEND friend const_iterator begin(StringRef path, Style style);
+  LLVM_ABI_FRIEND friend const_iterator end(StringRef path);
 
 public:
   reference operator*() const { return Component; }
@@ -105,8 +105,8 @@ class reverse_iterator
   size_t    Position = 0;  ///< The iterators current position within Path.
   Style S = Style::native; ///< The path style to use.
 
-  friend reverse_iterator rbegin(StringRef path, Style style);
-  friend reverse_iterator rend(StringRef path);
+  LLVM_ABI_FRIEND friend reverse_iterator rbegin(StringRef path, Style style);
+  LLVM_ABI_FRIEND friend reverse_iterator rend(StringRef path);
 
 public:
   reference operator*() const { return Component; }

--- a/llvm/include/llvm/Support/Path.h
+++ b/llvm/include/llvm/Support/Path.h
@@ -15,9 +15,9 @@
 #ifndef LLVM_SUPPORT_PATH_H
 #define LLVM_SUPPORT_PATH_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/ADT/iterator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 #include <iterator>
 
@@ -85,7 +85,7 @@ class const_iterator
 
 public:
   reference operator*() const { return Component; }
-  LLVM_ABI const_iterator &operator++();    // preincrement
+  LLVM_ABI const_iterator &operator++(); // preincrement
   LLVM_ABI bool operator==(const const_iterator &RHS) const;
 
   /// Difference in bytes between this and RHS.
@@ -110,7 +110,7 @@ class reverse_iterator
 
 public:
   reference operator*() const { return Component; }
-  LLVM_ABI reverse_iterator &operator++();    // preincrement
+  LLVM_ABI reverse_iterator &operator++(); // preincrement
   LLVM_ABI bool operator==(const reverse_iterator &RHS) const;
 
   /// Difference in bytes between this and RHS.
@@ -121,7 +121,7 @@ public:
 /// @param path Input path.
 /// @returns Iterator initialized with the first component of \a path.
 LLVM_ABI const_iterator begin(StringRef path LLVM_LIFETIME_BOUND,
-                     Style style = Style::native);
+                              Style style = Style::native);
 
 /// Get end iterator over \a path.
 /// @param path Input path.
@@ -132,7 +132,7 @@ LLVM_ABI const_iterator end(StringRef path LLVM_LIFETIME_BOUND);
 /// @param path Input path.
 /// @returns Iterator initialized with the first reverse component of \a path.
 LLVM_ABI reverse_iterator rbegin(StringRef path LLVM_LIFETIME_BOUND,
-                        Style style = Style::native);
+                                 Style style = Style::native);
 
 /// Get reverse end iterator over \a path.
 /// @param path Input path.
@@ -155,7 +155,8 @@ LLVM_ABI reverse_iterator rend(StringRef path LLVM_LIFETIME_BOUND);
 /// @endcode
 ///
 /// @param path A path that is modified to not have a file component.
-LLVM_ABI void remove_filename(SmallVectorImpl<char> &path, Style style = Style::native);
+LLVM_ABI void remove_filename(SmallVectorImpl<char> &path,
+                              Style style = Style::native);
 
 /// Replace the file extension of \a path with \a extension.
 ///
@@ -169,8 +170,9 @@ LLVM_ABI void remove_filename(SmallVectorImpl<char> &path, Style style = Style::
 /// @param extension The extension to be added. It may be empty. It may also
 ///                  optionally start with a '.', if it does not, one will be
 ///                  prepended.
-LLVM_ABI void replace_extension(SmallVectorImpl<char> &path, const Twine &extension,
-                       Style style = Style::native);
+LLVM_ABI void replace_extension(SmallVectorImpl<char> &path,
+                                const Twine &extension,
+                                Style style = Style::native);
 
 /// Replace matching path prefix with another path.
 ///
@@ -194,16 +196,16 @@ LLVM_ABI void replace_extension(SmallVectorImpl<char> &path, const Twine &extens
 /// @param style The style used to match the prefix. Exact match using
 /// Posix style, case/separator insensitive match for Windows style.
 /// @result true if \a Path begins with OldPrefix
-LLVM_ABI bool replace_path_prefix(SmallVectorImpl<char> &Path, StringRef OldPrefix,
-                         StringRef NewPrefix,
-                         Style style = Style::native);
+LLVM_ABI bool replace_path_prefix(SmallVectorImpl<char> &Path,
+                                  StringRef OldPrefix, StringRef NewPrefix,
+                                  Style style = Style::native);
 
 /// Remove redundant leading "./" pieces and consecutive separators.
 ///
 /// @param path Input path.
 /// @result The cleaned-up \a path.
 LLVM_ABI StringRef remove_leading_dotslash(StringRef path LLVM_LIFETIME_BOUND,
-                                  Style style = Style::native);
+                                           Style style = Style::native);
 
 /// In-place remove any './' and optionally '../' components from a path.
 ///
@@ -211,8 +213,9 @@ LLVM_ABI StringRef remove_leading_dotslash(StringRef path LLVM_LIFETIME_BOUND,
 /// @param remove_dot_dot specify if '../' (except for leading "../") should be
 /// removed
 /// @result True if path was changed
-LLVM_ABI bool remove_dots(SmallVectorImpl<char> &path, bool remove_dot_dot = false,
-                 Style style = Style::native);
+LLVM_ABI bool remove_dots(SmallVectorImpl<char> &path,
+                          bool remove_dot_dot = false,
+                          Style style = Style::native);
 
 /// Append to path.
 ///
@@ -225,12 +228,12 @@ LLVM_ABI bool remove_dots(SmallVectorImpl<char> &path, bool remove_dot_dot = fal
 /// @param path Set to \a path + \a component.
 /// @param a The component to be appended to \a path.
 LLVM_ABI void append(SmallVectorImpl<char> &path, const Twine &a,
-                                         const Twine &b = "",
-                                         const Twine &c = "",
-                                         const Twine &d = "");
+                     const Twine &b = "", const Twine &c = "",
+                     const Twine &d = "");
 
 LLVM_ABI void append(SmallVectorImpl<char> &path, Style style, const Twine &a,
-            const Twine &b = "", const Twine &c = "", const Twine &d = "");
+                     const Twine &b = "", const Twine &c = "",
+                     const Twine &d = "");
 
 /// Append to path.
 ///
@@ -244,7 +247,7 @@ LLVM_ABI void append(SmallVectorImpl<char> &path, Style style, const Twine &a,
 /// @param begin Start of components to append.
 /// @param end One past the end of components to append.
 LLVM_ABI void append(SmallVectorImpl<char> &path, const_iterator begin,
-            const_iterator end, Style style = Style::native);
+                     const_iterator end, Style style = Style::native);
 
 /// @}
 /// @name Transforms (or some other better name)
@@ -257,7 +260,7 @@ LLVM_ABI void append(SmallVectorImpl<char> &path, const_iterator begin,
 /// @param path A path that is transformed to native format.
 /// @param result Holds the result of the transformation.
 LLVM_ABI void native(const Twine &path, SmallVectorImpl<char> &result,
-            Style style = Style::native);
+                     Style style = Style::native);
 
 /// Convert path to the native form in place. This is used to give paths to
 /// users and operating system calls in the platform's normal way. For example,
@@ -283,7 +286,8 @@ inline void make_preferred(SmallVectorImpl<char> &path,
 /// @result The result of replacing backslashes with forward slashes if Windows.
 /// On Unix, this function is a no-op because backslashes are valid path
 /// chracters.
-LLVM_ABI std::string convert_to_slash(StringRef path, Style style = Style::native);
+LLVM_ABI std::string convert_to_slash(StringRef path,
+                                      Style style = Style::native);
 
 /// @}
 /// @name Lexical Observers
@@ -300,7 +304,7 @@ LLVM_ABI std::string convert_to_slash(StringRef path, Style style = Style::nativ
 /// @param path Input path.
 /// @result The root name of \a path if it has one, otherwise "".
 LLVM_ABI StringRef root_name(StringRef path LLVM_LIFETIME_BOUND,
-                    Style style = Style::native);
+                             Style style = Style::native);
 
 /// Get root directory.
 ///
@@ -314,7 +318,7 @@ LLVM_ABI StringRef root_name(StringRef path LLVM_LIFETIME_BOUND,
 /// @result The root directory of \a path if it has one, otherwise
 ///               "".
 LLVM_ABI StringRef root_directory(StringRef path LLVM_LIFETIME_BOUND,
-                         Style style = Style::native);
+                                  Style style = Style::native);
 
 /// Get root path.
 ///
@@ -323,7 +327,7 @@ LLVM_ABI StringRef root_directory(StringRef path LLVM_LIFETIME_BOUND,
 /// @param path Input path.
 /// @result The root path of \a path if it has one, otherwise "".
 LLVM_ABI StringRef root_path(StringRef path LLVM_LIFETIME_BOUND,
-                    Style style = Style::native);
+                             Style style = Style::native);
 
 /// Get relative path.
 ///
@@ -336,7 +340,7 @@ LLVM_ABI StringRef root_path(StringRef path LLVM_LIFETIME_BOUND,
 /// @param path Input path.
 /// @result The path starting after root_path if one exists, otherwise "".
 LLVM_ABI StringRef relative_path(StringRef path LLVM_LIFETIME_BOUND,
-                        Style style = Style::native);
+                                 Style style = Style::native);
 
 /// Get parent path.
 ///
@@ -349,7 +353,7 @@ LLVM_ABI StringRef relative_path(StringRef path LLVM_LIFETIME_BOUND,
 /// @param path Input path.
 /// @result The parent path of \a path if one exists, otherwise "".
 LLVM_ABI StringRef parent_path(StringRef path LLVM_LIFETIME_BOUND,
-                      Style style = Style::native);
+                               Style style = Style::native);
 
 /// Get filename.
 ///
@@ -364,7 +368,7 @@ LLVM_ABI StringRef parent_path(StringRef path LLVM_LIFETIME_BOUND,
 /// @result The filename part of \a path. This is defined as the last component
 ///         of \a path. Similar to the POSIX "basename" utility.
 LLVM_ABI StringRef filename(StringRef path LLVM_LIFETIME_BOUND,
-                   Style style = Style::native);
+                            Style style = Style::native);
 
 /// Get stem.
 ///
@@ -382,7 +386,8 @@ LLVM_ABI StringRef filename(StringRef path LLVM_LIFETIME_BOUND,
 ///
 /// @param path Input path.
 /// @result The stem of \a path.
-LLVM_ABI StringRef stem(StringRef path LLVM_LIFETIME_BOUND, Style style = Style::native);
+LLVM_ABI StringRef stem(StringRef path LLVM_LIFETIME_BOUND,
+                        Style style = Style::native);
 
 /// Get extension.
 ///
@@ -399,7 +404,7 @@ LLVM_ABI StringRef stem(StringRef path LLVM_LIFETIME_BOUND, Style style = Style:
 /// @param path Input path.
 /// @result The extension of \a path.
 LLVM_ABI StringRef extension(StringRef path LLVM_LIFETIME_BOUND,
-                    Style style = Style::native);
+                             Style style = Style::native);
 
 /// Check whether the given char is a path separator on the host OS.
 ///
@@ -421,7 +426,8 @@ LLVM_ABI StringRef get_separator(Style style = Style::native);
 /// (e.g., TEMP on Windows, TMPDIR on *nix) to specify a temporary directory.
 ///
 /// @param result Holds the resulting path name.
-LLVM_ABI void system_temp_directory(bool erasedOnReboot, SmallVectorImpl<char> &result);
+LLVM_ABI void system_temp_directory(bool erasedOnReboot,
+                                    SmallVectorImpl<char> &result);
 
 /// Get the user's home directory.
 ///
@@ -457,7 +463,8 @@ LLVM_ABI bool has_root_name(const Twine &path, Style style = Style::native);
 ///
 /// @param path Input path.
 /// @result True if the path has a root directory, false otherwise.
-LLVM_ABI bool has_root_directory(const Twine &path, Style style = Style::native);
+LLVM_ABI bool has_root_directory(const Twine &path,
+                                 Style style = Style::native);
 
 /// Has root path?
 ///

--- a/llvm/include/llvm/Support/PluginLoader.h
+++ b/llvm/include/llvm/Support/PluginLoader.h
@@ -17,6 +17,7 @@
 #define LLVM_SUPPORT_PLUGINLOADER_H
 
 #ifndef DONT_GET_PLUGIN_LOADER_OPTION
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/CommandLine.h"
 #endif
 
@@ -24,9 +25,9 @@
 
 namespace llvm {
   struct PluginLoader {
-    void operator=(const std::string &Filename);
-    static unsigned getNumPlugins();
-    static std::string& getPlugin(unsigned num);
+    LLVM_ABI void operator=(const std::string &Filename);
+    LLVM_ABI static unsigned getNumPlugins();
+    LLVM_ABI static std::string& getPlugin(unsigned num);
   };
 
 #ifndef DONT_GET_PLUGIN_LOADER_OPTION

--- a/llvm/include/llvm/Support/PluginLoader.h
+++ b/llvm/include/llvm/Support/PluginLoader.h
@@ -16,9 +16,10 @@
 #ifndef LLVM_SUPPORT_PLUGINLOADER_H
 #define LLVM_SUPPORT_PLUGINLOADER_H
 
+#include "llvm/Support/Compiler.h"
+
 #ifndef DONT_GET_PLUGIN_LOADER_OPTION
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Compiler.h"
 #endif
 
 #include <string>

--- a/llvm/include/llvm/Support/PluginLoader.h
+++ b/llvm/include/llvm/Support/PluginLoader.h
@@ -17,8 +17,8 @@
 #define LLVM_SUPPORT_PLUGINLOADER_H
 
 #ifndef DONT_GET_PLUGIN_LOADER_OPTION
-#include "llvm/Support/Compiler.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Compiler.h"
 #endif
 
 #include <string>
@@ -27,7 +27,7 @@ namespace llvm {
   struct PluginLoader {
     LLVM_ABI void operator=(const std::string &Filename);
     LLVM_ABI static unsigned getNumPlugins();
-    LLVM_ABI static std::string& getPlugin(unsigned num);
+    LLVM_ABI static std::string &getPlugin(unsigned num);
   };
 
 #ifndef DONT_GET_PLUGIN_LOADER_OPTION

--- a/llvm/include/llvm/Support/PrettyStackTrace.h
+++ b/llvm/include/llvm/Support/PrettyStackTrace.h
@@ -35,7 +35,8 @@ namespace llvm {
   ///
   /// \see EnablePrettyStackTrace
   /// \see PrettyStackTraceEntry
-  LLVM_ABI void EnablePrettyStackTraceOnSigInfoForThisThread(bool ShouldEnable = true);
+  LLVM_ABI void
+  EnablePrettyStackTraceOnSigInfoForThisThread(bool ShouldEnable = true);
 
   /// Replaces the generic bug report message that is output upon
   /// a crash.

--- a/llvm/include/llvm/Support/PrettyStackTrace.h
+++ b/llvm/include/llvm/Support/PrettyStackTrace.h
@@ -24,7 +24,7 @@ namespace llvm {
   /// Enables dumping a "pretty" stack trace when the program crashes.
   ///
   /// \see PrettyStackTraceEntry
-  void EnablePrettyStackTrace();
+  LLVM_ABI void EnablePrettyStackTrace();
 
   /// Enables (or disables) dumping a "pretty" stack trace when the user sends
   /// SIGINFO or SIGUSR1 to the current process.
@@ -35,21 +35,21 @@ namespace llvm {
   ///
   /// \see EnablePrettyStackTrace
   /// \see PrettyStackTraceEntry
-  void EnablePrettyStackTraceOnSigInfoForThisThread(bool ShouldEnable = true);
+  LLVM_ABI void EnablePrettyStackTraceOnSigInfoForThisThread(bool ShouldEnable = true);
 
   /// Replaces the generic bug report message that is output upon
   /// a crash.
-  void setBugReportMsg(const char *Msg);
+  LLVM_ABI void setBugReportMsg(const char *Msg);
 
   /// Get the bug report message that will be output upon a crash.
-  const char *getBugReportMsg();
+  LLVM_ABI const char *getBugReportMsg();
 
   /// PrettyStackTraceEntry - This class is used to represent a frame of the
   /// "pretty" stack trace that is dumped when a program crashes. You can define
   /// subclasses of this and declare them on the program stack: when they are
   /// constructed and destructed, they will add their symbolic frames to a
   /// virtual stack trace.  This gets dumped out if the program crashes.
-  class PrettyStackTraceEntry {
+  class LLVM_ABI PrettyStackTraceEntry {
     friend PrettyStackTraceEntry *ReverseStackTrace(PrettyStackTraceEntry *);
 
     PrettyStackTraceEntry *NextEntry;
@@ -69,7 +69,7 @@ namespace llvm {
   /// PrettyStackTraceString - This object prints a specified string (which
   /// should not contain newlines) to the stream as the stack trace when a crash
   /// occurs.
-  class PrettyStackTraceString : public PrettyStackTraceEntry {
+  class LLVM_ABI PrettyStackTraceString : public PrettyStackTraceEntry {
     const char *Str;
   public:
     PrettyStackTraceString(const char *str) : Str(str) {}
@@ -79,7 +79,7 @@ namespace llvm {
   /// PrettyStackTraceFormat - This object prints a string (which may use
   /// printf-style formatting but should not contain newlines) to the stream
   /// as the stack trace when a crash occurs.
-  class PrettyStackTraceFormat : public PrettyStackTraceEntry {
+  class LLVM_ABI PrettyStackTraceFormat : public PrettyStackTraceEntry {
     llvm::SmallVector<char, 32> Str;
   public:
     PrettyStackTraceFormat(const char *Format, ...);
@@ -88,7 +88,7 @@ namespace llvm {
 
   /// PrettyStackTraceProgram - This object prints a specified program arguments
   /// to the stream as the stack trace when a crash occurs.
-  class PrettyStackTraceProgram : public PrettyStackTraceEntry {
+  class LLVM_ABI PrettyStackTraceProgram : public PrettyStackTraceEntry {
     int ArgC;
     const char *const *ArgV;
   public:
@@ -100,7 +100,7 @@ namespace llvm {
   };
 
   /// Returns the topmost element of the "pretty" stack state.
-  const void *SavePrettyStackState();
+  LLVM_ABI const void *SavePrettyStackState();
 
   /// Restores the topmost element of the "pretty" stack state to State, which
   /// should come from a previous call to SavePrettyStackState().  This is
@@ -109,7 +109,7 @@ namespace llvm {
   /// happens after a crash that's been recovered by CrashRecoveryContext
   /// doesn't have frames on it that were added in code unwound by the
   /// CrashRecoveryContext.
-  void RestorePrettyStackState(const void *State);
+  LLVM_ABI void RestorePrettyStackState(const void *State);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/Support/PrettyStackTrace.h
+++ b/llvm/include/llvm/Support/PrettyStackTrace.h
@@ -51,7 +51,8 @@ namespace llvm {
   /// constructed and destructed, they will add their symbolic frames to a
   /// virtual stack trace.  This gets dumped out if the program crashes.
   class LLVM_ABI PrettyStackTraceEntry {
-    friend PrettyStackTraceEntry *ReverseStackTrace(PrettyStackTraceEntry *);
+    LLVM_ABI_FRIEND friend PrettyStackTraceEntry *
+    ReverseStackTrace(PrettyStackTraceEntry *);
 
     PrettyStackTraceEntry *NextEntry;
     PrettyStackTraceEntry(const PrettyStackTraceEntry &) = delete;

--- a/llvm/include/llvm/Support/Process.h
+++ b/llvm/include/llvm/Support/Process.h
@@ -24,6 +24,7 @@
 #ifndef LLVM_SUPPORT_PROCESS_H
 #define LLVM_SUPPORT_PROCESS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Chrono.h"
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/Error.h"
@@ -45,14 +46,14 @@ public:
   using Pid = int32_t;
 
   /// Get the process's identifier.
-  static Pid getProcessId();
+  LLVM_ABI static Pid getProcessId();
 
   /// Get the process's page size.
   /// This may fail if the underlying syscall returns an error. In most cases,
   /// page size information is used for optimization, and this error can be
   /// safely discarded by calling consumeError, and an estimated page size
   /// substituted instead.
-  static Expected<unsigned> getPageSize();
+  LLVM_ABI static Expected<unsigned> getPageSize();
 
   /// Get the process's estimated page size.
   /// This function always succeeds, but if the underlying syscall to determine
@@ -72,7 +73,7 @@ public:
   /// by the process. This only counts the memory allocated via the malloc,
   /// calloc and realloc functions and includes any "free" holes in the
   /// allocated space.
-  static size_t GetMallocUsage();
+  LLVM_ABI static size_t GetMallocUsage();
 
   /// This static function will set \p user_time to the amount of CPU time
   /// spent in user (non-kernel) mode and \p sys_time to the amount of CPU
@@ -82,7 +83,7 @@ public:
   /// \param elapsed Returns the system_clock::now() giving current time
   /// \param user_time Returns the current amount of user time for the process
   /// \param sys_time Returns the current amount of system time for the process
-  static void GetTimeUsage(TimePoint<> &elapsed,
+  LLVM_ABI static void GetTimeUsage(TimePoint<> &elapsed,
                            std::chrono::nanoseconds &user_time,
                            std::chrono::nanoseconds &sys_time);
 
@@ -90,14 +91,14 @@ public:
   /// prevent core files or any other kind of large memory dumps that can
   /// occur when a program fails.
   /// Prevent core file generation.
-  static void PreventCoreFiles();
+  LLVM_ABI static void PreventCoreFiles();
 
   /// true if PreventCoreFiles has been called, false otherwise.
-  static bool AreCoreFilesPrevented();
+  LLVM_ABI static bool AreCoreFilesPrevented();
 
   // This function returns the environment variable \arg name's value as a UTF-8
   // string. \arg Name is assumed to be in UTF-8 encoding too.
-  static std::optional<std::string> GetEnv(StringRef name);
+  LLVM_ABI static std::optional<std::string> GetEnv(StringRef name);
 
   /// This function searches for an existing file in the list of directories
   /// in a PATH like environment variable, and returns the first file found,
@@ -105,12 +106,12 @@ public:
   /// variable.  If an ignore list is specified, then any folder which is in
   /// the PATH like environment variable but is also in IgnoreList is not
   /// considered.
-  static std::optional<std::string>
+  LLVM_ABI static std::optional<std::string>
   FindInEnvPath(StringRef EnvName, StringRef FileName,
                 ArrayRef<std::string> IgnoreList,
                 char Separator = EnvPathSeparator);
 
-  static std::optional<std::string>
+  LLVM_ABI static std::optional<std::string>
   FindInEnvPath(StringRef EnvName, StringRef FileName,
                 char Separator = EnvPathSeparator);
 
@@ -118,7 +119,7 @@ public:
   // and error) are properly mapped to a file descriptor before we use any of
   // them.  This should only be called by standalone programs, library
   // components should not call this.
-  static std::error_code FixupStandardFileDescriptors();
+  LLVM_ABI static std::error_code FixupStandardFileDescriptors();
 
   // This function safely closes a file descriptor.  It is not safe to retry
   // close(2) when it returns with errno equivalent to EINTR; this is because
@@ -127,93 +128,93 @@ public:
   //
   // N.B. Some operating systems, due to thread cancellation, cannot properly
   // guarantee that it will or will not be closed one way or the other!
-  static std::error_code SafelyCloseFileDescriptor(int FD);
+  LLVM_ABI static std::error_code SafelyCloseFileDescriptor(int FD);
 
   /// This function determines if the standard input is connected directly
   /// to a user's input (keyboard probably), rather than coming from a file
   /// or pipe.
-  static bool StandardInIsUserInput();
+  LLVM_ABI static bool StandardInIsUserInput();
 
   /// This function determines if the standard output is connected to a
   /// "tty" or "console" window. That is, the output would be displayed to
   /// the user rather than being put on a pipe or stored in a file.
-  static bool StandardOutIsDisplayed();
+  LLVM_ABI static bool StandardOutIsDisplayed();
 
   /// This function determines if the standard error is connected to a
   /// "tty" or "console" window. That is, the output would be displayed to
   /// the user rather than being put on a pipe or stored in a file.
-  static bool StandardErrIsDisplayed();
+  LLVM_ABI static bool StandardErrIsDisplayed();
 
   /// This function determines if the given file descriptor is connected to
   /// a "tty" or "console" window. That is, the output would be displayed to
   /// the user rather than being put on a pipe or stored in a file.
-  static bool FileDescriptorIsDisplayed(int fd);
+  LLVM_ABI static bool FileDescriptorIsDisplayed(int fd);
 
   /// This function determines if the given file descriptor is displayd and
   /// supports colors.
-  static bool FileDescriptorHasColors(int fd);
+  LLVM_ABI static bool FileDescriptorHasColors(int fd);
 
   /// This function determines the number of columns in the window
   /// if standard output is connected to a "tty" or "console"
   /// window. If standard output is not connected to a tty or
   /// console, or if the number of columns cannot be determined,
   /// this routine returns zero.
-  static unsigned StandardOutColumns();
+  LLVM_ABI static unsigned StandardOutColumns();
 
   /// This function determines the number of columns in the window
   /// if standard error is connected to a "tty" or "console"
   /// window. If standard error is not connected to a tty or
   /// console, or if the number of columns cannot be determined,
   /// this routine returns zero.
-  static unsigned StandardErrColumns();
+  LLVM_ABI static unsigned StandardErrColumns();
 
   /// This function determines whether the terminal connected to standard
   /// output supports colors. If standard output is not connected to a
   /// terminal, this function returns false.
-  static bool StandardOutHasColors();
+  LLVM_ABI static bool StandardOutHasColors();
 
   /// This function determines whether the terminal connected to standard
   /// error supports colors. If standard error is not connected to a
   /// terminal, this function returns false.
-  static bool StandardErrHasColors();
+  LLVM_ABI static bool StandardErrHasColors();
 
   /// Enables or disables whether ANSI escape sequences are used to output
   /// colors. This only has an effect on Windows.
   /// Note: Setting this option is not thread-safe and should only be done
   /// during initialization.
-  static void UseANSIEscapeCodes(bool enable);
+  LLVM_ABI static void UseANSIEscapeCodes(bool enable);
 
   /// Whether changing colors requires the output to be flushed.
   /// This is needed on systems that don't support escape sequences for
   /// changing colors.
-  static bool ColorNeedsFlush();
+  LLVM_ABI static bool ColorNeedsFlush();
 
   /// This function returns the colorcode escape sequences.
   /// If ColorNeedsFlush() is true then this function will change the colors
   /// and return an empty escape sequence. In that case it is the
   /// responsibility of the client to flush the output stream prior to
   /// calling this function.
-  static const char *OutputColor(char c, bool bold, bool bg);
+  LLVM_ABI static const char *OutputColor(char c, bool bold, bool bg);
 
   /// Same as OutputColor, but only enables the bold attribute.
-  static const char *OutputBold(bool bg);
+  LLVM_ABI static const char *OutputBold(bool bg);
 
   /// This function returns the escape sequence to reverse forground and
   /// background colors.
-  static const char *OutputReverse();
+  LLVM_ABI static const char *OutputReverse();
 
   /// Resets the terminals colors, or returns an escape sequence to do so.
-  static const char *ResetColor();
+  LLVM_ABI static const char *ResetColor();
 
   /// Get the result of a process wide random number generator. The
   /// generator will be automatically seeded in non-deterministic fashion.
-  static unsigned GetRandomNumber();
+  LLVM_ABI static unsigned GetRandomNumber();
 
   /// Equivalent to ::exit(), except when running inside a CrashRecoveryContext.
   /// In that case, the control flow will resume after RunSafely(), like for a
   /// crash, rather than exiting the current process.
   /// Use \arg NoCleanup for calling _exit() instead of exit().
-  [[noreturn]] static void Exit(int RetCode, bool NoCleanup = false);
+  [[noreturn]] LLVM_ABI static void Exit(int RetCode, bool NoCleanup = false);
 
 private:
   [[noreturn]] static void ExitNoCleanup(int RetCode);

--- a/llvm/include/llvm/Support/Process.h
+++ b/llvm/include/llvm/Support/Process.h
@@ -24,8 +24,8 @@
 #ifndef LLVM_SUPPORT_PROCESS_H
 #define LLVM_SUPPORT_PROCESS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Chrono.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Program.h"
@@ -84,8 +84,8 @@ public:
   /// \param user_time Returns the current amount of user time for the process
   /// \param sys_time Returns the current amount of system time for the process
   LLVM_ABI static void GetTimeUsage(TimePoint<> &elapsed,
-                           std::chrono::nanoseconds &user_time,
-                           std::chrono::nanoseconds &sys_time);
+                                    std::chrono::nanoseconds &user_time,
+                                    std::chrono::nanoseconds &sys_time);
 
   /// This function makes the necessary calls to the operating system to
   /// prevent core files or any other kind of large memory dumps that can

--- a/llvm/include/llvm/Support/Program.h
+++ b/llvm/include/llvm/Support/Program.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_SUPPORT_PROGRAM_H
 #define LLVM_SUPPORT_PROGRAM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Config/llvm-config.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/FileSystem.h"
 #include <chrono>
@@ -77,7 +77,7 @@ struct ProcessStatistics {
 /// \returns The fully qualified path to the first \p Name in \p Paths if it
 ///   exists. \p Name if \p Name has slashes in it. Otherwise an error.
 LLVM_ABI ErrorOr<std::string> findProgramByName(StringRef Name,
-                                       ArrayRef<StringRef> Paths = {});
+                                                ArrayRef<StringRef> Paths = {});
 
 // These functions change the specified standard stream (stdin or stdout) mode
 // based on the Flags. They return errc::success if the specified stream was
@@ -161,12 +161,12 @@ LLVM_ABI ProcessInfo ExecuteNoWait(
 /// Return true if the given arguments fit within system-specific
 /// argument length limits.
 LLVM_ABI bool commandLineFitsWithinSystemLimits(StringRef Program,
-                                       ArrayRef<StringRef> Args);
+                                                ArrayRef<StringRef> Args);
 
 /// Return true if the given arguments fit within system-specific
 /// argument length limits.
 LLVM_ABI bool commandLineFitsWithinSystemLimits(StringRef Program,
-                                       ArrayRef<const char *> Args);
+                                                ArrayRef<const char *> Args);
 
 /// File encoding options when writing contents that a non-UTF8 tool will
 /// read (on Windows systems). For UNIX, we always use UTF-8.
@@ -209,27 +209,27 @@ writeFileWithEncoding(StringRef FileName, StringRef Contents,
 /// \li 0 if the child process has not changed state.
 /// \note Users of this function should always check the ReturnCode member of
 /// the \see ProcessInfo returned from this function.
-LLVM_ABI ProcessInfo
-Wait(const ProcessInfo &PI, ///< The child process that should be waited on.
-     std::optional<unsigned> SecondsToWait, ///< If std::nullopt, waits until
-     ///< child has terminated.
-     ///< If a value, this specifies the amount of time to wait for the child
-     ///< process. If the time expires, and \p Polling is false, the child is
-     ///< killed and this < function returns. If the time expires and \p
-     ///< Polling is true, the child is resumed.
-     ///<
-     ///< If zero, this function will perform a non-blocking
-     ///< wait on the child process.
-     std::string *ErrMsg = nullptr, ///< If non-zero, provides a pointer to a
-     ///< string instance in which error messages will be returned. If the
-     ///< string is non-empty upon return an error occurred while invoking the
-     ///< program.
-     std::optional<ProcessStatistics> *ProcStat =
-         nullptr, ///< If non-zero, provides
-     /// a pointer to a structure in which process execution statistics will
-     /// be stored.
+LLVM_ABI ProcessInfo Wait(
+    const ProcessInfo &PI, ///< The child process that should be waited on.
+    std::optional<unsigned> SecondsToWait, ///< If std::nullopt, waits until
+    ///< child has terminated.
+    ///< If a value, this specifies the amount of time to wait for the child
+    ///< process. If the time expires, and \p Polling is false, the child is
+    ///< killed and this < function returns. If the time expires and \p
+    ///< Polling is true, the child is resumed.
+    ///<
+    ///< If zero, this function will perform a non-blocking
+    ///< wait on the child process.
+    std::string *ErrMsg = nullptr, ///< If non-zero, provides a pointer to a
+    ///< string instance in which error messages will be returned. If the
+    ///< string is non-empty upon return an error occurred while invoking the
+    ///< program.
+    std::optional<ProcessStatistics> *ProcStat =
+        nullptr, ///< If non-zero, provides
+    /// a pointer to a structure in which process execution statistics will
+    /// be stored.
 
-     bool Polling = false ///< If true, do not kill the process on timeout.
+    bool Polling = false ///< If true, do not kill the process on timeout.
 );
 
 /// Print a command argument, and optionally quote it.
@@ -240,7 +240,8 @@ LLVM_ABI void printArg(llvm::raw_ostream &OS, StringRef Arg, bool Quote);
 /// to build a single flat command line appropriate for calling CreateProcess
 /// on
 /// Windows.
-LLVM_ABI ErrorOr<std::wstring> flattenWindowsCommandLine(ArrayRef<StringRef> Args);
+LLVM_ABI ErrorOr<std::wstring>
+flattenWindowsCommandLine(ArrayRef<StringRef> Args);
 #endif
 } // namespace sys
 } // namespace llvm

--- a/llvm/include/llvm/Support/Program.h
+++ b/llvm/include/llvm/Support/Program.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_PROGRAM_H
 #define LLVM_SUPPORT_PROGRAM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Config/llvm-config.h"
@@ -52,7 +53,7 @@ struct ProcessInfo {
   /// The return code, set after execution.
   int ReturnCode;
 
-  ProcessInfo();
+  LLVM_ABI ProcessInfo();
 };
 
 /// This struct encapsulates information about a process execution.
@@ -75,20 +76,20 @@ struct ProcessStatistics {
 ///
 /// \returns The fully qualified path to the first \p Name in \p Paths if it
 ///   exists. \p Name if \p Name has slashes in it. Otherwise an error.
-ErrorOr<std::string> findProgramByName(StringRef Name,
+LLVM_ABI ErrorOr<std::string> findProgramByName(StringRef Name,
                                        ArrayRef<StringRef> Paths = {});
 
 // These functions change the specified standard stream (stdin or stdout) mode
 // based on the Flags. They return errc::success if the specified stream was
 // changed. Otherwise, a platform dependent error is returned.
-std::error_code ChangeStdinMode(fs::OpenFlags Flags);
-std::error_code ChangeStdoutMode(fs::OpenFlags Flags);
+LLVM_ABI std::error_code ChangeStdinMode(fs::OpenFlags Flags);
+LLVM_ABI std::error_code ChangeStdoutMode(fs::OpenFlags Flags);
 
 // These functions change the specified standard stream (stdin or stdout) to
 // binary mode. They return errc::success if the specified stream
 // was changed. Otherwise a platform dependent error is returned.
-std::error_code ChangeStdinToBinary();
-std::error_code ChangeStdoutToBinary();
+LLVM_ABI std::error_code ChangeStdinToBinary();
+LLVM_ABI std::error_code ChangeStdoutToBinary();
 
 /// This function executes the program using the arguments provided.  The
 /// invoked program will inherit the stdin, stdout, and stderr file
@@ -101,7 +102,7 @@ std::error_code ChangeStdoutToBinary();
 /// A zero or positive value indicates the result code of the program.
 /// -1 indicates failure to execute
 /// -2 indicates a crash during execution or timeout
-int ExecuteAndWait(
+LLVM_ABI int ExecuteAndWait(
     StringRef Program, ///< Path of the program to be executed. It is
     ///< presumed this is the result of the findProgramByName method.
     ArrayRef<StringRef> Args, ///< An array of strings that are passed to the
@@ -146,7 +147,7 @@ int ExecuteAndWait(
 /// \note On Microsoft Windows systems, users will need to either call
 /// \ref Wait until the process has finished executing or win32's CloseHandle
 /// API on ProcessInfo.ProcessHandle to avoid memory leaks.
-ProcessInfo ExecuteNoWait(
+LLVM_ABI ProcessInfo ExecuteNoWait(
     StringRef Program, ArrayRef<StringRef> Args,
     std::optional<ArrayRef<StringRef>> Env,
     ArrayRef<std::optional<StringRef>> Redirects = {}, unsigned MemoryLimit = 0,
@@ -159,12 +160,12 @@ ProcessInfo ExecuteNoWait(
 
 /// Return true if the given arguments fit within system-specific
 /// argument length limits.
-bool commandLineFitsWithinSystemLimits(StringRef Program,
+LLVM_ABI bool commandLineFitsWithinSystemLimits(StringRef Program,
                                        ArrayRef<StringRef> Args);
 
 /// Return true if the given arguments fit within system-specific
 /// argument length limits.
-bool commandLineFitsWithinSystemLimits(StringRef Program,
+LLVM_ABI bool commandLineFitsWithinSystemLimits(StringRef Program,
                                        ArrayRef<const char *> Args);
 
 /// File encoding options when writing contents that a non-UTF8 tool will
@@ -197,7 +198,7 @@ enum WindowsEncodingMethod {
 /// should be changed as soon as binutils fix this to support UTF16 on mingw.
 ///
 /// \returns non-zero error_code if failed
-std::error_code
+LLVM_ABI std::error_code
 writeFileWithEncoding(StringRef FileName, StringRef Contents,
                       WindowsEncodingMethod Encoding = WEM_UTF8);
 
@@ -208,7 +209,7 @@ writeFileWithEncoding(StringRef FileName, StringRef Contents,
 /// \li 0 if the child process has not changed state.
 /// \note Users of this function should always check the ReturnCode member of
 /// the \see ProcessInfo returned from this function.
-ProcessInfo
+LLVM_ABI ProcessInfo
 Wait(const ProcessInfo &PI, ///< The child process that should be waited on.
      std::optional<unsigned> SecondsToWait, ///< If std::nullopt, waits until
      ///< child has terminated.
@@ -232,14 +233,14 @@ Wait(const ProcessInfo &PI, ///< The child process that should be waited on.
 );
 
 /// Print a command argument, and optionally quote it.
-void printArg(llvm::raw_ostream &OS, StringRef Arg, bool Quote);
+LLVM_ABI void printArg(llvm::raw_ostream &OS, StringRef Arg, bool Quote);
 
 #if defined(_WIN32)
 /// Given a list of command line arguments, quote and escape them as necessary
 /// to build a single flat command line appropriate for calling CreateProcess
 /// on
 /// Windows.
-ErrorOr<std::wstring> flattenWindowsCommandLine(ArrayRef<StringRef> Args);
+LLVM_ABI ErrorOr<std::wstring> flattenWindowsCommandLine(ArrayRef<StringRef> Args);
 #endif
 } // namespace sys
 } // namespace llvm

--- a/llvm/include/llvm/Support/RISCVAttributeParser.h
+++ b/llvm/include/llvm/Support/RISCVAttributeParser.h
@@ -9,11 +9,12 @@
 #ifndef LLVM_SUPPORT_RISCVATTRIBUTEPARSER_H
 #define LLVM_SUPPORT_RISCVATTRIBUTEPARSER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ELFAttrParserCompact.h"
 #include "llvm/Support/RISCVAttributes.h"
 
 namespace llvm {
-class RISCVAttributeParser : public ELFCompactAttrParser {
+class LLVM_ABI RISCVAttributeParser : public ELFCompactAttrParser {
   struct DisplayHandler {
     RISCVAttrs::AttrType attribute;
     Error (RISCVAttributeParser::*routine)(unsigned);

--- a/llvm/include/llvm/Support/RISCVAttributes.h
+++ b/llvm/include/llvm/Support/RISCVAttributes.h
@@ -17,12 +17,13 @@
 #ifndef LLVM_SUPPORT_RISCVATTRIBUTES_H
 #define LLVM_SUPPORT_RISCVATTRIBUTES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ELFAttributes.h"
 
 namespace llvm {
 namespace RISCVAttrs {
 
-const TagNameMap &getRISCVAttributeTags();
+LLVM_ABI const TagNameMap &getRISCVAttributeTags();
 
 enum AttrType : unsigned {
   // Attribute types in ELF/.riscv.attributes.

--- a/llvm/include/llvm/Support/RISCVISAUtils.h
+++ b/llvm/include/llvm/Support/RISCVISAUtils.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_SUPPORT_RISCVISAUTILS_H
 #define LLVM_SUPPORT_RISCVISAUTILS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include <map>
 #include <string>
 

--- a/llvm/include/llvm/Support/RISCVISAUtils.h
+++ b/llvm/include/llvm/Support/RISCVISAUtils.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_RISCVISAUTILS_H
 #define LLVM_SUPPORT_RISCVISAUTILS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include <map>
 #include <string>
@@ -28,7 +29,7 @@ struct ExtensionVersion {
   unsigned Minor;
 };
 
-bool compareExtension(const std::string &LHS, const std::string &RHS);
+LLVM_ABI bool compareExtension(const std::string &LHS, const std::string &RHS);
 
 /// Helper class for OrderedExtensionMap.
 struct ExtensionComparator {

--- a/llvm/include/llvm/Support/RandomNumberGenerator.h
+++ b/llvm/include/llvm/Support/RandomNumberGenerator.h
@@ -41,7 +41,7 @@ public:
   using result_type = generator_type::result_type;
 
   /// Returns a random number in the range [0, Max).
-  result_type operator()();
+  LLVM_ABI result_type operator()();
 
   static constexpr result_type min() { return generator_type::min(); }
   static constexpr result_type max() { return generator_type::max(); }
@@ -63,7 +63,7 @@ private:
 };
 
 // Get random vector of specified size
-std::error_code getRandomBytes(void *Buffer, size_t Size);
+LLVM_ABI std::error_code getRandomBytes(void *Buffer, size_t Size);
 }
 
 #endif

--- a/llvm/include/llvm/Support/Recycler.h
+++ b/llvm/include/llvm/Support/Recycler.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_RECYCLER_H
 #define LLVM_SUPPORT_RECYCLER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ilist.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -24,7 +25,7 @@ namespace llvm {
 /// PrintRecyclingAllocatorStats - Helper for RecyclingAllocator for
 /// printing statistics.
 ///
-void PrintRecyclerStats(size_t Size, size_t Align, size_t FreeListSize);
+LLVM_ABI void PrintRecyclerStats(size_t Size, size_t Align, size_t FreeListSize);
 
 /// Recycler - This class manages a linked-list of deallocated nodes
 /// and facilitates reusing deallocated memory in place of allocating

--- a/llvm/include/llvm/Support/Recycler.h
+++ b/llvm/include/llvm/Support/Recycler.h
@@ -14,9 +14,9 @@
 #ifndef LLVM_SUPPORT_RECYCLER_H
 #define LLVM_SUPPORT_RECYCLER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ilist.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <cassert>
 
@@ -25,7 +25,8 @@ namespace llvm {
 /// PrintRecyclingAllocatorStats - Helper for RecyclingAllocator for
 /// printing statistics.
 ///
-LLVM_ABI void PrintRecyclerStats(size_t Size, size_t Align, size_t FreeListSize);
+LLVM_ABI void PrintRecyclerStats(size_t Size, size_t Align,
+                                 size_t FreeListSize);
 
 /// Recycler - This class manages a linked-list of deallocated nodes
 /// and facilitates reusing deallocated memory in place of allocating

--- a/llvm/include/llvm/Support/Regex.h
+++ b/llvm/include/llvm/Support/Regex.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_SUPPORT_REGEX_H
 #define LLVM_SUPPORT_REGEX_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include <string>
 
@@ -45,31 +46,31 @@ namespace llvm {
       LLVM_MARK_AS_BITMASK_ENUM(BasicRegex)
     };
 
-    Regex();
+    LLVM_ABI Regex();
     /// Compiles the given regular expression \p Regex.
     ///
     /// \param Regex - referenced string is no longer needed after this
     /// constructor does finish.  Only its compiled form is kept stored.
-    Regex(StringRef Regex, RegexFlags Flags = NoFlags);
-    Regex(StringRef Regex, unsigned Flags);
+    LLVM_ABI Regex(StringRef Regex, RegexFlags Flags = NoFlags);
+    LLVM_ABI Regex(StringRef Regex, unsigned Flags);
     Regex(const Regex &) = delete;
     Regex &operator=(Regex regex) {
       std::swap(preg, regex.preg);
       std::swap(error, regex.error);
       return *this;
     }
-    Regex(Regex &&regex);
-    ~Regex();
+    LLVM_ABI Regex(Regex &&regex);
+    LLVM_ABI ~Regex();
 
     /// isValid - returns the error encountered during regex compilation, if
     /// any.
-    bool isValid(std::string &Error) const;
+    LLVM_ABI bool isValid(std::string &Error) const;
     bool isValid() const { return !error; }
 
     /// getNumMatches - In a valid regex, return the number of parenthesized
     /// matches it contains.  The number filled in by match will include this
     /// many entries plus one for the whole regex (as element 0).
-    unsigned getNumMatches() const;
+    LLVM_ABI unsigned getNumMatches() const;
 
     /// matches - Match the regex against a given \p String.
     ///
@@ -81,7 +82,7 @@ namespace llvm {
     /// as a non-empty string. If there is no error, it will be an empty string.
     ///
     /// This returns true on a successful match.
-    bool match(StringRef String, SmallVectorImpl<StringRef> *Matches = nullptr,
+    LLVM_ABI bool match(StringRef String, SmallVectorImpl<StringRef> *Matches = nullptr,
                std::string *Error = nullptr) const;
 
     /// sub - Return the result of replacing the first match of the regex in
@@ -95,15 +96,15 @@ namespace llvm {
     /// \param Error If non-null, any errors in the substitution (invalid
     /// backreferences, trailing backslashes) will be recorded as a non-empty
     /// string. If there is no error, it will be an empty string.
-    std::string sub(StringRef Repl, StringRef String,
+    LLVM_ABI std::string sub(StringRef Repl, StringRef String,
                     std::string *Error = nullptr) const;
 
     /// If this function returns true, ^Str$ is an extended regular
     /// expression that matches Str and only Str.
-    static bool isLiteralERE(StringRef Str);
+    LLVM_ABI static bool isLiteralERE(StringRef Str);
 
     /// Turn String into a regex by escaping its special characters.
-    static std::string escape(StringRef String);
+    LLVM_ABI static std::string escape(StringRef String);
 
   private:
     struct llvm_regex *preg;

--- a/llvm/include/llvm/Support/Regex.h
+++ b/llvm/include/llvm/Support/Regex.h
@@ -16,8 +16,8 @@
 #ifndef LLVM_SUPPORT_REGEX_H
 #define LLVM_SUPPORT_REGEX_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/BitmaskEnum.h"
+#include "llvm/Support/Compiler.h"
 #include <string>
 
 struct llvm_regex;
@@ -82,8 +82,9 @@ namespace llvm {
     /// as a non-empty string. If there is no error, it will be an empty string.
     ///
     /// This returns true on a successful match.
-    LLVM_ABI bool match(StringRef String, SmallVectorImpl<StringRef> *Matches = nullptr,
-               std::string *Error = nullptr) const;
+    LLVM_ABI bool match(StringRef String,
+                        SmallVectorImpl<StringRef> *Matches = nullptr,
+                        std::string *Error = nullptr) const;
 
     /// sub - Return the result of replacing the first match of the regex in
     /// \p String with the \p Repl string. Backreferences like "\0" and "\g<1>"
@@ -97,7 +98,7 @@ namespace llvm {
     /// backreferences, trailing backslashes) will be recorded as a non-empty
     /// string. If there is no error, it will be an empty string.
     LLVM_ABI std::string sub(StringRef Repl, StringRef String,
-                    std::string *Error = nullptr) const;
+                             std::string *Error = nullptr) const;
 
     /// If this function returns true, ^Str$ is an extended regular
     /// expression that matches Str and only Str.

--- a/llvm/include/llvm/Support/SHA1.h
+++ b/llvm/include/llvm/Support/SHA1.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_SUPPORT_SHA1_H
 #define LLVM_SUPPORT_SHA1_H
 
+#include "llvm/Support/Compiler.h"
 #include <array>
 #include <cstdint>
 
@@ -28,28 +29,28 @@ public:
   SHA1() { init(); }
 
   /// Reinitialize the internal state
-  void init();
+  LLVM_ABI void init();
 
   /// Digest more data.
-  void update(ArrayRef<uint8_t> Data);
+  LLVM_ABI void update(ArrayRef<uint8_t> Data);
 
   /// Digest more data.
-  void update(StringRef Str);
+  LLVM_ABI void update(StringRef Str);
 
   /// Return the current raw 160-bits SHA1 for the digested data
   /// since the last call to init(). This call will add data to the internal
   /// state and as such is not suited for getting an intermediate result
   /// (see result()).
-  std::array<uint8_t, 20> final();
+  LLVM_ABI std::array<uint8_t, 20> final();
 
   /// Return the current raw 160-bits SHA1 for the digested data
   /// since the last call to init(). This is suitable for getting the SHA1 at
   /// any time without invalidating the internal state so that more calls can be
   /// made into update.
-  std::array<uint8_t, 20> result();
+  LLVM_ABI std::array<uint8_t, 20> result();
 
   /// Returns a raw 160-bit SHA1 hash for the given data.
-  static std::array<uint8_t, 20> hash(ArrayRef<uint8_t> Data);
+  LLVM_ABI static std::array<uint8_t, 20> hash(ArrayRef<uint8_t> Data);
 
 private:
   /// Define some constants.

--- a/llvm/include/llvm/Support/SHA256.h
+++ b/llvm/include/llvm/Support/SHA256.h
@@ -22,6 +22,7 @@
 #ifndef LLVM_SUPPORT_SHA256_H
 #define LLVM_SUPPORT_SHA256_H
 
+#include "llvm/Support/Compiler.h"
 #include <array>
 #include <cstdint>
 
@@ -35,28 +36,28 @@ public:
   explicit SHA256() { init(); }
 
   /// Reinitialize the internal state
-  void init();
+  LLVM_ABI void init();
 
   /// Digest more data.
-  void update(ArrayRef<uint8_t> Data);
+  LLVM_ABI void update(ArrayRef<uint8_t> Data);
 
   /// Digest more data.
-  void update(StringRef Str);
+  LLVM_ABI void update(StringRef Str);
 
   /// Return the current raw 256-bits SHA256 for the digested
   /// data since the last call to init(). This call will add data to the
   /// internal state and as such is not suited for getting an intermediate
   /// result (see result()).
-  std::array<uint8_t, 32> final();
+  LLVM_ABI std::array<uint8_t, 32> final();
 
   /// Return the current raw 256-bits SHA256 for the digested
   /// data since the last call to init(). This is suitable for getting the
   /// SHA256 at any time without invalidating the internal state so that more
   /// calls can be made into update.
-  std::array<uint8_t, 32> result();
+  LLVM_ABI std::array<uint8_t, 32> result();
 
   /// Returns a raw 256-bit SHA256 hash for the given data.
-  static std::array<uint8_t, 32> hash(ArrayRef<uint8_t> Data);
+  LLVM_ABI static std::array<uint8_t, 32> hash(ArrayRef<uint8_t> Data);
 
 private:
   /// Define some constants.

--- a/llvm/include/llvm/Support/SMTAPI.h
+++ b/llvm/include/llvm/Support/SMTAPI.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_SMTAPI_H
 #define LLVM_SUPPORT_SMTAPI_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/FoldingSet.h"
@@ -70,7 +71,7 @@ public:
 
   virtual void print(raw_ostream &OS) const = 0;
 
-  LLVM_DUMP_METHOD void dump() const;
+  LLVM_ABI LLVM_DUMP_METHOD void dump() const;
 
 protected:
   /// Query the SMT solver and returns true if two sorts are equal (same kind
@@ -117,7 +118,7 @@ public:
 
   virtual void print(raw_ostream &OS) const = 0;
 
-  LLVM_DUMP_METHOD void dump() const;
+  LLVM_ABI LLVM_DUMP_METHOD void dump() const;
 
 protected:
   /// Query the SMT solver and returns true if two sorts are equal (same kind
@@ -135,7 +136,7 @@ public:
 
   virtual void print(raw_ostream &OS) const = 0;
 
-  LLVM_DUMP_METHOD void dump() const;
+  LLVM_ABI LLVM_DUMP_METHOD void dump() const;
 };
 
 /// Shared pointer for SMTExprs, used by SMTSolver API.
@@ -151,7 +152,7 @@ public:
   SMTSolver() = default;
   virtual ~SMTSolver() = default;
 
-  LLVM_DUMP_METHOD void dump() const;
+  LLVM_ABI LLVM_DUMP_METHOD void dump() const;
 
   // Returns an appropriate floating-point sort for the given bitwidth.
   SMTSortRef getFloatSort(unsigned BitWidth) {
@@ -459,7 +460,7 @@ public:
 using SMTSolverRef = std::shared_ptr<SMTSolver>;
 
 /// Convenience method to create and Z3Solver object
-SMTSolverRef CreateZ3Solver();
+LLVM_ABI SMTSolverRef CreateZ3Solver();
 
 } // namespace llvm
 

--- a/llvm/include/llvm/Support/SMTAPI.h
+++ b/llvm/include/llvm/Support/SMTAPI.h
@@ -14,10 +14,10 @@
 #ifndef LLVM_SUPPORT_SMTAPI_H
 #define LLVM_SUPPORT_SMTAPI_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/FoldingSet.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 #include <memory>
 

--- a/llvm/include/llvm/Support/ScaledNumber.h
+++ b/llvm/include/llvm/Support/ScaledNumber.h
@@ -136,14 +136,16 @@ inline std::pair<uint64_t, int16_t> getProduct64(uint64_t LHS, uint64_t RHS) {
 /// Implemented with long division.
 ///
 /// \pre \c Dividend and \c Divisor are non-zero.
-LLVM_ABI std::pair<uint64_t, int16_t> divide64(uint64_t Dividend, uint64_t Divisor);
+LLVM_ABI std::pair<uint64_t, int16_t> divide64(uint64_t Dividend,
+                                               uint64_t Divisor);
 
 /// Divide two 32-bit integers to create a 32-bit scaled number.
 ///
 /// Implemented with one 64-bit integer divide/remainder pair.
 ///
 /// \pre \c Dividend and \c Divisor are non-zero.
-LLVM_ABI std::pair<uint32_t, int16_t> divide32(uint32_t Dividend, uint32_t Divisor);
+LLVM_ABI std::pair<uint32_t, int16_t> divide32(uint32_t Dividend,
+                                               uint32_t Divisor);
 
 /// Divide two 32-bit numbers to create a 32-bit scaled number.
 ///
@@ -423,10 +425,10 @@ public:
   static constexpr int DefaultPrecision = 10;
 
   LLVM_ABI static void dump(uint64_t D, int16_t E, int Width);
-  LLVM_ABI static raw_ostream &print(raw_ostream &OS, uint64_t D, int16_t E, int Width,
-                            unsigned Precision);
+  LLVM_ABI static raw_ostream &print(raw_ostream &OS, uint64_t D, int16_t E,
+                                     int Width, unsigned Precision);
   LLVM_ABI static std::string toString(uint64_t D, int16_t E, int Width,
-                              unsigned Precision);
+                                       unsigned Precision);
   static int countLeadingZeros32(uint32_t N) { return llvm::countl_zero(N); }
   static int countLeadingZeros64(uint64_t N) { return llvm::countl_zero(N); }
   static uint64_t getHalf(uint64_t N) { return (N >> 1) + (N & 1); }

--- a/llvm/include/llvm/Support/ScaledNumber.h
+++ b/llvm/include/llvm/Support/ScaledNumber.h
@@ -21,6 +21,7 @@
 #ifndef LLVM_SUPPORT_SCALEDNUMBER_H
 #define LLVM_SUPPORT_SCALEDNUMBER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MathExtras.h"
 #include <algorithm>
 #include <cstdint>
@@ -105,7 +106,7 @@ inline std::pair<uint64_t, int16_t> getAdjusted64(uint64_t Digits,
 /// Multiply two 64-bit integers to create a 64-bit scaled number.
 ///
 /// Implemented with four 64-bit integer multiplies.
-std::pair<uint64_t, int16_t> multiply64(uint64_t LHS, uint64_t RHS);
+LLVM_ABI std::pair<uint64_t, int16_t> multiply64(uint64_t LHS, uint64_t RHS);
 
 /// Multiply two 32-bit integers to create a 32-bit scaled number.
 ///
@@ -135,14 +136,14 @@ inline std::pair<uint64_t, int16_t> getProduct64(uint64_t LHS, uint64_t RHS) {
 /// Implemented with long division.
 ///
 /// \pre \c Dividend and \c Divisor are non-zero.
-std::pair<uint64_t, int16_t> divide64(uint64_t Dividend, uint64_t Divisor);
+LLVM_ABI std::pair<uint64_t, int16_t> divide64(uint64_t Dividend, uint64_t Divisor);
 
 /// Divide two 32-bit integers to create a 32-bit scaled number.
 ///
 /// Implemented with one 64-bit integer divide/remainder pair.
 ///
 /// \pre \c Dividend and \c Divisor are non-zero.
-std::pair<uint32_t, int16_t> divide32(uint32_t Dividend, uint32_t Divisor);
+LLVM_ABI std::pair<uint32_t, int16_t> divide32(uint32_t Dividend, uint32_t Divisor);
 
 /// Divide two 32-bit numbers to create a 32-bit scaled number.
 ///
@@ -242,7 +243,7 @@ template <class DigitsT> int32_t getLgCeiling(DigitsT Digits, int16_t Scale) {
 /// 1, and 0 for less than, greater than, and equal, respectively.
 ///
 /// \pre 0 <= ScaleDiff < 64.
-int compareImpl(uint64_t L, uint64_t R, int ScaleDiff);
+LLVM_ABI int compareImpl(uint64_t L, uint64_t R, int ScaleDiff);
 
 /// Compare two scaled numbers.
 ///
@@ -421,10 +422,10 @@ class ScaledNumberBase {
 public:
   static constexpr int DefaultPrecision = 10;
 
-  static void dump(uint64_t D, int16_t E, int Width);
-  static raw_ostream &print(raw_ostream &OS, uint64_t D, int16_t E, int Width,
+  LLVM_ABI static void dump(uint64_t D, int16_t E, int Width);
+  LLVM_ABI static raw_ostream &print(raw_ostream &OS, uint64_t D, int16_t E, int Width,
                             unsigned Precision);
-  static std::string toString(uint64_t D, int16_t E, int Width,
+  LLVM_ABI static std::string toString(uint64_t D, int16_t E, int Width,
                               unsigned Precision);
   static int countLeadingZeros32(uint32_t N) { return llvm::countl_zero(N); }
   static int countLeadingZeros64(uint64_t N) { return llvm::countl_zero(N); }

--- a/llvm/include/llvm/Support/ScopedPrinter.h
+++ b/llvm/include/llvm/Support/ScopedPrinter.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_SCOPEDPRINTER_H
 #define LLVM_SUPPORT_SCOPEDPRINTER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
@@ -80,7 +81,7 @@ struct FlagEntry {
   uint64_t Value;
 };
 
-raw_ostream &operator<<(raw_ostream &OS, const HexNumber &Value);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, const HexNumber &Value);
 
 template <class T> std::string to_string(const T &Value) {
   std::string number;
@@ -97,7 +98,7 @@ std::string enumToString(T Value, ArrayRef<EnumEntry<TEnum>> EnumValues) {
   return utohexstr(Value, true);
 }
 
-class ScopedPrinter {
+class LLVM_ABI ScopedPrinter {
 public:
   enum class ScopedPrinterKind {
     Base,
@@ -572,7 +573,7 @@ private:
   std::unique_ptr<DelimitedScope> OuterScope;
 
 public:
-  JSONScopedPrinter(raw_ostream &OS, bool PrettyPrint = false,
+  LLVM_ABI JSONScopedPrinter(raw_ostream &OS, bool PrettyPrint = false,
                     std::unique_ptr<DelimitedScope> &&OuterScope =
                         std::unique_ptr<DelimitedScope>{});
 

--- a/llvm/include/llvm/Support/ScopedPrinter.h
+++ b/llvm/include/llvm/Support/ScopedPrinter.h
@@ -9,12 +9,12 @@
 #ifndef LLVM_SUPPORT_SCOPEDPRINTER_H
 #define LLVM_SUPPORT_SCOPEDPRINTER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/JSON.h"
@@ -574,8 +574,8 @@ private:
 
 public:
   LLVM_ABI JSONScopedPrinter(raw_ostream &OS, bool PrettyPrint = false,
-                    std::unique_ptr<DelimitedScope> &&OuterScope =
-                        std::unique_ptr<DelimitedScope>{});
+                             std::unique_ptr<DelimitedScope> &&OuterScope =
+                                 std::unique_ptr<DelimitedScope>{});
 
   static bool classof(const ScopedPrinter *SP) {
     return SP->getKind() == ScopedPrinter::ScopedPrinterKind::JSON;

--- a/llvm/include/llvm/Support/Signals.h
+++ b/llvm/include/llvm/Support/Signals.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_SIGNALS_H
 #define LLVM_SUPPORT_SIGNALS_H
 
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <string>
 
@@ -25,16 +26,16 @@ namespace sys {
 
 /// This function runs all the registered interrupt handlers, including the
 /// removal of files registered by RemoveFileOnSignal.
-void RunInterruptHandlers();
+LLVM_ABI void RunInterruptHandlers();
 
 /// This function registers signal handlers to ensure that if a signal gets
 /// delivered that the named file is removed.
 /// Remove a file if a fatal signal occurs.
-bool RemoveFileOnSignal(StringRef Filename, std::string *ErrMsg = nullptr);
+LLVM_ABI bool RemoveFileOnSignal(StringRef Filename, std::string *ErrMsg = nullptr);
 
 /// This function removes a file from the list of files to be removed on
 /// signal delivery.
-void DontRemoveFileOnSignal(StringRef Filename);
+LLVM_ABI void DontRemoveFileOnSignal(StringRef Filename);
 
 /// When an error signal (such as SIGABRT or SIGSEGV) is delivered to the
 /// process, print a stack trace and then exit.
@@ -44,26 +45,26 @@ void DontRemoveFileOnSignal(StringRef Filename);
 ///        StringRef(), in which case we will only search $PATH.
 /// \param DisableCrashReporting if \c true, disable the normal crash
 ///        reporting mechanisms on the underlying operating system.
-void PrintStackTraceOnErrorSignal(StringRef Argv0,
+LLVM_ABI void PrintStackTraceOnErrorSignal(StringRef Argv0,
                                   bool DisableCrashReporting = false);
 
 /// Disable all system dialog boxes that appear when the process crashes.
-void DisableSystemDialogsOnCrash();
+LLVM_ABI void DisableSystemDialogsOnCrash();
 
 /// Print the stack trace using the given \c raw_ostream object.
 /// \param Depth refers to the number of stackframes to print. If not
 ///        specified, the entire frame is printed.
-void PrintStackTrace(raw_ostream &OS, int Depth = 0);
+LLVM_ABI void PrintStackTrace(raw_ostream &OS, int Depth = 0);
 
 // Run all registered signal handlers.
-void RunSignalHandlers();
+LLVM_ABI void RunSignalHandlers();
 
 using SignalHandlerCallback = void (*)(void *);
 
 /// Add a function to be called when an abort/kill signal is delivered to the
 /// process. The handler can have a cookie passed to it to identify what
 /// instance of the handler it is.
-void AddSignalHandler(SignalHandlerCallback FnPtr, void *Cookie);
+LLVM_ABI void AddSignalHandler(SignalHandlerCallback FnPtr, void *Cookie);
 
 /// This function registers a function to be called when the user "interrupts"
 /// the program (typically by pressing ctrl-c).  When the user interrupts the
@@ -74,7 +75,7 @@ void AddSignalHandler(SignalHandlerCallback FnPtr, void *Cookie);
 /// functions.  An null interrupt function pointer disables the current
 /// installed function.  Note also that the handler may be executed on a
 /// different thread on some platforms.
-void SetInterruptFunction(void (*IF)());
+LLVM_ABI void SetInterruptFunction(void (*IF)());
 
 /// Registers a function to be called when an "info" signal is delivered to
 /// the process.
@@ -86,7 +87,7 @@ void SetInterruptFunction(void (*IF)());
 /// functions.  An null function pointer disables the current installed
 /// function.  Note also that the handler may be executed on a different
 /// thread on some platforms.
-void SetInfoSignalFunction(void (*Handler)());
+LLVM_ABI void SetInfoSignalFunction(void (*Handler)());
 
 /// Registers a function to be called in a "one-shot" manner when a pipe
 /// signal is delivered to the process (i.e., on a failed write to a pipe).
@@ -102,15 +103,15 @@ void SetInfoSignalFunction(void (*Handler)());
 /// functions.  A null handler pointer disables the current installed
 /// function.  Note also that the handler may be executed on a
 /// different thread on some platforms.
-void SetOneShotPipeSignalFunction(void (*Handler)());
+LLVM_ABI void SetOneShotPipeSignalFunction(void (*Handler)());
 
 /// On Unix systems and Windows, this function exits with an "IO error" exit
 /// code.
-void DefaultOneShotPipeSignalHandler();
+LLVM_ABI void DefaultOneShotPipeSignalHandler();
 
 #ifdef _WIN32
 /// Windows does not support signals and this handler must be called manually.
-void CallOneShotPipeSignalHandler();
+LLVM_ABI void CallOneShotPipeSignalHandler();
 #endif
 
 /// This function does the following:
@@ -120,9 +121,9 @@ void CallOneShotPipeSignalHandler();
 /// - create a core/mini dump of the exception context whenever possible
 /// Context is a system-specific failure context: it is the signal type on
 /// Unix; the ExceptionContext on Windows.
-void CleanupOnSignal(uintptr_t Context);
+LLVM_ABI void CleanupOnSignal(uintptr_t Context);
 
-void unregisterHandlers();
+LLVM_ABI void unregisterHandlers();
 } // namespace sys
 } // namespace llvm
 

--- a/llvm/include/llvm/Support/Signals.h
+++ b/llvm/include/llvm/Support/Signals.h
@@ -31,7 +31,8 @@ LLVM_ABI void RunInterruptHandlers();
 /// This function registers signal handlers to ensure that if a signal gets
 /// delivered that the named file is removed.
 /// Remove a file if a fatal signal occurs.
-LLVM_ABI bool RemoveFileOnSignal(StringRef Filename, std::string *ErrMsg = nullptr);
+LLVM_ABI bool RemoveFileOnSignal(StringRef Filename,
+                                 std::string *ErrMsg = nullptr);
 
 /// This function removes a file from the list of files to be removed on
 /// signal delivery.
@@ -46,7 +47,7 @@ LLVM_ABI void DontRemoveFileOnSignal(StringRef Filename);
 /// \param DisableCrashReporting if \c true, disable the normal crash
 ///        reporting mechanisms on the underlying operating system.
 LLVM_ABI void PrintStackTraceOnErrorSignal(StringRef Argv0,
-                                  bool DisableCrashReporting = false);
+                                           bool DisableCrashReporting = false);
 
 /// Disable all system dialog boxes that appear when the process crashes.
 LLVM_ABI void DisableSystemDialogsOnCrash();

--- a/llvm/include/llvm/Support/Signposts.h
+++ b/llvm/include/llvm/Support/Signposts.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_SUPPORT_SIGNPOSTS_H
 #define LLVM_SUPPORT_SIGNPOSTS_H
 
+#include "llvm/Support/Compiler.h"
 #include <memory>
 
 namespace llvm {
@@ -28,15 +29,15 @@ class SignpostEmitter {
   std::unique_ptr<SignpostEmitterImpl> Impl;
 
 public:
-  SignpostEmitter();
-  ~SignpostEmitter();
+  LLVM_ABI SignpostEmitter();
+  LLVM_ABI ~SignpostEmitter();
 
-  bool isEnabled() const;
+  LLVM_ABI bool isEnabled() const;
 
   /// Begin a signposted interval for a given object.
-  void startInterval(const void *O, StringRef Name);
+  LLVM_ABI void startInterval(const void *O, StringRef Name);
   /// End a signposted interval for a given object.
-  void endInterval(const void *O, StringRef Name);
+  LLVM_ABI void endInterval(const void *O, StringRef Name);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Support/SipHash.h
+++ b/llvm/include/llvm/Support/SipHash.h
@@ -17,6 +17,7 @@
 #ifndef LLVM_SUPPORT_SIPHASH_H
 #define LLVM_SUPPORT_SIPHASH_H
 
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 
 namespace llvm {
@@ -25,11 +26,11 @@ template <typename T> class ArrayRef;
 class StringRef;
 
 /// Computes a SipHash-2-4 64-bit result.
-void getSipHash_2_4_64(ArrayRef<uint8_t> In, const uint8_t (&K)[16],
+LLVM_ABI void getSipHash_2_4_64(ArrayRef<uint8_t> In, const uint8_t (&K)[16],
                        uint8_t (&Out)[8]);
 
 /// Computes a SipHash-2-4 128-bit result.
-void getSipHash_2_4_128(ArrayRef<uint8_t> In, const uint8_t (&K)[16],
+LLVM_ABI void getSipHash_2_4_128(ArrayRef<uint8_t> In, const uint8_t (&K)[16],
                         uint8_t (&Out)[16]);
 
 /// Compute a stable non-zero 16-bit hash of the given string.
@@ -45,7 +46,7 @@ void getSipHash_2_4_128(ArrayRef<uint8_t> In, const uint8_t (&K)[16],
 /// 16 bits is also sufficiently compact to not inflate a loader relocation.
 /// We disallow zero to guarantee a different discriminator from the places
 /// in the ABI that use a constant zero.
-uint16_t getPointerAuthStableSipHash(StringRef S);
+LLVM_ABI uint16_t getPointerAuthStableSipHash(StringRef S);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/Support/SipHash.h
+++ b/llvm/include/llvm/Support/SipHash.h
@@ -27,11 +27,11 @@ class StringRef;
 
 /// Computes a SipHash-2-4 64-bit result.
 LLVM_ABI void getSipHash_2_4_64(ArrayRef<uint8_t> In, const uint8_t (&K)[16],
-                       uint8_t (&Out)[8]);
+                                uint8_t (&Out)[8]);
 
 /// Computes a SipHash-2-4 128-bit result.
 LLVM_ABI void getSipHash_2_4_128(ArrayRef<uint8_t> In, const uint8_t (&K)[16],
-                        uint8_t (&Out)[16]);
+                                 uint8_t (&Out)[16]);
 
 /// Compute a stable non-zero 16-bit hash of the given string.
 ///

--- a/llvm/include/llvm/Support/SmallVectorMemoryBuffer.h
+++ b/llvm/include/llvm/Support/SmallVectorMemoryBuffer.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_SUPPORT_SMALLVECTORMEMORYBUFFER_H
 #define LLVM_SUPPORT_SMALLVECTORMEMORYBUFFER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
 

--- a/llvm/include/llvm/Support/SmallVectorMemoryBuffer.h
+++ b/llvm/include/llvm/Support/SmallVectorMemoryBuffer.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_SMALLVECTORMEMORYBUFFER_H
 #define LLVM_SUPPORT_SMALLVECTORMEMORYBUFFER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
@@ -26,7 +27,7 @@ namespace llvm {
 /// instances. This is useful for MCJIT and Orc, where object files are streamed
 /// into SmallVectors, then inspected using ObjectFile (which takes a
 /// MemoryBuffer).
-class SmallVectorMemoryBuffer : public MemoryBuffer {
+class LLVM_ABI SmallVectorMemoryBuffer : public MemoryBuffer {
 public:
   /// Construct a SmallVectorMemoryBuffer from the given SmallVector r-value.
   SmallVectorMemoryBuffer(SmallVectorImpl<char> &&SV,

--- a/llvm/include/llvm/Support/SourceMgr.h
+++ b/llvm/include/llvm/Support/SourceMgr.h
@@ -15,8 +15,8 @@
 #ifndef LLVM_SUPPORT_SOURCEMGR_H
 #define LLVM_SUPPORT_SOURCEMGR_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SMLoc.h"
 #include <vector>
@@ -173,8 +173,8 @@ public:
   /// If no file is found, this returns 0, otherwise it returns the buffer ID
   /// of the stacked file. The full path to the included file can be found in
   /// \p IncludedFile.
-  LLVM_ABI unsigned AddIncludeFile(const std::string &Filename, SMLoc IncludeLoc,
-                          std::string &IncludedFile);
+  LLVM_ABI unsigned AddIncludeFile(const std::string &Filename,
+                                   SMLoc IncludeLoc, std::string &IncludedFile);
 
   /// Search for a file with the specified name in the current directory or in
   /// one of the IncludeDirs, and try to open it **without** adding to the
@@ -200,40 +200,40 @@ public:
 
   /// Find the line and column number for the specified location in the
   /// specified file. This is not a fast method.
-  LLVM_ABI std::pair<unsigned, unsigned> getLineAndColumn(SMLoc Loc,
-                                                 unsigned BufferID = 0) const;
+  LLVM_ABI std::pair<unsigned, unsigned>
+  getLineAndColumn(SMLoc Loc, unsigned BufferID = 0) const;
 
   /// Get a string with the \p SMLoc filename and line number
   /// formatted in the standard style.
-  LLVM_ABI std::string getFormattedLocationNoOffset(SMLoc Loc,
-                                           bool IncludePath = false) const;
+  LLVM_ABI std::string
+  getFormattedLocationNoOffset(SMLoc Loc, bool IncludePath = false) const;
 
   /// Given a line and column number in a mapped buffer, turn it into an SMLoc.
   /// This will return a null SMLoc if the line/column location is invalid.
   LLVM_ABI SMLoc FindLocForLineAndColumn(unsigned BufferID, unsigned LineNo,
-                                unsigned ColNo);
+                                         unsigned ColNo);
 
   /// Emit a message about the specified location with the specified string.
   ///
   /// \param ShowColors Display colored messages if output is a terminal and
   /// the default error handler is used.
-  LLVM_ABI void PrintMessage(raw_ostream &OS, SMLoc Loc, DiagKind Kind, const Twine &Msg,
-                    ArrayRef<SMRange> Ranges = {},
-                    ArrayRef<SMFixIt> FixIts = {},
-                    bool ShowColors = true) const;
+  LLVM_ABI void PrintMessage(raw_ostream &OS, SMLoc Loc, DiagKind Kind,
+                             const Twine &Msg, ArrayRef<SMRange> Ranges = {},
+                             ArrayRef<SMFixIt> FixIts = {},
+                             bool ShowColors = true) const;
 
   /// Emits a diagnostic to llvm::errs().
   LLVM_ABI void PrintMessage(SMLoc Loc, DiagKind Kind, const Twine &Msg,
-                    ArrayRef<SMRange> Ranges = {},
-                    ArrayRef<SMFixIt> FixIts = {},
-                    bool ShowColors = true) const;
+                             ArrayRef<SMRange> Ranges = {},
+                             ArrayRef<SMFixIt> FixIts = {},
+                             bool ShowColors = true) const;
 
   /// Emits a manually-constructed diagnostic to the given output stream.
   ///
   /// \param ShowColors Display colored messages if output is a terminal and
   /// the default error handler is used.
   LLVM_ABI void PrintMessage(raw_ostream &OS, const SMDiagnostic &Diagnostic,
-                    bool ShowColors = true) const;
+                             bool ShowColors = true) const;
 
   /// Return an SMDiagnostic at the specified location with the specified
   /// string.
@@ -241,8 +241,8 @@ public:
   /// \param Msg If non-null, the kind of message (e.g., "error") which is
   /// prefixed to the message.
   LLVM_ABI SMDiagnostic GetMessage(SMLoc Loc, DiagKind Kind, const Twine &Msg,
-                          ArrayRef<SMRange> Ranges = {},
-                          ArrayRef<SMFixIt> FixIts = {}) const;
+                                   ArrayRef<SMRange> Ranges = {},
+                                   ArrayRef<SMFixIt> FixIts = {}) const;
 
   /// Prints the names of included files and the line of the file they were
   /// included from. A diagnostic handler can use this before printing its
@@ -298,10 +298,11 @@ public:
       : Filename(filename), LineNo(-1), ColumnNo(-1), Kind(Knd), Message(Msg) {}
 
   // Diagnostic with a location.
-  LLVM_ABI SMDiagnostic(const SourceMgr &sm, SMLoc L, StringRef FN, int Line, int Col,
-               SourceMgr::DiagKind Kind, StringRef Msg, StringRef LineStr,
-               ArrayRef<std::pair<unsigned, unsigned>> Ranges,
-               ArrayRef<SMFixIt> FixIts = {});
+  LLVM_ABI SMDiagnostic(const SourceMgr &sm, SMLoc L, StringRef FN, int Line,
+                        int Col, SourceMgr::DiagKind Kind, StringRef Msg,
+                        StringRef LineStr,
+                        ArrayRef<std::pair<unsigned, unsigned>> Ranges,
+                        ArrayRef<SMFixIt> FixIts = {});
 
   const SourceMgr *getSourceMgr() const { return SM; }
   SMLoc getLoc() const { return Loc; }
@@ -317,8 +318,9 @@ public:
 
   ArrayRef<SMFixIt> getFixIts() const { return FixIts; }
 
-  LLVM_ABI void print(const char *ProgName, raw_ostream &S, bool ShowColors = true,
-             bool ShowKindLabel = true, bool ShowLocation = true) const;
+  LLVM_ABI void print(const char *ProgName, raw_ostream &S,
+                      bool ShowColors = true, bool ShowKindLabel = true,
+                      bool ShowLocation = true) const;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Support/SourceMgr.h
+++ b/llvm/include/llvm/Support/SourceMgr.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_SUPPORT_SOURCEMGR_H
 #define LLVM_SUPPORT_SOURCEMGR_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SMLoc.h"
@@ -61,13 +62,13 @@ private:
 
     /// Look up a given \p Ptr in the buffer, determining which line it came
     /// from.
-    unsigned getLineNumber(const char *Ptr) const;
+    LLVM_ABI unsigned getLineNumber(const char *Ptr) const;
     template <typename T>
     unsigned getLineNumberSpecialized(const char *Ptr) const;
 
     /// Return a pointer to the first character of the specified line number or
     /// null if the line number is invalid.
-    const char *getPointerForLineNumber(unsigned LineNo) const;
+    LLVM_ABI const char *getPointerForLineNumber(unsigned LineNo) const;
     template <typename T>
     const char *getPointerForLineNumberSpecialized(unsigned LineNo) const;
 
@@ -75,10 +76,10 @@ private:
     SMLoc IncludeLoc;
 
     SrcBuffer() = default;
-    SrcBuffer(SrcBuffer &&);
+    LLVM_ABI SrcBuffer(SrcBuffer &&);
     SrcBuffer(const SrcBuffer &) = delete;
     SrcBuffer &operator=(const SrcBuffer &) = delete;
-    ~SrcBuffer();
+    LLVM_ABI ~SrcBuffer();
   };
 
   /// This is all of the buffers that we are reading from.
@@ -172,7 +173,7 @@ public:
   /// If no file is found, this returns 0, otherwise it returns the buffer ID
   /// of the stacked file. The full path to the included file can be found in
   /// \p IncludedFile.
-  unsigned AddIncludeFile(const std::string &Filename, SMLoc IncludeLoc,
+  LLVM_ABI unsigned AddIncludeFile(const std::string &Filename, SMLoc IncludeLoc,
                           std::string &IncludedFile);
 
   /// Search for a file with the specified name in the current directory or in
@@ -183,13 +184,13 @@ public:
   /// If no file is found, this returns an Error, otherwise it returns the
   /// buffer of the stacked file. The full path to the included file can be
   /// found in \p IncludedFile.
-  ErrorOr<std::unique_ptr<MemoryBuffer>>
+  LLVM_ABI ErrorOr<std::unique_ptr<MemoryBuffer>>
   OpenIncludeFile(const std::string &Filename, std::string &IncludedFile);
 
   /// Return the ID of the buffer containing the specified location.
   ///
   /// 0 is returned if the buffer is not found.
-  unsigned FindBufferContainingLoc(SMLoc Loc) const;
+  LLVM_ABI unsigned FindBufferContainingLoc(SMLoc Loc) const;
 
   /// Find the line number for the specified location in the specified file.
   /// This is not a fast method.
@@ -199,30 +200,30 @@ public:
 
   /// Find the line and column number for the specified location in the
   /// specified file. This is not a fast method.
-  std::pair<unsigned, unsigned> getLineAndColumn(SMLoc Loc,
+  LLVM_ABI std::pair<unsigned, unsigned> getLineAndColumn(SMLoc Loc,
                                                  unsigned BufferID = 0) const;
 
   /// Get a string with the \p SMLoc filename and line number
   /// formatted in the standard style.
-  std::string getFormattedLocationNoOffset(SMLoc Loc,
+  LLVM_ABI std::string getFormattedLocationNoOffset(SMLoc Loc,
                                            bool IncludePath = false) const;
 
   /// Given a line and column number in a mapped buffer, turn it into an SMLoc.
   /// This will return a null SMLoc if the line/column location is invalid.
-  SMLoc FindLocForLineAndColumn(unsigned BufferID, unsigned LineNo,
+  LLVM_ABI SMLoc FindLocForLineAndColumn(unsigned BufferID, unsigned LineNo,
                                 unsigned ColNo);
 
   /// Emit a message about the specified location with the specified string.
   ///
   /// \param ShowColors Display colored messages if output is a terminal and
   /// the default error handler is used.
-  void PrintMessage(raw_ostream &OS, SMLoc Loc, DiagKind Kind, const Twine &Msg,
+  LLVM_ABI void PrintMessage(raw_ostream &OS, SMLoc Loc, DiagKind Kind, const Twine &Msg,
                     ArrayRef<SMRange> Ranges = {},
                     ArrayRef<SMFixIt> FixIts = {},
                     bool ShowColors = true) const;
 
   /// Emits a diagnostic to llvm::errs().
-  void PrintMessage(SMLoc Loc, DiagKind Kind, const Twine &Msg,
+  LLVM_ABI void PrintMessage(SMLoc Loc, DiagKind Kind, const Twine &Msg,
                     ArrayRef<SMRange> Ranges = {},
                     ArrayRef<SMFixIt> FixIts = {},
                     bool ShowColors = true) const;
@@ -231,7 +232,7 @@ public:
   ///
   /// \param ShowColors Display colored messages if output is a terminal and
   /// the default error handler is used.
-  void PrintMessage(raw_ostream &OS, const SMDiagnostic &Diagnostic,
+  LLVM_ABI void PrintMessage(raw_ostream &OS, const SMDiagnostic &Diagnostic,
                     bool ShowColors = true) const;
 
   /// Return an SMDiagnostic at the specified location with the specified
@@ -239,7 +240,7 @@ public:
   ///
   /// \param Msg If non-null, the kind of message (e.g., "error") which is
   /// prefixed to the message.
-  SMDiagnostic GetMessage(SMLoc Loc, DiagKind Kind, const Twine &Msg,
+  LLVM_ABI SMDiagnostic GetMessage(SMLoc Loc, DiagKind Kind, const Twine &Msg,
                           ArrayRef<SMRange> Ranges = {},
                           ArrayRef<SMFixIt> FixIts = {}) const;
 
@@ -249,7 +250,7 @@ public:
   ///
   /// \param IncludeLoc The location of the include.
   /// \param OS the raw_ostream to print on.
-  void PrintIncludeStack(SMLoc IncludeLoc, raw_ostream &OS) const;
+  LLVM_ABI void PrintIncludeStack(SMLoc IncludeLoc, raw_ostream &OS) const;
 };
 
 /// Represents a single fixit, a replacement of one range of text with another.
@@ -259,7 +260,7 @@ class SMFixIt {
   std::string Text;
 
 public:
-  SMFixIt(SMRange R, const Twine &Replacement);
+  LLVM_ABI SMFixIt(SMRange R, const Twine &Replacement);
 
   SMFixIt(SMLoc Loc, const Twine &Replacement)
       : SMFixIt(SMRange(Loc, Loc), Replacement) {}
@@ -297,7 +298,7 @@ public:
       : Filename(filename), LineNo(-1), ColumnNo(-1), Kind(Knd), Message(Msg) {}
 
   // Diagnostic with a location.
-  SMDiagnostic(const SourceMgr &sm, SMLoc L, StringRef FN, int Line, int Col,
+  LLVM_ABI SMDiagnostic(const SourceMgr &sm, SMLoc L, StringRef FN, int Line, int Col,
                SourceMgr::DiagKind Kind, StringRef Msg, StringRef LineStr,
                ArrayRef<std::pair<unsigned, unsigned>> Ranges,
                ArrayRef<SMFixIt> FixIts = {});
@@ -316,7 +317,7 @@ public:
 
   ArrayRef<SMFixIt> getFixIts() const { return FixIts; }
 
-  void print(const char *ProgName, raw_ostream &S, bool ShowColors = true,
+  LLVM_ABI void print(const char *ProgName, raw_ostream &S, bool ShowColors = true,
              bool ShowKindLabel = true, bool ShowLocation = true) const;
 };
 

--- a/llvm/include/llvm/Support/SpecialCaseList.h
+++ b/llvm/include/llvm/Support/SpecialCaseList.h
@@ -12,6 +12,7 @@
 #ifndef LLVM_SUPPORT_SPECIALCASELIST_H
 #define LLVM_SUPPORT_SPECIALCASELIST_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/GlobPattern.h"
 #include "llvm/Support/Regex.h"
@@ -70,26 +71,26 @@ class SpecialCaseList {
 public:
   /// Parses the special case list entries from files. On failure, returns
   /// 0 and writes an error message to string.
-  static std::unique_ptr<SpecialCaseList>
+  LLVM_ABI static std::unique_ptr<SpecialCaseList>
   create(const std::vector<std::string> &Paths, llvm::vfs::FileSystem &FS,
          std::string &Error);
   /// Parses the special case list from a memory buffer. On failure, returns
   /// 0 and writes an error message to string.
-  static std::unique_ptr<SpecialCaseList> create(const MemoryBuffer *MB,
+  LLVM_ABI static std::unique_ptr<SpecialCaseList> create(const MemoryBuffer *MB,
                                                  std::string &Error);
   /// Parses the special case list entries from files. On failure, reports a
   /// fatal error.
-  static std::unique_ptr<SpecialCaseList>
+  LLVM_ABI static std::unique_ptr<SpecialCaseList>
   createOrDie(const std::vector<std::string> &Paths, llvm::vfs::FileSystem &FS);
 
-  ~SpecialCaseList();
+  LLVM_ABI ~SpecialCaseList();
 
   /// Returns true, if special case list contains a line
   /// \code
   ///   @Prefix:<E>=@Category
   /// \endcode
   /// where @Query satisfies the glob <E> in a given @Section.
-  bool inSection(StringRef Section, StringRef Prefix, StringRef Query,
+  LLVM_ABI bool inSection(StringRef Section, StringRef Prefix, StringRef Query,
                  StringRef Category = StringRef()) const;
 
   /// Returns the line number corresponding to the special case list entry if
@@ -100,15 +101,15 @@ public:
   /// where @Query satisfies the glob <E> in a given @Section.
   /// Returns zero if there is no exclusion entry corresponding to this
   /// expression.
-  unsigned inSectionBlame(StringRef Section, StringRef Prefix, StringRef Query,
+  LLVM_ABI unsigned inSectionBlame(StringRef Section, StringRef Prefix, StringRef Query,
                           StringRef Category = StringRef()) const;
 
 protected:
   // Implementations of the create*() functions that can also be used by derived
   // classes.
-  bool createInternal(const std::vector<std::string> &Paths,
+  LLVM_ABI bool createInternal(const std::vector<std::string> &Paths,
                       vfs::FileSystem &VFS, std::string &Error);
-  bool createInternal(const MemoryBuffer *MB, std::string &Error);
+  LLVM_ABI bool createInternal(const MemoryBuffer *MB, std::string &Error);
 
   SpecialCaseList() = default;
   SpecialCaseList(SpecialCaseList const &) = delete;
@@ -117,10 +118,10 @@ protected:
   /// Represents a set of globs and their line numbers
   class Matcher {
   public:
-    Error insert(StringRef Pattern, unsigned LineNumber, bool UseRegex);
+    LLVM_ABI Error insert(StringRef Pattern, unsigned LineNumber, bool UseRegex);
     // Returns the line number in the source file that this query matches to.
     // Returns zero if no match is found.
-    unsigned match(StringRef Query) const;
+    LLVM_ABI unsigned match(StringRef Query) const;
 
     StringMap<std::pair<GlobPattern, unsigned>> Globs;
     std::vector<std::pair<std::unique_ptr<Regex>, unsigned>> RegExes;
@@ -138,15 +139,15 @@ protected:
 
   StringMap<Section> Sections;
 
-  Expected<Section *> addSection(StringRef SectionStr, unsigned LineNo,
+  LLVM_ABI Expected<Section *> addSection(StringRef SectionStr, unsigned LineNo,
                                  bool UseGlobs = true);
 
   /// Parses just-constructed SpecialCaseList entries from a memory buffer.
-  bool parse(const MemoryBuffer *MB, std::string &Error);
+  LLVM_ABI bool parse(const MemoryBuffer *MB, std::string &Error);
 
   // Helper method for derived classes to search by Prefix, Query, and Category
   // once they have already resolved a section entry.
-  unsigned inSectionBlame(const SectionEntries &Entries, StringRef Prefix,
+  LLVM_ABI unsigned inSectionBlame(const SectionEntries &Entries, StringRef Prefix,
                           StringRef Query, StringRef Category) const;
 };
 

--- a/llvm/include/llvm/Support/SpecialCaseList.h
+++ b/llvm/include/llvm/Support/SpecialCaseList.h
@@ -12,8 +12,8 @@
 #ifndef LLVM_SUPPORT_SPECIALCASELIST_H
 #define LLVM_SUPPORT_SPECIALCASELIST_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/GlobPattern.h"
 #include "llvm/Support/Regex.h"
 #include <memory>
@@ -76,8 +76,8 @@ public:
          std::string &Error);
   /// Parses the special case list from a memory buffer. On failure, returns
   /// 0 and writes an error message to string.
-  LLVM_ABI static std::unique_ptr<SpecialCaseList> create(const MemoryBuffer *MB,
-                                                 std::string &Error);
+  LLVM_ABI static std::unique_ptr<SpecialCaseList>
+  create(const MemoryBuffer *MB, std::string &Error);
   /// Parses the special case list entries from files. On failure, reports a
   /// fatal error.
   LLVM_ABI static std::unique_ptr<SpecialCaseList>
@@ -91,7 +91,7 @@ public:
   /// \endcode
   /// where @Query satisfies the glob <E> in a given @Section.
   LLVM_ABI bool inSection(StringRef Section, StringRef Prefix, StringRef Query,
-                 StringRef Category = StringRef()) const;
+                          StringRef Category = StringRef()) const;
 
   /// Returns the line number corresponding to the special case list entry if
   /// the special case list contains a line
@@ -101,14 +101,15 @@ public:
   /// where @Query satisfies the glob <E> in a given @Section.
   /// Returns zero if there is no exclusion entry corresponding to this
   /// expression.
-  LLVM_ABI unsigned inSectionBlame(StringRef Section, StringRef Prefix, StringRef Query,
-                          StringRef Category = StringRef()) const;
+  LLVM_ABI unsigned inSectionBlame(StringRef Section, StringRef Prefix,
+                                   StringRef Query,
+                                   StringRef Category = StringRef()) const;
 
 protected:
   // Implementations of the create*() functions that can also be used by derived
   // classes.
   LLVM_ABI bool createInternal(const std::vector<std::string> &Paths,
-                      vfs::FileSystem &VFS, std::string &Error);
+                               vfs::FileSystem &VFS, std::string &Error);
   LLVM_ABI bool createInternal(const MemoryBuffer *MB, std::string &Error);
 
   SpecialCaseList() = default;
@@ -118,7 +119,8 @@ protected:
   /// Represents a set of globs and their line numbers
   class Matcher {
   public:
-    LLVM_ABI Error insert(StringRef Pattern, unsigned LineNumber, bool UseRegex);
+    LLVM_ABI Error insert(StringRef Pattern, unsigned LineNumber,
+                          bool UseRegex);
     // Returns the line number in the source file that this query matches to.
     // Returns zero if no match is found.
     LLVM_ABI unsigned match(StringRef Query) const;
@@ -140,15 +142,16 @@ protected:
   StringMap<Section> Sections;
 
   LLVM_ABI Expected<Section *> addSection(StringRef SectionStr, unsigned LineNo,
-                                 bool UseGlobs = true);
+                                          bool UseGlobs = true);
 
   /// Parses just-constructed SpecialCaseList entries from a memory buffer.
   LLVM_ABI bool parse(const MemoryBuffer *MB, std::string &Error);
 
   // Helper method for derived classes to search by Prefix, Query, and Category
   // once they have already resolved a section entry.
-  LLVM_ABI unsigned inSectionBlame(const SectionEntries &Entries, StringRef Prefix,
-                          StringRef Query, StringRef Category) const;
+  LLVM_ABI unsigned inSectionBlame(const SectionEntries &Entries,
+                                   StringRef Prefix, StringRef Query,
+                                   StringRef Category) const;
 };
 
 }  // namespace llvm

--- a/llvm/include/llvm/Support/StringSaver.h
+++ b/llvm/include/llvm/Support/StringSaver.h
@@ -9,11 +9,11 @@
 #ifndef LLVM_SUPPORT_STRINGSAVER_H
 #define LLVM_SUPPORT_STRINGSAVER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/Support/StringSaver.h
+++ b/llvm/include/llvm/Support/StringSaver.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_STRINGSAVER_H
 #define LLVM_SUPPORT_STRINGSAVER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
@@ -28,8 +29,8 @@ public:
 
   // All returned strings are null-terminated: *save(S).end() == 0.
   StringRef save(const char *S) { return save(StringRef(S)); }
-  StringRef save(StringRef S);
-  StringRef save(const Twine &S);
+  LLVM_ABI StringRef save(StringRef S);
+  LLVM_ABI StringRef save(const Twine &S);
   StringRef save(const std::string &S) { return save(StringRef(S)); }
 };
 
@@ -50,8 +51,8 @@ public:
 
   // All returned strings are null-terminated: *save(S).end() == 0.
   StringRef save(const char *S) { return save(StringRef(S)); }
-  StringRef save(StringRef S);
-  StringRef save(const Twine &S);
+  LLVM_ABI StringRef save(StringRef S);
+  LLVM_ABI StringRef save(const Twine &S);
   StringRef save(const std::string &S) { return save(StringRef(S)); }
 };
 

--- a/llvm/include/llvm/Support/SuffixTree.h
+++ b/llvm/include/llvm/Support/SuffixTree.h
@@ -181,7 +181,7 @@ public:
     bool OutlinerLeafDescendants = !LeafNodes.empty();
 
     /// Move the iterator to the next repeated substring.
-    void advance();
+    LLVM_ABI void advance();
 
   public:
     /// Return the current repeated substring.

--- a/llvm/include/llvm/Support/SuffixTree.h
+++ b/llvm/include/llvm/Support/SuffixTree.h
@@ -32,9 +32,9 @@
 #ifndef LLVM_SUPPORT_SUFFIXTREE_H
 #define LLVM_SUPPORT_SUFFIXTREE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/SuffixTreeNode.h"
 
 namespace llvm {
@@ -154,7 +154,7 @@ public:
   /// \param OutlinerLeafDescendants Whether to consider leaf descendants or
   /// only leaf children (used by Machine Outliner).
   LLVM_ABI SuffixTree(const ArrayRef<unsigned> &Str,
-             bool OutlinerLeafDescendants = false);
+                      bool OutlinerLeafDescendants = false);
 
   /// Iterator for finding all repeated substrings in the suffix tree.
   struct RepeatedSubstringIterator {

--- a/llvm/include/llvm/Support/SuffixTree.h
+++ b/llvm/include/llvm/Support/SuffixTree.h
@@ -32,6 +32,7 @@
 #ifndef LLVM_SUPPORT_SUFFIXTREE_H
 #define LLVM_SUPPORT_SUFFIXTREE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/SuffixTreeNode.h"
@@ -152,7 +153,7 @@ public:
   /// \param Str The string to construct the suffix tree for.
   /// \param OutlinerLeafDescendants Whether to consider leaf descendants or
   /// only leaf children (used by Machine Outliner).
-  SuffixTree(const ArrayRef<unsigned> &Str,
+  LLVM_ABI SuffixTree(const ArrayRef<unsigned> &Str,
              bool OutlinerLeafDescendants = false);
 
   /// Iterator for finding all repeated substrings in the suffix tree.

--- a/llvm/include/llvm/Support/SuffixTreeNode.h
+++ b/llvm/include/llvm/Support/SuffixTreeNode.h
@@ -25,8 +25,8 @@
 
 #ifndef LLVM_SUPPORT_SUFFIXTREE_NODE_H
 #define LLVM_SUPPORT_SUFFIXTREE_NODE_H
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/Support/SuffixTreeNode.h
+++ b/llvm/include/llvm/Support/SuffixTreeNode.h
@@ -25,6 +25,7 @@
 
 #ifndef LLVM_SUPPORT_SUFFIXTREE_NODE_H
 #define LLVM_SUPPORT_SUFFIXTREE_NODE_H
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 
 namespace llvm {
@@ -62,31 +63,31 @@ public:
   NodeKind getKind() const { return Kind; }
 
   /// \return the start index of this node's substring in the entire string.
-  unsigned getStartIdx() const;
+  LLVM_ABI unsigned getStartIdx() const;
 
   /// \returns the end index of this node.
   virtual unsigned getEndIdx() const = 0;
 
   /// \return the index of this node's left most leaf node.
-  unsigned getLeftLeafIdx() const;
+  LLVM_ABI unsigned getLeftLeafIdx() const;
 
   /// \return the index of this node's right most leaf node.
-  unsigned getRightLeafIdx() const;
+  LLVM_ABI unsigned getRightLeafIdx() const;
 
   /// Set the index of the left most leaf node of this node to \p Idx.
-  void setLeftLeafIdx(unsigned Idx);
+  LLVM_ABI void setLeftLeafIdx(unsigned Idx);
 
   /// Set the index of the right most leaf node of this node to \p Idx.
-  void setRightLeafIdx(unsigned Idx);
+  LLVM_ABI void setRightLeafIdx(unsigned Idx);
 
   /// Advance this node's StartIdx by \p Inc.
-  void incrementStartIdx(unsigned Inc);
+  LLVM_ABI void incrementStartIdx(unsigned Inc);
 
   /// Set the length of the string from the root to this node to \p Len.
-  void setConcatLen(unsigned Len);
+  LLVM_ABI void setConcatLen(unsigned Len);
 
   /// \returns the length of the string from the root to this node.
-  unsigned getConcatLen() const;
+  LLVM_ABI unsigned getConcatLen() const;
 
   SuffixTreeNode(NodeKind Kind, unsigned StartIdx)
       : Kind(Kind), StartIdx(StartIdx) {}
@@ -94,7 +95,7 @@ public:
 };
 
 // A node with two or more children, or the root.
-struct SuffixTreeInternalNode : SuffixTreeNode {
+struct LLVM_ABI SuffixTreeInternalNode : SuffixTreeNode {
 private:
   /// The end index of this node's substring in the main string.
   ///
@@ -158,7 +159,7 @@ public:
 };
 
 // A node representing a suffix.
-struct SuffixTreeLeafNode : SuffixTreeNode {
+struct LLVM_ABI SuffixTreeLeafNode : SuffixTreeNode {
 private:
   /// The start index of the suffix represented by this leaf.
   unsigned SuffixIdx = EmptyIdx;

--- a/llvm/include/llvm/Support/SystemUtils.h
+++ b/llvm/include/llvm/Support/SystemUtils.h
@@ -14,6 +14,8 @@
 #ifndef LLVM_SUPPORT_SYSTEMUTILS_H
 #define LLVM_SUPPORT_SYSTEMUTILS_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 class raw_ostream;
 

--- a/llvm/include/llvm/Support/SystemUtils.h
+++ b/llvm/include/llvm/Support/SystemUtils.h
@@ -21,7 +21,7 @@ class raw_ostream;
 /// generate a warning message to errs() advising against display of bitcode
 /// and return true. Otherwise just return false.
 /// Check for output written to a console
-bool CheckBitcodeOutputToConsole(
+LLVM_ABI bool CheckBitcodeOutputToConsole(
     raw_ostream &stream_to_check ///< The stream to be checked
 );
 

--- a/llvm/include/llvm/Support/TarWriter.h
+++ b/llvm/include/llvm/Support/TarWriter.h
@@ -9,17 +9,17 @@
 #ifndef LLVM_SUPPORT_TARWRITER_H
 #define LLVM_SUPPORT_TARWRITER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace llvm {
 class TarWriter {
 public:
-  LLVM_ABI static Expected<std::unique_ptr<TarWriter>> create(StringRef OutputPath,
-                                                     StringRef BaseDir);
+  LLVM_ABI static Expected<std::unique_ptr<TarWriter>>
+  create(StringRef OutputPath, StringRef BaseDir);
 
   LLVM_ABI void append(StringRef Path, StringRef Data);
 

--- a/llvm/include/llvm/Support/TarWriter.h
+++ b/llvm/include/llvm/Support/TarWriter.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_TARWRITER_H
 #define LLVM_SUPPORT_TARWRITER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Error.h"
@@ -17,10 +18,10 @@
 namespace llvm {
 class TarWriter {
 public:
-  static Expected<std::unique_ptr<TarWriter>> create(StringRef OutputPath,
+  LLVM_ABI static Expected<std::unique_ptr<TarWriter>> create(StringRef OutputPath,
                                                      StringRef BaseDir);
 
-  void append(StringRef Path, StringRef Data);
+  LLVM_ABI void append(StringRef Path, StringRef Data);
 
 private:
   TarWriter(int FD, StringRef BaseDir);

--- a/llvm/include/llvm/Support/TargetSelect.h
+++ b/llvm/include/llvm/Support/TargetSelect.h
@@ -16,34 +16,41 @@
 #define LLVM_SUPPORT_TARGETSELECT_H
 
 #include "llvm/Config/llvm-config.h"
+#include "llvm/Support/Compiler.h"
 
 extern "C" {
   // Declare all of the target-initialization functions that are available.
-#define LLVM_TARGET(TargetName) void LLVMInitialize##TargetName##TargetInfo();
+#define LLVM_TARGET(TargetName)                                                \
+  LLVM_ABI void LLVMInitialize##TargetName##TargetInfo();
 #include "llvm/Config/Targets.def"
 
-#define LLVM_TARGET(TargetName) void LLVMInitialize##TargetName##Target();
+#define LLVM_TARGET(TargetName)                                                \
+  LLVM_ABI void LLVMInitialize##TargetName##Target();
 #include "llvm/Config/Targets.def"
 
   // Declare all of the target-MC-initialization functions that are available.
-#define LLVM_TARGET(TargetName) void LLVMInitialize##TargetName##TargetMC();
+#define LLVM_TARGET(TargetName)                                                \
+  LLVM_ABI void LLVMInitialize##TargetName##TargetMC();
 #include "llvm/Config/Targets.def"
 
   // Declare all of the available assembly printer initialization functions.
-#define LLVM_ASM_PRINTER(TargetName) void LLVMInitialize##TargetName##AsmPrinter();
+#define LLVM_ASM_PRINTER(TargetName)                                           \
+  LLVM_ABI void LLVMInitialize##TargetName##AsmPrinter();
 #include "llvm/Config/AsmPrinters.def"
 
   // Declare all of the available assembly parser initialization functions.
-#define LLVM_ASM_PARSER(TargetName) void LLVMInitialize##TargetName##AsmParser();
+#define LLVM_ASM_PARSER(TargetName)                                            \
+  LLVM_ABI void LLVMInitialize##TargetName##AsmParser();
 #include "llvm/Config/AsmParsers.def"
 
   // Declare all of the available disassembler initialization functions.
-#define LLVM_DISASSEMBLER(TargetName) \
-  void LLVMInitialize##TargetName##Disassembler();
+#define LLVM_DISASSEMBLER(TargetName)                                          \
+  LLVM_ABI void LLVMInitialize##TargetName##Disassembler();
 #include "llvm/Config/Disassemblers.def"
 
 // Declare all of the available TargetMCA initialization functions.
-#define LLVM_TARGETMCA(TargetName) void LLVMInitialize##TargetName##TargetMCA();
+#define LLVM_TARGETMCA(TargetName)                                             \
+  LLVM_ABI void LLVMInitialize##TargetName##TargetMCA();
 #include "llvm/Config/TargetMCAs.def"
 }
 

--- a/llvm/include/llvm/Support/ThreadPool.h
+++ b/llvm/include/llvm/Support/ThreadPool.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_SUPPORT_THREADPOOL_H
 #define LLVM_SUPPORT_THREADPOOL_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Config/llvm-config.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/RWMutex.h"
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/thread.h"

--- a/llvm/include/llvm/Support/ThreadPool.h
+++ b/llvm/include/llvm/Support/ThreadPool.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_THREADPOOL_H
 #define LLVM_SUPPORT_THREADPOOL_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/RWMutex.h"
@@ -46,7 +47,7 @@ class ThreadPoolTaskGroup;
 /// available threads are used up by tasks waiting for a task that has no thread
 /// left to run on (this includes waiting on the returned future). It should be
 /// generally safe to wait() for a group as long as groups do not form a cycle.
-class ThreadPoolInterface {
+class LLVM_ABI ThreadPoolInterface {
   /// The actual method to enqueue a task to be defined by the concrete
   /// implementation.
   virtual void asyncEnqueue(std::function<void()> Task,
@@ -121,7 +122,7 @@ private:
 ///
 /// The pool keeps a vector of threads alive, waiting on a condition variable
 /// for some work to become available.
-class StdThreadPool : public ThreadPoolInterface {
+class LLVM_ABI StdThreadPool : public ThreadPoolInterface {
 public:
   /// Construct a pool using the hardware strategy \p S for mapping hardware
   /// execution resources (threads, cores, CPUs)
@@ -215,7 +216,7 @@ private:
 #endif // LLVM_ENABLE_THREADS
 
 /// A non-threaded implementation.
-class SingleThreadExecutor : public ThreadPoolInterface {
+class LLVM_ABI SingleThreadExecutor : public ThreadPoolInterface {
 public:
   /// Construct a non-threaded pool, ignoring using the hardware strategy.
   SingleThreadExecutor(ThreadPoolStrategy ignored = {});

--- a/llvm/include/llvm/Support/Threading.h
+++ b/llvm/include/llvm/Support/Threading.h
@@ -130,17 +130,17 @@ constexpr bool llvm_is_multithreaded() { return LLVM_ENABLE_THREADS; }
 
     /// Retrieves the max available threads for the current strategy. This
     /// accounts for affinity masks and takes advantage of all CPU sockets.
-    unsigned compute_thread_count() const;
+    LLVM_ABI unsigned compute_thread_count() const;
 
     /// Assign the current thread to an ideal hardware CPU or NUMA node. In a
     /// multi-socket system, this ensures threads are assigned to all CPU
     /// sockets. \p ThreadPoolNum represents a number bounded by [0,
     /// compute_thread_count()).
-    void apply_thread_strategy(unsigned ThreadPoolNum) const;
+    LLVM_ABI void apply_thread_strategy(unsigned ThreadPoolNum) const;
 
     /// Finds the CPU socket where a thread should go. Returns 'std::nullopt' if
     /// the thread shall remain on the actual CPU socket.
-    std::optional<unsigned> compute_cpu_socket(unsigned ThreadPoolNum) const;
+    LLVM_ABI std::optional<unsigned> compute_cpu_socket(unsigned ThreadPoolNum) const;
   };
 
   /// Build a strategy from a number of threads as a string provided in \p Num.
@@ -148,7 +148,7 @@ constexpr bool llvm_is_multithreaded() { return LLVM_ENABLE_THREADS; }
   /// strategy, we attempt to equally allocate the threads on all CPU sockets.
   /// "0" or an empty string will return the \p Default strategy.
   /// "all" for using all hardware threads.
-  std::optional<ThreadPoolStrategy>
+  LLVM_ABI std::optional<ThreadPoolStrategy>
   get_threadpool_strategy(StringRef Num, ThreadPoolStrategy Default = {});
 
   /// Returns a thread strategy for tasks requiring significant memory or other
@@ -213,11 +213,11 @@ constexpr bool llvm_is_multithreaded() { return LLVM_ENABLE_THREADS; }
   /// Note that not all platforms guarantee that the value returned will be
   /// unique across the entire system, so portable code should not assume
   /// this.
-  uint64_t get_threadid();
+  LLVM_ABI uint64_t get_threadid();
 
   /// Get the maximum length of a thread name on this platform.
   /// A value of 0 means there is no limit.
-  uint32_t get_max_thread_name_length();
+  LLVM_ABI uint32_t get_max_thread_name_length();
 
   /// Set the name of the current thread.  Setting a thread's name can
   /// be helpful for enabling useful diagnostics under a debugger or when
@@ -225,7 +225,7 @@ constexpr bool llvm_is_multithreaded() { return LLVM_ENABLE_THREADS; }
   /// wildly across operating systems, and we only make a best effort to
   /// perform the operation on supported platforms.  No indication of success
   /// or failure is returned.
-  void set_thread_name(const Twine &Name);
+  LLVM_ABI void set_thread_name(const Twine &Name);
 
   /// Get the name of the current thread.  The level of support for
   /// getting a thread's name varies wildly across operating systems, and it
@@ -233,20 +233,20 @@ constexpr bool llvm_is_multithreaded() { return LLVM_ENABLE_THREADS; }
   /// that you can later get it back.  This function is intended for diagnostic
   /// purposes, and as with setting a thread's name no indication of whether
   /// the operation succeeded or failed is returned.
-  void get_thread_name(SmallVectorImpl<char> &Name);
+  LLVM_ABI void get_thread_name(SmallVectorImpl<char> &Name);
 
   /// Returns a mask that represents on which hardware thread, core, CPU, NUMA
   /// group, the calling thread can be executed. On Windows, threads cannot
   /// cross CPU sockets boundaries.
-  llvm::BitVector get_thread_affinity_mask();
+  LLVM_ABI llvm::BitVector get_thread_affinity_mask();
 
   /// Returns how many physical CPUs or NUMA groups the system has.
-  unsigned get_cpus();
+  LLVM_ABI unsigned get_cpus();
 
   /// Returns how many physical cores (as opposed to logical cores returned from
   /// thread::hardware_concurrency(), which includes hyperthreads).
   /// Returns -1 if unknown for the current host system.
-  int get_physical_cores();
+  LLVM_ABI int get_physical_cores();
 
   enum class ThreadPriority {
     /// Lower the current thread's priority as much as possible. Can be used
@@ -264,7 +264,7 @@ constexpr bool llvm_is_multithreaded() { return LLVM_ENABLE_THREADS; }
     Default = 2,
   };
   enum class SetThreadPriorityResult { FAILURE, SUCCESS };
-  SetThreadPriorityResult set_thread_priority(ThreadPriority Priority);
+  LLVM_ABI SetThreadPriorityResult set_thread_priority(ThreadPriority Priority);
 }
 
 #endif

--- a/llvm/include/llvm/Support/Threading.h
+++ b/llvm/include/llvm/Support/Threading.h
@@ -140,7 +140,8 @@ constexpr bool llvm_is_multithreaded() { return LLVM_ENABLE_THREADS; }
 
     /// Finds the CPU socket where a thread should go. Returns 'std::nullopt' if
     /// the thread shall remain on the actual CPU socket.
-    LLVM_ABI std::optional<unsigned> compute_cpu_socket(unsigned ThreadPoolNum) const;
+    LLVM_ABI std::optional<unsigned>
+    compute_cpu_socket(unsigned ThreadPoolNum) const;
   };
 
   /// Build a strategy from a number of threads as a string provided in \p Num.

--- a/llvm/include/llvm/Support/TimeProfiler.h
+++ b/llvm/include/llvm/Support/TimeProfiler.h
@@ -76,8 +76,8 @@
 #ifndef LLVM_SUPPORT_TIMEPROFILER_H
 #define LLVM_SUPPORT_TIMEPROFILER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 namespace llvm {
@@ -117,8 +117,8 @@ struct TimeTraceProfilerEntry;
 /// This sets up the global \p TimeTraceProfilerInstance
 /// variable to be the profiler instance.
 LLVM_ABI void timeTraceProfilerInitialize(unsigned TimeTraceGranularity,
-                                 StringRef ProcName,
-                                 bool TimeTraceVerbose = false);
+                                          StringRef ProcName,
+                                          bool TimeTraceVerbose = false);
 
 /// Cleanup the time trace profiler, if it was initialized.
 LLVM_ABI void timeTraceProfilerCleanup();
@@ -142,14 +142,14 @@ LLVM_ABI void timeTraceProfilerWrite(raw_pwrite_stream &OS);
 /// Returns a StringError indicating a failure if the function is
 /// unable to open the file for writing.
 LLVM_ABI Error timeTraceProfilerWrite(StringRef PreferredFileName,
-                             StringRef FallbackFileName);
+                                      StringRef FallbackFileName);
 
 /// Manually begin a time section, with the given \p Name and \p Detail.
 /// Profiler copies the string data, so the pointers can be given into
 /// temporaries. Time sections can be hierarchical; every Begin must have a
 /// matching End pair but they can nest.
 LLVM_ABI TimeTraceProfilerEntry *timeTraceProfilerBegin(StringRef Name,
-                                               StringRef Detail);
+                                                        StringRef Detail);
 LLVM_ABI TimeTraceProfilerEntry *
 timeTraceProfilerBegin(StringRef Name,
                        llvm::function_ref<std::string()> Detail);
@@ -164,11 +164,12 @@ timeTraceProfilerBegin(StringRef Name,
 /// https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#heading=h.jh64i9l3vwa1
 /// for more details.
 LLVM_ABI TimeTraceProfilerEntry *timeTraceAsyncProfilerBegin(StringRef Name,
-                                                    StringRef Detail);
+                                                             StringRef Detail);
 
 // Mark an instant event.
-LLVM_ABI void timeTraceAddInstantEvent(StringRef Name,
-                              llvm::function_ref<std::string()> Detail);
+LLVM_ABI void
+timeTraceAddInstantEvent(StringRef Name,
+                         llvm::function_ref<std::string()> Detail);
 
 /// Manually end the last time section.
 LLVM_ABI void timeTraceProfilerEnd();

--- a/llvm/include/llvm/Support/TimeProfiler.h
+++ b/llvm/include/llvm/Support/TimeProfiler.h
@@ -76,6 +76,7 @@
 #ifndef LLVM_SUPPORT_TIMEPROFILER_H
 #define LLVM_SUPPORT_TIMEPROFILER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/Support/Error.h"
 
@@ -106,24 +107,24 @@ struct TimeTraceMetadata {
 };
 
 struct TimeTraceProfiler;
-TimeTraceProfiler *getTimeTraceProfilerInstance();
+LLVM_ABI TimeTraceProfiler *getTimeTraceProfilerInstance();
 
-bool isTimeTraceVerbose();
+LLVM_ABI bool isTimeTraceVerbose();
 
 struct TimeTraceProfilerEntry;
 
 /// Initialize the time trace profiler.
 /// This sets up the global \p TimeTraceProfilerInstance
 /// variable to be the profiler instance.
-void timeTraceProfilerInitialize(unsigned TimeTraceGranularity,
+LLVM_ABI void timeTraceProfilerInitialize(unsigned TimeTraceGranularity,
                                  StringRef ProcName,
                                  bool TimeTraceVerbose = false);
 
 /// Cleanup the time trace profiler, if it was initialized.
-void timeTraceProfilerCleanup();
+LLVM_ABI void timeTraceProfilerCleanup();
 
 /// Finish a time trace profiler running on a worker thread.
-void timeTraceProfilerFinishThread();
+LLVM_ABI void timeTraceProfilerFinishThread();
 
 /// Is the time trace profiler enabled, i.e. initialized?
 inline bool timeTraceProfilerEnabled() {
@@ -133,27 +134,27 @@ inline bool timeTraceProfilerEnabled() {
 /// Write profiling data to output stream.
 /// Data produced is JSON, in Chrome "Trace Event" format, see
 /// https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
-void timeTraceProfilerWrite(raw_pwrite_stream &OS);
+LLVM_ABI void timeTraceProfilerWrite(raw_pwrite_stream &OS);
 
 /// Write profiling data to a file.
 /// The function will write to \p PreferredFileName if provided, if not
 /// then will write to \p FallbackFileName appending .time-trace.
 /// Returns a StringError indicating a failure if the function is
 /// unable to open the file for writing.
-Error timeTraceProfilerWrite(StringRef PreferredFileName,
+LLVM_ABI Error timeTraceProfilerWrite(StringRef PreferredFileName,
                              StringRef FallbackFileName);
 
 /// Manually begin a time section, with the given \p Name and \p Detail.
 /// Profiler copies the string data, so the pointers can be given into
 /// temporaries. Time sections can be hierarchical; every Begin must have a
 /// matching End pair but they can nest.
-TimeTraceProfilerEntry *timeTraceProfilerBegin(StringRef Name,
+LLVM_ABI TimeTraceProfilerEntry *timeTraceProfilerBegin(StringRef Name,
                                                StringRef Detail);
-TimeTraceProfilerEntry *
+LLVM_ABI TimeTraceProfilerEntry *
 timeTraceProfilerBegin(StringRef Name,
                        llvm::function_ref<std::string()> Detail);
 
-TimeTraceProfilerEntry *
+LLVM_ABI TimeTraceProfilerEntry *
 timeTraceProfilerBegin(StringRef Name,
                        llvm::function_ref<TimeTraceMetadata()> MetaData);
 
@@ -162,16 +163,16 @@ timeTraceProfilerBegin(StringRef Name,
 /// separately from other traces. See
 /// https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#heading=h.jh64i9l3vwa1
 /// for more details.
-TimeTraceProfilerEntry *timeTraceAsyncProfilerBegin(StringRef Name,
+LLVM_ABI TimeTraceProfilerEntry *timeTraceAsyncProfilerBegin(StringRef Name,
                                                     StringRef Detail);
 
 // Mark an instant event.
-void timeTraceAddInstantEvent(StringRef Name,
+LLVM_ABI void timeTraceAddInstantEvent(StringRef Name,
                               llvm::function_ref<std::string()> Detail);
 
 /// Manually end the last time section.
-void timeTraceProfilerEnd();
-void timeTraceProfilerEnd(TimeTraceProfilerEntry *E);
+LLVM_ABI void timeTraceProfilerEnd();
+LLVM_ABI void timeTraceProfilerEnd(TimeTraceProfilerEntry *E);
 
 /// The TimeTraceScope is a helper class to call the begin and end functions
 /// of the time trace profiler.  When the object is constructed, it begins

--- a/llvm/include/llvm/Support/Timer.h
+++ b/llvm/include/llvm/Support/Timer.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_TIMER_H
 #define LLVM_SUPPORT_TIMER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/DataTypes.h"
@@ -37,7 +38,7 @@ public:
   /// usage before the time, otherwise we get time before memory usage.  This
   /// matters if the time to get the memory usage is significant and shouldn't
   /// be counted as part of a duration.
-  static TimeRecord getCurrentTime(bool Start = true);
+  LLVM_ABI static TimeRecord getCurrentTime(bool Start = true);
 
   double getProcessTime() const { return UserTime + SystemTime; }
   double getUserTime() const { return UserTime; }
@@ -68,7 +69,7 @@ public:
 
   /// Print the current time record to \p OS, with a breakdown showing
   /// contributions to the \p Total time record.
-  void print(const TimeRecord &Total, raw_ostream &OS) const;
+  LLVM_ABI void print(const TimeRecord &Total, raw_ostream &OS) const;
 };
 
 /// This class is used to track the amount of time spent between invocations of
@@ -103,12 +104,12 @@ public:
     assert(!TG && !T.TG && "Can only assign uninit timers");
     return *this;
   }
-  ~Timer();
+  LLVM_ABI ~Timer();
 
   /// Create an uninitialized timer, client must use 'init'.
   explicit Timer() = default;
-  void init(StringRef TimerName, StringRef TimerDescription);
-  void init(StringRef TimerName, StringRef TimerDescription, TimerGroup &tg);
+  LLVM_ABI void init(StringRef TimerName, StringRef TimerDescription);
+  LLVM_ABI void init(StringRef TimerName, StringRef TimerDescription, TimerGroup &tg);
 
   const std::string &getName() const { return Name; }
   const std::string &getDescription() const { return Description; }
@@ -123,16 +124,16 @@ public:
   /// Start the timer running.  Time between calls to startTimer/stopTimer is
   /// counted by the Timer class.  Note that these calls must be correctly
   /// paired.
-  void startTimer();
+  LLVM_ABI void startTimer();
 
   /// Stop the timer.
-  void stopTimer();
+  LLVM_ABI void stopTimer();
 
   /// Clear the timer state.
-  void clear();
+  LLVM_ABI void clear();
 
   /// Stop the timer and start another timer.
-  void yieldTo(Timer &);
+  LLVM_ABI void yieldTo(Timer &);
 
   /// Return the duration for which this timer has been running.
   TimeRecord getTotalTime() const { return Time; }
@@ -166,13 +167,13 @@ public:
 /// statement.  All timers with the same name are merged.  This is primarily
 /// used for debugging and for hunting performance problems.
 struct NamedRegionTimer : public TimeRegion {
-  explicit NamedRegionTimer(StringRef Name, StringRef Description,
+  LLVM_ABI explicit NamedRegionTimer(StringRef Name, StringRef Description,
                             StringRef GroupName,
                             StringRef GroupDescription, bool Enabled = true);
 
   // Create or get a TimerGroup stored in the same global map owned by
   // NamedRegionTimer.
-  static TimerGroup &getNamedTimerGroup(StringRef GroupName,
+  LLVM_ABI static TimerGroup &getNamedTimerGroup(StringRef GroupName,
                                         StringRef GroupDescription);
 };
 
@@ -211,12 +212,12 @@ class TimerGroup {
                       sys::SmartMutex<true> &lock);
 
 public:
-  explicit TimerGroup(StringRef Name, StringRef Description);
+  LLVM_ABI explicit TimerGroup(StringRef Name, StringRef Description);
 
-  explicit TimerGroup(StringRef Name, StringRef Description,
+  LLVM_ABI explicit TimerGroup(StringRef Name, StringRef Description,
                       const StringMap<TimeRecord> &Records);
 
-  ~TimerGroup();
+  LLVM_ABI ~TimerGroup();
 
   void setName(StringRef NewName, StringRef NewDescription) {
     Name.assign(NewName.begin(), NewName.end());
@@ -225,32 +226,32 @@ public:
 
   /// Print any started timers in this group, optionally resetting timers after
   /// printing them.
-  void print(raw_ostream &OS, bool ResetAfterPrint = false);
+  LLVM_ABI void print(raw_ostream &OS, bool ResetAfterPrint = false);
 
   /// Clear all timers in this group.
-  void clear();
+  LLVM_ABI void clear();
 
   /// This static method prints all timers.
-  static void printAll(raw_ostream &OS);
+  LLVM_ABI static void printAll(raw_ostream &OS);
 
   /// Clear out all timers. This is mostly used to disable automatic
   /// printing on shutdown, when timers have already been printed explicitly
   /// using \c printAll or \c printJSONValues.
-  static void clearAll();
+  LLVM_ABI static void clearAll();
 
-  const char *printJSONValues(raw_ostream &OS, const char *delim);
+  LLVM_ABI const char *printJSONValues(raw_ostream &OS, const char *delim);
 
   /// Prints all timers as JSON key/value pairs.
-  static const char *printAllJSONValues(raw_ostream &OS, const char *delim);
+  LLVM_ABI static const char *printAllJSONValues(raw_ostream &OS, const char *delim);
 
   /// Ensure global objects required for statistics printing are initialized.
   /// This function is used by the Statistic code to ensure correct order of
   /// global constructors and destructors.
-  static void constructForStatistics();
+  LLVM_ABI static void constructForStatistics();
 
   /// This makes the timer globals unmanaged, and lets the user manage the
   /// lifetime.
-  static void *acquireTimerGlobals();
+  LLVM_ABI static void *acquireTimerGlobals();
 
 private:
   friend class Timer;

--- a/llvm/include/llvm/Support/Timer.h
+++ b/llvm/include/llvm/Support/Timer.h
@@ -9,9 +9,9 @@
 #ifndef LLVM_SUPPORT_TIMER_H
 #define LLVM_SUPPORT_TIMER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/Mutex.h"
 #include <cassert>
@@ -109,7 +109,8 @@ public:
   /// Create an uninitialized timer, client must use 'init'.
   explicit Timer() = default;
   LLVM_ABI void init(StringRef TimerName, StringRef TimerDescription);
-  LLVM_ABI void init(StringRef TimerName, StringRef TimerDescription, TimerGroup &tg);
+  LLVM_ABI void init(StringRef TimerName, StringRef TimerDescription,
+                     TimerGroup &tg);
 
   const std::string &getName() const { return Name; }
   const std::string &getDescription() const { return Description; }
@@ -168,13 +169,14 @@ public:
 /// used for debugging and for hunting performance problems.
 struct NamedRegionTimer : public TimeRegion {
   LLVM_ABI explicit NamedRegionTimer(StringRef Name, StringRef Description,
-                            StringRef GroupName,
-                            StringRef GroupDescription, bool Enabled = true);
+                                     StringRef GroupName,
+                                     StringRef GroupDescription,
+                                     bool Enabled = true);
 
   // Create or get a TimerGroup stored in the same global map owned by
   // NamedRegionTimer.
   LLVM_ABI static TimerGroup &getNamedTimerGroup(StringRef GroupName,
-                                        StringRef GroupDescription);
+                                                 StringRef GroupDescription);
 };
 
 /// The TimerGroup class is used to group together related timers into a single
@@ -215,7 +217,7 @@ public:
   LLVM_ABI explicit TimerGroup(StringRef Name, StringRef Description);
 
   LLVM_ABI explicit TimerGroup(StringRef Name, StringRef Description,
-                      const StringMap<TimeRecord> &Records);
+                               const StringMap<TimeRecord> &Records);
 
   LLVM_ABI ~TimerGroup();
 
@@ -242,7 +244,8 @@ public:
   LLVM_ABI const char *printJSONValues(raw_ostream &OS, const char *delim);
 
   /// Prints all timers as JSON key/value pairs.
-  LLVM_ABI static const char *printAllJSONValues(raw_ostream &OS, const char *delim);
+  LLVM_ABI static const char *printAllJSONValues(raw_ostream &OS,
+                                                 const char *delim);
 
   /// Ensure global objects required for statistics printing are initialized.
   /// This function is used by the Statistic code to ensure correct order of

--- a/llvm/include/llvm/Support/ToolOutputFile.h
+++ b/llvm/include/llvm/Support/ToolOutputFile.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_TOOLOUTPUTFILE_H
 #define LLVM_SUPPORT_TOOLOUTPUTFILE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 #include <optional>
 
@@ -27,8 +28,8 @@ public:
   bool Keep;
 
   StringRef getFilename() { return Filename; }
-  explicit CleanupInstaller(StringRef Filename);
-  ~CleanupInstaller();
+  LLVM_ABI explicit CleanupInstaller(StringRef Filename);
+  LLVM_ABI ~CleanupInstaller();
 };
 
 /// This class contains a raw_fd_ostream and adds a few extra features commonly
@@ -53,10 +54,10 @@ class ToolOutputFile {
 public:
   /// This constructor's arguments are passed to raw_fd_ostream's
   /// constructor.
-  ToolOutputFile(StringRef Filename, std::error_code &EC,
+  LLVM_ABI ToolOutputFile(StringRef Filename, std::error_code &EC,
                  sys::fs::OpenFlags Flags);
 
-  ToolOutputFile(StringRef Filename, int FD);
+  LLVM_ABI ToolOutputFile(StringRef Filename, int FD);
 
   /// Return the contained raw_fd_ostream.
   raw_fd_ostream &os() { return *OS; }

--- a/llvm/include/llvm/Support/ToolOutputFile.h
+++ b/llvm/include/llvm/Support/ToolOutputFile.h
@@ -55,7 +55,7 @@ public:
   /// This constructor's arguments are passed to raw_fd_ostream's
   /// constructor.
   LLVM_ABI ToolOutputFile(StringRef Filename, std::error_code &EC,
-                 sys::fs::OpenFlags Flags);
+                          sys::fs::OpenFlags Flags);
 
   LLVM_ABI ToolOutputFile(StringRef Filename, int FD);
 

--- a/llvm/include/llvm/Support/TypeSize.h
+++ b/llvm/include/llvm/Support/TypeSize.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_SUPPORT_TYPESIZE_H
 #define LLVM_SUPPORT_TYPESIZE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -27,7 +28,7 @@ namespace llvm {
 
 /// Reports a diagnostic message to indicate an invalid size request has been
 /// done on a scalable vector. This function may not return.
-void reportInvalidSizeRequest(const char *Msg);
+LLVM_ABI void reportInvalidSizeRequest(const char *Msg);
 
 /// StackOffset holds a fixed and a scalable offset in bytes.
 class StackOffset {
@@ -374,7 +375,7 @@ public:
   //     else
   //       bail out early for scalable vectors and use getFixedValue()
   //   }
-  operator ScalarTy() const;
+  LLVM_ABI operator ScalarTy() const;
 
   // Additional operators needed to avoid ambiguous parses
   // because of the implicit conversion hack.

--- a/llvm/include/llvm/Support/Unicode.h
+++ b/llvm/include/llvm/Support/Unicode.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_SUPPORT_UNICODE_H
 #define LLVM_SUPPORT_UNICODE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
+#include "llvm/Support/Compiler.h"
 #include <optional>
 #include <string>
 
@@ -75,7 +75,8 @@ struct LooseMatchingResult {
   SmallString<64> Name;
 };
 
-LLVM_ABI std::optional<LooseMatchingResult> nameToCodepointLooseMatching(StringRef Name);
+LLVM_ABI std::optional<LooseMatchingResult>
+nameToCodepointLooseMatching(StringRef Name);
 
 struct MatchForCodepointName {
   std::string Name;

--- a/llvm/include/llvm/Support/Unicode.h
+++ b/llvm/include/llvm/Support/Unicode.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_UNICODE_H
 #define LLVM_SUPPORT_UNICODE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallString.h"
 #include <optional>
 #include <string>
@@ -36,10 +37,10 @@ enum ColumnWidthErrors {
 ///
 /// Printable codepoints are those in the categories L, M, N, P, S and Zs
 /// \return true if the character is considered printable.
-bool isPrintable(int UCS);
+LLVM_ABI bool isPrintable(int UCS);
 
 // Formatting codepoints are codepoints in the Cf category.
-bool isFormatting(int UCS);
+LLVM_ABI bool isFormatting(int UCS);
 
 /// Gets the number of positions the UTF8-encoded \p Text is likely to occupy
 /// when output on a terminal ("character width"). This depends on the
@@ -55,11 +56,11 @@ bool isFormatting(int UCS);
 ///   * 0 for each non-spacing and enclosing combining mark;
 ///   * 2 for each CJK character excluding halfwidth forms;
 ///   * 1 for each of the remaining characters.
-int columnWidthUTF8(StringRef Text);
+LLVM_ABI int columnWidthUTF8(StringRef Text);
 
 /// Fold input unicode character according the Simple unicode case folding
 /// rules.
-int foldCharSimple(int C);
+LLVM_ABI int foldCharSimple(int C);
 
 /// Maps the name or the alias of a Unicode character to its associated
 /// codepoints.
@@ -67,14 +68,14 @@ int foldCharSimple(int C);
 /// For compatibility with the semantics of named character escape sequences in
 /// C++, this mapping does an exact match sensitive to casing and spacing.
 /// \return The codepoint of the corresponding character, if any.
-std::optional<char32_t> nameToCodepointStrict(StringRef Name);
+LLVM_ABI std::optional<char32_t> nameToCodepointStrict(StringRef Name);
 
 struct LooseMatchingResult {
   char32_t CodePoint;
   SmallString<64> Name;
 };
 
-std::optional<LooseMatchingResult> nameToCodepointLooseMatching(StringRef Name);
+LLVM_ABI std::optional<LooseMatchingResult> nameToCodepointLooseMatching(StringRef Name);
 
 struct MatchForCodepointName {
   std::string Name;
@@ -82,7 +83,7 @@ struct MatchForCodepointName {
   char32_t Value = 0;
 };
 
-SmallVector<MatchForCodepointName>
+LLVM_ABI SmallVector<MatchForCodepointName>
 nearestMatchesForCodepointName(StringRef Pattern, std::size_t MaxMatchesCount);
 
 } // namespace unicode

--- a/llvm/include/llvm/Support/Valgrind.h
+++ b/llvm/include/llvm/Support/Valgrind.h
@@ -15,16 +15,17 @@
 #ifndef LLVM_SUPPORT_VALGRIND_H
 #define LLVM_SUPPORT_VALGRIND_H
 
+#include "llvm/Support/Compiler.h"
 #include <cstddef>
 
 namespace llvm {
 namespace sys {
   // True if Valgrind is controlling this process.
-  bool RunningOnValgrind();
+  LLVM_ABI bool RunningOnValgrind();
 
   // Discard valgrind's translation of code in the range [Addr .. Addr + Len).
   // Otherwise valgrind may continue to execute the old version of the code.
-  void ValgrindDiscardTranslations(const void *Addr, size_t Len);
+  LLVM_ABI void ValgrindDiscardTranslations(const void *Addr, size_t Len);
 } // namespace sys
 } // end namespace llvm
 

--- a/llvm/include/llvm/Support/Valgrind.h
+++ b/llvm/include/llvm/Support/Valgrind.h
@@ -21,11 +21,11 @@
 namespace llvm {
 namespace sys {
   // True if Valgrind is controlling this process.
-  LLVM_ABI bool RunningOnValgrind();
+LLVM_ABI bool RunningOnValgrind();
 
-  // Discard valgrind's translation of code in the range [Addr .. Addr + Len).
-  // Otherwise valgrind may continue to execute the old version of the code.
-  LLVM_ABI void ValgrindDiscardTranslations(const void *Addr, size_t Len);
+// Discard valgrind's translation of code in the range [Addr .. Addr + Len).
+// Otherwise valgrind may continue to execute the old version of the code.
+LLVM_ABI void ValgrindDiscardTranslations(const void *Addr, size_t Len);
 } // namespace sys
 } // end namespace llvm
 

--- a/llvm/include/llvm/Support/VersionTuple.h
+++ b/llvm/include/llvm/Support/VersionTuple.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_VERSIONTUPLE_H
 #define LLVM_SUPPORT_VERSIONTUPLE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/Hashing.h"
 #include <optional>
@@ -100,7 +101,7 @@ public:
 
   /// Return a version tuple that contains a different major version but
   /// everything else is the same.
-  VersionTuple withMajorReplaced(unsigned NewMajor) const;
+  LLVM_ABI VersionTuple withMajorReplaced(unsigned NewMajor) const;
 
   /// Return a version tuple that contains only components that are non-zero.
   VersionTuple normalize() const {
@@ -177,16 +178,16 @@ public:
   }
 
   /// Retrieve a string representation of the version number.
-  std::string getAsString() const;
+  LLVM_ABI std::string getAsString() const;
 
   /// Try to parse the given string as a version number.
   /// \returns \c true if the string does not match the regular expression
   ///   [0-9]+(\.[0-9]+){0,3}
-  bool tryParse(StringRef string);
+  LLVM_ABI bool tryParse(StringRef string);
 };
 
 /// Print a version number.
-raw_ostream &operator<<(raw_ostream &Out, const VersionTuple &V);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &Out, const VersionTuple &V);
 
 // Provide DenseMapInfo for version tuples.
 template <> struct DenseMapInfo<VersionTuple> {

--- a/llvm/include/llvm/Support/VersionTuple.h
+++ b/llvm/include/llvm/Support/VersionTuple.h
@@ -14,9 +14,9 @@
 #ifndef LLVM_SUPPORT_VERSIONTUPLE_H
 #define LLVM_SUPPORT_VERSIONTUPLE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/Support/Compiler.h"
 #include <optional>
 #include <string>
 #include <tuple>

--- a/llvm/include/llvm/Support/VirtualFileSystem.h
+++ b/llvm/include/llvm/Support/VirtualFileSystem.h
@@ -14,12 +14,12 @@
 #ifndef LLVM_SUPPORT_VIRTUALFILESYSTEM_H
 #define LLVM_SUPPORT_VIRTUALFILESYSTEM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Chrono.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorOr.h"
@@ -71,16 +71,17 @@ public:
   Status() = default;
   LLVM_ABI Status(const llvm::sys::fs::file_status &Status);
   LLVM_ABI Status(const Twine &Name, llvm::sys::fs::UniqueID UID,
-         llvm::sys::TimePoint<> MTime, uint32_t User, uint32_t Group,
-         uint64_t Size, llvm::sys::fs::file_type Type,
-         llvm::sys::fs::perms Perms);
+                  llvm::sys::TimePoint<> MTime, uint32_t User, uint32_t Group,
+                  uint64_t Size, llvm::sys::fs::file_type Type,
+                  llvm::sys::fs::perms Perms);
 
   /// Get a copy of a Status with a different size.
   LLVM_ABI static Status copyWithNewSize(const Status &In, uint64_t NewSize);
   /// Get a copy of a Status with a different name.
-  LLVM_ABI static Status copyWithNewName(const Status &In, const Twine &NewName);
+  LLVM_ABI static Status copyWithNewName(const Status &In,
+                                         const Twine &NewName);
   LLVM_ABI static Status copyWithNewName(const llvm::sys::fs::file_status &In,
-                                const Twine &NewName);
+                                         const Twine &NewName);
 
   /// Returns the name that should be used for this file or directory.
   StringRef getName() const { return Name; }
@@ -234,7 +235,7 @@ class recursive_directory_iterator {
 
 public:
   LLVM_ABI recursive_directory_iterator(FileSystem &FS, const Twine &Path,
-                               std::error_code &EC);
+                                        std::error_code &EC);
 
   /// Construct an 'end' iterator.
   recursive_directory_iterator() = default;
@@ -264,7 +265,7 @@ public:
 
 /// The virtual file system interface.
 class LLVM_ABI FileSystem : public llvm::ThreadSafeRefCountedBase<FileSystem>,
-                   public RTTIExtends<FileSystem, RTTIRoot> {
+                            public RTTIExtends<FileSystem, RTTIRoot> {
 public:
   static const char ID;
   virtual ~FileSystem();
@@ -389,7 +390,8 @@ LLVM_ABI std::unique_ptr<FileSystem> createPhysicalFileSystem();
 /// top-most (most recently added) directory are used.  When there is a file
 /// that exists in more than one file system, the file in the top-most file
 /// system overrides the other(s).
-class LLVM_ABI OverlayFileSystem : public RTTIExtends<OverlayFileSystem, FileSystem> {
+class LLVM_ABI OverlayFileSystem
+    : public RTTIExtends<OverlayFileSystem, FileSystem> {
   using FileSystemList = SmallVector<IntrusiveRefCntPtr<FileSystem>, 1>;
 
   /// The stack of file systems, implemented as a list in order of
@@ -449,7 +451,8 @@ protected:
 /// By default, this delegates all calls to the underlying file system. This
 /// is useful when derived file systems want to override some calls and still
 /// proxy other calls.
-class LLVM_ABI ProxyFileSystem : public RTTIExtends<ProxyFileSystem, FileSystem> {
+class LLVM_ABI ProxyFileSystem
+    : public RTTIExtends<ProxyFileSystem, FileSystem> {
 public:
   static const char ID;
   explicit ProxyFileSystem(IntrusiveRefCntPtr<FileSystem> FS)
@@ -535,7 +538,8 @@ public:
 } // namespace detail
 
 /// An in-memory file system.
-class LLVM_ABI InMemoryFileSystem : public RTTIExtends<InMemoryFileSystem, FileSystem> {
+class LLVM_ABI InMemoryFileSystem
+    : public RTTIExtends<InMemoryFileSystem, FileSystem> {
   std::unique_ptr<detail::InMemoryDirectory> Root;
   std::string WorkingDirectory;
   bool UseNormalizedPaths = true;
@@ -924,7 +928,7 @@ public:
 
   public:
     LLVM_ABI LookupResult(Entry *E, sys::path::const_iterator Start,
-                 sys::path::const_iterator End);
+                          sys::path::const_iterator End);
 
     /// If the found Entry maps the input path to a path in the external
     /// file system (i.e. it is a FileEntry or DirectoryRemapEntry), returns

--- a/llvm/include/llvm/Support/VirtualFileSystem.h
+++ b/llvm/include/llvm/Support/VirtualFileSystem.h
@@ -1036,6 +1036,10 @@ private:
 
   RedirectingFileSystem(IntrusiveRefCntPtr<FileSystem> ExternalFS);
 
+  // Explicitly non-copyable.
+  RedirectingFileSystem(RedirectingFileSystem const &) = delete;
+  RedirectingFileSystem &operator=(RedirectingFileSystem const &) = delete;
+
   /// Looks up the path <tt>[Start, End)</tt> in \p From, possibly recursing
   /// into the contents of \p From if it is a directory. Returns a LookupResult
   /// giving the matched entry and, if that entry is a FileEntry or

--- a/llvm/include/llvm/Support/VirtualFileSystem.h
+++ b/llvm/include/llvm/Support/VirtualFileSystem.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_VIRTUALFILESYSTEM_H
 #define LLVM_SUPPORT_VIRTUALFILESYSTEM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
@@ -68,17 +69,17 @@ public:
   bool ExposesExternalVFSPath = false;
 
   Status() = default;
-  Status(const llvm::sys::fs::file_status &Status);
-  Status(const Twine &Name, llvm::sys::fs::UniqueID UID,
+  LLVM_ABI Status(const llvm::sys::fs::file_status &Status);
+  LLVM_ABI Status(const Twine &Name, llvm::sys::fs::UniqueID UID,
          llvm::sys::TimePoint<> MTime, uint32_t User, uint32_t Group,
          uint64_t Size, llvm::sys::fs::file_type Type,
          llvm::sys::fs::perms Perms);
 
   /// Get a copy of a Status with a different size.
-  static Status copyWithNewSize(const Status &In, uint64_t NewSize);
+  LLVM_ABI static Status copyWithNewSize(const Status &In, uint64_t NewSize);
   /// Get a copy of a Status with a different name.
-  static Status copyWithNewName(const Status &In, const Twine &NewName);
-  static Status copyWithNewName(const llvm::sys::fs::file_status &In,
+  LLVM_ABI static Status copyWithNewName(const Status &In, const Twine &NewName);
+  LLVM_ABI static Status copyWithNewName(const llvm::sys::fs::file_status &In,
                                 const Twine &NewName);
 
   /// Returns the name that should be used for this file or directory.
@@ -97,18 +98,18 @@ public:
   /// @name Status queries
   /// These are static queries in llvm::sys::fs.
   /// @{
-  bool equivalent(const Status &Other) const;
-  bool isDirectory() const;
-  bool isRegularFile() const;
-  bool isOther() const;
-  bool isSymlink() const;
-  bool isStatusKnown() const;
-  bool exists() const;
+  LLVM_ABI bool equivalent(const Status &Other) const;
+  LLVM_ABI bool isDirectory() const;
+  LLVM_ABI bool isRegularFile() const;
+  LLVM_ABI bool isOther() const;
+  LLVM_ABI bool isSymlink() const;
+  LLVM_ABI bool isStatusKnown() const;
+  LLVM_ABI bool exists() const;
   /// @}
 };
 
 /// Represents an open file.
-class File {
+class LLVM_ABI File {
 public:
   /// Destroy the file after closing it (if open).
   /// Sub-classes should generally call close() inside their destructors.  We
@@ -162,7 +163,7 @@ namespace detail {
 
 /// An interface for virtual file systems to provide an iterator over the
 /// (non-recursive) contents of a directory.
-struct DirIterImpl {
+struct LLVM_ABI DirIterImpl {
   virtual ~DirIterImpl();
 
   /// Sets \c CurrentEntry to the next entry in the directory on success,
@@ -232,14 +233,14 @@ class recursive_directory_iterator {
       State; // Input iterator semantics on copy.
 
 public:
-  recursive_directory_iterator(FileSystem &FS, const Twine &Path,
+  LLVM_ABI recursive_directory_iterator(FileSystem &FS, const Twine &Path,
                                std::error_code &EC);
 
   /// Construct an 'end' iterator.
   recursive_directory_iterator() = default;
 
   /// Equivalent to operator++, with an error code.
-  recursive_directory_iterator &increment(std::error_code &EC);
+  LLVM_ABI recursive_directory_iterator &increment(std::error_code &EC);
 
   const directory_entry &operator*() const { return *State->Stack.back(); }
   const directory_entry *operator->() const { return &*State->Stack.back(); }
@@ -262,7 +263,7 @@ public:
 };
 
 /// The virtual file system interface.
-class FileSystem : public llvm::ThreadSafeRefCountedBase<FileSystem>,
+class LLVM_ABI FileSystem : public llvm::ThreadSafeRefCountedBase<FileSystem>,
                    public RTTIExtends<FileSystem, RTTIRoot> {
 public:
   static const char ID;
@@ -370,13 +371,13 @@ protected:
 /// the operating system.
 /// The working directory is linked to the process's working directory.
 /// (This is usually thread-hostile).
-IntrusiveRefCntPtr<FileSystem> getRealFileSystem();
+LLVM_ABI IntrusiveRefCntPtr<FileSystem> getRealFileSystem();
 
 /// Create an \p vfs::FileSystem for the 'real' file system, as seen by
 /// the operating system.
 /// It has its own working directory, independent of (but initially equal to)
 /// that of the process.
-std::unique_ptr<FileSystem> createPhysicalFileSystem();
+LLVM_ABI std::unique_ptr<FileSystem> createPhysicalFileSystem();
 
 /// A file system that allows overlaying one \p AbstractFileSystem on top
 /// of another.
@@ -388,7 +389,7 @@ std::unique_ptr<FileSystem> createPhysicalFileSystem();
 /// top-most (most recently added) directory are used.  When there is a file
 /// that exists in more than one file system, the file in the top-most file
 /// system overrides the other(s).
-class OverlayFileSystem : public RTTIExtends<OverlayFileSystem, FileSystem> {
+class LLVM_ABI OverlayFileSystem : public RTTIExtends<OverlayFileSystem, FileSystem> {
   using FileSystemList = SmallVector<IntrusiveRefCntPtr<FileSystem>, 1>;
 
   /// The stack of file systems, implemented as a list in order of
@@ -448,7 +449,7 @@ protected:
 /// By default, this delegates all calls to the underlying file system. This
 /// is useful when derived file systems want to override some calls and still
 /// proxy other calls.
-class ProxyFileSystem : public RTTIExtends<ProxyFileSystem, FileSystem> {
+class LLVM_ABI ProxyFileSystem : public RTTIExtends<ProxyFileSystem, FileSystem> {
 public:
   static const char ID;
   explicit ProxyFileSystem(IntrusiveRefCntPtr<FileSystem> FS)
@@ -510,7 +511,7 @@ struct NewInMemoryNodeInfo {
   llvm::sys::fs::file_type Type;
   llvm::sys::fs::perms Perms;
 
-  Status makeStatus() const;
+  LLVM_ABI Status makeStatus() const;
 };
 
 class NamedNodeOrError {
@@ -534,7 +535,7 @@ public:
 } // namespace detail
 
 /// An in-memory file system.
-class InMemoryFileSystem : public RTTIExtends<InMemoryFileSystem, FileSystem> {
+class LLVM_ABI InMemoryFileSystem : public RTTIExtends<InMemoryFileSystem, FileSystem> {
   std::unique_ptr<detail::InMemoryDirectory> Root;
   std::string WorkingDirectory;
   bool UseNormalizedPaths = true;
@@ -651,11 +652,11 @@ protected:
 };
 
 /// Get a globally unique ID for a virtual file or directory.
-llvm::sys::fs::UniqueID getNextVirtualUniqueID();
+LLVM_ABI llvm::sys::fs::UniqueID getNextVirtualUniqueID();
 
 /// Gets a \p FileSystem for a virtual file system described in YAML
 /// format.
-std::unique_ptr<FileSystem>
+LLVM_ABI std::unique_ptr<FileSystem>
 getVFSFromYAML(std::unique_ptr<llvm::MemoryBuffer> Buffer,
                llvm::SourceMgr::DiagHandlerTy DiagHandler,
                StringRef YAMLFilePath, void *DiagContext = nullptr,
@@ -774,7 +775,7 @@ class RedirectingFileSystemParser;
 /// FIXME: 'use-external-name' causes behaviour that's inconsistent with how
 /// "real" filesystems behave. Maybe there should be a separate channel for
 /// this information.
-class RedirectingFileSystem
+class LLVM_ABI RedirectingFileSystem
     : public RTTIExtends<RedirectingFileSystem, vfs::FileSystem> {
 public:
   static const char ID;
@@ -922,7 +923,7 @@ public:
     std::optional<std::string> ExternalRedirect;
 
   public:
-    LookupResult(Entry *E, sys::path::const_iterator Start,
+    LLVM_ABI LookupResult(Entry *E, sys::path::const_iterator Start,
                  sys::path::const_iterator End);
 
     /// If the found Entry maps the input path to a path in the external
@@ -938,7 +939,7 @@ public:
 
     /// Get the (canonical) path of the found entry. This uses the as-written
     /// path components from the VFS specification.
-    void getPath(llvm::SmallVectorImpl<char> &Path) const;
+    LLVM_ABI void getPath(llvm::SmallVectorImpl<char> &Path) const;
   };
 
 private:
@@ -1107,7 +1108,7 @@ protected:
 /// Collect all pairs of <virtual path, real path> entries from the
 /// \p YAMLFilePath. This is used by the module dependency collector to forward
 /// the entries into the reproducer output VFS YAML file.
-void collectVFSFromYAML(
+LLVM_ABI void collectVFSFromYAML(
     std::unique_ptr<llvm::MemoryBuffer> Buffer,
     llvm::SourceMgr::DiagHandlerTy DiagHandler, StringRef YAMLFilePath,
     SmallVectorImpl<YAMLVFSEntry> &CollectedEntries,
@@ -1126,8 +1127,8 @@ class YAMLVFSWriter {
 public:
   YAMLVFSWriter() = default;
 
-  void addFileMapping(StringRef VirtualPath, StringRef RealPath);
-  void addDirectoryMapping(StringRef VirtualPath, StringRef RealPath);
+  LLVM_ABI void addFileMapping(StringRef VirtualPath, StringRef RealPath);
+  LLVM_ABI void addDirectoryMapping(StringRef VirtualPath, StringRef RealPath);
 
   void setCaseSensitivity(bool CaseSensitive) {
     IsCaseSensitive = CaseSensitive;
@@ -1142,13 +1143,13 @@ public:
 
   const std::vector<YAMLVFSEntry> &getMappings() const { return Mappings; }
 
-  void write(llvm::raw_ostream &OS);
+  LLVM_ABI void write(llvm::raw_ostream &OS);
 };
 
 /// File system that tracks the number of calls to the underlying file system.
 /// This is particularly useful when wrapped around \c RealFileSystem to add
 /// lightweight tracking of expensive syscalls.
-class TracingFileSystem
+class LLVM_ABI TracingFileSystem
     : public llvm::RTTIExtends<TracingFileSystem, ProxyFileSystem> {
 public:
   static const char ID;

--- a/llvm/include/llvm/Support/Windows/WindowsSupport.h
+++ b/llvm/include/llvm/Support/Windows/WindowsSupport.h
@@ -55,18 +55,18 @@ namespace llvm {
 /// reimplements one of the helpers in the Windows 8.1 SDK, which are intended
 /// to supercede raw calls to GetVersionEx. Old SDKs, Cygwin, and MinGW don't
 /// yet have VersionHelpers.h, so we have our own helper.
-bool RunningWindows8OrGreater();
+LLVM_ABI bool RunningWindows8OrGreater();
 
 /// Determines if the program is running on Windows 11 or Windows Server 2022.
-bool RunningWindows11OrGreater();
+LLVM_ABI bool RunningWindows11OrGreater();
 
 /// Returns the Windows version as Major.Minor.0.BuildNumber. Uses
 /// RtlGetVersion or GetVersionEx under the hood depending on what is available.
 /// GetVersionEx is deprecated, but this API exposes the build number which can
 /// be useful for working around certain kernel bugs.
-llvm::VersionTuple GetWindowsOSVersion();
+LLVM_ABI llvm::VersionTuple GetWindowsOSVersion();
 
-bool MakeErrMsg(std::string *ErrMsg, const std::string &prefix);
+LLVM_ABI bool MakeErrMsg(std::string *ErrMsg, const std::string &prefix);
 
 // Include GetLastError() in a fatal error message.
 [[noreturn]] inline void ReportLastErrorFatal(const char *Msg) {
@@ -235,13 +235,15 @@ namespace windows {
 // Returns command line arguments. Unlike arguments given to main(),
 // this function guarantees that the returned arguments are encoded in
 // UTF-8 regardless of the current code page setting.
-std::error_code GetCommandLineArguments(SmallVectorImpl<const char *> &Args,
-                                        BumpPtrAllocator &Alloc);
+LLVM_ABI std::error_code
+GetCommandLineArguments(SmallVectorImpl<const char *> &Args,
+                        BumpPtrAllocator &Alloc);
 
 /// Convert UTF-8 path to a suitable UTF-16 path for use with the Win32 Unicode
 /// File API.
-std::error_code widenPath(const Twine &Path8, SmallVectorImpl<wchar_t> &Path16,
-                          size_t MaxPathLen = MAX_PATH);
+LLVM_ABI std::error_code widenPath(const Twine &Path8,
+                                   SmallVectorImpl<wchar_t> &Path16,
+                                   size_t MaxPathLen = MAX_PATH);
 
 } // end namespace windows
 } // end namespace sys

--- a/llvm/include/llvm/Support/WindowsError.h
+++ b/llvm/include/llvm/Support/WindowsError.h
@@ -9,11 +9,12 @@
 #ifndef LLVM_SUPPORT_WINDOWSERROR_H
 #define LLVM_SUPPORT_WINDOWSERROR_H
 
+#include "llvm/Support/Compiler.h"
 #include <system_error>
 
 namespace llvm {
-std::error_code mapLastWindowsError();
-std::error_code mapWindowsError(unsigned EV);
+LLVM_ABI std::error_code mapLastWindowsError();
+LLVM_ABI std::error_code mapWindowsError(unsigned EV);
 }
 
 #endif

--- a/llvm/include/llvm/Support/WithColor.h
+++ b/llvm/include/llvm/Support/WithColor.h
@@ -21,7 +21,7 @@ namespace cl {
 class OptionCategory;
 }
 
-extern cl::OptionCategory &getColorCategory();
+LLVM_ABI extern cl::OptionCategory &getColorCategory();
 
 // Symbolic names for various syntax elements.
 enum class HighlightColor {
@@ -59,7 +59,7 @@ public:
   /// @param OS The output stream
   /// @param S Symbolic name for syntax element to color
   /// @param Mode Enable, disable or compute whether to use colors.
-  LLVM_CTOR_NODISCARD WithColor(raw_ostream &OS, HighlightColor S,
+  LLVM_CTOR_NODISCARD LLVM_ABI WithColor(raw_ostream &OS, HighlightColor S,
                                 ColorMode Mode = ColorMode::Auto);
   /// To be used like this: WithColor(OS, raw_ostream::BLACK) << "text";
   /// @param OS The output stream
@@ -74,7 +74,7 @@ public:
       : OS(OS), Mode(Mode) {
     changeColor(Color, Bold, BG);
   }
-  ~WithColor();
+  LLVM_ABI ~WithColor();
 
   raw_ostream &get() { return OS; }
   operator raw_ostream &() { return OS; }
@@ -88,55 +88,55 @@ public:
   }
 
   /// Convenience method for printing "error: " to stderr.
-  static raw_ostream &error();
+  LLVM_ABI static raw_ostream &error();
   /// Convenience method for printing "warning: " to stderr.
-  static raw_ostream &warning();
+  LLVM_ABI static raw_ostream &warning();
   /// Convenience method for printing "note: " to stderr.
-  static raw_ostream &note();
+  LLVM_ABI static raw_ostream &note();
   /// Convenience method for printing "remark: " to stderr.
-  static raw_ostream &remark();
+  LLVM_ABI static raw_ostream &remark();
 
   /// Convenience method for printing "error: " to the given stream.
-  static raw_ostream &error(raw_ostream &OS, StringRef Prefix = "",
+  LLVM_ABI static raw_ostream &error(raw_ostream &OS, StringRef Prefix = "",
                             bool DisableColors = false);
   /// Convenience method for printing "warning: " to the given stream.
-  static raw_ostream &warning(raw_ostream &OS, StringRef Prefix = "",
+  LLVM_ABI static raw_ostream &warning(raw_ostream &OS, StringRef Prefix = "",
                               bool DisableColors = false);
   /// Convenience method for printing "note: " to the given stream.
-  static raw_ostream &note(raw_ostream &OS, StringRef Prefix = "",
+  LLVM_ABI static raw_ostream &note(raw_ostream &OS, StringRef Prefix = "",
                            bool DisableColors = false);
   /// Convenience method for printing "remark: " to the given stream.
-  static raw_ostream &remark(raw_ostream &OS, StringRef Prefix = "",
+  LLVM_ABI static raw_ostream &remark(raw_ostream &OS, StringRef Prefix = "",
                              bool DisableColors = false);
 
   /// Determine whether colors are displayed.
-  bool colorsEnabled();
+  LLVM_ABI bool colorsEnabled();
 
   /// Change the color of text that will be output from this point forward.
   /// @param Color ANSI color to use, the special SAVEDCOLOR can be used to
   /// change only the bold attribute, and keep colors untouched
   /// @param Bold Bold/brighter text, default false
   /// @param BG If true, change the background, default: change foreground
-  WithColor &changeColor(raw_ostream::Colors Color, bool Bold = false,
+  LLVM_ABI WithColor &changeColor(raw_ostream::Colors Color, bool Bold = false,
                          bool BG = false);
 
   /// Reset the colors to terminal defaults. Call this when you are done
   /// outputting colored text, or before program exit.
-  WithColor &resetColor();
+  LLVM_ABI WithColor &resetColor();
 
   /// Implement default handling for Error.
   /// Print "error: " to stderr.
-  static void defaultErrorHandler(Error Err);
+  LLVM_ABI static void defaultErrorHandler(Error Err);
 
   /// Implement default handling for Warning.
   /// Print "warning: " to stderr.
-  static void defaultWarningHandler(Error Warning);
+  LLVM_ABI static void defaultWarningHandler(Error Warning);
 
   /// Retrieve the default color auto detection function.
-  static AutoDetectFunctionType defaultAutoDetectFunction();
+  LLVM_ABI static AutoDetectFunctionType defaultAutoDetectFunction();
 
   /// Change the global auto detection function.
-  static void
+  LLVM_ABI static void
   setAutoDetectFunction(AutoDetectFunctionType NewAutoDetectFunction);
 
 private:

--- a/llvm/include/llvm/Support/WithColor.h
+++ b/llvm/include/llvm/Support/WithColor.h
@@ -60,7 +60,7 @@ public:
   /// @param S Symbolic name for syntax element to color
   /// @param Mode Enable, disable or compute whether to use colors.
   LLVM_CTOR_NODISCARD LLVM_ABI WithColor(raw_ostream &OS, HighlightColor S,
-                                ColorMode Mode = ColorMode::Auto);
+                                         ColorMode Mode = ColorMode::Auto);
   /// To be used like this: WithColor(OS, raw_ostream::BLACK) << "text";
   /// @param OS The output stream
   /// @param Color ANSI color to use, the special SAVEDCOLOR can be used to
@@ -98,16 +98,16 @@ public:
 
   /// Convenience method for printing "error: " to the given stream.
   LLVM_ABI static raw_ostream &error(raw_ostream &OS, StringRef Prefix = "",
-                            bool DisableColors = false);
+                                     bool DisableColors = false);
   /// Convenience method for printing "warning: " to the given stream.
   LLVM_ABI static raw_ostream &warning(raw_ostream &OS, StringRef Prefix = "",
-                              bool DisableColors = false);
+                                       bool DisableColors = false);
   /// Convenience method for printing "note: " to the given stream.
   LLVM_ABI static raw_ostream &note(raw_ostream &OS, StringRef Prefix = "",
-                           bool DisableColors = false);
+                                    bool DisableColors = false);
   /// Convenience method for printing "remark: " to the given stream.
   LLVM_ABI static raw_ostream &remark(raw_ostream &OS, StringRef Prefix = "",
-                             bool DisableColors = false);
+                                      bool DisableColors = false);
 
   /// Determine whether colors are displayed.
   LLVM_ABI bool colorsEnabled();
@@ -118,7 +118,7 @@ public:
   /// @param Bold Bold/brighter text, default false
   /// @param BG If true, change the background, default: change foreground
   LLVM_ABI WithColor &changeColor(raw_ostream::Colors Color, bool Bold = false,
-                         bool BG = false);
+                                  bool BG = false);
 
   /// Reset the colors to terminal defaults. Call this when you are done
   /// outputting colored text, or before program exit.

--- a/llvm/include/llvm/Support/YAMLParser.h
+++ b/llvm/include/llvm/Support/YAMLParser.h
@@ -36,9 +36,9 @@
 #ifndef LLVM_SUPPORT_YAMLPARSER_H
 #define LLVM_SUPPORT_YAMLPARSER_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/SMLoc.h"
 #include "llvm/Support/SourceMgr.h"
 #include <cassert>
@@ -88,10 +88,10 @@ class Stream {
 public:
   /// This keeps a reference to the string referenced by \p Input.
   LLVM_ABI Stream(StringRef Input, SourceMgr &, bool ShowColors = true,
-         std::error_code *EC = nullptr);
+                  std::error_code *EC = nullptr);
 
-  LLVM_ABI Stream(MemoryBufferRef InputBuffer, SourceMgr &, bool ShowColors = true,
-         std::error_code *EC = nullptr);
+  LLVM_ABI Stream(MemoryBufferRef InputBuffer, SourceMgr &,
+                  bool ShowColors = true, std::error_code *EC = nullptr);
   LLVM_ABI ~Stream();
 
   LLVM_ABI document_iterator begin();
@@ -105,9 +105,9 @@ public:
   }
 
   LLVM_ABI void printError(Node *N, const Twine &Msg,
-                  SourceMgr::DiagKind Kind = SourceMgr::DK_Error);
+                           SourceMgr::DiagKind Kind = SourceMgr::DK_Error);
   LLVM_ABI void printError(const SMRange &Range, const Twine &Msg,
-                  SourceMgr::DiagKind Kind = SourceMgr::DK_Error);
+                           SourceMgr::DiagKind Kind = SourceMgr::DK_Error);
 
 private:
   friend class Document;

--- a/llvm/include/llvm/Support/YAMLParser.h
+++ b/llvm/include/llvm/Support/YAMLParser.h
@@ -36,6 +36,7 @@
 #ifndef LLVM_SUPPORT_YAMLPARSER_H
 #define LLVM_SUPPORT_YAMLPARSER_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/SMLoc.h"
@@ -65,47 +66,47 @@ struct Token;
 
 /// Dump all the tokens in this stream to OS.
 /// \returns true if there was an error, false otherwise.
-bool dumpTokens(StringRef Input, raw_ostream &);
+LLVM_ABI bool dumpTokens(StringRef Input, raw_ostream &);
 
 /// Scans all tokens in input without outputting anything. This is used
 ///        for benchmarking the tokenizer.
 /// \returns true if there was an error, false otherwise.
-bool scanTokens(StringRef Input);
+LLVM_ABI bool scanTokens(StringRef Input);
 
 /// Escape \a Input for a double quoted scalar; if \p EscapePrintable
 /// is true, all UTF8 sequences will be escaped, if \p EscapePrintable is
 /// false, those UTF8 sequences encoding printable unicode scalars will not be
 /// escaped, but emitted verbatim.
-std::string escape(StringRef Input, bool EscapePrintable = true);
+LLVM_ABI std::string escape(StringRef Input, bool EscapePrintable = true);
 
 /// Parse \p S as a bool according to https://yaml.org/type/bool.html.
-std::optional<bool> parseBool(StringRef S);
+LLVM_ABI std::optional<bool> parseBool(StringRef S);
 
 /// This class represents a YAML stream potentially containing multiple
 ///        documents.
 class Stream {
 public:
   /// This keeps a reference to the string referenced by \p Input.
-  Stream(StringRef Input, SourceMgr &, bool ShowColors = true,
+  LLVM_ABI Stream(StringRef Input, SourceMgr &, bool ShowColors = true,
          std::error_code *EC = nullptr);
 
-  Stream(MemoryBufferRef InputBuffer, SourceMgr &, bool ShowColors = true,
+  LLVM_ABI Stream(MemoryBufferRef InputBuffer, SourceMgr &, bool ShowColors = true,
          std::error_code *EC = nullptr);
-  ~Stream();
+  LLVM_ABI ~Stream();
 
-  document_iterator begin();
-  document_iterator end();
-  void skip();
-  bool failed();
+  LLVM_ABI document_iterator begin();
+  LLVM_ABI document_iterator end();
+  LLVM_ABI void skip();
+  LLVM_ABI bool failed();
 
   bool validate() {
     skip();
     return !failed();
   }
 
-  void printError(Node *N, const Twine &Msg,
+  LLVM_ABI void printError(Node *N, const Twine &Msg,
                   SourceMgr::DiagKind Kind = SourceMgr::DK_Error);
-  void printError(const SMRange &Range, const Twine &Msg,
+  LLVM_ABI void printError(const SMRange &Range, const Twine &Msg,
                   SourceMgr::DiagKind Kind = SourceMgr::DK_Error);
 
 private:
@@ -116,7 +117,7 @@ private:
 };
 
 /// Abstract base class for all Nodes.
-class Node {
+class LLVM_ABI Node {
   virtual void anchor();
 
 public:
@@ -194,7 +195,7 @@ private:
 ///
 /// Example:
 ///   !!null null
-class NullNode final : public Node {
+class LLVM_ABI NullNode final : public Node {
   void anchor() override;
 
 public:
@@ -209,7 +210,7 @@ public:
 ///
 /// Example:
 ///   Adena
-class ScalarNode final : public Node {
+class LLVM_ABI ScalarNode final : public Node {
   void anchor() override;
 
 public:
@@ -257,7 +258,7 @@ private:
 ///   |
 ///     Hello
 ///     World
-class BlockScalarNode final : public Node {
+class LLVM_ABI BlockScalarNode final : public Node {
   void anchor() override;
 
 public:
@@ -287,7 +288,7 @@ private:
 ///
 /// Example:
 ///   Section: .text
-class KeyValueNode final : public Node {
+class LLVM_ABI KeyValueNode final : public Node {
   void anchor() override;
 
 public:
@@ -416,7 +417,7 @@ template <class CollectionType> void skip(CollectionType &C) {
 /// Example:
 ///   Name: _main
 ///   Scope: Global
-class MappingNode final : public Node {
+class LLVM_ABI MappingNode final : public Node {
   void anchor() override;
 
 public:
@@ -464,7 +465,7 @@ private:
 /// Example:
 ///   - Hello
 ///   - World
-class SequenceNode final : public Node {
+class LLVM_ABI SequenceNode final : public Node {
   void anchor() override;
 
 public:
@@ -516,7 +517,7 @@ private:
 ///
 /// Example:
 ///   *AnchorName
-class AliasNode final : public Node {
+class LLVM_ABI AliasNode final : public Node {
   void anchor() override;
 
 public:
@@ -535,14 +536,14 @@ private:
 ///        node.
 class Document {
 public:
-  Document(Stream &ParentStream);
+  LLVM_ABI Document(Stream &ParentStream);
 
   /// Root for parsing a node. Returns a single node.
-  Node *parseBlockNode();
+  LLVM_ABI Node *parseBlockNode();
 
   /// Finish parsing the current document and return true if there are
   ///        more. Return false otherwise.
-  bool skip();
+  LLVM_ABI bool skip();
 
   /// Parse and return the root level node.
   Node *getRoot() {

--- a/llvm/include/llvm/Support/YAMLTraits.h
+++ b/llvm/include/llvm/Support/YAMLTraits.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_YAMLTRAITS_H
 #define LLVM_SUPPORT_YAMLTRAITS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/SmallVector.h"
@@ -775,7 +776,7 @@ struct unvalidatedMappingTraits
                     !has_MappingValidateTraits<T, Context>::value> {};
 
 // Base class for Input and Output.
-class IO {
+class LLVM_ABI IO {
 public:
   IO(void *Ctxt = nullptr);
   virtual ~IO();
@@ -1196,92 +1197,92 @@ yamlize(IO &io, T &Seq, bool, Context &Ctx) {
 
 template<>
 struct ScalarTraits<bool> {
-  static void output(const bool &, void* , raw_ostream &);
-  static StringRef input(StringRef, void *, bool &);
+  LLVM_ABI static void output(const bool &, void* , raw_ostream &);
+  LLVM_ABI static StringRef input(StringRef, void *, bool &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
 
 template<>
 struct ScalarTraits<StringRef> {
-  static void output(const StringRef &, void *, raw_ostream &);
-  static StringRef input(StringRef, void *, StringRef &);
+  LLVM_ABI static void output(const StringRef &, void *, raw_ostream &);
+  LLVM_ABI static StringRef input(StringRef, void *, StringRef &);
   static QuotingType mustQuote(StringRef S) { return needsQuotes(S); }
 };
 
 template<>
 struct ScalarTraits<std::string> {
-  static void output(const std::string &, void *, raw_ostream &);
-  static StringRef input(StringRef, void *, std::string &);
+  LLVM_ABI static void output(const std::string &, void *, raw_ostream &);
+  LLVM_ABI static StringRef input(StringRef, void *, std::string &);
   static QuotingType mustQuote(StringRef S) { return needsQuotes(S); }
 };
 
 template<>
 struct ScalarTraits<uint8_t> {
-  static void output(const uint8_t &, void *, raw_ostream &);
-  static StringRef input(StringRef, void *, uint8_t &);
+  LLVM_ABI static void output(const uint8_t &, void *, raw_ostream &);
+  LLVM_ABI static StringRef input(StringRef, void *, uint8_t &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
 
 template<>
 struct ScalarTraits<uint16_t> {
-  static void output(const uint16_t &, void *, raw_ostream &);
-  static StringRef input(StringRef, void *, uint16_t &);
+  LLVM_ABI static void output(const uint16_t &, void *, raw_ostream &);
+  LLVM_ABI static StringRef input(StringRef, void *, uint16_t &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
 
 template<>
 struct ScalarTraits<uint32_t> {
-  static void output(const uint32_t &, void *, raw_ostream &);
-  static StringRef input(StringRef, void *, uint32_t &);
+  LLVM_ABI static void output(const uint32_t &, void *, raw_ostream &);
+  LLVM_ABI static StringRef input(StringRef, void *, uint32_t &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
 
 template<>
 struct ScalarTraits<uint64_t> {
-  static void output(const uint64_t &, void *, raw_ostream &);
-  static StringRef input(StringRef, void *, uint64_t &);
+  LLVM_ABI static void output(const uint64_t &, void *, raw_ostream &);
+  LLVM_ABI static StringRef input(StringRef, void *, uint64_t &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
 
 template<>
 struct ScalarTraits<int8_t> {
-  static void output(const int8_t &, void *, raw_ostream &);
-  static StringRef input(StringRef, void *, int8_t &);
+  LLVM_ABI static void output(const int8_t &, void *, raw_ostream &);
+  LLVM_ABI static StringRef input(StringRef, void *, int8_t &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
 
 template<>
 struct ScalarTraits<int16_t> {
-  static void output(const int16_t &, void *, raw_ostream &);
-  static StringRef input(StringRef, void *, int16_t &);
+  LLVM_ABI static void output(const int16_t &, void *, raw_ostream &);
+  LLVM_ABI static StringRef input(StringRef, void *, int16_t &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
 
 template<>
 struct ScalarTraits<int32_t> {
-  static void output(const int32_t &, void *, raw_ostream &);
-  static StringRef input(StringRef, void *, int32_t &);
+  LLVM_ABI static void output(const int32_t &, void *, raw_ostream &);
+  LLVM_ABI static StringRef input(StringRef, void *, int32_t &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
 
 template<>
 struct ScalarTraits<int64_t> {
-  static void output(const int64_t &, void *, raw_ostream &);
-  static StringRef input(StringRef, void *, int64_t &);
+  LLVM_ABI static void output(const int64_t &, void *, raw_ostream &);
+  LLVM_ABI static StringRef input(StringRef, void *, int64_t &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
 
 template<>
 struct ScalarTraits<float> {
-  static void output(const float &, void *, raw_ostream &);
-  static StringRef input(StringRef, void *, float &);
+  LLVM_ABI static void output(const float &, void *, raw_ostream &);
+  LLVM_ABI static StringRef input(StringRef, void *, float &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
 
 template<>
 struct ScalarTraits<double> {
-  static void output(const double &, void *, raw_ostream &);
-  static StringRef input(StringRef, void *, double &);
+  LLVM_ABI static void output(const double &, void *, raw_ostream &);
+  LLVM_ABI static StringRef input(StringRef, void *, double &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
 
@@ -1424,7 +1425,7 @@ private:
 /// the mapRequired() method calls may not be in the same order
 /// as the keys in the document.
 ///
-class Input : public IO {
+class LLVM_ABI Input : public IO {
 public:
   // Construct a yaml Input object from a StringRef and optional
   // user-data. The DiagHandler can be specified to provide
@@ -1582,7 +1583,7 @@ private:
 /// The Output class is used to generate a yaml document from in-memory structs
 /// and vectors.
 ///
-class Output : public IO {
+class LLVM_ABI Output : public IO {
 public:
   Output(raw_ostream &, void *Ctxt = nullptr, int WrapColumn = 70);
   ~Output() override;
@@ -1742,35 +1743,35 @@ LLVM_YAML_STRONG_TYPEDEF(uint64_t, Hex64)
 
 template<>
 struct ScalarTraits<Hex8> {
-  static void output(const Hex8 &, void *, raw_ostream &);
-  static StringRef input(StringRef, void *, Hex8 &);
+  LLVM_ABI static void output(const Hex8 &, void *, raw_ostream &);
+  LLVM_ABI static StringRef input(StringRef, void *, Hex8 &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
 
 template<>
 struct ScalarTraits<Hex16> {
-  static void output(const Hex16 &, void *, raw_ostream &);
-  static StringRef input(StringRef, void *, Hex16 &);
+  LLVM_ABI static void output(const Hex16 &, void *, raw_ostream &);
+  LLVM_ABI static StringRef input(StringRef, void *, Hex16 &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
 
 template<>
 struct ScalarTraits<Hex32> {
-  static void output(const Hex32 &, void *, raw_ostream &);
-  static StringRef input(StringRef, void *, Hex32 &);
+  LLVM_ABI static void output(const Hex32 &, void *, raw_ostream &);
+  LLVM_ABI static StringRef input(StringRef, void *, Hex32 &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
 
 template<>
 struct ScalarTraits<Hex64> {
-  static void output(const Hex64 &, void *, raw_ostream &);
-  static StringRef input(StringRef, void *, Hex64 &);
+  LLVM_ABI static void output(const Hex64 &, void *, raw_ostream &);
+  LLVM_ABI static StringRef input(StringRef, void *, Hex64 &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
 
 template <> struct ScalarTraits<VersionTuple> {
-  static void output(const VersionTuple &Value, void *, llvm::raw_ostream &Out);
-  static StringRef input(StringRef, void *, VersionTuple &);
+  LLVM_ABI static void output(const VersionTuple &Value, void *, llvm::raw_ostream &Out);
+  LLVM_ABI static StringRef input(StringRef, void *, VersionTuple &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
 

--- a/llvm/include/llvm/Support/YAMLTraits.h
+++ b/llvm/include/llvm/Support/YAMLTraits.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_SUPPORT_YAMLTRAITS_H
 #define LLVM_SUPPORT_YAMLTRAITS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/SmallVector.h"
@@ -19,6 +18,7 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/AlignOf.h"
 #include "llvm/Support/Allocator.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/SMLoc.h"
 #include "llvm/Support/SourceMgr.h"
@@ -1197,7 +1197,7 @@ yamlize(IO &io, T &Seq, bool, Context &Ctx) {
 
 template<>
 struct ScalarTraits<bool> {
-  LLVM_ABI static void output(const bool &, void* , raw_ostream &);
+  LLVM_ABI static void output(const bool &, void *, raw_ostream &);
   LLVM_ABI static StringRef input(StringRef, void *, bool &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };
@@ -1770,7 +1770,8 @@ struct ScalarTraits<Hex64> {
 };
 
 template <> struct ScalarTraits<VersionTuple> {
-  LLVM_ABI static void output(const VersionTuple &Value, void *, llvm::raw_ostream &Out);
+  LLVM_ABI static void output(const VersionTuple &Value, void *,
+                              llvm::raw_ostream &Out);
   LLVM_ABI static StringRef input(StringRef, void *, VersionTuple &);
   static QuotingType mustQuote(StringRef) { return QuotingType::None; }
 };

--- a/llvm/include/llvm/Support/raw_os_ostream.h
+++ b/llvm/include/llvm/Support/raw_os_ostream.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_RAW_OS_OSTREAM_H
 #define LLVM_SUPPORT_RAW_OS_OSTREAM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 #include <iosfwd>
 
@@ -21,7 +22,7 @@ namespace llvm {
 /// raw_os_ostream - A raw_ostream that writes to an std::ostream.  This is a
 /// simple adaptor class.  It does not check for output errors; clients should
 /// use the underlying stream to detect errors.
-class raw_os_ostream : public raw_ostream {
+class LLVM_ABI raw_os_ostream : public raw_ostream {
   std::ostream &OS;
 
   /// write_impl - See raw_ostream::write_impl.

--- a/llvm/include/llvm/Support/raw_ostream.h
+++ b/llvm/include/llvm/Support/raw_ostream.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_SUPPORT_RAW_OSTREAM_H
 #define LLVM_SUPPORT_RAW_OSTREAM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/DataTypes.h"
@@ -49,7 +50,7 @@ class FileLocker;
 /// output to a stream.  It does not support seeking, reopening, rewinding, line
 /// buffered disciplines etc. It is a simple buffer that outputs
 /// a chunk at a time.
-class raw_ostream {
+class LLVM_ABI raw_ostream {
 public:
   // Class kinds to support LLVM-style RTTI.
   enum class OStreamKind {
@@ -431,7 +432,7 @@ operator<<(OStream &&OS, const T &Value) {
 /// An abstract base class for streams implementations that also support a
 /// pwrite operation. This is useful for code that can mostly stream out data,
 /// but needs to patch in a header that needs to know the output size.
-class raw_pwrite_stream : public raw_ostream {
+class LLVM_ABI raw_pwrite_stream : public raw_ostream {
   virtual void pwrite_impl(const char *Ptr, size_t Size, uint64_t Offset) = 0;
   void anchor() override;
 
@@ -457,7 +458,7 @@ public:
 
 /// A raw_ostream that writes to a file descriptor.
 ///
-class raw_fd_ostream : public raw_pwrite_stream {
+class LLVM_ABI raw_fd_ostream : public raw_pwrite_stream {
   int FD;
   bool ShouldClose;
   bool SupportsSeeking = false;
@@ -607,17 +608,17 @@ public:
 
 /// This returns a reference to a raw_fd_ostream for standard output. Use it
 /// like: outs() << "foo" << "bar";
-raw_fd_ostream &outs();
+LLVM_ABI raw_fd_ostream &outs();
 
 /// This returns a reference to a raw_ostream for standard error.
 /// Use it like: errs() << "foo" << "bar";
 /// By default, the stream is tied to stdout to ensure stdout is flushed before
 /// stderr is written, to ensure the error messages are written in their
 /// expected place.
-raw_fd_ostream &errs();
+LLVM_ABI raw_fd_ostream &errs();
 
 /// This returns a reference to a raw_ostream which simply discards output.
-raw_ostream &nulls();
+LLVM_ABI raw_ostream &nulls();
 
 //===----------------------------------------------------------------------===//
 // File Streams
@@ -630,9 +631,9 @@ public:
   /// Open the specified file for reading/writing/seeking. If an error occurs,
   /// information about the error is put into EC, and the stream should be
   /// immediately destroyed.
-  raw_fd_stream(StringRef Filename, std::error_code &EC);
+  LLVM_ABI raw_fd_stream(StringRef Filename, std::error_code &EC);
 
-  raw_fd_stream(int fd, bool shouldClose);
+  LLVM_ABI raw_fd_stream(int fd, bool shouldClose);
 
   /// This reads the \p Size bytes into a buffer pointed by \p Ptr.
   ///
@@ -643,10 +644,10 @@ public:
   /// On success, the number of bytes read is returned, and the file position is
   /// advanced by this number. On error, -1 is returned, use error() to get the
   /// error code.
-  ssize_t read(char *Ptr, size_t Size);
+  LLVM_ABI ssize_t read(char *Ptr, size_t Size);
 
   /// Check if \p OS is a pointer of type raw_fd_stream*.
-  static bool classof(const raw_ostream *OS);
+  LLVM_ABI static bool classof(const raw_ostream *OS);
 };
 
 //===----------------------------------------------------------------------===//
@@ -658,7 +659,7 @@ public:
 /// raw_string_ostream operates without a buffer, delegating all memory
 /// management to the std::string. Thus the std::string is always up-to-date,
 /// may be used directly and there is no need to call flush().
-class raw_string_ostream : public raw_ostream {
+class LLVM_ABI raw_string_ostream : public raw_ostream {
   std::string &OS;
 
   /// See raw_ostream::write_impl.
@@ -688,7 +689,7 @@ public:
 /// raw_svector_ostream operates without a buffer, delegating all memory
 /// management to the SmallString. Thus the SmallString is always up-to-date,
 /// may be used directly and there is no need to call flush().
-class raw_svector_ostream : public raw_pwrite_stream {
+class LLVM_ABI raw_svector_ostream : public raw_pwrite_stream {
   SmallVectorImpl<char> &OS;
 
   /// See raw_ostream::write_impl.
@@ -728,7 +729,7 @@ public:
 };
 
 /// A raw_ostream that discards all output.
-class raw_null_ostream : public raw_pwrite_stream {
+class LLVM_ABI raw_null_ostream : public raw_pwrite_stream {
   /// See raw_ostream::write_impl.
   void write_impl(const char *Ptr, size_t size) override;
   void pwrite_impl(const char *Ptr, size_t Size, uint64_t Offset) override;
@@ -742,7 +743,7 @@ public:
   ~raw_null_ostream() override;
 };
 
-class buffer_ostream : public raw_svector_ostream {
+class LLVM_ABI buffer_ostream : public raw_svector_ostream {
   raw_ostream &OS;
   SmallVector<char, 0> Buffer;
 
@@ -753,7 +754,7 @@ public:
   ~buffer_ostream() override { OS << str(); }
 };
 
-class buffer_unique_ostream : public raw_svector_ostream {
+class LLVM_ABI buffer_unique_ostream : public raw_svector_ostream {
   std::unique_ptr<raw_ostream> OS;
   SmallVector<char, 0> Buffer;
 
@@ -835,10 +836,10 @@ class Error;
 /// for other names. For raw_fd_ostream instances, the stream writes to
 /// a temporary file. The final output file is atomically replaced with the
 /// temporary file after the \p Write function is finished.
-Error writeToOutput(StringRef OutputFileName,
+LLVM_ABI Error writeToOutput(StringRef OutputFileName,
                     std::function<Error(raw_ostream &)> Write);
 
-raw_ostream &operator<<(raw_ostream &OS, std::nullopt_t);
+LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, std::nullopt_t);
 
 template <typename T, typename = decltype(std::declval<raw_ostream &>()
                                           << std::declval<const T &>())>

--- a/llvm/include/llvm/Support/raw_ostream.h
+++ b/llvm/include/llvm/Support/raw_ostream.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_SUPPORT_RAW_OSTREAM_H
 #define LLVM_SUPPORT_RAW_OSTREAM_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 #include <cassert>
 #include <cstddef>
@@ -837,7 +837,7 @@ class Error;
 /// a temporary file. The final output file is atomically replaced with the
 /// temporary file after the \p Write function is finished.
 LLVM_ABI Error writeToOutput(StringRef OutputFileName,
-                    std::function<Error(raw_ostream &)> Write);
+                             std::function<Error(raw_ostream &)> Write);
 
 LLVM_ABI raw_ostream &operator<<(raw_ostream &OS, std::nullopt_t);
 

--- a/llvm/include/llvm/Support/raw_socket_stream.h
+++ b/llvm/include/llvm/Support/raw_socket_stream.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_RAW_SOCKET_STREAM_H
 #define LLVM_SUPPORT_RAW_SOCKET_STREAM_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -74,8 +75,8 @@ class ListeningSocket {
 #endif // _WIN32
 
 public:
-  ~ListeningSocket();
-  ListeningSocket(ListeningSocket &&LS);
+  LLVM_ABI ~ListeningSocket();
+  LLVM_ABI ListeningSocket(ListeningSocket &&LS);
   ListeningSocket(const ListeningSocket &LS) = delete;
   ListeningSocket &operator=(const ListeningSocket &) = delete;
 
@@ -87,7 +88,7 @@ public:
   /// a blocking call to ::poll to return.
   ///
   /// Once shutdown is called there is no way to reinitialize ListeningSocket.
-  void shutdown();
+  LLVM_ABI void shutdown();
 
   /// Accepts an incoming connection on the listening socket. This method can
   /// optionally either block until a connection is available or timeout after a
@@ -98,7 +99,7 @@ public:
   /// \param Timeout An optional timeout duration in milliseconds. Setting
   /// Timeout to a negative number causes ::accept to block indefinitely
   ///
-  Expected<std::unique_ptr<raw_socket_stream>> accept(
+  LLVM_ABI Expected<std::unique_ptr<raw_socket_stream>> accept(
       const std::chrono::milliseconds &Timeout = std::chrono::milliseconds(-1));
 
   /// Creates a listening socket bound to the specified file system path.
@@ -108,7 +109,7 @@ public:
   /// \param SocketPath The file system path where the socket will be created
   /// \param MaxBacklog The max number of connections in a socket's backlog
   ///
-  static Expected<ListeningSocket> createUnix(
+  LLVM_ABI static Expected<ListeningSocket> createUnix(
       StringRef SocketPath,
       int MaxBacklog = llvm::hardware_concurrency().compute_thread_count());
 };
@@ -117,7 +118,7 @@ public:
 //  raw_socket_stream
 //===----------------------------------------------------------------------===//
 
-class raw_socket_stream : public raw_fd_stream {
+class LLVM_ABI raw_socket_stream : public raw_fd_stream {
   uint64_t current_pos() const override { return 0; }
 #ifdef _WIN32
   WSABalancer _;

--- a/llvm/include/llvm/Support/raw_socket_stream.h
+++ b/llvm/include/llvm/Support/raw_socket_stream.h
@@ -31,8 +31,8 @@ class raw_socket_stream;
 /// Make sure that calls to WSAStartup and WSACleanup are balanced.
 class WSABalancer {
 public:
-  WSABalancer();
-  ~WSABalancer();
+  LLVM_ABI WSABalancer();
+  LLVM_ABI ~WSABalancer();
 };
 #endif // _WIN32
 

--- a/llvm/include/llvm/Support/thread.h
+++ b/llvm/include/llvm/Support/thread.h
@@ -16,8 +16,8 @@
 #ifndef LLVM_SUPPORT_THREAD_H
 #define LLVM_SUPPORT_THREAD_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/Config/llvm-config.h"
+#include "llvm/Support/Compiler.h"
 #include <optional>
 #include <tuple>
 #include <utility>

--- a/llvm/include/llvm/Support/thread.h
+++ b/llvm/include/llvm/Support/thread.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_SUPPORT_THREAD_H
 #define LLVM_SUPPORT_THREAD_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Config/llvm-config.h"
 #include <optional>
 #include <tuple>
@@ -69,7 +70,7 @@ public:
   }
 #endif
 
-  static const std::optional<unsigned> DefaultStackSize;
+  LLVM_ABI static const std::optional<unsigned> DefaultStackSize;
 
   thread() : Thread(native_handle_type()) {}
   thread(thread &&Other) noexcept
@@ -115,13 +116,13 @@ private:
   native_handle_type Thread;
 };
 
-thread::native_handle_type
+LLVM_ABI thread::native_handle_type
 llvm_execute_on_thread_impl(thread::start_routine_type ThreadFunc, void *Arg,
                             std::optional<unsigned> StackSizeInBytes);
-void llvm_thread_join_impl(thread::native_handle_type Thread);
-void llvm_thread_detach_impl(thread::native_handle_type Thread);
-thread::id llvm_thread_get_id_impl(thread::native_handle_type Thread);
-thread::id llvm_thread_get_current_id_impl();
+LLVM_ABI void llvm_thread_join_impl(thread::native_handle_type Thread);
+LLVM_ABI void llvm_thread_detach_impl(thread::native_handle_type Thread);
+LLVM_ABI thread::id llvm_thread_get_id_impl(thread::native_handle_type Thread);
+LLVM_ABI thread::id llvm_thread_get_current_id_impl();
 
 template <class Function, class... Args>
 thread::thread(std::optional<unsigned> StackSizeInBytes, Function &&f,

--- a/llvm/include/llvm/Support/xxhash.h
+++ b/llvm/include/llvm/Support/xxhash.h
@@ -38,9 +38,9 @@
 #ifndef LLVM_SUPPORT_XXHASH_H
 #define LLVM_SUPPORT_XXHASH_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/Support/xxhash.h
+++ b/llvm/include/llvm/Support/xxhash.h
@@ -38,15 +38,16 @@
 #ifndef LLVM_SUPPORT_XXHASH_H
 #define LLVM_SUPPORT_XXHASH_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace llvm {
 
-uint64_t xxHash64(llvm::StringRef Data);
-uint64_t xxHash64(llvm::ArrayRef<uint8_t> Data);
+LLVM_ABI uint64_t xxHash64(llvm::StringRef Data);
+LLVM_ABI uint64_t xxHash64(llvm::ArrayRef<uint8_t> Data);
 
-uint64_t xxh3_64bits(ArrayRef<uint8_t> data);
+LLVM_ABI uint64_t xxh3_64bits(ArrayRef<uint8_t> data);
 inline uint64_t xxh3_64bits(StringRef data) {
   return xxh3_64bits(ArrayRef(data.bytes_begin(), data.size()));
 }
@@ -72,7 +73,7 @@ struct XXH128_hash_t {
 };
 
 /// XXH3's 128-bit variant.
-XXH128_hash_t xxh3_128bits(ArrayRef<uint8_t> data);
+LLVM_ABI XXH128_hash_t xxh3_128bits(ArrayRef<uint8_t> data);
 
 } // namespace llvm
 

--- a/llvm/lib/Support/Chrono.cpp
+++ b/llvm/lib/Support/Chrono.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/Support/Chrono.h"
 #include "llvm/Config/llvm-config.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -15,12 +16,12 @@ namespace llvm {
 
 using namespace sys;
 
-const char llvm::detail::unit<std::ratio<3600>>::value[] = "h";
-const char llvm::detail::unit<std::ratio<60>>::value[] = "m";
-const char llvm::detail::unit<std::ratio<1>>::value[] = "s";
-const char llvm::detail::unit<std::milli>::value[] = "ms";
-const char llvm::detail::unit<std::micro>::value[] = "us";
-const char llvm::detail::unit<std::nano>::value[] = "ns";
+LLVM_ABI const char llvm::detail::unit<std::ratio<3600>>::value[] = "h";
+LLVM_ABI const char llvm::detail::unit<std::ratio<60>>::value[] = "m";
+LLVM_ABI const char llvm::detail::unit<std::ratio<1>>::value[] = "s";
+LLVM_ABI const char llvm::detail::unit<std::milli>::value[] = "ms";
+LLVM_ABI const char llvm::detail::unit<std::micro>::value[] = "us";
+LLVM_ABI const char llvm::detail::unit<std::nano>::value[] = "ns";
 
 static inline struct tm getStructTM(TimePoint<> TP) {
   struct tm Storage;

--- a/llvm/lib/Support/CommandLine.cpp
+++ b/llvm/lib/Support/CommandLine.cpp
@@ -29,6 +29,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Config/config.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Error.h"
@@ -54,18 +55,18 @@ using namespace cl;
 //
 namespace llvm {
 namespace cl {
-template class basic_parser<bool>;
-template class basic_parser<boolOrDefault>;
-template class basic_parser<int>;
-template class basic_parser<long>;
-template class basic_parser<long long>;
-template class basic_parser<unsigned>;
-template class basic_parser<unsigned long>;
-template class basic_parser<unsigned long long>;
-template class basic_parser<double>;
-template class basic_parser<float>;
-template class basic_parser<std::string>;
-template class basic_parser<char>;
+template class LLVM_EXPORT_TEMPLATE basic_parser<bool>;
+template class LLVM_EXPORT_TEMPLATE basic_parser<boolOrDefault>;
+template class LLVM_EXPORT_TEMPLATE basic_parser<int>;
+template class LLVM_EXPORT_TEMPLATE basic_parser<long>;
+template class LLVM_EXPORT_TEMPLATE basic_parser<long long>;
+template class LLVM_EXPORT_TEMPLATE basic_parser<unsigned>;
+template class LLVM_EXPORT_TEMPLATE basic_parser<unsigned long>;
+template class LLVM_EXPORT_TEMPLATE basic_parser<unsigned long long>;
+template class LLVM_EXPORT_TEMPLATE basic_parser<double>;
+template class LLVM_EXPORT_TEMPLATE basic_parser<float>;
+template class LLVM_EXPORT_TEMPLATE basic_parser<std::string>;
+template class LLVM_EXPORT_TEMPLATE basic_parser<char>;
 
 template class opt<unsigned>;
 template class opt<int>;


### PR DESCRIPTION
## Purpose

This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the `llvm/Support` library. These annotations currently have no meaningful impact on the LLVM build; however, they are a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background

This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

The bulk of these changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

The following manual adjustments were also applied after running IDS on Linux:
- Add `#include "llvm/Support/Compiler.h"` to files where it was not auto-added by IDS due to no pre-existing block of include statements.
- Add `LLVM_ABI` to Windows-only code (auto generated with IDS on Windows)
- Explicitly make classes non-copyable where needed to due IDS adding `LLVM_ABI` at the class level
- Add `LLVM_TEMPLATE_ABI` and `LLVM_EXPORT_TEMPLATE` to exported instantiated templates
- Add `LLVM_ABI_FRIEND` to a small number of `friend` function declarations
- Add `LLVM_ABI` to a subset of private class methods and fields that require export
- Add `LLVM_ABI` to a small number of symbols that require export but are not declared in headers
- Add `LLVM_ABI` functions defined via X-macro

## Validation

Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang