### PR TITLE
[WebKit checkers] Treat global const variables as safe

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
@@ -30,12 +30,11 @@ bool tryToFindPtrOrigin(
     std::function<bool(const clang::Expr *, bool)> callback) {
   while (E) {
     if (auto *DRE = dyn_cast<DeclRefExpr>(E)) {
-      auto *ValDecl = DRE->getDecl();
-      auto QT = ValDecl->getType();
-      auto ValName = ValDecl->getName();
-      if (ValDecl && (ValName.starts_with('k') || ValName.starts_with("_k")) &&
-          QT.isConstQualified()) { // Treat constants such as kCF* as safe.
-        return callback(E, true);
+      if (auto *VD = dyn_cast_or_null<VarDecl>(DRE->getDecl())) {
+        auto QT = VD->getType();
+        if (VD->hasGlobalStorage() && QT.isConstQualified()) {
+          return callback(E, true);
+        }
       }
     }
     if (auto *tempExpr = dyn_cast<MaterializeTemporaryExpr>(E)) {

--- a/clang/test/Analysis/Checkers/WebKit/unretained-call-args-arc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-call-args-arc.mm
@@ -18,6 +18,24 @@ void foo() {
 
 } // namespace raw_ptr
 
+namespace const_global {
+
+extern NSString * const SomeConstant;
+extern CFDictionaryRef const SomeDictionary;
+void doWork(NSString *str, CFDictionaryRef dict);
+void use_const_global() {
+  doWork(SomeConstant, SomeDictionary);
+}
+
+NSString *provide_str();
+CFDictionaryRef provide_dict();
+void use_const_local() {
+  doWork(provide_str(), provide_dict());
+  // expected-warning@-1{{Call argument for parameter 'dict' is unretained and unsafe}}
+}
+
+} // namespace const_global
+
 @interface AnotherObj : NSObject
 - (void)foo:(SomeObj *)obj;
 - (SomeObj *)getSomeObj;

--- a/clang/test/Analysis/Checkers/WebKit/unretained-call-args.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-call-args.mm
@@ -415,6 +415,25 @@ void idcf(CFTypeRef obj) {
 
 } // ptr_conversion
 
+namespace const_global {
+
+extern NSString * const SomeConstant;
+extern CFDictionaryRef const SomeDictionary;
+void doWork(NSString *str, CFDictionaryRef dict);
+void use_const_global() {
+  doWork(SomeConstant, SomeDictionary);
+}
+
+NSString *provide_str();
+CFDictionaryRef provide_dict();
+void use_const_local() {
+  doWork(provide_str(), provide_dict());
+  // expected-warning@-1{{Call argument for parameter 'str' is unretained and unsafe}}
+  // expected-warning@-2{{Call argument for parameter 'dict' is unretained and unsafe}}
+}
+
+} // namespace const_global
+
 @interface TestObject : NSObject
 - (void)doWork:(NSString *)msg, ...;
 - (void)doWorkOnSelf;

--- a/clang/test/Analysis/Checkers/WebKit/unretained-local-vars-arc.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-local-vars-arc.mm
@@ -25,6 +25,26 @@ void bar() {
 
 } // namespace raw_ptr
 
+namespace const_global {
+
+extern NSString * const SomeConstant;
+extern CFDictionaryRef const SomeDictionary;
+void doWork(NSString *, CFDictionaryRef);
+void use_const_global() {
+  doWork(SomeConstant, SomeDictionary);
+}
+
+NSString *provide_str();
+CFDictionaryRef provide_dict();
+void use_const_local() {
+  NSString * const str = provide_str();
+  CFDictionaryRef dict = provide_dict();
+  // expected-warning@-1{{Local variable 'dict' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  doWork(str, dict);
+}
+
+} // namespace const_global
+
 @interface AnotherObj : NSObject
 - (void)foo:(SomeObj *)obj;
 @end

--- a/clang/test/Analysis/Checkers/WebKit/unretained-local-vars.mm
+++ b/clang/test/Analysis/Checkers/WebKit/unretained-local-vars.mm
@@ -387,6 +387,27 @@ unsigned ccf(CFTypeRef obj) {
 
 } // ptr_conversion
 
+namespace const_global {
+
+extern NSString * const SomeConstant;
+extern CFDictionaryRef const SomeDictionary;
+void doWork(NSString *, CFDictionaryRef);
+void use_const_global() {
+  doWork(SomeConstant, SomeDictionary);
+}
+
+NSString *provide_str();
+CFDictionaryRef provide_dict();
+void use_const_local() {
+  NSString * const str = provide_str();
+  // expected-warning@-1{{Local variable 'str' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  CFDictionaryRef dict = provide_dict();
+  // expected-warning@-1{{Local variable 'dict' is unretained and unsafe [alpha.webkit.UnretainedLocalVarsChecker]}}
+  doWork(str, dict);
+}
+
+} // namespace const_global
+
 bool doMoreWorkOpaque(OtherObj*);
 SomeObj* provide();
 


### PR DESCRIPTION
This PR makes WebKit checkers treat a variable with global storage as safe instead of constraining to ones that start with k or _k.