### PR TITLE
[BOLT] Gadget scanner: clarify MCPlusBuilder callbacks interface

### DIFF
--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -566,7 +566,7 @@ public:
   /// or std::nullopt if not authenticating any register.
   ///
   /// Sets IsChecked if the instruction always checks authenticated pointer,
-  /// i.e. it either returns a successfully authenticated pointer or terminates
+  /// i.e. it either writes a successfully authenticated pointer or terminates
   /// the program abnormally (such as "ldra x0, [x1]!" on AArch64, which crashes
   /// on authentication failure even if FEAT_FPAC is not implemented).
   virtual std::optional<MCPhysReg>
@@ -610,7 +610,7 @@ public:
   getRegUsedAsIndirectBranchDest(const MCInst &Inst,
                                  bool &IsAuthenticatedInternally) const {
     llvm_unreachable("not implemented");
-    return getNoRegister();
+    return 0;
   }
 
   /// Returns the register containing an address safely materialized by `Inst`

--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -610,7 +610,8 @@ public:
   getRegUsedAsIndirectBranchDest(const MCInst &Inst,
                                  bool &IsAuthenticatedInternally) const {
     llvm_unreachable("not implemented");
-    return 0;
+    return 0; // Unreachable. A valid register should be returned by the
+              // target implementation.
   }
 
   /// Returns the register containing an address safely materialized by `Inst`

--- a/bolt/lib/Passes/PAuthGadgetScanner.cpp
+++ b/bolt/lib/Passes/PAuthGadgetScanner.cpp
@@ -66,14 +66,12 @@ namespace PAuthGadgetScanner {
 }
 
 [[maybe_unused]] static void traceReg(const BinaryContext &BC, StringRef Label,
-                                      ErrorOr<MCPhysReg> Reg) {
+                                      MCPhysReg Reg) {
   dbgs() << "    " << Label << ": ";
-  if (Reg.getError())
-    dbgs() << "(error)";
-  else if (*Reg == BC.MIB->getNoRegister())
+  if (Reg == BC.MIB->getNoRegister())
     dbgs() << "(none)";
   else
-    dbgs() << BC.MRI->getName(*Reg);
+    dbgs() << BC.MRI->getName(Reg);
   dbgs() << "\n";
 }
 

