### PR TITLE
[IR] Don't skip `catchswitch` when calling `BB::getFirstNonPHIOrDbgOrAlloca()`

### DIFF
--- a/llvm/lib/IR/BasicBlock.cpp
+++ b/llvm/lib/IR/BasicBlock.cpp
@@ -455,7 +455,7 @@ BasicBlock::const_iterator BasicBlock::getFirstNonPHIOrDbgOrAlloca() const {
   if (InsertPt == end())
     return end();
 
-  if (InsertPt->isEHPad())
+  if (InsertPt->isEHPad() && !InsertPt->isTerminator())
     ++InsertPt;
 
   if (isEntryBlock()) {


### PR DESCRIPTION
`BasicBlock::getFirstNonPHIOrDbgOrAlloca()` is supposed to yield the first instruction in the block which is not a PHI or dbg or alloca instruction. To that effect, it also skips an EHPad instruction which might be present after any PHIs. Normally, the latter is fine, but it has an unexpected interaction with `catchswitch` blocks:

```llvm
bb:
    ; optional PHIs
    %0 = catchswitch within none [label %catch] unwind to caller
```

If we skip over the `catchswitch` instruction in the previous block, we'll return the end iterator, despite `catchswitch` not being a PHI or dbg or alloca instruction.

This patch amends the logic to not skip an EHPad instruction which is also a terminator. This means that calling
`getFirstNonPHIOrDbgOrAlloca()` on a non-empty block with a terminator (such as the above) will always yield a valid instruction iterator. This appears to be the expected behavior anyways, as most usages of this method do not check if the returned iterator is `end()`.

Closes #136048.