### PR TITLE
[RISCV] Check that both registers of a CV Reg-Reg memory address are GPRs.

### DIFF
--- a/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/llvm/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -2581,28 +2581,31 @@ ParseStatus RISCVAsmParser::parseRegReg(OperandVector &Operands) {
   if (getLexer().getKind() != AsmToken::Identifier)
     return ParseStatus::NoMatch;
 
+  SMLoc S = getLoc();
   StringRef OffsetRegName = getLexer().getTok().getIdentifier();
   MCRegister OffsetReg = matchRegisterNameHelper(OffsetRegName);
-  if (!OffsetReg)
-    return Error(getLoc(), "invalid register");
+  if (!OffsetReg ||
+      !RISCVMCRegisterClasses[RISCV::GPRRegClassID].contains(OffsetReg))
+    return Error(getLoc(), "expected GPR register");
   getLexer().Lex();
 
   if (parseToken(AsmToken::LParen, "expected '(' or invalid operand"))
     return ParseStatus::Failure;
 
   if (getLexer().getKind() != AsmToken::Identifier)
-    return Error(getLoc(), "expected register");
+    return Error(getLoc(), "expected GPR register");
 
   StringRef BaseRegName = getLexer().getTok().getIdentifier();
   MCRegister BaseReg = matchRegisterNameHelper(BaseRegName);
-  if (!BaseReg)
-    return Error(getLoc(), "invalid register");
+  if (!BaseReg ||
+      !RISCVMCRegisterClasses[RISCV::GPRRegClassID].contains(BaseReg))
+    return Error(getLoc(), "expected GPR register");
   getLexer().Lex();
 
   if (parseToken(AsmToken::RParen, "expected ')'"))
     return ParseStatus::Failure;
 
-  Operands.push_back(RISCVOperand::createRegReg(BaseReg, OffsetReg, getLoc()));
+  Operands.push_back(RISCVOperand::createRegReg(BaseReg, OffsetReg, S));
 
   return ParseStatus::Success;
 }

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXCV.td
@@ -17,8 +17,6 @@
 def CVrrAsmOperand : AsmOperandClass {
   let Name = "RegReg";
   let ParserMethod = "parseRegReg";
-  let DiagnosticType = "InvalidRegReg";
-  let DiagnosticString = "operands must be register and register";
 }
 
 def CVrr : Operand<i32>,

--- a/llvm/test/MC/RISCV/corev/XCVmem-invalid.s
+++ b/llvm/test/MC/RISCV/corev/XCVmem-invalid.s
@@ -2,7 +2,7 @@
 # RUN:        | FileCheck %s --check-prefixes=CHECK-ERROR
 
 cv.lb t0, (0), 0
-# CHECK-ERROR: :[[@LINE-1]]:11: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.lb 0, (t1), 0
 # CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
@@ -17,7 +17,7 @@ cv.lb t0, (t1), 2048
 # CHECK-ERROR: :[[@LINE-1]]:17: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 cv.lb t0, (0), t1
-# CHECK-ERROR: :[[@LINE-1]]:11: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.lb 0, (t1), t1
 # CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
@@ -32,7 +32,7 @@ cv.lb t0, (t1), t2, t3
 # CHECK-ERROR: :[[@LINE-1]]:21: error: invalid operand for instruction
 
 cv.lbu t0, (0), 0
-# CHECK-ERROR: :[[@LINE-1]]:12: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:12: error: invalid operand for instruction
 
 cv.lbu 0, (t1), 0
 # CHECK-ERROR: :[[@LINE-1]]:8: error: invalid operand for instruction
@@ -47,7 +47,7 @@ cv.lbu t0, (t1), 2048
 # CHECK-ERROR: :[[@LINE-1]]:18: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 cv.lbu t0, (0), t1
-# CHECK-ERROR: :[[@LINE-1]]:12: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:12: error: invalid operand for instruction
 
 cv.lbu 0, (t1), t1
 # CHECK-ERROR: :[[@LINE-1]]:8: error: invalid operand for instruction
@@ -62,7 +62,7 @@ cv.lbu t0, (t1), t2, t3
 # CHECK-ERROR: :[[@LINE-1]]:22: error: invalid operand for instruction
 
 cv.lh t0, (0), 0
-# CHECK-ERROR: :[[@LINE-1]]:11: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.lh 0, (t1), 0
 # CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
@@ -77,10 +77,10 @@ cv.lh t0, (t1), 2048
 # CHECK-ERROR: :[[@LINE-1]]:17: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 cv.lh t0, (0), t1
-# CHECK-ERROR: :[[@LINE-1]]:11: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.lh t0, t1(0)
-# CHECK-ERROR: :[[@LINE-1]]:14: error: expected register
+# CHECK-ERROR: :[[@LINE-1]]:14: error: expected GPR register
 
 cv.lh 0, (t1), t1
 # CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
@@ -95,7 +95,7 @@ cv.lh t0, (t1), t2, t3
 # CHECK-ERROR: :[[@LINE-1]]:21: error: invalid operand for instruction
 
 cv.lhu t0, (0), 0
