### PR TITLE
[Clang] Bypass TAD during overload resolution if a perfect match exists

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -96,11 +96,11 @@ C++ Language Changes
       asm((std::string_view("nop")) ::: (std::string_view("memory")));
     }
 
-- Clang now implements the changes to overload resolution proposed by `P3606 <https://wg21.link/P3606R0>`_.
-  If a non-template candidate exists in an overload set that is a perfect match (all conversion sequences
-  are identity conversions) template candiates are not instantiated.
+- Clang now implements the changes to overload resolution proposed by section 1 and 2 of
+  `P3606 <https://wg21.link/P3606R0>`_. If a non-template candidate exists in an overload set that is
+  a perfect match (all conversion sequences are identity conversions) template candiates are not instantiated.
   Diagnostics that would have resulted from the instantiation of these template candidates are no longer
-  produced. This aligns Clang closer to the behavior of GCC and fixes (#GH62096), (#GH74581), and (#GH74581).
+  produced. This aligns Clang closer to the behavior of GCC, and fixes (#GH62096), (#GH74581), and (#GH74581).
 
 C++2c Feature Support
 ^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -98,7 +98,7 @@ C++ Language Changes
 
 - Clang now implements the changes to overload resolution proposed by section 1 and 2 of
   `P3606 <https://wg21.link/P3606R0>`_. If a non-template candidate exists in an overload set that is
-  a perfect match (all conversion sequences are identity conversions) template candiates are not instantiated.
+  a perfect match (all conversion sequences are identity conversions) template candidates are not instantiated.
   Diagnostics that would have resulted from the instantiation of these template candidates are no longer
   produced. This aligns Clang closer to the behavior of GCC, and fixes (#GH62096), (#GH74581), and (#GH74581).
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -96,6 +96,12 @@ C++ Language Changes
       asm((std::string_view("nop")) ::: (std::string_view("memory")));
     }
 
+- Clang now implements the changes to overload resolution proposed by `P3606 <https://wg21.link/P3606R0>`_.
+  If a non-template candidate exists in an overload set that is a perfect match (all conversion sequences
+  are identity conversions) template candiates are not instantiated.
+  Diagnostics that would have resulted from the instantiation of these template candidates are no longer
+  produced. This aligns Clang closer to the behavior of GCC and fixes (#GH62096), (#GH74581), and (#GH74581).
+
 C++2c Feature Support
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -1206,9 +1206,11 @@ class Sema;
     llvm::SmallPtrSet<uintptr_t, 16> Functions;
 
     DeferredTemplateOverloadCandidate *FirstDeferredCandidate;
-    unsigned DeferredCandidatesCount : 8 * sizeof(unsigned) - 1;
+    unsigned DeferredCandidatesCount : 8 * sizeof(unsigned) - 2;
     LLVM_PREFERRED_TYPE(bool)
     unsigned HasDeferredTemplateConstructors : 1;
+    LLVM_PREFERRED_TYPE(bool)
+    unsigned ResolutionByPerfectCandidateIsDisabled : 1;
 
     // Allocator for ConversionSequenceLists and deferred candidate args.
     // We store the first few of these
@@ -1274,7 +1276,8 @@ class Sema;
     OverloadCandidateSet(SourceLocation Loc, CandidateSetKind CSK,
                          OperatorRewriteInfo RewriteInfo = {})
         : FirstDeferredCandidate(nullptr), DeferredCandidatesCount(0),
-          HasDeferredTemplateConstructors(false), Loc(Loc), Kind(CSK),
+          HasDeferredTemplateConstructors(false),
+          ResolutionByPerfectCandidateIsDisabled(false), Loc(Loc), Kind(CSK),
           RewriteInfo(RewriteInfo) {}
     OverloadCandidateSet(const OverloadCandidateSet &) = delete;
     OverloadCandidateSet &operator=(const OverloadCandidateSet &) = delete;
@@ -1386,6 +1389,10 @@ class Sema;
         bool AllowResultConversion);
 
     void InjectNonDeducedTemplateCandidates(Sema &S);
+
+    void DisableResolutionByPerfectCandidate() {
+      ResolutionByPerfectCandidateIsDisabled = true;
+    }
 
     /// Find the best viable function on this overload set, if it exists.
     OverloadingResult BestViableFunction(Sema &S, SourceLocation Loc,

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -745,8 +745,9 @@ class Sema;
     }
 
     bool isPerfect(const ASTContext &C) const {
-      return (isStandard() && Standard.isIdentityConversion() &&
-              C.hasSameType(Standard.getFromType(), Standard.getToType(2))) ||
+      return (isStandard() && Standard.isIdentityConversion()
+              && !Standard.DirectBinding
+              ) ||
              getKind() == StaticObjectArgumentConversion;
     }
 
@@ -989,7 +990,7 @@ class Sema;
     bool isPerfectMatch(const ASTContext &Ctx) const {
       if (!Viable)
         return false;
-      for (auto &C : Conversions) {
+      for (const auto &C : Conversions) {
         if (!C.isInitialized())
           return false;
         if (!C.isPerfect(Ctx))

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -408,8 +408,15 @@ class Sema;
     }
 
     bool isPerfect(const ASTContext &C) const {
-      return isIdentityConversion() &&
-             (!ReferenceBinding || C.hasSameType(getFromType(), getToType(2)));
+      if(!isIdentityConversion())
+        return false;
+      if(!ReferenceBinding)
+        return true;
+      if(!C.hasSameType(getFromType(), getToType(2)))
+        return false;
+      if(BindsToRvalue && IsLvalueReference)
+        return false;
+      return true;
     }
 
     ImplicitConversionRank getRank() const;

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -1448,7 +1448,9 @@ class Sema;
         // For user defined conversion we need to check against different
         // combination of CV qualifiers and look at any expicit specifier, so
         // always deduce template candidate.
-        Kind != CSK_InitByUserDefinedConversion && Kind != CSK_CodeCompletion &&
+        Kind != CSK_InitByUserDefinedConversion
+        && Kind != CSK_InitByConstructor
+        && Kind != CSK_CodeCompletion &&
         Opts.CPlusPlus && (!Opts.CUDA || Opts.GPUExcludeWrongSideOverloads);
   }
 

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -407,6 +407,8 @@ class Sema;
              Third == ICK_Identity;
     }
 
+    /// A conversion sequence is perfect if it is an identity conversion and
+    /// the type of the source is the same as the type of the target.
     bool isPerfect(const ASTContext &C) const {
       if (!isIdentityConversion())
         return false;
@@ -759,8 +761,7 @@ class Sema;
       Standard.setAllToTypes(T);
     }
 
-    /// A conversion sequence is perfect if
-    /// it is an identity conversion and
+    /// A conversion sequence is perfect if it is an identity conversion and
     /// the type of the source is the same as the type of the target.
     bool isPerfect(const ASTContext &C) const {
       return isStandard() && Standard.isPerfect(C);
@@ -1008,9 +1009,7 @@ class Sema;
       if (!Viable)
         return false;
       for (const auto &C : Conversions) {
-        if (!C.isInitialized())
-          return false;
-        if (!C.isPerfect(Ctx))
+        if (!C.isInitialized() || !C.isPerfect(Ctx))
           return false;
       }
       if (isa_and_nonnull<CXXConversionDecl>(Function))
@@ -1142,6 +1141,9 @@ class Sema;
       /// Resolve a call through the address of an overload set.
       CSK_AddressOfOverloadSet,
 
+      /// When doing overload resolution during code completion,
+      /// we want to show all viable candidates, including otherwise
+      /// deferred template candidates.
       CSK_CodeCompletion,
     };
 
@@ -1217,7 +1219,7 @@ class Sema;
     SmallVector<OverloadCandidate, 16> Candidates;
     llvm::SmallPtrSet<uintptr_t, 16> Functions;
 
-    DeferredTemplateOverloadCandidate *FirstDeferredCandidate;
+    DeferredTemplateOverloadCandidate *FirstDeferredCandidate = nullptr;
     unsigned DeferredCandidatesCount : 8 * sizeof(unsigned) - 2;
     LLVM_PREFERRED_TYPE(bool)
     unsigned HasDeferredTemplateConstructors : 1;

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -1453,8 +1453,7 @@ class Sema;
         Kind != CSK_InitByConstructor
         // When doing code completion, we want to see all the
         // viable candidates.
-        && Kind != CSK_CodeCompletion &&
-        Opts.CPlusPlus
+        && Kind != CSK_CodeCompletion
         // When -fgpu-exclude-wrong-side-overloads, CUDA needs
         // to exclude templates from the overload sets after they
         // have been instantiated. See CudaExcludeWrongSideCandidates.

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -963,6 +963,10 @@ class Sema;
     LLVM_PREFERRED_TYPE(CallExpr::ADLCallKind)
     unsigned IsADLCandidate : 1;
 
+    /// Whether FinalConversion has been set.
+    LLVM_PREFERRED_TYPE(bool)
+    unsigned HasFinalConversion : 1;
+
     /// Whether this is a rewritten candidate, and if so, of what kind?
     LLVM_PREFERRED_TYPE(OverloadCandidateRewriteKind)
     unsigned RewriteKind : 2;
@@ -1005,14 +1009,14 @@ class Sema;
 
     // An overload is a perfect match if the conversion
     // sequences for each argument are perfect.
-    bool isPerfectMatch(const ASTContext &Ctx, bool ForConversion) const {
+    bool isPerfectMatch(const ASTContext &Ctx) const {
       if (!Viable)
         return false;
       for (const auto &C : Conversions) {
         if (!C.isInitialized() || !C.isPerfect(Ctx))
           return false;
       }
-      if (ForConversion && isa_and_nonnull<CXXConversionDecl>(Function))
+      if (HasFinalConversion)
         return FinalConversion.isPerfect(Ctx);
       return true;
     }
@@ -1050,7 +1054,7 @@ class Sema;
         : IsSurrogate(false), IgnoreObjectArgument(false),
           TookAddressOfOverload(false), StrictPackMatch(false),
           IsADLCandidate(llvm::to_underlying(CallExpr::NotADL)),
-          RewriteKind(CRK_None) {}
+          HasFinalConversion(false), RewriteKind(CRK_None) {}
   };
 
   struct DeferredTemplateOverloadCandidate {

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -1448,9 +1448,8 @@ class Sema;
         // For user defined conversion we need to check against different
         // combination of CV qualifiers and look at any expicit specifier, so
         // always deduce template candidate.
-        Kind != CSK_InitByUserDefinedConversion
-        && Kind != CSK_InitByConstructor
-        && Kind != CSK_CodeCompletion &&
+        Kind != CSK_InitByUserDefinedConversion &&
+        Kind != CSK_InitByConstructor && Kind != CSK_CodeCompletion &&
         Opts.CPlusPlus && (!Opts.CUDA || Opts.GPUExcludeWrongSideOverloads);
   }
 

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -745,10 +745,9 @@ class Sema;
     }
 
     bool isPerfect(const ASTContext &C) const {
-      return (isStandard() && Standard.isIdentityConversion()
-              && !Standard.DirectBinding
-              ) ||
-             getKind() == StaticObjectArgumentConversion;
+      return isStandard() && Standard.isIdentityConversion() &&
+              (!Standard.ReferenceBinding  || C.hasSameType(Standard.getFromType(), Standard.getToType(2)))
+              ;
     }
 
     // True iff this is a conversion sequence from an initializer list to an

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -415,7 +415,7 @@ class Sema;
       // If we are not performing a reference binding, we can skip comparing
       // the types, which has a noticeable performance impact.
       if (!ReferenceBinding) {
-        assert(C.hasSameType(getFromType(), getToType(2)));
+        assert(First || C.hasSameUnqualifiedType(getFromType(), getToType(2)));
         return true;
       }
       if (!C.hasSameType(getFromType(), getToType(2)))

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -1005,14 +1005,14 @@ class Sema;
 
     // An overload is a perfect match if the conversion
     // sequences for each argument are perfect.
-    bool isPerfectMatch(const ASTContext &Ctx) const {
+    bool isPerfectMatch(const ASTContext &Ctx, bool ForConversion) const {
       if (!Viable)
         return false;
       for (const auto &C : Conversions) {
         if (!C.isInitialized() || !C.isPerfect(Ctx))
           return false;
       }
-      if (isa_and_nonnull<CXXConversionDecl>(Function))
+      if (ForConversion && isa_and_nonnull<CXXConversionDecl>(Function))
         return FinalConversion.isPerfect(Ctx);
       return true;
     }

--- a/clang/include/clang/Sema/Overload.h
+++ b/clang/include/clang/Sema/Overload.h
@@ -415,6 +415,8 @@ class Sema;
       // If we are not performing a reference binding, we can skip comparing
       // the types, which has a noticeable performance impact.
       if (!ReferenceBinding) {
+        // The types might differ if there is an array-to-pointer conversion
+        // or lvalue-to-rvalue conversion.
         assert(First || C.hasSameUnqualifiedType(getFromType(), getToType(2)));
         return true;
       }

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10390,25 +10390,9 @@ public:
       OverloadCandidateSet &CandidateSet, bool SuppressUserConversions = false,
       bool PartialOverloading = false, OverloadCandidateParamOrder PO = {});
 
-  void AddMethodTemplateCandidateImmediately(
-      OverloadCandidateSet &CandidateSet, FunctionTemplateDecl *MethodTmpl,
-      DeclAccessPair FoundDecl, CXXRecordDecl *ActingContext,
-      TemplateArgumentListInfo *ExplicitTemplateArgs, QualType ObjectType,
-      Expr::Classification ObjectClassification, ArrayRef<Expr *> Args,
-      bool SuppressUserConversions, bool PartialOverloading,
-      OverloadCandidateParamOrder PO);
-
   /// Add a C++ function template specialization as a candidate
   /// in the candidate set, using template argument deduction to produce
   /// an appropriate function template specialization.
-
-  void AddTemplateOverloadCandidateImmediately(
-      OverloadCandidateSet &CandidateSet,
-      FunctionTemplateDecl *FunctionTemplate, DeclAccessPair FoundDecl,
-      TemplateArgumentListInfo *ExplicitTemplateArgs, ArrayRef<Expr *> Args,
-      bool SuppressUserConversions, bool PartialOverloading, bool AllowExplicit,
-      ADLCallKind IsADLCandidate, OverloadCandidateParamOrder PO,
-      bool AggregateCandidateDeduction);
 
   void AddTemplateOverloadCandidate(
       FunctionTemplateDecl *FunctionTemplate, DeclAccessPair FoundDecl,
@@ -10453,13 +10437,6 @@ public:
       CXXRecordDecl *ActingContext, Expr *From, QualType ToType,
       OverloadCandidateSet &CandidateSet, bool AllowObjCConversionOnExplicit,
       bool AllowExplicit, bool AllowResultConversion = true);
-
-  void AddTemplateConversionCandidateImmediately(
-      OverloadCandidateSet &CandidateSet,
-      FunctionTemplateDecl *FunctionTemplate, DeclAccessPair FoundDecl,
-      CXXRecordDecl *ActingContext, Expr *From, QualType ToType,
-      bool AllowObjCConversionOnExplicit, bool AllowExplicit,
-      bool AllowResultConversion);
 
   /// AddSurrogateCandidate - Adds a "surrogate" candidate function that
   /// converts the given @c Object to a function pointer via the

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -60,6 +60,7 @@
 #include "clang/Sema/DeclSpec.h"
 #include "clang/Sema/ExternalSemaSource.h"
 #include "clang/Sema/IdentifierResolver.h"
+#include "clang/Sema/Overload.h"
 #include "clang/Sema/Ownership.h"
 #include "clang/Sema/ParsedAttr.h"
 #include "clang/Sema/Redeclaration.h"
@@ -10389,9 +10390,26 @@ public:
       OverloadCandidateSet &CandidateSet, bool SuppressUserConversions = false,
       bool PartialOverloading = false, OverloadCandidateParamOrder PO = {});
 
