### PR TITLE
[SPIRV] OpEnqueueKernel Instruction generation correction

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -1317,6 +1317,7 @@ void addInstrRequirements(const MachineInstr &MI,
   case SPIRV::OpTypeDeviceEvent:
   case SPIRV::OpTypeQueue:
   case SPIRV::OpBuildNDRange:
+  case SPIRV::OpEnqueueKernel:
     Reqs.addCapability(SPIRV::Capability::DeviceEnqueue);
     break;
   case SPIRV::OpDecorate:

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -486,6 +486,16 @@ bool isEntryPoint(const Function &F) {
   return false;
 }
 
+Register stripAddrspaceCast(Register Reg, const MachineRegisterInfo &MRI) {
+  while (true) {
+    MachineInstr *Def = MRI.getVRegDef(Reg);
+    if (!Def || Def->getOpcode() != TargetOpcode::G_ADDRSPACE_CAST)
+      break;
+    Reg = Def->getOperand(1).getReg(); // Unwrap the cast
+  }
+  return Reg;
+}
+
 Type *parseBasicTypeName(StringRef &TypeName, LLVMContext &Ctx) {
   TypeName.consume_front("atomic_");
   if (TypeName.consume_front("void"))

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -256,6 +256,9 @@ bool isSpecialOpaqueType(const Type *Ty);
 // Check if the function is an SPIR-V entry point
 bool isEntryPoint(const Function &F);
 
+// Strips all address space casts from the given register. 
+Register stripAddrspaceCast(Register Reg, const MachineRegisterInfo &MRI);
+
 // Parse basic scalar type name, substring TypeName, and return LLVM type.
 Type *parseBasicTypeName(StringRef &TypeName, LLVMContext &Ctx);
 


### PR DESCRIPTION
 - Handled cases where size and align are explicitly given inside Global_Value
 - Created a SpirvUtil function for stripping addresscast similar to in spirv-llvm translator
 
 Current code on running enqueue_kernel.ll (in transcoding) will give error:
```
 *** Bad machine code: Expected a register operand. ***
- function:    device_side_enqueue
- basic block: %bb.1 entry (0x5cfb73b3bcd8)
- instruction: %172:iid(s32) = OpEnqueueKernel %6:type(s64), %152:pid(p0), %153:iid(s32), %46:pid(p0), %48:iid(s32), %171:pid(p4), %155:pid(p4), @__device_side_enqueue_block_invoke_5_kernel, %168:pid(p4), %112:iid(s32), %86:iid(s32)
- operand 8:   @__device_side_enqueue_block_invoke_5_kernel
```
I have given the register as adduse now. 
Also in the getBlockStructInstr function used, currently no bitcast instructions are present in between. So assertion failure occurs everytime. I have handled that case also.

The test file for enqueue_kernel is marked as xfail. So should i modify the test also?