### PR TITLE
[lldb] Fix SBTarget::ReadInstruction with flavor

### DIFF
--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -2020,9 +2020,9 @@ lldb::SBInstructionList SBTarget::ReadInstructions(lldb::SBAddress base_addr,
                                 error, force_live_memory, &load_addr);
       const bool data_from_file = load_addr == LLDB_INVALID_ADDRESS;
       sb_instructions.SetDisassembler(Disassembler::DisassembleBytes(
-          target_sp->GetArchitecture(), nullptr, target_sp->GetDisassemblyCPU(),
-          target_sp->GetDisassemblyFeatures(), flavor_string, *addr_ptr,
-          data.GetBytes(), bytes_read, count, data_from_file));
+          target_sp->GetArchitecture(), nullptr, flavor_string,
+          target_sp->GetDisassemblyCPU(), target_sp->GetDisassemblyFeatures(),
+          *addr_ptr, data.GetBytes(), bytes_read, count, data_from_file));
     }
   }
 

--- a/lldb/test/API/python_api/target/read-instructions-flavor/Makefile
+++ b/lldb/test/API/python_api/target/read-instructions-flavor/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/python_api/target/read-instructions-flavor/TestTargetReadInstructionsFlavor.py
+++ b/lldb/test/API/python_api/target/read-instructions-flavor/TestTargetReadInstructionsFlavor.py
@@ -1,0 +1,39 @@
+"""
+Test SBTarget Read Instruction.
+"""
+
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+
+class TargetReadInstructionsFlavor(TestBase):
+    @skipIf(archs=no_match(["x86_64", "x86", "i386"]), oslist=["windows"])
+    def test_read_instructions_with_flavor(self):
+        self.build()
+        executable = self.getBuildArtifact("a.out")
+
+        # create a target
+        target = self.dbg.CreateTarget(executable)
+        self.assertTrue(target.IsValid(), "target is not valid")
+
+        functions = target.FindFunctions("test_add")
+        self.assertEqual(len(functions), 1)
+        test_add = functions[0]
+
+        test_add_symbols = test_add.GetSymbol()
+        self.assertTrue(
+            test_add_symbols.IsValid(), "test_add function symbols is not valid"
+        )
+
+        expected_instructions = (("mov", "eax, edi"), ("add", "eax, esi"), ("ret", ""))
+        test_add_insts = test_add_symbols.GetInstructions(target, "intel")
+        # clang adds an extra nop instruction but gcc does not. It makes more sense
+        # to check if it is at least 3
+        self.assertLessEqual(len(expected_instructions), len(test_add_insts))
+
+        # compares only the expected instructions
+        for expected_instr, instr in zip(expected_instructions, test_add_insts):
+            self.assertTrue(instr.IsValid(), "instruction is not valid")
+            expected_mnemonic, expected_op_str = expected_instr
+            self.assertEqual(instr.GetMnemonic(target), expected_mnemonic)
+            self.assertEqual(instr.GetOperands(target), expected_op_str)

--- a/lldb/test/API/python_api/target/read-instructions-flavor/TestTargetReadInstructionsFlavor.py
+++ b/lldb/test/API/python_api/target/read-instructions-flavor/TestTargetReadInstructionsFlavor.py
@@ -7,7 +7,8 @@ from lldbsuite.test.lldbtest import *
 
 
 class TargetReadInstructionsFlavor(TestBase):
-    @skipIf(archs=no_match(["x86_64", "x86", "i386"]), oslist=["windows"])
+    @skipIfWindows
+    @skipIf(archs=no_match(["x86_64", "x86", "i386"]))
     def test_read_instructions_with_flavor(self):
         self.build()
         executable = self.getBuildArtifact("a.out")

--- a/lldb/test/API/python_api/target/read-instructions-flavor/main.c
+++ b/lldb/test/API/python_api/target/read-instructions-flavor/main.c
@@ -1,0 +1,21 @@
+
+// This simple program is to test the lldb Python API SBTarget ReadInstruction
+// function.
+//
+// When the target is create we get all the instructions using the intel
+// flavor and see if it is correct.
+
+int test_add(int a, int b);
+
+__asm__("test_add:\n"
+        "    movl    %edi, %eax\n"
+        "    addl    %esi, %eax\n"
+        "    ret     \n");
+
+int main(int argc, char **argv) {
+  int a = 10;
+  int b = 20;
+  int result = test_add(a, b);
+
+  return 0;
+}


### PR DESCRIPTION
Backported #134626 to 20.X 