### PR TITLE
[clang-tidy][NFC] fix `clang-tidy` warnings in `clang-tools-extra/clang-tidy` directory

### DIFF
--- a/clang-tools-extra/clang-tidy/abseil/CleanupCtadCheck.cpp
+++ b/clang-tools-extra/clang-tidy/abseil/CleanupCtadCheck.cpp
@@ -21,9 +21,9 @@ using namespace ::clang::transformer;
 
 namespace clang::tidy::abseil {
 
-RewriteRuleWith<std::string> CleanupCtadCheckImpl() {
-  auto warning_message = cat("prefer absl::Cleanup's class template argument "
-                             "deduction pattern in C++17 and higher");
+RewriteRuleWith<std::string> cleanupCtadCheckImpl() {
+  auto WarningMessage = cat("prefer absl::Cleanup's class template argument "
+                            "deduction pattern in C++17 and higher");
 
   return makeRule(
       declStmt(hasSingleDecl(varDecl(
@@ -34,10 +34,10 @@ RewriteRuleWith<std::string> CleanupCtadCheckImpl() {
                   .bind("make_cleanup_call")))))),
       {changeTo(node("auto_type_loc"), cat("absl::Cleanup")),
        changeTo(node("make_cleanup_call"), cat(callArgs("make_cleanup_call")))},
-      warning_message);
+      WarningMessage);
 }
 
 CleanupCtadCheck::CleanupCtadCheck(StringRef Name, ClangTidyContext *Context)
-    : utils::TransformerClangTidyCheck(CleanupCtadCheckImpl(), Name, Context) {}
+    : utils::TransformerClangTidyCheck(cleanupCtadCheckImpl(), Name, Context) {}
 
 } // namespace clang::tidy::abseil