--- a/bolt/lib/Passes/PAuthGadgetScanner.cpp
+++ b/bolt/lib/Passes/PAuthGadgetScanner.cpp
@@ -365,17 +365,15 @@ protected:
   SmallVector<MCPhysReg> getRegsMadeSafeToDeref(const MCInst &Point,
                                                 const SrcState &Cur) const {
     SmallVector<MCPhysReg> Regs;
-    const MCPhysReg NoReg = BC.MIB->getNoRegister();
 
     // A signed pointer can be authenticated, or
-    ErrorOr<MCPhysReg> AutReg = BC.MIB->getAuthenticatedReg(Point);
-    if (AutReg && *AutReg != NoReg)
+    bool Dummy = false;
+    if (auto AutReg = BC.MIB->getWrittenAuthenticatedReg(Point, Dummy))
       Regs.push_back(*AutReg);
 
     // ... a safe address can be materialized, or
-    MCPhysReg NewAddrReg = BC.MIB->getMaterializedAddressRegForPtrAuth(Point);
-    if (NewAddrReg != NoReg)
-      Regs.push_back(NewAddrReg);
+    if (auto NewAddrReg = BC.MIB->getMaterializedAddressRegForPtrAuth(Point))
+      Regs.push_back(*NewAddrReg);
 
     // ... an address can be updated in a safe manner, producing the result
     // which is as trusted as the input address.
@@ -391,13 +389,20 @@ protected:
   SmallVector<MCPhysReg> getRegsMadeTrusted(const MCInst &Point,
                                             const SrcState &Cur) const {
     SmallVector<MCPhysReg> Regs;
-    const MCPhysReg NoReg = BC.MIB->getNoRegister();
 
     // An authenticated pointer can be checked, or
-    MCPhysReg CheckedReg =
+    std::optional<MCPhysReg> CheckedReg =
         BC.MIB->getAuthCheckedReg(Point, /*MayOverwrite=*/false);
-    if (CheckedReg != NoReg && Cur.SafeToDerefRegs[CheckedReg])
-      Regs.push_back(CheckedReg);
+    if (CheckedReg && Cur.SafeToDerefRegs[*CheckedReg])
+      Regs.push_back(*CheckedReg);
+
+    // ... a pointer can be authenticated by an instruction that always checks
+    // the pointer, or
+    bool IsChecked = false;
+    std::optional<MCPhysReg> AutReg =
+        BC.MIB->getWrittenAuthenticatedReg(Point, IsChecked);
+    if (AutReg && IsChecked)
+      Regs.push_back(*AutReg);
 
     if (CheckerSequenceInfo.contains(&Point)) {
       MCPhysReg CheckedReg;
@@ -413,9 +418,8 @@ protected:
     }
 
     // ... a safe address can be materialized, or
-    MCPhysReg NewAddrReg = BC.MIB->getMaterializedAddressRegForPtrAuth(Point);
-    if (NewAddrReg != NoReg)
-      Regs.push_back(NewAddrReg);
+    if (auto NewAddrReg = BC.MIB->getMaterializedAddressRegForPtrAuth(Point))
+      Regs.push_back(*NewAddrReg);
 
     // ... an address can be updated in a safe manner, producing the result
     // which is as trusted as the input address.
@@ -738,25 +742,28 @@ shouldReportReturnGadget(const BinaryContext &BC, const MCInstReference &Inst,
   if (!BC.MIB->isReturn(Inst))
     return std::nullopt;
 
-  ErrorOr<MCPhysReg> MaybeRetReg = BC.MIB->getRegUsedAsRetDest(Inst);
-  if (MaybeRetReg.getError()) {
+  bool IsAuthenticated = false;
+  std::optional<MCPhysReg> RetReg =
+      BC.MIB->getRegUsedAsRetDest(Inst, IsAuthenticated);
+  if (!RetReg) {
     return make_generic_report(
         Inst, "Warning: pac-ret analysis could not analyze this return "
               "instruction");
   }
-  MCPhysReg RetReg = *MaybeRetReg;
-  LLVM_DEBUG({
-    traceInst(BC, "Found RET inst", Inst);
-    traceReg(BC, "RetReg", RetReg);
-    traceReg(BC, "Authenticated reg", BC.MIB->getAuthenticatedReg(Inst));
-  });
-  if (BC.MIB->isAuthenticationOfReg(Inst, RetReg))
-    return std::nullopt;
-  LLVM_DEBUG({ traceRegMask(BC, "SafeToDerefRegs", S.SafeToDerefRegs); });
-  if (S.SafeToDerefRegs[RetReg])
+  if (IsAuthenticated)
     return std::nullopt;
 
-  return make_gadget_report(RetKind, Inst, RetReg);
+  assert(*RetReg != BC.MIB->getNoRegister());
+  LLVM_DEBUG({
+    traceInst(BC, "Found RET inst", Inst);
+    traceReg(BC, "RetReg", *RetReg);
+    traceRegMask(BC, "SafeToDerefRegs", S.SafeToDerefRegs);
+  });
+
+  if (S.SafeToDerefRegs[*RetReg])
+    return std::nullopt;
+
+  return make_gadget_report(RetKind, Inst, *RetReg);
 }
 
 static std::optional<PartialReport<MCPhysReg>>
@@ -789,19 +796,20 @@ shouldReportSigningOracle(const BinaryContext &BC, const MCInstReference &Inst,
                           const SrcState &S) {
   static const GadgetKind SigningOracleKind("signing oracle found");
 
-  MCPhysReg SignedReg = BC.MIB->getSignedReg(Inst);
-  if (SignedReg == BC.MIB->getNoRegister())
+  std::optional<MCPhysReg> SignedReg = BC.MIB->getSignedReg(Inst);
+  if (!SignedReg)
     return std::nullopt;
 
+  assert(*SignedReg != BC.MIB->getNoRegister());
   LLVM_DEBUG({
     traceInst(BC, "Found sign inst", Inst);
-    traceReg(BC, "Signed reg", SignedReg);
+    traceReg(BC, "Signed reg", *SignedReg);
     traceRegMask(BC, "TrustedRegs", S.TrustedRegs);
   });
-  if (S.TrustedRegs[SignedReg])
+  if (S.TrustedRegs[*SignedReg])
     return std::nullopt;
 
-  return make_gadget_report(SigningOracleKind, Inst, SignedReg);
+  return make_gadget_report(SigningOracleKind, Inst, *SignedReg);
 }
 
 template <typename T> static void iterateOverInstrs(BinaryFunction &BF, T Fn) {

--- a/bolt/lib/Passes/PAuthGadgetScanner.cpp
+++ b/bolt/lib/Passes/PAuthGadgetScanner.cpp
@@ -753,7 +753,6 @@ shouldReportReturnGadget(const BinaryContext &BC, const MCInstReference &Inst,
   if (IsAuthenticated)
     return std::nullopt;
 
-  assert(*RetReg != BC.MIB->getNoRegister());
   LLVM_DEBUG({
     traceInst(BC, "Found RET inst", Inst);
     traceReg(BC, "RetReg", *RetReg);
@@ -779,7 +778,7 @@ shouldReportCallGadget(const BinaryContext &BC, const MCInstReference &Inst,
   if (IsAuthenticated)
     return std::nullopt;
 
-  assert(DestReg != BC.MIB->getNoRegister());
+  assert(DestReg != BC.MIB->getNoRegister() && "Valid register expected");
   LLVM_DEBUG({
     traceInst(BC, "Found call inst", Inst);
     traceReg(BC, "Call destination reg", DestReg);
@@ -800,7 +799,6 @@ shouldReportSigningOracle(const BinaryContext &BC, const MCInstReference &Inst,
   if (!SignedReg)
     return std::nullopt;
 
-  assert(*SignedReg != BC.MIB->getNoRegister());
   LLVM_DEBUG({
     traceInst(BC, "Found sign inst", Inst);
     traceReg(BC, "Signed reg", *SignedReg);

--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -196,7 +196,10 @@ public:
     return {AArch64::LR};
   }
 
-  ErrorOr<MCPhysReg> getAuthenticatedReg(const MCInst &Inst) const override {
+  std::optional<MCPhysReg>
+  getWrittenAuthenticatedReg(const MCInst &Inst,
+                             bool &IsChecked) const override {
+    IsChecked = false;
     switch (Inst.getOpcode()) {
     case AArch64::AUTIAZ:
     case AArch64::AUTIBZ:
@@ -206,33 +209,12 @@ public:
     case AArch64::AUTIBSPPCi:
     case AArch64::AUTIASPPCr:
     case AArch64::AUTIBSPPCr:
-    case AArch64::RETAA:
-    case AArch64::RETAB:
-    case AArch64::RETAASPPCi:
-    case AArch64::RETABSPPCi:
-    case AArch64::RETAASPPCr:
-    case AArch64::RETABSPPCr:
       return AArch64::LR;
-
     case AArch64::AUTIA1716:
     case AArch64::AUTIB1716:
     case AArch64::AUTIA171615:
     case AArch64::AUTIB171615:
       return AArch64::X17;
-
-    case AArch64::ERETAA:
-    case AArch64::ERETAB:
-      // The ERETA{A,B} instructions use either register ELR_EL1, ELR_EL2 or
-      // ELR_EL3, depending on the current Exception Level at run-time.
-      //
-      // Furthermore, these registers are not modelled by LLVM as a regular
-      // MCPhysReg.... So there is no way to indicate that through the current
-      // API.
-      //
-      // Therefore, return an error to indicate that LLVM/BOLT cannot model
-      // this.
-      return make_error_code(std::errc::result_out_of_range);
-
     case AArch64::AUTIA:
     case AArch64::AUTIB:
     case AArch64::AUTDA:
@@ -242,22 +224,18 @@ public:
     case AArch64::AUTDZA:
     case AArch64::AUTDZB:
       return Inst.getOperand(0).getReg();
-
-      // FIXME: BL?RA(A|B)Z? and LDRA(A|B) should probably be handled here too.
-
+    case AArch64::LDRAAwriteback:
+    case AArch64::LDRABwriteback:
+      // Note that LDRA(A|B)indexed are not listed here, as they do not write
+      // an authenticated pointer back to the register.
+      IsChecked = true;
+      return Inst.getOperand(2).getReg();
     default:
-      return getNoRegister();
+      return std::nullopt;
     }
   }
 
-  bool isAuthenticationOfReg(const MCInst &Inst, MCPhysReg Reg) const override {
-    if (Reg == getNoRegister())
-      return false;
-    ErrorOr<MCPhysReg> AuthenticatedReg = getAuthenticatedReg(Inst);
-    return AuthenticatedReg.getError() ? false : *AuthenticatedReg == Reg;
-  }
-
-  MCPhysReg getSignedReg(const MCInst &Inst) const override {
+  std::optional<MCPhysReg> getSignedReg(const MCInst &Inst) const override {
     switch (Inst.getOpcode()) {
     case AArch64::PACIA:
     case AArch64::PACIB:
@@ -283,26 +261,36 @@ public:
     case AArch64::PACIB171615:
       return AArch64::X17;
     default:
-      return getNoRegister();
+      return std::nullopt;
     }
   }
 
-  ErrorOr<MCPhysReg> getRegUsedAsRetDest(const MCInst &Inst) const override {
+  std::optional<MCPhysReg>
+  getRegUsedAsRetDest(const MCInst &Inst,
+                      bool &IsAuthenticatedInternally) const override {
     assert(isReturn(Inst));
     switch (Inst.getOpcode()) {
     case AArch64::RET:
+      IsAuthenticatedInternally = false;
       return Inst.getOperand(0).getReg();
+
     case AArch64::RETAA:
     case AArch64::RETAB:
     case AArch64::RETAASPPCi:
     case AArch64::RETABSPPCi:
     case AArch64::RETAASPPCr:
     case AArch64::RETABSPPCr:
+      IsAuthenticatedInternally = true;
       return AArch64::LR;
     case AArch64::ERET:
     case AArch64::ERETAA:
     case AArch64::ERETAB:
-      return make_error_code(std::errc::result_out_of_range);
+      // The ERET* instructions use either register ELR_EL1, ELR_EL2 or
+      // ELR_EL3, depending on the current Exception Level at run-time.
+      //
+      // Furthermore, these registers are not modelled by LLVM as a regular
+      // MCPhysReg, so there is no way to indicate that through the current API.
+      return std::nullopt;
     default:
       llvm_unreachable("Unhandled return instruction");
     }
@@ -332,7 +320,7 @@ public:
     }
   }
 
-  MCPhysReg
+  std::optional<MCPhysReg>
   getMaterializedAddressRegForPtrAuth(const MCInst &Inst) const override {
     switch (Inst.getOpcode()) {
     case AArch64::ADR:
@@ -343,7 +331,7 @@ public:
       // this instruction), so the produced value is not attacker-controlled.
       return Inst.getOperand(0).getReg();
     default:
-      return getNoRegister();
+      return std::nullopt;
     }
   }
 
@@ -483,8 +471,8 @@ public:
     }
   }
 
-  MCPhysReg getAuthCheckedReg(const MCInst &Inst,
-                              bool MayOverwrite) const override {
+  std::optional<MCPhysReg> getAuthCheckedReg(const MCInst &Inst,
+                                             bool MayOverwrite) const override {
     // Cannot trivially reuse AArch64InstrInfo::getMemOperandWithOffsetWidth()
     // method as it accepts an instance of MachineInstr, not MCInst.
     const MCInstrDesc &Desc = Info->get(Inst.getOpcode());
@@ -553,10 +541,10 @@ public:
       // the resulting address arbitrarily.
       for (unsigned I = BaseRegIndex + 1, E = Desc.getNumOperands(); I < E; ++I)
         if (Inst.getOperand(I).isReg())
-          return getNoRegister();
+          return std::nullopt;
 
       if (!MayOverwrite && ClobbersBaseRegExceptWriteback(BaseRegIndex))
-        return getNoRegister();
+        return std::nullopt;
 
       return Inst.getOperand(BaseRegIndex).getReg();
     }
@@ -564,7 +552,7 @@ public:
     // Store instructions are not handled yet, as they are not important for
     // pauthtest ABI. Though, they could be handled similar to loads, if needed.
 
-    return getNoRegister();
+    return std::nullopt;
   }
 
   bool isADRP(const MCInst &Inst) const override {

--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -846,6 +846,8 @@ public:
   }
 
   bool mayLoad(const MCInst &Inst) const override {
+    // FIXME: Probably this could be tablegen-erated not to miss any existing
+    //        or future opcodes.
     return isLDRB(Inst) || isLDRH(Inst) || isLDRW(Inst) || isLDRX(Inst) ||
            isLDRQ(Inst) || isLDRD(Inst) || isLDRS(Inst);
   }

--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -533,6 +533,10 @@ public:
       return false;
     };
 
+    // FIXME: Not all load instructions are handled by this->mayLoad(Inst).
+    //        On the other hand, MCInstrDesc::mayLoad() is permitted to return
+    //        true for non-load instructions (such as AArch64::HINT) which
+    //        would result in false negatives.
     if (mayLoad(Inst)) {
       // The first Use operand is the base address register.
       unsigned BaseRegIndex = Desc.getNumDefs();

--- a/bolt/test/binary-analysis/AArch64/gs-pauth-debug-output.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pauth-debug-output.s
@@ -119,7 +119,6 @@ simple:
 // PAUTH-NEXT:     SafeToDerefRegs: W0 X0 W0_HI{{[ \t]*$}}
 // CHECK-NEXT:   Found RET inst:     00000000:         ret # DataflowSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, TrustedRegs: BitVector, Insts: >
 // CHECK-NEXT:     RetReg: LR
-// CHECK-NEXT:     Authenticated reg: (none)
 // CHECK-NEXT:     SafeToDerefRegs: LR W30 W30_HI{{[ \t]*$}}
 
         .globl  clobber
@@ -146,7 +145,6 @@ clobber:
 // CHECK-EMPTY:
 // CHECK-NEXT:   Found RET inst:     00000000:         ret # DataflowSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, TrustedRegs: BitVector, Insts: >
 // CHECK-NEXT:     RetReg: LR
-// CHECK-NEXT:     Authenticated reg: (none)
 // CHECK-NEXT:     SafeToDerefRegs: W30_HI{{[ \t]*$}}
 // CHECK-EMPTY:
 // CHECK-NEXT: Running detailed src register safety analysis...
@@ -225,7 +223,6 @@ nocfg:
 // PAUTH-NEXT:     SafeToDerefRegs: LR W0 W30 X0 W0_HI W30_HI
 // CHECK-NEXT:   Found RET inst:     00000000:         ret # Offset: 8 # CFGUnawareSrcSafetyAnalysis: src-state<SafeToDerefRegs: BitVector, TrustedRegs: BitVector, Insts: >
 // CHECK-NEXT:     RetReg: LR
-// CHECK-NEXT:     Authenticated reg: (none)
 // CHECK-NEXT:     SafeToDerefRegs:
 // CHECK-EMPTY:
 // CHECK-NEXT: Running detailed src register safety analysis...

--- a/bolt/test/binary-analysis/AArch64/gs-pauth-signing-oracles.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pauth-signing-oracles.s
@@ -985,6 +985,26 @@ inst_pacnbibsppc:
         ret
         .size inst_pacnbibsppc, .-inst_pacnbibsppc
 
+// Test that write-back forms of LDRA(A|B) instructions are handled properly.
+
+        .globl  inst_ldraa_wb
+        .type   inst_ldraa_wb,@function
+inst_ldraa_wb:
+// CHECK-NOT: inst_ldraa_wb
+        ldraa   x2, [x0]!
+        pacda   x0, x1
+        ret
+        .size inst_ldraa_wb, .-inst_ldraa_wb
+
+        .globl  inst_ldrab_wb
+        .type   inst_ldrab_wb,@function
+inst_ldrab_wb:
+// CHECK-NOT: inst_ldrab_wb
+        ldraa   x2, [x0]!
+        pacda   x0, x1
+        ret
+        .size inst_ldrab_wb, .-inst_ldrab_wb
+
         .globl  main
         .type   main,@function
 main:

--- a/bolt/test/binary-analysis/AArch64/gs-pauth-signing-oracles.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pauth-signing-oracles.s
@@ -1000,10 +1000,36 @@ inst_ldraa_wb:
         .type   inst_ldrab_wb,@function
 inst_ldrab_wb:
 // CHECK-NOT: inst_ldrab_wb
-        ldraa   x2, [x0]!
+        ldrab   x2, [x0]!
         pacda   x0, x1
         ret
         .size inst_ldrab_wb, .-inst_ldrab_wb
+
+// Non write-back forms of LDRA(A|B) instructions do not modify the address
+// register, and thus do not make it safe.
+
+        .globl  inst_ldraa_non_wb
+        .type   inst_ldraa_non_wb,@function
+inst_ldraa_non_wb:
+// CHECK-LABEL: GS-PAUTH: signing oracle found in function inst_ldraa_non_wb, basic block {{[^,]+}}, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      pacdb   x0, x1
+// CHECK-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
+        ldraa   x2, [x0]
+        pacdb   x0, x1
+        ret
+        .size inst_ldraa_non_wb, .-inst_ldraa_non_wb
+
+        .globl  inst_ldrab_non_wb
+        .type   inst_ldrab_non_wb,@function
+inst_ldrab_non_wb:
+// CHECK-LABEL: GS-PAUTH: signing oracle found in function inst_ldrab_non_wb, basic block {{[^,]+}}, at address
+// CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      pacda   x0, x1
+// CHECK-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
+        autia   x0, x3
+        ldrab   x2, [x0]
+        pacda   x0, x1
+        ret
+        .size inst_ldrab_non_wb, .-inst_ldrab_non_wb
 
         .globl  main
         .type   main,@function

--- a/bolt/test/binary-analysis/AArch64/gs-pauth-signing-oracles.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pauth-signing-oracles.s
@@ -1025,7 +1025,6 @@ inst_ldrab_non_wb:
 // CHECK-LABEL: GS-PAUTH: signing oracle found in function inst_ldrab_non_wb, basic block {{[^,]+}}, at address
 // CHECK-NEXT:  The instruction is     {{[0-9a-f]+}}:      pacda   x0, x1
 // CHECK-NEXT:  The 0 instructions that write to the affected registers after any authentication are:
-        autia   x0, x3
         ldrab   x2, [x0]
         pacda   x0, x1
         ret


### PR DESCRIPTION
Clarify the semantics of `getAuthenticatedReg` and remove a redundant `isAuthenticationOfReg` method, as combined auth+something instructions (such as `retaa` on AArch64) should be handled carefully, especially when searching for authentication oracles: usually, such instructions cannot be authentication oracles and only some of them actually write an authenticated pointer to a register (such as "ldra x0, [x1]!").

Use `std::optional<MCPhysReg>` returned type instead of plain MCPhysReg and returning `getNoRegister()` as a "not applicable" indication.

Document a few existing methods, add information about preconditions.