### PR TITLE
[clang] Adds a RecursiveASTEnterExitVisitor data type

### DIFF
--- a/clang/include/clang/AST/StmtOpenACC.h
+++ b/clang/include/clang/AST/StmtOpenACC.h
@@ -81,6 +81,7 @@ class OpenACCAssociatedStmtConstruct : public OpenACCConstructStmt {
   friend class ASTStmtWriter;
   friend class ASTStmtReader;
   template <typename Derived> friend class RecursiveASTVisitor;
+  template <typename Derived> friend class RecursiveASTEnterExitVisitor;
   Stmt *AssociatedStmt = nullptr;
 
 protected:

--- a/clang/unittests/Tooling/CMakeLists.txt
+++ b/clang/unittests/Tooling/CMakeLists.txt
@@ -49,6 +49,40 @@ add_clang_unittest(ToolingTests
   RecursiveASTVisitorTestDeclVisitor.cpp
   RecursiveASTVisitorTestPostOrderVisitor.cpp
   RecursiveASTVisitorTestTypeLocVisitor.cpp
+  RecursiveASTEnterExitVisitorTests/Attr.cpp
+  RecursiveASTEnterExitVisitorTests/BitfieldInitializer.cpp
+  RecursiveASTEnterExitVisitorTests/CallbacksLeaf.cpp
+  RecursiveASTEnterExitVisitorTests/CallbacksUnaryOperator.cpp
+  RecursiveASTEnterExitVisitorTests/CallbacksBinaryOperator.cpp
+  RecursiveASTEnterExitVisitorTests/CallbacksCompoundAssignOperator.cpp
+  RecursiveASTEnterExitVisitorTests/CallbacksCallExpr.cpp
+  RecursiveASTEnterExitVisitorTests/Class.cpp
+  RecursiveASTEnterExitVisitorTests/Concept.cpp
+  RecursiveASTEnterExitVisitorTests/ConstructExpr.cpp
+  RecursiveASTEnterExitVisitorTests/CXXBoolLiteralExpr.cpp
+  RecursiveASTEnterExitVisitorTests/CXXMemberCall.cpp
+  RecursiveASTEnterExitVisitorTests/CXXMethodDecl.cpp
+  RecursiveASTEnterExitVisitorTests/CXXOperatorCallExprTraverser.cpp
+  RecursiveASTEnterExitVisitorTests/DeclRefExpr.cpp
+  RecursiveASTEnterExitVisitorTests/DeductionGuide.cpp
+  RecursiveASTEnterExitVisitorTests/ImplicitCtor.cpp
+  RecursiveASTEnterExitVisitorTests/ImplicitCtorInitializer.cpp
+  RecursiveASTEnterExitVisitorTests/InitListExprPostOrder.cpp
+  RecursiveASTEnterExitVisitorTests/InitListExprPostOrderNoQueue.cpp
+  RecursiveASTEnterExitVisitorTests/InitListExprPreOrder.cpp
+  RecursiveASTEnterExitVisitorTests/InitListExprPreOrderNoQueue.cpp
+  RecursiveASTEnterExitVisitorTests/IntegerLiteral.cpp
+  RecursiveASTEnterExitVisitorTests/LambdaDefaultCapture.cpp
+  RecursiveASTEnterExitVisitorTests/LambdaExpr.cpp
+  RecursiveASTEnterExitVisitorTests/LambdaTemplateParams.cpp
+  RecursiveASTEnterExitVisitorTests/MemberPointerTypeLoc.cpp
+  RecursiveASTEnterExitVisitorTests/NestedNameSpecifiers.cpp
+  RecursiveASTEnterExitVisitorTests/ParenExpr.cpp
+  RecursiveASTEnterExitVisitorTests/TemplateArgumentLocTraverser.cpp
+  RecursiveASTEnterExitVisitorTests/TraversalScope.cpp
+  RecursiveASTEnterExitVisitorTestDeclVisitor.cpp
+  RecursiveASTEnterExitVisitorTestPostOrderVisitor.cpp
+  RecursiveASTEnterExitVisitorTestTypeLocVisitor.cpp
   RefactoringActionRulesTest.cpp
   RefactoringCallbacksTest.cpp
   RefactoringTest.cpp

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTestDeclVisitor.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTestDeclVisitor.cpp
@@ -1,0 +1,138 @@
+//===- unittest/Tooling/EnterExitRecursiveASTVisitorTestDeclVisitor.cpp ------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+class VarDeclVisitor : public ExpectedLocationVisitor {
+public:
+  bool VisitVarDecl(VarDecl *Variable) override {
+    Match(Variable->getNameAsString(), Variable->getBeginLoc());
+    return true;
+  }
+};
+
+TEST(EnterExitRecursiveASTVisitor, VisitsCXXForRangeStmtLoopVariable) {
+  VarDeclVisitor Visitor;
+  Visitor.ExpectMatch("i", 2, 17);
+  EXPECT_TRUE(Visitor.runOver(
+    "int x[5];\n"
+    "void f() { for (int i : x) {} }",
+    VarDeclVisitor::Lang_CXX11));
+}
+
+class ParmVarDeclVisitorForImplicitCode : public ExpectedLocationVisitor {
+public:
+  ParmVarDeclVisitorForImplicitCode() { ShouldVisitImplicitCode = true; }
+
+  bool VisitParmVarDecl(ParmVarDecl *ParamVar) override {
+    Match(ParamVar->getNameAsString(), ParamVar->getBeginLoc());
+    return true;
+  }
+};
+
+// Test RAV visits parameter variable declaration of the implicit
+// copy assignment operator and implicit copy constructor.
+TEST(EnterExitRecursiveASTVisitor, VisitsParmVarDeclForImplicitCode) {
+  ParmVarDeclVisitorForImplicitCode Visitor;
+  // Match parameter variable name of implicit copy assignment operator and
+  // implicit copy constructor.
+  // This parameter name does not have a valid IdentifierInfo, and shares
+  // same SourceLocation with its class declaration, so we match an empty name
+  // with the class' source location.
+  Visitor.ExpectMatch("", 1, 7);
+  Visitor.ExpectMatch("", 3, 7);
+  EXPECT_TRUE(Visitor.runOver(
+    "class X {};\n"
+    "void foo(X a, X b) {a = b;}\n"
+    "class Y {};\n"
+    "void bar(Y a) {Y b = a;}"));
+}
+
+class NamedDeclVisitor : public ExpectedLocationVisitor {
+public:
+  bool VisitNamedDecl(NamedDecl *Decl) override {
+    std::string NameWithTemplateArgs;
+    llvm::raw_string_ostream OS(NameWithTemplateArgs);
+    Decl->getNameForDiagnostic(OS,
+                               Decl->getASTContext().getPrintingPolicy(),
+                               true);
+    Match(NameWithTemplateArgs, Decl->getLocation());
+    return true;
+  }
+};
+
+TEST(EnterExitRecursiveASTVisitor, VisitsPartialTemplateSpecialization) {
+  // From cfe-commits/Week-of-Mon-20100830/033998.html
+  // Contrary to the approach suggested in that email, we visit all
+  // specializations when we visit the primary template.  Visiting them when we
+  // visit the associated specialization is problematic for specializations of
+  // template members of class templates.
+  NamedDeclVisitor Visitor;
+  Visitor.ExpectMatch("A<bool>", 1, 26);
+  Visitor.ExpectMatch("A<char *>", 2, 26);
+  EXPECT_TRUE(Visitor.runOver(
+    "template <class T> class A {};\n"
+    "template <class T> class A<T*> {};\n"
+    "A<bool> ab;\n"
+    "A<char*> acp;\n"));
+}
+
+TEST(EnterExitRecursiveASTVisitor, VisitsUndefinedClassTemplateSpecialization) {
+  NamedDeclVisitor Visitor;
+  Visitor.ExpectMatch("A<int>", 1, 29);
+  EXPECT_TRUE(Visitor.runOver(
+    "template<typename T> struct A;\n"
+    "A<int> *p;\n"));
+}
+
+TEST(EnterExitRecursiveASTVisitor, VisitsNestedUndefinedClassTemplateSpecialization) {
+  NamedDeclVisitor Visitor;
+  Visitor.ExpectMatch("A<int>::B<char>", 2, 31);
+  EXPECT_TRUE(Visitor.runOver(
+    "template<typename T> struct A {\n"
+    "  template<typename U> struct B;\n"
+    "};\n"
+    "A<int>::B<char> *p;\n"));
+}
+
+TEST(EnterExitRecursiveASTVisitor, VisitsUndefinedFunctionTemplateSpecialization) {
+  NamedDeclVisitor Visitor;
+  Visitor.ExpectMatch("A<int>", 1, 26);
+  EXPECT_TRUE(Visitor.runOver(
+    "template<typename T> int A();\n"
+    "int k = A<int>();\n"));
+}
+
+TEST(EnterExitRecursiveASTVisitor, VisitsNestedUndefinedFunctionTemplateSpecialization) {
+  NamedDeclVisitor Visitor;
+  Visitor.ExpectMatch("A<int>::B<char>", 2, 35);
+  EXPECT_TRUE(Visitor.runOver(
+    "template<typename T> struct A {\n"
+    "  template<typename U> static int B();\n"
+    "};\n"
+    "int k = A<int>::B<char>();\n"));
+}
+
+TEST(EnterExitRecursiveASTVisitor, NoRecursionInSelfFriend) {
+  // From cfe-commits/Week-of-Mon-20100830/033977.html
+  NamedDeclVisitor Visitor;
+  Visitor.ExpectMatch("vector_iterator<int>", 2, 7);
+  EXPECT_TRUE(Visitor.runOver(
+    "template<typename Container>\n"
+    "class vector_iterator {\n"
+    "    template <typename C> friend class vector_iterator;\n"
+    "};\n"
+    "vector_iterator<int> it_int;\n"));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTestDeclVisitor.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTestDeclVisitor.cpp
@@ -1,4 +1,4 @@
-//===- unittest/Tooling/EnterExitRecursiveASTVisitorTestDeclVisitor.cpp ------------===//
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTestDeclVisitor.cpp ------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -21,7 +21,7 @@ public:
   }
 };
 