--- a/clang-tools-extra/clang-tidy/bugprone/BranchCloneCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/BranchCloneCheck.cpp
@@ -250,10 +250,10 @@ static bool isIdenticalStmt(const ASTContext &Ctx, const Stmt *Stmt1,
 
     if (!llvm::all_of(llvm::zip(CompStmt1->body(), CompStmt2->body()),
                       [&Ctx, IgnoreSideEffects](
-                          std::tuple<const Stmt *, const Stmt *> stmtPair) {
-                        const Stmt *stmt0 = std::get<0>(stmtPair);
-                        const Stmt *stmt1 = std::get<1>(stmtPair);
-                        return isIdenticalStmt(Ctx, stmt0, stmt1,
+                          std::tuple<const Stmt *, const Stmt *> StmtPair) {
+                        const Stmt *Stmt0 = std::get<0>(StmtPair);
+                        const Stmt *Stmt1 = std::get<1>(StmtPair);
+                        return isIdenticalStmt(Ctx, Stmt0, Stmt1,
                                                IgnoreSideEffects);
                       })) {
       return false;
@@ -477,7 +477,7 @@ void BranchCloneCheck::check(const MatchFinder::MatchResult &Result) {
 
   if (const auto *IS = Result.Nodes.getNodeAs<IfStmt>("ifWithDescendantIf")) {
     const Stmt *Then = IS->getThen();
-    auto CS = dyn_cast<CompoundStmt>(Then);
+    const auto *CS = dyn_cast<CompoundStmt>(Then);
     if (CS && (!CS->body_empty())) {
       const auto *InnerIf = dyn_cast<IfStmt>(*CS->body_begin());
       if (InnerIf && isIdenticalStmt(Context, IS->getCond(), InnerIf->getCond(),

--- a/clang-tools-extra/clang-tidy/bugprone/SignalHandlerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SignalHandlerCheck.cpp
@@ -301,7 +301,7 @@ bool isCXXOnlyStmt(const Stmt *S) {
 /// It is unspecified which call is found if multiple calls exist, but the order
 /// should be deterministic (depend only on the AST).
 Expr *findCallExpr(const CallGraphNode *Caller, const CallGraphNode *Callee) {
-  auto FoundCallee = llvm::find_if(
+  const auto *FoundCallee = llvm::find_if(
       Caller->callees(), [Callee](const CallGraphNode::CallRecord &Call) {
         return Call.Callee == Callee;
       });

--- a/clang-tools-extra/clang-tidy/bugprone/StandaloneEmptyCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/StandaloneEmptyCheck.cpp
@@ -99,8 +99,8 @@ void StandaloneEmptyCheck::check(const MatchFinder::MatchResult &Result) {
   if (Result.Nodes.getNodeAs<Expr>("parent"))
     return;
 
-  const auto PParentStmtExpr = Result.Nodes.getNodeAs<Expr>("stexpr");
-  const auto ParentCompStmt = Result.Nodes.getNodeAs<CompoundStmt>("parent");
+  const auto *PParentStmtExpr = Result.Nodes.getNodeAs<Expr>("stexpr");
+  const auto *ParentCompStmt = Result.Nodes.getNodeAs<CompoundStmt>("parent");
   const auto *ParentCond = getCondition(Result.Nodes, "parent");
   const auto *ParentReturnStmt = Result.Nodes.getNodeAs<ReturnStmt>("parent");
 

--- a/clang-tools-extra/clang-tidy/bugprone/StringviewNullptrCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/StringviewNullptrCheck.cpp
@@ -35,23 +35,23 @@ AST_MATCHER(clang::VarDecl, isDirectInitialization) {
 
 } // namespace
 
-RewriteRuleWith<std::string> StringviewNullptrCheckImpl() {
-  auto construction_warning =
+RewriteRuleWith<std::string> stringviewNullptrCheckImpl() {
+  auto ConstructionWarning =
       cat("constructing basic_string_view from null is undefined; replace with "
           "the default constructor");
-  auto static_cast_warning =
+  auto StaticCastWarning =
       cat("casting to basic_string_view from null is undefined; replace with "
           "the empty string");
-  auto argument_construction_warning =
+  auto ArgumentConstructionWarning =
       cat("passing null as basic_string_view is undefined; replace with the "
           "empty string");
-  auto assignment_warning =
+  auto AssignmentWarning =
       cat("assignment to basic_string_view from null is undefined; replace "
           "with the default constructor");
-  auto relative_comparison_warning =
+  auto RelativeComparisonWarning =
       cat("comparing basic_string_view to null is undefined; replace with the "
           "empty string");
-  auto equality_comparison_warning =
+  auto EqualityComparisonWarning =
       cat("comparing basic_string_view to null is undefined; replace with the "
           "emptiness query");
 
@@ -84,7 +84,7 @@ RewriteRuleWith<std::string> StringviewNullptrCheckImpl() {
   auto HandleTemporaryCXXFunctionalCastExpr =
       makeRule(cxxFunctionalCastExpr(hasSourceExpression(
                    BasicStringViewConstructingFromNullExpr)),
-               remove(node("null_arg_expr")), construction_warning);
+               remove(node("null_arg_expr")), ConstructionWarning);
 
   // `std::string_view{null_arg_expr}` and `(std::string_view){null_arg_expr}`
   auto HandleTemporaryCXXTemporaryObjectExprAndCompoundLiteralExpr = makeRule(
@@ -93,28 +93,28 @@ RewriteRuleWith<std::string> StringviewNullptrCheckImpl() {
           hasAnyArgument(/* `hasArgument` would skip over parens */ anyOf(
               NullLiteral, NullInitList, EmptyInitList)),
           has(expr().bind("null_arg_expr")))),
-      remove(node("null_arg_expr")), construction_warning);
+      remove(node("null_arg_expr")), ConstructionWarning);
 
   // `(std::string_view) null_arg_expr`
-  auto HandleTemporaryCStyleCastExpr = makeRule(
-      cStyleCastExpr(
-          hasSourceExpression(BasicStringViewConstructingFromNullExpr)),
-      changeTo(node("null_arg_expr"), cat("{}")), construction_warning);
+  auto HandleTemporaryCStyleCastExpr =
+      makeRule(cStyleCastExpr(hasSourceExpression(
+                   BasicStringViewConstructingFromNullExpr)),
+               changeTo(node("null_arg_expr"), cat("{}")), ConstructionWarning);
 
   // `static_cast<std::string_view>(null_arg_expr)`
-  auto HandleTemporaryCXXStaticCastExpr = makeRule(
-      cxxStaticCastExpr(
-          hasSourceExpression(BasicStringViewConstructingFromNullExpr)),
-      changeTo(node("null_arg_expr"), cat("\"\"")), static_cast_warning);
+  auto HandleTemporaryCXXStaticCastExpr =
+      makeRule(cxxStaticCastExpr(hasSourceExpression(
+                   BasicStringViewConstructingFromNullExpr)),
+               changeTo(node("null_arg_expr"), cat("\"\"")), StaticCastWarning);
 
   // `std::string_view sv = null_arg_expr;`
-  auto HandleStackCopyInitialization = makeRule(
-      varDecl(HasBasicStringViewType,
-              hasInitializer(ignoringImpCasts(
-                  cxxConstructExpr(BasicStringViewConstructingFromNullExpr,
-                                   unless(isListInitialization())))),
-              unless(isDirectInitialization())),
-      changeTo(node("null_arg_expr"), cat("{}")), construction_warning);
+  auto HandleStackCopyInitialization =
+      makeRule(varDecl(HasBasicStringViewType,
+                       hasInitializer(ignoringImpCasts(cxxConstructExpr(
+                           BasicStringViewConstructingFromNullExpr,
+                           unless(isListInitialization())))),
+                       unless(isDirectInitialization())),
+               changeTo(node("null_arg_expr"), cat("{}")), ConstructionWarning);
 
   // `std::string_view sv = {null_arg_expr};`
   auto HandleStackCopyListInitialization =
@@ -123,7 +123,7 @@ RewriteRuleWith<std::string> StringviewNullptrCheckImpl() {
                            BasicStringViewConstructingFromNullExpr,
                            isListInitialization())),
                        unless(isDirectInitialization())),
-               remove(node("null_arg_expr")), construction_warning);
+               remove(node("null_arg_expr")), ConstructionWarning);
 
   // `std::string_view sv(null_arg_expr);`
   auto HandleStackDirectInitialization =
@@ -134,7 +134,7 @@ RewriteRuleWith<std::string> StringviewNullptrCheckImpl() {
                        isDirectInitialization())
                    .bind("var_decl"),
                changeTo(node("construct_expr"), cat(name("var_decl"))),
-               construction_warning);
+               ConstructionWarning);
 
   // `std::string_view sv{null_arg_expr};`
   auto HandleStackDirectListInitialization =
@@ -143,7 +143,7 @@ RewriteRuleWith<std::string> StringviewNullptrCheckImpl() {
                            BasicStringViewConstructingFromNullExpr,
                            isListInitialization())),
                        isDirectInitialization()),
-               remove(node("null_arg_expr")), construction_warning);
+               remove(node("null_arg_expr")), ConstructionWarning);
 
   // `struct S { std::string_view sv = null_arg_expr; };`
   auto HandleFieldInClassCopyInitialization = makeRule(
@@ -151,7 +151,7 @@ RewriteRuleWith<std::string> StringviewNullptrCheckImpl() {
                 hasInClassInitializer(ignoringImpCasts(
                     cxxConstructExpr(BasicStringViewConstructingFromNullExpr,
                                      unless(isListInitialization()))))),
-      changeTo(node("null_arg_expr"), cat("{}")), construction_warning);
+      changeTo(node("null_arg_expr"), cat("{}")), ConstructionWarning);
 
   // `struct S { std::string_view sv = {null_arg_expr}; };` and
   // `struct S { std::string_view sv{null_arg_expr}; };`
@@ -160,7 +160,7 @@ RewriteRuleWith<std::string> StringviewNullptrCheckImpl() {
                 hasInClassInitializer(ignoringImpCasts(
                     cxxConstructExpr(BasicStringViewConstructingFromNullExpr,
                                      isListInitialization())))),
-      remove(node("null_arg_expr")), construction_warning);
+      remove(node("null_arg_expr")), ConstructionWarning);
 
   // `class C { std::string_view sv; C() : sv(null_arg_expr) {} };`
   auto HandleConstructorDirectInitialization =
