### PR TITLE
[lldb][nfc] Remove unused parameters in ThreadPlanStepOut ctor

### DIFF
--- a/lldb/include/lldb/API/SBThreadPlan.h
+++ b/lldb/include/lldb/API/SBThreadPlan.h
@@ -100,6 +100,7 @@ public:
                                              lldb::addr_t range_size,
                                              SBError &error);
 
+  // Note: first_insn is not used.
   SBThreadPlan QueueThreadPlanForStepOut(uint32_t frame_idx_to_step_to,
                                          bool first_insn = false);
   SBThreadPlan QueueThreadPlanForStepOut(uint32_t frame_idx_to_step_to,

--- a/lldb/include/lldb/Target/Thread.h
+++ b/lldb/include/lldb/Target/Thread.h
@@ -843,18 +843,6 @@ public:
   ///    this one.
   ///    Otherwise this plan will go on the end of the plan stack.
   ///
-  /// \param[in] addr_context
-  ///    When dealing with stepping through inlined functions the current PC is
-  ///    not enough information to know
-  ///    what "step" means.  For instance a series of nested inline functions
-  ///    might start at the same address.
-  //     The \a addr_context provides the current symbol context the step
-  ///    is supposed to be out of.
-  //   FIXME: Currently unused.
-  ///
-  /// \param[in] first_insn
-  ///     \b true if this is the first instruction of a function.
-  ///
   /// \param[in] stop_other_threads
   ///    \b true if we will stop other threads while we single step this one.
   ///
@@ -876,9 +864,8 @@ public:
   ///     A shared pointer to the newly queued thread plan, or nullptr if the
   ///     plan could not be queued.
   virtual lldb::ThreadPlanSP QueueThreadPlanForStepOut(
-      bool abort_other_plans, SymbolContext *addr_context, bool first_insn,
-      bool stop_other_threads, Vote report_stop_vote, Vote report_run_vote,
-      uint32_t frame_idx, Status &status,
+      bool abort_other_plans, bool stop_other_threads, Vote report_stop_vote,
+      Vote report_run_vote, uint32_t frame_idx, Status &status,
       LazyBool step_out_avoids_code_without_debug_info = eLazyBoolCalculate);
 
   /// Queue the plan used to step out of the function at the current PC of
@@ -891,18 +878,6 @@ public:
   ///    \b true if we discard the currently queued plans and replace them with
   ///    this one.
   ///    Otherwise this plan will go on the end of the plan stack.
-  ///
-  /// \param[in] addr_context
-  ///    When dealing with stepping through inlined functions the current PC is
-  ///    not enough information to know
-  ///    what "step" means.  For instance a series of nested inline functions
-  ///    might start at the same address.
-  //     The \a addr_context provides the current symbol context the step
-  ///    is supposed to be out of.
-  //   FIXME: Currently unused.
-  ///
-  /// \param[in] first_insn
-  ///     \b true if this is the first instruction of a function.
   ///
   /// \param[in] stop_other_threads
   ///    \b true if we will stop other threads while we single step this one.
@@ -940,9 +915,9 @@ public:
   ///     A shared pointer to the newly queued thread plan, or nullptr if the
   ///     plan could not be queued.
   virtual lldb::ThreadPlanSP QueueThreadPlanForStepOutNoShouldStop(
-      bool abort_other_plans, SymbolContext *addr_context, bool first_insn,
-      bool stop_other_threads, Vote report_stop_vote, Vote report_run_vote,
-      uint32_t frame_idx, Status &status, bool continue_to_next_branch = false);
+      bool abort_other_plans, bool stop_other_threads, Vote report_stop_vote,
+      Vote report_run_vote, uint32_t frame_idx, Status &status,
+      bool continue_to_next_branch = false);
 
   /// Gets the plan used to step through the code that steps from a function
   /// call site at the current PC into the actual function call.

--- a/lldb/include/lldb/Target/ThreadPlanStepOut.h
+++ b/lldb/include/lldb/Target/ThreadPlanStepOut.h
@@ -82,6 +82,10 @@ private:
       LazyBool step_out_avoids_code_without_debug_info);
 
   void SetupAvoidNoDebug(LazyBool step_out_avoids_code_without_debug_info);
