### PR TITLE
[clang][ptrauth] Make ptrauth feature detection tests more robust

### DIFF
--- a/clang/test/Sema/ptrauth-qualifier.c
+++ b/clang/test/Sema/ptrauth-qualifier.c
@@ -1,9 +1,11 @@
 // RUN: %clang_cc1 -triple arm64-apple-ios -std=c23 -fsyntax-only -verify -fptrauth-intrinsics %s
 // RUN: %clang_cc1 -triple aarch64-linux-gnu -std=c23 -fsyntax-only -verify -fptrauth-intrinsics %s
 
-#if __has_feature(ptrauth_qualifier)
-#warning __ptrauth qualifier enabled!
-// expected-warning@-1 {{__ptrauth qualifier enabled!}}
+#if !__has_extension(ptrauth_qualifier)
+// This error means that the __ptrauth qualifier availability test says  that it
+// is not available. This error is not expected in the output, if it is seen
+// there is a feature detection regression.
+#error __ptrauth qualifier not enabled
 #endif
 
 #if __aarch64__

--- a/clang/test/Sema/ptrauth.c
+++ b/clang/test/Sema/ptrauth.c
@@ -1,8 +1,10 @@
 // RUN: %clang_cc1 -triple arm64-apple-ios -fsyntax-only -verify -fptrauth-intrinsics %s -fexperimental-new-constant-interpreter
 
-#if __has_feature(ptrauth_intrinsics)
-#warning Pointer authentication enabled!
-// expected-warning@-1 {{Pointer authentication enabled!}}
+#if !__has_feature(ptrauth_intrinsics)
+// This error means that the __ptrauth intrinsics availability test says that
+// they are not available. This error is not expected in the output of this
+// test, if it is seen there is a feature detection regression.
+#error __ptrauth intrinsics not enabled
 #endif
 
 #if __aarch64__

--- a/clang/test/SemaObjC/ptrauth-qualifier.m
+++ b/clang/test/SemaObjC/ptrauth-qualifier.m
@@ -1,9 +1,11 @@
 // RUN: %clang_cc1 -triple arm64-apple-ios -fsyntax-only -verify -fptrauth-intrinsics %s
 // RUN: %clang_cc1 -triple aarch64-linux-gnu -fsyntax-only -verify -fptrauth-intrinsics %s
 
-#if __has_feature(ptrauth_qualifier)
-#warning __ptrauth qualifier enabled!
-// expected-warning@-1 {{__ptrauth qualifier enabled!}}
+#if !__has_extension(ptrauth_qualifier)
+// This error means that the __ptrauth qualifier availability test says  that it
+// is not available. This error is not expected in the output, if it is seen
+// there is a feature detection regression.
+#error __ptrauth qualifier not enabled
 #endif
 
 @interface Foo


### PR DESCRIPTION
The existing test behavior checked for a warning being emitted under an #if, but if the feature detection fails the #if fails and the warning is not expected in the output.

I've made the test more explicit, and added comments to ensure no one simply adds/moves any expected output around.