@@ -168,7 +168,7 @@ RewriteRuleWith<std::string> StringviewNullptrCheckImpl() {
                                   withInitializer(cxxConstructExpr(
                                       BasicStringViewConstructingFromNullExpr,
                                       unless(isListInitialization())))),
-               remove(node("null_arg_expr")), construction_warning);
+               remove(node("null_arg_expr")), ConstructionWarning);
 
   // `class C { std::string_view sv; C() : sv{null_arg_expr} {} };`
   auto HandleConstructorDirectListInitialization =
@@ -176,15 +176,15 @@ RewriteRuleWith<std::string> StringviewNullptrCheckImpl() {
                                   withInitializer(cxxConstructExpr(
                                       BasicStringViewConstructingFromNullExpr,
                                       isListInitialization()))),
-               remove(node("null_arg_expr")), construction_warning);
+               remove(node("null_arg_expr")), ConstructionWarning);
 
   // `void f(std::string_view sv = null_arg_expr);`
-  auto HandleDefaultArgumentCopyInitialization = makeRule(
-      parmVarDecl(HasBasicStringViewType,
-                  hasInitializer(ignoringImpCasts(
-                      cxxConstructExpr(BasicStringViewConstructingFromNullExpr,
-                                       unless(isListInitialization()))))),
-      changeTo(node("null_arg_expr"), cat("{}")), construction_warning);
+  auto HandleDefaultArgumentCopyInitialization =
+      makeRule(parmVarDecl(HasBasicStringViewType,
+                           hasInitializer(ignoringImpCasts(cxxConstructExpr(
+                               BasicStringViewConstructingFromNullExpr,
+                               unless(isListInitialization()))))),
+               changeTo(node("null_arg_expr"), cat("{}")), ConstructionWarning);
 
   // `void f(std::string_view sv = {null_arg_expr});`
   auto HandleDefaultArgumentCopyListInitialization =
