### PR TITLE
[lldb][Telemetry] Fix unit test compile failure with LLVM_ENABLE_TELEMETRY=0

### DIFF
--- a/lldb/unittests/Core/TelemetryTest.cpp
+++ b/lldb/unittests/Core/TelemetryTest.cpp
@@ -96,7 +96,7 @@ public:
 #if LLVM_ENABLE_TELEMETRY
 #define TELEMETRY_TEST(suite, test) TEST_F(suite, test)
 #else
-#define TELEMETRY_TEST(suite, test) TEST(DISABLED_##suite, test)
+#define TELEMETRY_TEST(suite, test) TEST_F(suite, DISABLED_##test)
 #endif
 
 TELEMETRY_TEST(TelemetryTest, PluginTest) {


### PR DESCRIPTION
It needs to be `TEST_F` to access `received_entries`.
Disabling also works based on the test not the fixture name.

Build failure:
```
lldb/unittests/Core/TelemetryTest.cpp:110:17: error: use of undeclared identifier 'received_entries'
  110 |   ASSERT_EQ(1U, received_entries.size());
      |                 ^
lldb/unittests/Core/TelemetryTest.cpp:112:61: error: use of undeclared identifier 'received_entries'
  112 |             llvm::dyn_cast<lldb_private::FakeTelemetryInfo>(received_entries[0])
      |                                                             ^
```

Fixes: 159b872b37363511a359c800bcc9230bb09f2457