-# CHECK-ERROR: :[[@LINE-1]]:12: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:12: error: invalid operand for instruction
 
 cv.lhu 0, (t1), 0
 # CHECK-ERROR: :[[@LINE-1]]:8: error: invalid operand for instruction
@@ -110,10 +110,10 @@ cv.lhu t0, (t1), 2048
 # CHECK-ERROR: :[[@LINE-1]]:18: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 cv.lhu t0, (0), t1
-# CHECK-ERROR: :[[@LINE-1]]:12: error: operands must be register and register 
+# CHECK-ERROR: :[[@LINE-1]]:12: error: invalid operand for instruction
 
 cv.lhu t0, t1(0)
-# CHECK-ERROR: :[[@LINE-1]]:15: error: expected register
+# CHECK-ERROR: :[[@LINE-1]]:15: error: expected GPR register
 
 cv.lhu 0, t0, t1
 # CHECK-ERROR: :[[@LINE-1]]:13: error: expected '(' or invalid operand
@@ -128,7 +128,7 @@ cv.lhu t0, (t1), t2, t3
 # CHECK-ERROR: :[[@LINE-1]]:22: error: invalid operand for instruction
 
 cv.lw t0, (0), 0
-# CHECK-ERROR: :[[@LINE-1]]:11: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.lw 0, (t1), 0
 # CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
@@ -143,10 +143,10 @@ cv.lw t0, (t1), 2048
 # CHECK-ERROR: :[[@LINE-1]]:17: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 cv.lw t0, (0), t1
-# CHECK-ERROR: :[[@LINE-1]]:11: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.lw t0, t1(0)
-# CHECK-ERROR: :[[@LINE-1]]:14: error: expected register
+# CHECK-ERROR: :[[@LINE-1]]:14: error: expected GPR register
 
 cv.lw 0, (t0), t1
 # CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
@@ -158,22 +158,22 @@ cv.lw t0, (t1)
 # CHECK-ERROR: :[[@LINE-1]]:1: error: too few operands for instruction
 
 cv.lw t0, (t1), t2, t3
-# CHECK-ERROR: :[[@LINE-1]]:21: error: invalid operand for instruction 
+# CHECK-ERROR: :[[@LINE-1]]:21: error: invalid operand for instruction
 
 cv.sb t0, (0), 0
-# CHECK-ERROR: :[[@LINE-1]]:11: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sb 0, (t0), 0
 # CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
 
 cv.sb t0, 0(t1)
-# CHECK-ERROR: :[[@LINE-1]]:11: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sb t0, (t1), 2048
 # CHECK-ERROR: :[[@LINE-1]]:17: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 cv.sb t0, (0), t1
-# CHECK-ERROR: :[[@LINE-1]]:11: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sb 0, (t1), t1
 # CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
@@ -182,19 +182,19 @@ cv.sb t0
 # CHECK-ERROR: :[[@LINE-1]]:1: error: too few operands for instruction
 
 cv.sh t0, (0), 0
-# CHECK-ERROR: :[[@LINE-1]]:11: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sh 0, (t1), 0
 # CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
 
 cv.sh t0, 0(t1)
-# CHECK-ERROR: :[[@LINE-1]]:11: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sh t0, (t1), 2048
 # CHECK-ERROR: :[[@LINE-1]]:17: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 cv.sh t0, (0), t1
-# CHECK-ERROR: :[[@LINE-1]]:11: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sh 0, (t1), t1
 # CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
@@ -203,22 +203,28 @@ cv.sh t0
 # CHECK-ERROR: :[[@LINE-1]]:1: error: too few operands for instruction
 
 cv.sw t0, (0), 0
-# CHECK-ERROR: :[[@LINE-1]]:11: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sw 0, (t1), 0
 # CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
 
 cv.sw t0, 0(t1)
-# CHECK-ERROR: :[[@LINE-1]]:11: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sw t0, (t1), 2048
 # CHECK-ERROR: :[[@LINE-1]]:17: error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo specifier or an integer in the range [-2048, 2047]
 
 cv.sw t0, (0), t1
-# CHECK-ERROR: :[[@LINE-1]]:11: error: operands must be register and register
+# CHECK-ERROR: :[[@LINE-1]]:11: error: invalid operand for instruction
 
 cv.sw 0, (t1), t1
 # CHECK-ERROR: :[[@LINE-1]]:7: error: invalid operand for instruction
 
 cv.sw t0
 # CHECK-ERROR: :[[@LINE-1]]:1: error: too few operands for instruction
+
+cv.lb t0, f0(t1)
+# CHECK-ERROR: :[[@LINE-1]]:11: error: expected GPR register
+
+cv.sb t0, t0(f1)
+# CHECK-ERROR: :[[@LINE-1]]:14: error: expected GPR register


### PR DESCRIPTION
The assembly parser was checking for any register instead of GPR.

I've removed the custom diagnostic message from the RegReg operand to give a less confusing error on bad input. The mnemonics are shared with other encodings that don't use reg-reg memory operand.

I also fixed the parsed operand location, but I'm not sure it matters.