### PR TITLE
[NFC][CFI] Remove unnecessary -rtlib=platform from tests

### DIFF
--- a/clang/test/Driver/sanitizer-ld.c
+++ b/clang/test/Driver/sanitizer-ld.c
@@ -831,7 +831,7 @@
 
 // CFI requirements.
 // RUN: not %clang -fsanitize=cfi \
-// RUN:     --target=x86_64-unknown-linux -fuse-ld=ld -rtlib=platform \
+// RUN:     --target=x86_64-unknown-linux -fuse-ld=ld \
 // RUN:     -resource-dir=%S/Inputs/resource_dir \
 // RUN:     --sysroot=%S/Inputs/basic_linux_tree \
 // RUN:     -### %s 2>&1 \
@@ -841,7 +841,7 @@
 
 // CFI by itself does not link runtime libraries.
 // RUN: not %clang -fsanitize=cfi \
-// RUN:     --target=x86_64-unknown-linux -fuse-ld=ld -rtlib=platform \
+// RUN:     --target=x86_64-unknown-linux -fuse-ld=ld \
 // RUN:     -resource-dir=%S/Inputs/resource_dir \
 // RUN:     --sysroot=%S/Inputs/basic_linux_tree \
 // RUN:     -### %s 2>&1 \


### PR DESCRIPTION
Should allow to reland https://github.com/llvm/llvm-project/pull/135981