### PR TITLE
[NVPTX] Add auto-upgrade rules for fabs.{f,d,ftz.f}

### DIFF
--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -1287,6 +1287,9 @@ static bool upgradeIntrinsicFunction1(Function *F, Function *&NewFn,
         // nvvm.abs.{i,ii}
         Expand =
             Name == "i" || Name == "ll" || Name == "bf16" || Name == "bf16x2";
+      else if (Name == "fabs.f" || Name == "fabs.ftz.f" || Name == "fabs.d")
+        // nvvm.fabs.{f,ftz.f,d}
+        Expand = true;
       else if (Name == "clz.ll" || Name == "popc.ll" || Name == "h2f" ||
                Name == "swap.lo.hi.b64")
         Expand = true;
@@ -2318,6 +2321,10 @@ static Value *upgradeNVVMIntrinsicCall(StringRef Name, CallBase *CI,
     Value *Arg = Builder.CreateBitCast(CI->getArgOperand(0), Ty);
     Value *Abs = Builder.CreateUnaryIntrinsic(Intrinsic::nvvm_fabs, Arg);
     Rep = Builder.CreateBitCast(Abs, CI->getType());
+  } else if (Name == "fabs.f" || Name == "fabs.ftz.f" || Name == "fabs.d") {
+    Intrinsic::ID IID = (Name == "fabs.ftz.f") ? Intrinsic::nvvm_fabs_ftz
+                                               : Intrinsic::nvvm_fabs;
+    Rep = Builder.CreateUnaryIntrinsic(IID, CI->getArgOperand(0));
   } else if (Name.starts_with("atomic.load.add.f32.p") ||
              Name.starts_with("atomic.load.add.f64.p")) {
     Value *Ptr = CI->getArgOperand(0);

--- a/llvm/test/Assembler/auto_upgrade_nvvm_intrinsics.ll
+++ b/llvm/test/Assembler/auto_upgrade_nvvm_intrinsics.ll
@@ -13,6 +13,10 @@ declare float @llvm.nvvm.h2f(i16)
 declare i32 @llvm.nvvm.abs.i(i32)
 declare i64 @llvm.nvvm.abs.ll(i64)
 
+declare float @llvm.nvvm.fabs.f(float)
+declare float @llvm.nvvm.fabs.ftz.f(float)
+declare double @llvm.nvvm.fabs.d(double)
+
 declare i16 @llvm.nvvm.max.s(i16, i16)
 declare i32 @llvm.nvvm.max.i(i32, i32)
 declare i64 @llvm.nvvm.max.ll(i64, i64)
@@ -94,6 +98,17 @@ define void @abs(i32 %a, i64 %b) {
 ; CHECK: select i1 [[cmpll]], i64 %b, i64 [[negll]]
   %r2 = call i64 @llvm.nvvm.abs.ll(i64 %b)
 
+  ret void
+}
+
+; CHECK-LABEL: @fabs
+define void @fabs(float %a, double %b) {
+; CHECK: call float @llvm.nvvm.fabs.f32(float %a)
+; CHECK: call float @llvm.nvvm.fabs.ftz.f32(float %a)
+; CHECK: call double @llvm.nvvm.fabs.f64(double %b)
+  %r1 = call float @llvm.nvvm.fabs.f(float %a)
+  %r2 = call float @llvm.nvvm.fabs.ftz.f(float %a)
+  %r3 = call double @llvm.nvvm.fabs.d(double %b)
   ret void
 }
 


### PR DESCRIPTION
These auto-upgrade rules are required after these intrinsics were removed in https://github.com/llvm/llvm-project/pull/135644/