### PR TITLE
Port a new flag for AArch64 tablegen to Bazel rules

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -2148,7 +2148,7 @@ llvm_target_lib_list = [lib for lib in [
                 "lib/Target/AArch64/AArch64GenSubtargetInfo.inc",
             ),
             (
-                ["-gen-disassembler"],
+                ["-gen-disassembler", "--num-to-skip-size=3"],
                 "lib/Target/AArch64/AArch64GenDisassemblerTables.inc",
             ),
             (


### PR DESCRIPTION
See #135882 for the introduction of this flag in CMake and TableGen.

Also note that #135882 has been reverted a couple of times -- this should only be merged once it sticks. Let me know @jurahul if you'd like to incorporate this into your PR so it goes in and out together. Otherwise I can just land this once yours is in place.