### PR TITLE
[BOLT] Gadget scanner: do not crash on debug-printing CFI instructions

### DIFF
--- a/bolt/lib/Passes/PAuthGadgetScanner.cpp
+++ b/bolt/lib/Passes/PAuthGadgetScanner.cpp
@@ -430,6 +430,9 @@ protected:
   }
 
   SrcState computeNext(const MCInst &Point, const SrcState &Cur) {
+    if (BC.MIB->isCFI(Point))
+      return Cur;
+
     SrcStatePrinter P(BC);
     LLVM_DEBUG({
       dbgs() << "  SrcSafetyAnalysis::ComputeNext(";
@@ -704,6 +707,8 @@ public:
     SrcState S = createEntryState();
     for (auto &I : BF.instrs()) {
       MCInst &Inst = I.second;
+      if (BC.MIB->isCFI(Inst))
+        continue;
 
       // If there is a label before this instruction, it is possible that it
       // can be jumped-to, thus conservatively resetting S. As an exception,
@@ -1010,6 +1015,9 @@ protected:
   }
 
   DstState computeNext(const MCInst &Point, const DstState &Cur) {
+    if (BC.MIB->isCFI(Point))
+      return Cur;
+
     DstStatePrinter P(BC);
     LLVM_DEBUG({
       dbgs() << "  DstSafetyAnalysis::ComputeNext(";
@@ -1177,6 +1185,8 @@ public:
     DstState S = createUnsafeState();
     for (auto &I : llvm::reverse(BF.instrs())) {
       MCInst &Inst = I.second;
+      if (BC.MIB->isCFI(Inst))
+        continue;
 
       // If Inst can change the control flow, we cannot be sure that the next
       // instruction (to be executed in analyzed program) is the one processed
@@ -1366,6 +1376,9 @@ void FunctionAnalysisContext::findUnsafeUses(
   });
 
   iterateOverInstrs(BF, [&](MCInstReference Inst) {
+    if (BC.MIB->isCFI(Inst))
+      return;
+
     const SrcState &S = Analysis->getStateBefore(Inst);
 
     // If non-empty state was never propagated from the entry basic block
@@ -1429,6 +1442,9 @@ void FunctionAnalysisContext::findUnsafeDefs(
   });
 
   iterateOverInstrs(BF, [&](MCInstReference Inst) {
+    if (BC.MIB->isCFI(Inst))
+      return;
+
     const DstState &S = Analysis->getStateAfter(Inst);
 
     if (auto Report = shouldReportAuthOracle(BC, Inst, S))

--- a/bolt/test/binary-analysis/AArch64/gs-pauth-debug-output.s
+++ b/bolt/test/binary-analysis/AArch64/gs-pauth-debug-output.s
@@ -329,6 +329,38 @@ auth_oracle:
 // PAUTH-EMPTY:
 // PAUTH-NEXT:   Attaching leakage info to:     00000000:      autia   x0, x1 # DataflowDstSafetyAnalysis: dst-state<CannotEscapeUnchecked: BitVector, Insts: [0](0x{{[0-9a-f]+}} )>
 
+// Gadget scanner should not crash on CFI instructions, including when debug-printing them.
+// Note that the particular debug output is not checked, but BOLT should be
+// compiled with assertions enabled to support -debug-only argument.
+
+        .globl  cfi_inst_df
+        .type   cfi_inst_df,@function
+cfi_inst_df:
+        .cfi_startproc
+        sub     sp, sp, #16
+        .cfi_def_cfa_offset 16
+        add     sp, sp, #16
+        .cfi_def_cfa_offset 0
+        ret
+        .size   cfi_inst_df, .-cfi_inst_df
+        .cfi_endproc
+
+        .globl  cfi_inst_nocfg
+        .type   cfi_inst_nocfg,@function
+cfi_inst_nocfg:
+        .cfi_startproc
+        sub     sp, sp, #16
+        .cfi_def_cfa_offset 16
+
+        adr     x0, 1f
+        br      x0
+1:
+        add     sp, sp, #16
+        .cfi_def_cfa_offset 0
+        ret
+        .size   cfi_inst_nocfg, .-cfi_inst_nocfg
+        .cfi_endproc
+
 // CHECK-LABEL:Analyzing function main, AllocatorId = 1
         .globl  main
         .type   main,@function


### PR DESCRIPTION
Some instruction-printing code used under LLVM_DEBUG does not handle CFI
instructions well. While CFI instructions seem to be harmless for the
correctness of the analysis results, they do not convey any useful
information to the analysis either, so skip them early.