@@ -192,21 +192,21 @@ RewriteRuleWith<std::string> StringviewNullptrCheckImpl() {
                            hasInitializer(cxxConstructExpr(
                                BasicStringViewConstructingFromNullExpr,
                                isListInitialization()))),
-               remove(node("null_arg_expr")), construction_warning);
+               remove(node("null_arg_expr")), ConstructionWarning);
 
   // `new std::string_view(null_arg_expr)`
   auto HandleHeapDirectInitialization = makeRule(
       cxxNewExpr(has(cxxConstructExpr(BasicStringViewConstructingFromNullExpr,
                                       unless(isListInitialization()))),
                  unless(isArray()), unless(hasAnyPlacementArg(anything()))),
-      remove(node("null_arg_expr")), construction_warning);
+      remove(node("null_arg_expr")), ConstructionWarning);
 
   // `new std::string_view{null_arg_expr}`
   auto HandleHeapDirectListInitialization = makeRule(
       cxxNewExpr(has(cxxConstructExpr(BasicStringViewConstructingFromNullExpr,
                                       isListInitialization())),
                  unless(isArray()), unless(hasAnyPlacementArg(anything()))),
-      remove(node("null_arg_expr")), construction_warning);
+      remove(node("null_arg_expr")), ConstructionWarning);
 
   // `function(null_arg_expr)`
   auto HandleFunctionArgumentInitialization =
@@ -214,22 +214,21 @@ RewriteRuleWith<std::string> StringviewNullptrCheckImpl() {
                             BasicStringViewConstructingFromNullExpr)),
                         unless(cxxOperatorCallExpr())),
                changeTo(node("construct_expr"), cat("\"\"")),
-               argument_construction_warning);
+               ArgumentConstructionWarning);
 
   // `sv = null_arg_expr`
   auto HandleAssignment = makeRule(
       cxxOperatorCallExpr(hasOverloadedOperatorName("="),
                           hasRHS(materializeTemporaryExpr(
                               has(BasicStringViewConstructingFromNullExpr)))),
-      changeTo(node("construct_expr"), cat("{}")), assignment_warning);
+      changeTo(node("construct_expr"), cat("{}")), AssignmentWarning);
 
   // `sv < null_arg_expr`
   auto HandleRelativeComparison = makeRule(
       cxxOperatorCallExpr(hasAnyOverloadedOperatorName("<", "<=", ">", ">="),
                           hasEitherOperand(ignoringImpCasts(
                               BasicStringViewConstructingFromNullExpr))),
-      changeTo(node("construct_expr"), cat("\"\"")),
-      relative_comparison_warning);
+      changeTo(node("construct_expr"), cat("\"\"")), RelativeComparisonWarning);
 
   // `sv == null_arg_expr`
   auto HandleEmptyEqualityComparison = makeRule(
@@ -240,7 +239,7 @@ RewriteRuleWith<std::string> StringviewNullptrCheckImpl() {
                                expr().bind("instance"))))
           .bind("root"),
       changeTo(node("root"), cat(access("instance", cat("empty")), "()")),
-      equality_comparison_warning);
+      EqualityComparisonWarning);
 
   // `sv != null_arg_expr`
   auto HandleNonEmptyEqualityComparison = makeRule(
@@ -251,13 +250,13 @@ RewriteRuleWith<std::string> StringviewNullptrCheckImpl() {
                                expr().bind("instance"))))
           .bind("root"),
       changeTo(node("root"), cat("!", access("instance", cat("empty")), "()")),
-      equality_comparison_warning);
+      EqualityComparisonWarning);
 
   // `return null_arg_expr;`
   auto HandleReturnStatement = makeRule(
       returnStmt(hasReturnValue(
           ignoringImpCasts(BasicStringViewConstructingFromNullExpr))),
-      changeTo(node("construct_expr"), cat("{}")), construction_warning);
+      changeTo(node("construct_expr"), cat("{}")), ConstructionWarning);
 
   // `T(null_arg_expr)`
   auto HandleConstructorInvocation =
@@ -267,7 +266,7 @@ RewriteRuleWith<std::string> StringviewNullptrCheckImpl() {
                                       BasicStringViewConstructingFromNullExpr)),
                    unless(HasBasicStringViewType)),
                changeTo(node("construct_expr"), cat("\"\"")),
