### PR TITLE
[Analysis] Restore the call to reserve

### DIFF
--- a/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h
+++ b/llvm/include/llvm/Analysis/BlockFrequencyInfoImpl.h
@@ -1159,6 +1159,7 @@ void BlockFrequencyInfoImpl<BT>::setBlockFreq(const BlockT *BB,
 
 template <class BT> void BlockFrequencyInfoImpl<BT>::initializeRPOT() {
   const BlockT *Entry = &F->front();
+  RPOT.reserve(F->size());
   llvm::append_range(RPOT, post_order(Entry));
   std::reverse(RPOT.begin(), RPOT.end());
 


### PR DESCRIPTION
  commit 47d8fec9b8bd5425af17711317a41743a30a8cef
  Author: Kazu Hirata <kazu@google.com>
  Date:   Wed Apr 16 19:30:01 2025 -0700

has removed the call to reserve here.  This patch restores it as
std::vector::insert, called by llvm::append_range, may not be able to
deduce the size of the range.  For example, std::vector in libc++
distinguishes has two versions of std::vector::insert depending on
whether the iterator is an input iterator or a foward iterator.