+  void AddMethodTemplateCandidateImmediately(
+      OverloadCandidateSet &CandidateSet, FunctionTemplateDecl *MethodTmpl,
+      DeclAccessPair FoundDecl, CXXRecordDecl *ActingContext,
+      TemplateArgumentListInfo *ExplicitTemplateArgs, QualType ObjectType,
+      Expr::Classification ObjectClassification, ArrayRef<Expr *> Args,
+      bool SuppressUserConversions, bool PartialOverloading,
+      OverloadCandidateParamOrder PO);
+
   /// Add a C++ function template specialization as a candidate
   /// in the candidate set, using template argument deduction to produce
   /// an appropriate function template specialization.
+
+  void AddTemplateOverloadCandidateImmediately(
+      OverloadCandidateSet &CandidateSet,
+      FunctionTemplateDecl *FunctionTemplate, DeclAccessPair FoundDecl,
+      TemplateArgumentListInfo *ExplicitTemplateArgs, ArrayRef<Expr *> Args,
+      bool SuppressUserConversions, bool PartialOverloading, bool AllowExplicit,
+      ADLCallKind IsADLCandidate, OverloadCandidateParamOrder PO,
+      bool AggregateCandidateDeduction);
+
   void AddTemplateOverloadCandidate(
       FunctionTemplateDecl *FunctionTemplate, DeclAccessPair FoundDecl,
       TemplateArgumentListInfo *ExplicitTemplateArgs, ArrayRef<Expr *> Args,
@@ -10435,6 +10453,13 @@ public:
       CXXRecordDecl *ActingContext, Expr *From, QualType ToType,
       OverloadCandidateSet &CandidateSet, bool AllowObjCConversionOnExplicit,
       bool AllowExplicit, bool AllowResultConversion = true);
