### PR TITLE
[clang] fix unresolved dependent template specialization mangling

### DIFF
--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -1405,16 +1405,6 @@ void CXXNameMangler::mangleUnresolvedPrefix(NestedNameSpecifier *qualifier,
     //   - a template template parameter with arguments
     // In all of these cases, we should have no prefix.
     if (NestedNameSpecifier *Prefix = qualifier->getPrefix()) {
-      if (const auto *DTST =
-              dyn_cast<DependentTemplateSpecializationType>(type)) {
-        Out << "srN";
-        TemplateName Template = getASTContext().getDependentTemplateName(
-            {Prefix, DTST->getDependentTemplateName().getName(),
-             /*HasTemplateKeyword=*/true});
-        mangleTemplatePrefix(Template);
-        mangleTemplateArgs(Template, DTST->template_arguments());
-        break;
-      }
       mangleUnresolvedPrefix(Prefix,
                              /*recursive=*/true);
     } else {
@@ -2618,7 +2608,8 @@ bool CXXNameMangler::mangleUnresolvedTypeOrSimpleId(QualType Ty,
         cast<DependentTemplateSpecializationType>(Ty);
     TemplateName Template = getASTContext().getDependentTemplateName(
         DTST->getDependentTemplateName());
-    mangleTemplatePrefix(Template);
+    const DependentTemplateStorage &S = DTST->getDependentTemplateName();
+    mangleSourceName(S.getName().getIdentifier());
     mangleTemplateArgs(Template, DTST->template_arguments());
     break;
   }

--- a/clang/test/CodeGenCXX/mangle-template.cpp
+++ b/clang/test/CodeGenCXX/mangle-template.cpp
@@ -416,3 +416,20 @@ namespace unresolved_template_specialization_type {
   template enable_if<true> raw_hash_set<int>::AbslHashValue<HashStateBase>();
   // CHECH: @_ZN39unresolved_template_specialization_type12raw_hash_setIiE13AbslHashValueINS_13HashStateBaseEEENS_9enable_ifIXsrNT_11is_hashableIiEE5valueEEEv
 } // namespace unresolved_template_specialization_type
+
+namespace GH133610 {
+  template <class T> struct A {
+    template <class V> struct B { int MEM; };
+  };
+
+  struct D {};
+  struct C: public A<int>::B<D> {};
+
+  template <class T, class U, class V>
+  auto k(T t, U u, V v) -> decltype (t.U::template B<V>::MEM) { return {}; }
+
+  void t() {
+    k( C(), A<int>(), D() );
+  }
+  // CHECK: @_ZN8GH1336101kINS_1CENS_1AIiEENS_1DEEEDtdtfp_sr1U1BIT1_EE3MEMET_T0_S5_
+} // namespace GH133610


### PR DESCRIPTION
This fixes a regression introduced in #133610 which was reported here #133610 (comment) and in #136119

This redoes previous attempt in #135111

When mangling a DTST which appears in the prefix,
the template name is not actually relevant, as its prefix is part of the nested name anyway, and a
substitution is not allowed at that position in any case.

Fixes #136119