### PR TITLE
[libc++] Use __array_rank in Clang versions without any known bugs

### DIFF
--- a/libcxx/include/__type_traits/rank.h
+++ b/libcxx/include/__type_traits/rank.h
@@ -19,11 +19,11 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-// TODO: Enable using the builtin __array_rank when https://llvm.org/PR57133 is resolved
-#if __has_builtin(__array_rank) && 0
+#if __has_builtin(__array_rank) && !defined(_LIBCPP_COMPILER_CLANG_BASED) ||                                           \
+    (defined(_LIBCPP_CLANG_VER) && _LIBCPP_CLANG_VER >= 2001)
 
 template <class _Tp>
-struct rank : integral_constant<size_t, __array_rank(_Tp)> {};
+struct _LIBCPP_NO_SPECIALIZATIONS rank : integral_constant<size_t, __array_rank(_Tp)> {};
 
 #else
 


### PR DESCRIPTION
There was a bug in the implementation of `__array_rank` until LLVM 20 which prevented us from using the builtin. Since the bug has been fixed now we can enable the use and remove the generic implementation in a few releases.