+
+  void AddTemplateConversionCandidateImmediately(
+      OverloadCandidateSet &CandidateSet,
+      FunctionTemplateDecl *FunctionTemplate, DeclAccessPair FoundDecl,
+      CXXRecordDecl *ActingContext, Expr *From, QualType ToType,
+      bool AllowObjCConversionOnExplicit, bool AllowExplicit,
+      bool AllowResultConversion);
 
   /// AddSurrogateCandidate - Adds a "surrogate" candidate function that
   /// converts the given @c Object to a function pointer via the

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -60,7 +60,6 @@
 #include "clang/Sema/DeclSpec.h"
 #include "clang/Sema/ExternalSemaSource.h"
 #include "clang/Sema/IdentifierResolver.h"
-#include "clang/Sema/Overload.h"
 #include "clang/Sema/Ownership.h"
 #include "clang/Sema/ParsedAttr.h"
 #include "clang/Sema/Redeclaration.h"
@@ -10393,7 +10392,6 @@ public:
   /// Add a C++ function template specialization as a candidate
   /// in the candidate set, using template argument deduction to produce
   /// an appropriate function template specialization.
-
   void AddTemplateOverloadCandidate(
       FunctionTemplateDecl *FunctionTemplate, DeclAccessPair FoundDecl,
       TemplateArgumentListInfo *ExplicitTemplateArgs, ArrayRef<Expr *> Args,

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -6354,7 +6354,8 @@ SemaCodeCompletion::ProduceCallSignatureHelp(Expr *Fn, ArrayRef<Expr *> Args,
   Expr *NakedFn = Fn->IgnoreParenCasts();
   // Build an overload candidate set based on the functions we find.
   SourceLocation Loc = Fn->getExprLoc();
-  OverloadCandidateSet CandidateSet(Loc, OverloadCandidateSet::CSK_Normal);
+  OverloadCandidateSet CandidateSet(Loc,
+                                    OverloadCandidateSet::CSK_CodeCompletion);
 
   if (auto ULE = dyn_cast<UnresolvedLookupExpr>(NakedFn)) {
     SemaRef.AddOverloadedCallCandidates(ULE, ArgsWithoutDependentTypes,
@@ -6557,7 +6558,8 @@ QualType SemaCodeCompletion::ProduceConstructorSignatureHelp(
   // FIXME: Provide support for variadic template constructors.
 
   if (CRD) {
-    OverloadCandidateSet CandidateSet(Loc, OverloadCandidateSet::CSK_Normal);
+    OverloadCandidateSet CandidateSet(Loc,
+                                      OverloadCandidateSet::CSK_CodeCompletion);
     for (NamedDecl *C : SemaRef.LookupConstructors(CRD)) {
       if (auto *FD = dyn_cast<FunctionDecl>(C)) {
         // FIXME: we can't yet provide correct signature help for initializer

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -10029,12 +10029,15 @@ QualType Sema::DeduceTemplateSpecializationFromInitializer(
     //   When [...] the constructor [...] is a candidate by
     //    - [over.match.copy] (in all cases)
     if (TD) {
-      SmallVector<Expr *, 8> TmpInits;
-      for (Expr *E : Inits)
+      MutableArrayRef<Expr *> TmpInits =
+          Candidates.getPersistentArgsArray(Inits.size());
+      for (auto [I, E] : llvm::enumerate(Inits)) {
         if (auto *DI = dyn_cast<DesignatedInitExpr>(E))
-          TmpInits.push_back(DI->getInit());
+          TmpInits[I] = DI->getInit();
         else
-          TmpInits.push_back(E);
+          TmpInits[I] = E;
+      }
+
       AddTemplateOverloadCandidate(
           TD, FoundDecl, /*ExplicitArgs=*/nullptr, TmpInits, Candidates,
           /*SuppressUserConversions=*/false,

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -10031,7 +10031,7 @@ QualType Sema::DeduceTemplateSpecializationFromInitializer(
     if (TD) {
 
       // As template candidates are not deduced immediately,
-      // persist the arry in the overload set.
+      // persist the array in the overload set.
       MutableArrayRef<Expr *> TmpInits =
           Candidates.getPersistentArgsArray(Inits.size());
 

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -5231,7 +5231,7 @@ static OverloadingResult TryRefInitWithConversionFunction(
 
   // Add the final conversion sequence, if necessary.
   if (NewRefRelationship == Sema::Ref_Incompatible) {
-    assert(!isa<CXXConstructorDecl>(Function) &&
+    assert(Best->HasFinalConversion && !isa<CXXConstructorDecl>(Function) &&
            "should not have conversion after constructor");
 
     ImplicitConversionSequence ICS;
@@ -6200,6 +6200,7 @@ static void TryUserDefinedConversion(Sema &S,
 
   // If the conversion following the call to the conversion function
   // is interesting, add it as a separate step.
+  assert(Best->HasFinalConversion);
   if (Best->FinalConversion.First || Best->FinalConversion.Second ||
       Best->FinalConversion.Third) {
     ImplicitConversionSequence ICS;

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -10029,8 +10029,12 @@ QualType Sema::DeduceTemplateSpecializationFromInitializer(
     //   When [...] the constructor [...] is a candidate by
     //    - [over.match.copy] (in all cases)
     if (TD) {
+
+      // As template candidates are not deduced immediately,
+      // persist the arry in the overload set.
       MutableArrayRef<Expr *> TmpInits =
           Candidates.getPersistentArgsArray(Inits.size());
+
       for (auto [I, E] : llvm::enumerate(Inits)) {
         if (auto *DI = dyn_cast<DesignatedInitExpr>(E))
           TmpInits[I] = DI->getInit();

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -8514,13 +8514,6 @@ void Sema::AddNonMemberOperatorCandidates(
     NamedDecl *D = F.getDecl()->getUnderlyingDecl();
     ArrayRef<Expr *> FunctionArgs = Args;
 
-    auto ReversedArgs = [&, Arr = ArrayRef<Expr *>{}]() mutable {
-      if (Arr.empty())
-        Arr = CandidateSet.getPersistentArgsArray(FunctionArgs[1],
-                                                  FunctionArgs[0]);
-      return Arr;
-    };
-
     FunctionTemplateDecl *FunTmpl = dyn_cast<FunctionTemplateDecl>(D);
     FunctionDecl *FD =
         FunTmpl ? FunTmpl->getTemplatedDecl() : cast<FunctionDecl>(D);
@@ -8536,8 +8529,10 @@ void Sema::AddNonMemberOperatorCandidates(
       AddTemplateOverloadCandidate(FunTmpl, F.getPair(), ExplicitTemplateArgs,
                                    FunctionArgs, CandidateSet);
       if (CandidateSet.getRewriteInfo().shouldAddReversed(*this, Args, FD)) {
+        ArrayRef<Expr *> Reversed = CandidateSet.getPersistentArgsArray(FunctionArgs[1],
+                                                                        FunctionArgs[0]);
         AddTemplateOverloadCandidate(FunTmpl, F.getPair(), ExplicitTemplateArgs,
-                                     ReversedArgs(), CandidateSet, false, false,
+                                     Reversed, CandidateSet, false, false,
                                      true, ADLCallKind::NotADL,
                                      OverloadCandidateParamOrder::Reversed);
       }
@@ -8546,7 +8541,8 @@ void Sema::AddNonMemberOperatorCandidates(
         continue;
       AddOverloadCandidate(FD, F.getPair(), FunctionArgs, CandidateSet);
       if (CandidateSet.getRewriteInfo().shouldAddReversed(*this, Args, FD))
-        AddOverloadCandidate(FD, F.getPair(), ReversedArgs(), CandidateSet,
+        AddOverloadCandidate(FD, F.getPair(), {FunctionArgs[1],
+                                               FunctionArgs[0]}, CandidateSet,
                              false, false, true, false, ADLCallKind::NotADL, {},
                              OverloadCandidateParamOrder::Reversed);
     }

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -11229,7 +11229,8 @@ void OverloadCandidateSet::PerfectViableFunction(
   Best = end();
   for (auto It = begin(); It != end(); ++It) {
 
-    if (!It->isPerfectMatch(S.getASTContext()))
+    if (!It->isPerfectMatch(S.getASTContext(),
+                            Kind == CSK_InitByUserDefinedConversion))
       continue;
 
     // We found a suitable conversion function

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -45,7 +45,6 @@
 #include <cstddef>
 #include <cstdlib>
 #include <optional>
-#include <variant>
 
 using namespace clang;
 using namespace sema;
@@ -7838,7 +7837,7 @@ static void AddMethodTemplateCandidateImmediately(
     Candidate.Function = MethodTmpl->getTemplatedDecl();
     Candidate.Viable = false;
     Candidate.RewriteKind =
-        CandidateSet.getRewriteInfo().getRewriteKind(Candidate.Function, PO);
+      CandidateSet.getRewriteInfo().getRewriteKind(Candidate.Function, PO);
     Candidate.IsSurrogate = false;
     Candidate.IgnoreObjectArgument =
         cast<CXXMethodDecl>(Candidate.Function)->isStatic() ||
@@ -7951,7 +7950,7 @@ static void AddTemplateOverloadCandidateImmediately(
     Candidate.Function = FunctionTemplate->getTemplatedDecl();
     Candidate.Viable = false;
     Candidate.RewriteKind =
-        CandidateSet.getRewriteInfo().getRewriteKind(Candidate.Function, PO);
+      CandidateSet.getRewriteInfo().getRewriteKind(Candidate.Function, PO);
     Candidate.IsSurrogate = false;
     Candidate.IsADLCandidate = llvm::to_underlying(IsADLCandidate);
     // Ignore the object argument if there is one, since we don't have an object

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -31,7 +31,6 @@
 #include "clang/Sema/Lookup.h"
 #include "clang/Sema/Overload.h"
 #include "clang/Sema/SemaCUDA.h"
-#include "clang/Sema/SemaCodeCompletion.h"
 #include "clang/Sema/SemaObjC.h"
 #include "clang/Sema/Template.h"
 #include "clang/Sema/TemplateDeduction.h"

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -11039,6 +11039,8 @@ void OverloadCandidateSet::AddDeferredMethodTemplateCandidate(
     bool SuppressUserConversions, bool PartialOverloading,
     OverloadCandidateParamOrder PO) {
 
+  assert(!isa<CXXConstructorDecl>(MethodTmpl->getTemplatedDecl()));
+
   auto *C =
       allocateDeferredCandidate<DeferredMethodTemplateOverloadCandidate>();
 

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -11165,25 +11165,25 @@ void OverloadCandidateSet::PerfectViableFunction(
 
   Best = end();
   for (auto It = begin(); It != end(); ++It) {
-    if (It->isPerfectMatch(S.getASTContext())) {
-      if (Best == end()) {
-        Best = It;
-      } else {
-        if (Best->Function && It->Function) {
-          FunctionDecl *D =
-              S.getMoreConstrainedFunction(Best->Function, It->Function);
-          if (D == nullptr) {
-            Best = end();
-            break;
-          }
-          if (D == It->Function)
-            Best = It;
-          continue;
-        }
+    if (!It->isPerfectMatch(S.getASTContext()))
+      continue;
+    if (Best == end()) {
+      Best = It;
+      continue;
+    }
+    if (Best->Function && It->Function) {
+      FunctionDecl *D =
+          S.getMoreConstrainedFunction(Best->Function, It->Function);
+      if (D == nullptr) {
         Best = end();
         break;
       }
+      if (D == It->Function)
+        Best = It;
+      continue;
     }
+    Best = end();
+    break;
   }
 }
 

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -5165,6 +5165,9 @@ FindConversionForRefInit(Sema &S, ImplicitConversionSequence &ICS,
   OverloadCandidateSet::iterator Best;
   switch (CandidateSet.BestViableFunction(S, DeclLoc, Best)) {
   case OR_Success:
+
+    assert(Best->HasFinalConversion);
+
     // C++ [over.ics.ref]p1:
     //
     //   [...] If the parameter binds directly to the result of
@@ -5178,7 +5181,6 @@ FindConversionForRefInit(Sema &S, ImplicitConversionSequence &ICS,
     if (!Best->FinalConversion.DirectBinding)
       return false;
 
-    assert(Best->HasFinalConversion);
     ICS.setUserDefined();
     ICS.UserDefined.Before = Best->Conversions[0].Standard;
     ICS.UserDefined.After = Best->FinalConversion;

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -4079,6 +4079,9 @@ IsUserDefinedConversion(Sema &S, Expr *From, QualType ToType,
     }
     if (CXXConversionDecl *Conversion
                  = dyn_cast<CXXConversionDecl>(Best->Function)) {
+
+      assert(Best->HasFinalConversion);
+
       // C++ [over.ics.user]p1:
       //
       //   [...] If the user-defined conversion is specified by a
@@ -5175,6 +5178,7 @@ FindConversionForRefInit(Sema &S, ImplicitConversionSequence &ICS,
     if (!Best->FinalConversion.DirectBinding)
       return false;
 
+    assert(Best->HasFinalConversion);
     ICS.setUserDefined();
     ICS.UserDefined.Before = Best->Conversions[0].Standard;
     ICS.UserDefined.After = Best->FinalConversion;
@@ -10758,6 +10762,8 @@ bool clang::isBetterOverloadCandidate(
       Cand1.Function && Cand2.Function &&
       isa<CXXConversionDecl>(Cand1.Function) &&
       isa<CXXConversionDecl>(Cand2.Function)) {
+
+    assert(Cand1.HasFinalConversion && Cand2.HasFinalConversion);
     // First check whether we prefer one of the conversion functions over the
     // other. This only distinguishes the results in non-standard, extension
     // cases such as the conversion from a lambda closure type to a function

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -11145,9 +11145,9 @@ void OverloadCandidateSet::CudaExcludeWrongSideCandidates(Sema &S) {
 /// function, \p Best points to the candidate function found.
 ///
 /// \returns The result of overload resolution.
-OverloadingResult
-OverloadCandidateSet::BestViableFunction(Sema &S, SourceLocation Loc,
-                                         iterator &Best) {
+OverloadingResult OverloadCandidateSet::BestViableFunction(Sema &S,
+                                                           SourceLocation Loc,
+                                                           iterator &Best) {
 
   assert(shouldDeferTemplateArgumentDeduction(S.getLangOpts()) ||
          DeferredCandidates.empty() &&

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -8174,6 +8174,7 @@ void Sema::AddConversionCandidate(
   Candidate.FinalConversion.setAsIdentityConversion();
   Candidate.FinalConversion.setFromType(ConvType);
   Candidate.FinalConversion.setAllToTypes(ToType);
+  Candidate.HasFinalConversion = true;
   Candidate.Viable = true;
   Candidate.ExplicitCallArguments = 1;
   Candidate.StrictPackMatch = StrictPackMatch;
@@ -8278,6 +8279,7 @@ void Sema::AddConversionCandidate(
   switch (ICS.getKind()) {
   case ImplicitConversionSequence::StandardConversion:
     Candidate.FinalConversion = ICS.Standard;
+    Candidate.HasFinalConversion = true;
 
     // C++ [over.ics.user]p3:
     //   If the user-defined conversion is specified by a specialization of a
@@ -11229,8 +11231,7 @@ void OverloadCandidateSet::PerfectViableFunction(
   Best = end();
   for (auto It = begin(); It != end(); ++It) {
 
-    if (!It->isPerfectMatch(S.getASTContext(),
-                            Kind == CSK_InitByUserDefinedConversion))
+    if (!It->isPerfectMatch(S.getASTContext()))
       continue;
 
     // We found a suitable conversion function

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -11120,7 +11120,10 @@ OverloadCandidateSet::BestViableFunction(Sema &S, SourceLocation Loc,
       return OR_Success;
     }
   }
-  InjectNonDeducedTemplateCandidates(S);
+
+  if(!NonDeducedCandidates.empty())
+    InjectNonDeducedTemplateCandidates(S);
+
   return BestViableFunctionImpl(S, Loc, Best);
 }
 

--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -6142,9 +6142,9 @@ FunctionDecl *Sema::getMoreConstrainedFunction(FunctionDecl *FD1,
   assert(!FD1->getDescribedTemplate() && !FD2->getDescribedTemplate() &&
          "not for function templates");
   assert(!FD1->isFunctionTemplateSpecialization() ||
-         isa<CXXConversionDecl>(FD1));
+         (isa<CXXConversionDecl, CXXConstructorDecl>(FD1)));
   assert(!FD2->isFunctionTemplateSpecialization() ||
-         isa<CXXConversionDecl>(FD2));
+         (isa<CXXConversionDecl, CXXConstructorDecl>(FD2)));
 
   FunctionDecl *F1 = FD1;
   if (FunctionDecl *P = FD1->getTemplateInstantiationPattern(false))

--- a/clang/test/CXX/temp/temp.constr/temp.constr.atomic/constrant-satisfaction-conversions.cpp
+++ b/clang/test/CXX/temp/temp.constr/temp.constr.atomic/constrant-satisfaction-conversions.cpp
@@ -14,7 +14,7 @@ template<typename T> struct S {
 // expected-note@#FINST{{in instantiation of function template specialization}}
 template<typename T> requires (S<T>{})
 void f(T);
-void f(int);
+void f(long);
 
 // Ensure this applies to operator && as well.
 // expected-error@+3{{atomic constraint must be of type 'bool' (found 'S<int>')}}
@@ -22,7 +22,7 @@ void f(int);
 // expected-note@#F2INST{{in instantiation of function template specialization}}
 template<typename T> requires (S<T>{} && true)
 void f2(T);
-void f2(int);
+void f2(long);
 
 template<typename T> requires requires {
   requires S<T>{};
@@ -36,12 +36,12 @@ template<typename T> requires requires {
   //
 }
 void f3(T);
-void f3(int);
+void f3(long);
 
 // Doesn't diagnose, since this is no longer a compound requirement.
 template<typename T> requires (bool(1 && 2))
 void f4(T);
-void f4(int);
+void f4(long);
 
 void g() {
   f(0); // #FINST

--- a/clang/test/SemaCUDA/function-overload.cu
+++ b/clang/test/SemaCUDA/function-overload.cu
@@ -1,6 +1,3 @@
-// REQUIRES: x86-registered-target
-// REQUIRES: nvptx-registered-target
-
 // RUN: %clang_cc1 -std=c++14 -triple x86_64-unknown-linux-gnu -fsyntax-only \
 // RUN:   -verify=host,hostdefer,devdefer,expected %s
 // RUN: %clang_cc1 -std=c++14 -triple nvptx64-nvidia-cuda -fsyntax-only \

--- a/clang/test/SemaCXX/implicit-member-functions.cpp
+++ b/clang/test/SemaCXX/implicit-member-functions.cpp
@@ -54,31 +54,24 @@ namespace PR7594 {
 namespace Recursion {
   template<typename T> struct InvokeCopyConstructor {
     static const T &get();
-    typedef decltype(T(get())) type; // expected-error {{no matching conver}}
+    typedef decltype(T(get())) type;
   };
   struct B;
   struct A {
-    // expected-note@-1 {{while substituting deduced template arguments}}
     typedef B type;
     template<typename T,
              typename = typename InvokeCopyConstructor<typename T::type>::type>
-    // expected-note@-1 {{in instantiation of template class}}
     A(const T &);
-    // expected-note@-1 {{in instantiation of default argument}}
   };
-  struct B { // expected-note {{while declaring the implicit copy constructor for 'B'}}
-    // expected-note@-1 {{candidate constructor (the implicit move }}
-    B(); // expected-note {{candidate constructor not viable}}
+  struct B {
+    B();
     A a;
   };
   // Triggering the declaration of B's copy constructor causes overload
-  // resolution to occur for A's copying constructor, which instantiates
-  // InvokeCopyConstructor<B>, which triggers the declaration of B's copy
-  // constructor. Notionally, this happens when we get to the end of the
-  // definition of 'struct B', so there is no declared copy constructor yet.
-  //
-  // This behavior is g++-compatible, but isn't exactly right; the class is
-  // supposed to be incomplete when we implicitly declare its special members.
+  // resolution to occur for A's copying constructor, which picks
+  // the implicit copy constructor of A.
+  // Because that copy constructor is always a perfect match the template
+  // candidate is not instantiated.
   B b = B();
 
 

--- a/clang/test/SemaCXX/overload-resolution-deferred-templates.cpp
+++ b/clang/test/SemaCXX/overload-resolution-deferred-templates.cpp
@@ -128,6 +128,27 @@ struct Test {
 static_assert(__is_constructible(S, Test));
 }
 
+namespace RefBinding {
+
+template <typename> struct remove_reference;
+template <typename _Tp> struct remove_reference<_Tp &> {
+  using type = _Tp;
+};
+template <typename _Tp> remove_reference<_Tp>::type move(_Tp &&);
+template <typename _Head> struct _Head_base {
+  _Head_base(_Head &__h) : _M_head_impl(__h) {}
+  template <typename _UHead> _Head_base(_UHead &&);
+  _Head _M_head_impl;
+};
+
+template <typename _Elements> void forward_as_tuple(_Elements &&) {
+  _Head_base<_Elements &&>(_Elements{});
+}
+struct StringRef {
+  void operator[](const StringRef __k) { forward_as_tuple((move)(__k)); }
+};
+
+}
 
 namespace GH62096 {
 template <typename T>

--- a/clang/test/SemaCXX/overload-resolution-deferred-templates.cpp
+++ b/clang/test/SemaCXX/overload-resolution-deferred-templates.cpp
@@ -183,3 +183,18 @@ void h(short n) { f(n); }
 }
 
 #endif
+
+template<typename ...Ts>
+struct t1 {
+};
+struct t6 {
+  template<typename T = int>
+  operator t1<float>() {
+    return {};
+  }
+};
+
+int main() {
+  t6 v6;
+  v6.operator t1<float>();
+}

--- a/clang/test/SemaCXX/overload-resolution-deferred-templates.cpp
+++ b/clang/test/SemaCXX/overload-resolution-deferred-templates.cpp
@@ -116,6 +116,18 @@ static_assert(m1.g(0) == 1);
 static_assert(Members<int[3]>{}.s(0) == 2);
 
 
+namespace ConstructorInit{
+struct S {
+  template <typename T>
+  S(T&&) {}
+};
+struct Test {
+  operator S() = delete;
+};
+
+static_assert(__is_constructible(S, Test));
+}
+
 
 namespace GH62096 {
 template <typename T>

--- a/clang/test/SemaCXX/overload-resolution-deferred-templates.cpp
+++ b/clang/test/SemaCXX/overload-resolution-deferred-templates.cpp
@@ -1,0 +1,145 @@
+// RUN: %clang_cc1 -triple=x86_64-unknown-unknown -fsyntax-only -verify -std=c++11 %s
+// RUN: %clang_cc1 -triple=x86_64-unknown-unknown -fsyntax-only -verify -std=c++20 %s
+// RUN: %clang_cc1 -triple=x86_64-unknown-unknown -fsyntax-only -verify -std=c++2c %s
+
+template <typename T>
+struct Invalid { static_assert(false, "instantiated Invalid"); }; // #err-invalid
+
+template <typename T>
+int f(T a, Invalid<T> = {}); // #note-f
+
+// sanity check
+int e1 = f(0);
+//expected-error@#err-invalid {{static assertion failed: instantiated Invalid}}
+//expected-note@-2 {{in instantiation of default function argument expression for 'f<int>' required here}}
+//expected-note@#note-f {{in instantiation of template class 'Invalid<int>' requested here}}
+//expected-note@#note-f {{passing argument to parameter here}}
+
+int f(int);
+int ok1 = f(0);
+int e4 = f((const int&)(ok1));
+
+int f(int, int = 0);
+int ok2 = f(0, 0);
+
+int e2  = f(0L);
+//expected-error@#err-invalid {{static assertion failed: instantiated Invalid}}
+//expected-note@-2 {{in instantiation of default function argument expression for 'f<long>' required here}}
+//expected-note@#note-f {{in instantiation of template class 'Invalid<long>' requested here}}
+//expected-note@#note-f {{passing argument to parameter here}}
+
+int f(long);
+int ok3 = f(0L);
+
+template <typename T>
+struct Invalid2 { static_assert(false, "instantiated Invalid2"); }; // #err-qualifiers
+
+template <typename T>
+int ref(T a, Invalid2<T> = {}); // expected-note 2{{here}}
+int ref(int&);
+int ref1 = ref(ok3);
+int ref2 = ref((const int&)ok3); // expected-note {{here}}
+//expected-error@#err-qualifiers {{static assertion failed: instantiated Invalid2}}
+
+
+template <typename T>
+int f_alias(T a, Invalid<T> = {});
+using Alias = int;
+int f_alias(Alias);
+int ok4 = f_alias(0);
+
+#if __cplusplus >= 202002
+
+struct Copyable {
+  template <typename T>
+  requires __is_constructible(Copyable, T)
+  explicit Copyable(T op) noexcept; // #1
+  Copyable(const Copyable&) noexcept = default; // #2
+};
+static_assert(__is_constructible(Copyable, const Copyable&));
+
+struct ImplicitlyCopyable {
+  template <typename T>
+  requires __is_constructible(ImplicitlyCopyable, T)
+  explicit ImplicitlyCopyable(T op) = delete; // #1
+};
+static_assert(__is_constructible(ImplicitlyCopyable, const ImplicitlyCopyable&));
+
+
+struct Movable {
+  template <typename T>
+  requires __is_constructible(Movable, T) // #err-self-constraint-1
+  explicit Movable(T op) noexcept; // #1
+  Movable(Movable&&) noexcept = default; // #2
+};
+static_assert(__is_constructible(Movable, Movable&&));
+static_assert(__is_constructible(Movable, const Movable&));
+// expected-error@-1 {{static assertion failed due to requirement '__is_constructible(Movable, const Movable &)'}}
+
+static_assert(__is_constructible(Movable, int));
+// expected-error@-1{{static assertion failed due to requirement '__is_constructible(Movable, int)'}} \
+// expected-note@-1 2{{}}
+// expected-error@#err-self-constraint-1{{satisfaction of constraint '__is_constructible(Movable, T)' depends on itself}}
+// expected-note@#err-self-constraint-1 4{{}}
+
+template <typename T>
+struct Members {
+    constexpr auto f(auto) {
+        static_assert(false, "");
+    }
+    constexpr auto f(int) { return 1; }
+    constexpr auto f(int) requires true { return 2; }
+
+    constexpr auto g(auto) {
+        static_assert(false, "instantiated member"); //#err-qualified-member
+        return 0;
+    }
+    constexpr auto g(int) & { return 1; }
+
+    static constexpr auto s(auto) {
+        static_assert(false, "");
+    }
+    static constexpr auto s(int) {
+        return 1;
+    }
+    static constexpr auto s(int) requires true {
+        return 2;
+    }
+};
+
+static_assert(Members<int[1]>{}.f(0) == 2);
+static_assert(Members<int[2]>{}.g(0) == 0);
+// expected-error@#err-qualified-member {{static assertion failed: instantiated member}} \
+// expected-note@-1{{in instantiation of function template specialization 'Members<int[2]>::g<int>' }}
+Members<int[3]> m1;
+static_assert(m1.g(0) == 1);
+static_assert(Members<int[3]>{}.s(0) == 2);
+
+
+
+namespace GH62096 {
+template <typename T>
+struct Oops {
+  static_assert(sizeof(T) == 0); // #GH62096-err
+  static constexpr bool value = true;
+};
+
+template <class OPERATOR>
+concept Operator = Oops<OPERATOR>::value; // #GH62096-note1
+
+template <Operator OP> void f(OP op); // // #GH62096-note2
+void f(int);
+
+void g(int n) { f(n); } // OK
+void h(short n) { f(n); }
+// expected-error@#GH62096-err {{static assertion failed due to requirement 'sizeof(short) == 0'}} \
+// expected-note@-1{{in instantiation of function template specialization}} \
+// expected-note@-1{{while checking constraint satisfaction for template}}
+// expected-note@#GH62096-note1{{in instantiation}}
+// expected-note@#GH62096-note1{{while substituting template arguments into constraint expression here}}
+// expected-note@#GH62096-note2{{while substituting template arguments into constraint expression here}}
+// expected-note@#GH62096-note2{{while checking the satisfaction of concept}}
+// expected-note@#GH62096-err {{expression evaluates}}
+}
+
+#endif

--- a/clang/test/SemaCXX/overload-resolution-deferred-templates.cpp
+++ b/clang/test/SemaCXX/overload-resolution-deferred-templates.cpp
@@ -150,6 +150,13 @@ struct StringRef {
 
 }
 
+template <class> struct tuple {};
+struct BonkersBananas {
+  template <class T> operator T();
+  template <class = void> explicit operator tuple<int>() = delete;
+};
+static_assert(!__is_constructible(tuple<int>, BonkersBananas));
+
 namespace GH62096 {
 template <typename T>
 struct Oops {

--- a/clang/test/SemaTemplate/instantiate-function-params.cpp
+++ b/clang/test/SemaTemplate/instantiate-function-params.cpp
@@ -6,13 +6,12 @@ template<typename T1> struct if_ {
   typedef if_c< static_cast<bool>(T1::value)> almost_type_; // expected-note 7{{in instantiation}}
 };
 template <class Model, void (Model::*)()> struct wrap_constraints { };
-template <class Model> 
+template <class Model>
 inline char has_constraints_(Model* , // expected-note 3{{candidate template ignored}}
-                               wrap_constraints<Model,&Model::constraints>* = 0); // expected-note 4{{in instantiation}}
-
+                               wrap_constraints<Model,&Model::constraints>* = 0);
 template <class Model> struct not_satisfied {
   static const bool value = sizeof( has_constraints_((Model*)0)  == 1); // expected-error 3{{no matching function}} \
-  // expected-note 4{{while substituting deduced template arguments into function template 'has_constraints_' [with }}
+  // expected-note 4{{in instantiation}}
 };
 template <class ModelFn> struct requirement_;
 template <void(*)()> struct instantiate {

--- a/clang/test/Templight/templight-empty-entries-fix.cpp
+++ b/clang/test/Templight/templight-empty-entries-fix.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -templight-dump -Wno-unused-value %s 2>&1 | FileCheck %s
 
-void a() {
+void a(long) {
   [] {};
 }
 
@@ -17,14 +17,14 @@ void a() {
 // CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:4:3'$}}
 // CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:4:3'$}}
 
-template <int = 0> void a() { a(); }
+template <int = 0> void a(long) { a(0); }
 
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+a$}}
 // CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+Begin$}}
 // CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:20:25'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:20:31'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:20:35'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+unnamed template non-type parameter 0 of a$}}
 // CHECK: {{^kind:[ ]+DefaultTemplateArgumentInstantiation$}}
@@ -42,29 +42,29 @@ template <int = 0> void a() { a(); }
 // CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+End$}}
 // CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:20:25'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:20:31'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:20:35'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+'a<0>'$}}
 // CHECK: {{^kind:[ ]+TemplateInstantiation$}}
 // CHECK: {{^event:[ ]+Begin$}}
 // CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:20:25'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:20:31'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:20:35'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+'a<0>'$}}
 // CHECK: {{^kind:[ ]+TemplateInstantiation$}}
 // CHECK: {{^event:[ ]+End$}}
 // CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:20:25'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:20:31'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:20:35'$}}
 
 template <int> struct b { typedef int c; };
-template <bool d = true, class = typename b<d>::c> void a() { a(); }
+template <bool d = true, class = typename b<d>::c> void a(long) { a(0); }
 
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+a$}}
 // CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+Begin$}}
 // CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:60:57'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:63'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:67'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+d$}}
 // CHECK: {{^kind:[ ]+DefaultTemplateArgumentInstantiation$}}
@@ -130,25 +130,25 @@ template <bool d = true, class = typename b<d>::c> void a() { a(); }
 // CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+End$}}
 // CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:60:57'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:63'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:67'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+'a<true, int>'$}}
 // CHECK: {{^kind:[ ]+TemplateInstantiation$}}
 // CHECK: {{^event:[ ]+Begin$}}
 // CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:60:57'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:63'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:67'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+'a<true, int>'$}}
 // CHECK: {{^kind:[ ]+TemplateInstantiation$}}
 // CHECK: {{^event:[ ]+End$}}
 // CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:60:57'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:63'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:67'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+a$}}
 // CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+Begin$}}
 // CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:20:25'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:63'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:67'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+unnamed template non-type parameter 0 of a$}}
 // CHECK: {{^kind:[ ]+DefaultTemplateArgumentInstantiation$}}
@@ -166,7 +166,7 @@ template <bool d = true, class = typename b<d>::c> void a() { a(); }
 // CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+End$}}
 // CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:20:25'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:63'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:67'$}}
 
 template <bool = true> void d(int = 0) { d(); }
 
@@ -175,25 +175,25 @@ template <bool = true> void d(int = 0) { d(); }
 // CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+Begin$}}
 // CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:60:57'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:63'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:67'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+a$}}
 // CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+End$}}
 // CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:60:57'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:63'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:67'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+a$}}
 // CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+Begin$}}
 // CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:20:25'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:63'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:67'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+a$}}
 // CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+End$}}
 // CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:20:25'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:63'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:67'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+d$}}
 // CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}

--- a/clang/test/Templight/templight-empty-entries-fix.cpp
+++ b/clang/test/Templight/templight-empty-entries-fix.cpp
@@ -171,30 +171,6 @@ template <bool d = true, class = typename b<d>::c> void a(long) { a(0); }
 template <bool = true> void d(int = 0) { d(); }
 
 // CHECK-LABEL: {{^---$}}
-// CHECK: {{^name:[ ]+a$}}
-// CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
-// CHECK: {{^event:[ ]+Begin$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:60:57'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:67'$}}
-// CHECK-LABEL: {{^---$}}
-// CHECK: {{^name:[ ]+a$}}
-// CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
-// CHECK: {{^event:[ ]+End$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:60:57'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:67'$}}
-// CHECK-LABEL: {{^---$}}
-// CHECK: {{^name:[ ]+a$}}
-// CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
-// CHECK: {{^event:[ ]+Begin$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:20:25'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:67'$}}
-// CHECK-LABEL: {{^---$}}
-// CHECK: {{^name:[ ]+a$}}
-// CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
-// CHECK: {{^event:[ ]+End$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:20:25'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:60:67'$}}
-// CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+d$}}
 // CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+Begin$}}
@@ -249,41 +225,41 @@ void e() {
 }
 
 // CHECK-LABEL: {{^---$}}
-// CHECK: {{^name:[ ]+'\(unnamed struct at .*templight-empty-entries-fix.cpp:247:3\)'$}}
+// CHECK: {{^name:[ ]+'\(unnamed struct at .*templight-empty-entries-fix.cpp:223:3\)'$}}
 // CHECK: {{^kind:[ ]+Memoization$}}
 // CHECK: {{^event:[ ]+Begin$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:247:3'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:248:5'$}}
+// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:223:3'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:224:5'$}}
 // CHECK-LABEL: {{^---$}}
-// CHECK: {{^name:[ ]+'\(unnamed struct at .*templight-empty-entries-fix.cpp:247:3\)'$}}
+// CHECK: {{^name:[ ]+'\(unnamed struct at .*templight-empty-entries-fix.cpp:223:3\)'$}}
 // CHECK: {{^kind:[ ]+Memoization$}}
 // CHECK: {{^event:[ ]+End$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:247:3'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:248:5'$}}
+// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:223:3'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:224:5'$}}
 // CHECK-LABEL: {{^---$}}
-// CHECK: {{^name:[ ]+'\(unnamed struct at .*templight-empty-entries-fix.cpp:247:3\)'$}}
+// CHECK: {{^name:[ ]+'\(unnamed struct at .*templight-empty-entries-fix.cpp:223:3\)'$}}
 // CHECK: {{^kind:[ ]+Memoization$}}
 // CHECK: {{^event:[ ]+Begin$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:247:3'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:248:5'$}}
+// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:223:3'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:224:5'$}}
 // CHECK-LABEL: {{^---$}}
-// CHECK: {{^name:[ ]+'\(unnamed struct at .*templight-empty-entries-fix.cpp:247:3\)'$}}
+// CHECK: {{^name:[ ]+'\(unnamed struct at .*templight-empty-entries-fix.cpp:223:3\)'$}}
 // CHECK: {{^kind:[ ]+Memoization$}}
 // CHECK: {{^event:[ ]+End$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:247:3'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:248:5'$}}
+// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:223:3'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:224:5'$}}
 // CHECK-LABEL: {{^---$}}
-// CHECK: {{^name:[ ]+'\(unnamed struct at .*templight-empty-entries-fix.cpp:247:3\)'$}}
+// CHECK: {{^name:[ ]+'\(unnamed struct at .*templight-empty-entries-fix.cpp:223:3\)'$}}
 // CHECK: {{^kind:[ ]+Memoization$}}
 // CHECK: {{^event:[ ]+Begin$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:247:3'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:247:3'$}}
+// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:223:3'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:223:3'$}}
 // CHECK-LABEL: {{^---$}}
-// CHECK: {{^name:[ ]+'\(unnamed struct at .*templight-empty-entries-fix.cpp:247:3\)'$}}
+// CHECK: {{^name:[ ]+'\(unnamed struct at .*templight-empty-entries-fix.cpp:223:3\)'$}}
 // CHECK: {{^kind:[ ]+Memoization$}}
 // CHECK: {{^event:[ ]+End$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:247:3'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:247:3'$}}
+// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:223:3'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:223:3'$}}
 
 
 template <template<typename> class>
@@ -299,71 +275,71 @@ void foo() {
 // CHECK: {{^name:[ ]+d$}}
 // CHECK: {{^kind:[ ]+ExplicitTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+Begin$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:290:6'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:295:3'$}}
+// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:266:6'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:271:3'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+unnamed template template parameter 0 of d$}}
 // CHECK: {{^kind:[ ]+PriorTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+Begin$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:289:35'$}}
+// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:265:35'$}}
 // CHECK: {{^poi:[ ]+''$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+unnamed template template parameter 0 of d$}}
 // CHECK: {{^kind:[ ]+PriorTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+End$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:289:35'$}}
+// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:265:35'$}}
 // CHECK: {{^poi:[ ]+''$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+unnamed template template parameter 0 of d$}}
 // CHECK: {{^kind:[ ]+PartialOrderingTTP$}}
 // CHECK: {{^event:[ ]+Begin$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:289:35'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:295:5'$}}
+// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:265:35'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:271:5'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+unnamed template template parameter 0 of d$}}
 // CHECK: {{^kind:[ ]+PartialOrderingTTP$}}
 // CHECK: {{^event:[ ]+End$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:289:35'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:295:5'$}}
+// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:265:35'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:271:5'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+d$}}
 // CHECK: {{^kind:[ ]+ExplicitTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+End$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:290:6'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:295:3'$}}
+// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:266:6'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:271:3'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+d$}}
 // CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+Begin$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:290:6'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:295:3'$}}
+// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:266:6'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:271:3'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+d$}}
 // CHECK: {{^kind:[ ]+DeducedTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+End$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:290:6'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:295:3'$}}
+// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:266:6'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:271:3'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+'d<C>'$}}
 // CHECK: {{^kind:[ ]+TemplateInstantiation$}}
 // CHECK: {{^event:[ ]+Begin$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:290:6'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:295:3'$}}
+// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:266:6'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:271:3'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+'d<C>'$}}
 // CHECK: {{^kind:[ ]+TemplateInstantiation$}}
 // CHECK: {{^event:[ ]+End$}}
-// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:290:6'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:295:3'$}}
+// CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:266:6'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:271:3'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+d$}}
 // CHECK: {{^kind:[ ]+ExplicitTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+Begin$}}
 // CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:171:29'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:295:3'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:271:3'$}}
 // CHECK-LABEL: {{^---$}}
 // CHECK: {{^name:[ ]+d$}}
 // CHECK: {{^kind:[ ]+ExplicitTemplateArgumentSubstitution$}}
 // CHECK: {{^event:[ ]+End$}}
 // CHECK: {{^orig:[ ]+'.*templight-empty-entries-fix.cpp:171:29'$}}
-// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:295:3'$}}
+// CHECK: {{^poi:[ ]+'.*templight-empty-entries-fix.cpp:271:3'$}}


### PR DESCRIPTION
This implements the same overload resolution behavior as GCC,
as described in https://wg21.link/p3606 (section 1-2, not 3)

If during overload resolution, there is a non-template candidate
that would be always be picked - because each of the argument
is a perfect match (ie the source and target types are the same),
we do not perform deduction for any template candidate
that might exists.

The goal is to be able to merge https://github.com/llvm/llvm-project/pull/122423 without being too disruptive.

This change means that the selection of the best viable candidate and
template argument deduction become interleaved.

To avoid rewriting half of Clang we store in `OverloadCandidateSet`
enough information to be able to deduce template candidates from
`OverloadCandidateSet::BestViableFunction`. Which means
the lifetime of any object used by template argument must outlive
a call to `Add*Template*Candidate`.

This two phase resolution is not performed for some initialization
as there are cases where template candidate are better match
in these cases per the standard. It's also bypassed for code completion.

The change has a nice impact on compile times
https://llvm-compile-time-tracker.com/compare.php?from=719b029c16eeb1035da522fd641dfcc4cee6be74&to=bf7041045c9408490c395230047c5461de72fc39&stat=instructions%3Au

Fixes https://github.com/llvm/llvm-project/issues/62096
Fixes https://github.com/llvm/llvm-project/issues/74581

Reapplies #133426