-TEST(EnterExitRecursiveASTVisitor, VisitsCXXForRangeStmtLoopVariable) {
+TEST(RecursiveASTEnterExitVisitor, VisitsCXXForRangeStmtLoopVariable) {
   VarDeclVisitor Visitor;
   Visitor.ExpectMatch("i", 2, 17);
   EXPECT_TRUE(Visitor.runOver(
@@ -42,7 +42,7 @@ public:
 
 // Test RAV visits parameter variable declaration of the implicit
 // copy assignment operator and implicit copy constructor.
-TEST(EnterExitRecursiveASTVisitor, VisitsParmVarDeclForImplicitCode) {
+TEST(RecursiveASTEnterExitVisitor, VisitsParmVarDeclForImplicitCode) {
   ParmVarDeclVisitorForImplicitCode Visitor;
   // Match parameter variable name of implicit copy assignment operator and
   // implicit copy constructor.
@@ -71,7 +71,7 @@ public:
   }
 };
 
-TEST(EnterExitRecursiveASTVisitor, VisitsPartialTemplateSpecialization) {
+TEST(RecursiveASTEnterExitVisitor, VisitsPartialTemplateSpecialization) {
   // From cfe-commits/Week-of-Mon-20100830/033998.html
   // Contrary to the approach suggested in that email, we visit all
   // specializations when we visit the primary template.  Visiting them when we
@@ -87,7 +87,7 @@ TEST(EnterExitRecursiveASTVisitor, VisitsPartialTemplateSpecialization) {
     "A<char*> acp;\n"));
 }
 
-TEST(EnterExitRecursiveASTVisitor, VisitsUndefinedClassTemplateSpecialization) {
+TEST(RecursiveASTEnterExitVisitor, VisitsUndefinedClassTemplateSpecialization) {
   NamedDeclVisitor Visitor;
   Visitor.ExpectMatch("A<int>", 1, 29);
   EXPECT_TRUE(Visitor.runOver(
@@ -95,7 +95,7 @@ TEST(EnterExitRecursiveASTVisitor, VisitsUndefinedClassTemplateSpecialization) {
     "A<int> *p;\n"));
 }
 
-TEST(EnterExitRecursiveASTVisitor, VisitsNestedUndefinedClassTemplateSpecialization) {
+TEST(RecursiveASTEnterExitVisitor, VisitsNestedUndefinedClassTemplateSpecialization) {
   NamedDeclVisitor Visitor;
   Visitor.ExpectMatch("A<int>::B<char>", 2, 31);
   EXPECT_TRUE(Visitor.runOver(
@@ -105,7 +105,7 @@ TEST(EnterExitRecursiveASTVisitor, VisitsNestedUndefinedClassTemplateSpecializat
     "A<int>::B<char> *p;\n"));
 }
 
-TEST(EnterExitRecursiveASTVisitor, VisitsUndefinedFunctionTemplateSpecialization) {
+TEST(RecursiveASTEnterExitVisitor, VisitsUndefinedFunctionTemplateSpecialization) {
   NamedDeclVisitor Visitor;
   Visitor.ExpectMatch("A<int>", 1, 26);
   EXPECT_TRUE(Visitor.runOver(
@@ -113,7 +113,7 @@ TEST(EnterExitRecursiveASTVisitor, VisitsUndefinedFunctionTemplateSpecialization
     "int k = A<int>();\n"));
 }
 
-TEST(EnterExitRecursiveASTVisitor, VisitsNestedUndefinedFunctionTemplateSpecialization) {
+TEST(RecursiveASTEnterExitVisitor, VisitsNestedUndefinedFunctionTemplateSpecialization) {
   NamedDeclVisitor Visitor;
   Visitor.ExpectMatch("A<int>::B<char>", 2, 35);
   EXPECT_TRUE(Visitor.runOver(
@@ -123,7 +123,7 @@ TEST(EnterExitRecursiveASTVisitor, VisitsNestedUndefinedFunctionTemplateSpeciali
     "int k = A<int>::B<char>();\n"));
 }
 
-TEST(EnterExitRecursiveASTVisitor, NoRecursionInSelfFriend) {
+TEST(RecursiveASTEnterExitVisitor, NoRecursionInSelfFriend) {
   // From cfe-commits/Week-of-Mon-20100830/033977.html
   NamedDeclVisitor Visitor;
   Visitor.ExpectMatch("vector_iterator<int>", 2, 7);

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTestPostOrderVisitor.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTestPostOrderVisitor.cpp
@@ -1,0 +1,114 @@
+//===- unittests/Tooling/EnterExitRecursiveASTVisitorPostOrderASTVisitor.cpp -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains tests for the post-order traversing functionality
+// of EnterExitRecursiveASTVisitor.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CRTPTestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+class RecordingVisitor : public CRTPTestVisitor<RecordingVisitor> {
+  bool VisitPostOrder;
+
+public:
+  explicit RecordingVisitor(bool VisitPostOrder)
+      : VisitPostOrder(VisitPostOrder) {}
+
+  // List of visited nodes during traversal.
+  std::vector<std::string> VisitedNodes;
+
+  bool shouldTraversePostOrder() const { return VisitPostOrder; }
+
+  bool VisitUnaryOperator(UnaryOperator *Op) {
+    VisitedNodes.push_back(std::string(Op->getOpcodeStr(Op->getOpcode())));
+    return true;
+  }
+
+  bool VisitBinaryOperator(BinaryOperator *Op) {
+    VisitedNodes.push_back(std::string(Op->getOpcodeStr()));
+    return true;
+  }
+
+  bool VisitIntegerLiteral(IntegerLiteral *Lit) {
+    VisitedNodes.push_back(toString(Lit->getValue(), 10, false));
+    return true;
+  }
+
+  bool VisitVarDecl(VarDecl *D) {
+    VisitedNodes.push_back(D->getNameAsString());
+    return true;
+  }
+
+  bool VisitCXXMethodDecl(CXXMethodDecl *D) {
+    VisitedNodes.push_back(D->getQualifiedNameAsString());
+    return true;
+  }
+
+  bool VisitReturnStmt(ReturnStmt *S) {
+    VisitedNodes.push_back("return");
+    return true;
+  }
+
+  bool VisitCXXRecordDecl(CXXRecordDecl *D) {
+    if (!D->isImplicit())
+      VisitedNodes.push_back(D->getQualifiedNameAsString());
+    return true;
+  }
+
+  bool VisitTemplateTypeParmType(TemplateTypeParmType *T) {
+    VisitedNodes.push_back(T->getDecl()->getQualifiedNameAsString());
+    return true;
+  }
+};
+} // namespace
+
+TEST(EnterExitRecursiveASTVisitor, PostOrderTraversal) {
+  // We traverse the translation unit and store all visited nodes.
+  RecordingVisitor Visitor(true);
+  Visitor.runOver("class A {\n"
+                  "  class B {\n"
+                  "    int foo() {\n"
+                  "      while(4) { int i = 9; int j = -5; }\n"
+                  "      return (1 + 3) + 2; }\n"
+                  "  };\n"
+                  "};\n");
+
+  std::vector<std::string> expected = {"4", "9",      "i",         "5",    "-",
+                                       "j", "1",      "3",         "+",    "2",
+                                       "+", "return", "A::B::foo", "A::B", "A"};
+  // Compare the list of actually visited nodes with the expected list of
+  // visited nodes.
+  ASSERT_EQ(expected.size(), Visitor.VisitedNodes.size());
+  for (std::size_t I = 0; I < expected.size(); I++) {
+    ASSERT_EQ(expected[I], Visitor.VisitedNodes[I]);
+  }
+}
+
+TEST(EnterExitRecursiveASTVisitor, NoPostOrderTraversal) {
+  // We traverse the translation unit and store all visited nodes.
+  RecordingVisitor Visitor(false);
+  Visitor.runOver("class A {\n"
+                  "  class B {\n"
+                  "    int foo() { return 1 + 2; }\n"
+                  "  };\n"
+                  "};\n");
+
+  std::vector<std::string> expected = {"A", "A::B", "A::B::foo", "return",
+                                       "+", "1",    "2"};
+  // Compare the list of actually visited nodes with the expected list of
+  // visited nodes.
+  ASSERT_EQ(expected.size(), Visitor.VisitedNodes.size());
+  for (std::size_t I = 0; I < expected.size(); I++) {
+    ASSERT_EQ(expected[I], Visitor.VisitedNodes[I]);
+  }
+}

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTestPostOrderVisitor.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTestPostOrderVisitor.cpp
@@ -1,4 +1,4 @@
-//===- unittests/Tooling/EnterExitRecursiveASTVisitorPostOrderASTVisitor.cpp -------===//
+//===- unittests/Tooling/RecursiveASTEnterExitVisitorPostOrderASTVisitor.cpp -------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 //
 // This file contains tests for the post-order traversing functionality
-// of EnterExitRecursiveASTVisitor.
+// of RecursiveASTEnterExitVisitor.
 //
 //===----------------------------------------------------------------------===//
 
@@ -72,7 +72,7 @@ public:
 };
 } // namespace
 
-TEST(EnterExitRecursiveASTVisitor, PostOrderTraversal) {
+TEST(RecursiveASTEnterExitVisitor, PostOrderTraversal) {
   // We traverse the translation unit and store all visited nodes.
   RecordingVisitor Visitor(true);
   Visitor.runOver("class A {\n"
@@ -94,7 +94,7 @@ TEST(EnterExitRecursiveASTVisitor, PostOrderTraversal) {
   }
 }
 
-TEST(EnterExitRecursiveASTVisitor, NoPostOrderTraversal) {
+TEST(RecursiveASTEnterExitVisitor, NoPostOrderTraversal) {
   // We traverse the translation unit and store all visited nodes.
   RecordingVisitor Visitor(false);
   Visitor.runOver("class A {\n"

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTestTypeLocVisitor.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTestTypeLocVisitor.cpp
@@ -21,13 +21,13 @@ public:
   }
 };
 
-TEST(EnterExitRecursiveASTVisitor, VisitsBaseClassDeclarations) {
+TEST(RecursiveASTEnterExitVisitor, VisitsBaseClassDeclarations) {
   TypeLocVisitor Visitor;
   Visitor.ExpectMatch("class X", 1, 30);
   EXPECT_TRUE(Visitor.runOver("class X {}; class Y : public X {};"));
 }
 
-TEST(EnterExitRecursiveASTVisitor, VisitsCXXBaseSpecifiersOfForwardDeclaredClass) {
+TEST(RecursiveASTEnterExitVisitor, VisitsCXXBaseSpecifiersOfForwardDeclaredClass) {
   TypeLocVisitor Visitor;
   Visitor.ExpectMatch("class X", 3, 18);
   EXPECT_TRUE(Visitor.runOver(
@@ -36,7 +36,7 @@ TEST(EnterExitRecursiveASTVisitor, VisitsCXXBaseSpecifiersOfForwardDeclaredClass
     "class Y : public X {};"));
 }
 
-TEST(EnterExitRecursiveASTVisitor, VisitsCXXBaseSpecifiersWithIncompleteInnerClass) {
+TEST(RecursiveASTEnterExitVisitor, VisitsCXXBaseSpecifiersWithIncompleteInnerClass) {
   TypeLocVisitor Visitor;
   Visitor.ExpectMatch("class X", 2, 18);
   EXPECT_TRUE(Visitor.runOver(
@@ -44,7 +44,7 @@ TEST(EnterExitRecursiveASTVisitor, VisitsCXXBaseSpecifiersWithIncompleteInnerCla
     "class Y : public X { class Z; };"));
 }
 
-TEST(EnterExitRecursiveASTVisitor, VisitsCXXBaseSpecifiersOfSelfReferentialType) {
+TEST(RecursiveASTEnterExitVisitor, VisitsCXXBaseSpecifiersOfSelfReferentialType) {
   TypeLocVisitor Visitor;
   Visitor.ExpectMatch("X<Y>", 2, 18, 2);
   EXPECT_TRUE(Visitor.runOver(
@@ -52,7 +52,7 @@ TEST(EnterExitRecursiveASTVisitor, VisitsCXXBaseSpecifiersOfSelfReferentialType)
     "class Y : public X<Y> {};"));
 }
 
-TEST(EnterExitRecursiveASTVisitor, VisitsClassTemplateTypeParmDefaultArgument) {
+TEST(RecursiveASTEnterExitVisitor, VisitsClassTemplateTypeParmDefaultArgument) {
   TypeLocVisitor Visitor;
   Visitor.ExpectMatch("class X", 2, 23);
   EXPECT_TRUE(Visitor.runOver(
@@ -61,7 +61,7 @@ TEST(EnterExitRecursiveASTVisitor, VisitsClassTemplateTypeParmDefaultArgument) {
     "template<typename T> class Y {};\n"));
 }
 
-TEST(EnterExitRecursiveASTVisitor, VisitsCompoundLiteralType) {
+TEST(RecursiveASTEnterExitVisitor, VisitsCompoundLiteralType) {
   TypeLocVisitor Visitor;
   Visitor.ExpectMatch("struct S", 1, 26);
   EXPECT_TRUE(Visitor.runOver(
@@ -69,7 +69,7 @@ TEST(EnterExitRecursiveASTVisitor, VisitsCompoundLiteralType) {
       TypeLocVisitor::Lang_C));
 }
 
-TEST(EnterExitRecursiveASTVisitor, VisitsObjCPropertyType) {
+TEST(RecursiveASTEnterExitVisitor, VisitsObjCPropertyType) {
   TypeLocVisitor Visitor;
   Visitor.ExpectMatch("NSNumber", 2, 33);
   EXPECT_TRUE(Visitor.runOver(
@@ -78,7 +78,7 @@ TEST(EnterExitRecursiveASTVisitor, VisitsObjCPropertyType) {
       TypeLocVisitor::Lang_OBJC));
 }
 
-TEST(EnterExitRecursiveASTVisitor, VisitInvalidType) {
+TEST(RecursiveASTEnterExitVisitor, VisitInvalidType) {
   TypeLocVisitor Visitor;
   // FIXME: It would be nice to have information about subtypes of invalid type
   //Visitor.ExpectMatch("typeof(struct F *) []", 1, 1);
@@ -89,7 +89,7 @@ TEST(EnterExitRecursiveASTVisitor, VisitInvalidType) {
       TypeLocVisitor::Lang_C));
 }
 
-TEST(EnterExitRecursiveASTVisitor, VisitsUsingEnumType) {
+TEST(RecursiveASTEnterExitVisitor, VisitsUsingEnumType) {
   TypeLocVisitor Visitor;
   Visitor.ExpectMatch("::A", 2, 12);
   EXPECT_TRUE(Visitor.runOver("enum class A {}; \n"

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTestTypeLocVisitor.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTestTypeLocVisitor.cpp
@@ -1,0 +1,100 @@
+//===- unittest/Tooling/RecursiveASTVisitorTestTypeLocVisitor.cpp ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+class TypeLocVisitor : public ExpectedLocationVisitor {
+public:
+  bool VisitTypeLoc(TypeLoc TypeLocation) override {
+    Match(TypeLocation.getType().getAsString(), TypeLocation.getBeginLoc());
+    return true;
+  }
+};
+
+TEST(EnterExitRecursiveASTVisitor, VisitsBaseClassDeclarations) {
+  TypeLocVisitor Visitor;
+  Visitor.ExpectMatch("class X", 1, 30);
+  EXPECT_TRUE(Visitor.runOver("class X {}; class Y : public X {};"));
+}
+
+TEST(EnterExitRecursiveASTVisitor, VisitsCXXBaseSpecifiersOfForwardDeclaredClass) {
+  TypeLocVisitor Visitor;
+  Visitor.ExpectMatch("class X", 3, 18);
+  EXPECT_TRUE(Visitor.runOver(
+    "class Y;\n"
+    "class X {};\n"
+    "class Y : public X {};"));
+}
+
+TEST(EnterExitRecursiveASTVisitor, VisitsCXXBaseSpecifiersWithIncompleteInnerClass) {
+  TypeLocVisitor Visitor;
+  Visitor.ExpectMatch("class X", 2, 18);
+  EXPECT_TRUE(Visitor.runOver(
+    "class X {};\n"
+    "class Y : public X { class Z; };"));
+}
+
+TEST(EnterExitRecursiveASTVisitor, VisitsCXXBaseSpecifiersOfSelfReferentialType) {
+  TypeLocVisitor Visitor;
+  Visitor.ExpectMatch("X<Y>", 2, 18, 2);
+  EXPECT_TRUE(Visitor.runOver(
+    "template<typename T> class X {};\n"
+    "class Y : public X<Y> {};"));
+}
+
+TEST(EnterExitRecursiveASTVisitor, VisitsClassTemplateTypeParmDefaultArgument) {
+  TypeLocVisitor Visitor;
+  Visitor.ExpectMatch("class X", 2, 23);
+  EXPECT_TRUE(Visitor.runOver(
+    "class X;\n"
+    "template<typename T = X> class Y;\n"
+    "template<typename T> class Y {};\n"));
+}
+
+TEST(EnterExitRecursiveASTVisitor, VisitsCompoundLiteralType) {
+  TypeLocVisitor Visitor;
+  Visitor.ExpectMatch("struct S", 1, 26);
+  EXPECT_TRUE(Visitor.runOver(
+      "int f() { return (struct S { int a; }){.a = 0}.a; }",
+      TypeLocVisitor::Lang_C));
+}
+
+TEST(EnterExitRecursiveASTVisitor, VisitsObjCPropertyType) {
+  TypeLocVisitor Visitor;
+  Visitor.ExpectMatch("NSNumber", 2, 33);
+  EXPECT_TRUE(Visitor.runOver(
+      "@class NSNumber; \n"
+      "@interface A @property (retain) NSNumber *x; @end\n",
+      TypeLocVisitor::Lang_OBJC));
+}
+
+TEST(EnterExitRecursiveASTVisitor, VisitInvalidType) {
+  TypeLocVisitor Visitor;
+  // FIXME: It would be nice to have information about subtypes of invalid type
+  //Visitor.ExpectMatch("typeof(struct F *) []", 1, 1);
+  // Even if the full type is invalid, it should still find sub types
+  //Visitor.ExpectMatch("struct F", 1, 19);
+  EXPECT_FALSE(Visitor.runOver(
+      "__typeof__(struct F*) var[invalid];\n",
+      TypeLocVisitor::Lang_C));
+}
+
+TEST(EnterExitRecursiveASTVisitor, VisitsUsingEnumType) {
+  TypeLocVisitor Visitor;
+  Visitor.ExpectMatch("::A", 2, 12);
+  EXPECT_TRUE(Visitor.runOver("enum class A {}; \n"
+                              "using enum ::A;\n",
+                              TypeLocVisitor::Lang_CXX2a));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/Attr.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/Attr.cpp
@@ -1,0 +1,51 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/Attr.cpp -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CRTPTestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+// Check to ensure that attributes and expressions within them are being
+// visited.
+class AttrVisitor : public CRTPExpectedLocationVisitor<AttrVisitor> {
+public:
+  bool VisitMemberExpr(MemberExpr *ME) {
+    Match(ME->getMemberDecl()->getNameAsString(), ME->getBeginLoc());
+    return true;
+  }
+  bool VisitAttr(Attr *A) {
+    Match("Attr", A->getLocation());
+    return true;
+  }
+  bool VisitGuardedByAttr(GuardedByAttr *A) {
+    Match("guarded_by", A->getLocation());
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, AttributesAreVisited) {
+  AttrVisitor Visitor;
+  Visitor.ExpectMatch("Attr", 4, 24);
+  Visitor.ExpectMatch("guarded_by", 4, 24);
+  Visitor.ExpectMatch("mu1",  4, 35);
+  Visitor.ExpectMatch("Attr", 5, 29);
+  Visitor.ExpectMatch("mu1",  5, 54);
+  Visitor.ExpectMatch("mu2",  5, 59);
+  EXPECT_TRUE(Visitor.runOver(
+    "class Foo {\n"
+    "  int mu1;\n"
+    "  int mu2;\n"
+    "  int a __attribute__((guarded_by(mu1)));\n"
+    "  void bar() __attribute__((exclusive_locks_required(mu1, mu2)));\n"
+    "};\n"));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/BitfieldInitializer.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/BitfieldInitializer.cpp
@@ -1,0 +1,34 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/BitfieldInitializer.cpp -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+#include <string>
+
+using namespace clang;
+
+namespace {
+
+// Check to ensure that bitfield initializers are visited.
+class BitfieldInitializerVisitor : public ExpectedLocationVisitor {
+public:
+  bool VisitIntegerLiteral(IntegerLiteral *IL) override {
+    Match(std::to_string(IL->getValue().getSExtValue()), IL->getLocation());
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, BitfieldInitializerIsVisited) {
+  BitfieldInitializerVisitor Visitor;
+  Visitor.ExpectMatch("123", 2, 15);
+  EXPECT_TRUE(Visitor.runOver("struct S {\n"
+                              "  int x : 8 = 123;\n"
+                              "};\n"));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CXXBoolLiteralExpr.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CXXBoolLiteralExpr.cpp
@@ -1,0 +1,36 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/CXXBoolLiteralExpr.cpp ---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+class CXXBoolLiteralExprVisitor : public ExpectedLocationVisitor {
+public:
+  bool VisitCXXBoolLiteralExpr(CXXBoolLiteralExpr *BE) override {
+    if (BE->getValue())
+      Match("true", BE->getLocation());
+    else
+      Match("false", BE->getLocation());
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, VisitsClassTemplateNonTypeParmDefaultArgument) {
+  CXXBoolLiteralExprVisitor Visitor;
+  Visitor.ExpectMatch("true", 2, 19);
+  EXPECT_TRUE(Visitor.runOver(
+    "template<bool B> class X;\n"
+    "template<bool B = true> class Y;\n"
+    "template<bool B> class Y {};\n"));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CXXMemberCall.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CXXMemberCall.cpp
@@ -1,0 +1,97 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/CXXMemberCall.cpp --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+class CXXMemberCallVisitor : public ExpectedLocationVisitor {
+public:
+  bool VisitCXXMemberCallExpr(CXXMemberCallExpr *Call) override {
+    Match(Call->getMethodDecl()->getQualifiedNameAsString(),
+          Call->getBeginLoc());
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, VisitsCallInTemplateInstantiation) {
+  CXXMemberCallVisitor Visitor;
+  Visitor.ExpectMatch("Y::x", 3, 3);
+  EXPECT_TRUE(Visitor.runOver(
+    "struct Y { void x(); };\n"
+    "template<typename T> void y(T t) {\n"
+    "  t.x();\n"
+    "}\n"
+    "void foo() { y<Y>(Y()); }"));
+}
+
+TEST(RecursiveASTEnterExitVisitor, VisitsCallInNestedFunctionTemplateInstantiation) {
+  CXXMemberCallVisitor Visitor;
+  Visitor.ExpectMatch("Y::x", 4, 5);
+  EXPECT_TRUE(Visitor.runOver(
+    "struct Y { void x(); };\n"
+    "template<typename T> struct Z {\n"
+    "  template<typename U> static void f() {\n"
+    "    T().x();\n"
+    "  }\n"
+    "};\n"
+    "void foo() { Z<Y>::f<int>(); }"));
+}
+
+TEST(RecursiveASTEnterExitVisitor, VisitsCallInNestedClassTemplateInstantiation) {
+  CXXMemberCallVisitor Visitor;
+  Visitor.ExpectMatch("A::x", 5, 7);
+  EXPECT_TRUE(Visitor.runOver(
+    "template <typename T1> struct X {\n"
+    "  template <typename T2> struct Y {\n"
+    "    void f() {\n"
+    "      T2 y;\n"
+    "      y.x();\n"
+    "    }\n"
+    "  };\n"
+    "};\n"
+    "struct A { void x(); };\n"
+    "int main() {\n"
+    "  (new X<A>::Y<A>())->f();\n"
+    "}"));
+}
+
+TEST(RecursiveASTEnterExitVisitor, VisitsCallInPartialTemplateSpecialization) {
+  CXXMemberCallVisitor Visitor;
+  Visitor.ExpectMatch("A::x", 6, 20);
+  EXPECT_TRUE(Visitor.runOver(
+    "template <typename T1> struct X {\n"
+    "  template <typename T2, bool B> struct Y { void g(); };\n"
+    "};\n"
+    "template <typename T1> template <typename T2>\n"
+    "struct X<T1>::Y<T2, true> {\n"
+    "  void f() { T2 y; y.x(); }\n"
+    "};\n"
+    "struct A { void x(); };\n"
+    "int main() {\n"
+    "  (new X<A>::Y<A, true>())->f();\n"
+    "}\n"));
+}
+
+TEST(RecursiveASTEnterExitVisitor, VisitsExplicitTemplateSpecialization) {
+  CXXMemberCallVisitor Visitor;
+  Visitor.ExpectMatch("A::f", 4, 5);
+  EXPECT_TRUE(Visitor.runOver(
+    "struct A {\n"
+    "  void f() const {}\n"
+    "  template<class T> void g(const T& t) const {\n"
+    "    t.f();\n"
+    "  }\n"
+    "};\n"
+    "template void A::g(const A& a) const;\n"));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CXXMethodDecl.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CXXMethodDecl.cpp
@@ -1,0 +1,73 @@
+//=------ unittest/Tooling/RecursiveASTEnterExitVisitorTests/CXXMethodDecl.cpp ------=//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+#include "clang/AST/Expr.h"
+
+using namespace clang;
+
+namespace {
+
+class CXXMethodDeclVisitor : public ExpectedLocationVisitor {
+public:
+  CXXMethodDeclVisitor(bool VisitImplicitCode) {
+    ShouldVisitImplicitCode = VisitImplicitCode;
+  }
+
+  bool VisitDeclRefExpr(DeclRefExpr *D) override {
+    Match("declref", D->getLocation());
+    return true;
+  }
+
+  bool VisitParmVarDecl(ParmVarDecl *P) override {
+    Match("parm", P->getLocation());
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, CXXMethodDeclNoDefaultBodyVisited) {
+  for (bool VisitImplCode : {false, true}) {
+    CXXMethodDeclVisitor Visitor(VisitImplCode);
+    if (VisitImplCode)
+      Visitor.ExpectMatch("declref", 8, 28);
+    else
+      Visitor.DisallowMatch("declref", 8, 28);
+
+    Visitor.ExpectMatch("parm", 8, 27);
+    llvm::StringRef Code = R"cpp(
+      struct B {};
+      struct A {
+        B BB;
+        A &operator=(A &&O);
+      };
+
+      A &A::operator=(A &&O) = default;
+    )cpp";
+    EXPECT_TRUE(Visitor.runOver(Code, CXXMethodDeclVisitor::Lang_CXX11));
+  }
+}
+
+TEST(RecursiveASTEnterExitVisitor, FunctionDeclNoDefaultBodyVisited) {
+  for (bool VisitImplCode : {false, true}) {
+    CXXMethodDeclVisitor Visitor(VisitImplCode);
+    if (VisitImplCode)
+      Visitor.ExpectMatch("declref", 4, 58, /*Times=*/2);
+    else
+      Visitor.DisallowMatch("declref", 4, 58);
+    llvm::StringRef Code = R"cpp(
+      struct s {
+        int x;
+        friend auto operator==(s a, s b) -> bool = default;
+      };
+      bool k = s() == s(); // make sure clang generates the "==" definition.
+    )cpp";
+    EXPECT_TRUE(Visitor.runOver(Code, CXXMethodDeclVisitor::Lang_CXX2a));
+  }
+}
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CXXOperatorCallExprTraverser.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CXXOperatorCallExprTraverser.cpp
@@ -1,0 +1,36 @@
+//===- CXXOperatorCallExprTraverser.cpp -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+class CXXOperatorCallExprTraverser : public ExpectedLocationVisitor {
+public:
+  // Use Traverse, not Visit, to check that data recursion optimization isn't
+  // bypassing the call of this function.
+  bool TraverseCXXOperatorCallExpr(CXXOperatorCallExpr *CE) override {
+    Match(getOperatorSpelling(CE->getOperator()), CE->getExprLoc());
+    return ExpectedLocationVisitor::TraverseCXXOperatorCallExpr(CE);
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, TraversesOverloadedOperator) {
+  CXXOperatorCallExprTraverser Visitor;
+  Visitor.ExpectMatch("()", 4, 9);
+  EXPECT_TRUE(Visitor.runOver(
+    "struct A {\n"
+    "  int operator()();\n"
+    "} a;\n"
+    "int k = a();\n"));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CallbacksBinaryOperator.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CallbacksBinaryOperator.cpp
@@ -1,0 +1,211 @@
+//===- CallbacksBinaryOperator.cpp ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CallbacksCommon.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+TEST(RecursiveASTEnterExitVisitor, StmtCallbacks_TraverseBinaryOperator) {
+  class RecordingVisitor : public RecordingVisitorBase<RecordingVisitor> {
+  public:
+    RecordingVisitor(ShouldTraversePostOrder ShouldTraversePostOrderValue)
+        : RecordingVisitorBase(ShouldTraversePostOrderValue) {}
+
+    bool TraverseBinaryOperator(BinaryOperator *BO) {
+      recordCallback(__func__, BO, [&]() {
+        RecordingVisitorBase::TraverseBinaryOperator(BO);
+      });
+      return true;
+    }
+
+    bool WalkUpFromStmt(Stmt *S) {
+      recordCallback(__func__, S,
+                     [&]() { RecordingVisitorBase::WalkUpFromStmt(S); });
+      return true;
+    }
+  };
+
+  StringRef Code = R"cpp(
+void test() {
+  1;
+  2 + 3;
+  4;
+}
+)cpp";
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::No), Code,
+      R"txt(
+WalkUpFromStmt CompoundStmt
+WalkUpFromStmt IntegerLiteral(1)
+TraverseBinaryOperator BinaryOperator(+)
+  WalkUpFromStmt BinaryOperator(+)
+  WalkUpFromStmt IntegerLiteral(2)
+  WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromStmt IntegerLiteral(4)
+)txt"));
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::Yes), Code,
+      R"txt(
+WalkUpFromStmt IntegerLiteral(1)
+TraverseBinaryOperator BinaryOperator(+)
+  WalkUpFromStmt IntegerLiteral(2)
+  WalkUpFromStmt IntegerLiteral(3)
+  WalkUpFromStmt BinaryOperator(+)
+WalkUpFromStmt IntegerLiteral(4)
+WalkUpFromStmt CompoundStmt
+)txt"));
+}
+
+TEST(RecursiveASTEnterExitVisitor,
+     StmtCallbacks_TraverseBinaryOperator_WalkUpFromBinaryOperator) {
+  class RecordingVisitor : public RecordingVisitorBase<RecordingVisitor> {
+  public:
+    RecordingVisitor(ShouldTraversePostOrder ShouldTraversePostOrderValue)
+        : RecordingVisitorBase(ShouldTraversePostOrderValue) {}
+
+    bool TraverseBinaryOperator(BinaryOperator *BO) {
+      recordCallback(__func__, BO, [&]() {
+        RecordingVisitorBase::TraverseBinaryOperator(BO);
+      });
+      return true;
+    }
+
+    bool WalkUpFromStmt(Stmt *S) {
+      recordCallback(__func__, S,
+                     [&]() { RecordingVisitorBase::WalkUpFromStmt(S); });
+      return true;
+    }
+
+    bool WalkUpFromExpr(Expr *E) {
+      recordCallback(__func__, E,
+                     [&]() { RecordingVisitorBase::WalkUpFromExpr(E); });
+      return true;
+    }
+
+    bool WalkUpFromBinaryOperator(BinaryOperator *BO) {
+      recordCallback(__func__, BO, [&]() {
+        RecordingVisitorBase::WalkUpFromBinaryOperator(BO);
+      });
+      return true;
+    }
+  };
+
+  StringRef Code = R"cpp(
+void test() {
+  1;
+  2 + 3;
+  4;
+}
+)cpp";
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::No), Code,
+      R"txt(
+WalkUpFromStmt CompoundStmt
+WalkUpFromExpr IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+TraverseBinaryOperator BinaryOperator(+)
+  WalkUpFromBinaryOperator BinaryOperator(+)
+    WalkUpFromExpr BinaryOperator(+)
+      WalkUpFromStmt BinaryOperator(+)
+  WalkUpFromExpr IntegerLiteral(2)
+    WalkUpFromStmt IntegerLiteral(2)
+  WalkUpFromExpr IntegerLiteral(3)
+    WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromExpr IntegerLiteral(4)
+  WalkUpFromStmt IntegerLiteral(4)
+)txt"));
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::Yes), Code,
+      R"txt(
+WalkUpFromExpr IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+TraverseBinaryOperator BinaryOperator(+)
+  WalkUpFromExpr IntegerLiteral(2)
+    WalkUpFromStmt IntegerLiteral(2)
+  WalkUpFromExpr IntegerLiteral(3)
+    WalkUpFromStmt IntegerLiteral(3)
+  WalkUpFromBinaryOperator BinaryOperator(+)
+    WalkUpFromExpr BinaryOperator(+)
+      WalkUpFromStmt BinaryOperator(+)
+WalkUpFromExpr IntegerLiteral(4)
+  WalkUpFromStmt IntegerLiteral(4)
+WalkUpFromStmt CompoundStmt
+)txt"));
+}
+
+TEST(RecursiveASTEnterExitVisitor, StmtCallbacks_WalkUpFromBinaryOperator) {
+  class RecordingVisitor : public RecordingVisitorBase<RecordingVisitor> {
+  public:
+    RecordingVisitor(ShouldTraversePostOrder ShouldTraversePostOrderValue)
+        : RecordingVisitorBase(ShouldTraversePostOrderValue) {}
+
+    bool WalkUpFromStmt(Stmt *S) {
+      recordCallback(__func__, S,
+                     [&]() { RecordingVisitorBase::WalkUpFromStmt(S); });
+      return true;
+    }
+
+    bool WalkUpFromExpr(Expr *E) {
+      recordCallback(__func__, E,
+                     [&]() { RecordingVisitorBase::WalkUpFromExpr(E); });
+      return true;
+    }
+
+    bool WalkUpFromBinaryOperator(BinaryOperator *BO) {
+      recordCallback(__func__, BO, [&]() {
+        RecordingVisitorBase::WalkUpFromBinaryOperator(BO);
+      });
+      return true;
+    }
+  };
+
+  StringRef Code = R"cpp(
+void test() {
+  1;
+  2 + 3;
+  4;
+}
+)cpp";
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::No), Code,
+      R"txt(
+WalkUpFromStmt CompoundStmt
+WalkUpFromExpr IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+WalkUpFromBinaryOperator BinaryOperator(+)
+  WalkUpFromExpr BinaryOperator(+)
+    WalkUpFromStmt BinaryOperator(+)
+WalkUpFromExpr IntegerLiteral(2)
+  WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromExpr IntegerLiteral(3)
+  WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromExpr IntegerLiteral(4)
+  WalkUpFromStmt IntegerLiteral(4)
+)txt"));
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::Yes), Code,
+      R"txt(
+WalkUpFromExpr IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+WalkUpFromExpr IntegerLiteral(2)
+  WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromExpr IntegerLiteral(3)
+  WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromBinaryOperator BinaryOperator(+)
+  WalkUpFromExpr BinaryOperator(+)
+    WalkUpFromStmt BinaryOperator(+)
+WalkUpFromExpr IntegerLiteral(4)
+  WalkUpFromStmt IntegerLiteral(4)
+WalkUpFromStmt CompoundStmt
+)txt"));
+}

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CallbacksCallExpr.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CallbacksCallExpr.cpp
@@ -1,0 +1,249 @@
+//===-- unittests/Tooling/RecursiveASTEnterExitVisitorTests/CallbacksCallExpr.cpp --===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CallbacksCommon.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+TEST(RecursiveASTEnterExitVisitor, StmtCallbacks_TraverseCallExpr) {
+  class RecordingVisitor : public RecordingVisitorBase<RecordingVisitor> {
+  public:
+    RecordingVisitor(ShouldTraversePostOrder ShouldTraversePostOrderValue)
+        : RecordingVisitorBase(ShouldTraversePostOrderValue) {}
+
+    bool TraverseCallExpr(CallExpr *CE) {
+      recordCallback(__func__, CE,
+                     [&]() { RecordingVisitorBase::TraverseCallExpr(CE); });
+      return true;
+    }
+
+    bool WalkUpFromStmt(Stmt *S) {
+      recordCallback(__func__, S,
+                     [&]() { RecordingVisitorBase::WalkUpFromStmt(S); });
+      return true;
+    }
+  };
+
+  StringRef Code = R"cpp(
+void add(int, int);
+void test() {
+  1;
+  2 + 3;
+  add(4, 5);
+}
+)cpp";
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::No), Code,
+      R"txt(
+WalkUpFromStmt CompoundStmt
+WalkUpFromStmt IntegerLiteral(1)
+WalkUpFromStmt BinaryOperator(+)
+WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromStmt IntegerLiteral(3)
+TraverseCallExpr CallExpr(add)
+  WalkUpFromStmt CallExpr(add)
+  WalkUpFromStmt ImplicitCastExpr
+  WalkUpFromStmt DeclRefExpr(add)
+  WalkUpFromStmt IntegerLiteral(4)
+  WalkUpFromStmt IntegerLiteral(5)
+)txt"));
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::Yes), Code,
+      R"txt(
+WalkUpFromStmt IntegerLiteral(1)
+WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromStmt BinaryOperator(+)
+TraverseCallExpr CallExpr(add)
+  WalkUpFromStmt DeclRefExpr(add)
+  WalkUpFromStmt ImplicitCastExpr
+  WalkUpFromStmt IntegerLiteral(4)
+  WalkUpFromStmt IntegerLiteral(5)
+  WalkUpFromStmt CallExpr(add)
+WalkUpFromStmt CompoundStmt
+)txt"));
+}
+
+TEST(RecursiveASTEnterExitVisitor, StmtCallbacks_TraverseCallExpr_WalkUpFromCallExpr) {
+  class RecordingVisitor : public RecordingVisitorBase<RecordingVisitor> {
+  public:
+    RecordingVisitor(ShouldTraversePostOrder ShouldTraversePostOrderValue)
+        : RecordingVisitorBase(ShouldTraversePostOrderValue) {}
+
+    bool TraverseCallExpr(CallExpr *CE) {
+      recordCallback(__func__, CE,
+                     [&]() { RecordingVisitorBase::TraverseCallExpr(CE); });
+      return true;
+    }
+
+    bool WalkUpFromStmt(Stmt *S) {
+      recordCallback(__func__, S,
+                     [&]() { RecordingVisitorBase::WalkUpFromStmt(S); });
+      return true;
+    }
+
+    bool WalkUpFromExpr(Expr *E) {
+      recordCallback(__func__, E,
+                     [&]() { RecordingVisitorBase::WalkUpFromExpr(E); });
+      return true;
+    }
+
+    bool WalkUpFromCallExpr(CallExpr *CE) {
+      recordCallback(__func__, CE,
+                     [&]() { RecordingVisitorBase::WalkUpFromCallExpr(CE); });
+      return true;
+    }
+  };
+
+  StringRef Code = R"cpp(
+void add(int, int);
+void test() {
+  1;
+  2 + 3;
+  add(4, 5);
+}
+)cpp";
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::No), Code,
+      R"txt(
+WalkUpFromStmt CompoundStmt
+WalkUpFromExpr IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+WalkUpFromExpr BinaryOperator(+)
+  WalkUpFromStmt BinaryOperator(+)
+WalkUpFromExpr IntegerLiteral(2)
+  WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromExpr IntegerLiteral(3)
+  WalkUpFromStmt IntegerLiteral(3)
+TraverseCallExpr CallExpr(add)
+  WalkUpFromCallExpr CallExpr(add)
+    WalkUpFromExpr CallExpr(add)
+      WalkUpFromStmt CallExpr(add)
+  WalkUpFromExpr ImplicitCastExpr
+    WalkUpFromStmt ImplicitCastExpr
+  WalkUpFromExpr DeclRefExpr(add)
+    WalkUpFromStmt DeclRefExpr(add)
+  WalkUpFromExpr IntegerLiteral(4)
+    WalkUpFromStmt IntegerLiteral(4)
+  WalkUpFromExpr IntegerLiteral(5)
+    WalkUpFromStmt IntegerLiteral(5)
+)txt"));
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::Yes), Code,
+      R"txt(
+WalkUpFromExpr IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+WalkUpFromExpr IntegerLiteral(2)
+  WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromExpr IntegerLiteral(3)
+  WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromExpr BinaryOperator(+)
+  WalkUpFromStmt BinaryOperator(+)
+TraverseCallExpr CallExpr(add)
+  WalkUpFromExpr DeclRefExpr(add)
+    WalkUpFromStmt DeclRefExpr(add)
+  WalkUpFromExpr ImplicitCastExpr
+    WalkUpFromStmt ImplicitCastExpr
+  WalkUpFromExpr IntegerLiteral(4)
+    WalkUpFromStmt IntegerLiteral(4)
+  WalkUpFromExpr IntegerLiteral(5)
+    WalkUpFromStmt IntegerLiteral(5)
+  WalkUpFromCallExpr CallExpr(add)
+    WalkUpFromExpr CallExpr(add)
+      WalkUpFromStmt CallExpr(add)
+WalkUpFromStmt CompoundStmt
+)txt"));
+}
+
+TEST(RecursiveASTEnterExitVisitor, StmtCallbacks_WalkUpFromCallExpr) {
+  class RecordingVisitor : public RecordingVisitorBase<RecordingVisitor> {
+  public:
+    RecordingVisitor(ShouldTraversePostOrder ShouldTraversePostOrderValue)
+        : RecordingVisitorBase(ShouldTraversePostOrderValue) {}
+
+    bool WalkUpFromStmt(Stmt *S) {
+      recordCallback(__func__, S,
+                     [&]() { RecordingVisitorBase::WalkUpFromStmt(S); });
+      return true;
+    }
+
+    bool WalkUpFromExpr(Expr *E) {
+      recordCallback(__func__, E,
+                     [&]() { RecordingVisitorBase::WalkUpFromExpr(E); });
+      return true;
+    }
+
+    bool WalkUpFromCallExpr(CallExpr *CE) {
+      recordCallback(__func__, CE,
+                     [&]() { RecordingVisitorBase::WalkUpFromCallExpr(CE); });
+      return true;
+    }
+  };
+
+  StringRef Code = R"cpp(
+void add(int, int);
+void test() {
+  1;
+  2 + 3;
+  add(4, 5);
+}
+)cpp";
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::No), Code,
+      R"txt(
+WalkUpFromStmt CompoundStmt
+WalkUpFromExpr IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+WalkUpFromExpr BinaryOperator(+)
+  WalkUpFromStmt BinaryOperator(+)
+WalkUpFromExpr IntegerLiteral(2)
+  WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromExpr IntegerLiteral(3)
+  WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromCallExpr CallExpr(add)
+  WalkUpFromExpr CallExpr(add)
+    WalkUpFromStmt CallExpr(add)
+WalkUpFromExpr ImplicitCastExpr
+  WalkUpFromStmt ImplicitCastExpr
+WalkUpFromExpr DeclRefExpr(add)
+  WalkUpFromStmt DeclRefExpr(add)
+WalkUpFromExpr IntegerLiteral(4)
+  WalkUpFromStmt IntegerLiteral(4)
+WalkUpFromExpr IntegerLiteral(5)
+  WalkUpFromStmt IntegerLiteral(5)
+)txt"));
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::Yes), Code,
+      R"txt(
+WalkUpFromExpr IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+WalkUpFromExpr IntegerLiteral(2)
+  WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromExpr IntegerLiteral(3)
+  WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromExpr BinaryOperator(+)
+  WalkUpFromStmt BinaryOperator(+)
+WalkUpFromExpr DeclRefExpr(add)
+  WalkUpFromStmt DeclRefExpr(add)
+WalkUpFromExpr ImplicitCastExpr
+  WalkUpFromStmt ImplicitCastExpr
+WalkUpFromExpr IntegerLiteral(4)
+  WalkUpFromStmt IntegerLiteral(4)
+WalkUpFromExpr IntegerLiteral(5)
+  WalkUpFromStmt IntegerLiteral(5)
+WalkUpFromCallExpr CallExpr(add)
+  WalkUpFromExpr CallExpr(add)
+    WalkUpFromStmt CallExpr(add)
+WalkUpFromStmt CompoundStmt
+)txt"));
+}

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CallbacksCommon.h
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CallbacksCommon.h
@@ -1,0 +1,102 @@
+//===--- unittests/Tooling/RecursiveASTEnterExitVisitorTests/CallbacksCommon.h -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CRTPTestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+enum class ShouldTraversePostOrder : bool {
+  No = false,
+  Yes = true,
+};
+
+/// Base class for tests for RecursiveASTEnterExitVisitor tests that validate the
+/// sequence of calls to user-defined callbacks like Traverse*(), WalkUp*(),
+/// Visit*().
+template <typename Derived>
+class RecordingVisitorBase : public CRTPTestVisitor<Derived> {
+  ShouldTraversePostOrder ShouldTraversePostOrderValue;
+
+public:
+  RecordingVisitorBase(ShouldTraversePostOrder ShouldTraversePostOrderValue)
+      : ShouldTraversePostOrderValue(ShouldTraversePostOrderValue) {}
+
+  bool shouldTraversePostOrder() const {
+    return static_cast<bool>(ShouldTraversePostOrderValue);
+  }
+
+  // Callbacks received during traversal.
+  std::string CallbackLog;
+  unsigned CallbackLogIndent = 0;
+
+  std::string stmtToString(Stmt *S) {
+    StringRef ClassName = S->getStmtClassName();
+    if (IntegerLiteral *IL = dyn_cast<IntegerLiteral>(S)) {
+      return (ClassName + "(" + toString(IL->getValue(), 10, false) + ")").str();
+    }
+    if (UnaryOperator *UO = dyn_cast<UnaryOperator>(S)) {
+      return (ClassName + "(" + UnaryOperator::getOpcodeStr(UO->getOpcode()) +
+              ")")
+          .str();
+    }
+    if (BinaryOperator *BO = dyn_cast<BinaryOperator>(S)) {
+      return (ClassName + "(" + BinaryOperator::getOpcodeStr(BO->getOpcode()) +
+              ")")
+          .str();
+    }
+    if (CallExpr *CE = dyn_cast<CallExpr>(S)) {
+      if (FunctionDecl *Callee = CE->getDirectCallee()) {
+        if (Callee->getIdentifier()) {
+          return (ClassName + "(" + Callee->getName() + ")").str();
+        }
+      }
+    }
+    if (DeclRefExpr *DRE = dyn_cast<DeclRefExpr>(S)) {
+      if (NamedDecl *ND = DRE->getFoundDecl()) {
+        if (ND->getIdentifier()) {
+          return (ClassName + "(" + ND->getName() + ")").str();
+        }
+      }
+    }
+    return ClassName.str();
+  }
+
+  /// Record the fact that the user-defined callback member function
+  /// \p CallbackName was called with the argument \p S. Then, record the
+  /// effects of calling the default implementation \p CallDefaultFn.
+  template <typename CallDefault>
+  void recordCallback(StringRef CallbackName, Stmt *S,
+                      CallDefault CallDefaultFn) {
+    for (unsigned i = 0; i != CallbackLogIndent; ++i) {
+      CallbackLog += "  ";
+    }
+    CallbackLog += (CallbackName + " " + stmtToString(S) + "\n").str();
+    ++CallbackLogIndent;
+    CallDefaultFn();
+    --CallbackLogIndent;
+  }
+};
+
+template <typename VisitorTy>
+::testing::AssertionResult visitorCallbackLogEqual(VisitorTy Visitor,
+                                                   StringRef Code,
+                                                   StringRef ExpectedLog) {
+  Visitor.runOver(Code);
+  // EXPECT_EQ shows the diff between the two strings if they are different.
+  EXPECT_EQ(ExpectedLog.trim().str(),
+            StringRef(Visitor.CallbackLog).trim().str());
+  if (ExpectedLog.trim() != StringRef(Visitor.CallbackLog).trim()) {
+    return ::testing::AssertionFailure();
+  }
+  return ::testing::AssertionSuccess();
+}
+
+} // namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CallbacksCompoundAssignOperator.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CallbacksCompoundAssignOperator.cpp
@@ -1,0 +1,212 @@
+//===- CallbacksCompoundAssignOperator.cpp --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CallbacksCommon.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+TEST(RecursiveASTEnterExitVisitor, StmtCallbacks_TraverseCompoundAssignOperator) {
+  class RecordingVisitor : public RecordingVisitorBase<RecordingVisitor> {
+  public:
+    RecordingVisitor(ShouldTraversePostOrder ShouldTraversePostOrderValue)
+        : RecordingVisitorBase(ShouldTraversePostOrderValue) {}
+
+    bool TraverseCompoundAssignOperator(CompoundAssignOperator *CAO) {
+      recordCallback(__func__, CAO, [&]() {
+        RecordingVisitorBase::TraverseCompoundAssignOperator(CAO);
+      });
+      return true;
+    }
+
+    bool WalkUpFromStmt(Stmt *S) {
+      recordCallback(__func__, S,
+                     [&]() { RecordingVisitorBase::WalkUpFromStmt(S); });
+      return true;
+    }
+  };
+
+  StringRef Code = R"cpp(
+void test(int a) {
+  1;
+  a += 2;
+  3;
+}
+)cpp";
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::No), Code,
+      R"txt(
+WalkUpFromStmt CompoundStmt
+WalkUpFromStmt IntegerLiteral(1)
+TraverseCompoundAssignOperator CompoundAssignOperator(+=)
+  WalkUpFromStmt CompoundAssignOperator(+=)
+  WalkUpFromStmt DeclRefExpr(a)
+  WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromStmt IntegerLiteral(3)
+)txt"));
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::Yes), Code,
+      R"txt(
+WalkUpFromStmt IntegerLiteral(1)
+TraverseCompoundAssignOperator CompoundAssignOperator(+=)
+  WalkUpFromStmt DeclRefExpr(a)
+  WalkUpFromStmt IntegerLiteral(2)
+  WalkUpFromStmt CompoundAssignOperator(+=)
+WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromStmt CompoundStmt
+)txt"));
+}
+
+TEST(
+    RecursiveASTEnterExitVisitor,
+    StmtCallbacks_TraverseCompoundAssignOperator_WalkUpFromCompoundAssignOperator) {
+  class RecordingVisitor : public RecordingVisitorBase<RecordingVisitor> {
+  public:
+    RecordingVisitor(ShouldTraversePostOrder ShouldTraversePostOrderValue)
+        : RecordingVisitorBase(ShouldTraversePostOrderValue) {}
+
+    bool TraverseCompoundAssignOperator(CompoundAssignOperator *CAO) {
+      recordCallback(__func__, CAO, [&]() {
+        RecordingVisitorBase::TraverseCompoundAssignOperator(CAO);
+      });
+      return true;
+    }
+
+    bool WalkUpFromStmt(Stmt *S) {
+      recordCallback(__func__, S,
+                     [&]() { RecordingVisitorBase::WalkUpFromStmt(S); });
+      return true;
+    }
+
+    bool WalkUpFromExpr(Expr *E) {
+      recordCallback(__func__, E,
+                     [&]() { RecordingVisitorBase::WalkUpFromExpr(E); });
+      return true;
+    }
+
+    bool WalkUpFromCompoundAssignOperator(CompoundAssignOperator *CAO) {
+      recordCallback(__func__, CAO, [&]() {
+        RecordingVisitorBase::WalkUpFromCompoundAssignOperator(CAO);
+      });
+      return true;
+    }
+  };
+
+  StringRef Code = R"cpp(
+void test(int a) {
+  1;
+  a += 2;
+  3;
+}
+)cpp";
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::No), Code,
+      R"txt(
+WalkUpFromStmt CompoundStmt
+WalkUpFromExpr IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+TraverseCompoundAssignOperator CompoundAssignOperator(+=)
+  WalkUpFromCompoundAssignOperator CompoundAssignOperator(+=)
+    WalkUpFromExpr CompoundAssignOperator(+=)
+      WalkUpFromStmt CompoundAssignOperator(+=)
+  WalkUpFromExpr DeclRefExpr(a)
+    WalkUpFromStmt DeclRefExpr(a)
+  WalkUpFromExpr IntegerLiteral(2)
+    WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromExpr IntegerLiteral(3)
+  WalkUpFromStmt IntegerLiteral(3)
+)txt"));
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::Yes), Code,
+      R"txt(
+WalkUpFromExpr IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+TraverseCompoundAssignOperator CompoundAssignOperator(+=)
+  WalkUpFromExpr DeclRefExpr(a)
+    WalkUpFromStmt DeclRefExpr(a)
+  WalkUpFromExpr IntegerLiteral(2)
+    WalkUpFromStmt IntegerLiteral(2)
+  WalkUpFromCompoundAssignOperator CompoundAssignOperator(+=)
+    WalkUpFromExpr CompoundAssignOperator(+=)
+      WalkUpFromStmt CompoundAssignOperator(+=)
+WalkUpFromExpr IntegerLiteral(3)
+  WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromStmt CompoundStmt
+)txt"));
+}
+
+TEST(RecursiveASTEnterExitVisitor, StmtCallbacks_WalkUpFromCompoundAssignOperator) {
+  class RecordingVisitor : public RecordingVisitorBase<RecordingVisitor> {
+  public:
+    RecordingVisitor(ShouldTraversePostOrder ShouldTraversePostOrderValue)
+        : RecordingVisitorBase(ShouldTraversePostOrderValue) {}
+
+    bool WalkUpFromStmt(Stmt *S) {
+      recordCallback(__func__, S,
+                     [&]() { RecordingVisitorBase::WalkUpFromStmt(S); });
+      return true;
+    }
+
+    bool WalkUpFromExpr(Expr *E) {
+      recordCallback(__func__, E,
+                     [&]() { RecordingVisitorBase::WalkUpFromExpr(E); });
+      return true;
+    }
+
+    bool WalkUpFromCompoundAssignOperator(CompoundAssignOperator *CAO) {
+      recordCallback(__func__, CAO, [&]() {
+        RecordingVisitorBase::WalkUpFromCompoundAssignOperator(CAO);
+      });
+      return true;
+    }
+  };
+
+  StringRef Code = R"cpp(
+void test(int a) {
+  1;
+  a += 2;
+  3;
+}
+)cpp";
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::No), Code,
+      R"txt(
+WalkUpFromStmt CompoundStmt
+WalkUpFromExpr IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+WalkUpFromCompoundAssignOperator CompoundAssignOperator(+=)
+  WalkUpFromExpr CompoundAssignOperator(+=)
+    WalkUpFromStmt CompoundAssignOperator(+=)
+WalkUpFromExpr DeclRefExpr(a)
+  WalkUpFromStmt DeclRefExpr(a)
+WalkUpFromExpr IntegerLiteral(2)
+  WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromExpr IntegerLiteral(3)
+  WalkUpFromStmt IntegerLiteral(3)
+)txt"));
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::Yes), Code,
+      R"txt(
+WalkUpFromExpr IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+WalkUpFromExpr DeclRefExpr(a)
+  WalkUpFromStmt DeclRefExpr(a)
+WalkUpFromExpr IntegerLiteral(2)
+  WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromCompoundAssignOperator CompoundAssignOperator(+=)
+  WalkUpFromExpr CompoundAssignOperator(+=)
+    WalkUpFromStmt CompoundAssignOperator(+=)
+WalkUpFromExpr IntegerLiteral(3)
+  WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromStmt CompoundStmt
+)txt"));
+}

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CallbacksLeaf.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CallbacksLeaf.cpp
@@ -1,0 +1,285 @@
+//===--- unittests/Tooling/RecursiveASTEnterExitVisitorTests/CallbacksLeaf.cpp -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CallbacksCommon.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+TEST(RecursiveASTEnterExitVisitor, StmtCallbacks_TraverseLeaf) {
+  class RecordingVisitor : public RecordingVisitorBase<RecordingVisitor> {
+  public:
+    RecordingVisitor(ShouldTraversePostOrder ShouldTraversePostOrderValue)
+        : RecordingVisitorBase(ShouldTraversePostOrderValue) {}
+
+    bool TraverseIntegerLiteral(IntegerLiteral *IL) {
+      recordCallback(__func__, IL, [&]() {
+        RecordingVisitorBase::TraverseIntegerLiteral(IL);
+      });
+      return true;
+    }
+
+    bool WalkUpFromStmt(Stmt *S) {
+      recordCallback(__func__, S,
+                     [&]() { RecordingVisitorBase::WalkUpFromStmt(S); });
+      return true;
+    }
+  };
+
+  StringRef Code = R"cpp(
+void add(int, int);
+void test() {
+  1;
+  2 + 3;
+  add(4, 5);
+}
+)cpp";
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::No), Code,
+      R"txt(
+WalkUpFromStmt CompoundStmt
+TraverseIntegerLiteral IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+WalkUpFromStmt BinaryOperator(+)
+TraverseIntegerLiteral IntegerLiteral(2)
+  WalkUpFromStmt IntegerLiteral(2)
+TraverseIntegerLiteral IntegerLiteral(3)
+  WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromStmt CallExpr(add)
+WalkUpFromStmt ImplicitCastExpr
+WalkUpFromStmt DeclRefExpr(add)
+TraverseIntegerLiteral IntegerLiteral(4)
+  WalkUpFromStmt IntegerLiteral(4)
+TraverseIntegerLiteral IntegerLiteral(5)
+  WalkUpFromStmt IntegerLiteral(5)
+)txt"));
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::Yes), Code,
+      R"txt(
+TraverseIntegerLiteral IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+TraverseIntegerLiteral IntegerLiteral(2)
+  WalkUpFromStmt IntegerLiteral(2)
+TraverseIntegerLiteral IntegerLiteral(3)
+  WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromStmt BinaryOperator(+)
+WalkUpFromStmt DeclRefExpr(add)
+WalkUpFromStmt ImplicitCastExpr
+TraverseIntegerLiteral IntegerLiteral(4)
+  WalkUpFromStmt IntegerLiteral(4)
+TraverseIntegerLiteral IntegerLiteral(5)
+  WalkUpFromStmt IntegerLiteral(5)
+WalkUpFromStmt CallExpr(add)
+WalkUpFromStmt CompoundStmt
+)txt"));
+}
+
+TEST(RecursiveASTEnterExitVisitor, StmtCallbacks_TraverseLeaf_WalkUpFromLeaf) {
+  class RecordingVisitor : public RecordingVisitorBase<RecordingVisitor> {
+  public:
+    RecordingVisitor(ShouldTraversePostOrder ShouldTraversePostOrderValue)
+        : RecordingVisitorBase(ShouldTraversePostOrderValue) {}
+
+    bool TraverseIntegerLiteral(IntegerLiteral *IL) {
+      recordCallback(__func__, IL, [&]() {
+        RecordingVisitorBase::TraverseIntegerLiteral(IL);
+      });
+      return true;
+    }
+
+    bool WalkUpFromStmt(Stmt *S) {
+      recordCallback(__func__, S,
+                     [&]() { RecordingVisitorBase::WalkUpFromStmt(S); });
+      return true;
+    }
+
+    bool WalkUpFromExpr(Expr *E) {
+      recordCallback(__func__, E,
+                     [&]() { RecordingVisitorBase::WalkUpFromExpr(E); });
+      return true;
+    }
+
+    bool WalkUpFromIntegerLiteral(IntegerLiteral *IL) {
+      recordCallback(__func__, IL, [&]() {
+        RecordingVisitorBase::WalkUpFromIntegerLiteral(IL);
+      });
+      return true;
+    }
+  };
+
+  StringRef Code = R"cpp(
+void add(int, int);
+void test() {
+  1;
+  2 + 3;
+  add(4, 5);
+}
+)cpp";
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::No), Code,
+      R"txt(
+WalkUpFromStmt CompoundStmt
+TraverseIntegerLiteral IntegerLiteral(1)
+  WalkUpFromIntegerLiteral IntegerLiteral(1)
+    WalkUpFromExpr IntegerLiteral(1)
+      WalkUpFromStmt IntegerLiteral(1)
+WalkUpFromExpr BinaryOperator(+)
+  WalkUpFromStmt BinaryOperator(+)
+TraverseIntegerLiteral IntegerLiteral(2)
+  WalkUpFromIntegerLiteral IntegerLiteral(2)
+    WalkUpFromExpr IntegerLiteral(2)
+      WalkUpFromStmt IntegerLiteral(2)
+TraverseIntegerLiteral IntegerLiteral(3)
+  WalkUpFromIntegerLiteral IntegerLiteral(3)
+    WalkUpFromExpr IntegerLiteral(3)
+      WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromExpr CallExpr(add)
+  WalkUpFromStmt CallExpr(add)
+WalkUpFromExpr ImplicitCastExpr
+  WalkUpFromStmt ImplicitCastExpr
+WalkUpFromExpr DeclRefExpr(add)
+  WalkUpFromStmt DeclRefExpr(add)
+TraverseIntegerLiteral IntegerLiteral(4)
+  WalkUpFromIntegerLiteral IntegerLiteral(4)
+    WalkUpFromExpr IntegerLiteral(4)
+      WalkUpFromStmt IntegerLiteral(4)
+TraverseIntegerLiteral IntegerLiteral(5)
+  WalkUpFromIntegerLiteral IntegerLiteral(5)
+    WalkUpFromExpr IntegerLiteral(5)
+      WalkUpFromStmt IntegerLiteral(5)
+)txt"));
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::Yes), Code,
+      R"txt(
+TraverseIntegerLiteral IntegerLiteral(1)
+  WalkUpFromIntegerLiteral IntegerLiteral(1)
+    WalkUpFromExpr IntegerLiteral(1)
+      WalkUpFromStmt IntegerLiteral(1)
+TraverseIntegerLiteral IntegerLiteral(2)
+  WalkUpFromIntegerLiteral IntegerLiteral(2)
+    WalkUpFromExpr IntegerLiteral(2)
+      WalkUpFromStmt IntegerLiteral(2)
+TraverseIntegerLiteral IntegerLiteral(3)
+  WalkUpFromIntegerLiteral IntegerLiteral(3)
+    WalkUpFromExpr IntegerLiteral(3)
+      WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromExpr BinaryOperator(+)
+  WalkUpFromStmt BinaryOperator(+)
+WalkUpFromExpr DeclRefExpr(add)
+  WalkUpFromStmt DeclRefExpr(add)
+WalkUpFromExpr ImplicitCastExpr
+  WalkUpFromStmt ImplicitCastExpr
+TraverseIntegerLiteral IntegerLiteral(4)
+  WalkUpFromIntegerLiteral IntegerLiteral(4)
+    WalkUpFromExpr IntegerLiteral(4)
+      WalkUpFromStmt IntegerLiteral(4)
+TraverseIntegerLiteral IntegerLiteral(5)
+  WalkUpFromIntegerLiteral IntegerLiteral(5)
+    WalkUpFromExpr IntegerLiteral(5)
+      WalkUpFromStmt IntegerLiteral(5)
+WalkUpFromExpr CallExpr(add)
+  WalkUpFromStmt CallExpr(add)
+WalkUpFromStmt CompoundStmt
+)txt"));
+}
+
+TEST(RecursiveASTEnterExitVisitor, StmtCallbacks_WalkUpFromLeaf) {
+  class RecordingVisitor : public RecordingVisitorBase<RecordingVisitor> {
+  public:
+    RecordingVisitor(ShouldTraversePostOrder ShouldTraversePostOrderValue)
+        : RecordingVisitorBase(ShouldTraversePostOrderValue) {}
+
+    bool WalkUpFromStmt(Stmt *S) {
+      recordCallback(__func__, S,
+                     [&]() { RecordingVisitorBase::WalkUpFromStmt(S); });
+      return true;
+    }
+
+    bool WalkUpFromExpr(Expr *E) {
+      recordCallback(__func__, E,
+                     [&]() { RecordingVisitorBase::WalkUpFromExpr(E); });
+      return true;
+    }
+
+    bool WalkUpFromIntegerLiteral(IntegerLiteral *IL) {
+      recordCallback(__func__, IL, [&]() {
+        RecordingVisitorBase::WalkUpFromIntegerLiteral(IL);
+      });
+      return true;
+    }
+  };
+
+  StringRef Code = R"cpp(
+void add(int, int);
+void test() {
+  1;
+  2 + 3;
+  add(4, 5);
+}
+)cpp";
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::No), Code,
+      R"txt(
+WalkUpFromStmt CompoundStmt
+WalkUpFromIntegerLiteral IntegerLiteral(1)
+  WalkUpFromExpr IntegerLiteral(1)
+    WalkUpFromStmt IntegerLiteral(1)
+WalkUpFromExpr BinaryOperator(+)
+  WalkUpFromStmt BinaryOperator(+)
+WalkUpFromIntegerLiteral IntegerLiteral(2)
+  WalkUpFromExpr IntegerLiteral(2)
+    WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromIntegerLiteral IntegerLiteral(3)
+  WalkUpFromExpr IntegerLiteral(3)
+    WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromExpr CallExpr(add)
+  WalkUpFromStmt CallExpr(add)
+WalkUpFromExpr ImplicitCastExpr
+  WalkUpFromStmt ImplicitCastExpr
+WalkUpFromExpr DeclRefExpr(add)
+  WalkUpFromStmt DeclRefExpr(add)
+WalkUpFromIntegerLiteral IntegerLiteral(4)
+  WalkUpFromExpr IntegerLiteral(4)
+    WalkUpFromStmt IntegerLiteral(4)
+WalkUpFromIntegerLiteral IntegerLiteral(5)
+  WalkUpFromExpr IntegerLiteral(5)
+    WalkUpFromStmt IntegerLiteral(5)
+)txt"));
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::Yes), Code,
+      R"txt(
+WalkUpFromIntegerLiteral IntegerLiteral(1)
+  WalkUpFromExpr IntegerLiteral(1)
+    WalkUpFromStmt IntegerLiteral(1)
+WalkUpFromIntegerLiteral IntegerLiteral(2)
+  WalkUpFromExpr IntegerLiteral(2)
+    WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromIntegerLiteral IntegerLiteral(3)
+  WalkUpFromExpr IntegerLiteral(3)
+    WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromExpr BinaryOperator(+)
+  WalkUpFromStmt BinaryOperator(+)
+WalkUpFromExpr DeclRefExpr(add)
+  WalkUpFromStmt DeclRefExpr(add)
+WalkUpFromExpr ImplicitCastExpr
+  WalkUpFromStmt ImplicitCastExpr
+WalkUpFromIntegerLiteral IntegerLiteral(4)
+  WalkUpFromExpr IntegerLiteral(4)
+    WalkUpFromStmt IntegerLiteral(4)
+WalkUpFromIntegerLiteral IntegerLiteral(5)
+  WalkUpFromExpr IntegerLiteral(5)
+    WalkUpFromStmt IntegerLiteral(5)
+WalkUpFromExpr CallExpr(add)
+  WalkUpFromStmt CallExpr(add)
+WalkUpFromStmt CompoundStmt
+)txt"));
+}

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CallbacksUnaryOperator.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/CallbacksUnaryOperator.cpp
@@ -1,0 +1,201 @@
+//===- CallbacksUnaryOperator.cpp -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CallbacksCommon.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+TEST(RecursiveASTEnterExitVisitor, StmtCallbacks_TraverseUnaryOperator) {
+  class RecordingVisitor : public RecordingVisitorBase<RecordingVisitor> {
+  public:
+    RecordingVisitor(ShouldTraversePostOrder ShouldTraversePostOrderValue)
+        : RecordingVisitorBase(ShouldTraversePostOrderValue) {}
+
+    bool TraverseUnaryOperator(UnaryOperator *UO) {
+      recordCallback(__func__, UO, [&]() {
+        RecordingVisitorBase::TraverseUnaryOperator(UO);
+      });
+      return true;
+    }
+
+    bool WalkUpFromStmt(Stmt *S) {
+      recordCallback(__func__, S,
+                     [&]() { RecordingVisitorBase::WalkUpFromStmt(S); });
+      return true;
+    }
+  };
+
+  StringRef Code = R"cpp(
+void test() {
+  1;
+  -2;
+  3;
+}
+)cpp";
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::No), Code,
+      R"txt(
+WalkUpFromStmt CompoundStmt
+WalkUpFromStmt IntegerLiteral(1)
+TraverseUnaryOperator UnaryOperator(-)
+  WalkUpFromStmt UnaryOperator(-)
+  WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromStmt IntegerLiteral(3)
+)txt"));
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::Yes), Code,
+      R"txt(
+WalkUpFromStmt IntegerLiteral(1)
+TraverseUnaryOperator UnaryOperator(-)
+  WalkUpFromStmt IntegerLiteral(2)
+  WalkUpFromStmt UnaryOperator(-)
+WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromStmt CompoundStmt
+)txt"));
+}
+
+TEST(RecursiveASTEnterExitVisitor,
+     StmtCallbacks_TraverseUnaryOperator_WalkUpFromUnaryOperator) {
+  class RecordingVisitor : public RecordingVisitorBase<RecordingVisitor> {
+  public:
+    RecordingVisitor(ShouldTraversePostOrder ShouldTraversePostOrderValue)
+        : RecordingVisitorBase(ShouldTraversePostOrderValue) {}
+
+    bool TraverseUnaryOperator(UnaryOperator *UO) {
+      recordCallback(__func__, UO, [&]() {
+        RecordingVisitorBase::TraverseUnaryOperator(UO);
+      });
+      return true;
+    }
+
+    bool WalkUpFromStmt(Stmt *S) {
+      recordCallback(__func__, S,
+                     [&]() { RecordingVisitorBase::WalkUpFromStmt(S); });
+      return true;
+    }
+
+    bool WalkUpFromExpr(Expr *E) {
+      recordCallback(__func__, E,
+                     [&]() { RecordingVisitorBase::WalkUpFromExpr(E); });
+      return true;
+    }
+
+    bool WalkUpFromUnaryOperator(UnaryOperator *UO) {
+      recordCallback(__func__, UO, [&]() {
+        RecordingVisitorBase::WalkUpFromUnaryOperator(UO);
+      });
+      return true;
+    }
+  };
+
+  StringRef Code = R"cpp(
+void test() {
+  1;
+  -2;
+  3;
+}
+)cpp";
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::No), Code,
+      R"txt(
+WalkUpFromStmt CompoundStmt
+WalkUpFromExpr IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+TraverseUnaryOperator UnaryOperator(-)
+  WalkUpFromUnaryOperator UnaryOperator(-)
+    WalkUpFromExpr UnaryOperator(-)
+      WalkUpFromStmt UnaryOperator(-)
+  WalkUpFromExpr IntegerLiteral(2)
+    WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromExpr IntegerLiteral(3)
+  WalkUpFromStmt IntegerLiteral(3)
+)txt"));
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::Yes), Code,
+      R"txt(
+WalkUpFromExpr IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+TraverseUnaryOperator UnaryOperator(-)
+  WalkUpFromExpr IntegerLiteral(2)
+    WalkUpFromStmt IntegerLiteral(2)
+  WalkUpFromUnaryOperator UnaryOperator(-)
+    WalkUpFromExpr UnaryOperator(-)
+      WalkUpFromStmt UnaryOperator(-)
+WalkUpFromExpr IntegerLiteral(3)
+  WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromStmt CompoundStmt
+)txt"));
+}
+
+TEST(RecursiveASTEnterExitVisitor, StmtCallbacks_WalkUpFromUnaryOperator) {
+  class RecordingVisitor : public RecordingVisitorBase<RecordingVisitor> {
+  public:
+    RecordingVisitor(ShouldTraversePostOrder ShouldTraversePostOrderValue)
+        : RecordingVisitorBase(ShouldTraversePostOrderValue) {}
+
+    bool WalkUpFromStmt(Stmt *S) {
+      recordCallback(__func__, S,
+                     [&]() { RecordingVisitorBase::WalkUpFromStmt(S); });
+      return true;
+    }
+
+    bool WalkUpFromExpr(Expr *E) {
+      recordCallback(__func__, E,
+                     [&]() { RecordingVisitorBase::WalkUpFromExpr(E); });
+      return true;
+    }
+
+    bool WalkUpFromUnaryOperator(UnaryOperator *UO) {
+      recordCallback(__func__, UO, [&]() {
+        RecordingVisitorBase::WalkUpFromUnaryOperator(UO);
+      });
+      return true;
+    }
+  };
+
+  StringRef Code = R"cpp(
+void test() {
+  1;
+  -2;
+  3;
+}
+)cpp";
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::No), Code,
+      R"txt(
+WalkUpFromStmt CompoundStmt
+WalkUpFromExpr IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+WalkUpFromUnaryOperator UnaryOperator(-)
+  WalkUpFromExpr UnaryOperator(-)
+    WalkUpFromStmt UnaryOperator(-)
+WalkUpFromExpr IntegerLiteral(2)
+  WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromExpr IntegerLiteral(3)
+  WalkUpFromStmt IntegerLiteral(3)
+)txt"));
+
+  EXPECT_TRUE(visitorCallbackLogEqual(
+      RecordingVisitor(ShouldTraversePostOrder::Yes), Code,
+      R"txt(
+WalkUpFromExpr IntegerLiteral(1)
+  WalkUpFromStmt IntegerLiteral(1)
+WalkUpFromExpr IntegerLiteral(2)
+  WalkUpFromStmt IntegerLiteral(2)
+WalkUpFromUnaryOperator UnaryOperator(-)
+  WalkUpFromExpr UnaryOperator(-)
+    WalkUpFromStmt UnaryOperator(-)
+WalkUpFromExpr IntegerLiteral(3)
+  WalkUpFromStmt IntegerLiteral(3)
+WalkUpFromStmt CompoundStmt
+)txt"));
+}

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/Class.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/Class.cpp
@@ -1,0 +1,42 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/Class.cpp ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+// Checks for lambda classes that are not marked as implicitly-generated.
+// (There should be none.)
+class ClassVisitor : public ExpectedLocationVisitor {
+public:
+  ClassVisitor() : SawNonImplicitLambdaClass(false) {}
+
+  bool VisitCXXRecordDecl(CXXRecordDecl *record) override {
+    if (record->isLambda() && !record->isImplicit())
+      SawNonImplicitLambdaClass = true;
+    return true;
+  }
+
+  bool sawOnlyImplicitLambdaClasses() const {
+    return !SawNonImplicitLambdaClass;
+  }
+
+private:
+  bool SawNonImplicitLambdaClass;
+};
+
+TEST(RecursiveASTEnterExitVisitor, LambdaClosureTypesAreImplicit) {
+  ClassVisitor Visitor;
+  EXPECT_TRUE(Visitor.runOver("auto lambda = []{};", ClassVisitor::Lang_CXX11));
+  EXPECT_TRUE(Visitor.sawOnlyImplicitLambdaClasses());
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/Concept.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/Concept.cpp
@@ -1,0 +1,167 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/Concept.cpp----------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+#include "clang/AST/ASTConcept.h"
+#include "clang/AST/DeclTemplate.h"
+#include "clang/AST/ExprConcepts.h"
+#include "clang/AST/Type.h"
+
+using namespace clang;
+
+namespace {
+
+struct ConceptVisitor : ExpectedLocationVisitor {
+  ConceptVisitor(bool VisitImplicitCode = false) {
+    ShouldVisitImplicitCode = VisitImplicitCode;
+  }
+
+  bool VisitConceptSpecializationExpr(ConceptSpecializationExpr *E) override {
+    ++ConceptSpecializationExprsVisited;
+    return true;
+  }
+  bool TraverseTypeConstraint(const TypeConstraint *C) override {
+    ++TypeConstraintsTraversed;
+    return ExpectedLocationVisitor::TraverseTypeConstraint(C);
+  }
+  bool TraverseConceptRequirement(concepts::Requirement *R) override {
+    ++ConceptRequirementsTraversed;
+    return ExpectedLocationVisitor::TraverseConceptRequirement(R);
+  }
+  bool TraverseConceptReference(ConceptReference *CR) override {
+    ++ConceptReferencesTraversed;
+    return ExpectedLocationVisitor::TraverseConceptReference(CR);
+  }
+  bool VisitConceptReference(ConceptReference *CR) override {
+    ++ConceptReferencesVisited;
+    return true;
+  }
+
+  int ConceptSpecializationExprsVisited = 0;
+  int TypeConstraintsTraversed = 0;
+  int ConceptRequirementsTraversed = 0;
+  int ConceptReferencesTraversed = 0;
+  int ConceptReferencesVisited = 0;
+};
+
+TEST(RecursiveASTEnterExitVisitor, Concepts) {
+  {
+    ConceptVisitor Visitor{true};
+    EXPECT_TRUE(
+        Visitor.runOver("template <typename T> concept Fooable = true;\n"
+                        "template <Fooable T> void bar(T);",
+                        ConceptVisitor::Lang_CXX2a));
+    // Check that we traverse the "Fooable T" template parameter's
+    // TypeConstraint's ImmediatelyDeclaredConstraint, which is a
+    // ConceptSpecializationExpr.
+    EXPECT_EQ(1, Visitor.ConceptSpecializationExprsVisited);
+    // Also check we traversed the TypeConstraint that produced the expr.
+    EXPECT_EQ(1, Visitor.TypeConstraintsTraversed);
+    EXPECT_EQ(1, Visitor.ConceptReferencesTraversed);
+    EXPECT_EQ(1, Visitor.ConceptReferencesVisited);
+  }
+
+  {
+    ConceptVisitor Visitor; // Don't visit implicit code now.
+    EXPECT_TRUE(
+        Visitor.runOver("template <typename T> concept Fooable = true;\n"
+                        "template <Fooable T> void bar(T);",
+                        ConceptVisitor::Lang_CXX2a));
+    // Check that we only visit the TypeConstraint, but not the implicitly
+    // generated immediately declared expression.
+    EXPECT_EQ(0, Visitor.ConceptSpecializationExprsVisited);
+    EXPECT_EQ(1, Visitor.TypeConstraintsTraversed);
+    EXPECT_EQ(1, Visitor.ConceptReferencesTraversed);
+    EXPECT_EQ(1, Visitor.ConceptReferencesVisited);
+  }
+
+  {
+    ConceptVisitor Visitor;
+    EXPECT_TRUE(
+        Visitor.runOver("template <class T> concept A = true;\n"
+                        "template <class T> struct vector {};\n"
+                        "template <class T> concept B = requires(T x) {\n"
+                        "  typename vector<T*>;\n"
+                        "  {x} -> A;\n"
+                        "  requires true;\n"
+                        "};",
+                        ConceptVisitor::Lang_CXX2a));
+    EXPECT_EQ(3, Visitor.ConceptRequirementsTraversed);
+    EXPECT_EQ(1, Visitor.ConceptReferencesTraversed);
+    EXPECT_EQ(1, Visitor.ConceptReferencesVisited);
+  }
+
+  ConceptVisitor Visitor;
+  llvm::StringRef Code =
+      R"cpp(
+template<typename T> concept True = false;
+template <typename F> struct Foo {};
+
+template <typename F>
+  requires requires { requires True<F>; }
+struct Foo<F> {};
+
+template <typename F> requires True<F>
+struct Foo<F>  {};
+  )cpp";
+  EXPECT_TRUE(Visitor.runOver(Code, ConceptVisitor::Lang_CXX2a));
+  // Check that the concept references from the partial specializations are
+  // visited.
+  EXPECT_EQ(2, Visitor.ConceptReferencesTraversed);
+  EXPECT_EQ(2, Visitor.ConceptReferencesVisited);
+}
+
+struct VisitDeclOnlyOnce : ExpectedLocationVisitor {
+  VisitDeclOnlyOnce() { ShouldWalkTypesOfTypeLocs = false; }
+
+  bool VisitConceptDecl(ConceptDecl *D) override {
+    ++ConceptDeclsVisited;
+    return true;
+  }
+
+  bool VisitAutoType(AutoType *) override {
+    ++AutoTypeVisited;
+    return true;
+  }
+  bool VisitAutoTypeLoc(AutoTypeLoc) override {
+    ++AutoTypeLocVisited;
+    return true;
+  }
+  bool VisitConceptReference(ConceptReference *) override {
+    ++ConceptReferencesVisited;
+    return true;
+  }
+
+  bool TraverseVarDecl(VarDecl *V) override {
+    // The base traversal visits only the `TypeLoc`.
+    // However, in the test we also validate the underlying `QualType`.
+    TraverseType(V->getType());
+    return ExpectedLocationVisitor::TraverseVarDecl(V);
+  }
+
+  int ConceptDeclsVisited = 0;
+  int AutoTypeVisited = 0;
+  int AutoTypeLocVisited = 0;
+  int ConceptReferencesVisited = 0;
+};
+
+TEST(RecursiveASTEnterExitVisitor, ConceptDeclInAutoType) {
+  // Check `AutoType` and `AutoTypeLoc` do not repeatedly traverse the
+  // underlying concept.
+  VisitDeclOnlyOnce Visitor;
+  Visitor.runOver("template <class T> concept A = true;\n"
+                  "A auto i = 0;\n",
+                  VisitDeclOnlyOnce::Lang_CXX2a);
+  EXPECT_EQ(1, Visitor.AutoTypeVisited);
+  EXPECT_EQ(1, Visitor.AutoTypeLocVisited);
+  EXPECT_EQ(1, Visitor.ConceptDeclsVisited);
+  EXPECT_EQ(1, Visitor.ConceptReferencesVisited);
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/ConstructExpr.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/ConstructExpr.cpp
@@ -1,0 +1,66 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/ConstructExpr.cpp --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+/// \brief A visitor that optionally includes implicit code and matches
+/// CXXConstructExpr.
+///
+/// The name recorded for the match is the name of the class whose constructor
+/// is invoked by the CXXConstructExpr, not the name of the class whose
+/// constructor the CXXConstructExpr is contained in.
+class ConstructExprVisitor : public ExpectedLocationVisitor {
+public:
+  ConstructExprVisitor() { ShouldVisitImplicitCode = false; }
+
+  bool VisitCXXConstructExpr(CXXConstructExpr *Expr) override {
+    if (const CXXConstructorDecl* Ctor = Expr->getConstructor()) {
+      if (const CXXRecordDecl* Class = Ctor->getParent()) {
+        Match(Class->getName(), Expr->getLocation());
+      }
+    }
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, CanVisitImplicitMemberInitializations) {
+  ConstructExprVisitor Visitor;
+  Visitor.ShouldVisitImplicitCode = true;
+  Visitor.ExpectMatch("WithCtor", 2, 8);
+  // Simple has a constructor that implicitly initializes 'w'.  Test
+  // that a visitor that visits implicit code visits that initialization.
+  // Note: Clang lazily instantiates implicit declarations, so we need
+  // to use them in order to force them to appear in the AST.
+  EXPECT_TRUE(Visitor.runOver(
+      "struct WithCtor { WithCtor(); }; \n"
+      "struct Simple { WithCtor w; }; \n"
+      "int main() { Simple s; }\n"));
+}
+
+// The same as CanVisitImplicitMemberInitializations, but checking that the
+// visits are omitted when the visitor does not include implicit code.
+TEST(RecursiveASTEnterExitVisitor, CanSkipImplicitMemberInitializations) {
+  ConstructExprVisitor Visitor;
+  Visitor.ShouldVisitImplicitCode = false;
+  Visitor.DisallowMatch("WithCtor", 2, 8);
+  // Simple has a constructor that implicitly initializes 'w'.  Test
+  // that a visitor that skips implicit code skips that initialization.
+  // Note: Clang lazily instantiates implicit declarations, so we need
+  // to use them in order to force them to appear in the AST.
+  EXPECT_TRUE(Visitor.runOver(
+      "struct WithCtor { WithCtor(); }; \n"
+      "struct Simple { WithCtor w; }; \n"
+      "int main() { Simple s; }\n"));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/DeclRefExpr.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/DeclRefExpr.cpp
@@ -1,0 +1,116 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/DeclRefExpr.cpp ----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+class DeclRefExprVisitor : public ExpectedLocationVisitor {
+public:
+  DeclRefExprVisitor() { ShouldVisitImplicitCode = false; }
+
+  bool VisitDeclRefExpr(DeclRefExpr *Reference) override {
+    Match(Reference->getNameInfo().getAsString(), Reference->getLocation());
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, VisitsBaseClassTemplateArguments) {
+  DeclRefExprVisitor Visitor;
+  Visitor.ExpectMatch("x", 2, 3);
+  EXPECT_TRUE(Visitor.runOver(
+    "void x(); template <void (*T)()> class X {};\nX<x> y;"));
+}
+
+TEST(RecursiveASTEnterExitVisitor, VisitsCXXForRangeStmtRange) {
+  DeclRefExprVisitor Visitor;
+  Visitor.ExpectMatch("x", 2, 25);
+  Visitor.ExpectMatch("x", 2, 30);
+  EXPECT_TRUE(Visitor.runOver(
+    "int x[5];\n"
+    "void f() { for (int i : x) { x[0] = 1; } }",
+    DeclRefExprVisitor::Lang_CXX11));
+}
+
+TEST(RecursiveASTEnterExitVisitor, VisitsCallExpr) {
+  DeclRefExprVisitor Visitor;
+  Visitor.ExpectMatch("x", 1, 22);
+  EXPECT_TRUE(Visitor.runOver(
+    "void x(); void y() { x(); }"));
+}
+
+TEST(RecursiveASTEnterExitVisitor, VisitsExplicitLambdaCaptureInit) {
+  DeclRefExprVisitor Visitor;
+  Visitor.ExpectMatch("i", 1, 20);
+  EXPECT_TRUE(Visitor.runOver(
+    "void f() { int i; [i]{}; }",
+    DeclRefExprVisitor::Lang_CXX11));
+}
+
+TEST(RecursiveASTEnterExitVisitor, VisitsUseOfImplicitLambdaCapture) {
+  DeclRefExprVisitor Visitor;
+  Visitor.ExpectMatch("i", 1, 24);
+  EXPECT_TRUE(Visitor.runOver(
+    "void f() { int i; [=]{ i; }; }",
+    DeclRefExprVisitor::Lang_CXX11));
+}
+
+TEST(RecursiveASTEnterExitVisitor, VisitsImplicitLambdaCaptureInit) {
+  DeclRefExprVisitor Visitor;
+  Visitor.ShouldVisitImplicitCode = true;
+  // We're expecting "i" to be visited twice: once for the initialization expr
+  // for the captured variable "i" outside of the lambda body, and again for
+  // the use of "i" inside the lambda.
+  Visitor.ExpectMatch("i", 1, 20, /*Times=*/1);
+  Visitor.ExpectMatch("i", 1, 24, /*Times=*/1);
+  EXPECT_TRUE(Visitor.runOver(
+    "void f() { int i; [=]{ i; }; }",
+    DeclRefExprVisitor::Lang_CXX11));
+}
+
+TEST(RecursiveASTEnterExitVisitor, VisitsLambdaInitCaptureInit) {
+  DeclRefExprVisitor Visitor;
+  Visitor.ExpectMatch("i", 1, 24);
+  EXPECT_TRUE(Visitor.runOver(
+    "void f() { int i; [a = i + 1]{}; }",
+    DeclRefExprVisitor::Lang_CXX14));
+}
+
+/* FIXME: According to Richard Smith this is a bug in the AST.
+TEST(RecursiveASTEnterExitVisitor, VisitsBaseClassTemplateArgumentsInInstantiation) {
+  DeclRefExprVisitor Visitor;
+  Visitor.ExpectMatch("x", 3, 43);
+  EXPECT_TRUE(Visitor.runOver(
+    "template <typename T> void x();\n"
+    "template <void (*T)()> class X {};\n"
+    "template <typename T> class Y : public X< x<T> > {};\n"
+    "Y<int> y;"));
+}
+*/
+
+TEST(RecursiveASTEnterExitVisitor, VisitsExtension) {
+  DeclRefExprVisitor Visitor;
+  Visitor.ExpectMatch("s", 1, 24);
+  EXPECT_TRUE(Visitor.runOver(
+    "int s = __extension__ (s);\n"));
+}
+
+TEST(RecursiveASTEnterExitVisitor, VisitsCopyExprOfBlockDeclCapture) {
+  DeclRefExprVisitor Visitor;
+  Visitor.ExpectMatch("x", 3, 24);
+  EXPECT_TRUE(Visitor.runOver("void f(int(^)(int)); \n"
+                              "void g() { \n"
+                              "  f([&](int x){ return x; }); \n"
+                              "}",
+                              DeclRefExprVisitor::Lang_OBJCXX11));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/DeductionGuide.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/DeductionGuide.cpp
@@ -1,0 +1,83 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/DeductionGuide.cpp -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+#include <string>
+
+using namespace clang;
+
+namespace {
+
+class DeductionGuideVisitor : public ExpectedLocationVisitor {
+public:
+  DeductionGuideVisitor(bool VisitImplicitCode) {
+    ShouldVisitImplicitCode = VisitImplicitCode;
+    ShouldVisitTemplateInstantiations = false;
+  }
+
+  bool VisitCXXDeductionGuideDecl(CXXDeductionGuideDecl *D) override {
+    std::string Storage;
+    llvm::raw_string_ostream Stream(Storage);
+    D->print(Stream);
+    Match(Storage, D->getLocation());
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, DeductionGuideNonImplicitMode) {
+  DeductionGuideVisitor Visitor(/*ShouldVisitImplicitCode*/ false);
+  // Verify that the synthezied deduction guide for alias is not visited in
+  // RAV's implicit mode.
+  Visitor.ExpectMatch("Foo(T) -> Foo<int>", 11, 1);
+  Visitor.DisallowMatch("Bar(T) -> Foo<int>", 14, 1);
+  EXPECT_TRUE(Visitor.runOver(
+      R"cpp(
+template <typename T>
+concept False = true;
+
+template <typename T> 
+struct Foo { 
+  Foo(T);
+};
+
+template<typename T> requires False<T>
+Foo(T) -> Foo<int>;
+
+template <typename U>
+using Bar = Foo<U>;
+Bar s(1); 
+   )cpp",
+      DeductionGuideVisitor::Lang_CXX2a));
+}
+
+TEST(RecursiveASTEnterExitVisitor, DeductionGuideImplicitMode) {
+  DeductionGuideVisitor Visitor(/*ShouldVisitImplicitCode*/ true);
+  Visitor.ExpectMatch("Foo(T) -> Foo<int>", 11, 1);
+  Visitor.ExpectMatch("Bar(T) -> Foo<int>", 14, 1);
+  EXPECT_TRUE(Visitor.runOver(
+      R"cpp(
+template <typename T>
+concept False = true;
+
+template <typename T> 
+struct Foo { 
+  Foo(T);
+};
+
+template<typename T> requires False<T>
+Foo(T) -> Foo<int>;
+
+template <typename U>
+using Bar = Foo<U>;
+Bar s(1); 
+   )cpp",
+      DeductionGuideVisitor::Lang_CXX2a));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/ImplicitCtor.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/ImplicitCtor.cpp
@@ -1,0 +1,40 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/ImplicitCtor.cpp ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+// A visitor that visits implicit declarations and matches constructors.
+class ImplicitCtorVisitor : public ExpectedLocationVisitor {
+public:
+  bool VisitCXXConstructorDecl(CXXConstructorDecl *Ctor) override {
+    if (Ctor->isImplicit()) {  // Was not written in source code
+      if (const CXXRecordDecl* Class = Ctor->getParent()) {
+        Match(Class->getName(), Ctor->getLocation());
+      }
+    }
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, VisitsImplicitCopyConstructors) {
+  ImplicitCtorVisitor Visitor;
+  Visitor.ExpectMatch("Simple", 2, 8);
+  // Note: Clang lazily instantiates implicit declarations, so we need
+  // to use them in order to force them to appear in the AST.
+  EXPECT_TRUE(Visitor.runOver(
+      "struct WithCtor { WithCtor(); }; \n"
+      "struct Simple { Simple(); WithCtor w; }; \n"
+      "int main() { Simple s; Simple t(s); }\n"));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/ImplicitCtorInitializer.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/ImplicitCtorInitializer.cpp
@@ -1,0 +1,52 @@
+//=- unittest/Tooling/RecursiveASTEnterExitVisitorTests/ImplicitCtorInitializer.cpp -=//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+class CXXCtorInitializerVisitor : public ExpectedLocationVisitor {
+public:
+  CXXCtorInitializerVisitor(bool VisitImplicitCode) {
+    ShouldVisitImplicitCode = VisitImplicitCode;
+  }
+
+  bool TraverseConstructorInitializer(CXXCtorInitializer *Init) override {
+    if (!Init->isWritten())
+      VisitedImplicitInitializer = true;
+    Match("initializer", Init->getSourceLocation());
+    return ExpectedLocationVisitor::TraverseConstructorInitializer(Init);
+  }
+
+  bool VisitedImplicitInitializer = false;
+};
+
+// Check to ensure that CXXCtorInitializer is not visited when implicit code
+// should not be visited and that it is visited when implicit code should be
+// visited.
+TEST(RecursiveASTEnterExitVisitor, CXXCtorInitializerVisitNoImplicit) {
+  for (bool VisitImplCode : {true, false}) {
+    CXXCtorInitializerVisitor Visitor(VisitImplCode);
+    Visitor.ExpectMatch("initializer", 7, 17);
+    llvm::StringRef Code = R"cpp(
+        class A {};
+        class B : public A {
+          B() {};
+        };
+        class C : public A {
+          C() : A() {}
+        };
+      )cpp";
+    EXPECT_TRUE(Visitor.runOver(Code, CXXCtorInitializerVisitor::Lang_CXX));
+    EXPECT_EQ(Visitor.VisitedImplicitInitializer, VisitImplCode);
+  }
+}
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/InitListExprPostOrder.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/InitListExprPostOrder.cpp
@@ -1,0 +1,36 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/InitListExprPostOrder.cpp -==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CRTPTestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+class InitListExprPostOrderVisitor
+    : public CRTPExpectedLocationVisitor<InitListExprPostOrderVisitor> {
+public:
+  bool shouldTraversePostOrder() const { return true; }
+
+  bool VisitInitListExpr(InitListExpr *ILE) {
+    Match(ILE->isSemanticForm() ? "semantic" : "syntactic", ILE->getBeginLoc());
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, InitListExprIsPostOrderVisitedTwice) {
+  InitListExprPostOrderVisitor Visitor;
+  Visitor.ExpectMatch("syntactic", 2, 21);
+  Visitor.ExpectMatch("semantic", 2, 21);
+  EXPECT_TRUE(Visitor.runOver("struct S { int x; };\n"
+                              "static struct S s = {.x = 0};\n",
+                              InitListExprPostOrderVisitor::Lang_C));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/InitListExprPostOrderNoQueue.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/InitListExprPostOrderNoQueue.cpp
@@ -1,0 +1,40 @@
+//===- InitListExprPostOrderNoQueue.cpp -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CRTPTestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+class InitListExprPostOrderNoQueueVisitor
+    : public CRTPExpectedLocationVisitor<InitListExprPostOrderNoQueueVisitor> {
+public:
+  bool shouldTraversePostOrder() const { return true; }
+
+  bool TraverseInitListExpr(InitListExpr *ILE) {
+    return CRTPExpectedLocationVisitor::TraverseInitListExpr(ILE);
+  }
+
+  bool VisitInitListExpr(InitListExpr *ILE) {
+    Match(ILE->isSemanticForm() ? "semantic" : "syntactic", ILE->getBeginLoc());
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, InitListExprIsPostOrderNoQueueVisitedTwice) {
+  InitListExprPostOrderNoQueueVisitor Visitor;
+  Visitor.ExpectMatch("syntactic", 2, 21);
+  Visitor.ExpectMatch("semantic", 2, 21);
+  EXPECT_TRUE(Visitor.runOver("struct S { int x; };\n"
+                              "static struct S s = {.x = 0};\n",
+                              InitListExprPostOrderNoQueueVisitor::Lang_C));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/InitListExprPreOrder.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/InitListExprPreOrder.cpp
@@ -1,0 +1,48 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/InitListExprPreOrder.cpp -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+// Check to ensure that InitListExpr is visited twice, once each for the
+// syntactic and semantic form.
+class InitListExprPreOrderVisitor : public ExpectedLocationVisitor {
+public:
+  InitListExprPreOrderVisitor(bool VisitImplicitCode) {
+    ShouldVisitImplicitCode = VisitImplicitCode;
+  }
+
+  bool VisitInitListExpr(InitListExpr *ILE) override {
+    Match(ILE->isSemanticForm() ? "semantic" : "syntactic", ILE->getBeginLoc());
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, InitListExprIsPreOrderVisitedTwice) {
+  InitListExprPreOrderVisitor Visitor(/*VisitImplicitCode=*/true);
+  Visitor.ExpectMatch("syntactic", 2, 21);
+  Visitor.ExpectMatch("semantic", 2, 21);
+  EXPECT_TRUE(Visitor.runOver("struct S { int x; };\n"
+                              "static struct S s = {.x = 0};\n",
+                              InitListExprPreOrderVisitor::Lang_C));
+}
+
+TEST(RecursiveASTEnterExitVisitor, InitListExprVisitedOnceWhenNoImplicit) {
+  InitListExprPreOrderVisitor Visitor(/*VisitImplicitCode=*/false);
+  Visitor.ExpectMatch("syntactic", 2, 21);
+  Visitor.DisallowMatch("semantic", 2, 21);
+  EXPECT_TRUE(Visitor.runOver("struct S { int x; };\n"
+                              "static struct S s = {.x = 0};\n",
+                              InitListExprPreOrderVisitor::Lang_C));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/InitListExprPreOrderNoQueue.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/InitListExprPreOrderNoQueue.cpp
@@ -1,0 +1,37 @@
+//===- InitListExprPreOrderNoQueue.cpp ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+class InitListExprPreOrderNoQueueVisitor : public ExpectedLocationVisitor {
+public:
+  bool TraverseInitListExpr(InitListExpr *ILE) override {
+    return ExpectedLocationVisitor::TraverseInitListExpr(ILE);
+  }
+
+  bool VisitInitListExpr(InitListExpr *ILE) override {
+    Match(ILE->isSemanticForm() ? "semantic" : "syntactic", ILE->getBeginLoc());
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, InitListExprIsPreOrderNoQueueVisitedTwice) {
+  InitListExprPreOrderNoQueueVisitor Visitor;
+  Visitor.ExpectMatch("syntactic", 2, 21);
+  Visitor.ExpectMatch("semantic", 2, 21);
+  EXPECT_TRUE(Visitor.runOver("struct S { int x; };\n"
+                              "static struct S s = {.x = 0};\n",
+                              InitListExprPreOrderNoQueueVisitor::Lang_C));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/IntegerLiteral.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/IntegerLiteral.cpp
@@ -1,0 +1,32 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/IntegerLiteral.cpp -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+// Check to ensure that implicit default argument expressions are visited.
+class IntegerLiteralVisitor : public ExpectedLocationVisitor {
+public:
+  bool VisitIntegerLiteral(IntegerLiteral *IL) override {
+    Match("literal", IL->getLocation());
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, DefaultArgumentsAreVisited) {
+  IntegerLiteralVisitor Visitor;
+  Visitor.ExpectMatch("literal", 1, 15, 2);
+  EXPECT_TRUE(Visitor.runOver("int f(int i = 1);\n"
+                              "static int k = f();\n"));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/LambdaDefaultCapture.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/LambdaDefaultCapture.cpp
@@ -1,0 +1,34 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/LambdaDefaultCapture.cpp -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+// Matches the (optional) capture-default of a lambda-introducer.
+class LambdaDefaultCaptureVisitor : public ExpectedLocationVisitor {
+public:
+  bool VisitLambdaExpr(LambdaExpr *Lambda) override {
+    if (Lambda->getCaptureDefault() != LCD_None) {
+      Match("", Lambda->getCaptureDefaultLoc());
+    }
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, HasCaptureDefaultLoc) {
+  LambdaDefaultCaptureVisitor Visitor;
+  Visitor.ExpectMatch("", 1, 20);
+  EXPECT_TRUE(Visitor.runOver("void f() { int a; [=]{a;}; }",
+                              LambdaDefaultCaptureVisitor::Lang_CXX11));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/LambdaExpr.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/LambdaExpr.cpp
@@ -1,0 +1,99 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/LambdaExpr.cpp -----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+#include "llvm/TargetParser/Host.h"
+#include <stack>
+
+using namespace clang;
+
+namespace {
+
+class LambdaExprVisitor : public ExpectedLocationVisitor {
+public:
+  LambdaExprVisitor() { ShouldVisitImplicitCode = false; }
+
+  bool VisitLambdaExpr(LambdaExpr *Lambda) override {
+    PendingBodies.push(Lambda->getBody());
+    PendingClasses.push(Lambda->getLambdaClass());
+    Match("", Lambda->getIntroducerRange().getBegin());
+    return true;
+  }
+  /// For each call to VisitLambdaExpr, we expect a subsequent call to visit
+  /// the body (and maybe the lambda class, which is implicit).
+  bool VisitStmt(Stmt *S) override {
+    if (!PendingBodies.empty() && S == PendingBodies.top())
+      PendingBodies.pop();
+    return true;
+  }
+  bool VisitDecl(Decl *D) override {
+    if (!PendingClasses.empty() && D == PendingClasses.top())
+      PendingClasses.pop();
+    return true;
+  }
+  /// Determine whether parts of lambdas (VisitLambdaExpr) were later traversed.
+  bool allBodiesHaveBeenTraversed() const { return PendingBodies.empty(); }
+  bool allClassesHaveBeenTraversed() const { return PendingClasses.empty(); }
+
+private:
+  std::stack<Stmt *> PendingBodies;
+  std::stack<Decl *> PendingClasses;
+};
+
+TEST(RecursiveASTEnterExitVisitor, VisitsLambdaExpr) {
+  LambdaExprVisitor Visitor;
+  Visitor.ExpectMatch("", 1, 12);
+  EXPECT_TRUE(Visitor.runOver("void f() { []{ return; }(); }",
+                              LambdaExprVisitor::Lang_CXX11));
+  EXPECT_TRUE(Visitor.allBodiesHaveBeenTraversed());
+  EXPECT_FALSE(Visitor.allClassesHaveBeenTraversed());
+}
+
+TEST(RecursiveASTEnterExitVisitor, LambdaInLambda) {
+  LambdaExprVisitor Visitor;
+  Visitor.ExpectMatch("", 1, 12);
+  Visitor.ExpectMatch("", 1, 16);
+  EXPECT_TRUE(Visitor.runOver("void f() { []{ []{ return; }; }(); }",
+                              LambdaExprVisitor::Lang_CXX11));
+  EXPECT_TRUE(Visitor.allBodiesHaveBeenTraversed());
+  EXPECT_FALSE(Visitor.allClassesHaveBeenTraversed());
+}
+
+TEST(RecursiveASTEnterExitVisitor, TopLevelLambda) {
+  LambdaExprVisitor Visitor;
+  Visitor.ShouldVisitImplicitCode = true;
+  Visitor.ExpectMatch("", 1, 10);
+  Visitor.ExpectMatch("", 1, 14);
+  EXPECT_TRUE(Visitor.runOver("auto x = []{ [] {}; };",
+                              LambdaExprVisitor::Lang_CXX11));
+  EXPECT_TRUE(Visitor.allBodiesHaveBeenTraversed());
+  EXPECT_TRUE(Visitor.allClassesHaveBeenTraversed());
+}
+
+TEST(RecursiveASTEnterExitVisitor, VisitsLambdaExprAndImplicitClass) {
+  LambdaExprVisitor Visitor;
+  Visitor.ShouldVisitImplicitCode = true;
+  Visitor.ExpectMatch("", 1, 12);
+  EXPECT_TRUE(Visitor.runOver("void f() { []{ return; }(); }",
+                              LambdaExprVisitor::Lang_CXX11));
+  EXPECT_TRUE(Visitor.allBodiesHaveBeenTraversed());
+  EXPECT_TRUE(Visitor.allClassesHaveBeenTraversed());
+}
+
+TEST(RecursiveASTEnterExitVisitor, VisitsAttributedLambdaExpr) {
+  if (llvm::Triple(llvm::sys::getDefaultTargetTriple()).isPS())
+    GTEST_SKIP(); // PS4/PS5 do not support fastcall.
+  LambdaExprVisitor Visitor;
+  Visitor.ExpectMatch("", 1, 12);
+  EXPECT_TRUE(Visitor.runOver(
+      "void f() { [] () __attribute__ (( fastcall )) { return; }(); }",
+      LambdaExprVisitor::Lang_CXX14));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/LambdaTemplateParams.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/LambdaTemplateParams.cpp
@@ -1,0 +1,52 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/LambdaTemplateParams.cpp -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+// Matches (optional) explicit template parameters.
+class LambdaTemplateParametersVisitor : public ExpectedLocationVisitor {
+public:
+  LambdaTemplateParametersVisitor() { ShouldVisitImplicitCode = false; }
+
+  bool VisitTemplateTypeParmDecl(TemplateTypeParmDecl *D) override {
+    EXPECT_FALSE(D->isImplicit());
+    Match(D->getName(), D->getBeginLoc());
+    return true;
+  }
+
+  bool VisitNonTypeTemplateParmDecl(NonTypeTemplateParmDecl *D) override {
+    EXPECT_FALSE(D->isImplicit());
+    Match(D->getName(), D->getBeginLoc());
+    return true;
+  }
+
+  bool VisitTemplateTemplateParmDecl(TemplateTemplateParmDecl *D) override {
+    EXPECT_FALSE(D->isImplicit());
+    Match(D->getName(), D->getBeginLoc());
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, VisitsLambdaExplicitTemplateParameters) {
+  LambdaTemplateParametersVisitor Visitor;
+  Visitor.ExpectMatch("T",  2, 15);
+  Visitor.ExpectMatch("I",  2, 24);
+  Visitor.ExpectMatch("TT", 2, 31);
+  EXPECT_TRUE(Visitor.runOver(
+      "void f() { \n"
+      "  auto l = []<class T, int I, template<class> class TT>(auto p) { }; \n"
+      "}",
+      LambdaTemplateParametersVisitor::Lang_CXX2a));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/MemberPointerTypeLoc.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/MemberPointerTypeLoc.cpp
@@ -1,0 +1,58 @@
+//===- unittest/Tooling/EnterExitRecursiveASTEnterExitVisitorTests/MemberPointerTypeLoc.cpp -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+#include "llvm/ADT/StringRef.h"
+
+using namespace clang;
+
+namespace {
+
+class MemberPointerTypeLocVisitor : public ExpectedLocationVisitor {
+public:
+  bool VisitTemplateTypeParmTypeLoc(TemplateTypeParmTypeLoc TL) override {
+    if (!TL)
+      return true;
+    Match(TL.getDecl()->getName(), TL.getNameLoc());
+    return true;
+  }
+  bool VisitRecordTypeLoc(RecordTypeLoc RTL) override {
+    if (!RTL)
+      return true;
+    Match(RTL.getDecl()->getName(), RTL.getNameLoc());
+    return true;
+  }
+};
+
+TEST(EnterExitRecursiveASTEnterExitVisitor, VisitTypeLocInMemberPointerTypeLoc) {
+  MemberPointerTypeLocVisitor Visitor;
+  Visitor.ExpectMatch("Bar", 4, 36);
+  Visitor.ExpectMatch("T", 7, 23);
+  llvm::StringLiteral Code = R"cpp(
+     class Bar { void func(int); };
+     class Foo {
+       void bind(const char*, void(Bar::*Foo)(int)) {}
+
+       template<typename T>
+       void test(void(T::*Foo)());
+     };
+  )cpp";
+  EXPECT_TRUE(Visitor.runOver(Code));
+}
+
+TEST(EnterExitRecursiveASTEnterExitVisitor, NoCrash) {
+  MemberPointerTypeLocVisitor Visitor;
+  llvm::StringLiteral Code = R"cpp(
+     // MemberPointerTypeLoc.getClassTInfo() is null.
+     class a(b(a::*)) class
+  )cpp";
+  EXPECT_FALSE(Visitor.runOver(Code));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/NestedNameSpecifiers.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/NestedNameSpecifiers.cpp
@@ -1,0 +1,73 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/NestedNameSpecifiers.cpp -===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+// Check to ensure that nested name specifiers are visited.
+class NestedNameSpecifiersVisitor : public ExpectedLocationVisitor {
+public:
+  bool VisitRecordTypeLoc(RecordTypeLoc RTL) override {
+    if (!RTL)
+      return true;
+    Match(RTL.getDecl()->getName(), RTL.getNameLoc());
+    return true;
+  }
+
+  bool TraverseNestedNameSpecifierLoc(NestedNameSpecifierLoc NNS) override {
+    if (!NNS)
+      return true;
+    if (const NamespaceDecl *ND =
+            NNS.getNestedNameSpecifier()->getAsNamespace())
+      Match(ND->getName(), NNS.getLocalBeginLoc());
+    return ExpectedLocationVisitor::TraverseNestedNameSpecifierLoc(NNS);
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor,
+     NestedNameSpecifiersForTemplateSpecializationsAreVisited) {
+  StringRef Source = R"(
+namespace ns {
+struct Outer {
+    template<typename T, typename U>
+    struct Nested { };
+
+    template<typename T>
+    static T x;
+};
+}
+
+template<>
+struct ns::Outer::Nested<int, int>;
+
+template<>
+struct ns::Outer::Nested<int, int> { };
+
+template<typename T>
+struct ns::Outer::Nested<int, T> { };
+
+template<>
+int ns::Outer::x<int> = 0;
+)";
+  NestedNameSpecifiersVisitor Visitor;
+  Visitor.ExpectMatch("ns", 13, 8);
+  Visitor.ExpectMatch("ns", 16, 8);
+  Visitor.ExpectMatch("ns", 19, 8);
+  Visitor.ExpectMatch("ns", 22, 5);
+  Visitor.ExpectMatch("Outer", 13, 12);
+  Visitor.ExpectMatch("Outer", 16, 12);
+  Visitor.ExpectMatch("Outer", 19, 12);
+  Visitor.ExpectMatch("Outer", 22, 9);
+  EXPECT_TRUE(Visitor.runOver(Source, NestedNameSpecifiersVisitor::Lang_CXX14));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/ParenExpr.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/ParenExpr.cpp
@@ -1,0 +1,30 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/ParenExpr.cpp ------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+class ParenExprVisitor : public ExpectedLocationVisitor {
+public:
+  bool VisitParenExpr(ParenExpr *Parens) override {
+    Match("", Parens->getExprLoc());
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, VisitsParensDuringDataRecursion) {
+  ParenExprVisitor Visitor;
+  Visitor.ExpectMatch("", 1, 9);
+  EXPECT_TRUE(Visitor.runOver("int k = (4) + 9;\n"));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/TemplateArgumentLocTraverser.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/TemplateArgumentLocTraverser.cpp
@@ -1,0 +1,38 @@
+//===- TemplateArgumentLocTraverser.cpp -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+class TemplateArgumentLocTraverser : public ExpectedLocationVisitor {
+public:
+  bool TraverseTemplateArgumentLoc(const TemplateArgumentLoc &ArgLoc) override {
+    std::string ArgStr;
+    llvm::raw_string_ostream Stream(ArgStr);
+    const TemplateArgument &Arg = ArgLoc.getArgument();
+
+    Arg.print(Context->getPrintingPolicy(), Stream, /*IncludeType*/ true);
+    Match(ArgStr, ArgLoc.getLocation());
+    return ExpectedLocationVisitor::TraverseTemplateArgumentLoc(ArgLoc);
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, VisitsClassTemplateTemplateParmDefaultArgument) {
+  TemplateArgumentLocTraverser Visitor;
+  Visitor.ExpectMatch("X", 2, 40);
+  EXPECT_TRUE(Visitor.runOver(
+    "template<typename T> class X;\n"
+    "template<template <typename> class T = X> class Y;\n"
+    "template<template <typename> class T> class Y {};\n"));
+}
+
+} // end anonymous namespace

--- a/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/TraversalScope.cpp
+++ b/clang/unittests/Tooling/RecursiveASTEnterExitVisitorTests/TraversalScope.cpp
@@ -1,0 +1,58 @@
+//===- unittest/Tooling/RecursiveASTEnterExitVisitorTests/TraversalScope.cpp -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestVisitor.h"
+#include "clang/AST/RecursiveASTEnterExitVisitor.h"
+
+using namespace clang;
+
+namespace {
+
+class Visitor : public ExpectedLocationVisitor {
+public:
+  Visitor(ASTContext *Context) { this->Context = Context; }
+
+  bool VisitTranslationUnitDecl(TranslationUnitDecl *D) override {
+    auto &SM = D->getParentASTContext().getSourceManager();
+    Match("TU", SM.getLocForStartOfFile(SM.getMainFileID()));
+    return true;
+  }
+
+  bool VisitNamedDecl(NamedDecl *D) override {
+    if (!D->isImplicit())
+      Match(D->getName(), D->getLocation());
+    return true;
+  }
+};
+
+TEST(RecursiveASTEnterExitVisitor, RespectsTraversalScope) {
+  auto AST = tooling::buildASTFromCode(
+      R"cpp(
+struct foo {
+  struct bar {
+    struct baz {};
+  };
+};
+      )cpp",
+      "foo.cpp", std::make_shared<PCHContainerOperations>());
+  auto &Ctx = AST->getASTContext();
+  auto &TU = *Ctx.getTranslationUnitDecl();
+  auto &Foo = *TU.lookup(&Ctx.Idents.get("foo")).front();
+  auto &Bar = *cast<DeclContext>(Foo).lookup(&Ctx.Idents.get("bar")).front();
+
+  Ctx.setTraversalScope({&Bar});
+
+  Visitor V(&Ctx);
+  V.ExpectMatch("TU", 1, 1);
+  V.DisallowMatch("foo", 2, 8);
+  V.ExpectMatch("bar", 3, 10);
+  V.ExpectMatch("baz", 4, 12);
+  V.TraverseAST(Ctx);
+}
+
+} // end anonymous namespace


### PR DESCRIPTION
@Sirraide : This is my first PR to clang and llvm.

The PR creates a RecursiveASTVisitor type called `RecursiveASTEnterExitVisitor` that allows users to implement Visit methods before visiting an AST node and after visiting an AST node. The additional functionality is additive in nature and extends the existing implementation.

Users can optionally implement `VisitEnter<AST NodeType>`, `Visit<AST NodeType>`, and `VisitExit<AST NodeType>`. This functionality makes visitation method behavior explicitly defined.