+
+  void SetupReturnAddress(lldb::StackFrameSP return_frame_sp,
+                          lldb::StackFrameSP immediate_return_from_sp,
+                          uint32_t frame_idx, bool continue_to_next_branch);
   // Need an appropriate marker for the current stack so we can tell step out
   // from step in.
 

--- a/lldb/include/lldb/Target/ThreadPlanStepOut.h
+++ b/lldb/include/lldb/Target/ThreadPlanStepOut.h
@@ -17,8 +17,7 @@ namespace lldb_private {
 
 class ThreadPlanStepOut : public ThreadPlan, public ThreadPlanShouldStopHere {
 public:
-  ThreadPlanStepOut(Thread &thread, SymbolContext *addr_context,
-                    bool first_insn, bool stop_others, Vote report_stop_vote,
+  ThreadPlanStepOut(Thread &thread, bool stop_others, Vote report_stop_vote,
                     Vote report_run_vote, uint32_t frame_idx,
                     LazyBool step_out_avoids_code_without_debug_info,
                     bool continue_to_next_branch = false,
@@ -76,9 +75,8 @@ private:
   StreamString m_constructor_errors;
 
   friend lldb::ThreadPlanSP Thread::QueueThreadPlanForStepOut(
-      bool abort_other_plans, SymbolContext *addr_context, bool first_insn,
-      bool stop_others, Vote report_stop_vote, Vote report_run_vote,
-      uint32_t frame_idx, Status &status,
+      bool abort_other_plans, bool stop_others, Vote report_stop_vote,
+      Vote report_run_vote, uint32_t frame_idx, Status &status,
       LazyBool step_out_avoids_code_without_debug_info);
 
   void SetupAvoidNoDebug(LazyBool step_out_avoids_code_without_debug_info);

--- a/lldb/source/API/SBThread.cpp
+++ b/lldb/source/API/SBThread.cpp
@@ -659,8 +659,8 @@ void SBThread::StepOut(SBError &error) {
   const LazyBool avoid_no_debug = eLazyBoolCalculate;
   Status new_plan_status;
   ThreadPlanSP new_plan_sp(thread->QueueThreadPlanForStepOut(
-      abort_other_plans, nullptr, false, stop_other_threads, eVoteYes,
-      eVoteNoOpinion, 0, new_plan_status, avoid_no_debug));
+      abort_other_plans, stop_other_threads, eVoteYes, eVoteNoOpinion, 0,
+      new_plan_status, avoid_no_debug));
 
   if (new_plan_status.Success())
     error = ResumeNewPlan(exe_ctx, new_plan_sp.get());
@@ -703,8 +703,8 @@ void SBThread::StepOutOfFrame(SBFrame &sb_frame, SBError &error) {
 
   Status new_plan_status;
   ThreadPlanSP new_plan_sp(thread->QueueThreadPlanForStepOut(
-      abort_other_plans, nullptr, false, stop_other_threads, eVoteYes,
-      eVoteNoOpinion, frame_sp->GetFrameIndex(), new_plan_status));
+      abort_other_plans, stop_other_threads, eVoteYes, eVoteNoOpinion,
+      frame_sp->GetFrameIndex(), new_plan_status));
 
   if (new_plan_status.Success())
     error = ResumeNewPlan(exe_ctx, new_plan_sp.get());

--- a/lldb/source/API/SBThreadPlan.cpp
+++ b/lldb/source/API/SBThreadPlan.cpp
@@ -312,8 +312,8 @@ SBThreadPlan::QueueThreadPlanForStepOut(uint32_t frame_idx_to_step_to,
     Status plan_status;
     SBThreadPlan plan =
         SBThreadPlan(thread_plan_sp->GetThread().QueueThreadPlanForStepOut(
-            false, &sc, first_insn, false, eVoteYes, eVoteNoOpinion,
-            frame_idx_to_step_to, plan_status));
+            false, false, eVoteYes, eVoteNoOpinion, frame_idx_to_step_to,
+            plan_status));
 
     if (plan_status.Fail())
       error.SetErrorString(plan_status.AsCString());

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -558,8 +558,7 @@ protected:
           true, abort_other_plans, bool_stop_other_threads, new_plan_status);
     } else if (m_step_type == eStepTypeOut) {
       new_plan_sp = thread->QueueThreadPlanForStepOut(
-          abort_other_plans, nullptr, false, bool_stop_other_threads, eVoteYes,
-          eVoteNoOpinion,
+          abort_other_plans, bool_stop_other_threads, eVoteYes, eVoteNoOpinion,
           thread->GetSelectedFrameIndex(DoNoSelectMostRelevantFrame),
           new_plan_status, m_options.m_step_out_avoid_no_debug);
     } else if (m_step_type == eStepTypeScripted) {

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleThreadPlanStepThroughObjCTrampoline.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleThreadPlanStepThroughObjCTrampoline.cpp
@@ -161,11 +161,10 @@ bool AppleThreadPlanStepThroughObjCTrampoline::ShouldStop(Event *event_ptr) {
           eSymbolContextEverything);
       Status status;
       const bool abort_other_plans = false;
-      const bool first_insn = true;
       const uint32_t frame_idx = 0;
       m_run_to_sp = GetThread().QueueThreadPlanForStepOutNoShouldStop(
-          abort_other_plans, &sc, first_insn, false, eVoteNoOpinion,
-          eVoteNoOpinion, frame_idx, status);
+          abort_other_plans, false, eVoteNoOpinion, eVoteNoOpinion, frame_idx,
+          status);
       if (m_run_to_sp && status.Success())
         m_run_to_sp->SetPrivate(true);
       return false;