-               argument_construction_warning);
+               ArgumentConstructionWarning);
 
   return applyFirst(
       {HandleTemporaryCXXFunctionalCastExpr,
@@ -297,7 +296,7 @@ RewriteRuleWith<std::string> StringviewNullptrCheckImpl() {
 
 StringviewNullptrCheck::StringviewNullptrCheck(StringRef Name,
                                                ClangTidyContext *Context)
-    : utils::TransformerClangTidyCheck(StringviewNullptrCheckImpl(), Name,
+    : utils::TransformerClangTidyCheck(stringviewNullptrCheckImpl(), Name,
                                        Context) {}
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/clang-tidy/bugprone/TaggedUnionMemberCountCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/TaggedUnionMemberCountCheck.cpp
@@ -52,9 +52,8 @@ AST_MATCHER_P2(RecordDecl, fieldCountOfKindIsOne,
     if (InnerMatcher.matches(*Field, Finder, &TempBuilder)) {
       if (FirstMatch) {
         return false;
-      } else {
-        FirstMatch = Field;
       }
+      FirstMatch = Field;
     }
   }
 
@@ -112,11 +111,11 @@ void TaggedUnionMemberCountCheck::registerMatchers(MatchFinder *Finder) {
   auto EnumField = fieldDecl(hasType(
       qualType(hasCanonicalType(enumType(hasDeclaration(enumDecl()))))));
 
-  auto hasOneUnionField = fieldCountOfKindIsOne(UnionField, UnionMatchBindName);
-  auto hasOneEnumField = fieldCountOfKindIsOne(EnumField, TagMatchBindName);
+  auto HasOneUnionField = fieldCountOfKindIsOne(UnionField, UnionMatchBindName);
+  auto HasOneEnumField = fieldCountOfKindIsOne(EnumField, TagMatchBindName);
 
-  Finder->addMatcher(recordDecl(anyOf(isStruct(), isClass()), hasOneUnionField,
-                                hasOneEnumField, unless(isImplicit()))
+  Finder->addMatcher(recordDecl(anyOf(isStruct(), isClass()), HasOneUnionField,
+                                HasOneEnumField, unless(isImplicit()))
                          .bind(RootMatchBindName),
                      this);
 }

--- a/clang-tools-extra/clang-tidy/hicpp/NoAssemblerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/hicpp/NoAssemblerCheck.cpp
@@ -18,7 +18,7 @@ namespace {
 AST_MATCHER(VarDecl, isAsm) { return Node.hasAttr<clang::AsmLabelAttr>(); }
 const ast_matchers::internal::VariadicDynCastAllOfMatcher<Decl,
                                                           FileScopeAsmDecl>
-    fileScopeAsmDecl;
+    fileScopeAsmDecl; // NOLINT(readability-identifier-*) preserve clang style
 } // namespace
 
 void NoAssemblerCheck::registerMatchers(MatchFinder *Finder) {

--- a/clang-tools-extra/clang-tidy/misc/ConfusableIdentifierCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ConfusableIdentifierCheck.cpp
@@ -66,9 +66,9 @@ static llvm::SmallString<64U> skeleton(StringRef Name) {
     }
 
     StringRef Key(Prev, Curr - Prev);
-    auto Where = llvm::lower_bound(ConfusableEntries, CodePoint,
-                                   [](decltype(ConfusableEntries[0]) x,
-                                      UTF32 y) { return x.codepoint < y; });
+    auto *Where = llvm::lower_bound(ConfusableEntries, CodePoint,
+                                    [](decltype(ConfusableEntries[0]) X,
+                                       UTF32 Y) { return X.codepoint < Y; });
     if (Where == std::end(ConfusableEntries) || CodePoint != Where->codepoint) {
       Skeleton.append(Prev, Curr);
     } else {

--- a/clang-tools-extra/clang-tidy/misc/ConfusableTable/BuildConfusableTable.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ConfusableTable/BuildConfusableTable.cpp
@@ -20,7 +20,7 @@ int main(int argc, char *argv[]) {
     return 1;
   std::unique_ptr<MemoryBuffer> Buffer = std::move(ErrorOrBuffer.get());
   StringRef Content = Buffer->getBuffer();
-  Content = Content.drop_until([](char c) { return c == '#'; });
+  Content = Content.drop_until([](char C) { return C == '#'; });
   SmallVector<StringRef> Lines;
   SplitString(Content, Lines, "\r\n");
 
@@ -44,9 +44,9 @@ int main(int argc, char *argv[]) {
     SmallVector<llvm::UTF32> To;
     SmallVector<StringRef> ToN;
     Values[1].split(ToN, ' ', -1, false);
-    for (StringRef To_ : ToN) {
+    for (StringRef ToI : ToN) {
       llvm::UTF32 ToCodePoint = 0;
-      To_.trim().getAsInteger(16, ToCodePoint);
+      ToI.trim().getAsInteger(16, ToCodePoint);
       To.push_back(ToCodePoint);
     }
     // Sentinel
@@ -63,23 +63,23 @@ int main(int argc, char *argv[]) {
                        })
           ->second.size();
 
-  std::error_code ec;
-  llvm::raw_fd_ostream os(argv[2], ec);
+  std::error_code Ec;
+  llvm::raw_fd_ostream Os(argv[2], Ec);
 
   // FIXME: If memory consumption and/or lookup time becomes a constraint, it
   // maybe worth using a more elaborate data structure.
-  os << "struct {llvm::UTF32 codepoint; llvm::UTF32 values[" << LargestValue
+  Os << "struct {llvm::UTF32 codepoint; llvm::UTF32 values[" << LargestValue
      << "];} "
         "ConfusableEntries[] = {\n";
   for (const auto &Values : Entries) {
-    os << "  { ";
-    os << Values.first;
-    os << ", {";
+    Os << "  { ";
+    Os << Values.first;
+    Os << ", {";
     for (auto CP : Values.second)
-      os << CP << ", ";
+      Os << CP << ", ";
 
-    os << "}},\n";
+    Os << "}},\n";
   }
-  os << "};\n";
+  Os << "};\n";
   return 0;
 }

--- a/clang-tools-extra/clang-tidy/modernize/MacroToEnumCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/MacroToEnumCheck.cpp
@@ -321,8 +321,8 @@ bool MacroToEnumCallbacks::isInitializer(ArrayRef<Token> MacroTokens)
 {
   IntegralLiteralExpressionMatcher Matcher(MacroTokens, LangOpts.C99 == 0);
   bool Matched = Matcher.match();
-  bool isC = !LangOpts.CPlusPlus;
-  if (isC && (Matcher.largestLiteralSize() != LiteralSize::Int &&
+  bool IsC = !LangOpts.CPlusPlus;
+  if (IsC && (Matcher.largestLiteralSize() != LiteralSize::Int &&
               Matcher.largestLiteralSize() != LiteralSize::UnsignedInt))
     return false;
 
@@ -375,7 +375,7 @@ void MacroToEnumCallbacks::MacroUndefined(const Token &MacroNameTok,
     return getTokenName(Macro.Name) == getTokenName(MacroNameTok);
   };
 
-  auto It = llvm::find_if(Enums, [MatchesToken](const MacroList &MacroList) {
+  auto *It = llvm::find_if(Enums, [MatchesToken](const MacroList &MacroList) {
     return llvm::any_of(MacroList, MatchesToken);
   });
   if (It != Enums.end())

--- a/clang-tools-extra/clang-tidy/objc/AssertEquals.cpp
+++ b/clang-tools-extra/clang-tidy/objc/AssertEquals.cpp
@@ -16,44 +16,44 @@ using namespace clang::ast_matchers;
 namespace clang::tidy::objc {
 
 // Mapping from `XCTAssert*Equal` to `XCTAssert*EqualObjects` name.
-static const std::map<std::string, std::string> &NameMap() {
-  static std::map<std::string, std::string> map{
+static const std::map<std::string, std::string> &nameMap() {
+  static std::map<std::string, std::string> Map{
       {"XCTAssertEqual", "XCTAssertEqualObjects"},
       {"XCTAssertNotEqual", "XCTAssertNotEqualObjects"},
 
   };
-  return map;
+  return Map;
 }
 
-void AssertEquals::registerMatchers(MatchFinder *finder) {
-  for (const auto &pair : NameMap()) {
-    finder->addMatcher(
+void AssertEquals::registerMatchers(MatchFinder *Finder) {
+  for (const auto &Pair : nameMap()) {
+    Finder->addMatcher(
         binaryOperator(anyOf(hasOperatorName("!="), hasOperatorName("==")),
-                       isExpandedFromMacro(pair.first),
+                       isExpandedFromMacro(Pair.first),
                        anyOf(hasLHS(hasType(qualType(
                                  hasCanonicalType(asString("NSString *"))))),
                              hasRHS(hasType(qualType(
                                  hasCanonicalType(asString("NSString *"))))))
 
                            )
-            .bind(pair.first),
+            .bind(Pair.first),
         this);
   }
 }
 
-void AssertEquals::check(const ast_matchers::MatchFinder::MatchResult &result) {
-  for (const auto &pair : NameMap()) {
-    if (const auto *root = result.Nodes.getNodeAs<BinaryOperator>(pair.first)) {
-      SourceManager *sm = result.SourceManager;
+void AssertEquals::check(const ast_matchers::MatchFinder::MatchResult &Result) {
+  for (const auto &Pair : nameMap()) {
+    if (const auto *Root = Result.Nodes.getNodeAs<BinaryOperator>(Pair.first)) {
+      SourceManager *Sm = Result.SourceManager;
       // The macros are nested two levels, so going up twice.
-      auto macro_callsite = sm->getImmediateMacroCallerLoc(
-          sm->getImmediateMacroCallerLoc(root->getBeginLoc()));
-      diag(macro_callsite, "use " + pair.second + " for comparing objects")
+      auto MacroCallsite = Sm->getImmediateMacroCallerLoc(
+          Sm->getImmediateMacroCallerLoc(Root->getBeginLoc()));
+      diag(MacroCallsite, "use " + Pair.second + " for comparing objects")
           << FixItHint::CreateReplacement(
                  clang::CharSourceRange::getCharRange(
-                     macro_callsite,
-                     macro_callsite.getLocWithOffset(pair.first.length())),
-                 pair.second);
+                     MacroCallsite,
+                     MacroCallsite.getLocWithOffset(Pair.first.length())),
+                 Pair.second);
     }
   }
 }

--- a/clang-tools-extra/clang-tidy/performance/MoveConstArgCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/MoveConstArgCheck.cpp
@@ -78,7 +78,7 @@ void MoveConstArgCheck::registerMatchers(MatchFinder *Finder) {
       this);
 }
 
-bool IsRValueReferenceParam(const Expr *Invocation,
+bool isRValueReferenceParam(const Expr *Invocation,
                             const QualType *InvocationParmType,
                             const Expr *Arg) {
   if (Invocation && (*InvocationParmType)->isRValueReferenceType() &&
@@ -147,7 +147,7 @@ void MoveConstArgCheck::check(const MatchFinder::MatchResult &Result) {
     // std::move shouldn't be removed when an lvalue wrapped by std::move is
     // passed to the function with an rvalue reference parameter.
     bool IsRVRefParam =
-        IsRValueReferenceParam(ReceivingExpr, InvocationParmType, Arg);
+        isRValueReferenceParam(ReceivingExpr, InvocationParmType, Arg);
     const auto *Var =
         IsVariable ? dyn_cast<DeclRefExpr>(Arg)->getDecl() : nullptr;
 

--- a/clang-tools-extra/clang-tidy/portability/StdAllocatorConstCheck.cpp
+++ b/clang-tools-extra/clang-tidy/portability/StdAllocatorConstCheck.cpp
@@ -15,12 +15,12 @@ namespace clang::tidy::portability {
 
 void StdAllocatorConstCheck::registerMatchers(MatchFinder *Finder) {
   // Match std::allocator<const T>.
-  auto allocatorConst =
+  auto AllocatorConst =
       recordType(hasDeclaration(classTemplateSpecializationDecl(
           hasName("::std::allocator"),
           hasTemplateArgument(0, refersToType(qualType(isConstQualified()))))));
 
-  auto hasContainerName =
+  auto HasContainerName =
       hasAnyName("::std::vector", "::std::deque", "::std::list",
                  "::std::multiset", "::std::set", "::std::unordered_multiset",
                  "::std::unordered_set", "::absl::flat_hash_set");
@@ -34,17 +34,17 @@ void StdAllocatorConstCheck::registerMatchers(MatchFinder *Finder) {
           templateSpecializationTypeLoc(),
           loc(hasUnqualifiedDesugaredType(anyOf(
               recordType(hasDeclaration(classTemplateSpecializationDecl(
-                  hasContainerName,
+                  HasContainerName,
                   anyOf(
-                      hasTemplateArgument(1, refersToType(allocatorConst)),
-                      hasTemplateArgument(2, refersToType(allocatorConst)),
-                      hasTemplateArgument(3, refersToType(allocatorConst)))))),
+                      hasTemplateArgument(1, refersToType(AllocatorConst)),
+                      hasTemplateArgument(2, refersToType(AllocatorConst)),
+                      hasTemplateArgument(3, refersToType(AllocatorConst)))))),
               // Match std::vector<const dependent>
               templateSpecializationType(
                   templateArgumentCountIs(1),
                   hasTemplateArgument(
                       0, refersToType(qualType(isConstQualified()))),
-                  hasDeclaration(namedDecl(hasContainerName)))))))
+                  hasDeclaration(namedDecl(HasContainerName)))))))
           .bind("type_loc"),
       this);
 }

--- a/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
+++ b/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
@@ -33,7 +33,7 @@
 using namespace clang::tooling;
 using namespace llvm;
 
-static cl::desc desc(StringRef description) { return {description.ltrim()}; }
+static cl::desc desc(StringRef Description) { return {Description.ltrim()}; }
 
 static cl::OptionCategory ClangTidyCategory("clang-tidy options");
 

--- a/clang-tools-extra/clang-tidy/utils/ExceptionAnalyzer.cpp
+++ b/clang-tools-extra/clang-tidy/utils/ExceptionAnalyzer.cpp
@@ -209,12 +209,14 @@ bool isQualificationConvertiblePointer(QualType From, QualType To,
   // cv-decomposition of T, that is, cv_1, cv_2, ... , cv_n, is called the
   // cv-qualification signature of T.
 
-  auto isValidP_i = [](QualType P) {
+  // NOLINTNEXTLINE (readability-identifier-naming): Preserve original notation
+  auto IsValidP_i = [](QualType P) {
     return P->isPointerType() || P->isMemberPointerType() ||
            P->isConstantArrayType() || P->isIncompleteArrayType();
   };
 
-  auto isSameP_i = [](QualType P1, QualType P2) {
+  // NOLINTNEXTLINE (readability-identifier-naming): Preserve original notation
+  auto IsSameP_i = [](QualType P1, QualType P2) {
     if (P1->isPointerType())
       return P2->isPointerType();
 
@@ -273,7 +275,7 @@ bool isQualificationConvertiblePointer(QualType From, QualType To,
     return true;
   };
 
-  while (isValidP_i(From) && isValidP_i(To)) {
+  while (IsValidP_i(From) && IsValidP_i(To)) {
     // Remove every sugar.
     From = From.getCanonicalType();
     To = To.getCanonicalType();
@@ -281,7 +283,7 @@ bool isQualificationConvertiblePointer(QualType From, QualType To,
     if (!SatisfiesCVRules(From, To))
       return false;
 
-    if (!isSameP_i(From, To)) {
+    if (!IsSameP_i(From, To)) {
       if (LangOpts.CPlusPlus20) {
         if (From->isConstantArrayType() && !To->isIncompleteArrayType())
           return false;
@@ -309,7 +311,7 @@ bool isQualificationConvertiblePointer(QualType From, QualType To,
   }
 
   // In this case the length (n) of From and To are not the same.
-  if (isValidP_i(From) || isValidP_i(To))
+  if (IsValidP_i(From) || IsValidP_i(To))
     return false;
 
   // We hit U.
@@ -337,7 +339,7 @@ static bool canThrow(const FunctionDecl *Func) {
   case CT_Dependent: {
     const Expr *NoexceptExpr = FunProto->getNoexceptExpr();
     if (!NoexceptExpr)
-      return true; // no noexept - can throw
+      return true; // no noexcept - can throw
 
     if (NoexceptExpr->isValueDependent())
       return true; // depend on template - some instance can throw
@@ -569,7 +571,7 @@ ExceptionAnalyzer::ExceptionInfo ExceptionAnalyzer::throwsException(
     Results.merge(throwsException(Coro->getExceptionHandler(),
                                   Excs.getExceptionTypes(), CallStack));
     for (const Type *Throwable : Excs.getExceptionTypes()) {
-      if (const auto ThrowableRec = Throwable->getAsCXXRecordDecl()) {
+      if (const auto *ThrowableRec = Throwable->getAsCXXRecordDecl()) {
         ExceptionInfo DestructorExcs =
             throwsException(ThrowableRec->getDestructor(), Caught, CallStack);
         Results.merge(DestructorExcs);

--- a/clang-tools-extra/clang-tidy/utils/ExprSequence.cpp
+++ b/clang-tools-extra/clang-tidy/utils/ExprSequence.cpp
@@ -71,12 +71,12 @@ bool isDescendantOfArgs(const Stmt *Descendant, const CallExpr *Call,
 
 llvm::SmallVector<const InitListExpr *>
 getAllInitListForms(const InitListExpr *InitList) {
-  llvm::SmallVector<const InitListExpr *> result = {InitList};
+  llvm::SmallVector<const InitListExpr *> Result = {InitList};
   if (const InitListExpr *AltForm = InitList->getSyntacticForm())
-    result.push_back(AltForm);
+    Result.push_back(AltForm);
   if (const InitListExpr *AltForm = InitList->getSemanticForm())
-    result.push_back(AltForm);
-  return result;
+    Result.push_back(AltForm);
+  return Result;
 }
 
 } // namespace


### PR DESCRIPTION
Mostly stylistic changes to `clang-tidy` source code.

Command run:
`python3 clang-tools-extra/clang-tidy/tool/run-clang-tidy.py -p build/ -j $(nproc) clang-tools-extra/clang-tidy`