### PR TITLE
Revert "[NFC][CFI] Dump test output to debug llvm-clang-win-x-aarch64 failure"

### DIFF
--- a/clang/test/Driver/sanitizer-ld.c
+++ b/clang/test/Driver/sanitizer-ld.c
@@ -845,14 +845,6 @@
 // RUN:     --target=x86_64-unknown-linux -fuse-ld=ld -rtlib=platform \
 // RUN:     -resource-dir=%S/Inputs/resource_dir \
 // RUN:     --sysroot=%S/Inputs/basic_linux_tree \
-// RUN:     -### %s
-
-// CFI by itself does not link runtime libraries.
-// RUN: %clang -fsanitize=cfi \
-// RUN:     -flto -fvisibility=hidden \
-// RUN:     --target=x86_64-unknown-linux -fuse-ld=ld -rtlib=platform \
-// RUN:     -resource-dir=%S/Inputs/resource_dir \
-// RUN:     --sysroot=%S/Inputs/basic_linux_tree \
 // RUN:     -### %s 2>&1 \
 // RUN:   | %{filecheck} --check-prefix=CHECK-CFI-LINUX
 // CHECK-CFI-LINUX: "{{.*}}ld{{(.exe)?}}"


### PR DESCRIPTION
Reverts llvm/llvm-project#136002

Not needed any more.