@@ -242,8 +241,7 @@ AppleThreadPlanStepThroughDirectDispatch ::
     AppleThreadPlanStepThroughDirectDispatch(
         Thread &thread, AppleObjCTrampolineHandler &handler,
         llvm::StringRef dispatch_func_name)
-    : ThreadPlanStepOut(thread, nullptr, true /* first instruction */, false,
-                        eVoteNoOpinion, eVoteNoOpinion,
+    : ThreadPlanStepOut(thread, false, eVoteNoOpinion, eVoteNoOpinion,
                         0 /* Step out of zeroth frame */,
                         eLazyBoolNo /* Our parent plan will decide this
                                when we are done */

--- a/lldb/source/Target/ThreadPlanCallOnFunctionExit.cpp
+++ b/lldb/source/Target/ThreadPlanCallOnFunctionExit.cpp
@@ -29,8 +29,6 @@ void ThreadPlanCallOnFunctionExit::DidPush() {
   Status status;
   m_step_out_threadplan_sp = GetThread().QueueThreadPlanForStepOut(
       false,             // abort other plans
-      nullptr,           // addr_context
-      true,              // first instruction
       true,              // stop other threads
       eVoteNo,           // do not say "we're stopping"
       eVoteNoOpinion,    // don't care about run state broadcasting

--- a/lldb/source/Target/ThreadPlanShouldStopHere.cpp
+++ b/lldb/source/Target/ThreadPlanShouldStopHere.cpp
@@ -176,8 +176,8 @@ ThreadPlanSP ThreadPlanShouldStopHere::DefaultStepFromHereCallback(
   if (!return_plan_sp)
     return_plan_sp =
         current_plan->GetThread().QueueThreadPlanForStepOutNoShouldStop(
-            false, nullptr, true, stop_others, eVoteNo, eVoteNoOpinion,
-            frame_index, status, true);
+            false, stop_others, eVoteNo, eVoteNoOpinion, frame_index, status,
+            true);
   return return_plan_sp;
 }
 

--- a/lldb/source/Target/ThreadPlanStepInstruction.cpp
+++ b/lldb/source/Target/ThreadPlanStepInstruction.cpp
@@ -198,8 +198,7 @@ bool ThreadPlanStepInstruction::ShouldStop(Event *event_ptr) {
           // for now it is safer to run others.
           const bool stop_others = false;
           thread.QueueThreadPlanForStepOutNoShouldStop(
-              false, nullptr, true, stop_others, eVoteNo, eVoteNoOpinion, 0,
-              m_status);
+              false, stop_others, eVoteNo, eVoteNoOpinion, 0, m_status);
           return false;
         } else {
           if (log) {

--- a/lldb/source/Target/ThreadPlanStepOut.cpp
+++ b/lldb/source/Target/ThreadPlanStepOut.cpp
@@ -59,8 +59,8 @@ ComputeTargetFrame(Thread &thread, uint32_t start_frame_idx,
 
 // ThreadPlanStepOut: Step out of the current frame
 ThreadPlanStepOut::ThreadPlanStepOut(
-    Thread &thread, SymbolContext *context, bool first_insn, bool stop_others,
-    Vote report_stop_vote, Vote report_run_vote, uint32_t frame_idx,
+    Thread &thread, bool stop_others, Vote report_stop_vote,
+    Vote report_run_vote, uint32_t frame_idx,
     LazyBool step_out_avoids_code_without_debug_info,
     bool continue_to_next_branch, bool gather_return_value)
     : ThreadPlan(ThreadPlan::eKindStepOut, "Step out", thread, report_stop_vote,
@@ -101,7 +101,7 @@ void ThreadPlanStepOut::SetupReturnAddress(
       // First queue a plan that gets us to this inlined frame, and when we get
       // there we'll queue a second plan that walks us out of this frame.
       m_step_out_to_inline_plan_sp = std::make_shared<ThreadPlanStepOut>(
-          GetThread(), nullptr, false, m_stop_others, eVoteNoOpinion, eVoteNoOpinion,
+          GetThread(), m_stop_others, eVoteNoOpinion, eVoteNoOpinion,
           frame_idx - 1, eLazyBoolNo, continue_to_next_branch);
       static_cast<ThreadPlanStepOut *>(m_step_out_to_inline_plan_sp.get())
           ->SetShouldStopHereCallbacks(nullptr, nullptr);
@@ -113,7 +113,6 @@ void ThreadPlanStepOut::SetupReturnAddress(
     }
   } else {
     // Find the return address and set a breakpoint there:
-    // FIXME - can we do this more securely if we know first_insn?
 
     Address return_address(return_frame_sp->GetFrameCodeAddress());
     if (continue_to_next_branch) {

--- a/lldb/source/Target/ThreadPlanStepOut.cpp
+++ b/lldb/source/Target/ThreadPlanStepOut.cpp
@@ -79,6 +79,13 @@ ThreadPlanStepOut::ThreadPlanStepOut(
       ComputeTargetFrame(thread, frame_idx, m_stepped_past_frames);
   StackFrameSP immediate_return_from_sp(thread.GetStackFrameAtIndex(frame_idx));
 
+  SetupReturnAddress(return_frame_sp, immediate_return_from_sp,
+                     frame_idx, continue_to_next_branch);
+}
+
+void ThreadPlanStepOut::SetupReturnAddress(
+    StackFrameSP return_frame_sp, StackFrameSP immediate_return_from_sp,
+    uint32_t frame_idx, bool continue_to_next_branch) {
   if (!return_frame_sp || !immediate_return_from_sp)
     return; // we can't do anything here.  ValidatePlan() will return false.
 
@@ -94,7 +101,7 @@ ThreadPlanStepOut::ThreadPlanStepOut(
       // First queue a plan that gets us to this inlined frame, and when we get
       // there we'll queue a second plan that walks us out of this frame.
       m_step_out_to_inline_plan_sp = std::make_shared<ThreadPlanStepOut>(
-          thread, nullptr, false, stop_others, eVoteNoOpinion, eVoteNoOpinion,
+          GetThread(), nullptr, false, m_stop_others, eVoteNoOpinion, eVoteNoOpinion,
           frame_idx - 1, eLazyBoolNo, continue_to_next_branch);
       static_cast<ThreadPlanStepOut *>(m_step_out_to_inline_plan_sp.get())
           ->SetShouldStopHereCallbacks(nullptr, nullptr);

--- a/lldb/source/Target/ThreadPlanStepOverRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepOverRange.cpp
@@ -192,8 +192,7 @@ bool ThreadPlanStepOverRange::ShouldStop(Event *event_ptr) {
         if (m_next_branch_bp_sp)
           return false;
         new_plan_sp = thread.QueueThreadPlanForStepOutNoShouldStop(
-            false, nullptr, true, stop_others, eVoteNo, eVoteNoOpinion, 0,
-            m_status, true);
+            false, stop_others, eVoteNo, eVoteNoOpinion, 0, m_status, true);
         break;
       } else {
         new_plan_sp = thread.QueueThreadPlanForStepThrough(


### PR DESCRIPTION
These have been unused for at least a decade.