### PR TITLE
[lldb-dap] Remove an incorrect assumption on reverse requests.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -343,25 +343,21 @@ class DebugCommunication(object):
                     self.send_packet(
                         {
                             "type": "response",
-                            "seq": 0,
                             "request_seq": response_or_request["seq"],
                             "success": True,
                             "command": "runInTerminal",
                             "body": {},
                         },
-                        set_sequence=False,
                     )
                 elif response_or_request["command"] == "startDebugging":
                     self.send_packet(
                         {
                             "type": "response",
-                            "seq": 0,
                             "request_seq": response_or_request["seq"],
                             "success": True,
                             "command": "startDebugging",
                             "body": {},
                         },
-                        set_sequence=False,
                     )
                 else:
                     desc = 'unknown reverse request "%s"' % (

--- a/lldb/tools/lldb-dap/Protocol/ProtocolBase.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolBase.cpp
@@ -163,11 +163,6 @@ bool fromJSON(json::Value const &Params, Response &R, json::Path P) {
     return false;
   }
 
-  if (seq != 0) {
-    P.field("seq").report("expected to be '0'");
-    return false;
-  }
-
   if (R.command.empty()) {
     P.field("command").report("expected to not be ''");
     return false;


### PR DESCRIPTION
Reverse requests do have a 'seq' set still from VSCode. I incorrectly interpreted https://github.com/microsoft/vscode/blob/dede7bb4b7e9c9ec69155a243bb84037a40588fe/src/vs/workbench/contrib/debug/common/abstractDebugAdapter.ts#L65 to mean they have a 'seq' of '0', however the 'seq' is set in 'internalSend' here https://github.com/microsoft/vscode/blob/dede7bb4b7e9c9ec69155a243bb84037a40588fe/src/vs/workbench/contrib/debug/common/abstractDebugAdapter.ts#L178.

Removing the check that 'seq=0' on reverse requests and updating the dap_server.py impl to also set the seq.