### PR TITLE
Revert "[Fuchsia] Not building llvm-mt when LIBXML2 is not enabled."

### DIFF
--- a/clang/cmake/caches/Fuchsia-stage2.cmake
+++ b/clang/cmake/caches/Fuchsia-stage2.cmake
@@ -459,6 +459,7 @@ set(LLVM_TOOLCHAIN_TOOLS
   llvm-libtool-darwin
   llvm-lipo
   llvm-ml
+  llvm-mt
   llvm-nm
   llvm-objcopy
   llvm-objdump
@@ -479,10 +480,6 @@ set(LLVM_TOOLCHAIN_TOOLS
   sancov
   scan-build-py
   CACHE STRING "")
-
-if (LLVM_ENABLE_LIBXML2)
-  list(APPEND LLVM_TOOLCHAIN_TOOLS llvm-mt)
-endif()
 
 set(LLVM_Toolchain_DISTRIBUTION_COMPONENTS
   bolt


### PR DESCRIPTION
Reverts llvm/llvm-project#135877

This is causing some problems on Fuchsia's windows CI. We'll need a different solution to triage other builders.

https://ci.chromium.org/ui/p/fuchsia/builders/toolchain.ci/clang-windows-x64/b8717476961063994817/overview