### PR TITLE
Enable `-m32`, `-maix32` and `-maix64` for Flang on AIX.

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4694,15 +4694,17 @@ def EB : Flag<["-"], "EB">, Alias<mbig_endian>;
 def m16 : Flag<["-"], "m16">, Group<m_Group>, Flags<[NoXarchOption]>,
   Visibility<[ClangOption, CLOption, DXCOption]>;
 def m32 : Flag<["-"], "m32">, Group<m_Group>, Flags<[NoXarchOption]>,
-  Visibility<[ClangOption, CLOption, DXCOption]>;
-def maix32 : Flag<["-"], "maix32">, Group<m_Group>, Flags<[NoXarchOption]>;
+  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>;
+def maix32 : Flag<["-"], "maix32">, Group<m_Group>, Flags<[NoXarchOption]>,
+  Visibility<[FlangOption]>;
 def mqdsp6_compat : Flag<["-"], "mqdsp6-compat">, Group<m_Group>,
   Flags<[NoXarchOption]>, Visibility<[ClangOption, CC1Option]>,
   HelpText<"Enable hexagon-qdsp6 backward compatibility">,
   MarshallingInfoFlag<LangOpts<"HexagonQdsp6Compat">>;
 def m64 : Flag<["-"], "m64">, Group<m_Group>, Flags<[NoXarchOption]>,
   Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>;
-def maix64 : Flag<["-"], "maix64">, Group<m_Group>, Flags<[NoXarchOption]>;
+def maix64 : Flag<["-"], "maix64">, Group<m_Group>, Flags<[NoXarchOption]>,
+  Visibility<[FlangOption]>;
 def mx32 : Flag<["-"], "mx32">, Group<m_Group>, Flags<[NoXarchOption]>,
   Visibility<[ClangOption, CLOption, DXCOption]>;
 def miamcu : Flag<["-"], "miamcu">, Group<m_Group>, Flags<[NoXarchOption]>,

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -733,7 +733,7 @@ static llvm::Triple computeTargetTriple(const Driver &D,
         Target.setEnvironment(llvm::Triple::GNUX32);
     } else if (A->getOption().matches(options::OPT_m32) ||
                A->getOption().matches(options::OPT_maix32)) {
-      if (D.IsFlangMode() && !Target.isOSAIX() )
+      if (D.IsFlangMode() && !Target.isOSAIX())
         D.Diag(diag::err_drv_unsupported_opt_for_target)
            << A->getAsString(Args) << Target.str();
       else {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -733,11 +733,16 @@ static llvm::Triple computeTargetTriple(const Driver &D,
         Target.setEnvironment(llvm::Triple::GNUX32);
     } else if (A->getOption().matches(options::OPT_m32) ||
                A->getOption().matches(options::OPT_maix32)) {
-      AT = Target.get32BitArchVariant().getArch();
-      if (Target.getEnvironment() == llvm::Triple::GNUX32)
-        Target.setEnvironment(llvm::Triple::GNU);
-      else if (Target.getEnvironment() == llvm::Triple::MuslX32)
-        Target.setEnvironment(llvm::Triple::Musl);
+      if (D.IsFlangMode() && !Target.isOSAIX() )
+        D.Diag(diag::err_drv_unsupported_opt_for_target)
+           << A->getAsString(Args) << Target.str();
+      else {
+        AT = Target.get32BitArchVariant().getArch();
+        if (Target.getEnvironment() == llvm::Triple::GNUX32)
+          Target.setEnvironment(llvm::Triple::GNU);
+        else if (Target.getEnvironment() == llvm::Triple::MuslX32)
+          Target.setEnvironment(llvm::Triple::Musl);
+      }
     } else if (A->getOption().matches(options::OPT_m16) &&
                Target.get32BitArchVariant().getArch() == llvm::Triple::x86) {
       AT = llvm::Triple::x86;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -736,8 +736,7 @@ static llvm::Triple computeTargetTriple(const Driver &D,
       if (D.IsFlangMode() && !Target.isOSAIX()) {
         D.Diag(diag::err_drv_unsupported_opt_for_target)
             << A->getAsString(Args) << Target.str();
-      }
-      else {
+      } else {
         AT = Target.get32BitArchVariant().getArch();
         if (Target.getEnvironment() == llvm::Triple::GNUX32)
           Target.setEnvironment(llvm::Triple::GNU);

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -735,7 +735,7 @@ static llvm::Triple computeTargetTriple(const Driver &D,
                A->getOption().matches(options::OPT_maix32)) {
       if (D.IsFlangMode() && !Target.isOSAIX())
         D.Diag(diag::err_drv_unsupported_opt_for_target)
-           << A->getAsString(Args) << Target.str();
+            << A->getAsString(Args) << Target.str();
       else {
         AT = Target.get32BitArchVariant().getArch();
         if (Target.getEnvironment() == llvm::Triple::GNUX32)

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -733,9 +733,10 @@ static llvm::Triple computeTargetTriple(const Driver &D,
         Target.setEnvironment(llvm::Triple::GNUX32);
     } else if (A->getOption().matches(options::OPT_m32) ||
                A->getOption().matches(options::OPT_maix32)) {
-      if (D.IsFlangMode() && !Target.isOSAIX())
+      if (D.IsFlangMode() && !Target.isOSAIX()) {
         D.Diag(diag::err_drv_unsupported_opt_for_target)
             << A->getAsString(Args) << Target.str();
+      }
       else {
         AT = Target.get32BitArchVariant().getArch();
         if (Target.getEnvironment() == llvm::Triple::GNUX32)

--- a/flang/test/Driver/m32-option.f90
+++ b/flang/test/Driver/m32-option.f90
@@ -1,0 +1,14 @@
+! Check support of -m32.
+! RUN: %flang -target powerpc-ibm-aix -m32 -### - %s 2>&1 | FileCheck -check-prefix=M32 %s
+! RUN: %flang -target powerpc64-ibm-aix -m32 -### - %s 2>&1 | FileCheck -check-prefix=M32 %s
+! RUN: %flang -target powerpc-ibm-aix -maix32 -### - %s 2>&1 | FileCheck -check-prefix=M32 %s
+! RUN: %flang -target powerpc64-ibm-aix -maix32 -### - %s 2>&1 | FileCheck -check-prefix=M32 %s
+! RUN: %flang -target powerpc-ibm-aix -maix64 -### - %s 2>&1 | FileCheck -check-prefix=M64 %s
+! RUN: %flang -target powerpc64-ibm-aix -maix64 -### - %s 2>&1 | FileCheck -check-prefix=M64 %s
+! RUN: not %flang -target powerpc64le-unknown-linux-gnu -m32 -### - %s 2>&1 | FileCheck -check-prefix=M32-ERROR %s
+! RUN: not %flang -target powerpc64le-unknown-linux-gnu -maix32 -### - %s 2>&1 | FileCheck -check-prefix=MAIX32-ERROR %s
+
+! M32: "-triple" "powerpc-ibm-aix{{.*}}"
+! M64: "-triple" "powerpc64-ibm-aix{{.*}}"
+! M32-ERROR: error: unsupported option '-m32' for target 'powerpc64le-unknown-linux-gnu'
+! MAIX32-ERROR: error: unsupported option '-maix32' for target 'powerpc64le-unknown-linux-gnu'


### PR DESCRIPTION
This PR enables `-m32`, -`maix32` and `-maix64` for AIX only. For other platforms, the driver will issue an error that `-m32` is not supported.
