### PR TITLE
[LLVM] Replace use of `LLVM_RUNTIMES_TARGET` with `LLVM_DEFAULT_TARGET_TRIPLE`

### DIFF
--- a/flang-rt/CMakeLists.txt
+++ b/flang-rt/CMakeLists.txt
@@ -223,9 +223,9 @@ endif()
 
 # The GPU targets require a few mandatory arguments to make the standard CMake
 # check flags happy.
-if ("${LLVM_RUNTIMES_TARGET}" MATCHES "^amdgcn")
+if ("${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^amdgcn")
   set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -nogpulib")
-elseif ("${LLVM_RUNTIMES_TARGET}" MATCHES "^nvptx")
+elseif ("${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^nvptx")
   set(CMAKE_REQUIRED_FLAGS
       "${CMAKE_REQUIRED_FLAGS} -flto -c -Wno-unused-command-line-argument")
 endif()

--- a/flang-rt/README.md
+++ b/flang-rt/README.md
@@ -107,11 +107,10 @@ The `CMAKE_Fortran_COMPILER_WORKS` parameter must be set because otherwise CMake
 will test whether the Fortran compiler can compile and link programs which will
 obviously fail without a runtime library available yet.
 
-Building Flang-RT for cross-compilation triple, the target triple can
-be selected using `LLVM_DEFAULT_TARGET_TRIPLE` AND `LLVM_RUNTIMES_TARGET`.
-Of course, Flang-RT can be built multiple times with different build
-configurations, but have to be located manually when using with the Flang
-driver using the `-L` option.
+Building Flang-RT for cross-compilation triple, the target triple can be
+selected using `LLVM_DEFAULT_TARGET_TRIPLE`. Of course, Flang-RT can be built
+multiple times with different build configurations, but have to be located
+manually when using with the Flang driver using the `-L` option.
 
 After configuration, build, test, and install the runtime via
 

--- a/flang-rt/cmake/modules/AddFlangRT.cmake
+++ b/flang-rt/cmake/modules/AddFlangRT.cmake
@@ -234,11 +234,11 @@ function (add_flangrt_library name)
     endif ()
 
     # Add target specific options if necessary.
-    if ("${LLVM_RUNTIMES_TARGET}" MATCHES "^amdgcn")
+    if ("${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^amdgcn")
       target_compile_options(${tgtname} PRIVATE
           $<$<COMPILE_LANGUAGE:CXX>:-nogpulib -flto -fvisibility=hidden>
         )
-    elseif ("${LLVM_RUNTIMES_TARGET}" MATCHES "^nvptx")
+    elseif ("${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^nvptx")
       target_compile_options(${tgtname} PRIVATE
           $<$<COMPILE_LANGUAGE:CXX>:-nogpulib -flto -fvisibility=hidden -Wno-unknown-cuda-version --cuda-feature=+ptx63>
         )

--- a/flang-rt/lib/runtime/CMakeLists.txt
+++ b/flang-rt/lib/runtime/CMakeLists.txt
@@ -172,7 +172,7 @@ else ()
   set(f128_sources "")
 endif ()
 
-if ("${LLVM_RUNTIMES_TARGET}" MATCHES "^amdgcn|^nvptx")
+if ("${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^amdgcn|^nvptx")
   set(sources ${gpu_sources})
 else ()
   set(sources ${supported_sources} ${host_sources} ${f128_sources})

--- a/libc/cmake/modules/LLVMLibCArchitectures.cmake
+++ b/libc/cmake/modules/LLVMLibCArchitectures.cmake
@@ -108,24 +108,24 @@ set(LIBC_TARGET_ARCHITECTURE ${compiler_arch})
 set(LIBC_TARGET_OS ${compiler_sys})
 set(LIBC_CROSSBUILD FALSE)
 
