### PR TITLE
[Mips] Guard emission of CFI instructions by `MF.needsFrameMoves()`

### DIFF
--- a/llvm/lib/Target/Mips/Mips16FrameLowering.cpp
+++ b/llvm/lib/Target/Mips/Mips16FrameLowering.cpp
@@ -53,13 +53,11 @@ void Mips16FrameLowering::emitPrologue(MachineFunction &MF,
   // Adjust stack.
   TII.makeFrame(Mips::SP, StackSize, MBB, MBBI);
 
-  CFIInstBuilder CFIBuilder(MBB, MBBI, MachineInstr::NoFlags);
-  CFIBuilder.buildDefCFAOffset(StackSize);
+  if (MF.needsFrameMoves()) {
+    CFIInstBuilder CFIBuilder(MBB, MBBI, MachineInstr::NoFlags);
+    CFIBuilder.buildDefCFAOffset(StackSize);
 
-  const std::vector<CalleeSavedInfo> &CSI = MFI.getCalleeSavedInfo();
-
-  if (!CSI.empty()) {
-    for (const CalleeSavedInfo &I : CSI)
+    for (const CalleeSavedInfo &I : MFI.getCalleeSavedInfo())
       CFIBuilder.buildOffset(I.getReg(), MFI.getObjectOffset(I.getFrameIdx()));
   }
 

--- a/llvm/test/CodeGen/Mips/analyzebranch.ll
+++ b/llvm/test/CodeGen/Mips/analyzebranch.ll
@@ -167,11 +167,10 @@ define void @f1(float %f) nounwind {
 ; MIPS32-LABEL: f1:
 ; MIPS32:       # %bb.0: # %entry
 ; MIPS32-NEXT:    addiu $sp, $sp, -24
-; MIPS32-NEXT:    sw $ra, 20($sp) # 4-byte Folded Spill
 ; MIPS32-NEXT:    mtc1 $zero, $f0
 ; MIPS32-NEXT:    c.eq.s $f12, $f0
 ; MIPS32-NEXT:    bc1f $BB1_2
-; MIPS32-NEXT:    nop
+; MIPS32-NEXT:    sw $ra, 20($sp)
 ; MIPS32-NEXT:  # %bb.1: # %if.end
 ; MIPS32-NEXT:    jal f2
 ; MIPS32-NEXT:    nop
@@ -185,11 +184,10 @@ define void @f1(float %f) nounwind {
 ; MIPS32R2-LABEL: f1:
 ; MIPS32R2:       # %bb.0: # %entry
 ; MIPS32R2-NEXT:    addiu $sp, $sp, -24
-; MIPS32R2-NEXT:    sw $ra, 20($sp) # 4-byte Folded Spill
 ; MIPS32R2-NEXT:    mtc1 $zero, $f0
 ; MIPS32R2-NEXT:    c.eq.s $f12, $f0
 ; MIPS32R2-NEXT:    bc1f $BB1_2
-; MIPS32R2-NEXT:    nop
+; MIPS32R2-NEXT:    sw $ra, 20($sp)
 ; MIPS32R2-NEXT:  # %bb.1: # %if.end
 ; MIPS32R2-NEXT:    jal f2
 ; MIPS32R2-NEXT:    nop
@@ -203,13 +201,12 @@ define void @f1(float %f) nounwind {
 ; MIPS32r6-LABEL: f1:
 ; MIPS32r6:       # %bb.0: # %entry
 ; MIPS32r6-NEXT:    addiu $sp, $sp, -24
-; MIPS32r6-NEXT:    sw $ra, 20($sp) # 4-byte Folded Spill
 ; MIPS32r6-NEXT:    mtc1 $zero, $f0
 ; MIPS32r6-NEXT:    cmp.eq.s $f0, $f12, $f0
 ; MIPS32r6-NEXT:    mfc1 $1, $f0
 ; MIPS32r6-NEXT:    andi $1, $1, 1
-; MIPS32r6-NEXT:    beqzc $1, $BB1_2
-; MIPS32r6-NEXT:    nop
+; MIPS32r6-NEXT:    beqz $1, $BB1_2
+; MIPS32r6-NEXT:    sw $ra, 20($sp)
 ; MIPS32r6-NEXT:  # %bb.1: # %if.end
 ; MIPS32r6-NEXT:    jal f2
 ; MIPS32r6-NEXT:    nop
@@ -223,11 +220,10 @@ define void @f1(float %f) nounwind {
 ; MIPS4-LABEL: f1:
 ; MIPS4:       # %bb.0: # %entry
 ; MIPS4-NEXT:    daddiu $sp, $sp, -16
-; MIPS4-NEXT:    sd $ra, 8($sp) # 8-byte Folded Spill
 ; MIPS4-NEXT:    mtc1 $zero, $f0
 ; MIPS4-NEXT:    c.eq.s $f12, $f0
 ; MIPS4-NEXT:    bc1f .LBB1_2
-; MIPS4-NEXT:    nop
+; MIPS4-NEXT:    sd $ra, 8($sp)
 ; MIPS4-NEXT:  # %bb.1: # %if.end
 ; MIPS4-NEXT:    jal f2
 ; MIPS4-NEXT:    nop
@@ -241,11 +237,10 @@ define void @f1(float %f) nounwind {
 ; MIPS64-LABEL: f1:
 ; MIPS64:       # %bb.0: # %entry
 ; MIPS64-NEXT:    daddiu $sp, $sp, -16
-; MIPS64-NEXT:    sd $ra, 8($sp) # 8-byte Folded Spill
 ; MIPS64-NEXT:    mtc1 $zero, $f0
 ; MIPS64-NEXT:    c.eq.s $f12, $f0
 ; MIPS64-NEXT:    bc1f .LBB1_2
-; MIPS64-NEXT:    nop
+; MIPS64-NEXT:    sd $ra, 8($sp)
 ; MIPS64-NEXT:  # %bb.1: # %if.end
 ; MIPS64-NEXT:    jal f2
 ; MIPS64-NEXT:    nop
@@ -259,11 +254,10 @@ define void @f1(float %f) nounwind {
 ; MIPS64R2-LABEL: f1:
 ; MIPS64R2:       # %bb.0: # %entry
 ; MIPS64R2-NEXT:    daddiu $sp, $sp, -16
-; MIPS64R2-NEXT:    sd $ra, 8($sp) # 8-byte Folded Spill
 ; MIPS64R2-NEXT:    mtc1 $zero, $f0
 ; MIPS64R2-NEXT:    c.eq.s $f12, $f0
 ; MIPS64R2-NEXT:    bc1f .LBB1_2
-; MIPS64R2-NEXT:    nop
+; MIPS64R2-NEXT:    sd $ra, 8($sp)
 ; MIPS64R2-NEXT:  # %bb.1: # %if.end
 ; MIPS64R2-NEXT:    jal f2
 ; MIPS64R2-NEXT:    nop
@@ -277,13 +271,12 @@ define void @f1(float %f) nounwind {
 ; MIPS64R6-LABEL: f1:
 ; MIPS64R6:       # %bb.0: # %entry
 ; MIPS64R6-NEXT:    daddiu $sp, $sp, -16
-; MIPS64R6-NEXT:    sd $ra, 8($sp) # 8-byte Folded Spill
 ; MIPS64R6-NEXT:    mtc1 $zero, $f0
 ; MIPS64R6-NEXT:    cmp.eq.s $f0, $f12, $f0
 ; MIPS64R6-NEXT:    mfc1 $1, $f0
 ; MIPS64R6-NEXT:    andi $1, $1, 1
-; MIPS64R6-NEXT:    beqzc $1, .LBB1_2
-; MIPS64R6-NEXT:    nop
+; MIPS64R6-NEXT:    beqz $1, .LBB1_2
+; MIPS64R6-NEXT:    sd $ra, 8($sp)
 ; MIPS64R6-NEXT:  # %bb.1: # %if.end
 ; MIPS64R6-NEXT:    jal f2
 ; MIPS64R6-NEXT:    nop

--- a/llvm/test/CodeGen/Mips/delay-slot-filler-bundled-insts.mir
+++ b/llvm/test/CodeGen/Mips/delay-slot-filler-bundled-insts.mir
@@ -7,12 +7,11 @@
 
 # ASM:  # %bb.0:
 # ASM-NEXT: daddiu	$sp, $sp, -16
-# ASM-NEXT: sd	$ra, 8($sp)
 ## BUNDLE should be emitted in order:
 # ASM-NEXT: daddiu	$sp, $sp, -16
 # ASM-NEXT: daddiu	$sp, $sp, 16
 # ASM-NEXT: beqz	$4, .LBB0_2
-# ASM-NEXT: nop
+# ASM-NEXT: sd	$ra, 8($sp)
 --- |
   target datalayout = "E-m:e-i8:8:32-i16:16:32-i64:64-n32:64-S128"
   target triple = "mips64-unknown-freebsd"
@@ -87,15 +86,12 @@ body:             |
   ; CHECK: bb.0.entry:
   ; CHECK:   successors: %bb.2(0x30000000), %bb.1(0x50000000)
   ; CHECK:   $sp_64 = DADDiu $sp_64, -16
-  ; CHECK:   CFI_INSTRUCTION def_cfa_offset 16
-  ; CHECK:   SD killed $ra_64, $sp_64, 8 :: (store (s64) into %stack.0)
-  ; CHECK:   CFI_INSTRUCTION offset $ra_64, -8
   ; CHECK:   BUNDLE {
   ; CHECK:     $sp_64 = DADDiu $sp_64, -16
   ; CHECK:     $sp_64 = DADDiu $sp_64, 16
   ; CHECK:   }
   ; CHECK:   BEQ64 renamable $a0_64, $zero_64, %bb.2, implicit-def $at {
-  ; CHECK:     $zero = SLL $zero, 0
+  ; CHECK:     SD killed $ra_64, $sp_64, 8 :: (store (s64) into %stack.0)
   ; CHECK:   }
   ; CHECK: bb.1.if.then:
   ; CHECK:   successors: %bb.3(0x80000000)
@@ -120,15 +116,14 @@ body:             |
     liveins: $a0_64, $ra_64
 
     $sp_64 = DADDiu $sp_64, -16
-    CFI_INSTRUCTION def_cfa_offset 16
-    SD killed $ra_64, $sp_64, 8 :: (store (s64) into %stack.0)
-    CFI_INSTRUCTION offset $ra_64, -8
     ; This BUNDLE instruction must not be split by the delay slot filler:
     BUNDLE {
       $sp_64 = DADDiu $sp_64, -16
       $sp_64 = DADDiu $sp_64, 16
     }
-    BEQ64 renamable $a0_64, $zero_64, %bb.2, implicit-def $at
+    BEQ64 renamable $a0_64, $zero_64, %bb.2, implicit-def $at {
+      SD killed $ra_64, $sp_64, 8 :: (store (s64) into %stack.0)
+    }
 
   bb.1.if.then:
     successors: %bb.3(0x80000000)

--- a/llvm/test/CodeGen/Mips/fpbr.ll
+++ b/llvm/test/CodeGen/Mips/fpbr.ll
@@ -20,7 +20,7 @@ entry:
 ; FIXME: We ought to be able to transform not+bnez -> beqz
 ; GPR:           not      $[[GPRCC]], $[[GPRCC]]
 ; 32-GPR:        bnez     $[[GPRCC]], $BB0_2
-; 64-GPR:        bnezc    $[[GPRCC]], .LBB0_2
+; 64-GPR:        bnez     $[[GPRCC]], .LBB0_2
 
   %cmp = fcmp oeq float %f2, %f3
   br i1 %cmp, label %if.then, label %if.else
@@ -55,7 +55,7 @@ entry:
 ; GPR:           mfc1     $[[GPRCC:[0-9]+]], $[[FGRCC:f[0-9]+]]
 ; GPR-NOT:       not      $[[GPRCC]], $[[GPRCC]]
 ; 32-GPR:        bnez     $[[GPRCC]], $BB1_2
-; 64-GPR:        bnezc    $[[GPRCC]], .LBB1_2
+; 64-GPR:        bnez     $[[GPRCC]], .LBB1_2
 
   %cmp = fcmp olt float %f2, %f3
   br i1 %cmp, label %if.then, label %if.else
@@ -86,7 +86,7 @@ entry:
 ; GPR:           mfc1     $[[GPRCC:[0-9]+]], $[[FGRCC:f[0-9]+]]
 ; GPR-NOT:       not      $[[GPRCC]], $[[GPRCC]]
 ; 32-GPR:        beqz     $[[GPRCC]], $BB2_2
-; 64-GPR:        beqzc    $[[GPRCC]], .LBB2_2
+; 64-GPR:        beqz     $[[GPRCC]], .LBB2_2
 
   %cmp = fcmp ugt float %f2, %f3
   br i1 %cmp, label %if.else, label %if.then

--- a/llvm/test/CodeGen/Mips/gprestore.ll
+++ b/llvm/test/CodeGen/Mips/gprestore.ll
@@ -116,10 +116,10 @@ define void @f0() nounwind {
 ; O3O32-NEXT:    lui $2, %hi(_gp_disp)
 ; O3O32-NEXT:    addiu $2, $2, %lo(_gp_disp)
 ; O3O32-NEXT:    addiu $sp, $sp, -32
-; O3O32-NEXT:    sw $ra, 28($sp) # 4-byte Folded Spill
-; O3O32-NEXT:    sw $17, 24($sp) # 4-byte Folded Spill
 ; O3O32-NEXT:    sw $16, 20($sp) # 4-byte Folded Spill
 ; O3O32-NEXT:    addu $16, $2, $25
+; O3O32-NEXT:    sw $ra, 28($sp) # 4-byte Folded Spill
+; O3O32-NEXT:    sw $17, 24($sp) # 4-byte Folded Spill
 ; O3O32-NEXT:    lw $25, %call16(f1)($16)
 ; O3O32-NEXT:    jalr $25
 ; O3O32-NEXT:    move $gp, $16
@@ -148,10 +148,10 @@ define void @f0() nounwind {
 ; O3N64-LABEL: f0:
 ; O3N64:       # %bb.0: # %entry
 ; O3N64-NEXT:    daddiu $sp, $sp, -32
-; O3N64-NEXT:    sd $ra, 24($sp) # 8-byte Folded Spill
-; O3N64-NEXT:    sd $gp, 16($sp) # 8-byte Folded Spill
-; O3N64-NEXT:    sd $16, 8($sp) # 8-byte Folded Spill
 ; O3N64-NEXT:    lui $1, %hi(%neg(%gp_rel(f0)))
+; O3N64-NEXT:    sd $gp, 16($sp) # 8-byte Folded Spill
+; O3N64-NEXT:    sd $ra, 24($sp) # 8-byte Folded Spill
+; O3N64-NEXT:    sd $16, 8($sp) # 8-byte Folded Spill
 ; O3N64-NEXT:    daddu $1, $1, $25
 ; O3N64-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(f0)))
 ; O3N64-NEXT:    ld $25, %call16(f1)($gp)
@@ -180,10 +180,10 @@ define void @f0() nounwind {
 ; O3N32-LABEL: f0:
 ; O3N32:       # %bb.0: # %entry
 ; O3N32-NEXT:    addiu $sp, $sp, -32
-; O3N32-NEXT:    sd $ra, 24($sp) # 8-byte Folded Spill
-; O3N32-NEXT:    sd $gp, 16($sp) # 8-byte Folded Spill
-; O3N32-NEXT:    sd $16, 8($sp) # 8-byte Folded Spill
 ; O3N32-NEXT:    lui $1, %hi(%neg(%gp_rel(f0)))
+; O3N32-NEXT:    sd $gp, 16($sp) # 8-byte Folded Spill
+; O3N32-NEXT:    sd $ra, 24($sp) # 8-byte Folded Spill
+; O3N32-NEXT:    sd $16, 8($sp) # 8-byte Folded Spill
 ; O3N32-NEXT:    addu $1, $1, $25
 ; O3N32-NEXT:    addiu $gp, $1, %lo(%neg(%gp_rel(f0)))
 ; O3N32-NEXT:    lw $25, %call16(f1)($gp)

--- a/llvm/test/CodeGen/Mips/llvm.sincos.ll
+++ b/llvm/test/CodeGen/Mips/llvm.sincos.ll
@@ -8,9 +8,8 @@ define { half, half } @test_sincos_f16(half %a) #0 {
 ; MIPSEL:       # %bb.0:
 ; MIPSEL-NEXT:    addiu $sp, $sp, -32
 ; MIPSEL-NEXT:    sw $ra, 28($sp) # 4-byte Folded Spill
-; MIPSEL-NEXT:    sw $16, 24($sp) # 4-byte Folded Spill
 ; MIPSEL-NEXT:    jal __extendhfsf2
-; MIPSEL-NEXT:    nop
+; MIPSEL-NEXT:    sw $16, 24($sp)
 ; MIPSEL-NEXT:    addiu $5, $sp, 20
 ; MIPSEL-NEXT:    addiu $6, $sp, 16
 ; MIPSEL-NEXT:    jal sincosf
@@ -31,9 +30,8 @@ define { half, half } @test_sincos_f16(half %a) #0 {
 ; SOFT-FLOAT-32:       # %bb.0:
 ; SOFT-FLOAT-32-NEXT:    addiu $sp, $sp, -32
 ; SOFT-FLOAT-32-NEXT:    sw $ra, 28($sp) # 4-byte Folded Spill
-; SOFT-FLOAT-32-NEXT:    sw $16, 24($sp) # 4-byte Folded Spill
 ; SOFT-FLOAT-32-NEXT:    jal __extendhfsf2
-; SOFT-FLOAT-32-NEXT:    nop
+; SOFT-FLOAT-32-NEXT:    sw $16, 24($sp)
 ; SOFT-FLOAT-32-NEXT:    addiu $5, $sp, 20
 ; SOFT-FLOAT-32-NEXT:    addiu $6, $sp, 16
 ; SOFT-FLOAT-32-NEXT:    jal sincosf

--- a/llvm/test/CodeGen/Mips/no-frame-pointer-elim.ll
+++ b/llvm/test/CodeGen/Mips/no-frame-pointer-elim.ll
@@ -12,9 +12,8 @@ define dso_local void @caller() nounwind "frame-pointer"="non-leaf" {
 ; STATIC-NEXT:    daddiu $sp, $sp, -16
 ; STATIC-NEXT:    sd $ra, 8($sp) # 8-byte Folded Spill
 ; STATIC-NEXT:    sd $fp, 0($sp) # 8-byte Folded Spill
-; STATIC-NEXT:    move $fp, $sp
 ; STATIC-NEXT:    jal callee
-; STATIC-NEXT:    nop
+; STATIC-NEXT:    move $fp, $sp
 ;
 ; PIC-LABEL: caller:
 ; PIC:       # %bb.0: # %entry
@@ -22,7 +21,6 @@ define dso_local void @caller() nounwind "frame-pointer"="non-leaf" {
 ; PIC-NEXT:    sd $ra, 24($sp) # 8-byte Folded Spill
 ; PIC-NEXT:    sd $fp, 16($sp) # 8-byte Folded Spill
 ; PIC-NEXT:    sd $gp, 8($sp) # 8-byte Folded Spill
-; PIC-NEXT:    move $fp, $sp
 ; PIC-NEXT:    lui $1, %hi(%neg(%gp_rel(caller)))
 ; PIC-NEXT:    daddu $1, $1, $25
 ; PIC-NEXT:    daddiu $gp, $1, %lo(%neg(%gp_rel(caller)))
@@ -30,7 +28,7 @@ define dso_local void @caller() nounwind "frame-pointer"="non-leaf" {
 ; PIC-NEXT:    .reloc .Ltmp0, R_MIPS_JALR, callee
 ; PIC-NEXT:  .Ltmp0:
 ; PIC-NEXT:    jalr $25
-; PIC-NEXT:    nop
+; PIC-NEXT:    move $fp, $sp
 entry:
   tail call void @callee()
   unreachable


### PR DESCRIPTION
Don't emit CFI instructions that will be skipped by AsmPrinter. Also, use a helper class to simplify emission.

As a side effect, this seems to unblock delay slot filler optimization on some tests, though it is not obvious to me whether the transformations are legitimate.

Similar to #135845 and #136060.