### PR TITLE
[BOLT] Fix warnings

### DIFF
--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -555,9 +555,9 @@ public:
                .addReg(RegCnt);
   }
 
-  InstructionListType createCmpJE(MCPhysReg RegNo, MCPhysReg RegTmp,
-                                  const MCSymbol *Target,
-                                  MCContext *Ctx) const {
+  InstructionListType createCmpJERISCV(MCPhysReg RegNo, MCPhysReg RegTmp,
+                                       const MCSymbol *Target,
+                                       MCContext *Ctx) const {
     InstructionListType Insts;
     Insts.emplace_back(
         MCInstBuilder(RISCV::SUB).addReg(RegTmp).addReg(RegNo).addReg(RegNo));
@@ -718,7 +718,7 @@ public:
     Insts.emplace_back();
     loadReg(Insts.back(), RISCV::X10, RISCV::X10, 0);
     InstructionListType cmpJmp =
-        createCmpJE(RISCV::X10, RISCV::X11, IndCallHandler, Ctx);
+        createCmpJERISCV(RISCV::X10, RISCV::X11, IndCallHandler, Ctx);
     Insts.insert(Insts.end(), cmpJmp.begin(), cmpJmp.end());
     Insts.emplace_back();
     createStackPointerIncrement(Insts.back(), 16);
@@ -777,8 +777,8 @@ public:
     return createGetter(Ctx, "__bolt_instr_num_funcs");
   }
 
-  void convertIndirectCallToLoad(MCInst &Inst, MCPhysReg Reg,
-                                 MCPhysReg ZeroReg) const {
+  void convertIndirectCallToLoadRISCV(MCInst &Inst, MCPhysReg Reg,
+                                      MCPhysReg ZeroReg) const {
     bool IsTailCall = isTailCall(Inst);
     if (IsTailCall)
       removeAnnotation(Inst, MCPlus::MCAnnotation::kTailCall);
@@ -845,7 +845,7 @@ public:
     InstructionListType Insts;
     spillRegs(Insts, {RISCV::X10, RISCV::X11});
     Insts.emplace_back(CallInst);
-    convertIndirectCallToLoad(Insts.back(), RISCV::X10, RISCV::X0);
+    convertIndirectCallToLoadRISCV(Insts.back(), RISCV::X10, RISCV::X0);
     InstructionListType LoadImm = createLoadImmediate(RISCV::X11, CallSiteID);
     Insts.insert(Insts.end(), LoadImm.begin(), LoadImm.end());
     spillRegs(Insts, {RISCV::X10, RISCV::X11});


### PR DESCRIPTION
This patch fixes:

  bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp:558:23: error:
  '(anonymous namespace)::RISCVMCPlusBuilder::createCmpJE' hides
  overloaded virtual function [-Werror,-Woverloaded-virtual]

  bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp:780:8: error:
  '(anonymous
  namespace)::RISCVMCPlusBuilder::convertIndirectCallToLoad' hides
  overloaded virtual function [-Werror,-Woverloaded-virtual]