-# One should not set LLVM_RUNTIMES_TARGET and LIBC_TARGET_TRIPLE
-if(LLVM_RUNTIMES_TARGET AND LIBC_TARGET_TRIPLE)
+# One should not set LLVM_DEFAULT_TARGET_TRIPLE and LIBC_TARGET_TRIPLE
+if(LLVM_DEFAULT_TARGET_TRIPLE AND LLVM_RUNTIMES_BUILD AND LIBC_TARGET_TRIPLE)
   message(FATAL_ERROR
-          "libc build: Specify only LLVM_RUNTIMES_TARGET if you are doing a "
+          "libc build: Specify only LLVM_DEFAULT_TARGET_TRIPLE if you are doing a "
           "runtimes/bootstrap build. If you are doing a standalone build, "
           "specify only LIBC_TARGET_TRIPLE.")
 endif()
 
 set(explicit_target_triple)
-if(LLVM_RUNTIMES_TARGET)
-  set(explicit_target_triple ${LLVM_RUNTIMES_TARGET})
+if(LLVM_DEFAULT_TARGET_TRIPLE AND LLVM_RUNTIMES_BUILD)
+  set(explicit_target_triple ${LLVM_DEFAULT_TARGET_TRIPLE})
 elseif(LIBC_TARGET_TRIPLE)
   set(explicit_target_triple ${LIBC_TARGET_TRIPLE})
 endif()
 
 # The libc's target architecture and OS are set to match the compiler's default
 # target triple above. However, one can explicitly set LIBC_TARGET_TRIPLE or
-# LLVM_RUNTIMES_TARGET (for runtimes/bootstrap build). If one of them is set,
+# LLVM_DEFAULT_TARGET_TRIPLE (for runtimes/bootstrap build). If one of them is set,
 # then we will use that target triple to deduce libc's target OS and
 # architecture.
 if(explicit_target_triple)
@@ -200,14 +200,14 @@ endif()
 
 
 # If the compiler target triple is not the same as the triple specified by
-# LIBC_TARGET_TRIPLE or LLVM_RUNTIMES_TARGET, we will add a --target option
+# LIBC_TARGET_TRIPLE or LLVM_DEFAULT_TARGET_TRIPLE, we will add a --target option
 # if the compiler is clang. If the compiler is GCC we just error out as there
 # is no equivalent of an option like --target.
 if(explicit_target_triple AND
    (NOT (libc_compiler_triple STREQUAL explicit_target_triple)))
   set(LIBC_CROSSBUILD TRUE)
   if(CMAKE_COMPILER_IS_GNUCXX)
-    message(FATAL_ERROR
+    message(WARNING
             "GCC target triple (${libc_compiler_triple}) and the explicity "
             "specified target triple (${explicit_target_triple}) do not match.")
   else()

--- a/libc/docs/gpu/building.rst
+++ b/libc/docs/gpu/building.rst
@@ -100,12 +100,12 @@ targeting a GPU architecture.
   $> TARGET_C_COMPILER=</path/to/clang>
   $> TARGET_CXX_COMPILER=</path/to/clang++>
   $> cmake ../runtimes \ # Point to the runtimes build
-     -G Ninja                                  \
-     -DLLVM_ENABLE_RUNTIMES=libc               \
-     -DCMAKE_C_COMPILER=$TARGET_C_COMPILER     \
-     -DCMAKE_CXX_COMPILER=$TARGET_CXX_COMPILER \
-     -DLLVM_LIBC_FULL_BUILD=ON                 \
-     -DLLVM_RUNTIMES_TARGET=$TARGET_TRIPLE     \
+     -G Ninja                                    \
+     -DLLVM_ENABLE_RUNTIMES=libc                 \
+     -DCMAKE_C_COMPILER=$TARGET_C_COMPILER       \
+     -DCMAKE_CXX_COMPILER=$TARGET_CXX_COMPILER   \
+     -DLLVM_LIBC_FULL_BUILD=ON                   \
+     -DLLVM_DEFAULT_TARGET_TRIPLE=$TARGET_TRIPLE \
      -DCMAKE_BUILD_TYPE=Release
   $> ninja install
 


### PR DESCRIPTION
Summary:
For purposes of determining the triple, it's more correct to use `LLVM_DEFAULT_TARGET_TRIPLE`.
